### PR TITLE
Handle WC_PENDING_E from ticketEncCb in DoClientTicket properly.

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -34008,9 +34008,16 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                                     et->enc_ticket, inLen, &outLen,
                                     ssl->ctx->ticketEncCtx);
         }
-        if (ret != WOLFSSL_TICKET_RET_OK && ret != WOLFSSL_TICKET_RET_CREATE) {
-            WOLFSSL_ERROR_VERBOSE(BAD_TICKET_KEY_CB_SZ);
-            return WOLFSSL_TICKET_RET_REJECT;
+        if (ret != WOLFSSL_TICKET_RET_OK) {
+        #ifdef WOLFSSL_ASYNC_CRYPT
+            if (ret == WC_PENDING_E) {
+                return ret;
+            }
+        #endif /* WOLFSSL_ASYNC_CRYPT */
+            if (ret != WOLFSSL_TICKET_RET_CREATE) {
+                WOLFSSL_ERROR_VERBOSE(BAD_TICKET_KEY_CB_SZ);
+                return WOLFSSL_TICKET_RET_REJECT;
+            }
         }
         if (outLen > (int)inLen || outLen < (int)sizeof(InternalTicket)) {
             WOLFSSL_MSG("Bad user ticket decrypt len");


### PR DESCRIPTION
# Description

ticketEncCb can return WC_PENDING_E. If it does in DoClientTicket, we need to propagate this up to the calling function (e.g. DoPreSharedKeys), rather than treating it as a failure.

Fixes ZD #14420.

# Testing

I tested this with config 

```
./configure --enable-all --enable-asynccrypt CFLAGS="-DWOLFSSL_NO_DEF_TICKET_ENC_CB"
```

and by running the following experiment

```
./examples/server/server -v 4 -r &
./examples/client/client -v 4 -r
```

and adding the following async simulation code to wc_ChaCha20Poly1305_Decrypt:

```
#ifdef WOLFSSL_ASYNC_CRYPT
    static int testAsync = 0;
    if ((testAsync++ % 2) == 0) {
        return WC_PENDING_E;
    }
#endif
```

Prior to these changes, you can see that the WC_PENDING_E will not be handled properly in DoClientTicket (using gdb). A full TLS handshake proceeds from there. With this commit, running the same experiment shows the pending error being handled properly.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
