### PR TITLE
drafted pathlen for cert struct

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -47073,8 +47073,7 @@ static void test_wc_ParseCert(void)
 
 static void test_MakeCertWithPathLen(void)
 {
-#if defined(WOLFSSL_CERT_REQ) && defined(WOLFSSL_CERT_GEN) && \
-    defined(WOLFSSL_KEY_GEN) && defined(HAVE_ECC)
+#if defined(WOLFSSL_CERT_REQ) && defined(WOLFSSL_CERT_GEN) && defined(HAVE_ECC)
     const byte expectedPathLen = 7;
     Cert cert;
     DecodedCert decodedCert;
@@ -47090,13 +47089,13 @@ static void test_MakeCertWithPathLen(void)
     AssertIntEQ(wc_ecc_make_key(&rng, 32, &key), 0);
     AssertIntEQ(wc_InitCert(&cert), 0);
 
-    (void)strncpy(cert.subject.country, "US", CTC_NAME_SIZE);
-    (void)strncpy(cert.subject.state, "state", CTC_NAME_SIZE);
-    (void)strncpy(cert.subject.locality, "Bozeman", CTC_NAME_SIZE);
-    (void)strncpy(cert.subject.org, "yourOrgNameHere", CTC_NAME_SIZE);
-    (void)strncpy(cert.subject.unit, "yourUnitNameHere", CTC_NAME_SIZE);
-    (void)strncpy(cert.subject.commonName, "www.yourDomain.com", CTC_NAME_SIZE);
-    (void)strncpy(cert.subject.email, "yourEmail@yourDomain.com", CTC_NAME_SIZE);
+    (void)XSTRNCPY(cert.subject.country, "US", CTC_NAME_SIZE);
+    (void)XSTRNCPY(cert.subject.state, "state", CTC_NAME_SIZE);
+    (void)XSTRNCPY(cert.subject.locality, "Bozeman", CTC_NAME_SIZE);
+    (void)XSTRNCPY(cert.subject.org, "yourOrgNameHere", CTC_NAME_SIZE);
+    (void)XSTRNCPY(cert.subject.unit, "yourUnitNameHere", CTC_NAME_SIZE);
+    (void)XSTRNCPY(cert.subject.commonName, "www.yourDomain.com", CTC_NAME_SIZE);
+    (void)XSTRNCPY(cert.subject.email, "yourEmail@yourDomain.com", CTC_NAME_SIZE);
 
     cert.selfSigned = 1;
     cert.isCA       = 1;

--- a/tests/api.c
+++ b/tests/api.c
@@ -47071,6 +47071,59 @@ static void test_wc_ParseCert(void)
 #endif
 }
 
+static void test_MakeCertWithPathLen(void)
+{
+#if defined(WOLFSSL_CERT_REQ) && defined(WOLFSSL_CERT_GEN) && \
+    defined(WOLFSSL_KEY_GEN) && defined(HAVE_ECC)
+    const byte expectedPathLen = 7;
+    Cert cert;
+    DecodedCert decodedCert;
+    byte der[FOURK_BUF];
+    int derSize = 0;
+    WC_RNG rng;
+    ecc_key key;
+
+    printf(testingFmt, "test_MakeCertWithPathLen");
+
+    AssertIntEQ(wc_InitRng(&rng), 0);
+    AssertIntEQ(wc_ecc_init(&key), 0);
+    AssertIntEQ(wc_ecc_make_key(&rng, 32, &key), 0);
+    AssertIntEQ(wc_InitCert(&cert), 0);
+
+    (void)strncpy(cert.subject.country, "US", CTC_NAME_SIZE);
+    (void)strncpy(cert.subject.state, "state", CTC_NAME_SIZE);
+    (void)strncpy(cert.subject.locality, "Bozeman", CTC_NAME_SIZE);
+    (void)strncpy(cert.subject.org, "yourOrgNameHere", CTC_NAME_SIZE);
+    (void)strncpy(cert.subject.unit, "yourUnitNameHere", CTC_NAME_SIZE);
+    (void)strncpy(cert.subject.commonName, "www.yourDomain.com", CTC_NAME_SIZE);
+    (void)strncpy(cert.subject.email, "yourEmail@yourDomain.com", CTC_NAME_SIZE);
+
+    cert.selfSigned = 1;
+    cert.isCA       = 1;
+    cert.pathLen    = expectedPathLen;
+    cert.sigType    = CTC_SHA256wECDSA;
+
+#ifdef WOLFSSL_CERT_EXT
+    cert.keyUsage |= KEYUSE_KEY_CERT_SIGN;
+#endif
+
+    AssertIntGE(wc_MakeCert(&cert, der, FOURK_BUF, NULL, &key, &rng), 0);
+    derSize = wc_SignCert(cert.bodySz, cert.sigType, der, FOURK_BUF, NULL,
+                          &key, &rng);
+    AssertIntGE(derSize, 0);
+
+    wc_InitDecodedCert(&decodedCert, der, derSize, NULL);
+    AssertIntEQ(wc_ParseCert(&decodedCert, CERT_TYPE, NO_VERIFY, NULL), 0);
+    AssertIntEQ(decodedCert.pathLength, expectedPathLen);
+
+    wc_FreeDecodedCert(&decodedCert);
+    AssertIntEQ(wc_ecc_free(&key), 0);
+    AssertIntEQ(wc_FreeRng(&rng), 0);
+
+    printf(resultFmt, passed);
+#endif
+}
+
 /*----------------------------------------------------------------------------*
  | wolfCrypt ECC
  *----------------------------------------------------------------------------*/
