### PR TITLE
FIPS in core hash using SHA2-256 and SHA2-384

### DIFF
--- a/fips-check.sh
+++ b/fips-check.sh
@@ -240,7 +240,7 @@ linuxv5)
   ;;
 linuxv5-ready|fips-ready|fips-v5-ready)
   FIPS_REPO="git@github.com:wolfSSL/fips.git"
-  FIPS_VERSION="WCv5.0-RC12"
+  FIPS_VERSION="master"
   CRYPT_INC_PATH=wolfssl/wolfcrypt
   CRYPT_SRC_PATH=wolfcrypt/src
   FIPS_SRCS=( fips.c fips_test.c wolfcrypt_first.c wolfcrypt_last.c )

--- a/wolfcrypt/src/port/cypress/psoc6_crypto.c
+++ b/wolfcrypt/src/port/cypress/psoc6_crypto.c
@@ -32,7 +32,7 @@
 #endif
 
 #if defined(WOLFSSL_PSOC6_CRYPTO)
-#ifdef WOLFSSL_SP_MATH
+#if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
     struct sp_int;
     #define MATH_INT_T struct sp_int
 #elif defined(USE_FAST_MATH)

--- a/wolfcrypt/src/port/nxp/se050_port.c
+++ b/wolfcrypt/src/port/nxp/se050_port.c
@@ -47,7 +47,7 @@
     #include "ex_sss_boot.h"
 #endif
 
-#ifdef WOLFSSL_SP_MATH
+#if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
     struct sp_int;
     #define MATH_INT_T struct sp_int
 #elif defined(USE_FAST_MATH)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -21002,7 +21002,7 @@ const char resMasterLabel[] = "res master";
 const char derivedLabel[] = "derived";
 
 
-int tls13_kdf_test(void)
+WOLFSSL_TEST_SUBROUTINE int tls13_kdf_test(void)
 {
     int ret = 0;
     word32 i;

--- a/wolfssl/wolfcrypt/fips_test.h
+++ b/wolfssl/wolfcrypt/fips_test.h
@@ -31,6 +31,25 @@
     extern "C" {
 #endif
 
+/* Added for FIPS v5.3 or later */
+#if defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)
+    /* Determine FIPS in core hash type and size */
+    #ifndef NO_SHA256
+        #define FIPS_IN_CORE_DIGEST_SIZE 32
+        #define FIPS_IN_CORE_HASH_TYPE   WC_SHA256
+        #define FIPS_IN_CORE_KEY_SZ      32
+        #define FIPS_IN_CORE_VERIFY_SZ   FIPS_IN_CORE_KEY_SZ
+    #elif defined(WOLFSSL_SHA384)
+        #define FIPS_IN_CORE_DIGEST_SIZE 48
+        #define FIPS_IN_CORE_HASH_TYPE   WC_SHA384
+        #define FIPS_IN_CORE_KEY_SZ      48
+        #define FIPS_IN_CORE_VERIFY_SZ   FIPS_IN_CORE_KEY_SZ
+    #else
+        #error No FIPS hash (SHA2-256 or SHA2-384)
+    #endif
+#endif /* FIPS v5.3 or later */
+
+
 enum FipsCastId {
     FIPS_CAST_AES_CBC,
     FIPS_CAST_AES_GCM,

--- a/wolfssl/wolfcrypt/port/nxp/se050_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/se050_port.h
@@ -118,7 +118,7 @@ WOLFSSL_LOCAL void se050_aes_free(struct Aes* aes);
 
 struct ecc_key;
 struct WC_RNG;
-#ifdef WOLFSSL_SP_MATH
+#if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
     struct sp_int;
     #define MATH_INT_T struct sp_int
 #elif defined(USE_FAST_MATH)

--- a/wolfssl/wolfcrypt/port/st/stm32.h
+++ b/wolfssl/wolfcrypt/port/st/stm32.h
@@ -152,7 +152,7 @@ int  wc_Stm32_Hash_Final(STM32_HASH_Context* stmCtx, word32 algo,
 #endif /* STM32_CRYPTO */
 
 #if defined(WOLFSSL_STM32_PKA) && defined(HAVE_ECC)
-#ifdef WOLFSSL_SP_MATH
+#if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
     struct sp_int;
     #define MATH_INT_T struct sp_int
 #elif defined(USE_FAST_MATH)


### PR DESCRIPTION
# Description

* Update to FIPS v5-ready will use latest master.
* Support for FIPS in core hash using SHA2-256 and SHA2-384 in fips_test.h.
* Fixes for `MATH_INT_T`.
* Fix `error: ‘tls13_kdf_test’ declared ‘static’ but never defined`.

# Testing

`wolfssl-multi-test.sh fips-140-3-dev-defaults`
`FIPS_DEV_BRANCH=local:fips_v5dev ../testing/git-hooks/wolfssl-multi-test.sh .*fips.*`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
