### PR TITLE
20220930-fixes-smallstack-shellcheck-etc

### DIFF
--- a/IDE/XilinxSDK/bench.sh
+++ b/IDE/XilinxSDK/bench.sh
@@ -16,7 +16,8 @@
 #  Preamble
 ###
 
-readonly my_path=$(dirname $(readlink -f $0))
+my_path=$(dirname $(readlink -f $0)) || exit $?
+readonly my_path
 readonly csv_path_suffix="$1"
 
 readonly common_opts="-blocks 128"

--- a/IDE/XilinxSDK/combine.sh
+++ b/IDE/XilinxSDK/combine.sh
@@ -9,7 +9,8 @@
 #  Preamble
 ###
 
-readonly my_path="$(dirname $(readlink -f $0))"
+my_path="$(dirname $(readlink -f $0))" || exit $?
+readonly my_path
 readonly csv_path="$my_path/data"
 
 function cleanup() {
@@ -32,7 +33,8 @@ trap error_out INT TERM
 #  Implementation
 ###
 
-readonly configs=$(find $csv_path -maxdepth 1 -type d -name '*results_*' | sed 's@.*results_@@g')
+configs=$(find $csv_path -maxdepth 1 -type d -name '*results_*' | sed 's@.*results_@@g') || exit $?
+readonly configs
 
 declare -A algos
 algos["asym"]="ecc rsa"
@@ -57,7 +59,7 @@ filters["cmac"]="-e s/\(128\|256\)-CMAC/CMAC,\1/g"
 filters["ecc"]='-e 1!{/SECP384R1\|SECP521R1/!d}'
 filters["sha2"]="-e s/SHA-/SHA2-/g"
 
-for t in ${!algos[@]}
+for t in "${!algos[@]}"
 do
     for algo in ${algos[$t]}
     do

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -909,8 +909,11 @@ static const char* bench_Usage_msg1[][21] = {
         "-base10     Display bytes as power of 10 (eg 1 kB = 1000 Bytes)\n",
         "-no_aad     No additional authentication data passed.\n",
         "-aad_size <num>   With <num> bytes of AAD.\n",
-        "-all_aad    With AAD length of 0, " WC_STRINGIFY(AES_AUTH_ADD_SZ) " and\n"
-        "            (if set via -aad_size) <aad_size> bytes.\n",
+       ("-all_aad    With AAD length of 0, "
+                     WC_STRINGIFY(AES_AUTH_ADD_SZ)
+                     " and\n"
+        "            (if set via -aad_size) <aad_size> bytes.\n"
+       ),
         "-dgst_full  Full digest operation performed.\n",
         "-rsa_sign   Measure RSA sign/verify instead of encrypt/decrypt.\n",
         "<keySz> -rsa-sz\n            Measure RSA <key size> performance.\n",
@@ -923,9 +926,10 @@ static const char* bench_Usage_msg1[][21] = {
         "-<alg>      Algorithm to benchmark. Available algorithms include:\n",
         "-lng <num>  Display benchmark result by specified language.\n            0: English, 1: Japanese\n",
         "<num>       Size of block in bytes\n",
-        "-blocks <num>  Number of blocks. Can be used together with the 'Size of block'\n"
+       ("-blocks <num>  Number of blocks. Can be used together with the 'Size of block'\n"
         "            option, but must be used after that one.\n"
-        "-threads <num> Number of threads to run\n",
+        "-threads <num> Number of threads to run\n"
+       ),
         "-print      Show benchmark stats summary\n"
     },
 #ifndef NO_MULTIBYTE_PRINT
@@ -1297,7 +1301,7 @@ static const char* bench_result_words2[][5] = {
             #define AES_AAD_OPTIONS_DEFAULT 0x3U
         #endif
     #endif
-    #define AES_AAD_STRING(s)           (aesAuthAddSz == 0 ? s "-no_AAD" : (aesAuthAddSz == AES_AUTH_ADD_SZ ? s : s "-custom"))
+    #define AES_AAD_STRING(s)           (aesAuthAddSz == 0 ? (s "-no_AAD") : (aesAuthAddSz == AES_AUTH_ADD_SZ ? (s) : (s "-custom")))
     enum en_aad_options {
         AAD_SIZE_DEFAULT = 0x1U,
         AAD_SIZE_ZERO = 0x2U,

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1079,9 +1079,6 @@ WOLFSSL_ABI WOLFSSL_API int wolfSSL_CTX_load_verify_locations(
 WOLFSSL_API const char** wolfSSL_get_system_CA_dirs(word32* num);
 #endif /* !_WIN32 */
 WOLFSSL_API int wolfSSL_CTX_load_system_CA_certs(WOLFSSL_CTX* ctx);
-#ifdef OPENSSL_EXTRA
-WOLFSSL_API int wolfSSL_CTX_set_default_verify_paths(WOLFSSL_CTX* ctx);
-#endif /* OPENSSL_EXTRA */
 #ifdef WOLFSSL_TRUST_PEER_CERT
 WOLFSSL_API int wolfSSL_CTX_trust_peer_cert(
     WOLFSSL_CTX* ctx, const char* file, int type);


### PR DESCRIPTION
wolfssl/ssl.h: remove redundant prototype for `wolfSSL_CTX_set_default_verify_paths()`.

wolfcrypt/test/test.c: fix gating, and smallstack refactors, for `ecc_test_deterministic_k()`, `ecc384_test_deterministic_k()`, and `ecc521_test_deterministic_k()`.

wolfcrypt/benchmark/benchmark.c: fix clang-tidy complaints around ungrouped string continuation and unparenthesized macro args.

shellcheck-guided fixes in `IDE/XilinxSDK/bench.sh`, `IDE/XilinxSDK/combine.sh`, `IDE/XilinxSDK/graph.sh`, and `scripts/bench/bench_functions.sh`.

tested with `wolfssl-multi-test.sh ... super-quick-check check-shell-scripts fips-140-3-all fips-140-3-ready-all fips-140-3-dev-all linuxkm-all-fips-140-3 linuxkm-all-fips-140-3-dyn-hash linuxkm-all-fips-140-3-dev-dyn-hash linuxkm-defaults-all-fips-140-3 fips-140-3-RC12 all-crypt-sp-math-vector-register-access all-crypto-linuxkm-defaults-max-func-stack-2k-build-fips all-linuxkm-defaults-max-total-stack-8k-fips all-clang-sp-all-Os all-clang-sp-all-intelasm all-clang-sp-all-intelasm-Os cross-aarch64-armasm-fips-140-3-dev-all-unittest-sanitizer clang-tidy-asn-template-sp-all-small-stack clang-tidy-asn-template-sp-all-small-stack clang-tidy-all-async-quic clang-tidy-fips-140-3-defaults clang-tidy-fips-140-3-all clang-tidy-fips-140-3-dev-defaults clang-tidy-fips-140-3-dev-all all-sp-all-Os-sanitizer`
