### PR TITLE
Changing ALPN selection to a deterministic point in the handshake.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3112,14 +3112,19 @@ int wolfSSL_ALPN_GetPeerProtocol(WOLFSSL* ssl, char **list, word16 *listSz)
     char *p;
     byte *s;
 
-    if (list == NULL || listSz == NULL)
+    if (ssl == NULL || list == NULL || listSz == NULL)
         return BAD_FUNC_ARG;
 
     if (ssl->alpn_peer_requested == NULL
         || ssl->alpn_peer_requested_length == 0)
         return BUFFER_ERROR;
 
-    *listSz = ssl->alpn_peer_requested_length -1;
+    /* ssl->alpn_peer_requested are the original bytes sent in a ClientHello,
+     * formatted as (len-byte chars+)+. To turn n protocols into a
+     * comma-separated C string, one needs (n-1) commas and a final 0 byte
+     * which has the same length as the original.
+     * The returned length is the strlen() of the C string, so -1 of that. */
+    *listSz = ssl->alpn_peer_requested_length-1;
     *list = p = (char *)XMALLOC(ssl->alpn_peer_requested_length, ssl->heap,
                                 DYNAMIC_TYPE_TLSX);
     if (p == NULL)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3108,22 +3108,32 @@ int wolfSSL_ALPN_GetProtocol(WOLFSSL* ssl, char **protocol_name, word16 *size)
 
 int wolfSSL_ALPN_GetPeerProtocol(WOLFSSL* ssl, char **list, word16 *listSz)
 {
+    int i, len;
+    char *p;
+    byte *s;
+
     if (list == NULL || listSz == NULL)
         return BAD_FUNC_ARG;
 
-    if (ssl->alpn_client_list == NULL)
+    if (ssl->alpn_peer_requested == NULL
+        || ssl->alpn_peer_requested_length == 0)
         return BUFFER_ERROR;
 
-    *listSz = (word16)XSTRLEN(ssl->alpn_client_list);
-    if (*listSz == 0)
-        return BUFFER_ERROR;
-
-    *list = (char *)XMALLOC((*listSz)+1, ssl->heap, DYNAMIC_TYPE_TLSX);
-    if (*list == NULL)
+    *listSz = ssl->alpn_peer_requested_length -1;
+    *list = p = (char *)XMALLOC(ssl->alpn_peer_requested_length, ssl->heap,
+                                DYNAMIC_TYPE_TLSX);
+    if (p == NULL)
         return MEMORY_ERROR;
 
-    XSTRNCPY(*list, ssl->alpn_client_list, (*listSz)+1);
-    (*list)[*listSz] = 0;
+    for (i = 0, s = ssl->alpn_peer_requested, len = 0;
+         i < ssl->alpn_peer_requested_length;
+         p += len, i += len) {
+        if (i)
+            *p++ = ',';
+        len = s[i++];
+        XSTRNCPY(p, (char *)(s + i), len);
+    }
+    *p = 0;
 
     return WOLFSSL_SUCCESS;
 }

