### PR TITLE
Generate an assembler-safe user_settings.h in configure.ac and CMakeLists.txt.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -401,3 +401,6 @@ XXX-fips-test
 
 # ASYNC
 async
+
+# Generated user_settings_asm.h.
+user_settings_asm.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1768,6 +1768,14 @@ generate_build_flags()
 if(WOLFSSL_USER_SETTINGS)
     # Replace all options and just use WOLFSSL_USER_SETTINGS
     set(WOLFSSL_DEFINITIONS "-DWOLFSSL_USER_SETTINGS")
+
+    # Create user_settings_asm.h for use in assembly files (e.g. .S files).
+    execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/user_settings_asm.sh
+                            "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS}"
+                    RESULT_VARIABLE USER_SETTINGS_ASM_RET)
+    if (NOT USER_SETTINGS_ASM_RET EQUAL 0)
+        message(FATAL_ERROR "${CMAKE_CURRENT_SOURCE_DIR}/scripts/user_settings_asm.sh failed.")
+    endif()
 endif()
 
 # TODO: Applying definitions to everything like this, rather than
@@ -1790,7 +1798,6 @@ endif()
 
 # Suppress some warnings about separate compilation, inlining
 add_definitions("-DWOLFSSL_IGNORE_FILE_WARN")
-
 # Generate user options header
 message("Generating user options header...")
 if (${CMAKE_DISABLE_SOURCE_CHANGES})

--- a/configure.ac
+++ b/configure.ac
@@ -8393,6 +8393,13 @@ esac
 
 rm cyassl/options.h.bak
 
+if test "x$ENABLED_USERSETTINGS" = "xyes"; then
+    $srcdir/scripts/user_settings_asm.sh "$CPPFLAGS $CFLAGS $CXXFLAGS"
+    if test $? -ne 0; then
+        AC_MSG_ERROR([$srcdir/scripts/user_settings_asm.sh failed.])
+    fi
+fi
+
 if test "$silent" != "yes"; then
 
 # output config summary

--- a/scripts/include.am
+++ b/scripts/include.am
@@ -120,3 +120,5 @@ EXTRA_DIST += scripts/dtlscid.test
 endif
 
 EXTRA_DIST += scripts/bench/bench_functions.sh
+
+EXTRA_DIST += scripts/user_settings_asm.sh

--- a/scripts/user_settings_asm.sh
+++ b/scripts/user_settings_asm.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+if test $# -eq 0; then
+    echo "user_settings_asm.sh requires one argument specifying compiler flags to pull include directories from."
+    exit 1
+fi
+
+user_settings_path=""
+user_settings_dir="./"
+
+# First, see if user_settings.h is in the current directory.
+if test -e "user_settings.h"; then
+    user_settings_path="user_settings.h"
+else
+    search_string="$1"
+    # Compress multiple spaces to single spaces, then replace instances of
+    # "-I " with "-I" (i.e. remove spaces between -I and the include path).
+    search_string=$(echo "$search_string" | sed -e 's/  */ /g' -e 's/-I /-I/g')
+
+    for token in $search_string
+    do
+        case "$token" in
+        -I*)
+            # Trim off the leading "-I".
+            path=$(echo "$token" | cut -c 3-)
+            if test -e "$path/user_settings.h"; then
+                user_settings_dir="$path"
+                user_settings_path="$path/user_settings.h"
+                break
+            fi
+            ;;
+        *)
+            ;;
+        esac
+    done
+fi
+
+if test -z "$user_settings_path"; then
+    echo "Unable to find user_settings.h."
+    exit 1
+else
+    # Strip out anything from user_settings.h that isn't a preprocessor
+    # directive (i.e. any lines not starting with #). Put the result in
+    # user_settings_asm.h in the same directory as user_settings.h.
+    # user_settings_asm.h is safe to include in assembly files (e.g. .S
+    # files).
+    sed -e '/^ *#/!d' -e :a -e '$!N;s/\\\n/ /;ta' -e 'P;D' < "$user_settings_path" > "$user_settings_dir/user_settings_asm.h"
+fi

