### PR TITLE
Allow Post Quantum Keyshare for DTLS 1.3

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -2838,8 +2838,8 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             fprintf(stderr,
                    "WARNING: If a TLS 1.3 connection is not negotiated, you "
                    "will not be using a post-quantum group.\n");
-        else if (version != 4)
-            err_sys("can only use post-quantum groups with TLS 1.3");
+        else if (version != 4 && version != -4)
+            err_sys("can only use post-quantum groups with TLS 1.3 or DTLS 1.3");
     }
 #endif
 

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -2368,8 +2368,8 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
             fprintf(stderr,
                    "WARNING: If a TLS 1.3 connection is not negotiated, you "
                    "will not be using a post-quantum group.\n");
-        } else if (version != 4) {
-            err_sys("can only use post-quantum groups with TLS 1.3");
+        } else if (version != 4 && version != -4) {
+            err_sys("can only use post-quantum groups with TLS 1.3 or DTLS 1.3");
         }
     }
 #endif
@@ -3104,7 +3104,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
     #endif
 
     #if defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES)
-        if (version >= 4) {
+        if (version >= 4 || version == -4) {
             #ifdef CAN_FORCE_CURVE
             if (force_curve_group_id > 0) {
                 do {

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -10659,7 +10659,8 @@ int wolfSSL_UseKeyShare(WOLFSSL* ssl, word16 group)
     if (WOLFSSL_NAMED_GROUP_IS_PQC(group)) {
 
         if (ssl->ctx != NULL && ssl->ctx->method != NULL &&
-            ssl->ctx->method->version.minor != TLSv1_3_MINOR) {
+            (ssl->ctx->method->version.minor != TLSv1_3_MINOR &&
+            ssl->ctx->method->version.minor != DTLSv1_3_MINOR)) {
             return BAD_FUNC_ARG;
         }
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -10659,8 +10659,7 @@ int wolfSSL_UseKeyShare(WOLFSSL* ssl, word16 group)
     if (WOLFSSL_NAMED_GROUP_IS_PQC(group)) {
 
         if (ssl->ctx != NULL && ssl->ctx->method != NULL &&
-            (ssl->ctx->method->version.minor != TLSv1_3_MINOR &&
-            ssl->ctx->method->version.minor != DTLSv1_3_MINOR)) {
+            !IsAtLeastTLSv1_3(ssl->version)) {
             return BAD_FUNC_ARG;
         }
 


### PR DESCRIPTION
# Description

Adds support for specifying post quantum key exchange within DTLS 1.3 through `wolfSSL_UseKeyShare`.

ZD14705

# Testing

- `wolfSSL_get_curve_name` on both a test client and server return specified post quantum curve, e.g `KYBER_LEVEL5`. 
- Tracing through the associated calls shows `server_generate_pqc_ciphertext` is reached on the server side of the connection. 
- Tested with all kyber KEM versions, and SECP256R1/521R1
- Tested with RSA certificate chains, and Dilithium certificate chains

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
