### PR TITLE
Fix: parsing oob read in dtls1.3

### DIFF
--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -90,8 +90,6 @@ typedef struct Dtls13RecordPlaintextHeader {
 
 /* size of the len field in the unified header */
 #define DTLS13_LEN_SIZE 2
-/* size of the mask used to encrypt/decrypt Record Number  */
-#define DTLS13_RN_MASK_SIZE 16
 /* size of the flags in the unified header */
 #define DTLS13_HDR_FLAGS_SIZE 1
 /* size of the sequence number wher SEQ_LEN_BIT is present */

--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -1362,6 +1362,8 @@ int Dtls13ParseUnifiedRecordLayer(WOLFSSL* ssl, const byte* input,
        to create record number xor mask). (draft 43 - Sec 4.2.3) */
     if (hdrInfo->recordLength < DTLS13_RN_MASK_SIZE)
         return LENGTH_ERROR;
+    if (inputSize < idx + DTLS13_RN_MASK_SIZE)
+        return BUFFER_ERROR;
 
     ret = Dtls13EncryptDecryptRecordNumber(ssl, seqNum, seqLen, input + idx,
         DEPROTECT);

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4640,6 +4640,9 @@ typedef enum EarlyDataState {
 
 #ifdef WOLFSSL_DTLS13
 
+/* size of the mask used to encrypt/decrypt Record Number  */
+#define DTLS13_RN_MASK_SIZE 16
+
 typedef struct Dtls13UnifiedHdrInfo {
     word16 recordLength;
     byte seqLo;


### PR DESCRIPTION
# Description

Use correct parameter for `GetInputData` in `GetDltsHeader()` and `GetDtls13RecordHeader()`.
Don't use temporary variables that can become stale after a call to `GetInputData`.
Add a check that we have the available bytes to decrypt RecordNumber in `Dtls13ParseUnifiedHeader()`

Fixes zd#14781

# Testing

`./configure && make check`
`./configure --enable-dtls --enable-dtls13 && make check`
ran in the fuzzer
