### PR TITLE
Fix coverity issues

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -12064,7 +12064,7 @@ static int GetHashId(const byte* id, int length, byte* hash)
 /* Id for jurisdiction country. */
 #define ASN_JURIS_C   0x203
 /* Id for jurisdiction state. */
-#define ASN_JURIS_ST  0x203
+#define ASN_JURIS_ST  0x202
 
 /* Set the string for a name component into the subject name. */
 #define SetCertNameSubject(cert, id, val) \

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -10586,7 +10586,7 @@ static int wc_ecc_import_raw_private(ecc_key* key, const char* qx,
             WOLFSSL_MSG("Invalid Qx");
             err = BAD_FUNC_ARG;
         }
-        if (mp_unsigned_bin_size(key->pubkey.y) > key->dp->size) {
+        if (mp_unsigned_bin_size(key->pubkey.x) > key->dp->size) {
             err = BAD_FUNC_ARG;
         }
     }

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -2668,6 +2668,8 @@ time_t stm32_hal_time(time_t *t1)
     RTC_TimeTypeDef time;
     RTC_DateTypeDef date;
 
+    XMEMSET(tm_time, 0, sizeof(struct tm));
+
     /* order of GetTime followed by GetDate required here due to STM32 HW
      * requirement */
     HAL_RTC_GetTime(&hrtc, &time, FORMAT_BIN);


### PR DESCRIPTION
# Description
Fixes for static analysis issues
* uninit_use_in_call: Using uninitialized value tm_time.tm_isdst when calling mktime .
* `ASN_JURIS_ST` and `ASN_JURIS_C` defined to same value
* copy_paste_error: y in key->pubkey.y looks like a copy-paste error.

Fixes zd14968

# Testing

Passes static analysis tool

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
