### PR TITLE
Fixes for various build configurations

### DIFF
--- a/IDE/Android/user_settings.h
+++ b/IDE/Android/user_settings.h
@@ -11,7 +11,7 @@
 #ifdef __aarch64__
     #if !defined(__clang__) || \
         (defined(__clang__) && defined(__clang_major__) && __clang_major__ >= 5)
-        /* older clang v4 has issue with inline assembly contraints */
+        /* older clang v4 has issue with inline assembly constraints */
         #define WOLFSSL_ARMASM
     #endif
 #endif
@@ -58,7 +58,7 @@
 #define HAVE_PK_CALLBACKS
 /* crypto callback support is not in FIPS 3389 */
 #ifndef HAVE_FIPS
-    #define WOLF_CRYPTO_CB 
+    #define WOLF_CRYPTO_CB
 #endif
 
 #define KEEP_OUR_CERT

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/main/helper.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/main/helper.c
@@ -33,6 +33,7 @@
 
 /* proto-type */
 extern void wolf_benchmark_task();
+extern void wolf_crypt_task();
 static const char* const TAG = "wolfbenchmark";
 char* __argv[22];
 
@@ -152,7 +153,6 @@ int construct_argv()
 void app_main(void)
 {
     (void) TAG;
-#ifndef NO_CRYPT_BENCHMARK
 
 /* when using atecc608a on esp32-wroom-32se */
 #if defined(WOLFSSL_ESPWROOM32SE) && defined(HAVE_PK_CALLBACKS) \
@@ -167,7 +167,11 @@ void app_main(void)
     atmel_set_slot_allocator(my_atmel_alloc, my_atmel_free);
     #endif
 #endif
+
+#ifndef NO_CRYPT_TEST
+    wolf_crypt_task();
+#endif
+#ifndef NO_CRYPT_BENCHMARK
     wolf_benchmark_task();
-#else
-#endif /* NO_CRYPT_BENCHMARK */
+#endif
 }

