### PR TITLE
Fix wolfSSL_GENERAL_NAMES_free memory leak.

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -4315,7 +4315,7 @@ void wolfSSL_GENERAL_NAMES_free(WOLFSSL_GENERAL_NAMES *gens)
         return;
     }
 
-    wolfSSL_sk_free(gens);
+    wolfSSL_sk_GENERAL_NAME_free(gens);
 }
 
 #if defined(OPENSSL_ALL) && !defined(NO_BIO)


### PR DESCRIPTION
# Description

This function was just freeing the stack object itself of GENERAL_NAMES with wolfSSL_sk_free, but this doesn't free the data in the items of the stack. The fix is to replace wolfSSL_sk_free with wolfSSL_sk_GENERAL_NAME_free.

Reported by a customer when using X509_get_ext_d2i then GENERAL_NAMES_free. 

# Testing

I added a regression to unit.c. Without the fix in x509.c but with the regression test, you'll see the leak with valgrind:

```
unit_test: Success for all configured tests.
==1410205== 
==1410205== HEAP SUMMARY:
==1410205==     in use at exit: 120 bytes in 2 blocks
==1410205==   total heap usage: 2,175,746 allocs, 2,175,744 frees, 587,295,780 bytes allocated
==1410205== 
==1410205== 120 (16 direct, 104 indirect) bytes in 1 blocks are definitely lost in loss record 2 of 2
==1410205==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==1410205==    by 0x48A32E8: wolfSSL_Malloc (memory.c:293)
==1410205==    by 0x492BFC3: wolfSSL_GENERAL_NAME_new (x509.c:3869)
==1410205==    by 0x4929AAF: wolfSSL_X509_get_ext_d2i (x509.c:1940)
==1410205==    by 0x1B157F: test_wolfSSL_sk_GENERAL_NAME (api.c:41530)
==1410205==    by 0x1FBFD8: ApiTest (api.c:58145)
==1410205==    by 0x12C92D: unit_test (unit.c:161)
==1410205==    by 0x12C8EC: main (unit.c:43)
==1410205== 
==1410205== LEAK SUMMARY:
==1410205==    definitely lost: 16 bytes in 1 blocks
==1410205==    indirectly lost: 104 bytes in 1 blocks
==1410205==      possibly lost: 0 bytes in 0 blocks
==1410205==    still reachable: 0 bytes in 0 blocks
==1410205==         suppressed: 0 bytes in 0 blocks
==1410205== 
==1410205== For lists of detected and suppressed errors, rerun with: -s
==1410205== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
