### PR TITLE
fix: dtls13: use correct buffer index to get epoch bits

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -9701,7 +9701,7 @@ static int GetDtls13RecordHeader(WOLFSSL* ssl, const byte* input,
     if (readSize < DTLS_UNIFIED_HEADER_MIN_SZ)
         return BUFFER_ERROR;
 
-    epochBits = *input & EE_MASK;
+    epochBits = *(input + *inOutIdx) & EE_MASK;
     ret = Dtls13ReconstructEpochNumber(ssl, epochBits, &epochNumber);
     if (ret != 0)
         return ret;


### PR DESCRIPTION
The bug was introduced by d0796627651674c0d1c24e6f60f1fb8fb5db6665

# Testing

`./configure --enable-dtls --enable-dtls13 --enable-opensslextra && make check` restricting the process to run on a single core