--- a/src/x509.c
+++ b/src/x509.c
@@ -6013,7 +6013,7 @@ static int X509PrintPubKey(WOLFSSL_BIO* bio, WOLFSSL_X509* x509, int indent)
     switch (x509->pubKeyOID) {
     #ifndef NO_RSA
         case RSAk:
-            len = XSNPRINTF(scratch, MAX_WIDTH, 
+            len = XSNPRINTF(scratch, MAX_WIDTH,
                     "%*sPublic Key Algorithm: rsaEncryption\n", indent + 4, "");
             if (len >= MAX_WIDTH)
                 return WOLFSSL_FAILURE;
@@ -6023,7 +6023,7 @@ static int X509PrintPubKey(WOLFSSL_BIO* bio, WOLFSSL_X509* x509, int indent)
     #endif
     #ifdef HAVE_ECC
         case ECDSAk:
-            len = XSNPRINTF(scratch, MAX_WIDTH, 
+            len = XSNPRINTF(scratch, MAX_WIDTH,
                     "%*sPublic Key Algorithm: EC\n", indent + 4, "");
             if (len >= MAX_WIDTH)
                 return WOLFSSL_FAILURE;
@@ -6031,11 +6031,11 @@ static int X509PrintPubKey(WOLFSSL_BIO* bio, WOLFSSL_X509* x509, int indent)
                 return WOLFSSL_FAILURE;
             break;
     #endif
-    	default:
+        default:
                 WOLFSSL_MSG("Unknown key type");
                 return WOLFSSL_FAILURE;
     }
-    
+
     pubKey = wolfSSL_X509_get_pubkey(x509);
     if (pubKey == NULL)
         return WOLFSSL_FAILURE;

--- a/tests/api.c
+++ b/tests/api.c
@@ -690,7 +690,7 @@ static int test_wolfSSL_CTX_new(void)
 #endif
 
 #if (!defined(NO_WOLFSSL_CLIENT) || !defined(NO_WOLFSSL_SERVER)) && \
-(!defined(NO_RSA) || defined(HAVE_ECC))
+    (!defined(NO_RSA) || defined(HAVE_ECC)) && !defined(NO_FILESYSTEM)
 static int test_for_double_Free(void)
 {
     WOLFSSL_CTX* ctx;
@@ -31245,7 +31245,7 @@ static int test_wolfSSL_DES(void)
 
 static int test_wc_PemToDer(void)
 {
-#if !defined(NO_CERTS) && defined(WOLFSSL_PEM_TO_DER)
+#if !defined(NO_CERTS) && defined(WOLFSSL_PEM_TO_DER) && !defined(NO_FILESYSTEM)
     int ret;
     DerBuffer* pDer = NULL;
     const char* ca_cert = "./certs/server-cert.pem";
@@ -31318,7 +31318,7 @@ static int test_wc_AllocDer(void)
 
 static int test_wc_CertPemToDer(void)
 {
-#if !defined(NO_CERTS) && defined(WOLFSSL_PEM_TO_DER)
+#if !defined(NO_CERTS) && defined(WOLFSSL_PEM_TO_DER) && !defined(NO_FILESYSTEM)
     int ret;
     const char* ca_cert = "./certs/ca-cert.pem";
     byte* cert_buf = NULL;
@@ -50283,7 +50283,7 @@ static int test_wolfSSL_SMIME_write_PKCS7(void)
  | Certificate Failure Checks
  *----------------------------------------------------------------------------*/
 #if !defined(NO_CERTS) && (!defined(NO_WOLFSSL_CLIENT) || \
-                           !defined(WOLFSSL_NO_CLIENT_AUTH))
+                    !defined(WOLFSSL_NO_CLIENT_AUTH)) && !defined(NO_FILESYSTEM)
     /* Use the Cert Manager(CM) API to generate the error ASN_SIG_CONFIRM_E */
     static int verify_sig_cm(const char* ca, byte* cert_buf, size_t cert_sz,
         int type)
@@ -50335,6 +50335,7 @@ static int test_wolfSSL_SMIME_write_PKCS7(void)
         return ret;
     }
 
+ #if !defined(NO_FILESYSTEM)
     static int test_RsaSigFailure_cm(void)
     {
         int ret = 0;
@@ -50406,6 +50407,7 @@ static int test_wolfSSL_SMIME_write_PKCS7(void)
         return ret;
     }
 
+#endif /* !NO_FILESYSTEM */
 #endif /* NO_CERTS */
 
 #ifdef WOLFSSL_TLS13
@@ -58590,7 +58592,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_CTX_new),
 #endif
 #if (!defined(NO_WOLFSSL_CLIENT) || !defined(NO_WOLFSSL_SERVER)) && \
-(!defined(NO_RSA) || defined(HAVE_ECC))
+    (!defined(NO_RSA) || defined(HAVE_ECC)) && !defined(NO_FILESYSTEM)
     TEST_DECL(test_for_double_Free),
 #endif
 #ifdef HAVE_IO_TESTS_DEPENDENCIES
@@ -59122,7 +59124,7 @@ TEST_CASE testCases[] = {
 #endif
 
 #if !defined(NO_CERTS) && (!defined(NO_WOLFSSL_CLIENT) || \
-                           !defined(WOLFSSL_NO_CLIENT_AUTH))
+    !defined(WOLFSSL_NO_CLIENT_AUTH)) && !defined(NO_FILESYSTEM)
     /* Use the Cert Manager(CM) API to generate the error ASN_SIG_CONFIRM_E */
     /* Bad certificate signature tests */
     TEST_DECL(test_EccSigFailure_cm),

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -632,13 +632,13 @@ static const bench_alg bench_digest_opt[] = {
     #ifndef WOLFSSL_NOSHA3_512
     { "-sha3-512",           BENCH_SHA3_512          },
     #endif
-    #if !defined(WOLFSSL_NO_SHAKE128) || !defined(WOLFSSL_NO_SHAKE256)
+    #if defined(WOLFSSL_SHAKE128) || defined(WOLFSSL_SHAKE256)
     { "-shake",              BENCH_SHAKE             },
     #endif
-    #ifndef WOLFSSL_NO_SHAKE128
+    #ifdef WOLFSSL_SHAKE128
     { "-shake128",           BENCH_SHAKE128          },
     #endif
-    #ifndef WOLFSSL_NO_SHAKE256
+    #ifdef WOLFSSL_SHAKE256
     { "-shake256",           BENCH_SHAKE256          },
     #endif
 #endif
@@ -2096,7 +2096,7 @@ static void* benchmarks_do(void* args)
     #endif
     }
     #endif /* WOLFSSL_NOSHA3_512 */