--- a/src/tls.c
+++ b/src/tls.c
@@ -1710,9 +1710,10 @@ static int TLSX_ALPN_ParseAndSet(WOLFSSL *ssl, const byte *input, word16 length,
     if (isRequest) {
         /* keep the list sent by peer, if this is from a request. We
          * use it later in ALPN_Select() for evaluation. */
-        if (ssl->alpn_peer_requested != NULL)
+        if (ssl->alpn_peer_requested != NULL) {
             XFREE(ssl->alpn_peer_requested, ssl->heap, DYNAMIC_TYPE_ALPN);
-
+            ssl->alpn_peer_requested_length = 0;
+        }
         ssl->alpn_peer_requested = (byte *)XMALLOC(size, ssl->heap,
                                                    DYNAMIC_TYPE_ALPN);
         if (ssl->alpn_peer_requested == NULL) {

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5950,6 +5950,12 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 #endif
     }
 
+#ifdef HAVE_ALPN
+    /* With PSK and all other things validated, it's time to
+     * select the ALPN protocol, if so requested */
+    if ((ret = ALPN_Select(ssl)) != 0)
+        return ret;
+#endif
     /* Advance state and proceed */
     ssl->options.asyncState = TLS_ASYNC_BUILD;
     } /* case TLS_ASYNC_BEGIN */

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5863,7 +5863,7 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
 #ifdef HAVE_SNI
         if ((ret = SNI_Callback(ssl)) != 0)
-            return ret;
+            goto exit_dch;
         ssl->options.side = WOLFSSL_SERVER_END;
 #endif
 
@@ -5954,7 +5954,7 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     /* With PSK and all other things validated, it's time to
      * select the ALPN protocol, if so requested */
     if ((ret = ALPN_Select(ssl)) != 0)
-        return ret;
+        goto exit_dch;
 #endif
     /* Advance state and proceed */
     ssl->options.asyncState = TLS_ASYNC_BUILD;

--- a/tests/quic.c
+++ b/tests/quic.c
@@ -1174,6 +1174,88 @@ static int test_quic_server_hello(int verbose) {
     return ret;
 }
 
+#if defined(HAVE_ALPN) && defined(HAVE_SNI)
+
+static int inspect_SNI(WOLFSSL *ssl, int *ad, void *baton)
+{
+    char *stripe = baton;
+
+    (void)ssl;
+    *ad = 0;
+    strcat(stripe, "S");
+    return 0;
+}
+
+static int select_ALPN(WOLFSSL *ssl,
+            const unsigned char **out,
+            unsigned char *outlen,
+            const unsigned char *in,
+            unsigned int inlen,
+            void *baton)
+{
+    char *stripe = baton;
+
+    (void)ssl;
+    (void)inlen;
+    /* just select the first */
+    *out = in + 1;
+    *outlen = in[0];
+    strcat(stripe, "A");
+    return 0;
+}
+
+static int test_quic_alpn(int verbose) {
+    WOLFSSL_CTX *ctx_c, *ctx_s;
+    int ret = 0;
+    QuicTestContext tclient, tserver;
+    QuicConversation conv;
+    char stripe[256];
+    unsigned char alpn_protos[256];
+
+    AssertNotNull(ctx_c = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
+    AssertNotNull(ctx_s = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
+    AssertTrue(wolfSSL_CTX_use_certificate_file(ctx_s, svrCertFile, WOLFSSL_FILETYPE_PEM));
+    AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx_s, svrKeyFile, WOLFSSL_FILETYPE_PEM));
+
+    stripe[0] = '\0';
+    wolfSSL_CTX_set_servername_callback(ctx_s, inspect_SNI);
+    wolfSSL_CTX_set_servername_arg(ctx_s, stripe);
+    wolfSSL_CTX_set_alpn_select_cb(ctx_s, select_ALPN, stripe);
+
+    /* setup ssls */
+    QuicTestContext_init(&tclient, ctx_c, "client", verbose);
+    QuicTestContext_init(&tserver, ctx_s, "server", verbose);
+
+    /* set SNI and ALPN callbacks on server side,
+     * provide values on client side */
+    wolfSSL_UseSNI(tclient.ssl, WOLFSSL_SNI_HOST_NAME,
+                   "wolfssl.com", sizeof("wolfssl.com")-1);
+    /* connect */
+    QuicConversation_init(&conv, &tclient, &tserver);
+
+    strcpy((char*)(alpn_protos + 1), "test");
+    alpn_protos[0] = 4;
+    wolfSSL_set_alpn_protos(tclient.ssl, alpn_protos, 5);
+
+    QuicConversation_do(&conv);
+    AssertIntEQ(tclient.output.len, 0);
+    AssertIntEQ(tserver.output.len, 0);
+
+    /* SNI callback needs to be called before ALPN callback */
+    AssertStrEQ(stripe, "SA");
+
+    QuicTestContext_free(&tclient);
+    QuicTestContext_free(&tserver);
+
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+    printf("    test_quic_alpn: %s\n", (ret == 0)? passed : failed);
+
+    return ret;
+}
+#endif /* defined(HAVE_ALPN) && defined(HAVE_SNI) */
+
+
 #ifdef HAVE_SESSION_TICKET
 
 static int test_quic_key_share(int verbose) {
@@ -1536,6 +1618,9 @@ int QuicTest(void)
     if ((ret = test_quic_crypt()) != 0) goto leave;
     if ((ret = test_quic_client_hello(verbose)) != 0) goto leave;
     if ((ret = test_quic_server_hello(verbose)) != 0) goto leave;
+#if defined(HAVE_ALPN) && defined(HAVE_SNI)
+    if ((ret = test_quic_alpn(verbose)) != 0) goto leave;
+#endif /* defined(HAVE_ALPN) && defined(HAVE_SNI) */
 #ifdef HAVE_SESSION_TICKET
     if ((ret = test_quic_key_share(verbose)) != 0) goto leave;
     if ((ret = test_quic_resumption(verbose)) != 0) goto leave;

--- a/tests/quic.c
+++ b/tests/quic.c
@@ -1174,8 +1174,18 @@ static int test_quic_server_hello(int verbose) {
     return ret;
 }
 
-#if defined(HAVE_ALPN) && defined(HAVE_SNI)
+/* This has gotten a bit out of hand. */
+#if (defined(OPENSSL_ALL) || (defined(OPENSSL_EXTRA) && \
+    (defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX) || \
+    defined(HAVE_LIGHTY) || defined(WOLFSSL_HAPROXY) || \
+    defined(WOLFSSL_OPENSSH) || defined(HAVE_SBLIM_SFCB)))) \
+    && defined(HAVE_ALPN) && defined(HAVE_SNI)
+#define REALLY_HAVE_ALPN_AND_SNI
+#else
+#undef REALLY_HAVE_ALPN_AND_SNI
+#endif
 
