### PR TITLE
Expand error queue usage with new macro WOLFSSL_ERROR_VERBOSE.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -833,6 +833,9 @@ then
 
     # Handle as many subject/issuer name OIDs as possible
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_CERT_NAME_ALL"
+
+    # More thorough error queue usage.
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_VERBOSE_ERRORS"
 fi
 
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -2149,6 +2149,7 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
     if (wc_InitMutex(&ctx->countMutex) < 0) {
         WOLFSSL_MSG("Mutex error on CTX init");
         ctx->err = CTX_INIT_MUTEX_E;
+        WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
         return BAD_MUTEX_E;
     }
 
@@ -2265,6 +2266,7 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
     ctx->cm = wolfSSL_CertManagerNew_ex(heap);
     if (ctx->cm == NULL) {
         WOLFSSL_MSG("Bad Cert Manager New");
+        WOLFSSL_ERROR_VERBOSE(BAD_CERT_MANAGER_ERROR);
         return BAD_CERT_MANAGER_ERROR;
     }
     #ifdef OPENSSL_EXTRA
@@ -2297,6 +2299,7 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
         ctx->param = NULL;
         XFREE(ctx->x509_store.lookup.dirs, heap, DYNAMIC_TYPE_OPENSSL);
         ctx->x509_store.lookup.dirs = NULL;
+        WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
         return BAD_MUTEX_E;
     }
     #endif
@@ -4048,12 +4051,12 @@ void InitX509(WOLFSSL_X509* x509, int dynamicFlag, void* heap)
     InitX509Name(&x509->issuer, 0, heap);
     InitX509Name(&x509->subject, 0, heap);
     x509->dynamicMemory  = (byte)dynamicFlag;
-    #if defined(OPENSSL_EXTRA_X509_SMALL) || defined(OPENSSL_EXTRA)
-        x509->refCount = 1;
-    #ifndef SINGLE_THREADED
-        (void)wc_InitMutex(&x509->refMutex);
-    #endif
-    #endif
+#if defined(OPENSSL_EXTRA_X509_SMALL) || defined(OPENSSL_EXTRA)
+    x509->refCount = 1;
+#ifndef SINGLE_THREADED
+    (void)wc_InitMutex(&x509->refMutex);
+#endif
+#endif
 }
 
 
@@ -4553,8 +4556,10 @@ int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig, word32 sigSz,
             if (ret > 0) {
                 ret = wc_RsaPSS_CheckPadding(plain, plainSz, out, ret,
                                              hashType);
-                if (ret != 0)
+                if (ret != 0) {
                     ret = VERIFY_CERT_ERROR;
+                    WOLFSSL_ERROR_VERBOSE(ret);
+                }
             }
         }
         else
@@ -4571,8 +4576,10 @@ int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig, word32 sigSz,
                                                 hashType, -1,
                                                 mp_count_bits(&key->n));
     #endif
-                if (ret != 0)
+                if (ret != 0) {
                     ret = VERIFY_CERT_ERROR;
+                    WOLFSSL_ERROR_VERBOSE(ret);
+                }
             }
         }
 
@@ -4602,7 +4609,9 @@ int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig, word32 sigSz,
                                             XMEMCMP(plain, out, plainSz) != 0) {
                 WOLFSSL_MSG("RSA Signature verification failed");
                 ret = RSA_SIGN_FAULT;
-            } else {
+                WOLFSSL_ERROR_VERBOSE(ret);
+            }
+            else {
                 ret = 0;  /* RSA reset */
             }
         }
@@ -4860,7 +4869,13 @@ int EccVerify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* out,
     else
 #endif /* WOLFSSL_ASYNC_CRYPT */
     {
-        ret = (ret != 0 || ssl->eccVerifyRes == 0) ? VERIFY_SIGN_ERROR : 0;
+        if (ret != 0 || ssl->eccVerifyRes == 0) {
+            ret = VERIFY_SIGN_ERROR;
+            WOLFSSL_ERROR_VERBOSE(ret);
+        }
+        else {
+            ret = 0;
+        }
     }
 
     WOLFSSL_LEAVE("EccVerify", ret);
@@ -5732,6 +5747,7 @@ int DhAgree(WOLFSSL* ssl, DhKey* dhKey,
         if (ret != 0) {
             /* translate to valid error (wc_DhCheckPubValue returns MP_VAL -1) */
             ret = PEER_KEY_ERROR;
+            WOLFSSL_ERROR_VERBOSE(ret);
 
     #ifdef OPENSSL_EXTRA
             SendAlert(ssl, alert_fatal, illegal_parameter);
@@ -5902,6 +5918,7 @@ int InitSSL_Suites(WOLFSSL* ssl)
         /* server certificate must be loaded */
         if (!ssl->buffers.certificate || !ssl->buffers.certificate->buffer) {
             WOLFSSL_MSG("Server missing certificate");
+            WOLFSSL_ERROR_VERBOSE(NO_PRIVATE_KEY);
             return NO_PRIVATE_KEY;
         }
 
@@ -5919,6 +5936,7 @@ int InitSSL_Suites(WOLFSSL* ssl)
         #endif
             {
                 WOLFSSL_MSG("Server missing private key");
+                WOLFSSL_ERROR_VERBOSE(NO_PRIVATE_KEY);
                 return NO_PRIVATE_KEY;
             }
         }
@@ -5939,6 +5957,7 @@ int SSL_CTX_RefCount(WOLFSSL_CTX* ctx, int incr)
 
     if (wc_LockMutex(&ctx->countMutex) != 0) {
         WOLFSSL_MSG("Couldn't lock CTX count mutex");
+        WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
         return BAD_MUTEX_E;
     }
 
@@ -6016,6 +6035,7 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         if (!ctx->method->downgrade) {
             WOLFSSL_MSG("\tInconsistent protocol options. TLS 1.3 set but not "
                         "allowed and downgrading disabled.");
+            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             return VERSION_ERROR;
         }
         WOLFSSL_MSG("\tOption set to not allow TLSv1.3, Downgrading");
@@ -6027,6 +6047,7 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         if (!ctx->method->downgrade) {
             WOLFSSL_MSG("\tInconsistent protocol options. TLS 1.2 set but not "
                         "allowed and downgrading disabled.");
+            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             return VERSION_ERROR;
         }
         WOLFSSL_MSG("\tOption set to not allow TLSv1.2, Downgrading");
@@ -6037,6 +6058,7 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         if (!ctx->method->downgrade) {
             WOLFSSL_MSG("\tInconsistent protocol options. TLS 1.1 set but not "
                         "allowed and downgrading disabled.");
+            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             return VERSION_ERROR;
         }
         WOLFSSL_MSG("\tOption set to not allow TLSv1.1, Downgrading");
@@ -6048,6 +6070,7 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         if (!ctx->method->downgrade) {
             WOLFSSL_MSG("\tInconsistent protocol options. TLS 1 set but not "
                         "allowed and downgrading disabled.");
+            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             return VERSION_ERROR;
         }
         WOLFSSL_MSG("\tOption set to not allow TLSv1, Downgrading");
@@ -6058,11 +6081,13 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
     if (ssl->version.minor == SSLv3_MINOR &&
         (ssl->options.mask & SSL_OP_NO_SSLv3) == SSL_OP_NO_SSLv3) {
         WOLFSSL_MSG("\tError, option set to not allow SSLv3");
+        WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
         return VERSION_ERROR;
     }
 
     if (ssl->version.minor < ssl->options.minDowngrade) {
         WOLFSSL_MSG("\tversion below minimum allowed, fatal error");
+        WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
         return VERSION_ERROR;
     }
 #endif
@@ -6400,6 +6425,7 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
             WOLFSSL_MSG("Bad memory_mutex lock");
             XFREE(ssl->heap, ctx->heap, DYNAMIC_TYPE_SSL);
             ssl->heap = NULL; /* free and set to NULL for IO counter */
+            WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
             return BAD_MUTEX_E;
         }
         if (ctx_hint->memory->maxHa > 0 &&
@@ -6439,6 +6465,7 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         if (ctx_hint->memory->flag & WOLFMEM_IO_POOL_FIXED) {
             if (wc_LockMutex(&(ctx_hint->memory->memory_mutex)) != 0) {
                 WOLFSSL_MSG("Bad memory_mutex lock");
+                WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
                 return BAD_MUTEX_E;
             }
             if (SetFixedIO(ctx_hint->memory, &(ssl_hint->inBuf)) != 1) {
@@ -9957,6 +9984,7 @@ static int GetRecordHeader(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 SendAlert(ssl, alert_fatal, protocol_version);
 #endif
             }
+            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             return VERSION_ERROR;              /* only use requested version */
         }
     }
@@ -9965,15 +9993,19 @@ static int GetRecordHeader(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 #ifdef HAVE_MAX_FRAGMENT
     if (*size > (ssl->max_fragment + MAX_COMP_EXTRA + MAX_MSG_EXTRA)) {
         SendAlert(ssl, alert_fatal, record_overflow);
+        WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
         return LENGTH_ERROR;
     }
 #else
-    if (*size > (MAX_RECORD_SIZE + MAX_COMP_EXTRA + MAX_MSG_EXTRA))
+    if (*size > (MAX_RECORD_SIZE + MAX_COMP_EXTRA + MAX_MSG_EXTRA)) {
+        WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
         return LENGTH_ERROR;
+    }
 #endif
 
     if (*size == 0 && rh->type != application_data) {
         WOLFSSL_MSG("0 length, non-app data record.");
+        WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
         return LENGTH_ERROR;
     }
 
@@ -10006,6 +10038,7 @@ static int GetRecordHeader(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             }
 #endif
             WOLFSSL_MSG("Unknown Record Type");
+            WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
             return UNKNOWN_RECORD_TYPE;
     }
 
@@ -11104,6 +11137,7 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         (const byte*)dCert->cPwd,
                                         dCert->cPwdLen) != WOLFSSL_SUCCESS) {
                 ret = REQ_ATTRIBUTE_E;
+                WOLFSSL_ERROR_VERBOSE(ret);
             }
         #endif
         }
@@ -11126,6 +11160,7 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         dCert->contentTypeLen) !=
                 WOLFSSL_SUCCESS) {
             ret = REQ_ATTRIBUTE_E;
+            WOLFSSL_ERROR_VERBOSE(ret);
         }
     #endif
     }
@@ -11138,6 +11173,7 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         (const byte*)dCert->sNum,
                                         dCert->sNumLen) != WOLFSSL_SUCCESS) {
             ret = REQ_ATTRIBUTE_E;
+            WOLFSSL_ERROR_VERBOSE(ret);
         }
     }
     if (dCert->unstructuredName) {
@@ -11148,6 +11184,7 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         dCert->unstructuredNameLen)
                 != WOLFSSL_SUCCESS) {
             ret = REQ_ATTRIBUTE_E;
+            WOLFSSL_ERROR_VERBOSE(ret);
         }
     }
     if (dCert->surname) {
@@ -11157,6 +11194,7 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         (const byte*)dCert->surname,
                                         dCert->surnameLen) != WOLFSSL_SUCCESS) {
             ret = REQ_ATTRIBUTE_E;
+            WOLFSSL_ERROR_VERBOSE(ret);
         }
     }
     if (dCert->givenName) {
@@ -11166,6 +11204,7 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         (const byte*)dCert->givenName,
                                         dCert->givenNameLen) != WOLFSSL_SUCCESS) {
             ret = REQ_ATTRIBUTE_E;
+            WOLFSSL_ERROR_VERBOSE(ret);
         }
     }
     if (dCert->dnQualifier) {
@@ -11175,6 +11214,7 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         (const byte*)dCert->dnQualifier,
                                         dCert->dnQualifierLen) != WOLFSSL_SUCCESS) {
             ret = REQ_ATTRIBUTE_E;
+            WOLFSSL_ERROR_VERBOSE(ret);
         }
     }
     if (dCert->initials) {
@@ -11184,9 +11224,11 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
                                         (const byte*)dCert->initials,
                                         dCert->initialsLen) != WOLFSSL_SUCCESS) {
             ret = REQ_ATTRIBUTE_E;
+            WOLFSSL_ERROR_VERBOSE(ret);
         }
     }
     #endif /* OPENSSL_ALL */
+
     return ret;
 }
 #endif /* WOLFSSL_CERT_REQ */
@@ -11204,6 +11246,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
 
     if (x509->issuer.name == NULL || x509->subject.name == NULL) {
         WOLFSSL_MSG("Either init was not called on X509 or programming error");
+        WOLFSSL_ERROR_VERBOSE(BAD_FUNC_ARG);
         return BAD_FUNC_ARG;
     }
 
@@ -11314,6 +11357,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
                 if (!(x509->key.algor->algorithm =
                     wolfSSL_OBJ_nid2obj(oid2nid(dCert->keyOID, oidKeyType)))) {
                     ret = PUBLIC_KEY_E;
+                    WOLFSSL_ERROR_VERBOSE(ret);
                 }
             }
 
@@ -11322,6 +11366,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
                                                       &dCert->publicKey,
                                                       dCert->pubKeySize))) {
                 ret = PUBLIC_KEY_E;
+                WOLFSSL_ERROR_VERBOSE(ret);
             }
         }
 #endif
@@ -11344,6 +11389,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
         if (!(x509->algor.algorithm =
                 wolfSSL_OBJ_nid2obj(oid2nid(dCert->signatureOID, oidSigType)))) {
             ret = PUBLIC_KEY_E;
+            WOLFSSL_ERROR_VERBOSE(ret);
         }
 #endif
     }
@@ -11807,6 +11853,7 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
                 if (CheckForAltNames(args->dCert, ssl->param->hostName, NULL) != 1) {
                     if (ret == 0) {
                         ret = DOMAIN_NAME_MISMATCH;
+                        WOLFSSL_ERROR_VERBOSE(ret);
                     }
                 }
             }
@@ -11818,6 +11865,7 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
                                         ssl->param->hostName) == 0) {
                         if (ret == 0) {
                             ret = DOMAIN_NAME_MISMATCH;
+                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                     }
                 }
@@ -11826,6 +11874,7 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
             else {
                 if (ret == 0) {
                     ret = DOMAIN_NAME_MISMATCH;
+                    WOLFSSL_ERROR_VERBOSE(ret);
                 }
             }
         #endif /* !WOLFSSL_HOSTNAME_VERIFY_ALT_NAME_ONLY */
@@ -11837,6 +11886,7 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
             if (CheckIPAddr(args->dCert, ssl->param->ipasc) != 0) {
                 if (ret == 0) {
                     ret = IPADDR_MISMATCH;
+                    WOLFSSL_ERROR_VERBOSE(ret);
                 }
             }
         }
