### PR TITLE
Add/Extend PEM_read compatibility API's

### DIFF
--- a/src/pk.c
+++ b/src/pk.c
@@ -1585,7 +1585,7 @@ WOLFSSL_RSA *wolfSSL_PEM_read_RSA_PUBKEY(XFILE fp,
     WOLFSSL_RSA* rsa = NULL;
 
     WOLFSSL_ENTER("wolfSSL_PEM_read_RSA_PUBKEY");
-    
+
     /* Validate parameters. */
     if (fp == NULL) {
         WOLFSSL_LEAVE("wolfSSL_PEM_read_RSA_PUBKEY", BAD_FUNC_ARG);
@@ -1609,7 +1609,7 @@ WOLFSSL_RSA *wolfSSL_PEM_read_RSA_PUBKEY(XFILE fp,
     else {
         WOLFSSL_MSG("wolfSSL_PEM_read_PUBKEY failed");
     }
-    
+
     WOLFSSL_LEAVE("wolfSSL_PEM_read_RSA_PUBKEY", 0);
 
     return rsa;

--- a/src/pk.c
+++ b/src/pk.c
@@ -1568,6 +1568,42 @@ WOLFSSL_RSA *wolfSSL_PEM_read_bio_RSA_PUBKEY(WOLFSSL_BIO* bio,
     return rsa;
 }
 
+#ifndef NO_FILESYSTEM
+/* Create an RSA public key by reading the PEM encoded data from the BIO.
+ *
+ * @param [in]  fp    File pointer to read from.
+ * @param [out] out   RSA key created.
+ * @param [in]  cb    Password callback when PEM encrypted.
+ * @param [in]  pass  NUL terminated string for passphrase when PEM encrypted.
+ * @return  RSA key on success.
+ * @return  NULL on failure.
+ */
+WOLFSSL_RSA *wolfSSL_PEM_read_RSA_PUBKEY(XFILE fp,
+    WOLFSSL_RSA** out, wc_pem_password_cb* cb, void *pass)
+{
+    WOLFSSL_EVP_PKEY* pkey;
+    WOLFSSL_RSA* rsa = NULL;
+
+    WOLFSSL_ENTER("wolfSSL_PEM_read_RSA_PUBKEY");
+
+    /* Read into a new EVP_PKEY. */
+    pkey = wolfSSL_PEM_read_PUBKEY(fp, NULL, cb, pass);
+    if (pkey != NULL) {
+        /* Since the WOLFSSL_RSA structure is being taken from WOLFSSL_EVP_PKEY
+         * the flag indicating that the WOLFSSL_RSA structure is owned should be
+         * FALSE to avoid having it free'd. */
+        pkey->ownRsa = 0;
+        rsa = pkey->rsa;
+        if (out != NULL) {
+            *out = rsa;
+        }
+
+        wolfSSL_EVP_PKEY_free(pkey);
+    }
+
+    return rsa;
+}
+#endif /* NO_FILESYSTEM */
 #endif /* !NO_BIO */
 
 #if defined(WOLFSSL_KEY_GEN) && !defined(HAVE_USER_RSA) && \

--- a/src/pk.c
+++ b/src/pk.c
@@ -1588,7 +1588,7 @@ WOLFSSL_RSA *wolfSSL_PEM_read_RSA_PUBKEY(XFILE fp,
     
     /* Validate parameters. */
     if (fp == NULL) {
-        WOLFSSL_MSG("Bad function arguments");
+        WOLFSSL_LEAVE("wolfSSL_PEM_read_RSA_PUBKEY", BAD_FUNC_ARG);
         return NULL;
     }
 
@@ -1609,6 +1609,8 @@ WOLFSSL_RSA *wolfSSL_PEM_read_RSA_PUBKEY(XFILE fp,
     else {
         WOLFSSL_MSG("wolfSSL_PEM_read_PUBKEY failed");
     }
+    
+    WOLFSSL_LEAVE("wolfSSL_PEM_read_RSA_PUBKEY", 0);
 
     return rsa;
 }

--- a/src/pk.c
+++ b/src/pk.c
@@ -1585,6 +1585,12 @@ WOLFSSL_RSA *wolfSSL_PEM_read_RSA_PUBKEY(XFILE fp,
     WOLFSSL_RSA* rsa = NULL;
 
     WOLFSSL_ENTER("wolfSSL_PEM_read_RSA_PUBKEY");
+    
+    /* Validate parameters. */
+    if (fp == NULL) {
+        WOLFSSL_MSG("Bad function arguments");
+        return NULL;
+    }
 
     /* Read into a new EVP_PKEY. */
     pkey = wolfSSL_PEM_read_PUBKEY(fp, NULL, cb, pass);
@@ -1599,6 +1605,9 @@ WOLFSSL_RSA *wolfSSL_PEM_read_RSA_PUBKEY(XFILE fp,
         }
 
         wolfSSL_EVP_PKEY_free(pkey);
+    }
+    else {
+        WOLFSSL_MSG("wolfSSL_PEM_read_PUBKEY failed");
     }
 
     return rsa;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -28261,22 +28261,38 @@ WOLFSSL_EVP_PKEY *wolfSSL_PEM_read_bio_PUBKEY(WOLFSSL_BIO* bio,
     return pkey;
 }
 
-#endif /* !NO_BIO */
-
 #if !defined(NO_FILESYSTEM)
 WOLFSSL_EVP_PKEY *wolfSSL_PEM_read_PUBKEY(XFILE fp, WOLFSSL_EVP_PKEY **x,
                                           wc_pem_password_cb *cb, void *u)
 {
-    (void)fp;
-    (void)x;
-    (void)cb;
-    (void)u;
+    int err = 0;
+    WOLFSSL_EVP_PKEY* ret = NULL;
+    WOLFSSL_BIO* bio = NULL;
 
-    WOLFSSL_MSG("wolfSSL_PEM_read_PUBKEY not implemented");
+    WOLFSSL_ENTER("wolfSSL_PEM_read_PUBKEY");
 
-    return NULL;
+    if (fp == XBADFILE) {
+        err = 1;
+    }
+    if (err == 0) {
+        bio = wolfSSL_BIO_new(wolfSSL_BIO_s_file());
+        err = bio == NULL;
+    }
+    if (err == 0) {
+        err = wolfSSL_BIO_set_fp(bio, fp, BIO_NOCLOSE) != WOLFSSL_SUCCESS;
+    }
+    if (err == 0) {
+        ret = wolfSSL_PEM_read_bio_PUBKEY(bio, x, cb, u);
+    }
+
+    if (bio != NULL) {
+        wolfSSL_BIO_free(bio);
+    }
+
+    return ret;
 }
 #endif /* NO_FILESYSTEM */
+#endif /* !NO_BIO */
 #endif /* OPENSSL_EXTRA */
 
 #ifdef WOLFSSL_ALT_CERT_CHAINS

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -28289,6 +28289,8 @@ WOLFSSL_EVP_PKEY *wolfSSL_PEM_read_PUBKEY(XFILE fp, WOLFSSL_EVP_PKEY **x,
         wolfSSL_BIO_free(bio);
     }
 
+    WOLFSSL_LEAVE("wolfSSL_PEM_read_PUBKEY", 0);
+
     return ret;
 }
 #endif /* NO_FILESYSTEM */

--- a/tests/api.c
+++ b/tests/api.c
@@ -32485,7 +32485,7 @@ static int test_wolfSSL_PEM_read_RSA_PUBKEY(void)
     XFILE file;
     const char* fname = "./certs/client-keyPub.pem";
     RSA *rsa;
-    
+
     file = XFOPEN(fname, "rb");
     AssertTrue((file != XBADFILE));
     AssertNotNull((rsa = PEM_read_RSA_PUBKEY(file, NULL, NULL, NULL)));

--- a/tests/api.c
+++ b/tests/api.c
@@ -31986,6 +31986,29 @@ static int test_wolfSSL_PEM_read_PrivateKey(void)
     return 0;
 }
 
+static int test_wolfSSL_PEM_read_PUBKEY(void)
+{
+#if defined(OPENSSL_EXTRA) && !defined(NO_RSA) \
+    && !defined(NO_FILESYSTEM) && !defined(NO_BIO)
+    XFILE file;
+    const char* fname = "./certs/client-keyPub.pem";
+    EVP_PKEY* pkey;
+
+    printf(testingFmt, "test_wolfSSL_PEM_read_PUBKEY()");
+
+    /* Check error case. */
+    AssertNull(pkey = PEM_read_PUBKEY(NULL, NULL, NULL, NULL));
+
+    /* Read in an RSA key. */
+    file = XFOPEN(fname, "rb");
+    AssertTrue(file != XBADFILE);
+    AssertNotNull(pkey = PEM_read_PUBKEY(file, NULL, NULL, NULL));
+    XFCLOSE(file);
+#endif
+
+    return 0;
+}
+
 static int test_wolfSSL_PEM_PrivateKey(void)
 {
 #if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && \
@@ -32450,6 +32473,24 @@ static int test_wolfSSL_PEM_RSAPrivateKey(void)
 
     printf(resultFmt, passed);
     #endif /* defined(OPENSSL_EXTRA) && !defined(NO_CERTS) */
+
+    return 0;
+}
+
+static int test_wolfSSL_PEM_read_RSA_PUBKEY(void)
+{
+#if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && \
+       !defined(NO_FILESYSTEM) && !defined(NO_RSA)
+    XFILE file;
+    const char* fname = "./certs/client-keyPub.pem";
+    RSA *rsa;
+    
+    file = XFOPEN(fname, "rb");
+    AssertTrue((file != XBADFILE));
+    AssertNotNull((rsa = PEM_read_RSA_PUBKEY(file, NULL, NULL, NULL)));
+    AssertIntEQ(RSA_size(rsa), 256);
+    RSA_free(rsa);
+#endif /* defined(OPENSSL_EXTRA) && !defined(NO_CERTS) */
 
     return 0;
 }
@@ -57245,6 +57286,8 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_ASN1_GENERALIZEDTIME_free),
     TEST_DECL(test_wolfSSL_private_keys),
     TEST_DECL(test_wolfSSL_PEM_read_PrivateKey),
+    TEST_DECL(test_wolfSSL_PEM_read_RSA_PUBKEY),
+    TEST_DECL(test_wolfSSL_PEM_read_PUBKEY),
     TEST_DECL(test_wolfSSL_PEM_PrivateKey),
 #ifndef NO_BIO
     TEST_DECL(test_wolfSSL_PEM_bio_RSAKey),

--- a/tests/api.c
+++ b/tests/api.c
@@ -32003,6 +32003,7 @@ static int test_wolfSSL_PEM_read_PUBKEY(void)
     file = XFOPEN(fname, "rb");
     AssertTrue(file != XBADFILE);
     AssertNotNull(pkey = PEM_read_PUBKEY(file, NULL, NULL, NULL));
+    EVP_PKEY_free(pkey);
     XFCLOSE(file);
 #endif
 
@@ -32490,6 +32491,7 @@ static int test_wolfSSL_PEM_read_RSA_PUBKEY(void)
     AssertNotNull((rsa = PEM_read_RSA_PUBKEY(file, NULL, NULL, NULL)));
     AssertIntEQ(RSA_size(rsa), 256);
     RSA_free(rsa);
+    XFCLOSE(file);
 #endif /* defined(OPENSSL_EXTRA) && !defined(NO_CERTS) */
 
     return 0;

--- a/wolfssl/openssl/pem.h
+++ b/wolfssl/openssl/pem.h
@@ -81,6 +81,10 @@ int wolfSSL_PEM_write_RSAPublicKey(XFILE fp, WOLFSSL_RSA* key);
 
 WOLFSSL_API
 int wolfSSL_PEM_write_RSA_PUBKEY(XFILE fp, WOLFSSL_RSA *x);
+
+WOLFSSL_API
+WOLFSSL_RSA *wolfSSL_PEM_read_RSA_PUBKEY(XFILE fp, WOLFSSL_RSA** rsa,
+                                         wc_pem_password_cb* cb, void *pass);
 #endif /* NO_FILESYSTEM */
 
 /* DSA */
@@ -232,6 +236,7 @@ int wolfSSL_PEM_write_DHparams(XFILE fp, WOLFSSL_DH* dh);
 #define PEM_read_bio_ECPKParameters     wolfSSL_PEM_read_bio_ECPKParameters
 #define PEM_write_RSAPrivateKey         wolfSSL_PEM_write_RSAPrivateKey
 #define PEM_write_RSA_PUBKEY            wolfSSL_PEM_write_RSA_PUBKEY
+#define PEM_read_RSA_PUBKEY             wolfSSL_PEM_read_RSA_PUBKEY
 #define PEM_write_RSAPublicKey          wolfSSL_PEM_write_RSAPublicKey
 #define PEM_read_RSAPublicKey           wolfSSL_PEM_read_RSAPublicKey
 /* DSA */


### PR DESCRIPTION
# Description

This PR adds wolfSSL_PEM_read_RSA_PUBKEY() to the OpenSSL compatible API,
and adds wolfSSL_PEM_read_PUBKEY() needed by wolfSSL_PEM_read_RSA_PUBKEY(),
and adds the unit-test code to tests/api.c .

# Testing

Built example app using wolfSSL_PEM_read_RSA_PUBKEY() and ran it.
Checked if wolfSSL_PEM_read_RSA_PUBKEY() returns RSA structure
and if RSA_print_fp() can print the RSA structure.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
