### PR TITLE
Fix for handling `WC_PENDING_E` from decrypt session ticket callback

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -616,9 +616,6 @@ static int ClientBenchmarkConnections(WOLFSSL_CTX* ctx, char* host, word16 port,
             do {
                 err = 0; /* reset error */
                 ret = wolfSSL_connect(ssl);
-#ifdef WOLFSSL_EARLY_DATA
-                EarlyDataStatus(ssl);
-#endif
                 if (ret != WOLFSSL_SUCCESS) {
                     err = wolfSSL_get_error(ssl, 0);
                 #ifdef WOLFSSL_ASYNC_CRYPT
@@ -630,6 +627,9 @@ static int ClientBenchmarkConnections(WOLFSSL_CTX* ctx, char* host, word16 port,
                 #endif
                 }
             } while (err == WC_PENDING_E);
+        #ifdef WOLFSSL_EARLY_DATA
+            EarlyDataStatus(ssl);
+        #endif
             if (ret != WOLFSSL_SUCCESS) {
                 err_sys("SSL_connect failed");
             }

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -3156,9 +3156,6 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
             do {
                 err = 0; /* reset error */
                 ret = SSL_accept(ssl);
-#ifdef WOLFSSL_EARLY_DATA
-                EarlyDataStatus(ssl);
-#endif
                 if (ret != WOLFSSL_SUCCESS) {
                     err = SSL_get_error(ssl, 0);
                 #ifdef WOLFSSL_ASYNC_CRYPT
@@ -3172,6 +3169,9 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
         }
 #else
         ret = NonBlockingSSL_Accept(ssl);
+#endif
+#ifdef WOLFSSL_EARLY_DATA
+        EarlyDataStatus(ssl);
 #endif
         if (ret != WOLFSSL_SUCCESS) {
             err = SSL_get_error(ssl, 0);


### PR DESCRIPTION
# Description

* Fix for handling `WC_PENDING_E` from decrypt session ticket callback.
* Fix location of test.h call for `EarlyDataStatus` in examples. Needs to be outside the async block.
Fixes ZD 14420



# Testing

```
./configure --enable-all --enable-asynccrypt CFLAGS="-DWOLFSSL_NO_DEF_TICKET_ENC_CB" && make
./examples/server/server -v 4 -r &
./examples/client/client -v 4 -r
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
