### PR TITLE
Translate the verify callback error to an X509_V_ERR_* value when OPENSSL_COMPATIBLE_DEFAULTS is defined

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -11992,7 +11992,11 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
             }
         }
 
+#ifndef OPENSSL_COMPATIBLE_DEFAULTS
         store->error = ret;
+#else
+        store->error = GetX509Error(ret);
+#endif
         store->error_depth = args->certIdx;
         store->discardSessionCerts = 0;
         store->domain = domain;

--- a/src/x509_str.c
+++ b/src/x509_str.c
@@ -181,7 +181,11 @@ static int GetX509Error(int e)
         case ASN_SIG_KEY_E:
             return X509_V_ERR_CERT_SIGNATURE_FAILURE;
         default:
+#ifdef HAVE_WOLFSSL_MSG_EX
+            WOLFSSL_MSG_EX("Error not configured or implemented yet: %d", e);
+#else
             WOLFSSL_MSG("Error not configured or implemented yet");
+#endif
             return e;
     }
 }

--- a/src/x509_str.c
+++ b/src/x509_str.c
@@ -161,7 +161,7 @@ void wolfSSL_X509_STORE_CTX_trusted_stack(WOLFSSL_X509_STORE_CTX *ctx, WOLF_STAC
 
 
 /* Returns corresponding X509 error from internal ASN error <e> */
-static int GetX509Error(int e)
+int GetX509Error(int e)
 {
     switch (e) {
         case ASN_BEFORE_DATE_E:

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -5605,6 +5605,9 @@ WOLFSSL_LOCAL int wolfSSL_StaticEphemeralKeyLoad(WOLFSSL* ssl, int keyAlgo, void
 WOLFSSL_LOCAL int wolfSSL_ASN1_STRING_canon(WOLFSSL_ASN1_STRING* asn_out,
     const WOLFSSL_ASN1_STRING* asn_in);
 #endif
+#ifdef OPENSSL_EXTRA
+WOLFSSL_LOCAL int GetX509Error(int e);
+#endif
 #endif
 
 #if defined(HAVE_EX_DATA) && \

--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -164,6 +164,7 @@ WOLFSSL_API void wolfSSL_Debugging_OFF(void);
     WOLFSSL_API int WOLFSSL_IS_DEBUG_ON(void);
 #if !defined(_WIN32) && defined(XVSNPRINTF)
     WOLFSSL_API void WOLFSSL_MSG_EX(const char* fmt, ...);
+    #define HAVE_WOLFSSL_MSG_EX
 #else
     #define WOLFSSL_MSG_EX(m, ...)
 #endif


### PR DESCRIPTION
Improve logging around what error is unrecognized in GetX509Error()

Fixes ZD14652