### PR TITLE
Make wolfSSL_(get|set)_options available outside compat layer.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -15844,7 +15844,6 @@ cleanup:
     }
 
 #ifdef OPENSSL_EXTRA
-
     void wolfSSL_CTX_set_tmp_rsa_callback(WOLFSSL_CTX* ctx,
                                       WOLFSSL_RSA*(*f)(WOLFSSL*, int, int))
     {
@@ -15865,7 +15864,7 @@ cleanup:
         ssl->options.sentNotify =  (opt&WOLFSSL_SENT_SHUTDOWN) > 0;
         ssl->options.closeNotify = (opt&WOLFSSL_RECEIVED_SHUTDOWN) > 0;
     }
-
+#endif
 
     long wolfSSL_CTX_get_options(WOLFSSL_CTX* ctx)
     {
@@ -15875,8 +15874,6 @@ cleanup:
             return BAD_FUNC_ARG;
         return ctx->mask;
     }
-
-#endif
 
     static long wolf_set_options(long old_op, long op);
     long wolfSSL_CTX_set_options(WOLFSSL_CTX* ctx, long opt)
@@ -22584,7 +22581,6 @@ static long wolf_set_options(long old_op, long op)
     return old_op | op;
 }
 
-#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)
 long wolfSSL_set_options(WOLFSSL* ssl, long op)
 {
     word16 haveRSA = 1;
@@ -22599,29 +22595,28 @@ long wolfSSL_set_options(WOLFSSL* ssl, long op)
 
     ssl->options.mask = wolf_set_options(ssl->options.mask, op);
 
-#ifdef SSL_OP_NO_TLSv1_3
-    if ((ssl->options.mask & SSL_OP_NO_TLSv1_3) == SSL_OP_NO_TLSv1_3) {
+    if ((ssl->options.mask & WOLFSSL_OP_NO_TLSv1_3) == WOLFSSL_OP_NO_TLSv1_3) {
         if (ssl->version.minor == TLSv1_3_MINOR)
             ssl->version.minor = TLSv1_2_MINOR;
     }
-#endif
 
-    if ((ssl->options.mask & SSL_OP_NO_TLSv1_2) == SSL_OP_NO_TLSv1_2) {
+    if ((ssl->options.mask & WOLFSSL_OP_NO_TLSv1_2) == WOLFSSL_OP_NO_TLSv1_2) {
         if (ssl->version.minor == TLSv1_2_MINOR)
             ssl->version.minor = TLSv1_1_MINOR;
     }
 
-    if ((ssl->options.mask & SSL_OP_NO_TLSv1_1) == SSL_OP_NO_TLSv1_1) {
+    if ((ssl->options.mask & WOLFSSL_OP_NO_TLSv1_1) == WOLFSSL_OP_NO_TLSv1_1) {
         if (ssl->version.minor == TLSv1_1_MINOR)
             ssl->version.minor = TLSv1_MINOR;
     }
 
-    if ((ssl->options.mask & SSL_OP_NO_TLSv1) == SSL_OP_NO_TLSv1) {
+    if ((ssl->options.mask & WOLFSSL_OP_NO_TLSv1) == WOLFSSL_OP_NO_TLSv1) {
         if (ssl->version.minor == TLSv1_MINOR)
             ssl->version.minor = SSLv3_MINOR;
     }
 
-    if ((ssl->options.mask & WOLFSSL_OP_NO_COMPRESSION) == WOLFSSL_OP_NO_COMPRESSION) {
+    if ((ssl->options.mask & WOLFSSL_OP_NO_COMPRESSION)
+        == WOLFSSL_OP_NO_COMPRESSION) {
     #ifdef HAVE_LIBZ
         ssl->options.usingCompression = 0;
     #endif
@@ -22656,8 +22651,6 @@ long wolfSSL_get_options(const WOLFSSL* ssl)
         return WOLFSSL_FAILURE;
     return ssl->options.mask;
 }
-
-#endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL */
 
 #if defined(HAVE_SECURE_RENEGOTIATION) \
         || defined(HAVE_SERVER_RENEGOTIATION_INFO)

--- a/tests/api.c
+++ b/tests/api.c
@@ -35483,90 +35483,112 @@ static void test_generate_cookie(void)
 
 static void test_wolfSSL_set_options(void)
 {
-#if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && \
-   !defined(NO_FILESYSTEM) && !defined(NO_RSA)
-    SSL*     ssl;
-    SSL_CTX* ctx;
+#if !defined(NO_CERTS) && !defined(NO_FILESYSTEM) && !defined(NO_RSA)
+    WOLFSSL*     ssl;
+    WOLFSSL_CTX* ctx;
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     char appData[] = "extra msg";
-
+#endif
+#ifdef OPENSSL_EXTRA
     unsigned char protos[] = {
         7, 't', 'l', 's', '/', '1', '.', '2',
         8, 'h', 't', 't', 'p', '/', '1', '.', '1'
     };
     unsigned int len = sizeof(protos);
-
     void *arg = (void *)TEST_ARG;
+#endif
 
     printf(testingFmt, "wolfSSL_set_options()");
 
 #ifndef NO_WOLFSSL_SERVER
-    AssertNotNull(ctx = SSL_CTX_new(wolfSSLv23_server_method()));
+    AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_server_method()));
 #else
-    AssertNotNull(ctx = SSL_CTX_new(wolfSSLv23_client_method()));
+    AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()));
 #endif
-    AssertTrue(SSL_CTX_use_certificate_file(ctx, svrCertFile, SSL_FILETYPE_PEM));
-    AssertTrue(SSL_CTX_use_PrivateKey_file(ctx, svrKeyFile, SSL_FILETYPE_PEM));
+    AssertTrue(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile,
+                                                WOLFSSL_FILETYPE_PEM));
+    AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKeyFile,
+                                               WOLFSSL_FILETYPE_PEM));
 
