### PR TITLE
i2d AIPs move pointer on when a pointer to a buffer is passed in

### DIFF
--- a/src/pk.c
+++ b/src/pk.c
@@ -861,7 +861,7 @@ int wolfSSL_i2d_RSAPrivateKey(WOLFSSL_RSA *rsa, unsigned char **pp)
     }
     /* Encode the RSA key as a DER. Call allocates buffer into pp.
      * No heap hint as this gets returned to the user */
-    else if ((ret = wolfSSL_RSA_To_Der(rsa, pp, 0, NULL)) < 0) {
+    else if ((ret = wolfSSL_RSA_To_Der_ex(rsa, pp, 0, NULL)) < 0) {
         WOLFSSL_MSG("wolfSSL_RSA_To_Der failed");
         ret = 0;
     }
@@ -898,7 +898,7 @@ int wolfSSL_i2d_RSAPublicKey(WOLFSSL_RSA *rsa, unsigned char **pp)
     }
     /* Encode the RSA key as a DER. Call allocates buffer into pp.
      * No heap hint as this gets returned to the user */
-    else if ((ret = wolfSSL_RSA_To_Der(rsa, pp, 1, NULL)) < 0) {
+    else if ((ret = wolfSSL_RSA_To_Der_ex(rsa, pp, 1, NULL)) < 0) {
         WOLFSSL_MSG("wolfSSL_RSA_To_Der failed");
         ret = 0;
     }

--- a/tests/api.c
+++ b/tests/api.c
@@ -40455,11 +40455,15 @@ static void test_wolfSSL_d2i_PrivateKeys_bio(void)
         AssertIntEQ(wolfSSL_i2d_RSAPrivateKey(rsa, NULL), 1192);
         AssertIntEQ(wolfSSL_i2d_RSAPrivateKey(rsa, &bufPtr),
                                                sizeof_client_key_der_2048);
-        AssertStrEQ((const char*)bufPtr, (const char*)client_key_der_2048); 
+        bufPtr -= sizeof_client_key_der_2048;
+        AssertIntEQ(XMEMCMP(bufPtr, client_key_der_2048,
+                            sizeof_client_key_der_2048), 0);
         bufPtr = NULL;
         AssertIntEQ(wolfSSL_i2d_RSAPrivateKey(rsa, &bufPtr),
                                                sizeof_client_key_der_2048);
         AssertNotNull(bufPtr);
+        AssertIntEQ(XMEMCMP(bufPtr, client_key_der_2048,
+                            sizeof_client_key_der_2048), 0);
         XFREE(bufPtr, NULL, DYNAMIC_TYPE_OPENSSL);
 
         RSA_free(rsa);
@@ -51619,8 +51623,7 @@ static void test_wolfSSL_RSA_DER(void)
         newBuff = NULL;
         AssertIntEQ(i2d_RSAPublicKey(rsa, &newBuff), pub[i].sz);
         AssertNotNull(newBuff);
-        AssertStrEQ((const char*)newBuff, (const char*)pub[i].der); 
-        AssertIntEQ(0, memcmp((void *)newBuff, (void *)pub[i].der, pub[i].sz));
+        AssertIntEQ(XMEMCMP((void *)newBuff, (void *)pub[i].der, pub[i].sz), 0);
         XFREE((void *)newBuff, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         RSA_free(rsa);
     }


### PR DESCRIPTION
# Description

Restore behaviour to be compatible with OpenSSL.
Replace comparison of DER data using AsserStrEQ to use memcmp.

# Testing

--enable-opensslextra --enable-keygen

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
