### PR TITLE
Add code to fallback to S/W if TSIP cannot handle

### DIFF
--- a/IDE/Renesas/e2studio/RX65N/GR-ROSE/test/src/wolf_client.c
+++ b/IDE/Renesas/e2studio/RX65N/GR-ROSE/test/src/wolf_client.c
@@ -180,16 +180,15 @@ void wolfSSL_TLS_client_init(const char* cipherlist)
     }
 
     /* set client private key data */
-    #ifdef WOLFSSL_TLS13
-    #ifdef WOLFSSL_RENESAS_TSIP_TLS
+    #if defined(WOLFSSL_TLS13) && defined(WOLFSSL_RENESAS_TSIP_TLS) && \
+        (WOLFSSL_RENESAS_TSIP_VER >= 115 )
     if (tsip_set_clientPrivateKeyEnc(
                         g_key_block_data.encrypted_user_ecc256_private_key,
                                                         TSIP_ECCP256) != 0) {
         printf("ERROR: can't load client-private key\n");
         return;
     }
-    #endif /* WOLFSSL_RENESAS_TSIP_TLS */
-    #else
+    #endif
     if (wolfSSL_CTX_use_PrivateKey_buffer(client_ctx, 
                                 ecc_clikey_der_256,
                                 sizeof_ecc_clikey_der_256,
@@ -197,7 +196,6 @@ void wolfSSL_TLS_client_init(const char* cipherlist)
         printf("ERROR: can't load private-key data.\n");
         return;
     }
-    #endif /* WOLFSSL_TLS13 */
 
 #else
     if (wolfSSL_CTX_use_certificate_chain_buffer_format(client_ctx,
@@ -209,14 +207,6 @@ void wolfSSL_TLS_client_init(const char* cipherlist)
     }
 
     /* set client private key data */
-    #ifdef WOLFSSL_RENESAS_TSIP_TLS
-    if (tsip_set_clientPrivateKeyEnc(
-                        g_key_block_data.encrypted_user_rsa2048_private_key,
-                                            TSIP_RSA2048) != 0) {
-        printf("ERROR: can't load client-private key\n");
-        return;
-    }
-    #endif
 
     if (wolfSSL_CTX_use_PrivateKey_buffer(client_ctx, client_key_der_2048,
             sizeof_client_key_der_2048, SSL_FILETYPE_ASN1)

--- a/IDE/Renesas/e2studio/RX65N/RSK/wolfssl_demo/wolfssl_demo.c
+++ b/IDE/Renesas/e2studio/RX65N/RSK/wolfssl_demo/wolfssl_demo.c
@@ -218,7 +218,7 @@ static void Tls_client_init(const char* cipherlist)
         printf("ERROR: can't load client-private key\n");
         return;
     }
-    #else
+    #endif
     if (wolfSSL_CTX_use_PrivateKey_buffer(client_ctx, 
                                 ecc_clikey_der_256,
                                 sizeof_ecc_clikey_der_256,
@@ -226,7 +226,7 @@ static void Tls_client_init(const char* cipherlist)
         printf("ERROR: can't load private-key data.\n");
         return;
     }
-    #endif /* WOLFSSL_TLS13 */
+
 #else
     if (wolfSSL_CTX_use_PrivateKey_buffer(client_ctx, 
                                 client_key_der_2048,

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_demo.c
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_demo.c
@@ -269,7 +269,7 @@ static void Tls_client_init()
         printf("ERROR: can't load client-private key\n");
         return;
     }
-    #else
+    #endif
     if (wolfSSL_CTX_use_PrivateKey_buffer(client_ctx, 
                                 ecc_clikey_der_256,
                                 sizeof_ecc_clikey_der_256,
@@ -277,7 +277,7 @@ static void Tls_client_init()
         printf("ERROR: can't load private-key data.\n");
         return;
     }
-    #endif /* WOLFSSL_TLS13 */
+
 #else
     if (wolfSSL_CTX_use_PrivateKey_buffer(client_ctx, 
                                 client_key_der_2048,

--- a/src/internal.c
+++ b/src/internal.c
@@ -4922,6 +4922,11 @@ int EccSign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
         }
         ret = ssl->ctx->EccSignCb(ssl, in, inSz, out, outSz, keyBuf,
             keySz, ctx);
+#if defined(WOLFSSL_RENESAS_TSIP_TLS)
+        if (ret == CRYPTOCB_UNAVAILABLE) {
+            ret = wc_ecc_sign_hash(in, inSz, out, outSz, ssl->rng, key);
+        }
+#endif /* WOLFSSL_RENESAS_TSIP_TLS */
     }
     else
 #endif /* HAVE_PK_CALLBACKS */

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -515,13 +515,7 @@ static int DeriveClientHandshakeSecret(WOLFSSL* ssl, byte* key)
     if (ssl == NULL || ssl->arrays == NULL) {
         return BAD_FUNC_ARG;
     }
-#if defined(WOLFSSL_RENESAS_TSIP_TLS) && (WOLFSSL_RENESAS_TSIP_Ver >= 115)
-    (void)key;
-    ret = tsip_DeriveClientHandshakeSecret(ssl);
-    if (ret != CRYPTOCB_UNAVAILABLE) {
-        return ret;
-    }
-#endif
+    
     ret = Tls13DeriveKey(ssl, key, -1, ssl->arrays->preMasterSecret,
                     clientHandshakeLabel, CLIENT_HANDSHAKE_LABEL_SZ,
                     ssl->specs.mac_algorithm, 1);

--- a/wolfcrypt/src/port/Renesas/renesas_common.c
+++ b/wolfcrypt/src/port/Renesas/renesas_common.c
@@ -66,7 +66,7 @@ WOLFSSL_LOCAL int Renesas_cmn_RsaSignCb(WOLFSSL* ssl,
                                 const unsigned char* keyDer, unsigned int keySz,
                                 void* ctx)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = CRYPTOCB_UNAVAILABLE;
     WOLFSSL_ENTER("Renesas_cmn_RsaSignCb");
 
     /* This is just a stub function that provides no logic */
@@ -81,7 +81,7 @@ WOLFSSL_LOCAL int Renesas_cmn_EccSignCb(WOLFSSL* ssl,
                                 const unsigned char* keyDer, unsigned int keySz,
                                 void* ctx)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = CRYPTOCB_UNAVAILABLE;
     WOLFSSL_ENTER("Renesas_cmn_EccSignCb");
 
     /* This is just a stub function that provides no logic */
@@ -118,6 +118,7 @@ static int Renesas_cmn_CryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
 #endif
 
 #if defined(WOLFSSL_RENESAS_TSIP)
+    ret = CRYPTOCB_UNAVAILABLE;
 
     if (info->algo_type == WC_ALGO_TYPE_CIPHER) {
 
@@ -327,7 +328,7 @@ static int Renesas_cmn_CryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
 
     (void)devIdArg;
     (void)ctx;
-
+    WOLFSSL_LEAVE("Renesas_cmn_CryptoDevCb", ret);
     return ret;
 }
 


### PR DESCRIPTION
# Description

This PR mainly resolves the issue  reported in ZD14428.  Since the latest TSIP(v1.15) can not handle generating client verify message, a callback function returns CRYPTOCB_UNAVAILABLE so that it falls back to S/W processing. The fallback does not occur when downgrading to TLS1.2 since the missing return code checking in EccSign.
Also, this PR removes unused logic in DeriveClientHandshakeSecret and adds code for loading private key in client example programs. 

Fixes zd#14428

# Testing

Fix code and run example application on the Renesas boards.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
