### PR TITLE
Support for DEOS RTEMS and minor build fixes

### DIFF
--- a/IDE/ECLIPSE/DEOS/tls_wolfssl.c
+++ b/IDE/ECLIPSE/DEOS/tls_wolfssl.c
@@ -31,19 +31,19 @@ int setupTransport(clientConnectionHandleType* connectionHandle,
                    char* connectionId) {
     int ret, error;
     void * sendBuffer;
-    DWORD bufferSizeInBytes;
+    size_t bufferSizeInBytes;
 
     if ((ret = socketTransportInitialize("mailbox-transport.config",
                                          "transportConfigurationId",
-                                         (DWORD)waitIndefinitely,&error)) != transportSuccess)
+                                         waitIndefinitely,&error)) != transportSuccess)
         printf("Initialize 0x%x, error=%d\n", ret, error);
 
-    else if ((ret = socketTransportClientInitialize((DWORD)waitIndefinitely,
+    else if ((ret = socketTransportClientInitialize(waitIndefinitely,
                                                     &error)) != transportSuccess)
         printf("ClientInitialize 0x%x, error=%d\n", ret, error);
 
     else if ((ret = socketTransportCreateConnection(connectionId,
-                                                    (DWORD)waitIndefinitely,
+                                                    waitIndefinitely,
                                                     COMPATIBILITY_ID_2,
                                                     connectionHandle,
                                                     &sendBuffer,
@@ -53,7 +53,7 @@ int setupTransport(clientConnectionHandleType* connectionHandle,
 
     else if ((ret = socketTransportSetConnectionForThread(currentThreadHandle(),
                                                           *connectionHandle,
-                                                          (DWORD)waitIndefinitely,
+                                                          waitIndefinitely,
                                                           &error)) != transportSuccess)
         printf("SetConnectionForThread 0x%x, error=%d\n", ret, error);
 
@@ -162,7 +162,7 @@ void wolfssl_client_test(uintData_t statusPtr) {
                     TCP_SERVER_IP_ADDR, TCP_SERVER_PORT);
 
     server_addr.sin_family = AF_INET;
-    server_addr.sin_addr = inet_addr(TCP_SERVER_IP_ADDR);
+    server_addr.sin_addr.s_addr = inet_addr(TCP_SERVER_IP_ADDR);
     server_addr.sin_port = htons(TCP_SERVER_PORT);
 
     printf("Calling connect on socket\n");
@@ -407,7 +407,7 @@ void wolfssl_server_test(uintData_t statusPtr)
 
     printf("Setting up server_addr struct\n");
     server_addr.sin_family = AF_INET;
-    server_addr.sin_addr = INADDR_ANY;
+    server_addr.sin_addr.s_addr = INADDR_ANY;
     server_addr.sin_port = htons(TLS_SERVER_PORT);
 
     bindStatus = bind(sock_listen, (sockaddr *) &server_addr, sizeof(server_addr));
@@ -510,7 +510,7 @@ void wolfssl_server_test(uintData_t statusPtr)
                 wolfSSL_CTX_free(ctx);
                 return;
             }
-            /* goToSleep() for 500 milli sec*/
+            /* goToSleep() for 500 milliseconds */
         }
     } while ((ret != SSL_SUCCESS) && (error == SSL_ERROR_WANT_READ));
 
@@ -580,14 +580,14 @@ int  wolfsslRunTests (void)
         ts = createThread("TCPclient", "TCPThreadTemplate", wolfssl_client_test,
                           0, &TCPhandle );
         if (ts != threadSuccess) {
-            printf("Unable to create TCP client thread, %i ", (DWORD)ts);
+            printf("Unable to create TCP client thread, %i ", (size_t)ts);
         }
     #endif
     #if !defined(NO_WOLFSSL_SERVER)
         ts = createThread("TCPserver", "TCPThreadTemplate", wolfssl_server_test,
                           0, &TCPhandle );
         if (ts != threadSuccess) {
-            printf("Unable to create TCP server thread, %i ", (DWORD)ts);
+            printf("Unable to create TCP server thread, %i ", (size_t)ts);
         }
     #endif
 

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -2445,7 +2445,7 @@ time_t pic32_time(time_t* timer)
 
 #endif /* MICROCHIP_TCPIP || MICROCHIP_TCPIP_V5 */
 
-#if defined(WOLFSSL_DEOS)
+#if defined(WOLFSSL_DEOS) || defined(WOLFSSL_DEOS_RTEMS)
 
 time_t deos_time(time_t* timer)
 {
@@ -2462,7 +2462,7 @@ time_t deos_time(time_t* timer)
         return (time_t) *systemTickPtr/systemTickTimeInHz;
     #endif
 }
-#endif /* WOLFSSL_DEOS */
+#endif /* WOLFSSL_DEOS || WOLFSSL_DEOS_RTEMS */
 
 #if defined(FREESCALE_RTC)
 #include "fsl_rtc.h"

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1935,7 +1935,16 @@ extern void uITRON4_free(void *p) ;
 /* user can specify what curves they want with ECC_USER_CURVES otherwise
  * all curves are on by default for now */
 #ifndef ECC_USER_CURVES
-    #if !defined(WOLFSSL_SP_MATH) && !defined(HAVE_ALL_CURVES)
+    #ifdef WOLFSSL_SP_MATH
+        /* for single precision math only make sure the enabled key sizes are
+         * included in the ECC curve table */
+        #if defined(WOLFSSL_SP_384) && !defined(HAVE_ECC384)
+            #define HAVE_ECC384
+        #endif
+        #if defined(WOLFSSL_SP_521) && !defined(HAVE_ECC521)
+            #define HAVE_ECC521
+        #endif
+    #elif !defined(HAVE_ALL_CURVES)
         #define HAVE_ALL_CURVES
     #endif
 #endif

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -788,7 +788,7 @@ typedef struct w64wrapper {
 
         #if defined(WOLFSSL_CERT_EXT) || defined(HAVE_OCSP) || \
             defined(HAVE_CRL_IO) || defined(HAVE_HTTP_CLIENT) || \
-            !defined(NO_CRYPT_BENCHMARK)
+            !defined(NO_CRYPT_BENCHMARK) || defined(OPENSSL_EXTRA)
 
             #ifndef XATOI /* if custom XATOI is not already defined */
                 #include <stdlib.h>

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -764,9 +764,12 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XTIME(tl)       (0)
     #define XGMTIME(c, t)   rtpsys_gmtime((c))
 
-#elif defined(WOLFSSL_DEOS)
+#elif defined(WOLFSSL_DEOS) || defined(WOLFSSL_DEOS_RTEMS)
     #include <time.h>
-
+	#ifndef XTIME
+		extern time_t deos_time(time_t* timer);
+		#define XTIME(t1) deos_time((t1))
+	#endif
 #elif defined(MICRIUM)
     #include <clk.h>
     #include <time.h>


### PR DESCRIPTION
# Description

* Support for RTEMS in the DEOS user_settings.h template and time.
* Fix for `bio.c` and `OPENSSL_EXTRA` which needs `XATOI`
* Fix for SP math ECC with 384-bit and 521-bit curves enabled.

# Testing

With the template user_settings.h in OpenArbor.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
