### PR TITLE
SP math: fix configure.ac to allow its use

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -603,7 +603,7 @@ then
 fi
 
 # if sp-math-all is not set, then enable fast math
-if test "x$ENABLED_FASTMATH" = "xyes" && test "$enable_sp_math_all" = ""
+if test "x$ENABLED_FASTMATH" = "xyes" && test "$enable_sp_math_all" = "" && test "$enable_sp_math" = ""
 then
     # turn off fastmth if leanpsk on or asn off (w/o DH and ECC)
     if test "$ENABLED_LEANPSK" = "yes" || test "$ENABLED_ASN" = "no"
@@ -640,7 +640,7 @@ AC_ARG_ENABLE([heapmath],
     [ ENABLED_HEAPMATH=$enableval ],
     [ ENABLED_HEAPMATH=no]
     )
-if test "x$ENABLED_HEAPMATH" = "xyes" || (test "x$ENABLED_SP_MATH_ALL" = "xno" && test "x$ENABLED_FASTMATH" = "xno")
+if test "x$ENABLED_HEAPMATH" = "xyes" || (test "x$ENABLED_SP_MATH_ALL" = "xno" && test "x$ENABLED_FASTMATH" = "xno" && test "x$ENABLED_SP_MATH" = "xno")
 then
     AM_CFLAGS="$AM_CFLAGS -DUSE_INTEGER_HEAP_MATH"
     ENABLED_HEAPMATH="yes"

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -1283,12 +1283,12 @@ void *xrealloc(void *p, size_t n, void* heap, int type, const char* func,
         p32[0] = (word32)n;
         newp = (void*)(p32 + 4);
 
-        fprintf(stderr, "Alloc: %p -> %u (%d) at %s:%s:%u\n", newp, (word32)n,
-                                                        type, func, file, line);
         if (p != NULL) {
             fprintf(stderr, "Free: %p -> %u (%d) at %s:%s:%u\n", p, oldLen,
                                                         type, func, file, line);
         }
+        fprintf(stderr, "Alloc: %p -> %u (%d) at %s:%s:%u\n", newp, (word32)n,
+                                                        type, func, file, line);
     }
 
     (void)heap;


### PR DESCRIPTION
# Description

Choosing SP and SP math was resulting in only integer.c being used.
Fixed now.
Reorder realloc calls for memory logging to ensure scripts can match
allocate and free calls.

Fixes from mremusage testing.

# Testing

Memory usage testing working.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
