### PR TITLE
Various build fixes

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -31414,8 +31414,8 @@ static int test_wc_CertPemToDer(void)
 
 static int test_wc_PubKeyPemToDer(void)
 {
-#ifdef WOLFSSL_PEM_TO_DER
-#if defined(WOLFSSL_CERT_EXT) || defined(WOLFSSL_PUB_PEM_TO_DER)
+#if defined(WOLFSSL_PEM_TO_DER) && !defined(NO_FILESYSTEM) && \
+   (defined(WOLFSSL_CERT_EXT) || defined(WOLFSSL_PUB_PEM_TO_DER))
     int ret;
     const char* key = "./certs/ecc-client-keyPub.pem";
     byte* cert_buf = NULL;
@@ -31447,14 +31447,14 @@ static int test_wc_PubKeyPemToDer(void)
 
     printf(resultFmt, passed);
 #endif
-#endif
 
     return 0;
 }
 
 static int test_wc_PemPubKeyToDer(void)
 {
-#if defined(WOLFSSL_CERT_EXT) || defined(WOLFSSL_PUB_PEM_TO_DER)
+#if !defined(NO_FILESYSTEM) && \
+    (defined(WOLFSSL_CERT_EXT) || defined(WOLFSSL_PUB_PEM_TO_DER))
     int ret;
     const char* key = "./certs/ecc-client-keyPub.pem";
     size_t cert_dersz = 1024;

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -43,6 +43,7 @@
 #include <wolfssl/wolfcrypt/ecc.h>
 #endif
 
+#include <wolfssl/wolfcrypt/memory.h> /* for LARGEST_MEM_BUCKET */
 
 #define MAX_ARGS 40
 #define MAX_COMMAND_SZ 240

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -12785,21 +12785,25 @@ void wc_ecc_fp_free(void)
 
 #endif /* FP_ECC */
 
-#ifdef ECC_TIMING_RESISTANT
 int wc_ecc_set_rng(ecc_key* key, WC_RNG* rng)
 {
     int err = 0;
 
+#ifdef ECC_TIMING_RESISTANT
     if (key == NULL) {
         err = BAD_FUNC_ARG;
     }
     else {
         key->rng = rng;
     }
+#else
+    (void)key;
+    (void)rng;
+    /* report success, not an error if ECC_TIMING_RESISTANT is not defined */
+#endif
 
     return err;
 }
-#endif
 
 #ifdef HAVE_ECC_ENCRYPT
 

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -2719,7 +2719,7 @@ static THREAD_LS_T int myVerifyAction = VERIFY_OVERRIDE_ERROR;
  * --enable-opensslextra is defined because it sets WOLFSSL_ALWAYS_VERIFY_CB and
  * WOLFSSL_VERIFY_CB_ALL_CERTS.
  * Normal cases of the verify callback only occur on certificate failures when the
- * wolfSSL_set_verify(ssl, SSL_VERIFY_PEER, myVerifyCb); is called
+ * wolfSSL_set_verify(ssl, SSL_VERIFY_PEER, myVerify); is called
 */
 
 static WC_INLINE int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
@@ -2734,7 +2734,6 @@ static WC_INLINE int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
     int i = 0;
 #endif
 #endif
-    (void)preverify;
 
     /* Verify Callback Arguments:
      * preverify:           1=Verify Okay, 0=Failure

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -666,10 +666,8 @@ WOLFSSL_ABI WOLFSSL_API
 void wc_ecc_fp_free(void);
 WOLFSSL_LOCAL
 void wc_ecc_fp_init(void);
-#ifdef ECC_TIMING_RESISTANT
 WOLFSSL_API
 int wc_ecc_set_rng(ecc_key* key, WC_RNG* rng);
-#endif
 
 WOLFSSL_API
 int wc_ecc_set_curve(ecc_key* key, int keysize, int curve_id);


### PR DESCRIPTION
# Description

* Fix api.c build error with `NO_FILESYSTEM` and `WOLFSSL_CERT_EXT`.
* Fix for building tests/suites.c with static memory (missing `LARGEST_MEM_BUCKET`).
* Always expose `wc_ecc_set_rng` for compatibility.

ZD 14992 and suggestions from OpenWRT.

# Testing

Custom `user_settings.h`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
