### PR TITLE
20220907-fixes

### DIFF
--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -7616,9 +7616,9 @@ static int PopulateRSAEvpPkeyDer(WOLFSSL_EVP_PKEY *pkey)
 #ifdef WOLFSSL_NO_REALLOC
     derBuf = (byte*)XMALLOC(derSz, pkey->heap, DYNAMIC_TYPE_DER);
     if (derBuf != NULL) {
-    	XMEMCPY(derBuf, pkey->pkey.ptr, pkey->pkey_sz);
-    	XFREE(pkey->pkey.ptr, pkey->heap, DYNAMIC_TYPE_DER);
-    	pkey->pkey.ptr = NULL;
+        XMEMCPY(derBuf, pkey->pkey.ptr, pkey->pkey_sz);
+        XFREE(pkey->pkey.ptr, pkey->heap, DYNAMIC_TYPE_DER);
+        pkey->pkey.ptr = NULL;
     }
 #else
     derBuf = (byte*)XREALLOC(pkey->pkey.ptr, derSz,

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -8651,7 +8651,8 @@ static int wc_PKCS7_DecryptKtri(PKCS7* pkcs7, byte* in, word32 inSz,
                     return ASN_PARSE_E;
 
                 if (encOID != pkcs7->publicKeyOID) {
-                    WOLFSSL_MSG("public key OID found in KTRI doesn't match OID stored earlier.");
+                    WOLFSSL_MSG("public key OID found in KTRI doesn't match "
+                                "OID stored earlier.");
                     WOLFSSL_ERROR(ALGO_ID_E);
                     return ALGO_ID_E;
                 }

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -781,8 +781,8 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
 
 #elif defined(FREESCALE_RTC)
     #include <time.h>
-	#include "fsl_rtc.h"
-	#ifndef XTIME
+        #include "fsl_rtc.h"
+        #ifndef XTIME
         #define XTIME(t1) fsl_time((t1))
     #endif
 


### PR DESCRIPTION
wolfcrypt/src/pkcs7.c: fix uninited value read detected by clang-analyzer-core.UndefinedBinaryOperatorResult; fix whitespace.

tested with `wolfssl-multi-test.sh ... super-quick-check`
