### PR TITLE
20220917-fixes

### DIFF
--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -259,7 +259,7 @@ static int Dtls13GetRnMask(WOLFSSL* ssl, const byte* ciphertext, byte* mask,
 #ifdef HAVE_CHACHA
     if (ssl->specs.bulk_cipher_algorithm == wolfssl_chacha) {
         word32 counter;
-		int ret;
+        int ret;
 
         if (c->chacha == NULL)
             return BAD_STATE_E;

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -518,7 +518,7 @@ static int DeriveClientHandshakeSecret(WOLFSSL* ssl, byte* key)
     if (ssl == NULL || ssl->arrays == NULL) {
         return BAD_FUNC_ARG;
     }
-    
+
     ret = Tls13DeriveKey(ssl, key, -1, ssl->arrays->preMasterSecret,
                     clientHandshakeLabel, CLIENT_HANDSHAKE_LABEL_SZ,
                     ssl->specs.mac_algorithm, 1);
@@ -6169,9 +6169,10 @@ int SendTls13ServerHello(WOLFSSL* ssl, byte extMsgType)
     {
 #ifdef WOLFSSL_DTLS13
         if (ssl->options.dtls) {
-            ret = Dtls13HashHandshake(ssl,
-									output + Dtls13GetRlHeaderLength(ssl, 0) ,
-                            (word16)sendSz - Dtls13GetRlHeaderLength(ssl, 0));
+            ret = Dtls13HashHandshake(
+                ssl,
+                output + Dtls13GetRlHeaderLength(ssl, 0) ,
+                (word16)sendSz - Dtls13GetRlHeaderLength(ssl, 0));
         }
         else
 #endif /* WOLFSSL_DTLS13 */
@@ -6452,7 +6453,7 @@ static int SendTls13CertificateRequest(WOLFSSL* ssl, byte* reqCtx,
         ssl->options.buildingMsg = 0;
         ret =
             Dtls13HandshakeSend(ssl, output, (word16)sendSz, (word16)i,
-								certificate_request, 1);
+                                certificate_request, 1);
 
         WOLFSSL_LEAVE("SendTls13CertificateRequest", ret);
         WOLFSSL_END(WC_FUNC_CERTIFICATE_REQUEST_SEND);
@@ -7263,7 +7264,7 @@ static int SendTls13Certificate(WOLFSSL* ssl)
             ssl->options.buildingMsg = 0;
             ssl->fragOffset = 0;
             ret = Dtls13HandshakeSend(ssl, output, (word16)sendSz, (word16)i,
-									  certificate, 1);
+                                      certificate, 1);
         }
         else
 #endif /* WOLFSSL_DTLS13 */

--- a/wolfcrypt/src/ext_kyber.c
+++ b/wolfcrypt/src/ext_kyber.c
@@ -240,7 +240,7 @@ int wc_KyberKey_CipherTextSize(KyberKey* key, word32* len)
     }
 
 #ifdef HAVE_LIBOQS
-    /* NOTE: SHAKE and AES variants have the same length ciphertext. */ 
+    /* NOTE: SHAKE and AES variants have the same length ciphertext. */
     if (ret == 0) {
         switch (key->type) {
         case KYBER_LEVEL1:
@@ -534,7 +534,7 @@ int wc_KyberKey_Decapsulate(KyberKey* key, unsigned char* ss,
 
 /**
  * Decode the private key.
- * 
+ *
  * We store the whole thing in the private key buffer. Note this means we cannot
  * do the encapsulation operation with the private key. But generally speaking
  * this is never done.
@@ -614,7 +614,7 @@ int wc_KyberKey_DecodePublicKey(KyberKey* key, unsigned char* in, word32 len)
 
 /**
  * Encode the private key.
- * 
+ *
  * We stored it as a blob so we can just copy it over.
  *
  * @param  [in]   key  Kyber key object.
@@ -664,7 +664,7 @@ int wc_KyberKey_EncodePrivateKey(KyberKey* key, unsigned char* out, word32 len)
  */
 int wc_KyberKey_EncodePublicKey(KyberKey* key, unsigned char* out, word32 len)
 {
-    int ret = 0; 
+    int ret = 0;
     unsigned int pubLen = 0;
 
     if ((key == NULL) || (out == NULL)) {

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -10600,11 +10600,16 @@ int sp_invmod(sp_int* a, sp_int* m, sp_int* r)
     else if (err != MP_OKAY) {
     }
     else {
-        sp_init_size(u, m->used + 1);
-        sp_init_size(v, m->used + 1);
-        sp_init_size(b, m->used + 1);
-        sp_init_size(c, 2 * m->used + 1);
+        err = sp_init_size(u, m->used + 1);
+        if (err == MP_OKAY)
+            err = sp_init_size(v, m->used + 1);
+        if (err == MP_OKAY)
+            err = sp_init_size(b, m->used + 1);
+        if (err == MP_OKAY)
+            err = sp_init_size(c, 2 * m->used + 1);
+    }
 
+    if ((err == MP_OKAY) && !sp_isone(a)) {
         if (sp_iseven(m)) {
             /* a^-1 mod m = m + ((1 - m*(m^-1 % a)) / a) */
             mm = a;
@@ -16363,10 +16368,14 @@ int sp_gcd(sp_int* a, sp_int* b, sp_int* r)
             u = d[0];
             v = d[1];
             t = d[2];
-            sp_init_size(u, used);
-            sp_init_size(v, used);
-            sp_init_size(t, used);
+            err = sp_init_size(u, used);
+        }
+        if (err == MP_OKAY)
+            err = sp_init_size(v, used);
+        if (err == MP_OKAY)
+            err = sp_init_size(t, used);
 
+        if (err == MP_OKAY) {
             if (_sp_cmp(a, b) != MP_LT) {
                 sp_copy(b, u);
                 /* First iteration - u = a, v = b */


### PR DESCRIPTION
wolfcrypt/src/sp_int.c: catch and propagate errors from `sp_init_size()` in `sp_invmod()` and `sp_gcd()` to fix `clang-analyzer-core.UndefinedBinaryOperatorResult`.

src/internal.c:

in `DtlsMsgNew()`, iff `WOLFSSL_ASYNC_CRYPT`, `allow sz==0` allocation, to fix infinite loop in `ProcessReplyEx()` around `DoDtlsHandShakeMsg()`;

in `DtlsMsgAssembleCompleteMessage()` restore fix from 0603031362a for `pointerOutOfBounds` (undefined behavior) construct;

in `ProcessReplyEx()`, in `WOLFSSL_DTLS13` `case ack`, check and propagate error from `DoDtls13Ack()` (fix from @guidovranken).

fix whitespace/linelength/indentation.

tested with `wolfssl-mult-test.sh ... all-asynccrypt check-source-text all-asynccrypt cppcheck-all cppcheck-all-intmath cppcheck-all-async-quic cppcheck-all-fips cppcheck-all-fips-dev clang-tidy-defaults clang-tidy-all-sp-all clang-tidy-all-async-quic clang-tidy-fips-140-3-dev-defaults clang-tidy-fips-140-3-dev-all sanitizer-all-asm-smallstack-async-quic all-dtls13 all-dtls13-asynccrypt super-quick-check`
