### PR TITLE
20220909-fixes

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -8326,6 +8326,8 @@ static DtlsFragBucket* DtlsMsgCombineFragBuckets(DtlsMsg* msg,
 
 static void DtlsMsgAssembleCompleteMessage(DtlsMsg* msg)
 {
+    DtlsHandShakeHeader* dtls;
+
     /* We have received all necessary fragments. Reconstruct the header. */
     if (msg->fragBucketListCount != 1 || msg->fragBucketList->m.m.offset != 0 ||
             msg->fragBucketList->m.m.sz != msg->sz) {
@@ -8341,9 +8343,9 @@ static void DtlsMsgAssembleCompleteMessage(DtlsMsg* msg)
 
     /* frag->padding makes sure we can fit the entire DTLS handshake header
      * before frag->buf */
-    DtlsHandShakeHeader* dtls =
-            (DtlsHandShakeHeader*)(msg->fragBucketList->buf -
-                                    DTLS_HANDSHAKE_HEADER_SZ);
+    dtls = (DtlsHandShakeHeader*)(void *)((char *)msg->fragBucketList
+                                          + OFFSETOF(DtlsFragBucket,buf)
+                                          - DTLS_HANDSHAKE_HEADER_SZ);
 
     msg->fragBucketList = NULL;
     msg->fragBucketListCount = 0;

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -4578,7 +4578,7 @@ WOLFSSL_API void wolfSSL_sk_X509_INFO_pop_free(WOLF_STACK_OF(WOLFSSL_X509_INFO)*
 WOLFSSL_API void wolfSSL_sk_X509_INFO_free(WOLF_STACK_OF(WOLFSSL_X509_INFO)*);
 
 #define WOLF_SK_COMPARE_CB(type, arg) \
-    int (*arg) (const type* const* a, const type* const* b)
+    int (*(arg)) (const type* const* a, const type* const* b)
 typedef unsigned long (*wolf_sk_hash_cb) (const void *v);
 WOLFSSL_API WOLF_STACK_OF(WOLFSSL_X509_NAME)* wolfSSL_sk_X509_NAME_new(
     WOLF_SK_COMPARE_CB(WOLFSSL_X509_NAME, cb));

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2753,11 +2753,11 @@ extern void uITRON4_free(void *p) ;
 /* Are we using an external private key store like:
  *     PKCS11 / HSM / crypto callback / PK callback */
 #if !defined(WOLF_PRIVATE_KEY_ID) && !defined(NO_WOLF_PRIVATE_KEY_ID) && \
-	(defined(HAVE_PKCS11) || defined(HAVE_PK_CALLBACKS) || \
-	 defined(WOLF_CRYPTO_CB) || defined(WOLFSSL_KCAPI))
-	 /* Enables support for using wolfSSL_CTX_use_PrivateKey_Id and
-	  *   wolfSSL_CTX_use_PrivateKey_Label */
-	#define WOLF_PRIVATE_KEY_ID
+        (defined(HAVE_PKCS11) || defined(HAVE_PK_CALLBACKS) || \
+         defined(WOLF_CRYPTO_CB) || defined(WOLFSSL_KCAPI))
+         /* Enables support for using wolfSSL_CTX_use_PrivateKey_Id and
+          *   wolfSSL_CTX_use_PrivateKey_Label */
+        #define WOLF_PRIVATE_KEY_ID
 #endif
 
 /* With titan cache size there is too many sessions to fit with the default


### PR DESCRIPTION
fix whitespace in wolfssl/wolfcrypt/settings.h;

fix bugprone-macro-parentheses in wolfssl/ssl.h;

fix pointerOutOfBounds and declaration-after-statement in src/internal.c `DtlsMsgAssembleCompleteMessage()`;

wolfcrypt/src/pkcs7.c: revert 57a7430b6a0, which broke SCEP use case, and redo using a simple stack variable initialization approach.
