### PR TITLE
20220911-fixes-re-multi-test

### DIFF
--- a/linuxkm/Makefile
+++ b/linuxkm/Makefile
@@ -61,9 +61,9 @@ libwolfssl.ko:
 	@mkdir -p linuxkm src wolfcrypt/src wolfcrypt/test
 	@if test ! -h $(SRC_TOP)/Kbuild; then ln -s $(MODULE_TOP)/Kbuild $(SRC_TOP)/Kbuild; fi
 ifeq "$(ENABLED_LINUXKM_PIE)" "yes"
-	+$(MAKE) -C $(KERNEL_ROOT) M=$(MODULE_TOP) src=$(SRC_TOP) CC_FLAGS_FTRACE=
+	+$(MAKE) -C $(KERNEL_ROOT) M=$(MODULE_TOP) src=$(SRC_TOP) $(KBUILD_EXTRA_FLAGS) CC_FLAGS_FTRACE=
 else
-	+$(MAKE) -C $(KERNEL_ROOT) M=$(MODULE_TOP) src=$(SRC_TOP)
+	+$(MAKE) -C $(KERNEL_ROOT) M=$(MODULE_TOP) src=$(SRC_TOP) $(KBUILD_EXTRA_FLAGS)
 endif
 
 libwolfssl.ko.signed: libwolfssl.ko

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -4352,10 +4352,10 @@ static int _sp_mont_red(sp_int* a, sp_int* m, sp_int_digit mp);
  */
 static void _sp_zero(sp_int* a)
 {
-    a->used = 0;
-    a->dp[0] = 0;
+    ((sp_int_minimal *)a)->used = 0;
+    ((sp_int_minimal *)a)->dp[0] = 0;
 #ifdef WOLFSSL_SP_INT_NEGATIVE
-    a->sign = MP_ZPOS;
+    ((sp_int_minimal *)a)->sign = MP_ZPOS;
 #endif
 }
 
@@ -4394,10 +4394,20 @@ int sp_init(sp_int* a)
  */
 int sp_init_size(sp_int* a, int size)
 {
-    int err = sp_init(a);
+    int err = MP_OKAY;
+
+    if (a == NULL) {
+        err = MP_VAL;
+    }
+    if (err == MP_OKAY) {
+    #ifdef HAVE_WOLF_BIGINT
+        wc_bigint_init(&a->raw);
+    #endif
+        _sp_zero(a);
+    }
 
     if (err == MP_OKAY) {
-        a->size = size;
+        ((sp_int_minimal *)a)->size = size;
     }
 
     return err;

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -4352,11 +4352,43 @@ static int _sp_mont_red(sp_int* a, sp_int* m, sp_int_digit mp);
  */
 static void _sp_zero(sp_int* a)
 {
-    ((sp_int_minimal *)a)->used = 0;
-    ((sp_int_minimal *)a)->dp[0] = 0;
+    sp_int_minimal* am = (sp_int_minimal *)a;
+    am->used = 0;
+    am->dp[0] = 0;
 #ifdef WOLFSSL_SP_INT_NEGATIVE
-    ((sp_int_minimal *)a)->sign = MP_ZPOS;
+    am->sign = MP_ZPOS;
 #endif
+}
+
+
+/* Initialize the multi-precision number to be zero with a given max size.
+ *
+ * @param  [out]  a     SP integer.
+ * @param  [in]   size  Number of words to say are available.
+ *
+ * @return  MP_OKAY on success.
+ * @return  MP_VAL when a is NULL.
+ */
+int sp_init_size(sp_int* a, int size)
+{
+    sp_int_minimal* am = (sp_int_minimal *)a;
+    int err = MP_OKAY;
+
+    if (a == NULL) {
+        err = MP_VAL;
+    }
+    if (err == MP_OKAY) {
+    #ifdef HAVE_WOLF_BIGINT
+        wc_bigint_init(&am->raw);
+    #endif
+        _sp_zero(a);
+    }
+
+    if (err == MP_OKAY) {
+        am->size = size;
+    }
+
+    return err;
 }
 
 /* Initialize the multi-precision number to be zero.
@@ -4368,49 +4400,7 @@ static void _sp_zero(sp_int* a)
  */
 int sp_init(sp_int* a)
 {
-    int err = MP_OKAY;
-
-    if (a == NULL) {
-        err = MP_VAL;
-    }
-    if (err == MP_OKAY) {
-    #ifdef HAVE_WOLF_BIGINT
-        wc_bigint_init(&a->raw);
-    #endif
-        _sp_zero(a);
-        a->size = SP_INT_DIGITS;
-    }
-
-    return err;
-}
-
-/* Initialize the multi-precision number to be zero and have a maximum size.
- *
- * @param  [out]  a     SP integer.
- * @param  [in]   size  Number of words to say are available.
- *
- * @return  MP_OKAY on success.
- * @return  MP_VAL when a is NULL.
- */
-int sp_init_size(sp_int* a, int size)
-{
-    int err = MP_OKAY;
-
-    if (a == NULL) {
-        err = MP_VAL;
-    }
-    if (err == MP_OKAY) {
-    #ifdef HAVE_WOLF_BIGINT
-        wc_bigint_init(&a->raw);
-    #endif
-        _sp_zero(a);
-    }
-
-    if (err == MP_OKAY) {
-        ((sp_int_minimal *)a)->size = size;
-    }
-
-    return err;
+    return sp_init_size(a, SP_INT_DIGITS);
 }
 
 #if !defined(WOLFSSL_RSA_PUBLIC_ONLY) || !defined(NO_DH) || defined(HAVE_ECC)

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -778,6 +778,19 @@ typedef struct sp_int {
     sp_int_digit dp[SP_INT_DIGITS];
 } sp_int;
 
+typedef struct sp_int_minimal {
+    int used;
+    int size;
+#ifdef WOLFSSL_SP_INT_NEGATIVE
+    int sign;
+#endif
+#ifdef HAVE_WOLF_BIGINT
+    struct WC_BIGINT raw;
+#endif
+    /** First digit of number.  */
+    sp_int_digit dp[1];
+} sp_int_minimal;
+
 /* Multi-precision integer type is SP integer type. */
 typedef sp_int       mp_int;
 /* Multi-precision integer digit type is SP integer digit type.


### PR DESCRIPTION
wolfssl/wolfcrypt/sp_int.h and wolfcrypt/src/sp_int.c:

add `struct sp_int_minimal`, with same structure as `struct sp_int` but only one digit, to allow error-free access to `sp_int`s allocated with `ALLOC_SP_INT()` with fewer than `SP_INT_DIGITS` digits, and use the new type in `_sp_zero()` and `sp_init_size()` to eliminate `-Werror=array-bounds` on `_sp_zero()` under gcc-13.

tested with `wolfssl-mult-test.sh ... super-quick-check fips-140-3-dev-optest-acvp-sp-asm-gcc-latest linuxkm-mainline-pie-gcc-latest` at testing commit 7ccf1f2c3b9 (PR#346).


also adds support for `$KBUILD_EXTRA_FLAGS` to linuxkm/Makefile, needed to activate `linuxkm-mainline-pie-gcc-latest`.
