### PR TITLE
Inline Function Guard

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -4691,6 +4691,7 @@ static void GenerateM0(Aes* aes)
 
 #elif defined(GCM_TABLE_4BIT)
 
+#if !defined(BIG_ENDIAN_ORDER) && !defined(WC_16BIT_CPU)
 static WC_INLINE void Shift4_M0(byte *r8, byte* z8)
 {
     int i;
@@ -4698,6 +4699,7 @@ static WC_INLINE void Shift4_M0(byte *r8, byte* z8)
         r8[i] = (z8[i-1] << 4) | (z8[i] >> 4);
     r8[0] = z8[0] >> 4;
 }
+#endif
 
 static void GenerateM0(Aes* aes)
 {


### PR DESCRIPTION
# Description

Fixed an inline function aes.c that was included, but never used. Added similar preprocessor guard around it as when it is used.

# Testing

Compiled on a PPC target.