### PR TITLE
Set correct types in wolfSSL_sk_*_new functions

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -19312,7 +19312,6 @@ int wolfSSL_sk_push(WOLFSSL_STACK* sk, const void *data)
     sk->num        += 1;
 
 #ifdef OPENSSL_ALL
-    node->comp = sk->comp;
     node->hash_fn = sk->hash_fn;
     node->hash = sk->hash;
     sk->hash = 0;

--- a/src/x509.c
+++ b/src/x509.c
@@ -11542,7 +11542,8 @@ error:
         defined(HAVE_LIGHTY) || defined(WOLFSSL_HAPROXY) || \
         defined(WOLFSSL_OPENSSH) || defined(HAVE_SBLIM_SFCB)
 
-WOLF_STACK_OF(WOLFSSL_X509_NAME)* wolfSSL_sk_X509_NAME_new(wolf_sk_compare_cb cb)
+WOLF_STACK_OF(WOLFSSL_X509_NAME)* wolfSSL_sk_X509_NAME_new(
+        WOLF_SK_COMPARE_CB(WOLFSSL_X509_NAME, cb))
 {
     WOLFSSL_STACK* sk;
     (void)cb;
@@ -11552,9 +11553,6 @@ WOLF_STACK_OF(WOLFSSL_X509_NAME)* wolfSSL_sk_X509_NAME_new(wolf_sk_compare_cb cb
     sk = wolfSSL_sk_new_node(NULL);
     if (sk != NULL) {
         sk->type = STACK_TYPE_X509_NAME;
-#ifdef OPENSSL_ALL
-        sk->comp = cb;
-#endif
     }
 
     return sk;
@@ -11656,16 +11654,12 @@ int wolfSSL_sk_X509_NAME_find(const WOLF_STACK_OF(WOLFSSL_X509_NAME) *sk,
 
 /* Name Entry */
 WOLF_STACK_OF(WOLFSSL_X509_NAME_ENTRY)* wolfSSL_sk_X509_NAME_ENTRY_new(
-    wolf_sk_compare_cb cb)
+    WOLF_SK_COMPARE_CB(WOLFSSL_X509_NAME_ENTRY, cb))
 {
     WOLFSSL_STACK* sk = wolfSSL_sk_new_node(NULL);
     if (sk != NULL) {
         sk->type = STACK_TYPE_X509_NAME_ENTRY;
-    #ifdef OPENSSL_ALL
-        sk->comp = cb;
-    #else
         (void)cb;
-    #endif
     }
     return sk;
 }
@@ -11827,7 +11821,7 @@ WOLF_STACK_OF(WOLFSSL_X509_NAME) *wolfSSL_dup_CA_list(
 
     WOLFSSL_ENTER("wolfSSL_dup_CA_list");
 
-    copy = wolfSSL_sk_X509_NAME_new(sk->comp);
+    copy = wolfSSL_sk_X509_NAME_new(NULL);
     if (copy == NULL) {
         WOLFSSL_MSG("Memory error");
         return NULL;
@@ -11867,14 +11861,15 @@ int wolfSSL_sk_X509_OBJECT_num(const WOLF_STACK_OF(WOLFSSL_X509_OBJECT) *s)
 }
 
 int wolfSSL_sk_X509_NAME_set_cmp_func(WOLF_STACK_OF(WOLFSSL_X509_NAME)* sk,
-    wolf_sk_compare_cb cb)
+    WOLF_SK_COMPARE_CB(WOLFSSL_X509_NAME, cb))
 {
     WOLFSSL_ENTER("wolfSSL_sk_X509_NAME_set_cmp_func");
 
     if (sk == NULL)
         return BAD_FUNC_ARG;
 
-    sk->comp = cb;
+    WOLFSSL_MSG("Stack comparison not used in wolfSSL");
+    (void)cb;
     return 0;
 }
 #endif /* OPENSSL_ALL */

--- a/tests/api.c
+++ b/tests/api.c
@@ -46674,7 +46674,7 @@ static int test_wolfSSL_TXT_DB(void)
 
     /* Test index */
     AssertIntEQ(TXT_DB_create_index(db, 3, NULL, (wolf_sk_hash_cb)TXT_DB_hash,
-            (wolf_sk_compare_cb)TXT_DB_cmp), 1);
+            (wolf_lh_compare_cb)TXT_DB_cmp), 1);
     AssertNotNull(TXT_DB_get_by_index(db, 3, (WOLFSSL_STRING*)fields));
     fields[3] = "12DA";
     AssertNotNull(TXT_DB_get_by_index(db, 3, (WOLFSSL_STRING*)fields));

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4217,7 +4217,6 @@ struct WOLFSSL_STACK {
     unsigned long num; /* number of nodes in stack
                         * (safety measure for freeing and shortcut for count) */
     #if defined(OPENSSL_ALL)
-    wolf_sk_compare_cb comp;
     wolf_sk_hash_cb hash_fn;
     unsigned long hash;
     #endif

--- a/wolfssl/openssl/txt_db.h
+++ b/wolfssl/openssl/txt_db.h
@@ -32,18 +32,19 @@ struct WOLFSSL_TXT_DB {
     long error;
     long arg1;
     long arg2;
-    wolf_sk_compare_cb comp[WOLFSSL_TXT_DB_MAX_FIELDS];
     wolf_sk_hash_cb hash_fn[WOLFSSL_TXT_DB_MAX_FIELDS];
 };
 
 typedef struct WOLFSSL_TXT_DB WOLFSSL_TXT_DB;
+typedef int (*wolf_lh_compare_cb)(const void* a,
+                                  const void* b);
 
 WOLFSSL_API WOLFSSL_TXT_DB *wolfSSL_TXT_DB_read(WOLFSSL_BIO *in, int num);
 WOLFSSL_API long wolfSSL_TXT_DB_write(WOLFSSL_BIO  *out, WOLFSSL_TXT_DB *db);
 WOLFSSL_API int wolfSSL_TXT_DB_insert(WOLFSSL_TXT_DB *db, WOLFSSL_STRING *row);
 WOLFSSL_API void wolfSSL_TXT_DB_free(WOLFSSL_TXT_DB *db);
 WOLFSSL_API int wolfSSL_TXT_DB_create_index(WOLFSSL_TXT_DB *db, int field,
-        void* qual, wolf_sk_hash_cb hash, wolf_sk_compare_cb cmp);
+        void* qual, wolf_sk_hash_cb hash, wolf_lh_compare_cb cmp);
 WOLFSSL_API WOLFSSL_STRING *wolfSSL_TXT_DB_get_by_index(WOLFSSL_TXT_DB *db,
         int idx, WOLFSSL_STRING *value);
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -4577,17 +4577,17 @@ WOLFSSL_API void wolfSSL_sk_X509_INFO_pop_free(WOLF_STACK_OF(WOLFSSL_X509_INFO)*
     void (*f) (WOLFSSL_X509_INFO*));
 WOLFSSL_API void wolfSSL_sk_X509_INFO_free(WOLF_STACK_OF(WOLFSSL_X509_INFO)*);
 
