### PR TITLE
Add support for wolfSSL_CTX_load_system_CA_certs on Windows and Mac.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1668,6 +1668,17 @@ add_option("WOLFSSL_OPTFLAGS"
     "Enable default optimization CFLAGS for the compiler (default: enabled)"
     "yes" "yes;no")
 
+add_option("WOLFSSL_SYS_CA_CERTS"
+    "Enable ability to load CA certs from OS (default: enabled)"
+    "yes" "yes;no")
+if(WOLFSSL_SYS_CA_CERTS)
+    if(NOT WOLFSSL_FILESYSTEM)
+        message(FATAL_ERROR "Cannot use system CA certs without a filesystem.")
+    else()
+        list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_SYS_CA_CERTS")
+    endif()
+endif()
+
 # FLAGS operations
 
 if(WOLFSSL_AESCCM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,18 @@ if(CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
     set(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
 endif()
 
+if(APPLE)
+    find_library(CORE_FOUNDATION_FRAMEWORK CoreFoundation)
+    if(NOT CORE_FOUNDATION_FRAMEWORK)
+        message(FATAL_ERROR "Couldn't find CoreFoundation framework.")
+    endif()
+
+    find_library(SECURITY_FRAMEWORK Security)
+    if(NOT SECURITY_FRAMEWORK)
+        message(FATAL_ERROR "Couldn't find Security framework.")
+    endif()
+endif()
+
 include(CheckIncludeFile)
 
 check_include_file("arpa/inet.h" HAVE_ARPA_INET_H)
@@ -1526,6 +1538,10 @@ endif()
 
 # TODO: - Fast huge math
 
+if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+    list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_X86_64_BUILD")
+endif()
+
 # SP math all
 add_option("WOLFSSL_SP_MATH_ALL"
     "Enable Single Precision math implementation for full algorithm suite (default: enabled)"
@@ -1900,6 +1916,10 @@ if(WIN32)
     # For Windows link ws2_32
     target_link_libraries(wolfssl PUBLIC
         $<$<PLATFORM_ID:Windows>:ws2_32>)
+elseif(APPLE)
+    target_link_libraries(wolfssl PUBLIC
+        ${CORE_FOUNDATION_FRAMEWORK}
+        ${SECURITY_FRAMEWORK})
 else()
     # DH requires math (m) library
     target_link_libraries(wolfssl

--- a/configure.ac
+++ b/configure.ac
@@ -940,7 +940,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_HAVE_ISSUER_NAMES"
 fi
 
-
 # liboqs
 ENABLED_LIBOQS="no"
 tryliboqsdir=""
@@ -7985,13 +7984,12 @@ then
     AM_CFLAGS="$AM_CFLAGS -DHAVE___UINT128_T=1"
 fi
 
-
 LIB_SOCKET_NSL
 AX_HARDEN_CC_COMPILER_FLAGS
 
-# if mingw then link to ws2_32 for sockets
 case $host_os in
     mingw*)
+        # if mingw then link to ws2_32 for sockets
         LDFLAGS="$LDFLAGS -lws2_32"
         if test "$enable_shared" = "yes"
         then
@@ -8001,6 +7999,10 @@ case $host_os in
                 MINGW_LIB_WARNING="yes"
             fi
         fi ;;
+    *darwin*)
+        # For Mac we need these frameworks to load system CA certs
+        LDFLAGS="$LDFLAGS -framework CoreFoundation -framework Security"
+        ;;
 esac
 
 if test "$enable_shared" = "no"; then

--- a/configure.ac
+++ b/configure.ac
@@ -1097,7 +1097,6 @@ AC_ARG_ENABLE([cryptonly],
 
 AS_IF([test "x$FIPS_VERSION" = "xrand"],[ENABLED_CRYPTONLY="yes"])
 
-
 # DTLS
 # DTLS is a prereq for the options mcast, sctp, and jni. Enabling any of those
 # without DTLS will also enable DTLS.
@@ -7346,6 +7345,12 @@ AC_ARG_ENABLE([optflags],
     [ ENABLED_OPTFLAGS=yes ]
     )
 
+# Adds functionality to load CA certificates from the operating system.
+AC_ARG_ENABLE([sys-ca-certs],
+    [AS_HELP_STRING([--enable-sys-ca-certs],[Enable ability to load CA certs from OS (default: enabled)])],
+    [ ENABLED_SYS_CA_CERTS=$enableval ],
+    [ ENABLED_SYS_CA_CERTS=yes ]
+    )
 
 # check if should run the trusted peer certs test
 # (for now checking both C_FLAGS and C_EXTRA_FLAGS)
@@ -7407,6 +7412,24 @@ esac
 ################################################################################
 # Update ENABLE_* variables                                                    #
 ################################################################################
+
+if test "x$ENABLED_LEANPSK" = "xyes" || test "x$ENABLED_CERTS" = "xno" || \
+   test "x$ENABLED_ASN" = "xno"
+then
+   ENABLED_CERTS=no
+   ENABLED_ASN=no
+fi
+
+if test "x$ENABLED_SYS_CA_CERTS" = "xyes"
+then
+    if test "x$ENABLED_FILESYSTEM" = "xno"
+    then
+        ENABLED_SYS_CA_CERTS="no"
+    elif test "x$ENABLED_CERTS" = "xno"
+    then
+        ENABLED_SYS_CA_CERTS="no"
+    fi
+fi
 
 if test "x$ENABLED_WOLFCLU" = "xyes"
 then
@@ -7621,6 +7644,14 @@ AS_IF([test "x$ENABLED_16BIT" = "xyes" && \
 ################################################################################
 # Update CFLAGS based on options                                               #
 ################################################################################
+AS_IF([test "x$ENABLED_CERTS" = "xno"],
+      [AM_CFLAGS="$AM_CFLAGS -DNO_CERTS"])
+
+AS_IF([test "x$ENABLED_ASN" = "xno"],
+      [AM_CFLAGS="$AM_CFLAGS -DNO_ASN"])
+
+AS_IF([test "x$ENABLED_SYS_CA_CERTS" = "xyes"],
+      [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SYS_CA_CERTS"])
 
 AS_IF([test "x$ENABLED_ALTNAMES" = "xyes"],
       [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALT_NAMES"])
@@ -7893,11 +7924,6 @@ if test "x$ENABLED_OPENSSLCOEXIST" = "xyes"; then
 fi
 
 AS_IF([test "x$ENABLED_WOLFSSH" = "xyes"],[AM_CPPFLAGS="$AM_CPPFLAGS -DWOLFSSL_WOLFSSH"])
-
-if test "x$ENABLED_CERTS" = "xno" || test "x$ENABLED_LEANPSK" = "xyes" || test "x$ENABLED_ASN" = "xno"; then
-   AM_CFLAGS="$AM_CFLAGS -DNO_ASN -DNO_CERTS"
-   ENABLED_ASN=no
-fi
 
 # only allow secure renegotiation info with TLSV12 and ASN
 if test "x$ENABLED_ASN" = "xno" || \
@@ -8664,6 +8690,7 @@ echo "   * IoT-Safe:                   $ENABLED_IOTSAFE"
 echo "   * IoT-Safe HWRNG:             $ENABLED_IOTSAFE_HWRNG"
 echo "   * NXP SE050:                  $ENABLED_SE050"
 echo "   * PSA:                        $ENABLED_PSA"
+echo "   * System CA certs:            $ENABLED_SYS_CA_CERTS"
 echo ""
 echo "---"
 

--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -1267,12 +1267,13 @@ const char** wolfSSL_get_system_CA_dirs(word32* num);
     \ingroup CertsKeys
 
     \brief This function attempts to load CA certificates into a WOLFSSL_CTX
-    from conventional CA cert directories, which is OS-dependent.
+    from an OS-dependent CA certificate store. Loaded certificates will be
+    trusted.
 
     \return WOLFSSL_SUCCESS on success.
     \return WOLFSSL_BAD_PATH if no system CA certs were loaded.
-    \return WOLFSSL_NOT_IMPLEMENTED if the function isn't supported for the
-    target OS.
+    \return WOLFSSL_FAILURE for other failure types (e.g. Windows cert store
+    wasn't properly closed).
 
     \param ctx pointer to the SSL context, created with wolfSSL_CTX_new().
 

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1318,7 +1318,7 @@ static const char* client_usage_msg[][70] = {
 #ifdef WOLFSSL_SRTP
         "--srtp <profile> (default is SRTP_AES128_CM_SHA1_80)\n",       /* 71 */
 #endif
-#if !defined(NO_FILESYSTEM) && !defined(NO_CERTS)
+#ifdef WOLFSSL_SYS_CA_CERTS
         "--sys-ca-certs Load system CA certs for server cert verification\n", /* 72 */
 #endif
         "\n"
@@ -1767,7 +1767,7 @@ static void Usage(void)
     printf("%s", msg[++msgid]);     /* more --pqc options */
     printf("%s", msg[++msgid]);     /* more --pqc options */
 #endif
-#if !defined(NO_FILESYSTEM) && !defined(NO_CERTS)
+#ifdef WOLFSSL_SYS_CA_CERTS
     printf("%s", msg[++msgid]); /* --sys-ca-certs */
 #endif
 #ifdef WOLFSSL_SRTP
@@ -1903,7 +1903,9 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #ifdef WOLFSSL_DTLS_CID
         {"cid", 2, 262},
 #endif /* WOLFSSL_DTLS_CID */
+#ifdef WOLFSSL_SYS_CA_CERTS
         { "sys-ca-certs", 0, 263 },
+#endif
         { 0, 0, 0 }
     };
 #endif
@@ -2013,7 +2015,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     char* pqcAlg = NULL;
     int exitWithRet = 0;
     int loadCertKeyIntoSSLObj = 0;
-#if !defined(NO_FILESYSTEM) && !defined(NO_CERTS)
+#ifdef WOLFSSL_SYS_CA_CERTS
     byte loadSysCaCerts = 0;
 #endif
 
@@ -2716,7 +2718,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 pqcAlg = myoptarg;
                 break;
 #endif
-#if !defined(NO_FILESYSTEM) && !defined(NO_CERTS)
+#ifdef WOLFSSL_SYS_CA_CERTS
             case 263:
                 loadSysCaCerts = 1;
                 break;
@@ -2977,12 +2979,12 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     }
 #endif
 
-#if !defined(NO_FILESYSTEM) && !defined(NO_CERTS)
+#ifdef WOLFSSL_SYS_CA_CERTS
     if (loadSysCaCerts &&
         wolfSSL_CTX_load_system_CA_certs(ctx) != WOLFSSL_SUCCESS) {
         err_sys("wolfSSL_CTX_load_system_CA_certs failed");
     }
-#endif
+#endif /* WOLFSSL_SYS_CA_CERTS */
 
     if (minVersion != CLIENT_INVALID_VERSION) {
 #ifdef WOLFSSL_DTLS

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -183,6 +183,9 @@
  *     ClientCache by default for backwards compatibility. This define will
  *     make wolfSSL_get_session return a reference to ssl->session. The returned
  *     pointer will be freed with the related WOLFSSL object.
+ * WOLFSSL_SYS_CA_CERTS
+ *     Enables ability to load system CA certs from the OS via
+ *     wolfSSL_CTX_load_system_CA_certs.
  */
 
 #define WOLFSSL_EVP_INCLUDED
@@ -8050,6 +8053,8 @@ int wolfSSL_CTX_load_verify_locations(WOLFSSL_CTX* ctx, const char* file,
     return WS_RETURN_CODE(ret,WOLFSSL_FAILURE);
 }
 
+#ifdef WOLFSSL_SYS_CA_CERTS
+
 #ifdef USE_WINDOWS_API
 
 static int LoadSystemCaCertsWindows(WOLFSSL_CTX* ctx, byte* loaded)
@@ -8244,6 +8249,8 @@ int wolfSSL_CTX_load_system_CA_certs(WOLFSSL_CTX* ctx)
 
     return ret;
 }
+
+#endif /* WOLFSSL_SYS_CA_CERTS */
 
 #ifdef WOLFSSL_TRUST_PEER_CERT
 /* Used to specify a peer cert to match when connecting
@@ -16355,7 +16362,7 @@ cleanup:
 
 #ifdef OPENSSL_EXTRA
 
-    #ifndef NO_FILESYSTEM
+    #ifdef WOLFSSL_SYS_CA_CERTS
     /*
      * This is an OpenSSL compatibility layer function, but it doesn't mirror
      * the exact functionality of its OpenSSL counterpart. We don't support the
@@ -16383,7 +16390,7 @@ cleanup:
 
         return ret;
     }
-    #endif /* !NO_FILESYSTEM */
+    #endif /* WOLFSSL_SYS_CA_CERTS */
 
     #if defined(WOLFCRYPT_HAVE_SRP) && !defined(NO_SHA256) \
         && !defined(WC_NO_RNG)

--- a/tests/api.c
+++ b/tests/api.c
@@ -1350,7 +1350,7 @@ static int test_wolfSSL_CTX_load_system_CA_certs(void)
 {
     int ret = 0;
 
-#if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && !defined(NO_WOLFSSL_CLIENT)
+#if defined(WOLFSSL_SYS_CA_CERTS) && !defined(NO_WOLFSSL_CLIENT)
     WOLFSSL_CTX* ctx;
     byte dirValid = 0;
 
@@ -1404,7 +1404,7 @@ static int test_wolfSSL_CTX_load_system_CA_certs(void)
 #endif /* OPENSSL_EXTRA */
 
     wolfSSL_CTX_free(ctx);
-#endif /* !NO_FILESYSTEM && !NO_CERTS && !NO_WOLFSSL_CLIENT */
+#endif /* WOLFSSL_SYS_CA_CERTS && !NO_WOLFSSL_CLIENT */
 
     return ret;
 }

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2857,6 +2857,17 @@ extern void uITRON4_free(void *p) ;
     #define WOLFSSL_ASYNC_IO
 #endif
 
+#ifdef WOLFSSL_SYS_CA_CERTS
+    #ifdef NO_FILESYSTEM
+        #warning "Turning off WOLFSSL_SYS_CA_CERTS b/c NO_FILESYSTEM is defined."
+        #undef WOLFSSL_SYS_CA_CERTS
+    #endif
+    #ifdef NO_CERTS
+        #warning "Turning off WOLFSSL_SYS_CA_CERTS b/c NO_CERTS is defined."
+        #undef WOLFSSL_SYS_CA_CERTS
+    #endif
+#endif /* WOLFSSL_SYS_CA_CERTS */
+
 #ifdef __cplusplus
     }   /* extern "C" */
 #endif


### PR DESCRIPTION
I ran the example client in Visual Studio with `-h google.com -p 443` and `-h google.com -p 443 --sys-ca-certs`. The former fails, as expected, and the latter succeeds, indicating system CA certs were loaded in order to validate google.com's cert chain. Ran the same test on macOS.

Adds `WOLFSSL_SYS_CA_CERTS` option for feature.