-    AssertTrue(SSL_CTX_set_options(ctx, SSL_OP_NO_TLSv1) == SSL_OP_NO_TLSv1);
-    AssertTrue(SSL_CTX_get_options(ctx) == SSL_OP_NO_TLSv1);
+    AssertTrue(wolfSSL_CTX_set_options(ctx, WOLFSSL_OP_NO_TLSv1)
+               == WOLFSSL_OP_NO_TLSv1);
+    AssertTrue(wolfSSL_CTX_get_options(ctx) == WOLFSSL_OP_NO_TLSv1);
 
-    AssertIntGT((int)SSL_CTX_set_options(ctx, (SSL_OP_COOKIE_EXCHANGE |
-                                                              SSL_OP_NO_SSLv2)), 0);
-    AssertTrue((SSL_CTX_set_options(ctx, SSL_OP_COOKIE_EXCHANGE) &
-                                 SSL_OP_COOKIE_EXCHANGE) == SSL_OP_COOKIE_EXCHANGE);
-    AssertTrue((SSL_CTX_set_options(ctx, SSL_OP_NO_TLSv1_2) &
-                                           SSL_OP_NO_TLSv1_2) == SSL_OP_NO_TLSv1_2);
-    AssertTrue((SSL_CTX_set_options(ctx, SSL_OP_NO_COMPRESSION) &
-                                   SSL_OP_NO_COMPRESSION) == SSL_OP_NO_COMPRESSION);
-    AssertNull((SSL_CTX_clear_options(ctx, SSL_OP_NO_COMPRESSION) &
-                                               SSL_OP_NO_COMPRESSION));
+    AssertIntGT((int)wolfSSL_CTX_set_options(ctx, (WOLFSSL_OP_COOKIE_EXCHANGE |
+                WOLFSSL_OP_NO_SSLv2)), 0);
+    AssertTrue((wolfSSL_CTX_set_options(ctx, WOLFSSL_OP_COOKIE_EXCHANGE) &
+                WOLFSSL_OP_COOKIE_EXCHANGE) == WOLFSSL_OP_COOKIE_EXCHANGE);
+    AssertTrue((wolfSSL_CTX_set_options(ctx, WOLFSSL_OP_NO_TLSv1_2) &
+                WOLFSSL_OP_NO_TLSv1_2) == WOLFSSL_OP_NO_TLSv1_2);
+    AssertTrue((wolfSSL_CTX_set_options(ctx, WOLFSSL_OP_NO_COMPRESSION) &
+                WOLFSSL_OP_NO_COMPRESSION) == WOLFSSL_OP_NO_COMPRESSION);
+#ifdef OPENSSL_EXTRA
+    AssertFalse((wolfSSL_CTX_clear_options(ctx, WOLFSSL_OP_NO_COMPRESSION) &
+                                           WOLFSSL_OP_NO_COMPRESSION));
+#endif
 
