### PR TITLE
ESP-IDF Build Cleanup

### DIFF
--- a/IDE/Espressif/ESP-IDF/libs/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/libs/CMakeLists.txt
@@ -38,10 +38,14 @@ if(IS_DIRECTORY ${IDF_PATH}/components/cryptoauthlib)
 endif()
 
 set(COMPONENT_SRCEXCLUDE
-    "wolfcrypt/src/aes_asm.S"
-    "wolfcrypt/src/evp.c"
-    "wolfcrypt/src/misc.c"
-    "src/bio.c"
+    "./src/bio.c"
+    "./src/conf.c"
+    "./src/misc.c"
+    "./src/pk.c"
+    "./src/x509.c"
+    "./src/x509_str.c"
+    "./wolfcrypt/src/evp.c"
+    "./wolfcrypt/src/misc.c"
     )
 
 register_component()


### PR DESCRIPTION
# Description

Update the list of files to leave out of the build. They are ones that are included into ssl.c automatically.

# Testing

Tested by running the wolfSSH ESP-IDF build.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