-    #ifndef WOLFSSL_NO_SHAKE128
+    #ifdef WOLFSSL_SHAKE128
     if (bench_all || (bench_digest_algs & BENCH_SHAKE128)) {
     #ifndef NO_SW_BENCH
         bench_shake128(0);
@@ -2106,8 +2106,8 @@ static void* benchmarks_do(void* args)
         bench_shake128(1);
     #endif
     }
-    #endif /* WOLFSSL_NO_SHAKE128 */
-    #ifndef WOLFSSL_NO_SHAKE256
+    #endif /* WOLFSSL_SHAKE128 */
+    #ifdef WOLFSSL_SHAKE256
     if (bench_all || (bench_digest_algs & BENCH_SHAKE256)) {
     #ifndef NO_SW_BENCH
         bench_shake256(0);
@@ -2117,7 +2117,7 @@ static void* benchmarks_do(void* args)
         bench_shake256(1);
     #endif
     }
-    #endif /* WOLFSSL_NO_SHAKE256 */
+    #endif /* WOLFSSL_SHAKE256 */
 #endif
 #ifdef WOLFSSL_RIPEMD
     if (bench_all || (bench_digest_algs & BENCH_RIPEMD))
@@ -4802,7 +4802,7 @@ exit:
 }
 #endif /* WOLFSSL_NO_SHAKE128 */
 
-#ifndef WOLFSSL_NO_SHAKE256
+#ifdef WOLFSSL_SHAKE256
 void bench_shake256(int useDeviceID)
 {
     wc_Shake hash[BENCH_MAX_PENDING];
@@ -4889,7 +4889,7 @@ exit:
 
     WC_FREE_ARRAY(digest, BENCH_MAX_PENDING, HEAP_HINT);
 }
-#endif /* WOLFSSL_NO_SHAKE256 */
+#endif /* WOLFSSL_SHAKE256 */
 #endif
 
 

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -8374,7 +8374,7 @@ static int string_matches(const char* arg, const char* str)
 #endif /* MAIN_NO_ARGS */
 
 #if defined(WOLFSSL_ESPIDF) || defined(_WIN32_WCE)
-int wolf_benchmark_task( )
+int wolf_benchmark_task(void)
 #elif defined(MAIN_NO_ARGS)
 int main()
 #else

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -12450,8 +12450,8 @@ static int GenerateDNSEntryIPString(DNS_entry* entry, void* heap)
 #endif /* OPENSSL_ALL || WOLFSSL_IP_ALT_NAME */
 
 #ifdef WOLFSSL_ASN_TEMPLATE
