### PR TITLE
implement sk_X509_shift for zd 14898

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -19532,7 +19532,7 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_set_peer_cert_chain(WOLFSSL* ssl)
     else if (ssl->options.side == WOLFSSL_SERVER_END) {
         /* to be compliant with openssl
            first element is kept as peer cert on server side.*/
-        wolfSSL_sk_X509_shift(sk);
+        wolfSSL_sk_X509_pop(sk);
     }
 #endif
     if (ssl->peerCertChain != NULL)

--- a/src/x509.c
+++ b/src/x509.c
@@ -3667,7 +3667,9 @@ int wolfSSL_sk_X509_push(WOLF_STACK_OF(WOLFSSL_X509_NAME)* sk, WOLFSSL_X509* x50
 }
 
 
-WOLFSSL_X509* wolfSSL_sk_X509_pop(WOLF_STACK_OF(WOLFSSL_X509_NAME)* sk) {
+/* Return and remove the last x509 pushed on stack */
+WOLFSSL_X509* wolfSSL_sk_X509_pop(WOLF_STACK_OF(WOLFSSL_X509_NAME)* sk)
+{
     WOLFSSL_STACK* node;
     WOLFSSL_X509*  x509;
 
@@ -3714,9 +3716,42 @@ WOLFSSL_X509* wolfSSL_sk_X509_value(STACK_OF(WOLFSSL_X509)* sk, int i)
     return sk->data.x509;
 }
 
+
+/* Return and remove the first x509 pushed on stack */
 WOLFSSL_X509* wolfSSL_sk_X509_shift(WOLF_STACK_OF(WOLFSSL_X509)* sk)
 {
-    return wolfSSL_sk_X509_pop(sk);
+    WOLFSSL_STACK* node;
+    WOLFSSL_X509*  x509;
+
+    if (sk == NULL) {
+        return NULL;
+    }
+
+    node = sk->next;
+    x509 = sk->data.x509;
+
+    if (node != NULL) {
+        /* walk to end of stack to first node pushed, and remove it */
+        WOLFSSL_STACK* prevNode = sk;
+
+        while (node->next != NULL) {
+            prevNode = node;
+            node = node->next;
+        }
+
+        x509 = node->data.x509;
+        prevNode->next = NULL;
+        XFREE(node, NULL, DYNAMIC_TYPE_X509);
+    }
+    else { /* only one x509 in stack */
+        sk->data.x509 = NULL;
+    }
+
+    if (sk->num > 0) {
+        sk->num -= 1;
+    }
+
+    return x509;
 }
 
 #endif /* OPENSSL_EXTRA */

--- a/tests/api.c
+++ b/tests/api.c
@@ -49536,26 +49536,88 @@ static void free_x509(X509* x)
 static int test_sk_X509(void)
 {
 #if defined(OPENSSL_ALL) && !defined(NO_CERTS)
-    STACK_OF(X509)* s;
+    {
+        STACK_OF(X509)* s;
 
-    AssertNotNull(s = sk_X509_new());
-    AssertIntEQ(sk_X509_num(s), 0);
-    sk_X509_pop_free(s, NULL);
+        AssertNotNull(s = sk_X509_new());
+        AssertIntEQ(sk_X509_num(s), 0);
+        sk_X509_pop_free(s, NULL);
 
-    AssertNotNull(s = sk_X509_new_null());
-    AssertIntEQ(sk_X509_num(s), 0);
-    sk_X509_pop_free(s, NULL);
+        AssertNotNull(s = sk_X509_new_null());
+        AssertIntEQ(sk_X509_num(s), 0);
+        sk_X509_pop_free(s, NULL);
 
-    AssertNotNull(s = sk_X509_new());
-    sk_X509_push(s, (X509*)1);
-    AssertIntEQ(sk_X509_num(s), 1);
-    AssertIntEQ((sk_X509_value(s, 0) == (X509*)1), 1);
-    sk_X509_push(s, (X509*)2);
-    AssertIntEQ(sk_X509_num(s), 2);
-    AssertIntEQ((sk_X509_value(s, 0) == (X509*)2), 1);
-    AssertIntEQ((sk_X509_value(s, 1) == (X509*)1), 1);
-    sk_X509_push(s, (X509*)2);
-    sk_X509_pop_free(s, free_x509);
+        AssertNotNull(s = sk_X509_new());
+        sk_X509_push(s, (X509*)1);
+        AssertIntEQ(sk_X509_num(s), 1);
+        AssertIntEQ((sk_X509_value(s, 0) == (X509*)1), 1);
+        sk_X509_push(s, (X509*)2);
+        AssertIntEQ(sk_X509_num(s), 2);
+        AssertIntEQ((sk_X509_value(s, 0) == (X509*)2), 1);
+        AssertIntEQ((sk_X509_value(s, 1) == (X509*)1), 1);
+        sk_X509_push(s, (X509*)2);
+        sk_X509_pop_free(s, free_x509);
+    }
+
+    {
+        /* Push a list of 10 X509s onto stack, then verify that
+         * value(), push(), shift(), and pop() behave as expected. */
+        STACK_OF(X509)* s;
+        X509*     xList[10];
+        int       i = 0;
+        const int len = (sizeof(xList) / sizeof(xList[0]));
+
+        for (i = 0; i < len; ++i)
+            AssertNotNull(xList[i] = X509_new());
+
+        /* test push, pop, and free */
+        AssertNotNull(s = sk_X509_new());
+
+        for (i = 0; i < len; ++i) {
+            sk_X509_push(s, xList[i]);
+            AssertIntEQ(sk_X509_num(s), i + 1);
+            AssertIntEQ((sk_X509_value(s, 0) == xList[i]), 1);
+            AssertIntEQ((sk_X509_value(s, i) == xList[0]), 1);
+        }
+
+        /* pop returns and removes last pushed on stack, which is index 0
+         * in sk_x509_value */
+        for (i = 0; i < len; ++i) {
+            X509 * x = sk_X509_value(s, 0);
+            X509 * y = sk_X509_pop(s);
+            X509 * z = xList[len - 1 - i];
+
+            AssertIntEQ((x == y), 1);
+            AssertIntEQ((x == z), 1);
+            AssertIntEQ(sk_X509_num(s), len - 1 - i);
+        }
+
+        sk_free(s);
+
+        /* test push, shift, and free */
+        AssertNotNull(s = sk_X509_new());
+
+        for (i = 0; i < len; ++i) {
+            sk_X509_push(s, xList[i]);
+            AssertIntEQ(sk_X509_num(s), i + 1);
+            AssertIntEQ((sk_X509_value(s, 0) == xList[i]), 1);
+            AssertIntEQ((sk_X509_value(s, i) == xList[0]), 1);
+        }
+
+        /* shift returns and removes first pushed on stack, which is index i
+         * in sk_x509_value() */
+        for (i = 0; i < len; ++i) {
+            X509 * x = sk_X509_value(s, len - 1 - i);
+            X509 * y = sk_X509_shift(s);
+            X509 * z = xList[i];
+
+            AssertIntEQ((x == y), 1);
+            AssertIntEQ((x == z), 1);
+            AssertIntEQ(sk_X509_num(s), len - 1 - i);
+        }
+
+        sk_X509_pop_free(s, NULL);
+    }
 
     printf(resultFmt, passed);
 #endif

--- a/tests/api.c
+++ b/tests/api.c
@@ -49616,7 +49616,10 @@ static int test_sk_X509(void)
             AssertIntEQ(sk_X509_num(s), len - 1 - i);
         }
 
-        sk_X509_pop_free(s, NULL);
+        sk_free(s);
+
+        for (i = 0; i < len; ++i)
+            X509_free(xList[i]);
     }
 
     printf(resultFmt, passed);


### PR DESCRIPTION
# Description

wolfSSL_sk_X509_shift() was returning wolfSSL_sk_X509_pop(), rather than returning and removing the value from the opposite end of the stack relative to pop().

In this commit wolfSSL_sk_X509_shift() is implemented. Existing functions that were calling wolfSSL_sk_X509_shift() were changed to call wolfSSL_sk_X509_pop(), so expected behavior is preserved.

Fixes zd#14898

# Testing

Updated test_sk_X509(void) in tests/api.c

Added a new test that pushes a list of 10 X509s onto stack, then verifies that shift(), pop(), and value() behave as expected.


