### PR TITLE
Kyber: only include source when not FIPS

### DIFF
--- a/src/include.am
+++ b/src/include.am
@@ -104,14 +104,6 @@ if BUILD_ECC
 src_libwolfssl_la_SOURCES += wolfcrypt/src/ecc.c
 endif
 
-if BUILD_WC_KYBER
-src_libwolfssl_la_SOURCES += wolfcrypt/src/wc_kyber.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/wc_kyber_poly.c
-if BUILD_INTELASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/wc_kyber_asm.S
-endif
-endif
-
 if BUILD_AES
 src_libwolfssl_la_SOURCES += wolfcrypt/src/aes.c
 endif
@@ -195,14 +187,6 @@ endif
 
 if BUILD_ECC
 src_libwolfssl_la_SOURCES += wolfcrypt/src/ecc.c
-endif
-
-if BUILD_WC_KYBER
-src_libwolfssl_la_SOURCES += wolfcrypt/src/wc_kyber.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/wc_kyber_poly.c
-if BUILD_INTELASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/wc_kyber_asm.S
-endif
 endif
 
 if BUILD_AES
@@ -625,11 +609,13 @@ src_libwolfssl_la_SOURCES += wolfcrypt/src/sakke.c
 endif
 endif
 
+if !BUILD_FIPS_CURRENT
 if BUILD_WC_KYBER
 src_libwolfssl_la_SOURCES += wolfcrypt/src/wc_kyber.c
 src_libwolfssl_la_SOURCES += wolfcrypt/src/wc_kyber_poly.c
 if BUILD_INTELASM
 src_libwolfssl_la_SOURCES += wolfcrypt/src/wc_kyber_asm.S
+endif
 endif
 endif
 


### PR DESCRIPTION
# Description

Don't include kyber source files in FIPS.

# Testing

Standard

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
