### PR TITLE
handle certificates with RSA-PSS signature that have RSAk public keys

### DIFF
--- a/certs/rsapss/include.am
+++ b/certs/rsapss/include.am
@@ -52,7 +52,8 @@ EXTRA_DIST += \
          certs/rsapss/server-3072-rsapss-key.der \
          certs/rsapss/server-3072-rsapss-key.pem \
          certs/rsapss/server-3072-rsapss-priv.der \
-         certs/rsapss/server-3072-rsapss-priv.pem
+         certs/rsapss/server-3072-rsapss-priv.pem \
+         certs/rsapss/server-mix-rsapss-cert.pem
 
 EXTRA_DIST += \
          certs/rsapss/renew-rsapss-certs.sh \

--- a/certs/rsapss/renew-rsapss-certs.sh
+++ b/certs/rsapss/renew-rsapss-certs.sh
@@ -53,6 +53,25 @@ echo "End of section"
 echo "---------------------------------------------------------------------"
 
 ############################################################
+####### update server-mix-rsapss.pem signed by ca ##########
+############################################################
+echo "Updating server-mix-rsapss.pem"
+echo ""
+#pipe the following arguments to openssl req...
+echo -e "US\\nMontana\\nBozeman\\nwolfSSL_RSAPSS\\nServer-MIX-RSAPSS\\nwww.wolfssl.com\\ninfo@wolfssl.com\\n\\n\\n\\n" | openssl req -new -key ../server-key.pem -config ../renewcerts/wolfssl.cnf -nodes -out server-mix-rsapss.csr
+check_result $? "Generate request"
+
+openssl x509 -req -in server-mix-rsapss.csr -days 1000 -extfile ../renewcerts/wolfssl.cnf -extensions server_ecc -CA ../ca-cert.pem -CAkey ../ca-key.pem -sigopt rsa_padding_mode:pss -set_serial 01 -out server-mix-rsapss-cert.pem
+check_result $? "Generate certificate"
+rm server-mix-rsapss.csr
+
+openssl x509 -in server-mix-rsapss-cert.pem -text > tmp.pem
+check_result $? "Add text"
+mv tmp.pem server-mix-rsapss-cert.pem
+echo "End of section"
+echo "---------------------------------------------------------------------"
+
+############################################################
 ####### update server-rsapss.pem signed by ca ##############
 ############################################################
 echo "Updating server-rsapss.pem"