@@ -12044,6 +12094,7 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
             /* induce error if one not present */
             if (ret == 0) {
                 ret = VERIFY_CERT_ERROR;
+                WOLFSSL_ERROR_VERBOSE(ret);
             }
 
             /* mark as verify error */
@@ -12272,6 +12323,7 @@ int LoadCertByIssuer(WOLFSSL_X509_STORE* store, X509_NAME* issuer, int type)
                 if (wc_LockMutex(&lookup->dirs->lock) != 0) {
                     WOLFSSL_MSG("wc_LockMutex cdir Lock error");
                     XFREE(filename, NULL, DYNAMIC_TYPE_OPENSSL);
+                    WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
                     return BAD_MUTEX_E;
                 }
                 if (ph == NULL) {
@@ -12461,6 +12513,7 @@ static int ProcessPeerCertCheckKey(WOLFSSL* ssl, ProcPeerCertArgs* args)
                 WOLFSSL_MSG(
                     "RSA key size in cert chain error");
                 ret = RSA_KEY_SIZE_E;
+                WOLFSSL_ERROR_VERBOSE(ret);
             }
             break;
     #endif /* !NO_RSA */
@@ -12472,6 +12525,7 @@ static int ProcessPeerCertCheckKey(WOLFSSL* ssl, ProcPeerCertArgs* args)
                 WOLFSSL_MSG(
                     "ECC key size in cert chain error");
                 ret = ECC_KEY_SIZE_E;
+                WOLFSSL_ERROR_VERBOSE(ret);
             }
             break;
     #endif /* HAVE_ECC */
@@ -12482,6 +12536,7 @@ static int ProcessPeerCertCheckKey(WOLFSSL* ssl, ProcPeerCertArgs* args)
                 WOLFSSL_MSG(
                     "ECC key size in cert chain error");
                 ret = ECC_KEY_SIZE_E;
+                WOLFSSL_ERROR_VERBOSE(ret);
             }
             break;
     #endif /* HAVE_ED25519 */
@@ -12492,6 +12547,7 @@ static int ProcessPeerCertCheckKey(WOLFSSL* ssl, ProcPeerCertArgs* args)
                 WOLFSSL_MSG(
                     "ECC key size in cert chain error");
                 ret = ECC_KEY_SIZE_E;
+                WOLFSSL_ERROR_VERBOSE(ret);
             }
             break;
     #endif /* HAVE_ED448 */
@@ -12502,6 +12558,7 @@ static int ProcessPeerCertCheckKey(WOLFSSL* ssl, ProcPeerCertArgs* args)
                 WOLFSSL_MSG(
                     "Falcon key size in cert chain error");
                 ret = FALCON_KEY_SIZE_E;
+                WOLFSSL_ERROR_VERBOSE(ret);
             }
             break;
         case FALCON_LEVEL5k:
@@ -12510,6 +12567,7 @@ static int ProcessPeerCertCheckKey(WOLFSSL* ssl, ProcPeerCertArgs* args)
                 WOLFSSL_MSG(
                     "Falcon key size in cert chain error");
                 ret = FALCON_KEY_SIZE_E;
+                WOLFSSL_ERROR_VERBOSE(ret);
             }
             break;
     #endif /* HAVE_PQC && HAVE_FALCON */
@@ -12611,6 +12669,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                 /* Must be empty when received from server. */
                 if (ssl->options.side == WOLFSSL_CLIENT_END) {
                     if (ctxSz != 0) {
+                        WOLFSSL_ERROR_VERBOSE(INVALID_CERT_CTX_E);
                         ERROR_OUT(INVALID_CERT_CTX_E, exit_ppc);
                     }
                 }
@@ -12620,6 +12679,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                 if (ssl->options.side == WOLFSSL_SERVER_END) {
                     if (ssl->options.handShakeState != HANDSHAKE_DONE &&
                                                                    ctxSz != 0) {
+                        WOLFSSL_ERROR_VERBOSE(INVALID_CERT_CTX_E);
                         ERROR_OUT(INVALID_CERT_CTX_E, exit_ppc);
                     }
                     else if (ssl->options.handShakeState == HANDSHAKE_DONE) {
@@ -12643,7 +12703,10 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         }
                         if (curr == NULL)
                 #endif
+                        {
+                            WOLFSSL_ERROR_VERBOSE(INVALID_CERT_CTX_E);
                             ERROR_OUT(INVALID_CERT_CTX_E, exit_ppc);
+                        }
                     }
                 }
             #endif
@@ -12691,6 +12754,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     if (ssl->peerVerifyRet == 0) /* Return first cert error here */
                         ssl->peerVerifyRet = X509_V_ERR_CERT_CHAIN_TOO_LONG;
                     ret = MAX_CHAIN_ERROR;
+                    WOLFSSL_ERROR_VERBOSE(ret);
                     WOLFSSL_MSG("Too many certs for MAX_CHAIN_DEPTH");
                     break; /* break out to avoid reading more certs then buffer
                             * can hold */
@@ -12698,6 +12762,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             #else
                 if (args->totalCerts >= ssl->verifyDepth ||
                         args->totalCerts >= MAX_CHAIN_DEPTH) {
+                    WOLFSSL_ERROR_VERBOSE(MAX_CHAIN_ERROR);
                     ERROR_OUT(MAX_CHAIN_ERROR, exit_ppc);
                 }
             #endif
@@ -12751,6 +12816,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         (word16)args->exts[args->totalCerts].length,
                         certificate, NULL);
                     if (ret < 0) {
+                        WOLFSSL_ERROR_VERBOSE(ret);
                         ERROR_OUT(ret, exit_ppc);
                     }
                 }
@@ -12770,12 +12836,14 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                              IsAtLeastTLSv1_3(ssl->version)))) {
                     WOLFSSL_MSG("No peer cert from Client");
                     ret = NO_PEER_CERT;
+                    WOLFSSL_ERROR_VERBOSE(ret);
                     DoCertFatalAlert(ssl, ret);
                 }
                 else if ((ssl->options.side == WOLFSSL_CLIENT_END) &&
                          IsAtLeastTLSv1_3(ssl->version)) {
                     WOLFSSL_MSG("No peer cert from Server");
                     ret = NO_PEER_CERT;
+                    WOLFSSL_ERROR_VERBOSE(ret);
                     SendAlert(ssl, alert_fatal, decode_error);
                 }
             }
@@ -12874,8 +12942,11 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             ret = ProcessPeerCertParse(ssl, args, CERT_TYPE,
                                 !ssl->options.verifyNone ? VERIFY : NO_VERIFY,
                                 &subjectHash, &alreadySigner);
-                        } else
+                        }
+                        else {
                             ret = ASN_NO_SIGNER_E;
+                            WOLFSSL_ERROR_VERBOSE(ret);
+                        }
                     }
 #endif
                 #ifdef WOLFSSL_ASYNC_CRYPT
@@ -12937,6 +13008,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             doCrlLookup = (ret == OCSP_CERT_UNKNOWN);
                             if (ret != 0) {
                                 doCrlLookup = 0;
+                                WOLFSSL_ERROR_VERBOSE(ret);
                                 WOLFSSL_MSG("\tOCSP Lookup not ok");
                             }
                         }
@@ -12955,6 +13027,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             }
                         #endif
                             if (ret != 0) {
+                                WOLFSSL_ERROR_VERBOSE(ret);
                                 WOLFSSL_MSG("\tCRL check not ok");
                             }
                         }
@@ -12970,6 +13043,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         if (ssl->peerVerifyRet == 0) /* Return first cert error here */
                             ssl->peerVerifyRet = X509_V_ERR_CERT_CHAIN_TOO_LONG;
                         ret = MAX_CHAIN_ERROR;
+                        WOLFSSL_ERROR_VERBOSE(ret);
                     }
             #endif
                 #ifdef WOLFSSL_ALT_CERT_CHAINS
@@ -13041,6 +13115,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     /* Handle error codes */
                     if (ret != 0) {
                         if (!ssl->options.verifyNone) {
+                            WOLFSSL_ERROR_VERBOSE(ret);
                             DoCertFatalAlert(ssl, ret);
                         }
                         ssl->error = ret; /* Report SSL error */
@@ -13094,8 +13169,11 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             ret = ProcessPeerCertParse(ssl, args, CERT_TYPE,
                                 !ssl->options.verifyNone ? VERIFY : NO_VERIFY,
                                 &subjectHash, &alreadySigner);
-                        } else
+                        }
+                        else {
                             ret = ASN_NO_SIGNER_E;
+                            WOLFSSL_ERROR_VERBOSE(ret);
+                        }
                     }
 #endif
             #ifdef WOLFSSL_ASYNC_CRYPT
@@ -13203,6 +13281,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                   "Peer sent different cert during scr, fatal");
                                 args->fatal = 1;
                                 ret = SCR_DIFFERENT_CERT_E;
+                                WOLFSSL_ERROR_VERBOSE(ret);
                             }
                         }
                     }
@@ -13255,8 +13334,10 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                            (CertificateStatusRequest*)ext->data;
                                     ret = ProcessCSR(ssl, csr->response.buffer,
                                                     &idx, csr->response.length);
-                                    if (ret < 0)
+                                    if (ret < 0) {
+                                        WOLFSSL_ERROR_VERBOSE(ret);
                                         goto exit_ppc;
+                                    }
                                 }
                             }
                         #endif
@@ -13380,6 +13461,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         (ssl->options.side == WOLFSSL_CLIENT_END) &&
                         (args->dCert->extKeyUsage & KEYUSE_KEY_ENCIPHER) == 0) {
                         ret = KEYUSE_ENCIPHER_E;
+                        WOLFSSL_ERROR_VERBOSE(ret);
                     }
                     if ((ssl->specs.kea != rsa_kea) &&
                         (ssl->specs.sig_algo == rsa_sa_algo ||
@@ -13388,6 +13470,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         (args->dCert->extKeyUsage & KEYUSE_DIGITAL_SIG) == 0) {
                         WOLFSSL_MSG("KeyUse Digital Sig not set");
                         ret = KEYUSE_SIGNATURE_E;
+                        WOLFSSL_ERROR_VERBOSE(ret);
                     }
                 }
 
@@ -13407,6 +13490,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                 (EXTKEYUSE_ANY | EXTKEYUSE_SERVER_AUTH)) == 0) {
                             WOLFSSL_MSG("ExtKeyUse Server Auth not set");
                             ret = EXTKEYUSE_AUTH_E;
+                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                     }
                     else {
@@ -13414,6 +13498,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                 (EXTKEYUSE_ANY | EXTKEYUSE_CLIENT_AUTH)) == 0) {
                             WOLFSSL_MSG("ExtKeyUse Client Auth not set");
                             ret = EXTKEYUSE_AUTH_E;
+                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                     }
                 }
@@ -13459,6 +13544,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             WOLFSSL_MSG("DomainName match on alt names failed");
                             /* try to get peer key still */
                             ret = DOMAIN_NAME_MISMATCH;
+                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                     }
                     else {
@@ -13468,6 +13554,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                  (char*)ssl->buffers.domainName.buffer) == 0) {
                             WOLFSSL_MSG("DomainName match on common name failed");
                             ret = DOMAIN_NAME_MISMATCH;
+                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                     }
                 #else /* WOLFSSL_ALL_NO_CN_IN_SAN */
@@ -13483,6 +13570,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                 "DomainName match on alt names failed too");
                             /* try to get peer key still */
                             ret = DOMAIN_NAME_MISMATCH;
+                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                     }
                 #endif /* WOLFSSL_ALL_NO_CN_IN_SAN */
@@ -13509,6 +13597,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                args->dCert->publicKey, &keyIdx, ssl->peerRsaKey,
                                                 args->dCert->pubKeySize) != 0) {
                             ret = PEER_KEY_ERROR;
+                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                         else {
                             ssl->peerRsaKeyPresent = 1;
@@ -13564,6 +13653,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                           wc_RsaEncryptSize(ssl->peerRsaKey)
                                               < ssl->options.minRsaKeySz) {
                             ret = RSA_KEY_SIZE_E;
+                            WOLFSSL_ERROR_VERBOSE(ret);
                             WOLFSSL_MSG("Peer RSA key is too small");
                         }
                         break;
@@ -13608,6 +13698,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                                 ssl->peerEccDsaKey,
                                                 args->dCert->pubKeySize) != 0) {
                             ret = PEER_KEY_ERROR;
+                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                         else {
                             ssl->peerEccDsaKeyPresent = 1;
@@ -13638,6 +13729,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                               wc_ecc_size(ssl->peerEccDsaKey)
                                               < ssl->options.minEccKeySz) {
                             ret = ECC_KEY_SIZE_E;
+                            WOLFSSL_ERROR_VERBOSE(ret);
                             WOLFSSL_MSG("Peer ECC key is too small");
                         }
 
@@ -13667,6 +13759,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                                      ssl->peerEd25519Key)
                                                                          != 0) {
                             ret = PEER_KEY_ERROR;
+                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                         else {
                             ssl->peerEd25519KeyPresent = 1;
@@ -13692,6 +13785,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                   !ssl->options.verifyNone &&
                                   ED25519_KEY_SIZE < ssl->options.minEccKeySz) {
                             ret = ECC_KEY_SIZE_E;
+                            WOLFSSL_ERROR_VERBOSE(ret);
                             WOLFSSL_MSG("Peer ECC key is too small");
                         }
 
@@ -13720,6 +13814,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                     args->dCert->pubKeySize,
                                     ssl->peerEd448Key) != 0) {
                             ret = PEER_KEY_ERROR;
+                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                         else {
                             ssl->peerEd448KeyPresent = 1;
@@ -13745,6 +13840,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                !ssl->options.verifyNone &&
                                ED448_KEY_SIZE < ssl->options.minEccKeySz) {
                             ret = ECC_KEY_SIZE_E;
+                            WOLFSSL_ERROR_VERBOSE(ret);
                             WOLFSSL_MSG("Peer ECC key is too small");
                         }
 
@@ -13785,6 +13881,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                                     args->dCert->pubKeySize,
                                                     ssl->peerFalconKey) != 0) {
                             ret = PEER_KEY_ERROR;
+                            WOLFSSL_ERROR_VERBOSE(ret);
                         }
                         else {
                             ssl->peerFalconKeyPresent = 1;
@@ -13796,6 +13893,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                FALCON_MAX_KEY_SIZE <
                                ssl->options.minFalconKeySz) {
                             ret = FALCON_KEY_SIZE_E;
+                            WOLFSSL_ERROR_VERBOSE(ret);
                             WOLFSSL_MSG("Peer Falcon key is too small");
                         }
                     }
