### PR TITLE
initial translation of API headers to Japanese

### DIFF
--- a/doc/dox_comments/header_files-ja/aes.h
+++ b/doc/dox_comments/header_files-ja/aes.h
@@ -1,0 +1,752 @@
+/*!
+    \ingroup AES 
+    \brief  この関数は、キーを設定して初期化ベクトルを設定することでAES構造を初期化します。
+    \return 0  キーと初期化ベクトルを正常に設定します。
+    \return BAD_FUNC_ARG  キーの長さが無効な場合は返されます。
+    \param aes  変更するAES構造へのポインタ
+    \param key  暗号化と復号化のための16,24、または32バイトの秘密鍵
+    \param len  渡されたキーの長さ
+    \param iv  キーを初期化するために使用される初期化ベクトルへのポインタ
+    _Example_
+    \code
+    Aes enc;
+    int ret = 0;
+    byte key[] = { some 16, 24 or 32 byte key };
+    byte iv[]  = { some 16 byte iv };
+    if (ret = wc_AesSetKey(&enc, key, AES_BLOCK_SIZE, iv,
+    AES_ENCRYPTION) != 0) {
+	// failed to set aes key
+    }
+    \endcode
+    \sa wc_AesSetKeyDirect
+    \sa wc_AesSetIV
+*/
+int  wc_AesSetKey(Aes* aes, const byte* key, word32 len,
+                              const byte* iv, int dir);
+
+/*!
+    \ingroup AES 
+    \brief  この関数は、特定のAESオブジェクトの初期化ベクトルを設定します。AESオブジェクトは、この関数を呼び出す前に初期化されるべきです。
+    \return 0  初期化ベクトルを正常に設定します。
+    \return BAD_FUNC_ARG  AESポインタがNULLの場合に返されます。
+    \param aes  初期化ベクトルを設定するAES構造へのポインタ
+    _Example_
+    \code
+    Aes enc;
+    // set enc key
+    byte iv[]  = { some 16 byte iv };
+    if (ret = wc_AesSetIV(&enc, iv) != 0) {
+	// failed to set aes iv
+    }
+    \endcode
+    \sa wc_AesSetKeyDirect
+    \sa wc_AesSetKey
+*/
+int  wc_AesSetIV(Aes* aes, const byte* iv);
+
+/*!
+    \ingroup AES 
+    \brief  入力バッファーから平文メッセージを暗号化し、AESでCipher Block Chainingを使用して出力バッファに出力バッファーに入れます。この機能は、メッセージが暗号化される前にAESSetKeyを呼び出すことによってAESオブジェクトが初期化されていることを必要とします。この関数は、入力メッセージがAESブロック長であると仮定し、入力された長さがブロック長の倍数になることを想定しているため、ビルド構成でWolfSSL_AES_CBC_LENGTH_CHECKSが定義されている場合は任意選択でチェックおよび適用されます。ブロック多入力を保証するために、PKCS＃7スタイルのパディングを事前に追加する必要があります。これはあなたのためにパディングを追加するOpenSSL AES-CBCメソッドとは異なります。WOLFSSLと対応するOpenSSL関数を相互運用するには、OpenSSLコマンドライン関数で-nopadオプションを指定して、WolfSSL AESCCENCRYPTメソッドのように動作し、暗号化中に追加のパディングを追加しません。
+    \return 0  メッセージの暗号化に成功しました。
+    \return BAD_ALIGN_E:  ブロック整列誤差で返される可能性があります
+    \return BAD_LENGTH_E  入力長がAESブロック長の倍数でない場合は、ライブラリーがwolfssl_aes_cbc_length_checksで構築されている場合に返されます。
+    \param aes  データの暗号化に使用されるAESオブジェクトへのポインタ
+    \param out  暗号化されたメッセージの暗号文を格納する出力バッファへのポインタ
+    \param in  暗号化されるメッセージを含む入力バッファへのポインタ
+    _Example_
+    \code
+    Aes enc;
+    int ret = 0;
+    // initialize enc with AesSetKey, using direction AES_ENCRYPTION
+    byte msg[AES_BLOCK_SIZE * n]; // multiple of 16 bytes
+    // fill msg with data
+    byte cipher[AES_BLOCK_SIZE * n]; // Some multiple of 16 bytes
+    if ((ret = wc_AesCbcEncrypt(&enc, cipher, message, sizeof(msg))) != 0 ) {
+	// block align error
+    }
+    \endcode
+    \sa wc_AesSetKey
+    \sa wc_AesSetIV
+    \sa wc_AesCbcDecrypt
+*/
+int  wc_AesCbcEncrypt(Aes* aes, byte* out,
+                                  const byte* in, word32 sz);
+
+/*!
+    \ingroup AES 
+    \brief  入力バッファーから暗号を復号化し、AESでCipher Block Chainingを使用して出力バッファに出力バッファーに入れます。この機能は、メッセージが復号化される前にAESSetKeyを呼び出すことによってAES構造が初期化されていることを必要とします。この関数は、元のメッセージがAESブロック長で整列していたと仮定し、入力された長さがブロック長の倍数になると予想しています。これはOpenSSL AES-CBCメソッドとは異なります。これは、PKCS＃7パディングを自動的に追加するため、ブロックマルチ入力を必要としません。WolfSSL機能と同等のOpenSSL関数を相互運用するには、OpenSSLコマンドライン関数で-nopadオプションを指定し、wolfssl aescbceNcryptメソッドのように動作し、復号化中にエラーを発生させません。
+    \return 0  メッセージを正常に復号化します。
+    \return BAD_ALIGN_E  ブロック整列エラーで返される可能性があります。
+    \return BAD_LENGTH_E  入力長がAESブロック長の倍数でない場合は、ライブラリーがwolfssl_aes_cbc_length_checksで構築されている場合に返されます。
+    \param aes  データを復号化するために使用されるAESオブジェクトへのポインタ。
+    \param out  復号化されたメッセージのプレーンテキストを保存する出力バッファへのポインタ。
+    \param in  復号化する暗号テキストを含む入力バッファへのポインタ。
+    _Example_
+    \code
+    Aes dec;
+    int ret = 0;
+    // initialize dec with AesSetKey, using direction AES_DECRYPTION
+    byte cipher[AES_BLOCK_SIZE * n]; // some multiple of 16 bytes
+    // fill cipher with cipher text
+    byte plain [AES_BLOCK_SIZE * n];
+    if ((ret = wc_AesCbcDecrypt(&dec, plain, cipher, sizeof(cipher))) != 0 ) {
+	// block align error
+    }
+    \endcode
+    \sa wc_AesSetKey
+    \sa wc_AesCbcEncrypt
+*/
+int  wc_AesCbcDecrypt(Aes* aes, byte* out,
+                                  const byte* in, word32 sz);
+
+/*!
+    \ingroup AES 
+    \brief  入力バッファーからメッセージを暗号化/復号化し、AESを使用してCTRモードを使用して出力バッファーに出力バッファーに入れます。この関数は、wolfssl_aes_counterがコンパイル時に有効になっている場合にのみ有効になります。この機能を呼び出す前に、AES構造体をAessetKeyで初期化する必要があります。この関数は復号化と暗号化の両方に使用されます。_注：暗号化と復号化のための同じAPIを使用することについて。ユーザーは暗号化/復号化のためのAES構造体を区別する必要があります。
+    \return int  WolfSSLエラーまたは成功状況に対応する整数値
+    \param aes  データを復号化するために使用されるAESオブジェクトへのポインタ
+    \param out  暗号化されたメッセージの暗号化テキストを保存する出力バッファへのポインタ
+    \param in  暗号化されるプレーンテキストを含む入力バッファへのポインタ
+    _Example_
+    \code
+    Aes enc;
+    Aes dec;
+    // initialize enc and dec with AesSetKeyDirect, using direction
+    AES_ENCRYPTION
+    // since the underlying API only calls Encrypt and by default calling
+    encrypt on
+    // a cipher results in a decryption of the cipher
+
+    byte msg[AES_BLOCK_SIZE * n]; //n being a positive integer making msg
+    some multiple of 16 bytes
+    // fill plain with message text
+    byte cipher[AES_BLOCK_SIZE * n];
+    byte decrypted[AES_BLOCK_SIZE * n];
+    wc_AesCtrEncrypt(&enc, cipher, msg, sizeof(msg)); // encrypt plain
+    wc_AesCtrEncrypt(&dec, decrypted, cipher, sizeof(cipher));
+    // decrypt cipher text
+    \endcode
+    \sa wc_AesSetKey
+*/
+int wc_AesCtrEncrypt(Aes* aes, byte* out,
+                                   const byte* in, word32 sz);
+
+/*!
+    \ingroup AES 
+    \brief  この関数は、入力ブロックの入力ブロック、IN、OUTPUTブロック、OUTです。提供されたAES構造体のキーを使用します。これはこの機能を呼び出す前にWC_AESSETKEYで初期化される必要があります。WC_AESSETKEYは、IVセットがNULLに呼び出されたはずです。これは、Configure Option WolfSSL_AES_DIRECTが有効になっている場合にのみ有効になります。__ warning：ほぼすべてのユースケースでECBモードは安全性が低いと考えられています。可能な限りECB APIを直接使用しないでください。
+    \return int  WolfSSLエラーまたは成功状況に対応する整数値
+    \param aes  データの暗号化に使用されるAESオブジェクトへのポインタ
+    \param out  暗号化されたメッセージの暗号化テキストを保存する出力バッファへのポインタ
+    _Example_
+    \code
+    Aes enc;
+    // initialize enc with AesSetKey, using direction AES_ENCRYPTION
+    byte msg [AES_BLOCK_SIZE]; // 16 bytes
+    // initialize msg with plain text to encrypt
+    byte cipher[AES_BLOCK_SIZE];
+    wc_AesEncryptDirect(&enc, cipher, msg);
+    \endcode
+    \sa wc_AesDecryptDirect
+    \sa wc_AesSetKeyDirect
+*/
+int wc_AesEncryptDirect(Aes* aes, byte* out, const byte* in);
+
+/*!
+    \ingroup AES 
+    \brief  この関数は、入力ブロックの1ブロック復号化、IN、IN、OUTPUT OUTです。提供されたAES構造体のキーを使用します。これはこの機能を呼び出す前にWC_AESSETKEYで初期化される必要があります。WC_AESSETKEYは、IVセットがNULLに呼び出されたはずです。これは、Configure Option WolfSSL_AES_DIRECTが有効になっている場合にのみ有効になります。__ warning：ほぼすべてのユースケースでECBモードは安全性が低いと考えられています。可能な限りECB APIを直接使用しないでください。
+    \return int  WolfSSLエラーまたは成功状況に対応する整数値
+    \param aes  データの暗号化に使用されるAESオブジェクトへのポインタ
+    \param out  復号化された暗号テキストのプレーンテキストを格納する出力バッファへのポインタ
+    _Example_
+    \code
+    Aes dec;
+    // initialize enc with AesSetKey, using direction AES_DECRYPTION
+    byte cipher [AES_BLOCK_SIZE]; // 16 bytes
+    // initialize cipher with cipher text to decrypt
+    byte msg[AES_BLOCK_SIZE];
+    wc_AesDecryptDirect(&dec, msg, cipher);
+    \endcode
+    \sa wc_AesEncryptDirect
+    \sa wc_AesSetKeyDirect
+ */
+int wc_AesDecryptDirect(Aes* aes, byte* out, const byte* in);
+
+/*!
+    \ingroup AES 
+    \brief  この関数は、CTRモードのAESキーをAESで設定するために使用されます。指定されたキー、IV（初期化ベクトル）、および暗号化DIR（方向）でAESオブジェクトを初期化します。構成オプションwolfssl_aes_directが有効になっている場合にのみ有効になります。現在WC_AessetKeyDirectは内部的にWC_AESSETKEYを使用します。__ warning：ほぼすべてのユースケースでECBモードは安全性が低いと考えられています。可能な限りECB APIを直接使用しないでください
+    \return 0  キーの設定に成功しました。
+    \return BAD_FUNC_ARG  与えられたキーが無効な長さの場合に返されます。
+    \param aes  データの暗号化に使用されるAESオブジェクトへのポインタ
+    \param key  暗号化と復号化のための16,24、または32バイトの秘密鍵
+    \param len  渡されたキーの長さ
+    \param iv  キーを初期化するために使用される初期化ベクトル
+    _Example_
+    \code
+    Aes enc;
+    int ret = 0;
+    byte key[] = { some 16, 24, or 32 byte key };
+    byte iv[]  = { some 16 byte iv };
+    if (ret = wc_AesSetKeyDirect(&enc, key, sizeof(key), iv,
+    AES_ENCRYPTION) != 0) {
+	// failed to set aes key
+    }
+    \endcode
+    \sa wc_AesEncryptDirect
+    \sa wc_AesDecryptDirect
+    \sa wc_AesSetKey
+*/
+int  wc_AesSetKeyDirect(Aes* aes, const byte* key, word32 len,
+                                const byte* iv, int dir);
+
+/*!
+    \ingroup AES 
+    \brief  この機能は、AES GCM（Galois / Counter Mode）のキーを設定するために使用されます。与えられたキーでAESオブジェクトを初期化します。コンパイル時にConfigureオプションhous_aesgcmが有効になっている場合にのみ有効になります。
+    \return 0  キーの設定に成功しました。
+    \return BAD_FUNC_ARG  与えられたキーが無効な長さの場合に返されます。
+    \param aes  データの暗号化に使用されるAESオブジェクトへのポインタ
+    \param key  暗号化と復号化のための16,24、または32バイトの秘密鍵
+    _Example_
+    \code
+    Aes enc;
+    int ret = 0;
+    byte key[] = { some 16, 24,32 byte key };
+    if (ret = wc_AesGcmSetKey(&enc, key, sizeof(key)) != 0) {
+	// failed to set aes key
+    }
+    \endcode
+    \sa wc_AesGcmEncrypt
+    \sa wc_AesGcmDecrypt
+*/
+int  wc_AesGcmSetKey(Aes* aes, const byte* key, word32 len);
+
+/*!
+    \ingroup AES 
+    \brief  この関数は、入力メッセージをバッファINに保持し、結果の暗号テキストを出力バッファOUTに格納します。暗号化する呼び出しごとに新しいIV（初期化ベクトル）が必要です。また、入力認証ベクトル、Authin、AuthTagへの入力認証ベクトルをエンコードします。
+    \return 0  入力メッセージの暗号化に成功しました
+    \param aes   - データの暗号化に使用されるAESオブジェクトへのポインタ
+    \param out  暗号テキストを保存する出力バッファへのポインタ
+    \param in  暗号化するメッセージを保持している入力バッファへのポインタ
+    \param sz  暗号化する入力メッセージの長さ
+    \param iv  初期化ベクトルを含むバッファへのポインタ
+    \param ivSz  初期化ベクトルの長さ
+    \param authTag  認証タグを保存するバッファへのポインタ
+    \param authTagSz  希望の認証タグの長さ
+    \param authIn  入力認証ベクトルを含むバッファへのポインタ
+    _Example_
+    \code
+    Aes enc;
+    // initialize aes structure by calling wc_AesGcmSetKey
+
+    byte plain[AES_BLOCK_LENGTH * n]; //n being a positive integer
+    making plain some multiple of 16 bytes
+    // initialize plain with msg to encrypt
+    byte cipher[sizeof(plain)];
+    byte iv[] = // some 16 byte iv
+    byte authTag[AUTH_TAG_LENGTH];
+    byte authIn[] = // Authentication Vector
+
+    wc_AesGcmEncrypt(&enc, cipher, plain, sizeof(cipher), iv, sizeof(iv),
+			authTag, sizeof(authTag), authIn, sizeof(authIn));
+    \endcode
+    \sa wc_AesGcmSetKey
+    \sa wc_AesGcmDecrypt
+*/
+int  wc_AesGcmEncrypt(Aes* aes, byte* out,
+                                   const byte* in, word32 sz,
+                                   const byte* iv, word32 ivSz,
+                                   byte* authTag, word32 authTagSz,
+                                   const byte* authIn, word32 authInSz);
+
+/*!
+    \ingroup AES 
+    \brief  この関数は、入力暗号テキストをバッファINに保持し、結果のメッセージテキストを出力バッファOUTに格納します。また、指定された認証タグ、authtagに対して、入力認証ベクトル、Authinをチェックします。
+    \return 0  入力メッセージの復号化に成功しました
+    \return AES_GCM_AUTH_E  認証タグが提供された認証コードベクトルと一致しない場合、authtag。
+    \param aes  データの暗号化に使用されるAESオブジェクトへのポインタ
+    \param out  メッセージテキストを保存する出力バッファへのポインタ
+    \param in  暗号テキストを復号化する入力バッファへのポインタ
+    \param sz  復号化する暗号テキストの長さ
+    \param iv  初期化ベクトルを含むバッファへのポインタ
+    \param ivSz  初期化ベクトルの長さ
+    \param authTag  認証タグを含むバッファへのポインタ
+    \param authTagSz  希望の認証タグの長さ
+    \param authIn  入力認証ベクトルを含むバッファへのポインタ
+    _Example_
+    \code
+    Aes enc; //can use the same struct as was passed to wc_AesGcmEncrypt
+    // initialize aes structure by calling wc_AesGcmSetKey if not already done
+
+    byte cipher[AES_BLOCK_LENGTH * n]; //n being a positive integer
+    making cipher some multiple of 16 bytes
+    // initialize cipher with cipher text to decrypt
+    byte output[sizeof(cipher)];
+    byte iv[] = // some 16 byte iv
+    byte authTag[AUTH_TAG_LENGTH];
+    byte authIn[] = // Authentication Vector
+
+    wc_AesGcmDecrypt(&enc, output, cipher, sizeof(cipher), iv, sizeof(iv),
+			authTag, sizeof(authTag), authIn, sizeof(authIn));
+    \endcode
+    \sa wc_AesGcmSetKey
+    \sa wc_AesGcmEncrypt
+*/
+int  wc_AesGcmDecrypt(Aes* aes, byte* out,
+                                   const byte* in, word32 sz,
+                                   const byte* iv, word32 ivSz,
+                                   const byte* authTag, word32 authTagSz,
+                                   const byte* authIn, word32 authInSz);
+
+/*!
+    \ingroup AES 
+    \brief  この関数は、GAROISメッセージ認証に使用されるGMACオブジェクトのキーを初期化して設定します。
+    \return 0  キーの設定に成功しました
+    \return BAD_FUNC_ARG  キーの長さが無効な場合は返されます。
+    \param gmac  認証に使用されるGMACオブジェクトへのポインタ
+    \param key  認証のための16,24、または32バイトの秘密鍵
+    _Example_
+    \code
+    Gmac gmac;
+    key[] = { some 16, 24, or 32 byte length key };
+    wc_GmacSetKey(&gmac, key, sizeof(key));
+    \endcode
+    \sa wc_GmacUpdate
+*/
+int wc_GmacSetKey(Gmac* gmac, const byte* key, word32 len);
+
+/*!
+    \ingroup AES 
+    \brief  この関数はAuthin InputのGMACハッシュを生成し、結果をAuthtagバッファに格納します。wc_gmacupdateを実行した後、生成されたauthtagを既知の認証タグに比較してメッセージの信頼性を検証する必要があります。
+    \return 0  GMACハッシュの計算に成功しました。
+    \param gmac  認証に使用されるGMACオブジェクトへのポインタ
+    \param iv  ハッシュに使用される初期化ベクトル
+    \param ivSz  使用される初期化ベクトルのサイズ
+    \param authIn  確認する認証ベクトルを含むバッファへのポインタ
+    \param authInSz  認証ベクトルのサイズ
+    \param authTag  GMACハッシュを保存する出力バッファへのポインタ
+    _Example_
+    \code
+    Gmac gmac;
+    key[] = { some 16, 24, or 32 byte length key };
+    iv[] = { some 16 byte length iv };
+
+    wc_GmacSetKey(&gmac, key, sizeof(key));
+    authIn[] = { some 16 byte authentication input };
+    tag[AES_BLOCK_SIZE]; // will store authentication code
+
+    wc_GmacUpdate(&gmac, iv, sizeof(iv), authIn, sizeof(authIn), tag,
+    sizeof(tag));
+    \endcode
+    \sa wc_GmacSetKey
+*/
+int wc_GmacUpdate(Gmac* gmac, const byte* iv, word32 ivSz,
+                               const byte* authIn, word32 authInSz,
+                               byte* authTag, word32 authTagSz);
+
+/*!
+    \ingroup AES 
+    \brief  この関数は、CCMを使用してAESオブジェクトのキーを設定します（CBC-MACのカウンタ）。AES構造体へのポインタを取り、付属のキーで初期化します。
+    \return none 
+    \param aes  付属のキーを保管するためのAES構造
+    \param key  暗号化と復号化のための16,24、または32バイトの秘密鍵
+    _Example_
+    \code
+    Aes enc;
+    key[] = { some 16, 24, or 32 byte length key };
+
+    wc_AesCcmSetKey(&aes, key, sizeof(key));
+    \endcode
+    \sa wc_AesCcmEncrypt
+    \sa wc_AesCcmDecrypt
+*/
+int  wc_AesCcmSetKey(Aes* aes, const byte* key, word32 keySz);
+
+/*!
+    \ingroup AES 
+    \brief  この関数は、CCMを使用して、入力メッセージ、IN、OUT、OUT、OUTをCCM（CBC-MACのカウンタ）を暗号化します。その後、Authin Inputから認証タグ、AuthtAgを計算して格納します。
+    \return none 
+    \param aes  データの暗号化に使用されるAESオブジェクトへのポインタ
+    \param out  暗号テキストを保存する出力バッファへのポインタ
+    \param in  暗号化するメッセージを保持している入力バッファへのポインタ
+    \param sz  暗号化する入力メッセージの長さ
+    \param nonce  nonceを含むバッファへのポインタ（1回だけ使用されている数）
+    \param nonceSz  ノンスの長さ
+    \param authTag  認証タグを保存するバッファへのポインタ
+    \param authTagSz  希望の認証タグの長さ
+    \param authIn  入力認証ベクトルを含むバッファへのポインタ
+    _Example_
+    \code
+    Aes enc;
+    // initialize enc with wc_AesCcmSetKey
+
+    nonce[] = { initialize nonce };
+    plain[] = { some plain text message };
+    cipher[sizeof(plain)];
+
+    authIn[] = { some 16 byte authentication input };
+    tag[AES_BLOCK_SIZE]; // will store authentication code
+
+    wc_AesCcmEncrypt(&enc, cipher, plain, sizeof(plain), nonce, sizeof(nonce),
+			tag, sizeof(tag), authIn, sizeof(authIn));
+    \endcode
+    \sa wc_AesCcmSetKey
+    \sa wc_AesCcmDecrypt
+*/
+int  wc_AesCcmEncrypt(Aes* aes, byte* out,
+                                   const byte* in, word32 inSz,
+                                   const byte* nonce, word32 nonceSz,
+                                   byte* authTag, word32 authTagSz,
+                                   const byte* authIn, word32 authInSz);
+
+/*!
+    \ingroup AES 
+    \brief  この関数は、CCMを使用して、入力暗号テキストを、CCM（CBC-MACのカウンタ）を使用して出力バッファーに復号化します。その後、Authin InputからAuthatAg、AuthatAgを計算します。許可タグが無効な場合は、出力バッファをゼロに設定し、AES_CCM_AUTH_Eを返します。
+    \return 0  入力メッセージの復号化に成功しました
+    \return AES_CCM_AUTH_E  認証タグが提供された認証コードベクトルと一致しない場合、authtag。
+    \param aes  データの暗号化に使用されるAESオブジェクトへのポインタ
+    \param out  暗号テキストを保存する出力バッファへのポインタ
+    \param in  暗号化するメッセージを保持している入力バッファへのポインタ
+    \param sz  入力暗号テキストの復号化
+    \param nonce  nonceを含むバッファへのポインタ（1回だけ使用されている数）
+    \param nonceSz  ノンスの長さ
+    \param authTag  認証タグを保存するバッファへのポインタ
+    \param authTagSz  希望の認証タグの長さ
+    \param authIn  入力認証ベクトルを含むバッファへのポインタ
+    _Example_
+    \code
+    Aes dec;
+    // initialize dec with wc_AesCcmSetKey
+
+    nonce[] = { initialize nonce };
+    cipher[] = { encrypted message };
+    plain[sizeof(cipher)];
+
+    authIn[] = { some 16 byte authentication input };
+    tag[AES_BLOCK_SIZE] = { authentication tag received for verification };
+
+    int return = wc_AesCcmDecrypt(&dec, plain, cipher, sizeof(cipher),
+    nonce, sizeof(nonce),tag, sizeof(tag), authIn, sizeof(authIn));
+    if(return != 0) {
+	// decrypt error, invalid authentication code
+    }
+    \endcode
+    \sa wc_AesCcmSetKey
+    \sa wc_AesCcmEncrypt
+*/
+int  wc_AesCcmDecrypt(Aes* aes, byte* out,
+                                   const byte* in, word32 inSz,
+                                   const byte* nonce, word32 nonceSz,
+                                   const byte* authTag, word32 authTagSz,
+                                   const byte* authIn, word32 authInSz);
+
+/*!
+    \ingroup AES 
+    \brief  これは、暗号化または復号化タイプを修正するためのキーの設定を支援することです。完了したら、AESキーでWC_AESXTSFREEを呼び出すことがユーザーになりました。
+    \return 0  成功
+    \param aes  ENCRYPT /復号化プロセスのためのAESキー
+    \param key  AESキーを保持しているバッファー| ..Tweak Key
+    \param len  キーバッファのバイト数の長さ。キーサイズの2倍にする必要があります。すなわち、16バイトのキーについて。
+    \param dir  方向、AES_EncryptionまたはAES_Decryptionのいずれか
+    \param heap  メモリに使用するヒントヒント。nullになることができます
+    _Example_
+    \code
+    XtsAes aes;
+
+    if(wc_AesXtsSetKey(&aes, key, sizeof(key), AES_ENCRYPTION, NULL, 0) != 0)
+    {
+        // Handle error
+    }
+    wc_AesXtsFree(&aes);
+    \endcode
+    \sa wc_AesXtsEncrypt
+    \sa wc_AesXtsDecrypt
+    \sa wc_AesXtsFree
+*/
+int wc_AesXtsSetKey(XtsAes* aes, const byte* key,
+         word32 len, int dir, void* heap, int devId);
+
+/*!
+    \ingroup AES 
+    \brief  WC_AESXTSENCRYPTと同じプロセスですが、バイト配列の代わりにTweak値としてWord64型を使用します。これは、Word64をバイト配列に変換し、WC_AESXTSENCRYPTを呼び出します。
+    \return 0  成功
+    \param aes  ブロック暗号化/復号化に使用するAESキー
+    \param out  暗号テキストを保持するための出力バッファ
+    \param in  暗号化する入力プレーンテキストバッファ
+    \param sz  両方ともバッファのサイズ
+    _Example_
+    \code
+    XtsAes aes;
+    unsigned char plain[SIZE];
+    unsigned char cipher[SIZE];
+    word64 s = VALUE;
+
+    //set up keys with AES_ENCRYPTION as dir
+
+    if(wc_AesXtsEncryptSector(&aes, cipher, plain, SIZE, s) != 0)
+    {
+        // Handle error
+    }
+    wc_AesXtsFree(&aes);
+    \endcode
+    \sa wc_AesXtsEncrypt
+    \sa wc_AesXtsDecrypt
+    \sa wc_AesXtsSetKey
+    \sa wc_AesXtsFree
+*/
+int wc_AesXtsEncryptSector(XtsAes* aes, byte* out,
+         const byte* in, word32 sz, word64 sector);
+
+/*!
+    \ingroup AES 
+    \brief  WC_AESXTSDECRYPTと同じプロセスではなく、BYTE配列の代わりにWord64タイプを使用します。これはWord64をバイト配列に変換するだけです。
+    \return 0  成功
+    \param aes  ブロック暗号化/復号化に使用するAESキー
+    \param out  プレーンテキストを保持するための出力バッファ
+    \param in  復号化する暗号テキストバッファーを入力します
+    \param sz  両方ともバッファのサイズ
+    _Example_
+    \code
+    XtsAes aes;
+    unsigned char plain[SIZE];
+    unsigned char cipher[SIZE];
+    word64 s = VALUE;
+
+    //set up aes key with AES_DECRYPTION as dir and tweak with AES_ENCRYPTION
+
+    if(wc_AesXtsDecryptSector(&aes, plain, cipher, SIZE, s) != 0)
+    {
+        // Handle error
+    }
+    wc_AesXtsFree(&aes);
+    \endcode
+    \sa wc_AesXtsEncrypt
+    \sa wc_AesXtsDecrypt
+    \sa wc_AesXtsSetKey
+    \sa wc_AesXtsFree
+*/
+int wc_AesXtsDecryptSector(XtsAes* aes, byte* out,
+         const byte* in, word32 sz, word64 sector);
+
+/*!
+    \ingroup AES 
+    \brief  XTSモードのあるAES。（XTS）XEX暗号化と暗号テキストを盗んだ暗号化。
+    \return 0  成功
+    \param aes  ブロック暗号化/復号化に使用するAESキー
+    \param out  暗号テキストを保持するための出力バッファ
+    \param in  暗号化する入力プレーンテキストバッファ
+    \param sz  両方ともバッファのサイズ
+    \param i  Tweakに使用する値
+    _Example_
+    \code
+    XtsAes aes;
+    unsigned char plain[SIZE];
+    unsigned char cipher[SIZE];
+    unsigned char i[AES_BLOCK_SIZE];
+
+    //set up key with AES_ENCRYPTION as dir
+
+    if(wc_AesXtsEncrypt(&aes, cipher, plain, SIZE, i, sizeof(i)) != 0)
+    {
+        // Handle error
+    }
+    wc_AesXtsFree(&aes);
+    \endcode
+    \sa wc_AesXtsDecrypt
+    \sa wc_AesXtsSetKey
+    \sa wc_AesXtsFree
+*/
+int wc_AesXtsEncrypt(XtsAes* aes, byte* out,
+         const byte* in, word32 sz, const byte* i, word32 iSz);
+
+/*!
+    \ingroup AES 
+    \brief  暗号化と同じプロセスですが、AESキーはAES_Decryptionタイプです。
+    \return 0  成功
+    \param aes  ブロック暗号化/復号化に使用するAESキー
+    \param out  プレーンテキストを保持するための出力バッファ
+    \param in  復号化する暗号テキストバッファーを入力します
+    \param sz  両方ともバッファのサイズ
+    \param i  Tweakに使用する値
+    _Example_
+    \code
+    XtsAes aes;
+    unsigned char plain[SIZE];
+    unsigned char cipher[SIZE];
+    unsigned char i[AES_BLOCK_SIZE];
+
+    //set up key with AES_DECRYPTION as dir and tweak with AES_ENCRYPTION
+
+    if(wc_AesXtsDecrypt(&aes, plain, cipher, SIZE, i, sizeof(i)) != 0)
+    {
+        // Handle error
+    }
+    wc_AesXtsFree(&aes);
+    \endcode
+    \sa wc_AesXtsEncrypt
+    \sa wc_AesXtsSetKey
+    \sa wc_AesXtsFree
+*/
+int wc_AesXtsDecrypt(XtsAes* aes, byte* out,
+        const byte* in, word32 sz, const byte* i, word32 iSz);
+
+/*!
+    \ingroup AES 
+    \brief  これはXTSAES構造によって使用されるすべてのリソースを解放することです
+    \return 0  成功
+    _Example_
+    \code
+    XtsAes aes;
+
+    if(wc_AesXtsSetKey(&aes, key, sizeof(key), AES_ENCRYPTION, NULL, 0) != 0)
+    {
+        // Handle error
+    }
+    wc_AesXtsFree(&aes);
+    \endcode
+    \sa wc_AesXtsEncrypt
+    \sa wc_AesXtsDecrypt
+    \sa wc_AesXtsSetKey
+*/
+int wc_AesXtsFree(XtsAes* aes);
+
+
+/*!
+    \ingroup AES 
+    \brief  AES構造を初期化します。ASYNCハードウェアで使用するためのヒープヒントとIDを設定する
+    \return 0  成功
+    \param aes  初期化にはAES構造
+    \param heap  必要に応じてmalloc / freeに使用するヒントヒント
+    _Example_
+    \code
+    Aes enc;
+    void* hint = NULL;
+    int devId = INVALID_DEVID; //if not using async INVALID_DEVID is default
+
+    //heap hint could be set here if used
+
+    wc_AesInit(&aes, hint, devId);
+    \endcode
+    \sa wc_AesSetKey
+    \sa wc_AesSetIV
+*/
+int  wc_AesInit(Aes* aes, void* heap, int devId);
+
+/*!
+    \ingroup AES 
+    \brief  CFBモードを持つAES。
+    \return 0  失敗時の成功と否定的なエラー値
+    \param aes  ブロック暗号化/復号化に使用するAESキー
+    \param out  暗号テキストを保持するための出力バッファは、少なくともInpectBufferと同じくらい大きい必要があります）
+    \param in  暗号化する入力プレーンテキストバッファ
+    _Example_
+    \code
+    Aes aes;
+    unsigned char plain[SIZE];
+    unsigned char cipher[SIZE];
+
+    //set up key with AES_ENCRYPTION as dir for both encrypt and decrypt
+
+    if(wc_AesCfbEncrypt(&aes, cipher, plain, SIZE) != 0)
+    {
+        // Handle error
+    }
+    \endcode
+    \sa wc_AesCfbDecrypt
+    \sa wc_AesSetKey
+*/
+int wc_AesCfbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz);
+
+/*!
+    \ingroup AES 
+    \brief  CFBモードを持つAES。
+    \return 0  失敗時の成功と否定的なエラー値
+    \param aes  ブロック暗号化/復号化に使用するAESキー
+    \param out  復号化されたテキストを保持するための出力バッファは、少なくともinputBufferと同じ大きさでなければなりません）
+    \param in  復号化する入力バッファ
+    _Example_
+    \code
+    Aes aes;
+    unsigned char plain[SIZE];
+    unsigned char cipher[SIZE];
+
+    //set up key with AES_ENCRYPTION as dir for both encrypt and decrypt
+
+    if(wc_AesCfbDecrypt(&aes, plain, cipher, SIZE) != 0)
+    {
+        // Handle error
+    }
+    \endcode
+    \sa wc_AesCfbEncrypt
+    \sa wc_AesSetKey
+*/
+int wc_AesCfbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz);
+
+/*!
+    \ingroup AES 
+    \brief  この関数は、RFC 5297に記載されているようにSIV（合成初期化ベクトル）暗号化を実行します。
+    \return 0  暗号化に成功した場合
+    \return BAD_FUNC_ARG  キー、SIV、または出力バッファがNULLの場合。キーサイズが32,48、または64バイトの場合にも返されます。
+    \return Other  AESまたはCMAC操作が失敗した場合に返されるその他の負のエラー値。
+    \param key  使用する鍵を含むバイトバッファ。
+    \param keySz  キーバッファの長さ（バイト単位）。
+    \param assoc  追加の認証された関連データ（AD）。
+    \param assocSz  ADバッファのバイト数
+    \param nonce  一度使用される数。ADと同じ方法でアルゴリズムによって使用されます。
+    \param nonceSz  バイト単位のNOCEバッファの長さ。
+    \param in  暗号化する平文のバッファ。
+    \param inSz  平文バッファの長さ
+    \param siv  S2VによるSIV出力（RFC 5297 2.4参照）。
+    _Example_
+    \code
+    byte key[] = { some 32, 48, or 64 byte key };
+    byte assoc[] = {0x01, 0x2, 0x3};
+    byte nonce[] = {0x04, 0x5, 0x6};
+    byte plainText[] = {0xDE, 0xAD, 0xBE, 0xEF};
+    byte siv[AES_BLOCK_SIZE];
+    byte cipherText[sizeof(plainText)];
+    if (wc_AesSivEncrypt(key, sizeof(key), assoc, sizeof(assoc), nonce,
+        sizeof(nonce), plainText, sizeof(plainText), siv, cipherText) != 0) {
+        // failed to encrypt
+    }
+    \endcode
+    \sa wc_AesSivDecrypt
+*/
+
+
+int wc_AesSivEncrypt(const byte* key, word32 keySz, const byte* assoc,
+                     word32 assocSz, const byte* nonce, word32 nonceSz,
+                     const byte* in, word32 inSz, byte* siv, byte* out);
+
+/*!
+    \ingroup AES 
+    \brief  この機能は、RFC 5297に記載されているようにSIV（合成初期化ベクトル）復号化を実行する。
+    \return 0  復号化に成功した場合
+    \return BAD_FUNC_ARG  キー、SIV、または出力バッファがNULLの場合。キーサイズが32,48、または64バイトの場合にも返されます。
+    \return AES_SIV_AUTH_E  S2Vによって派生したSIVが入力SIVと一致しない場合（RFC 5297 2.7を参照）。
+    \return Other  AESまたはCMAC操作が失敗した場合に返されるその他の負のエラー値。
+    \param key  使用する鍵を含むバイトバッファ。
+    \param keySz  キーバッファの長さ（バイト単位）。
+    \param assoc  追加の認証された関連データ（AD）。
+    \param assocSz  ADバッファのバイト数
+    \param nonce  一度使用される数。ADと同じ方法で、基礎となるアルゴリズムによって使用されます。
+    \param nonceSz  バイト単位のNOCEバッファの長さ。
+    \param in  復号化する暗号文バッファー。
+    \param inSz  暗号文バッファの長さ
+    \param siv  暗号文に付随するSIV（RFC 5297 2.4を参照）。
+    _Example_
+    \code
+    byte key[] = { some 32, 48, or 64 byte key };
+    byte assoc[] = {0x01, 0x2, 0x3};
+    byte nonce[] = {0x04, 0x5, 0x6};
+    byte cipherText[] = {0xDE, 0xAD, 0xBE, 0xEF};
+    byte siv[AES_BLOCK_SIZE] = { the SIV that came with the ciphertext };
+    byte plainText[sizeof(cipherText)];
+    if (wc_AesSivDecrypt(key, sizeof(key), assoc, sizeof(assoc), nonce,
+        sizeof(nonce), cipherText, sizeof(cipherText), siv, plainText) != 0) {
+        // failed to decrypt
+    }
+    \endcode
+    \sa wc_AesSivEncrypt
+*/
+
+int wc_AesSivDecrypt(const byte* key, word32 keySz, const byte* assoc,
+                     word32 assocSz, const byte* nonce, word32 nonceSz,
+                     const byte* in, word32 inSz, byte* siv, byte* out);

--- a/doc/dox_comments/header_files-ja/arc4.h
+++ b/doc/dox_comments/header_files-ja/arc4.h
@@ -1,0 +1,40 @@
+/*!
+    \ingroup ARC4 
+    \brief  この関数は、バッファ内の入力メッセージを暗号化し、出力バッファーに暗号文を配置するか、またはバッファーから暗号文を復号化したり、ARC4暗号化を使用して、出力バッファーOUTを出力したりします。この関数は暗号化と復号化の両方に使用されます。この方法が呼び出される可能性がある場合は、まずWC_ARC4SETKEYを使用してARC4構造を初期化する必要があります。
+    \return none 
+    \param arc4  メッセージの処理に使用されるARC4構造へのポインタ
+    \param out  処理されたメッセージを保存する出力バッファへのポインタ
+    \param in  プロセスするメッセージを含む入力バッファへのポインタ
+    _Example_
+    \code
+    Arc4 enc;
+    byte key[] = { key to use for encryption };
+    wc_Arc4SetKey(&enc, key, sizeof(key));
+
+    byte plain[] = { plain text to encode };
+    byte cipher[sizeof(plain)];
+    byte decrypted[sizeof(plain)];
+    // encrypt the plain into cipher
+    wc_Arc4Process(&enc, cipher, plain, sizeof(plain));
+    // decrypt the cipher
+    wc_Arc4Process(&enc, decrypted, cipher, sizeof(cipher));
+    \endcode
+    \sa wc_Arc4SetKey
+*/
+int wc_Arc4Process(Arc4* arc4, byte* out, const byte* in, word32 length);
+
+/*!
+    \ingroup ARC4 
+    \brief  この関数はARC4オブジェクトのキーを設定し、それを暗号として使用するために初期化します。WC_ARC4PROCESSを使用した暗号化に使用する前に呼び出される必要があります。
+    \return none 
+    \param arc4  暗号化に使用されるARC4構造へのポインタ
+    \param key  ARC4構造を初期化するためのキー
+    _Example_
+    \code
+    Arc4 enc;
+    byte key[] = { initialize with key to use for encryption };
+    wc_Arc4SetKey(&enc, key, sizeof(key));
+    \endcode
+    \sa wc_Arc4Process
+*/
+int wc_Arc4SetKey(Arc4* arc4, const byte* key, word32 length);

--- a/doc/dox_comments/header_files-ja/asn_public.h
+++ b/doc/dox_comments/header_files-ja/asn_public.h
@@ -1,0 +1,143 @@
+/*!
+    \ingroup ASN 
+    \brief  この関数はデフォルトの証明書を初期化します。デフォルトのオプション：version = 3（0x2）、sigtype = sha_with_rsa、issuer =空白、dayValid = 500、selfsigned = 1（true）発行者としての件名=空白
+    \return none  いいえ返します。
+    _Example_
+    \code
+    Cert myCert;
+    wc_InitCert(&myCert);
+    \endcode
+    \sa wc_MakeCert
+    \sa wc_MakeCertReq
+*/
+int wc_InitCert(Cert*);
+
+/*!
+    \ingroup ASN 
+    \brief  CA署名付き証明書を作成するために使用されます。被写体情報が入力された後に呼び出されました。この関数は、証明書入力からX509証明書V3 RSAまたはECCを作成します。その後、この証明書をDerbufferに書き込みます。証明書を生成するためのRSAKEYまたはECCKEYのいずれかを取ります。このメソッドが呼び出される前に、証明書をWC_INITCERTで初期化する必要があります。
+    \return Success  指定された入力証明書からX509証明書を正常に行うと、生成された証明書のサイズを返します。
+    \return MEMORY_E  xmallocでメモリを割り当てるエラーがある場合
+    \return BUFFER_E  提供されたDerbufferが生成された証明書を保存するには小さすぎる場合に返されます
+    \return Others  証明書の生成が成功しなかった場合、追加のエラーメッセージが返される可能性があります。
+    \param cert  初期化された証明書構造へのポインタ
+    \param derBuffer  生成された証明書を保持するバッファへのポインタ
+    \param derSz  証明書を保存するバッファのサイズ
+    \param rsaKey  証明書の生成に使用されるRSAキーを含むRSAKEY構造体へのポインタ
+    \param eccKey  証明書の生成に使用されるECCキーを含むECCKEY構造体へのポインタ
+    _Example_
+    \code
+    Cert myCert;
+    wc_InitCert(&myCert);
+    WC_RNG rng;
+    //initialize rng;
+    RsaKey key;
+    //initialize key;
+    byte * derCert = malloc(FOURK_BUF);
+    word32 certSz;
+    certSz = wc_MakeCert(&myCert, derCert, FOURK_BUF, &key, NULL, &rng);
+    \endcode
+    \sa wc_InitCert
+    \sa wc_MakeCertReq
+*/
+int  wc_MakeCert(Cert* cert, byte* derBuffer, word32 derSz, RsaKey* rsaKey,
+                             ecc_key* eccKey, WC_RNG* rng);
+
+/*!
+    \ingroup ASN 
+    \brief  この関数は、入力証明書を使用して証明書署名要求を行い、出力をDerbufferに書き込みます。証明書要求を生成するRSAKEYまたはECCKEYのどちらかを取ります。この関数が証明書要求に署名するためにwc_signcert（）を呼び出す必要があります。この関数の使用例については、WolfCryptテストアプリケーション（./wolfcrypt/test/test.c）を参照してください。
+    \return Success  指定された入力証明書からX.509証明書要求を正常に行うと、生成された証明書要求のサイズを返します。
+    \return MEMORY_E  xmallocでメモリを割り当てるエラーがある場合
+    \return BUFFER_E  提供されたDerbufferが生成された証明書を保存するには小さすぎる場合に返されます
+    \return Other  証明書要求生成が成功しなかった場合、追加のエラーメッセージが返される可能性があります。
+    \param cert  初期化された証明書構造へのポインタ
+    \param derBuffer  生成された証明書要求を保持するバッファへのポインタ
+    \param derSz  証明書要求を保存するバッファのサイズ
+    \param rsaKey  証明書要求を生成するために使用されるRSAキーを含むRSAKEY構造体へのポインタ
+    _Example_
+    \code
+    Cert myCert;
+    // initialize myCert
+    EccKey key;
+    //initialize key;
+    byte* derCert = (byte*)malloc(FOURK_BUF);
+
+    word32 certSz;
+    certSz = wc_MakeCertReq(&myCert, derCert, FOURK_BUF, NULL, &key);
+    \endcode
+    \sa wc_InitCert
+    \sa wc_MakeCert
+*/
+int  wc_MakeCertReq(Cert* cert, byte* derBuffer, word32 derSz,
+                                    RsaKey* rsaKey, ecc_key* eccKey);
+
+/*!
+    \ingroup ASN 
+    \brief  この関数はバッファーに署名し、署名をバッファの最後に追加します。署名の種類を取ります。CA署名付き証明書を作成する場合は、wc_makecert（）またはwc_makecertreq（）の後に呼び出す必要があります。
+    \return Success  証明書に正常に署名する場合は、CERTの新しいサイズ（署名を含む）を返します。
+    \return MEMORY_E  xmallocでメモリを割り当てるエラーがある場合
+    \return BUFFER_E  提供された証明書を保存するには提供されたバッファが小さすぎる場合に返されます。
+    \return Other  証明書の生成が成功しなかった場合、追加のエラーメッセージが返される可能性があります。
+    \param requestSz  署名したことを要求している証明書本文のサイズ
+    \param sType  作成する署名の種類。有効なオプションは次のとおりです.CTC_MD5WRSA、CTC_SHAWRSA、CTC_SHAWECDSA、CTC_SHA256WECDSA、ANDCTC_SHA256WRSA
+    \param buffer  署名する証明書を含むバッファへのポインタ。成功：新たに署名された証明書を保持します
+    \param buffSz  新たに署名された証明書を保存するバッファの（合計）サイズ
+    \param rsaKey  証明書に署名するために使用されるRSAキーを含むRSAKEY構造体へのポインタ
+    \param eccKey  証明書に署名するために使用されるECCキーを含むECCKey構造体へのポインタ
+    _Example_
+    \code
+    Cert myCert;
+    byte* derCert = (byte*)malloc(FOURK_BUF);
+    // initialize myCert, derCert
+    RsaKey key;
+    // initialize key;
+    WC_RNG rng;
+    // initialize rng
+
+    word32 certSz;
+    certSz = wc_SignCert(myCert.bodySz, myCert.sigType,derCert,FOURK_BUF,
+    &key, NULL,
+    &rng);
+    \endcode
+    \sa wc_InitCert
+    \sa wc_MakeCert
+*/
+int  wc_SignCert(int requestSz, int sigType, byte* derBuffer,
+                 word32 derSz, RsaKey* rsaKey, ecc_key* eccKey, WC_RNG* rng);
+
+/*!
+    \ingroup ASN 
+    \brief  この関数は、以前の2つの関数、wc_makecert、および自己署名のためのwc_signcertの組み合わせです（前の関数はCA要求に使用される場合があります）。証明書を作成してから、それに署名し、自己署名証明書を生成します。
+    \return Success  証明書に正常に署名する場合は、CERTの新しいサイズを返します。
+    \return MEMORY_E  xmallocでメモリを割り当てるエラーがある場合
+    \return BUFFER_E  提供された証明書を保存するには提供されたバッファが小さすぎる場合に返されます。
+    \return Other  証明書の生成が成功しなかった場合、追加のエラーメッセージが返される可能性があります。
+    \param cert  作成して署名する証明書へのポインタ
+    \param buffer  署名付き証明書を保持するためのバッファへのポインタ
+    \param buffSz  署名付き証明書を保存するバッファのサイズ
+    \param key  証明書に署名するために使用されるRSAキーを含むRSAKEY構造体へのポインタ
+    _Example_
+    \code
+    Cert myCert;
+    byte* derCert = (byte*)malloc(FOURK_BUF);
+    // initialize myCert, derCert
+    RsaKey key;
+    // initialize key;
+    WC_RNG rng;
+    // initialize rng
+
+    word32 certSz;
+    certSz = wc_MakeSelfCert(&myCert, derCert, FOURK_BUF, &key, NULL, &rng);
+    \endcode
+    \sa wc_InitCert
+    \sa wc_MakeCert
+    \sa wc_SignCert
+*/
+int  wc_MakeSelfCert(Cert* cert, byte* derBuffer, word32 derSz, RsaKey* key,
+                             WC_RNG* rng);
+
+/*!
+    \ingroup ASN 
+    \brief  この関数は、提供されたPEM ISSUERFILE内の証明書の発行者を発行者に設定します。また、証明書の自己署名属性をfalseに変更します。ISSUERFILEで指定された発行者は、CERT発行者を設定する前に確認されます。このメソッドは、署名の前にフィールドを設定するために使用されます。
+    \return 0  証明書の発行者を正常に設定した
+    \return MEMORY_E  xmallocでメモリを割り当てるエラーがある場合
+    \return ASN_PARSE_E  CERTヘッダーファイルの解析中にエラーがある場合は返されます。

--- a/doc/dox_comments/header_files-ja/blake2.h
+++ b/doc/dox_comments/header_files-ja/blake2.h
@@ -1,0 +1,66 @@
+/*!
+    \ingroup BLAKE2 
+    \brief  この関数はBlake2 Hash関数で使用するためのBlake2b構造を初期化します。
+    \return 0  Blake2B構造の初期化に成功し、ダイジェストサイズを設定したときに返されます。
+    \param b2b  初期化するためにBlake2b構造へのポインタ
+    _Example_
+    \code
+    Blake2b b2b;
+    // initialize Blake2b structure with 64 byte digest
+    wc_InitBlake2b(&b2b, 64);
+    \endcode
+    \sa wc_Blake2bUpdate
+*/
+int wc_InitBlake2b(Blake2b* b2b, word32 digestSz);
+
+/*!
+    \ingroup BLAKE2 
+    \brief  この関数は、与えられた入力データとBlake2Bハッシュを更新します。この関数は、wc_initblake2bの後に呼び出され、最後のハッシュ：wc_blake2bfinalの準備ができているまで繰り返します。
+    \return 0  与えられたデータを使用してBlake2B構造を正常に更新すると返されます。
+    \return -1  入力データの圧縮中に障害が発生した場合
+    \param b2b  更新するBlake2b構造へのポインタ
+    \param data  追加するデータを含むバッファへのポインタ
+    _Example_
+    \code
+    int ret;
+    Blake2b b2b;
+    // initialize Blake2b structure with 64 byte digest
+    wc_InitBlake2b(&b2b, 64);
+
+    byte plain[] = { // initialize input };
+
+    ret = wc_Blake2bUpdate(&b2b, plain, sizeof(plain));
+    if( ret != 0) {
+    	// error updating blake2b
+    }
+    \endcode
+    \sa wc_InitBlake2b
+    \sa wc_Blake2bFinal
+*/
+int wc_Blake2bUpdate(Blake2b* b2b, const byte* data, word32 sz);
+
+/*!
+    \ingroup BLAKE2 
+    \brief  この関数は、以前に供給された入力データのBlake2bハッシュを計算します。出力ハッシュは長さREQUESTSZ、あるいは要求された場合はB2B構造のDigestSZを使用します。この関数は、wc_initblake2bの後に呼び出され、wc_blake2bupdateは必要な各入力データに対して処理されています。
+    \return 0  Blake2B Hashの計算に成功したときに返されました
+    \return -1  blake2bハッシュを解析している間に失敗がある場合
+    \param b2b  更新するBlake2b構造へのポインタ
+    \param final  Blake2Bハッシュを保存するバッファへのポインタ。長さrequestszにする必要があります
+    _Example_
+    \code
+    int ret;
+    Blake2b b2b;
+    byte hash[64];
+    // initialize Blake2b structure with 64 byte digest
+    wc_InitBlake2b(&b2b, 64);
+    ... // call wc_Blake2bUpdate to add data to hash
+
+    ret = wc_Blake2bFinal(&b2b, hash, 64);
+    if( ret != 0) {
+    	// error generating blake2b hash
+    }
+    \endcode
+    \sa wc_InitBlake2b
+    \sa wc_Blake2bUpdate
+*/
+int wc_Blake2bFinal(Blake2b* b2b, byte* final, word32 requestSz);

--- a/doc/dox_comments/header_files-ja/bn.h
+++ b/doc/dox_comments/header_files-ja/bn.h
@@ -1,0 +1,22 @@
+/*!
+    \ingroup openSSL 
+    \brief  この関数は、次の数学「R =（A ^ P）％M」を実行します。
+    \return SSL_SUCCESS  数学操作をうまく実行します。
+    \return SSL_FAILURE  エラーケースに遭遇した場合
+    \param r  結果を保持するための構造。
+    \param a  電力で上げられる値。
+    \param p  によって上げる力。
+    \param m  使用率
+    _Example_
+    \code
+    WOLFSSL_BIGNUM r,a,p,m;
+    int ret;
+    // set big number values
+    ret  = wolfSSL_BN_mod_exp(r, a, p, m, NULL);
+    // check ret value
+    \endcode
+    \sa wolfSSL_BN_new
+    \sa wolfSSL_BN_free
+*/
+int wolfSSL_BN_mod_exp(WOLFSSL_BIGNUM *r, const WOLFSSL_BIGNUM *a,
+        const WOLFSSL_BIGNUM *p, const WOLFSSL_BIGNUM *m, WOLFSSL_BN_CTX *ctx);

--- a/doc/dox_comments/header_files-ja/camellia.h
+++ b/doc/dox_comments/header_files-ja/camellia.h
@@ -1,0 +1,128 @@
+/*!
+    \ingroup Camellia 
+    \brief  この関数は、Camelliaオブジェクトのキーと初期化ベクトルを設定し、それを暗号として使用するために初期化します。
+    \return 0  キーと初期化ベクトルを正常に設定すると返されます
+    \return BAD_FUNC_ARG  入力引数の1つがエラー処理がある場合に返されます
+    \return MEMORY_E  xmallocでメモリを割り当てるエラーがある場合
+    \param cam  キーとIVを設定する椿構造へのポインタ
+    \param key  暗号化と復号化に使用する16,24、または32バイトのキーを含むバッファへのポインタ
+    \param len  渡されたキーの長さ
+    _Example_
+    \code
+    Camellia cam;
+    byte key[32];
+    // initialize key
+    byte iv[16];
+    // initialize iv
+    if( wc_CamelliaSetKey(&cam, key, sizeof(key), iv) != 0) {
+    	// error initializing camellia structure
+    }
+    \endcode
+    \sa wc_CamelliaEncryptDirect
+    \sa wc_CamelliaDecryptDirect
+    \sa wc_CamelliaCbcEncrypt
+    \sa wc_CamelliaCbcDecrypt
+*/
+int  wc_CamelliaSetKey(Camellia* cam,
+                                   const byte* key, word32 len, const byte* iv);
+
+/*!
+    \ingroup Camellia 
+    \brief  この関数は、Camelliaオブジェクトの初期化ベクトルを設定します。
+    \return 0  キーと初期化ベクトルを正常に設定すると返されます
+    \return BAD_FUNC_ARG  入力引数の1つがエラー処理がある場合に返されます
+    \param cam  IVを設定する椿構造へのポインタ
+    _Example_
+    \code
+    Camellia cam;
+    byte iv[16];
+    // initialize iv
+    if( wc_CamelliaSetIV(&cam, iv) != 0) {
+	// error initializing camellia structure
+    }
+    \endcode
+    \sa wc_CamelliaSetKey
+*/
+int  wc_CamelliaSetIV(Camellia* cam, const byte* iv);
+
+/*!
+    \ingroup Camellia 
+    \brief  この機能は、提供されたCamelliaオブジェクトを使用して1ブロック暗号化します。それはバッファーの最初の16バイトブロックを解析し、暗号化結果をバッファアウトに格納します。この機能を使用する前に、WC_CAMELLIASETKEYを使用してCamelliaオブジェクトを初期化する必要があります。
+    \return none  いいえ返します。
+    \param cam  暗号化に使用する椿構造へのポインタ
+    \param out  暗号化されたブロックを保存するバッファへのポインタ
+    _Example_
+    \code
+    Camellia cam;
+    // initialize cam structure with key and iv
+    byte plain[] = { // initialize with message to encrypt };
+    byte cipher[16];
+
+    wc_CamelliaEncryptDirect(&ca, cipher, plain);
+    \endcode
+    \sa wc_CamelliaDecryptDirect
+*/
+int  wc_CamelliaEncryptDirect(Camellia* cam, byte* out,
+                                                                const byte* in);
+
+/*!
+    \ingroup Camellia 
+    \brief  この機能は、提供されたCamelliaオブジェクトを使用して1ブロック復号化します。それはバッファ内の最初の16バイトブロックを解析し、それを復号化し、結果をバッファアウトに格納します。この機能を使用する前に、WC_CAMELLIASETKEYを使用してCamelliaオブジェクトを初期化する必要があります。
+    \return none  いいえ返します。
+    \param cam  暗号化に使用する椿構造へのポインタ
+    \param out  復号化された平文ブロックを保存するバッファへのポインタ
+    _Example_
+    \code
+    Camellia cam;
+    // initialize cam structure with key and iv
+    byte cipher[] = { // initialize with encrypted message to decrypt };
+    byte decrypted[16];
+
+    wc_CamelliaDecryptDirect(&cam, decrypted, cipher);
+    \endcode
+    \sa wc_CamelliaEncryptDirect
+*/
+int  wc_CamelliaDecryptDirect(Camellia* cam, byte* out,
+                                                                const byte* in);
+
+/*!
+    \ingroup Camellia 
+    \brief  この関数は、バッファーの平文を暗号化し、その出力をバッファOUTに格納します。暗号ブロックチェーン（CBC）を使用してCamelliaを使用してこの暗号化を実行します。
+    \return none  いいえ返します。
+    \param cam  暗号化に使用する椿構造へのポインタ
+    \param out  暗号化された暗号文を保存するバッファへのポインタ
+    \param in  暗号化する平文を含むバッファへのポインタ
+    _Example_
+    \code
+    Camellia cam;
+    // initialize cam structure with key and iv
+    byte plain[] = { // initialize with encrypted message to decrypt };
+    byte cipher[sizeof(plain)];
+
+    wc_CamelliaCbcEncrypt(&cam, cipher, plain, sizeof(plain));
+    \endcode
+    \sa wc_CamelliaCbcDecrypt
+*/
+int wc_CamelliaCbcEncrypt(Camellia* cam,
+                                          byte* out, const byte* in, word32 sz);
+
+/*!
+    \ingroup Camellia 
+    \brief  この関数は、バッファ内の暗号文を復号化し、その出力をバッファOUTに格納します。暗号ブロックチェーン（CBC）を搭載したCamelliaを使用してこの復号化を実行します。
+    \return none  いいえ返します。
+    \param cam  暗号化に使用する椿構造へのポインタ
+    \param out  復号化されたメッセージを保存するバッファへのポインタ
+    \param in  暗号化された暗号文を含むバッファへのポインタ
+    _Example_
+    \code
+    Camellia cam;
+    // initialize cam structure with key and iv
+    byte cipher[] = { // initialize with encrypted message to decrypt };
+    byte decrypted[sizeof(cipher)];
+
+    wc_CamelliaCbcDecrypt(&cam, decrypted, cipher, sizeof(cipher));
+    \endcode
+    \sa wc_CamelliaCbcEncrypt
+*/
+int wc_CamelliaCbcDecrypt(Camellia* cam,
+                                          byte* out, const byte* in, word32 sz);

--- a/doc/dox_comments/header_files-ja/chacha.h
+++ b/doc/dox_comments/header_files-ja/chacha.h
@@ -1,0 +1,67 @@
+/*!
+    \ingroup ChaCha 
+    \brief  この関数はChachaオブジェクトの初期化ベクトル（nonce）を設定し、暗号として使用するために初期化します。WC_CHACHA_SETKEYを使用して、キーが設定された後に呼び出されるべきです。暗号化の各ラウンドに差し違いを使用する必要があります。
+    \return 0  初期化ベクトルを正常に設定すると返されます
+    \return BAD_FUNC_ARG  CTX入力引数の処理中にエラーが発生した場合
+    \param ctx  IVを設定するChacha構造へのポインタ
+    \param inIv  Chacha構造を初期化するための12バイトの初期化ベクトルを含むバッファへのポインタ
+    _Example_
+    \code
+    ChaCha enc;
+    // initialize enc with wc_Chacha_SetKey
+    byte iv[12];
+    // initialize iv
+    if( wc_Chacha_SetIV(&enc, iv, 0) != 0) {
+	    // error initializing ChaCha structure
+    }
+    \endcode
+    \sa wc_Chacha_SetKey
+    \sa wc_Chacha_Process
+*/
+int wc_Chacha_SetIV(ChaCha* ctx, const byte* inIv, word32 counter);
+
+/*!
+    \ingroup ChaCha 
+    \brief  この関数は、バッファ入力からテキストを処理し、暗号化または復号化し、結果をバッファ出力に格納します。
+    \return 0  入力の暗号化または復号化に成功したときに返されます
+    \return BAD_FUNC_ARG  CTX入力引数の処理中にエラーが発生した場合
+    \param ctx  IVを設定するChacha構造へのポインタ
+    \param output  出力暗号文または復号化された平文を保存するバッファへのポインタ
+    \param input  暗号化する入力平文を含むバッファへのポインタまたは復号化する入力暗号文
+    _Example_
+    \code
+    ChaCha enc;
+    // initialize enc with wc_Chacha_SetKey and wc_Chacha_SetIV
+
+    byte plain[] = { // initialize plaintext };
+    byte cipher[sizeof(plain)];
+    if( wc_Chacha_Process(&enc, cipher, plain, sizeof(plain)) != 0) {
+	    // error processing ChaCha cipher
+    }
+    \endcode
+    \sa wc_Chacha_SetKey
+    \sa wc_Chacha_Process
+*/
+int wc_Chacha_Process(ChaCha* ctx, byte* cipher, const byte* plain,
+                              word32 msglen);
+
+/*!
+    \ingroup ChaCha 
+    \brief  この関数はChachaオブジェクトのキーを設定し、それを暗号として使用するために初期化します。NONCEをWC_CHACHA_SETIVで設定する前に、WC_CHACHA_PROCESSを使用した暗号化に使用する前に呼び出す必要があります。
+    \return 0  キーの設定に成功したときに返されます
+    \return BAD_FUNC_ARG  CTX入力引数の処理中にエラーが発生した場合、またはキーが16または32バイトの長さがある場合
+    \param ctx  キーを設定するChacha構造へのポインタ
+    \param key  Chacha構造を初期化するための16または32バイトのキーを含むバッファへのポインタ
+    _Example_
+    \code
+    ChaCha enc;
+    byte key[] = { // initialize key };
+
+    if( wc_Chacha_SetKey(&enc, key, sizeof(key)) != 0) {
+	    // error initializing ChaCha structure
+    }
+    \endcode
+    \sa wc_Chacha_SetIV
+    \sa wc_Chacha_Process
+*/
+int wc_Chacha_SetKey(ChaCha* ctx, const byte* key, word32 keySz);

--- a/doc/dox_comments/header_files-ja/chacha20_poly1305.h
+++ b/doc/dox_comments/header_files-ja/chacha20_poly1305.h
@@ -1,0 +1,87 @@
+/*!
+    \ingroup ChaCha20Poly1305 
+    \brief  この関数は、Chacha20 Stream暗号を使用して、Chacha20 Stream暗号を使用して、Output BufferTextに入力メッセージ、InPleaintextを暗号化します。また、Poly-1305認証（暗号テキスト）を実行し、生成した認証タグを出力バッファOutauthTagに格納します。
+    \return 0  メッセージの暗号化に成功したら返されました
+    \return BAD_FUNC_ARG  暗号化プロセス中にエラーがある場合
+    \param inKey  暗号化に使用する32バイトのキーを含むバッファへのポインタ
+    \param inIv  暗号化に使用する12バイトのIVを含むバッファへのポインタ
+    \param inAAD  任意の長さの追加認証データ（AAD）を含むバッファへのポインタ
+    \param inAADLen  入力AADの長さ
+    \param inPlaintext  暗号化する平文を含むバッファへのポインタ
+    \param inPlaintextLen  暗号化するプレーンテキストの長さ
+    \param outCiphertext  暗号文を保存するバッファーへのポインタ
+    _Example_
+    \code
+    byte key[] = { // initialize 32 byte key };
+    byte iv[]  = { // initialize 12 byte key };
+    byte inAAD[] = { // initialize AAD };
+
+    byte plain[] = { // initialize message to encrypt };
+    byte cipher[sizeof(plain)];
+    byte authTag[16];
+
+    int ret = wc_ChaCha20Poly1305_Encrypt(key, iv, inAAD, sizeof(inAAD),
+    plain, sizeof(plain), cipher, authTag);
+
+    if(ret != 0) {
+    	// error running encrypt
+    }
+    \endcode
+    \sa wc_ChaCha20Poly1305_Decrypt
+    \sa wc_ChaCha_*
+    \sa wc_Poly1305*
+*/
+
+int wc_ChaCha20Poly1305_Encrypt(
+                const byte inKey[CHACHA20_POLY1305_AEAD_KEYSIZE],
+                const byte inIV[CHACHA20_POLY1305_AEAD_IV_SIZE],
+                const byte* inAAD, const word32 inAADLen,
+                const byte* inPlaintext, const word32 inPlaintextLen,
+                byte* outCiphertext,
+                byte outAuthTag[CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE]);
+
+/*!
+    \ingroup ChaCha20Poly1305 
+    \brief  この関数は、Chacha20 Stream暗号を使用して、Chacha20 Stream暗号を使用して、出力バッファ、OutpleAntextに入力された暗号文の入力を復号化します。また、Poly-1305認証を実行し、指定されたINAUTHTAGをINAADで生成された認証（任意の長さの追加認証データ）と比較します。注：生成された認証タグが提供された認証タグと一致しない場合、テキストは復号化されません。
+    \return 0  メッセージの復号化に成功したときに返されました
+    \return BAD_FUNC_ARG  関数引数のいずれかが予想されるものと一致しない場合に返されます
+    \return MAC_CMP_FAILED_E  生成された認証タグが提供されているINAUTHTAGと一致しない場合に返されます。
+    \param inKey  復号化に使用する32バイトのキーを含むバッファへのポインタ
+    \param inIv  復号化に使用する12バイトのIVを含むバッファへのポインタ
+    \param inAAD  任意の長さの追加認証データ（AAD）を含むバッファへのポインタ
+    \param inAADLen  入力AADの長さ
+    \param inCiphertext  復号化する暗号文を含むバッファへのポインタ
+    \param outCiphertextLen  復号化する暗号文の長さ
+    \param inAuthTag  認証のための16バイトのダイジェストを含むバッファへのポインタ
+    _Example_
+    \code
+    byte key[]   = { // initialize 32 byte key };
+    byte iv[]    = { // initialize 12 byte key };
+    byte inAAD[] = { // initialize AAD };
+
+    byte cipher[]    = { // initialize with received ciphertext };
+    byte authTag[16] = { // initialize with received authentication tag };
+
+    byte plain[sizeof(cipher)];
+
+    int ret = wc_ChaCha20Poly1305_Decrypt(key, iv, inAAD, sizeof(inAAD),
+    cipher, sizeof(cipher), plain, authTag);
+
+    if(ret == MAC_CMP_FAILED_E) {
+    	// error during authentication
+    } else if( ret != 0) {
+    	// error with function arguments
+    }
+    \endcode
+    \sa wc_ChaCha20Poly1305_Encrypt
+    \sa wc_ChaCha_*
+    \sa wc_Poly1305*
+*/
+
+int wc_ChaCha20Poly1305_Decrypt(
+                const byte inKey[CHACHA20_POLY1305_AEAD_KEYSIZE],
+                const byte inIV[CHACHA20_POLY1305_AEAD_IV_SIZE],
+                const byte* inAAD, const word32 inAADLen,
+                const byte* inCiphertext, const word32 inCiphertextLen,
+                const byte inAuthTag[CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE],
+                byte* outPlaintext);

--- a/doc/dox_comments/header_files-ja/coding.h
+++ b/doc/dox_comments/header_files-ja/coding.h
@@ -1,0 +1,158 @@
+/*!
+    \ingroup Base_Encoding 
+    \brief  この機能は、与えられたBASS64符号化入力、IN、および出力バッファを出力バッファOUTに格納します。また、変数outlen内の出力バッファに書き込まれたサイズも設定します。
+    \return 0  Base64エンコード入力の復号化に成功したときに返されます
+    \return BAD_FUNC_ARG  復号化された入力を保存するには、出力バッファが小さすぎる場合は返されます。
+    \return ASN_INPUT_E  入力バッファ内の文字がBASE64範囲（[A-ZA-Z0-9 + / =]）の外側にある場合、またはBASE64エンコード入力に無効な行が終了した場合
+    \param in  デコードする入力バッファへのポインタ
+    \param inLen  デコードする入力バッファの長さ
+    \param out  デコードされたメッセージを保存する出力バッファへのポインタ
+    _Example_
+    \code
+    byte encoded[] = { // initialize text to decode };
+    byte decoded[sizeof(encoded)];
+    // requires at least (sizeof(encoded) * 3 + 3) / 4 room
+
+    int outLen = sizeof(decoded);
+
+    if( Base64_Decode(encoded,sizeof(encoded), decoded, &outLen) != 0 ) {
+    	// error decoding input buffer
+    }
+    \endcode
+    \sa Base64_Encode
+    \sa Base16_Decode
+*/
+int Base64_Decode(const byte* in, word32 inLen, byte* out,
+                               word32* outLen);
+
+/*!
+    \ingroup Base_Encoding 
+    \brief  この機能は与えられた入力を符号化し、符号化結果を出力バッファOUTに格納します。エスケープ％0A行末の代わりに、従来の '\ N'行の終わりを持つデータを書き込みます。正常に完了すると、この機能はまた、出力バッファに書き込まれたバイト数に統一されます。
+    \return 0  Base64エンコード入力の復号化に成功したときに返されます
+    \return BAD_FUNC_ARG  出力バッファが小さすぎてエンコードされた入力を保存する場合は返されます。
+    \return BUFFER_E  出力バッファがエンコード中に部屋の外に実行された場合に返されます。
+    \param in  エンコードする入力バッファへのポインタ
+    \param inLen  エンコードする入力バッファの長さ
+    \param out  エンコードされたメッセージを保存する出力バッファへのポインタ
+    _Example_
+    \code
+    byte plain[] = { // initialize text to encode };
+    byte encoded[MAX_BUFFER_SIZE];
+
+    int outLen = sizeof(encoded);
+
+    if( Base64_Encode(plain, sizeof(plain), encoded, &outLen) != 0 ) {
+    	// error encoding input buffer
+    }
+    \endcode
+    \sa Base64_EncodeEsc
+    \sa Base64_Decode
+*/
+
+int Base64_Encode(const byte* in, word32 inLen, byte* out,
+                                  word32* outLen);
+
+/*!
+    \ingroup Base_Encoding 
+    \brief  この機能は与えられた入力を符号化し、符号化結果を出力バッファOUTに格納します。それは '\ n "行の終わりではなく、％0aエスケープ行の終わりを持つデータを書き込みます。正常に完了すると、この機能はまた、出力バッファに書き込まれたバイト数に統一されます。
+    \return 0  Base64エンコード入力の復号化に成功したときに返されます
+    \return BAD_FUNC_ARG  出力バッファが小さすぎてエンコードされた入力を保存する場合は返されます。
+    \return BUFFER_E  出力バッファがエンコード中に部屋の外に実行された場合に返されます。
+    \return ASN_INPUT_E  入力メッセージのデコードの処理中にエラーが発生した場合
+    \param in  エンコードする入力バッファへのポインタ
+    \param inLen  エンコードする入力バッファの長さ
+    \param out  エンコードされたメッセージを保存する出力バッファへのポインタ
+    _Example_
+    \code
+    byte plain[] = { // initialize text to encode };
+    byte encoded[MAX_BUFFER_SIZE];
+
+    int outLen = sizeof(encoded);
+
+    if( Base64_EncodeEsc(plain, sizeof(plain), encoded, &outLen) != 0 ) {
+    	// error encoding input buffer
+    }
+    \endcode
+    \sa Base64_Encode
+    \sa Base64_Decode
+*/
+int Base64_EncodeEsc(const byte* in, word32 inLen, byte* out,
+                                  word32* outLen);
+
+/*!
+    \ingroup Base_Encoding 
+    \brief  この機能は与えられた入力を符号化し、符号化結果を出力バッファOUTに格納します。それは新しい行なしでデータを書き込みます。正常に完了すると、この関数はまた、出力バッファに書き込まれたバイト数に統一されたものを設定します
+    \return 0  Base64エンコード入力の復号化に成功したときに返されます
+    \return BAD_FUNC_ARG  出力バッファが小さすぎてエンコードされた入力を保存する場合は返されます。
+    \return BUFFER_E  出力バッファがエンコード中に部屋の外に実行された場合に返されます。
+    \return ASN_INPUT_E  入力メッセージのデコードの処理中にエラーが発生した場合
+    \param in  エンコードする入力バッファへのポインタ
+    \param inLen  エンコードする入力バッファの長さ
+    \param out  エンコードされたメッセージを保存する出力バッファへのポインタ
+    _Example_
+    \code
+    byte plain[] = { // initialize text to encode };
+    byte encoded[MAX_BUFFER_SIZE];
+    int outLen = sizeof(encoded);
+    if( Base64_Encode_NoNl(plain, sizeof(plain), encoded, &outLen) != 0 ) {
+    	// error encoding input buffer
+    }
+    \endcode
+    \sa Base64_Encode
+    \sa Base64_Decode
+*/
+
+int Base64_Encode_NoNl(const byte* in, word32 inLen, byte* out,
+                                  word32* outLen);
+
+/*!
+    \ingroup Base_Encoding 
+    \brief  この機能は、与えられたBASE16符号化入力、IN、および出力バッファへの結果を記憶する。また、変数outlen内の出力バッファに書き込まれたサイズも設定します。
+    \return 0  Base16エンコード入力の復号にうまく復号化したときに返されます
+    \return BAD_FUNC_ARG  出力バッファが復号化された入力を保存するにも小さすぎる場合、または入力長が2つの倍数でない場合に返されます。
+    \return ASN_INPUT_E  入力バッファ内の文字がBASE16の範囲外にある場合は返されます（[0-9a-f]）
+    \param in  デコードする入力バッファへのポインタ
+    \param inLen  デコードする入力バッファの長さ
+    \param out  デコードされたメッセージを保存する出力バッファへのポインタ
+    _Example_
+    \code
+    byte encoded[] = { // initialize text to decode };
+    byte decoded[sizeof(encoded)];
+    int outLen = sizeof(decoded);
+
+    if( Base16_Decode(encoded,sizeof(encoded), decoded, &outLen) != 0 ) {
+    	// error decoding input buffer
+    }
+    \endcode
+    \sa Base64_Encode
+    \sa Base64_Decode
+    \sa Base16_Encode
+*/
+
+int Base16_Decode(const byte* in, word32 inLen, byte* out, word32* outLen);
+
+/*!
+    \ingroup Base_Encoding 
+    \brief  BASE16出力へのエンコード入力。
+    \return 0  成功
+    \return BAD_FUNC_ARG  IN、OUT、またはoutlenがNULLの場合、またはoutlenがInlen Plus 1を超えている場合は返します。
+    \param in  エンコードされる入力バッファへのポインタ。
+    \param inLen  入力バッファの長さ
+    \param out  出力バッファへのポインタ。
+    _Example_
+    \code
+    byte in[] = { // Contents of something to be encoded };
+    byte out[NECESSARY_OUTPUT_SIZE];
+    word32 outSz = sizeof(out);
+
+    if(Base16_Encode(in, sizeof(in), out, &outSz) != 0)
+    {
+        // Handle encode error
+    }
+    \endcode
+    \sa Base64_Encode
+    \sa Base64_Decode
+    \sa Base16_Decode
+*/
+
+int Base16_Encode(const byte* in, word32 inLen, byte* out, word32* outLen);

--- a/doc/dox_comments/header_files-ja/compress.h
+++ b/doc/dox_comments/header_files-ja/compress.h
@@ -1,0 +1,47 @@
+/*!
+    \ingroup Compression 
+    \brief  この関数は、ハフマン符号化を用いて与えられた入力データを圧縮し、出力をOUTに格納する。出力バッファは、圧縮が可能でないことが存在するため、出力バッファが入力バッファよりも大きいはずです。これはまだルックアップテーブルを必要とします。出力バッファに対してSRCSZ + 0.1％+ 12を割り当てることをお勧めします。
+    \return On  入力データの圧縮に成功し、出力バッファに格納されているバイト数を返します。
+    \return COMPRESS_INIT_E  圧縮のためにストリームの初期化中にエラーがある場合
+    \return COMPRESS_E  圧縮中にエラーが発生した場合は返されます
+    \param out  圧縮データを格納する出力バッファへのポインタ
+    \param outSz  出力バッファで保存されているサイズ
+    \param in  圧縮するメッセージを含むバッファへのポインタ
+    \param inSz  圧縮する入力メッセージのサイズ
+    _Example_
+    \code
+    byte message[] = { // initialize text to compress };
+    byte compressed[(sizeof(message) + sizeof(message) * .001 + 12 )];
+    // Recommends at least srcSz + .1% + 12
+
+    if( wc_Compress(compressed, sizeof(compressed), message, sizeof(message),
+    0) != 0){
+    	// error compressing data
+    }
+    \endcode
+    \sa wc_DeCompress
+*/
+int wc_Compress(byte* out, word32 outSz, const byte* in, word32 inSz, word32 flags);
+
+/*!
+    \ingroup Compression 
+    \brief  この関数は、ハフマン符号化を用いて所定の圧縮データを解凍し、出力をOUTに格納する。
+    \return Success  入力データの解凍に成功した場合は、出力バッファに格納されているバイト数を返します。
+    \return COMPRESS_INIT_E:  圧縮のためにストリームの初期化中にエラーがある場合
+    \return COMPRESS_E:  圧縮中にエラーが発生した場合は返されます
+    \param out  解凍されたデータを格納する出力バッファへのポインタ
+    \param outSz  出力バッファで保存されているサイズ
+    \param in  解凍するメッセージを含むバッファへのポインタ
+    _Example_
+    \code
+    byte compressed[] = { // initialize compressed message };
+    byte decompressed[MAX_MESSAGE_SIZE];
+
+    if( wc_DeCompress(decompressed, sizeof(decompressed),
+    compressed, sizeof(compressed)) != 0 ) {
+    	// error decompressing data
+    }
+    \endcode
+    \sa wc_Compress
+*/
+int wc_DeCompress(byte* out, word32 outSz, const byte* in, word32 inSz);

--- a/doc/dox_comments/header_files-ja/cryptocb.h
+++ b/doc/dox_comments/header_files-ja/cryptocb.h
@@ -1,0 +1,89 @@
+/*!
+    \ingroup CryptoCb 
+    \brief  この関数は、Crypto Operationsをキーストア、Secure Element、HSM、PKCS11またはTPMなどの外部ハードウェアにオフロードするための固有のデバイス識別子（DEVID）とコールバック関数を登録します。CryptoコールバックのSTSAFEの場合は、wolfcrypt / src / port / st / stsafe.cとwolfssl_stsafe_cryptodevcb関数を参照してください。TPMベースのCryptoコールバックの例では、wolftpm src / tpm2_wrap.cのwolftpm2_cryptodevcb関数を参照してください。
+    \return CRYPTOCB_UNAVAILABLE  ソフトウェア暗号を使用するためにフォールバックする
+    \return 0  成功のために
+    \return negative  失敗の値
+    \param devId  -2（invalid_devid）ではなく、一意の値ではありません。
+    _Example_
+    \code
+    #include <wolfssl/wolfcrypt/settings.h>
+    #include <wolfssl/wolfcrypt/cryptocb.h>
+    static int myCryptoCb_Func(int devId, wc_CryptoInfo* info, void* ctx)
+    {
+        int ret = CRYPTOCB_UNAVAILABLE;
+
+        if (info->algo_type == WC_ALGO_TYPE_PK) {
+        #ifndef NO_RSA
+            if (info->pk.type == WC_PK_TYPE_RSA) {
+                switch (info->pk.rsa.type) {
+                    case RSA_PUBLIC_ENCRYPT:
+                    case RSA_PUBLIC_DECRYPT:
+                        // RSA public op
+                        ret = wc_RsaFunction(
+                            info->pk.rsa.in, info->pk.rsa.inLen,
+                            info->pk.rsa.out, info->pk.rsa.outLen,
+                            info->pk.rsa.type, info->pk.rsa.key,
+                            info->pk.rsa.rng);
+                        break;
+                    case RSA_PRIVATE_ENCRYPT:
+                    case RSA_PRIVATE_DECRYPT:
+                        // RSA private op
+                        ret = wc_RsaFunction(
+                            info->pk.rsa.in, info->pk.rsa.inLen,
+                            info->pk.rsa.out, info->pk.rsa.outLen,
+                            info->pk.rsa.type, info->pk.rsa.key,
+                            info->pk.rsa.rng);
+                        break;
+                }
+            }
+        #endif
+        #ifdef HAVE_ECC
+            if (info->pk.type == WC_PK_TYPE_ECDSA_SIGN) {
+                // ECDSA
+                ret = wc_ecc_sign_hash(
+                    info->pk.eccsign.in, info->pk.eccsign.inlen,
+                    info->pk.eccsign.out, info->pk.eccsign.outlen,
+                    info->pk.eccsign.rng, info->pk.eccsign.key);
+            }
+        #endif
+        #ifdef HAVE_ED25519
+            if (info->pk.type == WC_PK_TYPE_ED25519_SIGN) {
+                // ED25519 sign
+                ret = wc_ed25519_sign_msg_ex(
+                    info->pk.ed25519sign.in, info->pk.ed25519sign.inLen,
+                    info->pk.ed25519sign.out, info->pk.ed25519sign.outLen,
+                    info->pk.ed25519sign.key, info->pk.ed25519sign.type,
+                    info->pk.ed25519sign.context,
+                    info->pk.ed25519sign.contextLen);
+            }
+        #endif
+        }
+        return ret;
+    }
+
+    int devId = 1;
+    wc_CryptoCb_RegisterDevice(devId, myCryptoCb_Func, &myCtx);
+    wolfSSL_CTX_SetDevId(ctx, devId);
+    \endcode
+    \sa wc_CryptoCb_UnRegisterDevice
+    \sa wolfSSL_SetDevId
+    \sa wolfSSL_CTX_SetDevId
+*/
+int  wc_CryptoCb_RegisterDevice(int devId, CryptoDevCallbackFunc cb, void* ctx);
+
+/*!
+    \ingroup CryptoCb 
+    \brief  この関数は、固有のデバイス識別子（devid）コールバック関数を除外します。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    wc_CryptoCb_UnRegisterDevice(devId);
+    devId = INVALID_DEVID;
+    wolfSSL_CTX_SetDevId(ctx, devId);
+    \endcode
+    \sa wc_CryptoCb_RegisterDevice
+    \sa wolfSSL_SetDevId
+    \sa wolfSSL_CTX_SetDevId
+*/
+void wc_CryptoCb_UnRegisterDevice(int devId);

--- a/doc/dox_comments/header_files-ja/curve25519.h
+++ b/doc/dox_comments/header_files-ja/curve25519.h
@@ -1,0 +1,575 @@
+/*!
+    \ingroup Curve25519 
+    \brief  この関数は、与えられたサイズ（Keysize）の指定された乱数発生器RNGを使用してCurve25519キーを生成し、それを指定されたCurve25519_Key構造体に格納します。キー構造がWC_CURVE25519_INIT（）を介して初期化された後に呼び出されるべきです。
+    \return 0  キーの生成に成功し、それを指定されたCurve25519_Key構造体に格納します。
+    \return ECC_BAD_ARG_E  入力キーサイズがCurve25519キー（32バイト）のキーシェイズに対応していない場合は返されます。
+    \return RNG_FAILURE_E  RNGの内部ステータスがDRBG_OKでない場合、またはRNGを使用して次のランダムブロックを生成する場合に返されます。
+    \return BAD_FUNC_ARG  渡された入力パラメータのいずれかがNULLの場合に返されます。
+    \param [in]  RNG ECCキーの生成に使用されるRNGオブジェクトへのポインタ。
+    \param [in]  キーサイズ生成キーのサイズ。Curve25519の32バイトでなければなりません。
+    _Example_
+    \code
+    int ret;
+
+    curve25519_key key;
+    wc_curve25519_init(&key); // initialize key
+    WC_RNG rng;
+    wc_InitRng(&rng); // initialize random number generator
+
+    ret = wc_curve25519_make_key(&rng, 32, &key);
+    if (ret != 0) {
+        // error making Curve25519 key
+    }
+    \endcode
+    \sa wc_curve25519_init
+*/
+
+int wc_curve25519_make_key(WC_RNG* rng, int keysize, curve25519_key* key);
+
+/*!
+    \ingroup Curve25519 
+    \brief  この関数は、秘密の秘密鍵と受信した公開鍵を考えると、共有秘密鍵を計算します。生成された秘密鍵をバッファアウトに保存し、ounlentの秘密鍵の変数を割り当てます。ビッグエンディアンのみをサポートします。
+    \return 0  共有秘密鍵を正常に計算したときに返されました。
+    \return BAD_FUNC_ARG  渡された入力パラメータのいずれかがNULLの場合に返されます。
+    \return ECC_BAD_ARG_E  公開鍵の最初のビットが設定されている場合は、実装の指紋を避けるために返されます。
+    \param [in]  Private_Key Curve25519_Key構造体の秘密鍵で初期化されました。
+    \param [in]  public_key受信した公開鍵を含むCurve25519_Key構造体へのポインタ。
+    \param [out]  32バイト計算された秘密鍵を格納するバッファへのポインタ。
+    _Example_
+    \code
+    int ret;
+
+    byte sharedKey[32];
+    word32 keySz;
+    curve25519_key privKey, pubKey;
+    // initialize both keys
+
+    ret = wc_curve25519_shared_secret(&privKey, &pubKey, sharedKey, &keySz);
+    if (ret != 0) {
+        // error generating shared key
+    }
+    \endcode
+    \sa wc_curve25519_init
+    \sa wc_curve25519_make_key
+    \sa wc_curve25519_shared_secret_ex
+*/
+
+int wc_curve25519_shared_secret(curve25519_key* private_key,
+                                curve25519_key* public_key,
+                                byte* out, word32* outlen);
+
+/*!
+    \ingroup Curve25519 
+    \brief  この関数は、秘密の秘密鍵と受信した公開鍵を考えると、共有秘密鍵を計算します。生成された秘密鍵をバッファアウトに保存し、ounlentの秘密鍵の変数を割り当てます。大きくてリトルエンディアンの両方をサポートします。
+    \return 0  共有秘密鍵を正常に計算したときに返されました。
+    \return BAD_FUNC_ARG  渡された入力パラメータのいずれかがNULLの場合に返されます。
+    \return ECC_BAD_ARG_E  公開鍵の最初のビットが設定されている場合は、実装の指紋を避けるために返されます。
+    \param [in]  Private_Key Curve25519_Key構造体の秘密鍵で初期化されました。
+    \param [in]  public_key受信した公開鍵を含むCurve25519_Key構造体へのポインタ。
+    \param [out]  32バイト計算された秘密鍵を格納するバッファへのポインタ。
+    \param pin,out]  出力バッファに書き込まれた長さを記憶するポインタの概要。
+    _Example_
+    \code
+    int ret;
+
+    byte sharedKey[32];
+    word32 keySz;
+
+    curve25519_key privKey, pubKey;
+    // initialize both keys
+
+    ret = wc_curve25519_shared_secret_ex(&privKey, &pubKey, sharedKey, &keySz,
+             EC25519_BIG_ENDIAN);
+    if (ret != 0) {
+        // error generating shared key
+    }
+    \endcode
+    \sa wc_curve25519_init
+    \sa wc_curve25519_make_key
+    \sa wc_curve25519_shared_secret
+*/
+
+int wc_curve25519_shared_secret_ex(curve25519_key* private_key,
+                                   curve25519_key* public_key,
+                                   byte* out, word32* outlen, int endian);
+
+/*!
+    \ingroup Curve25519 
+    \brief  この関数はCurve25519キーを初期化します。構造のキーを生成する前に呼び出されるべきです。
+    \return 0  Curve25519_Key構造体の初期化に成功しました。
+    \return BAD_FUNC_ARG  キーがNULLのときに返されます。
+    _Example_
+    \code
+    curve25519_key key;
+    wc_curve25519_init(&key); // initialize key
+    // make key and proceed to encryption
+    \endcode
+    \sa wc_curve25519_make_key
+*/
+
+int wc_curve25519_init(curve25519_key* key);
+
+/*!
+    \ingroup Curve25519 
+    \brief  この関数はCurve25519オブジェクトを解放します。
+    _Example_
+    \code
+    curve25519_key privKey;
+    // initialize key, use it to generate shared secret key
+    wc_curve25519_free(&privKey);
+    \endcode
+    \sa wc_curve25519_init
+    \sa wc_curve25519_make_key
+*/
+
+void wc_curve25519_free(curve25519_key* key);
+
+/*!
+    \ingroup Curve25519 
+    \brief  この関数はCurve25519秘密鍵のみをインポートします。（ビッグエンディアン）。
+    \return 0  秘密鍵のインポートに成功しました。
+    \return BAD_FUNC_ARG  キーまたはPRIVがNULLの場合は返します。
+    \return ECC_BAD_ARG_E  PRIVSZがcurve25519_KEY_SIZEと等しくない場合は返します。
+    \param [in]  インポートする秘密鍵を含むバッファへのポイント。
+    \param [in]  インポートする秘密鍵のPrivsz長。
+    _Example_
+    \code
+    int ret;
+
+    byte priv[] = { Contents of private key };
+    curve25519_key key;
+    wc_curve25519_init(&key);
+
+    ret = wc_curve25519_import_private(priv, sizeof(priv), &key);
+    if (ret != 0) {
+        // error importing keys
+    }
+    \endcode
+    \sa wc_curve25519_import_private_ex
+    \sa wc_curve25519_size
+*/
+
+int wc_curve25519_import_private(const byte* priv, word32 privSz,
+                                 curve25519_key* key);
+
+/*!
+    \ingroup Curve25519 
+    \brief  CURVE25519秘密鍵のインポートのみ。（大きなエンディアン）。
+    \return 0  秘密鍵のインポートに成功しました。
+    \return BAD_FUNC_ARG  キーまたはPRIVがNULLの場合は返します。
+    \return ECC_BAD_ARG_E  PRIVSZがcurve25519_KEY_SIZEと等しくない場合は返します。
+    \param [in]  インポートする秘密鍵を含むバッファへのポイント。
+    \param [in]  インポートする秘密鍵のPrivsz長。
+    \param [in,out]  インポートされたキーを保存する構造へのキーポインタ。
+    _Example_
+    \code
+    int ret;
+
+    byte priv[] = { // Contents of private key };
+    curve25519_key key;
+    wc_curve25519_init(&key);
+
+    ret = wc_curve25519_import_private_ex(priv, sizeof(priv), &key,
+            EC25519_BIG_ENDIAN);
+    if (ret != 0) {
+        // error importing keys
+    }
+
+    \endcode
+    \sa wc_curve25519_import_private
+    \sa wc_curve25519_size
+*/
+
+int wc_curve25519_import_private_ex(const byte* priv, word32 privSz,
+                                    curve25519_key* key, int endian);
+
+/*!
+    \ingroup Curve25519 
+    \brief  この関数は、パブリック秘密鍵ペアをCurve25519_Key構造体にインポートします。ビッグエンディアンのみ。
+    \return 0  Curve25519_Key構造体へのインポートに返されます
+    \return BAD_FUNC_ARG  入力パラメータのいずれかがNULLの場合に返します。
+    \return ECC_BAD_ARG_E  入力キーのキーサイズがPublicキーサイズまたは秘密鍵サイズと一致しない場合に返されます。
+    \param [in]  インポートする秘密鍵を含むバッファへのポイント。
+    \param [in]  インポートする秘密鍵のPrivsz長。
+    \param [in]  パブリックキーをインポートするバッファへのPub。
+    \param [in]  インポートする公開鍵のPubsz長さ。
+    _Example_
+    \code
+    int ret;
+
+    byte priv[32];
+    byte pub[32];
+    // initialize with public and private keys
+    curve25519_key key;
+
+    wc_curve25519_init(&key);
+    // initialize key
+
+    ret = wc_curve25519_import_private_raw(&priv, sizeof(priv), pub,
+            sizeof(pub), &key);
+    if (ret != 0) {
+        // error importing keys
+    }
+    \endcode
+    \sa wc_curve25519_init
+    \sa wc_curve25519_make_key
+    \sa wc_curve25519_import_public
+    \sa wc_curve25519_export_private_raw
+*/
+
+int wc_curve25519_import_private_raw(const byte* priv, word32 privSz,
+                            const byte* pub, word32 pubSz, curve25519_key* key);
+
+/*!
+    \ingroup Curve25519 
+    \brief  この関数は、パブリック秘密鍵ペアをCurve25519_Key構造体にインポートします。大きくてリトルエンディアンの両方をサポートします。
+    \return 0  Curve25519_Key構造体へのインポートに返されます
+    \return BAD_FUNC_ARG  入力パラメータのいずれかがNULLの場合に返します。
+    \return ECC_BAD_ARG_E  戻されたIFまたは入力キーのキーサイズがパブリックキーサイズまたは秘密鍵サイズと一致しない場合
+    \param [in]  インポートする秘密鍵を含むバッファへのポイント。
+    \param [in]  インポートする秘密鍵のPrivsz長。
+    \param [in]  パブリックキーをインポートするバッファへのPub。
+    \param [in]  インポートする公開鍵のPubsz長さ。
+    \param [in,out]  インポートされたキーを保存する構造へのキーポインタ。
+    _Example_
+    \code
+    int ret;
+    byte priv[32];
+    byte pub[32];
+    // initialize with public and private keys
+    curve25519_key key;
+
+    wc_curve25519_init(&key);
+    // initialize key
+
+    ret = wc_curve25519_import_private_raw_ex(&priv, sizeof(priv), pub,
+            sizeof(pub), &key, EC25519_BIG_ENDIAN);
+    if (ret != 0) {
+        // error importing keys
+    }
+    \endcode
+    \sa wc_curve25519_init
+    \sa wc_curve25519_make_key
+    \sa wc_curve25519_import_public
+    \sa wc_curve25519_export_private_raw
+    \sa wc_curve25519_import_private_raw
+*/
+
+int wc_curve25519_import_private_raw_ex(const byte* priv, word32 privSz,
+                                        const byte* pub, word32 pubSz,
+                                        curve25519_key* key, int endian);
+
+/*!
+    \ingroup Curve25519 
+    \brief  この関数はCurve25519_Key構造体から秘密鍵をエクスポートし、それを指定されたアウトバッファに格納します。また、エクスポートされたキーのサイズになるように概要を設定します。ビッグエンディアンのみ。
+    \return 0  Curve25519_Key構造体から秘密鍵を正常にエクスポートしました。
+    \return BAD_FUNC_ARG  入力パラメータがNULLの場合に返されます。
+    \return ECC_BAD_ARG_E  WC_CURVE25519_SIZE（）がキーと等しくない場合に返されます。
+    \param [in]  キーをエクスポートする構造へのキーポインタ。
+    \param [out]  エクスポートされたキーを保存するバッファへのポインタ。
+    _Example_
+    \code
+    int ret;
+    byte priv[32];
+    int privSz;
+
+    curve25519_key key;
+    // initialize and make key
+
+    ret = wc_curve25519_export_private_raw(&key, priv, &privSz);
+    if (ret != 0) {
+        // error exporting key
+    }
+    \endcode
+    \sa wc_curve25519_init
+    \sa wc_curve25519_make_key
+    \sa wc_curve25519_import_private_raw
+    \sa wc_curve25519_export_private_raw_ex
+*/
+
+int wc_curve25519_export_private_raw(curve25519_key* key, byte* out,
+                                     word32* outLen);
+
+/*!
+    \ingroup Curve25519 
+    \brief  この関数はCurve25519_Key構造体から秘密鍵をエクスポートし、それを指定されたアウトバッファに格納します。また、エクスポートされたキーのサイズになるように概要を設定します。それが大きいかリトルエンディアンかを指定できます。
+    \return 0  Curve25519_Key構造体から秘密鍵を正常にエクスポートしました。
+    \return BAD_FUNC_ARG  入力パラメータがNULLの場合に返されます。
+    \return ECC_BAD_ARG_E  WC_CURVE25519_SIZE（）がキーと等しくない場合に返されます。
+    \param [in]  キーをエクスポートする構造へのキーポインタ。
+    \param [out]  エクスポートされたキーを保存するバッファへのポインタ。
+    \param [in,out]  INに照会は、バイト数のサイズです。ON OUTでは、出力バッファに書き込まれたバイトを保存します。
+    _Example_
+    \code
+    int ret;
+
+    byte priv[32];
+    int privSz;
+    curve25519_key key;
+    // initialize and make key
+    ret = wc_curve25519_export_private_raw_ex(&key, priv, &privSz,
+            EC25519_BIG_ENDIAN);
+    if (ret != 0) {
+        // error exporting key
+    }
+    \endcode
+    \sa wc_curve25519_init
+    \sa wc_curve25519_make_key
+    \sa wc_curve25519_import_private_raw
+    \sa wc_curve25519_export_private_raw
+    \sa wc_curve25519_size
+*/
+
+int wc_curve25519_export_private_raw_ex(curve25519_key* key, byte* out,
+                                        word32* outLen, int endian);
+
+/*!
+    \ingroup Curve25519 
+    \brief  この関数は、指定されたバッファから公開鍵をインポートし、それをCurve25519_Key構造体に格納します。
+    \return 0  公開鍵をCurve25519_Key構造体に正常にインポートしました。
+    \return ECC_BAD_ARG_E  InLenパラメータがキー構造のキーサイズと一致しない場合に返されます。
+    \return BAD_FUNC_ARG  入力パラメータのいずれかがNULLの場合に返されます。
+    \param [in]  インポートする公開鍵を含むバッファへのポインタ。
+    \param [in]  インポートする公開鍵のインレル長。
+    _Example_
+    \code
+    int ret;
+
+    byte pub[32];
+    // initialize pub with public key
+
+    curve25519_key key;
+    // initialize key
+
+    ret = wc_curve25519_import_public(pub,sizeof(pub), &key);
+    if (ret != 0) {
+        // error importing key
+    }
+    \endcode
+    \sa wc_curve25519_init
+    \sa wc_curve25519_export_public
+    \sa wc_curve25519_import_private_raw
+    \sa wc_curve25519_import_public_ex
+    \sa wc_curve25519_check_public
+    \sa wc_curve25519_size
+*/
+
+int wc_curve25519_import_public(const byte* in, word32 inLen,
+                                curve25519_key* key);
+
+/*!
+    \ingroup Curve25519 
+    \brief  この関数は、指定されたバッファから公開鍵をインポートし、それをCurve25519_Key構造体に格納します。
+    \return 0  公開鍵をCurve25519_Key構造体に正常にインポートしました。
+    \return ECC_BAD_ARG_E  InLenパラメータがキー構造のキーサイズと一致しない場合に返されます。
+    \return BAD_FUNC_ARG  入力パラメータのいずれかがNULLの場合に返されます。
+    \param [in]  インポートする公開鍵を含むバッファへのポインタ。
+    \param [in]  インポートする公開鍵のインレル長。
+    \param [in,out]  キーを保存するカーブ25519キー構造へのキーポインタ。
+    _Example_
+    \code
+    int ret;
+
+    byte pub[32];
+    // initialize pub with public key
+    curve25519_key key;
+    // initialize key
+
+    ret = wc_curve25519_import_public_ex(pub, sizeof(pub), &key,
+            EC25519_BIG_ENDIAN);
+    if (ret != 0) {
+        // error importing key
+    }
+    \endcode
+    \sa wc_curve25519_init
+    \sa wc_curve25519_export_public
+    \sa wc_curve25519_import_private_raw
+    \sa wc_curve25519_import_public
+    \sa wc_curve25519_check_public
+    \sa wc_curve25519_size
+*/
+
+int wc_curve25519_import_public_ex(const byte* in, word32 inLen,
+                                   curve25519_key* key, int endian);
+
+/*!
+    \ingroup Curve25519 
+    \brief  この関数は、公開鍵バッファがエンディアン注文を与えられた有効なCurve2519キー値を保持していることを確認します。
+    \return 0  公開鍵の値が有効なときに返されます。
+    \return ECC_BAD_ARG_E  公開鍵の値が無効な場合は返されます。
+    \return BAD_FUNC_ARG  入力パラメータのいずれかがNULLの場合に返されます。
+    \param [in]  チェックするための公開鍵を含むバッファへのPubポインタ。
+    \param [in]  チェックするための公開鍵の長さを掲載します。
+    _Example_
+    \code
+    int ret;
+
+    byte pub[] = { Contents of public key };
+
+    ret = wc_curve25519_check_public_ex(pub, sizeof(pub), EC25519_BIG_ENDIAN);
+    if (ret != 0) {
+        // error importing key
+    }
+    \endcode
+    \sa wc_curve25519_init
+    \sa wc_curve25519_import_public
+    \sa wc_curve25519_import_public_ex
+    \sa wc_curve25519_size
+*/
+
+int wc_curve25519_check_public(const byte* pub, word32 pubSz, int endian);
+
+/*!
+    \ingroup Curve25519 
+    \brief  この関数は指定されたキー構造から公開鍵をエクスポートし、結果をアウトバッファに格納します。ビッグエンディアンのみ。
+    \return 0  Curve25519_Key構造体から公開鍵を正常にエクスポートする上で返されます。
+    \return ECC_BAD_ARG_E  outlenがcurve25519_pub_key_sizeより小さい場合に返されます。
+    \return BAD_FUNC_ARG  入力パラメータのいずれかがNULLの場合に返されます。
+    \param [in]  キーをエクスポートするCurve25519_Key構造体へのキーポインタ。
+    \param [out]  公開鍵を保存するバッファへのポインタ。
+    _Example_
+    \code
+    int ret;
+
+    byte pub[32];
+    int pubSz;
+
+    curve25519_key key;
+    // initialize and make key
+    ret = wc_curve25519_export_public(&key, pub, &pubSz);
+    if (ret != 0) {
+        // error exporting key
+    }
+    \endcode
+    \sa wc_curve25519_init
+    \sa wc_curve25519_export_private_raw
+    \sa wc_curve25519_import_public
+*/
+
+int wc_curve25519_export_public(curve25519_key* key, byte* out, word32* outLen);
+
+/*!
+    \ingroup Curve25519 
+    \brief  この関数は指定されたキー構造から公開鍵をエクスポートし、結果をアウトバッファに格納します。大きくてリトルエンディアンの両方をサポートします。
+    \return 0  Curve25519_Key構造体から公開鍵を正常にエクスポートする上で返されます。
+    \return ECC_BAD_ARG_E  outlenがcurve25519_pub_key_sizeより小さい場合に返されます。
+    \return BAD_FUNC_ARG  入力パラメータのいずれかがNULLの場合に返されます。
+    \param [in]  キーをエクスポートするCurve25519_Key構造体へのキーポインタ。
+    \param [out]  公開鍵を保存するバッファへのポインタ。
+    \param [in,out]  INに照会は、バイト数のサイズです。ON OUTでは、出力バッファに書き込まれたバイトを保存します。
+    _Example_
+    \code
+    int ret;
+
+    byte pub[32];
+    int pubSz;
+
+    curve25519_key key;
+    // initialize and make key
+
+    ret = wc_curve25519_export_public_ex(&key, pub, &pubSz, EC25519_BIG_ENDIAN);
+    if (ret != 0) {
+        // error exporting key
+    }
+    \endcode
+    \sa wc_curve25519_init
+    \sa wc_curve25519_export_private_raw
+    \sa wc_curve25519_import_public
+*/
+
+int wc_curve25519_export_public_ex(curve25519_key* key, byte* out,
+                                   word32* outLen, int endian);
+
+/*!
+    \ingroup Curve25519 
+    \brief  Export Curve25519キーペア。ビッグエンディアンのみ。
+    \return 0  Curve25519_Key構造体からキーペアのエクスポートに成功しました。
+    \return BAD_FUNC_ARG  入力パラメータがNULLの場合に返されます。
+    \return ECC_BAD_ARG_E  PRIVSZがCURUV25519_SEY_SIZEまたはPUBSZよりも小さい場合は、PUBSZがCURUG25519_PUB_KEY_SIZEよりも小さい場合に返されます。
+    \param [in]  キーペアをエクスポートするCURUN448_KEY構造体へのキーポインタ。
+    \param [out]  秘密鍵を保存するバッファへのPRIVポインタ。
+    \param [in,out]  PRIVSZ ON INは、PRIVバッファのサイズをバイト単位で）です。ON OUTは、PRIVバッファに書き込まれたバイトを保存します。
+    \param [out]  パブリックキーを保存するバッファへのPub。
+    _Example_
+    \code
+    int ret;
+
+    byte pub[32];
+    byte priv[32];
+    int pubSz;
+    int privSz;
+
+    curve25519_key key;
+    // initialize and make key
+
+    ret = wc_curve25519_export_key_raw(&key, priv, &privSz, pub, &pubSz);
+    if (ret != 0) {
+        // error exporting key
+    }
+    \endcode
+    \sa wc_curve25519_export_key_raw_ex
+    \sa wc_curve25519_export_private_raw
+*/
+
+int wc_curve25519_export_key_raw(curve25519_key* key,
+                                 byte* priv, word32 *privSz,
+                                 byte* pub, word32 *pubSz);
+
+/*!
+    \ingroup Curve25519 
+    \brief  Export Curve25519キーペア。大きいまたはリトルエンディアン。
+    \return 0  Curve25519_Key構造体からキーペアのエクスポートに成功しました。
+    \return BAD_FUNC_ARG  入力パラメータがNULLの場合に返されます。
+    \return ECC_BAD_ARG_E  PRIVSZがCURUV25519_SEY_SIZEまたはPUBSZよりも小さい場合は、PUBSZがCURUG25519_PUB_KEY_SIZEよりも小さい場合に返されます。
+    \param [in]  キーペアをエクスポートするCURUN448_KEY構造体へのキーポインタ。
+    \param [out]  秘密鍵を保存するバッファへのPRIVポインタ。
+    \param [in,out]  PRIVSZ ON INは、PRIVバッファのサイズをバイト単位で）です。ON OUTは、PRIVバッファに書き込まれたバイトを保存します。
+    \param [out]  パブリックキーを保存するバッファへのPub。
+    \param [in,out]  PUBSZ ON INは、パブバッファのサイズをバイト単位で）です。ON OUTでは、PUBバッファに書き込まれたバイトを保存します。
+    _Example_
+    \code
+    int ret;
+
+    byte pub[32];
+    byte priv[32];
+    int pubSz;
+    int privSz;
+
+    curve25519_key key;
+    // initialize and make key
+
+    ret = wc_curve25519_export_key_raw_ex(&key,priv, &privSz, pub, &pubSz,
+            EC25519_BIG_ENDIAN);
+    if (ret != 0) {
+        // error exporting key
+    }
+    \endcode
+    \sa wc_curve25519_export_key_raw
+    \sa wc_curve25519_export_private_raw_ex
+    \sa wc_curve25519_export_public_ex
+*/
+
+int wc_curve25519_export_key_raw_ex(curve25519_key* key,
+                                    byte* priv, word32 *privSz,
+                                    byte* pub, word32 *pubSz,
+                                    int endian);
+
+/*!
+    \ingroup Curve25519 
+    \brief  この関数は与えられたキー構造のキーサイズを返します。
+    \return Success  有効な初期化されたCurve25519_Key構造体を考慮すると、キーのサイズを返します。
+    \return 0  キーがNULLの場合は返されます
+    _Example_
+    \code
+    int keySz;
+
+    curve25519_key key;
+    // initialize and make key
+
+    keySz = wc_curve25519_size(&key);
+    \endcode
+    \sa wc_curve25519_init
+    \sa wc_curve25519_make_key
+*/
+
+int wc_curve25519_size(curve25519_key* key);

--- a/doc/dox_comments/header_files-ja/curve448.h
+++ b/doc/dox_comments/header_files-ja/curve448.h
@@ -1,0 +1,576 @@
+/*!
+    \ingroup Curve448 
+    \brief  この関数は、与えられたサイズ（Keysize）のサイズの指定された乱数発生器RNGを使用してCurve448キーを生成し、それを指定されたCurve448_Key構造体に格納します。キー構造がWC_CURVE448_INIT（）を介して初期化された後に呼び出されるべきです。
+    \return 0  キーの生成に成功し、それを指定されたCurve448_Key構造体に格納します。
+    \return ECC_BAD_ARG_E  入力キーサイズがCurve448キー（56バイト）のキーシェイズに対応していない場合は返されます。
+    \return RNG_FAILURE_E  RNGの内部ステータスがDRBG_OKでない場合、またはRNGを使用して次のランダムブロックを生成する場合に返されます。
+    \return BAD_FUNC_ARG  渡された入力パラメータのいずれかがNULLの場合に返されます。
+    \param [in]  RNG ECCキーの生成に使用されるRNGオブジェクトへのポインタ。
+    \param [in]  キーサイズ生成キーのサイズ。Curve448の場合は56バイトでなければなりません。
+    _Example_
+    \code
+    int ret;
+
+    curve448_key key;
+    wc_curve448_init(&key); // initialize key
+    WC_RNG rng;
+    wc_InitRng(&rng); // initialize random number generator
+
+    ret = wc_curve448_make_key(&rng, 56, &key);
+    if (ret != 0) {
+        // error making Curve448 key
+    }
+    \endcode
+    \sa wc_curve448_init
+*/
+
+int wc_curve448_make_key(WC_RNG* rng, int keysize, curve448_key* key);
+
+/*!
+    \ingroup Curve448 
+    \brief  この関数は、秘密の秘密鍵と受信した公開鍵を考えると、共有秘密鍵を計算します。生成された秘密鍵をバッファアウトに保存し、ounlentの秘密鍵の変数を割り当てます。ビッグエンディアンのみをサポートします。
+    \return 0  共有秘密鍵を正常に計算する上で返却されました
+    \return BAD_FUNC_ARG  渡された入力パラメーターのいずれかがNULLの場合に返されます
+    \param [in]  Private_Key Curve448_Key構造体へのポインタユーザーの秘密鍵で初期化されました。
+    \param [in]  public_key受信した公開鍵を含むCurve448_Key構造体へのポインタ。
+    \param [out]  56バイトの計算された秘密鍵を保存するバッファへのポインタ。
+    _Example_
+    \code
+    int ret;
+
+    byte sharedKey[56];
+    word32 keySz;
+    curve448_key privKey, pubKey;
+    // initialize both keys
+
+    ret = wc_curve448_shared_secret(&privKey, &pubKey, sharedKey, &keySz);
+    if (ret != 0) {
+        // error generating shared key
+    }
+    \endcode
+    \sa wc_curve448_init
+    \sa wc_curve448_make_key
+    \sa wc_curve448_shared_secret_ex
+*/
+
+int wc_curve448_shared_secret(curve448_key* private_key,
+                                curve448_key* public_key,
+                                byte* out, word32* outlen);
+
+/*!
+    \ingroup Curve448 
+    \brief  この関数は、秘密の秘密鍵と受信した公開鍵を考えると、共有秘密鍵を計算します。生成された秘密鍵をバッファアウトに保存し、ounlentの秘密鍵の変数を割り当てます。大きくてリトルエンディアンの両方をサポートします。
+    \return 0  共有秘密鍵を正常に計算したときに返されました。
+    \return BAD_FUNC_ARG  渡された入力パラメータのいずれかがNULLの場合に返されます。
+    \param [in]  Private_Key Curve448_Key構造体へのポインタユーザーの秘密鍵で初期化されました。
+    \param [in]  public_key受信した公開鍵を含むCurve448_Key構造体へのポインタ。
+    \param [out]  56バイトの計算された秘密鍵を保存するバッファへのポインタ。
+    \param [in,out]  出力バッファに書き込まれた長さを記憶するポインタの概要。
+    _Example_
+    \code
+    int ret;
+
+    byte sharedKey[56];
+    word32 keySz;
+
+    curve448_key privKey, pubKey;
+    // initialize both keys
+
+    ret = wc_curve448_shared_secret_ex(&privKey, &pubKey, sharedKey, &keySz,
+            EC448_BIG_ENDIAN);
+    if (ret != 0) {
+        // error generating shared key
+    }
+    \endcode
+    \sa wc_curve448_init
+    \sa wc_curve448_make_key
+    \sa wc_curve448_shared_secret
+*/
+
+int wc_curve448_shared_secret_ex(curve448_key* private_key,
+                                   curve448_key* public_key,
+                                   byte* out, word32* outlen, int endian);
+
+/*!
+    \ingroup Curve448 
+    \brief  この関数はCurve448キーを初期化します。構造のキーを生成する前に呼び出されるべきです。
+    \return 0  Curve448_Key構造体の初期化に成功しました。
+    \return BAD_FUNC_ARG  キーがNULLのときに返されます。
+    _Example_
+    \code
+    curve448_key key;
+    wc_curve448_init(&key); // initialize key
+    // make key and proceed to encryption
+    \endcode
+    \sa wc_curve448_make_key
+*/
+
+int wc_curve448_init(curve448_key* key);
+
+/*!
+    \ingroup Curve448 
+    \brief  この関数はCurve448オブジェクトを解放します。
+    _Example_
+    \code
+    curve448_key privKey;
+    // initialize key, use it to generate shared secret key
+    wc_curve448_free(&privKey);
+    \endcode
+    \sa wc_curve448_init
+    \sa wc_curve448_make_key
+*/
+
+void wc_curve448_free(curve448_key* key);
+
+/*!
+    \ingroup Curve448 
+    \brief  この関数はCurve448秘密鍵のみをインポートします。（ビッグエンディアン）。
+    \return 0  秘密鍵のインポートに成功しました。
+    \return BAD_FUNC_ARG  キーまたはPRIVがNULLの場合は返します。
+    \return ECC_BAD_ARG_E  PRIVSZがCURUG448_KEY_SIZEと等しくない場合は返します。
+    \param [in]  インポートする秘密鍵を含むバッファへのポイント。
+    \param [in]  インポートする秘密鍵のPrivsz長。
+    _Example_
+    \code
+    int ret;
+
+    byte priv[] = { Contents of private key };
+    curve448_key key;
+    wc_curve448_init(&key);
+
+    ret = wc_curve448_import_private(priv, sizeof(priv), &key);
+    if (ret != 0) {
+        // error importing key
+    }
+    \endcode
+    \sa wc_curve448_import_private_ex
+    \sa wc_curve448_size
+*/
+
+int wc_curve448_import_private(const byte* priv, word32 privSz,
+                                 curve448_key* key);
+
+/*!
+    \ingroup Curve448 
+    \brief  CURVE448秘密鍵のインポートのみ。（大きなエンディアン）。
+    \return 0  秘密鍵のインポートに成功しました。
+    \return BAD_FUNC_ARG  キーまたはPRIVがNULLの場合は返します。
+    \return ECC_BAD_ARG_E  PRIVSZがCURUG448_KEY_SIZEと等しくない場合は返します。
+    \param [in]  インポートする秘密鍵を含むバッファへのポイント。
+    \param [in]  インポートする秘密鍵のPrivsz長。
+    \param [in,out]  インポートされたキーを保存する構造へのキーポインタ。
+    _Example_
+    \code
+    int ret;
+
+    byte priv[] = { // Contents of private key };
+    curve448_key key;
+    wc_curve448_init(&key);
+
+    ret = wc_curve448_import_private_ex(priv, sizeof(priv), &key,
+            EC448_BIG_ENDIAN);
+    if (ret != 0) {
+        // error importing key
+    }
+
+    \endcode
+    \sa wc_curve448_import_private
+    \sa wc_curve448_size
+*/
+
+int wc_curve448_import_private_ex(const byte* priv, word32 privSz,
+                                    curve448_key* key, int endian);
+
+/*!
+    \ingroup Curve448 
+    \brief  この関数は、public-秘密鍵のペアをCurve448_Key構造体にインポートします。ビッグエンディアンのみ。
+    \return 0  Curve448_Key構造体へのインポート時に返されます。
+    \return BAD_FUNC_ARG  入力パラメータのいずれかがNULLの場合に返します。
+    \return ECC_BAD_ARG_E  入力キーのキーサイズがPublicキーサイズまたは秘密鍵サイズと一致しない場合に返されます。
+    \param [in]  インポートする秘密鍵を含むバッファへのポイント。
+    \param [in]  インポートする秘密鍵のPrivsz長。
+    \param [in]  パブリックキーをインポートするバッファへのPub。
+    \param [in]  インポートする公開鍵のPubsz長さ。
+    _Example_
+    \code
+    int ret;
+
+    byte priv[56];
+    byte pub[56];
+    // initialize with public and private keys
+    curve448_key key;
+
+    wc_curve448_init(&key);
+    // initialize key
+
+    ret = wc_curve448_import_private_raw(&priv, sizeof(priv), pub, sizeof(pub),
+            &key);
+    if (ret != 0) {
+        // error importing keys
+    }
+    \endcode
+    \sa wc_curve448_init
+    \sa wc_curve448_make_key
+    \sa wc_curve448_import_public
+    \sa wc_curve448_export_private_raw
+*/
+
+int wc_curve448_import_private_raw(const byte* priv, word32 privSz,
+                            const byte* pub, word32 pubSz, curve448_key* key);
+
+/*!
+    \ingroup Curve448 
+    \brief  この関数は、public-秘密鍵のペアをCurve448_Key構造体にインポートします。大きくてリトルエンディアンの両方をサポートします。
+    \return 0  Curve448_Key構造体へのインポート時に返されます。
+    \return BAD_FUNC_ARG  入力パラメータのいずれかがNULLの場合に返します。
+    \return ECC_BAD_ARG_E  入力キーのキーサイズがPublicキーサイズまたは秘密鍵サイズと一致しない場合に返されます。
+    \param [in]  インポートする秘密鍵を含むバッファへのポイント。
+    \param [in]  インポートする秘密鍵のPrivsz長。
+    \param [in]  パブリックキーをインポートするバッファへのPub。
+    \param [in]  インポートする公開鍵のPubsz長さ。
+    \param [in,out]  インポートされたキーを保存する構造へのキーポインタ。
+    _Example_
+    \code
+    int ret;
+
+    byte priv[56];
+    byte pub[56];
+    // initialize with public and private keys
+    curve448_key key;
+
+    wc_curve448_init(&key);
+    // initialize key
+
+    ret = wc_curve448_import_private_raw_ex(&priv, sizeof(priv), pub,
+            sizeof(pub), &key, EC448_BIG_ENDIAN);
+    if (ret != 0) {
+        // error importing keys
+    }
+    \endcode
+    \sa wc_curve448_init
+    \sa wc_curve448_make_key
+    \sa wc_curve448_import_public
+    \sa wc_curve448_export_private_raw
+    \sa wc_curve448_import_private_raw
+*/
+
+int wc_curve448_import_private_raw_ex(const byte* priv, word32 privSz,
+                                        const byte* pub, word32 pubSz,
+                                        curve448_key* key, int endian);
+
+/*!
+    \ingroup Curve448 
+    \brief  この関数はCurve448_Key構造体から秘密鍵をエクスポートし、それを指定されたバッファに格納します。また、エクスポートされたキーのサイズになるように概要を設定します。ビッグエンディアンのみ。
+    \return 0  Curve448_Key構造体から秘密鍵を正常にエクスポートする上で返されました。
+    \return BAD_FUNC_ARG  入力パラメータがNULLの場合に返されます。
+    \return ECC_BAD_ARG_E  WC_CURVE448_SIZE（）がキーと等しくない場合に返されます。
+    \param [in]  キーをエクスポートする構造へのキーポインタ。
+    \param [out]  エクスポートされたキーを保存するバッファへのポインタ。
+    _Example_
+    \code
+    int ret;
+    byte priv[56];
+    int privSz;
+
+    curve448_key key;
+    // initialize and make key
+
+    ret = wc_curve448_export_private_raw(&key, priv, &privSz);
+    if (ret != 0) {
+        // error exporting key
+    }
+    \endcode
+    \sa wc_curve448_init
+    \sa wc_curve448_make_key
+    \sa wc_curve448_import_private_raw
+    \sa wc_curve448_export_private_raw_ex
+*/
+
+int wc_curve448_export_private_raw(curve448_key* key, byte* out,
+                                     word32* outLen);
+
+/*!
+    \ingroup Curve448 
+    \brief  この関数はCurve448_Key構造体から秘密鍵をエクスポートし、それを指定されたバッファに格納します。また、エクスポートされたキーのサイズになるように概要を設定します。それが大きいかリトルエンディアンかを指定できます。
+    \return 0  Curve448_Key構造体から秘密鍵を正常にエクスポートする上で返されました。
+    \return BAD_FUNC_ARG  入力パラメータがNULLの場合に返されます。
+    \return ECC_BAD_ARG_E  WC_CURVE448_SIZE（）がキーと等しくない場合に返されます。
+    \param [in]  キーをエクスポートする構造へのキーポインタ。
+    \param [out]  エクスポートされたキーを保存するバッファへのポインタ。
+    \param [in,out]  INに照会は、バイト数のサイズです。ON OUTでは、出力バッファに書き込まれたバイトを保存します。
+    _Example_
+    \code
+    int ret;
+
+    byte priv[56];
+    int privSz;
+    curve448_key key;
+    // initialize and make key
+    ret = wc_curve448_export_private_raw_ex(&key, priv, &privSz,
+            EC448_BIG_ENDIAN);
+    if (ret != 0) {
+        // error exporting key
+    }
+    \endcode
+    \sa wc_curve448_init
+    \sa wc_curve448_make_key
+    \sa wc_curve448_import_private_raw
+    \sa wc_curve448_export_private_raw
+    \sa wc_curve448_size
+*/
+
+int wc_curve448_export_private_raw_ex(curve448_key* key, byte* out,
+                                        word32* outLen, int endian);
+
+/*!
+    \ingroup Curve448 
+    \brief  この関数は、指定されたバッファから公開鍵をインポートし、それをCurve448_Key構造体に格納します。
+    \return 0  公開鍵をCurve448_Key構造体に正常にインポートしました。
+    \return ECC_BAD_ARG_E  InLenパラメータがキー構造のキーサイズと一致しない場合に返されます。
+    \return BAD_FUNC_ARG  入力パラメータのいずれかがNULLの場合に返されます。
+    \param [in]  インポートする公開鍵を含むバッファへのポインタ。
+    \param [in]  インポートする公開鍵のインレル長。
+    _Example_
+    \code
+    int ret;
+
+    byte pub[56];
+    // initialize pub with public key
+
+    curve448_key key;
+    // initialize key
+
+    ret = wc_curve448_import_public(pub,sizeof(pub), &key);
+    if (ret != 0) {
+        // error importing key
+    }
+    \endcode
+    \sa wc_curve448_init
+    \sa wc_curve448_export_public
+    \sa wc_curve448_import_private_raw
+    \sa wc_curve448_import_public_ex
+    \sa wc_curve448_check_public
+    \sa wc_curve448_size
+*/
+
+int wc_curve448_import_public(const byte* in, word32 inLen,
+                                curve448_key* key);
+
+/*!
+    \ingroup Curve448 
+    \brief  この関数は、指定されたバッファから公開鍵をインポートし、それをCurve448_Key構造体に格納します。
+    \return 0  公開鍵をCurve448_Key構造体に正常にインポートしました。
+    \return ECC_BAD_ARG_E  InLenパラメータがキー構造のキーサイズと一致しない場合に返されます。
+    \return BAD_FUNC_ARG  入力パラメータのいずれかがNULLの場合に返されます。
+    \param [in]  インポートする公開鍵を含むバッファへのポインタ。
+    \param [in]  インポートする公開鍵のインレル長。
+    \param [in,out]  キーを保存するCurve448_Key構造体へのキーポインタ。
+    _Example_
+    \code
+    int ret;
+
+    byte pub[56];
+    // initialize pub with public key
+    curve448_key key;
+    // initialize key
+
+    ret = wc_curve448_import_public_ex(pub, sizeof(pub), &key,
+            EC448_BIG_ENDIAN);
+    if (ret != 0) {
+        // error importing key
+    }
+    \endcode
+    \sa wc_curve448_init
+    \sa wc_curve448_export_public
+    \sa wc_curve448_import_private_raw
+    \sa wc_curve448_import_public
+    \sa wc_curve448_check_public
+    \sa wc_curve448_size
+*/
+
+int wc_curve448_import_public_ex(const byte* in, word32 inLen,
+                                   curve448_key* key, int endian);
+
+/*!
+    \ingroup Curve448 
+    \brief  この関数は、公開鍵バッファがエンディアン順序付けを与えられた有効なCurve448キー値を保持することを確認します。
+    \return 0  公開鍵の値が有効なときに返されます。
+    \return ECC_BAD_ARG_E  公開鍵の値が無効な場合は返されます。
+    \return BAD_FUNC_ARG  入力パラメータのいずれかがNULLの場合に返されます。
+    \param [in]  チェックするための公開鍵を含むバッファへのPubポインタ。
+    \param [in]  チェックするための公開鍵の長さを掲載します。
+    _Example_
+    \code
+    int ret;
+
+    byte pub[] = { Contents of public key };
+
+    ret = wc_curve448_check_public_ex(pub, sizeof(pub), EC448_BIG_ENDIAN);
+    if (ret != 0) {
+        // error importing key
+    }
+    \endcode
+    \sa wc_curve448_init
+    \sa wc_curve448_import_public
+    \sa wc_curve448_import_public_ex
+    \sa wc_curve448_size
+*/
+
+int wc_curve448_check_public(const byte* pub, word32 pubSz, int endian);
+
+/*!
+    \ingroup Curve448 
+    \brief  この関数は指定されたキー構造から公開鍵をエクスポートし、結果をアウトバッファに格納します。ビッグエンディアンのみ。
+    \return 0  Curve448_Key構造体から公開鍵のエクスポートに成功しました。
+    \return ECC_BAD_ARG_E  outlenがcurve448_pub_key_sizeより小さい場合に返されます。
+    \return BAD_FUNC_ARG  入力パラメータのいずれかがNULLの場合に返されます。
+    \param [in]  キーをエクスポートするCurve448_Key構造体へのキーポインタ。
+    \param [out]  公開鍵を保存するバッファへのポインタ。
+    _Example_
+    \code
+    int ret;
+
+    byte pub[56];
+    int pubSz;
+
+    curve448_key key;
+    // initialize and make key
+
+    ret = wc_curve448_export_public(&key, pub, &pubSz);
+    if (ret != 0) {
+        // error exporting key
+    }
+    \endcode
+    \sa wc_curve448_init
+    \sa wc_curve448_export_private_raw
+    \sa wc_curve448_import_public
+*/
+
+int wc_curve448_export_public(curve448_key* key, byte* out, word32* outLen);
+
+/*!
+    \ingroup Curve448 
+    \brief  この関数は指定されたキー構造から公開鍵をエクスポートし、結果をアウトバッファに格納します。大きくてリトルエンディアンの両方をサポートします。
+    \return 0  Curve448_Key構造体から公開鍵のエクスポートに成功しました。
+    \return ECC_BAD_ARG_E  outlenがcurve448_pub_key_sizeより小さい場合に返されます。
+    \return BAD_FUNC_ARG  入力パラメータのいずれかがNULLの場合に返されます。
+    \param [in]  キーをエクスポートするCurve448_Key構造体へのキーポインタ。
+    \param [out]  公開鍵を保存するバッファへのポインタ。
+    \param [in,out]  INに照会は、バイト数のサイズです。ON OUTでは、出力バッファに書き込まれたバイトを保存します。
+    _Example_
+    \code
+    int ret;
+
+    byte pub[56];
+    int pubSz;
+
+    curve448_key key;
+    // initialize and make key
+
+    ret = wc_curve448_export_public_ex(&key, pub, &pubSz, EC448_BIG_ENDIAN);
+    if (ret != 0) {
+        // error exporting key
+    }
+    \endcode
+    \sa wc_curve448_init
+    \sa wc_curve448_export_private_raw
+    \sa wc_curve448_import_public
+*/
+
+int wc_curve448_export_public_ex(curve448_key* key, byte* out,
+                                   word32* outLen, int endian);
+
+/*!
+    \ingroup Curve448 
+    \brief  この関数は指定されたキー構造からキーペアをエクスポートし、結果をアウトバッファに格納します。ビッグエンディアンのみ。
+    \return 0  Curve448_Key構造体からキーペアのエクスポートに成功しました。
+    \return BAD_FUNC_ARG  入力パラメータがNULLの場合に返されます。
+    \return ECC_BAD_ARG_E  PRIVSZがCURUV448_KEY_SIZEまたはPUBSZよりも小さい場合は、Curge448_PUB_KEY_SIZEよりも小さい場合に返されます。
+    \param [in]  キーペアをエクスポートするCURUN448_KEY構造体へのキーポインタ。
+    \param [out]  秘密鍵を保存するバッファへのPRIVポインタ。
+    \param [in,out]  PRIVSZ ON INは、PRIVバッファのサイズをバイト単位で）です。ON OUTは、PRIVバッファに書き込まれたバイトを保存します。
+    \param [out]  パブリックキーを保存するバッファへのPub。
+    _Example_
+    \code
+    int ret;
+
+    byte pub[56];
+    byte priv[56];
+    int pubSz;
+    int privSz;
+
+    curve448_key key;
+    // initialize and make key
+
+    ret = wc_curve448_export_key_raw(&key, priv, &privSz, pub, &pubSz);
+    if (ret != 0) {
+        // error exporting key
+    }
+    \endcode
+    \sa wc_curve448_export_key_raw_ex
+    \sa wc_curve448_export_private_raw
+*/
+
+int wc_curve448_export_key_raw(curve448_key* key,
+                                 byte* priv, word32 *privSz,
+                                 byte* pub, word32 *pubSz);
+
+/*!
+    \ingroup Curve448 
+    \brief  Curve448キーペアをエクスポートします。大きいまたはリトルエンディアン。
+    \brief  この関数は指定されたキー構造からキーペアをエクスポートし、結果をアウトバッファに格納します。大きいまたはリトルエンディアン。
+    \return 0  成功
+    \return BAD_FUNC_ARG  入力パラメータがNULLの場合に返されます。
+    \return ECC_BAD_ARG_E  PRIVSZがCURUV448_KEY_SIZEまたはPUBSZよりも小さい場合は、Curge448_PUB_KEY_SIZEよりも小さい場合に返されます。
+    \param [in]  キーペアをエクスポートするCURUN448_KEY構造体へのキーポインタ。
+    \param [out]  秘密鍵を保存するバッファへのPRIVポインタ。
+    \param [in,out]  PRIVSZ ON INは、PRIVバッファのサイズをバイト単位で）です。ON OUTは、PRIVバッファに書き込まれたバイトを保存します。
+    \param [out]  パブリックキーを保存するバッファへのPub。
+    \param [in,out]  PUBSZ ON INは、パブバッファのサイズをバイト単位で）です。ON OUTでは、PUBバッファに書き込まれたバイトを保存します。
+    _Example_
+    \code
+    int ret;
+
+    byte pub[56];
+    byte priv[56];
+    int pubSz;
+    int privSz;
+
+    curve448_key key;
+    // initialize and make key
+
+    ret = wc_curve448_export_key_raw_ex(&key,priv, &privSz, pub, &pubSz,
+            EC448_BIG_ENDIAN);
+    if (ret != 0) {
+        // error exporting key
+    }
+    \endcode
+    \sa wc_curve448_export_key_raw
+    \sa wc_curve448_export_private_raw_ex
+    \sa wc_curve448_export_public_ex
+*/
+
+int wc_curve448_export_key_raw_ex(curve448_key* key,
+                                    byte* priv, word32 *privSz,
+                                    byte* pub, word32 *pubSz,
+                                    int endian);
+
+/*!
+    \ingroup Curve448 
+    \brief  この関数は与えられたキー構造のキーサイズを返します。
+    \return Success  有効な初期化されたCurve448_Key構造体を考慮すると、キーのサイズを返します。
+    \return 0  キーがNULLの場合は返されます。
+    _Example_
+    \code
+    int keySz;
+
+    curve448_key key;
+    // initialize and make key
+
+    keySz = wc_curve448_size(&key);
+    \endcode
+    \sa wc_curve448_init
+    \sa wc_curve448_make_key
+*/
+
+int wc_curve448_size(curve448_key* key);

--- a/doc/dox_comments/header_files-ja/des3.h
+++ b/doc/dox_comments/header_files-ja/des3.h
@@ -1,0 +1,234 @@
+/*!
+    \ingroup 3DES 
+    \brief  この関数は、引数として与えられたDES構造体のキーと初期化ベクトル（IV）を設定します。また、これらがまだ初期化されていない場合は、暗号化と復号化に必要なバッファーのスペースを初期化して割り当てます。注：IVが指定されていない場合（i.e.iv == null）初期化ベクトルは、デフォルトのIV 0になります。
+    \return 0  DES構造体のキーと初期化ベクトルを正常に設定する
+    \param des  初期化するDES構造へのポインタ
+    \param key  DES構造を初期化するための8バイトのキーを含むバッファへのポインタ
+    \param iv  DES構造を初期化するための8バイトIVを含むバッファへのポインタ。これが提供されていない場合、IVはデフォルトで0になります
+    _Example_
+    \code
+    Des enc; // Des structure used for encryption
+    int ret;
+    byte key[] = { // initialize with 8 byte key };
+    byte iv[]  = { // initialize with 8 byte iv };
+
+    ret = wc_Des_SetKey(&des, key, iv, DES_ENCRYPTION);
+    if (ret != 0) {
+    	// error initializing des structure
+    }
+    \endcode
+    \sa wc_Des_SetIV
+    \sa wc_Des3_SetKey
+*/
+int  wc_Des_SetKey(Des* des, const byte* key,
+                               const byte* iv, int dir);
+
+/*!
+    \ingroup 3DES 
+    \brief  この関数は、引数として与えられたDES構造体の初期化ベクトル（IV）を設定します。NULL IVを渡したら、初期化ベクトルを0に設定します。
+    \return none  いいえ返します。
+    \param des  IVを設定するためのDES構造へのポインタ
+    _Example_
+    \code
+    Des enc; // Des structure used for encryption
+    // initialize enc with wc_Des_SetKey
+    byte iv[]  = { // initialize with 8 byte iv };
+    wc_Des_SetIV(&enc, iv);
+    }
+    \endcode
+    \sa wc_Des_SetKey
+*/
+void wc_Des_SetIV(Des* des, const byte* iv);
+
+/*!
+    \ingroup 3DES 
+    \brief  この関数は入力メッセージを暗号化し、結果を出力バッファーに格納します。暗号ブロックチェーンチェーン（CBC）モードでDES暗号化を使用します。
+    \return 0  与えられた入力メッセージの暗号化に成功したときに返されます
+    \param des  暗号化に使用するDES構造へのポインタ
+    \param out  暗号化された暗号文を保存するバッファへのポインタ
+    \param in  暗号化するメッセージを含む入力バッファへのポインタ
+    _Example_
+    \code
+    Des enc; // Des structure used for encryption
+    // initialize enc with wc_Des_SetKey, use mode DES_ENCRYPTION
+
+    byte plain[]  = { // initialize with message };
+    byte cipher[sizeof(plain)];
+
+    if ( wc_Des_CbcEncrypt(&enc, cipher, plain, sizeof(plain)) != 0) {
+	    // error encrypting message
+    }
+    \endcode
+    \sa wc_Des_SetKey
+    \sa wc_Des_CbcDecrypt
+*/
+int  wc_Des_CbcEncrypt(Des* des, byte* out,
+                                   const byte* in, word32 sz);
+
+/*!
+    \ingroup 3DES 
+    \brief  この関数は入力暗号文を復号化し、結果の平文を出力バッファーに出力します。暗号ブロックチェーンチェーン（CBC）モードでDES暗号化を使用します。
+    \return 0  与えられた暗号文を正常に復号化したときに返されました
+    \param des  復号化に使用するDES構造へのポインタ
+    \param out  復号化された平文を保存するバッファへのポインタ
+    \param in  暗号化された暗号文を含む入力バッファへのポインタ
+    _Example_
+    \code
+    Des dec; // Des structure used for decryption
+    // initialize dec with wc_Des_SetKey, use mode DES_DECRYPTION
+
+    byte cipher[]  = { // initialize with ciphertext };
+    byte decoded[sizeof(cipher)];
+
+    if ( wc_Des_CbcDecrypt(&dec, decoded, cipher, sizeof(cipher)) != 0) {
+    	// error decrypting message
+    }
+    \endcode
+    \sa wc_Des_SetKey
+    \sa wc_Des_CbcEncrypt
+*/
+int  wc_Des_CbcDecrypt(Des* des, byte* out,
+                                   const byte* in, word32 sz);
+
+/*!
+    \ingroup 3DES 
+    \brief  この関数は入力メッセージを暗号化し、結果を出力バッファーに格納します。電子コードブック（ECB）モードでDES暗号化を使用します。
+    \return 0:  与えられた平文を正常に暗号化すると返されます。
+    \param des  暗号化に使用するDES構造へのポインタ
+    \param out  暗号化されたメッセージを保存するバッファへのポインタ
+    \param in  暗号化する平文を含む入力バッファへのポインタ
+    _Example_
+    \code
+    Des enc; // Des structure used for encryption
+    // initialize enc with wc_Des_SetKey, use mode DES_ENCRYPTION
+
+    byte plain[]  = { // initialize with message to encrypt };
+    byte cipher[sizeof(plain)];
+
+    if ( wc_Des_EcbEncrypt(&enc,cipher, plain, sizeof(plain)) != 0) {
+    	// error encrypting message
+    }
+    \endcode
+    \sa wc_Des_SetKe
+*/
+int  wc_Des_EcbEncrypt(Des* des, byte* out,
+                                   const byte* in, word32 sz);
+
+/*!
+    \ingroup 3DES 
+    \brief  この関数は入力メッセージを暗号化し、結果を出力バッファーに格納します。電子コードブック（ECB）モードでDES3暗号化を使用します。警告：ほぼすべてのユースケースでECBモードは安全性が低いと考えられています。可能な限りECB APIを直接使用しないでください。
+    \return 0  与えられた平文を正常に暗号化すると返されます
+    \param des3  暗号化に使用するDES3構造へのポインタ
+    \param out  暗号化されたメッセージを保存するバッファへのポインタ
+    \param in  暗号化する平文を含む入力バッファへのポインタ
+    _Example_
+    \code
+    Des3 enc; // Des3 structure used for encryption
+    // initialize enc with wc_Des3_SetKey, use mode DES_ENCRYPTION
+
+    byte plain[]  = { // initialize with message to encrypt };
+    byte cipher[sizeof(plain)];
+
+    if ( wc_Des3_EcbEncrypt(&enc,cipher, plain, sizeof(plain)) != 0) {
+        // error encrypting message
+    }
+    \endcode
+    \sa wc_Des3_SetKey
+*/
+int wc_Des3_EcbEncrypt(Des3* des, byte* out,
+                                   const byte* in, word32 sz);
+
+/*!
+    \ingroup 3DES 
+    \brief  この関数は、引数として与えられたDES3構造のキーと初期化ベクトル（IV）を設定します。また、これらがまだ初期化されていない場合は、暗号化と復号化に必要なバッファーのスペースを初期化して割り当てます。注：IVが指定されていない場合（i.e.iv == null）初期化ベクトルは、デフォルトのIV 0になります。
+    \return 0  DES構造体のキーと初期化ベクトルを正常に設定する
+    \param des3  初期化するDES3構造へのポインタ
+    \param key  DES3構造を初期化する24バイトのキーを含むバッファへのポインタ
+    \param iv  DES3構造を初期化するための8バイトIVを含むバッファへのポインタ。これが提供されていない場合、IVはデフォルトで0になります
+    _Example_
+    \code
+    Des3 enc; // Des3 structure used for encryption
+    int ret;
+    byte key[] = { // initialize with 24 byte key };
+    byte iv[]  = { // initialize with 8 byte iv };
+
+    ret = wc_Des3_SetKey(&des, key, iv, DES_ENCRYPTION);
+    if (ret != 0) {
+    	// error initializing des structure
+    }
+    \endcode
+    \sa wc_Des3_SetIV
+    \sa wc_Des3_CbcEncrypt
+    \sa wc_Des3_CbcDecrypt
+*/
+int  wc_Des3_SetKey(Des3* des, const byte* key,
+                                const byte* iv,int dir);
+
+/*!
+    \ingroup 3DES 
+    \brief  この関数は、引数として与えられたDES3構造の初期化ベクトル（IV）を設定します。NULL IVを渡したら、初期化ベクトルを0に設定します。
+    \return none  いいえ返します。
+    \param des  IVを設定するためのDES3構造へのポインタ
+    _Example_
+    \code
+    Des3 enc; // Des3 structure used for encryption
+    // initialize enc with wc_Des3_SetKey
+
+    byte iv[]  = { // initialize with 8 byte iv };
+
+    wc_Des3_SetIV(&enc, iv);
+    }
+    \endcode
+    \sa wc_Des3_SetKey
+*/
+int  wc_Des3_SetIV(Des3* des, const byte* iv);
+
+/*!
+    \ingroup 3DES 
+    \brief  この関数は入力メッセージを暗号化し、結果を出力バッファーに格納します。暗号ブロックチェーン（CBC）モードでトリプルDES（3DES）暗号化を使用します。
+    \return 0  与えられた入力メッセージの暗号化に成功したときに返されます
+    \param des  暗号化に使用するDES3構造へのポインタ
+    \param out  暗号化された暗号文を保存するバッファへのポインタ
+    \param in  暗号化するメッセージを含む入力バッファへのポインタ
+    _Example_
+    \code
+    Des3 enc; // Des3 structure used for encryption
+    // initialize enc with wc_Des3_SetKey, use mode DES_ENCRYPTION
+
+    byte plain[]  = { // initialize with message };
+    byte cipher[sizeof(plain)];
+
+    if ( wc_Des3_CbcEncrypt(&enc, cipher, plain, sizeof(plain)) != 0) {
+	    // error encrypting message
+    }
+    \endcode
+    \sa wc_Des3_SetKey
+    \sa wc_Des3_CbcDecrypt
+*/
+int  wc_Des3_CbcEncrypt(Des3* des, byte* out,
+                                    const byte* in,word32 sz);
+
+/*!
+    \ingroup 3DES 
+    \brief  この関数は入力暗号文を復号化し、結果の平文を出力バッファーに出力します。暗号ブロックチェーン（CBC）モードでトリプルDES（3DES）暗号化を使用します。
+    \return 0  与えられた暗号文を正常に復号化したときに返されました
+    \param des  復号化に使用するDES3構造へのポインタ
+    \param out  復号化された平文を保存するバッファへのポインタ
+    \param in  暗号化された暗号文を含む入力バッファへのポインタ
+    _Example_
+    \code
+    Des3 dec; // Des structure used for decryption
+    // initialize dec with wc_Des3_SetKey, use mode DES_DECRYPTION
+
+    byte cipher[]  = { // initialize with ciphertext };
+    byte decoded[sizeof(cipher)];
+
+    if ( wc_Des3_CbcDecrypt(&dec, decoded, cipher, sizeof(cipher)) != 0) {
+    	// error decrypting message
+    }
+    \endcode
+    \sa wc_Des3_SetKey
+    \sa wc_Des3_CbcEncrypt
+*/
+int  wc_Des3_CbcDecrypt(Des3* des, byte* out,
+                                    const byte* in,word32 sz);

--- a/doc/dox_comments/header_files-ja/dh.h
+++ b/doc/dox_comments/header_files-ja/dh.h
@@ -1,0 +1,281 @@
+/*!
+    \ingroup Diffie-Hellman 
+    \brief  この関数は、Diffie-Hellman Exchangeプロトコルを使用して安全な秘密鍵を交渉するのに使用するためのDiffie-Hellmanキーを初期化します。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    DhKey key;
+    wc_InitDhKey(&key); // initialize DH key
+    \endcode
+    \sa wc_FreeDhKey
+    \sa wc_DhGenerateKeyPair
+*/
+int wc_InitDhKey(DhKey* key);
+
+/*!
+    \ingroup Diffie-Hellman 
+    \brief  この関数は、Diffie-Hellman Exchangeプロトコルを使用して安全な秘密鍵をネゴシエートするために使用された後にDiffie-Hellmanキーを解放します。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    DhKey key;
+    // initialize key, perform key exchange
+
+    wc_FreeDhKey(&key); // free DH key to avoid memory leaks
+    \endcode
+    \sa wc_InitDhKey
+*/
+void wc_FreeDhKey(DhKey* key);
+
+/*!
+    \ingroup Diffie-Hellman 
+    \brief  この関数はdiffie-hellmanパブリックパラメータに基づいてパブリック/秘密鍵ペアを生成し、PRIVSの秘密鍵とPubの公開鍵を格納します。初期化されたDiffie-Hellmanキーと初期化されたRNG構造を取ります。
+    \return BAD_FUNC_ARG  この関数への入力の1つを解析するエラーがある場合に返されます
+    \return RNG_FAILURE_E  RNGを使用して乱数を生成するエラーが発生した場合
+    \return MP_INIT_E  公開鍵の生成中に数学ライブラリにエラーがある場合は返却される可能性があります
+    \return MP_READ_E  公開鍵の生成中に数学ライブラリにエラーがある場合は返却される可能性があります
+    \return MP_EXPTMOD_E  公開鍵の生成中に数学ライブラリにエラーがある場合は返却される可能性があります
+    \return MP_TO_E  公開鍵の生成中に数学ライブラリにエラーがある場合は返却される可能性があります
+    \param key  キーペアを生成するDHKEY構造体へのポインタ
+    \param rng  キーを生成するための初期化された乱数発生器（RNG）へのポインタ
+    \param priv  秘密鍵を保存するバッファへのポインタ
+    \param privSz  PRIVに書かれた秘密鍵のサイズを保存します
+    \param pub  公開鍵を保存するバッファへのポインタ
+    _Example_
+    \code
+    DhKey key;
+    int ret;
+    byte priv[256];
+    byte pub[256];
+    word32 privSz, pubSz;
+
+    wc_InitDhKey(&key); // initialize key
+    // Set DH parameters using wc_DhSetKey or wc_DhKeyDecode
+    WC_RNG rng;
+    wc_InitRng(&rng); // initialize rng
+    ret = wc_DhGenerateKeyPair(&key, &rng, priv, &privSz, pub, &pubSz);
+    \endcode
+    \sa wc_InitDhKey
+    \sa wc_DhSetKey
+    \sa wc_DhKeyDecode
+*/
+int wc_DhGenerateKeyPair(DhKey* key, WC_RNG* rng, byte* priv,
+                                 word32* privSz, byte* pub, word32* pubSz);
+
+/*!
+    \ingroup Diffie-Hellman 
+    \brief  この関数は、ローカル秘密鍵と受信した公開鍵に基づいて合意された秘密鍵を生成します。交換の両側で完了した場合、この関数は対称通信のための秘密鍵の合意を生成します。共有秘密鍵の生成に成功すると、書かれた秘密鍵のサイズは仲間に保存されます。
+    \return 0  合意された秘密鍵の生成に成功しました
+    \return MP_INIT_E  共有秘密鍵の生成中にエラーが発生した場合に返却される可能性があります
+    \return MP_READ_E  共有秘密鍵の生成中にエラーが発生した場合に返却される可能性があります
+    \return MP_EXPTMOD_E  共有秘密鍵の生成中にエラーが発生した場合に返却される可能性があります
+    \return MP_TO_E  共有秘密鍵の生成中にエラーが発生した場合に返却される可能性があります
+    \param key  共有キーを計算するために使用するDHKEY構造体へのポインタ
+    \param agree  秘密キーを保存するバッファへのポインタ
+    \param agreeSz  成功した後に秘密鍵のサイズを保持します
+    \param priv  ローカル秘密鍵を含むバッファへのポインタ
+    \param privSz  地元の秘密鍵のサイズ
+    \param otherPub  受信した公開鍵を含むバッファへのポインタ
+    _Example_
+    \code
+    DhKey key;
+    int ret;
+    byte priv[256];
+    byte agree[256];
+    word32 agreeSz;
+
+    // initialize key, set key prime and base
+    // wc_DhGenerateKeyPair -- store private key in priv
+    byte pub[] = { // initialized with the received public key };
+    ret = wc_DhAgree(&key, agree, &agreeSz, priv, sizeof(priv), pub,
+    sizeof(pub));
+    if ( ret != 0 ) {
+    	// error generating shared key
+    }
+    \endcode
+    \sa wc_DhGenerateKeyPair
+*/
+int wc_DhAgree(DhKey* key, byte* agree, word32* agreeSz,
+                       const byte* priv, word32 privSz, const byte* otherPub,
+                       word32 pubSz);
+
+/*!
+    \ingroup Diffie-Hellman 
+    \brief  この機能は、DERフォーマットのキーを含む与えられた入力バッファからDiffie-Hellmanキーをデコードします。結果をDHKEY構造体に格納します。
+    \return 0  入力キーの復号に成功したときに返されます
+    \return ASN_PARSE_E  入力のシーケンスを解析したエラーがある場合に返されます
+    \return ASN_DH_KEY_E  解析された入力から秘密鍵パラメータを読み取るエラーがある場合
+    \param input  derフォーマットされたdiffie-hellmanキーを含むバッファへのポインタ
+    \param inOutIdx  キーをデコードしている間に解析されたインデックスを保存する整数へのポインタ
+    \param key  入力キーで初期化するためのDHKEY構造体へのポインタ
+    _Example_
+    \code
+    DhKey key;
+    word32 idx = 0;
+
+    byte keyBuff[1024];
+    // initialize with DER formatted key
+    wc_DhKeyInit(&key);
+    ret = wc_DhKeyDecode(keyBuff, &idx, &key, sizeof(keyBuff));
+
+    if ( ret != 0 ) {
+    	// error decoding key
+    }
+    \endcode
+    \sa wc_DhSetKey
+*/
+int wc_DhKeyDecode(const byte* input, word32* inOutIdx, DhKey* key,
+                           word32);
+
+/*!
+    \ingroup Diffie-Hellman 
+    \brief  この関数は、入力秘密鍵パラメータを使用してDHKEY構造体のキーを設定します。WC_DHKEYDECODEとは異なり、この関数は入力キーがDERフォーマットでフォーマットされ、代わりにPARSED入力パラメータP（Prime）とG（Base）を受け入れる必要はありません。
+    \return 0  鍵の設定に成功しました
+    \return BAD_FUNC_ARG  入力パラメータのいずれかがNULLに評価された場合に返されます。
+    \return MP_INIT_E  ストレージのキーパラメータの初期化中にエラーがある場合に返されます。
+    \return ASN_DH_KEY_E  DHキーパラメータPおよびGでエラーの読み取りがある場合は返されます
+    \param key  キーを設定するDHKEY構造体へのポインタ
+    \param p  キーで使用するためのプライムを含むバッファへのポインタ
+    \param pSz  入力プライムの長さ
+    \param g  キーで使用するためのベースを含むバッファへのポインタ
+    _Example_
+    \code
+    DhKey key;
+
+    byte p[] = { // initialize with prime };
+    byte g[] = { // initialize with base };
+    wc_DhKeyInit(&key);
+    ret = wc_DhSetKey(key, p, sizeof(p), g, sizeof(g));
+
+    if ( ret != 0 ) {
+    	// error setting key
+    }
+    \endcode
+    \sa wc_DhKeyDecode
+*/
+int wc_DhSetKey(DhKey* key, const byte* p, word32 pSz, const byte* g,
+                        word32 gSz);
+
+/*!
+    \ingroup Diffie-Hellman 
+    \brief  この関数は、与えられた入力バッファからDiffie-HellmanパラメータP（Prime）とG（ベース）をフォーマットされています。
+    \return 0  DHパラメータの抽出に成功しました
+    \return ASN_PARSE_E  DERフォーマットのDH証明書の解析中にエラーが発生した場合に返されます。
+    \return BUFFER_E  解析されたパラメータを格納するためにPまたはGに不適切なスペースがある場合
+    \param input  解析するDERフォーマットされたDifie-Hellman証明書を含むバッファへのポインタ
+    \param inSz  入力バッファのサイズ
+    \param p  解析されたプライムを保存するバッファへのポインタ
+    \param pInOutSz  Pバッファ内の使用可能なサイズを含むWord32オブジェクトへのポインタ。関数呼び出しを完了した後にバッファに書き込まれたバイト数で上書きされます。
+    \param g  解析されたベースを保存するバッファへのポインタ
+    _Example_
+    \code
+    byte dhCert[] = { initialize with DER formatted certificate };
+    byte p[MAX_DH_SIZE];
+    byte g[MAX_DH_SIZE];
+    word32 pSz = MAX_DH_SIZE;
+    word32 gSz = MAX_DH_SIZE;
+
+    ret = wc_DhParamsLoad(dhCert, sizeof(dhCert), p, &pSz, g, &gSz);
+    if ( ret != 0 ) {
+    	// error parsing inputs
+    }
+    \endcode
+    \sa wc_DhSetKey
+    \sa wc_DhKeyDecode
+*/
+int wc_DhParamsLoad(const byte* input, word32 inSz, byte* p,
+                            word32* pInOutSz, byte* g, word32* gInOutSz);
+
+/*!
+    \ingroup Diffie-Hellman 
+    \sa wc_Dh_ffdhe3072_Get
+    \sa wc_Dh_ffdhe4096_Get
+    \sa wc_Dh_ffdhe6144_Get
+    \sa wc_Dh_ffdhe8192_Get
+*/
+const DhParams* wc_Dh_ffdhe2048_Get(void);
+
+/*!
+    \ingroup Diffie-Hellman 
+    \sa wc_Dh_ffdhe2048_Get
+    \sa wc_Dh_ffdhe4096_Get
+    \sa wc_Dh_ffdhe6144_Get
+    \sa wc_Dh_ffdhe8192_Get
+*/
+const DhParams* wc_Dh_ffdhe3072_Get(void);
+
+/*!
+    \ingroup Diffie-Hellman 
+    \sa wc_Dh_ffdhe2048_Get
+    \sa wc_Dh_ffdhe3072_Get
+    \sa wc_Dh_ffdhe6144_Get
+    \sa wc_Dh_ffdhe8192_Get
+*/
+const DhParams* wc_Dh_ffdhe4096_Get(void);
+
+/*!
+    \ingroup Diffie-Hellman 
+    \sa wc_Dh_ffdhe2048_Get
+    \sa wc_Dh_ffdhe3072_Get
+    \sa wc_Dh_ffdhe4096_Get
+    \sa wc_Dh_ffdhe8192_Get
+*/
+const DhParams* wc_Dh_ffdhe6144_Get(void);
+
+/*!
+    \ingroup Diffie-Hellman 
+    \sa wc_Dh_ffdhe2048_Get
+    \sa wc_Dh_ffdhe3072_Get
+    \sa wc_Dh_ffdhe4096_Get
+    \sa wc_Dh_ffdhe6144_Get
+*/
+const DhParams* wc_Dh_ffdhe8192_Get(void);
+
+/*!
+    \ingroup Diffie-Hellman 
+*/
+int wc_DhCheckKeyPair(DhKey* key, const byte* pub, word32 pubSz,
+                        const byte* priv, word32 privSz);
+
+/*!
+    \ingroup Diffie-Hellman 
+*/
+int wc_DhCheckPrivKey(DhKey* key, const byte* priv, word32 pubSz);
+
+/*!
+*/
+int wc_DhCheckPrivKey_ex(DhKey* key, const byte* priv, word32 pubSz,
+                            const byte* prime, word32 primeSz);
+
+/*!
+*/
+int wc_DhCheckPubKey(DhKey* key, const byte* pub, word32 pubSz);
+
+/*!
+*/
+int wc_DhCheckPubKey_ex(DhKey* key, const byte* pub, word32 pubSz,
+                            const byte* prime, word32 primeSz);
+
+/*!
+*/
+int wc_DhExportParamsRaw(DhKey* dh, byte* p, word32* pSz,
+                       byte* q, word32* qSz, byte* g, word32* gSz);
+
+/*!
+*/
+int wc_DhGenerateParams(WC_RNG *rng, int modSz, DhKey *dh);
+
+/*!
+*/
+int wc_DhSetCheckKey(DhKey* key, const byte* p, word32 pSz,
+                        const byte* g, word32 gSz, const byte* q, word32 qSz,
+                        int trusted, WC_RNG* rng);
+
+/*!
+*/
+int wc_DhSetKey_ex(DhKey* key, const byte* p, word32 pSz,
+                        const byte* g, word32 gSz, const byte* q, word32 qSz);
+
+/*!
+*/
+int wc_FreeDhKey(DhKey* key);

--- a/doc/dox_comments/header_files-ja/doxygen_groups.h
+++ b/doc/dox_comments/header_files-ja/doxygen_groups.h
@@ -1,0 +1,243 @@
+/*!
+    \defgroup 3DES Algorithms - 3DES
+    \defgroup AES Algorithms - AES
+    \defgroup ARC4 Algorithms - ARC4
+    \defgroup BLAKE2 Algorithms - BLAKE2
+    \defgroup Camellia Algorithms - Camellia
+    \defgroup ChaCha Algorithms - ChaCha
+    \defgroup ChaCha20Poly1305 Algorithms - ChaCha20_Poly1305
+    \defgroup Crypto Callbacks - CryptoCb
+    \defgroup Curve25519 Algorithms - Curve25519
+    \defgroup Curve448 Algorithms - Curve448
+    \defgroup DSA Algorithms - DSA
+    \defgroup Diffie-Hellman Algorithms - Diffie-Hellman
+    \defgroup ECC Algorithms - ECC
+    \defgroup ED25519 Algorithms - ED25519
+    \defgroup ED448 Algorithms - ED448
+    \defgroup ECCSI_Overview Overview of ECCSI
+    ECCSI (Elliptic Curve-Based Certificateless Signatures for Identity-Based Encryption) is specified in RFC 6507 (https://tools.ietf.org/html/rfc6507).
+
+    In Identity-Based cryptography, there is a Key Management Service that generates keys based on an identity for a client.
+    The private key (SSK) and public key (PVT) are delivered to the signer and the public key (PVT) only delivered to the verifier on request.\n\n
+    wolfCrypt offers the ability to:
+      -# Create KMS keys,
+      -# Generate signing key pairs,
+      -# Validate signing key pairs,
+      -# Sign messages and
+      -# Verify messages.
+
+    KMS:
+      -# Initialize ECCSI Key: wc_InitEccsiKey()
+      -# Make and save or load ECCSI Key:
+        -# wc_MakeEccsiKey(), wc_ExportEccsiKey(), wc_ExportEccsiPublicKey() or
+        -# wc_ImportEccsiKey()
+      -# Wait for request:
+        -# Receive signing ID from client.
+        -# Generate signing key pair from ID: wc_MakeEccsiPair()
+        -# Encode result:
+          -# For signer, signing key pair: wc_EncodeEccsiPair()
+        -# Send KPAK and result
+      -# Free ECCSI Key: wc_FreeEccsiKey()
+
+    Client, signer:
+      -# Initialize ECCSI Key: wc_InitEccsiKey()
+      -# (When signing pair not cached) Request KPAK and signing pair from KMS
+        -# Send signing ID to KMS.
+        -# Receive signing key pair from KMS.
+        -# Load KMS Public Key: wc_ImportEccsiPublicKey()
+        -# Decode signing key pair: wc_DecodeEccsiPair()
+        -# Validate the key pair: wc_ValidateEccsiPair()
+      -# (If not done above) Load KMS Public Key: wc_ImportEccsiPublicKey()
+      -# (If not cached) Calculate hash of the ID and PVT: wc_HashEccsiId()
+      -# For each message:
+        -# Set Hash of Identity: wc_SetEccsiHash()
+        -# Sign message: wc_SignEccsiHash()
+        -# Send hash ID, message and signature to peer.
+      -# Free ECCSI Key: wc_FreeEccsiKey()
+
+    Client, verifier:
+      -# Receive hash ID, message and signature from signer.
+      -# Request KPAK (if not cached) and PVT (if not cached) for hash ID from KMS.
+      -# Receive KPAK (if not cached) and PVT (if not cached) for hash ID from KMS.
+      -# Initialize ECCSI Key: wc_InitEccsiKey()
+      -# Load KMS Public Key: wc_ImportEccsiPublicKey()
+      -# Decode PVT: wc_DecodeEccsiPvtFromSig()
+      -# Calculate hash of the ID and PVT: wc_HashEccsiId()
+      -# Set ECCSI key pair: wc_SetEccsiPair()
+      -# Verify signature of message: wc_VerifyEccsiHash()
+      -# Free ECCSI Key: wc_FreeEccsiKey()
+
+    \defgroup ECCSI_Setup Setup ECCSI Key
+    Operations for establinshing an ECCSI key.
+
+    Initialize ECCSI Key before use (wc_InitEccsiKey()).\n
+    Initialize ECCSI Key before use (wc_InitEccsiKey_ex()) for use with a curve other than P256.\n
+    Either make a new key (wc_MakeEccsiKey()), import an existing key (wc_ImportEccsiKey()) or import existing private key (wc_ImportEccsiPrivateKey()) and public key (wc_ImportEccsiPublicKey()).\n
+    Export the key (wc_ExportEccsiKey()) after making a new key for future use.\n
+    Export the private key (wc_ExportEccsiPrivateKey()) after making a new key for future use.\n
+    Export the public key (wc_ExportEccsiPublicKey()) from KMS to pass to client.\n
+    Import the public key (wc_ImportEccsiPublicKey()) into client.\n
+    Free the ECCSI Key (wc_FreeEccsiKey()) when finished.
+
+    \defgroup ECCSI_Operations Operations for Signing and Verifying with ECCSI Key
+    These operations are for signing and verifying with ECCSI keys.
+
+    Make an ECCSI key pair (wc_MakeEccsiPair()) with the signer's ID for use when signing.\n
+    Validate the ECCSI key pair (wc_ValidateEccsiPair()) with the signer's ID.\n
+    Validate the ECCSI Public Validation Token (PVT) (wc_ValidateEccsiPvt()).\n
+    Encode the ECCSI key pair (wc_EncodeEccsiPair()) for transfer to client.\n
+    Encode the ECCSI SSK (wc_EncodeEccsiSsk()) for transfer to client.\n
+    Encode the ECCSI PVT (wc_EncodeEccsiPvt()) for transfer to verifier.\n
+    Decode the ECCSI key pair (wc_DecodeEccsiPair()) on client for signing.\n
+    Decode the ECCSI SSK (wc_DecodeEccsiSsk()) on client for signing.\n
+    Decode the ECCSI PVT (wc_DecodeEccsiPvt()) on client for signing.\n
+    Decode the ECCSI PVT from the signature (wc_DecodeEccsiPvtFromSig()) on client for verifying.\n
+    Calculate hash of the ID (wc_HashEccsiId()) for signing/verifying using ID and Public Validation Token (PVT).\n
+    Sign (wc_SignEccsiHash()) a message with the hash of the ID and the Secret Signing Key (SSK) and Public Validation Token (PVT).\n
+    Verify (wc_VerifyEccsiHash()) a message with the hash of the signer's ID.
+
+    \defgroup SAKKE_Overview Overview of SAKKE Key
+    SAKKE (Sakai-Kasahara Key Encryption) is specified in RFC 6508 (https://tools.ietf.org/html/rfc6508).
+
+    SAKKE is used to transfer a secret to a peer using Identity Based cryptography.\n
+    The Key Management Service (KMS) is responsible for issuing Receiver Secret %Keys (RSKs).
+    Data up to (2^hashlen)^hashlen bytes of data can be transferred.\n
+    The sender must know the identity of the receiver and the KMS Public Key.\n
+    The receiver must have obtained a Receiver Secret Key (RSK) for the identity from a KMS in order to derive the secret.
+
+    KMS:
+      -# Initialize SAKKE Key: wc_InitSakkeKey()
+      -# Make and save or load SAKKE Key:
+        -# wc_MakeSakkeKey(), wc_ExportSakkeKey(), wc_ExportSakkePublicKey() or
+        -# wc_ImportSakkeKey()
+      -# Wait for request:
+        -# Make an RSK base on ID for the client: wc_MakeSakkeRsk()
+        -# Encode RSK for transfer to client: wc_EncodeSakkeRsk()
+      -# Free SAKKE Key: wc_FreeSakkeKey()
+
+    Key Exchange, Peer A:
+      -# Initialize SAKKE Key: wc_InitSakkeKey()
+      -# Load KMS Public Key: wc_ImportSakkePublicKey()
+      -# Generate a random SSV: wc_GenerateSakkeSSV()
+      -# Set the identity of Peer B: wc_SetSakkeIdentity()
+      -# Make an encapsulated SSV and auth data: wc_MakeSakkeEncapsulatedSSV()
+      -# Send encapsulated data to Peer B
+      -# Free SAKKE Key: wc_FreeSakkeKey()
+
+    Key Exchange, Peer B:
+      -# Receive encapsulated data.
+      -# Initialize SAKKE Key: wc_InitSakkeKey()
+      -# Load KMS Public Key: wc_ImportSakkePublicKey()
+      -# Decode RSK transferred from KMS or stored locally: wc_DecodeSakkeRsk()
+      -# [Optional] Validate RSK before first use: wc_ValidateSakkeRsk()
+      -# Set the identity: wc_SetSakkeIdentity()
+      -# Set the RSK and, optionally precomputation table: wc_SetSakkeRsk()
+      -# Derive SSV with auth data: wc_DeriveSakkeSSV()
+      -# Free SAKKE Key: wc_FreeSakkeKey()
+
+    Transfer secret, Peer A:
+      -# Initialize SAKKE Key: wc_InitSakkeKey()
+      -# Load KMS Public Key: wc_ImportSakkePublicKey()
+      -# Set the identity of Peer B: wc_SetSakkeIdentity()
+      -# Make an encapsulation of the SSV and auth data: wc_MakeSakkeEncapsulatedSSV()
+      -# Send encapsulated data to Peer B
+      -# Free SAKKE Key: wc_FreeSakkeKey()
+
+    Transfer secret, Peer B:
+      -# Initialize SAKKE Key: wc_InitSakkeKey()
+      -# Load KMS Public Key: wc_ImportSakkePublicKey()
+      -# Decode RSK transferred from KMS or stored locally: wc_DecodeSakkeRsk()
+      -# [Optional] Validate RSK before first use: wc_ValidateSakkeRsk()
+      -# Receive encapsulated data.
+      -# Set the identity: wc_SetSakkeIdentity()
+      -# Set the RSK and, optionally precomputation table: wc_SetSakkeRsk()
+      -# Derive SSV and auth data: wc_DeriveSakkeSSV()
+      -# Free SAKKE Key: wc_FreeSakkeKey()
+    
+    \defgroup SAKKE_Setup Setup SAKKE Key
+    Operations for establishing a SAKKE key.
+
+    Initialization SAKKE Key before use (wc_InitSakkeKey() or wc_InitSakkeKey_ex()).\n
+    Either make a new key (wc_MakeSakkeKey()) or import an existing key (wc_ImportSakkeKey()).\n
+    Export the key (wc_ExportSakkeKey()) after making a new key for future use.\n
+    If only the private part of the KMS SAKKE Key is available, make the public key (wc_MakeSakkePublicKey()).\n
+    Export the private key (wc_ExportSakkePrivateKey()) from KMS from storage.\n
+    Import the private key (wc_ImportSakkePrivateKey()) into KMS from storage.\n
+    Export the public key (wc_ExportSakkePublicKey()) from KMS to pass to client.\n
+    Import the public key (wc_ImportSakkePublicKey()) into client.\n
+    Set the identity to use (wc_SetSakkeIdentity()) into client.\n
+    Free the SAKKE Key (wc_FreeSakkeKey()) when finished.
+
+    \defgroup SAKKE_RSK Operations on/with SAKKE RSK
+    These operations make, validate, encode and decode a Receiver Secret Key (RSK).
+
+    An RSK is required to derive an SSV (see wc_DeriveSakkeSSV()).\n
+    On the KMS, make an RSK (wc_MakeSakkeRsk()) from the client's ID.\n
+    On the client, validate the RSK (wc_ValidateSakkeRsk()) with the ID.\n
+    Encode the RSK (wc_EncodeSakkeRsk()) to pass to client or for storage.\n
+    Decode the RSK (wc_DecodeSakkeRsk()) on the client when needed.\n
+    Import the RSK (wc_ImportSakkeRsk()) on the client when needed.\n
+    Set the RSK and, optionally, a pre-computation table (wc_SetSakkeRsk()) on the client when needed.
+
+    \defgroup SAKKE_Operations Operations using SAKKE Key
+    These operations transfer a Shared Secret Value (SSV) from one client to another. The SSV may be randomly generated.
+
+    Calculate the size of the authentication data (wc_GetSakkeAuthSize()) to determine where the SSV starts in a buffer.\n
+    Make the intermediate point I (wc_MakeSakkePointI()) to speed making an encapsulated and deriving SSV.\n
+    Get intermediate point I (wc_GetSakkePointI()) for storage.\n
+    Set intermediate point I (wc_SetSakkePointI()) from storage.\n
+    Generate a pre-computation table for intermediate point I (wc_GenerateSakkePointITable()) to further enhance performance. Store as necessary.\n
+    Set the pre-computation table for intermediate point I (wc_SetSakkePointITable()) to further enhance performance.\n
+    Clear the pre-computation table for intermediate point I (wc_ClearSakkePointITable()) to remove reference to external table pointer.\n
+    Make an encapsulated SSV (wc_MakeSakkeEncapsulatedSSV()) to share with another client. Data in SSV is modified.\n
+    Generate a random SSV (wc_GenerateSakkeSSV()) for key exchange.\n
+    Derive the SSV, (wc_DeriveSakkeSSV()) on the recipient from the encapsulated SSV.
+
+    \defgroup HMAC Algorithms - HMAC
+    \defgroup MD2 Algorithms - MD2
+    \defgroup MD4 Algorithms - MD4
+    \defgroup MD5 Algorithms - MD5
+    \defgroup PKCS7 Algorithms - PKCS7
+    \defgroup PKCS11 Algorithms - PKCS11
+    \defgroup Password Algorithms - Password Based
+    \defgroup Poly1305 Algorithms - Poly1305
+    \defgroup RIPEMD Algorithms - RIPEMD
+    \defgroup RSA Algorithms - RSA
+    \defgroup SHA Algorithms - SHA 128/224/256/384/512
+    \defgroup SipHash Algorithm - SipHash
+    \defgroup SRP Algorithms - SRP
+
+    \defgroup ASN ASN.1
+    \defgroup Base_Encoding Base Encoding
+    \defgroup CertManager CertManager API
+    \defgroup Compression Compression
+    \defgroup Error Error Reporting
+    \defgroup IoTSafe IoT-Safe Module
+    IoT-Safe (IoT-SIM Applet For Secure End-2-End Communication) is a technology that leverage the SIM as robust,
+    scalable and standardized hardware Root of Trust to protect data communication.
+
+    IoT-Safe SSL sessions use the SIM as Hardware Security Module, offloading all the crypto public
+    key operations and reducing the attack surface by restricting access to certificate and keys
+    to the SIM.
+
+    IoT-Safe support can be enabled on an existing WOLFSSL_CTX contex, using wolfSSL_CTX_iotsafe_enable().\n
+    Session created within the context can set the parameters for IoT-Safe key and files usage, and enable
+    the public keys callback, with wolfSSL_iotsafe_on().
+
+    If compiled in, the module supports IoT-Safe random number generator as source of entropy for wolfCrypt.
+
+    \defgroup PSA Platform Security Architecture (PSA) API
+    \defgroup Keys Key and Cert Conversion
+    \defgroup Logging Logging
+    \defgroup Math Math API
+    \defgroup Memory Memory Handling
+    \defgroup Random Random Number Generation
+    \defgroup Signature Signature API
+    \defgroup openSSL OpenSSL API
+    \defgroup wolfCrypt wolfCrypt Init and Cleanup
+    \defgroup TLS wolfSSL Initialization/Shutdown
+    \defgroup CertsKeys wolfSSL Certificates and Keys
+    \defgroup Setup wolfSSL Context and Session Set Up
+    \defgroup IO wolfSSL Connection, Session, and I/O
+    \defgroup Debug wolfSSL Error Handling and Reporting
+*/

--- a/doc/dox_comments/header_files-ja/doxygen_pages.h
+++ b/doc/dox_comments/header_files-ja/doxygen_pages.h
@@ -1,0 +1,75 @@
+/*!
+    \page wolfssl_API wolfSSL API Reference
+    - \ref CertManager
+    - \ref Memory
+    - \ref openSSL
+
+    - \ref CertsKeys
+    - \ref IO
+    - \ref Setup
+    - \ref Debug
+    - \ref TLS
+*/
+/*!
+    \page wolfcrypt_API wolfCrypt API Reference
+    <ul>
+        <li>\ref ASN</li>
+        <li>\ref Base_Encoding</li>
+        <li>\ref Compression</li>
+        <li>\ref Error</li>
+        <li>\ref IoTSafe</li>
+        <li>\ref PSA</li>
+        <li>\ref Keys</li>
+        <li>\ref Logging</li>
+        <li>\ref Math</li>
+        <li>\ref Random</li>
+        <li>\ref Signature</li>
+        <li>\ref wolfCrypt</li>
+    </ul>
+    <ul>
+        <li>\ref DES</li>
+        <li>\ref AES</li>
+        <li>\ref ARC4</li>
+        <li>\ref BLAKE2</li>
+        <li>\ref Camellia</li>
+        <li>\ref ChaCha</li>
+        <li>\ref ChaCha20Poly1305</li>
+        <li>\ref Crypto Callbacks</li>
+        <li>\ref Curve25519</li>
+        <li>\ref Curve448</li>
+        <li>\ref DSA</li>
+        <li>\ref Diffie-Hellman</li>
+        <li>\ref ECC</li>
+        <li>\ref ED25519</li>
+        <li>\ref ED448</li>
+        <li>\ref ECCSI</li>
+        <li>\ref SAKKE</li>
+        <li>\ref HMAC</li>
+        <li>\ref MD2</li>
+        <li>\ref MD4</li>
+        <li>\ref MD5</li>
+        <li>\ref Password</li>
+        <li>\ref PKCS7</li>
+        <li>\ref PKCS11</li>
+        <li>\ref Poly1305</li>
+        <li>\ref RIPEMD</li>
+        <li>\ref RSA</li>
+        <li>\ref SHA</li>
+        <li>\ref SipHash</li>
+        <li>\ref SRP</li>
+    </ul>
+*/
+/*!
+    \page ECCSI ECCSI API Reference
+    - \ref ECCSI_Overview
+    - \ref ECCSI_Setup
+    - \ref ECCSI_Operations
+*/
+/*!
+    \page SAKKE SAKKE API Reference
+    - \ref SAKKE_Overview
+    - \ref SAKKE_Setup
+    - \ref SAKKE_RSK
+    - \ref SAKKE_Operations
+*/
+

--- a/doc/dox_comments/header_files-ja/dsa.h
+++ b/doc/dox_comments/header_files-ja/dsa.h
@@ -1,0 +1,237 @@
+/*!
+    \ingroup DSA 
+    \brief  この関数は、デジタル署名アルゴリズム（DSA）を介した認証に使用するためにDSAKEYオブジェクトを初期化します。
+    \return 0  成功に戻りました。
+    \return BAD_FUNC_ARG  NULLキーが渡された場合に返されます。
+    _Example_
+    \code
+    DsaKey key;
+    int ret;
+    ret = wc_InitDsaKey(&key); // initialize DSA key
+    \endcode
+    \sa wc_FreeDsaKey
+*/
+int wc_InitDsaKey(DsaKey* key);
+
+/*!
+    \ingroup DSA 
+    \brief  この関数は、使用された後にdsakeyオブジェクトを解放します。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    DsaKey key;
+    // initialize key, use for authentication
+    ...
+    wc_FreeDsaKey(&key); // free DSA key
+    \endcode
+    \sa wc_FreeDsaKey
+*/
+void wc_FreeDsaKey(DsaKey* key);
+
+/*!
+    \ingroup DSA 
+    \brief  この機能は入力ダイジェストに署名し、結果を出力バッファーに格納します。
+    \return 0  入力ダイジェストに正常に署名したときに返されました
+    \return MP_INIT_E  DSA署名の処理にエラーがある場合は返される可能性があります。
+    \return MP_READ_E  DSA署名の処理にエラーがある場合は返される可能性があります。
+    \return MP_CMP_E  DSA署名の処理にエラーがある場合は返される可能性があります。
+    \return MP_INVMOD_E  DSA署名の処理にエラーがある場合は返される可能性があります。
+    \return MP_EXPTMOD_E  DSA署名の処理にエラーがある場合は返される可能性があります。
+    \return MP_MOD_E  DSA署名の処理にエラーがある場合は返される可能性があります。
+    \return MP_MUL_E  DSA署名の処理にエラーがある場合は返される可能性があります。
+    \return MP_ADD_E  DSA署名の処理にエラーがある場合は返される可能性があります。
+    \return MP_MULMOD_E  DSA署名の処理にエラーがある場合は返される可能性があります。
+    \return MP_TO_E  DSA署名の処理にエラーがある場合は返される可能性があります。
+    \return MP_MEM  DSA署名の処理にエラーがある場合は返される可能性があります。
+    \param digest  署名するハッシュへのポインタ
+    \param out  署名を保存するバッファへのポインタ
+    \param key  署名を生成するための初期化されたDsakey構造へのポインタ
+    _Example_
+    \code
+    DsaKey key;
+    // initialize DSA key, load private Key
+    int ret;
+    WC_RNG rng;
+    wc_InitRng(&rng);
+    byte hash[] = { // initialize with hash digest };
+    byte signature[40]; // signature will be 40 bytes (320 bits)
+
+    ret = wc_DsaSign(hash, signature, &key, &rng);
+    if (ret != 0) {
+	    // error generating DSA signature
+    }
+    \endcode
+    \sa wc_DsaVerify
+*/
+int wc_DsaSign(const byte* digest, byte* out,
+                           DsaKey* key, WC_RNG* rng);
+
+/*!
+    \ingroup DSA 
+    \brief  この関数は、秘密鍵を考えると、ダイジェストの署名を検証します。回答パラメータでキーが正しく検証されているかどうか、正常な検証に対応する1、および失敗した検証に対応する0が格納されます。
+    \return 0  検証要求の処理に成功したときに返されます。注：これは、署名が検証されていることを意味するわけではなく、関数が成功したというだけです。
+    \return MP_INIT_E  DSA署名の処理にエラーがある場合は返される可能性があります。
+    \return MP_READ_E  DSA署名の処理にエラーがある場合は返される可能性があります。
+    \return MP_CMP_E  DSA署名の処理にエラーがある場合は返される可能性があります。
+    \return MP_INVMOD_E  DSA署名の処理にエラーがある場合は返される可能性があります。
+    \return MP_EXPTMOD_E  DSA署名の処理にエラーがある場合は返される可能性があります。
+    \return MP_MOD_E  DSA署名の処理にエラーがある場合は返される可能性があります。
+    \return MP_MUL_E  DSA署名の処理にエラーがある場合は返される可能性があります。
+    \return MP_ADD_E  DSA署名の処理にエラーがある場合は返される可能性があります。
+    \return MP_MULMOD_E  DSA署名の処理にエラーがある場合は返される可能性があります。
+    \return MP_TO_E  DSA署名の処理にエラーがある場合は返される可能性があります。
+    \return MP_MEM  DSA署名の処理にエラーがある場合は返される可能性があります。
+    \param digest  署名の主題を含むダイジェストへのポインタ
+    \param sig  確認する署名を含むバッファへのポインタ
+    \param key  署名を検証するための初期化されたDsakey構造へのポインタ
+    _Example_
+    \code
+    DsaKey key;
+    // initialize DSA key, load public Key
+
+    int ret;
+    int verified;
+    byte hash[] = { // initialize with hash digest };
+    byte signature[] = { // initialize with signature to verify };
+    ret = wc_DsaVerify(hash, signature, &key, &verified);
+    if (ret != 0) {
+    	// error processing verify request
+    } else if (answer == 0) {
+    	// invalid signature
+    }
+    \endcode
+    \sa wc_DsaSign
+*/
+int wc_DsaVerify(const byte* digest, const byte* sig,
+                             DsaKey* key, int* answer);
+
+/*!
+    \ingroup DSA 
+    \brief  この機能は、DSA公開鍵を含むDERフォーマットの証明書バッファを復号し、与えられたDSakey構造体にキーを格納します。また、入力読み取りの長さに応じてINOUTIDXパラメータを設定します。
+    \return 0  dsakeyオブジェクトの公開鍵を正常に設定する
+    \return ASN_PARSE_E  証明書バッファを読みながらエンコーディングにエラーがある場合
+    \return ASN_DH_KEY_E  DSAパラメータの1つが誤ってフォーマットされている場合に返されます
+    \param input  DERフォーマットDSA公開鍵を含むバッファへのポインタ
+    \param inOutIdx  証明書の最後のインデックスを保存する整数へのポインタ
+    \param key  公開鍵を保存するDsakey構造へのポインタ
+    _Example_
+    \code
+    int ret, idx=0;
+
+    DsaKey key;
+    wc_InitDsaKey(&key);
+    byte derBuff[] = { // DSA public key};
+    ret = wc_DsaPublicKeyDecode(derBuff, &idx, &key, inSz);
+    if (ret != 0) {
+    	// error reading public key
+    }
+    \endcode
+    \sa wc_InitDsaKey
+    \sa wc_DsaPrivateKeyDecode
+*/
+int wc_DsaPublicKeyDecode(const byte* input, word32* inOutIdx,
+                                      DsaKey* key, word32 inSz);
+
+/*!
+    \ingroup DSA 
+    \brief  この機能は、DSA秘密鍵を含むDERフォーマットの証明書バッファをデコードし、指定されたDSakey構造体にキーを格納します。また、入力読み取りの長さに応じてINOUTIDXパラメータを設定します。
+    \return 0  dsakeyオブジェクトの秘密鍵を正常に設定するに返されました
+    \return ASN_PARSE_E  証明書バッファを読みながらエンコーディングにエラーがある場合
+    \return ASN_DH_KEY_E  DSAパラメータの1つが誤ってフォーマットされている場合に返されます
+    \param input  DERフォーマットDSA秘密鍵を含むバッファへのポインタ
+    \param inOutIdx  証明書の最後のインデックスを保存する整数へのポインタ
+    \param key  秘密鍵を保存するDSakey構造へのポインタ
+    _Example_
+    \code
+    int ret, idx=0;
+
+    DsaKey key;
+    wc_InitDsaKey(&key);
+    byte derBuff[] = { // DSA private key };
+    ret = wc_DsaPrivateKeyDecode(derBuff, &idx, &key, inSz);
+    if (ret != 0) {
+    	// error reading private key
+    }
+    \endcode
+    \sa wc_InitDsaKey
+    \sa wc_DsaPublicKeyDecode
+*/
+int wc_DsaPrivateKeyDecode(const byte* input, word32* inOutIdx,
+                                       DsaKey* key, word32 inSz);
+
+/*!
+    \ingroup DSA 
+    \brief  DSAKEYキーをDERフォーマット、出力への書き込み（Inlen）、書き込まれたバイトを返します。
+    \return outLen  成功、書かれたバイト数
+    \return BAD_FUNC_ARG  キーまたは出力はNULLまたはキー - >タイプがDSA_PRIVATEではありません。
+    \return MEMORY_E  メモリの割り当て中にエラーが発生しました。
+    \param key  変換するdsakey構造へのポインタ。
+    \param output  変換キーの出力バッファへのポインタ。
+    _Example_
+    \code
+    DsaKey key;
+    WC_WC_RNG rng;
+    int derSz;
+    int bufferSize = // Sufficient buffer size;
+    byte der[bufferSize];
+
+    wc_InitDsaKey(&key);
+    wc_InitRng(&rng);
+    wc_MakeDsaKey(&rng, &key);
+    derSz = wc_DsaKeyToDer(&key, der, bufferSize);
+    \endcode
+    \sa wc_InitDsaKey
+    \sa wc_FreeDsaKey
+    \sa wc_MakeDsaKey
+*/
+int wc_DsaKeyToDer(DsaKey* key, byte* output, word32 inLen);
+
+/*!
+    \ingroup DSA 
+    \brief  DSAキーを作成します。
+    \return MP_OKAY  成功
+    \return BAD_FUNC_ARG  RNGまたはDSAのどちらかがnullです。
+    \return MEMORY_E  バッファにメモリを割り当てることができませんでした。
+    \return MP_INIT_E  MP_INTの初期化エラー
+    \param rng  WC_RNG構造体へのポインタ。
+    _Example_
+    \code
+    WC_WC_RNG rng;
+    DsaKey dsa;
+    wc_InitRng(&rng);
+    wc_InitDsa(&dsa);
+    if(wc_MakeDsaKey(&rng, &dsa) != 0)
+    {
+        // Error creating key
+    }
+    \endcode
+    \sa wc_InitDsaKey
+    \sa wc_FreeDsaKey
+    \sa wc_DsaSign
+*/
+int wc_MakeDsaKey(WC_RNG *rng, DsaKey *dsa);
+
+/*!
+    \ingroup DSA 
+    \brief  FIPS 186-4は、modulus_size値の有効な値を定義します（1024,160）（2048,256）（3072,256）
+    \return 0  成功
+    \return BAD_FUNC_ARG  RNGまたはDSAはNULLまたはMODULUS_SIZEが無効です。
+    \return MEMORY_E  メモリを割り当てようとするエラーが発生しました。
+    \param rng  WolfCrypt RNGへのポインタ。
+    \param modulus_size  1024,2048、または3072は有効な値です。
+    _Example_
+    \code
+    DsaKey key;
+    WC_WC_RNG rng;
+    wc_InitDsaKey(&key);
+    wc_InitRng(&rng);
+    if(wc_MakeDsaParameters(&rng, 1024, &genKey) != 0)
+    {
+        // Handle error
+    }
+    \endcode
+    \sa wc_MakeDsaKey
+    \sa wc_DsaKeyToDer
+    \sa wc_InitDsaKey
+*/
+int wc_MakeDsaParameters(WC_RNG *rng, int modulus_size, DsaKey *dsa);

--- a/doc/dox_comments/header_files-ja/ecc.h
+++ b/doc/dox_comments/header_files-ja/ecc.h
@@ -1,0 +1,1361 @@
+/*!
+    \ingroup ECC 
+    \brief  この関数は新しいECC_KEYを生成し、それをキーに格納します。
+    \return 0  成功に戻りました。
+    \return ECC_BAD_ARG_E  RNGまたはキーがNULLに評価された場合に返されます
+    \return BAD_FUNC_ARG  指定されたキーサイズがサポートされているキーの正しい範囲にない場合に返されます。
+    \return MEMORY_E  ECCキーの計算中にメモリの割り当てエラーがある場合に返されます。
+    \return MP_INIT_E  ECCキーの計算中にエラーが発生した場合に返される可能性があります
+    \return MP_READ_E  ECCキーの計算中にエラーが発生した場合に返される可能性があります
+    \return MP_CMP_E  ECCキーの計算中にエラーが発生した場合に返される可能性があります
+    \return MP_INVMOD_E  ECCキーの計算中にエラーが発生した場合に返される可能性があります
+    \return MP_EXPTMOD_E  ECCキーの計算中にエラーが発生した場合に返される可能性があります
+    \return MP_MOD_E  ECCキーの計算中にエラーが発生した場合に返される可能性があります
+    \return MP_MUL_E  ECCキーの計算中にエラーが発生した場合に返される可能性があります
+    \return MP_ADD_E  ECCキーの計算中にエラーが発生した場合に返される可能性があります
+    \return MP_MULMOD_E  ECCキーの計算中にエラーが発生した場合に返される可能性があります
+    \return MP_TO_E  ECCキーの計算中にエラーが発生した場合に返される可能性があります
+    \return MP_MEM  ECCキーの計算中にエラーが発生した場合に返される可能性があります
+    \param rng  キーを生成するための初期化されたRNGオブジェクトへのポインタ
+    \param keysize  ECC_KEYの希望の長さ
+    _Example_
+    \code
+    ecc_key key;
+    wc_ecc_init(&key);
+    WC_WC_RNG rng;
+    wc_InitRng(&rng);
+    wc_ecc_make_key(&rng, 32, &key); // initialize 32 byte ecc key
+    \endcode
+    \sa wc_ecc_init
+    \sa wc_ecc_shared_secret
+*/
+
+int wc_ecc_make_key(WC_RNG* rng, int keysize, ecc_key* key);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は新しいECC_KEYを生成し、それをキーに格納します。
+    \return 0  成功に戻りました。
+    \return ECC_BAD_ARG_E  RNGまたはキーがNULLに評価された場合に返されます
+    \return BAD_FUNC_ARG  指定されたキーサイズがサポートされているキーの正しい範囲にない場合に返されます。
+    \return MEMORY_E  ECCキーの計算中にメモリの割り当てエラーがある場合に返されます。
+    \return MP_INIT_E  ECCキーの計算中にエラーが発生した場合に返される可能性があります
+    \return MP_READ_E  ECCキーの計算中にエラーが発生した場合に返される可能性があります
+    \return MP_CMP_E  ECCキーの計算中にエラーが発生した場合に返される可能性があります
+    \return MP_INVMOD_E  ECCキーの計算中にエラーが発生した場合に返される可能性があります
+    \return MP_EXPTMOD_E  ECCキーの計算中にエラーが発生した場合に返される可能性があります
+    \return MP_MOD_E  ECCキーの計算中にエラーが発生した場合に返される可能性があります
+    \return MP_MUL_E  ECCキーの計算中にエラーが発生した場合に返される可能性があります
+    \return MP_ADD_E  ECCキーの計算中にエラーが発生した場合に返される可能性があります
+    \return MP_MULMOD_E  ECCキーの計算中にエラーが発生した場合に返される可能性があります
+    \return MP_TO_E  ECCキーの計算中にエラーが発生した場合に返される可能性があります
+    \return MP_MEM  ECCキーの計算中にエラーが発生した場合に返される可能性があります
+    \param key  作成したキーを保存するためのポインタ。
+    \param keysize  CavenIDに基づいて設定されたバイト単位で作成するキーのサイズ
+    \param rng  鍵作成に使用されるRNG
+    _Example_
+    \code
+    ecc_key key;
+    int ret;
+    WC_WC_RNG rng;
+    wc_ecc_init(&key);
+    wc_InitRng(&rng);
+    int curveId = ECC_SECP521R1;
+    int keySize = wc_ecc_get_curve_size_from_id(curveId);
+    ret = wc_ecc_make_key_ex(&rng, keySize, &key, curveId);
+    if (ret != MP_OKAY) {
+        // error handling
+    }
+
+    \endcode
+    \sa wc_ecc_make_key
+    \sa wc_ecc_get_curve_size_from_id
+*/
+
+int wc_ecc_make_key_ex(WC_RNG* rng, int keysize, ecc_key* key, int curve_id);
+
+/*!
+    \ingroup ECC 
+    \brief  ECCキーの有効性を有効にします。
+    \return MP_OKAY  成功、キーは大丈夫です。
+    \return BAD_FUNC_ARG  キーがNULLの場合は返します。
+    \return ECC_INF_E  WC_ECC_POINT_IS_AT_INFINITYが1を返す場合に返します。
+    _Example_
+    \code
+    ecc_key key;
+    WC_WC_RNG rng;
+    int check_result;
+    wc_ecc_init(&key);
+    wc_InitRng(&rng);
+    wc_ecc_make_key(&rng, 32, &key);
+    check_result = wc_ecc_check_key(&key);
+
+    if (check_result == MP_OKAY)
+    {
+        // key check succeeded
+    }
+    else
+    {
+        // key check failed
+    }
+    \endcode
+    \sa wc_ecc_point_is_at_infinity
+*/
+
+int wc_ecc_check_key(ecc_key* key);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は、使用された後にECC_KEYキーを解放します。
+    _Example_
+    \code
+    // initialize key and perform ECC operations
+    ...
+    wc_ecc_key_free(&key);
+    \endcode
+    \sa wc_ecc_key_new
+    \sa wc_ecc_init_ex
+*/
+
+void wc_ecc_key_free(ecc_key* key);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は、ローカル秘密鍵と受信した公開鍵を使用して新しい秘密鍵を生成します。この共有秘密鍵をバッファアウトに格納し、出力バッファに書き込まれたバイト数を保持するためにoutlentenを更新します。
+    \return 0  共有秘密鍵の生成に成功したときに返されます
+    \return BAD_FUNC_ARG  入力パラメータのいずれかがNULLに評価された場合に返されます。
+    \return ECC_BAD_ARG_E  引数として与えられた秘密鍵の種類がecc_privatekeyではない場合、またはパブリックキータイプ（ECC-> DPによって与えられた）が同等でない場合に返されます。
+    \return MEMORY_E  新しいECCポイントを生成するエラーが発生した場合
+    \return BUFFER_E  生成された共有秘密鍵が提供されたバッファーに格納するのに長すぎる場合に返されます
+    \return MP_INIT_E  共有キーの計算中にエラーが発生した場合は返される可能性があります
+    \return MP_READ_E  共有キーの計算中にエラーが発生した場合は返される可能性があります
+    \return MP_CMP_E  共有キーの計算中にエラーが発生した場合は返される可能性があります
+    \return MP_INVMOD_E  共有キーの計算中にエラーが発生した場合は返される可能性があります
+    \return MP_EXPTMOD_E  共有キーの計算中にエラーが発生した場合は返される可能性があります
+    \return MP_MOD_E  共有キーの計算中にエラーが発生した場合は返される可能性があります
+    \return MP_MUL_E  共有キーの計算中にエラーが発生した場合は返される可能性があります
+    \return MP_ADD_E  共有キーの計算中にエラーが発生した場合は返される可能性があります
+    \return MP_MULMOD_E  共有キーの計算中にエラーが発生した場合は返される可能性があります
+    \return MP_TO_E  共有キーの計算中にエラーが発生した場合は返される可能性があります
+    \return MP_MEM  共有キーの計算中にエラーが発生した場合は返される可能性があります
+    \param private_key  ローカル秘密鍵を含むECC_KEY構造体へのポインタ
+    \param public_key  受信した公開鍵を含むECC_Key構造体へのポインタ
+    \param out  生成された共有秘密鍵を保存する出力バッファへのポインタ
+    _Example_
+    \code
+    ecc_key priv, pub;
+    WC_WC_RNG rng;
+    byte secret[1024]; // can hold 1024 byte shared secret key
+    word32 secretSz = sizeof(secret);
+    int ret;
+
+    wc_InitRng(&rng); // initialize rng
+    wc_ecc_init(&priv); // initialize key
+    wc_ecc_make_key(&rng, 32, &priv); // make public/private key pair
+    // receive public key, and initialise into pub
+    ret = wc_ecc_shared_secret(&priv, &pub, secret, &secretSz);
+    // generate secret key
+    if ( ret != 0 ) {
+    	// error generating shared secret key
+    }
+    \endcode
+    \sa wc_ecc_init
+    \sa wc_ecc_make_key
+*/
+
+int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key, byte* out,
+                      word32* outlen);
+
+/*!
+    \ingroup ECC 
+    \brief  秘密鍵とパブリックポイントの間にECC共有秘密を作成します。
+    \return MP_OKAY  成功を示します。
+    \return BAD_FUNC_ARG  引数がNULLのときにエラーが返されます。
+    \return ECC_BAD_ARG_E  private_key-> typeがecc_privatekeyまたはprivate_key-> idxが検証できない場合に返されました。
+    \return BUFFER_E  outlenが小さすぎるとエラーが発生します。
+    \return MEMORY_E  新しいポイントを作成するためのエラー。
+    \return MP_VAL  初期化失敗が発生したときに可能です。
+    \return MP_MEM  初期化失敗が発生したときに可能です。
+    \param private_key  プライベートECCキー。
+    \param point  使用するポイント（公開鍵）。
+    \param out  共有秘密の出力先。ANSI X9.63からEC-DHに準拠しています。
+    _Example_
+    \code
+    ecc_key key;
+    ecc_point* point;
+    byte shared_secret[];
+    int secret_size;
+    int result;
+
+    point = wc_ecc_new_point();
+
+    result = wc_ecc_shared_secret_ex(&key, point,
+    &shared_secret, &secret_size);
+
+    if (result != MP_OKAY)
+    {
+        // Handle error
+    }
+    \endcode
+    \sa wc_ecc_verify_hash_ex
+*/
+
+int wc_ecc_shared_secret_ex(ecc_key* private_key, ecc_point* point,
+                             byte* out, word32 *outlen);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は、信頼性を保証するためにECC_KEYオブジェクトを使用してメッセージダイジェストに署名します。
+    \return 0  メッセージダイジェストの署名を正常に生成したときに返されました
+    \return BAD_FUNC_ARG  入力パラメータのいずれかがNULLに評価された場合、または出力バッファが小さすぎて生成された署名を保存する場合は返されます。
+    \return ECC_BAD_ARG_E  入力キーが秘密鍵ではない場合、またはECC OIDが無効な場合
+    \return RNG_FAILURE_E  RNGが満足のいくキーを正常に生成できない場合に返されます。
+    \return MP_INIT_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_READ_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_CMP_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_INVMOD_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_EXPTMOD_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_MOD_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_MUL_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_ADD_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_MULMOD_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_TO_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_MEM  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \param in  サインするメッセージハッシュを含むバッファへのポインタ
+    \param inlen  署名するメッセージの長さ
+    \param out  生成された署名を保存するためのバッファ
+    \param outlen  出力バッファの最大長。メッセージ署名の生成に成功したときに書き込まれたバイトを保存します
+    _Example_
+    \code
+    ecc_key key;
+    WC_WC_RNG rng;
+    int ret, sigSz;
+
+    byte sig[512]; // will hold generated signature
+    sigSz = sizeof(sig);
+    byte digest[] = { // initialize with message hash };
+    wc_InitRng(&rng); // initialize rng
+    wc_ecc_init(&key); // initialize key
+    wc_ecc_make_key(&rng, 32, &key); // make public/private key pair
+    ret = wc_ecc_sign_hash(digest, sizeof(digest), sig, &sigSz, &key);
+    if ( ret != 0 ) {
+	    // error generating message signature
+    }
+    \endcode
+    \sa wc_ecc_verify_hash
+*/
+
+int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
+                     WC_RNG* rng, ecc_key* key);
+
+/*!
+    \ingroup ECC 
+    \brief  メッセージダイジェストに署名します。
+    \return MP_OKAY  メッセージダイジェストの署名を正常に生成したときに返されました
+    \return ECC_BAD_ARG_E  入力キーが秘密鍵ではない場合、またはECC IDXが無効な場合、またはいずれかの入力パラメータがNULLに評価されている場合、または出力バッファが小さすぎて生成された署名を保存するには小さすぎる場合
+    \return RNG_FAILURE_E  RNGが満足のいくキーを正常に生成できない場合に返されます。
+    \return MP_INIT_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_READ_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_CMP_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_INVMOD_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_EXPTMOD_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_MOD_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_MUL_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_ADD_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_MULMOD_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_TO_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_MEM  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \param in  メッセージがサインにダイジェスト。
+    \param inlen  ダイジェストの長さ。
+    \param rng  WC_RNG構造体へのポインタ。
+    \param key  プライベートECCキー。
+    \param r  署名のRコンポーネントの宛先。
+    _Example_
+    \code
+    ecc_key key;
+    WC_WC_WC_RNG rng;
+    int ret, sigSz;
+    mp_int r; // destination for r component of signature.
+    mp_int s; // destination for s component of signature.
+
+    byte sig[512]; // will hold generated signature
+    sigSz = sizeof(sig);
+    byte digest[] = { initialize with message hash };
+    wc_InitRng(&rng); // initialize rng
+    wc_ecc_init(&key); // initialize key
+    mp_init(&r); // initialize r component
+    mp_init(&s); // initialize s component
+    wc_ecc_make_key(&rng, 32, &key); // make public/private key pair
+    ret = wc_ecc_sign_hash_ex(digest, sizeof(digest), &rng, &key, &r, &s);
+
+    if ( ret != MP_OKAY ) {
+    	// error generating message signature
+    }
+    \endcode
+    \sa wc_ecc_verify_hash_ex
+*/
+
+int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
+                        ecc_key* key, mp_int *r, mp_int *s);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は、真正性を確保するためにハッシュのECCシグネチャを検証します。答えを介して、有効な署名に対応する1、無効な署名に対応する0で答えを返します。
+    \return 0  署名検証に正常に実行されたときに返されます。注：これは署名が検証されていることを意味するわけではありません。信頼性情報は代わりにSTATで格納されます
+    \return BAD_FUNC_ARG  返された入力パラメータはNULLに評価されます
+    \return MEMORY_E  メモリの割り当て中にエラーが発生した場合に返されます
+    \return MP_INIT_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_READ_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_CMP_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_INVMOD_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_EXPTMOD_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_MOD_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_MUL_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_ADD_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_MULMOD_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_TO_E  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \return MP_MEM  メッセージ署名の計算中にエラーが発生した場合に返される可能性があります。
+    \param sig  確認する署名を含むバッファへのポインタ
+    \param siglen  検証する署名の長さ
+    \param hash  確認されたメッセージのハッシュを含むバッファへのポインタ
+    \param hashlen  認証されたメッセージのハッシュの長さ
+    \param stat  検証の結果へのポインタ。1メッセージが正常に認証されたことを示します
+    _Example_
+    \code
+    ecc_key key;
+    int ret, verified = 0;
+
+    byte sig[1024] { initialize with received signature };
+    byte digest[] = { initialize with message hash };
+    // initialize key with received public key
+    ret = wc_ecc_verify_hash(sig, sizeof(sig), digest,sizeof(digest),
+    &verified, &key);
+    if ( ret != 0 ) {
+	    // error performing verification
+    } else if ( verified == 0 ) {
+	    // the signature is invalid
+    }
+    \endcode
+    \sa wc_ecc_sign_hash
+    \sa wc_ecc_verify_hash_ex
+*/
+
+int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
+                    word32 hashlen, int* stat, ecc_key* key);
+
+/*!
+    \ingroup ECC 
+    \brief  ECC署名を確認してください。結果はstatに書き込まれます。1が有効で、0が無効です。注：有効なテストに戻り値を使用しないでください。statのみを使用してください。
+    \return MP_OKAY  成功した場合（署名が無効であっても）
+    \return ECC_BAD_ARG_E  引数がNULLの場合、またはkey-idxが無効な場合は返します。
+    \return MEMORY_E  INTまたはポイントの割り当て中にエラーが発生しました。
+    \param r  検証する署名Rコンポーネント
+    \param s  検証するシグネチャSコンポーネント
+    \param hash  署名されたハッシュ（メッセージダイジェスト）
+    \param hashlen  ハッシュの長さ（オクテット）
+    \param stat  署名の結果、1 ==有効、0 ==無効
+    _Example_
+    \code
+    mp_int r;
+    mp_int s;
+    int stat;
+    byte hash[] = { Some hash }
+    ecc_key key;
+
+    if(wc_ecc_verify_hash_ex(&r, &s, hash, hashlen, &stat, &key) == MP_OKAY)
+    {
+        // Check stat
+    }
+    \endcode
+    \sa wc_ecc_verify_hash
+*/
+
+int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
+                          word32 hashlen, int* stat, ecc_key* key);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は、メッセージ検証または鍵交渉で将来の使用のためにECC_KEYオブジェクトを初期化します。
+    \return 0  ECC_Keyオブジェクトの初期化に成功したときに返されます
+    \return MEMORY_E  メモリの割り当て中にエラーが発生した場合に返されます
+    _Example_
+    \code
+    ecc_key key;
+    wc_ecc_init(&key);
+    \endcode
+    \sa wc_ecc_make_key
+    \sa wc_ecc_free
+*/
+
+int wc_ecc_init(ecc_key* key);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は、メッセージ検証または鍵交渉で将来の使用のためにECC_KEYオブジェクトを初期化します。
+    \return 0  ECC_Keyオブジェクトの初期化に成功したときに返されます
+    \return MEMORY_E  メモリの割り当て中にエラーが発生した場合に返されます
+    \param key  初期化するECC_Keyオブジェクトへのポインタ
+    \param devId  非同期ハードウェアで使用するID
+    _Example_
+    \code
+    ecc_key key;
+    wc_ecc_init_ex(&key, heap, devId);
+    \endcode
+    \sa wc_ecc_make_key
+    \sa wc_ecc_free
+    \sa wc_ecc_init
+*/
+
+int wc_ecc_init_ex(ecc_key* key, void* heap, int devId);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数はユーザー定義ヒープを使用し、キー構造のスペースを割り当てます。
+    \return 0  ECC_Keyオブジェクトの初期化に成功したときに返されます
+    _Example_
+    \code
+    wc_ecc_key_new(&heap);
+    \endcode
+    \sa wc_ecc_make_key
+    \sa wc_ecc_key_free
+    \sa wc_ecc_init
+*/
+
+ecc_key* wc_ecc_key_new(void* heap);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は、使用後にECC_KEYオブジェクトを解放します。
+    \return int  integerがWolfSSLエラーまたは成功状況を示すことを返しました。
+    _Example_
+    \code
+    // initialize key and perform secure exchanges
+    ...
+    wc_ecc_free(&key);
+    \endcode
+    \sa wc_ecc_init
+*/
+
+int wc_ecc_free(ecc_key* key);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は固定小数点キャッシュを解放します。これはECCで使用でき、計算時間を高速化します。この機能を使用するには、FP_ECC（固定小数点ECC）を定義する必要があります。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    ecc_key key;
+    // initialize key and perform secure exchanges
+    ...
+
+    wc_ecc_fp_free();
+    \endcode
+    \sa wc_ecc_free
+*/
+
+void wc_ecc_fp_free(void);
+
+/*!
+    \ingroup ECC 
+    \brief  ECC IDXが有効かどうかを確認します。
+    \return 1  有効な場合は返品してください。
+    \return 0  無効な場合は返します。
+    _Example_
+    \code
+    ecc_key key;
+    WC_WC_RNG rng;
+    int is_valid;
+    wc_ecc_init(&key);
+    wc_InitRng(&rng);
+    wc_ecc_make_key(&rng, 32, &key);
+    is_valid = wc_ecc_is_valid_idx(key.idx);
+    if (is_valid == 1)
+    {
+        // idx is valid
+    }
+    else if (is_valid == 0)
+    {
+        // idx is not valid
+    }
+    \endcode
+    \sa none
+*/
+
+int wc_ecc_is_valid_idx(int n);
+
+/*!
+    \ingroup ECC 
+    \brief  新しいECCポイントを割り当てます。
+    \return p  新しく割り当てられたポイント。
+    \return NULL  エラー時にNULLを返します。
+    _Example_
+    \code
+    ecc_point* point;
+    point = wc_ecc_new_point();
+    if (point == NULL)
+    {
+        // Handle point creation error
+    }
+    // Do stuff with point
+    \endcode
+    \sa wc_ecc_del_point
+    \sa wc_ecc_cmp_point
+    \sa wc_ecc_copy_point
+*/
+
+ecc_point* wc_ecc_new_point(void);
+
+/*!
+    \ingroup ECC 
+    \brief  メモリからECCポイントを解放します。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    ecc_point* point;
+    point = wc_ecc_new_point();
+    if (point == NULL)
+    {
+        // Handle point creation error
+    }
+    // Do stuff with point
+    wc_ecc_del_point(point);
+    \endcode
+    \sa wc_ecc_new_point
+    \sa wc_ecc_cmp_point
+    \sa wc_ecc_copy_point
+*/
+
+void wc_ecc_del_point(ecc_point* p);
+
+/*!
+    \ingroup ECC 
+    \brief  あるポイントの値を別のポイントにコピーします。
+    \return ECC_BAD_ARG_E  PまたはRがNULLのときにスローされたエラー。
+    \return MP_OKAY  ポイントが正常にコピーされました
+    \return ret  内部関数からのエラー。になることができます...
+    \param p  コピーするポイント。
+    _Example_
+    \code
+    ecc_point* point;
+    ecc_point* copied_point;
+    int copy_return;
+
+    point = wc_ecc_new_point();
+    copy_return = wc_ecc_copy_point(point, copied_point);
+    if (copy_return != MP_OKAY)
+    {
+        // Handle error
+    }
+    \endcode
+    \sa wc_ecc_new_point
+    \sa wc_ecc_cmp_point
+    \sa wc_ecc_del_point
+*/
+
+int wc_ecc_copy_point(ecc_point* p, ecc_point *r);
+
+/*!
+    \ingroup ECC 
+    \brief  ポイントの値を別のものと比較してください。
+    \return BAD_FUNC_ARG  1つまたは両方の引数はnullです。
+    \return MP_EQ  ポイントは同じです。
+    \return ret  mp_ltまたはmp_gtのどちらかで、ポイントが等しくないことを意味します。
+    \param a  比較する最初のポイント。
+    _Example_
+    \code
+    ecc_point* point;
+    ecc_point* point_to_compare;
+    int cmp_result;
+
+    point = wc_ecc_new_point();
+    point_to_compare = wc_ecc_new_point();
+    cmp_result = wc_ecc_cmp_point(point, point_to_compare);
+    if (cmp_result == BAD_FUNC_ARG)
+    {
+        // arguments are invalid
+    }
+    else if (cmp_result == MP_EQ)
+    {
+        // Points are equal
+    }
+    else
+    {
+        // Points are not equal
+    }
+    \endcode
+    \sa wc_ecc_new_point
+    \sa wc_ecc_del_point
+    \sa wc_ecc_copy_point
+*/
+
+int wc_ecc_cmp_point(ecc_point* a, ecc_point *b);
+
+/*!
+    \ingroup ECC 
+    \brief  ポイントが無限大にあるかどうかを確認します。返品1が無限大である場合は0、そうでない場合は0、<0エラー時の0
+    \return 1  Pは無限大です。
+    \return 0  Pは無限大ではありません。
+    \return <0  エラー。
+    _Example_
+    \code
+    ecc_point* point;
+    int is_infinity;
+    point = wc_ecc_new_point();
+
+    is_infinity = wc_ecc_point_is_at_infinity(point);
+    if (is_infinity < 0)
+    {
+        // Handle error
+    }
+    else if (is_infinity == 0)
+    {
+        // Point is not at infinity
+    }
+    else if (is_infinity == 1)
+    {
+        // Point is at infinity
+    }
+    \endcode
+    \sa wc_ecc_new_point
+    \sa wc_ecc_del_point
+    \sa wc_ecc_cmp_point
+    \sa wc_ecc_copy_point
+*/
+
+int wc_ecc_point_is_at_infinity(ecc_point *p);
+
+/*!
+    \ingroup ECC 
+    \brief  ECC固定点乗算を実行します。
+    \return MP_OKAY  成功した操作で返します。
+    \return MP_INIT_E  複数のPrecision Integer（MP_INT）ライブラリで使用するための整数を初期化するエラーがある場合に返されます。
+    \param k  計量。
+    \param G  乗算する基点。
+    \param R  商品の目的地
+    \param modulus  曲線の弾性率
+    _Example_
+    \code
+    ecc_point* base;
+    ecc_point* destination;
+    // Initialize points
+    base = wc_ecc_new_point();
+    destination = wc_ecc_new_point();
+    // Setup other arguments
+    mp_int multiplicand;
+    mp_int modulus;
+    int map;
+    \endcode
+    \sa none
+*/
+
+int wc_ecc_mulmod(mp_int* k, ecc_point *G, ecc_point *R,
+                  mp_int* a, mp_int* modulus, int map);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数はECCキーをECC_KEY構造体からエクスポートし、結果をOUTに格納します。キーはANSI X9.63フォーマットに保存されます。outlenの出力バッファに書き込まれたバイトを格納します。
+    \return 0  ECC_KEYのエクスポートに正常に返されました
+    \return LENGTH_ONLY_E  出力バッファがNULLに評価されている場合は返されますが、他の2つの入力パラメータは有効です。関数がキーを保存するのに必要な長さを返すだけであることを示します
+    \return ECC_BAD_ARG_E  入力パラメータのいずれかがNULLの場合、またはキーがサポートされていない場合（無効なインデックスがあります）
+    \return BUFFER_E  出力バッファが小さすぎてECCキーを保存する場合は返されます。出力バッファが小さすぎると、必要なサイズはoutlenに返されます。
+    \return MEMORY_E  xmallocでメモリを割り当てるエラーがある場合
+    \return MP_INIT_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_READ_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_CMP_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_INVMOD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_EXPTMOD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_MOD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_MUL_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_ADD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_MULMOD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_TO_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_MEM  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \param key  エクスポートするECC_KEYオブジェクトへのポインタ
+    \param out  ANSI X9.63フォーマット済みキーを保存するバッファへのポインタ
+    _Example_
+    \code
+    int ret;
+    byte buff[1024];
+    word32 buffSz = sizeof(buff);
+
+    ecc_key key;
+    // initialize key, make key
+    ret = wc_ecc_export_x963(&key, buff, &buffSz);
+    if ( ret != 0) {
+    	// error exporting key
+    }
+    \endcode
+    \sa wc_ecc_export_x963_ex
+    \sa wc_ecc_import_x963
+*/
+
+int wc_ecc_export_x963(ecc_key* key, byte* out, word32* outLen);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数はECCキーをECC_KEY構造体からエクスポートし、結果をOUTに格納します。キーはANSI X9.63フォーマットに保存されます。outlenの出力バッファに書き込まれたバイトを格納します。この関数は、圧縮されたパラメータを介して証明書を圧縮する追加のオプションを使用する。このパラメータがtrueの場合、キーはANSI X9.63圧縮形式で保存されます。
+    \return 0  ECC_KEYのエクスポートに正常に返されました
+    \return NOT_COMPILED_IN  hand_comp_keyがコンパイル時に有効になっていない場合は返されますが、キーは圧縮形式で要求されました
+    \return LENGTH_ONLY_E  出力バッファがNULLに評価されている場合は返されますが、他の2つの入力パラメータは有効です。関数がキーを保存するのに必要な長さを返すだけであることを示します
+    \return ECC_BAD_ARG_E  入力パラメータのいずれかがNULLの場合、またはキーがサポートされていない場合（無効なインデックスがあります）
+    \return BUFFER_E  出力バッファが小さすぎてECCキーを保存する場合は返されます。出力バッファが小さすぎると、必要なサイズはoutlenに返されます。
+    \return MEMORY_E  xmallocでメモリを割り当てるエラーがある場合
+    \return MP_INIT_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_READ_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_CMP_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_INVMOD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_EXPTMOD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_MOD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_MUL_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_ADD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_MULMOD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_TO_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_MEM  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \param key  エクスポートするECC_KEYオブジェクトへのポインタ
+    \param out  ANSI X9.63フォーマット済みキーを保存するバッファへのポインタ
+    \param outLen  出力バッファのサイズ。キーの保存に成功した場合は、出力バッファに書き込まれたバイトを保持します。
+    _Example_
+    \code
+    int ret;
+    byte buff[1024];
+    word32 buffSz = sizeof(buff);
+    ecc_key key;
+    // initialize key, make key
+    ret = wc_ecc_export_x963_ex(&key, buff, &buffSz, 1);
+    if ( ret != 0) {
+	    // error exporting key
+    }
+    \endcode
+    \sa wc_ecc_export_x963
+    \sa wc_ecc_import_x963
+*/
+
+int wc_ecc_export_x963_ex(ecc_key* key, byte* out, word32* outLen, int compressed);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は、ANSI X9.63形式で保存されているキーを含むバッファからパブリックECCキーをインポートします。この関数は、圧縮キーがhand_comp_keyオプションを介してコンパイル時に有効になっている限り、圧縮キーと非圧縮キーの両方を処理します。
+    \return 0  ECC_KEYのインポートに成功しました
+    \return NOT_COMPILED_IN  hand_comp_keyがコンパイル時に有効になっていない場合は返されますが、キーは圧縮形式で保存されます。
+    \return ECC_BAD_ARG_E  INまたはKEYがNULLに評価された場合、またはInlenが偶数の場合（X9.63規格によれば、キーは奇数でなければなりません）。
+    \return MEMORY_E  メモリの割り当て中にエラーが発生した場合に返されます
+    \return ASN_PARSE_E  ECCキーの解析中にエラーがある場合は返されます。ECCキーが有効なANSI X9.63フォーマットに格納されていないことを示すことがあります。
+    \return IS_POINT_E  エクスポートされた公開鍵がECC曲線上の点ではない場合に返されます
+    \return MP_INIT_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_READ_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_CMP_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_INVMOD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_EXPTMOD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_MOD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_MUL_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_ADD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_MULMOD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_TO_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_MEM  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \param in  ANSI x9.63フォーマットされたECCキーを含むバッファへのポインタ
+    \param inLen  入力バッファの長さ
+    _Example_
+    \code
+    int ret;
+    byte buff[] = { initialize with ANSI X9.63 formatted key };
+
+    ecc_key pubKey;
+    wc_ecc_init(&pubKey);
+
+    ret = wc_ecc_import_x963(buff, sizeof(buff), &pubKey);
+    if ( ret != 0) {
+    	// error importing key
+    }
+    \endcode
+    \sa wc_ecc_export_x963
+    \sa wc_ecc_import_private_key
+*/
+
+int wc_ecc_import_x963(const byte* in, word32 inLen, ecc_key* key);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は、生の秘密鍵を含むバッファと、ANSI X9.63フォーマットされた公開鍵を含む2番目のバッファーからパブリック/プライベートECCキーのペアをインポートします。この関数は、圧縮キーがhand_comp_keyオプションを介してコンパイル時に有効になっている限り、圧縮キーと非圧縮キーの両方を処理します。
+    \return 0  habe_comp_keyがコンパイル時に有効になっていない場合は、ecc_key not_compiled_inを正常にインポートしましたが、キーは圧縮形式で保存されます。
+    \return ECC_BAD_ARG_E  INまたはKEYがNULLに評価された場合、またはInlenが偶数の場合（X9.63規格によれば、キーは奇数でなければなりません）。
+    \return MEMORY_E  メモリの割り当て中にエラーが発生した場合に返されます
+    \return ASN_PARSE_E  ECCキーの解析中にエラーがある場合は返されます。ECCキーが有効なANSI X9.63フォーマットに格納されていないことを示すことがあります。
+    \return IS_POINT_E  エクスポートされた公開鍵がECC曲線上の点ではない場合に返されます
+    \return MP_INIT_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_READ_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_CMP_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_INVMOD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_EXPTMOD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_MOD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_MUL_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_ADD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_MULMOD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_TO_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_MEM  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \param priv  RAW秘密鍵を含むバッファへのポインタ
+    \param privSz  秘密鍵バッファのサイズ
+    \param pub  ANSI x9.63フォーマットされたECC公開鍵を含むバッファへのポインタ
+    \param pubSz  公開鍵入力バッファの長さ
+    _Example_
+    \code
+    int ret;
+    byte pub[] = { initialize with ANSI X9.63 formatted key };
+    byte priv[] = { initialize with the raw private key };
+
+    ecc_key key;
+    wc_ecc_init(&key);
+    ret = wc_ecc_import_private_key(priv, sizeof(priv), pub, sizeof(pub),
+    &key);
+    if ( ret != 0) {
+    	// error importing key
+    }
+    \endcode
+    \sa wc_ecc_export_x963
+    \sa wc_ecc_import_private_key
+*/
+
+int wc_ecc_import_private_key(const byte* priv, word32 privSz, const byte* pub,
+                           word32 pubSz, ecc_key* key);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は、ECCシグネチャのR部分とS部分をDER符号化ECDSAシグネチャに変換します。この機能は、outlenでは、出力バッファに書き込まれた長さも記憶されています。
+    \return 0  署名の変換に成功したことに戻りました
+    \return ECC_BAD_ARG_E  いずれかの入力パラメータがNULLに評価された場合、または入力バッファがDERエンコードされたECDSAシグネチャを保持するのに十分な大きさでない場合に返されます。
+    \return MP_INIT_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_READ_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_CMP_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_INVMOD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_EXPTMOD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_MOD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_MUL_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_ADD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_MULMOD_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_TO_E  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \return MP_MEM  ECC_KEYの処理中にエラーが発生した場合に返される可能性があります
+    \param r  署名のR部分を文字列として含むバッファへのポインタ
+    \param s  シグネチャのS部分を含むバッファへのポインタ文字列としてのポインタ
+    \param out  DERエンコードされたECDSAシグネチャを保存するバッファへのポインタ
+    _Example_
+    \code
+    int ret;
+    ecc_key key;
+    // initialize key, generate R and S
+
+    char r[] = { initialize with R };
+    char s[] = { initialize with S };
+    byte sig[wc_ecc_sig_size(key)];
+    // signature size will be 2 * ECC key size + ~10 bytes for ASN.1 overhead
+    word32 sigSz = sizeof(sig);
+    ret = wc_ecc_rs_to_sig(r, s, sig, &sigSz);
+    if ( ret != 0) {
+    	// error converting parameters to signature
+    }
+    \endcode
+    \sa wc_ecc_sign_hash
+    \sa wc_ecc_sig_size
+*/
+
+int wc_ecc_rs_to_sig(const char* r, const char* s, byte* out, word32* outlen);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は、ECC署名のRAW成分を持つECC_KEY構造体を埋めます。
+    \return 0  ECC_Key構造体に正常にインポートされたときに返されます
+    \return ECC_BAD_ARG_E  いずれかの入力値がNULLに評価された場合に返されます。
+    \return MEMORY_E  ECC_Keyのパラメータを格納するためのエラーの初期化スペースがある場合に返されます。
+    \return ASN_PARSE_E  入力カーベナデがECC_SETSで定義されていない場合
+    \return MP_INIT_E  入力パラメータの処理中にエラーが発生した場合に返される可能性があります。
+    \return MP_READ_E  入力パラメータの処理中にエラーが発生した場合に返される可能性があります。
+    \return MP_CMP_E  入力パラメータの処理中にエラーが発生した場合に返される可能性があります。
+    \return MP_INVMOD_E  入力パラメータの処理中にエラーが発生した場合に返される可能性があります。
+    \return MP_EXPTMOD_E  入力パラメータの処理中にエラーが発生した場合に返される可能性があります。
+    \return MP_MOD_E  入力パラメータの処理中にエラーが発生した場合に返される可能性があります。
+    \return MP_MUL_E  入力パラメータの処理中にエラーが発生した場合に返される可能性があります。
+    \return MP_ADD_E  入力パラメータの処理中にエラーが発生した場合に返される可能性があります。
+    \return MP_MULMOD_E  入力パラメータの処理中にエラーが発生した場合に返される可能性があります。
+    \return MP_TO_E  入力パラメータの処理中にエラーが発生した場合に返される可能性があります。
+    \return MP_MEM  入力パラメータの処理中にエラーが発生した場合に返される可能性があります。
+    \param key  塗りつぶすためのECC_KEY構造体へのポインタ
+    \param qx  ASCII六角文字列として基点のXコンポーネントを含むバッファへのポインタ
+    \param qy  ASCII六角文字列として基点のY成分を含むバッファへのポインタ
+    \param d  ASCII hex文字列として秘密鍵を含むバッファへのポインタ
+    _Example_
+    \code
+    int ret;
+    ecc_key key;
+    wc_ecc_init(&key);
+
+    char qx[] = { initialize with x component of base point };
+    char qy[] = { initialize with y component of base point };
+    char d[]  = { initialize with private key };
+    ret = wc_ecc_import_raw(&key,qx, qy, d, "ECC-256");
+    if ( ret != 0) {
+    	// error initializing key with given inputs
+    }
+    \endcode
+    \sa wc_ecc_import_private_key
+*/
+
+int wc_ecc_import_raw(ecc_key* key, const char* qx, const char* qy,
+                   const char* d, const char* curveName);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は、ECC_KEY構造体から秘密鍵のみをエクスポートします。秘密鍵をバッファアウトに格納し、outlenにこのバッファに書き込まれたバイトを設定します。
+    \return 0  秘密鍵のエクスポートに成功したときに返されます
+    \return ECC_BAD_ARG_E  いずれかの入力値がNULLに評価された場合に返されます。
+    \return MEMORY_E  ECC_Keyのパラメータを格納するためのエラーの初期化スペースがある場合に返されます。
+    \return ASN_PARSE_E  入力カーベナデがECC_SETSで定義されていない場合
+    \return MP_INIT_E  入力パラメータの処理中にエラーが発生した場合に返される可能性があります。
+    \return MP_READ_E  入力パラメータの処理中にエラーが発生した場合に返される可能性があります。
+    \return MP_CMP_E  入力パラメータの処理中にエラーが発生した場合に返される可能性があります。
+    \return MP_INVMOD_E  入力パラメータの処理中にエラーが発生した場合に返される可能性があります。
+    \return MP_EXPTMOD_E  入力パラメータの処理中にエラーが発生した場合に返される可能性があります。
+    \return MP_MOD_E  入力パラメータの処理中にエラーが発生した場合に返される可能性があります。
+    \return MP_MUL_E  入力パラメータの処理中にエラーが発生した場合に返される可能性があります。
+    \return MP_ADD_E  入力パラメータの処理中にエラーが発生した場合に返される可能性があります。
+    \return MP_MULMOD_E  入力パラメータの処理中にエラーが発生した場合に返される可能性があります。
+    \return MP_TO_E  入力パラメータの処理中にエラーが発生した場合に返される可能性があります。
+    \return MP_MEM  入力パラメータの処理中にエラーが発生した場合に返される可能性があります。
+    \param key  秘密鍵をエクスポートするECC_Key構造体へのポインタ
+    \param out  秘密鍵を保存するバッファへのポインタ
+    _Example_
+    \code
+    int ret;
+    ecc_key key;
+    // initialize key, make key
+
+    char priv[ECC_KEY_SIZE];
+    word32 privSz = sizeof(priv);
+    ret = wc_ecc_export_private_only(&key, priv, &privSz);
+    if ( ret != 0) {
+    	// error exporting private key
+    }
+    \endcode
+    \sa wc_ecc_import_private_key
+*/
+
+int wc_ecc_export_private_only(ecc_key* key, byte* out, word32* outLen);
+
+/*!
+    \ingroup ECC 
+    \brief  DERへのエクスポートポイント。
+    \return 0  成功に戻りました。
+    \return ECC_BAD_ARG_E  curve_idxが0未満または無効である場合は返します。いつ来るのか
+    \return LENGTH_ONLY_E  outlenは設定されていますが、他にはありません。
+    \return BUFFER_E  outlennが1 + 2 *曲線サイズよりも小さい場合は返します。
+    \return MEMORY_E  メモリの割り当てに問題がある場合は返します。
+    \param curve_idx  ECC_SETSから使用される曲線のインデックス。
+    \param point  Derへのエクスポートを指す。
+    \param out  出力の目的地
+    _Example_
+    \code
+    int curve_idx;
+    ecc_point* point;
+    byte out[];
+    word32 outLen;
+    wc_ecc_export_point_der(curve_idx, point, out, &outLen);
+    \endcode
+    \sa wc_ecc_import_point_der
+*/
+
+int wc_ecc_export_point_der(const int curve_idx, ecc_point* point,
+                            byte* out, word32* outLen);
+
+/*!
+    \ingroup ECC 
+    \brief  Derフォーマットからのインポートポイント。
+    \return ECC_BAD_ARG_E  引数がnullの場合、またはInlenが偶数の場合は返します。
+    \return MEMORY_E  エラー初期化がある場合に返します
+    \return NOT_COMPILED_IN  habe_comp_keyが真実でない場合は返され、inは圧縮証明書です
+    \return MP_OKAY  操作が成功しました。
+    \param in  からのポイントをインポートするためのDer Buffer。
+    \param inLen  DERバッファの長さ
+    \param curve_idx  曲線のインデックス
+    _Example_
+    \code
+    byte in[];
+    word32 inLen;
+    int curve_idx;
+    ecc_point* point;
+    wc_ecc_import_point_der(in, inLen, curve_idx, point);
+    \endcode
+    \sa wc_ecc_export_point_der
+*/
+
+int wc_ecc_import_point_der(byte* in, word32 inLen, const int curve_idx,
+                            ecc_point* point);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は、ecc_key構造体のキーサイズをオクテットで返します。
+    \return Given  有効なキー、オクテットのキーサイズを返します
+    \return 0  与えられたキーがNULLの場合に返されます
+    _Example_
+    \code
+    int keySz;
+    ecc_key key;
+    // initialize key, make key
+    keySz = wc_ecc_size(&key);
+    if ( keySz == 0) {
+    	// error determining key size
+    }
+    \endcode
+    \sa wc_ecc_make_key
+*/
+
+int wc_ecc_size(ecc_key* key);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は、次のようにして指定されたECCシグネチャの最悪の場合のサイズを返します。（KEYSZ * 2）+ SIG_HEADER_SZ + ECC_MAX_PAD_SZ。実際のシグネチャサイズは、WC_ECC_SIGN_HASHで計算できます。
+    \return returns  最大署名サイズ（オクテット）
+    _Example_
+    \code
+    int sigSz = wc_ecc_sig_size_calc(32);
+    if ( sigSz == 0) {
+    	// error determining sig size
+    }
+    \endcode
+    \sa wc_ecc_sign_hash
+    \sa wc_ecc_sig_size
+*/
+
+int wc_ecc_sig_size_calc(int sz);
+
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は、次のようにして指定されたECCシグネチャの最悪の場合のサイズを返します。（KEYSZ * 2）+ SIG_HEADER_SZ + ECC_MAX_PAD_SZ。実際のシグネチャサイズは、WC_ECC_SIGN_HASHで計算できます。
+    \return Success  有効なキーを考えると、最大署名サイズをオクテットで返します。
+    \return 0  与えられたキーがNULLの場合に返されます
+    _Example_
+    \code
+    int sigSz;
+    ecc_key key;
+    // initialize key, make key
+
+    sigSz = wc_ecc_sig_size(&key);
+    if ( sigSz == 0) {
+        // error determining sig size
+    }
+    \endcode
+    \sa wc_ecc_sign_hash
+    \sa wc_ecc_sig_size_calc
+*/
+
+int wc_ecc_sig_size(ecc_key* key);
+
+
+/*!
+    \ingroup ECC 
+    \brief  この機能は、ECCとの安全なメッセージ交換を可能にするために、新しいECCコンテキストオブジェクトのスペースを割り当て、初期化します。
+    \return Success  新しいECENCCTXオブジェクトの生成に成功した場合は、そのオブジェクトへのポインタを返します
+    \return NULL  関数が新しいECENCCTXオブジェクトを生成できない場合に返されます
+    \param flags  これがサーバーであるかクライアントのコンテキストオプションがあるかどうかを示します.req_resp_client、およびreq_resp_server
+    _Example_
+    \code
+    ecEncCtx* ctx;
+    WC_WC_RNG rng;
+    wc_InitRng(&rng);
+    ctx = wc_ecc_ctx_new(REQ_RESP_CLIENT, &rng);
+    if(ctx == NULL) {
+        // error generating new ecEncCtx object
+    }
+    \endcode
+    \sa wc_ecc_encrypt
+    \sa wc_ecc_encrypt_ex
+    \sa wc_ecc_decrypt
+*/
+
+ecEncCtx* wc_ecc_ctx_new(int flags, WC_RNG* rng);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は、メッセージの暗号化と復号化に使用されるECENCCTXオブジェクトを解放します。
+    \return none  戻り値。
+    _Example_
+    \code
+    ecEncCtx* ctx;
+    WC_WC_RNG rng;
+    wc_InitRng(&rng);
+    ctx = wc_ecc_ctx_new(REQ_RESP_CLIENT, &rng);
+    // do secure communication
+    ...
+    wc_ecc_ctx_free(&ctx);
+    \endcode
+    \sa wc_ecc_ctx_new
+*/
+
+void wc_ecc_ctx_free(ecEncCtx*);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数はECENCCTX構造をリセットして、新しいコンテキストオブジェクトを解放し、新しいコンテキストオブジェクトを割り当てます。
+    \return 0  ecencctx構造が正常にリセットされた場合に返されます
+    \return BAD_FUNC_ARG  RNGまたはCTXがNULLの場合に返されます
+    \return RNG_FAILURE_E  ECCオブジェクトに新しい塩を生成するエラーがある場合
+    \param ctx  リセットするECENCCTXオブジェクトへのポインタ
+    _Example_
+    \code
+    ecEncCtx* ctx;
+    WC_WC_RNG rng;
+    wc_InitRng(&rng);
+    ctx = wc_ecc_ctx_new(REQ_RESP_CLIENT, &rng);
+    // do secure communication
+    ...
+    wc_ecc_ctx_reset(&ctx, &rng);
+    // do more secure communication
+    \endcode
+    \sa wc_ecc_ctx_new
+*/
+
+int wc_ecc_ctx_reset(ecEncCtx* ctx, WC_RNG* rng);  /* reset for use again w/o alloc/free */
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は、wc_ecc_ctx_newの後にオプションで呼び出されることができます。暗号化、KDF、およびMACアルゴリズムをECENCENCCTXオブジェクトに設定します。
+    \return 0  ECENCCTXオブジェクトの情報を正常に設定すると返されます。
+    \return BAD_FUNC_ARG  指定されたecencctxオブジェクトがNULLの場合に返されます。
+    \param ctx  情報を設定するECENCCTXへのポインタ
+    \param encAlgo  使用する暗号化アルゴリズム
+    \param kdfAlgo  使用するKDFアルゴリズム
+    _Example_
+    \code
+    ecEncCtx* ctx;
+    // initialize ctx
+    if(wc_ecc_ctx_set_algo(&ctx, ecAES_128_CTR, ecHKDF_SHA256, ecHMAC_SHA256))) {
+	    // error setting info
+    }
+    \endcode
+    \sa wc_ecc_ctx_new
+*/
+
+int wc_ecc_ctx_set_algo(ecEncCtx* ctx, byte encAlgo, byte kdfAlgo,
+    byte macAlgo);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数はECENCENCCTXオブジェクトの塩を返します。この関数は、ECENCCTXの状態がECSRV_INITまたはECCLI_INITの場合にのみ呼び出す必要があります。
+    \return Success  成功すると、ECENCENTX塩を返します
+    \return NULL  ecencctxオブジェクトがNULLの場合、またはECENCCTXの状態がECSRV_INITまたはECCLI_INITでない場合に返されます。後者の2つのケースでは、この機能はそれぞれECSRV_BAD_STATEまたはECCLI_BAD_STATEにECENCCTXの状態を設定します。
+    _Example_
+    \code
+    ecEncCtx* ctx;
+    WC_WC_RNG rng;
+    const byte* salt;
+    wc_InitRng(&rng);
+    ctx = wc_ecc_ctx_new(REQ_RESP_CLIENT, &rng);
+    salt = wc_ecc_ctx_get_own_salt(&ctx);
+    if(salt == NULL) {
+    	// error getting salt
+    }
+    \endcode
+    \sa wc_ecc_ctx_new
+    \sa wc_ecc_ctx_set_peer_salt
+*/
+
+const byte* wc_ecc_ctx_get_own_salt(ecEncCtx*);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は、ECENCENCCTXオブジェクトのピアソルトを設定します。
+    \return 0  ECENCCTXオブジェクトのピアソルトの設定に成功したときに返されます。
+    \return BAD_FUNC_ARG  指定されたecencctxオブジェクトがnullまたは無効なプロトコルがある場合、または指定された塩がNULLの場合
+    \return BAD_ENC_STATE_E  ecencctxの状態がECSRV_SALT_GETまたはECCLI_SALT_GETの場合に返されます。後者の2つのケースでは、この機能はそれぞれECSRV_BAD_STATEまたはECCLI_BAD_STATEにECENCCTXの状態を設定します。
+    \param ctx  塩を設定するためのecencctxへのポインタ
+    _Example_
+    \code
+    ecEncCtx* cliCtx, srvCtx;
+    WC_WC_RNG rng;
+    const byte* cliSalt, srvSalt;
+    int ret;
+
+    wc_InitRng(&rng);
+    cliCtx = wc_ecc_ctx_new(REQ_RESP_CLIENT, &rng);
+    srvCtx = wc_ecc_ctx_new(REQ_RESP_SERVER, &rng);
+
+    cliSalt = wc_ecc_ctx_get_own_salt(&cliCtx);
+    srvSalt = wc_ecc_ctx_get_own_salt(&srvCtx);
+    ret = wc_ecc_ctx_set_peer_salt(&cliCtx, srvSalt);
+    \endcode
+    \sa wc_ecc_ctx_get_own_salt
+*/
+
+int wc_ecc_ctx_set_peer_salt(ecEncCtx* ctx, const byte* salt);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は、wc_ecc_ctx_set_peer_saltの前後にオプションで呼び出されることができます。ECENCCTXオブジェクトのオプションの情報を設定します。
+    \return 0  ECENCCTXオブジェクトの情報を正常に設定すると返されます。
+    \return BAD_FUNC_ARG  与えられたECENCCTXオブジェクトがNULLの場合、入力情報はNULLまたはサイズが無効です。
+    \param ctx  情報を設定するECENCCTXへのポインタ
+    \param info  設定する情報を含むバッファへのポインタ
+    _Example_
+    \code
+    ecEncCtx* ctx;
+    byte info[] = { initialize with information };
+    // initialize ctx, get salt,
+    if(wc_ecc_ctx_set_info(&ctx, info, sizeof(info))) {
+	    // error setting info
+    }
+    \endcode
+    \sa wc_ecc_ctx_new
+*/
+
+int wc_ecc_ctx_set_info(ecEncCtx* ctx, const byte* info, int sz);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は指定された入力メッセージをMSGからOUTに暗号化します。この関数はパラメータとしてオプションのCTXオブジェクトを取ります。提供されている場合、ECENCCTXのEncalgo、Kdfalgo、およびMacalgoに基づいて暗号化が進みます。CTXが指定されていない場合、処理はデフォルトのアルゴリズム、ECAES_128_CBC、ECHKDF_SHA256、ECHMAC_SHA256で完了します。この機能は、メッセージがCTXで指定された暗号化タイプに従って埋め込まれている必要があります。
+    \return 0  入力メッセージの暗号化に成功したら返されます
+    \return BAD_FUNC_ARG  PRIVKEY、PUBKEY、MSG、MSGSZ、OUT、OUTSZがNULLの場合、またはCTXオブジェクトがサポートされていない暗号化タイプを指定します。
+    \return BAD_ENC_STATE_E  指定されたCTXオブジェクトが暗号化に適していない状態にある場合に返されます。
+    \return BUFFER_E  指定された出力バッファが小さすぎて暗号化された暗号文を保存する場合に返されます
+    \return MEMORY_E  共有秘密鍵のメモリの割り当て中にエラーがある場合に返されます
+    \param privKey  暗号化に使用する秘密鍵を含むECC_KEYオブジェクトへのポインタ
+    \param pubKey  コミュニケーションを希望するピアの公開鍵を含むECC_Keyオブジェクトへのポインタ
+    \param msg  暗号化するメッセージを保持しているバッファへのポインタ
+    \param msgSz  暗号化するバッファのサイズ
+    \param out  暗号化された暗号文を保存するバッファへのポインタ
+    \param outSz  OUTバッファ内の使用可能なサイズを含むWord32オブジェクトへのポインタ。メッセージの暗号化に成功したら、出力バッファに書き込まれたバイト数を保持します。
+    _Example_
+    \code
+    byte msg[] = { initialize with msg to encrypt. Ensure padded to block size };
+    byte out[sizeof(msg)];
+    word32 outSz = sizeof(out);
+    int ret;
+    ecc_key cli, serv;
+    // initialize cli with private key
+    // initialize serv with received public key
+
+    ecEncCtx* cliCtx, servCtx;
+    // initialize cliCtx and servCtx
+    // exchange salts
+    ret = wc_ecc_encrypt(&cli, &serv, msg, sizeof(msg), out, &outSz, cliCtx);
+    if(ret != 0) {
+    	// error encrypting message
+    }
+    \endcode
+    \sa wc_ecc_encrypt_ex
+    \sa wc_ecc_decrypt
+*/
+
+int wc_ecc_encrypt(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
+                word32 msgSz, byte* out, word32* outSz, ecEncCtx* ctx);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数は指定された入力メッセージをMSGからOUTに暗号化します。この関数はパラメータとしてオプションのCTXオブジェクトを取ります。提供されている場合、ECENCCTXのEncalgo、Kdfalgo、およびMacalgoに基づいて暗号化が進みます。CTXが指定されていない場合、処理はデフォルトのアルゴリズム、ECAES_128_CBC、ECHKDF_SHA256、ECHMAC_SHA256で完了します。この機能は、メッセージがCTXで指定された暗号化タイプに従って埋め込まれている必要があります。
+    \return 0  入力メッセージの暗号化に成功したら返されます
+    \return BAD_FUNC_ARG  PRIVKEY、PUBKEY、MSG、MSGSZ、OUT、OUTSZがNULLの場合、またはCTXオブジェクトがサポートされていない暗号化タイプを指定します。
+    \return BAD_ENC_STATE_E  指定されたCTXオブジェクトが暗号化に適していない状態にある場合に返されます。
+    \return BUFFER_E  指定された出力バッファが小さすぎて暗号化された暗号文を保存する場合に返されます
+    \return MEMORY_E  共有秘密鍵のメモリの割り当て中にエラーがある場合に返されます
+    \param privKey  暗号化に使用する秘密鍵を含むECC_KEYオブジェクトへのポインタ
+    \param pubKey  コミュニケーションを希望するピアの公開鍵を含むECC_Keyオブジェクトへのポインタ
+    \param msg  暗号化するメッセージを保持しているバッファへのポインタ
+    \param msgSz  暗号化するバッファのサイズ
+    \param out  暗号化された暗号文を保存するバッファへのポインタ
+    \param outSz  OUTバッファ内の使用可能なサイズを含むWord32オブジェクトへのポインタ。メッセージの暗号化に成功したら、出力バッファに書き込まれたバイト数を保持します。
+    \param ctx  オプション：使用するさまざまな暗号化アルゴリズムを指定するECENCCTXオブジェクトへのポインタ
+    _Example_
+    \code
+    byte msg[] = { initialize with msg to encrypt. Ensure padded to block size };
+    byte out[sizeof(msg)];
+    word32 outSz = sizeof(out);
+    int ret;
+    ecc_key cli, serv;
+    // initialize cli with private key
+    // initialize serv with received public key
+
+    ecEncCtx* cliCtx, servCtx;
+    // initialize cliCtx and servCtx
+    // exchange salts
+    ret = wc_ecc_encrypt_ex(&cli, &serv, msg, sizeof(msg), out, &outSz, cliCtx,
+        1);
+    if(ret != 0) {
+    	// error encrypting message
+    }
+    \endcode
+    \sa wc_ecc_encrypt
+    \sa wc_ecc_decrypt
+*/
+
+int wc_ecc_encrypt_ex(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
+    word32 msgSz, byte* out, word32* outSz, ecEncCtx* ctx, int compressed);
+
+/*!
+    \ingroup ECC 
+    \brief  この関数はMSGからOUTへの暗号文を復号化します。この関数はパラメータとしてオプションのCTXオブジェクトを取ります。提供されている場合、ECENCCTXのEncalgo、Kdfalgo、およびMacalgoに基づいて暗号化が進みます。CTXが指定されていない場合、処理はデフォルトのアルゴリズム、ECAES_128_CBC、ECHKDF_SHA256、ECHMAC_SHA256で完了します。この機能は、メッセージがCTXで指定された暗号化タイプに従って埋め込まれている必要があります。
+    \return 0  入力メッセージの復号化に成功したときに返されます
+    \return BAD_FUNC_ARG  PRIVKEY、PUBKEY、MSG、MSGSZ、OUT、OUTSZがNULLの場合、またはCTXオブジェクトがサポートされていない暗号化タイプを指定します。
+    \return BAD_ENC_STATE_E  指定されたCTXオブジェクトが復号化に適していない状態にある場合に返されます。
+    \return BUFFER_E  供給された出力バッファが小さすぎて復号化された平文を保存する場合は返されます。
+    \return MEMORY_E  共有秘密鍵のメモリの割り当て中にエラーがある場合に返されます
+    \param privKey  復号化に使用する秘密鍵を含むECC_Keyオブジェクトへのポインタ
+    \param pubKey  コミュニケーションを希望するピアの公開鍵を含むECC_Keyオブジェクトへのポインタ
+    \param msg  暗号文を復号化するためのバッファへのポインタ
+    \param msgSz  復号化するバッファのサイズ
+    \param out  復号化された平文を保存するバッファへのポインタ
+    \param outSz  OUTバッファ内の使用可能なサイズを含むWord32オブジェクトへのポインタ。暗号文を正常に復号化すると、出力バッファに書き込まれたバイト数を保持します。
+    _Example_
+    \code
+    byte cipher[] = { initialize with
+    ciphertext to decrypt. Ensure padded to block size };
+    byte plain[sizeof(cipher)];
+    word32 plainSz = sizeof(plain);
+    int ret;
+    ecc_key cli, serv;
+    // initialize cli with private key
+    // initialize serv with received public key
+    ecEncCtx* cliCtx, servCtx;
+    // initialize cliCtx and servCtx
+    // exchange salts
+    ret = wc_ecc_decrypt(&cli, &serv, cipher, sizeof(cipher),
+    plain, &plainSz, cliCtx);
+
+    if(ret != 0) {
+    	// error decrypting message
+    }
+    \endcode
+    \sa wc_ecc_encrypt
+    \sa wc_ecc_encrypt_ex
+*/
+
+int wc_ecc_decrypt(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
+                word32 msgSz, byte* out, word32* outSz, ecEncCtx* ctx);
+
+
+/*!
+    \ingroup ECC 
+    \brief  非ブロック操作のためのECCサポートを有効にします。次のビルドオプションを使用した単精度（SP）数学でサポートされています.WolfSSL_SP_SP_SMALL WOLFSSL_SP_NO_MALLOC WC_ECC_NONBLOCK
+    \return 0  コールバックコンテキストを入力メッセージに正常に設定すると返されます。
+    \param key  ECC_KEYオブジェクトへのポインタ
+    _Example_
+    \code
+    int ret;
+    ecc_key ecc;
+    ecc_nb_ctx_t nb_ctx;
+
+    ret = wc_ecc_init(&ecc);
+    if (ret == 0) {
+        ret = wc_ecc_set_nonblock(&ecc, &nb_ctx);
+        if (ret == 0) {
+            do {
+                ret = wc_ecc_verify_hash_ex(
+                    &r, &s,       // r/s as mp_int
+                    hash, hashSz, // computed hash digest
+                    &verify_res,  // verification result 1=success
+                    &key
+                );
+
+                // TODO: Real-time work can be called here 
+            } while (ret == FP_WOULDBLOCK);
+        }
+        wc_ecc_free(&key);
+    }
+    \endcode
+*/
+int wc_ecc_set_nonblock(ecc_key *key, ecc_nb_ctx_t* ctx);

--- a/doc/dox_comments/header_files-ja/eccsi.h
+++ b/doc/dox_comments/header_files-ja/eccsi.h
@@ -1,0 +1,106 @@
+
+/*!
+*/
+int wc_InitEccsiKey(EccsiKey* key, void* heap, int devId);
+/*!
+*/
+int wc_InitEccsiKey_ex(EccsiKey* key, int keySz, int curveId,
+        void* heap, int devId);
+/*!
+*/
+void wc_FreeEccsiKey(EccsiKey* key);
+
+/*!
+*/
+int wc_MakeEccsiKey(EccsiKey* key, WC_RNG* rng);
+
+/*!
+*/
+int wc_MakeEccsiPair(EccsiKey* key, WC_RNG* rng,
+        enum wc_HashType hashType, const byte* id, word32 idSz, mp_int* ssk,
+        ecc_point* pvt);
+/*!
+*/
+int wc_ValidateEccsiPair(EccsiKey* key, enum wc_HashType hashType,
+        const byte* id, word32 idSz, const mp_int* ssk, ecc_point* pvt,
+        int* valid);
+/*!
+*/
+int wc_ValidateEccsiPvt(EccsiKey* key, const ecc_point* pvt,
+        int* valid);
+/*!
+*/
+int wc_EncodeEccsiPair(const EccsiKey* key, mp_int* ssk,
+        ecc_point* pvt, byte* data, word32* sz);
+/*!
+*/
+int wc_EncodeEccsiSsk(const EccsiKey* key, mp_int* ssk, byte* data,
+        word32* sz);
+/*!
+*/
+int wc_EncodeEccsiPvt(const EccsiKey* key, ecc_point* pvt,
+        byte* data, word32* sz, int raw);
+/*!
+*/
+int wc_DecodeEccsiPair(const EccsiKey* key, const byte* data,
+        word32 sz, mp_int* ssk, ecc_point* pvt);
+/*!
+*/
+int wc_DecodeEccsiSsk(const EccsiKey* key, const byte* data,
+        word32 sz, mp_int* ssk);
+/*!
+*/
+int wc_DecodeEccsiPvt(const EccsiKey* key, const byte* data,
+        word32 sz, ecc_point* pvt);
+/*!
+*/
+int wc_DecodeEccsiPvtFromSig(const EccsiKey* key, const byte* sig,
+        word32 sz, ecc_point* pvt);
+
+/*!
+*/
+int wc_ExportEccsiKey(EccsiKey* key, byte* data, word32* sz);
+/*!
+*/
+int wc_ImportEccsiKey(EccsiKey* key, const byte* data, word32 sz);
+
+/*!
+*/
+int wc_ExportEccsiPrivateKey(EccsiKey* key, byte* data, word32* sz);
+/*!
+*/
+int wc_ImportEccsiPrivateKey(EccsiKey* key, const byte* data,
+        word32 sz);
+
+/*!
+*/
+int wc_ExportEccsiPublicKey(EccsiKey* key, byte* data, word32* sz,
+        int raw);
+/*!
+*/
+int wc_ImportEccsiPublicKey(EccsiKey* key, const byte* data,
+        word32 sz, int trusted);
+
+/*!
+*/
+int wc_HashEccsiId(EccsiKey* key, enum wc_HashType hashType,
+        const byte* id, word32 idSz, ecc_point* pvt, byte* hash, byte* hashSz);
+/*!
+*/
+int wc_SetEccsiHash(EccsiKey* key, const byte* hash, byte hashSz);
+/*!
+*/
+int wc_SetEccsiPair(EccsiKey* key, const mp_int* ssk,
+        const ecc_point* pvt);
+
+/*!
+*/
+int wc_SignEccsiHash(EccsiKey* key, WC_RNG* rng,
+        enum wc_HashType hashType, const byte* msg, word32 msgSz, byte* sig,
+        word32* sigSz);
+/*!
+*/
+int wc_VerifyEccsiHash(EccsiKey* key, enum wc_HashType hashType,
+        const byte* msg, word32 msgSz, const byte* sig, word32 sigSz,
+        int* verified);
+

--- a/doc/dox_comments/header_files-ja/ed25519.h
+++ b/doc/dox_comments/header_files-ja/ed25519.h
@@ -1,0 +1,719 @@
+/*!
+    \ingroup ED25519 
+    \brief  この関数は秘密鍵からED25519公開鍵を生成します。公開鍵をバッファPubkeyに格納し、Pubkeyszでこのバッファに書き込まれたバイトを設定します。
+    \return 0  公開鍵の作成に成功したときに返されます。
+    \return BAD_FUNC_ARG  IFIキーまたはPubKeyがNULLに評価された場合、または指定されたキーサイズが32バイトではない場合（ED25519に32バイトのキーがあります）。
+    \return MEMORY_E  関数の実行中にメモリを割り当てるエラーがある場合に返されます。
+    \param [in]  キーを生成するED25519_Keyへのキーポインタ。
+    \param [out]  公開鍵を保存するバッファへのポインタ。
+    _Example_
+    \code
+    int ret;
+
+    ed25519_key key;
+    byte priv[] = { initialize with 32 byte private key };
+    byte pub[32];
+    word32 pubSz = sizeof(pub);
+
+    wc_ed25519_init(&key);
+    wc_ed25519_import_private_only(priv, sizeof(priv), &key);
+    ret = wc_ed25519_make_public(&key, pub, &pubSz);
+    if (ret != 0) {
+        // error making public key
+    }
+    \endcode
+    \sa wc_ed25519_init
+    \sa wc_ed25519_import_private_only
+    \sa wc_ed25519_make_key
+*/
+
+int wc_ed25519_make_public(ed25519_key* key, unsigned char* pubKey,
+                           word32 pubKeySz);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数は新しいED25519キーを生成し、それをキーに格納します。
+    \return 0  ED25519_KEYを正常に行うと返されます。
+    \return BAD_FUNC_ARG  RNGまたはKEYがNULLに評価された場合、または指定されたキーサイズが32バイトではない場合（ED25519に32バイトのキーがあります）。
+    \return MEMORY_E  関数の実行中にメモリを割り当てるエラーがある場合に返されます。
+    \param [in]  RNGキーを生成する初期化されたRNGオブジェクトへのポインタ。
+    \param [in]  keysize keyの長さを生成します。ED25519の場合は常に32になります。
+    _Example_
+    \code
+    int ret;
+
+    WC_RNG rng;
+    ed25519_key key;
+
+    wc_InitRng(&rng);
+    wc_ed25519_init(&key);
+    wc_ed25519_make_key(&rng, 32, &key);
+    if (ret != 0) {
+        // error making key
+    }
+    \endcode
+    \sa wc_ed25519_init
+*/
+
+int wc_ed25519_make_key(WC_RNG* rng, int keysize, ed25519_key* key);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数は、ED25519_Keyオブジェクトを使用して認証を保証するメッセージに署名します。
+    \return 0  メッセージの署名を正常に生成すると返されます。
+    \return BAD_FUNC_ARG  入力パラメータのいずれかがNULLに評価された場合、または出力バッファが小さすぎて生成された署名を保存する場合は返されます。
+    \return MEMORY_E  関数の実行中にメモリを割り当てるエラーがある場合に返されます。
+    \param [in]  署名するメッセージを含むバッファへのポインタ。
+    \param [in]  署名するメッセージのインレル長。
+    \param [out]  生成された署名を格納するためのバッファー。
+    \param [in,out]  出力バッファの最大長の範囲内。メッセージ署名の生成に成功したときに、書き込まれたバイトを保存します。
+    _Example_
+    \code
+    ed25519_key key;
+    WC_RNG rng;
+    int ret, sigSz;
+
+    byte sig[64]; // will hold generated signature
+    sigSz = sizeof(sig);
+    byte message[] = { initialize with message };
+
+    wc_InitRng(&rng); // initialize rng
+    wc_ed25519_init(&key); // initialize key
+    wc_ed25519_make_key(&rng, 32, &key); // make public/private key pair
+    ret = wc_ed25519_sign_msg(message, sizeof(message), sig, &sigSz, &key);
+    if (ret != 0) {
+        // error generating message signature
+    }
+    \endcode
+    \sa wc_ed25519ctx_sign_msg
+    \sa wc_ed25519ph_sign_hash
+    \sa wc_ed25519ph_sign_msg
+    \sa wc_ed25519_verify_msg
+*/
+
+int wc_ed25519_sign_msg(const byte* in, word32 inlen, byte* out,
+                        word32 *outlen, ed25519_key* key);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数は、ED25519_Keyオブジェクトを使用して認証を保証するメッセージに署名します。コンテキストは署名されたデータの一部です。
+    \return 0  メッセージの署名を正常に生成すると返されます。
+    \return BAD_FUNC_ARG  返された入力パラメータはNULLに評価されます。出力バッファが小さすぎて生成された署名を保存するには小さすぎます。
+    \return MEMORY_E  関数の実行中にメモリを割り当てるエラーがある場合に返されます。
+    \param [in]  署名するメッセージを含むバッファへのポインタ。
+    \param [in]  署名するメッセージのインレル長。
+    \param [out]  生成された署名を格納するためのバッファー。
+    \param [in,out]  出力バッファの最大長の範囲内。メッセージ署名の生成に成功したときに、書き込まれたバイトを保存します。
+    \param [in]  署名を生成するプライベートED25519_KEYへのキーポインタ。
+    \param [in]  メッセージが署名されているコンテキストを含むバッファへのコンテキストポインタ。
+    _Example_
+    \code
+    ed25519_key key;
+    WC_RNG rng;
+    int ret, sigSz;
+
+    byte sig[64]; // will hold generated signature
+    sigSz = sizeof(sig);
+    byte message[] = { initialize with message };
+    byte context[] = { initialize with context of signing };
+
+    wc_InitRng(&rng); // initialize rng
+    wc_ed25519_init(&key); // initialize key
+    wc_ed25519_make_key(&rng, 32, &key); // make public/private key pair
+    ret = wc_ed25519ctx_sign_msg(message, sizeof(message), sig, &sigSz, &key,
+            context, sizeof(context));
+    if (ret != 0) {
+        // error generating message signature
+    }
+    \endcode
+    \sa wc_ed25519_sign_msg
+    \sa wc_ed25519ph_sign_hash
+    \sa wc_ed25519ph_sign_msg
+    \sa wc_ed25519_verify_msg
+*/
+
+int wc_ed25519ctx_sign_msg(const byte* in, word32 inlen, byte* out,
+                        word32 *outlen, ed25519_key* key,
+                        const byte* context, byte contextLen);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数は、ED25519_Keyオブジェクトを使用してメッセージダイジェストに署名して信頼性を保証します。コンテキストは署名されたデータの一部として含まれています。署名計算の前にメッセージは事前にハッシュされています。メッセージダイジェストを作成するために使用されるハッシュアルゴリズムはShake-256でなければなりません。
+    \return 0  メッセージダイジェストの署名を正常に生成すると返されます。
+    \return BAD_FUNC_ARG  返された入力パラメータはNULLに評価されます。出力バッファが小さすぎて生成された署名を保存するには小さすぎます。
+    \return MEMORY_E  関数の実行中にメモリを割り当てるエラーがある場合に返されます。
+    \param [in]  サインへのメッセージのハッシュを含むバッファへのハッシュポインタ。
+    \param [in]  サインへのメッセージのハッシュのハッシュの長さ。
+    \param [out]  生成された署名を格納するためのバッファー。
+    \param [in,out]  出力バッファの最大長の範囲内。メッセージ署名の生成に成功したときに、書き込まれたバイトを保存します。
+    \param [in]  署名を生成するプライベートED25519_KEYへのキーポインタ。
+    \param [in]  メッセージが署名されているコンテキストを含むバッファへのコンテキストポインタ。
+    _Example_
+    \code
+    ed25519_key key;
+    WC_RNG rng;
+    int ret, sigSz;
+
+    byte sig[64]; // will hold generated signature
+    sigSz = sizeof(sig);
+    byte hash[] = { initialize with SHA-512 hash of message };
+    byte context[] = { initialize with context of signing };
+
+    wc_InitRng(&rng); // initialize rng
+    wc_ed25519_init(&key); // initialize key
+    wc_ed25519_make_key(&rng, 32, &key); // make public/private key pair
+    ret = wc_ed25519ph_sign_hash(hash, sizeof(hash), sig, &sigSz, &key,
+            context, sizeof(context));
+    if (ret != 0) {
+        // error generating message signature
+    }
+    \endcode
+    \sa wc_ed25519_sign_msg
+    \sa wc_ed25519ctx_sign_msg
+    \sa wc_ed25519ph_sign_msg
+    \sa wc_ed25519_verify_msg
+*/
+
+int wc_ed25519ph_sign_hash(const byte* hash, word32 hashLen, byte* out,
+                           word32 *outLen, ed25519_key* key,
+                           const byte* context, byte contextLen);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数は、ED25519_Keyオブジェクトを使用して認証を保証するメッセージに署名します。コンテキストは署名されたデータの一部として含まれています。署名計算の前にメッセージは事前にハッシュされています。
+    \return 0  メッセージの署名を正常に生成すると返されます。
+    \return BAD_FUNC_ARG  返された入力パラメータはNULLに評価されます。出力バッファが小さすぎて生成された署名を保存するには小さすぎます。
+    \return MEMORY_E  関数の実行中にメモリを割り当てるエラーがある場合に返されます。
+    \param [in]  署名するメッセージを含むバッファへのポインタ。
+    \param [in]  署名するメッセージのインレル長。
+    \param [out]  生成された署名を格納するためのバッファー。
+    \param [in,out]  出力バッファの最大長の範囲内。メッセージ署名の生成に成功したときに、書き込まれたバイトを保存します。
+    \param [in]  署名を生成するプライベートED25519_KEYへのキーポインタ。
+    \param [in]  メッセージが署名されているコンテキストを含むバッファへのコンテキストポインタ。
+    _Example_
+    \code
+    ed25519_key key;
+    WC_RNG rng;
+    int ret, sigSz;
+
+    byte sig[64]; // will hold generated signature
+    sigSz = sizeof(sig);
+    byte message[] = { initialize with message };
+    byte context[] = { initialize with context of signing };
+
+    wc_InitRng(&rng); // initialize rng
+    wc_ed25519_init(&key); // initialize key
+    wc_ed25519_make_key(&rng, 32, &key); // make public/private key pair
+    ret = wc_ed25519ph_sign_msg(message, sizeof(message), sig, &sigSz, &key,
+            context, sizeof(context));
+    if (ret != 0) {
+        // error generating message signature
+    }
+    \endcode
+    \sa wc_ed25519_sign_msg
+    \sa wc_ed25519ctx_sign_msg
+    \sa wc_ed25519ph_sign_hash
+    \sa wc_ed25519_verify_msg
+*/
+
+int wc_ed25519ph_sign_msg(const byte* in, word32 inlen, byte* out,
+                        word32 *outlen, ed25519_key* key,
+                        const byte* context, byte contextLen);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数はメッセージのED25519署名を確認して信頼性を確保します。RESを介して答えを返し、有効な署名に対応する1、無効な署名に対応する0を返します。
+    \return 0  署名検証と認証を正常に実行したときに返されます。
+    \return BAD_FUNC_ARG  いずれかの入力パラメータがNULLに評価された場合、またはSIGLENが署名の実際の長さと一致しない場合に返されます。
+    \return SIG_VERIFY_E  検証が完了した場合は返されますが、生成された署名は提供された署名と一致しません。
+    \param [in]  検証するシグネチャを含むバッファへのSIGポインタ。
+    \param [in]  検証するシグネチャのシグレンの長さ。
+    \param [in]  メッセージを含むバッファへのMSGポインタを確認する。
+    \param [in]  検証するメッセージのMSGlen長。
+    \param [out]  検証の結果へのRESポインタ。1メッセージが正常に検証されたことを示します。
+    _Example_
+    \code
+    ed25519_key key;
+    int ret, verified = 0;
+
+    byte sig[] { initialize with received signature };
+    byte msg[] = { initialize with message };
+    // initialize key with received public key
+    ret = wc_ed25519_verify_msg(sig, sizeof(sig), msg, sizeof(msg), &verified,
+            &key);
+    if (ret < 0) {
+        // error performing verification
+    } else if (verified == 0)
+        // the signature is invalid
+    }
+    \endcode
+    \sa wc_ed25519ctx_verify_msg
+    \sa wc_ed25519ph_verify_hash
+    \sa wc_ed25519ph_verify_msg
+    \sa wc_ed25519_sign_msg
+*/
+
+int wc_ed25519_verify_msg(const byte* sig, word32 siglen, const byte* msg,
+                          word32 msgLen, int* ret, ed25519_key* key);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数はメッセージのED25519署名を確認して信頼性を確保します。文脈はデータ検証済みの一部として含まれています。RESを介して答えを返し、有効な署名に対応する1、無効な署名に対応する0を返します。
+    \return 0  署名検証と認証を正常に実行したときに返されます。
+    \return BAD_FUNC_ARG  いずれかの入力パラメータがNULLに評価された場合、またはSIGLENが署名の実際の長さと一致しない場合に返されます。
+    \return SIG_VERIFY_E  検証が完了した場合は返されますが、生成された署名は提供された署名と一致しません。
+    \param [in]  検証するシグネチャを含むバッファへのSIGポインタ。
+    \param [in]  検証するシグネチャのシグレンの長さ。
+    \param [in]  メッセージを含むバッファへのMSGポインタを確認する。
+    \param [in]  検証するメッセージのMSGlen長。
+    \param [out]  検証の結果へのRESポインタ。1メッセージが正常に検証されたことを示します。
+    \param [in]  署名を検証するためのPublic ED25519キーへのキーポインタ。
+    \param [in]  メッセージが署名されたコンテキストを含むバッファへのコンテキストポインタ。
+    _Example_
+    \code
+    ed25519_key key;
+    int ret, verified = 0;
+
+    byte sig[] { initialize with received signature };
+    byte msg[] = { initialize with message };
+    byte context[] = { initialize with context of signature };
+    // initialize key with received public key
+    ret = wc_ed25519ctx_verify_msg(sig, sizeof(sig), msg, sizeof(msg),
+            &verified, &key, );
+    if (ret < 0) {
+        // error performing verification
+    } else if (verified == 0)
+        // the signature is invalid
+    }
+    \endcode
+    \sa wc_ed25519_verify_msg
+    \sa wc_ed25519ph_verify_hash
+    \sa wc_ed25519ph_verify_msg
+    \sa wc_ed25519_sign_msg
+*/
+
+int wc_ed25519ctx_verify_msg(const byte* sig, word32 siglen, const byte* msg,
+                             word32 msgLen, int* ret, ed25519_key* key,
+                             const byte* context, byte contextLen);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数は、メッセージのダイジェストのED25519シグネチャを確認して、信頼性を確保します。文脈はデータ検証済みの一部として含まれています。ハッシュは、署名計算前のプリハッシュメッセージです。メッセージダイジェストを作成するために使用されるハッシュアルゴリズムはSHA-512でなければなりません。答えはRESを介して返され、有効な署名に対応する1、無効な署名に対応する0を返します。
+    \return 0  署名検証と認証を正常に実行したときに返されます。
+    \return BAD_FUNC_ARG  いずれかの入力パラメータがNULLに評価された場合、またはSIGLENが署名の実際の長さと一致しない場合に返されます。
+    \return SIG_VERIFY_E  検証が完了した場合は返されますが、生成された署名は提供された署名と一致しません。
+    \param [in]  検証するシグネチャを含むバッファへのSIGポインタ。
+    \param [in]  検証するシグネチャのシグレンの長さ。
+    \param [in]  検証するメッセージのハッシュを含むバッファへのハッシュポインタ。
+    \param [in]  検証するハッシュのハッシュレン長。
+    \param [out]  検証の結果へのRESポインタ。1メッセージが正常に検証されたことを示します。
+    \param [in]  署名を検証するためのPublic ED25519キーへのキーポインタ。
+    \param [in]  メッセージが署名されたコンテキストを含むバッファへのコンテキストポインタ。
+    _Example_
+    \code
+    ed25519_key key;
+    int ret, verified = 0;
+
+    byte sig[] { initialize with received signature };
+    byte hash[] = { initialize with SHA-512 hash of message };
+    byte context[] = { initialize with context of signature };
+    // initialize key with received public key
+    ret = wc_ed25519ph_verify_hash(sig, sizeof(sig), msg, sizeof(msg),
+            &verified, &key, );
+    if (ret < 0) {
+        // error performing verification
+    } else if (verified == 0)
+        // the signature is invalid
+    }
+    \endcode
+    \sa wc_ed25519_verify_msg
+    \sa wc_ed25519ctx_verify_msg
+    \sa wc_ed25519ph_verify_msg
+    \sa wc_ed25519_sign_msg
+*/
+
+int wc_ed25519ph_verify_hash(const byte* sig, word32 siglen, const byte* hash,
+                             word32 hashLen, int* ret, ed25519_key* key,
+                             const byte* context, byte contextLen);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数はメッセージのED25519署名を確認して信頼性を確保します。文脈はデータ検証済みの一部として含まれています。検証前にメッセージがプリハッシュされています。RESを介して答えを返し、有効な署名に対応する1、無効な署名に対応する0を返します。
+    \return 0  署名検証と認証を正常に実行したときに返されます。
+    \return BAD_FUNC_ARG  いずれかの入力パラメータがNULLに評価された場合、またはSIGLENが署名の実際の長さと一致しない場合に返されます。
+    \return SIG_VERIFY_E  検証が完了した場合は返されますが、生成された署名は提供された署名と一致しません。
+    \param [in]  検証するシグネチャを含むバッファへのSIGポインタ。
+    \param [in]  検証するシグネチャのシグレンの長さ。
+    \param [in]  メッセージを含むバッファへのMSGポインタを確認する。
+    \param [in]  検証するメッセージのMSGlen長。
+    \param [out]  検証の結果へのRESポインタ。1メッセージが正常に検証されたことを示します。
+    \param [in]  署名を検証するためのPublic ED25519キーへのキーポインタ。
+    \param [in]  メッセージが署名されたコンテキストを含むバッファへのコンテキストポインタ。
+    _Example_
+    \code
+    ed25519_key key;
+    int ret, verified = 0;
+
+    byte sig[] { initialize with received signature };
+    byte msg[] = { initialize with message };
+    byte context[] = { initialize with context of signature };
+    // initialize key with received public key
+    ret = wc_ed25519ctx_verify_msg(sig, sizeof(sig), msg, sizeof(msg),
+            &verified, &key, );
+    if (ret < 0) {
+        // error performing verification
+    } else if (verified == 0)
+        // the signature is invalid
+    }
+    \endcode
+    \sa wc_ed25519_verify_msg
+    \sa wc_ed25519ph_verify_hash
+    \sa wc_ed25519ph_verify_msg
+    \sa wc_ed25519_sign_msg
+*/
+
+int wc_ed25519ph_verify_msg(const byte* sig, word32 siglen, const byte* msg,
+                            word32 msgLen, int* ret, ed25519_key* key,
+                            const byte* context, byte contextLen);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数は、メッセージ検証で将来の使用のためにED25519_Keyオブジェクトを初期化します。
+    \return 0  ED25519_Keyオブジェクトの初期化に成功したときに返されます。
+    \return BAD_FUNC_ARG  キーがNULLの場合は返されます。
+    _Example_
+    \code
+    ed25519_key key;
+    wc_ed25519_init(&key);
+    \endcode
+    \sa wc_ed25519_make_key
+    \sa wc_ed25519_free
+*/
+
+int wc_ed25519_init(ed25519_key* key);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数は、使用された後にED25519オブジェクトを解放します。
+    _Example_
+    \code
+    ed25519_key key;
+    // initialize key and perform secure exchanges
+    ...
+    wc_ed25519_free(&key);
+    \endcode
+    \sa wc_ed25519_init
+*/
+
+void wc_ed25519_free(ed25519_key* key);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数は、公開鍵を含むバッファからPublic ED25519_Keyペアをインポートします。この関数は圧縮キーと非圧縮キーの両方を処理します。
+    \return 0  ED25519_KEYのインポートに成功しました。
+    \return BAD_FUNC_ARG  inまたはkeyがnullに評価された場合、またはInlenがED25519キーのサイズよりも小さい場合に返されます。
+    \param [in]  公開鍵を含むバッファへのポインタ。
+    \param [in]  公開鍵を含むバッファのインレル長。
+    _Example_
+    \code
+    int ret;
+    byte pub[] = { initialize Ed25519 public key };
+
+    ed_25519 key;
+    wc_ed25519_init_key(&key);
+    ret = wc_ed25519_import_public(pub, sizeof(pub), &key);
+    if (ret != 0) {
+        // error importing key
+    }
+    \endcode
+    \sa wc_ed25519_import_private_key
+    \sa wc_ed25519_export_public
+*/
+
+int wc_ed25519_import_public(const byte* in, word32 inLen, ed25519_key* key);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数は、ed25519秘密鍵をバッファからのみインポートします。
+    \return 0  ED25519キーのインポートに成功しました。
+    \return BAD_FUNC_ARG  INまたはKEYがNULLに評価された場合、またはPRIVSZがED25519_KEY_SIZEよりも小さい場合に返されます。
+    \param [in]  秘密鍵を含むバッファへのPRIVポインタ。
+    \param [in]  秘密鍵のPrivsz長さ。
+    \param [in]  公開鍵を含むバッファへのPubポインタ。
+    \param [in]  公開鍵のPubszの長さ。
+    _Example_
+    \code
+    int ret;
+    byte priv[] = { initialize with 32 byte private key };
+
+    ed25519_key key;
+    wc_ed25519_init_key(&key);
+    ret = wc_ed25519_import_private_key(priv, sizeof(priv), &key);
+    if (ret != 0) {
+        // error importing private key
+    }
+    \endcode
+    \sa wc_ed25519_import_public
+    \sa wc_ed25519_import_private_key
+    \sa wc_ed25519_export_private_only
+*/
+
+int wc_ed25519_import_private_only(const byte* priv, word32 privSz,
+                                   ed25519_key* key);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数は、一対のバッファからパブリック/プライベートED25519キーペアをインポートします。この関数は圧縮キーと非圧縮キーの両方を処理します。
+    \return 0  ED25519_KEYのインポートに成功しました。
+    \return BAD_FUNC_ARG  INまたはKEYがNULLに評価された場合、またはいずれかのPROVSZがED25519_SEY_SIZEまたはPUBSZよりも小さい場合は、ED25519_PUB_KEY_SIZEよりも小さい場合に返されます。
+    \param [in]  秘密鍵を含むバッファへのPRIVポインタ。
+    \param [in]  秘密鍵のPrivsz長さ。
+    \param [in]  公開鍵を含むバッファへのPubポインタ。
+    \param [in]  公開鍵のPubszの長さ。
+    _Example_
+    \code
+    int ret;
+    byte priv[] = { initialize with 32 byte private key };
+    byte pub[]  = { initialize with the corresponding public key };
+
+    ed25519_key key;
+    wc_ed25519_init_key(&key);
+    ret = wc_ed25519_import_private_key(priv, sizeof(priv), pub, sizeof(pub),
+            &key);
+    if (ret != 0) {
+        // error importing key
+    }
+    \endcode
+    \sa wc_ed25519_import_public
+    \sa wc_ed25519_import_private_only
+    \sa wc_ed25519_export_private
+*/
+
+int wc_ed25519_import_private_key(const byte* priv, word32 privSz,
+                               const byte* pub, word32 pubSz, ed25519_key* key);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数は、秘密鍵をED25519_Key構造体からエクスポートします。公開鍵をバッファアウトに格納し、ounterenでこのバッファに書き込まれたバイトを設定します。
+    \return 0  公開鍵のエクスポートに成功したら返されます。
+    \return BAD_FUNC_ARG  いずれかの入力値がNULLに評価された場合に返されます。
+    \return BUFFER_E  提供されたバッファーが秘密鍵を保存するのに十分な大きさでない場合に返されます。このエラーを返すと、outlenに必要なサイズを設定します。
+    \param [in]  公開鍵をエクスポートするためのED25519_Key構造体へのキーポインタ。
+    \param [out]  公開鍵を保存するバッファへのポインタ。
+    _Example_
+    \code
+    int ret;
+    ed25519_key key;
+    // initialize key, make key
+
+    char pub[32];
+    word32 pubSz = sizeof(pub);
+
+    ret = wc_ed25519_export_public(&key, pub, &pubSz);
+    if (ret != 0) {
+        // error exporting public key
+    }
+    \endcode
+    \sa wc_ed25519_import_public
+    \sa wc_ed25519_export_private_only
+*/
+
+int wc_ed25519_export_public(ed25519_key* key, byte* out, word32* outLen);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数は、ED25519_Key構造体からの秘密鍵のみをエクスポートします。秘密鍵をバッファアウトに格納し、outlenにこのバッファに書き込まれたバイトを設定します。
+    \return 0  秘密鍵のエクスポートに成功したら返されます。
+    \return ECC_BAD_ARG_E  いずれかの入力値がNULLに評価された場合に返されます。
+    \return BUFFER_E  提供されたバッファーが秘密鍵を保存するのに十分な大きさでない場合に返されます。
+    \param [in]  秘密鍵をエクスポートするためのED25519_Key構造体へのキーポインタ。
+    \param [out]  秘密鍵を保存するバッファへのポインタ。
+    _Example_
+    \code
+    int ret;
+    ed25519_key key;
+    // initialize key, make key
+
+    char priv[32]; // 32 bytes because only private key
+    word32 privSz = sizeof(priv);
+    ret = wc_ed25519_export_private_only(&key, priv, &privSz);
+    if (ret != 0) {
+        // error exporting private key
+    }
+    \endcode
+    \sa wc_ed25519_export_public
+    \sa wc_ed25519_import_private_key
+*/
+
+int wc_ed25519_export_private_only(ed25519_key* key, byte* out, word32* outLen);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数は、ED25519_Key構造体からキーペアをエクスポートします。キーペアをバッファOUTに格納し、ounterenでこのバッファに書き込まれたバイトを設定します。
+    \return 0  キーペアのエクスポートに成功したら返されます。
+    \return ECC_BAD_ARG_E  いずれかの入力値がNULLに評価された場合に返されます。
+    \return BUFFER_E  提供されているバッファーがキーペアを保存するのに十分な大きさでない場合に返されます。
+    \param [in]  キーペアをエクスポートするためのED25519_Key構造体へのキーポインタ。
+    \param [out]  キーペアを保存するバッファへのポインタ。
+    _Example_
+    \code
+    ed25519_key key;
+    wc_ed25519_init(&key);
+
+    WC_RNG rng;
+    wc_InitRng(&rng);
+
+    wc_ed25519_make_key(&rng, 32, &key); // initialize 32 byte Ed25519 key
+
+    byte out[64]; // out needs to be a sufficient buffer size
+    word32 outLen = sizeof(out);
+    int key_size = wc_ed25519_export_private(&key, out, &outLen);
+    if (key_size == BUFFER_E) {
+        // Check size of out compared to outLen to see if function reset outLen
+    }
+    \endcode
+    \sa wc_ed25519_import_private_key
+    \sa wc_ed25519_export_private_only
+*/
+
+int wc_ed25519_export_private(ed25519_key* key, byte* out, word32* outLen);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数は、ED25519_KEY構造体とは別にプライベートキーと公開鍵をエクスポートします。秘密鍵をバッファーPrivに格納し、PRIVSZでこのバッファに書き込まれたバイトを設定します。公開鍵をバッファPUBに格納し、Pubszでこのバッファに書き込まれたバイトを設定します。
+    \return 0  キーペアのエクスポートに成功したら返されます。
+    \return ECC_BAD_ARG_E  いずれかの入力値がNULLに評価された場合に返されます。
+    \return BUFFER_E  提供されているバッファーがキーペアを保存するのに十分な大きさでない場合に返されます。
+    \param [in]  キーペアをエクスポートするためのED25519_Key構造体へのキーポインタ。
+    \param [out]  秘密鍵を保存するバッファへのPRIVポインタ。
+    \param [in,out]  PRIVSZ PIVINSZポインタサイズが表示されているサイズを持つWord32オブジェクトへのポインタ。秘密鍵のエクスポート後に書き込まれたバイト数を設定します。
+    \param [out]  パブリックキーを保存するバッファへのPub。
+    _Example_
+    \code
+    int ret;
+    ed25519_key key;
+    // initialize key, make key
+
+    char pub[32];
+    word32 pubSz = sizeof(pub);
+    char priv[32];
+    word32 privSz = sizeof(priv);
+
+    ret = wc_ed25519_export_key(&key, priv, &pubSz, pub, &pubSz);
+    if (ret != 0) {
+        // error exporting public key
+    }
+    \endcode
+    \sa wc_ed25519_export_private
+    \sa wc_ed25519_export_public
+*/
+
+int wc_ed25519_export_key(ed25519_key* key,
+                          byte* priv, word32 *privSz,
+                          byte* pub, word32 *pubSz);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数は、ED25519_KEY構造体の公開鍵をチェックします。
+    \return 0  プライベートキーと公開鍵が一致した場合に返されます。
+    \return BAD_FUNC_ARGS  与えられたキーがNULLの場合に返されます。
+    _Example_
+    \code
+    int ret;
+    byte priv[] = { initialize with 57 byte private key };
+    byte pub[]  = { initialize with the corresponding public key };
+
+    ed25519_key key;
+    wc_ed25519_init_key(&key);
+    wc_ed25519_import_private_key(priv, sizeof(priv), pub, sizeof(pub), &key);
+    ret = wc_ed25519_check_key(&key);
+    if (ret != 0) {
+        // error checking key
+    }
+    \endcode
+    \sa wc_ed25519_import_private_key
+*/
+
+int wc_ed25519_check_key(ed25519_key* key);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数は、ED25519  -  32バイトのサイズを返します。
+    \return ED25519_KEY_SIZE  有効な秘密鍵のサイズ（32バイト）。
+    \return BAD_FUNC_ARGS  与えられたキーがNULLの場合に返されます。
+    _Example_
+    \code
+    int keySz;
+    ed25519_key key;
+    // initialize key, make key
+    keySz = wc_ed25519_size(&key);
+    if (keySz == 0) {
+        // error determining key size
+    }
+    \endcode
+    \sa wc_ed25519_make_key
+*/
+
+int wc_ed25519_size(ed25519_key* key);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数は、秘密鍵サイズ（secret + public）をバイト単位で返します。
+    \return ED25519_PRV_KEY_SIZE  秘密鍵のサイズ（64バイト）。
+    \return BAD_FUNC_ARG  key引数がnullの場合に返されます。
+    _Example_
+    \code
+    ed25519_key key;
+    wc_ed25519_init(&key);
+
+    WC_RNG rng;
+    wc_InitRng(&rng);
+
+    wc_ed25519_make_key(&rng, 32, &key); // initialize 32 byte Ed25519 key
+    int key_size = wc_ed25519_priv_size(&key);
+    \endcode
+    \sa wc_ed25519_pub_size
+*/
+
+int wc_ed25519_priv_size(ed25519_key* key);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数は圧縮鍵サイズをバイト単位で返します（公開鍵）。
+    \return ED25519_PUB_KEY_SIZE  圧縮公開鍵のサイズ（32バイト）。
+    \return BAD_FUNC_ARG  key引数がnullの場合は返します。
+    _Example_
+    \code
+    ed25519_key key;
+    wc_ed25519_init(&key);
+    WC_RNG rng;
+    wc_InitRng(&rng);
+
+    wc_ed25519_make_key(&rng, 32, &key); // initialize 32 byte Ed25519 key
+    int key_size = wc_ed25519_pub_size(&key);
+    \endcode
+    \sa wc_ed25519_priv_size
+*/
+
+int wc_ed25519_pub_size(ed25519_key* key);
+
+/*!
+    \ingroup ED25519 
+    \brief  この関数は、ED25519シグネチャのサイズ（バイト数64）を返します。
+    \return ED25519_SIG_SIZE  ED25519シグネチャ（64バイト）のサイズ。
+    \return BAD_FUNC_ARG  key引数がnullの場合は返します。
+    _Example_
+    \code
+    int sigSz;
+    ed25519_key key;
+    // initialize key, make key
+
+    sigSz = wc_ed25519_sig_size(&key);
+    if (sigSz == 0) {
+        // error determining sig size
+    }
+    \endcode
+    \sa wc_ed25519_sign_msg
+*/
+
+int wc_ed25519_sig_size(ed25519_key* key);

--- a/doc/dox_comments/header_files-ja/ed448.h
+++ b/doc/dox_comments/header_files-ja/ed448.h
@@ -1,0 +1,631 @@
+/*!
+    \ingroup ED448 
+    \brief  この関数は、秘密鍵からED448公開鍵を生成します。公開鍵をバッファPubkeyに格納し、Pubkeyszでこのバッファに書き込まれたバイトを設定します。
+    \return 0  公開鍵の作成に成功したときに返されます。
+    \return BAD_FUNC_ARG  IFIキーまたはPubKeyがNULLに評価された場合、または指定されたキーサイズが57バイトではない場合（ED448には57バイトのキーがあります）。
+    \return MEMORY_E  関数の実行中にメモリを割り当てるエラーがある場合に返されます。
+    \param [in]  キーを生成するED448_Keyへのキーポインタ。
+    \param [out]  公開鍵を保存するバッファへのポインタ。
+    _Example_
+    \code
+    int ret;
+
+    ed448_key key;
+    byte priv[] = { initialize with 57 byte private key };
+    byte pub[57];
+    word32 pubSz = sizeof(pub);
+
+    wc_ed448_init(&key);
+    wc_ed448_import_private_only(priv, sizeof(priv), &key);
+    ret = wc_ed448_make_public(&key, pub, &pubSz);
+    if (ret != 0) {
+        // error making public key
+    }
+    \endcode
+    \sa wc_ed448_init
+    \sa wc_ed448_import_private_only
+    \sa wc_ed448_make_key
+*/
+
+int wc_ed448_make_public(ed448_key* key, unsigned char* pubKey,
+                         word32 pubKeySz);
+
+/*!
+    \ingroup ED448 
+    \brief  この関数は新しいED448キーを生成し、それをキーに格納します。
+    \return 0  ED448_Keyを正常に作成したときに返されます。
+    \return BAD_FUNC_ARG  RNGまたはKeyがNULLに評価された場合、または指定されたキーサイズが57バイトではない場合（ED448には57バイトのキーがあります）。
+    \return MEMORY_E  関数の実行中にメモリを割り当てるエラーがある場合に返されます。
+    \param [in]  RNGキーを生成する初期化されたRNGオブジェクトへのポインタ。
+    \param [in]  keysize keyの長さを生成します。ED448の場合は常に57になります。
+    _Example_
+    \code
+    int ret;
+
+    WC_RNG rng;
+    ed448_key key;
+
+    wc_InitRng(&rng);
+    wc_ed448_init(&key);
+    ret = wc_ed448_make_key(&rng, 57, &key);
+    if (ret != 0) {
+        // error making key
+    }
+    \endcode
+    \sa wc_ed448_init
+*/
+
+int wc_ed448_make_key(WC_RNG* rng, int keysize, ed448_key* key);
+
+/*!
+    \ingroup ED448 
+    \brief  この関数は、ED448_Keyオブジェクトを使用したメッセージに正解を保証します。
+    \return 0  メッセージの署名を正常に生成すると返されます。
+    \return BAD_FUNC_ARG  入力パラメータのいずれかがNULLに評価された場合、または出力バッファが小さすぎて生成された署名を保存する場合は返されます。
+    \return MEMORY_E  関数の実行中にメモリを割り当てるエラーがある場合に返されます。
+    \param [in]  署名するメッセージを含むバッファへのポインタ。
+    \param [in]  署名するメッセージのインレル長。
+    \param [out]  生成された署名を格納するためのバッファー。
+    \param [in,out]  出力バッファの最大長の範囲内。メッセージ署名の生成に成功したときに、書き込まれたバイトを保存します。
+    _Example_
+    \code
+    ed448_key key;
+    WC_RNG rng;
+    int ret, sigSz;
+
+    byte sig[114]; // will hold generated signature
+    sigSz = sizeof(sig);
+    byte message[] = { initialize with message };
+
+    wc_InitRng(&rng); // initialize rng
+    wc_ed448_init(&key); // initialize key
+    wc_ed448_make_key(&rng, 57, &key); // make public/private key pair
+    ret = wc_ed448_sign_msg(message, sizeof(message), sig, &sigSz, &key);
+    if (ret != 0 ) {
+        // error generating message signature
+    }
+    \endcode
+    \sa wc_ed448ph_sign_hash
+    \sa wc_ed448ph_sign_msg
+    \sa wc_ed448_verify_msg
+*/
+
+int wc_ed448_sign_msg(const byte* in, word32 inlen, byte* out,
+                        word32 *outlen, ed448_key* key);
+
+/*!
+    \ingroup ED448 
+    \brief  この関数は、Ed448_Keyオブジェクトを使用してメッセージダイジェストに署名して信頼性を保証します。コンテキストは署名されたデータの一部として含まれています。ハッシュは、署名計算前のプリハッシュメッセージです。メッセージダイジェストを作成するために使用されるハッシュアルゴリズムはShake-256でなければなりません。
+    \return 0  メッセージダイジェストの署名を正常に生成すると返されます。
+    \return BAD_FUNC_ARG  返された入力パラメータはNULLに評価されます。出力バッファが小さすぎて生成された署名を保存するには小さすぎます。
+    \return MEMORY_E  関数の実行中にメモリを割り当てるエラーがある場合に返されます。
+    \param [in]  サインへのメッセージのハッシュを含むバッファへのハッシュポインタ。
+    \param [in]  サインへのメッセージのハッシュのハッシュの長さ。
+    \param [out]  生成された署名を格納するためのバッファー。
+    \param [in,out]  出力バッファの最大長の範囲内。メッセージ署名の生成に成功したときに、書き込まれたバイトを保存します。
+    \param [in]  署名を生成するためのプライベートED448_Keyへのキーポインタ。
+    \param [in]  メッセージが署名されているコンテキストを含むバッファへのコンテキストポインタ。
+    _Example_
+    \code
+    ed448_key key;
+    WC_RNG rng;
+    int ret, sigSz;
+
+    byte sig[114]; // will hold generated signature
+    sigSz = sizeof(sig);
+    byte hash[] = { initialize with SHAKE-256 hash of message };
+    byte context[] = { initialize with context of signing };
+
+    wc_InitRng(&rng); // initialize rng
+    wc_ed448_init(&key); // initialize key
+    wc_ed448_make_key(&rng, 57, &key); // make public/private key pair
+    ret = wc_ed448ph_sign_hash(hash, sizeof(hash), sig, &sigSz, &key,
+            context, sizeof(context));
+    if (ret != 0) {
+        // error generating message signature
+    }
+    \endcode
+    \sa wc_ed448_sign_msg
+    \sa wc_ed448ph_sign_msg
+    \sa wc_ed448ph_verify_hash
+*/
+
+int wc_ed448ph_sign_hash(const byte* hash, word32 hashLen, byte* out,
+                         word32 *outLen, ed448_key* key,
+                         const byte* context, byte contextLen);
+
+/*!
+    \ingroup ED448 
+    \brief  この関数は、ED448_Keyオブジェクトを使用したメッセージに正解を保証します。コンテキストは署名されたデータの一部として含まれています。署名計算の前にメッセージは事前にハッシュされています。
+    \return 0  メッセージの署名を正常に生成すると返されます。
+    \return BAD_FUNC_ARG  返された入力パラメータはNULLに評価されます。出力バッファが小さすぎて生成された署名を保存するには小さすぎます。
+    \return MEMORY_E  関数の実行中にメモリを割り当てるエラーがある場合に返されます。
+    \param [in]  署名するメッセージを含むバッファへのポインタ。
+    \param [in]  署名するメッセージのインレル長。
+    \param [out]  生成された署名を格納するためのバッファー。
+    \param [in,out]  出力バッファの最大長の範囲内。メッセージ署名の生成に成功したときに、書き込まれたバイトを保存します。
+    \param [in]  署名を生成するためのプライベートED448_Keyへのキーポインタ。
+    \param [in]  メッセージが署名されているコンテキストを含むバッファへのコンテキストポインタ。
+    _Example_
+    \code
+    ed448_key key;
+    WC_RNG rng;
+    int ret, sigSz;
+
+    byte sig[114]; // will hold generated signature
+    sigSz = sizeof(sig);
+    byte message[] = { initialize with message };
+    byte context[] = { initialize with context of signing };
+
+    wc_InitRng(&rng); // initialize rng
+    wc_ed448_init(&key); // initialize key
+    wc_ed448_make_key(&rng, 57, &key); // make public/private key pair
+    ret = wc_ed448ph_sign_msg(message, sizeof(message), sig, &sigSz, &key,
+            context, sizeof(context));
+    if (ret != 0) {
+        // error generating message signature
+    }
+    \endcode
+    \sa wc_ed448_sign_msg
+    \sa wc_ed448ph_sign_hash
+    \sa wc_ed448ph_verify_msg
+*/
+
+int wc_ed448ph_sign_msg(const byte* in, word32 inLen, byte* out,
+                        word32 *outLen, ed448_key* key, const byte* context,
+                        byte contextLen);
+
+/*!
+    \ingroup ED448 
+    \brief  この関数は、メッセージのED448署名を確認して信頼性を確保します。文脈はデータ検証済みの一部として含まれています。答えはRESを介して返され、有効な署名に対応する1、無効な署名に対応する0を返します。
+    \return 0  署名検証と認証を正常に実行したときに返されます。
+    \return BAD_FUNC_ARG  いずれかの入力パラメータがNULLに評価された場合、またはSIGLENが署名の実際の長さと一致しない場合に返されます。
+    \return SIG_VERIFY_E  検証が完了した場合は返されますが、生成された署名は提供された署名と一致しません。
+    \param [in]  検証するシグネチャを含むバッファへのSIGポインタ。
+    \param [in]  検証するシグネチャのシグレンの長さ。
+    \param [in]  メッセージを含むバッファへのMSGポインタを確認する。
+    \param [in]  検証するメッセージのMSGlen長。
+    \param [in]  署名を検証するためのパブリックED448キーへのキーポインタ。
+    \param [in]  メッセージが署名されたコンテキストを含むバッファへのコンテキストポインタ。
+    _Example_
+    \code
+    ed448_key key;
+    int ret, verified = 0;
+
+    byte sig[] { initialize with received signature };
+    byte msg[] = { initialize with message };
+    byte context[] = { initialize with context of signature };
+    // initialize key with received public key
+    ret = wc_ed448_verify_msg(sig, sizeof(sig), msg, sizeof(msg), &verified,
+            &key, context, sizeof(context));
+    if (ret < 0) {
+        // error performing verification
+    } else if (verified == 0)
+        // the signature is invalid
+    }
+    \endcode
+    \sa wc_ed448ph_verify_hash
+    \sa wc_ed448ph_verify_msg
+    \sa wc_ed448_sign_msg
+*/
+
+int wc_ed448_verify_msg(const byte* sig, word32 siglen, const byte* msg,
+                          word32 msgLen, int* res, ed448_key* key,
+                          const byte* context, byte contextLen);
+
+/*!
+    \ingroup ED448 
+    \brief  この関数は、メッセージのダイジェストのED448シグネチャを検証して、信頼性を確保します。文脈はデータ検証済みの一部として含まれています。ハッシュは、署名計算前のプリハッシュメッセージです。メッセージダイジェストを作成するために使用されるハッシュアルゴリズムはShake-256でなければなりません。答えはRESを介して返され、有効な署名に対応する1、無効な署名に対応する0を返します。
+    \return 0  署名検証と認証を正常に実行したときに返されます。
+    \return BAD_FUNC_ARG  いずれかの入力パラメータがNULLに評価された場合、またはSIGLENが署名の実際の長さと一致しない場合に返されます。
+    \return SIG_VERIFY_E  検証が完了した場合は返されますが、生成された署名は提供された署名と一致しません。
+    \param [in]  検証するシグネチャを含むバッファへのSIGポインタ。
+    \param [in]  検証するシグネチャのシグレンの長さ。
+    \param [in]  検証するメッセージのハッシュを含むバッファへのハッシュポインタ。
+    \param [in]  検証するハッシュのハッシュレン長。
+    \param [in]  署名を検証するためのパブリックED448キーへのキーポインタ。
+    \param [in]  メッセージが署名されたコンテキストを含むバッファへのコンテキストポインタ。
+    _Example_
+    \code
+    ed448_key key;
+    int ret, verified = 0;
+
+    byte sig[] { initialize with received signature };
+    byte hash[] = { initialize with SHAKE-256 hash of message };
+    byte context[] = { initialize with context of signature };
+    // initialize key with received public key
+    ret = wc_ed448ph_verify_hash(sig, sizeof(sig), hash, sizeof(hash),
+            &verified, &key, context, sizeof(context));
+    if (ret < 0) {
+        // error performing verification
+    } else if (verified == 0)
+        // the signature is invalid
+    }
+    \endcode
+    \sa wc_ed448_verify_msg
+    \sa wc_ed448ph_verify_msg
+    \sa wc_ed448ph_sign_hash
+*/
+
+int wc_ed448ph_verify_hash(const byte* sig, word32 siglen, const byte* hash,
+                          word32 hashlen, int* res, ed448_key* key,
+                          const byte* context, byte contextLen);
+
+/*!
+    \ingroup ED448 
+    \brief  この関数は、メッセージのED448署名を確認して信頼性を確保します。文脈はデータ検証済みの一部として含まれています。検証前にメッセージがプリハッシュされています。答えはRESを介して返され、有効な署名に対応する1、無効な署名に対応する0を返します。
+    \return 0  署名検証と認証を正常に実行したときに返されます。
+    \return BAD_FUNC_ARG  いずれかの入力パラメータがNULLに評価された場合、またはSIGLENが署名の実際の長さと一致しない場合に返されます。
+    \return SIG_VERIFY_E  検証が完了した場合は返されますが、生成された署名は提供された署名と一致しません。
+    \param [in]  検証するシグネチャを含むバッファへのSIGポインタ。
+    \param [in]  検証するシグネチャのシグレンの長さ。
+    \param [in]  メッセージを含むバッファへのMSGポインタを確認する。
+    \param [in]  検証するメッセージのMSGlen長。
+    \param [in]  署名を検証するためのパブリックED448キーへのキーポインタ。
+    \param [in]  メッセージが署名されたコンテキストを含むバッファへのコンテキストポインタ。
+    _Example_
+    \code
+    ed448_key key;
+    int ret, verified = 0;
+
+    byte sig[] { initialize with received signature };
+    byte msg[] = { initialize with message };
+    byte context[] = { initialize with context of signature };
+    // initialize key with received public key
+    ret = wc_ed448ph_verify_msg(sig, sizeof(sig), msg, sizeof(msg), &verified,
+            &key, context, sizeof(context));
+    if (ret < 0) {
+        // error performing verification
+    } else if (verified == 0)
+        // the signature is invalid
+    }
+    \endcode
+    \sa wc_ed448_verify_msg
+    \sa wc_ed448ph_verify_hash
+    \sa wc_ed448ph_sign_msg
+*/
+
+int wc_ed448ph_verify_msg(const byte* sig, word32 siglen, const byte* msg,
+                          word32 msgLen, int* res, ed448_key* key,
+                          const byte* context, byte contextLen);
+
+/*!
+    \ingroup ED448 
+    \brief  この関数は、メッセージ検証で将来の使用のためにED448_Keyオブジェクトを初期化します。
+    \return 0  ED448_Keyオブジェクトの初期化に成功したら返されます。
+    \return BAD_FUNC_ARG  キーがNULLの場合は返されます。
+    _Example_
+    \code
+    ed448_key key;
+    wc_ed448_init(&key);
+    \endcode
+    \sa wc_ed448_make_key
+    \sa wc_ed448_free
+*/
+
+int wc_ed448_init(ed448_key* key);
+
+/*!
+    \ingroup ED448 
+    \brief  この関数は、それが使用された後にED448オブジェクトを解放します。
+    _Example_
+    \code
+    ed448_key key;
+    // initialize key and perform secure exchanges
+    ...
+    wc_ed448_free(&key);
+    \endcode
+    \sa wc_ed448_init
+*/
+
+void wc_ed448_free(ed448_key* key);
+
+/*!
+    \ingroup ED448 
+    \brief  この関数は、公開鍵を含むバッファからPublic ED448_Keyペアをインポートします。この関数は圧縮キーと非圧縮キーの両方を処理します。
+    \return 0  ED448_Keyのインポートに成功しました。
+    \return BAD_FUNC_ARG  INまたはKEYがNULLに評価されている場合、またはINLENがED448キーのサイズより小さい場合に返されます。
+    \param [in]  公開鍵を含むバッファへのポインタ。
+    \param [in]  公開鍵を含むバッファのインレル長。
+    _Example_
+    \code
+    int ret;
+    byte pub[] = { initialize Ed448 public key };
+
+    ed_448 key;
+    wc_ed448_init_key(&key);
+    ret = wc_ed448_import_public(pub, sizeof(pub), &key);
+    if (ret != 0) {
+        // error importing key
+    }
+    \endcode
+    \sa wc_ed448_import_private_key
+    \sa wc_ed448_export_public
+*/
+
+int wc_ed448_import_public(const byte* in, word32 inLen, ed448_key* key);
+
+/*!
+    \ingroup ED448 
+    \brief  この関数は、ed448秘密鍵をバッファからのみインポートします。
+    \return 0  ED448秘密鍵のインポートに成功しました。
+    \return BAD_FUNC_ARG  INまたはKEYがNULLに評価された場合、またはPRIVSZがED448_KEY_SIZEよりも小さい場合に返されます。
+    \param [in]  秘密鍵を含むバッファへのPRIVポインタ。
+    \param [in]  秘密鍵のPrivsz長さ。
+    _Example_
+    \code
+    int ret;
+    byte priv[] = { initialize with 57 byte private key };
+
+    ed448_key key;
+    wc_ed448_init_key(&key);
+    ret = wc_ed448_import_private_only(priv, sizeof(priv), &key);
+    if (ret != 0) {
+        // error importing private key
+    }
+    \endcode
+    \sa wc_ed448_import_public
+    \sa wc_ed448_import_private_key
+    \sa wc_ed448_export_private_only
+*/
+
+int wc_ed448_import_private_only(const byte* priv, word32 privSz,
+                                 ed448_key* key);
+
+/*!
+    \ingroup ED448 
+    \brief  この関数は、一対のバッファからパブリック/プライベートED448キーペアをインポートします。この関数は圧縮キーと非圧縮キーの両方を処理します。
+    \return 0  ED448キーのインポートに成功しました。
+    \return BAD_FUNC_ARG  INまたはKEYがNULLに評価された場合、またはPROVSZがED448_KEY_SIZEまたはPUBSZのいずれかがeD448_PUB_KEY_SIZEよりも小さい場合に返されます。
+    \param [in]  秘密鍵を含むバッファへのPRIVポインタ。
+    \param [in]  秘密鍵のPrivsz長さ。
+    \param [in]  公開鍵を含むバッファへのPubポインタ。
+    \param [in]  公開鍵のPubszの長さ。
+    _Example_
+    \code
+    int ret;
+    byte priv[] = { initialize with 57 byte private key };
+    byte pub[]  = { initialize with the corresponding public key };
+
+    ed448_key key;
+    wc_ed448_init_key(&key);
+    ret = wc_ed448_import_private_key(priv, sizeof(priv), pub, sizeof(pub),
+            &key);
+    if (ret != 0) {
+        // error importing key
+    }
+    \endcode
+    \sa wc_ed448_import_public
+    \sa wc_ed448_import_private_only
+    \sa wc_ed448_export_private
+*/
+
+int wc_ed448_import_private_key(const byte* priv, word32 privSz,
+                               const byte* pub, word32 pubSz, ed448_key* key);
+
+/*!
+    \ingroup ED448 
+    \brief  この関数は、ED448_Key構造体から秘密鍵をエクスポートします。公開鍵をバッファアウトに格納し、ounterenでこのバッファに書き込まれたバイトを設定します。
+    \return 0  公開鍵のエクスポートに成功したら返されます。
+    \return BAD_FUNC_ARG  いずれかの入力値がNULLに評価された場合に返されます。
+    \return BUFFER_E  提供されたバッファーが秘密鍵を保存するのに十分な大きさでない場合に返されます。このエラーを返すと、outlenに必要なサイズを設定します。
+    \param [in]  公開鍵をエクスポートするED448_Key構造体へのキーポインタ。
+    \param [out]  公開鍵を保存するバッファへのポインタ。
+    _Example_
+    \code
+    int ret;
+    ed448_key key;
+    // initialize key, make key
+
+    char pub[57];
+    word32 pubSz = sizeof(pub);
+
+    ret = wc_ed448_export_public(&key, pub, &pubSz);
+    if (ret != 0) {
+        // error exporting public key
+    }
+    \endcode
+    \sa wc_ed448_import_public
+    \sa wc_ed448_export_private_only
+*/
+
+int wc_ed448_export_public(ed448_key* key, byte* out, word32* outLen);
+
+/*!
+    \ingroup ED448 
+    \brief  この関数は、ED448_Key構造体からの秘密鍵のみをエクスポートします。秘密鍵をバッファアウトに格納し、outlenにこのバッファに書き込まれたバイトを設定します。
+    \return 0  秘密鍵のエクスポートに成功したら返されます。
+    \return ECC_BAD_ARG_E  いずれかの入力値がNULLに評価された場合に返されます。
+    \return BUFFER_E  提供されたバッファーが秘密鍵を保存するのに十分な大きさでない場合に返されます。
+    \param [in]  秘密鍵をエクスポートするED448_Key構造体へのキーポインタ。
+    \param [out]  秘密鍵を保存するバッファへのポインタ。
+    _Example_
+    \code
+    int ret;
+    ed448_key key;
+    // initialize key, make key
+
+    char priv[57]; // 57 bytes because only private key
+    word32 privSz = sizeof(priv);
+    ret = wc_ed448_export_private_only(&key, priv, &privSz);
+    if (ret != 0) {
+        // error exporting private key
+    }
+    \endcode
+    \sa wc_ed448_export_public
+    \sa wc_ed448_import_private_key
+*/
+
+int wc_ed448_export_private_only(ed448_key* key, byte* out, word32* outLen);
+
+/*!
+    \ingroup ED448 
+    \brief  この関数は、ED448_Key構造体からキーペアをエクスポートします。キーペアをバッファOUTに格納し、ounterenでこのバッファに書き込まれたバイトを設定します。
+    \return 0  キーペアのエクスポートに成功したら返されます。
+    \return ECC_BAD_ARG_E  いずれかの入力値がNULLに評価された場合に返されます。
+    \return BUFFER_E  提供されているバッファーがキーペアを保存するのに十分な大きさでない場合に返されます。
+    \param [in]  キーペアをエクスポートするためのED448_Key構造体へのキーポインタ。
+    \param [out]  キーペアを保存するバッファへのポインタ。
+    _Example_
+    \code
+    ed448_key key;
+    wc_ed448_init(&key);
+
+    WC_RNG rng;
+    wc_InitRng(&rng);
+
+    wc_ed448_make_key(&rng, 57, &key); // initialize 57 byte Ed448 key
+
+    byte out[114]; // out needs to be a sufficient buffer size
+    word32 outLen = sizeof(out);
+    int key_size = wc_ed448_export_private(&key, out, &outLen);
+    if (key_size == BUFFER_E) {
+        // Check size of out compared to outLen to see if function reset outLen
+    }
+    \endcode
+    \sa wc_ed448_import_private
+    \sa wc_ed448_export_private_only
+*/
+
+int wc_ed448_export_private(ed448_key* key, byte* out, word32* outLen);
+
+/*!
+    \ingroup ED448 
+    \brief  この関数は、ED448_Key構造体とは別にプライベートキーと公開鍵をエクスポートします。秘密鍵をバッファーPrivに格納し、PRIVSZでこのバッファに書き込まれたバイトを設定します。公開鍵をバッファPUBに格納し、Pubszでこのバッファに書き込まれたバイトを設定します。
+    \return 0  キーペアのエクスポートに成功したら返されます。
+    \return ECC_BAD_ARG_E  いずれかの入力値がNULLに評価された場合に返されます。
+    \return BUFFER_E  提供されているバッファーがキーペアを保存するのに十分な大きさでない場合に返されます。
+    \param [in]  キーペアをエクスポートするためのED448_Key構造体へのキーポインタ。
+    \param [out]  秘密鍵を保存するバッファへのPRIVポインタ。
+    \param [in,out]  PRIVSZ PIVINSZポインタサイズが表示されているサイズを持つWord32オブジェクトへのポインタ。秘密鍵のエクスポート後に書き込まれたバイト数を設定します。
+    \param [out]  パブリックキーを保存するバッファへのPub。
+    _Example_
+    \code
+    int ret;
+    ed448_key key;
+    // initialize key, make key
+
+    char pub[57];
+    word32 pubSz = sizeof(pub);
+    char priv[57];
+    word32 privSz = sizeof(priv);
+
+    ret = wc_ed448_export_key(&key, priv, &pubSz, pub, &pubSz);
+    if (ret != 0) {
+        // error exporting private and public key
+    }
+    \endcode
+    \sa wc_ed448_export_private
+    \sa wc_ed448_export_public
+*/
+
+int wc_ed448_export_key(ed448_key* key,
+                          byte* priv, word32 *privSz,
+                          byte* pub, word32 *pubSz);
+
+/*!
+    \ingroup ED448 
+    \brief  この関数は、ed448_key構造体の公開鍵をチェックします。
+    \return 0  プライベートキーと公開鍵が一致した場合に返されます。
+    \return BAD_FUNC_ARGS  与えられたキーがNULLの場合に返されます。
+    _Example_
+    \code
+    int ret;
+    byte priv[] = { initialize with 57 byte private key };
+    byte pub[]  = { initialize with the corresponding public key };
+
+    ed448_key key;
+    wc_ed448_init_key(&key);
+    wc_ed448_import_private_key(priv, sizeof(priv), pub, sizeof(pub), &key);
+    ret = wc_ed448_check_key(&key);
+    if (ret != 0) {
+        // error checking key
+    }
+    \endcode
+    \sa wc_ed448_import_private_key
+*/
+
+int wc_ed448_check_key(ed448_key* key);
+
+
+/*!
+    \ingroup ED448 
+    \brief  この関数は、ED448秘密鍵のサイズ -  57バイトを返します。
+    \return ED448_KEY_SIZE  有効な秘密鍵のサイズ（57バイト）。
+    \return BAD_FUNC_ARGS  与えられたキーがNULLの場合に返されます。
+    _Example_
+    \code
+    int keySz;
+    ed448_key key;
+    // initialize key, make key
+    keySz = wc_ed448_size(&key);
+    if (keySz == 0) {
+        // error determining key size
+    }
+    \endcode
+    \sa wc_ed448_make_key
+*/
+
+int wc_ed448_size(ed448_key* key);
+
+/*!
+    \ingroup ED448 
+    \brief  この関数は、秘密鍵サイズ（secret + public）をバイト単位で返します。
+    \return ED448_PRV_KEY_SIZE  秘密鍵のサイズ（114バイト）。
+    \return BAD_FUNC_ARG  key引数がnullの場合は返します。
+    _Example_
+    \code
+    ed448_key key;
+    wc_ed448_init(&key);
+
+    WC_RNG rng;
+    wc_InitRng(&rng);
+
+    wc_ed448_make_key(&rng, 57, &key); // initialize 57 byte Ed448 key
+    int key_size = wc_ed448_priv_size(&key);
+    \endcode
+    \sa wc_ed448_pub_size
+*/
+
+int wc_ed448_priv_size(ed448_key* key);
+
+/*!
+    \ingroup ED448 
+    \brief  この関数は圧縮鍵サイズをバイト単位で返します（公開鍵）。
+    \return ED448_PUB_KEY_SIZE  圧縮公開鍵のサイズ（57バイト）。
+    \return BAD_FUNC_ARG  key引数がnullの場合は返します。
+    _Example_
+    \code
+    ed448_key key;
+    wc_ed448_init(&key);
+    WC_RNG rng;
+    wc_InitRng(&rng);
+
+    wc_ed448_make_key(&rng, 57, &key); // initialize 57 byte Ed448 key
+    int key_size = wc_ed448_pub_size(&key);
+    \endcode
+    \sa wc_ed448_priv_size
+*/
+
+int wc_ed448_pub_size(ed448_key* key);
+
+/*!
+    \ingroup ED448 
+    \brief  この関数は、ED448シグネチャのサイズ（バイト数114）を返します。
+    \return ED448_SIG_SIZE  ED448シグネチャ（114バイト）のサイズ。
+    \return BAD_FUNC_ARG  key引数がnullの場合は返します。
+    _Example_
+    \code
+    int sigSz;
+    ed448_key key;
+    // initialize key, make key
+
+    sigSz = wc_ed448_sig_size(&key);
+    if (sigSz == 0) {
+        // error determining sig size
+    }
+    \endcode
+    \sa wc_ed448_sign_msg
+*/
+
+int wc_ed448_sig_size(ed448_key* key);

--- a/doc/dox_comments/header_files-ja/error-crypt.h
+++ b/doc/dox_comments/header_files-ja/error-crypt.h
@@ -1,0 +1,34 @@
+/*!
+    \ingroup Error 
+    \brief  この関数は、特定のバッファ内の特定のエラーコードのエラー文字列を格納します。
+    \return none  いいえ返します。
+    \param error  文字列を取得するためのエラーコード
+    _Example_
+    \code
+    char errorMsg[WOLFSSL_MAX_ERROR_SZ];
+    int err = wc_some_function();
+
+    if( err != 0) { // error occurred
+    	wc_ErrorString(err, errorMsg);
+    }
+    \endcode
+    \sa wc_GetErrorString
+*/
+void wc_ErrorString(int err, char* buff);
+
+/*!
+    \ingroup Error 
+    \brief  この関数は、特定のエラーコードのエラー文字列を返します。
+    \return string  エラーコードのエラー文字列を文字列リテラルとして返します。
+    _Example_
+    \code
+    char * errorMsg;
+    int err = wc_some_function();
+
+    if( err != 0) { // error occurred
+    	errorMsg = wc_GetErrorString(err);
+    }
+    \endcode
+    \sa wc_ErrorString
+*/
+const char* wc_GetErrorString(int error);

--- a/doc/dox_comments/header_files-ja/evp.h
+++ b/doc/dox_comments/header_files-ja/evp.h
@@ -1,0 +1,333 @@
+/*!
+    \ingroup openSSL 
+    \brief  それぞれのwolfssl_evp_cipherポインタのゲッター関数。最初にプログラム内でwolfssl_evp_init（）を1回呼び出す必要があります。wolfssl_des_ecbマクロは、wolfssl_evp_des_ede3_ecb（）に対して定義する必要があります。
+    \return pointer  DES EDE3操作のためのwolfssl_evp_cipherポインタを返します。
+    _Example_
+    \code
+    printf("block size des ede3 cbc = %d\n",
+    wolfSSL_EVP_CIPHER_block_size(wolfSSL_EVP_des_ede3_cbc()));
+    printf("block size des ede3 ecb = %d\n",
+    wolfSSL_EVP_CIPHER_block_size(wolfSSL_EVP_des_ede3_ecb()));
+    \endcode
+    \sa wolfSSL_EVP_CIPHER_CTX_init
+*/
+const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_des_ede3_ecb(void);
+
+/*!
+    \ingroup openSSL 
+    \brief  それぞれのwolfssl_evp_cipherポインタのゲッター関数。最初にプログラム内でwolfssl_evp_init（）を1回呼び出す必要があります。wolfssl_des_ecbマクロは、wolfssl_evp_des_ecb（）に対して定義する必要があります。
+    \return pointer  DES操作のためのwolfssl_evp_cipherポインタを返します。
+    _Example_
+    \code
+    WOLFSSL_EVP_CIPHER* cipher;
+    cipher = wolfSSL_EVP_des_cbc();
+    …
+    \endcode
+    \sa wolfSSL_EVP_CIPHER_CTX_init
+*/
+const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_des_cbc(void);
+
+/*!
+    \ingroup openSSL 
+    \brief  wolfssl_evp_md_ctxを初期化する機能。この関数はwolfssl_engineがwolfssl_engineを使用しないため、wolfssl_evp_digestinit（）のラッパーです。
+    \return SSL_SUCCESS  正常に設定されている場合。
+    \return SSL_FAILURE  成功しなかった場合
+    \param ctx  初期化する構造
+    \param type  SHAなどのハッシュの種類。
+    _Example_
+    \code
+    WOLFSSL_EVP_MD_CTX* md = NULL;
+    wolfCrypt_Init();
+    md = wolfSSL_EVP_MD_CTX_new();
+    if (md == NULL) {
+        printf("error setting md\n");
+        return -1;
+    }
+    printf("cipher md init ret = %d\n", wolfSSL_EVP_DigestInit_ex(md,
+    wolfSSL_EVP_sha1(), e));
+    //free resources
+    \endcode
+    \sa wolfSSL_EVP_MD_CTX_new
+    \sa wolfCrypt_Init
+    \sa wolfSSL_EVP_MD_CTX_free
+*/
+int wolfSSL_EVP_DigestInit_ex(WOLFSSL_EVP_MD_CTX* ctx,
+                                     const WOLFSSL_EVP_MD* type,
+                                     WOLFSSL_ENGINE *impl);
+
+/*!
+    \ingroup openSSL 
+    \brief  wolfssl_evp_cipher_ctxを初期化する機能。この関数はwolfssl_engineがwolfssl_engineを使用しないため、wolfssl_ciphinit（）のラッパーです。
+    \return SSL_SUCCESS  正常に設定されている場合。
+    \return SSL_FAILURE  成功しなかった場合
+    \param ctx  初期化する構造
+    \param type  AESなどの暗号化/復号化の種類。
+    \param impl  使用するエンジン。wolfsslのn / aは、nullになることができます。
+    \param key  設定するキー
+    \param iv  アルゴリズムで必要な場合はIV。
+    _Example_
+    \code
+    WOLFSSL_EVP_CIPHER_CTX* ctx = NULL;
+    WOLFSSL_ENGINE* e = NULL;
+    unsigned char key[16];
+    unsigned char iv[12];
+    wolfCrypt_Init();
+    ctx = wolfSSL_EVP_CIPHER_CTX_new();
+    if (ctx == NULL) {
+        printf("issue creating ctx\n");
+        return -1;
+    }
+
+    printf("cipher init ex error ret = %d\n", wolfSSL_EVP_CipherInit_ex(NULL,
+    EVP_aes_128_    cbc(), e, key, iv, 1));
+    printf("cipher init ex success ret = %d\n", wolfSSL_EVP_CipherInit_ex(ctx,
+    EVP_aes_128_c    bc(), e, key, iv, 1));
+    // free resources
+    \endcode
+    \sa wolfSSL_EVP_CIPHER_CTX_new
+    \sa wolfCrypt_Init
+    \sa wolfSSL_EVP_CIPHER_CTX_free
+*/
+int  wolfSSL_EVP_CipherInit_ex(WOLFSSL_EVP_CIPHER_CTX* ctx,
+                                    const WOLFSSL_EVP_CIPHER* type,
+                                    WOLFSSL_ENGINE *impl,
+                                    const unsigned char* key,
+                                    const unsigned char* iv,
+                                    int enc);
+
+/*!
+    \ingroup openSSL 
+    \brief  wolfssl_evp_cipher_ctxを初期化する機能。WolfSSLはWOLFSSL_ENGINEを使用しないため、この関数はwolfssl_evp_ciphinit（）のラッパーです。暗号化フラグを暗号化するように設定します。
+    \return SSL_SUCCESS  正常に設定されている場合。
+    \return SSL_FAILURE  成功しなかった場合
+    \param ctx  初期化する構造
+    \param type  AESなどの暗号化の種類。
+    \param impl  使用するエンジン。wolfsslのn / aは、nullになることができます。
+    \param key  使用する鍵
+    _Example_
+    \code
+    WOLFSSL_EVP_CIPHER_CTX* ctx = NULL;
+    wolfCrypt_Init();
+    ctx = wolfSSL_EVP_CIPHER_CTX_new();
+    if (ctx == NULL) {
+        printf("error setting ctx\n");
+        return -1;
+    }
+    printf("cipher ctx init ret = %d\n", wolfSSL_EVP_EncryptInit_ex(ctx,
+    wolfSSL_EVP_aes_128_cbc(), e, key, iv));
+    //free resources
+    \endcode
+    \sa wolfSSL_EVP_CIPHER_CTX_new
+    \sa wolfCrypt_Init
+    \sa wolfSSL_EVP_CIPHER_CTX_free
+*/
+int  wolfSSL_EVP_EncryptInit_ex(WOLFSSL_EVP_CIPHER_CTX* ctx,
+                                    const WOLFSSL_EVP_CIPHER* type,
+                                    WOLFSSL_ENGINE *impl,
+                                    const unsigned char* key,
+                                    const unsigned char* iv);
+
+/*!
+    \ingroup openSSL 
+    \brief  wolfssl_evp_cipher_ctxを初期化する機能。WolfSSLはWOLFSSL_ENGINEを使用しないため、この関数はwolfssl_evp_ciphinit（）のラッパーです。暗号化フラグを復号化するように設定します。
+    \return SSL_SUCCESS  正常に設定されている場合。
+    \return SSL_FAILURE  成功しなかった場合
+    \param ctx  初期化する構造
+    \param type  AESなどの暗号化/復号化の種類。
+    \param impl  使用するエンジン。wolfsslのn / aは、nullになることができます。
+    \param key  設定するキー
+    \param iv  アルゴリズムで必要な場合はIV。
+    _Example_
+    \code
+    WOLFSSL_EVP_CIPHER_CTX* ctx = NULL;
+    WOLFSSL_ENGINE* e = NULL;
+    unsigned char key[16];
+    unsigned char iv[12];
+
+    wolfCrypt_Init();
+
+    ctx = wolfSSL_EVP_CIPHER_CTX_new();
+    if (ctx == NULL) {
+        printf("issue creating ctx\n");
+        return -1;
+    }
+
+    printf("cipher init ex error ret = %d\n", wolfSSL_EVP_DecryptInit_ex(NULL,
+    EVP_aes_128_    cbc(), e, key, iv, 1));
+    printf("cipher init ex success ret = %d\n", wolfSSL_EVP_DecryptInit_ex(ctx,
+    EVP_aes_128_c    bc(), e, key, iv, 1));
+    // free resources
+    \endcode
+    \sa wolfSSL_EVP_CIPHER_CTX_new
+    \sa wolfCrypt_Init
+    \sa wolfSSL_EVP_CIPHER_CTX_free
+*/
+int  wolfSSL_EVP_DecryptInit_ex(WOLFSSL_EVP_CIPHER_CTX* ctx,
+                                    const WOLFSSL_EVP_CIPHER* type,
+                                    WOLFSSL_ENGINE *impl,
+                                    const unsigned char* key,
+                                    const unsigned char* iv);
+
+/*!
+    \ingroup openSSL 
+    \brief  データを暗号化/復号化する機能。バッファ内では暗号化または復号化され、OUTバッファが結果を保持します。OUTORは暗号化/復号化された情報の長さになります。
+    \return SSL_SUCCESS  成功した場合
+    \return SSL_FAILURE  成功しなかった場合
+    \param ctx  から暗号化の種類を取得するための構造。
+    \param out  出力を保持するためのバッファ。
+    \param outl  出力のサイズになるように調整しました。
+    \param in  操作を実行するためのバッファー。
+    _Example_
+    \code
+    WOLFSSL_EVP_CIPHER_CTX* ctx = NULL;
+    unsigned char out[100];
+    int outl;
+    unsigned char in[100];
+    int inl = 100;
+
+    ctx = wolfSSL_EVP_CIPHER_CTX_new();
+    // set up ctx
+    ret = wolfSSL_EVP_CipherUpdate(ctx, out, outl, in, inl);
+    // check ret value
+    // buffer out holds outl bytes of data
+    // free resources
+    \endcode
+    \sa wolfSSL_EVP_CIPHER_CTX_new
+    \sa wolfCrypt_Init
+    \sa wolfSSL_EVP_CIPHER_CTX_free
+*/
+int wolfSSL_EVP_CipherUpdate(WOLFSSL_EVP_CIPHER_CTX *ctx,
+                                   unsigned char *out, int *outl,
+                                   const unsigned char *in, int inl);
+
+/*!
+    \ingroup openSSL 
+    \brief  この関数は、パディングを追加する最終暗号化操作を実行します。wolfssl_evp_ciph_no_paddingフラグがwolfssl_evp_cipher_ctx構造に設定されている場合、1が返され、暗号化/復号化は行われません。PADDING FLAGがSETIパディングを追加して暗号化すると、暗号化にCTXが設定されていると、復号化されたときにパディング値がチェックされます。
+    \return 1  成功に戻りました。
+    \return 0  失敗に遭遇した場合
+    \param ctx  復号化/暗号化する構造。
+    \param out  最後の復号化/暗号化のためのバッファ。
+    _Example_
+    \code
+    WOLFSSL_EVP_CIPHER_CTX* ctx;
+    int out1;
+    unsigned char out[64];
+    // create ctx
+    wolfSSL_EVP_CipherFinal(ctx, out, &out1);
+    \endcode
+    \sa wolfSSL_EVP_CIPHER_CTX_new
+*/
+int  wolfSSL_EVP_CipherFinal(WOLFSSL_EVP_CIPHER_CTX *ctx,
+                                   unsigned char *out, int *outl);
+
+/*!
+    \ingroup openSSL 
+    \brief  WolfSSL EVP_CIPHER_CTX構造キー長の設定機能
+    \return SSL_SUCCESS  正常に設定されている場合。
+    \return SSL_FAILURE  キーの長さを設定できなかった場合。
+    \param ctx  キーの長さを設定する構造
+    _Example_
+    \code
+    WOLFSSL_EVP_CIPHER_CTX* ctx;
+    int keylen;
+    // create ctx
+    wolfSSL_EVP_CIPHER_CTX_set_key_length(ctx, keylen);
+    \endcode
+    \sa wolfSSL_EVP_CIPHER_flags
+*/
+int  wolfSSL_EVP_CIPHER_CTX_set_key_length(WOLFSSL_EVP_CIPHER_CTX* ctx,
+                                                     int keylen);
+
+/*!
+    \ingroup openSSL 
+    \brief  これはCTXブロックサイズのGetter関数です。
+    \return size  ctx-> block_sizeを返します。
+    _Example_
+    \code
+    const WOLFSSL_CVP_CIPHER_CTX* ctx;
+    //set up ctx
+    printf(“block size = %d\n”, wolfSSL_EVP_CIPHER_CTX_block_size(ctx));
+    \endcode
+    \sa wolfSSL_EVP_CIPHER_block_size
+*/
+int wolfSSL_EVP_CIPHER_CTX_block_size(const WOLFSSL_EVP_CIPHER_CTX *ctx);
+
+/*!
+    \ingroup openSSL 
+    \brief  これは暗号のブロックサイズのゲッター関数です。
+    \return size  ブロックサイズを返します。
+    _Example_
+    \code
+    printf(“block size = %d\n”,
+    wolfSSL_EVP_CIPHER_block_size(wolfSSL_EVP_aes_256_ecb()));
+    \endcode
+    \sa wolfSSL_EVP_aes_256_ctr
+*/
+int wolfSSL_EVP_CIPHER_block_size(const WOLFSSL_EVP_CIPHER *cipher);
+
+/*!
+    \ingroup openSSL 
+    \brief  WolfSSL evp_cipher_ctx構造の設定機能
+    \return none  いいえ返します。
+    \param ctx  フラグを設定する構造
+    _Example_
+    \code
+    WOLFSSL_EVP_CIPHER_CTX* ctx;
+    int flag;
+    // create ctx
+    wolfSSL_EVP_CIPHER_CTX_set_flags(ctx, flag);
+    \endcode
+    \sa wolfSSL_EVP_CIPHER_flags
+    \sa wolfSSL_EVP_CIPHER_CTX_flags
+*/
+void wolfSSL_EVP_CIPHER_CTX_set_flags(WOLFSSL_EVP_CIPHER_CTX *ctx, int flags);
+
+/*!
+    \ingroup openSSL 
+    \brief  WolfSSL evp_cipher_ctx構造のクリア機能
+    \return none  いいえ返します。
+    \param ctx  フラグをクリアするための構造
+    _Example_
+    \code
+    WOLFSSL_EVP_CIPHER_CTX* ctx;
+    int flag;
+    // create ctx
+    wolfSSL_EVP_CIPHER_CTX_clear_flags(ctx, flag);
+    \endcode
+    \sa wolfSSL_EVP_CIPHER_flags
+    \sa wolfSSL_EVP_CIPHER_CTX_flags
+*/
+void wolfSSL_EVP_CIPHER_CTX_clear_flags(WOLFSSL_EVP_CIPHER_CTX *ctx, int flags);
+
+/*!
+    \ingroup openSSL 
+    \brief  wolfssl_evp_cipher_ctx構造のためのセッター機能パディングを使用する。
+    \return SSL_SUCCESS  正常に設定されている場合。
+    \return BAD_FUNC_ARG  NULL引数が渡された場合。
+    \param ctx  パディングフラグを設定する構造
+    _Example_
+    \code
+    WOLFSSL_EVP_CIPHER_CTX* ctx;
+    // create ctx
+    wolfSSL_EVP_CIPHER_CTX_set_padding(ctx, 1);
+    \endcode
+    \sa wolfSSL_EVP_CIPHER_CTX_new
+*/
+int  wolfSSL_EVP_CIPHER_CTX_set_padding(WOLFSSL_EVP_CIPHER_CTX *c, int pad);
+
+
+/*!
+    \ingroup openSSL 
+    \brief  wolfssl_evp_cipher_ctx構造のゲッター関数廃止予定のV1.1.0
+    \return unsigned  フラグ/モードの長い。
+    _Example_
+    \code
+    WOLFSSL_EVP_CIPHER_CTX* ctx;
+    unsigned long flags;
+    ctx = wolfSSL_EVP_CIPHER_CTX_new()
+    flags = wolfSSL_EVP_CIPHER_CTX_flags(ctx);
+    \endcode
+    \sa wolfSSL_EVP_CIPHER_CTX_new
+    \sa wolfSSL_EVP_CIPHER_flags
+*/
+unsigned long wolfSSL_EVP_CIPHER_CTX_flags(const WOLFSSL_EVP_CIPHER_CTX *ctx);

--- a/doc/dox_comments/header_files-ja/hash.h
+++ b/doc/dox_comments/header_files-ja/hash.h
@@ -1,0 +1,171 @@
+/*!
+    \ingroup wolfCrypt 
+    \brief  この関数は提供されたwc_hashtypeのOIDを返します。
+    \return OID  戻り値0を超えてください
+    \return HASH_TYPE_E  ハッシュ型はサポートされていません。
+    \return BAD_FUNC_ARG  提供された引数の1つが正しくありません。
+    _Example_
+    \code
+    enum wc_HashType hash_type = WC_HASH_TYPE_SHA256;
+    int oid = wc_HashGetOID(hash_type);
+    if (oid > 0) {
+    	// Success
+    }
+    \endcode
+    \sa wc_HashGetDigestSize
+    \sa wc_Hash
+*/
+int wc_HashGetOID(enum wc_HashType hash_type);
+
+/*!
+    \ingroup wolfCrypt 
+    \brief  この関数は、hash_typeのダイジェスト（出力）のサイズを返します。返品サイズは、WC_HASHに提供される出力バッファが十分に大きいことを確認するために使用されます。
+    \return Success  正の戻り値は、ハッシュのダイジェストサイズを示します。
+    \return Error  hash_typeがサポートされていない場合はhash_type_eを返します。
+    \return Failure  無効なhash_typeが使用された場合、bad_func_argを返します。
+    _Example_
+    \code
+    int hash_len = wc_HashGetDigestSize(hash_type);
+    if (hash_len <= 0) {
+    WOLFSSL_MSG("Invalid hash type/len");
+    return BAD_FUNC_ARG;
+    }
+    \endcode
+    \sa wc_Hash
+*/
+int wc_HashGetDigestSize(enum wc_HashType hash_type);
+
+/*!
+    \ingroup wolfCrypt 
+    \brief  この関数は、提供されたデータバッファ上にハッシュを実行し、提供されたハッシュバッファにそれを返します。
+    \return 0  そうでなければ、それ以外の誤り（bad_func_argやbuffer_eなど）。
+    \param hash_type  "wc_hash_type_sha256"などの "enum wc_hashtype"からのハッシュ型。
+    \param data  ハッシュへのデータを含むバッファへのポインタ。
+    \param data_len  データバッファの長さ。
+    \param hash  最後のハッシュを出力するために使用されるバッファへのポインタ。
+    _Example_
+    \code
+    enum wc_HashType hash_type = WC_HASH_TYPE_SHA256;
+    int hash_len = wc_HashGetDigestSize(hash_type);
+    if (hash_len > 0) {
+        int ret = wc_Hash(hash_type, data, data_len, hash_data, hash_len);
+        if(ret == 0) {
+		    // Success
+        }
+    }
+    \endcode
+    \sa wc_HashGetDigestSize
+*/
+int wc_Hash(enum wc_HashType hash_type,
+    const byte* data, word32 data_len,
+    byte* hash, word32 hash_len);
+
+/*!
+    \ingroup MD5 
+    \brief  利便性機能は、すべてのハッシュを処理し、その結果をハッシュに入れます。
+    \return 0  データを正常にハッシュしたときに返されます。
+    \return Memory_E  メモリエラー、メモリを割り当てることができません。これは、小さなスタックオプションが有効になっているだけです。
+    \param data  ハッシュへのデータ
+    \param len  データの長さ
+    _Example_
+    \code
+    const byte* data;
+    word32 data_len;
+    byte* hash;
+    int ret;
+    ...
+    ret = wc_Md5Hash(data, data_len, hash);
+    if (ret != 0) {
+         // Md5 Hash Failure Case.
+    }
+    \endcode
+    \sa wc_Md5Hash
+    \sa wc_Md5Final
+    \sa wc_InitMd5
+*/
+int wc_Md5Hash(const byte* data, word32 len, byte* hash);
+
+/*!
+    \ingroup SHA 
+    \brief  利便性機能は、すべてのハッシュを処理し、その結果をハッシュに入れます。
+    \return 0  うまく返されました...。
+    \return Memory_E  メモリエラー、メモリを割り当てることができません。これは、小さなスタックオプションが有効になっているだけです。
+    \param data  ハッシュへのデータ
+    \param len  データの長さ
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wc_ShaHash
+    \sa wc_ShaFinal
+    \sa wc_InitSha
+*/
+int wc_ShaHash(const byte* data, word32 len, byte* hash);
+
+/*!
+    \ingroup SHA 
+    \brief  利便性機能は、すべてのハッシュを処理し、その結果をハッシュに入れます。
+    \return 0  うまく返されました...
+    \return Memory_E  メモリエラー、メモリを割り当てることができません。これは、小さなスタックオプションが有効になっているだけです。
+    \param data  ハッシュへのデータ
+    \param len  データの長さ
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wc_Sha256Hash
+    \sa wc_Sha256Final
+    \sa wc_InitSha256
+*/
+int wc_Sha256Hash(const byte* data, word32 len, byte* hash);
+
+/*!
+    \ingroup SHA 
+    \brief  利便性機能は、すべてのハッシュを処理し、その結果をハッシュに入れます。
+    \return 0  成功
+    \return <0  エラー
+    \param data  ハッシュへのデータ
+    \param len  データの長さ
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wc_InitSha224
+    \sa wc_Sha224Update
+    \sa wc_Sha224Final
+*/
+int wc_Sha224Hash(const byte* data, word32 len, byte* hash);
+
+/*!
+    \ingroup SHA 
+    \brief  利便性機能は、すべてのハッシュを処理し、その結果をハッシュに入れます。
+    \return 0  入力されたデータを正常にハッシュしたときに返されます
+    \return Memory_E  メモリエラー、メモリを割り当てることができません。これは、小さなスタックオプションが有効になっているだけです。
+    \param data  ハッシュへのデータ
+    \param len  データの長さ
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wc_Sha512Hash
+    \sa wc_Sha512Final
+    \sa wc_InitSha512
+*/
+int wc_Sha512Hash(const byte* data, word32 len, byte* hash);
+
+/*!
+    \ingroup SHA 
+    \brief  利便性機能は、すべてのハッシュを処理し、その結果をハッシュに入れます。
+    \return 0  データを正常にハッシュしたときに返されます
+    \return Memory_E  メモリエラー、メモリを割り当てることができません。これは、小さなスタックオプションが有効になっているだけです。
+    \param data  ハッシュへのデータ
+    \param len  データの長さ
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wc_Sha384Hash
+    \sa wc_Sha384Final
+    \sa wc_InitSha384
+*/
+int wc_Sha384Hash(const byte* data, word32 len, byte* hash);

--- a/doc/dox_comments/header_files-ja/hmac.h
+++ b/doc/dox_comments/header_files-ja/hmac.h
@@ -1,0 +1,115 @@
+/*!
+    \ingroup HMAC 
+    \brief  この関数はHMACオブジェクトを初期化し、その暗号化タイプ、キー、およびHMACの長さを設定します。
+    \return 0  HMACオブジェクトの初期化に成功しました
+    \return BAD_FUNC_ARG  入力タイプが無効な場合は返されます。有効なオプションは次のとおりです.MD5、SHA、SHA256、SHA384、SHA3-224、SHA3-256、SHA3-384、SHA3-512
+    \return MEMORY_E  ハッシュに使用する構造体の割り当てメモリの割り当てがある場合
+    \return HMAC_MIN_KEYLEN_E  FIPS実装を使用するときに返されることがあり、指定されたキー長は最小許容FIPS規格よりも短いです。
+    \param hmac  初期化するHMACオブジェクトへのポインタ
+    \param type  HMACオブジェクトを使用する暗号化方式を指定します。有効なオプションは次のとおりです.MD5、SHA、SHA256、SHA384、SHA3-224、SHA3-256、SHA3-384、SHA3-512
+    \param key  HMACオブジェクトを初期化するキーを含むバッファへのポインタ
+    _Example_
+    \code
+    Hmac hmac;
+    byte key[] = { // initialize with key to use for encryption };
+    if (wc_HmacSetKey(&hmac, MD5, key, sizeof(key)) != 0) {
+    	// error initializing Hmac object
+    }
+    \endcode
+    \sa wc_HmacUpdate
+    \sa wc_HmacFinal
+*/
+int wc_HmacSetKey(Hmac* hmac, int type, const byte* key, word32 keySz);
+
+/*!
+    \ingroup HMAC 
+    \brief  この関数は、HMACを使用して認証するメッセージを更新します。HMACオブジェクトがWC_HMACSETKEYで初期化された後に呼び出されるべきです。この関数は、ハッシュへのメッセージを更新するために複数回呼び出されることがあります。必要に応じてwc_hmacupdateを呼び出した後、最終認証済みメッセージタグを取得するためにwc_hmacfinalを呼び出す必要があります。
+    \return 0  認証するメッセージの更新に成功しました
+    \return MEMORY_E  ハッシュアルゴリズムで使用するためにメモリを割り当てるエラーがある場合
+    \param hmac  メッセージを更新するHMACオブジェクトへのポインタ
+    \param msg  追加するメッセージを含むバッファへのポインタ
+    _Example_
+    \code
+    Hmac hmac;
+    byte msg[] = { // initialize with message to authenticate };
+    byte msg2[] = { // initialize with second half of message };
+    // initialize hmac
+    if( wc_HmacUpdate(&hmac, msg, sizeof(msg)) != 0) {
+    	// error updating message
+    }
+    if( wc_HmacUpdate(&hmac, msg2, sizeof(msg)) != 0) {
+    	// error updating with second message
+    }
+    \endcode
+    \sa wc_HmacSetKey
+    \sa wc_HmacFinal
+*/
+int wc_HmacUpdate(Hmac* hmac, const byte* in, word32 sz);
+
+/*!
+    \ingroup HMAC 
+    \brief  この関数は、HMACオブジェクトのメッセージの最終ハッシュを計算します。
+    \return 0  最後のハッシュの計算に成功した
+    \return MEMORY_E  ハッシュアルゴリズムで使用するためにメモリを割り当てるエラーがある場合
+    \param hmac  最終ハッシュを計算するHMACオブジェクトへのポインタ
+    _Example_
+    \code
+    Hmac hmac;
+    byte hash[MD5_DIGEST_SIZE];
+    // initialize hmac with MD5 as type
+    // wc_HmacUpdate() with messages
+
+    if (wc_HmacFinal(&hmac, hash) != 0) {
+    	// error computing hash
+    }
+    \endcode
+    \sa wc_HmacSetKey
+    \sa wc_HmacUpdate
+*/
+int wc_HmacFinal(Hmac* hmac, byte* out);
+
+/*!
+    \ingroup HMAC 
+    \brief  この関数は、構成された暗号スイートに基づいて使用可能な最大のHMACダイジェストサイズを返します。
+    \return Success  設定された暗号スイートに基づいて使用可能な最大のHMACダイジェストサイズを返します
+    _Example_
+    \code
+    int maxDigestSz = wolfSSL_GetHmacMaxSize();
+    \endcode
+    \sa none
+*/
+int wolfSSL_GetHmacMaxSize(void);
+
+/*!
+    \ingroup HMAC 
+    \brief  この関数は、HMACキー導出機能（HKDF）へのアクセスを提供します。HMACを利用して、任意のSALTとオプションの情報を派生したキーに変換します。0またはNULLが指定されている場合、ハッシュ型はデフォルトでMD5になります。
+    \return 0  与えられた入力でキーの生成に成功したら返されます
+    \return BAD_FUNC_ARG  無効なハッシュ型が引数として指定されている場合に返されます。有効な型は次のとおりです.MD5、SHA、SHA256、SHA384、SHA3-224、SHA3-256、SHA3-384、SHA3-512
+    \return MEMORY_E  メモリの割り当て中にエラーが発生した場合に返されます
+    \return HMAC_MIN_KEYLEN_E  FIPS実装を使用するときに返されることがあり、指定されたキー長は最小許容FIPS規格よりも短いです。
+    \param type  HKDFに使用するハッシュタイプ。有効な型は次のとおりです.MD5、SHA、SHA256、SHA384、SHA3-224、SHA3-256、SHA3-384、SHA3-512
+    \param inKey  KDFに使用するキーを含むバッファへのポインタ
+    \param inKeySz  入力キーの長さ
+    \param salt  任意の塩を含む緩衝液へのポインタ。塩を使用しない場合は代わりにNULLを使用してください
+    \param saltSz  塩の長さ。塩を使用しない場合は0を使用してください
+    \param info  オプションの追加情報を含むバッファへのポインタ。追加情報を追加していない場合はNULLを使用してください
+    \param infoSz  追加情報の長さ追加情報を使用しない場合は0を使用してください
+    \param out  派生キーを保存するバッファへのポインタ
+    _Example_
+    \code
+    byte key[] = { // initialize with key };
+    byte salt[] = { // initialize with salt };
+    byte derivedKey[MAX_DIGEST_SIZE];
+
+    int ret = wc_HKDF(SHA512, key, sizeof(key), salt, sizeof(salt),
+    NULL, 0, derivedKey, sizeof(derivedKey));
+    if ( ret != 0 ) {
+	    // error generating derived key
+    }
+    \endcode
+    \sa wc_HmacSetKey
+*/
+int wc_HKDF(int type, const byte* inKey, word32 inKeySz,
+                    const byte* salt, word32 saltSz,
+                    const byte* info, word32 infoSz,
+                    byte* out, word32 outSz);

--- a/doc/dox_comments/header_files-ja/iotsafe.h
+++ b/doc/dox_comments/header_files-ja/iotsafe.h
@@ -1,0 +1,352 @@
+/*!
+    \ingroup IoTSafe 
+    \brief  この関数は与えられたコンテキストでのIoTセーフサポートを有効にします。
+    \param ctx  IOTセーフサポートを有効にする必要があるWOLFSSL_CTXオブジェクトへのポインタ
+    \return 0  成功した
+    _Example_
+    \code
+    WOLFSSL_CTX *ctx;
+    ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method());
+    if (!ctx)
+        return NULL;
+    wolfSSL_CTX_iotsafe_enable(ctx);
+    \endcode
+    \sa wolfSSL_iotsafe_on
+    \sa wolfIoTSafe_SetCSIM_read_cb
+    \sa wolfIoTSafe_SetCSIM_write_cb
+*/
+int wolfSSL_CTX_iotsafe_enable(WOLFSSL_CTX *ctx);
+
+
+/*!
+    \ingroup IoTSafe 
+    \brief  この関数は、IOT-SAFE TLSコールバックを特定のSSLセッションに接続します。
+    \brief  スロットのIDが1バイトの長さの場合、SSLセッションをIoT-Safeアプレットに接続するように呼び出す必要があります。IOTセーフスロットのIDが2バイト以上の場合、\ REF WOLFSSL_IOTSAFE_ON_EX「WOLFSSL_IOTSAFE_ON_EX（）」を使用する必要があります。
+    \param ssl  コールバックが有効になるWolfSSLオブジェクトへのポインタ
+    \param privkey_id  ホストの秘密鍵を含むIOTセーフなアプレットスロットのID
+    \param ecdh_keypair_slot  ECDH鍵ペアを保存するためのIoT安全アプレットスロットのID
+    \param peer_pubkey_slot  ECDH用の他のエンドポイントの公開鍵を保存するためのIOT-SAFEアプレットスロットのID
+    \param peer_cert_slot  検証のための他のエンドポイントの公開鍵を保存するためのIOTセーフなアプレットスロットのID
+    \return 0  成功すると
+    \return NOT_COMPILED_IN  habe_pk_callbacksが無効になっている場合
+    _Example_
+    \code
+    // Define key ids for IoT-Safe
+    #define PRIVKEY_ID 0x02
+    #define ECDH_KEYPAIR_ID 0x03
+    #define PEER_PUBKEY_ID 0x04
+    #define PEER_CERT_ID 0x05
+    // Create new ssl session
+    WOLFSSL *ssl;
+    ssl = wolfSSL_new(ctx);
+    if (!ssl)
+        return NULL;
+    // Enable IoT-Safe and associate key slots
+    ret = wolfSSL_CTX_iotsafe_enable(ctx);
+    if (ret == 0) {
+        ret = wolfSSL_iotsafe_on(ssl, PRIVKEY_ID, ECDH_KEYPAIR_ID, PEER_PUBKEY_ID, PEER_CERT_ID);
+    }
+    \endcode
+    \sa wolfSSL_iotsafe_on_ex
+    \sa wolfSSL_CTX_iotsafe_enable
+*/
+int wolfSSL_iotsafe_on(WOLFSSL *ssl, byte privkey_id,
+       byte ecdh_keypair_slot, byte peer_pubkey_slot, byte peer_cert_slot);
+
+
+/*!
+    \ingroup IoTSafe 
+    \brief  この関数は、IOT-SAFE TLSコールバックを特定のSSLセッションに接続します。これは、IOTセーフスロットのIDを参照で渡すことができ、IDフィールドの長さをパラメータ "id_size"で指定できます。
+    \param ssl  コールバックが有効になるWolfSSLオブジェクトへのポインタ
+    \param privkey_id  ホストの秘密鍵を含むIoTセーフアプレットスロットのIDへのポインタ
+    \param ecdh_keypair_slot  ECDH鍵ペアを保存するIOT-SafeアプレットスロットのIDへのポインタ
+    \param peer_pubkey_slot  ECDH用の他のエンドポイントの公開鍵を保存するIOTセーフアプレットスロットのIDへのポインタ
+    \param peer_cert_slot  検証のために他のエンドポイントの公開鍵を保存するためのIOT-SAFEアプレットスロットのIDへのポインタ
+    \param id_size  各スロットIDのサイズ
+    \return 0  成功すると
+    \return NOT_COMPILED_IN  habe_pk_callbacksが無効になっている場合
+    _Example_
+    \code
+    // Define key ids for IoT-Safe (16 bit, little endian)
+    #define PRIVKEY_ID 0x0201
+    #define ECDH_KEYPAIR_ID 0x0301
+    #define PEER_PUBKEY_ID 0x0401
+    #define PEER_CERT_ID 0x0501
+    #define ID_SIZE (sizeof(word16))
+
+    word16 privkey = PRIVKEY_ID,
+             ecdh_keypair = ECDH_KEYPAIR_ID,
+             peer_pubkey = PEER_PUBKEY_ID,
+             peer_cert = PEER_CERT_ID;
+
+
+
+    // Create new ssl session
+    WOLFSSL *ssl;
+    ssl = wolfSSL_new(ctx);
+    if (!ssl)
+        return NULL;
+    // Enable IoT-Safe and associate key slots
+    ret = wolfSSL_CTX_iotsafe_enable(ctx);
+    if (ret == 0) {
+        ret = wolfSSL_CTX_iotsafe_on_ex(ssl, &privkey, &ecdh_keypair, &peer_pubkey, &peer_cert, ID_SIZE);
+    }
+    \endcode
+    \sa wolfSSL_iotsafe_on
+    \sa wolfSSL_CTX_iotsafe_enable
+*/
+int wolfSSL_iotsafe_on_ex(WOLFSSL *ssl, byte *privkey_id,
+       byte *ecdh_keypair_slot, byte *peer_pubkey_slot, byte *peer_cert_slot, word16 id_size);
+
+
+/*!
+    \ingroup IoTSafe 
+    \brief  AT + CSIMコマンドのリードコールバックを関連付けます。この入力関数は通常、モデムと通信するUARTチャネルの読み取りイベントに関連付けられています。読み取りコールバックが関連付けられているのは、同時にIoT-Safeサポートを使用するすべてのコンテキストのグローバルと変更です。
+    _Example_
+    \code
+
+    // USART read function, defined elsewhere
+    int usart_read(char *buf, int len);
+
+    wolfIoTSafe_SetCSIM_read_cb(usart_read);
+
+    \endcode
+    \sa wolfIoTSafe_SetCSIM_write_cb
+*/
+void wolfIoTSafe_SetCSIM_read_cb(wolfSSL_IOTSafe_CSIM_read_cb rf);
+
+/*!
+    \ingroup IoTSafe 
+    \brief  AT + CSIMコマンドの書き込みコールバックを関連付けます。この出力関数は通常、モデムと通信するUARTチャネル上のライトイベントに関連付けられています。Write Callbackが関連付けられているのは、同時にIoT-Safeサポートを使用するすべてのコンテキストのグローバルと変更です。
+    _Example_
+    \code
+    // USART write function, defined elsewhere
+    int usart_write(const char *buf, int len);
+    wolfIoTSafe_SetCSIM_write_cb(usart_write);
+    \endcode
+    \sa wolfIoTSafe_SetCSIM_read_cb
+*/
+void wolfIoTSafe_SetCSIM_write_cb(wolfSSL_IOTSafe_CSIM_write_cb wf);
+
+
+
+/*!
+    \ingroup IoTSafe 
+    \brief  IOTセーフ機能getrandomを使用して、指定されたサイズのランダムなバッファを生成します。この関数は、WolfCrypt RNGオブジェクトによって自動的に使用されます。
+    \param out  ランダムなバイトシーケンスが格納されているバッファ。
+    \param sz  生成するランダムシーケンスのサイズ（バイト単位）
+*/
+int wolfIoTSafe_GetRandom(unsigned char* out, word32 sz);
+
+
+/*!
+    \ingroup IoTSafe 
+    \brief  IOT-Safeアプレット上のファイルに保存されている証明書をインポートし、ローカルにメモリに保存します。1バイトのファイルIDフィールドで動作します。
+    \param id  証明書が保存されているIOTセーフ・アプレットのファイルID
+    \param output  証明書がインポートされるバッファー
+    \param sz  バッファ出力で使用可能な最大サイズ
+    \return the  輸入された証明書の長さ
+    _Example_
+    \code
+    #define CRT_CLIENT_FILE_ID 0x03
+    unsigned char cert_buffer[2048];
+    // Get the certificate into the buffer
+    cert_buffer_size = wolfIoTSafe_GetCert(CRT_CLIENT_FILE_ID, cert_buffer, 2048);
+    if (cert_buffer_size < 1) {
+        printf("Bad cli cert\n");
+        return -1;
+    }
+    printf("Loaded Client certificate from IoT-Safe, size = %lu\n", cert_buffer_size);
+
+    // Use the certificate buffer as identity for the TLS client context
+    if (wolfSSL_CTX_use_certificate_buffer(cli_ctx, cert_buffer,
+                cert_buffer_size, SSL_FILETYPE_ASN1) != SSL_SUCCESS) {
+        printf("Cannot load client cert\n");
+        return -1;
+    }
+    printf("Client certificate successfully imported.\n");
+    \endcode
+*/
+int wolfIoTSafe_GetCert(uint8_t id, unsigned char *output, unsigned long sz);
+
+
+/*!
+    \ingroup IoTSafe 
+    \brief  IOT-Safeアプレット上のファイルに保存されている証明書をインポートし、ローカルにメモリに保存します。\ ref wolfiotsafe_getcert "wolfiotsafe_getcert"と同等です。ただし、2バイト以上のファイルIDで呼び出すことができます。
+    \param id  証明書が保存されているIOT-SAFEアプレットのファイルIDへのポインタ
+    \param id_sz  ファイルIDのサイズ：バイト数
+    \param output  証明書がインポートされるバッファー
+    \param sz  バッファ出力で使用可能な最大サイズ
+    \return the  輸入された証明書の長さ
+    _Example_
+    \code
+    #define CRT_CLIENT_FILE_ID 0x0302
+    #define ID_SIZE (sizeof(word16))
+    unsigned char cert_buffer[2048];
+    word16 client_file_id = CRT_CLIENT_FILE_ID;
+
+
+
+    // Get the certificate into the buffer
+    cert_buffer_size = wolfIoTSafe_GetCert_ex(&client_file_id, ID_SIZE, cert_buffer, 2048);
+    if (cert_buffer_size < 1) {
+        printf("Bad cli cert\n");
+        return -1;
+    }
+    printf("Loaded Client certificate from IoT-Safe, size = %lu\n", cert_buffer_size);
+
+    // Use the certificate buffer as identity for the TLS client context
+    if (wolfSSL_CTX_use_certificate_buffer(cli_ctx, cert_buffer,
+                cert_buffer_size, SSL_FILETYPE_ASN1) != SSL_SUCCESS) {
+        printf("Cannot load client cert\n");
+        return -1;
+    }
+    printf("Client certificate successfully imported.\n");
+    \endcode
+*/
+int wolfIoTSafe_GetCert_ex(uint8_t *id, uint16_t id_sz, unsigned char *output, unsigned long sz);
+
+/*!
+    \ingroup IoTSafe 
+    \brief  IOTセーフアプレットに格納されているECC 256ビットの公開鍵をECC_Keyオブジェクトにインポートします。
+    \param key  IOT-SAFEアプレットからインポートされたキーを含むECC_KEYオブジェクト
+    \param id  公開鍵が保存されているIOTセーフアプレットのキーID
+    \return 0  成功すると
+    \sa wc_iotsafe_ecc_export_public
+    \sa wc_iotsafe_ecc_export_private
+*/
+int wc_iotsafe_ecc_import_public(ecc_key *key, byte key_id);
+
+/*!
+    \ingroup IoTSafe 
+    \brief  ECC_KEYオブジェクトからIOT-SAFEアプレットへの書き込み可能なパブリックキースロットにECC 256ビット公開鍵をエクスポートします。
+    \param key  エクスポートする鍵を含むecc_keyオブジェクト
+    \param id  公開鍵が保存されているIOTセーフアプレットのキーID
+    \return 0  成功すると
+    \sa wc_iotsafe_ecc_import_public_ex
+    \sa wc_iotsafe_ecc_export_private
+*/
+int wc_iotsafe_ecc_export_public(ecc_key *key, byte key_id);
+
+
+/*!
+    \ingroup IoTSafe 
+    \brief  ECC_KEYオブジェクトからIOT-SAFEアプレットへの書き込み可能なパブリックキースロットにECC 256ビット公開鍵をエクスポートします。\ ref WC_IOTSAFE_ECC_IMPORT_PUBLIC「WC_IOTSAFE_ECC_IMPORT_PUBLIC」と同等のものは、2バイト以上のキーIDで呼び出すことができる点を除きます。
+    \param key  エクスポートする鍵を含むecc_keyオブジェクト
+    \param id  公開鍵が保存されるIOTセーフアプレットのキーIDへのポインタ
+    \param id_size  キーIDサイズ
+    \return 0  成功すると
+    \sa wc_iotsafe_ecc_import_public
+    \sa wc_iotsafe_ecc_export_private
+*/
+int wc_iotsafe_ecc_import_public_ex(ecc_key *key, byte *key_id, word16 id_size);
+
+/*!
+    \ingroup IoTSafe 
+    \brief  ECC 256ビットキーをECC_KEYオブジェクトからIOTセーフアプレットに書き込み可能なプライベートキースロットにエクスポートします。
+    \param key  エクスポートする鍵を含むecc_keyオブジェクト
+    \param id  秘密鍵が保存されるIOTセーフアプレットのキーID
+    \return 0  成功すると
+    \sa wc_iotsafe_ecc_export_private_ex
+    \sa wc_iotsafe_ecc_import_public
+    \sa wc_iotsafe_ecc_export_public
+*/
+int wc_iotsafe_ecc_export_private(ecc_key *key, byte key_id);
+
+/*!
+    \ingroup IoTSafe 
+    \brief  ECC 256ビットキーをECC_KEYオブジェクトからIOTセーフアプレットに書き込み可能なプライベートキースロットにエクスポートします。\ ref WC_IOTSAFE_ECC_EXPORT_PRIVATE「WC_IOTSAFE_ECC_EXPORT_PRIVATE」を除き、2バイト以上のキーIDを呼び出すことができる点を除き、
+    \param key  エクスポートする鍵を含むecc_keyオブジェクト
+    \param id  秘密鍵が保存されるIOTセーフアプレットのキーIDへのポインタ
+    \param id_size  キーIDサイズ
+    \return 0  成功すると
+    \sa wc_iotsafe_ecc_export_private
+    \sa wc_iotsafe_ecc_import_public
+    \sa wc_iotsafe_ecc_export_public
+*/
+int wc_iotsafe_ecc_export_private_ex(ecc_key *key, byte *key_id, word16 id_size);
+
+/*!
+    \ingroup IoTSafe 
+    \brief  事前計算された256ビットハッシュに署名して、IOT-SAFEアプレットに、以前に保存されたプライベートキー、またはプリプロビジョニングされています。
+    \param in  サインするメッセージハッシュを含むバッファへのポインタ
+    \param inlen  署名するメッセージの長さ
+    \param out  生成された署名を保存するためのバッファ
+    \param outlen  出力バッファの最大長。バイトを保存します
+    \param id  メッセージ署名の生成に成功したときに書き込まれたペイロードに署名するための秘密鍵を含むスロットのIOTセーフアプレットのキーID
+    \return 0  成功すると
+    \sa wc_iotsafe_ecc_sign_hash_ex
+    \sa wc_iotsafe_ecc_verify_hash
+    \sa wc_iotsafe_ecc_gen_k
+*/
+int wc_iotsafe_ecc_sign_hash(byte *in, word32 inlen, byte *out, word32 *outlen, byte key_id);
+
+/*!
+    \ingroup IoTSafe 
+    \brief  事前計算された256ビットハッシュに署名して、IOT-SAFEアプレットに、以前に保存されたプライベートキー、またはプリプロビジョニングされています。\ ref wc_iotsafe_ecc_sign_hash "wc_iotsafe_ecc_sign_hash"と同等です。ただし、2バイト以上のキーIDで呼び出すことができます。
+    \param in  サインするメッセージハッシュを含むバッファへのポインタ
+    \param inlen  署名するメッセージの長さ
+    \param out  生成された署名を保存するためのバッファ
+    \param outlen  出力バッファの最大長。バイトを保存します
+    \param id  秘密鍵を含むスロットのIOT-SAFEアプレットのキーIDへのポインタメッセージ署名の生成に成功したときに書き込まれるペイロードに署名する
+    \param id_size  キーIDサイズ
+    \return 0  成功すると
+    \sa wc_iotsafe_ecc_sign_hash
+    \sa wc_iotsafe_ecc_verify_hash
+    \sa wc_iotsafe_ecc_gen_k
+*/
+int wc_iotsafe_ecc_sign_hash_ex(byte *in, word32 inlen, byte *out, word32 *outlen, byte *key_id, word16 id_size);
+
+/*!
+    \ingroup IoTSafe 
+    \brief  予め計算された256ビットハッシュに対するECCシグネチャを、IOT-SAFEアプレット内のプリプロビジョニング、またはプロビジョニングされたプリプロビジョニングを使用します。結果はRESに書き込まれます。1が有効で、0が無効です。注：有効なテストに戻り値を使用しないでください。Resのみを使用してください。
+    \return 0  成功すると（署名が無効であっても）
+    \return <  故障の場合は0
+    \param sig  検証する署名を含むバッファ
+    \param hash  署名されたハッシュ（メッセージダイジェスト）
+    \param hashlen  ハッシュの長さ（オクテット）
+    \param res  署名の結果、1 ==有効、0 ==無効
+    \sa wc_iotsafe_ecc_verify_hash_ex
+    \sa wc_iotsafe_ecc_sign_hash
+    \sa wc_iotsafe_ecc_gen_k
+*/
+int wc_iotsafe_ecc_verify_hash(byte *sig, word32 siglen, byte *hash, word32 hashlen, int *res, byte key_id);
+
+/*!
+    \ingroup IoTSafe 
+    \brief  予め計算された256ビットハッシュに対するECCシグネチャを、IOT-SAFEアプレット内のプリプロビジョニング、またはプロビジョニングされたプリプロビジョニングを使用します。結果はRESに書き込まれます。1が有効で、0が無効です。注：有効なテストに戻り値を使用しないでください。Resのみを使用してください。\ ref WC_IOTSAFE_ECC_VERIFY_HASH "WC_IOTSAFE_ECC_VERIFY_HASH"を除き、2バイト以上のキーIDで呼び出すことができる点を除きます。
+    \return 0  成功すると（署名が無効であっても）
+    \return <  故障の場合は0
+    \param sig  検証する署名を含むバッファ
+    \param hash  署名されたハッシュ（メッセージダイジェスト）
+    \param hashlen  ハッシュの長さ（オクテット）
+    \param res  署名の結果、1 ==有効、0 ==無効
+    \param key_id  パブリックECCキーがIOTセーフアプレットに保存されているスロットのID
+    \sa wc_iotsafe_ecc_verify_hash
+    \sa wc_iotsafe_ecc_sign_hash
+    \sa wc_iotsafe_ecc_gen_k
+*/
+int wc_iotsafe_ecc_verify_hash_ex(byte *sig, word32 siglen, byte *hash, word32 hashlen, int *res, byte *key_id, word16 id_size);
+
+/*!
+    \ingroup IoTSafe 
+    \brief  ECC 256ビットのキーペアを生成し、それを（書き込み可能な）スロットにIOTセーフなアプレットに保存します。
+    \param key_id  ECCキーペアがIOTセーフアプレットに格納されているスロットのID。
+    \return 0  成功すると
+    \sa wc_iotsafe_ecc_gen_k_ex
+    \sa wc_iotsafe_ecc_sign_hash
+    \sa wc_iotsafe_ecc_verify_hash
+*/
+int wc_iotsafe_ecc_gen_k(byte key_id);
+
+/*!
+    \ingroup IoTSafe 
+    \brief  ECC 256ビットのキーペアを生成し、それを（書き込み可能な）スロットにIOTセーフなアプレットに保存します。\ ref wc_iotsafe_ecc_gen_k "wc_iotsafe_ecc_gen_k"と同等です。ただし、2バイト以上のキーIDで呼び出すことができます。
+    \param key_id  ECCキーペアがIOTセーフアプレットに格納されているスロットのID。
+    \param id_size  キーIDサイズ
+    \return 0  成功すると
+    \sa wc_iotsafe_ecc_gen_k
+    \sa wc_iotsafe_ecc_sign_hash_ex
+    \sa wc_iotsafe_ecc_verify_hash_ex
+*/
+int wc_iotsafe_ecc_gen_k(byte key_id);

--- a/doc/dox_comments/header_files-ja/logging.h
+++ b/doc/dox_comments/header_files-ja/logging.h
@@ -1,0 +1,51 @@
+/*!
+    \ingroup Logging 
+    \brief  この関数は、WolfSSLログメッセージを処理するために使用されるロギングコールバックを登録します。デフォルトでは、システムがIT fprintf（）をSTDERRにサポートしている場合は、この関数を使用することによって、ユーザーによって何でも実行できます。
+    \return Success  成功した場合、この関数は0を返します。
+    \return BAD_FUNC_ARG  関数ポインタが提供されていない場合に返されるエラーです。
+    _Example_
+    \code
+    int ret = 0;
+    // Logging callback prototype
+    void MyLoggingCallback(const int logLevel, const char* const logMessage);
+    // Register the custom logging callback with wolfSSL
+    ret = wolfSSL_SetLoggingCb(MyLoggingCallback);
+    if (ret != 0) {
+	    // failed to set logging callback
+    }
+    void MyLoggingCallback(const int logLevel, const char* const logMessage)
+    {
+	// custom logging function
+    }
+    \endcode
+    \sa wolfSSL_Debugging_ON
+    \sa wolfSSL_Debugging_OFF
+*/
+int wolfSSL_SetLoggingCb(wolfSSL_Logging_cb log_function);
+
+/*!
+    \ingroup Debug 
+    \brief  ビルド時にロギングが有効になっている場合、この関数は実行時にロギングをオンにします。ビルド時にログ記録を有効にするには--enable-debugまたはdebug_wolfsslを定義します。
+    \return 0  成功すると。
+    \return NOT_COMPILED_IN  このビルドに対してロギングが有効になっていない場合は返されるエラーです。
+    _Example_
+    \code
+    wolfSSL_Debugging_ON();
+    \endcode
+    \sa wolfSSL_Debugging_OFF
+    \sa wolfSSL_SetLoggingCb
+*/
+int  wolfSSL_Debugging_ON(void);
+
+/*!
+    \ingroup Debug 
+    \brief  この関数はランタイムロギングメッセージをオフにします。彼らがすでに消えている場合は、行動はとられません。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    wolfSSL_Debugging_OFF();
+    \endcode
+    \sa wolfSSL_Debugging_ON
+    \sa wolfSSL_SetLoggingCb
+*/
+void wolfSSL_Debugging_OFF(void);

--- a/doc/dox_comments/header_files-ja/md2.h
+++ b/doc/dox_comments/header_files-ja/md2.h
@@ -1,0 +1,88 @@
+/*!
+    \ingroup MD2 
+    \brief  この関数はMD2を初期化します。これはWC_MD2HASHによって自動的に呼び出されます。
+    \return 0  初期化に成功したときに返されます
+    _Example_
+    \code
+    md2 md2[1];
+    if ((ret = wc_InitMd2(md2)) != 0) {
+       WOLFSSL_MSG("wc_Initmd2 failed");
+    }
+    else {
+       wc_Md2Update(md2, data, len);
+       wc_Md2Final(md2, hash);
+    }
+    \endcode
+    \sa wc_Md2Hash
+    \sa wc_Md2Update
+    \sa wc_Md2Final
+*/
+void wc_InitMd2(Md2*);
+
+/*!
+    \ingroup MD2 
+    \brief  長さLENの提供されたバイト配列を絶えずハッシュするように呼び出すことができます。
+    \return 0  データをダイジェストに正常に追加すると返されます。
+    \param md2  暗号化に使用するMD2構造へのポインタ
+    \param data  ハッシュするデータ
+    _Example_
+    \code
+    md2 md2[1];
+    byte data[] = { }; // Data to be hashed
+    word32 len = sizeof(data);
+
+    if ((ret = wc_InitMd2(md2)) != 0) {
+       WOLFSSL_MSG("wc_Initmd2 failed");
+    }
+    else {
+       wc_Md2Update(md2, data, len);
+       wc_Md2Final(md2, hash);
+    }
+    \endcode
+    \sa wc_Md2Hash
+    \sa wc_Md2Final
+    \sa wc_InitMd2
+*/
+void wc_Md2Update(Md2* md2, const byte* data, word32 len);
+
+/*!
+    \ingroup MD2 
+    \brief  データのハッシュを確定します。結果はハッシュに入れられます。
+    \return 0  ファイナライズに成功したときに返されます。
+    \param md2  暗号化に使用するMD2構造へのポインタ
+    _Example_
+    \code
+    md2 md2[1];
+    byte data[] = { }; // Data to be hashed
+    word32 len = sizeof(data);
+
+    if ((ret = wc_InitMd2(md2)) != 0) {
+       WOLFSSL_MSG("wc_Initmd2 failed");
+    }
+    else {
+       wc_Md2Update(md2, data, len);
+       wc_Md2Final(md2, hash);
+    }
+    \endcode
+    \sa wc_Md2Hash
+    \sa wc_Md2Final
+    \sa wc_InitMd2
+*/
+void wc_Md2Final(Md2* md2, byte* hash);
+
+/*!
+    \ingroup MD2 
+    \brief  利便性機能は、すべてのハッシュを処理し、その結果をハッシュに入れます。
+    \return 0  データを正常にハッシュしたときに返されます。
+    \return Memory_E  メモリエラー、メモリを割り当てることができません。これは、小さなスタックオプションが有効になっているだけです。
+    \param data  ハッシュへのデータ
+    \param len  データの長さ
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wc_Md2Hash
+    \sa wc_Md2Final
+    \sa wc_InitMd2
+*/
+int  wc_Md2Hash(const byte* data, word32 len, byte* hash);

--- a/doc/dox_comments/header_files-ja/md4.h
+++ b/doc/dox_comments/header_files-ja/md4.h
@@ -1,0 +1,68 @@
+/*!
+    \ingroup MD4 
+    \brief  この関数はMD4を初期化します。これはWC_MD4HASHによって自動的に呼び出されます。
+    \return 0  初期化に成功したときに返されます
+    _Example_
+    \code
+    md4 md4[1];
+    if ((ret = wc_InitMd4(md4)) != 0) {
+       WOLFSSL_MSG("wc_Initmd4 failed");
+    }
+    else {
+       wc_Md4Update(md4, data, len);
+       wc_Md4Final(md4, hash);
+    }
+    \endcode
+    \sa wc_Md4Hash
+    \sa wc_Md4Update
+    \sa wc_Md4Final
+*/
+void wc_InitMd4(Md4*);
+
+/*!
+    \ingroup MD4 
+    \brief  長さLENの提供されたバイト配列を絶えずハッシュするように呼び出すことができます。
+    \return 0  データをダイジェストに正常に追加すると返されます。
+    \param md4  暗号化に使用するMD4構造へのポインタ
+    \param data  ハッシュするデータ
+    _Example_
+    \code
+    md4 md4[1];
+    byte data[] = { }; // Data to be hashed
+    word32 len = sizeof(data);
+
+    if ((ret = wc_InitMd4(md4)) != 0) {
+       WOLFSSL_MSG("wc_Initmd4 failed");
+    }
+    else {
+       wc_Md4Update(md4, data, len);
+       wc_Md4Final(md4, hash);
+    }
+    \endcode
+    \sa wc_Md4Hash
+    \sa wc_Md4Final
+    \sa wc_InitMd4
+*/
+void wc_Md4Update(Md4* md4, const byte* data, word32 len);
+
+/*!
+    \ingroup MD4 
+    \brief  データのハッシュを確定します。結果はハッシュに入れられます。
+    \return 0  ファイナライズに成功したときに返されます。
+    \param md4  暗号化に使用するMD4構造へのポインタ
+    _Example_
+    \code
+    md4 md4[1];
+    if ((ret = wc_InitMd4(md4)) != 0) {
+        WOLFSSL_MSG("wc_Initmd4 failed");
+    }
+    else {
+        wc_Md4Update(md4, data, len);
+        wc_Md4Final(md4, hash);
+    }
+    \endcode
+    \sa wc_Md4Hash
+    \sa wc_Md4Final
+    \sa wc_InitMd4
+*/
+void wc_Md4Final(Md4* md4, byte* hash);

--- a/doc/dox_comments/header_files-ja/md5.h
+++ b/doc/dox_comments/header_files-ja/md5.h
@@ -1,0 +1,140 @@
+/*!
+    \ingroup MD5 
+    \brief  この関数はMD5を初期化します。これはWC_MD5HASHによって自動的に呼び出されます。
+    \return 0  初期化に成功したときに返されます。
+    \return BAD_FUNC_ARG  MD5構造がNULL値として渡された場合に返されます。
+    _Example_
+    \code
+    Md5 md5;
+    byte* hash;
+    if ((ret = wc_InitMd5(&md5)) != 0) {
+       WOLFSSL_MSG("wc_Initmd5 failed");
+    }
+    else {
+       ret = wc_Md5Update(&md5, data, len);
+       if (ret != 0) {
+    	 // Md5 Update Failure Case.
+       }
+       ret = wc_Md5Final(&md5, hash);
+      if (ret != 0) {
+    	// Md5 Final Failure Case.
+      }
+    }
+    \endcode
+    \sa wc_Md5Hash
+    \sa wc_Md5Update
+    \sa wc_Md5Final
+*/
+int wc_InitMd5(wc_Md5*);
+
+/*!
+    \ingroup MD5 
+    \brief  長さLENの提供されたバイト配列を絶えずハッシュするように呼び出すことができます。
+    \return 0  データをダイジェストに正常に追加すると返されます。
+    \return BAD_FUNC_ARG  MD5構造がNULLの場合、またはデータがNULLで、LENがゼロより大きい場合に返されます。DATAパラメーターがNULLでLENがゼロの場合、関数はエラーを返してはいけません。
+    \param md5  暗号化に使用するMD5構造へのポインタ
+    \param data  ハッシュするデータ
+    _Example_
+    \code
+    Md5 md5;
+    byte data[] = { Data to be hashed };
+    word32 len = sizeof(data);
+
+    if ((ret = wc_InitMd5(&md5)) != 0) {
+       WOLFSSL_MSG("wc_Initmd5 failed");
+    }
+    else {
+       ret = wc_Md5Update(&md5, data, len);
+       if (ret != 0) {
+    	 // Md5 Update Error Case.
+       }
+       ret = wc_Md5Final(&md5, hash);
+       if (ret != 0) {
+    	// Md5 Final Error Case.
+       }
+    }
+    \endcode
+    \sa wc_Md5Hash
+    \sa wc_Md5Final
+    \sa wc_InitMd5
+*/
+int wc_Md5Update(wc_Md5* md5, const byte* data, word32 len);
+
+/*!
+    \ingroup MD5 
+    \brief  データのハッシュを確定します。結果はハッシュに入れられます。MD5構造体がリセットされます。注：この関数は、habe_intel_qaが定義されている場合にintelqasymmd5（）を呼び出す結果も返します。
+    \return 0  ファイナライズに成功したときに返されます。
+    \return BAD_FUNC_ARG  MD5構造またはハッシュポインタがNULLで渡された場合に返されます。
+    \param md5  暗号化に使用するMD5構造へのポインタ
+    _Example_
+    \code
+    md5 md5[1];
+    byte data[] = { Data to be hashed };
+    word32 len = sizeof(data);
+
+    if ((ret = wc_InitMd5(md5)) != 0) {
+       WOLFSSL_MSG("wc_Initmd5 failed");
+    }
+    else {
+       ret = wc_Md5Update(md5, data, len);
+       if (ret != 0) {
+    	// Md5 Update Failure Case.
+       }
+      ret = wc_Md5Final(md5, hash);
+       if (ret != 0) {
+	    // Md5 Final Failure Case.
+       }
+    }
+    \endcode
+    \sa wc_Md5Hash
+    \sa wc_InitMd5
+    \sa wc_Md5GetHash
+*/
+int wc_Md5Final(wc_Md5* md5, byte* hash);
+
+/*!
+    \ingroup MD5 
+    \brief  MD5構造をリセットします。注：これは、wolfssl_ti_hashが定義されている場合にのみサポートされています。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    Md5 md5;
+    byte data[] = { Data to be hashed };
+    word32 len = sizeof(data);
+
+    if ((ret = wc_InitMd5(&md5)) != 0) {
+        WOLFSSL_MSG("wc_InitMd5 failed");
+    }
+    else {
+        wc_Md5Update(&md5, data, len);
+        wc_Md5Final(&md5, hash);
+        wc_Md5Free(&md5);
+    }
+    \endcode
+    \sa wc_InitMd5
+    \sa wc_Md5Update
+    \sa wc_Md5Final
+*/
+void wc_Md5Free(wc_Md5*);
+
+/*!
+    \ingroup MD5 
+    \brief  ハッシュデータを取得します。結果はハッシュに入れられます。MD5構造はリセットされません。
+    \return none  いいえリターン
+    \param md5  暗号化に使用するMD5構造へのポインタ。
+    _Example_
+    \code
+    md5 md5[1];
+    if ((ret = wc_InitMd5(md5)) != 0) {
+       WOLFSSL_MSG("wc_Initmd5 failed");
+    }
+    else {
+       wc_Md5Update(md5, data, len);
+       wc_Md5GetHash(md5, hash);
+    }
+    \endcode
+    \sa wc_Md5Hash
+    \sa wc_Md5Final
+    \sa wc_InitMd5
+*/
+int  wc_Md5GetHash(wc_Md5* md5, byte* hash);

--- a/doc/dox_comments/header_files-ja/memory.h
+++ b/doc/dox_comments/header_files-ja/memory.h
@@ -1,0 +1,145 @@
+/*!
+    \ingroup Memory 
+    \brief  この関数はmalloc（）と似ていますが、WolfSSLが使用するように構成されているメモリ割り当て関数を呼び出します。デフォルトでは、WolfSSLはmalloc（）を使用します。これは、WolfSSLメモリ抽象化レイヤを使用して変更できます -  wolfssl_setAllocator（）を参照してください。注WOLFSSL_MALLOCは、WOLFSSLによって直接呼び出されませんが、代わりにMacro XMallocによって呼び出されます。デフォルトのビルドの場合、size引数のみが存在します。wolfssl_static_memoryビルドを使用する場合は、ヒープとタイプ引数が含まれます。
+    \return pointer  成功した場合、この関数は割り当てられたメモリへのポインタを返します。
+    \return error  エラーがある場合は、NULLが返されます。
+    \param size  割り当てるメモリのサイズ（バイト）
+    \param heap  メモリに使用するヒントヒント。nullになることができます
+    _Example_
+    \code
+    int* tenInts = (int*)wolfSSL_Malloc(sizeof(int)*10);
+    \endcode
+    \sa wolfSSL_Free
+    \sa wolfSSL_Realloc
+    \sa wolfSSL_SetAllocators
+    \sa XMALLOC
+    \sa XFREE
+    \sa XREALLOC
+*/
+void* wolfSSL_Malloc(size_t size, void* heap, int type);
+
+/*!
+    \ingroup Memory 
+    \brief  この関数はfree（）と似ていますが、WolfSSLが使用するように構成されているメモリフリー機能を呼び出します。デフォルトでは、WolfSSLはfree（）を使用します。これは、WolfSSLメモリ抽象化レイヤを使用して変更できます -  wolfssl_setAllocator（）を参照してください。注WOLFSSL_FREEはWOLFSSLによって直接呼び出されませんが、代わりにマクロXFreeによって呼び出されます。デフォルトのビルドの場合、PTR引数のみが存在します。wolfssl_static_memoryビルドを使用する場合は、ヒープとタイプ引数が含まれます。
+    \return none  いいえ返します。
+    \param ptr  解放されるメモリへのポインタ。
+    \param heap  メモリに使用するヒントヒント。nullになることができます
+    _Example_
+    \code
+    int* tenInts = (int*)wolfSSL_Malloc(sizeof(int)*10);
+    // process data as desired
+    ...
+    if(tenInts) {
+    	wolfSSL_Free(tenInts);
+    }
+    \endcode
+    \sa wolfSSL_Alloc
+    \sa wolfSSL_Realloc
+    \sa wolfSSL_SetAllocators
+    \sa XMALLOC
+    \sa XFREE
+    \sa XREALLOC
+*/
+void  wolfSSL_Free(void *ptr, void* heap, int type);
+
+/*!
+    \ingroup Memory 
+    \brief  この関数はREALLOC（）と似ていますが、WolfSSLが使用するように構成されているメモリ再割り当て機能を呼び出します。デフォルトでは、WolfSSLはRealLoc（）を使用します。これは、WolfSSLメモリ抽象化レイヤを使用して変更できます -  wolfssl_setAllocator（）を参照してください。注WOLFSSL_REALLOCはWOLFSSLによって直接呼び出されませんが、代わりにマクロXreallocによって呼び出されます。デフォルトのビルドの場合、size引数のみが存在します。wolfssl_static_memoryビルドを使用する場合は、ヒープとタイプ引数が含まれます。
+    \return pointer  成功した場合、この関数はマイポイントを再割り当てするためのポインタを返します。これはPTRと同じポインタ、または新しいポインタの場所であり得る。
+    \return Null  エラーがある場合は、NULLが返されます。
+    \param ptr  再割り当てされているメモリへのポインタ。
+    \param size  割り当てるバイト数。
+    \param heap  メモリに使用するヒントヒント。nullになることができます
+    _Example_
+    \code
+    int* tenInts = (int*)wolfSSL_Malloc(sizeof(int)*10);
+    int* twentyInts = (int*)wolfSSL_Realloc(tenInts, sizeof(int)*20);
+    \endcode
+    \sa wolfSSL_Free
+    \sa wolfSSL_Malloc
+    \sa wolfSSL_SetAllocators
+    \sa XMALLOC
+    \sa XFREE
+    \sa XREALLOC
+*/
+void* wolfSSL_Realloc(void *ptr, size_t size, void* heap, int type);
+
+/*!
+    \ingroup Memory 
+    \brief  この機能は、WolfSSLが使用する割り当て関数を登録します。デフォルトでは、システムがそれをサポートしている場合、Malloc / FreeとRealLocが使用されます。この機能を使用すると、実行時にユーザーは独自のメモリハンドラをインストールできます。
+    \return Success  成功した場合、この関数は0を返します。
+    \return BAD_FUNC_ARG  関数ポインタが提供されていない場合に返されるエラーです。
+    \param malloc_function  使用するWolfSSLのメモリ割り当て機能関数署名は、上記のwolfssl_malloc_cbプロトタイプと一致する必要があります。
+    \param free_function  使用するWolfSSLのメモリフリー機能関数シグネチャは、上記のwolfssl_free_cbプロトタイプと一致する必要があります。
+    _Example_
+    \code
+    static void* MyMalloc(size_t size)
+    {
+    	// custom malloc function
+    }
+
+    static void MyFree(void* ptr)
+    {
+    	// custom free function
+    }
+
+    static void* MyRealloc(void* ptr, size_t size)
+    {
+    	// custom realloc function
+    }
+
+    // Register custom memory functions with wolfSSL
+    int ret = wolfSSL_SetAllocators(MyMalloc, MyFree, MyRealloc);
+    if (ret != 0) {
+    	// failed to set memory functions
+    }
+    \endcode
+    \sa none
+*/
+int wolfSSL_SetAllocators(wolfSSL_Malloc_cb,
+                                      wolfSSL_Free_cb,
+                                      wolfSSL_Realloc_cb);
+
+/*!
+    \ingroup Memory 
+    \brief  この機能は、静的メモリ機能が使用されている場合（--enable-staticMemory）の場合に使用できます。メモリの「バケット」に最適なバッファサイズを示します。これにより、パーティション化された後に追加の未使用のメモリが終了しないように、バッファサイズを計算する方法が可能になります。返された値は、正の場合、使用するコンピュータのバッファサイズです。
+    \return Success  バッファサイズ計算を正常に完了すると、正の値が返されます。この返された値は最適なバッファサイズです。
+    \return Failure  すべての負の値はエラーの場合と見なされます。
+    \param buffer  バッファへのポインタ
+    \param size  バッファのサイズ
+    _Example_
+    \code
+    byte buffer[1000];
+    word32 size = sizeof(buffer);
+    int optimum;
+    optimum = wolfSSL_StaticBufferSz(buffer, size, WOLFMEM_GENERAL);
+    if (optimum < 0) { //handle error case }
+    printf(“The optimum buffer size to make use of all memory is %d\n”,
+    optimum);
+    ...
+    \endcode
+    \sa wolfSSL_Malloc
+    \sa wolfSSL_Free
+*/
+int wolfSSL_StaticBufferSz(byte* buffer, word32 sz, int flag);
+
+/*!
+    \ingroup Memory 
+    \brief  この機能は、静的メモリ機能が使用されている場合（--enable-staticMemory）の場合に使用できます。メモリの各パーティションに必要なパディングのサイズを示します。このパディングサイズは、メモリアライメントのために追加のメモリ管理構造を含む必要があるサイズになります。
+    \return On  正常なメモリパディング計算戻り値は正の値になります
+    \return All  負の値はエラーケースと見なされます。
+    _Example_
+    \code
+    int padding;
+    padding = wolfSSL_MemoryPaddingSz();
+    if (padding < 0) { //handle error case }
+    printf(“The padding size needed for each \”bucket\” of memory is %d\n”,
+    padding);
+    // calculation of buffer for IO POOL size is number of buckets
+    // times (padding + WOLFMEM_IO_SZ)
+    ...
+    \endcode
+    \sa wolfSSL_Malloc
+    \sa wolfSSL_Free
+*/
+int wolfSSL_MemoryPaddingSz(void);

--- a/doc/dox_comments/header_files-ja/pem.h
+++ b/doc/dox_comments/header_files-ja/pem.h
@@ -1,0 +1,27 @@
+/*!
+    \ingroup openSSL 
+    \brief  この関数は、PEM形式のwolfssl_bio構造体にキーを書き込みます。
+    \return SSL_SUCCESS  成功すると。
+    \return SSL_FAILURE  失敗すると。
+    \param bio  wolfssl_bio構造体からPEMバッファを取得します。
+    \param key  PEM形式に変換するためのキー。
+    \param cipher  EVP暗号構造
+    \param passwd  パスワード。
+    \param len  パスワードの長さ
+    \param cb  パスワードコールバック
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    WOLFSSL_EVP_PKEY* key;
+    int ret;
+    // create bio and setup key
+    ret = wolfSSL_PEM_write_bio_PrivateKey(bio, key, NULL, NULL, 0, NULL, NULL);
+    //check ret value
+    \endcode
+    \sa wolfSSL_PEM_read_bio_X509_AUX
+*/
+
+int wolfSSL_PEM_write_bio_PrivateKey(WOLFSSL_BIO* bio, WOLFSSL_EVP_PKEY* key,
+                                        const WOLFSSL_EVP_CIPHER* cipher,
+                                        unsigned char* passwd, int len,
+                                        wc_pem_password_cb* cb, void* arg);

--- a/doc/dox_comments/header_files-ja/pkcs11.h
+++ b/doc/dox_comments/header_files-ja/pkcs11.h
@@ -1,0 +1,35 @@
+/*!
+*/
+int wc_Pkcs11_Initialize(Pkcs11Dev* dev, const char* library,
+                                     void* heap);
+
+/*!
+*/
+void wc_Pkcs11_Finalize(Pkcs11Dev* dev);
+
+/*!
+*/
+int wc_Pkcs11Token_Init(Pkcs11Token* token, Pkcs11Dev* dev,
+    int slotId, const char* tokenName, const unsigned char *userPin,
+    int userPinSz);
+
+/*!
+*/
+void wc_Pkcs11Token_Final(Pkcs11Token* token);
+
+/*!
+ */
+int wc_Pkcs11Token_Open(Pkcs11Token* token, int readWrite);
+
+/*!
+ */
+void wc_Pkcs11Token_Close(Pkcs11Token* token);
+
+/*!
+ */
+int wc_Pkcs11StoreKey(Pkcs11Token* token, int type, int clear,
+
+/*!
+ */
+int wc_Pkcs11_CryptoDevCb(int devId, wc_CryptoInfo* info,
+    void* ctx);

--- a/doc/dox_comments/header_files-ja/pkcs7.h
+++ b/doc/dox_comments/header_files-ja/pkcs7.h
@@ -1,0 +1,428 @@
+/*!
+    \ingroup PKCS7 
+    \brief  この関数は、DERフォーマットの証明書を使用してPKCS7構造を初期化します。空のPKCS7構造を初期化するには、NULL CERTとCERTSZの場合は0を渡すことができます。
+    \return 0  PKCS7構造の初期化に成功しました
+    \return MEMORY_E  xmallocでメモリを割り当てるエラーがある場合
+    \return ASN_PARSE_E  証明書ヘッダーの解析中にエラーがある場合
+    \return ASN_OBJECT_ID_E  証明書から暗号化タイプの解析中にエラーがある場合に返されます
+    \return ASN_EXPECT_0_E  CERTファイルの暗号化仕様にフォーマットエラーがある場合
+    \return ASN_BEFORE_DATE_E  日付が証明書開始日以前の場合返却
+    \return ASN_AFTER_DATE_E  日付が証明書の有効期限の後にある場合に返されます
+    \return ASN_BITSTR_E  証明書からビット文字列を解析したエラーがある場合に返されます。
+    \return ECC_CURVE_OID_E  証明書からECCキーの解析中にエラーがある場合
+    \return ASN_UNKNOWN_OID_E  証明書が不明なキーオブジェクトIDを使用している場合に返されます
+    \return ASN_VERSION_E  allow_v1_extensionsオプションが定義されておらず、証明書がV1またはV2の証明書の場合に返されます。
+    \return BAD_FUNC_ARG  証明書拡張機能の処理中にエラーがある場合
+    \return ASN_CRIT_EXT_E  証明書の処理中になじみのない重要な拡張機能が発生した場合に返されます。
+    \return ASN_SIG_OID_E  署名暗号化タイプが提供されたファイル内の証明書の暗号化タイプと同じでない場合に返されます。
+    \return ASN_SIG_CONFIRM_E  認証署名が失敗したことを確認した場合に返されます
+    \return ASN_NAME_INVALID_E  証明書の名前がCA名制約によって許可されていない場合に返されます。
+    \return ASN_NO_SIGNER_E  証明書の真正性を確認するためのCA署名者がない場合に返されました
+    \param pkcs7  デコードされた証明書を保存するPKCS7構造へのポインタ
+    \param cert  PKCS7構造を初期化するためのDERフォーマットのASN.1証明書を含むバッファへのポインタ
+    _Example_
+    \code
+    PKCS7 pkcs7;
+    byte derBuff[] = { }; // initialize with DER-encoded certificate
+    if ( wc_PKCS7_InitWithCert(&pkcs7, derBuff, sizeof(derBuff)) != 0 ) {
+    	// error parsing certificate into pkcs7 format
+    }
+    \endcode
+    \sa wc_PKCS7_Free
+*/
+int  wc_PKCS7_InitWithCert(PKCS7* pkcs7, byte* cert, word32 certSz);
+
+/*!
+    \ingroup PKCS7 
+    \brief  この関数は、PKCS7の初期化装置によって割り当てられたメモリを解放します。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    PKCS7 pkcs7;
+    // initialize and use PKCS7 object
+
+    wc_PKCS7_Free(pkcs7);
+    \endcode
+    \sa wc_PKCS7_InitWithCert
+*/
+void wc_PKCS7_Free(PKCS7* pkcs7);
+
+/*!
+    \ingroup PKCS7 
+    \brief  この関数はPKCS7データコンテンツタイプを構築し、PKCS7構造をパーセル可能なPKCS7データパケットを含むバッファにエンコードします。
+    \return Success  PKCS7データをバッファに正常にエンコードすると、PKCS7構造内の索引を返します。このインデックスは、出力バッファに書き込まれたバイトにも対応しています。
+    \return BUFFER_E  指定されたバッファがエンコードされた証明書を保持するのに十分な大きさでない場合に返されます
+    \param pkcs7  符号化するPKCS7構造へのポインタ
+    \param output  エンコードされた証明書を保存するバッファへのポインタ
+    _Example_
+    \code
+    PKCS7 pkcs7;
+    int ret;
+
+    byte derBuff[] = { }; // initialize with DER-encoded certificate
+    byte pkcs7Buff[FOURK_BUF];
+
+    wc_PKCS7_InitWithCert(&pkcs7, derBuff, sizeof(derBuff));
+    // update message and data to encode
+    pkcs7.privateKey = key;
+    pkcs7.privateKeySz = keySz;
+    pkcs7.content = data;
+    pkcs7.contentSz = dataSz;
+    ... etc.
+
+    ret = wc_PKCS7_EncodeData(&pkcs7, pkcs7Buff, sizeof(pkcs7Buff));
+    if ( ret != 0 ) {
+	    // error encoding into output buffer
+    }
+    \endcode
+    \sa wc_PKCS7_InitWithCert
+*/
+int  wc_PKCS7_EncodeData(PKCS7* pkcs7, byte* output,
+                                       word32 outputSz);
+
+/*!
+    \ingroup PKCS7 
+    \brief  この関数はPKCS7署名付きデータコンテンツタイプを構築し、PKCS7構造をPARSable PKCS7署名付きデータパケットを含むバッファにエンコードします。
+    \return Success  PKCS7データをバッファに正常にエンコードすると、PKCS7構造内の索引を返します。このインデックスは、出力バッファに書き込まれたバイトにも対応しています。
+    \return BAD_FUNC_ARG  PKCS7構造が署名付きデータパケットを生成するための1つ以上の要求要素が欠落している場合に返されます。
+    \return MEMORY_E  メモリの割り当て中にエラーが発生した場合に返されます
+    \return PUBLIC_KEY_E  公開鍵の解析中にエラーがある場合
+    \return RSA_BUFFER_E  バッファエラーが発生した場合は、小さすぎたり入力が大きすぎたりし過ぎました
+    \return BUFFER_E  指定されたバッファがエンコードされた証明書を保持するのに十分な大きさでない場合に返されます
+    \return MP_INIT_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_READ_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_CMP_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_INVMOD_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_EXPTMOD_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_MOD_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_MUL_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_ADD_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_MULMOD_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_TO_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_MEM  署名を生成するエラーがある場合は返却される可能性があります
+    \param pkcs7  符号化するPKCS7構造へのポインタ
+    \param output  エンコードされた証明書を保存するバッファへのポインタ
+    _Example_
+    \code
+    PKCS7 pkcs7;
+    int ret;
+
+    byte data[] = {}; // initialize with data to sign
+    byte derBuff[] = { }; // initialize with DER-encoded certificate
+    byte pkcs7Buff[FOURK_BUF];
+
+    wc_PKCS7_InitWithCert(&pkcs7, derBuff, sizeof(derBuff));
+    // update message and data to encode
+    pkcs7.privateKey = key;
+    pkcs7.privateKeySz = keySz;
+    pkcs7.content = data;
+    pkcs7.contentSz = dataSz;
+    pkcs7.hashOID = SHAh;
+    pkcs7.rng = &rng;
+    ... etc.
+
+    ret = wc_PKCS7_EncodeSignedData(&pkcs7, pkcs7Buff, sizeof(pkcs7Buff));
+    if ( ret != 0 ) {
+    	// error encoding into output buffer
+    }
+
+    wc_PKCS7_Free(&pkcs7);
+    \endcode
+    \sa wc_PKCS7_InitWithCert
+    \sa wc_PKCS7_VerifySignedData
+*/
+int  wc_PKCS7_EncodeSignedData(PKCS7* pkcs7,
+                                       byte* output, word32 outputSz);
+
+/*!
+    \ingroup PKCS7 
+    \brief  この関数は、PKCS7の署名付きデータコンテンツタイプを構築し、PKCS7構造をエンコードし、Parsable PKCS7署名付きデータパケットを含むヘッダーおよびフッターバッファにエンコードします。これにはコンテンツは含まれません。ハッシュを計算してデータに提供する必要があります
+    \return 0=Success 
+    \return BAD_FUNC_ARG  PKCS7構造が署名付きデータパケットを生成するための1つ以上の要求要素が欠落している場合に返されます。
+    \return MEMORY_E  メモリの割り当て中にエラーが発生した場合に返されます
+    \return PUBLIC_KEY_E  公開鍵の解析中にエラーがある場合
+    \return RSA_BUFFER_E  バッファエラーが発生した場合は、小さすぎたり入力が大きすぎたりし過ぎました
+    \return BUFFER_E  指定されたバッファがエンコードされた証明書を保持するのに十分な大きさでない場合に返されます
+    \return MP_INIT_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_READ_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_CMP_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_INVMOD_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_EXPTMOD_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_MOD_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_MUL_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_ADD_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_MULMOD_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_TO_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_MEM  署名を生成するエラーがある場合は返却される可能性があります
+    \param pkcs7  符号化するPKCS7構造へのポインタ
+    \param hashBuf  コンテンツデータの計算ハッシュへのポインタ
+    \param hashSz  ダイジェストのサイズ
+    \param outputHead  エンコードされた証明書ヘッダーを保存するバッファへのポインタ
+    \param outputHeadSz  出力ヘッダーバッファのサイズが入力され、実際のサイズを返します。
+    \param outputFoot  エンコードされた証明書フッターを保存するバッファへのポインタ
+    _Example_
+    \code
+    PKCS7 pkcs7;
+    int ret;
+    byte derBuff[] = { }; // initialize with DER-encoded certificate
+    byte data[] = {}; // initialize with data to sign
+    byte pkcs7HeadBuff[FOURK_BUF/2];
+    byte pkcs7FootBuff[FOURK_BUF/2];
+    word32 pkcs7HeadSz = (word32)sizeof(pkcs7HeadBuff);
+    word32 pkcs7FootSz = (word32)sizeof(pkcs7HeadBuff);
+    enum wc_HashType hashType = WC_HASH_TYPE_SHA;
+    byte   hashBuf[WC_MAX_DIGEST_SIZE];
+    word32 hashSz = wc_HashGetDigestSize(hashType);
+
+    wc_PKCS7_InitWithCert(&pkcs7, derBuff, sizeof(derBuff));
+    // update message and data to encode
+    pkcs7.privateKey = key;
+    pkcs7.privateKeySz = keySz;
+    pkcs7.content = NULL;
+    pkcs7.contentSz = dataSz;
+    pkcs7.hashOID = SHAh;
+    pkcs7.rng = &rng;
+    ... etc.
+
+    // calculate hash for content
+    ret = wc_HashInit(&hash, hashType);
+    if (ret == 0) {
+        ret = wc_HashUpdate(&hash, hashType, data, sizeof(data));
+        if (ret == 0) {
+            ret = wc_HashFinal(&hash, hashType, hashBuf);
+        }
+        wc_HashFree(&hash, hashType);
+    }
+
+    ret = wc_PKCS7_EncodeSignedData_ex(&pkcs7, hashBuf, hashSz, pkcs7HeadBuff, 
+        &pkcs7HeadSz, pkcs7FootBuff, &pkcs7FootSz);
+    if ( ret != 0 ) {
+        // error encoding into output buffer
+    }
+
+    wc_PKCS7_Free(&pkcs7);
+    \endcode
+    \sa wc_PKCS7_InitWithCert
+    \sa wc_PKCS7_VerifySignedData_ex
+*/
+int wc_PKCS7_EncodeSignedData_ex(PKCS7* pkcs7, const byte* hashBuf, 
+    word32 hashSz, byte* outputHead, word32* outputHeadSz, byte* outputFoot, 
+    word32* outputFootSz);
+
+/*!
+    \ingroup PKCS7 
+    \brief  この関数は、送信されたPKCS7の署名付きデータメッセージを取り、証明書リストと証明書失効リストを抽出してから署名を検証します。与えられたPKCS7構造に抽出されたコンテンツを格納します。
+    \return 0  メッセージから情報を抽出することに成功しました
+    \return BAD_FUNC_ARG  入力パラメータの1つが無効な場合は返されます
+    \return ASN_PARSE_E  与えられたPKIMSGから解析中のエラーがある場合に返されます
+    \return PKCS7_OID_E  与えられたPKIMSGが署名付きデータ型ではない場合に返されます
+    \return ASN_VERSION_E  PKCS7署名者情報がバージョン1ではない場合に返されます
+    \return MEMORY_E  メモリの割り当て中にエラーが発生した場合に返されます
+    \return PUBLIC_KEY_E  公開鍵の解析中にエラーがある場合
+    \return RSA_BUFFER_E  バッファエラーが発生した場合は、小さすぎたり入力が大きすぎたりし過ぎません
+    \return BUFFER_E  指定されたバッファがエンコードされた証明書を保持するのに十分な大きさでない場合に返されます
+    \return MP_INIT_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_READ_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_CMP_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_INVMOD_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_EXPTMOD_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_MOD_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_MUL_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_ADD_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_MULMOD_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_TO_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_MEM  署名を生成するエラーがある場合は返却される可能性があります
+    \param pkcs7  解析された証明書を保存するPKCS7構造へのポインタ
+    \param pkiMsg  署名されたメッセージを含むバッファへのポインタを検証および復号化する
+    _Example_
+    \code
+    PKCS7 pkcs7;
+    int ret;
+    byte pkcs7Buff[] = {}; // the PKCS7 signature
+
+    wc_PKCS7_InitWithCert(&pkcs7, NULL, 0);
+    // update message and data to encode
+    pkcs7.privateKey = key;
+    pkcs7.privateKeySz = keySz;
+    pkcs7.content = data;
+    pkcs7.contentSz = dataSz;
+    ... etc.
+
+    ret = wc_PKCS7_VerifySignedData(&pkcs7, pkcs7Buff, sizeof(pkcs7Buff));
+    if ( ret != 0 ) {
+    	// error encoding into output buffer
+    }
+
+    wc_PKCS7_Free(&pkcs7);
+    \endcode
+    \sa wc_PKCS7_InitWithCert
+    \sa wc_PKCS7_EncodeSignedData
+*/
+int  wc_PKCS7_VerifySignedData(PKCS7* pkcs7,
+                                       byte* pkiMsg, word32 pkiMsgSz);
+
+
+/*!
+    \ingroup PKCS7 
+    \brief  この機能は、送信されたPKCS7署名付きデータメッセージをHASH /ヘッダー/フッターとして取り出してから、証明書リストと証明書失効リストを抽出してから、署名を検証します。与えられたPKCS7構造に抽出されたコンテンツを格納します。
+    \return 0  メッセージから情報を抽出することに成功しました
+    \return BAD_FUNC_ARG  入力パラメータの1つが無効な場合は返されます
+    \return ASN_PARSE_E  与えられたPKIMSGから解析中のエラーがある場合に返されます
+    \return PKCS7_OID_E  与えられたPKIMSGが署名付きデータ型ではない場合に返されます
+    \return ASN_VERSION_E  PKCS7署名者情報がバージョン1ではない場合に返されます
+    \return MEMORY_E  メモリの割り当て中にエラーが発生した場合に返されます
+    \return PUBLIC_KEY_E  公開鍵の解析中にエラーがある場合
+    \return RSA_BUFFER_E  バッファエラーが発生した場合は、小さすぎたり入力が大きすぎたりし過ぎません
+    \return BUFFER_E  指定されたバッファがエンコードされた証明書を保持するのに十分な大きさでない場合に返されます
+    \return MP_INIT_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_READ_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_CMP_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_INVMOD_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_EXPTMOD_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_MOD_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_MUL_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_ADD_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_MULMOD_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_TO_E  署名を生成するエラーがある場合は返却される可能性があります
+    \return MP_MEM  署名を生成するエラーがある場合は返却される可能性があります
+    \param pkcs7  解析された証明書を保存するPKCS7構造へのポインタ
+    \param hashBuf  コンテンツデータの計算ハッシュへのポインタ
+    \param hashSz  ダイジェストのサイズ
+    \param pkiMsgHead  署名されたメッセージヘッダーを含むバッファへのポインタを検証およびデコードする
+    \param pkiMsgHeadSz  署名付きメッセージヘッダーのサイズ
+    \param pkiMsgFoot  署名されたメッセージフッターを含むバッファへのポインタを検証してデコードする
+    _Example_
+    \code
+    PKCS7 pkcs7;
+    int ret;
+    byte data[] = {}; // initialize with data to sign
+    byte pkcs7HeadBuff[] = {}; // initialize with PKCS7 header
+    byte pkcs7FootBuff[] = {}; // initialize with PKCS7 footer
+    enum wc_HashType hashType = WC_HASH_TYPE_SHA;
+    byte   hashBuf[WC_MAX_DIGEST_SIZE];
+    word32 hashSz = wc_HashGetDigestSize(hashType);
+
+    wc_PKCS7_InitWithCert(&pkcs7, NULL, 0);
+    // update message and data to encode
+    pkcs7.privateKey = key;
+    pkcs7.privateKeySz = keySz;
+    pkcs7.content = NULL;
+    pkcs7.contentSz = dataSz;
+    pkcs7.rng = &rng;
+    ... etc.
+
+    // calculate hash for content
+    ret = wc_HashInit(&hash, hashType);
+    if (ret == 0) {
+        ret = wc_HashUpdate(&hash, hashType, data, sizeof(data));
+        if (ret == 0) {
+            ret = wc_HashFinal(&hash, hashType, hashBuf);
+        }
+        wc_HashFree(&hash, hashType);
+    }
+
+    ret = wc_PKCS7_VerifySignedData_ex(&pkcs7, hashBuf, hashSz, pkcs7HeadBuff, 
+        sizeof(pkcs7HeadBuff), pkcs7FootBuff, sizeof(pkcs7FootBuff));
+    if ( ret != 0 ) {
+        // error encoding into output buffer
+    }
+
+    wc_PKCS7_Free(&pkcs7);
+    \endcode
+    \sa wc_PKCS7_InitWithCert
+    \sa wc_PKCS7_EncodeSignedData_ex
+*/
+int wc_PKCS7_VerifySignedData_ex(PKCS7* pkcs7, const byte* hashBuf, 
+    word32 hashSz, byte* pkiMsgHead, word32 pkiMsgHeadSz, byte* pkiMsgFoot, 
+    word32 pkiMsgFootSz);
+
+/*!
+    \ingroup PKCS7 
+    \brief  この関数は、PKCS7構造を編集し、PKCS7構造を符号化し、Parsable PKCS7エンベロープデータパケットを含むバッファに編集します。
+    \return Success  エンベロープデータ形式でメッセージを正常にエンコードする上で返信され、出力バッファに書き込まれたサイズを返します。
+    \return BAD_FUNC_ARG:  入力パラメータの1つが無効な場合、またはPKCS7構造が必要な要素を欠落している場合
+    \return ALGO_ID_E  pkcs7構造がサポートされていないアルゴリズムタイプを使用している場合に返されます。現在、DESBとDES3Bのみがサポートされています
+    \return BUFFER_E  与えられた出力バッファが小さすぎて出力データを保存する場合に返されます
+    \return MEMORY_E  メモリの割り当て中にエラーが発生した場合に返されます
+    \return RNG_FAILURE_E  暗号化の乱数発生器の初期化中にエラーがある場合
+    \return DRBG_FAILED  暗号化に使用される乱数発生器を使用して数字を生成するエラーが発生した場合
+    \param pkcs7  符号化するPKCS7構造へのポインタ
+    \param output  エンコードされた証明書を保存するバッファへのポインタ
+    _Example_
+    \code
+    PKCS7 pkcs7;
+    int ret;
+
+    byte derBuff[] = { }; // initialize with DER-encoded certificate
+    byte pkcs7Buff[FOURK_BUF];
+
+    wc_PKCS7_InitWithCert(&pkcs7, derBuff, sizeof(derBuff));
+    // update message and data to encode
+    pkcs7.privateKey = key;
+    pkcs7.privateKeySz = keySz;
+    pkcs7.content = data;
+    pkcs7.contentSz = dataSz;
+    ... etc.
+
+    ret = wc_PKCS7_EncodeEnvelopedData(&pkcs7, pkcs7Buff, sizeof(pkcs7Buff));
+    if ( ret != 0 ) {
+    	// error encoding into output buffer
+    }
+    \endcode
+    \sa wc_PKCS7_InitWithCert
+    \sa wc_PKCS7_DecodeEnvelopedData
+*/
+int  wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7,
+                                          byte* output, word32 outputSz);
+
+/*!
+    \ingroup PKCS7 
+    \brief  この関数はPKCS7エンベロープデータコンテンツタイプをアントラップして復号化し、メッセージを出力にデコードします。渡されたPKCS7オブジェクトの秘密鍵を使用してメッセージを復号化します。
+    \return On  メッセージから情報を抽出するには、出力に書き込まれたバイト数を返します。
+    \return BAD_FUNC_ARG  入力パラメータの1つが無効な場合は返されます
+    \return ASN_PARSE_E  与えられたPKIMSGから解析中のエラーがある場合に返されます
+    \return PKCS7_OID_E  与えられたPKIMSGがエンベロープデータ型ではない場合に返されます
+    \return ASN_VERSION_E  PKCS7署名者情報がバージョン0ではない場合に返されます
+    \return MEMORY_E  メモリの割り当て中にエラーが発生した場合に返されます
+    \return ALGO_ID_E  pkcs7構造がサポートされていないアルゴリズムタイプを使用している場合に返されます。現在、Signature Generation for Signature GenerationのRSAKを使用して、DESBとDES3Bのみが暗号化でサポートされています。
+    \return PKCS7_RECIP_E  提供された受信者と一致するエンベロープデータに受信者が見つからない場合
+    \return RSA_BUFFER_E  バッファエラーが原因でRSAシグネチャ検証中にエラーがある場合は、小さすぎたり入力が大きすぎたりすると元に戻されます。
+    \return MP_INIT_E  署名検証中にエラーがある場合は返却される可能性があります
+    \return MP_READ_E  署名検証中にエラーがある場合は返却される可能性があります
+    \return MP_CMP_E  署名検証中にエラーがある場合は返却される可能性があります
+    \return MP_INVMOD_E  署名検証中にエラーがある場合は返却される可能性があります
+    \return MP_EXPTMOD_E  署名検証中にエラーがある場合は返却される可能性があります
+    \return MP_MOD_E  署名検証中にエラーがある場合は返却される可能性があります
+    \return MP_MUL_E  署名検証中にエラーがある場合は返却される可能性があります
+    \return MP_ADD_E  署名検証中にエラーがある場合は返却される可能性があります
+    \return MP_MULMOD_E  署名検証中にエラーがある場合は返却される可能性があります
+    \return MP_TO_E  署名検証中にエラーがある場合は返却される可能性があります
+    \return MP_MEM  署名検証中にエラーがある場合は返却される可能性があります
+    \param pkcs7  エンベロープデータパッケージをデコードする秘密鍵を含むPKCS7構造へのポインタ
+    \param pkiMsg  エンベロープデータパッケージを含むバッファへのポインタ
+    \param pkiMsgSz  包み込まれたデータパッケージのサイズ
+    \param output  デコードされたメッセージを保存するバッファへのポインタ
+    _Example_
+    \code
+    PKCS7 pkcs7;
+    byte received[] = { }; // initialize with received enveloped message
+    byte decoded[FOURK_BUF];
+    int decodedSz;
+
+    // initialize pkcs7 with certificate
+    // update key
+    pkcs7.privateKey = key;
+    pkcs7.privateKeySz = keySz;
+
+    decodedSz = wc_PKCS7_DecodeEnvelopedData(&pkcs7, received,
+    sizeof(received),decoded, sizeof(decoded));
+    if ( decodedSz != 0 ) {
+    	// error decoding message
+    }
+    \endcode
+    \sa wc_PKCS7_InitWithCert
+    \sa wc_PKCS7_EncodeEnvelopedData
+*/
+int  wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
+                                          word32 pkiMsgSz, byte* output,
+                                          word32 outputSz);

--- a/doc/dox_comments/header_files-ja/poly1305.h
+++ b/doc/dox_comments/header_files-ja/poly1305.h
@@ -1,0 +1,101 @@
+/*!
+    \ingroup Poly1305 
+    \brief  この関数は、Poly1305コンテキスト構造のキーを設定し、ハッシュに初期化します。注：セキュリティを確保するために、WC_POLY1305FINALでメッセージハッシュを生成した後に新しいキーを設定する必要があります。
+    \return 0  キーを正常に設定し、Poly1305構造の初期化
+    \return BAD_FUNC_ARG  与えられたキーが32バイトの長さでない場合、またはPoly1305コンテキストがNULLの場合
+    \param ctx  初期化するためのPoly1305構造へのポインタ
+    \param key  ハッシュに使用する鍵を含むバッファへのポインタ
+    _Example_
+    \code
+    Poly1305 enc;
+    byte key[] = { initialize with 32 byte key to use for hashing };
+    wc_Poly1305SetKey(&enc, key, sizeof(key));
+    \endcode
+    \sa wc_Poly1305Update
+    \sa wc_Poly1305Final
+*/
+int wc_Poly1305SetKey(Poly1305* poly1305, const byte* key,
+                                  word32 kySz);
+
+/*!
+    \ingroup Poly1305 
+    \brief  この関数は、Poly1305構造を持つハッシュにメッセージを更新します。
+    \return 0  ハッシュへのメッセージの更新に成功しました
+    \return BAD_FUNC_ARG  Poly1305構造がNULLの場合に返されます
+    \param ctx  HASHにメッセージを更新するためのPoly1305構造へのポインタ
+    \param m  ハッシュに追加する必要があるメッセージを含むバッファへのポインタ
+    _Example_
+    \code
+    Poly1305 enc;
+    byte key[] = { }; // initialize with 32 byte key to use for encryption
+
+    byte msg[] = { }; // initialize with message to hash
+    wc_Poly1305SetKey(&enc, key, sizeof(key));
+
+    if( wc_Poly1305Update(key, msg, sizeof(msg)) != 0 ) {
+	    // error updating message to hash
+    }
+    \endcode
+    \sa wc_Poly1305SetKey
+    \sa wc_Poly1305Final
+*/
+int wc_Poly1305Update(Poly1305* poly1305, const byte* m, word32 bytes);
+
+/*!
+    \ingroup Poly1305 
+    \brief  この関数は入力メッセージのハッシュを計算し、結果をMACに格納します。この後、キーをリセットする必要があります。
+    \return 0  最後のMacの計算に成功した
+    \return BAD_FUNC_ARG  Poly1305構造がNULLの場合に返されます
+    \param ctx  MACを生成するためのPoly1305構造へのポインタ
+    _Example_
+    \code
+    Poly1305 enc;
+    byte mac[POLY1305_DIGEST_SIZE]; // space for a 16 byte mac
+
+    byte key[] = { }; // initialize with 32 byte key to use for encryption
+
+    byte msg[] = { }; // initialize with message to hash
+    wc_Poly1305SetKey(&enc, key, sizeof(key));
+    wc_Poly1305Update(key, msg, sizeof(msg));
+
+    if ( wc_Poly1305Final(&enc, mac) != 0 ) {
+    	// error computing final MAC
+    }
+    \endcode
+    \sa wc_Poly1305SetKey
+    \sa wc_Poly1305Update
+*/
+int wc_Poly1305Final(Poly1305* poly1305, byte* tag);
+
+/*!
+    \ingroup Poly1305 
+    \brief  鍵がロードされ、最近のTLS AEADパディング方式を使用してMAC（タグ）を作成する初期化されたPoly1305構造体を取ります。
+    \return 0  成功
+    \return BAD_FUNC_ARG  CTX、INPUT、またはTAGがNULLの場合、または追加がNULLで、ADDSZが0より大きい場合、またはTAGSZがWC_POLY1305_MAC_SZより小さい場合に返されます。
+    \param ctx  初期化されたPoly1305構造物
+    \param additional  使用する追加データ
+    \param addSz  追加バッファのサイズ
+    \param input  からタグを作成するための入力バッファ
+    \param sz  入力バッファのサイズ
+    \param tag  作成したタグを保持するためのバッファー
+    _Example_
+    \code
+    Poly1305 ctx;
+    byte key[] = { }; // initialize with 32 byte key to use for hashing
+    byte additional[] = { }; // initialize with additional data
+    byte msg[] = { }; // initialize with message
+    byte tag[16];
+
+    wc_Poly1305SetKey(&ctx, key, sizeof(key));
+    if(wc_Poly1305_MAC(&ctx, additional, sizeof(additional), (byte*)msg,
+    sizeof(msg), tag, sizeof(tag)) != 0)
+    {
+        // Handle the error
+    }
+    \endcode
+    \sa wc_Poly1305SetKey
+    \sa wc_Poly1305Update
+    \sa wcPoly1305Final
+*/
+int wc_Poly1305_MAC(Poly1305* ctx, byte* additional, word32 addSz,
+                               byte* input, word32 sz, byte* tag, word32 tagSz);

--- a/doc/dox_comments/header_files-ja/psa.h
+++ b/doc/dox_comments/header_files-ja/psa.h
@@ -1,0 +1,75 @@
+/*!
+    \ingroup PSA 
+    \brief  この関数は、与えられたコンテキストでのPSAサポートを可能にします。
+    \param ctx  PSAサポートを有効にする必要があるWOLFSSL_CTXオブジェクトへのポインタ
+    \return WOLFSSL_SUCCESS  成功した
+    _Example_
+    \code
+    WOLFSSL_CTX *ctx;
+    ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method());
+    if (!ctx)
+        return NULL;
+    ret = wolfSSL_CTX_psa_enable(ctx);
+    if (ret != WOLFSSL_SUCCESS)
+        printf("can't enable PSA on ctx");
+
+    \endcode
+    \sa wolfSSL_set_psa_ctx
+*/
+int wolfSSL_CTX_psa_enable(WOLFSSL_CTX *ctx);
+
+/*!
+    \ingroup PSA 
+    \brief  与えられたSSLセッションのPSAコンテキストを設定する機能
+    \param ssl  CTXが有効になるWolfSSLへのポインタ
+    \param ctx  Struct PSA_SSL_CTXへのポインタ（SSLセッションに固有である必要があります）
+    \return WOLFSSL_SUCCESS  成功した
+    _Example_
+    \code
+    // Create new ssl session
+    WOLFSSL *ssl;
+    struct psa_ssl_ctx psa_ctx = { 0 };
+    ssl = wolfSSL_new(ctx);
+    if (!ssl)
+        return NULL;
+    // setup PSA context
+    ret = wolfSSL_set_psa_ctx(ssl, ctx);
+    \endcode
+    \sa wolfSSL_psa_set_private_key_id
+    \sa wolfSSL_psa_free_psa_ctx
+*/
+int wolfSSL_set_psa_ctx(WOLFSSL *ssl, struct psa_ssl_ctx *ctx);
+
+/*!
+    \ingroup PSA 
+    \brief  この関数はPSAコンテキストによって使用されるリソースを解放します
+    \sa wolfSSL_set_psa_ctx
+*/
+void wolfSSL_free_psa_ctx(struct psa_ssl_ctx *ctx);
+
+/*!
+    \ingroup PSA 
+    \brief  この関数は、SSLセッションによって使用される秘密鍵を設定します
+    \param ctx  構造体PSA_SSL_CTXへのポインタ
+    _Example_
+    \code
+    // Create new ssl session
+    WOLFSSL *ssl;
+    struct psa_ssl_ctx psa_ctx = { 0 };
+    psa_key_id_t key_id;
+
+    // key provisioning already done
+    get_private_key_id(&key_id);
+
+    ssl = wolfSSL_new(ctx);
+    if (!ssl)
+        return NULL;
+
+    wolfSSL_psa_set_private_key_id(&psa_ctx, key_id);
+    wolfSSL_set_psa_ctx(ssl, ctx);
+    \endcode
+    \sa wolfSSL_set_psa_ctx
+*/
+
+int wolfSSL_psa_set_private_key_id(struct psa_ssl_ctx *ctx,
+                                               psa_key_id_t id);

--- a/doc/dox_comments/header_files-ja/pwdbased.h
+++ b/doc/dox_comments/header_files-ja/pwdbased.h
@@ -1,0 +1,110 @@
+/*!
+    \ingroup Password 
+    \brief  この機能はパスワードベースの鍵導出機能1（PBKDF1）を実装し、入力パスワードを連結塩と共により安全な鍵に変換し、出力に記憶する。これにより、HASH関数としてSHAとMD5を選択できます。
+    \return 0  入力パスワードからキーの派生に正常に戻された
+    \return BAD_FUNC_ARG  与えられた無効なハッシュタイプがある場合（有効なタイプは：MD5とSHA）、反復は1未満、または要求されたキーの長さ（Klen）は提供されたハッシュのハッシュ長よりも大きいです。
+    \return MEMORY_E  SHAまたはMD5オブジェクトにメモリを割り当てるエラーがある場合は返されます。
+    \param output  生成されたキーを保存するバッファへのポインタ。少なくともklen longになるべきです
+    \param passwd  キーの派生に使用するパスワードを含むバッファへのポインタ
+    \param pLen  キーの派生に使用するパスワードの長さ
+    \param salt  鍵由来に使用する塩を含む緩衝液へのポインター
+    \param sLen  塩の長さ
+    \param iterations  ハッシュを処理するための回数
+    \param kLen  派生キーの希望の長さ。選択したハッシュのダイジェストサイズより長くしてはいけません
+    _Example_
+    \code
+    int ret;
+    byte key[MD5_DIGEST_SIZE];
+    byte pass[] = { }; // initialize with password
+    byte salt[] = { }; // initialize with salt
+
+    ret = wc_PBKDF1(key, pass, sizeof(pass), salt, sizeof(salt), 1000,
+    sizeof(key), MD5);
+    if ( ret != 0 ) {
+    	// error deriving key from password
+    }
+    \endcode
+    \sa wc_PBKDF2
+    \sa wc_PKCS12_PBKDF
+*/
+int wc_PBKDF1(byte* output, const byte* passwd, int pLen,
+                      const byte* salt, int sLen, int iterations, int kLen,
+                      int typeH);
+
+/*!
+    \ingroup Password 
+    \brief  この機能はパスワードベースのキー導出機能2（PBKDF2）を実装し、入力パスワードを連結された塩とともにより安全なキーに変換し、出力に記憶されています。これにより、MD5、SHA、SHA256、SHA384、SHA512、およびBLAKE2Bなど、サポートされているHMACハッシュ関数のいずれかを選択できます。
+    \return 0  入力パスワードからキーの派生に正常に戻された
+    \return BAD_FUNC_ARG  無効なハッシュタイプがある場合、または反復が1未満の場合は返されます。
+    \return MEMORY_E  HMACオブジェクトに割り振りメモリがある場合
+    \param output  生成されたキーを保存するバッファへのポインタ。klen longにするべきです
+    \param passwd  キーの派生に使用するパスワードを含むバッファへのポインタ
+    \param pLen  キーの派生に使用するパスワードの長さ
+    \param salt  鍵由来に使用する塩を含む緩衝液へのポインター
+    \param sLen  塩の長さ
+    \param iterations  ハッシュを処理するための回数
+    \param kLen  派生鍵の望ましい長さ
+    _Example_
+    \code
+    int ret;
+    byte key[64];
+    byte pass[] = { }; // initialize with password
+    byte salt[] = { }; // initialize with salt
+
+    ret = wc_PBKDF2(key, pass, sizeof(pass), salt, sizeof(salt), 2048, sizeof(key),
+    SHA512);
+    if ( ret != 0 ) {
+    	// error deriving key from password
+    }
+    \endcode
+    \sa wc_PBKDF1
+    \sa wc_PKCS12_PBKDF
+*/
+int wc_PBKDF2(byte* output, const byte* passwd, int pLen,
+                      const byte* salt, int sLen, int iterations, int kLen,
+                      int typeH);
+
+/*!
+    \ingroup Password 
+    \brief  この関数は、RFC 7292付録Bに記載されているパスワードベースのキー導出機能（PBKDF）を実装しています。この関数は、入力パスワードを連結塩でより安全なキーに変換します。それは、MD5、SHA、SHA256、SHA384、SHA512、およびBLAKE2Bを含む、ユーザーはサポートされているHMACハッシュ関数のいずれかを選択できます。
+    \return 0  入力パスワードからキーの派生に正常に戻された
+    \return BAD_FUNC_ARG  返された無効なハッシュタイプが与えられた場合、繰り返しは1未満、または要求されたキーの長さ（klen）が提供されたハッシュのハッシュ長よりも大きいです。
+    \return MEMORY_E  割り当てメモリがある場合は返されます
+    \return MP_INIT_E  キー生成中にエラーがある場合は返却される可能性があります
+    \return MP_READ_E  キー生成中にエラーがある場合は返却される可能性があります
+    \return MP_CMP_E  キー生成中にエラーがある場合は返却される可能性があります
+    \return MP_INVMOD_E  キー生成中にエラーがある場合は返却される可能性があります
+    \return MP_EXPTMOD_E  キー生成中にエラーがある場合は返却される可能性があります
+    \return MP_MOD_E  キー生成中にエラーがある場合は返却される可能性があります
+    \return MP_MUL_E  キー生成中にエラーがある場合は返却される可能性があります
+    \return MP_ADD_E  キー生成中にエラーがある場合は返却される可能性があります
+    \return MP_MULMOD_E  キー生成中にエラーがある場合は返却される可能性があります
+    \return MP_TO_E  キー生成中にエラーがある場合は返却される可能性があります
+    \return MP_MEM  キー生成中にエラーがある場合は返却される可能性があります
+    \param output  生成されたキーを保存するバッファへのポインタ。klen longにするべきです
+    \param passwd  キーの派生に使用するパスワードを含むバッファへのポインタ
+    \param pLen  キーの派生に使用するパスワードの長さ
+    \param salt  鍵由来に使用する塩を含む緩衝液へのポインター
+    \param sLen  塩の長さ
+    \param iterations  ハッシュを処理するための回数
+    \param kLen  派生鍵の望ましい長さ
+    \param hashType  使用するハッシュアルゴリズム有効な選択肢は次のとおりです.MD5、SHA、SHA256、SHA384、SHA512、およびBLAKE2B
+    _Example_
+    \code
+    int ret;
+    byte key[64];
+    byte pass[] = { }; // initialize with password
+    byte salt[] = { }; // initialize with salt
+
+    ret = wc_PKCS512_PBKDF(key, pass, sizeof(pass), salt, sizeof(salt), 2048,
+    sizeof(key), SHA512, 1);
+    if ( ret != 0 ) {
+    	// error deriving key from password
+    }
+    \endcode
+    \sa wc_PBKDF1
+    \sa wc_PBKDF2
+*/
+int wc_PKCS12_PBKDF(byte* output, const byte* passwd, int pLen,
+                            const byte* salt, int sLen, int iterations,
+                            int kLen, int typeH, int purpose);

--- a/doc/dox_comments/header_files-ja/random.h
+++ b/doc/dox_comments/header_files-ja/random.h
@@ -1,0 +1,258 @@
+/*!
+    \ingroup Random 
+    \brief  Init Global WhiteWood Netrandomのコンテキスト
+    \return 0  成功
+    \return BAD_FUNC_ARG  configfileがnullまたはタイムアウトのどちらかが否定的です。
+    \return RNG_FAILURE_E  RNGの初期化に失敗しました。
+    \param configFile  設定ファイルへのパス
+    \param hmac_cb  HMACコールバックを作成するにはオプションです。
+    _Example_
+    \code
+    char* config = "path/to/config/example.conf";
+    int time = // Some sufficient timeout value;
+
+    if (wc_InitNetRandom(config, NULL, time) != 0)
+    {
+        // Some error occurred
+    }
+    \endcode
+    \sa wc_FreeNetRandom
+*/
+int  wc_InitNetRandom(const char* configFile, wnr_hmac_key hmac_cb, int timeout);
+
+/*!
+    \ingroup Random 
+    \brief  無料のGlobal WhiteWood Netrandomコンテキスト。
+    \return 0  成功
+    \return BAD_MUTEX_E  Wnr_Mutexでミューテックスをロックするエラー
+    _Example_
+    \code
+    int ret = wc_FreeNetRandom();
+    if(ret != 0)
+    {
+        // Handle the error
+    }
+    \endcode
+    \sa wc_InitNetRandom
+*/
+int  wc_FreeNetRandom(void);
+
+/*!
+    \ingroup Random 
+    \brief  RNGのシード（OSから）とキー暗号を取得します。割り当てられたRNG-> DRBG（決定論的ランダムビットジェネレータ）が割り当てられます（WC_FREERNGで割り当てられている必要があります）。これはブロッキング操作です。
+    \return 0  成功しています。
+    \return MEMORY_E  XMallocに失敗しました
+    \return WINCRYPT_E  WC_GENERATSEED：コンテキストの取得に失敗しました
+    \return CRYPTGEN_E  WC_GENERATSEED：ランダムになりました
+    \return BAD_FUNC_ARG  WC_RNG_GenerateBlock入力はNULLまたはSZがMAX_REQUEST_LENを超えています
+    \return DRBG_CONT_FIPS_E  wc_rng_generateblock：hash_genはdrbg_cont_failureを返しました
+    \return RNG_FAILURE_E  wc_rng_generateBlock：デフォルトエラーです。RNGのステータスはもともとOKではなく、drbg_failedに設定されています
+    _Example_
+    \code
+    RNG  rng;
+    int ret;
+
+    #ifdef HAVE_CAVIUM
+    ret = wc_InitRngCavium(&rng, CAVIUM_DEV_ID);
+    if (ret != 0){
+        printf(“RNG Nitrox init for device: %d failed”, CAVIUM_DEV_ID);
+        return -1;
+    }
+    #endif
+    ret = wc_InitRng(&rng);
+    if (ret != 0){
+        printf(“RNG init failed”);
+        return -1;
+    }
+    \endcode
+    \sa wc_InitRngCavium
+    \sa wc_RNG_GenerateBlock
+    \sa wc_RNG_GenerateByte
+    \sa wc_FreeRng
+    \sa wc_RNG_HealthTest
+*/
+int  wc_InitRng(WC_RNG*);
+
+/*!
+    \ingroup Random 
+    \brief  疑似ランダムデータのSZバイトを出力にコピーします。必要に応じてRNG（ブロッキング）します。
+    \return 0  成功した
+    \return BAD_FUNC_ARG  入力はNULLまたはSZがMAX_REQUEST_LENを超えています
+    \return DRBG_CONT_FIPS_E  hash_genはdrbg_cont_failureを返しました
+    \return RNG_FAILURE_E  デフォルトのエラーRNGのステータスはもともとOKではなく、drbg_failedに設定されています
+    \param rng  乱数発生器はWC_INITRNGで初期化された
+    \param output  ブロックがコピーされるバッファ
+    _Example_
+    \code
+    RNG  rng;
+    int  sz = 32;
+    byte block[sz];
+
+    int ret = wc_InitRng(&rng);
+    if (ret != 0) {
+        return -1; //init of rng failed!
+    }
+
+    ret = wc_RNG_GenerateBlock(&rng, block, sz);
+    if (ret != 0) {
+        return -1; //generating block failed!
+    }
+    \endcode
+    \sa wc_InitRngCavium, wc_InitRng
+    \sa wc_RNG_GenerateByte
+    \sa wc_FreeRng
+    \sa wc_RNG_HealthTest
+*/
+int  wc_RNG_GenerateBlock(WC_RNG* rng, byte* b, word32 sz);
+
+/*!
+    \ingroup Random 
+    \brief  新しいWC_RNG構造を作成します。
+    \return WC_RNG  成功の構造
+    \return NULL  誤りに
+    \param heap  ヒープ識別子へのポインタ
+    \param nonce  nonceを含むバッファへのポインタ
+    _Example_
+    \code
+    RNG  rng;
+    byte nonce[] = { initialize nonce };
+    word32 nonceSz = sizeof(nonce);
+
+    wc_rng_new(&nonce, nonceSz, &heap);
+
+
+    \endcode
+    \sa wc_InitRng
+    \sa wc_rng_free
+    \sa wc_FreeRng
+    \sa wc_RNG_HealthTest
+*/
+WC_RNG* wc_rng_new(byte* nonce, word32 nonceSz, void* heap)
+
+/*!
+    \ingroup Random 
+    \brief  wc_rng_generateBlockを呼び出して、疑似ランダムデータのバイトをbにコピーします。必要に応じてRNGが再販されます。
+    \return 0  成功した
+    \return BAD_FUNC_ARG  入力はNULLまたはSZがMAX_REQUEST_LENを超えています
+    \return DRBG_CONT_FIPS_E  hash_genはdrbg_cont_failureを返しました
+    \return RNG_FAILURE_E  デフォルトのエラーRNGのステータスはもともとOKではなく、drbg_failedに設定されています
+    \param rng:  乱数発生器はWC_INITRNGで初期化された
+    _Example_
+    \code
+    RNG  rng;
+    int  sz = 32;
+    byte b[1];
+
+    int ret = wc_InitRng(&rng);
+    if (ret != 0) {
+        return -1; //init of rng failed!
+    }
+
+    ret = wc_RNG_GenerateByte(&rng, b);
+    if (ret != 0) {
+        return -1; //generating block failed!
+    }
+    \endcode
+    \sa wc_InitRngCavium
+    \sa wc_InitRng
+    \sa wc_RNG_GenerateBlock
+    \sa wc_FreeRng
+    \sa wc_RNG_HealthTest
+*/
+int  wc_RNG_GenerateByte(WC_RNG* rng, byte* b);
+
+/*!
+    \ingroup Random 
+    \brief  RNGがDRGBを安全に解放するために必要なときに呼び出されるべきです。ゼロとXfrees RNG-DRBG。
+    \return 0  成功した
+    \return BAD_FUNC_ARG  RNGまたはRNG-> DRGB NULL
+    \return RNG_FAILURE_E  DRBGの割り当て解除に失敗しました
+    _Example_
+    \code
+    RNG  rng;
+    int ret = wc_InitRng(&rng);
+    if (ret != 0) {
+        return -1; //init of rng failed!
+    }
+
+    int ret = wc_FreeRng(&rng);
+    if (ret != 0) {
+        return -1; //free of rng failed!
+    }
+    \endcode
+    \sa wc_InitRngCavium
+    \sa wc_InitRng
+    \sa wc_RNG_GenerateBlock
+    \sa wc_RNG_GenerateByte,
+    \sa wc_RNG_HealthTest
+*/
+int  wc_FreeRng(WC_RNG*);
+
+/*!
+    \ingroup Random 
+    \brief  RNGを安全に自由に解放するためにRNGが不要になったときに呼び出されるべきです。
+    _Example_
+    \code
+    RNG  rng;
+    byte nonce[] = { initialize nonce };
+    word32 nonceSz = sizeof(nonce);
+
+    rng = wc_rng_new(&nonce, nonceSz, &heap);
+
+    // use rng
+
+    wc_rng_free(&rng);
+
+    \endcode
+    \sa wc_InitRng
+    \sa wc_rng_new
+    \sa wc_FreeRng
+    \sa wc_RNG_HealthTest
+*/
+WC_RNG* wc_rng_free(WC_RNG* rng);
+
+/*!
+    \ingroup Random 
+    \brief  DRBGの機能を作成しテストします。
+    \return 0  成功した
+    \return BAD_FUNC_ARG  ELTOPYAと出力はNULLにしないでください。Reseed Set EntropybがNULLでなければならない場合
+    \return -1  テスト失敗
+    \param int  RESEED：設定されている場合は、Reseed機能をテストします
+    \param entropyA:  DRGBをインスタンス化するエントロピー
+    \param entropyASz:  バイト数のエントロピヤのサイズ
+    \param entropyB:  Reseed Setを設定した場合、DRBGはEntropybでリサイードされます
+    \param entropyBSz:  バイト単位のEntropybのサイズ
+    \param output:  SEADRANDOMが設定されている場合は、Entropybに播種されたランダムなデータに初期化され、それ以外の場合はEntropya
+    _Example_
+    \code
+    byte output[SHA256_DIGEST_SIZE * 4];
+    const byte test1EntropyB[] = ....; // test input for reseed false
+    const byte test1Output[] = ....;   // testvector: expected output of
+                                   // reseed false
+    ret = wc_RNG_HealthTest(0, test1Entropy, sizeof(test1Entropy), NULL, 0,
+                        output, sizeof(output));
+    if (ret != 0)
+        return -1;//healthtest without reseed failed
+
+    if (XMEMCMP(test1Output, output, sizeof(output)) != 0)
+        return -1; //compare to testvector failed: unexpected output
+
+    const byte test2EntropyB[] = ....; // test input for reseed
+    const byte test2Output[] = ....;   // testvector expected output of reseed
+    ret = wc_RNG_HealthTest(1, test2EntropyA, sizeof(test2EntropyA),
+                        test2EntropyB, sizeof(test2EntropyB),
+                        output, sizeof(output));
+
+    if (XMEMCMP(test2Output, output, sizeof(output)) != 0)
+        return -1; //compare to testvector failed
+    \endcode
+    \sa wc_InitRngCavium
+    \sa wc_InitRng
+    \sa wc_RNG_GenerateBlock
+    \sa wc_RNG_GenerateByte
+    \sa wc_FreeRng
+*/
+int wc_RNG_HealthTest(int reseed,
+                                        const byte* entropyA, word32 entropyASz,
+                                        const byte* entropyB, word32 entropyBSz,
+                                        byte* output, word32 outputSz);

--- a/doc/dox_comments/header_files-ja/ripemd.h
+++ b/doc/dox_comments/header_files-ja/ripemd.h
@@ -1,0 +1,70 @@
+/*!
+    \ingroup RIPEMD 
+    \brief  この関数は、RIPemdのダイジェスト、バッファ、LOLEN ,HILENを初期化することによってRIPemd構造を初期化します。
+    \return 0  機能の実行に成功したことに戻ります。RIPEMD構造が初期化されます。
+    \return BAD_FUNC_ARG  RIPEMD構造がNULLの場合に返されます。
+    _Example_
+    \code
+    RipeMd md;
+    int ret;
+    ret = wc_InitRipeMd(&md);
+    if (ret != 0) {
+    	// Failure case.
+    }
+    \endcode
+    \sa wc_RipeMdUpdate
+    \sa wc_RipeMdFinal
+*/
+int wc_InitRipeMd(RipeMd*);
+
+/*!
+    \ingroup RIPEMD 
+    \brief  この関数はデータ入力のRIPemdダイジェストを生成し、結果をRIPemd-> Digestバッファに格納します。WC_RIPEMDUPDATEを実行した後、生成されたRIPemd-> Digestを既知の認証タグに比較してメッセージの信頼性を比較する必要があります。
+    \return 0  機能の実行に成功したことに戻ります。
+    \return BAD_FUNC_ARG  RIPEMD構造がNULLの場合、またはデータがNULLで、LENがゼロでない場合に返されます。データがNULLであり、LENが0の場合、この関数は実行されるはずです。
+    \param ripemd:  WC_INTRIPEMDで初期化されるRIPEMD構造へのポインタ
+    \param data  ハッシュするデータ
+    _Example_
+    \code
+    const byte* data; // The data to be hashed
+    ....
+    RipeMd md;
+    int ret;
+    ret = wc_InitRipeMd(&md);
+    if (ret == 0) {
+    ret = wc_RipeMdUpdate(&md, plain, sizeof(plain));
+    if (ret != 0) {
+	// Failure case …
+    \endcode
+    \sa wc_InitRipeMd
+    \sa wc_RipeMdFinal
+*/
+int wc_RipeMdUpdate(RipeMd* ripemd, const byte* data, word32 len);
+
+/*!
+    \ingroup RIPEMD 
+    \brief  この関数は計算されたダイジェストをハッシュにコピーします。無傷のブロックがある場合、この方法ではブロックを0Sでパッケージし、ハッシュにコピーする前にそのブロックのラウンドをダイジェストに含めます。RIPEMDの状態がリセットされます。
+    \return 0  機能の実行に成功したことに戻ります。RIPEMD構造の状態がリセットされました。
+    \return BAD_FUNC_ARG  RIPEMD構造体またはハッシュパラメータがNULLの場合に返されます。
+    \param ripemd  WC_INITRIPEMDで初期化するRIPEMD構造へのポインタ、およびWC_RIPEMDUPDATEからハッシュを含む。状態はリセットされます
+    _Example_
+    \code
+    RipeMd md;
+    int ret;
+    byte   digest[RIPEMD_DIGEST_SIZE];
+    const byte* data; // The data to be hashed
+    ...
+    ret = wc_InitRipeMd(&md);
+    if (ret == 0) {
+    ret = wc_RipeMdUpdate(&md, plain, sizeof(plain));
+    	if (ret != 0) {
+    		// RipeMd Update Failure Case.
+    }
+    ret = wc_RipeMdFinal(&md, digest);
+    if (ret != 0) {
+    	// RipeMd Final Failure Case.
+    }...
+    \endcode
+    \sa none
+*/
+int wc_RipeMdFinal(RipeMd* ripemd, byte* hash);

--- a/doc/dox_comments/header_files-ja/rsa.h
+++ b/doc/dox_comments/header_files-ja/rsa.h
@@ -1,0 +1,1201 @@
+/*!
+    \ingroup RSA 
+    \brief  この関数は提供されたRSAKEY構造体を初期化します。また、ユーザー定義メモリオーバーライドで使用するためのヒープ識別子も取ります（XMALLOC、XFREE、XREALLOCを参照）。wc_rsa_blindingが有効な場合、キーはWC_RSASETRNGによってRNGに関連付けられなければなりません。
+    \return 0  暗号化と復号化で使用するためのRSA構造の初期化に成功したときに返されます。
+    \return BAD_FUNC_ARGS  RSAキーポインタがNULLに評価された場合に返されます
+    \param key  初期化するRSAKEY構造へのポインタ
+    _Example_
+    \code
+    RsaKey enc;
+    int ret;
+    ret = wc_InitRsaKey(&enc, NULL); // not using heap hint. No custom memory
+    if ( ret != 0 ) {
+    	// error initializing RSA key
+    }
+    \endcode
+    \sa wc_RsaInitCavium
+    \sa wc_FreeRsaKey
+    \sa wc_RsaSetRNG
+*/
+int  wc_InitRsaKey(RsaKey* key, void* heap);
+
+/*!
+    \ingroup RSA 
+    \brief  この関数は提供されたRSAKEY構造体を初期化します。IDとLENは、DEVIDがデバイスを識別している間にデバイス上のキーを識別するために使用されます。また、ユーザー定義メモリオーバーライドで使用するためのヒープ識別子も取ります（XMALLOC、XFREE、XREALLOCを参照）。wc_rsa_blindingが有効な場合、キーはWC_RSASETRNGによってRNGに関連付けられなければなりません。
+    \return 0  暗号化と復号化で使用するためのRSA構造の初期化に成功したときに返されます。
+    \return BAD_FUNC_ARGS  RSAキーポインタがNULLに評価された場合に返されます
+    \return BUFFER_E  LENがRSA_MAX_ID_LENよりも小さい場合、または大きい場合は返されます。
+    \param key  初期化するRSAKEY構造へのポインタ
+    \param id  デバイス上のキーの識別子
+    \param len  バイト数の識別子の長さ
+    \param heap  メモリオーバーライドで使用するためのヒープ識別子へのポインタ。メモリ割り当てのカスタム処理を可能にします。このヒープは、このRSAオブジェクトで使用するためにメモリを割り当てるときに使用されるデフォルトになります。
+    _Example_
+    \code
+    RsaKey enc;
+    unsigned char* id = (unsigned char*)"RSA2048";
+    int len = 6;
+    int devId = 1;
+    int ret;
+    ret = wc_CryptoDev_RegisterDevice(devId, wc_Pkcs11_CryptoDevCb,
+                                      &token);
+    if ( ret != 0) {
+        // error associating callback and token with device id
+    }
+    ret = wc_InitRsaKey_Id(&enc, id, len, NULL, devId); // not using heap hint
+    if ( ret != 0 ) {
+        // error initializing RSA key
+    }
+    \endcode
+    \sa wc_InitRsaKey
+    \sa wc_RsaInitCavium
+    \sa wc_FreeRsaKey
+    \sa wc_RsaSetRNG
+*/
+int  wc_InitRsaKey_Id(RsaKey* key, unsigned char* id, int len,
+        void* heap, int devId);
+
+/*!
+    \ingroup RSA 
+    \brief  この関数はRNGをキーに関連付けます。WC_RSA_BLINDINGが有効になっている場合は必要です。
+    \return 0  成功に戻った
+    \return BAD_FUNC_ARGS  RSAキーの場合、RNGポインタがNULLに評価された場合
+    \param key  関連付けられるRSAKEY構造へのポインタ
+    _Example_
+    \code
+    ret = wc_InitRsaKey(&key, NULL);
+    if (ret == 0) {
+        ret = wc_InitRng(&rng);
+    } else return -1;
+    if (ret == 0) {
+        ret = wc_RsaSetRNG(&key, &rng);
+    \endcode
+    \sa wc_InitRsaKey
+    \sa wc_RsaSetRNG
+*/
+int wc_RsaSetRNG(RsaKey* key, WC_RNG* rng);
+
+/*!
+    \ingroup RSA 
+    \brief  この関数は、MP_Clearを使用して提供されたRSAKEY構造体を解放します。
+    \return 0  キーの解放に成功したら返品されます
+    _Example_
+    \code
+    RsaKey enc;
+    wc_InitRsaKey(&enc, NULL); // not using heap hint. No custom memory
+    ... set key, do encryption
+
+    wc_FreeRsaKey(&enc);
+    \endcode
+    \sa wc_InitRsaKey
+*/
+int  wc_FreeRsaKey(RsaKey* key);
+
+/*!
+    \ingroup RSA 
+    \brief  この関数はメッセージをINから暗号化し、その結果を格納します。初期化された公開鍵と乱数発生器が必要です。副作用として、この関数はounlenの中で書き込まれたバイトを返します。
+    \return Success  入力メッセージの暗号化に成功したら、成功の場合は0を返し、障害の場合はゼロ未満です。また、outlenの値を格納することによって、OUTに書き込まれた数のバイト数を返します。
+    \return BAD_FUNC_ARG  入力パラメータのいずれかが無効な場合に返されます
+    \return RSA_BUFFER_E  CipherTextを保存するには、出力バッファが小さすぎる場合は返されます。
+    \return RNG_FAILURE_E  提供されたRNG構造体を使用してランダムブロックを生成するエラーがある場合
+    \return MP_INIT_E  メッセージの暗号化中に使用されている数学ライブラリにエラーがある場合に返される可能性があります。
+    \return MP_READ_E  メッセージの暗号化中に使用されている数学ライブラリにエラーがある場合に返される可能性があります。
+    \return MP_CMP_E  メッセージの暗号化中に使用されている数学ライブラリにエラーがある場合に返される可能性があります。
+    \return MP_INVMOD_E  メッセージの暗号化中に使用されている数学ライブラリにエラーがある場合に返される可能性があります。
+    \return MP_EXPTMOD_E  メッセージの暗号化中に使用されている数学ライブラリにエラーがある場合に返される可能性があります。
+    \return MP_MOD_E  メッセージの暗号化中に使用されている数学ライブラリにエラーがある場合に返される可能性があります。
+    \return MP_MUL_E  メッセージの暗号化中に使用されている数学ライブラリにエラーがある場合に返される可能性があります。
+    \return MP_ADD_E  メッセージの暗号化中に使用されている数学ライブラリにエラーがある場合に返される可能性があります。
+    \return MP_MULMOD_E  メッセージの暗号化中に使用されている数学ライブラリにエラーがある場合に返される可能性があります。
+    \return MP_TO_E  メッセージの暗号化中に使用されている数学ライブラリにエラーがある場合に返される可能性があります。
+    \return MP_MEM  メッセージの暗号化中に使用されている数学ライブラリにエラーがある場合に返される可能性があります。
+    \return MP_ZERO_E  メッセージの暗号化中に使用されている数学ライブラリにエラーがある場合に返される可能性があります。
+    \param in  暗号化する入力メッセージを含むバッファへのポインタ
+    \param inLen  暗号化するメッセージの長さ
+    \param out  出力暗号文を保存するバッファへのポインタ
+    \param outLen  出力バッファの長さ
+    \param key  暗号化に使用する公開鍵を含むRSAKEY構造体へのポインタ
+    _Example_
+    \code
+    RsaKey pub;
+    int ret = 0;
+    byte n[] = { // initialize with received n component of public key };
+    byte e[] = { // initialize with received e component of public key };
+    byte msg[] = { // initialize with plaintext of message to encrypt };
+    byte cipher[256]; // 256 bytes is large enough to store 2048 bit RSA
+    ciphertext
+
+    wc_InitRsaKey(&pub, NULL); // not using heap hint. No custom memory
+    wc_RsaPublicKeyDecodeRaw(n, sizeof(n), e, sizeof(e), &pub);
+    // initialize with received public key parameters
+    ret = wc_RsaPublicEncrypt(msg, sizeof(msg), out, sizeof(out), &pub, &rng);
+    if ( ret != 0 ) {
+    	// error encrypting message
+    }
+    \endcode
+    \sa wc_RsaPrivateDecrypt
+*/
+int  wc_RsaPublicEncrypt(const byte* in, word32 inLen, byte* out,
+                                 word32 outLen, RsaKey* key, WC_RNG* rng);
+
+/*!
+    \ingroup RSA 
+    \brief  この関数は復号化のためにWC_RSAPrivateCrypt関数によって利用されます。
+    \return Success  復号化データの長さ
+    \return RSA_PAD_E  RSAUNPADエラー、フォーマットの悪いフォーマット
+    \param in  復号化されるバイト配列。
+    \param inLen  の長さ
+    \param out  格納する復号化データのバイト配列。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wc_RsaPrivateDecrypt
+*/
+int  wc_RsaPrivateDecryptInline(byte* in, word32 inLen, byte** out,
+                                        RsaKey* key);
+
+/*!
+    \ingroup RSA 
+    \brief  この関数は秘密のRSA復号化を提供します。
+    \return Success  復号化データの長さ
+    \return MEMORY_E  -125、メモリエラーが発生しました
+    \return BAD_FUNC_ARG  -173、関数の不良引数が提供されています
+    \param in  復号化されるバイト配列。
+    \param inLen  の長さ
+    \param out  格納する復号化データのバイト配列。
+    \param outLen  の長さ
+    _Example_
+    \code
+    ret = wc_RsaPublicEncrypt(in, inLen, out, sizeof(out), &key, &rng);
+    if (ret < 0) {
+        return -1;
+    }
+    ret = wc_RsaPrivateDecrypt(out, ret, plain, sizeof(plain), &key);
+    if (ret < 0) {
+        return -1;
+    }
+    \endcode
+    \sa RsaUnPad
+    \sa wc_RsaFunction
+    \sa wc_RsaPrivateDecryptInline
+*/
+int  wc_RsaPrivateDecrypt(const byte* in, word32 inLen, byte* out,
+                                  word32 outLen, RsaKey* key);
+
+/*!
+    \ingroup RSA 
+    \brief  提供された配列に秘密鍵と署名します。
+    \return RSA_BUFFER_E:  -131、RSAバッファエラー、出力が小さすぎたり入力が大きすぎたりする
+    \param in  暗号化されるバイト配列。
+    \param inLen  の長さ
+    \param out  格納する暗号化データのバイト配列。
+    \param outLen  の長さ
+    \param key  暗号化に使用する鍵。
+    _Example_
+    \code
+    ret = wc_RsaSSL_Sign(in, inLen, out, sizeof(out), &key, &rng);
+    if (ret < 0) {
+        return -1;
+    }
+    memset(plain, 0, sizeof(plain));
+    ret = wc_RsaSSL_Verify(out, ret, plain, sizeof(plain), &key);
+    if (ret < 0) {
+        return -1;
+    }
+    \endcode
+    \sa wc_RsaPad
+*/
+int  wc_RsaSSL_Sign(const byte* in, word32 inLen, byte* out,
+                            word32 outLen, RsaKey* key, WC_RNG* rng);
+
+/*!
+    \ingroup RSA 
+    \brief  メッセージがRSAキーによって署名されたことを確認するために使用されます。出力は入力と同じバイト配列を使用します。
+    \return >0  テキストの長さ
+    \return <0  エラーが発生しました。
+    \param in  復号化されるバイト配列。
+    \param inLen  バッファ入力の長さ。
+    \param out  復号化された情報のポインタへのポインタ。
+    _Example_
+    \code
+    RsaKey key;
+    WC_WC_RNG rng;
+    int ret = 0;
+    long e = 65537; // standard value to use for exponent
+    wc_InitRsaKey(&key, NULL); // not using heap hint. No custom memory
+    wc_InitRng(&rng);
+    wc_MakeRsaKey(&key, 2048, e, &rng);
+
+    byte in[] = { // Initialize with some RSA encrypted information }
+    byte* out;
+    if(wc_RsaSSL_VerifyInline(in, sizeof(in), &out, &key) < 0)
+    {
+        // handle error
+    }
+    \endcode
+    \sa wc_RsaSSL_Verify
+    \sa wc_RsaSSL_Sign
+*/
+int  wc_RsaSSL_VerifyInline(byte* in, word32 inLen, byte** out,
+                                    RsaKey* key);
+
+/*!
+    \ingroup RSA 
+    \brief  メッセージがキーによって署名されたことを確認するために使用されます。
+    \return Success  エラーのないテキストの長さ。
+    \return MEMORY_E  メモリ例外
+    \param in  復号化されるバイト配列。
+    \param inLen  の長さ
+    \param out  格納する復号化データのバイト配列。
+    \param outLen  の長さ
+    _Example_
+    \code
+    ret = wc_RsaSSL_Sign(in, inLen, out, sizeof(out), &key, &rng);
+    if (ret < 0) {
+        return -1;
+    }
+    memset(plain, 0, sizeof(plain));
+    ret = wc_RsaSSL_Verify(out, ret, plain, sizeof(plain), &key);
+    if (ret < 0) {
+        return -1;
+    }
+    \endcode
+    \sa wc_RsaSSL_Sign
+*/
+int  wc_RsaSSL_Verify(const byte* in, word32 inLen, byte* out,
+                              word32 outLen, RsaKey* key);
+
+/*!
+    \ingroup RSA 
+    \brief  提供された配列に秘密鍵と署名します。
+    \return RSA_BUFFER_E:  -131、RSAバッファエラー、出力が小さすぎたり入力が大きすぎたりする
+    \param in  暗号化されるバイト配列。
+    \param inLen  の長さ
+    \param out  格納する暗号化データのバイト配列。
+    \param outLen  の長さ
+    \param hash  メッセージに入るハッシュ型
+    \param mgf  マスク生成機能識別子
+    _Example_
+    \code
+    ret = wc_InitRsaKey(&key, NULL);
+    if (ret == 0) {
+        ret = wc_InitRng(&rng);
+    } else return -1;
+    if (ret == 0) {
+        ret = wc_RsaSetRNG(&key, &rng);
+    } else return -1;
+    if (ret == 0) {
+            ret = wc_MakeRsaKey(&key, 2048, WC_RSA_EXPONENT, &rng);
+    } else return -1;
+
+    ret = wc_RsaPSS_Sign((byte*)szMessage, (word32)XSTRLEN(szMessage)+1,
+            pSignature, sizeof(pSignature),
+            WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key, &rng);
+    if (ret > 0 ){
+        sz = ret;
+    } else return -1;
+
+    ret = wc_RsaPSS_Verify(pSignature, sz, pt, outLen,
+            WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key);
+    if (ret <= 0)return -1;
+
+    wc_FreeRsaKey(&key);
+    wc_FreeRng(&rng);
+    \endcode
+    \sa wc_RsaPSS_Verify
+    \sa wc_RsaSetRNG
+*/
+int  wc_RsaPSS_Sign(const byte* in, word32 inLen, byte* out,
+                                word32 outLen, enum wc_HashType hash, int mgf,
+                                RsaKey* key, WC_RNG* rng);
+
+/*!
+    \ingroup RSA 
+    \brief  入力署名を復号化して、メッセージがキーによって署名されたことを確認します。wc_rsa_blindingが有効な場合、キーはWC_RSASETRNGによってRNGに関連付けられなければなりません。
+    \return Success  エラーのないテキストの長さ。
+    \return MEMORY_E  メモリ例外
+    \param in  復号化されるバイト配列。
+    \param inLen  の長さ
+    \param out  格納する復号化データのバイト配列。
+    \param outLen  の長さ
+    \param hash  メッセージに入るハッシュ型
+    \param mgf  マスク生成機能識別子
+    _Example_
+    \code
+    ret = wc_InitRsaKey(&key, NULL);
+    if (ret == 0) {
+        ret = wc_InitRng(&rng);
+    } else return -1;
+    if (ret == 0) {
+        ret = wc_RsaSetRNG(&key, &rng);
+    } else return -1;
+    if (ret == 0) {
+            ret = wc_MakeRsaKey(&key, 2048, WC_RSA_EXPONENT, &rng);
+    } else return -1;
+    ret = wc_RsaPSS_Sign((byte*)szMessage, (word32)XSTRLEN(szMessage)+1,
+            pSignature, sizeof(pSignature),
+            WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key, &rng);
+    if (ret > 0 ){
+        sz = ret;
+    } else return -1;
+
+    ret = wc_RsaPSS_Verify(pSignature, sz, pt, outLen,
+            WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key);
+    if (ret <= 0)return -1;
+
+    wc_FreeRsaKey(&key);
+    wc_FreeRng(&rng);
+    \endcode
+    \sa wc_RsaPSS_Sign
+    \sa wc_RsaPSS_VerifyInline
+    \sa wc_RsaPSS_CheckPadding
+    \sa wc_RsaSetRNG
+*/
+int  wc_RsaPSS_Verify(byte* in, word32 inLen, byte* out,
+                                  word32 outLen, enum wc_HashType hash, int mgf,
+                                  RsaKey* key);
+
+/*!
+    \ingroup RSA 
+    \brief  入力署名を復号化して、メッセージがRSAキーによって署名されたことを確認します。出力は入力と同じバイト配列を使用します。wc_rsa_blindingが有効な場合、キーはWC_RSASETRNGによってRNGに関連付けられなければなりません。
+    \return >0  テキストの長さ
+    \return <0  エラーが発生しました。
+    \param in  復号化されるバイト配列。
+    \param inLen  バッファ入力の長さ。
+    \param out  PSSデータを含むアドレスへのポインタ。
+    \param hash  メッセージに入るハッシュ型
+    \param mgf  マスク生成機能識別子
+    _Example_
+    \code
+    ret = wc_InitRsaKey(&key, NULL);
+    if (ret == 0) {
+        ret = wc_InitRng(&rng);
+    } else return -1;
+    if (ret == 0) {
+        ret = wc_RsaSetRNG(&key, &rng);
+    } else return -1;
+    if (ret == 0) {
+            ret = wc_MakeRsaKey(&key, 2048, WC_RSA_EXPONENT, &rng);
+    } else return -1;
+    ret = wc_RsaPSS_Sign(digest, digestSz, pSignature, pSignatureSz,
+            WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key, &rng);
+    if (ret > 0 ){
+        sz = ret;
+    } else return -1;
+
+    ret = wc_RsaPSS_VerifyInline(pSignature, sz, pt,
+            WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key);
+    if (ret <= 0)return -1;
+
+    wc_FreeRsaKey(&key);
+    wc_FreeRng(&rng);
+    \endcode
+    \sa wc_RsaPSS_Verify
+    \sa wc_RsaPSS_Sign
+    \sa wc_RsaPSS_VerifyCheck
+    \sa wc_RsaPSS_VerifyCheck_ex
+    \sa wc_RsaPSS_VerifyCheckInline
+    \sa wc_RsaPSS_VerifyCheckInline_ex
+    \sa wc_RsaPSS_CheckPadding
+    \sa wc_RsaPSS_CheckPadding_ex
+    \sa wc_RsaSetRNG
+*/
+
+
+int  wc_RsaPSS_VerifyInline(byte* in, word32 inLen, byte** out,
+                                        enum wc_HashType hash, int mgf,
+                                        RsaKey* key);
+/*!
+    \ingroup RSA 
+    \brief  RSA-PSSで署名されたメッセージを確認してください。塩の長さはハッシュ長に等しい。wc_rsa_blindingが有効な場合、キーはWC_RSASETRNGによってRNGに関連付けられなければなりません。
+    \return the  PSSデータの長さが成功し、負に障害が発生します。
+    \return MEMORY_E  メモリ例外
+    \param in  復号化されるバイト配列。
+    \param inLen  の長さ
+    \param out  PSSデータを含むアドレスへのポインタ。
+    \param outLen  の長さ
+    \param digest  検証中のデータのハッシュ。
+    \param digestLen  ハッシュの長さ
+    \param hash  ハッシュアルゴリズム
+    \param mgf  マスク生成機能
+    _Example_
+    \code
+    ret = wc_InitRsaKey(&key, NULL);
+    if (ret == 0) {
+        ret = wc_InitRng(&rng);
+    } else return -1;
+    if (ret == 0) {
+        ret = wc_RsaSetRNG(&key, &rng);
+    } else return -1;
+    if (ret == 0) {
+            ret = wc_MakeRsaKey(&key, 2048, WC_RSA_EXPONENT, &rng);
+    } else return -1;
+
+    if (ret == 0) {
+        digestSz = wc_HashGetDigestSize(WC_HASH_TYPE_SHA256);
+        ret = wc_Hash(WC_HASH_TYPE_SHA256, message, sz, digest, digestSz);
+    } else return -1;
+
+    if (ret == 0) {
+        ret = wc_RsaPSS_Sign(digest, digestSz, pSignature, pSignatureSz,
+                WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key, &rng);
+        if (ret > 0 ){
+            sz = ret;
+        } else return -1;
+    } else return -1;
+    if (ret == 0) {
+        ret = wc_RsaPSS_VerifyCheck(pSignature, sz, pt, outLen,
+                digest, digestSz, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key);
+            if (ret <= 0) return -1;
+    } else return -1;
+
+    wc_FreeRsaKey(&key);
+    wc_FreeRng(&rng);
+    \endcode
+    \sa wc_RsaPSS_Sign
+    \sa wc_RsaPSS_Verify
+    \sa wc_RsaPSS_VerifyCheck_ex
+    \sa wc_RsaPSS_VerifyCheckInline
+    \sa wc_RsaPSS_VerifyCheckInline_ex
+    \sa wc_RsaPSS_CheckPadding
+    \sa wc_RsaPSS_CheckPadding_ex
+    \sa wc_RsaSetRNG
+*/
+
+int  wc_RsaPSS_VerifyCheck(byte* in, word32 inLen,
+                               byte* out, word32 outLen,
+                               const byte* digest, word32 digestLen,
+                               enum wc_HashType hash, int mgf,
+                               RsaKey* key);
+/*!
+    \ingroup RSA 
+    \brief  RSA-PSSで署名されたメッセージを確認してください。wc_rsa_blindingが有効な場合、キーはWC_RSASETRNGによってRNGに関連付けられなければなりません。
+    \return the  PSSデータの長さが成功し、負に障害が発生します。
+    \return MEMORY_E  メモリ例外
+    \param in  復号化されるバイト配列。
+    \param inLen  の長さ
+    \param out  PSSデータを含むアドレスへのポインタ。
+    \param outLen  の長さ
+    \param digest  検証中のデータのハッシュ。
+    \param digestLen  ハッシュの長さ
+    \param hash  ハッシュアルゴリズム
+    \param mgf  マスク生成機能
+    \param saltLen  使用される塩の長さ。RSA_PSSS_SALT_LEN_DEFAULT（-1）塩の長さはハッシュ長と同じです。RSA_PSS_SALT_LEN_DISCOVERは、塩の長さがデータから決定されます。
+    _Example_
+    \code
+    ret = wc_InitRsaKey(&key, NULL);
+    if (ret == 0) {
+        ret = wc_InitRng(&rng);
+    } else return -1;
+    if (ret == 0) {
+        ret = wc_RsaSetRNG(&key, &rng);
+    } else return -1;
+    if (ret == 0) {
+            ret = wc_MakeRsaKey(&key, 2048, WC_RSA_EXPONENT, &rng);
+    } else return -1;
+
+    if (ret == 0) {
+        digestSz = wc_HashGetDigestSize(WC_HASH_TYPE_SHA256);
+        ret = wc_Hash(WC_HASH_TYPE_SHA256, message, sz, digest, digestSz);
+    } else return -1;
+
+    if (ret == 0) {
+        ret = wc_RsaPSS_Sign(digest, digestSz, pSignature, pSignatureSz,
+                WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key, &rng);
+        if (ret > 0 ){
+            sz = ret;
+        } else return -1;
+    } else return -1;
+    if (ret == 0) {
+        ret = wc_RsaPSS_VerifyCheck_ex(pSignature, sz, pt, outLen,
+                digest, digestSz, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, saltLen, &key);
+            if (ret <= 0) return -1;
+    } else return -1;
+
+    wc_FreeRsaKey(&key);
+    wc_FreeRng(&rng);
+    \endcode
+    \sa wc_RsaPSS_Sign
+    \sa wc_RsaPSS_Verify
+    \sa wc_RsaPSS_VerifyCheck
+    \sa wc_RsaPSS_VerifyCheckInline
+    \sa wc_RsaPSS_VerifyCheckInline_ex
+    \sa wc_RsaPSS_CheckPadding
+    \sa wc_RsaPSS_CheckPadding_ex
+    \sa wc_RsaSetRNG
+*/
+int  wc_RsaPSS_VerifyCheck_ex(byte* in, word32 inLen,
+                               byte* out, word32 outLen,
+                               const byte* digest, word32 digestLen,
+                               enum wc_HashType hash, int mgf, int saltLen,
+                               RsaKey* key);
+
+/*!
+    \ingroup RSA 
+    \brief  RSA-PSSで署名されたメッセージを確認してください。入力バッファは出力バッファに再利用されます。塩の長さはハッシュ長に等しい。wc_rsa_blindingが有効な場合、キーはWC_RSASETRNGによってRNGに関連付けられなければなりません。
+    \return the  PSSデータの長さが成功し、負に障害が発生します。
+    \param in  復号化されるバイト配列。
+    \param inLen  の長さ
+    \param out  格納する復号化データのバイト配列。
+    \param digest  検証中のデータのハッシュ。
+    \param digestLen  ハッシュの長さ
+    \param hash  メッセージに入るハッシュ型
+    \param mgf  マスク生成機能識別子
+    _Example_
+    \code
+    ret = wc_InitRsaKey(&key, NULL);
+    if (ret == 0) {
+        ret = wc_InitRng(&rng);
+    } else return -1;
+    if (ret == 0) {
+        ret = wc_RsaSetRNG(&key, &rng);
+    } else return -1;
+    if (ret == 0) {
+            ret = wc_MakeRsaKey(&key, 2048, WC_RSA_EXPONENT, &rng);
+    } else return -1;
+
+    if (ret == 0) {
+        digestSz = wc_HashGetDigestSize(WC_HASH_TYPE_SHA256);
+        ret = wc_Hash(WC_HASH_TYPE_SHA256, message, sz, digest, digestSz);
+    } else return -1;
+
+    if (ret == 0) {
+        ret = wc_RsaPSS_Sign(digest, digestSz, pSignature, pSignatureSz,
+                WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key, &rng);
+        if (ret > 0 ){
+            sz = ret;
+        } else return -1;
+    } else return -1;
+    if (ret == 0) {
+        ret = wc_RsaPSS_VerifyCheckInline(pSignature, sz, pt,
+                digest, digestSz, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key);
+            if (ret <= 0) return -1;
+    } else return -1;
+
+    wc_FreeRsaKey(&key);
+    wc_FreeRng(&rng);
+    \endcode
+    \sa wc_RsaPSS_Sign
+    \sa wc_RsaPSS_Verify
+    \sa wc_RsaPSS_VerifyCheck
+    \sa wc_RsaPSS_VerifyCheck_ex
+    \sa wc_RsaPSS_VerifyCheckInline_ex
+    \sa wc_RsaPSS_CheckPadding
+    \sa wc_RsaPSS_CheckPadding_ex
+    \sa wc_RsaSetRNG
+*/
+int  wc_RsaPSS_VerifyCheckInline(byte* in, word32 inLen, byte** out,
+                               const byte* digest, word32 digentLen,
+                               enum wc_HashType hash, int mgf,
+                               RsaKey* key);
+/*!
+    \ingroup RSA 
+    \brief  RSA-PSSで署名されたメッセージを確認してください。入力バッファは出力バッファに再利用されます。wc_rsa_blindingが有効な場合、キーはWC_RSASETRNGによってRNGに関連付けられなければなりません。
+    \return the  PSSデータの長さが成功し、負に障害が発生します。
+    \param in  復号化されるバイト配列。
+    \param inLen  の長さ
+    \param out  格納する復号化データのバイト配列。
+    \param digest  検証中のデータのハッシュ。
+    \param digestLen  ハッシュの長さ
+    \param hash  メッセージに入るハッシュ型
+    \param mgf  マスク生成機能識別子
+    \param saltLen  使用される塩の長さ。RSA_PSSS_SALT_LEN_DEFAULT（-1）塩の長さはハッシュ長と同じです。RSA_PSS_SALT_LEN_DISCOVERは、塩の長さがデータから決定されます。
+    _Example_
+    \code
+    ret = wc_InitRsaKey(&key, NULL);
+    if (ret == 0) {
+        ret = wc_InitRng(&rng);
+    } else return -1;
+    if (ret == 0) {
+        ret = wc_RsaSetRNG(&key, &rng);
+    } else return -1;
+    if (ret == 0) {
+            ret = wc_MakeRsaKey(&key, 2048, WC_RSA_EXPONENT, &rng);
+    } else return -1;
+
+    if (ret == 0) {
+        digestSz = wc_HashGetDigestSize(WC_HASH_TYPE_SHA256);
+        ret = wc_Hash(WC_HASH_TYPE_SHA256, message, sz, digest, digestSz);
+    } else return -1;
+
+    if (ret == 0) {
+        ret = wc_RsaPSS_Sign(digest, digestSz, pSignature, pSignatureSz,
+                WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key, &rng);
+        if (ret > 0 ){
+            sz = ret;
+        } else return -1;
+    } else return -1;
+    if (ret == 0) {
+        ret = wc_RsaPSS_VerifyCheckInline_ex(pSignature, sz, pt,
+                digest, digestSz, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, saltLen, &key);
+            if (ret <= 0) return -1;
+    } else return -1;
+
+    wc_FreeRsaKey(&key);
+    wc_FreeRng(&rng);
+    \endcode
+    \sa wc_RsaPSS_Sign
+    \sa wc_RsaPSS_Verify
+    \sa wc_RsaPSS_VerifyCheck
+    \sa wc_RsaPSS_VerifyCheck_ex
+    \sa wc_RsaPSS_VerifyCheckInline
+    \sa wc_RsaPSS_CheckPadding
+    \sa wc_RsaPSS_CheckPadding_ex
+    \sa wc_RsaSetRNG
+*/
+int  wc_RsaPSS_VerifyCheckInline_ex(byte* in, word32 inLen, byte** out,
+                               const byte* digest, word32 digentLen,
+                               enum wc_HashType hash, int mgf, int saltLen,
+                               RsaKey* key);
+
+/*!
+    \ingroup RSA 
+    \brief  PSSデータを確認して、署名が一致するようにします。塩の長さはハッシュ長に等しい。wc_rsa_blindingが有効な場合、キーはWC_RSASETRNGによってRNGに関連付けられなければなりません。
+    \return BAD_PADDING_E  PSSデータが無効な場合、NULLがINまたはSIGまたはINSZに渡されると、BAD_FUNC_ARGはハッシュアルゴリズムの長さと同じではありません。
+    \return MEMORY_E  メモリ例外
+    \param in  検証中のデータのハッシュ。
+    \param inSz  ハッシュの長さ
+    \param sig  PSSデータを保持するバッファ。
+    \param sigSz  PSSデータのサイズ。
+    _Example_
+    \code
+    ret = wc_InitRsaKey(&key, NULL);
+    if (ret == 0) {
+        ret = wc_InitRng(&rng);
+    } else return -1;
+    if (ret == 0) {
+        ret = wc_RsaSetRNG(&key, &rng);
+    } else return -1;
+    if (ret == 0) {
+            ret = wc_MakeRsaKey(&key, 2048, WC_RSA_EXPONENT, &rng);
+    } else return -1;
+    if (ret == 0) {
+        digestSz = wc_HashGetDigestSize(WC_HASH_TYPE_SHA256);
+        ret = wc_Hash(WC_HASH_TYPE_SHA256, message, sz, digest, digestSz);
+    } else return -1;
+    ret = wc_RsaPSS_Sign(digest, digestSz, pSignature, sizeof(pSignature),
+            WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key, &rng);
+    if (ret > 0 ){
+        sz = ret;
+    } else return -1;
+
+    verify = wc_RsaPSS_Verify(pSignature, sz, out, outLen,
+            WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key);
+    if (verify <= 0)return -1;
+
+    ret = wc_RsaPSS_CheckPadding(digest, digestSz, out, verify, hash);
+
+    wc_FreeRsaKey(&key);
+    wc_FreeRng(&rng);
+    \endcode
+    \sa wc_RsaPSS_Sign
+    \sa wc_RsaPSS_Verify
+    \sa wc_RsaPSS_VerifyInline
+    \sa wc_RsaPSS_VerifyCheck
+    \sa wc_RsaPSS_VerifyCheck_ex
+    \sa wc_RsaPSS_VerifyCheckInline
+    \sa wc_RsaPSS_VerifyCheckInline_ex
+    \sa wc_RsaPSS_CheckPadding_ex
+    \sa wc_RsaSetRNG
+*/
+int  wc_RsaPSS_CheckPadding(const byte* in, word32 inLen, byte* sig,
+                                        word32 sigSz,
+                                        enum wc_HashType hashType);
+/*!
+    \ingroup RSA 
+    \brief  PSSデータを確認して、署名が一致するようにします。塩の長さはハッシュ長に等しい。
+    \return BAD_PADDING_E  PSSデータが無効な場合、NULLがINまたはSIGまたはINSZに渡されると、BAD_FUNC_ARGはハッシュアルゴリズムの長さと同じではありません。
+    \return MEMORY_E  メモリ例外
+    \param in  検証中のデータのハッシュ。
+    \param inSz  ハッシュの長さ
+    \param sig  PSSデータを保持するバッファ。
+    \param sigSz  PSSデータのサイズ。
+    \param hashType  ハッシュアルゴリズム
+    \param saltLen  使用される塩の長さ。RSA_PSSS_SALT_LEN_DEFAULT（-1）塩の長さはハッシュ長と同じです。RSA_PSS_SALT_LEN_DISCOVERは、塩の長さがデータから決定されます。
+    _Example_
+    \code
+    ret = wc_InitRsaKey(&key, NULL);
+    if (ret == 0) {
+        ret = wc_InitRng(&rng);
+    } else return -1;
+    if (ret == 0) {
+        ret = wc_RsaSetRNG(&key, &rng);
+    } else return -1;
+    if (ret == 0) {
+            ret = wc_MakeRsaKey(&key, 2048, WC_RSA_EXPONENT, &rng);
+    } else return -1;
+    if (ret == 0) {
+        digestSz = wc_HashGetDigestSize(WC_HASH_TYPE_SHA256);
+        ret = wc_Hash(WC_HASH_TYPE_SHA256, message, sz, digest, digestSz);
+    } else return -1;
+    ret = wc_RsaPSS_Sign(digest, digestSz, pSignature, sizeof(pSignature),
+            WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key, &rng);
+    if (ret > 0 ){
+        sz = ret;
+    } else return -1;
+
+    verify = wc_RsaPSS_Verify(pSignature, sz, out, outLen,
+            WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key);
+    if (verify <= 0)return -1;
+
+    ret = wc_RsaPSS_CheckPadding_ex(digest, digestSz, out, verify, hash, saltLen, 0);
+
+    wc_FreeRsaKey(&key);
+    wc_FreeRng(&rng);
+    \endcode
+    \sa wc_RsaPSS_Sign
+    \sa wc_RsaPSS_Verify
+    \sa wc_RsaPSS_VerifyInline
+    \sa wc_RsaPSS_VerifyCheck
+    \sa wc_RsaPSS_VerifyCheck_ex
+    \sa wc_RsaPSS_VerifyCheckInline
+    \sa wc_RsaPSS_VerifyCheckInline_ex
+    \sa wc_RsaPSS_CheckPadding
+*/
+int  wc_RsaPSS_CheckPadding_ex(const byte* in, word32 inLen, byte* sig,
+                word32 sigSz, enum wc_HashType hashType, int saltLen, int bits);
+/*!
+    \ingroup RSA 
+    \brief  提供されたキー構造の暗号化サイズを返します。
+    \return Success  提供されたキー構造の暗号化サイズ。
+    _Example_
+    \code
+    int sz = wc_RsaEncryptSize(&key);
+    \endcode
+    \sa wc_InitRsaKey
+    \sa wc_InitRsaKey_ex
+    \sa wc_MakeRsaKey
+*/
+int  wc_RsaEncryptSize(RsaKey* key);
+
+/*!
+    \ingroup RSA 
+    \brief  この関数はDerフォーマットされたRSA秘密鍵を解析し、秘密鍵を抽出し、それを与えられたResakey構造に格納します。IDXに解析された距離も設定します。
+    \return 0  DERエンコード入力から秘密鍵の解析に成功したときに返されます
+    \return ASN_PARSE_E  入力バッファから秘密鍵を解析するエラーがある場合に返されます。これは、入力秘密鍵がASN.1規格に従って正しくフォーマットされていない場合に発生する可能性があります。
+    \return ASN_RSA_KEY_E  RSAキー入力の秘密鍵要素を読み取るエラーがある場合
+    \param input  デコードするDERフォーマット秘密鍵を含むバッファへのポインタ
+    \param inOutIdx  キーが始まるバッファ内のインデックスへのポインタ（通常は0）。この関数の副作用として、InoutIDXは入力バッファを介して解析された距離を記憶します
+    \param key  デコードされた秘密鍵を保存するRSAKEY構造へのポインタ
+    _Example_
+    \code
+    RsaKey enc;
+    word32 idx = 0;
+    int ret = 0;
+    byte der[] = { // initialize with DER-encoded RSA private key };
+
+    wc_InitRsaKey(&enc, NULL); // not using heap hint. No custom memory
+    ret = wc_RsaPrivateKeyDecode(der, &idx, &enc, sizeof(der));
+    if( ret != 0 ) {
+    	// error parsing private key
+    }
+    \endcode
+    \sa wc_RsaPublicKeyDecode
+    \sa wc_MakeRsaKey
+*/
+int  wc_RsaPrivateKeyDecode(const byte* input, word32* inOutIdx,
+                            RsaKey* key, word32 inSz);
+
+/*!
+    \ingroup RSA 
+    \brief  この関数はDerフォーマットのRSA公開鍵を解析し、公開鍵を抽出し、それを指定されたResakey構造に格納します。IDXに解析された距離も設定します。
+    \return 0  DERエンコード入力から公開鍵の解析に成功したときに返された
+    \return ASN_PARSE_E  入力バッファから公開鍵を解析したエラーがある場合に返されます。これは、入力公開鍵がASN.1規格に従って正しくフォーマットされていない場合に発生する可能性があります。
+    \return ASN_OBJECT_ID_E  ASN.1オブジェクトIDがRSA公開鍵のそれと一致しない場合に返されます。
+    \return ASN_EXPECT_0_E  入力キーがASN.1規格に従って正しくフォーマットされていない場合
+    \return ASN_BITSTR_E  入力キーがASN.1規格に従って正しくフォーマットされていない場合
+    \return ASN_RSA_KEY_E  RSAキー入力の公開鍵要素を読み取るエラーがある場合
+    \param input  復号する入力DERエンコードRSA公開鍵を含むバッファへのポインタ
+    \param inOutIdx  キーが始まるバッファ内のインデックスへのポインタ（通常は0）。この関数の副作用として、InoutIDXは入力バッファを介して解析された距離を記憶します
+    \param key  デコードされた公開鍵を保存するRSAKEY構造体へのポインタ
+    _Example_
+    \code
+    RsaKey pub;
+    word32 idx = 0;
+    int ret = 0;
+    byte der[] = { // initialize with DER-encoded RSA public key };
+
+    wc_InitRsaKey(&pub, NULL); // not using heap hint. No custom memory
+    ret = wc_RsaPublicKeyDecode(der, &idx, &pub, sizeof(der));
+    if( ret != 0 ) {
+    	// error parsing public key
+    }
+    \endcode
+    \sa wc_RsaPublicKeyDecodeRaw
+*/
+int  wc_RsaPublicKeyDecode(const byte* input, word32* inOutIdx,
+                           RsaKey* key, word32 inSz);
+
+/*!
+    \ingroup RSA 
+    \brief  この関数は、公開弾性率（n）と指数（e）を撮影して、RSA公開鍵の生の要素を復号します。これらの生の要素を提供されたRSAKEY構造体に格納し、暗号化/復号化プロセスで使用することができます。
+    \return 0  公開鍵の生の要素をRSAKEY構造に復号したときに返された
+    \return BAD_FUNC_ARG  いずれかの入力引数がNULLに評価された場合に返されます。
+    \return MP_INIT_E  複数の精密整数（MP_INT）ライブラリで使用するための整数の初期化中にエラーがある場合
+    \return ASN_GETINT_E  提供されたRSAキー要素、nまたはeのいずれかを読むエラーがある場合に返されます
+    \param n  Public RSAキーのRAWモジュラスパラメータを含むバッファへのポインタ
+    \param nSz  Nを含むバッファのサイズ
+    \param e  Public RSAキーのRAW指数パラメータを含むバッファへのポインタ
+    \param eSz  Eを含むバッファのサイズ
+    _Example_
+    \code
+    RsaKey pub;
+    int ret = 0;
+    byte n[] = { // initialize with received n component of public key };
+    byte e[] = { // initialize with received e component of public key };
+
+    wc_InitRsaKey(&pub, NULL); // not using heap hint. No custom memory
+    ret = wc_RsaPublicKeyDecodeRaw(n, sizeof(n), e, sizeof(e), &pub);
+    if( ret != 0 ) {
+    	// error parsing public key elements
+    }
+    \endcode
+    \sa wc_RsaPublicKeyDecode
+*/
+int  wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz,
+                                        const byte* e, word32 eSz, RsaKey* key);
+
+/*!
+    \ingroup RSA 
+    \brief  この機能はRSAKEYキーをDERフォーマットに変換します。結果は出力に書き込まれ、書き込まれたバイト数を返します。
+    \return 0  成功
+    \return BAD_FUNC_ARG  キーまたは出力がNULLの場合、またはキー - >タイプがRSA_PRIVATEでない場合、またはINLENが出力バッファに十分な大きさでない場合は返されます。
+    \return MEMORY_E  メモリの割り当て中にエラーが発生した場合に返されます。
+    \param key  初期化されたRSAKEY構造
+    \param output  出力バッファへのポインタ。
+    _Example_
+    \code
+    byte* der;
+    // Allocate memory for der
+    int derSz = // Amount of memory allocated for der;
+    RsaKey key;
+    WC_WC_RNG rng;
+    long e = 65537; // standard value to use for exponent
+    ret = wc_MakeRsaKey(&key, 2048, e, &rng); // generate 2048 bit long
+    private key
+    wc_InitRsaKey(&key, NULL);
+    wc_InitRng(&rng);
+    if(wc_RsaKeyToDer(&key, der, derSz) != 0)
+    {
+        // Handle the error thrown
+    }
+    \endcode
+    \sa wc_RsaKeyToPublicDer
+    \sa wc_InitRsaKey
+    \sa wc_MakeRsaKey
+    \sa wc_InitRng
+*/
+int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen);
+
+/*!
+    \ingroup RSA 
+    \brief  この機能は、どのパディングを使用するかを選択しながらRSA暗号化を実行します。
+    \return size  正常に暗号化されていると、暗号化されたバッファのサイズが返されます
+    \return RSA_BUFFER_E  RSAバッファエラー、出力が小さすぎたり入力が大きすぎたりする
+    \param in  暗号化のためのバッファへのポインタ
+    \param inLen  暗号化するバッファの長さ
+    \param out  暗号化されたMSGが作成されました
+    \param outLen  暗号化されたMSGを保持するために利用可能なバッファの長さ
+    \param key  初期化RSAキー構造体
+    \param rng  初期化されたWC_RNG構造体
+    \param type  使用するパディングの種類（WC_RSA_OAEP_PADまたはWC_RSA_PKCSV15_PAD）
+    \param hash  使用するハッシュの種類（選択はhash.hにあります）
+    \param mgf  使用するマスク生成機能の種類
+    \param label  暗号化されたメッセージに関連付けるオプションのラベル
+    _Example_
+    \code
+    WC_WC_WC_RNG rng;
+    RsaKey key;
+    byte in[] = “I use Turing Machines to ask questions”
+    byte out[256];
+    int ret;
+    …
+
+    ret = wc_RsaPublicEncrypt_ex(in, sizeof(in), out, sizeof(out), &key, &rng,
+    WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA, WC_MGF1SHA1, NULL, 0);
+    if (ret < 0) {
+	    //handle error
+    }
+    \endcode
+    \sa wc_RsaPublicEncrypt
+    \sa wc_RsaPrivateDecrypt_ex
+*/
+int  wc_RsaPublicEncrypt_ex(const byte* in, word32 inLen, byte* out,
+                   word32 outLen, RsaKey* key, WC_RNG* rng, int type,
+                   enum wc_HashType hash, int mgf, byte* label, word32 labelSz);
+
+/*!
+    \ingroup RSA 
+    \brief  この関数はRSAを使用してメッセージを復号化し、どのパディングタイプのオプションを指定します。
+    \return size  復号化が成功すると、復号化されたメッセージのサイズが返されます。
+    \return MEMORY_E  必要な配列をMallocにMallocにするのに十分なメモリがない場合は返されます。
+    \return BAD_FUNC_ARG  関数に渡された引数が渡された場合に返されます。
+    \param in  復号化のためのバッファへのポインタ
+    \param inLen  復号化するバッファの長さ
+    \param out  復号化されたMSGが作成されました
+    \param outLen  復号化されたMSGを保持するために利用可能なバッファの長さ
+    \param key  初期化RSAキー構造体
+    \param type  使用するパディングの種類（WC_RSA_OAEP_PADまたはWC_RSA_PKCSV15_PAD）
+    \param hash  使用するハッシュの種類（選択はhash.hにあります）
+    \param mgf  使用するマスク生成機能の種類
+    \param label  暗号化されたメッセージに関連付けるオプションのラベル
+    _Example_
+    \code
+    WC_WC_WC_RNG rng;
+    RsaKey key;
+    byte in[] = “I use Turing Machines to ask questions”
+    byte out[256];
+    byte plain[256];
+    int ret;
+    …
+    ret = wc_RsaPublicEncrypt_ex(in, sizeof(in), out, sizeof(out), &key,
+    &rng, WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA, WC_MGF1SHA1, NULL, 0);
+    if (ret < 0) {
+	    //handle error
+    }
+    …
+    ret = wc_RsaPrivateDecrypt_ex(out, ret, plain, sizeof(plain), &key,
+    WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA, WC_MGF1SHA1, NULL, 0);
+
+    if (ret < 0) {
+	    //handle error
+    }
+    \endcode
+    \sa none
+*/
+int  wc_RsaPrivateDecrypt_ex(const byte* in, word32 inLen,
+                   byte* out, word32 outLen, RsaKey* key, int type,
+                   enum wc_HashType hash, int mgf, byte* label, word32 labelSz);
+
+/*!
+    \ingroup RSA 
+    \brief  この関数はRSAを使用してメッセージをインラインで復号化し、どのパディングタイプのオプションを示します。INバッファには、呼び出された後に復号化されたメッセージが含まれ、アウトバイトポインタはプレーンテキストがある「IN」バッファ内の場所を指します。
+    \return size  復号化が成功すると、復号化されたメッセージのサイズが返されます。
+    \return MEMORY_E:  必要な配列をMallocにMallocにするのに十分なメモリがない場合は返されます。
+    \return RSA_PAD_E:  パディングのエラーが発生した場合に返されます。
+    \return BAD_PADDING_E:  過去のパディングの解析中にエラーが発生した場合に返されます。
+    \return BAD_FUNC_ARG:  関数に渡された引数が渡された場合に返されます。
+    \param in  復号化のためのバッファへのポインタ
+    \param inLen  復号化するバッファの長さ
+    \param out  "in"バッファの復号化されたメッセージの位置へのポインタ
+    \param key  初期化RSAキー構造体
+    \param type  使用するパディングの種類（WC_RSA_OAEP_PADまたはWC_RSA_PKCSV15_PAD）
+    \param hash  使用するハッシュの種類（選択はhash.hにあります）
+    \param mgf  使用するマスク生成機能の種類
+    \param label  暗号化されたメッセージに関連付けるオプションのラベル
+    _Example_
+    \code
+    WC_WC_WC_RNG rng;
+    RsaKey key;
+    byte in[] = “I use Turing Machines to ask questions”
+    byte out[256];
+    byte* plain;
+    int ret;
+    …
+    ret = wc_RsaPublicEncrypt_ex(in, sizeof(in), out, sizeof(out), &key,
+    &rng, WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA, WC_MGF1SHA1, NULL, 0);
+
+    if (ret < 0) {
+	    //handle error
+    }
+    …
+    ret = wc_RsaPrivateDecryptInline_ex(out, ret, &plain, &key,
+    WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA, WC_MGF1SHA1, NULL, 0);
+
+    if (ret < 0) {
+	    //handle error
+    }
+    \endcode
+    \sa none
+*/
+int  wc_RsaPrivateDecryptInline_ex(byte* in, word32 inLen,
+                      byte** out, RsaKey* key, int type, enum wc_HashType hash,
+                      int mgf, byte* label, word32 labelSz);
+
+/*!
+    \ingroup RSA 
+    \brief  RSAアルゴリズムに使用される個々の要素（E、N）にRSAKEY構造体を平らにします。
+    \return 0  関数が正常に実行された場合は、エラーなしで返されます。
+    \return BAD_FUNC_ARG:  いずれかのパラメータがNULL値で渡された場合に返されます。
+    \return RSA_BUFFER_E:  渡されたeまたはnバッファが正しいサイズではない場合に返されます。
+    \return MP_MEM:  内部関数にメモリエラーがある場合に返されます。
+    \return MP_VAL:  内部関数引数が無効な場合に返されます。
+    \param key  検証に使用する鍵。
+    \param e  eの値のバッファー。eはRSAモジュラ演算での大きな正の整数です。
+    \param eSz  eバッファのサイズ。
+    \param n  nの値のバッファー。NはRSAモジュラー演算では大きな正の整数です。
+    _Example_
+    \code
+    Rsa key; // A valid RSA key.
+    byte e[ buffer sz E.g. 256 ];
+    byte n[256];
+    int ret;
+    word32 eSz = sizeof(e);
+    word32 nSz = sizeof(n);
+    ...
+    ret = wc_RsaFlattenPublicKey(&key, e, &eSz, n, &nSz);
+    if (ret != 0) {
+    	// Failure case.
+    }
+    \endcode
+    \sa wc_InitRsaKey
+    \sa wc_InitRsaKey_ex
+    \sa wc_MakeRsaKey
+*/
+int  wc_RsaFlattenPublicKey(RsaKey* key, byte* e, word32* eSz, byte* n,
+                            word32* nSz);
+
+/*!
+    \ingroup RSA 
+    \brief  RSA公開鍵をDERフォーマットに変換します。出力に書き込み、書き込まれたバイト数を返します。
+    \return >0  成功、書かれたバイト数。
+    \return BAD_FUNC_ARG  キーまたは出力がNULLの場合に返されます。
+    \return MEMORY_E  エラー割り当てメモリが発生したときに返されます。
+    \return <0  エラー
+    \param key  変換するRSAキー構造。
+    \param output  保留された出力バッファー。（NULLが長さのみを返す場合）
+    _Example_
+    \code
+    RsaKey key;
+
+    wc_InitRsaKey(&key, NULL);
+    // Use key
+
+    const int BUFFER_SIZE = 1024; // Some adequate size for the buffer
+    byte output[BUFFER_SIZE];
+    if (wc_RsaKeyToPublicDer(&key, output, sizeof(output)) != 0) {
+        // Handle Error
+    }
+    \endcode
+    \sa wc_RsaPublicKeyDerSize
+    \sa wc_RsaKeyToPublicDer_ex
+    \sa wc_InitRsaKey
+*/
+int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 inLen);
+
+/*!
+    \ingroup RSA 
+    \brief  RSA公開鍵をDERフォーマットに変換します。出力に書き込み、書き込まれたバイト数を返します。with_headerが0の場合（seq + n + e）だけがASN.1 Derフォーマットで返され、ヘッダーを除外します。
+    \return >0  成功、書かれたバイト数。
+    \return BAD_FUNC_ARG  キーまたは出力がNULLの場合に返されます。
+    \return MEMORY_E  エラー割り当てメモリが発生したときに返されます。
+    \return <0  エラー
+    \param key  変換するRSAキー構造。
+    \param output  保留された出力バッファー。（NULLが長さのみを返す場合）
+    _Example_
+    \code
+    RsaKey key;
+
+    wc_InitRsaKey(&key, NULL);
+    // Use key
+
+    const int BUFFER_SIZE = 1024; // Some adequate size for the buffer
+    byte output[BUFFER_SIZE];
+    if (wc_RsaKeyToPublicDer_ex(&key, output, sizeof(output), 0) != 0) {
+        // Handle Error
+    }
+    \endcode
+    \sa wc_RsaPublicKeyDerSize
+    \sa wc_RsaKeyToPublicDer
+    \sa wc_InitRsaKey
+*/
+int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 inLen,
+    int with_header);
+
+/*!
+    \ingroup RSA 
+    \brief  この関数は、長さサイズ（ビット単位）のRSA秘密鍵を生成し、指数（e）を指定します。次に、このキーを提供されたRSAKEY構造体に格納するため、暗号化/復号化に使用できます。Eに使用するセキュア番号は65537です。サイズは、RSA_MIN_SIZEよりも大きく、RSA_MAX_SIZEよりも大きくなる必要があります。この機能が利用可能であるため、コンパイル時にオプションwolfssl_key_genを有効にする必要があります。これは、 - を使用してください./configureを使用する場合は、-enable-keygenで実現できます。
+    \return 0  RSA秘密鍵の生成に成功したら返されました
+    \return BAD_FUNC_ARG  入力引数のいずれかがNULLの場合、サイズパラメータは必要な範囲外にあるか、eが誤って選択されている場合
+    \return RNG_FAILURE_E  提供されたRNG構造体を使用してランダムブロックを生成するエラーがある場合
+    \return MP_INIT_E 
+    \return MP_READ_E  RSAキーの生成中に使用された数学ライブラリにエラーがある場合に返されたRSAキーの生成中に使用された数学ライブラリにエラーがある場合に返される可能性があります。
+    \return MP_CMP_E  RSAキーの生成中に使用されている数学ライブラリにエラーがある場合は返される可能性があります。
+    \return MP_INVMOD_E  RSAキーの生成中に使用されている数学ライブラリにエラーがある場合は返される可能性があります。
+    \return MP_EXPTMOD_E  RSAキーの生成中に使用されている数学ライブラリにエラーがある場合は返される可能性があります。
+    \return MP_MOD_E  RSAキーの生成中に使用されている数学ライブラリにエラーがある場合は返される可能性があります。
+    \return MP_MUL_E  RSAキーの生成中に使用されている数学ライブラリにエラーがある場合は返される可能性があります。
+    \return MP_ADD_E  RSAキーの生成中に使用されている数学ライブラリにエラーがある場合は返される可能性があります。
+    \return MP_MULMOD_E  RSAキーの生成中に使用されている数学ライブラリにエラーがある場合は返される可能性があります。
+    \return MP_TO_E  RSAキーの生成中に使用されている数学ライブラリにエラーがある場合は返される可能性があります。
+    \return MP_MEM  RSAキーの生成中に使用されている数学ライブラリにエラーがある場合は返される可能性があります。
+    \return MP_ZERO_E  RSAキーの生成中に使用されている数学ライブラリにエラーがある場合は返される可能性があります。
+    \param key  生成された秘密鍵を保存するRSAKEY構造体へのポインタ
+    \param size  ビット単位の希望のキー長。rsa_min_sizeより大きく、rsa_max_sizeよりも大きくなる必要があります。
+    \param e  キーを生成するために使用する指数パラメータ。安全な選択は65537です
+    _Example_
+    \code
+    RsaKey priv;
+    WC_WC_RNG rng;
+    int ret = 0;
+    long e = 65537; // standard value to use for exponent
+
+    wc_InitRsaKey(&priv, NULL); // not using heap hint. No custom memory
+    wc_InitRng(&rng);
+    // generate 2048 bit long private key
+    ret = wc_MakeRsaKey(&priv, 2048, e, &rng);
+    if( ret != 0 ) {
+	    // error generating private key
+    }
+    \endcode
+    \sa none
+*/
+int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng);
+
+/*!
+    \ingroup RSA 
+    \brief  この関数は、ブロックされていないRSAコンテキストを設定します。RSANBコンテキストが設定されている場合、RSA関数を多くの小さな操作に分割する高速数学ベースの非ブロッキングEXPTMODが可能になります。wc_rsa_nonblockが定義されているときに有効になっています。
+    \return 0  成功
+    \return BAD_FUNC_ARG  キーまたはNBがNULLの場合に返されます。
+    \param key  RSAキー構造
+    _Example_
+    \code
+    int ret, count = 0;
+    RsaKey key;
+    RsaNb  nb;
+
+    wc_InitRsaKey(&key, NULL);
+
+    // Enable non-blocking RSA mode - provide context
+    ret = wc_RsaSetNonBlock(key, &nb);
+    if (ret != 0)
+        return ret;
+
+    do {
+        ret = wc_RsaSSL_Sign(in, inLen, out, outSz, key, rng);
+        count++; // track number of would blocks
+        if (ret == FP_WOULDBLOCK) {
+            // do "other" work here
+        }
+    } while (ret == FP_WOULDBLOCK);
+    if (ret < 0) {
+        return ret;
+    }
+
+    printf("RSA non-block sign: size %d, %d times\n", ret, count);
+    \endcode
+    \sa wc_RsaSetNonBlockTime
+*/
+int wc_RsaSetNonBlock(RsaKey* key, RsaNb* nb);
+
+/*!
+    \ingroup RSA 
+    \brief  この関数は最大ブロック時間の最大ブロック時間をマイクロ秒単位で設定します。それは、メガヘルツのCPU速度と共に事前計算されたテーブル（TFM.cexptModnbinstを参照）を使用して、提供された最大ブロック時間内に次の動作を完了できるかどうかを判断します。wc_rsa_nonblock_timeが定義されているときに有効になります。
+    \return 0  成功
+    \return BAD_FUNC_ARG  キーがNULLの場合、またはWC_RSASETNONBLOCKが以前に呼び出され、キー - > NBはNULLの場合に返されます。
+    \param key  RSAキー構造
+    \param maxBlockUs  マイクロ秒をブロックする最大時間。
+    _Example_
+    \code
+    RsaKey key;
+    RsaNb  nb;
+
+    wc_InitRsaKey(&key, NULL);
+    wc_RsaSetNonBlock(key, &nb);
+    wc_RsaSetNonBlockTime(&key, 4000, 160); // Block Max = 4 ms, CPU = 160MHz
+
+    \endcode
+    \sa wc_RsaSetNonBlock
+*/
+int wc_RsaSetNonBlockTime(RsaKey* key, word32 maxBlockUs,
+    word32 cpuMHz);

--- a/doc/dox_comments/header_files-ja/sakke.h
+++ b/doc/dox_comments/header_files-ja/sakke.h
@@ -1,0 +1,114 @@
+
+/*!
+*/
+int wc_InitSakkeKey(SakkeKey* key, void* heap, int devId);
+/*!
+*/
+int wc_InitSakkeKey_ex(SakkeKey* key, int keySize, int curveId,
+        void* heap, int devId);
+/*!
+*/
+void wc_FreeSakkeKey(SakkeKey* key);
+
+/*!
+*/
+int wc_MakeSakkeKey(SakkeKey* key, WC_RNG* rng);
+/*!
+*/
+int wc_MakeSakkePublicKey(SakkeKey* key, ecc_point* pub);
+
+/*!
+*/
+int wc_MakeSakkeRsk(SakkeKey* key, const byte* id, word16 idSz,
+        ecc_point* rsk);
+/*!
+*/
+int wc_ValidateSakkeRsk(SakkeKey* key, const byte* id, word16 idSz,
+        ecc_point* rsk, int* valid);
+/*!
+*/
+int wc_GenerateSakkeRskTable(const SakkeKey* key,
+        const ecc_point* rsk, byte* table, word32* len);
+
+
+/*!
+*/
+int wc_ExportSakkeKey(SakkeKey* key, byte* data, word32* sz);
+/*!
+*/
+int wc_ImportSakkeKey(SakkeKey* key, const byte* data, word32 sz);
+/*!
+*/
+int wc_ExportSakkePrivateKey(SakkeKey* key, byte* data, word32* sz);
+/*!
+*/
+int wc_ImportSakkePrivateKey(SakkeKey* key, const byte* data,
+        word32 sz);
+
+/*!
+*/
+int wc_EncodeSakkeRsk(const SakkeKey* key, ecc_point* rsk,
+        byte* out, word32* sz, int raw);
+/*!
+*/
+int wc_DecodeSakkeRsk(const SakkeKey* key, const byte* data,
+        word32 sz, ecc_point* rsk);
+
+/*!
+*/
+int wc_ImportSakkeRsk(SakkeKey* key, const byte* data, word32 sz);
+
+/*!
+*/
+int wc_ExportSakkePublicKey(SakkeKey* key, byte* data,
+        word32* sz, int raw);
+/*!
+*/
+int wc_ImportSakkePublicKey(SakkeKey* key, const byte* data,
+        word32 sz, int trusted);
+
+/*!
+*/
+int wc_GetSakkeAuthSize(SakkeKey* key, word16* authSz);
+/*!
+*/
+int wc_SetSakkeIdentity(SakkeKey* key, const byte* id, word16 idSz);
+/*!
+*/
+int wc_MakeSakkePointI(SakkeKey* key, const byte* id, word16 idSz);
+/*!
+*/
+int wc_GetSakkePointI(SakkeKey* key, byte* data, word32* sz);
+/*!
+*/
+int wc_SetSakkePointI(SakkeKey* key, const byte* id, word16 idSz,
+        const byte* data, word32 sz);
+/*!
+*/
+int wc_GenerateSakkePointITable(SakkeKey* key, byte* table,
+         word32* len);
+/*!
+*/
+int wc_SetSakkePointITable(SakkeKey* key, byte* table, word32 len);
+/*!
+*/
+int wc_ClearSakkePointITable(SakkeKey* key);
+/*!
+*/
+int wc_MakeSakkeEncapsulatedSSV(SakkeKey* key,
+        enum wc_HashType hashType, byte* ssv, word16 ssvSz, byte* auth,
+        word16* authSz);
+/*!
+*/
+int wc_GenerateSakkeSSV(SakkeKey* key, WC_RNG* rng, byte* ssv,
+        word16* ssvSz);
+/*!
+*/
+int wc_SetSakkeRsk(SakkeKey* key, const ecc_point* rsk, byte* table,
+        word32 len);
+/*!
+*/
+int wc_DeriveSakkeSSV(SakkeKey* key, enum wc_HashType hashType,
+        byte* ssv, word16 ssvSz, const byte* auth,
+        word16 authSz);
+

--- a/doc/dox_comments/header_files-ja/sha.h
+++ b/doc/dox_comments/header_files-ja/sha.h
@@ -1,0 +1,110 @@
+/*!
+    \ingroup SHA 
+    \brief  この関数はSHAを初期化します。これは自動的にWC_Shahashによって呼び出されます。
+    \return 0  初期化に成功したときに返されます
+    _Example_
+    \code
+    Sha sha[1];
+    if ((ret = wc_InitSha(sha)) != 0) {
+       WOLFSSL_MSG("wc_InitSha failed");
+    }
+    else {
+       wc_ShaUpdate(sha, data, len);
+       wc_ShaFinal(sha, hash);
+    }
+    \endcode
+    \sa wc_ShaHash
+    \sa wc_ShaUpdate
+    \sa wc_ShaFinal
+*/
+int wc_InitSha(wc_Sha*);
+
+/*!
+    \ingroup SHA 
+    \brief  長さLENの提供されたバイト配列を絶えずハッシュするように呼び出すことができます。
+    \return 0  データをダイジェストに正常に追加すると返されます。
+    \param sha  暗号化に使用するSHA構造へのポインタ
+    \param data  ハッシュするデータ
+    _Example_
+    \code
+    Sha sha[1];
+    byte data[] = { // Data to be hashed };
+    word32 len = sizeof(data);
+
+    if ((ret = wc_InitSha(sha)) != 0) {
+       WOLFSSL_MSG("wc_InitSha failed");
+    }
+    else {
+       wc_ShaUpdate(sha, data, len);
+       wc_ShaFinal(sha, hash);
+    }
+    \endcode
+    \sa wc_ShaHash
+    \sa wc_ShaFinal
+    \sa wc_InitSha
+*/
+int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len);
+
+/*!
+    \ingroup SHA 
+    \brief  データのハッシュを確定します。結果はハッシュに入れられます。SHA構造体の状態をリセットします。
+    \return 0  ファイナライズに成功したときに返されます。
+    \param sha  暗号化に使用するSHA構造へのポインタ
+    _Example_
+    \code
+    Sha sha[1];
+    byte data[] = { Data to be hashed };
+    word32 len = sizeof(data);
+
+    if ((ret = wc_InitSha(sha)) != 0) {
+       WOLFSSL_MSG("wc_InitSha failed");
+    }
+    else {
+       wc_ShaUpdate(sha, data, len);
+       wc_ShaFinal(sha, hash);
+    }
+    \endcode
+    \sa wc_ShaHash
+    \sa wc_InitSha
+    \sa wc_ShaGetHash
+*/
+int wc_ShaFinal(wc_Sha* sha, byte* hash);
+
+/*!
+    \ingroup SHA 
+    \brief  初期化されたSHA構造体によって使用されるメモリをクリーンアップするために使用されます。注：これは、wolfssl_ti_hashが定義されている場合にのみサポートされています。
+    \return No  戻り値。
+    _Example_
+    \code
+    Sha sha;
+    wc_InitSha(&sha);
+    // Use sha
+    wc_ShaFree(&sha);
+    \endcode
+    \sa wc_InitSha
+    \sa wc_ShaUpdate
+    \sa wc_ShaFinal
+*/
+void wc_ShaFree(wc_Sha*);
+
+/*!
+    \ingroup SHA 
+    \brief  ハッシュデータを取得します。結果はハッシュに入れられます。SHA構造体の状態をリセットしません。
+    \return 0  ファイナライズに成功したときに返されます。
+    \param sha  暗号化に使用するSHA構造へのポインタ
+    _Example_
+    \code
+    Sha sha[1];
+    if ((ret = wc_InitSha(sha)) != 0) {
+    WOLFSSL_MSG("wc_InitSha failed");
+    }
+    else {
+        wc_ShaUpdate(sha, data, len);
+        wc_ShaGetHash(sha, hash);
+    }
+    \endcode
+    \sa wc_ShaHash
+    \sa wc_ShaFinal
+    \sa wc_InitSha
+*/
+int wc_ShaGetHash(wc_Sha* sha, byte* hash);

--- a/doc/dox_comments/header_files-ja/sha256.h
+++ b/doc/dox_comments/header_files-ja/sha256.h
@@ -1,0 +1,191 @@
+/*!
+    \ingroup SHA 
+    \brief  この関数はSHA256を初期化します。これはWC_SHA256HASHによって自動的に呼び出されます。
+    \return 0  初期化に成功したときに返されます
+    _Example_
+    \code
+    Sha256 sha256[1];
+    if ((ret = wc_InitSha256(sha256)) != 0) {
+        WOLFSSL_MSG("wc_InitSha256 failed");
+    }
+    else {
+        wc_Sha256Update(sha256, data, len);
+        wc_Sha256Final(sha256, hash);
+    }
+    \endcode
+    \sa wc_Sha256Hash
+    \sa wc_Sha256Update
+    \sa wc_Sha256Final
+*/
+int wc_InitSha256(wc_Sha256*);
+
+/*!
+    \ingroup SHA 
+    \brief  長さLENの提供されたバイト配列を絶えずハッシュするように呼び出すことができます。
+    \return 0  データをダイジェストに正常に追加すると返されます。
+    \param sha256  暗号化に使用するSHA256構造へのポインタ
+    \param data  ハッシュするデータ
+    _Example_
+    \code
+    Sha256 sha256[1];
+    byte data[] = { Data to be hashed };
+    word32 len = sizeof(data);
+
+    if ((ret = wc_InitSha256(sha256)) != 0) {
+       WOLFSSL_MSG("wc_InitSha256 failed");
+    }
+    else {
+        wc_Sha256Update(sha256, data, len);
+        wc_Sha256Final(sha256, hash);
+    }
+    \endcode
+    \sa wc_Sha256Hash
+    \sa wc_Sha256Final
+    \sa wc_InitSha256
+*/
+int wc_Sha256Update(wc_Sha256* sha, const byte* data, word32 len);
+
+/*!
+    \ingroup SHA 
+    \brief  データのハッシュを確定します。結果はハッシュに入れられます。SHA256構造体の状態をリセットします。
+    \return 0  ファイナライズに成功したときに返されます。
+    \param sha256  暗号化に使用するSHA256構造へのポインタ
+    _Example_
+    \code
+    Sha256 sha256[1];
+    byte data[] = { Data to be hashed };
+    word32 len = sizeof(data);
+
+    if ((ret = wc_InitSha256(sha256)) != 0) {
+       WOLFSSL_MSG("wc_InitSha256 failed");
+    }
+    else {
+       wc_Sha256Update(sha256, data, len);
+       wc_Sha256Final(sha256, hash);
+    }
+    \endcode
+    \sa wc_Sha256Hash
+    \sa wc_Sha256GetHash
+    \sa wc_InitSha256
+*/
+int wc_Sha256Final(wc_Sha256* sha256, byte* hash);
+
+/*!
+    \ingroup SHA 
+    \brief  SHA256構造をリセットします。注：これは、wolfssl_ti_hashが定義されている場合にのみサポートされています。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    Sha256 sha256;
+    byte data[] = { Data to be hashed };
+    word32 len = sizeof(data);
+
+    if ((ret = wc_InitSha256(&sha256)) != 0) {
+        WOLFSSL_MSG("wc_InitSha256 failed");
+    }
+    else {
+        wc_Sha256Update(&sha256, data, len);
+        wc_Sha256Final(&sha256, hash);
+        wc_Sha256Free(&sha256);
+    }
+    \endcode
+    \sa wc_InitSha256
+    \sa wc_Sha256Update
+    \sa wc_Sha256Final
+*/
+void wc_Sha256Free(wc_Sha256*);
+
+/*!
+    \ingroup SHA 
+    \brief  ハッシュデータを取得します。結果はハッシュに入れられます。SHA256構造体の状態をリセットしません。
+    \return 0  ファイナライズに成功したときに返されます。
+    \param sha256  暗号化に使用するSHA256構造へのポインタ
+    _Example_
+    \code
+    Sha256 sha256[1];
+    if ((ret = wc_InitSha256(sha256)) != 0) {
+       WOLFSSL_MSG("wc_InitSha256 failed");
+    }
+    else {
+       wc_Sha256Update(sha256, data, len);
+       wc_Sha256GetHash(sha256, hash);
+    }
+    \endcode
+    \sa wc_Sha256Hash
+    \sa wc_Sha256Final
+    \sa wc_InitSha256
+*/
+int wc_Sha256GetHash(wc_Sha256* sha256, byte* hash);
+
+/*!
+    \ingroup SHA 
+    \brief  SHA224構造を初期化するために使用されます。
+    \return 0  成功
+    \return 1  SHA224がNULLなので、エラーが返されました。
+    _Example_
+    \code
+    Sha224 sha224;
+    if(wc_InitSha224(&sha224) != 0)
+    {
+        // Handle error
+    }
+    \endcode
+    \sa wc_Sha224Hash
+    \sa wc_Sha224Update
+    \sa wc_Sha224Final
+*/
+int wc_InitSha224(wc_Sha224*);
+
+/*!
+    \ingroup SHA 
+    \brief  長さLENの提供されたバイト配列を絶えずハッシュするように呼び出すことができます。
+    \return 0  成功
+    \return 1  関数が失敗した場合はエラーが返されます。
+    \return BAD_FUNC_ARG  SHA224またはデータがNULLの場合、エラーが返されます。
+    \param sha224  暗号化に使用するSHA224構造へのポインタ。
+    \param data  ハッシュするデータ。
+    _Example_
+    \code
+    Sha224 sha224;
+    byte data[] = { /* Data to be hashed };
+    word32 len = sizeof(data);
+
+    if ((ret = wc_InitSha224(&sha224)) != 0) {
+       WOLFSSL_MSG("wc_InitSha224 failed");
+    }
+    else {
+      wc_Sha224Update(&sha224, data, len);
+      wc_Sha224Final(&sha224, hash);
+    }
+    \endcode
+    \sa wc_InitSha224
+    \sa wc_Sha224Final
+    \sa wc_Sha224Hash
+*/
+int wc_Sha224Update(wc_Sha224* sha224, const byte* data, word32 len);
+
+/*!
+    \ingroup SHA 
+    \brief  データのハッシュを確定します。結果はハッシュに入れられます。SHA224構造体の状態をリセットします。
+    \return 0  成功
+    \return <0  エラー
+    \param sha224  暗号化に使用するSHA224構造へのポインタ
+    _Example_
+    \code
+    Sha224 sha224;
+    byte data[] = { /* Data to be hashed };
+    word32 len = sizeof(data);
+
+    if ((ret = wc_InitSha224(&sha224)) != 0) {
+        WOLFSSL_MSG("wc_InitSha224 failed");
+    }
+    else {
+        wc_Sha224Update(&sha224, data, len);
+        wc_Sha224Final(&sha224, hash);
+    }
+    \endcode
+    \sa wc_InitSha224
+    \sa wc_Sha224Hash
+    \sa wc_Sha224Update
+*/
+int wc_Sha224Final(wc_Sha224* sha224, byte* hash);

--- a/doc/dox_comments/header_files-ja/sha512.h
+++ b/doc/dox_comments/header_files-ja/sha512.h
@@ -1,0 +1,143 @@
+/*!
+    \ingroup SHA 
+    \brief  この関数はSHA512を初期化します。これはWC_SHA512HASHによって自動的に呼び出されます。
+    \return 0  初期化に成功したときに返されます
+    _Example_
+    \code
+    Sha512 sha512[1];
+    if ((ret = wc_InitSha512(sha512)) != 0) {
+       WOLFSSL_MSG("wc_InitSha512 failed");
+    }
+    else {
+       wc_Sha512Update(sha512, data, len);
+       wc_Sha512Final(sha512, hash);
+    }
+    \endcode
+    \sa wc_Sha512Hash
+    \sa wc_Sha512Update
+    \sa wc_Sha512Final
+*/
+int wc_InitSha512(wc_Sha512*);
+
+/*!
+    \ingroup SHA 
+    \brief  長さLENの提供されたバイト配列を絶えずハッシュするように呼び出すことができます。
+    \return 0  データをダイジェストに正常に追加すると返されます。
+    \param sha512  暗号化に使用するSHA512構造へのポインタ
+    \param data  ハッシュするデータ
+    _Example_
+    \code
+    Sha512 sha512[1];
+    byte data[] = { Data to be hashed };
+    word32 len = sizeof(data);
+
+    if ((ret = wc_InitSha512(sha512)) != 0) {
+       WOLFSSL_MSG("wc_InitSha512 failed");
+    }
+    else {
+       wc_Sha512Update(sha512, data, len);
+       wc_Sha512Final(sha512, hash);
+    }
+    \endcode
+    \sa wc_Sha512Hash
+    \sa wc_Sha512Final
+    \sa wc_InitSha512
+*/
+int wc_Sha512Update(wc_Sha512* sha, const byte* data, word32 len);
+
+/*!
+    \ingroup SHA 
+    \brief  データのハッシュを確定します。結果はハッシュに入れられます。
+    \return 0  ハッシュを確定するとうまく返されました。
+    \param sha512  暗号化に使用するSHA512構造へのポインタ
+    _Example_
+    \code
+    Sha512 sha512[1];
+    byte data[] = { Data to be hashed };
+    word32 len = sizeof(data);
+
+    if ((ret = wc_InitSha512(sha512)) != 0) {
+        WOLFSSL_MSG("wc_InitSha512 failed");
+    }
+    else {
+       wc_Sha512Update(sha512, data, len);
+       wc_Sha512Final(sha512, hash);
+    }
+    \endcode
+    \sa wc_Sha512Hash
+    \sa wc_Sha512Final
+    \sa wc_InitSha512
+*/
+int wc_Sha512Final(wc_Sha512* sha512, byte* hash);
+
+/*!
+    \ingroup SHA 
+    \brief  この関数はSHA384を初期化します。これはWC_SHA384HASHによって自動的に呼び出されます。
+    \return 0  初期化に成功したときに返されます
+    _Example_
+    \code
+    Sha384 sha384[1];
+    if ((ret = wc_InitSha384(sha384)) != 0) {
+       WOLFSSL_MSG("wc_InitSha384 failed");
+    }
+    else {
+       wc_Sha384Update(sha384, data, len);
+       wc_Sha384Final(sha384, hash);
+    }
+    \endcode
+    \sa wc_Sha384Hash
+    \sa wc_Sha384Update
+    \sa wc_Sha384Final
+*/
+int wc_InitSha384(wc_Sha384*);
+
+/*!
+    \ingroup SHA 
+    \brief  長さLENの提供されたバイト配列を絶えずハッシュするように呼び出すことができます。
+    \return 0  データをダイジェストに正常に追加すると返されます。
+    \param sha384  暗号化に使用するSHA384構造へのポインタ
+    \param data  ハッシュするデータ
+    _Example_
+    \code
+    Sha384 sha384[1];
+    byte data[] = { Data to be hashed };
+    word32 len = sizeof(data);
+
+    if ((ret = wc_InitSha384(sha384)) != 0) {
+       WOLFSSL_MSG("wc_InitSha384 failed");
+    }
+    else {
+       wc_Sha384Update(sha384, data, len);
+       wc_Sha384Final(sha384, hash);
+    }
+    \endcode
+    \sa wc_Sha384Hash
+    \sa wc_Sha384Final
+    \sa wc_InitSha384
+*/
+int wc_Sha384Update(wc_Sha384* sha, const byte* data, word32 len);
+
+/*!
+    \ingroup SHA 
+    \brief  データのハッシュを確定します。結果はハッシュに入れられます。
+    \return 0  ファイナライズに成功したときに返されます。
+    \param sha384  暗号化に使用するSHA384構造へのポインタ
+    _Example_
+    \code
+    Sha384 sha384[1];
+    byte data[] = { Data to be hashed };
+    word32 len = sizeof(data);
+
+    if ((ret = wc_InitSha384(sha384)) != 0) {
+       WOLFSSL_MSG("wc_InitSha384 failed");
+    }
+    else {
+       wc_Sha384Update(sha384, data, len);
+       wc_Sha384Final(sha384, hash);
+    }
+    \endcode
+    \sa wc_Sha384Hash
+    \sa wc_Sha384Final
+    \sa wc_InitSha384
+*/
+int wc_Sha384Final(wc_Sha384* sha384, byte* hash);

--- a/doc/dox_comments/header_files-ja/signature.h
+++ b/doc/dox_comments/header_files-ja/signature.h
@@ -1,0 +1,120 @@
+/*!
+    \ingroup Signature 
+    \brief  この関数は、結果のシグネチャの最大サイズを返します。
+    \return Returns  sig_type_e sig_typeがサポートされていない場合sig_typeが無効な場合はbad_func_argを返します。正の戻り値は、署名の最大サイズを示します。
+    \param sig_type  wc_signature_type_eccまたはwc_signature_type_rsaなどの署名型列挙型値。
+    \param key  ECC_KEYやRSAKEYなどのキー構造へのポインタ。
+    _Example_
+    \code
+    // Get signature length
+    enum wc_SignatureType sig_type = WC_SIGNATURE_TYPE_ECC;
+    ecc_key eccKey;
+    word32 sigLen;
+    wc_ecc_init(&eccKey);
+    sigLen = wc_SignatureGetSize(sig_type, &eccKey, sizeof(eccKey));
+    if (sigLen > 0) {
+    	// Success
+    }
+    \endcode
+    \sa wc_HashGetDigestSize
+    \sa wc_SignatureGenerate
+    \sa wc_SignatureVerify
+*/
+int wc_SignatureGetSize(enum wc_SignatureType sig_type,
+    const void* key, word32 key_len);
+
+/*!
+    \ingroup Signature 
+    \brief  この関数は、データをハッシュし、結果のハッシュとキーを使用して署名を使用して署名を使用して署名を検証します。
+    \return 0  成功
+    \return SIG_TYPE_E  -231、署名タイプが有効/利用可能です
+    \return BAD_FUNC_ARG  -173、関数の不良引数が提供されています
+    \return BUFFER_E  -132、出力バッファが小さすぎたり入力が大きすぎたりします。
+    \param hash_type  "wc_hash_type_sha256"などの "enum wc_hashtype"からのハッシュ型。
+    \param sig_type  wc_signature_type_eccまたはwc_signature_type_rsaなどの署名型列挙型値。
+    \param data  ハッシュへのデータを含むバッファへのポインタ。
+    \param data_len  データバッファの長さ。
+    \param sig  署名を出力するためのバッファへのポインタ。
+    \param sig_len  シグネチャ出力バッファの長さ。
+    \param key  ECC_KEYやRSAKEYなどのキー構造へのポインタ。
+    _Example_
+    \code
+    int ret;
+    ecc_key eccKey;
+
+    // Import the public key
+    wc_ecc_init(&eccKey);
+    ret = wc_ecc_import_x963(eccPubKeyBuf, eccPubKeyLen, &eccKey);
+    // Perform signature verification using public key
+    ret = wc_SignatureVerify(
+    WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_ECC,
+    fileBuf, fileLen,
+    sigBuf, sigLen,
+    &eccKey, sizeof(eccKey));
+    printf("Signature Verification: %s
+    (%d)\n", (ret == 0) ? "Pass" : "Fail", ret);
+    wc_ecc_free(&eccKey);
+    \endcode
+    \sa wc_SignatureGetSize
+    \sa wc_SignatureGenerate
+*/
+int wc_SignatureVerify(
+    enum wc_HashType hash_type, enum wc_SignatureType sig_type,
+    const byte* data, word32 data_len,
+    const byte* sig, word32 sig_len,
+    const void* key, word32 key_len);
+
+/*!
+    \ingroup Signature 
+    \brief  この関数は、キーを使用してデータから署名を生成します。まずデータのハッシュを作成し、キーを使用してハッシュに署名します。
+    \return 0  成功
+    \return SIG_TYPE_E  -231、署名タイプが有効/利用可能です
+    \return BAD_FUNC_ARG  -173、関数の不良引数が提供されています
+    \return BUFFER_E  -132、出力バッファが小さすぎたり入力が大きすぎたりします。
+    \param hash_type  "wc_hash_type_sha256"などの "enum wc_hashtype"からのハッシュ型。
+    \param sig_type  wc_signature_type_eccまたはwc_signature_type_rsaなどの署名型列挙型値。
+    \param data  ハッシュへのデータを含むバッファへのポインタ。
+    \param data_len  データバッファの長さ。
+    \param sig  署名を出力するためのバッファへのポインタ。
+    \param sig_len  シグネチャ出力バッファの長さ。
+    \param key  ECC_KEYやRSAKEYなどのキー構造へのポインタ。
+    \param key_len  キー構造のサイズ
+    _Example_
+    \code
+    int ret;
+    WC_RNG rng;
+    ecc_key eccKey;
+
+    wc_InitRng(&rng);
+    wc_ecc_init(&eccKey);
+
+    // Generate key
+    ret = wc_ecc_make_key(&rng, 32, &eccKey);
+
+    // Get signature length and allocate buffer
+    sigLen = wc_SignatureGetSize(sig_type, &eccKey, sizeof(eccKey));
+    sigBuf = malloc(sigLen);
+
+    // Perform signature verification using public key
+    ret = wc_SignatureGenerate(
+        WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_ECC,
+        fileBuf, fileLen,
+        sigBuf, &sigLen,
+        &eccKey, sizeof(eccKey),
+        &rng);
+    printf("Signature Generation: %s
+    (%d)\n", (ret == 0) ? "Pass" : "Fail", ret);
+
+    free(sigBuf);
+    wc_ecc_free(&eccKey);
+    wc_FreeRng(&rng);
+    \endcode
+    \sa wc_SignatureGetSize
+    \sa wc_SignatureVerify
+*/
+int wc_SignatureGenerate(
+    enum wc_HashType hash_type, enum wc_SignatureType sig_type,
+    const byte* data, word32 data_len,
+    byte* sig, word32 *sig_len,
+    const void* key, word32 key_len,
+    WC_RNG* rng);

--- a/doc/dox_comments/header_files-ja/siphash.h
+++ b/doc/dox_comments/header_files-ja/siphash.h
@@ -1,0 +1,124 @@
+
+/*!
+    \ingroup SipHash 
+    \brief  この関数は、MacサイズのキーでSiphashを初期化します。
+    \return 0  初期化に成功したときに返されます
+    \return BAD_FUNC_ARG  SiphashまたはキーがNULLのときに返されます
+    \return BAD_FUNC_ARG  OUTSZが8でも16でもない場合に返されます
+    \param siphash  Macingに使用するサイプハッシュ構造へのポインタ
+    \param key  16バイト配列へのポインタ
+    _Example_
+    \code
+    SipHash siphash[1];
+    unsigned char key[16] = { ... };
+    byte macSz = 8; // 8 or 16
+
+    if ((ret = wc_InitSipHash(siphash, key, macSz)) != 0) {
+        WOLFSSL_MSG("wc_InitSipHash failed");
+    }
+    else if ((ret = wc_SipHashUpdate(siphash, data, len)) != 0) {
+        WOLFSSL_MSG("wc_SipHashUpdate failed");
+    }
+    else if ((ret = wc_SipHashFinal(siphash, mac, macSz)) != 0) {
+        WOLFSSL_MSG("wc_SipHashFinal failed");
+    }
+    \endcode
+    \sa wc_SipHash
+    \sa wc_SipHashUpdate
+    \sa wc_SipHashFinal
+*/
+int wc_InitSipHash(SipHash* siphash, const unsigned char* key,
+    unsigned char outSz);
+
+/*!
+    \ingroup SipHash 
+    \brief  長さLENの提供されたバイト配列を絶えずハッシュするように呼び出すことができます。
+    \return 0  Macにデータを追加したら、返されます
+    \return BAD_FUNC_ARG  Siphashがnullのとき返されました
+    \return BAD_FUNC_ARG  inneがnullのとき返され、Inszはゼロではありません
+    \param siphash  Macingに使用するサイプハッシュ構造へのポインタ
+    \param in  マイートするデータ
+    _Example_
+    \code
+    SipHash siphash[1];
+    byte data[] = { Data to be MACed };
+    word32 len = sizeof(data);
+
+    if ((ret = wc_InitSipHash(siphash, key, macSz)) != 0) {
+        WOLFSSL_MSG("wc_InitSipHash failed");
+    }
+    else if ((ret = wc_SipHashUpdate(siphash, data, len)) != 0) {
+        WOLFSSL_MSG("wc_SipHashUpdate failed");
+    }
+    else if ((ret = wc_SipHashFinal(siphash, mac, macSz)) != 0) {
+        WOLFSSL_MSG("wc_SipHashFinal failed");
+    }
+    \endcode
+    \sa wc_SipHash
+    \sa wc_InitSipHash
+    \sa wc_SipHashFinal
+*/
+int wc_SipHashUpdate(SipHash* siphash, const unsigned char* in,
+    word32 inSz);
+
+/*!
+    \ingroup SipHash 
+    \brief  データのMacingを確定します。結果が出入りする。
+    \return 0  ファイナライズに成功したときに返されます。
+    \return BAD_FUNC_ARG  SiphashのOUTがNULLのときに返されます
+    \return BAD_FUNC_ARG  OUTSZが初期化された値と同じではない場合に返されます
+    \param siphash  Macingに使用するサイプハッシュ構造へのポインタ
+    \param out  MAC値を保持するためのバイト配列
+    _Example_
+    \code
+    SipHash siphash[1];
+    byte mac[8] = { ... }; // 8 or 16 bytes
+    byte macSz = sizeof(mac);
+
+    if ((ret = wc_InitSipHash(siphash, key, macSz)) != 0) {
+        WOLFSSL_MSG("wc_InitSipHash failed");
+    }
+    else if ((ret = wc_SipHashUpdate(siphash, data, len)) != 0) {
+        WOLFSSL_MSG("wc_SipHashUpdate failed");
+    }
+    else if ((ret = wc_SipHashFinal(siphash, mac, macSz)) != 0) {
+        WOLFSSL_MSG("wc_SipHashFinal failed");
+    }
+    \endcode
+    \sa wc_SipHash
+    \sa wc_InitSipHash
+    \sa wc_SipHashUpdate
+*/
+int wc_SipHashFinal(SipHash* siphash, unsigned char* out,
+    unsigned char outSz);
+
+/*!
+    \ingroup SipHash 
+    \brief  この機能はSiphashを使用してデータを1ショットして、キーに基づいてMACを計算します。
+    \return 0  Macingに成功したときに返されました
+    \return BAD_FUNC_ARG  キーまたはOUTがNULLのときに返されます
+    \return BAD_FUNC_ARG  inneがnullのとき返され、Inszはゼロではありません
+    \return BAD_FUNC_ARG  OUTSZが8でも16でもない場合に返されます
+    \param key  16バイト配列へのポインタ
+    \param in  マイートするデータ
+    \param inSz  マイクされるデータのサイズ
+    \param out  MAC値を保持するためのバイト配列
+    _Example_
+    \code
+    unsigned char key[16] = { ... };
+    byte data[] = { Data to be MACed };
+    word32 len = sizeof(data);
+    byte mac[8] = { ... }; // 8 or 16 bytes
+    byte macSz = sizeof(mac);
+
+    if ((ret = wc_SipHash(key, data, len, mac, macSz)) != 0) {
+        WOLFSSL_MSG("wc_SipHash failed");
+    }
+    \endcode
+    \sa wc_InitSipHash
+    \sa wc_SipHashUpdate
+    \sa wc_SipHashFinal
+*/
+int wc_SipHash(const unsigned char* key, const unsigned char* in,
+    word32 inSz, unsigned char* out, unsigned char outSz);
+

--- a/doc/dox_comments/header_files-ja/srp.h
+++ b/doc/dox_comments/header_files-ja/srp.h
@@ -1,0 +1,399 @@
+/*!
+    \ingroup SRP 
+    \brief  使用方法のためにSRP構造体を初期化します。
+    \return 0  成功しています。
+    \return BAD_FUNC_ARG  SRPなどの引数がNULLまたはSRPSIDEの問題がある場合は、SRP_CLIENT_SIESまたはSRP_SERVER_SIEDでは問題がある場合に返します。
+    \return NOT_COMPILED_IN  タイプが引数として渡されたが、WolfCryptビルドに設定されていない場合。
+    \return <0  エラー時に。
+    \param srp  初期化されるSRP構造。
+    \param type  使用するハッシュ型。
+    _Example_
+    \code
+    Srp srp;
+    if (wc_SrpInit(&srp, SRP_TYPE_SHA, SRP_CLIENT_SIDE) != 0)
+    {
+        // Initialization error
+    }
+    else
+    {
+        wc_SrpTerm(&srp);
+    }
+    \endcode
+    \sa wc_SrpTerm
+    \sa wc_SrpSetUsername
+*/
+int wc_SrpInit(Srp* srp, SrpType type, SrpSide side);
+
+/*!
+    \ingroup SRP 
+    \brief  使用後にSRP構造リソースを解放します。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    Srp srp;
+    wc_SrpInit(&srp, SRP_TYPE_SHA, SRP_CLIENT_SIDE);
+    // Use srp
+    wc_SrpTerm(&srp)
+    \endcode
+    \sa wc_SrpInit
+*/
+void wc_SrpTerm(Srp* srp);
+
+/*!
+    \ingroup SRP 
+    \brief  ユーザー名を設定します。この関数は、wc_srpinitの後に呼び出す必要があります。
+    \return 0  ユーザー名は正常に設定されました。
+    \return BAD_FUNC_ARG:  srpまたはusernameがnullの場合に返します。
+    \return MEMORY_E:  SRP->ユーザーにメモリを割り当てる問題がある場合
+    \return <  0：エラー。
+    \param srp  SRP構造
+    \param username  ユーザー名を含むバッファ。
+    _Example_
+    \code
+    Srp srp;
+    byte username[] = "user";
+    word32 usernameSize = 4;
+
+    wc_SrpInit(&srp, SRP_TYPE_SHA, SRP_CLIENT_SIDE);
+    if(wc_SrpSetUsername(&srp, username, usernameSize) != 0)
+    {
+        // Error occurred setting username.
+    }
+    wc_SrpTerm(&srp);
+    \endcode
+    \sa wc_SrpInit
+    \sa wc_SrpSetParams
+    \sa wc_SrpTerm
+*/
+int wc_SrpSetUsername(Srp* srp, const byte* username, word32 size);
+
+/*!
+    \ingroup SRP 
+    \brief  ユーザー名に基づいてSRPパラメータを設定します.. wc_srpsetuserNameの後に呼び出す必要があります。
+    \return 0  成功
+    \return BAD_FUNC_ARG  SRP、N、G、またはSALTがNULLの場合、またはNSZ <GSZの場合は返します。
+    \return SRP_CALL_ORDER_E  wc_srpsetuserNameの前にwc_srpsetparamsが呼び出された場合、返します。
+    \return <0  エラー
+    \param srp  SRP構造
+    \param N  弾性率n = 2q + 1、[q、n]はプリムです。
+    \param nSz  nサイズをバイト単位で。
+    \param g  ジェネレータモジュロN.
+    \param gSz  バイト数のGサイズ
+    \param salt  小さいランダムな塩。各ユーザー名に特有のものです。
+    _Example_
+    \code
+    Srp srp;
+    byte username[] = "user";
+    word32 usernameSize = 4;
+
+    byte N[] = { }; // Contents of byte array N
+    byte g[] = { }; // Contents of byte array g
+    byte salt[] = { }; // Contents of byte array salt
+
+    wc_SrpInit(&srp, SRP_TYPE_SHA, SRP_CLIENT_SIDE);
+    wc_SrpSetUsername(&srp, username, usernameSize);
+
+    if(wc_SrpSetParams(&srp, N, sizeof(N), g, sizeof(g), salt,
+    sizeof(salt)) != 0)
+    {
+        // Error setting params
+    }
+    wc_SrpTerm(&srp);
+    \endcode
+    \sa wc_SrpInit
+    \sa wc_SrpSetUsername
+    \sa wc_SrpTerm
+*/
+int wc_SrpSetParams(Srp* srp, const byte* N,    word32 nSz,
+                                          const byte* g,    word32 gSz,
+                                          const byte* salt, word32 saltSz);
+
+/*!
+    \ingroup SRP 
+    \brief  パスワードを設定します。パスワードを設定しても、SRP構造内のパスワードデータが消去されません。クライアントは、x = h（salt + h（user：pswd））を計算し、それを認証フィールドに格納します。この関数は、wc_srpsetparamsの後に呼び出されなければならず、クライアント側のみです。
+    \return 0  成功
+    \return BAD_FUNC_ARG  srpまたはpasswordがnullの場合、またはsrp-> sideがsrp_client_sideに設定されていない場合。
+    \return SRP_CALL_ORDER_E  WC_SRPSETPASSWORDが順不同で呼び出されたときに戻ります。
+    \return <0  エラー
+    \param srp  SRP構造
+    \param password  パスワードを含むバッファ。
+    _Example_
+    \code
+    Srp srp;
+    byte username[] = "user";
+    word32 usernameSize = 4;
+    byte password[] = "password";
+    word32 passwordSize = 8;
+
+    byte N[] = { }; // Contents of byte array N
+    byte g[] = { }; // Contents of byte array g
+    byte salt[] = { }; // Contents of byte array salt
+
+    wc_SrpInit(&srp, SRP_TYPE_SHA, SRP_CLIENT_SIDE);
+    wc_SrpSetUsername(&srp, username, usernameSize);
+    wc_SrpSetParams(&srp, N, sizeof(N), g, sizeof(g), salt, sizeof(salt));
+
+    if(wc_SrpSetPassword(&srp, password, passwordSize) != 0)
+    {
+        // Error setting password
+    }
+
+    wc_SrpTerm(&srp);
+    \endcode
+    \sa wc_SrpInit
+    \sa wc_SrpSetUsername
+    \sa wc_SrpSetParams
+*/
+int wc_SrpSetPassword(Srp* srp, const byte* password, word32 size);
+
+/*!
+    \ingroup SRP 
+    \brief  検証者を設定します。この関数は、wc_srpsetparamsの後に呼び出され、サーバー側のみです。
+    \return 0  成功
+    \return BAD_FUNC_ARG  SRPまたはVerifierがNULLまたはSRP-> ISの場合、SRP_SERVER_SIEDではなく返されます。
+    \return <0  エラー
+    \param srp  SRP構造
+    \param verifier  検証者を含む構造体。
+    _Example_
+    \code
+    Srp srp;
+    byte username[] = "user";
+    word32 usernameSize = 4;
+
+    byte N[] = { }; // Contents of byte array N
+    byte g[] = { }; // Contents of byte array g
+    byte salt[] = { }; // Contents of byte array salt
+    wc_SrpInit(&srp, SRP_TYPE_SHA, SRP_SERVER_SIDE);
+    wc_SrpSetUsername(&srp, username, usernameSize);
+    wc_SrpSetParams(&srp, N, sizeof(N), g, sizeof(g), salt, sizeof(salt))
+    byte verifier[] = { }; // Contents of some verifier
+
+    if(wc_SrpSetVerifier(&srp, verifier, sizeof(verifier)) != 0)
+    {
+        // Error setting verifier
+    }
+
+    wc_SrpTerm(&srp);
+    \endcode
+    \sa wc_SrpInit
+    \sa wc_SrpSetParams
+    \sa wc_SrpGetVerifier
+*/
+int wc_SrpSetVerifier(Srp* srp, const byte* verifier, word32 size);
+
+/*!
+    \ingroup SRP 
+    \brief  検証者を取得します。クライアントはV = g ^ x％Nで検証者を計算します。この関数は、wc_srpsetpasswordの後に呼び出され、クライアント側のみです。
+    \return 0  成功
+    \return BAD_FUNC_ARG  SRP、Verifier、またはSizeがNULLの場合、またはSRP-> SIDEがSRP_CLIENT_SIEDではない場合に返されます。
+    \return SRP_CALL_ORDER_E  WC_SRPGetverifierが順不同で呼び出された場合に返されます。
+    \return <0  エラー
+    \param srp  SRP構造
+    \param verifier  検証者を書き込むためのバッファー。
+    _Example_
+    \code
+    Srp srp;
+    byte username[] = "user";
+    word32 usernameSize = 4;
+    byte password[] = "password";
+    word32 passwordSize = 8;
+
+    byte N[] = { }; // Contents of byte array N
+    byte g[] = { }; // Contents of byte array g
+    byte salt[] = { }; // Contents of byte array salt
+    byte v[64];
+    word32 vSz = 0;
+    vSz = sizeof(v);
+
+    wc_SrpInit(&srp, SRP_TYPE_SHA, SRP_CLIENT_SIDE);
+    wc_SrpSetUsername(&srp, username, usernameSize);
+    wc_SrpSetParams(&srp, N, sizeof(N), g, sizeof(g), salt, sizeof(salt))
+    wc_SrpSetPassword(&srp, password, passwordSize)
+
+    if( wc_SrpGetVerifier(&srp, v, &vSz ) != 0)
+    {
+        // Error getting verifier
+    }
+    wc_SrpTerm(&srp);
+    \endcode
+    \sa wc_SrpSetVerifier
+    \sa wc_SrpSetPassword
+*/
+int wc_SrpGetVerifier(Srp* srp, byte* verifier, word32* size);
+
+/*!
+    \ingroup SRP 
+    \brief  プライベートのエフェラル値を設定します。プライベートの一時的な値は、クライアント側のAとして知られています。サーバー側のand random（）b。b = random（）この関数は、ユニットテストケース、または開発者が外部ランダムソースを使用してエフェメラル値を設定したい場合は便利です。この関数は、WC_SRPGetPublicの前に呼び出されることがあります。
+    \return 0  成功
+    \return BAD_FUNC_ARG  SRP、Private、またはSizeがNULLの場合に返されます。
+    \return SRP_CALL_ORDER_E  WC_SRPSetPrivateが順不同で呼び出された場合に返されます。
+    \return <0  エラー
+    \param srp  SRP構造
+    \param priv  一時的な値。
+    _Example_
+    \code
+    Srp srp;
+    byte username[] = "user";
+    word32 usernameSize = 4;
+
+    byte N[] = { }; // Contents of byte array N
+    byte g[] = { }; // Contents of byte array g
+    byte salt[] = { }; // Contents of byte array salt
+    byte verifier = { }; // Contents of some verifier
+    wc_SrpInit(&srp, SRP_TYPE_SHA, SRP_SERVER_SIDE);
+    wc_SrpSetUsername(&srp, username, usernameSize);
+    wc_SrpSetParams(&srp, N, sizeof(N), g, sizeof(g), salt, sizeof(salt))
+    wc_SrpSetVerifier(&srp, verifier, sizeof(verifier))
+
+    byte b[] = { }; // Some ephemeral value
+    if( wc_SrpSetPrivate(&srp, b, sizeof(b)) != 0)
+    {
+        // Error setting private ephemeral
+    }
+
+    wc_SrpTerm(&srp);
+    \endcode
+    \sa wc_SrpGetPublic
+*/
+int wc_SrpSetPrivate(Srp* srp, const byte* priv, word32 size);
+
+/*!
+    \ingroup SRP 
+    \brief  公共の一時的な値を取得します。公共の一時的な値は、クライアント側のAとして知られています。サーバ側のA = g ^ A％n b。B =（k * v +（g b％n））％n wc_srpsetpasswordまたはwc_srpsetverifierの後に呼び出す必要があります。関数WC_SRPSetPrivateは、WC_SRPGetPublicの前に呼び出されることがあります。
+    \return 0  成功
+    \return BAD_FUNC_ARG  srp、pub、またはsizeがnullの場合に返されます。
+    \return SRP_CALL_ORDER_E  WC_SRPGetPublicが順不同で呼び出された場合に返されます。
+    \return BUFFER_E  サイズ<srp.nの場合は返しました。
+    \return <0  エラー
+    \param srp  SRP構造
+    \param pub  パブリックエフェラル値を書き込むためのバッファ。
+    _Example_
+    \code
+    Srp srp;
+    byte username[] = "user";
+    word32 usernameSize = 4;
+    byte password[] = "password";
+    word32 passwordSize = 8;
+
+    byte N[] = { }; // Contents of byte array N
+    byte g[] = { }; // Contents of byte array g
+    byte salt[] = { }; // Contents of byte array salt
+    wc_SrpInit(&srp, SRP_TYPE_SHA, SRP_CLIENT_SIDE);
+    wc_SrpSetUsername(&srp, username, usernameSize);
+    wc_SrpSetParams(&srp, N, sizeof(N), g, sizeof(g), salt, sizeof(salt));
+    wc_SrpSetPassword(&srp, password, passwordSize)
+
+    byte public[64];
+    word32 publicSz = 0;
+
+    if( wc_SrpGetPublic(&srp, public, &publicSz) != 0)
+    {
+        // Error getting public ephemeral
+    }
+
+    wc_SrpTerm(&srp);
+    \endcode
+    \sa wc_SrpSetPrivate
+    \sa wc_SrpSetPassword
+    \sa wc_SrpSetVerifier
+*/
+int wc_SrpGetPublic(Srp* srp, byte* pub, word32* size);
+
+/*!
+    \ingroup SRP 
+    \brief  セッションキーを計算します。成功後にSRP->キーでキーをアクセスできます。
+    \return 0  成功
+    \return BAD_FUNC_ARG  SRP、ClientPubKey、またはServerPubKeyの場合、またはClientPubkeyszまたはServerPubKeyszが0の場合に返されます。
+    \return SRP_CALL_ORDER_E  WC_SRPComputeKeyが順不同で呼び出された場合に返されます。
+    \return <0  エラー
+    \param srp  SRP構造
+    \param clientPubKey  クライアントの公共の一時的な価値。
+    \param clientPubKeySz  クライアントの公共の一時的な値のサイズ。
+    \param serverPubKey  サーバーの一般の一時的な値。
+    _Example_
+    \code
+    Srp server;
+
+    byte username[] = "user";
+        word32 usernameSize = 4;
+    byte password[] = "password";
+    word32 passwordSize = 8;
+    byte N[] = { }; // Contents of byte array N
+    byte g[] = { }; // Contents of byte array g
+    byte salt[] = { }; // Contents of byte array salt
+    byte verifier[] = { }; // Contents of some verifier
+    byte serverPubKey[] = { }; // Contents of server pub key
+    word32 serverPubKeySize = sizeof(serverPubKey);
+    byte clientPubKey[64];
+    word32 clientPubKeySize = 64;
+
+    wc_SrpInit(&server, SRP_TYPE_SHA, SRP_SERVER_SIDE);
+    wc_SrpSetUsername(&server, username, usernameSize);
+    wc_SrpSetParams(&server, N, sizeof(N), g, sizeof(g), salt, sizeof(salt));
+    wc_SrpSetVerifier(&server, verifier, sizeof(verifier));
+    wc_SrpGetPublic(&server, serverPubKey, &serverPubKeySize);
+
+    wc_SrpComputeKey(&server, clientPubKey, clientPubKeySz,
+                                          serverPubKey, serverPubKeySize)
+    wc_SrpTerm(&server);
+    \endcode
+    \sa wc_SrpGetPublic
+*/
+int wc_SrpComputeKey(Srp* srp,
+                                 byte* clientPubKey, word32 clientPubKeySz,
+                                 byte* serverPubKey, word32 serverPubKeySz);
+
+/*!
+    \ingroup SRP 
+    \brief  証明を取得します。この関数は、wc_srpcomputekeyの後に呼び出す必要があります。
+    \return 0  成功
+    \return BAD_FUNC_ARG  SRP、PROV、またはSIZEがNULLの場合に返します。
+    \return BUFFER_E  サイズがSRP-> Typeのハッシュサイズより小さい場合に返します。
+    \return <0  エラー
+    \param srp  SRP構造
+    \param proof  ピアプルーフ。
+    _Example_
+    \code
+    Srp cli;
+    byte clientProof[SRP_MAX_DIGEST_SIZE];
+    word32 clientProofSz = SRP_MAX_DIGEST_SIZE;
+
+    // Initialize Srp following steps from previous examples
+
+    if (wc_SrpGetProof(&cli, clientProof, &clientProofSz) != 0)
+    {
+        // Error getting proof
+    }
+    \endcode
+    \sa wc_SrpComputeKey
+*/
+int wc_SrpGetProof(Srp* srp, byte* proof, word32* size);
+
+/*!
+    \ingroup SRP 
+    \brief  ピアプルーフを確認します。この関数は、WC_SRPGetSessionKeyの前に呼び出す必要があります。
+    \return 0  成功
+    \return <0  エラー
+    \param srp  SRP構造
+    \param proof  ピアプルーフ。
+    _Example_
+    \code
+    Srp cli;
+    Srp srv;
+    byte clientProof[SRP_MAX_DIGEST_SIZE];
+    word32 clientProofSz = SRP_MAX_DIGEST_SIZE;
+
+    // Initialize Srp following steps from previous examples
+    // First get the proof
+    wc_SrpGetProof(&cli, clientProof, &clientProofSz)
+
+    if (wc_SrpVerifyPeersProof(&srv, clientProof, clientProofSz) != 0)
+    {
+        // Error verifying proof
+    }
+    \endcode
+    \sa wc_SrpGetSessionKey
+    \sa wc_SrpGetProof
+    \sa wc_SrpTerm
+*/
+int wc_SrpVerifyPeersProof(Srp* srp, byte* proof, word32 size);

--- a/doc/dox_comments/header_files-ja/ssl.h
+++ b/doc/dox_comments/header_files-ja/ssl.h
@@ -1,0 +1,9519 @@
+/*!
+    \brief  
+    \return pointer  この関数は、新しいwolfssl_method構造体へのポインタを返します。
+    _Example_
+    \code
+    wolfSSL_Init();
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new(wolfDTLSv1_2_client_method());
+    …
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    …
+    \endcode
+    \sa wolfSSL_Init
+    \sa wolfSSL_CTX_new
+*/
+WOLFSSL_METHOD *wolfDTLSv1_2_client_method_ex(void* heap);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、Wolfsslv23_client_methodと同様のwolfssl_methodを返します（サーバー/クライアント）。
+    \return WOLFSSL_METHOD*  成功した作成では、wolfssl_methodポインタを返します
+    \return NULL  メモリ割り当てエラーまたはメソッドの作成の失敗の場合はnull
+    _Example_
+    \code
+    WOLFSSL* ctx;
+    ctx  = wolfSSL_CTX_new(wolfSSLv23_method());
+    // check ret value
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_free
+*/
+WOLFSSL_METHOD *wolfSSLv23_method(void);
+
+/*!
+    \ingroup Setup 
+    \brief  WOLFSSLV3_SERVER_METHOD（）関数は、アプリケーションがサーバーであることを示すために使用され、SSL 3.0プロトコルのみをサポートします。この関数は、wolfssl_ctx_new（）を使用してSSL / TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。
+    \return *  成功した場合、呼び出しは新しく作成されたwolfssl_method構造へのポインタを返します。
+    \return FAIL  xmallocを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc（）実装の失敗値が返されます（通常はerrnoがenomeemに設定されます）。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_METHOD* method;
+    WOLFSSL_CTX* ctx;
+
+    method = wolfSSLv3_server_method();
+    if (method == NULL) {
+	    unable to get method
+    }
+
+    ctx = wolfSSL_CTX_new(method);
+    ...
+    \endcode
+    \sa wolfTLSv1_server_method
+    \sa wolfTLSv1_1_server_method
+    \sa wolfTLSv1_2_server_method
+    \sa wolfTLSv1_3_server_method
+    \sa wolfDTLSv1_server_method
+    \sa wolfSSLv23_server_method
+    \sa wolfSSL_CTX_new
+*/
+WOLFSSL_METHOD *wolfSSLv3_server_method(void);
+
+/*!
+    \ingroup Setup 
+    \brief  wolfsslv3_client_method（）関数は、アプリケーションがクライアントであり、SSL 3.0プロトコルのみをサポートすることを示すために使用されます。この関数は、wolfssl_ctx_new（）を使用してSSL / TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。
+    \return *  成功した場合、呼び出しは新しく作成されたwolfssl_method構造へのポインタを返します。
+    \return FAIL  xmallocを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc（）実装の失敗値が返されます（通常はerrnoがenomeemに設定されます）。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_METHOD* method;
+    WOLFSSL_CTX* ctx;
+
+    method = wolfSSLv3_client_method();
+    if (method == NULL) {
+	    unable to get method
+    }
+
+    ctx = wolfSSL_CTX_new(method);
+    ...
+    \endcode
+    \sa wolfTLSv1_client_method
+    \sa wolfTLSv1_1_client_method
+    \sa wolfTLSv1_2_client_method
+    \sa wolfTLSv1_3_client_method
+    \sa wolfDTLSv1_client_method
+    \sa wolfSSLv23_client_method
+    \sa wolfSSL_CTX_new
+*/
+WOLFSSL_METHOD *wolfSSLv3_client_method(void);
+
+/*!
+    \ingroup Setup 
+    \brief  WOLFTLSV1_SERVER_METHOD（）関数は、アプリケーションがサーバーであることを示すために使用され、TLS 1.0プロトコルのみをサポートします。この関数は、wolfssl_ctx_new（）を使用してSSL / TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。
+    \return *  成功した場合、呼び出しは新しく作成されたwolfssl_method構造へのポインタを返します。
+    \return FAIL  xmallocを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc（）実装の失敗値が返されます（通常はerrnoがenomeemに設定されます）。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_METHOD* method;
+    WOLFSSL_CTX* ctx;
+
+    method = wolfTLSv1_server_method();
+    if (method == NULL) {
+	    unable to get method
+    }
+
+    ctx = wolfSSL_CTX_new(method);
+    ...
+    \endcode
+    \sa wolfSSLv3_server_method
+    \sa wolfTLSv1_1_server_method
+    \sa wolfTLSv1_2_server_method
+    \sa wolfTLSv1_3_server_method
+    \sa wolfDTLSv1_server_method
+    \sa wolfSSLv23_server_method
+    \sa wolfSSL_CTX_new
+*/
+WOLFSSL_METHOD *wolfTLSv1_server_method(void);
+
+/*!
+    \ingroup Setup 
+    \brief  wolftlsv1_client_method（）関数は、アプリケーションがクライアントであり、TLS 1.0プロトコルのみをサポートすることを示すために使用されます。この関数は、wolfssl_ctx_new（）を使用してSSL / TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。
+    \return *  成功した場合、呼び出しは新しく作成されたwolfssl_method構造へのポインタを返します。
+    \return FAIL  xmallocを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc（）実装の失敗値が返されます（通常はerrnoがenomeemに設定されます）。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_METHOD* method;
+    WOLFSSL_CTX* ctx;
+
+    method = wolfTLSv1_client_method();
+    if (method == NULL) {
+	    unable to get method
+    }
+
+    ctx = wolfSSL_CTX_new(method);
+    ...
+    \endcode
+    \sa wolfSSLv3_client_method
+    \sa wolfTLSv1_1_client_method
+    \sa wolfTLSv1_2_client_method
+    \sa wolfTLSv1_3_client_method
+    \sa wolfDTLSv1_client_method
+    \sa wolfSSLv23_client_method
+    \sa wolfSSL_CTX_new
+*/
+WOLFSSL_METHOD *wolfTLSv1_client_method(void);
+
+/*!
+    \ingroup Setup 
+    \brief  WOLFTLSV1_1_SERVER_METHOD（）関数は、アプリケーションがサーバーであることを示すために使用され、TLS 1.1プロトコルのみをサポートします。この関数は、wolfssl_ctx_new（）を使用してSSL / TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。
+    \return *  成功した場合、呼び出しは新しく作成されたwolfssl_method構造へのポインタを返します。
+    \return FAIL  xmallocを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc（）実装の失敗値が返されます（通常はerrnoがenomeemに設定されます）。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_METHOD* method;
+    WOLFSSL_CTX* ctx;
+
+    method = wolfTLSv1_1_server_method();
+    if (method == NULL) {
+        // unable to get method
+    }
+
+    ctx = wolfSSL_CTX_new(method);
+    ...
+    \endcode
+    \sa wolfSSLv3_server_method
+    \sa wolfTLSv1_server_method
+    \sa wolfTLSv1_2_server_method
+    \sa wolfTLSv1_3_server_method
+    \sa wolfDTLSv1_server_method
+    \sa wolfSSLv23_server_method
+    \sa wolfSSL_CTX_new
+*/
+WOLFSSL_METHOD *wolfTLSv1_1_server_method(void);
+
+/*!
+    \ingroup Setup 
+    \brief  WOLFTLSV1_1_CLIENT_METHOD（）関数は、アプリケーションがクライアントであり、TLS 1.0プロトコルのみをサポートすることを示すために使用されます。この関数は、wolfssl_ctx_new（）を使用してSSL / TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。
+    \return *  成功した場合、呼び出しは新しく作成されたwolfssl_method構造へのポインタを返します。
+    \return FAIL  xmallocを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc（）実装の失敗値が返されます（通常はerrnoがenomeemに設定されます）。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_METHOD* method;
+    WOLFSSL_CTX* ctx;
+
+    method = wolfTLSv1_1_client_method();
+    if (method == NULL) {
+        // unable to get method
+    }
+
+    ctx = wolfSSL_CTX_new(method);
+    ...
+    \endcode
+    \sa wolfSSLv3_client_method
+    \sa wolfTLSv1_client_method
+    \sa wolfTLSv1_2_client_method
+    \sa wolfTLSv1_3_client_method
+    \sa wolfDTLSv1_client_method
+    \sa wolfSSLv23_client_method
+    \sa wolfSSL_CTX_new
+*/
+WOLFSSL_METHOD *wolfTLSv1_1_client_method(void);
+
+/*!
+    \ingroup Setup 
+    \brief  WOLFTLSV1_2_SERVER_METHOD（）関数は、アプリケーションがサーバーであることを示すために使用され、TLS 1.2プロトコルのみをサポートします。この関数は、wolfssl_ctx_new（）を使用してSSL / TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。
+    \return *  成功した場合、呼び出しは新しく作成されたwolfssl_method構造へのポインタを返します。
+    \return FAIL  xmallocを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc（）実装の失敗値が返されます（通常はerrnoがenomeemに設定されます）。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_METHOD* method;
+    WOLFSSL_CTX* ctx;
+
+    method = wolfTLSv1_2_server_method();
+    if (method == NULL) {
+	    // unable to get method
+    }
+
+    ctx = wolfSSL_CTX_new(method);
+    ...
+    \endcode
+    \sa wolfSSLv3_server_method
+    \sa wolfTLSv1_server_method
+    \sa wolfTLSv1_1_server_method
+    \sa wolfTLSv1_3_server_method
+    \sa wolfDTLSv1_server_method
+    \sa wolfSSLv23_server_method
+    \sa wolfSSL_CTX_new
+*/
+WOLFSSL_METHOD *wolfTLSv1_2_server_method(void);
+
+/*!
+    \ingroup Setup 
+    \brief  wolftlsv1_2_client_method（）関数は、アプリケーションがクライアントであり、TLS 1.2プロトコルのみをサポートすることを示すために使用されます。この関数は、wolfssl_ctx_new（）を使用してSSL / TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。
+    \return *  成功した場合、呼び出しは新しく作成されたwolfssl_method構造へのポインタを返します。
+    \return FAIL  xmallocを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc（）実装の失敗値が返されます（通常はerrnoがenomeemに設定されます）。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_METHOD* method;
+    WOLFSSL_CTX* ctx;
+
+    method = wolfTLSv1_2_client_method();
+    if (method == NULL) {
+	    // unable to get method
+    }
+
+    ctx = wolfSSL_CTX_new(method);
+    ...
+    \endcode
+    \sa wolfSSLv3_client_method
+    \sa wolfTLSv1_client_method
+    \sa wolfTLSv1_1_client_method
+    \sa wolfTLSv1_3_client_method
+    \sa wolfDTLSv1_client_method
+    \sa wolfSSLv23_client_method
+    \sa wolfSSL_CTX_new
+*/
+WOLFSSL_METHOD *wolfTLSv1_2_client_method(void);
+
+/*!
+    \ingroup Setup 
+    \brief  wolfdtlsv1_client_method（）関数は、アプリケーションがクライアントであり、DTLS 1.0プロトコルのみをサポートすることを示すために使用されます。この関数は、wolfssl_ctx_new（）を使用してSSL / TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。この関数は、WolfSSLがDTLSサポート（ -  enable-dtls、またはWolfSSL_DTLSを定義することによって）コンパイルされている場合にのみ使用できます。
+    \return *  成功した場合、呼び出しは新しく作成されたwolfssl_method構造へのポインタを返します。
+    \return FAIL  xmallocを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc（）実装の失敗値が返されます（通常はerrnoがenomeemに設定されます）。
+    _Example_
+    \code
+    WOLFSSL_METHOD* method;
+    WOLFSSL_CTX* ctx;
+
+    method = wolfDTLSv1_client_method();
+    if (method == NULL) {
+	    // unable to get method
+    }
+
+    ctx = wolfSSL_CTX_new(method);
+    ...
+    \endcode
+    \sa wolfSSLv3_client_method
+    \sa wolfTLSv1_client_method
+    \sa wolfTLSv1_1_client_method
+    \sa wolfTLSv1_2_client_method
+    \sa wolfTLSv1_3_client_method
+    \sa wolfSSLv23_client_method
+    \sa wolfSSL_CTX_new
+*/
+WOLFSSL_METHOD *wolfDTLSv1_client_method(void);
+
+/*!
+    \ingroup Setup 
+    \brief  WOLFDTLSV1_SERVER_METHOD（）関数は、アプリケーションがサーバーであることを示すために使用され、DTLS 1.0プロトコルのみをサポートします。この関数は、wolfssl_ctx_new（）を使用してSSL / TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。この関数は、WolfSSLがDTLSサポート（ -  enable-dtls、またはWolfSSL_DTLSを定義することによって）コンパイルされている場合にのみ使用できます。
+    \return *  成功した場合、呼び出しは新しく作成されたwolfssl_method構造へのポインタを返します。
+    \return FAIL  xmallocを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc（）実装の失敗値が返されます（通常はerrnoがenomeemに設定されます）。
+    _Example_
+    \code
+    WOLFSSL_METHOD* method;
+    WOLFSSL_CTX* ctx;
+
+    method = wolfDTLSv1_server_method();
+    if (method == NULL) {
+	    // unable to get method
+    }
+
+    ctx = wolfSSL_CTX_new(method);
+    ...
+    \endcode
+    \sa wolfSSLv3_server_method
+    \sa wolfTLSv1_server_method
+    \sa wolfTLSv1_1_server_method
+    \sa wolfTLSv1_2_server_method
+    \sa wolfTLSv1_3_server_method
+    \sa wolfSSLv23_server_method
+    \sa wolfSSL_CTX_new
+*/
+WOLFSSL_METHOD *wolfDTLSv1_server_method(void);
+
+/*!
+    \brief  サーバ側。
+    \return This  関数はwolfssl_methodポインタを返します。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new(wolfDTLSv1_2_server_method());
+    WOLFSSL* ssl = WOLFSSL_new(ctx);
+    …
+    \endcode
+    \sa wolfSSL_CTX_new
+*/
+WOLFSSL_METHOD *wolfDTLSv1_2_server_method(void);
+
+/*!
+    \ingroup Setup 
+    \brief  Chacha-Poly Aead Constructionの最初のリリースと新しいバージョンの間にいくつかの違いがあるため、古いバージョンを使用してサーバー/クライアントと通信するオプションを追加しました。デフォルトでは、WolfSSLは新しいバージョンを使用します。
+    \return 0  成功すると
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL* ssl;
+    ...
+
+    ret = wolfSSL_use_old_poly(ssl, 1);
+    if (ret != 0) {
+        // failed to set poly1305 AEAD version
+    }
+    \endcode
+    \sa none
+*/
+int wolfSSL_use_old_poly(WOLFSSL* ssl, int value);
+
+/*!
+    \brief  セッション状態これにより、ハンドシェイクが完了した後に接続をピックアップすることができます。
+    \return Success  成功した場合、読み取ったバッファの量が返されます。
+    \return Failure  すべての失敗した戻り値は0未満になります。
+    \return VERSION_ERROR  バージョンの不一致が見つかった場合、IE DTLS V1とCTXがDTLS V1.2に設定された場合、Version_Errorが返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param buf  インポートするシリアル化されたセッション。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    int ret;
+    unsigned char buf[MAX];
+    bufSz = MAX;
+    ...
+    //get information sent from wc_dtls_export function and place it in buf
+    fread(buf, 1, bufSz, input);
+    ret = wolfSSL_dtls_import(ssl, buf, bufSz);
+    if (ret < 0) {
+    // handle error case
+    }
+    // no wolfSSL_accept needed since handshake was already done
+    ...
+    ret = wolfSSL_write(ssl) and wolfSSL_read(ssl);
+    ...
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_CTX_dtls_set_export
+*/
+int wolfSSL_dtls_import(WOLFSSL* ssl, unsigned char* buf,
+                                                               unsigned int sz);
+
+
+/*!
+    \brief  接続の状態をインポートします。警告：BUFには、状態に関する機密情報が含まれており、保存されている場合は保存する前に暗号化されるのが最善です。追加のデバッグ情報をマクロwolfssl_session_export_debugが定義して表示できます。
+    \return the  バッファ 'BUF'から読み込まれたバイト数
+    \param ssl  セッションをインポートするためのWolfSSL構造
+    \param buf  シリアル化されたセッション
+    \sa wolfSSL_dtls_import
+    \sa wolfSSL_tls_export
+ */
+int wolfSSL_tls_import(WOLFSSL* ssl, const unsigned char* buf,
+        unsigned int sz);
+
+/*!
+    \brief  セッションをエクスポートするためのコールバック関数。これは、以前に格納されているエクスポート機能をクリアするためのパラメータfuncとしてnullを渡すことが許可されています。サーバー側で使用され、ハンドシェイクが完了した直後に呼び出されます。
+    \return SSL_SUCCESS  成功すると。
+    \return BAD_FUNC_ARG  NULLまたは予想されない引数が渡された場合
+    \param ctx  wolfssl_ctx_new（）で作成されたwolfssl_ctx構造へのポインタ。
+    _Example_
+    \code
+    int send_session(WOLFSSL* ssl, byte* buf, word32 sz, void* userCtx);
+    // body of send session (wc_dtls_export) that passses
+    // buf (serialized session) to destination
+    WOLFSSL_CTX* ctx;
+    int ret;
+    ...
+    ret = wolfSSL_CTX_dtls_set_export(ctx, send_session);
+    if (ret != SSL_SUCCESS) {
+        // handle error case
+    }
+    ...
+    ret = wolfSSL_accept(ssl);
+    ...
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_dtls_set_export
+    \sa Static buffer use
+*/
+int wolfSSL_CTX_dtls_set_export(WOLFSSL_CTX* ctx,
+                                                           wc_dtls_export func);
+
+/*!
+    \brief  セッションをエクスポートする機能。これは、以前に格納されているエクスポート機能をクリアするためのパラメータfuncとしてnullを渡すことが許可されています。サーバー側で使用され、ハンドシェイクが完了した直後に呼び出されます。
+    \return SSL_SUCCESS  成功すると。
+    \return BAD_FUNC_ARG  NULLまたは予想されない引数が渡された場合
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    int send_session(WOLFSSL* ssl, byte* buf, word32 sz, void* userCtx);
+    // body of send session (wc_dtls_export) that passses
+    // buf (serialized session) to destination
+    WOLFSSL* ssl;
+    int ret;
+    ...
+    ret = wolfSSL_dtls_set_export(ssl, send_session);
+    if (ret != SSL_SUCCESS) {
+        // handle error case
+    }
+    ...
+    ret = wolfSSL_accept(ssl);
+    ...
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_CTX_dtls_set_export
+*/
+int wolfSSL_dtls_set_export(WOLFSSL* ssl, wc_dtls_export func);
+
+/*!
+    \brief  提供されたバッファへのWolfSSLセッション。セッションをシリアル化したときにセッションを送信するための関数コールバックを使用するよりも少ないメモリオーバーヘッドを許可します。関数に渡されたときにバッファがNULLの場合、SZはWolfSSLセッションの直列化に必要なバッファのサイズに設定されます。
+    \return Success  成功した場合、使用されるバッファの量が返されます。
+    \return Failure  すべての失敗した戻り値は0未満になります。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param buf  直列化セッションを保持するためのバッファ。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    int ret;
+    unsigned char buf[MAX];
+    bufSz = MAX;
+    ...
+    ret = wolfSSL_dtls_export(ssl, buf, bufSz);
+    if (ret < 0) {
+        // handle error case
+    }
+    ...
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_CTX_dtls_set_export
+    \sa wolfSSL_dtls_import
+*/
+int wolfSSL_dtls_export(WOLFSSL* ssl, unsigned char* buf,
+                                                              unsigned int* sz);
+
+/*!
+    \brief  接続の直列化された状態をインポートします。ほとんどの場合、wolfssl_tls_exportの代わりにwolfssl_get1_sessionを使用する必要があります。追加のデバッグ情報をマクロwolfssl_session_export_debugが定義して表示できます。警告：BUFには、状態に関する機密情報が含まれており、保存されている場合は保存する前に暗号化されるのが最善です。
+    \return the  バッファー 'BUF'に書き込まれたバイト数
+    \param ssl  セッションをエクスポートするためのWolfSSL構造
+    \param buf  直列化セッションの出力
+    \sa wolfSSL_dtls_import
+    \sa wolfSSL_tls_import
+ */
+int wolfSSL_tls_export(WOLFSSL* ssl, unsigned char* buf,
+        unsigned int* sz);
+
+/*!
+    \brief  その後、CTXの有効期間およびCTXから作成されたSSLオブジェクトには、asideを設定します。NULL CTXポインタとWOLFSSL_METHOD_FUNC関数を渡すことによって、CTX自体の作成も静的メモリを使用します。wolfssl_method_funcには、wolfssl_method *（* wolfssl_method_func）の関数署名があります（void *ヒープ）。MAXに0を渡すと、設定されていないかのように動作し、最大の同時使用制限が適用されません。渡されたフラグ値によって、メモリの使用方法と動作中の動作が決まります。利用可能なフラグは次のとおりです.0  - デフォルトの一般メモリ、WolfMEM_IO_POOL  - 受信メッセージの送信と一般メモリをオーバーライドするときに入出力バッファに使用されるので、渡されたバッファ内のすべてのメモリがIO、WolfMem_IO_FIXED  -  WOLFMEM_IO_POOLと同じですが、今度は各SSLと同じです。2つのバッファを自分のライフタイムで自分自身に保ちます。wolfmem_track_stats  - 各SSLは実行中にメモリ統計を追跡します。
+    \return SSL_SUCCESS  成功すると。
+    \return SSL_FAILURE  失敗すると。
+    \param ctx  wolfssl_ctx構造へのポインタのアドレス。
+    \param method  プロトコルを作成する機能。（CTXもNULLでもない場合はNULLにする必要があります）
+    \param buf  すべての操作に使用するメモリ。
+    \param sz  渡されているメモリバッファのサイズ。
+    \param flag  メモリの種類
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx;
+    WOLFSSL* ssl;
+    int ret;
+    unsigned char memory[MAX];
+    int memorySz = MAX;
+    unsigned char IO[MAX];
+    int IOSz = MAX;
+    int flag = WOLFMEM_IO_FIXED | WOLFMEM_TRACK_STATS;
+    ...
+    // create ctx also using static memory, start with general memory to use
+    ctx = NULL:
+    ret = wolfSSL_CTX_load_static_memory(&ctx, wolfSSLv23_server_method_ex,
+    memory, memorySz, 0,    MAX_CONCURRENT_HANDSHAKES);
+    if (ret != SSL_SUCCESS) {
+    // handle error case
+    }
+    // load in memory for use with IO
+    ret = wolfSSL_CTX_load_static_memory(&ctx, NULL, IO, IOSz, flag,
+    MAX_CONCURRENT_IO);
+    if (ret != SSL_SUCCESS) {
+    // handle error case
+    }
+    ...
+    \endcode
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_CTX_is_static_memory
+    \sa wolfSSL_is_static_memory
+*/
+int wolfSSL_CTX_load_static_memory(WOLFSSL_CTX** ctx,
+                                            wolfSSL_method_func method,
+                                            unsigned char* buf, unsigned int sz,
+                                            int flag, int max);
+
+/*!
+    \brief  そして、静的メモリ使用量に関する情報を収集するためにのみ使用されます。
+    \return 1  CTXの静的メモリを使用する場合は返されます。
+    \return 0  静的メモリを使用しない場合は返されます。
+    \param ctx  wolfssl_ctx_new（）を使用して作成されたwolfssl_ctx構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx;
+    int ret;
+    WOLFSSL_MEM_STATS mem_stats;
+    ...
+    //get information about static memory with CTX
+    ret = wolfSSL_CTX_is_static_memory(ctx, &mem_stats);
+    if (ret == 1) {
+        // handle case of is using static memory
+        // print out or inspect elements of mem_stats
+    }
+    if (ret == 0) {
+        //handle case of ctx not using static memory
+    }
+    …
+    \endcode
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_CTX_load_static_memory
+    \sa wolfSSL_is_static_memory
+*/
+int wolfSSL_CTX_is_static_memory(WOLFSSL_CTX* ctx,
+                                                 WOLFSSL_MEM_STATS* mem_stats);
+
+/*!
+    \brief  SSLの静的メモリ使用量。戻り値は、静的メモリを読み込むときに、静的メモリが使用されているかどうかを示します。
+    \return 1  CTXの静的メモリを使用する場合は返されます。
+    \return 0  静的メモリを使用しない場合は返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    int ret;
+    WOLFSSL_MEM_CONN_STATS mem_stats;
+    ...
+    ret = wolfSSL_is_static_memory(ssl, mem_stats);
+    if (ret == 1) {
+        // handle case when is static memory
+        // investigate elements in mem_stats if WOLFMEM_TRACK_STATS flag
+    }
+    ...
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_CTX_is_static_memory
+*/
+int wolfSSL_is_static_memory(WOLFSSL* ssl,
+                                            WOLFSSL_MEM_CONN_STATS* mem_stats);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は証明書ファイルをSSLコンテキストにロードします（wolfssl_ctx）。ファイルはファイル引数によって提供されます。format引数は、ファイルのフォーマットタイプ（SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM）を指定します。適切な使用法の例をご覧ください。
+    \return SSL_SUCCESS  成功すると。
+    \return SSL_FAILURE  関数呼び出しが失敗した場合、可能な原因が誤った形式にある場合、または「format」引数を使用して誤ったフォーマットが指定されている場合があります。ファイルは存在しません。読み取られない、または破損しているメモリ状態が発生すると、ベース16のデコードはファイルで失敗します。
+    \param ctx  wolfssl_ctx_new（）を使用して作成されたwolfssl_ctx構造へのポインタ
+    \param file  WolfSSL SSLコンテキストにロードする証明書を含むファイルの名前へのポインタ。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL_CTX* ctx;
+    ...
+    ret = wolfSSL_CTX_use_certificate_file(ctx, “./client-cert.pem”,
+                                     SSL_FILETYPE_PEM);
+    if (ret != SSL_SUCCESS) {
+	    // error loading cert file
+    }
+    ...
+    \endcode
+    \sa wolfSSL_CTX_use_certificate_buffer
+    \sa wolfSSL_use_certificate_file
+    \sa wolfSSL_use_certificate_buffer
+*/
+int wolfSSL_CTX_use_certificate_file(WOLFSSL_CTX* ctx, const char* file,
+                                     int format);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、秘密鍵ファイルをSSLコンテキスト（WolfSSL_CTX）にロードします。ファイルはファイル引数によって提供されます。format引数は、ファイルのフォーマットタイプを指定します.SSL_FILETYPE_ASN1OR SSL_FILETYPE_PEM。適切な使用法の例をご覧ください。外部キーストアを使用し、秘密鍵を持っていない場合は、代わりに公開鍵を入力してCryProコールバックを登録して署名を処理することができます。このためには、CryptoコールバックまたはPKコールバックを使用したビルドで構築できます。Cryptoコールバックを有効にするには、-enable-cryptocbまたはwolf_crypto_cbを使用し、wc_cryptocb_registerDeviceを使用して暗号コールバックを登録し、wolfssl_ctx_setdevidを使用して関連するdevidを設定します。
+    \return SSL_SUCCESS  成功すると。
+    \return SSL_FAILURE  ファイルは間違った形式で、または「format」引数を使用して誤った形式が与えられています。ファイルが存在しない、読み込めない、または破損しています。メモリ不足状態が発生します。base16デコードはファイルで失敗します。キーファイルは暗号化されていますが、パスワードは提供されません。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL_CTX* ctx;
+    ...
+    ret = wolfSSL_CTX_use_PrivateKey_file(ctx, “./server-key.pem”,
+                                    SSL_FILETYPE_PEM);
+    if (ret != SSL_SUCCESS) {
+	    // error loading key file
+    }
+    ...
+    \endcode
+    \sa wolfSSL_CTX_use_PrivateKey_buffer
+    \sa wolfSSL_use_PrivateKey_file
+    \sa wolfSSL_use_PrivateKey_buffer
+    \sa wc_CryptoCb_RegisterDevice
+    \sa wolfSSL_CTX_SetDevId
+*/
+int wolfSSL_CTX_use_PrivateKey_file(WOLFSSL_CTX* ctx, const char* file, int format);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、PEM形式のCA証明書ファイルをSSLコンテキスト（WolfSSL_CTX）にロードします。これらの証明書は、信頼できるルート証明書として扱われ、SSLハンドシェイク中にピアから受信した証明書を検証するために使用されます。ファイル引数によって提供されるルート証明書ファイルは、単一の証明書または複数の証明書を含むファイルであり得る。複数のCA CERTが同じファイルに含まれている場合、WolfSSLはファイルに表示されているのと同じ順序でそれらをロードします。 path引数は、信頼できるルートCAの証明書を含むディレクトリの名前へのポインタです。ファイルの値がNULLではない場合、パスを必要な場合はパスをNULLとして指定できます。 Libraryの構築時にパスが指定されていない場合は、WOLFSSLが指定されたディレクトリにあるすべてのCA証明書をロードします。この関数はディレクトリ内のすべてのファイルをロードしようとします。この関数は、ヘッダー "-----証明書-----"を持つpemフォーマットされたcert_typeファイルを期待しています。
+    \return SSL_SUCCESS  成功しました。
+    \return SSL_FAILURE  CTXがNULLの場合、またはファイルとパスの両方がNULLの場合は返されます。
+    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合は返されます。
+    \return SSL_BAD_FILE  ファイルが存在しない場合は返されます。読み込め、または破損していません。
+    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
+    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
+    \return ASN_BEFORE_DATE_E  現在の日付が前日の前にある場合は返されます。
+    \return ASN_AFTER_DATE_E  現在の日付が後の日付の後の場合は返されます。
+    \return BUFFER_E  チェーンバッファが受信バッファよりも大きい場合に返されます。
+    \return BAD_PATH_ERROR  OpenDir（）がパスを開こうとしたときに失敗した場合に返されます。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    \param file  PEM形式のCA証明書を含むファイルの名前へのポインタ。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL_CTX* ctx;
+    ...
+    ret = wolfSSL_CTX_load_verify_locations(ctx, “./ca-cert.pem”, NULL);
+    if (ret != WOLFSSL_SUCCESS) {
+    	// error loading CA certs
+    }
+    ...
+    \endcode
+    \sa wolfSSL_CTX_load_verify_locations_ex
+    \sa wolfSSL_CTX_load_verify_buffer
+    \sa wolfSSL_CTX_use_certificate_file
+    \sa wolfSSL_CTX_use_PrivateKey_file
+    \sa wolfSSL_CTX_use_certificate_chain_file
+    \sa wolfSSL_use_certificate_file
+    \sa wolfSSL_use_PrivateKey_file
+    \sa wolfSSL_use_certificate_chain_file
+*/
+int wolfSSL_CTX_load_verify_locations(WOLFSSL_CTX* ctx, const char* file,
+                                                const char* format);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、PEM形式のCA証明書ファイルをSSLコンテキスト（WolfSSL_CTX）にロードします。これらの証明書は、信頼できるルート証明書として扱われ、SSLハンドシェイク中にピアから受信した証明書を検証するために使用されます。ファイル引数によって提供されるルート証明書ファイルは、単一の証明書または複数の証明書を含むファイルであり得る。複数のCA CERTが同じファイルに含まれている場合、WolfSSLはファイルに表示されているのと同じ順序でそれらをロードします。 path引数は、信頼できるルートCAの証明書を含むディレクトリの名前へのポインタです。ファイルの値がNULLではない場合、パスを必要な場合はパスをNULLとして指定できます。 Libraryの構築時にパスが指定されていない場合は、WOLFSSLが指定されたディレクトリにあるすべてのCA証明書をロードします。この関数は、指定されたフラグに基づいてディレクトリ内のすべてのファイルをロードしようとします。この関数は、ヘッダー "-----証明書-----"を持つPEM形式のcert_typeファイルを想定しています。
+    \return SSL_SUCCESS  成功しました。
+    \return SSL_FAILURE  CTXがNULLの場合、またはファイルとパスの両方がNULLの場合は返されます。少なくとも1つの証明書が正常にロードされているが、失敗した1つ以上がある場合、これも返されます。理由でエラースタックを確認してください。
+    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合は返されます。
+    \return SSL_BAD_FILE  ファイルが存在しない場合は返されます。読み込め、または破損していません。
+    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
+    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
+    \return BUFFER_E  チェーンバッファが受信バッファよりも大きい場合に返されます。
+    \return BAD_PATH_ERROR  OpenDir（）がパスを開こうとしたときに失敗した場合に返されます。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    \param file  PEM形式のCA証明書を含むファイルの名前へのポインタ。
+    \param path  PEM形式の証明書をロードするディレクトリの名前へのポインタ。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL_CTX* ctx;
+    ...
+    ret = wolfSSL_CTX_load_verify_locations_ex(ctx, NUULL, “./certs/external",
+        WOLFSSL_LOAD_FLAG_PEM_CA_ONLY);
+    if (ret != WOLFSSL_SUCCESS) {
+        // error loading CA certs
+    }
+    ...
+    \endcode
+    \sa wolfSSL_CTX_load_verify_locations
+    \sa wolfSSL_CTX_load_verify_buffer
+    \sa wolfSSL_CTX_use_certificate_file
+    \sa wolfSSL_CTX_use_PrivateKey_file
+    \sa wolfSSL_CTX_use_certificate_chain_file
+    \sa wolfSSL_use_certificate_file
+    \sa wolfSSL_use_PrivateKey_file
+    \sa wolfSSL_use_certificate_chain_file
+*/
+int wolfSSL_CTX_load_verify_locations_ex(WOLFSSL_CTX* ctx, const char* file,
+                                         const char* path, unsigned int flags);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、TLS / SSLハンドシェイクを実行するときにピアを検証するために使用する証明書をロードします。ハンドシェイク中に送信されたピア証明書は、使用可能なときにスキッドを使用することによって比較されます。これら2つのことが一致しない場合は、ロードされたCASが使用されます。マクロwolfssl_trust_peer_certを定義することで機能が有効になっています。適切な使用法の例をご覧ください。
+    \return SSL_SUCCES  成功すると。
+    \return SSL_FAILURE  CTXがNULLの場合、または両方のファイルと種類が無効な場合は返されます。
+    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合は返されます。
+    \return SSL_BAD_FILE  ファイルが存在しない場合は返されます。読み込め、または破損していません。
+    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
+    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    \param file  証明書を含むファイルの名前へのポインタ
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    ...
+
+    ret = wolfSSL_CTX_trust_peer_cert(ctx, “./peer-cert.pem”,
+    SSL_FILETYPE_PEM);
+    if (ret != SSL_SUCCESS) {
+        // error loading trusted peer cert
+    }
+    ...
+    \endcode
+    \sa wolfSSL_CTX_load_verify_buffer
+    \sa wolfSSL_CTX_use_certificate_file
+    \sa wolfSSL_CTX_use_PrivateKey_file
+    \sa wolfSSL_CTX_use_certificate_chain_file
+    \sa wolfSSL_CTX_trust_peer_buffer
+    \sa wolfSSL_CTX_Unload_trust_peers
+    \sa wolfSSL_use_certificate_file
+    \sa wolfSSL_use_PrivateKey_file
+    \sa wolfSSL_use_certificate_chain_file
+*/
+int wolfSSL_CTX_trust_peer_cert(WOLFSSL_CTX* ctx, const char* file, int type);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、Chain of chainをSSLコンテキスト（WolfSSL_CTX）にロードします。証明書チェーンを含むファイルはファイル引数によって提供され、PEM形式の証明書を含める必要があります。この関数は、最大MAX_CHAIN_DEPTH（Default = 9、internal.hで定義されている）証明書に加えて、サブジェクト証明書を処理します。
+    \return SSL_SUCCESS  成功すると
+    \return SSL_FAILURE  関数呼び出しが失敗した場合、可能な原因が誤った形式にある場合、または「format」引数を使用して誤ったフォーマットが指定されている場合があります。ファイルは存在しません。読み取られない、または破損しているメモリ状態が発生します。
+    \param ctx  wolfssl_ctx_new（）を使用して作成されたwolfssl_ctx構造へのポインタ
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL_CTX* ctx;
+    ...
+    ret = wolfSSL_CTX_use_certificate_chain_file(ctx, “./cert-chain.pem”);
+    if (ret != SSL_SUCCESS) {
+	    // error loading cert file
+    }
+    ...
+    \endcode
+    \sa wolfSSL_CTX_use_certificate_file
+    \sa wolfSSL_CTX_use_certificate_buffer
+    \sa wolfSSL_use_certificate_file
+    \sa wolfSSL_use_certificate_buffer
+*/
+int wolfSSL_CTX_use_certificate_chain_file(WOLFSSL_CTX *ctx,
+                                                     const char *file);
+
+/*!
+    \ingroup openSSL 
+    \brief  この関数は、SSL接続で使用されているプライベートRSAキーをSSLコンテキスト（WolfSSL_CTX）にロードします。この関数は、wolfsslがOpenSSL互換層有効（--enable-openSSlextra、#define openssl_extra）でコンパイルされている場合にのみ利用可能で、より一般的に使用されているwolfssl_ctx_use_privatekey_file（）関数と同じです。ファイル引数には、RSA秘密鍵ファイルへのポインタが、フォーマットで指定された形式で含まれています。
+    \return SSL_SUCCESS  成功すると。
+    \return SSL_FAILURE  関数呼び出しが失敗した場合、可能な原因には次のようになります。入力キーファイルが誤った形式であるか、または「format」引数を使用して誤った形式が与えられている場合は、ファイルが存在しない、読み込めない、または破損していない、メモリ不足状態が発生します。
+    \param ctx  wolfssl_ctx_new（）を使用して作成されたwolfssl_ctx構造へのポインタ
+    \param file  フォーマットで指定された形式で、WolfSSL SSLコンテキストにロードされるRSA秘密鍵を含むファイルの名前へのポインタ。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL_CTX* ctx;
+    ...
+    ret = wolfSSL_CTX_use_RSAPrivateKey_file(ctx, “./server-key.pem”,
+                                       SSL_FILETYPE_PEM);
+    if (ret != SSL_SUCCESS) {
+	    // error loading private key file
+    }
+    ...
+    \endcode
+    \sa wolfSSL_CTX_use_PrivateKey_buffer
+    \sa wolfSSL_CTX_use_PrivateKey_file
+    \sa wolfSSL_use_RSAPrivateKey_file
+    \sa wolfSSL_use_PrivateKey_buffer
+    \sa wolfSSL_use_PrivateKey_file
+*/
+int wolfSSL_CTX_use_RSAPrivateKey_file(WOLFSSL_CTX* ctx, const char* file, int format);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、有効なセッションのために、デフォルトで9の最大チェーン深度を返します。これは、NULL以外のセッションオブジェクト（SSL）があります。
+    \return MAX_CHAIN_DEPTH  wolfssl_ctx構造がnullではない場合に返されます。デフォルトでは値は9です。
+    \return BAD_FUNC_ARG  wolfssl_ctx構造がnullの場合に返されます。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    ...
+    long sslDep = wolfSSL_get_verify_depth(ssl);
+
+    if(sslDep > EXPECTED){
+    	// The verified depth is greater than what was expected
+    } else {
+    	// The verified depth is smaller or equal to the expected value
+    }
+    \endcode
+    \sa wolfSSL_CTX_get_verify_depth
+*/
+long wolfSSL_get_verify_depth(WOLFSSL* ssl);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、CTX構造を使用して証明書チェーン深度を取得します。
+    \return MAX_CHAIN_DEPTH  CTX構造体がNULLではない場合に返されます。最大証明書チェーンピア深度の定数表現。
+    \return BAD_FUNC_ARG  CTX構造がNULLの場合に返されます。
+    _Example_
+    \code
+    WOLFSSL_METHOD method; // protocol method
+    WOLFSSL_CTX* ctx = WOLFSSL_CTX_new(method);
+    …
+    long ret = wolfSSL_CTX_get_verify_depth(ctx);
+
+    if(ret == EXPECTED){
+    	//  You have the expected value
+    } else {
+    	//  Handle an unexpected depth
+    }
+    \endcode
+    \sa wolfSSL_CTX_use_certificate_chain_file
+    \sa wolfSSL_get_verify_depth
+*/
+long wolfSSL_CTX_get_verify_depth(WOLFSSL_CTX* ctx);
+
+/*!
+    \ingroup openSSL 
+    \brief  この関数は証明書ファイルをSSLセッション（WolfSSL構造体）にロードします。証明書ファイルはファイル引数によって提供されます。format引数は、ファイルのフォーマットタイプ（SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM）を指定します。
+    \return SSL_SUCCESS  成功すると
+    \return SSL_FAILURE  関数呼び出しが失敗した場合、可能な原因には次のようになります。ファイルは誤った形式で、または「format」引数を使用して誤った形式が与えられています。メモリ不足状態が発生すると、ファイルでbase16のデコードが失敗する
+    \param ssl  wolfssl_new（）で作成されたwolfssl構造へのポインタ。
+    \param file  wolfssl sslセッションにロードされる証明書を含むファイルの名前へのポインタは、フォーマットで指定された形式でフォーマットします。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL* ssl;
+    ...
+    ret = wolfSSL_use_certificate_file(ssl, “./client-cert.pem”,
+                                 SSL_FILETYPE_PEM);
+    if (ret != SSL_SUCCESS) {
+    	// error loading cert file
+    }
+    ...
+    \endcode
+    \sa wolfSSL_CTX_use_certificate_buffer
+    \sa wolfSSL_CTX_use_certificate_file
+    \sa wolfSSL_use_certificate_buffer
+*/
+int wolfSSL_use_certificate_file(WOLFSSL* ssl, const char* file, int format);
+
+/*!
+    \ingroup openSSL 
+    \brief  この関数は、秘密鍵ファイルをSSLセッション（WolfSSL構造体）にロードします。キーファイルはファイル引数によって提供されます。format引数は、ファイルの形式タイプを指定します -  SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM。外部キーストアを使用し、秘密鍵を持っていない場合は、代わりに公開鍵を入力してCryProコールバックを登録して署名を処理することができます。このためには、CryptoコールバックまたはPKコールバックを使用したビルドで構築できます。Cryptoコールバックを有効にするには、--enable-cryptocbまたはwolf_crypto_cbを使用し、wc_cryptocb_registerDeviceを使用して暗号コールバックを登録し、wolfssl_setdevidを使用して関連するdevidを設定します。
+    \return SSL_SUCCESS  成功すると。
+    \return SSL_FAILURE  関数呼び出しが失敗した場合、可能な原因には次のようになります。ファイルは誤った形式で、または「format」引数を使用して誤った形式が与えられていますが、ファイルは存在しません。メモリ不足状態が発生すると、ベース16のデコードがファイルで失敗し、キーファイルは暗号化されていますが、パスワードは提供されていません。
+    \param ssl  wolfssl_new（）で作成されたwolfssl構造へのポインタ。
+    \param file  wolfssl sslセッションにロードされるキーファイルを含むファイルの名前へのポインタは、フォーマットで指定された形式でフォーマットします。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL* ssl;
+    ...
+    ret = wolfSSL_use_PrivateKey_file(ssl, “./server-key.pem”,
+                                SSL_FILETYPE_PEM);
+    if (ret != SSL_SUCCESS) {
+	    // error loading key file
+    }
+    ...
+    \endcode
+    \sa wolfSSL_CTX_use_PrivateKey_buffer
+    \sa wolfSSL_CTX_use_PrivateKey_file
+    \sa wolfSSL_use_PrivateKey_buffer
+    \sa wc_CryptoCb_RegisterDevice
+    \sa wolfSSL_SetDevId
+*/
+int wolfSSL_use_PrivateKey_file(WOLFSSL* ssl, const char* file, int format);
+
+/*!
+    \ingroup openSSL 
+    \brief  この関数は、Chain of chainをSSLセッション（WolfSSL構造体）にロードします。証明書チェーンを含むファイルはファイル引数によって提供され、PEM形式の証明書を含める必要があります。この関数は、MAX_CHAIN_DEPTH（Default = 9、internal.hで定義されている）証明書に加えて、サブジェクト証明書を処理します。
+    \return SSL_SUCCESS  成功すると。
+    \return SSL_FAILURE  関数呼び出しが失敗した場合、可能な原因には次のようになります。ファイルは誤った形式で、または「format」引数を使用して誤った形式が与えられています。メモリの状態が発生します
+    \param ssl  wolfssl_new（）を使用して作成されたwolfssl構造へのポインタ
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL* ctx;
+    ...
+    ret = wolfSSL_use_certificate_chain_file(ssl, “./cert-chain.pem”);
+    if (ret != SSL_SUCCESS) {
+    	// error loading cert file
+    }
+    ...
+    \endcode
+    \sa wolfSSL_CTX_use_certificate_chain_file
+    \sa wolfSSL_CTX_use_certificate_chain_buffer
+    \sa wolfSSL_use_certificate_chain_buffer
+*/
+int wolfSSL_use_certificate_chain_file(WOLFSSL* ssl, const char *file);
+
+/*!
+    \ingroup openSSL 
+    \brief  この関数は、SSL接続で使用されているプライベートRSAキーをSSLセッション（WolfSSL構造体）にロードします。この関数は、wolfsslがOpenSSL互換層有効（--enable-openSSlextra、#define openssl_extra）でコンパイルされている場合にのみ利用可能で、より一般的に使用されるwolfssl_use_privatekey_file（）関数と同じです。ファイル引数には、RSA秘密鍵ファイルへのポインタが、フォーマットで指定された形式で含まれています。
+    \return SSL_SUCCESS  成功すると
+    \return SSL_FAILURE  関数呼び出しが失敗した場合、可能な原因には次のようになります。入力キーファイルが誤った形式であるか、または「format」引数を使用して誤った形式が与えられている場合は、ファイルが存在しない、読み込めない、または破損していない、メモリ不足状態が発生します
+    \param ssl  wolfssl_new（）を使用して作成されたwolfssl構造へのポインタ
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL* ssl;
+    ...
+    ret = wolfSSL_use_RSAPrivateKey_file(ssl, “./server-key.pem”,
+                                   SSL_FILETYPE_PEM);
+    if (ret != SSL_SUCCESS) {
+	    // error loading private key file
+    }
+    ...
+    \endcode
+    \sa wolfSSL_CTX_use_RSAPrivateKey_file
+    \sa wolfSSL_CTX_use_PrivateKey_buffer
+    \sa wolfSSL_CTX_use_PrivateKey_file
+    \sa wolfSSL_use_PrivateKey_buffer
+    \sa wolfSSL_use_PrivateKey_file
+*/
+int wolfSSL_use_RSAPrivateKey_file(WOLFSSL* ssl, const char* file, int format);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数はwolfssl_ctx_load_verify_locationsと似ていますが、DerフォーマットされたCAファイルをSSLコンテキスト（WolfSSL_CTX）にロードすることを許可します。それはまだPEM形式のCAファイルをロードするためにも使用されるかもしれません。これらの証明書は、信頼できるルート証明書として扱われ、SSLハンドシェイク中にピアから受信した証明書を検証するために使用されます。ファイル引数によって提供されるルート証明書ファイルは、単一の証明書または複数の証明書を含むファイルであり得る。複数のCA CERTが同じファイルに含まれている場合、WolfSSLはファイルに表示されているのと同じ順序でそれらをロードします。 format引数は、証明書がSSL_FILETYPE_PEMまたはSSL_FILETYPE_ASN1（DER）のいずれかにある形式を指定します。 wolfssl_ctx_load_verify_locationsとは異なり、この関数は特定のディレクトリパスからのCA証明書のロードを許可しません。この関数は、WolfSSLライブラリがwolfssl_der_doad定義された状態でコンパイルされたときにのみ利用可能です。
+    \return SSL_SUCCESS  成功すると。
+    \return SSL_FAILURE  失敗すると。
+    \param ctx  wolfssl_ctx_new（）を使用して作成されたwolfssl_ctx構造へのポインタ
+    \param file  wolfssl SSLコンテキストにロードされるCA証明書を含むファイルの名前をフォーマットで指定された形式で指定します。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL_CTX* ctx;
+    ...
+    ret = wolfSSL_CTX_der_load_verify_locations(ctx, “./ca-cert.der”,
+                                          SSL_FILETYPE_ASN1);
+    if (ret != SSL_SUCCESS) {
+	    // error loading CA certs
+    }
+    ...
+    \endcode
+    \sa wolfSSL_CTX_load_verify_locations
+    \sa wolfSSL_CTX_load_verify_buffer
+*/
+int wolfSSL_CTX_der_load_verify_locations(WOLFSSL_CTX* ctx,
+                                          const char* file, int format);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、入力のための所望のSSL / TLSプロトコル方式を取って、新しいSSLコンテキストを作成します。
+    \return pointer  正常にコールが新しく作成されたwolfssl_ctxへのポインタを返します。
+    \return NULL  失敗すると。
+    _Example_
+    \code
+    WOLFSSL_CTX*    ctx    = 0;
+    WOLFSSL_METHOD* method = 0;
+
+    method = wolfSSLv3_client_method();
+    if (method == NULL) {
+    	// unable to get method
+    }
+
+    ctx = wolfSSL_CTX_new(method);
+    if (ctx == NULL) {
+    	// context creation failed
+    }
+    \endcode
+    \sa wolfSSL_new
+*/
+WOLFSSL_CTX* wolfSSL_CTX_new(WOLFSSL_METHOD*);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は新しいSSLセッションを作成し、すでに作成されたSSLコンテキストを入力として作成します。
+    \return *  成功した場合、呼び出しが新しく作成されたWolfSSL構造へのポインタを返します。
+    \return NULL  失敗すると。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL*     ssl = NULL;
+    WOLFSSL_CTX* ctx = 0;
+
+    ctx = wolfSSL_CTX_new(method);
+    if (ctx == NULL) {
+	    // context creation failed
+    }
+
+    ssl = wolfSSL_new(ctx);
+    if (ssl == NULL) {
+	    // SSL object creation failed
+    }
+    \endcode
+    \sa wolfSSL_CTX_new
+*/
+WOLFSSL* wolfSSL_new(WOLFSSL_CTX*);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、SSL接続の入出力機能としてファイル記述子（FD）を割り当てます。通常これはソケットファイル記述子になります。
+    \return SSL_SUCCESS  成功すると。
+    \return Bad_FUNC_ARG  失敗すると。
+    \param ssl  wolfssl_new（）で作成されたSSLセッションへのポインタ。
+    _Example_
+    \code
+    int sockfd;
+    WOLFSSL* ssl = 0;
+    ...
+
+    ret = wolfSSL_set_fd(ssl, sockfd);
+    if (ret != SSL_SUCCESS) {
+    	// failed to set SSL file descriptor
+    }
+    \endcode
+    \sa wolfSSL_CTX_SetIOSend
+    \sa wolfSSL_CTX_SetIORecv
+    \sa wolfSSL_SetIOReadCtx
+    \sa wolfSSL_SetIOWriteCtx
+*/
+int  wolfSSL_set_fd (WOLFSSL* ssl, int fd);
+
+/*!
+    \ingroup IO 
+    \brief  渡された優先順位の暗号の名前を取得します。
+    \return string  成功
+    \return 0  優先順位は範囲外または無効です。
+    _Example_
+    \code
+    printf("The cipher at 1 is %s", wolfSSL_get_cipher_list(1));
+    \endcode
+    \sa wolfSSL_CIPHER_get_name
+    \sa wolfSSL_get_current_cipher
+*/
+char* wolfSSL_get_cipher_list(int priority);
+
+/*!
+    \ingroup IO 
+    \brief  この関数はwolfsslでイネーブルされた暗号を取得します。
+    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。
+    \return BAD_FUNC_ARG  bufパラメータがnullの場合、またはlen引数がゼロ以下の場合に返されます。
+    \return BUFFER_E  バッファが十分に大きくなく、オーバーフローすると返されます。
+    \param buf  バッファを表す文字ポインタ。
+    _Example_
+    \code
+    static void ShowCiphers(void){
+	char* ciphers;
+	int ret = wolfSSL_get_ciphers(ciphers, (int)sizeof(ciphers));
+
+	if(ret == SSL_SUCCES){
+	    	printf(“%s\n”, ciphers);
+	    }
+    }
+    \endcode
+    \sa GetCipherNames
+    \sa wolfSSL_get_cipher_list
+    \sa ShowCiphers
+*/
+int  wolfSSL_get_ciphers(char* buf, int len);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、引数をwolfssl_get_cipher_name_internalに渡すことによって、DHE-RSAの形式の暗号名を取得します。
+    \return string  この関数は、一致した暗号スイートの文字列表現を返します。
+    \return NULL  エラーまたは暗号が見つかりません。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    …
+    char* cipherS = wolfSSL_get_cipher_name(ssl);
+
+    if(cipher == NULL){
+	    // There was not a cipher suite matched
+    } else {
+	    // There was a cipher suite matched
+	    printf(“%s\n”, cipherS);
+    }
+    \endcode
+    \sa wolfSSL_CIPHER_get_name
+    \sa wolfSSL_get_current_cipher
+    \sa wolfSSL_get_cipher_name_internal
+*/
+const char* wolfSSL_get_cipher_name(WOLFSSL* ssl);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、SSL接続の入出力機能として使用されるファイル記述子（FD）を返します。通常これはソケットファイル記述子になります。
+    \return fd  正常にコールがSSLセッションファイル記述子を返します。
+    _Example_
+    \code
+    int sockfd;
+    WOLFSSL* ssl = 0;
+    ...
+    sockfd = wolfSSL_get_fd(ssl);
+    ...
+    \endcode
+    \sa wolfSSL_set_fd
+*/
+int  wolfSSL_get_fd(const WOLFSSL*);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、wolfsslオブジェクトに基礎となるI / Oがブロックされていないことを通知します。アプリケーションがWolfSSLオブジェクトを作成した後、ブロッキング以外のソケットで使用される場合は、wolfssl_set_using_nonblock（）を呼び出します。これにより、wolfsslオブジェクトは、Ewouldblockを受信することを意味します。
+    \return none  返品不可。
+    \param ssl  wolfssl_new（）で作成されたSSLセッションへのポインタ。
+    _Example_
+    \code
+    WOLFSSL* ssl = 0;
+    ...
+    wolfSSL_set_using_nonblock(ssl, 1);
+    \endcode
+    \sa wolfSSL_get_using_nonblock
+    \sa wolfSSL_dtls_got_timeout
+    \sa wolfSSL_dtls_get_current_timeout
+*/
+void wolfSSL_set_using_nonblock(WOLFSSL* ssl, int nonblock);
+
+/*!
+    \ingroup IO 
+    \brief  この機能により、WolfSSLが非ブロッキングI / Oを使用しているかどうかをアプリケーションが判断できます。WolfSSLがノンブロッキングI / Oを使用している場合、この関数は1を返します。これにより、wolfsslオブジェクトは、Ewouldblockを受信することを意味します。
+    \return 0  基礎となるI / Oがブロックされています。
+    \return 1  基礎となるI / Oは非ブロッキングです。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL* ssl = 0;
+    ...
+    ret = wolfSSL_get_using_nonblock(ssl);
+    if (ret == 1) {
+    	// underlying I/O is non-blocking
+    }
+    ...
+    \endcode
+    \sa wolfSSL_set_session
+*/
+int  wolfSSL_get_using_nonblock(WOLFSSL*);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、バッファ、データ、SSL接続、SSLにSZバイトを書き込みます。必要に応じて、wolfssl_write（）はまだwolfssl_connect（）またはwolfssl_accept（）によってまだ実行されていない場合、wolfssl_write（）はSSL / TLSセッションをネゴシエートします。wolfssl_write（）は、ブロックと非ブロッキングI / Oの両方で動作します。基礎となる入出力がブロックされていない場合、wolfssl_write（）がwolfssl_write（）のニーズを満たすことができなかったときにwolfssl_write（）が戻ります。この場合、wolfssl_get_error（）への呼び出しはSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかを生成します。その結果、基礎となるI / Oが準備ができたら、呼び出し側プロセスはwolfssl_write（）への呼び出しを繰り返す必要があります。基礎となる入出力がブロックされている場合、WolfSSL_WRITE（）は、サイズSZのバッファデータが完全に書かれたかエラーが発生したら、戻るだけです。
+    \return >0  成功時に書かれたバイト数。
+    \return 0  失敗したときに返されます。特定のエラーコードについてwolfssl_get_error（）を呼び出します。
+    \return SSL_FATAL_ERROR  エラーが発生したとき、または非ブロッキングソケットを使用するときには、SSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEエラーが受信され、再度WOLFSSL_WRITE（）を呼び出す必要がある場合は、障害が発生します。特定のエラーコードを取得するには、wolfssl_get_error（）を使用してください。
+    \param ssl  wolfssl_new（）で作成されたSSLセッションへのポインタ。
+    \param data  ピアに送信されるデータバッファ。
+    _Example_
+    \code
+    WOLFSSL* ssl = 0;
+    char msg[64] = “hello wolfssl!”;
+    int msgSz = (int)strlen(msg);
+    int flags;
+    int ret;
+    ...
+
+    ret = wolfSSL_write(ssl, msg, msgSz);
+    if (ret <= 0) {
+    	// wolfSSL_write() failed, call wolfSSL_get_error()
+    }
+    \endcode
+    \sa wolfSSL_send
+    \sa wolfSSL_read
+    \sa wolfSSL_recv
+*/
+int  wolfSSL_write(WOLFSSL* ssl, const void* data, int sz);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、SSLセッション（SSL）内部読み取りバッファからSZバイトをバッファデータに読み出します。読み取られたバイトは内部受信バッファから削除されます。必要に応じて、wolfssl_read（）がまだwolfssl_connect（）またはwolfssl_accept（）によってまだ実行されていない場合は、wolfssl_read（）がSSL / TLSセッションをネゴシエートします。 SSL / TLSプロトコルは、最大サイズのSSLレコードを使用します（最大レコードサイズは<wolfssl_root> /wolfssl/internal.h）。そのため、WolfSSLは、レコードを処理および復号化することができる前に、SSLレコード全体を内部的に読み取る必要があります。このため、wolfssl_read（）への呼び出しは、呼び出し時に復号化された最大バッファサイズを返すことができます。検索され、次回のwolfssl_read（）への呼び出しで復号化される内部WolfSSL受信バッファで待機していない追加の復号化データがあるかもしれません。 SZが内部読み取りバッファ内のバイト数より大きい場合、SSL_READ（）は内部読み取りバッファで使用可能なバイトを返します。 BYTESが内部読み取りバッファにバッファされていない場合は、WOLFSSL_READ（）への呼び出しは次のレコードの処理をトリガーします。
+    \return >0  成功時に読み取られたバイト数。
+    \return 0  失敗したときに返されます。これは、クリーン（通知アラートを閉じる）シャットダウンまたはピアが接続を閉じただけであることによって発生する可能性があります。特定のエラーコードについてwolfssl_get_error（）を呼び出します。
+    \return SSL_FATAL_ERROR  エラーが発生したとき、または非ブロッキングソケットを使用するときに、SSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEエラーが受信され、再度WOLFSL_READ（）を呼び出す必要がある場合は、障害が発生します。特定のエラーコードを取得するには、wolfssl_get_error（）を使用してください。
+    \param ssl  wolfssl_new（）で作成されたSSLセッションへのポインタ。
+    \param data  wolfssl_read（）がデータを読み取るバッファー。
+    _Example_
+    \code
+    WOLFSSL* ssl = 0;
+    char reply[1024];
+    ...
+
+    input = wolfSSL_read(ssl, reply, sizeof(reply));
+    if (input > 0) {
+    	// “input” number of bytes returned into buffer “reply”
+    }
+
+    See wolfSSL examples (client, server, echoclient, echoserver) for more
+    complete examples of wolfSSL_read().
+    \endcode
+    \sa wolfSSL_recv
+    \sa wolfSSL_write
+    \sa wolfSSL_peek
+    \sa wolfSSL_pending
+*/
+int  wolfSSL_read(WOLFSSL* ssl, void* data, int sz);
+
+/*!
+    \ingroup IO 
+    \brief  この関数はSSLセッション（SSL）内部読み取りバッファからSZバイトをバッファデータにコピーします。この関数は、内部SSLセッション受信バッファ内のデータが削除されていないか変更されていないことを除いて、wolfssl_read（）と同じです。必要に応じて、wolfssl_read（）のように、wolfssl_peek（）はまだwolfssl_connect（）またはwolfssl_accept（）によってまだ実行されていない場合、wolfssl_peek（）はSSL / TLSセッションをネゴシエートします。 SSL / TLSプロトコルは、最大サイズのSSLレコードを使用します（最大レコードサイズは<wolfssl_root> /wolfssl/internal.h）。そのため、WolfSSLは、レコードを処理および復号化することができる前に、SSLレコード全体を内部的に読み取る必要があります。このため、wolfssl_peek（）への呼び出しは、呼び出し時に復号化された最大バッファサイズを返すことができます。 wolfssl_peek（）/ wolfssl_read（）への次の呼び出しで検索および復号化される内部WolfSSL受信バッファ内で待機していない追加の復号化データがあるかもしれません。 SZが内部読み取りバッファ内のバイト数よりも大きい場合、SSL_PEEK（）は内部読み取りバッファで使用可能なバイトを返します。バイトが内部読み取りバッファにバッファされていない場合、Wolfssl_peek（）への呼び出しは次のレコードの処理をトリガーします。
+    \return >0  成功時に読み取られたバイト数。
+    \return 0  失敗したときに返されます。これは、クリーン（通知アラートを閉じる）シャットダウンまたはピアが接続を閉じただけであることによって発生する可能性があります。特定のエラーコードについてwolfssl_get_error（）を呼び出します。
+    \return SSL_FATAL_ERROR  エラーが発生したとき、または非ブロッキングソケットを使用するときに、SSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEエラーが受信され、再度WolfSSL_PEEK（）を呼び出す必要がある場合は、障害が発生します。特定のエラーコードを取得するには、wolfssl_get_error（）を使用してください。
+    \param ssl  wolfssl_new（）で作成されたSSLセッションへのポインタ。
+    \param data  wolfssl_peek（）がデータを読み取るバッファー。
+    _Example_
+    \code
+    WOLFSSL* ssl = 0;
+    char reply[1024];
+    ...
+
+    input = wolfSSL_peek(ssl, reply, sizeof(reply));
+    if (input > 0) {
+	    // “input” number of bytes returned into buffer “reply”
+    }
+    \endcode
+    \sa wolfSSL_read
+*/
+int  wolfSSL_peek(WOLFSSL* ssl, void* data, int sz);
+
+/*!
+    \ingroup IO 
+    \brief  この関数はサーバー側で呼び出され、SSLクライアントがSSL / TLSハンドシェイクを開始するのを待ちます。この関数が呼び出されると、基礎となる通信チャネルはすでに設定されています。wolfssl_accept（）は、ブロックと非ブロッキングI / Oの両方で動作します。基礎となる入出力がノンブロッキングである場合、wolfssl_accept（）は、基礎となるI / Oがwolfssl_acceptのニーズを満たすことができなかったときに戻ります。この場合、wolfssl_get_error（）への呼び出しはSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかを生成します。通話プロセスは、読み取り可能なデータが使用可能であり、wolfsslが停止した場所を拾うときに、wolfssl_acceptの呼び出しを繰り返す必要があります。ノンブロッキングソケットを使用する場合は、何も実行する必要がありますが、select（）を使用して必要な条件を確認できます。基礎となるI / Oがブロックされている場合、wolfssl_accept（）はハンドシェイクが終了したら、またはエラーが発生したら戻ります。
+    \return SSL_SUCCESS  成功すると。
+    \return SSL_FATAL_ERROR  エラーが発生した場合は返されます。より詳細なエラーコードを取得するには、wolfssl_get_error（）を呼び出します。
+    _Example_
+    \code
+    int ret = 0;
+    int err = 0;
+    WOLFSSL* ssl;
+    char buffer[80];
+    ...
+
+    ret = wolfSSL_accept(ssl);
+    if (ret != SSL_SUCCESS) {
+        err = wolfSSL_get_error(ssl, ret);
+        printf(“error = %d, %s\n”, err, wolfSSL_ERR_error_string(err, buffer));
+    }
+    \endcode
+    \sa wolfSSL_get_error
+    \sa wolfSSL_connect
+*/
+int  wolfSSL_accept(WOLFSSL*);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、割り当てられたwolfssl_ctxオブジェクトを解放します。この関数はCTX参照数を減らし、参照カウントが0に達したときにのみコンテキストを解放します。
+    \return none  返品不可。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = 0;
+    ...
+    wolfSSL_CTX_free(ctx);
+    \endcode
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_new
+    \sa wolfSSL_free
+*/
+void wolfSSL_CTX_free(WOLFSSL_CTX*);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は割り当てられたwolfsslオブジェクトを解放します。
+    \return none  返品不可。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL* ssl = 0;
+    ...
+    wolfSSL_free(ssl);
+    \endcode
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_new
+    \sa wolfSSL_CTX_free
+*/
+void wolfSSL_free(WOLFSSL*);
+
+/*!
+    \ingroup TLS 
+    \brief  この関数は、SSLセッションSSLを使用してアクティブなSSL / TLS接続をシャットダウンします。この関数は、ピアに「Close Notify」アラートを送信しようとします。呼び出し側アプリケーションは、Peerがその「閉じる通知」アラートを応答に送信するのを待つか、または直接wolfssl_shutdownを呼び出した後（リソースを保存するために）wolfssl_shutdownを直接通話した後に基礎となる接続を停止するのを待つことができます。どちらのオプションはTLS仕様で許可されています。将来、基礎となる接続が再び使用される場合、同期をピア間で無傷のまま保つために完全な2方向のシャットダウン手順を実行する必要があります。 wolfssl_shutdown（）は、ブロックと非ブロッキングI / Oの両方で動作します。基礎となるI / Oがノンブロッキングされていない場合、wolfsl_shutdown（）がwolfssl_shutdown（）のニーズを満たすことができなかった場合、wolfssl_shutdown（）はエラーを返します。この場合、wolfssl_get_error（）への呼び出しはSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかを生成します。その結果、基礎となるI / Oが準備ができたら、呼び出し側プロセスはwolfssl_shutdown（）への呼び出しを繰り返す必要があります。
+    \return SSL_SUCCESS  成功に戻ります。
+    \return SSL_SHUTDOWN_NOT_DONE  シャットダウンが終了していない場合は返され、機能を再度呼び出す必要があります。
+    \return SSL_FATAL_ERROR  失敗したときに返されます。より具体的なエラーコードに対してwolfssl_get_error（）を呼び出します。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    int ret = 0;
+    WOLFSSL* ssl = 0;
+    ...
+    ret = wolfSSL_shutdown(ssl);
+    if (ret != 0) {
+	    // failed to shut down SSL connection
+    }
+    \endcode
+    \sa wolfSSL_free
+    \sa wolfSSL_CTX_free
+*/
+int  wolfSSL_shutdown(WOLFSSL*);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、基礎となる書き込み操作のために指定されたフラグを使用して、バッファ、データ、データからSZバイトをSSL接続SSLに書き込みます。必要に応じて、wolfssl_send（）がまだwolfssl_connect（）またはwolfssl_accept（）によってまだ実行されていない場合は、wolfssl_send（）がSSL / TLSセッションをネゴシエートします。wolfssl_send（）は、ブロックと非ブロッキングI / Oの両方で動作します。基礎となる入出力が非ブロックされていない場合、wolfssl_send（）がwolfssl_sendのニーズを満たすことができなかったときにwolfssl_send（）が戻ります。この場合、wolfssl_get_error（）への呼び出しはSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかを生成します。その結果、基礎となる入出力が準備ができたら、呼び出し側プロセスはwolfssl_send（）への呼び出しを繰り返す必要があります。基礎となる入出力がブロックされている場合、Wolfssl_send（）は、サイズSZのバッファデータが完全に書き込まれたかエラーが発生したら、戻るだけです。
+    \return >0  成功時に書かれたバイト数。
+    \return 0  失敗したときに返されます。特定のエラーコードについてwolfssl_get_error（）を呼び出します。
+    \return SSL_FATAL_ERROR  エラーが発生したとき、または非ブロッキングソケットを使用するときに、SSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEエラーが受信され、再度WOLFSSL_SEND（）を呼び出す必要がある場合は、障害が発生します。特定のエラーコードを取得するには、wolfssl_get_error（）を使用してください。
+    \param ssl  wolfssl_new（）で作成されたSSLセッションへのポインタ。
+    \param data  ピアに送信するデータバッファ。
+    \param sz  ピアに送信されるデータのサイズ（バイト）。
+    _Example_
+    \code
+    WOLFSSL* ssl = 0;
+    char msg[64] = “hello wolfssl!”;
+    int msgSz = (int)strlen(msg);
+    int flags = ... ;
+    ...
+
+    input = wolfSSL_send(ssl, msg, msgSz, flags);
+    if (input != msgSz) {
+    	// wolfSSL_send() failed
+    }
+    \endcode
+    \sa wolfSSL_write
+    \sa wolfSSL_read
+    \sa wolfSSL_recv
+*/
+int  wolfSSL_send(WOLFSSL* ssl, const void* data, int sz, int flags);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、基礎となるRECV動作のために指定されたフラグを使用して、SSLセッション（SSL）内部読み取りバッファからSZバイトをバッファデータに読み出します。読み取られたバイトは内部受信バッファから削除されます。この関数はwolfssl_read（）と同じです。ただし、アプリケーションが基礎となる読み取り操作のRECVフラグを設定できることを許可します。必要に応じてwolfssl_recv（）がwolfssl_connect（）またはwolfssl_accept（）によってハンドシェイクがまだ実行されていない場合は、SSL / TLSセッションをネゴシエートします。 SSL / TLSプロトコルは、最大サイズのSSLレコードを使用します（最大レコードサイズは<wolfssl_root> /wolfssl/internal.h）。そのため、WolfSSLは、レコードを処理および復号化することができる前に、SSLレコード全体を内部的に読み取る必要があります。このため、wolfssl_recv（）への呼び出しは、呼び出し時に復号化された最大バッファサイズを返すことができるだけです。 wolfssl_recv（）への次の呼び出しで検索および復号化される内部WolfSSL受信バッファで待機していない追加の復号化されたデータがあるかもしれません。 SZが内部読み取りバッファ内のバイト数よりも大きい場合、SSL_RECV（）は内部読み取りバッファで使用可能なバイトを返します。バイトが内部読み取りバッファにバッファされていない場合は、WOLFSSL_RECV（）への呼び出しは次のレコードの処理をトリガーします。
+    \return >0  成功時に読み取られたバイト数。
+    \return 0  失敗したときに返されます。これは、クリーン（通知アラートを閉じる）シャットダウンまたはピアが接続を閉じただけであることによって発生する可能性があります。特定のエラーコードについてwolfssl_get_error（）を呼び出します。
+    \return SSL_FATAL_ERROR  エラーが発生した場合、または非ブロッキングソケットを使用するときには、SSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEエラーが発生し、アプリケーションが再びWOLFSSL_RECV（）を呼び出す必要があります。特定のエラーコードを取得するには、wolfssl_get_error（）を使用してください。
+    \param ssl  wolfssl_new（）で作成されたSSLセッションへのポインタ。
+    \param data  wolfssl_recv（）がデータを読み取るバッファー。
+    \param sz  データを読み込むためのバイト数。
+    _Example_
+    \code
+    WOLFSSL* ssl = 0;
+    char reply[1024];
+    int flags = ... ;
+    ...
+
+    input = wolfSSL_recv(ssl, reply, sizeof(reply), flags);
+    if (input > 0) {
+    	// “input” number of bytes returned into buffer “reply”
+    }
+    \endcode
+    \sa wolfSSL_read
+    \sa wolfSSL_write
+    \sa wolfSSL_peek
+    \sa wolfSSL_pending
+*/
+int  wolfSSL_recv(WOLFSSL* ssl, void* data, int sz, int flags);
+
+/*!
+    \ingroup Debug 
+    \brief  この関数は、以前のAPI関数呼び出し（wolfssl_connect、wolfssl_accept、wolfssl_read、wolfssl_writeなど）がエラー戻りコード（ssl_failure）を呼び出した理由を表す一意のエラーコードを返します。前の関数の戻り値は、RETを介してwolfssl_get_errorに渡されます。wolfssl_get_errorが呼び出された後、一意のエラーコードを返します、wolfssl_err_error_string（）を呼び出して人間が読めるエラー文字列を取得することができます。詳細については、wolfssl_err_error_string（）を参照してください。
+    \return On  完了成功、この関数は、前のAPI関数が失敗した理由を説明する固有のエラーコードを返します。
+    \return SSL_ERROR_NONE  RET> 0の場合は返されます.Ret <= 0の場合、以前のAPIがエラーコードを返すが実際に発生しなかった場合にこの値を返す場合があります。例は、ゼロSZパラメータを使用してwolfssl_read（）を呼び出すことです。a 0 wolfssl_read（）からの戻り値は通常エラーを示しますが、この場合はエラーは発生しませんでした。wolfssl_get_error（）がその後呼び出された場合、ssl_error_noneが返されます。
+    \param ssl  wolfssl_new（）で作成されたSSLオブジェクトへのポインタ。
+    _Example_
+    \code
+    int err = 0;
+    WOLFSSL* ssl;
+    char buffer[80];
+    ...
+    err = wolfSSL_get_error(ssl, 0);
+    wolfSSL_ERR_error_string(err, buffer);
+    printf(“err = %d, %s\n”, err, buffer);
+    \endcode
+    \sa wolfSSL_ERR_error_string
+    \sa wolfSSL_ERR_error_string_n
+    \sa wolfSSL_ERR_print_errors_fp
+    \sa wolfSSL_load_error_strings
+*/
+int  wolfSSL_get_error(WOLFSSL* ssl, int ret);
+
+/*!
+    \ingroup IO 
+    \brief  この関数はアラート履歴を取得します。
+    \return SSL_SUCCESS  関数が正常に完了したときに返されます。警告履歴があったか、またはいずれにも、戻り値はSSL_SUCCESSです。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new(protocol method);
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    WOLFSSL_ALERT_HISTORY* h;
+    ...
+    wolfSSL_get_alert_history(ssl, h);
+    // h now has a copy of the ssl->alert_history  contents
+    \endcode
+    \sa wolfSSL_get_error
+*/
+int  wolfSSL_get_alert_history(WOLFSSL* ssl, WOLFSSL_ALERT_HISTORY *h);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、SSLオブジェクトSSLがSSL / TLS接続を確立するために使用されるときに使用されるセッションを設定します。セッションの再開の場合、wolfssl_shutdown（）をセッションオブジェクトに呼び出す前に、アプリケーションはオブジェクトからwolfssl_get1_session（）を呼び出して保存する必要があります。これはセッションへのポインタを返します。後で、アプリケーションは新しいWolfSSLオブジェクトを作成し、保存したセッションをwolfssl_set_session（）に割り当てる必要があります。この時点で、アプリケーションはwolfssl_connect（）を呼び出し、WolfSSLはセッションを再開しようとします。WolfSSLサーバーコードでは、デフォルトでセッションの再開を許可します。wolfssl_get1_session（）によって返されたオブジェクトは、アプリケーションがそれを使用してそれを使用して解放される必要があります。
+    \return SSL_SUCCESS  セッションを正常に設定すると返されます。
+    \return SSL_FAILURE  失敗した場合に返されます。これはセッションキャッシュが無効になっている、またはセッションがタイムアウトした場合によって発生する可能性があります。
+    \return When  OpenSSL_EXTRAとWOLFSSL_ERROR_CODE_OPENSSLが定義されているため、セッションがタイムアウトしていてもSSL_SUCCESSが返されます。
+    \param ssl  wolfssl_new（）で作成されたSSLオブジェクトへのポインタ。
+    _Example_
+    \code
+    int ret;
+    WOLFSSL* ssl;
+    WOLFSSL_SESSION* session;
+    ...
+    session = wolfSSL_get1_session(ssl);
+    if (session == NULL) {
+        // failed to get session object from ssl object
+    }
+    ...
+    ret = wolfSSL_set_session(ssl, session);
+    if (ret != SSL_SUCCESS) {
+    	// failed to set the SSL session
+    }
+    wolfSSL_SESSION_free(session);
+    ...
+    \endcode
+    \sa wolfSSL_get1_session
+*/
+int        wolfSSL_set_session(WOLFSSL* ssl, WOLFSSL_SESSION* session);
+
+/*!
+    \ingroup IO 
+    \brief  NO_SESSION_CACHE_REFが定義されている場合、この関数はSSLで使用されている現在のセッション（WolfSSL_SESSION）へのポインタを返します。この関数は、wolfssl_sessionオブジェクトへの永続的なポインタを返します。返されるポインタは、wolfssl_freeが呼び出されたときに解放されます。この呼び出しは、現在のセッションを検査または変更するためにのみ使用されます。セッションの再開の場合は、wolfssl_get1_session（）を使用することをお勧めします。NO_SESSION_CACHE_REFが定義されていない場合の後方互換性のために、この関数はローカルキャッシュに格納されている永続セッションオブジェクトポインタを返します。キャッシュサイズは有限であり、アプリケーションがwolfssl_set_session（）を呼び出す時までにセッションオブジェクトが別のSSL接続によって上書きされる危険性があります。アプリケーションにNO_SESSION_CACHE_REFを定義し、セッション再開にwolfssl_get1_session（）を使用することをお勧めします。
+    \return pointer  正常にコールが現在のSSLセッションオブジェクトへのポインタを返します。
+    \return NULL  SSLがNULLの場合、SSLセッションキャッシュが無効になっている場合、WolfSSLはセッションIDを使用できない、またはミューテックス関数が失敗します。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    WOLFSSL_SESSION* session;
+    ...
+    session = wolfSSL_get_session(ssl);
+    if (session == NULL) {
+	    // failed to get session pointer
+    }
+    ...
+    \endcode
+    \sa wolfSSL_get1_session
+    \sa wolfSSL_set_session
+*/
+WOLFSSL_SESSION* wolfSSL_get_session(WOLFSSL* ssl);
+
+/*!
+    \ingroup IO 
+    \brief  この機能は、期限切れになったセッションキャッシュからセッションをフラッシュします。時間比較にはTMが使用されます。WolfSSLは現在セッションに静的テーブルを使用しているため、フラッシングは不要です。そのため、この機能は現在サブだけです。この関数は、wolfsslがOpenSSL互換層でコンパイルされているときのOpenSSL互換性（ssl_flush_sessions）を提供します。
+    \return none  いいえ返します。
+    \param ctx  wolfssl_ctx_new（）を使用して作成されたwolfssl_ctx構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ssl;
+    ...
+    wolfSSL_flush_sessions(ctx, time(0));
+    \endcode
+    \sa wolfSSL_get1_session
+    \sa wolfSSL_set_session
+*/
+void       wolfSSL_flush_sessions(WOLFSSL_CTX* ctx, long tm);
+
+/*!
+    \ingroup TLS 
+    \brief  この関数はクライアントセッションをサーバーIDと関連付けます。Newsessionフラグがオンの場合、既存のセッションは再利用されません。
+    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。
+    \return BAD_FUNC_ARG  wolfssl structまたはidパラメータがnullの場合、またはLenがゼロ以下の場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param id  wolfssl_session構造体のServerIDメンバーにコピーされる定数バイトポインタ。
+    \param len  セッションIDパラメータの長さを表すint型。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol );
+    WOLFSSL* ssl = WOLFSSL_new(ctx);
+    const byte id[MAX_SIZE];  // or dynamically create space
+    int len = 0; // initialize length
+    int newSession = 0; // flag to allow
+    …
+    int ret = wolfSSL_SetServerID(ssl, id, len, newSession);
+
+    if (ret == WOLFSSL_SUCCESS) {
+	    // The Id was successfully set
+    }
+    \endcode
+    \sa wolfSSL_set_session
+*/
+int        wolfSSL_SetServerID(WOLFSSL* ssl, const unsigned char* id,
+                                         int len, int newSession);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、WolfSSL構造体のセッションインデックスを取得します。
+    \return int  この関数は、wolfssl構造体内のSessionIndexを表すint型を返します。
+    _Example_
+    \code
+    WOLFSSL_CTX_new( protocol method );
+    WOLFSSL* ssl = WOLFSSL_new(ctx);
+    ...
+    int sesIdx = wolfSSL_GetSessionIndex(ssl);
+
+    if(sesIdx < 0 || sesIdx > sizeof(ssl->sessionIndex)/sizeof(int)){
+    	// You have an out of bounds index number and something is not right.
+    }
+    \endcode
+    \sa wolfSSL_GetSessionAtIndex
+*/
+int wolfSSL_GetSessionIndex(WOLFSSL* ssl);
+
+/*!
+    \ingroup IO 
+    \brief  この関数はセッションキャッシュの指定されたインデックスでセッションを取得し、それをメモリにコピーします。wolfssl_session構造体はセッション情報を保持します。
+    \return SSL_SUCCESS  関数が正常に実行され、エラーがスローされなかった場合に返されます。
+    \return BAD_MUTEX_E  アンロックまたはロックミューテックスエラーが発生した場合は返されます。
+    \return SSL_FAILURE  関数が正常に実行されなかった場合に返されます。
+    \param idx  セッションインデックスを表すint型。
+    _Example_
+    \code
+    int idx; // The index to locate the session.
+    WOLFSSL_SESSION* session;  // Buffer to copy to.
+    ...
+    if(wolfSSL_GetSessionAtIndex(idx, session) != SSL_SUCCESS){
+    	// Failure case.
+    }
+    \endcode
+    \sa UnLockMutex
+    \sa LockMutex
+    \sa wolfSSL_GetSessionIndex
+*/
+int wolfSSL_GetSessionAtIndex(int index, WOLFSSL_SESSION* session);
+
+/*!
+    \ingroup IO 
+    \brief  wolfssl_session構造体からピア証明書チェーンを返します。
+    \return pointer  ピア認証チェーンを含むWOLFSSL_X509_CHAIN構造体へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_SESSION* session;
+    WOLFSSL_X509_CHAIN* chain;
+    ...
+    chain = wolfSSL_SESSION_get_peer_chain(session);
+    if(!chain){
+    	// There was no chain. Failure case.
+    }
+    \endcode
+    \sa wolfSSL_GetSessionAtIndex
+    \sa wolfSSL_GetSessionIndex
+    \sa AddSession
+*/
+
+    WOLFSSL_X509_CHAIN* wolfSSL_SESSION_get_peer_chain(WOLFSSL_SESSION* session);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数はリモートピアの検証方法を設定し、またSSLコンテキストに登録されることを確認することもできます。検証コールバックは、検証障害が発生した場合にのみ呼び出されます。検証コールバックが必要な場合は、NULLポインタをverify_callbackに使用できます。ピア証明書の検証モードは、論理的またはフラグのリストです。可能なフラグ値は次のとおりです.SSL_VERIFY_NONEクライアントモード：クライアントはサーバーから受信した証明書を検証せず、ハンドシェイクは通常どおり続きます。サーバーモード：サーバーはクライアントに証明書要求を送信しません。そのため、クライアント検証は有効になりません。 ssl_verify_peerクライアントモード：クライアントはハンドシェイク中にサーバーから受信した証明書を検証します。これはwolfsslではデフォルトでオンにされます。したがって、このオプションを使用すると効果がありません。サーバーモード：サーバーは証明書要求をクライアントに送信し、受信したクライアント証明書を確認します。 ssl_verify_fail_if_no_peer_certクライアントモード：クライアント側で使用されていない場合は効果がありません。サーバーモード：要求されたときにクライアントが証明書の送信に失敗した場合は、サーバー側で検証が失敗します（SSLサーバーのSSL_VERIFY_PEERを使用する場合）。 ssl_verify_fail_except_pskクライアントモード：クライアント側で使用されていない場合は効果がありません。サーバーモード：PSK接続の場合を除き、検証はssl_verify_fail_if_no_peer_certと同じです。 PSK接続が行われている場合、接続はピア証明書なしで通過します。
+    \return none  返品不可。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    \param mode  セッションタイムアウト値（秒）
+    _Example_
+    \code
+    WOLFSSL_CTX*    ctx    = 0;
+    ...
+    wolfSSL_CTX_set_verify(ctx, (WOLFSSL_VERIFY_PEER |
+                           WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT), NULL);
+    \endcode
+    \sa wolfSSL_set_verify
+*/
+void wolfSSL_CTX_set_verify(WOLFSSL_CTX* ctx, int mode,
+                                      VerifyCallback verify_callback);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数はリモートピアの検証方法を設定し、またSSLセッションに登録するのを登録することもできます。検証コールバックは、検証障害が発生した場合にのみ呼び出されます。検証コールバックが必要な場合は、NULLポインタをverify_callbackに使用できます。ピア証明書の検証モードは、論理的またはフラグのリストです。可能なフラグ値は次のとおりです.SSL_VERIFY_NONEクライアントモード：クライアントはサーバーから受信した証明書を検証せず、ハンドシェイクは通常どおり続きます。サーバーモード：サーバーはクライアントに証明書要求を送信しません。そのため、クライアント検証は有効になりません。 ssl_verify_peerクライアントモード：クライアントはハンドシェイク中にサーバーから受信した証明書を検証します。これはwolfsslではデフォルトでオンにされます。したがって、このオプションを使用すると効果がありません。サーバーモード：サーバーは証明書要求をクライアントに送信し、受信したクライアント証明書を確認します。 ssl_verify_fail_if_no_peer_certクライアントモード：クライアント側で使用されていない場合は効果がありません。サーバーモード：要求されたときにクライアントが証明書の送信に失敗した場合は、サーバー側で検証が失敗します（SSLサーバーのSSL_VERIFY_PEERを使用する場合）。 ssl_verify_fail_except_pskクライアントモード：クライアント側で使用されていない場合は効果がありません。サーバーモード：PSK接続の場合を除き、検証はssl_verify_fail_if_no_peer_certと同じです。 PSK接続が行われている場合、接続はピア証明書なしで通過します。
+    \return none  返品不可。
+    \param ssl  wolfssl_new（）で作成されたSSLセッションへのポインタ。
+    \param mode  セッションタイムアウト値（秒単位）。
+    _Example_
+    \code
+    WOLFSSL* ssl = 0;
+    ...
+    wolfSSL_set_verify(ssl, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, 0);
+    \endcode
+    \sa wolfSSL_CTX_set_verify
+*/
+void wolfSSL_set_verify(WOLFSSL* ssl, int mode, VerifyCallback verify_callback);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、検証コールバックのためのユーザーCTXオブジェクト情報を格納します。
+    \return none  返品不可。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    (void*)ctx;
+    ...
+    if(ssl != NULL){
+    wolfSSL_SetCertCbCtx(ssl, ctx);
+    } else {
+	    // Error case, the SSL is not initialized properly.
+    }
+    \endcode
+    \sa wolfSSL_CTX_save_cert_cache
+    \sa wolfSSL_CTX_restore_cert_cache
+    \sa wolfSSL_CTX_set_verify
+*/
+void wolfSSL_SetCertCbCtx(WOLFSSL* ssl, void* ctx);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、検証コールバックのためのユーザーCTXオブジェクト情報を格納します。
+    \return none  返品不可。
+    \param ctx  wolfssl_ctx構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    void* userCtx = NULL; // Assign some user defined context
+    ...
+    if(ctx != NULL){
+        wolfSSL_SetCertCbCtx(ctx, userCtx);
+    } else {
+        // Error case, the SSL is not initialized properly.
+    }
+    \endcode
+    \sa wolfSSL_CTX_save_cert_cache
+    \sa wolfSSL_CTX_restore_cert_cache
+    \sa wolfSSL_CTX_set_verify
+*/
+void wolfSSL_CTX_SetCertCbCtx(WOLFSSL_CTX* ctx, void* userCtx);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、wolfssl_read（）によって読み取られるSSLオブジェクトでバッファされているバイト数を返します。
+    \return int  この関数は、保留中のバイト数を返します。
+    _Example_
+    \code
+    int pending = 0;
+    WOLFSSL* ssl = 0;
+    ...
+
+    pending = wolfSSL_pending(ssl);
+    printf(“There are %d bytes buffered and available for reading”, pending);
+    \endcode
+    \sa wolfSSL_recv
+    \sa wolfSSL_read
+    \sa wolfSSL_peek
+*/
+int  wolfSSL_pending(WOLFSSL*);
+
+/*!
+    \ingroup Debug 
+    \brief  この機能はOpenSSL互換性（SSL_LOAD_ERROR_STRING）のみであり、アクションを取ります。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    wolfSSL_load_error_strings();
+    \endcode
+    \sa wolfSSL_get_error
+    \sa wolfSSL_ERR_error_string
+    \sa wolfSSL_ERR_error_string_n
+    \sa wolfSSL_ERR_print_errors_fp
+    \sa wolfSSL_load_error_strings
+*/
+void wolfSSL_load_error_strings(void);
+
+/*!
+    \ingroup TLS 
+    \brief  この関数はwolfssl_ctx_new（）内で内部的に呼び出されます。この関数はwolfssl_init（）の周囲のラッパーで、wolfsslがOpenSSL互換層でコンパイルされたときにOpenSSL互換性（ssl_library_init）に存在します。wolfssl_init（）は、より一般的に使用されているWolfSSL初期化機能です。
+    \return SSL_SUCCESS  成功した場合、通話が戻ります。
+    \return SSL_FATAL_ERROR  失敗したときに返されます。
+    _Example_
+    \code
+    int ret = 0;
+    ret = wolfSSL_library_init();
+    if (ret != SSL_SUCCESS) {
+	    failed to initialize wolfSSL
+    }
+    ...
+    \endcode
+    \sa wolfSSL_Init
+    \sa wolfSSL_Cleanup
+*/
+int  wolfSSL_library_init(void);
+
+/*!
+    \brief  
+    \return WOLFSSL_SUCCESS  成功すると。
+    \return BAD_FUNC_ARG  SSLがNULLの場合
+    \param ssl  wolfssl_new（）で作成されたSSLオブジェクトへのポインタ。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    int DevId = -2;
+
+    wolfSSL_SetDevId(ssl, devId);
+
+    \endcode
+    \sa wolfSSL_CTX_SetDevId
+    \sa wolfSSL_CTX_GetDevId
+*/
+int wolfSSL_SetDevId(WOLFSSL* ssl, int devId);
+
+/*!
+    \brief  
+    \return WOLFSSL_SUCCESS  成功すると。
+    \return BAD_FUNC_ARG  SSLがNULLの場合
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx;
+    int DevId = -2;
+
+    wolfSSL_CTX_SetDevId(ctx, devId);
+
+    \endcode
+    \sa wolfSSL_SetDevId
+    \sa wolfSSL_CTX_GetDevId
+*/
+int wolfSSL_CTX_SetDevId(WOLFSSL_CTX* ctx, int devId);
+
+/*!
+    \brief  
+    \return devId  成功すると。
+    \return INVALID_DEVID  SSLとCTXの両方がNULLの場合。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx;
+
+    wolfSSL_CTX_GetDevId(ctx, ssl);
+
+    \endcode
+    \sa wolfSSL_SetDevId
+    \sa wolfSSL_CTX_SetDevId
+*/
+int wolfSSL_CTX_GetDevId(WOLFSSL_CTX* ctx, WOLFSSL* ssl);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数はSSLセッションキャッシュを有効または無効にします。動作はモードに使用される値によって異なります。モードの値は次のとおりです.SSL_SESS_CACHE_OFF  - セッションキャッシングを無効にします。デフォルトでセッションキャッシングがオンになっています。SSL_SESS_CACHE_NO_AUTO_CLEAR  - セッションキャッシュのオートフラッシュを無効にします。デフォルトで自動フラッシングはオンになっています。
+    \return SSL_SUCCESS  成功に戻ります。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = 0;
+    ...
+    ret = wolfSSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_OFF);
+    if (ret != SSL_SUCCESS) {
+    	// failed to turn SSL session caching off
+    }
+    \endcode
+    \sa wolfSSL_flush_sessions
+    \sa wolfSSL_get1_session
+    \sa wolfSSL_set_session
+    \sa wolfSSL_get_sessionID
+    \sa wolfSSL_CTX_set_timeout
+*/
+long wolfSSL_CTX_set_session_cache_mode(WOLFSSL_CTX* ctx, long mode);
+
+/*!
+    \brief  SessionSecRETCBタイプには、署名があります。int（* sessioneCretcb）（wolfssl * ssl、void * secret、int * secretsz、void * ctx）。WolfSSL構造体のSESSIONSECRETCBメンバーはパラメータCBに設定されています。
+    \return SSL_SUCCESS  関数の実行がエラーを返されなかった場合に返されます。
+    \return SSL_FATAL_ERROR  WolfSSL構造がNULLの場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    // Signature of SessionSecretCb
+    int SessionSecretCB (WOLFSSL* ssl, void* secret, int* secretSz,
+    void* ctx) = SessionSecretCb;
+    …
+    int wolfSSL_set_session_secret_cb(ssl, SessionSecretCB, (void*)ssl->ctx){
+	    // Function body.
+    }
+    \endcode
+    \sa SessionSecretCb
+*/
+int  wolfSSL_set_session_secret_cb(WOLFSSL* ssl, SessionSecretCb cb, void* ctx);
+
+/*!
+    \ingroup IO 
+    \brief  この関数はセッションキャッシュをファイルに持続します。追加のメモリ使用のため、MEMSAVEは使用されません。
+    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。セッションキャッシュはファイルに書き込まれました。
+    \return SSL_BAD_FILE  FNAMEを開くことができないか、それ以外の場合は破損した場合に返されます。
+    \return FWRITE_ERROR  XfWriteがファイルへの書き込みに失敗した場合に返されます。
+    \return BAD_MUTEX_E  ミューテックスロック障害が発生した場合は返されます。
+    _Example_
+    \code
+    const char* fname;
+    ...
+    if(wolfSSL_save_session_cache(fname) != SSL_SUCCESS){
+    	// Fail to write to file.
+    }
+    \endcode
+    \sa XFWRITE
+    \sa wolfSSL_restore_session_cache
+    \sa wolfSSL_memrestore_session_cache
+*/
+int  wolfSSL_save_session_cache(const char*);
+
+/*!
+    \ingroup IO 
+    \brief  この関数はファイルから永続セッションキャッシュを復元します。追加のメモリ使用のため、MEMSTOREは使用しません。
+    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。
+    \return SSL_BAD_FILE  関数に渡されたファイルが破損していてXFOPENによって開くことができなかった場合に返されます。
+    \return FREAD_ERROR  ファイルにXFREADから読み取りエラーが発生した場合は返されます。
+    \return CACHE_MATCH_ERROR  セッションキャッシュヘッダの一致が失敗した場合に返されます。
+    \return BAD_MUTEX_E  ミューテックスロック障害が発生した場合は返されます。
+    _Example_
+    \code
+    const char *fname;
+    ...
+    if(wolfSSL_restore_session_cache(fname) != SSL_SUCCESS){
+        // Failure case. The function did not return SSL_SUCCESS.
+    }
+    \endcode
+    \sa XFREAD
+    \sa XFOPEN
+*/
+int  wolfSSL_restore_session_cache(const char*);
+
+/*!
+    \ingroup IO 
+    \brief  この関数はセッションキャッシュをメモリに保持します。
+    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。セッションキャッシュはメモリに正常に永続化されました。
+    \return BAD_MUTEX_E  ミューテックスロックエラーが発生した場合は返されます。
+    \return BUFFER_E  バッファサイズが小さすぎると返されます。
+    \param mem  メモリコピーxmemcpy（）の宛先を表すvoidポインタ。
+    _Example_
+    \code
+    void* mem;
+    int sz; // Max size of the memory buffer.
+    …
+    if(wolfSSL_memsave_session_cache(mem, sz) != SSL_SUCCESS){
+    	// Failure case, you did not persist the session cache to memory
+    }
+    \endcode
+    \sa XMEMCPY
+    \sa wolfSSL_get_session_cache_memsize
+*/
+int  wolfSSL_memsave_session_cache(void* mem, int sz);
+
+/*!
+    \ingroup IO 
+    \brief  この関数はメモリから永続セッションキャッシュを復元します。
+    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。
+    \return BUFFER_E  メモリバッファが小さすぎると返されます。
+    \return BAD_MUTEX_E  セッションキャッシュミューテックスロックが失敗した場合に返されます。
+    \return CACHE_MATCH_ERROR  セッションキャッシュヘッダの一致が失敗した場合に返されます。
+    \param mem  復元の原因を含む定数のボイドポインタ。
+    _Example_
+    \code
+    const void* memoryFile;
+    int szMf;
+    ...
+    if(wolfSSL_memrestore_session_cache(memoryFile, szMf) != SSL_SUCCESS){
+    	// Failure case. SSL_SUCCESS was not returned.
+    }
+    \endcode
+    \sa wolfSSL_save_session_cache
+*/
+int  wolfSSL_memrestore_session_cache(const void* mem, int sz);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、セッションキャッシュ保存バッファをどのように大きくするかを返します。
+    \return int  この関数は、セッションキャッシュ保存バッファのサイズを表す整数を返します。
+    _Example_
+    \code
+    int sz = // Minimum size for error checking;
+    ...
+    if(sz < wolfSSL_get_session_cache_memsize()){
+        // Memory buffer is too small
+    }
+    \endcode
+    \sa wolfSSL_memrestore_session_cache
+*/
+int  wolfSSL_get_session_cache_memsize(void);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数はCertキャッシュをメモリからファイルに書き込みます。
+    \return SSL_SUCCESS  CM_SaveCertCacheが正常に終了した場合。
+    \return BAD_FUNC_ARG  引数のいずれかの引数がNULLの場合に返されます。
+    \return SSL_BAD_FILE  証明書キャッシュ保存ファイルを開くことができなかった場合。
+    \return BAD_MUTEX_E  ロックミューテックスが失敗した場合
+    \return MEMORY_E  メモリの割り当てに失敗しました。
+    \return FWRITE_ERROR  証明書キャッシュファイルの書き込みに失敗しました。
+    \param ctx  wolfssl_ctx構造へのポインタ、証明書情報を保持します。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = WOLFSSL_CTX_new( protocol def );
+    const char* fname;
+    ...
+    if(wolfSSL_CTX_save_cert_cache(ctx, fname)){
+	    // file was written.
+    }
+    \endcode
+    \sa CM_SaveCertCache
+    \sa DoMemSaveCertCache
+*/
+int  wolfSSL_CTX_save_cert_cache(WOLFSSL_CTX* ctx, const char* fname);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数はファイルから証明書キャッシュを担当します。
+    \return SSL_SUCCESS  関数cm_restorecertcacheが正常に実行された場合に返されます。
+    \return SSL_BAD_FILE  xfopenがxbadfileを返すと返されます。ファイルが破損しています。
+    \return MEMORY_E  TEMPバッファの割り当てられたメモリが失敗した場合に返されます。
+    \return BAD_FUNC_ARG  FNAMEまたはCTXにNULL値がある場合は返されます。
+    \param ctx  wolfssl_ctx構造へのポインタ、証明書情報を保持します。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    const char* fname = "path to file";
+    ...
+    if(wolfSSL_CTX_restore_cert_cache(ctx, fname)){
+    	// check to see if the execution was successful
+    }
+    \endcode
+    \sa CM_RestoreCertCache
+    \sa XFOPEN
+*/
+int  wolfSSL_CTX_restore_cert_cache(WOLFSSL_CTX* ctx, const char* fname);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は証明書キャッシュをメモリに持続します。
+    \return SSL_SUCCESS  機能の実行に成功したことに戻ります。エラーが投げられていません。
+    \return BAD_MUTEX_E  wolfssl_cert_managerメンバーのカーボックが0（ゼロ）ではなかったミューテックスエラー。
+    \return BAD_FUNC_ARG  CTX、MEM、または使用がNULLの場合、またはSZが0以下の場合（0（ゼロ）。
+    \return BUFFER_E  出力バッファMEMが小さすぎました。
+    \param ctx  wolfssl_ctx_new（）を使用して作成されたwolfssl_ctx構造へのポインタ。
+    \param mem  宛先へのvoidポインタ（出力バッファ）。
+    \param sz  出力バッファのサイズ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = WOLFSSL_CTX_new( protocol );
+    void* mem;
+    int sz;
+    int* used;
+    ...
+    if(wolfSSL_CTX_memsave_cert_cache(ctx, mem, sz, used) != SSL_SUCCESS){
+	    // The function returned with an error
+    }
+    \endcode
+    \sa DoMemSaveCertCache
+    \sa GetCertCacheMemSize
+    \sa CM_MemRestoreCertCache
+    \sa CM_GetCertCacheMemSize
+*/
+int  wolfSSL_CTX_memsave_cert_cache(WOLFSSL_CTX* ctx, void* mem, int sz, int* used);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は証明書キャッシュをメモリから復元します。
+    \return SSL_SUCCESS  関数とサブルーチンがエラーなしで実行された場合に返されます。
+    \return BAD_FUNC_ARG  CTXまたはMEMパラメータがNULLまたはSZパラメータがゼロ以下の場合に返されます。
+    \return BUFFER_E  CERTキャッシュメモリバッファが小さすぎると戻ります。
+    \return CACHE_MATCH_ERROR  CERTキャッシュヘッダーの不一致があった場合に返されます。
+    \return BAD_MUTEX_E  ロックミューテックスが失敗した場合に返されます。
+    \param ctx  wolfssl_ctx_new（）を使用して作成されたwolfssl_ctx構造へのポインタ。
+    \param mem  証明書キャッシュに復元される値を持つvoidポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = WOLFSSL_CTX_new( protocol method );
+    WOLFSSL* ssl = WOLFSSL_new(ctx);
+    void* mem;
+    int sz = (*int) sizeof(mem);
+    …
+    if(wolfSSL_CTX_memrestore_cert_cache(ssl->ctx, mem, sz)){
+    	// The success case
+    }
+    \endcode
+    \sa CM_MemRestoreCertCache
+*/
+int  wolfSSL_CTX_memrestore_cert_cache(WOLFSSL_CTX* ctx, const void* mem, int sz);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  Certificate Cache Saveバッファが必要なサイズを返します。
+    \return int  成功したときにメモリサイズを表す整数値。
+    \return BAD_FUNC_ARG  wolfssl_ctx構造体がNULLの場合に返されます。
+    \return BAD_MUTEX_E   - ミューテックスロックエラーが発生した場合は返されます。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = WOLFSSL_CTX_new(protocol);
+    ...
+    int certCacheSize = wolfSSL_CTX_get_cert_cache_memsize(ctx);
+
+    if(certCacheSize != BAD_FUNC_ARG || certCacheSize != BAD_MUTEX_E){
+	// Successfully retrieved the memory size.
+    }
+    \endcode
+    \sa CM_GetCertCacheMemSize
+*/
+int  wolfSSL_CTX_get_cert_cache_memsize(WOLFSSL_CTX*);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、与えられたwolfssl_ctxの暗号スイートリストを設定します。このCipher Suiteリストは、このコンテキストを使用して作成された新しいSSLセッション（WolfSSL）のデフォルトリストになります。リスト内の暗号は、最高から最低への好みの順にソートされるべきです。wolfssl_ctx_set_cipher_list（）の各呼び出しは、関数が呼び出されるたびに、特定のSSLコンテキストの暗号スイートリストを提供されたリストにリセットします。暗号スイートリスト、リストは、ヌル終端テキスト文字列、およびコロン区切りリストです。たとえば、リストの値が「DHE-RSA-AES256-SHA256：DHE-RSA-AES128-SHA256：AES256-SHA256」有効な暗号値は、src / internal.cのcipher_names []配列のフルネーム値です。（有効な暗号化値の明確なリストの場合はsrc / internal.cをチェックしてください）
+    \return SSL_SUCCESS  機能完了に成功したときに返されます。
+    \return SSL_FAILURE  失敗した場合に返されます。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = 0;
+    ...
+    ret = wolfSSL_CTX_set_cipher_list(ctx,
+    “DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:AES256-SHA256”);
+    if (ret != SSL_SUCCESS) {
+    	// failed to set cipher suite list
+    }
+    \endcode
+    \sa wolfSSL_set_cipher_list
+    \sa wolfSSL_CTX_new
+*/
+int  wolfSSL_CTX_set_cipher_list(WOLFSSL_CTX* ctx, const char* list);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、特定のWolfSSLオブジェクト（SSLセッション）の暗号スイートリストを設定します。リスト内の暗号は、最高から最低への好みの順にソートされるべきです。wolfssl_set_cipher_list（）の各呼び出しは、関数が呼び出されるたびに、特定のSSLセッションの暗号スイートリストを提供されたリストにリセットします。暗号スイートリスト、リストは、ヌル終端テキスト文字列、およびコロン区切りリストです。例えば、リストのための1つの値は、「DHE-RSA-AES256-SHA256：DHE-RSA-AES128-SHA256：AES256-SHA256」であり得る。有効な暗号化値は、src / internal.c（有効な暗号化値の明確なリストのリストの場合はsrc / internal.cを指定してください）のcipher_names []配列のフルネーム値です。
+    \return SSL_SUCCESS  機能完了に成功したときに返されます。
+    \return SSL_FAILURE  失敗した場合に返されます。
+    \param ssl  wolfssl_new（）で作成されたSSLセッションへのポインタ。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL* ssl = 0;
+    ...
+    ret = wolfSSL_set_cipher_list(ssl,
+    “DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:AES256-SHA256”);
+    if (ret != SSL_SUCCESS) {
+    	// failed to set cipher suite list
+    }
+    \endcode
+    \sa wolfSSL_CTX_set_cipher_list
+    \sa wolfSSL_new
+*/
+int  wolfSSL_set_cipher_list(WOLFSSL* ssl, const char* list);
+
+/*!
+    \brief  UDP I / Oはノンブロッキングです。アプリケーションがWolfSSLオブジェクトを作成した後、ブロックされていないUDPソケットで使用される場合は、WolfsSL_DTLS_SET_USING_NONBLOCK（）を呼び出します。これにより、wolfsslオブジェクトは、Ewouldblockを受信することを意味します。
+    \return none  返品不可。
+    \param ssl  wolfssl_new（）で作成されたDTLSセッションへのポインタ。
+    _Example_
+    \code
+    WOLFSSL* ssl = 0;
+    ...
+    wolfSSL_dtls_set_using_nonblock(ssl, 1);
+    \endcode
+    \sa wolfSSL_dtls_get_using_nonblock
+    \sa wolfSSL_dtls_got_timeout
+    \sa wolfSSL_dtls_get_current_timeout
+*/
+void wolfSSL_dtls_set_using_nonblock(WOLFSSL* ssl, int nonblock);
+/*!
+    \brief  UDPを使用して非ブロッキングI / Oを使用する。WolfSSLがノンブロッキングI / Oを使用している場合、この関数は1を返します。これにより、wolfsslオブジェクトは、Ewouldblockを受信することを意味します。この機能はDTLSセッションにとってのみ意味があります。
+    \return 0  基礎となるI / Oがブロックされています。
+    \return 1  基礎となるI / Oは非ブロッキングです。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL* ssl = 0;
+    ...
+    ret = wolfSSL_dtls_get_using_nonblock(ssl);
+    if (ret == 1) {
+    	// underlying I/O is non-blocking
+    }
+    ...
+    \endcode
+    \sa wolfSSL_dtls_set_using_nonblock
+    \sa wolfSSL_dtls_got_timeout
+    \sa wolfSSL_dtls_set_using_nonblock
+*/
+int  wolfSSL_dtls_get_using_nonblock(WOLFSSL*);
+/*!
+    \brief  wolfsslオブジェクト。遮断されていないソケットを使用する場合、ユーザーコード内の何かは、利用可能なRECVデータをチェックするときにいつでも待機しているのかを決定する必要があります。この関数によって返される値は、アプリケーションがどのくらい待機するかを示します。
+    \return seconds  現在のDTLSタイムアウト値（秒）
+    \return NOT_COMPILED_IN  WolfSSLがDTLSサポートで構築されていない場合。
+    _Example_
+    \code
+    int timeout = 0;
+    WOLFSSL* ssl;
+    ...
+    timeout = wolfSSL_get_dtls_current_timeout(ssl);
+    printf(“DTLS timeout (sec) = %d\n”, timeout);
+    \endcode
+    \sa wolfSSL_dtls
+    \sa wolfSSL_dtls_get_peer
+    \sa wolfSSL_dtls_got_timeout
+    \sa wolfSSL_dtls_set_peer
+*/
+int  wolfSSL_dtls_get_current_timeout(WOLFSSL* ssl);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数はDTLSタイムアウトを設定します。
+    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。SSLのDTLS_TIMEOUT_INITとDTLS_TIMEOUTメンバーが設定されています。
+    \return BAD_FUNC_ARG  wolfssl structがnullの場合、またはタイムアウトが0以下の場合に返されます。タイムアウト引数が許可されている最大値を超えると、戻ります。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    int timeout = TIMEOUT;
+    ...
+    if(wolfSSL_dtls_set_timeout_init(ssl, timeout)){
+    	// the dtls timeout was set
+    } else {
+    	// Failed to set DTLS timeout.
+    }
+    \endcode
+    \sa wolfSSL_dtls_set_timeout_max
+    \sa wolfSSL_dtls_got_timeout
+*/
+int  wolfSSL_dtls_set_timeout_init(WOLFSSL* ssl, int);
+
+/*!
+    \brief  
+    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。
+    \return BAD_FUNC_ARG  wolfssl構造体がNULLの場合、またはTIMEOUT引数がゼロ以下である場合、またはWolfSSL構造体のDTLS_TIMEOUT_INITメンバーよりも小さい場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    int timeout = TIMEOUTVAL;
+    ...
+    int ret = wolfSSL_dtls_set_timeout_max(ssl);
+    if(!ret){
+    	// Failed to set the max timeout
+    }
+    \endcode
+    \sa wolfSSL_dtls_set_timeout_init
+    \sa wolfSSL_dtls_got_timeout
+*/
+int  wolfSSL_dtls_set_timeout_max(WOLFSSL* ssl, int);
+
+/*!
+    \brief  制御コードが送信がタイムアウトしたと考えると、WolfSSLオブジェクトで呼び出されます。タイムアウト値の調整を含む、最後の送信を再試行するために必要な操作を実行します。長すぎると、これは失敗を返します。
+    \return SSL_SUCCESS  成功に戻ります
+    \return SSL_FATAL_ERROR  ピアからの応答を得ることなく、再送信/タイムアウトが多すぎる場合に返されます。
+    \return NOT_COMPILED_IN  WolfSSLがDTLSサポートでコンパイルされていない場合は返されます。
+    _Example_
+    \code
+    See the following files for usage examples:
+    <wolfssl_root>/examples/client/client.c
+    <wolfssl_root>/examples/server/server.c
+    \endcode
+    \sa wolfSSL_dtls_get_current_timeout
+    \sa wolfSSL_dtls_get_peer
+    \sa wolfSSL_dtls_set_peer
+    \sa wolfSSL_dtls
+*/
+int  wolfSSL_dtls_got_timeout(WOLFSSL* ssl);
+
+/*!
+    \brief  DTLSを使用するように構成されています。
+    \return 1  SSLセッション（SSL）がDTLSを使用するように設定されている場合、この関数は1を返します。
+    \return 0  そうでなければ。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL* ssl;
+    ...
+    ret = wolfSSL_dtls(ssl);
+    if (ret) {
+    	// SSL session has been configured to use DTLS
+    }
+    \endcode
+    \sa wolfSSL_dtls_get_current_timeout
+    \sa wolfSSL_dtls_get_peer
+    \sa wolfSSL_dtls_got_timeout
+    \sa wolfSSL_dtls_set_peer
+*/
+int  wolfSSL_dtls(WOLFSSL* ssl);
+
+/*!
+    \brief  ピースズ。
+    \return SSL_SUCCESS  成功に戻ります。
+    \return SSL_FAILURE  失敗したときに返されます。
+    \return SSL_NOT_IMPLEMENTED  WolfSSLがDTLSサポートでコンパイルされていない場合は返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param peer  ピアのSOCKADDR_IN構造へのポインタ。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL* ssl;
+    sockaddr_in addr;
+    ...
+    ret = wolfSSL_dtls_set_peer(ssl, &addr, sizeof(addr));
+    if (ret != SSL_SUCCESS) {
+	    // failed to set DTLS peer
+    }
+    \endcode
+    \sa wolfSSL_dtls_get_current_timeout
+    \sa wolfSSL_dtls_get_peer
+    \sa wolfSSL_dtls_got_timeout
+    \sa wolfSSL_dtls
+*/
+int  wolfSSL_dtls_set_peer(WOLFSSL* ssl, void* peer, unsigned int peerSz);
+
+/*!
+    \brief  DTLSピアこの関数は、PeerszをSSLセッションに格納されている実際のDTLSピアサイズに比較します。ピアがピアに収まる場合、ピアのSOCKADDR_INはピアにコピーされ、ピースがピアのサイズに設定されます。
+    \return SSL_SUCCESS  成功に戻ります。
+    \return SSL_FAILURE  失敗したときに返されます。
+    \return SSL_NOT_IMPLEMENTED  WolfSSLがDTLSサポートでコンパイルされていない場合は返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param peer  ピアのSOCKADDR_IN構造を保存するには、メモリの場所へのポインタ。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL* ssl;
+    sockaddr_in addr;
+    ...
+    ret = wolfSSL_dtls_get_peer(ssl, &addr, sizeof(addr));
+    if (ret != SSL_SUCCESS) {
+	    // failed to get DTLS peer
+    }
+    \endcode
+    \sa wolfSSL_dtls_get_current_timeout
+    \sa wolfSSL_dtls_got_timeout
+    \sa wolfSSL_dtls_set_peer
+    \sa wolfSSL_dtls
+*/
+int  wolfSSL_dtls_get_peer(WOLFSSL* ssl, void* peer, unsigned int* peerSz);
+
+/*!
+    \ingroup Debug 
+    \brief  この関数は、wolfssl_get_error（）によって返されたエラーコードをより人間が読めるエラー文字列に変換します。errnumberは、wolfssl_get_error（）によって返され、データはエラー文字列が配置されるストレージバッファです。MAX_ERROR_SZで定義されているように、データの最大長はデフォルトで80文字です。これはwolfssl / wolfcrypt / error.hです。
+    \return success  正常に完了すると、この関数はデータに返されるのと同じ文字列を返します。
+    \return failure  失敗すると、この関数は適切な障害理由、MSGを持つ文字列を返します。
+    \param errNumber  wolfssl_get_error（）によって返されたエラーコード。
+    _Example_
+    \code
+    int err = 0;
+    WOLFSSL* ssl;
+    char buffer[80];
+    ...
+    err = wolfSSL_get_error(ssl, 0);
+    wolfSSL_ERR_error_string(err, buffer);
+    printf(“err = %d, %s\n”, err, buffer);
+    \endcode
+    \sa wolfSSL_get_error
+    \sa wolfSSL_ERR_error_string_n
+    \sa wolfSSL_ERR_print_errors_fp
+    \sa wolfSSL_load_error_strings
+*/
+char* wolfSSL_ERR_error_string(unsigned long,char*);
+
+/*!
+    \ingroup Debug 
+    \brief  この関数は、wolfssl_err_error_string（）のバージョンです。ここで、lenはbufに書き込まれ得る最大文字数を指定します。wolfssl_err_error_string（）と同様に、この関数はwolfssl_get_error（）から返されたエラーコードをより人間が読めるエラー文字列に変換します。人間が読める文字列はbufに置かれます。
+    \return none  いいえ返します。
+    \param e  wolfssl_get_error（）によって返されたエラーコード。
+    \param buff  eと一致する人間が読めるエラー文字列を含む出力バッファ。
+    _Example_
+    \code
+    int err = 0;
+    WOLFSSL* ssl;
+    char buffer[80];
+    ...
+    err = wolfSSL_get_error(ssl, 0);
+    wolfSSL_ERR_error_string_n(err, buffer, 80);
+    printf(“err = %d, %s\n”, err, buffer);
+    \endcode
+    \sa wolfSSL_get_error
+    \sa wolfSSL_ERR_error_string
+    \sa wolfSSL_ERR_print_errors_fp
+    \sa wolfSSL_load_error_strings
+*/
+void  wolfSSL_ERR_error_string_n(unsigned long e, char* buf,
+                                           unsigned long sz);
+
+/*!
+    \ingroup TLS 
+    \brief  この関数は、Options構造体のClosEnotifyまたはConnresetまたはSentNotifyメンバーのシャットダウン条件をチェックします。オプション構造はWolfSSL構造内にあります。
+    \return 1  SSL_SENT_SHUTDOWNが返されます。
+    \return 2  ss_received_shutdownが返されます。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_CTX* ctx = WOLFSSL_CTX_new( protocol method );
+    WOLFSSL* ssl = WOLFSSL_new(ctx);
+    …
+    int ret;
+    ret = wolfSSL_get_shutdown(ssl);
+
+    if(ret == 1){
+	    SSL_SENT_SHUTDOWN
+    } else if(ret == 2){
+	    SSL_RECEIVED_SHUTDOWN
+    } else {
+	    Fatal error.
+    }
+    \endcode
+    \sa wolfSSL_SESSION_free
+*/
+int  wolfSSL_get_shutdown(const WOLFSSL*);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、オプション構造体の再開メンバを返します。フラグはセッションを再利用するかどうかを示します。そうでなければ、新しいセッションを確立する必要があります。
+    \return This  関数セッションの再利用のフラグを表すオプション構造に保持されているint型を返します。
+    _Example_
+    \code
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    …
+    if(!wolfSSL_session_reused(sslResume)){
+	    // No session reuse allowed.
+    }
+    \endcode
+    \sa wolfSSL_SESSION_free
+    \sa wolfSSL_GetSessionIndex
+    \sa wolfSSL_memsave_session_cache
+*/
+int  wolfSSL_session_reused(WOLFSSL*);
+
+/*!
+    \ingroup TLS 
+    \brief  この関数は、接続が確立されているかどうかを確認します。
+    \return 0  接続が確立されていない場合、すなわちWolfSSL構造体がNULLまたはハンドシェイクが行われていない場合に返されます。
+    \return 1  接続が確立されていない場合は返されます.WolfSSL構造体はNULLまたはハンドシェイクが行われていません。
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    ...
+    if(wolfSSL_is_init_finished(ssl)){
+	    Handshake is done and connection is established
+    }
+    \endcode
+    \sa wolfSSL_set_accept_state
+    \sa wolfSSL_get_keys
+    \sa wolfSSL_set_shutdown
+*/
+int  wolfSSL_is_init_finished(WOLFSSL*);
+
+/*!
+    \ingroup IO 
+    \brief  文字列として使用されているSSLバージョンを返します。
+    \return "SSLv3"  SSLv3を使う
+    \return "TLSv1"  TLSV1を使用する
+    \return "TLSv1.1"  TLSV1.1を使用する
+    \return "TLSv1.2"  TLSV1.2を使用する
+    \return "TLSv1.3"  TLSV1.3を使用する
+    \return "DTLS":  DTLSを使う
+    \return "DTLSv1.2"  DTLSV1.2を使用する
+    \return "unknown"  どのバージョンのTLSが使用されているかを判断するという問題がありました。
+    _Example_
+    \code
+    wolfSSL_Init();
+    WOLFSSL_CTX* ctx;
+    WOLFSSL* ssl;
+    WOLFSSL_METHOD method = // Some wolfSSL method
+    ctx = wolfSSL_CTX_new(method);
+    ssl = wolfSSL_new(ctx);
+    printf(wolfSSL_get_version("Using version: %s", ssl));
+    \endcode
+    \sa wolfSSL_lib_version
+*/
+const char*  wolfSSL_get_version(WOLFSSL*);
+
+/*!
+    \ingroup IO 
+    \brief  SSLセッションで現在の暗号スイートを返します。
+    \return ssl->options.cipherSuite  現在の暗号スイートを表す整数。
+    \return 0  提供されているSSLセッションはNULLです。
+    _Example_
+    \code
+    wolfSSL_Init();
+    WOLFSSL_CTX* ctx;
+    WOLFSSL* ssl;
+    WOLFSSL_METHOD method = // Some wolfSSL method
+    ctx = wolfSSL_CTX_new(method);
+    ssl = wolfSSL_new(ctx);
+
+    if(wolfSSL_get_current_cipher_suite(ssl) == 0)
+    {
+        // Error getting cipher suite
+    }
+    \endcode
+    \sa wolfSSL_CIPHER_get_name
+    \sa wolfSSL_get_current_cipher
+    \sa wolfSSL_get_cipher_list
+*/
+int  wolfSSL_get_current_cipher_suite(WOLFSSL* ssl);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、SSLセッションの現在の暗号へのポインタを返します。
+    \return The  関数WolfSSL構造体の暗号メンバーのアドレスを返します。これはwolfssl_icipher構造へのポインタです。
+    \return NULL  WolfSSL構造がNULLの場合に返されます。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    …
+    WOLFSSL_CIPHER* cipherCurr = wolfSSL_get_current_cipher;
+
+    if(!cipherCurr){
+    	// Failure case.
+    } else {
+    	// The cipher was returned to cipherCurr
+    }
+    \endcode
+    \sa wolfSSL_get_cipher
+    \sa wolfSSL_get_cipher_name_internal
+    \sa wolfSSL_get_cipher_name
+*/
+WOLFSSL_CIPHER*  wolfSSL_get_current_cipher(WOLFSSL*);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、SSLオブジェクト内のCipher Suiteと使用可能なスイートと一致し、文字列表現を返します。
+    \return string  この関数は、一致した暗号スイートの文字列表現を返します。
+    \return none  スイートが一致していない場合は「なし」を返します。
+    _Example_
+    \code
+    // gets cipher name in the format DHE_RSA ...
+    const char* wolfSSL_get_cipher_name_internal(WOLFSSL* ssl){
+	WOLFSSL_CIPHER* cipher;
+	const char* fullName;
+    …
+	cipher = wolfSSL_get_curent_cipher(ssl);
+	fullName = wolfSSL_CIPHER_get_name(cipher);
+
+	if(fullName){
+		// sanity check on returned cipher
+	}
+    \endcode
+    \sa wolfSSL_get_cipher
+    \sa wolfSSL_get_current_cipher
+    \sa wolfSSL_get_cipher_name_internal
+    \sa wolfSSL_get_cipher_name
+*/
+const char*  wolfSSL_CIPHER_get_name(const WOLFSSL_CIPHER* cipher);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、SSLオブジェクト内の暗号スイートと使用可能なスイートと一致します。
+    \return This  関数Suiteが一致させたString値を返します。スイートが一致していない場合は「なし」を返します。
+    _Example_
+    \code
+    #ifdef WOLFSSL_DTLS
+    …
+    // make sure a valid suite is used
+    if(wolfSSL_get_cipher(ssl) == NULL){
+	    WOLFSSL_MSG(“Can not match cipher suite imported”);
+	    return MATCH_SUITE_ERROR;
+    }
+    …
+    #endif // WOLFSSL_DTLS
+    \endcode
+    \sa wolfSSL_CIPHER_get_name
+    \sa wolfSSL_get_current_cipher
+*/
+const char*  wolfSSL_get_cipher(WOLFSSL*);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、wolfssl構造からのwolfssl_sessionを参照型として返します。これには、wolfssl_session_freeを呼び出してセッション参照を解除する必要があります。 wolfssl_sessionは、セッションの再開を実行するために必要なすべての必要な情報を含むことを指摘し、新しいハンドシェイクなしで接続を再確立します。セッションの再開の場合、wolfssl_shutdown（）をセッションオブジェクトに呼び出す前に、アプリケーションはオブジェクトからwolfssl_get1_session（）を呼び出して保存する必要があります。これはセッションへのポインタを返します。後で、アプリケーションは新しいWolfSSLオブジェクトを作成し、保存したセッションをwolfssl_set_session（）に割り当てる必要があります。この時点で、アプリケーションはwolfssl_connect（）を呼び出し、WolfSSLはセッションを再開しようとします。 WolfSSLサーバーコードでは、デフォルトでセッションの再開を許可します。 wolfssl_get1_session（）によって返されたオブジェクトは、アプリケーションがそれを使用してそれを使用して解放される必要があります。
+    \return WOLFSSL_SESSION  成功の場合はセッションポインタを返します。
+    \return NULL  SSLがNULLの場合、SSLセッションキャッシュが無効になっている場合、WolfSSLはセッションIDを使用できない、またはミューテックス関数が失敗します。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    WOLFSSL_SESSION* ses;
+    // attempt/complete handshake
+    wolfSSL_connect(ssl);
+    ses  = wolfSSL_get1_session(ssl);
+    // check ses information
+    // disconnect / setup new SSL instance
+    wolfSSL_set_session(ssl, ses);
+    // attempt/resume handshake
+    wolfSSL_SESSION_free(ses);
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_free
+    \sa wolfSSL_SESSION_free
+*/
+WOLFSSL_SESSION* wolfSSL_get1_session(WOLFSSL* ssl);
+
+/*!
+    \ingroup Setup 
+    \brief  wolfsslv23_client_method（）関数は、アプリケーションがクライアントであることを示すために使用され、SSL 3.0  -  TLS 1.3の間でサーバーでサポートされている最高のプロトコルバージョンをサポートします。この関数は、wolfssl_ctx_new（）を使用してSSL / TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。WolfSSLクライアントとサーバーの両方が堅牢なバージョンのダウングレード機能を持っています。特定のプロトコルバージョンメソッドがどちらの側で使用されている場合は、そのバージョンのみがネゴシエートされたり、エラーが返されます。たとえば、TLSV1を使用し、SSLv3のみに接続しようとするクライアントは、TLSV1.1に接続しても失敗します。この問題を解決するために、wolfsslv23_client_method（）関数を使用するクライアントは、サーバーでサポートされている最高のプロトコルバージョンを使用し、必要に応じてSSLv3にダウングレードします。この場合、クライアントはSSLv3  -  TLSv1.3を実行しているサーバーに接続できるようになります。
+    \return pointer  成功すると、wolfssl_methodへのポインタがあります。
+    \return Failure  xmallocを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc（）実装の失敗値が返されます（通常はerrnoがenomeemに設定されます）。
+    _Example_
+    \code
+    WOLFSSL_METHOD* method;
+    WOLFSSL_CTX* ctx;
+    method = wolfSSLv23_client_method();
+    if (method == NULL) {
+	// unable to get method
+    }
+
+    ctx = wolfSSL_CTX_new(method);
+    ...
+    \endcode
+    \sa wolfSSLv3_client_method
+    \sa wolfTLSv1_client_method
+    \sa wolfTLSv1_1_client_method
+    \sa wolfTLSv1_2_client_method
+    \sa wolfTLSv1_3_client_method
+    \sa wolfDTLSv1_client_method
+    \sa wolfSSL_CTX_new
+*/
+WOLFSSL_METHOD* wolfSSLv23_client_method(void);
+
+/*!
+    \ingroup IO 
+    \brief  これは、内部メモリバッファの先頭へのバイトポインタを設定するために使用されます。
+    \return size  成功すると、バッファのサイズが返されます
+    \return SSL_FATAL_ERROR  エラーケースに遭遇した場合
+    \param bio  のメモリバッファを取得するためのwolfssl_bio構造。
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    const byte* p;
+    int ret;
+    bio  = wolfSSL_BIO_new(wolfSSL_BIO_s_mem());
+    ret  = wolfSSL_BIO_get_mem_data(bio, &p);
+    // check ret value
+    \endcode
+    \sa wolfSSL_BIO_new
+    \sa wolfSSL_BIO_s_mem
+    \sa wolfSSL_BIO_set_fp
+    \sa wolfSSL_BIO_free
+*/
+int wolfSSL_BIO_get_mem_data(WOLFSSL_BIO* bio,void* p);
+
+/*!
+    \ingroup IO 
+    \brief  使用するBIOのファイル記述子を設定します。
+    \return SSL_SUCCESS(1)  成功すると。
+    \param bio  FDを設定するためのWOLFSSL_BIO構造。
+    \param fd  使用するファイル記述子。
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    int fd;
+    // setup bio
+    wolfSSL_BIO_set_fd(bio, fd, BIO_NOCLOSE);
+    \endcode
+    \sa wolfSSL_BIO_new
+    \sa wolfSSL_BIO_free
+*/
+long wolfSSL_BIO_set_fd(WOLFSSL_BIO* b, int fd, int flag);
+
+/*!
+    \ingroup IO 
+    \brief  BIOが解放されたときにI / Oストリームを閉じる必要があることを示すために使用されるクローズフラグを設定します。
+    \return SSL_SUCCESS(1)  成功すると。
+    \param bio  wolfssl_bio構造体。
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    // setup bio
+    wolfSSL_BIO_set_close(bio, BIO_NOCLOSE);
+    \endcode
+    \sa wolfSSL_BIO_new
+    \sa wolfSSL_BIO_free
+*/
+int wolfSSL_BIO_set_close(WOLFSSL_BIO *b, long flag);
+
+/*!
+    \ingroup IO 
+    \brief  これはBio_Socketタイプのwolfssl_bio_methodを取得するために使用されます。
+    \return WOLFSSL_BIO_METHOD  ソケットタイプであるwolfssl_bio_method構造へのポインタ
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    bio = wolfSSL_BIO_new(wolfSSL_BIO_s_socket);
+    \endcode
+    \sa wolfSSL_BIO_new
+    \sa wolfSSL_BIO_s_mem
+*/
+WOLFSSL_BIO_METHOD *wolfSSL_BIO_s_socket(void);
+
+/*!
+    \ingroup IO 
+    \brief  これは、WolfSSL_BIOのライトバッファのサイズを設定するために使用されます。書き込みバッファが以前に設定されている場合、この関数はサイズをリセットするときに解放されます。読み書きインデックスを0にリセットするという点で、wolfssl_bio_resetに似ています。
+    \return SSL_SUCCESS  書き込みバッファの設定に成功しました。
+    \return SSL_FAILURE  エラーケースに遭遇した場合
+    \param bio  FDを設定するためのWOLFSSL_BIO構造。
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    int ret;
+    bio = wolfSSL_BIO_new(wolfSSL_BIO_s_mem());
+    ret = wolfSSL_BIO_set_write_buf_size(bio, 15000);
+    // check return value
+    \endcode
+    \sa wolfSSL_BIO_new
+    \sa wolfSSL_BIO_s_mem
+    \sa wolfSSL_BIO_free
+*/
+int  wolfSSL_BIO_set_write_buf_size(WOLFSSL_BIO *b, long size);
+
+/*!
+    \ingroup IO 
+    \brief  これは2つのBIOSを一緒にペアリングするために使用されます。一対のBIOSは、2つの方法パイプと同様に、他方で読み取られることができ、その逆も同様である。BIOSの両方が同じスレッド内にあることが予想されます。この機能はスレッドセーフではありません。2つのBIOSのうちの1つを解放すると、両方ともペアになっています。書き込みバッファサイズが以前に設定されていない場合、それはペアになる前に17000（wolfssl_bio_size）のデフォルトサイズに設定されます。
+    \return SSL_SUCCESS  2つのBIOSをうまくペアリングします。
+    \return SSL_FAILURE  エラーケースに遭遇した場合
+    \param b1  ペアを設定するためのwolfssl_bio構造。
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    WOLFSSL_BIO* bio2;
+    int ret;
+    bio  = wolfSSL_BIO_new(wolfSSL_BIO_s_bio());
+    bio2 = wolfSSL_BIO_new(wolfSSL_BIO_s_bio());
+    ret = wolfSSL_BIO_make_bio_pair(bio, bio2);
+    // check ret value
+    \endcode
+    \sa wolfSSL_BIO_new
+    \sa wolfSSL_BIO_s_mem
+    \sa wolfSSL_BIO_free
+*/
+int  wolfSSL_BIO_make_bio_pair(WOLFSSL_BIO *b1, WOLFSSL_BIO *b2);
+
+/*!
+    \ingroup IO 
+    \brief  これは、読み取り要求フラグを0に戻すために使用されます。
+    \return SSL_SUCCESS  値を正常に設定します。
+    \return SSL_FAILURE  エラーケースに遭遇した場合
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    int ret;
+    ...
+    ret = wolfSSL_BIO_ctrl_reset_read_request(bio);
+    // check ret value
+    \endcode
+    \sa wolfSSL_BIO_new, wolfSSL_BIO_s_mem
+    \sa wolfSSL_BIO_new, wolfSSL_BIO_free
+*/
+int  wolfSSL_BIO_ctrl_reset_read_request(WOLFSSL_BIO *b);
+
+/*!
+    \ingroup IO 
+    \brief  これは、読み取り用のバッファポインタを取得するために使用されます。WOLFSSL_BIO_NREADとは異なり、内部読み取りインデックスは関数呼び出しから返された番号によって高度にはなりません。返される値を超えて読み取ると、アレイの境界から読み出される可能性があります。
+    \return >=0  成功すると、読み取るバイト数を返します
+    \param bio  wolfssl_bio構造体から読み取り。
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    char* bufPt;
+    int ret;
+    // set up bio
+    ret = wolfSSL_BIO_nread0(bio, &bufPt); // read as many bytes as possible
+    // handle negative ret check
+    // read ret bytes from bufPt
+    \endcode
+    \sa wolfSSL_BIO_new
+    \sa wolfSSL_BIO_nwrite0
+*/
+int  wolfSSL_BIO_nread0(WOLFSSL_BIO *bio, char **buf);
+
+/*!
+    \ingroup IO 
+    \brief  これは、読み取り用のバッファポインタを取得するために使用されます。内部読み取りインデックスは、読み取り元のバッファの先頭に指されているBUFを使用して、関数呼び出しから返される数によって高度です。数numで要求された値よりもバイトが少ない場合、より少ない値が返されます。返される値を超えて読み取ると、アレイの境界から読み出される可能性があります。
+    \return >=0  成功すると、読み取るバイト数を返します
+    \return WOLFSSL_BIO_ERROR(-1)  Return -1を読むものではないエラーケースについて
+    \param bio  wolfssl_bio構造体から読み取り。
+    \param buf  読み取り配列の先頭に設定するポインタ。
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    char* bufPt;
+    int ret;
+
+    // set up bio
+    ret = wolfSSL_BIO_nread(bio, &bufPt, 10); // try to read 10 bytes
+    // handle negative ret check
+    // read ret bytes from bufPt
+    \endcode
+    \sa wolfSSL_BIO_new
+    \sa wolfSSL_BIO_nwrite
+*/
+int  wolfSSL_BIO_nread(WOLFSSL_BIO *bio, char **buf, int num);
+
+/*!
+    \ingroup IO 
+    \brief  関数によって返される数のバイトを書き込むためにバッファーへのポインタを取得します。返されるポインタに追加のバイトを書き込んだ場合、返された値は範囲外の書き込みにつながる可能性があります。
+    \return int  返されたバッファポインタに書き込むことができるバイト数を返します。
+    \return WOLFSSL_BIO_UNSET(-2)  バイオペアの一部ではない場合
+    \return WOLFSSL_BIO_ERROR(-1)  に書くべき部屋がこれ以上ない場合
+    \param bio  WOLFSSL_BIO構造に書き込む構造。
+    \param buf  書き込むためのバッファへのポインタ。
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    char* bufPt;
+    int ret;
+    // set up bio
+    ret = wolfSSL_BIO_nwrite(bio, &bufPt, 10); // try to write 10 bytes
+    // handle negative ret check
+    // write ret bytes to bufPt
+    \endcode
+    \sa wolfSSL_BIO_new
+    \sa wolfSSL_BIO_free
+    \sa wolfSSL_BIO_nread
+*/
+int  wolfSSL_BIO_nwrite(WOLFSSL_BIO *bio, char **buf, int num);
+
+/*!
+    \ingroup IO 
+    \brief  バイオを初期状態にリセットします。タイプBIO_BIOの例として、これは読み書きインデックスをリセットします。
+    \return 0  バイオのリセットに成功しました。
+    \return WOLFSSL_BIO_ERROR(-1)  不良入力または失敗したリセットで返されます。
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    // setup bio
+    wolfSSL_BIO_reset(bio);
+    //use pt
+    \endcode
+    \sa wolfSSL_BIO_new
+    \sa wolfSSL_BIO_free
+*/
+int  wolfSSL_BIO_reset(WOLFSSL_BIO *bio);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、指定されたオフセットへのファイルポインタを調整します。これはファイルの先頭からのオフセットです。
+    \return 0  正常に探しています。
+    \return -1  エラーケースに遭遇した場合
+    \param bio  設定するwolfssl_bio構造体。
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    XFILE fp;
+    int ret;
+    bio  = wolfSSL_BIO_new(wolfSSL_BIO_s_file());
+    ret  = wolfSSL_BIO_set_fp(bio, &fp);
+    // check ret value
+    ret  = wolfSSL_BIO_seek(bio, 3);
+    // check ret value
+    \endcode
+    \sa wolfSSL_BIO_new
+    \sa wolfSSL_BIO_s_mem
+    \sa wolfSSL_BIO_set_fp
+    \sa wolfSSL_BIO_free
+*/
+int  wolfSSL_BIO_seek(WOLFSSL_BIO *bio, int ofs);
+
+/*!
+    \ingroup IO 
+    \brief  これはファイルに設定および書き込むために使用されます。現在ファイル内のデータを上書きし、BIOが解放されたときにファイルを閉じるように設定されます。
+    \return SSL_SUCCESS  ファイルの開きと設定に成功しました。
+    \return SSL_FAILURE  エラーケースに遭遇した場合
+    \param bio  ファイルを設定するwolfssl_bio構造体。
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    int ret;
+    bio  = wolfSSL_BIO_new(wolfSSL_BIO_s_file());
+    ret  = wolfSSL_BIO_write_filename(bio, “test.txt”);
+    // check ret value
+    \endcode
+    \sa wolfSSL_BIO_new
+    \sa wolfSSL_BIO_s_file
+    \sa wolfSSL_BIO_set_fp
+    \sa wolfSSL_BIO_free
+*/
+int  wolfSSL_BIO_write_filename(WOLFSSL_BIO *bio, char *name);
+
+/*!
+    \ingroup IO 
+    \brief  これはファイル値の終わりを設定するために使用されます。一般的な値は予想される正の値と混同されないように-1です。
+    \return 0  完了に戻りました
+    \param bio  ファイル値の終わりを設定するためのwolfssl_bio構造体。
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    int ret;
+    bio  = wolfSSL_BIO_new(wolfSSL_BIO_s_mem());
+    ret  = wolfSSL_BIO_set_mem_eof_return(bio, -1);
+    // check ret value
+    \endcode
+    \sa wolfSSL_BIO_new
+    \sa wolfSSL_BIO_s_mem
+    \sa wolfSSL_BIO_set_fp
+    \sa wolfSSL_BIO_free
+*/
+long wolfSSL_BIO_set_mem_eof_return(WOLFSSL_BIO *bio, int v);
+
+/*!
+    \ingroup IO 
+    \brief  これはWolfSSL_BIOメモリポインタのゲッター関数です。
+    \return SSL_SUCCESS  ポインタSSL_SUCCESSを返す正常に（現在1の値）。
+    \return SSL_FAILURE  null引数が渡された場合（現在0の値）に渡された場合は返されます。
+    \param bio  メモリポインタを取得するためのWOLFSSL_BIO構造体へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    WOLFSSL_BUF_MEM* pt;
+    // setup bio
+    wolfSSL_BIO_get_mem_ptr(bio, &pt);
+    //use pt
+    \endcode
+    \sa wolfSSL_BIO_new
+    \sa wolfSSL_BIO_s_mem
+*/
+long wolfSSL_BIO_get_mem_ptr(WOLFSSL_BIO *bio, WOLFSSL_BUF_MEM **m);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数はX509の名前をバッファにコピーします。
+    \return A  WOLFSSL_X509_NAME構造名メンバーのデータが正常に実行された場合、バッファへのPOINTER found struffer nameメンバーのデータが返されます。
+    \param name  wolfssl_x509構造へのポインタ。
+    \param in  wolfssl_x509_name構造からコピーされた名前を保持するためのバッファ。
+    _Example_
+    \code
+    WOLFSSL_X509 x509;
+    char* name;
+    ...
+    name = wolfSSL_X509_NAME_oneline(wolfSSL_X509_get_issuer_name(x509), 0, 0);
+
+    if(name <= 0){
+    	// There’s nothing in the buffer.
+    }
+    \endcode
+    \sa wolfSSL_X509_get_subject_name
+    \sa wolfSSL_X509_get_issuer_name
+    \sa wolfSSL_X509_get_isCA
+    \sa wolfSSL_get_peer_certificate
+    \sa wolfSSL_X509_version
+*/
+char*       wolfSSL_X509_NAME_oneline(WOLFSSL_X509_NAME* name, char* in, int sz);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は証明書発行者の名前を返します。
+    \return point  WOLFSSL_X509構造体の発行者メンバーへのポインタが返されます。
+    \return NULL  渡された証明書がNULLの場合
+    _Example_
+    \code
+    WOLFSSL_X509* x509;
+    WOLFSSL_X509_NAME issuer;
+    ...
+    issuer = wolfSSL_X509_NAME_oneline(wolfSSL_X509_get_issuer_name(x509), 0, 0);
+
+    if(!issuer){
+    	// NULL was returned
+    } else {
+    	// issuer hods the name of the certificate issuer.
+    }
+    \endcode
+    \sa wolfSSL_X509_get_subject_name
+    \sa wolfSSL_X509_get_isCA
+    \sa wolfSSL_get_peer_certificate
+    \sa wolfSSL_X509_NAME_oneline
+*/
+WOLFSSL_X509_NAME*  wolfSSL_X509_get_issuer_name(WOLFSSL_X509*);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、wolfssl_x509構造の件名メンバーを返します。
+    \return pointer  wolfssl_x509_name構造へのポインタ。WOLFSSL_X509構造体がNULLの場合、または構造体の件名メンバーがNULLの場合、ポインタはNULLになることがあります。
+    _Example_
+    \code
+    WOLFSSL_X509* cert;
+    WOLFSSL_X509_NAME name;
+    …
+    name = wolfSSL_X509_get_subject_name(cert);
+    if(name == NULL){
+	    // Deal with the NULL cacse
+    }
+    \endcode
+    \sa wolfSSL_X509_get_issuer_name
+    \sa wolfSSL_X509_get_isCA
+    \sa wolfSSL_get_peer_certificate
+*/
+WOLFSSL_X509_NAME*  wolfSSL_X509_get_subject_name(WOLFSSL_X509*);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  wolfssl_x509構造のISCAメンバーをチェックして値を返します。
+    \return isCA  wolfssl_x509構造のISCAメンバー内の値を返します。
+    \return 0  有効なX509構造が渡されない場合は返されます。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    ...
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    ...
+    if(wolfSSL_X509_get_isCA(ssl)){
+    	// This is the CA
+    }else {
+    	// Failure case
+    }
+    \endcode
+    \sa wolfSSL_X509_get_issuer_name
+    \sa wolfSSL_X509_get_isCA
+*/
+int  wolfSSL_X509_get_isCA(WOLFSSL_X509*);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、渡されたNID値に関連するテキストを取得します。
+    \return int  テキストバッファのサイズを返します。
+    \param name  wolfssl_x509_nameテキストを検索する。
+    \param nid  検索するNID。
+    \param buf  見つかったときにテキストを保持するためのバッファー。
+    _Example_
+    \code
+    WOLFSSL_X509_NAME* name;
+    char buffer[100];
+    int bufferSz;
+    int ret;
+    // get WOLFSSL_X509_NAME
+    ret = wolfSSL_X509_NAME_get_text_by_NID(name, NID_commonName,
+    buffer, bufferSz);
+
+    //check ret value
+    \endcode
+    \sa none
+*/
+int wolfSSL_X509_NAME_get_text_by_NID(WOLFSSL_X509_NAME* name, int nid,
+                                      char* buf, int len);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、wolfssl_x509構造のSigoidメンバーに格納されている値を返します。
+    \return 0  wolfssl_x509構造がNULLの場合に返されます。
+    \return int  x509オブジェクトから取得された整数値が返されます。
+    _Example_
+    \code
+    WOLFSSL_X509 x509 = (WOLFSSL_X509*)XMALLOC(sizeof(WOLFSSL_X509), NULL,
+							DYNAMIC_TYPE_X509);
+    ...
+    int x509SigType = wolfSSL_X509_get_signature_type(x509);
+
+    if(x509SigType != EXPECTED){
+	// Deal with an unexpected value
+    }
+    \endcode
+    \sa wolfSSL_X509_get_signature
+    \sa wolfSSL_X509_version
+    \sa wolfSSL_X509_get_der
+    \sa wolfSSL_X509_get_serial_number
+    \sa wolfSSL_X509_notBefore
+    \sa wolfSSL_X509_notAfter
+    \sa wolfSSL_X509_free
+*/
+int wolfSSL_X509_get_signature_type(WOLFSSL_X509*);
+
+/*!
+    \brief  
+    _Example_
+    \code
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)XMALOC(sizeof(WOLFSSL_X509), NULL,
+    DYNAMIC_TYPE_X509) ;
+
+    wolfSSL_X509_free(x509);
+
+    \endcode
+    \sa wolfSSL_X509_get_signature
+    \sa wolfSSL_X509_version
+    \sa wolfSSL_X509_get_der
+    \sa wolfSSL_X509_get_serial_number
+    \sa wolfSSL_X509_notBefore
+    \sa wolfSSL_X509_notAfter
+*/
+void wolfSSL_X509_free(WOLFSSL_X509* x509);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  x509署名を取得し、それをバッファに保存します。
+    \return SSL_SUCCESS  関数が正常に実行された場合に返されます。署名がバッファにロードされます。
+    \return SSL_FATAL_ERRROR  X509構造体またはBUFSZメンバーがNULLの場合に返します。SIG構造の長さメンバのチェックもある（SIGはX509のメンバーである）。
+    \param x509  wolfssl_x509構造へのポインタ。
+    \param buf  バッファへの文字ポインタ。
+    _Example_
+    \code
+    WOLFSSL_X509* x509 = (WOLFSSL_X509)XMALOC(sizeof(WOLFSSL_X509), NULL,
+    DYNAMIC_TYPE_X509);
+    unsigned char* buf; // Initialize
+    int* bufSz = sizeof(buf)/sizeof(unsigned char);
+    ...
+    if(wolfSSL_X509_get_signature(x509, buf, bufSz) != SSL_SUCCESS){
+	    // The function did not execute successfully.
+    } else{
+	    // The buffer was written to correctly.
+    }
+    \endcode
+    \sa wolfSSL_X509_get_serial_number
+    \sa wolfSSL_X509_get_signature_type
+    \sa wolfSSL_X509_get_device_type
+*/
+int wolfSSL_X509_get_signature(WOLFSSL_X509* x509, unsigned char* buf, int* bufSz);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、wolfssl_x509_stre構造に証明書を追加します。
+    \return SSL_SUCCESS  証明書が正常に追加された場合。
+    \return SSL_FATAL_ERROR:  証明書が正常に追加されない場合
+    \param str  証明書を追加する証明書ストア。
+    _Example_
+    \code
+    WOLFSSL_X509_STORE* str;
+    WOLFSSL_X509* x509;
+    int ret;
+    ret = wolfSSL_X509_STORE_add_cert(str, x509);
+    //check ret value
+    \endcode
+    \sa wolfSSL_X509_free
+*/
+int wolfSSL_X509_STORE_add_cert(WOLFSSL_X509_STORE* store, WOLFSSL_X509* x509);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、wolfssl_x509_store_ctx構造体のチェーン変数のgetter関数です。現在チェーンは取り込まれていません。
+    \return pointer  成功した場合wolfssl_stack（stack_of（wolfssl_x509））ポインタと同じ
+    \return Null  失敗すると
+    _Example_
+    \code
+    WOLFSSL_STACK* sk;
+    WOLFSSL_X509_STORE_CTX* ctx;
+    sk = wolfSSL_X509_STORE_CTX_get_chain(ctx);
+    //check sk for NULL and then use it. sk needs freed after done.
+    \endcode
+    \sa wolfSSL_sk_X509_free
+*/
+WOLFSSL_STACK* wolfSSL_X509_STORE_CTX_get_chain(
+                                                   WOLFSSL_X509_STORE_CTX* ctx);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、渡されたwolfssl_x509_store構造体の動作を変更するためのフラグを取ります。使用されるフラグの例はwolfssl_crl_checkです。
+    \return SSL_SUCCESS  フラグを設定するときにエラーが発生しなかった場合。
+    \return <0  障害の際に負の値が返されます。
+    \param str  フラグを設定する証明書ストア。
+    _Example_
+    \code
+    WOLFSSL_X509_STORE* str;
+    int ret;
+    // create and set up str
+    ret = wolfSSL_X509_STORE_set_flags(str, WOLFSSL_CRL_CHECKALL);
+    If (ret != SSL_SUCCESS) {
+    	//check ret value and handle error case
+    }
+    \endcode
+    \sa wolfSSL_X509_STORE_new
+    \sa wolfSSL_X509_STORE_free
+*/
+int wolfSSL_X509_STORE_set_flags(WOLFSSL_X509_STORE* store,
+                                                            unsigned long flag);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  これは、BYTEアレイとして符号化された有効性の証明書「NOT BEFISE」を機能します。
+    \return NULL  wolfssl_x509構造がNULLの場合に返されます。
+    \return byte  NetBeforEdataを含む返されます。
+    _Example_
+    \code
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)XMALLOC(sizeof(WOLFSSL_X509), NULL,
+							DYNAMIC_TYPE_X509);
+    ...
+    byte* notBeforeData = wolfSSL_X509_notBefore(x509);
+
+
+    \endcode
+    \sa wolfSSL_X509_get_signature
+    \sa wolfSSL_X509_version
+    \sa wolfSSL_X509_get_der
+    \sa wolfSSL_X509_get_serial_number
+    \sa wolfSSL_X509_notAfter
+    \sa wolfSSL_X509_free
+*/
+const byte* wolfSSL_X509_notBefore(WOLFSSL_X509* x509);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  これは、BYTE配列として符号化された有効性の証明書「未処理」を機能します。
+    \return NULL  wolfssl_x509構造がNULLの場合に返されます。
+    \return byte  NOTAFTERDATAを含む返されます。
+    _Example_
+    \code
+    WOLFSSL_X509* x509 = (WOLFSSL_X509*)XMALLOC(sizeof(WOLFSSL_X509), NULL,
+							DYNAMIC_TYPE_X509);
+    ...
+    byte* notAfterData = wolfSSL_X509_notAfter(x509);
+
+
+    \endcode
+    \sa wolfSSL_X509_get_signature
+    \sa wolfSSL_X509_version
+    \sa wolfSSL_X509_get_der
+    \sa wolfSSL_X509_get_serial_number
+    \sa wolfSSL_X509_notBefore
+    \sa wolfSSL_X509_free
+*/
+const byte* wolfSSL_X509_notAfter(WOLFSSL_X509* x509);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、wolfssl_asn1_integer値をwolfssl_bignum構造にコピーするために使用されます。
+    \return pointer  wolfssl_asn1_integer値を正常にコピーすると、wolfssl_bignumポインタが返されます。
+    \return Null  失敗すると。
+    \param ai  wolfssl asn1_integer構造体からコピーする。
+    _Example_
+    \code
+    WOLFSSL_ASN1_INTEGER* ai;
+    WOLFSSL_BIGNUM* bn;
+    // create ai
+    bn = wolfSSL_ASN1_INTEGER_to_BN(ai, NULL);
+
+    // or if having already created bn and wanting to reuse structure
+    // wolfSSL_ASN1_INTEGER_to_BN(ai, bn);
+    // check bn is or return value is not NULL
+    \endcode
+    \sa none
+*/
+WOLFSSL_BIGNUM *wolfSSL_ASN1_INTEGER_to_BN(const WOLFSSL_ASN1_INTEGER *ai,
+                                       WOLFSSL_BIGNUM *bn);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、wolfssl_ctx構造で構築されている内部チェーンに証明書を追加します。
+    \return SSL_SUCCESS  証明書の追加に成功したら。
+    \return SSL_FAILURE  チェーンに証明書を追加することが失敗した場合。
+    \param ctx  証明書を追加するためのwolfssl_ctx構造。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx;
+    WOLFSSL_X509* x509;
+    int ret;
+    // create ctx
+    ret = wolfSSL_CTX_add_extra_chain_cert(ctx, x509);
+    // check ret value
+    \endcode
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_CTX_free
+*/
+long wolfSSL_CTX_add_extra_chain_cert(WOLFSSL_CTX* ctx, WOLFSSL_X509* x509);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、wolfssl_ctx構造からGet Read Hapeフラグを返します。
+    \return flag  成功すると、読み取り先のフラグを返します。
+    \return SSL_FAILURE  ctxがnullの場合、ssl_failureが返されます。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx;
+    int flag;
+    // setup ctx
+    flag = wolfSSL_CTX_get_read_ahead(ctx);
+    //check flag
+    \endcode
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_CTX_free
+    \sa wolfSSL_CTX_set_read_ahead
+*/
+int  wolfSSL_CTX_get_read_ahead(WOLFSSL_CTX*);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、wolfssl_ctx構造内の読み出し先のフラグを設定します。
+    \return SSL_SUCCESS  CTXが先読みフラグを設定した場合。
+    \return SSL_FAILURE  ctxがnullの場合、ssl_failureが返されます。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx;
+    int flag;
+    int ret;
+    // setup ctx
+    ret = wolfSSL_CTX_set_read_ahead(ctx, flag);
+    // check return value
+    \endcode
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_CTX_free
+    \sa wolfSSL_CTX_get_read_ahead
+*/
+int  wolfSSL_CTX_set_read_ahead(WOLFSSL_CTX* ctx, int v);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数はOCSPで使用するオプション引数を設定します。
+    \return SSL_FAILURE  CTXまたはITのCERT ManagerがNULLの場合。
+    \return SSL_SUCCESS  正常に設定されている場合。
+    \param ctx  wolfssl_ctx構造ユーザー引数を設定するための構造。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx;
+    void* data;
+    int ret;
+    // setup ctx
+    ret = wolfSSL_CTX_set_tlsext_status_arg(ctx, data);
+
+    //check ret value
+    \endcode
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_CTX_free
+*/
+long wolfSSL_CTX_set_tlsext_status_arg(WOLFSSL_CTX* ctx, void* arg);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、PRFコールバックに渡すオプションの引数を設定します。
+    \return SSL_FAILURE  CTXがNULLの場合
+    \return SSL_SUCCESS  正常に設定されている場合。
+    \param ctx  wolfssl_ctx構造ユーザー引数を設定するための構造。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx;
+    void* data;
+    int ret;
+    // setup ctx
+    ret = wolfSSL_CTX_set_tlsext_opaques_prf_input_callback_arg(ctx, data);
+    //check ret value
+    \endcode
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_CTX_free
+*/
+long wolfSSL_CTX_set_tlsext_opaque_prf_input_callback_arg(
+        WOLFSSL_CTX* ctx, void* arg);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、SSLのオプションマスクを設定します。いくつかの有効なオプションは、ssl_op_all、ssl_op_cookie_exchange、ssl_op_no_sslv2、ssl_op_no_sslv3、ssl_op_no_tlsv1_1、ssl_op_no_tlsv1_2、ssl_op_no_compressionです。
+    \return val  SSLに格納されている更新されたオプションマスク値を返します。
+    \param s  オプションマスクを設定するためのWolfSSL構造。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    unsigned long mask;
+    mask = SSL_OP_NO_TLSv1
+    mask  = wolfSSL_set_options(ssl, mask);
+    // check mask
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_free
+    \sa wolfSSL_get_options
+*/
+long wolfSSL_set_options(WOLFSSL *s, long op);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は現在のオプションマスクを返します。
+    \return val  SSLに格納されているマスク値を返します。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    unsigned long mask;
+    mask  = wolfSSL_get_options(ssl);
+    // check mask
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_free
+    \sa wolfSSL_set_options
+*/
+long wolfSSL_get_options(const WOLFSSL *s);
+
+/*!
+    \ingroup Setup 
+    \brief  これは、渡されたデバッグ引数を設定するために使用されます。
+    \return SSL_SUCCESS  設定の成功した引数について。
+    \return SSL_FAILURE  NULL SSLが渡された場合。
+    \param ssl  引数を設定するためのWolfSSL構造。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    void* args;
+    int ret;
+    // create ssl object
+    ret  = wolfSSL_set_tlsext_debug_arg(ssl, args);
+    // check ret value
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_free
+*/
+long wolfSSL_set_tlsext_debug_arg(WOLFSSL *s, void *arg);
+
+/*!
+    \ingroup openSSL 
+    \brief  この関数は、サーバがOCSPステータス応答（OCSPステイプルとも呼ばれる）を送受信するクライアントアプリケーションが要求されたときに呼び出されます。
+    \return 1  成功すると。
+    \return 0  エラー時に。
+    \param s  ssl_new（）関数によって作成されたwolfssl構造体へのポインタ
+    _Example_
+    \code
+    WOLFSSL *ssl;
+    WOLFSSL_CTX *ctx;
+    int ret;
+    ctx = wolfSSL_CTX_new(wolfSSLv23_server_method());
+    ssl = wolfSSL_new(ctx);
+    ret = WolfSSL_set_tlsext_status_type(ssl,TLSEXT_STATUSTYPE_ocsp);
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_free
+    \sa wolfSSL_CTX_free
+*/
+long wolfSSL_set_tlsext_status_type(WOLFSSL *s, int type);
+
+/*!
+    \ingroup Setup 
+    \brief  これは、ピアの証明書を確認しようとした後に結果を取得するために使用されます。
+    \return X509_V_OK  成功した検証について
+    \return SSL_FAILURE  NULL SSLが渡された場合。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    long ret;
+    // attempt/complete handshake
+    ret  = wolfSSL_get_verify_result(ssl);
+    // check ret value
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_free
+*/
+long wolfSSL_get_verify_result(const WOLFSSL *ssl);
+
+/*!
+    \ingroup Debug 
+    \brief  この関数は、wolfssl_get_error（）によって返されたエラーコードをより多くの人間が読めるエラー文字列に変換し、その文字列を出力ファイルに印刷します。ERRは、WOLFSSL_GET_ERROR（）によって返され、FPがエラー文字列が配置されるファイルであるエラーコードです。
+    \return none  いいえ返します。
+    \param fp  に書き込まれる人間が読めるエラー文字列の出力ファイル。
+    _Example_
+    \code
+    int err = 0;
+    WOLFSSL* ssl;
+    FILE* fp = ...
+    ...
+    err = wolfSSL_get_error(ssl, 0);
+    wolfSSL_ERR_print_errors_fp(fp, err);
+    \endcode
+    \sa wolfSSL_get_error
+    \sa wolfSSL_ERR_error_string
+    \sa wolfSSL_ERR_error_string_n
+    \sa wolfSSL_load_error_strings
+*/
+void  wolfSSL_ERR_print_errors_fp(XFILE fp, int err);
+
+/*!
+    \ingroup Debug 
+    \brief  この関数は提供されたコールバックを使用してエラー報告を処理します。コールバック関数はエラー回線ごとに実行されます。文字列、長さ、およびUSERDATAはコールバックパラメータに渡されます。
+    \return none  いいえ返します。
+    \param cb  コールバック関数
+    _Example_
+    \code
+    int error_cb(const char *str, size_t len, void *u)
+    { fprintf((FILE*)u, "%-*.*s\n", (int)len, (int)len, str); return 0; }
+    ...
+    FILE* fp = ...
+    wolfSSL_ERR_print_errors_cb(error_cb, fp);
+    \endcode
+    \sa wolfSSL_get_error
+    \sa wolfSSL_ERR_error_string
+    \sa wolfSSL_ERR_error_string_n
+    \sa wolfSSL_load_error_strings
+*/
+void  wolfSSL_ERR_print_errors_cb (
+        int (*cb)(const char *str, size_t len, void *u), void *u);
+
+/*!
+    \brief  wolfssl_ctx構造
+    \return none  いいえ返します。
+    \param ctx  wolfssl_ctx_new（）を使用して作成されたwolfssl_ctx構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = WOLFSSL_CTX_new( protocol def );
+    …
+    static WC_INLINE unsigned int my_psk_client_cb(WOLFSSL* ssl, const char* hint,
+    char* identity, unsigned int id_max_len, unsigned char* key,
+    Unsigned int key_max_len){
+    …
+    wolfSSL_CTX_set_psk_client_callback(ctx, my_psk_client_cb);
+    \endcode
+    \sa wolfSSL_set_psk_client_callback
+    \sa wolfSSL_set_psk_server_callback
+    \sa wolfSSL_CTX_set_psk_server_callback
+    \sa wolfSSL_CTX_set_psk_client_callback
+*/
+void wolfSSL_CTX_set_psk_client_callback(WOLFSSL_CTX* ctx,
+                                                    wc_psk_client_callback);
+
+/*!
+    \brief  
+    \return none  いいえ返します。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    static WC_INLINE unsigned int my_psk_client_cb(WOLFSSL* ssl, const char* hint,
+    char* identity, unsigned int id_max_len, unsigned char* key,
+    Unsigned int key_max_len){
+    …
+    if(ssl){
+    wolfSSL_set_psk_client_callback(ssl, my_psk_client_cb);
+    } else {
+    	// could not set callback
+    }
+    \endcode
+    \sa wolfSSL_CTX_set_psk_client_callback
+    \sa wolfSSL_CTX_set_psk_server_callback
+    \sa wolfSSL_set_psk_server_callback
+*/
+void wolfSSL_set_psk_client_callback(WOLFSSL* ssl,
+                                                    wc_psk_client_callback);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数はPSKアイデンティティヒントを返します。
+    \return pointer  WolfSSL構造の配列メンバーに格納されている値へのconst charポインタが返されます。
+    \return NULL  WOLFSSLまたは配列構造がNULLの場合に返されます。
+    _Example_
+    \code
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    char* idHint;
+    ...
+    idHint = wolfSSL_get_psk_identity_hint(ssl);
+    if(idHint){
+    	// The hint was retrieved
+    	return idHint;
+    } else {
+    	// Hint wasn’t successfully retrieved
+    }
+    \endcode
+    \sa wolfSSL_get_psk_identity
+*/
+const char* wolfSSL_get_psk_identity_hint(const WOLFSSL*);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  関数は、配列構造のClient_Identityメンバーへの定数ポインタを返します。
+    \return string  配列構造のclient_identityメンバの文字列値。
+    \return NULL  WOLFSSL構造がNULLの場合、またはWOLFSSL構造の配列メンバーがNULLの場合。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    const char* pskID;
+    ...
+    pskID = wolfSSL_get_psk_identity(ssl);
+
+    if(pskID == NULL){
+	    // There is not a value in pskID
+    }
+    \endcode
+    \sa wolfSSL_get_psk_identity_hint
+    \sa wolfSSL_use_psk_identity_hint
+*/
+const char* wolfSSL_get_psk_identity(const WOLFSSL*);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、wolfssl_ctx構造体のserver_hintメンバーにHINT引数を格納します。
+    \return SSL_SUCCESS  機能の実行が成功したために返されます。
+    \param ctx  wolfssl_ctx_new（）を使用して作成されたwolfssl_ctx構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    const char* hint;
+    int ret;
+    …
+    ret = wolfSSL_CTX_use_psk_identity_hint(ctx, hint);
+    if(ret == SSL_SUCCESS){
+    	// Function was successful.
+	return ret;
+    } else {
+    	// Failure case.
+    }
+    \endcode
+    \sa wolfSSL_use_psk_identity_hint
+*/
+int wolfSSL_CTX_use_psk_identity_hint(WOLFSSL_CTX* ctx, const char* hint);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、wolfssl構造内の配列構造のserver_hintメンバーにHINT引数を格納します。
+    \return SSL_SUCCESS  ヒントがWolfSSL構造に正常に保存された場合に返されます。
+    \return SSL_FAILURE  WOLFSSLまたは配列構造がNULLの場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    const char* hint;
+    ...
+    if(wolfSSL_use_psk_identity_hint(ssl, hint) != SSL_SUCCESS){
+    	// Handle failure case.
+    }
+    \endcode
+    \sa wolfSSL_CTX_use_psk_identity_hint
+*/
+int wolfSSL_use_psk_identity_hint(WOLFSSL* ssl, const char* hint);
+
+/*!
+    \brief  wolfssl_ctx構造体
+    \return none  いいえ返します。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    …
+    static unsigned int my_psk_server_cb(WOLFSSL* ssl, const char* identity,
+                           unsigned char* key, unsigned int key_max_len)
+    {
+        // Function body.
+    }
+    …
+    if(ctx != NULL){
+        wolfSSL_CTX_set_psk_server_callback(ctx, my_psk_server_cb);
+    } else {
+    	// The CTX object was not properly initialized.
+    }
+    \endcode
+    \sa wc_psk_server_callback
+    \sa wolfSSL_set_psk_client_callback
+    \sa wolfSSL_set_psk_server_callback
+    \sa wolfSSL_CTX_set_psk_client_callback
+*/
+void wolfSSL_CTX_set_psk_server_callback(WOLFSSL_CTX* ctx,
+                                                    wc_psk_server_callback cb);
+
+/*!
+    \brief  WolfSSL構造オプションメンバー。
+    \return none  いいえ返します。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx;
+    WOLFSSL* ssl;
+    …
+    static unsigned int my_psk_server_cb(WOLFSSL* ssl, const char* identity,
+                           unsigned char* key, unsigned int key_max_len)
+    {
+        // Function body.
+    }
+    …
+    if(ssl != NULL && cb != NULL){
+        wolfSSL_set_psk_server_callback(ssl, my_psk_server_cb);
+    }
+    \endcode
+    \sa wolfSSL_set_psk_client_callback
+    \sa wolfSSL_CTX_set_psk_server_callback
+    \sa wolfSSL_CTX_set_psk_client_callback
+    \sa wolfSSL_get_psk_identity_hint
+    \sa wc_psk_server_callback
+    \sa InitSuites
+*/
+void wolfSSL_set_psk_server_callback(WOLFSSL* ssl,
+                                                    wc_psk_server_callback cb);
+
+
+/*!
+    \brief  
+    \return WOLFSSL_SUCCESS  またはwolfssl_failure.
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \sa wolfSSL_get_psk_callback_ctx
+    \sa wolfSSL_CTX_set_psk_callback_ctx
+    \sa wolfSSL_CTX_get_psk_callback_ctx
+*/
+int wolfSSL_set_psk_callback_ctx(WOLFSSL* ssl, void* psk_ctx);
+
+/*!
+    \brief  
+    \return WOLFSSL_SUCCESS  またはwolfssl_failure.
+    \param ctx  wolfssl_ctx_new（）を使用して作成されたwolfssl_ctx構造へのポインタ。
+    \sa wolfSSL_set_psk_callback_ctx
+    \sa wolfSSL_get_psk_callback_ctx
+    \sa wolfSSL_CTX_get_psk_callback_ctx
+*/
+int wolfSSL_CTX_set_psk_callback_ctx(WOLFSSL_CTX* ctx, void* psk_ctx);
+
+/*!
+    \brief  
+    \return void  ユーザーPSKコンテキストへのポインタ
+    \sa wolfSSL_set_psk_callback_ctx
+    \sa wolfSSL_CTX_set_psk_callback_ctx
+    \sa wolfSSL_CTX_get_psk_callback_ctx
+*/
+void* wolfSSL_get_psk_callback_ctx(WOLFSSL* ssl);
+
+/*!
+    \brief  
+    \return void  ユーザーPSKコンテキストへのポインタ
+    \sa wolfSSL_CTX_set_psk_callback_ctx
+    \sa wolfSSL_set_psk_callback_ctx
+    \sa wolfSSL_get_psk_callback_ctx
+*/
+void* wolfSSL_CTX_get_psk_callback_ctx(WOLFSSL_CTX* ctx);
+
+/*!
+    \ingroup Setup 
+    \brief  この機能により、CTX構造のHAVAnonメンバーがコンパイル中に定義されている場合は、CTX構造のHABANONメンバーを有効にします。
+    \return SSL_SUCCESS  機能が正常に実行され、CTXのHaveannonメンバーが1に設定されている場合に返されます。
+    \return SSL_FAILURE  CTX構造がNULLの場合に返されます。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    ...
+    #ifdef HAVE_ANON
+	if(cipherList == NULL){
+	    wolfSSL_CTX_allow_anon_cipher(ctx);
+	    if(wolfSSL_CTX_set_cipher_list(ctx, “ADH_AES128_SHA”) != SSL_SUCCESS){
+		    // failure case
+	    }
+    }
+    #endif
+    \endcode
+    \sa none
+*/
+int wolfSSL_CTX_allow_anon_cipher(WOLFSSL_CTX*);
+
+/*!
+    \ingroup Setup 
+    \brief  wolfsslv23_server_method（）関数は、アプリケーションがサーバーであることを示すために使用され、SSL 3.0  -  TLS 1.3からプロトコルバージョンと接続するクライアントをサポートします。この関数は、wolfssl_ctx_new（）を使用してSSL / TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。
+    \return pointer  成功した場合、呼び出しは新しく作成されたwolfssl_method構造へのポインタを返します。
+    \return Failure  xmallocを呼び出すときにメモリ割り当てが失敗した場合、基礎となるMalloc（）実装の失敗値が返されます（通常はerrnoがenomeemに設定されます）。
+    _Example_
+    \code
+    WOLFSSL_METHOD* method;
+    WOLFSSL_CTX* ctx;
+
+    method = wolfSSLv23_server_method();
+    if (method == NULL) {
+    	// unable to get method
+    }
+
+    ctx = wolfSSL_CTX_new(method);
+    ...
+    \endcode
+    \sa wolfSSLv3_server_method
+    \sa wolfTLSv1_server_method
+    \sa wolfTLSv1_1_server_method
+    \sa wolfTLSv1_2_server_method
+    \sa wolfTLSv1_3_server_method
+    \sa wolfDTLSv1_server_method
+    \sa wolfSSL_CTX_new
+*/
+WOLFSSL_METHOD *wolfSSLv23_server_method(void);
+
+/*!
+    \ingroup Setup 
+    \brief  これは、WolfSSL構造体の内部エラー状態を取得するために使用されます。
+    \return wolfssl_error  SSLエラー状態、通常はマイナスを返します
+    \return BAD_FUNC_ARG  SSLがNULLの場合
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    int ret;
+    // create ssl object
+    ret  = wolfSSL_state(ssl);
+    // check ret value
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_free
+*/
+int  wolfSSL_state(WOLFSSL* ssl);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数はピアの証明書を取得します。
+    \return pointer  WOLFSSL_X509構造のPECRERTメンバーへのポインタが存在する場合は。
+    \return 0  ピア証明書発行者サイズが定義されていない場合に返されます。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    ...
+    WOLFSSL_X509* peerCert = wolfSSL_get_peer_certificate(ssl);
+
+    if(peerCert){
+    	// You have a pointer peerCert to the peer certification
+    }
+    \endcode
+    \sa wolfSSL_X509_get_issuer_name
+    \sa wolfSSL_X509_get_subject_name
+    \sa wolfSSL_X509_get_isCA
+*/
+WOLFSSL_X509* wolfSSL_get_peer_certificate(WOLFSSL* ssl);
+
+/*!
+    \ingroup Debug 
+    \brief  この関数は、wolfssl_get_error（）を呼び出してssl_error_want_readを取得するのと似ています。基礎となるエラー状態がSSL_ERROR_WANT_READの場合、この関数は1を返しますが、それ以外の場合は0です。
+    \return 1  WOLFSSL_GET_ERROR（）はSSL_ERROR_WANT_READを返し、基礎となるI / Oには読み取り可能なデータがあります。
+    \return 0  SSL_ERROR_WANT_READエラー状態はありません。
+    _Example_
+    \code
+    int ret;
+    WOLFSSL* ssl = 0;
+    ...
+
+    ret = wolfSSL_want_read(ssl);
+    if (ret == 1) {
+    	// underlying I/O has data available for reading (SSL_ERROR_WANT_READ)
+    }
+    \endcode
+    \sa wolfSSL_want_write
+    \sa wolfSSL_get_error
+*/
+int wolfSSL_want_read(WOLFSSL*);
+
+/*!
+    \ingroup Debug 
+    \brief  この関数は、wolfssl_get_error（）を呼び出し、RETURSのSSL_ERROR_WANT_WRITEを取得するのと同じです。基礎となるエラー状態がSSL_ERROR_WANT_WRITEの場合、この関数は1を返しますが、それ以外の場合は0です。
+    \return 1  WOLFSSL_GET_ERROR（）はSSL_ERROR_WANT_WRITEを返します。基礎となるI / Oは、基礎となるSSL接続で進行状況を行うために書き込まれるデータを必要とします。
+    \return 0  ssl_error_want_writeエラー状態はありません。
+    _Example_
+    \code
+    int ret;
+    WOLFSSL* ssl = 0;
+    ...
+    ret = wolfSSL_want_write(ssl);
+    if (ret == 1) {
+    	// underlying I/O needs data to be written (SSL_ERROR_WANT_WRITE)
+    }
+    \endcode
+    \sa wolfSSL_want_read
+    \sa wolfSSL_get_error
+*/
+int wolfSSL_want_write(WOLFSSL*);
+
+/*!
+    \ingroup Setup 
+    \brief  wolfsslデフォルトでは、有効な日付範囲と検証済みの署名のためにピア証明書をチェックします。wolfssl_connect（）またはwolfssl_accept（）の前にこの関数を呼び出すと、実行するチェックのリストにドメイン名チェックが追加されます。DN受信時にピア証明書を確認するためのドメイン名を保持します。
+    \return SSL_SUCCESS  成功すると。
+    \return SSL_FAILURE  メモリエラーが発生した場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL* ssl;
+    char* domain = (char*) “www.yassl.com”;
+    ...
+
+    ret = wolfSSL_check_domain_name(ssl, domain);
+    if (ret != SSL_SUCCESS) {
+       // failed to enable domain name check
+    }
+    \endcode
+    \sa none
+*/
+int wolfSSL_check_domain_name(WOLFSSL* ssl, const char* dn);
+
+/*!
+    \ingroup TLS 
+    \brief  使用するためにWolfSSLライブラリを初期化します。アプリケーションごとに1回、その他のライブラリへの呼び出しの前に呼び出す必要があります。
+    \return SSL_SUCCESS  成功した場合、通話が戻ります。
+    \return BAD_MUTEX_E  返される可能性があるエラーです。
+    _Example_
+    \code
+    int ret = 0;
+    ret = wolfSSL_Init();
+    if (ret != SSL_SUCCESS) {
+	    failed to initialize wolfSSL library
+    }
+
+    \endcode
+    \sa wolfSSL_Cleanup
+*/
+int wolfSSL_Init(void);
+
+/*!
+    \ingroup TLS 
+    \brief  さらなる使用からWOLFSSLライブラリを初期化します。ライブラリによって使用されるリソースを解放しますが、呼び出される必要はありません。
+    \return SSL_SUCCESS  エラーを返しません。
+    _Example_
+    \code
+    wolfSSL_Cleanup();
+    \endcode
+    \sa wolfSSL_Init
+*/
+int wolfSSL_Cleanup(void);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は現在のライブラリーバージョンを返します。
+    \return LIBWOLFSSL_VERSION_STRING  バージョンを定義するconst charポインタ。
+    _Example_
+    \code
+    char version[MAXSIZE];
+    version = wolfSSL_KeepArrays();
+    …
+    if(version != ExpectedVersion){
+	    // Handle the mismatch case
+    }
+    \endcode
+    \sa word32_wolfSSL_lib_version_hex
+*/
+const char* wolfSSL_lib_version(void);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、現在のライブラリーのバージョンを16進表記で返します。
+    \return LILBWOLFSSL_VERSION_HEX  wolfssl / version.hで定義されている16進数バージョンを返します。
+    _Example_
+    \code
+    word32 libV;
+    libV = wolfSSL_lib_version_hex();
+
+    if(libV != EXPECTED_HEX){
+	    // How to handle an unexpected value
+    } else {
+	    // The expected result for libV
+    }
+    \endcode
+    \sa wolfSSL_lib_version
+*/
+word32 wolfSSL_lib_version_hex(void);
+
+/*!
+    \ingroup IO 
+    \brief  SSLメソッドの側面に基づいて、実際の接続または承認を実行します。クライアント側から呼び出された場合、サーバ側から呼び出された場合にwolfssl_accept（）が実行されている間にwolfssl_connect（）が行われる。
+    \return SSL_SUCCESS  成功した場合に返却されます。（注意、古いバージョンは0を返します）
+    \return SSL_FATAL_ERROR  基礎となる呼び出しがエラーになった場合に返されます。特定のエラーコードを取得するには、wolfssl_get_error（）を使用してください。
+    _Example_
+    \code
+    int ret = SSL_FATAL_ERROR;
+    WOLFSSL* ssl = 0;
+    ...
+    ret = wolfSSL_negotiate(ssl);
+    if (ret == SSL_FATAL_ERROR) {
+    	// SSL establishment failed
+	int error_code = wolfSSL_get_error(ssl);
+	...
+    }
+    ...
+    \endcode
+    \sa SSL_connect
+    \sa SSL_accept
+*/
+int wolfSSL_negotiate(WOLFSSL* ssl);
+
+/*!
+    \ingroup Setup 
+    \brief  SSL接続に圧縮を使用する機能をオンにします。両側には圧縮がオンになっている必要があります。そうでなければ圧縮は使用されません。ZLIBライブラリは実際のデータ圧縮を実行します。ライブラリにコンパイルするには、システムの設定システムに--with-libzを使用し、そうでない場合はhand_libzを定義します。送受信されるメッセージの実際のサイズを減らす前にデータを圧縮している間に、圧縮によって保存されたデータの量は通常、ネットワークの遅いすべてのネットワークを除いたものよりも分析に時間がかかります。
+    \return SSL_SUCCESS  成功すると。
+    \return NOT_COMPILED_IN  圧縮サポートがライブラリに組み込まれていない場合に返されます。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL* ssl = 0;
+    ...
+    ret = wolfSSL_set_compression(ssl);
+    if (ret == SSL_SUCCESS) {
+    	// successfully enabled compression for SSL session
+    }
+    \endcode
+    \sa none
+*/
+int wolfSSL_set_compression(WOLFSSL* ssl);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数はSSLセッションタイムアウト値を秒単位で設定します。
+    \return SSL_SUCCESS  セッションを正常に設定すると返されます。
+    \return BAD_FUNC_ARG  SSLがNULLの場合に返されます。
+    \param ssl  wolfssl_new（）で作成されたSSLオブジェクトへのポインタ。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL* ssl = 0;
+    ...
+
+    ret = wolfSSL_set_timeout(ssl, 500);
+    if (ret != SSL_SUCCESS) {
+    	// failed to set session timeout value
+    }
+    ...
+    \endcode
+    \sa wolfSSL_get1_session
+    \sa wolfSSL_set_session
+*/
+int wolfSSL_set_timeout(WOLFSSL* ssl, unsigned int to);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、指定されたSSLコンテキストに対して、SSLセッションのタイムアウト値を秒単位で設定します。
+    \return the  wolfssl_error_code_opensslの場合、以前のタイムアウト値
+    \return defined  成功しています。定義されていない場合、SSL_SUCCESSは返されます。
+    \return BAD_FUNC_ARG  入力コンテキスト（CTX）がNULLのときに返されます。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX*    ctx    = 0;
+    ...
+    ret = wolfSSL_CTX_set_timeout(ctx, 500);
+    if (ret != SSL_SUCCESS) {
+	    // failed to set session timeout value
+    }
+    \endcode
+    \sa wolfSSL_flush_sessions
+    \sa wolfSSL_get1_session
+    \sa wolfSSL_set_session
+    \sa wolfSSL_get_sessionID
+    \sa wolfSSL_CTX_set_session_cache_mode
+*/
+int wolfSSL_CTX_set_timeout(WOLFSSL_CTX* ctx, unsigned int to);
+
+/*!
+    \ingroup openSSL 
+    \brief  ピアの証明書チェーンを取得します。
+    \return chain  正常にコールがピアの証明書チェーンを返します。
+    \return 0  無効なWolfSSLポインタが関数に渡されると返されます。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_get_chain_count
+    \sa wolfSSL_get_chain_length
+    \sa wolfSSL_get_chain_cert
+    \sa wolfSSL_get_chain_cert_pem
+*/
+WOLFSSL_X509_CHAIN* wolfSSL_get_peer_chain(WOLFSSL* ssl);
+
+/*!
+    \ingroup openSSL 
+    \brief  ピアの証明書チェーン数を取得します。
+    \return Success  正常にコールがピアの証明書チェーン数を返します。
+    \return 0  無効なチェーンポインタが関数に渡されると返されます。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_get_peer_chain
+    \sa wolfSSL_get_chain_length
+    \sa wolfSSL_get_chain_cert
+    \sa wolfSSL_get_chain_cert_pem
+*/
+int  wolfSSL_get_chain_count(WOLFSSL_X509_CHAIN* chain);
+
+/*!
+    \ingroup openSSL 
+    \brief  Index（IDX）のピアのASN1.DER証明書長をバイト単位で取得します。
+    \return Success  正常にコールがインデックス別にピアの証明書長をバイト単位で返します。
+    \return 0  無効なチェーンポインタが関数に渡されると返されます。
+    \param chain  有効なwolfssl_x509_chain構造へのポインタ。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_get_peer_chain
+    \sa wolfSSL_get_chain_count
+    \sa wolfSSL_get_chain_cert
+    \sa wolfSSL_get_chain_cert_pem
+*/
+int  wolfSSL_get_chain_length(WOLFSSL_X509_CHAIN* chain, int idx);
+
+/*!
+    \ingroup openSSL 
+    \brief  インデックス（IDX）でピアのASN1.DER証明書を取得します。
+    \return Success  正常にコールがインデックスでピアの証明書を返します。
+    \return 0  無効なチェーンポインタが関数に渡されると返されます。
+    \param chain  有効なwolfssl_x509_chain構造へのポインタ。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_get_peer_chain
+    \sa wolfSSL_get_chain_count
+    \sa wolfSSL_get_chain_length
+    \sa wolfSSL_get_chain_cert_pem
+*/
+unsigned char* wolfSSL_get_chain_cert(WOLFSSL_X509_CHAIN* chain, int idx);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、証明書のチェーンからのピアのwolfssl_x509_209_Certificateをインデックス（IDX）で取得します。
+    \return pointer  wolfssl_x509構造へのポインタを返します。
+    \param chain  動的メモリsession_cacheの場合に使用されるWOLFSSL_X509_CHAINへのポインタ。
+    _Example_
+    \code
+    WOLFSSL_X509_CHAIN* chain = &session->chain;
+    int idx = 999; // set idx
+    ...
+    WOLFSSL_X509_CHAIN ptr;
+    prt = wolfSSL_get_chain_X509(chain, idx);
+
+    if(ptr != NULL){
+        //ptr contains the cert at the index specified
+    } else {
+	    // ptr is NULL
+    }
+    \endcode
+    \sa InitDecodedCert
+    \sa ParseCertRelative
+    \sa CopyDecodedToX509
+*/
+WOLFSSL_X509* wolfSSL_get_chain_X509(WOLFSSL_X509_CHAIN* chain, int idx);
+
+/*!
+    \ingroup openSSL 
+    \brief  インデックス（IDX）でピアのPEM証明書を取得します。
+    \return Success  正常にコールがインデックスでピアの証明書を返します。
+    \return 0  無効なチェーンポインタが関数に渡されると返されます。
+    \param chain  有効なwolfssl_x509_chain構造へのポインタ。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_get_peer_chain
+    \sa wolfSSL_get_chain_count
+    \sa wolfSSL_get_chain_length
+    \sa wolfSSL_get_chain_cert
+*/
+int  wolfSSL_get_chain_cert_pem(WOLFSSL_X509_CHAIN* chain, int idx,
+                                unsigned char* buf, int inLen, int* outLen);
+
+/*!
+    \ingroup openSSL 
+    \brief  セッションのIDを取得します。セッションIDは常に32バイトの長さです。
+    \return id  セッションID。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa SSL_get_session
+*/
+const unsigned char* wolfSSL_get_sessionID(const WOLFSSL_SESSION* s);
+
+/*!
+    \ingroup openSSL 
+    \brief  ピアの証明書のシリアル番号を取得します。シリアル番号バッファ（IN）は少なくとも32バイト以上であり、入力として* INOUTSZ引数として提供されます。関数を呼び出した後* INOUTSZはINバッファに書き込まれた実際の長さをバイト単位で保持します。
+    \return SSL_SUCCESS  成功すると。
+    \return BAD_FUNC_ARG  関数の不良引数が見つかった場合に返されます。
+    \param in  シリアル番号バッファは少なくとも32バイトの長さであるべきです
+    _Example_
+    \code
+    none
+    \endcode
+    \sa SSL_get_peer_certificate
+*/
+int  wolfSSL_X509_get_serial_number(WOLFSSL_X509* x509, unsigned char* in,
+                                    int* inOutSz);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  証明書から件名の共通名を返します。
+    \return NULL  X509構造がNULLの場合に返されます
+    \return string  サブジェクトの共通名の文字列表現は成功に返されます
+    _Example_
+    \code
+    WOLFSSL_X509 x509 = (WOLFSSL_X509*)XMALLOC(sizeof(WOLFSSL_X509), NULL,
+							DYNAMIC_TYPE_X509);
+    ...
+    int x509Cn = wolfSSL_X509_get_subjectCN(x509);
+    if(x509Cn == NULL){
+	    // Deal with NULL case
+    } else {
+	    // x509Cn contains the common name
+    }
+    \endcode
+    \sa wolfSSL_X509_Name_get_entry
+    \sa wolfSSL_X509_get_next_altname
+    \sa wolfSSL_X509_get_issuer_name
+    \sa wolfSSL_X509_get_subject_name
+*/
+char*  wolfSSL_X509_get_subjectCN(WOLFSSL_X509*);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、wolfssl_x509構造体のDERエンコードされた証明書を取得します。
+    \return buffer  この関数はDerbuffer構造体のバッファメンバーを返します。これはバイト型です。
+    \return NULL  x509またはoutszパラメーターがnullの場合に返されます。
+    \param x509  証明書情報を含むWolfSSL_X509構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_X509 x509 = (WOLFSSL_X509*)XMALLOC(sizeof(WOLFSSL_X509), NULL,
+							DYNAMIC_TYPE_X509);
+    int* outSz; // initialize
+    ...
+    byte* x509Der = wolfSSL_X509_get_der(x509, outSz);
+    if(x509Der == NULL){
+	    // Failure case one of the parameters was NULL
+    }
+    \endcode
+    \sa wolfSSL_X509_version
+    \sa wolfSSL_X509_Name_get_entry
+    \sa wolfSSL_X509_get_next_altname
+    \sa wolfSSL_X509_get_issuer_name
+    \sa wolfSSL_X509_get_subject_name
+*/
+const unsigned char* wolfSSL_X509_get_der(WOLFSSL_X509* x509, int* outSz);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、x509がnullのかどうかを確認し、そうでない場合は、x509構造体のノッカスメンバーを返します。
+    \return pointer  ASN1_TIMEを使用してX509構造体のノカフターメンバーに構造体を表明します。
+    \return NULL  X509オブジェクトがNULLの場合に返されます。
+    _Example_
+    \code
+    WOLFSSL_X509* x509 = (WOLFSSL_X509)XMALOC(sizeof(WOLFSSL_X509), NULL,
+    DYNAMIC_TYPE_X509) ;
+    ...
+    const WOLFSSL_ASN1_TIME* notAfter = wolfSSL_X509_get_notAfter(x509);
+    if(notAfter == NULL){
+        // Failure case, the x509 object is null.
+    }
+    \endcode
+    \sa wolfSSL_X509_get_notBefore
+*/
+WOLFSSL_ASN1_TIME* wolfSSL_X509_get_notAfter(WOLFSSL_X509*);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数はX509証明書のバージョンを取得します。
+    \return 0  X509構造がNULLの場合に返されます。
+    \return version  X509構造に保存されているバージョンが返されます。
+    _Example_
+    \code
+    WOLFSSL_X509* x509;
+    int version;
+    ...
+    version = wolfSSL_X509_version(x509);
+    if(!version){
+	    // The function returned 0, failure case.
+    }
+    \endcode
+    \sa wolfSSL_X509_get_subject_name
+    \sa wolfSSL_X509_get_issuer_name
+    \sa wolfSSL_X509_get_isCA
+    \sa wolfSSL_get_peer_certificate
+*/
+int wolfSSL_X509_version(WOLFSSL_X509*);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  no_stdio_filesystemが定義されている場合、この関数はヒープメモリを割り当て、wolfssl_x509構造を初期化してそれにポインタを返します。
+    \return *WOLFSSL_X509  関数が正常に実行された場合、WolfSSL_X509構造ポインタが返されます。
+    \return NULL  Xftellマクロの呼び出しが負の値を返す場合。
+    \param x509  wolfssl_x509ポインタへのポインタ。
+    _Example_
+    \code
+    WOLFSSL_X509* x509a = (WOLFSSL_X509*)XMALLOC(sizeof(WOLFSSL_X509), NULL,
+    DYNAMIC_TYPE_X509);
+    WOLFSSL_X509** x509 = x509a;
+    XFILE file;  (mapped to struct fs_file*)
+    ...
+    WOLFSSL_X509* newX509 = wolfSSL_X509_d2i_fp(x509, file);
+    if(newX509 == NULL){
+	    // The function returned NULL
+    }
+    \endcode
+    \sa wolfSSL_X509_d2i
+    \sa XFTELL
+    \sa XREWIND
+    \sa XFSEEK
+*/
+WOLFSSL_X509*
+        wolfSSL_X509_d2i_fp(WOLFSSL_X509** x509, FILE* file);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  関数はX509証明書をメモリにロードします。
+    \return pointer  実行された実行は、wolfssl_x509構造へのポインタを返します。
+    \return NULL  証明書が書き込まれなかった場合に返されます。
+    \param fname  ロードする証明書ファイル。
+    _Example_
+    \code
+    #define cliCert    “certs/client-cert.pem”
+    …
+    X509* x509;
+    …
+    x509 = wolfSSL_X509_load_certificate_file(cliCert, SSL_FILETYPE_PEM);
+    AssertNotNull(x509);
+    \endcode
+    \sa InitDecodedCert
+    \sa PemToDer
+    \sa wolfSSL_get_certificate
+    \sa AssertNotNull
+*/
+WOLFSSL_X509*
+    wolfSSL_X509_load_certificate_file(const char* fname, int format);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、デバイスの種類をX509構造からバッファにコピーします。
+    \return pointer  X509構造からデバイスの種類を保持するバイトポインタを返します。
+    \return NULL  バッファサイズがNULLの場合に返されます。
+    \param x509  wolfssl_x509_new（）で作成されたwolfssl_x509構造へのポインタ。
+    \param in  デバイスタイプ（バッファ）を保持するバイトタイプへのポインタ。
+    _Example_
+    \code
+    WOLFSSL_X509* x509 = (WOLFSSL_X509)XMALOC(sizeof(WOLFSSL_X509), NULL,
+    DYNAMIC_TYPE_X509);
+    byte* in;
+    int* inOutSz;
+    ...
+    byte* deviceType = wolfSSL_X509_get_device_type(x509, in, inOutSz);
+
+    if(!deviceType){
+	    // Failure case, NULL was returned.
+    }
+    \endcode
+    \sa wolfSSL_X509_get_hw_type
+    \sa wolfSSL_X509_get_hw_serial_number
+    \sa wolfSSL_X509_d2i
+*/
+unsigned char*
+           wolfSSL_X509_get_device_type(WOLFSSL_X509* x509, unsigned char* in,
+                                        int* inOutSz);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、wolfssl_x509構造のHWTypeメンバーをバッファにコピーします。
+    \return byte  この関数は、wolfssl_x509構造のHWTypeメンバーに以前に保持されているデータのバイトタイプを返します。
+    \return NULL  inoutszがnullの場合に返されます。
+    \param x509  証明書情報を含むWolfSSL_X509構造へのポインタ。
+    \param in  バッファを表すバイトを入力するポインタ。
+    _Example_
+    \code
+    WOLFSSL_X509* x509;  // X509 certificate
+    byte* in;  // initialize the buffer
+    int* inOutSz;  // holds the size of the buffer
+    ...
+    byte* hwType = wolfSSL_X509_get_hw_type(x509, in, inOutSz);
+
+    if(hwType == NULL){
+	    // Failure case function returned NULL.
+    }
+    \endcode
+    \sa wolfSSL_X509_get_hw_serial_number
+    \sa wolfSSL_X509_get_device_type
+*/
+unsigned char*
+           wolfSSL_X509_get_hw_type(WOLFSSL_X509* x509, unsigned char* in,
+                                    int* inOutSz);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数はX509オブジェクトのhwserialNumメンバを返します。
+    \return pointer  この関数は、X509オブジェクトからロードされたシリアル番号を含むINバッファへのバイトポインタを返します。
+    \param x509  証明書情報を含むWOLFSSL_X509構造へのポインタ。
+    \param in  コピーされるバッファへのポインタ。
+    _Example_
+    \code
+    char* serial;
+    byte* in;
+    int* inOutSz;
+    WOLFSSL_X509 x509;
+    ...
+    serial = wolfSSL_X509_get_hw_serial_number(x509, in, inOutSz);
+
+    if(serial == NULL || serial <= 0){
+    	// Failure case
+    }
+    \endcode
+    \sa wolfSSL_X509_get_subject_name
+    \sa wolfSSL_X509_get_issuer_name
+    \sa wolfSSL_X509_get_isCA
+    \sa wolfSSL_get_peer_certificate
+    \sa wolfSSL_X509_version
+*/
+unsigned char*
+           wolfSSL_X509_get_hw_serial_number(WOLFSSL_X509* x509,
+                                             unsigned char* in, int* inOutSz);
+
+/*!
+    \ingroup IO 
+    \brief  この関数はクライアント側で呼び出され、ピアの証明書チェーンを取得するのに十分な長さだけサーバーを持つSSL / TLSハンドシェイクを開始します。この関数が呼び出されると、基礎となる通信チャネルはすでに設定されています。 wolfssl_connect_cert（）は、ブロックと非ブロックI / Oの両方で動作します。基礎となるI / Oがノンブロッキングである場合、wolfsl_connect_cert（）は、wolfssl_connect_cert_cert（）のニーズを満たすことができなかったときに戻ります。ハンドシェイクを続けます。この場合、wolfssl_get_error（）への呼び出しはSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかを生成します。通話プロセスは、基礎となるI / Oが準備ができて、wolfsslがオフになっているところを拾うときに、wolfssl_connect_cert（）への呼び出しを繰り返す必要があります。ノンブロッキングソケットを使用する場合は、何も実行する必要がありますが、select（）を使用して必要な条件を確認できます。基礎となる入出力がブロックされている場合、wolfssl_connect_cert（）はピアの証明書チェーンが受信されたらのみ返されます。
+    \return SSL_SUCCESS  成功すると。
+    \return SSL_FAILURE  SSLセッションパラメータがNULLの場合、返されます。
+    \return SSL_FATAL_ERROR  エラーが発生した場合は返されます。より詳細なエラーコードを取得するには、wolfssl_get_error（）を呼び出します。
+    _Example_
+    \code
+    int ret = 0;
+    int err = 0;
+    WOLFSSL* ssl;
+    char buffer[80];
+    ...
+    ret = wolfSSL_connect_cert(ssl);
+    if (ret != SSL_SUCCESS) {
+        err = wolfSSL_get_error(ssl, ret);
+        printf(“error = %d, %s\n”, err, wolfSSL_ERR_error_string(err, buffer));
+    }
+    \endcode
+    \sa wolfSSL_get_error
+    \sa wolfSSL_connect
+    \sa wolfSSL_accept
+*/
+int  wolfSSL_connect_cert(WOLFSSL* ssl);
+
+/*!
+    \ingroup openSSL 
+    \brief  WOLFSSL_D2I_PKCS12_BIO（D2I_PKCS12_BIO）は、WOLFSSL_BIOから構造WC_PKCS12へのPKCS12情報にコピーされます。この情報は、オプションのMAC情報を保持するための構造とともにコンテンツに関する情報のリストとして構造内に分割されています。構造体WC_PKCS12で情報がチャンク（ただし復号化されていない）に分割された後、それはその後、呼び出しによって解析および復号化され得る。
+    \return WC_PKCS12  WC_PKCS12構造へのポインタ。
+    \return Failure  関数に失敗した場合はNULLを返します。
+    \param bio  PKCS12バッファを読み取るためのWOLFSSL_BIO構造。
+    _Example_
+    \code
+    WC_PKCS12* pkcs;
+    WOLFSSL_BIO* bio;
+    WOLFSSL_X509* cert;
+    WOLFSSL_EVP_PKEY* pkey;
+    STACK_OF(X509) certs;
+    //bio loads in PKCS12 file
+    wolfSSL_d2i_PKCS12_bio(bio, &pkcs);
+    wolfSSL_PKCS12_parse(pkcs, “a password”, &pkey, &cert, &certs)
+    wc_PKCS12_free(pkcs)
+    //use cert, pkey, and optionally certs stack
+    \endcode
+    \sa wolfSSL_PKCS12_parse
+    \sa wc_PKCS12_free
+*/
+WC_PKCS12* wolfSSL_d2i_PKCS12_bio(WOLFSSL_BIO* bio,
+                                       WC_PKCS12** pkcs12);
+
+/*!
+    \ingroup openSSL 
+    \brief  WOLFSSL_I2D_PKCS12_BIO（I2D_PKCS12_BIO）は、構造WC_PKCS12からWOLFSSL_BIOへの証明書情報にコピーされます。
+    \return 1  成功のために。
+    \return Failure  0。
+    \param bio  PKCS12バッファを書き込むためのWOLFSSL_BIO構造。
+    _Example_
+    \code
+    WC_PKCS12 pkcs12;
+    FILE *f;
+    byte buffer[5300];
+    char file[] = "./test.p12";
+    int bytes;
+    WOLFSSL_BIO* bio;
+    pkcs12 = wc_PKCS12_new();
+    f = fopen(file, "rb");
+    bytes = (int)fread(buffer, 1, sizeof(buffer), f);
+    fclose(f);
+    //convert the DER file into an internal structure
+    wc_d2i_PKCS12(buffer, bytes, pkcs12);
+    bio = wolfSSL_BIO_new(wolfSSL_BIO_s_mem());
+    //convert PKCS12 structure into bio
+    wolfSSL_i2d_PKCS12_bio(bio, pkcs12);
+    wc_PKCS12_free(pkcs)
+    //use bio
+    \endcode
+    \sa wolfSSL_PKCS12_parse
+    \sa wc_PKCS12_free
+*/
+WC_PKCS12* wolfSSL_i2d_PKCS12_bio(WOLFSSL_BIO* bio,
+                                       WC_PKCS12* pkcs12);
+
+/*!
+    \ingroup openSSL 
+    \brief  pkcs12は、configureコマンドへの-enable-openSSLAXTRAを追加することで有効にできます。それは復号化のためにトリプルDESとRC4を使うことができるので、OpenSSlextra（--enable-des3 -enable-arc4）を有効にするときにもこれらの機能を有効にすることをお勧めします。 wolfsslは現在RC2をサポートしていませんので、RC2での復号化は現在利用できません。これは、.p12ファイルを作成するためにOpenSSLコマンドラインで使用されるデフォルトの暗号化方式では注目すかもしれません。 WOLFSSL_PKCS12_PARSE（PKCS12_PARSE）。この関数が最初に行っているのは、存在する場合はMacが正しいチェックです。 MACが失敗した場合、関数は返され、保存されているコンテンツ情報のいずれかを復号化しようとしません。この関数は、バッグタイプを探している各コンテンツ情報を介して解析します。バッグタイプがわかっている場合は、必要に応じて復号化され、構築されている証明書のリストに格納されているか、見つかったキーとして保存されます。すべてのバッグを介して解析した後、見つかったキーは、一致するペアが見つかるまで証明書リストと比較されます。この一致するペアはキーと証明書として返され、オプションで見つかった証明書リストはstack_of証明書として返されます。瞬間、CRL、秘密または安全なバッグがスキップされ、解析されません。デバッグプリントアウトを見ることで、これらまたは他の「不明」バッグがスキップされているかどうかがわかります。フレンドリー名などの追加の属性は、PKCS12ファイルを解析するときにスキップされます。
+    \return SSL_SUCCESS  PKCS12の解析に成功しました。
+    \return SSL_FAILURE  エラーケースに遭遇した場合
+    \param pkcs12  wc_pkcs12解析する構造
+    \param paswd  PKCS12を復号化するためのパスワード。
+    \param pkey  PKCS12からデコードされた秘密鍵を保持するための構造。
+    \param cert  PKCS12から復号された証明書を保持する構造
+    _Example_
+    \code
+    WC_PKCS12* pkcs;
+    WOLFSSL_BIO* bio;
+    WOLFSSL_X509* cert;
+    WOLFSSL_EVP_PKEY* pkey;
+    STACK_OF(X509) certs;
+    //bio loads in PKCS12 file
+    wolfSSL_d2i_PKCS12_bio(bio, &pkcs);
+    wolfSSL_PKCS12_parse(pkcs, “a password”, &pkey, &cert, &certs)
+    wc_PKCS12_free(pkcs)
+    //use cert, pkey, and optionally certs stack
+    \endcode
+    \sa wolfSSL_d2i_PKCS12_bio
+    \sa wc_PKCS12_free
+*/
+int wolfSSL_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
+     WOLFSSL_EVP_PKEY** pkey, WOLFSSL_X509** cert, WOLF_STACK_OF(WOLFSSL_X509)** ca);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  サーバーDIFFIE-HELLMANエフェメラルパラメータ設定。この関数は、サーバーがDHEを使用する暗号スイートをネゴシエートしている場合に使用するグループパラメータを設定します。
+    \return SSL_SUCCESS  成功すると。
+    \return MEMORY_ERROR  メモリエラーが発生した場合に返されます。
+    \return SIDE_ERROR  この関数がSSLサーバではなくSSLクライアントで呼び出されると返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param p  Diffie-Hellman素数パラメータ。
+    \param pSz  pのサイズ。
+    \param g  Diffie-Hellman "Generator"パラメータ。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    static unsigned char p[] = {...};
+    static unsigned char g[] = {...};
+    ...
+    wolfSSL_SetTmpDH(ssl, p, sizeof(p), g, sizeof(g));
+    \endcode
+    \sa SSL_accept
+*/
+int  wolfSSL_SetTmpDH(WOLFSSL* ssl, const unsigned char* p, int pSz,
+                                const unsigned char* g, int gSz);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  関数はwolfssl_settmph_buffer_wrapperを呼び出します。これはDiffie-Hellmanパラメータのラッパーです。
+    \return SSL_SUCCESS  実行に成功した場合。
+    \return SSL_BAD_FILETYPE  ファイルの種類がpemではなく、asn.1ではない場合WC_DHParamSLOADが正常に戻っていない場合は、も返されます。
+    \return SSL_NO_PEM_HEADER  PEMヘッダーがない場合はPemToderから返します。
+    \return SSL_BAD_FILE  PemToderにファイルエラーがある場合は返されます。
+    \return SSL_FATAL_ERROR  コピーエラーが発生した場合はPemToderから返されました。
+    \return MEMORY_E   - メモリ割り当てエラーが発生した場合
+    \return BAD_FUNC_ARG  wolfssl構造体がnullの場合、またはそうでない場合はサブルーチンに渡された場合に返されます。
+    \return DH_KEY_SIZE_E  wolfssl_settmph（）またはwolfssl_ctx_settmph（）のキーサイズエラーがある場合に返されます。
+    \return SIDE_ERROR  wolfssl_settmphのサーバー側ではない場合は返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param buf  wolfssl_settmph_file_wrapperから渡された割り当てバッファー。
+    \param sz  ファイルのサイズ（wolfssl_settmph_file_wrapper内のfname）を保持するロングint。
+    _Example_
+    \code
+    Static int wolfSSL_SetTmpDH_file_wrapper(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    Const char* fname, int format);
+    long sz = 0;
+    byte* myBuffer = staticBuffer[FILE_BUFFER_SIZE];
+    …
+    if(ssl)
+    ret = wolfSSL_SetTmpDH_buffer(ssl, myBuffer, sz, format);
+    \endcode
+    \sa wolfSSL_SetTmpDH_buffer_wrapper
+    \sa wc_DhParamsLoad
+    \sa wolfSSL_SetTmpDH
+    \sa PemToDer
+    \sa wolfSSL_CTX_SetTmpDH
+    \sa wolfSSL_CTX_SetTmpDH_file
+*/
+int  wolfSSL_SetTmpDH_buffer(WOLFSSL* ssl, const unsigned char* b, long sz,
+                                       int format);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、wolfssl_settmph_file_wrapperを呼び出してサーバdiffie-hellmanパラメータを設定します。
+    \return SSL_SUCCESS  この機能の正常な完了とそのサブルーチンの完了に戻りました。
+    \return MEMORY_E  この関数またはサブルーチンにメモリ割り当てが失敗した場合に返されます。
+    \return SIDE_ERROR  WolfSSL構造体にあるオプション構造のサイドメンバーがサーバー側ではない場合。
+    \return SSL_BAD_FILETYPE  証明書が一連のチェックに失敗した場合は返します。
+    \return DH_KEY_SIZE_E  DHパラメーターのキーサイズがWolfSSL構造体のMinkKeyszメンバーの値より小さい場合に返されます。
+    \return DH_KEY_SIZE_E  DHパラメータのキーサイズがwolfssl構造体のMAXDHKEYSZメンバーの値よりも大きい場合に返されます。
+    \return BAD_FUNC_ARG  wolfssl構造など、引数値がnullの場合に返します。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param fname  証明書を保持している定数の文字ポインタ。
+    _Example_
+    \code
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    const char* dhParam;
+    …
+    AssertIntNE(SSL_SUCCESS,
+    wolfSSL_SetTmpDH_file(ssl, dhParam, SSL_FILETYPE_PEM));
+    \endcode
+    \sa wolfSSL_CTX_SetTmpDH_file
+    \sa wolfSSL_SetTmpDH_file_wrapper
+    \sa wolfSSL_SetTmpDH_buffer
+    \sa wolfSSL_CTX_SetTmpDH_buffer
+    \sa wolfSSL_SetTmpDH_buffer_wrapper
+    \sa wolfSSL_SetTmpDH
+    \sa wolfSSL_CTX_SetTmpDH
+*/
+int  wolfSSL_SetTmpDH_file(WOLFSSL* ssl, const char* f, int format);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  サーバーCTX Diffie-Hellmanのパラメータを設定します。
+    \return SSL_SUCCESS  関数とすべてのサブルーチンがエラーなしで戻った場合に返されます。
+    \return BAD_FUNC_ARG  CTX、P、またはGパラメーターがNULLの場合に返されます。
+    \return DH_KEY_SIZE_E  DHパラメータのキーサイズがwolfssl_ctx構造体のMindHKEYSZメンバーの値より小さい場合に返されます。
+    \return DH_KEY_SIZE_E  DHパラメータのキーサイズがwolfssl_ctx構造体のMaxDhkeySZメンバーの値よりも大きい場合に返されます。
+    \return MEMORY_E  この関数またはサブルーチンにメモリの割り当てが失敗した場合は返されます。
+    \param ctx  wolfssl_ctx_new（）を使用して作成されたwolfssl_ctx構造へのポインタ。
+    \param p  ServerDH_P構造体のバッファメンバーにロードされた定数の符号なし文字ポインタ。
+    \param pSz  pのサイズを表すint型は、max_dh_sizeに初期化されます。
+    \param g  ServerDh_g構造体のバッファメンバーにロードされた定数の符号なし文字ポインタ。
+    \code
+    WOLFSSL_CTX* ctx =  WOLFSSL_CTX_new( protocol );
+    byte* p;
+    byte* g;
+    word32 pSz = (word32)sizeof(p)/sizeof(byte);
+    word32 gSz = (word32)sizeof(g)/sizeof(byte);
+    …
+    int ret =  wolfSSL_CTX_SetTmpDH(ctx, p, pSz, g, gSz);
+
+    if(ret != SSL_SUCCESS){
+    	// Failure case
+    }
+    \endcode
+    \sa wolfSSL_SetTmpDH
+    \sa wc_DhParamsLoad
+*/
+int  wolfSSL_CTX_SetTmpDH(WOLFSSL_CTX* ctx, const unsigned char* p,
+                                    int pSz, const unsigned char* g, int gSz);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  wolfssl_settmph_buffer_wrapperを呼び出すラッパー関数
+    \return 0  実行が成功するために返されました。
+    \return BAD_FUNC_ARG  CTXパラメータまたはBUFパラメータがNULLの場合に返されます。
+    \return MEMORY_E  メモリ割り当てエラーがある場合
+    \return SSL_BAD_FILETYPE  フォーマットが正しくない場合は返されます。
+    \param ctx  wolfssl_ctx_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param buf  バッファとして割り当てられ、wolfssl_settmpdh_buffer_wrapperに渡された定数の符号なし文字型へのポインタ。
+    \param sz  wolfssl_settmph_file_wrapper（）のFNAMEパラメータから派生した長い整数型。
+    _Example_
+    \code
+    static int wolfSSL_SetTmpDH_file_wrapper(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    Const char* fname, int format);
+    #ifdef WOLFSSL_SMALL_STACK
+    byte staticBuffer[1]; // force heap usage
+    #else
+    byte* staticBuffer;
+    long sz = 0;
+    …
+    if(ssl){
+    	ret = wolfSSL_SetTmpDH_buffer(ssl, myBuffer, sz, format);
+    } else {
+    ret = wolfSSL_CTX_SetTmpDH_buffer(ctx, myBuffer, sz, format);
+    }
+    \endcode
+    \sa wolfSSL_SetTmpDH_buffer_wrapper
+    \sa wolfSSL_SetTMpDH_buffer
+    \sa wolfSSL_SetTmpDH_file_wrapper
+    \sa wolfSSL_CTX_SetTmpDH_file
+*/
+int  wolfSSL_CTX_SetTmpDH_buffer(WOLFSSL_CTX* ctx, const unsigned char* b,
+                                           long sz, int format);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、wolfssl_settmph_file_wrapperを呼び出してサーバーDiffie-Hellmanパラメータを設定します。
+    \return SSL_SUCCESS  wolfssl_settmph_file_wrapperまたはそのサブルーチンのいずれかが正常に戻った場合に返されます。
+    \return MEMORY_E  動的メモリの割り当てがサブルーチンで失敗した場合に返されます。
+    \return BAD_FUNC_ARG  CTXまたはFNAMEパラメータがNULLまたはサブルーチンがNULL引数に渡された場合に返されます。
+    \return SSL_BAD_FILE  証明書ファイルが開くことができない場合、またはファイルの一連のチェックがwolfssl_settmpdh_file_wrapperから失敗した場合に返されます。
+    \return SSL_BAD_FILETYPE  フォーマットがwolfssl_settmph_buffer_wrapper（）からPEMまたはASN.1ではない場合に返されます。
+    \return DH_KEY_SIZE_E  DHパラメータのキーサイズがwolfssl_ctx構造体のMindHKEYSZメンバーの値より小さい場合に返されます。
+    \return DH_KEY_SIZE_E  DHパラメータのキーサイズがwolfssl_ctx構造体のMaxDhkeySZメンバーの値よりも大きい場合に返されます。
+    \return SIDE_ERROR  wolfssl_settmph（）で返されたサイドがサーバー終了ではない場合。
+    \return SSL_NO_PEM_HEADER  PEMヘッダーがない場合はPemToderから返されます。
+    \return SSL_FATAL_ERROR  メモリコピーの失敗がある場合はPemToderから返されます。
+    \param ctx  wolfssl_ctx_new（）を使用して作成されたwolfssl_ctx構造へのポインタ。
+    \param fname  証明書ファイルへの定数文字ポインタ。
+    _Example_
+    \code
+    #define dhParam     “certs/dh2048.pem”
+    #DEFINE aSSERTiNTne(x, y)     AssertInt(x, y, !=, ==)
+    WOLFSSL_CTX* ctx;
+    …
+    AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()))
+    …
+    AssertIntNE(SSL_SUCCESS, wolfSSL_CTX_SetTmpDH_file(NULL, dhParam,
+    SSL_FILETYPE_PEM));
+    \endcode
+    \sa wolfSSL_SetTmpDH_buffer_wrapper
+    \sa wolfSSL_SetTmpDH
+    \sa wolfSSL_CTX_SetTmpDH
+    \sa wolfSSL_SetTmpDH_buffer
+    \sa wolfSSL_CTX_SetTmpDH_buffer
+    \sa wolfSSL_SetTmpDH_file_wrapper
+    \sa AllocDer
+    \sa PemToDer
+*/
+int  wolfSSL_CTX_SetTmpDH_file(WOLFSSL_CTX* ctx, const char* f,
+                                             int format);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、wolfssl_ctx構造体のminkkeyszメンバーにアクセスして、Diffie Hellmanキーサイズの最小サイズ（ビット単位）を設定します。
+    \return SSL_SUCCESS  関数が正常に完了した場合に返されます。
+    \return BAD_FUNC_ARG  wolfssl_ctx構造体がnullの場合、またはキーz_BITSが16,000を超えるか、または8によって割り切れない場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    public static int CTX_SetMinDhKey_Sz(IntPtr ctx, short minDhKey){
+    …
+    return wolfSSL_CTX_SetMinDhKey_Sz(local_ctx, minDhKeyBits);
+    \endcode
+    \sa wolfSSL_SetMinDhKey_Sz
+    \sa wolfSSL_CTX_SetMaxDhKey_Sz
+    \sa wolfSSL_SetMaxDhKey_Sz
+    \sa wolfSSL_GetDhKey_Sz
+    \sa wolfSSL_CTX_SetTMpDH_file
+*/
+int wolfSSL_CTX_SetMinDhKey_Sz(WOLFSSL_CTX* ctx, word16);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  WolfSSL構造のDiffie-Hellmanキーの最小サイズ（ビット単位）を設定します。
+    \return SSL_SUCCESS  最小サイズは正常に設定されました。
+    \return BAD_FUNC_ARG  wolfssl構造はNULL、またはKeysz_BITSが16,000を超えるか、または8によって割り切れない場合
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    word16 keySz_bits;
+    ...
+    if(wolfSSL_SetMinDhKey_Sz(ssl, keySz_bits) != SSL_SUCCESS){
+	    // Failed to set.
+    }
+    \endcode
+    \sa wolfSSL_CTX_SetMinDhKey_Sz
+    \sa wolfSSL_GetDhKey_Sz
+*/
+int wolfSSL_SetMinDhKey_Sz(WOLFSSL* ssl, word16 keySz_bits);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、wolfssl_ctx構造体のmaxdhkeyszメンバーにアクセスして、Diffie Hellmanキーサイズの最大サイズ（ビット単位）を設定します。
+    \return SSL_SUCCESS  関数が正常に完了した場合に返されます。
+    \return BAD_FUNC_ARG  wolfssl_ctx構造体がnullの場合、またはキーz_BITSが16,000を超えるか、または8によって割り切れない場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    public static int CTX_SetMaxDhKey_Sz(IntPtr ctx, short maxDhKey){
+    …
+    return wolfSSL_CTX_SetMaxDhKey_Sz(local_ctx, keySz_bits);
+    \endcode
+    \sa wolfSSL_SetMinDhKey_Sz
+    \sa wolfSSL_CTX_SetMinDhKey_Sz
+    \sa wolfSSL_SetMaxDhKey_Sz
+    \sa wolfSSL_GetDhKey_Sz
+    \sa wolfSSL_CTX_SetTMpDH_file
+*/
+int wolfSSL_CTX_SetMaxDhKey_Sz(WOLFSSL_CTX* ctx, word16 keySz_bits);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  WolfSSL構造のDiffie-Hellmanキーの最大サイズ（ビット単位）を設定します。
+    \return SSL_SUCCESS  最大サイズは正常に設定されました。
+    \return BAD_FUNC_ARG  WOLFSSL構造はNULLまたはKEYSZパラメータは許容サイズより大きかったか、または8によって割り切れませんでした。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    word16 keySz;
+    ...
+    if(wolfSSL_SetMaxDhKey(ssl, keySz) != SSL_SUCCESS){
+	    // Failed to set.
+    }
+    \endcode
+    \sa wolfSSL_CTX_SetMaxDhKey_Sz
+    \sa wolfSSL_GetDhKey_Sz
+*/
+int wolfSSL_SetMaxDhKey_Sz(WOLFSSL* ssl, word16 keySz_bits);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  オプション構造のメンバーであるDHKEYSZ（ビット内）の値を返します。この値は、Diffie-Hellmanキーサイズをバイト単位で表します。
+    \return dhKeySz  サイズを表す整数値であるssl-> options.dhkeyszで保持されている値を返します。
+    \return BAD_FUNC_ARG  wolfssl構造体がNULLの場合に返します。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    int dhKeySz;
+    ...
+    dhKeySz = wolfSSL_GetDhKey_Sz(ssl);
+
+    if(dhKeySz == BAD_FUNC_ARG || dhKeySz <= 0){
+    	// Failure case
+    } else {
+    	// dhKeySz holds the size of the key.
+    }
+    \endcode
+    \sa wolfSSL_SetMinDhKey_sz
+    \sa wolfSSL_CTX_SetMinDhKey_Sz
+    \sa wolfSSL_CTX_SetTmpDH
+    \sa wolfSSL_SetTmpDH
+    \sa wolfSSL_CTX_SetTmpDH_file
+*/
+int wolfSSL_GetDhKey_Sz(WOLFSSL*);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  wolfssl_ctx構造体とwolfssl_cert_manager構造の両方で最小RSAキーサイズを設定します。
+    \return SSL_SUCCESS  機能の実行に成功したことに戻ります。
+    \return BAD_FUNC_ARG  CTX構造がNULLの場合、またはKEYSZがゼロより小さいか、または8によって割り切れない場合は返されます。
+    \param ctx  wolfssl_ctx_new（）を使用して作成されたwolfssl_ctx構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = SSL_CTX_new(method);
+    (void)minDhKeyBits;
+    ourCert = myoptarg;
+    …
+    minDhKeyBits = atoi(myoptarg);
+    …
+    if(wolfSSL_CTX_SetMinRsaKey_Sz(ctx, minRsaKeyBits) != SSL_SUCCESS){
+    …
+    \endcode
+    \sa wolfSSL_SetMinRsaKey_Sz
+*/
+int wolfSSL_CTX_SetMinRsaKey_Sz(WOLFSSL_CTX* ctx, short keySz);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  WolfSSL構造にあるRSAのためのビットで最小許容キーサイズを設定します。
+    \return SSL_SUCCESS  最小値が正常に設定されました。
+    \return BAD_FUNC_ARG  SSL構造がNULLの場合、またはKSYSZがゼロより小さい場合、または8によって割り切れない場合は返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    short keySz;
+    …
+
+    int isSet =  wolfSSL_SetMinRsaKey_Sz(ssl, keySz);
+    if(isSet != SSL_SUCCESS){
+	    Failed to set.
+    }
+    \endcode
+    \sa wolfSSL_CTX_SetMinRsaKey_Sz
+*/
+int wolfSSL_SetMinRsaKey_Sz(WOLFSSL* ssl, short keySz);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  wolf_ctx構造体とwolfssl_cert_manager構造体のECCキーの最小サイズをビット単位で設定します。
+    \return SSL_SUCCESS  実行が成功したために返され、MineCkeyszメンバーが設定されます。
+    \return BAD_FUNC_ARG  wolfssl_ctx構造体がnullの場合、またはキーが負の場合、または8によって割り切れない場合は返されます。
+    \param ctx  wolfssl_ctx_new（）を使用して作成されたwolfssl_ctx構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    short keySz; // minimum key size
+    …
+    if(wolfSSL_CTX_SetMinEccKey(ctx, keySz) != SSL_SUCCESS){
+	    // Failed to set min key size
+    }
+    \endcode
+    \sa wolfSSL_SetMinEccKey_Sz
+*/
+int wolfSSL_CTX_SetMinEccKey_Sz(WOLFSSL_CTX* ssl, short keySz);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  オプション構造のMineCckeyszメンバーの値を設定します。オプション構造体は、WolfSSL構造のメンバーであり、SSLパラメータを介してアクセスされます。
+    \return SSL_SUCCESS  関数がオプション構造のMineCckeyszメンバーを正常に設定した場合。
+    \return BAD_FUNC_ARG  wolfssl_ctx構造体がnullの場合、またはキーサイズ（keysz）が0（ゼロ）未満の場合、または8で割り切れない場合。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL* ssl = wolfSSL_new(ctx); // New session
+    short keySz = 999; // should be set to min key size allowable
+    ...
+    if(wolfSSL_SetMinEccKey_Sz(ssl, keySz) != SSL_SUCCESS){
+	    // Failure case.
+    }
+    \endcode
+    \sa wolfSSL_CTX_SetMinEccKey_Sz
+    \sa wolfSSL_CTX_SetMinRsaKey_Sz
+    \sa wolfSSL_SetMinRsaKey_Sz
+*/
+int wolfSSL_SetMinEccKey_Sz(WOLFSSL* ssl, short keySz);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、eap_tlsとeap-ttlsによって、マスターシークレットからキーイングマテリアルを導出します。
+    \return BUFFER_E  バッファの実際のサイズが許容最大サイズを超える場合は返されます。
+    \return MEMORY_E  メモリ割り当てにエラーがある場合は返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param msk  p_hash関数の結果を保持するvoidポインタ変数。
+    \param len  MSK変数の長さを表す符号なし整数。
+    _Example_
+    \code
+    WOLFSSL* ssl = wolfSSL_new(ctx);;
+    void* msk;
+    unsigned int len;
+    const char* label;
+    …
+    return wolfSSL_make_eap_keys(ssl, msk, len, label);
+    \endcode
+    \sa wc_PRF
+    \sa wc_HmacFinal
+    \sa wc_HmacUpdate
+*/
+int wolfSSL_make_eap_keys(WOLFSSL* ssl, void* key, unsigned int len,
+                                                             const char* label);
+
+/*!
+    \ingroup IO 
+    \brief  Writev Semanticsをシミュレートしますが、SSL_Write（）の動作のために実際にはブロックしないため、フロント追加が小さくなる可能性があるためWritevを使いやすいソフトウェアに移植する。
+    \return >0  成功時に書かれたバイト数。
+    \return 0  失敗したときに返されます。特定のエラーコードについてwolfssl_get_error（）を呼び出します。
+    \return MEMORY_ERROR  メモリエラーが発生した場合に返されます。
+    \return SSL_FATAL_ERROR  エラーが発生したとき、または非ブロッキングソケットを使用するときには、SSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEエラーが受信され、再度WOLFSSL_WRITE（）を呼び出す必要がある場合は、障害が発生します。特定のエラーコードを取得するには、wolfssl_get_error（）を使用してください。
+    \param ssl  wolfssl_new（）で作成されたSSLセッションへのポインタ。
+    \param iov  書き込みへのI / Oベクトルの配列
+    _Example_
+    \code
+    WOLFSSL* ssl = 0;
+    char *bufA = “hello\n”;
+    char *bufB = “hello world\n”;
+    int iovcnt;
+    struct iovec iov[2];
+
+    iov[0].iov_base = buffA;
+    iov[0].iov_len = strlen(buffA);
+    iov[1].iov_base = buffB;
+    iov[1].iov_len = strlen(buffB);
+    iovcnt = 2;
+    ...
+    ret = wolfSSL_writev(ssl, iov, iovcnt);
+    // wrote “ret” bytes, or error if <= 0.
+    \endcode
+    \sa wolfSSL_write
+*/
+int wolfSSL_writev(WOLFSSL* ssl, const struct iovec* iov,
+                                     int iovcnt);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数はCA署名者リストをアンロードし、署名者全体のテーブルを解放します。
+    \return SSL_SUCCESS  機能の実行に成功したことに戻ります。
+    \return BAD_FUNC_ARG  wolfssl_ctx構造体がnullの場合、または他の方法では未解決の引数値がサブルーチンに渡された場合に返されます。
+    \return BAD_MUTEX_E  ミューテックスエラーが発生した場合は返されます。lockmutex（）は0を返しませんでした。
+    _Example_
+    \code
+    WOLFSSL_METHOD method = wolfTLSv1_2_client_method();
+    WOLFSSL_CTX* ctx = WOLFSSL_CTX_new(method);
+    …
+    if(!wolfSSL_CTX_UnloadCAs(ctx)){
+    	// The function did not unload CAs
+    }
+    \endcode
+    \sa wolfSSL_CertManagerUnloadCAs
+    \sa LockMutex
+    \sa FreeSignerTable
+    \sa UnlockMutex
+*/
+int wolfSSL_CTX_UnloadCAs(WOLFSSL_CTX*);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、以前にロードされたすべての信頼できるピア証明書をアンロードするために使用されます。マクロwolfssl_trust_peer_certを定義することで機能が有効になっています。
+    \return SSL_SUCCESS  成功すると。
+    \return BAD_FUNC_ARG  CTXがNULLの場合は返されます。
+    \return SSL_BAD_FILE  ファイルが存在しない場合は返されます。読み込め、または破損していません。
+    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL_CTX* ctx;
+    ...
+    ret = wolfSSL_CTX_Unload_trust_peers(ctx);
+    if (ret != SSL_SUCCESS) {
+        // error unloading trusted peer certs
+    }
+    ...
+    \endcode
+    \sa wolfSSL_CTX_trust_peer_buffer
+    \sa wolfSSL_CTX_trust_peer_cert
+*/
+int wolfSSL_CTX_Unload_trust_peers(WOLFSSL_CTX*);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、TLS / SSLハンドシェイクを実行するときにピアを検証するために使用する証明書をロードします。ハンドシェイク中に送信されたピア証明書は、使用可能なときにスキッドを使用することによって比較されます。これら2つのことが一致しない場合は、ロードされたCASが使用されます。ファイルの代わりにバッファーの場合は、wolfssl_ctx_trust_peer_certと同じ機能です。特徴はマクロwolfssl_trust_peer_certを定義することによって有効になっています適切な使用法の例を参照してください。
+    \return SSL_SUCCESS  成功すると
+    \return SSL_FAILURE  CTXがNULLの場合、または両方のファイルと種類が無効な場合は返されます。
+    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合は返されます。
+    \return SSL_BAD_FILE  ファイルが存在しない場合は返されます。読み込め、または破損していません。
+    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
+    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    \param buffer  証明書を含むバッファへのポインタ。
+    \param sz  バッファ入力の長さ。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL_CTX* ctx;
+    ...
+
+    ret = wolfSSL_CTX_trust_peer_buffer(ctx, bufferPtr, bufferSz,
+    SSL_FILETYPE_PEM);
+    if (ret != SSL_SUCCESS) {
+    // error loading trusted peer cert
+    }
+    ...
+    \endcode
+    \sa wolfSSL_CTX_load_verify_buffer
+    \sa wolfSSL_CTX_use_certificate_file
+    \sa wolfSSL_CTX_use_PrivateKey_file
+    \sa wolfSSL_CTX_use_certificate_chain_file
+    \sa wolfSSL_CTX_trust_peer_cert
+    \sa wolfSSL_CTX_Unload_trust_peers
+    \sa wolfSSL_use_certificate_file
+    \sa wolfSSL_use_PrivateKey_file
+    \sa wolfSSL_use_certificate_chain_file
+*/
+int wolfSSL_CTX_trust_peer_buffer(WOLFSSL_CTX* ctx, const unsigned char* in,
+                                  long sz, int format);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数はCA証明書バッファをWolfSSLコンテキストにロードします。バッファ以外のバージョンのように動作し、ファイルの代わりに入力としてバッファと呼ばれる機能が異なるだけです。バッファはサイズSZの引数によって提供されます。形式バッファのフォーマットタイプを指定します。SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM。フォーマットがPEM内にある限り、バッファあたり複数のCA証明書をロードすることができます。適切な使用法の例をご覧ください。
+    \return SSL_SUCCESS  成功すると
+    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合は返されます。
+    \return SSL_BAD_FILE  ファイルが存在しない場合は返されます。読み込め、または破損していません。
+    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
+    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
+    \return BUFFER_E  チェーンバッファが受信バッファよりも大きい場合に返されます。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    \param in  CA証明書バッファへのポインタ。
+    \param sz  入力CA証明書バッファのサイズ、IN。
+    _Example_
+    \code
+    int ret = 0;
+    int sz = 0;
+    WOLFSSL_CTX* ctx;
+    byte certBuff[...];
+    ...
+
+    ret = wolfSSL_CTX_load_verify_buffer(ctx, certBuff, sz, SSL_FILETYPE_PEM);
+    if (ret != SSL_SUCCESS) {
+    	// error loading CA certs from buffer
+    }
+    ...
+    \endcode
+    \sa wolfSSL_CTX_load_verify_locations
+    \sa wolfSSL_CTX_use_certificate_buffer
+    \sa wolfSSL_CTX_use_PrivateKey_buffer
+    \sa wolfSSL_CTX_use_certificate_chain_buffer
+    \sa wolfSSL_use_certificate_buffer
+    \sa wolfSSL_use_PrivateKey_buffer
+    \sa wolfSSL_use_certificate_chain_buffer
+*/
+int wolfSSL_CTX_load_verify_buffer(WOLFSSL_CTX* ctx, const unsigned char* in,
+                                   long sz, int format);
+
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数はCA証明書バッファをWolfSSLコンテキストにロードします。バッファ以外のバージョンのように動作し、ファイルの代わりに入力としてバッファと呼ばれる機能が異なるだけです。バッファはサイズSZの引数によって提供されます。形式バッファのフォーマットタイプを指定します。SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM。フォーマットがPEM内にある限り、バッファあたり複数のCA証明書をロードすることができます。_EXバージョンはPR 2413に追加され、UserChainとFlagsの追加の引数をサポートします。
+    \return SSL_SUCCESS  成功すると
+    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合は返されます。
+    \return SSL_BAD_FILE  ファイルが存在しない場合は返されます。読み込め、または破損していません。
+    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
+    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
+    \return BUFFER_E  チェーンバッファが受信バッファよりも大きい場合に返されます。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    \param in  CA証明書バッファへのポインタ。
+    \param sz  入力CA証明書バッファのサイズ、IN。
+    \param format  バッファ証明書の形式、SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM。
+    \param userChain  フォーマットwolfssl_filetype_asn1を使用する場合、このセットはゼロ以外のセットを示しています.Derのチェーンが表示されています。
+    _Example_
+    \code
+    int ret = 0;
+    int sz = 0;
+    WOLFSSL_CTX* ctx;
+    byte certBuff[...];
+    ...
+
+    // Example for force loading an expired certificate
+    ret = wolfSSL_CTX_load_verify_buffer_ex(ctx, certBuff, sz, SSL_FILETYPE_PEM,
+        0, (WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY));
+    if (ret != SSL_SUCCESS) {
+    	// error loading CA certs from buffer
+    }
+    ...
+    \endcode
+    \sa wolfSSL_CTX_load_verify_buffer
+    \sa wolfSSL_CTX_load_verify_locations
+    \sa wolfSSL_CTX_use_certificate_buffer
+    \sa wolfSSL_CTX_use_PrivateKey_buffer
+    \sa wolfSSL_CTX_use_certificate_chain_buffer
+    \sa wolfSSL_use_certificate_buffer
+    \sa wolfSSL_use_PrivateKey_buffer
+    \sa wolfSSL_use_certificate_chain_buffer
+*/
+int wolfSSL_CTX_load_verify_buffer_ex(WOLFSSL_CTX* ctx,
+                                      const unsigned char* in, long sz,
+                                      int format, int userChain, word32 flags);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、CA証明書チェーンバッファをWolfSSLコンテキストにロードします。バッファ以外のバージョンのように動作し、ファイルの代わりに入力としてバッファと呼ばれる機能が異なるだけです。バッファはサイズSZの引数によって提供されます。形式バッファのフォーマットタイプを指定します。SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM。フォーマットがPEM内にある限り、バッファあたり複数のCA証明書をロードすることができます。適切な使用法の例をご覧ください。
+    \return SSL_SUCCESS  成功すると
+    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合は返されます。
+    \return SSL_BAD_FILE  ファイルが存在しない場合は返されます。読み込め、または破損していません。
+    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
+    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
+    \return BUFFER_E  チェーンバッファが受信バッファよりも大きい場合に返されます。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    \param in  CA証明書バッファへのポインタ。
+    \param sz  入力CA証明書バッファのサイズ、IN。
+    _Example_
+    \code
+    int ret = 0;
+    int sz = 0;
+    WOLFSSL_CTX* ctx;
+    byte certBuff[...];
+    ...
+
+    ret = wolfSSL_CTX_load_verify_chain_buffer_format(ctx,
+                         certBuff, sz, WOLFSSL_FILETYPE_ASN1);
+    if (ret != SSL_SUCCESS) {
+        // error loading CA certs from buffer
+    }
+    ...
+    \endcode
+    \sa wolfSSL_CTX_load_verify_locations
+    \sa wolfSSL_CTX_use_certificate_buffer
+    \sa wolfSSL_CTX_use_PrivateKey_buffer
+    \sa wolfSSL_CTX_use_certificate_chain_buffer
+    \sa wolfSSL_use_certificate_buffer
+    \sa wolfSSL_use_PrivateKey_buffer
+    \sa wolfSSL_use_certificate_chain_buffer
+*/
+int wolfSSL_CTX_load_verify_chain_buffer_format(WOLFSSL_CTX* ctx,
+                                               const unsigned char* in,
+                                               long sz, int format);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は証明書バッファをWolfSSLコンテキストにロードします。バッファ以外のバージョンのように動作し、ファイルの代わりに入力としてバッファと呼ばれる機能が異なるだけです。バッファはサイズSZの引数によって提供されます。形式バッファのフォーマットタイプを指定します。SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM。適切な使用法の例をご覧ください。
+    \return SSL_SUCCESS  成功すると
+    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合は返されます。
+    \return SSL_BAD_FILE  ファイルが存在しない場合は返されます。読み込め、または破損していません。
+    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
+    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    \param in  ロードする証明書を含む入力バッファ。
+    \param sz  入力バッファのサイズ。
+    _Example_
+    \code
+    int ret = 0;
+    int sz = 0;
+    WOLFSSL_CTX* ctx;
+    byte certBuff[...];
+    ...
+    ret = wolfSSL_CTX_use_certificate_buffer(ctx, certBuff, sz, SSL_FILETYPE_PEM);
+    if (ret != SSL_SUCCESS) {
+	    // error loading certificate from buffer
+    }
+    ...
+    \endcode
+    \sa wolfSSL_CTX_load_verify_buffer
+    \sa wolfSSL_CTX_use_PrivateKey_buffer
+    \sa wolfSSL_CTX_use_certificate_chain_buffer
+    \sa wolfSSL_use_certificate_buffer
+    \sa wolfSSL_use_PrivateKey_buffer
+    \sa wolfSSL_use_certificate_chain_buffer
+*/
+int wolfSSL_CTX_use_certificate_buffer(WOLFSSL_CTX* ctx,
+                                       const unsigned char* in, long sz,
+                                       int format);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、秘密鍵バッファをSSLコンテキストにロードします。バッファ以外のバージョンのように動作し、ファイルの代わりに入力としてバッファと呼ばれる機能が異なるだけです。バッファはサイズSZの引数によって提供されます。形式バッファのフォーマットタイプを指定します。SSL_FILETYPE_ASN1OR SSL_FILETYPE_PEM。適切な使用法の例をご覧ください。
+    \return SSL_SUCCESS  成功すると
+    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合は返されます。
+    \return SSL_BAD_FILE  ファイルが存在しない場合は返されます。読み込め、または破損していません。
+    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
+    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
+    \return NO_PASSWORD  キーファイルが暗号化されているがパスワードが提供されていない場合は返されます。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    \param in  ロードする秘密鍵を含む入力バッファ。
+    \param sz  入力バッファのサイズ。
+    _Example_
+    \code
+    int ret = 0;
+    int sz = 0;
+    WOLFSSL_CTX* ctx;
+    byte keyBuff[...];
+    ...
+    ret = wolfSSL_CTX_use_PrivateKey_buffer(ctx, keyBuff, sz, SSL_FILETYPE_PEM);
+    if (ret != SSL_SUCCESS) {
+    	// error loading private key from buffer
+    }
+    ...
+    \endcode
+    \sa wolfSSL_CTX_load_verify_buffer
+    \sa wolfSSL_CTX_use_certificate_buffer
+    \sa wolfSSL_CTX_use_certificate_chain_buffer
+    \sa wolfSSL_use_certificate_buffer
+    \sa wolfSSL_use_PrivateKey_buffer
+    \sa wolfSSL_use_certificate_chain_buffer
+*/
+int wolfSSL_CTX_use_PrivateKey_buffer(WOLFSSL_CTX* ctx,
+                                      const unsigned char* in, long sz,
+                                      int format);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、証明書チェーンバッファをWolfSSLコンテキストにロードします。バッファ以外のバージョンのように動作し、ファイルの代わりに入力としてバッファと呼ばれる機能が異なるだけです。バッファはサイズSZの引数によって提供されます。バッファはPEM形式で、ルート証明書で終わる対象の証明書から始めてください。適切な使用法の例をご覧ください。
+    \return SSL_SUCCESS  成功すると
+    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合は返されます。
+    \return SSL_BAD_FILE  ファイルが存在しない場合は返されます。読み込め、または破損していません。
+    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
+    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
+    \return BUFFER_E  チェーンバッファが受信バッファよりも大きい場合に返されます。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    \param in  ロードされるPEM形式の証明書チェーンを含む入力バッファ。
+    _Example_
+    \code
+    int ret = 0;
+    int sz = 0;
+    WOLFSSL_CTX* ctx;
+    byte certChainBuff[...];
+    ...
+    ret = wolfSSL_CTX_use_certificate_chain_buffer(ctx, certChainBuff, sz);
+    if (ret != SSL_SUCCESS) {
+    	// error loading certificate chain from buffer
+    }
+    ...
+    \endcode
+    \sa wolfSSL_CTX_load_verify_buffer
+    \sa wolfSSL_CTX_use_certificate_buffer
+    \sa wolfSSL_CTX_use_PrivateKey_buffer
+    \sa wolfSSL_use_certificate_buffer
+    \sa wolfSSL_use_PrivateKey_buffer
+    \sa wolfSSL_use_certificate_chain_buffer
+*/
+int wolfSSL_CTX_use_certificate_chain_buffer(WOLFSSL_CTX* ctx,
+                                             const unsigned char* in, long sz);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、証明書バッファをWolfSSLオブジェクトにロードします。バッファ以外のバージョンのように動作し、ファイルの代わりに入力としてバッファと呼ばれる機能が異なるだけです。バッファはサイズSZの引数によって提供されます。形式バッファのフォーマットタイプを指定します。SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM。適切な使用法の例をご覧ください。
+    \return SSL_SUCCESS  成功すると。
+    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合は返されます。
+    \return SSL_BAD_FILE  ファイルが存在しない場合は返されます。読み込め、または破損していません。
+    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
+    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
+    \param ssl  wolfssl_new（）で作成されたSSLセッションへのポインタ。
+    \param in  ロードする証明書を含むバッファ。
+    \param sz  バッファにある証明書のサイズ。
+    _Example_
+    \code
+    int buffSz;
+    int ret;
+    byte certBuff[...];
+    WOLFSSL* ssl = 0;
+    ...
+
+    ret = wolfSSL_use_certificate_buffer(ssl, certBuff, buffSz, SSL_FILETYPE_PEM);
+    if (ret != SSL_SUCCESS) {
+    	// failed to load certificate from buffer
+    }
+    \endcode
+    \sa wolfSSL_CTX_load_verify_buffer
+    \sa wolfSSL_CTX_use_certificate_buffer
+    \sa wolfSSL_CTX_use_PrivateKey_buffer
+    \sa wolfSSL_CTX_use_certificate_chain_buffer
+    \sa wolfSSL_use_PrivateKey_buffer
+    \sa wolfSSL_use_certificate_chain_buffer
+*/
+int wolfSSL_use_certificate_buffer(WOLFSSL* ssl, const unsigned char* in,
+                                               long sz, int format);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、秘密鍵バッファをWolfSSLオブジェクトにロードします。バッファ以外のバージョンのように動作し、ファイルの代わりに入力としてバッファと呼ばれる機能が異なるだけです。バッファはサイズSZの引数によって提供されます。形式バッファのフォーマットタイプを指定します。SSL_FILETYPE_ASN1またはSSL_FILETYPE_PEM。適切な使用法の例をご覧ください。
+    \return SSL_SUCCESS  成功すると。
+    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合は返されます。
+    \return SSL_BAD_FILE  ファイルが存在しない場合は返されます。読み込め、または破損していません。
+    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
+    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
+    \return NO_PASSWORD  キーファイルが暗号化されているがパスワードが提供されていない場合は返されます。
+    \param ssl  wolfssl_new（）で作成されたSSLセッションへのポインタ。
+    \param in  ロードする秘密鍵を含むバッファ。
+    \param sz  バッファにある秘密鍵のサイズ。
+    _Example_
+    \code
+    int buffSz;
+    int ret;
+    byte keyBuff[...];
+    WOLFSSL* ssl = 0;
+    ...
+    ret = wolfSSL_use_PrivateKey_buffer(ssl, keyBuff, buffSz, SSL_FILETYPE_PEM);
+    if (ret != SSL_SUCCESS) {
+    	// failed to load private key from buffer
+    }
+    \endcode
+    \sa wolfSSL_use_PrivateKey
+    \sa wolfSSL_CTX_load_verify_buffer
+    \sa wolfSSL_CTX_use_certificate_buffer
+    \sa wolfSSL_CTX_use_PrivateKey_buffer
+    \sa wolfSSL_CTX_use_certificate_chain_buffer
+    \sa wolfSSL_use_certificate_buffer
+    \sa wolfSSL_use_certificate_chain_buffer
+*/
+int wolfSSL_use_PrivateKey_buffer(WOLFSSL* ssl, const unsigned char* in,
+                                               long sz, int format);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、証明書チェーンバッファをWolfSSLオブジェクトにロードします。バッファ以外のバージョンのように動作し、ファイルの代わりに入力としてバッファと呼ばれる機能が異なるだけです。バッファはサイズSZの引数によって提供されます。バッファはPEM形式で、ルート証明書で終わる対象の証明書から始めてください。適切な使用法の例をご覧ください。
+    \return SSL_SUCCES  成功すると。
+    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合は返されます。
+    \return SSL_BAD_FILE  ファイルが存在しない場合は返されます。読み込め、または破損していません。
+    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
+    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
+    \return BUFFER_E  チェーンバッファが受信バッファよりも大きい場合に返されます。
+    \param ssl  wolfssl_new（）で作成されたSSLセッションへのポインタ。
+    \param in  ロードする証明書を含むバッファ。
+    _Example_
+    \code
+    int buffSz;
+    int ret;
+    byte certChainBuff[...];
+    WOLFSSL* ssl = 0;
+    ...
+    ret = wolfSSL_use_certificate_chain_buffer(ssl, certChainBuff, buffSz);
+    if (ret != SSL_SUCCESS) {
+    	// failed to load certificate chain from buffer
+    }
+    \endcode
+    \sa wolfSSL_CTX_load_verify_buffer
+    \sa wolfSSL_CTX_use_certificate_buffer
+    \sa wolfSSL_CTX_use_PrivateKey_buffer
+    \sa wolfSSL_CTX_use_certificate_chain_buffer
+    \sa wolfSSL_use_certificate_buffer
+    \sa wolfSSL_use_PrivateKey_buffer
+*/
+int wolfSSL_use_certificate_chain_buffer(WOLFSSL* ssl,
+                                         const unsigned char* in, long sz);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、SSLが所有する証明書またはキーをアンロードします。
+    \return SSL_SUCCESS   - 関数が正常に実行された場合に返されます。
+    \return BAD_FUNC_ARG   -  wolfsslオブジェクトがnullの場合に返されます。
+    _Example_
+    \code
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    ...
+    int unloadKeys = wolfSSL_UnloadCertsKeys(ssl);
+    if(unloadKeys != SSL_SUCCESS){
+	    // Failure case.
+    }
+    \endcode
+    \sa wolfSSL_CTX_UnloadCAs
+*/
+int wolfSSL_UnloadCertsKeys(WOLFSSL*);
+
+/*!
+    \ingroup Setup 
+    \brief  この機能は、可能な限りハンドシェイクメッセージのグループ化をオンにします。
+    \return SSL_SUCCESS  成功に戻ります。
+    \return BAD_FUNC_ARG  入力コンテキストがNULLの場合、返されます。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = 0;
+    ...
+    ret = wolfSSL_CTX_set_group_messages(ctx);
+    if (ret != SSL_SUCCESS) {
+	    // failed to set handshake message grouping
+    }
+    \endcode
+    \sa wolfSSL_set_group_messages
+    \sa wolfSSL_CTX_new
+*/
+int wolfSSL_CTX_set_group_messages(WOLFSSL_CTX*);
+
+/*!
+    \ingroup Setup 
+    \brief  この機能は、可能な限りハンドシェイクメッセージのグループ化をオンにします。
+    \return SSL_SUCCESS  成功に戻ります。
+    \return BAD_FUNC_ARG  入力コンテキストがNULLの場合、返されます。
+    _Example_
+    \code
+    WOLFSSL* ssl = 0;
+    ...
+    ret = wolfSSL_set_group_messages(ssl);
+    if (ret != SSL_SUCCESS) {
+	// failed to set handshake message grouping
+    }
+    \endcode
+    \sa wolfSSL_CTX_set_group_messages
+    \sa wolfSSL_new
+*/
+int wolfSSL_set_group_messages(WOLFSSL*);
+
+/*!
+    \brief  
+    \return none  いいえ返します。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param cbf  フォームの関数ポインタであるCallBackFozzerタイプ：int（* callbackfuzzer）（wolfssl * ssl、consigned char * buf、int sz、int型、void * fuzzctx）;
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    void* fCtx;
+
+    int callbackFuzzerCB(WOLFSSL* ssl, const unsigned char* buf, int sz,
+				int type, void* fuzzCtx){
+    // function definition
+    }
+    …
+    wolfSSL_SetFuzzerCb(ssl, callbackFuzzerCB, fCtx);
+    \endcode
+    \sa CallbackFuzzer
+*/
+void wolfSSL_SetFuzzerCb(WOLFSSL* ssl, CallbackFuzzer cbf, void* fCtx);
+
+/*!
+    \brief  
+    \return 0  関数がエラーなしで実行された場合に返されます。
+    \return BAD_FUNC_ARG  許容できない値で関数に渡された引数があった場合に返されます。
+    \return COOKIE_SECRET_SZ  秘密サイズが0の場合に返されます。
+    \return MEMORY_ERROR  新しいCookie Secretにメモリを割り当てる問題がある場合は返されました。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param secret  秘密バッファを表す定数バイトポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    const* byte secret;
+    word32 secretSz; // size of secret
+    …
+    if(!wolfSSL_DTLS_SetCookieSecret(ssl, secret, secretSz)){
+    	// Code block for failure to set DTLS cookie secret
+    } else {
+    	// Success! Cookie secret is set.
+    }
+    \endcode
+    \sa ForceZero
+    \sa wc_RNG_GenerateBlock
+*/
+int   wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
+                                               const unsigned char* secret,
+                                               unsigned int secretSz);
+
+/*!
+    \brief  
+    \return rng  成功すると。
+    \return NULL  SSLがNULLの場合
+    _Example_
+    \code
+    WOLFSSL* ssl;
+
+    wolfSSL_GetRNG(ssl);
+
+    \endcode
+    \sa  wolfSSL_CTX_new_rng
+*/
+WC_RNG* wolfSSL_GetRNG(WOLFSSL* ssl);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、許可されている最小のダウングレードバージョンを設定します。接続が（wolfsslv23_client_methodまたはwolfsslv23_server_method）を使用して、接続がダウングレードできる場合にのみ適用されます。
+    \return SSL_SUCCESS  エラーなしで返された関数と最小バージョンが設定されている場合に返されます。
+    \return BAD_FUNC_ARG  wolfssl_ctx構造がNULLの場合、または最小バージョンがサポートされていない場合に返されます。
+    \param ctx  wolfssl_ctx_new（）を使用して作成されたwolfssl_ctx構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = WOLFSSL_CTX_new( protocol method );
+    WOLFSSL* ssl = WOLFSSL_new(ctx);
+    int version; // macrop representation
+    …
+    if(wolfSSL_CTX_SetMinVersion(ssl->ctx, version) != SSL_SUCCESS){
+    	// Failed to set min version
+    }
+    \endcode
+    \sa SetMinVersionHelper
+*/
+int wolfSSL_CTX_SetMinVersion(WOLFSSL_CTX* ctx, int version);
+
+/*!
+    \ingroup TLS 
+    \brief  この関数は、許可されている最小のダウングレードバージョンを設定します。接続が（wolfsslv23_client_methodまたはwolfsslv23_server_method）を使用して、接続がダウングレードできる場合にのみ適用されます。
+    \return SSL_SUCCESS  この関数とそのサブルーチンがエラーなしで実行された場合に返されます。
+    \return BAD_FUNC_ARG  SSLオブジェクトがNULLの場合に返されます。サブルーチンでは、良いバージョンが一致しない場合、このエラーはスローされます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = WOLFSSL_CTX_new(protocol method);
+    WOLFSSL* ssl = WOLFSSL_new(ctx);
+    int version;  macro representation
+    …
+    if(wolfSSL_CTX_SetMinVersion(ssl->ctx, version) != SSL_SUCCESS){
+	    Failed to set min version
+    }
+    \endcode
+    \sa SetMinVersionHelper
+*/
+int wolfSSL_SetMinVersion(WOLFSSL* ssl, int version);
+
+/*!
+    \brief  ビルドオプションと設定に依存します。WolfSSLを構築するときにshow_sizesが定義されている場合、この関数はWolfSSLオブジェクト（スイート、暗号など）内の個々のオブジェクトのサイズもstdoutに印刷されます。
+    \return size  この関数は、WolfSSLオブジェクトのサイズを返します。
+    _Example_
+    \code
+    int size = 0;
+    size = wolfSSL_GetObjectSize();
+    printf(“sizeof(WOLFSSL) = %d\n”, size);
+    \endcode
+    \sa wolfSSL_new
+*/
+int wolfSSL_GetObjectSize(void);  /* object size based on build */
+/*!
+    \brief  アプリケーションがトランスポートレイヤ間で何バイトを送信したい場合は、指定された平文の入力サイズを指定してください。SSL / TLSハンドシェイクが完了した後に呼び出す必要があります。
+    \return size  成功すると、要求されたサイズが返されます
+    \return INPUT_SIZE_E  入力サイズが最大TLSフラグメントサイズより大きい場合は返されます（WOLFSSL_GETMAXOUTPUTSIZE（））。
+    \return BAD_FUNC_ARG  無効な関数引数に戻り、またはSSL / TLSハンドシェイクがまだ完了していない場合
+    \param ssl  wolfssl_new（）を使用して作成されたwolfsslオブジェクトへのポインタ。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_GetMaxOutputSize
+*/
+int wolfSSL_GetOutputSize(WOLFSSL* ssl, int inSz);
+
+/*!
+    \brief  プロトコル規格で指定されている最大SSL / TLSレコードサイズのいずれかに対応します。この関数は、アプリケーションがwolfssl_getOutputSize（）と呼ばれ、input_size_eエラーを受信したときに役立ちます。SSL / TLSハンドシェイクが完了した後に呼び出す必要があります。
+    \return size  成功すると、最大出力サイズが返されます
+    \return BAD_FUNC_ARG  無効な関数引数のときに返されるか、SSL / TLSハンドシェイクがまだ完了していない場合。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_GetOutputSize
+*/
+int wolfSSL_GetMaxOutputSize(WOLFSSL*);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、バージョンで指定されたバージョンを使用して、指定されたSSLセッション（WolfSSLオブジェクト）のSSL / TLSプロトコルバージョンを設定します。これにより、SSLセッション（SSL）のプロトコル設定が最初に定義され、SSLコンテキスト（WolfSSL_CTX_NEW（））メソッドの種類によって上書きされます。
+    \return SSL_SUCCESS  成功すると。
+    \return BAD_FUNC_ARG  入力SSLオブジェクトがNULLまたは誤ったプロトコルバージョンがバージョンで指定されている場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL* ssl;
+    ...
+
+    ret = wolfSSL_SetVersion(ssl, WOLFSSL_TLSV1);
+    if (ret != SSL_SUCCESS) {
+        // failed to set SSL session protocol version
+    }
+    \endcode
+    \sa wolfSSL_CTX_new
+*/
+int wolfSSL_SetVersion(WOLFSSL* ssl, int version);
+
+/*!
+    \brief  MAC /暗号化コールバック。コールバックは成功の場合は0を返すか、エラーの場合は<0です。SSLとCTXポインタはユーザーの利便性に利用できます。MacOutは、MACの結果を保存する必要がある出力バッファです。MacinはMac入力バッファーとMacinszのサイズを注意しています。MacContentとMacverifyは、Wolfssl_SettlShmacinner（）に必要であり、そのまま通過します。Encoutは、暗号化の結果を格納する必要がある出力バッファです。ENCINはENCSZが入力のサイズである間は暗号化する入力バッファです。コールバックの例は、wolfssl / test.h mymacencryptcb（）を見つけることができます。
+    \return none  返品不可。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_SetMacEncryptCtx
+    \sa wolfSSL_GetMacEncryptCtx
+*/
+void  wolfSSL_CTX_SetMacEncryptCb(WOLFSSL_CTX* ctx, CallbackMacEncrypti cb);
+
+/*!
+    \brief  CTXへのコールバックコンテキスト。
+    \return none  返品不可。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_CTX_SetMacEncryptCb
+    \sa wolfSSL_GetMacEncryptCtx
+*/
+void  wolfSSL_SetMacEncryptCtx(WOLFSSL* ssl, void *ctx);
+
+/*!
+    \brief  Mac / Encryptコールバックコンテキストは、wolfssl_setmacencryptx（）で保存されていました。
+    \return pointer  正常にコールがコンテキストへの有効なポインタを返します。
+    \return NULL  空白のコンテキストのために返されます。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_CTX_SetMacEncryptCb
+    \sa wolfSSL_SetMacEncryptCtx
+*/
+void* wolfSSL_GetMacEncryptCtx(WOLFSSL* ssl);
+
+/*!
+    \brief  コールバックを復号化/確認します。コールバックは成功の場合は0を返すか、エラーの場合は<0です。SSLとCTXポインタはユーザーの利便性に利用できます。DECOUTは、復号化の結果を格納する出力バッファです。DECINは暗号化された入力バッファーとDecinszのサイズを注意しています。コンテンツと検証は、WolfSSL_SettlShmacinner（）に必要であり、そのまま通過します。PADSZは、パディングの合計値で設定する出力変数です。つまり、MACサイズとパディングバイトとパッドバイトを加えています。コールバックの例は、wolfssl / test.h mydecryptverifycb（）を見つけることができます。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_SetMacEncryptCtx
+    \sa wolfSSL_GetMacEncryptCtx
+*/
+void  wolfSSL_CTX_SetDecryptVerifyCb(WOLFSSL_CTX* ctx,
+                                               CallbackDecryptVerify cb);
+
+/*!
+    \brief  コールバックコンテキストをCTXに復号化/検証します。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_CTX_SetDecryptVerifyCb
+    \sa wolfSSL_GetDecryptVerifyCtx
+*/
+void  wolfSSL_SetDecryptVerifyCtx(WOLFSSL* ssl, void *ctx);
+
+/*!
+    \brief  wolfssl_setdecryptverifyctx（）で以前に保存されているコールバックコンテキストを復号化/検証します。
+    \return pointer  正常にコールがコンテキストへの有効なポインタを返します。
+    \return NULL  空白のコンテキストのために返されます。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_CTX_SetDecryptVerifyCb
+    \sa wolfSSL_SetDecryptVerifyCtx
+*/
+void* wolfSSL_GetDecryptVerifyCtx(WOLFSSL* ssl);
+
+/*!
+    \brief  VERIFYパラメーターは、これがピア・メッセージの検証のためのものであるかどうかを指定します。
+    \return pointer  正常にコールが秘密に有効なポインタを返します。秘密のサイズは、Wolfssl_gethmacsize（）から入手できます。
+    \return NULL  エラー状態に戻ります。
+    \param ssl  wolfssl_new（）を使用して作成されたwolfsslオブジェクトへのポインタ。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_GetHmacSize
+*/
+const unsigned char* wolfSSL_GetMacSecret(WOLFSSL* ssl, int verify);
+
+/*!
+    \brief  
+    \return pointer  正常にコールがキーへの有効なポインタを返します。キーのサイズは、wolfssl_getkeysize（）から取得できます。
+    \return NULL  エラー状態に戻ります。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_GetKeySize
+    \sa wolfSSL_GetClientWriteIV
+*/
+const unsigned char* wolfSSL_GetClientWriteKey(WOLFSSL*);
+
+/*!
+    \brief  ハンドシェイクプロセスから。
+    \return pointer  正常にコールがIVへの有効なポインタを返します。IVのサイズは、wolfssl_getCipherBlockSize（）から取得できます。
+    \return NULL  エラー状態に戻ります。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_GetCipherBlockSize()
+    \sa wolfSSL_GetClientWriteKey()
+*/
+const unsigned char* wolfSSL_GetClientWriteIV(WOLFSSL*);
+
+/*!
+    \brief  
+    \return pointer  正常にコールがキーへの有効なポインタを返します。キーのサイズは、wolfssl_getkeysize（）から取得できます。
+    \return NULL  エラー状態に戻ります。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_GetKeySize
+    \sa wolfSSL_GetServerWriteIV
+*/
+const unsigned char* wolfSSL_GetServerWriteKey(WOLFSSL*);
+
+/*!
+    \brief  ハンドシェイクプロセスから。
+    \return pointer  正常にコールがIVへの有効なポインタを返します。IVのサイズは、wolfssl_getCipherBlockSize（）から取得できます。
+    \return NULL  エラー状態に戻ります。
+    \sa wolfSSL_GetCipherBlockSize
+    \sa wolfSSL_GetClientWriteKey
+*/
+const unsigned char* wolfSSL_GetServerWriteIV(WOLFSSL*);
+
+/*!
+    \brief  
+    \return size  正常にコールがキーサイズをバイト単位で返します。
+    \return BAD_FUNC_ARG  エラー状態に戻ります。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_GetClientWriteKey
+    \sa wolfSSL_GetServerWriteKey
+*/
+int                  wolfSSL_GetKeySize(WOLFSSL*);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  WolfSSL構造体に保持されているSpecs構造体のIV_SIZEメンバーを返します。
+    \return iv_size  ssl-> specs.iv_sizeで保持されている値を返します。
+    \return BAD_FUNC_ARG  WolfSSL構造がNULLの場合に返されます。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    int ivSize;
+    ...
+    ivSize = wolfSSL_GetIVSize(ssl);
+
+    if(ivSize > 0){
+    	// ivSize holds the specs.iv_size value.
+    }
+    \endcode
+    \sa wolfSSL_GetKeySize
+    \sa wolfSSL_GetClientWriteIV
+    \sa wolfSSL_GetServerWriteIV
+*/
+int                  wolfSSL_GetIVSize(WOLFSSL*);
+
+/*!
+    \brief  
+    \return success  成功した場合、呼び出しがWolfSSLオブジェクトの側面に応じてwolfssl_server_endまたはwolfssl_client_endを返します。
+    \return BAD_FUNC_ARG  エラー状態に戻ります。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_GetClientWriteKey
+    \sa wolfSSL_GetServerWriteKey
+*/
+int                  wolfSSL_GetSide(WOLFSSL*);
+
+/*!
+    \brief  少なくともTLSバージョン1.1以上です。
+    \return true/false  成功した場合、呼び出しがTRUEまたは0の場合は0を返します。
+    \return BAD_FUNC_ARG  エラー状態に戻ります。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_GetSide
+*/
+int                  wolfSSL_IsTLSv1_1(WOLFSSL*);
+
+/*!
+    \brief  ハンドシェイクから。
+    \return If  コールが成功すると、wolfssl_cipher_null、wolfssl_des、wolfssl_triple_des、wolfssl_aes、wolfssl_aes_gcm、wolfssl_aes_ccm、wolfssl_camellia。
+    \return BAD_FUNC_ARG  エラー状態に戻ります。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_GetCipherBlockSize
+    \sa wolfSSL_GetKeySize
+*/
+int                  wolfSSL_GetBulkCipher(WOLFSSL*);
+
+/*!
+    \brief  ハンドシェイク。
+    \return size  正常にコールが暗号ブロックサイズのサイズをバイト単位で戻します。
+    \return BAD_FUNC_ARG  エラー状態に戻ります。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_GetBulkCipher
+    \sa wolfSSL_GetKeySize
+*/
+int                  wolfSSL_GetCipherBlockSize(WOLFSSL*);
+
+/*!
+    \brief  ハンドシェーク。暗号タイプのwolfssl_aead_typeの場合。
+    \return size  正常にコールがEAD MACサイズのサイズをバイト単位で戻します。
+    \return BAD_FUNC_ARG  エラー状態に戻ります。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_GetBulkCipher
+    \sa wolfSSL_GetKeySize
+*/
+int                  wolfSSL_GetAeadMacSize(WOLFSSL*);
+
+/*!
+    \brief  ハンドシェーク。wolfssl_aead_type以外の暗号タイプの場合。
+    \return size  正常にコールが（H）MACサイズのサイズをバイト単位で戻します。
+    \return BAD_FUNC_ARG  エラー状態に戻ります。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_GetBulkCipher
+    \sa wolfSSL_GetHmacType
+*/
+int                  wolfSSL_GetHmacSize(WOLFSSL*);
+
+/*!
+    \brief  ハンドシェーク。wolfssl_aead_type以外の暗号タイプの場合。
+    \return If  コールが成功すると、次のいずれかが返されます.MD5、SHA、SHA256、SHA384。
+    \return BAD_FUNC_ARG  エラー状態に対して返される可能性があります。
+    \return SSL_FATAL_ERROR  エラー状態にも返される可能性があります。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_GetBulkCipher
+    \sa wolfSSL_GetHmacSize
+*/
+int                  wolfSSL_GetHmacType(WOLFSSL*);
+
+/*!
+    \brief  ハンドシェイクから。
+    \return If  正常にコールは次のいずれかを返します.WolfSSL_BLOCK_TYPE、WOLFSSL_STREAM_TYPE、WOLFSSL_AEAD_TYPE。
+    \return BAD_FUNC_ARG  エラー状態に戻ります。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_GetBulkCipher
+    \sa wolfSSL_GetHmacType
+*/
+int                  wolfSSL_GetCipherType(WOLFSSL*);
+
+/*!
+    \brief  送受信結果は、少なくともwolfssl_gethmacsize（）バイトであるべきである内部に書き込まれます。メッセージのサイズはSZで指定され、内容はメッセージの種類であり、検証はこれがピアメッセージの検証であるかどうかを指定します。wolfssl_aead_typeを除く暗号タイプに有効です。
+    \return 1  成功すると。
+    \return BAD_FUNC_ARG  エラー状態に戻ります。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_GetBulkCipher
+    \sa wolfSSL_GetHmacType
+*/
+int wolfSSL_SetTlsHmacInner(WOLFSSL* ssl, byte* inner,
+                            word32 sz, int content, int verify);
+
+/*!
+    \brief  コールバックは成功の場合は0を返すか、エラーの場合は<0です。SSLとCTXポインタはユーザーの利便性に利用できます。INSは入力バッファーが入力の長さを表します。OUTは、署名の結果を保存する必要がある出力バッファです。OUTSZは、呼び出し時に出力バッファのサイズを指定する入力/出力変数であり、署名の実際のサイズを戻す前に格納する必要があります。keyderはASN1フォーマットのECC秘密鍵であり、Keyszはキーのキーの長さです。コールバックの例は、wolfssl / test.h myeccsign（）を見つけることができます。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_SetEccSignCtx
+    \sa wolfSSL_GetEccSignCtx
+*/
+void  wolfSSL_CTX_SetEccSignCb(WOLFSSL_CTX* ctx, CallbackEccSign cb);
+
+/*!
+    \brief  CTXへのコンテキスト。
+    \return none  いいえ返します。
+    \param ssl  wolfssl_new（）を使用して作成されたwolfsslオブジェクトへのポインタ。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_CTX_SetEccSignCb
+    \sa wolfSSL_GetEccSignCtx
+*/
+void  wolfSSL_SetEccSignCtx(WOLFSSL* ssl, void *ctx);
+
+/*!
+    \brief  以前にwolfssl_seteccsignctx（）で保存されていたコンテキスト。
+    \return pointer  正常にコールがコンテキストへの有効なポインタを返します。
+    \return NULL  空白のコンテキストのために返されます。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_CTX_SetEccSignCb
+    \sa wolfSSL_SetEccSignCtx
+*/
+void* wolfSSL_GetEccSignCtx(WOLFSSL* ssl);
+
+/*!
+    \brief  CTXへのコンテキスト。
+    \return none  いいえ返します。
+    \param ctx  wolfssl_ctx_new（）で作成されたwolfssl_ctx構造へのポインタ。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_CTX_SetEccSignCb
+    \sa wolfSSL_CTX_GetEccSignCtx
+*/
+void  wolfSSL_CTX_SetEccSignCtx(WOLFSSL_CTX* ctx, void *userCtx);
+
+/*!
+    \brief  以前にwolfssl_seteccsignctx（）で保存されていたコンテキスト。
+    \return pointer  正常にコールがコンテキストへの有効なポインタを返します。
+    \return NULL  空白のコンテキストのために返されます。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_CTX_SetEccSignCb
+    \sa wolfSSL_CTX_SetEccSignCtx
+*/
+void* wolfSSL_CTX_GetEccSignCtx(WOLFSSL_CTX* ctx);
+
+/*!
+    \brief  コールバックは成功の場合は0を返すか、エラーの場合は<0です。SSLとCTXポインタはユーザーの利便性に利用できます。SIGは検証の署名であり、SIGSZは署名の長さを表します。ハッシュはメッセージのダイジェストを含む入力バッファであり、HASHSZはハッシュの長さを意味します。結果は、検証の結果を格納する出力変数、成功のために1、失敗のために0を記憶する必要があります。keyderはASN1フォーマットのECC秘密鍵であり、Keyszはキーのキーの長さです。コールバックの例は、wolfssl / test.h myeccverify（）を見つけることができます。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_SetEccVerifyCtx
+    \sa wolfSSL_GetEccVerifyCtx
+*/
+void  wolfSSL_CTX_SetEccVerifyCb(WOLFSSL_CTX* ctx, CallbackEccVerify cb);
+
+/*!
+    \brief  CTXへのコンテキスト。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_CTX_SetEccVerifyCb
+    \sa wolfSSL_GetEccVerifyCtx
+*/
+void  wolfSSL_SetEccVerifyCtx(WOLFSSL* ssl, void *ctx);
+
+/*!
+    \brief  以前にwolfssl_setecverifyctx（）で保存されていたコンテキスト。
+    \return pointer  正常にコールがコンテキストへの有効なポインタを返します。
+    \return NULL  空白のコンテキストのために返されます。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_CTX_SetEccVerifyCb
+    \sa wolfSSL_SetEccVerifyCtx
+*/
+void* wolfSSL_GetEccVerifyCtx(WOLFSSL* ssl);
+
+/*!
+    \brief  コールバックは成功の場合は0を返すか、エラーの場合は<0です。SSLとCTXポインタはユーザーの利便性に利用できます。INSは入力バッファーが入力の長さを表します。OUTは、署名の結果を保存する必要がある出力バッファです。OUTSZは、呼び出し時に出力バッファのサイズを指定する入力/出力変数であり、署名の実際のサイズを戻す前に格納する必要があります。keyderはASN1フォーマットのRSA秘密鍵であり、Keyszはバイト数のキーの長さです。コールバックの例は、wolfssl / test.h myrsasign（）を見つけることができます。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_SetRsaSignCtx
+    \sa wolfSSL_GetRsaSignCtx
+*/
+void  wolfSSL_CTX_SetRsaSignCb(WOLFSSL_CTX* ctx, CallbackRsaSign cb);
+
+/*!
+    \brief  ctxに。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_CTX_SetRsaSignCb
+    \sa wolfSSL_GetRsaSignCtx
+*/
+void  wolfSSL_SetRsaSignCtx(WOLFSSL* ssl, void *ctx);
+
+/*!
+    \brief  以前にwolfssl_setrsAsignctx（）で保存されていたコンテキスト。
+    \return pointer  正常にコールがコンテキストへの有効なポインタを返します。
+    \return NULL  空白のコンテキストのために返されます。
+    \param none  パラメータはありません。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_CTX_SetRsaSignCb
+    \sa wolfSSL_SetRsaSignCtx
+*/
+void* wolfSSL_GetRsaSignCtx(WOLFSSL* ssl);
+
+/*!
+    \brief  コールバックは、成功のための平文バイト数または<0エラーの場合は<0を返すべきです。SSLとCTXポインタはユーザーの利便性に利用できます。SIGは検証の署名であり、SIGSZは署名の長さを表します。復号化プロセスとパディングの後に検証バッファの先頭に設定する必要があります。keyderはASN1形式のRSA公開鍵であり、Keyszはキーのキーの長さです。コールバックの例は、wolfssl / test.h myrsaverify（）を見つけることができます。
+    \return none  いいえ返します。
+    \sa wolfSSL_SetRsaVerifyCtx
+    \sa wolfSSL_GetRsaVerifyCtx
+*/
+void  wolfSSL_CTX_SetRsaVerifyCb(WOLFSSL_CTX* ctx, CallbackRsaVerify cb);
+
+/*!
+    \brief  CTXへのコンテキスト。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_CTX_SetRsaVerifyCb
+    \sa wolfSSL_GetRsaVerifyCtx
+*/
+void  wolfSSL_SetRsaVerifyCtx(WOLFSSL* ssl, void *ctx);
+
+/*!
+    \brief  以前にwolfssl_setrsaverifyctx（）で保存されていたコンテキスト。
+    \return pointer  正常にコールがコンテキストへの有効なポインタを返します。
+    \return NULL  空白のコンテキストのために返されます。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_CTX_SetRsaVerifyCb
+    \sa wolfSSL_SetRsaVerifyCtx
+*/
+void* wolfSSL_GetRsaVerifyCtx(WOLFSSL* ssl);
+
+/*!
+    \brief  暗号化します。コールバックは成功の場合は0を返すか、エラーの場合は<0です。SSLとCTXポインタはユーザーの利便性に利用できます。INは入力バッファですが、INSZは入力の長さを表します。暗号化の結果を保存する必要がある出力バッファです。OUTSZは、呼び出し時に出力バッファのサイズを指定する入力/出力変数であり、暗号化の実際のサイズは戻って前に格納されるべきです。keyderはASN1形式のRSA公開鍵であり、Keyszはキーのキーの長さです。例コールバックの例は、wolfssl / test.h myrsaenc（）を見つけることができます。
+    \return none  いいえ返します。
+    \code
+    none
+    \endcode
+    \sa wolfSSL_SetRsaEncCtx
+    \sa wolfSSL_GetRsaEncCtx
+*/
+void  wolfSSL_CTX_SetRsaEncCb(WOLFSSL_CTX* ctx, CallbackRsaEnc cb);
+
+/*!
+    \brief  CTXへのコールバックコンテキスト。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_CTX_SetRsaEncCb
+    \sa wolfSSL_GetRsaEncCtx
+*/
+void  wolfSSL_SetRsaEncCtx(WOLFSSL* ssl, void *ctx);
+
+/*!
+    \brief  コールバックコンテキストは、wolfssl_setrsaencctx（）で以前に保存されていました。
+    \return pointer  正常にコールがコンテキストへの有効なポインタを返します。
+    \return NULL  空白のコンテキストのために返されます。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_CTX_SetRsaEncCb
+    \sa wolfSSL_SetRsaEncCtx
+*/
+void* wolfSSL_GetRsaEncCtx(WOLFSSL* ssl);
+
+/*!
+    \brief  復号化します。コールバックは、成功のための平文バイト数または<0エラーの場合は<0を返すべきです。SSLとCTXポインタはユーザーの利便性に利用できます。INは、復号化する入力バッファが入力の長さを表します。復号化プロセスおよび任意のパディングの後、復号化バッファの先頭に設定する必要があります。keyderはASN1フォーマットのRSA秘密鍵であり、Keyszはバイト数のキーの長さです。コールバックの例は、wolfssl / test.h myrsadec（）を見つけることができます。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_SetRsaDecCtx
+    \sa wolfSSL_GetRsaDecCtx
+*/
+void  wolfSSL_CTX_SetRsaDecCb(WOLFSSL_CTX* ctx, CallbackRsaDec cb);
+
+/*!
+    \brief  CTXへのコールバックコンテキスト。
+    \return none  いいえ返します。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_CTX_SetRsaDecCb
+    \sa wolfSSL_GetRsaDecCtx
+*/
+void  wolfSSL_SetRsaDecCtx(WOLFSSL* ssl, void *ctx);
+
+/*!
+    \brief  コールバックコンテキストは、wolfssl_setrsadecctx（）で以前に保存されていました。
+    \return pointer  正常にコールがコンテキストへの有効なポインタを返します。
+    \return NULL  空白のコンテキストのために返されます。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_CTX_SetRsaDecCb
+    \sa wolfSSL_SetRsaDecCtx
+*/
+void* wolfSSL_GetRsaDecCtx(WOLFSSL* ssl);
+
+/*!
+    \brief  新しいCA証明書がWolfSSLにロードされたときに呼び出される（WolfSSL_CTX）。コールバックには、符号化された証明書を持つバッファが与えられます。
+    \return none  返品不可。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = 0;
+
+    // CA callback prototype
+    int MyCACallback(unsigned char *der, int sz, int type);
+
+    // Register the custom CA callback with the SSL context
+    wolfSSL_CTX_SetCACb(ctx, MyCACallback);
+
+    int MyCACallback(unsigned char* der, int sz, int type)
+    {
+    	// custom CA callback function, DER-encoded cert
+        // located in “der” of size “sz” with type “type”
+    }
+    \endcode
+    \sa wolfSSL_CTX_load_verify_locations
+*/
+void wolfSSL_CTX_SetCACb(WOLFSSL_CTX* ctx, CallbackCACache cb);
+
+/*!
+    \ingroup CertManager 
+    \brief  新しい証明書マネージャコンテキストを割り当てて初期化します。このコンテキストは、SSLのニーズとは無関係に使用できます。証明書をロードしたり、証明書を確認したり、失効状況を確認したりするために使用することができます。
+    \return WOLFSSL_CERT_MANAGER  正常にコールが有効なwolfssl_cert_managerポインタを返します。
+    \return NULL  エラー状態に戻ります。
+    \sa wolfSSL_CertManagerFree
+*/
+WOLFSSL_CERT_MANAGER* wolfSSL_CertManagerNew_ex(void* heap);
+
+/*!
+    \ingroup CertManager 
+    \brief  新しい証明書マネージャコンテキストを割り当てて初期化します。このコンテキストは、SSLのニーズとは無関係に使用できます。証明書をロードしたり、証明書を確認したり、失効状況を確認したりするために使用することができます。
+    \return WOLFSSL_CERT_MANAGER  正常にコールが有効なwolfssl_cert_managerポインタを返します。
+    \return NULL  エラー状態に戻ります。
+    _Example_
+    \code
+    #import <wolfssl/ssl.h>
+
+    WOLFSSL_CERT_MANAGER* cm;
+    cm = wolfSSL_CertManagerNew();
+    if (cm == NULL) {
+	// error creating new cert manager
+    }
+    \endcode
+    \sa wolfSSL_CertManagerFree
+*/
+WOLFSSL_CERT_MANAGER* wolfSSL_CertManagerNew(void);
+
+/*!
+    \ingroup CertManager 
+    \brief  証明書マネージャのコンテキストに関連付けられているすべてのリソースを解放します。証明書マネージャを使用する必要がなくなるときにこれを呼び出します。
+    \return none 
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_CERT_MANAGER* cm;
+    ...
+    wolfSSL_CertManagerFree(cm);
+    \endcode
+    \sa wolfSSL_CertManagerNew
+*/
+void wolfSSL_CertManagerFree(WOLFSSL_CERT_MANAGER*);
+
+/*!
+    \ingroup CertManager 
+    \brief  ManagerコンテキストへのCA証明書のロードの場所を指定します。PEM証明書カフェイルには、複数の信頼できるCA証明書が含まれている可能性があります。capathがnullでない場合、PEM形式のCA証明書を含むディレクトリを指定します。
+    \return SSL_SUCCESS  成功した場合、通話が戻ります。
+    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合は返されます。
+    \return SSL_BAD_FILE  ファイルが存在しない場合は返されます。読み込め、または破損していません。
+    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
+    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
+    \return BAD_FUNC_ARG  ポインタが提供されていない場合に返されるエラーです。
+    \return SSL_FATAL_ERROR   - 失敗時に返されます。
+    \param cm  wolfssl_certmanagernew（）を使用して作成されたwolfssl_cert_manager構造体へのポインタ。
+    \param file  ロードするCA証明書を含むファイルの名前へのポインタ。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    int ret = 0;
+    WOLFSSL_CERT_MANAGER* cm;
+    ...
+    ret = wolfSSL_CertManagerLoadCA(cm, “path/to/cert-file.pem”, 0);
+    if (ret != SSL_SUCCESS) {
+	// error loading CA certs into cert manager
+    }
+    \endcode
+    \sa wolfSSL_CertManagerVerify
+*/
+int wolfSSL_CertManagerLoadCA(WOLFSSL_CERT_MANAGER* cm, const char* f,
+                                                                 const char* d);
+
+/*!
+    \ingroup CertManager 
+    \brief  wolfssl_ctx_load_verify_bufferを呼び出して、関数に渡されたCM内の情報を失うことなく一時的なCMを使用してその結果を返すことによってCAバッファをロードします。
+    \return SSL_FATAL_ERROR  wolfssl_cert_manager構造体がNULLの場合、またはwolfssl_ctx_new（）がNULLを返す場合に返されます。
+    \return SSL_SUCCESS  実行が成功するために返されます。
+    \param cm  wolfssl_certmanagernew（）を使用して作成されたwolfssl_cert_manager構造体へのポインタ。
+    \param in  CERT情報用のバッファー。
+    \param sz  バッファの長さ。
+    _Example_
+    \code
+    WOLFSSL_CERT_MANAGER* cm = (WOLFSSL_CERT_MANAGER*)vp;
+    …
+    const unsigned char* in;
+    long sz;
+    int format;
+    …
+    if(wolfSSL_CertManagerLoadCABuffer(vp, sz, format) != SSL_SUCCESS){
+	    Error returned. Failure case code block.
+    }
+    \endcode
+    \sa wolfSSL_CTX_load_verify_buffer
+    \sa ProcessChainBuffer
+    \sa ProcessBuffer
+    \sa cm_pick_method
+*/
+int wolfSSL_CertManagerLoadCABuffer(WOLFSSL_CERT_MANAGER* cm,
+                                  const unsigned char* in, long sz, int format);
+
+/*!
+    \ingroup CertManager 
+    \brief  この関数はCA署名者リストをアンロードします。
+    \return SSL_SUCCESS  機能の実行に成功したことに戻ります。
+    \return BAD_FUNC_ARG  wolfssl_cert_managerがnullの場合に返されます。
+    \return BAD_MUTEX_E  ミューテックスエラーが発生した場合は返されます。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new(protocol method);
+    WOLFSSL_CERT_MANAGER* cm = wolfSSL_CertManagerNew();
+    ...
+    if(wolfSSL_CertManagerUnloadCAs(ctx->cm) != SSL_SUCCESS){
+    	Failure case.
+    }
+    \endcode
+    \sa FreeSignerTable
+    \sa UnlockMutex
+*/
+int wolfSSL_CertManagerUnloadCAs(WOLFSSL_CERT_MANAGER* cm);
+
+/*!
+    \ingroup CertManager 
+    \brief  関数は信頼できるピアリンクリストを解放し、信頼できるピアリストのロックを解除します。
+    \return SSL_SUCCESS  関数が正常に完了した場合
+    \return BAD_FUNC_ARG  wolfssl_cert_managerがnullの場合
+    \return BAD_MUTEX_E  ミューテックスエラーTPLOCKでは、WOLFSSL_CERT_MANAGER構造体のメンバーは0（ニル）です。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_CTX* ctx = WOLFSSL_CTX_new(Protocol define);
+    WOLFSSL_CERT_MANAGER* cm = wolfSSL_CertManagerNew();
+    ...
+    if(wolfSSL_CertManagerUnload_trust_peers(cm) != SSL_SUCCESS){
+	    The function did not execute successfully.
+    }
+    \endcode
+    \sa UnLockMutex
+*/
+int wolfSSL_CertManagerUnload_trust_peers(WOLFSSL_CERT_MANAGER* cm);
+
+/*!
+    \ingroup CertManager 
+    \brief  証明書マネージャのコンテキストで確認する証明書を指定します。フォーマットはSSL_FILETYPE_PEMまたはSSL_FILETYPE_ASN1にすることができます。
+    \return SSL_SUCCESS  成功した場合
+    \return ASN_SIG_CONFIRM_E  署名が検証できなかった場合に返されます。
+    \return ASN_SIG_OID_E  署名の種類がサポートされていない場合は返されます。
+    \return CRL_CERT_REVOKED  この証明書が取り消された場合に返されるエラーです。
+    \return CRL_MISSING  現在の発行者CRLが利用できない場合に返されるエラーです。
+    \return ASN_BEFORE_DATE_E  現在の日付が前日の前にある場合は返されます。
+    \return ASN_AFTER_DATE_E  現在の日付が後の日付の後の場合は返されます。
+    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合は返されます。
+    \return SSL_BAD_FILE  ファイルが存在しない場合は返されます。読み込め、または破損していません。
+    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
+    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
+    \return BAD_FUNC_ARG  ポインタが提供されていない場合に返されるエラーです。
+    \param cm  wolfssl_certmanagernew（）を使用して作成されたwolfssl_cert_manager構造体へのポインタ。
+    \param fname  検証する証明書を含むファイルの名前へのポインタ。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL_CERT_MANAGER* cm;
+    ...
+
+    ret = wolfSSL_CertManagerVerify(cm, “path/to/cert-file.pem”,
+    SSL_FILETYPE_PEM);
+    if (ret != SSL_SUCCESS) {
+	    error verifying certificate
+    }
+    \endcode
+    \sa wolfSSL_CertManagerLoadCA
+    \sa wolfSSL_CertManagerVerifyBuffer
+*/
+int wolfSSL_CertManagerVerify(WOLFSSL_CERT_MANAGER* cm, const char* f,
+                                                                    int format);
+
+/*!
+    \ingroup CertManager 
+    \brief  証明書マネージャのコンテキストを使用して確認する証明書バッファを指定します。フォーマットはSSL_FILETYPE_PEMまたはSSL_FILETYPE_ASN1にすることができます。
+    \return SSL_SUCCESS  成功した場合
+    \return ASN_SIG_CONFIRM_E  署名が検証できなかった場合に返されます。
+    \return ASN_SIG_OID_E  署名の種類がサポートされていない場合は返されます。
+    \return CRL_CERT_REVOKED  この証明書が取り消された場合に返されるエラーです。
+    \return CRL_MISSING  現在の発行者CRLが利用できない場合に返されるエラーです。
+    \return ASN_BEFORE_DATE_E  現在の日付が前日の前にある場合は返されます。
+    \return ASN_AFTER_DATE_E  現在の日付が後の日付の後の場合は返されます。
+    \return SSL_BAD_FILETYPE  ファイルが間違った形式である場合は返されます。
+    \return SSL_BAD_FILE  ファイルが存在しない場合は返されます。読み込め、または破損していません。
+    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
+    \return ASN_INPUT_E  base16デコードがファイルに対して失敗した場合に返されます。
+    \return BAD_FUNC_ARG  ポインタが提供されていない場合に返されるエラーです。
+    \param cm  wolfssl_certmanagernew（）を使用して作成されたwolfssl_cert_manager構造体へのポインタ。
+    \param buff  検証する証明書を含むバッファ。
+    \param sz  バッファのサイズ、BUF。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    int ret = 0;
+    int sz = 0;
+    WOLFSSL_CERT_MANAGER* cm;
+    byte certBuff[...];
+    ...
+
+    ret = wolfSSL_CertManagerVerifyBuffer(cm, certBuff, sz, SSL_FILETYPE_PEM);
+    if (ret != SSL_SUCCESS) {
+    	error verifying certificate
+    }
+
+    \endcode
+    \sa wolfSSL_CertManagerLoadCA
+    \sa wolfSSL_CertManagerVerify
+*/
+int wolfSSL_CertManagerVerifyBuffer(WOLFSSL_CERT_MANAGER* cm,
+                                const unsigned char* buff, long sz, int format);
+
+/*!
+    \ingroup CertManager 
+    \brief  この関数は、証明書マネージャーのverifyCallback関数を設定します。存在する場合、それはロードされた各CERTに対して呼び出されます。検証エラーがある場合は、検証コールバックを使用してエラーを過度に乗り越えます。
+    \return none  返品不可。
+    \param cm  wolfssl_certmanagernew（）を使用して作成されたwolfssl_cert_manager構造体へのポインタ。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
+    { // do custom verification of certificate }
+
+    WOLFSSL_CTX* ctx = WOLFSSL_CTX_new(Protocol define);
+    WOLFSSL_CERT_MANAGER* cm = wolfSSL_CertManagerNew();
+    ...
+    wolfSSL_CertManagerSetVerify(cm, myVerify);
+
+    \endcode
+    \sa wolfSSL_CertManagerVerify
+*/
+void wolfSSL_CertManagerSetVerify(WOLFSSL_CERT_MANAGER* cm,
+                                                             VerifyCallback vc);
+
+/*!
+    \brief  CRLリスト。
+    \return SSL_SUCCESS  関数が予想どおりに返された場合は返します。wolfssl_cert_manager構造体のCRLENABLEDメンバーがオンになっている場合。
+    \return MEMORY_E  割り当てられたメモリが失敗した場合は返します。
+    \return BAD_FUNC_ARG  wolfssl_cert_managerがnullの場合
+    \param cm  wolfssl_cert_manager構造体へのポインタ。
+    \param der  DERフォーマット証明書へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CERT_MANAGER* cm;
+    byte* der;
+    int sz; // size of der
+    ...
+    if(wolfSSL_CertManagerCheckCRL(cm, der, sz) != SSL_SUCCESS){
+    	// Error returned. Deal with failure case.
+    }
+    \endcode
+    \sa CheckCertCRL
+    \sa ParseCertRelative
+    \sa wolfSSL_CertManagerSetCRL_CB
+    \sa InitDecodedCert
+*/
+int wolfSSL_CertManagerCheckCRL(WOLFSSL_CERT_MANAGER* cm,
+                                unsigned char* der, int sz);
+
+/*!
+    \ingroup CertManager 
+    \brief  証明書マネージャを使用して証明書を検証するときに証明書失効リストの確認をオンにします。デフォルトでは、CRLチェックはオフです。オプションには、wolfssl_crl_checkallが含まれます。これは、チェーン内の各証明書に対してCRL検査を実行します。これはデフォルトであるリーフ証明書のみです。
+    \return SSL_SUCCESS  成功した場合、通話が戻ります。
+    \return NOT_COMPILED_IN  WolfSSLがCRLを有効にして構築されていない場合は返されます。
+    \return MEMORY_E  メモリ不足状態が発生した場合に返されます。
+    \return BAD_FUNC_ARG  ポインタが提供されていない場合に返されるエラーです。
+    \return SSL_FAILURE  CRLコンテキストを正しく初期化できない場合は返されます。
+    \param cm  wolfssl_certmanagernew（）を使用して作成されたwolfssl_cert_manager構造体へのポインタ。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    int ret = 0;
+    WOLFSSL_CERT_MANAGER* cm;
+    ...
+
+    ret = wolfSSL_CertManagerEnableCRL(cm, 0);
+    if (ret != SSL_SUCCESS) {
+    	error enabling cert manager
+    }
+
+    ...
+    \endcode
+    \sa wolfSSL_CertManagerDisableCRL
+*/
+int wolfSSL_CertManagerEnableCRL(WOLFSSL_CERT_MANAGER* cm,
+                                                                   int options);
+
+/*!
+    \ingroup CertManager 
+    \brief  証明書マネージャを使用して証明書を検証するときに証明書失効リストの確認をオフにします。デフォルトでは、CRLチェックはオフです。この関数を使用して、このCertificate Managerコンテキストを使用してCRL検査を一時的または恒久的に無効にして、以前はCRL検査が有効になっていました。
+    \return SSL_SUCCESS  成功した場合、通話が戻ります。
+    \return BAD_FUNC_ARG  関数ポインタが提供されていない場合に返されるエラーです。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    int ret = 0;
+    WOLFSSL_CERT_MANAGER* cm;
+    ...
+    ret = wolfSSL_CertManagerDisableCRL(cm);
+    if (ret != SSL_SUCCESS) {
+    	error disabling cert manager
+    }
+    ...
+    \endcode
+    \sa wolfSSL_CertManagerEnableCRL
+*/
+int wolfSSL_CertManagerDisableCRL(WOLFSSL_CERT_MANAGER*);
+
+/*!
+    \ingroup CertManager 
+    \brief  失効確認のためにCERTをCRLにロードするために、CERTをCRLにロードするために、ROADCRL（）へのエラーがチェックされ、渡されます。
+    \return SSL_SUCCESS  wolfssl_certmanagerLoadcrlにエラーがない場合、およびloadcrlが正常に戻る場合。
+    \return BAD_FUNC_ARG  wolfssl_cert_manager構造体がnullの場合
+    \return SSL_FATAL_ERROR  wolfssl_certmanagerEnableCRLがSSL_SUCCESS以外のものを返す場合。
+    \return BAD_PATH_ERROR  パスがNULLの場合
+    \return MEMORY_E  LOADCRLがヒープメモリの割り当てに失敗した場合。
+    \param cm  wolfssl_certmanagernew（）を使用して作成されたwolfssl_cert_manager構造体へのポインタ。
+    \param path  CRL経路を保持している一定のチャールポインタ。
+    \param type  ロードする証明書の種類。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    int wolfSSL_LoadCRL(WOLFSSL* ssl, const char* path, int type,
+    int monitor);
+    …
+    wolfSSL_CertManagerLoadCRL(SSL_CM(ssl), path, type, monitor);
+    \endcode
+    \sa wolfSSL_CertManagerEnableCRL
+    \sa wolfSSL_LoadCRL
+*/
+int wolfSSL_CertManagerLoadCRL(WOLFSSL_CERT_MANAGER* cm,
+                               const char* path, int type, int monitor);
+
+/*!
+    \ingroup CertManager 
+    \brief  この関数は、BufferLoadCRLを呼び出すことによってCRLファイルをロードします。
+    \return SSL_SUCCESS  関数がエラーなしで完了した場合に返されます。
+    \return BAD_FUNC_ARG  wolfssl_cert_managerがnullの場合に返されます。
+    \return SSL_FATAL_ERROR  wolfssl_cert_managerに関連付けられているエラーがある場合は返されます。
+    \param cm  wolfssl_cert_manager構造体へのポインタ。
+    \param buff  定数バイトタイプとバッファです。
+    \param sz  バッファのサイズを表す長いint。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_CERT_MANAGER* cm;
+    const unsigned char* buff;
+    long sz; size of buffer
+    int type;  cert type
+    ...
+    int ret = wolfSSL_CertManagerLoadCRLBuffer(cm, buff, sz, type);
+    if(ret == SSL_SUCCESS){
+	return ret;
+    } else {
+    	Failure case.
+    }
+    \endcode
+    \sa BufferLoadCRL
+    \sa wolfSSL_CertManagerEnableCRL
+*/
+int wolfSSL_CertManagerLoadCRLBuffer(WOLFSSL_CERT_MANAGER* cm,
+                                     const unsigned char* buff, long sz,
+                                     int type);
+
+/*!
+    \ingroup CertManager 
+    \brief  この関数はCRL証明書マネージャコールバックを設定します。LABE_CRLが定義されていて一致するCRLレコードが見つからない場合、CBMissingCRLは呼び出されます（WolfSSL_CertManagerSetCRL_CBを介して設定）。これにより、CRLを外部に検索してロードすることができます。
+    \return SSL_SUCCESS  関数とサブルーチンの実行が成功したら返されます。
+    \return BAD_FUNC_ARG  wolfssl_cert_manager構造体がNULLの場合に返されます。
+    \param cm  証明書の情報を保持しているWOLFSSL_CERT_MANAGER構造。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new(protocol method);
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    …
+    void cb(const char* url){
+	    Function body.
+    }
+    …
+    CbMissingCRL cb = CbMissingCRL;
+    …
+    if(ctx){
+        return wolfSSL_CertManagerSetCRL_Cb(SSL_CM(ssl), cb);
+    }
+    \endcode
+    \sa CbMissingCRL
+    \sa wolfSSL_SetCRL_Cb
+*/
+int wolfSSL_CertManagerSetCRL_Cb(WOLFSSL_CERT_MANAGER* cm,
+                                 CbMissingCRL cb);
+
+/*!
+    \ingroup CertManager 
+    \brief  この機能により、OCSPENABLED OCSPENABLEDがOCSPチェックオプションが有効になっていることを意味します。
+    \return SSL_SUCCESS  機能の実行に成功したことに戻ります。wolfssl_cert_managerのOCSPENABLEDメンバーが有効になっています。
+    \return BAD_FUNC_ARG  wolfssl_cert_manager構造体がnullの場合、または許可されていない引数値がサブルーチンに渡された場合に返されます。
+    \return MEMORY_E  この関数内にメモリを割り当てるエラーまたはサブルーチンがある場合に返されます。
+    \param cm  wolfssl_certmanagernew（）を使用して作成されたwolfssl_cert_manager構造体へのポインタ。
+    \param der  証明書へのバイトポインタ。
+    _Example_
+    \code
+    #import <wolfssl/ssl.h>
+
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    byte* der;
+    int sz; size of der
+    ...
+    if(wolfSSL_CertManagerCheckOCSP(cm, der, sz) != SSL_SUCCESS){
+	 Failure case.
+    }
+    \endcode
+    \sa ParseCertRelative
+    \sa CheckCertOCSP
+*/
+int wolfSSL_CertManagerCheckOCSP(WOLFSSL_CERT_MANAGER* cm,
+                                 unsigned char* der, int sz);
+
+/*!
+    \ingroup CertManager 
+    \brief  OCSPがオフになっている場合はOCSPをオンにし、[設定]オプションを使用可能になっている場合。
+    \return SSL_SUCCESS  関数呼び出しが成功した場合に返されます。
+    \return BAD_FUNC_ARG  cm構造体がnullの場合
+    \return MEMORY_E  wolfssl_ocsp struct値がnullの場合
+    \return SSL_FAILURE  WOLFSSL_OCSP構造体の初期化は初期化に失敗します。
+    \return NOT_COMPILED_IN  正しい機能を有効にしてコンパイルされていないビルド。
+    \param cm  wolfssl_certmanagernew（）を使用して作成されたwolfssl_cert_manager構造体へのポインタ。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new(protocol method);
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    WOLFSSL_CERT_MANAGER* cm = wolfSSL_CertManagerNew();
+    int options;
+    …
+    if(wolfSSL_CertManagerEnableOCSP(SSL_CM(ssl), options) != SSL_SUCCESS){
+	    Failure case.
+    }
+    \endcode
+    \sa wolfSSL_CertManagerNew
+*/
+int wolfSSL_CertManagerEnableOCSP(WOLFSSL_CERT_MANAGER* cm,
+                                                                   int options);
+
+/*!
+    \ingroup CertManager 
+    \brief  OCSP証明書の失効を無効にします。
+    \return SSL_SUCCESS  WolfSSL_CertMangerDisableCRLは、WolfSSL_CERT_MANAGER構造体のCRLEnabledメンバを無効にしました。
+    \return BAD_FUNC_ARG  WOLFSSL構造はヌルでした。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new(method);
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    ...
+    if(wolfSSL_CertManagerDisableOCSP(ssl) != SSL_SUCCESS){
+	    Fail case.
+    }
+    \endcode
+    \sa wolfSSL_DisableCRL
+*/
+int wolfSSL_CertManagerDisableOCSP(WOLFSSL_CERT_MANAGER*);
+
+/*!
+    \ingroup CertManager 
+    \brief  この関数は、URLをwolfssl_cert_manager構造体のOCSpoverrideURLメンバーにコピーします。
+    \return SSL_SUCCESS  この機能は期待どおりに実行できました。
+    \return BAD_FUNC_ARG  wolfssl_cert_manager構造体はnullです。
+    \return MEMEORY_E  証明書マネージャのOCSPoverRideURLメンバーにメモリを割り当てることができませんでした。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+    WOLFSSL_CERT_MANAGER* cm = wolfSSL_CertManagerNew();
+    const char* url;
+    …
+    int wolfSSL_SetOCSP_OverrideURL(WOLFSSL* ssl, const char* url)
+    …
+    if(wolfSSL_CertManagerSetOCSPOverrideURL(SSL_CM(ssl), url) != SSL_SUCCESS){
+	    Failure case.
+    }
+    \endcode
+    \sa ocspOverrideURL
+    \sa wolfSSL_SetOCSP_OverrideURL
+*/
+int wolfSSL_CertManagerSetOCSPOverrideURL(WOLFSSL_CERT_MANAGER* cm,
+                                          const char* url);
+
+/*!
+    \ingroup CertManager 
+    \brief  この関数は、wolfssl_cert_managerのOCSPコールバックを設定します。
+    \return SSL_SUCCESS  実行に成功したことに戻ります。引数はwolfssl_cert_manager構造体に保存されます。
+    \return BAD_FUNC_ARG  wolfssl_cert_managerがnullの場合に返されます。
+    \param cm  wolfssl_cert_manager構造体へのポインタ。
+    \param ioCb  CBocSpio型の関数ポインタ。
+    \param respFreeCb   -  CBOCSPRESPFREAS型の関数ポインタ。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    wolfSSL_SetOCSP_Cb(WOLFSSL* ssl, CbOCSPIO ioCb,
+    CbOCSPRespFree respFreeCb, void* ioCbCtx){
+    …
+    return wolfSSL_CertManagerSetOCSP_Cb(SSL_CM(ssl), ioCb, respFreeCb, ioCbCtx);
+    \endcode
+    \sa wolfSSL_CertManagerSetOCSPOverrideURL
+    \sa wolfSSL_CertManagerCheckOCSP
+    \sa wolfSSL_CertManagerEnableOCSPStapling
+    \sa wolfSSL_ENableOCSP
+    \sa wolfSSL_DisableOCSP
+    \sa wolfSSL_SetOCSP_Cb
+*/
+int wolfSSL_CertManagerSetOCSP_Cb(WOLFSSL_CERT_MANAGER* cm,
+                                  CbOCSPIO ioCb, CbOCSPRespFree respFreeCb,
+                                  void* ioCbCtx);
+
+/*!
+    \ingroup CertManager 
+    \brief  この関数は、オプションをオンにしないとOCSPステープルをオンにします。オプションを設定します。
+    \return SSL_SUCCESS  エラーがなく、関数が正常に実行された場合に返されます。
+    \return BAD_FUNC_ARG  wolfssl_cert_manager構造体がNULLまたはそうでない場合は、サブルーチンに渡された未解決の引数値があった場合に返されます。
+    \return MEMORY_E  メモリ割り当てがある問題が発生した場合は返されます。
+    \return SSL_FAILURE  OCSP構造体の初期化が失敗した場合に返されます。
+    \return NOT_COMPILED_IN  wolfsslがhaber_certificate_status_requestオプションでコンパイルされていない場合に返されます。
+    _Example_
+    \code
+    int wolfSSL_CTX_EnableOCSPStapling(WOLFSSL_CTX* ctx){
+    …
+    return wolfSSL_CertManagerEnableOCSPStapling(ctx->cm);
+    \endcode
+    \sa wolfSSL_CTX_EnableOCSPStapling
+*/
+int wolfSSL_CertManagerEnableOCSPStapling(
+                                                      WOLFSSL_CERT_MANAGER* cm);
+
+/*!
+    \brief  
+    \return SSL_SUCCESS  関数とサブルーチンはエラーなしで返されました。
+    \return BAD_FUNC_ARG  WolfSSL構造がNULLの場合に返されます。
+    \return MEMORY_E  メモリの割り当てが失敗した場合に返されます。
+    \return SSL_FAILURE  initcrl関数が正常に戻されない場合に返されます。
+    \return NOT_COMPILED_IN  have_crlはコンパイル中に有効になっていませんでした。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    …
+    if (wolfSSL_EnableCRL(ssl, WOLFSSL_CRL_CHECKALL) != SSL_SUCCESS){
+	    // Failure case. SSL_SUCCESS was not returned by this function or
+    a subroutine
+    }
+    \endcode
+    \sa wolfSSL_CertManagerEnableCRL
+    \sa InitCRL
+*/
+int wolfSSL_EnableCRL(WOLFSSL* ssl, int options);
+
+/*!
+    \brief  
+    \return SSL_SUCCESS  WolfSSL_CertMangerDisableCRLは、WolfSSL_CERT_MANAGER構造体のCRLEnabledメンバを無効にしました。
+    \return BAD_FUNC_ARG  WOLFSSL構造はヌルでした。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    ...
+    if(wolfSSL_DisableCRL(ssl) != SSL_SUCCESS){
+    	// Failure case
+    }
+    \endcode
+    \sa wolfSSL_CertManagerDisableCRL
+    \sa wolfSSL_CertManagerDisableOCSP
+*/
+int wolfSSL_DisableCRL(WOLFSSL* ssl);
+
+/*!
+    \brief  失効検査の証明書
+    \return WOLFSSL_SUCCESS  関数とすべてのサブルーチンがエラーなしで実行された場合に返されます。
+    \return SSL_FATAL_ERROR  サブルーチンの1つが正常に戻されない場合に返されます。
+    \return BAD_FUNC_ARG  wolfssl_cert_managerまたはwolfssl構造がnullの場合
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param path  CRLファイルへのパスを保持する定数文字ポインタ。
+    \param type  証明書の種類を表す整数。
+    _Example_
+    \code
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    const char* crlPemDir;
+    …
+    if(wolfSSL_LoadCRL(ssl, crlPemDir, SSL_FILETYPE_PEM, 0) != SSL_SUCCESS){
+    	// Failure case. Did not return SSL_SUCCESS.
+    }
+    \endcode
+    \sa wolfSSL_CertManagerLoadCRL
+    \sa wolfSSL_CertManagerEnableCRL
+    \sa LoadCRL
+*/
+int wolfSSL_LoadCRL(WOLFSSL* ssl, const char* path, int type, int monitor);
+
+/*!
+    \brief  
+    \return SSL_SUCCESS  関数またはサブルーチンがエラーなしで実行された場合に返されます。wolfssl_cert_managerのCBMissingCRLメンバーが設定されています。
+    \return BAD_FUNC_ARG  WOLFSSLまたはWOLFSSL_CERT_MANAGER構造体がNULLの場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    …
+    void cb(const char* url) // required signature
+    {
+    	// Function body
+    }
+    …
+    int crlCb = wolfSSL_SetCRL_Cb(ssl, cb);
+    if(crlCb != SSL_SUCCESS){
+    	// The callback was not set properly
+    }
+    \endcode
+    \sa CbMissingCRL
+    \sa wolfSSL_CertManagerSetCRL_Cb
+*/
+int wolfSSL_SetCRL_Cb(WOLFSSL* ssl, CbMissingCRL cb);
+
+/*!
+    \brief  
+    \return SSL_SUCCESS  関数とサブルーチンがエラーなしで実行された場合に返されます。
+    \return BAD_FUNC_ARG  この関数またはサブルーチンの引数が無効な引数値を受信した場合に返されます。
+    \return MEMORY_E  構造体やその他の変数にメモリを割り当てるエラーが発生した場合は返されます。
+    \return NOT_COMPILED_IN  wolfsslがhane_ocspオプションでコンパイルされていない場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    int options; // initialize to option constant
+    …
+    int ret = wolfSSL_EnableOCSP(ssl, options);
+    if(ret != SSL_SUCCESS){
+    	// OCSP is not enabled
+    }
+    \endcode
+    \sa wolfSSL_CertManagerEnableOCSP
+*/
+int wolfSSL_EnableOCSP(WOLFSSL* ssl, int options);
+
+/*!
+    \brief  
+    \return SSL_SUCCESS  関数とそのサブルーチンがエラーなしで戻った場合に返されます。wolfssl_cert_manager構造体のOCSPENABLEDメンバーは正常に設定されました。
+    \return BAD_FUNC_ARG  WolfSSL構造がNULLの場合に返されます。
+    _Example_
+    \code
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    …
+    if(wolfSSL_DisableOCSP(ssl) != SSL_SUCCESS){
+	    // Returned with an error. Failure case in this block.
+    }
+    \endcode
+    \sa wolfSSL_CertManagerDisableOCSP
+*/
+int wolfSSL_DisableOCSP(WOLFSSL*);
+
+/*!
+    \brief  wolfssl_cert_manager構造体。
+    \return SSL_SUCCESS  機能の実行に成功したことに戻ります。
+    \return BAD_FUNC_ARG  wolfssl構造体がnullの場合、または未解決の引数がサブルーチンに渡された場合に返されます。
+    \return MEMORY_E  サブルーチンにメモリを割り当てるエラーが発生した場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    char url[URLSZ];
+    ...
+    if(wolfSSL_SetOCSP_OverrideURL(ssl, url)){
+    	// The override url is set to the new value
+    }
+    \endcode
+    \sa wolfSSL_CertManagerSetOCSPOverrideURL
+*/
+int wolfSSL_SetOCSP_OverrideURL(WOLFSSL* ssl, const char* url);
+
+/*!
+    \brief  wolfssl_cert_manager構造体。
+    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。CMのOCSPIOCB、OCSPRESPFREECB、およびOCSPIOCTXメンバーが設定されています。
+    \return BAD_FUNC_ARG  WOLFSSLまたはWOLFSSL_CERT_MANAGER構造がNULLの場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param ioCb  CBocSpioを入力するための関数ポインタ。
+    \param respFreeCb  応答メモリを解放するための呼び出しであるCBocSpreSpFreeを入力するための関数ポインタ。
+    _Example_
+    \code
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    …
+    int OCSPIO_CB(void* , const char*, int , unsigned char* , int,
+    unsigned char**){  // must have this signature
+    // Function Body
+    }
+    …
+    void OCSPRespFree_CB(void* , unsigned char* ){ // must have this signature
+    	// function body
+    }
+    …
+    void* ioCbCtx;
+    CbOCSPRespFree CB_OCSPRespFree;
+
+    if(wolfSSL_SetOCSP_Cb(ssl, OCSPIO_CB( pass args ), CB_OCSPRespFree,
+				ioCbCtx) != SSL_SUCCESS){
+	    // Callback not set
+    }
+    \endcode
+    \sa wolfSSL_CertManagerSetOCSP_Cb
+    \sa CbOCSPIO
+    \sa CbOCSPRespFree
+*/
+int wolfSSL_SetOCSP_Cb(WOLFSSL* ssl, CbOCSPIO ioCb, CbOCSPRespFree respFreeCb,
+                       void* ioCbCtx);
+
+/*!
+    \brief  
+    \return SSL_SUCCESS  この関数とそれがサブルーチンの場合はエラーなしで実行されます。
+    \return BAD_FUNC_ARG  CTX構造体がNULLの場合、またはその他の点ではサブルーチンに無効な引数があった場合に返されます。
+    \return MEMORY_E  関数の実行中にメモリの割り当てエラーが発生した場合に返されます。
+    \return SSL_FAILURE  wolfssl_cert_managerのCRLメンバーが正しく初期化されなかった場合に返されます。
+    \return NOT_COMPILED_IN  wolfsslはhane_crlオプションでコンパイルされませんでした。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    ...
+    if(wolfSSL_CTX_EnableCRL(ssl->ctx, options) != SSL_SUCCESS){
+    	// The function failed
+    }
+    \endcode
+    \sa wolfSSL_CertManagerEnableCRL
+    \sa InitCRL
+    \sa wolfSSL_CTX_DisableCRL
+*/
+int wolfSSL_CTX_EnableCRL(WOLFSSL_CTX* ctx, int options);
+
+/*!
+    \brief  
+    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。wolfssl_cert_manager構造体のCRLEnabledメンバーは0に設定されています。
+    \return BAD_FUNC_ARG  CTX構造体またはCM構造体にNULL値がある場合に返されます。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    ...
+    if(wolfSSL_CTX_DisableCRL(ssl->ctx) != SSL_SUCCESS){
+    	// Failure case.
+    }
+    \endcode
+    \sa wolfSSL_CertManagerDisableCRL
+*/
+int wolfSSL_CTX_DisableCRL(WOLFSSL_CTX* ctx);
+
+/*!
+    \brief  wolfssl_certmanagerLoadcr（）。
+    \return SSL_SUCCESS   - 関数とそのサブルーチンがエラーなしで実行された場合に返されます。
+    \return BAD_FUNC_ARG   - この関数またはサブルーチンがNULL構造に渡された場合に返されます。
+    \return BAD_PATH_ERROR   - パス変数がnullとして開くと戻ります。
+    \return MEMORY_E   - メモリの割り当てが失敗した場合に返されます。
+    \param ctx  wolfssl_ctx_new（）を使用して作成されたwolfssl_ctx構造へのポインタ。
+    \param path  証明書へのパス。
+    \param type  証明書の種類を保持する整数変数。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx;
+    const char* path;
+    …
+    return wolfSSL_CTX_LoadCRL(ctx, path, SSL_FILETYPE_PEM, 0);
+    \endcode
+    \sa wolfSSL_CertManagerLoadCRL
+    \sa LoadCRL
+*/
+int wolfSSL_CTX_LoadCRL(WOLFSSL_CTX* ctx, const char* path, int type, int monitor);
+
+/*!
+    \brief  wolfssl_certmanagersetCRL_CBを呼び出して、WolfSSL_CERT_MANAGER構造のメンバー。
+    \return SSL_SUCCESS  実行が成功するために返されました。WOLFSSL_CERT_MANAGER構造体のCBMSSINGCRLはCBに正常に設定されました。
+    \return BAD_FUNC_ARG  wolfssl_ctxまたはwolfssl_cert_managerがNULLの場合に返されます。
+    \param ctx  wolfssl_ctx_new（）で作成されたwolfssl_ctx構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    …
+    void cb(const char* url) // Required signature
+    {
+    	// Function body
+    }
+    …
+    if (wolfSSL_CTX_SetCRL_Cb(ctx, cb) != SSL_SUCCESS){
+    	// Failure case, cb was not set correctly.
+    }
+    \endcode
+    \sa wolfSSL_CertManagerSetCRL_Cb
+    \sa CbMissingCRL
+*/
+int wolfSSL_CTX_SetCRL_Cb(WOLFSSL_CTX* ctx, CbMissingCRL cb);
+
+/*!
+    \brief  wolfsslの機能オプションの値が1つ以上のオプションで構成されている場合は、次のオプションを1つ以上にします.wolfssl_ocsp_enable  -  OCSPルックアップを有効にするwolfssl_ocsp_url_override  - 証明書のURLの代わりにURLをオーバーライドします。オーバーライドURLは、wolfssl_ctx_setocsp_overrideURL（）関数を使用して指定されます。この関数は、wolfsslがOCSPサポート（--enable-ocsp、#define hane_ocsp）でコンパイルされたときにのみOCSPオプションを設定します。
+    \return SSL_SUCCESS  成功したときに返されます。
+    \return SSL_FAILURE  失敗したときに返されます。
+    \return NOT_COMPILED_IN  この関数が呼び出されたときに返されますが、wolfsslがコンパイルされたときにOCSPサポートは有効になっていませんでした。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = 0;
+    ...
+    wolfSSL_CTX_OCSP_set_options(ctx, WOLFSSL_OCSP_ENABLE);
+    \endcode
+    \sa wolfSSL_CTX_OCSP_set_override_url
+*/
+int wolfSSL_CTX_EnableOCSP(WOLFSSL_CTX* ctx, int options);
+
+/*!
+    \brief  wolfssl_cert_manager構造体のOCSPENABLEDメンバーに影響を与えます。
+    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。CMのOCSPENABLEDメンバーは無効になっています。
+    \return BAD_FUNC_ARG  wolfssl_ctx構造がnullの場合に返されます。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    ...
+    if(!wolfSSL_CTX_DisableOCSP(ssl->ctx)){
+    	// OCSP is not disabled
+    }
+    \endcode
+    \sa wolfSSL_DisableOCSP
+    \sa wolfSSL_CertManagerDisableOCSP
+*/
+int wolfSSL_CTX_DisableOCSP(WOLFSSL_CTX*);
+
+/*!
+    \brief  wolfssl_csp_url_overrideオプションがwolfssl_ctx_enableocspを使用して設定されていない限り、OCSPは個々の証明書にあるURLを使用します。
+    \return SSL_SUCCESS  成功したときに返されます。
+    \return SSL_FAILURE  失敗したときに返されます。
+    \return NOT_COMPILED_IN  この関数が呼び出されたときに返されますが、wolfsslがコンパイルされたときにOCSPサポートは有効になっていませんでした。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = 0;
+    ...
+    wolfSSL_CTX_OCSP_set_override_url(ctx, “custom-url-here”);
+    \endcode
+    \sa wolfSSL_CTX_OCSP_set_options
+*/
+int wolfSSL_CTX_SetOCSP_OverrideURL(WOLFSSL_CTX* ctx, const char* url);
+
+/*!
+    \brief  
+    \return SSL_SUCCESS  関数が正常に実行された場合に返されます。CM内のOCSPIOCB、OCSPRESPFREECB、およびOCSPIOCTXメンバーは正常に設定されました。
+    \return BAD_FUNC_ARG  wolfssl_ctxまたはwolfssl_cert_manager構造体がnullの場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param ioCb  関数ポインタであるCBocSpio型。
+    \param respFreeCb  関数ポインタであるCBocSprepSprepFree型。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    …
+    CbOCSPIO ocspIOCb;
+    CbOCSPRespFree ocspRespFreeCb;
+    …
+    void* ioCbCtx;
+
+    int isSetOCSP = wolfSSL_CTX_SetOCSP_Cb(ctx, ocspIOCb,
+    ocspRespFreeCb, ioCbCtx);
+
+    if(isSetOCSP != SSL_SUCCESS){
+    	// The function did not return successfully.
+    }
+    \endcode
+    \sa wolfSSL_CertManagerSetOCSP_Cb
+    \sa CbOCSPIO
+    \sa CbOCSPRespFree
+*/
+int wolfSSL_CTX_SetOCSP_Cb(WOLFSSL_CTX* ctx,
+                           CbOCSPIO ioCb, CbOCSPRespFree respFreeCb,
+                           void* ioCbCtx);
+
+/*!
+    \brief  wolfssl_certmanagerEnableOcspStapling（）。
+    \return SSL_SUCCESS  エラーがなく、関数が正常に実行された場合に返されます。
+    \return BAD_FUNC_ARG  wolfssl_ctx構造体がNULLまたはそうでない場合は、サブルーチンに渡された未解決の引数値があった場合に返されます。
+    \return MEMORY_E  メモリ割り当てがある問題が発生した場合は返されます。
+    \return SSL_FAILURE  OCSP構造体の初期化が失敗した場合に返されます。
+    \return NOT_COMPILED_IN  wolfsslがhaber_certificate_status_requestオプションでコンパイルされていない場合に返されます。
+    _Example_
+    \code
+    WOLFSSL* ssl = WOLFSSL_new();
+    ssl->method.version; // set to desired protocol
+    ...
+    if(!wolfSSL_CTX_EnableOCSPStapling(ssl->ctx)){
+    	// OCSP stapling is not enabled
+    }
+    \endcode
+    \sa wolfSSL_CertManagerEnableOCSPStapling
+    \sa InitOCSP
+*/
+int wolfSSL_CTX_EnableOCSPStapling(WOLFSSL_CTX*);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  通常、SSLハンドシェイクの最後に、WolfSSLは一時的なアレイを解放します。ハンドシェイクが始まる前にこの関数を呼び出すと、WolfSSLは一時的な配列を解放するのを防ぎます。Wolfssl_get_keys（）またはPSKのヒントなどのものには、一時的な配列が必要になる場合があります。ユーザが一時的な配列で行われると、wolfssl_freearray（）のいずれかが即座にリソースを解放することができ、あるいは、関連するSSLオブジェクトが解放されたときにリソースが解放されるようになる可能性がある。
+    \return none  返品不可。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    ...
+    wolfSSL_KeepArrays(ssl);
+    \endcode
+    \sa wolfSSL_FreeArrays
+*/
+void wolfSSL_KeepArrays(WOLFSSL*);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  通常、SSLハンドシェイクの最後に、WolfSSLは一時的なアレイを解放します。wolfssl_keeparrays（）がハンドシェイクの前に呼び出された場合、WolfSSLは一時的な配列を解放しません。この関数は一時的な配列を明示的に解放し、ユーザーが一時的な配列で行われたときに呼び出されるべきであり、SSLオブジェクトがこれらのリソースを解放するのを待ったくない。
+    \return none  返品不可。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    ...
+    wolfSSL_FreeArrays(ssl);
+    \endcode
+    \sa wolfSSL_KeepArrays
+*/
+void wolfSSL_FreeArrays(WOLFSSL*);
+
+/*!
+    \brief  'ssl'パラメータに渡されたオブジェクト。これは、WolfSSLクライアントによってSNI拡張機能がClientHelloで送信され、WolfSSL ServerはServerHello + SNIまたはSNIミスマッチの場合は致命的なAlert Hello + SNIを応答します。
+    \return WOLFSSL_SUCCESS  成功すると。
+    \return BAD_FUNC_ARG  次のいずれかの場合で返されるエラーです.SSLはNULL、データはNULL、タイプは不明な値です。（下記参照）
+    \return MEMORY_E  十分なメモリがないときにエラーが返されます。
+    \param ssl  wolfssl_new（）で作成されたSSLオブジェクトへのポインタ。
+    \param type  どの種類のサーバー名がデータに渡されたかを示します。既知の型は次のとおりです。enum {wolfssl_sni_host_name = 0};
+    \param data  サーバー名データへのポインタ。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL_CTX* ctx = 0;
+    WOLFSSL* ssl = 0;
+    ctx = wolfSSL_CTX_new(method);
+    if (ctx == NULL) {
+        // context creation failed
+    }
+    ssl = wolfSSL_new(ctx);
+    if (ssl == NULL) {
+        // ssl creation failed
+    }
+    ret = wolfSSL_UseSNI(ssl, WOLFSSL_SNI_HOST_NAME, "www.yassl.com",
+        strlen("www.yassl.com"));
+    if (ret != WOLFSSL_SUCCESS) {
+        // sni usage failed
+    }
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_CTX_UseSNI
+*/
+int wolfSSL_UseSNI(WOLFSSL* ssl, unsigned char type,
+                                         const void* data, unsigned short size);
+
+/*!
+    \brief  SSLコンテキストから作成されたオブジェクトは 'ctx'パラメータに渡されました。これは、WolfSSLクライアントによってSNI拡張機能がClientHelloで送信され、WolfSSLサーバーはServerHello + SNIまたはSNIの不一致の場合には致命的なALERT Hello + SNIを応答します。
+    \return WOLFSSL_SUCCESS  成功すると。
+    \return BAD_FUNC_ARG  次のいずれかの場合で返されるエラーです.CTXはNULL、データはNULL、タイプは不明な値です。（下記参照）
+    \return MEMORY_E  十分なメモリがないときにエラーが返されます。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    \param type  どの種類のサーバー名がデータに渡されたかを示します。既知の型は次のとおりです。enum {wolfssl_sni_host_name = 0};
+    \param data  サーバー名データへのポインタ。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL_CTX* ctx = 0;
+    ctx = wolfSSL_CTX_new(method);
+    if (ctx == NULL) {
+        // context creation failed
+    }
+    ret = wolfSSL_CTX_UseSNI(ctx, WOLFSSL_SNI_HOST_NAME, "www.yassl.com",
+        strlen("www.yassl.com"));
+    if (ret != WOLFSSL_SUCCESS) {
+        // sni usage failed
+    }
+    \endcode
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_UseSNI
+*/
+int wolfSSL_CTX_UseSNI(WOLFSSL_CTX* ctx, unsigned char type,
+                                         const void* data, unsigned short size);
+
+/*!
+    \brief  'ssl'パラメータに渡されたSSLオブジェクト内のサーバー名表示を使用したSSLセッションの動作。オプションを以下に説明します。
+    \return none  いいえ返します。
+    \param ssl  wolfssl_new（）で作成されたSSLオブジェクトへのポインタ。
+    \param type  どの種類のサーバー名がデータに渡されたかを示します。既知の型は次のとおりです。enum {wolfssl_sni_host_name = 0};
+    \param options  選択されたオプションを持つビット単位のセマフォ。利用可能なオプションは次のとおりです。enum {wolfssl_sni_continue_on_mismatch = 0x01、wolfssl_sni_answer_on_mismatch = 0x02};通常、サーバーは、クライアントによって提供されたホスト名がサーバーと表示されているホスト名がサーバーで提供されている場合、サーバーはhandshakeを中止します。
+    \param WOLFSSL_SNI_CONTINUE_ON_MISMATCH  このオプションを設定すると、サーバーはセッションを中止する代わりにSNI応答を送信しません。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL_CTX* ctx = 0;
+    WOLFSSL* ssl = 0;
+    ctx = wolfSSL_CTX_new(method);
+    if (ctx == NULL) {
+        // context creation failed
+    }
+    ssl = wolfSSL_new(ctx);
+    if (ssl == NULL) {
+        // ssl creation failed
+    }
+    ret = wolfSSL_UseSNI(ssl, 0, "www.yassl.com", strlen("www.yassl.com"));
+    if (ret != WOLFSSL_SUCCESS) {
+        // sni usage failed
+    }
+    wolfSSL_SNI_SetOptions(ssl, WOLFSSL_SNI_HOST_NAME,
+        WOLFSSL_SNI_CONTINUE_ON_MISMATCH);
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_UseSNI
+    \sa wolfSSL_CTX_SNI_SetOptions
+*/
+void wolfSSL_SNI_SetOptions(WOLFSSL* ssl, unsigned char type,
+                                                         unsigned char options);
+
+/*!
+    \brief  SSLセッションを使用したSSLオブジェクトのサーバ名指示を使用して、SSLコンテキストから作成されたSSLオブジェクトから作成されます。オプションを以下に説明します。
+    \return none  いいえ返します。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    \param type  どの種類のサーバー名がデータに渡されたかを示します。既知の型は次のとおりです。enum {wolfssl_sni_host_name = 0};
+    \param options  選択されたオプションを持つビット単位のセマフォ。利用可能なオプションは次のとおりです。enum {wolfssl_sni_continue_on_mismatch = 0x01、wolfssl_sni_answer_on_mismatch = 0x02};通常、サーバーは、クライアントによって提供されたホスト名がサーバーと表示されているホスト名がサーバーで提供されている場合、サーバーはhandshakeを中止します。
+    \param WOLFSSL_SNI_CONTINUE_ON_MISMATCH  このオプションを設定すると、サーバーはセッションを中止する代わりにSNI応答を送信しません。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL_CTX* ctx = 0;
+    ctx = wolfSSL_CTX_new(method);
+    if (ctx == NULL) {
+       // context creation failed
+    }
+    ret = wolfSSL_CTX_UseSNI(ctx, 0, "www.yassl.com", strlen("www.yassl.com"));
+    if (ret != WOLFSSL_SUCCESS) {
+        // sni usage failed
+    }
+    wolfSSL_CTX_SNI_SetOptions(ctx, WOLFSSL_SNI_HOST_NAME,
+    WOLFSSL_SNI_CONTINUE_ON_MISMATCH);
+    \endcode
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_CTX_UseSNI
+    \sa wolfSSL_SNI_SetOptions
+*/
+void wolfSSL_CTX_SNI_SetOptions(WOLFSSL_CTX* ctx,
+                                     unsigned char type, unsigned char options);
+
+/*!
+    \brief  クライアントによってクライアントから提供された名前表示クライアントによって送信されたメッセージセッションを開始する。SNIを取得するためのコンテキストまたはセッション設定が必要ありません。
+    \return WOLFSSL_SUCCESS  成功すると。
+    \return BAD_FUNC_ARG  このケースで返されるエラーは、次のいずれかの場合で返されます。バッファはNULL、BUFFERSZ <= 0、SNIはNULL、INOUTSZはNULLまたは<= 0です。
+    \return BUFFER_ERROR  不正なクライアントhelloメッセージがあるときにエラーが返されます。
+    \return INCOMPLETE_DATA  抽出を完了するのに十分なデータがない場合に返されるエラーです。
+    \param buffer  クライアントから提供されたデータへのポインタ（クライアントhello）。
+    \param bufferSz  クライアントhelloメッセージのサイズ。
+    \param type  どの種類のサーバー名がバッファーから取得されているかを示します。既知の型は次のとおりです。enum {wolfssl_sni_host_name = 0};
+    \param sni  出力が保存される場所へのポインタ。
+    _Example_
+    \code
+    unsigned char buffer[1024] = {0};
+    unsigned char result[32]   = {0};
+    int           length       = 32;
+    // read Client Hello to buffer...
+    ret = wolfSSL_SNI_GetFromBuffer(buffer, sizeof(buffer), 0, result, &length));
+    if (ret != WOLFSSL_SUCCESS) {
+        // sni retrieve failed
+    }
+    \endcode
+    \sa wolfSSL_UseSNI
+    \sa wolfSSL_CTX_UseSNI
+    \sa wolfSSL_SNI_GetRequest
+*/
+int wolfSSL_SNI_GetFromBuffer(
+                 const unsigned char* clientHello, unsigned int helloSz,
+                 unsigned char type, unsigned char* sni, unsigned int* inOutSz);
+
+/*!
+    \ingroup IO 
+    \brief  この関数はSNIオブジェクトのステータスを取得します。
+    \return value  SNIがNULLでない場合、この関数はSNI構造体のステータスメンバーのバイト値を返します。
+    \return 0  SNIオブジェクトがNULLの場合
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    …
+    #define AssertIntEQ(x, y) AssertInt(x, y, ==, !=)
+    …
+    Byte type = WOLFSSL_SNI_HOST_NAME;
+    char* request = (char*)&type;
+    AssertIntEQ(WOLFSSL_SNI_NO_MATCH, wolfSSL_SNI_Status(ssl, type));
+    …
+    \endcode
+    \sa TLSX_SNI_Status
+    \sa TLSX_SNI_find
+    \sa TLSX_Find
+*/
+unsigned char wolfSSL_SNI_Status(WOLFSSL* ssl, unsigned char type);
+
+/*!
+    \brief  SSLセッションでクライアントによって提供されるサーバー名の表示。
+    \return size  提供されたSNIデータのサイズ。
+    \param ssl  wolfssl_new（）で作成されたSSLオブジェクトへのポインタ。
+    \param type  どの種類のサーバー名がデータ内で取得されているかを示します。既知の型は次のとおりです。enum {wolfssl_sni_host_name = 0};
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL_CTX* ctx = 0;
+    WOLFSSL* ssl = 0;
+    ctx = wolfSSL_CTX_new(method);
+    if (ctx == NULL) {
+        // context creation failed
+    }
+    ssl = wolfSSL_new(ctx);
+    if (ssl == NULL) {
+        // ssl creation failed
+    }
+    ret = wolfSSL_UseSNI(ssl, 0, "www.yassl.com", strlen("www.yassl.com"));
+    if (ret != WOLFSSL_SUCCESS) {
+        // sni usage failed
+    }
+    if (wolfSSL_accept(ssl) == SSL_SUCCESS) {
+        void *data = NULL;
+        unsigned short size = wolfSSL_SNI_GetRequest(ssl, 0, &data);
+    }
+    \endcode
+    \sa wolfSSL_UseSNI
+    \sa wolfSSL_CTX_UseSNI
+*/
+unsigned short wolfSSL_SNI_GetRequest(WOLFSSL *ssl,
+                                               unsigned char type, void** data);
+
+/*!
+    \ingroup Setup 
+    \brief  wolfsslセッションにALPNを設定します。
+    \return WOLFSSL_SUCCESS:  成功すると。
+    \return BAD_FUNC_ARG  SSLまたはPROTOCOL_NAME_LISTがNULLまたはPROTOCOL_NAME_LISTSZが大きすぎたり、オプションがサポートされていないものを含みます。
+    \return MEMORY_ERROR  プロトコルリストのメモリの割り当て中にエラーが発生しました。
+    \return SSL_FAILURE  失敗すると。
+    \param ssl  使用するWolfSSLセッション。
+    \param protocol_name_list  使用するプロトコル名のリスト。カンマ区切り文字列が必要です。
+    \param protocol_name_listSz  プロトコル名のリストのサイズ。
+    _Example_
+    \code
+    wolfSSL_Init();
+    WOLFSSL_CTX* ctx;
+    WOLFSSL* ssl;
+    WOLFSSL_METHOD method = // Some wolfSSL method
+    ctx = wolfSSL_CTX_new(method);
+    ssl = wolfSSL_new(ctx);
+
+    char alpn_list[] = {};
+
+    if (wolfSSL_UseALPN(ssl, alpn_list, sizeof(alpn_list),
+        WOLFSSL_APN_FAILED_ON_MISMATCH) != WOLFSSL_SUCCESS)
+    {
+       // Error setting session ticket
+    }
+    \endcode
+    \sa TLSX_UseALPN
+*/
+int wolfSSL_UseALPN(WOLFSSL* ssl, char *protocol_name_list,
+                                unsigned int protocol_name_listSz,
+                                unsigned char options);
+
+/*!
+    \ingroup TLS 
+    \brief  この関数は、サーバーによって設定されたプロトコル名を取得します。
+    \return SSL_SUCCESS  エラーが投げられていない正常な実行に戻りました。
+    \return SSL_FATAL_ERROR  拡張子が見つからなかった場合、またはピアとプロトコルが一致しなかった場合に返されます。2つ以上のプロトコル名が受け入れられている場合は、スローされたエラーもあります。
+    \return SSL_ALPN_NOT_FOUND  ピアとプロトコルの一致が見つからなかったことを示す返されました。
+    \return BAD_FUNC_ARG  関数に渡されたnull引数があった場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param protocol_name  プロトコル名を表すCHARへのポインタは、ALPN構造に保持されます。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = WOLFSSL_CTX_new( protocol method );
+    WOLFSSL* ssl = WOLFSSL_new(ctx);
+    ...
+    int err;
+    char* protocol_name = NULL;
+    Word16 protocol_nameSz = 0;
+    err = wolfSSL_ALPN_GetProtocol(ssl, &protocol_name, &protocol_nameSz);
+
+    if(err == SSL_SUCCESS){
+	    // Sent ALPN protocol
+    }
+    \endcode
+    \sa TLSX_ALPN_GetRequest
+    \sa TLSX_Find
+*/
+int wolfSSL_ALPN_GetProtocol(WOLFSSL* ssl, char **protocol_name,
+                                         unsigned short *size);
+
+/*!
+    \ingroup TLS 
+    \brief  この関数は、alpn_client_listデータをSSLオブジェクトからバッファにコピーします。
+    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。SSLオブジェクトのALPN_CLIENT_LISTメンバーがLISTパラメータにコピーされました。
+    \return BAD_FUNC_ARG  listまたはlistszパラメーターがnullの場合に返されます。
+    \return BUFFER_ERROR  リストバッファに問題がある場合は（NULLまたはサイズが0の場合）に問題がある場合は返されます。
+    \return MEMORY_ERROR  メモリを動的に割り当てる問題がある場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param list  バッファへのポインタ。SSLオブジェクトからのデータがコピーされます。
+    _Example_
+    \code
+    #import <wolfssl/ssl.h>
+
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method);
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    …
+    #ifdef HAVE_ALPN
+    char* list = NULL;
+    word16 listSz = 0;
+    …
+    err = wolfSSL_ALPN_GetPeerProtocol(ssl, &list, &listSz);
+
+    if(err == SSL_SUCCESS){
+	    List of protocols names sent by client
+    }
+    \endcode
+    \sa wolfSSL_UseALPN
+*/
+int wolfSSL_ALPN_GetPeerProtocol(WOLFSSL* ssl, char **list,
+                                             unsigned short *listSz);
+
+/*!
+    \brief  'ssl'パラメータに渡されたSSLオブジェクト内の最大フラグメント長。これは、最大フラグメント長拡張機能がWolfSSLクライアントによってClientHelloで送信されることを意味します。
+    \return SSL_SUCCESS  成功すると。
+    \return BAD_FUNC_ARG  次のいずれかの場合に返されるエラーです.SSLはNULL、MFLは範囲外です。
+    \return MEMORY_E  十分なメモリがないときにエラーが返されます。
+    \param ssl  wolfssl_new（）で作成されたSSLオブジェクトへのポインタ。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL_CTX* ctx = 0;
+    WOLFSSL* ssl = 0;
+    ctx = wolfSSL_CTX_new(method);
+    if (ctx == NULL) {
+        // context creation failed
+    }
+    ssl = wolfSSL_new(ctx);
+    if (ssl == NULL) {
+        // ssl creation failed
+    }
+    ret = wolfSSL_UseMaxFragment(ssl, WOLFSSL_MFL_2_11);
+    if (ret != 0) {
+        // max fragment usage failed
+    }
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_CTX_UseMaxFragment
+*/
+int wolfSSL_UseMaxFragment(WOLFSSL* ssl, unsigned char mfl);
+
+/*!
+    \brief  SSLコンテキストから作成されたSSLオブジェクトの最大フラグメント長さ 'ctx'パラメータに渡されました。これは、最大フラグメント長拡張機能がWolfSSLクライアントによってClientHelloで送信されることを意味します。
+    \return SSL_SUCCESS  成功すると。
+    \return BAD_FUNC_ARG  次のいずれかの場合に返されるエラーです.CTXはNULL、MFLは範囲外です。
+    \return MEMORY_E  十分なメモリがないときにエラーが返されます。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL_CTX* ctx = 0;
+    ctx = wolfSSL_CTX_new(method);
+    if (ctx == NULL) {
+        // context creation failed
+    }
+    ret = wolfSSL_CTX_UseMaxFragment(ctx, WOLFSSL_MFL_2_11);
+    if (ret != 0) {
+        // max fragment usage failed
+    }
+    \endcode
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_UseMaxFragment
+*/
+int wolfSSL_CTX_UseMaxFragment(WOLFSSL_CTX* ctx, unsigned char mfl);
+
+/*!
+    \brief  'ssl'パラメータに渡されたSSLオブジェクト内のtruncated HMAC。これは、切り捨てられたHMAC拡張機能がWolfSSLクライアントによってClientHelloで送信されることを意味します。
+    \return SSL_SUCCESS  成功すると。
+    \return BAD_FUNC_ARG  次のいずれかの場合に返されるエラーです.SSLはNULLです
+    \return MEMORY_E  十分なメモリがないときにエラーが返されます。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL_CTX* ctx = 0;
+    WOLFSSL* ssl = 0;
+    ctx = wolfSSL_CTX_new(method);
+    if (ctx == NULL) {
+        // context creation failed
+    }
+    ssl = wolfSSL_new(ctx);
+    if (ssl == NULL) {
+        // ssl creation failed
+    }
+    ret = wolfSSL_UseTruncatedHMAC(ssl);
+    if (ret != 0) {
+        // truncated HMAC usage failed
+    }
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_CTX_UseMaxFragment
+*/
+int wolfSSL_UseTruncatedHMAC(WOLFSSL* ssl);
+
+/*!
+    \brief  'ctx'パラメータに渡されたSSLコンテキストから作成されたSSLオブジェクトのためのTruncated HMAC。これは、切り捨てられたHMAC拡張機能がWolfSSLクライアントによってClientHelloで送信されることを意味します。
+    \return SSL_SUCCESS  成功すると。
+    \return BAD_FUNC_ARG  次のいずれかの場合に返されるエラーです.CTXはNULL
+    \return MEMORY_E  十分なメモリがないときにエラーが返されます。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL_CTX* ctx = 0;
+    ctx = wolfSSL_CTX_new(method);
+    if (ctx == NULL) {
+        // context creation failed
+    }
+    ret = wolfSSL_CTX_UseTruncatedHMAC(ctx);
+    if (ret != 0) {
+        // truncated HMAC usage failed
+    }
+    \endcode
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_UseMaxFragment
+*/
+int wolfSSL_CTX_UseTruncatedHMAC(WOLFSSL_CTX* ctx);
+
+/*!
+    \brief  OCSPで提示された証明書失効チェックのコストを下げます。
+    \return SSL_SUCCESS  tlsx_usecertificateStatusRequestがエラーなしで実行された場合に返されます。
+    \return MEMORY_E  メモリの割り当てにエラーがある場合は返されます。
+    \return BAD_FUNC_ARG  NULLまたはその他の点では、関数に渡された値が渡される引数がある場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param status_type  tlsx_usecertificateSrequest（）に渡され、CertificateStatusRequest構造体に格納されているバイトタイプ。
+    _Example_
+    \code
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    …
+    if (wolfSSL_UseOCSPStapling(ssl, WOLFSSL_CSR2_OCSP,
+    WOLFSSL_CSR2_OCSP_USE_NONCE) != SSL_SUCCESS){
+	    // Failed case.
+    }
+    \endcode
+    \sa TLSX_UseCertificateStatusRequest
+    \sa wolfSSL_CTX_UseOCSPStapling
+*/
+int wolfSSL_UseOCSPStapling(WOLFSSL* ssl,
+                              unsigned char status_type, unsigned char options);
+
+/*!
+    \brief  
+    \return SSL_SUCCESS  関数とサブルーチンがエラーなしで実行された場合に返されます。
+    \return BAD_FUNC_ARG  未解決の値がサブルーチンに渡された場合、wolfssl_ctx構造体がNULLまたはそうでない場合は返されます。
+    \return MEMORY_E  関数またはサブルーチンがメモリを正しく割り振ることができなかった場合に返されます。
+    \param ctx  wolfssl_ctx_new（）を使用して作成されたwolfssl_ctx構造へのポインタ。
+    \param status_type  tlsx_usecertificateSrequest（）に渡され、CertificateStatusRequest構造体に格納されているバイトタイプ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    byte statusRequest = 0; // Initialize status request
+    …
+    switch(statusRequest){
+    	case WOLFSSL_CSR_OCSP:
+    		if(wolfSSL_CTX_UseOCSPStapling(ssl->ctx, WOLFSSL_CSR_OCSP,
+    WOLF_CSR_OCSP_USE_NONCE) != SSL_SUCCESS){
+    // UseCertificateStatusRequest failed
+    }
+    // Continue switch cases
+    \endcode
+    \sa wolfSSL_UseOCSPStaplingV2
+    \sa wolfSSL_UseOCSPStapling
+    \sa TLSX_UseCertificateStatusRequest
+*/
+int wolfSSL_CTX_UseOCSPStapling(WOLFSSL_CTX* ctx,
+                              unsigned char status_type, unsigned char options);
+
+/*!
+    \brief  
+    \return SSL_SUCCESS   - 関数とサブルーチンがエラーなしで実行された場合に返されます。
+    \return MEMORY_E   - メモリエラーの割り当てがあった場合に返されます。
+    \return BAD_FUNC_ARG   -  NULLまたはそれ以外の場合は解読されていない引数が関数またはサブルーチンに渡された場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param status_type  OCSPステータスタイプをロードするバイトタイプ。
+    _Example_
+    \code
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    ...
+    if (wolfSSL_UseOCSPStaplingV2(ssl, WOLFSSL_CSR2_OCSP_MULTI, 0) != SSL_SUCCESS){
+    	// Did not execute properly. Failure case code block.
+    }
+    \endcode
+    \sa TLSX_UseCertificatStatusRequestV2
+    \sa wolfSSL_SNI_SetOptions
+    \sa wolfSSL_CTX_SNI_SetOptions
+*/
+int wolfSSL_UseOCSPStaplingV2(WOLFSSL* ssl,
+                              unsigned char status_type, unsigned char options);
+
+/*!
+    \brief  OCSPステイプルのために。
+    \return SSL_SUCCESS  関数とサブルーチンがエラーなしで実行された場合。
+    \return BAD_FUNC_ARG  wolfssl_ctx構造がnullの場合、または側数変数がクライアント側ではない場合に返されます。
+    \return MEMORY_E  メモリの割り当てが失敗した場合に返されます。
+    \param ctx  wolfssl_ctx_new（）を使用して作成されたwolfssl_ctx構造へのポインタ。
+    \param status_type  CertificatStatusRequest構造体にあるバイトタイプで、wolfssl_csr2_ocspまたはwolfssl_csr2_ocsp_multiでなければなりません。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx  = wolfSSL_CTX_new( protocol method );
+    byte status_type;
+    byte options;
+    ...
+    if(wolfSSL_CTX_UseOCSPStaplingV2(ctx, status_type, options); != SSL_SUCCESS){
+    	// Failure case.
+    }
+    \endcode
+    \sa TLSX_UseCertificateStatusRequestV2
+    \sa wc_RNG_GenerateBlock
+    \sa TLSX_Push
+*/
+int wolfSSL_CTX_UseOCSPStaplingV2(WOLFSSL_CTX* ctx,
+                              unsigned char status_type, unsigned char options);
+
+/*!
+    \brief  サポートされている楕円曲線拡張子は、 'SSL'パラメータに渡されたSSLオブジェクトでサポートされています。これは、サポートされているカーブがWolfSSLクライアントによってClientHelloで送信されることを意味します。この機能は複数の曲線を有効にするために複数の時間と呼ぶことができます。
+    \return SSL_SUCCESS  成功すると。
+    \return BAD_FUNC_ARG  次のいずれかの場合に返されるエラーです.SSLはNULLです。名前は未知の値です。（下記参照）
+    \return MEMORY_E  十分なメモリがないときにエラーが返されます。
+    \param ssl  wolfssl_new（）で作成されたSSLオブジェクトへのポインタ。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL_CTX* ctx = 0;
+    WOLFSSL* ssl = 0;
+    ctx = wolfSSL_CTX_new(method);
+    if (ctx == NULL) {
+        // context creation failed
+    }
+    ssl = wolfSSL_new(ctx);
+    if (ssl == NULL) {
+        // ssl creation failed
+    }
+    ret = wolfSSL_UseSupportedCurve(ssl, WOLFSSL_ECC_SECP256R1);
+    if (ret != 0) {
+        // Elliptic Curve Extension usage failed
+    }
+    \endcode
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_CTX_UseSupportedCurve
+*/
+int wolfSSL_UseSupportedCurve(WOLFSSL* ssl, word16 name);
+
+/*!
+    \brief  サポートされている楕円曲線は、 'ctx'パラメータに渡されたSSLコンテキストから作成されたSSLオブジェクトの拡張子です。これは、サポートされているカーブがWolfSSLクライアントによってClientHelloで送信されることを意味します。この機能は複数の曲線を有効にするために複数の時間と呼ぶことができます。
+    \return SSL_SUCCESS  成功すると。
+    \return BAD_FUNC_ARG  次のいずれかの場合に返されるエラーです.CTXはNULL、名前は未知の値です。（下記参照）
+    \return MEMORY_E  十分なメモリがないときにエラーが返されます。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    _Example_
+    \code
+    int ret = 0;
+    WOLFSSL_CTX* ctx = 0;
+    ctx = wolfSSL_CTX_new(method);
+    if (ctx == NULL) {
+        // context creation failed
+    }
+    ret = wolfSSL_CTX_UseSupportedCurve(ctx, WOLFSSL_ECC_SECP256R1);
+    if (ret != 0) {
+        // Elliptic Curve Extension usage failed
+    }
+    \endcode
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_UseSupportedCurve
+*/
+int wolfSSL_CTX_UseSupportedCurve(WOLFSSL_CTX* ctx,
+                                                           word16 name);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、供給されたWOLFSSL構造の安全な再交渉を強制します。これはお勧めできません。
+    \return SSL_SUCCESS  安全な再ネゴシエーションを正常に設定します。
+    \return BAD_FUNC_ARG  SSLがNULLの場合、エラーを返します。
+    \return MEMORY_E  安全な再交渉のためにメモリを割り当てることができない場合、エラーを返します。
+    _Example_
+    \code
+    wolfSSL_Init();
+    WOLFSSL_CTX* ctx;
+    WOLFSSL* ssl;
+    WOLFSSL_METHOD method = // Some wolfSSL method
+    ctx = wolfSSL_CTX_new(method);
+    ssl = wolfSSL_new(ctx);
+
+    if(wolfSSL_UseSecureRenegotiation(ssl) != SSL_SUCCESS)
+    {
+        // Error setting secure renegotiation
+    }
+    \endcode
+    \sa TLSX_Find
+    \sa TLSX_UseSecureRenegotiation
+*/
+int wolfSSL_UseSecureRenegotiation(WOLFSSL* ssl);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は安全な再交渉ハンドシェイクを実行します。これは、WolfSSLがこの機能を妨げるように強制されます。
+    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。
+    \return BAD_FUNC_ARG  wolfssl構造がnullまたはそうでなければ、許容できない引数がサブルーチンに渡された場合に返されます。
+    \return SECURE_RENEGOTIATION_E  ハンドシェイクを再ネゴシエーションすることにエラーが発生した場合は返されます。
+    \return SSL_FATAL_ERROR  サーバーまたはクライアント構成にエラーが発生した場合は、再ネゴシエーションが完了できなかった場合に返されます。wolfssl_negotiate（）を参照してください。
+    _Example_
+    \code
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    ...
+    if(wolfSSL_Rehandshake(ssl) != SSL_SUCCESS){
+	    // There was an error and the rehandshake is not successful.
+    }
+    \endcode
+    \sa wolfSSL_negotiate
+    \sa wc_InitSha512
+    \sa wc_InitSha384
+    \sa wc_InitSha256
+    \sa wc_InitSha
+    \sa wc_InitMd5
+*/
+int wolfSSL_Rehandshake(WOLFSSL* ssl);
+
+/*!
+    \ingroup IO 
+    \brief  セッションチケットを使用するようにWolfSSL構造を強制します。定数hous_session_ticketを定義し、定数NO_WOLFSSL_CLIENTをこの関数を使用するように定義しないでください。
+    \return SSL_SUCCESS  セッションチケットを使用したセットに成功しました。
+    \return BAD_FUNC_ARG  SSLがNULLの場合に返されます。
+    \return MEMORY_E  セッションチケットを設定するためのメモリの割り当て中にエラーが発生しました。
+    _Example_
+    \code
+    wolfSSL_Init();
+    WOLFSSL_CTX* ctx;
+    WOLFSSL* ssl;
+    WOLFSSL_METHOD method = // Some wolfSSL method
+    ctx = wolfSSL_CTX_new(method);
+    ssl = wolfSSL_new(ctx);
+
+    if(wolfSSL_UseSessionTicket(ssl) != SSL_SUCCESS)
+    {
+        // Error setting session ticket
+    }
+    \endcode
+    \sa TLSX_UseSessionTicket
+*/
+int wolfSSL_UseSessionTicket(WOLFSSL* ssl);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、セッションチケットを使用するようにWolfSSLコンテキストを設定します。
+    \return SSL_SUCCESS  関数は正常に実行されます。
+    \return BAD_FUNC_ARG  CTXがNULLの場合に返されます。
+    \return MEMORY_E  内部関数内のメモリの割り当て中にエラーが発生しました。
+    _Example_
+    \code
+    wolfSSL_Init();
+    WOLFSSL_CTX* ctx;
+    WOLFSSL_METHOD method = // Some wolfSSL method ;
+    ctx = wolfSSL_CTX_new(method);
+
+    if(wolfSSL_CTX_UseSessionTicket(ctx) != SSL_SUCCESS)
+    {
+        // Error setting session ticket
+    }
+    \endcode
+    \sa TLSX_UseSessionTicket
+*/
+int wolfSSL_CTX_UseSessionTicket(WOLFSSL_CTX* ctx);
+
+/*!
+    \ingroup IO 
+    \brief  この機能は、セッション構造のチケットメンバーをバッファにコピーします。
+    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。
+    \return BAD_FUNC_ARG  引数の1つがNULLの場合、またはbufsz引数が0の場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param buf  メモリバッファを表すバイトポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    byte* buf;
+    word32 bufSz;  // Initialize with buf size
+    …
+    if(wolfSSL_get_SessionTicket(ssl, buf, bufSz) <= 0){
+	    // Nothing was written to the buffer
+    } else {
+	    // the buffer holds the content from ssl->session->ticket
+    }
+    \endcode
+    \sa wolfSSL_UseSessionTicket
+    \sa wolfSSL_set_SessionTicket
+*/
+int wolfSSL_get_SessionTicket(WOLFSSL* ssl, unsigned char* buf, word32* bufSz);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、WolfSSL構造体内のwolfssl_session構造体のチケットメンバーを設定します。関数に渡されたバッファはメモリにコピーされます。
+    \return SSL_SUCCESS  機能の実行に成功したことに戻ります。関数はエラーなしで返されました。
+    \return BAD_FUNC_ARG  WolfSSL構造がNULLの場合に返されます。BUF引数がNULLの場合は、これはスローされますが、bufsz引数はゼロではありません。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param buf  セッション構造のチケットメンバーにロードされるバイトポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    byte* buffer; // File to load
+    word32 bufSz;
+    ...
+    if(wolfSSL_KeepArrays(ssl, buffer, bufSz) != SSL_SUCCESS){
+    	// There was an error loading the buffer to memory.
+    }
+    \endcode
+    \sa wolfSSL_set_SessionTicket_cb
+*/
+int wolfSSL_set_SessionTicket(WOLFSSL* ssl, const unsigned char* buf,
+                              word32 bufSz);
+
+/*!
+    \brief  CallbackSessionTicketは、int（* callbacksessionTicket）（wolfssl *、const unsigned char *、int、void *）の関数ポインタです。
+    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。
+    \return BAD_FUNC_ARG  WolfSSL構造がNULLの場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param cb  Type CallbackSessionTicketへの関数ポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    …
+    int sessionTicketCB(WOLFSSL* ssl, const unsigned char* ticket, int ticketSz,
+				void* ctx){ … }
+    wolfSSL_set_SessionTicket_cb(ssl, sessionTicketCB, (void*)”initial session”);
+    \endcode
+    \sa wolfSSL_set_SessionTicket
+    \sa CallbackSessionTicket
+    \sa sessionTicketCB
+*/
+int wolfSSL_set_SessionTicket_cb(WOLFSSL* ssl,
+                                 CallbackSessionTicket cb, void* ctx);
+
+/*!
+    \brief  RFC 5077で指定されているセッションチケットをサポートするためのサーバーが。
+    \return SSL_SUCCESS  セッションを正常に設定すると返されます。
+    \return BAD_FUNC_ARG  失敗した場合に返されます。これは、無効な引数を関数に渡すことによって発生します。
+    \param ctx  wolfssl_ctx_new（）で作成されたwolfssl_ctxオブジェクトへのポインタ。
+    \param cb  セッションチケットを暗号化/復号化するためのユーザーコールバック関数
+    \param ssl(Callback)  WOLFSSL_NEW（）で作成されたWolfSSLオブジェクトへのポインタ
+    \param key_name(Callback)  このチケットコンテキストの一意のキー名はランダムに生成されるべきです
+    \param iv(Callback)  ユニークなIVこのチケットの場合、最大128ビット、ランダムに生成されるべきです
+    \param mac(Callback)  このチケットの最大256ビットMAC
+    \param enc(Callback)  この暗号化パラメータがtrueの場合、ユーザーはキーコード、IV、Macを記入し、チケットを長さのインレルの範囲内に暗号化し、結果として生じる出力長を* outreenに設定する必要があります。 wolfssl_ticket_ret_okを返す暗号化が成功したことをWolfSSLに指示します。この暗号化パラメータがfalseの場合、key_name、iv、およびmacを使用して、リングインレーンの範囲内のチケットの復号化を実行する必要があります。結果の復号長は* outreenに設定する必要があります。 wolfssl_ticket_ret_okを返すと、復号化されたチケットの使用を続行するようにWolfSSLに指示します。 wolfssl_ticket_ret_createを返すと、復号化されたチケットを使用するだけでなく、クライアントに送信するための新しいものを生成するように指示し、最近ロールされている場合に役立つ、フルハンドシェイクを強制したくない。 wolfssl_ticket_ret_rejectを返すと、WolfSSLにこのチケットを拒否し、フルハンドシェイクを実行し、通常のセッション再開のための新しい標準セッションIDを作成します。 wolfssl_ticket_ret_fatalを返すと、致命的なエラーで接続の試みを終了するようにWolfSSLに指示します。
+    \param ticket(Callback)  暗号化チケットの入出力バッファ。ENCパラメータを参照してください
+    \param inLen(Callback)  チケットパラメータの入力長
+    \param outLen(Callback)  チケットパラメータの結果の出力長。コールバックoutlenを入力すると、チケットバッファで使用可能な最大サイズが表示されます。
+    _Example_
+    \code
+    See wolfssl/test.h myTicketEncCb() used by the example
+    server and example echoserver.
+    \endcode
+    \sa wolfSSL_CTX_set_TicketHint
+    \sa wolfSSL_CTX_set_TicketEncCtx
+*/
+int wolfSSL_CTX_set_TicketEncCb(WOLFSSL_CTX* ctx,
+                                            SessionTicketEncCb);
+
+/*!
+    \brief  サーバーサイドの使用のために。
+    \return SSL_SUCCESS  セッションを正常に設定すると返されます。
+    \return BAD_FUNC_ARG  失敗した場合に返されます。これは、無効な引数を関数に渡すことによって発生します。
+    \param ctx  wolfssl_ctx_new（）で作成されたwolfssl_ctxオブジェクトへのポインタ。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_CTX_set_TicketEncCb
+*/
+int wolfSSL_CTX_set_TicketHint(WOLFSSL_CTX* ctx, int);
+
+/*!
+    \brief  折り返し電話。サーバーサイドの使用のために。
+    \return SSL_SUCCESS  セッションを正常に設定すると返されます。
+    \return BAD_FUNC_ARG  失敗した場合に返されます。これは、無効な引数を関数に渡すことによって発生します。
+    \param ctx  wolfssl_ctx_new（）で作成されたwolfssl_ctxオブジェクトへのポインタ。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_CTX_set_TicketEncCb
+*/
+int wolfSSL_CTX_set_TicketEncCtx(WOLFSSL_CTX* ctx, void*);
+
+/*!
+    \brief  折り返し電話。サーバーサイドの使用のために。
+    \return userCtx  セッションを正常に取得すると返されます。
+    \return NULL  失敗した場合に返されます。これは、無効な引数を関数に渡すことによって、またはユーザーコンテキストが設定されていないときに発生します。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_CTX_set_TicketEncCtx
+*/
+void* wolfSSL_CTX_get_TicketEncCtx(WOLFSSL_CTX* ctx);
+
+/*!
+    \brief  この機能には、WolfSSL構造のHSDonectxメンバーが設定されています。
+    \return SSL_SUCCESS  関数がエラーなしで実行された場合に返されます。WolfSSL構造体のHSDONECBとHSDonectxメンバーが設定されています。
+    \return BAD_FUNC_ARG  wolfssl構造体がNULLの場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param cb  int（* HandshakedOneCB）（wolfssl *、void *）の署名を持つタイプHandshakedOneCBの関数ポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    …
+    int myHsDoneCb(WOLFSSL* ssl, void* user_ctx){
+        // callback function
+    }
+    …
+    wolfSSL_SetHsDoneCb(ssl, myHsDoneCb, NULL);
+    \endcode
+    \sa HandShakeDoneCb
+*/
+int wolfSSL_SetHsDoneCb(WOLFSSL* ssl, HandShakeDoneCb cb, void* user_ctx);
+
+/*!
+    \ingroup IO 
+    \brief  この関数はセッションから統計を印刷します。
+    \return SSL_SUCCESS  関数とサブルーチンがエラーなしで戻った場合に返されます。セッション統計は正常に取得され印刷されました。
+    \return BAD_FUNC_ARG  サブルーチンwolfssl_get_session_stats（）が許容できない引数に渡された場合に返されます。
+    \return BAD_MUTEX_E  サブルーチンにミューテックスエラーがあった場合に返されます。
+    _Example_
+    \code
+    // You will need to have a session object to retrieve stats from.
+    if(wolfSSL_PrintSessionStats(void) != SSL_SUCCESS	){
+        // Did not print session stats
+    }
+
+    \endcode
+    \sa wolfSSL_get_session_stats
+*/
+int wolfSSL_PrintSessionStats(void);
+
+/*!
+    \ingroup IO 
+    \brief  この関数はセッションの統計を取得します。
+    \return SSL_SUCCESS  関数とサブルーチンがエラーなしで戻った場合に返されます。セッション統計は正常に取得され印刷されました。
+    \return BAD_FUNC_ARG  サブルーチンwolfssl_get_session_stats（）が許容できない引数に渡された場合に返されます。
+    \return BAD_MUTEX_E  サブルーチンにミューテックスエラーがあった場合に返されます。
+    \param active  現在のセッションの合計を表すWord32ポインタ。
+    \param total  総セッションを表すWord32ポインタ。
+    \param peak  ピークセッションを表すWord32ポインタ。
+    _Example_
+    \code
+    int wolfSSL_PrintSessionStats(void){
+    …
+    ret = wolfSSL_get_session_stats(&totalSessionsNow,
+    &totalSessionsSeen, &peak, &maxSessions);
+    …
+    return ret;
+    \endcode
+    \sa wolfSSL_PrintSessionStats
+*/
+int wolfSSL_get_session_stats(unsigned int* active,
+                                          unsigned int* total,
+                                          unsigned int* peak,
+                                          unsigned int* maxSessions);
+
+/*!
+    \ingroup TLS 
+    \brief  この関数はCRとSRの値をコピーしてからWC_PRF（疑似ランダム関数）に渡し、その値を返します。
+    \return 0  成功した
+    \return BUFFER_E  バッファのサイズにエラーが発生した場合は返されます。
+    \return MEMORY_E  サブルーチンが動的メモリを割り当てることができなかった場合に返されます。
+    \param ms  マスターシークレットはアレイ構造に保持されています。
+    \param msLen  マスターシークレットの長さ。
+    \param pms  マスター前の秘密はアレイ構造に保持されています。
+    \param pmsLen  マスタープレマスターシークレットの長さ。
+    \param cr  クライアントのランダム
+    \param sr  サーバーのランダムです。
+    \param tls1_2  バージョンが少なくともTLSバージョン1.2であることを意味します。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+
+    called in MakeTlsMasterSecret and retrieves the necessary
+    information as follows:
+
+    int MakeTlsMasterSecret(WOLFSSL* ssl){
+	int ret;
+	ret = wolfSSL_makeTlsMasterSecret(ssl->arrays->masterSecret, SECRET_LEN,
+    ssl->arrays->preMasterSecret, ssl->arrays->preMasterSz,
+    ssl->arrays->clientRandom, ssl->arrays->serverRandom,
+    IsAtLeastTLSv1_2(ssl), ssl->specs.mac_algorithm);
+    …
+    return ret;
+
+    }
+    \endcode
+    \sa wc_PRF
+    \sa MakeTlsMasterSecret
+*/
+
+int wolfSSL_MakeTlsMasterSecret(unsigned char* ms, word32 msLen,
+                               const unsigned char* pms, word32 pmsLen,
+                               const unsigned char* cr, const unsigned char* sr,
+                               int tls1_2, int hash_type);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  TLSキーを導き出すための外部のラッパー。
+    \return 0  成功に戻りました。
+    \return BUFFER_E  LABLENとSEADLENの合計（合計サイズを計算）が最大サイズを超えると返されます。
+    \return MEMORY_E  メモリの割り当てが失敗した場合に返されます。
+    \param key_data  DeriveTlSkeysに割り当てられ、最終ハッシュを保持するためにWC_PRFに渡されたバイトポインタ。
+    \param keyLen  WOLFSSL構造体のスペックメンバーからのDerivetlskeysで派生したWord32タイプ。
+    \param ms  WolfSSL構造内でアレイ構造に保持されているマスターシークレットを保持する定数ポインタ型。
+    \param msLen  列挙された定義で、マスターシークレットの長さを保持するWord32タイプ。
+    \param sr  WOLFSSL構造内の配列構造のServerRandomメンバーへの定数バイトポインタ。
+    \param cr  WolfSSL構造内の配列構造のClientRandomメンバーへの定数バイトポインタ。
+    \param tls1_2  ISATLEASTLSV1_2（）から返された整数型。
+    _Example_
+    \code
+    int DeriveTlsKeys(WOLFSSL* ssl){
+    int ret;
+    …
+    ret = wolfSSL_DeriveTlsKeys(key_data, length, ssl->arrays->masterSecret,
+    SECRET_LEN, ssl->arrays->clientRandom,
+    IsAtLeastTLSv1_2(ssl), ssl->specs.mac_algorithm);
+    …
+    }
+    \endcode
+    \sa wc_PRF
+    \sa DeriveTlsKeys
+    \sa IsAtLeastTLSv1_2
+*/
+
+int wolfSSL_DeriveTlsKeys(unsigned char* key_data, word32 keyLen,
+                               const unsigned char* ms, word32 msLen,
+                               const unsigned char* sr, const unsigned char* cr,
+                               int tls1_2, int hash_type);
+
+/*!
+    \brief  ハンドシェイクコールバックが設定されます。これは、デバッガが利用できず、スニッフィングが実用的ではない場合に、サポートをデバッグするための組み込みシステムで役立ちます。ハンドシェイクエラーが発生したか否かが呼び出されます。SSLパケットの最大数が既知であるため、動的メモリは使用されません。パケット名をPacketNames []でアクセスできます。接続拡張機能は、タイムアウト値とともにタイムアウトコールバックを設定することもできます。これは、ユーザーがTCPスタックをタイムアウトするのを待ったくない場合に便利です。この拡張子は、コールバックのどちらか、またはどちらのコールバックも呼び出されません。
+    \return SSL_SUCCESS  成功すると。
+    \return GETTIME_ERROR  gettimeofday（）がエラーを検出した場合、返されます。
+    \return SETITIMER_ERROR  setItimer（）がエラーを検出した場合、返されます。
+    \return SIGACT_ERROR  sigAction（）がエラーを検出した場合、返されます。
+    \return SSL_FATAL_ERROR  基になるssl_connect（）呼び出しがエラーを検出した場合に返されます。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_accept_ex
+*/
+int wolfSSL_connect_ex(WOLFSSL* ssl, HandShakeCallBack hsCb,
+                       TimeoutCallBack toCb, WOLFSSL_TIMEVAL timeout);
+
+/*!
+    \brief  設定する。これは、デバッガが利用できず、スニッフィングが実用的ではない場合に、サポートをデバッグするための組み込みシステムで役立ちます。ハンドシェイクエラーが発生したか否かが呼び出されます。SSLパケットの最大数が既知であるため、動的メモリは使用されません。パケット名をPacketNames []でアクセスできます。接続拡張機能は、タイムアウト値とともにタイムアウトコールバックを設定することもできます。これは、ユーザーがTCPスタックをタイムアウトするのを待ったくない場合に便利です。この拡張子は、コールバックのどちらか、またはどちらのコールバックも呼び出されません。
+    \return SSL_SUCCESS  成功すると。
+    \return GETTIME_ERROR  gettimeofday（）がエラーを検出した場合、返されます。
+    \return SETITIMER_ERROR  setItimer（）がエラーを検出した場合、返されます。
+    \return SIGACT_ERROR  sigAction（）がエラーを検出した場合、返されます。
+    \return SSL_FATAL_ERROR  基礎となるssl_accept（）呼び出しがエラーを検出した場合に返されます。
+    _Example_
+    \code
+    none
+    \endcode
+    \sa wolfSSL_connect_ex
+*/
+int wolfSSL_accept_ex(WOLFSSL* ssl, HandShakeCallBacki hsCb,
+                      TimeoutCallBack toCb, WOLFSSL_TIMEVAL timeout);
+
+/*!
+    \ingroup IO 
+    \brief  これはBIOの内部ファイルポインタを設定するために使用されます。
+    \return SSL_SUCCESS  ファイルポインタを正常に設定します。
+    \return SSL_FAILURE  エラーケースに遭遇した場合
+    \param bio  ペアを設定するためのwolfssl_bio構造。
+    \param fp  バイオで設定するファイルポインタ。
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    XFILE fp;
+    int ret;
+    bio  = wolfSSL_BIO_new(wolfSSL_BIO_s_file());
+    ret  = wolfSSL_BIO_set_fp(bio, fp, BIO_CLOSE);
+    // check ret value
+    \endcode
+    \sa wolfSSL_BIO_new
+    \sa wolfSSL_BIO_s_mem
+    \sa wolfSSL_BIO_get_fp
+    \sa wolfSSL_BIO_free
+*/
+long wolfSSL_BIO_set_fp(WOLFSSL_BIO *bio, XFILE fp, int c);
+
+/*!
+    \ingroup IO 
+    \brief  これは、BIOの内部ファイルポインタを取得するために使用されます。
+    \return SSL_SUCCESS  ファイルポインタを正常に取得します。
+    \return SSL_FAILURE  エラーケースに遭遇した場合
+    \param bio  ペアを設定するためのwolfssl_bio構造。
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    XFILE fp;
+    int ret;
+    bio  = wolfSSL_BIO_new(wolfSSL_BIO_s_file());
+    ret  = wolfSSL_BIO_get_fp(bio, &fp);
+    // check ret value
+    \endcode
+    \sa wolfSSL_BIO_new
+    \sa wolfSSL_BIO_s_mem
+    \sa wolfSSL_BIO_set_fp
+    \sa wolfSSL_BIO_free
+*/
+long wolfSSL_BIO_get_fp(WOLFSSL_BIO *bio, XFILE* fp);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、秘密鍵が使用されている証明書との一致であることを確認します。
+    \return SSL_SUCCESS  うまく一致します。
+    \return SSL_FAILURE  エラーケースに遭遇した場合
+    \return <0  ssl_failure以外のすべてのエラーケースは負の値です。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    int ret;
+    // create and set up ssl
+    ret  = wolfSSL_check_private_key(ssl);
+    // check ret value
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_free
+*/
+int wolfSSL_check_private_key(const WOLFSSL* ssl);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この機能は、渡されたNID値に一致する拡張索引を探して返します。
+    \return >=  0拡張インデックスが成功した場合は返されます。
+    \return -1  拡張が見つからないかエラーが発生した場合
+    \param x509  拡張のために解析する証明書。
+    \param nid  見つかる拡張OID。
+    _Example_
+    \code
+    const WOLFSSL_X509* x509;
+    int lastPos = -1;
+    int idx;
+
+    idx = wolfSSL_X509_get_ext_by_NID(x509, NID_basic_constraints, lastPos);
+    \endcode
+*/
+int wolfSSL_X509_get_ext_by_NID(const WOLFSSL_X509* x509,
+                                             int nid, int lastPos);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、渡されたNID値に合った拡張子を探して返します。
+    \return pointer  STACK_OF（wolfssl_asn1_object）ポインタが成功した場合は返されます。
+    \return NULL  拡張が見つからないかエラーが発生した場合
+    \param x509  拡張のために解析する証明書。
+    \param nid  見つかる拡張OID。
+    \param c  not nullが複数の拡張子に-2に設定されていない場合は-1が見つかりませんでした。
+    _Example_
+    \code
+    const WOLFSSL_X509* x509;
+    int c;
+    int idx = 0;
+    STACK_OF(WOLFSSL_ASN1_OBJECT)* sk;
+
+    sk = wolfSSL_X509_get_ext_d2i(x509, NID_basic_constraints, &c, &idx);
+    //check sk for NULL and then use it. sk needs freed after done.
+    \endcode
+    \sa wolfSSL_sk_ASN1_OBJECT_free
+*/
+void* wolfSSL_X509_get_ext_d2i(const WOLFSSL_X509* x509,
+                                                     int nid, int* c, int* idx);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数はDER証明書のハッシュを返します。
+    \return SSL_SUCCESS  ハッシュの作成に成功しました。
+    \return SSL_FAILURE  不良入力または失敗したハッシュに戻りました。
+    \param x509  ハッシュを得るための証明書。
+    \param digest  使用するハッシュアルゴリズム
+    \param buf  ハッシュを保持するためのバッファ。
+    _Example_
+    \code
+    WOLFSSL_X509* x509;
+    unsigned char buffer[64];
+    unsigned int bufferSz;
+    int ret;
+
+    ret = wolfSSL_X509_digest(x509, wolfSSL_EVP_sha256(), buffer, &bufferSz);
+    //check ret value
+    \endcode
+    \sa none
+*/
+int wolfSSL_X509_digest(const WOLFSSL_X509* x509,
+        const WOLFSSL_EVP_MD* digest, unsigned char* buf, unsigned int* len);
+
+/*!
+    \ingroup Setup 
+    \brief  ハンドシェイク中に使用するために、WolfSSL構造の証明書を設定するために使用されます。
+    \return SSL_SUCCESS  設定の成功した引数について。
+    \return SSL_FAILURE  NULL引数が渡された場合。
+    \param ssl  証明書を設定するためのWolfSSL構造。
+    _Example_
+    \code WOLFSSL* ssl;
+    WOLFSSL_X509* x509
+    int ret;
+    // create ssl object and x509
+    ret  = wolfSSL_use_certificate(ssl, x509);
+    // check ret value
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_free
+*/
+int wolfSSL_use_certificate(WOLFSSL* ssl, WOLFSSL_X509* x509);
+
+/*!
+    \ingroup Setup 
+    \brief  これは、handshakeの間に使用するためにWolfSSL構造の証明書を設定するために使用されます。DERフォーマットバッファが予想されます。
+    \return SSL_SUCCESS  設定の成功した引数について。
+    \return SSL_FAILURE  NULL引数が渡された場合。
+    \param ssl  証明書を設定するためのWolfSSL構造。
+    \param der  使用する証明書。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    unsigned char* der;
+    int derSz;
+    int ret;
+    // create ssl object and set DER variables
+    ret  = wolfSSL_use_certificate_ASN1(ssl, der, derSz);
+    // check ret value
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_free
+*/
+int wolfSSL_use_certificate_ASN1(WOLFSSL* ssl, unsigned char* der,
+                                                                     int derSz);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  これはWolfSSL構造の秘密鍵を設定するために使用されます。
+    \return SSL_SUCCESS  設定の成功した引数について。
+    \return SSL_FAILURE  NULL SSLが渡された場合。すべてのエラーケースは負の値になります。
+    \param ssl  引数を設定するためのWolfSSL構造。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    WOLFSSL_EVP_PKEY* pkey;
+    int ret;
+    // create ssl object and set up private key
+    ret  = wolfSSL_use_PrivateKey(ssl, pkey);
+    // check ret value
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_free
+*/
+int wolfSSL_use_PrivateKey(WOLFSSL* ssl, WOLFSSL_EVP_PKEY* pkey);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  これはWolfSSL構造の秘密鍵を設定するために使用されます。DERフォーマットのキーバッファが予想されます。
+    \return SSL_SUCCESS  秘密鍵の構文解析と設定に成功した場合。
+    \return SSL_FAILURE  NULL SSLが渡された場合。すべてのエラーケースは負の値になります。
+    \param pri  秘密鍵の種類。
+    \param ssl  引数を設定するためのWolfSSL構造。
+    \param der  バッファー保持DERキー。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    unsigned char* pkey;
+    long pkeySz;
+    int ret;
+    // create ssl object and set up private key
+    ret  = wolfSSL_use_PrivateKey_ASN1(1, ssl, pkey, pkeySz);
+    // check ret value
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_free
+    \sa wolfSSL_use_PrivateKey
+*/
+int wolfSSL_use_PrivateKey_ASN1(int pri, WOLFSSL* ssl,
+                                            unsigned char* der, long derSz);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  これはWolfSSL構造の秘密鍵を設定するために使用されます。DERフォーマットのRSAキーバッファが予想されます。
+    \return SSL_SUCCESS  秘密鍵の構文解析と設定に成功した場合。
+    \return SSL_FAILURE  NULL SSLが渡された場合。すべてのエラーケースは負の値になります。
+    \param ssl  引数を設定するためのWolfSSL構造。
+    \param der  バッファー保持DERキー。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    unsigned char* pkey;
+    long pkeySz;
+    int ret;
+    // create ssl object and set up RSA private key
+    ret  = wolfSSL_use_RSAPrivateKey_ASN1(ssl, pkey, pkeySz);
+    // check ret value
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_free
+    \sa wolfSSL_use_PrivateKey
+*/
+int wolfSSL_use_RSAPrivateKey_ASN1(WOLFSSL* ssl, unsigned char* der,
+                                                                long derSz);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、DSAのパラメータを新しく作成されたWOLFSSL_DH構造体に重複しています。
+    \return WOLFSSL_DH  重複した場合はWolfSSL_DH構造体を返す場合
+    \return NULL  失敗すると
+    _Example_
+    \code
+    WOLFSSL_DH* dh;
+    WOLFSSL_DSA* dsa;
+    // set up dsa
+    dh = wolfSSL_DSA_dup_DH(dsa);
+
+    // check dh is not null
+    \endcode
+    \sa none
+*/
+WOLFSSL_DH *wolfSSL_DSA_dup_DH(const WOLFSSL_DSA *r);
+
+/*!
+    \ingroup Setup 
+    \brief  これはハンドシェイクを完了した後にマスターキーを取得するために使用されます。
+    \return >0  データの取得に成功した場合、0より大きい値を返します。
+    \return 0  ランダムなデータバッファまたはエラー状態が返されない場合は0
+    \return max  渡されたOUTSZが0の場合、必要な最大バッファサイズが返されます。
+    \param ses  マスターシークレットバッファを取得するためのWolfSSL_SESSION構造。
+    \param out  データを保持するためのバッファ。
+    _Example_
+    \code
+    WOLFSSL_SESSION ssl;
+    unsigned char* buffer;
+    size_t bufferSz;
+    size_t ret;
+    // complete handshake and get session structure
+    bufferSz  = wolfSSL_SESSION_get_master_secret(ses, NULL, 0);
+    buffer = malloc(bufferSz);
+    ret  = wolfSSL_SESSION_get_master_secret(ses, buffer, bufferSz);
+    // check ret value
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_free
+*/
+int wolfSSL_SESSION_get_master_key(const WOLFSSL_SESSION* ses,
+        unsigned char* out, int outSz);
+
+/*!
+    \ingroup Setup 
+    \brief  これはマスター秘密鍵の長さを取得するために使用されます。
+    \return size  マスターシークレットキーサイズを返します。
+    _Example_
+    \code
+    WOLFSSL_SESSION ssl;
+    unsigned char* buffer;
+    size_t bufferSz;
+    size_t ret;
+    // complete handshake and get session structure
+    bufferSz  = wolfSSL_SESSION_get_master_secret_length(ses);
+    buffer = malloc(bufferSz);
+    // check ret value
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_free
+*/
+int wolfSSL_SESSION_get_master_key_length(const WOLFSSL_SESSION* ses);
+
+/*!
+    \ingroup Setup 
+    \brief  これは、CTXのWOLFSSL_X509_STORE構造の設定機能です。
+    \return none  返品不可。
+    \param ctx  Cert Storeポインタを設定するためのWolfSSL_CTX構造体へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX ctx;
+    WOLFSSL_X509_STORE* st;
+    // setup ctx and st
+    st = wolfSSL_CTX_set_cert_store(ctx, st);
+    //use st
+    \endcode
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_CTX_free
+*/
+void wolfSSL_CTX_set_cert_store(WOLFSSL_CTX* ctx,
+                                                       WOLFSSL_X509_STORE* str);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数はBIOからDERバッファを取得し、それをWolfSSL_X509構造に変換します。
+    \return pointer  成功したwolfssl_x509構造ポインタを返します。
+    \return Null  失敗時にNULLを返します
+    \param bio  DER証明書バッファを持つwolfssl_bio構造体へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    WOLFSSL_X509* x509;
+    // load DER into bio
+    x509 = wolfSSL_d2i_X509_bio(bio, NULL);
+    Or
+    wolfSSL_d2i_X509_bio(bio, &x509);
+    // use x509 returned (check for NULL)
+    \endcode
+    \sa none
+*/
+WOLFSSL_X509* wolfSSL_d2i_X509_bio(WOLFSSL_BIO* bio, WOLFSSL_X509** x509);
+
+/*!
+    \ingroup Setup 
+    \brief  これは、CTXのWOLFSSL_X509_STORE構造のゲッター関数です。
+    \return WOLFSSL_X509_STORE*  ポインタを正常に入手します。
+    \return NULL  NULL引数が渡された場合に返されます。
+    _Example_
+    \code
+    WOLFSSL_CTX ctx;
+    WOLFSSL_X509_STORE* st;
+    // setup ctx
+    st = wolfSSL_CTX_get_cert_store(ctx);
+    //use st
+    \endcode
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_CTX_free
+    \sa wolfSSL_CTX_set_cert_store
+*/
+WOLFSSL_X509_STORE* wolfSSL_CTX_get_cert_store(WOLFSSL_CTX* ctx);
+
+/*!
+    \ingroup IO 
+    \brief  保留中のバイト数を読み取る数を取得します。BIOタイプがBIO_BIOの場合、ペアから読み取る番号です。BIOにSSLオブジェクトが含まれている場合は、SSLオブジェクトからのデータを保留中です（WolfSSL_Pending（SSL））。bio_memoryタイプがある場合は、メモリバッファのサイズを返します。
+    \return >=0  保留中のバイト数。
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    int pending;
+    bio = wolfSSL_BIO_new();
+    …
+    pending = wolfSSL_BIO_ctrl_pending(bio);
+    \endcode
+    \sa wolfSSL_BIO_make_bio_pair
+    \sa wolfSSL_BIO_new
+*/
+size_t wolfSSL_BIO_ctrl_pending(WOLFSSL_BIO *b);
+
+/*!
+    \ingroup Setup 
+    \brief  これは、ハンドシェイク中にサーバーによって送信されたランダムなデータを取得するために使用されます。
+    \return >0  データの取得に成功した場合、0より大きい値を返します。
+    \return 0  ランダムなデータバッファまたはエラー状態が返されない場合は0
+    \return max  渡されたOUTSZが0の場合、必要な最大バッファサイズが返されます。
+    \param ssl  クライアントのランダムデータバッファを取得するためのWolfSSL構造。
+    \param out  ランダムデータを保持するためのバッファ。
+    _Example_
+    \code
+    WOLFSSL ssl;
+    unsigned char* buffer;
+    size_t bufferSz;
+    size_t ret;
+    bufferSz  = wolfSSL_get_server_random(ssl, NULL, 0);
+    buffer = malloc(bufferSz);
+    ret  = wolfSSL_get_server_random(ssl, buffer, bufferSz);
+    // check ret value
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_free
+*/
+size_t wolfSSL_get_server_random(const WOLFSSL *ssl,
+                                             unsigned char *out, size_t outlen);
+
+/*!
+    \ingroup Setup 
+    \brief  これは、ハンドシェイク中にクライアントによって送信されたランダムなデータを取得するために使用されます。
+    \return >0  データの取得に成功した場合、0より大きい値を返します。
+    \return 0  ランダムなデータバッファまたはエラー状態が返されない場合は0
+    \return max  渡されたOUTSZが0の場合、必要な最大バッファサイズが返されます。
+    \param ssl  クライアントのランダムデータバッファを取得するためのWolfSSL構造。
+    \param out  ランダムデータを保持するためのバッファ。
+    _Example_
+    \code
+    WOLFSSL ssl;
+    unsigned char* buffer;
+    size_t bufferSz;
+    size_t ret;
+    bufferSz  = wolfSSL_get_client_random(ssl, NULL, 0);
+    buffer = malloc(bufferSz);
+    ret  = wolfSSL_get_client_random(ssl, buffer, bufferSz);
+    // check ret value
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_free
+*/
+size_t wolfSSL_get_client_random(const WOLFSSL* ssl,
+                                              unsigned char* out, size_t outSz);
+
+/*!
+    \ingroup Setup 
+    \brief  これはCTXで設定されたパスワードコールバックのゲッター関数です。
+    \return func  成功すると、コールバック関数を返します。
+    \return NULL  CTXがNULLの場合、NULLが返されます。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx;
+    wc_pem_password_cb cb;
+    // setup ctx
+    cb = wolfSSL_CTX_get_default_passwd_cb(ctx);
+    //use cb
+    \endcode
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_CTX_free
+*/
+wc_pem_password_cb* wolfSSL_CTX_get_default_passwd_cb(WOLFSSL_CTX*
+                                                                  ctx);
+
+/*!
+    \ingroup Setup 
+    \brief  これは、CTXで設定されているパスワードコールバックユーザーデータの取得機能です。
+    \return pointer  成功すると、ユーザーデータポインタを返します。
+    \return NULL  CTXがNULLの場合、NULLが返されます。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx;
+    void* data;
+    // setup ctx
+    data = wolfSSL_CTX_get_default_passwd_cb(ctx);
+    //use data
+    \endcode
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_CTX_free
+*/
+void *wolfSSL_CTX_get_default_passwd_cb_userdata(WOLFSSL_CTX *ctx);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数はwolfssl_pem_read_bio_x509と同じように動作します。AUXは、信頼できる/拒否されたユースケースや人間の読みやすさのためのフレンドリーな名前などの追加情報を含むことを意味します。
+    \return WOLFSSL_X509  PEMバッファの解析に成功した場合、wolfssl_x509構造が返されます。
+    \return Null  PEMバッファの解析に失敗した場合。
+    \param bp  wolfssl_bio構造体からPEMバッファを取得します。
+    \param x  wolfssl_x509を機能副作用で設定する場合
+    \param cb  パスワードコールバック
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    WOLFSSL_X509* x509;
+    // setup bio
+    X509 = wolfSSL_PEM_read_bio_X509_AUX(bio, NULL, NULL, NULL);
+    //check x509 is not null and then use it
+    \endcode
+    \sa wolfSSL_PEM_read_bio_X509
+*/
+WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509_AUX
+        (WOLFSSL_BIO *bp, WOLFSSL_X509 **x, wc_pem_password_cb *cb, void *u);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  wolfssl_ctx構造体のDHメンバーをdiffie-hellmanパラメータで初期化します。
+    \return SSL_SUCCESS  関数が正常に実行された場合に返されます。
+    \return BAD_FUNC_ARG  CTXまたはDH構造体がNULLの場合に返されます。
+    \return SSL_FATAL_ERROR  構造値を設定するエラーが発生した場合は返されます。
+    \return MEMORY_E  メモリを割り当てることができなかった場合は返されます。
+    \param ctx  wolfssl_ctx_new（）を使用して作成されたwolfssl_ctx構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    WOLFSSL_DH* dh;
+    …
+    return wolfSSL_CTX_set_tmp_dh(ctx, dh);
+    \endcode
+    \sa wolfSSL_BN_bn2bin
+*/
+long wolfSSL_CTX_set_tmp_dh(WOLFSSL_CTX* ctx, WOLFSSL_DH* dh);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、BIOのPEMバッファからDSAパラメータを取得します。
+    \return WOLFSSL_DSA  PEMバッファの解析に成功した場合、WolfSSL_DSA構造が作成され、返されます。
+    \return Null  PEMバッファの解析に失敗した場合。
+    \param bio  PEMメモリポインタを取得するためのwolfssl_bio構造体へのポインタ。
+    \param x  新しいWolfSSL_DSA構造に設定するポインタ。
+    \param cb  パスワードコールバック関数
+    _Example_
+    \code
+    WOLFSSL_BIO* bio;
+    WOLFSSL_DSA* dsa;
+    // setup bio
+    dsa = wolfSSL_PEM_read_bio_DSAparams(bio, NULL, NULL, NULL);
+
+    // check dsa is not NULL and then use dsa
+    \endcode
+    \sa none
+*/
+WOLFSSL_DSA *wolfSSL_PEM_read_bio_DSAparams(WOLFSSL_BIO *bp,
+    WOLFSSL_DSA **x, wc_pem_password_cb *cb, void *u);
+
+/*!
+    \ingroup Debug 
+    \brief  この関数は、wolfssl_Errorに遭遇した最後のエラーの絶対値を返します。
+    \return error  最後のエラーの絶対値を返します。
+    _Example_
+    \code
+    unsigned long err;
+    ...
+    err = wolfSSL_ERR_peek_last_error();
+    // inspect err value
+    \endcode
+    \sa wolfSSL_ERR_print_errors_fp
+*/
+unsigned long wolfSSL_ERR_peek_last_error(void);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数はピアの証明書チェーンを取得します。
+    \return pointer  ピアの証明書スタックへのポインタを返します。
+    \return NULL  ピア証明書がない場合は返されます。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    ...
+    wolfSSL_connect(ssl);
+    STACK_OF(WOLFSSL_X509)* chain = wolfSSL_get_peer_cert_chain(ssl);
+    ifchain){
+	    // You have a pointer to the peer certificate chain
+    }
+    \endcode
+    \sa wolfSSL_X509_get_issuer_name
+    \sa wolfSSL_X509_get_subject_name
+    \sa wolfSSL_X509_get_isCA
+*/
+WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_get_peer_cert_chain(const WOLFSSL*);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、wolfssl_ctxオブジェクトのオプションビットをリセットします。
+    \return option  新しいオプションビット
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = 0;
+    ...
+    wolfSSL_CTX_clear_options(ctx, SSL_OP_NO_TLSv1);
+    \endcode
+    \sa wolfSSL_CTX_new
+    \sa wolfSSL_new
+    \sa wolfSSL_free
+*/
+long wolfSSL_CTX_clear_options(WOLFSSL_CTX* ctx, long opt);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、WolfSSL構造のjobjectrefメンバーを設定します。
+    \return SSL_SUCCESS  jobjectrefがobjptrに正しく設定されている場合に返されます。
+    \return SSL_FAILURE  関数が正しく実行されず、jobjectrefが設定されていない場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    WOLFSSL* ssl = WOLFSSL_new();
+    void* objPtr = &obj;
+    ...
+    if(wolfSSL_set_jobject(ssl, objPtr)){
+    	// The success case
+    }
+    \endcode
+    \sa wolfSSL_get_jobject
+*/
+int wolfSSL_set_jobject(WOLFSSL* ssl, void* objPtr);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、wolfssl構造のjobjectrefメンバーを返します。
+    \return value  wolfssl構造体がnullでない場合、関数はjobjectref値を返します。
+    \return NULL  wolfssl構造体がNULLの場合に返されます。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    WOLFSSL* ssl = wolfSSL(ctx);
+    ...
+    void* jobject = wolfSSL_get_jobject(ssl);
+
+    if(jobject != NULL){
+    	// Success case
+    }
+    \endcode
+    \sa wolfSSL_set_jobject
+*/
+void* wolfSSL_get_jobject(WOLFSSL* ssl);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数はSSL内のコールバックを設定します。コールバックはハンドシェイクメッセージを観察することです。CBのNULL値はコールバックをリセットします。
+    \return SSL_SUCCESS  成功しています。
+    \return SSL_FAILURE  NULL SSLが渡された場合。
+    _Example_
+    \code
+    static cb(int write_p, int version, int content_type,
+    const void *buf, size_t len, WOLFSSL *ssl, void *arg)
+    …
+    WOLFSSL* ssl;
+    ret  = wolfSSL_set_msg_callback(ssl, cb);
+    // check ret
+    \endcode
+    \sa wolfSSL_set_msg_callback_arg
+*/
+int wolfSSL_set_msg_callback(WOLFSSL *ssl, SSL_Msg_Cb cb);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、SSL内の関連コールバックコンテキスト値を設定します。値はコールバック引数に渡されます。
+    \return none  返品不可。
+    _Example_
+    \code
+    static cb(int write_p, int version, int content_type,
+    const void *buf, size_t len, WOLFSSL *ssl, void *arg)
+    …
+    WOLFSSL* ssl;
+    ret  = wolfSSL_set_msg_callback(ssl, cb);
+    // check ret
+    wolfSSL_set_msg_callback(ssl, arg);
+    \endcode
+    \sa wolfSSL_set_msg_callback
+*/
+int wolfSSL_set_msg_callback_arg(WOLFSSL *ssl, void* arg);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  この関数は、存在する場合は、ピア証明書からaltnameを返します。
+    \return NULL  次のAltNameがない場合。
+    \return cert->altNamesNext->name  wolfssl_x509から、AltNameリストからの文字列値である構造が存在する場合に返されます。
+    _Example_
+    \code
+    WOLFSSL_X509 x509 = (WOLFSSL_X509*)XMALLOC(sizeof(WOLFSSL_X509), NULL,
+                                                        DYNAMIC_TYPE_X509);
+    …
+    int x509NextAltName = wolfSSL_X509_get_next_altname(x509);
+    if(x509NextAltName == NULL){
+            //There isn’t another alt name
+    }
+    \endcode
+    \sa wolfSSL_X509_get_issuer_name
+    \sa wolfSSL_X509_get_subject_name
+*/
+char* wolfSSL_X509_get_next_altname(WOLFSSL_X509*);
+
+/*!
+    \ingroup CertsKeys 
+    \brief  関数は、x509がnullのかどうかを確認し、そうでない場合は、x509構造体のNotBeforeメンバーを返します。
+    \return pointer  X509構造体のNotBeforeメンバーにASN1_TIMEを使用して構造体に。
+    \return NULL  x509構造がnullの場合、関数はnullを返します。
+    _Example_
+    \code
+    WOLFSSL_X509* x509 = (WOLFSSL_X509)XMALLOC(sizeof(WOLFSSL_X509), NULL,
+    DYNAMIC_TYPE_X509) ;
+    …
+    const WOLFSSL_ASN1_TIME* notAfter = wolfSSL_X509_get_notBefore(x509);
+    if(notAfter == NULL){
+            //The x509 object was NULL
+    }
+    \endcode
+    \sa wolfSSL_X509_get_notAfter
+*/
+WOLFSSL_ASN1_TIME* wolfSSL_X509_get_notBefore(WOLFSSL_X509*);
+
+/*!
+    \ingroup IO 
+    \brief  この関数はクライアント側で呼び出され、サーバーとのSSL / TLSハンドシェイクを開始します。この関数が呼び出されると、基礎となる通信チャネルはすでに設定されています。 wolfssl_connect（）は、ブロックと非ブロックI / Oの両方で動作します。基礎となるI / Oがノンブロッキングされていない場合、wolfssl_connect（）は、基になるI / Oがwolfssl_connectのニーズを満たすことができなかったときに戻ります。この場合、wolfssl_get_error（）への呼び出しはSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかを生成します。通話プロセスは、基礎となるI / OがREADYおよびWOLFSSLが停止したときにwolfssl_connect（）への呼び出しを繰り返す必要があります。ノンブロッキングソケットを使用する場合は、何も実行する必要がありますが、select（）を使用して必要な条件を確認できます。基礎となる入出力がブロックされている場合、wolfssl_connect（）はハンドシェイクが終了したら、またはエラーが発生したらのみ戻る。 WolfSSLはOpenSSLよりも証明書検証に異なるアプローチを取ります。クライアントのデフォルトポリシーはサーバーを確認することです。これは、CASを読み込まない場合、サーバーを確認することができ、確認できません（-155）。 SSL_CONNECTを持つことのOpenSSLの動作が成功した場合は、サーバーを検証してセキュリティを抑えることができます.SSL_CTX_SET_VERIFY（CTX、SSL_VERIFY_NONE、0）。 ssl_new（）を呼び出す前に。お勧めできませんが。
+    \return SSL_SUCCESS  成功した場合
+    \return SSL_FATAL_ERROR  エラーが発生した場合は返されます。より詳細なエラーコードを取得するには、wolfssl_get_error（）を呼び出します。
+    _Example_
+    \code
+    int ret = 0;
+    int err = 0;
+    WOLFSSL* ssl;
+    char buffer[80];
+    ...
+    ret = wolfSSL_connect(ssl);
+    if (ret != SSL_SUCCESS) {
+    err = wolfSSL_get_error(ssl, ret);
+    printf(“error = %d, %s\n”, err, wolfSSL_ERR_error_string(err, buffer));
+    }
+    \endcode
+    \sa wolfSSL_get_error
+    \sa wolfSSL_accept
+*/
+int  wolfSSL_connect(WOLFSSL* ssl);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数はサーバー側で呼び出されて、HellORetryRequestメッセージにCookieを含める必要があることを示します。Cookieは現在のトランスクリプトのハッシュを保持しているので、別のサーバープロセスは応答でClientHelloを処理できます。秘密はCookieデータの整合性チェックをGenertingするときに使用されます。
+    \param [in,out]  SSL wolfssl_new（）を使用して作成されたwolfssl構造へのポインタ。
+    \param [in]  秘密を保持しているバッファへのポインタを秘密にします。渡すNULLは、新しいランダムシークレットを生成することを示します。
+    \param [in]  シークスのサイズをバイト単位でサイズ。0を渡すと、デフォルトのサイズを使用することを示します.WC_SHA256_DIGEST_SIZE（またはSHA-256が使用できない場合はWC_SHA_DIGEST_SIZE）。
+    \return BAD_FUNC_ARG  SSLがNULLの場合、またはTLS v1.3を使用していない場合。
+    \return SIDE_ERROR  クライアントで呼び出された場合。
+    \return WOLFSSL_SUCCESS  成功した場合
+    \return MEMORY_ERROR  秘密を保存するために動的メモリを割り当てる場合に失敗しました。
+    _Example_
+    \code
+    int ret;
+    WOLFSSL* ssl;
+    char secret[32];
+    ...
+    ret = wolfSSL__send_hrr_cookie(ssl, secret, sizeof(secret));
+    if (ret != WOLFSSL_SUCCESS) {
+        // failed to set use of Cookie and secret
+    }
+    \endcode
+    \sa wolfSSL_new
+*/
+int  wolfSSL_send_hrr_cookie(WOLFSSL* ssl,
+    const unsigned char* secret, unsigned int secretSz);
+
+/*!
+    \ingroup Setup 
+    \brief  ハンドシェイクが完了すると、この関数はサーバー上で再開セッションチケットの送信を停止するように呼び出されます。
+    \param [in,out]  ctx wolfssl_ctx_new（）で作成されたwolfssl_ctx構造へのポインタ。
+    \return BAD_FUNC_ARG  CTXがNULLの場合、またはTLS v1.3を使用していない場合。
+    \return SIDE_ERROR  クライアントで呼び出された場合。
+    _Example_
+    \code
+    int ret;
+    WOLFSSL_CTX* ctx;
+    ...
+    ret = wolfSSL_CTX_no_ticket_TLSv13(ctx);
+    if (ret != 0) {
+        // failed to set no ticket
+    }
+    \endcode
+    \sa wolfSSL_no_ticket_TLSv13
+*/
+int  wolfSSL_CTX_no_ticket_TLSv13(WOLFSSL_CTX* ctx);
+
+/*!
+    \ingroup Setup 
+    \brief  ハンドシェイクが完了すると、この関数はサーバー上で再開セッションチケットの送信を停止するように呼び出されます。
+    \param [in,out]  SSL wolfssl_new（）を使用して作成されたwolfssl構造へのポインタ。
+    \return BAD_FUNC_ARG  SSLがNULLの場合、またはTLS v1.3を使用していない場合。
+    \return SIDE_ERROR  クライアントで呼び出された場合。
+    _Example_
+    \code
+    int ret;
+    WOLFSSL* ssl;
+    ...
+    ret = wolfSSL_no_ticket_TLSv13(ssl);
+    if (ret != 0) {
+        // failed to set no ticket
+    }
+    \endcode
+    \sa wolfSSL_CTX_no_ticket_TLSv13
+*/
+int  wolfSSL_no_ticket_TLSv13(WOLFSSL* ssl);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、Authenticationにプリシェアキーを使用している場合、DIFFIE-HELLMAN（DH）スタイルのキー交換を許可するTLS V1.3 WolfSSLコンテキストで呼び出されます。
+    \param [in,out]  ctx wolfssl_ctx_new（）で作成されたwolfssl_ctx構造へのポインタ。
+    \return BAD_FUNC_ARG  CTXがNULLの場合、またはTLS v1.3を使用していない場合。
+    _Example_
+    \code
+    int ret;
+    WOLFSSL_CTX* ctx;
+    ...
+    ret = wolfSSL_CTX_no_dhe_psk(ctx);
+    if (ret != 0) {
+        // failed to set no DHE for PSK handshakes
+    }
+    \endcode
+    \sa wolfSSL_no_dhe_psk
+*/
+int  wolfSSL_CTX_no_dhe_psk(WOLFSSL_CTX* ctx);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、Authenticationのためにプリシェアキーを使用しているときにDiffie-Hellman（DH）スタイルのキー交換を許可するTLS V1.3クライアントまたはサーバーのWolfSSLで呼び出されます。
+    \param [in,out]  SSL wolfssl_new（）を使用して作成されたwolfssl構造へのポインタ。
+    \return BAD_FUNC_ARG  SSLがNULLの場合、またはTLS v1.3を使用していない場合。
+    _Example_
+    \code
+    int ret;
+    WOLFSSL* ssl;
+    ...
+    ret = wolfSSL_no_dhe_psk(ssl);
+    if (ret != 0) {
+        // failed to set no DHE for PSK handshakes
+    }
+    \endcode
+    \sa wolfSSL_CTX_no_dhe_psk
+*/
+int  wolfSSL_no_dhe_psk(WOLFSSL* ssl);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、TLS v1.3クライアントまたはサーバーのwolfsslで呼び出されて、キーのロールオーバーを強制します。KeyUpdateメッセージがピアに送信され、新しいキーが暗号化のために計算されます。ピアはKeyUpdateメッセージを送り、新しい復号化キーWILを計算します。この機能は、ハンドシェイクが完了した後にのみ呼び出すことができます。
+    \param [in,out]  SSL wolfssl_new（）を使用して作成されたwolfssl構造へのポインタ。
+    \return BAD_FUNC_ARG  SSLがNULLの場合、またはTLS v1.3を使用していない場合。
+    \return WANT_WRITE  書き込みが準備ができていない場合
+    _Example_
+    \code
+    int ret;
+    WOLFSSL* ssl;
+    ...
+    ret = wolfSSL_update_keys(ssl);
+    if (ret == WANT_WRITE) {
+        // need to call again when I/O ready
+    }
+    else if (ret != WOLFSSL_SUCCESS) {
+        // failed to send key update
+    }
+    \endcode
+    \sa wolfSSL_write
+*/
+int  wolfSSL_update_keys(WOLFSSL* ssl);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、TLS v1.3クライアントまたはサーバーのwolfsslで呼び出され、キーのロールオーバーが進行中かどうかを判断します。wolfssl_update_keys（）が呼び出されると、KeyUpdateメッセージが送信され、暗号化キーが更新されます。復号化キーは、応答が受信されたときに更新されます。
+    \param [in]  SSL wolfssl_new（）を使用して作成されたwolfssl構造へのポインタ。
+    \param [out]  キー更新応答が必要ない場合は必須0。1キー更新応答が必要ない場合。
+    \return 0  成功した。
+    _Example_
+    \code
+    int ret;
+    WOLFSSL* ssl;
+    int required;
+    ...
+    ret = wolfSSL_key_update_response(ssl, &required);
+    if (ret != 0) {
+        // bad parameters
+    }
+    if (required) {
+        // encrypt Key updated, awaiting response to change decrypt key
+    }
+    \endcode
+    \sa wolfSSL_update_keys
+*/
+int  wolfSSL_key_update_response(WOLFSSL* ssl, int* required);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、TLS v1.3クライアントのWolfSSLコンテキストで呼び出され、クライアントはサーバーからの要求に応じてPost Handshakeを送信できるようにします。これは、クライアント認証などを必要としないページを持つWebサーバーに接続するときに役立ちます。
+    \param [in,out]  ctx wolfssl_ctx_new（）で作成されたwolfssl_ctx構造へのポインタ。
+    \return BAD_FUNC_ARG  CTXがNULLの場合、またはTLS v1.3を使用していない場合。
+    \return SIDE_ERROR  サーバーで呼び出された場合。
+    _Example_
+    \code
+    int ret;
+    WOLFSSL_CTX* ctx;
+    ...
+    ret = wolfSSL_allow_post_handshake_auth(ctx);
+    if (ret != 0) {
+        // failed to allow post handshake authentication
+    }
+    \endcode
+    \sa wolfSSL_allow_post_handshake_auth
+    \sa wolfSSL_request_certificate
+*/
+int  wolfSSL_CTX_allow_post_handshake_auth(WOLFSSL_CTX* ctx);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、TLS V1.3クライアントWolfSSLで呼び出され、クライアントはサーバーからの要求に応じてハンドシェイクを送ります。handshakeクライアント認証拡張機能はClientHelloで送信されます。これは、クライアント認証などを必要としないページを持つWebサーバーに接続するときに役立ちます。
+    \param [in,out]  SSL wolfssl_new（）を使用して作成されたwolfssl構造へのポインタ。
+    \return BAD_FUNC_ARG  SSLがNULLの場合、またはTLS v1.3を使用していない場合。
+    \return SIDE_ERROR  サーバーで呼び出された場合。
+    _Example_
+    \code
+    int ret;
+    WOLFSSL* ssl;
+    ...
+    ret = wolfSSL_allow_post_handshake_auth(ssl);
+    if (ret != 0) {
+        // failed to allow post handshake authentication
+    }
+    \endcode
+    \sa wolfSSL_CTX_allow_post_handshake_auth
+    \sa wolfSSL_request_certificate
+*/
+int  wolfSSL_allow_post_handshake_auth(WOLFSSL* ssl);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、TLS v1.3クライアントからクライアント証明書を要求します。これは、Webサーバーがクライアント認証やその他のものを必要とするページにサービスを提供している場合に役立ちます。接続で最大256の要求を送信できます。
+    \param [in,out]  SSL wolfssl_new（）を使用して作成されたwolfssl構造へのポインタ。
+    \return BAD_FUNC_ARG  SSLがNULLの場合、またはTLS v1.3を使用していない場合。
+    \return WANT_WRITE  書き込みが準備ができていない場合
+    \return SIDE_ERROR  クライアントで呼び出された場合。
+    \return NOT_READY_ERROR  ハンドシェイクが終了していないときに呼び出された場合。
+    \return POST_HAND_AUTH_ERROR  送付後認証が許可されていない場合。
+    \return MEMORY_E  動的メモリ割り当てが失敗した場合
+    _Example_
+    \code
+    int ret;
+    WOLFSSL* ssl;
+    ...
+    ret = wolfSSL_request_certificate(ssl);
+    if (ret == WANT_WRITE) {
+        // need to call again when I/O ready
+    }
+    else if (ret != WOLFSSL_SUCCESS) {
+        // failed to request a client certificate
+    }
+    \endcode
+    \sa wolfSSL_allow_post_handshake_auth
+    \sa wolfSSL_write
+*/
+int  wolfSSL_request_certificate(WOLFSSL* ssl);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は楕円曲線グループのリストを設定して、WolfSSLコンテキストを希望の順に設定します。リストはヌル終了したテキスト文字列、およびコロン区切りリストです。この関数を呼び出して、TLS v1.3接続で使用する鍵交換楕円曲線パラメータを設定します。
+    \param [in,out]  ctx wolfssl_ctx_new（）で作成されたwolfssl_ctx構造へのポインタ。
+    \param [in]  楕円曲線グループのコロン区切りリストである文字列をリストします。
+    \return WOLFSSL_FAILURE  ポインタパラメータがNULLの場合、wolfssl_max_group_countグループが多い場合は、グループ名が認識されないか、TLS v1.3を使用していません。
+    _Example_
+    \code
+    int ret;
+    WOLFSSL_CTX* ctx;
+    const char* list = "P-384:P-256";
+    ...
+    ret = wolfSSL_CTX_set1_groups_list(ctx, list);
+    if (ret != WOLFSSL_SUCCESS) {
+        // failed to set group list
+    }
+    \endcode
+    \sa wolfSSL_set1_groups_list
+    \sa wolfSSL_CTX_set_groups
+    \sa wolfSSL_set_groups
+    \sa wolfSSL_UseKeyShare
+    \sa wolfSSL_preferred_group
+*/
+int  wolfSSL_CTX_set1_groups_list(WOLFSSL_CTX *ctx, char *list);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は楕円曲線グループのリストを設定して、WolfSSLを希望の順に設定します。リストはヌル終了したテキスト文字列、およびコロン区切りリストです。この関数を呼び出して、TLS v1.3接続で使用する鍵交換楕円曲線パラメータを設定します。
+    \param [in,out]  SSL wolfssl_new（）を使用して作成されたwolfssl構造へのポインタ。
+    \param [in]  鍵交換グループのコロン区切りリストである文字列をリストします。
+    \return WOLFSSL_FAILURE  ポインタパラメータがNULLの場合、wolfssl_max_group_countグループが多い場合は、グループ名が認識されないか、TLS v1.3を使用していません。
+    _Example_
+    \code
+    int ret;
+    WOLFSSL* ssl;
+    const char* list = "P-384:P-256";
+    ...
+    ret = wolfSSL_CTX_set1_groups_list(ssl, list);
+    if (ret != WOLFSSL_SUCCESS) {
+        // failed to set group list
+    }
+    \endcode
+    \sa wolfSSL_CTX_set1_groups_list
+    \sa wolfSSL_CTX_set_groups
+    \sa wolfSSL_set_groups
+    \sa wolfSSL_UseKeyShare
+    \sa wolfSSL_preferred_group
+*/
+int  wolfSSL_set1_groups_list(WOLFSSL *ssl, char *list);
+
+/*!
+    \ingroup TLS 
+    \brief  この関数は、クライアントがTLS v1.3ハンドシェイクで使用することを好むキー交換グループを返します。この情報を完了した後にこの機能を呼び出して、サーバーがどのグループが予想されるようにこの情報が将来の接続で使用できるようになるかを決定するために、この情報が将来の接続で鍵交換のための鍵ペアを事前生成することができます。
+    \param [in,out]  SSL wolfssl_new（）を使用して作成されたwolfssl構造へのポインタ。
+    \return BAD_FUNC_ARG  SSLがNULLの場合、またはTLS v1.3を使用していない場合。
+    \return SIDE_ERROR  サーバーで呼び出された場合。
+    \return NOT_READY_ERROR  ハンドシェイクが完了する前に呼び出された場合。
+    _Example_
+    \code
+    int ret;
+    int group;
+    WOLFSSL* ssl;
+    ...
+    ret = wolfSSL_CTX_set1_groups_list(ssl)
+    if (ret < 0) {
+        // failed to get group
+    }
+    group = ret;
+    \endcode
+    \sa wolfSSL_UseKeyShare
+    \sa wolfSSL_CTX_set_groups
+    \sa wolfSSL_set_groups
+    \sa wolfSSL_CTX_set1_groups_list
+    \sa wolfSSL_set1_groups_list
+*/
+int  wolfSSL_preferred_group(WOLFSSL* ssl);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は楕円曲線グループのリストを設定して、WolfSSLコンテキストを希望の順に設定します。リストは、Countで指定された識別子の数を持つグループ識別子の配列です。この関数を呼び出して、TLS v1.3接続で使用する鍵交換楕円曲線パラメータを設定します。
+    \param [in,out]  ctx wolfssl_ctx_new（）で作成されたwolfssl_ctx構造へのポインタ。
+    \param [in]  識別子によって鍵交換グループのリストをグループ化します。
+    \param [in]  グループ内の鍵交換グループの数を数えます。
+    \return BAD_FUNC_ARG  ポインタパラメータがNULLの場合、グループ数はwolfssl_max_group_countを超えているか、TLS v1.3を使用していません。
+    _Example_
+    \code
+    int ret;
+    WOLFSSL_CTX* ctx;
+    int* groups = { WOLFSSL_ECC_X25519, WOLFSSL_ECC_SECP256R1 };
+    int count = 2;
+    ...
+    ret = wolfSSL_CTX_set1_groups_list(ctx, groups, count);
+    if (ret != WOLFSSL_SUCCESS) {
+        // failed to set group list
+    }
+    \endcode
+    \sa wolfSSL_set_groups
+    \sa wolfSSL_UseKeyShare
+    \sa wolfSSL_CTX_set_groups
+    \sa wolfSSL_set_groups
+    \sa wolfSSL_CTX_set1_groups_list
+    \sa wolfSSL_set1_groups_list
+    \sa wolfSSL_preferred_group
+*/
+int  wolfSSL_CTX_set_groups(WOLFSSL_CTX* ctx, int* groups,
+    int count);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、wolfsslを許すために楕円曲線グループのリストを設定します。リストは、Countで指定された識別子の数を持つグループ識別子の配列です。この関数を呼び出して、TLS v1.3接続で使用する鍵交換楕円曲線パラメータを設定します。
+    \param [in,out]  SSL wolfssl_new（）を使用して作成されたwolfssl構造へのポインタ。
+    \param [in]  識別子によって鍵交換グループのリストをグループ化します。
+    \param [in]  グループ内の鍵交換グループの数を数えます。
+    \return BAD_FUNC_ARG  ポインタパラメータがNULLの場合、グループ数がWolfSSL_MAX_GROUP_COUNTを超えている場合、任意の識別子は認識されないか、TLS v1.3を使用していません。
+    _Example_
+    \code
+    int ret;
+    WOLFSSL* ssl;
+    int* groups = { WOLFSSL_ECC_X25519, WOLFSSL_ECC_SECP256R1 };
+    int count = 2;
+    ...
+    ret = wolfSSL_set_groups(ssl, groups, count);
+    if (ret != WOLFSSL_SUCCESS) {
+        // failed to set group list
+    }
+    \endcode
+    \sa wolfSSL_CTX_set_groups
+    \sa wolfSSL_UseKeyShare
+    \sa wolfSSL_CTX_set_groups
+    \sa wolfSSL_set_groups
+    \sa wolfSSL_CTX_set1_groups_list
+    \sa wolfSSL_set1_groups_list
+    \sa wolfSSL_preferred_group
+*/
+int  wolfSSL_set_groups(WOLFSSL* ssl, int* groups, int count);
+
+/*!
+    \ingroup IO 
+    \brief  この関数はクライアント側で呼び出され、サーバーとのTLS v1.3ハンドシェイクを開始します。この関数が呼び出されると、基礎となる通信チャネルはすでに設定されています。 wolfssl_connect（）は、ブロックと非ブロックI / Oの両方で動作します。基礎となるI / Oがノンブロッキングされていない場合、wolfssl_connect（）は、基になるI / Oがwolfssl_connectのニーズを満たすことができなかったときに戻ります。この場合、wolfssl_get_error（）への呼び出しはSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかを生成します。通話プロセスは、基礎となるI / OがREADYおよびWOLFSSLが停止したときにwolfssl_connect（）への呼び出しを繰り返す必要があります。ノンブロッキングソケットを使用する場合は、何も実行する必要がありますが、select（）を使用して必要な条件を確認できます。基礎となる入出力がブロックされている場合、wolfssl_connect（）はハンドシェイクが終了したら、またはエラーが発生したらのみ戻る。 WolfSSLはOpenSSLよりも証明書検証に異なるアプローチを取ります。クライアントのデフォルトポリシーはサーバーを確認することです。これは、CASを読み込まない場合、サーバーを確認することができ、確認できません（-155）。 SSL_CONNECTを持つことのOpenSSLの動作が成功した場合は、サーバーを検証してセキュリティを抑えることができます.SSL_CTX_SET_VERIFY（CTX、SSL_VERIFY_NONE、0）。 ssl_new（）を呼び出す前に。お勧めできませんが。
+    \return SSL_SUCCESS  成功すると。
+    \return SSL_FATAL_ERROR  エラーが発生した場合は返されます。より詳細なエラーコードを取得するには、wolfssl_get_error（）を呼び出します。
+    _Example_
+    \code
+    int ret = 0;
+    int err = 0;
+    WOLFSSL* ssl;
+    char buffer[80];
+    ...
+
+    ret = wolfSSL_connect_TLSv13(ssl);
+    if (ret != SSL_SUCCESS) {
+        err = wolfSSL_get_error(ssl, ret);
+        printf(“error = %d, %s\n”, err, wolfSSL_ERR_error_string(err, buffer));
+    }
+    \endcode
+    \sa wolfSSL_get_error
+    \sa wolfSSL_connect
+    \sa wolfSSL_accept_TLSv13
+    \sa wolfSSL_accept
+*/
+int  wolfSSL_connect_TLSv13(WOLFSSL*);
+
+/*!
+    \ingroup IO 
+    \brief  この関数はサーバー側で呼び出され、SSL / TLSクライアントがSSL / TLSハンドシェイクを開始するのを待ちます。この関数が呼び出されると、基礎となる通信チャネルはすでに設定されています。 wolfssl_accept（）は、ブロックと非ブロッキングI / Oの両方で動作します。基礎となる入出力がノンブロッキングである場合、wolfssl_accept（）は、基礎となるI / Oがwolfssl_acceptのニーズを満たすことができなかったときに戻ります。この場合、wolfssl_get_error（）への呼び出しはSSL_ERROR_WANT_READまたはSSL_ERROR_WANT_WRITEのいずれかを生成します。通話プロセスは、読み取り可能なデータが使用可能であり、wolfsslが停止した場所を拾うときに、wolfssl_acceptの呼び出しを繰り返す必要があります。ノンブロッキングソケットを使用する場合は、何も実行する必要がありますが、select（）を使用して必要な条件を確認できます。基礎となるI / Oがブロックされている場合、wolfssl_accept（）はハンドシェイクが終了したら、またはエラーが発生したら戻ります。古いバージョンのClientHelloメッセージがサポートされていますが、TLS v1.3接続を期待するときにこの関数を呼び出します。
+    \return SSL_SUCCESS  成功すると。
+    \return SSL_FATAL_ERROR  エラーが発生した場合は返されます。より詳細なエラーコードを取得するには、wolfssl_get_error（）を呼び出します。
+    _Example_
+    \code
+    int ret = 0;
+    int err = 0;
+    WOLFSSL* ssl;
+    char buffer[80];
+    ...
+
+    ret = wolfSSL_accept_TLSv13(ssl);
+    if (ret != SSL_SUCCESS) {
+        err = wolfSSL_get_error(ssl, ret);
+        printf(“error = %d, %s\n”, err, wolfSSL_ERR_error_string(err, buffer));
+    }
+    \endcode
+    \sa wolfSSL_get_error
+    \sa wolfSSL_connect_TLSv13
+    \sa wolfSSL_connect
+    \sa wolfSSL_accept_TLSv13
+    \sa wolfSSL_accept
+*/
+wolfSSL_accept_TLSv13(WOLFSSL* ssl);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、WolfSSLコンテキストを使用してTLS V1.3サーバーによって受け入れられる早期データの最大量を設定します。この関数を呼び出して、再生攻撃を軽減するためのプロセスへの早期データの量を制限します。初期のデータは、セッションチケットが送信されたこと、したがってセッションチケットが再開されるたびに同じ接続のキーから派生したキーによって保護されます。値は再開のためにセッションチケットに含まれています。ゼロの値は、セッションチケットを使用してクライアントによって早期データを送信することを示します。早期データバイト数をアプリケーションで実際には可能な限り低く保つことをお勧めします。
+    \param [in,out]  ctx wolfssl_ctx_new（）で作成されたwolfssl_ctx構造へのポインタ。
+    \param [in]  SZバイト単位で受け入れる早期データの量。
+    \return BAD_FUNC_ARG  CTXがNULLの場合、またはTLS v1.3を使用していない場合。
+    \return SIDE_ERROR  クライアントで呼び出された場合。
+    _Example_
+    \code
+    int ret;
+    WOLFSSL_CTX* ctx;
+    ...
+    ret = wolfSSL_CTX_set_max_early_data(ctx, 128);
+    if (ret != WOLFSSL_SUCCESS) {
+        // failed to set group list
+    }
+    \endcode
+    \sa wolfSSL_set_max_early_data
+    \sa wolfSSL_write_early_data
+    \sa wolfSSL_read_early_data
+*/
+int  wolfSSL_CTX_set_max_early_data(WOLFSSL_CTX* ctx,
+    unsigned int sz);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、WolfSSLコンテキストを使用してTLS V1.3サーバーによって受け入れられる早期データの最大量を設定します。この関数を呼び出して、再生攻撃を軽減するためのプロセスへの早期データの量を制限します。初期のデータは、セッションチケットが送信されたこと、したがってセッションチケットが再開されるたびに同じ接続のキーから派生したキーによって保護されます。値は再開のためにセッションチケットに含まれています。ゼロの値は、セッションチケットを使用してクライアントによって早期データを送信することを示します。早期データバイト数をアプリケーションで実際には可能な限り低く保つことをお勧めします。
+    \param [in,out]  SSL wolfssl_new（）を使用して作成されたwolfssl構造へのポインタ。
+    \param [in]  SZクライアントからバイト単位で受け入れる早期データの量。
+    \return BAD_FUNC_ARG  SSLがNULLの場合、またはTLS v1.3を使用していない場合。
+    \return SIDE_ERROR  クライアントで呼び出された場合。
+    _Example_
+    \code
+    int ret;
+    WOLFSSL* ssl;
+    ...
+    ret = wolfSSL_set_max_early_data(ssl, 128);
+    if (ret != WOLFSSL_SUCCESS) {
+        // failed to set group list
+    }
+    \endcode
+    \sa wolfSSL_CTX_set_max_early_data
+    \sa wolfSSL_write_early_data
+    \sa wolfSSL_read_early_data
+*/
+int  wolfSSL_set_max_early_data(WOLFSSL* ssl, unsigned int sz);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、再開時にサーバーに早期データを書き込みます。wolfssl_connect（）またはwolfssl_connect_tlsv13（）の代わりにこの関数を呼び出して、サーバーに接続してハンドシェイクにデータを送ります。この機能はクライアントでのみ使用されます。
+    \param [in,out]  SSL wolfssl_new（）を使用して作成されたwolfssl構造へのポインタ。
+    \param [in]  データ早期データを保持してサーバーに書き込むバッファ。
+    \param [in]  SZバイト単位で書き込む早期データの量。
+    \param [out]  OUTSZバイト単位で書かれた早期データの量。
+    \return BAD_FUNC_ARG  ポインタパラメータがNULLの場合、SZは0未満またはTLSV1.3を使用しない。
+    \return SIDE_ERROR  サーバーで呼び出された場合。
+    \return WOLFSSL_FATAL_ERROR  接続が行われていない場合。
+    _Example_
+    \code
+    int ret = 0;
+    int err = 0;
+    WOLFSSL* ssl;
+    byte earlyData[] = { early data };
+    int outSz;
+    char buffer[80];
+    ...
+
+    ret = wolfSSL_write_early_data(ssl, earlyData, sizeof(earlyData), &outSz);
+    if (ret != WOLFSSL_SUCCESS) {
+        err = wolfSSL_get_error(ssl, ret);
+        printf(“error = %d, %s\n”, err, wolfSSL_ERR_error_string(err, buffer));
+        goto err_label;
+    }
+    if (outSz < sizeof(earlyData)) {
+        // not all early data was sent
+    }
+    ret = wolfSSL_connect_TLSv13(ssl);
+    if (ret != SSL_SUCCESS) {
+        err = wolfSSL_get_error(ssl, ret);
+        printf(“error = %d, %s\n”, err, wolfSSL_ERR_error_string(err, buffer));
+    }
+    \endcode
+    \sa wolfSSL_read_early_data
+    \sa wolfSSL_connect
+    \sa wolfSSL_connect_TLSv13
+*/
+int  wolfSSL_write_early_data(OLFSSL* ssl, const void* data,
+    int sz, int* outSz);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、再開時にクライアントからの早期データを読み取ります。wolfssl_accept（）またはwolfssl_accept_tlsv13（）の代わりにこの関数を呼び出して、クライアントを受け入れ、ハンドシェイク内の早期データを読み取ります。ハンドシェイクよりも早期データがない場合は、通常として処理されます。この機能はサーバーでのみ使用されます。
+    \param [in,out]  SSL wolfssl_new（）を使用して作成されたwolfssl構造へのポインタ。
+    \param [out]  データはクライアントから読み込まれた早期データを保持するためのバッファ。
+    \param [in]  バッファのSZサイズバイト数。
+    \param [out]  OUTSZ初期データのバイト数。
+    \return BAD_FUNC_ARG  ポインタパラメータがNULLの場合、SZは0未満またはTLSV1.3を使用しない。
+    \return SIDE_ERROR  クライアントで呼び出された場合。
+    \return WOLFSSL_FATAL_ERROR  接続を受け入れると失敗した場合
+    _Example_
+    \code
+    int ret = 0;
+    int err = 0;
+    WOLFSSL* ssl;
+    byte earlyData[128];
+    int outSz;
+    char buffer[80];
+    ...
+
+    ret = wolfSSL_read_early_data(ssl, earlyData, sizeof(earlyData), &outSz);
+    if (ret != SSL_SUCCESS) {
+        err = wolfSSL_get_error(ssl, ret);
+        printf(“error = %d, %s\n”, err, wolfSSL_ERR_error_string(err, buffer));
+    }
+    if (outSz > 0) {
+        // early data available
+    }
+    ret = wolfSSL_accept_TLSv13(ssl);
+    if (ret != SSL_SUCCESS) {
+        err = wolfSSL_get_error(ssl, ret);
+        printf(“error = %d, %s\n”, err, wolfSSL_ERR_error_string(err, buffer));
+    }
+    \endcode
+    \sa wolfSSL_write_early_data
+    \sa wolfSSL_accept
+    \sa wolfSSL_accept_TLSv13
+*/
+int  wolfSSL_read_early_data(WOLFSSL* ssl, void* data, int sz,
+    int* outSz);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、TLS v1.3接続のプレシェアキー（PSK）クライアント側コールバックを設定します。コールバックはPSKアイデンティティを見つけ、そのキーと、ハンドシェイクに使用する暗号の名前を返します。この関数は、wolfssl_ctx構造体のclient_psk_tls13_cbメンバーを設定します。
+    \param [in,out]  ctx wolfssl_ctx_new（）で作成されたwolfssl_ctx構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx;
+    ...
+    wolfSSL_CTX_set_psk_client_tls13_callback(ctx, my_psk_client_tls13_cb);
+    \endcode
+    \sa wolfSSL_set_psk_client_tls13_callback
+    \sa wolfSSL_CTX_set_psk_server_tls13_callback
+    \sa wolfSSL_set_psk_server_tls13_callback
+*/
+void wolfSSL_CTX_set_psk_client_tls13_callback(WOLFSSL_CTX* ctx,
+    wc_psk_client_tls13_callback cb);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、TLS v1.3接続のプレシェアキー（PSK）クライアント側コールバックを設定します。コールバックはPSKアイデンティティを見つけ、そのキーと、ハンドシェイクに使用する暗号の名前を返します。この関数は、wolfssl構造体のOptionsフィールドのclient_psk_tls13_cbメンバーを設定します。
+    \param [in,out]  SSL wolfssl_new（）を使用して作成されたwolfssl構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    ...
+    wolfSSL_set_psk_client_tls13_callback(ssl, my_psk_client_tls13_cb);
+    \endcode
+    \sa wolfSSL_CTX_set_psk_client_tls13_callback
+    \sa wolfSSL_CTX_set_psk_server_tls13_callback
+    \sa wolfSSL_set_psk_server_tls13_callback
+*/
+void wolfSSL_set_psk_client_tls13_callback(WOLFSSL* ssl,
+    wc_psk_client_tls13_callback cb);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、TLS v1.3接続用の事前共有キー（PSK）サーバ側コールバックを設定します。コールバックはPSKアイデンティティを見つけ、そのキーと、ハンドシェイクに使用する暗号の名前を返します。この関数は、wolfssl_ctx構造体のserver_psk_tls13_cbメンバーを設定します。
+    \param [in,out]  ctx wolfssl_ctx_new（）で作成されたwolfssl_ctx構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx;
+    ...
+    wolfSSL_CTX_set_psk_server_tls13_callback(ctx, my_psk_client_tls13_cb);
+    \endcode
+    \sa wolfSSL_CTX_set_psk_client_tls13_callback
+    \sa wolfSSL_set_psk_client_tls13_callback
+    \sa wolfSSL_set_psk_server_tls13_callback
+*/
+void wolfSSL_CTX_set_psk_server_tls13_callback(WOLFSSL_CTX* ctx,
+    wc_psk_server_tls13_callback cb);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、TLS v1.3接続用の事前共有キー（PSK）サーバ側コールバックを設定します。コールバックはPSKアイデンティティを見つけ、そのキーと、ハンドシェイクに使用する暗号の名前を返します。この関数は、wolfssl構造体のオプションフィールドのserver_psk_tls13_cbメンバーを設定します。
+    \param [in,out]  SSL wolfssl_new（）を使用して作成されたwolfssl構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    ...
+    wolfSSL_set_psk_server_tls13_callback(ssl, my_psk_server_tls13_cb);
+    \endcode
+    \sa wolfSSL_CTX_set_psk_client_tls13_callback
+    \sa wolfSSL_set_psk_client_tls13_callback
+    \sa wolfSSL_CTX_set_psk_server_tls13_callback
+*/
+void wolfSSL_set_psk_server_tls13_callback(WOLFSSL* ssl,
+    wc_psk_server_tls13_callback cb);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、キーペアの生成を含むグループからキーシェアエントリを作成します。Keyshareエクステンションには、鍵交換のための生成されたすべての公開鍵が含まれています。この関数が呼び出されると、指定されたグループのみが含まれます。優先グループがサーバーに対して以前に確立されているときにこの関数を呼び出します。
+    \param [in,out]  SSL wolfssl_new（）を使用して作成されたwolfssl構造へのポインタ。
+    \param [in]  キー交換グループ識別子をグループ化します。
+    \return BAD_FUNC_ARG  SSLがNULLの場合
+    \return MEMORY_E  動的メモリ割り当てが失敗すると失敗すると。
+    _Example_
+    \code
+    int ret;
+    WOLFSSL* ssl;
+    ...
+    ret = wolfSSL_UseKeyShare(ssl, WOLFSSL_ECC_X25519);
+    if (ret != WOLFSSL_SUCCESS) {
+        // failed to set key share
+    }
+    \endcode
+    \sa wolfSSL_preferred_group
+    \sa wolfSSL_CTX_set1_groups_list
+    \sa wolfSSL_set1_groups_list
+    \sa wolfSSL_CTX_set_groups
+    \sa wolfSSL_set_groups
+    \sa wolfSSL_NoKeyShares
+*/
+int wolfSSL_UseKeyShare(WOLFSSL* ssl, word16 group);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、ClientHelloで鍵共有が送信されないように呼び出されます。これにより、ハンドシェイクに鍵交換が必要な場合は、サーバーがHelloretryRequestで応答するように強制します。予想される鍵交換グループが知られておらず、キーの生成を不必要に回避するときにこの機能を呼び出します。鍵交換が必要なときにハンドシェイクを完了するために追加の往復が必要になることに注意してください。
+    \param [in,out]  SSL wolfssl_new（）を使用して作成されたwolfssl構造へのポインタ。
+    \return BAD_FUNC_ARG  SSLがNULLの場合
+    \return SIDE_ERROR  サーバーで呼び出された場合。
+    _Example_
+    \code
+    int ret;
+    WOLFSSL* ssl;
+    ...
+    ret = wolfSSL_NoKeyShares(ssl);
+    if (ret != WOLFSSL_SUCCESS) {
+        // failed to set no key shares
+    }
+    \endcode
+    \sa wolfSSL_UseKeyShare
+*/
+int wolfSSL_NoKeyShares(WOLFSSL* ssl);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、アプリケーションがサーバーであることを示すために使用され、TLS 1.3プロトコルのみをサポートします。この関数は、wolfssl_ctx_new（）を使用してSSL / TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。
+    \param [in]  ヒープ静的メモリ割り当て中に静的メモリ割り当て器が使用するバッファへのポインタを使用します。
+    \return If  成功すると、呼び出しは新しく作成されたwolfssl_method構造体へのポインタを返します。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_METHOD* method;
+    WOLFSSL_CTX* ctx;
+
+    method = wolfTLSv1_3_server_method_ex(NULL);
+    if (method == NULL) {
+        // unable to get method
+    }
+
+    ctx = wolfSSL_CTX_new(method);
+    ...
+    \endcode
+    \sa wolfSSLv3_server_method
+    \sa wolfTLSv1_server_method
+    \sa wolfTLSv1_1_server_method
+    \sa wolfTLSv1_2_server_method
+    \sa wolfTLSv1_3_server_method
+    \sa wolfDTLSv1_server_method
+    \sa wolfSSLv23_server_method
+    \sa wolfSSL_CTX_new
+*/
+WOLFSSL_METHOD *wolfTLSv1_3_server_method_ex(void* heap);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、アプリケーションがクライアントであることを示すために使用され、TLS 1.3プロトコルのみをサポートします。この関数は、wolfssl_ctx_new（）を使用してSSL / TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。
+    \param [in]  ヒープ静的メモリ割り当て中に静的メモリ割り当て器が使用するバッファへのポインタを使用します。
+    \return If  成功すると、呼び出しは新しく作成されたwolfssl_method構造体へのポインタを返します。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_METHOD* method;
+    WOLFSSL_CTX* ctx;
+
+    method = wolfTLSv1_3_client_method_ex(NULL);
+    if (method == NULL) {
+        // unable to get method
+    }
+
+    ctx = wolfSSL_CTX_new(method);
+    ...
+    \endcode
+    \sa wolfSSLv3_client_method
+    \sa wolfTLSv1_client_method
+    \sa wolfTLSv1_1_client_method
+    \sa wolfTLSv1_2_client_method
+    \sa wolfTLSv1_3_client_method
+    \sa wolfDTLSv1_client_method
+    \sa wolfSSLv23_client_method
+    \sa wolfSSL_CTX_new
+*/
+WOLFSSL_METHOD *wolfTLSv1_3_client_method_ex(void* heap);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、アプリケーションがサーバーであることを示すために使用され、TLS 1.3プロトコルのみをサポートします。この関数は、wolfssl_ctx_new（）を使用してSSL / TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。
+    \return If  成功すると、呼び出しは新しく作成されたwolfssl_method構造体へのポインタを返します。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_METHOD* method;
+    WOLFSSL_CTX* ctx;
+
+    method = wolfTLSv1_3_server_method();
+    if (method == NULL) {
+        // unable to get method
+    }
+
+    ctx = wolfSSL_CTX_new(method);
+    ...
+    \endcode
+    \sa wolfSSLv3_server_method
+    \sa wolfTLSv1_server_method
+    \sa wolfTLSv1_1_server_method
+    \sa wolfTLSv1_2_server_method
+    \sa wolfTLSv1_3_server_method_ex
+    \sa wolfDTLSv1_server_method
+    \sa wolfSSLv23_server_method
+    \sa wolfSSL_CTX_new
+*/
+WOLFSSL_METHOD *wolfTLSv1_3_server_method(void);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、アプリケーションがクライアントであることを示すために使用され、TLS 1.3プロトコルのみをサポートします。この関数は、wolfssl_ctx_new（）を使用してSSL / TLSコンテキストを作成するときに使用される新しいWolfssl_method構造体のメモリを割り当てて初期化します。
+    \return If  成功すると、呼び出しは新しく作成されたwolfssl_method構造体へのポインタを返します。
+    _Example_
+    \code
+    #include <wolfssl/ssl.h>
+
+    WOLFSSL_METHOD* method;
+    WOLFSSL_CTX* ctx;
+
+    method = wolfTLSv1_3_client_method();
+    if (method == NULL) {
+        // unable to get method
+    }
+
+    ctx = wolfSSL_CTX_new(method);
+    ...
+    \endcode
+    \sa wolfSSLv3_client_method
+    \sa wolfTLSv1_client_method
+    \sa wolfTLSv1_1_client_method
+    \sa wolfTLSv1_2_client_method
+    \sa wolfTLSv1_3_client_method_ex
+    \sa wolfDTLSv1_client_method
+    \sa wolfSSLv23_client_method
+    \sa wolfSSL_CTX_new
+*/
+WOLFSSL_METHOD *wolfTLSv1_3_client_method(void);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、まだどちらの側（サーバ/クライアント）を決定していないことを除いて、Wolftlsv1_3_client_methodと同様のwolfssl_methodを返します。
+    \param [in]  ヒープ静的メモリ割り当て中に静的メモリ割り当て器が使用するバッファへのポインタを使用します。
+    \return WOLFSSL_METHOD  成功した作成では、wolfssl_methodポインタを返します
+    _Example_
+    \code
+    WOLFSSL* ctx;
+    ctx  = wolfSSL_CTX_new(wolfTLSv1_3_method_ex(NULL));
+    // check ret value
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_free
+*/
+WOLFSSL_METHOD *wolfTLSv1_3_method_ex(void* heap);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、まだどちらの側（サーバ/クライアント）を決定していないことを除いて、Wolftlsv1_3_client_methodと同様のwolfssl_methodを返します。
+    \return WOLFSSL_METHOD  成功した作成では、wolfssl_methodポインタを返します
+    _Example_
+    \code
+    WOLFSSL* ctx;
+    ctx  = wolfSSL_CTX_new(wolfTLSv1_3_method());
+    // check ret value
+    \endcode
+    \sa wolfSSL_new
+    \sa wolfSSL_free
+*/
+WOLFSSL_METHOD *wolfTLSv1_3_method(void);
+
+/*!
+ \ingroup SSL 
+ \brief  この関数はテストのための固定/静的なエフェラルキーを設定します。
+ \return 0  キーが正常にロードされました
+ \param ctx  wolfssl_ctxコンテキストポインタ
+ \param keyAlgo  WC_PK_TYPE_DHおよびWC_PK_TYPE_ECDHのようなenum wc_pktype
+ \param key  キーファイルパス（Keysz == 0）または実際のキーバッファ（PEMまたはASN.1）
+ \param keySz  キーサイズ（「キー」argはファイルパスの場合は0になります）
+ \sa wolfSSL_CTX_get_ephemeral_key
+ */
+int wolfSSL_CTX_set_ephemeral_key(WOLFSSL_CTX* ctx, int keyAlgo, const char* key, unsigned int keySz, int format);
+
+/*!
+ \ingroup SSL 
+ \brief  この関数はテストのための固定/静的なエフェラルキーを設定します。
+ \return 0  キーが正常にロードされました
+ \param ssl  wolfsslオブジェクトポインタ
+ \param keyAlgo  WC_PK_TYPE_DHおよびWC_PK_TYPE_ECDHのようなenum wc_pktype
+ \param key  キーファイルパス（Keysz == 0）または実際のキーバッファ（PEMまたはASN.1）
+ \param keySz  キーサイズ（「キー」argはファイルパスの場合は0になります）
+ \sa wolfSSL_get_ephemeral_key
+ */
+int wolfSSL_set_ephemeral_key(WOLFSSL* ssl, int keyAlgo, const char* key, unsigned int keySz, int format);
+
+/*!
+ \ingroup SSL 
+ \brief  この関数はasn.1 / derとしてロードされたキーへのポインタを返します
+ \return 0  キーが正常に戻りました
+ \param ctx  wolfssl_ctxコンテキストポインタ
+ \param keyAlgo  WC_PK_TYPE_DHおよびWC_PK_TYPE_ECDHのようなenum wc_pktype
+ \param key  キーバッファポインタ
+ \sa wolfSSL_CTX_set_ephemeral_key
+ */
+int wolfSSL_CTX_get_ephemeral_key(WOLFSSL_CTX* ctx, int keyAlgo, 
+    const unsigned char** key, unsigned int* keySz);
+
+/*!
+ \ingroup SSL 
+ \brief  この関数はasn.1 / derとしてロードされたキーへのポインタを返します
+ \return 0  キーが正常に戻りました
+ \param ssl  wolfsslオブジェクトポインタ
+ \param keyAlgo  WC_PK_TYPE_DHおよびWC_PK_TYPE_ECDHのようなenum wc_pktype
+ \param key  キーバッファポインタ
+ \sa wolfSSL_set_ephemeral_key
+ */
+int wolfSSL_get_ephemeral_key(WOLFSSL* ssl, int keyAlgo, 
+    const unsigned char** key, unsigned int* keySz);
+
+/*!
+ \ingroup SSL 
+ \brief  選択したメッセージダイジェスト、パディング、およびRSAキーを使用してメッセージに署名する
+ \return WOLFSSL_SUCCESS  Errorの成功とwolfssl_failureについて
+ \param type  ハッシュNID
+ \param m  署名するメッセージ。これは署名するメッセージのダイジェストになる可能性が高い
+ \param mLen  署名するメッセージの長さ
+ \param sigRet  出力バッファ
+ \param sigLen  オン入力：出力時のSigretバッファの長さ：Sigretに書き込まれたデータの長さ
+ \param rsa  RSAキー入力に署名するために使用されます
+ \param flag  1：シグニチャ0：未パワード署名を比較する値を出力します。注：RSA_PKCS1_PSS_PADDINGの場合は、wc_rsapss_checkpadding_ex関数を使用して* VERIFY *関数の出力を確認する必要があります。
+ */
+int wolfSSL_RSA_sign_generic_padding(int type, const unsigned char* m,
+                               unsigned int mLen, unsigned char* sigRet,
+                               unsigned int* sigLen, WOLFSSL_RSA* rsa,
+                               int flag, int padding);

--- a/doc/dox_comments/header_files-ja/tfm.h
+++ b/doc/dox_comments/header_files-ja/tfm.h
@@ -1,0 +1,17 @@
+/*!
+    \ingroup Math 
+    \brief  この関数は、整数の最大サイズのランタイムFastMath設定をチェックします。FP_SIZEが正しく機能するために、FP_SIZEが各ライブラリーに一致しなければならないため、ユーザーがWolfCryptライブラリを独立して使用している場合に重要です。このチェックはCheckFastMathSettings（）として定義されています。これは、CheckRuntimeFastMathとFP_SIZEを比較するだけで、ミスマッチがある場合は0を返します。
+    \return FP_SIZE  数学ライブラリで利用可能な最大サイズに対応するFP_SIZEを返します。
+    _Example_
+    \code
+    if (CheckFastMathSettings() != 1) {
+	return err_sys("Build vs. runtime fastmath FP_MAX_BITS mismatch\n");
+    }
+    // This is converted by the preprocessor to:
+    // if ( (CheckRunTimeFastMath() == FP_SIZE) != 1) {
+    // and confirms that the fast math settings match
+    // the compile time settings
+    \endcode
+    \sa CheckRunTimeSettings
+*/
+word32 CheckRunTimeFastMath(void);

--- a/doc/dox_comments/header_files-ja/types.h
+++ b/doc/dox_comments/header_files-ja/types.h
@@ -1,0 +1,81 @@
+/*!
+    \ingroup Memory 
+    \brief  これは実際には関数ではなく、むしろプリプロセッサマクロであり、ユーザーは自分のMalloc、Realloc、および標準のCメモリ関数の代わりに自由な関数に置き換えることができます。外部メモリ機能を使用するには、xmalloc_userを定義します。これにより、メモリ機能をフォームの外部関数に置き換えます.extern void * xmalloc（size_t n、void * heap、int型）; extern void * XrealLoc（void * p、size_t n、void *ヒープ、int型）。 extern void xfree（void * p、void * heap、int型）; wolfssl_malloc、wolfssl_realloc、wolfssl_freeの代わりに基本的なCメモリ機能を使用するには、NO_WOLFSSL_MEMORYを定義します。これにより、メモリ関数が次のものに置き換えられます。#define Xmalloc（s、h、t）（（void）h、（void）t、malloc（（s）））#define xfree（p、h、t）{void * xp =（p）; if（（xp））free（（xp））; #define xrealloc（p、n、h、t）Realloc（（p）、（n））これらのオプションのどれも選択されていない場合、システムはデフォルトで使用されます。 WolfSSLメモリ機能ユーザーはコールバックフックを介してカスタムメモリ機能を設定できます（Wolfssl_Malloc、WolfSSL_Realloc、wolfssl_freeを参照）。このオプションは、メモリ関数を次のものに置き換えます。#define xmalloc（s、h、t）（（void）H、（Void）T、wolfssl_malloc（（s）））#define xfree（p、h、t）{void * XP =（P）; if（（xp））wolfssl_free（（xp））; #define xrealloc（p、n、h、t）wolfssl_realloc（（p）、（n））
+    \return pointer  成功したメモリへのポインタを返します
+	\return NULL  失敗した
+	\param s  割り当てるメモリのサイズ
+	\param h  （カスタムXMalloc関数で使用されています）使用するヒープへのポインタ
+	_Example_
+	\code
+	int* tenInts = XMALLOC(sizeof(int)*10, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (tenInts == NULL) {
+	    // error allocating space
+	    return MEMORY_E;
+    }
+	\endcode
+	\sa wolfSSL_Malloc
+	\sa wolfSSL_Realloc
+	\sa wolfSSL_Free
+	\sa wolfSSL_SetAllocators
+*/
+void* XMALLOC(size_t n, void* heap, int type);
+
+/*!
+    \ingroup Memory 
+    \brief  これは実際には関数ではなく、むしろプリプロセッサマクロであり、ユーザーは自分のMalloc、Realloc、および標準のCメモリ関数の代わりに自由な関数に置き換えることができます。外部メモリ機能を使用するには、xmalloc_userを定義します。これにより、メモリ機能をフォームの外部関数に置き換えます.extern void * xmalloc（size_t n、void * heap、int型）; extern void * XrealLoc（void * p、size_t n、void *ヒープ、int型）。 extern void xfree（void * p、void * heap、int型）; wolfssl_malloc、wolfssl_realloc、wolfssl_freeの代わりに基本的なCメモリ機能を使用するには、NO_WOLFSSL_MEMORYを定義します。これにより、メモリ関数が次のものに置き換えられます。#define Xmalloc（s、h、t）（（void）h、（void）t、malloc（（s）））#define xfree（p、h、t）{void * xp =（p）; if（（xp））free（（xp））; #define xrealloc（p、n、h、t）Realloc（（p）、（n））これらのオプションのどれも選択されていない場合、システムはデフォルトで使用されます。 WolfSSLメモリ機能ユーザーはコールバックフックを介してカスタムメモリ機能を設定できます（Wolfssl_Malloc、WolfSSL_Realloc、wolfssl_freeを参照）。このオプションは、メモリ関数を次のものに置き換えます。#define xmalloc（s、h、t）（（void）H、（Void）T、wolfssl_malloc（（s）））#define xfree（p、h、t）{void * XP =（P）; if（（xp））wolfssl_free（（xp））; #define xrealloc（p、n、h、t）wolfssl_realloc（（p）、（n））
+    \return Return  成功したメモリを割り当てるポインタ
+	\return NULL  失敗した
+	\param p  Reallocateへのアドレスへのポインタ
+	\param n  割り当てるメモリのサイズ
+	\param h  （カスタムXrealloc関数で使用されています）使用するヒープへのポインタ
+	_Example_
+	\code
+	int* tenInts = (int*)XMALLOC(sizeof(int)*10, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    int* twentyInts = (int*)XREALLOC(tenInts, sizeof(int)*20, NULL,
+        DYNAMIC_TYPE_TMP_BUFFER);
+	\endcode
+	\sa wolfSSL_Malloc
+	\sa wolfSSL_Realloc
+	\sa wolfSSL_Free
+	\sa wolfSSL_SetAllocators
+*/
+void* XREALLOC(void *p, size_t n, void* heap, int type);
+
+/*!
+    \ingroup Memory 
+    \brief  これは実際には関数ではなく、むしろプリプロセッサマクロであり、ユーザーは自分のMalloc、Realloc、および標準のCメモリ関数の代わりに自由な関数に置き換えることができます。外部メモリ機能を使用するには、xmalloc_userを定義します。これにより、メモリ機能をフォームの外部関数に置き換えます.extern void * xmalloc（size_t n、void * heap、int型）; extern void * XrealLoc（void * p、size_t n、void *ヒープ、int型）。 extern void xfree（void * p、void * heap、int型）; wolfssl_malloc、wolfssl_realloc、wolfssl_freeの代わりに基本的なCメモリ機能を使用するには、NO_WOLFSSL_MEMORYを定義します。これにより、メモリ関数が次のものに置き換えられます。#define Xmalloc（s、h、t）（（void）h、（void）t、malloc（（s）））#define xfree（p、h、t）{void * xp =（p）; if（（xp））free（（xp））; #define xrealloc（p、n、h、t）Realloc（（p）、（n））これらのオプションのどれも選択されていない場合、システムはデフォルトで使用されます。 WolfSSLメモリ機能ユーザーはコールバックフックを介してカスタムメモリ機能を設定できます（Wolfssl_Malloc、WolfSSL_Realloc、wolfssl_freeを参照）。このオプションは、メモリ関数を次のものに置き換えます。#define xmalloc（s、h、t）（（void）H、（Void）T、wolfssl_malloc（（s）））#define xfree（p、h、t）{void * XP =（P）; if（（xp））wolfssl_free（（xp））; #define xrealloc（p、n、h、t）wolfssl_realloc（（p）、（n））
+    \return none  いいえ返します。
+    \param p  無料のアドレスへのポインタ
+	\param h  使用するヒープへの（カスタムXFree関数で使用されています）。
+	_Example_
+	\code
+	int* tenInts = XMALLOC(sizeof(int) * 10, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (tenInts == NULL) {
+	    // error allocating space
+	    return MEMORY_E;
+    }
+	\endcode
+	\sa wolfSSL_Malloc
+	\sa wolfSSL_Realloc
+	\sa wolfSSL_Free
+	\sa wolfSSL_SetAllocators
+*/
+void XFREE(void *p, void* heap, int type);
+
+/*!
+    \ingroup Math 
+    \brief  この関数はコンパイル時クラスの設定をチェックします。設定が正しく機能するためのライブラリ間のライブラリ間で一致する必要があるため、ユーザーがWolfCryptライブラリを独立して使用している場合は重要です。このチェックはCheckCtcSettings（）として定義されています。これは、CheckRuntimeSettingsとCTC_Settingsを比較するだけで、ミスマッチがある場合は0、または1が一致した場合は1を返します。
+    \return settings  実行時CTC_SETTINGS（コンパイル時設定）を返します。
+    _Example_
+    \code
+    if (CheckCtcSettings() != 1) {
+	    return err_sys("Build vs. runtime math mismatch\n");
+    }
+    // This is converted by the preprocessor to:
+    // if ( (CheckCtcSettings() == CTC_SETTINGS) != 1) {
+    // and will compare whether the compile time class settings
+    // match the current settings
+    \endcode
+    \sa CheckRunTimeFastMath
+*/
+word32 CheckRunTimeSettings(void);

--- a/doc/dox_comments/header_files-ja/wc_encrypt.h
+++ b/doc/dox_comments/header_files-ja/wc_encrypt.h
@@ -1,0 +1,150 @@
+/*!
+    \ingroup AES 
+    \brief  入力バッファーから暗号を復号化し、AESでCipher Block Chainingを使用して出力バッファに出力バッファーに入れます。この関数は、AES構造を初期化する必要はありません。代わりに、キーとIV（初期化ベクトル）を取り、これらを使用してAESオブジェクトを初期化してから暗号テキストを復号化します。
+    \return 0  メッセージの復号化に成功しました
+    \return BAD_ALIGN_E  ブロック整列エラーに戻りました
+    \return BAD_FUNC_ARG  aesetivの間にキーの長さが無効な場合、またはAESオブジェクトがNULLの場合
+    \return MEMORY_E  wolfssl_small_stackが有効になっていて、xmallocがAESオブジェクトのインスタンス化に失敗した場合に返されます。
+    \param out  復号化されたメッセージのプレーンテキストを保存する出力バッファへのポインタ
+    \param in  復号化される暗号テキストを含む入力バッファへのポインタ
+    \param inSz  入力メッセージのサイズ
+    \param key  復号化のための16,24、または32バイトの秘密鍵
+    _Example_
+    \code
+    int ret = 0;
+    byte key[] = { some 16, 24, or 32 byte key };
+    byte iv[]  = { some 16 byte iv };
+    byte cipher[AES_BLOCK_SIZE * n]; //n being a positive integer making
+    cipher some multiple of 16 bytes
+    // fill cipher with cipher text
+    byte plain [AES_BLOCK_SIZE * n];
+    if ((ret = wc_AesCbcDecryptWithKey(plain, cipher, AES_BLOCK_SIZE, key,
+    AES_BLOCK_SIZE, iv)) != 0 ) {
+	// Decrypt Error
+    }
+    \endcode
+    \sa wc_AesSetKey
+    \sa wc_AesSetIV
+    \sa wc_AesCbcEncrypt
+    \sa wc_AesCbcDecrypt
+*/
+int  wc_AesCbcDecryptWithKey(byte* out, const byte* in, word32 inSz,
+                                         const byte* key, word32 keySz,
+                                         const byte* iv);
+
+/*!
+    \ingroup 3DES 
+    \brief  この関数は入力暗号文を復号化し、結果の平文を出力バッファーに出力します。暗号ブロックチェーンチェーン（CBC）モードでDES暗号化を使用します。この関数は、wc_des_cbcdecryptの代わりに、ユーザーがDES構造体を直接インスタンス化せずにメッセージを復号化できるようにします。
+    \return 0  与えられた暗号文を正常に復号化したときに返されました
+    \return MEMORY_E  DES構造体の割り当てスペースが割り当てられている場合に返された
+    \param out  復号化された平文を保存するバッファへのポインタ
+    \param in  暗号化された暗号文を含む入力バッファへのポインタ
+    \param sz  復号化する暗号文の長さ
+    \param key  復号化に使用する8バイトのキーを含むバッファへのポインタ
+    _Example_
+    \code
+    int ret;
+    byte key[] = { // initialize with 8 byte key };
+    byte iv[]  = { // initialize with 8 byte iv };
+
+    byte cipher[]  = { // initialize with ciphertext };
+    byte decoded[sizeof(cipher)];
+
+    if ( wc_Des_CbcDecryptWithKey(decoded, cipher, sizeof(cipher), key,
+    iv) != 0) {
+    	// error decrypting message
+    }
+    \endcode
+    \sa wc_Des_CbcDecrypt
+*/
+int  wc_Des_CbcDecryptWithKey(byte* out,
+                                          const byte* in, word32 sz,
+                                          const byte* key, const byte* iv);
+
+/*!
+    \ingroup 3DES 
+    \brief  この関数は入力平文を暗号化し、結果の暗号文を出力バッファーに出力します。暗号ブロックチェーンチェーン（CBC）モードでDES暗号化を使用します。この関数は、WC_DES_CBCENCRYPTの代わりになり、ユーザーがDES構造を直接インスタンス化せずにメッセージを暗号化できます。
+    \return 0  データの暗号化に成功した後に返されます。
+    \return MEMORY_E  DES構造体にメモリを割り当てるエラーがある場合は返されます。
+    \return <0  暗号化中に任意のエラーに戻ります。
+    \param out  最終暗号化データ
+    \param in  暗号化されるデータは、DESブロックサイズに埋められなければなりません。
+    \param sz  入力バッファのサイズ
+    \param key  暗号化に使用するキーへのポインタ。
+    _Example_
+    \code
+    byte key[] = { // initialize with 8 byte key };
+    byte iv[]  = { // initialize with 8 byte iv };
+    byte in[] = { // Initialize with plaintext };
+    byte out[sizeof(in)];
+    if ( wc_Des_CbcEncryptWithKey(&out, in, sizeof(in), key, iv) != 0)
+    {
+    	// error encrypting message
+    }
+    \endcode
+    \sa wc_Des_CbcDecryptWithKey
+    \sa wc_Des_CbcEncrypt
+*/
+int  wc_Des_CbcEncryptWithKey(byte* out,
+                                          const byte* in, word32 sz,
+                                          const byte* key, const byte* iv);
+
+/*!
+    \ingroup 3DES 
+    \brief  この関数は入力平文を暗号化し、結果の暗号文を出力バッファーに出力します。暗号ブロックチェーン（CBC）モードでトリプルDES（3DES）暗号化を使用します。この関数は、WC_DES3_CBCENCRYPTの代わりになり、ユーザーがDES3構造を直接インスタンス化せずにメッセージを暗号化できます。
+    \return 0  データの暗号化に成功した後に返されます。
+    \return MEMORY_E  DES構造体にメモリを割り当てるエラーがある場合は返されます。
+    \return <0  暗号化中に任意のエラーに戻ります。
+    \param out  最終暗号化データ
+    \param in  暗号化されるデータは、DESブロックサイズに埋められなければなりません。
+    \param sz  入力バッファのサイズ
+    \param key  暗号化に使用するキーへのポインタ。
+    _Example_
+    \code
+    byte key[] = { // initialize with 8 byte key };
+    byte iv[]  = { // initialize with 8 byte iv };
+
+    byte in[] = { // Initialize with plaintext };
+    byte out[sizeof(in)];
+
+    if ( wc_Des3_CbcEncryptWithKey(&out, in, sizeof(in), key, iv) != 0)
+    {
+    	// error encrypting message
+    }
+    \endcode
+    \sa wc_Des3_CbcDecryptWithKey
+    \sa wc_Des_CbcEncryptWithKey
+    \sa wc_Des_CbcDecryptWithKey
+*/
+int  wc_Des3_CbcEncryptWithKey(byte* out,
+                                           const byte* in, word32 sz,
+                                           const byte* key, const byte* iv);
+
+/*!
+    \ingroup 3DES 
+    \brief  この関数は入力暗号文を復号化し、結果の平文を出力バッファーに出力します。暗号ブロックチェーン（CBC）モードでトリプルDES（3DES）暗号化を使用します。この関数は、wc_des3_cbcdecryptの代わりに、ユーザーがDES3構造を直接インスタンス化せずにメッセージを復号化できるようにします。
+    \return 0  与えられた暗号文を正常に復号化したときに返されました
+    \return MEMORY_E  DES構造体の割り当てスペースが割り当てられている場合に返された
+    \param out  復号化された平文を保存するバッファへのポインタ
+    \param in  暗号化された暗号文を含む入力バッファへのポインタ
+    \param sz  復号化する暗号文の長さ
+    \param key  復号化に使用する24バイトのキーを含むバッファへのポインタ
+    _Example_
+    \code
+    int ret;
+    byte key[] = { // initialize with 24 byte key };
+    byte iv[]  = { // initialize with 8 byte iv };
+
+    byte cipher[]  = { // initialize with ciphertext };
+    byte decoded[sizeof(cipher)];
+
+    if ( wc_Des3_CbcDecryptWithKey(decoded, cipher, sizeof(cipher),
+    key, iv) != 0) {
+    	// error decrypting message
+    }
+    \endcode
+    \sa wc_Des3_CbcDecrypt
+*/
+int  wc_Des3_CbcDecryptWithKey(byte* out,
+                                           const byte* in, word32 sz,
+                                           const byte* key, const byte* iv);

--- a/doc/dox_comments/header_files-ja/wc_port.h
+++ b/doc/dox_comments/header_files-ja/wc_port.h
@@ -1,0 +1,31 @@
+/*!
+    \ingroup wolfCrypt 
+    \brief  WolfCryptによって使用されるリソースを初期化するために使用されます。
+    \return 0  成功すると。
+    \return <0  initリソースが失敗すると。
+    _Example_
+    \code
+    ...
+    if (wolfCrypt_Init() != 0) {
+        WOLFSSL_MSG("Error with wolfCrypt_Init call");
+    }
+    \endcode
+    \sa wolfCrypt_Cleanup
+*/
+int wolfCrypt_Init(void);
+
+/*!
+    \ingroup wolfCrypt 
+    \brief  WolfCryptによって使用されるリソースをクリーンアップするために使用されます。
+    \return 0  成功すると。
+    \return <0  リソースのクリーンアップが失敗したとき。
+    _Example_
+    \code
+    ...
+    if (wolfCrypt_Cleanup() != 0) {
+        WOLFSSL_MSG("Error with wolfCrypt_Cleanup call");
+    }
+    \endcode
+    \sa wolfCrypt_Init
+*/
+int wolfCrypt_Cleanup(void);

--- a/doc/dox_comments/header_files-ja/wolfio.h
+++ b/doc/dox_comments/header_files-ja/wolfio.h
@@ -1,0 +1,398 @@
+/*!
+    \brief  
+    \return Success  この関数は、読み取られたバイト数を返します。
+    \return WOLFSSL_CBIO_ERR_WANT_READ  最後のエラーがsocket_ewouldbolcokまたはsocket_eagainであれば、メッセージを返されます。
+    \return WOLFSSL_CBIO_ERR_TIMEOUT  "Socket Timeout"メッセージを返しました。
+    \return WOLFSSL_CBIO_ERR_CONN_RST  最後のエラーがsocket_econnresetの場合、 "Connection Reset"メッセージで返されます。
+    \return WOLFSSL_CBIO_ERR_ISR  最後のエラーがsocket_eintrの場合、 "Socket Interrupted"メッセージが返されます。
+    \return WOLFSSL_CBIO_ERR_WANT_READ  最後のエラーがsocket_econneRefusedの場合、「接続拒否」メッセージを返しました。
+    \return WOLFSSL_CBIO_ERR_CONN_CLOSE  最後のエラーがSOCKET_ECONNABORTEDの場合、「接続中止」メッセージで返されます。
+    \return WOLFSSL_CBIO_ERR_GENERAL  最後のエラーが指定されていない場合は、「一般的なエラー」メッセージで返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param buf  バッファのチャーポインタ表現。
+    \param sz  バッファのサイズ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    char* buf;
+    int sz;
+    void* ctx;
+    int bytesRead = EmbedReceive(ssl, buf, sz, ctx);
+    if(bytesRead <= 0){
+	    // There were no bytes read. Failure case.
+    }
+    \endcode
+    \sa EmbedSend
+    \sa wolfSSL_CTX_SetIORecv
+    \sa wolfSSL_SSLSetIORecv
+*/
+int EmbedReceive(WOLFSSL* ssl, char* buf, int sz, void* ctx);
+
+/*!
+    \brief  
+    \return Success  この関数は送信されたバイト数を返します。
+    \return WOLFSSL_CBIO_ERR_WANT_WRITE  最後のエラーがsocket_ewouldblockまたはsocket_eagainであれば、 "Block"メッセージを返します。
+    \return WOLFSSL_CBIO_ERR_CONN_RST  最後のエラーがsocket_econnresetの場合、 "Connection Reset"メッセージで返されます。
+    \return WOLFSSL_CBIO_ERR_ISR  最後のエラーがsocket_eintrの場合、 "Socket Interrupted"メッセージが返されます。
+    \return WOLFSSL_CBIO_ERR_CONN_CLOSE  最後のエラーがsocket_epipeの場合、 "Socket Epipe"メッセージを返しました。
+    \return WOLFSSL_CBIO_ERR_GENERAL  最後のエラーが指定されていない場合は、「一般的なエラー」メッセージで返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param buf  バッファを表す文字ポインタ。
+    \param sz  バッファのサイズ。
+    _Example_
+    \code
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    char* buf;
+    int sz;
+    void* ctx;
+    int dSent = EmbedSend(ssl, buf, sz, ctx);
+    if(dSent <= 0){
+    	// No byes sent. Failure case.
+    }
+    \endcode
+    \sa EmbedReceive
+    \sa wolfSSL_CTX_SetIOSend
+    \sa wolfSSL_SSLSetIOSend
+*/
+int EmbedSend(WOLFSSL* ssl, char* buf, int sz, void* ctx);
+
+/*!
+    \brief  
+    \return Success  この関数は、実行が成功した場合に読み込まれたNBバイトを返します。
+    \return WOLFSSL_CBIO_ERR_WANT_READ  接続が拒否された場合、または「ブロック」エラーが発生した場合は機能にスローされました。
+    \return WOLFSSL_CBIO_ERR_TIMEOUT  ソケットがタイムアウトした場合は返されます。
+    \return WOLFSSL_CBIO_ERR_CONN_RST  接続がリセットされている場合は返されます。
+    \return WOLFSSL_CBIO_ERR_ISR  ソケットが中断された場合は返されます。
+    \return WOLFSSL_CBIO_ERR_GENERAL  一般的なエラーがあった場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param buf  バッファへの定数の文字ポインタ。
+    \param sz  バッファのサイズを表すint型。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
+    WOLFSSL* ssl = WOLFSSL_new(ctx);
+    char* buf;
+    int sz = sizeof(buf)/sizeof(char);
+    (void*)ctx;
+    …
+    int nb = EmbedReceiveFrom(ssl, buf, sz, ctx);
+    if(nb > 0){
+	    // nb is the number of bytes written and is positive
+    }
+    \endcode
+    \sa EmbedSendTo
+    \sa wolfSSL_CTX_SetIORecv
+    \sa wolfSSL_SSLSetIORecv
+    \sa wolfSSL_dtls_get_current_timeout
+*/
+int EmbedReceiveFrom(WOLFSSL* ssl, char* buf, int sz, void*);
+
+/*!
+    \brief  
+    \return Success  この関数は送信されたバイト数を返します。
+    \return WOLFSSL_CBIO_ERR_WANT_WRITE  最後のエラーがsocket_ewouldblockまたはsocket_eagainエラーの場合、 "Block"メッセージを返します。
+    \return WOLFSSL_CBIO_ERR_CONN_RST  最後のエラーがsocket_econnresetの場合、 "Connection Reset"メッセージで返されます。
+    \return WOLFSSL_CBIO_ERR_ISR  最後のエラーがsocket_eintrの場合、 "Socket Interrupted"メッセージが返されます。
+    \return WOLFSSL_CBIO_ERR_CONN_CLOSE  最後のエラーがwolfssl_cbio_err_conn_croseの場合、 "Socket Epipe"メッセージを返しました。
+    \return WOLFSSL_CBIO_ERR_GENERAL  最後のエラーが指定されていない場合は、「一般的なエラー」メッセージで返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param buf  バッファを表す文字ポインタ。
+    \param sz  バッファのサイズ。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    …
+    char* buf;
+    int sz;
+    void* ctx;
+
+    int sEmbed = EmbedSendto(ssl, buf, sz, ctx);
+    if(sEmbed <= 0){
+    	// No bytes sent. Failure case.
+    }
+    \endcode
+    \sa EmbedReceiveFrom
+    \sa wolfSSL_CTX_SetIOSend
+    \sa wolfSSL_SSLSetIOSend
+*/
+int EmbedSendTo(WOLFSSL* ssl, char* buf, int sz, void* ctx);
+
+/*!
+    \brief  
+    \return Success  この関数は、バッファにコピーされたバイト数を返します。
+    \return GEN_COOKIE_E  getPeernameがEmbedGenerateCookieに失敗した場合に返されます。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param buf  バッファを表すバイトポインタ。xmemcpy（）からの宛先です。
+    \param sz  バッファのサイズ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    byte buffer[BUFFER_SIZE];
+    int sz = sizeof(buffer)/sizeof(byte);
+    void* ctx;
+    …
+    int ret = EmbedGenerateCookie(ssl, buffer, sz, ctx);
+
+    if(ret > 0){
+    	// EmbedGenerateCookie code block for success
+    }
+    \endcode
+    \sa wolfSSL_CTX_SetGenCookie
+*/
+int EmbedGenerateCookie(WOLFSSL* ssl, unsigned char* buf,
+                                           int sz, void*);
+
+/*!
+    \brief  
+    \return none  いいえ返します。
+    \param ctx  ヒープヒントへのvoidポインタ。
+    _Example_
+    \code
+    void* ctx;
+    byte* resp; // Response buffer.
+    …
+    EmbedOcspRespFree(ctx, resp);
+    \endcode
+    \sa wolfSSL_CertManagerSetOCSP_Cb
+    \sa wolfSSL_CertManagerEnableOCSPStapling
+    \sa wolfSSL_CertManagerEnableOCSP
+*/
+void EmbedOcspRespFree(void* ctx, byte* resp);
+
+/*!
+    \brief  データ。デフォルトでは、WolfSSLはシステムのTCP RECV（）関数を使用するコールバックとしてEmbedReceive（）を使用します。ユーザは、メモリ、他のネットワークモジュール、またはどこからでも入力するように機能を登録できます。関数の機能とエラーコードのためのガイドとして、src / io.cの埋め込みReceive（）関数を参照してください。特に、データが準備ができていないときに、IO_ERR_WANT_READを非ブロック受信用に返す必要があります。
+    \return none  いいえ返します。
+    \param ctx  wolfssl_ctx_new（）で作成されたSSLコンテキストへのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = 0;
+    // Receive callback prototype
+    int MyEmbedReceive(WOLFSSL* ssl, char* buf, int sz, void* ctx);
+    // Register the custom receive callback with wolfSSL
+    wolfSSL_CTX_SetIORecv(ctx, MyEmbedReceive);
+    int MyEmbedReceive(WOLFSSL* ssl, char* buf, int sz, void* ctx)
+    {
+	    // custom EmbedReceive function
+    }
+    \endcode
+    \sa wolfSSL_CTX_SetIOSend
+    \sa wolfSSL_SetIOReadCtx
+    \sa wolfSSL_SetIOWriteCtx
+*/
+void wolfSSL_CTX_SetIORecv(WOLFSSL_CTX* ctx, CallbackIORecv CBIORecv);
+
+/*!
+    \brief  コールバック関数デフォルトでは、WolfSSLは、WolfSSLがシステムのTCPライブラリを使用している場合、wolfssl_set_fd（）に渡されたファイル記述子をコンテキストとして設定します。自分の受信コールバックを登録した場合は、セッションの特定のコンテキストを設定することができます。たとえば、メモリバッファを使用している場合、コンテキストは、メモリバッファーのどこにありかを説明する構造へのポインタであり得る。
+    \return none  いいえ返します。
+    \param ssl  wolfssl_new（）で作成されたSSLセッションへのポインタ。
+    _Example_
+    \code
+    int sockfd;
+    WOLFSSL* ssl = 0;
+    ...
+    // Manually setting the socket fd as the receive CTX, for example
+    wolfSSL_SetIOReadCtx(ssl, &sockfd);
+    ...
+    \endcode
+    \sa wolfSSL_CTX_SetIORecv
+    \sa wolfSSL_CTX_SetIOSend
+    \sa wolfSSL_SetIOWriteCtx
+*/
+void wolfSSL_SetIOReadCtx( WOLFSSL* ssl, void *ctx);
+
+/*!
+    \brief  コールバック関数デフォルトでは、WolfSSLは、WolfSSLがシステムのTCPライブラリを使用している場合、wolfssl_set_fd（）に渡されたファイル記述子をコンテキストとして設定します。独自の送信コールバックを登録した場合は、セッションの特定のコンテキストを設定することができます。たとえば、メモリバッファを使用している場合、コンテキストは、メモリバッファーのどこにありかを説明する構造へのポインタであり得る。
+    \return none  いいえ返します。
+    \param ssl  wolfssl_new（）で作成されたSSLセッションへのポインタ。
+    _Example_
+    \code
+    int sockfd;
+    WOLFSSL* ssl = 0;
+    ...
+    // Manually setting the socket fd as the send CTX, for example
+    wolfSSL_SetIOWriteCtx(ssl, &sockfd);
+    ...
+    \endcode
+    \sa wolfSSL_CTX_SetIORecv
+    \sa wolfSSL_CTX_SetIOSend
+    \sa wolfSSL_SetIOReadCtx
+*/
+void wolfSSL_SetIOWriteCtx(WOLFSSL* ssl, void *ctx);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、WolfSSL構造体のIOCB_READCTXメンバーを返します。
+    \return pointer  この関数は、wolfssl構造体のiocb_readctxメンバーへのvoidポインタを返します。
+    \return NULL  wolfssl構造体がNULLの場合に返されます。
+    _Example_
+    \code
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    void* ioRead;
+    ...
+    ioRead = wolfSSL_GetIOReadCtx(ssl);
+    if(ioRead == NULL){
+    	// Failure case. The ssl object was NULL.
+    }
+    \endcode
+    \sa wolfSSL_GetIOWriteCtx
+    \sa wolfSSL_SetIOReadFlags
+    \sa wolfSSL_SetIOWriteCtx
+    \sa wolfSSL_SetIOReadCtx
+    \sa wolfSSL_CTX_SetIOSend
+*/
+void* wolfSSL_GetIOReadCtx( WOLFSSL* ssl);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、WolfSSL構造のIOCB_WRITECTXメンバーを返します。
+    \return pointer  この関数は、WolfSSL構造のIOCB_WRITECTXメンバーへのvoidポインタを返します。
+    \return NULL  wolfssl構造体がNULLの場合に返されます。
+    _Example_
+    \code
+    WOLFSSL* ssl;
+    void* ioWrite;
+    ...
+    ioWrite = wolfSSL_GetIOWriteCtx(ssl);
+    if(ioWrite == NULL){
+    	// The function returned NULL.
+    }
+    \endcode
+    \sa wolfSSL_GetIOReadCtx
+    \sa wolfSSL_SetIOWriteCtx
+    \sa wolfSSL_SetIOReadCtx
+    \sa wolfSSL_CTX_SetIOSend
+*/
+void* wolfSSL_GetIOWriteCtx(WOLFSSL* ssl);
+
+/*!
+    \brief  与えられたSSLセッション受信コールバックは、デフォルトのwolfssl埋め込み受信コールバック、またはユーザによって指定されたカスタムコールバックであり得る（wolfssl_ctx_setiorecvを参照）。デフォルトのフラグ値は、WolfSSLによってwolfsslによって0の値に設定されます。デフォルトのWolfSSL受信コールバックはRECV（）関数を使用してソケットからデータを受信します。 「Recv（）」ページから：「Recv（）関数へのflags引数は、1つ以上の値をOR処理するか、MSG_OOBプロセス帯域外データ、MSG_PEEK PEEK、MSG_PEEK PEEK、MSG_WAITALLがフルを待っています要求またはエラー。 MSG_OOBフラグは、通常のデータストリームで受信されないであろう帯域外データの受信を要求します。一部のプロトコルは通常のデータキューの先頭に迅速なデータを配置し、このフラグをそのようなプロトコルで使用することはできません。 MSG_PEEKフラグは、受信操作によって受信キューの先頭からのデータをキューから削除することなくデータを返します。したがって、以降の受信呼び出しは同じデータを返します。 MSG_WAITALLフラグは、完全な要求が満たされるまで操作ブロックを要求します。ただし、信号がキャッチされている場合は、呼び出し側よりも少ないデータが少なく、エラーまたは切断が発生するか、または受信されるデータが返されるものとは異なるタイプのデータを返します。
+    \return none  いいえ返します。
+    \param ssl  wolfssl_new（）で作成されたSSLセッションへのポインタ。
+    _Example_
+    \code
+    WOLFSSL* ssl = 0;
+    ...
+    // Manually setting recv flags to 0
+    wolfSSL_SetIOReadFlags(ssl, 0);
+    ...
+    \endcode
+    \sa wolfSSL_CTX_SetIORecv
+    \sa wolfSSL_CTX_SetIOSend
+    \sa wolfSSL_SetIOReadCtx
+*/
+void wolfSSL_SetIOReadFlags( WOLFSSL* ssl, int flags);
+
+/*!
+    \brief  SSLセッションを考えると送信コールバックは、デフォルトのWolfSSL EmbedEndコールバック、またはユーザーによって指定されたカスタムコールバックのいずれかです（WolfSSL_CTX_SetiosEndを参照）。デフォルトのフラグ値は、wolfsslによって0の値に設定されます。デフォルトのWolfSSL Send Callbackはsend（）関数を使用してソケットからデータを送信します。send（）manページから： "flagsパラメータには、次のうち1つ以上が含まれていてもよい。フラグMSG_OOBは、この概念（例えばSOCK_STREAM）をサポートするソケットに「帯域外」データを送信するために使用される。基礎となるプロトコルは、「帯域外」のデータもサポートする必要があります。MSG_DONTROUTEは通常、診断プログラムまたはルーティングプログラムによってのみ使用されます。」
+    \return none  いいえ返します。
+    \param ssl  wolfssl_new（）で作成されたSSLセッションへのポインタ。
+    _Example_
+    \code
+    WOLFSSL* ssl = 0;
+    ...
+    // Manually setting send flags to 0
+    wolfSSL_SetIOWriteFlags(ssl, 0);
+    ...
+    \endcode
+    \sa wolfSSL_CTX_SetIORecv
+    \sa wolfSSL_CTX_SetIOSend
+    \sa wolfSSL_SetIOReadCtx
+*/
+void wolfSSL_SetIOWriteFlags(WOLFSSL* ssl, int flags);
+
+/*!
+    \ingroup IO 
+    \brief  この関数は、wolfssl構造内のnxctx構造体のNxSocketメンバーとNXWAITメンバーを設定します。
+    \return none  いいえ返します。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    \param nxSocket  NXCTX構造のNXSOCTOCKメンバーに設定されているNX_TCP_SOCKETを入力するためのポインタ。
+    _Example_
+    \code
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    NX_TCP_SOCKET* nxSocket;
+    ULONG waitOption;
+    …
+    if(ssl != NULL || nxSocket != NULL || waitOption <= 0){
+    wolfSSL_SetIO_NetX(ssl, nxSocket, waitOption);
+    } else {
+    	// You need to pass in good parameters.
+    }
+    \endcode
+    \sa set_fd
+    \sa NetX_Send
+    \sa NetX_Receive
+*/
+void wolfSSL_SetIO_NetX(WOLFSSL* ssl, NX_TCP_SOCKET* nxsocket,
+                                      ULONG waitoption);
+
+/*!
+    \brief  wolfssl_ctx構造CallBackGencookie Typeは関数ポインタで、署名：int（* callbackgencookie）（wolfssl * ssl、unsigned char * buf、int sz、void * ctx）を持っています。
+    \return none  いいえ返します。
+    \param ssl  wolfssl_new（）を使用して作成されたWolfSSL構造へのポインタ。
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    …
+    int SetGenCookieCB(WOLFSSL* ssl, unsigned char* buf, int sz, void* ctx){
+	// Callback function body.
+    }
+    …
+    wolfSSL_CTX_SetGenCookie(ssl->ctx, SetGenCookieCB);
+    \endcode
+    \sa CallbackGenCookie
+*/
+void  wolfSSL_CTX_SetGenCookie(WOLFSSL_CTX* ctx, CallbackGenCookie cb);
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、WolfSSL構造のIOCB_COOKIECTXメンバーを返します。
+    \return pointer  この関数は、iocb_cookiectxに格納されているvoidポインタ値を返します。
+    \return NULL  WolfSSL構造体がNULLの場合
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    void* cookie;
+    ...
+    cookie = wolfSSL_GetCookieCtx(ssl);
+    if(cookie != NULL){
+	// You have the cookie
+    }
+    \endcode
+    \sa wolfSSL_SetCookieCtx
+    \sa wolfSSL_CTX_SetGenCookie
+*/
+void* wolfSSL_GetCookieCtx(WOLFSSL* ssl);
+
+
+/*!
+    \ingroup Setup 
+    \brief  この関数は、WolfSSLがWolfSSL_ISOTPでコンパイルされている場合に使用する場合は、WolfSSLの場合はISO-TPコンテキストを設定します。
+    \return 0  成功すると、故障のwolfssl_cbio_err_general
+    \param ssl  wolfsslコンテキスト
+    \param ctx  ユーザーはこの関数が初期化されるISOTPコンテキストを作成しました
+    \param recv_fn  ユーザーはバスを受信できます
+    \param send_fn  ユーザーはバスを送ることができます
+    \param delay_fn  ユーザーマイクロ秒の粒度遅延関数
+    \param receive_delay  各CANバスパケットを遅らせるためのマイクロ秒のセット数
+    \param receive_buffer  ユーザーがデータを受信するためのバッファーが提供され、ISOTP_DEFAULT_BUFFER_SIZEバイトに割り当てられていることをお勧めします。
+    \param receive_buffer_size   -  receive_bufferのサイズ
+    _Example_
+    \code
+    struct can_info can_con_info;
+    isotp_wolfssl_ctx isotp_ctx;
+    char *receive_buffer = malloc(ISOTP_DEFAULT_BUFFER_SIZE);
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new(method);
+    WOLFSSL* ssl = wolfSSL_new(ctx);
+    ...
+    wolfSSL_SetIO_ISOTP(ssl, &isotp_ctx, can_receive, can_send, can_delay, 0,
+            receive_buffer, ISOTP_DEFAULT_BUFFER_SIZE, &can_con_info);
+    \endcode
+ */
+int wolfSSL_SetIO_ISOTP(WOLFSSL *ssl, isotp_wolfssl_ctx *ctx,
+        can_recv_fn recv_fn, can_send_fn send_fn, can_delay_fn delay_fn,
+        word32 receive_delay, char *receive_buffer, int receive_buffer_size,
+        void *arg);


### PR DESCRIPTION
# Description

initial translation of API headers to Japanese.
This is sync with pr37, documentation

https://github.com/wolfSSL/documentation/pull/37

Fixes zd#

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
