### PR TITLE
Fix for build with NO_TLS

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -6544,7 +6544,7 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
 #ifndef WOLFSSL_AEAD_ONLY
     #ifndef NO_OLD_TLS
         ssl->hmac = SSL_hmac; /* default to SSLv3 */
-    #elif !defined(WOLFSSL_NO_TLS12)
+    #elif !defined(WOLFSSL_NO_TLS12) && !defined(NO_TLS)
       #if !defined(WOLFSSL_RENESAS_SCEPROTECT) && \
           !defined(WOLFSSL_RENESAS_TSIP_TLS)
         ssl->hmac = TLS_hmac;
@@ -10185,6 +10185,9 @@ static int BuildFinished(WOLFSSL* ssl, Hashes* hashes, const byte* sender)
     if (ssl->options.tls) {
         ret = BuildTlsFinished(ssl, hashes, sender);
     }
+#else
+    (void)hashes;
+    (void)sender;
 #endif
 #ifndef NO_OLD_TLS
     if (!ssl->options.tls) {
@@ -17311,6 +17314,8 @@ static WC_INLINE int GetRounds(int pLen, int padLen, int t)
     return ret;
 }
 #else
+
+#if !defined(WOLFSSL_NO_TLS12) && !defined(WOLFSSL_AEAD_ONLY)
 /* check all length bytes for the pad value, return 0 on success */
 static int PadCheck(const byte* a, byte pad, int length)
 {
@@ -17448,9 +17453,9 @@ int TimingPadVerify(WOLFSSL* ssl, const byte* input, int padLen, int macSz,
 
     return ret;
 }
-#endif
-#endif
-
+#endif /* !WOLFSSL_NO_TLS12 && !WOLFSSL_AEAD_ONLY */
+#endif /* WOLSSL_OLD_TIMINGPADVERIFY */
+#endif /* WOLFSSL_AEAD_ONLY */
 
 int DoApplicationData(WOLFSSL* ssl, byte* input, word32* inOutIdx, int sniff)
 {
@@ -18483,6 +18488,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                         ret = DECRYPT_ERROR;
                 #endif /* WOLFSSL_TLS13 */
                     }
+                    (void)in;
                 }
 
             #ifdef WOLFSSL_ASYNC_CRYPT
@@ -19545,6 +19551,7 @@ int BuildMessage(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
 
     (void)epochOrder;
 
+#ifndef NO_TLS
 #ifdef WOLFSSL_NO_TLS12
     return BuildTls13Message(ssl, output, outSz, input, inSz, type,
                                                hashOutput, sizeOnly, asyncOkay);
@@ -19992,6 +19999,15 @@ exit_buildmsg:
 
     return ret;
 #endif /* !WOLFSSL_NO_TLS12 */
+#else
+    (void)outSz;
+    (void)inSz;
+    (void)type;
+    (void)hashOutput;
+    (void)asyncOkay;
+    return NOT_COMPILED_IN;
+#endif /* NO_TLS */
+
 }
 
 #ifndef WOLFSSL_NO_TLS12

--- a/src/keys.c
+++ b/src/keys.c
@@ -3510,7 +3510,7 @@ int MakeMasterSecret(WOLFSSL* ssl)
 #ifndef NO_OLD_TLS
     if (ssl->options.tls) return MakeTlsMasterSecret(ssl);
     return MakeSslMasterSecret(ssl);
-#elif !defined(WOLFSSL_NO_TLS12)
+#elif !defined(WOLFSSL_NO_TLS12) && !defined(NO_TLS)
     return MakeTlsMasterSecret(ssl);
 #else
     (void)ssl;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -16918,6 +16918,7 @@ WOLFSSL_API int wolfSSL_CTX_get_min_proto_version(WOLFSSL_CTX* ctx)
  * returns WOLFSSL_FATAL_ERROR on no match */
 static int GetMaxProtoVersion(long options)
 {
+#ifndef NO_TLS
 #ifdef WOLFSSL_TLS13
     if (!(options & WOLFSSL_OP_NO_TLSv1_3))
         return TLS1_3_VERSION;
@@ -16938,7 +16939,9 @@ static int GetMaxProtoVersion(long options)
         return SSL3_VERSION;
     #endif
 #endif
-
+#else
+    (void)options;
+#endif /* NO_TLS */
     return WOLFSSL_FATAL_ERROR;
 }
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -64,6 +64,8 @@
     #include <wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h>
 #endif
 
+#ifndef NO_TLS
+
 #if defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES)
 static int TLSX_KeyShare_IsSupported(int namedGroup);
 static void TLSX_KeyShare_FreeAll(KeyShareEntry* list, void* heap);
@@ -72,8 +74,6 @@ static void TLSX_KeyShare_FreeAll(KeyShareEntry* list, void* heap);
 #ifdef HAVE_SUPPORTED_CURVES
 static int TLSX_PopulateSupportedGroups(WOLFSSL* ssl, TLSX** extensions);
 #endif
-
-#ifndef NO_TLS
 
 /* Digest enable checks */
 #ifdef NO_OLD_TLS /* TLS 1.2 only */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -11142,6 +11142,8 @@ static int GenerateDNSEntryIPString(DNS_entry* entry, void* heap)
         entry->ipString[nameSz] = '\0';
     }
 
+    (void)heap;
+
     return ret;
 }
 #endif /* OPENSSL_ALL || WOLFSSL_IP_ALT_NAME */

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2396,8 +2396,8 @@ extern void uITRON4_free(void *p) ;
     #undef HAVE_GMTIME_R /* don't trust macro with windows */
 #endif /* WOLFSSL_MYSQL_COMPATIBLE */
 
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) \
- || defined(HAVE_LIGHTY)
+#if (defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) \
+ || defined(HAVE_LIGHTY)) && !defined(NO_TLS)
     #define OPENSSL_NO_ENGINE
     #ifndef OPENSSL_EXTRA
         #define OPENSSL_EXTRA


### PR DESCRIPTION
# Description

Building with 

```
./configure --enable-static --enable-opensslall --enable-pkcs7 --enable-singlethreaded --disable-pkcs8 --disable-dh --disable-poly1305 --disable-md5 --disable-sha224 --disable-sha384 --disable-sha3 --disable-chacha --disable-examples --disable-crypttests --disable-pkcs11 --disable-benchmark --disable-tls13 --disable-harden --disable-aligndata --disable-eccshamir --disable-errorstrings --disable-errorqueue --disable-oldtls --disable-secure-renegotiation-info --disable-extended-master --disable-enc-then-mac --disable-crypttests --disable-asyncthreads --disable-oldnames --disable-ocsp --disable-rsa --disable-rsapss --disable-shared --disable-oaep --disable-inline --disable-memory --disable-asm --disable-base64encode --disable-fastmath --disable-sni --disable-supportedcurves --disable-tlsv12 CFLAGS="-DNO_WOLFSSL_CLIENT -DNO_WOLFSSL_SERVER -DNO_TLS"
```

Fixes zd14491

# Testing

How did you test?
Clean compile

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