+#ifdef REALLY_HAVE_ALPN_AND_SNI
 static int inspect_SNI(WOLFSSL *ssl, int *ad, void *baton)
 {
     char *stripe = baton;
@@ -1253,7 +1263,7 @@ static int test_quic_alpn(int verbose) {
 
     return ret;
 }
-#endif /* defined(HAVE_ALPN) && defined(HAVE_SNI) */
+#endif /* REALLY_HAVE_ALPN_AND_SNI */
 
 
 #ifdef HAVE_SESSION_TICKET
@@ -1618,9 +1628,9 @@ int QuicTest(void)
     if ((ret = test_quic_crypt()) != 0) goto leave;
     if ((ret = test_quic_client_hello(verbose)) != 0) goto leave;
     if ((ret = test_quic_server_hello(verbose)) != 0) goto leave;
-#if defined(HAVE_ALPN) && defined(HAVE_SNI)
+#ifdef REALLY_HAVE_ALPN_AND_SNI
     if ((ret = test_quic_alpn(verbose)) != 0) goto leave;
-#endif /* defined(HAVE_ALPN) && defined(HAVE_SNI) */
+#endif /* REALLY_HAVE_ALPN_AND_SNI */
 #ifdef HAVE_SESSION_TICKET
     if ((ret = test_quic_key_share(verbose)) != 0) goto leave;
     if ((ret = test_quic_resumption(verbose)) != 0) goto leave;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1975,6 +1975,10 @@ WOLFSSL_LOCAL int SNI_Callback(WOLFSSL* ssl);
 #endif
 #endif
 
+#ifdef HAVE_ALPN
+WOLFSSL_LOCAL int ALPN_Select(WOLFSSL* ssl);
+#endif
+
 WOLFSSL_LOCAL int ChachaAEADEncrypt(WOLFSSL* ssl, byte* out, const byte* input,
                               word16 sz); /* needed by sniffer */
 
@@ -5080,7 +5084,9 @@ struct WOLFSSL {
         SecureRenegotiation* secure_renegotiation; /* valid pointer indicates */
     #endif                                         /* user turned on */
     #ifdef HAVE_ALPN
-        char*   alpn_client_list;  /* keep the client's list */
+        byte *alpn_peer_requested; /* the ALPN bytes requested by peer, sequence
+                                    * of length byte + chars */
+        word16 alpn_peer_requested_length; /* number of bytes total */
         #if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX)  || \
             defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_QUIC)
             CallbackALPNSelect alpnSelect;


### PR DESCRIPTION
# Description

SNI and ALPN callbacks are now called in a deterministic order during the handshake:

* ALPN selection is done *after* the SNI callback has been invoked. Meaning any config/CTX changes based on SNI evaluation see the correct values
* ALPN evaluation happens after all TLSX from a ClientHello have been parsed. This mean that the SNI value is always available, regardless of the extension ordering the client used.
* OpenSSL documents exactly this ordering as guaranteed in its API, meaning this PR increases compatibility. 

Fixes #5710

# Testing

Added a test to the quic unittest suite in `tests/quic.c`. `--enable-quic` needs to be configured.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
