### PR TITLE
ASN template: allow SAN to be critical

### DIFF
--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -450,6 +450,9 @@ typedef struct Cert {
     void*   heap;             /* heap hint */
     byte    basicConstSet:1;  /* Indicator for when Basic Constaint is set */
     byte    pathLenSet:1;     /* Indicator for when path length is set */
+#ifdef WOLFSSL_ALT_NAMES
+    byte    altNamesCrit:1;   /* Indicator of criticality of SAN extension */
+#endif
 } Cert;
 
 


### PR DESCRIPTION
# Description

Define WOLFSSL_X509_SAN_CRITICAL to encode certificate extension Subject
Alternative Name as critical.

Fixes zd#14581

# Testing

Standard testing.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