@@ -56063,6 +56116,7 @@ void ApiTest(void)
     test_wc_SetSubject();
     test_CheckCertSignature();
     test_wc_ParseCert();
+    test_MakeCertWithPathLen();
 
     /* wolfCrypt ECC tests */
     test_wc_ecc_get_curve_size_from_name();

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -22751,10 +22751,10 @@ static int SetExtensionsHeader(byte* out, word32 outSz, int extSz)
 
 /* encode CA basic constraints true with path length
  * return total bytes written */
-static int SetCaWithPathLen(byte* out, word32 outSz, char pathLen)
+static int SetCaWithPathLen(byte* out, word32 outSz, byte pathLen)
 {
     /* ASN1->DER sequence for Basic Constraints True and path length */
-    byte caPathLenBasicConstASN1[] = {
+    const byte caPathLenBasicConstASN1[] = {
         0x30, 0x0F, 0x06, 0x03, 0x55, 0x1D, 0x13, 0x04,
         0x08, 0x30, 0x06, 0x01, 0x01, 0xFF, 0x02, 0x01,
         0x00
@@ -22766,9 +22766,9 @@ static int SetCaWithPathLen(byte* out, word32 outSz, char pathLen)
     if (outSz < sizeof(caPathLenBasicConstASN1))
         return BUFFER_E;
 
-    caPathLenBasicConstASN1[16U] = pathLen;
-
     XMEMCPY(out, caPathLenBasicConstASN1, sizeof(caPathLenBasicConstASN1));
+
+    out[sizeof(caPathLenBasicConstASN1)-1] = pathLen;
 
     return (int)sizeof(caPathLenBasicConstASN1);
 }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -24946,7 +24946,7 @@ static int EncodeCert(Cert* cert, DerCert* der, RsaKey* rsaKey, ecc_key* eccKey,
     der->extensionsSz = 0;
 
     /* RFC 5280 : 4.2.1.9. Basic Constraints
-     * The pathLenConstraint field is meaningful only if the cA boolean is
+     * The pathLenConstraint field is meaningful only if the CA boolean is
      * asserted and the key usage extension, if present, asserts the
      * keyCertSign bit */
     /* Set CA and path length */
@@ -26133,7 +26133,7 @@ static int EncodeCertReq(Cert* cert, DerCert* der, RsaKey* rsaKey,
     der->extensionsSz = 0;
 
     /* RFC 5280 : 4.2.1.9. Basic Constraints
-     * The pathLenConstraint field is meaningful only if the cA boolean is
+     * The pathLenConstraint field is meaningful only if the CA boolean is
      * asserted and the key usage extension, if present, asserts the
      * keyCertSign bit */
     /* Set CA and path length */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -26137,8 +26137,11 @@ static int EncodeCertReq(Cert* cert, DerCert* der, RsaKey* rsaKey,
      * asserted and the key usage extension, if present, asserts the
      * keyCertSign bit */
     /* Set CA and path length */
-    if ((cert->isCA) && (cert->pathLen) &&
-        ((cert->keyUsage & KEYUSE_KEY_CERT_SIGN) || (!cert->keyUsage))) {
+    if ((cert->isCA) && (cert->pathLen)
+#ifdef WOLFSSL_CERT_EXT
+        && ((cert->keyUsage & KEYUSE_KEY_CERT_SIGN) || (!cert->keyUsage))
+#endif
+        ) {
         der->caSz = SetCaWithPathLen(der->ca, sizeof(der->ca), cert->pathLen);
         if (der->caSz <= 0)
             return CA_TRUE_E;

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -384,6 +384,8 @@ typedef struct Cert {
     int      selfSigned;                /* self signed flag */
     CertName subject;                   /* subject info */
     int      isCA;                      /* is this going to be a CA */
+    char     pathLen;                   /* max depth of valid certification
+                                         * paths that include this cert */
     /* internal use only */
     int      bodySz;                    /* pre sign total size */
     int      keyType;                   /* public key type of subject */

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -384,7 +384,7 @@ typedef struct Cert {
     int      selfSigned;                /* self signed flag */
     CertName subject;                   /* subject info */
     int      isCA;                      /* is this going to be a CA */
-    char     pathLen;                   /* max depth of valid certification
+    byte     pathLen;                   /* max depth of valid certification
                                          * paths that include this cert */
     /* internal use only */
     int      bodySz;                    /* pre sign total size */


### PR DESCRIPTION
# Description

Support creating certificates and CSRs with pathLenConstraint as defined in https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.9?

Fixes ZD14418

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