--- a/certs/rsapss/server-mix-rsapss-cert.pem
+++ b/certs/rsapss/server-mix-rsapss-cert.pem
@@ -1,0 +1,100 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1 (0x1)
+        Signature Algorithm: rsassaPss         
+         Hash Algorithm: sha256
+         Mask Algorithm: mgf1 with sha256
+          Salt Length: 0xDE
+         Trailer Field: 0xBC (default)
+        Issuer: C = US, ST = Montana, L = Bozeman, O = Sawtooth, OU = Consulting, CN = www.wolfssl.com, emailAddress = info@wolfssl.com
+        Validity
+            Not Before: Sep 20 23:01:48 2022 GMT
+            Not After : Jun 16 23:01:48 2025 GMT
+        Subject: C = US, ST = Montana, L = Bozeman, O = wolfSSL_RSAPSS, OU = Server-MIX-RSAPSS, CN = www.wolfssl.com, emailAddress = info@wolfssl.com, UID = wolfSSL
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
+
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment, Key Agreement
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication
+            Netscape Cert Type: 
+                SSL Server
+    Signature Algorithm: rsassaPss         
+         Hash Algorithm: sha256
+         Mask Algorithm: mgf1 with sha256
+          Salt Length: 0xDE
+         Trailer Field: 0xBC (default)
+
+         33:53:6d:d1:35:14:22:63:54:8a:78:31:5b:dd:5e:86:55:e8:
+         a8:1f:ed:f2:b9:1a:ea:89:64:aa:39:87:21:15:aa:72:c9:65:
+         08:fb:36:09:d6:9a:a1:b2:39:59:2c:7a:0a:77:72:d9:60:27:
+         7a:6f:68:a6:a0:19:20:dd:d0:dd:21:d3:1d:06:ce:b5:60:9a:
+         2b:82:84:99:1b:06:56:95:8e:7a:cc:a4:ef:38:95:36:41:3d:
+         21:dc:d7:db:52:58:4a:ab:74:fc:50:87:c8:26:a1:0a:2e:e8:
+         e7:15:52:2f:32:b8:a5:69:61:79:13:1c:52:bd:9e:a5:31:89:
+         30:0e:50:8e:65:da:f5:13:fe:22:d6:57:0e:f4:32:b0:a6:5e:
+         53:ff:44:25:d5:e7:03:93:98:85:de:3d:3e:9c:a7:dc:45:62:
+         f8:96:f9:82:c3:5f:20:1e:37:c3:14:e7:9b:db:dc:5d:df:f4:
+         16:9a:93:8b:3c:47:3d:73:c8:55:ff:7f:00:15:1c:4d:bb:de:
+         76:d3:5a:2d:8f:0f:bf:88:d1:54:e6:13:5e:f0:a5:aa:b9:74:
+         64:ca:a8:22:cc:12:51:8a:84:be:35:31:d6:b3:b4:45:c5:9d:
+         87:53:32:7c:7a:be:21:e4:55:f4:f3:a7:14:7a:4d:17:b9:9c:
+         8f:1f:d8:fd
+-----BEGIN CERTIFICATE-----
+MIIEtzCCA26gAwIBAgIBATA+BgkqhkiG9w0BAQowMaANMAsGCWCGSAFlAwQCAaEa
+MBgGCSqGSIb3DQEBCDALBglghkgBZQMEAgGiBAICAN4wgZQxCzAJBgNVBAYTAlVT
+MRAwDgYDVQQIDAdNb250YW5hMRAwDgYDVQQHDAdCb3plbWFuMREwDwYDVQQKDAhT
+YXd0b290aDETMBEGA1UECwwKQ29uc3VsdGluZzEYMBYGA1UEAwwPd3d3LndvbGZz
+c2wuY29tMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tMB4XDTIyMDky
+MDIzMDE0OFoXDTI1MDYxNjIzMDE0OFowgboxCzAJBgNVBAYTAlVTMRAwDgYDVQQI
+DAdNb250YW5hMRAwDgYDVQQHDAdCb3plbWFuMRcwFQYDVQQKDA53b2xmU1NMX1JT
+QVBTUzEaMBgGA1UECwwRU2VydmVyLU1JWC1SU0FQU1MxGDAWBgNVBAMMD3d3dy53
+b2xmc3NsLmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbTEXMBUG
+CgmSJomT8ixkAQEMB3dvbGZTU0wwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+AoIBAQDAlQjhV0HycW230kVBJwFlxkWu8rwkMLiVzi9O1vYciLx8n/uoZ3/+XJxR
+dfeKygfnNS+P4b17wC98q2SoF/zKXXu64CHlci5vLobYlXParBtTuV8/1xkNJU/h
+Y2NRiwtkP61DuKUcXDSzrgCgY8X2fwtZaHhzpowYqQJtr8MZAS64EOPGzEC0aaNG
+M2mHbsS7F6bz6N2tc7x7LyG1/WZRDL1Us+FtXxy8I3PRCQOJFNIQuWTDKtChlkq8
+4dQaW8egwMFjeA9ENzAyloAyI5Whd7oT0pdz4l0lyWoNwzlgpLSwaUJCCenYCLwz
+ILNYIqeq68Th5mGDxdKW39nQT63XAgMBAAGjgYkwgYYwHQYDVR0OBBYEFLMRMsmS
+mITiyfjQO24DQsofDo48MB8GA1UdIwQYMBaAFCeOZxF0wyYdP+0zY7Ok2B0w5ejV
+MAwGA1UdEwEB/wQCMAAwDgYDVR0PAQH/BAQDAgOoMBMGA1UdJQQMMAoGCCsGAQUF
+BwMBMBEGCWCGSAGG+EIBAQQEAwIGQDA+BgkqhkiG9w0BAQowMaANMAsGCWCGSAFl
+AwQCAaEaMBgGCSqGSIb3DQEBCDALBglghkgBZQMEAgGiBAICAN4DggEBADNTbdE1
+FCJjVIp4MVvdXoZV6Kgf7fK5GuqJZKo5hyEVqnLJZQj7NgnWmqGyOVksegp3ctlg
+J3pvaKagGSDd0N0h0x0GzrVgmiuChJkbBlaVjnrMpO84lTZBPSHc19tSWEqrdPxQ
+h8gmoQou6OcVUi8yuKVpYXkTHFK9nqUxiTAOUI5l2vUT/iLWVw70MrCmXlP/RCXV
+5wOTmIXePT6cp9xFYviW+YLDXyAeN8MU55vb3F3f9Baak4s8Rz1zyFX/fwAVHE27
+3nbTWi2PD7+I0VTmE17wpaq5dGTKqCLMElGKhL41MdaztEXFnYdTMnx6viHkVfTz
+pxR6TRe5nI8f2P0=
+-----END CERTIFICATE-----