-#if defined(WOLFSSL_CERT_GEN) || \
-    (!defined(NO_CERTS) && !defined(IGNORE_NAME_CONSTRAINTS))
+
+#if defined(WOLFSSL_CERT_GEN) || !defined(NO_CERTS)
 
 /* Adds a DNS entry to a list of DNS entries
  *

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -9499,6 +9499,9 @@ int wc_RsaPublicKeyDecode(const byte* input, word32* inOutIdx, RsaKey* key,
                (int)(rsaPublicKeyASN_Length - RSAPUBLICKEYASN_IDX_PUBKEY_RSA_SEQ),
                0, input, inOutIdx, inSz);
         if (ret != 0) {
+            mp_free(&key->n);
+            mp_free(&key->e);
+
             /* Didn't work - try whole SubjectKeyInfo instead. */
             /* Set the OID to expect. */
             GetASN_ExpBuffer(&dataASN[RSAPUBLICKEYASN_IDX_ALGOID_OID],
@@ -9849,6 +9852,9 @@ int wc_DhKeyDecode(const byte* input, word32* inOutIdx, DhKey* key, word32 inSz)
                            inOutIdx, inSz);
 #ifdef WOLFSSL_DH_EXTRA
         if (ret != 0) {
+            mp_free(&key->p);
+            mp_free(&key->g);
+
             /* Initialize data and set mp_ints to hold p, g, q, priv and pub. */
             XMEMSET(dataASN, 0, sizeof(*dataASN) * dhKeyPkcs8ASN_Length);
             GetASN_ExpBuffer(&dataASN[DHKEYPKCS8ASN_IDX_PKEYALGO_OID],

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -401,7 +401,7 @@ static word32 SizeASNLength(word32 length)
     #define DECL_ASNGETDATA(name, cnt)                  \
         ASNGetData name[cnt]
 
-    /* No implementation as declartion is static.
+    /* No implementation as declaration is static.
      *
      * @param [in]      name  Variable name to declare.
      * @param [in]      cnt   Number of elements required.
@@ -420,7 +420,7 @@ static word32 SizeASNLength(word32 length)
     #define CALLOC_ASNGETDATA(name, cnt, err, heap)     \
         XMEMSET(name, 0, sizeof(name))
 
-    /* No implementation as declartion is static.
+    /* No implementation as declaration is static.
      *
      * @param [in]      name  Variable name to declare.
      * @param [in]      heap  Dynamic memory allocation hint.
@@ -435,7 +435,7 @@ static word32 SizeASNLength(word32 length)
     #define DECL_ASNSETDATA(name, cnt)                  \
         ASNSetData name[cnt]
 
-    /* No implementation as declartion is static.
+    /* No implementation as declaration is static.
      *
      * @param [in]      name  Variable name to declare.
      * @param [in]      cnt   Number of elements required.
@@ -454,7 +454,7 @@ static word32 SizeASNLength(word32 length)
     #define CALLOC_ASNSETDATA(name, cnt, err, heap)     \
         XMEMSET(name, 0, sizeof(name))
 
-    /* No implementation as declartion is static.
+    /* No implementation as declaration is static.
      *
      * @param [in]      name  Variable name to declare.
      * @param [in]      heap  Dynamic memory allocation hint.
@@ -2107,7 +2107,7 @@ int GetLength_ex(const byte* input, word32* inOutIdx, int* len, word32 maxIdx,
     /* Check if the first byte indicates the count of bytes. */
     if (b >= ASN_LONG_LENGTH) {
         /* Bottom 7 bits are the number of bytes to calculate length with.
-         * Note: 0 indicates indefinte length encoding *not* 0 bytes of length.
+         * Note: 0 indicates indefinite length encoding *not* 0 bytes of length.
          */
         word32 bytes = b & 0x7F;
         int minLen;
@@ -3680,7 +3680,7 @@ int wc_BerToDer(const byte* ber, word32 berSz, byte* der, word32* derSz)
 
                 /* Set the header length to include the length field */
                 IndefItems_UpdateHeaderLen(indefItems);
-                /* Go to indefinte parent item */
+                /* Go to indefinite parent item */
                 IndefItems_Up(indefItems);
             }
         }
@@ -3698,7 +3698,7 @@ int wc_BerToDer(const byte* ber, word32 berSz, byte* der, word32* derSz)
 
             /* Finish calculation of data length for indefinite item */
             IndefItems_CalcLength(indefItems);
-            /* Go to indefinte parent item */
+            /* Go to indefinite parent item */
             IndefItems_Up(indefItems);
         }
         else {
@@ -18746,7 +18746,7 @@ static int DecodeSubtreeGeneralName(const byte* input, int sz, byte tag,
 }
 #endif
 
-/* Decode a subtree of a name contraint in a certificate.
+/* Decode a subtree of a name constraints in a certificate.
  *
  * X.509: RFC 5280, 4.2.1.10 - Name Contraints.
  *

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -9245,7 +9245,7 @@ static int PrintPubKeyRSA(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
             nSz++;
         }
 
-        if (PrintHexWithColon(out, n, nSz, 
+        if (PrintHexWithColon(out, n, nSz,
                     indent + 4, 1/* lower case */) != WOLFSSL_SUCCESS) {
             break;
         }
