### PR TITLE
20220831-analyzer-coddling

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -55082,6 +55082,7 @@ static void test_wolfSSL_dtls12_fragments_spammer(WOLFSSL* ssl)
     /* frag length */
     c32to24(30, b + idx);
     idx += 3;
+    (void)idx; /* inhibit clang-analyzer-deadcode.DeadStores */
 
     for (i = 0; i < DTLS_POOL_SZ * 2 && ret > 0;
             seq_number++, msg_number++, i++) {

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -35042,7 +35042,8 @@ static int ParseCRL_Extensions(DecodedCRL* dcrl, const byte* buf,
                         if (ret == 0) {
                             dcrl->crlNumber = 0;
                             for (i = 0; i < (*m).used; ++i) {
-                                if (i > (int)sizeof(word32)) {
+                                if (i > (CHAR_BIT *
+                                         (int)sizeof(word32) / DIGIT_BIT)) {
                                     break;
                                 }
                                 dcrl->crlNumber |= ((word32)(*m).dp[i]) <<

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -552,7 +552,7 @@ WC_STATIC WC_INLINE void ctMaskCopy(byte mask, byte* dst, byte* src,
 {
     int i;
     for (i = 0; i < size; ++i) {
-        dst[i] ^= (dst[i] ^ src[i]) & mask;
+        *(dst + i) ^= (*(dst + i) ^ *(src + i)) & mask;
     }
 }
 


### PR DESCRIPTION
analyzer coddling:

in api.c `test_wolfSSL_dtls12_fragments_spammer()`, inhibit `clang-analyzer-deadcode.DeadStores`;

in asn.c `ParseCRL_Extensions()` old (`!WOLFSSL_ASN_TEMPLATE`) version, fix bounds check to prevent overshift;

in misc.c `ctMaskCopy()`, use `*(x + i)`, not x[i], to tiptoe around cppcheck-2.9 `objectIndex` bug.

tested with `wolfssl-multi-test.sh super-quick-check cppcheck-all-async-quic`
