### PR TITLE
20221010-fixes-missing-field-initializers-etc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,9 @@ find_package(Threads)
 # Example for map file and custom linker script
 #set(CMAKE_EXE_LINKER_FLAGS " -Xlinker -Map=output.map -T\"${CMAKE_CURRENT_SOURCE_DIR}/linker.ld\"")
 
-if(WIN32)
+if(DEFINED WARNING_C_FLAGS)
+set(CMAKE_C_FLAGS "${WARNING_C_FLAGS} ${CMAKE_C_FLAGS}")
+elseif(WIN32)
 # Windows cl.exe does not support the -Wextra, -Wno-unused and -Werror flags.
 set(CMAKE_C_FLAGS "-Wall ${CMAKE_C_FLAGS}")
 else()

--- a/configure.ac
+++ b/configure.ac
@@ -4188,7 +4188,7 @@ AS_CASE([$FIPS_VERSION],
         AS_IF([test "$ENABLED_AESGCM" = "no" && (test "$FIPS_VERSION" != "dev" || test "$enable_aesgcm" != "no")],
             [ENABLED_AESGCM="yes"; AM_CFLAGS="$AM_CFLAGS -DHAVE_AESGCM"])
 
-	# AES-GCM streaming isn't part of the current FIPS suite.
+        # AES-GCM streaming isn't part of the current FIPS suite.
         AS_IF([test "$ENABLED_AESGCM_STREAM" = "yes" && (test "$FIPS_VERSION" != "dev" || test "$enable_aesgcm_stream" != "yes")],
             [ENABLED_AESGCM_STREAM="no"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -4188,6 +4188,10 @@ AS_CASE([$FIPS_VERSION],
         AS_IF([test "$ENABLED_AESGCM" = "no" && (test "$FIPS_VERSION" != "dev" || test "$enable_aesgcm" != "no")],
             [ENABLED_AESGCM="yes"; AM_CFLAGS="$AM_CFLAGS -DHAVE_AESGCM"])
 
+	# AES-GCM streaming isn't part of the current FIPS suite.
+        AS_IF([test "$ENABLED_AESGCM_STREAM" = "yes" && (test "$FIPS_VERSION" != "dev" || test "$enable_aesgcm_stream" != "yes")],
+            [ENABLED_AESGCM_STREAM="no"])
+
         # Old TLS requires MD5 + HMAC, which is not allowed under FIPS 140-3
         AS_IF([test "$ENABLED_OLD_TLS" != "no"],
             [ENABLED_OLD_TLS="no"; AM_CFLAGS="$AM_CFLAGS -DNO_OLD_TLS"])

--- a/tests/api.c
+++ b/tests/api.c
@@ -58973,10 +58973,12 @@ static int test_wolfSSL_DTLS_fragment_buckets(void)
     !defined(NO_OLD_TLS)
 static int test_WOLFSSL_dtls_version_alert(void)
 {
-    struct test_memio_ctx test_ctx = { 0 };
+    struct test_memio_ctx test_ctx;
     WOLFSSL_CTX *ctx_c, *ctx_s;
     WOLFSSL *ssl_c, *ssl_s;
     int ret;
+
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
 
     ret = test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
         wolfDTLSv1_2_client_method, wolfDTLSv1_server_method);
@@ -59147,11 +59149,13 @@ static int test_ticket_nonce_cache(WOLFSSL *ssl_s, WOLFSSL *ssl_c, byte len)
 
 static int test_ticket_nonce_malloc(void)
 {
-    struct test_memio_ctx test_ctx = { 0 };
+    struct test_memio_ctx test_ctx;
     WOLFSSL_CTX *ctx_c, *ctx_s;
     byte small, medium, big;
     WOLFSSL *ssl_c, *ssl_s;
     int ret;
+
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
 
     ret = test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
         wolfTLSv1_3_client_method, wolfTLSv1_3_server_method);

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -5117,7 +5117,7 @@ void DEBUG_WRITE_DER(const byte* der, int derSz, const char* fileName);
     (defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12) &&                    \
     !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) &&              \
     !defined(NO_OLD_TLS))
-#define TEST_MEMIO_BUF_SZ 64 * 1024
+#define TEST_MEMIO_BUF_SZ (64 * 1024)
 struct test_memio_ctx
 {
     byte c_buff[TEST_MEMIO_BUF_SZ];


### PR DESCRIPTION
tests/api.c: refactor struct initializer using `XMEMCPY()` to mollify `-Werror=missing-field-initializers` in C++ builds.

configure.ac: when FIPS 140-3, disable AES-GCM streaming API, unless "dev".

CMakeLists.txt: add handling for `WARNING_C_FLAGS` in setup for `CMAKE_C_FLAGS`, to allow override warning config, e.g. without `-Werror`.

wolfssl/test.h: fix `bugprone-macro-parentheses`.


tested with `wolfssl-multi-test.sh ... super-quick-check`
