### PR TITLE
Added multi thread use case for Renesas TSIP Rx72N

### DIFF
--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/include.am
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/include.am
@@ -15,3 +15,4 @@ EXTRA_DIST+= IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/key_data.h
 EXTRA_DIST+= IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_demo.c
 EXTRA_DIST+= IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_demo.h
 EXTRA_DIST+= IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/user_settings.h
+EXTRA_DIST+= IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_tsip_unit_test.c

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_demo.c
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_demo.c
@@ -55,10 +55,13 @@
     #include <wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h>
 
     extern const st_key_block_data_t g_key_block_data;
-    user_PKCbInfo                    guser_PKCbInfo;
     uint32_t                         g_encrypted_root_public_key[140];
-    static   TsipUserCtx             userContext;
-
+   #if defined(TLS_MULTITHREAD_TEST)
+    static TsipUserCtx userContext_taskA;
+    static TsipUserCtx userContext_taskB;
+   #else
+    static TsipUserCtx userContext;
+   #endif
 #endif /* WOLFSSL_RENESAS_TSIP_TLS */
 
     static WOLFSSL_CTX* client_ctx;
@@ -69,9 +72,60 @@
 #define YEAR 2022
 #define MON  3
 #define FREQ 10000 /* Hz */
+#define MAX_MSGSTR  80
 
 static long         tick;
 static int          tmTick;
+
+
+#if defined(TSIP_CRYPT_UNIT_TEST)
+ int tsip_crypt_test();
+ int tsip_crypt_sha_multitest();
+ int tsip_crypt_AesCbc_multitest();
+ int tsip_crypt_AesGcm_multitest();
+ int tsip_crypt_Sha_AesCbcGcm_multitest();
+#endif
+
+#if defined(TLS_MULTITHREAD_TEST)
+xSemaphoreHandle exit_semaph;
+static xSemaphoreHandle Mutex;
+#endif
+
+static int msg(const char* pname, int l,
+                         const char * sFormat, ...)
+{
+    int ret = 0;
+    char buf[MAX_MSGSTR] = {0};
+
+    va_list ParamList;
+
+#if defined(TLS_MULTITHREAD_TEST)
+    xSemaphoreTake(Mutex, portMAX_DELAY);
+#endif
+    va_start(ParamList, sFormat);
+
+    printf("[%s][%02d] ", pname, l);
+    ret = vsnprintf(buf, sizeof(buf), sFormat, ParamList);
+    printf(buf);
+
+    va_end(ParamList);
+
+#if defined(TLS_MULTITHREAD_TEST)
+    xSemaphoreGive(Mutex);
+#endif
+
+    return ret;
+}
+
+
+#if defined(TLS_MULTITHREAD_TEST)
+static void my_Logging_cb(const int logLevel, const char *const logMessage)
+{
+    (void)logLevel;
+    msg("custom-log", logLevel, "%s\n", logMessage);
+}
+#endif
+
 /* time
  * returns seconds from EPOCH
  */
@@ -97,10 +151,6 @@ double current_time(int reset)
       if(reset) tick = 0 ;
       return ((double)tick/FREQ) ;
 }
-
-
-
-
 
 /* --------------------------------------------------------*/
 /*  Benchmark_demo                                         */
@@ -141,7 +191,7 @@ static void CryptTest_demo(void)
 /*  Tls_client_demo                                        */
 /* --------------------------------------------------------*/
 #if defined(TLS_CLIENT)
