### PR TITLE
Add ICCARM and IAR_SYSTEM_ICC to a macro guard to use bge assembly instruction

### DIFF
--- a/wolfcrypt/src/sp_cortexm.c
+++ b/wolfcrypt/src/sp_cortexm.c
@@ -18471,7 +18471,7 @@ SP_NOINLINE static sp_int32 sp_256_cmp_8(const sp_digit* a, const sp_digit* b)
         "and	r3, r3, r8\n\t"
         "sub	r6, r6, #4\n\t"
         "cmp	r6, #0\n\t"
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
         "bge	1b\n\t"
 #else
         "bge.n	1b\n\t"


### PR DESCRIPTION
# Description

This PR addresses an issue reported in ZD14944.
ICCARM or IAR_SYSTEM_ICC compliler uses inappropriate assembly instruction when WOLFSSL_SP_ARM_CORTEX_M_ASM option is specified and then causes error in ECC operations.

Fixes zd14944

# Testing

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