--- a/wolfcrypt/src/aes_gcm_asm.S
+++ b/wolfcrypt/src/aes_gcm_asm.S
@@ -20,7 +20,7 @@
  */
 
 #ifdef WOLFSSL_USER_SETTINGS
-#include "wolfssl/wolfcrypt/settings.h"
+#include "user_settings_asm.h"
 #endif
 
 #ifndef HAVE_INTEL_AVX1

--- a/wolfcrypt/src/chacha_asm.S
+++ b/wolfcrypt/src/chacha_asm.S
@@ -20,7 +20,7 @@
  */
 
 #ifdef WOLFSSL_USER_SETTINGS
-#include "wolfssl/wolfcrypt/settings.h"
+#include "user_settings_asm.h"
 #endif
 
 #ifndef HAVE_INTEL_AVX1

--- a/wolfcrypt/src/fe_x25519_asm.S
+++ b/wolfcrypt/src/fe_x25519_asm.S
@@ -20,7 +20,7 @@
  */
 
 #ifdef WOLFSSL_USER_SETTINGS
-#include "wolfssl/wolfcrypt/settings.h"
+#include "user_settings_asm.h"
 #endif
 
 #ifndef HAVE_INTEL_AVX1

--- a/wolfcrypt/src/poly1305_asm.S
+++ b/wolfcrypt/src/poly1305_asm.S
@@ -20,7 +20,7 @@
  */
 
 #ifdef WOLFSSL_USER_SETTINGS
-#include "wolfssl/wolfcrypt/settings.h"
+#include "user_settings_asm.h"
 #endif
 
 #ifndef HAVE_INTEL_AVX1

--- a/wolfcrypt/src/sha256_asm.S
+++ b/wolfcrypt/src/sha256_asm.S
@@ -20,7 +20,7 @@
  */
 
 #ifdef WOLFSSL_USER_SETTINGS
-#include "wolfssl/wolfcrypt/settings.h"
+#include "user_settings_asm.h"
 #endif
 
 #ifndef HAVE_INTEL_AVX1

--- a/wolfcrypt/src/sha3_asm.S
+++ b/wolfcrypt/src/sha3_asm.S
@@ -20,7 +20,7 @@
  */
 
 #ifdef WOLFSSL_USER_SETTINGS
-#include "wolfssl/wolfcrypt/settings.h"
+#include "user_settings_asm.h"
 #endif
 
 #ifndef HAVE_INTEL_AVX1

--- a/wolfcrypt/src/sha512_asm.S
+++ b/wolfcrypt/src/sha512_asm.S
@@ -20,7 +20,7 @@
  */
 
 #ifdef WOLFSSL_USER_SETTINGS
-#include "wolfssl/wolfcrypt/settings.h"
+#include "user_settings_asm.h"
 #endif
 
 #ifndef HAVE_INTEL_AVX1

--- a/wolfcrypt/src/sp_x86_64_asm.S
+++ b/wolfcrypt/src/sp_x86_64_asm.S
@@ -20,7 +20,7 @@
  */
 
 #ifdef WOLFSSL_USER_SETTINGS
-#include "wolfssl/wolfcrypt/settings.h"
+#include "user_settings_asm.h"
 #endif
 
 #ifndef HAVE_INTEL_AVX1


### PR DESCRIPTION
# Description

For user_settings.h builds, .S assembly files need to include user_settings.h in order to get the defines used by the build. However, a user_settings.h may contain code only understood by a C compiler and not the assembler (e.g. a typedef). This commit makes it so our autotools and CMake builds produce a file user_settings_asm.h when doing a user_settings.h build. This generated header contains only the preprocessor directives from the user_settings.h. As a result, it can be safely included by our assembly code files.

Fixes ZD #14843.

# Testing

I did user_settings.h builds with both autotools and CMake, using a simple user_settings.h derived from options.h produced by `./configure`. I put a typedef in user_settings.h so that prior to my changes here, the assembler would fail to build the .S files (specifically sp_x86_64_asm.S). After these changes, those builds succeeded.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
