### PR TITLE
20220628-multi-test-and-crossbuild-fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -291,8 +291,6 @@ AS_CASE([$ENABLED_FIPS],
     [disabled],[
         FIPS_VERSION="disabled"
         ENABLED_FIPS="no"
-        DEF_SP_MATH="no"
-        DEF_FAST_MATH="yes"
     ],
     [v1|yes|cert2425],[
         FIPS_VERSION="v1"
@@ -6480,7 +6478,12 @@ do
   esac
 done
 
-if test "$ENABLED_SP_MATH_ALL" = "yes"; then
+AC_ARG_WITH([arm-target],
+    [AS_HELP_STRING([--with-arm-target=x],[x can be "thumb" or "cortex"])],
+    [ARM_TARGET="$withval"],
+    [ARM_TARGET=''])
+
+if test "$ENABLED_SP_MATH_ALL" = "yes" && test "$ENABLED_ASM" != "no"; then
 
   ENABLED_FASTMATH="no"
   ENABLED_SLOWMATH="no"
@@ -6498,10 +6501,10 @@ if test "$ENABLED_SP_MATH_ALL" = "yes"; then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_ARM64 -DWOLFSSL_AARCH64_BUILD"
     ;;
   *arm*)
-    if test $host_alias = "thumb"; then
+    if test "$host_alias" = "thumb" || test "$ARM_TARGET" = "thumb"; then
       AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_ARM_THUMB"
     else
-      if test $host_alias = "cortex"; then
+      if test "$host_alias" = "cortex" || test "$ARM_TARGET" = "cortex"; then
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_ARM_CORTEX_M"
       else
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_ARM32"
@@ -6554,12 +6557,12 @@ if test "$ENABLED_SP_ASM" = "yes" && test "$ENABLED_SP" = "yes"; then
     ENABLED_SP_ARM64_ASM=yes
     ;;
   *arm*)
-    if test $host_alias = "thumb"; then
+    if test "$host_alias" = "thumb" || test "$ARM_TARGET" = "thumb"; then
       AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_ARM_THUMB_ASM"
       AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_SP_ARM_THUMB_ASM"
       ENABLED_SP_ARM_THUMB_ASM=yes
     else
-      if test $host_alias = "cortex"; then
+      if test "$host_alias" = "cortex" || test "$ARM_TARGET" = "cortex"; then
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_ARM_CORTEX_M_ASM"
         AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_SP_ARM_CORTEX_M_ASM"
         ENABLED_SP_ARM_CORTEX_ASM=yes
@@ -7128,10 +7131,10 @@ AM_CFLAGS=$NEW_AM_CFLAGS])
 
 case $host_cpu in
   *arm*)
-    if test $host_alias = "thumb"; then
+    if test "$host_alias" = "thumb" || test "$ARM_TARGET" = "thumb"; then
       AM_CFLAGS="$AM_CFLAGS -mthumb -march=armv6"
     else
-      if test $host_alias = "cortex"; then
+      if test "$host_alias" = "cortex" || test "$ARM_TARGET" = "cortex"; then
         AM_CFLAGS="$AM_CFLAGS -mcpu=cortex-r5"
       fi
     fi

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -29351,17 +29351,19 @@ static int wc_BuildEccKeyDer(ecc_key* key, byte* output, word32 *inLen,
             SetASNItem_NoOutNode(dataASN, eccKeyASN, ECCKEYASN_IDX_PARAMS,
                     eccKeyASN_Length);
         }
