### PR TITLE
Fix for sniffer to decode out of order packets

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -5753,7 +5753,11 @@ static int CheckSequence(IpInfo* ipInfo, TcpInfo* tcpInfo,
                 *ackFault = 1;
                 UpdateMissedDataSessions();
             }
-            return FixSequence(tcpInfo, session);
+            if (FixSequence(tcpInfo, session) != 1)
+                return -1;
+            else
+                return CheckSequence(ipInfo, tcpInfo, session, sslBytes,
+                                     sslFrame, error);
         }
     }
 


### PR DESCRIPTION
# Description

Fix the sequence, then check it again when an `ACK_MISSED_STR` is encountered.
Fixes zd14846

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
