### PR TITLE
Fixes for ECC OID encoding/decoding

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -26322,7 +26322,7 @@ static int test_wc_ecc_get_curve_id_from_oid (void)
     /* Good Case */
     if (ret == 0) {
         ret = wc_ecc_get_curve_id_from_oid(oid, len);
-        if (ret == 7) {
+        if (ret == ECC_SECP256R1) {
             ret = 0;
         }
     }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -5216,7 +5216,7 @@ int EncodeObjectId(const word16* in, word32 inSz, byte* out, word32* outSz)
  * @param [in]      in     Byte array containing OID.
  * @param [in]      inSz   Size of OID in bytes.
  * @param [in]      out    Array to hold dotted form of OID.
- * @param [in, out] outSz  On in, number of elemnts in array.
+ * @param [in, out] outSz  On in, number of elements in array.
  *                         On out, count of numbers in dotted form.
  * @return  0 on success
  * @return  BAD_FUNC_ARG when in or outSz is NULL.
@@ -13289,14 +13289,16 @@ static int SetCurve(ecc_key* key, byte* output, size_t outSz)
         return idx + oidSz;
     }
 
+    /* verify output buffer has room */
+    if (oidSz > outSz)
+        return BUFFER_E;
+
 #ifdef HAVE_OID_ENCODING
     ret = EncodeObjectId(key->dp->oid, key->dp->oidSz, output+idx, &oidSz);
     if (ret != 0) {
         return ret;
     }
 #else
-    if (oidSz > outSz)
-        return BUFFER_E;
     XMEMCPY(output+idx, key->dp->oid, oidSz);
 #endif
     idx += oidSz;

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4096,16 +4096,21 @@ int wc_ecc_get_curve_id_from_dp_params(const ecc_set_type* dp)
 int wc_ecc_get_curve_id_from_oid(const byte* oid, word32 len)
 {
     int curve_idx;
-#ifdef HAVE_OID_DECODING
+#if defined(HAVE_OID_DECODING) || defined(HAVE_OID_ENCODING)
     int ret;
-    word16 decOid[MAX_OID_SZ];
-    word32 decOidSz = sizeof(decOid);
+    #ifdef HAVE_OID_DECODING
+    word16 decOid[MAX_OID_SZ/sizeof(word16)];
+    #else
+    byte  decOid[MAX_OID_SZ];
+    #endif
+    word32 decOidSz;
 #endif
 
     if (oid == NULL)
         return BAD_FUNC_ARG;
 
 #ifdef HAVE_OID_DECODING
+    decOidSz = (word32)sizeof(decOid);
     ret = DecodeObjectId(oid, len, decOid, &decOidSz);
     if (ret != 0) {
         return ret;
@@ -4113,18 +4118,29 @@ int wc_ecc_get_curve_id_from_oid(const byte* oid, word32 len)
 #endif
 
     for (curve_idx = 0; ecc_sets[curve_idx].size != 0; curve_idx++) {
+    #if defined(HAVE_OID_ENCODING) && !defined(HAVE_OID_DECODING)
+        decOidSz = (word32)sizeof(decOid);
+        ret = EncodeObjectId(ecc_sets[curve_idx].oid, ecc_sets[curve_idx].oidSz,
+            decOid, &decOidSz);
+        if (ret != 0) {
+            continue;
+        }
+    #endif
+
         if (
         #ifndef WOLFSSL_ECC_CURVE_STATIC
             ecc_sets[curve_idx].oid &&
         #endif
-        #ifdef HAVE_OID_DECODING
+        #if defined(HAVE_OID_ENCODING) && !defined(HAVE_OID_DECODING)
+            decOidSz == len &&
+                XMEMCMP(decOid, oid, len) == 0
+        #elif defined(HAVE_OID_ENCODING) && defined(HAVE_OID_DECODING)
             /* We double because decOidSz is a count of word16 elements. */
             ecc_sets[curve_idx].oidSz == decOidSz &&
-                              XMEMCMP(ecc_sets[curve_idx].oid, decOid,
-                                      decOidSz * 2) == 0
+                XMEMCMP(ecc_sets[curve_idx].oid, decOid, decOidSz * 2) == 0
         #else
             ecc_sets[curve_idx].oidSz == len &&
-                              XMEMCMP(ecc_sets[curve_idx].oid, oid, len) == 0
+                XMEMCMP(ecc_sets[curve_idx].oid, oid, len) == 0
         #endif
         ) {
             break;

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -929,7 +929,8 @@ enum Misc_ASN {
                                    /* Max total extensions, id + len + others */
 #endif
 #if defined(WOLFSSL_CERT_EXT) || defined(OPENSSL_EXTRA) || \
-        defined(HAVE_PKCS7) || defined(OPENSSL_EXTRA_X509_SMALL)
+        defined(HAVE_PKCS7) || defined(OPENSSL_EXTRA_X509_SMALL) || \
+        defined(HAVE_OID_DECODING) || defined(HAVE_OID_ENCODING)
     MAX_OID_SZ          = 32,      /* Max DER length of OID*/
     MAX_OID_STRING_SZ   = 64,      /* Max string length representation of OID*/
 #endif


### PR DESCRIPTION
# Description

* Fix for `wc_ecc_get_curve_id_from_oid` with combinations of `HAVE_OID_ENCODING` and `HAVE_OID_DECODING`.
* Fix in `SetCurve` for unused `outSz` with `HAVE_OID_ENCODING`.

# Testing

Tested all combinations of `HAVE_OID_ENCODING` and `HAVE_OID_DECODING` with and without ASN template:

```
./configure --enable-certgen CFLAGS="-DWOLFSSL_CUSTOM_OID -DHAVE_OID_ENCODING" && make check
./configure --enable-certgen CFLAGS="-DWOLFSSL_CUSTOM_OID -DHAVE_OID_ENCODING" && make check
./configure --enable-certgen CFLAGS="-DWOLFSSL_CUSTOM_OID -DHAVE_OID_DECODING -DHAVE_OID_ENCODING" && make check
./configure --enable-certgen CFLAGS="-DWOLFSSL_CUSTOM_OID -DHAVE_OID_ENCODING" --enable-asn=template && make check
./configure --enable-certgen CFLAGS="-DWOLFSSL_CUSTOM_OID -DHAVE_OID_ENCODING" --enable-asn=template && make check
./configure --enable-certgen CFLAGS="-DWOLFSSL_CUSTOM_OID -DHAVE_OID_DECODING -DHAVE_OID_ENCODING" --enable-asn=template && make check
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
