### PR TITLE
20220728-fixes

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -39,8 +39,10 @@
 #ifdef HAVE_PTHREAD
     #include <pthread.h>
 #endif
-#if defined(HAVE_PTHREAD) || \
-        (!defined(NO_STDIO_FILESYSTEM) && !defined(NO_ERROR_STRINGS))
+#if defined(HAVE_PTHREAD) ||                                          \
+    (!defined(NO_CRYPT_BENCHMARK) && !defined(NO_STDIO_FILESYSTEM) && \
+     !defined(NO_ERROR_STRINGS) && !defined(NO_MAIN_DRIVER) &&        \
+     !defined(BENCH_EMBEDDED))
     #include <errno.h>
     #include <unistd.h>
 #endif
@@ -320,7 +322,8 @@
 #endif
 
 #undef LIBCALL_CHECK_RET
-#if defined(NO_STDIO_FILESYSTEM) || defined(NO_ERROR_STRINGS)
+#if defined(NO_STDIO_FILESYSTEM) || defined(NO_ERROR_STRINGS) || \
+    defined(NO_MAIN_DRIVER) || defined(BENCH_EMBEDDED)
 #define LIBCALL_CHECK_RET(...) __VA_ARGS__
 #else
 #define LIBCALL_CHECK_RET(...) do {                           \

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -7121,7 +7121,7 @@ int sp_div(sp_int* a, sp_int* d, sp_int* r, sp_int* rem)
         }
     }
 
-    if (!done) {
+    if ((!done) && (err == MP_OKAY)) {
 #if (defined(WOLFSSL_SMALL_STACK) || defined(SP_ALLOC)) && \
     !defined(WOLFSSL_SP_NO_MALLOC)
         int cnt = 4;


### PR DESCRIPTION
fixes for `clang-analyzer-core.NullDereference` in `sp_div()`, and inadequate gating on `#include <unistd.h>` in benchmark.c.

tested with `wolfssl-multi-test.sh ... super-quick-check`.