-        if (pubIn) {
-            /* Leave space for public key. */
-            SetASN_Buffer(&dataASN[ECCKEYASN_IDX_PUBKEY_VAL], NULL, pubSz);
+        if (ret == 0) {
+            if (pubIn) {
+                /* Leave space for public key. */
+                SetASN_Buffer(&dataASN[ECCKEYASN_IDX_PUBKEY_VAL], NULL, pubSz);
+            }
+            else {
+                /* Don't write out public key. */
+                SetASNItem_NoOutNode(dataASN, eccKeyASN, ECCKEYASN_IDX_PUBKEY,
+                                     eccKeyASN_Length);
+            }
+            /* Calculate size of the private key encoding. */
+            ret = SizeASN_Items(eccKeyASN, dataASN, eccKeyASN_Length, &sz);
         }
-        else {
-            /* Don't write out public key. */
-            SetASNItem_NoOutNode(dataASN, eccKeyASN, ECCKEYASN_IDX_PUBKEY,
-                    eccKeyASN_Length);
-        }
-        /* Calculate size of the private key encoding. */
-        ret = SizeASN_Items(eccKeyASN, dataASN, eccKeyASN_Length, &sz);
     }
     /* Return the size if no buffer. */
     if ((ret == 0) && (output == NULL)) {

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -1329,7 +1329,7 @@ int GetASN_Items(const ASNItem* asn, ASNGetData *data, int count, int complete,
     word32 endIdx[GET_ASN_MAX_DEPTH] = { length, length, length, length, length,
                                          length, length };
     /* Set choices to -1 to indicate they haven't been seen or found. */
-    char   choiceMet[GET_ASN_MAX_CHOICES] = { -1, -1 };
+    signed char   choiceMet[GET_ASN_MAX_CHOICES] = { -1, -1 };
     /* Not matching a choice right now. */
     int    choice = 0;
     /* Current depth of ASN.1 item. */
@@ -4728,6 +4728,7 @@ const byte* OidFromId(word32 id, word32 type, word32* oidSz)
                 case AIA_CA_REPO_OID:
                     oid = extAuthInfoCaRespOid;
                     *oidSz = sizeof(extAuthInfoCaRespOid);
+                    break;
                 #endif /* WOLFSSL_SUBJ_INFO_ACC */
                 default:
                     break;
@@ -17300,7 +17301,7 @@ static int DecodeSubjInfoAcc(const byte* input, int sz, DecodedCert* cert)
      */
 
     while (idx < (word32)sz) {
-        word32 oid;
+        word32 oid = 0;
         byte b;
 
         /* Unwrap an AccessDescription */

--- a/wolfcrypt/src/siphash.c
+++ b/wolfcrypt/src/siphash.c
@@ -352,7 +352,7 @@ int wc_SipHashFinal(SipHash* sipHash, unsigned char* out, unsigned char outSz)
     return ret;
 }
 
-#if defined(__GNUC__) && defined(__x86_64__) && \
+#if !defined(WOLFSSL_NO_ASM) && defined(__GNUC__) && defined(__x86_64__) && \
     (WOLFSSL_SIPHASH_CROUNDS == 1 || WOLFSSL_SIPHASH_CROUNDS == 2) && \
     (WOLFSSL_SIPHASH_DROUNDS == 2 || WOLFSSL_SIPHASH_DROUNDS == 4)
 
@@ -566,7 +566,7 @@ int wc_SipHash(const unsigned char* key, const unsigned char* in, word32 inSz,
     return 0;
 }
 
-#elif defined(__GNUC__) && defined(__aarch64__) && \
+#elif !defined(WOLFSSL_NO_ASM) && defined(__GNUC__) && defined(__aarch64__) && \
     (WOLFSSL_SIPHASH_CROUNDS == 1 || WOLFSSL_SIPHASH_CROUNDS == 2) && \
     (WOLFSSL_SIPHASH_DROUNDS == 2 || WOLFSSL_SIPHASH_DROUNDS == 4)
 


### PR DESCRIPTION
fixes for various defects identified by wolfssl-multi-test analyzers and cross builds/qemu runs.  also usability improvements, e.g. a new `--with-arm-target=x` where `x` can be `cortex` or `thumb`.

tested with `wolfssl-multi-test.sh ... 'cross-.*' super-quick-check all-gcc-latest-c99 all-gcc-latest-c99-smallstack 'all-g\+\+-latest' all-sp-small-stack-asn-template all-asn-template clang-tidy-asn-template-sp-all-small-stack clang-tidy-all-sp-all clang-tidy-all-async clang-tidy-fips-140-3-all clang-tidy-fips-140-3-dev-all`
