### PR TITLE
Adding C library support function to Rowley Crossworks ARM re-targetting layer

### DIFF
--- a/IDE/ROWLEY-CROSSWORKS-ARM/retarget.c
+++ b/IDE/ROWLEY-CROSSWORKS-ARM/retarget.c
@@ -83,6 +83,15 @@ int __putchar(int c, __printf_tag_ptr ctx)
     hw_uart_printchar(c);
 }
 
+/* C library support function to write buffer (always to UART) */
+int __write(int __fildes, const unsigned char *__buf, unsigned __len)
+{
+    (void)__fildes;
+    for (unsigned i = 0; i < __len; i++) {
+        hw_uart_printchar((int)__buf[i]);
+    }
+}
+
 extern unsigned char __stack_process_start__[];
 unsigned char * __aeabi_read_tp(void)
 {


### PR DESCRIPTION
# Description

Add implementation of C library support function ```__write()``` to the Rowley Crossworks ARM re-targeting layer to provide missing symbol needed by ```fflush()```.  This addresses a build error seen in some of the nightly tests.

# Testing

Sample of build error fixed:
```
1>C1>/usr/share/.../lib/libc_v7em_t_le_eabi.a(libc2.o): In function `fflush':
1>libc2.c:(.text.libc.fflush+0x38): undefined reference to `__write'
```
The fix was tested using same test configuration which failed, using the branch in the PR instead of master.  Build completed successfully and test ran / passed.