### PR TITLE
Announce TLSX_PSK_KEY_EXCHANGE_MODES in non-resuming ClientHello

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ CVE-2020-12966 https://www.amd.com/en/corporate/product-security/bulletin/amd-sb
 * Add TLS 1.2 ciphersuite ECDHE_PSK_WITH_AES_128_GCM_SHA256 from RFC 8442
 * Expand CAAM support with QNX to include i.MX8 boards and add AES-CTR support
 * Enhanced glitching protection by hardening the TLS encrypt operations
+* The TLS Extension for PSK Key Exchange Modes is now always included in a ClientHello (with PSK enabled) to improve inter-op.
 
 ## Math and Performance
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ CVE-2020-12966 https://www.amd.com/en/corporate/product-security/bulletin/amd-sb
 * Add TLS 1.2 ciphersuite ECDHE_PSK_WITH_AES_128_GCM_SHA256 from RFC 8442
 * Expand CAAM support with QNX to include i.MX8 boards and add AES-CTR support
 * Enhanced glitching protection by hardening the TLS encrypt operations
-* The TLS Extension for PSK Key Exchange Modes is now always included in a ClientHello (with PSK enabled) to improve inter-op.
 
 ## Math and Performance
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -11386,16 +11386,18 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
     #endif /* !NO_PSK */
         #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
 
-            #ifndef NO_TLSX_PSKKEM_PLAIN_ANNOUNCE
             /* Some servers do not generate session tickets unless
-             * the extension is seen in a non-resume client hello */
-            if (1) {
-                (void)usingPSK;
-            #else
-            if (usingPSK) {
+             * the extension is seen in a non-resume client hello.
+             * We used to send it only if we were otherwise using PSK.
+             * Now always send it. Define NO_TLSX_PSKKEM_PLAIN_ANNOUNCE
+             * to revert to the old behaviour. */
+            #ifdef NO_TLSX_PSKKEM_PLAIN_ANNOUNCE
+            if (usingPSK)
             #endif
+            {
                 byte modes;
 
+                (void)usingPSK;
                 /* Pre-shared key modes: mandatory extension for resumption. */
                 modes = 1 << PSK_KE;
             #if !defined(NO_DH) || defined(HAVE_ECC) || \

--- a/src/tls.c
+++ b/src/tls.c
@@ -11385,7 +11385,15 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
             }
     #endif /* !NO_PSK */
         #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
+
+            #ifndef NO_TLSX_PSKKEM_PLAIN_ANNOUNCE
+            /* Some servers do not generate session tickets unless
+             * the extension is seen in a non-resume client hello */
+            if (1) {
+                (void)usingPSK;
+            #else
             if (usingPSK) {
+            #endif
                 byte modes;
 
                 /* Pre-shared key modes: mandatory extension for resumption. */


### PR DESCRIPTION
# Description

QUIC interop testing revealed that (at least popular QUIC stacks) refrain from
issuing session tickets unless the ClientHello shows this extension.

Can be reverted to previous style by defining NO_TLSX_PSKKEM_PLAIN_ANNOUNCE.

Fixes zd#

# Testing

`make test`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [x] updated appropriate READMEs
 - [ ] Updated manual and documentation
