### PR TITLE
Do not perform IV Wrap test when using cert3389 inlined armasm

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -9719,9 +9719,11 @@ static int aesctr_test(Aes* enc, Aes* dec, byte* cipher, byte* plain)
         if (XMEMCMP(plain, ctrPlain, testVec[i].len)) {
             ERROR_OUT(-5934 - i * 10, out);
         }
+#if !(FIPS_VERSION_EQ(2,0) && defined(WOLFSSL_ARMASM))
         if (XMEMCMP(cipher, testVec[i].cipher, testVec[i].len)) {
             ERROR_OUT(-5935 - i * 10, out);
         }
+#endif
     }
 
 out:


### PR DESCRIPTION
# Description

Disabled the IV wrap test when using the armasm inlined in the FIPS module (test will be relevant for future armasm code once the latest has been through FIPS certification)

Testing done an an M1 macOS
