### PR TITLE
Fix --enable-devcrypto build error for sys without u_int8_t type

### DIFF
--- a/wolfcrypt/src/port/devcrypto/README.md
+++ b/wolfcrypt/src/port/devcrypto/README.md
@@ -22,7 +22,7 @@ modprobe cryptodev
 For default build with all supported features use:
 
 ```
-./configure --enable-cryptodev
+./configure --enable-devcrypto
 ```
 
 Or for more control over features used:

--- a/wolfcrypt/src/port/devcrypto/wc_devcrypto.c
+++ b/wolfcrypt/src/port/devcrypto/wc_devcrypto.c
@@ -122,7 +122,7 @@ int wc_DevCryptoCreate(WC_CRYPTODEV* ctx, int type, byte* key, word32 keySz)
         case CRYPTO_SHA2_512_HMAC:
             ctx->sess.cipher = 0;
             ctx->sess.mac    = type;
-            ctx->sess.mackey    = (u_int8_t*)key;
+            ctx->sess.mackey    = (byte*)key;
             ctx->sess.mackeylen = keySz;
             break;
 


### PR DESCRIPTION
# Description

Change use of sys type (`u_int8_t`) to std C type (`uint8_t`). Also fix config option in devcrypto readme.

Fixes GitHub issue #5693 

# Testing

Build test

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [X] updated appropriate READMEs
 - [ ] Updated manual and documentation
