### PR TITLE
DTLS 1.3: additions for event driven server in wolfssl-examples

### DIFF
--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -1595,7 +1595,7 @@ WOLFSSL* wolfSSL_new(WOLFSSL_CTX*);
     \sa wolfSSL_SetIOReadCtx
     \sa wolfSSL_SetIOWriteCtx
 */
-int  wolfSSL_set_fd (WOLFSSL* ssl, int fd);
+int  wolfSSL_set_fd(WOLFSSL* ssl, int fd);
 
 /*!
     \ingroup Setup
@@ -1631,8 +1631,39 @@ int  wolfSSL_set_fd (WOLFSSL* ssl, int fd);
     \sa wolfSSL_CTX_SetIORecv
     \sa wolfSSL_SetIOReadCtx
     \sa wolfSSL_SetIOWriteCtx
+    \sa wolfDTLS_SetChGoodCb
 */
 int wolfSSL_set_dtls_fd_connected(WOLFSSL* ssl, int fd)
+
+/*!
+    \ingroup Setup
+
+    \brief Allows setting a callback for DTLS client hello "good".
+
+    \return SSL_SUCCESS upon success.
+    \return BAD_FUNC_ARG upon failure.
+
+    \param ssl pointer to the SSL session, created with wolfSSL_new().
+    \param fd file descriptor to use with SSL/TLS connection.
+
+    _Example_
+    \code
+
+    // Called when we have verified a connection
+    static int chGoodCb(WOLFSSL* ssl, void* arg)
+    {
+        // setup peer and file descriptors
+
+    }
+
+    if (wolfDTLS_SetChGoodCb(ssl, chGoodCb, NULL) != WOLFSSL_SUCCESS) {
+         // error setting callback
+    }
+    \endcode
+
+    \sa wolfSSL_set_dtls_fd_connected
+*/
+int wolfDTLS_SetChGoodCb(WOLFSSL* ssl, ClientHelloGoodCb cb, void* user_ctx);
 
 /*!
     \ingroup IO

--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -1638,7 +1638,19 @@ int wolfSSL_set_dtls_fd_connected(WOLFSSL* ssl, int fd)
 /*!
     \ingroup Setup
 
-    \brief Allows setting a callback for DTLS client hello "good".
+    \brief Allows setting a callback for a correctly processed and verified DTLS
+           client hello. When using a cookie exchange mechanism (either the
+           HelloVerifyRequest in DTLS 1.2 or the HelloRetryRequest with a cookie
+           extension in DTLS 1.3) this callback is called after the cookie
+           exchange has succeeded. This is useful to use one WOLFSSL object as
+           the listener for new connections and being able to isolate the
+           WOLFSSL object once the ClientHello is verified (either through a
+           cookie exchange or just checking if the ClientHello had the correct
+           format).
+           DTLS 1.2:
+           https://datatracker.ietf.org/doc/html/rfc6347#section-4.2.1
+           DTLS 1.3:
+           https://www.rfc-editor.org/rfc/rfc8446#section-4.2.2
 
     \return SSL_SUCCESS upon success.
     \return BAD_FUNC_ARG upon failure.

--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -1598,6 +1598,43 @@ WOLFSSL* wolfSSL_new(WOLFSSL_CTX*);
 int  wolfSSL_set_fd (WOLFSSL* ssl, int fd);
 
 /*!
+    \ingroup Setup
+
+    \brief This function assigns a file descriptor (fd) as the
+    input/output facility for the SSL connection. Typically this will be
+    a socket file descriptor. This is a DTLS specific API because it marks that
+    the socket is connected. recvfrom and sendto calls on this fd will have the
+    addr and addr_len parameters set to NULL.
+
+    \return SSL_SUCCESS upon success.
+    \return Bad_FUNC_ARG upon failure.
+
+    \param ssl pointer to the SSL session, created with wolfSSL_new().
+    \param fd file descriptor to use with SSL/TLS connection.
+
+    _Example_
+    \code
+    int sockfd;
+    WOLFSSL* ssl = 0;
+    ...
+    if (connect(sockfd, peer_addr, peer_addr_len) != 0) {
+        // handle connect error
+    }
+    ...
+    ret = wolfSSL_set_dtls_fd_connected(ssl, sockfd);
+    if (ret != SSL_SUCCESS) {
+        // failed to set SSL file descriptor
+    }
+    \endcode
+
+    \sa wolfSSL_CTX_SetIOSend
+    \sa wolfSSL_CTX_SetIORecv
+    \sa wolfSSL_SetIOReadCtx
+    \sa wolfSSL_SetIOWriteCtx
+*/
+int wolfSSL_set_dtls_fd_connected(WOLFSSL* ssl, int fd)
+
+/*!
     \ingroup IO
 
     \brief Get the name of cipher at priority level passed in.
@@ -3521,9 +3558,11 @@ int  wolfSSL_dtls(WOLFSSL* ssl);
     \return SSL_NOT_IMPLEMENTED will be returned if wolfSSL was not compiled
     with DTLS support.
 
-    \param ssl a pointer to a WOLFSSL structure, created using wolfSSL_new().
-    \param peer pointer to peer’s sockaddr_in structure.
-    \param peerSz size of the sockaddr_in structure pointed to by peer.
+    \param ssl    a pointer to a WOLFSSL structure, created using wolfSSL_new().
+    \param peer   pointer to peer’s sockaddr_in structure. If NULL then the peer
+                  information in ssl is cleared.
+    \param peerSz size of the sockaddr_in structure pointed to by peer. If 0
+                  then the peer information in ssl is cleared.
 
     _Example_
     \code

--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -331,6 +331,8 @@ static byte Dtls13RtxMsgNeedsAck(WOLFSSL* ssl, enum HandShakeType hs)
        message */
     if (ssl->options.side == WOLFSSL_SERVER_END && (hs == finished))
         return 1;
