### PR TITLE
Fix for incorrect DN NID and confusion with DC

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -11962,8 +11962,8 @@ static int get_dn_attr_by_nid(int n, const char** buf)
             str = "initials";
             len = 8;
             break;
-        case NID_distinguishedName:
-            str = "DN";
+        case NID_domainComponent:
+            str = "DC";
             len = 2;
             break;
         default:

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -798,7 +798,6 @@ enum
     NID_inhibit_any_policy = 168,      /* 2.5.29.54 */
     NID_tlsfeature = 1020,             /* id-pe 24 */
     NID_buildingName = 1494,
-    NID_distinguishedName = 25,
 
     NID_dnQualifier = 174,             /* 2.5.4.46 */
     NID_commonName = 14,               /* CN Changed to not conflict


### PR DESCRIPTION
# Description
X509_NAME_print_ex was printing `DN` instead of the correct `DC`. Botched the print line in 
https://github.com/wolfSSL/wolfssl/commit/2df1c2526320494ee5f4022a32026d068dc2f8fd

Fixes zd14833

# Testing

Using test case customer provided.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
