### PR TITLE
fix: wrong size using DTLSv1.3 in RestartHandshakeHashWithCookie

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -3197,7 +3197,11 @@ static int CreateCookie(WOLFSSL* ssl, byte* hash, byte hashSz)
 }
 #endif
 
+#ifdef WOLFSSL_DTLS13
+#define HRR_MAX_HS_HEADER_SZ DTLS_HANDSHAKE_HEADER_SZ
+#else
 #define HRR_MAX_HS_HEADER_SZ HANDSHAKE_HEADER_SZ
+#endif /* WOLFSSL_DTLS13 */
 
 /* Restart the handshake hash with a hash of the previous messages.
  *
@@ -3208,7 +3212,7 @@ int RestartHandshakeHash(WOLFSSL* ssl)
 {
     int    ret;
     Hashes hashes;
-    byte   header[HRR_MAX_HS_HEADER_SZ] = {0};
+    byte   header[HANDSHAKE_HEADER_SZ] = {0};
     byte*  hash = NULL;
     byte   hashSz = 0;
 
@@ -5396,7 +5400,7 @@ static int CheckCookie(WOLFSSL* ssl, byte* cookie, byte cookieSz)
  */
 static int RestartHandshakeHashWithCookie(WOLFSSL* ssl, Cookie* cookie)
 {
-    byte   header[HRR_MAX_HS_HEADER_SZ] = {0};
+    byte   header[HANDSHAKE_HEADER_SZ] = {0};
     byte   hrr[MAX_HRR_SZ] = {0};
     int    hrrIdx;
     word32 idx;

--- a/tests/test-dtls13-psk.conf
+++ b/tests/test-dtls13-psk.conf
@@ -52,3 +52,19 @@
 -u
 -s
 -l TLS13-AES256-GCM-SHA384
+
+# server TLSv1.3 PSK and resumption
+# AES256-GCM and SHA384
+-v 4
+-u
+-s
+-l TLS13-AES256-GCM-SHA384
+-r
+
+# client TLSv1.3 PSK
+# AES256-GCM and SHA384
+-v 4
+-u
+-s
+-l TLS13-AES256-GCM-SHA384
+-r


### PR DESCRIPTION
# Description

HRR_MAX_HS_HEADER_SZ does not consider DTLS handshake extra fields.


# Testing
`./configure --enable-dtls13 --enable-dtls --enable-sesson-ticket --enable-psk` 
`./example/server/server -v4 -u -r -s`
`./example/client/client -v4 -u -r -s`

