### PR TITLE
Fix for CMake not installing sp_int.h for SP math all

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2044,7 +2044,11 @@ endif()
 
 if(NOT BUILD_SP)
   list(APPEND HEADER_EXCLUDE
-    "wolfssl/wolfcrypt/sp.h"
+    "wolfssl/wolfcrypt/sp.h")
+endif()
+
+if(NOT BUILD_SP_INT)
+  list(APPEND HEADER_EXCLUDE
     "wolfssl/wolfcrypt/sp_int.h")
 endif()
 


### PR DESCRIPTION
# Description

Fix for CMake not installing sp_int.h for SP math all.

Fixes https://github.com/microsoft/vcpkg/pull/25936

# Testing

```
mkdir build
cd build
cmake .. -DCMAKE_INSTALL_PREFIX=install
make
make install
find install -name sp_int.h
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
