### PR TITLE
TLS memusage: reduce usage

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -13909,8 +13909,8 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
 
                     sigCtx->key.rsa = (RsaKey*)XMALLOC(sizeof(RsaKey),
                                                 sigCtx->heap, DYNAMIC_TYPE_RSA);
-                    sigCtx->sigCpy = (byte*)XMALLOC(MAX_ENCODED_SIG_SZ,
-                                         sigCtx->heap, DYNAMIC_TYPE_SIGNATURE);
+                    sigCtx->sigCpy = (byte*)XMALLOC(sigSz, sigCtx->heap,
+                                                        DYNAMIC_TYPE_SIGNATURE);
                     if (sigCtx->key.rsa == NULL || sigCtx->sigCpy == NULL) {
                         ERROR_OUT(MEMORY_E, exit_cs);
                     }

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -921,17 +921,21 @@ static int RsaMGF1(enum wc_HashType hType, byte* seed, word32 seedSz,
 #ifdef WOLFSSL_SMALL_STACK_CACHE
     hash = (wc_HashAlg*)XMALLOC(sizeof(*hash), heap, DYNAMIC_TYPE_DIGEST);
     if (hash == NULL) {
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
         if (tmpF) {
             XFREE(tmp, heap, DYNAMIC_TYPE_RSA_BUFFER);
         }
+    #endif
         return MEMORY_E;
     }
     ret = wc_HashInit_ex(hash, hType, heap, INVALID_DEVID);
     if (ret != 0) {
         XFREE(hash, heap, DYNAMIC_TYPE_DIGEST);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
         if (tmpF) {
             XFREE(tmp, heap, DYNAMIC_TYPE_RSA_BUFFER);
         }
+    #endif
         return ret;
     }
 #endif


### PR DESCRIPTION
# Description

Reduce the amount allocated to reduce maximum overall dynamic memory
usage.
Rework ServerKeyExchange by extracting the handling of the signed data.

# Testing

Memory usage testing, regression tested locally.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
