### PR TITLE
20220812-fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,8 @@ find_package(Threads)
 # Example for map file and custom linker script
 #set(CMAKE_EXE_LINKER_FLAGS " -Xlinker -Map=output.map -T\"${CMAKE_CURRENT_SOURCE_DIR}/linker.ld\"")
 
+set(CMAKE_C_FLAGS "-Wall -Wextra -Wno-unused -Werror ${CMAKE_C_FLAGS}")
+
 ####################################################
 # Build Options
 ####################################################
@@ -874,6 +876,7 @@ else()
 endif()
 if(WOLFSSL_RSA_PSS)
     list(APPEND WOLFSSL_DEFINITIONS "-DWC_RSA_PSS")
+    list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_PSS_LONG_SALT")
 endif()
 
 # DH

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -905,8 +905,6 @@ function(add_to_options_file DEFINITIONS OPTION_FILE)
             endif()
 
             file(APPEND ${OPTION_FILE} "\n")
-        else()
-            message("option w/o begin -D is ${DEF}, not saving to ${OPTION_FILE}")
         endif()
     endforeach()
 endfunction()

--- a/tests/api.c
+++ b/tests/api.c
@@ -2416,7 +2416,7 @@ static int test_wolfSSL_CertRsaPss(void)
     AssertIntEQ(wc_ParseCert(&cert, CERT_TYPE, VERIFY, cm), 0);
     wc_FreeDecodedCert(&cert);
 
-#ifdef WOLFSSL_SHA384
+#if defined(WOLFSSL_SHA384) && defined(WOLFSSL_PSS_LONG_SALT)
     f = XFOPEN(rsaPssSha384Cert, "rb");
     AssertTrue((f != XBADFILE));
     bytes = (int)XFREAD(buf, 1, sizeof(buf), f);

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -14800,7 +14800,7 @@ void FreeSignatureCtx(SignatureCtx* sigCtx)
                 sigCtx->key.ed448 = NULL;
                 break;
         #endif /* HAVE_ED448 */
-        #if defined(HAVE_PQC) 
+        #if defined(HAVE_PQC)
         #if defined(HAVE_FALCON)
             case FALCON_LEVEL1k:
             case FALCON_LEVEL5k:

--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -950,7 +950,7 @@ int wc_Dilithium_PublicKeyToDer(dilithium_key* key, byte* output, word32 inLen,
 
     return ret;
 }
-#endif 
+#endif
 
 int wc_Dilithium_KeyToDer(dilithium_key* key, byte* output, word32 inLen)
 {

--- a/zephyr/nrf5340dk_nrf5340_user_settings.h
+++ b/zephyr/nrf5340dk_nrf5340_user_settings.h
@@ -59,11 +59,11 @@ extern "C" {
 
 #define HAVE_ECC
 #define ECC_USER_CURVES
-//#define HAVE_ECC192
-//#define HAVE_ECC224
+/* #define HAVE_ECC192 */
+/* #define HAVE_ECC224 */
 #undef NO_ECC256
-//#define HAVE_ECC384
-//#define HAVE_ECC521
+/* #define HAVE_ECC384 */
+/* #define HAVE_ECC521 */
 #define ECC_SHAMIR
 #define ECC_TIMING_RESISTANT
 


### PR DESCRIPTION
Fix cmake build, and fix whitespace and C++-style comments.

Note this PR also ports the autotools `-Wall -Wextra -Wno-unused -Werror` flags over to CMakeLists.txt.

Tested with `wolfssl-multi-test.sh ... super-quick-check` (to which I've now added `cmake-defaults`).
