### PR TITLE
Add wolfSSL_set1_host to OpenSSL compatible API

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -22353,6 +22353,17 @@ int wolfSSL_i2d_PublicKey(const WOLFSSL_EVP_PKEY *key, unsigned char **der)
 
 #ifdef OPENSSL_EXTRA
 
+/* Sets the DNS hostname to name.
+ * Hostname is cleared if name is NULL or empty. */
+int wolfSSL_set1_host(WOLFSSL * ssl, const char* name)
+{
+    if (ssl == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+
+    return wolfSSL_X509_VERIFY_PARAM_set1_host(ssl->param, name, 0);
+}
+
 /******************************************************************************
 * wolfSSL_CTX_set1_param - set a pointer to the SSL verification parameters
 *

--- a/src/x509.c
+++ b/src/x509.c
@@ -8168,6 +8168,7 @@ static int wolfSSL_X509_VERIFY_PARAM_inherit(WOLFSSL_X509_VERIFY_PARAM *to,
 
     return ret;
 }
+
 /******************************************************************************
 * wolfSSL_X509_VERIFY_PARAM_set1_host - sets the DNS hostname to name
 * hostnames is cleared if name is NULL or empty.
@@ -8184,8 +8185,11 @@ int wolfSSL_X509_VERIFY_PARAM_set1_host(WOLFSSL_X509_VERIFY_PARAM* pParam,
     if (pParam == NULL)
         return WOLFSSL_FAILURE;
 
-    if (name == NULL)
+    /* If name is NULL, clear hostname. */
+    if (name == NULL) {
+        XMEMSET(pParam->hostName, 0, WOLFSSL_HOST_NAME_MAX);
         return WOLFSSL_SUCCESS;
+    }
 
     /* If name is NULL-terminated, namelen can be set to zero. */
     if (nameSz == 0) {

--- a/tests/api.c
+++ b/tests/api.c
@@ -35246,6 +35246,54 @@ static int test_wolfSSL_X509_VERIFY_PARAM_set1_host(void)
     return 0;
 }
 
+static int test_wolfSSL_set1_host(void)
+{
+#if defined(OPENSSL_EXTRA)
+#if !defined(NO_WOLFSSL_CLIENT) || !defined(NO_WOLFSSL_SERVER)
+    const char host[] = "www.test_wolfSSL_set1_host.com";
+    const char emptyStr[] = "";
+    SSL_CTX*   ctx;
+    SSL*       ssl;
+    WOLFSSL_X509_VERIFY_PARAM* pParam;
+
+    printf(testingFmt, "wolfSSL_set1_host()");
+
+    #ifndef NO_WOLFSSL_SERVER
+    AssertNotNull(ctx = SSL_CTX_new(wolfSSLv23_server_method()));
+    #else
+    AssertNotNull(ctx = SSL_CTX_new(wolfSSLv23_client_method()));
+    #endif
+    AssertTrue(SSL_CTX_use_certificate_file(ctx, svrCertFile, SSL_FILETYPE_PEM));
+    AssertTrue(SSL_CTX_use_PrivateKey_file(ctx, svrKeyFile, SSL_FILETYPE_PEM));
+    AssertNotNull(ssl = SSL_new(ctx));
+
+    pParam = SSL_get0_param(ssl);
+
+    /* we should get back host string */
+    SSL_set1_host(ssl, host);
+    AssertIntEQ(XMEMCMP(pParam->hostName, host, sizeof(host)), 0);
+
+    /* we should get back empty string */
+    SSL_set1_host(ssl, emptyStr);
+    AssertIntEQ(XMEMCMP(pParam->hostName, emptyStr, sizeof(emptyStr)), 0);
+
+    /* we should get back host string */
+    SSL_set1_host(ssl, host);
+    AssertIntEQ(XMEMCMP(pParam->hostName, host, sizeof(host)), 0);
+
+    /* we should get back empty string */
+    SSL_set1_host(ssl, NULL);
+    AssertIntEQ(XMEMCMP(pParam->hostName, emptyStr, sizeof(emptyStr)), 0);
+
+    SSL_free(ssl);
+    SSL_CTX_free(ctx);
+    printf(resultFmt, passed);
+#endif /* !NO_WOLFSSL_CLIENT || !NO_WOLFSSL_SERVER */
+#endif /* OPENSSL_EXTRA */
+
+    return 0;
+}
+
 static int test_wolfSSL_X509_VERIFY_PARAM_set1_ip(void)
 {
 #if defined(OPENSSL_EXTRA)
@@ -59689,6 +59737,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_X509_STORE_CTX_set_time),
     TEST_DECL(test_wolfSSL_get0_param),
     TEST_DECL(test_wolfSSL_X509_VERIFY_PARAM_set1_host),
+    TEST_DECL(test_wolfSSL_set1_host),
     TEST_DECL(test_wolfSSL_X509_VERIFY_PARAM_set1_ip),
     TEST_DECL(test_wolfSSL_X509_STORE_CTX_get0_store),
     TEST_DECL(test_wolfSSL_X509_STORE),

--- a/tests/api.c
+++ b/tests/api.c
@@ -35248,7 +35248,7 @@ static int test_wolfSSL_X509_VERIFY_PARAM_set1_host(void)
 
 static int test_wolfSSL_set1_host(void)
 {
-#if defined(OPENSSL_EXTRA)
+#if defined(OPENSSL_EXTRA) && !defined(NO_RSA)
 #if !defined(NO_WOLFSSL_CLIENT) || !defined(NO_WOLFSSL_SERVER)
     const char host[] = "www.test_wolfSSL_set1_host.com";
     const char emptyStr[] = "";

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -682,6 +682,7 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #define X509_VERIFY_PARAM_get_flags     wolfSSL_X509_VERIFY_PARAM_get_flags
 #define X509_VERIFY_PARAM_clear_flags   wolfSSL_X509_VERIFY_PARAM_clear_flags
 #define X509_VERIFY_PARAM_set_hostflags wolfSSL_X509_VERIFY_PARAM_set_hostflags
+#define SSL_set1_host                   wolfSSL_set1_host
 #define X509_VERIFY_PARAM_set1_host     wolfSSL_X509_VERIFY_PARAM_set1_host
 #define X509_VERIFY_PARAM_set1_ip_asc   wolfSSL_X509_VERIFY_PARAM_set1_ip_asc
 #define X509_VERIFY_PARAM_set1_ip       wolfSSL_X509_VERIFY_PARAM_set1_ip

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2018,6 +2018,7 @@ WOLFSSL_API int wolfSSL_X509_VERIFY_PARAM_clear_flags(WOLFSSL_X509_VERIFY_PARAM 
         unsigned long flags);
 WOLFSSL_API void wolfSSL_X509_VERIFY_PARAM_set_hostflags(
                 WOLFSSL_X509_VERIFY_PARAM* param, unsigned int flags);
+WOLFSSL_API int wolfSSL_set1_host(WOLFSSL* ssl, const char * name);
 WOLFSSL_API int wolfSSL_X509_VERIFY_PARAM_set1_host(WOLFSSL_X509_VERIFY_PARAM* pParam,
                                                     const char* name,
                                                     unsigned int nameSz);


### PR DESCRIPTION
# Description

This commit adds wolfSSL_set1_host() to the OpenSSL compatibility layer.

It also corrects the behavior of wolfSSL_X509_VERIFY_PARAM_set1_host() to clear the hostname if a NULL name is passed.

Addresses github issue #5681.

# Testing

The function test_wolfSSL_set1_host() was added to the API unit tests, which verifies correct behavior for an input host string, empty string, and null.

```bash
./configure CC="clang -fsanitize=address,undefined -g" --enable-all --enable-opensslall --enable-opensslextra --enable-rsa

make

./scripts/unit.test
```
