### PR TITLE
Fix typos and bad macro names

### DIFF
--- a/IDE/Espressif/ESP-IDF/setup.sh
+++ b/IDE/Espressif/ESP-IDF/setup.sh
@@ -23,10 +23,10 @@ WOLFSSLLIB_TRG_DIR=${IDF_PATH}/components/wolfssl
 WOLFSSLEXP_TRG_DIR=${IDF_PATH}/examples/protocols
 
 if [ "$1" == "--verbose" ]; then
-  WOLFSSSL_SETUP_VERBOSE=true
+  WOLFSSL_SETUP_VERBOSE=true
 fi
 
-if [ "${WOLFSSSL_SETUP_VERBOSE}" == "true" ]; then
+if [ "${WOLFSSL_SETUP_VERBOSE}" == "true" ]; then
   echo Verbose mode on!
   echo BASEDIR=${BASEDIR}
   echo SCRIPTDIR=${SCRIPTDIR}
@@ -47,7 +47,7 @@ pushd $IDF_PATH > /dev/null
 echo "Copy files into $IDF_PATH"
 
 # Remove/Create directories
-if [ "${WOLFSSSL_SETUP_VERBOSE}" == "true" ]; then
+if [ "${WOLFSSL_SETUP_VERBOSE}" == "true" ]; then
   echo "Remove/Create directories..."
 fi
 
@@ -67,7 +67,7 @@ pushd ${BASEDIR} > /dev/null # WOLFSSL TOP DIR
 
 # copying ... files in src/ into $WOLFSSLLIB_TRG_DIR/src
 
-if [ "${WOLFSSSL_SETUP_VERBOSE}" == "true" ]; then
+if [ "${WOLFSSL_SETUP_VERBOSE}" == "true" ]; then
   echo "Copying ... files in src/ into \$WOLFSSLLIB_TRG_DIR/srcs ..."
 fi
 
