### PR TITLE
20220720-fixes

### DIFF
--- a/IDE/HEXAGON/DSP/Makefile
+++ b/IDE/HEXAGON/DSP/Makefile
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
-#/
-#/
 
 ENVI=hexagon
 

--- a/IDE/HEXAGON/Makefile
+++ b/IDE/HEXAGON/Makefile
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
-#/
-#/
 
 ENVI=UbuntuARM
 

--- a/IDE/MYSQL/CMakeLists_wolfCrypt.txt
+++ b/IDE/MYSQL/CMakeLists_wolfCrypt.txt
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
-#/
-#/
-#/
 
 INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/include

--- a/IDE/MYSQL/CMakeLists_wolfSSL.txt
+++ b/IDE/MYSQL/CMakeLists_wolfSSL.txt
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
-#/
-#/
-#/
 
 INCLUDE_DIRECTORIES(
  ${CMAKE_SOURCE_DIR}/include

--- a/IDE/mynewt/apps.wolfcrypttest.pkg.yml
+++ b/IDE/mynewt/apps.wolfcrypttest.pkg.yml
@@ -15,10 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
-#/
-#/
-#/
-# 
 
 pkg.name: "apps/wolfcrypttest"
 pkg.type: app

--- a/IDE/mynewt/crypto.wolfssl.pkg.yml
+++ b/IDE/mynewt/crypto.wolfssl.pkg.yml
@@ -15,10 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
-#/
-#/
-#/
-# 
 
 pkg.name: "crypto/wolfssl"
 pkg.description: "wolfSSL Embedded SSL/TLS Library"

--- a/configure.ac
+++ b/configure.ac
@@ -7812,8 +7812,8 @@ if test "x$ENABLED_LINUXKM" = "xyes"; then
     AC_SUBST([ASFLAGS_FPUSIMD_DISABLE])
     AC_SUBST([ASFLAGS_FPUSIMD_ENABLE])
 
-    if test "$ENABLED_OPENSSLEXTRA" != "no"; then
-        AC_MSG_ERROR([--enable-opensslextra is incompatible with --enable-linuxkm.])
+    if test "$ENABLED_OPENSSLEXTRA" != "no" && test "$ENABLED_CRYPTONLY" = "no"; then
+        AC_MSG_ERROR([--enable-opensslextra without --enable-cryptonly is incompatible with --enable-linuxkm.])
     fi
     if test "$ENABLED_FILESYSTEM" = "yes"; then
         AC_MSG_ERROR([--enable-filesystem is incompatible with --enable-linuxkm.])

--- a/linuxkm/Kbuild
+++ b/linuxkm/Kbuild
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
-#/
-#
 
 SHELL=/bin/bash
 

--- a/linuxkm/Makefile
+++ b/linuxkm/Makefile
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
-#/
-#/
 
 SHELL=/bin/bash
 

--- a/m4/ax_linuxkm.m4
+++ b/m4/ax_linuxkm.m4
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
-#/
-#/
 
 AC_DEFUN([AC_PATH_DEFAULT_KERNEL_SOURCE],
 [

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -3339,6 +3339,10 @@ int SendTls13ClientHello(WOLFSSL* ssl)
     WOLFSSL_START(WC_FUNC_CLIENT_HELLO_SEND);
     WOLFSSL_ENTER("SendTls13ClientHello");
 
+    if (ssl == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
     ssl->options.buildingMsg = 1;
     major = SSLv3_MAJOR;
     tls12minor = TLSv1_2_MINOR;
@@ -3349,10 +3353,6 @@ int SendTls13ClientHello(WOLFSSL* ssl)
         tls12minor = DTLSv1_2_MINOR;
     }
 #endif /* WOLFSSL_DTLS */
-
-    if (ssl == NULL) {
-        return BAD_FUNC_ARG;
-    }
 
 #ifdef HAVE_SESSION_TICKET
     if (ssl->options.resuming &&


### PR DESCRIPTION
fixes nullness check in `SendTls13ClientHello()` detected by `cppcheck`.

relax mutex between linuxkm and opensslextra, provided cryptonly is given (supports customer use case).

fix copyright boilerplate noise added by accident.
