### PR TITLE
Don't require digital signature bit for static RSA cipher suites.  Make wolfSSL_CTX_clear_options available without OPENSSL_EXTRA.

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -13379,7 +13379,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         (args->dCert->extKeyUsage & KEYUSE_KEY_ENCIPHER) == 0) {
                         ret = KEYUSE_ENCIPHER_E;
                     }
-                    if ((ssl->specs.sig_algo == rsa_sa_algo ||
+                    if ((ssl->specs.kea != rsa_kea) &&
+                        (ssl->specs.sig_algo == rsa_sa_algo ||
                             (ssl->specs.sig_algo == ecc_dsa_sa_algo &&
                                  !ssl->specs.static_ecdh)) &&
                         (args->dCert->extKeyUsage & KEYUSE_DIGITAL_SIG) == 0) {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -15896,8 +15896,6 @@ cleanup:
         return ctx->mask;
     }
 
-#ifdef OPENSSL_EXTRA
-
     long wolfSSL_CTX_clear_options(WOLFSSL_CTX* ctx, long opt)
     {
         WOLFSSL_ENTER("SSL_CTX_clear_options");
@@ -15906,6 +15904,8 @@ cleanup:
         ctx->mask &= ~opt;
         return ctx->mask;
     }
+
+#ifdef OPENSSL_EXTRA
 
     int wolfSSL_set_rfd(WOLFSSL* ssl, int rfd)
     {

--- a/tests/api.c
+++ b/tests/api.c
@@ -35525,10 +35525,8 @@ static void test_wolfSSL_set_options(void)
                 WOLFSSL_OP_NO_TLSv1_2) == WOLFSSL_OP_NO_TLSv1_2);
     AssertTrue((wolfSSL_CTX_set_options(ctx, WOLFSSL_OP_NO_COMPRESSION) &
                 WOLFSSL_OP_NO_COMPRESSION) == WOLFSSL_OP_NO_COMPRESSION);
-#ifdef OPENSSL_EXTRA
     AssertFalse((wolfSSL_CTX_clear_options(ctx, WOLFSSL_OP_NO_COMPRESSION) &
                                            WOLFSSL_OP_NO_COMPRESSION));
-#endif
 
     wolfSSL_CTX_free(ctx);
 


### PR DESCRIPTION
# Description

Don't require digital signature bit for static RSA cipher suites.  Make wolfSSL_CTX_clear_options available without OPENSSL_EXTRA.

Fixes zd# 14475 ZD# 14532

# Testing

Confirmed built in tests passing

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
