### PR TITLE
Fixes to better handle re-use of a WOLFSSL object via wolfSSL_clear

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -1406,9 +1406,7 @@ int TLSX_HandleUnsupportedExtension(WOLFSSL* ssl)
 #endif
 
 /** Mark an extension to be sent back to the client. */
-void TLSX_SetResponse(WOLFSSL* ssl, TLSX_Type type);
-
-void TLSX_SetResponse(WOLFSSL* ssl, TLSX_Type type)
+static void TLSX_SetResponse(WOLFSSL* ssl, TLSX_Type type)
 {
     TLSX *extension = TLSX_Find(ssl->extensions, type);
 
@@ -5991,7 +5989,7 @@ static int TLSX_SupportedVersions_Parse(WOLFSSL* ssl, const byte* input,
 
             /* No upgrade allowed. */
             if (versionIsGreater(isDtls, minor, ssl->version.minor))
-                    continue;
+                continue;
 
             /* Check downgrade. */
             if (versionIsLesser(isDtls, minor, ssl->version.minor)) {
@@ -6011,8 +6009,10 @@ static int TLSX_SupportedVersions_Parse(WOLFSSL* ssl, const byte* input,
             }
 
             if (versionIsAtLeast(isDtls, minor, tls13minor)) {
-                if (!ssl->options.tls1_3) {
-                    ssl->options.tls1_3 = 1;
+                ssl->options.tls1_3 = 1;
+
+                /* TLS v1.3 requires supported version extension */
+                if (TLSX_Find(ssl->extensions, TLSX_SUPPORTED_VERSIONS) == NULL) {
                     ret = TLSX_Prepend(&ssl->extensions,
                               TLSX_SUPPORTED_VERSIONS, ssl, ssl->heap);
                     if (ret != 0) {

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -10134,14 +10134,23 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
 
     WOLFSSL_ENTER("wolfSSL_connect_TLSv13()");
 
-    #ifdef HAVE_ERRNO_H
+#ifdef HAVE_ERRNO_H
     errno = 0;
-    #endif
+#endif
+
+    if (ssl == NULL)
+        return BAD_FUNC_ARG;
 
     if (ssl->options.side != WOLFSSL_CLIENT_END) {
         ssl->error = SIDE_ERROR;
         WOLFSSL_ERROR(ssl->error);
         return WOLFSSL_FATAL_ERROR;
+    }
+
+    /* make sure this wolfSSL object has arrays and rng setup. Protects
+     * case where the WOLFSSL object is re-used via wolfSSL_clear() */
+    if ((ret = ReinitSSL(ssl, ssl->ctx, 0)) != 0) {
+        return ret;
     }
 
 #ifdef WOLFSSL_WOLFSENTRY_HOOKS
@@ -11185,10 +11194,12 @@ int wolfSSL_accept_TLSv13(WOLFSSL* ssl)
 
     WOLFSSL_ENTER("SSL_accept_TLSv13()");
 
-
 #ifdef HAVE_ERRNO_H
     errno = 0;
 #endif
+
+    if (ssl == NULL)
+        return WOLFSSL_FATAL_ERROR;
 
 #if !defined(NO_CERTS) && (defined(HAVE_SESSION_TICKET) || !defined(NO_PSK))
     havePSK = ssl->options.havePSK;
@@ -11198,6 +11209,12 @@ int wolfSSL_accept_TLSv13(WOLFSSL* ssl)
         ssl->error = SIDE_ERROR;
         WOLFSSL_ERROR(ssl->error);
         return WOLFSSL_FATAL_ERROR;
+    }
+
+    /* make sure this wolfSSL object has arrays and rng setup. Protects
+     * case where the WOLFSSL object is re-used via wolfSSL_clear() */
+    if ((ret = ReinitSSL(ssl, ssl->ctx, 0)) != 0) {
+        return ret;
     }
 
 #ifdef WOLFSSL_WOLFSENTRY_HOOKS

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -5062,6 +5062,7 @@ struct WOLFSSL {
 WOLFSSL_LOCAL int  SSL_CTX_RefCount(WOLFSSL_CTX* ctx, int incr);
 WOLFSSL_LOCAL int  SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup);
 WOLFSSL_LOCAL int  InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup);
+WOLFSSL_LOCAL int  ReinitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup);
 WOLFSSL_LOCAL void FreeSSL(WOLFSSL* ssl, void* heap);
 WOLFSSL_API   void SSL_ResourceFree(WOLFSSL* ssl);   /* Micrium uses */
 


### PR DESCRIPTION
# Description

Fixes to better handle re-use of a WOLFSSL object via wolfSSL_clear. The `ssl->arrays` and `ssl->rng` fields (as well as a few options bits) needed to be cleared to enable this use-case.

Fixes ZD14659

# Testing

Patched example server and client to use `wolfSSL_clear`:

```
diff --git a/examples/client/client.c b/examples/client/client.c
index 1d12aa6bf..152988d86 100644
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -4190,12 +4190,20 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     wolfSSL_PrintStatsConn(&ssl_stats);
 #endif

-    wolfSSL_free(ssl); ssl = NULL;
+    if (!resumeSession) {
+        wolfSSL_free(ssl); ssl = NULL;
+    }
     CloseSocket(sockfd);

 #ifndef NO_SESSION_CACHE
     if (resumeSession) {
+    #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)
+        /* test re-use of wolfSSL session via wolfSSL_clear */
+        wolfSSL_clear(ssl);
+        sslResume = ssl;
+    #else
         sslResume = wolfSSL_new(ctx);
+    #endif
         if (sslResume == NULL) {
             wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("unable to get SSL object");
diff --git a/examples/server/server.c b/examples/server/server.c
index 049986b97..b1e4fcf18 100644
--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -2764,7 +2764,9 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
         SetupPkCallbacks(ctx);
 #endif

-    ssl = SSL_new(ctx);
+    if (ssl == NULL) {
+        ssl = SSL_new(ctx);
+    }
     if (ssl == NULL)
         err_sys_ex(catastrophic, "unable to create an SSL object");

@@ -3515,7 +3517,13 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
         wolfSSL_PrintStatsConn(&ssl_stats);

 #endif
+
+    #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)
+        /* test re-use of wolfSSL session via wolfSSL_clear */
+        wolfSSL_clear(ssl);
+    #else
         SSL_free(ssl); ssl = NULL;
+    #endif

         CloseSocket(clientfd);

@@ -3531,6 +3539,8 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
         }
     } /* while(1) */

+    SSL_free(ssl); ssl = NULL;
+
     WOLFSSL_TIME(cnt);
     (void)cnt;
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
