### PR TITLE
Fixes for build warnings and string macros for DTLS CID

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -2189,7 +2189,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         case 262:
             useDtlsCID = 1;
             if (myoptarg != NULL) {
-                if (strlen(myoptarg) >= DTLS_CID_BUFFER_SIZE) {
+                if (XSTRLEN(myoptarg) >= DTLS_CID_BUFFER_SIZE) {
                     err_sys("provided connection ID is too big");
                 }
                 else {
@@ -3733,8 +3733,8 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         ret = wolfSSL_dtls_cid_use(ssl);
         if (ret != WOLFSSL_SUCCESS)
             err_sys("Can't enable DTLS ConnectionID");
-        ret =
-            wolfSSL_dtls_cid_set(ssl, (unsigned char*)dtlsCID, strlen(dtlsCID));
+        ret = wolfSSL_dtls_cid_set(ssl, (unsigned char*)dtlsCID,
+            (word32)XSTRLEN(dtlsCID));
         if (ret != WOLFSSL_SUCCESS)
             err_sys("Can't set DTLS ConnectionID");
     }

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -2303,7 +2303,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
         case 263:
             useDtlsCID = 1;
             if (myoptarg != NULL) {
-                if (strlen(myoptarg) >= DTLS_CID_BUFFER_SIZE) {
+                if (XSTRLEN(myoptarg) >= DTLS_CID_BUFFER_SIZE) {
                     err_sys("provided connection ID is too big");
                 }
                 else {
@@ -3288,7 +3288,8 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
         ret = wolfSSL_dtls_cid_use(ssl);
         if (ret != WOLFSSL_SUCCESS)
             err_sys("Can't enable DTLS ConnectionID");
-        ret = wolfSSL_dtls_cid_set(ssl, (byte*)dtlsCID, strlen(dtlsCID));
+        ret = wolfSSL_dtls_cid_set(ssl, (byte*)dtlsCID,
+            (word32)XSTRLEN(dtlsCID));
         if (ret != WOLFSSL_SUCCESS)
             err_sys("Can't set DTLS ConnectionID");
     }


### PR DESCRIPTION
# Description

Fix for type warnings in examples for DTLS CID. Fix to use `XSTRLEN`.

```
examples/client/client.c:3737:64: error: implicit conversion loses integer precision: 'unsigned long' to 'unsigned int' [-Werror,-Wshorten-64-to-32]
            wolfSSL_dtls_cid_set(ssl, (unsigned char*)dtlsCID, strlen(dtlsCID));
            ~~~~~~~~~~~~~~~~~~~~                               ^~~~~~~~~~~~~~~
1 error generated.

examples/server/server.c:3291:57: error: implicit conversion loses integer precision: 'unsigned long' to 'unsigned int' [-Werror,-Wshorten-64-to-32]
        ret = wolfSSL_dtls_cid_set(ssl, (byte*)dtlsCID, strlen(dtlsCID));
              ~~~~~~~~~~~~~~~~~~~~                      ^~~~~~~~~~~~~~~
1 error generated.
```

# Testing

```
./configure --enable-dtls --enable-dtlscid --enable-dtls13 && make check
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