@@ -9669,7 +9669,7 @@ static int PrintPubKeyDSA(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
         if (wolfSSL_BIO_write(out, line, (int)XSTRLEN(line)) <= 0) {
             break;
         }
-        if (PrintHexWithColon(out, y, ySz, indent + 4, 0/* upper case */) 
+        if (PrintHexWithColon(out, y, ySz, indent + 4, 0/* upper case */)
                                                         != WOLFSSL_SUCCESS) {
             break;
         }
@@ -9679,7 +9679,7 @@ static int PrintPubKeyDSA(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
         if (wolfSSL_BIO_write(out, line, (int)XSTRLEN(line)) <= 0) {
             break;
         }
-        if (PrintHexWithColon(out, p, pSz, indent + 4, 0/* upper case */) 
+        if (PrintHexWithColon(out, p, pSz, indent + 4, 0/* upper case */)
                                                         != WOLFSSL_SUCCESS) {
             break;
         }
@@ -9699,7 +9699,7 @@ static int PrintPubKeyDSA(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
         if (wolfSSL_BIO_write(out, line, (int)XSTRLEN(line)) <= 0) {
             break;
         }
-        if (PrintHexWithColon(out, g, gSz, indent + 4, 0/* upper case */) 
+        if (PrintHexWithColon(out, g, gSz, indent + 4, 0/* upper case */)
                                                         != WOLFSSL_SUCCESS) {
             break;
         }
@@ -9878,7 +9878,7 @@ static int PrintPubKeyDH(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
         if (wolfSSL_BIO_write(out, line, (int)XSTRLEN(line)) <= 0) {
             break;
         }
-        if (PrintHexWithColon(out, publicKey, 
+        if (PrintHexWithColon(out, publicKey,
                                 publicKeySz, indent + 4, 0/* upper case */)
                                                     != WOLFSSL_SUCCESS) {
             break;
@@ -9888,7 +9888,7 @@ static int PrintPubKeyDH(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
         if (wolfSSL_BIO_write(out, line, (int)XSTRLEN(line)) <= 0) {
             break;
         }
-        if (PrintHexWithColon(out, prime, primeSz, 
+        if (PrintHexWithColon(out, prime, primeSz,
                                             indent + 4, 0/* upper case */)
                 != WOLFSSL_SUCCESS) {
             break;

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -1989,10 +1989,10 @@ int wc_hash2mgf(enum wc_HashType hType)
     case WC_HASH_TYPE_SHA3_512:
     case WC_HASH_TYPE_BLAKE2B:
     case WC_HASH_TYPE_BLAKE2S:
-    #ifndef WOLFSSL_NO_SHAKE128
+    #ifdef WOLFSSL_SHAKE128
         case WC_HASH_TYPE_SHAKE128:
     #endif
-    #ifndef WOLFSSL_NO_SHAKE256
+    #ifdef WOLFSSL_SHAKE256
         case WC_HASH_TYPE_SHAKE256:
     #endif
     default:

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -3919,8 +3919,8 @@ int fp_set_int(fp_int *a, unsigned long b)
 #else
   fp_set (a, (fp_digit)b);
 #endif
-  
-  return FP_OKAY;  
+
+  return FP_OKAY;
 }
 
 /* check if a bit is set */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -1526,16 +1526,15 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 
 #ifndef NO_MAIN_DRIVER
 
-    /* so overall tests can pull in test function */
-#ifdef WOLFSSL_ESPIDF
-    void app_main( )
-#else
-
 #ifdef HAVE_WOLFCRYPT_TEST_OPTIONS
     int myoptind = 0;
     char* myoptarg = NULL;
 #endif
 
+    /* so overall tests can pull in test function */
+#if defined(WOLFSSL_ESPIDF) || defined(_WIN32_WCE)
+    int wolf_test_task(void)
+#else
     int main(int argc, char** argv)
 #endif
     {

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2806,6 +2806,23 @@ extern void uITRON4_free(void *p) ;
     #define WOLFSSL_RSA_KEY_CHECK
 #endif
 
+/* SHAKE - Not allowed in FIPS */
+#if defined(WOLFSSL_SHA3) && !defined(HAVE_SELFTEST) && !defined(HAVE_FIPS)
+    #ifndef WOLFSSL_NO_SHAKE128
+        #undef  WOLFSSL_SHAKE128
+        #define WOLFSSL_SHAKE128
+    #endif
+    #ifndef WOLFSSL_NO_SHAKE256
+        #undef  WOLFSSL_SHAKE256
+        #define WOLFSSL_SHAKE256
+    #endif
+#else
+    #undef  WOLFSSL_NO_SHAKE128
+    #define WOLFSSL_NO_SHAKE128
+    #undef  WOLFSSL_NO_SHAKE256
+    #define WOLFSSL_NO_SHAKE256
+#endif
+
 
 
 

--- a/wolfssl/wolfcrypt/sha3.h
+++ b/wolfssl/wolfcrypt/sha3.h
@@ -61,10 +61,10 @@ enum {
     WC_SHA3_512_DIGEST_SIZE  = 64,
     WC_SHA3_512_COUNT        =  9,
 
-    #ifndef WOLFSSL_NO_SHAKE128
+    #ifdef WOLFSSL_SHAKE128
         WC_SHAKE128          = WC_HASH_TYPE_SHAKE128,
     #endif
-    #ifndef WOLFSSL_NO_SHAKE256
+    #ifdef WOLFSSL_SHAKE256
         WC_SHAKE256          = WC_HASH_TYPE_SHAKE256,
     #endif
 
@@ -90,8 +90,10 @@ enum {
     #define SHA3_512             WC_SHA3_512
     #define SHA3_512_DIGEST_SIZE WC_SHA3_512_DIGEST_SIZE
     #define Sha3 wc_Sha3
-    #ifndef WOLFSSL_NO_SHAKE256
+    #ifdef WOLFSSL_SHAKE128
         #define SHAKE128             WC_SHAKE128
+    #endif
+    #ifdef WOLFSSL_SHAKE256
         #define SHAKE256             WC_SHAKE256
     #endif
 #endif
@@ -130,7 +132,7 @@ struct wc_Sha3 {
 
 #endif
 
-#if !defined(WOLFSSL_NO_SHAKE128) || !defined(WOLFSSL_NO_SHAKE256)
+#if defined(WOLFSSL_SHAKE128) || defined(WOLFSSL_SHAKE256)
 typedef wc_Sha3 wc_Shake;
 #endif
 
@@ -162,7 +164,7 @@ WOLFSSL_API void wc_Sha3_512_Free(wc_Sha3* sha3);
 WOLFSSL_API int wc_Sha3_512_GetHash(wc_Sha3* sha3, byte* hash);
 WOLFSSL_API int wc_Sha3_512_Copy(wc_Sha3* src, wc_Sha3* dst);
 
-#ifndef WOLFSSL_NO_SHAKE128
+#ifdef WOLFSSL_SHAKE128
 WOLFSSL_API int wc_InitShake128(wc_Shake* shake, void* heap, int devId);
 WOLFSSL_API int wc_Shake128_Update(wc_Shake* shake, const byte* data, word32 len);
 WOLFSSL_API int wc_Shake128_Final(wc_Shake* shake, byte* hash, word32 hashLen);
@@ -174,7 +176,7 @@ WOLFSSL_API void wc_Shake128_Free(wc_Shake* shake);
 WOLFSSL_API int wc_Shake128_Copy(wc_Shake* src, wc_Sha3* dst);
 #endif
 
-#ifndef WOLFSSL_NO_SHAKE256
+#ifdef WOLFSSL_SHAKE256
 WOLFSSL_API int wc_InitShake256(wc_Shake* shake, void* heap, int devId);
 WOLFSSL_API int wc_Shake256_Update(wc_Shake* shake, const byte* data, word32 len);
 WOLFSSL_API int wc_Shake256_Final(wc_Shake* shake, byte* hash, word32 hashLen);

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1011,9 +1011,6 @@ typedef struct w64wrapper {
         #ifndef WOLFSSL_NOSHA512_256
             #define WOLFSSL_NOSHA512_256
         #endif
-        #ifndef WOLFSSL_NO_SHAKE256
-            #define WOLFSSL_NO_SHAKE256
-        #endif
     #else
         WC_HASH_TYPE_NONE = 0,
         WC_HASH_TYPE_MD2 = 1,
@@ -1031,27 +1028,27 @@ typedef struct w64wrapper {
         WC_HASH_TYPE_SHA3_512 = 13,
         WC_HASH_TYPE_BLAKE2B = 14,
         WC_HASH_TYPE_BLAKE2S = 15,
-#define _WC_HASH_TYPE_MAX WC_HASH_TYPE_BLAKE2S
+        #define _WC_HASH_TYPE_MAX WC_HASH_TYPE_BLAKE2S
         #ifndef WOLFSSL_NOSHA512_224
             WC_HASH_TYPE_SHA512_224 = 16,
-#undef _WC_HASH_TYPE_MAX
-#define _WC_HASH_TYPE_MAX WC_HASH_TYPE_SHA512_224
+            #undef _WC_HASH_TYPE_MAX
+            #define _WC_HASH_TYPE_MAX WC_HASH_TYPE_SHA512_224
         #endif
         #ifndef WOLFSSL_NOSHA512_256
             WC_HASH_TYPE_SHA512_256 = 17,
-#undef _WC_HASH_TYPE_MAX
-#define _WC_HASH_TYPE_MAX WC_HASH_TYPE_SHA512_256
+            #undef _WC_HASH_TYPE_MAX
+            #define _WC_HASH_TYPE_MAX WC_HASH_TYPE_SHA512_256
         #endif
-        #ifndef WOLFSSL_NO_SHAKE128
+        #ifdef WOLFSSL_SHAKE128
             WC_HASH_TYPE_SHAKE128 = 18,
         #endif
-        #ifndef WOLFSSL_NO_SHAKE256
+        #ifdef WOLFSSL_SHAKE256
             WC_HASH_TYPE_SHAKE256 = 19,
-#undef _WC_HASH_TYPE_MAX
-#define _WC_HASH_TYPE_MAX WC_HASH_TYPE_SHAKE256
+            #undef _WC_HASH_TYPE_MAX
+            #define _WC_HASH_TYPE_MAX WC_HASH_TYPE_SHAKE256
         #endif
         WC_HASH_TYPE_MAX = _WC_HASH_TYPE_MAX
-#undef _WC_HASH_TYPE_MAX
+        #undef _WC_HASH_TYPE_MAX
 
     #endif /* HAVE_SELFTEST */
     };


### PR DESCRIPTION
# Description

* Fix for possible memory leak on failure in RSA/DH public key decode with heap based math.
* Fixes for building without SHAKE.
* Fixes for building the API unit test without filesystem `NO_FILESYSTEM`.
* Fix for building with `WOLFSSL_ASN_TEMPLATE` and `IGNORE_NAME_CONSTRAINTS`.
 ```
wolfcrypt/src/asn.c:16984:15: error: implicit declaration of function 'SetDNSEntry' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        ret = SetDNSEntry(cert, (const char*)(input + idx), len, ASN_DNS_TYPE,
              ^
```

* Fix for ESP32 wolfcrypt_test entry point.
* Spelling and whitespace cleanups.


# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
