### PR TITLE
Add Irq install for Aruix example

### DIFF
--- a/IDE/AURIX/Cpu0_Main.c
+++ b/IDE/AURIX/Cpu0_Main.c
@@ -81,6 +81,8 @@ static void init_UART(void)
 {
     IfxAsclin_Asc_Config ascConfig;
 
+    IfxCpu_Irq_installInterruptHandler(asclin0_Tx_ISR, INTPRIO_ASCLIN0_TX);
+
     /* Port pins configuration */
     const IfxAsclin_Asc_Pins pins = {
         NULL_PTR,         IfxPort_InputMode_pullUp,     /* CTS pin not used   */


### PR DESCRIPTION
# Description

This fixes UART interrupts not being called on the Tricore example.

# Testing

Local testing with miniwiggler.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
