### PR TITLE
DTLS socket and timeout fixes

### DIFF
--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -2296,6 +2296,10 @@ int Dtls13RtxTimeout(WOLFSSL* ssl)
         return 0;
     }
 
+    /* Increase timeout on long timeout */
+    if (DtlsMsgPoolTimeout(ssl) != 0)
+        return -1;
+
     return Dtls13RtxSendBuffered(ssl);
 }
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -7962,8 +7962,6 @@ void DtlsTxMsgListClean(WOLFSSL* ssl)
              * verify */
             break;
         ssl->dtls_tx_msg_list_sz--;
-        /* Reset timer as deleting a node means that state has progressed */
-        ssl->dtls_timeout = ssl->dtls_timeout_init;
         head = next;
     }
     ssl->dtls_tx_msg_list = head;
@@ -8263,8 +8261,7 @@ int DtlsMsgPoolTimeout(WOLFSSL* ssl)
 }
 
 
-/* DtlsMsgPoolReset() deletes the stored transmit list and resets the timeout
- * value. */
+/* DtlsMsgPoolReset() deletes the stored transmit list. */
 void DtlsMsgPoolReset(WOLFSSL* ssl)
 {
     WOLFSSL_ENTER("DtlsMsgPoolReset()");
@@ -8274,7 +8271,6 @@ void DtlsMsgPoolReset(WOLFSSL* ssl)
         ssl->dtls_tx_msg = NULL;
         ssl->dtls_tx_msg_list_sz = 0;
     }
-    ssl->dtls_timeout = ssl->dtls_timeout_init;
 }
 
 
@@ -18744,6 +18740,11 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
 #ifdef WOLFSSL_DTLS
             if (IsDtlsNotSctpMode(ssl) && !IsAtLeastTLSv1_3(ssl->version)) {
                 _DtlsUpdateWindow(ssl);
+            }
+
+            if (ssl->options.dtls) {
+                /* Reset timeout as we have received a valid DTLS message */
+                ssl->dtls_timeout = ssl->dtls_timeout_init;
             }
 #endif /* WOLFSSL_DTLS */
 

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -4790,7 +4790,7 @@ static const byte* DecryptMessage(WOLFSSL* ssl, const byte* input, word32 sz,
 
 #ifdef WOLFSSL_TLS13
     if (IsAtLeastTLSv1_3(ssl->version)) {
-        ret = DecryptTls13(ssl, output, input, sz, (byte*)rh, RECORD_HEADER_SZ, 0);
+        ret = DecryptTls13(ssl, output, input, sz, (byte*)rh, RECORD_HEADER_SZ);
     }
     else
 #endif

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -2278,11 +2278,10 @@ static int Tls13IntegrityOnly_Decrypt(WOLFSSL* ssl, byte* output,
  * sz      The length of the encrypted data plus authentication tag.
  * aad     The additional authentication data.
  * aadSz   The size of the addition authentication data.
- * doAlert Generate alert on error (set to 0 for sniffer use cases)
  * returns 0 on success, otherwise failure.
  */
 int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
-                 const byte* aad, word16 aadSz, int doAlert)
+                 const byte* aad, word16 aadSz)
 {
     int    ret    = 0;
     word16 dataSz = sz - ssl->specs.aead_mac_size;
@@ -2476,17 +2475,6 @@ int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
        default:
             break;
     }
-
-#ifndef WOLFSSL_EARLY_DATA
-    if (ret < 0) {
-        if (doAlert) {
-            SendAlert(ssl, alert_fatal, bad_record_mac);
-        }
-        ret = VERIFY_MAC_ERROR;
-    }
-#else
-    (void)doAlert;
-#endif
 
     return ret;
 }

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -481,6 +481,20 @@ int EmbedReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
         }
         return recvd;
     }
+    else if (recvd == 0) {
+        int type;
+        XSOCKLENT length = sizeof(int); /* optvalue 'type' is of size int */
+
+        if (getsockopt(sd, SOL_SOCKET, SO_TYPE, &type, &length) == 0 &&
+                type != SOCK_DGRAM) {
+            /* Closed TCP connection */
+            recvd = WOLFSSL_CBIO_ERR_CONN_CLOSE;
+        }
+        else {
+            WOLFSSL_MSG("Ignoring 0-length datagram");
+        }
+        return recvd;
+    }
     else if (dtlsCtx->connected) {
         /* Nothing to do */
     }

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -372,6 +372,20 @@ static int sockAddrEqual(
     return 0;
 }
 
+static int isDGramSock(int sfd)
+{
+    int type = 0;
+    XSOCKLENT length = sizeof(int); /* optvalue 'type' is of size int */
+
+    if (getsockopt(sfd, SOL_SOCKET, SO_TYPE, &type, &length) == 0 &&
+            type != SOCK_DGRAM) {
+        return 0;
+    }
+    else {
+        return 1;
+    }
+}
+
 /* The receive embedded callback
  *  return : nb bytes read, or error
  */
@@ -482,11 +496,7 @@ int EmbedReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
         return recvd;
     }
     else if (recvd == 0) {
-        int type;
-        XSOCKLENT length = sizeof(int); /* optvalue 'type' is of size int */
-
-        if (getsockopt(sd, SOL_SOCKET, SO_TYPE, &type, &length) == 0 &&
-                type != SOCK_DGRAM) {
+        if (!isDGramSock(sd)) {
             /* Closed TCP connection */
             recvd = WOLFSSL_CBIO_ERR_CONN_CLOSE;
         }
@@ -530,13 +540,10 @@ int EmbedSendTo(WOLFSSL* ssl, char *buf, int sz, void *ctx)
     int sent;
     const SOCKADDR_S* peer = NULL;
     XSOCKLENT peerSz = 0;
-    int type;
-    XSOCKLENT length = sizeof(int); /* optvalue 'type' is of size int */
 
     WOLFSSL_ENTER("EmbedSendTo()");
 
-    if (getsockopt(sd, SOL_SOCKET, SO_TYPE, &type, &length) == 0 &&
-            type != SOCK_DGRAM) {
+    if (!isDGramSock(sd)) {
         /* Probably a TCP socket. peer and peerSz MUST be NULL and 0 */
     }
     else if (!dtlsCtx->connected) {

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1867,8 +1867,7 @@ WOLFSSL_LOCAL int ChachaAEADEncrypt(WOLFSSL* ssl, byte* out, const byte* input,
 
 #ifdef WOLFSSL_TLS13
 WOLFSSL_LOCAL int  DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
-                                word16 sz, const byte* aad, word16 aadSz,
-                                int doAlert);
+                                word16 sz, const byte* aad, word16 aadSz);
 WOLFSSL_LOCAL int  DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input,
                                            word32* inOutIdx, byte type,
                                            word32 size, word32 totalSz);


### PR DESCRIPTION
- Handle `recvfrom()` 0 return. This indicates a closed socket.
- TCP sockets set `errno == SOCKET_EINTR` on a timeout
- Don't send alerts on a decryption error in DTLS
- We should always send alerts when TLS fails decryption