### PR TITLE
Display SKIP instead of PASS when tests skipped for make check

### DIFF
--- a/scripts/external.test
+++ b/scripts/external.test
@@ -12,7 +12,7 @@ ca=./certs/wolfssl-website-ca.pem
 # www.wolfssl.com isn't using RFC 8446 yet but the draft instead.
 if ! ./examples/client/client -V | grep -q 3; then
     echo 'skipping external.test because TLS1.2 is not available.' 1>&2
-    exit 0
+    exit 77
 fi
 
 # cloudflare seems to change CAs quickly, disabled by default
@@ -21,18 +21,18 @@ if test -n "$WOLFSSL_EXTERNAL_TEST"; then
     BUILD_FLAGS="$(./examples/client/client '-#')"
     if echo "$BUILD_FLAGS" | fgrep -q -e ' -DWOLFSSL_SNIFFER '; then
         echo 'skipping WOLFSSL_EXTERNAL_TEST because -DWOLFSSL_SNIFFER configuration of build is incompatible.'
-        exit 0
+        exit 77
     fi
 
     if echo "$BUILD_FLAGS" | fgrep -v -q -e ' -DHAVE_ECC '; then
         echo 'skipping WOLFSSL_EXTERNAL_TEST because -UHAVE_ECC configuration of build is incompatible.'
-        exit 0
+        exit 77
     fi
 
     echo "WOLFSSL_EXTERNAL_TEST set, running test..."
 else
     echo "WOLFSSL_EXTERNAL_TEST NOT set, won't run"
-    exit 0
+    exit 77
 fi
 
 # is our desired server there?

--- a/scripts/google.test
+++ b/scripts/google.test
@@ -8,7 +8,7 @@ server=www.google.com
 
 if ! ./examples/client/client -V | grep -q 3; then
     echo 'skipping google.test because TLS1.2 is not available.' 1>&2
-    exit 0
+    exit 77
 fi
 
 # is our desired server there?

--- a/scripts/ocsp-stapling-with-ca-as-responder.test
+++ b/scripts/ocsp-stapling-with-ca-as-responder.test
@@ -25,7 +25,7 @@ fi
 
 if ! ./examples/client/client -V | grep -q 3; then
     echo 'skipping ocsp-stapling-with-ca-as-responder.test because TLS1.2 is not available.' 1>&2
-    exit 0
+    exit 77
 fi
 
 PARENTDIR="$PWD"

--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -13,7 +13,7 @@ fi
 
 if ! ./examples/client/client -V | grep -q 3; then
     echo 'skipping ocsp-stapling.test because TLS1.2 is not available.' 1>&2
-    exit 0
+    exit 77
 fi
 
 if openssl s_server -help 2>&1 | fgrep -q -i ipv6 && nc -h 2>&1 | fgrep -q -i ipv6; then
@@ -25,7 +25,7 @@ fi
 if ./examples/client/client '-#' | fgrep -q -e ' -DTEST_IPV6 '; then
     if [[ "$IPV6_SUPPORTED" == "no" ]]; then
         echo 'Skipping IPV6 test in environment lacking IPV6 support.'
-        exit 0
+        exit 77
     fi
     LOCALHOST='[::1]'
     LOCALHOST_FOR_NC='::1'

--- a/scripts/ocsp-stapling2.test
+++ b/scripts/ocsp-stapling2.test
@@ -26,7 +26,7 @@ fi
 
 if ! ./examples/client/client -V | grep -q 3; then
     echo 'skipping ocsp-stapling2.test because TLS1.2 is not available.' 1>&2
-    exit 0
+    exit 77
 fi
 
 if openssl s_server -help 2>&1 | fgrep -q -i ipv6 && nc -h 2>&1 | fgrep -q -i ipv6; then

--- a/scripts/ocsp.test
+++ b/scripts/ocsp.test
@@ -14,7 +14,7 @@ ca=certs/external/ca-globalsign-root.pem
 
 if ! ./examples/client/client -V | grep -q 3; then
     echo 'skipping ocsp.test because TLS1.2 is not available.' 1>&2
-    exit 0
+    exit 77
 fi
 
 GL_UNREACHABLE=0

--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -10,7 +10,7 @@ CERT_DIR="$PWD/$(dirname "$0")/../certs"
 
 if ! test -n "$WOLFSSL_OPENSSL_TEST"; then
     echo "WOLFSSL_OPENSSL_TEST NOT set, won't run"
-    exit 0
+    exit 77
 fi
 
 # if we can, isolate the network namespace to eliminate port collisions.


### PR DESCRIPTION
```
$ make check
SKIP: scripts/openssl.test
SKIP: scripts/external.test
PASS: testsuite/testsuite.test
PASS: scripts/resume.test
PASS: scripts/google.test
PASS: scripts/tls13.test
PASS: scripts/unit.test
============================================================================
Testsuite summary for wolfssl 5.3.0
============================================================================
# TOTAL: 7
# PASS:  5
# SKIP:  2
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```