### PR TITLE
linuxkm: inhibit thunk generation in get_thread_size.

### DIFF
--- a/linuxkm/Kbuild
+++ b/linuxkm/Kbuild
@@ -48,7 +48,9 @@ $(obj)/linuxkm/module_exports.o: $(WOLFSSL_OBJ_TARGETS)
 # this mechanism only works in kernel 5.x+ (fallback to hardcoded value)
 hostprogs := linuxkm/get_thread_size
 always-y := $(hostprogs)
-HOST_EXTRACFLAGS += $(NOSTDINC_FLAGS) $(LINUXINCLUDE) $(KBUILD_CFLAGS) -static -fno-omit-frame-pointer
+# "-mindirect-branch=keep -mfunction-return=keep" to avoid "undefined reference
+#  to `__x86_return_thunk'" on CONFIG_RETHUNK kernels (5.19.0-rc7)
+HOST_EXTRACFLAGS += $(NOSTDINC_FLAGS) $(LINUXINCLUDE) $(KBUILD_CFLAGS) -static -fno-omit-frame-pointer -mindirect-branch=keep -mfunction-return=keep
 
 # this rule is needed to get build to succeed in 4.x (get_thread_size still doesn't get built)
 $(obj)/linuxkm/get_thread_size: $(src)/linuxkm/get_thread_size.c


### PR DESCRIPTION
tested with `wolfssl-multi-test.sh ... super-quick-check` (which includes `linuxkm-mainline-pie`).

the fix was prompted by this failure report:
```
[linuxkm-mainline-pie] [73 of 118] [9a3efb67b8]
    [targeting kernel /usr/src/linux-5.19-rc7]
    configure...   real 0m6.952s  user 0m3.874s  sys 0m3.750s
    build.../usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: /home/wolfbot/tmp/ccVVNc11.o: in function `main':
get_thread_size.c:(.text.startup+0x1e): undefined reference to `__x86_return_thunk'
collect2: error: ld returned 1 exit status
make[4]: *** [scripts/Makefile.host:95: /home/wolfbot/tmp/wolfssl_test_workdir.11289/wolfssl/linuxkm/linuxkm/get_thread_size] Error 1
make[4]: *** Waiting for unfinished jobs....
make[3]: *** [Makefile:1843: /home/wolfbot/tmp/wolfssl_test_workdir.11289/wolfssl/linuxkm] Error 2
make[2]: *** [Makefile:64: libwolfssl.ko] Error 2
make[1]: *** [Makefile:6764: all-recursive] Error 1
make: *** [Makefile:3994: all] Error 2
   real 0m1.077s  user 0m0.760s  sys 0m0.594s
    linuxkm-mainline-pie fail_build
    failed config: '--enable-all' '--enable-aesni' '--enable-sp-asm' '--enable-linuxkm' '--enable-linuxkm-pie' '--enable-reproducible-build' '--enable-crypttests' '--with-linux-source=/usr/src/linux-5.19-rc7'
```
