### PR TITLE
Adding allocator funcs for dtls peer (for wrappers)

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1205,6 +1205,34 @@ int wolfSSL_set_ConnectFilter(
 #endif /* WOLFSSL_WOLFSENTRY_HOOKS */
 
 #ifndef WOLFSSL_LEANPSK
+#if defined(WOLFSSL_DTLS) && defined(XINET_PTON) && \
+    !defined(WOLFSSL_NO_SOCK) && defined(HAVE_SOCKADDR)
+void* wolfSSL_dtls_create_peer(int port, char* ip)
+{
+    SOCKADDR_IN *addr;
+    addr = (SOCKADDR_IN*)XMALLOC(sizeof(*addr), NULL,
+            DYNAMIC_TYPE_SOCKADDR);
+    if (addr == NULL) {
+        return NULL;
+    }
+
+    addr->sin_family = AF_INET;
+    addr->sin_port = htons(port);
+    if (XINET_PTON(AF_INET, ip, &addr->sin_addr) < 1) {
+        XFREE(addr, NULL, DYNAMIC_TYPE_SOCKADDR);
+        return NULL;
+    }
+
+    return addr;
+}
+
+int wolfSSL_dtls_free_peer(void* addr)
+{
+    XFREE(addr, NULL, DYNAMIC_TYPE_SOCKADDR);
+    return WOLFSSL_SUCCESS;
+}
+#endif
+
 int wolfSSL_dtls_set_peer(WOLFSSL* ssl, void* peer, unsigned int peerSz)
 {
 #ifdef WOLFSSL_DTLS

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1398,6 +1398,9 @@ WOLFSSL_API int  wolfSSL_dtls_got_timeout(WOLFSSL* ssl);
 WOLFSSL_API int  wolfSSL_dtls_retransmit(WOLFSSL* ssl);
 WOLFSSL_API int  wolfSSL_dtls(WOLFSSL* ssl);
 
+WOLFSSL_API void* wolfSSL_dtls_create_peer(int port, char* ip);
+WOLFSSL_API int   wolfSSL_dtls_free_peer(void* addr);
+
 WOLFSSL_API int  wolfSSL_dtls_set_peer(WOLFSSL* ssl, void* peer, unsigned int peerSz);
 WOLFSSL_API int  wolfSSL_dtls_get_peer(WOLFSSL* ssl, void* peer, unsigned int* peerSz);
 

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -244,7 +244,12 @@ typedef struct WOLFSSL_ASN1_TIME {
 
 enum {
     IV_SZ   = 32,                   /* max iv sz */
+#ifdef OPENSSL_ALL
+    NAME_SZ = 160,                  /* larger max one line, allows for longer
+                                       encryption password support */
+#else
     NAME_SZ = 80,                   /* max one line */
+#endif
 
     PEM_PASS_READ  = 0,
     PEM_PASS_WRITE = 1,


### PR DESCRIPTION
# Description

- Adding functions to help create/free `sockaddr_in*` input for `wolfSSL_dtls_set_peer()` for python and go wrappers. Guarded by `WOLFSSL_WRAPPER_ALLOCATORS` macro.
-  Increase the max password length `NAME_SZ` to 160


# Testing

With python and go wrappers.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
