### PR TITLE
Fix TSIP ret value in TLSX_KeyShare_ProcessEcc

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -7869,6 +7869,7 @@ static int TLSX_KeyShare_ProcessEcc(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
         if (ret != CRYPTOCB_UNAVAILABLE) {
             return ret;
         }
+        ret = 0;
 #endif
 
         ssl->peerEccKey = (ecc_key*)XMALLOC(sizeof(ecc_key), ssl->heap,


### PR DESCRIPTION
# Description

Return value must be set to 0 after calling `tsip_Tls13GenSharedSecret`

Fixes zd14428

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
