### PR TITLE
Add RSA PSS salt defines to engine builds if not FIPS v2.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -253,6 +253,10 @@ AS_CASE([$ENABLED_WOLFENGINE],
         ENABLED_WOLFENGINE="yes"
         ENABLED_FIPS="v2"
     ],
+    [fips-v5],[
+        ENABLED_WOLFENGINE="yes"
+        ENABLED_FIPS="v5"
+    ],
     [fips-ready],[
         ENABLED_WOLFENGINE="yes"
         ENABLED_FIPS="ready"
@@ -7817,7 +7821,7 @@ then
     AM_CFLAGS="$AM_CFLAGS -DNO_OLD_MD5_NAME"
 fi
 
-if test "$ENABLED_WOLFENGINE" = "yes" && test "$ENABLED_FIPS" = "no"
+if test "$ENABLED_WOLFENGINE" = "yes" && test "$ENABLED_FIPS" != "v2"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_PSS_LONG_SALT"
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_PSS_SALT_LEN_DISCOVER"


### PR DESCRIPTION
# Description

WOLFSSL_PSS_LONG_SALT and WOLFSSL_PSS_SALT_LEN_DISCOVER are supported in our latest FIPS module (v5). These should be defined for engine builds as long as the FIPS version isn't v2.

# Testing

I used fips-check.sh to create a linuxv5 bundle and ensured wolfEngine built and passed all its tests using it.