-typedef int (*wolf_sk_compare_cb)(const void* a,
-                                  const void* b);
+#define WOLF_SK_COMPARE_CB(type, arg) \
+    int (*arg) (const type* const* a, const type* const* b)
 typedef unsigned long (*wolf_sk_hash_cb) (const void *v);
 WOLFSSL_API WOLF_STACK_OF(WOLFSSL_X509_NAME)* wolfSSL_sk_X509_NAME_new(
-    wolf_sk_compare_cb cb);
+    WOLF_SK_COMPARE_CB(WOLFSSL_X509_NAME, cb));
 WOLFSSL_API int wolfSSL_sk_X509_NAME_push(WOLF_STACK_OF(WOLFSSL_X509_NAME)*,
     WOLFSSL_X509_NAME* name);
 WOLFSSL_API int wolfSSL_sk_X509_NAME_find(const WOLF_STACK_OF(WOLFSSL_X509_NAME)* sk,
     WOLFSSL_X509_NAME* name);
 WOLFSSL_API int wolfSSL_sk_X509_NAME_set_cmp_func(
-    WOLF_STACK_OF(WOLFSSL_X509_NAME)*, wolf_sk_compare_cb cb);
+    WOLF_STACK_OF(WOLFSSL_X509_NAME)*, WOLF_SK_COMPARE_CB(WOLFSSL_X509_NAME, cb));
 WOLFSSL_API WOLFSSL_X509_NAME* wolfSSL_sk_X509_NAME_value(const WOLF_STACK_OF(WOLFSSL_X509_NAME)* sk, int i);
 WOLFSSL_API int wolfSSL_sk_X509_NAME_num(const WOLF_STACK_OF(WOLFSSL_X509_NAME)* sk);
 WOLFSSL_API WOLFSSL_X509_NAME* wolfSSL_sk_X509_NAME_pop(WOLF_STACK_OF(WOLFSSL_X509_NAME)*);
@@ -4596,7 +4596,7 @@ WOLFSSL_API void wolfSSL_sk_X509_NAME_pop_free(WOLF_STACK_OF(WOLFSSL_X509_NAME)*
 WOLFSSL_API void wolfSSL_sk_X509_NAME_free(WOLF_STACK_OF(WOLFSSL_X509_NAME) *);
 
 WOLFSSL_API WOLF_STACK_OF(WOLFSSL_X509_NAME_ENTRY)*
-                 wolfSSL_sk_X509_NAME_ENTRY_new(wolf_sk_compare_cb cb);
+     wolfSSL_sk_X509_NAME_ENTRY_new(WOLF_SK_COMPARE_CB(WOLFSSL_X509_NAME_ENTRY, cb));
 WOLFSSL_API int  wolfSSL_sk_X509_NAME_ENTRY_push(WOLF_STACK_OF(WOLFSSL_X509_NAME_ENTRY)* sk,
                                            WOLFSSL_X509_NAME_ENTRY* name_entry);
 WOLFSSL_API WOLFSSL_X509_NAME_ENTRY*
@@ -4614,7 +4614,7 @@ WOLFSSL_API int wolfSSL_X509_NAME_print_ex_fp(XFILE fp,WOLFSSL_X509_NAME* name,i
         unsigned long flags);
 #endif
 
-WOLFSSL_API WOLFSSL_STACK *wolfSSL_sk_CONF_VALUE_new(wolf_sk_compare_cb compFunc);
+WOLFSSL_API WOLFSSL_STACK *wolfSSL_sk_CONF_VALUE_new(WOLF_SK_COMPARE_CB(WOLFSSL_CONF_VALUE, compFunc));
 WOLFSSL_API void wolfSSL_sk_CONF_VALUE_free(struct WOLFSSL_STACK *sk);
 WOLFSSL_API int wolfSSL_sk_CONF_VALUE_num(const WOLFSSL_STACK *sk);
 WOLFSSL_API WOLFSSL_CONF_VALUE *wolfSSL_sk_CONF_VALUE_value(


### PR DESCRIPTION
- Use WOLF_SK_COMPARE_CB() to generate the correct types instead of using void* for the callback parameters.
- Remove WOLFSSL_STACK.comp entirely since it is not used anywhere. Ignore input parameters that used to set this member.