### PR TITLE
Fixes from small stack refactor

### DIFF
--- a/wolfssl/wolfcrypt/mem_track.h
+++ b/wolfssl/wolfcrypt/mem_track.h
@@ -672,17 +672,17 @@ static WC_INLINE int StackSizeCheck_launch(struct func_args* args,
     unsigned char* myStack = NULL;
     size_t stackSize = 1024*1024*2;
     pthread_attr_t myAttr;
+    struct stack_size_debug_context* shim_args;
 
 #ifdef PTHREAD_STACK_MIN
     if (stackSize < PTHREAD_STACK_MIN)
         stackSize = PTHREAD_STACK_MIN;
 #endif
 
-    struct stack_size_debug_context *shim_args =
-        (struct stack_size_debug_context *)malloc(sizeof *shim_args);
-    if (! shim_args) {
+    shim_args = (struct stack_size_debug_context *)malloc(sizeof *shim_args);
+    if (shim_args == NULL) {
         perror("malloc");
-        exit(EXIT_FAILURE);
+        return -1;
     }
 
     ret = posix_memalign((void**)&myStack, sysconf(_SC_PAGESIZE), stackSize);
@@ -697,6 +697,8 @@ static WC_INLINE int StackSizeCheck_launch(struct func_args* args,
     ret = pthread_attr_init(&myAttr);
     if (ret != 0) {
         fprintf(stderr, "attr_init failed\n");
+        free(shim_args);
+        free(myStack);
         return ret;
     }
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1236,39 +1236,24 @@ typedef struct w64wrapper {
 
     #ifdef SINGLE_THREADED
         #if defined(WC_32BIT_CPU)
-            typedef void*   THREAD_RETURN;
+            typedef void*        THREAD_RETURN;
         #else
-            typedef unsigned int  THREAD_RETURN;
+            typedef unsigned int THREAD_RETURN;
         #endif
-        typedef void*         THREAD_TYPE;
+        typedef void*            THREAD_TYPE;
         #define WOLFSSL_THREAD
-    #elif (defined(_POSIX_THREADS) || defined(HAVE_PTHREAD)) && \
-        !defined(__MINGW32__)
-        typedef void*         THREAD_RETURN;
-        typedef pthread_t     THREAD_TYPE;
-        #define WOLFSSL_THREAD
-        #define INFINITE (-1)
-        #define WAIT_OBJECT_0 0L
     #elif defined(WOLFSSL_MDK_ARM) || defined(WOLFSSL_KEIL_TCP_NET) || \
-            defined(FREESCALE_MQX)
+          defined(FREESCALE_MQX)
         typedef unsigned int  THREAD_RETURN;
         typedef int           THREAD_TYPE;
         #define WOLFSSL_THREAD
     #elif defined(WOLFSSL_TIRTOS)
         typedef void          THREAD_RETURN;
         typedef Task_Handle   THREAD_TYPE;
-        #ifdef HAVE_STACK_SIZE
-        #undef EXIT_TEST
-        #define EXIT_TEST(ret)
-        #endif
         #define WOLFSSL_THREAD
     #elif defined(WOLFSSL_ZEPHYR)
         typedef void            THREAD_RETURN;
         typedef struct k_thread THREAD_TYPE;
-        #ifdef HAVE_STACK_SIZE
-        #undef EXIT_TEST
-        #define EXIT_TEST(ret)
-        #endif
         #define WOLFSSL_THREAD
     #elif defined(NETOS)
         typedef UINT        THREAD_RETURN;
@@ -1280,9 +1265,16 @@ typedef struct w64wrapper {
         typedef unsigned int  THREAD_RETURN;
         typedef size_t        THREAD_TYPE;
         #define WOLFSSL_THREAD
+    #elif (defined(_POSIX_THREADS) || defined(HAVE_PTHREAD)) && \
+        !defined(__MINGW32__)
+        typedef void*         THREAD_RETURN;
+        typedef pthread_t     THREAD_TYPE;
+        #define WOLFSSL_THREAD
+        #define INFINITE      (-1)
+        #define WAIT_OBJECT_0 0L
     #else
         typedef unsigned int  THREAD_RETURN;
-        typedef size_t      THREAD_TYPE;
+        typedef size_t        THREAD_TYPE;
         #define WOLFSSL_THREAD __stdcall
     #endif
 


### PR DESCRIPTION
# Description

Resolves these multi-test errors:

```
wolfssl/wolfcrypt/mem_track.h:700:9: error: Memory leak: shim_args [memleak]
        return ret;
        ^

wolfssl/wolfssl/wolfcrypt/types.h:1248:17: error: unknown type name ‘pthread_t’
 1248 |         typedef pthread_t     THREAD_TYPE;
```

Fixes from small stack refactor (#5631). 

# Testing

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
