### PR TITLE
Added ARM poly1305 routine that uses NEON registers.  By using the re…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2000,19 +2000,6 @@ then
 fi
 
 
-AC_ARG_ENABLE([no-neon],
-    [AS_HELP_STRING([--enable-no-neon],[Enable wolfSSL ARMv8 ASM support (default: disabled). Set to sha512-crypto or sha3-crypto to use SHA512 and SHA3 instructions with Aarch64 CPU.])],
-    [ ENABLED_ARMASM_NO_NEON=$enableval ],
-    [ ENABLED_ARMASM_NO_NEON=no ]
-    )
-
-if test "$ENABLED_ARMASM_NO_NEON" != "no"
-then
-    AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_ARMASM_NO_NEON2"
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ARMASM_NO_NEON2"
-fi
-
-
 ENABLED_ARMASM_INLINE="no"
 ENABLED_ARMASM_SHA3="no"
 # ARM Assembly
@@ -2022,9 +2009,6 @@ AC_ARG_ENABLE([armasm],
     [ ENABLED_ARMASM=$enableval ],
     [ ENABLED_ARMASM=no ]
     )
-
-
-
 if test "$ENABLED_ARMASM" != "no" && test "$ENABLED_ASM" = "yes"
 then
 
@@ -2061,11 +2045,6 @@ then
         break;; #Do not override user set values
     *)
         case $host_cpu in
-	*arm*)
-	    ENABLED_ARM32ASM=yes
-	    ;;
-	esac
-	case $host_cpu in
         *aarch64*)
             case $host_os in
             *darwin*)
@@ -7974,7 +7953,6 @@ AM_CONDITIONAL([BUILD_SNIFFTEST],[ test "x$ENABLED_SNIFFTEST" = "xyes"])
 AM_CONDITIONAL([BUILD_AESGCM],[test "x$ENABLED_AESGCM" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_AESCCM],[test "x$ENABLED_AESCCM" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_ARMASM],[test "x$ENABLED_ARMASM" = "xyes"])
-AM_CONDITIONAL([BUILD_ARM32ASM],[test "x$ENABLED_ARM32ASM" = "xyes"])
 AM_CONDITIONAL([BUILD_ARMASM_INLINE],[test "x$ENABLED_ARMASM_INLINE" = "xyes"])
 AM_CONDITIONAL([BUILD_XILINX],[test "x$ENABLED_XILINX" = "xyes"])
 AM_CONDITIONAL([BUILD_AESNI],[test "x$ENABLED_AESNI" = "xyes"])

--- a/configure.ac
+++ b/configure.ac
@@ -2000,6 +2000,19 @@ then
 fi
 
 
+AC_ARG_ENABLE([no-neon],
+    [AS_HELP_STRING([--enable-no-neon],[Enable wolfSSL ARMv8 ASM support (default: disabled). Set to sha512-crypto or sha3-crypto to use SHA512 and SHA3 instructions with Aarch64 CPU.])],
+    [ ENABLED_ARMASM_NO_NEON=$enableval ],
+    [ ENABLED_ARMASM_NO_NEON=no ]
+    )
+
+if test "$ENABLED_ARMASM_NO_NEON" != "no"
+then
+    AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_ARMASM_NO_NEON2"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ARMASM_NO_NEON2"
+fi
+
+
 ENABLED_ARMASM_INLINE="no"
 ENABLED_ARMASM_SHA3="no"
 # ARM Assembly
@@ -2009,6 +2022,9 @@ AC_ARG_ENABLE([armasm],
     [ ENABLED_ARMASM=$enableval ],
     [ ENABLED_ARMASM=no ]
     )
+
+
+
 if test "$ENABLED_ARMASM" != "no" && test "$ENABLED_ASM" = "yes"
 then
 
@@ -2045,6 +2061,11 @@ then
         break;; #Do not override user set values
     *)
         case $host_cpu in
+	*arm*)
+	    ENABLED_ARM32ASM=yes
+	    ;;
+	esac
+	case $host_cpu in
         *aarch64*)
             case $host_os in
             *darwin*)
@@ -7953,6 +7974,7 @@ AM_CONDITIONAL([BUILD_SNIFFTEST],[ test "x$ENABLED_SNIFFTEST" = "xyes"])
 AM_CONDITIONAL([BUILD_AESGCM],[test "x$ENABLED_AESGCM" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_AESCCM],[test "x$ENABLED_AESCCM" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_ARMASM],[test "x$ENABLED_ARMASM" = "xyes"])
+AM_CONDITIONAL([BUILD_ARM32ASM],[test "x$ENABLED_ARM32ASM" = "xyes"])
 AM_CONDITIONAL([BUILD_ARMASM_INLINE],[test "x$ENABLED_ARMASM_INLINE" = "xyes"])
 AM_CONDITIONAL([BUILD_XILINX],[test "x$ENABLED_XILINX" = "xyes"])
 AM_CONDITIONAL([BUILD_AESNI],[test "x$ENABLED_AESNI" = "xyes"])

--- a/src/include.am
+++ b/src/include.am
@@ -485,7 +485,12 @@ if !BUILD_FIPS_RAND
 
 if BUILD_POLY1305
 if BUILD_ARMASM
+if !BUILD_ARM32ASM
 src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-poly1305.c
+endif
+if BUILD_ARM32ASM
+src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-poly1305.c
+endif
 endif
 src_libwolfssl_la_SOURCES += wolfcrypt/src/poly1305.c
 if BUILD_INTELASM

--- a/src/include.am
+++ b/src/include.am
@@ -485,8 +485,12 @@ if !BUILD_FIPS_RAND
 
 if BUILD_POLY1305
 if BUILD_ARMASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-poly1305.c
+if !BUILD_ARM32ASM
 src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-poly1305.c
+endif
+if BUILD_ARM32ASM
+src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-poly1305.c
+endif
 endif
 src_libwolfssl_la_SOURCES += wolfcrypt/src/poly1305.c
 if BUILD_INTELASM

--- a/src/include.am
+++ b/src/include.am
@@ -485,12 +485,8 @@ if !BUILD_FIPS_RAND
 
 if BUILD_POLY1305
 if BUILD_ARMASM
-if !BUILD_ARM32ASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-poly1305.c
-endif
-if BUILD_ARM32ASM
 src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-poly1305.c
-endif
+src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-poly1305.c
 endif
 src_libwolfssl_la_SOURCES += wolfcrypt/src/poly1305.c
 if BUILD_INTELASM

--- a/wolfcrypt/src/poly1305.c
+++ b/wolfcrypt/src/poly1305.c
@@ -221,6 +221,7 @@ extern void poly1305_final_avx2(Poly1305* ctx, byte* mac);
     }
 #endif/* WOLFSSL_ARMASM */
 #else /* if not 64 bit then use 32 bit */
+#ifndef WOLFSSL_ARMASM
 
     static word32 U8TO32(const byte *p)
     {
@@ -237,6 +238,7 @@ extern void poly1305_final_avx2(Poly1305* ctx, byte* mac);
         p[2] = (byte)((v >> 16) & 0xff);
         p[3] = (byte)((v >> 24) & 0xff);
     }
+#endif
 #endif
 
 
@@ -427,9 +429,9 @@ static int poly1305_block(Poly1305* ctx, const unsigned char *m)
     return poly1305_blocks(ctx, m, POLY1305_BLOCK_SIZE);
 #endif
 }
-#endif /* !defined(WOLFSSL_ARMASM) || !defined(__aarch64__) */
+#endif /* !WOLFSSL_ARMASM */
 
-#if !defined(WOLFSSL_ARMASM) || !defined(__aarch64__)
+#ifndef WOLFSSL_ARMASM
 int wc_Poly1305SetKey(Poly1305* ctx, const byte* key, word32 keySz)
 {
 #if defined(POLY130564) && !defined(USE_INTEL_SPEEDUP)
@@ -700,7 +702,7 @@ int wc_Poly1305Final(Poly1305* ctx, byte* mac)
 
     return 0;
 }
-#endif /* !defined(WOLFSSL_ARMASM) || !defined(__aarch64__) */
+#endif /* !WOLFSSL_ARMASM */
 
 
 int wc_Poly1305Update(Poly1305* ctx, const byte* m, word32 bytes)
@@ -795,7 +797,7 @@ int wc_Poly1305Update(Poly1305* ctx, const byte* m, word32 bytes)
         /* process full blocks */
         if (bytes >= POLY1305_BLOCK_SIZE) {
             size_t want = (bytes & ~(POLY1305_BLOCK_SIZE - 1));
-#if !defined(WOLFSSL_ARMASM) || !defined(__aarch64__)
+#ifndef WOLFSSL_ARMASM
             int ret;
             ret = poly1305_blocks(ctx, m, want);
             if (ret != 0)

--- a/wolfcrypt/src/poly1305.c
+++ b/wolfcrypt/src/poly1305.c
@@ -241,7 +241,6 @@ extern void poly1305_final_avx2(Poly1305* ctx, byte* mac);
 #endif
 #endif
 
-
 /* convert 32-bit unsigned to little endian 64 bit type as byte array */
 static WC_INLINE void u32tole64(const word32 inLe32, byte outLe64[8])
 {
@@ -259,20 +258,8 @@ static WC_INLINE void u32tole64(const word32 inLe32, byte outLe64[8])
 #endif
 }
 
-void armv8_32_poly1305_blocks(Poly1305* ctx, 
-			const unsigned char *msgData,
-                     	size_t msgDataLen);
 
-#if defined (WOLFSSL_ARMASM) && !defined(__aarch64__)
-static int poly1305_blocks(Poly1305* ctx, const unsigned char *m,
-                     size_t bytes)
-{
-	armv8_32_poly1305_blocks(ctx, m, bytes);
-	return 0;
-}
-#endif
-
-#if !defined(WOLFSSL_ARMASM)
+#ifndef WOLFSSL_ARMASM
 /*
 This local function operates on a message with a given number of bytes
 with a given ctx pointer to a Poly1305 structure.
@@ -280,7 +267,6 @@ with a given ctx pointer to a Poly1305 structure.
 static int poly1305_blocks(Poly1305* ctx, const unsigned char *m,
                      size_t bytes)
 {
-
 #ifdef USE_INTEL_SPEEDUP
     /* AVX2 is handled in wc_Poly1305Update. */
     SAVE_VECTOR_REGISTERS(return _svr_ret;);
@@ -347,6 +333,7 @@ static int poly1305_blocks(Poly1305* ctx, const unsigned char *m,
     word64 d0,d1,d2,d3,d4;
     word32 c;
 
+
     r0 = ctx->r[0];
     r1 = ctx->r[1];
     r2 = ctx->r[2];
@@ -365,7 +352,6 @@ static int poly1305_blocks(Poly1305* ctx, const unsigned char *m,
     h4 = ctx->h[4];
 
     while (bytes >= POLY1305_BLOCK_SIZE) {
-
         /* h += m[i] */
         h0 += (U8TO32(m+ 0)     ) & 0x3ffffff;
         h1 += (U8TO32(m+ 3) >> 2) & 0x3ffffff;
@@ -408,10 +394,6 @@ static int poly1305_blocks(Poly1305* ctx, const unsigned char *m,
 
 #endif /* end of 64 bit cpu blocks or 32 bit cpu */
 }
-#endif
-
-
-#if !defined(WOLFSSL_ARMASM) || !defined(__aarch64__)
 
 /*
 This local function is used for the last call when a message with a given
@@ -521,7 +503,7 @@ int wc_Poly1305SetKey(Poly1305* ctx, const byte* key, word32 keySz)
 }
 
 int wc_Poly1305Final(Poly1305* ctx, byte* mac)
-{ 
+{
 #ifdef USE_INTEL_SPEEDUP
 #elif defined(POLY130564)
 
@@ -895,7 +877,7 @@ int wc_Poly1305_EncodeSizes64(Poly1305* ctx, word64 aadSz, word64 dataSz)
 }
 #endif
 
-/*  Takes in an initialized Poly1305 struct that has a key loadedarm32_poly1305 and creates
+/*  Takes in an initialized Poly1305 struct that has a key loaded and creates
     a MAC (tag) using recent TLS AEAD padding scheme.
     ctx        : Initialized Poly1305 struct to use
     additional : Additional data to use

--- a/wolfcrypt/src/poly1305.c
+++ b/wolfcrypt/src/poly1305.c
@@ -239,6 +239,7 @@ extern void poly1305_final_avx2(Poly1305* ctx, byte* mac);
     }
 #endif
 
+
 /* convert 32-bit unsigned to little endian 64 bit type as byte array */
 static WC_INLINE void u32tole64(const word32 inLe32, byte outLe64[8])
 {
@@ -256,8 +257,20 @@ static WC_INLINE void u32tole64(const word32 inLe32, byte outLe64[8])
 #endif
 }
 
+void armv8_32_poly1305_blocks(Poly1305* ctx, 
+			const unsigned char *msgData,
+                     	size_t msgDataLen);
 
-#if !defined(WOLFSSL_ARMASM) || !defined(__aarch64__)
+#if defined (WOLFSSL_ARMASM) && !defined(__aarch64__)
+static int poly1305_blocks(Poly1305* ctx, const unsigned char *m,
+                     size_t bytes)
+{
+	armv8_32_poly1305_blocks(ctx, m, bytes);
+	return 0;
+}
+#endif
+
+#if !defined(WOLFSSL_ARMASM)
 /*
 This local function operates on a message with a given number of bytes
 with a given ctx pointer to a Poly1305 structure.
@@ -265,6 +278,7 @@ with a given ctx pointer to a Poly1305 structure.
 static int poly1305_blocks(Poly1305* ctx, const unsigned char *m,
                      size_t bytes)
 {
+
 #ifdef USE_INTEL_SPEEDUP
     /* AVX2 is handled in wc_Poly1305Update. */
     SAVE_VECTOR_REGISTERS(return _svr_ret;);
@@ -331,7 +345,6 @@ static int poly1305_blocks(Poly1305* ctx, const unsigned char *m,
     word64 d0,d1,d2,d3,d4;
     word32 c;
 
-
     r0 = ctx->r[0];
     r1 = ctx->r[1];
     r2 = ctx->r[2];
@@ -350,6 +363,7 @@ static int poly1305_blocks(Poly1305* ctx, const unsigned char *m,
     h4 = ctx->h[4];
 
     while (bytes >= POLY1305_BLOCK_SIZE) {
+
         /* h += m[i] */
         h0 += (U8TO32(m+ 0)     ) & 0x3ffffff;
         h1 += (U8TO32(m+ 3) >> 2) & 0x3ffffff;
@@ -392,6 +406,10 @@ static int poly1305_blocks(Poly1305* ctx, const unsigned char *m,
 
 #endif /* end of 64 bit cpu blocks or 32 bit cpu */
 }
+#endif
+
+
+#if !defined(WOLFSSL_ARMASM) || !defined(__aarch64__)
 
 /*
 This local function is used for the last call when a message with a given
@@ -501,7 +519,7 @@ int wc_Poly1305SetKey(Poly1305* ctx, const byte* key, word32 keySz)
 }
 
 int wc_Poly1305Final(Poly1305* ctx, byte* mac)
-{
+{ 
 #ifdef USE_INTEL_SPEEDUP
 #elif defined(POLY130564)
 
@@ -875,7 +893,7 @@ int wc_Poly1305_EncodeSizes64(Poly1305* ctx, word64 aadSz, word64 dataSz)
 }
 #endif
 
-/*  Takes in an initialized Poly1305 struct that has a key loaded and creates
+/*  Takes in an initialized Poly1305 struct that has a key loadedarm32_poly1305 and creates
     a MAC (tag) using recent TLS AEAD padding scheme.
     ctx        : Initialized Poly1305 struct to use
     additional : Additional data to use

--- a/wolfcrypt/src/port/arm/armv8-32-poly1305.c
+++ b/wolfcrypt/src/port/arm/armv8-32-poly1305.c
@@ -1,0 +1,1230 @@
+/*****************************************************************
+
+   The test data in this code matches the test data in RFC 7539.
+
+   The poly1305 algorithm takes two inputs, they are as follows.
+	1. the message data
+	2. a 256 bit key
+   The algorithm outputs a 16 byte authentication value.
+  
+   The 16 bytes are transmitted with the message.  
+   The receiving side runs the poly1305 algorithm and 
+   compares the 16 byte result on the receiving side to
+   16 bytes sent with the message.  If the two 16 byte
+   values match, then the message is authenticated.
+
+   The poly1305 algorithm requires a unique 256 bit key
+   for each message.  The sender and receiver keys must
+   stay in sync. This means that a pseudo random key must 
+   be generated on both sides using the same algorithm 
+   and the same initial key.
+  
+   It is common to use the ChaCha20 algorithm to generate
+   the pseudo random key.  The initial 256 bit key is normally
+   shared during the setup up of the connection between 
+   sender and receiver.	
+
+   The 256 bit key is broken down into two 128 bit parts; 
+   namely r and s.  In the algorithm, r is clamped, meaning
+   certain bits are set to zero.  According to the RFC, r can
+   remain the same between runs of the algorithm, but s must 
+   always change.  Therefore the ChaCha20 solution mentioned 
+   above could be used to generate a 128 bit or 256 bit unique
+   key each time. 
+
+   This code was compiled and tested with the following tool chain.
+
+	gcc-arm-10.2-2020.11-aarch64-arm-none-linux-guneabihf
+
+   The development environment was Ubunutu, image file
+	
+	libre-computer-aml-s905x-cc-ubuntu-bionic-mate-mali-4.19.55+-2019-06-24.img 
+
+   In order the run the resulting executable the 32 bit libs must
+   be added to the system.  The following commands accomplish this.
+
+	sudo dpkg --add-architecture armhf
+	sudo apt-get update
+	sudo apt-get install libc6:armhf libstdc++6:armhf
+
+*****************************************************************/
+
+
+/* if building as a standalone to match the RFC 7539 
+   Be sure to pass gcc "-D POLY1305_STAND_ALONE". */
+#ifdef POLY1305_STAND_ALONE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stddef.h>
+
+typedef struct poly1305_struct
+{
+    unsigned r[5];
+    unsigned h[5];
+    unsigned finished;
+} Poly1305;
+
+#define WOLFSSL_ARMASM		1
+/* leave __aarch64__ undefined */
+#define POLY1305_VERBOSE 	1
+#else
+
+#ifdef WOLFSSL_ARMASM
+#ifndef __aarch64__
+/* these includes are technically not necessary */
+#include <wolfssl/wolfcrypt/settings.h>
+
+#include <stdint.h>
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif /* HAVE_CONFIG_H */
+#include <wolfssl/wolfcrypt/settings.h>
+
+#include <wolfssl/wolfcrypt/poly1305.h>
+#include <stddef.h>
+
+#endif
+#endif
+
+#endif
+
+
+#ifdef WOLFSSL_ARMASM
+#ifndef __aarch64__
+
+
+/**********************************************************
+  armv8_32_poly1305_blocks	This routine implements the 
+			poly1305 algorithm.  The processing
+			of the 16 byte pieces of the 
+			message is implemented in assembly.
+			Care was taken in implementing the
+			assembly to optimize speed by 
+			minimizing memory references as
+			well as minimizing instructions.
+			The poly1305 algorithm is implemented
+			by using multiple 26 bit values 
+			to represent the larger 16 byte and 
+			17 byte numbers.  Breaking the 
+			larger numbers down into 26 bit 
+			pieces means that math operations will
+			not overflow the 32 bit registers.
+			For more information reference the article 
+			NEON Cryto by Daniel Berstein and Peter
+			Schwabe.
+
+  ctx			poly1305 structure containing the r and
+		 	h values broke into 26 bit pieces.
+			The result of this routine is returned
+			int the h array of 26 bit values.
+  msgData		Message data to run the algorithm 
+			against.
+  keyData		256 bit key that is broken down 
+			into the r and s subcomponents.
+**********************************************************/
+/* variable assembly code creates on stack */
+
+#define BYTES_SP_OFF		20
+#define HIBIT_LOCAL_SP_OFF	24
+
+void armv8_32_poly1305_blocks(Poly1305* ctx, 
+			const unsigned char *msgData,
+                     	size_t msgDataLen);
+
+/* WOLFSSL_ARMASM_NO_NEON is used in armv8-32-sha512-asm.S */
+#ifdef WOLFSSL_ARMASM_NO_NEON2
+void armv8_32_poly1305_blocks(Poly1305* ctx, 
+			const unsigned char *msgData,
+                     	size_t msgDataLen)
+{
+	/* these variables will be referenced via r7 in the assembly */
+	unsigned r[5], *r_ptrLocal, h[5], *h_ptrLocal;
+	unsigned msgDataOnStack = (unsigned)msgData;
+	unsigned msgDataLenOnStack = msgDataLen;
+ 	unsigned hibitOnStack = (ctx->finished) ? 0 : ((unsigned) 1 << 24); /* 1 << 128 */
+
+	memcpy(r, ctx->r, 5 * sizeof(unsigned));
+	memcpy(h, ctx->h, 5 * sizeof(unsigned));
+
+	/* 32 bit pointer, this is necessary to pass the pointer value
+           into the assembly code */
+	r_ptrLocal = (unsigned *) r;
+	h_ptrLocal = (unsigned *) h;
+
+#ifdef POLY1305_VERBOSE
+	int i;
+	for (i=0;i<5;++i) printf("h%d %07X ", i, h[i]);
+	printf("\n");
+
+	printf("armv8_32_poly1305_blocks() data len %d\n", msgDataLen);
+#endif
+
+	__asm__ __volatile__ (
+		".align	8				\n\t"
+		
+		/* valid registers are r0..r12, sp, lr, pc, cpsr, fpscr */
+		
+		/* now load the stored h, this should all zero */
+		"LDR	r5, %[h_ptr]			\n\t"
+		"LDM	r5, { r6, r8, r9, r10, r11 }	\n\t"
+		/* r6 = h0  r8 = h1  r9 = h2  r10 = h3  r11 = h4 */
+	
+		/* in some cases, r7 is used to reference the local variables 
+		   on the stack; if -O2 is passed to gcc, the sp may used 
+	     	   used to reference local variables. */
+		"LDR 	r0, %[bytes]			\n\t"
+		"LDR 	r1, %[r_ptr]			\n\t"
+		"LDR	r2, %[hibit]			\n\t"
+		"LDR	r5, %[m]			\n\t"
+
+		"PUSH	{ r7 }				\n\t"
+		"SUB	sp, #28				\n\t"
+		
+		/* -O2 gcc parameters means r7 is not used for local
+                   variables, but sp is used for local variables */
+		/* free up r7 by moving variables referenced
+		   via r7 to recently allocated stack space */
+		"STR	r0, [sp, %[BYTES_STORE]]	\n\t"
+		"STR	r2, [sp, %[HIBIT_LOCAL]]	\n\t"
+
+		"LDM	r1, { r0, r1, r2, r3, r4 }	\n\t"
+		"STM	sp, { r0, r1, r2, r3, r4 }	\n\t"
+
+		"MOV	r7, r5				\n\t"
+
+	"armv8_32_poly1305_loop:				\n\t"
+
+		/* The poly1305 algorithm requires that a 01 byte 
+		   be placed after the last byte of the block. */ 		
+		
+		"LDR	r5, [sp, %[BYTES_STORE]]	\n\t"  // mem 1
+		"CMP	r5, #0				\n\t"
+		"BEQ	armv8_32_poly1305_done		\n\t"
+		"SUBS 	r5, r5, #16			\n\t"
+		
+		/* branch for least likely case, may help with pipelining */
+		/* ARMv8 uses predictive pipelining.  There is no way
+		   to specify in the instruction encoding the more likely
+		   case.  */
+		"BLT	armv8_32_poly1305_last_block	\n\t"  
+
+		/* this block is 16 bytes */
+		"STR	r5, [sp, %[BYTES_STORE]]	\n\t"  // mem 2
+
+		/* load next 16 byte block of message */		
+		"LDM	r7, { r0, r1, r2, r3 }		\n\t"  // mem 3
+		"ADD	r7, r7, #16			\n\t"
+
+		/* in RFC 7539, each block processed is prepended by
+  		   a byte of value 0x01.  In the wolfSSL implementation,
+		   the setting of this value is based on the value found
+		   in ctx->finish. To save a memory reference, this code
+		   could be replicated one version adding the byte, one
+		   version not. */
+
+		/* This is byte 16, past the 128 bits of w19:w18:w17:w16 
+		   Hence, update is done to h4. */  
+		"LDR	r5, [sp, %[HIBIT_LOCAL]]	\n\t"	// mem 4
+		"ADD	r11, r11, r5 			\n\t"
+			
+	"armv8_32_poly1305_done_01_byte_appended:	\n\t"
+
+		"mov	r5, #0x3FFFFFF			\n\t"
+
+		/* break data into 26 bit pieces. 
+		   Bit offsets are 0, 26, 52, 78 and 104 */
+		   
+		/* h0 += r0 & 0x3FFFFFF; */
+		"AND	r12, r0, r5			\n\t"
+		"ADD	r6, r6, r12			\n\t"
+		/* h1 += (r1:r0 >> 26) & 0x3FFFFFF */
+		"LSR	r12, r0, #26			\n\t"	/* 26 */
+		"ADD	r12, r12, r1, LSL #6		\n\t"
+		"AND 	r12, r12, r5			\n\t"
+		"ADD	r8, r8, r12			\n\t"
+		/* h2 += (r2:r1 >> 20) & 0x3FFFFFF */
+		"LSR	r12, r1, #20			\n\t"   /* 20+32 = 52 */
+		"ADD	r12, r12, r2, LSL #12		\n\t"
+		"AND 	r12, r12, r5			\n\t"
+		"ADD	r9, r9, r12			\n\t"
+		/* h3 += (r3:r2 >> 14) & 0x3FFFFFF */
+		"LSR	r12, r2, #14			\n\t"	/* 14+32+32 = 78 */
+		"ADD	r12, r12, r3, LSL #18		\n\t"
+		"AND 	r12, r12, r5			\n\t"
+		"ADD	r10, r10, r12			\n\t"
+		/* h4 += r3 >> 8	           */
+		"ADD	r11, r11, r3, LSR #8		\n\t"	/* 8+32+32+32 = 104 */
+
+		/* pull in the 26 bit components of the r key */
+		"LDM	sp, { r0, r1, r2, r3, r4 } 	\n\t"	// mem 5
+		/* r0 = BED685  r1 = 3555502  r2 = 47C036  r3 = 1003949  r4 = 806D5 */
+		
+		"MOV	r5, #5				\n\t"
+
+	"checkRegs:					\n\t"
+		/* d0 = h0 * r0 + h1 * 5*r4 + h2 * 5*r3 + h3 * 5*r2 + h4 * 5*r1 */
+		/* d1 = h0 * r1 + h1 * r0   + h2 * 5*r4 + h3 * 5*r3 + h4 * 5*r2 */
+		/* d2 = h0 * r2 + h1 * r1   + h2 * r0   + h3 * 5*r4 + h4 * 5*r3 */
+		/* d3 = h0 * r3 + h1 * r2   + h2 * r1   + h3 * r0   + h4 * 5*r4 */
+		/* d4 = h0 * r4 + h1 * r3   + h2 * r2   + h3 * r1   + h4 * r0   */
+
+		/*  r14 is the link register, r13 is the sp */
+		/*  r14:r12 = r6 * r0 + (r8 * r4 +  r9 * r3 +  r10 * r2 +  r11 * r1) * r5 */
+		/*  r14:r12 = r6 * r1 +  r8 * r0 + (r9 * r4 +  r10 * r3 +  r11 * r2) * r5 */
+		/*  r14:r12 = r6 * r2 +  r8 * r1 +  r9 * r0 + (r10 * r4 +  r11 * r3) * r5 */
+		/*  r14:r12 = r6 * r3 +  r8 * r2 +  r9 * r1 +  r10 * r0 + (r11 * r4) * r5 */
+		/*  r14:r12 = r6 * r4 +  r8 * r3 +  r9 * r2 +  r10 * r1 +  r11 * r0       */
+
+		/* d4 */
+		"UMULL	r12, r14, r6, r4		\n\t"
+		"UMLAL 	r12, r14, r8, r3		\n\t"
+		"UMLAL 	r12, r14, r9, r2		\n\t"
+		"UMLAL 	r12, r14, r10, r1		\n\t"
+		"UMLAL 	r12, r14, r11, r0		\n\t"
+
+		"PUSH   { r12, r14 }			\n\t"	// mem 6
+
+		/* 8F852 C3AB3DA1 */
+
+		/* d3 */
+		"UMULL	r12, r14, r6, r3		\n\t"
+		"UMLAL 	r12, r14, r8, r2		\n\t"
+		"UMLAL 	r12, r14, r9, r1		\n\t"
+		"UMLAL 	r12, r14, r10, r0		\n\t"
+		"MUL	r11, r11, r5			\n\t"
+		"UMLAL 	r12, r14, r11, r4		\n\t"
+
+		"PUSH   { r12, r14 }			\n\t"	// mem 7
+
+		/* C753B 56120E14 */
+
+		/* d2 */
+		"UMULL	r12, r14, r6, r2		\n\t"
+		"UMLAL 	r12, r14, r8, r1		\n\t"
+		"UMLAL 	r12, r14, r9, r0		\n\t"
+		"MUL	r10, r10, r5			\n\t"
+		"UMLAL 	r12, r14, r10, r4		\n\t"
+		"UMLAL 	r12, r14, r11, r3		\n\t"
+
+		"PUSH   { r12, r14 }			\n\t"	// mem 8
+
+		/* 10019D F79AAF81 */
+
+		/* d1 */
+		"UMULL	r12, r14, r6, r1		\n\t"
+		"UMLAL 	r12, r14, r8, r0		\n\t"
+		"MUL	r9, r9, r5			\n\t"
+		"UMLAL 	r12, r14, r9, r4		\n\t"
+		"UMLAL 	r12, r14, r10, r3		\n\t"
+		"UMLAL 	r12, r14, r11, r2		\n\t"
+
+		"PUSH   { r12, r14 }			\n\t"	// mem 9
+
+		/* D3993 E9038575 */
+
+		/* d0 */
+		"UMULL	r12, r14, r6, r0		\n\t"
+		"MUL	r8, r8, r5			\n\t"
+		"UMLAL 	r12, r14, r8, r4		\n\t"
+		"UMLAL 	r12, r14, r9, r3		\n\t"
+		"UMLAL 	r12, r14, r10, r2		\n\t"
+		"UMLAL 	r12, r14, r11, r1		\n\t"
+
+		/* 29DD73 07661C87 */
+
+
+		/* registers r6, r8, r9, r10, r11 must be 
+		   populated with above results after accounting 
+		   for overflow past 26 bit. */
+
+		/* doing d0 --> d1 --> d2 --> d3 --> d4 --> d1 -->d2 */
+
+		"MOV	r5, #0x3FFFFFF			\n\t"
+		"AND	r6, r12, r5			\n\t"	/* d0 */
+
+		/* d0 overflow to d1 */
+		"POP	{ r0, r1, r2, r3, r4, r9, r10, r11 }	\n\t"	// mem 10
+
+		"ADDS	r0, r0, r12, LSR #26		\n\t"
+		"ADC	r1, r1, #0			\n\t"
+		"ADDS	r0, r0, r14, LSL #6		\n\t"
+		"ADC	r1, r1, #0			\n\t"
+
+		"AND	r8, r0, r5			\n\t"   /* d1 */
+
+		/* d1 overflow to d2 */
+
+		"ADDS	r2, r2, r0, LSR #26		\n\t"
+		"ADC	r3, r3, #0			\n\t"
+		"ADDS	r2, r2, r1, LSL #6		\n\t"
+		"ADC	r3, r3, #0			\n\t"
+
+		"MOV    r0, r9				\n\t"
+
+		"AND	r9, r2, r5			\n\t"	/* d2 */
+
+		/* d2 overflow to d3 */
+
+		"ADDS	r4, r4, r2, LSR #26		\n\t"
+		"ADC	r0, r0, #0			\n\t"
+		"ADDS	r4, r4, r3, LSL #6		\n\t"
+		"ADC	r0, r0, #0			\n\t"
+
+		/* d3 overflow to d4 */
+
+		"ADDS	r10, r10, r4, LSR #26		\n\t"
+		"ADC	r11, r11, #0			\n\t"
+		"ADDS	r10, r10, r0, LSL #6		\n\t"
+		"ADC	r11, r11, #0			\n\t"
+
+		/* d4 overflow to d0, must be multiplied by 5 */	
+
+		"LSR	r0, r10, #26			\n\t"
+		"ADD	r0, r0, r11, LSL #6		\n\t"
+		"MOV	r1, #5				\n\t"	
+		"MUL	r0, r0, r1			\n\t"
+		"ADD	r6, r6, r0			\n\t"
+
+		"AND	r11, r10, r5			\n\t"	/* d4 */
+
+		"AND	r10, r4, r5			\n\t"	/* d3 */
+
+		/* d0 overflow to d1 */
+
+		"ADD	r8, r8, r6, LSR #26		\n\t"	/* d1 done */
+
+		"AND	r6, r6, r5			\n\t"	/* d0 done */	
+
+		"B	armv8_32_poly1305_loop		\n\t"
+	
+	"armv8_32_poly1305_last_block:			\n\t"
+
+		/* This is the last block of the message
+		   and the block is less than 16 bytes */
+		"MOV 	r0, #0				\n\t"
+		"STR	r0, [sp, %[BYTES_STORE]]	\n\t"
+	
+		"LDR	r0, [sp, %[HIBIT_LOCAL]]	\n\t"
+
+		/* Make sure the upper bytes of the 
+		   32 bit pieces are set to zero. 
+		   Set the byte past the last message
+		   data byte to 01. */
+
+		"PUSH	{ r4, r6, r8 } 			\n\t"	
+
+		"MOV    r1,  #0				\n\t"
+		"MOV	r2,  #0				\n\t"
+		"MOV	r3,  #0				\n\t"
+		"MOV	r4,  #0xFFFFFFFF		\n\t"
+		"LSR	r0, r0, #24			\n\t"
+		"MOV	r6,  r0				\n\t"
+
+		/* always going to load at least one */		
+		"LDR	r0, [r7]			\n\t"
+
+		/* byte offset to bit offset */ 
+		"ADD	r5, r5, #16			\n\t"
+		"LSL	r5, r5, #3			\n\t"			
+
+		/* which block */
+		"CMP	r5, #32				\n\t"
+		"BGE	not_word_0			\n\t"
+
+		/* case word 0 */
+	"case0:"
+		"LSL	r8, r4, r5			\n\t"
+		"BIC  	r0, r0, r8			\n\t"
+		"LSL	r8, r6, r5			\n\t"
+		"ADD	r0, r0, r8			\n\t"
+		"B	last_block_done			\n\t"
+
+	"not_word_0:	 				\n\t"
+		"LDR	r1, [r7, #4]			\n\t"
+		
+		"SUB	r5, r5, #32			\n\t"
+		"CMP	r5, #32				\n\t"
+		"BGE	not_word_1			\n\t"
+
+		"LSL	r8, r4, r5			\n\t"
+		"BIC  	r1, r1, r8			\n\t"
+		"LSL	r8, r6, r5			\n\t"
+		"ADD	r1, r1, r8			\n\t"		
+		"B	last_block_done			\n\t"
+
+	"not_word_1:					\n\t"
+		"LDR	r2, [r7, #8]			\n\t"
+
+		"SUB	r5, r5, #32			\n\t"
+		"CMP	r5, #32				\n\t"
+		"BGE	not_word_2			\n\t"
+
+		"LSL	r8, r4, r5			\n\t"
+		"BIC  	r2, r2, r8			\n\t"
+		"LSL	r8, r6, r5			\n\t"
+		"ADD	r2, r2, r8			\n\t"		
+		"B	last_block_done			\n\t"
+
+	"not_word_2:					\n\t"
+		"LDR	r3, [r7, #0xC]			\n\t"
+
+		"SUB	r5, r5, #32			\n\t"
+
+		"LSL	r8, r4, r5			\n\t"
+		"BIC  	r3, r3, r8			\n\t"
+		"LSL	r8, r6, r5			\n\t"
+		"ADD	r3, r3, r8			\n\t"	
+
+	"last_block_done:				\n\t"
+
+		"POP	{ r4, r6, r8 } 			\n\t"	
+	
+		"b 	armv8_32_poly1305_done_01_byte_appended \n\t"
+	
+		".align 2 \n\t"
+	"armv8_32_poly1305_done:				\n\t"
+
+		"ADD	sp, #28				\n\t"
+		"POP	{ r7 }				\n\t"
+
+		/* store final result */
+		"LDR	r0, %[h_ptr]			\n\t"
+		"STM	r0, { r6, r8, r9, r10, r11 } 	\n\t"
+		
+		: [m] 		  "+m" (msgDataOnStack),	/* input */
+		  [r_ptr]  	  "+m" (r_ptrLocal),		/* input */
+		  [h_ptr]  	  "+m" (h_ptrLocal),		/* input, output */
+		  [bytes]  	  "+m" (msgDataLenOnStack),	/* input */
+		  [hibit]	  "+m" (hibitOnStack)		/* input */
+		  
+		: [BYTES_STORE]    "I" (BYTES_SP_OFF),
+		  [HIBIT_LOCAL]    "I" (HIBIT_LOCAL_SP_OFF)
+		: "memory", "cc", 
+			"r0", "r1", "r2", "r3", "r4", "r5", "r6", "r8", "r9", "r10",
+			"r11", "r12", "lr"
+	);
+
+	memcpy(ctx->r, r, 5 * sizeof(unsigned));
+	memcpy(ctx->h, h, 5 * sizeof(unsigned));
+
+#ifdef POLY1305_VERBOSE
+	for (i=0;i<5;++i) printf("h%d %07X ", i, ctx->h[i]);
+	printf("\n");
+
+	printf("armv8_32_poly1305_blocks() leaving\n");
+#endif
+
+}
+#else
+
+/**********************************************************
+  armv8_32_poly1305_blocks	This routine implements the 
+			poly1305 algorithm.  The processing
+			of the 16 byte pieces of the 
+			message is implemented in assembly.
+			Care was taken in implementing the
+			assembly to optimize speed by 
+			minimizing memory references as
+			well as minimizing instructions.
+			The poly1305 algorithm is implemented
+			by using multiple 26 bit values 
+			to represent the larger 16 byte and 
+			17 byte numbers.  Breaking the 
+			larger numbers down into 26 bit 
+			pieces means that math operations will
+			not overflow the 32 bit registers.
+			For more information reference the article 
+			NEON Cryto by Daniel Berstein and Peter
+			Schwabe.
+			
+			This version of the algorithm uses 
+			NEON s registers to temporarily store
+			values so that the stack does not need
+			to be used.
+
+  ctx			poly1305 structure containing the r and
+		 	h values broke into 26 bit pieces.
+			The result of this routine is returned
+			int the h array of 26 bit values.
+  msgData		Message data to run the algorithm 
+			against.
+  keyData		256 bit key that is broken down 
+			into the r and s subcomponents.
+**********************************************************/
+void armv8_32_poly1305_blocks(Poly1305* ctx, 
+			const unsigned char *msgData,
+                     	size_t msgDataLen)
+{
+	/* these variables will be referenced via r7 in the assembly */
+	unsigned r[5], *r_ptrLocal, h[5], *h_ptrLocal;
+	unsigned msgDataOnStack = (unsigned)msgData;
+	unsigned msgDataLenOnStack = msgDataLen;
+ 	unsigned hibitOnStack = (ctx->finished) ? 0 : ((unsigned) 1 << 24); /* 1 << 128 */
+
+	memcpy(r, ctx->r, 5 * sizeof(unsigned));
+	memcpy(h, ctx->h, 5 * sizeof(unsigned));
+
+	/* 32 bit pointer, this is necessary to pass the pointer value
+           into the assembly code */
+	r_ptrLocal = (unsigned *) r;
+	h_ptrLocal = (unsigned *) h;
+
+#ifdef POLY1305_VERBOSE
+	int i;
+	for (i=0;i<5;++i) printf("h%d %07X ", i, h[i]);
+	printf("\n");
+
+	printf("armv8_32_poly1305_blocks() data len %d\n", msgDataLen);
+#endif
+
+	__asm__ __volatile__ (
+		".align	8				\n\t"
+		
+		/* valid registers are r0..r12, sp, lr, pc, cpsr, fpscr */
+		
+		/* now load the stored h, this should all zero */
+		"LDR	r5, %[h_ptr]			\n\t"
+		"LDM	r5, { r6, r8, r9, r10, r11 }	\n\t"
+		/* r6 = h0  r8 = h1  r9 = h2  r10 = h3  r11 = h4 */
+	
+		/* in some cases, r7 is used to reference the local variables 
+		   on the stack; if -O2 is passed to gcc, the sp may used 
+	     	   used to reference local variables. */
+		"LDR	r0, %[hibit]			\n\t"
+		"LDR 	r1, %[bytes]			\n\t"
+		"LDR 	r2, %[r_ptr]			\n\t"
+
+		"VMOV	s2, r0				\n\t"
+		"VMOV   s4, r1				\n\t"
+
+		"LDM	r2, { r0, r1, r2, r3, r4 }	\n\t"
+		"VMOV	s6, r0				\n\t"
+		"VMOV	s7, r1				\n\t"
+		"VMOV	s8, r2				\n\t"
+		"VMOV	s9, r3				\n\t"
+		"VMOV	s10, r4				\n\t"
+
+		"LDR	r5, %[m]			\n\t"
+		"PUSH	{ r7 }				\n\t"
+		"MOV	r7, r5				\n\t"
+
+		/* s2 - hibit
+	 	   s4 - bytes
+	           s6, s7, s8, s9, s10 - r in 26 bit pieces */
+
+	"armv8_32_poly1305_loop:				\n\t"
+
+		/* The poly1305 algorithm requires that a 01 byte 
+		   be placed after the last byte of the block. */ 		
+		
+		"VMOV	r5, s4				\n\t"
+		"CMP	r5, #0				\n\t"
+		"BEQ	armv8_32_poly1305_done		\n\t"
+		"SUBS 	r5, r5, #16			\n\t"
+		
+		/* branch for least likely case, may help with pipelining */
+		/* ARMv8 uses predictive pipelining.  There is no way
+		   to specify in the instruction encoding the more likely
+		   case.  */
+		"BLT	armv8_32_poly1305_last_block	\n\t"  
+
+		/* this block is 16 bytes */
+		"VMOV	s4, r5				\n\t"
+
+		/* load next 16 byte block of message */		
+		"LDM	r7, { r0, r1, r2, r3 }		\n\t"  // mem 1
+		"ADD	r7, r7, #16			\n\t"
+
+		/* in RFC 7539, each block processed is prepended by
+  		   a byte of value 0x01.  In the wolfSSL implementation,
+		   the setting of this value is based on the value found
+		   in ctx->finish. To save a memory reference, this code
+		   could be replicated one version adding the byte, one
+		   version not. */
+
+		/* This is byte 16, past the 128 bits of w19:w18:w17:w16 
+		   Hence, update is done to h4. */  
+		/* add in hibit */
+		"VMOV	r5, s2				\n\t"
+		"ADD	r11, r11, r5 			\n\t"
+			
+	"armv8_32_poly1305_done_01_byte_appended:	\n\t"
+
+		"mov	r5, #0x3FFFFFF			\n\t"
+
+		/* break data into 26 bit pieces. 
+		   Bit offsets are 0, 26, 52, 78 and 104 */
+		   
+		/* h0 += r0 & 0x3FFFFFF; */
+		"AND	r12, r0, r5			\n\t"
+		"ADD	r6, r6, r12			\n\t"
+		/* h1 += (r1:r0 >> 26) & 0x3FFFFFF */
+		"LSR	r12, r0, #26			\n\t"	/* 26 */
+		"ADD	r12, r12, r1, LSL #6		\n\t"
+		"AND 	r12, r12, r5			\n\t"
+		"ADD	r8, r8, r12			\n\t"
+		/* h2 += (r2:r1 >> 20) & 0x3FFFFFF */
+		"LSR	r12, r1, #20			\n\t"   /* 20+32 = 52 */
+		"ADD	r12, r12, r2, LSL #12		\n\t"
+		"AND 	r12, r12, r5			\n\t"
+		"ADD	r9, r9, r12			\n\t"
+		/* h3 += (r3:r2 >> 14) & 0x3FFFFFF */
+		"LSR	r12, r2, #14			\n\t"	/* 14+32+32 = 78 */
+		"ADD	r12, r12, r3, LSL #18		\n\t"
+		"AND 	r12, r12, r5			\n\t"
+		"ADD	r10, r10, r12			\n\t"
+		/* h4 += r3 >> 8	           */
+		"ADD	r11, r11, r3, LSR #8		\n\t"	/* 8+32+32+32 = 104 */
+
+		/* pull in the 26 bit components of the r key */
+		"VMOV	r0, s6				\n\t"
+		"VMOV	r1, s7				\n\t"
+		"VMOV	r2, s8				\n\t"
+		"VMOV	r3, s9				\n\t"
+		"VMOV	r4, s10				\n\t"
+
+		/* r0 = BED685  r1 = 3555502  r2 = 47C036  r3 = 1003949  r4 = 806D5 */
+		"MOV	r5, #5				\n\t"
+
+	"checkRegs:					\n\t"
+		/* d0 = h0 * r0 + h1 * 5*r4 + h2 * 5*r3 + h3 * 5*r2 + h4 * 5*r1 */
+		/* d1 = h0 * r1 + h1 * r0   + h2 * 5*r4 + h3 * 5*r3 + h4 * 5*r2 */
+		/* d2 = h0 * r2 + h1 * r1   + h2 * r0   + h3 * 5*r4 + h4 * 5*r3 */
+		/* d3 = h0 * r3 + h1 * r2   + h2 * r1   + h3 * r0   + h4 * 5*r4 */
+		/* d4 = h0 * r4 + h1 * r3   + h2 * r2   + h3 * r1   + h4 * r0   */
+
+		/*  r14 is the link register, r13 is the sp */
+		/*  r14:r12 = r6 * r0 + (r8 * r4 +  r9 * r3 +  r10 * r2 +  r11 * r1) * r5 */
+		/*  r14:r12 = r6 * r1 +  r8 * r0 + (r9 * r4 +  r10 * r3 +  r11 * r2) * r5 */
+		/*  r14:r12 = r6 * r2 +  r8 * r1 +  r9 * r0 + (r10 * r4 +  r11 * r3) * r5 */
+		/*  r14:r12 = r6 * r3 +  r8 * r2 +  r9 * r1 +  r10 * r0 + (r11 * r4) * r5 */
+		/*  r14:r12 = r6 * r4 +  r8 * r3 +  r9 * r2 +  r10 * r1 +  r11 * r0       */
+
+		/* d4 */
+		"UMULL	r12, r14, r6, r4		\n\t"
+		"UMLAL 	r12, r14, r8, r3		\n\t"
+		"UMLAL 	r12, r14, r9, r2		\n\t"
+		"UMLAL 	r12, r14, r10, r1		\n\t"
+		"UMLAL 	r12, r14, r11, r0		\n\t"
+
+		"VMOV	s12, s13, r12, r14		\n\t"
+
+		/* 8F852 C3AB3DA1 */
+
+		/* d3 */
+		"UMULL	r12, r14, r6, r3		\n\t"
+		"UMLAL 	r12, r14, r8, r2		\n\t"
+		"UMLAL 	r12, r14, r9, r1		\n\t"
+		"UMLAL 	r12, r14, r10, r0		\n\t"
+		"MUL	r11, r11, r5			\n\t"
+		"UMLAL 	r12, r14, r11, r4		\n\t"
+
+		"VMOV	s14, s15, r12, r14		\n\t"
+
+		/* C753B 56120E14 */
+
+		/* d2 */
+		"UMULL	r12, r14, r6, r2		\n\t"
+		"UMLAL 	r12, r14, r8, r1		\n\t"
+		"UMLAL 	r12, r14, r9, r0		\n\t"
+		"MUL	r10, r10, r5			\n\t"
+		"UMLAL 	r12, r14, r10, r4		\n\t"
+		"UMLAL 	r12, r14, r11, r3		\n\t"
+
+		"VMOV	s16, s17, r12, r14		\n\t"
+
+		/* 10019D F79AAF81 */
+
+		/* d1 */
+		"UMULL	r12, r14, r6, r1		\n\t"
+		"UMLAL 	r12, r14, r8, r0		\n\t"
+		"MUL	r9, r9, r5			\n\t"
+		"UMLAL 	r12, r14, r9, r4		\n\t"
+		"UMLAL 	r12, r14, r10, r3		\n\t"
+		"UMLAL 	r12, r14, r11, r2		\n\t"
+
+		"VMOV	s18, s19, r12, r14		\n\t"
+
+		/* D3993 E9038575 */
+
+		/* d0 */
+		"UMULL	r12, r14, r6, r0		\n\t"
+		"MUL	r8, r8, r5			\n\t"
+		"UMLAL 	r12, r14, r8, r4		\n\t"
+		"UMLAL 	r12, r14, r9, r3		\n\t"
+		"UMLAL 	r12, r14, r10, r2		\n\t"
+		"UMLAL 	r12, r14, r11, r1		\n\t"
+
+		/* 29DD73 07661C87 */
+
+		/* registers r6, r8, r9, r10, r11 must be 
+		   populated with above results after accounting 
+		   for overflow past 26 bit. */
+
+		/* doing d0 --> d1 --> d2 --> d3 --> d4 --> d1 -->d2 */
+
+		"MOV	r5, #0x3FFFFFF			\n\t"
+		"AND	r6, r12, r5			\n\t"	/* d0 */
+
+		/* d0 overflow to d1 */
+
+		"VMOV 	r0, r1, s18, s19 		\n\t"
+		"ADDS	r0, r0, r12, LSR #26		\n\t"
+		"ADC	r1, r1, #0			\n\t"
+		"ADDS	r0, r0, r14, LSL #6		\n\t"
+		"ADC	r1, r1, #0			\n\t"
+
+		"AND	r8, r0, r5			\n\t"   /* d1 */
+
+		/* d1 overflow to d2 */
+
+		"VMOV 	r2, r3, s16, s17		\n\t"
+		"ADDS	r2, r2, r0, LSR #26		\n\t"
+		"ADC	r3, r3, #0			\n\t"
+		"ADDS	r2, r2, r1, LSL #6		\n\t"
+		"ADC	r3, r3, #0			\n\t"
+
+		"AND	r9, r2, r5			\n\t"	/* d2 */
+
+		/* d2 overflow to d3 */
+
+		"VMOV 	r0, r1, s14, s15		\n\t"
+		"ADDS	r0, r0, r2, LSR #26		\n\t"
+		"ADC	r1, r1, #0			\n\t"
+		"ADDS	r0, r0, r3, LSL #6		\n\t"
+		"ADC	r1, r1, #0			\n\t"
+
+		"AND	r10, r0, r5			\n\t"	/* d3 */
+
+		/* d3 overflow to d4 */
+
+		"VMOV 	r2, r3, s12, s13		\n\t"
+		"ADDS	r2, r2, r0, LSR #26		\n\t"
+		"ADC	r3, r3, #0			\n\t"
+		"ADDS	r2, r2, r1, LSL #6		\n\t"
+		"ADC	r3, r3, #0			\n\t"
+
+		"AND	r11, r2, r5			\n\t"	/* d4 */
+
+		/* d4 overflow to d0, must be multiplied by 5 */	
+
+		"LSR	r0, r2, #26			\n\t"
+		"ADD	r0, r0, r3, LSL #6		\n\t"
+		"MOV	r1, #5				\n\t"	
+		"MUL	r0, r0, r1			\n\t"
+		"ADD	r6, r6, r0			\n\t"   /* d0 updated */
+
+		/* d0 overflow to d1 */
+
+		"ADD	r8, r8, r6, LSR #26		\n\t"	/* d1 done */
+
+		"AND	r6, r6, r5			\n\t"	/* d0 done */	
+
+		"B	armv8_32_poly1305_loop		\n\t"
+	
+	"armv8_32_poly1305_last_block:			\n\t"
+
+		/* This is the last block of the message
+		   and the block is less than 16 byte */
+
+		/* set s4 to 0, d2 is s5:s4 */
+		"VEOR	d2, d2				\n\t"
+	
+		"VMOV	r0, s2				\n\t"	/* hibit */
+
+		/* Make sure the upper bytes of the 
+		   32 bit pieces are set to zero. 
+		   Set the byte past the last message
+		   data byte to 01. */
+
+		"PUSH	{ r4, r6, r8 } 			\n\t"	
+
+		"MOV    r1,  #0				\n\t"
+		"MOV	r2,  #0				\n\t"
+		"MOV	r3,  #0				\n\t"
+		"MOV	r4,  #0xFFFFFFFF		\n\t"
+		"LSR	r0, r0, #24			\n\t"
+		"MOV	r6,  r0				\n\t"
+
+		/* always going to load at least one */		
+		"LDR	r0, [r7]			\n\t"
+
+		/* byte offset to bit offset */ 
+		"ADD	r5, r5, #16			\n\t"
+		"LSL	r5, r5, #3			\n\t"			
+
+		/* which block */
+		"CMP	r5, #32				\n\t"
+		"BGE	not_word_0			\n\t"
+
+		/* case word 0 */
+	"case0:"
+		"LSL	r8, r4, r5			\n\t"
+		"BIC  	r0, r0, r8			\n\t"
+		"LSL	r8, r6, r5			\n\t"
+		"ADD	r0, r0, r8			\n\t"
+		"B	last_block_done			\n\t"
+
+	"not_word_0:	 				\n\t"
+		"LDR	r1, [r7, #4]			\n\t"
+		
+		"SUB	r5, r5, #32			\n\t"
+		"CMP	r5, #32				\n\t"
+		"BGE	not_word_1			\n\t"
+
+		"LSL	r8, r4, r5			\n\t"
+		"BIC  	r1, r1, r8			\n\t"
+		"LSL	r8, r6, r5			\n\t"
+		"ADD	r1, r1, r8			\n\t"		
+		"B	last_block_done			\n\t"
+
+	"not_word_1:					\n\t"
+		"LDR	r2, [r7, #8]			\n\t"
+
+		"SUB	r5, r5, #32			\n\t"
+		"CMP	r5, #32				\n\t"
+		"BGE	not_word_2			\n\t"
+
+		"LSL	r8, r4, r5			\n\t"
+		"BIC  	r2, r2, r8			\n\t"
+		"LSL	r8, r6, r5			\n\t"
+		"ADD	r2, r2, r8			\n\t"		
+		"B	last_block_done			\n\t"
+
+	"not_word_2:					\n\t"
+		"LDR	r3, [r7, #0xC]			\n\t"
+
+		"SUB	r5, r5, #32			\n\t"
+
+		"LSL	r8, r4, r5			\n\t"
+		"BIC  	r3, r3, r8			\n\t"
+		"LSL	r8, r6, r5			\n\t"
+		"ADD	r3, r3, r8			\n\t"	
+
+	"last_block_done:				\n\t"
+
+		"POP	{ r4, r6, r8 } 			\n\t"	
+	
+		"b 	armv8_32_poly1305_done_01_byte_appended \n\t"
+	
+		".align 2 \n\t"
+	"armv8_32_poly1305_done:				\n\t"
+
+		"POP	{ r7 }				\n\t"
+
+		/* store final result */
+		"LDR	r0, %[h_ptr]			\n\t"
+		"STM	r0, { r6, r8, r9, r10, r11 } 	\n\t"
+		
+		: [m] 		  "+m" (msgDataOnStack),	/* input */
+		  [r_ptr]  	  "+m" (r_ptrLocal),		/* input */
+		  [h_ptr]  	  "+m" (h_ptrLocal),		/* input, output */
+		  [bytes]  	  "+m" (msgDataLenOnStack),	/* input */
+		  [hibit]	  "+m" (hibitOnStack)		/* input */
+		: 
+		: "memory", "cc", 
+			"r0", "r1", "r2", "r3", "r4", "r5", "r6", "r8", "r9", "r10",
+			"r11", "r12", "lr", 
+			"s2", "s4", "s6", "s7", "s8", "s9", "s10", "d2"
+	);
+
+	memcpy(ctx->r, r, 5 * sizeof(unsigned));
+	memcpy(ctx->h, h, 5 * sizeof(unsigned));
+
+#ifdef POLY1305_VERBOSE
+	for (i=0;i<5;++i) printf("h%d %07X ", i, ctx->h[i]);
+	printf("\n");
+
+	printf("armv8_32_poly1305_blocks() leaving\n");
+#endif
+
+}
+
+#endif  /* #ifdef  WOLFSSL_ARMASM_NO_NEON */
+
+#endif	/* #ifndef __aarch64__   */
+#endif  /* #ifdef  WOLFSSL_ARMASM */
+
+
+#ifdef STAND_ALONE_DEBUG
+/**********************************************************
+  printRegs	Test routine used to display the register 
+		values save by the call to the assembly
+		routine saveRegs.  The r6, r8, r9, r10
+		and r11 values are approperiately added
+		together to create a 17 byte value that is
+		displayed.  
+**********************************************************/
+void printRegs(unsigned *regArray)
+{
+	unsigned result26Bit[5];
+	unsigned char result[17];
+	int i;	
+
+	printf("\n\n*** Register dump ***\n");
+	for (i=0; i<13;++i)
+		printf("r%d = 0x%08X \n", i, regArray[i]);
+	printf(" sp (r13) skiped\n");
+	printf(" lr (r14) = 0x%08X \n", regArray[i]);
+
+	/* r6, r8, r9, r10, r11 could be 26 bit components
+	   print the result of reassembling them. */
+
+	result26Bit[0] = regArray[6];
+	result26Bit[1] = regArray[8];
+	result26Bit[2] = regArray[9];
+	result26Bit[3] = regArray[10];	
+	result26Bit[4] = regArray[11];
+	convert26BitValuesTo17Byte(result26Bit, result);
+
+	//printBytes("result = ", result, 17);
+	print17("result = ", result);
+}
+
+#define SAVE_REGS	"PUSH 	{ r14 }				\n\t" \
+			"BL	recordRegs			\n\t" \
+			"NOP					\n\t" \
+			"POP	{ r14 }				\n\t"
+#endif
+
+
+#ifdef POLY1305_STAND_ALONE
+
+/**********************************************************
+  print16	Output the given 16 bytes as one big
+		number.  Note 16 bytes is 128 bit.
+**********************************************************/
+void print16(const char *startText, unsigned char *data);
+void print16(const char *startText, unsigned char *data)
+{
+	printf("%s %08X %08X %08X %08X\n", startText, *(unsigned*)(data+0xc),
+			*(unsigned*)(data+0x8),
+			*(unsigned*)(data+4),
+			*(unsigned*)data);
+}
+
+
+/**********************************************************
+  print17	Output the given 17 bytes as one big
+		number.  
+**********************************************************/
+void print17(const char *startText, unsigned char *data);
+void print17(const char *startText, unsigned char *data)
+{
+	printf("%s %02X %08X%08X %08X%08X \n", startText, data[16], 
+				*(unsigned *)(data+0xC), *(unsigned *)(data+8),
+				*(unsigned *)(data+4), *(unsigned *)(data));
+}
+
+
+/**********************************************************
+  printBytes	Print the specified number of bytes, one
+		byte at a time.
+**********************************************************/
+void printBytes(const char *startText, unsigned char *data, int len);
+void printBytes(const char *startText, unsigned char *data, int len)
+{
+	int i;
+	
+	printf("%s", startText);
+	
+	for (i=0;i<len;++i)
+	{
+		printf("%02X", data[i]);
+		if (i<len-1) printf(":");
+	}
+	printf("\n");
+}
+
+
+/**********************************************************
+  clamp_r	Set the correct bits in the 128 bit r key
+		to zero.
+**********************************************************/
+void clamp_r(unsigned char *r);
+void clamp_r(unsigned char *r)
+{
+	printBytes("r = ", r, 16);
+	
+	r[3] &= 0xF;
+	r[7] &= 0xF;
+	r[11] &= 0xF;
+	r[15] &= 0xF;
+	
+	r[4] &= 0xFC;
+	r[8] &= 0xFC;
+	r[12] &= 0xFC;
+	
+	print16("after clamp ", r);
+}
+
+
+/**********************************************************
+  add17		Add two 17 byte numbers together.  This is
+		used as part of the algorithm to combine
+		26 bit pieces into one 17 byte number.
+**********************************************************/
+void add17(unsigned char *dest, unsigned char *src);
+void add17(unsigned char *dest, unsigned char *src)
+{
+	int i;
+	short result;
+	unsigned char of=0;
+	
+	for (i=0;i<17;++i)
+	{
+		result = dest[i] + src[i] + of;
+		
+		dest[i] = (unsigned char)result;
+		
+		if (result & 0xFF00) of=1; else of=0; 
+	}
+}
+
+
+/**********************************************************
+  convert26BitValuesTo17Byte
+		Convert the 5 specified 26 bit values to
+		a single 17 byte value.
+  input16Bit	Input array of 5 26 bit values.  
+  result	Output of 17 bytes which represent one
+		130 bit number.
+**********************************************************/
+void convert26BitValuesTo17Byte(unsigned *input26Bit, unsigned char *result);
+void convert26BitValuesTo17Byte(unsigned *input26Bit, unsigned char *result)
+{
+	unsigned char tmp[17];
+
+	memset(result, 0, 17);
+	*(unsigned*)(result+0) = input26Bit[0];
+
+	memset(tmp, 0, 17);
+	*(unsigned*)(tmp+3)  = input26Bit[1] << 2;
+	add17(result, tmp);
+
+	memset(tmp, 0, 17);
+	*(unsigned*)(tmp+6)  = input26Bit[2] << 4;
+	add17(result, tmp);
+
+	memset(tmp, 0, 17);
+	*(unsigned*)(tmp+9)  = input26Bit[3] << 6;
+	add17(result, tmp);
+
+	memset(tmp, 0, 17);
+	*(unsigned*)(tmp+13) = input26Bit[4];
+	add17(result, tmp);	
+
+	result[16] &= 3;
+}
+
+
+/* test data set from RFC 7539 */
+//unsigned char testData []="Cryptographic Forum Research set"; 
+unsigned char testData[]="Cryptographic Forum Research Group"; 
+//unsigned char testData []="12345678901234561234567890123456";
+unsigned char testKey[]="\x85\xd6\xBE\x78\x57\x55\x6d\x33\x7F\x44\x52\xfe\x42\xd5\x06\xa8\x01\x03\x80\x8a\xfb\x0d\xb2\xFD\x4A\xBF\xF6\xAF\x41\x49\xF5\x1B";
+
+unsigned char resultCheck[]="\xA8\x06\x1D\xC1\x30\x51\x36\xC6\xC2\x2B\x8B\xAF\x0C\x01\x27\xA9";
+
+
+unsigned char msgDataCopy[100];		
+
+int main(void)
+{
+	unsigned char *msgData, *keyData;
+	int msgDataLen;
+	unsigned char result16Byte[16];
+	Poly1305  ctx;
+ 	unsigned char *r, *s, acc[17];
+
+	msgData = testData;
+	msgDataLen = strlen((const char *)msgData);	
+	keyData = testKey;
+
+
+	unsigned *pt;
+	pt = (unsigned*)msgData;
+
+	int i;
+	printf("%s\n", msgData);
+	for (i=0;i<10;++i) printf(" %d %X\n", i, pt[i]);
+	printf("\n");
+
+	printf("message len %d\n", msgDataLen);
+
+
+	/* some modifications of the test data for test
+	   purposes.  Used in part to test the assembly
+	   algorithm for the last block of the message. */
+#if 0
+	/* add junk at end for testing */
+	memcpy(msgDataCopy, msgData, msgDataLen);
+	msgData = msgDataCopy;
+	*(unsigned*)(msgData+msgDataLen) = 0x12345678;
+	*(unsigned*)(msgData+msgDataLen+4) = 0x12345678;
+	*(unsigned*)(msgData+msgDataLen+8) = 0x11111111;
+#endif
+	
+#if 0
+	/* make test data a boundary case length
+	   for testing. */
+	memcpy(msgDataCopy, msgData, msgDataLen);
+	msgData = msgDataCopy;
+
+	strcat(msgData, "more stuff");
+	msgDataLen = strlen(msgData);	
+#endif
+
+#if 0
+	/* just run poly1305 on the first 16 byte 
+ 	   block of the test data. */
+	strcpy(msgDataCopy, "Cryptographic Fo");
+	msgData = msgDataCopy;
+	msgDataLen = strlen(msgData);		
+#endif
+
+	r = keyData;
+	s = keyData+16;
+
+	print16("s as a 128-bit number ", s);
+	clamp_r(r);
+
+	/* break the 16 byte value into 26 bit parts. */         
+	ctx.r[0] = *(unsigned *)(r) & 0x3FFFFFF;
+	ctx.r[1] = ((*(unsigned *)(r + 3)) >> 2) & 0x3FFFFFF;
+	ctx.r[2] = ((*(unsigned *)(r + 6)) >> 4) & 0x3FFFFFF;
+	ctx.r[3] = ((*(unsigned *)(r + 9)) >> 6) & 0x3FFFFFF;
+	/* + 12 so you don't reference outside array, ie don't use +13 */
+	ctx.r[4] = ((*(unsigned *)(r + 12)) >> 8) & 0xFFFFFF;
+
+	ctx.finished = 0;
+
+	/* Should always start as zero.
+           Passing into assembly routine to match what is already 
+	   implemented in wolfSSL armv8_poly1305.c.  
+	   For debugging, the C routine could break the message into 
+	   16 byte chunks and call the assembly routine over and over
+	   with the 16 byte chunks and the updated h value. */
+	memset(ctx.h, 0, 5 * sizeof(unsigned));
+
+	armv8_32_poly1305_blocks(&ctx, msgData, msgDataLen);
+
+	convert26BitValuesTo17Byte(ctx.h, acc);
+
+	/* make output match what is seen in RFC */
+	print17("Acc = ((Acc+Block) * r) % P = ", acc);
+	add17(acc, s);
+	print17("Acc + s = ", acc);
+
+	memcpy(result16Byte, acc, 16);
+
+	printBytes(" Tag = ", result16Byte, 16); 
+
+	if (!memcmp(result16Byte, resultCheck, 16))
+		printf("Result matches RFC 7539\n\n");
+	else	
+		printf("Result does not match RFC 7539\n\n");
+}
+#endif
+

--- a/wolfcrypt/src/port/arm/armv8-32-poly1305.c
+++ b/wolfcrypt/src/port/arm/armv8-32-poly1305.c
@@ -25,58 +25,58 @@
 
    This code can be built as a standalone application, the test
    code to support that is at the bottom of the file.  One of
-   the test cases matches the test data in RFC 7539.  The 
+   the test cases matches the test data in RFC 7539.  The
    standalone test output is similar to RFC 7539.
 
    The poly1305 algorithm takes two inputs, they are as follows.
-	1. the message data
-	2. a 256 bit key
+        1. the message data
+        2. a 256 bit key
    The algorithm outputs a 16 byte authentication value.
-  
-   The 16 bytes are transmitted with the message.  
-   The receiving side runs the poly1305 algorithm and 
+
+   The 16 bytes are transmitted with the message.
+   The receiving side runs the poly1305 algorithm and
    compares the 16 byte result on the receiving side to
    16 bytes sent with the message.  If the two 16 byte
    values match, then the message is authenticated.
 
    The poly1305 algorithm requires a unique 256 bit key
    for each message.  The sender and receiver keys must
-   stay in sync. This means that a pseudo random key must 
-   be generated on both sides using the same algorithm 
+   stay in sync. This means that a pseudo random key must
+   be generated on both sides using the same algorithm
    and the same initial key.
-  
+
    It is common to use the ChaCha20 algorithm to generate
    the pseudo random key.  The initial 256 bit key is normally
-   shared during the setup up of the connection between 
-   sender and receiver.	
+   shared during the setup up of the connection between
+   sender and receiver.
 
-   The 256 bit key is broken down into two 128 bit parts; 
+   The 256 bit key is broken down into two 128 bit parts;
    namely r and s.  In the algorithm, r is clamped, meaning
    certain bits are set to zero.  According to the RFC, r can
-   remain the same between runs of the algorithm, but s must 
-   always change.  Therefore the ChaCha20 solution mentioned 
+   remain the same between runs of the algorithm, but s must
+   always change.  Therefore the ChaCha20 solution mentioned
    above could be used to generate a 128 bit or 256 bit unique
-   key each time. 
+   key each time.
 
    This code was compiled and tested with the following tool chain.
 
-	gcc-arm-10.2-2020.11-aarch64-arm-none-linux-guneabihf
+        gcc-arm-10.2-2020.11-aarch64-arm-none-linux-guneabihf
 
    The development environment was Ubunutu, image file
-	
-	libre-computer-aml-s905x-cc-ubuntu-bionic-mate-mali-4.19.55+-2019-06-24.img 
+
+        libre-computer-aml-s905x-cc-ubuntu-bionic-mate-mali-4.19.55+-2019-06-24.img
 
    In order the run the resulting executable the 32 bit libs must
    be added to the system.  The following commands accomplish this.
 
-	sudo dpkg --add-architecture armhf
-	sudo apt-get update
-	sudo apt-get install libc6:armhf libstdc++6:armhf
+        sudo dpkg --add-architecture armhf
+        sudo apt-get update
+        sudo apt-get install libc6:armhf libstdc++6:armhf
 
 *****************************************************************/
 
 
-/* if building as a standalone to match the RFC 7539 
+/* if building as a standalone to match the RFC 7539
    Be sure to pass gcc "-D POLY1305_STAND_ALONE". */
 #ifdef POLY1305_STAND_ALONE
 #include <stdio.h>
@@ -122,1187 +122,1189 @@ typedef struct poly1305_struct
 
 
 /**********************************************************
-  calculateRsquared	Take the input array of 5 26 bit
-			values, and multiply it by itself
-		        to create a squared result.
-  r			input array of 5 26 bit values
-  rsquared		output array of 5 26 bit values
+  calculateRsquared     Take the input array of 5 26 bit
+                        values, and multiply it by itself
+                        to create a squared result.
+  r                     input array of 5 26 bit values
+  rsquared              output array of 5 26 bit values
 **********************************************************/
 void calculateRsquared(unsigned *r, unsigned *rsquared);
 void calculateRsquared(unsigned *r, unsigned *rsquared)
 {
-	unsigned long long r_2_l[5];
-	unsigned long long c;
-	int i;
+    unsigned long long r_2_l[5];
+    unsigned long long c;
+    int i;
 
-	/* d0 = h0 * r0 + h1 * 5*r4 + h2 * 5*r3 + h3 * 5*r2 + h4 * 5*r1 */
-	/* d1 = h0 * r1 + h1 * r0   + h2 * 5*r4 + h3 * 5*r3 + h4 * 5*r2 */
-	/* d2 = h0 * r2 + h1 * r1   + h2 * r0   + h3 * 5*r4 + h4 * 5*r3 */
-	/* d3 = h0 * r3 + h1 * r2   + h2 * r1   + h3 * r0   + h4 * 5*r4 */
-	/* d4 = h0 * r4 + h1 * r3   + h2 * r2   + h3 * r1   + h4 * r0   */
+    /* d0 = h0 * r0 + h1 * 5*r4 + h2 * 5*r3 + h3 * 5*r2 + h4 * 5*r1 */
+    /* d1 = h0 * r1 + h1 * r0   + h2 * 5*r4 + h3 * 5*r3 + h4 * 5*r2 */
+    /* d2 = h0 * r2 + h1 * r1   + h2 * r0   + h3 * 5*r4 + h4 * 5*r3 */
+    /* d3 = h0 * r3 + h1 * r2   + h2 * r1   + h3 * r0   + h4 * 5*r4 */
+    /* d4 = h0 * r4 + h1 * r3   + h2 * r2   + h3 * r1   + h4 * r0   */
 
-        r_2_l[0] = ((unsigned long long) r[0] * (unsigned long long) r[0] )
- 	       + ((unsigned long long) r[1] * ((unsigned long long) r[4]) * 5) 
-	       + ((unsigned long long) r[2] * ((unsigned long long) r[3]) * 5) 
-	       + ((unsigned long long) r[3] * ((unsigned long long) r[2]) * 5) 
-	       + ((unsigned long long) r[4] * ((unsigned long long) r[1]) * 5); 
+    r_2_l[0] = ((unsigned long long) r[0] * (unsigned long long) r[0] )
+        + ((unsigned long long) r[1] * ((unsigned long long) r[4]) * 5)
+        + ((unsigned long long) r[2] * ((unsigned long long) r[3]) * 5)
+        + ((unsigned long long) r[3] * ((unsigned long long) r[2]) * 5)
+        + ((unsigned long long) r[4] * ((unsigned long long) r[1]) * 5);
 
-        r_2_l[1] = ((unsigned long long) r[0] * (unsigned long long) r[1] )	 		       + ((unsigned long long) r[1] * (unsigned long long) r[0] ) 
-	       + ((unsigned long long) r[2] * ((unsigned long long) r[4]) * 5) 
-	       + ((unsigned long long) r[3] * ((unsigned long long) r[3]) * 5 ) 
-	       + ((unsigned long long) r[4] * ((unsigned long long) r[2]) * 5 ); 
+    r_2_l[1] = ((unsigned long long) r[0] * (unsigned long long) r[1] )
+        + ((unsigned long long) r[1] * (unsigned long long) r[0] )
+        + ((unsigned long long) r[2] * ((unsigned long long) r[4]) * 5)
+        + ((unsigned long long) r[3] * ((unsigned long long) r[3]) * 5)
+        + ((unsigned long long) r[4] * ((unsigned long long) r[2]) * 5);
 
-        r_2_l[2] = ((unsigned long long) r[0] * (unsigned long long) r[2] )	 		       + ((unsigned long long) r[1] * (unsigned long long) r[1] ) 
-	       + ((unsigned long long) r[2] * (unsigned long long) r[0] ) 
-	       + ((unsigned long long) r[3] * ((unsigned long long) r[4]) * 5 ) 
-	       + ((unsigned long long) r[4] * ((unsigned long long) r[3]) * 5 ); 
+    r_2_l[2] = ((unsigned long long) r[0] * (unsigned long long) r[2] )
+        + ((unsigned long long) r[1] * (unsigned long long) r[1] )
+        + ((unsigned long long) r[2] * (unsigned long long) r[0] )
+        + ((unsigned long long) r[3] * ((unsigned long long) r[4]) * 5)
+        + ((unsigned long long) r[4] * ((unsigned long long) r[3]) * 5);
 
-        r_2_l[3] = ((unsigned long long) r[0] * (unsigned long long) r[3] )	 		       + ((unsigned long long) r[1] * (unsigned long long) r[2] ) 
-	       + ((unsigned long long) r[2] * (unsigned long long) r[1] ) 
-	       + ((unsigned long long) r[3] * (unsigned long long) r[0] ) 
-	       + ((unsigned long long) r[4] * ((unsigned long long) r[4]) * 5 ); 
+    r_2_l[3] = ((unsigned long long) r[0] * (unsigned long long) r[3] )
+        + ((unsigned long long) r[1] * (unsigned long long) r[2] )
+        + ((unsigned long long) r[2] * (unsigned long long) r[1] )
+        + ((unsigned long long) r[3] * (unsigned long long) r[0] )
+        + ((unsigned long long) r[4] * ((unsigned long long) r[4]) * 5);
 
-        r_2_l[4] = ((unsigned long long) r[0] * (unsigned long long) r[4] )	 		       + ((unsigned long long) r[1] * (unsigned long long) r[3] ) 
-	       + ((unsigned long long) r[2] * (unsigned long long) r[2] ) 
-	       + ((unsigned long long) r[3] * (unsigned long long) r[1] ) 
-	       + ((unsigned long long) r[4] * (unsigned long long) r[0] ); 
+    r_2_l[4] = ((unsigned long long) r[0] * (unsigned long long) r[4] )
+        + ((unsigned long long) r[1] * (unsigned long long) r[3] )
+        + ((unsigned long long) r[2] * (unsigned long long) r[2] )
+        + ((unsigned long long) r[3] * (unsigned long long) r[1] )
+        + ((unsigned long long) r[4] * (unsigned long long) r[0] );
 
-        c = (r_2_l[0] >> 26); 
-	r_2_l[0] = r_2_l[0] & 0x3ffffff;
-        r_2_l[1] += c;
+    c = (r_2_l[0] >> 26);
+    r_2_l[0] = r_2_l[0] & 0x3ffffff;
+    r_2_l[1] += c;
 
-        c = (r_2_l[1] >> 26);
-	r_2_l[1] = r_2_l[1] & 0x3ffffff;
-        r_2_l[2] += c;     
+    c = (r_2_l[1] >> 26);
+    r_2_l[1] = r_2_l[1] & 0x3ffffff;
+    r_2_l[2] += c;
 
-        c = (r_2_l[2] >> 26);
-	r_2_l[2] = r_2_l[2] & 0x3ffffff;
-        r_2_l[3] += c;     
+    c = (r_2_l[2] >> 26);
+    r_2_l[2] = r_2_l[2] & 0x3ffffff;
+    r_2_l[3] += c;
 
-        c = (r_2_l[3] >> 26);
-	r_2_l[3] = r_2_l[3] & 0x3ffffff;
-        r_2_l[4] += c;     
+    c = (r_2_l[3] >> 26);
+    r_2_l[3] = r_2_l[3] & 0x3ffffff;
+    r_2_l[4] += c;
 
-        c = (r_2_l[4] >> 26);
-	r_2_l[4] = r_2_l[4] & 0x3ffffff;
-        r_2_l[0] += 5 * c;     
+    c = (r_2_l[4] >> 26);
+    r_2_l[4] = r_2_l[4] & 0x3ffffff;
+    r_2_l[0] += 5 * c;
 
-        r_2_l[1] += (r_2_l[0] >> 26);
-	r_2_l[0] = r_2_l[0] & 0x3ffffff;
+    r_2_l[1] += (r_2_l[0] >> 26);
+    r_2_l[0] = r_2_l[0] & 0x3ffffff;
 
-	for (i=0;i<5;++i)
-		rsquared[i] = (unsigned) r_2_l[i];
+    for (i=0;i<5;++i)
+        rsquared[i] = (unsigned) r_2_l[i];
 }
 
 
 
 /**********************************************************
-  armv8_32_poly1305_blocks	This routine implements the 
-			poly1305 algorithm.  The processing
-			of the 16 byte pieces of the 
-			message is implemented in assembly.
-			Care was taken in implementing the
-			assembly to optimize speed by 
-			minimizing memory references as
-			well as minimizing instructions.
-			The poly1305 algorithm is implemented
-			by using multiple 26 bit values 
-			to represent the larger 16 byte and 
-			17 byte numbers.  This is control
-			register overflow during the 
-			multiplications and subsequent 
-			additions.  For more information
-			reference the article NEON Cryto
-			by Daniel Berstein and Peter
-			Schwabe.
-  ctx			poly1305 structure containing the r and
-		 	h values broke into 26 bit pieces.
-			The result of this routine is returned
-			int the h array of 26 bit values.
-  msgData		Message data to run the algorithm 
-			against.
-  keyData		256 bit key that is broken down 
-			into the r and s subcomponents.
+  armv8_32_poly1305_blocks      This routine implements the
+                        poly1305 algorithm.  The processing
+                        of the 16 byte pieces of the
+                        message is implemented in assembly.
+                        Care was taken in implementing the
+                        assembly to optimize speed by
+                        minimizing memory references as
+                        well as minimizing instructions.
+                        The poly1305 algorithm is implemented
+                        by using multiple 26 bit values
+                        to represent the larger 16 byte and
+                        17 byte numbers.  This is control
+                        register overflow during the
+                        multiplications and subsequent
+                        additions.  For more information
+                        reference the article NEON Cryto
+                        by Daniel Berstein and Peter
+                        Schwabe.
+  ctx                   poly1305 structure containing the r and
+                        h values broke into 26 bit pieces.
+                        The result of this routine is returned
+                        int the h array of 26 bit values.
+  msgData               Message data to run the algorithm
+                        against.
+  keyData               256 bit key that is broken down
+                        into the r and s subcomponents.
 **********************************************************/
 /* variable assembly code creates on stack */
 #define BYTES_SP_OFF              20
 #define HIBIT_LOCAL_SP_OFF        24
 
-void armv8_32_poly1305_blocks(Poly1305* ctx, 
-                              const unsigned char *msgData,
-                              size_t msgDataLen);
+void armv8_32_poly1305_blocks(Poly1305* ctx, const unsigned char *msgData,
+    size_t msgDataLen);
 
 /* WOLFSSL_ARMASM_NO_NEON is used in armv8-32-sha512-asm.S */
 #ifdef WOLFSSL_ARMASM_NO_NEON2
-void armv8_32_poly1305_blocks(Poly1305* ctx, 
-                              const unsigned char *msgData,
-                              size_t msgDataLen)
+void armv8_32_poly1305_blocks(Poly1305* ctx, const unsigned char *msgData,
+    size_t msgDataLen)
 {
-        /* these variables will be referenced via r7 in the assembly */
-        unsigned r[5], *r_ptrLocal, h[5], *h_ptrLocal;
-        unsigned msgDataOnStack = (unsigned)msgData;
-        unsigned msgDataLenOnStack = msgDataLen;
-        unsigned hibitOnStack = (ctx->finished) ? 0 : ((unsigned) 1 << 24);
+    /* these variables will be referenced via r7 in the assembly */
+    unsigned r[5], *r_ptrLocal, h[5], *h_ptrLocal;
+    unsigned msgDataOnStack = (unsigned)msgData;
+    unsigned msgDataLenOnStack = msgDataLen;
+    unsigned hibitOnStack = (ctx->finished) ? 0 : ((unsigned) 1 << 24);
 
-        memcpy(r, ctx->r, 5 * sizeof(unsigned));
-        memcpy(h, ctx->h, 5 * sizeof(unsigned));
+    memcpy(r, ctx->r, 5 * sizeof(unsigned));
+    memcpy(h, ctx->h, 5 * sizeof(unsigned));
 
-        /* 32 bit pointer, this is necessary to pass the pointer value
-           into the assembly code */
-        r_ptrLocal = (unsigned *) r;
-        h_ptrLocal = (unsigned *) h;
+    /* 32 bit pointer, this is necessary to pass the pointer value
+       into the assembly code */
+    r_ptrLocal = (unsigned *) r;
+    h_ptrLocal = (unsigned *) h;
 
 #ifdef POLY1305_VERBOSE
-        int i;
-        for (i=0;i<5;++i) printf("h%d %07X ", i, h[i]);
-        printf("\n");
+    int i;
+    for (i=0;i<5;++i)
+        printf("h%d %07X ", i, h[i]);
+    printf("\n");
 
-        printf("armv8_32_poly1305_blocks() data len %d\n", msgDataLen);
+    printf("armv8_32_poly1305_blocks() data len %d\n", msgDataLen);
 #endif
 
-        __asm__ __volatile__ (
-                ".align        8                                \n\t"
-                
-                /* valid registers are r0..r12, sp, lr, pc, cpsr, fpscr */
-                
-                /* now load the stored h, this should all zero */
-                "LDR        r5, %[h_ptr]                        \n\t"
-                "LDM        r5, { r6, r8, r9, r10, r11 }        \n\t"
-                /* r6 = h0  r8 = h1  r9 = h2  r10 = h3  r11 = h4 */
-        
-                /* in some cases, r7 is used to reference the local variables 
-                   on the stack; if -O2 is passed to gcc, the sp may used 
-                        used to reference local variables. */
-                "LDR        r0, %[bytes]                        \n\t"
-                "LDR        r1, %[r_ptr]                        \n\t"
-                "LDR        r2, %[hibit]                        \n\t"
-                "LDR        r5, %[m]                            \n\t"
-
-                "PUSH       { r7 }                              \n\t"
-                "SUB        sp, #28                             \n\t"
-                
-                /* -O2 gcc parameters means r7 is not used for local
-                   variables, but sp is used for local variables */
-                /* free up r7 by moving variables referenced
-                   via r7 to recently allocated stack space */
-                "STR        r0, [sp, %[BYTES_STORE]]            \n\t"
-                "STR        r2, [sp, %[HIBIT_LOCAL]]            \n\t"
-
-                "LDM        r1, { r0, r1, r2, r3, r4 }          \n\t"
-                "STM        sp, { r0, r1, r2, r3, r4 }          \n\t"
-
-                "MOV        r7, r5                              \n\t"
-
-        "armv8_32_poly1305_loop:                                \n\t"
-
-                /* The poly1305 algorithm requires that a 01 byte 
-                   be placed after the last byte of the block. */                 
-                
-                "LDR        r5, [sp, %[BYTES_STORE]]            \n\t"  /* mem 1 */
-                "CMP        r5, #0                              \n\t"
-                "BEQ        armv8_32_poly1305_done              \n\t"
-                "SUBS       r5, r5, #16                         \n\t"
-                
-                /* branch for least likely case, may help with pipelining */
-                /* ARMv8 uses predictive pipelining.  There is no way
-                   to specify in the instruction encoding the more likely
-                   case.  */
-                "BLT        armv8_32_poly1305_last_block        \n\t"  
-
-                /* this block is 16 bytes */
-                "STR        r5, [sp, %[BYTES_STORE]]            \n\t"  /* mem 2 */
-
-                /* load next 16 byte block of message */                
-                "LDM        r7, { r0, r1, r2, r3 }              \n\t"  /* mem 3 */
-                "ADD        r7, r7, #16                         \n\t"
-
-                /* in RFC 7539, each block processed is prepended by
-                     a byte of value 0x01.  In the wolfSSL implementation,
-                   the setting of this value is based on the value found
-                   in ctx->finish. To save a memory reference, this code
-                   could be replicated one version adding the byte, one
-                   version not. */
-
-                /* This is byte 16, past the 128 bits of w19:w18:w17:w16 
-                   Hence, update is done to h4. */  
-                "LDR        r5, [sp, %[HIBIT_LOCAL]]            \n\t"  /* mem 4 */
-                "ADD        r11, r11, r5                        \n\t"
-                        
-        "armv8_32_poly1305_done_01_byte_appended:               \n\t"
-
-                "MOV        r5, #0x3FFFFFF                      \n\t"
-
-                /* break data into 26 bit pieces. 
-                   Bit offsets are 0, 26, 52, 78 and 104 */
-                   
-                /* h0 += r0 & 0x3FFFFFF; */
-                "AND        r12, r0, r5                         \n\t"
-                "ADD        r6, r6, r12                         \n\t"
-                /* h1 += (r1:r0 >> 26) & 0x3FFFFFF */
-                "LSR        r12, r0, #26                        \n\t"  /* 26 */
-                "ADD        r12, r12, r1, LSL #6                \n\t"
-                "AND        r12, r12, r5                        \n\t"
-                "ADD        r8, r8, r12                         \n\t"
-                /* h2 += (r2:r1 >> 20) & 0x3FFFFFF */
-                "LSR        r12, r1, #20                        \n\t"  /* 20+32 = 52 */
-                "ADD        r12, r12, r2, LSL #12               \n\t"
-                "AND        r12, r12, r5                        \n\t"
-                "ADD        r9, r9, r12                         \n\t"
-                /* h3 += (r3:r2 >> 14) & 0x3FFFFFF */
-                "LSR        r12, r2, #14                        \n\t"  /* 14+32+32 = 78 */
-                "ADD        r12, r12, r3, LSL #18               \n\t"
-                "AND        r12, r12, r5                        \n\t"
-                "ADD        r10, r10, r12                       \n\t"
-                /* h4 += r3 >> 8                   */
-                "ADD        r11, r11, r3, LSR #8                \n\t"  /* 8+32+32+32 = 104 */
-
-                /* pull in the 26 bit components of the r key */
-                "LDM        sp, { r0, r1, r2, r3, r4 }          \n\t"   /* mem 5 */
-                /* r0 = BED685  r1 = 3555502  r2 = 47C036  r3 = 1003949  r4 = 806D5 */
-                
-                "MOV        r5, #5                              \n\t"
+    __asm__ __volatile__ (
+        ".align        8                                \n\t"
+
+        /* valid registers are r0..r12, sp, lr, pc, cpsr, fpscr */
+
+        /* now load the stored h, this should all zero */
+        "LDR        r5, %[h_ptr]                        \n\t"
+        "LDM        r5, { r6, r8, r9, r10, r11 }        \n\t"
+        /* r6 = h0  r8 = h1  r9 = h2  r10 = h3  r11 = h4 */
+
+        /* in some cases, r7 is used to reference the local variables
+           on the stack; if -O2 is passed to gcc, the sp may used
+                used to reference local variables. */
+        "LDR        r0, %[bytes]                        \n\t"
+        "LDR        r1, %[r_ptr]                        \n\t"
+        "LDR        r2, %[hibit]                        \n\t"
+        "LDR        r5, %[m]                            \n\t"
+
+        "PUSH       { r7 }                              \n\t"
+        "SUB        sp, #28                             \n\t"
+
+        /* -O2 gcc parameters means r7 is not used for local
+           variables, but sp is used for local variables */
+        /* free up r7 by moving variables referenced
+           via r7 to recently allocated stack space */
+        "STR        r0, [sp, %[BYTES_STORE]]            \n\t"
+        "STR        r2, [sp, %[HIBIT_LOCAL]]            \n\t"
+
+        "LDM        r1, { r0, r1, r2, r3, r4 }          \n\t"
+        "STM        sp, { r0, r1, r2, r3, r4 }          \n\t"
+
+        "MOV        r7, r5                              \n\t"
+
+    "armv8_32_poly1305_loop:                                \n\t"
+
+        /* The poly1305 algorithm requires that a 01 byte
+           be placed after the last byte of the block. */
+
+        "LDR        r5, [sp, %[BYTES_STORE]]            \n\t"  /* mem 1 */
+        "CMP        r5, #0                              \n\t"
+        "BEQ        armv8_32_poly1305_done              \n\t"
+        "SUBS       r5, r5, #16                         \n\t"
+
+        /* branch for least likely case, may help with pipelining */
+        /* ARMv8 uses predictive pipelining.  There is no way
+           to specify in the instruction encoding the more likely
+           case.  */
+        "BLT        armv8_32_poly1305_last_block        \n\t"
+
+        /* this block is 16 bytes */
+        "STR        r5, [sp, %[BYTES_STORE]]            \n\t"  /* mem 2 */
+
+        /* load next 16 byte block of message */
+        "LDM        r7, { r0, r1, r2, r3 }              \n\t"  /* mem 3 */
+        "ADD        r7, r7, #16                         \n\t"
+
+        /* in RFC 7539, each block processed is prepended by
+             a byte of value 0x01.  In the wolfSSL implementation,
+           the setting of this value is based on the value found
+           in ctx->finish. To save a memory reference, this code
+           could be replicated one version adding the byte, one
+           version not. */
+
+        /* This is byte 16, past the 128 bits of w19:w18:w17:w16
+           Hence, update is done to h4. */
+        "LDR        r5, [sp, %[HIBIT_LOCAL]]            \n\t"  /* mem 4 */
+        "ADD        r11, r11, r5                        \n\t"
+
+    "armv8_32_poly1305_done_01_byte_appended:           \n\t"
+
+        "MOV        r5, #0x3FFFFFF                      \n\t"
+
+        /* break data into 26 bit pieces.
+           Bit offsets are 0, 26, 52, 78 and 104 */
+
+        /* h0 += r0 & 0x3FFFFFF; */
+        "AND        r12, r0, r5                         \n\t"
+        "ADD        r6, r6, r12                         \n\t"
+        /* h1 += (r1:r0 >> 26) & 0x3FFFFFF */
+        "LSR        r12, r0, #26                        \n\t"  /* 26 */
+        "ADD        r12, r12, r1, LSL #6                \n\t"
+        "AND        r12, r12, r5                        \n\t"
+        "ADD        r8, r8, r12                         \n\t"
+        /* h2 += (r2:r1 >> 20) & 0x3FFFFFF */
+        "LSR        r12, r1, #20                        \n\t"  /* 20+32 = 52 */
+        "ADD        r12, r12, r2, LSL #12               \n\t"
+        "AND        r12, r12, r5                        \n\t"
+        "ADD        r9, r9, r12                         \n\t"
+        /* h3 += (r3:r2 >> 14) & 0x3FFFFFF */
+        "LSR        r12, r2, #14                        \n\t"  /* 14+32+32 = 78 */
+        "ADD        r12, r12, r3, LSL #18               \n\t"
+        "AND        r12, r12, r5                        \n\t"
+        "ADD        r10, r10, r12                       \n\t"
+        /* h4 += r3 >> 8                   */
+        "ADD        r11, r11, r3, LSR #8                \n\t"  /* 8+32+32+32 = 104 */
+
+        /* pull in the 26 bit components of the r key */
+        "LDM        sp, { r0, r1, r2, r3, r4 }          \n\t"   /* mem 5 */
+        /* r0 = BED685  r1 = 3555502  r2 = 47C036  r3 = 1003949  r4 = 806D5 */
+
+        "MOV        r5, #5                              \n\t"
 
-        "checkRegs:                                             \n\t"
-                /* d0 = h0 * r0 + h1 * 5*r4 + h2 * 5*r3 + h3 * 5*r2 + h4 * 5*r1 */
-                /* d1 = h0 * r1 + h1 * r0   + h2 * 5*r4 + h3 * 5*r3 + h4 * 5*r2 */
-                /* d2 = h0 * r2 + h1 * r1   + h2 * r0   + h3 * 5*r4 + h4 * 5*r3 */
-                /* d3 = h0 * r3 + h1 * r2   + h2 * r1   + h3 * r0   + h4 * 5*r4 */
-                /* d4 = h0 * r4 + h1 * r3   + h2 * r2   + h3 * r1   + h4 * r0   */
+    "checkRegs:                                         \n\t"
+        /* d0 = h0 * r0 + h1 * 5*r4 + h2 * 5*r3 + h3 * 5*r2 + h4 * 5*r1 */
+        /* d1 = h0 * r1 + h1 * r0   + h2 * 5*r4 + h3 * 5*r3 + h4 * 5*r2 */
+        /* d2 = h0 * r2 + h1 * r1   + h2 * r0   + h3 * 5*r4 + h4 * 5*r3 */
+        /* d3 = h0 * r3 + h1 * r2   + h2 * r1   + h3 * r0   + h4 * 5*r4 */
+        /* d4 = h0 * r4 + h1 * r3   + h2 * r2   + h3 * r1   + h4 * r0   */
 
-                /*  r14 is the link register, r13 is the sp */
-                /*  r14:r12 = r6 * r0 + (r8 * r4 +  r9 * r3 +  r10 * r2 +  r11 * r1) * r5 */
-                /*  r14:r12 = r6 * r1 +  r8 * r0 + (r9 * r4 +  r10 * r3 +  r11 * r2) * r5 */
-                /*  r14:r12 = r6 * r2 +  r8 * r1 +  r9 * r0 + (r10 * r4 +  r11 * r3) * r5 */
-                /*  r14:r12 = r6 * r3 +  r8 * r2 +  r9 * r1 +  r10 * r0 + (r11 * r4) * r5 */
-                /*  r14:r12 = r6 * r4 +  r8 * r3 +  r9 * r2 +  r10 * r1 +  r11 * r0       */
+        /*  r14 is the link register, r13 is the sp */
+        /*  r14:r12 = r6 * r0 + (r8 * r4 +  r9 * r3 +  r10 * r2 +  r11 * r1) * r5 */
+        /*  r14:r12 = r6 * r1 +  r8 * r0 + (r9 * r4 +  r10 * r3 +  r11 * r2) * r5 */
+        /*  r14:r12 = r6 * r2 +  r8 * r1 +  r9 * r0 + (r10 * r4 +  r11 * r3) * r5 */
+        /*  r14:r12 = r6 * r3 +  r8 * r2 +  r9 * r1 +  r10 * r0 + (r11 * r4) * r5 */
+        /*  r14:r12 = r6 * r4 +  r8 * r3 +  r9 * r2 +  r10 * r1 +  r11 * r0       */
 
-                /* d4 */
-                "UMULL      r12, r14, r6, r4                    \n\t"
-                "UMLAL      r12, r14, r8, r3                    \n\t"
-                "UMLAL      r12, r14, r9, r2                    \n\t"
-                "UMLAL      r12, r14, r10, r1                   \n\t"
-                "UMLAL      r12, r14, r11, r0                   \n\t"
+        /* d4 */
+        "UMULL      r12, r14, r6, r4                    \n\t"
+        "UMLAL      r12, r14, r8, r3                    \n\t"
+        "UMLAL      r12, r14, r9, r2                    \n\t"
+        "UMLAL      r12, r14, r10, r1                   \n\t"
+        "UMLAL      r12, r14, r11, r0                   \n\t"
 
-                "PUSH       { r12, r14 }                        \n\t"   /* mem 6 */
+        "PUSH       { r12, r14 }                        \n\t"   /* mem 6 */
 
-                /* 8F852 C3AB3DA1 */
+        /* 8F852 C3AB3DA1 */
 
-                /* d3 */
-                "UMULL      r12, r14, r6, r3                    \n\t"
-                "UMLAL      r12, r14, r8, r2                    \n\t"
-                "UMLAL      r12, r14, r9, r1                    \n\t"
-                "UMLAL      r12, r14, r10, r0                   \n\t"
-                "MUL        r11, r11, r5                        \n\t"
-                "UMLAL      r12, r14, r11, r4                   \n\t"
+        /* d3 */
+        "UMULL      r12, r14, r6, r3                    \n\t"
+        "UMLAL      r12, r14, r8, r2                    \n\t"
+        "UMLAL      r12, r14, r9, r1                    \n\t"
+        "UMLAL      r12, r14, r10, r0                   \n\t"
+        "MUL        r11, r11, r5                        \n\t"
+        "UMLAL      r12, r14, r11, r4                   \n\t"
 
-                "PUSH       { r12, r14 }                        \n\t"   /* mem 7 */
+        "PUSH       { r12, r14 }                        \n\t"   /* mem 7 */
 
-                /* C753B 56120E14 */
+        /* C753B 56120E14 */
 
-                /* d2 */
-                "UMULL      r12, r14, r6, r2                    \n\t"
-                "UMLAL      r12, r14, r8, r1                    \n\t"
-                "UMLAL      r12, r14, r9, r0                    \n\t"
-                "MUL        r10, r10, r5                        \n\t"
-                "UMLAL      r12, r14, r10, r4                   \n\t"
-                "UMLAL      r12, r14, r11, r3                   \n\t"
+        /* d2 */
+        "UMULL      r12, r14, r6, r2                    \n\t"
+        "UMLAL      r12, r14, r8, r1                    \n\t"
+        "UMLAL      r12, r14, r9, r0                    \n\t"
+        "MUL        r10, r10, r5                        \n\t"
+        "UMLAL      r12, r14, r10, r4                   \n\t"
+        "UMLAL      r12, r14, r11, r3                   \n\t"
 
-                "PUSH       { r12, r14 }                        \n\t"   /* mem 8 */
+        "PUSH       { r12, r14 }                        \n\t"   /* mem 8 */
 
-                /* 10019D F79AAF81 */
+        /* 10019D F79AAF81 */
 
-                /* d1 */
-                "UMULL      r12, r14, r6, r1                    \n\t"
-                "UMLAL      r12, r14, r8, r0                    \n\t"
-                "MUL        r9, r9, r5                          \n\t"
-                "UMLAL      r12, r14, r9, r4                    \n\t"
-                "UMLAL      r12, r14, r10, r3                   \n\t"
-                "UMLAL      r12, r14, r11, r2                   \n\t"
+        /* d1 */
+        "UMULL      r12, r14, r6, r1                    \n\t"
+        "UMLAL      r12, r14, r8, r0                    \n\t"
+        "MUL        r9, r9, r5                          \n\t"
+        "UMLAL      r12, r14, r9, r4                    \n\t"
+        "UMLAL      r12, r14, r10, r3                   \n\t"
+        "UMLAL      r12, r14, r11, r2                   \n\t"
 
-                "PUSH       { r12, r14 }                        \n\t"   /* mem 9 */
+        "PUSH       { r12, r14 }                        \n\t"   /* mem 9 */
 
-                /* D3993 E9038575 */
+        /* D3993 E9038575 */
 
-                /* d0 */
-                "UMULL      r12, r14, r6, r0                    \n\t"
-                "MUL        r8, r8, r5                          \n\t"
-                "UMLAL      r12, r14, r8, r4                    \n\t"
-                "UMLAL      r12, r14, r9, r3                    \n\t"
-                "UMLAL      r12, r14, r10, r2                   \n\t"
-                "UMLAL      r12, r14, r11, r1                   \n\t"
+        /* d0 */
+        "UMULL      r12, r14, r6, r0                    \n\t"
+        "MUL        r8, r8, r5                          \n\t"
+        "UMLAL      r12, r14, r8, r4                    \n\t"
+        "UMLAL      r12, r14, r9, r3                    \n\t"
+        "UMLAL      r12, r14, r10, r2                   \n\t"
+        "UMLAL      r12, r14, r11, r1                   \n\t"
 
-                /* 29DD73 07661C87 */
+        /* 29DD73 07661C87 */
 
 
-                /* registers r6, r8, r9, r10, r11 must be 
-                   populated with above results after accounting 
-                   for overflow past 26 bit. */
+        /* registers r6, r8, r9, r10, r11 must be
+           populated with above results after accounting
+           for overflow past 26 bit. */
 
-                /* doing d0 --> d1 --> d2 --> d3 --> d4 --> d1 -->d2 */
+        /* doing d0 --> d1 --> d2 --> d3 --> d4 --> d1 -->d2 */
 
-                "MOV        r5, #0x3FFFFFF                      \n\t"
-                "AND        r6, r12, r5                         \n\t"   /* d0 */
+        "MOV        r5, #0x3FFFFFF                      \n\t"
+        "AND        r6, r12, r5                         \n\t"   /* d0 */
 
-                /* d0 overflow to d1 */
-                "POP        { r0, r1, r2, r3, r4, r9, r10, r11 } \n\t"  /* mem 10 */
+        /* d0 overflow to d1 */
+        "POP        { r0, r1, r2, r3, r4, r9, r10, r11 } \n\t"  /* mem 10 */
 
-                "ADDS       r0, r0, r12, LSR #26                \n\t"
-                "ADC        r1, r1, #0                          \n\t"
-                "ADDS       r0, r0, r14, LSL #6                 \n\t"
-                "ADC        r1, r1, #0                          \n\t"
+        "ADDS       r0, r0, r12, LSR #26                \n\t"
+        "ADC        r1, r1, #0                          \n\t"
+        "ADDS       r0, r0, r14, LSL #6                 \n\t"
+        "ADC        r1, r1, #0                          \n\t"
 
-                "AND        r8, r0, r5                          \n\t"   /* d1 */
+        "AND        r8, r0, r5                          \n\t"   /* d1 */
 
-                /* d1 overflow to d2 */
+        /* d1 overflow to d2 */
 
-                "ADDS       r2, r2, r0, LSR #26                 \n\t"
-                "ADC        r3, r3, #0                          \n\t"
-                "ADDS       r2, r2, r1, LSL #6                  \n\t"
-                "ADC        r3, r3, #0                          \n\t"
+        "ADDS       r2, r2, r0, LSR #26                 \n\t"
+        "ADC        r3, r3, #0                          \n\t"
+        "ADDS       r2, r2, r1, LSL #6                  \n\t"
+        "ADC        r3, r3, #0                          \n\t"
 
-                "MOV        r0, r9                              \n\t"
+        "MOV        r0, r9                              \n\t"
 
-                "AND        r9, r2, r5                          \n\t"   /* d2 */
+        "AND        r9, r2, r5                          \n\t"   /* d2 */
 
-                /* d2 overflow to d3 */
+        /* d2 overflow to d3 */
 
-                "ADDS       r4, r4, r2, LSR #26                 \n\t"
-                "ADC        r0, r0, #0                          \n\t"
-                "ADDS       r4, r4, r3, LSL #6                  \n\t"
-                "ADC        r0, r0, #0                          \n\t"
+        "ADDS       r4, r4, r2, LSR #26                 \n\t"
+        "ADC        r0, r0, #0                          \n\t"
+        "ADDS       r4, r4, r3, LSL #6                  \n\t"
+        "ADC        r0, r0, #0                          \n\t"
 
-                /* d3 overflow to d4 */
+        /* d3 overflow to d4 */
 
-                "ADDS       r10, r10, r4, LSR #26               \n\t"
-                "ADC        r11, r11, #0                        \n\t"
-                "ADDS       r10, r10, r0, LSL #6                \n\t"
-                "ADC        r11, r11, #0                        \n\t"
+        "ADDS       r10, r10, r4, LSR #26               \n\t"
+        "ADC        r11, r11, #0                        \n\t"
+        "ADDS       r10, r10, r0, LSL #6                \n\t"
+        "ADC        r11, r11, #0                        \n\t"
 
-                /* d4 overflow to d0, must be multiplied by 5 */        
+        /* d4 overflow to d0, must be multiplied by 5 */
 
-                "LSR        r0, r10, #26                        \n\t"
-                "ADD        r0, r0, r11, LSL #6                 \n\t"
-                "MOV        r1, #5                              \n\t"        
-                "MUL        r0, r0, r1                          \n\t"
-                "ADD        r6, r6, r0                          \n\t"
+        "LSR        r0, r10, #26                        \n\t"
+        "ADD        r0, r0, r11, LSL #6                 \n\t"
+        "MOV        r1, #5                              \n\t"
+        "MUL        r0, r0, r1                          \n\t"
+        "ADD        r6, r6, r0                          \n\t"
 
-                "AND        r11, r10, r5                        \n\t"   /* d4 */
+        "AND        r11, r10, r5                        \n\t"   /* d4 */
 
-                "AND        r10, r4, r5                         \n\t"   /* d3 */
+        "AND        r10, r4, r5                         \n\t"   /* d3 */
 
-                /* d0 overflow to d1 */
+        /* d0 overflow to d1 */
 
-                "ADD        r8, r8, r6, LSR #26                 \n\t"   /* d1 done */
+        "ADD        r8, r8, r6, LSR #26                 \n\t"   /* d1 done */
 
-                "AND        r6, r6, r5                          \n\t"   /* d0 done */        
+        "AND        r6, r6, r5                          \n\t"   /* d0 done */
 
-                "B          armv8_32_poly1305_loop              \n\t"
-        
-        "armv8_32_poly1305_last_block:                          \n\t"
-
-                /* This is the last block of the message
-                   and the block is less than 16 bytes */
-                "MOV        r0, #0                              \n\t"
-                "STR        r0, [sp, %[BYTES_STORE]]            \n\t"
-        
-                "LDR        r0, [sp, %[HIBIT_LOCAL]]            \n\t"
-
-                /* Make sure the upper bytes of the 
-                   32 bit pieces are set to zero. 
-                   Set the byte past the last message
-                   data byte to 01. */
-
-                "PUSH       { r4, r6, r8 }                      \n\t"        
-
-                "MOV        r1,  #0                             \n\t"
-                "MOV        r2,  #0                             \n\t"
-                "MOV        r3,  #0                             \n\t"
-                "MOV        r4,  #0xFFFFFFFF                    \n\t"
-                "LSR        r0, r0, #24                         \n\t"
-                "MOV        r6,  r0                             \n\t"
-
-                /* always going to load at least one */                
-                "LDR        r0, [r7]                            \n\t"
-
-                /* byte offset to bit offset */ 
-                "ADD        r5, r5, #16                         \n\t"
-                "LSL        r5, r5, #3                          \n\t"                        
-
-                /* which block */
-                "CMP        r5, #32                             \n\t"
-                "BGE        not_word_0                          \n\t"
-
-                /* case word 0 */
-        "case0:"
-                "LSL        r8, r4, r5                          \n\t"
-                "BIC        r0, r0, r8                          \n\t"
-                "LSL        r8, r6, r5                          \n\t"
-                "ADD        r0, r0, r8                          \n\t"
-                "B          last_block_done                     \n\t"
-
-        "not_word_0:                                            \n\t"
-                "LDR        r1, [r7, #4]                        \n\t"
-                
-                "SUB        r5, r5, #32                         \n\t"
-                "CMP        r5, #32                             \n\t"
-                "BGE        not_word_1                          \n\t"
-
-                "LSL        r8, r4, r5                          \n\t"
-                "BIC        r1, r1, r8                          \n\t"
-                "LSL        r8, r6, r5                          \n\t"
-                "ADD        r1, r1, r8                          \n\t"                
-                "B          last_block_done                     \n\t"
-
-        "not_word_1:                                            \n\t"
-                "LDR        r2, [r7, #8]                        \n\t"
-
-                "SUB        r5, r5, #32                         \n\t"
-                "CMP        r5, #32                             \n\t"
-                "BGE        not_word_2                          \n\t"
-
-                "LSL        r8, r4, r5                          \n\t"
-                "BIC        r2, r2, r8                          \n\t"
-                "LSL        r8, r6, r5                          \n\t"
-                "ADD        r2, r2, r8                          \n\t"                
-                "B          last_block_done                     \n\t"
-
-        "not_word_2:                                            \n\t"
-                "LDR        r3, [r7, #0xC]                      \n\t"
-
-                "SUB        r5, r5, #32                         \n\t"
-
-                "LSL        r8, r4, r5                          \n\t"
-                "BIC        r3, r3, r8                          \n\t"
-                "LSL        r8, r6, r5                          \n\t"
-                "ADD        r3, r3, r8                          \n\t"        
-
-        "last_block_done:                                       \n\t"
-
-                "POP        { r4, r6, r8 }                      \n\t"        
-        
-                "b          armv8_32_poly1305_done_01_byte_appended \n\t"
-        
-        "armv8_32_poly1305_done:                                \n\t"
-
-                "ADD        sp, #28                             \n\t"
-                "POP        { r7 }                              \n\t"
-
-                /* store final result */
-                "LDR        r0, %[h_ptr]                        \n\t"
-                "STM        r0, { r6, r8, r9, r10, r11 }        \n\t"
-                
-                : [m]              "+m" (msgDataOnStack),        /* input */
-                  [r_ptr]          "+m" (r_ptrLocal),            /* input */
-                  [h_ptr]          "+m" (h_ptrLocal),            /* input, output */
-                  [bytes]          "+m" (msgDataLenOnStack),     /* input */
-                  [hibit]          "+m" (hibitOnStack)           /* input */
-                  
-                : [BYTES_STORE]    "I" (BYTES_SP_OFF),
-                  [HIBIT_LOCAL]    "I" (HIBIT_LOCAL_SP_OFF)
-                : "memory", "cc", 
-                        "r0", "r1", "r2", "r3", "r4", "r5", "r6", "r8", "r9", "r10",
-                        "r11", "r12", "lr"
-        );
-
-        memcpy(ctx->r, r, 5 * sizeof(unsigned));
-        memcpy(ctx->h, h, 5 * sizeof(unsigned));
+        "B          armv8_32_poly1305_loop              \n\t"
+
+    "armv8_32_poly1305_last_block:                      \n\t"
+
+        /* This is the last block of the message
+           and the block is less than 16 bytes */
+        "MOV        r0, #0                              \n\t"
+        "STR        r0, [sp, %[BYTES_STORE]]            \n\t"
+
+        "LDR        r0, [sp, %[HIBIT_LOCAL]]            \n\t"
+
+        /* Make sure the upper bytes of the
+           32 bit pieces are set to zero.
+           Set the byte past the last message
+           data byte to 01. */
+
+        "PUSH       { r4, r6, r8 }                      \n\t"
+
+        "MOV        r1,  #0                             \n\t"
+        "MOV        r2,  #0                             \n\t"
+        "MOV        r3,  #0                             \n\t"
+        "MOV        r4,  #0xFFFFFFFF                    \n\t"
+        "LSR        r0, r0, #24                         \n\t"
+        "MOV        r6,  r0                             \n\t"
+
+        /* always going to load at least one */
+        "LDR        r0, [r7]                            \n\t"
+
+        /* byte offset to bit offset */
+        "ADD        r5, r5, #16                         \n\t"
+        "LSL        r5, r5, #3                          \n\t"
+
+        /* which block */
+        "CMP        r5, #32                             \n\t"
+        "BGE        not_word_0                          \n\t"
+
+        /* case word 0 */
+    "case0:"
+        "LSL        r8, r4, r5                          \n\t"
+        "BIC        r0, r0, r8                          \n\t"
+        "LSL        r8, r6, r5                          \n\t"
+        "ADD        r0, r0, r8                          \n\t"
+        "B          last_block_done                     \n\t"
+
+    "not_word_0:                                        \n\t"
+        "LDR        r1, [r7, #4]                        \n\t"
+
+        "SUB        r5, r5, #32                         \n\t"
+        "CMP        r5, #32                             \n\t"
+        "BGE        not_word_1                          \n\t"
+
+        "LSL        r8, r4, r5                          \n\t"
+        "BIC        r1, r1, r8                          \n\t"
+        "LSL        r8, r6, r5                          \n\t"
+        "ADD        r1, r1, r8                          \n\t"
+        "B          last_block_done                     \n\t"
+
+    "not_word_1:                                        \n\t"
+        "LDR        r2, [r7, #8]                        \n\t"
+
+        "SUB        r5, r5, #32                         \n\t"
+        "CMP        r5, #32                             \n\t"
+        "BGE        not_word_2                          \n\t"
+
+        "LSL        r8, r4, r5                          \n\t"
+        "BIC        r2, r2, r8                          \n\t"
+        "LSL        r8, r6, r5                          \n\t"
+        "ADD        r2, r2, r8                          \n\t"
+        "B          last_block_done                     \n\t"
+
+    "not_word_2:                                        \n\t"
+        "LDR        r3, [r7, #0xC]                      \n\t"
+
+        "SUB        r5, r5, #32                         \n\t"
+
+        "LSL        r8, r4, r5                          \n\t"
+        "BIC        r3, r3, r8                          \n\t"
+        "LSL        r8, r6, r5                          \n\t"
+        "ADD        r3, r3, r8                          \n\t"
+
+    "last_block_done:                                   \n\t"
+
+        "POP        { r4, r6, r8 }                      \n\t"
+
+        "b          armv8_32_poly1305_done_01_byte_appended \n\t"
+
+    "armv8_32_poly1305_done:                                \n\t"
+
+        "ADD        sp, #28                             \n\t"
+        "POP        { r7 }                              \n\t"
+
+        /* store final result */
+        "LDR        r0, %[h_ptr]                        \n\t"
+        "STM        r0, { r6, r8, r9, r10, r11 }        \n\t"
+
+        : [m]              "+m" (msgDataOnStack),        /* input */
+          [r_ptr]          "+m" (r_ptrLocal),            /* input */
+          [h_ptr]          "+m" (h_ptrLocal),            /* input, output */
+          [bytes]          "+m" (msgDataLenOnStack),     /* input */
+          [hibit]          "+m" (hibitOnStack)           /* input */
+
+        : [BYTES_STORE]    "I" (BYTES_SP_OFF),
+          [HIBIT_LOCAL]    "I" (HIBIT_LOCAL_SP_OFF)
+        : "memory", "cc",
+                    "r0", "r1", "r2", "r3", "r4", "r5", "r6", "r8", "r9", "r10",
+                    "r11", "r12", "lr"
+    );
+
+    memcpy(ctx->r, r, 5 * sizeof(unsigned));
+    memcpy(ctx->h, h, 5 * sizeof(unsigned));
 
 #ifdef POLY1305_VERBOSE
-        for (i=0;i<5;++i) printf("h%d %07X ", i, ctx->h[i]);
-        printf("\n");
+    for (i=0;i<5;++i) printf("h%d %07X ", i, ctx->h[i]);
+    printf("\n");
 
-        printf("armv8_32_poly1305_blocks() leaving\n");
+    printf("armv8_32_poly1305_blocks() leaving\n");
 #endif
 
 }
 
 #else
 
-void armv8_32_poly1305_blocks(Poly1305* ctx, 
-			const unsigned char *msgData,
-                     	size_t msgDataLen)
+void armv8_32_poly1305_blocks(Poly1305* ctx, const unsigned char *msgData,
+    size_t msgDataLen)
 {
-	unsigned r[5], *r_ptrLocal, h1[5], h2[5], *h1_ptrLocal;
-	unsigned *h2_ptrLocal, *r2_ptrLocal;
-	unsigned msgDataOnStack = (unsigned)msgData;
-	unsigned msgDataLenOnStack = msgDataLen;
-	/* 1 << 128 */
- 	unsigned hibitOnStack = (ctx->finished) ? 0 : ((unsigned) 1 << 24); 
-    	unsigned r_2[5];
-	int i;
-
-	memcpy(r, ctx->r, 5*sizeof(unsigned));
-
-	if (msgDataLen <= 16)
-	{
-		memcpy(h1, ctx->h, 5*sizeof(unsigned));
-		memset(h2, 0, 5*sizeof(unsigned));
-	}
-	else
-	{
-		memset(h1, 0, 5*sizeof(unsigned));
-		memcpy(h2, ctx->h, 5*sizeof(unsigned));
-	}
-
-	calculateRsquared(r, r_2);
-
-	/* 32 bit pointer, this is necessary to pass the pointer value
-           into the assembly code */
-	r_ptrLocal = (unsigned *) r;
- 	r2_ptrLocal = r_2;
-	h1_ptrLocal = (unsigned *) h1;
-	h2_ptrLocal = (unsigned *) h2;
-
+    unsigned r[5], *r_ptrLocal, h1[5], h2[5], *h1_ptrLocal;
+    unsigned *h2_ptrLocal, *r2_ptrLocal;
+    unsigned msgDataOnStack = (unsigned)msgData;
+    unsigned msgDataLenOnStack = msgDataLen;
+    /* 1 << 128 */
+    unsigned hibitOnStack = (ctx->finished) ? 0 : ((unsigned) 1 << 24);
+    unsigned r_2[5];
 #ifdef POLY1305_VERBOSE
-	int j;
-	printf("armv8_32_poly1305_blocks() >> Before Assembly << ");
-	printf("  length of data (%d) 0x%X\n\n", msgDataLen, msgDataLen);
-
-	for (i=0;i<5;++i) 
-		printf("h%d %08X ", i, h1[i]);
-	printf("\n");
-
-	printf(" r ");
-	for (j=0;j<5;++j) 
-		printf(" %d %08X ", j, r[j]);
-	printf("\n");
-	/* 00BED685  03555502  0047C036  01003949  000806D5 */
-	
-	printf(" r^2 ");
-	for (j=0;j<5;++j) 
-		printf(" %d %08X ", j, r_2[j]);
-	printf("\n");
-	
-	/* CA0455  1DD847D  23C50AA  36BC0AC  19106A3 */
+    int i;
 #endif
 
-	__asm__ __volatile__ (
-		".align	8	 				\n\t"
-
-		/* valid registers are d0..d31 */
-
-		/* load r values into d0..d4 */
-		"LDR		r11, %[r_ptr]			\n\t"
-		"LDM		r11, { r0, r1, r2, r3, r4 }	\n\t"
-
-		"LDR		r11, %[r2_ptr]			\n\t"
-		"LDM		r11, { r5, r6, r8, r9, r10 }	\n\t"
-
-		"VMOV		s0, s1, r0, r5			\n\t"   /* d0 */
-		"VMOV		s2, s3, r1, r6			\n\t"   /* d1 */
-		"VMOV		s4, s5, r2, r8			\n\t"   /* d2 */
-		"VMOV		s6, s7, r3, r9			\n\t"   /* d3 */
-		"VMOV		s8, s9, r4, r10			\n\t"   /* d4 */
-
-		"MOV		r0, #5				\n\t"
-		"MUL		r1, r1, r0			\n\t"
-		"MUL		r2, r2, r0			\n\t"
-		"MUL		r3, r3, r0			\n\t"
-		"MUL		r4, r4, r0			\n\t"
-
-		"MUL		r6, r6, r0			\n\t"
-		"MUL		r8, r8, r0			\n\t"
-		"MUL		r9, r9, r0			\n\t"
-		"MUL		r10, r10, r0			\n\t"
-
-		"VMOV		s10, s11, r1, r6		\n\t"   /* d5 */
-		"VMOV		s12, s13, r2, r8		\n\t"   /* d6 */
-		"VMOV		s14, s15, r3, r9		\n\t"   /* d7 */
-		"VMOV		s16, s17, r4, r10		\n\t"   /* d8 */
-		
-		/* load h values into d10..d15 */
-		"LDR		r11, %[h_ptr1]			\n\t"
-		"LDM		r11, { r0, r1, r2, r3, r4 }	\n\t"
-		"LDR		r11, %[h_ptr2]			\n\t"
-		"LDM		r11, { r5, r6, r8, r9, r10 }	\n\t"
-
-		"VMOV		s18, s19, r0, r5		\n\t"   /* d9  */
-		"VMOV		s20, s21, r1, r6		\n\t"   /* d10 */
-		"VMOV		s22, s23, r2, r8		\n\t"   /* d11 */
-		"VMOV		s24, s25, r3, r9		\n\t"   /* d12 */
-		"VMOV		s26, s27, r4, r10		\n\t"   /* d13 */
-
-		"VMOV		d24, d9				\n\t"
-		"VMOV		d25, d10			\n\t"
-		"VMOV		d26, d11			\n\t"
-		"VMOV		d27, d12			\n\t"
-		"VMOV		d28, d13			\n\t"
-		"LDR		r1, %[m]			\n\t"
-		"LDR		r2, %[bytes]			\n\t"
-		"LDR		r3, %[hibit]			\n\t"
-
-		"VMOV		s28, s29, r3, r3		\n\t"   /* d14 */
-		"VMOV 		d29, d14 			\n\t"   /* d29 */
-
-		"VMOV.i32	d30, #0x3FFFFFF			\n\t"
-		"VSHR.u64	d30, #32			\n\t"
-
-		"VMOV.i32	d27, #0x5			\n\t"
-		"VSHR.u64	d27, #32			\n\t"
-
-	"armv8_32_poly1305_loop:				\n\t"
-
-		/* The poly1305 algorithm requires that a 01 byte 
-		   be placed after the last byte of the block. */ 		
-
-		"CMP		r2, #0				\n\t"
-		"BEQ		armv8_32_poly1305_done		\n\t"
-	
-		/* branch for least likely case, may help with pipelining */
-		/* ARMv8 uses predictive pipelining.  There is no way
-		   to specify in the instruction encoding the more likely
-		   case.  */
-		"CMP		r2, #16				\n\t"
-		"BLT		armv8_32_poly1305_last_block	\n\t"  
-
-		"SUBS 		r2, r2, #16			\n\t"
-
-		/* this block is 16 bytes */		
-
-		/* load next 16 byte block of message */		
-		"LDM		r1, { r4, r5, r6, r8 }		\n\t"
-		"ADD		r1, r1, #16			\n\t"
-
-		/* in RFC 7539, each block processed is prepended by
-  		   a byte of value 0x01.  In the wolfSSL implementation,
-		   the setting of this value is based on the value found
-		   in ctx->finish. To save a memory reference, this code
-		   could be replicated one version adding the byte, one
-		   version not. */
-
-		/* This is byte 16, past the 128 bits of 
-		   Hence, update is done to h4. */  
-	
-
-	"armv8_32_poly1305_done_01_byte_appended:		\n\t"
-
-		"CMP		r2, #0				\n\t"
-		"BEQ		onlyOneBlock			\n\t"			
-
-	"twoBlocks:						\n\t"
-		/* r4 = 70797243  r5 = 72676F74  r6 = 69687061  r8 = 6F462063 */
-
-		"VMOV		r9, s27				\n\t"
-		"ADD		r9, r9, r3			\n\t"
-		"VMOV		s27, r9				\n\t"
-
-		"MOV	    r9, #0x3FFFFFF			\n\t"
-
-              	/* h0 += r4 & 0x3FFFFFF; */
-		"VMOV	    r10, s19				\n\t"	/* s19, s21 */
-		"VMOV	    r11, s21				\n\t"
-
-                "AND        r0, r4, r9                         \n\t"
-                "ADD        r10, r10, r0                       \n\t"   /* 797243 */
-
-                /* h1 += (r5:r4 >> 26) & 0x3FFFFFF */
-                "LSR        r0, r4, #26                        \n\t"   /* 26 */
-                "ADD        r0, r0, r5, LSL #6                \n\t"
-                "AND        r0, r0, r9                        \n\t"
-                "ADD        r11, r11, r0                       \n\t"   /* 1DBDD1C */
-	
-		"VMOV	    s19, r10				\n\t"
-		"VMOV	    s21, r11				\n\t"	
-
-                /* h2 += (r6:r5 >> 20) & 0x3FFFFFF */
-		"VMOV	    r10, s23				\n\t"  /* s23, s25 */
-		"VMOV	    r11, s25				\n\t"
-
-                "LSR        r0, r5, #20                        \n\t"  /* 20+32 = 52 */
-                "ADD        r0, r0, r6, LSL #12               \n\t"
-                "AND        r0, r0, r9                        \n\t"
-                "ADD        r10, r10, r0                       \n\t"  /* 3061726 */
-                /* h3 += (r8:r6 >> 14) & 0x3FFFFFF */
-                "LSR        r0, r6, #14                        \n\t"  /* 14+32+32 = 78 */
-                "ADD        r0, r0, r8, LSL #18               \n\t"
-                "AND        r0, r0, r9                        \n\t"
-                "ADD        r11, r11, r0                       \n\t"  /* 18dA5A1 */
-
-		"VMOV	    s23, r10				\n\t"
-		"VMOV	    s25, r11				\n\t"
-
-                /* h4 += r3 >> 8                   */
-		"VMOV	    r10, s27				\n\t"
-                "ADD        r10, r10, r8, LSR #8                \n\t"  /* 8+32+32+32 = 104 */
-		"VMOV	    s27, r10				\n\t"  /* 16F4620 */
-
-		/* s19 = 0797243  s21 = 1DBDD1C  s23 = 3061726  s25 = 18DA5A1  s27 = 16F4620 */
-		
-		"CMP	    r2, #16				\n\t"
-		"BLT	    armv8_32_poly1305_last_block	\n\t"  
-
-		/* FIX */
-		"LDM	    r1, { r4, r5, r6, r8 }		\n\t"
-		"ADD	    r1, r1, #16				\n\t"
-		"SUBS 	    r2, r2, #16				\n\t"
-
-	"onlyOneBlock:						\n\t"
-
-		/* FIX must handle short blocks as well */
-		/* FIX HIBIT */
-		/* set hibit for a full size 16 byte block */
-		"VMOV	    r9, s26				\n\t"
-		"ADD	    r9, r9, r3				\n\t"
-		"VMOV	    s26, r9				\n\t"
-
-	"onlyOneBlock_hibit_set:				\n\t"
-
-		"MOV	    r9, #0x3FFFFFF 			\n\t"
-
-              	/* h0 += r4 & 0x3FFFFFF; */
-		"VMOV	    r10, s18				\n\t"	/* s18, s20 */
-		"VMOV	    r11, s20				\n\t"
-
-                "AND        r0, r4, r9                         \n\t"
-                "ADD        r10, r10, r0                       \n\t"
-
-                /* h1 += (r5:r4 >> 26) & 0x3FFFFFF */
-                "LSR        r0, r4, #26                        \n\t"   /* 26 */
-                "ADD        r0, r0, r5, LSL #6                \n\t"
-                "AND        r0, r0, r9                        \n\t"
-                "ADD        r11, r11, r0                       \n\t"  
-	
-		"VMOV	    s18, r10				\n\t"
-		"VMOV	    s20, r11				\n\t"	
-
-                /* h2 += (r6:r5 >> 20) & 0x3FFFFFF */
-		"VMOV	    r10, s22				\n\t"  /* s22, s24 */
-		"VMOV	    r11, s24				\n\t"
-
-                "LSR        r0, r5, #20                        \n\t"  /* 20+32 = 52 */
-                "ADD        r0, r0, r6, LSL #12               \n\t"
-                "AND        r0, r0, r9                        \n\t"
-                "ADD        r10, r10, r0                       \n\t"  
-                /* h3 += (r8:r6 >> 14) & 0x3FFFFFF */
-                "LSR        r0, r6, #14                        \n\t"  /* 14+32+32 = 78 */
-                "ADD        r0, r0, r8, LSL #18               \n\t"
-                "AND        r0, r0, r9                        \n\t"
-                "ADD        r11, r11, r0                       \n\t"  
-
-		"VMOV	    s22, r10				\n\t"
-		"VMOV	    s24, r11				\n\t"
-
-                /* h4 += r3 >> 8                   */
-		"VMOV	    r10, s26				\n\t"  /* s26 */
-                "ADD        r10, r10, r8, LSR #8                \n\t"  /* 8+32+32+32 = 104 */
-		"VMOV	    s26, r10				\n\t" 
-
-		/* s18 = 06D7572  s20 = 0D95488  s22 = 3261657  s24 = 081A18D  s26 = 1746573 */
-
-	"checkRegs:						\n\t"
-		/* partial0 = h0 * r0 + h1 * 5*r4 + h2 * 5*r3 + h3 * 5*r2 + h4 * 5*r1 */
-		/* partial1 = h0 * r1 + h1 * r0   + h2 * 5*r4 + h3 * 5*r3 + h4 * 5*r2 */
-		/* partial2 = h0 * r2 + h1 * r1   + h2 * r0   + h3 * 5*r4 + h4 * 5*r3 */
-		/* partial3 = h0 * r3 + h1 * r2   + h2 * r1   + h3 * r0   + h4 * 5*r4 */
-		/* partial4 = h0 * r4 + h1 * r3   + h2 * r2   + h3 * r1   + h4 * r0   */
-
-	
-		/*  d15 = d9 * d0 +  d10 * d8 +  d11 * d7 +  d12 * d6 +  d13 * d5 */
-		/*  d16 = d9 * d1 +  d10 * d0 +  d11 * d8 +  d12 * d7 +  d13 * d6 */
-		/*  d17 = d9 * d2 +  d10 * d1 +  d11 * d0 +  d12 * d8 +  d13 * d7 */
-		/*  d18 = d9 * d3 +  d10 * d2 +  d11 * d1 +  d12 * d0 +  d13 * d8 */
-		/*  d19 = d9 * d4 +  d10 * d3 +  d11 * d2 +  d12 * d1 +  d13 * d0  */
-
-
-		/* registers d15, d16, d17, d18, d19 contain the 
-		   incremental d results. */
-
-
-      		/* partial0 = q8 = d17:d16 */
-		"VMULL.u32	q8,  d9, d0   			\n\t"
-		"VMLAL.u32	q8, d10, d8   			\n\t"
-		"VMLAL.u32	q8, d11, d7   			\n\t"
-		"VMLAL.u32	q8, d12, d6   			\n\t"
-		"VMLAL.u32	q8, d13, d5   			\n\t"
-		/* 29DD73 07661C87 */
-
-      		/* partial1 = q9 = d19:d18 */
-		"VMULL.u32	q9,  d9, d1   			\n\t"
-		"VMLAL.u32	q9, d10, d0   			\n\t"
-		"VMLAL.u32	q9, d11, d8   			\n\t"
-		"VMLAL.u32	q9, d12, d7   			\n\t"
-		"VMLAL.u32	q9, d13, d6   			\n\t"
-		/* D3993 E9038575 */
-
- 		/* partial1 = q10 = d21:d20 */
-		"VMULL.u32	q10,  d9, d2   			\n\t"
-		"VMLAL.u32	q10, d10, d1   			\n\t"
-		"VMLAL.u32	q10, d11, d0   			\n\t"
-		"VMLAL.u32	q10, d12, d8   			\n\t"
-		"VMLAL.u32	q10, d13, d7   			\n\t"
-		/* 10019D F79AAF81 */
-
- 		/* partial1 = q11 = d23:d22 */
-		"VMULL.u32	q11,  d9, d3   			\n\t"
-		"VMLAL.u32	q11, d10, d2   			\n\t"
-		"VMLAL.u32	q11, d11, d1   			\n\t"
-		"VMLAL.u32	q11, d12, d0   			\n\t"
-		"VMLAL.u32	q11, d13, d8   			\n\t"
-		/* C753B 56120E14 */
-
- 		/* partial1 = q12 = d25:d24 */
-		"VMULL.u32	q12,  d9, d4   			\n\t"
-		"VMLAL.u32	q12, d10, d3   			\n\t"
-		"VMLAL.u32	q12, d11, d2   			\n\t"
-		"VMLAL.u32	q12, d12, d1   			\n\t"
-		"VMLAL.u32	q12, d13, d0   			\n\t"
-	        /* 8F852 C3AB3DA1 */
-
-		/* message buff 1 times r 
-		   d16 = 02929E2 D10FA341 
-	 	   d18 = 0071FD6 14380FCE 
-		   d20 = 00CA7F3 14E3B1DB 
-		   d22 = 00BC46F BD0D158C  
-		   d24 = 0048496 DE32A7D5 */
-
-		/* message buff 2 times r squared 
-		   d17 = 06165D0 CB2EA8BD 
-		   d19 = 044A41C F0475619 
-		   d21 = 02B9EA1 79EE3BD7 
-                   d23 = 017E1B1 ED6D017F 
-		   d25 = 011E440 9C3DCCF2 */
-
-		/* doing d0 --> d1 --> d2 --> d3 --> d4 --> d1 -->d2 */
-		
-		/* d16 --> d18 --> d20 --> d22 --> d24 --> d16 --> d18 */
-
-		/* d0 = d16 * 0x3FFFFF */
-		"VAND.u64	d15, d16, d30			\n\t"  
-		"VMOV 		s18, s30			\n\t"	/* d0 */
-
-		/* d9 = 10FA341 value before wrap around */
-
-		/* d1 = (d18 + (d16 >> 26)) & 0x3FFFFFF */
-		"VSHR.u64	d28, d16, #26			\n\t"
-		"VADD.u64	d18, d18, d28			\n\t"
-		"VAND.u64	d15, d18, d30			\n\t"   /* d1 */
-		"VMOV		s20, s30			\n\t"
-
-		/* d10 = 43EA6A8   */
-
-		/* d1 overflow to d2 */
-
-		/* d2 = (d20 + (d18 >> 26)) & 0x3FFFFFF */
-		"VSHR.u64	d28, d18, #26			\n\t"
-		"VADD.u64	d20, d20, d28			\n\t"
-		"VAND.u64	d15, d20, d30			\n\t"   /* d2 */
-		"VMOV		s22, s30			\n\t"		
-
-		/* d2 overflow to d3 */
-
-		"VSHR.u64	d28, d20, #26			\n\t"
-		"VADD.u64	d22, d22, d28			\n\t"
-		"VAND.u64	d15, d22, d30			\n\t"   /* d3 */
-		"VMOV		s24, s30			\n\t"
-
-		/* d3 overflow to d4 */
-
-		"VSHR.u64	d28, d22, #26			\n\t"
-		"VADD.u64	d24, d24, d28			\n\t"
-		"VAND.u64	d15, d24, d30			\n\t"   /* d4 */
-		"VMOV		s26, s30			\n\t"
-		
-		/* d4 overflow to d0 */
-
-		"VSHR.u64	d15, d24, #26			\n\t"
-		/* multiply d15 by 5 */
-		"VMOV		r6, s30				\n\t"
-		"MOV		r5, #5				\n\t"
-		"MUL		r6, r5, r6			\n\t"
-		"VMOV		r4, s18				\n\t"
-		"ADD		r4, r4, r6			\n\t"   /* d0 + 5 * d4 roll over */
-		
-		"MOV		r5, #0x3FFFFFF			\n\t"
-		"AND		r8, r4, r5			\n\t"
-		"VMOV		s18, r8				\n\t"
-		
-		"VMOV		r6, s20				\n\t"	
-		"ADD		r6, r6, r4, LSR #26		\n\t"
-		"VMOV		s20, r6				\n\t"
-
-
-		/* final H values : d9 = 2B55FD9  d10 = 2828883  d11 = 2ABA762 
-				   d12 = 371251  d13 = 123C3C5 */
-
-
-		/* doing d0 --> d1 --> d2 --> d3 --> d4 --> d1 -->d2 */
-		
-		/* d17 --> d19 --> d21 --> d23 --> d25 --> d17 --> d19 */
-
-		/* d0 = d16 * 0x3FFFFF */
-		"VAND.u64	d15, d17, d30			\n\t"  
-		"VMOV 		s19, s30			\n\t"	/* d0 */
-
-		/* d9 = 10FA341 value before wrap around */
-
-		/* d1 = (d18 + (d16 >> 26)) & 0x3FFFFFF */
-		"VSHR.u64	d28, d17, #26			\n\t"
-		"VADD.u64	d19, d19, d28			\n\t"
-		"VAND.u64	d15, d19, d30			\n\t"   /* d1 */
-		"VMOV		s21, s30			\n\t"
-
-		/* d10 = 43EA6A8   */
-
-		/* d1 overflow to d2 */
-
-		/* d2 = (d20 + (d18 >> 26)) & 0x3FFFFFF */
-		"VSHR.u64	d28, d19, #26			\n\t"
-		"VADD.u64	d21, d21, d28			\n\t"
-		"VAND.u64	d15, d21, d30			\n\t"   /* d2 */
-		"VMOV		s23, s30			\n\t"		
-
-		/* d2 overflow to d3 */
-
-		"VSHR.u64	d28, d21, #26			\n\t"
-		"VADD.u64	d23, d23, d28			\n\t"
-		"VAND.u64	d15, d23, d30			\n\t"   /* d3 */
-		"VMOV		s25, s30			\n\t"
-
-		/* d3 overflow to d4 */
-
-		"VSHR.u64	d28, d23, #26			\n\t"
-		"VADD.u64	d25, d25, d28			\n\t"
-		"VAND.u64	d15, d25, d30			\n\t"   /* d4 */
-		"VMOV		s27, s30			\n\t"
-		
-		/* d4 overflow to d0 */
-
-		"VSHR.u64	d15, d25, #26			\n\t"
-		/* multiply d15 by 5 */
-		"VMOV		r6, s30				\n\t"
-		"MOV		r5, #5				\n\t"
-		"MUL		r6, r5, r6			\n\t"
-		"VMOV		r4, s19				\n\t"
-		"ADD		r4, r4, r6			\n\t"   /* d0 + 5 * d4 roll over */
-		
-		"MOV		r5, #0x3FFFFFF			\n\t"
-		"AND		r8, r4, r5			\n\t"
-		"VMOV		s19, r8				\n\t"
-		
-		"VMOV		r6, s21				\n\t"	
-		"ADD		r6, r6, r4, LSR #26		\n\t"
-		"VMOV		s21, r6				\n\t"
-
-		/* final H values : d9 = 18BF985  d10 = A0CA51  d11 = 3174319  
-				   d12 = 54A9E1  d13 = 2363970 */
-
-		"CMP 		r2, #0x10  		 \n\t"
-		"BLE		oneBlockLeft		 \n\t"
-
-		/* add the two h vectors together */
-		"MOV		r5, #0			\n\t"
-		"VMOV		r4, r10, s18, s19	\n\t"
-		"ADD		r4, r4, r10		\n\t"
-		"VMOV		s18, s19, r5, r4	\n\t"
-
-		"VMOV		r4, r10, s20, s21	\n\t"
-		"ADD		r4, r4, r10		\n\t"
-		"VMOV		s20, s21, r5, r4	\n\t"
-
-		"VMOV		r4, r10, s22, s23	\n\t"
-		"ADD		r4, r4, r10		\n\t"
-		"VMOV		s22, s23, r5, r4	\n\t"
-
-		"VMOV		r4, r10, s24, s25	\n\t"
-		"ADD		r4, r4, r10		\n\t"
-		"VMOV		s24, s25, r5, r4	\n\t"
-
-		"VMOV		r4, r10, s26, s27	\n\t"
-		"ADD		r4, r4, r10		\n\t"
-		"VMOV		s26, s27, r5, r4	\n\t"
-		"B		armv8_32_poly1305_loop	\n\t"
-
-	"oneBlockLeft: 					\n\t"
-		/* only one block left in message */
-		/* add the two h vectors together */
-		"MOV		r5, #0			\n\t"
-		"VMOV		r4, r10, s18, s19	\n\t"
-		"ADD		r4, r4, r10		\n\t"
-		"VMOV		s18, s19, r4, r5	\n\t"
-
-		"VMOV		r4, r10, s20, s21	\n\t"
-		"ADD		r4, r4, r10		\n\t"
-		"VMOV		s20, s21, r4, r5	\n\t"
-
-		"VMOV		r4, r10, s22, s23	\n\t"
-		"ADD		r4, r4, r10		\n\t"
-		"VMOV		s22, s23, r4, r5	\n\t"
-
-		"VMOV		r4, r10, s24, s25	\n\t"
-		"ADD		r4, r4, r10		\n\t"
-		"VMOV		s24, s25, r4, r5	\n\t"
-
-		"VMOV		r4, r10, s26, s27	\n\t"
-		"ADD		r4, r4, r10		\n\t"
-		"VMOV		s26, s27, r4, r5	\n\t"
-		"B		armv8_32_poly1305_loop	\n\t"
-	
-	"armv8_32_poly1305_last_block:			\n\t"
-
-		/* This is the last block of the message
-		   and the block is less than 16 bytes */
-
-		/* r1 is message pointer
-		   r2 is byte count, which is less than 16 
-		   r3 is hibit	*/
-
-		/* Make sure the upper bytes of the 
-		   32 bit pieces are set to zero. 
-		   Set the byte past the last message
-		   data byte to 01. */
-
-		"MOV	r10, r2				\n\t"
-
-		"PUSH	{ r0, r1, r2, r3 } 		\n\t"
-
-		"MOV	r9,  r1				\n\t"	
-
-		"LSR	r3,  r3, #24			\n\t"
-		"MOV	r6,  r3				\n\t"
-
-		"MOV    r1,  #0				\n\t"
-		"MOV	r2,  #0				\n\t"
-		"MOV	r3,  #0				\n\t"
-		"MOV	r4,  #0xFFFFFFFF		\n\t"
-
-		/* always going to load at least one */		
-		"LDR	r0, [r9]			\n\t"
-
-		/* byte offset to bit offset */ 
-		"LSL	r10, r10, #3			\n\t"			
-
-		/* which block */
-		"CMP	r10, #32			\n\t"
-		"BGE	not_word_0			\n\t"
-
-		/* case word 0 */
-	"case0:"
-		"LSL	r8, r4, r10			\n\t"
-		"BIC  	r0, r0, r8			\n\t"
-		"LSL	r8, r6, r10			\n\t"
-		"ADD	r0, r0, r8			\n\t"
-		"B	last_block_done			\n\t"
-
-	"not_word_0:	 				\n\t"
-		"LDR	r1, [r9, #4]			\n\t"
-		
-		"SUB	r10, r10, #32			\n\t"
-		"CMP	r10, #32			\n\t"
-		"BGE	not_word_1			\n\t"
-
-		"LSL	r8, r4, r10			\n\t"
-		"BIC  	r1, r1, r8			\n\t"
-		"LSL	r8, r6, r10			\n\t"
-		"ADD	r1, r1, r8			\n\t"		
-		"B	last_block_done			\n\t"
-
-	"not_word_1:					\n\t"
-		"LDR	r2, [r9, #8]			\n\t"
-
-		"SUB	r10, r10, #32			\n\t"
-		"CMP	r10, #32			\n\t"
-		"BGE	not_word_2			\n\t"
-
-		"LSL	r8, r4, r10			\n\t"
-		"BIC  	r2, r2, r8			\n\t"
-		"LSL	r8, r6, r10			\n\t"
-		"ADD	r2, r2, r8			\n\t"		
-		"B	last_block_done			\n\t"
-
-	"not_word_2:					\n\t"
-		"LDR	r3, [r9, #0xC]			\n\t"
-
-		"SUB	r10, r10, #32			\n\t"
-
-		"LSL	r8, r4, r10			\n\t"
-		"BIC  	r3, r3, r8			\n\t"
-		"LSL	r8, r6, r10			\n\t"
-		"ADD	r3, r3, r8			\n\t"	
-
-	"last_block_done:				\n\t"
-
-		"MOV 	r4, r0				\n\t"
-		"MOV 	r5, r1				\n\t"
-		"MOV 	r6, r2				\n\t"
-		"MOV 	r8, r3				\n\t"
-
-		"POP	{ r0, r1, r2, r3 }	\n\t"	
-
-		/* set the byte count to 0 */
-		"MOV		r2, #0			\n\t"
-	
-		"b		onlyOneBlock_hibit_set	\n\t"	
-
-		"b 	armv8_32_poly1305_done_01_byte_appended \n\t"
-	
-		".align 2 \n\t"
-	"armv8_32_poly1305_done:			\n\t"
-
-		"VMOV	r0, s18				\n\t"
-		"VMOV	r1, s20				\n\t"
-		"VMOV	r2, s22				\n\t"
-		"VMOV	r3, s24				\n\t"
-		"VMOV	r4, s26				\n\t"
+    memcpy(r, ctx->r, 5*sizeof(unsigned));
+
+    if (msgDataLen <= 16) {
+        memcpy(h1, ctx->h, 5*sizeof(unsigned));
+        memset(h2, 0, 5*sizeof(unsigned));
+    }
+    else {
+        memset(h1, 0, 5*sizeof(unsigned));
+        memcpy(h2, ctx->h, 5*sizeof(unsigned));
+    }
+
+    calculateRsquared(r, r_2);
+
+    /* 32 bit pointer, this is necessary to pass the pointer value
+       into the assembly code */
+    r_ptrLocal = (unsigned *) r;
+    r2_ptrLocal = r_2;
+    h1_ptrLocal = (unsigned *) h1;
+    h2_ptrLocal = (unsigned *) h2;
+
+#ifdef POLY1305_VERBOSE
+    int j;
+    printf("armv8_32_poly1305_blocks() >> Before Assembly << ");
+    printf("  length of data (%d) 0x%X\n\n", msgDataLen, msgDataLen);
+
+    for (i=0;i<5;++i)
+        printf("h%d %08X ", i, h1[i]);
+    printf("\n");
+
+    printf(" r ");
+    for (j=0;j<5;++j)
+        printf(" %d %08X ", j, r[j]);
+    printf("\n");
+    /* 00BED685  03555502  0047C036  01003949  000806D5 */
+
+    printf(" r^2 ");
+    for (j=0;j<5;++j)
+        printf(" %d %08X ", j, r_2[j]);
+    printf("\n");
+
+    /* CA0455  1DD847D  23C50AA  36BC0AC  19106A3 */
+#endif
+
+    __asm__ __volatile__ (
+        ".align	8	 				\n\t"
+
+        /* valid registers are d0..d31 */
+
+        /* load r values into d0..d4 */
+        "LDR		r11, %[r_ptr]			\n\t"
+        "LDM		r11, { r0, r1, r2, r3, r4 }	\n\t"
+
+        "LDR		r11, %[r2_ptr]			\n\t"
+        "LDM		r11, { r5, r6, r8, r9, r10 }	\n\t"
+
+        "VMOV		s0, s1, r0, r5			\n\t"   /* d0 */
+        "VMOV		s2, s3, r1, r6			\n\t"   /* d1 */
+        "VMOV		s4, s5, r2, r8			\n\t"   /* d2 */
+        "VMOV		s6, s7, r3, r9			\n\t"   /* d3 */
+        "VMOV		s8, s9, r4, r10			\n\t"   /* d4 */
+
+        "MOV		r0, #5				\n\t"
+        "MUL		r1, r1, r0			\n\t"
+        "MUL		r2, r2, r0			\n\t"
+        "MUL		r3, r3, r0			\n\t"
+        "MUL		r4, r4, r0			\n\t"
+
+        "MUL		r6, r6, r0			\n\t"
+        "MUL		r8, r8, r0			\n\t"
+        "MUL		r9, r9, r0			\n\t"
+        "MUL		r10, r10, r0			\n\t"
+
+        "VMOV		s10, s11, r1, r6		\n\t"   /* d5 */
+        "VMOV		s12, s13, r2, r8		\n\t"   /* d6 */
+        "VMOV		s14, s15, r3, r9		\n\t"   /* d7 */
+        "VMOV		s16, s17, r4, r10		\n\t"   /* d8 */
+
+        /* load h values into d10..d15 */
+        "LDR		r11, %[h_ptr1]			\n\t"
+        "LDM		r11, { r0, r1, r2, r3, r4 }	\n\t"
+        "LDR		r11, %[h_ptr2]			\n\t"
+        "LDM		r11, { r5, r6, r8, r9, r10 }	\n\t"
+
+        "VMOV		s18, s19, r0, r5		\n\t"   /* d9  */
+        "VMOV		s20, s21, r1, r6		\n\t"   /* d10 */
+        "VMOV		s22, s23, r2, r8		\n\t"   /* d11 */
+        "VMOV		s24, s25, r3, r9		\n\t"   /* d12 */
+        "VMOV		s26, s27, r4, r10		\n\t"   /* d13 */
+
+        "VMOV		d24, d9				\n\t"
+        "VMOV		d25, d10			\n\t"
+        "VMOV		d26, d11			\n\t"
+        "VMOV		d27, d12			\n\t"
+        "VMOV		d28, d13			\n\t"
+        "LDR		r1, %[m]			\n\t"
+        "LDR		r2, %[bytes]			\n\t"
+        "LDR		r3, %[hibit]			\n\t"
+
+        "VMOV		s28, s29, r3, r3		\n\t"   /* d14 */
+        "VMOV 		d29, d14 			\n\t"   /* d29 */
+
+        "VMOV.i32	d30, #0x3FFFFFF			\n\t"
+        "VSHR.u64	d30, #32			\n\t"
+
+        "VMOV.i32	d27, #0x5			\n\t"
+        "VSHR.u64	d27, #32			\n\t"
+
+    "armv8_32_poly1305_loop:				\n\t"
+
+        /* The poly1305 algorithm requires that a 01 byte
+           be placed after the last byte of the block. */
+
+        "CMP		r2, #0				\n\t"
+        "BEQ		armv8_32_poly1305_done		\n\t"
+
+        /* branch for least likely case, may help with pipelining */
+        /* ARMv8 uses predictive pipelining.  There is no way
+           to specify in the instruction encoding the more likely
+           case.  */
+        "CMP		r2, #16				\n\t"
+        "BLT		armv8_32_poly1305_last_block	\n\t"
+
+        "SUBS 		r2, r2, #16			\n\t"
+
+        /* this block is 16 bytes */
+
+        /* load next 16 byte block of message */
+        "LDM		r1, { r4, r5, r6, r8 }		\n\t"
+        "ADD		r1, r1, #16			\n\t"
+
+        /* in RFC 7539, each block processed is prepended by
+           a byte of value 0x01.  In the wolfSSL implementation,
+           the setting of this value is based on the value found
+           in ctx->finish. To save a memory reference, this code
+           could be replicated one version adding the byte, one
+           version not. */
+
+        /* This is byte 16, past the 128 bits of
+           Hence, update is done to h4. */
+
+
+    "armv8_32_poly1305_done_01_byte_appended:		\n\t"
+
+        "CMP		r2, #0				\n\t"
+        "BEQ		onlyOneBlock			\n\t"
+
+    "twoBlocks:						\n\t"
+        /* r4 = 70797243  r5 = 72676F74  r6 = 69687061  r8 = 6F462063 */
+
+       "VMOV		r9, s27				\n\t"
+       "ADD		r9, r9, r3			\n\t"
+       "VMOV		s27, r9				\n\t"
+
+       "MOV	    r9, #0x3FFFFFF			\n\t"
+
+       /* h0 += r4 & 0x3FFFFFF; */
+       "VMOV	    r10, s19				\n\t"	/* s19, s21 */
+       "VMOV	    r11, s21				\n\t"
+
+       "AND        r0, r4, r9                           \n\t"
+       "ADD        r10, r10, r0                         \n\t"   /* 797243 */
+
+       /* h1 += (r5:r4 >> 26) & 0x3FFFFFF */
+       "LSR        r0, r4, #26                          \n\t"   /* 26 */
+       "ADD        r0, r0, r5, LSL #6                   \n\t"
+       "AND        r0, r0, r9                           \n\t"
+       "ADD        r11, r11, r0                         \n\t"   /* 1DBDD1C */
+
+       "VMOV	    s19, r10				\n\t"
+       "VMOV	    s21, r11				\n\t"
+
+       /* h2 += (r6:r5 >> 20) & 0x3FFFFFF */
+       "VMOV	    r10, s23				\n\t"  /* s23, s25 */
+       "VMOV	    r11, s25				\n\t"
+
+       "LSR        r0, r5, #20                          \n\t"  /* 20+32 = 52 */
+       "ADD        r0, r0, r6, LSL #12                  \n\t"
+       "AND        r0, r0, r9                           \n\t"
+       "ADD        r10, r10, r0                         \n\t"  /* 3061726 */
+       /* h3 += (r8:r6 >> 14) & 0x3FFFFFF */
+       "LSR        r0, r6, #14                          \n\t"  /* 14+32+32 = 78 */
+       "ADD        r0, r0, r8, LSL #18                  \n\t"
+       "AND        r0, r0, r9                           \n\t"
+       "ADD        r11, r11, r0                         \n\t"  /* 18dA5A1 */
+
+       "VMOV	    s23, r10				\n\t"
+       "VMOV	    s25, r11				\n\t"
+
+       /* h4 += r3 >> 8                   */
+       "VMOV	    r10, s27				\n\t"
+       "ADD        r10, r10, r8, LSR #8                 \n\t"  /* 8+32+32+32 = 104 */
+       "VMOV	    s27, r10				\n\t"  /* 16F4620 */
+
+       /* s19 = 0797243  s21 = 1DBDD1C  s23 = 3061726  s25 = 18DA5A1  s27 = 16F4620 */
+
+       "CMP	    r2, #16				\n\t"
+       "BLT	    armv8_32_poly1305_last_block	\n\t"
+
+       /* FIX */
+       "LDM	    r1, { r4, r5, r6, r8 }		\n\t"
+       "ADD	    r1, r1, #16				\n\t"
+       "SUBS 	    r2, r2, #16				\n\t"
+
+    "onlyOneBlock:					\n\t"
+
+        /* FIX must handle short blocks as well */
+        /* FIX HIBIT */
+        /* set hibit for a full size 16 byte block */
+        "VMOV	    r9, s26				\n\t"
+        "ADD	    r9, r9, r3				\n\t"
+        "VMOV	    s26, r9				\n\t"
+
+    "onlyOneBlock_hibit_set:				\n\t"
+
+        "MOV	    r9, #0x3FFFFFF 			\n\t"
+
+        /* h0 += r4 & 0x3FFFFFF; */
+        "VMOV	    r10, s18				\n\t"	/* s18, s20 */
+        "VMOV	    r11, s20				\n\t"
+
+        "AND        r0, r4, r9                          \n\t"
+        "ADD        r10, r10, r0                        \n\t"
+
+        /* h1 += (r5:r4 >> 26) & 0x3FFFFFF */
+        "LSR        r0, r4, #26                         \n\t"   /* 26 */
+        "ADD        r0, r0, r5, LSL #6                  \n\t"
+        "AND        r0, r0, r9                          \n\t"
+        "ADD        r11, r11, r0                        \n\t"
+
+        "VMOV	    s18, r10				\n\t"
+        "VMOV	    s20, r11				\n\t"
+
+        /* h2 += (r6:r5 >> 20) & 0x3FFFFFF */
+        "VMOV	    r10, s22				\n\t"  /* s22, s24 */
+        "VMOV	    r11, s24				\n\t"
+
+        "LSR        r0, r5, #20                         \n\t"  /* 20+32 = 52 */
+        "ADD        r0, r0, r6, LSL #12                 \n\t"
+        "AND        r0, r0, r9                          \n\t"
+        "ADD        r10, r10, r0                        \n\t"
+        /* h3 += (r8:r6 >> 14) & 0x3FFFFFF */
+        "LSR        r0, r6, #14                         \n\t"  /* 14+32+32 = 78 */
+        "ADD        r0, r0, r8, LSL #18                 \n\t"
+        "AND        r0, r0, r9                          \n\t"
+        "ADD        r11, r11, r0                        \n\t"
+
+        "VMOV	    s22, r10				\n\t"
+        "VMOV	    s24, r11				\n\t"
+
+        /* h4 += r3 >> 8                   */
+        "VMOV	    r10, s26				\n\t"  /* s26 */
+        "ADD        r10, r10, r8, LSR #8                \n\t"  /* 8+32+32+32 = 104 */
+        "VMOV	    s26, r10				\n\t"
+
+        /* s18 = 06D7572  s20 = 0D95488  s22 = 3261657  s24 = 081A18D  s26 = 1746573 */
+
+    "checkRegs:						\n\t"
+        /* partial0 = h0 * r0 + h1 * 5*r4 + h2 * 5*r3 + h3 * 5*r2 + h4 * 5*r1 */
+        /* partial1 = h0 * r1 + h1 * r0   + h2 * 5*r4 + h3 * 5*r3 + h4 * 5*r2 */
+        /* partial2 = h0 * r2 + h1 * r1   + h2 * r0   + h3 * 5*r4 + h4 * 5*r3 */
+        /* partial3 = h0 * r3 + h1 * r2   + h2 * r1   + h3 * r0   + h4 * 5*r4 */
+        /* partial4 = h0 * r4 + h1 * r3   + h2 * r2   + h3 * r1   + h4 * r0   */
+
+
+        /*  d15 = d9 * d0 +  d10 * d8 +  d11 * d7 +  d12 * d6 +  d13 * d5 */
+        /*  d16 = d9 * d1 +  d10 * d0 +  d11 * d8 +  d12 * d7 +  d13 * d6 */
+        /*  d17 = d9 * d2 +  d10 * d1 +  d11 * d0 +  d12 * d8 +  d13 * d7 */
+        /*  d18 = d9 * d3 +  d10 * d2 +  d11 * d1 +  d12 * d0 +  d13 * d8 */
+        /*  d19 = d9 * d4 +  d10 * d3 +  d11 * d2 +  d12 * d1 +  d13 * d0  */
+
+
+        /* registers d15, d16, d17, d18, d19 contain the
+           incremental d results. */
+
+
+        /* partial0 = q8 = d17:d16 */
+        "VMULL.u32	q8,  d9, d0   			\n\t"
+        "VMLAL.u32	q8, d10, d8   			\n\t"
+        "VMLAL.u32	q8, d11, d7   			\n\t"
+        "VMLAL.u32	q8, d12, d6   			\n\t"
+        "VMLAL.u32	q8, d13, d5   			\n\t"
+        /* 29DD73 07661C87 */
+
+        /* partial1 = q9 = d19:d18 */
+        "VMULL.u32	q9,  d9, d1   			\n\t"
+        "VMLAL.u32	q9, d10, d0   			\n\t"
+        "VMLAL.u32	q9, d11, d8   			\n\t"
+        "VMLAL.u32	q9, d12, d7   			\n\t"
+        "VMLAL.u32	q9, d13, d6   			\n\t"
+        /* D3993 E9038575 */
+
+        /* partial1 = q10 = d21:d20 */
+        "VMULL.u32	q10,  d9, d2   			\n\t"
+        "VMLAL.u32	q10, d10, d1   			\n\t"
+        "VMLAL.u32	q10, d11, d0   			\n\t"
+        "VMLAL.u32	q10, d12, d8   			\n\t"
+        "VMLAL.u32	q10, d13, d7   			\n\t"
+        /* 10019D F79AAF81 */
+
+        /* partial1 = q11 = d23:d22 */
+        "VMULL.u32	q11,  d9, d3   			\n\t"
+        "VMLAL.u32	q11, d10, d2   			\n\t"
+        "VMLAL.u32	q11, d11, d1   			\n\t"
+        "VMLAL.u32	q11, d12, d0   			\n\t"
+        "VMLAL.u32	q11, d13, d8   			\n\t"
+        /* C753B 56120E14 */
+
+         /* partial1 = q12 = d25:d24 */
+        "VMULL.u32	q12,  d9, d4   			\n\t"
+        "VMLAL.u32	q12, d10, d3   			\n\t"
+        "VMLAL.u32	q12, d11, d2   			\n\t"
+        "VMLAL.u32	q12, d12, d1   			\n\t"
+        "VMLAL.u32	q12, d13, d0   			\n\t"
+        /* 8F852 C3AB3DA1 */
+
+        /* message buff 1 times r
+           d16 = 02929E2 D10FA341
+           d18 = 0071FD6 14380FCE
+           d20 = 00CA7F3 14E3B1DB
+           d22 = 00BC46F BD0D158C
+           d24 = 0048496 DE32A7D5 */
+
+        /* message buff 2 times r squared
+           d17 = 06165D0 CB2EA8BD
+           d19 = 044A41C F0475619
+           d21 = 02B9EA1 79EE3BD7
+           d23 = 017E1B1 ED6D017F
+           d25 = 011E440 9C3DCCF2 */
+
+        /* doing d0 --> d1 --> d2 --> d3 --> d4 --> d1 -->d2 */
+
+        /* d16 --> d18 --> d20 --> d22 --> d24 --> d16 --> d18 */
+
+        /* d0 = d16 * 0x3FFFFF */
+        "VAND.u64	d15, d16, d30			\n\t"
+        "VMOV 		s18, s30			\n\t"	/* d0 */
+
+        /* d9 = 10FA341 value before wrap around */
+
+        /* d1 = (d18 + (d16 >> 26)) & 0x3FFFFFF */
+        "VSHR.u64	d28, d16, #26			\n\t"
+        "VADD.u64	d18, d18, d28			\n\t"
+        "VAND.u64	d15, d18, d30			\n\t"   /* d1 */
+        "VMOV		s20, s30			\n\t"
+
+        /* d10 = 43EA6A8   */
+
+        /* d1 overflow to d2 */
+
+        /* d2 = (d20 + (d18 >> 26)) & 0x3FFFFFF */
+        "VSHR.u64	d28, d18, #26			\n\t"
+        "VADD.u64	d20, d20, d28			\n\t"
+        "VAND.u64	d15, d20, d30			\n\t"   /* d2 */
+        "VMOV		s22, s30			\n\t"
+
+        /* d2 overflow to d3 */
+
+        "VSHR.u64	d28, d20, #26			\n\t"
+        "VADD.u64	d22, d22, d28			\n\t"
+        "VAND.u64	d15, d22, d30			\n\t"   /* d3 */
+        "VMOV		s24, s30			\n\t"
+
+        /* d3 overflow to d4 */
+
+        "VSHR.u64	d28, d22, #26			\n\t"
+        "VADD.u64	d24, d24, d28			\n\t"
+        "VAND.u64	d15, d24, d30			\n\t"   /* d4 */
+        "VMOV		s26, s30			\n\t"
+
+        /* d4 overflow to d0 */
+
+        "VSHR.u64	d15, d24, #26			\n\t"
+        /* multiply d15 by 5 */
+        "VMOV		r6, s30				\n\t"
+        "MOV		r5, #5				\n\t"
+        "MUL		r6, r5, r6			\n\t"
+        "VMOV		r4, s18				\n\t"
+        "ADD		r4, r4, r6			\n\t"   /* d0 + 5 * d4 roll over */
+
+        "MOV		r5, #0x3FFFFFF			\n\t"
+        "AND		r8, r4, r5			\n\t"
+        "VMOV		s18, r8				\n\t"
+
+        "VMOV		r6, s20				\n\t"
+        "ADD		r6, r6, r4, LSR #26		\n\t"
+        "VMOV		s20, r6				\n\t"
+
+
+        /* final H values : d9 = 2B55FD9  d10 = 2828883  d11 = 2ABA762
+                           d12 = 371251  d13 = 123C3C5 */
+
+
+        /* doing d0 --> d1 --> d2 --> d3 --> d4 --> d1 -->d2 */
+
+        /* d17 --> d19 --> d21 --> d23 --> d25 --> d17 --> d19 */
+
+        /* d0 = d16 * 0x3FFFFF */
+        "VAND.u64	d15, d17, d30			\n\t"
+        "VMOV 		s19, s30			\n\t"	/* d0 */
+
+        /* d9 = 10FA341 value before wrap around */
+
+        /* d1 = (d18 + (d16 >> 26)) & 0x3FFFFFF */
+        "VSHR.u64	d28, d17, #26			\n\t"
+        "VADD.u64	d19, d19, d28			\n\t"
+        "VAND.u64	d15, d19, d30			\n\t"   /* d1 */
+        "VMOV		s21, s30			\n\t"
+
+        /* d10 = 43EA6A8   */
+
+        /* d1 overflow to d2 */
+
+        /* d2 = (d20 + (d18 >> 26)) & 0x3FFFFFF */
+        "VSHR.u64	d28, d19, #26			\n\t"
+        "VADD.u64	d21, d21, d28			\n\t"
+        "VAND.u64	d15, d21, d30			\n\t"   /* d2 */
+        "VMOV		s23, s30			\n\t"
+
+        /* d2 overflow to d3 */
+
+        "VSHR.u64	d28, d21, #26			\n\t"
+        "VADD.u64	d23, d23, d28			\n\t"
+        "VAND.u64	d15, d23, d30			\n\t"   /* d3 */
+        "VMOV		s25, s30			\n\t"
+
+        /* d3 overflow to d4 */
+
+        "VSHR.u64	d28, d23, #26			\n\t"
+        "VADD.u64	d25, d25, d28			\n\t"
+        "VAND.u64	d15, d25, d30			\n\t"   /* d4 */
+        "VMOV		s27, s30			\n\t"
+
+        /* d4 overflow to d0 */
+
+        "VSHR.u64	d15, d25, #26			\n\t"
+        /* multiply d15 by 5 */
+        "VMOV		r6, s30				\n\t"
+        "MOV		r5, #5				\n\t"
+        "MUL		r6, r5, r6			\n\t"
+        "VMOV		r4, s19				\n\t"
+        "ADD		r4, r4, r6			\n\t"   /* d0 + 5 * d4 roll over */
+
+        "MOV		r5, #0x3FFFFFF			\n\t"
+        "AND		r8, r4, r5			\n\t"
+        "VMOV		s19, r8				\n\t"
+
+        "VMOV		r6, s21				\n\t"
+        "ADD		r6, r6, r4, LSR #26		\n\t"
+        "VMOV		s21, r6				\n\t"
+
+        /* final H values : d9 = 18BF985  d10 = A0CA51  d11 = 3174319
+                           d12 = 54A9E1  d13 = 2363970 */
+
+        "CMP 		r2, #0x10  		 \n\t"
+        "BLE		oneBlockLeft		 \n\t"
+
+        /* add the two h vectors together */
+        "MOV		r5, #0			\n\t"
+        "VMOV		r4, r10, s18, s19	\n\t"
+        "ADD		r4, r4, r10		\n\t"
+        "VMOV		s18, s19, r5, r4	\n\t"
+
+        "VMOV		r4, r10, s20, s21	\n\t"
+        "ADD		r4, r4, r10		\n\t"
+        "VMOV		s20, s21, r5, r4	\n\t"
+
+        "VMOV		r4, r10, s22, s23	\n\t"
+        "ADD		r4, r4, r10		\n\t"
+        "VMOV		s22, s23, r5, r4	\n\t"
+
+        "VMOV		r4, r10, s24, s25	\n\t"
+        "ADD		r4, r4, r10		\n\t"
+        "VMOV		s24, s25, r5, r4	\n\t"
+
+        "VMOV		r4, r10, s26, s27	\n\t"
+        "ADD		r4, r4, r10		\n\t"
+        "VMOV		s26, s27, r5, r4	\n\t"
+        "B		armv8_32_poly1305_loop	\n\t"
+
+    "oneBlockLeft: 				\n\t"
+        /* only one block left in message */
+        /* add the two h vectors together */
+        "MOV		r5, #0			\n\t"
+        "VMOV		r4, r10, s18, s19	\n\t"
+        "ADD		r4, r4, r10		\n\t"
+        "VMOV		s18, s19, r4, r5	\n\t"
+
+        "VMOV		r4, r10, s20, s21	\n\t"
+        "ADD		r4, r4, r10		\n\t"
+        "VMOV		s20, s21, r4, r5	\n\t"
+
+        "VMOV		r4, r10, s22, s23	\n\t"
+        "ADD		r4, r4, r10		\n\t"
+        "VMOV		s22, s23, r4, r5	\n\t"
+
+        "VMOV		r4, r10, s24, s25	\n\t"
+        "ADD		r4, r4, r10		\n\t"
+        "VMOV		s24, s25, r4, r5	\n\t"
+
+        "VMOV		r4, r10, s26, s27	\n\t"
+        "ADD		r4, r4, r10		\n\t"
+        "VMOV		s26, s27, r4, r5	\n\t"
+        "B		armv8_32_poly1305_loop	\n\t"
+
+    "armv8_32_poly1305_last_block:		\n\t"
+
+        /* This is the last block of the message
+           and the block is less than 16 bytes */
+
+        /* r1 is message pointer
+           r2 is byte count, which is less than 16
+           r3 is hibit	*/
+
+        /* Make sure the upper bytes of the
+           32 bit pieces are set to zero.
+           Set the byte past the last message
+           data byte to 01. */
+
+        "MOV	r10, r2				\n\t"
+
+        "PUSH	{ r0, r1, r2, r3 } 		\n\t"
+
+        "MOV	r9,  r1				\n\t"
+
+        "LSR	r3,  r3, #24			\n\t"
+        "MOV	r6,  r3				\n\t"
+
+        "MOV    r1,  #0				\n\t"
+        "MOV	r2,  #0				\n\t"
+        "MOV	r3,  #0				\n\t"
+        "MOV	r4,  #0xFFFFFFFF		\n\t"
+
+        /* always going to load at least one */
+        "LDR	r0, [r9]			\n\t"
+
+        /* byte offset to bit offset */
+        "LSL	r10, r10, #3			\n\t"
+
+        /* which block */
+        "CMP	r10, #32			\n\t"
+        "BGE	not_word_0			\n\t"
+
+        /* case word 0 */
+    "case0:"
+        "LSL	r8, r4, r10			\n\t"
+        "BIC  	r0, r0, r8			\n\t"
+        "LSL	r8, r6, r10			\n\t"
+        "ADD	r0, r0, r8			\n\t"
+        "B	last_block_done			\n\t"
+
+    "not_word_0:	 			\n\t"
+        "LDR	r1, [r9, #4]			\n\t"
+
+        "SUB	r10, r10, #32			\n\t"
+        "CMP	r10, #32			\n\t"
+        "BGE	not_word_1			\n\t"
+
+        "LSL	r8, r4, r10			\n\t"
+        "BIC  	r1, r1, r8			\n\t"
+        "LSL	r8, r6, r10			\n\t"
+        "ADD	r1, r1, r8			\n\t"
+        "B	last_block_done			\n\t"
+
+    "not_word_1:				\n\t"
+        "LDR	r2, [r9, #8]			\n\t"
+
+        "SUB	r10, r10, #32			\n\t"
+        "CMP	r10, #32			\n\t"
+        "BGE	not_word_2			\n\t"
+
+        "LSL	r8, r4, r10			\n\t"
+        "BIC  	r2, r2, r8			\n\t"
+        "LSL	r8, r6, r10			\n\t"
+        "ADD	r2, r2, r8			\n\t"
+        "B	last_block_done			\n\t"
+
+    "not_word_2:				\n\t"
+        "LDR	r3, [r9, #0xC]			\n\t"
+
+        "SUB	r10, r10, #32			\n\t"
+
+        "LSL	r8, r4, r10			\n\t"
+        "BIC  	r3, r3, r8			\n\t"
+        "LSL	r8, r6, r10			\n\t"
+        "ADD	r3, r3, r8			\n\t"
+
+    "last_block_done:				\n\t"
+
+        "MOV 	r4, r0				\n\t"
+        "MOV 	r5, r1				\n\t"
+        "MOV 	r6, r2				\n\t"
+        "MOV 	r8, r3				\n\t"
+
+        "POP	{ r0, r1, r2, r3 }		\n\t"
+
+        /* set the byte count to 0 */
+        "MOV		r2, #0			\n\t"
+
+        "b		onlyOneBlock_hibit_set	\n\t"
+
+        "b 	armv8_32_poly1305_done_01_byte_appended \n\t"
+
+        ".align 2 \n\t"
+    "armv8_32_poly1305_done:			\n\t"
+
+        "VMOV	r0, s18				\n\t"
+        "VMOV	r1, s20				\n\t"
+        "VMOV	r2, s22				\n\t"
+        "VMOV	r3, s24				\n\t"
+        "VMOV	r4, s26				\n\t"
 
                 /* store final result */
                 "LDR    r10, %[h_ptr1]                   \n\t"
                 "STM    r10, { r0, r1, r2, r3, r4 }      \n\t"
 
-		: [m] 		  "+m" (msgDataOnStack),	/* input */
-		  [r_ptr]  	  "+m" (r_ptrLocal),		/* input */
-		  [r2_ptr]	  "+m" (r2_ptrLocal),		/* input */
-		  [h_ptr1]  	  "+m" (h1_ptrLocal),		/* input, output */
-		  [h_ptr2]  	  "+m" (h2_ptrLocal),		/* input, output */
-		  [bytes]  	  "+m" (msgDataLenOnStack),	/* input */
-		  [hibit]	  "+m" (hibitOnStack)		/* input */
-		: [BYTES_STORE]    "I" (BYTES_SP_OFF),
-		  [HIBIT_LOCAL]    "I" (HIBIT_LOCAL_SP_OFF)
-		: "memory", "cc", 
-			"r0", "r1", "r2", "r3", "r4",
-			"r5", "r6", "r8", "r9", "r10",
-			"r11",
-			"r12",
-			"d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
-			"d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18",
-			"d19", "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27",
-			"d28", "d29", "d30", "d31"
-	);
+        : [m] 		  "+m" (msgDataOnStack),	/* input */
+          [r_ptr]  	  "+m" (r_ptrLocal),		/* input */
+          [r2_ptr]	  "+m" (r2_ptrLocal),		/* input */
+          [h_ptr1]  	  "+m" (h1_ptrLocal),		/* input, output */
+          [h_ptr2]  	  "+m" (h2_ptrLocal),		/* input, output */
+          [bytes]  	  "+m" (msgDataLenOnStack),	/* input */
+          [hibit]	  "+m" (hibitOnStack)		/* input */
+        : [BYTES_STORE]    "I" (BYTES_SP_OFF),
+          [HIBIT_LOCAL]    "I" (HIBIT_LOCAL_SP_OFF)
+        : "memory", "cc",
+        	"r0", "r1", "r2", "r3", "r4",
+        	"r5", "r6", "r8", "r9", "r10",
+        	"r11",
+        	"r12",
+        	"d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        	"d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18",
+        	"d19", "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27",
+        	"d28", "d29", "d30", "d31"
+    );
 
-	/* testing with testsuite/testsuite.test demonstrates that the
-	   below reduction is necessary. */
+    /* testing with testsuite/testsuite.test demonstrates that the
+       below reduction is necessary. */
 
-	/* do reduction */
-	int over;
-	
-	over = h1[0]>>26;
-	h1[0] = h1[0] & 0x3FFFFFF;
-	h1[1] += over;
+    /* do reduction */
+    int over;
 
-	over = h1[1]>>26;
-	h1[1] = h1[1] & 0x3FFFFFF;
-	h1[2] += over;
-	
-	over = h1[2]>>26;
-	h1[2] = h1[2] & 0x3FFFFFF;
-	h1[3] += over;
+    over = h1[0]>>26;
+    h1[0] = h1[0] & 0x3FFFFFF;
+    h1[1] += over;
 
-	over = h1[3]>>26;
-	h1[3] = h1[3] & 0x3FFFFFF;
-	h1[4] += over;
+    over = h1[1]>>26;
+    h1[1] = h1[1] & 0x3FFFFFF;
+    h1[2] += over;
 
-	over = h1[4]>>26;
-	h1[4] = h1[4] & 0x3FFFFFF;
+    over = h1[2]>>26;
+    h1[2] = h1[2] & 0x3FFFFFF;
+    h1[3] += over;
 
-	h1[0] += (over * 5);
-	over = h1[0]>>26;
-	h1[0] = h1[0] & 0x3FFFFFF;
+    over = h1[3]>>26;
+    h1[3] = h1[3] & 0x3FFFFFF;
+    h1[4] += over;
 
-	h1[1] += over;
+    over = h1[4]>>26;
+    h1[4] = h1[4] & 0x3FFFFFF;
 
-	memcpy(ctx->h, h1, 5 * sizeof(unsigned));
+    h1[0] += (over * 5);
+    over = h1[0]>>26;
+    h1[0] = h1[0] & 0x3FFFFFF;
+
+    h1[1] += over;
+
+    memcpy(ctx->h, h1, 5 * sizeof(unsigned));
 
 #ifdef POLY1305_VERBOSE
-	printf("\narmv8_32_poly1305_blocks() leaving\n");
+    printf("\narmv8_32_poly1305_blocks() leaving\n");
 #endif
 
 }
@@ -1314,47 +1316,47 @@ void armv8_32_poly1305_blocks(Poly1305* ctx,
 
 
 /**********************************************************
-  assembly test code  this code can be placed in the NEON 
+  assembly test code  this code can be placed in the NEON
   assembly routine to copy out the d registers
 **********************************************************/
 #if 0
 
 	"testArray:  \n\t"
 		"LDR 		r6, %[test1] \n\t"
-		"VSTR 		d0, [r6, #0] \n\t" 	
-		"VSTR 		d1, [r6, #8] \n\t" 	
-		"VSTR 		d2, [r6, #0x10] \n\t" 	
-		"VSTR 		d3, [r6, #0x18] \n\t" 	
-		"VSTR 		d4, [r6, #0x20] \n\t" 
-		"VSTR 		d5, [r6, #0x28] \n\t" 	
-		"VSTR 		d6, [r6, #0x30] \n\t" 	
-		"VSTR 		d7, [r6, #0x38] \n\t" 	
-		"VSTR 		d8, [r6, #0x40] \n\t" 	
-		"VSTR 		d9, [r6, #0x48] \n\t" 
-		"VSTR 		d10, [r6, #0x50] \n\t" 	
-		"VSTR 		d11, [r6, #0x58] \n\t" 	
-		"VSTR 		d12, [r6, #0x60] \n\t" 	
-		"VSTR 		d13, [r6, #0x68] \n\t" 	
-		"VSTR 		d14, [r6, #0x70] \n\t" 
-		"VSTR 		d15, [r6, #0x78] \n\t" 	
+		"VSTR 		d0, [r6, #0] \n\t"
+		"VSTR 		d1, [r6, #8] \n\t"
+		"VSTR 		d2, [r6, #0x10] \n\t"
+		"VSTR 		d3, [r6, #0x18] \n\t"
+		"VSTR 		d4, [r6, #0x20] \n\t"
+		"VSTR 		d5, [r6, #0x28] \n\t"
+		"VSTR 		d6, [r6, #0x30] \n\t"
+		"VSTR 		d7, [r6, #0x38] \n\t"
+		"VSTR 		d8, [r6, #0x40] \n\t"
+		"VSTR 		d9, [r6, #0x48] \n\t"
+		"VSTR 		d10, [r6, #0x50] \n\t"
+		"VSTR 		d11, [r6, #0x58] \n\t"
+		"VSTR 		d12, [r6, #0x60] \n\t"
+		"VSTR 		d13, [r6, #0x68] \n\t"
+		"VSTR 		d14, [r6, #0x70] \n\t"
+		"VSTR 		d15, [r6, #0x78] \n\t"
 
-		"VSTR 		d16, [r6, #0x80] \n\t" 	
-		"VSTR 		d17, [r6, #0x88] \n\t" 
-		"VSTR 		d18, [r6, #0x90] \n\t" 	
-		"VSTR 		d19, [r6, #0x98] \n\t" 	
-		"VSTR 		d20, [r6, #0xA0] \n\t" 	
-		"VSTR 		d21, [r6, #0xA8] \n\t" 	
-		"VSTR 		d22, [r6, #0xB0] \n\t" 
-		"VSTR 		d23, [r6, #0xB8] \n\t" 	
+		"VSTR 		d16, [r6, #0x80] \n\t"
+		"VSTR 		d17, [r6, #0x88] \n\t"
+		"VSTR 		d18, [r6, #0x90] \n\t"
+		"VSTR 		d19, [r6, #0x98] \n\t"
+		"VSTR 		d20, [r6, #0xA0] \n\t"
+		"VSTR 		d21, [r6, #0xA8] \n\t"
+		"VSTR 		d22, [r6, #0xB0] \n\t"
+		"VSTR 		d23, [r6, #0xB8] \n\t"
 
-		"VSTR 		d24, [r6, #0xC0] \n\t" 	
-		"VSTR 		d25, [r6, #0xC8] \n\t" 
-		"VSTR 		d26, [r6, #0xD0] \n\t" 	
-		"VSTR 		d27, [r6, #0xD8] \n\t" 	
-		"VSTR 		d28, [r6, #0xE0] \n\t" 	
-		"VSTR 		d29, [r6, #0xE8] \n\t" 	
-		"VSTR 		d30, [r6, #0xF0] \n\t" 
-		"VSTR 		d31, [r6, #0xF8] \n\t" 	
+		"VSTR 		d24, [r6, #0xC0] \n\t"
+		"VSTR 		d25, [r6, #0xC8] \n\t"
+		"VSTR 		d26, [r6, #0xD0] \n\t"
+		"VSTR 		d27, [r6, #0xD8] \n\t"
+		"VSTR 		d28, [r6, #0xE0] \n\t"
+		"VSTR 		d29, [r6, #0xE8] \n\t"
+		"VSTR 		d30, [r6, #0xF0] \n\t"
+		"VSTR 		d31, [r6, #0xF8] \n\t"
 
 void output_test_array(unsigned *test1Array)
 {
@@ -1392,12 +1394,12 @@ void print16(const char *startText, unsigned char *data)
 
 /**********************************************************
   print17	Output the given 17 bytes as one big
-		number.  
+		number.
 **********************************************************/
 void print17(const char *startText, unsigned char *data);
 void print17(const char *startText, unsigned char *data)
 {
-	printf("%s %02X %08X%08X %08X%08X \n", startText, data[16], 
+	printf("%s %02X %08X%08X %08X%08X \n", startText, data[16],
 				*(unsigned *)(data+0xC), *(unsigned *)(data+8),
 				*(unsigned *)(data+4), *(unsigned *)(data));
 }
@@ -1411,9 +1413,9 @@ void printBytes(const char *startText, unsigned char *data, int len);
 void printBytes(const char *startText, unsigned char *data, int len)
 {
 	int i;
-	
+
 	printf("%s", startText);
-	
+
 	for (i=0;i<len;++i)
 	{
 		printf("%02X", data[i]);
@@ -1431,16 +1433,16 @@ void clamp_r(unsigned char *r);
 void clamp_r(unsigned char *r)
 {
 	printBytes("r = ", r, 16);
-	
+
 	r[3] &= 0xF;
 	r[7] &= 0xF;
 	r[11] &= 0xF;
 	r[15] &= 0xF;
-	
+
 	r[4] &= 0xFC;
 	r[8] &= 0xFC;
 	r[12] &= 0xFC;
-	
+
 	print16("after clamp ", r);
 }
 
@@ -1456,14 +1458,14 @@ void add17(unsigned char *dest, unsigned char *src)
 	int i;
 	short result;
 	unsigned char of=0;
-	
+
 	for (i=0;i<17;++i)
 	{
 		result = dest[i] + src[i] + of;
-		
+
 		dest[i] = (unsigned char)result;
-		
-		if (result & 0xFF00) of=1; else of=0; 
+
+		if (result & 0xFF00) of=1; else of=0;
 	}
 }
 
@@ -1472,7 +1474,7 @@ void add17(unsigned char *dest, unsigned char *src)
   convert26BitValuesTo17Byte
 		Convert the 5 specified 26 bit values to
 		a single 17 byte value.
-  input16Bit	Input array of 5 26 bit values.  
+  input16Bit	Input array of 5 26 bit values.
   result	Output of 17 bytes which represent one
 		130 bit number.
 *********************************************************/
@@ -1488,7 +1490,7 @@ void convert26BitValuesTo17Byte(unsigned *input26Bit, unsigned char *result)
 	over = input26Bit[1] >> (24-2);
 	val24 = (input26Bit[1] << 2) & 0xFFFFFF;    /* 26 + 2 = 28 */
 	memset(tmp, 0, 17);
-	*(unsigned *)(tmp+3) = val24; 
+	*(unsigned *)(tmp+3) = val24;
 	add17(result, tmp);
 	memset(tmp, 0, 17);
 	*(unsigned *)(tmp+6) = over;
@@ -1516,7 +1518,7 @@ void convert26BitValuesTo17Byte(unsigned *input26Bit, unsigned char *result)
 
 	memset(tmp, 0, 17);
 	*(unsigned*)(tmp+13) = input26Bit[4];		/* 26+26+26+26 =104 */
-	add17(result, tmp);	
+	add17(result, tmp);
 
 	result[16] &= 3;
 }
@@ -1525,72 +1527,72 @@ void convert26BitValuesTo17Byte(unsigned *input26Bit, unsigned char *result)
 /* test data set from RFC 7539 */
 #if 0
 /* two 16 byte blocks */
-unsigned char testData[]="Cryptographic Forum Research set"; 
+unsigned char testData[]="Cryptographic Forum Research set";
 unsigned char testData1[]="Cryptographic Fo";
-unsigned char testData2[]="rum Research set"; 
+unsigned char testData2[]="rum Research set";
 unsigned char resultCheck[]="\x5F\x5C\xC1\xDE\x46\x9B\x6E\xA5\x79\x9B\x03\x9F\x64\x7E\xF2\x75";
 #endif
 
 unsigned char testKey[]="\x85\xd6\xBE\x78\x57\x55\x6d\x33\x7F\x44\x52\xfe\x42\xd5\x06\xa8\x01\x03\x80\x8a\xfb\x0d\xb2\xFD\x4A\xBF\xF6\xAF\x41\x49\xF5\x1B";
 
 #if 0
-unsigned char testData[]="Cryptographic Forum Research Group"; 
+unsigned char testData[]="Cryptographic Forum Research Group";
 unsigned char resultCheck[]="\xA8\x06\x1D\xC1\x30\x51\x36\xC6\xC2\x2B\x8B\xAF\x0C\x01\x27\xA9";
 #endif
 
 #if 0
 /* four 16 byte blocks  - neon matches A32 */
-unsigned char testData[]="Cryptographic Forum Research setCryptographic Forum Research set"; 
+unsigned char testData[]="Cryptographic Forum Research setCryptographic Forum Research set";
 unsigned char resultCheck[]="\x4A\xD3\x08\x6D\x13\x5B\x12\x5C\xCF\xC2\x1A\xAD\xA0\xBA\x75\x3F";
 #endif
 
 #if 0
 /* three 16 byte blocks */
-unsigned char testData[]="Cryptographic Forum Research set1234567890123456"; 
+unsigned char testData[]="Cryptographic Forum Research set1234567890123456";
 unsigned char resultCheck[]="\x90\x0A\xA4\x0B\xFD\x90\xC7\x12\x52\x95\x08\x49\xF6\x20\x86\xEC";
 #endif
 
 #if 0
 /* three 16 byte blocks + an under sized block */
-unsigned char testData[]="Cryptographic Forum Research set1234567890123456123"; 
+unsigned char testData[]="Cryptographic Forum Research set1234567890123456123";
 unsigned char resultCheck[]="\x32\x03\x0B\x51\x7E\x49\xA8\x0D\xBF\x02\xD6\x99\x46\x79\xE2\x28";
 #endif
 
 #if 0
 /* three 16 byte blocks + an under sized block */
-unsigned char testData[]="Cryptographic Forum Research set12345678901234561234"; 
+unsigned char testData[]="Cryptographic Forum Research set12345678901234561234";
 /* neon version gets \x67\x20\x0F\xFA */
-unsigned char resultCheck[]="\x5D\x41\x13\xDC\xBF\x24\x25\xD4\x12\x20\xF2\x51\x67\x21\x0F\xFA";  
+unsigned char resultCheck[]="\x5D\x41\x13\xDC\xBF\x24\x25\xD4\x12\x20\xF2\x51\x67\x21\x0F\xFA";
 #endif
 
 #if 0
 /* four 16 byte blocks - neon results push limits of 17 byte add. */
-unsigned char testData[]="Cryptographic Forum Research set12345678901234561234567890123456"; 
+unsigned char testData[]="Cryptographic Forum Research set12345678901234561234567890123456";
 /* neon gets  \x59\xBB\x07\x1C */
-unsigned char resultCheck[]="\x46\x3C\x3D\x0F\xD4\x1A\x8C\xF0\xE7\x34\x9C\x72\x59\xBC\x07\x1C";  
+unsigned char resultCheck[]="\x46\x3C\x3D\x0F\xD4\x1A\x8C\xF0\xE7\x34\x9C\x72\x59\xBC\x07\x1C";
 #endif
 
 #if 0
 /* three 16 byte blocks + an under sized block */
-unsigned char testData[]="Cryptographic Forum Research set1234567890123456111111"; 
-unsigned char resultCheck[]="\xF8\x2E\xC4\xEF\x9B\x3C\x6A\xC1\x61\x73\xD4\xE9\x3C\x65\x93\x3B";  
+unsigned char testData[]="Cryptographic Forum Research set1234567890123456111111";
+unsigned char resultCheck[]="\xF8\x2E\xC4\xEF\x9B\x3C\x6A\xC1\x61\x73\xD4\xE9\x3C\x65\x93\x3B";
 #endif
 
 #if 0
 /* two 16 byte blocks + an under sized block */
-unsigned char testData[]="Cryptographic Forum Research set1234"; 
+unsigned char testData[]="Cryptographic Forum Research set1234";
 unsigned char resultCheck[]="\xA2\x0F\x7A\xD8\xE8\x9A\x60\xF6\x7C\x80\x5E\x28\x04\x86\x8D\xCA";
 #endif
 
 #if 1
 /* eight 16 byte blocks */
-unsigned char testData[]="Cryptographic Forum Research setCryptographic Forum Research setCryptographic Forum Research setCryptographic Forum Research set"; 
+unsigned char testData[]="Cryptographic Forum Research setCryptographic Forum Research setCryptographic Forum Research setCryptographic Forum Research set";
 unsigned char resultCheck[]="\xAE\xF7\x74\x3B\x69\x72\x8A\x4F\xD7\x32\x60\xB6\x7E\x0B\x60\x88";
 #endif
-	
+
 #if 0
 /* eight 16 byte blocks */
-unsigned char testData[]="Crypto"; 
+unsigned char testData[]="Crypto";
 unsigned char resultCheck[]="\xE2\x33\xC2\x33\x97\x5C\xDC\x37\xE6\x7B\xF9\xFC\x59\x33\xB5\x7F";
 #endif
 
@@ -1607,13 +1609,13 @@ int main(void)
 	unsigned *pt;
 
 	msgData = testData;
-	msgDataLen = strlen((const char *)msgData);	
+	msgDataLen = strlen((const char *)msgData);
 	keyData = testKey;
 
 	pt = (unsigned*)msgData;
 
 	printf("\n%s\n", msgData);
-	for (i=0;i<10;++i) 
+	for (i=0;i<10;++i)
 		printf(" %d %X\n", i, pt[i]);
 	printf("\n");
 
@@ -1629,7 +1631,7 @@ int main(void)
 	print16("s as a 128-bit number ", s);
 	clamp_r(r);
 
-	/* break the 16 byte value into 26 bit parts. */         
+	/* break the 16 byte value into 26 bit parts. */
 	ctx.r[0] = *(unsigned *)(r) & 0x3FFFFFF;
 	ctx.r[1] = ((*(unsigned *)(r + 3)) >> 2) & 0x3FFFFFF;
 	ctx.r[2] = ((*(unsigned *)(r + 6)) >> 4) & 0x3FFFFFF;
@@ -1640,14 +1642,14 @@ int main(void)
 	ctx.finished = 0;  /* setups up hibit, 0 is normal value */
 
 	/* Should always start as zero.
-           Passing into assembly routine to match what is already 
-	   implemented in wolfSSL armv8_poly1305.c.  
-	   For debugging, the C routine could break the message into 
+           Passing into assembly routine to match what is already
+	   implemented in wolfSSL armv8_poly1305.c.
+	   For debugging, the C routine could break the message into
 	   16 byte chunks and call the assembly routine over and over
 	   with the 16 byte chunks and the updated h value. */
 	memset(ctx.h, 0, 5 * sizeof(unsigned));
 
-	/* Some of the test cases found in 
+	/* Some of the test cases found in
            wolfcrypt/test/test.c : poly1305_test() start with a
 	   non-zero h vector. */
 
@@ -1686,7 +1688,7 @@ int main(void)
         msgDataLen=strlen((char *)msgData);
 
 	printf("\n\nr ");
-	for (q=0;q<5;++q)	
+	for (q=0;q<5;++q)
 	{
 		printf(" %X ", ctx.r[q]);
 	}
@@ -1699,7 +1701,7 @@ int main(void)
 	armv8_32_poly1305_blocks(&ctx, msgData, msgDataLen);
 
 	printf("\n(M block 2) * r values :");
-	
+
 	for (o=0;o<5;++o)
 	{
 		printf(" %X ", ctx.h[o]);
@@ -1725,7 +1727,7 @@ int main(void)
 	}
 	printf("\n\n");
 #endif
-	
+
 	convert26BitValuesTo17Byte(ctx.h, acc);
 
 	/* make output match what is seen in RFC */
@@ -1735,11 +1737,11 @@ int main(void)
 
 	memcpy(result16Byte, acc, 16);
 
-	printBytes(" Tag = ", result16Byte, 16); 
+	printBytes(" Tag = ", result16Byte, 16);
 
 	if (!memcmp(result16Byte, resultCheck, 16))
 		printf("Result matches RFC 7539\n\n");
-	else	
+	else
 		printf("Result does not match RFC 7539\n\n");
 }
 #endif

--- a/wolfcrypt/src/port/arm/armv8-32-poly1305.c
+++ b/wolfcrypt/src/port/arm/armv8-32-poly1305.c
@@ -3,51 +3,73 @@
    The test data in this code matches the test data in RFC 7539.
 
    The poly1305 algorithm takes two inputs, they are as follows.
-    1. the message data
-    2. a 256 bit key
+	1. the message data
+	2. a 256 bit key
    The algorithm outputs a 16 byte authentication value.
-
-   The 16 bytes are transmitted with the message.
-   The receiving side runs the poly1305 algorithm and
+  
+   The 16 bytes are transmitted with the message.  
+   The receiving side runs the poly1305 algorithm and 
    compares the 16 byte result on the receiving side to
    16 bytes sent with the message.  If the two 16 byte
    values match, then the message is authenticated.
 
    The poly1305 algorithm requires a unique 256 bit key
    for each message.  The sender and receiver keys must
-   stay in sync. This means that a pseudo random key must
-   be generated on both sides using the same algorithm
+   stay in sync. This means that a pseudo random key must 
+   be generated on both sides using the same algorithm 
    and the same initial key.
-
+  
    It is common to use the ChaCha20 algorithm to generate
    the pseudo random key.  The initial 256 bit key is normally
-   shared during the setup up of the connection between
-   sender and receiver.
+   shared during the setup up of the connection between 
+   sender and receiver.	
 
-   The 256 bit key is broken down into two 128 bit parts;
+   The 256 bit key is broken down into two 128 bit parts; 
    namely r and s.  In the algorithm, r is clamped, meaning
    certain bits are set to zero.  According to the RFC, r can
-   remain the same between runs of the algorithm, but s must
-   always change.  Therefore the ChaCha20 solution mentioned
+   remain the same between runs of the algorithm, but s must 
+   always change.  Therefore the ChaCha20 solution mentioned 
    above could be used to generate a 128 bit or 256 bit unique
-   key each time.
+   key each time. 
 
    This code was compiled and tested with the following tool chain.
 
-    gcc-arm-10.2-2020.11-aarch64-arm-none-linux-guneabihf
+	gcc-arm-10.2-2020.11-aarch64-arm-none-linux-guneabihf
 
    The development environment was Ubunutu, image file
-
-    libre-computer-aml-s905x-cc-ubuntu-bionic-mate-mali-4.19.55+-2019-06-24.img
+	
+	libre-computer-aml-s905x-cc-ubuntu-bionic-mate-mali-4.19.55+-2019-06-24.img 
 
    In order the run the resulting executable the 32 bit libs must
    be added to the system.  The following commands accomplish this.
 
-    sudo dpkg --add-architecture armhf
-    sudo apt-get update
-    sudo apt-get install libc6:armhf libstdc++6:armhf
+	sudo dpkg --add-architecture armhf
+	sudo apt-get update
+	sudo apt-get install libc6:armhf libstdc++6:armhf
 
 *****************************************************************/
+
+
+/* if building as a standalone to match the RFC 7539 
+   Be sure to pass gcc "-D POLY1305_STAND_ALONE". */
+#ifdef POLY1305_STAND_ALONE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stddef.h>
+
+typedef struct poly1305_struct
+{
+    unsigned r[5];
+    unsigned h[5];
+    unsigned finished;
+} Poly1305;
+
+#define WOLFSSL_ARMASM		1
+/* leave __aarch64__ undefined */
+//#define WOLFSSL_ARMASM_NO_NEON  1
+#define POLY1305_VERBOSE 	1
+#else
 
 #ifdef WOLFSSL_ARMASM
 #ifndef __aarch64__
@@ -61,1030 +83,1244 @@
 #include <wolfssl/wolfcrypt/settings.h>
 
 #include <wolfssl/wolfcrypt/poly1305.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
+#include <stddef.h>
+
+#endif
+#endif
+
+#endif
+
+
+#ifdef WOLFSSL_ARMASM
+#ifndef __aarch64__
 
 
 /**********************************************************
-  armv8_32_poly1305_blocks    This routine implements the
-            poly1305 algorithm.  The processing
-            of the 16 byte pieces of the
-            message is implemented in assembly.
-            Care was taken in implementing the
-            assembly to optimize speed by
-            minimizing memory references as
-            well as minimizing instructions.
-            The poly1305 algorithm is implemented
-            by using multiple 26 bit values
-            to represent the larger 16 byte and
-            17 byte numbers.  Breaking the
-            larger numbers down into 26 bit
-            pieces means that math operations will
-            not overflow the 32 bit registers.
-            For more information reference the article
-            NEON Cryto by Daniel Berstein and Peter
-            Schwabe.
-
-  ctx            poly1305 structure containing the r and
-             h values broke into 26 bit pieces.
-            The result of this routine is returned
-            int the h array of 26 bit values.
-  msgData        Message data to run the algorithm
-            against.
-  keyData        256 bit key that is broken down
-            into the r and s subcomponents.
+  armv8_32_poly1305_blocks	This routine implements the 
+			poly1305 algorithm.  The processing
+			of the 16 byte pieces of the 
+			message is implemented in assembly.
+			Care was taken in implementing the
+			assembly to optimize speed by 
+			minimizing memory references as
+			well as minimizing instructions.
+			The poly1305 algorithm is implemented
+			by using multiple 26 bit values 
+			to represent the larger 16 byte and 
+			17 byte numbers.  This is control
+			register overflow during the 
+			multiplications and subsequent 
+			additions.  For more information
+			reference the article NEON Cryto
+			by Daniel Berstein and Peter
+			Schwabe.
+  ctx			poly1305 structure containing the r and
+		 	h values broke into 26 bit pieces.
+			The result of this routine is returned
+			int the h array of 26 bit values.
+  msgData		Message data to run the algorithm 
+			against.
+  keyData		256 bit key that is broken down 
+			into the r and s subcomponents.
 **********************************************************/
 /* variable assembly code creates on stack */
 
-#define BYTES_SP_OFF            20
-#define HIBIT_LOCAL_SP_OFF      24
+#define BYTES_SP_OFF		20
+#define HIBIT_LOCAL_SP_OFF	24
+#define TEST1_SP_OFF		28
+void armv8_32_poly1305_blocks(Poly1305* ctx, 
+			const unsigned char *msgData,
+                     	size_t msgDataLen);
 
 /* WOLFSSL_ARMASM_NO_NEON is used in armv8-32-sha512-asm.S */
 #ifdef WOLFSSL_ARMASM_NO_NEON2
-static void armv8_32_poly1305_blocks(Poly1305* ctx,
-    const unsigned char *msgData, size_t msgDataLen)
+void armv8_32_poly1305_blocks(Poly1305* ctx, 
+			const unsigned char *msgData,
+                     	size_t msgDataLen)
 {
-    /* these variables will be referenced via r7 in the assembly */
-    word32 r[5], *r_ptrLocal, h[5], *h_ptrLocal;
-    word32 msgDataOnStack = (word32)msgData;
-    word32 msgDataLenOnStack = msgDataLen;
-    /* 1 << 128 */
-    word32 hibitOnStack = (ctx->finished) ? 0 : ((word32) 1 << 24);
+	/* these variables will be referenced via r7 in the assembly */
+	unsigned r[5], *r_ptrLocal, h[5], *h_ptrLocal;
+	unsigned msgDataOnStack = (unsigned)msgData;
+	unsigned msgDataLenOnStack = msgDataLen;
+ 	unsigned hibitOnStack = (ctx->finished) ? 0 : ((unsigned) 1 << 24); /* 1 << 128 */
 
-    memcpy(r, ctx->r, 5 * sizeof(word32));
-    memcpy(h, ctx->h, 5 * sizeof(word32));
+	unsigned test1Array[10*2], test1OnStack;
+	test1OnStack = (unsigned )test1Array;
 
-    /* 32 bit pointer, this is necessary to pass the pointer value
+	memcpy(r, ctx->r, 5 * sizeof(unsigned));
+	memcpy(h, ctx->h, 5 * sizeof(unsigned));
+
+	/* 32 bit pointer, this is necessary to pass the pointer value
            into the assembly code */
-    r_ptrLocal = (word32 *) r;
-    h_ptrLocal = (word32 *) h;
+	r_ptrLocal = (unsigned *) r;
+	h_ptrLocal = (unsigned *) h;
 
 #ifdef POLY1305_VERBOSE
-    int i;
-    for (i=0;i<5;++i) printf("h%d %07X ", i, h[i]);
-    printf("\n");
+	int i;
+	for (i=0;i<5;++i) printf("h%d %07X ", i, h[i]);
+	printf("\n");
 
-    printf("armv8_32_poly1305_blocks() data len %d\n", msgDataLen);
+	printf("armv8_32_poly1305_blocks() data len %d\n", msgDataLen);
 #endif
 
-    __asm__ __volatile__ (
-        ".align    8                \n\t"
+	__asm__ __volatile__ (
+		".align	8				\n\t"
+		
+		/* valid registers are r0..r12, sp, lr, pc, cpsr, fpscr */
+		
+		/* now load the stored h, this should all zero */
+		"LDR	r5, %[h_ptr]			\n\t"
+		"LDM	r5, { r6, r8, r9, r10, r11 }	\n\t"
+		/* r6 = h0  r8 = h1  r9 = h2  r10 = h3  r11 = h4 */
+	
+		/* in some cases, r7 is used to reference the local variables 
+		   on the stack; if -O2 is passed to gcc, the sp may used 
+	     	   used to reference local variables. */
+		"LDR 	r0, %[bytes]			\n\t"
+		"LDR 	r1, %[r_ptr]			\n\t"
+		"LDR	r2, %[hibit]			\n\t"
+		"LDR    r3, %[test1]			\n\t"
+		"LDR	r5, %[m]			\n\t"
 
-        /* valid registers are r0..r12, sp, lr, pc, cpsr, fpscr */
-
-        /* now load the stored h, this should all zero */
-        "LDR	r5, %[h_ptr]            \n\t"
-        "LDM	r5, { r6, r8, r9, r10, r11 }    \n\t"
-        /* r6 = h0  r8 = h1  r9 = h2  r10 = h3  r11 = h4 */
-
-        /* in some cases, r7 is used to reference the local variables
-           on the stack; if -O2 is passed to gcc, the sp may used
-                used to reference local variables. */
-        "LDR	r0, %[bytes]            \n\t"
-        "LDR	r1, %[r_ptr]            \n\t"
-        "LDR	r2, %[hibit]            \n\t"
-        "LDR	r5, %[m]            \n\t"
-
-        "PUSH	{ r7 }                \n\t"
-        "SUB	sp, #28                \n\t"
-
-        /* -O2 gcc parameters means r7 is not used for local
+		"PUSH	{ r7 }				\n\t"
+		"SUB	sp, #32				\n\t"
+		
+		/* -O2 gcc parameters means r7 is not used for local
                    variables, but sp is used for local variables */
-        /* free up r7 by moving variables referenced
-           via r7 to recently allocated stack space */
-        "STR	r0, [sp, %[BYTES_STORE]]    \n\t"
-        "STR	r2, [sp, %[HIBIT_LOCAL]]    \n\t"
-
-        "LDM	r1, { r0, r1, r2, r3, r4 }    \n\t"
-        "STM	sp, { r0, r1, r2, r3, r4 }    \n\t"
-
-        "MOV	r7, r5                \n\t"
-
-    "armv8_32_poly1305_loop:                \n\t"
-
-        /* The poly1305 algorithm requires that a 01 byte
-           be placed after the last byte of the block. */
-
-        "LDR	r5, [sp, %[BYTES_STORE]]    \n\t"  /* mem 1 */
-        "CMP	r5, #0                \n\t"
-        "BEQ	armv8_32_poly1305_done        \n\t"
-        "SUBS	r5, r5, #16            \n\t"
-
-        /* branch for least likely case, may help with pipelining */
-        /* ARMv8 uses predictive pipelining.  There is no way
-           to specify in the instruction encoding the more likely
-           case.  */
-        "BLT	armv8_32_poly1305_last_block    \n\t"
-
-        /* this block is 16 bytes */
-        "STR	r5, [sp, %[BYTES_STORE]]    \n\t"  /* mem 2 */
-
-        /* load next 16 byte block of message */
-        "LDM	r7, { r0, r1, r2, r3 }        \n\t"  /* mem 3 */
-        "ADD	r7, r7, #16            \n\t"
-
-        /* in RFC 7539, each block processed is prepended by
-             a byte of value 0x01.  In the wolfSSL implementation,
-           the setting of this value is based on the value found
-           in ctx->finish. To save a memory reference, this code
-           could be replicated one version adding the byte, one
-           version not. */
-
-        /* This is byte 16, past the 128 bits of w19:w18:w17:w16
-           Hence, update is done to h4. */
-        "LDR	r5, [sp, %[HIBIT_LOCAL]]    \n\t"    /* mem 4 */
-        "ADD	r11, r11, r5             \n\t"
-
-    "armv8_32_poly1305_done_01_byte_appended:    \n\t"
-
-        "mov	r5, #0x3FFFFFF            \n\t"
-
-        /* break data into 26 bit pieces.
-           Bit offsets are 0, 26, 52, 78 and 104 */
-
-        /* h0 += r0 & 0x3FFFFFF; */
-        "AND	r12, r0, r5            \n\t"
-        "ADD	r6, r6, r12            \n\t"
-        /* h1 += (r1:r0 >> 26) & 0x3FFFFFF */
-        "LSR	r12, r0, #26            \n\t"    /* 26 */
-        "ADD	r12, r12, r1, LSL #6        \n\t"
-        "AND	r12, r12, r5            \n\t"
-        "ADD	r8, r8, r12            \n\t"
-        /* h2 += (r2:r1 >> 20) & 0x3FFFFFF */
-        "LSR	r12, r1, #20            \n\t"   /* 20+32 = 52 */
-        "ADD	r12, r12, r2, LSL #12        \n\t"
-        "AND	r12, r12, r5            \n\t"
-        "ADD	r9, r9, r12            \n\t"
-        /* h3 += (r3:r2 >> 14) & 0x3FFFFFF */
-        "LSR	r12, r2, #14            \n\t"    /* 14+32+32 = 78 */
-        "ADD	r12, r12, r3, LSL #18        \n\t"
-        "AND	r12, r12, r5            \n\t"
-        "ADD	r10, r10, r12            \n\t"
-        /* h4 += r3 >> 8               */
-        "ADD	r11, r11, r3, LSR #8        \n\t"    /* 8+32+32+32 = 104 */
-
-        /* pull in the 26 bit components of the r key */
-        "LDM	sp, { r0, r1, r2, r3, r4 }     \n\t"    /* mem 5 */
-        /* r0 = BED685  r1 = 3555502  r2 = 47C036  r3 = 1003949  r4 = 806D5 */
-
-        "MOV	r5, #5                \n\t"
-
-    "checkRegs:                    \n\t"
-        /* d0 = h0 * r0 + h1 * 5*r4 + h2 * 5*r3 + h3 * 5*r2 + h4 * 5*r1 */
-        /* d1 = h0 * r1 + h1 * r0   + h2 * 5*r4 + h3 * 5*r3 + h4 * 5*r2 */
-        /* d2 = h0 * r2 + h1 * r1   + h2 * r0   + h3 * 5*r4 + h4 * 5*r3 */
-        /* d3 = h0 * r3 + h1 * r2   + h2 * r1   + h3 * r0   + h4 * 5*r4 */
-        /* d4 = h0 * r4 + h1 * r3   + h2 * r2   + h3 * r1   + h4 * r0   */
-
-        /*  r14 is the link register, r13 is the sp */
-        /*  r14:r12 = r6 * r0 + (r8 * r4 +  r9 * r3 +  r10 * r2 +  r11 * r1) * r5 */
-        /*  r14:r12 = r6 * r1 +  r8 * r0 + (r9 * r4 +  r10 * r3 +  r11 * r2) * r5 */
-        /*  r14:r12 = r6 * r2 +  r8 * r1 +  r9 * r0 + (r10 * r4 +  r11 * r3) * r5 */
-        /*  r14:r12 = r6 * r3 +  r8 * r2 +  r9 * r1 +  r10 * r0 + (r11 * r4) * r5 */
-        /*  r14:r12 = r6 * r4 +  r8 * r3 +  r9 * r2 +  r10 * r1 +  r11 * r0       */
-
-        /* d4 */
-        "UMULL	r12, r14, r6, r4        \n\t"
-        "UMLAL	r12, r14, r8, r3        \n\t"
-        "UMLAL	r12, r14, r9, r2        \n\t"
-        "UMLAL	r12, r14, r10, r1        \n\t"
-        "UMLAL	r12, r14, r11, r0        \n\t"
-
-        "PUSH	{ r12, r14 }            \n\t"    /* mem 6 */
+		/* free up r7 by moving variables referenced
+		   via r7 to recently allocated stack space */
+		"STR	r0, [sp, %[BYTES_STORE]]	\n\t"
+		"STR	r2, [sp, %[HIBIT_LOCAL]]	\n\t"
+		"STR	r3, [sp, %[TEST1_LOCAL]]	\n\t"	
+
+		"LDM	r1, { r0, r1, r2, r3, r4 }	\n\t"
+		"STM	sp, { r0, r1, r2, r3, r4 }	\n\t"
+
+		"MOV	r7, r5				\n\t"
+
+	"armv8_32_poly1305_loop:				\n\t"
+
+		/* The poly1305 algorithm requires that a 01 byte 
+		   be placed after the last byte of the block. */ 		
+		
+		"LDR	r5, [sp, %[BYTES_STORE]]	\n\t"  // mem 1
+		"CMP	r5, #0				\n\t"
+		"BEQ	armv8_32_poly1305_done		\n\t"
+		"SUBS 	r5, r5, #16			\n\t"
+		
+		/* branch for least likely case, may help with pipelining */
+		/* ARMv8 uses predictive pipelining.  There is no way
+		   to specify in the instruction encoding the more likely
+		   case.  */
+		"BLT	armv8_32_poly1305_last_block	\n\t"  
+
+		/* this block is 16 bytes */
+		"STR	r5, [sp, %[BYTES_STORE]]	\n\t"  // mem 2
+
+		/* load next 16 byte block of message */		
+		"LDM	r7, { r0, r1, r2, r3 }		\n\t"  // mem 3
+		"ADD	r7, r7, #16			\n\t"
+
+		/* in RFC 7539, each block processed is prepended by
+  		   a byte of value 0x01.  In the wolfSSL implementation,
+		   the setting of this value is based on the value found
+		   in ctx->finish. To save a memory reference, this code
+		   could be replicated one version adding the byte, one
+		   version not. */
+
+		/* This is byte 16, past the 128 bits of w19:w18:w17:w16 
+		   Hence, update is done to h4. */  
+		"LDR	r5, [sp, %[HIBIT_LOCAL]]	\n\t"	// mem 4
+		"ADD	r11, r11, r5 			\n\t"
+			
+	"armv8_32_poly1305_done_01_byte_appended:	\n\t"
+
+		"mov	r5, #0x3FFFFFF			\n\t"
+
+		/* break data into 26 bit pieces. 
+		   Bit offsets are 0, 26, 52, 78 and 104 */
+		   
+		/* h0 += r0 & 0x3FFFFFF; */
+		"AND	r12, r0, r5			\n\t"
+		"ADD	r6, r6, r12			\n\t"
+		/* h1 += (r1:r0 >> 26) & 0x3FFFFFF */
+		"LSR	r12, r0, #26			\n\t"	/* 26 */
+		"ADD	r12, r12, r1, LSL #6		\n\t"
+		"AND 	r12, r12, r5			\n\t"
+		"ADD	r8, r8, r12			\n\t"
+		/* h2 += (r2:r1 >> 20) & 0x3FFFFFF */
+		"LSR	r12, r1, #20			\n\t"   /* 20+32 = 52 */
+		//"MOV    r12, #0 \n\t"
+		//"ADD	r12, r12, r2, LSL #12		\n\t"
+		"AND 	r12, r12, r5			\n\t"
+		"ADD	r9, r9, r12			\n\t"
+		/* h3 += (r3:r2 >> 14) & 0x3FFFFFF */
+		"LSR	r12, r2, #14			\n\t"	/* 14+32+32 = 78 */
+		"ADD	r12, r12, r3, LSL #18		\n\t"
+		"AND 	r12, r12, r5			\n\t"
+		"ADD	r10, r10, r12			\n\t"
+		/* h4 += r3 >> 8	           */
+		"ADD	r11, r11, r3, LSR #8		\n\t"	/* 8+32+32+32 = 104 */
+
+		/* pull in the 26 bit components of the r key */
+		"LDM	sp, { r0, r1, r2, r3, r4 } 	\n\t"	// mem 5
+		/* r0 = BED685  r1 = 3555502  r2 = 47C036  r3 = 1003949  r4 = 806D5 */		
+#if 0
+		"LDR 	r5, [sp, %[TEST1_LOCAL]]  \n\t"
+		"STR	r6, [r5]	\n\t"
+		"STR	r8, [r5, #4]	\n\t"
+		"STR	r9, [r5, #8]	\n\t"
+		"STR	r10, [r5, #12]	\n\t"
+		"STR	r11, [r5, #16]	\n\t"
+		"B      armv8_32_poly1305_done \n\t"
+#endif
+		
+		"MOV	r5, #5				\n\t"
+
+	"checkRegs:					\n\t"
+		/* d0 = h0 * r0 + h1 * 5*r4 + h2 * 5*r3 + h3 * 5*r2 + h4 * 5*r1 */
+		/* d1 = h0 * r1 + h1 * r0   + h2 * 5*r4 + h3 * 5*r3 + h4 * 5*r2 */
+		/* d2 = h0 * r2 + h1 * r1   + h2 * r0   + h3 * 5*r4 + h4 * 5*r3 */
+		/* d3 = h0 * r3 + h1 * r2   + h2 * r1   + h3 * r0   + h4 * 5*r4 */
+		/* d4 = h0 * r4 + h1 * r3   + h2 * r2   + h3 * r1   + h4 * r0   */
+
+		/*  r14 is the link register, r13 is the sp */
+		/*  r14:r12 = r6 * r0 + (r8 * r4 +  r9 * r3 +  r10 * r2 +  r11 * r1) * r5 */
+		/*  r14:r12 = r6 * r1 +  r8 * r0 + (r9 * r4 +  r10 * r3 +  r11 * r2) * r5 */
+		/*  r14:r12 = r6 * r2 +  r8 * r1 +  r9 * r0 + (r10 * r4 +  r11 * r3) * r5 */
+		/*  r14:r12 = r6 * r3 +  r8 * r2 +  r9 * r1 +  r10 * r0 + (r11 * r4) * r5 */
+		/*  r14:r12 = r6 * r4 +  r8 * r3 +  r9 * r2 +  r10 * r1 +  r11 * r0       */
 
-        /* 8F852 C3AB3DA1 */
+		/* d4 */
+		"UMULL	r12, r14, r6, r4		\n\t"
+		"UMLAL 	r12, r14, r8, r3		\n\t"
+		"UMLAL 	r12, r14, r9, r2		\n\t"
+		"UMLAL 	r12, r14, r10, r1		\n\t"
+		"UMLAL 	r12, r14, r11, r0		\n\t"
 
-        /* d3 */
-        "UMULL	r12, r14, r6, r3        \n\t"
-        "UMLAL	r12, r14, r8, r2        \n\t"
-        "UMLAL	r12, r14, r9, r1        \n\t"
-        "UMLAL	r12, r14, r10, r0        \n\t"
-        "MUL	r11, r11, r5            \n\t"
-        "UMLAL	r12, r14, r11, r4        \n\t"
+		"PUSH   { r12, r14 }			\n\t"	// mem 6
 
-        "PUSH	{ r12, r14 }            \n\t"    /* mem 7 */
+		/* 8F852 C3AB3DA1 */
 
-        /* C753B 56120E14 */
+		/* d3 */
+		"UMULL	r12, r14, r6, r3		\n\t"
+		"UMLAL 	r12, r14, r8, r2		\n\t"
+		"UMLAL 	r12, r14, r9, r1		\n\t"
+		"UMLAL 	r12, r14, r10, r0		\n\t"
+		"MUL	r11, r11, r5			\n\t"
+		"UMLAL 	r12, r14, r11, r4		\n\t"
 
-        /* d2 */
-        "UMULL	r12, r14, r6, r2        \n\t"
-        "UMLAL	r12, r14, r8, r1        \n\t"
-        "UMLAL	r12, r14, r9, r0        \n\t"
-        "MUL	r10, r10, r5            \n\t"
-        "UMLAL	r12, r14, r10, r4        \n\t"
-        "UMLAL	r12, r14, r11, r3        \n\t"
+		"PUSH   { r12, r14 }			\n\t"	// mem 7
 
-        "PUSH	{ r12, r14 }            \n\t"    /* mem 8 */
+		/* C753B 56120E14 */
 
-        /* 10019D F79AAF81 */
+		/* d2 */
+		"UMULL	r12, r14, r6, r2		\n\t"
+		"UMLAL 	r12, r14, r8, r1		\n\t"
+		"UMLAL 	r12, r14, r9, r0		\n\t"
+		"MUL	r10, r10, r5			\n\t"
+		"UMLAL 	r12, r14, r10, r4		\n\t"
+		"UMLAL 	r12, r14, r11, r3		\n\t"
 
-        /* d1 */
-        "UMULL	r12, r14, r6, r1        \n\t"
-        "UMLAL	r12, r14, r8, r0        \n\t"
-        "MUL	r9, r9, r5            \n\t"
-        "UMLAL	r12, r14, r9, r4        \n\t"
-        "UMLAL	r12, r14, r10, r3        \n\t"
-        "UMLAL	r12, r14, r11, r2        \n\t"
+		"PUSH   { r12, r14 }			\n\t"	// mem 8
 
-        "PUSH	{ r12, r14 }            \n\t"    /* mem 9 */
+		/* 10019D F79AAF81 */
 
-        /* D3993 E9038575 */
+		/* d1 */
+		"UMULL	r12, r14, r6, r1		\n\t"
+		"UMLAL 	r12, r14, r8, r0		\n\t"
+		"MUL	r9, r9, r5			\n\t"
+		"UMLAL 	r12, r14, r9, r4		\n\t"
+		"UMLAL 	r12, r14, r10, r3		\n\t"
+		"UMLAL 	r12, r14, r11, r2		\n\t"
 
-        /* d0 */
-        "UMULL	r12, r14, r6, r0        \n\t"
-        "MUL	r8, r8, r5            \n\t"
-        "UMLAL	r12, r14, r8, r4        \n\t"
-        "UMLAL	r12, r14, r9, r3        \n\t"
-        "UMLAL	r12, r14, r10, r2        \n\t"
-        "UMLAL	r12, r14, r11, r1        \n\t"
+		"PUSH   { r12, r14 }			\n\t"	// mem 9
 
-        /* 29DD73 07661C87 */
+		/* D3993 E9038575 */
 
+		/* d0 */
+		"UMULL	r12, r14, r6, r0		\n\t"
+		"MUL	r8, r8, r5			\n\t"
+		"UMLAL 	r12, r14, r8, r4		\n\t"
+		"UMLAL 	r12, r14, r9, r3		\n\t"
+		"UMLAL 	r12, r14, r10, r2		\n\t"
+		"UMLAL 	r12, r14, r11, r1		\n\t"
 
-        /* registers r6, r8, r9, r10, r11 must be
-           populated with above results after accounting
-           for overflow past 26 bit. */
+		/* 29DD73 07661C87 */
 
-        /* doing d0 --> d1 --> d2 --> d3 --> d4 --> d1 -->d2 */
 
-        "MOV	r5, #0x3FFFFFF            \n\t"
-        "AND	r6, r12, r5            \n\t"    /* d0 */
 
-        /* d0 overflow to d1 */
-        "POP	{ r0, r1, r2, r3, r4, r9, r10, r11 }    \n\t"    /* mem 10 */
+		/* registers r6, r8, r9, r10, r11 must be 
+		   populated with above results after accounting 
+		   for overflow past 26 bit. */
 
-        "ADDS	r0, r0, r12, LSR #26        \n\t"
-        "ADC	r1, r1, #0            \n\t"
-        "ADDS	r0, r0, r14, LSL #6        \n\t"
-        "ADC	r1, r1, #0            \n\t"
+		/* doing d0 --> d1 --> d2 --> d3 --> d4 --> d1 -->d2 */
 
-        "AND	r8, r0, r5            \n\t"   /* d1 */
+		"MOV	r5, #0x3FFFFFF			\n\t"
+		"AND	r6, r12, r5			\n\t"	/* d0 */
 
-        /* d1 overflow to d2 */
+		/* d0 overflow to d1 */
+		"POP	{ r0, r1, r2, r3, r4, r9, r10, r11 }	\n\t"	// mem 10
 
-        "ADDS	r2, r2, r0, LSR #26        \n\t"
-        "ADC	r3, r3, #0            \n\t"
-        "ADDS	r2, r2, r1, LSL #6        \n\t"
-        "ADC	r3, r3, #0            \n\t"
+		"LDR 	r5, [sp, %[TEST1_LOCAL]]  \n\t"
+		"STR	r0, [r5]	\n\t"
+		"STR	r1, [r5, #4]	\n\t"
+		"STR	r2, [r5, #8]	\n\t"
+		"STR	r3, [r5, #12]	\n\t"
+		"STR	r4, [r5, #16]	\n\t"
+		"B      armv8_32_poly1305_done \n\t"
 
-        "MOV	r0, r9                \n\t"
+		"ADDS	r0, r0, r12, LSR #26		\n\t"
+		"ADC	r1, r1, #0			\n\t"
+		"ADDS	r0, r0, r14, LSL #6		\n\t"
+		"ADC	r1, r1, #0			\n\t"
 
-        "AND	r9, r2, r5            \n\t"    /* d2 */
+		"AND	r8, r0, r5			\n\t"   /* d1 */
 
-        /* d2 overflow to d3 */
+		/* d1 overflow to d2 */
 
-        "ADDS	r4, r4, r2, LSR #26        \n\t"
-        "ADC	r0, r0, #0            \n\t"
-        "ADDS	r4, r4, r3, LSL #6        \n\t"
-        "ADC	r0, r0, #0            \n\t"
+		"ADDS	r2, r2, r0, LSR #26		\n\t"
+		"ADC	r3, r3, #0			\n\t"
+		"ADDS	r2, r2, r1, LSL #6		\n\t"
+		"ADC	r3, r3, #0			\n\t"
 
-        /* d3 overflow to d4 */
+		"MOV    r0, r9				\n\t"
 
-        "ADDS	r10, r10, r4, LSR #26        \n\t"
-        "ADC	r11, r11, #0            \n\t"
-        "ADDS	r10, r10, r0, LSL #6        \n\t"
-        "ADC	r11, r11, #0            \n\t"
+		"AND	r9, r2, r5			\n\t"	/* d2 */
 
-        /* d4 overflow to d0, must be multiplied by 5 */
+		/* d2 overflow to d3 */
 
-        "LSR	r0, r10, #26            \n\t"
-        "ADD	r0, r0, r11, LSL #6        \n\t"
-        "MOV	r1, #5                \n\t"
-        "MUL	r0, r0, r1            \n\t"
-        "ADD	r6, r6, r0            \n\t"
+		"ADDS	r4, r4, r2, LSR #26		\n\t"
+		"ADC	r0, r0, #0			\n\t"
+		"ADDS	r4, r4, r3, LSL #6		\n\t"
+		"ADC	r0, r0, #0			\n\t"
 
-        "AND	r11, r10, r5            \n\t"    /* d4 */
+		/* d3 overflow to d4 */
 
-        "AND	r10, r4, r5            \n\t"    /* d3 */
+		"ADDS	r10, r10, r4, LSR #26		\n\t"
+		"ADC	r11, r11, #0			\n\t"
+		"ADDS	r10, r10, r0, LSL #6		\n\t"
+		"ADC	r11, r11, #0			\n\t"
 
-        /* d0 overflow to d1 */
+		/* d4 overflow to d0, must be multiplied by 5 */	
 
-        "ADD	r8, r8, r6, LSR #26        \n\t"    /* d1 done */
+		"LSR	r0, r10, #26			\n\t"
+		"ADD	r0, r0, r11, LSL #6		\n\t"
+		"MOV	r1, #5				\n\t"	
+		"MUL	r0, r0, r1			\n\t"
+		"ADD	r6, r6, r0			\n\t"
 
-        "AND	r6, r6, r5            \n\t"    /* d0 done */
+		"AND	r11, r10, r5			\n\t"	/* d4 */
 
-        "B	armv8_32_poly1305_loop        \n\t"
+		"AND	r10, r4, r5			\n\t"	/* d3 */
 
-    "armv8_32_poly1305_last_block:            \n\t"
+		/* d0 overflow to d1 */
 
-        /* This is the last block of the message
-           and the block is less than 16 bytes */
-        "MOV	r0, #0                \n\t"
-        "STR	r0, [sp, %[BYTES_STORE]]    \n\t"
+		"ADD	r8, r8, r6, LSR #26		\n\t"	/* d1 done */
 
-        "LDR	r0, [sp, %[HIBIT_LOCAL]]    \n\t"
+		"AND	r6, r6, r5			\n\t"	/* d0 done */	
 
-        /* Make sure the upper bytes of the
-           32 bit pieces are set to zero.
-           Set the byte past the last message
-           data byte to 01. */
+		"B	armv8_32_poly1305_loop		\n\t"
+	
+	"armv8_32_poly1305_last_block:			\n\t"
 
-        "PUSH	{ r4, r6, r8 }             \n\t"
-
-        "MOV	r1,  #0                \n\t"
-        "MOV	r2,  #0                \n\t"
-        "MOV	r3,  #0                \n\t"
-        "MOV	r4,  #0xFFFFFFFF        \n\t"
-        "LSR	r0, r0, #24            \n\t"
-        "MOV	r6,  r0                \n\t"
-
-        /* always going to load at least one */
-        "LDR	r0, [r7]            \n\t"
-
-        /* byte offset to bit offset */
-        "ADD	r5, r5, #16            \n\t"
-        "LSL	r5, r5, #3            \n\t"
-
-        /* which block */
-        "CMP	r5, #32                \n\t"
-        "BGE	not_word_0            \n\t"
-
-        /* case word 0 */
-    "case0:"
-        "LSL	r8, r4, r5            \n\t"
-        "BIC	r0, r0, r8            \n\t"
-        "LSL	r8, r6, r5            \n\t"
-        "ADD	r0, r0, r8            \n\t"
-        "B	last_block_done            \n\t"
-
-    "not_word_0:                     \n\t"
-        "LDR	r1, [r7, #4]            \n\t"
-
-        "SUB	r5, r5, #32            \n\t"
-        "CMP	r5, #32                \n\t"
-        "BGE	not_word_1            \n\t"
-
-        "LSL	r8, r4, r5            \n\t"
-        "BIC	r1, r1, r8            \n\t"
-        "LSL	r8, r6, r5            \n\t"
-        "ADD	r1, r1, r8            \n\t"
-        "B	last_block_done            \n\t"
-
-    "not_word_1:                    \n\t"
-        "LDR	r2, [r7, #8]            \n\t"
-
-        "SUB	r5, r5, #32            \n\t"
-        "CMP	r5, #32                \n\t"
-        "BGE	not_word_2            \n\t"
-
-        "LSL	r8, r4, r5            \n\t"
-        "BIC	r2, r2, r8            \n\t"
-        "LSL	r8, r6, r5            \n\t"
-        "ADD	r2, r2, r8            \n\t"
-        "B	last_block_done            \n\t"
-
-    "not_word_2:                    \n\t"
-        "LDR	r3, [r7, #0xC]            \n\t"
-
-        "SUB	r5, r5, #32            \n\t"
-
-        "LSL	r8, r4, r5            \n\t"
-        "BIC	r3, r3, r8            \n\t"
-        "LSL	r8, r6, r5            \n\t"
-        "ADD	r3, r3, r8            \n\t"
-
-    "last_block_done:                \n\t"
-
-        "POP	{ r4, r6, r8 }             \n\t"
-
-        "b	armv8_32_poly1305_done_01_byte_appended \n\t"
-
-        ".align 2 \n\t"
-    "armv8_32_poly1305_done:                \n\t"
-
-        "ADD	sp, #28                \n\t"
-        "POP	{ r7 }                \n\t"
-
-        /* store final result */
-        "LDR	r0, %[h_ptr]            \n\t"
-        "STM	r0, { r6, r8, r9, r10, r11 }     \n\t"
-
-        : [m]     "+m" (msgDataOnStack),    /* input */
-          [r_ptr] "+m" (r_ptrLocal),        /* input */
-          [h_ptr] "+m" (h_ptrLocal),        /* input, output */
-          [bytes] "+m" (msgDataLenOnStack),    /* input */
-          [hibit] "+m" (hibitOnStack)        /* input */
-
-        : [BYTES_STORE] "I" (BYTES_SP_OFF),
-          [HIBIT_LOCAL] "I" (HIBIT_LOCAL_SP_OFF)
-        : "memory", "cc",
-            "r0", "r1", "r2", "r3", "r4", "r5", "r6", "r8", "r9", "r10",
-            "r11", "r12", "lr"
-    );
-
-    memcpy(ctx->r, r, 5 * sizeof(word32));
-    memcpy(ctx->h, h, 5 * sizeof(word32));
+		/* This is the last block of the message
+		   and the block is less than 16 bytes */
+		"MOV 	r0, #0				\n\t"
+		"STR	r0, [sp, %[BYTES_STORE]]	\n\t"
+	
+		"LDR	r0, [sp, %[HIBIT_LOCAL]]	\n\t"
+
+		/* Make sure the upper bytes of the 
+		   32 bit pieces are set to zero. 
+		   Set the byte past the last message
+		   data byte to 01. */
+
+		"PUSH	{ r4, r6, r8 } 			\n\t"	
+
+		"MOV    r1,  #0				\n\t"
+		"MOV	r2,  #0				\n\t"
+		"MOV	r3,  #0				\n\t"
+		"MOV	r4,  #0xFFFFFFFF		\n\t"
+		"LSR	r0, r0, #24			\n\t"
+		"MOV	r6,  r0				\n\t"
+
+		/* always going to load at least one */		
+		"LDR	r0, [r7]			\n\t"
+
+		/* byte offset to bit offset */ 
+		"ADD	r5, r5, #16			\n\t"
+		"LSL	r5, r5, #3			\n\t"			
+
+		/* which block */
+		"CMP	r5, #32				\n\t"
+		"BGE	not_word_0			\n\t"
+
+		/* case word 0 */
+	"case0:"
+		"LSL	r8, r4, r5			\n\t"
+		"BIC  	r0, r0, r8			\n\t"
+		"LSL	r8, r6, r5			\n\t"
+		"ADD	r0, r0, r8			\n\t"
+		"B	last_block_done			\n\t"
+
+	"not_word_0:	 				\n\t"
+		"LDR	r1, [r7, #4]			\n\t"
+		
+		"SUB	r5, r5, #32			\n\t"
+		"CMP	r5, #32				\n\t"
+		"BGE	not_word_1			\n\t"
+
+		"LSL	r8, r4, r5			\n\t"
+		"BIC  	r1, r1, r8			\n\t"
+		"LSL	r8, r6, r5			\n\t"
+		"ADD	r1, r1, r8			\n\t"		
+		"B	last_block_done			\n\t"
+
+	"not_word_1:					\n\t"
+		"LDR	r2, [r7, #8]			\n\t"
+
+		"SUB	r5, r5, #32			\n\t"
+		"CMP	r5, #32				\n\t"
+		"BGE	not_word_2			\n\t"
+
+		"LSL	r8, r4, r5			\n\t"
+		"BIC  	r2, r2, r8			\n\t"
+		"LSL	r8, r6, r5			\n\t"
+		"ADD	r2, r2, r8			\n\t"		
+		"B	last_block_done			\n\t"
+
+	"not_word_2:					\n\t"
+		"LDR	r3, [r7, #0xC]			\n\t"
+
+		"SUB	r5, r5, #32			\n\t"
+
+		"LSL	r8, r4, r5			\n\t"
+		"BIC  	r3, r3, r8			\n\t"
+		"LSL	r8, r6, r5			\n\t"
+		"ADD	r3, r3, r8			\n\t"	
+
+	"last_block_done:				\n\t"
+
+		"POP	{ r4, r6, r8 } 			\n\t"	
+	
+		"b 	armv8_32_poly1305_done_01_byte_appended \n\t"
+	
+		".align 2 \n\t"
+	"armv8_32_poly1305_done:				\n\t"
+
+		"ADD	sp, #32				\n\t"
+		"POP	{ r7 }				\n\t"
+
+		/* store final result */
+		"LDR	r0, %[h_ptr]			\n\t"
+		"STM	r0, { r6, r8, r9, r10, r11 } 	\n\t"
+		
+		: [m] 		  "+m" (msgDataOnStack),	/* input */
+		  [r_ptr]  	  "+m" (r_ptrLocal),		/* input */
+		  [h_ptr]  	  "+m" (h_ptrLocal),		/* input, output */
+		  [bytes]  	  "+m" (msgDataLenOnStack),	/* input */
+		  [test1]	  "+m" (test1OnStack),
+		  [hibit]	  "+m" (hibitOnStack)		/* input */
+		  
+		: [BYTES_STORE]    "I" (BYTES_SP_OFF),
+		  [HIBIT_LOCAL]    "I" (HIBIT_LOCAL_SP_OFF),
+		  [TEST1_LOCAL]	   "I" (TEST1_SP_OFF)
+		: "memory", "cc", 
+			"r0", "r1", "r2", "r3", "r4", "r5", "r6", "r8", "r9", "r10",
+			"r11", "r12", "lr"
+	);
+
+	memcpy(ctx->r, r, 5 * sizeof(unsigned));
+	memcpy(ctx->h, h, 5 * sizeof(unsigned));
 
 #ifdef POLY1305_VERBOSE
-    for (i=0;i<5;++i) printf("h%d %07X ", i, ctx->h[i]);
-    printf("\n");
+	for (i=0;i<5;++i) printf("%d %07X ", i, test1Array[i]);
+	printf("\n");
 
-    printf("armv8_32_poly1305_blocks() leaving\n");
+	for (i=0;i<5;++i) printf("h%d %07X ", i, ctx->h[i]);
+	printf("\n");
+
+	printf("armv8_32_poly1305_blocks() leaving\n");
 #endif
 
 }
 #else
 
-/**********************************************************
-  armv8_32_poly1305_blocks    This routine implements the
-            poly1305 algorithm.  The processing
-            of the 16 byte pieces of the
-            message is implemented in assembly.
-            Care was taken in implementing the
-            assembly to optimize speed by
-            minimizing memory references as
-            well as minimizing instructions.
-            The poly1305 algorithm is implemented
-            by using multiple 26 bit values
-            to represent the larger 16 byte and
-            17 byte numbers.  Breaking the
-            larger numbers down into 26 bit
-            pieces means that math operations will
-            not overflow the 32 bit registers.
-            For more information reference the article
-            NEON Cryto by Daniel Berstein and Peter
-            Schwabe.
+void print16(const char *startText, unsigned char *data);
+void multiplyBasic(unsigned char *finalResult, unsigned char *val1, 
+	unsigned char *val2);
 
-            This version of the algorithm uses
-            NEON s registers to temporarily store
-            values so that the stack does not need
-            to be used.
-
-  ctx            poly1305 structure containing the r and
-             h values broke into 26 bit pieces.
-            The result of this routine is returned
-            int the h array of 26 bit values.
-  msgData        Message data to run the algorithm
-            against.
-  keyData        256 bit key that is broken down
-            into the r and s subcomponents.
-**********************************************************/
-static void armv8_32_poly1305_blocks(Poly1305* ctx,
-    const unsigned char *msgData, size_t msgDataLen)
+void armv8_32_poly1305_blocks(Poly1305* ctx, 
+			const unsigned char *msgData,
+                     	size_t msgDataLen)
 {
-    /* these variables will be referenced via r7 in the assembly */
-    word32 r[5], *r_ptrLocal, h[5], *h_ptrLocal;
-    word32 msgDataOnStack = (word32)msgData;
-    word32 msgDataLenOnStack = msgDataLen;
-    /* 1 << 128 */
-    word32 hibitOnStack = (ctx->finished) ? 0 : ((word32) 1 << 24);
+	unsigned long long *r_ptrLocal, *h_ptrLocal;
+	unsigned msgDataOnStack = (unsigned)msgData;
+	unsigned msgDataLenOnStack = msgDataLen;
+ 	unsigned hibitOnStack = (ctx->finished) ? 0 : ((unsigned) 1 << 24); /* 1 << 128 */
+	unsigned test1Array[5*2], *test1OnStack = test1Array;
+	unsigned long long r_44bitPieces[3], h_44bitPieces[3], result;
 
-    memcpy(r, ctx->r, 5 * sizeof(word32));
-    memcpy(h, ctx->h, 5 * sizeof(word32));
+	unsigned char bit128Result[32];
 
-    /* 32 bit pointer, this is necessary to pass the pointer value
+	r_44bitPieces[0] = ((unsigned long long)ctx->r[0] 
+			+ ((unsigned long long)ctx->r[1] << 26))
+			& 0xFFFFFFFFFFF;
+	r_44bitPieces[1] = (((unsigned long long)ctx->r[1] >> 18) 
+			+ ((unsigned long long)ctx->r[2] << 8)
+			+ ((unsigned long long)ctx->r[3] << 34))
+			& 0xFFFFFFFFFFF;
+	r_44bitPieces[2] = (((unsigned long long)ctx->r[3] >> 10) 
+			+ ((unsigned long long)ctx->r[4] << 16))
+			& 0xFFFFFFFFFFF;
+
+	printf("44 bit r0 values \n");
+	printf(" r0  %llx\n", r_44bitPieces[0]);
+	printf(" r1  %llx\n", r_44bitPieces[1]);
+	printf(" r2  %llx\n", r_44bitPieces[2]);
+	printf(" r0 * r1 = 1B657B439E69174EC88AA9\n");
+	
+	multiplyBasic(bit128Result, (unsigned char*)&r_44bitPieces[0],
+		(unsigned char*)&r_44bitPieces[1]);
+	print16("0 * 1 = ", (unsigned char*) bit128Result);
+
+
+	multiplyBasic(bit128Result, (unsigned char*)&r_44bitPieces[1],
+		(unsigned char*)&r_44bitPieces[2]);
+	print16("1 * 2 = ", (unsigned char*) bit128Result);
+
+
+	printf("lower result %llx\n", r_44bitPieces[0] * r_44bitPieces[1] );
+	printf("lower result %llx\n", r_44bitPieces[1] * r_44bitPieces[2]);
+
+
+	h_44bitPieces[0] = ((unsigned long long)ctx->h[0] 
+			+ ((unsigned long long)ctx->h[1] << 26))
+			& 0xFFFFFFFFFFF;
+	h_44bitPieces[1] = (((unsigned long long)ctx->h[1] >> 18) 
+			+ ((unsigned long long)ctx->h[2] << 8)
+			+ ((unsigned long long)ctx->h[3] << 34))
+			& 0xFFFFFFFFFFF;
+	h_44bitPieces[2] = (((unsigned long long)ctx->h[3] >> 10) 
+			+ ((unsigned long long)ctx->h[4] << 16))
+			& 0xFFFFFFFFFFF;
+
+	/* 32 bit pointer, this is necessary to pass the pointer value
            into the assembly code */
-    r_ptrLocal = (word32 *) r;
-    h_ptrLocal = (word32 *) h;
+	r_ptrLocal = (unsigned long long *) r_44bitPieces;
+	h_ptrLocal = (unsigned long long *) h_44bitPieces;
+
+
 
 #ifdef POLY1305_VERBOSE
-    int i;
-    for (i=0;i<5;++i) printf("h%d %07X ", i, h[i]);
-    printf("\n");
+	int i;
+	for (i=0;i<5;++i) printf("r%d %07X ", i, ctx->r[i]);
+	printf("\n");
 
-    printf("armv8_32_poly1305_blocks() data len %d\n", msgDataLen);
+	for (i=0;i<5;++i) printf("h%d %07X ", i, ctx->h[i]);
+	printf("\n");
+
+	printf("armv8_32_poly1305_blocks() data len %d\n", msgDataLen);
 #endif
 
-    __asm__ __volatile__ (
-        ".align    8                \n\t"
-
-        /* valid registers are r0..r12, sp, lr, pc, cpsr, fpscr */
-
-        /* now load the stored h, this should all zero */
-        "LDR	r5, %[h_ptr]            \n\t"
-        "LDM	r5, { r6, r8, r9, r10, r11 }    \n\t"
-        /* r6 = h0  r8 = h1  r9 = h2  r10 = h3  r11 = h4 */
-
-        /* in some cases, r7 is used to reference the local variables
-           on the stack; if -O2 is passed to gcc, the sp may used
-                used to reference local variables. */
-        "LDR	r0, %[hibit]            \n\t"
-        "LDR	r1, %[bytes]            \n\t"
-        "LDR	r2, %[r_ptr]            \n\t"
-
-        "VMOV	s2, r0                \n\t"
-        "VMOV	s4, r1                \n\t"
-
-        "LDM	r2, { r0, r1, r2, r3, r4 }    \n\t"
-        "VMOV	s6, r0                \n\t"
-        "VMOV	s7, r1                \n\t"
-        "VMOV	s8, r2                \n\t"
-        "VMOV	s9, r3                \n\t"
-        "VMOV	s10, r4                \n\t"
-
-        "LDR	r5, %[m]            \n\t"
-        "PUSH	{ r7 }                \n\t"
-        "MOV	r7, r5                \n\t"
-
-        /* s2 - hibit
-            s4 - bytes
-               s6, s7, s8, s9, s10 - r in 26 bit pieces */
-
-    "armv8_32_poly1305_loop:                \n\t"
-
-        /* The poly1305 algorithm requires that a 01 byte
-           be placed after the last byte of the block. */
-
-        "VMOV	r5, s4                \n\t"
-        "CMP	r5, #0                \n\t"
-        "BEQ	armv8_32_poly1305_done        \n\t"
-        "SUBS	r5, r5, #16            \n\t"
-
-        /* branch for least likely case, may help with pipelining */
-        /* ARMv8 uses predictive pipelining.  There is no way
-           to specify in the instruction encoding the more likely
-           case.  */
-        "BLT	armv8_32_poly1305_last_block    \n\t"
-
-        /* this block is 16 bytes */
-        "VMOV	s4, r5                \n\t"
-
-        /* load next 16 byte block of message */
-        "LDM	r7, { r0, r1, r2, r3 }        \n\t"  /* mem 1 */
-        "ADD	r7, r7, #16            \n\t"
-
-        /* in RFC 7539, each block processed is prepended by
-             a byte of value 0x01.  In the wolfSSL implementation,
-           the setting of this value is based on the value found
-           in ctx->finish. To save a memory reference, this code
-           could be replicated one version adding the byte, one
-           version not. */
-
-        /* This is byte 16, past the 128 bits of w19:w18:w17:w16
-           Hence, update is done to h4. */
-        /* add in hibit */
-        "VMOV	r5, s2                \n\t"
-        "ADD	r11, r11, r5             \n\t"
-
-    "armv8_32_poly1305_done_01_byte_appended:    \n\t"
-
-        "mov	r5, #0x3FFFFFF            \n\t"
-
-        /* break data into 26 bit pieces.
-           Bit offsets are 0, 26, 52, 78 and 104 */
-
-        /* h0 += r0 & 0x3FFFFFF; */
-        "AND	r12, r0, r5            \n\t"
-        "ADD	r6, r6, r12            \n\t"
-        /* h1 += (r1:r0 >> 26) & 0x3FFFFFF */
-        "LSR	r12, r0, #26            \n\t"    /* 26 */
-        "ADD	r12, r12, r1, LSL #6        \n\t"
-        "AND	r12, r12, r5            \n\t"
-        "ADD	r8, r8, r12            \n\t"
-        /* h2 += (r2:r1 >> 20) & 0x3FFFFFF */
-        "LSR	r12, r1, #20            \n\t"   /* 20+32 = 52 */
-        "ADD	r12, r12, r2, LSL #12        \n\t"
-        "AND	r12, r12, r5            \n\t"
-        "ADD	r9, r9, r12            \n\t"
-        /* h3 += (r3:r2 >> 14) & 0x3FFFFFF */
-        "LSR	r12, r2, #14            \n\t"    /* 14+32+32 = 78 */
-        "ADD	r12, r12, r3, LSL #18        \n\t"
-        "AND	r12, r12, r5            \n\t"
-        "ADD	r10, r10, r12            \n\t"
-        /* h4 += r3 >> 8               */
-        "ADD	r11, r11, r3, LSR #8        \n\t"    /* 8+32+32+32 = 104 */
-
-        /* pull in the 26 bit components of the r key */
-        "VMOV	r0, s6                \n\t"
-        "VMOV	r1, s7                \n\t"
-        "VMOV	r2, s8                \n\t"
-        "VMOV	r3, s9                \n\t"
-        "VMOV	r4, s10                \n\t"
-
-        /* r0 = BED685  r1 = 3555502  r2 = 47C036  r3 = 1003949  r4 = 806D5 */
-        "MOV	r5, #5                \n\t"
-
-    "checkRegs:                    \n\t"
-        /* d0 = h0 * r0 + h1 * 5*r4 + h2 * 5*r3 + h3 * 5*r2 + h4 * 5*r1 */
-        /* d1 = h0 * r1 + h1 * r0   + h2 * 5*r4 + h3 * 5*r3 + h4 * 5*r2 */
-        /* d2 = h0 * r2 + h1 * r1   + h2 * r0   + h3 * 5*r4 + h4 * 5*r3 */
-        /* d3 = h0 * r3 + h1 * r2   + h2 * r1   + h3 * r0   + h4 * 5*r4 */
-        /* d4 = h0 * r4 + h1 * r3   + h2 * r2   + h3 * r1   + h4 * r0   */
-
-        /*  r14 is the link register, r13 is the sp */
-        /*  r14:r12 = r6 * r0 + (r8 * r4 +  r9 * r3 +  r10 * r2 +  r11 * r1) * r5 */
-        /*  r14:r12 = r6 * r1 +  r8 * r0 + (r9 * r4 +  r10 * r3 +  r11 * r2) * r5 */
-        /*  r14:r12 = r6 * r2 +  r8 * r1 +  r9 * r0 + (r10 * r4 +  r11 * r3) * r5 */
-        /*  r14:r12 = r6 * r3 +  r8 * r2 +  r9 * r1 +  r10 * r0 + (r11 * r4) * r5 */
-        /*  r14:r12 = r6 * r4 +  r8 * r3 +  r9 * r2 +  r10 * r1 +  r11 * r0       */
-
-        /* d4 */
-#if 0
-        "UMULL	r12, r14, r6, r4        \n\t"
-        "UMLAL	r12, r14, r8, r3        \n\t"
-        "UMLAL	r12, r14, r9, r2        \n\t"
-        "UMLAL	r12, r14, r10, r1        \n\t"
-        "UMLAL	r12, r14, r11, r0        \n\t"
-
-        "VMOV	s12, s13, r12, r14        \n\t"
-#else
-        "VMOV	s20, s21, r4, r3        \n\t"
-        "VMOV	s22, s23, r2, r1        \n\t"
-        "VMOV	s24, s25, r6, r8        \n\t"
-        "VMOV	s26, s27, r9, r10       \n\t"
-        "UMULL	r12, r14, r11, r0        \n\t"
-        "VMULL.U32	q14, d12, d10   \n\t"
-        "VMLAL.U32	q14, d13, d11   \n\t"
-        "VMOV	s28, s29, r12, r14       \n\t"
-        "VADD.U64	d28, d28, d29        \n\t"
-        "VADD.U64	d6, d28, d14        \n\t"
-#endif
-
-        /* 8F852 C3AB3DA1 */
-
-        /* d3 */
-        "UMULL	r12, r14, r6, r3        \n\t"
-        "UMLAL	r12, r14, r8, r2        \n\t"
-        "UMLAL	r12, r14, r9, r1        \n\t"
-        "UMLAL	r12, r14, r10, r0        \n\t"
-        "MUL	r11, r11, r5            \n\t"
-        "UMLAL	r12, r14, r11, r4        \n\t"
-
-        "VMOV    s14, s15, r12, r14        \n\t"
-
-        /* C753B 56120E14 */
-
-        /* d2 */
-        "UMULL	r12, r14, r6, r2        \n\t"
-        "UMLAL	r12, r14, r8, r1        \n\t"
-        "UMLAL	r12, r14, r9, r0        \n\t"
-        "MUL	r10, r10, r5            \n\t"
-        "UMLAL	r12, r14, r10, r4        \n\t"
-        "UMLAL	r12, r14, r11, r3        \n\t"
 
-        "VMOV	s16, s17, r12, r14        \n\t"
+	__asm__ __volatile__ (
+		".align	8				\n\t"
+		
+		/* valid registers are d0..d31 */
+
+		"VMOV.i32	d30, #0xFFFFFFFFFFF		\n\t"
+		"VSHR.u64	d30, #32		 	\n\t"
+
+		/* load r values into d0..d4 */
+		"LDR		r0, %[r_ptr]			\n\t"
+		"VLDR		d0, [r0]			\n\t"
+		"VLDR		d1, [r0, #8]			\n\t"
+		"VLDR		d2, [r0, #16]			\n\t"
+
+		"VEOR		q11, q11 \n\t"
+		"VEOR		q12, q12 \n\t"
+		//"VMULL.u32	q11, d0, d1  \n\t"
+		//"VMLAL.u64	q11, d0, d1  \n\t"
+		"VMULL.F64	q11, d0, d1			\n\t"
+
+		"LDR		r6, %[test1]	\n\t"
+		"VSTR		d22, [r6, #0]	\n\t"
+		"VSTR		d23, [r6, #8]	\n\t"
+		"VSTR		d24, [r6, #16]	\n\t"
+		"VSTR		d25, [r6, #24]	\n\t"
+		"VSTR		d23, [r6, #32]	\n\t"
+
+		"B 		armv8_32_poly1305_done		\n\t"
+
+
+		/* now create the times 5 values */
+		/* d3..d5 r values times 5 */
+		"VMOV.i32	d31, #5				\n\t"
+		"VSHR.u64	d30, #32		 	\n\t"
+
+		"VMUL.F64	d3, d0, d31			\n\t"
+		"VMUL.F64	d4, d1, d31			\n\t"
+		"VMUL.F64	d5, d2, d31			\n\t"
+
+		/* load h values into d10..d15 */
+		"LDR		r0, %[h_ptr]			\n\t"
+		//"VLDM 		r0, {d10, d12}			\n\t"
+		"VLDR		d10, [r0]			\n\t"
+		"VLDR		d12, [r0, #8]			\n\t"
+		"VLDR		d14, [r0, #16]			\n\t"
+		"VSHR.u64	d11, d10, #32			\n\t"
+		"VSHR.u64	d13, d12, #32			\n\t"		
+		"VAND.u64	d10, d10, d30			\n\t"
+		"VAND.u64	d12, d12, d30			\n\t"
+		"VAND.u64	d14, d14, d30			\n\t"
+		
+		"LDR		r1, %[m]			\n\t"
+		"LDR		r2, %[bytes]			\n\t"
+		"VLDR		d25, %[hibit]			\n\t"
+
+	"armv8_32_poly1305_loop:				\n\t"
+
+
+		/* The poly1305 algorithm requires that a 01 byte 
+		   be placed after the last byte of the block. */ 		
+
+		"CMP		r2, #0				\n\t"
+		"BEQ		armv8_32_poly1305_done		\n\t"
+		"SUBS 		r2, r2, #16			\n\t"
+	
+		/* branch for least likely case, may help with pipelining */
+		/* ARMv8 uses predictive pipelining.  There is no way
+		   to specify in the instruction encoding the more likely
+		   case.  */
+		"BLT		armv8_32_poly1305_last_block	\n\t"  
 
-        /* 10019D F79AAF81 */
+		/* this block is 16 bytes */		
 
-        /* d1 */
-        "UMULL	r12, r14, r6, r1        \n\t"
-        "UMLAL	r12, r14, r8, r0        \n\t"
-        "MUL	r9, r9, r5            \n\t"
-        "UMLAL	r12, r14, r9, r4        \n\t"
-        "UMLAL	r12, r14, r10, r3        \n\t"
-        "UMLAL	r12, r14, r11, r2        \n\t"
+		/* load next 16 byte block of message */		
+		//"VLDM		r1, { d15, d16 }		\n\t"   
+		"VLDR		d15, [r1]			\n\t"
+		"VLDR		d16, [r1, #8]			\n\t"
+		"ADD		r1, r1, #16			\n\t"
 
-        "VMOV	s18, s19, r12, r14        \n\t"
+		/* in RFC 7539, each block processed is prepended by
+  		   a byte of value 0x01.  In the wolfSSL implementation,
+		   the setting of this value is based on the value found
+		   in ctx->finish. To save a memory reference, this code
+		   could be replicated one version adding the byte, one
+		   version not. */
 
-        /* D3993 E9038575 */
+		/* This is byte 16, past the 128 bits of 
+		   Hence, update is done to h4. */  
+	
+		"VADD.u64	d14, d14, d25 			\n\t"
 
-        /* d0 */
-        "UMULL	r12, r14, r6, r0        \n\t"
-        "MUL	r8, r8, r5            \n\t"
-        "UMLAL	r12, r14, r8, r4        \n\t"
-        "UMLAL	r12, r14, r9, r3        \n\t"
-        "UMLAL	r12, r14, r10, r2        \n\t"
-        "UMLAL	r12, r14, r11, r1        \n\t"
+	"armv8_32_poly1305_done_01_byte_appended:		\n\t"
 
-        /* 29DD73 07661C87 */
+		/* break data into 26 bit pieces. 
+		   Bit offsets are 0, 26, 52, 78 and 104 */
+	
+		/* h0 += d15 & 0x3FFFFFF; */
+		"VAND		d28, d15, d30			\n\t"
+		"VADD.u64	d10, d10, d28			\n\t"
+		/* h1 += (d15 >> 26) & 0x3FFFFFF */
+		"VSHR.u64	d28, d15, #26			\n\t"	/* 26 */
+		"VAND 		d28, d28, d30			\n\t"
+		"VADD.u64	d11, d11, d28			\n\t"
+		/* h2 += ((d15 >> 52) + (d16 << 12)) & 0x3FFFFFF */
+		"VSHL.u64	d28, d16, #12	 		\n\t"
+		"VSHR.u64	d27, d15, #52			\n\t"   /* 20+32 = 52 */
+		"VADD.u64	d28, d28, d27			\n\t"
+		"VAND 		d28, d28, d30			\n\t"
+		"VADD.u64	d12, d12, d28			\n\t"
+		/* h3 += (d16 >> 14) & 0x3FFFFFF */
+		"VSHR.u64	d28, d16, #14			\n\t"	/* 14+32+32 = 78 */
+		"VAND   	d28, d28, d30			\n\t"
+		"VADD.u64	d13, d13, d28			\n\t"
+		/* h4 += r3 >> 8	           */
+		"VSHR.u64	d28, d16, #40			\n\t"
+		"VADD.u64	d14, d14, d28			\n\t"	/* 8+32+32+32 = 104 */
 
-        /* registers r6, r8, r9, r10, r11 must be
-           populated with above results after accounting
-           for overflow past 26 bit. */
+	
 
-        /* doing d0 --> d1 --> d2 --> d3 --> d4 --> d1 -->d2 */
-
-        "MOV	r5, #0x3FFFFFF            \n\t"
-        "AND	r6, r12, r5            \n\t"    /* d0 */
-
-        /* d0 overflow to d1 */
-
-        "VMOV	r0, r1, s18, s19         \n\t"
-        "ADDS	r0, r0, r12, LSR #26        \n\t"
-        "ADC	r1, r1, #0            \n\t"
-        "ADDS	r0, r0, r14, LSL #6        \n\t"
-        "ADC	r1, r1, #0            \n\t"
-
-        "AND	r8, r0, r5            \n\t"   /* d1 */
-
-        /* d1 overflow to d2 */
-
-        "VMOV	r2, r3, s16, s17        \n\t"
-        "ADDS	r2, r2, r0, LSR #26        \n\t"
-        "ADC	r3, r3, #0            \n\t"
-        "ADDS	r2, r2, r1, LSL #6        \n\t"
-        "ADC	r3, r3, #0            \n\t"
-
-        "AND	r9, r2, r5            \n\t"    /* d2 */
-
-        /* d2 overflow to d3 */
-
-        "VMOV	r0, r1, s14, s15        \n\t"
-        "ADDS	r0, r0, r2, LSR #26        \n\t"
-        "ADC	r1, r1, #0            \n\t"
-        "ADDS	r0, r0, r3, LSL #6        \n\t"
-        "ADC	r1, r1, #0            \n\t"
-
-        "AND	r10, r0, r5            \n\t"    /* d3 */
-
-        /* d3 overflow to d4 */
-
-        "VMOV	r2, r3, s12, s13        \n\t"
-        "ADDS	r2, r2, r0, LSR #26        \n\t"
-        "ADC	r3, r3, #0            \n\t"
-        "ADDS	r2, r2, r1, LSL #6        \n\t"
-        "ADC	r3, r3, #0            \n\t"
+	"checkRegs:						\n\t"
+		/*  d0 = h0 * r0 + h1 * 5*r2 + h2 * 5*r1  */
+		/*  d1 = h0 * r1 + h1 * r0   + h2 * 5*r2  */
+		/*  d2 = h0 * r2 + h1 * r1   + h2 * r0    */
 
-        "AND	r11, r2, r5            \n\t"    /* d4 */
+	
+		/*  d15 = d10 * d0 +  d11 * d8 +  d12 * d7  */
+		/*  d16 = d10 * d1 +  d11 * d0 +  d12 * d8  */
+		/*  d17 = d10 * d2 +  d11 * d1 +  d12 * d0  */
 
-        /* d4 overflow to d0, must be multiplied by 5 */
 
-        "LSR	r0, r2, #26            \n\t"
-        "ADD	r0, r0, r3, LSL #6        \n\t"
-        "MOV	r1, #5                \n\t"
-        "MUL	r0, r0, r1            \n\t"
-        "ADD	r6, r6, r0            \n\t"   /* d0 updated */
+		"VMLAL.u32	q1, d0, d1  \n\t"
 
-        /* d0 overflow to d1 */
+		
 
-        "ADD	r8, r8, r6, LSR #26        \n\t"    /* d1 done */
 
-        "AND	r6, r6, r5            \n\t"    /* d0 done */
+		/* registers  contain the 
+		   incremental d results. */
 
-        "B	armv8_32_poly1305_loop        \n\t"
+		/* doing d0 --> d1 --> d2 -times 5-> d0 --> d1 --> d2 */
 
-    "armv8_32_poly1305_last_block:            \n\t"
+		"VAND.u64	d10, d15, d30			\n\t"	/* d0 */
 
-        /* This is the last block of the message
-           and the block is less than 16 byte */
-
-        /* set s4 to 0, d2 is s5:s4 */
-        "VEOR	d2, d2                \n\t"
-
-        "VMOV	r0, s2                \n\t"    /* hibit */
-
-        /* Make sure the upper bytes of the
-           32 bit pieces are set to zero.
-           Set the byte past the last message
-           data byte to 01. */
-
-        "PUSH	{ r4, r6, r8 }             \n\t"
-
-        "MOV	r1,  #0                \n\t"
-        "MOV	r2,  #0                \n\t"
-        "MOV	r3,  #0                \n\t"
-        "MOV	r4,  #0xFFFFFFFF        \n\t"
-        "LSR	r0, r0, #24            \n\t"
-        "MOV	r6,  r0                \n\t"
-
-        /* always going to load at least one */
-        "LDR	r0, [r7]            \n\t"
-
-        /* byte offset to bit offset */
-        "ADD	r5, r5, #16            \n\t"
-        "LSL	r5, r5, #3            \n\t"
-
-        /* which block */
-        "CMP	r5, #32                \n\t"
-        "BGE	not_word_0            \n\t"
-
-        /* case word 0 */
-    "case0:"
-        "LSL	r8, r4, r5            \n\t"
-        "BIC	r0, r0, r8            \n\t"
-        "LSL	r8, r6, r5            \n\t"
-        "ADD	r0, r0, r8            \n\t"
-        "B	last_block_done            \n\t"
-
-    "not_word_0:                     \n\t"
-        "LDR	r1, [r7, #4]            \n\t"
-
-        "SUB	r5, r5, #32            \n\t"
-        "CMP	r5, #32                \n\t"
-        "BGE	not_word_1            \n\t"
-
-        "LSL	r8, r4, r5            \n\t"
-        "BIC	r1, r1, r8            \n\t"
-        "LSL	r8, r6, r5            \n\t"
-        "ADD	r1, r1, r8            \n\t"
-        "B	last_block_done            \n\t"
-
-    "not_word_1:                    \n\t"
-        "LDR	r2, [r7, #8]            \n\t"
-
-        "SUB	r5, r5, #32            \n\t"
-        "CMP	r5, #32                \n\t"
-        "BGE	not_word_2            \n\t"
-
-        "LSL	r8, r4, r5            \n\t"
-        "BIC	r2, r2, r8            \n\t"
-        "LSL	r8, r6, r5            \n\t"
-        "ADD	r2, r2, r8            \n\t"
-        "B	last_block_done            \n\t"
-
-    "not_word_2:                    \n\t"
-        "LDR	r3, [r7, #0xC]            \n\t"
-
-        "SUB	r5, r5, #32            \n\t"
-
-        "LSL	r8, r4, r5            \n\t"
-        "BIC	r3, r3, r8            \n\t"
-        "LSL	r8, r6, r5            \n\t"
-        "ADD	r3, r3, r8            \n\t"
-
-    "last_block_done:                \n\t"
-
-        "POP	{ r4, r6, r8 }             \n\t"
-
-        "b	armv8_32_poly1305_done_01_byte_appended \n\t"
-
-        ".align 2 \n\t"
-    "armv8_32_poly1305_done:                \n\t"
-
-        "POP	{ r7 }                \n\t"
-
-        /* store final result */
-        "LDR	r0, %[h_ptr]            \n\t"
-        "STM	r0, { r6, r8, r9, r10, r11 }     \n\t"
-
-        : [m]     "+m" (msgDataOnStack),    /* input */
-          [r_ptr] "+m" (r_ptrLocal),        /* input */
-          [h_ptr] "+m" (h_ptrLocal),        /* input, output */
-          [bytes] "+m" (msgDataLenOnStack),    /* input */
-          [hibit] "+m" (hibitOnStack)        /* input */
-        :
-        : "memory", "cc",
-            "r0", "r1", "r2", "r3", "r4", "r5", "r6", "r8", "r9", "r10",
-            "r11", "r12", "lr",
-            "s2", "s4", "s6", "s7", "s8", "s9", "s10", "s12", "s13", "s14",
-            "s15", "s16", "s17", "s18", "s19", "s20", "s21", "s22", "s23",
-            "s24", "s25", "s26", "s27", "s28", "s29", "s30", "s31",
-            "d2", "q14", "q15"
-    );
-
-    memcpy(ctx->r, r, 5 * sizeof(word32));
-    memcpy(ctx->h, h, 5 * sizeof(word32));
+
+		"VSHL.u64	d28, d15, #26			\n\t"
+		"VADD.u64	d16, d28			\n\t"
+
+		"VAND.u64	d11, d16, d30			\n\t"   /* d1 */
+
+		/* d1 overflow to d2 */
+
+		"VSHL.u64	d28, d16, #26			\n\t"
+		"VADD.u64	d17, d28			\n\t"
+
+		"VAND.u64	d12, d17, d30			\n\t"   /* d2 */
+
+		/* d2 overflow to d3 */
+
+		"VSHL.u64	d28, d17, #26			\n\t"
+		"VADD.u64	d18, d28			\n\t"
+
+		"VAND.u64	d13, d18, d30			\n\t"   /* d3 */
+
+		/* d3 overflow to d4 */
+
+		"VSHL.u64	d28, d18, #26			\n\t"
+		"VADD.u64	d19, d28			\n\t"
+
+		"VAND.u64	d14, d19, d30			\n\t"   /* d4 */
+
+
+		/* d4 overflow to d0, must be multiplied by 5 */
+
+		"VSHL.u64	d28, d14, #26			\n\t"
+		"VMUL.F64	d27, d28, d31			\n\t"
+		"VADD.u64	d10, d27			\n\t"
+
+		"VAND.u64	d10, d10, d30			\n\t"   /* d0 */
+
+		
+		/* d0 overflow to d1 */
+
+		"VSHL.u64	d28, d10, #26			\n\t"
+		"VADD.u64	d11, d28, d31			\n\t"
+
+		"B	armv8_32_poly1305_loop		\n\t"
+	
+	"armv8_32_poly1305_last_block:			\n\t"
+
+		/* This is the last block of the message
+		   and the block is less than 16 bytes */
+		"MOV 	r0, #0				\n\t"
+		"STR	r0, [sp, %[BYTES_STORE]]	\n\t"
+	
+		"LDR	r0, [sp, %[HIBIT_LOCAL]]	\n\t"
+
+		/* Make sure the upper bytes of the 
+		   32 bit pieces are set to zero. 
+		   Set the byte past the last message
+		   data byte to 01. */
+
+		"PUSH	{ r4, r6, r8 } 			\n\t"	
+
+		"MOV    r1,  #0				\n\t"
+		"MOV	r2,  #0				\n\t"
+		"MOV	r3,  #0				\n\t"
+		"MOV	r4,  #0xFFFFFFFF		\n\t"
+		"LSR	r0, r0, #24			\n\t"
+		"MOV	r6,  r0				\n\t"
+
+		/* always going to load at least one */		
+		"LDR	r0, [r7]			\n\t"
+
+		/* byte offset to bit offset */ 
+		"ADD	r5, r5, #16			\n\t"
+		"LSL	r5, r5, #3			\n\t"			
+
+		/* which block */
+		"CMP	r5, #32				\n\t"
+		"BGE	not_word_0			\n\t"
+
+		/* case word 0 */
+	"case0:"
+		"LSL	r8, r4, r5			\n\t"
+		"BIC  	r0, r0, r8			\n\t"
+		"LSL	r8, r6, r5			\n\t"
+		"ADD	r0, r0, r8			\n\t"
+		"B	last_block_done			\n\t"
+
+	"not_word_0:	 				\n\t"
+		"LDR	r1, [r7, #4]			\n\t"
+		
+		"SUB	r5, r5, #32			\n\t"
+		"CMP	r5, #32				\n\t"
+		"BGE	not_word_1			\n\t"
+
+		"LSL	r8, r4, r5			\n\t"
+		"BIC  	r1, r1, r8			\n\t"
+		"LSL	r8, r6, r5			\n\t"
+		"ADD	r1, r1, r8			\n\t"		
+		"B	last_block_done			\n\t"
+
+	"not_word_1:					\n\t"
+		"LDR	r2, [r7, #8]			\n\t"
+
+		"SUB	r5, r5, #32			\n\t"
+		"CMP	r5, #32				\n\t"
+		"BGE	not_word_2			\n\t"
+
+		"LSL	r8, r4, r5			\n\t"
+		"BIC  	r2, r2, r8			\n\t"
+		"LSL	r8, r6, r5			\n\t"
+		"ADD	r2, r2, r8			\n\t"		
+		"B	last_block_done			\n\t"
+
+	"not_word_2:					\n\t"
+		"LDR	r3, [r7, #0xC]			\n\t"
+
+		"SUB	r5, r5, #32			\n\t"
+
+		"LSL	r8, r4, r5			\n\t"
+		"BIC  	r3, r3, r8			\n\t"
+		"LSL	r8, r6, r5			\n\t"
+		"ADD	r3, r3, r8			\n\t"	
+
+	"last_block_done:				\n\t"
+
+		"POP	{ r4, r6, r8 } 			\n\t"	
+	
+		"b 	armv8_32_poly1305_done_01_byte_appended \n\t"
+	
+		".align 2 \n\t"
+	"armv8_32_poly1305_done:			\n\t"
+
+		/* store final result */
+		"VSHL.u64	d28, d11, #32			\n\t"
+		"VADD.u64	d10, d10, d11			\n\t"
+
+		"VSHL.u64	d28, d13, #32			\n\t"
+		"VADD.u64	d12, d12, d11			\n\t"
+
+		"VSHL.u64	d28, d15, #32			\n\t"
+		"VADD.u64	d14, d14, d11			\n\t"
+
+		"VSTR		d10, [r0]			\n\t"
+		"VSTR		d12, [r0, #8]			\n\t"
+		"VSTR		d14, [r0, #16]			\n\t"
+		
+		: [m] 		  "+m" (msgDataOnStack),	/* input */
+		  [r_ptr]  	  "+m" (r_ptrLocal),		/* input */
+		  [h_ptr]  	  "+m" (h_ptrLocal),		/* input, output */
+		  [bytes]  	  "+m" (msgDataLenOnStack),	/* input */
+		  [hibit]	  "+m" (hibitOnStack),		/* input */
+		  [test1]	  "+m" (test1OnStack)
+		: [BYTES_STORE]    "I" (BYTES_SP_OFF),
+		  [HIBIT_LOCAL]    "I" (HIBIT_LOCAL_SP_OFF)
+		: "memory", "cc", 
+			"r0", "r1", "r2", "r3", "r4", "r5", "r6", "r8", "r9", "r10",
+			"d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+			"d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18",
+			"d19", "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27",
+			"d28", "d29", "d30", "d31"
+	);
+
+	ctx->r[0] = r_44bitPieces[0] & 0x3FFFFFF;
+	ctx->r[1] = ((r_44bitPieces[0] >> 26)		/* 44 - 26 = 18 */
+ 		    + (r_44bitPieces[1] << 18)) 	/* 26 - 18 = 8  */
+		    & 0x3FFFFFF;
+	ctx->r[2] = (r_44bitPieces[1] >> 8)    		/* 44 - 8  = 36  */
+		    & 0x3FFFFFF;
+	ctx->r[3] = ((r_44bitPieces[1] >> (44-10))	/* 36 - 26 = 10 */
+ 		    + (r_44bitPieces[2] << 10))		/* 26 - 10 = 16 */
+		    & 0x3FFFFFF;
+	ctx->r[4] = (r_44bitPieces[2] >> 16);		/* 44 - 16 = 28 */ 
+
 
 #ifdef POLY1305_VERBOSE
-    for (i=0;i<5;++i) printf("h%d %07X ", i, ctx->h[i]);
-    printf("\n");
 
-    printf("armv8_32_poly1305_blocks() leaving\n");
+	printf("\n\n THIS stuff \n\n");
+	for (i=0;i<10;){
+		 printf("%d %07X ", i, test1Array[i+1]);
+		 printf(" %07X ",  test1Array[i]);
+		 i+=2;
+	}
+	printf("\n\n");
+
+
+	for (i=0;i<5;++i) printf("r%d %07X ", i, ctx->r[i]);
+	printf("\n");
+
+	printf("armv8_32_poly1305_blocks() leaving\n");
 #endif
 
 }
 
 #endif  /* #ifdef  WOLFSSL_ARMASM_NO_NEON */
 
-void poly1305_blocks(Poly1305* ctx, const unsigned char *m, size_t bytes)
-{
-    armv8_32_poly1305_blocks(ctx, m, bytes);
-}
-
-void poly1305_block(Poly1305* ctx, const unsigned char *m)
-{
-    armv8_32_poly1305_blocks(ctx, m, POLY1305_BLOCK_SIZE);
-}
-
-static word32 U8TO32(const byte *p)
-{
-    return
-        (((word32)(p[0] & 0xff)      ) |
-         ((word32)(p[1] & 0xff) <<  8) |
-         ((word32)(p[2] & 0xff) << 16) |
-         ((word32)(p[3] & 0xff) << 24));
-}
-
-static void U32TO8(byte *p, word32 v) {
-    p[0] = (byte)((v      ) & 0xff);
-    p[1] = (byte)((v >>  8) & 0xff);
-    p[2] = (byte)((v >> 16) & 0xff);
-    p[3] = (byte)((v >> 24) & 0xff);
-}
-
-int wc_Poly1305SetKey(Poly1305* ctx, const byte* key, word32 keySz)
-{
-    if (key == NULL)
-        return BAD_FUNC_ARG;
-
-#ifdef CHACHA_AEAD_TEST
-    word32 k;
-    printf("Poly key used:\n");
-    for (k = 0; k < keySz; k++) {
-        printf("%02x", key[k]);
-        if ((k+1) % 8 == 0)
-            printf("\n");
-    }
-    printf("\n");
-#endif
-
-    if (keySz != 32 || ctx == NULL)
-        return BAD_FUNC_ARG;
-
-    /* r &= 0xffffffc0ffffffc0ffffffc0fffffff */
-    ctx->r[0] = (U8TO32(key +  0)     ) & 0x3ffffff;
-    ctx->r[1] = (U8TO32(key +  3) >> 2) & 0x3ffff03;
-    ctx->r[2] = (U8TO32(key +  6) >> 4) & 0x3ffc0ff;
-    ctx->r[3] = (U8TO32(key +  9) >> 6) & 0x3f03fff;
-    ctx->r[4] = (U8TO32(key + 12) >> 8) & 0x00fffff;
-
-    /* h = 0 */
-    ctx->h[0] = 0;
-    ctx->h[1] = 0;
-    ctx->h[2] = 0;
-    ctx->h[3] = 0;
-    ctx->h[4] = 0;
-
-    /* save pad for later */
-    ctx->pad[0] = U8TO32(key + 16);
-    ctx->pad[1] = U8TO32(key + 20);
-    ctx->pad[2] = U8TO32(key + 24);
-    ctx->pad[3] = U8TO32(key + 28);
-
-    ctx->leftover = 0;
-    ctx->finished = 0;
-
-    return 0;
-}
-
-int wc_Poly1305Final(Poly1305* ctx, byte* mac)
-{
-    word32 h0,h1,h2,h3,h4,c;
-    word32 g0,g1,g2,g3,g4;
-    word64 f;
-    word32 mask;
-
-    /* process the remaining block */
-    if (ctx->leftover) {
-        size_t i = ctx->leftover;
-        ctx->buffer[i++] = 1;
-        for (; i < POLY1305_BLOCK_SIZE; i++)
-            ctx->buffer[i] = 0;
-        ctx->finished = 1;
-        poly1305_block(ctx, ctx->buffer);
-    }
-
-    /* fully carry h */
-    h0 = ctx->h[0];
-    h1 = ctx->h[1];
-    h2 = ctx->h[2];
-    h3 = ctx->h[3];
-    h4 = ctx->h[4];
-
-                 c = h1 >> 26; h1 = h1 & 0x3ffffff;
-    h2 +=     c; c = h2 >> 26; h2 = h2 & 0x3ffffff;
-    h3 +=     c; c = h3 >> 26; h3 = h3 & 0x3ffffff;
-    h4 +=     c; c = h4 >> 26; h4 = h4 & 0x3ffffff;
-    h0 += c * 5; c = h0 >> 26; h0 = h0 & 0x3ffffff;
-    h1 +=     c;
-
-    /* compute h + -p */
-    g0 = h0 + 5; c = g0 >> 26; g0 &= 0x3ffffff;
-    g1 = h1 + c; c = g1 >> 26; g1 &= 0x3ffffff;
-    g2 = h2 + c; c = g2 >> 26; g2 &= 0x3ffffff;
-    g3 = h3 + c; c = g3 >> 26; g3 &= 0x3ffffff;
-    g4 = h4 + c - ((word32)1 << 26);
-
-    /* select h if h < p, or h + -p if h >= p */
-    mask = ((word32)g4 >> ((sizeof(word32) * 8) - 1)) - 1;
-    g0 &= mask;
-    g1 &= mask;
-    g2 &= mask;
-    g3 &= mask;
-    g4 &= mask;
-    mask = ~mask;
-    h0 = (h0 & mask) | g0;
-    h1 = (h1 & mask) | g1;
-    h2 = (h2 & mask) | g2;
-    h3 = (h3 & mask) | g3;
-    h4 = (h4 & mask) | g4;
-
-    /* h = h % (2^128) */
-    h0 = ((h0      ) | (h1 << 26)) & 0xffffffff;
-    h1 = ((h1 >>  6) | (h2 << 20)) & 0xffffffff;
-    h2 = ((h2 >> 12) | (h3 << 14)) & 0xffffffff;
-    h3 = ((h3 >> 18) | (h4 <<  8)) & 0xffffffff;
-
-    /* mac = (h + pad) % (2^128) */
-    f = (word64)h0 + ctx->pad[0]            ; h0 = (word32)f;
-    f = (word64)h1 + ctx->pad[1] + (f >> 32); h1 = (word32)f;
-    f = (word64)h2 + ctx->pad[2] + (f >> 32); h2 = (word32)f;
-    f = (word64)h3 + ctx->pad[3] + (f >> 32); h3 = (word32)f;
-
-    U32TO8(mac + 0, h0);
-    U32TO8(mac + 4, h1);
-    U32TO8(mac + 8, h2);
-    U32TO8(mac + 12, h3);
-
-    /* zero out the state */
-    ctx->h[0] = 0;
-    ctx->h[1] = 0;
-    ctx->h[2] = 0;
-    ctx->h[3] = 0;
-    ctx->h[4] = 0;
-    ctx->r[0] = 0;
-    ctx->r[1] = 0;
-    ctx->r[2] = 0;
-    ctx->r[3] = 0;
-    ctx->r[4] = 0;
-    ctx->pad[0] = 0;
-    ctx->pad[1] = 0;
-    ctx->pad[2] = 0;
-    ctx->pad[3] = 0;
-
-    return 0;
-}
-
-#endif  /* #ifndef __aarch64__   */
+#endif	/* #ifndef __aarch64__   */
 #endif  /* #ifdef  WOLFSSL_ARMASM */
 
+
+#ifdef STAND_ALONE_DEBUG
+/**********************************************************
+  printRegs	Test routine used to display the register 
+		values save by the call to the assembly
+		routine saveRegs.  The r6, r8, r9, r10
+		and r11 values are approperiately added
+		together to create a 17 byte value that is
+		displayed.  
+**********************************************************/
+void printRegs(unsigned *regArray)
+{
+	unsigned result26Bit[5];
+	unsigned char result[17];
+	int i;	
+
+	printf("\n\n*** Register dump ***\n");
+	for (i=0; i<13;++i)
+		printf("r%d = 0x%08X \n", i, regArray[i]);
+	printf(" sp (r13) skiped\n");
+	printf(" lr (r14) = 0x%08X \n", regArray[i]);
+
+	/* r6, r8, r9, r10, r11 could be 26 bit components
+	   print the result of reassembling them. */
+
+	result26Bit[0] = regArray[6];
+	result26Bit[1] = regArray[8];
+	result26Bit[2] = regArray[9];
+	result26Bit[3] = regArray[10];	
+	result26Bit[4] = regArray[11];
+	convert26BitValuesTo17Byte(result26Bit, result);
+
+	//printBytes("result = ", result, 17);
+	print17("result = ", result);
+}
+
+#define SAVE_REGS	"PUSH 	{ r14 }				\n\t" \
+			"BL	recordRegs			\n\t" \
+			"NOP					\n\t" \
+			"POP	{ r14 }				\n\t"
+#endif
+
+
+#ifdef POLY1305_STAND_ALONE
+
+void byte32Add(unsigned char *destByte, unsigned char *srcByte)
+{
+	int i;
+	unsigned *dest, *src;
+	unsigned long long result;
+	unsigned long long of=0;
+	
+	dest = (unsigned *)destByte;
+	src = (unsigned *)srcByte;
+	
+	for (i=0;i<8;++i)
+	{
+		/* the type cast to unsigned long is necessary */
+		result = (unsigned long long)dest[i]+(unsigned long long)src[i]+of;
+		of = result >> 32;
+		dest[i] = (unsigned) result;
+	}
+}
+
+void multiplyBasic(unsigned char *finalResult, unsigned char *val1, 
+	unsigned char *val2)
+{
+	unsigned char intermediateResult[32];
+	unsigned bit32Val1, bit32Val2;
+	/* if compiling 32 bit needs to be unsigned long long for 64 bit */
+	unsigned long long result;   
+	int i,j;
+	
+	/* set to 0 then do repeated adds */
+	memset(finalResult, 0, 32);
+
+	/* generate 4 intermediate results */
+	/* then shift and add those results */
+	
+	for (i=0;i<2;++i)
+	{
+		bit32Val1 = *(unsigned*)(val1 + 4*i);
+		
+		/* multiple the 32 bit value times the entire 17 byte */
+		for (j=0;j<2;++j)
+		{
+			bit32Val2 = *(unsigned*)(val2 + 4*j);
+			
+			memset(intermediateResult,0,32);
+			//printf("32 bit vals %X %X \n", bit32Val1, bit32Val2);
+
+			/* must convert to 64 bit before the mult or the mult
+			   will give a 32 bit result not a 64 bit */
+			result = (unsigned long long)bit32Val1 
+				* (unsigned long long)bit32Val2;
+			//printf("result %lX \n", result);
+			*(unsigned long long*)(intermediateResult + 4*j + 4*i) 
+				= result;
+				
+			/* add the intermediate result to byte32Result */
+			byte32Add(finalResult, intermediateResult);
+			//print32(" ", byte32Result);
+		}
+		
+#if 0
+		/* multiple final byte */
+		memset(intermediateResult,0,32);
+		result = (unsigned long long)bit32Val1 * (unsigned long long)val2[16];
+		
+		if ((4*j + 4*i) == 0x1C)
+			*(unsigned*)(intermediateResult + 4*j + 4*i) 
+				= (unsigned)result;
+		else
+			*(unsigned long long*)(intermediateResult + 4*j + 4*i) 
+				= (unsigned long long)result;
+				
+		/* add the intermediate result to byte32Result */
+		byte32Add(finalResult, intermediateResult);
+#endif
+	}
+}
+
+
+/**********************************************************
+  print16	Output the given 16 bytes as one big
+		number.  Note 16 bytes is 128 bit.
+**********************************************************/
+void print16(const char *startText, unsigned char *data);
+void print16(const char *startText, unsigned char *data)
+{
+	printf("%s %08X %08X %08X %08X\n", startText, *(unsigned*)(data+0xc),
+			*(unsigned*)(data+0x8),
+			*(unsigned*)(data+4),
+			*(unsigned*)data);
+}
+
+
+/**********************************************************
+  print17	Output the given 17 bytes as one big
+		number.  
+**********************************************************/
+void print17(const char *startText, unsigned char *data);
+void print17(const char *startText, unsigned char *data)
+{
+	printf("%s %02X %08X%08X %08X%08X \n", startText, data[16], 
+				*(unsigned *)(data+0xC), *(unsigned *)(data+8),
+				*(unsigned *)(data+4), *(unsigned *)(data));
+}
+
+
+/**********************************************************
+  printBytes	Print the specified number of bytes, one
+		byte at a time.
+**********************************************************/
+void printBytes(const char *startText, unsigned char *data, int len);
+void printBytes(const char *startText, unsigned char *data, int len)
+{
+	int i;
+	
+	printf("%s", startText);
+	
+	for (i=0;i<len;++i)
+	{
+		printf("%02X", data[i]);
+		if (i<len-1) printf(":");
+	}
+	printf("\n");
+}
+
+
+/**********************************************************
+  clamp_r	Set the correct bits in the 128 bit r key
+		to zero.
+**********************************************************/
+void clamp_r(unsigned char *r);
+void clamp_r(unsigned char *r)
+{
+	printBytes("r = ", r, 16);
+	
+	r[3] &= 0xF;
+	r[7] &= 0xF;
+	r[11] &= 0xF;
+	r[15] &= 0xF;
+	
+	r[4] &= 0xFC;
+	r[8] &= 0xFC;
+	r[12] &= 0xFC;
+	
+	print16("after clamp ", r);
+}
+
+
+/**********************************************************
+  add17		Add two 17 byte numbers together.  This is
+		used as part of the algorithm to combine
+		26 bit pieces into one 17 byte number.
+**********************************************************/
+void add17(unsigned char *dest, unsigned char *src);
+void add17(unsigned char *dest, unsigned char *src)
+{
+	int i;
+	short result;
+	unsigned char of=0;
+	
+	for (i=0;i<17;++i)
+	{
+		result = dest[i] + src[i] + of;
+		
+		dest[i] = (unsigned char)result;
+		
+		if (result & 0xFF00) of=1; else of=0; 
+	}
+}
+
+
+/**********************************************************
+  convert26BitValuesTo17Byte
+		Convert the 5 specified 26 bit values to
+		a single 17 byte value.
+  input16Bit	Input array of 5 26 bit values.  
+  result	Output of 17 bytes which represent one
+		130 bit number.
+**********************************************************/
+void convert26BitValuesTo17Byte(unsigned *input26Bit, unsigned char *result);
+void convert26BitValuesTo17Byte(unsigned *input26Bit, unsigned char *result)
+{
+	unsigned char tmp[17];
+
+	memset(result, 0, 17);
+	*(unsigned*)(result+0) = input26Bit[0];
+
+	memset(tmp, 0, 17);
+	*(unsigned*)(tmp+3)  = input26Bit[1] << 2;
+	add17(result, tmp);
+
+	memset(tmp, 0, 17);
+	*(unsigned*)(tmp+6)  = input26Bit[2] << 4;
+	add17(result, tmp);
+
+	memset(tmp, 0, 17);
+	*(unsigned*)(tmp+9)  = input26Bit[3] << 6;
+	add17(result, tmp);
+
+	memset(tmp, 0, 17);
+	*(unsigned*)(tmp+13) = input26Bit[4];
+	add17(result, tmp);	
+
+	result[16] &= 3;
+}
+
+
+/* test data set from RFC 7539 */
+unsigned char testData []="Cryptographic Forum Research set"; 
+//unsigned char testData []="Cryptographic Forum Research Group"; 
+//unsigned char testData []="12345678901234561234567890123456";
+unsigned char testKey[]="\x85\xd6\xBE\x78\x57\x55\x6d\x33\x7F\x44\x52\xfe\x42\xd5\x06\xa8\x01\x03\x80\x8a\xfb\x0d\xb2\xFD\x4A\xBF\xF6\xAF\x41\x49\xF5\x1B";
+
+unsigned char resultCheck[]="\xA8\x06\x1D\xC1\x30\x51\x36\xC6\xC2\x2B\x8B\xAF\x0C\x01\x27\xA9";
+
+
+unsigned char msgDataCopy[100];		
+
+int main(void)
+{
+	unsigned char *msgData, *keyData;
+	int msgDataLen;
+	unsigned char result16Byte[16];
+	Poly1305  ctx;
+ 	unsigned char *r, *s, acc[17];
+
+	msgData = testData;
+	msgDataLen = strlen((const char *)msgData);	
+	keyData = testKey;
+
+
+	unsigned *pt;
+	pt = (unsigned*)msgData;
+
+	int i;
+	printf("%s\n", msgData);
+	for (i=0;i<10;++i) printf(" %d %X\n", i, pt[i]);
+	printf("\n");
+
+	printf("message len %d\n", msgDataLen);
+
+
+	/* some modifications of the test data for test
+	   purposes.  Used in part to test the assembly
+	   algorithm for the last block of the message. */
+#if 0
+	/* add junk at end for testing */
+	memcpy(msgDataCopy, msgData, msgDataLen);
+	msgData = msgDataCopy;
+	*(unsigned*)(msgData+msgDataLen) = 0x12345678;
+	*(unsigned*)(msgData+msgDataLen+4) = 0x12345678;
+	*(unsigned*)(msgData+msgDataLen+8) = 0x11111111;
+#endif
+	
+#if 0
+	/* make test data a boundary case length
+	   for testing. */
+	memcpy(msgDataCopy, msgData, msgDataLen);
+	msgData = msgDataCopy;
+
+	strcat(msgData, "more stuff");
+	msgDataLen = strlen(msgData);	
+#endif
+
+#if 0
+	/* just run poly1305 on the first 16 byte 
+ 	   block of the test data. */
+	strcpy(msgDataCopy, "Cryptographic Fo");
+	msgData = msgDataCopy;
+	msgDataLen = strlen(msgData);		
+#endif
+
+	r = keyData;
+	s = keyData+16;
+
+	print16("s as a 128-bit number ", s);
+	clamp_r(r);
+
+	/* break the 16 byte value into 26 bit parts. */         
+	ctx.r[0] = *(unsigned *)(r) & 0x3FFFFFF;
+	ctx.r[1] = ((*(unsigned *)(r + 3)) >> 2) & 0x3FFFFFF;
+	ctx.r[2] = ((*(unsigned *)(r + 6)) >> 4) & 0x3FFFFFF;
+	ctx.r[3] = ((*(unsigned *)(r + 9)) >> 6) & 0x3FFFFFF;
+	/* + 12 so you don't reference outside array, ie don't use +13 */
+	ctx.r[4] = ((*(unsigned *)(r + 12)) >> 8) & 0xFFFFFF;
+
+	ctx.finished = 0;
+
+	/* Should always start as zero.
+           Passing into assembly routine to match what is already 
+	   implemented in wolfSSL armv8_poly1305.c.  
+	   For debugging, the C routine could break the message into 
+	   16 byte chunks and call the assembly routine over and over
+	   with the 16 byte chunks and the updated h value. */
+	memset(ctx.h, 0, 5 * sizeof(unsigned));
+
+	armv8_32_poly1305_blocks(&ctx, msgData, msgDataLen);
+
+	convert26BitValuesTo17Byte(ctx.h, acc);
+
+	/* make output match what is seen in RFC */
+	print17("Acc = ((Acc+Block) * r) % P = ", acc);
+	add17(acc, s);
+	print17("Acc + s = ", acc);
+
+	memcpy(result16Byte, acc, 16);
+
+	printBytes(" Tag = ", result16Byte, 16); 
+
+	if (!memcmp(result16Byte, resultCheck, 16))
+		printf("Result matches RFC 7539\n\n");
+	else	
+		printf("Result does not match RFC 7539\n\n");
+}
+#endif
 

--- a/wolfcrypt/src/port/arm/armv8-32-poly1305.c
+++ b/wolfcrypt/src/port/arm/armv8-32-poly1305.c
@@ -3,8 +3,8 @@
    The test data in this code matches the test data in RFC 7539.
 
    The poly1305 algorithm takes two inputs, they are as follows.
-	1. the message data
-	2. a 256 bit key
+        1. the message data
+        2. a 256 bit key
    The algorithm outputs a 16 byte authentication value.
   
    The 16 bytes are transmitted with the message.  
@@ -22,7 +22,7 @@
    It is common to use the ChaCha20 algorithm to generate
    the pseudo random key.  The initial 256 bit key is normally
    shared during the setup up of the connection between 
-   sender and receiver.	
+   sender and receiver.        
 
    The 256 bit key is broken down into two 128 bit parts; 
    namely r and s.  In the algorithm, r is clamped, meaning
@@ -34,18 +34,18 @@
 
    This code was compiled and tested with the following tool chain.
 
-	gcc-arm-10.2-2020.11-aarch64-arm-none-linux-guneabihf
+        gcc-arm-10.2-2020.11-aarch64-arm-none-linux-guneabihf
 
    The development environment was Ubunutu, image file
-	
-	libre-computer-aml-s905x-cc-ubuntu-bionic-mate-mali-4.19.55+-2019-06-24.img 
+        
+        libre-computer-aml-s905x-cc-ubuntu-bionic-mate-mali-4.19.55+-2019-06-24.img 
 
    In order the run the resulting executable the 32 bit libs must
    be added to the system.  The following commands accomplish this.
 
-	sudo dpkg --add-architecture armhf
-	sudo apt-get update
-	sudo apt-get install libc6:armhf libstdc++6:armhf
+        sudo dpkg --add-architecture armhf
+        sudo apt-get update
+        sudo apt-get install libc6:armhf libstdc++6:armhf
 
 *****************************************************************/
 
@@ -65,10 +65,10 @@ typedef struct poly1305_struct
     unsigned finished;
 } Poly1305;
 
-#define WOLFSSL_ARMASM		1
+#define WOLFSSL_ARMASM           1
 /* leave __aarch64__ undefined */
-//#define WOLFSSL_ARMASM_NO_NEON  1
-#define POLY1305_VERBOSE 	1
+#define POLY1305_VERBOSE         1
+
 #else
 
 #ifdef WOLFSSL_ARMASM
@@ -96,1231 +96,1098 @@ typedef struct poly1305_struct
 
 
 /**********************************************************
-  armv8_32_poly1305_blocks	This routine implements the 
-			poly1305 algorithm.  The processing
-			of the 16 byte pieces of the 
-			message is implemented in assembly.
-			Care was taken in implementing the
-			assembly to optimize speed by 
-			minimizing memory references as
-			well as minimizing instructions.
-			The poly1305 algorithm is implemented
-			by using multiple 26 bit values 
-			to represent the larger 16 byte and 
-			17 byte numbers.  This is control
-			register overflow during the 
-			multiplications and subsequent 
-			additions.  For more information
-			reference the article NEON Cryto
-			by Daniel Berstein and Peter
-			Schwabe.
-  ctx			poly1305 structure containing the r and
-		 	h values broke into 26 bit pieces.
-			The result of this routine is returned
-			int the h array of 26 bit values.
-  msgData		Message data to run the algorithm 
-			against.
-  keyData		256 bit key that is broken down 
-			into the r and s subcomponents.
+  armv8_32_poly1305_blocks        This routine implements the 
+                        poly1305 algorithm.  The processing
+                        of the 16 byte pieces of the 
+                        message is implemented in assembly.
+                        Care was taken in implementing the
+                        assembly to optimize speed by 
+                        minimizing memory references as
+                        well as minimizing instructions.
+                        The poly1305 algorithm is implemented
+                        by using multiple 26 bit values 
+                        to represent the larger 16 byte and 
+                        17 byte numbers.  Breaking the 
+                        larger numbers down into 26 bit 
+                        pieces means that math operations will
+                        not overflow the 32 bit registers.
+                        For more information reference the article 
+                        NEON Cryto by Daniel Berstein and Peter
+                        Schwabe.
+
+  ctx                   poly1305 structure containing the r and
+                        h values broke into 26 bit pieces.
+                        The result of this routine is returned
+                        int the h array of 26 bit values.
+  msgData               Message data to run the algorithm 
+                        against.
+  keyData               256 bit key that is broken down 
+                        into the r and s subcomponents.
 **********************************************************/
 /* variable assembly code creates on stack */
 
-#define BYTES_SP_OFF		20
-#define HIBIT_LOCAL_SP_OFF	24
-#define TEST1_SP_OFF		28
+#define BYTES_SP_OFF              20
+#define HIBIT_LOCAL_SP_OFF        24
+
 void armv8_32_poly1305_blocks(Poly1305* ctx, 
-			const unsigned char *msgData,
-                     	size_t msgDataLen);
+                              const unsigned char *msgData,
+                              size_t msgDataLen);
 
 /* WOLFSSL_ARMASM_NO_NEON is used in armv8-32-sha512-asm.S */
 #ifdef WOLFSSL_ARMASM_NO_NEON2
 void armv8_32_poly1305_blocks(Poly1305* ctx, 
-			const unsigned char *msgData,
-                     	size_t msgDataLen)
+                              const unsigned char *msgData,
+                              size_t msgDataLen)
 {
-	/* these variables will be referenced via r7 in the assembly */
-	unsigned r[5], *r_ptrLocal, h[5], *h_ptrLocal;
-	unsigned msgDataOnStack = (unsigned)msgData;
-	unsigned msgDataLenOnStack = msgDataLen;
- 	unsigned hibitOnStack = (ctx->finished) ? 0 : ((unsigned) 1 << 24); /* 1 << 128 */
+        /* these variables will be referenced via r7 in the assembly */
+        unsigned r[5], *r_ptrLocal, h[5], *h_ptrLocal;
+        unsigned msgDataOnStack = (unsigned)msgData;
+        unsigned msgDataLenOnStack = msgDataLen;
+        unsigned hibitOnStack = (ctx->finished) ? 0 : ((unsigned) 1 << 24);
 
-	unsigned test1Array[10*2], test1OnStack;
-	test1OnStack = (unsigned )test1Array;
+        memcpy(r, ctx->r, 5 * sizeof(unsigned));
+        memcpy(h, ctx->h, 5 * sizeof(unsigned));
 
-	memcpy(r, ctx->r, 5 * sizeof(unsigned));
-	memcpy(h, ctx->h, 5 * sizeof(unsigned));
-
-	/* 32 bit pointer, this is necessary to pass the pointer value
+        /* 32 bit pointer, this is necessary to pass the pointer value
            into the assembly code */
-	r_ptrLocal = (unsigned *) r;
-	h_ptrLocal = (unsigned *) h;
+        r_ptrLocal = (unsigned *) r;
+        h_ptrLocal = (unsigned *) h;
 
 #ifdef POLY1305_VERBOSE
-	int i;
-	for (i=0;i<5;++i) printf("h%d %07X ", i, h[i]);
-	printf("\n");
+        int i;
+        for (i=0;i<5;++i) printf("h%d %07X ", i, h[i]);
+        printf("\n");
 
-	printf("armv8_32_poly1305_blocks() data len %d\n", msgDataLen);
+        printf("armv8_32_poly1305_blocks() data len %d\n", msgDataLen);
 #endif
 
-	__asm__ __volatile__ (
-		".align	8				\n\t"
-		
-		/* valid registers are r0..r12, sp, lr, pc, cpsr, fpscr */
-		
-		/* now load the stored h, this should all zero */
-		"LDR	r5, %[h_ptr]			\n\t"
-		"LDM	r5, { r6, r8, r9, r10, r11 }	\n\t"
-		/* r6 = h0  r8 = h1  r9 = h2  r10 = h3  r11 = h4 */
-	
-		/* in some cases, r7 is used to reference the local variables 
-		   on the stack; if -O2 is passed to gcc, the sp may used 
-	     	   used to reference local variables. */
-		"LDR 	r0, %[bytes]			\n\t"
-		"LDR 	r1, %[r_ptr]			\n\t"
-		"LDR	r2, %[hibit]			\n\t"
-		"LDR    r3, %[test1]			\n\t"
-		"LDR	r5, %[m]			\n\t"
+        __asm__ __volatile__ (
+                ".align        8                                \n\t"
+                
+                /* valid registers are r0..r12, sp, lr, pc, cpsr, fpscr */
+                
+                /* now load the stored h, this should all zero */
+                "LDR        r5, %[h_ptr]                        \n\t"
+                "LDM        r5, { r6, r8, r9, r10, r11 }        \n\t"
+                /* r6 = h0  r8 = h1  r9 = h2  r10 = h3  r11 = h4 */
+        
+                /* in some cases, r7 is used to reference the local variables 
+                   on the stack; if -O2 is passed to gcc, the sp may used 
+                        used to reference local variables. */
+                "LDR        r0, %[bytes]                        \n\t"
+                "LDR        r1, %[r_ptr]                        \n\t"
+                "LDR        r2, %[hibit]                        \n\t"
+                "LDR        r5, %[m]                            \n\t"
 
-		"PUSH	{ r7 }				\n\t"
-		"SUB	sp, #32				\n\t"
-		
-		/* -O2 gcc parameters means r7 is not used for local
+                "PUSH       { r7 }                              \n\t"
+                "SUB        sp, #28                             \n\t"
+                
+                /* -O2 gcc parameters means r7 is not used for local
                    variables, but sp is used for local variables */
-		/* free up r7 by moving variables referenced
-		   via r7 to recently allocated stack space */
-		"STR	r0, [sp, %[BYTES_STORE]]	\n\t"
-		"STR	r2, [sp, %[HIBIT_LOCAL]]	\n\t"
-		"STR	r3, [sp, %[TEST1_LOCAL]]	\n\t"	
-
-		"LDM	r1, { r0, r1, r2, r3, r4 }	\n\t"
-		"STM	sp, { r0, r1, r2, r3, r4 }	\n\t"
-
-		"MOV	r7, r5				\n\t"
-
-	"armv8_32_poly1305_loop:				\n\t"
-
-		/* The poly1305 algorithm requires that a 01 byte 
-		   be placed after the last byte of the block. */ 		
-		
-		"LDR	r5, [sp, %[BYTES_STORE]]	\n\t"  // mem 1
-		"CMP	r5, #0				\n\t"
-		"BEQ	armv8_32_poly1305_done		\n\t"
-		"SUBS 	r5, r5, #16			\n\t"
-		
-		/* branch for least likely case, may help with pipelining */
-		/* ARMv8 uses predictive pipelining.  There is no way
-		   to specify in the instruction encoding the more likely
-		   case.  */
-		"BLT	armv8_32_poly1305_last_block	\n\t"  
-
-		/* this block is 16 bytes */
-		"STR	r5, [sp, %[BYTES_STORE]]	\n\t"  // mem 2
-
-		/* load next 16 byte block of message */		
-		"LDM	r7, { r0, r1, r2, r3 }		\n\t"  // mem 3
-		"ADD	r7, r7, #16			\n\t"
-
-		/* in RFC 7539, each block processed is prepended by
-  		   a byte of value 0x01.  In the wolfSSL implementation,
-		   the setting of this value is based on the value found
-		   in ctx->finish. To save a memory reference, this code
-		   could be replicated one version adding the byte, one
-		   version not. */
-
-		/* This is byte 16, past the 128 bits of w19:w18:w17:w16 
-		   Hence, update is done to h4. */  
-		"LDR	r5, [sp, %[HIBIT_LOCAL]]	\n\t"	// mem 4
-		"ADD	r11, r11, r5 			\n\t"
-			
-	"armv8_32_poly1305_done_01_byte_appended:	\n\t"
-
-		"mov	r5, #0x3FFFFFF			\n\t"
-
-		/* break data into 26 bit pieces. 
-		   Bit offsets are 0, 26, 52, 78 and 104 */
-		   
-		/* h0 += r0 & 0x3FFFFFF; */
-		"AND	r12, r0, r5			\n\t"
-		"ADD	r6, r6, r12			\n\t"
-		/* h1 += (r1:r0 >> 26) & 0x3FFFFFF */
-		"LSR	r12, r0, #26			\n\t"	/* 26 */
-		"ADD	r12, r12, r1, LSL #6		\n\t"
-		"AND 	r12, r12, r5			\n\t"
-		"ADD	r8, r8, r12			\n\t"
-		/* h2 += (r2:r1 >> 20) & 0x3FFFFFF */
-		"LSR	r12, r1, #20			\n\t"   /* 20+32 = 52 */
-		//"MOV    r12, #0 \n\t"
-		//"ADD	r12, r12, r2, LSL #12		\n\t"
-		"AND 	r12, r12, r5			\n\t"
-		"ADD	r9, r9, r12			\n\t"
-		/* h3 += (r3:r2 >> 14) & 0x3FFFFFF */
-		"LSR	r12, r2, #14			\n\t"	/* 14+32+32 = 78 */
-		"ADD	r12, r12, r3, LSL #18		\n\t"
-		"AND 	r12, r12, r5			\n\t"
-		"ADD	r10, r10, r12			\n\t"
-		/* h4 += r3 >> 8	           */
-		"ADD	r11, r11, r3, LSR #8		\n\t"	/* 8+32+32+32 = 104 */
-
-		/* pull in the 26 bit components of the r key */
-		"LDM	sp, { r0, r1, r2, r3, r4 } 	\n\t"	// mem 5
-		/* r0 = BED685  r1 = 3555502  r2 = 47C036  r3 = 1003949  r4 = 806D5 */		
-#if 0
-		"LDR 	r5, [sp, %[TEST1_LOCAL]]  \n\t"
-		"STR	r6, [r5]	\n\t"
-		"STR	r8, [r5, #4]	\n\t"
-		"STR	r9, [r5, #8]	\n\t"
-		"STR	r10, [r5, #12]	\n\t"
-		"STR	r11, [r5, #16]	\n\t"
-		"B      armv8_32_poly1305_done \n\t"
-#endif
-		
-		"MOV	r5, #5				\n\t"
-
-	"checkRegs:					\n\t"
-		/* d0 = h0 * r0 + h1 * 5*r4 + h2 * 5*r3 + h3 * 5*r2 + h4 * 5*r1 */
-		/* d1 = h0 * r1 + h1 * r0   + h2 * 5*r4 + h3 * 5*r3 + h4 * 5*r2 */
-		/* d2 = h0 * r2 + h1 * r1   + h2 * r0   + h3 * 5*r4 + h4 * 5*r3 */
-		/* d3 = h0 * r3 + h1 * r2   + h2 * r1   + h3 * r0   + h4 * 5*r4 */
-		/* d4 = h0 * r4 + h1 * r3   + h2 * r2   + h3 * r1   + h4 * r0   */
-
-		/*  r14 is the link register, r13 is the sp */
-		/*  r14:r12 = r6 * r0 + (r8 * r4 +  r9 * r3 +  r10 * r2 +  r11 * r1) * r5 */
-		/*  r14:r12 = r6 * r1 +  r8 * r0 + (r9 * r4 +  r10 * r3 +  r11 * r2) * r5 */
-		/*  r14:r12 = r6 * r2 +  r8 * r1 +  r9 * r0 + (r10 * r4 +  r11 * r3) * r5 */
-		/*  r14:r12 = r6 * r3 +  r8 * r2 +  r9 * r1 +  r10 * r0 + (r11 * r4) * r5 */
-		/*  r14:r12 = r6 * r4 +  r8 * r3 +  r9 * r2 +  r10 * r1 +  r11 * r0       */
+                /* free up r7 by moving variables referenced
+                   via r7 to recently allocated stack space */
+                "STR        r0, [sp, %[BYTES_STORE]]            \n\t"
+                "STR        r2, [sp, %[HIBIT_LOCAL]]            \n\t"
+
+                "LDM        r1, { r0, r1, r2, r3, r4 }          \n\t"
+                "STM        sp, { r0, r1, r2, r3, r4 }          \n\t"
+
+                "MOV        r7, r5                              \n\t"
+
+        "armv8_32_poly1305_loop:                                \n\t"
+
+                /* The poly1305 algorithm requires that a 01 byte 
+                   be placed after the last byte of the block. */                 
+                
+                "LDR        r5, [sp, %[BYTES_STORE]]            \n\t"  /* mem 1 */
+                "CMP        r5, #0                              \n\t"
+                "BEQ        armv8_32_poly1305_done              \n\t"
+                "SUBS       r5, r5, #16                         \n\t"
+                
+                /* branch for least likely case, may help with pipelining */
+                /* ARMv8 uses predictive pipelining.  There is no way
+                   to specify in the instruction encoding the more likely
+                   case.  */
+                "BLT        armv8_32_poly1305_last_block        \n\t"  
+
+                /* this block is 16 bytes */
+                "STR        r5, [sp, %[BYTES_STORE]]            \n\t"  /* mem 2 */
+
+                /* load next 16 byte block of message */                
+                "LDM        r7, { r0, r1, r2, r3 }              \n\t"  /* mem 3 */
+                "ADD        r7, r7, #16                         \n\t"
+
+                /* in RFC 7539, each block processed is prepended by
+                     a byte of value 0x01.  In the wolfSSL implementation,
+                   the setting of this value is based on the value found
+                   in ctx->finish. To save a memory reference, this code
+                   could be replicated one version adding the byte, one
+                   version not. */
+
+                /* This is byte 16, past the 128 bits of w19:w18:w17:w16 
+                   Hence, update is done to h4. */  
+                "LDR        r5, [sp, %[HIBIT_LOCAL]]            \n\t"  /* mem 4 */
+                "ADD        r11, r11, r5                        \n\t"
+                        
+        "armv8_32_poly1305_done_01_byte_appended:               \n\t"
+
+                "MOV        r5, #0x3FFFFFF                      \n\t"
+
+                /* break data into 26 bit pieces. 
+                   Bit offsets are 0, 26, 52, 78 and 104 */
+                   
+                /* h0 += r0 & 0x3FFFFFF; */
+                "AND        r12, r0, r5                         \n\t"
+                "ADD        r6, r6, r12                         \n\t"
+                /* h1 += (r1:r0 >> 26) & 0x3FFFFFF */
+                "LSR        r12, r0, #26                        \n\t"  /* 26 */
+                "ADD        r12, r12, r1, LSL #6                \n\t"
+                "AND        r12, r12, r5                        \n\t"
+                "ADD        r8, r8, r12                         \n\t"
+                /* h2 += (r2:r1 >> 20) & 0x3FFFFFF */
+                "LSR        r12, r1, #20                        \n\t"  /* 20+32 = 52 */
+                "ADD        r12, r12, r2, LSL #12               \n\t"
+                "AND        r12, r12, r5                        \n\t"
+                "ADD        r9, r9, r12                         \n\t"
+                /* h3 += (r3:r2 >> 14) & 0x3FFFFFF */
+                "LSR        r12, r2, #14                        \n\t"  /* 14+32+32 = 78 */
+                "ADD        r12, r12, r3, LSL #18               \n\t"
+                "AND        r12, r12, r5                        \n\t"
+                "ADD        r10, r10, r12                       \n\t"
+                /* h4 += r3 >> 8                   */
+                "ADD        r11, r11, r3, LSR #8                \n\t"  /* 8+32+32+32 = 104 */
+
+                /* pull in the 26 bit components of the r key */
+                "LDM        sp, { r0, r1, r2, r3, r4 }          \n\t"   /* mem 5 */
+                /* r0 = BED685  r1 = 3555502  r2 = 47C036  r3 = 1003949  r4 = 806D5 */
+                
+                "MOV        r5, #5                              \n\t"
+
+        "checkRegs:                                             \n\t"
+                /* d0 = h0 * r0 + h1 * 5*r4 + h2 * 5*r3 + h3 * 5*r2 + h4 * 5*r1 */
+                /* d1 = h0 * r1 + h1 * r0   + h2 * 5*r4 + h3 * 5*r3 + h4 * 5*r2 */
+                /* d2 = h0 * r2 + h1 * r1   + h2 * r0   + h3 * 5*r4 + h4 * 5*r3 */
+                /* d3 = h0 * r3 + h1 * r2   + h2 * r1   + h3 * r0   + h4 * 5*r4 */
+                /* d4 = h0 * r4 + h1 * r3   + h2 * r2   + h3 * r1   + h4 * r0   */
+
+                /*  r14 is the link register, r13 is the sp */
+                /*  r14:r12 = r6 * r0 + (r8 * r4 +  r9 * r3 +  r10 * r2 +  r11 * r1) * r5 */
+                /*  r14:r12 = r6 * r1 +  r8 * r0 + (r9 * r4 +  r10 * r3 +  r11 * r2) * r5 */
+                /*  r14:r12 = r6 * r2 +  r8 * r1 +  r9 * r0 + (r10 * r4 +  r11 * r3) * r5 */
+                /*  r14:r12 = r6 * r3 +  r8 * r2 +  r9 * r1 +  r10 * r0 + (r11 * r4) * r5 */
+                /*  r14:r12 = r6 * r4 +  r8 * r3 +  r9 * r2 +  r10 * r1 +  r11 * r0       */
+
+                /* d4 */
+                "UMULL      r12, r14, r6, r4                    \n\t"
+                "UMLAL      r12, r14, r8, r3                    \n\t"
+                "UMLAL      r12, r14, r9, r2                    \n\t"
+                "UMLAL      r12, r14, r10, r1                   \n\t"
+                "UMLAL      r12, r14, r11, r0                   \n\t"
+
+                "PUSH       { r12, r14 }                        \n\t"   /* mem 6 */
 
-		/* d4 */
-		"UMULL	r12, r14, r6, r4		\n\t"
-		"UMLAL 	r12, r14, r8, r3		\n\t"
-		"UMLAL 	r12, r14, r9, r2		\n\t"
-		"UMLAL 	r12, r14, r10, r1		\n\t"
-		"UMLAL 	r12, r14, r11, r0		\n\t"
+                /* 8F852 C3AB3DA1 */
 
-		"PUSH   { r12, r14 }			\n\t"	// mem 6
+                /* d3 */
+                "UMULL      r12, r14, r6, r3                    \n\t"
+                "UMLAL      r12, r14, r8, r2                    \n\t"
+                "UMLAL      r12, r14, r9, r1                    \n\t"
+                "UMLAL      r12, r14, r10, r0                   \n\t"
+                "MUL        r11, r11, r5                        \n\t"
+                "UMLAL      r12, r14, r11, r4                   \n\t"
 
-		/* 8F852 C3AB3DA1 */
+                "PUSH       { r12, r14 }                        \n\t"   /* mem 7 */
 
-		/* d3 */
-		"UMULL	r12, r14, r6, r3		\n\t"
-		"UMLAL 	r12, r14, r8, r2		\n\t"
-		"UMLAL 	r12, r14, r9, r1		\n\t"
-		"UMLAL 	r12, r14, r10, r0		\n\t"
-		"MUL	r11, r11, r5			\n\t"
-		"UMLAL 	r12, r14, r11, r4		\n\t"
+                /* C753B 56120E14 */
 
-		"PUSH   { r12, r14 }			\n\t"	// mem 7
+                /* d2 */
+                "UMULL      r12, r14, r6, r2                    \n\t"
+                "UMLAL      r12, r14, r8, r1                    \n\t"
+                "UMLAL      r12, r14, r9, r0                    \n\t"
+                "MUL        r10, r10, r5                        \n\t"
+                "UMLAL      r12, r14, r10, r4                   \n\t"
+                "UMLAL      r12, r14, r11, r3                   \n\t"
 
-		/* C753B 56120E14 */
+                "PUSH       { r12, r14 }                        \n\t"   /* mem 8 */
 
-		/* d2 */
-		"UMULL	r12, r14, r6, r2		\n\t"
-		"UMLAL 	r12, r14, r8, r1		\n\t"
-		"UMLAL 	r12, r14, r9, r0		\n\t"
-		"MUL	r10, r10, r5			\n\t"
-		"UMLAL 	r12, r14, r10, r4		\n\t"
-		"UMLAL 	r12, r14, r11, r3		\n\t"
+                /* 10019D F79AAF81 */
 
-		"PUSH   { r12, r14 }			\n\t"	// mem 8
+                /* d1 */
+                "UMULL      r12, r14, r6, r1                    \n\t"
+                "UMLAL      r12, r14, r8, r0                    \n\t"
+                "MUL        r9, r9, r5                          \n\t"
+                "UMLAL      r12, r14, r9, r4                    \n\t"
+                "UMLAL      r12, r14, r10, r3                   \n\t"
+                "UMLAL      r12, r14, r11, r2                   \n\t"
 
-		/* 10019D F79AAF81 */
+                "PUSH       { r12, r14 }                        \n\t"   /* mem 9 */
 
-		/* d1 */
-		"UMULL	r12, r14, r6, r1		\n\t"
-		"UMLAL 	r12, r14, r8, r0		\n\t"
-		"MUL	r9, r9, r5			\n\t"
-		"UMLAL 	r12, r14, r9, r4		\n\t"
-		"UMLAL 	r12, r14, r10, r3		\n\t"
-		"UMLAL 	r12, r14, r11, r2		\n\t"
+                /* D3993 E9038575 */
 
-		"PUSH   { r12, r14 }			\n\t"	// mem 9
+                /* d0 */
+                "UMULL      r12, r14, r6, r0                    \n\t"
+                "MUL        r8, r8, r5                          \n\t"
+                "UMLAL      r12, r14, r8, r4                    \n\t"
+                "UMLAL      r12, r14, r9, r3                    \n\t"
+                "UMLAL      r12, r14, r10, r2                   \n\t"
+                "UMLAL      r12, r14, r11, r1                   \n\t"
 
-		/* D3993 E9038575 */
+                /* 29DD73 07661C87 */
 
-		/* d0 */
-		"UMULL	r12, r14, r6, r0		\n\t"
-		"MUL	r8, r8, r5			\n\t"
-		"UMLAL 	r12, r14, r8, r4		\n\t"
-		"UMLAL 	r12, r14, r9, r3		\n\t"
-		"UMLAL 	r12, r14, r10, r2		\n\t"
-		"UMLAL 	r12, r14, r11, r1		\n\t"
 
-		/* 29DD73 07661C87 */
+                /* registers r6, r8, r9, r10, r11 must be 
+                   populated with above results after accounting 
+                   for overflow past 26 bit. */
 
+                /* doing d0 --> d1 --> d2 --> d3 --> d4 --> d1 -->d2 */
 
+                "MOV        r5, #0x3FFFFFF                      \n\t"
+                "AND        r6, r12, r5                         \n\t"   /* d0 */
 
-		/* registers r6, r8, r9, r10, r11 must be 
-		   populated with above results after accounting 
-		   for overflow past 26 bit. */
+                /* d0 overflow to d1 */
+                "POP        { r0, r1, r2, r3, r4, r9, r10, r11 } \n\t"  /* mem 10 */
 
-		/* doing d0 --> d1 --> d2 --> d3 --> d4 --> d1 -->d2 */
+                "ADDS       r0, r0, r12, LSR #26                \n\t"
+                "ADC        r1, r1, #0                          \n\t"
+                "ADDS       r0, r0, r14, LSL #6                 \n\t"
+                "ADC        r1, r1, #0                          \n\t"
 
-		"MOV	r5, #0x3FFFFFF			\n\t"
-		"AND	r6, r12, r5			\n\t"	/* d0 */
+                "AND        r8, r0, r5                          \n\t"   /* d1 */
 
-		/* d0 overflow to d1 */
-		"POP	{ r0, r1, r2, r3, r4, r9, r10, r11 }	\n\t"	// mem 10
+                /* d1 overflow to d2 */
 
-		"LDR 	r5, [sp, %[TEST1_LOCAL]]  \n\t"
-		"STR	r0, [r5]	\n\t"
-		"STR	r1, [r5, #4]	\n\t"
-		"STR	r2, [r5, #8]	\n\t"
-		"STR	r3, [r5, #12]	\n\t"
-		"STR	r4, [r5, #16]	\n\t"
-		"B      armv8_32_poly1305_done \n\t"
+                "ADDS       r2, r2, r0, LSR #26                 \n\t"
+                "ADC        r3, r3, #0                          \n\t"
+                "ADDS       r2, r2, r1, LSL #6                  \n\t"
+                "ADC        r3, r3, #0                          \n\t"
 
-		"ADDS	r0, r0, r12, LSR #26		\n\t"
-		"ADC	r1, r1, #0			\n\t"
-		"ADDS	r0, r0, r14, LSL #6		\n\t"
-		"ADC	r1, r1, #0			\n\t"
+                "MOV        r0, r9                              \n\t"
 
-		"AND	r8, r0, r5			\n\t"   /* d1 */
+                "AND        r9, r2, r5                          \n\t"   /* d2 */
 
-		/* d1 overflow to d2 */
+                /* d2 overflow to d3 */
 
-		"ADDS	r2, r2, r0, LSR #26		\n\t"
-		"ADC	r3, r3, #0			\n\t"
-		"ADDS	r2, r2, r1, LSL #6		\n\t"
-		"ADC	r3, r3, #0			\n\t"
+                "ADDS       r4, r4, r2, LSR #26                 \n\t"
+                "ADC        r0, r0, #0                          \n\t"
+                "ADDS       r4, r4, r3, LSL #6                  \n\t"
+                "ADC        r0, r0, #0                          \n\t"
 
-		"MOV    r0, r9				\n\t"
+                /* d3 overflow to d4 */
 
-		"AND	r9, r2, r5			\n\t"	/* d2 */
+                "ADDS       r10, r10, r4, LSR #26               \n\t"
+                "ADC        r11, r11, #0                        \n\t"
+                "ADDS       r10, r10, r0, LSL #6                \n\t"
+                "ADC        r11, r11, #0                        \n\t"
 
-		/* d2 overflow to d3 */
+                /* d4 overflow to d0, must be multiplied by 5 */        
 
-		"ADDS	r4, r4, r2, LSR #26		\n\t"
-		"ADC	r0, r0, #0			\n\t"
-		"ADDS	r4, r4, r3, LSL #6		\n\t"
-		"ADC	r0, r0, #0			\n\t"
+                "LSR        r0, r10, #26                        \n\t"
+                "ADD        r0, r0, r11, LSL #6                 \n\t"
+                "MOV        r1, #5                              \n\t"        
+                "MUL        r0, r0, r1                          \n\t"
+                "ADD        r6, r6, r0                          \n\t"
 
-		/* d3 overflow to d4 */
+                "AND        r11, r10, r5                        \n\t"   /* d4 */
 
-		"ADDS	r10, r10, r4, LSR #26		\n\t"
-		"ADC	r11, r11, #0			\n\t"
-		"ADDS	r10, r10, r0, LSL #6		\n\t"
-		"ADC	r11, r11, #0			\n\t"
+                "AND        r10, r4, r5                         \n\t"   /* d3 */
 
-		/* d4 overflow to d0, must be multiplied by 5 */	
+                /* d0 overflow to d1 */
 
-		"LSR	r0, r10, #26			\n\t"
-		"ADD	r0, r0, r11, LSL #6		\n\t"
-		"MOV	r1, #5				\n\t"	
-		"MUL	r0, r0, r1			\n\t"
-		"ADD	r6, r6, r0			\n\t"
+                "ADD        r8, r8, r6, LSR #26                 \n\t"   /* d1 done */
 
-		"AND	r11, r10, r5			\n\t"	/* d4 */
+                "AND        r6, r6, r5                          \n\t"   /* d0 done */        
 
-		"AND	r10, r4, r5			\n\t"	/* d3 */
+                "B          armv8_32_poly1305_loop              \n\t"
+        
+        "armv8_32_poly1305_last_block:                          \n\t"
 
-		/* d0 overflow to d1 */
+                /* This is the last block of the message
+                   and the block is less than 16 bytes */
+                "MOV        r0, #0                              \n\t"
+                "STR        r0, [sp, %[BYTES_STORE]]            \n\t"
+        
+                "LDR        r0, [sp, %[HIBIT_LOCAL]]            \n\t"
 
-		"ADD	r8, r8, r6, LSR #26		\n\t"	/* d1 done */
+                /* Make sure the upper bytes of the 
+                   32 bit pieces are set to zero. 
+                   Set the byte past the last message
+                   data byte to 01. */
 
-		"AND	r6, r6, r5			\n\t"	/* d0 done */	
+                "PUSH       { r4, r6, r8 }                      \n\t"        
 
-		"B	armv8_32_poly1305_loop		\n\t"
-	
-	"armv8_32_poly1305_last_block:			\n\t"
+                "MOV        r1,  #0                             \n\t"
+                "MOV        r2,  #0                             \n\t"
+                "MOV        r3,  #0                             \n\t"
+                "MOV        r4,  #0xFFFFFFFF                    \n\t"
+                "LSR        r0, r0, #24                         \n\t"
+                "MOV        r6,  r0                             \n\t"
 
-		/* This is the last block of the message
-		   and the block is less than 16 bytes */
-		"MOV 	r0, #0				\n\t"
-		"STR	r0, [sp, %[BYTES_STORE]]	\n\t"
-	
-		"LDR	r0, [sp, %[HIBIT_LOCAL]]	\n\t"
-
-		/* Make sure the upper bytes of the 
-		   32 bit pieces are set to zero. 
-		   Set the byte past the last message
-		   data byte to 01. */
-
-		"PUSH	{ r4, r6, r8 } 			\n\t"	
-
-		"MOV    r1,  #0				\n\t"
-		"MOV	r2,  #0				\n\t"
-		"MOV	r3,  #0				\n\t"
-		"MOV	r4,  #0xFFFFFFFF		\n\t"
-		"LSR	r0, r0, #24			\n\t"
-		"MOV	r6,  r0				\n\t"
-
-		/* always going to load at least one */		
-		"LDR	r0, [r7]			\n\t"
-
-		/* byte offset to bit offset */ 
-		"ADD	r5, r5, #16			\n\t"
-		"LSL	r5, r5, #3			\n\t"			
-
-		/* which block */
-		"CMP	r5, #32				\n\t"
-		"BGE	not_word_0			\n\t"
-
-		/* case word 0 */
-	"case0:"
-		"LSL	r8, r4, r5			\n\t"
-		"BIC  	r0, r0, r8			\n\t"
-		"LSL	r8, r6, r5			\n\t"
-		"ADD	r0, r0, r8			\n\t"
-		"B	last_block_done			\n\t"
-
-	"not_word_0:	 				\n\t"
-		"LDR	r1, [r7, #4]			\n\t"
-		
-		"SUB	r5, r5, #32			\n\t"
-		"CMP	r5, #32				\n\t"
-		"BGE	not_word_1			\n\t"
-
-		"LSL	r8, r4, r5			\n\t"
-		"BIC  	r1, r1, r8			\n\t"
-		"LSL	r8, r6, r5			\n\t"
-		"ADD	r1, r1, r8			\n\t"		
-		"B	last_block_done			\n\t"
-
-	"not_word_1:					\n\t"
-		"LDR	r2, [r7, #8]			\n\t"
-
-		"SUB	r5, r5, #32			\n\t"
-		"CMP	r5, #32				\n\t"
-		"BGE	not_word_2			\n\t"
-
-		"LSL	r8, r4, r5			\n\t"
-		"BIC  	r2, r2, r8			\n\t"
-		"LSL	r8, r6, r5			\n\t"
-		"ADD	r2, r2, r8			\n\t"		
-		"B	last_block_done			\n\t"
-
-	"not_word_2:					\n\t"
-		"LDR	r3, [r7, #0xC]			\n\t"
-
-		"SUB	r5, r5, #32			\n\t"
-
-		"LSL	r8, r4, r5			\n\t"
-		"BIC  	r3, r3, r8			\n\t"
-		"LSL	r8, r6, r5			\n\t"
-		"ADD	r3, r3, r8			\n\t"	
-
-	"last_block_done:				\n\t"
-
-		"POP	{ r4, r6, r8 } 			\n\t"	
-	
-		"b 	armv8_32_poly1305_done_01_byte_appended \n\t"
-	
-		".align 2 \n\t"
-	"armv8_32_poly1305_done:				\n\t"
-
-		"ADD	sp, #32				\n\t"
-		"POP	{ r7 }				\n\t"
-
-		/* store final result */
-		"LDR	r0, %[h_ptr]			\n\t"
-		"STM	r0, { r6, r8, r9, r10, r11 } 	\n\t"
-		
-		: [m] 		  "+m" (msgDataOnStack),	/* input */
-		  [r_ptr]  	  "+m" (r_ptrLocal),		/* input */
-		  [h_ptr]  	  "+m" (h_ptrLocal),		/* input, output */
-		  [bytes]  	  "+m" (msgDataLenOnStack),	/* input */
-		  [test1]	  "+m" (test1OnStack),
-		  [hibit]	  "+m" (hibitOnStack)		/* input */
-		  
-		: [BYTES_STORE]    "I" (BYTES_SP_OFF),
-		  [HIBIT_LOCAL]    "I" (HIBIT_LOCAL_SP_OFF),
-		  [TEST1_LOCAL]	   "I" (TEST1_SP_OFF)
-		: "memory", "cc", 
-			"r0", "r1", "r2", "r3", "r4", "r5", "r6", "r8", "r9", "r10",
-			"r11", "r12", "lr"
-	);
-
-	memcpy(ctx->r, r, 5 * sizeof(unsigned));
-	memcpy(ctx->h, h, 5 * sizeof(unsigned));
+                /* always going to load at least one */                
+                "LDR        r0, [r7]                            \n\t"
+
+                /* byte offset to bit offset */ 
+                "ADD        r5, r5, #16                         \n\t"
+                "LSL        r5, r5, #3                          \n\t"                        
+
+                /* which block */
+                "CMP        r5, #32                             \n\t"
+                "BGE        not_word_0                          \n\t"
+
+                /* case word 0 */
+        "case0:"
+                "LSL        r8, r4, r5                          \n\t"
+                "BIC        r0, r0, r8                          \n\t"
+                "LSL        r8, r6, r5                          \n\t"
+                "ADD        r0, r0, r8                          \n\t"
+                "B          last_block_done                     \n\t"
+
+        "not_word_0:                                            \n\t"
+                "LDR        r1, [r7, #4]                        \n\t"
+                
+                "SUB        r5, r5, #32                         \n\t"
+                "CMP        r5, #32                             \n\t"
+                "BGE        not_word_1                          \n\t"
+
+                "LSL        r8, r4, r5                          \n\t"
+                "BIC        r1, r1, r8                          \n\t"
+                "LSL        r8, r6, r5                          \n\t"
+                "ADD        r1, r1, r8                          \n\t"                
+                "B          last_block_done                     \n\t"
+
+        "not_word_1:                                            \n\t"
+                "LDR        r2, [r7, #8]                        \n\t"
+
+                "SUB        r5, r5, #32                         \n\t"
+                "CMP        r5, #32                             \n\t"
+                "BGE        not_word_2                          \n\t"
+
+                "LSL        r8, r4, r5                          \n\t"
+                "BIC        r2, r2, r8                          \n\t"
+                "LSL        r8, r6, r5                          \n\t"
+                "ADD        r2, r2, r8                          \n\t"                
+                "B          last_block_done                     \n\t"
+
+        "not_word_2:                                            \n\t"
+                "LDR        r3, [r7, #0xC]                      \n\t"
+
+                "SUB        r5, r5, #32                         \n\t"
+
+                "LSL        r8, r4, r5                          \n\t"
+                "BIC        r3, r3, r8                          \n\t"
+                "LSL        r8, r6, r5                          \n\t"
+                "ADD        r3, r3, r8                          \n\t"        
+
+        "last_block_done:                                       \n\t"
+
+                "POP        { r4, r6, r8 }                      \n\t"        
+        
+                "b          armv8_32_poly1305_done_01_byte_appended \n\t"
+        
+        "armv8_32_poly1305_done:                                \n\t"
+
+                "ADD        sp, #28                             \n\t"
+                "POP        { r7 }                              \n\t"
+
+                /* store final result */
+                "LDR        r0, %[h_ptr]                        \n\t"
+                "STM        r0, { r6, r8, r9, r10, r11 }        \n\t"
+                
+                : [m]              "+m" (msgDataOnStack),        /* input */
+                  [r_ptr]          "+m" (r_ptrLocal),            /* input */
+                  [h_ptr]          "+m" (h_ptrLocal),            /* input, output */
+                  [bytes]          "+m" (msgDataLenOnStack),     /* input */
+                  [hibit]          "+m" (hibitOnStack)           /* input */
+                  
+                : [BYTES_STORE]    "I" (BYTES_SP_OFF),
+                  [HIBIT_LOCAL]    "I" (HIBIT_LOCAL_SP_OFF)
+                : "memory", "cc", 
+                        "r0", "r1", "r2", "r3", "r4", "r5", "r6", "r8", "r9", "r10",
+                        "r11", "r12", "lr"
+        );
+
+        memcpy(ctx->r, r, 5 * sizeof(unsigned));
+        memcpy(ctx->h, h, 5 * sizeof(unsigned));
 
 #ifdef POLY1305_VERBOSE
-	for (i=0;i<5;++i) printf("%d %07X ", i, test1Array[i]);
-	printf("\n");
+        for (i=0;i<5;++i) printf("h%d %07X ", i, ctx->h[i]);
+        printf("\n");
 
-	for (i=0;i<5;++i) printf("h%d %07X ", i, ctx->h[i]);
-	printf("\n");
-
-	printf("armv8_32_poly1305_blocks() leaving\n");
+        printf("armv8_32_poly1305_blocks() leaving\n");
 #endif
 
 }
+
 #else
 
-void print16(const char *startText, unsigned char *data);
-void multiplyBasic(unsigned char *finalResult, unsigned char *val1, 
-	unsigned char *val2);
+/**********************************************************
+  armv8_32_poly1305_blocks        This routine implements the 
+                        poly1305 algorithm.  The processing
+                        of the 16 byte pieces of the 
+                        message is implemented in assembly.
+                        Care was taken in implementing the
+                        assembly to optimize speed by 
+                        minimizing memory references as
+                        well as minimizing instructions.
+                        The poly1305 algorithm is implemented
+                        by using multiple 26 bit values 
+                        to represent the larger 16 byte and 
+                        17 byte numbers.  Breaking the 
+                        larger numbers down into 26 bit 
+                        pieces means that math operations will
+                        not overflow the 32 bit registers.
+                        For more information reference the article 
+                        NEON Cryto by Daniel Berstein and Peter
+                        Schwabe.
+                        
+                        This version of the algorithm uses 
+                        NEON s registers to temporarily store
+                        values so that the stack does not need
+                        to be used.
 
+  ctx                   poly1305 structure containing the r and
+                        h values broke into 26 bit pieces.
+                        The result of this routine is returned
+                        int the h array of 26 bit values.
+  msgData                Message data to run the algorithm 
+                        against.
+  keyData               256 bit key that is broken down 
+                        into the r and s subcomponents.
+**********************************************************/
 void armv8_32_poly1305_blocks(Poly1305* ctx, 
-			const unsigned char *msgData,
-                     	size_t msgDataLen)
+                        const unsigned char *msgData,
+                             size_t msgDataLen)
 {
-	unsigned long long *r_ptrLocal, *h_ptrLocal;
-	unsigned msgDataOnStack = (unsigned)msgData;
-	unsigned msgDataLenOnStack = msgDataLen;
- 	unsigned hibitOnStack = (ctx->finished) ? 0 : ((unsigned) 1 << 24); /* 1 << 128 */
-	unsigned test1Array[5*2], *test1OnStack = test1Array;
-	unsigned long long r_44bitPieces[3], h_44bitPieces[3], result;
+        /* these variables will be referenced via r7 in the assembly */
+        unsigned r[5], *r_ptrLocal, h[5], *h_ptrLocal;
+        unsigned msgDataOnStack = (unsigned)msgData;
+        unsigned msgDataLenOnStack = msgDataLen;
+        unsigned hibitOnStack = (ctx->finished) ? 0 : ((unsigned) 1 << 24);
 
-	unsigned char bit128Result[32];
+        memcpy(r, ctx->r, 5 * sizeof(unsigned));
+        memcpy(h, ctx->h, 5 * sizeof(unsigned));
 
-	r_44bitPieces[0] = ((unsigned long long)ctx->r[0] 
-			+ ((unsigned long long)ctx->r[1] << 26))
-			& 0xFFFFFFFFFFF;
-	r_44bitPieces[1] = (((unsigned long long)ctx->r[1] >> 18) 
-			+ ((unsigned long long)ctx->r[2] << 8)
-			+ ((unsigned long long)ctx->r[3] << 34))
-			& 0xFFFFFFFFFFF;
-	r_44bitPieces[2] = (((unsigned long long)ctx->r[3] >> 10) 
-			+ ((unsigned long long)ctx->r[4] << 16))
-			& 0xFFFFFFFFFFF;
-
-	printf("44 bit r0 values \n");
-	printf(" r0  %llx\n", r_44bitPieces[0]);
-	printf(" r1  %llx\n", r_44bitPieces[1]);
-	printf(" r2  %llx\n", r_44bitPieces[2]);
-	printf(" r0 * r1 = 1B657B439E69174EC88AA9\n");
-	
-	multiplyBasic(bit128Result, (unsigned char*)&r_44bitPieces[0],
-		(unsigned char*)&r_44bitPieces[1]);
-	print16("0 * 1 = ", (unsigned char*) bit128Result);
-
-
-	multiplyBasic(bit128Result, (unsigned char*)&r_44bitPieces[1],
-		(unsigned char*)&r_44bitPieces[2]);
-	print16("1 * 2 = ", (unsigned char*) bit128Result);
-
-
-	printf("lower result %llx\n", r_44bitPieces[0] * r_44bitPieces[1] );
-	printf("lower result %llx\n", r_44bitPieces[1] * r_44bitPieces[2]);
-
-
-	h_44bitPieces[0] = ((unsigned long long)ctx->h[0] 
-			+ ((unsigned long long)ctx->h[1] << 26))
-			& 0xFFFFFFFFFFF;
-	h_44bitPieces[1] = (((unsigned long long)ctx->h[1] >> 18) 
-			+ ((unsigned long long)ctx->h[2] << 8)
-			+ ((unsigned long long)ctx->h[3] << 34))
-			& 0xFFFFFFFFFFF;
-	h_44bitPieces[2] = (((unsigned long long)ctx->h[3] >> 10) 
-			+ ((unsigned long long)ctx->h[4] << 16))
-			& 0xFFFFFFFFFFF;
-
-	/* 32 bit pointer, this is necessary to pass the pointer value
+        /* 32 bit pointer, this is necessary to pass the pointer value
            into the assembly code */
-	r_ptrLocal = (unsigned long long *) r_44bitPieces;
-	h_ptrLocal = (unsigned long long *) h_44bitPieces;
-
-
+        r_ptrLocal = (unsigned *) r;
+        h_ptrLocal = (unsigned *) h;
 
 #ifdef POLY1305_VERBOSE
-	int i;
-	for (i=0;i<5;++i) printf("r%d %07X ", i, ctx->r[i]);
-	printf("\n");
+        int i;
+        for (i=0;i<5;++i) printf("h%d %07X ", i, h[i]);
+        printf("\n");
 
-	for (i=0;i<5;++i) printf("h%d %07X ", i, ctx->h[i]);
-	printf("\n");
-
-	printf("armv8_32_poly1305_blocks() data len %d\n", msgDataLen);
+        printf("armv8_32_poly1305_blocks() data len %d\n", msgDataLen);
 #endif
 
+        __asm__ __volatile__ (
+                ".align     8                                   \n\t"
+                
+                /* valid registers are r0..r12, sp, lr, pc, cpsr, fpscr */
+                
+                /* now load the stored h, this should all zero */
+                "LDR        r5, %[h_ptr]                        \n\t"
+                "LDM        r5, { r6, r8, r9, r10, r11 }        \n\t"
+                /* r6 = h0  r8 = h1  r9 = h2  r10 = h3  r11 = h4 */
+        
+                /* in some cases, r7 is used to reference the local variables 
+                   on the stack; if -O2 is passed to gcc, the sp may used 
+                        used to reference local variables. */
+                "LDR        r0, %[hibit]                        \n\t"
+                "LDR        r1, %[bytes]                        \n\t"
+                "LDR        r2, %[r_ptr]                        \n\t"
+
+                "VMOV       s2, r0                              \n\t"
+                "VMOV       s4, r1                              \n\t"
+
+                "LDM        r2, { r0, r1, r2, r3, r4 }          \n\t"
+                "VMOV       s6, r0                              \n\t"
+                "VMOV       s7, r1                              \n\t"
+                "VMOV       s8, r2                              \n\t"
+                "VMOV       s9, r3                              \n\t"
+                "VMOV       s10, r4                             \n\t"
+
+                "LDR        r5, %[m]                            \n\t"
+                "PUSH       { r7 }                              \n\t"
+                "MOV        r7, r5                              \n\t"
+
+                /* s2 - hibit
+                   s4 - bytes
+                   s6, s7, s8, s9, s10 - r in 26 bit pieces */
+
+        "armv8_32_poly1305_loop:                                \n\t"
+
+                /* The poly1305 algorithm requires that a 01 byte 
+                   be placed after the last byte of the block. */                 
+                
+                "VMOV       r5, s4                              \n\t"
+                "CMP        r5, #0                              \n\t"
+                "BEQ        armv8_32_poly1305_done              \n\t"
+                "SUBS       r5, r5, #16                         \n\t"
+                
+                /* branch for least likely case, may help with pipelining */
+                /* ARMv8 uses predictive pipelining.  There is no way
+                   to specify in the instruction encoding the more likely
+                   case.  */
+                "BLT        armv8_32_poly1305_last_block        \n\t"  
+
+                /* this block is 16 bytes */
+                "VMOV       s4, r5                              \n\t"
+
+                /* load next 16 byte block of message */                
+                "LDM        r7, { r0, r1, r2, r3 }              \n\t"   /* mem 1 */
+                "ADD        r7, r7, #16                         \n\t"
+
+                /* in RFC 7539, each block processed is prepended by
+                     a byte of value 0x01.  In the wolfSSL implementation,
+                   the setting of this value is based on the value found
+                   in ctx->finish. To save a memory reference, this code
+                   could be replicated one version adding the byte, one
+                   version not. */
+
+                /* This is byte 16, past the 128 bits of w19:w18:w17:w16 
+                   Hence, update is done to h4. */  
+                /* add in hibit */
+                "VMOV       r5, s2                              \n\t"
+                "ADD        r11, r11, r5                        \n\t"
+                        
+        "armv8_32_poly1305_done_01_byte_appended:               \n\t"
+
+                "mov        r5, #0x3FFFFFF                      \n\t"
+
+                /* break data into 26 bit pieces. 
+                   Bit offsets are 0, 26, 52, 78 and 104 */
+                   
+                /* h0 += r0 & 0x3FFFFFF; */
+                "AND        r12, r0, r5                         \n\t"
+                "ADD        r6, r6, r12                         \n\t"
+                /* h1 += (r1:r0 >> 26) & 0x3FFFFFF */
+                "LSR        r12, r0, #26                        \n\t"   /* 26 */
+                "ADD        r12, r12, r1, LSL #6                \n\t"
+                "AND        r12, r12, r5                        \n\t"
+                "ADD        r8, r8, r12                         \n\t"
+                /* h2 += (r2:r1 >> 20) & 0x3FFFFFF */         
+                "LSR        r12, r1, #20                        \n\t"   /* 20+32 = 52 */
+                "ADD        r12, r12, r2, LSL #12               \n\t"
+                "AND        r12, r12, r5                        \n\t"
+                "ADD        r9, r9, r12                         \n\t"
+                /* h3 += (r3:r2 >> 14) & 0x3FFFFFF */
+                "LSR        r12, r2, #14                        \n\t"   /* 14+32+32 = 78 */
+                "ADD        r12, r12, r3, LSL #18               \n\t"
+                "AND        r12, r12, r5                        \n\t"
+                "ADD        r10, r10, r12                       \n\t"
+                /* h4 += r3 >> 8                   */
+                "ADD        r11, r11, r3, LSR #8                \n\t"   /* 8+32+32+32 = 104 */
+
+                /* pull in the 26 bit components of the r key */
+                "VMOV       r0, s6                              \n\t"
+                "VMOV       r1, s7                              \n\t"
+                "VMOV       r2, s8                              \n\t"
+                "VMOV       r3, s9                              \n\t"
+                "VMOV       r4, s10                             \n\t"
+
+                /* r0 = BED685  r1 = 3555502  r2 = 47C036  r3 = 1003949  r4 = 806D5 */
+                "MOV        r5, #5                              \n\t"
+
+        "checkRegs:                                             \n\t"
+                /* d0 = h0 * r0 + h1 * 5*r4 + h2 * 5*r3 + h3 * 5*r2 + h4 * 5*r1 */
+                /* d1 = h0 * r1 + h1 * r0   + h2 * 5*r4 + h3 * 5*r3 + h4 * 5*r2 */
+                /* d2 = h0 * r2 + h1 * r1   + h2 * r0   + h3 * 5*r4 + h4 * 5*r3 */
+                /* d3 = h0 * r3 + h1 * r2   + h2 * r1   + h3 * r0   + h4 * 5*r4 */
+                /* d4 = h0 * r4 + h1 * r3   + h2 * r2   + h3 * r1   + h4 * r0   */
+
+                /*  r14 is the link register, r13 is the sp */
+                /*  r14:r12 = r6 * r0 + (r8 * r4 +  r9 * r3 +  r10 * r2 +  r11 * r1) * r5 */
+                /*  r14:r12 = r6 * r1 +  r8 * r0 + (r9 * r4 +  r10 * r3 +  r11 * r2) * r5 */
+                /*  r14:r12 = r6 * r2 +  r8 * r1 +  r9 * r0 + (r10 * r4 +  r11 * r3) * r5 */
+                /*  r14:r12 = r6 * r3 +  r8 * r2 +  r9 * r1 +  r10 * r0 + (r11 * r4) * r5 */
+                /*  r14:r12 = r6 * r4 +  r8 * r3 +  r9 * r2 +  r10 * r1 +  r11 * r0       */
 
-	__asm__ __volatile__ (
-		".align	8				\n\t"
-		
-		/* valid registers are d0..d31 */
-
-		"VMOV.i32	d30, #0xFFFFFFFFFFF		\n\t"
-		"VSHR.u64	d30, #32		 	\n\t"
-
-		/* load r values into d0..d4 */
-		"LDR		r0, %[r_ptr]			\n\t"
-		"VLDR		d0, [r0]			\n\t"
-		"VLDR		d1, [r0, #8]			\n\t"
-		"VLDR		d2, [r0, #16]			\n\t"
-
-		"VEOR		q11, q11 \n\t"
-		"VEOR		q12, q12 \n\t"
-		//"VMULL.u32	q11, d0, d1  \n\t"
-		//"VMLAL.u64	q11, d0, d1  \n\t"
-		"VMULL.F64	q11, d0, d1			\n\t"
-
-		"LDR		r6, %[test1]	\n\t"
-		"VSTR		d22, [r6, #0]	\n\t"
-		"VSTR		d23, [r6, #8]	\n\t"
-		"VSTR		d24, [r6, #16]	\n\t"
-		"VSTR		d25, [r6, #24]	\n\t"
-		"VSTR		d23, [r6, #32]	\n\t"
-
-		"B 		armv8_32_poly1305_done		\n\t"
-
-
-		/* now create the times 5 values */
-		/* d3..d5 r values times 5 */
-		"VMOV.i32	d31, #5				\n\t"
-		"VSHR.u64	d30, #32		 	\n\t"
-
-		"VMUL.F64	d3, d0, d31			\n\t"
-		"VMUL.F64	d4, d1, d31			\n\t"
-		"VMUL.F64	d5, d2, d31			\n\t"
-
-		/* load h values into d10..d15 */
-		"LDR		r0, %[h_ptr]			\n\t"
-		//"VLDM 		r0, {d10, d12}			\n\t"
-		"VLDR		d10, [r0]			\n\t"
-		"VLDR		d12, [r0, #8]			\n\t"
-		"VLDR		d14, [r0, #16]			\n\t"
-		"VSHR.u64	d11, d10, #32			\n\t"
-		"VSHR.u64	d13, d12, #32			\n\t"		
-		"VAND.u64	d10, d10, d30			\n\t"
-		"VAND.u64	d12, d12, d30			\n\t"
-		"VAND.u64	d14, d14, d30			\n\t"
-		
-		"LDR		r1, %[m]			\n\t"
-		"LDR		r2, %[bytes]			\n\t"
-		"VLDR		d25, %[hibit]			\n\t"
-
-	"armv8_32_poly1305_loop:				\n\t"
-
-
-		/* The poly1305 algorithm requires that a 01 byte 
-		   be placed after the last byte of the block. */ 		
-
-		"CMP		r2, #0				\n\t"
-		"BEQ		armv8_32_poly1305_done		\n\t"
-		"SUBS 		r2, r2, #16			\n\t"
-	
-		/* branch for least likely case, may help with pipelining */
-		/* ARMv8 uses predictive pipelining.  There is no way
-		   to specify in the instruction encoding the more likely
-		   case.  */
-		"BLT		armv8_32_poly1305_last_block	\n\t"  
+                /* d4 */
+                "UMULL      r12, r14, r6, r4                    \n\t"
+                "UMLAL      r12, r14, r8, r3                    \n\t"
+                "UMLAL      r12, r14, r9, r2                    \n\t"
+                "UMLAL      r12, r14, r10, r1                   \n\t"
+                "UMLAL      r12, r14, r11, r0                   \n\t"
 
-		/* this block is 16 bytes */		
+                "VMOV       s12, s13, r12, r14                  \n\t"
 
-		/* load next 16 byte block of message */		
-		//"VLDM		r1, { d15, d16 }		\n\t"   
-		"VLDR		d15, [r1]			\n\t"
-		"VLDR		d16, [r1, #8]			\n\t"
-		"ADD		r1, r1, #16			\n\t"
+                /* 8F852 C3AB3DA1 */
 
-		/* in RFC 7539, each block processed is prepended by
-  		   a byte of value 0x01.  In the wolfSSL implementation,
-		   the setting of this value is based on the value found
-		   in ctx->finish. To save a memory reference, this code
-		   could be replicated one version adding the byte, one
-		   version not. */
+                /* d3 */
+                "UMULL      r12, r14, r6, r3                    \n\t"
+                "UMLAL      r12, r14, r8, r2                    \n\t"
+                "UMLAL      r12, r14, r9, r1                    \n\t"
+                "UMLAL      r12, r14, r10, r0                   \n\t"
+                "MUL        r11, r11, r5                        \n\t"
+                "UMLAL      r12, r14, r11, r4                   \n\t"
 
-		/* This is byte 16, past the 128 bits of 
-		   Hence, update is done to h4. */  
-	
-		"VADD.u64	d14, d14, d25 			\n\t"
+                "VMOV       s14, s15, r12, r14                  \n\t"
 
-	"armv8_32_poly1305_done_01_byte_appended:		\n\t"
+                /* C753B 56120E14 */
 
-		/* break data into 26 bit pieces. 
-		   Bit offsets are 0, 26, 52, 78 and 104 */
-	
-		/* h0 += d15 & 0x3FFFFFF; */
-		"VAND		d28, d15, d30			\n\t"
-		"VADD.u64	d10, d10, d28			\n\t"
-		/* h1 += (d15 >> 26) & 0x3FFFFFF */
-		"VSHR.u64	d28, d15, #26			\n\t"	/* 26 */
-		"VAND 		d28, d28, d30			\n\t"
-		"VADD.u64	d11, d11, d28			\n\t"
-		/* h2 += ((d15 >> 52) + (d16 << 12)) & 0x3FFFFFF */
-		"VSHL.u64	d28, d16, #12	 		\n\t"
-		"VSHR.u64	d27, d15, #52			\n\t"   /* 20+32 = 52 */
-		"VADD.u64	d28, d28, d27			\n\t"
-		"VAND 		d28, d28, d30			\n\t"
-		"VADD.u64	d12, d12, d28			\n\t"
-		/* h3 += (d16 >> 14) & 0x3FFFFFF */
-		"VSHR.u64	d28, d16, #14			\n\t"	/* 14+32+32 = 78 */
-		"VAND   	d28, d28, d30			\n\t"
-		"VADD.u64	d13, d13, d28			\n\t"
-		/* h4 += r3 >> 8	           */
-		"VSHR.u64	d28, d16, #40			\n\t"
-		"VADD.u64	d14, d14, d28			\n\t"	/* 8+32+32+32 = 104 */
+                /* d2 */
+                "UMULL      r12, r14, r6, r2                    \n\t"
+                "UMLAL      r12, r14, r8, r1                    \n\t"
+                "UMLAL      r12, r14, r9, r0                    \n\t"
+                "MUL        r10, r10, r5                        \n\t"
+                "UMLAL      r12, r14, r10, r4                   \n\t"
+                "UMLAL      r12, r14, r11, r3                   \n\t"
 
-	
+                "VMOV       s16, s17, r12, r14                  \n\t"
 
-	"checkRegs:						\n\t"
-		/*  d0 = h0 * r0 + h1 * 5*r2 + h2 * 5*r1  */
-		/*  d1 = h0 * r1 + h1 * r0   + h2 * 5*r2  */
-		/*  d2 = h0 * r2 + h1 * r1   + h2 * r0    */
+                /* 10019D F79AAF81 */
 
-	
-		/*  d15 = d10 * d0 +  d11 * d8 +  d12 * d7  */
-		/*  d16 = d10 * d1 +  d11 * d0 +  d12 * d8  */
-		/*  d17 = d10 * d2 +  d11 * d1 +  d12 * d0  */
+                /* d1 */
+                "UMULL      r12, r14, r6, r1                    \n\t"
+                "UMLAL      r12, r14, r8, r0                    \n\t"
+                "MUL        r9, r9, r5                          \n\t"
+                "UMLAL      r12, r14, r9, r4                    \n\t"
+                "UMLAL      r12, r14, r10, r3                   \n\t"
+                "UMLAL      r12, r14, r11, r2                   \n\t"
 
+                "VMOV       s18, s19, r12, r14                  \n\t"
 
-		"VMLAL.u32	q1, d0, d1  \n\t"
+                /* D3993 E9038575 */
 
-		
+                /* d0 */
+                "UMULL      r12, r14, r6, r0                    \n\t"
+                "MUL        r8, r8, r5                          \n\t"
+                "UMLAL      r12, r14, r8, r4                    \n\t"
+                "UMLAL      r12, r14, r9, r3                    \n\t"
+                "UMLAL      r12, r14, r10, r2                   \n\t"
+                "UMLAL      r12, r14, r11, r1                   \n\t"
 
+                /* 29DD73 07661C87 */
 
-		/* registers  contain the 
-		   incremental d results. */
+                /* registers r6, r8, r9, r10, r11 must be 
+                   populated with above results after accounting 
+                   for overflow past 26 bit. */
 
-		/* doing d0 --> d1 --> d2 -times 5-> d0 --> d1 --> d2 */
+                /* doing d0 --> d1 --> d2 --> d3 --> d4 --> d1 -->d2 */
 
-		"VAND.u64	d10, d15, d30			\n\t"	/* d0 */
+                "MOV        r5, #0x3FFFFFF                      \n\t"
+                "AND        r6, r12, r5                         \n\t"  /* d0 */
 
+                /* d0 overflow to d1 */
 
-		"VSHL.u64	d28, d15, #26			\n\t"
-		"VADD.u64	d16, d28			\n\t"
+                "VMOV       r0, r1, s18, s19                    \n\t"
+                "ADDS       r0, r0, r12, LSR #26                \n\t"
+                "ADC        r1, r1, #0                          \n\t"
+                "ADDS       r0, r0, r14, LSL #6                 \n\t"
+                "ADC        r1, r1, #0                          \n\t"
 
-		"VAND.u64	d11, d16, d30			\n\t"   /* d1 */
+                "AND        r8, r0, r5                          \n\t"  /* d1 */
+
+                /* d1 overflow to d2 */
+
+                "VMOV       r2, r3, s16, s17                    \n\t"
+                "ADDS       r2, r2, r0, LSR #26                 \n\t"
+                "ADC        r3, r3, #0                          \n\t"
+                "ADDS       r2, r2, r1, LSL #6                  \n\t"
+                "ADC        r3, r3, #0                          \n\t"
+
+                "AND        r9, r2, r5                          \n\t"  /* d2 */
 
-		/* d1 overflow to d2 */
+                /* d2 overflow to d3 */
+
+                "VMOV       r0, r1, s14, s15                    \n\t"
+                "ADDS       r0, r0, r2, LSR #26                 \n\t"
+                "ADC        r1, r1, #0                          \n\t"
+                "ADDS       r0, r0, r3, LSL #6                  \n\t"
+                "ADC        r1, r1, #0                          \n\t"
+
+                "AND        r10, r0, r5                         \n\t"  /* d3 */
+
+                /* d3 overflow to d4 */
 
-		"VSHL.u64	d28, d16, #26			\n\t"
-		"VADD.u64	d17, d28			\n\t"
+                "VMOV       r2, r3, s12, s13                    \n\t"
+                "ADDS       r2, r2, r0, LSR #26                 \n\t"
+                "ADC        r3, r3, #0                          \n\t"
+                "ADDS       r2, r2, r1, LSL #6                  \n\t"
+                "ADC        r3, r3, #0                          \n\t"
 
-		"VAND.u64	d12, d17, d30			\n\t"   /* d2 */
+                "AND        r11, r2, r5                         \n\t"  /* d4 */
 
-		/* d2 overflow to d3 */
-
-		"VSHL.u64	d28, d17, #26			\n\t"
-		"VADD.u64	d18, d28			\n\t"
-
-		"VAND.u64	d13, d18, d30			\n\t"   /* d3 */
-
-		/* d3 overflow to d4 */
-
-		"VSHL.u64	d28, d18, #26			\n\t"
-		"VADD.u64	d19, d28			\n\t"
-
-		"VAND.u64	d14, d19, d30			\n\t"   /* d4 */
-
-
-		/* d4 overflow to d0, must be multiplied by 5 */
-
-		"VSHL.u64	d28, d14, #26			\n\t"
-		"VMUL.F64	d27, d28, d31			\n\t"
-		"VADD.u64	d10, d27			\n\t"
-
-		"VAND.u64	d10, d10, d30			\n\t"   /* d0 */
-
-		
-		/* d0 overflow to d1 */
-
-		"VSHL.u64	d28, d10, #26			\n\t"
-		"VADD.u64	d11, d28, d31			\n\t"
-
-		"B	armv8_32_poly1305_loop		\n\t"
-	
-	"armv8_32_poly1305_last_block:			\n\t"
-
-		/* This is the last block of the message
-		   and the block is less than 16 bytes */
-		"MOV 	r0, #0				\n\t"
-		"STR	r0, [sp, %[BYTES_STORE]]	\n\t"
-	
-		"LDR	r0, [sp, %[HIBIT_LOCAL]]	\n\t"
-
-		/* Make sure the upper bytes of the 
-		   32 bit pieces are set to zero. 
-		   Set the byte past the last message
-		   data byte to 01. */
-
-		"PUSH	{ r4, r6, r8 } 			\n\t"	
-
-		"MOV    r1,  #0				\n\t"
-		"MOV	r2,  #0				\n\t"
-		"MOV	r3,  #0				\n\t"
-		"MOV	r4,  #0xFFFFFFFF		\n\t"
-		"LSR	r0, r0, #24			\n\t"
-		"MOV	r6,  r0				\n\t"
-
-		/* always going to load at least one */		
-		"LDR	r0, [r7]			\n\t"
-
-		/* byte offset to bit offset */ 
-		"ADD	r5, r5, #16			\n\t"
-		"LSL	r5, r5, #3			\n\t"			
-
-		/* which block */
-		"CMP	r5, #32				\n\t"
-		"BGE	not_word_0			\n\t"
-
-		/* case word 0 */
-	"case0:"
-		"LSL	r8, r4, r5			\n\t"
-		"BIC  	r0, r0, r8			\n\t"
-		"LSL	r8, r6, r5			\n\t"
-		"ADD	r0, r0, r8			\n\t"
-		"B	last_block_done			\n\t"
-
-	"not_word_0:	 				\n\t"
-		"LDR	r1, [r7, #4]			\n\t"
-		
-		"SUB	r5, r5, #32			\n\t"
-		"CMP	r5, #32				\n\t"
-		"BGE	not_word_1			\n\t"
-
-		"LSL	r8, r4, r5			\n\t"
-		"BIC  	r1, r1, r8			\n\t"
-		"LSL	r8, r6, r5			\n\t"
-		"ADD	r1, r1, r8			\n\t"		
-		"B	last_block_done			\n\t"
-
-	"not_word_1:					\n\t"
-		"LDR	r2, [r7, #8]			\n\t"
-
-		"SUB	r5, r5, #32			\n\t"
-		"CMP	r5, #32				\n\t"
-		"BGE	not_word_2			\n\t"
-
-		"LSL	r8, r4, r5			\n\t"
-		"BIC  	r2, r2, r8			\n\t"
-		"LSL	r8, r6, r5			\n\t"
-		"ADD	r2, r2, r8			\n\t"		
-		"B	last_block_done			\n\t"
-
-	"not_word_2:					\n\t"
-		"LDR	r3, [r7, #0xC]			\n\t"
-
-		"SUB	r5, r5, #32			\n\t"
-
-		"LSL	r8, r4, r5			\n\t"
-		"BIC  	r3, r3, r8			\n\t"
-		"LSL	r8, r6, r5			\n\t"
-		"ADD	r3, r3, r8			\n\t"	
-
-	"last_block_done:				\n\t"
-
-		"POP	{ r4, r6, r8 } 			\n\t"	
-	
-		"b 	armv8_32_poly1305_done_01_byte_appended \n\t"
-	
-		".align 2 \n\t"
-	"armv8_32_poly1305_done:			\n\t"
-
-		/* store final result */
-		"VSHL.u64	d28, d11, #32			\n\t"
-		"VADD.u64	d10, d10, d11			\n\t"
-
-		"VSHL.u64	d28, d13, #32			\n\t"
-		"VADD.u64	d12, d12, d11			\n\t"
-
-		"VSHL.u64	d28, d15, #32			\n\t"
-		"VADD.u64	d14, d14, d11			\n\t"
-
-		"VSTR		d10, [r0]			\n\t"
-		"VSTR		d12, [r0, #8]			\n\t"
-		"VSTR		d14, [r0, #16]			\n\t"
-		
-		: [m] 		  "+m" (msgDataOnStack),	/* input */
-		  [r_ptr]  	  "+m" (r_ptrLocal),		/* input */
-		  [h_ptr]  	  "+m" (h_ptrLocal),		/* input, output */
-		  [bytes]  	  "+m" (msgDataLenOnStack),	/* input */
-		  [hibit]	  "+m" (hibitOnStack),		/* input */
-		  [test1]	  "+m" (test1OnStack)
-		: [BYTES_STORE]    "I" (BYTES_SP_OFF),
-		  [HIBIT_LOCAL]    "I" (HIBIT_LOCAL_SP_OFF)
-		: "memory", "cc", 
-			"r0", "r1", "r2", "r3", "r4", "r5", "r6", "r8", "r9", "r10",
-			"d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
-			"d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18",
-			"d19", "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27",
-			"d28", "d29", "d30", "d31"
-	);
-
-	ctx->r[0] = r_44bitPieces[0] & 0x3FFFFFF;
-	ctx->r[1] = ((r_44bitPieces[0] >> 26)		/* 44 - 26 = 18 */
- 		    + (r_44bitPieces[1] << 18)) 	/* 26 - 18 = 8  */
-		    & 0x3FFFFFF;
-	ctx->r[2] = (r_44bitPieces[1] >> 8)    		/* 44 - 8  = 36  */
-		    & 0x3FFFFFF;
-	ctx->r[3] = ((r_44bitPieces[1] >> (44-10))	/* 36 - 26 = 10 */
- 		    + (r_44bitPieces[2] << 10))		/* 26 - 10 = 16 */
-		    & 0x3FFFFFF;
-	ctx->r[4] = (r_44bitPieces[2] >> 16);		/* 44 - 16 = 28 */ 
-
+                /* d4 overflow to d0, must be multiplied by 5 */        
+
+                "LSR        r0, r2, #26                         \n\t"
+                "ADD        r0, r0, r3, LSL #6                  \n\t"
+                "MOV        r1, #5                              \n\t"        
+                "MUL        r0, r0, r1                          \n\t"
+                "ADD        r6, r6, r0                          \n\t"  /* d0 updated */
+
+                /* d0 overflow to d1 */
+
+                "ADD        r8, r8, r6, LSR #26                 \n\t"  /* d1 done */
+
+                "AND        r6, r6, r5                          \n\t"  /* d0 done */
+
+                "B          armv8_32_poly1305_loop              \n\t"
+        
+        "armv8_32_poly1305_last_block:                          \n\t"
+
+                /* This is the last block of the message
+                   and the block is less than 16 byte */
+
+                /* set s4 to 0, d2 is s5:s4 */
+                "VEOR       d2, d2                              \n\t"
+        
+                "VMOV       r0, s2                              \n\t"  /* hibit */
+
+                /* Make sure the upper bytes of the 
+                   32 bit pieces are set to zero. 
+                   Set the byte past the last message
+                   data byte to 01. */
+
+                "PUSH        { r4, r6, r8 }                     \n\t"        
+
+                "MOV        r1,  #0                             \n\t"
+                "MOV        r2,  #0                             \n\t"
+                "MOV        r3,  #0                             \n\t"
+                "MOV        r4,  #0xFFFFFFFF                    \n\t"
+                "LSR        r0,  r0, #24                        \n\t"
+                "MOV        r6,  r0                             \n\t"
+
+                /* always going to load at least one */                
+                "LDR        r0, [r7]                            \n\t"
+
+                /* byte offset to bit offset */ 
+                "ADD        r5, r5, #16                         \n\t"
+                "LSL        r5, r5, #3                          \n\t"                        
+
+                /* which block */
+                "CMP        r5, #32                             \n\t"
+                "BGE        not_word_0                          \n\t"
+
+                /* case word 0 */
+        "case0:"
+                "LSL        r8, r4, r5                          \n\t"
+                "BIC        r0, r0, r8                          \n\t"
+                "LSL        r8, r6, r5                          \n\t"
+                "ADD        r0, r0, r8                          \n\t"
+                "B          last_block_done                     \n\t"
+
+        "not_word_0:                                            \n\t"
+                "LDR        r1, [r7, #4]                        \n\t"
+                
+                "SUB        r5, r5, #32                         \n\t"
+                "CMP        r5, #32                             \n\t"
+                "BGE        not_word_1                          \n\t"
+
+                "LSL        r8, r4, r5                          \n\t"
+                "BIC        r1, r1, r8                          \n\t"
+                "LSL        r8, r6, r5                          \n\t"
+                "ADD        r1, r1, r8                          \n\t"                
+                "B          last_block_done                     \n\t"
+
+        "not_word_1:                                            \n\t"
+                "LDR        r2, [r7, #8]                        \n\t"
+
+                "SUB        r5, r5, #32                         \n\t"
+                "CMP        r5, #32                             \n\t"
+                "BGE        not_word_2                          \n\t"
+
+                "LSL        r8, r4, r5                          \n\t"
+                "BIC        r2, r2, r8                          \n\t"
+                "LSL        r8, r6, r5                          \n\t"
+                "ADD        r2, r2, r8                          \n\t"                
+                "B          last_block_done                     \n\t"
+
+        "not_word_2:                                            \n\t"
+                "LDR        r3, [r7, #0xC]                      \n\t"
+
+                "SUB        r5, r5, #32                         \n\t"
+
+                "LSL        r8, r4, r5                          \n\t"
+                "BIC        r3, r3, r8                          \n\t"
+                "LSL        r8, r6, r5                          \n\t"
+                "ADD        r3, r3, r8                          \n\t"        
+
+        "last_block_done:                                       \n\t"
+
+                "POP        { r4, r6, r8 }                      \n\t"        
+        
+                "b          armv8_32_poly1305_done_01_byte_appended \n\t"
+        
+                ".align 2 \n\t"
+        "armv8_32_poly1305_done:                                \n\t"
+                "POP        { r7 }                              \n\t"
+
+                /* store final result */
+                "LDR        r0, %[h_ptr]                        \n\t"
+                "STM        r0, { r6, r8, r9, r10, r11 }        \n\t"
+                
+                : [m]            "+m" (msgDataOnStack),        /* input */
+                  [r_ptr]        "+m" (r_ptrLocal),            /* input */
+                  [h_ptr]        "+m" (h_ptrLocal),            /* input, output */
+                  [bytes]        "+m" (msgDataLenOnStack),     /* input */
+                  [hibit]        "+m" (hibitOnStack)           /* input */
+                : 
+                : "memory", "cc", 
+                        "r0", "r1", "r2", "r3", "r4", "r5", "r6", "r8", "r9", "r10",
+                        "r11", "r12", "lr",
+                        "s2", "s4", "s6", "s7", "s8", "s9", "s10", "d2",
+                        "s12", "s13", "s14", "s15", "s16", "s17", "s18", "s19"
+        );
+
+        memcpy(ctx->r, r, 5 * sizeof(unsigned));
+        memcpy(ctx->h, h, 5 * sizeof(unsigned));
 
 #ifdef POLY1305_VERBOSE
+        for (i=0;i<5;++i) printf("h%d %07X ", i, ctx->h[i]);
+        printf("\n");
 
-	printf("\n\n THIS stuff \n\n");
-	for (i=0;i<10;){
-		 printf("%d %07X ", i, test1Array[i+1]);
-		 printf(" %07X ",  test1Array[i]);
-		 i+=2;
-	}
-	printf("\n\n");
-
-
-	for (i=0;i<5;++i) printf("r%d %07X ", i, ctx->r[i]);
-	printf("\n");
-
-	printf("armv8_32_poly1305_blocks() leaving\n");
+        printf("armv8_32_poly1305_blocks() leaving\n");
 #endif
 
 }
 
 #endif  /* #ifdef  WOLFSSL_ARMASM_NO_NEON */
 
-#endif	/* #ifndef __aarch64__   */
+#endif  /* #ifndef __aarch64__   */
 #endif  /* #ifdef  WOLFSSL_ARMASM */
 
 
-#ifdef STAND_ALONE_DEBUG
-/**********************************************************
-  printRegs	Test routine used to display the register 
-		values save by the call to the assembly
-		routine saveRegs.  The r6, r8, r9, r10
-		and r11 values are approperiately added
-		together to create a 17 byte value that is
-		displayed.  
-**********************************************************/
-void printRegs(unsigned *regArray)
-{
-	unsigned result26Bit[5];
-	unsigned char result[17];
-	int i;	
-
-	printf("\n\n*** Register dump ***\n");
-	for (i=0; i<13;++i)
-		printf("r%d = 0x%08X \n", i, regArray[i]);
-	printf(" sp (r13) skiped\n");
-	printf(" lr (r14) = 0x%08X \n", regArray[i]);
-
-	/* r6, r8, r9, r10, r11 could be 26 bit components
-	   print the result of reassembling them. */
-
-	result26Bit[0] = regArray[6];
-	result26Bit[1] = regArray[8];
-	result26Bit[2] = regArray[9];
-	result26Bit[3] = regArray[10];	
-	result26Bit[4] = regArray[11];
-	convert26BitValuesTo17Byte(result26Bit, result);
-
-	//printBytes("result = ", result, 17);
-	print17("result = ", result);
-}
-
-#define SAVE_REGS	"PUSH 	{ r14 }				\n\t" \
-			"BL	recordRegs			\n\t" \
-			"NOP					\n\t" \
-			"POP	{ r14 }				\n\t"
-#endif
 
 
 #ifdef POLY1305_STAND_ALONE
 
-void byte32Add(unsigned char *destByte, unsigned char *srcByte)
-{
-	int i;
-	unsigned *dest, *src;
-	unsigned long long result;
-	unsigned long long of=0;
-	
-	dest = (unsigned *)destByte;
-	src = (unsigned *)srcByte;
-	
-	for (i=0;i<8;++i)
-	{
-		/* the type cast to unsigned long is necessary */
-		result = (unsigned long long)dest[i]+(unsigned long long)src[i]+of;
-		of = result >> 32;
-		dest[i] = (unsigned) result;
-	}
-}
-
-void multiplyBasic(unsigned char *finalResult, unsigned char *val1, 
-	unsigned char *val2)
-{
-	unsigned char intermediateResult[32];
-	unsigned bit32Val1, bit32Val2;
-	/* if compiling 32 bit needs to be unsigned long long for 64 bit */
-	unsigned long long result;   
-	int i,j;
-	
-	/* set to 0 then do repeated adds */
-	memset(finalResult, 0, 32);
-
-	/* generate 4 intermediate results */
-	/* then shift and add those results */
-	
-	for (i=0;i<2;++i)
-	{
-		bit32Val1 = *(unsigned*)(val1 + 4*i);
-		
-		/* multiple the 32 bit value times the entire 17 byte */
-		for (j=0;j<2;++j)
-		{
-			bit32Val2 = *(unsigned*)(val2 + 4*j);
-			
-			memset(intermediateResult,0,32);
-			//printf("32 bit vals %X %X \n", bit32Val1, bit32Val2);
-
-			/* must convert to 64 bit before the mult or the mult
-			   will give a 32 bit result not a 64 bit */
-			result = (unsigned long long)bit32Val1 
-				* (unsigned long long)bit32Val2;
-			//printf("result %lX \n", result);
-			*(unsigned long long*)(intermediateResult + 4*j + 4*i) 
-				= result;
-				
-			/* add the intermediate result to byte32Result */
-			byte32Add(finalResult, intermediateResult);
-			//print32(" ", byte32Result);
-		}
-		
-#if 0
-		/* multiple final byte */
-		memset(intermediateResult,0,32);
-		result = (unsigned long long)bit32Val1 * (unsigned long long)val2[16];
-		
-		if ((4*j + 4*i) == 0x1C)
-			*(unsigned*)(intermediateResult + 4*j + 4*i) 
-				= (unsigned)result;
-		else
-			*(unsigned long long*)(intermediateResult + 4*j + 4*i) 
-				= (unsigned long long)result;
-				
-		/* add the intermediate result to byte32Result */
-		byte32Add(finalResult, intermediateResult);
-#endif
-	}
-}
-
-
 /**********************************************************
-  print16	Output the given 16 bytes as one big
-		number.  Note 16 bytes is 128 bit.
+  print16        Output the given 16 bytes as one big
+                number.  Note 16 bytes is 128 bit.
 **********************************************************/
 void print16(const char *startText, unsigned char *data);
 void print16(const char *startText, unsigned char *data)
 {
-	printf("%s %08X %08X %08X %08X\n", startText, *(unsigned*)(data+0xc),
-			*(unsigned*)(data+0x8),
-			*(unsigned*)(data+4),
-			*(unsigned*)data);
+        printf("%s %08X %08X %08X %08X\n", startText, *(unsigned*)(data+0xc),
+                        *(unsigned*)(data+0x8),
+                        *(unsigned*)(data+4),
+                        *(unsigned*)data);
 }
 
 
 /**********************************************************
-  print17	Output the given 17 bytes as one big
-		number.  
+  print17        Output the given 17 bytes as one big
+                number.  
 **********************************************************/
 void print17(const char *startText, unsigned char *data);
 void print17(const char *startText, unsigned char *data)
 {
-	printf("%s %02X %08X%08X %08X%08X \n", startText, data[16], 
-				*(unsigned *)(data+0xC), *(unsigned *)(data+8),
-				*(unsigned *)(data+4), *(unsigned *)(data));
+        printf("%s %02X %08X%08X %08X%08X \n", startText, data[16], 
+                                *(unsigned *)(data+0xC), *(unsigned *)(data+8),
+                                *(unsigned *)(data+4), *(unsigned *)(data));
 }
 
 
 /**********************************************************
-  printBytes	Print the specified number of bytes, one
-		byte at a time.
+  printBytes        Print the specified number of bytes, one
+                byte at a time.
 **********************************************************/
 void printBytes(const char *startText, unsigned char *data, int len);
 void printBytes(const char *startText, unsigned char *data, int len)
 {
-	int i;
-	
-	printf("%s", startText);
-	
-	for (i=0;i<len;++i)
-	{
-		printf("%02X", data[i]);
-		if (i<len-1) printf(":");
-	}
-	printf("\n");
+        int i;
+        
+        printf("%s", startText);
+        
+        for (i=0;i<len;++i)
+        {
+                printf("%02X", data[i]);
+                if (i<len-1) printf(":");
+        }
+        printf("\n");
 }
 
 
 /**********************************************************
-  clamp_r	Set the correct bits in the 128 bit r key
-		to zero.
+  clamp_r        Set the correct bits in the 128 bit r key
+                to zero.
 **********************************************************/
 void clamp_r(unsigned char *r);
 void clamp_r(unsigned char *r)
 {
-	printBytes("r = ", r, 16);
-	
-	r[3] &= 0xF;
-	r[7] &= 0xF;
-	r[11] &= 0xF;
-	r[15] &= 0xF;
-	
-	r[4] &= 0xFC;
-	r[8] &= 0xFC;
-	r[12] &= 0xFC;
-	
-	print16("after clamp ", r);
+        printBytes("r = ", r, 16);
+        
+        r[3] &= 0xF;
+        r[7] &= 0xF;
+        r[11] &= 0xF;
+        r[15] &= 0xF;
+        
+        r[4] &= 0xFC;
+        r[8] &= 0xFC;
+        r[12] &= 0xFC;
+        
+        print16("after clamp ", r);
 }
 
 
 /**********************************************************
-  add17		Add two 17 byte numbers together.  This is
-		used as part of the algorithm to combine
-		26 bit pieces into one 17 byte number.
+  add17                Add two 17 byte numbers together.  This is
+                used as part of the algorithm to combine
+                26 bit pieces into one 17 byte number.
 **********************************************************/
 void add17(unsigned char *dest, unsigned char *src);
 void add17(unsigned char *dest, unsigned char *src)
 {
-	int i;
-	short result;
-	unsigned char of=0;
-	
-	for (i=0;i<17;++i)
-	{
-		result = dest[i] + src[i] + of;
-		
-		dest[i] = (unsigned char)result;
-		
-		if (result & 0xFF00) of=1; else of=0; 
-	}
+        int i;
+        short result;
+        unsigned char of=0;
+        
+        for (i=0;i<17;++i)
+        {
+                result = dest[i] + src[i] + of;
+                
+                dest[i] = (unsigned char)result;
+                
+                if (result & 0xFF00) of=1; else of=0; 
+        }
 }
 
 
 /**********************************************************
   convert26BitValuesTo17Byte
-		Convert the 5 specified 26 bit values to
-		a single 17 byte value.
-  input16Bit	Input array of 5 26 bit values.  
-  result	Output of 17 bytes which represent one
-		130 bit number.
+                Convert the 5 specified 26 bit values to
+                a single 17 byte value.
+  input16Bit        Input array of 5 26 bit values.  
+  result        Output of 17 bytes which represent one
+                130 bit number.
 **********************************************************/
 void convert26BitValuesTo17Byte(unsigned *input26Bit, unsigned char *result);
 void convert26BitValuesTo17Byte(unsigned *input26Bit, unsigned char *result)
 {
-	unsigned char tmp[17];
+        unsigned char tmp[17];
 
-	memset(result, 0, 17);
-	*(unsigned*)(result+0) = input26Bit[0];
+        memset(result, 0, 17);
+        *(unsigned*)(result+0) = input26Bit[0];
 
-	memset(tmp, 0, 17);
-	*(unsigned*)(tmp+3)  = input26Bit[1] << 2;
-	add17(result, tmp);
+        memset(tmp, 0, 17);
+        *(unsigned*)(tmp+3)  = input26Bit[1] << 2;
+        add17(result, tmp);
 
-	memset(tmp, 0, 17);
-	*(unsigned*)(tmp+6)  = input26Bit[2] << 4;
-	add17(result, tmp);
+        memset(tmp, 0, 17);
+        *(unsigned*)(tmp+6)  = input26Bit[2] << 4;
+        add17(result, tmp);
 
-	memset(tmp, 0, 17);
-	*(unsigned*)(tmp+9)  = input26Bit[3] << 6;
-	add17(result, tmp);
+        memset(tmp, 0, 17);
+        *(unsigned*)(tmp+9)  = input26Bit[3] << 6;
+        add17(result, tmp);
 
-	memset(tmp, 0, 17);
-	*(unsigned*)(tmp+13) = input26Bit[4];
-	add17(result, tmp);	
+        memset(tmp, 0, 17);
+        *(unsigned*)(tmp+13) = input26Bit[4];
+        add17(result, tmp);        
 
-	result[16] &= 3;
+        result[16] &= 3;
 }
 
 
 /* test data set from RFC 7539 */
-unsigned char testData []="Cryptographic Forum Research set"; 
-//unsigned char testData []="Cryptographic Forum Research Group"; 
+//unsigned char testData []="Cryptographic Forum Research set"; 
+unsigned char testData[]="Cryptographic Forum Research Group"; 
 //unsigned char testData []="12345678901234561234567890123456";
 unsigned char testKey[]="\x85\xd6\xBE\x78\x57\x55\x6d\x33\x7F\x44\x52\xfe\x42\xd5\x06\xa8\x01\x03\x80\x8a\xfb\x0d\xb2\xFD\x4A\xBF\xF6\xAF\x41\x49\xF5\x1B";
 
 unsigned char resultCheck[]="\xA8\x06\x1D\xC1\x30\x51\x36\xC6\xC2\x2B\x8B\xAF\x0C\x01\x27\xA9";
 
 
-unsigned char msgDataCopy[100];		
+unsigned char msgDataCopy[100];                
 
 int main(void)
 {
-	unsigned char *msgData, *keyData;
-	int msgDataLen;
-	unsigned char result16Byte[16];
-	Poly1305  ctx;
- 	unsigned char *r, *s, acc[17];
+        unsigned char *msgData, *keyData;
+        int msgDataLen;
+        unsigned char result16Byte[16];
+        Poly1305  ctx;
+         unsigned char *r, *s, acc[17];
 
-	msgData = testData;
-	msgDataLen = strlen((const char *)msgData);	
-	keyData = testKey;
-
-
-	unsigned *pt;
-	pt = (unsigned*)msgData;
-
-	int i;
-	printf("%s\n", msgData);
-	for (i=0;i<10;++i) printf(" %d %X\n", i, pt[i]);
-	printf("\n");
-
-	printf("message len %d\n", msgDataLen);
+        msgData = testData;
+        msgDataLen = strlen((const char *)msgData);        
+        keyData = testKey;
 
 
-	/* some modifications of the test data for test
-	   purposes.  Used in part to test the assembly
-	   algorithm for the last block of the message. */
+        unsigned *pt;
+        pt = (unsigned*)msgData;
+
+        int i;
+        printf("%s\n", msgData);
+        for (i=0;i<10;++i) printf(" %d %X\n", i, pt[i]);
+        printf("\n");
+
+        printf("message len %d\n", msgDataLen);
+
+
+        /* some modifications of the test data for test
+           purposes.  Used in part to test the assembly
+           algorithm for the last block of the message. */
 #if 0
-	/* add junk at end for testing */
-	memcpy(msgDataCopy, msgData, msgDataLen);
-	msgData = msgDataCopy;
-	*(unsigned*)(msgData+msgDataLen) = 0x12345678;
-	*(unsigned*)(msgData+msgDataLen+4) = 0x12345678;
-	*(unsigned*)(msgData+msgDataLen+8) = 0x11111111;
+        /* add junk at end for testing */
+        memcpy(msgDataCopy, msgData, msgDataLen);
+        msgData = msgDataCopy;
+        *(unsigned*)(msgData+msgDataLen) = 0x12345678;
+        *(unsigned*)(msgData+msgDataLen+4) = 0x12345678;
+        *(unsigned*)(msgData+msgDataLen+8) = 0x11111111;
 #endif
-	
+        
 #if 0
-	/* make test data a boundary case length
-	   for testing. */
-	memcpy(msgDataCopy, msgData, msgDataLen);
-	msgData = msgDataCopy;
+        /* make test data a boundary case length
+           for testing. */
+        memcpy(msgDataCopy, msgData, msgDataLen);
+        msgData = msgDataCopy;
 
-	strcat(msgData, "more stuff");
-	msgDataLen = strlen(msgData);	
-#endif
-
-#if 0
-	/* just run poly1305 on the first 16 byte 
- 	   block of the test data. */
-	strcpy(msgDataCopy, "Cryptographic Fo");
-	msgData = msgDataCopy;
-	msgDataLen = strlen(msgData);		
+        strcat(msgData, "more stuff");
+        msgDataLen = strlen(msgData);        
 #endif
 
-	r = keyData;
-	s = keyData+16;
+#if 0
+        /* just run poly1305 on the first 16 byte 
+            block of the test data. */
+        strcpy(msgDataCopy, "Cryptographic Fo");
+        msgData = msgDataCopy;
+        msgDataLen = strlen(msgData);                
+#endif
 
-	print16("s as a 128-bit number ", s);
-	clamp_r(r);
+        r = keyData;
+        s = keyData+16;
 
-	/* break the 16 byte value into 26 bit parts. */         
-	ctx.r[0] = *(unsigned *)(r) & 0x3FFFFFF;
-	ctx.r[1] = ((*(unsigned *)(r + 3)) >> 2) & 0x3FFFFFF;
-	ctx.r[2] = ((*(unsigned *)(r + 6)) >> 4) & 0x3FFFFFF;
-	ctx.r[3] = ((*(unsigned *)(r + 9)) >> 6) & 0x3FFFFFF;
-	/* + 12 so you don't reference outside array, ie don't use +13 */
-	ctx.r[4] = ((*(unsigned *)(r + 12)) >> 8) & 0xFFFFFF;
+        print16("s as a 128-bit number ", s);
+        clamp_r(r);
 
-	ctx.finished = 0;
+        /* break the 16 byte value into 26 bit parts. */         
+        ctx.r[0] = *(unsigned *)(r) & 0x3FFFFFF;
+        ctx.r[1] = ((*(unsigned *)(r + 3)) >> 2) & 0x3FFFFFF;
+        ctx.r[2] = ((*(unsigned *)(r + 6)) >> 4) & 0x3FFFFFF;
+        ctx.r[3] = ((*(unsigned *)(r + 9)) >> 6) & 0x3FFFFFF;
+        /* + 12 so you don't reference outside array, ie don't use +13 */
+        ctx.r[4] = ((*(unsigned *)(r + 12)) >> 8) & 0xFFFFFF;
 
-	/* Should always start as zero.
+        ctx.finished = 0;
+
+        /* Should always start as zero.
            Passing into assembly routine to match what is already 
-	   implemented in wolfSSL armv8_poly1305.c.  
-	   For debugging, the C routine could break the message into 
-	   16 byte chunks and call the assembly routine over and over
-	   with the 16 byte chunks and the updated h value. */
-	memset(ctx.h, 0, 5 * sizeof(unsigned));
+           implemented in wolfSSL armv8_poly1305.c.  
+           For debugging, the C routine could break the message into 
+           16 byte chunks and call the assembly routine over and over
+           with the 16 byte chunks and the updated h value. */
+        memset(ctx.h, 0, 5 * sizeof(unsigned));
 
-	armv8_32_poly1305_blocks(&ctx, msgData, msgDataLen);
+        armv8_32_poly1305_blocks(&ctx, msgData, msgDataLen);
 
-	convert26BitValuesTo17Byte(ctx.h, acc);
+        convert26BitValuesTo17Byte(ctx.h, acc);
 
-	/* make output match what is seen in RFC */
-	print17("Acc = ((Acc+Block) * r) % P = ", acc);
-	add17(acc, s);
-	print17("Acc + s = ", acc);
+        /* make output match what is seen in RFC */
+        print17("Acc = ((Acc+Block) * r) % P = ", acc);
+        add17(acc, s);
+        print17("Acc + s = ", acc);
 
-	memcpy(result16Byte, acc, 16);
+        memcpy(result16Byte, acc, 16);
 
-	printBytes(" Tag = ", result16Byte, 16); 
+        printBytes(" Tag = ", result16Byte, 16); 
 
-	if (!memcmp(result16Byte, resultCheck, 16))
-		printf("Result matches RFC 7539\n\n");
-	else	
-		printf("Result does not match RFC 7539\n\n");
+        if (!memcmp(result16Byte, resultCheck, 16))
+                printf("Result matches RFC 7539\n\n");
+        else        
+                printf("Result does not match RFC 7539\n\n");
 }
 #endif
+
+
 

--- a/wolfcrypt/src/port/arm/armv8-32-poly1305.c
+++ b/wolfcrypt/src/port/arm/armv8-32-poly1305.c
@@ -3,72 +3,51 @@
    The test data in this code matches the test data in RFC 7539.
 
    The poly1305 algorithm takes two inputs, they are as follows.
-	1. the message data
-	2. a 256 bit key
+    1. the message data
+    2. a 256 bit key
    The algorithm outputs a 16 byte authentication value.
-  
-   The 16 bytes are transmitted with the message.  
-   The receiving side runs the poly1305 algorithm and 
+
+   The 16 bytes are transmitted with the message.
+   The receiving side runs the poly1305 algorithm and
    compares the 16 byte result on the receiving side to
    16 bytes sent with the message.  If the two 16 byte
    values match, then the message is authenticated.
 
    The poly1305 algorithm requires a unique 256 bit key
    for each message.  The sender and receiver keys must
-   stay in sync. This means that a pseudo random key must 
-   be generated on both sides using the same algorithm 
+   stay in sync. This means that a pseudo random key must
+   be generated on both sides using the same algorithm
    and the same initial key.
-  
+
    It is common to use the ChaCha20 algorithm to generate
    the pseudo random key.  The initial 256 bit key is normally
-   shared during the setup up of the connection between 
-   sender and receiver.	
+   shared during the setup up of the connection between
+   sender and receiver.
 
-   The 256 bit key is broken down into two 128 bit parts; 
+   The 256 bit key is broken down into two 128 bit parts;
    namely r and s.  In the algorithm, r is clamped, meaning
    certain bits are set to zero.  According to the RFC, r can
-   remain the same between runs of the algorithm, but s must 
-   always change.  Therefore the ChaCha20 solution mentioned 
+   remain the same between runs of the algorithm, but s must
+   always change.  Therefore the ChaCha20 solution mentioned
    above could be used to generate a 128 bit or 256 bit unique
-   key each time. 
+   key each time.
 
    This code was compiled and tested with the following tool chain.
 
-	gcc-arm-10.2-2020.11-aarch64-arm-none-linux-guneabihf
+    gcc-arm-10.2-2020.11-aarch64-arm-none-linux-guneabihf
 
    The development environment was Ubunutu, image file
-	
-	libre-computer-aml-s905x-cc-ubuntu-bionic-mate-mali-4.19.55+-2019-06-24.img 
+
+    libre-computer-aml-s905x-cc-ubuntu-bionic-mate-mali-4.19.55+-2019-06-24.img
 
    In order the run the resulting executable the 32 bit libs must
    be added to the system.  The following commands accomplish this.
 
-	sudo dpkg --add-architecture armhf
-	sudo apt-get update
-	sudo apt-get install libc6:armhf libstdc++6:armhf
+    sudo dpkg --add-architecture armhf
+    sudo apt-get update
+    sudo apt-get install libc6:armhf libstdc++6:armhf
 
 *****************************************************************/
-
-
-/* if building as a standalone to match the RFC 7539 
-   Be sure to pass gcc "-D POLY1305_STAND_ALONE". */
-#ifdef POLY1305_STAND_ALONE
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stddef.h>
-
-typedef struct poly1305_struct
-{
-    unsigned r[5];
-    unsigned h[5];
-    unsigned finished;
-} Poly1305;
-
-#define WOLFSSL_ARMASM		1
-/* leave __aarch64__ undefined */
-#define POLY1305_VERBOSE 	1
-#else
 
 #ifdef WOLFSSL_ARMASM
 #ifndef __aarch64__
@@ -82,1149 +61,1030 @@ typedef struct poly1305_struct
 #include <wolfssl/wolfcrypt/settings.h>
 
 #include <wolfssl/wolfcrypt/poly1305.h>
-#include <stddef.h>
-
-#endif
-#endif
-
-#endif
-
-
-#ifdef WOLFSSL_ARMASM
-#ifndef __aarch64__
+#include <wolfssl/wolfcrypt/error-crypt.h>
 
 
 /**********************************************************
-  armv8_32_poly1305_blocks	This routine implements the 
-			poly1305 algorithm.  The processing
-			of the 16 byte pieces of the 
-			message is implemented in assembly.
-			Care was taken in implementing the
-			assembly to optimize speed by 
-			minimizing memory references as
-			well as minimizing instructions.
-			The poly1305 algorithm is implemented
-			by using multiple 26 bit values 
-			to represent the larger 16 byte and 
-			17 byte numbers.  Breaking the 
-			larger numbers down into 26 bit 
-			pieces means that math operations will
-			not overflow the 32 bit registers.
-			For more information reference the article 
-			NEON Cryto by Daniel Berstein and Peter
-			Schwabe.
+  armv8_32_poly1305_blocks    This routine implements the
+            poly1305 algorithm.  The processing
+            of the 16 byte pieces of the
+            message is implemented in assembly.
+            Care was taken in implementing the
+            assembly to optimize speed by
+            minimizing memory references as
+            well as minimizing instructions.
+            The poly1305 algorithm is implemented
+            by using multiple 26 bit values
+            to represent the larger 16 byte and
+            17 byte numbers.  Breaking the
+            larger numbers down into 26 bit
+            pieces means that math operations will
+            not overflow the 32 bit registers.
+            For more information reference the article
+            NEON Cryto by Daniel Berstein and Peter
+            Schwabe.
 
-  ctx			poly1305 structure containing the r and
-		 	h values broke into 26 bit pieces.
-			The result of this routine is returned
-			int the h array of 26 bit values.
-  msgData		Message data to run the algorithm 
-			against.
-  keyData		256 bit key that is broken down 
-			into the r and s subcomponents.
+  ctx            poly1305 structure containing the r and
+             h values broke into 26 bit pieces.
+            The result of this routine is returned
+            int the h array of 26 bit values.
+  msgData        Message data to run the algorithm
+            against.
+  keyData        256 bit key that is broken down
+            into the r and s subcomponents.
 **********************************************************/
 /* variable assembly code creates on stack */
 
-#define BYTES_SP_OFF		20
-#define HIBIT_LOCAL_SP_OFF	24
-
-void armv8_32_poly1305_blocks(Poly1305* ctx, 
-			const unsigned char *msgData,
-                     	size_t msgDataLen);
+#define BYTES_SP_OFF            20
+#define HIBIT_LOCAL_SP_OFF      24
 
 /* WOLFSSL_ARMASM_NO_NEON is used in armv8-32-sha512-asm.S */
 #ifdef WOLFSSL_ARMASM_NO_NEON2
-void armv8_32_poly1305_blocks(Poly1305* ctx, 
-			const unsigned char *msgData,
-                     	size_t msgDataLen)
+static void armv8_32_poly1305_blocks(Poly1305* ctx,
+    const unsigned char *msgData, size_t msgDataLen)
 {
-	/* these variables will be referenced via r7 in the assembly */
-	unsigned r[5], *r_ptrLocal, h[5], *h_ptrLocal;
-	unsigned msgDataOnStack = (unsigned)msgData;
-	unsigned msgDataLenOnStack = msgDataLen;
- 	unsigned hibitOnStack = (ctx->finished) ? 0 : ((unsigned) 1 << 24); /* 1 << 128 */
+    /* these variables will be referenced via r7 in the assembly */
+    word32 r[5], *r_ptrLocal, h[5], *h_ptrLocal;
+    word32 msgDataOnStack = (word32)msgData;
+    word32 msgDataLenOnStack = msgDataLen;
+    /* 1 << 128 */
+    word32 hibitOnStack = (ctx->finished) ? 0 : ((word32) 1 << 24);
 
-	memcpy(r, ctx->r, 5 * sizeof(unsigned));
-	memcpy(h, ctx->h, 5 * sizeof(unsigned));
+    memcpy(r, ctx->r, 5 * sizeof(word32));
+    memcpy(h, ctx->h, 5 * sizeof(word32));
 
-	/* 32 bit pointer, this is necessary to pass the pointer value
+    /* 32 bit pointer, this is necessary to pass the pointer value
            into the assembly code */
-	r_ptrLocal = (unsigned *) r;
-	h_ptrLocal = (unsigned *) h;
+    r_ptrLocal = (word32 *) r;
+    h_ptrLocal = (word32 *) h;
 
 #ifdef POLY1305_VERBOSE
-	int i;
-	for (i=0;i<5;++i) printf("h%d %07X ", i, h[i]);
-	printf("\n");
+    int i;
+    for (i=0;i<5;++i) printf("h%d %07X ", i, h[i]);
+    printf("\n");
 
-	printf("armv8_32_poly1305_blocks() data len %d\n", msgDataLen);
+    printf("armv8_32_poly1305_blocks() data len %d\n", msgDataLen);
 #endif
 
-	__asm__ __volatile__ (
-		".align	8				\n\t"
-		
-		/* valid registers are r0..r12, sp, lr, pc, cpsr, fpscr */
-		
-		/* now load the stored h, this should all zero */
-		"LDR	r5, %[h_ptr]			\n\t"
-		"LDM	r5, { r6, r8, r9, r10, r11 }	\n\t"
-		/* r6 = h0  r8 = h1  r9 = h2  r10 = h3  r11 = h4 */
-	
-		/* in some cases, r7 is used to reference the local variables 
-		   on the stack; if -O2 is passed to gcc, the sp may used 
-	     	   used to reference local variables. */
-		"LDR 	r0, %[bytes]			\n\t"
-		"LDR 	r1, %[r_ptr]			\n\t"
-		"LDR	r2, %[hibit]			\n\t"
-		"LDR	r5, %[m]			\n\t"
+    __asm__ __volatile__ (
+        ".align    8                \n\t"
 
-		"PUSH	{ r7 }				\n\t"
-		"SUB	sp, #28				\n\t"
-		
-		/* -O2 gcc parameters means r7 is not used for local
+        /* valid registers are r0..r12, sp, lr, pc, cpsr, fpscr */
+
+        /* now load the stored h, this should all zero */
+        "LDR	r5, %[h_ptr]            \n\t"
+        "LDM	r5, { r6, r8, r9, r10, r11 }    \n\t"
+        /* r6 = h0  r8 = h1  r9 = h2  r10 = h3  r11 = h4 */
+
+        /* in some cases, r7 is used to reference the local variables
+           on the stack; if -O2 is passed to gcc, the sp may used
+                used to reference local variables. */
+        "LDR	r0, %[bytes]            \n\t"
+        "LDR	r1, %[r_ptr]            \n\t"
+        "LDR	r2, %[hibit]            \n\t"
+        "LDR	r5, %[m]            \n\t"
+
+        "PUSH	{ r7 }                \n\t"
+        "SUB	sp, #28                \n\t"
+
+        /* -O2 gcc parameters means r7 is not used for local
                    variables, but sp is used for local variables */
-		/* free up r7 by moving variables referenced
-		   via r7 to recently allocated stack space */
-		"STR	r0, [sp, %[BYTES_STORE]]	\n\t"
-		"STR	r2, [sp, %[HIBIT_LOCAL]]	\n\t"
-
-		"LDM	r1, { r0, r1, r2, r3, r4 }	\n\t"
-		"STM	sp, { r0, r1, r2, r3, r4 }	\n\t"
-
-		"MOV	r7, r5				\n\t"
-
-	"armv8_32_poly1305_loop:				\n\t"
-
-		/* The poly1305 algorithm requires that a 01 byte 
-		   be placed after the last byte of the block. */ 		
-		
-		"LDR	r5, [sp, %[BYTES_STORE]]	\n\t"  // mem 1
-		"CMP	r5, #0				\n\t"
-		"BEQ	armv8_32_poly1305_done		\n\t"
-		"SUBS 	r5, r5, #16			\n\t"
-		
-		/* branch for least likely case, may help with pipelining */
-		/* ARMv8 uses predictive pipelining.  There is no way
-		   to specify in the instruction encoding the more likely
-		   case.  */
-		"BLT	armv8_32_poly1305_last_block	\n\t"  
-
-		/* this block is 16 bytes */
-		"STR	r5, [sp, %[BYTES_STORE]]	\n\t"  // mem 2
-
-		/* load next 16 byte block of message */		
-		"LDM	r7, { r0, r1, r2, r3 }		\n\t"  // mem 3
-		"ADD	r7, r7, #16			\n\t"
-
-		/* in RFC 7539, each block processed is prepended by
-  		   a byte of value 0x01.  In the wolfSSL implementation,
-		   the setting of this value is based on the value found
-		   in ctx->finish. To save a memory reference, this code
-		   could be replicated one version adding the byte, one
-		   version not. */
-
-		/* This is byte 16, past the 128 bits of w19:w18:w17:w16 
-		   Hence, update is done to h4. */  
-		"LDR	r5, [sp, %[HIBIT_LOCAL]]	\n\t"	// mem 4
-		"ADD	r11, r11, r5 			\n\t"
-			
-	"armv8_32_poly1305_done_01_byte_appended:	\n\t"
-
-		"mov	r5, #0x3FFFFFF			\n\t"
-
-		/* break data into 26 bit pieces. 
-		   Bit offsets are 0, 26, 52, 78 and 104 */
-		   
-		/* h0 += r0 & 0x3FFFFFF; */
-		"AND	r12, r0, r5			\n\t"
-		"ADD	r6, r6, r12			\n\t"
-		/* h1 += (r1:r0 >> 26) & 0x3FFFFFF */
-		"LSR	r12, r0, #26			\n\t"	/* 26 */
-		"ADD	r12, r12, r1, LSL #6		\n\t"
-		"AND 	r12, r12, r5			\n\t"
-		"ADD	r8, r8, r12			\n\t"
-		/* h2 += (r2:r1 >> 20) & 0x3FFFFFF */
-		"LSR	r12, r1, #20			\n\t"   /* 20+32 = 52 */
-		"ADD	r12, r12, r2, LSL #12		\n\t"
-		"AND 	r12, r12, r5			\n\t"
-		"ADD	r9, r9, r12			\n\t"
-		/* h3 += (r3:r2 >> 14) & 0x3FFFFFF */
-		"LSR	r12, r2, #14			\n\t"	/* 14+32+32 = 78 */
-		"ADD	r12, r12, r3, LSL #18		\n\t"
-		"AND 	r12, r12, r5			\n\t"
-		"ADD	r10, r10, r12			\n\t"
-		/* h4 += r3 >> 8	           */
-		"ADD	r11, r11, r3, LSR #8		\n\t"	/* 8+32+32+32 = 104 */
-
-		/* pull in the 26 bit components of the r key */
-		"LDM	sp, { r0, r1, r2, r3, r4 } 	\n\t"	// mem 5
-		/* r0 = BED685  r1 = 3555502  r2 = 47C036  r3 = 1003949  r4 = 806D5 */
-		
-		"MOV	r5, #5				\n\t"
-
-	"checkRegs:					\n\t"
-		/* d0 = h0 * r0 + h1 * 5*r4 + h2 * 5*r3 + h3 * 5*r2 + h4 * 5*r1 */
-		/* d1 = h0 * r1 + h1 * r0   + h2 * 5*r4 + h3 * 5*r3 + h4 * 5*r2 */
-		/* d2 = h0 * r2 + h1 * r1   + h2 * r0   + h3 * 5*r4 + h4 * 5*r3 */
-		/* d3 = h0 * r3 + h1 * r2   + h2 * r1   + h3 * r0   + h4 * 5*r4 */
-		/* d4 = h0 * r4 + h1 * r3   + h2 * r2   + h3 * r1   + h4 * r0   */
-
-		/*  r14 is the link register, r13 is the sp */
-		/*  r14:r12 = r6 * r0 + (r8 * r4 +  r9 * r3 +  r10 * r2 +  r11 * r1) * r5 */
-		/*  r14:r12 = r6 * r1 +  r8 * r0 + (r9 * r4 +  r10 * r3 +  r11 * r2) * r5 */
-		/*  r14:r12 = r6 * r2 +  r8 * r1 +  r9 * r0 + (r10 * r4 +  r11 * r3) * r5 */
-		/*  r14:r12 = r6 * r3 +  r8 * r2 +  r9 * r1 +  r10 * r0 + (r11 * r4) * r5 */
-		/*  r14:r12 = r6 * r4 +  r8 * r3 +  r9 * r2 +  r10 * r1 +  r11 * r0       */
-
-		/* d4 */
-		"UMULL	r12, r14, r6, r4		\n\t"
-		"UMLAL 	r12, r14, r8, r3		\n\t"
-		"UMLAL 	r12, r14, r9, r2		\n\t"
-		"UMLAL 	r12, r14, r10, r1		\n\t"
-		"UMLAL 	r12, r14, r11, r0		\n\t"
-
-		"PUSH   { r12, r14 }			\n\t"	// mem 6
+        /* free up r7 by moving variables referenced
+           via r7 to recently allocated stack space */
+        "STR	r0, [sp, %[BYTES_STORE]]    \n\t"
+        "STR	r2, [sp, %[HIBIT_LOCAL]]    \n\t"
+
+        "LDM	r1, { r0, r1, r2, r3, r4 }    \n\t"
+        "STM	sp, { r0, r1, r2, r3, r4 }    \n\t"
+
+        "MOV	r7, r5                \n\t"
+
+    "armv8_32_poly1305_loop:                \n\t"
+
+        /* The poly1305 algorithm requires that a 01 byte
+           be placed after the last byte of the block. */
+
+        "LDR	r5, [sp, %[BYTES_STORE]]    \n\t"  /* mem 1 */
+        "CMP	r5, #0                \n\t"
+        "BEQ	armv8_32_poly1305_done        \n\t"
+        "SUBS	r5, r5, #16            \n\t"
+
+        /* branch for least likely case, may help with pipelining */
+        /* ARMv8 uses predictive pipelining.  There is no way
+           to specify in the instruction encoding the more likely
+           case.  */
+        "BLT	armv8_32_poly1305_last_block    \n\t"
+
+        /* this block is 16 bytes */
+        "STR	r5, [sp, %[BYTES_STORE]]    \n\t"  /* mem 2 */
+
+        /* load next 16 byte block of message */
+        "LDM	r7, { r0, r1, r2, r3 }        \n\t"  /* mem 3 */
+        "ADD	r7, r7, #16            \n\t"
+
+        /* in RFC 7539, each block processed is prepended by
+             a byte of value 0x01.  In the wolfSSL implementation,
+           the setting of this value is based on the value found
+           in ctx->finish. To save a memory reference, this code
+           could be replicated one version adding the byte, one
+           version not. */
+
+        /* This is byte 16, past the 128 bits of w19:w18:w17:w16
+           Hence, update is done to h4. */
+        "LDR	r5, [sp, %[HIBIT_LOCAL]]    \n\t"    /* mem 4 */
+        "ADD	r11, r11, r5             \n\t"
+
+    "armv8_32_poly1305_done_01_byte_appended:    \n\t"
+
+        "mov	r5, #0x3FFFFFF            \n\t"
+
+        /* break data into 26 bit pieces.
+           Bit offsets are 0, 26, 52, 78 and 104 */
+
+        /* h0 += r0 & 0x3FFFFFF; */
+        "AND	r12, r0, r5            \n\t"
+        "ADD	r6, r6, r12            \n\t"
+        /* h1 += (r1:r0 >> 26) & 0x3FFFFFF */
+        "LSR	r12, r0, #26            \n\t"    /* 26 */
+        "ADD	r12, r12, r1, LSL #6        \n\t"
+        "AND	r12, r12, r5            \n\t"
+        "ADD	r8, r8, r12            \n\t"
+        /* h2 += (r2:r1 >> 20) & 0x3FFFFFF */
+        "LSR	r12, r1, #20            \n\t"   /* 20+32 = 52 */
+        "ADD	r12, r12, r2, LSL #12        \n\t"
+        "AND	r12, r12, r5            \n\t"
+        "ADD	r9, r9, r12            \n\t"
+        /* h3 += (r3:r2 >> 14) & 0x3FFFFFF */
+        "LSR	r12, r2, #14            \n\t"    /* 14+32+32 = 78 */
+        "ADD	r12, r12, r3, LSL #18        \n\t"
+        "AND	r12, r12, r5            \n\t"
+        "ADD	r10, r10, r12            \n\t"
+        /* h4 += r3 >> 8               */
+        "ADD	r11, r11, r3, LSR #8        \n\t"    /* 8+32+32+32 = 104 */
+
+        /* pull in the 26 bit components of the r key */
+        "LDM	sp, { r0, r1, r2, r3, r4 }     \n\t"    /* mem 5 */
+        /* r0 = BED685  r1 = 3555502  r2 = 47C036  r3 = 1003949  r4 = 806D5 */
+
+        "MOV	r5, #5                \n\t"
+
+    "checkRegs:                    \n\t"
+        /* d0 = h0 * r0 + h1 * 5*r4 + h2 * 5*r3 + h3 * 5*r2 + h4 * 5*r1 */
+        /* d1 = h0 * r1 + h1 * r0   + h2 * 5*r4 + h3 * 5*r3 + h4 * 5*r2 */
+        /* d2 = h0 * r2 + h1 * r1   + h2 * r0   + h3 * 5*r4 + h4 * 5*r3 */
+        /* d3 = h0 * r3 + h1 * r2   + h2 * r1   + h3 * r0   + h4 * 5*r4 */
+        /* d4 = h0 * r4 + h1 * r3   + h2 * r2   + h3 * r1   + h4 * r0   */
+
+        /*  r14 is the link register, r13 is the sp */
+        /*  r14:r12 = r6 * r0 + (r8 * r4 +  r9 * r3 +  r10 * r2 +  r11 * r1) * r5 */
+        /*  r14:r12 = r6 * r1 +  r8 * r0 + (r9 * r4 +  r10 * r3 +  r11 * r2) * r5 */
+        /*  r14:r12 = r6 * r2 +  r8 * r1 +  r9 * r0 + (r10 * r4 +  r11 * r3) * r5 */
+        /*  r14:r12 = r6 * r3 +  r8 * r2 +  r9 * r1 +  r10 * r0 + (r11 * r4) * r5 */
+        /*  r14:r12 = r6 * r4 +  r8 * r3 +  r9 * r2 +  r10 * r1 +  r11 * r0       */
+
+        /* d4 */
+        "UMULL	r12, r14, r6, r4        \n\t"
+        "UMLAL	r12, r14, r8, r3        \n\t"
+        "UMLAL	r12, r14, r9, r2        \n\t"
+        "UMLAL	r12, r14, r10, r1        \n\t"
+        "UMLAL	r12, r14, r11, r0        \n\t"
+
+        "PUSH	{ r12, r14 }            \n\t"    /* mem 6 */
 
-		/* 8F852 C3AB3DA1 */
+        /* 8F852 C3AB3DA1 */
 
-		/* d3 */
-		"UMULL	r12, r14, r6, r3		\n\t"
-		"UMLAL 	r12, r14, r8, r2		\n\t"
-		"UMLAL 	r12, r14, r9, r1		\n\t"
-		"UMLAL 	r12, r14, r10, r0		\n\t"
-		"MUL	r11, r11, r5			\n\t"
-		"UMLAL 	r12, r14, r11, r4		\n\t"
+        /* d3 */
+        "UMULL	r12, r14, r6, r3        \n\t"
+        "UMLAL	r12, r14, r8, r2        \n\t"
+        "UMLAL	r12, r14, r9, r1        \n\t"
+        "UMLAL	r12, r14, r10, r0        \n\t"
+        "MUL	r11, r11, r5            \n\t"
+        "UMLAL	r12, r14, r11, r4        \n\t"
 
-		"PUSH   { r12, r14 }			\n\t"	// mem 7
+        "PUSH	{ r12, r14 }            \n\t"    /* mem 7 */
 
-		/* C753B 56120E14 */
+        /* C753B 56120E14 */
 
-		/* d2 */
-		"UMULL	r12, r14, r6, r2		\n\t"
-		"UMLAL 	r12, r14, r8, r1		\n\t"
-		"UMLAL 	r12, r14, r9, r0		\n\t"
-		"MUL	r10, r10, r5			\n\t"
-		"UMLAL 	r12, r14, r10, r4		\n\t"
-		"UMLAL 	r12, r14, r11, r3		\n\t"
+        /* d2 */
+        "UMULL	r12, r14, r6, r2        \n\t"
+        "UMLAL	r12, r14, r8, r1        \n\t"
+        "UMLAL	r12, r14, r9, r0        \n\t"
+        "MUL	r10, r10, r5            \n\t"
+        "UMLAL	r12, r14, r10, r4        \n\t"
+        "UMLAL	r12, r14, r11, r3        \n\t"
 
-		"PUSH   { r12, r14 }			\n\t"	// mem 8
+        "PUSH	{ r12, r14 }            \n\t"    /* mem 8 */
 
-		/* 10019D F79AAF81 */
+        /* 10019D F79AAF81 */
 
-		/* d1 */
-		"UMULL	r12, r14, r6, r1		\n\t"
-		"UMLAL 	r12, r14, r8, r0		\n\t"
-		"MUL	r9, r9, r5			\n\t"
-		"UMLAL 	r12, r14, r9, r4		\n\t"
-		"UMLAL 	r12, r14, r10, r3		\n\t"
-		"UMLAL 	r12, r14, r11, r2		\n\t"
+        /* d1 */
+        "UMULL	r12, r14, r6, r1        \n\t"
+        "UMLAL	r12, r14, r8, r0        \n\t"
+        "MUL	r9, r9, r5            \n\t"
+        "UMLAL	r12, r14, r9, r4        \n\t"
+        "UMLAL	r12, r14, r10, r3        \n\t"
+        "UMLAL	r12, r14, r11, r2        \n\t"
 
-		"PUSH   { r12, r14 }			\n\t"	// mem 9
+        "PUSH	{ r12, r14 }            \n\t"    /* mem 9 */
 
-		/* D3993 E9038575 */
+        /* D3993 E9038575 */
 
-		/* d0 */
-		"UMULL	r12, r14, r6, r0		\n\t"
-		"MUL	r8, r8, r5			\n\t"
-		"UMLAL 	r12, r14, r8, r4		\n\t"
-		"UMLAL 	r12, r14, r9, r3		\n\t"
-		"UMLAL 	r12, r14, r10, r2		\n\t"
-		"UMLAL 	r12, r14, r11, r1		\n\t"
+        /* d0 */
+        "UMULL	r12, r14, r6, r0        \n\t"
+        "MUL	r8, r8, r5            \n\t"
+        "UMLAL	r12, r14, r8, r4        \n\t"
+        "UMLAL	r12, r14, r9, r3        \n\t"
+        "UMLAL	r12, r14, r10, r2        \n\t"
+        "UMLAL	r12, r14, r11, r1        \n\t"
 
-		/* 29DD73 07661C87 */
+        /* 29DD73 07661C87 */
 
 
-		/* registers r6, r8, r9, r10, r11 must be 
-		   populated with above results after accounting 
-		   for overflow past 26 bit. */
+        /* registers r6, r8, r9, r10, r11 must be
+           populated with above results after accounting
+           for overflow past 26 bit. */
 
-		/* doing d0 --> d1 --> d2 --> d3 --> d4 --> d1 -->d2 */
+        /* doing d0 --> d1 --> d2 --> d3 --> d4 --> d1 -->d2 */
 
-		"MOV	r5, #0x3FFFFFF			\n\t"
-		"AND	r6, r12, r5			\n\t"	/* d0 */
+        "MOV	r5, #0x3FFFFFF            \n\t"
+        "AND	r6, r12, r5            \n\t"    /* d0 */
 
-		/* d0 overflow to d1 */
-		"POP	{ r0, r1, r2, r3, r4, r9, r10, r11 }	\n\t"	// mem 10
+        /* d0 overflow to d1 */
+        "POP	{ r0, r1, r2, r3, r4, r9, r10, r11 }    \n\t"    /* mem 10 */
 
-		"ADDS	r0, r0, r12, LSR #26		\n\t"
-		"ADC	r1, r1, #0			\n\t"
-		"ADDS	r0, r0, r14, LSL #6		\n\t"
-		"ADC	r1, r1, #0			\n\t"
+        "ADDS	r0, r0, r12, LSR #26        \n\t"
+        "ADC	r1, r1, #0            \n\t"
+        "ADDS	r0, r0, r14, LSL #6        \n\t"
+        "ADC	r1, r1, #0            \n\t"
 
-		"AND	r8, r0, r5			\n\t"   /* d1 */
+        "AND	r8, r0, r5            \n\t"   /* d1 */
 
-		/* d1 overflow to d2 */
+        /* d1 overflow to d2 */
 
-		"ADDS	r2, r2, r0, LSR #26		\n\t"
-		"ADC	r3, r3, #0			\n\t"
-		"ADDS	r2, r2, r1, LSL #6		\n\t"
-		"ADC	r3, r3, #0			\n\t"
+        "ADDS	r2, r2, r0, LSR #26        \n\t"
+        "ADC	r3, r3, #0            \n\t"
+        "ADDS	r2, r2, r1, LSL #6        \n\t"
+        "ADC	r3, r3, #0            \n\t"
 
-		"MOV    r0, r9				\n\t"
+        "MOV	r0, r9                \n\t"
 
-		"AND	r9, r2, r5			\n\t"	/* d2 */
+        "AND	r9, r2, r5            \n\t"    /* d2 */
 
-		/* d2 overflow to d3 */
+        /* d2 overflow to d3 */
 
-		"ADDS	r4, r4, r2, LSR #26		\n\t"
-		"ADC	r0, r0, #0			\n\t"
-		"ADDS	r4, r4, r3, LSL #6		\n\t"
-		"ADC	r0, r0, #0			\n\t"
+        "ADDS	r4, r4, r2, LSR #26        \n\t"
+        "ADC	r0, r0, #0            \n\t"
+        "ADDS	r4, r4, r3, LSL #6        \n\t"
+        "ADC	r0, r0, #0            \n\t"
 
-		/* d3 overflow to d4 */
+        /* d3 overflow to d4 */
 
-		"ADDS	r10, r10, r4, LSR #26		\n\t"
-		"ADC	r11, r11, #0			\n\t"
-		"ADDS	r10, r10, r0, LSL #6		\n\t"
-		"ADC	r11, r11, #0			\n\t"
+        "ADDS	r10, r10, r4, LSR #26        \n\t"
+        "ADC	r11, r11, #0            \n\t"
+        "ADDS	r10, r10, r0, LSL #6        \n\t"
+        "ADC	r11, r11, #0            \n\t"
 
-		/* d4 overflow to d0, must be multiplied by 5 */	
+        /* d4 overflow to d0, must be multiplied by 5 */
 
-		"LSR	r0, r10, #26			\n\t"
-		"ADD	r0, r0, r11, LSL #6		\n\t"
-		"MOV	r1, #5				\n\t"	
-		"MUL	r0, r0, r1			\n\t"
-		"ADD	r6, r6, r0			\n\t"
+        "LSR	r0, r10, #26            \n\t"
+        "ADD	r0, r0, r11, LSL #6        \n\t"
+        "MOV	r1, #5                \n\t"
+        "MUL	r0, r0, r1            \n\t"
+        "ADD	r6, r6, r0            \n\t"
 
-		"AND	r11, r10, r5			\n\t"	/* d4 */
+        "AND	r11, r10, r5            \n\t"    /* d4 */
 
-		"AND	r10, r4, r5			\n\t"	/* d3 */
+        "AND	r10, r4, r5            \n\t"    /* d3 */
 
-		/* d0 overflow to d1 */
+        /* d0 overflow to d1 */
 
-		"ADD	r8, r8, r6, LSR #26		\n\t"	/* d1 done */
+        "ADD	r8, r8, r6, LSR #26        \n\t"    /* d1 done */
 
-		"AND	r6, r6, r5			\n\t"	/* d0 done */	
+        "AND	r6, r6, r5            \n\t"    /* d0 done */
 
-		"B	armv8_32_poly1305_loop		\n\t"
-	
-	"armv8_32_poly1305_last_block:			\n\t"
+        "B	armv8_32_poly1305_loop        \n\t"
 
-		/* This is the last block of the message
-		   and the block is less than 16 bytes */
-		"MOV 	r0, #0				\n\t"
-		"STR	r0, [sp, %[BYTES_STORE]]	\n\t"
-	
-		"LDR	r0, [sp, %[HIBIT_LOCAL]]	\n\t"
+    "armv8_32_poly1305_last_block:            \n\t"
 
-		/* Make sure the upper bytes of the 
-		   32 bit pieces are set to zero. 
-		   Set the byte past the last message
-		   data byte to 01. */
+        /* This is the last block of the message
+           and the block is less than 16 bytes */
+        "MOV	r0, #0                \n\t"
+        "STR	r0, [sp, %[BYTES_STORE]]    \n\t"
 
-		"PUSH	{ r4, r6, r8 } 			\n\t"	
+        "LDR	r0, [sp, %[HIBIT_LOCAL]]    \n\t"
 
-		"MOV    r1,  #0				\n\t"
-		"MOV	r2,  #0				\n\t"
-		"MOV	r3,  #0				\n\t"
-		"MOV	r4,  #0xFFFFFFFF		\n\t"
-		"LSR	r0, r0, #24			\n\t"
-		"MOV	r6,  r0				\n\t"
+        /* Make sure the upper bytes of the
+           32 bit pieces are set to zero.
+           Set the byte past the last message
+           data byte to 01. */
 
-		/* always going to load at least one */		
-		"LDR	r0, [r7]			\n\t"
+        "PUSH	{ r4, r6, r8 }             \n\t"
 
-		/* byte offset to bit offset */ 
-		"ADD	r5, r5, #16			\n\t"
-		"LSL	r5, r5, #3			\n\t"			
+        "MOV	r1,  #0                \n\t"
+        "MOV	r2,  #0                \n\t"
+        "MOV	r3,  #0                \n\t"
+        "MOV	r4,  #0xFFFFFFFF        \n\t"
+        "LSR	r0, r0, #24            \n\t"
+        "MOV	r6,  r0                \n\t"
 
-		/* which block */
-		"CMP	r5, #32				\n\t"
-		"BGE	not_word_0			\n\t"
+        /* always going to load at least one */
+        "LDR	r0, [r7]            \n\t"
 
-		/* case word 0 */
-	"case0:"
-		"LSL	r8, r4, r5			\n\t"
-		"BIC  	r0, r0, r8			\n\t"
-		"LSL	r8, r6, r5			\n\t"
-		"ADD	r0, r0, r8			\n\t"
-		"B	last_block_done			\n\t"
+        /* byte offset to bit offset */
+        "ADD	r5, r5, #16            \n\t"
+        "LSL	r5, r5, #3            \n\t"
 
-	"not_word_0:	 				\n\t"
-		"LDR	r1, [r7, #4]			\n\t"
-		
-		"SUB	r5, r5, #32			\n\t"
-		"CMP	r5, #32				\n\t"
-		"BGE	not_word_1			\n\t"
+        /* which block */
+        "CMP	r5, #32                \n\t"
+        "BGE	not_word_0            \n\t"
 
-		"LSL	r8, r4, r5			\n\t"
-		"BIC  	r1, r1, r8			\n\t"
-		"LSL	r8, r6, r5			\n\t"
-		"ADD	r1, r1, r8			\n\t"		
-		"B	last_block_done			\n\t"
+        /* case word 0 */
+    "case0:"
+        "LSL	r8, r4, r5            \n\t"
+        "BIC	r0, r0, r8            \n\t"
+        "LSL	r8, r6, r5            \n\t"
+        "ADD	r0, r0, r8            \n\t"
+        "B	last_block_done            \n\t"
 
-	"not_word_1:					\n\t"
-		"LDR	r2, [r7, #8]			\n\t"
+    "not_word_0:                     \n\t"
+        "LDR	r1, [r7, #4]            \n\t"
 
-		"SUB	r5, r5, #32			\n\t"
-		"CMP	r5, #32				\n\t"
-		"BGE	not_word_2			\n\t"
+        "SUB	r5, r5, #32            \n\t"
+        "CMP	r5, #32                \n\t"
+        "BGE	not_word_1            \n\t"
 
-		"LSL	r8, r4, r5			\n\t"
-		"BIC  	r2, r2, r8			\n\t"
-		"LSL	r8, r6, r5			\n\t"
-		"ADD	r2, r2, r8			\n\t"		
-		"B	last_block_done			\n\t"
+        "LSL	r8, r4, r5            \n\t"
+        "BIC	r1, r1, r8            \n\t"
+        "LSL	r8, r6, r5            \n\t"
+        "ADD	r1, r1, r8            \n\t"
+        "B	last_block_done            \n\t"
 
-	"not_word_2:					\n\t"
-		"LDR	r3, [r7, #0xC]			\n\t"
+    "not_word_1:                    \n\t"
+        "LDR	r2, [r7, #8]            \n\t"
 
-		"SUB	r5, r5, #32			\n\t"
+        "SUB	r5, r5, #32            \n\t"
+        "CMP	r5, #32                \n\t"
+        "BGE	not_word_2            \n\t"
 
-		"LSL	r8, r4, r5			\n\t"
-		"BIC  	r3, r3, r8			\n\t"
-		"LSL	r8, r6, r5			\n\t"
-		"ADD	r3, r3, r8			\n\t"	
+        "LSL	r8, r4, r5            \n\t"
+        "BIC	r2, r2, r8            \n\t"
+        "LSL	r8, r6, r5            \n\t"
+        "ADD	r2, r2, r8            \n\t"
+        "B	last_block_done            \n\t"
 
-	"last_block_done:				\n\t"
+    "not_word_2:                    \n\t"
+        "LDR	r3, [r7, #0xC]            \n\t"
 
-		"POP	{ r4, r6, r8 } 			\n\t"	
-	
-		"b 	armv8_32_poly1305_done_01_byte_appended \n\t"
-	
-		".align 2 \n\t"
-	"armv8_32_poly1305_done:				\n\t"
+        "SUB	r5, r5, #32            \n\t"
 
-		"ADD	sp, #28				\n\t"
-		"POP	{ r7 }				\n\t"
+        "LSL	r8, r4, r5            \n\t"
+        "BIC	r3, r3, r8            \n\t"
+        "LSL	r8, r6, r5            \n\t"
+        "ADD	r3, r3, r8            \n\t"
 
-		/* store final result */
-		"LDR	r0, %[h_ptr]			\n\t"
-		"STM	r0, { r6, r8, r9, r10, r11 } 	\n\t"
-		
-		: [m] 		  "+m" (msgDataOnStack),	/* input */
-		  [r_ptr]  	  "+m" (r_ptrLocal),		/* input */
-		  [h_ptr]  	  "+m" (h_ptrLocal),		/* input, output */
-		  [bytes]  	  "+m" (msgDataLenOnStack),	/* input */
-		  [hibit]	  "+m" (hibitOnStack)		/* input */
-		  
-		: [BYTES_STORE]    "I" (BYTES_SP_OFF),
-		  [HIBIT_LOCAL]    "I" (HIBIT_LOCAL_SP_OFF)
-		: "memory", "cc", 
-			"r0", "r1", "r2", "r3", "r4", "r5", "r6", "r8", "r9", "r10",
-			"r11", "r12", "lr"
-	);
+    "last_block_done:                \n\t"
 
-	memcpy(ctx->r, r, 5 * sizeof(unsigned));
-	memcpy(ctx->h, h, 5 * sizeof(unsigned));
+        "POP	{ r4, r6, r8 }             \n\t"
+
+        "b	armv8_32_poly1305_done_01_byte_appended \n\t"
+
+        ".align 2 \n\t"
+    "armv8_32_poly1305_done:                \n\t"
+
+        "ADD	sp, #28                \n\t"
+        "POP	{ r7 }                \n\t"
+
+        /* store final result */
+        "LDR	r0, %[h_ptr]            \n\t"
+        "STM	r0, { r6, r8, r9, r10, r11 }     \n\t"
+
+        : [m]     "+m" (msgDataOnStack),    /* input */
+          [r_ptr] "+m" (r_ptrLocal),        /* input */
+          [h_ptr] "+m" (h_ptrLocal),        /* input, output */
+          [bytes] "+m" (msgDataLenOnStack),    /* input */
+          [hibit] "+m" (hibitOnStack)        /* input */
+
+        : [BYTES_STORE] "I" (BYTES_SP_OFF),
+          [HIBIT_LOCAL] "I" (HIBIT_LOCAL_SP_OFF)
+        : "memory", "cc",
+            "r0", "r1", "r2", "r3", "r4", "r5", "r6", "r8", "r9", "r10",
+            "r11", "r12", "lr"
+    );
+
+    memcpy(ctx->r, r, 5 * sizeof(word32));
+    memcpy(ctx->h, h, 5 * sizeof(word32));
 
 #ifdef POLY1305_VERBOSE
-	for (i=0;i<5;++i) printf("h%d %07X ", i, ctx->h[i]);
-	printf("\n");
+    for (i=0;i<5;++i) printf("h%d %07X ", i, ctx->h[i]);
+    printf("\n");
 
-	printf("armv8_32_poly1305_blocks() leaving\n");
+    printf("armv8_32_poly1305_blocks() leaving\n");
 #endif
 
 }
 #else
 
 /**********************************************************
-  armv8_32_poly1305_blocks	This routine implements the 
-			poly1305 algorithm.  The processing
-			of the 16 byte pieces of the 
-			message is implemented in assembly.
-			Care was taken in implementing the
-			assembly to optimize speed by 
-			minimizing memory references as
-			well as minimizing instructions.
-			The poly1305 algorithm is implemented
-			by using multiple 26 bit values 
-			to represent the larger 16 byte and 
-			17 byte numbers.  Breaking the 
-			larger numbers down into 26 bit 
-			pieces means that math operations will
-			not overflow the 32 bit registers.
-			For more information reference the article 
-			NEON Cryto by Daniel Berstein and Peter
-			Schwabe.
-			
-			This version of the algorithm uses 
-			NEON s registers to temporarily store
-			values so that the stack does not need
-			to be used.
+  armv8_32_poly1305_blocks    This routine implements the
+            poly1305 algorithm.  The processing
+            of the 16 byte pieces of the
+            message is implemented in assembly.
+            Care was taken in implementing the
+            assembly to optimize speed by
+            minimizing memory references as
+            well as minimizing instructions.
+            The poly1305 algorithm is implemented
+            by using multiple 26 bit values
+            to represent the larger 16 byte and
+            17 byte numbers.  Breaking the
+            larger numbers down into 26 bit
+            pieces means that math operations will
+            not overflow the 32 bit registers.
+            For more information reference the article
+            NEON Cryto by Daniel Berstein and Peter
+            Schwabe.
 
-  ctx			poly1305 structure containing the r and
-		 	h values broke into 26 bit pieces.
-			The result of this routine is returned
-			int the h array of 26 bit values.
-  msgData		Message data to run the algorithm 
-			against.
-  keyData		256 bit key that is broken down 
-			into the r and s subcomponents.
+            This version of the algorithm uses
+            NEON s registers to temporarily store
+            values so that the stack does not need
+            to be used.
+
+  ctx            poly1305 structure containing the r and
+             h values broke into 26 bit pieces.
+            The result of this routine is returned
+            int the h array of 26 bit values.
+  msgData        Message data to run the algorithm
+            against.
+  keyData        256 bit key that is broken down
+            into the r and s subcomponents.
 **********************************************************/
-void armv8_32_poly1305_blocks(Poly1305* ctx, 
-			const unsigned char *msgData,
-                     	size_t msgDataLen)
+static void armv8_32_poly1305_blocks(Poly1305* ctx,
+    const unsigned char *msgData, size_t msgDataLen)
 {
-	/* these variables will be referenced via r7 in the assembly */
-	unsigned r[5], *r_ptrLocal, h[5], *h_ptrLocal;
-	unsigned msgDataOnStack = (unsigned)msgData;
-	unsigned msgDataLenOnStack = msgDataLen;
- 	unsigned hibitOnStack = (ctx->finished) ? 0 : ((unsigned) 1 << 24); /* 1 << 128 */
+    /* these variables will be referenced via r7 in the assembly */
+    word32 r[5], *r_ptrLocal, h[5], *h_ptrLocal;
+    word32 msgDataOnStack = (word32)msgData;
+    word32 msgDataLenOnStack = msgDataLen;
+    /* 1 << 128 */
+    word32 hibitOnStack = (ctx->finished) ? 0 : ((word32) 1 << 24);
 
-	memcpy(r, ctx->r, 5 * sizeof(unsigned));
-	memcpy(h, ctx->h, 5 * sizeof(unsigned));
+    memcpy(r, ctx->r, 5 * sizeof(word32));
+    memcpy(h, ctx->h, 5 * sizeof(word32));
 
-	/* 32 bit pointer, this is necessary to pass the pointer value
+    /* 32 bit pointer, this is necessary to pass the pointer value
            into the assembly code */
-	r_ptrLocal = (unsigned *) r;
-	h_ptrLocal = (unsigned *) h;
+    r_ptrLocal = (word32 *) r;
+    h_ptrLocal = (word32 *) h;
 
 #ifdef POLY1305_VERBOSE
-	int i;
-	for (i=0;i<5;++i) printf("h%d %07X ", i, h[i]);
-	printf("\n");
+    int i;
+    for (i=0;i<5;++i) printf("h%d %07X ", i, h[i]);
+    printf("\n");
 
-	printf("armv8_32_poly1305_blocks() data len %d\n", msgDataLen);
+    printf("armv8_32_poly1305_blocks() data len %d\n", msgDataLen);
 #endif
 
-	__asm__ __volatile__ (
-		".align	8				\n\t"
-		
-		/* valid registers are r0..r12, sp, lr, pc, cpsr, fpscr */
-		
-		/* now load the stored h, this should all zero */
-		"LDR	r5, %[h_ptr]			\n\t"
-		"LDM	r5, { r6, r8, r9, r10, r11 }	\n\t"
-		/* r6 = h0  r8 = h1  r9 = h2  r10 = h3  r11 = h4 */
-	
-		/* in some cases, r7 is used to reference the local variables 
-		   on the stack; if -O2 is passed to gcc, the sp may used 
-	     	   used to reference local variables. */
-		"LDR	r0, %[hibit]			\n\t"
-		"LDR 	r1, %[bytes]			\n\t"
-		"LDR 	r2, %[r_ptr]			\n\t"
-
-		"VMOV	s2, r0				\n\t"
-		"VMOV   s4, r1				\n\t"
-
-		"LDM	r2, { r0, r1, r2, r3, r4 }	\n\t"
-		"VMOV	s6, r0				\n\t"
-		"VMOV	s7, r1				\n\t"
-		"VMOV	s8, r2				\n\t"
-		"VMOV	s9, r3				\n\t"
-		"VMOV	s10, r4				\n\t"
-
-		"LDR	r5, %[m]			\n\t"
-		"PUSH	{ r7 }				\n\t"
-		"MOV	r7, r5				\n\t"
-
-		/* s2 - hibit
-	 	   s4 - bytes
-	           s6, s7, s8, s9, s10 - r in 26 bit pieces */
-
-	"armv8_32_poly1305_loop:				\n\t"
-
-		/* The poly1305 algorithm requires that a 01 byte 
-		   be placed after the last byte of the block. */ 		
-		
-		"VMOV	r5, s4				\n\t"
-		"CMP	r5, #0				\n\t"
-		"BEQ	armv8_32_poly1305_done		\n\t"
-		"SUBS 	r5, r5, #16			\n\t"
-		
-		/* branch for least likely case, may help with pipelining */
-		/* ARMv8 uses predictive pipelining.  There is no way
-		   to specify in the instruction encoding the more likely
-		   case.  */
-		"BLT	armv8_32_poly1305_last_block	\n\t"  
-
-		/* this block is 16 bytes */
-		"VMOV	s4, r5				\n\t"
-
-		/* load next 16 byte block of message */		
-		"LDM	r7, { r0, r1, r2, r3 }		\n\t"  // mem 1
-		"ADD	r7, r7, #16			\n\t"
-
-		/* in RFC 7539, each block processed is prepended by
-  		   a byte of value 0x01.  In the wolfSSL implementation,
-		   the setting of this value is based on the value found
-		   in ctx->finish. To save a memory reference, this code
-		   could be replicated one version adding the byte, one
-		   version not. */
-
-		/* This is byte 16, past the 128 bits of w19:w18:w17:w16 
-		   Hence, update is done to h4. */  
-		/* add in hibit */
-		"VMOV	r5, s2				\n\t"
-		"ADD	r11, r11, r5 			\n\t"
-			
-	"armv8_32_poly1305_done_01_byte_appended:	\n\t"
-
-		"mov	r5, #0x3FFFFFF			\n\t"
-
-		/* break data into 26 bit pieces. 
-		   Bit offsets are 0, 26, 52, 78 and 104 */
-		   
-		/* h0 += r0 & 0x3FFFFFF; */
-		"AND	r12, r0, r5			\n\t"
-		"ADD	r6, r6, r12			\n\t"
-		/* h1 += (r1:r0 >> 26) & 0x3FFFFFF */
-		"LSR	r12, r0, #26			\n\t"	/* 26 */
-		"ADD	r12, r12, r1, LSL #6		\n\t"
-		"AND 	r12, r12, r5			\n\t"
-		"ADD	r8, r8, r12			\n\t"
-		/* h2 += (r2:r1 >> 20) & 0x3FFFFFF */
-		"LSR	r12, r1, #20			\n\t"   /* 20+32 = 52 */
-		"ADD	r12, r12, r2, LSL #12		\n\t"
-		"AND 	r12, r12, r5			\n\t"
-		"ADD	r9, r9, r12			\n\t"
-		/* h3 += (r3:r2 >> 14) & 0x3FFFFFF */
-		"LSR	r12, r2, #14			\n\t"	/* 14+32+32 = 78 */
-		"ADD	r12, r12, r3, LSL #18		\n\t"
-		"AND 	r12, r12, r5			\n\t"
-		"ADD	r10, r10, r12			\n\t"
-		/* h4 += r3 >> 8	           */
-		"ADD	r11, r11, r3, LSR #8		\n\t"	/* 8+32+32+32 = 104 */
-
-		/* pull in the 26 bit components of the r key */
-		"VMOV	r0, s6				\n\t"
-		"VMOV	r1, s7				\n\t"
-		"VMOV	r2, s8				\n\t"
-		"VMOV	r3, s9				\n\t"
-		"VMOV	r4, s10				\n\t"
-
-		/* r0 = BED685  r1 = 3555502  r2 = 47C036  r3 = 1003949  r4 = 806D5 */
-		"MOV	r5, #5				\n\t"
-
-	"checkRegs:					\n\t"
-		/* d0 = h0 * r0 + h1 * 5*r4 + h2 * 5*r3 + h3 * 5*r2 + h4 * 5*r1 */
-		/* d1 = h0 * r1 + h1 * r0   + h2 * 5*r4 + h3 * 5*r3 + h4 * 5*r2 */
-		/* d2 = h0 * r2 + h1 * r1   + h2 * r0   + h3 * 5*r4 + h4 * 5*r3 */
-		/* d3 = h0 * r3 + h1 * r2   + h2 * r1   + h3 * r0   + h4 * 5*r4 */
-		/* d4 = h0 * r4 + h1 * r3   + h2 * r2   + h3 * r1   + h4 * r0   */
-
-		/*  r14 is the link register, r13 is the sp */
-		/*  r14:r12 = r6 * r0 + (r8 * r4 +  r9 * r3 +  r10 * r2 +  r11 * r1) * r5 */
-		/*  r14:r12 = r6 * r1 +  r8 * r0 + (r9 * r4 +  r10 * r3 +  r11 * r2) * r5 */
-		/*  r14:r12 = r6 * r2 +  r8 * r1 +  r9 * r0 + (r10 * r4 +  r11 * r3) * r5 */
-		/*  r14:r12 = r6 * r3 +  r8 * r2 +  r9 * r1 +  r10 * r0 + (r11 * r4) * r5 */
-		/*  r14:r12 = r6 * r4 +  r8 * r3 +  r9 * r2 +  r10 * r1 +  r11 * r0       */
+    __asm__ __volatile__ (
+        ".align    8                \n\t"
+
+        /* valid registers are r0..r12, sp, lr, pc, cpsr, fpscr */
+
+        /* now load the stored h, this should all zero */
+        "LDR	r5, %[h_ptr]            \n\t"
+        "LDM	r5, { r6, r8, r9, r10, r11 }    \n\t"
+        /* r6 = h0  r8 = h1  r9 = h2  r10 = h3  r11 = h4 */
+
+        /* in some cases, r7 is used to reference the local variables
+           on the stack; if -O2 is passed to gcc, the sp may used
+                used to reference local variables. */
+        "LDR	r0, %[hibit]            \n\t"
+        "LDR	r1, %[bytes]            \n\t"
+        "LDR	r2, %[r_ptr]            \n\t"
+
+        "VMOV	s2, r0                \n\t"
+        "VMOV	s4, r1                \n\t"
+
+        "LDM	r2, { r0, r1, r2, r3, r4 }    \n\t"
+        "VMOV	s6, r0                \n\t"
+        "VMOV	s7, r1                \n\t"
+        "VMOV	s8, r2                \n\t"
+        "VMOV	s9, r3                \n\t"
+        "VMOV	s10, r4                \n\t"
+
+        "LDR	r5, %[m]            \n\t"
+        "PUSH	{ r7 }                \n\t"
+        "MOV	r7, r5                \n\t"
+
+        /* s2 - hibit
+            s4 - bytes
+               s6, s7, s8, s9, s10 - r in 26 bit pieces */
+
+    "armv8_32_poly1305_loop:                \n\t"
+
+        /* The poly1305 algorithm requires that a 01 byte
+           be placed after the last byte of the block. */
+
+        "VMOV	r5, s4                \n\t"
+        "CMP	r5, #0                \n\t"
+        "BEQ	armv8_32_poly1305_done        \n\t"
+        "SUBS	r5, r5, #16            \n\t"
+
+        /* branch for least likely case, may help with pipelining */
+        /* ARMv8 uses predictive pipelining.  There is no way
+           to specify in the instruction encoding the more likely
+           case.  */
+        "BLT	armv8_32_poly1305_last_block    \n\t"
+
+        /* this block is 16 bytes */
+        "VMOV	s4, r5                \n\t"
+
+        /* load next 16 byte block of message */
+        "LDM	r7, { r0, r1, r2, r3 }        \n\t"  /* mem 1 */
+        "ADD	r7, r7, #16            \n\t"
+
+        /* in RFC 7539, each block processed is prepended by
+             a byte of value 0x01.  In the wolfSSL implementation,
+           the setting of this value is based on the value found
+           in ctx->finish. To save a memory reference, this code
+           could be replicated one version adding the byte, one
+           version not. */
+
+        /* This is byte 16, past the 128 bits of w19:w18:w17:w16
+           Hence, update is done to h4. */
+        /* add in hibit */
+        "VMOV	r5, s2                \n\t"
+        "ADD	r11, r11, r5             \n\t"
+
+    "armv8_32_poly1305_done_01_byte_appended:    \n\t"
+
+        "mov	r5, #0x3FFFFFF            \n\t"
+
+        /* break data into 26 bit pieces.
+           Bit offsets are 0, 26, 52, 78 and 104 */
+
+        /* h0 += r0 & 0x3FFFFFF; */
+        "AND	r12, r0, r5            \n\t"
+        "ADD	r6, r6, r12            \n\t"
+        /* h1 += (r1:r0 >> 26) & 0x3FFFFFF */
+        "LSR	r12, r0, #26            \n\t"    /* 26 */
+        "ADD	r12, r12, r1, LSL #6        \n\t"
+        "AND	r12, r12, r5            \n\t"
+        "ADD	r8, r8, r12            \n\t"
+        /* h2 += (r2:r1 >> 20) & 0x3FFFFFF */
+        "LSR	r12, r1, #20            \n\t"   /* 20+32 = 52 */
+        "ADD	r12, r12, r2, LSL #12        \n\t"
+        "AND	r12, r12, r5            \n\t"
+        "ADD	r9, r9, r12            \n\t"
+        /* h3 += (r3:r2 >> 14) & 0x3FFFFFF */
+        "LSR	r12, r2, #14            \n\t"    /* 14+32+32 = 78 */
+        "ADD	r12, r12, r3, LSL #18        \n\t"
+        "AND	r12, r12, r5            \n\t"
+        "ADD	r10, r10, r12            \n\t"
+        /* h4 += r3 >> 8               */
+        "ADD	r11, r11, r3, LSR #8        \n\t"    /* 8+32+32+32 = 104 */
+
+        /* pull in the 26 bit components of the r key */
+        "VMOV	r0, s6                \n\t"
+        "VMOV	r1, s7                \n\t"
+        "VMOV	r2, s8                \n\t"
+        "VMOV	r3, s9                \n\t"
+        "VMOV	r4, s10                \n\t"
+
+        /* r0 = BED685  r1 = 3555502  r2 = 47C036  r3 = 1003949  r4 = 806D5 */
+        "MOV	r5, #5                \n\t"
+
+    "checkRegs:                    \n\t"
+        /* d0 = h0 * r0 + h1 * 5*r4 + h2 * 5*r3 + h3 * 5*r2 + h4 * 5*r1 */
+        /* d1 = h0 * r1 + h1 * r0   + h2 * 5*r4 + h3 * 5*r3 + h4 * 5*r2 */
+        /* d2 = h0 * r2 + h1 * r1   + h2 * r0   + h3 * 5*r4 + h4 * 5*r3 */
+        /* d3 = h0 * r3 + h1 * r2   + h2 * r1   + h3 * r0   + h4 * 5*r4 */
+        /* d4 = h0 * r4 + h1 * r3   + h2 * r2   + h3 * r1   + h4 * r0   */
+
+        /*  r14 is the link register, r13 is the sp */
+        /*  r14:r12 = r6 * r0 + (r8 * r4 +  r9 * r3 +  r10 * r2 +  r11 * r1) * r5 */
+        /*  r14:r12 = r6 * r1 +  r8 * r0 + (r9 * r4 +  r10 * r3 +  r11 * r2) * r5 */
+        /*  r14:r12 = r6 * r2 +  r8 * r1 +  r9 * r0 + (r10 * r4 +  r11 * r3) * r5 */
+        /*  r14:r12 = r6 * r3 +  r8 * r2 +  r9 * r1 +  r10 * r0 + (r11 * r4) * r5 */
+        /*  r14:r12 = r6 * r4 +  r8 * r3 +  r9 * r2 +  r10 * r1 +  r11 * r0       */
+
+        /* d4 */
+#if 0
+        "UMULL	r12, r14, r6, r4        \n\t"
+        "UMLAL	r12, r14, r8, r3        \n\t"
+        "UMLAL	r12, r14, r9, r2        \n\t"
+        "UMLAL	r12, r14, r10, r1        \n\t"
+        "UMLAL	r12, r14, r11, r0        \n\t"
+
+        "VMOV	s12, s13, r12, r14        \n\t"
+#else
+        "VMOV	s20, s21, r4, r3        \n\t"
+        "VMOV	s22, s23, r2, r1        \n\t"
+        "VMOV	s24, s25, r6, r8        \n\t"
+        "VMOV	s26, s27, r9, r10       \n\t"
+        "UMULL	r12, r14, r11, r0        \n\t"
+        "VMULL.U32	q14, d12, d10   \n\t"
+        "VMLAL.U32	q14, d13, d11   \n\t"
+        "VMOV	s28, s29, r12, r14       \n\t"
+        "VADD.U64	d28, d28, d29        \n\t"
+        "VADD.U64	d6, d28, d14        \n\t"
+#endif
+
+        /* 8F852 C3AB3DA1 */
+
+        /* d3 */
+        "UMULL	r12, r14, r6, r3        \n\t"
+        "UMLAL	r12, r14, r8, r2        \n\t"
+        "UMLAL	r12, r14, r9, r1        \n\t"
+        "UMLAL	r12, r14, r10, r0        \n\t"
+        "MUL	r11, r11, r5            \n\t"
+        "UMLAL	r12, r14, r11, r4        \n\t"
+
+        "VMOV    s14, s15, r12, r14        \n\t"
+
+        /* C753B 56120E14 */
+
+        /* d2 */
+        "UMULL	r12, r14, r6, r2        \n\t"
+        "UMLAL	r12, r14, r8, r1        \n\t"
+        "UMLAL	r12, r14, r9, r0        \n\t"
+        "MUL	r10, r10, r5            \n\t"
+        "UMLAL	r12, r14, r10, r4        \n\t"
+        "UMLAL	r12, r14, r11, r3        \n\t"
 
-		/* d4 */
-		"UMULL	r12, r14, r6, r4		\n\t"
-		"UMLAL 	r12, r14, r8, r3		\n\t"
-		"UMLAL 	r12, r14, r9, r2		\n\t"
-		"UMLAL 	r12, r14, r10, r1		\n\t"
-		"UMLAL 	r12, r14, r11, r0		\n\t"
+        "VMOV	s16, s17, r12, r14        \n\t"
 
-		"VMOV	s12, s13, r12, r14		\n\t"
+        /* 10019D F79AAF81 */
 
-		/* 8F852 C3AB3DA1 */
+        /* d1 */
+        "UMULL	r12, r14, r6, r1        \n\t"
+        "UMLAL	r12, r14, r8, r0        \n\t"
+        "MUL	r9, r9, r5            \n\t"
+        "UMLAL	r12, r14, r9, r4        \n\t"
+        "UMLAL	r12, r14, r10, r3        \n\t"
+        "UMLAL	r12, r14, r11, r2        \n\t"
 
-		/* d3 */
-		"UMULL	r12, r14, r6, r3		\n\t"
-		"UMLAL 	r12, r14, r8, r2		\n\t"
-		"UMLAL 	r12, r14, r9, r1		\n\t"
-		"UMLAL 	r12, r14, r10, r0		\n\t"
-		"MUL	r11, r11, r5			\n\t"
-		"UMLAL 	r12, r14, r11, r4		\n\t"
+        "VMOV	s18, s19, r12, r14        \n\t"
 
-		"VMOV	s14, s15, r12, r14		\n\t"
+        /* D3993 E9038575 */
 
-		/* C753B 56120E14 */
+        /* d0 */
+        "UMULL	r12, r14, r6, r0        \n\t"
+        "MUL	r8, r8, r5            \n\t"
+        "UMLAL	r12, r14, r8, r4        \n\t"
+        "UMLAL	r12, r14, r9, r3        \n\t"
+        "UMLAL	r12, r14, r10, r2        \n\t"
+        "UMLAL	r12, r14, r11, r1        \n\t"
 
-		/* d2 */
-		"UMULL	r12, r14, r6, r2		\n\t"
-		"UMLAL 	r12, r14, r8, r1		\n\t"
-		"UMLAL 	r12, r14, r9, r0		\n\t"
-		"MUL	r10, r10, r5			\n\t"
-		"UMLAL 	r12, r14, r10, r4		\n\t"
-		"UMLAL 	r12, r14, r11, r3		\n\t"
+        /* 29DD73 07661C87 */
 
-		"VMOV	s16, s17, r12, r14		\n\t"
+        /* registers r6, r8, r9, r10, r11 must be
+           populated with above results after accounting
+           for overflow past 26 bit. */
 
-		/* 10019D F79AAF81 */
+        /* doing d0 --> d1 --> d2 --> d3 --> d4 --> d1 -->d2 */
+
+        "MOV	r5, #0x3FFFFFF            \n\t"
+        "AND	r6, r12, r5            \n\t"    /* d0 */
+
+        /* d0 overflow to d1 */
+
+        "VMOV	r0, r1, s18, s19         \n\t"
+        "ADDS	r0, r0, r12, LSR #26        \n\t"
+        "ADC	r1, r1, #0            \n\t"
+        "ADDS	r0, r0, r14, LSL #6        \n\t"
+        "ADC	r1, r1, #0            \n\t"
+
+        "AND	r8, r0, r5            \n\t"   /* d1 */
+
+        /* d1 overflow to d2 */
+
+        "VMOV	r2, r3, s16, s17        \n\t"
+        "ADDS	r2, r2, r0, LSR #26        \n\t"
+        "ADC	r3, r3, #0            \n\t"
+        "ADDS	r2, r2, r1, LSL #6        \n\t"
+        "ADC	r3, r3, #0            \n\t"
+
+        "AND	r9, r2, r5            \n\t"    /* d2 */
+
+        /* d2 overflow to d3 */
+
+        "VMOV	r0, r1, s14, s15        \n\t"
+        "ADDS	r0, r0, r2, LSR #26        \n\t"
+        "ADC	r1, r1, #0            \n\t"
+        "ADDS	r0, r0, r3, LSL #6        \n\t"
+        "ADC	r1, r1, #0            \n\t"
+
+        "AND	r10, r0, r5            \n\t"    /* d3 */
+
+        /* d3 overflow to d4 */
+
+        "VMOV	r2, r3, s12, s13        \n\t"
+        "ADDS	r2, r2, r0, LSR #26        \n\t"
+        "ADC	r3, r3, #0            \n\t"
+        "ADDS	r2, r2, r1, LSL #6        \n\t"
+        "ADC	r3, r3, #0            \n\t"
 
-		/* d1 */
-		"UMULL	r12, r14, r6, r1		\n\t"
-		"UMLAL 	r12, r14, r8, r0		\n\t"
-		"MUL	r9, r9, r5			\n\t"
-		"UMLAL 	r12, r14, r9, r4		\n\t"
-		"UMLAL 	r12, r14, r10, r3		\n\t"
-		"UMLAL 	r12, r14, r11, r2		\n\t"
+        "AND	r11, r2, r5            \n\t"    /* d4 */
 
-		"VMOV	s18, s19, r12, r14		\n\t"
+        /* d4 overflow to d0, must be multiplied by 5 */
 
-		/* D3993 E9038575 */
+        "LSR	r0, r2, #26            \n\t"
+        "ADD	r0, r0, r3, LSL #6        \n\t"
+        "MOV	r1, #5                \n\t"
+        "MUL	r0, r0, r1            \n\t"
+        "ADD	r6, r6, r0            \n\t"   /* d0 updated */
 
-		/* d0 */
-		"UMULL	r12, r14, r6, r0		\n\t"
-		"MUL	r8, r8, r5			\n\t"
-		"UMLAL 	r12, r14, r8, r4		\n\t"
-		"UMLAL 	r12, r14, r9, r3		\n\t"
-		"UMLAL 	r12, r14, r10, r2		\n\t"
-		"UMLAL 	r12, r14, r11, r1		\n\t"
+        /* d0 overflow to d1 */
 
-		/* 29DD73 07661C87 */
+        "ADD	r8, r8, r6, LSR #26        \n\t"    /* d1 done */
 
-		/* registers r6, r8, r9, r10, r11 must be 
-		   populated with above results after accounting 
-		   for overflow past 26 bit. */
+        "AND	r6, r6, r5            \n\t"    /* d0 done */
 
-		/* doing d0 --> d1 --> d2 --> d3 --> d4 --> d1 -->d2 */
+        "B	armv8_32_poly1305_loop        \n\t"
 
-		"MOV	r5, #0x3FFFFFF			\n\t"
-		"AND	r6, r12, r5			\n\t"	/* d0 */
+    "armv8_32_poly1305_last_block:            \n\t"
 
-		/* d0 overflow to d1 */
-
-		"VMOV 	r0, r1, s18, s19 		\n\t"
-		"ADDS	r0, r0, r12, LSR #26		\n\t"
-		"ADC	r1, r1, #0			\n\t"
-		"ADDS	r0, r0, r14, LSL #6		\n\t"
-		"ADC	r1, r1, #0			\n\t"
-
-		"AND	r8, r0, r5			\n\t"   /* d1 */
-
-		/* d1 overflow to d2 */
-
-		"VMOV 	r2, r3, s16, s17		\n\t"
-		"ADDS	r2, r2, r0, LSR #26		\n\t"
-		"ADC	r3, r3, #0			\n\t"
-		"ADDS	r2, r2, r1, LSL #6		\n\t"
-		"ADC	r3, r3, #0			\n\t"
-
-		"AND	r9, r2, r5			\n\t"	/* d2 */
-
-		/* d2 overflow to d3 */
-
-		"VMOV 	r0, r1, s14, s15		\n\t"
-		"ADDS	r0, r0, r2, LSR #26		\n\t"
-		"ADC	r1, r1, #0			\n\t"
-		"ADDS	r0, r0, r3, LSL #6		\n\t"
-		"ADC	r1, r1, #0			\n\t"
-
-		"AND	r10, r0, r5			\n\t"	/* d3 */
-
-		/* d3 overflow to d4 */
-
-		"VMOV 	r2, r3, s12, s13		\n\t"
-		"ADDS	r2, r2, r0, LSR #26		\n\t"
-		"ADC	r3, r3, #0			\n\t"
-		"ADDS	r2, r2, r1, LSL #6		\n\t"
-		"ADC	r3, r3, #0			\n\t"
-
-		"AND	r11, r2, r5			\n\t"	/* d4 */
-
-		/* d4 overflow to d0, must be multiplied by 5 */	
-
-		"LSR	r0, r2, #26			\n\t"
-		"ADD	r0, r0, r3, LSL #6		\n\t"
-		"MOV	r1, #5				\n\t"	
-		"MUL	r0, r0, r1			\n\t"
-		"ADD	r6, r6, r0			\n\t"   /* d0 updated */
-
-		/* d0 overflow to d1 */
-
-		"ADD	r8, r8, r6, LSR #26		\n\t"	/* d1 done */
-
-		"AND	r6, r6, r5			\n\t"	/* d0 done */	
-
-		"B	armv8_32_poly1305_loop		\n\t"
-	
-	"armv8_32_poly1305_last_block:			\n\t"
-
-		/* This is the last block of the message
-		   and the block is less than 16 byte */
-
-		/* set s4 to 0, d2 is s5:s4 */
-		"VEOR	d2, d2				\n\t"
-	
-		"VMOV	r0, s2				\n\t"	/* hibit */
-
-		/* Make sure the upper bytes of the 
-		   32 bit pieces are set to zero. 
-		   Set the byte past the last message
-		   data byte to 01. */
-
-		"PUSH	{ r4, r6, r8 } 			\n\t"	
-
-		"MOV    r1,  #0				\n\t"
-		"MOV	r2,  #0				\n\t"
-		"MOV	r3,  #0				\n\t"
-		"MOV	r4,  #0xFFFFFFFF		\n\t"
-		"LSR	r0, r0, #24			\n\t"
-		"MOV	r6,  r0				\n\t"
-
-		/* always going to load at least one */		
-		"LDR	r0, [r7]			\n\t"
-
-		/* byte offset to bit offset */ 
-		"ADD	r5, r5, #16			\n\t"
-		"LSL	r5, r5, #3			\n\t"			
-
-		/* which block */
-		"CMP	r5, #32				\n\t"
-		"BGE	not_word_0			\n\t"
-
-		/* case word 0 */
-	"case0:"
-		"LSL	r8, r4, r5			\n\t"
-		"BIC  	r0, r0, r8			\n\t"
-		"LSL	r8, r6, r5			\n\t"
-		"ADD	r0, r0, r8			\n\t"
-		"B	last_block_done			\n\t"
-
-	"not_word_0:	 				\n\t"
-		"LDR	r1, [r7, #4]			\n\t"
-		
-		"SUB	r5, r5, #32			\n\t"
-		"CMP	r5, #32				\n\t"
-		"BGE	not_word_1			\n\t"
-
-		"LSL	r8, r4, r5			\n\t"
-		"BIC  	r1, r1, r8			\n\t"
-		"LSL	r8, r6, r5			\n\t"
-		"ADD	r1, r1, r8			\n\t"		
-		"B	last_block_done			\n\t"
-
-	"not_word_1:					\n\t"
-		"LDR	r2, [r7, #8]			\n\t"
-
-		"SUB	r5, r5, #32			\n\t"
-		"CMP	r5, #32				\n\t"
-		"BGE	not_word_2			\n\t"
-
-		"LSL	r8, r4, r5			\n\t"
-		"BIC  	r2, r2, r8			\n\t"
-		"LSL	r8, r6, r5			\n\t"
-		"ADD	r2, r2, r8			\n\t"		
-		"B	last_block_done			\n\t"
-
-	"not_word_2:					\n\t"
-		"LDR	r3, [r7, #0xC]			\n\t"
-
-		"SUB	r5, r5, #32			\n\t"
-
-		"LSL	r8, r4, r5			\n\t"
-		"BIC  	r3, r3, r8			\n\t"
-		"LSL	r8, r6, r5			\n\t"
-		"ADD	r3, r3, r8			\n\t"	
-
-	"last_block_done:				\n\t"
-
-		"POP	{ r4, r6, r8 } 			\n\t"	
-	
-		"b 	armv8_32_poly1305_done_01_byte_appended \n\t"
-	
-		".align 2 \n\t"
-	"armv8_32_poly1305_done:				\n\t"
-
-		"POP	{ r7 }				\n\t"
-
-		/* store final result */
-		"LDR	r0, %[h_ptr]			\n\t"
-		"STM	r0, { r6, r8, r9, r10, r11 } 	\n\t"
-		
-		: [m] 		  "+m" (msgDataOnStack),	/* input */
-		  [r_ptr]  	  "+m" (r_ptrLocal),		/* input */
-		  [h_ptr]  	  "+m" (h_ptrLocal),		/* input, output */
-		  [bytes]  	  "+m" (msgDataLenOnStack),	/* input */
-		  [hibit]	  "+m" (hibitOnStack)		/* input */
-		: 
-		: "memory", "cc", 
-			"r0", "r1", "r2", "r3", "r4", "r5", "r6", "r8", "r9", "r10",
-			"r11", "r12", "lr", 
-			"s2", "s4", "s6", "s7", "s8", "s9", "s10", "d2"
-	);
-
-	memcpy(ctx->r, r, 5 * sizeof(unsigned));
-	memcpy(ctx->h, h, 5 * sizeof(unsigned));
+        /* This is the last block of the message
+           and the block is less than 16 byte */
+
+        /* set s4 to 0, d2 is s5:s4 */
+        "VEOR	d2, d2                \n\t"
+
+        "VMOV	r0, s2                \n\t"    /* hibit */
+
+        /* Make sure the upper bytes of the
+           32 bit pieces are set to zero.
+           Set the byte past the last message
+           data byte to 01. */
+
+        "PUSH	{ r4, r6, r8 }             \n\t"
+
+        "MOV	r1,  #0                \n\t"
+        "MOV	r2,  #0                \n\t"
+        "MOV	r3,  #0                \n\t"
+        "MOV	r4,  #0xFFFFFFFF        \n\t"
+        "LSR	r0, r0, #24            \n\t"
+        "MOV	r6,  r0                \n\t"
+
+        /* always going to load at least one */
+        "LDR	r0, [r7]            \n\t"
+
+        /* byte offset to bit offset */
+        "ADD	r5, r5, #16            \n\t"
+        "LSL	r5, r5, #3            \n\t"
+
+        /* which block */
+        "CMP	r5, #32                \n\t"
+        "BGE	not_word_0            \n\t"
+
+        /* case word 0 */
+    "case0:"
+        "LSL	r8, r4, r5            \n\t"
+        "BIC	r0, r0, r8            \n\t"
+        "LSL	r8, r6, r5            \n\t"
+        "ADD	r0, r0, r8            \n\t"
+        "B	last_block_done            \n\t"
+
+    "not_word_0:                     \n\t"
+        "LDR	r1, [r7, #4]            \n\t"
+
+        "SUB	r5, r5, #32            \n\t"
+        "CMP	r5, #32                \n\t"
+        "BGE	not_word_1            \n\t"
+
+        "LSL	r8, r4, r5            \n\t"
+        "BIC	r1, r1, r8            \n\t"
+        "LSL	r8, r6, r5            \n\t"
+        "ADD	r1, r1, r8            \n\t"
+        "B	last_block_done            \n\t"
+
+    "not_word_1:                    \n\t"
+        "LDR	r2, [r7, #8]            \n\t"
+
+        "SUB	r5, r5, #32            \n\t"
+        "CMP	r5, #32                \n\t"
+        "BGE	not_word_2            \n\t"
+
+        "LSL	r8, r4, r5            \n\t"
+        "BIC	r2, r2, r8            \n\t"
+        "LSL	r8, r6, r5            \n\t"
+        "ADD	r2, r2, r8            \n\t"
+        "B	last_block_done            \n\t"
+
+    "not_word_2:                    \n\t"
+        "LDR	r3, [r7, #0xC]            \n\t"
+
+        "SUB	r5, r5, #32            \n\t"
+
+        "LSL	r8, r4, r5            \n\t"
+        "BIC	r3, r3, r8            \n\t"
+        "LSL	r8, r6, r5            \n\t"
+        "ADD	r3, r3, r8            \n\t"
+
+    "last_block_done:                \n\t"
+
+        "POP	{ r4, r6, r8 }             \n\t"
+
+        "b	armv8_32_poly1305_done_01_byte_appended \n\t"
+
+        ".align 2 \n\t"
+    "armv8_32_poly1305_done:                \n\t"
+
+        "POP	{ r7 }                \n\t"
+
+        /* store final result */
+        "LDR	r0, %[h_ptr]            \n\t"
+        "STM	r0, { r6, r8, r9, r10, r11 }     \n\t"
+
+        : [m]     "+m" (msgDataOnStack),    /* input */
+          [r_ptr] "+m" (r_ptrLocal),        /* input */
+          [h_ptr] "+m" (h_ptrLocal),        /* input, output */
+          [bytes] "+m" (msgDataLenOnStack),    /* input */
+          [hibit] "+m" (hibitOnStack)        /* input */
+        :
+        : "memory", "cc",
+            "r0", "r1", "r2", "r3", "r4", "r5", "r6", "r8", "r9", "r10",
+            "r11", "r12", "lr",
+            "s2", "s4", "s6", "s7", "s8", "s9", "s10", "s12", "s13", "s14",
+            "s15", "s16", "s17", "s18", "s19", "s20", "s21", "s22", "s23",
+            "s24", "s25", "s26", "s27", "s28", "s29", "s30", "s31",
+            "d2", "q14", "q15"
+    );
+
+    memcpy(ctx->r, r, 5 * sizeof(word32));
+    memcpy(ctx->h, h, 5 * sizeof(word32));
 
 #ifdef POLY1305_VERBOSE
-	for (i=0;i<5;++i) printf("h%d %07X ", i, ctx->h[i]);
-	printf("\n");
+    for (i=0;i<5;++i) printf("h%d %07X ", i, ctx->h[i]);
+    printf("\n");
 
-	printf("armv8_32_poly1305_blocks() leaving\n");
+    printf("armv8_32_poly1305_blocks() leaving\n");
 #endif
 
 }
 
 #endif  /* #ifdef  WOLFSSL_ARMASM_NO_NEON */
 
-#endif	/* #ifndef __aarch64__   */
+void poly1305_blocks(Poly1305* ctx, const unsigned char *m, size_t bytes)
+{
+    armv8_32_poly1305_blocks(ctx, m, bytes);
+}
+
+void poly1305_block(Poly1305* ctx, const unsigned char *m)
+{
+    armv8_32_poly1305_blocks(ctx, m, POLY1305_BLOCK_SIZE);
+}
+
+static word32 U8TO32(const byte *p)
+{
+    return
+        (((word32)(p[0] & 0xff)      ) |
+         ((word32)(p[1] & 0xff) <<  8) |
+         ((word32)(p[2] & 0xff) << 16) |
+         ((word32)(p[3] & 0xff) << 24));
+}
+
+static void U32TO8(byte *p, word32 v) {
+    p[0] = (byte)((v      ) & 0xff);
+    p[1] = (byte)((v >>  8) & 0xff);
+    p[2] = (byte)((v >> 16) & 0xff);
+    p[3] = (byte)((v >> 24) & 0xff);
+}
+
+int wc_Poly1305SetKey(Poly1305* ctx, const byte* key, word32 keySz)
+{
+    if (key == NULL)
+        return BAD_FUNC_ARG;
+
+#ifdef CHACHA_AEAD_TEST
+    word32 k;
+    printf("Poly key used:\n");
+    for (k = 0; k < keySz; k++) {
+        printf("%02x", key[k]);
+        if ((k+1) % 8 == 0)
+            printf("\n");
+    }
+    printf("\n");
+#endif
+
+    if (keySz != 32 || ctx == NULL)
+        return BAD_FUNC_ARG;
+
+    /* r &= 0xffffffc0ffffffc0ffffffc0fffffff */
+    ctx->r[0] = (U8TO32(key +  0)     ) & 0x3ffffff;
+    ctx->r[1] = (U8TO32(key +  3) >> 2) & 0x3ffff03;
+    ctx->r[2] = (U8TO32(key +  6) >> 4) & 0x3ffc0ff;
+    ctx->r[3] = (U8TO32(key +  9) >> 6) & 0x3f03fff;
+    ctx->r[4] = (U8TO32(key + 12) >> 8) & 0x00fffff;
+
+    /* h = 0 */
+    ctx->h[0] = 0;
+    ctx->h[1] = 0;
+    ctx->h[2] = 0;
+    ctx->h[3] = 0;
+    ctx->h[4] = 0;
+
+    /* save pad for later */
+    ctx->pad[0] = U8TO32(key + 16);
+    ctx->pad[1] = U8TO32(key + 20);
+    ctx->pad[2] = U8TO32(key + 24);
+    ctx->pad[3] = U8TO32(key + 28);
+
+    ctx->leftover = 0;
+    ctx->finished = 0;
+
+    return 0;
+}
+
+int wc_Poly1305Final(Poly1305* ctx, byte* mac)
+{
+    word32 h0,h1,h2,h3,h4,c;
+    word32 g0,g1,g2,g3,g4;
+    word64 f;
+    word32 mask;
+
+    /* process the remaining block */
+    if (ctx->leftover) {
+        size_t i = ctx->leftover;
+        ctx->buffer[i++] = 1;
+        for (; i < POLY1305_BLOCK_SIZE; i++)
+            ctx->buffer[i] = 0;
+        ctx->finished = 1;
+        poly1305_block(ctx, ctx->buffer);
+    }
+
+    /* fully carry h */
+    h0 = ctx->h[0];
+    h1 = ctx->h[1];
+    h2 = ctx->h[2];
+    h3 = ctx->h[3];
+    h4 = ctx->h[4];
+
+                 c = h1 >> 26; h1 = h1 & 0x3ffffff;
+    h2 +=     c; c = h2 >> 26; h2 = h2 & 0x3ffffff;
+    h3 +=     c; c = h3 >> 26; h3 = h3 & 0x3ffffff;
+    h4 +=     c; c = h4 >> 26; h4 = h4 & 0x3ffffff;
+    h0 += c * 5; c = h0 >> 26; h0 = h0 & 0x3ffffff;
+    h1 +=     c;
+
+    /* compute h + -p */
+    g0 = h0 + 5; c = g0 >> 26; g0 &= 0x3ffffff;
+    g1 = h1 + c; c = g1 >> 26; g1 &= 0x3ffffff;
+    g2 = h2 + c; c = g2 >> 26; g2 &= 0x3ffffff;
+    g3 = h3 + c; c = g3 >> 26; g3 &= 0x3ffffff;
+    g4 = h4 + c - ((word32)1 << 26);
+
+    /* select h if h < p, or h + -p if h >= p */
+    mask = ((word32)g4 >> ((sizeof(word32) * 8) - 1)) - 1;
+    g0 &= mask;
+    g1 &= mask;
+    g2 &= mask;
+    g3 &= mask;
+    g4 &= mask;
+    mask = ~mask;
+    h0 = (h0 & mask) | g0;
+    h1 = (h1 & mask) | g1;
+    h2 = (h2 & mask) | g2;
+    h3 = (h3 & mask) | g3;
+    h4 = (h4 & mask) | g4;
+
+    /* h = h % (2^128) */
+    h0 = ((h0      ) | (h1 << 26)) & 0xffffffff;
+    h1 = ((h1 >>  6) | (h2 << 20)) & 0xffffffff;
+    h2 = ((h2 >> 12) | (h3 << 14)) & 0xffffffff;
+    h3 = ((h3 >> 18) | (h4 <<  8)) & 0xffffffff;
+
+    /* mac = (h + pad) % (2^128) */
+    f = (word64)h0 + ctx->pad[0]            ; h0 = (word32)f;
+    f = (word64)h1 + ctx->pad[1] + (f >> 32); h1 = (word32)f;
+    f = (word64)h2 + ctx->pad[2] + (f >> 32); h2 = (word32)f;
+    f = (word64)h3 + ctx->pad[3] + (f >> 32); h3 = (word32)f;
+
+    U32TO8(mac + 0, h0);
+    U32TO8(mac + 4, h1);
+    U32TO8(mac + 8, h2);
+    U32TO8(mac + 12, h3);
+
+    /* zero out the state */
+    ctx->h[0] = 0;
+    ctx->h[1] = 0;
+    ctx->h[2] = 0;
+    ctx->h[3] = 0;
+    ctx->h[4] = 0;
+    ctx->r[0] = 0;
+    ctx->r[1] = 0;
+    ctx->r[2] = 0;
+    ctx->r[3] = 0;
+    ctx->r[4] = 0;
+    ctx->pad[0] = 0;
+    ctx->pad[1] = 0;
+    ctx->pad[2] = 0;
+    ctx->pad[3] = 0;
+
+    return 0;
+}
+
+#endif  /* #ifndef __aarch64__   */
 #endif  /* #ifdef  WOLFSSL_ARMASM */
 
-
-#ifdef STAND_ALONE_DEBUG
-/**********************************************************
-  printRegs	Test routine used to display the register 
-		values save by the call to the assembly
-		routine saveRegs.  The r6, r8, r9, r10
-		and r11 values are approperiately added
-		together to create a 17 byte value that is
-		displayed.  
-**********************************************************/
-void printRegs(unsigned *regArray)
-{
-	unsigned result26Bit[5];
-	unsigned char result[17];
-	int i;	
-
-	printf("\n\n*** Register dump ***\n");
-	for (i=0; i<13;++i)
-		printf("r%d = 0x%08X \n", i, regArray[i]);
-	printf(" sp (r13) skiped\n");
-	printf(" lr (r14) = 0x%08X \n", regArray[i]);
-
-	/* r6, r8, r9, r10, r11 could be 26 bit components
-	   print the result of reassembling them. */
-
-	result26Bit[0] = regArray[6];
-	result26Bit[1] = regArray[8];
-	result26Bit[2] = regArray[9];
-	result26Bit[3] = regArray[10];	
-	result26Bit[4] = regArray[11];
-	convert26BitValuesTo17Byte(result26Bit, result);
-
-	//printBytes("result = ", result, 17);
-	print17("result = ", result);
-}
-
-#define SAVE_REGS	"PUSH 	{ r14 }				\n\t" \
-			"BL	recordRegs			\n\t" \
-			"NOP					\n\t" \
-			"POP	{ r14 }				\n\t"
-#endif
-
-
-#ifdef POLY1305_STAND_ALONE
-
-/**********************************************************
-  print16	Output the given 16 bytes as one big
-		number.  Note 16 bytes is 128 bit.
-**********************************************************/
-void print16(const char *startText, unsigned char *data);
-void print16(const char *startText, unsigned char *data)
-{
-	printf("%s %08X %08X %08X %08X\n", startText, *(unsigned*)(data+0xc),
-			*(unsigned*)(data+0x8),
-			*(unsigned*)(data+4),
-			*(unsigned*)data);
-}
-
-
-/**********************************************************
-  print17	Output the given 17 bytes as one big
-		number.  
-**********************************************************/
-void print17(const char *startText, unsigned char *data);
-void print17(const char *startText, unsigned char *data)
-{
-	printf("%s %02X %08X%08X %08X%08X \n", startText, data[16], 
-				*(unsigned *)(data+0xC), *(unsigned *)(data+8),
-				*(unsigned *)(data+4), *(unsigned *)(data));
-}
-
-
-/**********************************************************
-  printBytes	Print the specified number of bytes, one
-		byte at a time.
-**********************************************************/
-void printBytes(const char *startText, unsigned char *data, int len);
-void printBytes(const char *startText, unsigned char *data, int len)
-{
-	int i;
-	
-	printf("%s", startText);
-	
-	for (i=0;i<len;++i)
-	{
-		printf("%02X", data[i]);
-		if (i<len-1) printf(":");
-	}
-	printf("\n");
-}
-
-
-/**********************************************************
-  clamp_r	Set the correct bits in the 128 bit r key
-		to zero.
-**********************************************************/
-void clamp_r(unsigned char *r);
-void clamp_r(unsigned char *r)
-{
-	printBytes("r = ", r, 16);
-	
-	r[3] &= 0xF;
-	r[7] &= 0xF;
-	r[11] &= 0xF;
-	r[15] &= 0xF;
-	
-	r[4] &= 0xFC;
-	r[8] &= 0xFC;
-	r[12] &= 0xFC;
-	
-	print16("after clamp ", r);
-}
-
-
-/**********************************************************
-  add17		Add two 17 byte numbers together.  This is
-		used as part of the algorithm to combine
-		26 bit pieces into one 17 byte number.
-**********************************************************/
-void add17(unsigned char *dest, unsigned char *src);
-void add17(unsigned char *dest, unsigned char *src)
-{
-	int i;
-	short result;
-	unsigned char of=0;
-	
-	for (i=0;i<17;++i)
-	{
-		result = dest[i] + src[i] + of;
-		
-		dest[i] = (unsigned char)result;
-		
-		if (result & 0xFF00) of=1; else of=0; 
-	}
-}
-
-
-/**********************************************************
-  convert26BitValuesTo17Byte
-		Convert the 5 specified 26 bit values to
-		a single 17 byte value.
-  input16Bit	Input array of 5 26 bit values.  
-  result	Output of 17 bytes which represent one
-		130 bit number.
-**********************************************************/
-void convert26BitValuesTo17Byte(unsigned *input26Bit, unsigned char *result);
-void convert26BitValuesTo17Byte(unsigned *input26Bit, unsigned char *result)
-{
-	unsigned char tmp[17];
-
-	memset(result, 0, 17);
-	*(unsigned*)(result+0) = input26Bit[0];
-
-	memset(tmp, 0, 17);
-	*(unsigned*)(tmp+3)  = input26Bit[1] << 2;
-	add17(result, tmp);
-
-	memset(tmp, 0, 17);
-	*(unsigned*)(tmp+6)  = input26Bit[2] << 4;
-	add17(result, tmp);
-
-	memset(tmp, 0, 17);
-	*(unsigned*)(tmp+9)  = input26Bit[3] << 6;
-	add17(result, tmp);
-
-	memset(tmp, 0, 17);
-	*(unsigned*)(tmp+13) = input26Bit[4];
-	add17(result, tmp);	
-
-	result[16] &= 3;
-}
-
-
-/* test data set from RFC 7539 */
-//unsigned char testData []="Cryptographic Forum Research set"; 
-unsigned char testData[]="Cryptographic Forum Research Group"; 
-//unsigned char testData []="12345678901234561234567890123456";
-unsigned char testKey[]="\x85\xd6\xBE\x78\x57\x55\x6d\x33\x7F\x44\x52\xfe\x42\xd5\x06\xa8\x01\x03\x80\x8a\xfb\x0d\xb2\xFD\x4A\xBF\xF6\xAF\x41\x49\xF5\x1B";
-
-unsigned char resultCheck[]="\xA8\x06\x1D\xC1\x30\x51\x36\xC6\xC2\x2B\x8B\xAF\x0C\x01\x27\xA9";
-
-
-unsigned char msgDataCopy[100];		
-
-int main(void)
-{
-	unsigned char *msgData, *keyData;
-	int msgDataLen;
-	unsigned char result16Byte[16];
-	Poly1305  ctx;
- 	unsigned char *r, *s, acc[17];
-
-	msgData = testData;
-	msgDataLen = strlen((const char *)msgData);	
-	keyData = testKey;
-
-
-	unsigned *pt;
-	pt = (unsigned*)msgData;
-
-	int i;
-	printf("%s\n", msgData);
-	for (i=0;i<10;++i) printf(" %d %X\n", i, pt[i]);
-	printf("\n");
-
-	printf("message len %d\n", msgDataLen);
-
-
-	/* some modifications of the test data for test
-	   purposes.  Used in part to test the assembly
-	   algorithm for the last block of the message. */
-#if 0
-	/* add junk at end for testing */
-	memcpy(msgDataCopy, msgData, msgDataLen);
-	msgData = msgDataCopy;
-	*(unsigned*)(msgData+msgDataLen) = 0x12345678;
-	*(unsigned*)(msgData+msgDataLen+4) = 0x12345678;
-	*(unsigned*)(msgData+msgDataLen+8) = 0x11111111;
-#endif
-	
-#if 0
-	/* make test data a boundary case length
-	   for testing. */
-	memcpy(msgDataCopy, msgData, msgDataLen);
-	msgData = msgDataCopy;
-
-	strcat(msgData, "more stuff");
-	msgDataLen = strlen(msgData);	
-#endif
-
-#if 0
-	/* just run poly1305 on the first 16 byte 
- 	   block of the test data. */
-	strcpy(msgDataCopy, "Cryptographic Fo");
-	msgData = msgDataCopy;
-	msgDataLen = strlen(msgData);		
-#endif
-
-	r = keyData;
-	s = keyData+16;
-
-	print16("s as a 128-bit number ", s);
-	clamp_r(r);
-
-	/* break the 16 byte value into 26 bit parts. */         
-	ctx.r[0] = *(unsigned *)(r) & 0x3FFFFFF;
-	ctx.r[1] = ((*(unsigned *)(r + 3)) >> 2) & 0x3FFFFFF;
-	ctx.r[2] = ((*(unsigned *)(r + 6)) >> 4) & 0x3FFFFFF;
-	ctx.r[3] = ((*(unsigned *)(r + 9)) >> 6) & 0x3FFFFFF;
-	/* + 12 so you don't reference outside array, ie don't use +13 */
-	ctx.r[4] = ((*(unsigned *)(r + 12)) >> 8) & 0xFFFFFF;
-
-	ctx.finished = 0;
-
-	/* Should always start as zero.
-           Passing into assembly routine to match what is already 
-	   implemented in wolfSSL armv8_poly1305.c.  
-	   For debugging, the C routine could break the message into 
-	   16 byte chunks and call the assembly routine over and over
-	   with the 16 byte chunks and the updated h value. */
-	memset(ctx.h, 0, 5 * sizeof(unsigned));
-
-	armv8_32_poly1305_blocks(&ctx, msgData, msgDataLen);
-
-	convert26BitValuesTo17Byte(ctx.h, acc);
-
-	/* make output match what is seen in RFC */
-	print17("Acc = ((Acc+Block) * r) % P = ", acc);
-	add17(acc, s);
-	print17("Acc + s = ", acc);
-
-	memcpy(result16Byte, acc, 16);
-
-	printBytes(" Tag = ", result16Byte, 16); 
-
-	if (!memcmp(result16Byte, resultCheck, 16))
-		printf("Result matches RFC 7539\n\n");
-	else	
-		printf("Result does not match RFC 7539\n\n");
-}
-#endif
 

--- a/wolfcrypt/src/port/arm/armv8-32-poly1305.c
+++ b/wolfcrypt/src/port/arm/armv8-32-poly1305.c
@@ -3,8 +3,8 @@
    The test data in this code matches the test data in RFC 7539.
 
    The poly1305 algorithm takes two inputs, they are as follows.
-        1. the message data
-        2. a 256 bit key
+	1. the message data
+	2. a 256 bit key
    The algorithm outputs a 16 byte authentication value.
   
    The 16 bytes are transmitted with the message.  
@@ -22,7 +22,7 @@
    It is common to use the ChaCha20 algorithm to generate
    the pseudo random key.  The initial 256 bit key is normally
    shared during the setup up of the connection between 
-   sender and receiver.        
+   sender and receiver.	
 
    The 256 bit key is broken down into two 128 bit parts; 
    namely r and s.  In the algorithm, r is clamped, meaning
@@ -34,18 +34,18 @@
 
    This code was compiled and tested with the following tool chain.
 
-        gcc-arm-10.2-2020.11-aarch64-arm-none-linux-guneabihf
+	gcc-arm-10.2-2020.11-aarch64-arm-none-linux-guneabihf
 
    The development environment was Ubunutu, image file
-        
-        libre-computer-aml-s905x-cc-ubuntu-bionic-mate-mali-4.19.55+-2019-06-24.img 
+	
+	libre-computer-aml-s905x-cc-ubuntu-bionic-mate-mali-4.19.55+-2019-06-24.img 
 
    In order the run the resulting executable the 32 bit libs must
    be added to the system.  The following commands accomplish this.
 
-        sudo dpkg --add-architecture armhf
-        sudo apt-get update
-        sudo apt-get install libc6:armhf libstdc++6:armhf
+	sudo dpkg --add-architecture armhf
+	sudo apt-get update
+	sudo apt-get install libc6:armhf libstdc++6:armhf
 
 *****************************************************************/
 
@@ -65,10 +65,10 @@ typedef struct poly1305_struct
     unsigned finished;
 } Poly1305;
 
-#define WOLFSSL_ARMASM           1
+#define WOLFSSL_ARMASM		1
 /* leave __aarch64__ undefined */
-#define POLY1305_VERBOSE         1
-
+//#define WOLFSSL_ARMASM_NO_NEON  1
+#define POLY1305_VERBOSE 	1
 #else
 
 #ifdef WOLFSSL_ARMASM
@@ -96,73 +96,150 @@ typedef struct poly1305_struct
 
 
 /**********************************************************
-  armv8_32_poly1305_blocks        This routine implements the 
-                        poly1305 algorithm.  The processing
-                        of the 16 byte pieces of the 
-                        message is implemented in assembly.
-                        Care was taken in implementing the
-                        assembly to optimize speed by 
-                        minimizing memory references as
-                        well as minimizing instructions.
-                        The poly1305 algorithm is implemented
-                        by using multiple 26 bit values 
-                        to represent the larger 16 byte and 
-                        17 byte numbers.  Breaking the 
-                        larger numbers down into 26 bit 
-                        pieces means that math operations will
-                        not overflow the 32 bit registers.
-                        For more information reference the article 
-                        NEON Cryto by Daniel Berstein and Peter
-                        Schwabe.
+  calculateRsquared	Take the input array of 5 26 bit
+			values, and multiply it by itself
+		        to create a squared result.
+  r			input array of 5 26 bit values
+  rsquared		output array of 5 26 bit values
+**********************************************************/
+void calculateRsquared(unsigned *r, unsigned *rsquared);
+void calculateRsquared(unsigned *r, unsigned *rsquared)
+{
+	unsigned long long r_2_l[5];
+	unsigned long long c;
+	int i;
 
-  ctx                   poly1305 structure containing the r and
-                        h values broke into 26 bit pieces.
-                        The result of this routine is returned
-                        int the h array of 26 bit values.
-  msgData               Message data to run the algorithm 
-                        against.
-  keyData               256 bit key that is broken down 
-                        into the r and s subcomponents.
+	/* d0 = h0 * r0 + h1 * 5*r4 + h2 * 5*r3 + h3 * 5*r2 + h4 * 5*r1 */
+	/* d1 = h0 * r1 + h1 * r0   + h2 * 5*r4 + h3 * 5*r3 + h4 * 5*r2 */
+	/* d2 = h0 * r2 + h1 * r1   + h2 * r0   + h3 * 5*r4 + h4 * 5*r3 */
+	/* d3 = h0 * r3 + h1 * r2   + h2 * r1   + h3 * r0   + h4 * 5*r4 */
+	/* d4 = h0 * r4 + h1 * r3   + h2 * r2   + h3 * r1   + h4 * r0   */
+
+        r_2_l[0] = ((unsigned long long) r[0] * (unsigned long long) r[0] )
+ 	       + ((unsigned long long) r[1] * ((unsigned long long) r[4]) * 5) 
+	       + ((unsigned long long) r[2] * ((unsigned long long) r[3]) * 5) 
+	       + ((unsigned long long) r[3] * ((unsigned long long) r[2]) * 5) 
+	       + ((unsigned long long) r[4] * ((unsigned long long) r[1]) * 5); 
+
+        r_2_l[1] = ((unsigned long long) r[0] * (unsigned long long) r[1] )	 		       + ((unsigned long long) r[1] * (unsigned long long) r[0] ) 
+	       + ((unsigned long long) r[2] * ((unsigned long long) r[4]) * 5) 
+	       + ((unsigned long long) r[3] * ((unsigned long long) r[3]) * 5 ) 
+	       + ((unsigned long long) r[4] * ((unsigned long long) r[2]) * 5 ); 
+
+        r_2_l[2] = ((unsigned long long) r[0] * (unsigned long long) r[2] )	 		       + ((unsigned long long) r[1] * (unsigned long long) r[1] ) 
+	       + ((unsigned long long) r[2] * (unsigned long long) r[0] ) 
+	       + ((unsigned long long) r[3] * ((unsigned long long) r[4]) * 5 ) 
+	       + ((unsigned long long) r[4] * ((unsigned long long) r[3]) * 5 ); 
+
+        r_2_l[3] = ((unsigned long long) r[0] * (unsigned long long) r[3] )	 		       + ((unsigned long long) r[1] * (unsigned long long) r[2] ) 
+	       + ((unsigned long long) r[2] * (unsigned long long) r[1] ) 
+	       + ((unsigned long long) r[3] * (unsigned long long) r[0] ) 
+	       + ((unsigned long long) r[4] * ((unsigned long long) r[4]) * 5 ); 
+
+        r_2_l[4] = ((unsigned long long) r[0] * (unsigned long long) r[4] )	 		       + ((unsigned long long) r[1] * (unsigned long long) r[3] ) 
+	       + ((unsigned long long) r[2] * (unsigned long long) r[2] ) 
+	       + ((unsigned long long) r[3] * (unsigned long long) r[1] ) 
+	       + ((unsigned long long) r[4] * (unsigned long long) r[0] ); 
+
+        c = (r_2_l[0] >> 26); 
+	r_2_l[0] = r_2_l[0] & 0x3ffffff;
+        r_2_l[1] += c;
+
+        c = (r_2_l[1] >> 26);
+	r_2_l[1] = r_2_l[1] & 0x3ffffff;
+        r_2_l[2] += c;     
+
+        c = (r_2_l[2] >> 26);
+	r_2_l[2] = r_2_l[2] & 0x3ffffff;
+        r_2_l[3] += c;     
+
+        c = (r_2_l[3] >> 26);
+	r_2_l[3] = r_2_l[3] & 0x3ffffff;
+        r_2_l[4] += c;     
+
+        c = (r_2_l[4] >> 26);
+	r_2_l[4] = r_2_l[4] & 0x3ffffff;
+        r_2_l[0] += 5 * c;     
+
+        r_2_l[1] += (r_2_l[0] >> 26);
+	r_2_l[0] = r_2_l[0] & 0x3ffffff;
+
+	for (i=0;i<5;++i)
+		rsquared[i] = (unsigned) r_2_l[i];
+}
+
+
+
+/**********************************************************
+  armv8_32_poly1305_blocks	This routine implements the 
+			poly1305 algorithm.  The processing
+			of the 16 byte pieces of the 
+			message is implemented in assembly.
+			Care was taken in implementing the
+			assembly to optimize speed by 
+			minimizing memory references as
+			well as minimizing instructions.
+			The poly1305 algorithm is implemented
+			by using multiple 26 bit values 
+			to represent the larger 16 byte and 
+			17 byte numbers.  This is control
+			register overflow during the 
+			multiplications and subsequent 
+			additions.  For more information
+			reference the article NEON Cryto
+			by Daniel Berstein and Peter
+			Schwabe.
+  ctx			poly1305 structure containing the r and
+		 	h values broke into 26 bit pieces.
+			The result of this routine is returned
+			int the h array of 26 bit values.
+  msgData		Message data to run the algorithm 
+			against.
+  keyData		256 bit key that is broken down 
+			into the r and s subcomponents.
 **********************************************************/
 /* variable assembly code creates on stack */
 
-#define BYTES_SP_OFF              20
-#define HIBIT_LOCAL_SP_OFF        24
-
+#define BYTES_SP_OFF		20
+#define HIBIT_LOCAL_SP_OFF	24
+#define TEST1_SP_OFF		28
 void armv8_32_poly1305_blocks(Poly1305* ctx, 
-                              const unsigned char *msgData,
-                              size_t msgDataLen);
+			const unsigned char *msgData,
+                     	size_t msgDataLen);
 
 /* WOLFSSL_ARMASM_NO_NEON is used in armv8-32-sha512-asm.S */
 #ifdef WOLFSSL_ARMASM_NO_NEON2
 void armv8_32_poly1305_blocks(Poly1305* ctx, 
-                              const unsigned char *msgData,
-                              size_t msgDataLen)
+			const unsigned char *msgData,
+                     	size_t msgDataLen)
 {
-        /* these variables will be referenced via r7 in the assembly */
-        unsigned r[5], *r_ptrLocal, h[5], *h_ptrLocal;
-        unsigned msgDataOnStack = (unsigned)msgData;
-        unsigned msgDataLenOnStack = msgDataLen;
-        unsigned hibitOnStack = (ctx->finished) ? 0 : ((unsigned) 1 << 24);
+	/* these variables will be referenced via r7 in the assembly */
+	unsigned r[5], *r_ptrLocal, h[5], *h_ptrLocal;
+	unsigned msgDataOnStack = (unsigned)msgData;
+	unsigned msgDataLenOnStack = msgDataLen;
+ 	unsigned hibitOnStack = (ctx->finished) ? 0 : ((unsigned) 1 << 24); /* 1 << 128 */
 
-        memcpy(r, ctx->r, 5 * sizeof(unsigned));
-        memcpy(h, ctx->h, 5 * sizeof(unsigned));
+	unsigned test1Array[10*2], test1OnStack;
+	test1OnStack = (unsigned )test1Array;
 
-        /* 32 bit pointer, this is necessary to pass the pointer value
+	memcpy(r, ctx->r, 5 * sizeof(unsigned));
+	memcpy(h, ctx->h, 5 * sizeof(unsigned));
+
+	/* 32 bit pointer, this is necessary to pass the pointer value
            into the assembly code */
-        r_ptrLocal = (unsigned *) r;
-        h_ptrLocal = (unsigned *) h;
+	r_ptrLocal = (unsigned *) r;
+	h_ptrLocal = (unsigned *) h;
 
 #ifdef POLY1305_VERBOSE
-        int i;
-        for (i=0;i<5;++i) printf("h%d %07X ", i, h[i]);
-        printf("\n");
+	int i;
+	for (i=0;i<5;++i) printf("h%d %07X ", i, h[i]);
+	printf("\n");
 
-        printf("armv8_32_poly1305_blocks() data len %d\n", msgDataLen);
+	printf("armv8_32_poly1305_blocks() data len %d\n", msgDataLen);
 #endif
 
-        __asm__ __volatile__ (
-                ".align        8                                \n\t"
+	__asm__ __volatile__ (
+             ".align        8                                \n\t"
                 
                 /* valid registers are r0..r12, sp, lr, pc, cpsr, fpscr */
                 
@@ -178,9 +255,10 @@ void armv8_32_poly1305_blocks(Poly1305* ctx,
                 "LDR        r1, %[r_ptr]                        \n\t"
                 "LDR        r2, %[hibit]                        \n\t"
                 "LDR        r5, %[m]                            \n\t"
+		"LDR	    r3, %[test1]			\n\t"
 
                 "PUSH       { r7 }                              \n\t"
-                "SUB        sp, #28                             \n\t"
+                "SUB        sp, #32                             \n\t"
                 
                 /* -O2 gcc parameters means r7 is not used for local
                    variables, but sp is used for local variables */
@@ -188,6 +266,7 @@ void armv8_32_poly1305_blocks(Poly1305* ctx,
                    via r7 to recently allocated stack space */
                 "STR        r0, [sp, %[BYTES_STORE]]            \n\t"
                 "STR        r2, [sp, %[HIBIT_LOCAL]]            \n\t"
+		"STR        r3, [sp, %[TEST1_LOCAL]]		\n\t"
 
                 "LDM        r1, { r0, r1, r2, r3, r4 }          \n\t"
                 "STM        sp, { r0, r1, r2, r3, r4 }          \n\t"
@@ -256,6 +335,8 @@ void armv8_32_poly1305_blocks(Poly1305* ctx,
                 "ADD        r10, r10, r12                       \n\t"
                 /* h4 += r3 >> 8                   */
                 "ADD        r11, r11, r3, LSR #8                \n\t"  /* 8+32+32+32 = 104 */
+
+		/* r6 = 0797243  r8 = 1DBDD1C  r9 = 3061000  r10 = 18DA5A1  r11 = 16F4620 */
 
                 /* pull in the 26 bit components of the r key */
                 "LDM        sp, { r0, r1, r2, r3, r4 }          \n\t"   /* mem 5 */
@@ -334,7 +415,6 @@ void armv8_32_poly1305_blocks(Poly1305* ctx,
 
                 /* 29DD73 07661C87 */
 
-
                 /* registers r6, r8, r9, r10, r11 must be 
                    populated with above results after accounting 
                    for overflow past 26 bit. */
@@ -346,6 +426,16 @@ void armv8_32_poly1305_blocks(Poly1305* ctx,
 
                 /* d0 overflow to d1 */
                 "POP        { r0, r1, r2, r3, r4, r9, r10, r11 } \n\t"  /* mem 10 */
+
+		/* r12 D10FA341 r14 02929E2 
+	 	   r0  14380FCE  r1 0071FD6 r2 14E3B1DB r3 00CA7F3 
+		   r4  BD0D158C  r9 00BC46F r10 DE32A7D5 r11 0048496 */
+
+		/* r12 CB2EA8BD r14 06165D0
+		   r0 F0475619 r1 044A41C r2 79EE3BD7 r3 02B9EA1 
+                   r4 ED6D017F r9 017E1B1 r10 9C3DCCF2 r11 011E440  */
+
+
 
                 "ADDS       r0, r0, r12, LSR #26                \n\t"
                 "ADC        r1, r1, #0                          \n\t"
@@ -485,7 +575,7 @@ void armv8_32_poly1305_blocks(Poly1305* ctx,
         
         "armv8_32_poly1305_done:                                \n\t"
 
-                "ADD        sp, #28                             \n\t"
+                "ADD        sp, #32                             \n\t"
                 "POP        { r7 }                              \n\t"
 
                 /* store final result */
@@ -496,698 +586,1200 @@ void armv8_32_poly1305_blocks(Poly1305* ctx,
                   [r_ptr]          "+m" (r_ptrLocal),            /* input */
                   [h_ptr]          "+m" (h_ptrLocal),            /* input, output */
                   [bytes]          "+m" (msgDataLenOnStack),     /* input */
-                  [hibit]          "+m" (hibitOnStack)           /* input */
-                  
+                  [hibit]          "+m" (hibitOnStack),          /* input */
+		  [test1]	   "+m" (test1OnStack)
                 : [BYTES_STORE]    "I" (BYTES_SP_OFF),
-                  [HIBIT_LOCAL]    "I" (HIBIT_LOCAL_SP_OFF)
+                  [HIBIT_LOCAL]    "I" (HIBIT_LOCAL_SP_OFF),
+		  [TEST1_LOCAL]    "I" (TEST1_SP_OFF)
                 : "memory", "cc", 
                         "r0", "r1", "r2", "r3", "r4", "r5", "r6", "r8", "r9", "r10",
                         "r11", "r12", "lr"
         );
 
-        memcpy(ctx->r, r, 5 * sizeof(unsigned));
-        memcpy(ctx->h, h, 5 * sizeof(unsigned));
+	/* do reduction */
+	int over;
+	
+	over = h[0]>>26;
+	h[0] = h[0] & 0x3FFFFFF;
+	h[1] += over;
+
+	over = h[1]>>26;
+	h[1] = h[1] & 0x3FFFFFF;
+	h[2] += over;
+	
+	over = h[2]>>26;
+	h[2] = h[2] & 0x3FFFFFF;
+	h[3] += over;
+
+	over = h[3]>>26;
+	h[3] = h[3] & 0x3FFFFFF;
+	h[4] += over;
+
+	over = h[4]>>26;
+	h[4] = h[4] & 0x3FFFFFF;
+
+	h[0] += (over * 5);
+	over = h[0]>>26;
+	h[0] = h[0] & 0x3FFFFFF;
+
+	h[1] += over;
+
+	printf("\nH values  ");
+
+	for (i=0;i<5;++i)
+	{
+//		ctx->h[i] = h1[i];
+		printf("  %X  ", h[i]);
+	}
+	printf("\n\n");
+
+	memcpy(ctx->h, h, 5 * sizeof(unsigned));
 
 #ifdef POLY1305_VERBOSE
-        for (i=0;i<5;++i) printf("h%d %07X ", i, ctx->h[i]);
-        printf("\n");
 
-        printf("armv8_32_poly1305_blocks() leaving\n");
+	printf("\n\ntest array\n\n");
+	for (i=0;i<5;++i) printf("%d %07X ", i, test1Array[i]);
+	printf("\n\n");
+
+	for (i=0;i<5;++i) printf("h%d %07X ", i, ctx->h[i]);
+	printf("\n");
+
+	printf("armv8_32_poly1305_blocks() leaving\n");
 #endif
 
 }
-
 #else
 
-/**********************************************************
-  armv8_32_poly1305_blocks        This routine implements the 
-                        poly1305 algorithm.  The processing
-                        of the 16 byte pieces of the 
-                        message is implemented in assembly.
-                        Care was taken in implementing the
-                        assembly to optimize speed by 
-                        minimizing memory references as
-                        well as minimizing instructions.
-                        The poly1305 algorithm is implemented
-                        by using multiple 26 bit values 
-                        to represent the larger 16 byte and 
-                        17 byte numbers.  Breaking the 
-                        larger numbers down into 26 bit 
-                        pieces means that math operations will
-                        not overflow the 32 bit registers.
-                        For more information reference the article 
-                        NEON Cryto by Daniel Berstein and Peter
-                        Schwabe.
-                        
-                        This version of the algorithm uses 
-                        NEON s registers to temporarily store
-                        values so that the stack does not need
-                        to be used.
-
-  ctx                   poly1305 structure containing the r and
-                        h values broke into 26 bit pieces.
-                        The result of this routine is returned
-                        int the h array of 26 bit values.
-  msgData                Message data to run the algorithm 
-                        against.
-  keyData               256 bit key that is broken down 
-                        into the r and s subcomponents.
-**********************************************************/
 void armv8_32_poly1305_blocks(Poly1305* ctx, 
-                        const unsigned char *msgData,
-                             size_t msgDataLen)
+			const unsigned char *msgData,
+                     	size_t msgDataLen)
 {
-        /* these variables will be referenced via r7 in the assembly */
-        unsigned r[5], *r_ptrLocal, h[5], *h_ptrLocal;
-        unsigned msgDataOnStack = (unsigned)msgData;
-        unsigned msgDataLenOnStack = msgDataLen;
-        unsigned hibitOnStack = (ctx->finished) ? 0 : ((unsigned) 1 << 24);
+	unsigned r[5], *r_ptrLocal, h1[5], h2[5], *h1_ptrLocal;
+	unsigned *h2_ptrLocal, *r2_ptrLocal;
+	unsigned msgDataOnStack = (unsigned)msgData;
+	unsigned msgDataLenOnStack = msgDataLen;
+	/* 1 << 128 */
+ 	unsigned hibitOnStack = (ctx->finished) ? 0 : ((unsigned) 1 << 24); 
+    	unsigned r_2[5];
+	int i;
 
-        memcpy(r, ctx->r, 5 * sizeof(unsigned));
-        memcpy(h, ctx->h, 5 * sizeof(unsigned));
+	memcpy(r, ctx->r, 5*sizeof(unsigned));
 
-        /* 32 bit pointer, this is necessary to pass the pointer value
+	if (msgDataLen <= 16)
+	{
+		memcpy(h1, ctx->h, 5*sizeof(unsigned));
+		memset(h2, 0, 5*sizeof(unsigned));
+	}
+	else
+	{
+		memset(h1, 0, 5*sizeof(unsigned));
+		memcpy(h2, ctx->h, 5*sizeof(unsigned));
+	}
+
+	calculateRsquared(r, r_2);
+
+	/* 32 bit pointer, this is necessary to pass the pointer value
            into the assembly code */
-        r_ptrLocal = (unsigned *) r;
-        h_ptrLocal = (unsigned *) h;
+	r_ptrLocal = (unsigned *) r;
+ 	r2_ptrLocal = r_2;
+	h1_ptrLocal = (unsigned *) h1;
+	h2_ptrLocal = (unsigned *) h2;
 
 #ifdef POLY1305_VERBOSE
-        int i;
-        for (i=0;i<5;++i) printf("h%d %07X ", i, h[i]);
-        printf("\n");
+	int j;
+	printf("armv8_32_poly1305_blocks() >> Before Assembly << ");
+	printf("  length of data (%d) 0x%X\n\n", msgDataLen, msgDataLen);
 
-        printf("armv8_32_poly1305_blocks() data len %d\n", msgDataLen);
+	for (i=0;i<5;++i) 
+		printf("h%d %08X ", i, h1[i]);
+	printf("\n");
+
+	printf(" r ");
+	for (j=0;j<5;++j) 
+		printf(" %d %08X ", j, r[j]);
+	printf("\n");
+	/* 00BED685  03555502  0047C036  01003949  000806D5 */
+	
+	printf(" r^2 ");
+	for (j=0;j<5;++j) 
+		printf(" %d %08X ", j, r_2[j]);
+	printf("\n");
+	
+	/* CA0455  1DD847D  23C50AA  36BC0AC  19106A3 */
 #endif
 
-        __asm__ __volatile__ (
-                ".align     8                                   \n\t"
-                
-                /* valid registers are r0..r12, sp, lr, pc, cpsr, fpscr */
-                
-                /* now load the stored h, this should all zero */
-                "LDR        r5, %[h_ptr]                        \n\t"
-                "LDM        r5, { r6, r8, r9, r10, r11 }        \n\t"
-                /* r6 = h0  r8 = h1  r9 = h2  r10 = h3  r11 = h4 */
-        
-                /* in some cases, r7 is used to reference the local variables 
-                   on the stack; if -O2 is passed to gcc, the sp may used 
-                        used to reference local variables. */
-                "LDR        r0, %[hibit]                        \n\t"
-                "LDR        r1, %[bytes]                        \n\t"
-                "LDR        r2, %[r_ptr]                        \n\t"
+	__asm__ __volatile__ (
+		".align	8	 				\n\t"
 
-                "VMOV       s2, r0                              \n\t"
-                "VMOV       s4, r1                              \n\t"
+		/* valid registers are d0..d31 */
 
-                "LDM        r2, { r0, r1, r2, r3, r4 }          \n\t"
-                "VMOV       s6, r0                              \n\t"
-                "VMOV       s7, r1                              \n\t"
-                "VMOV       s8, r2                              \n\t"
-                "VMOV       s9, r3                              \n\t"
-                "VMOV       s10, r4                             \n\t"
+		//"PUSH		{ r11, r12 }			\n\t"
 
-                "LDR        r5, %[m]                            \n\t"
-                "PUSH       { r7 }                              \n\t"
-                "MOV        r7, r5                              \n\t"
+		/* load r values into d0..d4 */
+		"LDR		r11, %[r_ptr]			\n\t"
+		"LDM		r11, { r0, r1, r2, r3, r4 }	\n\t"
 
-                /* s2 - hibit
-                   s4 - bytes
-                   s6, s7, s8, s9, s10 - r in 26 bit pieces */
+		"LDR		r11, %[r2_ptr]			\n\t"
+		"LDM		r11, { r5, r6, r8, r9, r10 }	\n\t"
 
-        "armv8_32_poly1305_loop:                                \n\t"
+		"VMOV		s0, s1, r0, r5			\n\t"   /* d0 */
+		"VMOV		s2, s3, r1, r6			\n\t"   /* d1 */
+		"VMOV		s4, s5, r2, r8			\n\t"   /* d2 */
+		"VMOV		s6, s7, r3, r9			\n\t"   /* d3 */
+		"VMOV		s8, s9, r4, r10			\n\t"   /* d4 */
 
-                /* The poly1305 algorithm requires that a 01 byte 
-                   be placed after the last byte of the block. */                 
-                
-                "VMOV       r5, s4                              \n\t"
-                "CMP        r5, #0                              \n\t"
-                "BEQ        armv8_32_poly1305_done              \n\t"
-                "SUBS       r5, r5, #16                         \n\t"
-                
-                /* branch for least likely case, may help with pipelining */
-                /* ARMv8 uses predictive pipelining.  There is no way
-                   to specify in the instruction encoding the more likely
-                   case.  */
-                "BLT        armv8_32_poly1305_last_block        \n\t"  
+		"MOV		r0, #5				\n\t"
+		"MUL		r1, r1, r0			\n\t"
+		"MUL		r2, r2, r0			\n\t"
+		"MUL		r3, r3, r0			\n\t"
+		"MUL		r4, r4, r0			\n\t"
 
-                /* this block is 16 bytes */
-                "VMOV       s4, r5                              \n\t"
+		"MUL		r6, r6, r0			\n\t"
+		"MUL		r8, r8, r0			\n\t"
+		"MUL		r9, r9, r0			\n\t"
+		"MUL		r10, r10, r0			\n\t"
 
-                /* load next 16 byte block of message */                
-                "LDM        r7, { r0, r1, r2, r3 }              \n\t"   /* mem 1 */
-                "ADD        r7, r7, #16                         \n\t"
+		"VMOV		s10, s11, r1, r6		\n\t"   /* d5 */
+		"VMOV		s12, s13, r2, r8		\n\t"   /* d6 */
+		"VMOV		s14, s15, r3, r9		\n\t"   /* d7 */
+		"VMOV		s16, s17, r4, r10		\n\t"   /* d8 */
+		
+		/* load h values into d10..d15 */
+		"LDR		r11, %[h_ptr1]			\n\t"
+		"LDM		r11, { r0, r1, r2, r3, r4 }	\n\t"
+		"LDR		r11, %[h_ptr2]			\n\t"
+		"LDM		r11, { r5, r6, r8, r9, r10 }	\n\t"
 
-                /* in RFC 7539, each block processed is prepended by
-                     a byte of value 0x01.  In the wolfSSL implementation,
-                   the setting of this value is based on the value found
-                   in ctx->finish. To save a memory reference, this code
-                   could be replicated one version adding the byte, one
-                   version not. */
+		"VMOV		s18, s19, r0, r5		\n\t"   /* d9  */
+		"VMOV		s20, s21, r1, r6		\n\t"   /* d10 */
+		"VMOV		s22, s23, r2, r8		\n\t"   /* d11 */
+		"VMOV		s24, s25, r3, r9		\n\t"   /* d12 */
+		"VMOV		s26, s27, r4, r10		\n\t"   /* d13 */
 
-                /* This is byte 16, past the 128 bits of w19:w18:w17:w16 
-                   Hence, update is done to h4. */  
-                /* add in hibit */
-                "VMOV       r5, s2                              \n\t"
-                "ADD        r11, r11, r5                        \n\t"
-                        
-        "armv8_32_poly1305_done_01_byte_appended:               \n\t"
+		"VMOV		d24, d9				\n\t"
+		"VMOV		d25, d10			\n\t"
+		"VMOV		d26, d11			\n\t"
+		"VMOV		d27, d12			\n\t"
+		"VMOV		d28, d13			\n\t"
+		"LDR		r1, %[m]			\n\t"
+		"LDR		r2, %[bytes]			\n\t"
+		"LDR		r3, %[hibit]			\n\t"
 
-                "mov        r5, #0x3FFFFFF                      \n\t"
+		"VMOV		s28, s29, r3, r3		\n\t"   /* d14 */
+		"VMOV 		d29, d14 			\n\t"   /* d29 */
 
-                /* break data into 26 bit pieces. 
-                   Bit offsets are 0, 26, 52, 78 and 104 */
-                   
-                /* h0 += r0 & 0x3FFFFFF; */
-                "AND        r12, r0, r5                         \n\t"
-                "ADD        r6, r6, r12                         \n\t"
-                /* h1 += (r1:r0 >> 26) & 0x3FFFFFF */
-                "LSR        r12, r0, #26                        \n\t"   /* 26 */
-                "ADD        r12, r12, r1, LSL #6                \n\t"
-                "AND        r12, r12, r5                        \n\t"
-                "ADD        r8, r8, r12                         \n\t"
-                /* h2 += (r2:r1 >> 20) & 0x3FFFFFF */         
-                "LSR        r12, r1, #20                        \n\t"   /* 20+32 = 52 */
-                "ADD        r12, r12, r2, LSL #12               \n\t"
-                "AND        r12, r12, r5                        \n\t"
-                "ADD        r9, r9, r12                         \n\t"
-                /* h3 += (r3:r2 >> 14) & 0x3FFFFFF */
-                "LSR        r12, r2, #14                        \n\t"   /* 14+32+32 = 78 */
-                "ADD        r12, r12, r3, LSL #18               \n\t"
-                "AND        r12, r12, r5                        \n\t"
-                "ADD        r10, r10, r12                       \n\t"
+		"VMOV.i32	d30, #0x3FFFFFF			\n\t"
+		"VSHR.u64	d30, #32			\n\t"
+
+		"VMOV.i32	d27, #0x5			\n\t"
+		"VSHR.u64	d27, #32			\n\t"
+
+	"armv8_32_poly1305_loop:				\n\t"
+
+		/* The poly1305 algorithm requires that a 01 byte 
+		   be placed after the last byte of the block. */ 		
+
+		"CMP		r2, #0				\n\t"
+		"BEQ		armv8_32_poly1305_done		\n\t"
+	
+		/* branch for least likely case, may help with pipelining */
+		/* ARMv8 uses predictive pipelining.  There is no way
+		   to specify in the instruction encoding the more likely
+		   case.  */
+		"CMP		r2, #16				\n\t"
+		"BLT		armv8_32_poly1305_last_block	\n\t"  
+
+		"SUBS 		r2, r2, #16			\n\t"
+
+		/* this block is 16 bytes */		
+
+		/* load next 16 byte block of message */		
+		"LDM		r1, { r4, r5, r6, r8 }		\n\t"
+		"ADD		r1, r1, #16			\n\t"
+
+		/* in RFC 7539, each block processed is prepended by
+  		   a byte of value 0x01.  In the wolfSSL implementation,
+		   the setting of this value is based on the value found
+		   in ctx->finish. To save a memory reference, this code
+		   could be replicated one version adding the byte, one
+		   version not. */
+
+		/* This is byte 16, past the 128 bits of 
+		   Hence, update is done to h4. */  
+	
+
+	"armv8_32_poly1305_done_01_byte_appended:		\n\t"
+
+		"CMP		r2, #0				\n\t"
+		"BEQ		onlyOneBlock			\n\t"			
+
+	"twoBlocks:						\n\t"
+		/* r4 = 70797243  r5 = 72676F74  r6 = 69687061  r8 = 6F462063 */
+
+		"VMOV		r9, s27				\n\t"
+		"ADD		r9, r9, r3			\n\t"
+		"VMOV		s27, r9				\n\t"
+
+		"MOV	    r9, #0x3FFFFFF			\n\t"
+
+              	/* h0 += r4 & 0x3FFFFFF; */
+		"VMOV	    r10, s19				\n\t"	/* s19, s21 */
+		"VMOV	    r11, s21				\n\t"
+
+                "AND        r0, r4, r9                         \n\t"
+                "ADD        r10, r10, r0                       \n\t"   /* 797243 */
+
+                /* h1 += (r5:r4 >> 26) & 0x3FFFFFF */
+                "LSR        r0, r4, #26                        \n\t"   /* 26 */
+                "ADD        r0, r0, r5, LSL #6                \n\t"
+                "AND        r0, r0, r9                        \n\t"
+                "ADD        r11, r11, r0                       \n\t"   /* 1DBDD1C */
+	
+		"VMOV	    s19, r10				\n\t"
+		"VMOV	    s21, r11				\n\t"	
+
+                /* h2 += (r6:r5 >> 20) & 0x3FFFFFF */
+		"VMOV	    r10, s23				\n\t"  /* s23, s25 */
+		"VMOV	    r11, s25				\n\t"
+
+                "LSR        r0, r5, #20                        \n\t"  /* 20+32 = 52 */
+                "ADD        r0, r0, r6, LSL #12               \n\t"
+                "AND        r0, r0, r9                        \n\t"
+                "ADD        r10, r10, r0                       \n\t"  /* 3061726 */
+                /* h3 += (r8:r6 >> 14) & 0x3FFFFFF */
+                "LSR        r0, r6, #14                        \n\t"  /* 14+32+32 = 78 */
+                "ADD        r0, r0, r8, LSL #18               \n\t"
+                "AND        r0, r0, r9                        \n\t"
+                "ADD        r11, r11, r0                       \n\t"  /* 18dA5A1 */
+
+		"VMOV	    s23, r10				\n\t"
+		"VMOV	    s25, r11				\n\t"
+
                 /* h4 += r3 >> 8                   */
-                "ADD        r11, r11, r3, LSR #8                \n\t"   /* 8+32+32+32 = 104 */
+		"VMOV	    r10, s27				\n\t"
+                "ADD        r10, r10, r8, LSR #8                \n\t"  /* 8+32+32+32 = 104 */
+		"VMOV	    s27, r10				\n\t"  /* 16F4620 */
 
-                /* pull in the 26 bit components of the r key */
-                "VMOV       r0, s6                              \n\t"
-                "VMOV       r1, s7                              \n\t"
-                "VMOV       r2, s8                              \n\t"
-                "VMOV       r3, s9                              \n\t"
-                "VMOV       r4, s10                             \n\t"
+		/* s19 = 0797243  s21 = 1DBDD1C  s23 = 3061726  s25 = 18DA5A1  s27 = 16F4620 */
+		
+		"CMP	    r2, #16				\n\t"
+		"BLT	    armv8_32_poly1305_last_block	\n\t"  
 
-                /* r0 = BED685  r1 = 3555502  r2 = 47C036  r3 = 1003949  r4 = 806D5 */
-                "MOV        r5, #5                              \n\t"
+		/* FIX */
+		"LDM	    r1, { r4, r5, r6, r8 }		\n\t"
+		"ADD	    r1, r1, #16				\n\t"
+		"SUBS 	    r2, r2, #16				\n\t"
 
-        "checkRegs:                                             \n\t"
-                /* d0 = h0 * r0 + h1 * 5*r4 + h2 * 5*r3 + h3 * 5*r2 + h4 * 5*r1 */
-                /* d1 = h0 * r1 + h1 * r0   + h2 * 5*r4 + h3 * 5*r3 + h4 * 5*r2 */
-                /* d2 = h0 * r2 + h1 * r1   + h2 * r0   + h3 * 5*r4 + h4 * 5*r3 */
-                /* d3 = h0 * r3 + h1 * r2   + h2 * r1   + h3 * r0   + h4 * 5*r4 */
-                /* d4 = h0 * r4 + h1 * r3   + h2 * r2   + h3 * r1   + h4 * r0   */
+	"onlyOneBlock:						\n\t"
 
-                /*  r14 is the link register, r13 is the sp */
-                /*  r14:r12 = r6 * r0 + (r8 * r4 +  r9 * r3 +  r10 * r2 +  r11 * r1) * r5 */
-                /*  r14:r12 = r6 * r1 +  r8 * r0 + (r9 * r4 +  r10 * r3 +  r11 * r2) * r5 */
-                /*  r14:r12 = r6 * r2 +  r8 * r1 +  r9 * r0 + (r10 * r4 +  r11 * r3) * r5 */
-                /*  r14:r12 = r6 * r3 +  r8 * r2 +  r9 * r1 +  r10 * r0 + (r11 * r4) * r5 */
-                /*  r14:r12 = r6 * r4 +  r8 * r3 +  r9 * r2 +  r10 * r1 +  r11 * r0       */
+		/* FIX must handle short blocks as well */
+		/* FIX HIBIT */
+		/* set hibit for a full size 16 byte block */
+		"VMOV	    r9, s26				\n\t"
+		"ADD	    r9, r9, r3				\n\t"
+		"VMOV	    s26, r9				\n\t"
 
-                /* d4 */
-                "UMULL      r12, r14, r6, r4                    \n\t"
-                "UMLAL      r12, r14, r8, r3                    \n\t"
-                "UMLAL      r12, r14, r9, r2                    \n\t"
-                "UMLAL      r12, r14, r10, r1                   \n\t"
-                "UMLAL      r12, r14, r11, r0                   \n\t"
+	"onlyOneBlock_hibit_set:				\n\t"
 
-                "VMOV       s12, s13, r12, r14                  \n\t"
+		"MOV	    r9, #0x3FFFFFF 			\n\t"
 
-                /* 8F852 C3AB3DA1 */
+              	/* h0 += r4 & 0x3FFFFFF; */
+		"VMOV	    r10, s18				\n\t"	/* s18, s20 */
+		"VMOV	    r11, s20				\n\t"
 
-                /* d3 */
-                "UMULL      r12, r14, r6, r3                    \n\t"
-                "UMLAL      r12, r14, r8, r2                    \n\t"
-                "UMLAL      r12, r14, r9, r1                    \n\t"
-                "UMLAL      r12, r14, r10, r0                   \n\t"
-                "MUL        r11, r11, r5                        \n\t"
-                "UMLAL      r12, r14, r11, r4                   \n\t"
+                "AND        r0, r4, r9                         \n\t"
+                "ADD        r10, r10, r0                       \n\t"
 
-                "VMOV       s14, s15, r12, r14                  \n\t"
+                /* h1 += (r5:r4 >> 26) & 0x3FFFFFF */
+                "LSR        r0, r4, #26                        \n\t"   /* 26 */
+                "ADD        r0, r0, r5, LSL #6                \n\t"
+                "AND        r0, r0, r9                        \n\t"
+                "ADD        r11, r11, r0                       \n\t"  
+	
+		"VMOV	    s18, r10				\n\t"
+		"VMOV	    s20, r11				\n\t"	
 
-                /* C753B 56120E14 */
+                /* h2 += (r6:r5 >> 20) & 0x3FFFFFF */
+		"VMOV	    r10, s22				\n\t"  /* s22, s24 */
+		"VMOV	    r11, s24				\n\t"
 
-                /* d2 */
-                "UMULL      r12, r14, r6, r2                    \n\t"
-                "UMLAL      r12, r14, r8, r1                    \n\t"
-                "UMLAL      r12, r14, r9, r0                    \n\t"
-                "MUL        r10, r10, r5                        \n\t"
-                "UMLAL      r12, r14, r10, r4                   \n\t"
-                "UMLAL      r12, r14, r11, r3                   \n\t"
+                "LSR        r0, r5, #20                        \n\t"  /* 20+32 = 52 */
+                "ADD        r0, r0, r6, LSL #12               \n\t"
+                "AND        r0, r0, r9                        \n\t"
+                "ADD        r10, r10, r0                       \n\t"  
+                /* h3 += (r8:r6 >> 14) & 0x3FFFFFF */
+                "LSR        r0, r6, #14                        \n\t"  /* 14+32+32 = 78 */
+                "ADD        r0, r0, r8, LSL #18               \n\t"
+                "AND        r0, r0, r9                        \n\t"
+                "ADD        r11, r11, r0                       \n\t"  
 
-                "VMOV       s16, s17, r12, r14                  \n\t"
+		"VMOV	    s22, r10				\n\t"
+		"VMOV	    s24, r11				\n\t"
 
-                /* 10019D F79AAF81 */
+                /* h4 += r3 >> 8                   */
+		"VMOV	    r10, s26				\n\t"  /* s26 */
+                "ADD        r10, r10, r8, LSR #8                \n\t"  /* 8+32+32+32 = 104 */
+		"VMOV	    s26, r10				\n\t" 
 
-                /* d1 */
-                "UMULL      r12, r14, r6, r1                    \n\t"
-                "UMLAL      r12, r14, r8, r0                    \n\t"
-                "MUL        r9, r9, r5                          \n\t"
-                "UMLAL      r12, r14, r9, r4                    \n\t"
-                "UMLAL      r12, r14, r10, r3                   \n\t"
-                "UMLAL      r12, r14, r11, r2                   \n\t"
+		/* s18 = 06D7572  s20 = 0D95488  s22 = 3261657  s24 = 081A18D  s26 = 1746573 */
 
-                "VMOV       s18, s19, r12, r14                  \n\t"
+	"checkRegs:						\n\t"
+		/* partial0 = h0 * r0 + h1 * 5*r4 + h2 * 5*r3 + h3 * 5*r2 + h4 * 5*r1 */
+		/* partial1 = h0 * r1 + h1 * r0   + h2 * 5*r4 + h3 * 5*r3 + h4 * 5*r2 */
+		/* partial2 = h0 * r2 + h1 * r1   + h2 * r0   + h3 * 5*r4 + h4 * 5*r3 */
+		/* partial3 = h0 * r3 + h1 * r2   + h2 * r1   + h3 * r0   + h4 * 5*r4 */
+		/* partial4 = h0 * r4 + h1 * r3   + h2 * r2   + h3 * r1   + h4 * r0   */
 
-                /* D3993 E9038575 */
+	
+		/*  d15 = d9 * d0 +  d10 * d8 +  d11 * d7 +  d12 * d6 +  d13 * d5 */
+		/*  d16 = d9 * d1 +  d10 * d0 +  d11 * d8 +  d12 * d7 +  d13 * d6 */
+		/*  d17 = d9 * d2 +  d10 * d1 +  d11 * d0 +  d12 * d8 +  d13 * d7 */
+		/*  d18 = d9 * d3 +  d10 * d2 +  d11 * d1 +  d12 * d0 +  d13 * d8 */
+		/*  d19 = d9 * d4 +  d10 * d3 +  d11 * d2 +  d12 * d1 +  d13 * d0  */
 
-                /* d0 */
-                "UMULL      r12, r14, r6, r0                    \n\t"
-                "MUL        r8, r8, r5                          \n\t"
-                "UMLAL      r12, r14, r8, r4                    \n\t"
-                "UMLAL      r12, r14, r9, r3                    \n\t"
-                "UMLAL      r12, r14, r10, r2                   \n\t"
-                "UMLAL      r12, r14, r11, r1                   \n\t"
 
-                /* 29DD73 07661C87 */
+		/* registers d15, d16, d17, d18, d19 contain the 
+		   incremental d results. */
 
-                /* registers r6, r8, r9, r10, r11 must be 
-                   populated with above results after accounting 
-                   for overflow past 26 bit. */
 
-                /* doing d0 --> d1 --> d2 --> d3 --> d4 --> d1 -->d2 */
+      		/* partial0 = q8 = d17:d16 */
+		"VMULL.u32	q8,  d9, d0   			\n\t"
+		"VMLAL.u32	q8, d10, d8   			\n\t"
+		"VMLAL.u32	q8, d11, d7   			\n\t"
+		"VMLAL.u32	q8, d12, d6   			\n\t"
+		"VMLAL.u32	q8, d13, d5   			\n\t"
+		/* 29DD73 07661C87 */
 
-                "MOV        r5, #0x3FFFFFF                      \n\t"
-                "AND        r6, r12, r5                         \n\t"  /* d0 */
+      		/* partial1 = q9 = d19:d18 */
+		"VMULL.u32	q9,  d9, d1   			\n\t"
+		"VMLAL.u32	q9, d10, d0   			\n\t"
+		"VMLAL.u32	q9, d11, d8   			\n\t"
+		"VMLAL.u32	q9, d12, d7   			\n\t"
+		"VMLAL.u32	q9, d13, d6   			\n\t"
+		/* D3993 E9038575 */
 
-                /* d0 overflow to d1 */
+ 		/* partial1 = q10 = d21:d20 */
+		"VMULL.u32	q10,  d9, d2   			\n\t"
+		"VMLAL.u32	q10, d10, d1   			\n\t"
+		"VMLAL.u32	q10, d11, d0   			\n\t"
+		"VMLAL.u32	q10, d12, d8   			\n\t"
+		"VMLAL.u32	q10, d13, d7   			\n\t"
+		/* 10019D F79AAF81 */
 
-                "VMOV       r0, r1, s18, s19                    \n\t"
-                "ADDS       r0, r0, r12, LSR #26                \n\t"
-                "ADC        r1, r1, #0                          \n\t"
-                "ADDS       r0, r0, r14, LSL #6                 \n\t"
-                "ADC        r1, r1, #0                          \n\t"
+ 		/* partial1 = q11 = d23:d22 */
+		"VMULL.u32	q11,  d9, d3   			\n\t"
+		"VMLAL.u32	q11, d10, d2   			\n\t"
+		"VMLAL.u32	q11, d11, d1   			\n\t"
+		"VMLAL.u32	q11, d12, d0   			\n\t"
+		"VMLAL.u32	q11, d13, d8   			\n\t"
+		/* C753B 56120E14 */
 
-                "AND        r8, r0, r5                          \n\t"  /* d1 */
+ 		/* partial1 = q12 = d25:d24 */
+		"VMULL.u32	q12,  d9, d4   			\n\t"
+		"VMLAL.u32	q12, d10, d3   			\n\t"
+		"VMLAL.u32	q12, d11, d2   			\n\t"
+		"VMLAL.u32	q12, d12, d1   			\n\t"
+		"VMLAL.u32	q12, d13, d0   			\n\t"
+	        /* 8F852 C3AB3DA1 */
 
-                /* d1 overflow to d2 */
+		/* message buff 1 times r 
+		   d16 = 02929E2 D10FA341 
+	 	   d18 = 0071FD6 14380FCE 
+		   d20 = 00CA7F3 14E3B1DB 
+		   d22 = 00BC46F BD0D158C  
+		   d24 = 0048496 DE32A7D5 */
 
-                "VMOV       r2, r3, s16, s17                    \n\t"
-                "ADDS       r2, r2, r0, LSR #26                 \n\t"
-                "ADC        r3, r3, #0                          \n\t"
-                "ADDS       r2, r2, r1, LSL #6                  \n\t"
-                "ADC        r3, r3, #0                          \n\t"
+		/* message buff 2 times r squared 
+		   d17 = 06165D0 CB2EA8BD 
+		   d19 = 044A41C F0475619 
+		   d21 = 02B9EA1 79EE3BD7 
+                   d23 = 017E1B1 ED6D017F 
+		   d25 = 011E440 9C3DCCF2 */
 
-                "AND        r9, r2, r5                          \n\t"  /* d2 */
+		/* doing d0 --> d1 --> d2 --> d3 --> d4 --> d1 -->d2 */
+		
+		/* d16 --> d18 --> d20 --> d22 --> d24 --> d16 --> d18 */
 
-                /* d2 overflow to d3 */
+		/* d0 = d16 * 0x3FFFFF */
+		"VAND.u64	d15, d16, d30			\n\t"  
+		"VMOV 		s18, s30			\n\t"	/* d0 */
 
-                "VMOV       r0, r1, s14, s15                    \n\t"
-                "ADDS       r0, r0, r2, LSR #26                 \n\t"
-                "ADC        r1, r1, #0                          \n\t"
-                "ADDS       r0, r0, r3, LSL #6                  \n\t"
-                "ADC        r1, r1, #0                          \n\t"
+		/* d9 = 10FA341 value before wrap around */
 
-                "AND        r10, r0, r5                         \n\t"  /* d3 */
+		/* d1 = (d18 + (d16 >> 26)) & 0x3FFFFFF */
+		"VSHR.u64	d28, d16, #26			\n\t"
+		"VADD.u64	d18, d18, d28			\n\t"
+		"VAND.u64	d15, d18, d30			\n\t"   /* d1 */
+		"VMOV		s20, s30			\n\t"
 
-                /* d3 overflow to d4 */
+		/* d10 = 43EA6A8   */
 
-                "VMOV       r2, r3, s12, s13                    \n\t"
-                "ADDS       r2, r2, r0, LSR #26                 \n\t"
-                "ADC        r3, r3, #0                          \n\t"
-                "ADDS       r2, r2, r1, LSL #6                  \n\t"
-                "ADC        r3, r3, #0                          \n\t"
+		/* d1 overflow to d2 */
 
-                "AND        r11, r2, r5                         \n\t"  /* d4 */
+		/* d2 = (d20 + (d18 >> 26)) & 0x3FFFFFF */
+		"VSHR.u64	d28, d18, #26			\n\t"
+		"VADD.u64	d20, d20, d28			\n\t"
+		"VAND.u64	d15, d20, d30			\n\t"   /* d2 */
+		"VMOV		s22, s30			\n\t"		
 
-                /* d4 overflow to d0, must be multiplied by 5 */        
+		/* d2 overflow to d3 */
 
-                "LSR        r0, r2, #26                         \n\t"
-                "ADD        r0, r0, r3, LSL #6                  \n\t"
-                "MOV        r1, #5                              \n\t"        
-                "MUL        r0, r0, r1                          \n\t"
-                "ADD        r6, r6, r0                          \n\t"  /* d0 updated */
+		"VSHR.u64	d28, d20, #26			\n\t"
+		"VADD.u64	d22, d22, d28			\n\t"
+		"VAND.u64	d15, d22, d30			\n\t"   /* d3 */
+		"VMOV		s24, s30			\n\t"
 
-                /* d0 overflow to d1 */
+		/* d3 overflow to d4 */
 
-                "ADD        r8, r8, r6, LSR #26                 \n\t"  /* d1 done */
+		"VSHR.u64	d28, d22, #26			\n\t"
+		"VADD.u64	d24, d24, d28			\n\t"
+		"VAND.u64	d15, d24, d30			\n\t"   /* d4 */
+		"VMOV		s26, s30			\n\t"
+		
+		/* d4 overflow to d0 */
 
-                "AND        r6, r6, r5                          \n\t"  /* d0 done */
+		"VSHR.u64	d15, d24, #26			\n\t"
+		/* multiply d15 by 5 */
+		"VMOV		r6, s30				\n\t"
+		"MOV		r5, #5				\n\t"
+		"MUL		r6, r5, r6			\n\t"
+		"VMOV		r4, s18				\n\t"
+		"ADD		r4, r4, r6			\n\t"   /* d0 + 5 * d4 roll over */
+		
+		"MOV		r5, #0x3FFFFFF			\n\t"
+		"AND		r8, r4, r5			\n\t"
+		"VMOV		s18, r8				\n\t"
+		
+		"VMOV		r6, s20				\n\t"	
+		"ADD		r6, r6, r4, LSR #26		\n\t"
+		"VMOV		s20, r6				\n\t"
 
-                "B          armv8_32_poly1305_loop              \n\t"
-        
-        "armv8_32_poly1305_last_block:                          \n\t"
 
-                /* This is the last block of the message
-                   and the block is less than 16 byte */
+		/* final H values : d9 = 2B55FD9  d10 = 2828883  d11 = 2ABA762 
+				   d12 = 371251  d13 = 123C3C5 */
 
-                /* set s4 to 0, d2 is s5:s4 */
-                "VEOR       d2, d2                              \n\t"
-        
-                "VMOV       r0, s2                              \n\t"  /* hibit */
 
-                /* Make sure the upper bytes of the 
-                   32 bit pieces are set to zero. 
-                   Set the byte past the last message
-                   data byte to 01. */
+		/* doing d0 --> d1 --> d2 --> d3 --> d4 --> d1 -->d2 */
+		
+		/* d17 --> d19 --> d21 --> d23 --> d25 --> d17 --> d19 */
 
-                "PUSH        { r4, r6, r8 }                     \n\t"        
+		/* d0 = d16 * 0x3FFFFF */
+		"VAND.u64	d15, d17, d30			\n\t"  
+		"VMOV 		s19, s30			\n\t"	/* d0 */
 
-                "MOV        r1,  #0                             \n\t"
-                "MOV        r2,  #0                             \n\t"
-                "MOV        r3,  #0                             \n\t"
-                "MOV        r4,  #0xFFFFFFFF                    \n\t"
-                "LSR        r0,  r0, #24                        \n\t"
-                "MOV        r6,  r0                             \n\t"
+		/* d9 = 10FA341 value before wrap around */
 
-                /* always going to load at least one */                
-                "LDR        r0, [r7]                            \n\t"
+		/* d1 = (d18 + (d16 >> 26)) & 0x3FFFFFF */
+		"VSHR.u64	d28, d17, #26			\n\t"
+		"VADD.u64	d19, d19, d28			\n\t"
+		"VAND.u64	d15, d19, d30			\n\t"   /* d1 */
+		"VMOV		s21, s30			\n\t"
 
-                /* byte offset to bit offset */ 
-                "ADD        r5, r5, #16                         \n\t"
-                "LSL        r5, r5, #3                          \n\t"                        
+		/* d10 = 43EA6A8   */
 
-                /* which block */
-                "CMP        r5, #32                             \n\t"
-                "BGE        not_word_0                          \n\t"
+		/* d1 overflow to d2 */
 
-                /* case word 0 */
-        "case0:"
-                "LSL        r8, r4, r5                          \n\t"
-                "BIC        r0, r0, r8                          \n\t"
-                "LSL        r8, r6, r5                          \n\t"
-                "ADD        r0, r0, r8                          \n\t"
-                "B          last_block_done                     \n\t"
+		/* d2 = (d20 + (d18 >> 26)) & 0x3FFFFFF */
+		"VSHR.u64	d28, d19, #26			\n\t"
+		"VADD.u64	d21, d21, d28			\n\t"
+		"VAND.u64	d15, d21, d30			\n\t"   /* d2 */
+		"VMOV		s23, s30			\n\t"		
 
-        "not_word_0:                                            \n\t"
-                "LDR        r1, [r7, #4]                        \n\t"
-                
-                "SUB        r5, r5, #32                         \n\t"
-                "CMP        r5, #32                             \n\t"
-                "BGE        not_word_1                          \n\t"
+		/* d2 overflow to d3 */
 
-                "LSL        r8, r4, r5                          \n\t"
-                "BIC        r1, r1, r8                          \n\t"
-                "LSL        r8, r6, r5                          \n\t"
-                "ADD        r1, r1, r8                          \n\t"                
-                "B          last_block_done                     \n\t"
+		"VSHR.u64	d28, d21, #26			\n\t"
+		"VADD.u64	d23, d23, d28			\n\t"
+		"VAND.u64	d15, d23, d30			\n\t"   /* d3 */
+		"VMOV		s25, s30			\n\t"
 
-        "not_word_1:                                            \n\t"
-                "LDR        r2, [r7, #8]                        \n\t"
+		/* d3 overflow to d4 */
 
-                "SUB        r5, r5, #32                         \n\t"
-                "CMP        r5, #32                             \n\t"
-                "BGE        not_word_2                          \n\t"
+		"VSHR.u64	d28, d23, #26			\n\t"
+		"VADD.u64	d25, d25, d28			\n\t"
+		"VAND.u64	d15, d25, d30			\n\t"   /* d4 */
+		"VMOV		s27, s30			\n\t"
+		
+		/* d4 overflow to d0 */
 
-                "LSL        r8, r4, r5                          \n\t"
-                "BIC        r2, r2, r8                          \n\t"
-                "LSL        r8, r6, r5                          \n\t"
-                "ADD        r2, r2, r8                          \n\t"                
-                "B          last_block_done                     \n\t"
+		"VSHR.u64	d15, d25, #26			\n\t"
+		/* multiply d15 by 5 */
+		"VMOV		r6, s30				\n\t"
+		"MOV		r5, #5				\n\t"
+		"MUL		r6, r5, r6			\n\t"
+		"VMOV		r4, s19				\n\t"
+		"ADD		r4, r4, r6			\n\t"   /* d0 + 5 * d4 roll over */
+		
+		"MOV		r5, #0x3FFFFFF			\n\t"
+		"AND		r8, r4, r5			\n\t"
+		"VMOV		s19, r8				\n\t"
+		
+		"VMOV		r6, s21				\n\t"	
+		"ADD		r6, r6, r4, LSR #26		\n\t"
+		"VMOV		s21, r6				\n\t"
 
-        "not_word_2:                                            \n\t"
-                "LDR        r3, [r7, #0xC]                      \n\t"
+		/* final H values : d9 = 18BF985  d10 = A0CA51  d11 = 3174319  
+				   d12 = 54A9E1  d13 = 2363970 */
 
-                "SUB        r5, r5, #32                         \n\t"
+		"CMP 		r2, #0x10  		 \n\t"
+		"BLE		oneBlockLeft		 \n\t"
 
-                "LSL        r8, r4, r5                          \n\t"
-                "BIC        r3, r3, r8                          \n\t"
-                "LSL        r8, r6, r5                          \n\t"
-                "ADD        r3, r3, r8                          \n\t"        
+		/* add the two h vectors together */
+		"MOV		r5, #0			\n\t"
+		"VMOV		r4, r10, s18, s19	\n\t"
+		"ADD		r4, r4, r10		\n\t"
+		"VMOV		s18, s19, r5, r4	\n\t"
 
-        "last_block_done:                                       \n\t"
+		"VMOV		r4, r10, s20, s21	\n\t"
+		"ADD		r4, r4, r10		\n\t"
+		"VMOV		s20, s21, r5, r4	\n\t"
 
-                "POP        { r4, r6, r8 }                      \n\t"        
-        
-                "b          armv8_32_poly1305_done_01_byte_appended \n\t"
-        
-                ".align 2 \n\t"
-        "armv8_32_poly1305_done:                                \n\t"
-                "POP        { r7 }                              \n\t"
+		"VMOV		r4, r10, s22, s23	\n\t"
+		"ADD		r4, r4, r10		\n\t"
+		"VMOV		s22, s23, r5, r4	\n\t"
+
+		"VMOV		r4, r10, s24, s25	\n\t"
+		"ADD		r4, r4, r10		\n\t"
+		"VMOV		s24, s25, r5, r4	\n\t"
+
+		"VMOV		r4, r10, s26, s27	\n\t"
+		"ADD		r4, r4, r10		\n\t"
+		"VMOV		s26, s27, r5, r4	\n\t"
+		"B		armv8_32_poly1305_loop	\n\t"
+
+	"oneBlockLeft: 					\n\t"
+		/* only one block left in message */
+		/* add the two h vectors together */
+		"MOV		r5, #0			\n\t"
+		"VMOV		r4, r10, s18, s19	\n\t"
+		"ADD		r4, r4, r10		\n\t"
+		"VMOV		s18, s19, r4, r5	\n\t"
+
+		"VMOV		r4, r10, s20, s21	\n\t"
+		"ADD		r4, r4, r10		\n\t"
+		"VMOV		s20, s21, r4, r5	\n\t"
+
+		"VMOV		r4, r10, s22, s23	\n\t"
+		"ADD		r4, r4, r10		\n\t"
+		"VMOV		s22, s23, r4, r5	\n\t"
+
+		"VMOV		r4, r10, s24, s25	\n\t"
+		"ADD		r4, r4, r10		\n\t"
+		"VMOV		s24, s25, r4, r5	\n\t"
+
+		"VMOV		r4, r10, s26, s27	\n\t"
+		"ADD		r4, r4, r10		\n\t"
+		"VMOV		s26, s27, r4, r5	\n\t"
+		"B		armv8_32_poly1305_loop	\n\t"
+	
+	"armv8_32_poly1305_last_block:			\n\t"
+
+		/* This is the last block of the message
+		   and the block is less than 16 bytes */
+
+		/* r1 is message pointer
+		   r2 is byte count, which is less than 16 
+		   r3 is hibit	*/
+
+		/* Make sure the upper bytes of the 
+		   32 bit pieces are set to zero. 
+		   Set the byte past the last message
+		   data byte to 01. */
+
+		"MOV	r10, r2				\n\t"
+
+		"PUSH	{ r0, r1, r2, r3 } 		\n\t"
+
+		"MOV	r9,  r1				\n\t"	
+
+		"LSR	r3,  r3, #24			\n\t"
+		"MOV	r6,  r3				\n\t"
+
+		"MOV    r1,  #0				\n\t"
+		"MOV	r2,  #0				\n\t"
+		"MOV	r3,  #0				\n\t"
+		"MOV	r4,  #0xFFFFFFFF		\n\t"
+
+		/* always going to load at least one */		
+		"LDR	r0, [r9]			\n\t"
+
+		/* byte offset to bit offset */ 
+		"LSL	r10, r10, #3			\n\t"			
+
+		/* which block */
+		"CMP	r10, #32			\n\t"
+		"BGE	not_word_0			\n\t"
+
+		/* case word 0 */
+	"case0:"
+		"LSL	r8, r4, r10			\n\t"
+		"BIC  	r0, r0, r8			\n\t"
+		"LSL	r8, r6, r10			\n\t"
+		"ADD	r0, r0, r8			\n\t"
+		"B	last_block_done			\n\t"
+
+	"not_word_0:	 				\n\t"
+		"LDR	r1, [r9, #4]			\n\t"
+		
+		"SUB	r10, r10, #32			\n\t"
+		"CMP	r10, #32			\n\t"
+		"BGE	not_word_1			\n\t"
+
+		"LSL	r8, r4, r10			\n\t"
+		"BIC  	r1, r1, r8			\n\t"
+		"LSL	r8, r6, r10			\n\t"
+		"ADD	r1, r1, r8			\n\t"		
+		"B	last_block_done			\n\t"
+
+	"not_word_1:					\n\t"
+		"LDR	r2, [r9, #8]			\n\t"
+
+		"SUB	r10, r10, #32			\n\t"
+		"CMP	r10, #32			\n\t"
+		"BGE	not_word_2			\n\t"
+
+		"LSL	r8, r4, r10			\n\t"
+		"BIC  	r2, r2, r8			\n\t"
+		"LSL	r8, r6, r10			\n\t"
+		"ADD	r2, r2, r8			\n\t"		
+		"B	last_block_done			\n\t"
+
+	"not_word_2:					\n\t"
+		"LDR	r3, [r9, #0xC]			\n\t"
+
+		"SUB	r10, r10, #32			\n\t"
+
+		"LSL	r8, r4, r10			\n\t"
+		"BIC  	r3, r3, r8			\n\t"
+		"LSL	r8, r6, r10			\n\t"
+		"ADD	r3, r3, r8			\n\t"	
+
+	"last_block_done:				\n\t"
+
+		"MOV 	r4, r0				\n\t"
+		"MOV 	r5, r1				\n\t"
+		"MOV 	r6, r2				\n\t"
+		"MOV 	r8, r3				\n\t"
+
+		"POP	{ r0, r1, r2, r3 }	\n\t"	
+
+		/* set the byte count to 0 */
+		"MOV		r2, #0			\n\t"
+	
+		"b		onlyOneBlock_hibit_set	\n\t"	
+
+		"b 	armv8_32_poly1305_done_01_byte_appended \n\t"
+	
+		".align 2 \n\t"
+	"armv8_32_poly1305_done:			\n\t"
+
+		"VMOV	r0, s18				\n\t"
+		"VMOV	r1, s20				\n\t"
+		"VMOV	r2, s22				\n\t"
+		"VMOV	r3, s24				\n\t"
+		"VMOV	r4, s26				\n\t"
 
                 /* store final result */
-                "LDR        r0, %[h_ptr]                        \n\t"
-                "STM        r0, { r6, r8, r9, r10, r11 }        \n\t"
-                
-                : [m]            "+m" (msgDataOnStack),        /* input */
-                  [r_ptr]        "+m" (r_ptrLocal),            /* input */
-                  [h_ptr]        "+m" (h_ptrLocal),            /* input, output */
-                  [bytes]        "+m" (msgDataLenOnStack),     /* input */
-                  [hibit]        "+m" (hibitOnStack)           /* input */
-                : 
-                : "memory", "cc", 
-                        "r0", "r1", "r2", "r3", "r4", "r5", "r6", "r8", "r9", "r10",
-                        "r11", "r12", "lr",
-                        "s2", "s4", "s6", "s7", "s8", "s9", "s10", "d2",
-                        "s12", "s13", "s14", "s15", "s16", "s17", "s18", "s19"
-        );
+                "LDR    r10, %[h_ptr1]                   \n\t"
+                "STM    r10, { r0, r1, r2, r3, r4 }      \n\t"
 
-        memcpy(ctx->r, r, 5 * sizeof(unsigned));
-        memcpy(ctx->h, h, 5 * sizeof(unsigned));
+		//"POP	{ r11, r12 }			 \n\t"
+
+		: [m] 		  "+m" (msgDataOnStack),	/* input */
+		  [r_ptr]  	  "+m" (r_ptrLocal),		/* input */
+		  [r2_ptr]	  "+m" (r2_ptrLocal),		/* input */
+		  [h_ptr1]  	  "+m" (h1_ptrLocal),		/* input, output */
+		  [h_ptr2]  	  "+m" (h2_ptrLocal),		/* input, output */
+		  [bytes]  	  "+m" (msgDataLenOnStack),	/* input */
+		  [hibit]	  "+m" (hibitOnStack)		/* input */
+		: [BYTES_STORE]    "I" (BYTES_SP_OFF),
+		  [HIBIT_LOCAL]    "I" (HIBIT_LOCAL_SP_OFF)
+		: "memory", "cc", 
+			"r0", "r1", "r2", "r3", "r4",
+			"r5", "r6", "r8", "r9", "r10",
+			"r11",
+			"r12",
+			"d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+			"d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18",
+			"d19", "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27",
+			"d28", "d29", "d30", "d31"
+	);
+
+
+	/* do reduction */
+	int over;
+	
+	over = h1[0]>>26;
+	h1[0] = h1[0] & 0x3FFFFFF;
+	h1[1] += over;
+
+	over = h1[1]>>26;
+	h1[1] = h1[1] & 0x3FFFFFF;
+	h1[2] += over;
+	
+	over = h1[2]>>26;
+	h1[2] = h1[2] & 0x3FFFFFF;
+	h1[3] += over;
+
+	over = h1[3]>>26;
+	h1[3] = h1[3] & 0x3FFFFFF;
+	h1[4] += over;
+
+	over = h1[4]>>26;
+	h1[4] = h1[4] & 0x3FFFFFF;
+
+	h1[0] += (over * 5);
+	over = h1[0]>>26;
+	h1[0] = h1[0] & 0x3FFFFFF;
+
+	h1[1] += over;
+
+	printf("\nH values  ");
+	for (i=0;i<5;++i)
+	{
+		ctx->h[i] = h1[i];
+		printf("  %X  ", h1[i]);
+	}
+	printf("\n\n");
+	
 
 #ifdef POLY1305_VERBOSE
-        for (i=0;i<5;++i) printf("h%d %07X ", i, ctx->h[i]);
-        printf("\n");
-
-        printf("armv8_32_poly1305_blocks() leaving\n");
+	printf("\narmv8_32_poly1305_blocks() leaving\n");
 #endif
 
 }
 
 #endif  /* #ifdef  WOLFSSL_ARMASM_NO_NEON */
 
-#endif  /* #ifndef __aarch64__   */
+#endif	/* #ifndef __aarch64__   */
 #endif  /* #ifdef  WOLFSSL_ARMASM */
 
 
+/**********************************************************
+  assembly test code  this code can be placed in the NEON 
+  assembly routine to copy out the d registers
+**********************************************************/
+#if 0
+
+	"testArray:  \n\t"
+		"LDR 		r6, %[test1] \n\t"
+		"VSTR 		d0, [r6, #0] \n\t" 	
+		"VSTR 		d1, [r6, #8] \n\t" 	
+		"VSTR 		d2, [r6, #0x10] \n\t" 	
+		"VSTR 		d3, [r6, #0x18] \n\t" 	
+		"VSTR 		d4, [r6, #0x20] \n\t" 
+		"VSTR 		d5, [r6, #0x28] \n\t" 	
+		"VSTR 		d6, [r6, #0x30] \n\t" 	
+		"VSTR 		d7, [r6, #0x38] \n\t" 	
+		"VSTR 		d8, [r6, #0x40] \n\t" 	
+		"VSTR 		d9, [r6, #0x48] \n\t" 
+		"VSTR 		d10, [r6, #0x50] \n\t" 	
+		"VSTR 		d11, [r6, #0x58] \n\t" 	
+		"VSTR 		d12, [r6, #0x60] \n\t" 	
+		"VSTR 		d13, [r6, #0x68] \n\t" 	
+		"VSTR 		d14, [r6, #0x70] \n\t" 
+		"VSTR 		d15, [r6, #0x78] \n\t" 	
+
+		"VSTR 		d16, [r6, #0x80] \n\t" 	
+		"VSTR 		d17, [r6, #0x88] \n\t" 
+		"VSTR 		d18, [r6, #0x90] \n\t" 	
+		"VSTR 		d19, [r6, #0x98] \n\t" 	
+		"VSTR 		d20, [r6, #0xA0] \n\t" 	
+		"VSTR 		d21, [r6, #0xA8] \n\t" 	
+		"VSTR 		d22, [r6, #0xB0] \n\t" 
+		"VSTR 		d23, [r6, #0xB8] \n\t" 	
+
+		"VSTR 		d24, [r6, #0xC0] \n\t" 	
+		"VSTR 		d25, [r6, #0xC8] \n\t" 
+		"VSTR 		d26, [r6, #0xD0] \n\t" 	
+		"VSTR 		d27, [r6, #0xD8] \n\t" 	
+		"VSTR 		d28, [r6, #0xE0] \n\t" 	
+		"VSTR 		d29, [r6, #0xE8] \n\t" 	
+		"VSTR 		d30, [r6, #0xF0] \n\t" 
+		"VSTR 		d31, [r6, #0xF8] \n\t" 	
+
+void output_test_array(unsigned *test1Array)
+{
+	int i;
+
+	printf("\n\n THIS stuff \n\n");
+	for (i=0;i<64;){
+		 printf("%d %08X ", i/2, test1Array[i+1]);
+		 printf(" %08X \n",  test1Array[i]);
+		 i+=2;
+	}
+}
+
+
+
+
+#endif
 
 
 #ifdef POLY1305_STAND_ALONE
 
 /**********************************************************
-  print16        Output the given 16 bytes as one big
-                number.  Note 16 bytes is 128 bit.
+  print16	Output the given 16 bytes as one big
+		number.  Note 16 bytes is 128 bit.
 **********************************************************/
 void print16(const char *startText, unsigned char *data);
 void print16(const char *startText, unsigned char *data)
 {
-        printf("%s %08X %08X %08X %08X\n", startText, *(unsigned*)(data+0xc),
-                        *(unsigned*)(data+0x8),
-                        *(unsigned*)(data+4),
-                        *(unsigned*)data);
+	printf("%s %08X %08X %08X %08X\n", startText, *(unsigned*)(data+0xc),
+			*(unsigned*)(data+0x8),
+			*(unsigned*)(data+4),
+			*(unsigned*)data);
 }
 
 
 /**********************************************************
-  print17        Output the given 17 bytes as one big
-                number.  
+  print17	Output the given 17 bytes as one big
+		number.  
 **********************************************************/
 void print17(const char *startText, unsigned char *data);
 void print17(const char *startText, unsigned char *data)
 {
-        printf("%s %02X %08X%08X %08X%08X \n", startText, data[16], 
-                                *(unsigned *)(data+0xC), *(unsigned *)(data+8),
-                                *(unsigned *)(data+4), *(unsigned *)(data));
+	printf("%s %02X %08X%08X %08X%08X \n", startText, data[16], 
+				*(unsigned *)(data+0xC), *(unsigned *)(data+8),
+				*(unsigned *)(data+4), *(unsigned *)(data));
 }
 
 
 /**********************************************************
-  printBytes        Print the specified number of bytes, one
-                byte at a time.
+  printBytes	Print the specified number of bytes, one
+		byte at a time.
 **********************************************************/
 void printBytes(const char *startText, unsigned char *data, int len);
 void printBytes(const char *startText, unsigned char *data, int len)
 {
-        int i;
-        
-        printf("%s", startText);
-        
-        for (i=0;i<len;++i)
-        {
-                printf("%02X", data[i]);
-                if (i<len-1) printf(":");
-        }
-        printf("\n");
+	int i;
+	
+	printf("%s", startText);
+	
+	for (i=0;i<len;++i)
+	{
+		printf("%02X", data[i]);
+		if (i<len-1) printf(":");
+	}
+	printf("\n");
 }
 
 
 /**********************************************************
-  clamp_r        Set the correct bits in the 128 bit r key
-                to zero.
+  clamp_r	Set the correct bits in the 128 bit r key
+		to zero.
 **********************************************************/
 void clamp_r(unsigned char *r);
 void clamp_r(unsigned char *r)
 {
-        printBytes("r = ", r, 16);
-        
-        r[3] &= 0xF;
-        r[7] &= 0xF;
-        r[11] &= 0xF;
-        r[15] &= 0xF;
-        
-        r[4] &= 0xFC;
-        r[8] &= 0xFC;
-        r[12] &= 0xFC;
-        
-        print16("after clamp ", r);
+	printBytes("r = ", r, 16);
+	
+	r[3] &= 0xF;
+	r[7] &= 0xF;
+	r[11] &= 0xF;
+	r[15] &= 0xF;
+	
+	r[4] &= 0xFC;
+	r[8] &= 0xFC;
+	r[12] &= 0xFC;
+	
+	print16("after clamp ", r);
 }
 
 
 /**********************************************************
-  add17                Add two 17 byte numbers together.  This is
-                used as part of the algorithm to combine
-                26 bit pieces into one 17 byte number.
+  add17		Add two 17 byte numbers together.  This is
+		used as part of the algorithm to combine
+		26 bit pieces into one 17 byte number.
 **********************************************************/
 void add17(unsigned char *dest, unsigned char *src);
 void add17(unsigned char *dest, unsigned char *src)
 {
-        int i;
-        short result;
-        unsigned char of=0;
-        
-        for (i=0;i<17;++i)
-        {
-                result = dest[i] + src[i] + of;
-                
-                dest[i] = (unsigned char)result;
-                
-                if (result & 0xFF00) of=1; else of=0; 
-        }
+	int i;
+	short result;
+	unsigned char of=0;
+	
+	for (i=0;i<17;++i)
+	{
+		result = dest[i] + src[i] + of;
+		
+		dest[i] = (unsigned char)result;
+		
+		if (result & 0xFF00) of=1; else of=0; 
+	}
 }
 
 
 /**********************************************************
   convert26BitValuesTo17Byte
-                Convert the 5 specified 26 bit values to
-                a single 17 byte value.
-  input16Bit        Input array of 5 26 bit values.  
-  result        Output of 17 bytes which represent one
-                130 bit number.
-**********************************************************/
+		Convert the 5 specified 26 bit values to
+		a single 17 byte value.
+  input16Bit	Input array of 5 26 bit values.  
+  result	Output of 17 bytes which represent one
+		130 bit number.
+*********************************************************/
 void convert26BitValuesTo17Byte(unsigned *input26Bit, unsigned char *result);
 void convert26BitValuesTo17Byte(unsigned *input26Bit, unsigned char *result)
 {
-        unsigned char tmp[17];
+	unsigned char tmp[25];
+	unsigned over, val24;
 
-        memset(result, 0, 17);
-        *(unsigned*)(result+0) = input26Bit[0];
+	memset(result, 0, 17);
+	*(unsigned *)(result+0) = (unsigned)input26Bit[0];		/* 0 */
 
-        memset(tmp, 0, 17);
-        *(unsigned*)(tmp+3)  = input26Bit[1] << 2;
-        add17(result, tmp);
+	over = input26Bit[1] >> (24-2);
+	val24 = (input26Bit[1] << 2) & 0xFFFFFF;    /* 26 + 2 = 28 */
+	memset(tmp, 0, 17);
+	*(unsigned *)(tmp+3) = val24; 
+	add17(result, tmp);
+	memset(tmp, 0, 17);
+	*(unsigned *)(tmp+6) = over;
+	add17(result, tmp);
 
-        memset(tmp, 0, 17);
-        *(unsigned*)(tmp+6)  = input26Bit[2] << 4;
-        add17(result, tmp);
+	over = input26Bit[2] >> (24-4);
+	val24 = (input26Bit[2] << 4) & 0xFFFFFF;    /* 26 + 2 = 28 */
 
-        memset(tmp, 0, 17);
-        *(unsigned*)(tmp+9)  = input26Bit[3] << 6;
-        add17(result, tmp);
+	memset(tmp, 0, 17);
+	*(unsigned*)(tmp+6) = val24;
+	add17(result, tmp);
+	memset(tmp, 0, 17);
+	*(unsigned *)(tmp+9) = over;
+	add17(result, tmp);
 
-        memset(tmp, 0, 17);
-        *(unsigned*)(tmp+13) = input26Bit[4];
-        add17(result, tmp);        
+	over = input26Bit[3] >> (24-6);
+	val24 = (input26Bit[3] << 6) & 0xFFFFFF;    /* 26 + 2 = 28 */
 
-        result[16] &= 3;
+	memset(tmp, 0, 17);
+	*(unsigned*)(tmp+9) = val24;
+	add17(result, tmp);
+	memset(tmp, 0, 17);
+	*(unsigned *)(tmp+12) = over;
+	add17(result, tmp);
+
+	memset(tmp, 0, 17);
+	*(unsigned*)(tmp+13) = input26Bit[4];		/* 26+26+26+26 =104 */
+	add17(result, tmp);	
+
+	result[16] &= 3;
 }
 
 
 /* test data set from RFC 7539 */
-//unsigned char testData []="Cryptographic Forum Research set"; 
-unsigned char testData[]="Cryptographic Forum Research Group"; 
-//unsigned char testData []="12345678901234561234567890123456";
+#if 0
+/* two 16 byte blocks */
+unsigned char testData[]="Cryptographic Forum Research set"; 
+unsigned char testData1[]="Cryptographic Fo";
+unsigned char testData2[]="rum Research set"; 
+unsigned char resultCheck[]="\x5F\x5C\xC1\xDE\x46\x9B\x6E\xA5\x79\x9B\x03\x9F\x64\x7E\xF2\x75";
+#endif
+
 unsigned char testKey[]="\x85\xd6\xBE\x78\x57\x55\x6d\x33\x7F\x44\x52\xfe\x42\xd5\x06\xa8\x01\x03\x80\x8a\xfb\x0d\xb2\xFD\x4A\xBF\xF6\xAF\x41\x49\xF5\x1B";
 
+#if 0
+unsigned char testData[]="Cryptographic Forum Research Group"; 
 unsigned char resultCheck[]="\xA8\x06\x1D\xC1\x30\x51\x36\xC6\xC2\x2B\x8B\xAF\x0C\x01\x27\xA9";
+#endif
+
+#if 0
+/* four 16 byte blocks  - neon matches A32 */
+unsigned char testData[]="Cryptographic Forum Research setCryptographic Forum Research set"; 
+unsigned char resultCheck[]="\x4A\xD3\x08\x6D\x13\x5B\x12\x5C\xCF\xC2\x1A\xAD\xA0\xBA\x75\x3F";
+#endif
+
+#if 0
+/* three 16 byte blocks */
+unsigned char testData[]="Cryptographic Forum Research set1234567890123456"; 
+unsigned char resultCheck[]="\x90\x0A\xA4\x0B\xFD\x90\xC7\x12\x52\x95\x08\x49\xF6\x20\x86\xEC";
+#endif
+
+#if 0
+/* three 16 byte blocks + an under sized block */
+unsigned char testData[]="Cryptographic Forum Research set1234567890123456123"; 
+unsigned char resultCheck[]="\x32\x03\x0B\x51\x7E\x49\xA8\x0D\xBF\x02\xD6\x99\x46\x79\xE2\x28";
+#endif
+
+#if 0
+/* three 16 byte blocks + an under sized block */
+unsigned char testData[]="Cryptographic Forum Research set12345678901234561234"; 
+/* neon version gets \x67\x20\x0F\xFA */
+unsigned char resultCheck[]="\x5D\x41\x13\xDC\xBF\x24\x25\xD4\x12\x20\xF2\x51\x67\x21\x0F\xFA";  
+#endif
+
+#if 0
+/* four 16 byte blocks - neon results push limits of 17 byte add. */
+unsigned char testData[]="Cryptographic Forum Research set12345678901234561234567890123456"; 
+/* neon gets  \x59\xBB\x07\x1C */
+unsigned char resultCheck[]="\x46\x3C\x3D\x0F\xD4\x1A\x8C\xF0\xE7\x34\x9C\x72\x59\xBC\x07\x1C";  
+#endif
+
+#if 0
+/* three 16 byte blocks + an under sized block */
+unsigned char testData[]="Cryptographic Forum Research set1234567890123456111111"; 
+unsigned char resultCheck[]="\xF8\x2E\xC4\xEF\x9B\x3C\x6A\xC1\x61\x73\xD4\xE9\x3C\x65\x93\x3B";  
+#endif
+
+#if 1
+/* two 16 byte blocks + an under sized block */
+unsigned char testData[]="Cryptographic Forum Research set1234"; 
+unsigned char resultCheck[]="\xA2\x0F\x7A\xD8\xE8\x9A\x60\xF6\x7C\x80\x5E\x28\x04\x86\x8D\xCA";
+#endif
+
+#if 0
+/* eight 16 byte blocks */
+unsigned char testData[]="Cryptographic Forum Research setCryptographic Forum Research setCryptographic Forum Research setCryptographic Forum Research set"; 
+unsigned char resultCheck[]="\xAE\xF7\x74\x3B\x69\x72\x8A\x4F\xD7\x32\x60\xB6\x7E\x0B\x60\x88";
+#endif
+	
+#if 0
+/* eight 16 byte blocks */
+unsigned char testData[]="Crypto"; 
+unsigned char resultCheck[]="\xE2\x33\xC2\x33\x97\x5C\xDC\x37\xE6\x7B\xF9\xFC\x59\x33\xB5\x7F";
+#endif
 
 
-unsigned char msgDataCopy[100];                
 
 int main(void)
 {
-        unsigned char *msgData, *keyData;
-        int msgDataLen;
-        unsigned char result16Byte[16];
-        Poly1305  ctx;
-         unsigned char *r, *s, acc[17];
+	unsigned char *msgData, *keyData;
+	int msgDataLen;
+	unsigned char result16Byte[16];
+	Poly1305  ctx;
+ 	unsigned char *r, *s, acc[17];
+	int i;
+	unsigned *pt;
 
-        msgData = testData;
-        msgDataLen = strlen((const char *)msgData);        
-        keyData = testKey;
+	msgData = testData;
+	msgDataLen = strlen((const char *)msgData);	
+	keyData = testKey;
 
+	pt = (unsigned*)msgData;
 
-        unsigned *pt;
-        pt = (unsigned*)msgData;
+	printf("\n%s\n", msgData);
+	for (i=0;i<10;++i) 
+		printf(" %d %X\n", i, pt[i]);
+	printf("\n");
 
-        int i;
-        printf("%s\n", msgData);
-        for (i=0;i<10;++i) printf(" %d %X\n", i, pt[i]);
-        printf("\n");
+	printf("message len %d\n\n", msgDataLen);
 
-        printf("message len %d\n", msgDataLen);
+	/* some modifications of the test data for test
+	   purposes.  Used in part to test the assembly
+	   algorithm for the last block of the message. */
 
+	r = keyData;
+	s = keyData+16;
 
-        /* some modifications of the test data for test
-           purposes.  Used in part to test the assembly
-           algorithm for the last block of the message. */
-#if 0
-        /* add junk at end for testing */
-        memcpy(msgDataCopy, msgData, msgDataLen);
-        msgData = msgDataCopy;
-        *(unsigned*)(msgData+msgDataLen) = 0x12345678;
-        *(unsigned*)(msgData+msgDataLen+4) = 0x12345678;
-        *(unsigned*)(msgData+msgDataLen+8) = 0x11111111;
-#endif
-        
-#if 0
-        /* make test data a boundary case length
-           for testing. */
-        memcpy(msgDataCopy, msgData, msgDataLen);
-        msgData = msgDataCopy;
+	print16("s as a 128-bit number ", s);
+	clamp_r(r);
 
-        strcat(msgData, "more stuff");
-        msgDataLen = strlen(msgData);        
-#endif
+	/* break the 16 byte value into 26 bit parts. */         
+	ctx.r[0] = *(unsigned *)(r) & 0x3FFFFFF;
+	ctx.r[1] = ((*(unsigned *)(r + 3)) >> 2) & 0x3FFFFFF;
+	ctx.r[2] = ((*(unsigned *)(r + 6)) >> 4) & 0x3FFFFFF;
+	ctx.r[3] = ((*(unsigned *)(r + 9)) >> 6) & 0x3FFFFFF;
+	/* + 12 so you don't reference outside array, ie don't use +13 */
+	ctx.r[4] = ((*(unsigned *)(r + 12)) >> 8) & 0xFFFFFF;
 
-#if 0
-        /* just run poly1305 on the first 16 byte 
-            block of the test data. */
-        strcpy(msgDataCopy, "Cryptographic Fo");
-        msgData = msgDataCopy;
-        msgDataLen = strlen(msgData);                
-#endif
+	ctx.finished = 0;  /* setups up hibit, 0 is normal value */
 
-        r = keyData;
-        s = keyData+16;
-
-        print16("s as a 128-bit number ", s);
-        clamp_r(r);
-
-        /* break the 16 byte value into 26 bit parts. */         
-        ctx.r[0] = *(unsigned *)(r) & 0x3FFFFFF;
-        ctx.r[1] = ((*(unsigned *)(r + 3)) >> 2) & 0x3FFFFFF;
-        ctx.r[2] = ((*(unsigned *)(r + 6)) >> 4) & 0x3FFFFFF;
-        ctx.r[3] = ((*(unsigned *)(r + 9)) >> 6) & 0x3FFFFFF;
-        /* + 12 so you don't reference outside array, ie don't use +13 */
-        ctx.r[4] = ((*(unsigned *)(r + 12)) >> 8) & 0xFFFFFF;
-
-        ctx.finished = 0;
-
-        /* Should always start as zero.
+	/* Should always start as zero.
            Passing into assembly routine to match what is already 
-           implemented in wolfSSL armv8_poly1305.c.  
-           For debugging, the C routine could break the message into 
-           16 byte chunks and call the assembly routine over and over
-           with the 16 byte chunks and the updated h value. */
-        memset(ctx.h, 0, 5 * sizeof(unsigned));
+	   implemented in wolfSSL armv8_poly1305.c.  
+	   For debugging, the C routine could break the message into 
+	   16 byte chunks and call the assembly routine over and over
+	   with the 16 byte chunks and the updated h value. */
+	memset(ctx.h, 0, 5 * sizeof(unsigned));
 
-        armv8_32_poly1305_blocks(&ctx, msgData, msgDataLen);
+	/* for the sake of testing ... */
+	for (i=0;i<5;++i)
+		ctx.h[i] = i;
 
-        convert26BitValuesTo17Byte(ctx.h, acc);
+#if 0
+	unsigned r_1[5], r_2[5];
+	unsigned h1[5];
+	unsigned h3[5];
+	int o, q;
 
-        /* make output match what is seen in RFC */
-        print17("Acc = ((Acc+Block) * r) % P = ", acc);
-        add17(acc, s);
-        print17("Acc + s = ", acc);
+        msgData=testData1;
+        msgDataLen=strlen((char *)msgData);
 
-        memcpy(result16Byte, acc, 16);
+	memcpy(r_1, ctx.r, 5*sizeof(unsigned));
 
-        printBytes(" Tag = ", result16Byte, 16); 
+	/* copy r_2 to r */
+	calculateRsquared(r_1, r_2);
 
-        if (!memcmp(result16Byte, resultCheck, 16))
-                printf("Result matches RFC 7539\n\n");
-        else        
-                printf("Result does not match RFC 7539\n\n");
+	memcpy(ctx.r, r_2, 5*sizeof(unsigned));
+
+	armv8_32_poly1305_blocks(&ctx, msgData, msgDataLen);
+
+	printf("\n(M block 1) * r^2 values :");
+
+	for (o=0;o<5;++o)
+	{
+		printf(" %X ", ctx.h[o]);
+	}
+	printf("\n\n");
+
+	memcpy(h3, ctx.h, 5 * sizeof(unsigned));
+
+        msgData=testData2;
+        msgDataLen=strlen((char *)msgData);
+
+	printf("\n\nr ");
+	for (q=0;q<5;++q)	
+	{
+		printf(" %X ", ctx.r[q]);
+	}
+	printf("\n");
+
+	memset(ctx.h, 0, 5*sizeof(unsigned));
+
+	memcpy(ctx.r, r_1, 5*sizeof(unsigned));
+
+	armv8_32_poly1305_blocks(&ctx, msgData, msgDataLen);
+
+	printf("\n(M block 2) * r values :");
+	
+	for (o=0;o<5;++o)
+	{
+		printf(" %X ", ctx.h[o]);
+	}
+	printf("\n\n");
+
+	int k;
+	for (k=0;k<5;++k)
+		ctx.h[k] += h3[k];
+#endif
+
+#if 1
+	msgData = testData;
+	msgDataLen = strlen((char *)msgData);
+
+	armv8_32_poly1305_blocks(&ctx, msgData, msgDataLen);
+
+	printf("\n\nFinal H values :");
+	int o;
+	for (o=0;o<5;++o)
+	{
+		printf(" %X ", ctx.h[o]);
+	}
+	printf("\n\n");
+#endif
+	
+//return 0;
+	convert26BitValuesTo17Byte(ctx.h, acc);
+
+	/* make output match what is seen in RFC */
+	print17("Acc = ((Acc+Block) * r) % P = ", acc);
+	add17(acc, s);
+	print17("Acc + s = ", acc);
+
+	memcpy(result16Byte, acc, 16);
+
+	printBytes(" Tag = ", result16Byte, 16); 
+
+	if (!memcmp(result16Byte, resultCheck, 16))
+		printf("Result matches RFC 7539\n\n");
+	else	
+		printf("Result does not match RFC 7539\n\n");
 }
 #endif
-
-
 

--- a/wolfssl/wolfcrypt/poly1305.h
+++ b/wolfssl/wolfcrypt/poly1305.h
@@ -124,8 +124,9 @@ WOLFSSL_API int wc_Poly1305_EncodeSizes64(Poly1305* ctx, word64 aadSz,
 WOLFSSL_API int wc_Poly1305_MAC(Poly1305* ctx, const byte* additional,
     word32 addSz, const byte* input, word32 sz, byte* tag, word32 tagSz);
 
-#ifdef WOLFSSL_ARMASM
-void poly1305_blocks(Poly1305* ctx, const unsigned char *m, size_t bytes);
+#if defined(__aarch64__ ) && defined(WOLFSSL_ARMASM)
+void poly1305_blocks(Poly1305* ctx, const unsigned char *m,
+                            size_t bytes);
 void poly1305_block(Poly1305* ctx, const unsigned char *m);
 #endif
 

--- a/wolfssl/wolfcrypt/poly1305.h
+++ b/wolfssl/wolfcrypt/poly1305.h
@@ -124,9 +124,8 @@ WOLFSSL_API int wc_Poly1305_EncodeSizes64(Poly1305* ctx, word64 aadSz,
 WOLFSSL_API int wc_Poly1305_MAC(Poly1305* ctx, const byte* additional,
     word32 addSz, const byte* input, word32 sz, byte* tag, word32 tagSz);
 
-#if defined(__aarch64__ ) && defined(WOLFSSL_ARMASM)
-void poly1305_blocks(Poly1305* ctx, const unsigned char *m,
-                            size_t bytes);
+#ifdef WOLFSSL_ARMASM
+void poly1305_blocks(Poly1305* ctx, const unsigned char *m, size_t bytes);
 void poly1305_block(Poly1305* ctx, const unsigned char *m);
 #endif
 


### PR DESCRIPTION
…gisters,

all the memory references in the non-NEON poly1305 routine were removed
except the memory references for the message block itself.

Still researching other possible uses of NEON instructions to accelerate
poly 1305 algorithm.

# Description

Please describe the scope of the fix or feature addition.

Fixes zd#

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