@@ -13834,6 +13932,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                 if (ssl->peerVerifyRet == 0) /* Return first cert error here */
                     ssl->peerVerifyRet = X509_V_ERR_CERT_CHAIN_TOO_LONG;
                 ret = MAX_CHAIN_ERROR;
+                WOLFSSL_ERROR_VERBOSE(ret);
             }
         #endif
 
@@ -14095,8 +14194,10 @@ static int DoCertificateStatus(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             ret = BUFFER_ERROR;
     }
 
-    if (ret != 0)
+    if (ret != 0) {
+        WOLFSSL_ERROR_VERBOSE(ret);
         SendAlert(ssl, alert_fatal, bad_certificate_status_response);
+    }
 
     if (IsEncryptionOn(ssl, 0)) {
     #if defined(HAVE_ENCRYPT_THEN_MAC) && !defined(WOLFSSL_AEAD_ONLY)
@@ -14165,6 +14266,7 @@ static int DoHelloRequest(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
     if (ssl->options.side == WOLFSSL_SERVER_END) {
         SendAlert(ssl, alert_fatal, unexpected_message); /* try */
+        WOLFSSL_ERROR_VERBOSE(FATAL_ERROR);
         return FATAL_ERROR;
     }
 #ifdef HAVE_SECURE_RENEGOTIATION
@@ -14220,6 +14322,7 @@ int DoFinished(WOLFSSL* ssl, const byte* input, word32* inOutIdx, word32 size,
     #ifdef WOLFSSL_EXTRA_ALERTS
             SendAlert(ssl, alert_fatal, decrypt_error);
     #endif
+            WOLFSSL_ERROR_VERBOSE(VERIFY_FINISHED_ERROR);
             return VERIFY_FINISHED_ERROR;
         }
     }
@@ -14317,11 +14420,13 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("HelloRequest received by server");
+                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             if (ssl->msgsReceived.got_hello_request) {
                 WOLFSSL_MSG("Duplicate HelloRequest received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_hello_request = 1;
@@ -14334,6 +14439,7 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_CLIENT
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 WOLFSSL_MSG("ClientHello received by client");
+                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
@@ -14342,6 +14448,7 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
     #ifdef WOLFSSL_EXTRA_ALERTS
                 SendAlert(ssl, alert_fatal, unexpected_message);
     #endif
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_client_hello = 1;
@@ -14354,11 +14461,13 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("ServerHello received by server");
+                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             if (ssl->msgsReceived.got_server_hello) {
                 WOLFSSL_MSG("Duplicate ServerHello received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_server_hello = 1;
@@ -14371,11 +14480,13 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("HelloVerifyRequest received by server");
+                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             if (ssl->msgsReceived.got_hello_verify_request) {
                 WOLFSSL_MSG("Duplicate HelloVerifyRequest received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_hello_verify_request = 1;
@@ -14388,11 +14499,13 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("SessionTicket received by server");
+                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             if (ssl->msgsReceived.got_session_ticket) {
                 WOLFSSL_MSG("Duplicate SessionTicket received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_session_ticket = 1;
@@ -14403,6 +14516,7 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         case certificate:
             if (ssl->msgsReceived.got_certificate) {
                 WOLFSSL_MSG("Duplicate Certificate received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_certificate = 1;
@@ -14411,6 +14525,7 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 if ( ssl->msgsReceived.got_server_hello == 0) {
                     WOLFSSL_MSG("No ServerHello before Cert");
+                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
             }
@@ -14419,6 +14534,7 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 if ( ssl->msgsReceived.got_client_hello == 0) {
                     WOLFSSL_MSG("No ClientHello before Cert");
+                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
             }
@@ -14430,21 +14546,25 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("CertificateStatus received by server");
+                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             if (ssl->msgsReceived.got_certificate_status) {
                 WOLFSSL_MSG("Duplicate CertificateStatus received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_certificate_status = 1;
 
             if (ssl->msgsReceived.got_certificate == 0) {
                 WOLFSSL_MSG("No Certificate before CertificateStatus");
+                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             if (ssl->msgsReceived.got_server_key_exchange != 0) {
                 WOLFSSL_MSG("CertificateStatus after ServerKeyExchange");
+                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
 
@@ -14456,17 +14576,20 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("ServerKeyExchange received by server");
+                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             if (ssl->msgsReceived.got_server_key_exchange) {
                 WOLFSSL_MSG("Duplicate ServerKeyExchange received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_server_key_exchange = 1;
 
             if (ssl->msgsReceived.got_server_hello == 0) {
                 WOLFSSL_MSG("No ServerHello before ServerKeyExchange");
+                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             if (ssl->msgsReceived.got_certificate_status == 0) {
@@ -14501,6 +14624,7 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                      !ssl->status_request_v2 &&
     #endif
                                                  SSL_CM(ssl)->ocspMustStaple) {
+                    WOLFSSL_ERROR_VERBOSE(OCSP_CERT_UNKNOWN);
                     return OCSP_CERT_UNKNOWN;
                 }
                 #endif
@@ -14514,11 +14638,13 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("CertificateRequest received by server");
+                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             if (ssl->msgsReceived.got_certificate_request) {
                 WOLFSSL_MSG("Duplicate CertificateRequest received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_certificate_request = 1;
@@ -14531,11 +14657,13 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_SERVER
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("ServerHelloDone received by server");
+                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             if (ssl->msgsReceived.got_server_hello_done) {
                 WOLFSSL_MSG("Duplicate ServerHelloDone received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_server_hello_done = 1;
@@ -14546,8 +14674,10 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                     ssl->specs.kea == ecdhe_psk_kea ||
                     ssl->options.usingAnon_cipher) {
                     WOLFSSL_MSG("No Cert required");
-                } else {
+                }
+                else {
                     WOLFSSL_MSG("No Certificate before ServerHelloDone");
+                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
             }
@@ -14564,8 +14694,10 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                     ssl->specs.kea == rsa_kea ||
                     pskNoServerHint) {
                     WOLFSSL_MSG("No KeyExchange required");
-                } else {
+                }
+                else {
                     WOLFSSL_MSG("No ServerKeyExchange before ServerDone");
+                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
             }
@@ -14577,17 +14709,20 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_CLIENT
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 WOLFSSL_MSG("CertificateVerify received by client");
+                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             if (ssl->msgsReceived.got_certificate_verify) {
                 WOLFSSL_MSG("Duplicate CertificateVerify received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_certificate_verify = 1;
 
             if ( ssl->msgsReceived.got_certificate == 0) {
                 WOLFSSL_MSG("No Cert before CertVerify");
+                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             break;
@@ -14598,6 +14733,7 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         #ifndef NO_WOLFSSL_CLIENT
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 WOLFSSL_MSG("ClientKeyExchange received by client");
+                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
@@ -14606,12 +14742,14 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
     #ifdef WOLFSSL_EXTRA_ALERTS
                 SendAlert(ssl, alert_fatal, unexpected_message);
     #endif
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_client_key_exchange = 1;
 
             if (ssl->msgsReceived.got_client_hello == 0) {
                 WOLFSSL_MSG("No ClientHello before ClientKeyExchange");
+                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             break;
@@ -14620,12 +14758,14 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         case finished:
             if (ssl->msgsReceived.got_finished) {
                 WOLFSSL_MSG("Duplicate Finished received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
 #ifdef WOLFSSL_DTLS
             if (ssl->options.dtls) {
                 if (ssl->keys.curEpoch == 0) {
                     WOLFSSL_MSG("Finished received with epoch 0");
+                    WOLFSSL_ERROR_VERBOSE(SEQUENCE_ERROR);
                     return SEQUENCE_ERROR;
                 }
             }
@@ -14637,6 +14777,7 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
     #ifdef WOLFSSL_EXTRA_ALERTS
                 SendAlert(ssl, alert_fatal, unexpected_message);
     #endif
+                WOLFSSL_ERROR_VERBOSE(NO_CHANGE_CIPHER_E);
                 return NO_CHANGE_CIPHER_E;
             }
             break;
@@ -14644,6 +14785,7 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
         case change_cipher_hs:
             if (ssl->msgsReceived.got_change_cipher) {
                 WOLFSSL_MSG("Duplicate ChangeCipher received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             /* DTLS is going to ignore the CCS message if the client key
@@ -14656,12 +14798,15 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                 if (!ssl->options.resuming) {
                    if (ssl->msgsReceived.got_server_hello_done == 0) {
                         WOLFSSL_MSG("No ServerHelloDone before ChangeCipher");
+                        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                         return OUT_OF_ORDER_E;
                    }
                 }
                 else {
                     if (ssl->msgsReceived.got_server_hello == 0) {
-                        WOLFSSL_MSG("No ServerHello before ChangeCipher on Resume");
+                        WOLFSSL_MSG("No ServerHello before ChangeCipher on "
+                                    "Resume");
+                        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                         return OUT_OF_ORDER_E;
                     }
                 }
@@ -14669,9 +14814,12 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                     if (ssl->expect_session_ticket) {
                         WOLFSSL_MSG("Expected session ticket missing");
                         #ifdef WOLFSSL_DTLS
-                            if (ssl->options.dtls)
+                            if (ssl->options.dtls) {
+                                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                                 return OUT_OF_ORDER_E;
+                            }
                         #endif
+                        WOLFSSL_ERROR_VERBOSE(SESSION_TICKET_EXPECT_E);
                         return SESSION_TICKET_EXPECT_E;
                     }
                 #endif
@@ -14685,6 +14833,7 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
     #ifdef WOLFSSL_EXTRA_ALERTS
                     SendAlert(ssl, alert_fatal, unexpected_message);
     #endif
+                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
                 #ifndef NO_CERTS
@@ -14695,9 +14844,12 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                                 !ssl->msgsReceived.got_certificate_verify) {
                             WOLFSSL_MSG("client didn't send cert verify");
                             #ifdef WOLFSSL_DTLS
-                                if (ssl->options.dtls)
+                                if (ssl->options.dtls) {
+                                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                                     return OUT_OF_ORDER_E;
+                                }
                             #endif
+                            WOLFSSL_ERROR_VERBOSE(NO_PEER_VERIFY);
                             return NO_PEER_VERIFY;
                         }
                     }
@@ -14710,6 +14862,7 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
 
         default:
             WOLFSSL_MSG("Unknown message type");
+            WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
             return SANITY_MSG_E;
     }
 
@@ -14735,6 +14888,7 @@ static int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     /* make sure can read the message */
     if (*inOutIdx + size > totalSz) {
         WOLFSSL_MSG("Incomplete Data");
+        WOLFSSL_ERROR_VERBOSE(INCOMPLETE_DATA);
         return INCOMPLETE_DATA;
     }
 
@@ -14788,6 +14942,7 @@ static int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     if (ssl->options.handShakeState == HANDSHAKE_DONE && type != hello_request){
         WOLFSSL_MSG("HandShake message after handshake complete");
         SendAlert(ssl, alert_fatal, unexpected_message);
+        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
         return OUT_OF_ORDER_E;
     }
 
@@ -14795,6 +14950,7 @@ static int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                ssl->options.serverState == NULL_STATE && type != server_hello) {
         WOLFSSL_MSG("First server message not server hello");
         SendAlert(ssl, alert_fatal, unexpected_message);
+        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
         return OUT_OF_ORDER_E;
     }
 
@@ -14803,6 +14959,7 @@ static int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             ssl->options.serverState < SERVER_HELLO_COMPLETE) {
         WOLFSSL_MSG("Server hello done received before server hello in DTLS");
         SendAlert(ssl, alert_fatal, unexpected_message);
+        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
         return OUT_OF_ORDER_E;
     }
 
@@ -14810,6 +14967,7 @@ static int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                ssl->options.clientState == NULL_STATE && type != client_hello) {
         WOLFSSL_MSG("First client message not client hello");
         SendAlert(ssl, alert_fatal, unexpected_message);
+        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
         return OUT_OF_ORDER_E;
     }
 
@@ -14852,6 +15010,7 @@ static int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                  * allow for reverting back to a full handshake after the
                  * server has indicated the intention to do a resumption. */
                 (void)SendAlert(ssl, alert_fatal, unexpected_message);
+                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
 #endif
             }
@@ -15050,6 +15209,7 @@ static int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         if (!ssl->options.dtls)
             SendAlert(ssl, alert_fatal, decode_error);
         ret = DECODE_E;
+        WOLFSSL_ERROR_VERBOSE(ret);
     }
 
 #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
@@ -15100,8 +15260,10 @@ static int DoHandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         byte   type;
         word32 size;
 
-        if (GetHandShakeHeader(ssl,input,inOutIdx,&type, &size, totalSz) != 0)
+        if (GetHandShakeHeader(ssl,input,inOutIdx,&type, &size, totalSz) != 0) {
+            WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
             return PARSE_ERROR;
+        }
 
         return DoHandShakeMsgType(ssl, input, inOutIdx, type, size, totalSz);
     }
@@ -15114,14 +15276,18 @@ static int DoHandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         byte   type;
         word32 size;
 
-        if (GetHandShakeHeader(ssl,input, inOutIdx, &type, &size, totalSz) != 0)
+        if (GetHandShakeHeader(ssl, input, inOutIdx, &type, &size,
+                               totalSz) != 0) {
+            WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
             return PARSE_ERROR;
+        }
 
         /* Cap the maximum size of a handshake message to something reasonable.
          * By default is the maximum size of a certificate message assuming
          * nine 2048-bit RSA certificates in the chain. */
         if (size > MAX_HANDSHAKE_SZ) {
             WOLFSSL_MSG("Handshake message too large");
+            WOLFSSL_ERROR_VERBOSE(HANDSHAKE_SIZE_ERROR);
             return HANDSHAKE_SIZE_ERROR;
         }
 
@@ -16355,6 +16521,7 @@ static int ChachaAEADDecrypt(WOLFSSL* ssl, byte* plain, const byte* input,
         WOLFSSL_MSG("MAC did not match");
         if (!ssl->options.dtls)
             SendAlert(ssl, alert_fatal, bad_record_mac);
+        WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         return VERIFY_MAC_ERROR;
     }
 
@@ -16563,6 +16730,7 @@ static WC_INLINE int EncryptDo(WOLFSSL* ssl, byte* out, const byte* input,
         default:
             WOLFSSL_MSG("wolfSSL Encrypt programming error");
             ret = ENCRYPT_ERROR;
+            WOLFSSL_ERROR_VERBOSE(ret);
     }
 
 #ifdef WOLFSSL_ASYNC_CRYPT
@@ -16591,6 +16759,7 @@ static WC_INLINE int Encrypt(WOLFSSL* ssl, byte* out, const byte* input,
         {
             if (ssl->encrypt.setup == 0) {
                 WOLFSSL_MSG("Encrypt ciphers not setup");
+                WOLFSSL_ERROR_VERBOSE(ENCRYPT_ERROR);
                 return ENCRYPT_ERROR;
             }
 
@@ -16661,6 +16830,7 @@ static WC_INLINE int Encrypt(WOLFSSL* ssl, byte* out, const byte* input,
                     min(sz, sizeof(ssl->encrypt.sanityCheck))) == 0) {
 
                 WOLFSSL_MSG("Encrypt sanity check failed! Glitch?");
+                WOLFSSL_ERROR_VERBOSE(ENCRYPT_ERROR);
                 return ENCRYPT_ERROR;
             }
             ForceZero(ssl->encrypt.sanityCheck,
@@ -16842,6 +17012,7 @@ static WC_INLINE int DecryptDo(WOLFSSL* ssl, byte* plain, const byte* input,
 
         default:
             WOLFSSL_MSG("wolfSSL Decrypt programming error");
+            WOLFSSL_ERROR_VERBOSE(DECRYPT_ERROR);
             ret = DECRYPT_ERROR;
     }
 
@@ -16883,6 +17054,7 @@ static int DecryptTls(WOLFSSL* ssl, byte* plain, const byte* input, word16 sz)
         {
             if (ssl->decrypt.setup == 0) {
                 WOLFSSL_MSG("Decrypt ciphers not setup");
+                WOLFSSL_ERROR_VERBOSE(DECRYPT_ERROR);
                 return DECRYPT_ERROR;
             }
 
@@ -16965,8 +17137,10 @@ static int DecryptTls(WOLFSSL* ssl, byte* plain, const byte* input, word16 sz)
                 if (ssl->decrypt.nonce)
                     ForceZero(ssl->decrypt.nonce, AESGCM_NONCE_SZ);
 
-                if (ret < 0)
+                if (ret < 0) {
                     ret = VERIFY_MAC_ERROR;
+                    WOLFSSL_ERROR_VERBOSE(ret);
+                }
             }
         #endif /* BUILD_AESGCM || HAVE_AESCCM */
             break;
@@ -17015,6 +17189,7 @@ static int SanityCheckCipherText(WOLFSSL* ssl, word32 encryptSz)
         if (ssl->options.startedETMRead) {
             if ((encryptSz - MacSize(ssl)) % ssl->specs.block_size) {
                 WOLFSSL_MSG("Block ciphertext not block size");
+                WOLFSSL_ERROR_VERBOSE(SANITY_CIPHER_E);
                 return SANITY_CIPHER_E;
             }
         }
@@ -17022,6 +17197,7 @@ static int SanityCheckCipherText(WOLFSSL* ssl, word32 encryptSz)
 #endif
         if (encryptSz % ssl->specs.block_size) {
             WOLFSSL_MSG("Block ciphertext not block size");
+            WOLFSSL_ERROR_VERBOSE(SANITY_CIPHER_E);
             return SANITY_CIPHER_E;
         }
 
@@ -17043,6 +17219,7 @@ static int SanityCheckCipherText(WOLFSSL* ssl, word32 encryptSz)
 
     if (encryptSz < minLength) {
         WOLFSSL_MSG("Ciphertext not minimum size");
+        WOLFSSL_ERROR_VERBOSE(SANITY_CIPHER_E);
         return SANITY_CIPHER_E;
     }
 
@@ -17281,7 +17458,7 @@ static WC_INLINE int GetRounds(int pLen, int padLen, int t)
         /* still compare */
         ssl->hmac(ssl, verify, input, pLen - t, -1, content, 1, PEER_ORDER);
         ConstantCompare(verify, input + pLen - t, t);
-
+        WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         return VERIFY_MAC_ERROR;
     }
 
@@ -17291,7 +17468,7 @@ static WC_INLINE int GetRounds(int pLen, int padLen, int t)
         /* still compare */
         ssl->hmac(ssl, verify, input, pLen - t, -1, content, 1, PEER_ORDER);
         ConstantCompare(verify, input + pLen - t, t);
-
+        WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         return VERIFY_MAC_ERROR;
     }
 
@@ -17303,12 +17480,15 @@ static WC_INLINE int GetRounds(int pLen, int padLen, int t)
 
     if (ConstantCompare(verify, input + (pLen - padLen - 1 - t), t) != 0) {
         WOLFSSL_MSG("Verify MAC compare failed");
+        WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         return VERIFY_MAC_ERROR;
     }
 
     /* treat any failure as verify MAC error */
-    if (ret != 0)
+    if (ret != 0) {
         ret = VERIFY_MAC_ERROR;
+        WOLFSSL_ERROR_VERBOSE(ret);
+    }
 
     return ret;
 }
@@ -17447,8 +17627,10 @@ int TimingPadVerify(WOLFSSL* ssl, const byte* input, int padLen, int macSz,
     ret -= 1 - good;
 
     /* Treat any failure as verify MAC error. */
-    if (ret != 0)
+    if (ret != 0) {
         ret = VERIFY_MAC_ERROR;
+        WOLFSSL_ERROR_VERBOSE(ret);
+    }
 
     return ret;
 }
@@ -17490,6 +17672,7 @@ int DoApplicationData(WOLFSSL* ssl, byte* input, word32* inOutIdx, int sniff)
             if (sniff == NO_SNIFF) {
                 SendAlert(ssl, alert_fatal, unexpected_message);
             }
+            WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
             return OUT_OF_ORDER_E;
         }
     }
@@ -17500,6 +17683,7 @@ int DoApplicationData(WOLFSSL* ssl, byte* input, word32* inOutIdx, int sniff)
         if (sniff == NO_SNIFF) {
             SendAlert(ssl, alert_fatal, unexpected_message);
         }
+        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
         return OUT_OF_ORDER_E;
     }
 
@@ -17525,6 +17709,7 @@ int DoApplicationData(WOLFSSL* ssl, byte* input, word32* inOutIdx, int sniff)
         if (sniff == NO_SNIFF) {
             SendAlert(ssl, alert_fatal, unexpected_message);
         }
+        WOLFSSL_ERROR_VERBOSE(BUFFER_ERROR);
         return BUFFER_ERROR;
     }
 #ifdef WOLFSSL_EARLY_DATA
@@ -17853,6 +18038,7 @@ static int DoAlert(WOLFSSL* ssl, byte* input, word32* inOutIdx, int* type)
         if (level != alert_warning || code != close_notify)
             SendAlert(ssl, alert_fatal, unexpected_message);
 #endif
+        WOLFSSL_ERROR_VERBOSE(ALERT_COUNT_E);
         return ALERT_COUNT_E;
     }
 
@@ -17930,11 +18116,15 @@ static int GetInputData(WOLFSSL *ssl, word32 size)
         if (in == WANT_READ)
             return WANT_READ;
 
-        if (in < 0)
+        if (in < 0) {
+            WOLFSSL_ERROR_VERBOSE(SOCKET_ERROR_E);
             return SOCKET_ERROR_E;
+        }
 
-        if (in > inSz)
+        if (in > inSz) {
+            WOLFSSL_ERROR_VERBOSE(RECV_OVERFLOW_E);
             return RECV_OVERFLOW_E;
+        }
 
         ssl->buffers.inputBuffer.length += in;
         inSz -= in;
@@ -17968,12 +18158,14 @@ static WC_INLINE int VerifyMacEnc(WOLFSSL* ssl, const byte* input, word32 msgSz,
     WOLFSSL_MSG("Verify MAC of Encrypted Data");
 
     if (msgSz < digestSz) {
+        WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         return VERIFY_MAC_ERROR;
     }
 
     ret  = ssl->hmac(ssl, verify, input, msgSz - digestSz, -1, content, 1, PEER_ORDER);
     ret |= ConstantCompare(verify, input + msgSz - digestSz, digestSz);
     if (ret != 0) {
+        WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         return VERIFY_MAC_ERROR;
     }
 
@@ -18039,20 +18231,27 @@ static WC_INLINE int VerifyMac(WOLFSSL* ssl, const byte* input, word32 msgSz,
             ret = ssl->hmac(ssl, verify, input, msgSz - digestSz - pad - 1,
                             pad, content, 1, PEER_ORDER);
             if (ConstantCompare(verify, input + msgSz - digestSz - pad - 1,
-                                digestSz) != 0)
+                                digestSz) != 0) {
+                WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
                 return VERIFY_MAC_ERROR;
-            if (ret != 0 || badPadLen)
+            }
+            if (ret != 0 || badPadLen) {
+                WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
                 return VERIFY_MAC_ERROR;
+            }
         }
     }
     else if (ssl->specs.cipher_type == stream) {
         ret = ssl->hmac(ssl, verify, input, msgSz - digestSz, -1, content, 1,
                         PEER_ORDER);
-        if (ConstantCompare(verify, input + msgSz - digestSz, digestSz) != 0){
+        if (ConstantCompare(verify, input + msgSz - digestSz, digestSz) != 0) {
+            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
         }
-        if (ret != 0)
+        if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
+        }
     }
 #endif /* !WOLFSSL_NO_TLS12 && !WOLFSSL_AEAD_ONLY */
 
@@ -18192,6 +18391,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                 if (ssl->buffers.inputBuffer.buffer[
                           ssl->buffers.inputBuffer.idx + OPAQUE16_LEN] != OLD_HELLO_ID) {
                     WOLFSSL_MSG("Not a valid old client hello");
+                    WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
                     return PARSE_ERROR;
                 }
 
@@ -18200,6 +18400,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                     ssl->buffers.inputBuffer.buffer[
                           ssl->buffers.inputBuffer.idx + OPAQUE24_LEN] != DTLS_MAJOR) {
                     WOLFSSL_MSG("Not a valid version in old client hello");
+                    WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
                     return PARSE_ERROR;
                 }
 
@@ -18291,6 +18492,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                                         ssl->curRL.type != application_data &&
                                         ssl->curRL.type != change_cipher_spec) {
                 SendAlert(ssl, alert_fatal, unexpected_message);
+                WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
                 return PARSE_ERROR;
             }
 #endif
@@ -18383,6 +18585,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                     if (!ssl->options.dtls)
                         SendAlert(ssl, alert_fatal, bad_record_mac);
                 #endif
+                    WOLFSSL_ERROR_VERBOSE(DECRYPT_ERROR);
                     return DECRYPT_ERROR;
                 }
                 ssl->keys.encryptSz    = ssl->curSize;
@@ -18620,6 +18823,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                         if (!ssl->options.dtls)
                             SendAlert(ssl, alert_fatal, bad_record_mac);
                     #endif
+                        WOLFSSL_ERROR_VERBOSE(DECRYPT_ERROR);
                         return DECRYPT_ERROR;
                     }
                 }
@@ -18711,6 +18915,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
             #if defined(WOLFSSL_EXTRA_ALERTS)
                     SendAlert(ssl, alert_fatal, record_overflow);
             #endif
+                    WOLFSSL_ERROR_VERBOSE(BUFFER_ERROR);
                     return BUFFER_ERROR;
                 }
             }
@@ -18732,6 +18937,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
 #if defined(WOLFSSL_TLS13) || defined(WOLFSSL_EXTRA_ALERTS)
                 SendAlert(ssl, alert_fatal, record_overflow);
 #endif
+                WOLFSSL_ERROR_VERBOSE(BUFFER_ERROR);
                 return BUFFER_ERROR;
             }
 
@@ -18864,11 +19070,13 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                         word32 i = ssl->buffers.inputBuffer.idx;
                         if (ssl->options.handShakeState == HANDSHAKE_DONE) {
                             SendAlert(ssl, alert_fatal, unexpected_message);
+                            WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
                             return UNKNOWN_RECORD_TYPE;
                         }
                         if (ssl->curSize != 1 ||
                                       ssl->buffers.inputBuffer.buffer[i] != 1) {
                             SendAlert(ssl, alert_fatal, illegal_parameter);
+                            WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
                             return UNKNOWN_RECORD_TYPE;
                         }
                         ssl->buffers.inputBuffer.idx++;
@@ -18877,6 +19085,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                         }
                         else {
                             SendAlert(ssl, alert_fatal, illegal_parameter);
+                            WOLFSSL_ERROR_VERBOSE(UNKNOWN_RECORD_TYPE);
                             return UNKNOWN_RECORD_TYPE;
                         }
                         break;
@@ -18888,11 +19097,13 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                             ssl->buffers.inputBuffer.length ||
                             ssl->curSize < 1) {
                         WOLFSSL_MSG("ChangeCipher msg too short");
+                        WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
                         return LENGTH_ERROR;
                     }
                     if (ssl->buffers.inputBuffer.buffer[
                             ssl->buffers.inputBuffer.idx] != 1) {
                         WOLFSSL_MSG("ChangeCipher msg wrong value");
+                        WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
                         return LENGTH_ERROR;
                     }
 
