### PR TITLE
20220707-attend-return-values

### DIFF
--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -393,7 +393,7 @@ int DoneHandShake = 0;
 static double gettime_secs(int reset)
 {
     struct timeval tv;
-    gettimeofday(&tv, 0);
+    LIBCALL_CHECK_RET(gettimeofday(&tv, 0));
     (void)reset;
 
     return (double)tv.tv_sec + (double)tv.tv_usec / 1000000;
@@ -404,12 +404,12 @@ static double gettime_secs(int reset)
 /* server send callback */
 static int ServerMemSend(info_t* info, char* buf, int sz)
 {
-    pthread_mutex_lock(&info->to_client.mutex);
+    PTHREAD_CHECK_RET(pthread_mutex_lock(&info->to_client.mutex));
 
 #ifndef BENCH_USE_NONBLOCK
     /* check for overflow */
     if (info->to_client.write_idx + sz > MEM_BUFFER_SZ) {
-        pthread_mutex_unlock(&info->to_client.mutex);
+        PTHREAD_CHECK_RET(pthread_mutex_unlock(&info->to_client.mutex));
         fprintf(stderr, "ServerMemSend overflow\n");
         return -1;
     }
@@ -423,8 +423,8 @@ static int ServerMemSend(info_t* info, char* buf, int sz)
     info->to_client.write_idx += sz;
     info->to_client.write_bytes += sz;
 
-    pthread_cond_signal(&info->to_client.cond);
-    pthread_mutex_unlock(&info->to_client.mutex);
+    PTHREAD_CHECK_RET(pthread_cond_signal(&info->to_client.cond));
+    PTHREAD_CHECK_RET(pthread_mutex_unlock(&info->to_client.mutex));
 
 #ifdef BENCH_USE_NONBLOCK
     if (sz == 0) {
@@ -437,12 +437,13 @@ static int ServerMemSend(info_t* info, char* buf, int sz)
 /* server recv callback */
 static int ServerMemRecv(info_t* info, char* buf, int sz)
 {
-    pthread_mutex_lock(&info->to_server.mutex);
+    PTHREAD_CHECK_RET(pthread_mutex_lock(&info->to_server.mutex));
 
 #ifndef BENCH_USE_NONBLOCK
     while (info->to_server.write_idx - info->to_server.read_idx < sz &&
             !info->to_client.done) {
-        pthread_cond_wait(&info->to_server.cond, &info->to_server.mutex);
+        PTHREAD_CHECK_RET(pthread_cond_wait(&info->to_server.cond,
+                                            &info->to_server.mutex));
     }
 #else
     if (info->to_server.write_idx - info->to_server.read_idx < sz) {
@@ -460,7 +461,7 @@ static int ServerMemRecv(info_t* info, char* buf, int sz)
         info->to_server.write_bytes = info->to_server.write_idx = 0;
     }
 
-    pthread_mutex_unlock(&info->to_server.mutex);
+    PTHREAD_CHECK_RET(pthread_mutex_unlock(&info->to_server.mutex));
 
     if (info->to_client.done != 0) {
         return -1;
@@ -477,14 +478,14 @@ static int ServerMemRecv(info_t* info, char* buf, int sz)
 /* client send callback */
 static int ClientMemSend(info_t* info, char* buf, int sz)
 {
-    pthread_mutex_lock(&info->to_server.mutex);
+    PTHREAD_CHECK_RET(pthread_mutex_lock(&info->to_server.mutex));
 
 #ifndef BENCH_USE_NONBLOCK
     /* check for overflow */
     if (info->to_server.write_idx + sz > MEM_BUFFER_SZ) {
         fprintf(stderr, "ClientMemSend overflow %d %d %d\n",
             info->to_server.write_idx, sz, MEM_BUFFER_SZ);
-        pthread_mutex_unlock(&info->to_server.mutex);
+        PTHREAD_CHECK_RET(pthread_mutex_unlock(&info->to_server.mutex));
         return -1;
     }
 #else
@@ -497,8 +498,8 @@ static int ClientMemSend(info_t* info, char* buf, int sz)
     info->to_server.write_idx += sz;
     info->to_server.write_bytes += sz;
 
-    pthread_cond_signal(&info->to_server.cond);
-    pthread_mutex_unlock(&info->to_server.mutex);
+    PTHREAD_CHECK_RET(pthread_cond_signal(&info->to_server.cond));
+    PTHREAD_CHECK_RET(pthread_mutex_unlock(&info->to_server.mutex));
 
 #ifdef BENCH_USE_NONBLOCK
     if (sz == 0) {
@@ -511,12 +512,13 @@ static int ClientMemSend(info_t* info, char* buf, int sz)
 /* client recv callback */
 static int ClientMemRecv(info_t* info, char* buf, int sz)
 {
-    pthread_mutex_lock(&info->to_client.mutex);
+    PTHREAD_CHECK_RET(pthread_mutex_lock(&info->to_client.mutex));
 
 #ifndef BENCH_USE_NONBLOCK
     while (info->to_client.write_idx - info->to_client.read_idx < sz &&
             !info->to_server.done) {
-        pthread_cond_wait(&info->to_client.cond, &info->to_client.mutex);
+        PTHREAD_CHECK_RET(pthread_cond_wait(&info->to_client.cond,
+                                            &info->to_client.mutex));
     }
 #else
     if (info->to_client.write_idx - info->to_client.read_idx < sz) {
@@ -534,7 +536,7 @@ static int ClientMemRecv(info_t* info, char* buf, int sz)
         info->to_client.write_bytes = info->to_client.write_idx = 0;
     }
 
-    pthread_mutex_unlock(&info->to_client.mutex);
+    PTHREAD_CHECK_RET(pthread_mutex_unlock(&info->to_client.mutex));
 
     if (info->to_server.done != 0) {
         return -1;
@@ -1056,13 +1058,14 @@ static int bench_tls_client(info_t* info)
 #if defined(HAVE_PTHREAD) && defined(WOLFSSL_DTLS)
         /* synchronize with server */
         if (info->doDTLS && !info->clientOrserverOnly) {
-            pthread_mutex_lock(&info->dtls_mutex);
+            PTHREAD_CHECK_RET(pthread_mutex_lock(&info->dtls_mutex));
             if (info->serverReady != 1) {
-                pthread_cond_wait(&info->dtls_cond, &info->dtls_mutex);
+                PTHREAD_CHECK_RET(pthread_cond_wait(&info->dtls_cond,
+                                                    &info->dtls_mutex));
             }
             /* for next loop */
             info->serverReady = 0;
-            pthread_mutex_unlock(&info->dtls_mutex);
+            PTHREAD_CHECK_RET(pthread_mutex_unlock(&info->dtls_mutex));
         }
 #endif
         /* perform connect */
@@ -1204,7 +1207,7 @@ static void* client_thread(void* args)
 
     ret = bench_tls_client(info);
 
-    pthread_cond_signal(&info->to_server.cond);
+    PTHREAD_CHECK_RET(pthread_cond_signal(&info->to_server.cond));
     info->to_client.done = 1;
     info->client.ret = ret;
 
@@ -1294,10 +1297,10 @@ static int SocketWaitClient(info_t* info)
     if (info->doDTLS) {
 #ifdef HAVE_PTHREAD
         if (!info->clientOrserverOnly) {
-            pthread_mutex_lock(&info->dtls_mutex);
+            PTHREAD_CHECK_RET(pthread_mutex_lock(&info->dtls_mutex));
             info->serverReady = 1;
-            pthread_cond_signal(&info->dtls_cond);
-            pthread_mutex_unlock(&info->dtls_mutex);
+            PTHREAD_CHECK_RET(pthread_cond_signal(&info->dtls_cond));
+            PTHREAD_CHECK_RET(pthread_mutex_unlock(&info->dtls_mutex));
         }
 #endif
         connd = (int)recvfrom(info->listenFd, (char *)msg, sizeof(msg),
@@ -1664,7 +1667,7 @@ static void* server_thread(void* args)
         }
     }
 
-    pthread_cond_signal(&info->to_client.cond);
+    PTHREAD_CHECK_RET(pthread_cond_signal(&info->to_client.cond));
     info->to_server.done = 1;
     info->server.ret = ret;
 
@@ -2126,23 +2129,31 @@ int bench_tls(void* args)
                 else {
             #ifdef HAVE_PTHREAD
                     info->useLocalMem = argLocalMem;
-                    pthread_mutex_init(&info->to_server.mutex, NULL);
-                    pthread_mutex_init(&info->to_client.mutex, NULL);
+                    PTHREAD_CHECK_RET(pthread_mutex_init(&info->to_server.mutex,
+                                                         NULL));
+                    PTHREAD_CHECK_RET(pthread_mutex_init(&info->to_client.mutex,
+                                                         NULL));
             #ifdef WOLFSSL_DTLS
-                    pthread_mutex_init(&info->dtls_mutex, NULL);
-                    pthread_cond_init(&info->dtls_cond, NULL);
+                    PTHREAD_CHECK_RET(pthread_mutex_init(&info->dtls_mutex,
+                                                         NULL));
+                    PTHREAD_CHECK_RET(pthread_cond_init(&info->dtls_cond,
+                                                        NULL));
             #endif
-                    pthread_cond_init(&info->to_server.cond, NULL);
-                    pthread_cond_init(&info->to_client.cond, NULL);
+                    PTHREAD_CHECK_RET(pthread_cond_init(&info->to_server.cond,
+                                                        NULL));
+                    PTHREAD_CHECK_RET(pthread_cond_init(&info->to_client.cond,
+                                                        NULL));
 
-                    pthread_create(&info->to_server.tid, NULL, server_thread,
-                                   info);
-                    pthread_create(&info->to_client.tid, NULL, client_thread,
-                                   info);
+                    PTHREAD_CHECK_RET(
+                        pthread_create(&info->to_server.tid, NULL,
+                                       server_thread, info));
+                    PTHREAD_CHECK_RET(
+                        pthread_create(&info->to_client.tid, NULL,
+                                       client_thread, info));
 
                     /* State that we won't be joining this thread */
-                    pthread_detach(info->to_server.tid);
-                    pthread_detach(info->to_client.tid);
+                    PTHREAD_CHECK_RET(pthread_detach(info->to_server.tid));
+                    PTHREAD_CHECK_RET(pthread_detach(info->to_client.tid));
             #endif
                 }
             }

--- a/examples/echoclient/echoclient.c
+++ b/examples/echoclient/echoclient.c
@@ -285,12 +285,14 @@ void echoclient_test(void* args)
         }
 
         if (strncmp(msg, "quit", 4) == 0) {
-            fputs("sending server shutdown command: quit!\n", fout);
+            LIBCALL_CHECK_RET(fputs("sending server shutdown command: quit!\n",
+                                    fout));
             break;
         }
 
         if (strncmp(msg, "break", 5) == 0) {
-            fputs("sending server session close: break!\n", fout);
+            LIBCALL_CHECK_RET(fputs("sending server session close: break!\n",
+                                    fout));
             break;
         }
 
@@ -313,8 +315,8 @@ void echoclient_test(void* args)
             } while (err == WC_PENDING_E);
             if (ret > 0) {
                 reply[ret] = 0;
-                fputs(reply, fout);
-                fflush(fout) ;
+                LIBCALL_CHECK_RET(fputs(reply, fout));
+                LIBCALL_CHECK_RET(fflush(fout));
                 sendSz -= ret;
             }
 #ifdef CYASSL_DTLS
@@ -362,7 +364,7 @@ void echoclient_test(void* args)
     wolfAsync_DevClose(&devId);
 #endif
 
-    fflush(fout);
+    LIBCALL_CHECK_RET(fflush(fout));
 #ifndef WOLFSSL_MDK_SHELL
     if (inCreated)  fclose(fin);
     if (outCreated) fclose(fout);

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -71,11 +71,11 @@ static void SignalReady(void* args, word16 port)
     /* signal ready to tcp_accept */
     func_args* server_args = (func_args*)args;
     tcp_ready* ready = server_args->signal;
-    pthread_mutex_lock(&ready->mutex);
+    PTHREAD_CHECK_RET(pthread_mutex_lock(&ready->mutex));
     ready->ready = 1;
     ready->port = port;
-    pthread_cond_signal(&ready->cond);
-    pthread_mutex_unlock(&ready->mutex);
+    PTHREAD_CHECK_RET(pthread_cond_signal(&ready->cond));
+    PTHREAD_CHECK_RET(pthread_mutex_unlock(&ready->mutex));
 #endif
     (void)args;
     (void)port;
@@ -456,7 +456,7 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
             command[echoSz] = 0;
 
         #ifdef ECHO_OUT
-            fputs(command, fout);
+            LIBCALL_CHECK_RET(fputs(command, fout));
         #endif
 
             do {

--- a/src/crl.c
+++ b/src/crl.c
@@ -174,13 +174,20 @@ void FreeCRL(WOLFSSL_CRL* crl, int dynamic)
 #ifdef HAVE_CRL_MONITOR
     if (crl->tid != 0) {
         WOLFSSL_MSG("stopping monitor thread");
-        if (StopMonitor(crl->mfd) == 0)
-            pthread_join(crl->tid, NULL);
+        if (StopMonitor(crl->mfd) == 0) {
+            int _pthread_ret = pthread_join(crl->tid, NULL);
+            if (_pthread_ret != 0)
+                WOLFSSL_MSG("stop monitor failed in pthread_join");
+        }
         else {
             WOLFSSL_MSG("stop monitor failed");
         }
     }
-    pthread_cond_destroy(&crl->cond);
+    {
+        int _pthread_ret = pthread_cond_destroy(&crl->cond);
+        if (_pthread_ret != 0)
+            WOLFSSL_MSG("pthread_cond_destroy failed in FreeCRL()");
+    }
 #endif
     wc_FreeMutex(&crl->crlLock);
     if (dynamic)   /* free self */
@@ -1116,8 +1123,10 @@ static void* DoMonitor(void* arg)
             XFREE(buff, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         #endif
 
-        if (wd > 0)
-            inotify_rm_watch(notifyFd, wd);
+        if (wd > 0) {
+            if (inotify_rm_watch(notifyFd, wd) < 0)
+                WOLFSSL_MSG("inotify_rm_watch #1 failed in DoMonitor");
+        }
         (void)close(crl->mfd);
         (void)close(notifyFd);
         return NULL;
@@ -1171,8 +1180,10 @@ static void* DoMonitor(void* arg)
     XFREE(buff, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
-    if (wd > 0)
-        inotify_rm_watch(notifyFd, wd);
+    if (wd > 0) {
+        if (inotify_rm_watch(notifyFd, wd) < 0)
+            WOLFSSL_MSG("inotify_rm_watch #2 failed in DoMonitor");
+    }
     (void)close(crl->mfd);
     (void)close(notifyFd);
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -12196,8 +12196,15 @@ int LoadCertByIssuer(WOLFSSL_X509_STORE* store, X509_NAME* issuer, int type)
 
         for (; suffix < MAX_SUFFIX; suffix++) {
             /* /folder-path/<hash>.(r)N[0..9] */
-            XSNPRINTF(filename, len, "%s/%08lx.%s%d", entry->dir_name,
-                                                       hash, post, suffix);
+            if (XSNPRINTF(filename, len, "%s/%08lx.%s%d", entry->dir_name,
+                                                       hash, post, suffix)
+                >= len)
+            {
+                WOLFSSL_MSG("buffer overrun in LoadCertByIssuer");
+                ret = BUFFER_E;
+                break;
+            }
+
             if(wc_FileExists(filename) == 0/*0 file exists */) {
 
                 if (type == X509_LU_X509) {

--- a/src/pk.c
+++ b/src/pk.c
@@ -78,37 +78,72 @@ static int pk_bn_field_print_fp(XFILE fp, int indent, const char* field,
     if (ret == 1) {
         /* Print leading spaces, name and spaces before data. */
         if (indent > 0) {
-            XFPRINTF(fp, "%*s", indent, "");
+            if (XFPRINTF(fp, "%*s", indent, "") < 0)
+                ret = 0;
         }
-        XFPRINTF(fp, "%s:\n", field);
+    }
+    if (ret == 1) {
+        if (XFPRINTF(fp, "%s:\n", field) < 0)
+            ret = 0;
+    }
+    if (ret == 1) {
         if (indent > 0) {
-            XFPRINTF(fp, "%*s", indent, "");
+            if (XFPRINTF(fp, "%*s", indent, "") < 0)
+                ret = 0;
         }
-        XFPRINTF(fp, "%*s", HEX_INDENT, "");
-
+    }
+    if (ret == 1) {
+        if (XFPRINTF(fp, "%*s", HEX_INDENT, "") < 0)
+            ret = 0;
+    }
+    if (ret == 1) {
         /* Print first byte - should always exist. */
         if ((buf[i] != '\0') && (buf[i+1] != '\0')) {
-            XFPRINTF(fp, "%c", buf[i++]);
-            XFPRINTF(fp, "%c", buf[i++]);
+            if (XFPRINTF(fp, "%c", buf[i++]) < 0)
+                ret = 0;
+            else if (XFPRINTF(fp, "%c", buf[i++]) < 0)
+                    ret = 0;
         }
+    }
+    if (ret == 1) {
         /* Print each hexadecimal character with byte separator. */
         while ((buf[i] != '\0') && (buf[i+1] != '\0')) {
             /* Byte separator every two nibbles - one byte. */
-            XFPRINTF(fp, ":");
+            if (XFPRINTF(fp, ":") < 0) {
+                ret = 0;
+                break;
+            }
             /* New line after every 15 bytes - 30 nibbles. */
             if (i % MAX_DIGITS_PER_LINE == 0) {
-                XFPRINTF(fp, "\n");
-                if (indent > 0) {
-                    XFPRINTF(fp, "%*s", indent, "");
+                if (XFPRINTF(fp, "\n") < 0) {
+                    ret = 0;
+                    break;
                 }
-                XFPRINTF(fp, "%*s", HEX_INDENT, "");
+                if (indent > 0) {
+                    if (XFPRINTF(fp, "%*s", indent, "") < 0) {
+                        ret = 0;
+                        break;
+                    }
+                }
+                if (XFPRINTF(fp, "%*s", HEX_INDENT, "") < 0) {
+                    ret = 0;
+                    break;
+                }
             }
             /* Print two nibbles - one byte. */
-            XFPRINTF(fp, "%c", buf[i++]);
-            XFPRINTF(fp, "%c", buf[i++]);
+            if (XFPRINTF(fp, "%c", buf[i++]) < 0) {
+                ret = 0;
+                break;
+            }
+            if (XFPRINTF(fp, "%c", buf[i++]) < 0) {
+                ret = 0;
+                break;
+            }
         }
         /* Ensure on new line after data. */
-        XFPRINTF(fp, "\n");
+        if (XFPRINTF(fp, "\n") < 0) {
+            ret = 0;
+        }
     }
 
     /* Dispose of any allocated character array. */
@@ -1836,8 +1871,11 @@ int wolfSSL_RSA_print_fp(XFILE fp, WOLFSSL_RSA* rsa, int indent)
             ret = 0;
         }
         else {
-            XFPRINTF(fp, "%*s", indent, "");
-            XFPRINTF(fp, "RSA Private-Key: (%d bit, 2 primes)\n", keySize);
+            if (XFPRINTF(fp, "%*s", indent, "") < 0)
+                ret = 0;
+            else if (XFPRINTF(fp, "RSA Private-Key: (%d bit, 2 primes)\n",
+                              keySize) < 0)
+                ret = 0;
         }
     }
     /* Print out any components available. */
@@ -4184,8 +4222,10 @@ int wolfSSL_DSA_print_fp(XFILE fp, WOLFSSL_DSA* dsa, int indent)
             ret = 0;
         }
         else {
-            XFPRINTF(fp, "%*s", indent, "");
-            XFPRINTF(fp, "Private-Key: (%d bit)\n", pBits);
+            if (XFPRINTF(fp, "%*s", indent, "") < 0)
+                ret = 0;
+            else if (XFPRINTF(fp, "Private-Key: (%d bit)\n", pBits) < 0)
+                ret = 0;
         }
     }
     if (ret == 1 && dsa->priv_key != NULL) {
@@ -7673,13 +7713,18 @@ int wolfSSL_EC_KEY_print_fp(XFILE fp, WOLFSSL_EC_KEY* key, int indent)
         }
     }
     if (ret == 1) {
-        XFPRINTF(fp, "%*s", indent, "");
+        if (XFPRINTF(fp, "%*s", indent, "") < 0)
+            ret = 0;
+    }
+    if (ret == 1) {
         if (key->priv_key != NULL && !wolfSSL_BN_is_zero(key->priv_key)) {
-            XFPRINTF(fp, "Private-Key: (%d bit)\n", bits);
+            if (XFPRINTF(fp, "Private-Key: (%d bit)\n", bits) < 0)
+                ret = 0;
             priv = 1;
         }
         else {
-            XFPRINTF(fp, "Public-Key: (%d bit)\n", bits);
+            if (XFPRINTF(fp, "Public-Key: (%d bit)\n", bits) < 0)
+                ret = 0;
         }
 
         if (priv) {
@@ -7703,13 +7748,17 @@ int wolfSSL_EC_KEY_print_fp(XFILE fp, WOLFSSL_EC_KEY* key, int indent)
         if (nid > 0) {
             curve = wolfSSL_OBJ_nid2ln(nid);
             if (curve != NULL) {
-                XFPRINTF(fp, "%*s", indent, "");
-                XFPRINTF(fp, "ASN1 OID: %s\n", curve);
+                if (XFPRINTF(fp, "%*s", indent, "") < 0)
+                    ret = 0;
+                else if (XFPRINTF(fp, "ASN1 OID: %s\n", curve) < 0)
+                    ret = 0;
             }
             nistName = wolfSSL_EC_curve_nid2nist(nid);
             if (nistName != NULL) {
-                XFPRINTF(fp, "%*s", indent, "");
-                XFPRINTF(fp, "NIST CURVE: %s\n", nistName);
+                if (XFPRINTF(fp, "%*s", indent, "") < 0)
+                    ret = 0;
+                else if (XFPRINTF(fp, "NIST CURVE: %s\n", nistName) < 0)
+                    ret = 0;
             }
         }
     }

--- a/src/x509.c
+++ b/src/x509.c
@@ -1193,8 +1193,10 @@ int wolfSSL_X509V3_EXT_print(WOLFSSL_BIO *out, WOLFSSL_X509_EXTENSION *ext,
         {
             char isCa[] = "TRUE";
             char notCa[] = "FALSE";
-            XSNPRINTF(tmp, sz, "%*sCA:%s", indent, "",
-                                                    obj->ca ? isCa : notCa);
+            if (XSNPRINTF(tmp, sz, "%*sCA:%s", indent, "",
+                                                    obj->ca ? isCa : notCa)
+                >= sz)
+                return rc;
             break;
         }
         case ALT_NAMES_OID:
@@ -1221,11 +1223,17 @@ int wolfSSL_X509V3_EXT_print(WOLFSSL_BIO *out, WOLFSSL_X509_EXTENSION *ext,
                         WOLFSSL_MSG("Memory error");
                         return rc;
                     }
-                    if (sk->next)
-                        XSNPRINTF(val, len, "%*s%s,", indent, "", str->strData);
-                    else
-                        XSNPRINTF(val, len, "%*s%s", indent, "", str->strData);
-
+                    if (sk->next) {
+                        if (XSNPRINTF(val, len, "%*s%s,",
+                                      indent, "", str->strData)
+                            >= len)
+                            return rc;
+                    } else {
+                        if (XSNPRINTF(val, len, "%*s%s",
+                                      indent, "", str->strData)
+                            >= len)
+                            return rc;
+                    }
                     XSTRNCAT(tmp, val, len);
                     XFREE(val, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                 }
@@ -1238,7 +1246,9 @@ int wolfSSL_X509V3_EXT_print(WOLFSSL_BIO *out, WOLFSSL_X509_EXTENSION *ext,
         {
             char* asn1str;
             asn1str = wolfSSL_i2s_ASN1_STRING(NULL, str);
-            XSNPRINTF(tmp, sz, "%*s%s", indent, "", asn1str);
+            if (XSNPRINTF(tmp, sz, "%*s%s", indent, "", asn1str)
+                >= sz)
+                return rc;
             XFREE(asn1str, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             break;
         }
@@ -1250,7 +1260,9 @@ int wolfSSL_X509V3_EXT_print(WOLFSSL_BIO *out, WOLFSSL_X509_EXTENSION *ext,
             break;
 
         default:
-            XSNPRINTF(tmp, sz, "%*s%s", indent, "", str->strData);
+            if (XSNPRINTF(tmp, sz, "%*s%s", indent, "", str->strData)
+                >= sz)
+                return rc;
     }
 
     if (wolfSSL_BIO_write(out, tmp, (int)XSTRLEN(tmp)) == (int)XSTRLEN(tmp)) {
@@ -3051,7 +3063,10 @@ char* wolfSSL_X509_get_name_oneline(WOLFSSL_X509_NAME* name, char* in, int sz)
                 WOLFSSL_MSG("Memory error");
                 return NULL;
             }
-            XSNPRINTF(str, strSz, "%s=%s, ", sn, buf);
+            if (XSNPRINTF(str, strSz, "%s=%s, ", sn, buf) >= strSz) {
+                WOLFSSL_MSG("buffer overrun");
+                return NULL;
+            }
         }
         else {
             /* Copy last name entry
@@ -3064,7 +3079,10 @@ char* wolfSSL_X509_get_name_oneline(WOLFSSL_X509_NAME* name, char* in, int sz)
                 WOLFSSL_MSG("Memory error");
                 return NULL;
             }
-            XSNPRINTF(str, strSz, "%s=%s", sn, buf);
+            if (XSNPRINTF(str, strSz, "%s=%s", sn, buf) >= strSz) {
+                WOLFSSL_MSG("buffer overrun");
+                return NULL;
+            }
         }
         /* Copy string to tmpBuf */
         XSTRNCAT(tmpBuf, str, strSz);
@@ -5478,7 +5496,13 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
                       (int)XSTRLEN("        Version:")) <= 0) {
             return WOLFSSL_FAILURE;
         }
-        XSNPRINTF(tmp, sizeof(tmp), " %d (0x%x)\n", version, (byte)version-1);
+        if (XSNPRINTF(tmp, sizeof(tmp), " %d (0x%x)\n",
+                      version, (byte)version-1)
+            >= (int)sizeof(tmp))
+        {
+            WOLFSSL_MSG("buffer overrun");
+            return WOLFSSL_FAILURE;
+        }
         if (wolfSSL_BIO_write(bio, tmp, (int)XSTRLEN(tmp)) <= 0) {
             return WOLFSSL_FAILURE;
         }
@@ -5503,7 +5527,12 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
         /* if serial can fit into byte than print on the same line */
         if (sz <= (int)sizeof(byte)) {
             char tmp[17];
-            XSNPRINTF(tmp, sizeof(tmp), " %d (0x%x)\n", serial[0],serial[0]);
+            if (XSNPRINTF(tmp, sizeof(tmp), " %d (0x%x)\n", serial[0],serial[0])
+                >= (int)sizeof(tmp))
+            {
+                WOLFSSL_MSG("buffer overrun");
+                return WOLFSSL_FAILURE;
+            }
             if (wolfSSL_BIO_write(bio, tmp, (int)XSTRLEN(tmp)) <= 0) {
                 return WOLFSSL_FAILURE;
             }
@@ -5522,11 +5551,21 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
             }
             tmp[0] = '\0';
             for (i = 0; i < sz - 1 && (3 * i) < tmpSz - valSz; i++) {
-                XSNPRINTF(val, sizeof(val) - 1, "%02x:", serial[i]);
+                if (XSNPRINTF(val, sizeof(val), "%02x:", serial[i])
+                    >= (int)sizeof(val))
+                {
+                    WOLFSSL_MSG("buffer overrun");
+                    return WOLFSSL_FAILURE;
+                }
                 val[3] = '\0'; /* make sure is null terminated */
                 XSTRNCAT(tmp, val, valSz);
             }
-            XSNPRINTF(val, sizeof(val) - 1, "%02x\n", serial[i]);
+            if (XSNPRINTF(val, sizeof(val), "%02x\n", serial[i])
+                >= (int)sizeof(val))
+            {
+                WOLFSSL_MSG("buffer overrun");
+                return WOLFSSL_FAILURE;
+            }
             val[3] = '\0'; /* make sure is null terminated */
             XSTRNCAT(tmp, val, valSz);
             if (wolfSSL_BIO_write(bio, tmp, (int)XSTRLEN(tmp)) <= 0) {
@@ -5748,9 +5787,14 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
                     #endif
                         return WOLFSSL_FAILURE;
                     }
-                    XSNPRINTF(tmp, sizeof(tmp) - 1, "%s%s: (%d bit)\n%s\n",
+                    if (XSNPRINTF(tmp, sizeof(tmp), "%s%s: (%d bit)\n%s\n",
                             "                ", "Public-Key", 8 * sz,
-                            "                Modulus:");
+                            "                Modulus:")
+                        >= (int)sizeof(tmp))
+                    {
+                        WOLFSSL_MSG("buffer overrun");
+                        return WOLFSSL_FAILURE;
+                    }
                     tmp[sizeof(tmp) - 1] = '\0';
                     if (wolfSSL_BIO_write(bio, tmp,
                                                   (int)XSTRLEN(tmp)) <= 0) {
@@ -5762,7 +5806,12 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
                     }
 
                     /* print out modulus */
-                    XSNPRINTF(tmp, sizeof(tmp) - 1,"                    ");
+                    if (XSNPRINTF(tmp, sizeof(tmp), "                    ")
+                        >= (int)sizeof(tmp))
+                    {
+                        WOLFSSL_MSG("buffer overrun");
+                        return WOLFSSL_FAILURE;
+                    }
                     tmp[sizeof(tmp) - 1] = '\0';
                     if (mp_leading_bit(&rsa->n)) {
                         lbit = 1;
@@ -5783,10 +5832,15 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
                     mp_to_unsigned_bin(&rsa->n, rawKey);
                     for (idx = 0; idx < (word32)rawLen; idx++) {
                         char val[5];
-                        int valSz = 5;
+                        int valSz = (int)sizeof(val);
 
                         if ((idx == 0) && !lbit) {
-                            XSNPRINTF(val, valSz - 1, "%02x", rawKey[idx]);
+                            if (XSNPRINTF(val, valSz, "%02x", rawKey[idx])
+                                >= valSz)
+                            {
+                                WOLFSSL_MSG("buffer overrun");
+                                return WOLFSSL_FAILURE;
+                            }
                         }
                         else if ((idx != 0) && (((idx + lbit) % 15) == 0)) {
                             tmp[sizeof(tmp) - 1] = '\0';
@@ -5800,12 +5854,27 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
                             #endif
                                 return WOLFSSL_FAILURE;
                             }
-                            XSNPRINTF(tmp, sizeof(tmp) - 1,
-                                    ":\n                    ");
-                            XSNPRINTF(val, valSz - 1, "%02x", rawKey[idx]);
+                            if (XSNPRINTF(tmp, sizeof(tmp),
+                                    ":\n                    ")
+                                >= (int)sizeof(tmp))
+                            {
+                                WOLFSSL_MSG("buffer overrun");
+                                return WOLFSSL_FAILURE;
+                            }
+                            if (XSNPRINTF(val, valSz, "%02x", rawKey[idx])
+                                >= valSz)
+                            {
+                                WOLFSSL_MSG("buffer overrun");
+                                return WOLFSSL_FAILURE;
+                            }
                         }
                         else {
-                            XSNPRINTF(val, valSz - 1, ":%02x", rawKey[idx]);
+                            if (XSNPRINTF(val, valSz, ":%02x", rawKey[idx])
+                                >= valSz)
+                            {
+                                WOLFSSL_MSG("buffer overrun");
+                                return WOLFSSL_FAILURE;
+                            }
                         }
                         XSTRNCAT(tmp, val, valSz);
                     }
@@ -5856,8 +5925,13 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
                         idx = ByteReverseWord32(idx);
                     #endif
                     }
-                    XSNPRINTF(tmp, sizeof(tmp) - 1,
-                        "\n                Exponent: %u (0x%x)\n",idx, idx);
+                    if (XSNPRINTF(tmp, sizeof(tmp),
+                        "\n                Exponent: %u (0x%x)\n",idx, idx)
+                        >= (int)sizeof(tmp))
+                    {
+                        WOLFSSL_MSG("buffer overrun");
+                        return WOLFSSL_FAILURE;
+                    }
                     if (wolfSSL_BIO_write(bio, tmp,
                                                   (int)XSTRLEN(tmp)) <= 0) {
                         XFREE(rawKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -5915,10 +5989,15 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
                     #endif
                         return WOLFSSL_FAILURE;
                     }
-                    XSNPRINTF(tmp, sizeof(tmp) - 1, "%s%s: (%d bit)\n%s\n",
+                    if (XSNPRINTF(tmp, sizeof(tmp), "%s%s: (%d bit)\n%s\n",
                             "                 ", "Public-Key",
                             8 * wc_ecc_size(ecc),
-                            "                 pub:");
+                            "                 pub:")
+                        >= (int)sizeof(tmp))
+                    {
+                        WOLFSSL_MSG("buffer overrun");
+                        return WOLFSSL_FAILURE;
+                    }
                     tmp[sizeof(tmp) - 1] = '\0';
                     if (wolfSSL_BIO_write(bio, tmp,
                                                   (int)XSTRLEN(tmp)) <= 0) {
@@ -5928,7 +6007,12 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
                     #endif
                         return WOLFSSL_FAILURE;
                     }
-                    XSNPRINTF(tmp, sizeof(tmp) - 1,"                     ");
+                    if (XSNPRINTF(tmp, sizeof(tmp),"                     ")
+                        >= (int)sizeof(tmp))
+                    {
+                        WOLFSSL_MSG("buffer overrun");
+                        return WOLFSSL_FAILURE;
+                    }
                     {
                         word32 derSz;
                         byte*  der;
@@ -5959,7 +6043,12 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
                             int valSz = 5;
 
                             if (i == 0) {
-                                XSNPRINTF(val, valSz - 1, "%02x", der[i]);
+                                if (XSNPRINTF(val, valSz, "%02x", der[i])
+                                    >= valSz)
+                                {
+                                    WOLFSSL_MSG("buffer overrun");
+                                    return WOLFSSL_FAILURE;
+                                }
                             }
                             else if ((i % 15) == 0) {
                                 tmp[sizeof(tmp) - 1] = '\0';
@@ -5973,12 +6062,27 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
                                             DYNAMIC_TYPE_TMP_BUFFER);
                                     return WOLFSSL_FAILURE;
                                 }
-                                XSNPRINTF(tmp, sizeof(tmp) - 1,
-                                    ":\n                     ");
-                                XSNPRINTF(val, valSz - 1, "%02x", der[i]);
+                                if (XSNPRINTF(tmp, sizeof(tmp),
+                                    ":\n                     ")
+                                    >= (int)sizeof(tmp))
+                                {
+                                    WOLFSSL_MSG("buffer overrun");
+                                    return WOLFSSL_FAILURE;
+                                }
+                                if (XSNPRINTF(val, valSz, "%02x", der[i])
+                                    >= valSz)
+                                {
+                                    WOLFSSL_MSG("buffer overrun");
+                                    return WOLFSSL_FAILURE;
+                                }
                             }
                             else {
-                                XSNPRINTF(val, valSz - 1, ":%02x", der[i]);
+                                if (XSNPRINTF(val, valSz, ":%02x", der[i])
+                                    >= valSz)
+                                {
+                                    WOLFSSL_MSG("buffer overrun");
+                                    return WOLFSSL_FAILURE;
+                                }
                             }
                             XSTRNCAT(tmp, val, valSz);
                         }
@@ -6000,9 +6104,14 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
 
                         XFREE(der, x509->heap, DYNAMIC_TYPE_TMP_BUFFER);
                     }
-                    XSNPRINTF(tmp, sizeof(tmp) - 1, "\n%s%s: %s\n",
+                    if (XSNPRINTF(tmp, sizeof(tmp), "\n%s%s: %s\n",
                             "                ", "ASN1 OID",
-                            ecc->dp->name);
+                            ecc->dp->name)
+                        >= (int)sizeof(tmp))
+                    {
+                        WOLFSSL_MSG("buffer overrun");
+                        return WOLFSSL_FAILURE;
+                    }
                     if (wolfSSL_BIO_write(bio, tmp,
                                                   (int)XSTRLEN(tmp)) <= 0) {
                         wc_ecc_free(ecc);
@@ -6038,8 +6147,13 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
         char val[5];
         int valSz = 5;
 
-        XSNPRINTF(tmp, sizeof(tmp),
-                  "            X509v3 Subject Key Identifier: ");
+        if (XSNPRINTF(tmp, sizeof(tmp),
+                  "            X509v3 Subject Key Identifier: ")
+            >= (int)sizeof(tmp))
+        {
+            WOLFSSL_MSG("buffer overrun");
+            return WOLFSSL_FAILURE;
+        }
         if (x509->subjKeyIdCrit) {
             XSTRNCAT(tmp, "critical", sizeof(tmp) - XSTRLEN(tmp) - 1);
         }
@@ -6050,12 +6164,27 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
         }
         XMEMSET(tmp, 0, sizeof(tmp));
 
-        XSNPRINTF(tmp, sizeof(tmp) - 1, "                ");
+        if (XSNPRINTF(tmp, sizeof(tmp), "                ")
+            >= (int)sizeof(tmp))
+        {
+            WOLFSSL_MSG("buffer overrun");
+            return WOLFSSL_FAILURE;
+        }
         for (i = 0; i < sizeof(tmp) && i < (x509->subjKeyIdSz - 1); i++) {
-            XSNPRINTF(val, valSz - 1, "%02X:", x509->subjKeyId[i]);
+            if (XSNPRINTF(val, valSz, "%02X:", x509->subjKeyId[i])
+                >= valSz)
+            {
+                WOLFSSL_MSG("buffer overrun");
+                return WOLFSSL_FAILURE;
+            }
             XSTRNCAT(tmp, val, valSz);
         }
-        XSNPRINTF(val, valSz - 1, "%02X\n", x509->subjKeyId[i]);
+        if (XSNPRINTF(val, valSz, "%02X\n", x509->subjKeyId[i])
+            >= valSz)
+        {
+            WOLFSSL_MSG("buffer overrun");
+            return WOLFSSL_FAILURE;
+        }
         XSTRNCAT(tmp, val, valSz);
         if (wolfSSL_BIO_write(bio, tmp, (int)XSTRLEN(tmp)) <= 0) {
             return WOLFSSL_FAILURE;
@@ -6071,8 +6200,13 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
         int valSz = 5;
         int len = 0;
 
-        XSNPRINTF(tmp, sizeof(tmp),
-                  "            X509v3 Authority Key Identifier: ");
+        if (XSNPRINTF(tmp, sizeof(tmp),
+                  "            X509v3 Authority Key Identifier: ")
+            >= (int)sizeof(tmp))
+        {
+            WOLFSSL_MSG("buffer overrun");
+            return WOLFSSL_FAILURE;
+        }
         if (x509->authKeyIdCrit) {
             XSTRNCAT(tmp, "critical", sizeof(tmp) - XSTRLEN(tmp) - 1);
         }
@@ -6083,7 +6217,12 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
         }
         XMEMSET(tmp, 0, sizeof(tmp));
 
-        XSNPRINTF(tmp, sizeof(tmp) - 1, "                keyid");
+        if (XSNPRINTF(tmp, sizeof(tmp), "                keyid")
+            >= (int)sizeof(tmp))
+        {
+            WOLFSSL_MSG("buffer overrun");
+            return WOLFSSL_FAILURE;
+        }
         for (i = 0; i < x509->authKeyIdSz; i++) {
             /* check if buffer is almost full */
             if (XSTRLEN(tmp) >= sizeof(tmp) - valSz) {
@@ -6092,7 +6231,12 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
                 }
                 tmp[0] = '\0';
             }
-            XSNPRINTF(val, valSz - 1, ":%02X", x509->authKeyId[i]);
+            if (XSNPRINTF(val, valSz, ":%02X", x509->authKeyId[i])
+                >= valSz)
+            {
+                WOLFSSL_MSG("buffer overrun");
+                return WOLFSSL_FAILURE;
+            }
             XSTRNCAT(tmp, val, valSz);
         }
         len = (int)XSTRLEN("\n");
@@ -6106,8 +6250,13 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
     if (x509->basicConstSet) {
         char tmp[100];
 
-        XSNPRINTF(tmp, sizeof(tmp),
-                  "\n            X509v3 Basic Constraints: ");
+        if (XSNPRINTF(tmp, sizeof(tmp),
+                  "\n            X509v3 Basic Constraints: ")
+            >= (int)sizeof(tmp))
+        {
+            WOLFSSL_MSG("buffer overrun");
+            return WOLFSSL_FAILURE;
+        }
         if (x509->basicConstCrit) {
             XSTRNCAT(tmp, "critical", sizeof(tmp) - XSTRLEN(tmp) - 1);
         }
@@ -6118,9 +6267,14 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
         }
         XMEMSET(tmp, 0, sizeof(tmp));
 
-        XSNPRINTF(tmp, sizeof(tmp),
+        if (XSNPRINTF(tmp, sizeof(tmp),
                 "                CA:%s\n",
-                (x509->isCa)? "TRUE": "FALSE");
+                (x509->isCa)? "TRUE": "FALSE")
+            >= (int)sizeof(tmp))
+        {
+            WOLFSSL_MSG("buffer overrun");
+            return WOLFSSL_FAILURE;
+        }
         if (wolfSSL_BIO_write(bio, tmp, (int)XSTRLEN(tmp)) <= 0) {
             return WOLFSSL_FAILURE;
         }
@@ -6143,7 +6297,12 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
                (int)XSTRLEN("    Signature Algorithm: ")) <= 0) {
             return WOLFSSL_FAILURE;
         }
-        XSNPRINTF(tmp, sizeof(tmp) - 1,"%s\n", GetSigName(sigOid));
+        if (XSNPRINTF(tmp, sizeof(tmp),"%s\n", GetSigName(sigOid))
+            >= (int)sizeof(tmp))
+        {
+            WOLFSSL_MSG("buffer overrun");
+            return WOLFSSL_FAILURE;
+        }
         tmp[sizeof(tmp) - 1] = '\0';
         if (wolfSSL_BIO_write(bio, tmp, (int)XSTRLEN(tmp)) <= 0) {
             return WOLFSSL_FAILURE;
@@ -6159,14 +6318,24 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
             XFREE(sig, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             return WOLFSSL_FAILURE;
         }
-        XSNPRINTF(tmp, sizeof(tmp) - 1,"         ");
+        if (XSNPRINTF(tmp, sizeof(tmp),"         ")
+            >= (int)sizeof(tmp))
+        {
+            WOLFSSL_MSG("buffer overrun");
+            return WOLFSSL_FAILURE;
+        }
         tmp[sizeof(tmp) - 1] = '\0';
         for (i = 0; i < sigSz; i++) {
             char val[5];
             int valSz = 5;
 
             if (i == 0) {
-                XSNPRINTF(val, valSz - 1, "%02x", sig[i]);
+                if (XSNPRINTF(val, valSz, "%02x", sig[i])
+                    >= valSz - 1)
+                {
+                    WOLFSSL_MSG("buffer overrun");
+                    return WOLFSSL_FAILURE;
+                }
             }
             else if (((i % 18) == 0)) {
                 tmp[sizeof(tmp) - 1] = '\0';
@@ -6175,12 +6344,27 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
                     XFREE(sig, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                     return WOLFSSL_FAILURE;
                 }
-                XSNPRINTF(tmp, sizeof(tmp) - 1,
-                        ":\n         ");
-                XSNPRINTF(val, valSz - 1, "%02x", sig[i]);
+                if (XSNPRINTF(tmp, sizeof(tmp),
+                        ":\n         ")
+                    >= (int)sizeof(tmp))
+                {
+                    WOLFSSL_MSG("buffer overrun");
+                    return WOLFSSL_FAILURE;
+                }
+                if (XSNPRINTF(val, valSz, "%02x", sig[i])
+                    >= valSz)
+                {
+                    WOLFSSL_MSG("buffer overrun");
+                    return WOLFSSL_FAILURE;
+                }
             }
             else {
-                XSNPRINTF(val, valSz - 1, ":%02x", sig[i]);
+                if (XSNPRINTF(val, valSz, ":%02x", sig[i])
+                    >= valSz)
+                {
+                    WOLFSSL_MSG("buffer overrun");
+                    return WOLFSSL_FAILURE;
+                }
             }
             XSTRNCAT(tmp, val, valSz);
         }
@@ -6278,8 +6462,13 @@ int wolfSSL_X509_signature_print(WOLFSSL_BIO *bp,
     for (i = 0; i < length; ++i) {
         char hex_digits[4];
 #ifdef XSNPRINTF
-        XSNPRINTF(hex_digits, sizeof(hex_digits), "%c%02X", i>0 ? ':' : ' ',
-                  (unsigned int)sigalg->algorithm->obj[idx+i]);
+        if (XSNPRINTF(hex_digits, sizeof(hex_digits), "%c%02X", i>0 ? ':' : ' ',
+                  (unsigned int)sigalg->algorithm->obj[idx+i])
+            >= (int)sizeof(hex_digits))
+        {
+            WOLFSSL_MSG("buffer overrun");
+            return WOLFSSL_FAILURE;
+        }
 #else
         XSPRINTF(hex_digits, "%c%02X", i>0 ? ':' : ' ',
                  (unsigned int)sigalg->algorithm->obj[idx+i]);
@@ -11422,11 +11611,21 @@ int wolfSSL_X509_NAME_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509_NAME* name,
         }
 
         if (i < count - 1) {
-            XSNPRINTF(tmp, tmpSz, "%s=%s,", buf, nameStr);
+            if (XSNPRINTF(tmp, tmpSz, "%s=%s,", buf, nameStr)
+                >= tmpSz)
+            {
+                WOLFSSL_MSG("buffer overrun");
+                return WOLFSSL_FAILURE;
+            }
             tmpSz = len + nameStrSz + 2; /* 2 for '=', comma */
         }
         else {
-            XSNPRINTF(tmp, tmpSz, "%s=%s", buf, nameStr);
+            if (XSNPRINTF(tmp, tmpSz, "%s=%s", buf, nameStr)
+                >= tmpSz)
+            {
+                WOLFSSL_MSG("buffer overrun");
+                return WOLFSSL_FAILURE;
+            }
             tmpSz = len + nameStrSz + 1; /* 1 for '=' */
             if (bio->type != WOLFSSL_BIO_FILE)
                 ++tmpSz; /* include the terminating null when not writing to a

--- a/tests/api.c
+++ b/tests/api.c
@@ -21804,20 +21804,20 @@ static int test_wc_curve25519_export_key_raw (void)
 
     if(0 != wc_InitRng(&rng)){
         printf(testingFmt, "failed due to wc_InitRng");
-        fflush( stdout );
+        fflush(stdout);
         return  1;
     }
 
     if(0 != wc_curve25519_init(&key)){
         printf(testingFmt, "failed due to wc_curve25519_init");
-        fflush( stdout );
+        fflush(stdout);
         wc_FreeRng(&rng);
         return  1;
     }
 
     if(0 != wc_curve25519_make_key(&rng, CURVE25519_KEYSIZE, &key)){
         printf(testingFmt, "failed due to wc_curve25519_make_key");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -21834,7 +21834,7 @@ static int test_wc_curve25519_export_key_raw (void)
             NULL , privateKey, &prvkSz, publicKey, &pubkSz)){
 
         printf(testingFmt,"failed at bad-arg-case-1.");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -21848,7 +21848,7 @@ static int test_wc_curve25519_export_key_raw (void)
             &key , NULL, &prvkSz, publicKey, &pubkSz)){
 
         printf(testingFmt,"failed at bad-arg-case-2.");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -21862,7 +21862,7 @@ static int test_wc_curve25519_export_key_raw (void)
             &key , privateKey, NULL, publicKey, &pubkSz)){
 
         printf(testingFmt,"failed at bad-arg-case-3.");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -21876,7 +21876,7 @@ static int test_wc_curve25519_export_key_raw (void)
             &key , privateKey, &prvkSz, NULL, &pubkSz)){
 
         printf(testingFmt,"failed at bad-arg-case-4.");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -21890,7 +21890,7 @@ static int test_wc_curve25519_export_key_raw (void)
             &key , privateKey, &prvkSz, publicKey, NULL )){
 
         printf(testingFmt,"failed at bad-arg-case-5.");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -21905,7 +21905,7 @@ static int test_wc_curve25519_export_key_raw (void)
     if( 0 != wc_curve25519_export_private_raw(&key, prik, &prksz)){
 
         printf(testingFmt,"failed due to wc_curve25519_export_private_raw");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -21917,7 +21917,7 @@ static int test_wc_curve25519_export_key_raw (void)
     if(0 != wc_curve25519_export_public(&key, pubk, &pbksz)){
 
         printf(testingFmt,"failed due to wc_curve25519_export_public");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -21931,7 +21931,7 @@ static int test_wc_curve25519_export_key_raw (void)
                                                      publicKey,  &pubkSz)){
 
         printf(testingFmt,"failed due to wc_curve25519_export_key_raw");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -21947,7 +21947,7 @@ static int test_wc_curve25519_export_key_raw (void)
             0 == XMEMCMP(publicKey,  pubk, CURVE25519_KEYSIZE)){
 
             printf(resultFmt,passed);
-            fflush( stdout );
+            fflush(stdout);
             wc_curve25519_free(&key);
             wc_FreeRng(&rng);
             return  0;
@@ -21956,7 +21956,7 @@ static int test_wc_curve25519_export_key_raw (void)
         else{
 
             printf(testingFmt,"failed due to key-contents-inconsistency.");
-            fflush( stdout );
+            fflush(stdout);
             wc_curve25519_free(&key);
             wc_FreeRng(&rng);
             return  1;
@@ -21965,14 +21965,14 @@ static int test_wc_curve25519_export_key_raw (void)
     else{
 
         printf(testingFmt,"failed due to bad-key-size.");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
     }
 
 #endif
-    fflush( stdout );
+    fflush(stdout);
 
     return 0;
 } /* end of test_wc_curve25519_export_key_raw */
@@ -22002,20 +22002,20 @@ static int test_wc_curve25519_export_key_raw_ex (void)
 
     if(0 != wc_InitRng(&rng)){
         printf(testingFmt, "failed due to wc_InitRng");
-        fflush( stdout );
+        fflush(stdout);
         return  1;
     }
 
     if(0 != wc_curve25519_init(&key)){
         printf(testingFmt, "failed due to wc_curve25519_init");
-        fflush( stdout );
+        fflush(stdout);
         wc_FreeRng(&rng);
         return  1;
     }
 
     if(0 != wc_curve25519_make_key(&rng, CURVE25519_KEYSIZE, &key)){
         printf(testingFmt, "failed due to wc_curve25519_make_key");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -22032,7 +22032,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
                      &prvkSz, publicKey, &pubkSz, EC25519_LITTLE_ENDIAN)){
 
         printf(testingFmt,"failed at bad-arg-case-1.");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -22046,7 +22046,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
                     &prvkSz, publicKey, &pubkSz, EC25519_LITTLE_ENDIAN)){
 
         printf(testingFmt,"failed at bad-arg-case-2.");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -22059,7 +22059,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
                             NULL,publicKey, &pubkSz,EC25519_LITTLE_ENDIAN)){
 
         printf(testingFmt,"failed at bad-arg-case-3.");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -22072,7 +22072,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
      &prvkSz, NULL, &pubkSz, EC25519_LITTLE_ENDIAN)){
 
         printf(testingFmt,"failed at bad-arg-case-4.");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -22085,7 +22085,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
      &prvkSz, publicKey, NULL, EC25519_LITTLE_ENDIAN)){
 
         printf(testingFmt,"failed at bad-arg-case-5.");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -22098,7 +22098,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
      &prvkSz, publicKey, &pubkSz, EC25519_BIG_ENDIAN)){
 
         printf(testingFmt,"failed at bad-arg-case-6.");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -22111,7 +22111,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
             publicKey, &pubkSz, EC25519_BIG_ENDIAN)){
 
         printf(testingFmt,"failed at bad-arg-case-7.");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -22124,7 +22124,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
                               NULL, publicKey, &pubkSz, EC25519_BIG_ENDIAN)){
 
         printf(testingFmt,"failed at bad-arg-case-8.");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -22137,7 +22137,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
     &prvkSz, NULL, &pubkSz, EC25519_BIG_ENDIAN)){
 
         printf(testingFmt,"failed at bad-arg-case-9.");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -22150,7 +22150,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
      &prvkSz, publicKey, NULL, EC25519_BIG_ENDIAN)){
 
         printf(testingFmt,"failed at bad-arg-case-10.");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -22165,7 +22165,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
      &prvkSz, publicKey, NULL, EC25519_BIG_ENDIAN + 10 )){
 
         printf(testingFmt,"failed at bad-arg-case-11.");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -22179,7 +22179,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
     if(0 != wc_curve25519_export_private_raw( &key, prik, &prksz )){
 
         printf(testingFmt,"failed due to wc_curve25519_export_private_raw");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -22190,7 +22190,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
     if(0 != wc_curve25519_export_public( &key, pubk, &pbksz )){
 
         printf(testingFmt,"failed due to wc_curve25519_export_public");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -22204,7 +22204,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
                     publicKey, &pubkSz, EC25519_BIG_ENDIAN)) {
 
         printf(testingFmt,"failed due to wc_curve25519_export_key_raw_ex");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -22229,7 +22229,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
                 else{
 
                     printf(testingFmt,"failed due to key-size-inconsistency");
-                    fflush( stdout );
+                    fflush(stdout);
                     wc_curve25519_free(&key);
                     wc_FreeRng(&rng);
                     return  1;
@@ -22239,7 +22239,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
 
                 printf(testingFmt,
                             "failed due to wc_curve25519_export_key_raw_ex");
-                fflush( stdout );
+                fflush(stdout);
                 wc_curve25519_free(&key);
                 wc_FreeRng(&rng);
                 return  1;
@@ -22249,7 +22249,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
         else{
 
             printf(testingFmt,"failed due to key-contents-inconsistency");
-            fflush( stdout );
+            fflush(stdout);
             wc_curve25519_free(&key);
             wc_FreeRng(&rng);
             return  1;
@@ -22259,7 +22259,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
     else{
 
         printf(testingFmt,"failed due to bad-key-size");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -22280,7 +22280,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
 
                 /* no more test*/
                 printf(resultFmt, passed );
-                fflush( stdout );
+                fflush(stdout);
                 wc_curve25519_free(&key);
                 wc_FreeRng(&rng);
                 return 0;
@@ -22288,7 +22288,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
         else{
 
             printf(testingFmt,"failed due to key-size-inconsistency");
-            fflush( stdout );
+            fflush(stdout);
             wc_curve25519_free(&key);
             wc_FreeRng(&rng);
             return  1;
@@ -22298,7 +22298,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
 
         printf(testingFmt,
                    "failed due to wc_curve25519_export_key_raw_ex(BIGENDIAN)");
-        fflush( stdout );
+        fflush(stdout);
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
@@ -22482,6 +22482,7 @@ static int test_wc_curve25519_shared_secret_ex(void)
 
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     wc_curve25519_free(&private_key);
     wc_curve25519_free(&public_key);
     wc_FreeRng(&rng);
@@ -22551,6 +22552,7 @@ static int test_wc_curve25519_make_pub(void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     wc_curve25519_free(&key);
     wc_FreeRng(&rng);
 #endif
@@ -22620,6 +22622,7 @@ static int test_wc_curve25519_export_public_ex (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     wc_curve25519_free(&key);
     wc_FreeRng(&rng);
 #endif
@@ -22712,6 +22715,7 @@ static int test_wc_curve25519_import_private_raw_ex (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     wc_curve25519_free(&key);
     wc_FreeRng(&rng);
 
@@ -22748,6 +22752,7 @@ static int test_wc_curve25519_import_private (void)
         ret = wc_curve25519_import_private(priv, privSz, &key);
     }
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     wc_curve25519_free(&key);
     wc_FreeRng(&rng);
 #endif
@@ -22811,6 +22816,7 @@ static int test_wc_curve25519_export_private_raw_ex (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     wc_curve25519_free(&key);
 #endif
     return ret;
@@ -22857,6 +22863,7 @@ static int test_wc_ed448_make_key (void)
 
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     if (wc_FreeRng(&rng) && ret == 0) {
         ret = WOLFSSL_FATAL_ERROR;
@@ -22895,6 +22902,7 @@ static int test_wc_ed448_init (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     wc_ed448_free(&key);
 
@@ -22964,6 +22972,7 @@ static int test_wc_ed448_sign_msg (void)
     } /* END sign */
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     #ifdef HAVE_ED448_VERIFY
         printf(testingFmt, "wc_ed448_verify_msg()");
 
@@ -23016,6 +23025,7 @@ static int test_wc_ed448_sign_msg (void)
         } /* END verify. */
 
         printf(resultFmt, ret == 0 ? passed : failed);
+        fflush(stdout);
     #endif /* Verify. */
 
     if (wc_FreeRng(&rng) && ret == 0) {
@@ -23079,6 +23089,7 @@ static int test_wc_ed448_import_public (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     if (wc_FreeRng(&rng) && ret == 0) {
         ret = WOLFSSL_FATAL_ERROR;
@@ -23180,6 +23191,7 @@ static int test_wc_ed448_import_private_key (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     if (wc_FreeRng(&rng) && ret == 0) {
         ret = WOLFSSL_FATAL_ERROR;
@@ -23246,6 +23258,7 @@ static int test_wc_ed448_export (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     printf(testingFmt, "wc_ed448_export_private_only()");
 
     if (ret == 0) {
@@ -23271,6 +23284,7 @@ static int test_wc_ed448_export (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     if (wc_FreeRng(&rng) && ret == 0) {
         ret = WOLFSSL_FATAL_ERROR;
@@ -23319,6 +23333,7 @@ static int test_wc_ed448_size (void)
         }
     }
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     if (ret == 0) {
         printf(testingFmt, "wc_ed448_sig_size()");
@@ -23336,6 +23351,7 @@ static int test_wc_ed448_size (void)
         }
 
         printf(resultFmt, ret == 0 ? passed : failed);
+        fflush(stdout);
     } /* END wc_ed448_sig_size() */
 
     if (ret == 0) {
@@ -23351,6 +23367,7 @@ static int test_wc_ed448_size (void)
             }
         }
         printf(resultFmt, ret == 0 ? passed : failed);
+        fflush(stdout);
     } /* END wc_ed448_pub_size */
 
     if (ret == 0) {
@@ -23366,6 +23383,7 @@ static int test_wc_ed448_size (void)
             }
         }
         printf(resultFmt, ret == 0 ? passed : failed);
+        fflush(stdout);
     } /* END wc_ed448_pub_size */
 
     if (wc_FreeRng(&rng) && ret == 0) {
@@ -23430,6 +23448,7 @@ static int test_wc_ed448_exportKey (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     if (ret == 0) {
         printf(testingFmt, "wc_ed448_export_key()");
@@ -23456,6 +23475,7 @@ static int test_wc_ed448_exportKey (void)
             }
         }
         printf(resultFmt, ret == 0 ? passed : failed);
+        fflush(stdout);
     } /* END wc_ed448_export_key() */
 
     /* Cross check output. */
@@ -23532,6 +23552,7 @@ static int test_wc_Ed448PublicKeyToDer (void)
         wc_ed448_free(&key);
     }
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 #endif
     return ret;
 
@@ -23562,6 +23583,7 @@ static int test_wc_curve448_init (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     /*  Test good args for wc_curve_448_free */
     wc_curve448_free(&key);
 
@@ -23634,6 +23656,7 @@ static int test_wc_curve448_make_key (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     wc_curve448_free(&key);
 #endif
     return ret;
@@ -23719,6 +23742,7 @@ static int test_wc_curve448_shared_secret_ex (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     wc_curve448_free(&private_key);
     wc_curve448_free(&public_key);
     wc_FreeRng(&rng);
@@ -23789,6 +23813,7 @@ static int test_wc_curve448_export_public_ex (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     wc_curve448_free(&key);
     wc_FreeRng(&rng);
 #endif
@@ -23852,6 +23877,7 @@ static int test_wc_curve448_export_private_raw_ex (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     wc_curve448_free(&key);
 #endif
     return ret;
@@ -23945,6 +23971,7 @@ static int test_wc_curve448_import_private_raw_ex (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     wc_curve448_free(&key);
 
 #endif
@@ -23985,6 +24012,7 @@ static int test_wc_curve448_export_key_raw (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     wc_curve448_free(&key);
     wc_FreeRng(&rng);
 #endif
@@ -24023,6 +24051,7 @@ static int test_wc_curve448_import_private (void)
         ret = wc_curve448_import_private(priv, privSz, &key);
     }
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     wc_curve448_free(&key);
     wc_FreeRng(&rng);
 #endif
@@ -24055,6 +24084,7 @@ static int test_wc_curve448_size (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     wc_curve448_free(&key);
 #endif
     return ret;
@@ -24109,6 +24139,7 @@ static int test_wc_ecc_make_key (void)
 #endif
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 #endif
 
     return ret;
@@ -24140,6 +24171,7 @@ static int test_wc_ecc_init (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     wc_ecc_free(&key);
 
@@ -24190,6 +24222,7 @@ static int test_wc_ecc_check_key (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     if (wc_FreeRng(&rng) && ret == 0) {
         ret = WOLFSSL_FATAL_ERROR;
@@ -24243,6 +24276,7 @@ static int test_wc_ecc_get_generator(void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     wc_ecc_del_point(pt);
 #endif
@@ -24291,6 +24325,7 @@ static int test_wc_ecc_size (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     if (wc_FreeRng(&rng) && ret == 0) {
         ret = WOLFSSL_FATAL_ERROR;
@@ -24572,6 +24607,7 @@ static int test_wc_ecc_shared_secret (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     if (wc_FreeRng(&rng) && ret == 0) {
         ret = WOLFSSL_FATAL_ERROR;
@@ -24643,6 +24679,7 @@ static int test_wc_ecc_export_x963 (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     if (wc_FreeRng(&rng) && ret == 0) {
         ret = WOLFSSL_FATAL_ERROR;
@@ -24756,6 +24793,7 @@ static int test_wc_ecc_export_x963_ex (void)
     #endif
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     if (wc_FreeRng(&rng) && ret == 0) {
         ret = WOLFSSL_FATAL_ERROR;
@@ -24832,6 +24870,7 @@ static int test_wc_ecc_import_x963 (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     if (wc_FreeRng(&rng) && ret == 0) {
         ret = WOLFSSL_FATAL_ERROR;
@@ -24915,6 +24954,7 @@ static int ecc_import_private_key (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     if (wc_FreeRng(&rng) && ret == 0) {
         ret = WOLFSSL_FATAL_ERROR;
@@ -24982,6 +25022,7 @@ static int test_wc_ecc_export_private_only (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     if (wc_FreeRng(&rng) && ret == 0) {
         ret = WOLFSSL_FATAL_ERROR;
@@ -25054,6 +25095,7 @@ static int test_wc_ecc_rs_to_sig (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     printf(testingFmt, "wc_ecc_sig_to_rs()");
     if (ret == 0) {
         ret = wc_ecc_sig_to_rs(sig, siglen, r, &rlen, s, &slen);
@@ -25081,6 +25123,7 @@ static int test_wc_ecc_rs_to_sig (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
 #endif
     return ret;
@@ -25153,6 +25196,7 @@ static int test_wc_ecc_import_raw(void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     wc_ecc_free(&key);
 
@@ -25227,6 +25271,7 @@ static int test_wc_ecc_import_unsigned(void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     wc_ecc_free(&key);
 
@@ -25272,6 +25317,7 @@ static int test_wc_ecc_sig_size (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     if (wc_FreeRng(&rng) && ret == 0) {
         ret = WOLFSSL_FATAL_ERROR;
@@ -25323,6 +25369,7 @@ static int test_wc_ecc_ctx_new (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     if (wc_FreeRng(&rng) && ret == 0) {
         ret = WOLFSSL_FATAL_ERROR;
@@ -25372,6 +25419,7 @@ static int test_wc_ecc_ctx_reset (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     if (wc_FreeRng(&rng) && ret == 0) {
         ret = WOLFSSL_FATAL_ERROR;
@@ -25424,6 +25472,7 @@ static int test_wc_ecc_ctx_set_peer_salt (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     printf(testingFmt, "wc_ecc_ctx_set_peer_salt()");
 
     if (ret == 0) {
@@ -25443,6 +25492,7 @@ static int test_wc_ecc_ctx_set_peer_salt (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     if (wc_FreeRng(&rng) && ret == 0) {
         ret = WOLFSSL_FATAL_ERROR;
@@ -25496,6 +25546,7 @@ static int test_wc_ecc_ctx_set_info (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     if (wc_FreeRng(&rng) && ret == 0) {
         ret = WOLFSSL_FATAL_ERROR;
@@ -25604,6 +25655,7 @@ static int test_wc_ecc_encryptDecrypt (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     printf(testingFmt, "wc_ecc_decrypt()");
 
 #ifdef WOLFSSL_ECIES_OLD
@@ -25652,6 +25704,7 @@ static int test_wc_ecc_encryptDecrypt (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     if (wc_FreeRng(&rng) && ret == 0) {
         ret = WOLFSSL_FATAL_ERROR;
@@ -25683,6 +25736,7 @@ static int test_wc_ecc_del_point (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     wc_ecc_del_point(pt);
 
@@ -25772,6 +25826,7 @@ static int test_wc_ecc_pointFns (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     /* Import */
     printf(testingFmt, "wc_ecc_import_point_der()");
@@ -25803,6 +25858,7 @@ static int test_wc_ecc_pointFns (void)
         }
     }
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     /* Copy */
     printf(testingFmt, "wc_ecc_copy_point()");
@@ -25824,6 +25880,7 @@ static int test_wc_ecc_pointFns (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     printf(testingFmt, "wc_ecc_cmp_point()");
     /* Compare point */
@@ -25843,6 +25900,7 @@ static int test_wc_ecc_pointFns (void)
         }
     }
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     printf(testingFmt, "wc_ecc_point_is_at_infinity()");
     /* At infinity if return == 1, otherwise return == 0. */
@@ -25860,6 +25918,7 @@ static int test_wc_ecc_pointFns (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
 #if !defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION>2))
 #ifdef USE_ECC_B_PARAM
@@ -25881,6 +25940,7 @@ static int test_wc_ecc_pointFns (void)
         }
     }
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 #endif /* USE_ECC_B_PARAM */
 #endif /* !HAVE_FIPS || HAVE_FIPS_VERSION > 2 */
 
@@ -25986,6 +26046,7 @@ static int test_wc_ecc_shared_secret_ssh (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     if (wc_FreeRng(&rng) && ret == 0) {
         ret = WOLFSSL_FATAL_ERROR;
@@ -26218,6 +26279,7 @@ static int test_wc_ecc_mulmod (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     wc_ecc_free(&key1);
     wc_ecc_free(&key2);
@@ -26281,6 +26343,7 @@ static int test_wc_ecc_is_valid_idx (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     if (wc_FreeRng(&rng) && ret == 0) {
         ret = WOLFSSL_FATAL_ERROR;
@@ -26328,6 +26391,7 @@ static int test_wc_ecc_get_curve_id_from_oid (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
 #endif
     return ret;
@@ -26362,7 +26426,8 @@ static int test_wc_ecc_sig_size_calc (void)
             ret = 0;
         }
     }
-     printf(resultFmt, ret == 0 ? passed : failed);
+    printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     wc_ecc_free(&key);
     wc_FreeRng(&rng);
 #endif
@@ -26415,6 +26480,7 @@ static int test_ToTraditional (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 #endif
     return ret;
 }/* End test_ToTraditional*/
@@ -26496,6 +26562,7 @@ static int test_wc_EccPrivateKeyToDer (void)
     wc_FreeRng(&rng);
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 #endif
     return ret;
 }/* End test_wc_EccPrivateKeyToDer*/
@@ -26603,6 +26670,7 @@ static int test_wc_Ed25519KeyToDer (void)
     wc_FreeRng(&rng);
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 #endif
     return ret;
 }/* End test_wc_Ed25519KeyToDer*/
@@ -26669,6 +26737,7 @@ static int test_wc_Ed25519PrivateKeyToDer (void)
     wc_FreeRng(&rng);
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 #endif
     return ret;
 }/* End test_wc_Ed25519PrivateKeyToDer*/
@@ -26734,6 +26803,7 @@ static int test_wc_Ed448KeyToDer (void)
     wc_FreeRng(&rng);
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 #endif
     return ret;
 }/* End test_wc_Ed448KeyToDer*/
@@ -26799,6 +26869,7 @@ static int test_wc_Ed448PrivateKeyToDer (void)
     wc_FreeRng(&rng);
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 #endif
     return ret;
 }/* End test_wc_Ed448PrivateKeyToDer*/
@@ -26847,6 +26918,7 @@ static int test_wc_SetSubjectBuffer (void)
     }
     XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 #endif
     return ret;
 }/* End test_wc_SetSubjectBuffer*/
@@ -26938,6 +27010,7 @@ static int test_wc_SetSubjectKeyIdFromPublicKey_ex (void)
 #endif
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     wc_FreeRng(&rng);
 #endif
@@ -27030,6 +27103,7 @@ static int test_wc_SetAuthKeyIdFromPublicKey_ex (void)
 #endif
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     wc_FreeRng(&rng);
 #endif /*defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_CERT_GEN)*/
@@ -29365,6 +29439,7 @@ static int test_wc_SignatureGetSize_ecc(void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     #endif /* NO_SIG_WRAPPER */
     return ret;
 }/* END test_wc_SignatureGetSize_ecc() */
@@ -29633,6 +29708,7 @@ static int test_wc_HashSetFlags(void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
 #endif
     return ret;
@@ -29735,6 +29811,7 @@ static int test_wc_HashGetFlags(void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
 #endif
     return ret;
@@ -32035,7 +32112,7 @@ static void test_wolfSSL_PEM_PUBKEY(void)
 
         file = XFOPEN(fname, "rb");
         AssertTrue((file != XBADFILE));
-        XFSEEK(file, 0, XSEEK_END);
+        AssertIntGE(XFSEEK(file, 0, XSEEK_END), 0);
         sz = XFTELL(file);
         XREWIND(file);
         AssertNotNull(buf = (byte*)XMALLOC(sz, NULL, DYNAMIC_TYPE_FILE));
@@ -38068,6 +38145,7 @@ static int test_WOLFSSL_ERROR_MSG (void)
     WOLFSSL_ERROR_MSG(msg);
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
 #endif
     return ret;
@@ -38085,6 +38163,7 @@ static int test_wc_ERR_remove_state (void)
     wc_ERR_remove_state();
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
 #endif
     return ret;
@@ -38120,6 +38199,7 @@ static int test_wc_ERR_print_errors_fp (void)
     #endif
 #endif
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     XFCLOSE(fp);
     (void)sz;
 #endif
@@ -38175,6 +38255,7 @@ static int test_wolfSSL_GetLoggingCb (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     return ret;
 }/*End test_wolfSSL_GetLoggingCb*/
@@ -46157,6 +46238,7 @@ static void test_wolfSSL_X509_cmp(void)
     ret = wolfSSL_X509_cmp(cert1, cert1);
     AssertIntEQ(0, wolfSSL_X509_cmp(cert1, cert1));
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 
     printf(testingFmt, "wolfSSL_X509_cmp() testing mismatched certs");
     ret = wolfSSL_X509_cmp(cert1, cert2);
@@ -49533,6 +49615,7 @@ static int test_get_rand_digit (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 #endif
     return ret;
 
@@ -49559,6 +49642,7 @@ static int test_get_digit_count (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     mp_clear(&a);
 #endif
     return ret;
@@ -49609,6 +49693,7 @@ static int test_mp_cond_copy (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     mp_clear(&a);
     mp_clear(&b);
 #endif
@@ -49658,6 +49743,7 @@ static int test_mp_rand (void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     mp_clear(&a);
     wc_FreeRng(&rng);
 #endif
@@ -49701,6 +49787,7 @@ static int test_get_digit (void)
 
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     mp_clear(&a);
 #endif
     return ret;
@@ -49760,6 +49847,7 @@ static int test_wc_export_int(void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
     mp_clear(&mp);
 #endif
     return ret;
@@ -49785,6 +49873,7 @@ static int test_wc_InitRngNonce(void)
     wc_FreeRng(&rng);
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 #endif
     return ret;
 }/* End test_wc_InitRngNonce*/
@@ -49810,6 +49899,7 @@ static int test_wc_InitRngNonce_ex(void)
     wc_FreeRng(&rng);
 
     printf(resultFmt, ret == 0 ? passed : failed);
+    fflush(stdout);
 #endif
     return ret;
 }/*End test_wc_InitRngNonce_ex*/
@@ -49889,6 +49979,7 @@ static void test_wolfSSL_X509_CRL(void)
 #endif
 
     printf(resultFmt, passed);
+    fflush(stdout);
 #endif
         return;
 }
@@ -51987,7 +52078,7 @@ static void test_wolfSSL_RSA_verify(void)
     /* read privete key file */
     fp = XFOPEN(svrKeyFile, "rb");
     AssertTrue((fp != XBADFILE));
-    XFSEEK(fp, 0, XSEEK_END);
+    AssertIntGE(XFSEEK(fp, 0, XSEEK_END), 0);
     sz = XFTELL(fp);
     XREWIND(fp);
     AssertNotNull(buf = (byte*)XMALLOC(sz, NULL, DYNAMIC_TYPE_FILE));
@@ -55638,6 +55729,7 @@ static void test_wolfSSL_DtlsUpdateWindow(void)
     DUW_TEST(152, 0xFFFFFFFF, next_hi, next_lo, window, 153, 0, 0, 0x01);
 
     printf(resultFmt, passed);
+    fflush(stdout);
 }
 #endif /* WOLFSSL_DTLS */
 
@@ -55651,6 +55743,7 @@ void ApiTest(void)
     AssertTrue(test_fileAccess());
 
     printf(" Begin API Tests\n");
+    fflush(stdout);
     AssertIntEQ(test_wolfSSL_Init(), WOLFSSL_SUCCESS);
     /* wolfcrypt initialization tests */
     test_wolfSSL_Method_Allocators();
@@ -56557,5 +56650,5 @@ void ApiTest(void)
     (void)devId;
 
     printf(" End API Tests\n");
-
+    fflush(stdout);
 }

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -494,7 +494,8 @@ static int execute_test_case(int svr_argc, char** svr_argv,
         if (cliArgs.argc + 2 > MAX_ARGS)
             printf("cannot add the magic port number flag to client\n");
         else {
-            snprintf(portNumber, sizeof(portNumber), "%d", (int)ready.port);
+            (void)snprintf(portNumber, sizeof(portNumber), "%d",
+                           (int)ready.port);
             cli_argv[cliArgs.argc++] = portFlag;
             cli_argv[cliArgs.argc++] = portNumber;
         }
@@ -633,15 +634,20 @@ static void test_harness(void* vargs)
         args->return_code = 1;
         return;
     }
-    fseek(file, 0, SEEK_END);
+    if (fseek(file, 0, SEEK_END) < 0) {
+        fprintf(stderr, "error %d fseeking %s\n", errno, fname);
+        fclose(file);
+        args->return_code = 1;
+        return;
+    }
     sz = ftell(file);
-    rewind(file);
     if (sz <= 0) {
         fprintf(stderr, "%s is empty\n", fname);
         fclose(file);
         args->return_code = 1;
         return;
     }
+    rewind(file);
 
     script = (char*)malloc(sz+1);
     if (script == 0) {

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -54,12 +54,13 @@ int unit_test(int argc, char** argv)
 #ifdef WOLFSSL_FORCE_MALLOC_FAIL_TEST
     if (argc > 1) {
         int memFailCount = atoi(argv[1]);
-        printf("\n--- SET RNG MALLOC FAIL AT %d---\n", memFailCount);
+        fprintf(stderr, "\n--- SET RNG MALLOC FAIL AT %d---\n", memFailCount);
         wolfSSL_SetMemFailCount(memFailCount);
     }
 #endif
 
     printf("starting unit tests...\n");
+    fflush(stdout);
 
 #if defined(DEBUG_WOLFSSL) && !defined(HAVE_VALGRIND)
     wolfSSL_Debugging_ON();
@@ -160,13 +161,13 @@ int unit_test(int argc, char** argv)
         ApiTest();
 
         if ( (ret = HashTest()) != 0){
-            printf("hash test failed with %d\n", ret);
+            fprintf(stderr, "hash test failed with %d\n", ret);
             goto exit;
         }
 
 #ifdef WOLFSSL_W64_WRAPPER
         if ((ret = w64wrapper_test()) != 0) {
-            printf("w64wrapper test failed with %d\n", ret);
+            fprintf(stderr, "w64wrapper test failed with %d\n", ret);
             goto exit;
         }
 #endif /* WOLFSSL_W64_WRAPPER */
@@ -177,7 +178,7 @@ int unit_test(int argc, char** argv)
 #if !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER)
 #ifndef SINGLE_THREADED
     if ( (ret = SuiteTest(argc, argv)) != 0){
-        printf("suite test failed with %d\n", ret);
+        fprintf(stderr, "suite test failed with %d\n", ret);
         goto exit;
     }
 #endif
@@ -192,6 +193,11 @@ exit:
         err_sys("Failed to free netRandom context");
 #endif /* HAVE_WNR */
 
+    if (ret == 0) {
+        puts("\nunit_test: Success for all configured tests.");
+        fflush(stdout);
+    }
+
     return ret;
 }
 
@@ -202,13 +208,14 @@ void wait_tcp_ready(func_args* args)
 #ifdef SINGLE_THREADED
     (void)args;
 #elif defined(_POSIX_THREADS) && !defined(__MINGW32__)
-    pthread_mutex_lock(&args->signal->mutex);
+    PTHREAD_CHECK_RET(pthread_mutex_lock(&args->signal->mutex));
 
     if (!args->signal->ready)
-        pthread_cond_wait(&args->signal->cond, &args->signal->mutex);
+        PTHREAD_CHECK_RET(pthread_cond_wait(&args->signal->cond,
+                                            &args->signal->mutex));
     args->signal->ready = 0; /* reset */
 
-    pthread_mutex_unlock(&args->signal->mutex);
+    PTHREAD_CHECK_RET(pthread_mutex_unlock(&args->signal->mutex));
 #else
     (void)args;
 #endif
@@ -222,7 +229,7 @@ void start_thread(THREAD_FUNC fun, func_args* args, THREAD_TYPE* thread)
     (void)args;
     (void)thread;
 #elif defined(_POSIX_THREADS) && !defined(__MINGW32__)
-    pthread_create(thread, 0, fun, args);
+    PTHREAD_CHECK_RET(pthread_create(thread, 0, fun, args));
     return;
 #elif defined (WOLFSSL_TIRTOS)
     /* Initialize the defaults and set the parameters. */
@@ -232,7 +239,7 @@ void start_thread(THREAD_FUNC fun, func_args* args, THREAD_TYPE* thread)
     taskParams.stackSize = 65535;
     *thread = Task_create((Task_FuncPtr)fun, &taskParams, NULL);
     if (*thread == NULL) {
-        printf("Failed to create new Task\n");
+        fprintf(stderr, "Failed to create new Task\n");
     }
     Task_yield();
 #else
@@ -246,7 +253,7 @@ void join_thread(THREAD_TYPE thread)
 #ifdef SINGLE_THREADED
     (void)thread;
 #elif defined(_POSIX_THREADS) && !defined(__MINGW32__)
-    pthread_join(thread, 0);
+    PTHREAD_CHECK_RET(pthread_join(thread, 0));
 #elif defined (WOLFSSL_TIRTOS)
     while(1) {
         if (Task_getMode(thread) == Task_Mode_TERMINATED) {

--- a/tests/unit.h
+++ b/tests/unit.h
@@ -35,15 +35,17 @@
 #ifndef WOLFSSL_PASSTHRU_ERR
 #define Fail(description, result) do {                                         \
     printf("\nERROR - %s line %d failed with:", __FILE__, __LINE__);           \
-    printf("\n    expected: "); printf description;                            \
-    printf("\n    result:   "); printf result; printf("\n\n");                 \
+    fputs("\n    expected: ", stdout); printf description;                     \
+    fputs("\n    result:   ", stdout); printf result; fputs("\n\n", stdout);   \
+    fflush(stdout);                                                            \
     XABORT();                                                                  \
 } while(0)
 #else
-#define Fail(description, result) do {                               \
-    printf("\nERROR - %s line %d failed with:", __FILE__, __LINE__); \
-    printf("\n    expected: ");printf description;                   \
-    printf("\n    result:   "); printf result; printf("\n\n");       \
+#define Fail(description, result) do {                                         \
+    printf("\nERROR - %s line %d failed with:", __FILE__, __LINE__);           \
+    fputs("\n    expected: ", stdout); printf description;                     \
+    fputs("\n    result:   ", stdout); printf result; fputs("\n\n", stdout);   \
+    fflush(stdout);                                                            \
 } while (0)
 #endif
 
@@ -90,9 +92,17 @@
 #define AssertStrLE(x, y) AssertStr(x, y, <=,  >)
 
 #define AssertPtr(x, y, op, er) do {                                           \
+    PRAGMA_GCC_DIAG_PUSH;                                                      \
+      /* remarkably, without this inhibition, */                               \
+      /* the _Pragma()s make the declarations warn. */                         \
+    PRAGMA_GCC("GCC diagnostic ignored \"-Wdeclaration-after-statement\"");    \
+      /* inhibit "ISO C forbids conversion of function pointer */              \
+      /* to object pointer type [-Werror=pedantic]" */                         \
+    PRAGMA_GCC("GCC diagnostic ignored \"-Wpedantic\"");                       \
     void* _x = (void*)(x);                                                     \
     void* _y = (void*)(y);                                                     \
     Assert(_x op _y, ("%s " #op " %s", #x, #y), ("%p " #er " %p", _x, _y));    \
+    PRAGMA_GCC_DIAG_POP;                                                       \
 } while(0)
 
 #define AssertPtrEq(x, y) AssertPtr(x, y, ==, !=)

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -402,7 +402,7 @@ static void simple_test(func_args* args)
 #ifndef USE_WINDOWS_API
     cliArgs.argc = NUMARGS;
     XSTRLCPY(argvc[1], "-p", sizeof(argvc[1]));
-    snprintf(argvc[2], sizeof(argvc[2]), "%d", (int)svrArgs.signal->port);
+    (void)snprintf(argvc[2], sizeof(argvc[2]), "%d", (int)svrArgs.signal->port);
 #else
     cliArgs.argc = 1;
 #endif
@@ -432,13 +432,14 @@ static void simple_test(func_args* args)
 void wait_tcp_ready(func_args* args)
 {
 #if defined(_POSIX_THREADS) && !defined(__MINGW32__)
-    pthread_mutex_lock(&args->signal->mutex);
+    PTHREAD_CHECK_RET(pthread_mutex_lock(&args->signal->mutex));
 
     if (!args->signal->ready)
-        pthread_cond_wait(&args->signal->cond, &args->signal->mutex);
+        PTHREAD_CHECK_RET(pthread_cond_wait(&args->signal->cond,
+                                            &args->signal->mutex));
     args->signal->ready = 0; /* reset */
 
-    pthread_mutex_unlock(&args->signal->mutex);
+    PTHREAD_CHECK_RET(pthread_mutex_unlock(&args->signal->mutex));
 #elif defined(NETOS)
     (void)tx_mutex_get(&args->signal->mutex, TX_WAIT_FOREVER);
 
@@ -464,7 +465,7 @@ void wait_tcp_ready(func_args* args)
 void start_thread(THREAD_FUNC fun, func_args* args, THREAD_TYPE* thread)
 {
 #if defined(_POSIX_THREADS) && !defined(__MINGW32__)
-    pthread_create(thread, 0, fun, args);
+    PTHREAD_CHECK_RET(pthread_create(thread, 0, fun, args));
     return;
 #elif defined(WOLFSSL_TIRTOS)
     /* Initialize the defaults and set the parameters. */
@@ -533,7 +534,7 @@ void start_thread(THREAD_FUNC fun, func_args* args, THREAD_TYPE* thread)
 void join_thread(THREAD_TYPE thread)
 {
 #if defined(_POSIX_THREADS) && !defined(__MINGW32__)
-    pthread_join(thread, 0);
+    PTHREAD_CHECK_RET(pthread_join(thread, 0));
 #elif defined(WOLFSSL_TIRTOS)
     while(1) {
         if (Task_getMode(thread) == Task_Mode_TERMINATED) {

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -38,6 +38,7 @@
 
 #ifdef HAVE_PTHREAD
     #include <pthread.h>
+    #include <errno.h>
 #endif
 
 /* Macro to disable benchmark */
@@ -313,6 +314,31 @@
 #ifndef EXIT_FAILURE
 #define EXIT_FAILURE 1
 #endif
+
+#undef LIBCALL_CHECK_RET
+#if defined(NO_STDIO_FILESYSTEM) || defined(NO_ERROR_STRINGS)
+#define LIBCALL_CHECK_RET(...) __VA_ARGS__
+#else
+#define LIBCALL_CHECK_RET(...) do {                           \
+        int _libcall_ret = (__VA_ARGS__);                     \
+        if (_libcall_ret < 0) {                               \
+            fprintf(stderr, "%s L%d error %d for \"%s\"\n",   \
+                    __FILE__, __LINE__, errno, #__VA_ARGS__); \
+            _exit(1);                                         \
+        }                                                     \
+    } while(0)
+#endif
+
+#undef PTHREAD_CHECK_RET
+#define PTHREAD_CHECK_RET(...) do {                                  \
+        int _pthread_ret = (__VA_ARGS__);                            \
+        if (_pthread_ret != 0) {                                     \
+            errno = _pthread_ret;                                    \
+            fprintf(stderr, "%s L%d error %d for \"%s\"\n",          \
+                    __FILE__, __LINE__, _pthread_ret, #__VA_ARGS__); \
+            _exit(1);                                                \
+        }                                                            \
+    } while(0)
 
 /* optional macro to add sleep between tests */
 #ifndef TEST_SLEEP
@@ -854,11 +880,11 @@ static const char* bench_desc_words[][14] = {
     #define END_INTEL_CYCLES   total_cycles = get_intel_cycles() - total_cycles;
     /* s == size in bytes that 1 count represents, normally BENCH_SIZE */
     #define SHOW_INTEL_CYCLES(b, n, s) \
-        XSNPRINTF((b) + XSTRLEN(b), (n) - XSTRLEN(b), " %s = %6.2f\n", \
+        (void)XSNPRINTF((b) + XSTRLEN(b), (n) - XSTRLEN(b), " %s = %6.2f\n", \
             bench_result_words1[lng_index][2], \
             count == 0 ? 0 : (float)total_cycles / ((word64)count*(s)))
     #define SHOW_INTEL_CYCLES_CSV(b, n, s) \
-        XSNPRINTF((b) + XSTRLEN(b), (n) - XSTRLEN(b), "%.2f,\n", \
+        (void)XSNPRINTF((b) + XSTRLEN(b), (n) - XSTRLEN(b), "%.2f,\n", \
             count == 0 ? 0 : (float)total_cycles / ((word64)count*(s)))
 #elif defined(LINUX_CYCLE_COUNT)
     #include <linux/perf_event.h>
@@ -884,11 +910,11 @@ static const char* bench_desc_words[][14] = {
 
     /* s == size in bytes that 1 count represents, normally BENCH_SIZE */
     #define SHOW_INTEL_CYCLES(b, n, s) \
-        XSNPRINTF(b + XSTRLEN(b), n - XSTRLEN(b), " %s = %6.2f\n", \
+        (void)XSNPRINTF(b + XSTRLEN(b), n - XSTRLEN(b), " %s = %6.2f\n", \
         bench_result_words1[lng_index][2], \
             (float)total_cycles / (count*s))
     #define SHOW_INTEL_CYCLES_CSV(b, n, s) \
-        XSNPRINTF(b + XSTRLEN(b), n - XSTRLEN(b), "%.2f,\n", \
+        (void)XSNPRINTF(b + XSTRLEN(b), n - XSTRLEN(b), "%.2f,\n", \
             (float)total_cycles / (count*s))
 
 #elif defined(SYNERGY_CYCLE_COUNT)
@@ -902,11 +928,11 @@ static const char* bench_desc_words[][14] = {
 
     /* s == size in bytes that 1 count represents, normally BENCH_SIZE */
     #define SHOW_INTEL_CYCLES(b, n, s) \
-        XSNPRINTF(b + XSTRLEN(b), n - XSTRLEN(b), " %s = %6.2f\n", \
+        (void)XSNPRINTF(b + XSTRLEN(b), n - XSTRLEN(b), " %s = %6.2f\n", \
         bench_result_words1[lng_index][2], \
             (float)total_cycles / (count*s))
     #define SHOW_INTEL_CYCLES_CSV(b, n, s) \
-        XSNPRINTF(b + XSTRLEN(b), n - XSTRLEN(b), "%.2f,\n", \
+        (void)XSNPRINTF(b + XSTRLEN(b), n - XSTRLEN(b), "%.2f,\n", \
             (float)total_cycles / (count*s))
 
 #else
@@ -1305,7 +1331,7 @@ typedef enum bench_stat_type {
         bench_stats_t* bstat = NULL;
 
         /* protect bench_stats_head and bench_stats_tail access */
-        pthread_mutex_lock(&bench_lock);
+        PTHREAD_CHECK_RET(pthread_mutex_lock(&bench_lock));
 
         if (algo != NULL) {
             /* locate existing in list */
@@ -1352,7 +1378,7 @@ typedef enum bench_stat_type {
             if (bstat->lastRet > ret)
                 bstat->lastRet = ret; /* track last error */
         }
-        pthread_mutex_unlock(&bench_lock);
+        PTHREAD_CHECK_RET(pthread_mutex_unlock(&bench_lock));
 
         return bstat;
     }
@@ -1362,7 +1388,7 @@ typedef enum bench_stat_type {
         bench_stats_t* bstat;
 
         /* protect bench_stats_head and bench_stats_tail access */
-        pthread_mutex_lock(&bench_lock);
+        PTHREAD_CHECK_RET(pthread_mutex_lock(&bench_lock));
 
         for (bstat = bench_stats_head; bstat != NULL; ) {
             if (bstat->type == BENCH_STAT_SYM) {
@@ -1379,7 +1405,7 @@ typedef enum bench_stat_type {
             bstat = bstat->next;
         }
 
-        pthread_mutex_unlock(&bench_lock);
+        PTHREAD_CHECK_RET(pthread_mutex_unlock(&bench_lock));
     }
 
 #else /* !WC_ENABLE_BENCH_THREADING */
@@ -1513,12 +1539,12 @@ static void bench_stats_sym_finish(const char* desc, int useDeviceID, int count,
 
     /* format and print to terminal */
     if (csv_format == 1) {
-        XSNPRINTF(msg, sizeof(msg), "%s,%.3f,", desc, persec);
+        (void)XSNPRINTF(msg, sizeof(msg), "%s,%.3f,", desc, persec);
         SHOW_INTEL_CYCLES_CSV(msg, sizeof(msg), countSz);
     } else {
-        XSNPRINTF(msg, sizeof(msg), "%-16s%s %5.0f %s %s %5.3f %s, %8.3f %s/s",
-        desc, BENCH_ASYNC_GET_NAME(useDeviceID), blocks, blockType, word[0],
-            total, word[1], persec, blockType);
+        (void)XSNPRINTF(msg, sizeof(msg), "%-16s%s %5.0f %s %s %5.3f %s, %8.3f %s/s",
+                 desc, BENCH_ASYNC_GET_NAME(useDeviceID), blocks, blockType, word[0],
+                 total, word[1], persec, blockType);
         SHOW_INTEL_CYCLES(msg, sizeof(msg), countSz);
     }
     printf("%s", msg);
@@ -1564,9 +1590,9 @@ static void bench_stats_asym_finish(const char* algo, int strength,
             printf("Algorithm,avg ms,ops/sec,\n");
             csv_header_count++;
         }
-        XSNPRINTF(msg, sizeof(msg), "%s %d %s,%.3f,%.3f,\n", algo, strength, desc, milliEach, opsSec);
+        (void)XSNPRINTF(msg, sizeof(msg), "%s %d %s,%.3f,%.3f,\n", algo, strength, desc, milliEach, opsSec);
     } else {
-        XSNPRINTF(msg, sizeof(msg), "%-6s %5d %-9s %s %6d %s %5.3f %s, %s %5.3f ms,"
+        (void)XSNPRINTF(msg, sizeof(msg), "%-6s %5d %-9s %s %6d %s %5.3f %s, %s %5.3f ms,"
         " %.3f %s\n", algo, strength, desc, BENCH_ASYNC_GET_NAME(useDeviceID),
         count, word[0], total, word[1], word[2], milliEach, opsSec, word[3]);
     }
@@ -1610,9 +1636,9 @@ static void bench_stats_pq_asym_finish(const char* algo, int useDeviceID, int co
             printf("Algorithm,avg ms,ops/sec,\n");
             csv_header_count++;
         }
-        XSNPRINTF(msg, sizeof(msg), "%s %.3f,%.3f,\n", algo, milliEach, opsSec);
+        (void)XSNPRINTF(msg, sizeof(msg), "%s %.3f,%.3f,\n", algo, milliEach, opsSec);
     } else {
-         XSNPRINTF(msg, sizeof(msg), "%-18s %s %6d %s %5.3f %s, %s %5.3f ms,"
+         (void)XSNPRINTF(msg, sizeof(msg), "%-18s %s %6d %s %5.3f %s, %s %5.3f ms,"
          " %.3f %s\n", algo, BENCH_ASYNC_GET_NAME(useDeviceID),
          count, word[0], total, word[1], word[2], milliEach, opsSec, word[3]);
     }
@@ -2490,11 +2516,11 @@ static int benchmark_test_threaded(void* args)
     }
 
     for (i = 0; i < g_threadCount; i++) {
-        pthread_create(&g_threadData[i].thread_id, NULL, run_bench, args);
+        PTHREAD_CHECK_RET(pthread_create(&g_threadData[i].thread_id, NULL, run_bench, args));
     }
 
     for (i = 0; i < g_threadCount; i++) {
-        pthread_join(g_threadData[i].thread_id, 0);
+        PTHREAD_CHECK_RET(pthread_join(g_threadData[i].thread_id, 0));
     }
 
     printf("\n");
@@ -5890,7 +5916,7 @@ void bench_eccMakeKey(int useDeviceID, int curveId)
         count += times;
     } while (bench_stats_sym_check(start));
 exit:
-    XSNPRINTF(name, BENCH_ECC_NAME_SZ, "ECC   [%15s]",
+    (void)XSNPRINTF(name, BENCH_ECC_NAME_SZ, "ECC   [%15s]",
             wc_ecc_get_name(curveId));
     bench_stats_asym_finish(name, keySize * 8, desc[2], useDeviceID, count, start,
             ret);
@@ -6010,7 +6036,7 @@ void bench_ecc(int useDeviceID, int curveId)
     } while (bench_stats_sym_check(start));
     PRIVATE_KEY_UNLOCK();
 exit_ecdhe:
-    XSNPRINTF(name, BENCH_ECC_NAME_SZ, "ECDHE [%15s]", wc_ecc_get_name(curveId));
+    (void)XSNPRINTF(name, BENCH_ECC_NAME_SZ, "ECDHE [%15s]", wc_ecc_get_name(curveId));
 
     bench_stats_asym_finish(name, keySize * 8, desc[3], useDeviceID, count, start,
             ret);
@@ -6054,7 +6080,7 @@ exit_ecdhe:
         count += times;
     } while (bench_stats_sym_check(start));
 exit_ecdsa_sign:
-    XSNPRINTF(name, BENCH_ECC_NAME_SZ, "ECDSA [%15s]", wc_ecc_get_name(curveId));
+    (void)XSNPRINTF(name, BENCH_ECC_NAME_SZ, "ECDSA [%15s]", wc_ecc_get_name(curveId));
 
     bench_stats_asym_finish(name, keySize * 8, desc[4], useDeviceID, count, start,
             ret);
@@ -6090,7 +6116,7 @@ exit_ecdsa_sign:
         count += times;
     } while (bench_stats_sym_check(start));
 exit_ecdsa_verify:
-    XSNPRINTF(name, BENCH_ECC_NAME_SZ, "ECDSA [%15s]", wc_ecc_get_name(curveId));
+    (void)XSNPRINTF(name, BENCH_ECC_NAME_SZ, "ECDSA [%15s]", wc_ecc_get_name(curveId));
 
     bench_stats_asym_finish(name, keySize * 8, desc[5], useDeviceID, count, start,
             ret);
@@ -6197,7 +6223,7 @@ void bench_eccEncrypt(int curveId)
         count += i;
     } while (bench_stats_sym_check(start));
 exit_enc:
-    XSNPRINTF(name, BENCH_ECC_NAME_SZ, "ECC   [%15s]", wc_ecc_get_name(curveId));
+    (void)XSNPRINTF(name, BENCH_ECC_NAME_SZ, "ECC   [%15s]", wc_ecc_get_name(curveId));
     bench_stats_asym_finish(name, keySize * 8, desc[6], 0, count, start, ret);
 
     bench_stats_start(&count, &start);
@@ -7477,7 +7503,7 @@ void bench_falconKeySign(byte level)
 
         (void)reset;
 
-        gettimeofday(&tv, 0);
+        LIBCALL_CHECK_RET(gettimeofday(&tv, 0));
 
         return (double)tv.tv_sec + (double)tv.tv_usec / 1000000;
     }

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -38,7 +38,11 @@
 
 #ifdef HAVE_PTHREAD
     #include <pthread.h>
+#endif
+#if defined(HAVE_PTHREAD) || \
+        (!defined(NO_STDIO_FILESYSTEM) && !defined(NO_ERROR_STRINGS))
     #include <errno.h>
+    #include <unistd.h>
 #endif
 
 /* Macro to disable benchmark */

--- a/wolfcrypt/src/error.c
+++ b/wolfcrypt/src/error.c
@@ -567,6 +567,12 @@ const char* wc_GetErrorString(int error)
     case NO_VALID_DEVID:
         return "No valid device ID set";
 
+    case IO_FAILED_E:
+        return "Input/output failure";
+
+    case SYSLIB_FAILED_E:
+        return "System/library call failed";
+
     default:
         return "unknown error number";
 

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -502,7 +502,7 @@ void WOLFSSL_ERROR(int error)
 
         if (wc_LockMutex(&debug_mutex) != 0) {
             WOLFSSL_MSG("Lock debug mutex failed");
-            XSNPRINTF(buffer, sizeof(buffer),
+            (void)XSNPRINTF(buffer, sizeof(buffer),
                     "wolfSSL error occurred, error = %d", error);
         }
         else {
@@ -513,7 +513,7 @@ void WOLFSSL_ERROR(int error)
             #endif
             if (error < 0)
                 error = error - (2 * error); /* get absolute value */
-            XSNPRINTF(buffer, sizeof(buffer),
+            (void)XSNPRINTF(buffer, sizeof(buffer),
                     "wolfSSL error occurred, error = %d line:%u file:%s",
                     error, line, file);
 
@@ -525,7 +525,7 @@ void WOLFSSL_ERROR(int error)
             #if defined(OPENSSL_EXTRA) && !defined(WOLFCRYPT_ONLY)
             }
             else {
-                XSNPRINTF(buffer, sizeof(buffer),
+                (void)XSNPRINTF(buffer, sizeof(buffer),
                     "wolfSSL error occurred, error = %d", error);
             }
             #endif
@@ -533,7 +533,7 @@ void WOLFSSL_ERROR(int error)
             wc_UnLockMutex(&debug_mutex);
         }
     #else
-        XSNPRINTF(buffer, sizeof(buffer),
+        (void)XSNPRINTF(buffer, sizeof(buffer),
                 "wolfSSL error occurred, error = %d", error);
     #endif
 
@@ -929,7 +929,8 @@ int wc_ERR_remove_state(void)
 static int wc_ERR_dump_to_file (const char *str, size_t len, void *u)
 {
     XFILE fp = (XFILE ) u;
-    fprintf(fp, "%-*.*s\n", (int)len, (int)len, str);
+    if (fprintf(fp, "%-*.*s\n", (int)len, (int)len, str) < 0)
+        return IO_FAILED_E;
     return 0;
 }
 

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -6605,11 +6605,11 @@ int sp_addmod_ct(sp_int* a, sp_int* b, sp_int* m, sp_int* r)
     }
 
     if (err == MP_OKAY) {
-        if (0) {
-            sp_print(a, "a");
-            sp_print(b, "b");
-            sp_print(m, "m");
-        }
+#if 0
+        sp_print(a, "a");
+        sp_print(b, "b");
+        sp_print(m, "m");
+#endif
 
         /* Add a to b into r. Do the subtract of modulus but don't store result.
          * When subtract result is negative, the overflow will be negative.
@@ -6694,9 +6694,9 @@ int sp_addmod_ct(sp_int* a, sp_int* b, sp_int* m, sp_int* r)
     #endif /* WOLFSSL_SP_INT_NEGATIVE */
         sp_clamp(r);
 
-        if (0) {
-            sp_print(r, "rma");
-        }
+#if 0
+        sp_print(r, "rma");
+#endif
     }
 
     return err;
@@ -6740,11 +6740,11 @@ int sp_submod_ct(sp_int* a, sp_int* b, sp_int* m, sp_int* r)
     }
 
     if (err == MP_OKAY) {
-        if (0) {
-            sp_print(a, "a");
-            sp_print(b, "b");
-            sp_print(m, "m");
-        }
+#if 0
+        sp_print(a, "a");
+        sp_print(b, "b");
+        sp_print(m, "m");
+#endif
 
         /* In constant time, subtract b from a putting result in r. */
     #ifndef SQR_MUL_ASM
@@ -6809,9 +6809,9 @@ int sp_submod_ct(sp_int* a, sp_int* b, sp_int* m, sp_int* r)
     #endif /* WOLFSSL_SP_INT_NEGATIVE */
         sp_clamp(r);
 
-        if (0) {
-            sp_print(r, "rms");
-        }
+#if 0
+        sp_print(r, "rms");
+#endif
     }
 
     return err;
@@ -11117,11 +11117,11 @@ static int _sp_exptmod_base_2(sp_int* e, int digits, sp_int* m, sp_int* r)
     sp_int_digit mp = 0, n = 0;
     DECL_SP_INT_ARRAY(d, m->used * 2 + 1, 2);
 
-    if (0) {
-        sp_print_int(2, "a");
-        sp_print(e, "b");
-        sp_print(m, "m");
-    }
+#if 0
+    sp_print_int(2, "a");
+    sp_print(e, "b");
+    sp_print(m, "m");
+#endif
 
     ALLOC_SP_INT_ARRAY(d, m->used * 2 + 1, 2, err, NULL);
     if (err == MP_OKAY) {
@@ -11240,9 +11240,9 @@ static int _sp_exptmod_base_2(sp_int* e, int digits, sp_int* m, sp_int* r)
         err = sp_copy(tr, r);
     }
 
-    if (0) {
-        sp_print(r, "rme");
-    }
+#if 0
+    sp_print(r, "rme");
+#endif
 
     FREE_SP_INT_ARRAY(d, NULL);
     return err;
@@ -11995,14 +11995,14 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
     }
 
     if (err == MP_OKAY) {
-        if (0) {
-            sp_print(a, "a");
-            sp_print_int(e, "n");
-        }
+#if 0
+        sp_print(a, "a");
+        sp_print_int(e, "n");
+#endif
         err = sp_lshb(r, e);
-        if (0) {
-            sp_print(r, "rsl");
-        }
+#if 0
+        sp_print(r, "rsl");
+#endif
     }
 
     return err;
@@ -14495,10 +14495,10 @@ static int _sp_mont_red(sp_int* a, sp_int* m, sp_int_digit mp)
     sp_int_word w;
     sp_int_digit mu;
 
-    if (0) {
-        sp_print(a, "a");
-        sp_print(m, "m");
-    }
+#if 0
+    sp_print(a, "a");
+    sp_print(m, "m");
+#endif
 
     bits = sp_count_bits(m);
 
@@ -14563,9 +14563,9 @@ static int _sp_mont_red(sp_int* a, sp_int* m, sp_int_digit mp)
         _sp_sub_off(a, m, a, 0);
     }
 
-    if (0) {
-        sp_print(a, "rr");
-    }
+#if 0
+    sp_print(a, "rr");
+#endif
 
     return MP_OKAY;
 #else /* !SQR_MUL_ASM */

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -854,7 +854,8 @@ void wc_ReadDirClose(ReadDirCtx* ctx)
     }
 #else
     if (ctx->dir) {
-        closedir(ctx->dir);
+        if (closedir(ctx->dir) < 0)
+            WOLFSSL_MSG("closedir() failed");
         ctx->dir = NULL;
     }
 #endif

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -204,6 +204,11 @@
         #undef  printf
         #define printf XPRINTF
     #elif !defined(printf)
+        /* arrange for printf() to flush after every message -- this assures
+         * redirected output (to a log file) records progress right up to the
+         * moment of a crash/abort(); otherwise anything queued in stdout would
+         * be lost.
+         */
         #define printf(...) ( printf(__VA_ARGS__), fflush(stdout) )
     #endif
 #endif

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -203,6 +203,8 @@
     #ifdef XPRINTF
         #undef  printf
         #define printf XPRINTF
+    #elif !defined(printf)
+        #define printf(...) ( printf(__VA_ARGS__), fflush(stdout) )
     #endif
 #endif
 
@@ -35028,7 +35030,7 @@ static int pkcs7signed_run_vectors(
                 #if defined(WOLF_C89)
                     XSPRINTF((char*)&transId[k], "%02x", digest[j]);
                 #else
-                    XSNPRINTF((char*)&transId[k], 3, "%02x", digest[j]);
+                    (void)XSNPRINTF((char*)&transId[k], 3, "%02x", digest[j]);
                 #endif
             }
         }

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -250,7 +250,10 @@ enum {
     AES_SIV_AUTH_E = -289, /* AES-SIV authentication failed */
     NO_VALID_DEVID = -290, /* no valid device ID */
 
-    WC_LAST_E           = -290,  /* Update this to indicate last error */
+    IO_FAILED_E = -291,          /* Input/output failure */
+    SYSLIB_FAILED_E = -292,      /* System/library call failed */
+
+    WC_LAST_E           = -292,  /* Update this to indicate last error */
     MIN_CODE_E          = -300   /* errors -101 - -299 */
 
     /* add new companion error id strings for any new error codes


### PR DESCRIPTION
global fixup to check or explicitly ignore return values from failable library/system calls that weren't already being checked;

add wolfCrypt error codes `IO_FAILED_E` "Input/output failure" and `SYSLIB_FAILED_E` "System/library call failed";

tests/api.c and tests/unit.c: flush `stdout` for error message in `Fail()` macro, add `fflush(stdout)` after `printf()`s, print success message at end of `unit_test()`, and send several error messages to `stderr` instead of `stdout`;

wolfcrypt/test/test.c: add fallthrough macro definition of `printf()` that pairs it with `fflush(stdout)`;

unit.h: in definition of macro `AssertPtr()`, add `PRAGMA_GCC("GCC diagnostic ignored \"-Wpedantic\"")`;

sp_int.c: refactor several lingering instances of "`if (0) { ... }`" code pattern to `#if 0 ... #endif`.


tested with full run of wolfssl-multi-test.sh with new `CLANG_TIDY_CONFIG` section
```
{key: bugprone-unused-return-value.CheckedFunctions, value: pthread_cond_wait;pthread_attr_destroy;pthread_attr_init;pthread_attr_setdetachstate;pthread_attr_setinheritsched;pthread_attr_setschedparam;pthread_attr_setschedpolicy;pthread_attr_setscope;pthread_attr_setstack;pthread_cancel;pthread_cond_destroy;pthread_cond_init;pthread_cond_signal;pthread_cond_wait;pthread_create;pthread_detach;pthread_getschedparam;pthread_getspecific;pthread_join;pthread_key_create;pthread_mach_thread_np;pthread_mutex_destroy;pthread_mutex_init;pthread_mutex_lock;pthread_mutex_unlock;pthread_setaffinity_np;pthread_setschedparam;pthread_setspecific;snprintf;vsnprintf;gettimeofday;clock_gettime;bind;closedir;connect;fcntl;fgets;fputc;fread;fseek;fwrite;getaddrinfo;getpeername;gmtime_r;inet_pton;inotify_rm_watch;listen;read;realloc;recvfrom;recv;select;send;sendto;setsockopt;stat;write}
```
