### PR TITLE
Fixed issuer email in SAN.

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -11764,7 +11764,8 @@ static int GetCertName(DecodedCert* cert, char* full, byte* hash, int nameType,
                         && !defined(WOLFCRYPT_ONLY)
                     nid = NID_emailAddress;
                 #endif /* OPENSSL_EXTRA */
-                #ifndef IGNORE_NAME_CONSTRAINTS
+                #if !defined(IGNORE_NAME_CONSTRAINTS) \
+                        && !defined(NO_POLLUTE_SAN)
                     {
                         DNS_entry* emailName;
 


### PR DESCRIPTION
# Description

Unfortunate design of certificate parsing causes abstract layer at Rockwell Automation product to fail parsing of email address with type 0 == ASN_OTHER_TYPE inside of DecodedCert::altEmailNames.
1. Abstract layer not willing to sanitize the DecodedCert::altEmailNames for reasons:
1.1. Modify memory (possible memory leak or double free in case of mistake).
1.2. Modify a certificate when parsed might lead to tampering when serialized.
2. Abstract layer not willing to skip email addresses with type ASN_OTHER_TYPE inside of DecodedCert::altEmailNames.
2.1. Leads to obscure code that is difficult to read in the abstract layer.
2.2. Code is not generic and reusable in the abstract layer (uncertain of type of DecodedCert::altNames which might include type ASN_IP_TYPE and not only ASN_DNS_TYPE ??). i.e. It is unclear whether or not DecodedCert::altNames has a corresponding type.

Fixes zd#14357

# Testing

Use int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm) to load a certificate that has an email address in the issuer distinguished name and any kind of subject alternative name. The email address is added to the SAN with an invalid type 0 (but shared with possible valid ASN_OTHER_TYPE - which cannot be distinguished).

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
