### PR TITLE
Add wolfSSL_PEM_read_RSAPrivateKey to OpenSSL compatible API

### DIFF
--- a/src/pk.c
+++ b/src/pk.c
@@ -1779,6 +1779,47 @@ WOLFSSL_RSA* wolfSSL_PEM_read_bio_RSAPrivateKey(WOLFSSL_BIO* bio,
     return rsa;
 }
 
+/* Create an RSA private key by reading the PEM encoded data from the file
+ * pointer.
+ *
+ * @param [in]  fp    BIO object to read from.
+ * @param [out] out   RSA key created.
+ * @param [in]  cb    Password callback when PEM encrypted.
+ * @param [in]  pass  NUL terminated string for passphrase when PEM encrypted.
+ * @return  RSA key on success.
+ * @return  NULL on failure.
+ */
+#ifndef NO_FILESYSTEM
+WOLFSSL_RSA* wolfSSL_PEM_read_RSAPrivateKey(XFILE fp, WOLFSSL_RSA** out,
+    wc_pem_password_cb* cb, void* pass)
+{
+    WOLFSSL_EVP_PKEY* pkey;
+    WOLFSSL_RSA* rsa = NULL;
+
+    WOLFSSL_ENTER("PEM_read_RSAPrivateKey");
+
+    /* Read PEM encoded RSA private key from a file pointer. using generic EVP
+     * function.
+     */
+    pkey = wolfSSL_PEM_read_PrivateKey(fp, NULL, cb, pass);
+    if (pkey != NULL) {
+        /* Since the WOLFSSL_RSA structure is being taken from WOLFSSL_EVP_PKEY
+         * the flag indicating that the WOLFSSL_RSA structure is owned should be
+         * FALSE to avoid having it free'd. */
+        pkey->ownRsa = 0;
+        rsa = pkey->rsa;
+        if (out != NULL) {
+            /* Return WOLFSSL_RSA object through parameter too. */
+            *out = rsa;
+        }
+    }
+
+    /* Dispose of EVP_PKEY wrapper. */
+    wolfSSL_EVP_PKEY_free(pkey);
+    return rsa;
+}
+#endif /* !NO_FILESYSTEM */
+
 #endif /* NO_BIO */
 
 #if !defined(NO_FILESYSTEM)

