### PR TITLE
fix: examples/server: dtls mode checking

### DIFF
--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -2342,7 +2342,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
 
     if (minVersion != SERVER_INVALID_VERSION) {
 #ifdef WOLFSSL_DTLS13
-        if (wolfSSL_dtls(ssl)) {
+        if (doDTLS) {
             switch (minVersion) {
             case 4:
                 minVersion = WOLFSSL_DTLSV1_3;


### PR DESCRIPTION

# Description
This fixes using ssl to check if we are using dtls or not, when ssl is not yet
valid.

Fix: 060dfe1a693940fff31616570166be7f53b49ad8

# Testing
`./configure --enable-dtls --enable-dtls13 && make check`

