### PR TITLE
correct DIST_POINT_NAME type value

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -4118,7 +4118,8 @@ static WOLFSSL_DIST_POINT_NAME* wolfSSL_DIST_POINT_NAME_new(void)
     }
     gns->type = STACK_TYPE_GEN_NAME;
 
-    /* Setting type to 0 because this is fullname */
+    /* DIST_POINT_NAME type may be 0 or 1, indicating whether fullname or
+     * relativename is used. See: RFC 5280 section 4.2.1.13 */
     dpn->name.fullname = gns;
     dpn->type = 0;
 

--- a/src/x509.c
+++ b/src/x509.c
@@ -4118,8 +4118,9 @@ static WOLFSSL_DIST_POINT_NAME* wolfSSL_DIST_POINT_NAME_new(void)
     }
     gns->type = STACK_TYPE_GEN_NAME;
 
+    /* Setting type to 0 because this is fullname */
     dpn->name.fullname = gns;
-    dpn->type = CRL_DIST_OID;
+    dpn->type = 0;
 
     return dpn;
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -42524,6 +42524,7 @@ static int test_wolfSSL_sk_DIST_POINT(void)
     int bytes, i, j;
     XFILE f;
     DIST_POINT* dp;
+    DIST_POINT_NAME* dpn;
     GENERAL_NAME* gn;
     ASN1_IA5STRING* uri;
     STACK_OF(DIST_POINT)* dps;
@@ -42546,6 +42547,10 @@ static int test_wolfSSL_sk_DIST_POINT(void)
     AssertIntEQ(sk_DIST_POINT_num(dps), 1);
     for (i = 0; i < sk_DIST_POINT_num(dps); i++) {
         AssertNotNull(dp = sk_DIST_POINT_value(dps, i));
+        AssertNotNull(dpn = dp->distpoint);
+
+        /* this should be type 0, fullname */
+        AssertIntEQ(dpn->type, 0);
 
         gns = dp->distpoint->name.fullname;
         AssertNotNull(gns);


### PR DESCRIPTION
# Description

The type field in WOLFSSL_DIST_POINT_NAME was being set to an invalid value. This commit sets it to 0 to match the use of the fullname member.

Fixes zd#15011

# Testing

Updated unit test function `test_wolfSSL_sk_DIST_POINT()`.
