### PR TITLE
Use the correct mutex type for embOS

### DIFF
--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -2270,7 +2270,7 @@ int wolfSSL_CryptHwMutexUnLock(void)
 
     int wc_LockMutex(wolfSSL_Mutex* m)
     {
-        OS_MUTEX_Lock((OS_MUTEX*) m);
+        OS_MUTEX_LockBlocked((OS_MUTEX*) m);
         return 0;
     }
 


### PR DESCRIPTION
OS_MUTEX_Lock() is actually a non-blocking mutex lock, for
wc_LockMutex() we need a blocking mutex. Switch to this.

# Testing

Mutex locking for multiple tasks accessing an SE050 simultaneously using wolfCrypt.