### PR TITLE
Support for asynchronous session ticket callback

### DIFF
--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -98,6 +98,9 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
     int    argc = ((func_args*)args)->argc;
     char** argv = ((func_args*)args)->argv;
     char   buffer[CYASSL_MAX_ERROR_SZ];
+#ifdef HAVE_TEST_SESSION_TICKET
+    MyTicketCtx myTicketCtx;
+#endif
 
 #ifdef ECHO_OUT
     FILE* fout = stdout;
@@ -168,11 +171,12 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
     CyaSSL_CTX_set_default_passwd_cb(ctx, PasswordCallBack);
 #endif
 
-#if defined(HAVE_SESSION_TICKET) && defined(WOLFSSL_NO_DEF_TICKET_ENC_CB) && \
-    ((defined(HAVE_CHACHA) && defined(HAVE_POLY1305)) || defined(HAVE_AESGCM))
+#ifdef HAVE_TEST_SESSION_TICKET
     if (TicketInit() != 0)
         err_sys("unable to setup Session Ticket Key context");
     wolfSSL_CTX_set_TicketEncCb(ctx, myTicketEncCb);
+    XMEMSET(&myTicketCtx, 0, sizeof(myTicketCtx));
+    wolfSSL_CTX_set_TicketEncCtx(ctx, &myTicketCtx);
 #endif
 
 #ifndef NO_FILESYSTEM
@@ -512,8 +516,7 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
     fdCloseSession(Task_self());
 #endif
 
-#if defined(HAVE_SESSION_TICKET) && defined(WOLFSSL_NO_DEF_TICKET_ENC_CB) && \
-    ((defined(HAVE_CHACHA) && defined(HAVE_POLY1305)) || defined(HAVE_AESGCM))
+#ifdef HAVE_TEST_SESSION_TICKET
     TicketCleanup();
 #endif
 

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -1572,6 +1572,10 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
     const char* dtlsSrtpProfiles = NULL;
 #endif
 
+#ifdef HAVE_TEST_SESSION_TICKET
+    MyTicketCtx myTicketCtx;
+#endif
+
     ((func_args*)args)->return_code = -1; /* error state */
 
 #ifndef NO_RSA
@@ -2398,11 +2402,12 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
     #endif
     }
 
-#if defined(HAVE_SESSION_TICKET) && defined(WOLFSSL_NO_DEF_TICKET_ENC_CB) && \
-    ((defined(HAVE_CHACHA) && defined(HAVE_POLY1305)) || defined(HAVE_AESGCM))
+#ifdef HAVE_TEST_SESSION_TICKET
     if (TicketInit() != 0)
         err_sys_ex(catastrophic, "unable to setup Session Ticket Key context");
     wolfSSL_CTX_set_TicketEncCb(ctx, myTicketEncCb);
+    XMEMSET(&myTicketCtx, 0, sizeof(myTicketCtx));
+    wolfSSL_CTX_set_TicketEncCtx(ctx, &myTicketCtx);
 #endif
 
 #if defined(WOLFSSL_SNIFFER) && defined(WOLFSSL_STATIC_EPHEMERAL)
@@ -3559,8 +3564,7 @@ exit:
     fdCloseSession(Task_self());
 #endif
 
-#if defined(HAVE_SESSION_TICKET) && defined(WOLFSSL_NO_DEF_TICKET_ENC_CB) && \
-    ((defined(HAVE_CHACHA) && defined(HAVE_POLY1305)) || defined(HAVE_AESGCM))
+#ifdef HAVE_TEST_SESSION_TICKET
     TicketCleanup();
 #endif
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -32540,6 +32540,11 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                                     et->enc_ticket, sizeof(InternalTicket),
                                     &encLen, ssl->ctx->ticketEncCtx);
             if (ret != WOLFSSL_TICKET_RET_OK) {
+            #ifdef WOLFSSL_ASYNC_CRYPT
+                if (ret == WC_PENDING_E) {
+                    return ret;
+                }
+            #endif
             #ifdef WOLFSSL_CHECK_MEM_ZERO
                 /* Internal ticket data wasn't encrypted maybe. */
                 wc_MemZero_Add("Create Ticket enc_ticket", et->enc_ticket,
@@ -32779,7 +32784,8 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
         if (ssl->options.createTicket) {
             ret = CreateTicket(ssl);
-            if (ret != 0) return ret;
+            if (ret != 0)
+                return ret;
         }
 
         length += ssl->session->ticketLen;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -12740,13 +12740,14 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
             FALL_THROUGH;
 
         case ACCEPT_FINISHED_DONE :
-            if (ssl->options.resuming)
-                while (ssl->options.clientState < CLIENT_FINISHED_COMPLETE)
+            if (ssl->options.resuming) {
+                while (ssl->options.clientState < CLIENT_FINISHED_COMPLETE) {
                     if ( (ssl->error = ProcessReply(ssl)) < 0) {
                         WOLFSSL_ERROR(ssl->error);
                         return WOLFSSL_FATAL_ERROR;
                     }
-
+                }
+            }
             ssl->options.acceptState = ACCEPT_THIRD_REPLY_DONE;
             WOLFSSL_MSG("accept state ACCEPT_THIRD_REPLY_DONE");
             FALL_THROUGH;


### PR DESCRIPTION
# Description

Support for asynchronous session ticket callback (can return WC_PENDING_E). Requires wolfAsyncCrypt support.
ZD 14420.

# Testing

I tested using:
```
./configure --enable-all --enable-asynccrypt --enable-debug --disable-shared CFLAGS="-DWOLFSSL_NO_DEF_TICKET_ENC_CB"
make
./examples/server/server &
./examples/client/client
```

I added some logic to return a WC_PENDING_E in wc_ChaCha20Poly1305_Encrypt as a test like this:
```
#ifdef WOLFSSL_ASYNC_CRYPT
    static int testAsync;
    if ((testAsync++ % 2) == 0) {
        return WC_PENDING_E;
    }
#endif
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
