### PR TITLE
Improve EVP support for CHACHA20_POLY1305

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -52052,7 +52052,6 @@ static int test_wolfssl_EVP_chacha20_poly1305(void)
     /* Test partial Inits. CipherInit() allow setting of key and iv
      * in separate calls. */
     AssertNotNull((ctx = EVP_CIPHER_CTX_new()));
-    EVP_CIPHER_CTX_free(ctx);
     AssertIntEQ(wolfSSL_EVP_CipherInit(ctx, EVP_chacha20_poly1305(),
                 key, NULL, 1), WOLFSSL_SUCCESS);
     AssertIntEQ(wolfSSL_EVP_CipherInit(ctx, NULL, NULL, iv, 1),

--- a/tests/api.c
+++ b/tests/api.c
@@ -52049,6 +52049,25 @@ static int test_wolfssl_EVP_chacha20_poly1305(void)
     AssertIntEQ(outSz, 0);
     EVP_CIPHER_CTX_free(ctx);
 
+    /* Test partial Inits. CipherInit() allow setting of key and iv
+     * in separate calls. */
+    AssertNotNull((ctx = EVP_CIPHER_CTX_new()));
+    EVP_CIPHER_CTX_free(ctx);
+    AssertIntEQ(wolfSSL_EVP_CipherInit(ctx, EVP_chacha20_poly1305(),
+                key, NULL, 1), WOLFSSL_SUCCESS);
+    AssertIntEQ(wolfSSL_EVP_CipherInit(ctx, NULL, NULL, iv, 1),
+                WOLFSSL_SUCCESS);
+    AssertIntEQ(wolfSSL_EVP_CipherUpdate(ctx, NULL, &outSz,
+                aad, sizeof(aad)), WOLFSSL_SUCCESS);
+    AssertIntEQ(outSz, sizeof(aad));
+    AssertIntEQ(EVP_DecryptUpdate(ctx, decryptedText, &outSz, cipherText,
+                sizeof(cipherText)), WOLFSSL_SUCCESS);
+    AssertIntEQ(outSz, sizeof(cipherText));
+    AssertIntEQ(EVP_DecryptFinal_ex(ctx, decryptedText, &outSz),
+            WOLFSSL_SUCCESS);
+    AssertIntEQ(outSz, 0);
+    EVP_CIPHER_CTX_free(ctx);
+
     printf(resultFmt, passed);
 #endif
 

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -6634,7 +6634,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
             if (key != NULL) {
                 if (!ctx->key) {
                     ctx->key = (byte*)XMALLOC(ctx->keyLen, NULL,
-                                              DYNAMIC_TYPE_TMP_BUFFER);
+                                              DYNAMIC_TYPE_OPENSSL);
                     if (!ctx->key) {
                         return MEMORY_E;
                     }

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -6633,8 +6633,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
              * since wc_ChaCha20Poly1305_Init() does not. */
             if (key != NULL) {
                 if (!ctx->key) {
-                    ctx->key = XMALLOC(ctx->keyLen, NULL,
-                                       DYNAMIC_TYPE_TMP_BUFFER);
+                    ctx->key = (byte*)XMALLOC(ctx->keyLen, NULL,
+                                              DYNAMIC_TYPE_TMP_BUFFER);
                     if (!ctx->key) {
                         return MEMORY_E;
                     }

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -431,6 +431,9 @@ struct WOLFSSL_EVP_CIPHER_CTX {
     byte*   gcmAuthIn;
     int     gcmAuthInSz;
 #endif
+#if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
+    byte*   key;                 /* used in partial Init()s */
+#endif
 #if defined(HAVE_AESGCM) || (defined(HAVE_CHACHA) && defined(HAVE_POLY1305))
 #ifdef HAVE_AESGCM
     ALIGN16 unsigned char authTag[AES_BLOCK_SIZE];


### PR DESCRIPTION
# Description

   EVP handling of CHACHA20_POLY1305 improvemnt

    - save key at ctx for Init()s without IV
    - reuse stored key for Init()s with new IV, reusing ctx
    - free and zero key on ctx clenaup

# Testing

Added test in api.c

# Checklist

 - [ x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
