### PR TITLE
Make custom extension OID a buffer.

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -29503,6 +29503,12 @@ int wc_SetCustomExtension(Cert *cert, int critical, const char *oid,
         return MEMORY_E;
     }
 
+#ifndef WOLFTPM2_NO_HEAP
+    if (XSTRLEN(oid) >= MAX_OID_STRING_SZ) {
+        return BUFFER_E;
+    }
+#endif /* !WOLFTPM2_NO_HEAP */
+
     /* Make sure we can properly parse the OID. */
     ret = EncodePolicyOID(encodedOid, &encodedOidSz, oid, NULL);
     if (ret != 0) {
@@ -29511,7 +29517,12 @@ int wc_SetCustomExtension(Cert *cert, int critical, const char *oid,
 
     ext = &cert->customCertExt[cert->customCertExtCount];
 
+#ifdef WOLFTPM2_NO_HEAP
     ext->oid = oid;
+#else
+    XSTRNCPY(ext->oid, oid, MAX_OID_STRING_SZ);
+#endif /* WOLFTPM2_NO_HEAP */
+
     ext->crit = (critical == 0) ? 0 : 1;
     ext->val = der;
     ext->valSz = derSz;

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -942,12 +942,6 @@ enum Misc_ASN {
     #endif
                                    /* Max total extensions, id + len + others */
 #endif
-#if defined(WOLFSSL_CERT_EXT) || defined(OPENSSL_EXTRA) || \
-        defined(HAVE_PKCS7) || defined(OPENSSL_EXTRA_X509_SMALL) || \
-        defined(HAVE_OID_DECODING) || defined(HAVE_OID_ENCODING)
-    MAX_OID_SZ          = 32,      /* Max DER length of OID*/
-    MAX_OID_STRING_SZ   = 64,      /* Max string length representation of OID*/
-#endif
 #ifdef WOLFSSL_CERT_EXT
     MAX_KID_SZ          = 45,      /* Max encoded KID length (SHA-256 case) */
     MAX_KEYUSAGE_SZ     = 18,      /* Max encoded Key Usage length */

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -250,7 +250,12 @@ enum {
 #else
     NAME_SZ = 80,                   /* max one line */
 #endif
-
+#if defined(WOLFSSL_CERT_EXT) || defined(OPENSSL_EXTRA) || \
+        defined(HAVE_PKCS7) || defined(OPENSSL_EXTRA_X509_SMALL) || \
+        defined(HAVE_OID_DECODING) || defined(HAVE_OID_ENCODING)
+    MAX_OID_SZ          = 32,      /* Max DER length of OID*/
+    MAX_OID_STRING_SZ   = 64,      /* Max string length representation of OID*/
+#endif
     PEM_PASS_READ  = 0,
     PEM_PASS_WRITE = 1,
 };
@@ -341,7 +346,11 @@ typedef struct CertOidField {
 } CertOidField;
 
 typedef struct CertExtension {
+#ifdef WOLFTPM2_NO_HEAP
     const char* oid;
+#else
+    char        oid[MAX_OID_STRING_SZ];
+#endif
     byte        crit;
     const byte* val;
     int         valSz;


### PR DESCRIPTION
This allows for passed in OIDs to be memory managed by wolfssl. Gated.

Fixes ZD14745

