### PR TITLE
Fix casts in evp.c and build issue in ParseCRL

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -36359,7 +36359,7 @@ end:
     }
     if (ret == 0) {
     #endif
-#if defined(OPENSSL_EXTRA)
+    #ifdef OPENSSL_EXTRA
         /* Parse and store the issuer name. */
         dcrl->issuerSz = GetASNItem_Length(dataASN[CRLASN_IDX_TBS_ISSUER],
                             buff);
@@ -36372,7 +36372,7 @@ end:
         if (ret < 0) {
             ret = ASN_PARSE_E;
         }
-#endif
+    #endif
     }
 
     if ((ret == 0) && (dataASN[CRLASN_IDX_TBS_REVOKEDCERTS].tag != 0)) {

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -6779,8 +6779,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
                  * combines them to a new iv. EVP is given exactly *one* iv,
                  * so to pass it into chacha, we have to revert that first.
                  * The counter comes first in little-endian */
-                word32 counter = (uint32_t)iv[0] + (uint32_t)(iv[1] << 8) +
-                    (uint32_t)(iv[2] << 16) + (uint32_t)(iv[3] << 24);
+                word32 counter = (word32)iv[0] + (word32)(iv[1] << 8) +
+                    (word32)(iv[2] << 16) + (word32)(iv[3] << 24);
                 if (wc_Chacha_SetIV(&ctx->cipher.chacha,
                                     iv + sizeof(counter), counter) != 0) {
 


### PR DESCRIPTION
# Description

In evp.c, replace casts to`uint32_t` with `word32`
Fix build error with `./configure --enable-crl --enable-asn=template`

# Testing

Clean build

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
