### PR TITLE
Fix warning in DecodeAltNames

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -17540,7 +17540,7 @@ static int DecodeAltNames(const byte* input, int sz, DecodedCert* cert)
             int strLen;
             word32 lenStartIdx = idx;
             word32 oid = 0;
-            int    ret;
+            int    ret = 0;
 
             if (GetLength(input, &idx, &strLen, sz) < 0) {
                 WOLFSSL_MSG("\tfail: other name length");


### PR DESCRIPTION
# Description

`warning [#551]-D: variable "ret" is used before its value is set`

Fixes zd14776

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
