### PR TITLE
TLS 1.3 Middle-Box compat: fix missing brace

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -4459,6 +4459,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             WOLFSSL_MSG("session id doesn't match client random");
             WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
             return INVALID_PARAMETER;
+        }
     }
     else
 #endif /* WOLFSSL_TLS13_MIDDLEBOX_COMPAT */


### PR DESCRIPTION
# Description

Missing brace when compiled with WOLFSSL_TLS13_MIDDLEBOX_COMPAT.

# Testing

./configure '--disable-shared' '--enable-tls13' 'C_EXTRA_FLAGS=-DWOLFSSL_TLS13_MIDDLEBOX_COMPAT'

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
