### PR TITLE
Add wolfSSL_EVP_PKEY_new_CMAC_key to OpenSSL compatible API

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -32956,6 +32956,7 @@ static int test_wolfSSL_EVP_PKEY_new_CMAC_key(void)
 
     AssertNotNull(key = wolfSSL_EVP_PKEY_new_CMAC_key(
         NULL, (const unsigned char *)priv, AES_128_KEY_SIZE, cipher));
+    wolfSSL_EVP_PKEY_free(key);
 
     printf(resultFmt, passed);
 #endif /* defined(WOLFSSL_CMAC) && !defined(NO_AES) && defined(WOLFSSL_AES_DIRECT) */

--- a/tests/api.c
+++ b/tests/api.c
@@ -32943,20 +32943,19 @@ static int test_wolfSSL_EVP_PKEY_new_CMAC_key(void)
 #if defined(WOLFSSL_CMAC) && !defined(NO_AES) && defined(WOLFSSL_AES_DIRECT)
 
     const char *priv = "ABCDEFGHIJKLMNOP";
-    int len = strlen(priv);
     const WOLFSSL_EVP_CIPHER* cipher = EVP_aes_128_cbc();
     WOLFSSL_EVP_PKEY* key = NULL;
     printf(testingFmt, "wolfSSL_EVP_PKEY_new_CMAC_key()");
 
     AssertNull(key = wolfSSL_EVP_PKEY_new_CMAC_key(
-        NULL, NULL, len, cipher));
+        NULL, NULL, AES_128_KEY_SIZE, cipher));
     AssertNull(key = wolfSSL_EVP_PKEY_new_CMAC_key(
         NULL, (const unsigned char *)priv, 0, cipher));
     AssertNull(key = wolfSSL_EVP_PKEY_new_CMAC_key(
-        NULL, (const unsigned char *)priv, len, NULL));
+        NULL, (const unsigned char *)priv, AES_128_KEY_SIZE, NULL));
 
     AssertNotNull(key = wolfSSL_EVP_PKEY_new_CMAC_key(
-        NULL, (const unsigned char *)priv, len, cipher));
+        NULL, (const unsigned char *)priv, AES_128_KEY_SIZE, cipher));
 
     printf(resultFmt, passed);
 #endif /* defined(WOLFSSL_CMAC) && !defined(NO_AES) && defined(WOLFSSL_AES_DIRECT) */

--- a/tests/api.c
+++ b/tests/api.c
@@ -32935,6 +32935,36 @@ static int test_wolfSSL_EVP_PKEY_new_mac_key(void)
 
     return 0;
 }
+
+
+static int test_wolfSSL_EVP_PKEY_new_CMAC_key(void)
+{
+#ifdef OPENSSL_EXTRA
+#if defined(WOLFSSL_CMAC) && !defined(NO_AES) && defined(WOLFSSL_AES_DIRECT)
+
+    const char *priv = "ABCDEFGHIJKLMNOP";
+    int len = strlen(priv);
+    const WOLFSSL_EVP_CIPHER* cipher = EVP_aes_128_cbc();
+    WOLFSSL_EVP_PKEY* key = NULL;
+    printf(testingFmt, "wolfSSL_EVP_PKEY_new_CMAC_key()");
+
+    AssertNull(key = wolfSSL_EVP_PKEY_new_CMAC_key(
+        NULL, NULL, len, cipher));
+    AssertNull(key = wolfSSL_EVP_PKEY_new_CMAC_key(
+        NULL, (const unsigned char *)priv, 0, cipher));
+    AssertNull(key = wolfSSL_EVP_PKEY_new_CMAC_key(
+        NULL, (const unsigned char *)priv, len, NULL));
+
+    AssertNotNull(key = wolfSSL_EVP_PKEY_new_CMAC_key(
+        NULL, (const unsigned char *)priv, len, cipher));
+
+    printf(resultFmt, passed);
+#endif /* defined(WOLFSSL_CMAC) && !defined(NO_AES) && defined(WOLFSSL_AES_DIRECT) */
+#endif /* OPENSSL_EXTRA */
+
+    return 0;
+}
+
 static int test_wolfSSL_EVP_Digest(void)
 {
 #if defined(OPENSSL_EXTRA) && !defined(NO_SHA256) && !defined(NO_PWDBASED)
@@ -57566,6 +57596,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_EVP_Digest),
     TEST_DECL(test_wolfSSL_EVP_Digest_all),
     TEST_DECL(test_wolfSSL_EVP_PKEY_new_mac_key),
+    TEST_DECL(test_wolfSSL_EVP_PKEY_new_CMAC_key),
     TEST_DECL(test_wolfSSL_EVP_MD_hmac_signing),
     TEST_DECL(test_wolfSSL_EVP_MD_rsa_signing),
     TEST_DECL(test_wolfSSL_EVP_MD_ecc_signing),

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -3420,6 +3420,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_EVP_PKEY_new_CMAC_key(WOLFSSL_ENGINE* e,
 
     ret = wolfSSL_CMAC_Init(ctx, priv, len, cipher, e);
     if (ret == WOLFSSL_FAILURE) {
+        wolfSSL_CMAC_CTX_free(ctx);
         WOLFSSL_LEAVE("wolfSSL_EVP_PKEY_new_CMAC_key", 0);
         return NULL;
     }
@@ -3440,6 +3441,9 @@ WOLFSSL_EVP_PKEY* wolfSSL_EVP_PKEY_new_CMAC_key(WOLFSSL_ENGINE* e,
             pkey->type = pkey->save_type = EVP_PKEY_CMAC;
             pkey->cmacCtx = ctx;
         }
+    }
+    else {
+        wolfSSL_CMAC_CTX_free(ctx);
     }
 
     WOLFSSL_LEAVE("wolfSSL_EVP_PKEY_new_CMAC_key", 0);

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -8868,6 +8868,16 @@ void wolfSSL_EVP_PKEY_free(WOLFSSL_EVP_PKEY* key)
                     break;
                 #endif /* HAVE_HKDF */
 
