### PR TITLE
Respect disabled curves on HelloRetryRequests

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -6797,6 +6797,8 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
     if (ctx->protoMsgCb != NULL) {
         ssl->toInfoOn = 1;
     }
+
+    ssl->disabledCurves = ctx->disabledCurves;
 #endif
 
     InitCiphers(ssl);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -33905,18 +33905,18 @@ void wolfSSL_get0_next_proto_negotiated(const WOLFSSL *s, const unsigned char **
 #endif /* WOLFSSL_NGINX  / WOLFSSL_HAPROXY */
 
 #ifdef OPENSSL_EXTRA
-int wolfSSL_CTX_curve_is_disabled(WOLFSSL_CTX* ctx, word16 named_curve)
+int wolfSSL_CTX_curve_is_disabled(WOLFSSL_CTX* ctx, word16 curve_id)
 {
-    return (named_curve <= WOLFSSL_ECC_MAX &&
+    return (curve_id <= WOLFSSL_ECC_MAX &&
             ctx->disabledCurves &&
-            ctx->disabledCurves & (1 << named_curve));
+            ctx->disabledCurves & (1 << curve_id));
 }
 
-int wolfSSL_curve_is_disabled(WOLFSSL* ssl, word16 named_curve)
+int wolfSSL_curve_is_disabled(WOLFSSL* ssl, word16 curve_id)
 {
     /* FIXME: see wolfSSL_set1_curves_list() below on why
      * this dependency on ssl->ctx alone is insufficient. */
-    return wolfSSL_CTX_curve_is_disabled(ssl->ctx, named_curve);
+    return wolfSSL_CTX_curve_is_disabled(ssl->ctx, curve_id);
 }
 #endif
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -33904,6 +33904,22 @@ void wolfSSL_get0_next_proto_negotiated(const WOLFSSL *s, const unsigned char **
 
 #endif /* WOLFSSL_NGINX  / WOLFSSL_HAPROXY */
 
+#ifdef OPENSSL_EXTRA
+int wolfSSL_CTX_curve_is_disabled(WOLFSSL_CTX* ctx, word16 named_curve)
+{
+    return (named_curve <= WOLFSSL_ECC_MAX &&
+            ctx->disabledCurves &&
+            ctx->disabledCurves & (1 << named_curve));
+}
+
+int wolfSSL_curve_is_disabled(WOLFSSL* ssl, word16 named_curve)
+{
+    /* FIXME: see wolfSSL_set1_curves_list() below on why
+     * this dependency on ssl->ctx alone is insufficient. */
+    return wolfSSL_CTX_curve_is_disabled(ssl->ctx, named_curve);
+}
+#endif
+
 #if defined(OPENSSL_EXTRA) && (defined(HAVE_ECC) || \
     defined(HAVE_CURVE25519) || defined(HAVE_CURVE448))
 int wolfSSL_CTX_set1_curves_list(WOLFSSL_CTX* ctx, const char* names)
@@ -34011,6 +34027,8 @@ int wolfSSL_set1_curves_list(WOLFSSL* ssl, const char* names)
     if (ssl == NULL) {
         return WOLFSSL_FAILURE;
     }
+    /* FIXME: this manipulates the context from a WOLFSSL* and
+     * will lead to surprises for some. */
     return wolfSSL_CTX_set1_curves_list(ssl->ctx, names);
 }
 #endif /* OPENSSL_EXTRA && (HAVE_ECC || HAVE_CURVE25519 || HAVE_CURVE448) */

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -4803,6 +4803,8 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
 #ifdef WOLFSSL_EARLY_DATA
         ssl->earlyData = no_early_data;
 #endif
+        if (usingPSK)
+            *usingPSK = 0;
         /* Hash data up to binders for deriving binders in PSK extension. */
         ret = HashInput(ssl, input,  helloSz);
         return ret;
@@ -4860,8 +4862,18 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
         return ret;
 #endif
 
