### PR TITLE
Fixes for build and runtime issues

### DIFF
--- a/doc/dox_comments/header_files/ecc.h
+++ b/doc/dox_comments/header_files/ecc.h
@@ -636,7 +636,8 @@ int wc_ecc_free(ecc_key* key);
 
     \brief This function frees the fixed-point cache, which can be used
     with ecc to speed up computation times. To use this functionality,
-    FP_ECC (fixed-point ecc), should be defined.
+    FP_ECC (fixed-point ecc), should be defined. Threaded applications should
+    call this function before exiting the thread.
 
     \return none No returns.
 

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -3732,6 +3732,9 @@ exit:
 #ifdef HAVE_SECURE_RENEGOTIATION
     (void) forceScr;
 #endif
+#ifdef WOLFSSL_CALLBACKS
+    (void) earlyData;
+#endif
 #ifndef WOLFSSL_TIRTOS
     return 0;
 #endif

--- a/src/bio.c
+++ b/src/bio.c
@@ -1865,7 +1865,7 @@ int wolfSSL_BIO_meth_set_create(WOLFSSL_BIO_METHOD *biom,
 int wolfSSL_BIO_meth_set_destroy(WOLFSSL_BIO_METHOD *biom,
         wolfSSL_BIO_meth_destroy_cb biom_destroy)
 {
-    WOLFSSL_STUB("wolfSSL_BIO_meth_set_destroy");
+    WOLFSSL_ENTER("wolfSSL_BIO_meth_set_destroy");
     if (biom) {
         biom->freeCb = biom_destroy;
         return WOLFSSL_SUCCESS;
@@ -3194,7 +3194,8 @@ void wolfSSL_BIO_clear_retry_flags(WOLFSSL_BIO* bio)
     WOLFSSL_ENTER("wolfSSL_BIO_clear_retry_flags");
 
     if (bio)
-        bio->flags &= ~(WOLFSSL_BIO_FLAG_READ|WOLFSSL_BIO_FLAG_RETRY);
+        bio->flags &= ~(WOLFSSL_BIO_FLAG_READ | WOLFSSL_BIO_FLAG_WRITE |
+                        WOLFSSL_BIO_FLAG_RETRY);
 }
 
 int wolfSSL_BIO_should_retry(WOLFSSL_BIO *bio)

--- a/src/internal.c
+++ b/src/internal.c
@@ -24583,21 +24583,7 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
     /* Initialize TimeoutInfo */
     void InitTimeoutInfo(TimeoutInfo* info)
     {
-        int i;
-
-        info->timeoutName[0] = 0;
-        info->flags          = 0;
-
-        for (i = 0; i < MAX_PACKETS_HANDSHAKE; i++) {
-            info->packets[i].packetName[0]     = 0;
-            info->packets[i].timestamp.tv_sec  = 0;
-            info->packets[i].timestamp.tv_usec = 0;
-            info->packets[i].bufferValue       = 0;
-            info->packets[i].valueSz           = 0;
-        }
-        info->numberPackets        = 0;
-        info->timeoutValue.tv_sec  = 0;
-        info->timeoutValue.tv_usec = 0;
+        XMEMSET(info, 0, sizeof(TimeoutInfo));
     }
 
 
@@ -24606,12 +24592,12 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
     {
         int i;
         (void)heap;
-        for (i = 0; i < MAX_PACKETS_HANDSHAKE; i++)
+        for (i = 0; i < MAX_PACKETS_HANDSHAKE; i++) {
             if (info->packets[i].bufferValue) {
                 XFREE(info->packets[i].bufferValue, heap, DYNAMIC_TYPE_INFO);
-                info->packets[i].bufferValue = 0;
+                info->packets[i].bufferValue = NULL;
             }
-
+        }
     }
 
     /* Add packet name to previously added packet info */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -14860,10 +14860,12 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
                 ssl->timeoutInfo.timeoutValue.tv_usec = timeout.tv_usec;
                 (toCb)(&ssl->timeoutInfo);
             }
-            /* clean up */
-            FreeTimeoutInfo(&ssl->timeoutInfo, ssl->heap);
             ssl->toInfoOn = 0;
         }
+
+        /* clean up buffers allocated by AddPacketInfo */
+        FreeTimeoutInfo(&ssl->timeoutInfo, ssl->heap);
+
         if (hsCb) {
             FinishHandShakeInfo(&ssl->handShakeInfo);
             (hsCb)(&ssl->handShakeInfo);

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -56,7 +56,7 @@ Possible ECC enable options:
  *                      FP cache is not supported for SECP160R1, SECP160R2,
  *                      SECP160K1 and SECP224K1. These do not work with scalars
  *                      that are the length of the order when the order is
- *                      longer than the prime.
+ *                      longer than the prime. Use wc_ecc_fp_free to free cache.
  * USE_ECC_B_PARAM:     Enable ECC curve B param                default: off
  *                      (on for HAVE_COMP_KEY)
  * WOLFSSL_ECC_CURVE_STATIC:                                    default off (on for windows)

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3263,6 +3263,9 @@ WOLFSSL_LOCAL
 void SSL_CtxResourceFree(WOLFSSL_CTX* ctx);
 
 #ifdef HAVE_EX_DATA_CLEANUP_HOOKS
+    #ifndef HAVE_EX_DATA
+        #error "HAVE_EX_DATA_CLEANUP_HOOKS requires HAVE_EX_DATA to be defined"
+    #endif
 void wolfSSL_CRYPTO_cleanup_ex_data(WOLFSSL_CRYPTO_EX_DATA* ex_data);
 #endif
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -4799,7 +4799,7 @@ WOLFSSL_API int wolfSSL_X509_set_ex_data(WOLFSSL_X509 *x509, int idx,
     void *data);
 #ifdef HAVE_EX_DATA_CLEANUP_HOOKS
 WOLFSSL_API int wolfSSL_X509_set_ex_data_with_cleanup(
-    X509 *x509,
+    WOLFSSL_X509 *x509,
     int idx,
     void *data,
     wolfSSL_ex_data_cleanup_routine_t cleanup_routine);


### PR DESCRIPTION
# Description

Fixes the following:
* Documentation for freeing fixed point ECC cache
* Free packet memory when WOLFSSL_CALLBACKS timeout CB is null
* Build error with `HAVE_EX_DATA_CLEANUP_HOOKS` and `HAVE_EX_DATA` not defined
* `wolfSSL_BIO_clear_retry_flags` to also clear the WOLFSSL_BIO_FLAG_WRITE flag
* fixed a build error in the example server when `WOLFSSL_CALLBACKS` and `WOLFSSL_EARLY_DATA` are defined

Fixes zd14659

# Testing

commit checks

# Checklist

 - [ ] added tests
 - [X] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [X] Updated manual and documentation
