### PR TITLE
WOLFSSL_ALLOW_CRIT_AKID for Authority Key Identifier.

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -19146,7 +19146,7 @@ exit:
                     return ASN_PARSE_E;
                 }
             #ifndef WOLFSSL_DUP_CERTPOL
-                /* From RFC 5280 section 4.2.1.3 "A certificate policy OID MUST
+                /* From RFC 5280 section 4.2.1.4 "A certificate policy OID MUST
                  * NOT appear more than once in a certificate policies
                  * extension". This is a sanity check for duplicates.
                  * extCertPolicies should only have OID values, additional
@@ -19254,7 +19254,7 @@ exit:
                 }
             }
             #ifndef WOLFSSL_DUP_CERTPOL
-            /* From RFC 5280 section 4.2.1.3 "A certificate policy OID MUST
+            /* From RFC 5280 section 4.2.1.4 "A certificate policy OID MUST
              * NOT appear more than once in a certificate policies
              * extension". This is a sanity check for duplicates.
              * extCertPolicies should only have OID values, additional

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -19596,14 +19596,14 @@ static int DecodeExtensionType(const byte* input, int length, word32 oid,
         case AUTH_KEY_OID:
             VERIFY_AND_SET_OID(cert->extAuthKeyIdSet);
             cert->extAuthKeyIdCrit = critical;
-            #ifndef WOLFSSL_ALLOW_CRIT_SKID
+            #ifndef WOLFSSL_ALLOW_CRIT_AKID
                 /* This check is added due to RFC 5280 section 4.2.1.1
                  * stating that conforming CA's must mark this extension
                  * as non-critical. When parsing extensions check that
                  * certificate was made in compliance with this. */
                 if (critical) {
                     WOLFSSL_MSG("Critical Auth Key ID is not allowed");
-                    WOLFSSL_MSG("Use macro WOLFSSL_ALLOW_CRIT_SKID if wanted");
+                    WOLFSSL_MSG("Use macro WOLFSSL_ALLOW_CRIT_AKID if wanted");
                     ret = ASN_CRIT_EXT_E;
                 }
             #endif


### PR DESCRIPTION
# Description

WolfSSL checks the Authority Key Identifier or Subject Key Identifier is non-critical according to 4.2.1.1 and 4.2.1.2 of RFC5280. 
If you want to ignore the critical check logic for Subject Key Identifier, you can define WOLFSSL_ALLOW_CRIT_SKID.
However, the critical check logic for the Authority Key Identifier is also ignored as WOLFSSL_ALLOW_CRIT_SKID.

So I changed WOLFSSL_ALLOW_CRIT_SKID to WOLFSSL_ALLOW_CRIT_AKID for Authority Key Identifier.

Fixes:
* add WOLFSSL_ALLOW_CRIT_AKID
* Fix wrong section number for Certificate Policy

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
