### PR TITLE
Added support for P384 pre-share in server

### DIFF
--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -1689,7 +1689,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
     /* Not Used: h, z, W, X */
     while ((ch = mygetopt_long(argc, argv, "?:"
                 "abc:defgijk:l:mop:q:rstu;v:wxy"
-                "A:B:C:D:EFGH:IJKL:MNO:PQR:S:T;UVYZ:"
+                "A:B:C:D:E:FGH:IJKL:MNO:PQR:S:T;UVYZ:"
                 "01:23:4:567:89"
                 "@#", long_options, 0)) != -1) {
         switch (ch) {

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -45,6 +45,35 @@
 static const char *wolfsentry_config_path = NULL;
 #endif
 #endif /* WOLFSSL_WOLFSENTRY_HOOKS */
+#if defined(WOLFSSL_MDK_ARM) || defined(WOLFSSL_KEIL_TCP_NET)
+        #include <stdio.h>
+        #include <string.h>
+        #include "rl_fs.h"
+        #include "rl_net.h"
+#endif
+
+#ifdef NO_FILESYSTEM
+    #ifdef NO_RSA
+    #error currently the example only tries to load in a RSA buffer
+    #endif
+    #undef USE_CERT_BUFFERS_2048
+    #define USE_CERT_BUFFERS_2048
+    #include <wolfssl/certs_test.h>
+#endif
+
+#include <wolfssl/test.h>
+#include <wolfssl/error-ssl.h>
+
+/* Force enable the compatibility macros for this example */
+#ifndef OPENSSL_EXTRA_X509_SMALL
+#define OPENSSL_EXTRA_X509_SMALL
+#endif
+#include <wolfssl/openssl/ssl.h>
+
+#include "examples/server/server.h"
+
+#ifndef NO_WOLFSSL_SERVER
+
 #if defined(WOLFSSL_TLS13) && ( \
        defined(HAVE_ECC) \
     || defined(HAVE_CURVE25519) \
@@ -75,34 +104,6 @@ static struct group_info group_id_to_text[] = {
     { 0, NULL }
 };
 #endif /* CAN_FORCE_CURVE && HAVE_ECC */
-#if defined(WOLFSSL_MDK_ARM) || defined(WOLFSSL_KEIL_TCP_NET)
-        #include <stdio.h>
-        #include <string.h>
-        #include "rl_fs.h"
-        #include "rl_net.h"
-#endif
-
-#ifdef NO_FILESYSTEM
-    #ifdef NO_RSA
-    #error currently the example only tries to load in a RSA buffer
-    #endif
-    #undef USE_CERT_BUFFERS_2048
-    #define USE_CERT_BUFFERS_2048
-    #include <wolfssl/certs_test.h>
-#endif
-
-#include <wolfssl/test.h>
-#include <wolfssl/error-ssl.h>
-
-/* Force enable the compatibility macros for this example */
-#ifndef OPENSSL_EXTRA_X509_SMALL
-#define OPENSSL_EXTRA_X509_SMALL
-#endif
-#include <wolfssl/openssl/ssl.h>
-
-#include "examples/server/server.h"
-
-#ifndef NO_WOLFSSL_SERVER
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     static int devId = INVALID_DEVID;

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -52,8 +52,7 @@ static const char *wolfsentry_config_path = NULL;
     || defined(HAVE_FFDHE_2048))
     #define CAN_FORCE_CURVE
 #endif
-#ifdef CAN_FORCE_CURVE
-/* Not sure of group/curve relationship, and no group decoder so here's one */
+#if defined(CAN_FORCE_CURVE) && defined(HAVE_ECC)
 struct group_info {
     word16 group;
     const char *name;
@@ -75,7 +74,7 @@ static struct group_info group_id_to_text[] = {
     { WOLFSSL_ECC_BRAINPOOLP512R1, "BRAINPOOLP512R1" },
     { 0, NULL }
 };
-#endif
+#endif /* CAN_FORCE_CURVE && HAVE_ECC */
 #if defined(WOLFSSL_MDK_ARM) || defined(WOLFSSL_KEIL_TCP_NET)
         #include <stdio.h>
         #include <string.h>
@@ -2224,8 +2223,10 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
 #ifdef CAN_FORCE_CURVE
             case 262: {
                 /* Note: this requires TSL1.3 (version >= 4) */
+                #ifdef HAVE_ECC
                 int idx = 0; /* ecc curve index */
                 int j = 0; /* our group index */
+                #endif
                 if (NULL == myoptarg) {
                     Usage();
                     if (lng_index == 1) {

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -1689,7 +1689,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
     /* Not Used: h, z, W, X */
     while ((ch = mygetopt_long(argc, argv, "?:"
                 "abc:defgijk:l:mop:q:rstu;v:wxy"
-                "A:B:C:D:E:FGH:IJKL:MNO:PQR:S:T;UVYZ:"
+                "A:B:C:D:EFGH:IJKL:MNO:PQR:S:T;UVYZ:"
                 "01:23:4:567:89"
                 "@#", long_options, 0)) != -1) {
         switch (ch) {

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -59,7 +59,7 @@ struct group_info {
     word16 group;
     const char *name;
 };
-static struct group_info groups[] = {
+static struct group_info group_id_to_text[] = {
     { WOLFSSL_ECC_SECP160K1, "SECP160K1" },
     { WOLFSSL_ECC_SECP160R1, "SECP160R1" },
     { WOLFSSL_ECC_SECP160R2, "SECP160R2" },
@@ -2233,8 +2233,9 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                     #ifdef HAVE_ECC
                     // Compare groups with compiled curves...
                     for (int i=0; ecc_sets[i].id != ECC_CURVE_INVALID; ++i) {
-                        for (int j=0; groups[j].group != 0; ++j) {
-                            if (strcmp(groups[j].name, ecc_sets[i].name) == 0) {
+                        for (int j=0; group_id_to_text[j].group != 0; ++j) {
+                            if (strcmp(group_id_to_text[j].name, 
+                                    ecc_sets[i].name) == 0) {
                                 printf("\t%s\n", ecc_sets[i].name);
                             }
                         }
@@ -2258,9 +2259,9 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                 */
                 #ifdef HAVE_ECC
                 // This is actually an index into the table, not the ID
-                for (int j=0; groups[j].group != 0; ++j) {
-                    if (strcmp(groups[j].name, myoptarg) == 0) {
-                        force_curve_group_id = groups[j].group;
+                for (int j=0; group_id_to_text[j].group != 0; ++j) {
+                    if (strcmp(group_id_to_text[j].name, myoptarg) == 0) {
+                        force_curve_group_id = group_id_to_text[j].group;
                     }
                 }
                 #endif
@@ -3091,13 +3092,11 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                     }
                     #endif
                     else {
-                        printf("%d\n", ret);
                         err_sys("Failed wolfSSL_UseKeyShare in force-curve");
                     }
                 } while (ret == WC_PENDING_E);
                 ret = wolfSSL_set_groups(ssl, &force_curve_group_id, 1);
                 if (WOLFSSL_SUCCESS != ret) {
-                    printf("%d 0x%x -0x%x\n", ret, ret, -ret);
                     err_sys("Failed wolfSSL_set_groups in force-curve");
                 }
             }

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -3087,7 +3087,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
             #ifdef CAN_FORCE_CURVE
             if (force_curve_group_id > 0) {
                 do {
-                    ret = wolfSSL_UseKeyShare(ssl, WOLFSSL_ECC_SECP384R1);
+                    ret = wolfSSL_UseKeyShare(ssl, force_curve_group_id);
                     if (ret == WOLFSSL_SUCCESS) {
 
                     }


### PR DESCRIPTION
# Description

EEMBC has been doing testing with various SSL server implementations for P256, P384 and 25519. We added this switch, and thought it would be easier for our users if it was in the wolf repo instead of us having to supply a diff patch.

# Testing

I simply ran:

```bash
% cd examples/server
% ./server -v 4 -E &
% cd ../client
% ./client -v 4
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation

Since this is an example, there were no tests (AFAIK), doxygen, or READMEs. However, I did update the help screen (took a guess at the Japanese.)

