### PR TITLE
20221018-linux6v1-and-WOLFSSL_CALLBACKS-fixes

### DIFF
--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -3360,6 +3360,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
             } while (err == WC_PENDING_E);
         }
 #else
+        (void)nonBlocking;
         ret = NonBlockingSSL_Accept(ssl);
 #endif
 #ifdef WOLFSSL_EARLY_DATA

--- a/linuxkm/linuxkm_memory.c
+++ b/linuxkm/linuxkm_memory.c
@@ -305,3 +305,19 @@
         return;
     }
 #endif /* WOLFSSL_LINUXKM_SIMD_X86 && WOLFSSL_LINUXKM_SIMD_X86_IRQ_ALLOWED */
+
+#if defined(__PIE__) && (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
+/* needed in 6.1+ because show_free_areas() static definition in mm.h calls
+ * __show_free_areas(), which isn't exported (neither was show_free_areas()).
+ */
+void my__show_free_areas(
+    unsigned int flags,
+    nodemask_t *nodemask,
+    int max_zone_idx)
+{
+    (void)flags;
+    (void)nodemask;
+    (void)max_zone_idx;
+    return;
+}
+#endif

--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -105,6 +105,13 @@
          */
         #undef USE_SPLIT_PMD_PTLOCKS
         #define USE_SPLIT_PMD_PTLOCKS 0
+
+        #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+            /* without this, static show_free_areas() mm.h brings in direct
+             * reference to unexported __show_free_areas().
+             */
+            #define __show_free_areas my__show_free_areas
+        #endif
     #endif
     #include <linux/mm.h>
     #ifndef SINGLE_THREADED
@@ -267,8 +274,13 @@
         typeof(kvfree) *kvfree;
         #endif
         typeof(is_vmalloc_addr) *is_vmalloc_addr;
-        typeof(kmem_cache_alloc_trace) *kmem_cache_alloc_trace;
-        typeof(kmalloc_order_trace) *kmalloc_order_trace;
+
+        #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+            typeof(kmalloc_trace) *kmalloc_trace;
+        #else
+            typeof(kmem_cache_alloc_trace) *kmem_cache_alloc_trace;
+            typeof(kmalloc_order_trace) *kmalloc_order_trace;
+        #endif
 
         typeof(get_random_bytes) *get_random_bytes;
         #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 0, 0)
@@ -402,8 +414,12 @@
         #define kvfree (wolfssl_linuxkm_get_pie_redirect_table()->kvfree)
     #endif
     #define is_vmalloc_addr (wolfssl_linuxkm_get_pie_redirect_table()->is_vmalloc_addr)
