### PR TITLE
SP int: fix for SP_INT_DIGITS calc

### DIFF
--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -425,10 +425,10 @@ typedef struct sp_ecc_ctx {
      * numbers in bits that will be used.
      * Double the size to hold multiplication result.
      * Add one to accommodate extra digit used by sp_mul(), sp_mulmod(),
-     * sp_sqr(), and sp_sqrmod().
+     * sp_sqr(), sp_sqrmod() and sp_mont_red().
      */
     #define SP_INT_DIGITS                                                      \
-        (((SP_INT_BITS * 2 + SP_WORD_SIZE - 1) / SP_WORD_SIZE) + 1)
+        (((SP_INT_BITS + SP_WORD_SIZE - 1) / SP_WORD_SIZE) * 2 + 1)
 #endif
 
 #ifndef SP_INT_MAX_BITS


### PR DESCRIPTION
# Description

Implementation of sp_mont_red needs words * 2 + 1.

# Testing

./configure --disable-shared --enable-ecc --disable-rsa --disable-dh CFLAGS="-DSP_WORD_SIZE=64 -DSP_INT_BITS=521"

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
