### PR TITLE
Fix for async session tickets

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -33462,7 +33462,12 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         et = (ExternalTicket*)ssl->session->ticket;
         it = (InternalTicket*)et->enc_ticket;
 
-        XMEMSET(et, 0, sizeof(*et));
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        if (ssl->error != WC_PENDING_E)
+    #endif
+        {
+            XMEMSET(et, 0, sizeof(*et));
+        }
 
         /* build internal */
         it->pv.major = ssl->version.major;

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -9127,8 +9127,13 @@ static int SendTls13NewSessionTicket(WOLFSSL* ssl)
         ssl->session->ticketNonce.len = DEF_TICKET_NONCE_SZ;
         ssl->session->ticketNonce.data[0] = 0;
     }
-    else
-        ssl->session->ticketNonce.data[0]++;
+    else 
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        if (ssl->error != WC_PENDING_E)
+    #endif
+    {
+            ssl->session->ticketNonce.data[0]++;
+    }
 
     if (!ssl->options.noTicketTls13) {
         if ((ret = CreateTicket(ssl)) != 0)


### PR DESCRIPTION
# Description

Fix for async session tickets.

Fixes ZD14420

# Testing

```
./configure --enable-all --enable-asynccrypt CFLAGS="-DWOLFSSL_NO_DEF_TICKET_ENC_CB" && make
./examples/server/server -v 4 -r &
./examples/client/client -v 4 -r
```


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
