### PR TITLE
RSA max and SP_INT_BITS: disabled RSA fix

### DIFF
--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1231,7 +1231,7 @@ enum {
         #error "MySQL needs SP_INT_BITS at least at 8192"
     #endif
 
-    #if WOLFSSL_MAX_RSA_BITS > SP_INT_BITS
+    #if !defined(NO_RSA) && WOLFSSL_MAX_RSA_BITS > SP_INT_BITS
         #error "SP_INT_BITS too small for WOLFSSL_MAX_RSA_BITS"
     #endif
 #else


### PR DESCRIPTION
# Description

Checking WOLFSSL_MAX_RSA_BITS against SP_INT_BITS even though RSA is
disabled.

# Testing

Fixes: /configure --disable-shared --enable-sp --enable-sp-math --disable-rsa
--disable-dh --enable-ecc

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
