### PR TITLE
wolfSSL_set1_curves_list(), wolfSSL_CTX_set1_curves_list() improvements.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -34041,8 +34041,8 @@ static int set_curves_list(WOLFSSL* ssl, WOLFSSL_CTX *ctx, const char* names)
         /* Switch the bit to off and therefore is enabled. */
         curve = (word16)groups[i];
         disabled &= ~(1U << curve);
-
-    #if defined(HAVE_SUPPORTED_CURVES) && !defined(WOLFSSL_OLD_SET_CURVES_LIST)
+    #ifdef HAVE_SUPPORTED_CURVES
+    #if defined(WOLFSSL_TLS13) && !defined(WOLFSSL_OLD_SET_CURVES_LIST)
         /* using the wolfSSL API to set the groups, this will populate
          * (ssl|ctx)->groups and reset any TLSX_SUPPORTED_GROUPS.
          * The order in (ssl|ctx)->groups will then be respected
@@ -34054,7 +34054,7 @@ static int set_curves_list(WOLFSSL* ssl, WOLFSSL_CTX *ctx, const char* names)
             WOLFSSL_MSG("Unable to set supported curve");
             goto leave;
         }
-    #elif defined(HAVE_SUPPORTED_CURVES) && !defined(NO_WOLFSSL_CLIENT)
+    #elif !defined(NO_WOLFSSL_CLIENT)
         /* set the supported curve so client TLS extension contains only the
          * desired curves */
         if ((ssl && wolfSSL_UseSupportedCurve(ssl, curve) != WOLFSSL_SUCCESS)
@@ -34064,6 +34064,7 @@ static int set_curves_list(WOLFSSL* ssl, WOLFSSL_CTX *ctx, const char* names)
             goto leave;
         }
     #endif
+    #endif /* HAVE_SUPPORTED_CURVES */
     }
 
     if (ssl)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -33939,8 +33939,8 @@ static int set_curves_list(WOLFSSL* ssl, WOLFSSL_CTX *ctx, const char* names)
 #endif
 
 #ifdef WOLFSSL_SMALL_STACK
