### PR TITLE
of SSL/CTX_set_max_early_data() for client side

### DIFF
--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -13754,15 +13754,16 @@ wolfSSL_accept_TLSv13(WOLFSSL* ssl);
 /*!
     \ingroup Setup
 
-    \brief This function sets the maximum amount of early data that will be
-    accepted by a TLS v1.3 server using the wolfSSL context.
+    \brief This function sets the maximum amount of early data that a
+    TLS v1.3 client or server is willing to exchange using the wolfSSL context.
     Call this function to limit the amount of early data to process to mitigate
     replay attacks. Early data is protected by keys derived from those of the
     connection that the session ticket was sent and therefore will be the same
     every time a session ticket is used in resumption.
     The value is included in the session ticket for resumption.
-    A value of zero indicates no early data is to be sent by client using
-    session tickets.
+    A server value of zero indicates no early data is to be sent by client using
+    session tickets. A client value of zero indicates that the client will
+    not send any early data.
     It is recommended that the number of early data bytes be kept as low as
     practically possible in the application.
 
@@ -13771,7 +13772,6 @@ wolfSSL_accept_TLSv13(WOLFSSL* ssl);
     \param [in] sz the amount of early data to accept in bytes.
 
     \return BAD_FUNC_ARG if ctx is NULL or not using TLS v1.3.
-    \return SIDE_ERROR if called with a client.
     \return 0 if successful.
 
     _Example_
@@ -13795,15 +13795,16 @@ int  wolfSSL_CTX_set_max_early_data(WOLFSSL_CTX* ctx,
 /*!
     \ingroup Setup
 
-    \brief This function sets the maximum amount of early data that will be
-    accepted by a TLS v1.3 server using the wolfSSL context.
+    \brief This function sets the maximum amount of early data that a
+    TLS v1.3 client or server is willing to exchange.
     Call this function to limit the amount of early data to process to mitigate
     replay attacks. Early data is protected by keys derived from those of the
     connection that the session ticket was sent and therefore will be the same
     every time a session ticket is used in resumption.
     The value is included in the session ticket for resumption.
-    A value of zero indicates no early data is to be sent by client using
-    session tickets.
+    A server value of zero indicates no early data is to be sent by client using
+    session tickets. A client value of zero indicates that the client will
+    not send any early data.
     It is recommended that the number of early data bytes be kept as low as
     practically possible in the application.
 
@@ -13811,7 +13812,6 @@ int  wolfSSL_CTX_set_max_early_data(WOLFSSL_CTX* ctx,
     \param [in] sz the amount of early data to accept from client in bytes.
 
     \return BAD_FUNC_ARG if ssl is NULL or not using TLS v1.3.
-    \return SIDE_ERROR if called with a client.
     \return 0 if successful.
 
     _Example_

--- a/src/quic.c
+++ b/src/quic.c
@@ -273,7 +273,6 @@ void wolfSSL_quic_clear(WOLFSSL* ssl)
     }
     ssl->quic.enc_level_write = wolfssl_encryption_initial;
     ssl->quic.enc_level_latest_recvd = wolfssl_encryption_initial;
-    ssl->quic.early_data_enabled = 0;
 
     while ((qd = ssl->quic.input_head)) {
         ssl->quic.input_head = qd->next;
@@ -547,10 +546,7 @@ void wolfSSL_set_quic_early_data_enabled(WOLFSSL* ssl, int enabled)
         WOLFSSL_MSG("wolfSSL_set_quic_early_data_enabled: handshake started");
     }
     else {
-        ssl->quic.early_data_enabled = enabled;
-        if (ssl->options.side != WOLFSSL_CLIENT_END) {
-            wolfSSL_set_max_early_data(ssl, enabled ? UINT32_MAX : 0);
-        }
+        wolfSSL_set_max_early_data(ssl, enabled ? UINT32_MAX : 0);
     }
 }
 #endif /* WOLFSSL_EARLY_DATA */
@@ -578,7 +574,7 @@ int wolfSSL_quic_do_handshake(WOLFSSL* ssl)
          * This confuses the QUIC state handling.
          */
 #ifdef WOLFSSL_EARLY_DATA
