### PR TITLE
SP int: default to 16 bit word size when NO_64BIT defined

### DIFF
--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -213,7 +213,9 @@ extern "C" {
  * with compiler.
  */
 #ifndef SP_WORD_SIZE
-    #if defined(NO_64BIT) || !defined(HAVE___UINT128_T)
+    #ifdef NO_64BIT
+        #define SP_WORD_SIZE 16
+    #elif !defined(HAVE___UINT128_T)
         #define SP_WORD_SIZE 32
     #else
         #define SP_WORD_SIZE 64


### PR DESCRIPTION
# Description

Fix auto-detect of SP_WORD_SIZE when 64-bit type not available.

# Testing

Nothing specific.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
