### PR TITLE
20220620-multi-test-fixes

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -38614,8 +38614,8 @@ static void test_wolfSSL_PEM_write_bio_X509(void)
     BIO_free(output);
     X509_free(x509a);
 
-    /* test CA and basicConstSet values are encoded when 
-     * the cert is a CA */ 
+    /* test CA and basicConstSet values are encoded when
+     * the cert is a CA */
     AssertNotNull(input = BIO_new_file(
             "certs/server-cert.pem", "rb"));
 
@@ -38631,14 +38631,14 @@ static void test_wolfSSL_PEM_write_bio_X509(void)
     AssertNotNull(PEM_read_bio_X509(output, &x509b, NULL, NULL));
     AssertIntEQ(x509b->isCa, 1);
     AssertIntEQ(x509b->basicConstSet, 1);
-    
+
     X509_free(x509a);
     X509_free(x509b);
     BIO_free(input);
     BIO_free(output);
 
-    /* test CA and basicConstSet values are encoded when 
-     * the cert is not CA */ 
+    /* test CA and basicConstSet values are encoded when
+     * the cert is not CA */
     AssertNotNull(input = BIO_new_file(
             "certs/client-uri-cert.pem", "rb"));
 
@@ -38654,7 +38654,7 @@ static void test_wolfSSL_PEM_write_bio_X509(void)
     AssertNotNull(PEM_read_bio_X509(output, &x509b, NULL, NULL));
     AssertIntEQ(x509b->isCa, 0);
     AssertIntEQ(x509b->basicConstSet, 1);
-    
+
     X509_free(x509a);
     X509_free(x509b);
     BIO_free(input);

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -315,7 +315,7 @@ static int test_tls(func_args* server_args)
 }
 
 /* Show cipher suites available. */
-static void show_ciphers()
+static void show_ciphers(void)
 {
     char ciphers[WOLFSSL_CIPHER_LIST_MAX_SIZE];
     XMEMSET(ciphers, 0, sizeof(ciphers));
@@ -324,7 +324,7 @@ static void show_ciphers()
 }
 
 /* Cleanup temporary output file. */
-static void cleanup_output()
+static void cleanup_output(void)
 {
     remove(outputName);
 }
@@ -334,7 +334,7 @@ static void cleanup_output()
  * @return  0 on success.
  * @return  1 on failure.
  */
-static int validate_cleanup_output()
+static int validate_cleanup_output(void)
 {
 #ifndef NO_SHA256
     byte input[WC_SHA256_DIGEST_SIZE];

--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -1268,7 +1268,7 @@ int wc_CryptoCb_Cmac(Cmac* cmac, const byte* key, word32 keySz,
 #endif
 
 /* returns the default dev id for the current build */
-int wc_CryptoCb_DefaultDevID()
+int wc_CryptoCb_DefaultDevID(void)
 {
     int ret;
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -13825,7 +13825,7 @@ static WC_INLINE void IncrementX963KdfCounter(byte* inOutCtr)
 int wc_X963_KDF(enum wc_HashType type, const byte* secret, word32 secretSz,
                 const byte* sinfo, word32 sinfoSz, byte* out, word32 outSz)
 {
-    int ret, i;
+    int ret;
     int digestSz, copySz;
     int remaining = outSz;
     byte* outIdx;
@@ -13869,7 +13869,7 @@ int wc_X963_KDF(enum wc_HashType type, const byte* secret, word32 secretSz,
     outIdx = out;
     XMEMSET(counter, 0, sizeof(counter));
 
-    for (i = 1; remaining > 0; i++) {
+    while (remaining > 0) {
 
         IncrementX963KdfCounter(counter);
 

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -4497,7 +4497,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
      * @param none
      * @return "blake2b512"
      */
-    const WOLFSSL_EVP_MD* wolfSSL_EVP_blake2b512()
+    const WOLFSSL_EVP_MD* wolfSSL_EVP_blake2b512(void)
     {
         WOLFSSL_ENTER("EVP_blake2b512");
         return EVP_get_digestbyname("BLAKE2b512");
@@ -4510,7 +4510,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
      * @param none
      * @return "blake2s256"
      */
-    const WOLFSSL_EVP_MD* wolfSSL_EVP_blake2s256()
+    const WOLFSSL_EVP_MD* wolfSSL_EVP_blake2s256(void)
     {
         WOLFSSL_ENTER("EVP_blake2s256");
         return EVP_get_digestbyname("BLAKE2s256");


### PR DESCRIPTION
fixes for defects identified by wolfssl-multi-test: whitespace, missing void in arg lists, and -Wunused-but-set-variable found by clang-15 (prerelease).

(new true-positive warnings after update to LLVM c2d27c89593e92f8e557f27ec02f083760eeab2d)

tested with `wolfssl-multi-test.sh ... clang-tidy-fips-140-3-all super-quick-check`
