### PR TITLE
fix qt unit test failure

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -5526,8 +5526,8 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
             WOLFSSL_MSG("Error getting x509 signature type");
             return WOLFSSL_FAILURE;
         }
-        if (wolfSSL_BIO_write(bio, "        Signature Algorithm: ",
-                      (int)XSTRLEN("        Signature Algorithm: ")) <= 0) {
+        if (wolfSSL_BIO_write(bio, "    Signature Algorithm: ",
+                      (int)XSTRLEN("    Signature Algorithm: ")) <= 0) {
             return WOLFSSL_FAILURE;
         }
         sig = GetSigName(oid);
@@ -6089,7 +6089,7 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
         char tmp[100];
 
         XSNPRINTF(tmp, sizeof(tmp),
-                  "            X509v3 Basic Constraints: ");
+                  "\n            X509v3 Basic Constraints: ");
         if (x509->basicConstCrit) {
             XSTRNCAT(tmp, "critical", sizeof(tmp) - XSTRLEN(tmp) - 1);
         }
@@ -6141,7 +6141,7 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
             XFREE(sig, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             return WOLFSSL_FAILURE;
         }
-        XSNPRINTF(tmp, sizeof(tmp) - 1,"        ");
+        XSNPRINTF(tmp, sizeof(tmp) - 1,"         ");
         tmp[sizeof(tmp) - 1] = '\0';
         for (i = 0; i < sigSz; i++) {
             char val[5];
@@ -6158,7 +6158,7 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
                     return WOLFSSL_FAILURE;
                 }
                 XSNPRINTF(tmp, sizeof(tmp) - 1,
-                        ":\n        ");
+                        ":\n         ");
                 XSNPRINTF(val, valSz - 1, "%02x", sig[i]);
             }
             else {

--- a/tests/api.c
+++ b/tests/api.c
@@ -51234,9 +51234,9 @@ static void test_wolfSSL_X509_print(void)
 
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME)
     /* Will print IP address subject alt name. */
-    AssertIntEQ(BIO_get_mem_data(bio, NULL), 3329);
+    AssertIntEQ(BIO_get_mem_data(bio, NULL), 3341);
 #else
-    AssertIntEQ(BIO_get_mem_data(bio, NULL), 3307);
+    AssertIntEQ(BIO_get_mem_data(bio, NULL), 3319);
 #endif
     BIO_free(bio);
 


### PR DESCRIPTION
# Description

Removed or added spaces and line-feed by [PR5087](https://github.com/wolfSSL/wolfssl/pull/5087) causes qt unit test failure.

The PR reverts the number of spaces and a position of line-feed to be the same as before.

# Testing

Run qt unit test

# Checklist

 - [x] updated tests

