### PR TITLE
Configuration consistency fixes for RSA keys and way to force disable of private keys

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -6309,13 +6309,15 @@ static int DecodeRsaPssParams(const byte* params, word32 sz,
 size_t rsaIntOffset[] = {
     OFFSETOF(RsaKey, n),
     OFFSETOF(RsaKey, e),
-#if !defined(WOLFSSL_RSA_PUBLIC_ONLY) || defined(WOLFSSL_KEY_GEN)
+#ifndef WOLFSSL_RSA_PUBLIC_ONLY
     OFFSETOF(RsaKey, d),
     OFFSETOF(RsaKey, p),
     OFFSETOF(RsaKey, q),
+#if defined(WOLFSSL_KEY_GEN) || defined(OPENSSL_EXTRA) || !defined(RSA_LOW_MEM)
     OFFSETOF(RsaKey, dP),
     OFFSETOF(RsaKey, dQ),
     OFFSETOF(RsaKey, u)
+#endif
 #endif
 };
 

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -878,7 +878,13 @@ enum Misc_ASN {
 #else
     KEYID_SIZE          = WC_SHA_DIGEST_SIZE,
 #endif
+#if !defined(WOLFSSL_RSA_PUBLIC_ONLY) && (defined(WOLFSSL_KEY_GEN) || defined(OPENSSL_EXTRA) || !defined(RSA_LOW_MEM))
     RSA_INTS            =   8,     /* RSA ints in private key */
+#elif !defined(WOLFSSL_RSA_PUBLIC_ONLY)
+    RSA_INTS            =   5,     /* RSA ints in private key */
+#else
+    RSA_INTS            =   2,     /* RSA ints in private key */
+#endif
     DSA_PARAM_INTS      =   3,     /* DSA paramater ints */
     RSA_PUB_INTS        =   2,     /* RSA ints in public key */
     DSA_PUB_INTS        =   4,     /* DSA ints in public key */

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2752,14 +2752,13 @@ extern void uITRON4_free(void *p) ;
 
 /* Are we using an external private key store like:
  *     PKCS11 / HSM / crypto callback / PK callback */
-#if !defined(WOLF_PRIVATE_KEY_ID) && \
-    (defined(HAVE_PKCS11) || defined(HAVE_PK_CALLBACKS) || \
-     defined(WOLF_CRYPTO_CB) || defined(WOLFSSL_KCAPI))
-     /* Enables support for using wolfSSL_CTX_use_PrivateKey_Id and
-      *   wolfSSL_CTX_use_PrivateKey_Label */
-    #define WOLF_PRIVATE_KEY_ID
+#if !defined(WOLF_PRIVATE_KEY_ID) && !defined(NO_WOLF_PRIVATE_KEY_ID) && \
+	(defined(HAVE_PKCS11) || defined(HAVE_PK_CALLBACKS) || \
+	 defined(WOLF_CRYPTO_CB) || defined(WOLFSSL_KCAPI))
+	 /* Enables support for using wolfSSL_CTX_use_PrivateKey_Id and
+	  *   wolfSSL_CTX_use_PrivateKey_Label */
+	#define WOLF_PRIVATE_KEY_ID
 #endif
-
 
 /* With titan cache size there is too many sessions to fit with the default
  * multiplier of 8 */


### PR DESCRIPTION
# Description

Add way to disable private keys in wolfcrypt (settings). Make RSA key integer usage match structure configuration.

Related to [zd14615](https://wolfssl.zendesk.com/agent/tickets/14615)
