### PR TITLE
TLS 1.3 Early Data indication extension fix

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -10388,7 +10388,6 @@ int TLSX_EarlyData_Use(WOLFSSL* ssl, word32 maxSz)
             return MEMORY_E;
     }
 
-    extension->resp = 1;
     extension->val  = maxSz;
 
     return 0;


### PR DESCRIPTION
# Description

Don't assume a response is to be sent to the Early Data Indication
extension.
Only sent when the PSK is chosen and it is the first entry.
CheckPreSharedKeys() does this check and sets resp field.

Fixes #5463

# Testing

Standard

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
