### PR TITLE
Fixes for RSA PSS with `--enable-asynccrypt` in `ConfirmSignature`

### DIFF
--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1439,6 +1439,11 @@ struct SignatureCtx {
     defined(HAVE_PK_CALLBACKS)
     CertAttribute  CertAtt;
 #endif
+#ifdef WC_RSA_PSS
+    enum wc_HashType hash;
+    int mgf;
+    int saltLen;
+#endif
 #endif
 };
 


### PR DESCRIPTION
# Description

Fixes for RSA PSS with `--enable-asynccrypt` in `ConfirmSignature`.

# Testing

```
./configure --enable-all --enable-asynccrypt && make check
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
