### PR TITLE
Fix storage of SendBuffered's return code in wolfSSL_Connect.  

### DIFF
--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -1969,7 +1969,7 @@ int Dtls13SetRecordNumberKeys(WOLFSSL* ssl, enum encrypt_side side)
 {
     RecordNumberCiphers* enc = NULL;
     RecordNumberCiphers* dec = NULL;
-    byte *encKey, *decKey;
+    byte *encKey = NULL, *decKey = NULL;
     int ret;
 
     if (ssl == NULL) {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -11983,7 +11983,8 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
             && ssl->error != WC_PENDING_E
         #endif
         ) {
-            if ( (ssl->error = SendBuffered(ssl)) == 0) {
+            ret = SendBuffered(ssl);
+            if (ret == 0) {
                 if (ssl->fragOffset == 0 && !ssl->options.buildingMsg) {
                     if (advanceState) {
                         ssl->options.connectState++;
@@ -12501,7 +12502,8 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
             && ssl->error != WC_PENDING_E
         #endif
         ) {
-            if ( (ret = SendBuffered(ssl)) == 0) {
+            ret = SendBuffered(ssl);
+            if (ret == 0) {
                 /* fragOffset is non-zero when sending fragments. On the last
                  * fragment, fragOffset is zero again, and the state can be
                  * advanced. */


### PR DESCRIPTION
# Description

Store in ret initially, only store in ssl->error if there's an error.  This matches the logic in wolfSSL_accept.

Fixes #5325

# Testing

Build + test suite

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
