### PR TITLE
wolfSSL_CTX_set1_curves_list: X25519 and X448 defines

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -33498,7 +33498,8 @@ void wolfSSL_get0_next_proto_negotiated(const WOLFSSL *s, const unsigned char **
 
 #endif /* WOLFSSL_NGINX  / WOLFSSL_HAPROXY */
 
-#if defined(OPENSSL_EXTRA) && defined(HAVE_ECC)
+#if defined(OPENSSL_EXTRA) && (defined(HAVE_ECC) || \
+    defined(HAVE_CURVE25519) || defined(HAVE_CURVE448))
 int wolfSSL_CTX_set1_curves_list(WOLFSSL_CTX* ctx, const char* names)
 {
     int idx, start = 0, len;
@@ -33539,14 +33540,18 @@ int wolfSSL_CTX_set1_curves_list(WOLFSSL_CTX* ctx, const char* names)
         {
             curve = WOLFSSL_ECC_SECP521R1;
         }
+    #ifdef HAVE_CURVE25519
         else if (XSTRCMP(name, "X25519") == 0)
         {
             curve = WOLFSSL_ECC_X25519;
         }
+    #endif
+    #ifdef HAVE_CURVE448
         else if (XSTRCMP(name, "X448") == 0)
         {
             curve = WOLFSSL_ECC_X448;
         }
+    #endif
         else {
         #if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
             int   ret;
@@ -33602,7 +33607,7 @@ int wolfSSL_set1_curves_list(WOLFSSL* ssl, const char* names)
     }
     return wolfSSL_CTX_set1_curves_list(ssl->ctx, names);
 }
-#endif /* OPENSSL_EXTRA && HAVE_ECC */
+#endif /* OPENSSL_EXTRA && (HAVE_ECC || HAVE_CURVE25519 || HAVE_CURVE448) */
 
 #ifdef OPENSSL_EXTRA
 /* Sets a callback for when sending and receiving protocol messages.

--- a/tests/api.c
+++ b/tests/api.c
@@ -36154,7 +36154,7 @@ static int test_wolfSSL_sk_SSL_CIPHER(void)
 
 static int test_wolfSSL_set1_curves_list(void)
 {
-#if defined(OPENSSL_EXTRA) && defined(HAVE_RSA)
+#if defined(OPENSSL_EXTRA) && defined(HAVE_ECC)
 #if !defined(NO_WOLFSSL_CLIENT) || !defined(NO_WOLFSSL_SERVER)
     SSL*     ssl = NULL;
     SSL_CTX* ctx = NULL;
@@ -36164,18 +36164,43 @@ static int test_wolfSSL_set1_curves_list(void)
 #else
     AssertNotNull(ctx = SSL_CTX_new(wolfSSLv23_client_method()));
 #endif
-    AssertTrue(SSL_CTX_use_certificate_file(ctx, svrCertFile,
+    AssertTrue(SSL_CTX_use_certificate_file(ctx, eccCertFile,
                SSL_FILETYPE_PEM));
-    AssertTrue(SSL_CTX_use_PrivateKey_file(ctx, svrKeyFile, SSL_FILETYPE_PEM));
+    AssertTrue(SSL_CTX_use_PrivateKey_file(ctx, eccKeyFile, SSL_FILETYPE_PEM));
     AssertNotNull(ssl = SSL_new(ctx));
 
     AssertIntEQ(SSL_CTX_set1_curves_list(ctx, NULL), WOLFSSL_FAILURE);
+#ifdef HAVE_ECC
     AssertIntEQ(SSL_CTX_set1_curves_list(ctx, "P-25X"), WOLFSSL_FAILURE);
     AssertIntEQ(SSL_CTX_set1_curves_list(ctx, "P-256"), WOLFSSL_SUCCESS);
+#endif
+#ifdef HAVE_CURVE25519
+    AssertIntEQ(SSL_CTX_set1_curves_list(ctx, "X25519"), WOLFSSL_SUCCESS);
+#else
+    AssertIntEQ(SSL_CTX_set1_curves_list(ctx, "X25519"), WOLFSSL_FAILURE);
+#endif
+#ifdef HAVE_CURVE448
+    AssertIntEQ(SSL_CTX_set1_curves_list(ctx, "X448"), WOLFSSL_SUCCESS);
+#else
+    AssertIntEQ(SSL_CTX_set1_curves_list(ctx, "X448"), WOLFSSL_FAILURE);
+#endif
 
     AssertIntEQ(SSL_set1_curves_list(ssl, NULL), WOLFSSL_FAILURE);
+#ifdef HAVE_ECC
     AssertIntEQ(SSL_set1_curves_list(ssl, "P-25X"), WOLFSSL_FAILURE);
     AssertIntEQ(SSL_set1_curves_list(ssl, "P-256"), WOLFSSL_SUCCESS);
+#endif
+
+#ifdef HAVE_CURVE25519
+    AssertIntEQ(SSL_set1_curves_list(ssl, "X25519"), WOLFSSL_SUCCESS);
+#else
+    AssertIntEQ(SSL_set1_curves_list(ssl, "X25519"), WOLFSSL_FAILURE);
+#endif
+#ifdef HAVE_CURVE448
+    AssertIntEQ(SSL_set1_curves_list(ssl, "X448"), WOLFSSL_SUCCESS);
+#else
+    AssertIntEQ(SSL_set1_curves_list(ssl, "X448"), WOLFSSL_FAILURE);
+#endif
 
     SSL_free(ssl);
     SSL_CTX_free(ctx);


### PR DESCRIPTION
# Description

Support wolfSSL_CTX_set1_curves_list being available when X25519 and/or
X448 only defined.
Don't recognize X25519 or X448 if corresponding define is not set.
Enable test in api.c.

# Testing

With and without --enable-curve25519.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