-    /* Hash the rest of the ClientHello. */
-    ret = HashRaw(ssl, input + helloSz - bindersLen, bindersLen);
+    if (*usingPSK) {
+        /* While verifying the selected PSK, we updated the
+         * handshake hash up to the binder bytes in the PSK extensions.
+         * Continuing, we need the rest of the ClientHello hashed as well.
+         */
+        ret = HashRaw(ssl, input + helloSz - bindersLen, bindersLen);
+    }
+    else {
+        /* No suitable PSK found, Hash the complete ClientHello,
+         * as caller expect it after we return */
+        ret = HashInput(ssl, input,  helloSz);
+    }
     if (ret != 0)
         return ret;
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -10606,8 +10606,7 @@ int wolfSSL_UseKeyShare(WOLFSSL* ssl, word16 group)
 #endif
 
 #ifdef HAVE_PQC
-    if (group >= WOLFSSL_PQC_MIN &&
-        group <= WOLFSSL_PQC_MAX) {
+    if (WOLFSSL_NAMED_GROUP_IS_PQC(group)) {
 
         if (ssl->ctx != NULL && ssl->ctx->method != NULL &&
             ssl->ctx->method->version.minor != TLSv1_3_MINOR) {

--- a/tests/quic.c
+++ b/tests/quic.c
@@ -1037,7 +1037,8 @@ static int test_quic_client_hello(int verbose) {
     /* Set transport params, expect both extensions */
     QuicTestContext_init(&tctx, ctx, "client", verbose);
 #ifdef HAVE_SNI
-    wolfSSL_UseSNI(tctx.ssl, WOLFSSL_SNI_HOST_NAME, "wolfssl.com", sizeof("wolfssl.com")-1);
+    wolfSSL_UseSNI(tctx.ssl, WOLFSSL_SNI_HOST_NAME,
+                   "wolfssl.com", sizeof("wolfssl.com")-1);
 #endif
     AssertTrue(wolfSSL_connect(tctx.ssl) != 0);
     AssertIntEQ(wolfSSL_get_error(tctx.ssl, 0), SSL_ERROR_WANT_READ);
@@ -1106,9 +1107,11 @@ static int test_quic_server_hello(int verbose) {
     AssertIntEQ(tserver.output.len, 0);
     /* what have we seen? */
 #ifdef HAVE_SESSION_TICKET
-    AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:Certificate:CertificateVerify:Finished:Finished:SessionTicket");
+    AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
+        "Certificate:CertificateVerify:Finished:Finished:SessionTicket");
 #else
-    AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:Certificate:CertificateVerify:Finished:Finished");
+    AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
+        "Certificate:CertificateVerify:Finished:Finished");
 #endif
     /* we are at application encryption level */
     AssertTrue(wolfSSL_quic_read_level(tclient.ssl) == wolfssl_encryption_application);
@@ -1158,8 +1161,8 @@ static int test_quic_key_share(int verbose) {
     QuicTestContext_init(&tserver, ctx_s, "server", verbose);
     QuicConversation_init(&conv, &tclient, &tserver);
     QuicConversation_do(&conv);
-    AssertStrEQ(conv.rec_log,
-        "ClientHello:ServerHello:EncryptedExtension:Certificate:CertificateVerify:Finished:Finished:SessionTicket");
+    AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
+        "Certificate:CertificateVerify:Finished:Finished:SessionTicket");
     QuicTestContext_free(&tclient);
     QuicTestContext_free(&tserver);
 
@@ -1174,7 +1177,8 @@ static int test_quic_key_share(int verbose) {
     QuicConversation_init(&conv, &tclient, &tserver);
     QuicConversation_do(&conv);
     AssertStrEQ(conv.rec_log,
-        "ClientHello:ServerHello:ClientHello:ServerHello:EncryptedExtension:Certificate:CertificateVerify:Finished:Finished:SessionTicket");
+        "ClientHello:ServerHello:ClientHello:ServerHello:EncryptedExtension:"
+            "Certificate:CertificateVerify:Finished:Finished:SessionTicket");
     QuicTestContext_free(&tclient);
     QuicTestContext_free(&tserver);
 
@@ -1207,7 +1211,8 @@ static int test_quic_resumption(int verbose) {
     /* run till end */
     QuicConversation_do(&conv);
     /* what have we seen? */
-    AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:Certificate:CertificateVerify:Finished:Finished:SessionTicket");
+    AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
+        "Certificate:CertificateVerify:Finished:Finished:SessionTicket");
 
     /* Should have received a session ticket, save the session
      * and also make a serialized/deserialized copy to check that persisting
@@ -1232,7 +1237,8 @@ static int test_quic_resumption(int verbose) {
     QuicConversation_init(&conv, &tclient, &tserver);
     QuicConversation_do(&conv);
     /* this is what should happen. Look Ma, no certificate! */
-    AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:Finished:Finished:SessionTicket");
+    AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
+        "Finished:Finished:SessionTicket");
     QuicTestContext_free(&tclient);
     QuicTestContext_free(&tserver);
 
@@ -1244,12 +1250,12 @@ static int test_quic_resumption(int verbose) {
     QuicConversation_init(&conv, &tclient, &tserver);
     QuicConversation_do(&conv);
     /* this is what should happen. Look Ma, no certificate! */
-    AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:Finished:Finished:SessionTicket");
+    AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
+        "Finished:Finished:SessionTicket");
     QuicTestContext_free(&tclient);
     QuicTestContext_free(&tserver);
 
-    if (/*disables code*/(0)) {
-        /* FIXME: this fails with a RSA Padding error in DoTls13CertificateVerify */
+    {
         /* Do a Session resumption with a new server ctx */
         WOLFSSL_CTX *ctx_s2;
         AssertNotNull(ctx_s2 = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
@@ -1262,7 +1268,8 @@ static int test_quic_resumption(int verbose) {
         /* let them talk */
         QuicConversation_init(&conv, &tclient, &tserver);
         QuicConversation_do(&conv);
-        AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:XEncryptedExtension:Finished:Finished:SessionTicket");
+        AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
+            "Certificate:CertificateVerify:Finished:Finished:SessionTicket");
         QuicTestContext_free(&tclient);
         QuicTestContext_free(&tserver);
         wolfSSL_CTX_free(ctx_s2);
@@ -1306,7 +1313,8 @@ static int test_quic_early_data(int verbose) {
     /* run till end */
     QuicConversation_do(&conv);
     /* what have we seen? */
-    AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:Certificate:CertificateVerify:Finished:Finished:SessionTicket");
+    AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
+        "Certificate:CertificateVerify:Finished:Finished:SessionTicket");
 
     /* Should have received a session ticket, save the session */
     AssertTrue(tclient.ticket_len > 0);
@@ -1466,7 +1474,7 @@ int QuicTest(void)
     if ((ret = test_quic_server_hello(verbose)) != 0) goto leave;
 #ifdef HAVE_SESSION_TICKET
     if ((ret = test_quic_key_share(verbose)) != 0) goto leave;
-    if ((ret = test_quic_resumption(verbose || 1)) != 0) goto leave;
+    if ((ret = test_quic_resumption(verbose)) != 0) goto leave;
 #ifdef WOLFSSL_EARLY_DATA
     if ((ret = test_quic_early_data(verbose)) != 0) goto leave;
 #endif /* WOLFSSL_EARLY_DATA */

--- a/tests/quic.c
+++ b/tests/quic.c
@@ -1178,6 +1178,8 @@ static int test_quic_key_share(int verbose) {
     QuicTestContext_free(&tclient);
     QuicTestContext_free(&tserver);
 
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
     printf("    test_quic_key_share: %s\n", (ret == 0)? passed : failed);
     return ret;
 }

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1570,6 +1570,15 @@ enum Misc {
     READ_PROTO         = 0     /* reading a protocol message */
 };
 
+#define WOLFSSL_NAMED_GROUP_IS_FFHDE(group) \
+    (MIN_FFHDE_GROUP <= (group) && (group) <= MAX_FFHDE_GROUP)
+#ifdef HAVE_PQC
+#define WOLFSSL_NAMED_GROUP_IS_PQC(group) \
+    (WOLFSSL_PQC_MIN <= (group) && (group) <= WOLFSSL_PQC_MAX)
+#else
+#define WOLFSSL_NAMED_GROUP_IS_PQC(group)    ((void)(group), 0)
+#endif /* HAVE_PQC */
+
 /* minimum Downgrade Minor version */
 #ifndef WOLFSSL_MIN_DOWNGRADE
     #ifndef NO_OLD_TLS
@@ -5239,6 +5248,14 @@ WOLFSSL_LOCAL int wolfSSL_set_iotsafe_ctx(WOLFSSL *ssl, IOTSAFE *iotsafe);
 #if (defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)) && defined(HAVE_ECC)
 WOLFSSL_LOCAL int SetECKeyInternal(WOLFSSL_EC_KEY* eckey);
 WOLFSSL_LOCAL int SetECKeyExternal(WOLFSSL_EC_KEY* eckey);
+#endif
+
+#if defined(OPENSSL_EXTRA)
+WOLFSSL_LOCAL int wolfSSL_CTX_curve_is_disabled(WOLFSSL_CTX* ctx, word16 named_curve);
+WOLFSSL_LOCAL int wolfSSL_curve_is_disabled(WOLFSSL* ssl, word16 named_curve);
+#else
+#define wolfSSL_CTX_curve_is_disabled(ctx, c)   ((void)(ctx), (void)(c), 0)
+#define wolfSSL_curve_is_disabled(ssl, c)   ((void)(ssl), (void)(c), 0)
 #endif
 
 WOLFSSL_LOCAL WC_RNG* WOLFSSL_RSA_GetRNG(WOLFSSL_RSA *rsa, WC_RNG **tmpRNG,

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4668,6 +4668,7 @@ struct WOLFSSL {
     WOLFSSL_BIO*     biowr;              /* socket bio write to free/close */
     byte             sessionCtx[ID_LEN]; /* app session context ID */
     WOLFSSL_X509_VERIFY_PARAM* param;    /* verification parameters*/
+    word32            disabledCurves;    /* curves disabled by user */
 #endif
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     unsigned long    peerVerifyRet;
@@ -5251,10 +5252,8 @@ WOLFSSL_LOCAL int SetECKeyExternal(WOLFSSL_EC_KEY* eckey);
 #endif
 
 #if defined(OPENSSL_EXTRA)
-WOLFSSL_LOCAL int wolfSSL_CTX_curve_is_disabled(WOLFSSL_CTX* ctx, word16 named_curve);
 WOLFSSL_LOCAL int wolfSSL_curve_is_disabled(WOLFSSL* ssl, word16 named_curve);
 #else
-#define wolfSSL_CTX_curve_is_disabled(ctx, c)   ((void)(ctx), (void)(c), 0)
 #define wolfSSL_curve_is_disabled(ssl, c)   ((void)(ssl), (void)(c), 0)
 #endif
 


### PR DESCRIPTION
# Description

When a TLS/QUIC client sends a KEY_SHARE extension with a curve that is
*disabled* in the server (via `wolfSSL_CTX_set1_curves_list()`), the server
correctly sends a HelloRetryRequest, but the proposed curve in that ones
KEY_SHARE is calculated using the *supported* curves and disregards
the disabled ones.

The proposed fix adds that check, making the server correctly proposing
a curve it is willing to use.

# Testing

- added test_quic_key_share() in quic unittests to reproduce
  the problem. Have a client with curves 'X25519:P-256' talk
  to a server with only 'X25519'. This triggers a HelloRetryRequest
  and the curve proposed in the KEY_SHARE needs to be 'X25519'

Run `make test` to verify the fix (or the failure without the code change).

