### PR TITLE
fix: async: don't rewind index if post-handshake connect() fails

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -9473,6 +9473,14 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         break;
     }
 
+#if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_ASYNC_IO)
+    /* if async, offset index so this msg will be processed again */
+    /* NOTE: check this now before other calls can overwirte ret */
+    if ((ret == WC_PENDING_E || ret == OCSP_WANT_READ) && *inOutIdx > 0) {
+        *inOutIdx -= HANDSHAKE_HEADER_SZ;
+    }
+#endif
+
     /* reset error */
     if (ret == 0 && ssl->error == WC_PENDING_E)
         ssl->error = 0;
@@ -9592,13 +9600,6 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     #endif
 #endif /* NO_WOLFSSL_SERVER */
     }
-
-#if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_ASYNC_IO)
-    /* if async, offset index so this msg will be processed again */
-    if ((ret == WC_PENDING_E || ret == OCSP_WANT_READ) && *inOutIdx > 0) {
-        *inOutIdx -= HANDSHAKE_HEADER_SZ;
-    }
-#endif
 
     WOLFSSL_LEAVE("DoTls13HandShakeMsgType()", ret);
     return ret;


### PR DESCRIPTION
 # Description
During post-handshake authentication async code mistakes connect() error code
with the error code of DoTls13CertificateRequest and wrongly rewinds the buffer.

The bug was never triggered because of side effects of ShrinkBuffer (removed in
40cb6e0853c6c2cdcef393fca905f40338b41506)


# Testing

`async-check.sh`


