### PR TITLE
Cert path length: add flag to indicate path length set

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -48069,6 +48069,7 @@ static int test_MakeCertWithPathLen(void)
     cert.selfSigned = 1;
     cert.isCA       = 1;
     cert.pathLen    = expectedPathLen;
+    cert.pathLenSet = 1;
     cert.sigType    = CTC_SHA256wECDSA;
 
 #ifdef WOLFSSL_CERT_EXT

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -24451,7 +24451,7 @@ static int EncodeExtensions(Cert* cert, byte* output, word32 maxSz,
             /* Set Basic Constraints to be a Certificate Authority. */
             SetASN_Boolean(&dataASN[CERTEXTSASN_IDX_BC_CA], 1);
             SetASN_Buffer(&dataASN[CERTEXTSASN_IDX_BC_OID], bcOID, sizeof(bcOID));
-            if (cert->pathLen
+            if (cert->pathLenSet
             #ifdef WOLFSSL_CERT_EXT
                 && ((cert->keyUsage & KEYUSE_KEY_CERT_SIGN) || (!cert->keyUsage))
             #endif
@@ -25057,7 +25057,7 @@ static int EncodeCert(Cert* cert, DerCert* der, RsaKey* rsaKey, ecc_key* eccKey,
      * asserted and the key usage extension, if present, asserts the
      * keyCertSign bit */
     /* Set CA and path length */
-    if ((cert->isCA) && (cert->pathLen)
+    if ((cert->isCA) && (cert->pathLenSet)
 #ifdef WOLFSSL_CERT_EXT
         && ((cert->keyUsage & KEYUSE_KEY_CERT_SIGN) || (!cert->keyUsage))
 #endif
@@ -26244,7 +26244,7 @@ static int EncodeCertReq(Cert* cert, DerCert* der, RsaKey* rsaKey,
      * asserted and the key usage extension, if present, asserts the
      * keyCertSign bit */
     /* Set CA and path length */
-    if ((cert->isCA) && (cert->pathLen)
+    if ((cert->isCA) && (cert->pathLenSet)
 #ifdef WOLFSSL_CERT_EXT
         && ((cert->keyUsage & KEYUSE_KEY_CERT_SIGN) || (!cert->keyUsage))
 #endif

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -449,6 +449,7 @@ typedef struct Cert {
     byte*   der;              /* Pointer to buffer of current DecodedCert cache */
     void*   heap;             /* heap hint */
     byte    basicConstSet:1;  /* Indicator for when Basic Constaint is set */
+    byte    pathLenSet:1;     /* Indicator for when path length is set */
 } Cert;
 
 


### PR DESCRIPTION
# Description

A path length is allowed to be 0.
Can't check path len for 0 to determine when value is set.
Added flag to indicate path length is set.

Fixes zd#14418

# Testing

Changed test.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
