### PR TITLE
QUIC session resumption and early data handshake handling.

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -8063,6 +8063,13 @@ int DoTls13Finished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         ssl->earlyData = done_early_data;
     }
 #endif /* WOLFSSL_DTLS13 && WOLFSSL_EARLY_DATA */
+#if defined(WOLFSSL_QUIC) && defined(WOLFSSL_EARLY_DATA)
+    if (WOLFSSL_IS_QUIC(ssl) && ssl->earlyData > early_data_ext) {
+        /* QUIC has no EndOfearlydata messages. We stop processing EarlyData
+           as soon we receive the client's finished message */
+        ssl->earlyData = done_early_data;
+    }
+#endif /* WOLFSSL_QUIC && WOLFSSL_EARLY_DATA */
 
     WOLFSSL_LEAVE("DoTls13Finished", 0);
     WOLFSSL_END(WC_FUNC_FINISHED_DO);

--- a/wolfssl/quic.h
+++ b/wolfssl/quic.h
@@ -189,6 +189,9 @@ WOLFSSL_API
 int wolfSSL_provide_quic_data(WOLFSSL* ssl, WOLFSSL_ENCRYPTION_LEVEL level,
                               const uint8_t* data, size_t len);
 
+WOLFSSL_API
+int wolfSSL_quic_do_handshake(WOLFSSL* ssl);
+
 /**
  * Process any CRYPTO data added post-handshake.
  */


### PR DESCRIPTION
# Description

In test with ngtcp2 example client using openssl, session resumption
against a QUIC wolfssl server failed. The error was tracked down to
wolfSSL believing EaryData needs to be handled and returning SUCCESS
from wolfSSL_SSL_do_handshake() after the server Finished had been
sent.

However the handshake was not complete and ngtcp2 invoked the
post_handshake processing for new data arriving from the client.
This failed a check in post processing that the ssl->handShakeState
actually was HANDSHAKE_DONE.

The workaround in this PR repeats do_handshake until the ssl
state acually says it is complete. This way, session resumption works.

Either this alternative do_handshake() is merged for QUIC protocol
hanlders. Or we need to fix the 'normal' do_handshake() to no return
SUCCESS when early data is expected on a QUIC WOLFSSL.

# Testing

Using ngtcp2 example client/server mix with OpenSSL and wolfSSL crypto libraries.
