### PR TITLE
Fix for EVP_PKEY_DH memory leak

### DIFF
--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -8977,7 +8977,8 @@ void wolfSSL_EVP_PKEY_free(WOLFSSL_EVP_PKEY* key)
                     break;
                 #endif /* NO_DSA */
 
-                #if !defined(NO_DH) && (defined(WOLFSSL_QT) || defined(OPENSSL_ALL))
+                #if !defined(NO_DH) && (defined(WOLFSSL_QT) || \
+                       defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL))
                 case EVP_PKEY_DH:
                     if (key->dh != NULL && key->ownDh == 1) {
                         wolfSSL_DH_free(key->dh);


### PR DESCRIPTION
# Description

Free `EVP_PKEY_DH `keys with openssl_extra defined.


# Testing

Building with `./configure CC="clang -fsanitize=address,undefined" --enable-debug --enable-opensslextra --enable-sniffer && make check` doesn't fail with this commit.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