--- a/src/pk.c
+++ b/src/pk.c
@@ -1782,7 +1782,7 @@ WOLFSSL_RSA* wolfSSL_PEM_read_bio_RSAPrivateKey(WOLFSSL_BIO* bio,
 /* Create an RSA private key by reading the PEM encoded data from the file
  * pointer.
  *
- * @param [in]  fp    BIO object to read from.
+ * @param [in]  fp    File pointer to read from.
  * @param [out] out   RSA key created.
  * @param [in]  cb    Password callback when PEM encrypted.
  * @param [in]  pass  NUL terminated string for passphrase when PEM encrypted.

--- a/tests/api.c
+++ b/tests/api.c
@@ -32284,6 +32284,7 @@ static int test_wolfSSL_PEM_RSAPrivateKey(void)
     RSA* rsa = NULL;
     RSA* rsa_dup = NULL;
     BIO* bio = NULL;
+    XFILE f = NULL;
 
     printf(testingFmt, "wolfSSL_PEM_RSAPrivateKey()");
 
@@ -32308,6 +32309,12 @@ static int test_wolfSSL_PEM_RSAPrivateKey(void)
     BIO_free(bio);
     RSA_free(rsa);
     RSA_free(rsa_dup);
+
+    f = XFOPEN(svrKeyFile, "r");
+    AssertTrue((f != XBADFILE));
+    AssertNotNull((rsa = PEM_read_RSAPrivateKey(f, NULL, NULL, NULL)));
+    AssertIntEQ(RSA_size(rsa), 256);
+    RSA_free(rsa);
 
 #ifdef HAVE_ECC
     AssertNotNull(bio = BIO_new_file(eccKeyFile, "rb"));

--- a/tests/api.c
+++ b/tests/api.c
@@ -32315,6 +32315,7 @@ static int test_wolfSSL_PEM_RSAPrivateKey(void)
     AssertNotNull((rsa = PEM_read_RSAPrivateKey(f, NULL, NULL, NULL)));
     AssertIntEQ(RSA_size(rsa), 256);
     RSA_free(rsa);
+    XFCLOSE(f);
 
 #ifdef HAVE_ECC
     AssertNotNull(bio = BIO_new_file(eccKeyFile, "rb"));

--- a/wolfssl/openssl/pem.h
+++ b/wolfssl/openssl/pem.h
@@ -50,10 +50,6 @@ WOLFSSL_RSA* wolfSSL_PEM_read_bio_RSAPrivateKey(WOLFSSL_BIO* bio,
         WOLFSSL_RSA** rsa, wc_pem_password_cb* cb, void* pass);
 
 WOLFSSL_API
-WOLFSSL_RSA* wolfSSL_PEM_read_RSAPrivateKey(XFILE fp,
-        WOLFSSL_RSA** rsa, wc_pem_password_cb* cb, void* pass);
-
-WOLFSSL_API
 int wolfSSL_PEM_write_bio_RSA_PUBKEY(WOLFSSL_BIO* bio, WOLFSSL_RSA* rsa);
 
 WOLFSSL_API
@@ -77,6 +73,11 @@ int wolfSSL_PEM_write_RSAPrivateKey(XFILE fp, WOLFSSL_RSA *rsa,
                                     const WOLFSSL_EVP_CIPHER *enc,
                                     unsigned char *kstr, int klen,
                                     wc_pem_password_cb *cb, void *u);
+
+WOLFSSL_API
+WOLFSSL_RSA* wolfSSL_PEM_read_RSAPrivateKey(XFILE fp, WOLFSSL_RSA** rsa,
+                                            wc_pem_password_cb* cb, void* pass);
+
 WOLFSSL_API
 WOLFSSL_RSA *wolfSSL_PEM_read_RSAPublicKey(XFILE fp, WOLFSSL_RSA **x,
                                            wc_pem_password_cb *cb, void *u);

--- a/wolfssl/openssl/pem.h
+++ b/wolfssl/openssl/pem.h
@@ -50,6 +50,10 @@ WOLFSSL_RSA* wolfSSL_PEM_read_bio_RSAPrivateKey(WOLFSSL_BIO* bio,
         WOLFSSL_RSA** rsa, wc_pem_password_cb* cb, void* pass);
 
 WOLFSSL_API
+WOLFSSL_RSA* wolfSSL_PEM_read_RSAPrivateKey(XFILE fp,
+        WOLFSSL_RSA** rsa, wc_pem_password_cb* cb, void* pass);
+
+WOLFSSL_API
 int wolfSSL_PEM_write_bio_RSA_PUBKEY(WOLFSSL_BIO* bio, WOLFSSL_RSA* rsa);
 
 WOLFSSL_API
@@ -226,6 +230,7 @@ int wolfSSL_PEM_write_DHparams(XFILE fp, WOLFSSL_DH* dh);
 /* RSA */
 #define PEM_write_bio_RSAPrivateKey     wolfSSL_PEM_write_bio_RSAPrivateKey
 #define PEM_read_bio_RSAPrivateKey      wolfSSL_PEM_read_bio_RSAPrivateKey
+#define PEM_read_RSAPrivateKey          wolfSSL_PEM_read_RSAPrivateKey
 #define PEM_write_bio_RSA_PUBKEY        wolfSSL_PEM_write_bio_RSA_PUBKEY
 #define PEM_read_bio_RSA_PUBKEY         wolfSSL_PEM_read_bio_RSA_PUBKEY
 #define PEM_read_bio_RSAPublicKey       wolfSSL_PEM_read_bio_RSA_PUBKEY


### PR DESCRIPTION
# Description

This PR adds wolfSSL_PEM_read_RSAPrivateKey() to the OpenSSL compatible API,
and adds the unit-test code to tests/api.c .

wolfSSL_PEM_read_RSAPrivateKey() was added from line 1782 to line 1822.
\#ifdef is on line 1346.
\#endif is on line 2062.

# Testing

Built example app using wolfSSL_PEM_read_RSAPrivateKey() and ran it.
Checked if wolfSSL_PEM_read_RSAPrivateKey() returns RSA structure 
and if RSA_print_fp() can print the RSA structure.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
