### PR TITLE
Ensure ChaCha20 updates out length during cipher update

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -51683,9 +51683,12 @@ static int test_wolfssl_EVP_chacha20_poly1305(void)
     AssertIntEQ(EVP_EncryptInit_ex(ctx, NULL, NULL, key, iv), WOLFSSL_SUCCESS);
     AssertIntEQ(EVP_EncryptUpdate(ctx, NULL, &outSz, aad, sizeof(aad)),
                WOLFSSL_SUCCESS);
+    AssertIntEQ(outSz, sizeof(aad));
     AssertIntEQ(EVP_EncryptUpdate(ctx, cipherText, &outSz, plainText,
                 sizeof(plainText)), WOLFSSL_SUCCESS);
+    AssertIntEQ(outSz, sizeof(plainText));
     AssertIntEQ(EVP_EncryptFinal_ex(ctx, cipherText, &outSz), WOLFSSL_SUCCESS);
+    AssertIntEQ(outSz, 0);
     /* Invalid tag length. */
     AssertIntEQ(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG,
                 CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE-1, tag), WOLFSSL_FAILURE);
@@ -51705,10 +51708,13 @@ static int test_wolfssl_EVP_chacha20_poly1305(void)
     AssertIntEQ(EVP_DecryptInit_ex(ctx, NULL, NULL, key, iv), WOLFSSL_SUCCESS);
     AssertIntEQ(EVP_DecryptUpdate(ctx, NULL, &outSz, aad, sizeof(aad)),
                WOLFSSL_SUCCESS);
+    AssertIntEQ(outSz, sizeof(aad));
     AssertIntEQ(EVP_DecryptUpdate(ctx, decryptedText, &outSz, cipherText,
                 sizeof(cipherText)), WOLFSSL_SUCCESS);
+    AssertIntEQ(outSz, sizeof(cipherText));
     AssertIntEQ(EVP_DecryptFinal_ex(ctx, decryptedText, &outSz),
                 WOLFSSL_SUCCESS);
+    AssertIntEQ(outSz, 0);
     EVP_CIPHER_CTX_free(ctx);
 
     printf(resultFmt, passed);

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -687,6 +687,7 @@ int wolfSSL_EVP_CipherUpdate(WOLFSSL_EVP_CIPHER_CTX *ctx,
                     return WOLFSSL_FAILURE;
                 }
                 else {
+                    *outl = inl;
                     return WOLFSSL_SUCCESS;
                 }
             }
@@ -697,6 +698,7 @@ int wolfSSL_EVP_CipherUpdate(WOLFSSL_EVP_CIPHER_CTX *ctx,
                     return WOLFSSL_FAILURE;
                 }
                 else {
+                    *outl = inl;
                     return WOLFSSL_SUCCESS;
                 }
             }
@@ -946,6 +948,7 @@ int wolfSSL_EVP_CipherFinal(WOLFSSL_EVP_CIPHER_CTX *ctx, unsigned char *out,
                 return WOLFSSL_FAILURE;
             }
             else {
+                *outl = 0;
                 return WOLFSSL_SUCCESS;
             }
 #endif


### PR DESCRIPTION
# Description

Right now, `wolfSSL_EVP_CipherFinal` and `wolfSSL_EVP_CipherUpdate` do NOT update the `outl` parameter when using ChaCha20-Poly1305. This is a problem, because it also breaks the OpenSSL compatibility layer.

This PR ensures that `outl` is updated and the caller receives the number of bytes updated during a ChaCha20 update/finalization round.

# Testing

I've updated the test cases to check the expected values of the `outl` parameter when using the ChaCha20-Poly1305 cipher. I've also manually compared it to OpenSSL's return values and found that they match.

# Checklist

 - [X] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