+#else
+    (void)ssl;
 #endif /* NO_WOLFSSL_SERVER */
 
     if (hs == session_ticket || hs == key_update)

--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -1388,6 +1388,18 @@ static int _Dtls13HandshakeRecv(WOLFSSL* ssl, byte* input, word32 size,
     if (frag_off + frag_length > message_length)
         return BUFFER_ERROR;
 
+    if (handshake_type == client_hello &&
+            /* Only when receiving an unverified ClientHello */
+            ssl->options.serverState < SERVER_HELLO_COMPLETE) {
+        /* To be able to operate in stateless mode, we assume the ClientHello
+         * is in order and we use its Handshake Message number and Sequence
+         * Number for our Tx. */
+        ssl->keys.dtls_expected_peer_handshake_number =
+                ssl->keys.dtls_handshake_number =
+                        ssl->keys.dtls_peer_handshake_number;
+        ssl->dtls13Epochs[0].nextSeqNumber = ssl->keys.curSeq;
+    }
+
     ret = Dtls13RtxMsgRecvd(ssl, (enum HandShakeType)handshake_type, frag_off);
     if (ret != 0)
         return ret;

--- a/src/internal.c
+++ b/src/internal.c
@@ -8788,6 +8788,14 @@ static int EdDSA_Update(WOLFSSL* ssl, const byte* data, int sz)
 int HashRaw(WOLFSSL* ssl, const byte* data, int sz)
 {
     int ret = 0;
+#ifdef WOLFSSL_DEBUG_TLS
+    byte digest[WC_MAX_DIGEST_SIZE];
+
+    WOLFSSL_MSG("HashRaw:");
+    WOLFSSL_MSG("Data:");
+    WOLFSSL_BUFFER(data, sz);
+    WOLFSSL_MSG("Hashes:");
+#endif
 
     (void)data;
     (void)sz;
@@ -8817,16 +8825,31 @@ int HashRaw(WOLFSSL* ssl, const byte* data, int sz)
         ret = wc_Sha256Update(&ssl->hsHashes->hashSha256, data, sz);
         if (ret != 0)
             return ret;
+    #ifdef WOLFSSL_DEBUG_TLS
+        WOLFSSL_MSG("Sha256");
+        wc_Sha256GetHash(&ssl->hsHashes->hashSha256, digest);
+        WOLFSSL_BUFFER(digest, WC_SHA224_DIGEST_SIZE);
+    #endif
     #endif
     #ifdef WOLFSSL_SHA384
         ret = wc_Sha384Update(&ssl->hsHashes->hashSha384, data, sz);
         if (ret != 0)
             return ret;
+    #ifdef WOLFSSL_DEBUG_TLS
+        WOLFSSL_MSG("Sha384");
+        wc_Sha384GetHash(&ssl->hsHashes->hashSha384, digest);
+        WOLFSSL_BUFFER(digest, WC_SHA384_DIGEST_SIZE);
+    #endif
     #endif
     #ifdef WOLFSSL_SHA512
         ret = wc_Sha512Update(&ssl->hsHashes->hashSha512, data, sz);
         if (ret != 0)
             return ret;
+    #ifdef WOLFSSL_DEBUG_TLS
+        WOLFSSL_MSG("Sha512");
+        wc_Sha512GetHash(&ssl->hsHashes->hashSha512, digest);
+        WOLFSSL_BUFFER(digest, WC_SHA512_DIGEST_SIZE);
+    #endif
     #endif
     #if !defined(WOLFSSL_NO_CLIENT_AUTH) && \
                ((defined(HAVE_ED25519) && !defined(NO_ED25519_CLIENT_AUTH)) || \

--- a/src/internal.c
+++ b/src/internal.c
@@ -554,7 +554,7 @@ int IsDtlsNotSctpMode(WOLFSSL* ssl)
 #endif
 }
 
-#ifndef WOLFSSL_NO_TLS12
+#if !defined(WOLFSSL_NO_TLS12) && !defined(NO_WOLFSSL_SERVER)
 /* Secure Real-time Transport Protocol */
 /* If SRTP is not enabled returns the state of the dtls option.
  * If SRTP is enabled returns dtls && !dtlsSrtpProfiles. */
@@ -566,7 +566,7 @@ static WC_INLINE int IsDtlsNotSrtpMode(WOLFSSL* ssl)
     return ssl->options.dtls;
 #endif
 }
-#endif /* !WOLFSSL_NO_TLS12 */
+#endif /* !WOLFSSL_NO_TLS12 && !NO_WOLFSSL_SERVER */
 #endif /* WOLFSSL_DTLS */
 
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -12794,9 +12794,9 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
 #endif /* NO_WOLFSSL_SERVER */
 
 #if defined(WOLFSSL_DTLS) && !defined(NO_WOLFSSL_SERVER)
-int wolfSSL_SetChGoodCb(WOLFSSL* ssl, ClientHelloGoodCb cb, void* user_ctx)
+int wolfDTLS_SetChGoodCb(WOLFSSL* ssl, ClientHelloGoodCb cb, void* user_ctx)
 {
-    WOLFSSL_ENTER("wolfSSL_SetChGoodCb");
+    WOLFSSL_ENTER("wolfDTLS_SetChGoodCb");
 
     if (ssl == NULL)
         return BAD_FUNC_ARG;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -12793,7 +12793,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
 
 #endif /* NO_WOLFSSL_SERVER */
 
-#ifdef WOLFSSL_DTLS
+#if defined(WOLFSSL_DTLS) && !defined(NO_WOLFSSL_SERVER)
 int wolfSSL_SetChGoodCb(WOLFSSL* ssl, ClientHelloGoodCb cb, void* user_ctx)
 {
     WOLFSSL_ENTER("wolfSSL_SetChGoodCb");

--- a/src/tls.c
+++ b/src/tls.c
@@ -6169,9 +6169,10 @@ static int TLSX_Cookie_Parse(WOLFSSL* ssl, const byte* input, word16 length,
     extension = TLSX_Find(ssl->extensions, TLSX_COOKIE);
     if (extension == NULL) {
 #ifdef WOLFSSL_DTLS13
-        if (ssl->options.dtls)
-            /* TODO: Should we allow a ClientHello with a valid cookie even if
-             *       the cookie wasn't sent by this WOLFSSL object? */
+        if (ssl->options.dtls && IsAtLeastTLSv1_3(ssl->version))
+            /* Allow a cookie extension with DTLS 1.3 because it is possible
+             * that a different SSL instance sent the cookie but we are now
+             * receiving it. */
             return TLSX_Cookie_Use(ssl, input + idx, len, NULL, 0, 0);
         else
 #endif

--- a/src/tls.c
+++ b/src/tls.c
@@ -6167,8 +6167,16 @@ static int TLSX_Cookie_Parse(WOLFSSL* ssl, const byte* input, word16 length,
 
     /* client_hello */
     extension = TLSX_Find(ssl->extensions, TLSX_COOKIE);
-    if (extension == NULL)
-        return HRR_COOKIE_ERROR;
+    if (extension == NULL) {
+#ifdef WOLFSSL_DTLS13
+        if (ssl->options.dtls)
+            /* TODO: Should we allow a ClientHello with a valid cookie even if
+             *       the cookie wasn't sent by this WOLFSSL object? */
+            return TLSX_Cookie_Use(ssl, input + idx, len, NULL, 0, 0);
+        else
+#endif
+            return HRR_COOKIE_ERROR;
+    }
 
     cookie = (Cookie*)extension->data;
     if (cookie->len != len || XMEMCMP(&cookie->data, input + idx, len) != 0)

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -2832,6 +2832,13 @@ static int CreateCookie(WOLFSSL* ssl, byte* hash, byte hashSz)
         return ret;
     if ((ret = wc_HmacUpdate(&cookieHmac, hash, hashSz)) != 0)
         return ret;
+#ifdef WOLFSSL_DTLS13
+    /* Tie cookie to peer address */
+    if (ssl->options.dtls && ssl->buffers.dtlsCtx.peer.sz > 0 &&
+            (ret = wc_HmacUpdate(&cookieHmac, ssl->buffers.dtlsCtx.peer.sa,
+                    ssl->buffers.dtlsCtx.peer.sz)) != 0)
+        return ret;
+#endif
     if ((ret = wc_HmacFinal(&cookieHmac, mac)) != 0)
         return ret;
 
@@ -4775,6 +4782,13 @@ static int CheckCookie(WOLFSSL* ssl, byte* cookie, byte cookieSz)
         return ret;
     if ((ret = wc_HmacUpdate(&cookieHmac, cookie, cookieSz)) != 0)
         return ret;
+#ifdef WOLFSSL_DTLS13
+    /* Tie cookie to peer address */
+    if (ssl->options.dtls && ssl->buffers.dtlsCtx.peer.sz > 0 &&
+            (ret = wc_HmacUpdate(&cookieHmac, ssl->buffers.dtlsCtx.peer.sa,
+                    ssl->buffers.dtlsCtx.peer.sz)) != 0)
+        return ret;
+#endif
     if ((ret = wc_HmacFinal(&cookieHmac, mac)) != 0)
         return ret;
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -10834,6 +10834,8 @@ int wolfSSL_accept_TLSv13(WOLFSSL* ssl)
                     ssl->keys.dtls_handshake_number = 0;
 
                     ssl->msgsReceived.got_client_hello = 0;
+                    /* Remove cookie so that it will get computed again */
+                    TLSX_Remove(&ssl->extensions, TLSX_COOKIE, ssl->heap);
 
                     /* Reset states */
                     ssl->options.serverState = NULL_STATE;

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -10798,6 +10798,17 @@ int wolfSSL_accept_TLSv13(WOLFSSL* ssl)
                 }
             }
 
+#ifdef WOLFSSL_DTLS
+            if (ssl->chGoodCb != NULL) {
+                int cbret = ssl->chGoodCb(ssl, ssl->chGoodCtx);
+                if (cbret < 0) {
+                    ssl->error = cbret;
+                    WOLFSSL_MSG("ClientHello Good Cb don't continue error");
+                    return WOLFSSL_FATAL_ERROR;
+                }
+            }
+#endif
+
             ssl->options.acceptState = TLS13_ACCEPT_SECOND_REPLY_DONE;
             WOLFSSL_MSG("accept state ACCEPT_SECOND_REPLY_DONE");
             FALL_THROUGH;

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -407,7 +407,7 @@ int EmbedReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
             else
                 dtlsCtx->peer.bufSz = 0;
         }
-        peer = dtlsCtx->peer.sa;
+        peer = (SOCKADDR_S*)dtlsCtx->peer.sa;
         peerSz = dtlsCtx->peer.bufSz;
     }
 
@@ -518,8 +518,8 @@ int EmbedSendTo(WOLFSSL* ssl, char *buf, int sz, void *ctx)
     WOLFSSL_ENTER("EmbedSendTo()");
 
     sent = (int)DTLS_SENDTO_FUNCTION(sd, buf, sz, ssl->wflags,
-                                (const SOCKADDR*)dtlsCtx->peer.sa,
-                                dtlsCtx->peer.sz);
+                !dtlsCtx->connected ? (const SOCKADDR*)dtlsCtx->peer.sa : NULL,
+                !dtlsCtx->connected ? dtlsCtx->peer.sz                  : 0);
 
     sent = TranslateReturnCode(sent, sd);
 

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -463,6 +463,7 @@ int wc_PRF_TLS(byte* digest, word32 digLen, const byte* secret, word32 secLen,
         WOLFSSL_BUFFER(prk, prkLen);
         WOLFSSL_MSG("  Info");
         WOLFSSL_BUFFER(data, idx);
+        WOLFSSL_MSG_EX("  Digest %d", digest);
 #endif
 
         ret = wc_HKDF_Expand(digest, prk, prkLen, data, idx, okm, okmLen);

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4478,6 +4478,11 @@ struct WOLFSSL {
 #ifdef WOLFSSL_STATIC_MEMORY
     WOLFSSL_HEAP_HINT heap_hint;
 #endif
+#ifdef WOLFSSL_DTLS
+    ClientHelloGoodCb chGoodCb;        /*  notify user we parsed a verified
+                                        *  ClientHello */
+    void*             chGoodCtx;       /*  user ClientHello cb context  */
+#endif
 #ifndef NO_HANDSHAKE_DONE_CB
     HandShakeDoneCb hsDoneCb;          /*  notify user handshake done */
     void*           hsDoneCtx;         /*  user handshake cb context  */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2219,6 +2219,7 @@ WOLFSSL_LOCAL int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl,
 /* wolfSSL Sock Addr */
 struct WOLFSSL_SOCKADDR {
     unsigned int sz; /* sockaddr size */
+    unsigned int bufSz; /* sockaddr size */
     void*        sa; /* pointer to the sockaddr_in or sockaddr_in6 */
 };
 
@@ -2226,6 +2227,8 @@ typedef struct WOLFSSL_DTLS_CTX {
     WOLFSSL_SOCKADDR peer;
     int rfd;
     int wfd;
+    byte userSet:1;
+    byte connected:1; /* Set when the rfd and wfd are connected sockets */
 } WOLFSSL_DTLS_CTX;
 
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2228,7 +2228,10 @@ typedef struct WOLFSSL_DTLS_CTX {
     int rfd;
     int wfd;
     byte userSet:1;
-    byte connected:1; /* Set when the rfd and wfd are connected sockets */
+    byte connected:1; /* When set indicates rfd and wfd sockets are
+                       * connected (connect() and bind() both called).
+                       * This means that sendto and recvfrom do not need to
+                       * specify and store the peer address. */
 } WOLFSSL_DTLS_CTX;
 
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2219,7 +2219,7 @@ WOLFSSL_LOCAL int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl,
 /* wolfSSL Sock Addr */
 struct WOLFSSL_SOCKADDR {
     unsigned int sz; /* sockaddr size */
-    unsigned int bufSz; /* sockaddr size */
+    unsigned int bufSz; /* size of allocated buffer */
     void*        sa; /* pointer to the sockaddr_in or sockaddr_in6 */
 };
 
@@ -4481,7 +4481,7 @@ struct WOLFSSL {
 #ifdef WOLFSSL_STATIC_MEMORY
     WOLFSSL_HEAP_HINT heap_hint;
 #endif
-#ifdef WOLFSSL_DTLS
+#if defined(WOLFSSL_DTLS) && !defined(NO_WOLFSSL_SERVER)
     ClientHelloGoodCb chGoodCb;        /*  notify user we parsed a verified
                                         *  ClientHello */
     void*             chGoodCtx;       /*  user ClientHello cb context  */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1045,6 +1045,7 @@ WOLFSSL_API int wolfSSL_CTX_set1_param(WOLFSSL_CTX* ctx, WOLFSSL_X509_VERIFY_PAR
 WOLFSSL_API int  wolfSSL_is_server(WOLFSSL* ssl);
 WOLFSSL_API WOLFSSL* wolfSSL_write_dup(WOLFSSL* ssl);
 WOLFSSL_ABI WOLFSSL_API int  wolfSSL_set_fd(WOLFSSL* ssl, int fd);
+WOLFSSL_API int wolfSSL_set_dtls_fd_connected(WOLFSSL* ssl, int fd);
 WOLFSSL_API int  wolfSSL_set_write_fd (WOLFSSL* ssl, int fd);
 WOLFSSL_API int  wolfSSL_set_read_fd (WOLFSSL* ssl, int fd);
 WOLFSSL_API char* wolfSSL_get_cipher_list(int priority);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3940,6 +3940,10 @@ WOLFSSL_API int wolfSSL_CTX_DisableExtendedMasterSecret(WOLFSSL_CTX* ctx);
 #define WOLFSSL_CRL_START_MON 0x02   /* start monitoring flag */
 
 
+/* notify user we parsed a verified ClientHello is done. This only has an effect
+ * on the server end. */
+typedef int (*ClientHelloGoodCb)(WOLFSSL* ssl, void*);
+WOLFSSL_API int wolfSSL_SetChGoodCb(WOLFSSL* ssl, ClientHelloGoodCb cb, void* user_ctx);
 /* notify user the handshake is done */
 typedef int (*HandShakeDoneCb)(WOLFSSL* ssl, void*);
 WOLFSSL_API int wolfSSL_SetHsDoneCb(WOLFSSL* ssl, HandShakeDoneCb cb, void* user_ctx);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1045,7 +1045,9 @@ WOLFSSL_API int wolfSSL_CTX_set1_param(WOLFSSL_CTX* ctx, WOLFSSL_X509_VERIFY_PAR
 WOLFSSL_API int  wolfSSL_is_server(WOLFSSL* ssl);
 WOLFSSL_API WOLFSSL* wolfSSL_write_dup(WOLFSSL* ssl);
 WOLFSSL_ABI WOLFSSL_API int  wolfSSL_set_fd(WOLFSSL* ssl, int fd);
+#ifdef WOLFSSL_DTLS
 WOLFSSL_API int wolfSSL_set_dtls_fd_connected(WOLFSSL* ssl, int fd);
+#endif
 WOLFSSL_API int  wolfSSL_set_write_fd (WOLFSSL* ssl, int fd);
 WOLFSSL_API int  wolfSSL_set_read_fd (WOLFSSL* ssl, int fd);
 WOLFSSL_API char* wolfSSL_get_cipher_list(int priority);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3943,10 +3943,13 @@ WOLFSSL_API int wolfSSL_CTX_DisableExtendedMasterSecret(WOLFSSL_CTX* ctx);
 #define WOLFSSL_CRL_START_MON 0x02   /* start monitoring flag */
 
 
+#if defined(WOLFSSL_DTLS) && !defined(NO_WOLFSSL_SERVER)
 /* notify user we parsed a verified ClientHello is done. This only has an effect
  * on the server end. */
 typedef int (*ClientHelloGoodCb)(WOLFSSL* ssl, void*);
-WOLFSSL_API int wolfSSL_SetChGoodCb(WOLFSSL* ssl, ClientHelloGoodCb cb, void* user_ctx);
+WOLFSSL_API int wolfDTLS_SetChGoodCb(WOLFSSL* ssl, ClientHelloGoodCb cb, void* user_ctx);
+#endif
+
 /* notify user the handshake is done */
 typedef int (*HandShakeDoneCb)(WOLFSSL* ssl, void*);
 WOLFSSL_API int wolfSSL_SetHsDoneCb(WOLFSSL* ssl, HandShakeDoneCb cb, void* user_ctx);


### PR DESCRIPTION
- Add callback when we parse a verified ClientHello
- Allow the DTLS server to operate without maintaining state