### PR TITLE
Fix a very frequent stuck scenario with the openssl.test script

### DIFF
--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -383,7 +383,18 @@ fi
 
 # need a unique port since may run the same time as testsuite
 generate_port() {
-    port=$(($(od -An -N2 /dev/random) % (65535-49512) + 49512))
+    #-------------------------------------------------------------------------#
+    # Generate a random port number
+    #-------------------------------------------------------------------------#
+
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        port=$(($(od -An -N2 /dev/urandom) % (65535-49512) + 49512))
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        port=$(($(od -An -N2 /dev/random) % (65535-49512) + 49512))
+    else
+        echo "Unknown OS TYPE"
+        exit 1
+    fi
 }
 
 # Start OpenSSL server that has no OCSP responses to return

--- a/scripts/ocsp-stapling2.test
+++ b/scripts/ocsp-stapling2.test
@@ -448,7 +448,18 @@ printf '%s\n\n' "Test successfully REVOKED!"
 
 # need a unique port since may run the same time as testsuite
 generate_port() {
-    port=$(($(od -An -N2 /dev/random) % (65535-49512) + 49512))
+    #-------------------------------------------------------------------------#
+    # Generate a random port number
+    #-------------------------------------------------------------------------#
+
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        port=$(($(od -An -N2 /dev/urandom) % (65535-49512) + 49512))
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        port=$(($(od -An -N2 /dev/random) % (65535-49512) + 49512))
+    else
+        echo "Unknown OS TYPE"
+        exit 1
+    fi
 }
 
 # Start OpenSSL server that has no OCSP responses to return

--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -32,9 +32,19 @@ echo "WOLFSSL_OPENSSL_TEST set, running test..."
 
 # need a unique port since may run the same time as testsuite
 generate_port() {
-    port=$(($(od -An -N2 /dev/random) % (65535-49512) + 49512))
-}
+    #-------------------------------------------------------------------------#
+    # Generate a random port number
+    #-------------------------------------------------------------------------#
 
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        port=$(($(od -An -N2 /dev/urandom) % (65535-49512) + 49512))
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        port=$(($(od -An -N2 /dev/random) % (65535-49512) + 49512))
+    else
+        echo "Unknown OS TYPE"
+        exit 1
+    fi
+}
 
 no_pid=-1
 servers=""

--- a/scripts/openssl_srtp.test
+++ b/scripts/openssl_srtp.test
@@ -15,7 +15,18 @@ WOLFSSL_CLIENT=${WOLFSSL_CLIENT:="./examples/client/client"}
 
 # need a unique port since may run the same time as testsuite
 generate_port() {
-    port=$(($(od -An -N2 /dev/random) % (65535-49512) + 49512))
+    #-------------------------------------------------------------------------#
+    # Generate a random port number
+    #-------------------------------------------------------------------------#
+
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        port=$(($(od -An -N2 /dev/urandom) % (65535-49512) + 49512))
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        port=$(($(od -An -N2 /dev/random) % (65535-49512) + 49512))
+    else
+        echo "Unknown OS TYPE"
+        exit 1
+    fi
 }
 
 # get size of key material based on the profile


### PR DESCRIPTION
# Description

Testing the solution to get a port number on fuzzer node gets stuck insanely often, crazy. simply switching to /dev/urandom fixes the issue.

Doing a bit more research on this: /dev/random is a blocking call on many systems where /dev/urandom is not. This can easily explain why using /dev/random on linux based systems (Jenkins slave nodes) often time out or take too long. I ran a report and attached it to the slack discussion on this topic, you can see in just 34 calls how it blocks a total of 10 times for 40+ seconds. In a jenkins test where we have 50 configure options and we double check each option with opensslextra setting we are running a total of 100 configures per test. At his rate if it blocks 10 times per 30 calls for 40 seconds each we're looking at a total of 22 minutes (+the regular time for config and make check) added onto a test just due to using /dev/random to get a random port number.

I would also note this would not typically be overly observable in a single run of `make check` (IE what customers are doing) but for the sake of our CI testing this has significant impact.