### PR TITLE
20220914-fix-quic-test-default-build

### DIFF
--- a/tests/quic.c
+++ b/tests/quic.c
@@ -1029,6 +1029,8 @@ static void QuicConversation_do(QuicConversation *conv)
     }
 }
 
+#ifdef HAVE_SESSION_TICKET
+
 static void QuicConversation_fail(QuicConversation *conv)
 {
     if (!conv->started) {
@@ -1044,6 +1046,8 @@ static void QuicConversation_fail(QuicConversation *conv)
         }
     }
 }
+
+#endif /* HAVE_SESSION_TICKET */
 
 static int test_quic_client_hello(int verbose) {
     WOLFSSL_CTX *ctx;


### PR DESCRIPTION
tests/quic.c: gate QuicConversation_fail() definition to avoid -Wunused-function.

tested with `wolfssl-multi-test.sh ... defaults-quic`.
