### PR TITLE
fixed Renesas SCE jenkins failure

### DIFF
--- a/wolfcrypt/src/port/Renesas/renesas_common.c
+++ b/wolfcrypt/src/port/Renesas/renesas_common.c
@@ -25,8 +25,12 @@
 
 #if defined(WOLFSSL_RENESAS_SCEPROTECT)
   #include <wolfssl/wolfcrypt/port/Renesas/renesas-sce-crypt.h>
+  #define cmn_hw_lock    wc_sce_hw_lock
+  #define cmn_hw_unlock  wc_sce_hw_unlock
 #elif defined(WOLFSSL_RENESAS_TSIP_TLS)
   #include <wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h>
+  #define cmn_hw_lock    tsip_hw_lock
+  #define cmn_hw_unlock  tsip_hw_unlock
 #endif
 
 #include <wolfssl/wolfcrypt/wc_port.h>
@@ -371,9 +375,9 @@ int wc_CryptoCb_CryptInitRenesasCmn(WOLFSSL* ssl, void* ctx)
         return INVALID_DEVID;
     }
     /* need exclusive control because of static variable */
-    if ((tsip_hw_lock()) == 0) {
+    if ((cmn_hw_lock()) == 0) {
         cbInfo->devId = gdevId++;
-        tsip_hw_unlock();
+        cmn_hw_unlock();
     }
     else {
         WOLFSSL_MSG("Failed to lock tsip hw");
@@ -669,7 +673,7 @@ WOLFSSL_LOCAL int Renesas_cmn_generateSessionKey(WOLFSSL* ssl, void* ctx)
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
         ret = wc_tsip_generateSessionKey(ssl, (TsipUserCtx*)ctx, cbInfo->devId);
 #elif defined(WOLFSSL_RENESAS_SCEPROTECT)
-        ret = wc_sce_generateSessionKey(ssl, ctx, devId);
+        ret = wc_sce_generateSessionKey(ssl, ctx, cbInfo->devId);
 #endif
     } 
     else {

--- a/wolfcrypt/src/port/Renesas/renesas_sce_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_sce_util.c
@@ -267,7 +267,6 @@ WOLFSSL_LOCAL int wc_SCE_EccVerify(WOLFSSL* ssl, const uint8_t* sig,
 {
     int ret = WOLFSSL_FAILURE;
     uint8_t *sigforSCE;
-    uint8_t *pSig;
     const byte rs_size = HW_SCE_ECDSA_DATA_BYTE_SIZE/2;
     byte offset = 0x3;
     (void) sigSz;
@@ -277,7 +276,6 @@ WOLFSSL_LOCAL int wc_SCE_EccVerify(WOLFSSL* ssl, const uint8_t* sig,
     (void) keySz;
 
     sigforSCE = NULL;
-    pSig = NULL;
 
     WOLFSSL_PKMSG("SCE ECC Verify: ssl->options.serverState = %d sigSz %d, hashSz %d, keySz %d\n",
                     ssl->options.serverState, sigSz, hashSz, keySz);
@@ -321,9 +319,10 @@ WOLFSSL_LOCAL int wc_SCE_EccVerify(WOLFSSL* ssl, const uint8_t* sig,
         }
     }
 
-    pSig = sigforSCE;
+    ret = SCE_ServerKeyExVerify(2, ssl, sigforSCE, 64, ctx);
 
-    ret = SCE_ServerKeyExVerify(2, ssl, pSig, 64, ctx);
+    if (sigforSCE)
+        XFREE(sigforSCE, NULL, DYNAMIC_TYPE_TEMP);
 
     if (ret == WOLFSSL_SUCCESS) {
         *result = 1;


### PR DESCRIPTION
# Description
fixed Renesas SCE compile error due to degression by [PR5321](https://github.com/wolfSSL/wolfssl/pull/5321)
fixed memory leak in wc_SCE_EccVerify

# Testing

Run unit test, Crypt test, Bench mark test and Client test.
Also confirmed TSIP was successfully compiled on the branch.


