### PR TITLE
--enable-dh=const

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -128,7 +128,6 @@ AC_TYPE_SIZE_T
 AC_TYPE_UINT8_T
 AC_TYPE_UINTPTR_T
 AM_PROG_AS
-LT_LIB_M
 
 OPTIMIZE_CFLAGS="-Os"
 OPTIMIZE_FAST_CFLAGS="-O2"
@@ -827,6 +826,15 @@ then
 
     # Enable multiple attribute additions such as DC
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_MULTI_ATTRIB"
+
+    # Enable DH Extra
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DH_EXTRA"
+
+    # Enable deterministic ECC signing API with variant
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ECDSA_DETERMINISTIC_K_VARIANT"
+
+    # Store issuer name components when parsing certificates.
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_HAVE_ISSUER_NAMES"
 fi
 
 
@@ -3373,7 +3381,7 @@ AC_ARG_ENABLE([dh],
     [ ENABLED_DH=yes ]
     )
 
-if test "$ENABLED_OPENSSH" = "yes"
+if test "$ENABLED_OPENSSH" = "yes" && test "$ENABLED_DH" = "no"
 then
     ENABLED_DH="yes"
 fi
@@ -3390,7 +3398,12 @@ else
     fi
 fi
 
-if test "x$ENABLED_SNIFFER" = "xyes" && test "x$ENABLED_DH" = "xyes"
+if test "$ENABLED_DH" = "const"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DH_CONST"
+fi
+
+if test "$ENABLED_SNIFFER" = "yes" && test "$ENABLED_DH" != "no"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DH_EXTRA"
 fi
@@ -3410,7 +3423,7 @@ then
 fi
 if test "x$ENABLED_ANON" = "xyes"
 then
-    if test "x$ENABLED_DH" != "xyes"
+    if test "$ENABLED_DH" = "no"
     then
         AC_MSG_ERROR([Anonymous suite requires DH.])
     fi
@@ -4494,7 +4507,7 @@ then
 fi
 
 # Diffie-Hellman
-if test "$ENABLED_DH" = "yes"
+if test "$ENABLED_DH" != "no"
 then
     if test "$ENABLED_TLS13" = "yes" || test "$ENABLED_SUPPORTED_CURVES" = "yes"
     then
@@ -4533,7 +4546,7 @@ then
     ENABLED_TLS13=no
 fi
 if test "$ENABLED_TLS13" = "yes" && (test "x$ENABLED_ECC" = "xyes" || \
-    test "x$ENABLED_DH" = "xyes")
+    test "$ENABLED_DH" != "no")
 then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_SUPPORTED_CURVES"
 fi
@@ -6284,7 +6297,7 @@ if test "$ENABLED_RSA" = "yes" && test "$ENABLED_SP_RSA" = "yes"; then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_HAVE_SP_RSA"
     AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_HAVE_SP_RSA"
 fi
-if test "$ENABLED_DH" = "yes" && test "$ENABLED_SP_DH" = "yes"; then
+if test "$ENABLED_DH" != "no" && test "$ENABLED_SP_DH" = "yes"; then
     ENABLED_SP=yes
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_HAVE_SP_DH"
     AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_HAVE_SP_DH"
@@ -6369,7 +6382,7 @@ if test "$ENABLED_SP_MATH" = "yes"; then
     if test "$ENABLED_SP_RSA" = "no" && test "$ENABLED_RSA" = "yes"; then
         AC_MSG_ERROR([Cannot use RSA single precision only math and RSA])
     fi
-    if test "$ENABLED_SP_DH" = "no" && test "$ENABLED_DH" = "yes"; then
+    if test "$ENABLED_SP_DH" = "no" && test "$ENABLED_DH" != "no"; then
         AC_MSG_ERROR([Cannot use DH single precision only math and DH])
     fi
 
@@ -7574,6 +7587,12 @@ then
 fi
 
 
+# Link with the math library iff needed.
+if test "$ENABLED_DH" != "no" && test "$ENABLED_DH" != "const"; then
+   LT_LIB_M
+fi
+
+
 ################################################################################
 
 # USER SETTINGS
@@ -7776,7 +7795,7 @@ AM_CONDITIONAL([BUILD_ECCSI],[test "x$ENABLED_ECCSI" = "xyes" || test "x$ENABLED
 AM_CONDITIONAL([BUILD_SAKKE],[test "x$ENABLED_SAKKE" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_MEMORY],[test "x$ENABLED_MEMORY" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_RSA],[test "x$ENABLED_RSA" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
-AM_CONDITIONAL([BUILD_DH],[test "x$ENABLED_DH" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
+AM_CONDITIONAL([BUILD_DH],[test "x$ENABLED_DH" != "xno" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_ASN],[test "x$ENABLED_ASN" != "xno" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_AES],[test "x$ENABLED_AES" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_CODING],[test "x$ENABLED_CODING" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1165,12 +1165,12 @@ static const char* client_usage_msg[][70] = {
         "-D          Override Date Errors example\n",                   /* 18 */
         "-e          List Every cipher suite available, \n",            /* 19 */
         "-g          Send server HTTP GET\n",                           /* 20 */
-        "-u          Use UDP DTLS,"
 #ifndef WOLFSSL_DTLS13
-                 " add -v 2 for DTLSv1, -v 3 for DTLSv1.2 (default)\n", /* 21 */
+        "-u          Use UDP DTLS, add -v 2 for DTLSv1, -v 3 for DTLSv1.2"
+            " (default)\n",                                             /* 21 */
 #else
-                 " add -v 2 for DTLSv1, -v 3 for DTLSv1.2 (default), -v 4 for "
-                 "DTLSv1.3\n",                                          /* 21 */
+        "-u          Use UDP DTLS, add -v 2 for DTLSv1, -v 3 for DTLSv1.2"
+            " (default), -v 4 for DTLSv1.3\n",                          /* 21 */
 #endif /* !WOLFSSL_DTLS13 */
 #ifdef WOLFSSL_SCTP
         "-G          Use SCTP DTLS,"

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -828,12 +828,12 @@ static const char* server_usage_msg[][64] = {
         "-d          Disable client cert check\n",                      /* 12 */
         "-b          Bind to any interface instead of localhost only\n",/* 13 */
         "-s          Use pre Shared keys\n",                            /* 14 */
-        "-u          Use UDP DTLS,"
 #ifndef WOLFSSL_DTLS13
-                 " add -v 2 for DTLSv1, -v 3 for DTLSv1.2 (default)\n", /* 21 */
+        "-u          Use UDP DTLS, add -v 2 for DTLSv1, -v 3 for DTLSv1.2"
+            " (default)\n",                                             /* 15 */
 #else
-                 " add -v 2 for DTLSv1, -v 3 for DTLSv1.2 (default), -v 4 for "
-                 "DTLSv1.3\n",                                          /* 21 */
+        "-u          Use UDP DTLS, add -v 2 for DTLSv1, -v 3 for DTLSv1.2"
+            " (default), -v 4 for DTLSv1.3\n",                          /* 15 */
 #endif /* !WOLFSSL_DTLS13 */
 #ifdef WOLFSSL_SCTP
         "-G          Use SCTP DTLS,"


### PR DESCRIPTION
Allows `--enable-dh=const`, building DH with `-DWOLFSSL_DH_CONST`.

Also conditionalizes linking with libm, which is only needed when `ENABLED_DH` is `yes` (versus `no` or `const`).

Tested with `wolfssl-multi-test.sh ... super-quick-check`.

ZD 14379