### PR TITLE
Fixed logic errors in initialization

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5479,12 +5479,14 @@ int wolfSSL_Init(void)
         }
 
 #ifdef HAVE_GLOBAL_RNG
-        if ((ret == WOLFSSL_SUCCESS) && (wc_InitMutex(&globalRNGMutex) != 0)) {
-            WOLFSSL_MSG("Bad Init Mutex rng");
-            ret = BAD_MUTEX_E;
-        }
-        else {
-            globalRNGMutex_valid = 1;
+        if (ret == WOLFSSL_SUCCESS) {
+            if (wc_InitMutex(&globalRNGMutex) != 0) {
+                WOLFSSL_MSG("Bad Init Mutex rng");
+                ret = BAD_MUTEX_E;
+            }
+            else {
+                globalRNGMutex_valid = 1;
+            }
         }
 #endif
 
@@ -5520,31 +5522,36 @@ int wolfSSL_Init(void)
             }
         }
     #else
-        if ((ret == WOLFSSL_SUCCESS) && (wc_InitMutex(&session_mutex) != 0)) {
-            WOLFSSL_MSG("Bad Init Mutex session");
-            ret = BAD_MUTEX_E;
-        }
-        else {
-            session_mutex_valid = 1;
+        if (ret == WOLFSSL_SUCCESS) {
+            if (wc_InitMutex(&session_mutex) != 0) {
+                WOLFSSL_MSG("Bad Init Mutex session");
+                ret = BAD_MUTEX_E;
+            }
+            else {
+                session_mutex_valid = 1;
+            }
         }
     #endif
     #ifndef NO_CLIENT_CACHE
-        if ((ret == WOLFSSL_SUCCESS) &&
-            (wc_InitMutex(&clisession_mutex) != 0)) {
-            WOLFSSL_MSG("Bad Init Mutex session");
-            ret = BAD_MUTEX_E;
-        }
-        else {
-            clisession_mutex_valid = 1;
+        if (ret == WOLFSSL_SUCCESS) {
+            if (wc_InitMutex(&clisession_mutex) != 0) {
+                WOLFSSL_MSG("Bad Init Mutex session");
+                ret = BAD_MUTEX_E;
+            }
+            else {
+                clisession_mutex_valid = 1;
+            }
         }
     #endif
 #endif
-        if ((ret == WOLFSSL_SUCCESS) && (wc_InitMutex(&count_mutex) != 0)) {
-            WOLFSSL_MSG("Bad Init Mutex count");
-            ret = BAD_MUTEX_E;
-        }
-        else {
-            count_mutex_valid = 1;
+        if (ret == WOLFSSL_SUCCESS) {
+            if (wc_InitMutex(&count_mutex) != 0) {
+                WOLFSSL_MSG("Bad Init Mutex count");
+                ret = BAD_MUTEX_E;
+            }
+            else {
+                count_mutex_valid = 1;
+            }
         }
 
 #if defined(OPENSSL_EXTRA) && defined(HAVE_ATEXIT)
@@ -5556,13 +5563,15 @@ int wolfSSL_Init(void)
 #endif
     }
 
-    if ((ret == WOLFSSL_SUCCESS) && (wc_LockMutex(&count_mutex) != 0)) {
-        WOLFSSL_MSG("Bad Lock Mutex count");
-        ret = BAD_MUTEX_E;
-    }
-    else {
-        initRefCount++;
-        wc_UnLockMutex(&count_mutex);
+    if (ret == WOLFSSL_SUCCESS) {
+        if (wc_LockMutex(&count_mutex) != 0) {
+            WOLFSSL_MSG("Bad Lock Mutex count");
+            ret = BAD_MUTEX_E;
+        }
+        else {
+            initRefCount++;
+            wc_UnLockMutex(&count_mutex);
+        }
     }
 
     if (ret != WOLFSSL_SUCCESS) {


### PR DESCRIPTION
# Description

This fixes a problem in the wolfSSL_Init function where, if "ret" gets set to an error code, the "success" code of each subsequent initialization step is executed without performing the actual initialization step.

For example, if the FIPS power-on-self-test fails, ret gets set to an error code earlier on. Because of this, the initialization of count_mutex (line 5542 old, 5548 new) gets skipped. But further down in the function (line 5565 old), the code tries to unlock the count_mutex. On Windows this results in an access violation exception.

This PR is a minimal change to fix the problem in wolfSSL_Init. It would (arguably) be better if the same change (i.e. make the "ret == WOLFSSL_SUCCESS" test go into a surrounding "if" instead of using "&&") would be applied to the entire function. See the commit comment in my own fork for more information.

I only fixed the problem for WolfSSL_Init, I don't know if it occurs elsewhere.

# Testing

I'm new to WolfSSL, I don't know if there's a proper test for this. I didn't attempt to find out if the same problem occurs elsewhere.

I'm trying to integrate WolfSSL FIPS into our Windows project and for some reason the FIPS self-test fails (I'm working on this with Tech Support). This caused a crash (access violation) in the WolfSSL_Init function because it tries to ws_UnlockMutex(&count_mutex) without calling ws_InitMutex(&count_mutex) first.

Modifying the code to make sure the "success" code doesn't get executed if ret != WOLFSSL_SUCCESS fixed the problem: WolfSSL_Init now returns an error code for my project.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
