### PR TITLE
Fix to copy TLS version with wolfSSL_write_dup

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -753,6 +753,9 @@ static int DupSSL(WOLFSSL* dup, WOLFSSL* ssl)
     XMEMCPY(&dup->options, &ssl->options, sizeof(Options));
     XMEMCPY(&dup->keys,    &ssl->keys,    sizeof(Keys));
     XMEMCPY(&dup->encrypt, &ssl->encrypt, sizeof(Ciphers));
+    XMEMCPY(&dup->version, &ssl->version, sizeof(ProtocolVersion));
+    XMEMCPY(&dup->chVersion, &ssl->chVersion, sizeof(ProtocolVersion));
+
     /* dup side now owns encrypt/write ciphers */
     XMEMSET(&ssl->encrypt, 0, sizeof(Ciphers));
 


### PR DESCRIPTION
# Description

`wolfSSL_write_dup`  was not copying the version structure from the SSL object.

Fixes #5366 

# Testing

Added server writedup example: https://github.com/wolfSSL/wolfssl-examples/pull/329

# Checklist

 - [X] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
