### PR TITLE
Fixes to SE050 port

### DIFF
--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -358,7 +358,6 @@
         int ret = 0;
         ret = se050_hash_final(&sha->se050Ctx, hash, WC_SHA_DIGEST_SIZE,
                                kAlgorithm_SSS_SHA1);
-        (void)wc_InitSha(sha);
         return ret;
     }
     int wc_ShaFinalRaw(wc_Sha* sha, byte* hash)
@@ -366,7 +365,6 @@
         int ret = 0;
         ret = se050_hash_final(&sha->se050Ctx, hash, WC_SHA_DIGEST_SIZE,
                                kAlgorithm_SSS_SHA1);
-        (void)wc_InitSha(sha);
         return ret;
     }
 
@@ -849,7 +847,7 @@ void wc_ShaFree(wc_Sha* sha)
     wc_ShaPic32Free(sha);
 #endif
 #if defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
-   se050_hash_free(&sha->se050Ctx);
+    se050_hash_free(&sha->se050Ctx);
 #endif
 #if (defined(WOLFSSL_RENESAS_TSIP_CRYPT) && \
     !defined(NO_WOLFSSL_RENESAS_TSIP_CRYPT_HASH))

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -619,7 +619,6 @@ static int InitSha256(wc_Sha256* sha256)
         int ret = 0;
         ret = se050_hash_final(&sha256->se050Ctx, hash, WC_SHA256_DIGEST_SIZE,
                                kAlgorithm_SSS_SHA256);
-        (void)wc_InitSha256(sha256);
         return ret;
     }
     int wc_Sha256FinalRaw(wc_Sha256* sha256, byte* hash)
@@ -627,7 +626,6 @@ static int InitSha256(wc_Sha256* sha256)
         int ret = 0;
         ret = se050_hash_final(&sha256->se050Ctx, hash, WC_SHA256_DIGEST_SIZE,
                                kAlgorithm_SSS_SHA256);
-        (void)wc_InitSha256(sha256);
         return ret;
     }
 
@@ -1695,6 +1693,9 @@ void wc_Sha256Free(wc_Sha256* sha256)
         XFREE(sha256->msg, sha256->heap, DYNAMIC_TYPE_TMP_BUFFER);
         sha256->msg = NULL;
     }
+#endif
+#if defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
+    se050_hash_free(&sha256->se050Ctx);
 #endif
 #if defined(WOLFSSL_KCAPI_HASH)
     KcapiHashFree(&sha256->kcapi);

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -232,7 +232,6 @@
     #endif
         ret = se050_hash_final(&sha512->se050Ctx, hash, WC_SHA512_DIGEST_SIZE,
                                kAlgorithm_SSS_SHA512);
-        (void)wc_InitSha512_ex(sha512, sha512->heap, devId);
         return ret;
     }
     int wc_Sha512FinalRaw(wc_Sha512* sha512, byte* hash)
@@ -247,12 +246,11 @@
     #endif
         ret = se050_hash_final(&sha512->se050Ctx, hash, WC_SHA512_DIGEST_SIZE,
                                kAlgorithm_SSS_SHA512);
-        (void)wc_InitSha512_ex(sha512, sha512->heap, devId);
         return ret;
     }
     void wc_Sha512Free(wc_Sha512* sha512)
     {
-        (void)sha512;
+        se050_hash_free(&sha512->se050Ctx);
     }
 
 #else
@@ -1264,7 +1262,6 @@ int wc_Sha512Transform(wc_Sha512* sha, const unsigned char* data)
         int ret = 0;
         ret = se050_hash_final(&sha384->se050Ctx, hash, WC_SHA384_DIGEST_SIZE,
                                kAlgorithm_SSS_SHA384);
-        (void)wc_InitSha384(sha384);
         return ret;
     }
     int wc_Sha384FinalRaw(wc_Sha384* sha384, byte* hash)
@@ -1272,7 +1269,6 @@ int wc_Sha512Transform(wc_Sha512* sha, const unsigned char* data)
         int ret = 0;
         ret = se050_hash_final(&sha384->se050Ctx, hash, WC_SHA384_DIGEST_SIZE,
                                kAlgorithm_SSS_SHA384);
-        (void)wc_InitSha384(sha384);
         return ret;
     }
 
@@ -1480,6 +1476,10 @@ void wc_Sha384Free(wc_Sha384* sha384)
         XFREE(sha384->msg, sha384->heap, DYNAMIC_TYPE_TMP_BUFFER);
         sha384->msg = NULL;
     }
+#endif
+
+#if defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
+    se050_hash_free(&sha384->se050Ctx);
 #endif
 
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_SHA384)

--- a/wolfssl/wolfcrypt/port/nxp/se050_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/se050_port.h
@@ -24,7 +24,6 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/visibility.h>
-#include <wolfssl/wolfcrypt/asn_public.h>
 
 #ifdef __GNUC__
 #pragma GCC diagnostic push
@@ -39,7 +38,7 @@
 #include "fsl_sss_api.h"
 #endif
 
-#ifdef WOLFSSL_SE050
+#if defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
     /* NXP SE050 - Disable SHA512 224/256 support */
     #ifndef WOLFSSL_NOSHA512_224
     #define WOLFSSL_NOSHA512_224
@@ -105,7 +104,7 @@ WOLFSSL_LOCAL int se050_hash_init(SE050_HASH_Context* se050Ctx, void* heap);
 WOLFSSL_LOCAL int se050_hash_update(SE050_HASH_Context* se050Ctx,
     const byte* data, word32 len);
 WOLFSSL_LOCAL int se050_hash_final(SE050_HASH_Context* se050Ctx, byte* hash,
-    size_t digestLen, word32 algo);
+    size_t digestLen, sss_algorithm_t algo);
 WOLFSSL_LOCAL void se050_hash_free(SE050_HASH_Context* se050Ctx);
 
 struct Aes;

--- a/wolfssl/wolfcrypt/sha512.h
+++ b/wolfssl/wolfcrypt/sha512.h
@@ -142,7 +142,7 @@ enum {
 #if defined(WOLFSSL_IMX6_CAAM) && !defined(WOLFSSL_QNX_CAAM)
     #include "wolfssl/wolfcrypt/port/caam/wolfcaam_sha.h"
 #else
-#if defined(WOLFSSL_SE050)
+#if defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
     #include "wolfssl/wolfcrypt/port/nxp/se050_port.h"
 #endif
 /* wc_Sha512 digest */
@@ -177,7 +177,7 @@ struct wc_Sha512 {
 #ifdef WOLFSSL_KCAPI_HASH
     wolfssl_KCAPI_Hash kcapi;
 #endif
-#if defined(WOLFSSL_SE050)
+#if defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
     SE050_HASH_Context se050Ctx;
 #endif
 #if defined(WOLFSSL_HASH_KEEP)


### PR DESCRIPTION
This fixes the following things:

* Memory leaks in SE050 SHA messages
* Add key to SE050 for ECC sign hash function
* Remove circular include
* Correct prototype for `se050_hash_final`
* A few defined check fixes

# Testing

TLS v1.3 handshake on an SE050 + S32K146 in embOS with SEGGER Studio v5.70a compiler.