### PR TITLE
Remove stub debug log for wolfSSL_BIO_meth_set_destroy

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -1865,7 +1865,7 @@ int wolfSSL_BIO_meth_set_create(WOLFSSL_BIO_METHOD *biom,
 int wolfSSL_BIO_meth_set_destroy(WOLFSSL_BIO_METHOD *biom,
         wolfSSL_BIO_meth_destroy_cb biom_destroy)
 {
-    WOLFSSL_STUB("wolfSSL_BIO_meth_set_destroy");
+    WOLFSSL_ENTER("wolfSSL_BIO_meth_set_destroy");
     if (biom) {
         biom->freeCb = biom_destroy;
         return WOLFSSL_SUCCESS;


### PR DESCRIPTION
# Description

I tested this API and it seems to work. Therefore it is not a stub.

# Testing

I developed an application which uses the destroy callback. It get's called correctly.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
