### PR TITLE
DH: Fix names wolSSL_* -> wolfSSL_*

### DIFF
--- a/src/pk.c
+++ b/src/pk.c
@@ -5947,7 +5947,7 @@ WOLFSSL_DH* wolfSSL_DH_new(void)
     return external;
 }
 
-WOLFSSL_DH* wolSSL_DH_new_by_nid(int nid)
+WOLFSSL_DH* wolfSSL_DH_new_by_nid(int nid)
 {
     WOLFSSL_DH* dh = NULL;
     int err = 0;

--- a/wolfssl/openssl/dh.h
+++ b/wolfssl/openssl/dh.h
@@ -60,7 +60,7 @@ WOLFSSL_API WOLFSSL_DH *wolfSSL_d2i_DHparams(WOLFSSL_DH **dh,
                                          const unsigned char **pp, long length);
 WOLFSSL_API int wolfSSL_i2d_DHparams(const WOLFSSL_DH *dh, unsigned char **out);
 WOLFSSL_API WOLFSSL_DH* wolfSSL_DH_new(void);
-WOLFSSL_API WOLFSSL_DH* wolSSL_DH_new_by_nid(int nid);
+WOLFSSL_API WOLFSSL_DH* wolfSSL_DH_new_by_nid(int nid);
 WOLFSSL_API void        wolfSSL_DH_free(WOLFSSL_DH* dh);
 WOLFSSL_API WOLFSSL_DH* wolfSSL_DH_dup(WOLFSSL_DH* dh);
 WOLFSSL_API int         wolfSSL_DH_up_ref(WOLFSSL_DH* dh);
@@ -85,7 +85,7 @@ typedef WOLFSSL_DH                   DH;
 #define DH_new        wolfSSL_DH_new
 #define DH_free       wolfSSL_DH_free
 #define DH_up_ref     wolfSSL_DH_up_ref
-#define DH_new_by_nid wolSSL_DH_new_by_nid
+#define DH_new_by_nid wolfSSL_DH_new_by_nid
 
 #define d2i_DHparams    wolfSSL_d2i_DHparams
 #define i2d_DHparams    wolfSSL_i2d_DHparams


### PR DESCRIPTION
# Description

Change name of API wolSSL_DH_new_by_nid() to wolfSSL_DH_new_by_nid().

Fixes #5263

# Testing

Standard testing

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
