### PR TITLE
Fix wolfCrypt only build with wincrypt.h

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -163,6 +163,7 @@
 #endif /* !WOLFCRYPT_ONLY || OPENSSL_EXTRA */
 
 #ifdef _WIN32
+#include <windows.h>
 #include <Wincrypt.h>
 #pragma comment(lib, "crypt32")
 #endif


### PR DESCRIPTION
# Description

wincrypt.h requires windows.h, which isn't included in internal.h when WOLFCRYPT_ONLY set

# Testing

Perform wolfSSL build using the wolfSSH user_settings.h file.