-static void Tls_client_init(const char* cipherlist)
+static void Tls_client_init()
 {
 
     #ifndef NO_FILESYSTEM
@@ -164,10 +214,6 @@ static void Tls_client_init(const char* cipherlist)
     client_ctx = NULL;
 
     wolfSSL_Init();
-
-    #ifdef DEBUG_WOLFSSL
-        wolfSSL_Debugging_ON();
-    #endif
 
     /* Create and initialize WOLFSSL_CTX */
     if ((client_ctx = 
@@ -254,33 +300,32 @@ static void Tls_client_init(const char* cipherlist)
         return;
     }
     #endif
-
-
-    /* use specific cipher */
-    if (cipherlist != NULL && 
-        wolfSSL_CTX_set_cipher_list(client_ctx, cipherlist) != 
-                                                            WOLFSSL_SUCCESS) {
-        wolfSSL_CTX_free(client_ctx); client_ctx = NULL;
-        printf("client can't set cipher list");
-    }
 }
 
-static void Tls_client()
+static void Tls_client(void *pvParam)
 {
     #define BUFF_SIZE 256
     #define ADDR_SIZE 16
     int             ret;
+#if defined(TLS_MULTITHREAD_TEST)
+    BaseType_t xStatus;
+#endif
+    TestInfo* p = (TestInfo*)pvParam;
     WOLFSSL_CTX*    ctx = (WOLFSSL_CTX *)client_ctx;
-    WOLFSSL*        ssl;
+    WOLFSSL*        ssl = NULL;
     Socket_t        socket;
     socklen_t       socksize = sizeof(struct freertos_sockaddr);
     struct freertos_sockaddr    PeerAddr;
     char    addrBuff[ADDR_SIZE] = {0};
-  
-    static const char sendBuff[]= "Hello Server\n" ;    
+    const char* pcName = p->name;
+
+    static const char sendBuff[]= "Hello Server\n" ;
     char    rcvBuff[BUFF_SIZE] = {0};
 
-
+    if (!p) {
+        printf("Unexpected error. Thread parameter is null\n");
+        return;
+    }
     /* create TCP socket */
 
     socket = FreeRTOS_socket(FREERTOS_AF_INET,
@@ -294,78 +339,126 @@ static void Tls_client()
     /* attempt to connect TLS server */
 
     PeerAddr.sin_addr = FreeRTOS_inet_addr(TLSSERVER_IP);
-    PeerAddr.sin_port = FreeRTOS_htons(TLSSERVER_PORT);
+    PeerAddr.sin_port = FreeRTOS_htons(p->port);
 
     ret = FreeRTOS_connect(socket, &PeerAddr, sizeof(PeerAddr));
 
     if (ret != 0) {
-        printf("ERROR FreeRTOS_connect: %d\n",ret);
+        msg(pcName, p->id, "ERROR FreeRTOS_connect: %d\n",ret);
+        ret = -1;
     }
+
+   #if defined(TLS_MULTITHREAD_TEST)
+    msg(pcName, p->id, " Ready to connect.\n");
+    xStatus = xSemaphoreTake(p->xBinarySemaphore, portMAX_DELAY);
+    if (xStatus != pdTRUE) {
+        msg(pcName, p->id, " Error : Failed to xSemaphoreTake\n");
+        goto out;
+    }
+   #endif
 
     /* create WOLFSSL object */
     if (ret == 0) {
         ssl = wolfSSL_new(ctx);
         if (ssl == NULL) {
-            printf("ERROR wolfSSL_new: %d\n", wolfSSL_get_error(ssl, 0));
+            msg(pcName, p->id, "ERROR wolfSSL_new: %d\n", 
+                                        wolfSSL_get_error(ssl, 0));
             ret = -1;
         }
     }
+
     if (ret == 0) {
         #ifdef WOLFSSL_RENESAS_TSIP_TLS
-        tsip_set_callback_ctx(ssl, &userContext);
+         #if !defined(TLS_MULTITHREAD_TEST)
+          memset(&userContext, 0, sizeof(TsipUserCtx));
+          tsip_set_callback_ctx(ssl, &userContext);
+         #else
+          if (p->port - TLSSERVER_PORT == 0) {
+             memset(&userContext_taskA, 0, sizeof(TsipUserCtx));
+             tsip_set_callback_ctx(ssl, (void*)&userContext_taskA);
+          }
+          else {
+             memset(&userContext_taskB, 0, sizeof(TsipUserCtx));
+             tsip_set_callback_ctx(ssl, (void*)&userContext_taskB);
+          }
+         #endif
         #endif
+    }
+
+    msg(pcName, p->id, "  Cipher : %s\n", p->cipher);
+    /* use specific cipher */
+    if (p->cipher != NULL &&
+        wolfSSL_set_cipher_list(ssl, p->cipher) != WOLFSSL_SUCCESS) {
+        ret = -1;
     }
 
     if (ret == 0) {
         /* associate socket with ssl object */
         if (wolfSSL_set_fd(ssl, (int)socket) != WOLFSSL_SUCCESS) {
-            printf("ERROR wolfSSL_set_fd: %d\n", wolfSSL_get_error(ssl, 0));
+            msg(pcName, p->id, "ERROR wolfSSL_set_fd: %d\n", 
+                                                    wolfSSL_get_error(ssl, 0));
             ret = -1;
         }
     }
-
+#ifdef DEBUG_WOLFSSL
+    wolfSSL_Debugging_ON();
+#endif
     if (ret == 0) {
         if (wolfSSL_connect(ssl) != WOLFSSL_SUCCESS) {
-            printf("ERROR wolfSSL_connect: %d\n", wolfSSL_get_error(ssl, 0));
+            msg(pcName, p->id, "ERROR wolfSSL_connect: %d\n", 
+                                                    wolfSSL_get_error(ssl, 0));
             ret = -1;
         }
     }
-
+#ifdef DEBUG_WOLFSSL
+   wolfSSL_Debugging_OFF();
+#endif
     if (ret == 0) {
         if (wolfSSL_write(ssl, sendBuff, strlen(sendBuff)) != 
                                                             strlen(sendBuff)) {
-            printf("ERROR wolfSSL_write: %d\n", wolfSSL_get_error(ssl, 0));
+            msg(pcName, p->id, "ERROR wolfSSL_write: %d\n", 
+                                                    wolfSSL_get_error(ssl, 0));
             ret = -1;
         }
     }
 
     if (ret == 0) {
         if ((ret=wolfSSL_read(ssl, rcvBuff, BUFF_SIZE -1)) < 0) {
-            printf("ERROR wolfSSL_read: %d\n", wolfSSL_get_error(ssl, 0));
+            msg(pcName, p->id, "ERROR wolfSSL_read: %d\n", 
+                                                    wolfSSL_get_error(ssl, 0));
             ret = -1;
         }
         else {
             rcvBuff[ret] = '\0';
-            printf("Received: %s\n\n", rcvBuff);
+            msg(pcName, p->id, "Received: %s\n\n", rcvBuff);
             ret = 0;
         }
     }
-
     
-    wolfSSL_shutdown(ssl);
-
-    FreeRTOS_shutdown(socket, FREERTOS_SHUT_RDWR);
-    while(FreeRTOS_recv(socket, rcvBuff, BUFF_SIZE -1, 0) >=0) {
-    	vTaskDelay(250);
+out:
+    if (ssl) {
+        wolfSSL_shutdown(ssl);
+        wolfSSL_free(ssl);
+        ssl = NULL;
+        /* reset call backs */
+    #ifdef WOLFSSL_RENESAS_TSIP_TLS
+        tsip_set_callbacks(client_ctx);
+    #endif
     }
 
-    FreeRTOS_closesocket(socket);
+    if (socket) {
+        FreeRTOS_shutdown(socket, FREERTOS_SHUT_RDWR);
+        while (FreeRTOS_recv(socket, rcvBuff, BUFF_SIZE -1, 0) >=0) {
+            vTaskDelay(250);
+        }
+        FreeRTOS_closesocket(socket);
+        socket = NULL;
+    }
 
-
-    wolfSSL_free(ssl);
-    wolfSSL_CTX_free(ctx);
-    wolfSSL_Cleanup();
-
+#ifdef TLS_MULTITHREAD_TEST
+    xSemaphoreGive(exit_semaph);
+    vTaskDelete(NULL);
+#endif
     return;
 }
 
@@ -376,24 +469,23 @@ static void Tls_client_demo(void)
 
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
 
-    #ifdef USE_ECC_CERT
+  #ifdef USE_ECC_CERT
     const char* cipherlist[] = {
     #if defined(WOLFSSL_TLS13)
         "TLS13-AES128-GCM-SHA256",
         "TLS13-AES128-CCM-SHA256",
     #endif
+    	"ECDHE-ECDSA-AES128-SHA256",
         "ECDHE-ECDSA-AES128-GCM-SHA256",
-        "ECDHE-ECDSA-AES128-SHA256"
     };
-    int cipherlist_sz;
     #if defined(WOLFSSL_TLS13)
-        cipherlist_sz = 2;
+        #define cipherlist_sz 2
     #else
-        cipherlist_sz = 2;
+        #define cipherlist_sz 2
     #endif
-
-    #else
-    const char* cipherlist[] = {
+    TestInfo info[cipherlist_sz];
+  #else
+        const char* cipherlist[] = {
     #if defined(WOLFSSL_TLS13)
         "TLS13-AES128-GCM-SHA256",
         "TLS13-AES128-CCM-SHA256",
@@ -404,23 +496,29 @@ static void Tls_client_demo(void)
         "AES128-SHA256",
         "AES256-SHA",
         "AES256-SHA256"
-    };
-    int cipherlist_sz;
-    #if defined(WOLFSSL_TLS13)
-        cipherlist_sz = 2;
-    #else
-        cipherlist_sz = 6;
+        };
+        #if defined(WOLFSSL_TLS13)
+            #define cipherlist_sz 2
+        #else
+            #define cipherlist_sz 6
+        #endif
+        TestInfo info[cipherlist_sz];
     #endif
-
-    #endif
-
 #else
     const char* cipherlist[] = { NULL };
-    const int cipherlist_sz = 0;
-
+    #define cipherlist_sz 1
+    TestInfo info[cipherlist_sz];
 #endif
 
     int i = 0;
+#ifdef TLS_MULTITHREAD_TEST
+    int j = 0;
+    BaseType_t xReturned;
+    BaseType_t xHigherPriorityTaskWoken;
+    xHigherPriorityTaskWoken = pdFALSE;
+
+    Mutex = xSemaphoreCreateMutex();
+#endif
 
     printf("/*------------------------------------------------*/\n");
     printf("    TLS_Client demo\n");
@@ -455,15 +553,81 @@ static void Tls_client_demo(void)
 
 #endif /* WOLFSSL_RENESAS_TSIP_TLS && (WOLFSSL_RENESAS_TSIP_VER >=109) */
 
+    Tls_client_init();
+
+#ifdef TLS_MULTITHREAD_TEST
+
+    exit_semaph = xSemaphoreCreateCounting(cipherlist_sz, 0);
+
+#ifdef DEBUG_WOLFSSL
+    wolfSSL_SetLoggingCb(my_Logging_cb);
+#endif
+
     do {
-        if(cipherlist_sz > 0 ) printf("cipher : %s\n", cipherlist[i]);
+        for (j = i; j < (i+2); j++) {
+            info[j].id = j;
+            info[j].port = TLSSERVER_PORT + (j%2);
+            info[j].cipher = cipherlist[j];
+            info[j].ctx = client_ctx;
+            info[j].xBinarySemaphore = xSemaphoreCreateBinary();
+            info[j].log_f = my_Logging_cb;
 
-        Tls_client_init(cipherlist[i]);
+            memset(info[j].name, 0, sizeof(info[j].name));
+            sprintf(info[j].name, "clt_thd_%s", ((j%2) == 0) ?
+                                                            "taskA" : "taskB");
 
-        Tls_client();
+            printf(" %s connecting to %d port\n", info[j].name, info[j].port);
+
+            xReturned = xTaskCreate(Tls_client, info[j].name, 
+                                        THREAD_STACK_SIZE, &info[j], 3, NULL);
+            if (xReturned != pdPASS) {
+                printf("Failed to create task\n");
+            }
+        }
+
+        for (j = i; j < (i+2); j++) {
+            xSemaphoreGiveFromISR(info[j].xBinarySemaphore, 
+                                                    &xHigherPriorityTaskWoken);
+        }
+
+        /* check if all tasks are completed */
+        for (j = i; j < (i+2); j++) {
+            if(!xSemaphoreTake(exit_semaph, portMAX_DELAY)) {
+                printf("a semaphore was not given by a test task.");
+            }
+        }
+
+        i += 2;
+
+    } while (i < cipherlist_sz);
+
+    vSemaphoreDelete(exit_semaph);
+    vSemaphoreDelete(Mutex);
+
+#else
+
+    do {
+
+        info[i].port = TLSSERVER_PORT;
+        info[i].cipher = cipherlist[i];
+        info[i].ctx = client_ctx;
+        info[i].id = i;
+
+        memset(info[i].name, 0, sizeof(info[i].name));
+        sprintf(info[i].name, "wolfSSL_TLS_client_do(%02d)", i);
+
+        Tls_client(&info[i]);
 
         i++;
     } while (i < cipherlist_sz);
+
+    if (client_ctx) {
+         wolfSSL_CTX_free(client_ctx);
+    }
+
+#endif
+
+    wolfSSL_Cleanup();
 
     printf("End of TLS_Client demo.\n");
 }
@@ -494,6 +658,44 @@ void wolfSSL_demo_task(bool         awsIotMqttMode,
 #elif defined(BENCHMARK)
 
     Benchmark_demo();
+
+#elif defined(TSIP_CRYPT_UNIT_TEST)
+    int ret = 0;
+
+    if ((ret = wolfCrypt_Init()) != 0) {
+        printf("wolfCrypt_Init failed %d\n", ret);
+    }
+
+    printf("Start wolf tsip crypt Test\n");
+
+    printf(" \n");
+    printf(" simple crypt test by using TSIP\n");
+    tsip_crypt_test();
+
+    printf(" \n");
+    printf(" multi sha thread test\n");
+    tsip_crypt_sha_multitest();
+
+    printf(" \n");
+    printf(" multi aes cbc thread test\n");
+
+    tsip_crypt_AesCbc_multitest();
+
+    printf(" \n");
+    printf(" multi aes gcm thread test\n");
+
+    tsip_crypt_AesGcm_multitest();
+
+    printf(" \n");
+    printf(" multi sha aescbc aesgcm thread test\n");
+    tsip_crypt_Sha_AesCbcGcm_multitest();
+
+    printf(" \n");
+    printf("End wolf tsip crypt Test\n");
+
+    if ((ret = wolfCrypt_Cleanup()) != 0) {
+        printf("wolfCrypt_Cleanup failed %d\n", ret);
+    }
 
 #elif defined(TLS_CLIENT)
 

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_demo.c
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_demo.c
@@ -369,19 +369,19 @@ static void Tls_client(void *pvParam)
 
     if (ret == 0) {
         #ifdef WOLFSSL_RENESAS_TSIP_TLS
-         #if !defined(TLS_MULTITHREAD_TEST)
-          memset(&userContext, 0, sizeof(TsipUserCtx));
-          tsip_set_callback_ctx(ssl, &userContext);
-         #else
-          if (p->port - TLSSERVER_PORT == 0) {
-             memset(&userContext_taskA, 0, sizeof(TsipUserCtx));
-             tsip_set_callback_ctx(ssl, (void*)&userContext_taskA);
-          }
-          else {
-             memset(&userContext_taskB, 0, sizeof(TsipUserCtx));
-             tsip_set_callback_ctx(ssl, (void*)&userContext_taskB);
-          }
-         #endif
+            #if !defined(TLS_MULTITHREAD_TEST)
+            memset(&userContext, 0, sizeof(TsipUserCtx));
+            tsip_set_callback_ctx(ssl, &userContext);
+            #else
+            if (p->port - TLSSERVER_PORT == 0) {
+                memset(&userContext_taskA, 0, sizeof(TsipUserCtx));
+                tsip_set_callback_ctx(ssl, (void*)&userContext_taskA);
+            }
+            else {
+                memset(&userContext_taskB, 0, sizeof(TsipUserCtx));
+                tsip_set_callback_ctx(ssl, (void*)&userContext_taskB);
+            }
+            #endif
         #endif
     }
 

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_demo.h
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_demo.h
@@ -60,7 +60,8 @@
 /* use multi-thread example */
 /* #define TLS_MULTITHREAD_TEST */
 #if defined(TLS_MULTITHREAD_TEST) && defined(WOLFSSL_TLS13)
-    #error "MULTITHREAD_TEST is only available when not set WOLFSSL_TLS13"
+    #error "MULTITHREAD_TEST is only available when not set WOLFSSL_TLS13 \
+           because it is not verified yet."
 #endif
 
 #if defined(TLS_MULTITHREAD_TEST)

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_demo.h
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_demo.h
@@ -47,10 +47,8 @@
 #include "logging_stack.h"
 
 
-
-
 /* Enable wolfcrypt test demo */
-/*#define CRYPT_TEST*/
+/*#define CRYPT_TEST */
 
 /* Enable benchmark demo      */
 /*#define BENCHMARK*/
@@ -58,6 +56,29 @@
 /* Enable TLS client demo     */
 /* cannot enable with other definition */
 #define TLS_CLIENT
+
+/* use multi-thread example */
+/* #define TLS_MULTITHREAD_TEST */
+#if defined(TLS_MULTITHREAD_TEST) && defined(WOLFSSL_TLS13)
+    #error "MULTITHREAD_TEST is only available when not set WOLFSSL_TLS13"
+#endif
+
+#if defined(TLS_MULTITHREAD_TEST)
+ #define THREAD_STACK_SIZE (5 * 1024)
+#endif
+
+typedef struct tagTestInfo
+{
+     int  id;
+     int  port;
+     char name[32];
+     const char* cipher;
+     WOLFSSL_CTX* ctx;
+     wolfSSL_Logging_cb log_f;
+#if defined(TLS_MULTITHREAD_TEST)
+     SemaphoreHandle_t xBinarySemaphore;
+#endif
+} TestInfo;
 
 
 #endif /* WOLFSSL_DEMO_H_ */

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_tsip_unit_test.c
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_tsip_unit_test.c
@@ -1,0 +1,1026 @@
+/* wolfssl_tsip_unit_test.c
+ *
+ * Copyright (C) 2006-2022 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/sha.h>
+#include <wolfssl/wolfcrypt/sha256.h>
+#include <wolfssl/wolfcrypt/aes.h>
+#ifdef NO_INLINE
+    #include <wolfssl/wolfcrypt/misc.h>
+#else
+    #define WOLFSSL_MISC_INCLUDED
+    #include <wolfcrypt/src/misc.c>
+#endif
+#include <wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h>
+
+#include "FreeRTOS.h"
+#if defined(FREERTOS_TCP)
+    #include "FreeRTOS_IP.h"
+    #include "FreeRTOS_Sockets.h"
+    #include "platform/iot_network.h"
+    #include "platform.h"
+#endif
+
+#ifndef NO_SHA
+ int sha_test();
+#endif
+
+#ifndef NO_SHA256
+ int sha256_test();
+#endif
+
+#define SMALL_STACK_SIZE (1 * 1024)
+#define STACK_SIZE       (4 * 1024)
+
+#define RESULT_STR(ret)  if (ret == 0)\
+                          printf(" passed \n");\
+                         else \
+                          printf(" failed \n");
+
+static xSemaphoreHandle exit_semaph;
+static byte exit_loop = 0;
+static byte sha_multTst_rslt = 0;
+static byte sha256_multTst_rslt = 0;
+static byte Aes128_Cbc_multTst_rslt = 0;
+static byte Aes256_Cbc_multTst_rslt = 0;
+static byte Aes128_Gcm_multTst_rslt = 0;
+static byte Aes256_Gcm_multTst_rslt = 0;
+
+#if defined(HAVE_AES_CBC)
+
+#if defined(WOLFSSL_AES_128)
+static tsip_aes_key_index_t g_user_aes128_key_index1;
+static tsip_aes_key_index_t g_user_aes128_key_index2;
+#endif
+
+#if defined(WOLFSSL_AES_256)
+static tsip_aes_key_index_t g_user_aes256_key_index1;
+static tsip_aes_key_index_t g_user_aes256_key_index2;
+#endif
+
+#endif
+
+typedef struct tagInfo
+{
+    tsip_aes_key_index_t aes_key;
+} Info;
+
+#if defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_128)
+
+static int tsip_aes_cbc_test(int prnt, tsip_aes_key_index_t* aes_key)
+{
+
+    Aes  aes[1];
+
+    byte cipher[AES_BLOCK_SIZE];
+    byte plain[AES_BLOCK_SIZE];
+    int  ret = 0;
+
+    WOLFSSL_SMALL_STACK_STATIC const byte msg[] = { 
+        /* "Now is the time for all " w/o trailing 0 */
+        0x6e,0x6f,0x77,0x20,0x69,0x73,0x20,0x74,
+        0x68,0x65,0x20,0x74,0x69,0x6d,0x65,0x20,
+        0x66,0x6f,0x72,0x20,0x61,0x6c,0x6c,0x20
+    };
+    byte key[] = "0123456789abcdef   ";  /* align */
+    byte iv[]  = "1234567890abcdef   ";  /* align */
+
+    ForceZero(cipher, AES_BLOCK_SIZE);
+    ForceZero(plain, AES_BLOCK_SIZE);
+
+    if (prnt) {
+        printf(" tsip_aes_cbc_test() ");
+    }
+    
+    ret = wc_AesInit(aes, NULL, INVALID_DEVID);
+    if (ret == 0) {
+        ret = wc_AesSetKey(aes, key, AES_BLOCK_SIZE, iv, AES_ENCRYPTION);
+        XMEMCPY(&aes->ctx.tsip_keyIdx, aes_key,
+                        sizeof(tsip_aes_key_index_t));
+
+        aes->ctx.keySize = aes->keylen;
+        if (ret == 0) {
+            ret = wc_tsip_AesCbcEncrypt(aes, cipher, msg, AES_BLOCK_SIZE);
+        }
+
+        wc_AesFree(aes);
+    }
+
+    if (ret != 0)
+        ret = -1;
+
+#ifdef HAVE_AES_DECRYPT
+    ret = wc_AesInit(aes, NULL, INVALID_DEVID);
+    if (ret == 0) {
+        ret = wc_AesSetKey(aes, key, AES_BLOCK_SIZE, iv, AES_DECRYPTION);
+        XMEMCPY(&aes->ctx.tsip_keyIdx, aes_key,
+                sizeof(tsip_aes_key_index_t));
+        aes->ctx.keySize = aes->keylen;
+        if (ret == 0)
+            ret = wc_tsip_AesCbcDecrypt(aes, plain, cipher, AES_BLOCK_SIZE);
+
+        wc_AesFree(aes);
+    }
+    if (ret != 0)
+        ret = -2;
+    if (XMEMCMP(plain, msg, AES_BLOCK_SIZE) != 0)
+        ret = -3;
+#endif /* HAVE_AES_DECRYPT */
+
+    (void)plain;
+
+    if (prnt) {
+        RESULT_STR(ret)
+    }
+    
+    return ret;
+}
+
+static void tskAes128_Cbc_Test(void *pvParam)
+{
+    int ret = 0;
+    Info *p = (Info*)pvParam;
+    
+    while (exit_loop == false) {
+        ret = tsip_aes_cbc_test(0, &p->aes_key);
+        vTaskDelay(10/portTICK_PERIOD_MS);
+        if (ret != 0) {
+            printf(" result was not good(%d). tsip_aes_cbc_test\n", ret);
+            Aes128_Cbc_multTst_rslt = 1;
+        }
+    }
+
+    xSemaphoreGive(exit_semaph);
+    vTaskDelete(NULL);
+}
+
+#endif
+
+#ifdef WOLFSSL_AES_256
+static int tsip_aes256_test(int prnt, tsip_aes_key_index_t* aes_key)
+{
+    Aes enc[1];
+    byte cipher[AES_BLOCK_SIZE];
+    byte plain[AES_BLOCK_SIZE];
+    Aes dec[1];
+    int  ret = 0;
+
+    /* Test vectors from NIST Special Publication 800-38A, 2001 Edition,
+     * Appendix F.2.5  */
+    WOLFSSL_SMALL_STACK_STATIC const byte msg[] = {
+        0x6b,0xc1,0xbe,0xe2,0x2e,0x40,0x9f,0x96,
+        0xe9,0x3d,0x7e,0x11,0x73,0x93,0x17,0x2a
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const byte verify[] =
+    {
+        0xf5,0x8c,0x4c,0x04,0xd6,0xe5,0xf1,0xba,
+        0x77,0x9e,0xab,0xfb,0x5f,0x7b,0xfb,0xd6
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC byte key[] = {
+        0x60,0x3d,0xeb,0x10,0x15,0xca,0x71,0xbe,
+        0x2b,0x73,0xae,0xf0,0x85,0x7d,0x77,0x81,
+        0x1f,0x35,0x2c,0x07,0x3b,0x61,0x08,0xd7,
+        0x2d,0x98,0x10,0xa3,0x09,0x14,0xdf,0xf4
+    };
+    WOLFSSL_SMALL_STACK_STATIC byte iv[]  = {
+        0x00,0x01,0x02,0x03,0x04,0x05,0x06,0x07,
+        0x08,0x09,0x0A,0x0B,0x0C,0x0D,0x0E,0x0F
+    };
+
+    if (prnt)
+        printf(" tsip_aes256_test() ");
+    
+    if (wc_AesInit(enc, NULL, INVALID_DEVID) != 0) {
+        ret = -1;
+        goto out;
+    }
+
+    if (wc_AesInit(dec, NULL, INVALID_DEVID) != 0){
+        ret = -2;
+        goto out;
+    }
+
+    ret = wc_AesSetKey(enc, key, (int) sizeof(key), iv, AES_ENCRYPTION);
+    if (ret != 0){
+        ret = -3;
+        goto out;
+    } else {
+        XMEMCPY(&enc->ctx.tsip_keyIdx, aes_key,
+                                sizeof(tsip_aes_key_index_t));
+        enc->ctx.keySize = enc->keylen;
+    }
+
+    ret = wc_AesSetKey(dec, key, (int) sizeof(key), iv, AES_DECRYPTION);
+    if (ret != 0) {
+        ret = -4;
+        goto out;
+    } else {
+        XMEMCPY(&dec->ctx.tsip_keyIdx, aes_key,
+                                sizeof(tsip_aes_key_index_t));
+        dec->ctx.keySize = dec->keylen;
+    }
+
+    ForceZero(cipher, AES_BLOCK_SIZE);
+    ret = wc_tsip_AesCbcEncrypt(enc, cipher, msg, (int) sizeof(msg));
+
+    if (ret != 0) {
+        ret = -5;
+        goto out;
+    }
+
+    ForceZero(plain, AES_BLOCK_SIZE);
+    ret = wc_tsip_AesCbcDecrypt(dec, plain, cipher, (int) sizeof(cipher));
+
+    if (ret != 0){
+        ret = -6;
+        goto out;
+    }
+    if (XMEMCMP(plain, msg, (int) sizeof(plain))) {
+        ret = -7;
+        goto out;
+    }
+
+out:
+    wc_AesFree(enc);
+    wc_AesFree(dec);
+
+    if (prnt) {
+        RESULT_STR(ret)
+    }
+    
+    return ret;
+}
+
+static void tskAes256_Cbc_Test(void *pvParam)
+{
+    int ret = 0;
+    Info *p = (Info*)pvParam;
+    
+    while (exit_loop == false) {
+        ret = tsip_aes256_test(0, &p->aes_key);
+        vTaskDelay(10/portTICK_PERIOD_MS);
+        if (ret != 0) {
+            printf(" result was not good(%d). tsip_aes256_test\n", ret);
+            Aes256_Cbc_multTst_rslt = 1;
+        }
+    }
+
+    xSemaphoreGive(exit_semaph);
+    vTaskDelete(NULL);
+}
+
+#endif /* WOLFSSL_AES_256 */
+
+#if defined(WOLFSSL_AES_256)
+static int tsip_aesgcm256_test(int prnt, tsip_aes_key_index_t* aes256_key)
+{
+    Aes enc[1];
+    Aes dec[1];
+    TsipUserCtx userContext;
+    
+    
+    /*
+     * This is Test Case 16 from the document Galois/
+     * Counter Mode of Operation (GCM) by McGrew and
+     * Viega.
+     */
+    WOLFSSL_SMALL_STACK_STATIC const byte p[] =
+    {
+        0xd9, 0x31, 0x32, 0x25, 0xf8, 0x84, 0x06, 0xe5,
+        0xa5, 0x59, 0x09, 0xc5, 0xaf, 0xf5, 0x26, 0x9a,
+        0x86, 0xa7, 0xa9, 0x53, 0x15, 0x34, 0xf7, 0xda,
+        0x2e, 0x4c, 0x30, 0x3d, 0x8a, 0x31, 0x8a, 0x72,
+        0x1c, 0x3c, 0x0c, 0x95, 0x95, 0x68, 0x09, 0x53,
+        0x2f, 0xcf, 0x0e, 0x24, 0x49, 0xa6, 0xb5, 0x25,
+        0xb1, 0x6a, 0xed, 0xf5, 0xaa, 0x0d, 0xe6, 0x57,
+        0xba, 0x63, 0x7b, 0x39
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const byte a[] =
+    {
+        0xfe, 0xed, 0xfa, 0xce, 0xde, 0xad, 0xbe, 0xef,
+        0xfe, 0xed, 0xfa, 0xce, 0xde, 0xad, 0xbe, 0xef,
+        0xab, 0xad, 0xda, 0xd2
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const byte k1[] =
+    {
+        0xfe, 0xff, 0xe9, 0x92, 0x86, 0x65, 0x73, 0x1c,
+        0x6d, 0x6a, 0x8f, 0x94, 0x67, 0x30, 0x83, 0x08,
+        0xfe, 0xff, 0xe9, 0x92, 0x86, 0x65, 0x73, 0x1c,
+        0x6d, 0x6a, 0x8f, 0x94, 0x67, 0x30, 0x83, 0x08
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const byte iv1[] =
+    {
+        0xca, 0xfe, 0xba, 0xbe, 0xfa, 0xce, 0xdb, 0xad,
+        0xde, 0xca, 0xf8, 0x88
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const byte c1[] =
+    {
+        0x52, 0x2d, 0xc1, 0xf0, 0x99, 0x56, 0x7d, 0x07,
+        0xf4, 0x7f, 0x37, 0xa3, 0x2a, 0x84, 0x42, 0x7d,
+        0x64, 0x3a, 0x8c, 0xdc, 0xbf, 0xe5, 0xc0, 0xc9,
+        0x75, 0x98, 0xa2, 0xbd, 0x25, 0x55, 0xd1, 0xaa,
+        0x8c, 0xb0, 0x8e, 0x48, 0x59, 0x0d, 0xbb, 0x3d,
+        0xa7, 0xb0, 0x8b, 0x10, 0x56, 0x82, 0x88, 0x38,
+        0xc5, 0xf6, 0x1e, 0x63, 0x93, 0xba, 0x7a, 0x0a,
+        0xbc, 0xc9, 0xf6, 0x62
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const byte t1[] =
+    {
+        0x76, 0xfc, 0x6e, 0xce, 0x0f, 0x4e, 0x17, 0x68,
+        0xcd, 0xdf, 0x88, 0x53, 0xbb, 0x2d, 0x55, 0x1b
+    };
+
+    int ivlen;
+
+    byte resultT[sizeof(t1)];
+    byte resultP[sizeof(p) + AES_BLOCK_SIZE];
+    byte resultC[sizeof(p) + AES_BLOCK_SIZE];
+    int  result = 0;
+    int  ret;
+    int  alen;
+    int  plen;
+
+    (void) result;
+
+    if (prnt) {
+        printf(" tsip_aes256_gcm_test() ");
+    }
+    
+    ForceZero(resultT, sizeof(resultT));
+    ForceZero(resultC, sizeof(resultC));
+    ForceZero(resultP, sizeof(resultP));
+    ForceZero(&userContext, sizeof(TsipUserCtx));
+
+    if (wc_AesInit(enc, NULL, INVALID_DEVID) != 0) {
+        ret = -1;
+        goto out;
+    }
+    if (wc_AesInit(dec, NULL, INVALID_DEVID) != 0) {
+        ret = -2;
+        goto out;
+    }
+
+    result = wc_AesGcmSetKey(enc, k1, sizeof(k1));
+    if (result != 0) {
+        ret = -3;
+        goto out;
+    } else {
+        XMEMCPY(&userContext.user_aes256_key_index, aes256_key,
+                                sizeof(tsip_aes_key_index_t));
+        userContext.user_aes256_key_set = 1;
+        enc->ctx.keySize = enc->keylen;
+    }
+
+    /* AES-GCM encrypt and decrypt both use AES encrypt internally */
+    result = wc_tsip_AesGcmEncrypt(enc, resultC, p, sizeof(p), 
+                        (byte*)iv1, sizeof(iv1), resultT, sizeof(resultT), 
+                        a, sizeof(a), &userContext);
+
+    if (result != 0) {
+        ret = -4;
+        goto out;
+    }
+
+    result = wc_AesGcmSetKey(dec, k1, sizeof(k1));
+    if (result != 0) {
+        ret = -7;
+        goto out;
+    } else {
+        dec->ctx.keySize = enc->keylen;
+    }
+
+    result = wc_tsip_AesGcmDecrypt(dec, resultP, resultC, sizeof(c1),
+                        iv1, sizeof(iv1), resultT, sizeof(resultT), 
+                        a, sizeof(a), &userContext);
+    if (result != 0){
+        ret = -8;
+        goto out;
+    }
+    if (XMEMCMP(p, resultP, sizeof(p))) {
+        ret = -9;
+        goto out;
+    }
+
+    ForceZero(resultT, sizeof(resultT));
+    ForceZero(resultC, sizeof(resultC));
+    ForceZero(resultP, sizeof(resultP));
+
+    wc_AesGcmSetKey(enc, k1, sizeof(k1));
+    /* AES-GCM encrypt and decrypt both use AES encrypt internally */
+    result = wc_tsip_AesGcmEncrypt(enc, resultC, p, sizeof(p), iv1, sizeof(iv1),
+                                resultT + 1, sizeof(resultT) - 1, 
+                                a, sizeof(a), &userContext);
+    if (result != 0) {
+        ret = -10;
+        goto out;
+    }
+
+    result = wc_tsip_AesGcmDecrypt(enc, resultP, resultC, sizeof(p),
+                            iv1, sizeof(iv1), resultT + 1, sizeof(resultT) - 1, 
+                            a, sizeof(a), &userContext);
+
+    if (result != 0) {
+        ret = -11;
+        goto out;
+    }
+    if (XMEMCMP(p, resultP, sizeof(p))) {
+        ret = -12;
+        goto out;
+    }
+
+    ret = 0;
+
+  out:
+    wc_AesFree(enc);
+    wc_AesFree(dec);
+    
+    if (prnt) {
+        RESULT_STR(ret)
+    }
+    
+    return ret;
+}
+
+static void tskAes256_Gcm_Test(void *pvParam)
+{
+    int ret = 0;
+    Info *p = (Info*)pvParam;
+    
+    while (exit_loop == false) {
+        ret = tsip_aesgcm256_test(0, &p->aes_key);
+        vTaskDelay(10/portTICK_PERIOD_MS);
+        if (ret != 0) {
+            printf(" result was not good(%d). tsip_aesgcm256_test\n", ret);
+            Aes256_Gcm_multTst_rslt = 1;
+        }
+    }
+
+    xSemaphoreGive(exit_semaph);
+    vTaskDelete(NULL);
+}
+#endif
+
+#if defined(WOLFSSL_AES_128)
+
+static int tsip_aesgcm128_test(int prnt, tsip_aes_key_index_t* aes128_key)
+{
+    Aes enc[1];
+    Aes dec[1];
+    TsipUserCtx userContext;
+
+    /* The following is an interesting test case from the example
+     * FIPS test vectors for AES-GCM. IVlen = 1 byte */
+    WOLFSSL_SMALL_STACK_STATIC const byte p3[] =
+    {
+        0x57, 0xce, 0x45, 0x1f, 0xa5, 0xe2, 0x35, 0xa5,
+        0x8e, 0x1a, 0xa2, 0x3b, 0x77, 0xcb, 0xaf, 0xe2
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const byte k3[] =
+    {
+        0xbb, 0x01, 0xd7, 0x03, 0x81, 0x1c, 0x10, 0x1a,
+        0x35, 0xe0, 0xff, 0xd2, 0x91, 0xba, 0xf2, 0x4b
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const byte iv3[] =
+    {
+        0xca
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const byte c3[] =
+    {
+        0x6b, 0x5f, 0xb3, 0x9d, 0xc1, 0xc5, 0x7a, 0x4f,
+        0xf3, 0x51, 0x4d, 0xc2, 0xd5, 0xf0, 0xd0, 0x07
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const byte a3[] =
+    {
+        0x40, 0xfc, 0xdc, 0xd7, 0x4a, 0xd7, 0x8b, 0xf1,
+        0x3e, 0x7c, 0x60, 0x55, 0x50, 0x51, 0xdd, 0x54
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const byte t3[] =
+    {
+        0x06, 0x90, 0xed, 0x01, 0x34, 0xdd, 0xc6, 0x95,
+        0x31, 0x2e, 0x2a, 0xf9, 0x57, 0x7a, 0x1e, 0xa6
+    };
+
+    byte resultT[16];
+    byte resultP[60 + AES_BLOCK_SIZE];
+    byte resultC[60 + AES_BLOCK_SIZE];
+    int  result = 0;
+    int ret;
+
+    (void) result;
+
+    if (prnt) {
+        printf(" tsip_aes128_gcm_test() ");
+    }
+
+    ForceZero(resultT, sizeof(resultT));
+    ForceZero(resultC, sizeof(resultC));
+    ForceZero(resultP, sizeof(resultP));
+    ForceZero(&userContext, sizeof(TsipUserCtx));
+
+    if (wc_AesInit(enc, NULL, INVALID_DEVID) != 0) {
+        ret = -1;
+        goto out;
+    }
+
+    if (wc_AesInit(dec, NULL, INVALID_DEVID) != 0) {
+        ret = -2;
+        goto out;
+    }
+
+    wc_AesGcmSetKey(enc, k3, sizeof(k3));
+    if (result != 0) {
+        ret = -3;
+        goto out;
+    } else {
+        XMEMCPY(&userContext.user_aes128_key_index, aes128_key,
+                                sizeof(tsip_aes_key_index_t));
+        userContext.user_aes128_key_set = 1;
+        enc->ctx.keySize = enc->keylen;
+    }
+    /* AES-GCM encrypt and decrypt both use AES encrypt internally */
+    result = wc_tsip_AesGcmEncrypt(enc, resultC, p3, sizeof(p3), 
+                                        iv3, sizeof(iv3),
+                                        resultT, sizeof(t3), 
+                                        a3, sizeof(a3), &userContext);
+    if (result != 0) {
+        ret = -4;
+        goto out;
+    }
+    result = wc_tsip_AesGcmDecrypt(enc, resultP, resultC, sizeof(c3),
+                                iv3, sizeof(iv3), resultT, sizeof(resultT), 
+                                a3, sizeof(a3), &userContext);
+    if (result != 0) {
+        ret = -5;
+        goto out;
+    }
+    if (XMEMCMP(p3, resultP, sizeof(p3))) {
+        ret = -6;
+        goto out;
+    }
+
+    ret = 0;
+
+  out:
+    wc_AesFree(enc);
+    wc_AesFree(dec);
+    
+    if (prnt) {
+        RESULT_STR(ret)
+    }
+    
+    return ret;
+}
+
+static void tskAes128_Gcm_Test(void *pvParam)
+{
+    int ret = 0;
+    Info *p = (Info*)pvParam;
+
+    while (exit_loop == false) {
+        ret = tsip_aesgcm128_test(0, &p->aes_key);
+        vTaskDelay(10/portTICK_PERIOD_MS);
+        if (ret != 0) {
+            printf(" result was not good(%d). tsip_aesgcm128_test\n", ret);
+            Aes128_Gcm_multTst_rslt = 1;
+        }
+    }
+
+    xSemaphoreGive(exit_semaph);
+    vTaskDelete(NULL);
+}
+
+#endif
+
+int tsip_crypt_test()
+{
+    int ret = 0;
+    e_tsip_err_t tsip_error_code;
+
+    /* Generate AES tsip Key */
+    tsip_error_code = R_TSIP_GenerateAes128RandomKeyIndex(
+                &g_user_aes128_key_index1);
+    
+    if (tsip_error_code == TSIP_SUCCESS)
+    tsip_error_code = R_TSIP_GenerateAes128RandomKeyIndex(
+                &g_user_aes128_key_index2);
+                        
+    if (tsip_error_code == TSIP_SUCCESS)
+    tsip_error_code = R_TSIP_GenerateAes256RandomKeyIndex(
+                &g_user_aes256_key_index1);
+    
+    if (tsip_error_code == TSIP_SUCCESS)
+    tsip_error_code = R_TSIP_GenerateAes256RandomKeyIndex(
+                &g_user_aes256_key_index2);
+                            
+    if (tsip_error_code == TSIP_SUCCESS) {
+
+   #ifndef NO_SHA
+        printf(" sha_test()");
+        ret = sha_test();
+        RESULT_STR(ret)
+   #endif
+
+   #ifndef NO_SHA256
+        printf(" sha256_test()");
+        ret = sha256_test();
+        RESULT_STR(ret)
+   #endif
+
+        ret = tsip_aes_cbc_test(1, &g_user_aes128_key_index1);
+
+        if (ret == 0) {
+
+            ret = tsip_aes256_test(1, &g_user_aes256_key_index1);
+
+        }
+
+        if (ret == 0) {
+
+            ret = tsip_aesgcm128_test(1, &g_user_aes128_key_index1);
+
+        }
+        
+        if (ret == 0) {
+
+            ret = tsip_aesgcm256_test(1, &g_user_aes256_key_index1);
+
+        }
+    }
+    else
+        ret = -1;
+
+    return ret;
+}
+
+#ifndef NO_SHA
+
+static void tskSha_Test(void *pvParam)
+{
+    int ret = 0;
+
+    while (exit_loop == false) {
+        ret = sha_test();
+        vTaskDelay(10/portTICK_PERIOD_MS);
+        if (ret != 0) {
+            printf(" result was not good(%d). sha_test\n", ret);
+            sha_multTst_rslt = 1;
+        }
+    }
+
+    xSemaphoreGive(exit_semaph);
+    vTaskDelete(NULL);
+}
+#endif
+
+#ifndef NO_SHA256
+static void tskSha256_Test(void *pvParam)
+{
+    int ret = 0;
+
+    while (exit_loop == false) {
+        ret = sha256_test();
+        vTaskDelay(10/portTICK_PERIOD_MS);
+        if (ret != 0) {
+            printf(" result was not good(%d). sha256_test\n", ret);
+            sha256_multTst_rslt = 1;
+        }
+    }
+
+    xSemaphoreGive(exit_semaph);
+    vTaskDelete(NULL);
+}
+#endif
+
+int tsip_crypt_sha_multitest()
+{
+    int ret = 0;
+    int num = 0;
+    int i;
+    BaseType_t xRet;
+    
+#ifndef NO_SHA
+    num++;
+#endif
+#ifndef NO_SHA256
+    num++;
+#endif
+    exit_loop = 0;
+    sha_multTst_rslt = 0;
+    sha256_multTst_rslt = 0;
+
+    exit_semaph = xSemaphoreCreateCounting(num, 0);
+    xRet = pdPASS;
+    
+#ifndef NO_SHA
+    xRet = xTaskCreate(tskSha_Test, "sha_test", 
+                            SMALL_STACK_SIZE, NULL, 3, NULL);
+#endif
+#ifndef NO_SHA256
+    if (xRet == pdPASS)
+        xRet = xTaskCreate(tskSha256_Test, "sha256_test", 
+                            SMALL_STACK_SIZE, NULL, 3, NULL);
+#endif
+
+    if (xRet == pdPASS) {
+        printf(" Waiting for completing tasks ...");
+        vTaskDelay(10000/portTICK_PERIOD_MS);
+        exit_loop = true;
+
+        for (i = 0; i < num; i++) {
+            if (!xSemaphoreTake(exit_semaph, 2000/portTICK_PERIOD_MS)) {
+                printf("a semaphore was not given by a test task.");
+                ret = -1;
+                xRet = pdFAIL;
+            }
+        }
+    }
+    
+    vSemaphoreDelete(exit_semaph);
+    
+    if ((xRet == pdPASS) &&
+       (sha_multTst_rslt == 0 && sha256_multTst_rslt == 0))
+        ret = 0;
+    else
+        ret = -1;
+    
+    RESULT_STR(ret)
+
+    return ret;
+}
+
+
+int tsip_crypt_AesCbc_multitest()
+{
+    int ret = 0;
+    int num = 0;
+    int i;
+    Info info_aes1;
+    Info info_aes2;
+    Info info_aes256_1;
+    Info info_aes256_2;
+    BaseType_t xRet;
+    
+#if defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_128)
+    num+=2;
+#endif
+#if defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_256)
+    num+=2;
+#endif
+    exit_loop = 0;
+    Aes128_Cbc_multTst_rslt = 0;
+    Aes256_Cbc_multTst_rslt = 0;
+
+    exit_semaph = xSemaphoreCreateCounting(num, 0);
+    xRet = pdPASS;
+    
+#if defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_128)
+    XMEMCPY(&info_aes1.aes_key, &g_user_aes128_key_index1,
+                                            sizeof(tsip_aes_key_index_t));
+    xRet = xTaskCreate(tskAes128_Cbc_Test, "aes_cbc_tes1t",
+            SMALL_STACK_SIZE, &info_aes1, 3, NULL);
+#endif
+#if defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_128)
+    XMEMCPY(&info_aes2.aes_key, &g_user_aes128_key_index2,
+                                            sizeof(tsip_aes_key_index_t));
+    if (xRet == pdPASS)
+        xRet = xTaskCreate(tskAes128_Cbc_Test, "aes_cbc_test2",
+                SMALL_STACK_SIZE, &info_aes2, 3, NULL);
+#endif
+
+#if defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_256)
+    XMEMCPY(&info_aes256_1.aes_key, &g_user_aes256_key_index1,
+                                            sizeof(tsip_aes_key_index_t));
+    if (xRet == pdPASS)
+        xRet = xTaskCreate(tskAes256_Cbc_Test, "aes256_cbc_test1",
+                SMALL_STACK_SIZE, &info_aes256_1, 3, NULL);
+#endif
+#if defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_256)
+    XMEMCPY(&info_aes256_2.aes_key, &g_user_aes256_key_index2,
+                                            sizeof(tsip_aes_key_index_t));
+    if (xRet == pdPASS)
+        xRet = xTaskCreate(tskAes256_Cbc_Test, "aes256_cbc_test2",
+                SMALL_STACK_SIZE, &info_aes256_2, 3, NULL);
+#endif
+    
+    if (xRet == pdPASS) {
+    printf(" Waiting for completing tasks ...");
+        vTaskDelay(10000/portTICK_PERIOD_MS);
+        exit_loop = true;
+
+        for (i = 0; i < num; i++) {
+            if (!xSemaphoreTake(exit_semaph, 2000/portTICK_PERIOD_MS)) {
+                printf("a semaphore was not given by a test task.");
+                ret = -1;
+                xRet = pdFAIL;
+            }
+        }
+    }
+    
+    vSemaphoreDelete(exit_semaph);
+
+    if ((xRet == pdPASS) &&
+       (Aes128_Cbc_multTst_rslt == 0 && Aes256_Cbc_multTst_rslt == 0))
+        ret = 0;
+    else
+        ret = -1;
+
+    RESULT_STR(ret)
+
+    return ret;
+}
+
+
+int tsip_crypt_AesGcm_multitest()
+{
+    int ret = 0;
+    int num = 0;
+    int i;
+    Info info_aes1;
+    Info info_aes2;
+    Info info_aes256_1;
+    Info info_aes256_2;
+    BaseType_t xRet;
+    
+#if defined(WOLFSSL_AES_128)
+    num+=2;
+#endif
+#if defined(WOLFSSL_AES_256)
+    num+=2;
+#endif
+
+    exit_loop = 0;
+    Aes128_Gcm_multTst_rslt = 0;
+    Aes256_Gcm_multTst_rslt = 0;
+
+    exit_semaph = xSemaphoreCreateCounting(num, 0);
+    xRet = pdPASS;
+
+#if defined(WOLFSSL_AES_128)
+    XMEMCPY(&info_aes1.aes_key, &g_user_aes128_key_index1,
+                                    sizeof(tsip_aes_key_index_t));
+    xTaskCreate(tskAes128_Gcm_Test, "aes128_gcm_test1",
+                                    STACK_SIZE, &info_aes1, 3, NULL);
+
+    XMEMCPY(&info_aes2.aes_key, &g_user_aes128_key_index2,
+                                        sizeof(tsip_aes_key_index_t));
+    if (xRet == pdPASS)
+        xRet = xTaskCreate(tskAes128_Gcm_Test, "aes128_gcm_test2",
+                                    STACK_SIZE, &info_aes2, 3, NULL);
+#endif
+
+
+#if defined(WOLFSSL_AES_256)
+    XMEMCPY(&info_aes256_1.aes_key, &g_user_aes256_key_index1,
+                                        sizeof(tsip_aes_key_index_t));
+    if (xRet == pdPASS)
+        xRet = xTaskCreate(tskAes256_Gcm_Test, "aes256_gcm_test1",
+                                    STACK_SIZE, &info_aes256_1, 3, NULL);
+    XMEMCPY(&info_aes256_2.aes_key, &g_user_aes256_key_index2,
+                                        sizeof(tsip_aes_key_index_t));
+    if (xRet == pdPASS)
+        xRet = xTaskCreate(tskAes256_Gcm_Test, "aes256_gcm_test2",
+                                    STACK_SIZE, &info_aes256_2, 3, NULL);
+#endif
+
+    if (xRet == pdPASS) {
+        printf(" Waiting for completing tasks ...");
+        vTaskDelay(10000/portTICK_PERIOD_MS);
+        exit_loop = true;
+
+        for (i = 0; i < num; i++) {
+            if (!xSemaphoreTake(exit_semaph, 5000/portTICK_PERIOD_MS)) {
+                printf("a semaphore was not given by a test task.");
+                ret = -1;
+                xRet = pdFAIL;
+            }
+        }
+    }
+    
+    vSemaphoreDelete(exit_semaph);
+
+    if ((xRet == pdPASS) &&
+        (Aes128_Gcm_multTst_rslt == 0 && Aes256_Gcm_multTst_rslt == 0))
+        ret = 0;
+    else
+        ret = -1;
+
+    RESULT_STR(ret)
+
+    return ret;
+}
+
+int tsip_crypt_Sha_AesCbcGcm_multitest()
+{
+    int ret = 0;
+    int num = 0;
+    int i;
+    Info info_aes128cbc;
+    Info info_aes128gcm;
+    Info info_aes256cbc;
+    Info info_aes256gcm;
+    BaseType_t xRet;
+    
+#ifndef NO_SHA
+    num++;
+#endif
+
+#if defined(WOLFSSL_AES_128)
+    num+=1;
+#endif
+#if defined(WOLFSSL_AES_256)
+    num+=1;
+#endif
+
+    exit_loop = 0;
+    sha_multTst_rslt = 0;
+    Aes256_Cbc_multTst_rslt = 0;
+    Aes256_Gcm_multTst_rslt = 0;
+
+    exit_semaph = xSemaphoreCreateCounting(num, 0);
+    xRet = pdPASS;
+    
+#ifndef NO_SHA
+    xRet = xTaskCreate(tskSha_Test, "sha_test",
+                                SMALL_STACK_SIZE, NULL, 3, NULL);
+#endif
+
+#if defined(WOLFSSL_AES_256)
+    XMEMCPY(&info_aes256cbc.aes_key, &g_user_aes256_key_index1,
+                                                sizeof(tsip_aes_key_index_t));
+    if (xRet == pdPASS)
+        xRet = xTaskCreate(tskAes256_Cbc_Test, "aes256_cbc_test1",
+                SMALL_STACK_SIZE, &info_aes256cbc, 3, NULL);
+#endif
+
+#if defined(WOLFSSL_AES_256)
+    XMEMCPY(&info_aes256gcm.aes_key, &g_user_aes256_key_index2,
+                                                sizeof(tsip_aes_key_index_t));
+    if (xRet == pdPASS)
+        xRet = xTaskCreate(tskAes256_Gcm_Test, "aes256_gcm_test2", 
+                                    STACK_SIZE, &info_aes256gcm, 3, NULL);
+#endif
+
+    if (xRet == pdPASS) {
+        printf(" Waiting for completing tasks ...");
+        vTaskDelay(10000/portTICK_PERIOD_MS);
+        exit_loop = true;
+
+        for (i = 0; i < num; i++) {
+            if (!xSemaphoreTake(exit_semaph, 2000/portTICK_PERIOD_MS)) {
+                printf("a semaphore was not given by a test task.");
+                ret = -1;
+                xRet = pdFAIL;
+            }
+        }
+    }
+    
+    vSemaphoreDelete(exit_semaph);
+    
+    if (xRet == pdPASS && sha_multTst_rslt == 0 &&
+       (Aes256_Cbc_multTst_rslt == 0 && Aes256_Gcm_multTst_rslt == 0)) {
+        ret = 0;
+    }
+    else {
+        ret = -1;
+    }
+    
+    RESULT_STR(ret)
+
+    return ret;
+}
+

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_tsip_unit_test.c
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_tsip_unit_test.c
@@ -133,7 +133,8 @@ static int tsip_aes_cbc_test(int prnt, tsip_aes_key_index_t* aes_key)
         ret = -1;
 
 #ifdef HAVE_AES_DECRYPT
-    ret = wc_AesInit(aes, NULL, INVALID_DEVID);
+    if (ret == 0)
+        ret = wc_AesInit(aes, NULL, INVALID_DEVID);
     if (ret == 0) {
         ret = wc_AesSetKey(aes, key, AES_BLOCK_SIZE, iv, AES_DECRYPTION);
         XMEMCPY(&aes->ctx.tsip_keyIdx, aes_key,

--- a/wolfcrypt/src/port/Renesas/renesas_common.c
+++ b/wolfcrypt/src/port/Renesas/renesas_common.c
@@ -360,7 +360,7 @@ int wc_CryptoCb_CryptInitRenesasCmn(WOLFSSL* ssl, void* ctx)
 {
     (void)ssl;
     (void)ctx;
-     
+
  #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     TsipUserCtx* cbInfo = (TsipUserCtx*)ctx;
  #elif defined(WOLFSSL_RENESAS_SCEPROTECT)

--- a/wolfcrypt/src/port/Renesas/renesas_common.c
+++ b/wolfcrypt/src/port/Renesas/renesas_common.c
@@ -360,7 +360,7 @@ int wc_CryptoCb_CryptInitRenesasCmn(WOLFSSL* ssl, void* ctx)
 {
     (void)ssl;
     (void)ctx;
-
+     
  #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     TsipUserCtx* cbInfo = (TsipUserCtx*)ctx;
  #elif defined(WOLFSSL_RENESAS_SCEPROTECT)
@@ -370,9 +370,16 @@ int wc_CryptoCb_CryptInitRenesasCmn(WOLFSSL* ssl, void* ctx)
     if (cbInfo == NULL || ssl == NULL) {
         return INVALID_DEVID;
     }
-
-    cbInfo->devId = gdevId++;
-
+    /* need exclusive control because of static variable */
+    if ((tsip_hw_lock()) == 0) {
+        cbInfo->devId = gdevId++;
+        tsip_hw_unlock();
+    }
+    else {
+        WOLFSSL_MSG("Failed to lock tsip hw");
+        return INVALID_DEVID;
+    }
+    
     if (wc_CryptoCb_RegisterDevice(cbInfo->devId, 
                             Renesas_cmn_CryptoDevCb, cbInfo) < 0) {
         /* undo devId number */
@@ -584,18 +591,17 @@ WOLFSSL_LOCAL int Renesas_cmn_TlsFinished(WOLFSSL* ssl, const byte *side,
 
     WOLFSSL_ENTER("Renesas_cmn_TlsFinished");
 
-
+    if (Renesas_cmn_usable(ssl, 1)) {
  #if defined(WOLFSSL_RENESAS_TSIP_TLS)
-    ret = wc_tsip_generateVerifyData(ssl->arrays->tsip_masterSecret,
+        ret = wc_tsip_generateVerifyData(ssl->arrays->tsip_masterSecret,
                             side, handshake_hash, hashes);
  #elif defined(WOLFSSL_RENESAS_SCEPROTECT)
-    if (Renesas_cmn_usable(ssl, 1)) {
          ret = wc_sce_generateVerifyData(ssl->arrays->sce_masterSecret,
                    side, handshake_hash, hashes);
+ #endif
     }
      else
          ret = PROTOCOLCB_UNAVAILABLE;
- #endif
 
     return ret;
 }
@@ -659,14 +665,17 @@ WOLFSSL_LOCAL int Renesas_cmn_generateSessionKey(WOLFSSL* ssl, void* ctx)
     (void)ctx;
  
     WOLFSSL_ENTER("Renesas_cmn_generateSessionKey");
+    if (Renesas_cmn_usable(ssl, 0)) {
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
         ret = wc_tsip_generateSessionKey(ssl, (TsipUserCtx*)ctx, cbInfo->devId);
 #elif defined(WOLFSSL_RENESAS_SCEPROTECT)
-    if (Renesas_cmn_usable(ssl, 0)) {
-         ret = wc_sce_generateSessionKey(ssl, ctx, cbInfo->devId);
-    } else
-         ret = PROTOCOLCB_UNAVAILABLE;
+        ret = wc_sce_generateSessionKey(ssl, ctx, devId);
 #endif
+    } 
+    else {
+         ret = PROTOCOLCB_UNAVAILABLE;
+    }
+    
     if (ret == 0) {
         wolfSSL_CTX_SetEncryptKeysCb(ssl->ctx, Renesas_cmn_EncryptKeys);
         wolfSSL_SetEncryptKeysCtx(ssl, ctx);

--- a/wolfcrypt/src/port/Renesas/renesas_sce_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_sce_util.c
@@ -471,7 +471,7 @@ static uint32_t GetSceCipherSuite(
 /* ssl     : a pointer to WOLFSSL object                       */
 /* session_key_generated : if session key has been generated   */
 /* return  1 for usable, 0 for unusable                        */
-WOLFSSL_LOCAL int wc_sce_usable(const struct WOLFSSL *ssl,
+WOLFSSL_LOCAL int wc_sce_usable(const WOLFSSL *ssl,
                                                 uint8_t session_key_generated)
 {
     WOLFSSL_ENTER("sce_usable");
@@ -523,7 +523,7 @@ WOLFSSL_LOCAL int wc_sce_usable(const struct WOLFSSL *ssl,
 }
 
 /* Generate Hmac by sha256*/
-WOLFSSL_LOCAL int wc_sce_Sha256GenerateHmac(const struct WOLFSSL *ssl,const uint8_t* myInner,
+WOLFSSL_LOCAL int wc_sce_Sha256GenerateHmac(const WOLFSSL *ssl,const uint8_t* myInner,
         uint32_t innerSz,const uint8_t* in, uint32_t sz, byte* digest)
 {
     WOLFSSL_ENTER("sce_Sha256HmacGenerate");
@@ -574,7 +574,7 @@ WOLFSSL_LOCAL int wc_sce_Sha256GenerateHmac(const struct WOLFSSL *ssl,const uint
 }
 
 /* Verify hmac */
-WOLFSSL_LOCAL int wc_sce_Sha256VerifyHmac(const struct WOLFSSL *ssl,
+WOLFSSL_LOCAL int wc_sce_Sha256VerifyHmac(const WOLFSSL *ssl,
         const uint8_t* message, uint32_t messageSz,
         uint32_t macSz, uint32_t content)
 {
@@ -595,7 +595,7 @@ WOLFSSL_LOCAL int wc_sce_Sha256VerifyHmac(const struct WOLFSSL *ssl,
         return ret;
     }
 
-    wolfSSL_SetTlsHmacInner((struct WOLFSSL*)ssl, myInner,
+    wolfSSL_SetTlsHmacInner((WOLFSSL*)ssl, myInner,
                                                         (word32)messageSz, (int)content, 1);
 
     ret = R_SCE_SHA256HMAC_VerifyInit(
@@ -663,7 +663,7 @@ WOLFSSL_LOCAL int wc_sce_generateVerifyData(const uint8_t *ms, /* master secret 
 }
 
 /* generate keys for TLS communication */
-WOLFSSL_LOCAL int wc_sce_generateSessionKey(struct WOLFSSL *ssl,
+WOLFSSL_LOCAL int wc_sce_generateSessionKey(WOLFSSL *ssl,
                 User_SCEPKCbInfo* cbInfo, int devId)
 {
     WOLFSSL_MSG("sce_generateSessionKey()");
@@ -1056,7 +1056,7 @@ WOLFSSL_LOCAL int wc_sce_tls_RootCertVerify(
 /*  store elements for session key generation into ssl->keys.
  *  return 0 on success, negative value on failure
  */
-WOLFSSL_LOCAL int wc_sce_storeKeyCtx(struct WOLFSSL* ssl, User_SCEPKCbInfo* info)
+WOLFSSL_LOCAL int wc_sce_storeKeyCtx(WOLFSSL* ssl, User_SCEPKCbInfo* info)
 {
     int ret = 0;
 

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_aes.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_aes.c
@@ -719,8 +719,9 @@ int wc_tsip_AesGcmEncrypt(
 
         if (ret == 0) {
 
-            /* since generated session key is coupled to iv, no need to pass
+            /* Since generated session key is coupled to iv, no need to pass
              * iv init func.
+             * It expects to pass iv when users create their own key.
              */
             err = initFn(&hdl, &key_client_aes, iv_l, ivSz_l);
 
@@ -913,6 +914,8 @@ int wc_tsip_AesGcmDecrypt(
         if (ret == 0) {
             /* since key_index has iv and ivSz in it, no need to pass them init
              * func. Pass NULL and 0 as 3rd and 4th parameter respectively.
+             *
+             * It expects to pass iv when users create their own key.
              */
             err = initFn(&hdl, &key_server_aes, iv_l, ivSz_l);
 

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_aes.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_aes.c
@@ -618,18 +618,18 @@ int wc_tsip_AesGcmEncrypt(
     uint8_t* cipherBuf = NULL;
     uint8_t* aTagBuf   = NULL;
     uint8_t* aadBuf    = NULL;
-
+    const uint8_t* iv_l = NULL;
+    uint32_t ivSz_l = 0;
+    
     tsip_aes_key_index_t key_client_aes;
     TsipUserCtx *userCtx;
 
     WOLFSSL_ENTER("wc_tsip_AesGcmEncrypt");
 
-    if (aes == NULL || ctx == NULL ||
-       (sz != 0       && (in == NULL || out == NULL)) ||
+    if (aes == NULL || ctx == NULL || (ivSz == 0)   ||
+       (sz != 0       && (in == NULL  || out == NULL)) ||
        (ivSz != 0     &&  iv == NULL) ||
-       (ivSz < AESGCM_NONCE_SZ && iv != NULL) ||  /* Requires 12 bytes of iv */
-       (authInSz != 0 && authIn == NULL) ||
-       (authTagSz < AES_BLOCK_SIZE)) {
+       (authInSz != 0 && authIn == NULL)) {
         WOLFSSL_LEAVE("wc_tsip_AesGcmEncrypt", BAD_FUNC_ARG);
         return BAD_FUNC_ARG;
     }
@@ -665,7 +665,7 @@ int wc_tsip_AesGcmEncrypt(
         cipherBuf = XMALLOC(cipherBufSz, aes->heap, DYNAMIC_TYPE_AES);
         aTagBuf   = XMALLOC(TSIP_AES_GCM_AUTH_TAG_SIZE, aes->heap,
                                                         DYNAMIC_TYPE_AES);
-        aadBuf    = XMALLOC(authTagSz, aes->heap, DYNAMIC_TYPE_AES);
+        aadBuf    = XMALLOC(authInSz, aes->heap, DYNAMIC_TYPE_AES);
 
         if (plainBuf == NULL || cipherBuf == NULL || aTagBuf == NULL ||
                                                       aadBuf == NULL ) {
@@ -677,10 +677,11 @@ int wc_tsip_AesGcmEncrypt(
             XMEMCPY(plainBuf, in, sz);
             ForceZero(cipherBuf, cipherBufSz);
             ForceZero(authTag, authTagSz);
-            XMEMCPY(aadBuf, authIn, min(authInSz, TSIP_AES_GCM_AUTH_TAG_SIZE));
+            XMEMCPY(aadBuf, authIn, authInSz);
         }
 
-        if (ret == 0) {
+        if (ret == 0 && 
+            userCtx->session_key_set == 1) {
             /* generate AES-GCM session key. The key stored in
              * Aes.ctx.tsip_keyIdx is not used here.
              */
@@ -700,6 +701,20 @@ int wc_tsip_AesGcmEncrypt(
                 WOLFSSL_MSG("R_TSIP_TlsGenerateSessionKey failed");
                 ret = -1;
             }
+        } else if (userCtx->user_aes128_key_set == 1 || 
+                   userCtx->user_aes256_key_set == 1) {
+            if (aes->ctx.keySize == 32) {
+                XMEMCPY(&key_client_aes, &userCtx->user_aes256_key_index,
+                        sizeof(tsip_aes_key_index_t));
+            }
+            else {
+                 XMEMCPY(&key_client_aes, &userCtx->user_aes128_key_index,
+                        sizeof(tsip_aes_key_index_t));
+            }
+            
+            iv_l = iv;
+            ivSz_l = ivSz;
+            
         }
 
         if (ret == 0) {
@@ -707,11 +722,10 @@ int wc_tsip_AesGcmEncrypt(
             /* since generated session key is coupled to iv, no need to pass
              * iv init func.
              */
-            err = initFn(&hdl, &key_client_aes, NULL, 0UL);
+            err = initFn(&hdl, &key_client_aes, iv_l, ivSz_l);
 
             if (err == TSIP_SUCCESS) {
-                err = updateFn(&hdl, NULL, NULL, 0UL, (uint8_t*)aadBuf,
-                                    min(authInSz, TSIP_AES_GCM_AUTH_TAG_SIZE));
+            	err = updateFn(&hdl, NULL, NULL, 0UL, (uint8_t*)aadBuf, authInSz);
             }
             if (err == TSIP_SUCCESS) {
                 err = updateFn(&hdl, plainBuf, cipherBuf, sz, NULL, 0UL);
@@ -786,7 +800,7 @@ int wc_tsip_AesGcmDecrypt(
     e_tsip_err_t        err;
     tsip_gcm_handle_t   hdl;
 
-    uint32_t            dataLen = sz;
+    uint32_t            dataLen;
     uint32_t            plainBufSz;
 
     aesGcmDecInitFn     initFn;
@@ -797,14 +811,16 @@ int wc_tsip_AesGcmDecrypt(
     uint8_t* plainBuf  = NULL;
     uint8_t* aTagBuf   = NULL;
     uint8_t* aadBuf    = NULL;
-
+    const uint8_t* iv_l = NULL;
+    uint32_t ivSz_l = 0;
+    
     tsip_aes_key_index_t key_server_aes;
     TsipUserCtx *userCtx;
 
     WOLFSSL_ENTER("wc_tsip_AesGcmDecrypt");
 
     if (aes == NULL || in == NULL || out == NULL || sz == 0 || ctx == NULL ||
-        (ivSz < AESGCM_NONCE_SZ && iv != NULL) ||  /* Requires 12 bytes of iv */
+        iv == 0 || 
         (authInSz != 0 && authIn == NULL) ||
         (authInSz == 0 && authIn != NULL) ||
         (authTagSz != 0 && authTag == NULL) ||
@@ -858,7 +874,8 @@ int wc_tsip_AesGcmDecrypt(
             XMEMCPY(aadBuf, authIn, authInSz);
         }
 
-        if (ret == 0) {
+        if (ret == 0 && 
+            userCtx->session_key_set == 1) {
             /* generate AES-GCM session key. The key stored in
              * Aes.ctx.tsip_keyIdx is not used here.
              */
@@ -877,13 +894,27 @@ int wc_tsip_AesGcmDecrypt(
                 WOLFSSL_MSG("R_TSIP_TlsGenerateSessionKey failed");
                 ret = -1;
             }
+        } else if (userCtx->user_aes128_key_set == 1 || 
+                   userCtx->user_aes256_key_set == 1) {
+            if (aes->ctx.keySize == 32) {
+                XMEMCPY(&key_server_aes, &userCtx->user_aes256_key_index,
+                        sizeof(tsip_aes_key_index_t));
+            }
+            else {
+                 XMEMCPY(&key_server_aes, &userCtx->user_aes128_key_index,
+                        sizeof(tsip_aes_key_index_t));
+            }
+            
+            iv_l = iv;
+            ivSz_l = ivSz;
+            
         }
 
         if (ret == 0) {
             /* since key_index has iv and ivSz in it, no need to pass them init
              * func. Pass NULL and 0 as 3rd and 4th parameter respectively.
              */
-            err = initFn(&hdl, &key_server_aes, NULL, 0UL);
+            err = initFn(&hdl, &key_server_aes, iv_l, ivSz_l);
 
             if (err == TSIP_SUCCESS) {
                 /* pass only AAD and it's size before passing cipher text */

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_util.c
@@ -2120,7 +2120,7 @@ int wc_tsip_EccVerify(
  *  output 64 bytes premaster secret to "out" buffer.
  */
 int wc_tsip_EccSharedSecret(
-    struct WOLFSSL* ssl,
+    WOLFSSL* ssl,
     ecc_key* otherKey,
     unsigned char* pubKeyDer,   unsigned int* pubKeySz,
     unsigned char* out,         unsigned int* outlen,
@@ -2177,7 +2177,7 @@ int wc_tsip_EccSharedSecret(
 }
 
 
-WOLFSSL_API void tsip_set_callbacks(struct WOLFSSL_CTX* ctx)
+WOLFSSL_API void tsip_set_callbacks(WOLFSSL_CTX* ctx)
 {
     WOLFSSL_ENTER("tsip_set_callbacks");
     wolfSSL_CTX_SetEccVerifyCb(ctx, (CallbackEccVerify)Renesas_cmn_EccVerify);
@@ -2210,7 +2210,7 @@ WOLFSSL_API void tsip_set_callbacks(struct WOLFSSL_CTX* ctx)
     WOLFSSL_LEAVE("tsip_set_callbacks", 0);
 }
 
-WOLFSSL_API int tsip_set_callback_ctx(struct WOLFSSL* ssl, void* user_ctx)
+WOLFSSL_API int tsip_set_callback_ctx(WOLFSSL* ssl, void* user_ctx)
 {
     WOLFSSL_ENTER("tsip_set_callback_ctx");
 
@@ -2302,7 +2302,7 @@ WOLFSSL_LOCAL void tsip_hw_unlock(void)
 
 /* check if tsip tls functions can be used for the cipher      */
 /* return  :1 when tsip can be used , 0 not be used.           */
-int tsip_usable(const struct WOLFSSL *ssl, uint8_t session_key_generated)
+int tsip_usable(const WOLFSSL *ssl, uint8_t session_key_generated)
 {
     byte cipher0 = ssl->options.cipherSuite0;
     byte cipher  = ssl->options.cipherSuite;
@@ -2582,7 +2582,7 @@ void tsip_inform_user_keys(
 
 /* Sha1Hmac */
 int wc_tsip_Sha1HmacGenerate(
-        const struct WOLFSSL *ssl,
+        const WOLFSSL *ssl,
         const byte* myInner,
         word32      innerSz,
         const byte* in,
@@ -2639,7 +2639,7 @@ int wc_tsip_Sha1HmacGenerate(
 
 /* Sha256Hmac */
 int wc_tsip_Sha256HmacGenerate(
-        const struct WOLFSSL *ssl,
+        const WOLFSSL *ssl,
         const byte* myInner,
         word32      innerSz,
         const byte* in,
@@ -2708,7 +2708,7 @@ int wc_tsip_Sha256HmacGenerate(
  *  Perform SHA1 and SHA256 Hmac verification
  */
 int wc_tsip_ShaXHmacVerify(
-        const struct WOLFSSL *ssl,
+        const WOLFSSL *ssl,
         const byte* message,
         word32      messageSz,
         word32      macSz,
@@ -2756,7 +2756,7 @@ int wc_tsip_ShaXHmacVerify(
         return ret;
     }
 
-    wolfSSL_SetTlsHmacInner((struct WOLFSSL*)ssl, (byte*)myInner,
+    wolfSSL_SetTlsHmacInner((WOLFSSL*)ssl, (byte*)myInner,
                                                      messageSz, content, 1);
 
     ret = initFn(&handle, &wrapped_key);
@@ -2818,7 +2818,7 @@ int wc_tsip_generateVerifyData(
 
 /* generate keys for TLS communication */
 int wc_tsip_generateSessionKey(
-    struct WOLFSSL *ssl,
+    WOLFSSL *ssl,
     TsipUserCtx*    ctx,
     int             devId)
 {
@@ -3051,7 +3051,7 @@ int wc_tsip_generateMasterSecret(
 /*  store elements for session key generation into ssl->keys.
  *  return 0 on success, negative value on failure
  */
-int wc_tsip_storeKeyCtx(struct  WOLFSSL* ssl, TsipUserCtx* userCtx)
+int wc_tsip_storeKeyCtx(WOLFSSL* ssl, TsipUserCtx* userCtx)
 {
     int ret = 0;
 

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -106,7 +106,7 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
 
 #if defined(WOLFSSL_RENESAS_TSIP_TLS) && \
     defined(WOLFSSL_RENESAS_TSIP_TLS_AES_CRYPT)
-    #include <wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h>
+    #include <wolfssl/wolfcrypt/port/Renesas/renesas_tsip_types.h>
 #endif
 
 #ifdef __cplusplus

--- a/wolfssl/wolfcrypt/include.am
+++ b/wolfssl/wolfcrypt/include.am
@@ -95,6 +95,7 @@ noinst_HEADERS+= \
                          wolfssl/wolfcrypt/port/Renesas/renesas-sce-crypt.h \
                          wolfssl/wolfcrypt/port/Renesas/renesas_sync.h \
                          wolfssl/wolfcrypt/port/Renesas/renesas_cmn.h \
+                         wolfssl/wolfcrypt/port/Renesas/renesas_tsip_types.h \
                          wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h
 
 if BUILD_CRYPTOAUTHLIB

--- a/wolfssl/wolfcrypt/port/Renesas/renesas_tsip_types.h
+++ b/wolfssl/wolfcrypt/port/Renesas/renesas_tsip_types.h
@@ -1,5 +1,5 @@
 
-/* renesas-tsip-crypt-types.h
+/* renesas_tsip_types.h
  *
  * Copyright (C) 2006-2022 wolfSSL Inc.
  *
@@ -20,8 +20,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
  
-#ifndef __RENESAS_TSIP_CRYPT_TYPES_H__
-#define __RENESAS_TSIP_CRYPT_TYPES_H__
+#ifndef __RENESAS_TSIP_TYPES_H__
+#define __RENESAS_TSIP_TYPES_H__
 
 
 #include <wolfssl/wolfcrypt/settings.h>
@@ -74,4 +74,4 @@ typedef struct {
 
 #endif
 
-#endif /* __RENESAS_TSIP_CRYPT_TYPES_H__ */
+#endif /* __RENESAS_TSIP_TYPES_H__ */

--- a/wolfssl/wolfcrypt/port/Renesas/renesas_tsip_types.h
+++ b/wolfssl/wolfcrypt/port/Renesas/renesas_tsip_types.h
@@ -1,0 +1,77 @@
+
+/* renesas-tsip-crypt-types.h
+ *
+ * Copyright (C) 2006-2022 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+ 
+#ifndef __RENESAS_TSIP_CRYPT_TYPES_H__
+#define __RENESAS_TSIP_CRYPT_TYPES_H__
+
+
+#include <wolfssl/wolfcrypt/settings.h>
+
+#if (!defined(NO_SHA) || !defined(NO_SHA256)) && \
+    !defined(NO_WOLFSSL_RENESAS_TSIP_CRYPT_HASH)
+typedef enum {
+    TSIP_SHA1 = 0,
+    TSIP_SHA256 = 1,
+} TSIP_SHA_TYPE;
+
+typedef enum {
+    TSIP_RSA2048,
+    TSIP_RSA4096,
+    TSIP_ECCP256,
+} TSIP_KEY_TYPE;
+
+typedef struct {
+    byte*  msg;
+    void*  heap;
+    word32 used;
+    word32 len;
+    word32 sha_type;
+#if defined(WOLF_CRYPTO_CB)
+    word32 flags;
+    int devId;
+#endif    
+} wolfssl_TSIP_Hash;
+
+/* RAW hash function APIs are not implemented with TSIP */
+#define WOLFSSL_NO_HASH_RAW
+
+typedef wolfssl_TSIP_Hash wc_Sha;
+
+#if !defined(NO_SHA256)
+typedef wolfssl_TSIP_Hash wc_Sha256;
+#endif
+
+#endif /* NO_SHA */
+
+
+#if defined(WOLFSSL_RENESAS_TSIP_TLS_AES_CRYPT)
+#include "r_tsip_rx_if.h"
+
+typedef struct {
+    tsip_aes_key_index_t tsip_keyIdx;
+    word32               keySize;
+    byte                 setup;
+} TSIP_AES_CTX;
+
+#endif
+
+#endif /* __RENESAS_TSIP_CRYPT_TYPES_H__ */

--- a/wolfssl/wolfcrypt/sha.h
+++ b/wolfssl/wolfcrypt/sha.h
@@ -107,7 +107,7 @@ enum {
     #include "wolfssl/wolfcrypt/port/caam/wolfcaam_sha.h"
 #elif defined(WOLFSSL_RENESAS_TSIP_CRYPT) && \
    !defined(NO_WOLFSSL_RENESAS_TSIP_CRYPT_HASH)
-    #include "wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h"
+    #include "wolfssl/wolfcrypt/port/Renesas/renesas_tsip_types.h"
 #else
 
 #if defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -147,7 +147,7 @@ enum {
     #include "wolfssl/wolfcrypt/port/af_alg/afalg_hash.h"
 #elif defined(WOLFSSL_RENESAS_TSIP_CRYPT) && \
    !defined(NO_WOLFSSL_RENESAS_TSIP_CRYPT_HASH)
-    #include "wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h"
+    #include "wolfssl/wolfcrypt/port/Renesas/renesas_tsip_types.h"
 #elif defined(WOLFSSL_RENESAS_SCEPROTECT) && \
    !defined(NO_WOLFSSL_RENESAS_SCEPROTECT_HASH)
     #include "wolfssl/wolfcrypt/port/Renesas/renesas-sce-crypt.h"


### PR DESCRIPTION
# Description

Added multi thread use case for Renesas TSIP Rx72N
Added simple unit test case for Renesas TSIP Rx72N
Improve not to use forward struct declaration
  - Include ssl.h rather than forward declaration to resolve struct name
  - Sha and Aes definitions are moved to another header file

# Testing

Run tests including unit test, cyrpt test, benchmark and client example on the board