-    groups = (byte*)XMALLOC(sizeof(int)*WOLFSSL_MAX_GROUP_COUNT,
-                            heap, DYNAMIC_TYPE_TMP_BUFFER);
+    groups = (int*)XMALLOC(sizeof(int)*WOLFSSL_MAX_GROUP_COUNT,
+                           heap, DYNAMIC_TYPE_TMP_BUFFER);
     if (groups == NULL) {
         ret = MEMORY_E;
         goto leave;
@@ -34042,7 +34042,7 @@ static int set_curves_list(WOLFSSL* ssl, WOLFSSL_CTX *ctx, const char* names)
         curve = (word16)groups[i];
         disabled &= ~(1U << curve);
 
-    #ifndef WOLFSSL_OLD_SET_CURVES_LIST
+    #if defined(HAVE_SUPPORTED_CURVES) && !defined(WOLFSSL_OLD_SET_CURVES_LIST)
         /* using the wolfSSL API to set the groups, this will populate
          * (ssl|ctx)->groups and reset any TLSX_SUPPORTED_GROUPS.
          * The order in (ssl|ctx)->groups will then be respected

--- a/tests/quic.c
+++ b/tests/quic.c
@@ -949,20 +949,26 @@ static int QuicConversation_start(QuicConversation *conv, const byte *data,
     return ret;
 }
 
-static int QuicConversation_step(QuicConversation *conv)
+static int QuicConversation_step(QuicConversation *conv, int may_fail)
 {
     int n;
 
     if (!conv->started) {
-        AssertTrue(wolfSSL_connect(conv->client->ssl) != WOLFSSL_SUCCESS);
-        AssertIntEQ(SSL_ERROR_WANT_READ, wolfSSL_get_error(conv->client->ssl, 0));
+        n = wolfSSL_connect(conv->client->ssl);
+        if (n != WOLFSSL_SUCCESS
+            && wolfSSL_get_error(conv->client->ssl, 0) != SSL_ERROR_WANT_READ) {
+            if (may_fail) return 0;
+            AssertIntEQ(SSL_ERROR_WANT_READ, wolfSSL_get_error(conv->client->ssl, 0));
+        }
         conv->started = 1;
     }
     if (conv->server->output.len > 0) {
         QuicTestContext_forward(conv->server, conv->client, conv->rec_log, sizeof(conv->rec_log));
         n = wolfSSL_quic_read_write(conv->client->ssl);
-        if (n != WOLFSSL_SUCCESS) {
-            AssertIntEQ(wolfSSL_get_error(conv->client->ssl, 0), SSL_ERROR_WANT_READ);
+        if (n != WOLFSSL_SUCCESS
+            && wolfSSL_get_error(conv->client->ssl, 0) != SSL_ERROR_WANT_READ) {
+            if (may_fail) return 0;
+            AssertIntEQ(SSL_ERROR_WANT_READ, wolfSSL_get_error(conv->client->ssl, 0));
         }
         return 1;
     }
@@ -976,7 +982,10 @@ static int QuicConversation_step(QuicConversation *conv)
                                         (int)(sizeof(conv->early_data) - conv->early_data_len),
                                         &written);
             if (n < 0) {
-                AssertIntEQ(wolfSSL_get_error(conv->server->ssl, 0), SSL_ERROR_WANT_READ);
+                if (wolfSSL_get_error(conv->server->ssl, 0) != SSL_ERROR_WANT_READ) {
+                    if (may_fail) return 0;
+                    AssertIntEQ(wolfSSL_get_error(conv->server->ssl, 0), SSL_ERROR_WANT_READ);
+                }
             }
             else if (n > 0) {
                 conv->early_data_len += n;
@@ -988,7 +997,9 @@ static int QuicConversation_step(QuicConversation *conv)
  #endif /* WOLFSSL_EARLY_DATA */
         {
             n = wolfSSL_quic_read_write(conv->server->ssl);
-            if (n != WOLFSSL_SUCCESS) {
+            if (n != WOLFSSL_SUCCESS
+                && wolfSSL_get_error(conv->server->ssl, 0) != SSL_ERROR_WANT_READ) {
+                if (may_fail) return 0;
                 AssertIntEQ(wolfSSL_get_error(conv->server->ssl, 0), SSL_ERROR_WANT_READ);
             }
         }
@@ -1004,7 +1015,7 @@ static void QuicConversation_do(QuicConversation *conv)
     }
 
     while (1) {
-        if (!QuicConversation_step(conv)) {
+        if (!QuicConversation_step(conv, 0)) {
             int c_err = wolfSSL_get_error(conv->client->ssl, 0);
             int s_err = wolfSSL_get_error(conv->server->ssl, 0);
             if (c_err == 0 && s_err == 0) {
@@ -1014,6 +1025,22 @@ static void QuicConversation_do(QuicConversation *conv)
                    "but client_error=%d, server_error=%d\n",
                    c_err, s_err);
             AssertFalse(1);
+        }
+    }
+}
+
+static void QuicConversation_fail(QuicConversation *conv)
+{
+    if (!conv->started) {
+        QuicConversation_start(conv, NULL, 0, NULL);
+    }
+
+    while (1) {
+        if (!QuicConversation_step(conv, 1)) {
+            int c_err = wolfSSL_get_error(conv->client->ssl, 0);
+            int s_err = wolfSSL_get_error(conv->server->ssl, 0);
+            AssertTrue(c_err != 0 || s_err != 0);
+            break;
         }
     }
 }
@@ -1089,14 +1116,14 @@ static int test_quic_server_hello(int verbose) {
 
     /* connect */
     QuicConversation_init(&conv, &tclient, &tserver);
-    QuicConversation_step(&conv);
+    QuicConversation_step(&conv, 0);
     /* check established/missing secrets */
     check_secrets(&tserver, wolfssl_encryption_initial, 0, 0);
     check_secrets(&tserver, wolfssl_encryption_handshake, 32, 32);
     check_secrets(&tserver, wolfssl_encryption_application, 32, 32);
     check_secrets(&tclient, wolfssl_encryption_handshake, 0, 0);
     /* feed the server data to the client */
-    QuicConversation_step(&conv);
+    QuicConversation_step(&conv, 0);
     /* client has generated handshake secret */
     check_secrets(&tclient, wolfssl_encryption_handshake, 32, 32);
     /* continue the handshake till done */
@@ -1166,8 +1193,9 @@ static int test_quic_key_share(int verbose) {
     QuicTestContext_free(&tclient);
     QuicTestContext_free(&tserver);
 
-    /* setup & handshake, restricted groups, will trigger a
-     * HelloRetryRequest(ServerHello) and a new ClientHello */
+    /* setup & handshake, restricted groups. KEY_SHARE should use
+     * the first configured group. */
+    /*If that is supported by the server, expect a smooth handshake.*/
     QuicTestContext_init(&tclient, ctx_c, "client", verbose);
     QuicTestContext_init(&tserver, ctx_s, "server", verbose);
     AssertTrue(wolfSSL_set1_curves_list(tclient.ssl, "X25519:P-256")
@@ -1177,10 +1205,42 @@ static int test_quic_key_share(int verbose) {
     QuicConversation_init(&conv, &tclient, &tserver);
     QuicConversation_do(&conv);
     AssertStrEQ(conv.rec_log,
+        "ClientHello:ServerHello:EncryptedExtension:"
+            "Certificate:CertificateVerify:Finished:Finished:SessionTicket");
+    QuicTestContext_free(&tclient);
+    QuicTestContext_free(&tserver);
+    printf("    test_quic_key_share: priority ok\n");
+
+    /* If group is not supported by server, expect HelloRetry */
+    QuicTestContext_init(&tclient, ctx_c, "client", verbose);
+    QuicTestContext_init(&tserver, ctx_s, "server", verbose);
+    AssertTrue(wolfSSL_set1_curves_list(tclient.ssl, "X25519:P-256")
+               == WOLFSSL_SUCCESS);
+    AssertTrue(wolfSSL_set1_curves_list(tserver.ssl, "P-256")
+               == WOLFSSL_SUCCESS);
+    QuicConversation_init(&conv, &tclient, &tserver);
+    QuicConversation_do(&conv);
+    AssertStrEQ(conv.rec_log,
         "ClientHello:ServerHello:ClientHello:ServerHello:EncryptedExtension:"
             "Certificate:CertificateVerify:Finished:Finished:SessionTicket");
     QuicTestContext_free(&tclient);
     QuicTestContext_free(&tserver);
+    printf("    test_quic_key_share: retry ok\n");
+
+    /* If no group overlap, expect failure */
+    QuicTestContext_init(&tclient, ctx_c, "client", verbose);
+    QuicTestContext_init(&tserver, ctx_s, "server", verbose);
+    AssertTrue(wolfSSL_set1_curves_list(tclient.ssl, "P-256")
+               == WOLFSSL_SUCCESS);
+    AssertTrue(wolfSSL_set1_curves_list(tserver.ssl, "X25519")
+               == WOLFSSL_SUCCESS);
+    QuicConversation_init(&conv, &tclient, &tserver);
+    QuicConversation_fail(&conv);
+    AssertIntEQ(wolfSSL_get_error(tserver.ssl, 0), SSL_ERROR_WANT_READ);
+    AssertIntEQ(wolfSSL_get_error(tclient.ssl, 0), BAD_KEY_SHARE_DATA);
+    QuicTestContext_free(&tclient);
+    QuicTestContext_free(&tserver);
+    printf("    test_quic_key_share: no match ok\n");
 
     wolfSSL_CTX_free(ctx_c);
     wolfSSL_CTX_free(ctx_s);
@@ -1476,7 +1536,7 @@ int QuicTest(void)
     if ((ret = test_quic_key_share(verbose)) != 0) goto leave;
     if ((ret = test_quic_resumption(verbose)) != 0) goto leave;
 #ifdef WOLFSSL_EARLY_DATA
-    if ((ret = test_quic_early_data(verbose || 1)) != 0) goto leave;
+    if ((ret = test_quic_early_data(verbose)) != 0) goto leave;
 #endif /* WOLFSSL_EARLY_DATA */
     if ((ret = test_quic_session_export(verbose)) != 0) goto leave;
 #endif /* HAVE_SESSION_TICKET */


### PR DESCRIPTION
# Description

- Use wolfSSL API wolfSSL_set_groups() and wolfSSL_CTX_set_groups() to configure curves list
- This sets ssl->groups and ctx->groups accordingly and makes TLSX_KEY_SHARE generation respect the selection and precedence.
- Add tests in quic to assert the order of selections.

# Testing

The added tests in the quic unit.tests verify that the selection and precedence is respected this way.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