-    SSL_CTX_free(ctx);
+    wolfSSL_CTX_free(ctx);
 
 #ifndef NO_WOLFSSL_SERVER
-    ctx = SSL_CTX_new(wolfSSLv23_server_method());
+    ctx = wolfSSL_CTX_new(wolfSSLv23_server_method());
     AssertNotNull(ctx);
 #else
-    ctx = SSL_CTX_new(wolfSSLv23_client_method());
+    ctx = wolfSSL_CTX_new(wolfSSLv23_client_method());
     AssertNotNull(ctx);
 #endif
-    AssertTrue(SSL_CTX_use_certificate_file(ctx, svrCertFile, SSL_FILETYPE_PEM));
-    AssertTrue(SSL_CTX_use_PrivateKey_file(ctx, svrKeyFile, SSL_FILETYPE_PEM));
-    AssertTrue(SSL_CTX_set_msg_callback(ctx, msg_cb) == SSL_SUCCESS);
+    AssertTrue(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile,
+                                               WOLFSSL_FILETYPE_PEM));
+    AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKeyFile,
+                                               WOLFSSL_FILETYPE_PEM));
+#ifdef OPENSSL_EXTRA
+    AssertTrue(wolfSSL_CTX_set_msg_callback(ctx, msg_cb) == WOLFSSL_SUCCESS);
+#endif
 
