### PR TITLE
Adding X509_CRL_print() function

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -94,7 +94,7 @@ static int InitCRL_Entry(CRL_Entry* crle, DecodedCRL* dcrl, const byte* buff,
 #if defined(OPENSSL_EXTRA)
     crle->issuer = NULL;
     wolfSSL_d2i_X509_NAME(&crle->issuer, (unsigned char**)&dcrl->issuer,
-            XSTRLEN((const char*)dcrl->issuer));
+                          dcrl->issuerSz);
     if (crle->issuer == NULL) {
         return WOLFSSL_FAILURE;
     }

--- a/src/x509.c
+++ b/src/x509.c
@@ -5812,8 +5812,8 @@ static int X509PrintExtensions(WOLFSSL_BIO* bio, WOLFSSL_X509* x509, int indent)
  * wolfSSL_X509_print()
  * return WOLFSSL_SUCCESS on success
  */
-static int X509PrintSignature_ex(WOLFSSL_BIO* bio, byte* sig, int sigSz, int sigNid,
-        int algOnly, int indent)
+static int X509PrintSignature_ex(WOLFSSL_BIO* bio, byte* sig,
+        int sigSz, int sigNid, int algOnly, int indent)
 {
     char scratch[MAX_WIDTH];
     int scratchLen;
@@ -6160,7 +6160,8 @@ int wolfSSL_X509_REQ_print(WOLFSSL_BIO* bio, WOLFSSL_X509* x509)
     }
 
     /* print version of cert */
-    if (X509PrintVersion(bio, wolfSSL_X509_version(x509), 8) != WOLFSSL_SUCCESS) {
+    if (X509PrintVersion(bio, wolfSSL_X509_version(x509), 8)
+            != WOLFSSL_SUCCESS) {
         return WOLFSSL_FAILURE;
     }
 
@@ -6238,7 +6239,8 @@ int wolfSSL_X509_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
     }
 
     /* print version of cert */
