### PR TITLE
Add ECC private key insertion for SE050

### DIFF
--- a/wolfcrypt/src/port/nxp/se050_port.c
+++ b/wolfcrypt/src/port/nxp/se050_port.c
@@ -554,8 +554,8 @@ int se050_ecc_insert_private_key(int keyId, const byte* eccDer,
             kKeyObject_Mode_Persistent);
     }
     if (status == kStatus_SSS_Success) {
-        status = sss_key_store_set_key(&host_keystore, &newKey, ecc_key_der_256,
-                                       sizeof_ecc_key_der_256, keySizeBits,
+        status = sss_key_store_set_key(&host_keystore, &newKey, eccDer,
+                                       eccDerSize, keySizeBits,
                                        NULL, 0);
     }
     wolfSSL_CryptHwMutexUnLock();

--- a/wolfssl/wolfcrypt/port/nxp/se050_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/se050_port.h
@@ -138,6 +138,8 @@ WOLFSSL_LOCAL int se050_ecc_create_key(struct ecc_key* key, int curve_id, int ke
 WOLFSSL_LOCAL int se050_ecc_shared_secret(struct ecc_key* private_key,
     struct ecc_key* public_key, byte* out, word32* outlen);
 WOLFSSL_LOCAL void se050_ecc_free_key(struct ecc_key* key);
+WOLFSSL_LOCAL int se050_ecc_insert_private_key(int keyId, const byte* eccDer,
+    word32 eccDerSize);
 
 struct ed25519_key;
 WOLFSSL_LOCAL int se050_ed25519_create_key(struct ed25519_key* key);

--- a/wolfssl/wolfcrypt/port/nxp/se050_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/se050_port.h
@@ -95,6 +95,8 @@ WOLFSSL_API int wc_se050_set_config(sss_session_t *pSession,
 #ifdef WOLFSSL_SE050_INIT
 WOLFSSL_API int wc_se050_init(const char* portName);
 #endif
+WOLFSSL_API int se050_ecc_insert_private_key(int keyId, const byte* eccDer,
+    word32 eccDerSize);
 
 /* Private Functions */
 WOLFSSL_LOCAL int se050_allocate_key(int keyType);
@@ -138,8 +140,7 @@ WOLFSSL_LOCAL int se050_ecc_create_key(struct ecc_key* key, int curve_id, int ke
 WOLFSSL_LOCAL int se050_ecc_shared_secret(struct ecc_key* private_key,
     struct ecc_key* public_key, byte* out, word32* outlen);
 WOLFSSL_LOCAL void se050_ecc_free_key(struct ecc_key* key);
-WOLFSSL_LOCAL int se050_ecc_insert_private_key(int keyId, const byte* eccDer,
-    word32 eccDerSize);
+
 
 struct ed25519_key;
 WOLFSSL_LOCAL int se050_ed25519_create_key(struct ed25519_key* key);


### PR DESCRIPTION
This adds a utility function which allows an ECC private key to be
inserted into the SE050's permanent storage.

# Testing

Using an SE050:

1. Enable `WOLFSSL_SE050_FACTORY_RESET`
2. Using the new function, insert a key
3. Disable `WOLFSSL_SE050_FACTORY_RESET`
4. Power cycle device
5. Use key in TLS v1.3 handshake