### PR TITLE
SP math all: don't use sp_int_word when SQR_MUL_ASM available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6528,7 +6528,7 @@ if test "$ENABLED_SP_MATH_ALL" = "yes"; then
     ;;
   esac
 
-  if test "$ENABLED_FIPS=" != "no" || test "$SELFTEST_VERSION=" != "no"; then
+  if test "$ENABLED_FIPS" != "no" || test "$SELFTEST_VERSION" != "none"; then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_INT_NEGATIVE"
   fi
 fi

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -9522,7 +9522,7 @@ int wc_ecc_import_x963_ex(const byte* in, word32 inLen, ecc_key* key,
 
         /* compute x^3 */
         if (err == MP_OKAY)
-            err = mp_sqr(key->pubkey.x, t1);
+            err = mp_sqrmod(key->pubkey.x, curve->prime, t1);
         if (err == MP_OKAY)
             err = mp_mulmod(t1, key->pubkey.x, curve->prime, t1);
 

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -267,7 +267,8 @@ extern "C" {
 #elif SP_WORD_SIZE == 64
     typedef  sp_uint64  sp_int_digit;
     typedef   sp_int64 sp_sint_digit;
-#if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
+#if (defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)) && \
+    !defined(_WIN64)
     typedef sp_uint128  sp_int_word;
     typedef  sp_int128  sp_int_sword;
 #endif


### PR DESCRIPTION
# Description

1. _WIN64 doesn't have 128-bit type but now can use 64-bit sp_int_digit
when assembly code snippets are being used.
2. Fix sp_div() to support values closer to maximum size.
3. Fix builds to work for more configurations.
4. Have ECC uncompressed code keep intermediate values in range of
maximum (x^3 calculation fixed).
5. Fix configuation.ac's check of FIPS for using signed SP Math All.
Default now not signed as intended.

# Testing

Regression tested - including QEMU.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
