### PR TITLE
TFM: change inline x86 asm code to compile with clang

### DIFF
--- a/wolfcrypt/src/asm.c
+++ b/wolfcrypt/src/asm.c
@@ -703,7 +703,7 @@ __asm__(                                                  \
      "addl  %%eax,%0     \n\t"                            \
      "adcl  %%edx,%1     \n\t"                            \
      "adcl  $0,%2        \n\t"                            \
-     :"+rm"(c0), "+rm"(c1), "+rm"(c2)                     \
+     :"+m"(c0), "+m"(c1), "+m"(c2)                        \
      : "m"(i)                                             \
      :"%eax","%edx","cc");
 
@@ -717,7 +717,7 @@ __asm__(                                                  \
      "addl  %%eax,%0     \n\t"                            \
      "adcl  %%edx,%1     \n\t"                            \
      "adcl  $0,%2        \n\t"                            \
-     :"+rm"(c0), "+rm"(c1), "+rm"(c2)                     \
+     :"+m"(c0), "+m"(c1), "+m"(c2)                        \
      : "m"(i), "m"(j)                                     \
      :"%eax","%edx", "cc");
 


### PR DESCRIPTION
# Description

TFM not compiling for x86 with clang.

Fixes #5396

# Testing

./configure '--disable-shared' '--enable-32bit' '--enable-fastmath' 'CFLAGS=-m32 -msse3 -march=i686' 'CC=clang'

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
