### PR TITLE
Fix memory leak in QUIC transport parameters extension

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -10445,6 +10445,10 @@ int TLSX_QuicTP_Use(WOLFSSL* ssl, TLSX_Type ext_type, int is_response)
             goto cleanup;
         }
     }
+    if (extension->data) {
+        QuicTransportParam_free(extension->data, ssl->heap);
+        extension->data = NULL;
+    }
     extension->resp = is_response;
     extension->data = (void*)QuicTransportParam_dup(ssl->quic.transport_local, ssl->heap);
     if (!extension->data) {


### PR DESCRIPTION
# Description

A memory leak was detected when a ClientHello needed to be retried. This set
the QUIC Transport Parameters extensions again without freeing the previously
used value.

This was reported in https://github.com/ngtcp2/ngtcp2/issues/510

# Testing

Build ngtcp2 with `--enable-asan`, run the example openssl server via

```
./examples/server --groups X25519 localhost 4433  key.pem cert.pem
```

invoke the wolfSSL example client via:

```
ASAN_OPTIONS='detect_leaks=1' ./examples/wsslclient localhost 4433 https://localhost
```

wait for the connection to timeout and the process to exit. Without this PR, a memory leak is reported.

This was tested on a debian unstable machine, but should reproduce wherever the LeakSanitizer is available.