@@ -18923,6 +19134,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
 
                     if (ssl->curSize != 1) {
                         WOLFSSL_MSG("Malicious or corrupted ChangeCipher msg");
+                        WOLFSSL_ERROR_VERBOSE(LENGTH_ERROR);
                         return LENGTH_ERROR;
                     }
 
@@ -19020,6 +19232,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                     #ifdef WOLFSSL_TLS13
                         if (ssl->keys.keyUpdateRespond) {
                             WOLFSSL_MSG("No KeyUpdate from peer seen");
+                            WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                             return SANITY_MSG_E;
                         }
                     #endif
@@ -19112,6 +19325,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                         }
                         else {
                             WOLFSSL_MSG("\tmiddle padding error");
+                            WOLFSSL_ERROR_VERBOSE(FATAL_ERROR);
                             return FATAL_ERROR;
                         }
                     }
@@ -19123,6 +19337,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                         }
                         else {
                             WOLFSSL_MSG("\tmiddle padding error");
+                            WOLFSSL_ERROR_VERBOSE(FATAL_ERROR);
                             return FATAL_ERROR;
                         }
                     }
@@ -19146,6 +19361,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
             continue;
         default:
             WOLFSSL_MSG("Bad process input state, programming error");
+            WOLFSSL_ERROR_VERBOSE(INPUT_CASE_ERROR);
             return INPUT_CASE_ERROR;
         }
     }
@@ -19317,8 +19533,10 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         ret |= wc_Md5Update(&md5, conLen, sizeof(conLen));
         /* in buffer */
         ret |= wc_Md5Update(&md5, in, sz);
-        if (ret != 0)
+        if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
+        }
         ret = wc_Md5Final(&md5, result);
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* TODO: Make non-blocking */
@@ -19326,15 +19544,19 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
             ret = wc_AsyncWait(ret, &md5.asyncDev, WC_ASYNC_FLAG_NONE);
         }
     #endif
