### PR TITLE
Fixes for loading a DER/ASN.1 certificate chain

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5622,7 +5622,8 @@ static int ProcessUserChain(WOLFSSL_CTX* ctx, const unsigned char* buff,
                 cnt++;
 #endif
                 if ((idx + part->length + CERT_HEADER_SZ) > bufferSz) {
-                    WOLFSSL_MSG("   Cert Chain bigger than buffer");
+                    WOLFSSL_MSG("   Cert Chain bigger than buffer. "
+                                "Consider increasing MAX_CHAIN_DEPTH");
                     ret = BUFFER_E;
                 }
                 else {
@@ -5636,9 +5637,12 @@ static int ProcessUserChain(WOLFSSL_CTX* ctx, const unsigned char* buff,
                 }
 
                 /* add CA's to certificate manager */
-                if (type == CA_TYPE) {
+                if (ret == 0 && type == CA_TYPE) {
                     /* verify CA unless user set to no verify */
                     ret = AddCA(ctx->cm, &part, WOLFSSL_USER_CA, verify);
+                    if (ret == WOLFSSL_SUCCESS) {
+                        ret = 0; /* converted success case */
+                    }
                     gotOne = 0; /* don't exit loop for CA type */
                 }
             }


### PR DESCRIPTION
# Description

* Fix for loading certificate DER chain longer than 2 deep
* Fix to properly trap BUFFER_E in `ProcessUserChain` related to `MAX_CHAIN_DEPTH`.

Fixes ZD14048

# Testing

Custom test case with DER chain 127 long using `wolfSSL_CTX_load_verify_buffer_ex` with `WOLFSSL_FILETYPE_ASN1`.

```
./configure CFLAGS="-DMAX_CHAIN_DEPTH=128" && make
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
