### PR TITLE
Add missing DN nid to work with PrintName()

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -5526,7 +5526,7 @@ static int X509PrintSerial_ex(WOLFSSL_BIO* bio, byte* serial, int sz,
 
         /* serial is larger than int size so print off hex values */
         if ((scratchLen = XSNPRINTF(
-                 scratch, MAX_WIDTH, "\n%*s", indent, ""))
+                 scratch, MAX_WIDTH, "%*s", indent, ""))
                 >= MAX_WIDTH) {
             WOLFSSL_MSG("buffer overrun");
             return WOLFSSL_FAILURE;
@@ -11937,6 +11937,10 @@ static int get_dn_attr_by_nid(int n, const char** buf)
         case NID_initials:
             str = "initials";
             len = 8;
+            break;
+        case NID_distinguishedName:
+            str = "DN";
+            len = 2;
             break;
         default:
             WOLFSSL_MSG("Attribute type not found");

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -798,7 +798,7 @@ enum
     NID_inhibit_any_policy = 168,      /* 2.5.29.54 */
     NID_tlsfeature = 1020,             /* id-pe 24 */
     NID_buildingName = 1494,
-
+    NID_distinguishedName = 25,
 
     NID_dnQualifier = 174,             /* 2.5.4.46 */
     NID_commonName = 14,               /* CN Changed to not conflict


### PR DESCRIPTION
# Description
get_dn_attr_by_nid() can now handle printing distinguished name entries of X509_NAME type 


# Testing

Using CRL Lenovo sent over 

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
