### PR TITLE
Update sp_rand_prime's preprocessor gating to match wolfSSL_BN_generate_prime_ex's.

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -15672,8 +15672,8 @@ int sp_radix_size(sp_int* a, int radix, int* size)
  * Prime number generation and checking.
  ***************************************/
 
-#if defined(WOLFSSL_KEY_GEN) && (!defined(NO_DH) || !defined(NO_DSA)) && \
-    !defined(WC_NO_RNG)
+#if defined(WOLFSSL_KEY_GEN) && (!defined(NO_RSA) || !defined(NO_DH) || \
+    !defined(NO_DSA)) && !defined(WC_NO_RNG)
 /* Generate a random prime for RSA only.
  *
  * @param  [out]  r     SP integer to hold result.


### PR DESCRIPTION
# Description

wolfSSL_BN_generate_prime_ex is using sp_rand_prime, but sp_rand_prime is being excluded from the build with NO_RSA undefined while wolfSSL_BN_generate_prime_ex is not.  Update preprocessor gating to match.

Fixes #5386

# Testing

Confirmed building and passing all tests

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