-        if (ssl->quic.early_data_enabled) {
+        if (ssl->options.maxEarlyDataSz) {
             byte tmpbuffer[256];
             int len;
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -12265,22 +12265,22 @@ int wolfSSL_CTX_set_max_early_data(WOLFSSL_CTX* ctx, unsigned int sz)
 #endif
 }
 
-/* Sets the maximum amount of early data that can be seen by server when using
- * session tickets for resumption.
- * A value of zero indicates no early data is to be sent by client using session
- * tickets.
+/* Sets the maximum amount of early data that a client or server would like
+ * to exchange. Servers will advertise this value in session tickets sent
+ * to a client.
+ * A value of zero indicates no early data will be sent by a client, or
+ * no early data is accepted by a server (and announced as such in send out
+ * session tickets).
  *
  * ssl  The SSL/TLS object.
  * sz   Maximum size of the early data.
  * returns BAD_FUNC_ARG when ssl is NULL, or not using TLS v1.3,
- * SIDE_ERROR when not a server and 0 on success.
+ * and 0 on success.
  */
 int wolfSSL_set_max_early_data(WOLFSSL* ssl, unsigned int sz)
 {
     if (ssl == NULL || !IsAtLeastTLSv1_3(ssl->version))
         return BAD_FUNC_ARG;
-    if (ssl->options.side == WOLFSSL_CLIENT_END)
-        return SIDE_ERROR;
 
     ssl->options.maxEarlyDataSz = sz;
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_ERROR_CODE_OPENSSL)
@@ -12324,8 +12324,6 @@ int wolfSSL_get_max_early_data(WOLFSSL* ssl)
 {
     if (ssl == NULL || !IsAtLeastTLSv1_3(ssl->version))
         return BAD_FUNC_ARG;
-    if (ssl->options.side == WOLFSSL_CLIENT_END)
-        return SIDE_ERROR;
 
     return ssl->options.maxEarlyDataSz;
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -51290,11 +51290,11 @@ static int test_tls13_apis(void)
 #endif
 #ifndef NO_WOLFSSL_CLIENT
 #ifndef OPENSSL_EXTRA
-    AssertIntEQ(wolfSSL_set_max_early_data(clientSsl, 0), SIDE_ERROR);
-    AssertIntEQ(wolfSSL_get_max_early_data(clientSsl), SIDE_ERROR);
+    AssertIntEQ(wolfSSL_set_max_early_data(clientSsl, 17), 0);
+    AssertIntEQ(wolfSSL_get_max_early_data(clientSsl), 17);
 #else
-    AssertIntEQ(SSL_set_max_early_data(clientSsl, 0), SIDE_ERROR);
-    AssertIntEQ(SSL_get_max_early_data(clientSsl), SIDE_ERROR);
+    AssertIntEQ(SSL_set_max_early_data(clientSsl, 17), WOLFSSL_SUCCESS);
+    AssertIntEQ(SSL_get_max_early_data(clientSsl), 17);
 #endif
 #endif
 #ifndef NO_WOLFSSL_SERVER

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -399,6 +399,7 @@ typedef struct testVector {
 #endif
 
 PRAGMA_GCC("GCC diagnostic ignored \"-Wunused-function\"")
+PRAGMA_CLANG("clang diagnostic ignored \"-Wunused-function\"")
 
 WOLFSSL_TEST_SUBROUTINE int  error_test(void);
 WOLFSSL_TEST_SUBROUTINE int  base64_test(void);

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -5235,7 +5235,6 @@ struct WOLFSSL {
         WOLFSSL_ENCRYPTION_LEVEL enc_level_write;
         WOLFSSL_ENCRYPTION_LEVEL enc_level_write_next;
         int transport_version;
-        int early_data_enabled;
         const QuicTransportParam* transport_local;
         const QuicTransportParam* transport_peer;
         const QuicTransportParam* transport_peer_draft;


### PR DESCRIPTION

# Description

Use of these functions was restricted to server side so far, returning SIDE_ERROR on clients.

This PR removes that error, updated documentation and tests, and allows setting the value for clients:

* this is more compatible with the same function in other SSL libraries
* a client may indicate, by passing 0, that it has no intention of sending early data
* in QUIC, early data is passed without wolfSSL, but wolfSSL needs to know if the client does use it.
   * the internal flag `early_data_enabled` was kept for that purpose and is now removed as obsolete by this change
   * `early_data_enabled` was incomplete, as an application might not use the QUIC related functions, but just call `SSL_set_max_early_data(0xffffffff)` directly on client side. Having multiple flags for the same thing just complicates code.

Allowing clients to use this function could be seen as a break in the API. That this was an error case before make this less likely. Especially when considering the use in other SSL libs.

# Testing

make test

# Checklist

 - [x] added tests
 - [x ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
