### PR TITLE
Sniffer fixes (async TLS v1.3, async removal of `WC_HW_WAIT_E` and sanitize leak)

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -5718,7 +5718,7 @@ static int CheckSequence(IpInfo* ipInfo, TcpInfo* tcpInfo,
     if (session->sslServer->error == WC_PENDING_E &&
         session->pendSeq != tcpInfo->sequence) {
         /* this stream is processing, queue packet */
-        return WC_HW_WAIT_E;
+        return WC_PENDING_E;
     }
 #endif
 

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -3994,12 +3994,14 @@ static int ProcessClientHello(const byte* input, int* sslBytes,
             }
             /* cache key share data till server_hello */
             session->cliKeyShareSz = ksLen;
-            session->cliKeyShare = (byte*)XMALLOC(ksLen, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-            if (session->cliKeyShare == NULL) {
-                SetError(MEMORY_STR, error, session, FATAL_ERROR_STATE);
-                break;
+            if (ksLen > 0) {
+                session->cliKeyShare = (byte*)XMALLOC(ksLen, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                if (session->cliKeyShare == NULL) {
+                    SetError(MEMORY_STR, error, session, FATAL_ERROR_STATE);
+                    break;
+                }
+                XMEMCPY(session->cliKeyShare, &input[2], ksLen);
             }
-            XMEMCPY(session->cliKeyShare, &input[2], ksLen);
             break;
         }
         #ifdef HAVE_SESSION_TICKET

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -4398,7 +4398,11 @@ static int DoHandShake(const byte* input, int* sslBytes,
 #endif
 
 #ifdef WOLFSSL_TLS13
-    if (type != client_hello && type != server_hello) {
+    if (type != client_hello && type != server_hello
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        && session->sslServer->error != WC_PENDING_E
+    #endif
+    ) {
         /* For resumption the hash is before / after client_hello PSK binder */
         /* hash the packet including header */
         /* TLS v1.3 requires the hash for the handshake and transfer key derivation */

--- a/src/tls.c
+++ b/src/tls.c
@@ -158,7 +158,7 @@ int BuildTlsHandshakeHash(WOLFSSL* ssl, byte* hash, word32* hashLen)
 
     *hashLen = hashSz;
 #ifdef WOLFSSL_CHECK_MEM_ZERO
-     wc_MemZero_Add("TLS hasndshake hash", hash, hashSz);
+     wc_MemZero_Add("TLS handshake hash", hash, hashSz);
 #endif
 
     if (ret != 0)

--- a/sslSniffer/sslSnifferTest/snifftest.c
+++ b/sslSniffer/sslSnifferTest/snifftest.c
@@ -827,7 +827,7 @@ int main(int argc, char** argv)
             /* grab next pcap packet */
             packetNumber++;
             packet = pcap_next(pcap, &header);
-        #ifdef QAT_DEBUG
+        #if defined(WOLFSSL_ASYNC_CRYPT) && defined(DEBUG_SNIFFER)
             printf("Packet Number: %d\n", packetNumber);
         #endif
         }

--- a/sslSniffer/sslSnifferTest/snifftest.c
+++ b/sslSniffer/sslSnifferTest/snifftest.c
@@ -867,9 +867,9 @@ int main(int argc, char** argv)
             ret = ssl_DecodePacketAsync(chain, chainSz, isChain, &data, err,
                 &sslInfo, NULL);
 
-            /* WC_PENDING_E: Hardware is processing */
-            /* WC_HW_WAIT_E: Hardware is already processing stream */
-            if (ret == WC_PENDING_E || ret == WC_HW_WAIT_E) {
+            /* WC_PENDING_E: Hardware is processing or stream is blocked
+             *               (waiting on WC_PENDING_E) */
+            if (ret == WC_PENDING_E) {
                 /* add to queue, for later processing */
             #ifdef DEBUG_SNIFFER
                 printf("Steam is pending, queue packet %d\n", packetNumber);


### PR DESCRIPTION
# Description

* Fix for sniffer async issue with TLS v1.3.
* Fix to avoid using `WC_HW_WAIT_E` for sniffer.
* Fix for sniffer possible malloc of zero size causing a `-fsanitize=address` leak report.

Fixes ZD14398

# Testing

```
./configure --enable-sniffer --enable-asynccrypt CFLAGS="-DWOLFSSL_SNIFFER_CHAIN_INPUT" --enable-curve25519 --enable-curve448 --enable-session-ticket && make
./scripts/sniffer-testsuite.test
```

```
./configure --enable-sniffer --enable-asynccrypt CFLAGS="-DWOLFSSL_SNIFFER_CHAIN_INPUT" --enable-curve25519 --enable-curve448 --enable-session-ticket --with-intelqa=../QAT1.8 && make
sudo ./scripts/sniffer-testsuite.test
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
