### PR TITLE
Fix for sniffer to ensure the session was polled before trying to reprocess it

### DIFF
--- a/sslSniffer/sslSnifferTest/snifftest.c
+++ b/sslSniffer/sslSnifferTest/snifftest.c
@@ -522,6 +522,7 @@ static int SnifferAsyncQueueAdd(int lastRet, void* chain, int chainSz,
         asyncQueue[ret].lastRet = lastRet;
         asyncQueue[ret].packetNumber = packetNumber;
     }
+    (void)isChain;
 
     return ret;
 }


### PR DESCRIPTION
# Description

Fix for sniffer to ensure the session was polled before trying to reprocess it

Fixes ZD14596

# Testing

```
./configure --enable-asynccrypt --enable-sniffer
make
./scripts/sniffer-testsuite.test
```

Also using QAT `--with-intelqa=../QAT1.8`.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
