### PR TITLE
20220629-multi-test-fixes

### DIFF
--- a/src/pk.c
+++ b/src/pk.c
@@ -267,8 +267,8 @@ static int wolfssl_print_number(WOLFSSL_BIO* bio, mp_int* num, const char* name,
     for (i = 0; (ret == 1) && (i < rawLen); i++) {
         /* Check for a complete line. */
         if (li >= PRINT_NUM_MAX_DIGIT_LINE) {
-            /* More bytes coming so append carriage return. */
-            line[li++] = '\n';
+            /* More bytes coming so change the trailing ':' to a line break. */
+            line[li-1] = '\n';
             /* Write out the line. */
             if (wolfSSL_BIO_write(bio, line, li) <= 0) {
                 ret = 0;

--- a/src/pk.c
+++ b/src/pk.c
@@ -155,7 +155,8 @@ static int wolfssl_print_indent(WOLFSSL_BIO* bio, char* line, int lineLen,
         if (len_wanted >= lineLen) {
             WOLFSSL_MSG("Buffer overflow formatting indentation");
             ret = 0;
-        } else {
+        }
+        else {
             /* Write indents string to BIO */
             if (wolfSSL_BIO_write(bio, line, len_wanted) <= 0) {
                 ret = 0;
@@ -261,7 +262,8 @@ static int wolfssl_print_number(WOLFSSL_BIO* bio, mp_int* num, const char* name,
         if (li >= (int)sizeof(line)) {
             WOLFSSL_MSG("Buffer overflow formatting name");
             ret = 0;
-        } else {
+        }
+        else {
             if (wolfSSL_BIO_write(bio, line, li) <= 0) {
                 ret = 0;
             }
@@ -306,8 +308,10 @@ static int wolfssl_print_number(WOLFSSL_BIO* bio, mp_int* num, const char* name,
             /* Put the leading spaces on new line. */
             XSTRNCPY(line, PRINT_NUM_INDENT, PRINT_NUM_INDENT_CNT + 1);
             li = PRINT_NUM_INDENT_CNT;
-        } else
+        }
+        else {
             li += len_wanted;
+        }
     }
 
     if (ret == 1) {
@@ -1922,7 +1926,8 @@ int wolfSSL_RSA_print(WOLFSSL_BIO* bio, WOLFSSL_RSA* rsa, int indent)
         if (len >= (int)sizeof(line)) {
             WOLFSSL_MSG("Buffer overflow while formatting key preamble");
             ret = 0;
-        } else {
+        }
+        else {
             if (wolfSSL_BIO_write(bio, line, len) <= 0) {
                 ret = 0;
             }

--- a/src/pk.c
+++ b/src/pk.c
@@ -151,10 +151,15 @@ static int wolfssl_print_indent(WOLFSSL_BIO* bio, char* line, int lineLen,
 
     if (indent > 0) {
         /* Print indent spaces. */
-        lineLen = (int)XSNPRINTF(line, lineLen - 1, "%*s", indent, " ");
-        /* Write indents string to BIO */
-        if (wolfSSL_BIO_write(bio, line, lineLen) <= 0) {
+        int len_wanted = XSNPRINTF(line, lineLen, "%*s", indent, " ");
+        if (len_wanted >= lineLen) {
+            WOLFSSL_MSG("Buffer overflow formatting indentation");
             ret = 0;
+        } else {
+            /* Write indents string to BIO */
+            if (wolfSSL_BIO_write(bio, line, len_wanted) <= 0) {
+                ret = 0;
+            }
         }
     }
 
@@ -193,11 +198,16 @@ static int wolfssl_print_value(WOLFSSL_BIO* bio, mp_int* value,
         /* Get 32-bits of value. */
         v = (word32)value->dp[0];
         /* Print the line to the string. */
-        len = (int)XSNPRINTF(line, sizeof(line) - 1, "%s %u (0x%x)\n", name, v,
+        len = (int)XSNPRINTF(line, sizeof(line), "%s %u (0x%x)\n", name, v,
             v);
-        /* Write string to BIO */
-        if (wolfSSL_BIO_write(bio, line, len) <= 0) {
+        if (len >= (int)sizeof(line)) {
+            WOLFSSL_MSG("Buffer overflow while formatting value");
             ret = 0;
+        } else {
+            /* Write string to BIO */
+            if (wolfSSL_BIO_write(bio, line, len) <= 0) {
+                ret = 0;
+            }
         }
     }
 
@@ -247,9 +257,14 @@ static int wolfssl_print_number(WOLFSSL_BIO* bio, mp_int* num, const char* name,
     }
     if (ret == 1) {
         /* Print header string line to string. */
-        li = XSNPRINTF(line, sizeof(line) - 1, "%s\n", name);
-        if (wolfSSL_BIO_write(bio, line, li) <= 0) {
+        li = XSNPRINTF(line, sizeof(line), "%s\n", name);
+        if (li >= (int)sizeof(line)) {
+            WOLFSSL_MSG("Buffer overflow formatting name");
             ret = 0;
+        } else {
+            if (wolfSSL_BIO_write(bio, line, li) <= 0) {
+                ret = 0;
+            }
         }
     }
     if (ret == 1) {
@@ -259,16 +274,27 @@ static int wolfssl_print_number(WOLFSSL_BIO* bio, mp_int* num, const char* name,
     if (ret == 1) {
         /* Start first digit line with spaces.
          * Writing out zeros ensures number is a positive value. */
-        li = XSNPRINTF(line, sizeof(line) - 1, PRINT_NUM_INDENT "%s",
+        li = XSNPRINTF(line, sizeof(line), PRINT_NUM_INDENT "%s",
             mp_leading_bit(num) ?  "00:" : "");
+        if (li >= (int)sizeof(line)) {
+            WOLFSSL_MSG("Buffer overflow formatting spaces");
+            ret = 0;
+        }
     }
 
     /* Put out each line of numbers. */
     for (i = 0; (ret == 1) && (i < rawLen); i++) {
-        /* Check for a complete line. */
-        if (li >= PRINT_NUM_MAX_DIGIT_LINE) {
-            /* More bytes coming so change the trailing ':' to a line break. */
-            line[li-1] = '\n';
+        /* Encode another byte as 2 hex digits and append colon. */
+        int len_wanted = XSNPRINTF(line + li, sizeof(line) - li, "%02x:",
+                                   rawKey[i]);
+        /* Check if there was room -- if not, print the current line, not
+         * including the newest octet.
+         */
+        if (len_wanted >= (int)sizeof(line) - li) {
+            /* bump current octet to the next line. */
+            --i;
+            /* More bytes coming so add a line break. */
+            line[li++] = '\n';
             /* Write out the line. */
             if (wolfSSL_BIO_write(bio, line, li) <= 0) {
                 ret = 0;
@@ -280,9 +306,8 @@ static int wolfssl_print_number(WOLFSSL_BIO* bio, mp_int* num, const char* name,
             /* Put the leading spaces on new line. */
             XSTRNCPY(line, PRINT_NUM_INDENT, PRINT_NUM_INDENT_CNT + 1);
             li = PRINT_NUM_INDENT_CNT;
-        }
-        /* Encode another byte as 2 hex digits and append colon. */
-        li += XSNPRINTF(line + li, sizeof(line) - 1 - li, "%02x:", rawKey[i]);
+        } else
+            li += len_wanted;
     }
 
     if (ret == 1) {
@@ -1892,10 +1917,15 @@ int wolfSSL_RSA_print(WOLFSSL_BIO* bio, WOLFSSL_RSA* rsa, int indent)
     }
     if (ret == 1) {
         /* Print header line. */
-        len = XSNPRINTF(line, sizeof(line) - 1, "\nRSA %s: (%d bit)\n",
+        len = XSNPRINTF(line, sizeof(line), "\nRSA %s: (%d bit)\n",
             (!mp_iszero(&key->d)) ? "Private-Key" : "Public-Key", sz);
-        if (wolfSSL_BIO_write(bio, line, len) <= 0) {
+        if (len >= (int)sizeof(line)) {
+            WOLFSSL_MSG("Buffer overflow while formatting key preamble");
             ret = 0;
+        } else {
+            if (wolfSSL_BIO_write(bio, line, len) <= 0) {
+                ret = 0;
+            }
         }
     }
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -1963,7 +1963,7 @@ static int EncryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
     if (ret != CRYPTOCB_UNAVAILABLE) {
         if (ret > 0) {
             ret = 0; /* tsip_Tls13AesEncrypt returns output size */
-        } 
+        }
         return ret;
     }
     ret = 0;

--- a/src/x509.c
+++ b/src/x509.c
@@ -6244,10 +6244,12 @@ int wolfSSL_X509_signature_print(WOLFSSL_BIO *bp,
         return WOLFSSL_FAILURE;
     }
 
-    if ((sigalg->algorithm->obj == NULL) || (sigalg->algorithm->obj[idx++] != ASN_OBJECT_ID)) {
+    if ((sigalg->algorithm->obj == NULL) ||
+        (sigalg->algorithm->obj[idx] != ASN_OBJECT_ID)) {
         WOLFSSL_MSG("Bad ASN1 Object");
         return WOLFSSL_FAILURE;
     }
+    idx++; /* skip object id */
 
     if (GetLength((const byte*)sigalg->algorithm->obj, &idx, &length,
                   sigalg->algorithm->objSz) < 0 || length < 0) {
@@ -6262,7 +6264,7 @@ int wolfSSL_X509_signature_print(WOLFSSL_BIO *bp,
     for (i = 0; i < length; ++i) {
         char hex_digits[4];
 #ifdef XSNPRINTF
-        XSNPRINTF(hex_digits, sizeof hex_digits, "%c%02X", i>0 ? ':' : ' ',
+        XSNPRINTF(hex_digits, sizeof(hex_digits), "%c%02X", i>0 ? ':' : ' ',
                   (unsigned int)sigalg->algorithm->obj[idx+i]);
 #else
         XSPRINTF(hex_digits, "%c%02X", i>0 ? ':' : ' ',

--- a/wolfcrypt/src/siphash.c
+++ b/wolfcrypt/src/siphash.c
@@ -886,19 +886,19 @@ int wc_SipHash(const unsigned char* key, const unsigned char* in, word32 inSz,
         switch (inSz) {
             case 7:
                 b |= (word64)in[6] << 48;
-                /* fall-through */
+                FALL_THROUGH;
             case 6:
                 b |= (word64)in[5] << 40;
-                /* fall-through */
+                FALL_THROUGH;
             case 5:
                 b |= (word64)in[4] << 32;
-                /* fall-through */
+                FALL_THROUGH;
             case 4:
                 b |= (word64)GET_U32(in);
                 break;
             case 3:
                 b |= (word64)in[2] << 16;
-                /* fall-through */
+                FALL_THROUGH;
             case 2:
                 b |= (word64)GET_U16(in);
                 break;


### PR DESCRIPTION
Fixes for `-Wimplicit-fallthrough` and gunk in output from unit.test.

Tested with `wolfssl-multi-test.sh ... super-quick-check`.
