### PR TITLE
fix HashRaw WC_SHA256_DIGEST_SIZE for wc_Sha256GetHash

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -9053,7 +9053,7 @@ int HashRaw(WOLFSSL* ssl, const byte* data, int sz)
     #ifdef WOLFSSL_DEBUG_TLS
         WOLFSSL_MSG("Sha256");
         wc_Sha256GetHash(&ssl->hsHashes->hashSha256, digest);
-        WOLFSSL_BUFFER(digest, WC_SHA224_DIGEST_SIZE);
+        WOLFSSL_BUFFER(digest, WC_SHA256_DIGEST_SIZE);
     #endif
     #endif
     #ifdef WOLFSSL_SHA384


### PR DESCRIPTION


# Description

The current `HashRaw()` in `src/internal.c` incorrectly uses `WC_SHA224_DIGEST_SIZE` for `wc_Sha256GetHash`.

Please describe the scope of the fix or feature addition.

Anything using wolfSSL with `WOLFSSL_DEBUG_TLS` and `WOLFSSL_SHA224` turned on will see a different value for a SHA256 digest.

This also fixes a compile error, in my case for Espressif ESP32 that did not use the `WOLFSSL_SHA224`.

![image](https://user-images.githubusercontent.com/13059545/188250208-a1bd6e55-d9e6-4a5a-8691-bd4d881d3dbf.png)


Fixes zd#  n/a

# Testing

How did you test?

just a visual inspection when turning on `WOLFSSL_DEBUG_TLS` 

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