-        if (ret != 0)
+        if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
+        }
 
         /* outer */
         ret =  wc_Md5Update(&md5, macSecret, digestSz);
         ret |= wc_Md5Update(&md5, PAD2, padSz);
         ret |= wc_Md5Update(&md5, result, digestSz);
-        if (ret != 0)
+        if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
+        }
         ret =  wc_Md5Final(&md5, digest);
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* TODO: Make non-blocking */
@@ -19342,8 +19564,10 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
             ret = wc_AsyncWait(ret, &md5.asyncDev, WC_ASYNC_FLAG_NONE);
         }
     #endif
-        if (ret != 0)
+        if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
+        }
 
         wc_Md5Free(&md5);
     }
@@ -19359,8 +19583,10 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         ret |= wc_ShaUpdate(&sha, conLen, sizeof(conLen));
         /* in buffer */
         ret |= wc_ShaUpdate(&sha, in, sz);
-        if (ret != 0)
+        if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
+        }
         ret = wc_ShaFinal(&sha, result);
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* TODO: Make non-blocking */
@@ -19368,15 +19594,19 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
             ret = wc_AsyncWait(ret, &sha.asyncDev, WC_ASYNC_FLAG_NONE);
         }
     #endif
-        if (ret != 0)
+        if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
+        }
 
         /* outer */
         ret =  wc_ShaUpdate(&sha, macSecret, digestSz);
         ret |= wc_ShaUpdate(&sha, PAD2, padSz);
         ret |= wc_ShaUpdate(&sha, result, digestSz);
-        if (ret != 0)
+        if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
+        }
         ret =  wc_ShaFinal(&sha, digest);
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* TODO: Make non-blocking */
@@ -19384,8 +19614,10 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
             ret = wc_AsyncWait(ret, &sha.asyncDev, WC_ASYNC_FLAG_NONE);
         }
     #endif
-        if (ret != 0)
+        if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
+        }
 
         wc_ShaFree(&sha);
     }
@@ -20021,8 +20253,12 @@ exit_buildmsg:
     #endif
 
     /* return sz on success */
-    if (ret == 0)
+    if (ret == 0) {
         ret = args->sz;
+    }
+    else {
+        WOLFSSL_ERROR_VERBOSE(ret);
+    }
 
     /* Final cleanup */
     FreeBuildMsgArgs(ssl, args);
@@ -24561,7 +24797,12 @@ int DecodePrivateKey(WOLFSSL *ssl, word16* length)
     (void)idx;
     (void)keySz;
     (void)length;
+
 exit_dpk:
+    if (ret != 0) {
+        WOLFSSL_ERROR_VERBOSE(ret);
+    }
+
     return ret;
 }
 
@@ -25032,20 +25273,25 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
         #endif
 
         if (ssl->options.dtls) {
-            if (pv.major != DTLS_MAJOR || pv.minor == DTLS_BOGUS_MINOR)
+            if (pv.major != DTLS_MAJOR || pv.minor == DTLS_BOGUS_MINOR) {
+                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
+            }
             lowerVersion = pv.minor > ssl->version.minor;
             higherVersion = pv.minor < ssl->version.minor;
         }
         else {
-            if (pv.major != SSLv3_MAJOR)
+            if (pv.major != SSLv3_MAJOR) {
+                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
+            }
             lowerVersion = pv.minor < ssl->version.minor;
             higherVersion = pv.minor > ssl->version.minor;
         }
 
         if (higherVersion) {
             WOLFSSL_MSG("Server using higher version, fatal error");
+            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             return VERSION_ERROR;
         }
         if (lowerVersion) {
@@ -25054,11 +25300,13 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             /* Check for downgrade attack. */
             if (!ssl->options.downgrade) {
                 WOLFSSL_MSG("\tno downgrade allowed, fatal error");
+                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
             if ((!ssl->options.dtls && pv.minor < ssl->options.minDowngrade) ||
                 (ssl->options.dtls && pv.minor > ssl->options.minDowngrade)) {
                 WOLFSSL_MSG("\tversion below minimum allowed, fatal error");
+                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
 
@@ -25067,6 +25315,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
                                          ssl->secure_renegotiation->enabled &&
                                          ssl->options.handShakeDone) {
                     WOLFSSL_MSG("Server changed version during scr");
+                    WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                     return VERSION_ERROR;
                 }
             #endif
@@ -25099,6 +25348,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
                     break;
                 default:
                     WOLFSSL_MSG("\tbad minor version");
+                    WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                     return VERSION_ERROR;
                 }
         }
@@ -25136,11 +25386,13 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
                 (ssl->options.mask & WOLFSSL_OP_NO_SSLv3) ==
                 WOLFSSL_OP_NO_SSLv3) {
                 WOLFSSL_MSG("\tError, option set to not allow SSLv3");
+                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
 
             if (ssl->version.minor < ssl->options.minDowngrade) {
                 WOLFSSL_MSG("\tversion below minimum allowed, fatal error");
+                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
         }
@@ -25223,6 +25475,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             if (ssl->options.cipherSuite0 != cs0 ||
                 ssl->options.cipherSuite  != cs1) {
                 WOLFSSL_MSG("Server changed cipher suite during scr");
+                WOLFSSL_ERROR_VERBOSE(MATCH_SUITE_ERROR);
                 return MATCH_SUITE_ERROR;
             }
         }
@@ -25251,6 +25504,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             }
             if (!found) {
                 WOLFSSL_MSG("ServerHello did not use cipher suite from ClientHello");
+                WOLFSSL_ERROR_VERBOSE(MATCH_SUITE_ERROR);
                 return MATCH_SUITE_ERROR;
             }
         }
@@ -25258,6 +25512,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
 
         if (compression != NO_COMPRESSION && !ssl->options.usingCompression) {
             WOLFSSL_MSG("Server forcing compression w/o support");
+            WOLFSSL_ERROR_VERBOSE(COMPRESSION_ERROR);
             return COMPRESSION_ERROR;
         }
 
@@ -25376,8 +25631,10 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             int secretSz = SECRET_LEN;
             ret = ssl->sessionSecretCb(ssl, ssl->session->masterSecret,
                                               &secretSz, ssl->sessionSecretCtx);
-            if (ret != 0 || secretSz != SECRET_LEN)
+            if (ret != 0 || secretSz != SECRET_LEN) {
+                WOLFSSL_ERROR_VERBOSE(SESSION_SECRET_CB_E);
                 return SESSION_SECRET_CB_E;
+            }
         }
 #endif /* HAVE_SECRET_CALLBACK */
 
@@ -25406,6 +25663,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
                 if (XMEMCMP(down, tls13Downgrade, TLS13_DOWNGRADE_SZ) == 0 &&
                                                      (vers == 0 || vers == 1)) {
                     SendAlert(ssl, alert_fatal, illegal_parameter);
+                    WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                     return VERSION_ERROR;
                 }
             }
@@ -25420,6 +25678,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
                 if (XMEMCMP(down, tls13Downgrade, TLS13_DOWNGRADE_SZ) == 0 &&
                                                                     vers == 0) {
                     SendAlert(ssl, alert_fatal, illegal_parameter);
+                    WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                     return VERSION_ERROR;
                 }
             }
@@ -25449,6 +25708,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
                 }
                 else {
                     WOLFSSL_MSG("Unsupported cipher suite, DoServerHello");
+                    WOLFSSL_ERROR_VERBOSE(UNSUPPORTED_SUITE);
                     return UNSUPPORTED_SUITE;
                 }
             }
@@ -25544,10 +25804,12 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             #ifdef HAVE_PK_CALLBACKS
                 if (wolfSSL_CTX_IsPrivatePkSet(ssl->ctx)) {
                     WOLFSSL_MSG("Using PK for client private key");
+                    WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
                     return INVALID_PARAMETER;
                 }
             #endif
                 if (ssl->buffers.key && ssl->buffers.key->buffer) {
+                    WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
                     return INVALID_PARAMETER;
                 }
             }
@@ -25636,12 +25898,14 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             if (ret == 1) {
                 if ((wolfSSL_use_certificate(ssl, x509) != WOLFSSL_SUCCESS) ||
                     (wolfSSL_use_PrivateKey(ssl, pkey) != WOLFSSL_SUCCESS)) {
+                    WOLFSSL_ERROR_VERBOSE(CLIENT_CERT_CB_ERROR);
                     return CLIENT_CERT_CB_ERROR;
                 }
                 wolfSSL_X509_free(x509);
                 wolfSSL_EVP_PKEY_free(pkey);
 
-            } else if (ret < 0) {
+            }
+            else if (ret < 0) {
                 return WOLFSSL_ERROR_WANT_X509_LOOKUP;
             }
         }
@@ -26048,6 +26312,9 @@ static int GetDhPublicKey(WOLFSSL* ssl, const byte* input, word32 size,
 #endif /* HAVE_FFDHE */
 
 exit_gdpk:
+    if (ret != 0) {
+        WOLFSSL_ERROR_VERBOSE(ret);
+    }
     return ret;
 }
 #endif
@@ -27048,6 +27315,9 @@ exit_dske:
     /* Final cleanup */
     FreeKeyExchange(ssl);
 
+    if (ret != 0) {
+        WOLFSSL_ERROR_VERBOSE(ret);
+    }
     return ret;
 }
 
@@ -28278,6 +28548,9 @@ exit_scke:
 #endif
     FreeKeyExchange(ssl);
 
+    if (ret != 0) {
+        WOLFSSL_ERROR_VERBOSE(ret);
+    }
     return ret;
 }
 
@@ -28738,6 +29011,10 @@ exit_scv:
 #endif
     FreeKeyExchange(ssl);
 
+    if (ret != 0) {
+        WOLFSSL_ERROR_VERBOSE(ret);
+    }
+
     return ret;
 }
 #endif /* WOLFSSL_NO_CLIENT_AUTH */
@@ -28808,6 +29085,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
     if (ssl->expect_session_ticket == 0) {
         WOLFSSL_MSG("Unexpected session ticket");
+        WOLFSSL_ERROR_VERBOSE(SESSION_TICKET_EXPECT_E);
         return SESSION_TICKET_EXPECT_E;
     }
 
@@ -30807,6 +31085,10 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     #endif
         FreeKeyExchange(ssl);
 
+        if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(ret);
+        }
+
         return ret;
     }
 
@@ -31025,6 +31307,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             }
         }
 
+        WOLFSSL_ERROR_VERBOSE(MATCH_SUITE_ERROR);
         return MATCH_SUITE_ERROR;
     }
 
@@ -31297,6 +31580,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 SendAlert(ssl, alert_fatal, handshake_failure);
             #endif
                 ret = EXT_MASTER_SECRET_NEEDED_E;
+                WOLFSSL_ERROR_VERBOSE(ret);
             }
         }
         else {
@@ -31316,6 +31600,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 SendAlert(ssl, alert_fatal, illegal_parameter);
             #endif
                 ret = UNSUPPORTED_SUITE;
+                WOLFSSL_ERROR_VERBOSE(ret);
             }
         #endif
 
@@ -31333,6 +31618,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 if (MatchSuite(ssl, clSuites) < 0) {
                     WOLFSSL_MSG("Unsupported cipher suite, ClientHello");
                     ret = UNSUPPORTED_SUITE;
+                    WOLFSSL_ERROR_VERBOSE(ret);
                 }
             }
             if (ret == 0) {
@@ -32037,6 +32323,10 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         WOLFSSL_LEAVE("DoClientHello", ret);
         WOLFSSL_END(WC_FUNC_CLIENT_HELLO_DO);
 
+        if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(ret);
+        }
+
         return ret;
     }
 
@@ -32474,6 +32764,10 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         /* Final cleanup */
         FreeKeyExchange(ssl);
 
+        if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(ret);
+        }
+
         return ret;
     }
 
@@ -32756,6 +33050,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                         ) {
             ForceZero(&it, sizeof(it));
             ret = WOLFSSL_TICKET_RET_FATAL;
+            WOLFSSL_ERROR_VERBOSE(ret);
         }
         else {
             /* build external */
@@ -32788,6 +33083,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             #ifdef WOLFSSL_CHECK_MEM_ZERO
                 wc_MemZero_Check(&it, sizeof(InternalTicket));
             #endif
+                WOLFSSL_ERROR_VERBOSE(BAD_TICKET_KEY_CB_SZ);
                 return BAD_TICKET_KEY_CB_SZ;
             }
 
@@ -32803,6 +33099,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             #ifdef WOLFSSL_CHECK_MEM_ZERO
                 wc_MemZero_Check(&it, sizeof(InternalTicket));
             #endif
+                WOLFSSL_ERROR_VERBOSE(BAD_TICKET_ENCRYPT);
                 return BAD_TICKET_ENCRYPT;
             }
 
@@ -32815,6 +33112,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             #ifdef WOLFSSL_CHECK_MEM_ZERO
                 wc_MemZero_Check(&it, sizeof(InternalTicket));
             #endif
+                WOLFSSL_ERROR_VERBOSE(BAD_TICKET_ENCRYPT);
                 return BAD_TICKET_ENCRYPT;
             }
 
@@ -32824,6 +33122,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             #ifdef WOLFSSL_CHECK_MEM_ZERO
                 wc_MemZero_Check(&it, sizeof(InternalTicket));
             #endif
+                WOLFSSL_ERROR_VERBOSE(BAD_TICKET_ENCRYPT);
                 return BAD_TICKET_ENCRYPT;
             }
 
@@ -32833,6 +33132,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             #ifdef WOLFSSL_CHECK_MEM_ZERO
                 wc_MemZero_Check(&it, sizeof(InternalTicket));
             #endif
+                WOLFSSL_ERROR_VERBOSE(BAD_TICKET_ENCRYPT);
                 return BAD_TICKET_ENCRYPT;
             }
 
@@ -32866,6 +33166,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
         if (len > SESSION_TICKET_LEN ||
              len < (word32)(sizeof(InternalTicket) + WOLFSSL_TICKET_FIXED_SZ)) {
+            WOLFSSL_ERROR_VERBOSE(BAD_TICKET_MSG_SZ);
             return BAD_TICKET_MSG_SZ;
         }
 
@@ -32874,6 +33175,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         /* decrypt */
         ato32(et->enc_len, &inLen);
         if (inLen > (word16)(len - WOLFSSL_TICKET_FIXED_SZ)) {
+            WOLFSSL_ERROR_VERBOSE(BAD_TICKET_MSG_SZ);
             return BAD_TICKET_MSG_SZ;
         }
         outLen = (int)inLen;   /* may be reduced by user padding */
