### PR TITLE
Fix HMAC compat layer function for SHA-1.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -18299,10 +18299,11 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
     #endif
 #endif
 #ifndef NO_SHA
-        if (XSTRCMP(evp_md, "SHA") == 0) {
+        if (XSTRCMP(evp_md, "SHA") == 0 || XSTRCMP(evp_md, "SHA1") == 0) {
             type = WC_SHA;
             mdlen = WC_SHA_DIGEST_SIZE;
-        } else
+        }
+        else
 #endif
         {
             return NULL;

--- a/tests/api.c
+++ b/tests/api.c
@@ -39202,6 +39202,9 @@ static int test_wolfSSL_HMAC(void)
             test_openssl_hmac(EVP_sha3_512(), (int)WC_SHA3_512_DIGEST_SIZE);
         #endif
     #endif
+    #ifndef NO_SHA
+        test_openssl_hmac(EVP_sha1(), (int)WC_SHA_DIGEST_SIZE);
+    #endif
 
     printf(resultFmt, passed);
 #endif

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -985,8 +985,6 @@ WOLFSSL_API int wolfSSL_EVP_SignInit_ex(WOLFSSL_EVP_MD_CTX* ctx,
 #define EVP_get_cipherbynid           wolfSSL_EVP_get_cipherbynid
 #define EVP_get_digestbynid           wolfSSL_EVP_get_digestbynid
 #define EVP_MD_nid                    wolfSSL_EVP_MD_type
-#define EVP_get_cipherbyname          wolfSSL_EVP_get_cipherbyname
-#define EVP_get_digestbyname          wolfSSL_EVP_get_digestbyname
 
 #define EVP_PKEY_assign                wolfSSL_EVP_PKEY_assign
 #define EVP_PKEY_assign_RSA            wolfSSL_EVP_PKEY_assign_RSA


### PR DESCRIPTION
# Description

This function would only accept the string "SHA" for SHA-1-based HMAC, but it should also accept "SHA1." This is similar to how wolfSSL_EVP_get_digestbyname allows both "SHA" and "SHA1." We didn't have a test for this in api.c. I added one, and it failed before my fix here.

Fixes ZD 14721.

# Testing

I added a regression test in api.c.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
