### PR TITLE
Fix memory leak in ECDHE with TSIP

### DIFF
--- a/IDE/Renesas/e2studio/RX65N/GR-ROSE/test/src/wolf_client.c
+++ b/IDE/Renesas/e2studio/RX65N/GR-ROSE/test/src/wolf_client.c
@@ -27,7 +27,9 @@
 #include "wolfssl/certs_test.h"
 #include "key_data.h"
 #include "wolfssl_demo.h"
-
+#if defined(WOLFSSL_RENESAS_TSIP_TLS)
+    #include <wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h>
+#endif
 
 #define SIMPLE_TLSSEVER_IP       "192.168.1.12"
 #define SIMPLE_TLSSERVER_PORT    "11111"

--- a/wolfcrypt/src/port/Renesas/renesas_common.c
+++ b/wolfcrypt/src/port/Renesas/renesas_common.c
@@ -544,7 +544,7 @@ WOLFSSL_LOCAL int Renesas_cmn_EccVerify(WOLFSSL* ssl, const unsigned char* sig,
  * key_e_start Byte position of public key exponent in cert
  * key_e_len   Length of public key exponent
  * cm_row      CA index
- * return FSP_SUCCESS(0) on success, otherwise FSP/TSIP error code
+ * return FSP_SUCCESS(0) on success, otherwise WOLFSSL_FATAL_ERROR
  */
 int wc_Renesas_cmn_RootCertVerify(const byte* cert, word32 cert_len, word32 key_n_start,
         word32 key_n_len, word32 key_e_start, word32 key_e_len, word32 cm_row)
@@ -564,11 +564,16 @@ int wc_Renesas_cmn_RootCertVerify(const byte* cert, word32 cert_len, word32 key_
         ret = wc_sce_tls_RootCertVerify(cert, cert_len, key_n_start,
                 key_n_len, key_e_start, key_e_len, cm_row);
     #endif
+
+        if (ret != TSIP_SUCCESS) {
+            ret = WOLFSSL_FATAL_ERROR;
+        }
     }
     else {
         /* already verified. skipped */
         ret = 0;
     }
+    WOLFSSL_LEAVE("wc_Renesas_cmn_RootCertVerify", ret);
     return ret;
 }
 

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_aes.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_aes.c
@@ -723,7 +723,7 @@ int wc_tsip_AesGcmEncrypt(
              * iv init func.
              * It expects to pass iv when users create their own key.
              */
-            err = initFn(&hdl, &key_client_aes, iv_l, ivSz_l);
+            err = initFn(&hdl, &key_client_aes, (uint8_t*)iv_l, ivSz_l);
 
             if (err == TSIP_SUCCESS) {
             	err = updateFn(&hdl, NULL, NULL, 0UL, (uint8_t*)aadBuf, authInSz);
@@ -917,7 +917,7 @@ int wc_tsip_AesGcmDecrypt(
              *
              * It expects to pass iv when users create their own key.
              */
-            err = initFn(&hdl, &key_server_aes, iv_l, ivSz_l);
+            err = initFn(&hdl, &key_server_aes, (uint8_t*)iv_l, ivSz_l);
 
             if (err == TSIP_SUCCESS) {
                 /* pass only AAD and it's size before passing cipher text */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -257,6 +257,9 @@
     #include <wolfssl/wolfcrypt/port/iotsafe/iotsafe.h>
 #endif
 
+#if defined(WOLFSSL_RENESAS_TSIP_TLS)
+    #include <wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h>
+#endif
 
 #ifdef __cplusplus
     extern "C" {


### PR DESCRIPTION
# Description

This PR is to fix memory leak in ECDHE with TSIP. There is a memory leak in the logic for adjusting the signature data so that TSIP can process it. Fix it by rewriting the logic not to use the dynamically allocated memory.
Also includes fix for warnings and fix for result code from wc_Renesas_cmn_RootCertVerify on error.

Fixes zd#

# Testing

Build a example code with CC-RX compiler and run it on the board.  

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