+                #if defined(WOLFSSL_CMAC) && !defined(NO_AES) && \
+                    defined(WOLFSSL_AES_DIRECT)
+                case EVP_PKEY_CMAC:
+                    if (key->cmacCtx != NULL) {
+                        wolfSSL_CMAC_CTX_free(key->cmacCtx);
+                        key->cmacCtx = NULL;
+                    }
+                    break;
+                #endif /* defined(WOLFSSL_CMAC) ... */
+
                 default:
                     break;
             }

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -3436,7 +3436,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_EVP_PKEY_new_CMAC_key(WOLFSSL_ENGINE* e,
             if (len) {
                 XMEMCPY(pkey->pkey.ptr, priv, len);
             }
-            pkey->pkey_sz = len;
+            pkey->pkey_sz = (int)len;
             pkey->type = pkey->save_type = EVP_PKEY_CMAC;
             pkey->cmacCtx = ctx;
         }

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -265,6 +265,7 @@ enum {
     NID_cast5_ofb64   = 111,
     EVP_PKEY_DH       = NID_dhKeyAgreement,
     EVP_PKEY_HMAC     = NID_hmac,
+    EVP_PKEY_CMAC     = NID_cmac,
     EVP_PKEY_HKDF     = NID_hkdf,
     EVP_PKEY_FALCON   = 300, /* Randomly picked value. */
     EVP_PKEY_DILITHIUM= 301, /* Randomly picked value. */
@@ -776,6 +777,11 @@ WOLFSSL_API int wolfSSL_EVP_PKEY_CTX_hkdf_mode(WOLFSSL_EVP_PKEY_CTX* ctx,
 /* EVP ENGINE API's */
 WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_EVP_PKEY_new_mac_key(int type, WOLFSSL_ENGINE* e,
                                           const unsigned char* key, int keylen);
+
+WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_EVP_PKEY_new_CMAC_key(WOLFSSL_ENGINE* e,
+                                          const unsigned char* priv, size_t len,
+                                          const WOLFSSL_EVP_CIPHER* cipher);
+
 WOLFSSL_API int wolfSSL_EVP_DigestInit_ex(WOLFSSL_EVP_MD_CTX* ctx,
                                      const WOLFSSL_EVP_MD* type,
                                      WOLFSSL_ENGINE *impl);
@@ -992,6 +998,7 @@ WOLFSSL_API int wolfSSL_EVP_SignInit_ex(WOLFSSL_EVP_MD_CTX* ctx,
 #define EVP_PKEY_get0_EC_KEY           wolfSSL_EVP_PKEY_get0_EC_KEY
 #define EVP_PKEY_get0_hmac             wolfSSL_EVP_PKEY_get0_hmac
 #define EVP_PKEY_new_mac_key           wolfSSL_EVP_PKEY_new_mac_key
+#define EVP_PKEY_new_CMAC_key          wolfSSL_EVP_PKEY_new_CMAC_key
 #define EVP_MD_CTX_copy                wolfSSL_EVP_MD_CTX_copy
 #define EVP_MD_CTX_copy_ex             wolfSSL_EVP_MD_CTX_copy_ex
 #define EVP_PKEY_sign_init             wolfSSL_EVP_PKEY_sign_init

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -89,6 +89,9 @@
     #ifndef WOLFCRYPT_ONLY
         #include <wolfssl/openssl/hmac.h>
     #endif
+    #if defined(WOLFSSL_CMAC) && !defined(NO_AES) && defined(WOLFSSL_AES_DIRECT)
+        #include <wolfssl/openssl/cmac.h>
+    #endif
 
     /* We need the old SSL names */
     #ifdef NO_OLD_SSL_NAMES
@@ -410,6 +413,9 @@ struct WOLFSSL_EVP_PKEY {
     byte* hkdfInfo;
     word32 hkdfInfoSz;
     int hkdfMode;
+    #endif
+    #if defined(WOLFSSL_CMAC) && !defined(NO_AES) && defined(WOLFSSL_AES_DIRECT)
+    WOLFSSL_CMAC_CTX* cmacCtx;
     #endif
 #endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
 #ifdef HAVE_ECC


### PR DESCRIPTION
# Description

This PR adds wolfSSL_EVP_PKEY_new_CMAC_key() to the OpenSSL compatible API.
Details:
- add CMAC_CTX parameter to EVP_PKEY structure, because CMAC generation needs CMAC_CTX.
- generate CMAC_CTX and register it to EVP_PKEY in wolfSSL_EVP_PKEY_new_CMAC_key().
  (It was created with reference to an existing API, wolfSSL_EVP_PKEY_new_mac_key())
- add a constant EVP_PKEY_CMAC.

wolfSSL_EVP_PKEY_new_CMAC_key() is for generating EVP_PKEY data having a CMAC key.
The generated EVP_PKEY is given to EVP_DigestSignInit().
And the following APIs are used for generating CMAC. 
 - EVP_DigestSignInit()
 - EVP_DigestSignUpdate()
 - EVP_DigestSignFinal()

# Testing

Built example app using wolfSSL_EVP_PKEY_new_CMAC_key() and ran it.
Checked if wolfSSL_EVP_PKEY_new_CMAC_key() returns EVP_PKEY structure
and if EVP_PKEY_id() can return EVP_PKEY_CMAC (==894).

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
