### PR TITLE
20220706-fips-and-aarch64-fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2879,10 +2879,6 @@ if test "$ENABLED_WPAS" = "yes"
 then
     ENABLED_COMPKEY=yes
 fi
-if test "$ENABLED_COMPKEY" = "yes"
-then
-    AM_CFLAGS="$AM_CFLAGS -DHAVE_COMP_KEY"
-fi
 
 
 # for using memory optimization setting on both curve25519 and ed25519
@@ -3946,6 +3942,9 @@ AS_CASE([$FIPS_VERSION],
 
         AS_IF([test "$ENABLED_KEYGEN" != "yes" && (test "$FIPS_VERSION" != "v5-dev" || test "$enable_keygen" != "no")],
             [ENABLED_KEYGEN="yes"; AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_KEY_GEN"])
+
+        AS_IF([test "$ENABLED_COMPKEY" = "yes" && (test "$FIPS_VERSION" != "v5-dev" || test "$enable_compkey" != "yes")],
+            [ENABLED_COMPKEY="no"])
 
         AS_IF([test "$ENABLED_SHA224" != "yes" && (test "$FIPS_VERSION" != "v5-dev" || test "$enable_sha224" != "no")],
             [ENABLED_SHA224="yes"; AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SHA224"])
@@ -7701,8 +7700,13 @@ if test "x$ENABLED_SECURE_RENEGOTIATION_INFO" = "xyes"; then
 fi
 
 
+if test "$ENABLED_COMPKEY" = "yes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_COMP_KEY"
+fi
 
-# Depricated Algorithm Handling
+
+# Deprecated Algorithm Handling
 if test "$ENABLED_ARC4" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALLOW_RC4"

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -2952,7 +2952,6 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 break;
 #else
                 err_sys("invalid minimum downgrade version");
-                break;
 #endif /* WOLFSSL_DTLS13 */
             case 3:
                 minVersion = WOLFSSL_DTLSV1_2;

--- a/src/include.am
+++ b/src/include.am
@@ -170,8 +170,7 @@ src_libwolfssl_la_SOURCES += \
 
 src_libwolfssl_la_SOURCES += \
                wolfcrypt/src/hmac.c \
-               wolfcrypt/src/random.c \
-               wolfcrypt/src/sha256.c
+               wolfcrypt/src/random.c
 
 src_libwolfssl_la_SOURCES += wolfcrypt/src/kdf.c
 
@@ -201,13 +200,14 @@ endif
 
 if BUILD_ARMASM
 src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha256.c
-endif
+else
+src_libwolfssl_la_SOURCES += wolfcrypt/src/sha256.c
 if BUILD_INTELASM
 src_libwolfssl_la_SOURCES += wolfcrypt/src/sha256_asm.S
 endif
+endif
 
 if BUILD_SHA512
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sha512.c
 if BUILD_ARMASM
 src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha512.c
 if BUILD_ARMASM_INLINE
@@ -217,9 +217,11 @@ else
 src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha512-asm.S
 src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha512-asm.S
 endif
-endif
+else
+src_libwolfssl_la_SOURCES += wolfcrypt/src/sha512.c
 if BUILD_INTELASM
 src_libwolfssl_la_SOURCES += wolfcrypt/src/sha512_asm.S
+endif
 endif
 endif
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -24715,7 +24715,12 @@ static int test_wc_ecc_export_x963_ex (void)
         if (ret == BAD_FUNC_ARG) {
             ret = wc_ecc_export_x963_ex(&key, out, &badOutLen, COMP);
         }
-        if (ret == LENGTH_ONLY_E) {
+#if defined(HAVE_FIPS) && (!defined(FIPS_VERSION_LT) || FIPS_VERSION_LT(5,3))
+        if (ret == BUFFER_E)
+#else
+        if (ret == LENGTH_ONLY_E)
+#endif
+        {
             key.idx = -4;
             ret = wc_ecc_export_x963_ex(&key, out, &outlen, COMP);
         }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -28276,8 +28276,8 @@ int DecodeECC_DSA_Sig(const byte* sig, word32 sigLen, mp_int* r, mp_int* s)
         ret = ASN_ECC_KEY_E;
     }
 
-    return ret;
 #endif
+    return ret;
 #endif /* WOLFSSL_ASN_TEMPLATE */
 }
 #endif

--- a/wolfcrypt/src/port/arm/armv8-sha512.c
+++ b/wolfcrypt/src/port/arm/armv8-sha512.c
@@ -797,6 +797,8 @@ void wc_Sha384Free(wc_Sha384* sha384)
 
 #ifdef WOLFSSL_SHA512
 
+#if !defined(WOLFSSL_NOSHA512_224) || !defined(WOLFSSL_NOSHA512_256)
+
 static int Sha512_Family_GetHash(wc_Sha512* sha512, byte* hash,
                                             enum wc_HashType type )
 {
@@ -832,6 +834,8 @@ static int Sha512_Family_GetHash(wc_Sha512* sha512, byte* hash,
     }
     return ret;
 }
+
+#endif /* !WOLFSSL_NOSHA512_224 || !WOLFSSL_NOSHA512_256 */
 
 int wc_Sha512GetHash(wc_Sha512* sha512, byte* hash)
 {


### PR DESCRIPTION
wolfssl-multi-test-guided fixes, mostly around aarch64 and fips builds and unit.tests, particularly in combination.

tested with `wolfssl-multi-test.sh ... super-quick-check '.*all.*140-3.*' '.*140-3.*all.*' 'clang-tidy-.*' 'cross.*fips.*'
