### PR TITLE
Add --enable-openldap option to configure.ac.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1144,6 +1144,7 @@ AC_ARG_ENABLE([mcast],
 # krb (--enable-krb) WOLFSSL_KRB
 # FFmpeg (--enable-ffmpeg) WOLFSSL_FFMPEG
 # strongSwan (--enable-strongswan)
+# OpenLDAP (--enable-openldap)
 
 # Bind DNS compatibility Build
 AC_ARG_ENABLE([bind],
@@ -1199,6 +1200,13 @@ if test "$ENABLED_OPENRESTY" = "yes"
 then
     ENABLED_NGINX="yes"
 fi
+
+# OpenLDAP support
+AC_ARG_ENABLE([openldap],
+    [AS_HELP_STRING([--enable-openldap],[Enable OpenLDAP support (default: disabled)])],
+    [ ENABLED_OPENLDAP=$enableval ],
+    [ ENABLED_OPENLDAP=no ]
+    )
 
 # lighty Support
 AC_ARG_ENABLE([lighty],
@@ -1450,7 +1458,8 @@ if test "$ENABLED_LIBWEBSOCKETS" = "yes" || test "$ENABLED_OPENVPN" = "yes" || \
    test "$ENABLED_NTP" = "yes" || test "$ENABLED_NETSNMP" = "yes" || \
    test "$ENABLED_OPENRESTY" = "yes" || test "$ENABLED_RSYSLOG" = "yes" || \
    test "$ENABLED_KRB" = "yes" || test "$ENABLED_CHRONY" = "yes" || \
-   test "$ENABLED_FFMPEG" = "yes" || test "$ENABLED_STRONGSWAN" = "yes"
+   test "$ENABLED_FFMPEG" = "yes" || test "$ENABLED_STRONGSWAN" = "yes" || \
+   test "$ENABLED_OPENLDAP" = "yes"
 then
     ENABLED_OPENSSLALL="yes"
 fi
@@ -2665,7 +2674,8 @@ AC_ARG_ENABLE([certgen],
     )
 if test "$ENABLED_OPENVPN" = "yes" || test "$ENABLED_OPENSSH" = "yes" || \
    test "$ENABLED_BIND" = "yes" || test "$ENABLED_NTP" = "yes" || \
-   test "$ENABLED_CHRONY" = "yes" || test "$ENABLED_STRONGSWAN" = "yes"
+   test "$ENABLED_CHRONY" = "yes" || test "$ENABLED_STRONGSWAN" = "yes" || \
+   test "$ENABLED_OPENLDAP" = "yes"
 then
     ENABLED_CERTGEN=yes
 fi
@@ -7255,7 +7265,8 @@ if test "$ENABLED_OPENSSH" = "yes" || test "$ENABLED_NGINX" = "yes" || \
    test "$ENABLED_OPENSSLALL" = "yes" || \
    test "$ENABLED_LIBWEBSOCKETS" = "yes" || \
    test "x$ENABLED_LIGHTY" = "xyes" || test "$ENABLED_LIBSSH2" = "yes" || \
-   test "x$ENABLED_NTP" = "xyes" || test "$ENABLED_RSYSLOG" = "yes"
+   test "x$ENABLED_NTP" = "xyes" || test "$ENABLED_RSYSLOG" = "yes" || \
+   test "$ENABLED_OPENLDAP" = "yes"
 then
     ENABLED_OPENSSLEXTRA="yes"
 fi
@@ -7411,6 +7422,8 @@ AS_IF([test "x$ENABLED_OCSP" = "xyes"],
 
 AS_IF([test "x$ENABLED_STRONGSWAN" = "xyes"],
       [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DES_ECB -DWOLFSSL_LOG_PRINTF -DWOLFSSL_PUBLIC_MP -DHAVE_EX_DATA"])
+
+AS_IF([test "x$ENABLED_OPENLDAP" = "xyes"], [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SIGNER_DER_CERT"])
 
 if test "$ENABLED_ED25519_STREAM" != "no"
 then
@@ -8316,6 +8329,7 @@ echo "   * Qt Unit Testing:            $ENABLED_QT_TEST"
 echo "   * SIGNAL:                     $ENABLED_SIGNAL"
 echo "   * chrony:                     $ENABLED_CHRONY"
 echo "   * strongSwan:                 $ENABLED_STRONGSWAN"
+echo "   * OpenLDAP:                   $ENABLED_OPENLDAP"
 echo "   * ERROR_STRINGS:              $ENABLED_ERROR_STRINGS"
 echo "   * DTLS:                       $ENABLED_DTLS"
 echo "   * DTLS v1.3:                  $ENABLED_DTLS13"

--- a/src/x509.c
+++ b/src/x509.c
@@ -1550,6 +1550,18 @@ void* wolfSSL_X509V3_EXT_d2i(WOLFSSL_X509_EXTENSION* ext)
             WOLFSSL_MSG("cRLDistributionPoints not supported yet");
             return NULL;
 
+        case NID_subject_alt_name:
+            if (ext->ext_sk == NULL) {
+                WOLFSSL_MSG("Subject alt name stack NULL");
+                return NULL;
+            }
+            sk = wolfSSL_sk_dup(ext->ext_sk);
+            if (sk == NULL) {
+                WOLFSSL_MSG("Failed to duplicate subject alt names stack.");
+                return NULL;
+            }
+            return sk;
+
         /* authorityInfoAccess */
         case (NID_info_access):
             WOLFSSL_MSG("AuthorityInfoAccess");
@@ -3858,6 +3870,7 @@ WOLFSSL_GENERAL_NAME* wolfSSL_GENERAL_NAME_dup(WOLFSSL_GENERAL_NAME* gn)
         WOLFSSL_MSG("Unrecognized or unsupported GENERAL_NAME type");
         goto error;
     }
+    dupl->type = gn->type;
 
     return dupl;
 error:
@@ -3897,6 +3910,7 @@ int wolfSSL_sk_GENERAL_NAME_push(WOLFSSL_GENERAL_NAMES* sk,
     XMEMSET(node, 0, sizeof(WOLFSSL_STACK));
 
     /* push new obj onto head of stack */
+    node->type    = STACK_TYPE_GEN_NAME;
     node->data.gn = sk->data.gn;
     node->next    = sk->next;
     sk->next      = node;


### PR DESCRIPTION
# Description

Prior to this commit, you needed to configure with `CPPFLAGS=-DWOLFSSL_SIGNER_DER_CERT --enable-opensslextra --enable-opensslall --enable-certgen` to build our OpenLDAP port. Now, all of these options are implied by `--enable-openldap`.

# Testing

Confirmed that the port still compiles successfully with this new option.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
