### PR TITLE
FIPSv2 builds on win10 adjust for new fastmath default in settings.h

### DIFF
--- a/IDE/WIN10/wolfssl-fips.vcxproj
+++ b/IDE/WIN10/wolfssl-fips.vcxproj
@@ -258,6 +258,7 @@
     <ClCompile Include="..\..\wolfcrypt\src\hash.c" />
     <ClCompile Include="..\..\wolfcrypt\src\hmac.c" />
     <ClCompile Include="..\..\wolfcrypt\src\integer.c" />
+    <ClCompile Include="..\..\wolfcrypt\src\tfm.c" />
     <ClCompile Include="..\..\src\internal.c" />
     <ClCompile Include="..\..\src\wolfio.c" />
     <ClCompile Include="..\..\wolfcrypt\src\kdf.c" />


### PR DESCRIPTION
# Description

Bring file in master in-line with the test .vcxproj file (which already pulls in tfm.c)
