### PR TITLE
20220803-gcc-12-ASAN

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -22927,6 +22927,15 @@ const char* GetCipherSegment(const WOLFSSL_CIPHER* cipher, char n[][MAX_SEGMENT_
     return name;
 }
 
+/* gcc-12 and later, building with ASAN at -O2 and higher, generate spurious
+ * stringop-overread warnings on some (but not all...) reads of n[1] in
+ * GetCipherKeaStr().
+ */
+#if defined(__GNUC__) && __GNUC__ > 11 && defined(__SANITIZE_ADDRESS__)
+PRAGMA_GCC_DIAG_PUSH
+PRAGMA_GCC("GCC diagnostic ignored \"-Wstringop-overread\"")
+#endif
+
 const char* GetCipherKeaStr(char n[][MAX_SEGMENT_SZ]) {
     const char* keaStr = NULL;
 
@@ -22957,6 +22966,9 @@ const char* GetCipherKeaStr(char n[][MAX_SEGMENT_SZ]) {
     return keaStr;
 }
 
+#if defined(__GNUC__) && __GNUC__ > 11 && defined(__SANITIZE_ADDRESS__)
+PRAGMA_GCC_DIAG_POP
+#endif
 
 const char* GetCipherAuthStr(char n[][MAX_SEGMENT_SZ]) {
 

--- a/wolfssl/wolfcrypt/blake2-int.h
+++ b/wolfssl/wolfcrypt/blake2-int.h
@@ -77,7 +77,7 @@
     byte  personal[BLAKE2S_PERSONALBYTES];  /* 32 */
   } blake2s_param;
 
-  typedef struct ALIGN32 __blake2s_state
+  typedef struct __blake2s_state
   {
     word32 h[8];
     word32 t[2];
@@ -102,7 +102,7 @@
     byte  personal[BLAKE2B_PERSONALBYTES];  /* 64 */
   } blake2b_param;
 
-  typedef struct ALIGN64 __blake2b_state
+  typedef struct __blake2b_state
   {
     word64 h[8];
     word64 t[2];


### PR DESCRIPTION
adjustments/workarounds for gcc-12 `-O2 -fsanitize=address`.

tested with
```GCC=gcc-12.1.1 GCXX=g++-12.1.1 ../testing/git-hooks/wolfssl-multi-test.sh ... super-quick-check```
and
```GCC=gcc-13.0.1 GCXX=g++-13.0.1 ../testing/git-hooks/wolfssl-multi-test.sh ... super-quick-check```

(`super-quick-check` includes `all-gcc-c99`, `all-g++`, and `sp-asn-template-asm-smallstack-sanitizer`)
