### PR TITLE
20220707-DtlsUpdateWindowGTSeq-overshift

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -15380,7 +15380,10 @@ static void _DtlsUpdateWindowGTSeq(word32 diff, word32* window)
             else {
                 temp |= (oldWindow[i-idx] << diff);
                 window[i] = temp;
-                temp = oldWindow[i-idx] >> (DTLS_WORD_BITS - diff);
+                if (diff > 0)
+                    temp = oldWindow[i-idx] >> (DTLS_WORD_BITS - diff);
+                else
+                    temp = 0;
             }
         }
     }

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1887,34 +1887,34 @@ extern void uITRON4_free(void *p) ;
 
 /* ---------------------------------------------------------------------------
  * Math Library Selection (in order of preference)
- * ---------------------------------------------------------------------------*/
-/* Only evaluate this if:
- *  A) Not fips
- *  B) FIPS 140-3 (v5 or greater) */
+ * ---------------------------------------------------------------------------
+ */
 #if !defined(HAVE_FIPS_VERSION) || \
     (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 5))
-    /*  1) SP Math: wolfSSL proprietary math implementation (sp_int.c).
-     *      Constant time: Always
-     *      Enable:        WOLFSSL_SP_MATH_ALL
-     *
-     *  2) Fast Math: Stack based (tfm.c)
-     *      Constant time: Only with TFM_TIMING_RESISTANT
-     *      Enable:        USE_FAST_MATH
-     *
-     *  3) Integer Heap Math:  Heap based (integer.c)
-     *      Constant time: Not supported
-     *      Enable:        USE_INTEGER_HEAP_MATH
-     */
-    #if defined(WOLFSSL_SP_MATH_ALL) || \
-        (!defined(USE_FAST_MATH) && !defined(USE_INTEGER_HEAP_MATH))
-        /* 1) Using wolfSSL SP Math (sp_int.c) */
-        #ifndef WOLFSSL_SP_MATH_ALL
-            #define WOLFSSL_SP_MATH_ALL
-        #endif
+    #if defined(WOLFSSL_SP_MATH_ALL)
+        /*  1) SP Math: wolfSSL proprietary math implementation (sp_int.c).
+         *      Constant time: Always
+         *      Enable:        WOLFSSL_SP_MATH_ALL
+         */
+    #elif defined(WOLFSSL_SP_MATH)
+        /*  2) SP Math with restricted key sizes: wolfSSL proprietary math
+         *         implementation (sp_*.c).
+         *      Constant time: Always
+         *      Enable:        WOLFSSL_SP_MATH
+         */
     #elif defined(USE_FAST_MATH)
-        /* 2) Using fast math (tfm.c) - USE_FAST_MATH */
+        /*  3) Tom's Fast Math: Stack based (tfm.c)
+         *      Constant time: Only with TFM_TIMING_RESISTANT
+         *      Enable:        USE_FAST_MATH
+         */
+    #elif defined(USE_INTEGER_HEAP_MATH)
+        /*  4) Integer Heap Math:  Heap based (integer.c)
+         *      Constant time: Not supported
+         *      Enable:        USE_INTEGER_HEAP_MATH
+         */
     #else
-        /* 3) Using heap math (integer.c) - USE_INTEGER_HEAP_MATH */
+        /* default is SP Math. */
+        #define WOLFSSL_SP_MATH_ALL
     #endif
 #else
     /* FIPS 140-2 or older */


### PR DESCRIPTION
fixes overshift in `DtlsUpdateWindowGTSeq()`.

also fixes math back end selector logic in settings.h.  with this fix, `--enable-sp-math` is once again passing unit.test.

tested with various wolfssl-multi-tests that detected the problems in the first place.
