### PR TITLE
Integrate chacha20-poly1305 into the EVP interface

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -25788,6 +25788,9 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
         { NID_des, DESb, oidBlkType, "DES-CBC", "des-cbc"},
         { NID_des3, DES3b, oidBlkType, "DES-EDE3-CBC", "des-ede3-cbc"},
     #endif /* !NO_DES3 */
+    #if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
+        { NID_chacha20_poly1305, NID_chacha20_poly1305, oidBlkType, "ChaCha20-Poly1305", "chacha20-poly1305"},
+    #endif
 
         /* oidOcspType */
     #ifdef HAVE_OCSP

--- a/tests/api.c
+++ b/tests/api.c
@@ -4462,6 +4462,10 @@ static int test_wolfSSL_EVP_get_cipherbynid(void)
 #endif
 #endif /* !NO_DES3 */
 
+#if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
+    AssertNotNull(strcmp("EVP_CHACHA20_POLY13O5", EVP_get_cipherbynid(1018)));
+#endif
+
   /* test for nid is out of range */
   AssertNull(wolfSSL_EVP_get_cipherbynid(1));
 
@@ -45587,6 +45591,10 @@ static int test_wolfSSL_EVP_CIPHER_block_size(void)
     AssertIntEQ(EVP_CIPHER_block_size(wolfSSL_EVP_rc4()), 1);
 #endif
 
+#if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
+    AssertIntEQ(EVP_CIPHER_block_size(wolfSSL_EVP_chacha20_poly1305()), 1);
+#endif
+
     return 0;
 }
 
@@ -45636,6 +45644,9 @@ static int test_wolfSSL_EVP_CIPHER_iv_length(void)
          NID_des_cbc,
          NID_des_ede3_cbc,
     #endif
+    #if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
+         NID_chacha20_poly1305,
+    #endif
     };
 
     int iv_lengths[] = {
@@ -45678,6 +45689,9 @@ static int test_wolfSSL_EVP_CIPHER_iv_length(void)
     #ifndef NO_DES3
             DES_BLOCK_SIZE,
             DES_BLOCK_SIZE,
+    #endif
+    #if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
+            CHACHA20_POLY1305_AEAD_IV_SIZE,
     #endif
     };
 

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -244,6 +244,9 @@ int wolfSSL_EVP_Cipher_key_length(const WOLFSSL_EVP_CIPHER* c)
       case DES_ECB_TYPE:      return 8;
       case DES_EDE3_ECB_TYPE: return 24;
   #endif
+  #if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
+      case CHACHA20_POLY1305_TYPE: return 32;
+  #endif
       default:
           return 0;
       }
@@ -1289,6 +1292,12 @@ static unsigned int cipherType(const WOLFSSL_EVP_CIPHER *cipher)
     else if (EVP_CIPHER_TYPE_MATCHES(cipher, EVP_ARC4))
       return ARC4_TYPE;
 #endif
+
+#if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
+    else if (EVP_CIPHER_TYPE_MATCHES(cipher, EVP_CHACHA20_POLY1305))
+        return CHACHA20_POLY1305_TYPE;
+#endif
+
       else return 0;
 }
 
@@ -1357,6 +1366,11 @@ int wolfSSL_EVP_CIPHER_block_size(const WOLFSSL_EVP_CIPHER *cipher)
       case DES_ECB_TYPE: return 8;
       case DES_EDE3_ECB_TYPE: return 8;
 #endif
+
+#if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
+      case CHACHA20_POLY1305_TYPE:
+          return 1;
+#endif
       default:
           return 0;
       }
@@ -1424,6 +1438,10 @@ unsigned long WOLFSSL_CIPHER_mode(const WOLFSSL_EVP_CIPHER *cipher)
     #ifndef NO_RC4
         case ARC4_TYPE:
             return EVP_CIPH_STREAM_CIPHER;
+    #endif
+    #if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
+        case CHACHA20_POLY1305_TYPE:
+            return WOLFSSL_EVP_CIPH_STREAM_CIPHER;
     #endif
         default:
             return 0;
