### PR TITLE
Add support for non-blocking ECDHE/ECDSA in TLS/DTLS layer.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6985,6 +6985,13 @@ then
     AC_MSG_ERROR([please use --with-libz if enabling mcapi.])
 fi
 
+# Asynchronous Crypto
+AC_ARG_ENABLE([asynccrypt],
+    [AS_HELP_STRING([--enable-asynccrypt],[Enable Asynchronous Crypto (default: disabled)])],
+    [ ENABLED_ASYNCCRYPT=$enableval ],
+    [ ENABLED_ASYNCCRYPT=no ]
+    )
+
 # Asynchronous crypto using software (i.e. not hardware). Required for
 # non-blocking crypto with TLS/DTLS.
 AC_ARG_ENABLE([asynccrypt-sw],
@@ -6995,14 +7002,8 @@ AC_ARG_ENABLE([asynccrypt-sw],
 if test "$ENABLED_ASYNCCRYPT_SW" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ASYNC_CRYPT_SW"
+    ENABLED_ASYNCCRYPT=yes
 fi
-
-# Asynchronous Crypto
-AC_ARG_ENABLE([asynccrypt],
-    [AS_HELP_STRING([--enable-asynccrypt],[Enable Asynchronous Crypto (default: disabled)])],
-    [ ENABLED_ASYNCCRYPT=$enableval ],
-    [ ENABLED_ASYNCCRYPT=no ]
-    )
 
 if test "$ENABLED_ASYNCCRYPT" = "yes"
 then

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -6389,12 +6389,25 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
     }
 #endif
 
+
+#if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_ECC) && \
+       defined(WOLFSSL_ASYNC_CRYPT_SW)
+    if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_ECC) {
+        if (wc_AsyncSwInit(&key->asyncDev, ASYNC_SW_ECC_SIGN)) {
+            WC_ASYNC_SW* sw = &key->asyncDev.sw;
+            sw->eccSign.in = in;
+            sw->eccSign.inSz = inlen;
+            sw->eccSign.rng = rng;
+            sw->eccSign.key = key;
+            sw->eccSign.r = r;
+            sw->eccSign.s = s;
+            return WC_PENDING_E;
+        }
+    }
+#endif
+
 #if defined(WOLFSSL_HAVE_SP_ECC)
-    if (key->idx != ECC_CUSTOM_IDX
-    #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_ECC)
-        && key->asyncDev.marker != WOLFSSL_ASYNC_MARKER_ECC
-    #endif
-    ) {
+    if (key->idx != ECC_CUSTOM_IDX) {
     #if defined(WOLFSSL_ECDSA_SET_K) || defined(WOLFSSL_ECDSA_SET_K_ONE_LOOP) \
         || defined(WOLFSSL_ECDSA_DETERMINISTIC_K) || \
            defined(WOLFSSL_ECDSA_DETERMINISTIC_K_VARIANT)
@@ -6493,23 +6506,6 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
 #else
    (void)inlen;
 #endif
-
-#if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_ECC) && \
-       defined(WOLFSSL_ASYNC_CRYPT_SW)
-    if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_ECC) {
-        if (wc_AsyncSwInit(&key->asyncDev, ASYNC_SW_ECC_SIGN)) {
-            WC_ASYNC_SW* sw = &key->asyncDev.sw;
-            sw->eccSign.in = in;
-            sw->eccSign.inSz = inlen;
-            sw->eccSign.rng = rng;
-            sw->eccSign.key = key;
-            sw->eccSign.r = r;
-            sw->eccSign.s = s;
-            return WC_PENDING_E;
-        }
-    }
-#endif
-
 
 #if !defined(WOLFSSL_SP_MATH)
 
@@ -8010,11 +8006,7 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
 #endif
 
 #if defined(WOLFSSL_HAVE_SP_ECC)
-    if (key->idx != ECC_CUSTOM_IDX
-    #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_ECC)
-        && key->asyncDev.marker != WOLFSSL_ASYNC_MARKER_ECC
-    #endif
-    ) {
+    if (key->idx != ECC_CUSTOM_IDX) {
     #if defined(WC_ECC_NONBLOCK) && defined(WC_ECC_NONBLOCK_ONLY)
         /* perform blocking call to non-blocking function */
         ecc_nb_ctx_t nb_ctx;


### PR DESCRIPTION
This requires the async code.

Fixes ZD 14141.

# Testing

Along with [this async PR](https://github.com/wolfSSL/wolfAsyncCrypt/pull/53), I tested cipher suites using ECDHE and ECDSA for TLS and DTLS. I added temporary debug counters (not committed) to the sign, verify, key gen, and shared secret functions to ensure that they were all being called multiple times (in the thousands) in a non-blocking fashion. Configured with:

```
./configure --enable-asynccrypt-sw --enable-ecc=nonblock --enable-sp=yes,nonblock --enable-dtls
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
