### PR TITLE
Add Support for critical extension check following RFC 5280 4.2.2.1 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -57,6 +57,8 @@ Release 5.5.0 of wolfSSL embedded TLS has bug fixes and new features including:
 * SP int: exptmod ensure base is less than modulus
 * Fix for AddPacketInfo with WOLFSSL_CALLBACKS to not pass encrypted TLS 1.3 handshake messages to callbacks
 * Fix for sniffer to ensure the session was polled before trying to reprocess it
+* Adds checking for critical extension with certificate Authority Information Access and the macro WOLFSSL_ALLOW_CRIT_AIA to override the check
+
 
 # wolfSSL Release 5.4.0 (July 11, 2022)
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -18417,7 +18417,7 @@ enum {
 
 /* Decode key usage extension in a certificate.
  *
- * X.509: RFC 5280, 4.2.1.3 - Subject Key Identifier.
+ * X.509: RFC 5280, 4.2.1.3 - Key Usage.
  *
  * @param [in]      input  Buffer holding data.
  * @param [in]      sz     Size of data in buffer.


### PR DESCRIPTION
# Description

Problem:
- RFC 5280 4.2.2.1 Says Conforming CAs MUST mark Authority Information Access Extension as non-critical.
- Description of function DecodeAuthKeyId had wrong section (RFC 5280 4.2.2.1 - AuthInfo)
- Description of function DecodeSubjKeyId had wrong section (RFC 5280 4.2.2.1 - AuthInfo)
- Description of function DecodeKeyUsage had wrong section (RFC 5280 4.2.2.1 - AuthInfo)

Fix:
- added Critical check of Authority Information Access Extension in function DecodeExtensionType
- fixed Description of function DecodeAuthKeyId to RFC 5280 4.2.1.1 - Authority Key Identifier
- fixed Description of function DecodeSubjKeyId to RFC 5280 4.2.1.2 - Subject Key Identifier
- fixed Description of function DecodeKeyUsage to RFC 5280 4.2.1.3 - Key Usage
- added AuthInfo fix to Changelog

Fixes #5635 

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
