### PR TITLE
20220729-fixes

### DIFF
--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1164,7 +1164,7 @@ enum {
         #define WOLFSSL_MAX_RSA_BITS    (FP_MAX_BITS / 2)
     #elif defined(WOLFSSL_SP_MATH_ALL) || defined(WOLFSSL_SP_MATH)
         /* SP implementation supports numbers of SP_INT_BITS bits. */
-        #define WOLFSSL_MAX_RSA_BITS    ((SP_INT_BITS + 7) / 8) * 8
+        #define WOLFSSL_MAX_RSA_BITS    (((SP_INT_BITS + 7) / 8) * 8)
     #else
         /* Integer maths is dynamic but we only go up to 4096 bits. */
         #define WOLFSSL_MAX_RSA_BITS 4096
@@ -1227,7 +1227,7 @@ enum {
         #error "MySQL needs SP_INT_BITS at least at 8192"
     #endif
 
-    #if WOLFSSL_MAX_RSA_BITS > ENCRYPT_BASE_BITS
+    #if WOLFSSL_MAX_RSA_BITS > SP_INT_BITS
         #error "SP_INT_BITS too small for WOLFSSL_MAX_RSA_BITS"
     #endif
 #else


### PR DESCRIPTION
wolfssl/internal.h: fix spurious assert failure on jumbo RSA key configurations (> 8192 bits); mollify `bugprone-macro-parentheses`.

tested with `wolfssl-multi-test.sh ... super-quick-check all-crypto-linuxkm-defaults-max-func-stack-2k-build all-crypto-linuxkm-defaults-max-func-stack-2k-build-fips`
