### PR TITLE
kdf: fix clang uninitialized.Assign

### DIFF
--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -150,6 +150,11 @@ int wc_PRF(byte* result, word32 resLen, const byte* secret,
     if (lastLen)
         times += 1;
 
+    /* times == 0 iif resLen == 0, but times == 0 abides clang static analyzer
+       while resLen == 0 doesn't */
+    if (times == 0)
+        return BAD_FUNC_ARG;
+
     lastTime = times - 1;
 
     ret = wc_HmacInit(hmac, heap, devId);


### PR DESCRIPTION
commit f1ce0cc95d22569640bc522354025fbc16c88e43 tigger static analyzer warnings
about unitialized assign.

# Description

Fixing clang warnings