@@ -4152,6 +4170,10 @@ static const struct cipher{
     {ARC4_TYPE, EVP_ARC4, NID_undef},
 #endif
 
+#if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
+    {CHACHA20_POLY1305_TYPE, EVP_CHACHA20_POLY1305, NID_chacha20_poly1305},
+#endif
+
     { 0, NULL, 0}
 };
 
@@ -4248,6 +4270,9 @@ const WOLFSSL_EVP_CIPHER *wolfSSL_EVP_get_cipherbyname(const char *name)
 #endif
 #ifndef NO_RC4
         {EVP_ARC4, "RC4"},
+#endif
+#if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
+        {EVP_CHACHA20_POLY1305, "chacha20-poly1305"},
 #endif
         { NULL, NULL}
     };
@@ -4361,6 +4386,11 @@ const WOLFSSL_EVP_CIPHER *wolfSSL_EVP_get_cipherbynid(int id)
             return wolfSSL_EVP_des_ede3_ecb();
 #endif
 #endif /*NO_DES3*/
+
+#if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
+        case NID_chacha20_poly1305:
+            return wolfSSL_EVP_chacha20_poly1305();
+#endif
 
         default:
             WOLFSSL_MSG("Bad cipher id value");
@@ -8355,6 +8385,11 @@ int wolfSSL_EVP_CIPHER_CTX_iv_length(const WOLFSSL_EVP_CIPHER_CTX* ctx)
             WOLFSSL_MSG("AES XTS");
             return AES_BLOCK_SIZE;
 #endif /* WOLFSSL_AES_XTS */
+#if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
+        case CHACHA20_POLY1305_TYPE:
+            WOLFSSL_MSG("CHACHA20 POLY1305");
+            return CHACHA20_POLY1305_AEAD_IV_SIZE;
+#endif /* HAVE_CHACHA HAVE_POLY1305 */
 
         case NULL_CIPHER_TYPE :
             WOLFSSL_MSG("NULL");
@@ -8437,6 +8472,11 @@ int wolfSSL_EVP_CIPHER_iv_length(const WOLFSSL_EVP_CIPHER* cipher)
            (XSTRCMP(name, EVP_DES_EDE3_CBC) == 0)) {
         return DES_BLOCK_SIZE;
     }
+#endif
+
+#if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
+    if (XSTRCMP(name, EVP_CHACHA20_POLY1305) == 0)
+        return CHACHA20_POLY1305_AEAD_IV_SIZE;
 #endif
 
     (void)name;

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -1441,7 +1441,8 @@ unsigned long WOLFSSL_CIPHER_mode(const WOLFSSL_EVP_CIPHER *cipher)
     #endif
     #if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
         case CHACHA20_POLY1305_TYPE:
-            return WOLFSSL_EVP_CIPH_STREAM_CIPHER;
+            return WOLFSSL_EVP_CIPH_STREAM_CIPHER |
+                    WOLFSSL_EVP_CIPH_FLAG_AEAD_CIPHER;
     #endif
         default:
             return 0;


### PR DESCRIPTION
# Description

ChaCha20-Poly1305 support was missing from several EVP methods: `EVP_CIPHER_type`, `EVP_CIPHER_block_size`, `EVP_get_cipherbyname`, `EVP_get_cipherbynid`, `EVP_CIPHER_iv_length` and `EVP_CIPHER_CTX_iv_length`.

This PR adds the missing cases for ChaCha20-Poly1305, allowing its various properties to be queried, and allows for ChaCha20 to be found using `EVP_get_cipherbyname` and `EVP_get_cipherbynid`.

# Testing

I've compiled an application I'm porting that currently uses OpenSSL's ChaCha20 interface, with the new WolfSSL changes and it's working fine. I've also compared, manually, the return values of OpenSSL's implementation and the return values of WolfSSL with the changes applied, and they match nicely. I've also added some new tests.

# Checklist

 - [X] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