@@ -86,7 +86,7 @@ ${CPDCMD} -r ./wolfssl/openssl/*.h ${WOLFSSLLIB_TRG_DIR}/wolfssl/openssl/
 ${CPDCMD} -r ./wolfssl/wolfcrypt ${WOLFSSLLIB_TRG_DIR}/wolfssl/
 
 # user_settings.h
-if [ "${WOLFSSSL_SETUP_VERBOSE}" == "true" ]; then
+if [ "${WOLFSSL_SETUP_VERBOSE}" == "true" ]; then
   echo "Copying user_settings.h to ${WOLFSSLLIB_TRG_DIR}/include/"
 fi
 
@@ -104,7 +104,7 @@ ${CPDCMD} ./libs/component.mk ${WOLFSSLLIB_TRG_DIR}/
 pushd ${BASEDIR} > /dev/null # WOLFSSL TOP DIR
 
 # Benchmark program
-if [ "${WOLFSSSL_SETUP_VERBOSE}" == "true" ]; then
+if [ "${WOLFSSL_SETUP_VERBOSE}" == "true" ]; then
   echo ""
 fi
 ${RMDCMD} ${WOLFSSLEXP_TRG_DIR}/wolfssl_benchmark/
@@ -119,7 +119,7 @@ ${CPDCMD} -r ${WOLFSSL_ESPIDFDIR}/examples/wolfssl_benchmark/* ${WOLFSSLEXP_TRG_
 ${CPDCMD} -r ${WOLFSSL_ESPIDFDIR}/examples/wolfssl_benchmark/main/* ${WOLFSSLEXP_TRG_DIR}/wolfssl_benchmark/main/
 
 # Crypt Test program
-if [ "${WOLFSSSL_SETUP_VERBOSE}" == "true" ]; then
+if [ "${WOLFSSL_SETUP_VERBOSE}" == "true" ]; then
   echo "Copying wolfssl_test to ${WOLFSSLEXP_TRG_DIR}/wolfssl_test/main/"
 fi
 ${RMDCMD} ${WOLFSSLEXP_TRG_DIR}/wolfssl_test/
@@ -131,7 +131,7 @@ ${CPDCMD} -r ${WOLFSSL_ESPIDFDIR}/examples/wolfssl_test/* ${WOLFSSLEXP_TRG_DIR}/
 ${CPDCMD} -r ${WOLFSSL_ESPIDFDIR}/examples/wolfssl_test/main/* ${WOLFSSLEXP_TRG_DIR}/wolfssl_test/main/
 
 # TLS Client program
-if [ "${WOLFSSSL_SETUP_VERBOSE}" == "true" ]; then
+if [ "${WOLFSSL_SETUP_VERBOSE}" == "true" ]; then
   echo "Copying TLS Client program to ${WOLFSSLEXP_TRG_DIR}/wolfssl_client/..."
 fi
 ${RMDCMD} ${WOLFSSLEXP_TRG_DIR}/wolfssl_client/
@@ -144,7 +144,7 @@ ${CPDCMD} -r ${WOLFSSL_ESPIDFDIR}/examples/wolfssl_client/main/* ${WOLFSSLEXP_TR
 ${CPDCMD} -r ${WOLFSSL_ESPIDFDIR}/examples/wolfssl_client/main/include/* ${WOLFSSLEXP_TRG_DIR}/wolfssl_client/main/include/
 
 # TLS Server program
-if [ "${WOLFSSSL_SETUP_VERBOSE}" == "true" ]; then
+if [ "${WOLFSSL_SETUP_VERBOSE}" == "true" ]; then
   echo "Copying TLS Server program to ${WOLFSSLEXP_TRG_DIR}/wolfssl_server/..."
 fi
 ${RMDCMD} ${WOLFSSLEXP_TRG_DIR}/wolfssl_server/
@@ -158,7 +158,7 @@ ${CPDCMD} -r ${WOLFSSL_ESPIDFDIR}/examples/wolfssl_server/main/include/* ${WOLFS
 
 popd > /dev/null # 
 
-if [ "${WOLFSSSL_SETUP_VERBOSE}" == "true" ]; then
+if [ "${WOLFSSL_SETUP_VERBOSE}" == "true" ]; then
   echo "Copy complete!"
 fi
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -60,7 +60,7 @@
 #endif
 #endif
 
-#if defined(WOLFSSSL_RENESAS_TSIP_TLS)
+#if defined(WOLFSSL_RENESAS_TSIP_TLS)
     #include <wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h>
 #endif
 

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -1593,7 +1593,7 @@ WOLFSSL_EVP_PKEY_CTX *wolfSSL_EVP_PKEY_CTX_new_id(int id, WOLFSSL_ENGINE *e)
         ctx = wolfSSL_EVP_PKEY_CTX_new(pkey, e);
         /* wolfSSL_EVP_PKEY_CTX_new calls wolfSSL_EVP_PKEY_up_ref so we need
          * to always call wolfSSL_EVP_PKEY_free (either to free it if an
-         * error occured in the previous function or to decrease the reference
+         * error occurred in the previous function or to decrease the reference
          * count so that pkey is actually free'd when wolfSSL_EVP_PKEY_CTX_free
          * is called) */
         wolfSSL_EVP_PKEY_free(pkey);
@@ -5686,7 +5686,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
 
 #if defined(HAVE_AES_CBC) || defined(WOLFSSL_AES_COUNTER) || \
     defined(HAVE_AES_ECB) || defined(WOLFSSL_AES_CFB) || \
-    defined(WOLFSSSL_AES_OFB)
+    defined(WOLFSSL_AES_OFB)
     #define AES_SET_KEY
 #endif
 
@@ -8817,7 +8817,7 @@ static int Indent(WOLFSSL_BIO* out, int indents)
  * four spaces, then hex coded 15 byte data with separator ":" follow.
  * Each line looks like:
  * "    00:e6:ab: --- 9f:ef:"
- * Parmeters:
+ * Parameters:
  * out     bio to output dump data
  * input   buffer holding data to dump
  * inlen   input data size
@@ -9923,7 +9923,7 @@ struct WOLFSSL_EVP_ENCODE_CTX* wolfSSL_EVP_ENCODE_CTX_new(void)
     }
     return NULL;
 }
-/*  wolfSSL_EVP_ENCODE_CTX_free frees specified WOLFSSL_EVP_ENCODE_CTX struc.
+/*  wolfSSL_EVP_ENCODE_CTX_free frees specified WOLFSSL_EVP_ENCODE_CTX struct.
  */
 void wolfSSL_EVP_ENCODE_CTX_free(WOLFSSL_EVP_ENCODE_CTX* ctx)
 {


### PR DESCRIPTION
# Description

"WOLFSSSL" (three S's) used in several places. Also fix spelling issues in evp.c. Thanks @syncsynchalt!

Replaces #5314 

