### PR TITLE
Fix for --disable-aes without --disable-aesgcm

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3676,7 +3676,7 @@ then
     then
         AC_MSG_ERROR([cannot enable eccencrypt and hkdf without aes.])
     fi
-    if test "$ENABLED_AESGCM" = "yes"
+    if test "$ENABLED_AESGCM" != "no"
     then
         AC_MSG_ERROR([AESGCM requires AES.])
     fi


### PR DESCRIPTION
Configuring wolfSSL with `./configure --disable-aes` without `--disable-aesgcm` should error out. The if case on line 3679 in `configure.ac` is never entered because `ENABLED_AESGCM = 4bits`  on little endian targets.