### PR TITLE
fix: dtls13: do not negotiate ConnectionID in HelloRetryRequest

### DIFF
--- a/src/dtls.c
+++ b/src/dtls.c
@@ -240,8 +240,19 @@ int TLSX_ConnectionID_Parse(WOLFSSL* ssl, const byte* input, word16 length,
     }
 
     info = DtlsCidGetInfo(ssl);
-    if (info == NULL || info->tx != NULL)
+    if (info == NULL)
         return BAD_STATE_E;
+
+    /* it may happen if we process two ClientHello because the server sent an
+     * HRR request */
+    if (info->tx != NULL) {
+        if (ssl->options.side != WOLFSSL_SERVER_END &&
+            ssl->options.serverState != SERVER_HELLO_RETRY_REQUEST_COMPLETE)
+            return BAD_STATE_E;
+
+        XFREE(info->tx, ssl->heap, DYNAMIC_TYPE_TLSX);
+        info->tx = NULL;
+    }
 
     if (length < OPAQUE8_LEN)
         return BUFFER_ERROR;

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -4086,7 +4086,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     }
 
 #ifdef WOLFSSL_DTLS_CID
-    if (ssl->options.useDtlsCID)
+    if (ssl->options.useDtlsCID && *extMsgType == server_hello)
         DtlsCIDOnExtensionsParsed(ssl);
 #endif /* WOLFSSL_DTLS_CID */
 
@@ -5522,11 +5522,6 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         goto exit_dch;
     }
 
-#ifdef WOLFSSL_DTLS_CID
-    if (ssl->options.useDtlsCID)
-        DtlsCIDOnExtensionsParsed(ssl);
-#endif /* WOLFSSL_DTLS_CID */
-
 #ifdef HAVE_SNI
         if ((ret = SNI_Callback(ssl)) != 0)
             return ret;
@@ -5721,6 +5716,15 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         ssl->options.serverState = SERVER_HELLO_RETRY_REQUEST_COMPLETE;
     }
 #endif /* WOLFSSL_DTLS13 */
+
+#ifdef WOLFSSL_DTLS_CID
+    /* do not modify CID state if we are sending an HRR  */
+    if (ssl->options.useDtlsCID &&
+            ssl->options.serverState != SERVER_HELLO_RETRY_REQUEST_COMPLETE)
+        DtlsCIDOnExtensionsParsed(ssl);
+#endif /* WOLFSSL_DTLS_CID */
+
+
 
 exit_dch:
 


### PR DESCRIPTION
# Description

ConnectionID extension can be wrongly negotiated during an HelloRetryRequest. If it happens Client wrongly assumes that the Server doesn't support the extension.
Also, on the server side, don't error out if we parse the extensions twice if the server sent an HRR.


# Testing

`./configure --enable-dtls --enable-dtls13 --enable-dtlscid && make check`
