### PR TITLE
Fix for using track memory feature with FreeRTOS.

### DIFF
--- a/wolfssl/wolfcrypt/mem_track.h
+++ b/wolfssl/wolfcrypt/mem_track.h
@@ -158,7 +158,11 @@
         if (sz == 0)
             return NULL;
 
+    #ifdef FREERTOS
+        mt = (memoryTrack*)pvPortMalloc(sizeof(memoryTrack) + sz);
+    #else
         mt = (memoryTrack*)malloc(sizeof(memoryTrack) + sz);
+    #endif
         if (mt == NULL)
             return NULL;
 
@@ -284,7 +288,11 @@
 #endif
         (void)sz;
 
+    #ifdef FREERTOS
+        vPortFree(mt);
+    #else
         free(mt);
+    #endif
     }
 
 

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -795,7 +795,7 @@ extern void uITRON4_free(void *p) ;
     #include "FreeRTOS.h"
 
     #if !defined(XMALLOC_USER) && !defined(NO_WOLFSSL_MEMORY) && \
-        !defined(WOLFSSL_STATIC_MEMORY)
+        !defined(WOLFSSL_STATIC_MEMORY) && !defined(WOLFSSL_TRACK_MEMORY)
         #define XMALLOC(s, h, type)  pvPortMalloc((s))
         #define XFREE(p, h, type)    vPortFree((p))
         /* FreeRTOS pvPortRealloc() implementation can be found here:

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -495,7 +495,7 @@ typedef struct w64wrapper {
                 #endif
                 #define XREALLOC(p, n, h, t) wolfSSL_Realloc((p), (n), (h), (t))
             #endif /* WOLFSSL_DEBUG_MEMORY */
-        #elif !defined(FREERTOS) && !defined(FREERTOS_TCP)
+        #elif (!defined(FREERTOS) && !defined(FREERTOS_TCP)) || defined(WOLFSSL_TRACK_MEMORY)
             #ifdef WOLFSSL_DEBUG_MEMORY
                 #define XMALLOC(s, h, t)     ((void)(h), (void)(t), wolfSSL_Malloc((s), __func__, __LINE__))
                 #ifdef WOLFSSL_XFREE_NO_NULLNESS_CHECK


### PR DESCRIPTION
# Description

Fix for using track memory feature (`--enable-trackmemory`) with FreeRTOS.

# Testing

Tested on ESP32 by @gojimmypi.

```
#define USE_WOLFSSL_MEMORY
#define WOLFSSL_TRACK_MEMORY

/* On startup call: */
InitMemoryTracker();

/* When ready to dump the memory report call: */
ShowMemoryTracker();
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