@@ -32889,6 +33191,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 #endif
                         ) {
             ret = WOLFSSL_TICKET_RET_FATAL;
+            WOLFSSL_ERROR_VERBOSE(ret);
         }
         else {
             ret = ssl->ctx->ticketEncCb(ssl, et->key_name, et->iv,
@@ -32902,6 +33205,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             return ret;
         if (outLen > (int)inLen || outLen < (int)sizeof(InternalTicket)) {
             WOLFSSL_MSG("Bad user ticket decrypt len");
+            WOLFSSL_ERROR_VERBOSE(BAD_TICKET_KEY_CB_SZ);
             return BAD_TICKET_KEY_CB_SZ;
         }
 
@@ -32916,6 +33220,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             if (ssl->version.minor < it->pv.minor) {
                 ForceZero(it, sizeof(*it));
                 WOLFSSL_MSG("Ticket has greater version");
+                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
             else if (ssl->version.minor > it->pv.minor) {
@@ -32923,12 +33228,14 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                     ForceZero(it, sizeof(*it));
                     WOLFSSL_MSG("Tickets cannot be shared between "
                                                "TLS 1.3 and TLS 1.2 and lower");
+                    WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                     return VERSION_ERROR;
                 }
 
                 if (!ssl->options.downgrade) {
                     ForceZero(it, sizeof(*it));
                     WOLFSSL_MSG("Ticket has lesser version");
+                    WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                     return VERSION_ERROR;
                 }
 
@@ -32936,6 +33243,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
                 if (it->pv.minor < ssl->options.minDowngrade) {
                     ForceZero(it, sizeof(*it));
+                    WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                     return VERSION_ERROR;
                 }
                 ssl->version.minor = it->pv.minor;

--- a/src/keys.c
+++ b/src/keys.c
@@ -49,6 +49,7 @@ int SetCipherSpecs(WOLFSSL* ssl)
         /* server side verified before SetCipherSpecs call */
         if (VerifyClientSuite(ssl) != 1) {
             WOLFSSL_MSG("SetCipherSpecs() client has an unusable suite");
+            WOLFSSL_ERROR_VERBOSE(UNSUPPORTED_SUITE);
             return UNSUPPORTED_SUITE;
         }
     }
@@ -2056,6 +2057,7 @@ int SetCipherSpecs(WOLFSSL* ssl)
 
     default:
         WOLFSSL_MSG("Unsupported cipher suite, SetCipherSpecs");
+        WOLFSSL_ERROR_VERBOSE(UNSUPPORTED_SUITE);
         return UNSUPPORTED_SUITE;
     }  /* switch */
     }  /* if ECC / Normal suites else */

--- a/src/pk.c
+++ b/src/pk.c
@@ -1331,6 +1331,7 @@ int wolfSSL_RSA_LoadDer_ex(WOLFSSL_RSA* rsa, const unsigned char* derBuf,
             else {
                  WOLFSSL_MSG("RsaPublicKeyDecode failed");
             }
+            WOLFSSL_ERROR_VERBOSE(res);
             ret = -1;
         }
     }
@@ -5597,10 +5598,12 @@ int wolfSSL_DSA_LoadDer_ex(WOLFSSL_DSA* dsa, const unsigned char* derBuf,
     }
 
     if (ret < 0 && opt == WOLFSSL_DSA_LOAD_PRIVATE) {
+        WOLFSSL_ERROR_VERBOSE(ret);
         WOLFSSL_MSG("DsaPrivateKeyDecode failed");
         return -1;
     }
     else if (ret < 0 && opt == WOLFSSL_DSA_LOAD_PUBLIC) {
+        WOLFSSL_ERROR_VERBOSE(ret);
         WOLFSSL_MSG("DsaPublicKeyDecode failed");
         return -1;
     }

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -472,6 +472,7 @@ static int DeriveEarlyTrafficSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13SecretCb(ssl, CLIENT_EARLY_TRAFFIC_SECRET, key,
                                  ssl->specs.hash_size, ssl->tls13SecretCtx);
         if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -480,6 +481,7 @@ static int DeriveEarlyTrafficSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13KeyLogCb(ssl, CLIENT_EARLY_TRAFFIC_SECRET, key,
                                 ssl->specs.hash_size, NULL);
         if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -524,6 +526,7 @@ static int DeriveClientHandshakeSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13SecretCb(ssl, CLIENT_HANDSHAKE_TRAFFIC_SECRET, key,
                                  ssl->specs.hash_size, ssl->tls13SecretCtx);
         if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -532,6 +535,7 @@ static int DeriveClientHandshakeSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13KeyLogCb(ssl, CLIENT_HANDSHAKE_TRAFFIC_SECRET, key,
                                 ssl->specs.hash_size, NULL);
         if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -567,6 +571,7 @@ static int DeriveServerHandshakeSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13SecretCb(ssl, SERVER_HANDSHAKE_TRAFFIC_SECRET, key,
                                  ssl->specs.hash_size, ssl->tls13SecretCtx);
         if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -575,6 +580,7 @@ static int DeriveServerHandshakeSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13KeyLogCb(ssl, SERVER_HANDSHAKE_TRAFFIC_SECRET, key,
                                 ssl->specs.hash_size, NULL);
         if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -610,6 +616,7 @@ static int DeriveClientTrafficSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13SecretCb(ssl, CLIENT_TRAFFIC_SECRET, key,
                                  ssl->specs.hash_size, ssl->tls13SecretCtx);
         if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -618,6 +625,7 @@ static int DeriveClientTrafficSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13KeyLogCb(ssl, CLIENT_TRAFFIC_SECRET, key,
                                 ssl->specs.hash_size, NULL);
         if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -653,6 +661,7 @@ static int DeriveServerTrafficSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13SecretCb(ssl, SERVER_TRAFFIC_SECRET, key,
                                  ssl->specs.hash_size, ssl->tls13SecretCtx);
         if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -661,6 +670,7 @@ static int DeriveServerTrafficSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13KeyLogCb(ssl, SERVER_TRAFFIC_SECRET, key,
                                 ssl->specs.hash_size, NULL);
         if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -697,6 +707,7 @@ static int DeriveExporterSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13SecretCb(ssl, EXPORTER_SECRET, key,
                                  ssl->specs.hash_size, ssl->tls13SecretCtx);
         if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -705,6 +716,7 @@ static int DeriveExporterSecret(WOLFSSL* ssl, byte* key)
         ret = ssl->tls13KeyLogCb(ssl, EXPORTER_SECRET, key,
                                 ssl->specs.hash_size, NULL);
         if (ret != 0) {
+            WOLFSSL_ERROR_VERBOSE(TLS13_SECRET_CB_E);
             return TLS13_SECRET_CB_E;
         }
     }
@@ -1339,6 +1351,10 @@ end:
 #elif defined(WOLFSSL_CHECK_MEM_ZERO)
     wc_MemZero_Check(key_dig, MAX_PRF_DIG);
 #endif
+
+    if (ret != 0) {
+        WOLFSSL_ERROR_VERBOSE(ret);
+    }
 
     return ret;
 }
@@ -2300,6 +2316,7 @@ int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
                 SendAlert(ssl, alert_fatal, bad_record_mac);
             }
             ret = VERIFY_MAC_ERROR;
+            WOLFSSL_ERROR_VERBOSE(ret);
         }
         #else
             (void)doAlert;
@@ -2474,6 +2491,10 @@ int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
 
        default:
             break;
+    }
+
+    if (ret < 0) {
+        WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     return ret;
@@ -2685,8 +2706,12 @@ exit_buildmsg:
     ssl->options.buildMsgState = BUILD_MSG_BEGIN;
 
     /* return sz on success */
-    if (ret == 0)
+    if (ret == 0) {
         ret = args->sz;
+    }
+    else {
+        WOLFSSL_ERROR_VERBOSE(ret);
+    }
 
     /* Final cleanup */
 #ifdef WOLFSSL_ASYNC_CRYPT
@@ -3003,8 +3028,10 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
         if (clientHello) {
             /* Ensure cipher suite is supported or changed suite to one with
              * the same MAC algorithm. */
-            if (!FindSuiteSSL(ssl, suite))
+            if (!FindSuiteSSL(ssl, suite)) {
+                WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
                 return PSK_KEY_ERROR;
+            }
 
             /* Setting mac for binder and keys for deriving EarlyData. */
             ret = SetCipherSpecs(ssl);
@@ -3068,6 +3095,7 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
                 if (idlen > MAX_PSK_KEY_LEN) {
                     wolfSSL_FreeSession(ssl->ctx, psksession);
                     WOLFSSL_MSG("psk key length is too long");
+                    WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
                     return PSK_KEY_ERROR;
                 }
 
@@ -3104,6 +3132,7 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
                 byte pskCS[2] = { psk->cipherSuite0, psk->cipherSuite };
                 /* Ensure PSK and negotiated cipher suites have same hash. */
                 if (SuiteMac(pskCS) != SuiteMac(suite)) {
+                    WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
                     return PSK_KEY_ERROR;
                 }
                 /* Negotiated cipher suite is to be used - update PSK. */
@@ -3122,6 +3151,7 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
                     &cipherName);
             if (GetCipherSuiteFromName(cipherName, &cipherSuite0,
                                        &cipherSuite, &cipherSuiteFlags) != 0) {
+                WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
                 return PSK_KEY_ERROR;
             }
             ssl->options.cipherSuite0 = cipherSuite0;
@@ -3137,6 +3167,7 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
         }
         if (ssl->arrays->psk_keySz == 0 ||
                                      ssl->arrays->psk_keySz > MAX_PSK_KEY_LEN) {
+            WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
             return PSK_KEY_ERROR;
         }
 
@@ -3149,6 +3180,7 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
 
         if (!clientHello && (psk->cipherSuite0 != suite[0] ||
                                                 psk->cipherSuite != suite[1])) {
+            WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
             return PSK_KEY_ERROR;
         }
 
@@ -3357,7 +3389,10 @@ int SendTls13ClientHello(WOLFSSL* ssl)
         }
         else
     #endif
+        {
+            WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             return VERSION_ERROR;
+        }
     }
 #endif
 
@@ -3810,6 +3845,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
     if (args->pv.major != ssl->version.major ||
         args->pv.minor != tls12minor) {
+        WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
         return VERSION_ERROR;
     }
 
@@ -3827,6 +3863,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
          * Don't allow more than one HelloRetryRequest or ServerHello.
          */
         if (ssl->msgsReceived.got_hello_retry_request) {
+            WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
             return DUPLICATE_MSG_E;
         }
     }
@@ -3862,6 +3899,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     b = input[args->idx++];
     if (b != 0) {
         WOLFSSL_MSG("Must be no compression types in list");
+        WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
         return INVALID_PARAMETER;
     }
 
@@ -3914,6 +3952,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             if (!ssl->options.downgrade) {
                 WOLFSSL_MSG("Server trying to downgrade to version less than "
                             "TLS v1.3");
+                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
 #if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER) || \
@@ -3922,16 +3961,22 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             if (args->pv.minor == TLSv1_2_MINOR &&
                 (ssl->options.mask & SSL_OP_NO_TLSv1_2) == SSL_OP_NO_TLSv1_2) {
                 WOLFSSL_MSG("\tOption set to not allow TLSv1.2");
+                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
 #endif
 
             if (!ssl->options.dtls &&
-                args->pv.minor < ssl->options.minDowngrade)
+                args->pv.minor < ssl->options.minDowngrade) {
+                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
+            }
 
-            if (ssl->options.dtls && args->pv.minor > ssl->options.minDowngrade)
+            if (ssl->options.dtls &&
+                args->pv.minor > ssl->options.minDowngrade) {
+                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
+            }
 
             ssl->version.minor = args->pv.minor;
 
@@ -4005,6 +4050,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         ret = ssl->sessionSecretCb(ssl, ssl->session->masterSecret,
                                    &secretSz, ssl->sessionSecretCtx);
         if (ret != 0 || secretSz != SECRET_LEN) {
+            WOLFSSL_ERROR_VERBOSE(SESSION_SECRET_CB_E);
             return SESSION_SECRET_CB_E;
         }
     }
@@ -4034,6 +4080,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         ret = CompleteServerHello(ssl);
 #else
         WOLFSSL_MSG("Client using higher version, fatal error");
+        WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
         ret = VERSION_ERROR;
 #endif
 
@@ -4052,6 +4099,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 #ifdef WOLFSSL_TLS13_MIDDLEBOX_COMPAT
     if (args->sessIdSz == 0) {
         WOLFSSL_MSG("args->sessIdSz == 0");
+        WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
         return INVALID_PARAMETER;
     }
     if (ssl->session->sessionIDSz != 0) {
@@ -4059,12 +4107,14 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             XMEMCMP(ssl->session->sessionID, args->sessId,
                 args->sessIdSz) != 0) {
             WOLFSSL_MSG("session id doesn't match");
+            WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
             return INVALID_PARAMETER;
         }
     }
     else if (XMEMCMP(ssl->arrays->clientRandom, args->sessId,
             args->sessIdSz) != 0) {
         WOLFSSL_MSG("session id doesn't match client random");
+        WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
         return INVALID_PARAMETER;
     }
 #else
@@ -4072,6 +4122,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         XMEMCMP(ssl->session->sessionID, args->sessId, args->sessIdSz) != 0))
     {
         WOLFSSL_MSG("Server sent different session id");
+        WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
         return INVALID_PARAMETER;
     }
 #endif /* WOLFSSL_TLS13_MIDDLEBOX_COMPAT */
@@ -4090,6 +4141,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     /* Check that the negotiated ciphersuite matches protocol version. */
     if (ssl->options.cipherSuite0 != TLS13_BYTE) {
         WOLFSSL_MSG("Server sent non-TLS13 cipher suite in TLS 1.3 packet");
+        WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
         return INVALID_PARAMETER;
     }
 
