### PR TITLE
Correct wolfSSL_sk_X509_new in OpenSSL compatible API

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4367,7 +4367,7 @@ WOLFSSL_STACK* wolfSSL_CertManagerGetCerts(WOLFSSL_CERT_MANAGER* cm)
     if (cm == NULL)
         return NULL;
 
-    sk = wolfSSL_sk_X509_new();
+    sk = wolfSSL_sk_X509_new_null();
     if (sk == NULL)
         goto error;
 
@@ -19495,7 +19495,7 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_set_peer_cert_chain(WOLFSSL* ssl)
     if ((ssl == NULL) || (ssl->session->chain.count == 0))
         return NULL;
 
-    sk = wolfSSL_sk_X509_new();
+    sk = wolfSSL_sk_X509_new_null();
     i = ssl->session->chain.count-1;
     for (; i >= 0; i--) {
         x509 = wolfSSL_X509_new();
@@ -30397,9 +30397,9 @@ int wolfSSL_ASN1_STRING_canon(WOLFSSL_ASN1_STRING* asn_out,
             }
             /* Store cert to free it later */
             if (ret == WOLFSSL_SUCCESS && ctx->x509Chain == NULL) {
-                ctx->x509Chain = wolfSSL_sk_X509_new();
+                ctx->x509Chain = wolfSSL_sk_X509_new_null();
                 if (ctx->x509Chain == NULL) {
-                    WOLFSSL_MSG("wolfSSL_sk_X509_new error");
+                    WOLFSSL_MSG("wolfSSL_sk_X509_new_null error");
                     ret =  WOLFSSL_FAILURE;
                 }
             }
@@ -30445,9 +30445,9 @@ int wolfSSL_ASN1_STRING_canon(WOLFSSL_ASN1_STRING* asn_out,
                 ssl->buffers.weOwnCertChain = 1;
                 /* Store cert to free it later */
                 if (ssl->ourCertChain == NULL) {
-                    ssl->ourCertChain = wolfSSL_sk_X509_new();
+                    ssl->ourCertChain = wolfSSL_sk_X509_new_null();
                     if (ssl->ourCertChain == NULL) {
-                        WOLFSSL_MSG("wolfSSL_sk_X509_new error");
+                        WOLFSSL_MSG("wolfSSL_sk_X509_new_null error");
                         return WOLFSSL_FAILURE;
                     }
                 }
@@ -39806,7 +39806,7 @@ WOLFSSL_STACK* wolfSSL_PKCS7_to_stack(PKCS7* pkcs7)
         WOLFSSL_X509* x509 = wolfSSL_X509_d2i(NULL, p7->pkcs7.cert[i],
             p7->pkcs7.certSz[i]);
         if (!ret)
-            ret = wolfSSL_sk_X509_new();
+            ret = wolfSSL_sk_X509_new_null();
         if (x509) {
             if (wolfSSL_sk_X509_push(ret, x509) != WOLFSSL_SUCCESS) {
                 wolfSSL_X509_free(x509);
@@ -39863,7 +39863,7 @@ WOLFSSL_STACK* wolfSSL_PKCS7_get0_signers(PKCS7* pkcs7, WOLFSSL_STACK* certs,
         return NULL;
     }
 
-    signers = wolfSSL_sk_X509_new();
+    signers = wolfSSL_sk_X509_new_null();
     if (signers == NULL)
         return NULL;
 

--- a/src/x509.c
+++ b/src/x509.c
@@ -12768,15 +12768,8 @@ int wolfSSL_X509_get_signature_nid(const WOLFSSL_X509 *x)
 #if defined(OPENSSL_EXTRA)
 WOLFSSL_STACK* wolfSSL_sk_X509_new(WOLF_SK_COMPARE_CB(WOLFSSL_X509, cb))
 {
-    WOLFSSL_STACK* s = (WOLFSSL_STACK*)XMALLOC(sizeof(WOLFSSL_STACK), NULL,
-            DYNAMIC_TYPE_OPENSSL);
-    if (s != NULL) {
-        XMEMSET(s, 0, sizeof(*s));
-        s->type = STACK_TYPE_X509;
-        (void)cb;
-    }
-
-    return s;
+    (void)cb;
+    return wolfSSL_sk_X509_new_null();
 }
 
 WOLFSSL_STACK* wolfSSL_sk_X509_new_null(void)

--- a/src/x509.c
+++ b/src/x509.c
@@ -12766,7 +12766,20 @@ int wolfSSL_X509_get_signature_nid(const WOLFSSL_X509 *x)
 #endif  /* OPENSSL_EXTRA */
 
 #if defined(OPENSSL_EXTRA)
-WOLFSSL_STACK* wolfSSL_sk_X509_new(void)
+WOLFSSL_STACK* wolfSSL_sk_X509_new(WOLF_SK_COMPARE_CB(WOLFSSL_X509, cb))
+{
+    (void)cb;
+    WOLFSSL_STACK* s = (WOLFSSL_STACK*)XMALLOC(sizeof(WOLFSSL_STACK), NULL,
+            DYNAMIC_TYPE_OPENSSL);
+    if (s != NULL) {
+        XMEMSET(s, 0, sizeof(*s));
+        s->type = STACK_TYPE_X509;
+    }
+
+    return s;
+}
+
+WOLFSSL_STACK* wolfSSL_sk_X509_new_null(void)
 {
     WOLFSSL_STACK* s = (WOLFSSL_STACK*)XMALLOC(sizeof(WOLFSSL_STACK), NULL,
             DYNAMIC_TYPE_OPENSSL);
@@ -12777,7 +12790,7 @@ WOLFSSL_STACK* wolfSSL_sk_X509_new(void)
 
     return s;
 }
-#endif
+#endif  /* OPENSSL_EXTRA */
 
 #ifdef OPENSSL_ALL
 

--- a/src/x509.c
+++ b/src/x509.c
@@ -12768,12 +12768,12 @@ int wolfSSL_X509_get_signature_nid(const WOLFSSL_X509 *x)
 #if defined(OPENSSL_EXTRA)
 WOLFSSL_STACK* wolfSSL_sk_X509_new(WOLF_SK_COMPARE_CB(WOLFSSL_X509, cb))
 {
-    (void)cb;
     WOLFSSL_STACK* s = (WOLFSSL_STACK*)XMALLOC(sizeof(WOLFSSL_STACK), NULL,
             DYNAMIC_TYPE_OPENSSL);
     if (s != NULL) {
         XMEMSET(s, 0, sizeof(*s));
         s->type = STACK_TYPE_X509;
+        (void)cb;
     }
 
     return s;

--- a/src/x509_str.c
+++ b/src/x509_str.c
@@ -621,7 +621,7 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_X509_STORE_get1_certs(
     }
 
     if (err == 0) {
-        filteredCerts = wolfSSL_sk_X509_new();
+        filteredCerts = wolfSSL_sk_X509_new_null();
         if (filteredCerts == NULL) {
             err = 1;
         }
@@ -1138,7 +1138,7 @@ WOLFSSL_STACK* wolfSSL_X509_STORE_GetCerts(WOLFSSL_X509_STORE_CTX* s)
         return NULL;
     }
 
-    sk = wolfSSL_sk_X509_new();
+    sk = wolfSSL_sk_X509_new_null();
 
     if (sk == NULL) {
         return NULL;

--- a/tests/api.c
+++ b/tests/api.c
@@ -34685,7 +34685,7 @@ static int test_wolfSSL_X509_STORE_CTX(void)
     AssertIntEQ(X509_STORE_add_cert(str, x509), SSL_SUCCESS);
 #ifdef OPENSSL_ALL
     /* sk_X509_new only in OPENSSL_ALL */
-    sk = sk_X509_new();
+    sk = sk_X509_new_null();
     AssertNotNull(sk);
     AssertIntEQ(X509_STORE_CTX_init(ctx, str, x509, sk), SSL_SUCCESS);
 #else
@@ -34712,7 +34712,7 @@ static int test_wolfSSL_X509_STORE_CTX(void)
                                                      SSL_FILETYPE_PEM)));
     AssertNotNull((x5092 = X509_load_certificate_file(cliCertFile,
                                                      SSL_FILETYPE_PEM)));
-    AssertNotNull((sk = sk_X509_new()));
+    AssertNotNull((sk = sk_X509_new_null()));
     AssertIntEQ(sk_X509_push(sk, x509), 1);
     AssertNotNull((str = X509_STORE_new()));
     AssertNotNull((ctx = X509_STORE_CTX_new()));
@@ -49539,7 +49539,7 @@ static int test_sk_X509(void)
     {
         STACK_OF(X509)* s;
 
-        AssertNotNull(s = sk_X509_new());
+        AssertNotNull(s = sk_X509_new_null());
         AssertIntEQ(sk_X509_num(s), 0);
         sk_X509_pop_free(s, NULL);
 
@@ -49547,7 +49547,7 @@ static int test_sk_X509(void)
         AssertIntEQ(sk_X509_num(s), 0);
         sk_X509_pop_free(s, NULL);
 
-        AssertNotNull(s = sk_X509_new());
+        AssertNotNull(s = sk_X509_new_null());
         sk_X509_push(s, (X509*)1);
         AssertIntEQ(sk_X509_num(s), 1);
         AssertIntEQ((sk_X509_value(s, 0) == (X509*)1), 1);
@@ -49571,7 +49571,7 @@ static int test_sk_X509(void)
             AssertNotNull(xList[i] = X509_new());
 
         /* test push, pop, and free */
-        AssertNotNull(s = sk_X509_new());
+        AssertNotNull(s = sk_X509_new_null());
 
         for (i = 0; i < len; ++i) {
             sk_X509_push(s, xList[i]);
@@ -49595,7 +49595,7 @@ static int test_sk_X509(void)
         sk_free(s);
 
         /* test push, shift, and free */
-        AssertNotNull(s = sk_X509_new());
+        AssertNotNull(s = sk_X509_new_null());
 
         for (i = 0; i < len; ++i) {
             sk_X509_push(s, xList[i]);

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -522,7 +522,7 @@ typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS;
 #define X509_EXTENSION_dup              wolfSSL_X509_EXTENSION_dup
 
 #define sk_X509_new                     wolfSSL_sk_X509_new
-#define sk_X509_new_null                wolfSSL_sk_X509_new
+#define sk_X509_new_null                wolfSSL_sk_X509_new_null
 #define sk_X509_num                     wolfSSL_sk_X509_num
 #define sk_X509_value                   wolfSSL_sk_X509_value
 #define sk_X509_shift                   wolfSSL_sk_X509_shift

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -4573,7 +4573,11 @@ WOLFSSL_API int wolfSSL_RAND_set_rand_method(const WOLFSSL_RAND_METHOD *methods)
 
 WOLFSSL_API int wolfSSL_CIPHER_get_bits(const WOLFSSL_CIPHER *c, int *alg_bits);
 
-WOLFSSL_API WOLFSSL_STACK* wolfSSL_sk_X509_new(void);
+#define WOLF_SK_COMPARE_CB(type, arg) \
+    int (*(arg)) (const type* const* a, const type* const* b)
+WOLFSSL_API WOLFSSL_STACK* wolfSSL_sk_X509_new(
+    WOLF_SK_COMPARE_CB(WOLFSSL_X509, cb));
+WOLFSSL_API WOLFSSL_STACK* wolfSSL_sk_X509_new_null(void);
 WOLFSSL_API int wolfSSL_sk_X509_num(const WOLF_STACK_OF(WOLFSSL_X509) *s);
 
 WOLFSSL_API WOLFSSL_STACK* wolfSSL_sk_X509_OBJECT_new(void);
@@ -4596,8 +4600,6 @@ WOLFSSL_API void wolfSSL_sk_X509_INFO_pop_free(WOLF_STACK_OF(WOLFSSL_X509_INFO)*
     void (*f) (WOLFSSL_X509_INFO*));
 WOLFSSL_API void wolfSSL_sk_X509_INFO_free(WOLF_STACK_OF(WOLFSSL_X509_INFO)*);
 
-#define WOLF_SK_COMPARE_CB(type, arg) \
-    int (*(arg)) (const type* const* a, const type* const* b)
 typedef unsigned long (*wolf_sk_hash_cb) (const void *v);
 WOLFSSL_API WOLF_STACK_OF(WOLFSSL_X509_NAME)* wolfSSL_sk_X509_NAME_new(
     WOLF_SK_COMPARE_CB(WOLFSSL_X509_NAME, cb));


### PR DESCRIPTION
# Description

sk_X509_new was incorrectly defined as sk_X509_new(void), when the correct definitions are sk_X509_new_null(void) and sk_X509_new(comparator callback). This created needless additional steps when porting between wolfSSL and OpenSSL.

In this commit wolfSSL_sk_X509_new_null() and wolfSSL_sk_X509_new() are implemented as separate functions. Existing functions that were calling wolfSSL_sk_X509_new() were changed to call wolfSSL_sk_X509_new_null().

# Testing

Normal unit/sanity tests (make test, address sanitize and leak tests, etc).

