### PR TITLE
Support for setting cipher list with bytes

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -24092,6 +24092,7 @@ int SetCipherListFromBytes(WOLFSSL_CTX* ctx, Suites* suites, const byte* list,
 {
     int ret = 0;
     int idx = 0;
+    int i;
 
     int haveRSAsig       = 0;
     int haveECDSAsig     = 0;
@@ -24105,7 +24106,7 @@ int SetCipherListFromBytes(WOLFSSL_CTX* ctx, Suites* suites, const byte* list,
         return 0;
     }
 
-    for (int i = 0; (i + 1) < listSz; i += 2) {
+    for (i = 0; (i + 1) < listSz; i += 2) {
         const byte firstByte = list[i];
         const byte secondByte = list[i + 1];
         const char* name = NULL;

--- a/src/internal.c
+++ b/src/internal.c
@@ -24086,6 +24086,114 @@ int SetCipherList(WOLFSSL_CTX* ctx, Suites* suites, const char* list)
     return ret;
 }
 
+
+int SetCipherListFromBytes(WOLFSSL_CTX* ctx, Suites* suites, const byte* list,
+                           const int listSz)
+{
+    int ret = 0;
+    int idx = 0;
+
+    int haveRSAsig       = 0;
+    int haveECDSAsig     = 0;
+    int haveFalconSig    = 0;
+    int haveDilithiumSig = 0;
+    int haveAnon         = 0;
+
+
+    if (suites == NULL || list == NULL) {
+        WOLFSSL_MSG("SetCipherListFromBytes parameter error");
+        return 0;
+    }
+
+    for (int i = 0; (i + 1) < listSz; i += 2) {
+        const byte firstByte = list[i];
+        const byte secondByte = list[i + 1];
+        const char* name = NULL;
+
+        name = GetCipherNameInternal(firstByte, secondByte);
+        if (XSTRCMP(name, "None") == 0) {
+            /* bytes don't match any known cipher */
+            continue;
+        }
+
+    #ifdef WOLFSSL_DTLS
+        /* don't allow stream ciphers with DTLS */
+        if (ctx->method->version.major == DTLS_MAJOR) {
+            if (XSTRSTR(name, "RC4")) {
+                WOLFSSL_MSG("Stream ciphers not supported with DTLS");
+                continue;
+            }
+        }
+    #endif /* WOLFSSL_DTLS */
+
+        if (idx + 1 >= WOLFSSL_MAX_SUITE_SZ) {
+            WOLFSSL_MSG("WOLFSSL_MAX_SUITE_SZ set too low");
+            return 0; /* suites buffer not large enough, error out */
+        }
+
+        suites->suites[idx++] = firstByte;
+        suites->suites[idx++] = secondByte;
+
+        /* The suites are either ECDSA, RSA, PSK, or Anon. The RSA
+         * suites don't necessarily have RSA in the name. */
+    #ifdef WOLFSSL_TLS13
+        if (firstByte == TLS13_BYTE || (firstByte == ECC_BYTE &&
+                                        (secondByte == TLS_SHA256_SHA256 ||
+                                         secondByte == TLS_SHA384_SHA384))) {
+        #ifndef NO_RSA
+            haveRSAsig = 1;
+        #endif
+        #if defined(HAVE_ECC) || defined(HAVE_ED25519) || defined(HAVE_ED448)
+            haveECDSAsig = 1;
+        #endif
+        #if defined(HAVE_PQC)
+        #ifdef HAVE_FALCON
+            haveFalconSig = 1;
+        #endif /* HAVE_FALCON */
+        #ifdef HAVE_DILITHIUM
+            haveDilithiumSig = 1;
+        #endif /* HAVE_DILITHIUM */
+        #endif /* HAVE_PQC */
+        }
+        else
+    #endif /* WOLFSSL_TLS13 */
+    #if defined(HAVE_ECC) || defined(HAVE_ED25519) || defined(HAVE_ED448)
+        if ((haveECDSAsig == 0) && XSTRSTR(name, "ECDSA"))
+            haveECDSAsig = 1;
+        else
+    #endif
+    #ifdef HAVE_ANON
+        if (XSTRSTR(name, "ADH"))
+            haveAnon = 1;
+        else
+    #endif
+        if (haveRSAsig == 0
+        #ifndef NO_PSK
+            && (XSTRSTR(name, "PSK") == NULL)
+        #endif
+        ) {
+            haveRSAsig = 1;
+        }
+
+        ret = 1; /* found at least one */
+    }
+
+    if (ret) {
+        int keySz = 0;
+    #ifndef NO_CERTS
+        keySz = ctx->privateKeySz;
+    #endif
+        suites->suiteSz = (word16)idx;
+        InitSuitesHashSigAlgo(suites, haveECDSAsig, haveRSAsig, haveFalconSig,
+                              haveDilithiumSig, haveAnon, 1, keySz);
+        suites->setSuites = 1;
+    }
+
+    (void)ctx;
+
+    return ret;
+}
+
 #ifdef OPENSSL_EXTRA
 
 struct mac_algs {

--- a/src/internal.c
+++ b/src/internal.c
@@ -24086,7 +24086,7 @@ int SetCipherList(WOLFSSL_CTX* ctx, Suites* suites, const char* list)
     return ret;
 }
 
-
+#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_SET_CIPHER_BYTES)
 int SetCipherListFromBytes(WOLFSSL_CTX* ctx, Suites* suites, const byte* list,
                            const int listSz)
 {
@@ -24099,7 +24099,6 @@ int SetCipherListFromBytes(WOLFSSL_CTX* ctx, Suites* suites, const byte* list,
     int haveFalconSig    = 0;
     int haveDilithiumSig = 0;
     int haveAnon         = 0;
-
 
     if (suites == NULL || list == NULL) {
         WOLFSSL_MSG("SetCipherListFromBytes parameter error");
@@ -24194,6 +24193,8 @@ int SetCipherListFromBytes(WOLFSSL_CTX* ctx, Suites* suites, const byte* list,
 
     return ret;
 }
+#endif /* OPENSSL_EXTRA */
+
 
 #ifdef OPENSSL_EXTRA
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -11660,6 +11660,31 @@ int wolfSSL_CTX_set_cipher_list(WOLFSSL_CTX* ctx, const char* list)
 }
 
 
+int wolfSSL_CTX_set_cipher_list_bytes(WOLFSSL_CTX* ctx, const byte* list,
+                                      const int listSz)
+{
+    WOLFSSL_ENTER("wolfSSL_CTX_set_cipher_list_bytes");
+
+    if (ctx == NULL)
+        return WOLFSSL_FAILURE;
+
+    /* alloc/init on demand only */
+    if (ctx->suites == NULL) {
+        ctx->suites = (Suites*)XMALLOC(sizeof(Suites), ctx->heap,
+                                       DYNAMIC_TYPE_SUITES);
+        if (ctx->suites == NULL) {
+            WOLFSSL_MSG("Memory alloc for Suites failed");
+            return WOLFSSL_FAILURE;
+        }
+        XMEMSET(ctx->suites, 0, sizeof(Suites));
+    }
+
+    return (SetCipherListFromBytes(ctx, ctx->suites, list, listSz))
+           ? WOLFSSL_SUCCESS
+           : WOLFSSL_FAILURE;
+}
+
+
 int wolfSSL_set_cipher_list(WOLFSSL* ssl, const char* list)
 {
     WOLFSSL_ENTER("wolfSSL_set_cipher_list");
@@ -11681,6 +11706,29 @@ int wolfSSL_set_cipher_list(WOLFSSL* ssl, const char* list)
 #else
     return (SetCipherList(ssl->ctx, ssl->suites, list)) ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
 #endif
+}
+
+
+int wolfSSL_set_cipher_list_bytes(WOLFSSL* ssl, const byte* list,
+                                  const int listSz)
+{
+    WOLFSSL_ENTER("wolfSSL_set_cipher_list_bytes");
+#ifdef SINGLE_THREADED
+    if (ssl->ctx->suites == ssl->suites) {
+        ssl->suites = (Suites*)XMALLOC(sizeof(Suites), ssl->heap,
+                                       DYNAMIC_TYPE_SUITES);
+        if (ssl->suites == NULL) {
+            WOLFSSL_MSG("Suites Memory error");
+            return MEMORY_E;
+        }
+        *ssl->suites = *ssl->ctx->suites;
+        ssl->options.ownSuites = 1;
+    }
+#endif
+
+    return (SetCipherListFromBytes(ssl->ctx, ssl->suites, list, listSz))
+           ? WOLFSSL_SUCCESS
+           : WOLFSSL_FAILURE;
 }
 
 #ifdef HAVE_KEYING_MATERIAL

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -11655,11 +11655,12 @@ int wolfSSL_CTX_set_cipher_list(WOLFSSL_CTX* ctx, const char* list)
 #ifdef OPENSSL_EXTRA
     return wolfSSL_parse_cipher_list(ctx, ctx->suites, list);
 #else
-    return (SetCipherList(ctx, ctx->suites, list)) ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
+    return (SetCipherList(ctx, ctx->suites, list)) ?
+        WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
 #endif
 }
 
-
+#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_SET_CIPHER_BYTES)
 int wolfSSL_CTX_set_cipher_list_bytes(WOLFSSL_CTX* ctx, const byte* list,
                                       const int listSz)
 {
@@ -11679,15 +11680,19 @@ int wolfSSL_CTX_set_cipher_list_bytes(WOLFSSL_CTX* ctx, const byte* list,
         XMEMSET(ctx->suites, 0, sizeof(Suites));
     }
 
-    return (SetCipherListFromBytes(ctx, ctx->suites, list, listSz))
-           ? WOLFSSL_SUCCESS
-           : WOLFSSL_FAILURE;
+    return (SetCipherListFromBytes(ctx, ctx->suites, list, listSz)) ?
+        WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
 }
-
+#endif /* OPENSSL_EXTRA || WOLFSSL_SET_CIPHER_BYTES */
 
 int wolfSSL_set_cipher_list(WOLFSSL* ssl, const char* list)
 {
     WOLFSSL_ENTER("wolfSSL_set_cipher_list");
+
+    if (ssl == NULL || ssl->ctx == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+
 #ifdef SINGLE_THREADED
     if (ssl->ctx->suites == ssl->suites) {
         ssl->suites = (Suites*)XMALLOC(sizeof(Suites), ssl->heap,
@@ -11704,15 +11709,22 @@ int wolfSSL_set_cipher_list(WOLFSSL* ssl, const char* list)
 #ifdef OPENSSL_EXTRA
     return wolfSSL_parse_cipher_list(ssl->ctx, ssl->suites, list);
 #else
-    return (SetCipherList(ssl->ctx, ssl->suites, list)) ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
+    return (SetCipherList(ssl->ctx, ssl->suites, list)) ?
+        WOLFSSL_SUCCESS :
+        WOLFSSL_FAILURE;
 #endif
 }
 
-
+#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_SET_CIPHER_BYTES)
 int wolfSSL_set_cipher_list_bytes(WOLFSSL* ssl, const byte* list,
                                   const int listSz)
 {
     WOLFSSL_ENTER("wolfSSL_set_cipher_list_bytes");
+
+    if (ssl == NULL || ssl->ctx == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+
 #ifdef SINGLE_THREADED
     if (ssl->ctx->suites == ssl->suites) {
         ssl->suites = (Suites*)XMALLOC(sizeof(Suites), ssl->heap,
@@ -11730,6 +11742,8 @@ int wolfSSL_set_cipher_list_bytes(WOLFSSL* ssl, const byte* list,
            ? WOLFSSL_SUCCESS
            : WOLFSSL_FAILURE;
 }
+#endif /* OPENSSL_EXTRA || WOLFSSL_SET_CIPHER_BYTES */
+
 
 #ifdef HAVE_KEYING_MATERIAL
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -841,7 +841,8 @@ static int test_for_double_Free(void)
 
 static int test_wolfSSL_CTX_set_cipher_list_bytes(void)
 {
-#if (!defined(NO_WOLFSSL_CLIENT) || !defined(NO_WOLFSSL_SERVER)) && \
+#if (defined(OPENSSL_EXTRA) || defined(WOLFSSL_SET_CIPHER_BYTES)) && \
+    (!defined(NO_WOLFSSL_CLIENT) || !defined(NO_WOLFSSL_SERVER)) && \
     (!defined(NO_RSA) || defined(HAVE_ECC))
     const char* testCertFile;
     const char* testKeyFile;
@@ -1033,7 +1034,8 @@ static int test_wolfSSL_CTX_set_cipher_list_bytes(void)
     wolfSSL_free(ssl);
     wolfSSL_CTX_free(ctx);
 
-#endif /* (!NO_WOLFSSL_CLIENT || !NO_WOLFSSL_SERVER) && (!NO_RSA || HAVE_ECC) */
+#endif /* (OPENSSL_EXTRA || WOLFSSL_SET_CIPHER_BYTES) &&
+    (!NO_WOLFSSL_CLIENT || !NO_WOLFSSL_SERVER) && (!NO_RSA || HAVE_ECC) */
 
     return 0;
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -839,6 +839,173 @@ static int test_for_double_Free(void)
 #endif
 
 
+static int test_wolfSSL_CTX_set_cipher_list_bytes(void)
+{
+#if (!defined(NO_WOLFSSL_CLIENT) || !defined(NO_WOLFSSL_SERVER)) && \
+    (!defined(NO_RSA) || defined(HAVE_ECC))
+    WOLFSSL_CTX* ctx;
+
+    const byte cipherList[] =
+    {
+        /* TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA */ 0xC0, 0x16,
+        /* TLS_DHE_RSA_WITH_AES_256_CBC_SHA  */ 0xC0, 0x39,
+        /* TLS_DHE_RSA_WITH_AES_128_CBC_SHA  */ 0xC0, 0x33,
+        /* TLS_DH_anon_WITH_AES_128_CBC_SHA  */ 0xC0, 0x34,
+        /* TLS_RSA_WITH_AES_256_CBC_SHA      */ 0xC0, 0x35,
+        /* TLS_RSA_WITH_AES_128_CBC_SHA      */ 0xC0, 0x2F,
+        /* TLS_RSA_WITH_NULL_MD5             */ 0xC0, 0x01,
+        /* TLS_RSA_WITH_NULL_SHA             */ 0xC0, 0x02,
+        /* TLS_PSK_WITH_AES_256_CBC_SHA      */ 0xC0, 0x8d,
+        /* TLS_PSK_WITH_AES_128_CBC_SHA256   */ 0xC0, 0xae,
+        /* TLS_PSK_WITH_AES_256_CBC_SHA384   */ 0xC0, 0xaf,
+        /* TLS_PSK_WITH_AES_128_CBC_SHA      */ 0xC0, 0x8c,
+        /* TLS_PSK_WITH_NULL_SHA256          */ 0xC0, 0xb0,
+        /* TLS_PSK_WITH_NULL_SHA384          */ 0xC0, 0xb1,
+        /* TLS_PSK_WITH_NULL_SHA             */ 0xC0, 0x2c,
+        /* SSL_RSA_WITH_RC4_128_SHA          */ 0xC0, 0x05,
+        /* SSL_RSA_WITH_RC4_128_MD5          */ 0xC0, 0x04,
+        /* SSL_RSA_WITH_3DES_EDE_CBC_SHA     */ 0xC0, 0x0A,
+
+        /* ECC suites, first byte is 0xC0 (ECC_BYTE) */
+        /* TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA     */ 0xC0, 0x14,
+        /* TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA     */ 0xC0, 0x13,
+        /* TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA   */ 0xC0, 0x0A,
+        /* TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA   */ 0xC0, 0x09,
+        /* TLS_ECDHE_RSA_WITH_RC4_128_SHA         */ 0xC0, 0x11,
+        /* TLS_ECDHE_ECDSA_WITH_RC4_128_SHA       */ 0xC0, 0x07,
+        /* TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA    */ 0xC0, 0x12,
+        /* TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA  */ 0xC0, 0x08,
+        /* TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256  */ 0xC0, 0x27,
+        /* TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256*/ 0xC0, 0x23,
+        /* TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384  */ 0xC0, 0x28,
+        /* TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384*/ 0xC0, 0x24,
+        /* TLS_ECDHE_ECDSA_WITH_NULL_SHA          */ 0xC0, 0x06,
+        /* TLS_ECDHE_PSK_WITH_NULL_SHA256         */ 0xC0, 0x3a,
+        /* TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256  */ 0xC0, 0x37,
+
+        /* static ECDH, first byte is 0xC0 (ECC_BYTE) */
+        /* TLS_ECDH_RSA_WITH_AES_256_CBC_SHA      */ 0xC0, 0x0F,
+        /* TLS_ECDH_RSA_WITH_AES_128_CBC_SHA      */ 0xC0, 0x0E,
+        /* TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA    */ 0xC0, 0x05,
+        /* TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA    */ 0xC0, 0x04,
+        /* TLS_ECDH_RSA_WITH_RC4_128_SHA          */ 0xC0, 0x0C,
+        /* TLS_ECDH_ECDSA_WITH_RC4_128_SHA        */ 0xC0, 0x02,
+        /* TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA     */ 0xC0, 0x0D,
+        /* TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA   */ 0xC0, 0x03,
+        /* TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256   */ 0xC0, 0x29,
+        /* TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256 */ 0xC0, 0x25,
+        /* TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384   */ 0xC0, 0x2A,
+        /* TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384 */ 0xC0, 0x26,
+
+        /* WDM_WITH_NULL_SHA256 */ 0x00, 0xFE, /* wolfSSL DTLS Multicast */
+
+        /* SHA256 */
+        /* TLS_DHE_RSA_WITH_AES_256_CBC_SHA256 */ 0x00, 0x6b,
+        /* TLS_DHE_RSA_WITH_AES_128_CBC_SHA256 */ 0x00, 0x67,
+        /* TLS_RSA_WITH_AES_256_CBC_SHA256     */ 0x00, 0x3d,
+        /* TLS_RSA_WITH_AES_128_CBC_SHA256     */ 0x00, 0x3c,
+        /* TLS_RSA_WITH_NULL_SHA256            */ 0x00, 0x3b,
+        /* TLS_DHE_PSK_WITH_AES_128_CBC_SHA256 */ 0x00, 0xb2,
+        /* TLS_DHE_PSK_WITH_NULL_SHA256        */ 0x00, 0xb4,
+
+        /* SHA384 */
+        /* TLS_DHE_PSK_WITH_AES_256_CBC_SHA384 */ 0x00, 0xb3,
+        /* TLS_DHE_PSK_WITH_NULL_SHA384        */ 0x00, 0xb5,
+
+        /* AES-GCM */
+        /* TLS_RSA_WITH_AES_128_GCM_SHA256      */ 0x00, 0x9c,
+        /* TLS_RSA_WITH_AES_256_GCM_SHA384      */ 0x00, 0x9d,
+        /* TLS_DHE_RSA_WITH_AES_128_GCM_SHA256  */ 0x00, 0x9e,
+        /* TLS_DHE_RSA_WITH_AES_256_GCM_SHA384  */ 0x00, 0x9f,
+        /* TLS_DH_anon_WITH_AES_256_GCM_SHA384  */ 0x00, 0xa7,
+        /* TLS_PSK_WITH_AES_128_GCM_SHA256      */ 0x00, 0xa8,
+        /* TLS_PSK_WITH_AES_256_GCM_SHA384      */ 0x00, 0xa9,
+        /* TLS_DHE_PSK_WITH_AES_128_GCM_SHA256  */ 0x00, 0xaa,
+        /* TLS_DHE_PSK_WITH_AES_256_GCM_SHA384  */ 0x00, 0xab,
+
+        /* ECC AES-GCM, first byte is 0xC0 (ECC_BYTE) */
+        /* TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 */ 0xC0, 0x2b,
+        /* TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 */ 0xC0, 0x2c,
+        /* TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256  */ 0xC0, 0x2d,
+        /* TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384  */ 0xC0, 0x2e,
+        /* TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256   */ 0xC0, 0x2f,
+        /* TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384   */ 0xC0, 0x30,
+        /* TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256    */ 0xC0, 0x31,
+        /* TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384    */ 0xC0, 0x32,
+
+        /* AES-CCM, first byte is 0xC0 but isn't ECC,
+         * also, in some of the other AES-CCM suites
+         * there will be second byte number conflicts
+         * with non-ECC AES-GCM */
+        /* TLS_RSA_WITH_AES_128_CCM_8         */ 0xC0, 0xa0,
+        /* TLS_RSA_WITH_AES_256_CCM_8         */ 0xC0, 0xa1,
+        /* TLS_ECDHE_ECDSA_WITH_AES_128_CCM   */ 0xC0, 0xac,
+        /* TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8 */ 0xC0, 0xae,
+        /* TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8 */ 0xC0, 0xaf,
+        /* TLS_PSK_WITH_AES_128_CCM           */ 0xC0, 0xa4,
+        /* TLS_PSK_WITH_AES_256_CCM           */ 0xC0, 0xa5,
+        /* TLS_PSK_WITH_AES_128_CCM_8         */ 0xC0, 0xa8,
+        /* TLS_PSK_WITH_AES_256_CCM_8         */ 0xC0, 0xa9,
+        /* TLS_DHE_PSK_WITH_AES_128_CCM       */ 0xC0, 0xa6,
+        /* TLS_DHE_PSK_WITH_AES_256_CCM       */ 0xC0, 0xa7,
+
+        /* Camellia */
+        /* TLS_RSA_WITH_CAMELLIA_128_CBC_SHA        */ 0x00, 0x41,
+        /* TLS_RSA_WITH_CAMELLIA_256_CBC_SHA        */ 0x00, 0x84,
+        /* TLS_RSA_WITH_CAMELLIA_128_CBC_SHA256     */ 0x00, 0xba,
+        /* TLS_RSA_WITH_CAMELLIA_256_CBC_SHA256     */ 0x00, 0xc0,
+        /* TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA    */ 0x00, 0x45,
+        /* TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA    */ 0x00, 0x88,
+        /* TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256 */ 0x00, 0xbe,
+        /* TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256 */ 0x00, 0xc4,
+
+        /* chacha20-poly1305 suites first byte is 0xCC (CHACHA_BYTE) */
+        /* TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256   */ 0xCC, 0xa8,
+        /* TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 */ 0xCC, 0xa9,
+        /* TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256     */ 0xCC, 0xaa,
+        /* TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256   */ 0xCC, 0xac,
+        /* TLS_PSK_WITH_CHACHA20_POLY1305_SHA256         */ 0xCC, 0xab,
+        /* TLS_DHE_PSK_WITH_CHACHA20_POLY1305_SHA256     */ 0xCC, 0xad,
+
+        /* chacha20-poly1305 earlier version of nonce and padding (CHACHA_BYTE) */
+        /* TLS_ECDHE_RSA_WITH_CHACHA20_OLD_POLY1305_SHA256   */ 0xCC, 0x13,
+        /* TLS_ECDHE_ECDSA_WITH_CHACHA20_OLD_POLY1305_SHA256 */ 0xCC, 0x14,
+        /* TLS_DHE_RSA_WITH_CHACHA20_OLD_POLY1305_SHA256     */ 0xCC, 0x15,
+
+        /* ECDHE_PSK RFC8442, first byte is 0xD0 (ECDHE_PSK_BYTE) */
+        /* TLS_ECDHE_PSK_WITH_AES_128_GCM_SHA256 */ 0xD0, 0x01,
+
+        /* TLS v1.3 cipher suites */
+        /* TLS_AES_128_GCM_SHA256       */ 0x13, 0x01,
+        /* TLS_AES_256_GCM_SHA384       */ 0x13, 0x02,
+        /* TLS_CHACHA20_POLY1305_SHA256 */ 0x13, 0x03,
+        /* TLS_AES_128_CCM_SHA256       */ 0x13, 0x04,
+        /* TLS_AES_128_CCM_8_SHA256     */ 0x13, 0x05,
+
+        /* TLS v1.3 Integrity only cipher suites - 0xC0 (ECC) first byte */
+        /* TLS_SHA256_SHA256 */ 0xC0, 0xB4,
+        /* TLS_SHA384_SHA384 */ 0xC0, 0xB5
+    };
+
+#ifndef NO_WOLFSSL_SERVER
+    ctx = wolfSSL_CTX_new(wolfSSLv23_server_method());
+    AssertNotNull(ctx);
+#else
+    ctx = wolfSSL_CTX_new(wolfSSLv23_client_method());
+    AssertNotNull(ctx);
+#endif
+
+    AssertTrue(wolfSSL_CTX_set_cipher_list_bytes(ctx, &cipherList[0U],
+                                                           sizeof(cipherList)));
+
+    wolfSSL_CTX_free(ctx);
+
+#endif /* (!NO_WOLFSSL_CLIENT || !NO_WOLFSSL_SERVER) && (!NO_RSA || HAVE_ECC) */
+
+    return 0;
+}
+
+
 static int test_wolfSSL_CTX_use_certificate_file(void)
 {
 #if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && !defined(NO_WOLFSSL_SERVER)
@@ -57156,6 +57323,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_EVP_blake2),
     TEST_DECL(test_EVP_MD_do_all),
     TEST_DECL(test_OBJ_NAME_do_all),
+    TEST_DECL(test_wolfSSL_CTX_set_cipher_list_bytes),
     TEST_DECL(test_wolfSSL_CTX_use_certificate_file),
     TEST_DECL(test_wolfSSL_CTX_use_certificate_buffer),
     TEST_DECL(test_wolfSSL_CTX_use_PrivateKey_file),

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2032,6 +2032,8 @@ WOLFSSL_LOCAL void InitSuites(Suites* suites, ProtocolVersion pv, int keySz,
 WOLFSSL_LOCAL int  MatchSuite(WOLFSSL* ssl, Suites* peerSuites);
 WOLFSSL_LOCAL int  SetCipherList(WOLFSSL_CTX* ctx, Suites* suites,
                                  const char* list);
+WOLFSSL_LOCAL int  SetCipherListFromBytes(WOLFSSL_CTX* ctx, Suites* suites,
+                                          const byte* list, const int listSz);
 WOLFSSL_LOCAL int  SetSuitesHashSigAlgo(Suites* suites, const char* list);
 
 #ifndef PSK_TYPES_DEFINED

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1337,6 +1337,10 @@ WOLFSSL_API int  wolfSSL_CTX_get_cert_cache_memsize(WOLFSSL_CTX* ctx);
 WOLFSSL_API int  wolfSSL_CTX_set_cipher_list(WOLFSSL_CTX* ctx, const char* list);
 WOLFSSL_API int  wolfSSL_set_cipher_list(WOLFSSL* ssl, const char* list);
 
+/* supports 2 byte code from cipher_name[] */
+WOLFSSL_API int  wolfSSL_CTX_set_cipher_list_bytes(WOLFSSL_CTX* ctx, const byte* list, const int listSz);
+WOLFSSL_API int  wolfSSL_set_cipher_list_bytes(WOLFSSL* ssl, const byte* list, const int listSz);
+
 #ifdef HAVE_KEYING_MATERIAL
 /* Keying Material Exporter for TLS */
 WOLFSSL_API int wolfSSL_export_keying_material(WOLFSSL *ssl,


### PR DESCRIPTION
# Description

Set cipher suites using their 2byte codes instead of string names.

Adds two new API's:
```
/* supports 2 byte code from cipher_name[] */
WOLFSSL_API int  wolfSSL_CTX_set_cipher_list_bytes(WOLFSSL_CTX* ctx, const byte* list, const int listSz);
WOLFSSL_API int  wolfSSL_set_cipher_list_bytes(WOLFSSL* ssl, const byte* list, const int listSz);
```

Fixes ZD14669

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
