### PR TITLE
wolfio: fix some conversion warnings

### DIFF
--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -494,12 +494,12 @@ int EmbedReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     }
     else if (dtlsCtx->userSet) {
         /* Truncate peer size */
-        if (peerSz > sizeof(lclPeer))
+        if (peerSz > (XSOCKLENT)sizeof(lclPeer))
             peerSz = sizeof(lclPeer);
     }
     else {
         /* Truncate peer size */
-        if (peerSz > dtlsCtx->peer.bufSz)
+        if (peerSz > (XSOCKLENT)dtlsCtx->peer.bufSz)
             peerSz = dtlsCtx->peer.bufSz;
     }
 


### PR DESCRIPTION
# Description

Fixes a compile warning that results in an error on 32bit android builds
Almost identical to a previous issue https://github.com/wolfSSL/wolfssl/pull/5189

Fixes zd#

# Testing

Tested manually

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
