### PR TITLE
20220926-fixes

### DIFF
--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -190,8 +190,8 @@ WC_STATIC WC_INLINE void ByteReverseWords(word32* out, const word32* in,
     word32 count, i;
 
 #ifdef WOLFSSL_USE_ALIGN
-    if ((((unsigned long)in & 0x3) == 0) &&
-        (((unsigned long)out & 0x3) == 0))
+    if ((((size_t)in & 0x3) == 0) &&
+        (((size_t)out & 0x3) == 0))
     {
 #endif
         count = byteCount/(word32)sizeof(word32);

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -766,10 +766,10 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
 
 #elif defined(WOLFSSL_DEOS) || defined(WOLFSSL_DEOS_RTEMS)
     #include <time.h>
-	#ifndef XTIME
-		extern time_t deos_time(time_t* timer);
-		#define XTIME(t1) deos_time((t1))
-	#endif
+        #ifndef XTIME
+            extern time_t deos_time(time_t* timer);
+            #define XTIME(t1) deos_time((t1))
+        #endif
 #elif defined(MICRIUM)
     #include <clk.h>
     #include <time.h>


### PR DESCRIPTION
fix for
```
[cross-armv7a-all-armasm-testwolfcrypt-sanitizer] [105 of 131] [b4077d80c9]
    configure...   real 0m9.156s  user 0m5.509s  sys 0m4.413s
    build...   real 2m35.580s  user 8m33.410s  sys 0m18.683s
    testwolfcrypt...   real 8m44.082s  user 8m43.203s  sys 0m0.234s
5107c6c12b (<jacob@wolfssl.com> 2014-12-19 15:30:07 -0700 193)         out[i] = ByteReverseWord32(in[i]);
wolfcrypt/src/misc.c:193:16: runtime error: store to misaligned address 0x3fffd81f for type 'word32', which requires 4 byte alignment
    cross-armv7a-all-armasm-testwolfcrypt-sanitizer fail_analytic_check
```

plus some whitespace fixes.

tested with `wolfssl-multi-test.sh ... cross-armv7a-all-armasm-testwolfcrypt-sanitizer super-quick-check`
