### PR TITLE
20220817-make-quic-optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -743,7 +743,6 @@ then
     if test "$ENABLED_LINUXKM_DEFAULTS" != "yes"
     then
         test "$enable_compkey" = "" && enable_compkey=yes
-        test "$enable_quic" = "" && enable_quic=yes
         AM_CFLAGS="$AM_CFLAGS -DHAVE_CRL_IO -DHAVE_IO_TIMEOUT"
     fi
 
@@ -2927,6 +2926,10 @@ AC_ARG_ENABLE([curve25519],
     [ ENABLED_CURVE25519=no ]
     )
 
+if test "$ENABLED_QUIC" = "yes" && test "$ENABLED_CURVE25519" = "no"
+then
+    ENABLED_CURVE25519=yes
+fi
 
 if test "$ENABLED_OPENSSH" = "yes" && test "x$ENABLED_FIPS" = "xno"
 then
@@ -5708,12 +5711,6 @@ then
 
     # FTPS server requires pointer to session cache
     AM_CFLAGS="$AM_CFLAGS -DNO_SESSION_CACHE_REF"
-
-    if test "x$ENABLED_QUIC" = "xno"
-    then
-        ENABLED_QUIC="yes"
-        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_QUIC"
-    fi
 
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DES_ECB"
 fi

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -174,6 +174,15 @@ int unit_test(int argc, char** argv)
 
     }
 
+#ifdef WOLFSSL_QUIC
+    if ( (ret = QuicTest()) != 0){
+        printf("quic test failed with %d\n", ret);
+        goto exit;
+    }
+#endif
+
+    SrpTest();
+
 #ifndef NO_WOLFSSL_CIPHER_SUITE_TEST
 #if !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER)
 #ifndef SINGLE_THREADED
@@ -184,15 +193,6 @@ int unit_test(int argc, char** argv)
 #endif
 #endif
 #endif /* NO_WOLFSSL_CIPHER_SUITE_TEST */
-
-#ifdef WOLFSSL_QUIC
-    if ( (ret = QuicTest()) != 0){
-        printf("quic test failed with %d\n", ret);
-        goto exit;
-    }
-#endif
-
-    SrpTest();
 
 exit:
 #ifdef HAVE_WNR


### PR DESCRIPTION
configure.ac: remove enable-quic from enable-all feature set;
remove `ENABLED_QUIC="yes"` from `"$ENABLED_CURL" = "yes"` setup section;
add `ENABLED_CURVE25519=yes` if `$ENABLED_QUIC = yes`;

tests/unit.c: move `QuicTest()` and `SrpTest()` before `SuiteTest()`.

this reverts the change to enable-all in 4431438fb2 by @icing, part of #5384.


tested with `wolfssl-multi-test super-quick-check`, and `make check` on the config permutations not covered by multi-test.

also tested with new multi-test scenarios, which will be activated for nightlies after this merges:
`all-quic defaults-quic cppcheck-all-async-quic clang-tidy-all-async-quic sanitizer-all-asm-smallstack-async-quic`
