### PR TITLE
Fix typos in evp.c

### DIFF
--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -1593,7 +1593,7 @@ WOLFSSL_EVP_PKEY_CTX *wolfSSL_EVP_PKEY_CTX_new_id(int id, WOLFSSL_ENGINE *e)
         ctx = wolfSSL_EVP_PKEY_CTX_new(pkey, e);
         /* wolfSSL_EVP_PKEY_CTX_new calls wolfSSL_EVP_PKEY_up_ref so we need
          * to always call wolfSSL_EVP_PKEY_free (either to free it if an
-         * error occured in the previous function or to decrease the reference
+         * error occurred in the previous function or to decrease the reference
          * count so that pkey is actually free'd when wolfSSL_EVP_PKEY_CTX_free
          * is called) */
         wolfSSL_EVP_PKEY_free(pkey);
@@ -5686,7 +5686,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
 
 #if defined(HAVE_AES_CBC) || defined(WOLFSSL_AES_COUNTER) || \
     defined(HAVE_AES_ECB) || defined(WOLFSSL_AES_CFB) || \
-    defined(WOLFSSSL_AES_OFB)
+    defined(WOLFSSL_AES_OFB)
     #define AES_SET_KEY
 #endif
 
@@ -8817,7 +8817,7 @@ static int Indent(WOLFSSL_BIO* out, int indents)
  * four spaces, then hex coded 15 byte data with separator ":" follow.
  * Each line looks like:
  * "    00:e6:ab: --- 9f:ef:"
- * Parmeters:
+ * Parameters:
  * out     bio to output dump data
  * input   buffer holding data to dump
  * inlen   input data size
@@ -9923,7 +9923,7 @@ struct WOLFSSL_EVP_ENCODE_CTX* wolfSSL_EVP_ENCODE_CTX_new(void)
     }
     return NULL;
 }
-/*  wolfSSL_EVP_ENCODE_CTX_free frees specified WOLFSSL_EVP_ENCODE_CTX struc.
+/*  wolfSSL_EVP_ENCODE_CTX_free frees specified WOLFSSL_EVP_ENCODE_CTX struct.
  */
 void wolfSSL_EVP_ENCODE_CTX_free(WOLFSSL_EVP_ENCODE_CTX* ctx)
 {


### PR DESCRIPTION
# Description

Random typo fixes from an IDE spellchecker while looking through this file.

All of these are harmless comment fixes _except_ the `WOLFSSL_AES_OFB` fix which seems like it could cause an error in compilation. I wasn't going to submit a PR until I noticed that one, it seemed worth putting up a friendly PR.

# Testing

Tested via recompile after running the following `./configure`:
```
./configure --disable-aescbc --disable-aesctr --disable-aescfb --enable-aesofb
```
however this probably doesn't disable `HAVE_AES_ECB`, which doesn't have its own enable/disable config.  It's likely that the typo being fixed isn't really reachable, but it still seems worth fixing.

The PR fixes are hopefully self-evident enough to stand alone.

# Checklist

 - [n/a] added tests
 - [n/a] updated/added doxygen
 - [n/a] updated appropriate READMEs
 - [n/a] Updated manual and documentation