-    AssertNotNull(ssl = SSL_new(ctx));
+    AssertNotNull(ssl = wolfSSL_new(ctx));
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 #ifdef HAVE_EX_DATA
-    AssertIntEQ(SSL_set_app_data(ssl, (void*)appData), SSL_SUCCESS);
-    AssertNotNull(SSL_get_app_data((const WOLFSSL*)ssl));
+    AssertIntEQ(wolfSSL_set_app_data(ssl, (void*)appData), WOLFSSL_SUCCESS);
+    AssertNotNull(wolfSSL_get_app_data((const WOLFSSL*)ssl));
     if (ssl) {
-        AssertIntEQ(XMEMCMP(SSL_get_app_data((const WOLFSSL*)ssl),
+        AssertIntEQ(XMEMCMP(wolfSSL_get_app_data((const WOLFSSL*)ssl),
                     appData, sizeof(appData)), 0);
     }
 #else
-    AssertIntEQ(SSL_set_app_data(ssl, (void*)appData), SSL_FAILURE);
-    AssertNull(SSL_get_app_data((const WOLFSSL*)ssl));
+    AssertIntEQ(wolfSSL_set_app_data(ssl, (void*)appData), WOLFSSL_FAILURE);
+    AssertNull(wolfSSL_get_app_data((const WOLFSSL*)ssl));
+#endif
 #endif
 
-    AssertTrue(SSL_set_options(ssl, SSL_OP_NO_TLSv1) == SSL_OP_NO_TLSv1);
-    AssertTrue(SSL_get_options(ssl) == SSL_OP_NO_TLSv1);
+    AssertTrue(wolfSSL_set_options(ssl, WOLFSSL_OP_NO_TLSv1) ==
+                                   WOLFSSL_OP_NO_TLSv1);
 
-    AssertIntGT((int)SSL_set_options(ssl, (SSL_OP_COOKIE_EXCHANGE |
-                                                          WOLFSSL_OP_NO_SSLv2)), 0);
-    AssertTrue((SSL_set_options(ssl, SSL_OP_COOKIE_EXCHANGE) &
-                             SSL_OP_COOKIE_EXCHANGE) == SSL_OP_COOKIE_EXCHANGE);
-    AssertTrue((SSL_set_options(ssl, SSL_OP_NO_TLSv1_2) &
-                                       SSL_OP_NO_TLSv1_2) == SSL_OP_NO_TLSv1_2);
-    AssertTrue((SSL_set_options(ssl, SSL_OP_NO_COMPRESSION) &
-                               SSL_OP_NO_COMPRESSION) == SSL_OP_NO_COMPRESSION);
-    AssertNull((SSL_clear_options(ssl, SSL_OP_NO_COMPRESSION) &
-                                       SSL_OP_NO_COMPRESSION));
+    AssertTrue(wolfSSL_get_options(ssl) == WOLFSSL_OP_NO_TLSv1);
 
-    AssertTrue(SSL_set_msg_callback(ssl, msg_cb) == SSL_SUCCESS);
-    SSL_set_msg_callback_arg(ssl, arg);
+    AssertIntGT((int)wolfSSL_set_options(ssl, (WOLFSSL_OP_COOKIE_EXCHANGE |
+                                         WOLFSSL_OP_NO_SSLv2)), 0);
+
+    AssertTrue((wolfSSL_set_options(ssl, WOLFSSL_OP_COOKIE_EXCHANGE) &
+                WOLFSSL_OP_COOKIE_EXCHANGE) == WOLFSSL_OP_COOKIE_EXCHANGE);
+
+    AssertTrue((wolfSSL_set_options(ssl, WOLFSSL_OP_NO_TLSv1_2) &
+                WOLFSSL_OP_NO_TLSv1_2) == WOLFSSL_OP_NO_TLSv1_2);
+
+    AssertTrue((wolfSSL_set_options(ssl, WOLFSSL_OP_NO_COMPRESSION) &
+               WOLFSSL_OP_NO_COMPRESSION) == WOLFSSL_OP_NO_COMPRESSION);
+
+#ifdef OPENSSL_EXTRA
+    AssertNull((wolfSSL_clear_options(ssl, WOLFSSL_OP_NO_COMPRESSION) &
+                                      WOLFSSL_OP_NO_COMPRESSION));
+#endif
+
+#ifdef OPENSSL_EXTRA
+    AssertTrue(wolfSSL_set_msg_callback(ssl, msg_cb) == WOLFSSL_SUCCESS);
+    wolfSSL_set_msg_callback_arg(ssl, arg);
 #ifdef WOLFSSL_ERROR_CODE_OPENSSL
-    AssertTrue(SSL_CTX_set_alpn_protos(ctx, protos, len) == 0);
+    AssertTrue(wolfSSL_CTX_set_alpn_protos(ctx, protos, len) == 0);
 #else
-    AssertTrue(SSL_CTX_set_alpn_protos(ctx, protos, len) == SSL_SUCCESS);
+    AssertTrue(wolfSSL_CTX_set_alpn_protos(ctx, protos, len) == WOLFSSL_SUCCESS);
+#endif
 #endif
 
 #if defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) || \
@@ -35576,20 +35598,19 @@ static void test_wolfSSL_set_options(void)
 #if defined(HAVE_ALPN) && !defined(NO_BIO)
 
 #ifdef WOLFSSL_ERROR_CODE_OPENSSL
-    AssertTrue(SSL_set_alpn_protos(ssl, protos, len) == 0);
+    AssertTrue(wolfSSL_set_alpn_protos(ssl, protos, len) == 0);
 #else
-    AssertTrue(SSL_set_alpn_protos(ssl, protos, len) == SSL_SUCCESS);
+    AssertTrue(wolfSSL_set_alpn_protos(ssl, protos, len) == WOLFSSL_SUCCESS);
 #endif
 
 #endif /* HAVE_ALPN && !NO_BIO */
 #endif
 
-    SSL_free(ssl);
-    SSL_CTX_free(ctx);
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
 
     printf(resultFmt, passed);
-#endif /* defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && \
-         !defined(NO_FILESYSTEM) && !defined(NO_RSA) */
+#endif /* !defined(NO_CERTS) && !defined(NO_FILESYSTEM) && !defined(NO_RSA) */
 }
 
 static void test_wolfSSL_sk_SSL_CIPHER(void)

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3740,8 +3740,8 @@ typedef struct Options {
 #endif
     void*             psk_ctx;
 #endif /* NO_PSK */
-#if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER) || defined(WOLFSSL_WPAS_SMALL)
     unsigned long     mask; /* store SSL_OP_ flags */
+#if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER) || defined(WOLFSSL_WPAS_SMALL)
     word16            minProto:1; /* sets min to min available */
     word16            maxProto:1; /* sets max to max available */
 #endif


### PR DESCRIPTION
# Description

Make wolfSSL_CTX_get_options available, too.

# Testing

The unit test test_wolfSSL_set_options now runs even when OPENSSL_EXTRA isn't defined.  

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
