### PR TITLE
20220822-bugprone-macro-parentheses

### DIFF
--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1266,13 +1266,13 @@ typedef void (CallbackInfoState)(const WOLFSSL* ssl, int, int);
 #ifdef HAVE_EX_DATA
 /* Helper macro to log that input arguments should not be used */
 #define WOLFSSL_CRYPTO_EX_DATA_IGNORE_PARAMS(a1, a2, a3, a4, a5) \
-    (void)a1;                                                    \
-    (void)a2;                                                    \
-    (void)a3;                                                    \
-    (void)a4;                                                    \
-    (void)a5;                                                    \
+    (void)(a1);                                                  \
+    (void)(a2);                                                  \
+    (void)(a3);                                                  \
+    (void)(a4);                                                  \
+    (void)(a5);                                                  \
     do {                                                         \
-        if (a3 != NULL || a4 != NULL || a5 != NULL) {            \
+        if ((a3) != NULL || (a4) != NULL || (a5) != NULL) {      \
             WOLFSSL_MSG("get_ex_new_index API does not support " \
                         "new, dup, or free callbacks");          \
         }                                                        \


### PR DESCRIPTION
fix bugprone-macro-parentheses in `WOLFSSL_CRYPTO_EX_DATA_IGNORE_PARAMS()` added in 8b2fcd0643.

detected and tested with `wolfssl-multi-test.sh ... super-quick-check` (`clang-tidy-asn-template-sp-all-small-stack` in particular)
