### PR TITLE
Call RSA_To_Der instead of RSA_To_Der_ex in i2dd_RSA key funcs

### DIFF
--- a/src/pk.c
+++ b/src/pk.c
@@ -861,7 +861,7 @@ int wolfSSL_i2d_RSAPrivateKey(WOLFSSL_RSA *rsa, unsigned char **pp)
     }
     /* Encode the RSA key as a DER. Call allocates buffer into pp.
      * No heap hint as this gets returned to the user */
-    else if ((ret = wolfSSL_RSA_To_Der_ex(rsa, pp, 0, NULL)) < 0) {
+    else if ((ret = wolfSSL_RSA_To_Der(rsa, pp, 0, NULL)) < 0) {
         WOLFSSL_MSG("wolfSSL_RSA_To_Der failed");
         ret = 0;
     }
@@ -898,7 +898,7 @@ int wolfSSL_i2d_RSAPublicKey(WOLFSSL_RSA *rsa, unsigned char **pp)
     }
     /* Encode the RSA key as a DER. Call allocates buffer into pp.
      * No heap hint as this gets returned to the user */
-    else if ((ret = wolfSSL_RSA_To_Der_ex(rsa, pp, 1, NULL)) < 0) {
+    else if ((ret = wolfSSL_RSA_To_Der(rsa, pp, 1, NULL)) < 0) {
         WOLFSSL_MSG("wolfSSL_RSA_To_Der failed");
         ret = 0;
     }

--- a/tests/api.c
+++ b/tests/api.c
@@ -40408,6 +40408,7 @@ static void test_wolfSSL_d2i_PrivateKeys_bio(void)
         AssertIntEQ(wolfSSL_i2d_RSAPrivateKey(rsa, NULL), 1192);
         AssertIntEQ(wolfSSL_i2d_RSAPrivateKey(rsa, &bufPtr),
                                                sizeof_client_key_der_2048);
+        AssertStrEQ((const char*)bufPtr, (const char*)client_key_der_2048); 
         bufPtr = NULL;
         AssertIntEQ(wolfSSL_i2d_RSAPrivateKey(rsa, &bufPtr),
                                                sizeof_client_key_der_2048);
@@ -51571,6 +51572,7 @@ static void test_wolfSSL_RSA_DER(void)
         newBuff = NULL;
         AssertIntEQ(i2d_RSAPublicKey(rsa, &newBuff), pub[i].sz);
         AssertNotNull(newBuff);
+        AssertStrEQ((const char*)newBuff, (const char*)pub[i].der); 
         AssertIntEQ(0, memcmp((void *)newBuff, (void *)pub[i].der, pub[i].sz));
         XFREE((void *)newBuff, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         RSA_free(rsa);


### PR DESCRIPTION
# Description

Fix for `wolfSSL_i2d_RSAPrivateKey` and `wolfSSL_i2d_RSAPublicKey` as well as testing

Fixes zd#

# Testing

 Using test to added to api.c.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
