### PR TITLE
Fix SHA string check in wolfSSL_HMAC.  Remove duplicate definitions in evp.h.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -18299,7 +18299,8 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
     #endif
 #endif
 #ifndef NO_SHA
-        if (XSTRCMP(evp_md, "SHA") == 0) {
+        if (XSTRCMP(evp_md, "SHA") == 0 ||
+            XSTRCMP(evp_md, "SHA1") == 0) {
             type = WC_SHA;
             mdlen = WC_SHA_DIGEST_SIZE;
         } else

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -945,9 +945,6 @@ WOLFSSL_API int wolfSSL_EVP_SignInit_ex(WOLFSSL_EVP_MD_CTX* ctx,
 #define EVP_DigestVerifyFinal  wolfSSL_EVP_DigestVerifyFinal
 #define EVP_BytesToKey         wolfSSL_EVP_BytesToKey
 
-#define EVP_get_cipherbyname wolfSSL_EVP_get_cipherbyname
-#define EVP_get_digestbyname wolfSSL_EVP_get_digestbyname
-
 #define EVP_CIPHER_CTX_init           wolfSSL_EVP_CIPHER_CTX_init
 #define EVP_CIPHER_CTX_cleanup        wolfSSL_EVP_CIPHER_CTX_cleanup
 #define EVP_CIPHER_CTX_iv_length      wolfSSL_EVP_CIPHER_CTX_iv_length


### PR DESCRIPTION
# Description

Fixes zd# 14773

# Testing

Built + ran tests

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
