### PR TITLE
Clear the leftover byte count in Aes struct when setting IV.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -24082,10 +24082,13 @@ void wolfSSL_AES_cfb128_encrypt(const unsigned char *in, unsigned char* out,
     }
 
     aes = (Aes*)key;
-    if (wc_AesSetIV(aes, (const byte*)iv) != 0) {
-        WOLFSSL_MSG("Error with setting iv");
-        return;
-    }
+
+    /*
+     * We copy the IV directly into reg here because using wc_AesSetIV will
+     * clear the leftover bytes field "left", and this function relies on the
+     * leftover bytes being preserved between calls.
+     */
+    XMEMCPY(aes->reg, iv, AES_BLOCK_SIZE);
 
     if (enc == AES_ENCRYPT) {
         if (wc_AesCfbEncrypt(aes, out, in, (word32)len) != 0) {

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -3212,6 +3212,13 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
         XMEMCPY(aes->reg, iv, AES_BLOCK_SIZE);
     else
         XMEMSET(aes->reg,  0, AES_BLOCK_SIZE);
+
+#if defined(WOLFSSL_AES_COUNTER) || defined(WOLFSSL_AES_CFB) || \
+    defined(WOLFSSL_AES_OFB) || defined(WOLFSSL_AES_XTS)
+    /* Clear any unused bytes from last cipher op. */
+    aes->left = 0;
+#endif
+
     return 0;
 }
 


### PR DESCRIPTION
# Description

Setting the key already does this. The same needs to be done when setting the IV.

Fixes ZD 14050 and 12581, although this won't immediately help current FIPS users since the changes here are within the FIPS module boundary.

# Testing

See ZD 14050 and [this wolfEngine PR](https://github.com/wolfSSL/wolfEngine/pull/185), where I resolved this in wolfEngine since we can't change the FIPS v2 module.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