-    if (X509PrintVersion(bio, wolfSSL_X509_version(x509), 8) != WOLFSSL_SUCCESS) {
+    if (X509PrintVersion(bio, wolfSSL_X509_version(x509), 8)
+            != WOLFSSL_SUCCESS) {
         return WOLFSSL_FAILURE;
     }
 
@@ -7737,7 +7739,8 @@ static int X509CRLPrintRevoked(WOLFSSL_BIO* bio, WOLFSSL_X509_CRL* crl,
 
         for (i = 0; i < crl->crlList->totalCerts; i++) {
             if (revoked->serialSz > 0) {
-                if (X509RevokedPrintSerial(bio, revoked, indent + 4) != WOLFSSL_SUCCESS) {
+                if (X509RevokedPrintSerial(bio, revoked, indent + 4)
+                        != WOLFSSL_SUCCESS) {
                     return WOLFSSL_FAILURE;
                 }
             }
@@ -7884,7 +7887,8 @@ int wolfSSL_X509_CRL_print(WOLFSSL_BIO* bio, WOLFSSL_X509_CRL* crl)
     }
 
     /* print version */
-    if (X509PrintVersion(bio, wolfSSL_X509_CRL_version(crl), 8) != WOLFSSL_SUCCESS) {
+    if (X509PrintVersion(bio, wolfSSL_X509_CRL_version(crl), 8)
+            != WOLFSSL_SUCCESS) {
         return WOLFSSL_FAILURE;
     }
 

--- a/src/x509.c
+++ b/src/x509.c
@@ -5534,7 +5534,7 @@ static int X509PrintSerial_ex(WOLFSSL_BIO* bio, byte* serial, int sz,
         for (i = 0; i < sz; i++) {
             if ((valLen = XSNPRINTF(
                      scratch + scratchLen, scratchSz - scratchLen,
-                     "%02x%s", serial[i], (i < sz - 1) ? 
+                     "%02x%s", serial[i], (i < sz - 1) ?
                      (delimiter ? ":" : "") : "\n"))
                 >= scratchSz - scratchLen)
             {
@@ -5944,17 +5944,25 @@ static int X509PrintSignature_ex(WOLFSSL_BIO* bio, byte* sig, int sigSz, int sig
     if (obj != NULL)
         wolfSSL_ASN1_OBJECT_free(obj);
 
-    return ret; 
+    return ret;
 }
 
 static int X509PrintSignature(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
         int algOnly, int indent)
 {
     int sigSz = 0;
-    wolfSSL_X509_get_signature(x509, NULL, &sigSz);
+    if (wolfSSL_X509_get_signature(x509, NULL, &sigSz) <= 0) {
+        return WOLFSSL_FAILURE;
+    }
+
     if (sigSz > 0) {
         unsigned char* sig;
-        int sigNid = wolfSSL_X509_get_signature_nid(x509);
+        int sigNid;
+
+        sigNid = wolfSSL_X509_get_signature_nid(x509);
+        if (sigNid <= 0) {
+            return WOLFSSL_FAILURE;
+        }
 
         sig = (unsigned char*)XMALLOC(sigSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         if (sig == NULL) {

--- a/tests/api.c
+++ b/tests/api.c
@@ -52574,7 +52574,8 @@ static int test_wolfSSL_X509_CRL_print(void)
 
     fp = XFOPEN("./certs/crl/crl.pem", "rb");
     AssertTrue((fp != XBADFILE));
-    AssertNotNull(crl = (X509_CRL*)PEM_read_X509_CRL(fp, (X509_CRL **)NULL, NULL, NULL));
+    AssertNotNull(crl = (X509_CRL*)PEM_read_X509_CRL(fp, (X509_CRL **)NULL,
+                NULL, NULL));
     XFCLOSE(fp);
 
     AssertNotNull(bio = BIO_new(BIO_s_mem()));

--- a/tests/api.c
+++ b/tests/api.c
@@ -52533,9 +52533,9 @@ static int test_wolfSSL_X509_print(void)
 
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME)
     /* Will print IP address subject alt name. */
-    AssertIntEQ(BIO_get_mem_data(bio, NULL), 3240);
+    AssertIntEQ(BIO_get_mem_data(bio, NULL), 3255);
 #else
-    AssertIntEQ(BIO_get_mem_data(bio, NULL), 3218);
+    AssertIntEQ(BIO_get_mem_data(bio, NULL), 3233);
 #endif
     BIO_free(bio);
 
@@ -52555,6 +52555,32 @@ static int test_wolfSSL_X509_print(void)
     AssertIntEQ(X509_print_fp(stdout, x509), SSL_SUCCESS);
 
     X509_free(x509);
+    BIO_free(bio);
+    printf(resultFmt, passed);
+#endif
+
+    return 0;
+}
+
+static int test_wolfSSL_X509_CRL_print(void)
+{
+#if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && defined(HAVE_CRL)\
+    && !defined(NO_FILESYSTEM) && defined(XSNPRINTF)
+    X509_CRL* crl;
+    BIO *bio;
+    XFILE fp;
+
+    printf(testingFmt, "test_X509_CRL_print");
+
+    fp = XFOPEN("./certs/crl/crl.pem", "rb");
+    AssertTrue((fp != XBADFILE));
+    AssertNotNull(crl = (X509_CRL*)PEM_read_X509_CRL(fp, (X509_CRL **)NULL, NULL, NULL));
+    XFCLOSE(fp);
+
+    AssertNotNull(bio = BIO_new(BIO_s_mem()));
+    AssertIntEQ(X509_CRL_print(bio, crl), SSL_SUCCESS);
+
+    X509_CRL_free(crl);
     BIO_free(bio);
     printf(resultFmt, passed);
 #endif
@@ -57430,6 +57456,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_X509_get_version),
 #ifndef NO_BIO
     TEST_DECL(test_wolfSSL_X509_print),
+    TEST_DECL(test_wolfSSL_X509_CRL_print),
     TEST_DECL(test_wolfSSL_BIO_get_len),
 #endif
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -33116,10 +33116,8 @@ static int ParseCRL_CertList(DecodedCRL* dcrl, const byte* buf,
         return ASN_PARSE_E;
     }
 #ifdef OPENSSL_EXTRA
-    else {
-        dcrl->issuerSz = length + 3;
-        dcrl->issuer   = (byte*)GetNameFromDer(buf + idx, dcrl->issuerSz);
-    }
+    dcrl->issuerSz = length + (checkIdx - idx);
+    dcrl->issuer   = (byte*)GetNameFromDer(buf + idx, (int)dcrl->issuerSz);
 #endif
 
     if (GetNameHash(buf, &idx, dcrl->issuerHash, sz) < 0)
@@ -33377,7 +33375,7 @@ static int ParseCRL_Extensions(DecodedCRL* dcrl, const byte* buf,
                         }
 
                     #ifdef WOLFSSL_SMALL_STACK
-                        XFREE(m, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                        XFREE(m, NULL, DYNAMIC_TYPE_BIGINT);
                     #endif
                         mp_free(m);
                     }
@@ -33691,7 +33689,7 @@ end:
                             buff);
         dcrl->issuer   = (byte*)GetNameFromDer((byte*)GetASNItem_Addr(
                             dataASN[CRLASN_IDX_TBS_ISSUER], buff),
-                            dcrl->issuerSz);
+                            (int)dcrl->issuerSz);
         /* Calculate the Hash id from the issuer name. */
         ret = CalcHashId(GetASNItem_Addr(dataASN[CRLASN_IDX_TBS_ISSUER], buff),
                 dcrl->issuerSz, dcrl->issuerHash);

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2101,6 +2101,7 @@ struct CRL_Entry {
     byte    nextDateFormat;          /* next date format */
     RevokedCert* certs;              /* revoked cert list  */
     int          totalCerts;         /* number on list     */
+    int     version;                 /* version of certficate */
     int     verified;
     byte*   toBeSigned;
     word32  tbsSz;
@@ -2110,6 +2111,10 @@ struct CRL_Entry {
 #if !defined(NO_SKID) && !defined(NO_ASN)
     byte    extAuthKeyIdSet;
     byte    extAuthKeyId[KEYID_SIZE];
+#endif
+    int                   crlNumber;  /* CRL number extension */
+#if defined(OPENSSL_EXTRA)
+    WOLFSSL_X509_NAME*    issuer;     /* X509_NAME type issuer */
 #endif
 };
 

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -496,6 +496,7 @@ typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS;
 #define X509_REQ_print                  wolfSSL_X509_print
 #define X509_print_ex                   wolfSSL_X509_print_ex
 #define X509_print_fp                   wolfSSL_X509_print_fp
+#define X509_CRL_print                  wolfSSL_X509_CRL_print
 #define X509_REQ_print_fp               wolfSSL_X509_print_fp
 #define X509_signature_print            wolfSSL_X509_signature_print
 #define X509_get0_signature             wolfSSL_X509_get0_signature

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2790,11 +2790,16 @@ WOLFSSL_API WOLFSSL_X509_CRL *wolfSSL_d2i_X509_CRL_fp(XFILE file, WOLFSSL_X509_C
 #if defined(HAVE_CRL) && defined(OPENSSL_EXTRA)
 WOLFSSL_API int wolfSSL_X509_CRL_version(WOLFSSL_X509_CRL *crl);
 WOLFSSL_API int wolfSSL_X509_CRL_get_signature_type(WOLFSSL_X509_CRL* crl);
-WOLFSSL_API int wolfSSL_X509_CRL_get_signature_nid(const WOLFSSL_X509_CRL* crl);
-WOLFSSL_API int wolfSSL_X509_CRL_get_signature(WOLFSSL_X509_CRL* crl, unsigned char* buf, int* bufSz);
-WOLFSSL_API int wolfSSL_X509_CRL_print(WOLFSSL_BIO* bio, WOLFSSL_X509_CRL* crl);
-WOLFSSL_API WOLFSSL_X509_NAME* wolfSSL_X509_CRL_get_issuer_name(WOLFSSL_X509_CRL *crl);
-WOLFSSL_API int wolfSSL_X509_REVOKED_get_serial_number(RevokedCert* rev, byte* in, int* inOutSz);
+WOLFSSL_API int wolfSSL_X509_CRL_get_signature_nid(
+                                                  const WOLFSSL_X509_CRL* crl);
+WOLFSSL_API int wolfSSL_X509_CRL_get_signature(WOLFSSL_X509_CRL* crl,
+                                               unsigned char* buf, int* bufSz);
+WOLFSSL_API int wolfSSL_X509_CRL_print(WOLFSSL_BIO* bio,
+                                       WOLFSSL_X509_CRL* crl);
+WOLFSSL_API WOLFSSL_X509_NAME* wolfSSL_X509_CRL_get_issuer_name(
+                                                        WOLFSSL_X509_CRL *crl);
+WOLFSSL_API int wolfSSL_X509_REVOKED_get_serial_number(RevokedCert* rev,
+                                                       byte* in, int* inOutSz);
 WOLFSSL_API void wolfSSL_X509_CRL_free(WOLFSSL_X509_CRL *crl);
 #endif
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1413,7 +1413,7 @@ WOLFSSL_API int wolfSSL_sk_push_node(WOLFSSL_STACK** stack, WOLFSSL_STACK* in);
 WOLFSSL_API WOLFSSL_STACK* wolfSSL_sk_get_node(WOLFSSL_STACK* sk, int idx);
 WOLFSSL_API int wolfSSL_sk_push(WOLFSSL_STACK *st, const void *data);
 
-#ifdef HAVE_OCSP
+#if defined(HAVE_OCSP) || defined(HAVE_CRL)
 #include "wolfssl/wolfcrypt/asn.h"
 #endif
 
@@ -2787,7 +2787,16 @@ WOLFSSL_API WOLFSSL_X509_CRL *wolfSSL_d2i_X509_CRL_bio(WOLFSSL_BIO *bp,
 #if !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)
 WOLFSSL_API WOLFSSL_X509_CRL *wolfSSL_d2i_X509_CRL_fp(XFILE file, WOLFSSL_X509_CRL **crl);
 #endif
+#if defined(HAVE_CRL) && defined(OPENSSL_EXTRA)
+WOLFSSL_API int wolfSSL_X509_CRL_version(WOLFSSL_X509_CRL *crl);
+WOLFSSL_API int wolfSSL_X509_CRL_get_signature_type(WOLFSSL_X509_CRL* crl);
+WOLFSSL_API int wolfSSL_X509_CRL_get_signature_nid(const WOLFSSL_X509_CRL* crl);
+WOLFSSL_API int wolfSSL_X509_CRL_get_signature(WOLFSSL_X509_CRL* crl, unsigned char* buf, int* bufSz);
+WOLFSSL_API int wolfSSL_X509_CRL_print(WOLFSSL_BIO* bio, WOLFSSL_X509_CRL* crl);
+WOLFSSL_API WOLFSSL_X509_NAME* wolfSSL_X509_CRL_get_issuer_name(WOLFSSL_X509_CRL *crl);
+WOLFSSL_API int wolfSSL_X509_REVOKED_get_serial_number(RevokedCert* rev, byte* in, int* inOutSz);
 WOLFSSL_API void wolfSSL_X509_CRL_free(WOLFSSL_X509_CRL *crl);
+#endif
 
 #ifndef NO_FILESYSTEM
     #ifndef NO_STDIO_FILESYSTEM

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -2412,6 +2412,7 @@ struct DecodedCRL {
     RevokedCert* certs;              /* revoked cert list  */
 #if defined(OPENSSL_EXTRA)
     byte*   issuer;                  /* full name including common name  */
+    int     issuerSz;                /* length of the issuer             */
 #endif
     int          totalCerts;         /* number on list     */
     int          version;            /* version of cert    */

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -2412,7 +2412,7 @@ struct DecodedCRL {
     RevokedCert* certs;              /* revoked cert list  */
 #if defined(OPENSSL_EXTRA)
     byte*   issuer;                  /* full name including common name  */
-    int     issuerSz;                /* length of the issuer             */
+    word32  issuerSz;                /* length of the issuer             */
 #endif
     int          totalCerts;         /* number on list     */
     int          version;            /* version of cert    */

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -2391,6 +2391,8 @@ struct RevokedCert {
     byte         serialNumber[EXTERNAL_SERIAL_SIZE];
     int          serialSz;
     RevokedCert* next;
+    byte         revDate[MAX_DATE_SIZE];
+    byte         revDateFormat;
 };
 
 typedef struct DecodedCRL DecodedCRL;
@@ -2408,12 +2410,17 @@ struct DecodedCRL {
     byte    lastDateFormat;          /* format of last date */
     byte    nextDateFormat;          /* format of next date */
     RevokedCert* certs;              /* revoked cert list  */
+#if defined(OPENSSL_EXTRA)
+    byte*   issuer;                  /* full name including common name  */
+#endif
     int          totalCerts;         /* number on list     */
+    int          version;            /* version of cert    */
     void*   heap;
 #ifndef NO_SKID
     byte    extAuthKeyIdSet;
     byte    extAuthKeyId[SIGNER_DIGEST_SIZE]; /* Authority Key ID        */
 #endif
+    int          crlNumber;          /* CRL number extension  */
 };
 
 WOLFSSL_LOCAL void InitDecodedCRL(DecodedCRL* dcrl, void* heap);


### PR DESCRIPTION
Adding `X509_CRL_print()` function, some parse methods, and fields to the appropriate structs when necessary.