--- a/tests/test-rsapss.conf
+++ b/tests/test-rsapss.conf
@@ -72,3 +72,19 @@
 -A ./certs/rsapss/root-rsapss.pem
 -C
 
+# server TLSv1.2 - RSA PSS SHA256 MGF1 SHA256
+-v 3
+-l DHE-RSA-AES128-GCM-SHA256
+-c ./certs/rsapss/server-mixed-rsapss-cert.pem
+-k ./certs/server-key.pem
+-A ./certs/rsapss/client-rsapss.pem
+-V
+
+# client TLSv1.2 - RSA PSS SHA256 MGF1 SHA256
+-v 3
+-l DHE-RSA-AES128-GCM-SHA256
+-c ./certs/rsapss/client-rsapss.pem
+-k ./certs/rsapss/client-rsapss-priv.pem
+-A ./certs/ca-cert.pem
+-C
+

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -15395,7 +15395,7 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
         case SIG_STATE_HASH:
         {
         #if !defined(NO_RSA) && defined(WC_RSA_PSS)
-            if (keyOID == RSAPSSk) {
+            if (sigOID == RSAPSSk) {
                 word32 fakeSigOID = 0;
                 ret = DecodeRsaPssParams(sigParams, sigParamsSz, &sigCtx->hash,
                     &sigCtx->mgf, &sigCtx->saltLen);
@@ -16061,15 +16061,17 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
         {
             switch (keyOID) {
             #ifndef NO_RSA
+                case RSAk:
                 #ifdef WC_RSA_PSS
                 case RSAPSSk:
+                if (sigOID == RSAPSSk) {
                     /* TODO: pkCbRsaPss - RSA PSS callback. */
                     ret = wc_RsaPSS_VerifyInline_ex(sigCtx->sigCpy, sigSz,
                         &sigCtx->out, sigCtx->hash, sigCtx->mgf,
                         sigCtx->saltLen, sigCtx->key.rsa);
-                    break;
+                }
+                else
                 #endif
-                case RSAk:
                 {
                 #if defined(HAVE_PK_CALLBACKS)
                     if (sigCtx->pkCbRsa) {
@@ -16089,8 +16091,8 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
                         ret = wc_RsaSSL_VerifyInline(sigCtx->sigCpy, sigSz,
                                                  &sigCtx->out, sigCtx->key.rsa);
                     }
-                    break;
                 }
+                break;
             #endif /* !NO_RSA */
             #if !defined(NO_DSA) && !defined(HAVE_SELFTEST)
                 case DSAk:
@@ -16208,8 +16210,10 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
         {
             switch (keyOID) {
             #ifndef NO_RSA
+                case RSAk:
                 #ifdef WC_RSA_PSS
                 case RSAPSSk:
+                if (sigOID == RSAPSSk) {
                 #if (defined(HAVE_SELFTEST) && \
                      (!defined(HAVE_SELFTEST_VERSION) || \
                       (HAVE_SELFTEST_VERSION < 2))) || \
@@ -16232,8 +16236,9 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
                         sigCtx->heap);
                 #endif
                     break;
+                }
+                else
                 #endif
-                case RSAk:
                 {
                     int encodedSigSz, verifySz;
                 #if defined(WOLFSSL_RENESAS_TSIP_TLS) || \


### PR DESCRIPTION
# Description

RSAk CA signing a RSAk pub key cert with RSA-PSS signature.


```
$ ./examples/server/server -c ./certs/rsapss/server-mix-rsapss-cert.pem -k ./certs/server-key.pem -A ./certs/rsapss/client-rsapss.pem -V

$ ./examples/client/client -A ./certs/ca-cert.pem -C -c ./certs/rsapss/client-rsapss.pem -k ./certs/rsapss/client-rsapss-priv.pem
```
