### PR TITLE
Fix undesirable kyber dependencies when not building kyber (#2)

### DIFF
--- a/wolfcrypt/src/wc_kyber.c
+++ b/wolfcrypt/src/wc_kyber.c
@@ -1,3 +1,26 @@
+/* wc_kyber.c
+ *
+ * Copyright (C) 2006-2022 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
 
-#error "Contact wolfSSL to get the implementation of this file"
+#include <wolfssl/wolfcrypt/settings.h>
 
+#ifdef WOLFSSL_HAVE_KYBER
+    #error "Contact wolfSSL to get the implementation of this file"
+#endif

--- a/wolfcrypt/src/wc_kyber_asm.S
+++ b/wolfcrypt/src/wc_kyber_asm.S
@@ -1,3 +1,27 @@
+/* wc_kyber_asm.S
+ *
+ * Copyright (C) 2006-2022 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
 
-#error "Contact wolfSSL to get the implementation of this file"
+#include <wolfssl/wolfcrypt/settings.h>
+
+#ifdef WOLFSSL_HAVE_KYBER
+    #error "Contact wolfSSL to get the implementation of this file"
+#endif
 

--- a/wolfcrypt/src/wc_kyber_poly.c
+++ b/wolfcrypt/src/wc_kyber_poly.c
@@ -1,3 +1,26 @@
+/* wc_kyber_poly.c
+ *
+ * Copyright (C) 2006-2022 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
 
-#error "Contact wolfSSL to get the implementation of this file"
+#include <wolfssl/wolfcrypt/settings.h>
 
+#ifdef WOLFSSL_HAVE_KYBER
+    #error "Contact wolfSSL to get the implementation of this file"
+#endif


### PR DESCRIPTION
Some IDE setups just pull in all source files in a given directory, only force errors when customers are trying to configure the kyber feature.
Add licensing even though these are just stubs.