### PR TITLE
20220804 fixes

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -26227,8 +26227,10 @@ static int SetReqAttribSingle(byte* output, int* idx, char* attr, int attrSz,
         if (strSz > 0) {
             XMEMCPY(&output[*idx], str, strSz);
             *idx += strSz;
-            XMEMCPY(&output[*idx], attr, attrSz);
-            *idx += attrSz;
+            if (attrSz > 0) {
+                XMEMCPY(&output[*idx], attr, attrSz);
+                *idx += attrSz;
+            }
         }
     }
     return totalSz;


### PR DESCRIPTION
fixes for defects identified by wolfssl-multi-test nightly run.

tested with `../testing/git-hooks/wolfssl-multi-test.sh ... super-quick-check all-crypto-linuxkm-defaults-max-func-stack-2k-build clang-tidy-all-sp-all clang-tidy-all-async clang-tidy-fips-140-3-all clang-tidy-fips-140-3-dev-all`
