### PR TITLE
SP: config option to force no asm

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6497,6 +6497,10 @@ do
     ENABLED_SP_ASM=yes
     ;;
 
+  noasm)
+    ENABLED_SP_ASM=no
+    ;;
+
   *)
     AC_MSG_ERROR([Invalid choice of Single Precision length in bits [256, 384, 521, 1024, 2048, 3072, 4096]: $ENABLED_SP.])
     break;;


### PR DESCRIPTION
# Description

Added to configure.ac the option to specify SP to be built with ASM as x64 defaults to with asm.

# Testing

--enable-sp=noasm

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