@@ -4097,7 +4149,8 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     suite[1] = ssl->options.cipherSuite;
     if (!FindSuiteSSL(ssl, suite)) {
         WOLFSSL_MSG("Cipher suite not supported on client");
-        return PSK_KEY_ERROR;
+        WOLFSSL_ERROR_VERBOSE(MATCH_SUITE_ERROR);
+        return MATCH_SUITE_ERROR;
     }
 
     if (*extMsgType == server_hello) {
@@ -4310,6 +4363,7 @@ static int DoTls13CertificateRequest(WOLFSSL* ssl, const byte* input,
             ) {
         if (PickHashSigAlgo(ssl, peerSuites.hashSigAlgo,
                                                peerSuites.hashSigAlgoSz) != 0) {
+            WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
             return INVALID_PARAMETER;
         }
         ssl->options.sendVerify = SEND_CERT;
@@ -4320,6 +4374,7 @@ static int DoTls13CertificateRequest(WOLFSSL* ssl, const byte* input,
 #else
         WOLFSSL_MSG("Certificate required but none set on client");
         SendAlert(ssl, alert_fatal, illegal_parameter);
+        WOLFSSL_ERROR_VERBOSE(NO_CERT_ERROR);
         return NO_CERT_ERROR;
 #endif
     }
@@ -4417,6 +4472,7 @@ static int FindPsk(WOLFSSL* ssl, PreSharedKey* psk, byte* suite, int* err)
     if (found) {
         if (sa->psk_keySz > MAX_PSK_KEY_LEN) {
             ret = PSK_KEY_ERROR;
+            WOLFSSL_ERROR_VERBOSE(ret);
         }
         if (ret == 0) {
         #ifndef WOLFSSL_PSK_ONE_ID
@@ -4438,6 +4494,7 @@ static int FindPsk(WOLFSSL* ssl, PreSharedKey* psk, byte* suite, int* err)
             /* PSK age is always zero. */
             if (psk->ticketAge != ssl->session->ticketAdd) {
                 ret = PSK_KEY_ERROR;
+                WOLFSSL_ERROR_VERBOSE(ret);
             }
         }
         if ((ret == 0) && found) {
@@ -4612,6 +4669,7 @@ static int DoPreSharedKeys(WOLFSSL* ssl, byte* suite, int* usingPSK, int* first)
             return ret;
         if (binderLen != current->binderLen ||
                              XMEMCMP(binder, current->binder, binderLen) != 0) {
+            WOLFSSL_ERROR_VERBOSE(BAD_BINDER);
             return BAD_BINDER;
         }
 
@@ -4627,6 +4685,7 @@ static int DoPreSharedKeys(WOLFSSL* ssl, byte* suite, int* usingPSK, int* first)
         if (ssl->buffers.certChainCnt != 0)
             return 0;
     #endif
+        WOLFSSL_ERROR_VERBOSE(BAD_BINDER);
         return BAD_BINDER;
 #else
         return 0;
@@ -4678,8 +4737,10 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
     }
 
     /* Extensions pushed on stack/list and PSK must be last. */
-    if (ssl->extensions != ext)
+    if (ssl->extensions != ext) {
+        WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
         return PSK_KEY_ERROR;
+    }
 
     /* Assume we are going to resume with a pre-shared key. */
     ssl->options.resuming = 1;
@@ -4774,8 +4835,10 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
 
         /* Get the PSK key exchange modes the client wants to negotiate. */
         ext = TLSX_Find(ssl->extensions, TLSX_PSK_KEY_EXCHANGE_MODES);
-        if (ext == NULL)
+        if (ext == NULL) {
+            WOLFSSL_ERROR_VERBOSE(MISSING_HANDSHAKE_DATA);
             return MISSING_HANDSHAKE_DATA;
+        }
         modes = ext->val;
 
     #ifdef HAVE_SUPPORTED_CURVES
@@ -4793,6 +4856,7 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
         {
             if ((modes & (1 << PSK_KE)) == 0) {
                 WOLFSSL_MSG("psk_ke mode does not allow key share");
+                WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
                 return PSK_KEY_ERROR;
             }
             ssl->options.noPskDheKe = 1;
@@ -4807,6 +4871,7 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
         if (ssl->buffers.certChainCnt != 0)
             return 0;
     #endif
+        WOLFSSL_ERROR_VERBOSE(BAD_BINDER);
         return BAD_BINDER;
     }
 #endif
@@ -4870,8 +4935,10 @@ static int CheckCookie(WOLFSSL* ssl, byte* cookie, byte cookieSz)
     if (ret != 0)
         return ret;
 
-    if (ConstantCompare(cookie + cookieSz, mac, macSz) != 0)
+    if (ConstantCompare(cookie + cookieSz, mac, macSz) != 0) {
+        WOLFSSL_ERROR_VERBOSE(HRR_COOKIE_ERROR);
         return HRR_COOKIE_ERROR;
+    }
     return cookieSz;
 }
 
@@ -5577,6 +5644,10 @@ exit_dch:
     FreeAsyncCtx(ssl, 0);
 #endif
     WOLFSSL_END(WC_FUNC_CLIENT_HELLO_DO);
+
+    if (ret != 0) {
+        WOLFSSL_ERROR_VERBOSE(ret);
+    }
 
     return ret;
 }
@@ -7251,6 +7322,10 @@ exit_scv:
     FreeAsyncCtx(ssl, 0);
 #endif
 
+    if (ret != 0) {
+        WOLFSSL_ERROR_VERBOSE(ret);
+    }
+
     return ret;
 }
 #endif
@@ -7753,8 +7828,13 @@ exit_dcv:
     }
     else
 #endif /* WOLFSSL_ASYNC_CRYPT */
-    if (ret != 0 && ret != INVALID_PARAMETER)
-        SendAlert(ssl, alert_fatal, decrypt_error);
+    if (ret != 0) {
+        WOLFSSL_ERROR_VERBOSE(ret);
+
+        if (ret != INVALID_PARAMETER) {
+            SendAlert(ssl, alert_fatal, decrypt_error);
+        }
+    }
 
     /* Final cleanup */
     FreeDcv13Args(ssl, args);
@@ -7888,6 +7968,7 @@ int DoTls13Finished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         if (XMEMCMP(input + *inOutIdx, mac, size) != 0){
             WOLFSSL_MSG("Verify finished error on hashes");
             SendAlert(ssl, alert_fatal, decrypt_error);
+            WOLFSSL_ERROR_VERBOSE(VERIFY_FINISHED_ERROR);
             return VERIFY_FINISHED_ERROR;
         }
     }
@@ -8049,8 +8130,10 @@ static int SendTls13Finished(WOLFSSL* ssl)
     /* This message is always encrypted. */
     sendSz = BuildTls13Message(ssl, output, outputSz, input,
                                headerSz + finishedSz, handshake, 1, 0, 0);
-    if (sendSz < 0)
+    if (sendSz < 0) {
+        WOLFSSL_ERROR_VERBOSE(BUILD_MSG_ERROR);
         return BUILD_MSG_ERROR;
+    }
 
     #ifdef WOLFSSL_CALLBACKS
         if (ssl->hsInfoOn) AddPacketName(ssl, "Finished");
@@ -8329,6 +8412,7 @@ static int DoTls13KeyUpdate(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             ssl->keys.keyUpdateRespond = 1;
             break;
         default:
+            WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
             return INVALID_PARAMETER;
     }
 
