### PR TITLE
Add missing BIO_should_read and BIO_should_write functions

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -3207,6 +3207,26 @@ int wolfSSL_BIO_should_retry(WOLFSSL_BIO *bio)
     return ret;
 }
 
+int wolfSSL_BIO_should_read(WOLFSSL_BIO *bio)
+{
+    int ret = 0;
+    if (bio != NULL) {
+        ret = (int)(bio->flags & WOLFSSL_BIO_FLAG_READ);
+    }
+
+    return ret;
+}
+
+int wolfSSL_BIO_should_write(WOLFSSL_BIO *bio)
+{
+    int ret = 0;
+    if (bio != NULL) {
+        ret = (int)(bio->flags & WOLFSSL_BIO_FLAG_WRITE);
+    }
+
+    return ret;
+}
+
 #endif /* OPENSSL_ALL */
 
 #endif /* WOLFSSL_BIO_INCLUDED */

--- a/wolfssl/openssl/bio.h
+++ b/wolfssl/openssl/bio.h
@@ -79,6 +79,8 @@
 #define BIO_puts      wolfSSL_BIO_puts
 
 #define BIO_should_retry                wolfSSL_BIO_should_retry
+#define BIO_should_write                wolfSSL_BIO_should_write
+#define BIO_should_read                 wolfSSL_BIO_should_read
 
 #define BIO_TYPE_FILE WOLFSSL_BIO_FILE
 #define BIO_TYPE_BIO  WOLFSSL_BIO_BIO

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1625,6 +1625,8 @@ WOLFSSL_API void wolfSSL_BIO_set_shutdown(WOLFSSL_BIO* bio, int shut);
 WOLFSSL_API int wolfSSL_BIO_get_shutdown(WOLFSSL_BIO* bio);
 WOLFSSL_API void wolfSSL_BIO_clear_retry_flags(WOLFSSL_BIO* bio);
 WOLFSSL_API int wolfSSL_BIO_should_retry(WOLFSSL_BIO *bio);
+WOLFSSL_API int wolfSSL_BIO_should_read(WOLFSSL_BIO *bio);
+WOLFSSL_API int wolfSSL_BIO_should_write(WOLFSSL_BIO *bio);
 
 WOLFSSL_API WOLFSSL_BIO_METHOD *wolfSSL_BIO_meth_new(int type, const char* name);
 WOLFSSL_API void wolfSSL_BIO_meth_free(WOLFSSL_BIO_METHOD* biom);


### PR DESCRIPTION
# Description
Currently, BIO_should_retry exists as a component of the OpenSSL compatibility layer. However, there is no way to check the should_read/should_write flag of a BIO object - the BIO_should_read and BIO_should_write functions from OpenSSL are not implemented.

I've implemented the two missing functions as `wolfSSL_BIO_should_read` and `wolfSSL_BIO_should_write` by letting wolfSSL check the flags of the BIO, then created the compatibility definitions for `BIO_should_read` and `BIO_should_write` in the OpenSSL compatibility header.

# Testing

I've created two unit tests, `test_wolfSSL_BIO_should_read` and `test_wolfSSL_BIO_should_write`. They each test the respective function before creating the connection and when a read or write is expected to happen.

I've ran the unit_test program after creating these unit tests, and all unit tests completed successfully.

# Checklist

 - [X] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
