### PR TITLE
Various fixes and cleanups

### DIFF
--- a/cyassl/ssl.h
+++ b/cyassl/ssl.h
@@ -700,7 +700,9 @@
  * wrapper around macros until they are changed in cyassl code
  * needs investigation in regards to macros in fips
  */
-#define NO_WOLFSSL_ALLOC_ALIGN NO_CYASSL_ALLOC_ALIGN /* @TODO */
+#ifdef NO_CYASSL_ALLOC_ALIGN
+#define NO_WOLFSSL_ALLOC_ALIGN NO_CYASSL_ALLOC_ALIGN
+#endif
 
 
 /* examples/client/client.h */

--- a/src/pk.c
+++ b/src/pk.c
@@ -10375,7 +10375,7 @@ WOLFSSL_ECDSA_SIG *wolfSSL_ECDSA_do_sign(const unsigned char *d, int dlen,
             }
         }
         else {
-            WOLFSSL_MSG("wc_ecc_sign_hash_ex failed");
+            WOLFSSL_MSG("wc_ecc_sign_hash failed");
         }
     }
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4308,8 +4308,6 @@ static int wc_ecc_shared_secret_gen_sync(ecc_key* private_key, ecc_point* point,
 #endif
 #endif
 
-    WOLFSSL_ENTER("wc_ecc_shared_secret_gen_sync");
-
 #ifdef HAVE_ECC_CDH
     /* if cofactor flag has been set */
     if (private_key->flags & WC_ECC_FLAG_COFACTOR) {
@@ -4463,8 +4461,6 @@ static int wc_ecc_shared_secret_gen_sync(ecc_key* private_key, ecc_point* point,
         XFREE(k_lcl, private_key->heap, DYNAMIC_TYPE_ECC_BUFFER);
 #endif
 #endif
-
-    WOLFSSL_LEAVE("wc_ecc_shared_secret_gen_sync", err);
 
     return err;
 }
@@ -4649,8 +4645,6 @@ int wc_ecc_shared_secret_ex(ecc_key* private_key, ecc_point* point,
     } /* switch */
 
     RESTORE_VECTOR_REGISTERS();
-
-    WOLFSSL_LEAVE("wc_ecc_shared_secret_ex", err);
 
     /* if async pending then return and skip done cleanup below */
     if (err == WC_PENDING_E) {

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -57,6 +57,7 @@
 #ifdef WOLFSSL_KCAPI_HMAC
     #include <wolfssl/wolfcrypt/port/kcapi/kcapi_hmac.h>
 
+    /* map the _Software calls used by kcapi_hmac.c */
     #define wc_HmacSetKey  wc_HmacSetKey_Software
     #define wc_HmacUpdate  wc_HmacUpdate_Software
     #define wc_HmacFinal   wc_HmacFinal_Software
@@ -993,6 +994,11 @@ int wc_HmacFinal(Hmac* hmac, byte* hash)
 
 #ifdef WOLFSSL_KCAPI_HMAC
     /* implemented in wolfcrypt/src/port/kcapi/kcapi_hmac.c */
+
+    /* unmap the _Software calls used by kcapi_hmac.c */
+    #undef wc_HmacSetKey
+    #undef wc_HmacUpdate
+    #undef wc_HmacFinal
 
 #else
 /* Initialize Hmac for use with async device */


### PR DESCRIPTION
# Description

* Fix with macro redefinition error if building with `NO_WOLFSSL_ALLOC_ALIGN`.
* Fix for KCAPI HMAC forcing use of software for HKDF. Fixes ZD 14464.
* Improvements to error handling for `AddSessionToClientCache`.
* Fix PK function name in log. Remove the ECC logging (spams benchmark with `--enable-debug`).

# Testing

See KCAPI tests and use `NO_WOLFSSL_ALLOC_ALIGN`.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