@@ -8466,6 +8550,7 @@ static int DoTls13EndOfEarlyData(WOLFSSL* ssl, const byte* input,
     if (ssl->earlyData == no_early_data) {
         WOLFSSL_MSG("EndOfEarlyData received unexpectedly");
         SendAlert(ssl, alert_fatal, unexpected_message);
+        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
         return OUT_OF_ORDER_E;
     }
 
@@ -8516,8 +8601,10 @@ static int DoTls13NewSessionTicket(WOLFSSL* ssl, const byte* input,
         return BUFFER_ERROR;
     ato32(input + *inOutIdx, &lifetime);
     *inOutIdx += SESSION_HINT_SZ;
-    if (lifetime > MAX_LIFETIME)
+    if (lifetime > MAX_LIFETIME) {
+        WOLFSSL_ERROR_VERBOSE(SERVER_HINT_ERROR);
         return SERVER_HINT_ERROR;
+    }
 
     /* Age add. */
     if ((*inOutIdx - begin) + SESSION_ADD_SZ > size)
@@ -8531,6 +8618,7 @@ static int DoTls13NewSessionTicket(WOLFSSL* ssl, const byte* input,
     nonceLength = input[*inOutIdx];
     if (nonceLength > MAX_TICKET_NONCE_SZ) {
         WOLFSSL_MSG("Nonce length not supported");
+        WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
         return INVALID_PARAMETER;
     }
     *inOutIdx += 1;
@@ -8861,18 +8949,21 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only valid when received on SERVER side. */
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 WOLFSSL_MSG("ClientHello received by client");
+                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             /* Check state. */
             if (ssl->options.clientState >= CLIENT_HELLO_COMPLETE) {
                 WOLFSSL_MSG("ClientHello received out of order");
+                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             /* Check previously seen. */
             /* Initial and after HelloRetryRequest - no more than 2. */
             if (ssl->msgsReceived.got_client_hello == 2) {
                 WOLFSSL_MSG("Too many ClientHello received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             /* Second only after HelloRetryRequest seen. */
@@ -8880,6 +8971,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                 ssl->options.serverState !=
                                           SERVER_HELLO_RETRY_REQUEST_COMPLETE) {
                 WOLFSSL_MSG("Duplicate ClientHello received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_client_hello++;
@@ -8893,12 +8985,14 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only valid when received on CLIENT side. */
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("ServerHello received by server");
+                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
             /* Check state. */
             if (ssl->options.serverState >= SERVER_HELLO_COMPLETE) {
                 WOLFSSL_MSG("ServerHello received out of order");
+                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             /* Check previously seen. */
@@ -8908,6 +9002,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
              */
             if (ssl->msgsReceived.got_server_hello) {
                 WOLFSSL_MSG("Duplicate ServerHello received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_server_hello = 1;
@@ -8921,6 +9016,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only valid when received on CLIENT side. */
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("NewSessionTicket received by server");
+                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
@@ -8929,12 +9025,14 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only allowed after server's Finished message. */
             if (ssl->options.serverState < SERVER_FINISHED_COMPLETE) {
                 WOLFSSL_MSG("NewSessionTicket received out of order");
+                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
         #else
             /* Only allowed after client's Finished message. */
             if (ssl->options.clientState < CLIENT_FINISHED_COMPLETE) {
                 WOLFSSL_MSG("NewSessionTicket received out of order");
+                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
         #endif
@@ -8951,6 +9049,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only valid when received on SERVER side. */
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 WOLFSSL_MSG("EndOfEarlyData received by client");
+                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
@@ -8958,15 +9057,18 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only after server's Finished and before client's Finished. */
             if (ssl->options.serverState < SERVER_FINISHED_COMPLETE) {
                 WOLFSSL_MSG("EndOfEarlyData received out of order");
+                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             if (ssl->options.clientState >= CLIENT_FINISHED_COMPLETE) {
                 WOLFSSL_MSG("EndOfEarlyData received out of order");
+                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             /* Check previously seen. */
             if (ssl->msgsReceived.got_end_of_early_data) {
                 WOLFSSL_MSG("Too many EndOfEarlyData received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_end_of_early_data = 1;
@@ -8981,6 +9083,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only valid when received on CLIENT side. */
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("EncryptedExtensions received by server");
+                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
@@ -8991,11 +9094,13 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
              */
             if (ssl->options.serverState != SERVER_HELLO_COMPLETE) {
                 WOLFSSL_MSG("EncryptedExtensions received out of order");
+                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             /* Check previously seen. */
             if (ssl->msgsReceived.got_encrypted_extensions) {
                 WOLFSSL_MSG("Duplicate EncryptedExtensions received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_encrypted_extensions = 1;
@@ -9015,6 +9120,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                 ssl->options.serverState !=
                                          SERVER_ENCRYPTED_EXTENSIONS_COMPLETE) {
                 WOLFSSL_MSG("Certificate received out of order - Client");
+                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
         #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
@@ -9023,6 +9129,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                              ssl->options.serverState == SERVER_CERT_COMPLETE &&
                              ssl->options.pskNegotiated) {
                 WOLFSSL_MSG("Certificate received while using PSK");
+                WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                 return SANITY_MSG_E;
             }
         #endif
@@ -9035,12 +9142,14 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                 ssl->options.clientState != CLIENT_HELLO_COMPLETE &&
                 ssl->options.serverState < SERVER_FINISHED_COMPLETE) {
                 WOLFSSL_MSG("Certificate received out of order - Server");
+                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
     #endif
             /* Check previously seen. */
             if (ssl->msgsReceived.got_certificate) {
                 WOLFSSL_MSG("Duplicate Certificate received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_certificate = 1;
@@ -9053,6 +9162,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only valid when received on CLIENT side. */
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("CertificateRequest received by server");
+                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
         #endif
@@ -9063,6 +9173,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             if (ssl->options.serverState !=
                                          SERVER_ENCRYPTED_EXTENSIONS_COMPLETE) {
                 WOLFSSL_MSG("CertificateRequest received out of order");
+                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
         #else
@@ -9074,6 +9185,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                        (ssl->options.serverState < SERVER_FINISHED_COMPLETE ||
                         ssl->options.clientState != CLIENT_FINISHED_COMPLETE)) {
                 WOLFSSL_MSG("CertificateRequest received out of order");
+                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
         #endif
@@ -9081,6 +9193,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Server's authenticating with PSK must not send this. */
             if (ssl->options.pskNegotiated) {
                 WOLFSSL_MSG("CertificateRequest received while using PSK");
+                WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                 return SANITY_MSG_E;
             }
         #endif
@@ -9089,6 +9202,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Only once during handshake. */
             if (ssl->msgsReceived.got_certificate_request) {
                 WOLFSSL_MSG("Duplicate CertificateRequest received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
         #else
@@ -9096,6 +9210,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             if (ssl->msgsReceived.got_certificate_request &&
                 ssl->options.clientState != CLIENT_FINISHED_COMPLETE) {
                 WOLFSSL_MSG("Duplicate CertificateRequest received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
         #endif
@@ -9112,12 +9227,14 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 if (ssl->options.serverState != SERVER_CERT_COMPLETE) {
                     WOLFSSL_MSG("No Cert before CertVerify");
+                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
             #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
                 /* Server's authenticating with PSK must not send this. */
                 if (ssl->options.pskNegotiated) {
                     WOLFSSL_MSG("CertificateVerify received while using PSK");
+                    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
                     return SANITY_MSG_E;
                 }
             #endif
@@ -9129,15 +9246,18 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                 /* Server must have sent Finished message. */
                 if (ssl->options.serverState < SERVER_FINISHED_COMPLETE) {
                     WOLFSSL_MSG("CertificateVerify received out of order");
+                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
                 /* Valid only directly after a Certificate message. */
                 if (ssl->options.clientState < CLIENT_HELLO_COMPLETE) {
                     WOLFSSL_MSG("CertificateVerify before ClientHello done");
+                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
                 if (!ssl->msgsReceived.got_certificate) {
                     WOLFSSL_MSG("No Cert before CertificateVerify");
+                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
             }
@@ -9145,6 +9265,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             /* Check previously seen. */
             if (ssl->msgsReceived.got_certificate_verify) {
                 WOLFSSL_MSG("Duplicate CertificateVerify received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_certificate_verify = 1;
@@ -9159,6 +9280,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                 /* After sending ClientHello */
                 if (ssl->options.clientState < CLIENT_HELLO_COMPLETE) {
                     WOLFSSL_MSG("Finished received out of order - clientState");
+                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
                 /* Must have seen certificate and verify from server except when
@@ -9168,6 +9290,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                     if (ssl->options.serverState !=
                                          SERVER_ENCRYPTED_EXTENSIONS_COMPLETE) {
                         WOLFSSL_MSG("Finished received out of order - PSK");
+                        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                         return OUT_OF_ORDER_E;
                     }
                 }
@@ -9175,6 +9298,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             #endif
                 if (ssl->options.serverState != SERVER_CERT_VERIFY_COMPLETE) {
                     WOLFSSL_MSG("Finished received out of order - serverState");
+                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
             }
@@ -9184,16 +9308,19 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 if (ssl->options.serverState < SERVER_FINISHED_COMPLETE) {
                     WOLFSSL_MSG("Finished received out of order - serverState");
+                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
                 if (ssl->options.clientState < CLIENT_HELLO_COMPLETE) {
                     WOLFSSL_MSG("Finished received out of order - clientState");
+                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
             #ifdef WOLFSSL_EARLY_DATA
                 if (ssl->earlyData == process_early_data &&
                     /* early data may be lost when using DTLS */
                     !ssl->options.dtls) {
+                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
             #endif
@@ -9211,6 +9338,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                                            !ssl->msgsReceived.got_certificate) {
                     WOLFSSL_MSG("Finished received out of order - "
                                 "missing Certificate message");
+                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
                 /* Mutual authentication on server requires a certificate from
@@ -9222,6 +9350,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                      ssl->options.verifyPeer)) && !ssl->options.havePeerCert) {
                     WOLFSSL_MSG("Finished received out of order - "
                                 "no valid certificate");
+                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
                 /* Must have received a valid CertificateVerify if verifying
@@ -9231,12 +9360,14 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                     ssl->options.havePeerCert && !ssl->options.havePeerVerify) {
                     WOLFSSL_MSG("Finished received out of order - "
                                 "Certificate message but no CertificateVerify");
+                    WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                     return OUT_OF_ORDER_E;
                 }
             }
             /* Check previously seen. */
             if (ssl->msgsReceived.got_finished) {
                 WOLFSSL_MSG("Duplicate Finished received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_finished = 1;
@@ -9251,6 +9382,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
              */
             if (!ssl->msgsReceived.got_finished) {
                 WOLFSSL_MSG("No KeyUpdate before Finished");
+                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             /* Multiple KeyUpdates can be sent. */
@@ -9259,32 +9391,38 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
         case hello_verify_request:
             if (!ssl->options.dtls) {
                 WOLFSSL_MSG("HelloVerifyRequest when not in DTLS");
+                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             if (ssl->msgsReceived.got_hello_verify_request) {
                 WOLFSSL_MSG("Duplicate HelloVerifyRequest received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             ssl->msgsReceived.got_hello_verify_request = 1;
             if (ssl->msgsReceived.got_hello_retry_request) {
                 WOLFSSL_MSG(
                     "Both HelloVerifyRequest and HelloRetryRequest received");
+                WOLFSSL_ERROR_VERBOSE(DUPLICATE_MSG_E);
                 return DUPLICATE_MSG_E;
             }
             if (ssl->options.serverState >=
                     SERVER_HELLO_RETRY_REQUEST_COMPLETE ||
                 ssl->options.connectState != CLIENT_HELLO_SENT) {
                 WOLFSSL_MSG("HelloVerifyRequest received out of order");
+                WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
             if (ssl->options.side == WOLFSSL_SERVER_END) {
                 WOLFSSL_MSG("HelloVerifyRequest recevied on the server");
+                WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
             if (!ssl->options.downgrade ||
                 ssl->options.minDowngrade < DTLSv1_2_MINOR) {
                 WOLFSSL_MSG(
                     "HelloVerifyRequest recevied but not DTLSv1.2 allowed");
+                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
             break;
@@ -9292,6 +9430,7 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
 
         default:
             WOLFSSL_MSG("Unknown message type");
+            WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
             return SANITY_MSG_E;
     }
 
@@ -9344,6 +9483,7 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             type != certificate && type != key_update && type != finished) {
         WOLFSSL_MSG("HandShake message after handshake complete");
         SendAlert(ssl, alert_fatal, unexpected_message);
+        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
         return OUT_OF_ORDER_E;
     }
 
@@ -9356,6 +9496,7 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         ) {
         WOLFSSL_MSG("First server message not server hello");
         SendAlert(ssl, alert_fatal, unexpected_message);
+        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
         return OUT_OF_ORDER_E;
     }
 
@@ -9363,6 +9504,7 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                ssl->options.clientState == NULL_STATE && type != client_hello) {
         WOLFSSL_MSG("First client message not client hello");
         SendAlert(ssl, alert_fatal, unexpected_message);
+        WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
         return OUT_OF_ORDER_E;
     }
 
@@ -9620,6 +9762,7 @@ int DoTls13HandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         if (GetHandshakeHeader(ssl, input, inOutIdx, &type, &size,
                                                                 totalSz) != 0) {
             SendAlert(ssl, alert_fatal, unexpected_message);
+            WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
             return PARSE_ERROR;
         }
 
@@ -9633,14 +9776,18 @@ int DoTls13HandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
      * pending message size will be non-zero. */
     if (ssl->arrays->pendingMsgSz == 0) {
 
-        if (GetHandshakeHeader(ssl,input, inOutIdx, &type, &size, totalSz) != 0)
+        if (GetHandshakeHeader(ssl, input, inOutIdx, &type, &size,
+                               totalSz) != 0) {
+            WOLFSSL_ERROR_VERBOSE(PARSE_ERROR);
             return PARSE_ERROR;
+        }
 
         /* Cap the maximum size of a handshake message to something reasonable.
          * By default is the maximum size of a certificate message assuming
          * nine 2048-bit RSA certificates in the chain. */
         if (size > MAX_HANDSHAKE_SZ) {
             WOLFSSL_MSG("Handshake message too large");
+            WOLFSSL_ERROR_VERBOSE(HANDSHAKE_SIZE_ERROR);
             return HANDSHAKE_SIZE_ERROR;
         }
 
@@ -9884,6 +10031,7 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
                     return wolfSSL_connect(ssl);
     #endif
                 WOLFSSL_MSG("Client using higher version, fatal error");
+                WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
 
@@ -9973,6 +10121,7 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
             /* CLIENT: check peer authentication. */
             if (!ssl->options.peerAuthGood) {
                 WOLFSSL_MSG("Server authentication did not happen");
+                WOLFSSL_ERROR_VERBOSE(WOLFSSL_FATAL_ERROR);
                 return WOLFSSL_FATAL_ERROR;
             }
         #ifndef NO_CERTS
@@ -10055,6 +10204,7 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
                 int cbret = ssl->hsDoneCb(ssl, ssl->hsDoneCtx);
                 if (cbret < 0) {
                     ssl->error = cbret;
+                    WOLFSSL_ERROR_VERBOSE(ssl->error);
                     WOLFSSL_MSG("HandShake Done Cb don't continue error");
                     return WOLFSSL_FATAL_ERROR;
                 }

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -1791,6 +1791,7 @@ static WARN_UNUSED_RESULT int wc_AesEncrypt(
     const word32* rk = aes->key;
 
     if (r > 7 || r == 0) {
+        WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
         return KEYUSAGE_E;
     }
 
@@ -1824,6 +1825,7 @@ static WARN_UNUSED_RESULT int wc_AesEncrypt(
             return 0;
         #else
             WOLFSSL_MSG("AES-ECB encrypt with bad alignment");
+            WOLFSSL_ERROR_VERBOSE(BAD_ALIGN_E);
             return BAD_ALIGN_E;
         #endif
         }
@@ -2146,6 +2148,7 @@ static WARN_UNUSED_RESULT int wc_AesDecrypt(
     const word32* rk = aes->key;
 
     if (r > 7 || r == 0) {
+        WOLFSSL_ERROR_VERBOSE(KEYUSAGE_E);
         return KEYUSAGE_E;
     }
 
@@ -4006,6 +4009,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
         blocks = sz / AES_BLOCK_SIZE;
 #ifdef WOLFSSL_AES_CBC_LENGTH_CHECKS
         if (sz % AES_BLOCK_SIZE) {
+            WOLFSSL_ERROR_VERBOSE(BAD_LENGTH_E);
             return BAD_LENGTH_E;
         }
 #endif
@@ -4081,6 +4085,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
                 return 0;
             #else
                 WOLFSSL_MSG("AES-CBC encrypt with bad alignment");
+                WOLFSSL_ERROR_VERBOSE(BAD_ALIGN_E);
                 return BAD_ALIGN_E;
             #endif
             }

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -26,6 +26,7 @@
 
 #include <wolfssl/wolfcrypt/wc_port.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
+#include <wolfssl/wolfcrypt/logging.h>
 
 #ifndef NO_HMAC
 
@@ -329,8 +330,10 @@ int wc_HmacSetKey(Hmac* hmac, int type, const byte* key, word32 length)
         return ret;
 
 #ifdef HAVE_FIPS
-    if (length < HMAC_FIPS_MIN_KEY)
+    if (length < HMAC_FIPS_MIN_KEY) {
+        WOLFSSL_ERROR_VERBOSE(HMAC_MIN_KEYLEN_E);
         return HMAC_MIN_KEYLEN_E;
+    }
 #endif
 
 #ifdef WOLF_CRYPTO_CB

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -668,6 +668,7 @@ int wc_d2i_PKCS12(const byte* der, word32 derSz, WC_PKCS12* pkcs12)
 
     if (version != WC_PKCS12_VERSION_DEFAULT) {
         WOLFSSL_MSG("PKCS12 unsupported version!");
+        WOLFSSL_ERROR_VERBOSE(ASN_VERSION_E);
         return ASN_VERSION_E;
     }
 

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -261,10 +261,13 @@ int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
 
     /* use file's salt for key derivation, hex decode first */
     if (Base16_Decode(info->iv, info->ivSz, info->iv, &info->ivSz) != 0) {
+        WOLFSSL_ERROR_VERBOSE(BUFFER_E);
         return BUFFER_E;
     }
-    if (info->ivSz < PKCS5_SALT_SZ)
+    if (info->ivSz < PKCS5_SALT_SZ) {
+        WOLFSSL_ERROR_VERBOSE(BUFFER_E);
         return BUFFER_E;
+    }
 
 #ifdef WOLFSSL_SMALL_STACK
     key = (byte*)XMALLOC(WC_MAX_SYM_KEY_SIZE, NULL, DYNAMIC_TYPE_SYMMETRIC_KEY);
@@ -482,6 +485,7 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
             WOLFSSL_MSG("Unknown/Unsupported encrypt/decrypt id");
             (void)shaOid;
             ret = ALGO_ID_E;
+            WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -541,6 +545,7 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
             default:
                 WOLFSSL_MSG("Unknown/Unsupported PKCS version");
                 ret = ALGO_ID_E;
+                WOLFSSL_ERROR_VERBOSE(ret);
         } /* switch (version) */
     }
 
@@ -685,6 +690,7 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
             default:
                 WOLFSSL_MSG("Unknown/Unsupported encrypt/decryption algorithm");
                 ret = ALGO_ID_E;
+                WOLFSSL_ERROR_VERBOSE(ret);
         }
     }
 

--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -193,13 +193,20 @@ WOLFSSL_API void wolfSSL_Debugging_OFF(void);
             WOLFSSL_ERROR_LINE((x), __func__, __LINE__, __FILE__, NULL)
     #else
         WOLFSSL_API void WOLFSSL_ERROR(int err);
-    #endif
-    WOLFSSL_API void WOLFSSL_ERROR_MSG(const char* msg);
+    #endif /* WOLFSSL_HAVE_ERROR_QUEUE */
 
+    WOLFSSL_API void WOLFSSL_ERROR_MSG(const char* msg);
 #else
     #define WOLFSSL_ERROR(e)
     #define WOLFSSL_ERROR_MSG(m)
-#endif
+#endif /* DEBUG_WOLFSSL | OPENSSL_ALL || WOLFSSL_NGINX || WOLFSSL_HAPROXY ||
+          OPENSSL_EXTRA */
+
+#ifdef WOLFSSL_VERBOSE_ERRORS
+    #define WOLFSSL_ERROR_VERBOSE WOLFSSL_ERROR
+#else
+    #define WOLFSSL_ERROR_VERBOSE(e)
+#endif /* WOLFSSL_VERBOSE_ERRORS */
 
 #ifdef HAVE_STACK_SIZE_VERBOSE
     extern WOLFSSL_API THREAD_LS_T unsigned char *StackSizeCheck_myStack;


### PR DESCRIPTION
# Description

We have users who need to debug errors coming out of libwolfssl in production,
where --enable-debug isn't an option. Our error queue implementation is the
solution, but our usage of WOLFSSL_ERROR isn't consistent. This commit greatly
expands our usage of WOLFSSL_ERROR. There are too many error cases to tackle
all at once, and not all error cases are particularly meaningful or likely to be
hit in regular operation of the library. I've tried to focus on errors that
users are likely to hit, and I've chosen to ignore things like the mountain of
BUFFER_E and BAD_FUNC_ARG cases (for the most part). I've also tried to expand
WOLFSSL_ERROR usage in files where we haven't been using it historically
(e.g. aes.c), so the pattern is now there for other developers to follow. In
order to prevent these additions from exploding the size of libwolfssl, they're
all behind a new macro, WOLFSSL_ERROR_VERBOSE. If WOLFSSL_VERBOSE_ERRORS is
defined, WOLFSSL_ERROR_VERBOSE just maps to WOLFSSL_ERROR.

# Testing

`./configure --enable-opensslextra CFLAGS="-DWOLFSSL_VERBOSE_ERRORS"`

User can loop through `wolfSSL_ERR_get_error_line_data` to show errors captured:

```
static void ShowErrorQueue(void)
{
    unsigned long err;
    const char* file;
    int line = 0;

    while ((err = wolfSSL_ERR_get_error_line_data(&file, &line,
                                                  NULL, NULL)) != 0) {
        if (file != NULL) {
            fprintf(stderr, "Error %s:%d: %s (%ld)\n", file, line,
                    wolfSSL_ERR_error_string(err, NULL), -err);
        }
        else {
            fprintf(stderr, "Error: %s (%ld)\n",
                    wolfSSL_ERR_error_string(err, NULL), -err);
        }
    }
}
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
