### PR TITLE
Improved EarlyData Indicator reply fix based on PR #5486

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -10324,7 +10324,7 @@ static int TLSX_EarlyData_Parse(WOLFSSL* ssl, const byte* input, word16 length,
             else
                 ssl->earlyDataStatus = WOLFSSL_EARLY_DATA_REJECTED;
 
-            return TLSX_EarlyData_Use(ssl, 0);
+            return TLSX_EarlyData_Use(ssl, 0, 0);
         }
         ssl->earlyData = early_data_ext;
 
@@ -10347,7 +10347,7 @@ static int TLSX_EarlyData_Parse(WOLFSSL* ssl, const byte* input, word16 length,
             ssl->earlyDataStatus = WOLFSSL_EARLY_DATA_ACCEPTED;
         }
 
-        return TLSX_EarlyData_Use(ssl, 1);
+        return TLSX_EarlyData_Use(ssl, 1, 1);
     }
     if (msgType == session_ticket) {
         word32 maxSz;
@@ -10368,9 +10368,10 @@ static int TLSX_EarlyData_Parse(WOLFSSL* ssl, const byte* input, word16 length,
  *
  * ssl    The SSL/TLS object.
  * maxSz  The maximum early data size.
+ * is_response   if this extension is part of a response
  * returns 0 on success and other values indicate failure.
  */
-int TLSX_EarlyData_Use(WOLFSSL* ssl, word32 maxSz)
+int TLSX_EarlyData_Use(WOLFSSL* ssl, word32 maxSz, int is_response)
 {
     int   ret = 0;
     TLSX* extension;
@@ -10388,7 +10389,7 @@ int TLSX_EarlyData_Use(WOLFSSL* ssl, word32 maxSz)
             return MEMORY_E;
     }
 
-    extension->resp = 1;
+    extension->resp = is_response;
     extension->val  = maxSz;
 
     return 0;

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -3523,7 +3523,7 @@ int SendTls13ClientHello(WOLFSSL* ssl)
     if (ssl->earlyData == no_early_data)
         TLSX_Remove(&ssl->extensions, TLSX_EARLY_DATA, ssl->heap);
     if (ssl->earlyData != no_early_data &&
-                                       (ret = TLSX_EarlyData_Use(ssl, 0)) < 0) {
+        (ret = TLSX_EarlyData_Use(ssl, 0, 0)) < 0) {
         return ret;
     }
 #endif
@@ -9097,7 +9097,7 @@ static int SendTls13NewSessionTicket(WOLFSSL* ssl)
 #ifdef WOLFSSL_EARLY_DATA
     ssl->session->maxEarlyDataSz = ssl->options.maxEarlyDataSz;
     if (ssl->session->maxEarlyDataSz > 0)
-        TLSX_EarlyData_Use(ssl, ssl->session->maxEarlyDataSz);
+        TLSX_EarlyData_Use(ssl, ssl->session->maxEarlyDataSz, 1);
     extSz = 0;
     ret = TLSX_GetResponseSize(ssl, session_ticket, &extSz);
     if (ret != 0)

--- a/tests/quic.c
+++ b/tests/quic.c
@@ -1381,7 +1381,7 @@ int QuicTest(void)
 #ifdef HAVE_SESSION_TICKET
     if ((ret = test_quic_resumption(verbose)) != 0) goto leave;
 #ifdef WOLFSSL_EARLY_DATA
-    if ((ret = test_quic_early_data(verbose)) != 0) goto leave;
+    if ((ret = test_quic_early_data(verbose || 1)) != 0) goto leave;
 #endif /* WOLFSSL_EARLY_DATA */
     if ((ret = test_quic_session_export(verbose)) != 0) goto leave;
 #endif /* HAVE_SESSION_TICKET */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2827,7 +2827,7 @@ enum PskKeyExchangeMode {
 WOLFSSL_LOCAL int TLSX_PskKeModes_Use(WOLFSSL* ssl, byte modes);
 
 #ifdef WOLFSSL_EARLY_DATA
-WOLFSSL_LOCAL int TLSX_EarlyData_Use(WOLFSSL* ssl, word32 max);
+WOLFSSL_LOCAL int TLSX_EarlyData_Use(WOLFSSL* ssl, word32 max, int is_response);
 #endif
 #endif /* HAVE_SESSION_TICKET || !NO_PSK */
 


### PR DESCRIPTION
- PR #5486 had test failures in tls13.test and quit unit.test
- the extension was no longer added in SessionTicket messages
- added extra parameter to clarify how the TLSX is used

# Description

Please describe the scope of the fix or feature addition.

Fixes zd#

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
