### PR TITLE
Check return from call to wc_Time

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -13727,6 +13727,12 @@ int wc_ValidateDate(const byte* date, byte format, int dateType)
     (void)tmpTime;
 
     ltime = wc_Time(0);
+    if (ltime < 0){
+        /* A negative response here could be due to a 32-bit time_t
+         * where the year is 2038 or later. */
+        WOLFSSL_MSG("wc_Time failed to return a valid value");
+        return 0;
+    }
 
 #ifdef WOLFSSL_BEFORE_DATE_CLOCK_SKEW
     if (dateType == BEFORE) {


### PR DESCRIPTION
# Description

`wc_ValidateDate` should check that the system time returned is a valid value (`>=0`). This can occur if a 32-bit clib time function is used after Jan. 19, 2038

Fixes zd14665

# Testing

* Install 32-bit lib:
`sudo apt-get install gcc-multilib`
* Build with:
`./configure --enable-debug --enable-32bit CFLAGS="-m32" LDFLAGS="-m32"`
`make && sudo make install`
* Set system clock to 2038 (I just used GUI clock settings)
* Run any cert verify app. I used wolfssl-examples/certmanager/certverify.c

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
