### PR TITLE
Added new CTX callback: SslCreatedCb

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -689,10 +689,12 @@ WOLFSSL* wolfSSL_new(WOLFSSL_CTX* ctx)
             FreeSSL(ssl, ctx->heap);
             ssl = 0;
         }
-
-    WOLFSSL_LEAVE("SSL_new", ret);
     (void)ret;
-
+#ifdef HAVE_PK_CALLBACKS
+    if (ssl && ctx->SslCreatedCb)
+        ctx->SslCreatedCb(ctx, ssl);
+#endif
+    WOLFSSL_LEAVE("SSL_new", ret);
     return ssl;
 }
 
@@ -29428,6 +29430,17 @@ void* wolfSSL_GetEncryptKeysCtx(WOLFSSL* ssl)
         return ssl->EncryptKeysCtx;
 
     return NULL;
+}
+
+/* callback for SSL session created */
+/* the callback can be used to acknowledge the creation of a new SSL in the 
+ * context */
+void wolfSSL_CTX_SetSslCreatedCb(WOLFSSL_CTX *ctx, CallbackSslCreated cb)
+{
+    WOLFSSL_ENTER("wolfSSL_CTX_SetSslCreatedCb");
+    if (ctx)
+        ctx->SslCreatedCb = cb;
+    WOLFSSL_LEAVE("wolfSSL_CTX_SetSslCreatedCb", 0);
 }
 
 /* callback for Tls finished */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3396,6 +3396,7 @@ struct WOLFSSL_CTX {
     CallbackGenMasterSecret     GenMasterCb;        /* Use generate master secret handler */
     CallbackGenSessionKey       GenSessionKeyCb;    /* Use generate session key handler */
     CallbackEncryptKeys         EncryptKeysCb;/* Use setting encrypt keys handler */
+    CallbackSslCreated          SslCreatedCb;      /* Use session created handler */
     CallbackTlsFinished         TlsFinishedCb;      /* Use Tls finished handler */
 #if !defined(WOLFSSL_NO_TLS12) && !defined(WOLFSSL_AEAD_ONLY)
     CallbackVerifyMac           VerifyMacCb;        /* Use Verify mac handler */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3508,6 +3508,9 @@ WOLFSSL_API void  wolfSSL_CTX_SetEncryptKeysCb(WOLFSSL_CTX* ctx,
 WOLFSSL_API void  wolfSSL_SetEncryptKeysCtx(WOLFSSL* ssl, void *ctx);
 WOLFSSL_API void* wolfSSL_GetEncryptKeysCtx(WOLFSSL* ssl);
 
+typedef int (*CallbackSslCreated)(WOLFSSL_CTX* ctx, WOLFSSL *ssl);
+WOLFSSL_API void wolfSSL_CTX_SetSslCreatedCb(WOLFSSL_CTX *ctx, CallbackSslCreated cb);
+
 typedef int (*CallbackTlsFinished)(WOLFSSL* ssl,
                             const byte *side,
                             const byte *handshake_hash,

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -4557,6 +4557,16 @@ static WC_INLINE int myVerifyMac(WOLFSSL *ssl, const byte* message,
 }
 #endif
 
+static WC_INLINE int mySslCreated(WOLFSSL_CTX* ctx, WOLFSSL *ssl)
+{
+    int       ret;
+    (void)ctx;
+    (void)ssl;
+    WOLFSSL_PKMSG("Ssl Created Cb: created session %p\n", ssl);
+    ret = WOLFSSL_SUCCESS;
+    return ret;
+}
+
 static WC_INLINE int myTlsFinished(WOLFSSL* ssl,
                             const byte *side,
                             const byte *handshake_hash,
@@ -4641,6 +4651,8 @@ static WC_INLINE void SetupPkCallbacks(WOLFSSL_CTX* ctx)
     #if !defined(WOLFSSL_NO_TLS12) && !defined(WOLFSSL_AEAD_ONLY)
     wolfSSL_CTX_SetVerifyMacCb(ctx, myVerifyMac);
     #endif
+
+    wolfSSL_CTX_SetSslCreatedCb(ctx, mySslCreated);
 
     wolfSSL_CTX_SetTlsFinishedCb(ctx, myTlsFinished);
     #endif /* NO_CERTS */


### PR DESCRIPTION
# Description

Add new CTX callback: SslCreatedCb

The callback can be registered to acknowledge the creation of a new `WOLFSSL` object within the given `WOLFSSL_CTX`.

Should fix zd#14909

# Testing

Tested via wolfssl/test.h by adding a custom mySslCreated callback

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
