### PR TITLE
TLSX_COOKIE is only defined with WOLFSSL_SEND_HRR_COOKIE

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -10834,8 +10834,10 @@ int wolfSSL_accept_TLSv13(WOLFSSL* ssl)
                     ssl->keys.dtls_handshake_number = 0;
 
                     ssl->msgsReceived.got_client_hello = 0;
+#ifdef WOLFSSL_SEND_HRR_COOKIE
                     /* Remove cookie so that it will get computed again */
                     TLSX_Remove(&ssl->extensions, TLSX_COOKIE, ssl->heap);
+#endif
 
                     /* Reset states */
                     ssl->options.serverState = NULL_STATE;


### PR DESCRIPTION
When compiling with `./configure --enable-dtls --enable-dtls13` (without `--enable-hrrcookie`) we get a compilation error.