-    #define kmem_cache_alloc_trace (wolfssl_linuxkm_get_pie_redirect_table()->kmem_cache_alloc_trace)
-    #define kmalloc_order_trace (wolfssl_linuxkm_get_pie_redirect_table()->kmalloc_order_trace)
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+        #define kmalloc_trace (wolfssl_linuxkm_get_pie_redirect_table()->kmalloc_trace)
+    #else
+        #define kmem_cache_alloc_trace (wolfssl_linuxkm_get_pie_redirect_table()->kmem_cache_alloc_trace)
+        #define kmalloc_order_trace (wolfssl_linuxkm_get_pie_redirect_table()->kmalloc_order_trace)
+    #endif
 
     #define get_random_bytes (wolfssl_linuxkm_get_pie_redirect_table()->get_random_bytes)
     #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 0, 0)

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -394,10 +394,15 @@ static int set_up_wolfssl_linuxkm_pie_redirect_table(void) {
     wolfssl_linuxkm_pie_redirect_table.kvfree = kvfree;
 #endif
     wolfssl_linuxkm_pie_redirect_table.is_vmalloc_addr = is_vmalloc_addr;
-    wolfssl_linuxkm_pie_redirect_table.kmem_cache_alloc_trace =
-        kmem_cache_alloc_trace;
-    wolfssl_linuxkm_pie_redirect_table.kmalloc_order_trace =
-        kmalloc_order_trace;
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+        wolfssl_linuxkm_pie_redirect_table.kmalloc_trace =
+            kmalloc_trace;
+    #else
+        wolfssl_linuxkm_pie_redirect_table.kmem_cache_alloc_trace =
+            kmem_cache_alloc_trace;
+        wolfssl_linuxkm_pie_redirect_table.kmalloc_order_trace =
+            kmalloc_order_trace;
+    #endif
 
     wolfssl_linuxkm_pie_redirect_table.get_random_bytes = get_random_bytes;
     #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 0, 0)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -15201,29 +15201,29 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
 
     #define AddTimes(a, b, c)                       \
         do {                                        \
-            c.tv_sec  = a.tv_sec  + b.tv_sec;       \
-            c.tv_usec = a.tv_usec + b.tv_usec;      \
-            if (c.tv_usec >=  1000000) {            \
-                c.tv_sec++;                         \
-                c.tv_usec -= 1000000;               \
+            (c).tv_sec  = (a).tv_sec + (b).tv_sec;  \
+            (c).tv_usec = (a).tv_usec + (b).tv_usec;\
+            if ((c).tv_usec >=  1000000) {          \
+                (c).tv_sec++;                       \
+                (c).tv_usec -= 1000000;             \
             }                                       \
         } while (0)
 
 
     #define SubtractTimes(a, b, c)                  \
         do {                                        \
-            c.tv_sec  = a.tv_sec  - b.tv_sec;       \
-            c.tv_usec = a.tv_usec - b.tv_usec;      \
-            if (c.tv_usec < 0) {                    \
-                c.tv_sec--;                         \
-                c.tv_usec += 1000000;               \
+            (c).tv_sec  = (a).tv_sec - (b).tv_sec;  \
+            (c).tv_usec = (a).tv_usec - (b).tv_usec;\
+            if ((c).tv_usec < 0) {                  \
+                (c).tv_sec--;                       \
+                (c).tv_usec += 1000000;             \
             }                                       \
         } while (0)
 
     #define CmpTimes(a, b, cmp)                     \
-        ((a.tv_sec  ==  b.tv_sec) ?                 \
-            (a.tv_usec cmp b.tv_usec) :             \
-            (a.tv_sec  cmp b.tv_sec))               \
+        (((a).tv_sec  ==  (b).tv_sec) ?             \
+            ((a).tv_usec cmp (b).tv_usec) :         \
+            ((a).tv_sec  cmp (b).tv_sec))           \
 
 
     /* do nothing handler */
@@ -15306,7 +15306,8 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         /* do callbacks */
         if (toCb) {
             if (oldTimerOn) {
-                gettimeofday(&endTime, 0);
+                if (gettimeofday(&endTime, 0) < 0)
+                    ERR_OUT(SYSLIB_FAILED_E);
                 SubtractTimes(endTime, startTime, totalTime);
                 /* adjust old timer for elapsed time */
                 if (CmpTimes(totalTime, oldTimeout.it_value, <))

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -3989,8 +3989,10 @@ int SendTls13ClientHello(WOLFSSL* ssl)
 #if defined(WOLFSSL_CALLBACKS) || defined(OPENSSL_EXTRA)
     if (ssl->hsInfoOn) AddPacketName(ssl, "ClientHello");
     if (ssl->toInfoOn) {
-        AddPacketInfo(ssl, "ClientHello", handshake, args->output, args->sendSz,
-                      WRITE_PROTO, 0, ssl->heap);
+        ret = AddPacketInfo(ssl, "ClientHello", handshake, args->output,
+                      args->sendSz, WRITE_PROTO, 0, ssl->heap);
+        if (ret != 0)
+            return ret;
     }
 #endif
 
@@ -6217,8 +6219,10 @@ int SendTls13ServerHello(WOLFSSL* ssl, byte extMsgType)
     if (ssl->hsInfoOn)
         AddPacketName(ssl, "ServerHello");
     if (ssl->toInfoOn) {
-        AddPacketInfo(ssl, "ServerHello", handshake, output, sendSz,
+        ret = AddPacketInfo(ssl, "ServerHello", handshake, output, sendSz,
                       WRITE_PROTO, 0, ssl->heap);
+        if (ret != 0)
+            return ret;
     }
     #endif
 
@@ -6361,8 +6365,10 @@ static int SendTls13EncryptedExtensions(WOLFSSL* ssl)
     if (ssl->hsInfoOn)
         AddPacketName(ssl, "EncryptedExtensions");
     if (ssl->toInfoOn) {
-        AddPacketInfo(ssl, "EncryptedExtensions", handshake, output,
+        ret = AddPacketInfo(ssl, "EncryptedExtensions", handshake, output,
                       sendSz, WRITE_PROTO, 0, ssl->heap);
+        if (ret != 0)
+            return ret;
     }
 #endif
 
@@ -6502,8 +6508,10 @@ static int SendTls13CertificateRequest(WOLFSSL* ssl, byte* reqCtx,
         if (ssl->hsInfoOn)
             AddPacketName(ssl, "CertificateRequest");
         if (ssl->toInfoOn) {
-            AddPacketInfo(ssl, "CertificateRequest", handshake, output,
+            ret = AddPacketInfo(ssl, "CertificateRequest", handshake, output,
                           sendSz, WRITE_PROTO, 0, ssl->heap);
+            if (ret != 0)
+                return ret;
         }
     #endif
 
@@ -7309,8 +7317,10 @@ static int SendTls13Certificate(WOLFSSL* ssl)
             if (ssl->hsInfoOn)
                 AddPacketName(ssl, "Certificate");
             if (ssl->toInfoOn) {
-                AddPacketInfo(ssl, "Certificate", handshake, output,
+                ret = AddPacketInfo(ssl, "Certificate", handshake, output,
                               sendSz, WRITE_PROTO, 0, ssl->heap);
+                if (ret != 0)
+                    return ret;
             }
 #endif
 
@@ -7857,9 +7867,11 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
             if (ssl->hsInfoOn)
                 AddPacketName(ssl, "CertificateVerify");
             if (ssl->toInfoOn) {
-                AddPacketInfo(ssl, "CertificateVerify", handshake,
+                ret = AddPacketInfo(ssl, "CertificateVerify", handshake,
                             args->output, args->sendSz, WRITE_PROTO, 0,
                             ssl->heap);
+                if (ret != 0)
+                    goto exit_scv;
             }
         #endif
 
@@ -8778,8 +8790,10 @@ static int SendTls13Finished(WOLFSSL* ssl)
     #if defined(WOLFSSL_CALLBACKS) || defined(OPENSSL_EXTRA)
         if (ssl->hsInfoOn) AddPacketName(ssl, "Finished");
         if (ssl->toInfoOn) {
-            AddPacketInfo(ssl, "Finished", handshake, output, sendSz,
+            ret = AddPacketInfo(ssl, "Finished", handshake, output, sendSz,
                           WRITE_PROTO, 0, ssl->heap);
+            if (ret != 0)
+                return ret;
         }
     #endif
 
@@ -8987,8 +9001,10 @@ static int SendTls13KeyUpdate(WOLFSSL* ssl)
         #if defined(WOLFSSL_CALLBACKS) || defined(OPENSSL_EXTRA)
             if (ssl->hsInfoOn) AddPacketName(ssl, "KeyUpdate");
             if (ssl->toInfoOn) {
-                AddPacketInfo(ssl, "KeyUpdate", handshake, output, sendSz,
+                ret = AddPacketInfo(ssl, "KeyUpdate", handshake, output, sendSz,
                               WRITE_PROTO, 0, ssl->heap);
+                if (ret != 0)
+                    return ret;
             }
         #endif
 
@@ -10168,9 +10184,11 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 #if defined(WOLFSSL_CALLBACKS)
     /* add name later, add on record and handshake header part back on */
     if (ssl->toInfoOn) {
-        AddPacketInfo(ssl, 0, handshake, input + *inOutIdx -
+        ret = AddPacketInfo(ssl, 0, handshake, input + *inOutIdx -
             HANDSHAKE_HEADER_SZ, size + HANDSHAKE_HEADER_SZ, READ_PROTO,
             RECORD_HEADER_SZ, ssl->heap);
+        if (ret != 0)
+            return ret;
         AddLateRecordHeader(&ssl->curRL, &ssl->timeoutInfo);
     }
 #endif

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2072,8 +2072,8 @@ enum {
         #error Invalid static buffer length
     #endif
 #elif defined(LARGE_STATIC_BUFFERS)
-    #define STATIC_BUFFER_LEN RECORD_HEADER_SZ + RECORD_SIZE + COMP_EXTRA + \
-             MTU_EXTRA + MAX_MSG_EXTRA
+    #define STATIC_BUFFER_LEN (RECORD_HEADER_SZ + RECORD_SIZE + COMP_EXTRA + \
+             MTU_EXTRA + MAX_MSG_EXTRA)
 #else
     /* don't fragment memory from the record header */
     #define STATIC_BUFFER_LEN RECORD_HEADER_SZ
@@ -5311,7 +5311,7 @@ WOLFSSL_API   void SSL_ResourceFree(WOLFSSL* ssl);   /* Micrium uses */
 
     WOLFSSL_LOCAL void InitTimeoutInfo(TimeoutInfo* info);
     WOLFSSL_LOCAL void FreeTimeoutInfo(TimeoutInfo* info, void* heap);
-    WOLFSSL_LOCAL void AddPacketInfo(WOLFSSL* ssl, const char* name, int type,
+    WOLFSSL_LOCAL int AddPacketInfo(WOLFSSL* ssl, const char* name, int type,
                              const byte* data, int sz, int written, int lateRL,
                              void* heap);
     WOLFSSL_LOCAL void AddLateName(const char* name, TimeoutInfo* info);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -4104,10 +4104,10 @@ typedef int (*TimeoutCallBack)(TimeoutInfo*);
 
 /* wolfSSL connect extension allowing HandShakeCallBack and/or TimeoutCallBack
    for diagnostics */
-WOLFSSL_API int wolfSSL_connect_ex(WOLFSSL* ssl, HandShakeCallBack, TimeoutCallBack,
-                                 WOLFSSL_TIMEVAL);
-WOLFSSL_API int wolfSSL_accept_ex(WOLFSSL* ssl, HandShakeCallBack, TimeoutCallBack,
-                                WOLFSSL_TIMEVAL);
+WOLFSSL_API int wolfSSL_connect_ex(WOLFSSL* ssl, HandShakeCallBack hsCb,
+                                 TimeoutCallBack toCb, WOLFSSL_TIMEVAL timeout);
+WOLFSSL_API int wolfSSL_accept_ex(WOLFSSL* ssl, HandShakeCallBack hsCb,
+                                 TimeoutCallBack toCb, WOLFSSL_TIMEVAL timeout);
 
 #endif /* WOLFSSL_CALLBACKS */
 


### PR DESCRIPTION
linuxkm/: fixes to deal with kernel 6.1+ `show_free_areas()` mess.  also accommodates some other refactoring in mm.h.  build transcript excerpt below.

`WOLFSSL_CALLBACKS` codepaths: fixes for `bugprone-unused-return-value`, `bugprone-macro-parentheses`, `readability-named-parameter`, and `clang-analyzer-deadcode.DeadStores`

tested with `wolfssl-multi-test.sh ... super-quick-check '.*linuxkm-mainline.*' '.*WOLFSSL_CALLBACKS.*'`

(note `WOLFSSL_CALLBACKS` scenarios are not yet merged or in production.)


```
[linuxkm-mainline-pie] [81 of 132] [a272731d45]
    [targeting kernel /usr/src/linux-6.1-rc1]
    configure...   real 0m6.832s  user 0m3.790s  sys 0m3.743s
    build...In file included from /home/wolfbot/tmp/wolfssl_test_workdir.9845/wolfssl/wolfssl/wolfcrypt/wc_port.h:58,
                 from /home/wolfbot/tmp/wolfssl_test_workdir.9845/wolfssl/wolfssl/wolfcrypt/types.h:35,
                 from /home/wolfbot/tmp/wolfssl_test_workdir.9845/wolfssl/wolfssl/wolfcrypt/error-crypt.h:34,
                 from /home/wolfbot/tmp/wolfssl_test_workdir.9845/wolfssl/linuxkm/module_hooks.c:35:
ff4c6e5d7b (<douzzer@wolfssl.com> 2022-01-07 22:39:38 -0600 270)         typeof(kmem_cache_alloc_trace) *kmem_cache_alloc_trace;
/home/wolfbot/tmp/wolfssl_test_workdir.9845/wolfssl/wolfssl/wolfcrypt/../../linuxkm/linuxkm_wc_port.h:270:16: error: ‘kmem_cache_alloc_trace’ undeclared here (not in a function); did you mean ‘kmem_cache_alloc_node’?
  270 |         typeof(kmem_cache_alloc_trace) *kmem_cache_alloc_trace;
      |                ^~~~~~~~~~~~~~~~~~~~~~
      |                kmem_cache_alloc_node
ff4c6e5d7b (<douzzer@wolfssl.com> 2022-01-07 22:39:38 -0600 271)         typeof(kmalloc_order_trace) *kmalloc_order_trace;
/home/wolfbot/tmp/wolfssl_test_workdir.9845/wolfssl/wolfssl/wolfcrypt/../../linuxkm/linuxkm_wc_port.h:271:16: error: ‘kmalloc_order_trace’ undeclared here (not in a function); did you mean ‘kmalloc_node_trace’?
  271 |         typeof(kmalloc_order_trace) *kmalloc_order_trace;
      |                ^~~~~~~~~~~~~~~~~~~
      |                kmalloc_node_trace
make[4]: *** [scripts/Makefile.build:250: /home/wolfbot/tmp/wolfssl_test_workdir.9845/wolfssl/linuxkm/linuxkm/module_hooks.o] Error 1
make[3]: *** [Makefile:1992: /home/wolfbot/tmp/wolfssl_test_workdir.9845/wolfssl/linuxkm] Error 2
make[2]: *** [Makefile:63: libwolfssl.ko] Error 2
make[1]: *** [Makefile:7137: all-recursive] Error 1
make: *** [Makefile:4220: all] Error 2
   real 0m1.201s  user 0m0.784s  sys 0m0.446s
    linuxkm-mainline-pie fail_build
    failed config: '--enable-all' '--enable-aesni' '--enable-sp-asm' '--enable-linuxkm' '--enable-linuxkm-pie' '--enable-reproducible-build' '--enable-crypttests' '--with-linux-source=/usr/src/linux-6.1-rc1'
```
