### PR TITLE
Fixes for STM32 PKA ECC (not 256-bit)

### DIFF
--- a/IDE/STM32Cube/README.md
+++ b/IDE/STM32Cube/README.md
@@ -111,35 +111,32 @@ To enable the latest Cube HAL support please define `STM32_HAL_V2`.
 
 If you'd like to use the older Standard Peripheral library undefine `WOLFSSL_STM32_CUBEMX`.
 
-With STM32 Cube HAL v2 some AES GCM hardware has a limitation for the AAD header, which must be a multiple of 4 bytes.
+With STM32 Cube HAL v2 some AES GCM hardware has a limitation for the AAD header, which must be a multiple of 4 bytes. If your HAL does not support `CRYP_HEADERWIDTHUNIT_BYTE` then consider adding `STM32_AESGCM_PARTIAL` if you are getting AES GCM authentication failures. This bug existed in v1.16.0 or later.
 
-If using `STM32_AESGCM_PARTIAL` with the following patch it will enable use for all AAD header sizes. The `STM32Cube_FW_F7_V1.16.0` patch is:
+The STM32F7 v1.17.0 pack has a bug in the AES GCM code for handling of additional authentication data when not a multiple of 4 bytes. To patch see `stm32f7xx_hal_cryp.c` -> `CRYP_GCMCCM_SetHeaderPhase`:
 
 ```diff
-diff --git a/Drivers/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_cryp.h b/Drivers/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_cryp.h
---- a/Drivers/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_cryp.h
-+++ b/Drivers/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_cryp.h
-@@ -63,6 +63,7 @@ typedef struct
-                                         GCM : also known as Additional Authentication Data
-                                         CCM : named B1 composed of the associated data length and Associated Data. */
-   uint32_t HeaderSize;                /*!< The size of header buffer in word  */
-+  uint32_t HeaderPadSize;             /*!< <PATCH> The size of padding in bytes added to actual header data to pad it to a multiple of 32 bits </PATCH>  */
-   uint32_t *B0;                       /*!< B0 is first authentication block used only  in AES CCM mode */
-   uint32_t DataWidthUnit;              /*!< Data With Unit, this parameter can be value of @ref CRYP_Data_Width_Unit*/
-   uint32_t KeyIVConfigSkip;            /*!< CRYP peripheral Key and IV configuration skip, to config Key and Initialization
+diff --git a/stm32f7xx_hal_cryp.c b/stm32f7xx_hal_cryp.c
+index 2ae42d0..9666f26 100644
+--- a/stm32f7xx_hal_cryp.c
++++ b/stm32f7xx_hal_cryp.c
+@@ -5600,7 +5600,6 @@ static HAL_StatusTypeDef CRYP_GCMCCM_SetHeaderPhase(CRYP_HandleTypeDef *hcryp, u
+   uint32_t size_in_bytes;
+   uint32_t tmp;
+   uint32_t mask[12] = {0x0U, 0xFF000000U, 0xFFFF0000U, 0xFFFFFF00U,  /* 32-bit data type */
+-                       0x0U, 0x0000FF00U, 0x0000FFFFU, 0xFF00FFFFU,  /* 16-bit data type */
+                        0x0U, 0x000000FFU, 0x0000FFFFU, 0x00FFFFFFU}; /*  8-bit data type */
 
-diff --git a/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_cryp_ex.c b/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_cryp_ex.c
---- a/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_cryp_ex.c
-+++ b/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_cryp_ex.c
-@@ -132,6 +132,8 @@ HAL_StatusTypeDef HAL_CRYPEx_AESGCM_GenerateAuthTAG(CRYP_HandleTypeDef *hcryp, u
-   uint64_t inputlength = (uint64_t)hcryp->SizesSum * 8U; /* input length in bits */
-   uint32_t tagaddr = (uint32_t)AuthTag;
- 
-+  headerlength -= ((uint64_t)(hcryp->Init.HeaderPadSize) * 8U); /* <PATCH> Decrement the header size removing the pad size </PATCH> */  
-+
-   if (hcryp->State == HAL_CRYP_STATE_READY)
-   {
-     /* Process locked */
+   /***************************** Header phase for GCM/GMAC or CCM *********************************/
+@@ -5842,7 +5841,7 @@ static HAL_StatusTypeDef CRYP_GCMCCM_SetHeaderPhase(CRYP_HandleTypeDef *hcryp, u
+       {
+         /* Enter last bytes, padded with zeroes */
+         tmp =  *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
+-        tmp &= mask[(hcryp->Init.DataType * 2U) + (size_in_bytes % 4U)];
++        tmp &= mask[(hcryp->Init.HeaderWidthUnit * 4U) + (size_in_bytes % 4U)];
+         hcryp->Instance->DINR = tmp;
+         loopcounter++;
+         /* Pad the data with zeros to have a complete block */
 ```
 
 If you are using FreeRTOS make sure your `FreeRTOSConfig.h` has its `configTOTAL_HEAP_SIZE` increased.
@@ -155,9 +152,29 @@ The TLS client/server benchmark example requires about 76 KB for allocated tasks
 .b. WolfCrypt Benchmark
 .l. WolfSSL TLS Bench
 .e. Show Cipher List
+.s. Run TLS 1.3 Server over UART
+.c. Run TLS 1.3 Client over UART
 
 Please select one of the above options:
 ```
+
+### Example for TLS v1.3 over UART
+
+A tutorial for setting this up can be found here: https://www.youtube.com/watch?v=OK6MKXYiVBY
+
+The TLS v1.3 client/server examples over UART are paired with these host-side applications:
+* https://github.com/wolfSSL/wolfssl-examples/blob/master/tls/client-tls-uart.c
+* https://github.com/wolfSSL/wolfssl-examples/blob/master/tls/server-tls-uart.c
+
+To use this example you will need to use the STM32Cube interface to enable an additional USART and enable DMA for the RX with defaults. Enabling DMA for the USART requires adding the USART RX DMA in the STM32Cube tool. Under Connectivity click on your TLS USART# and goto DMA Settings and "Add" one for USART#_RX with default options.
+
+Then set the TLS_UART macro to the correct `huart#` instance. This USART will be used as a TLS transport.
+
+```c
+#define TLS_UART huart2
+```
+
+To disable the TLS UART example you can define `NO_TLS_UART_TEST`.
 
 ## Benchmarks
 

--- a/IDE/STM32Cube/default_conf.ftl
+++ b/IDE/STM32Cube/default_conf.ftl
@@ -29,8 +29,8 @@
 [/#list]
 [/#if]
 
-[#-- SWIPdatas is a list of SWIPconfigModel --]  
-[#list SWIPdatas as SWIP]  
+[#-- SWIPdatas is a list of SWIPconfigModel --]
+[#list SWIPdatas as SWIP]
 [#-- Global variables --]
 [#if SWIP.variables??]
 	[#list SWIP.variables as variable]
@@ -40,9 +40,9 @@ extern ${variable.value} ${variable.name};
 
 [#-- Global variables --]
 
-[#assign instName = SWIP.ipName]   
-[#assign fileName = SWIP.fileName]   
-[#assign version = SWIP.version]   
+[#assign instName = SWIP.ipName]
+[#assign fileName = SWIP.fileName]
+[#assign version = SWIP.version]
 
 /**
 	MiddleWare name : ${instName}
@@ -50,9 +50,9 @@ extern ${variable.value} ${variable.name};
 	MiddleWare version : ${version}
 */
 [#if SWIP.defines??]
-	[#list SWIP.defines as definition]	
+	[#list SWIP.defines as definition]
 /*---------- [#if definition.comments??]${definition.comments}[/#if] -----------*/
-#define ${definition.name} #t#t ${definition.value} 
+#define ${definition.name} #t#t ${definition.value}
 [#if definition.description??]${definition.description} [/#if]
 	[/#list]
 [/#if]
@@ -87,7 +87,12 @@ extern ${variable.value} ${variable.name};
     #undef  NO_STM32_CRYPTO
     #define STM32_HAL_V2
     #define HAL_CONSOLE_UART huart2
-    #define STM32_AESGCM_PARTIAL /* allow partial blocks and add auth info (header) */
+#elif defined(STM32F756xx)
+    #define WOLFSSL_STM32F7
+    #undef  NO_STM32_HASH
+    #undef  NO_STM32_CRYPTO
+    #define STM32_HAL_V2
+    #define HAL_CONSOLE_UART huart3
 #elif defined(STM32H753xx)
     #define WOLFSSL_STM32H7
     #undef  NO_STM32_HASH
@@ -144,7 +149,7 @@ extern ${variable.value} ${variable.name};
     #warning Please define a hardware platform!
     /* This means there is not a pre-defined platform for your board/CPU */
     /* You need to define a CPU type, HW crypto and debug UART */
-    /* CPU Type: WOLFSSL_STM32F1, WOLFSSL_STM32F2, WOLFSSL_STM32F4, 
+    /* CPU Type: WOLFSSL_STM32F1, WOLFSSL_STM32F2, WOLFSSL_STM32F4,
         WOLFSSL_STM32F7, WOLFSSL_STM32H7, WOLFSSL_STM32L4, WOLFSSL_STM32L5,
         WOLFSSL_STM32G0, WOLFSSL_STM32WB and WOLFSSL_STM32U5 */
     #define WOLFSSL_STM32F4

--- a/IDE/STM32Cube/default_conf.ftl
+++ b/IDE/STM32Cube/default_conf.ftl
@@ -197,16 +197,18 @@ extern ${variable.value} ${variable.name};
  * 6=Single Precision C all small
  * 7=Single Precision C all big
  */
-#if defined(WOLF_CONF_MATH) && WOLF_CONF_MATH != 2
-    /* fast (stack) math */
+#if defined(WOLF_CONF_MATH) && WOLF_CONF_MATH == 1
+    /* fast (stack) math - tfm.c */
     #define USE_FAST_MATH
     #define TFM_TIMING_RESISTANT
 
     /* Optimizations (TFM_ARM, TFM_ASM or none) */
     //#define TFM_NO_ASM
     //#define TFM_ASM
-#endif
-#if defined(WOLF_CONF_MATH) && (WOLF_CONF_MATH >= 3)
+#elif defined(WOLF_CONF_MATH) && WOLF_CONF_MATH == 2
+    /* heap math - integer.c */
+    #define USE_INTEGER_HEAP_MATH
+#elif defined(WOLF_CONF_MATH) && (WOLF_CONF_MATH >= 3)
     /* single precision only */
     #define WOLFSSL_SP
     #if WOLF_CONF_MATH != 7
@@ -405,7 +407,7 @@ extern ${variable.value} ${variable.name};
     #define HAVE_AES_DECRYPT
 #endif
 
-/* Other possible AES modes */    
+/* Other possible AES modes */
 //#define WOLFSSL_AES_COUNTER
 //#define HAVE_AESCCM
 //#define WOLFSSL_AES_XTS

--- a/IDE/STM32Cube/wolfssl_example.c
+++ b/IDE/STM32Cube/wolfssl_example.c
@@ -71,8 +71,8 @@
 #define MEM_BUFFER_SZ        (TEST_PACKET_SIZE + 38 + WC_MAX_DIGEST_SIZE)
 /* make sure memory buffer size is large enough */
 #if MEM_BUFFER_SZ < 2048
-	#undef  MEM_BUFFER_SZ
-	#define MEM_BUFFER_SZ 2048
+    #undef  MEM_BUFFER_SZ
+    #define MEM_BUFFER_SZ 2048
 #endif
 #define SHOW_VERBOSE         0 /* 0=tab del (minimal), 1=info, 2=debug, 3=debug w/wolf logs */
 #ifndef WOLFSSL_CIPHER_LIST_MAX_SIZE
@@ -126,9 +126,9 @@ extern UART_HandleTypeDef HAL_CONSOLE_UART;
  * Public types/enumerations/variables
  ****************************************************************************/
 typedef struct func_args {
-	int argc;
-	char** argv;
-	int return_code;
+    int argc;
+    char** argv;
+    int return_code;
 } func_args;
 
 const char menu1[] = "\n"
@@ -508,7 +508,7 @@ static void ShowPeer(WOLFSSL* ssl)
 static int ServerMemSend(info_t* info, char* buf, int sz)
 {
 #ifdef CMSIS_OS2_H_
-	osSemaphoreAcquire(info->client.mutex, osWaitForever);
+    osSemaphoreAcquire(info->client.mutex, osWaitForever);
 #else
     osSemaphoreWait(info->client.mutex, osWaitForever);
 #endif
@@ -560,13 +560,13 @@ static int ServerMemRecv(info_t* info, char* buf, int sz)
         osSemaphoreRelease(info->server.mutex);
 #ifdef CMSIS_OS2_H_
         if (osThreadFlagsWait(1, osFlagsWaitAny, RECV_WAIT_TIMEOUT) == osFlagsErrorTimeout) {
-        	printf("Server Recv: Timeout!\n");
-        	return WOLFSSL_CBIO_ERR_TIMEOUT;
+            printf("Server Recv: Timeout!\n");
+            return WOLFSSL_CBIO_ERR_TIMEOUT;
         }
         osSemaphoreAcquire(info->server.mutex, osWaitForever);
 #else
         if (osSignalWait(1, RECV_WAIT_TIMEOUT).status == osEventTimeout) {
-        	printf("Server Recv: Timeout!\n");
+            printf("Server Recv: Timeout!\n");
             return WOLFSSL_CBIO_ERR_TIMEOUT;
         }
         osSemaphoreWait(info->server.mutex, osWaitForever);
@@ -656,14 +656,14 @@ static int ClientMemRecv(info_t* info, char* buf, int sz)
         osSemaphoreRelease(info->client.mutex);
 #ifdef CMSIS_OS2_H_
         if (osThreadFlagsWait(1, osFlagsWaitAny, RECV_WAIT_TIMEOUT) == osFlagsErrorTimeout) {
-        	printf("Client Recv: Timeout!\n");
-        	return WOLFSSL_CBIO_ERR_TIMEOUT;
+            printf("Client Recv: Timeout!\n");
+            return WOLFSSL_CBIO_ERR_TIMEOUT;
         }
         osSemaphoreAcquire(info->client.mutex, osWaitForever);
 #else
         if (osSignalWait(1, RECV_WAIT_TIMEOUT).status == osEventTimeout) {
-        	printf("Client Recv: Timeout!\n");
-        	return WOLFSSL_CBIO_ERR_TIMEOUT;
+            printf("Client Recv: Timeout!\n");
+            return WOLFSSL_CBIO_ERR_TIMEOUT;
         }
         osSemaphoreWait(info->client.mutex, osWaitForever);
 #endif
@@ -738,29 +738,29 @@ static int bench_tls_client(info_t* info)
     /* set up client */
 #ifdef WOLFSSL_TLS13
     if (tls13) {
-	#ifdef WOLFSSL_STATIC_MEMORY
-    	ret = wolfSSL_CTX_load_static_memory(&cli_ctx, wolfTLSv1_3_client_method_ex,
+    #ifdef WOLFSSL_STATIC_MEMORY
+        ret = wolfSSL_CTX_load_static_memory(&cli_ctx, wolfTLSv1_3_client_method_ex,
             gWolfCTXCli, sizeof(gWolfCTXCli), WOLFMEM_GENERAL , 10);
-	#else
+    #else
         cli_ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method());
-	#endif
+    #endif
     }
 #endif
     if (!tls13) {
 #if !defined(WOLFSSL_TLS13)
-	#ifdef WOLFSSL_STATIC_MEMORY
-    	ret = wolfSSL_CTX_load_static_memory(&cli_ctx, wolfSSLv23_client_method_ex,
+    #ifdef WOLFSSL_STATIC_MEMORY
+        ret = wolfSSL_CTX_load_static_memory(&cli_ctx, wolfSSLv23_client_method_ex,
             gWolfCTXCli, sizeof(gWolfCTXCli), WOLFMEM_GENERAL , 10);
-	#else
+    #else
         cli_ctx = wolfSSL_CTX_new(wolfSSLv23_client_method());
-	#endif
+    #endif
 #elif !defined(WOLFSSL_NO_TLS12)
-	#ifdef WOLFSSL_STATIC_MEMORY
+    #ifdef WOLFSSL_STATIC_MEMORY
         ret = wolfSSL_CTX_load_static_memory(&cli_ctx, wolfTLSv1_2_client_method_ex,
             gWolfCTXCli, sizeof(gWolfCTXCli), WOLFMEM_GENERAL , 10);
-	#else
+    #else
         cli_ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method());
-	#endif
+    #endif
 #endif
     }
 
@@ -949,7 +949,7 @@ static int bench_tls_client(info_t* info)
 exit:
 
     if (ret != 0 && ret != WOLFSSL_SUCCESS) {
-    	info->doShutdown = 1;
+        info->doShutdown = 1;
         printf("Client Error: %d (%s)\n", ret,
             wolfSSL_ERR_reason_error_string(ret));
     }
@@ -986,7 +986,7 @@ static void client_thread(const void* args)
 #ifdef CMSIS_OS2_H_
             osThreadFlagsSet(info->server.threadId, 1);
 #else
-        	osSignalSet(info->server.threadId, 1);
+            osSignalSet(info->server.threadId, 1);
 #endif
         }
         info->client.ret = ret;
@@ -1014,29 +1014,29 @@ static int bench_tls_server(info_t* info)
     /* set up server */
 #ifdef WOLFSSL_TLS13
     if (tls13) {
-	#ifdef WOLFSSL_STATIC_MEMORY
-    	ret = wolfSSL_CTX_load_static_memory(&srv_ctx, wolfTLSv1_3_server_method_ex,
+    #ifdef WOLFSSL_STATIC_MEMORY
+        ret = wolfSSL_CTX_load_static_memory(&srv_ctx, wolfTLSv1_3_server_method_ex,
             gWolfCTXSrv, sizeof(gWolfCTXSrv), WOLFMEM_GENERAL , 10);
-	#else
-    	srv_ctx = wolfSSL_CTX_new(wolfTLSv1_3_server_method());
-	#endif
+    #else
+        srv_ctx = wolfSSL_CTX_new(wolfTLSv1_3_server_method());
+    #endif
     }
 #endif
     if (!tls13) {
 #if !defined(WOLFSSL_TLS13)
-	#ifdef WOLFSSL_STATIC_MEMORY
-    	ret = wolfSSL_CTX_load_static_memory(&srv_ctx, wolfSSLv23_server_method_ex,
+    #ifdef WOLFSSL_STATIC_MEMORY
+        ret = wolfSSL_CTX_load_static_memory(&srv_ctx, wolfSSLv23_server_method_ex,
             gWolfCTXSrv, sizeof(gWolfCTXSrv), WOLFMEM_GENERAL , 10);
-	#else
-    	srv_ctx = wolfSSL_CTX_new(wolfSSLv23_server_method());
-	#endif
+    #else
+        srv_ctx = wolfSSL_CTX_new(wolfSSLv23_server_method());
+    #endif
 #elif !defined(WOLFSSL_NO_TLS12)
-	#ifdef WOLFSSL_STATIC_MEMORY
+    #ifdef WOLFSSL_STATIC_MEMORY
         ret = wolfSSL_CTX_load_static_memory(&srv_ctx, wolfTLSv1_2_server_method_ex,
             gWolfCTXSrv, sizeof(gWolfCTXSrv), WOLFMEM_GENERAL , 10);
-	#else
+    #else
         srv_ctx = wolfSSL_CTX_new(wolfTLSv1_2_server_method());
-	#endif
+    #endif
 #endif
     }
 
@@ -1225,7 +1225,7 @@ static int bench_tls_server(info_t* info)
 exit:
 
     if (ret != 0 && ret != WOLFSSL_SUCCESS) {
-    	info->doShutdown = 1;
+        info->doShutdown = 1;
         printf("Server Error: %d (%s)\n", ret,
             wolfSSL_ERR_reason_error_string(ret));
     }
@@ -1259,7 +1259,7 @@ static void server_thread(const void* args)
         /* signal client */
         if (!info->client.done && info->client.threadId != 0) {
 #ifdef CMSIS_OS2_H_
-        	osThreadFlagsSet(info->client.threadId, 1);
+            osThreadFlagsSet(info->client.threadId, 1);
 #else
             osSignalSet(info->client.threadId, 1);
 #endif
@@ -1813,23 +1813,23 @@ done:
 extern RTC_HandleTypeDef hrtc;
 double current_time(void)
 {
-	RTC_TimeTypeDef time;
-	RTC_DateTypeDef date;
-	uint32_t subsec = 0;
+    RTC_TimeTypeDef time;
+    RTC_DateTypeDef date;
+    uint32_t subsec = 0;
 
-	/* must get time and date here due to STM32 HW bug */
-	HAL_RTC_GetTime(&hrtc, &time, FORMAT_BIN);
-	HAL_RTC_GetDate(&hrtc, &date, FORMAT_BIN);
-	/* Not all STM32 RTCs have subseconds in the struct */
+    /* must get time and date here due to STM32 HW bug */
+    HAL_RTC_GetTime(&hrtc, &time, FORMAT_BIN);
+    HAL_RTC_GetDate(&hrtc, &date, FORMAT_BIN);
+    /* Not all STM32 RTCs have subseconds in the struct */
 #ifdef RTC_ALARMSUBSECONDMASK_ALL
-	subsec = (255 - time.SubSeconds) * 1000 / 255;
+    subsec = (255 - time.SubSeconds) * 1000 / 255;
 #endif
 
-	(void) date;
+    (void) date;
 
-	/* return seconds.milliseconds */
-	return ((double) time.Hours * 24) + ((double) time.Minutes * 60)
-			+ (double) time.Seconds + ((double) subsec / 1000);
+    /* return seconds.milliseconds */
+    return ((double) time.Hours * 24) + ((double) time.Minutes * 60)
+            + (double) time.Seconds + ((double) subsec / 1000);
 }
 #endif /* HAL_RTC_MODULE_ENABLED */
 
@@ -1840,8 +1840,8 @@ void wolfCryptDemo(const void* argument)
 #endif
 {
     HAL_StatusTypeDef halRet;
-	uint8_t buffer[2];
-	func_args args;
+    uint8_t buffer[2];
+    func_args args;
 
 #if 0
     wolfSSL_Debugging_ON();
@@ -1857,46 +1857,46 @@ void wolfCryptDemo(const void* argument)
 #ifdef WOLFSSL_STATIC_MEMORY
     if (wc_LoadStaticMemory(&HEAP_HINT, gWolfMem, sizeof(gWolfMem),
             WOLFMEM_GENERAL, 10) != 0) {
-    	printf("unable to load static memory");
+        printf("unable to load static memory");
     }
 #endif
 
     //wolfSSL_SetAllocators(wolfMallocCb, wolfFreeCb, wolfReallocCb);
 
-	while (1) {
+    while (1) {
         memset(&args, 0, sizeof(args));
         args.return_code = NOT_COMPILED_IN; /* default */
 
-		printf("\n\t\t\t\tMENU\n");
-		printf(menu1);
-		printf("Please select one of the above options:\n");
+        printf("\n\t\t\t\tMENU\n");
+        printf(menu1);
+        printf("Please select one of the above options:\n");
 
         do {
-    		halRet = HAL_UART_Receive(&HAL_CONSOLE_UART, buffer, sizeof(buffer), 100);
+            halRet = HAL_UART_Receive(&HAL_CONSOLE_UART, buffer, sizeof(buffer), 100);
         } while (halRet != HAL_OK || buffer[0] == '\n' || buffer[0] == '\r');
 
-		switch (buffer[0]) {
-		case 't':
-			printf("Running wolfCrypt Tests...\n");
+        switch (buffer[0]) {
+        case 't':
+            printf("Running wolfCrypt Tests...\n");
         #ifndef NO_CRYPT_TEST
-			args.return_code = 0;
-			wolfcrypt_test(&args);
+            args.return_code = 0;
+            wolfcrypt_test(&args);
         #else
             args.return_code = NOT_COMPILED_IN;
         #endif
-			printf("Crypt Test: Return code %d\n", args.return_code);
-			break;
+            printf("Crypt Test: Return code %d\n", args.return_code);
+            break;
 
-		case 'b':
-			printf("Running wolfCrypt Benchmarks...\n");
+        case 'b':
+            printf("Running wolfCrypt Benchmarks...\n");
         #ifndef NO_CRYPT_BENCHMARK
-			args.return_code = 0;
-			benchmark_test(&args);
+            args.return_code = 0;
+            benchmark_test(&args);
         #else
             args.return_code = NOT_COMPILED_IN;
         #endif
-			printf("Benchmark Test: Return code %d\n", args.return_code);
-			break;
+            printf("Benchmark Test: Return code %d\n", args.return_code);
+            break;
 
         case 'l':
             printf("Running TLS Benchmarks...\n");
@@ -1936,14 +1936,14 @@ void wolfCryptDemo(const void* argument)
             printf("TLS 1.3 Client: Return code %d\n", args.return_code);
             break;
 #endif /* ENABLE_TLS_UART */
-			/* All other cases go here */
-		default:
-			printf("\nSelection out of range\n");
-			break;
-		}
+            /* All other cases go here */
+        default:
+            printf("\nSelection out of range\n");
+            break;
+        }
 
         PrintMemStats();
-	}
+    }
 
 #ifdef WOLFCRYPT_ONLY
     wolfCrypt_Cleanup();

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -7419,9 +7419,8 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
 #ifdef STM32_CRYPTO_AES_GCM
 
 /* this function supports inline encrypt */
-/* define STM32_AESGCM_PARTIAL for newer STM Cube HAL's with workaround
-   for handling partial packets to improve auth tag calculation performance by
-   using hardware */
+/* define STM32_AESGCM_PARTIAL for STM HW that does not support authentication
+ * on byte multiples (see CRYP_HEADERWIDTHUNIT_BYTE) */
 static WARN_UNUSED_RESULT int wc_AesGcmEncrypt_STM32(
                                   Aes* aes, byte* out, const byte* in, word32 sz,
                                   const byte* iv, word32 ivSz,
@@ -7527,9 +7526,6 @@ static WARN_UNUSED_RESULT int wc_AesGcmEncrypt_STM32(
     hcryp.Init.HeaderSize = authInSz;
     #else
     hcryp.Init.HeaderSize = authPadSz/sizeof(word32);
-    #endif
-    #ifdef STM32_AESGCM_PARTIAL
-    hcryp.Init.HeaderPadSize = authPadSz - authInSz;
     #endif
     #ifdef CRYP_KEYIVCONFIG_ONCE
     /* allows repeated calls to HAL_CRYP_Encrypt */
@@ -8054,9 +8050,6 @@ static WARN_UNUSED_RESULT int wc_AesGcmDecrypt_STM32(
     hcryp.Init.HeaderSize = authInSz;
     #else
     hcryp.Init.HeaderSize = authPadSz/sizeof(word32);
-    #endif
-    #ifdef STM32_AESGCM_PARTIAL
-    hcryp.Init.HeaderPadSize = authPadSz - authInSz;
     #endif
     #ifdef CRYP_KEYIVCONFIG_ONCE
     /* allows repeated calls to HAL_CRYP_Decrypt */

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -8080,7 +8080,7 @@ static WARN_UNUSED_RESULT int wc_AesGcmDecrypt_STM32(
         XMEMSET(partialBlock, 0, sizeof(partialBlock));
         XMEMCPY(partialBlock, in + (blocks * AES_BLOCK_SIZE), partial);
         status = HAL_CRYP_Decrypt(&hcryp, (uint32_t*)partialBlock, partial,
-(           uint32_t*)partialBlock, STM32_HAL_TIMEOUT);
+            (uint32_t*)partialBlock, STM32_HAL_TIMEOUT);
         XMEMCPY(out + (blocks * AES_BLOCK_SIZE), partialBlock, partial);
     }
     #endif

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -1266,7 +1266,8 @@ static int wc_ecc_export_x963_compressed(ecc_key* key, byte* out, word32* outLen
 #if !defined(WOLFSSL_SP_MATH) && \
     !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
     !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_SILABS_SE_ACCEL) && \
-    !defined(WOLFSSL_SE050) && !defined(WOLF_CRYPTO_CB_ONLY_ECC)
+    !defined(WOLFSSL_SE050) && !defined(WOLF_CRYPTO_CB_ONLY_ECC) && \
+    !defined(WOLFSSL_STM32_PKA)
 static int ecc_check_pubkey_order(ecc_key* key, ecc_point* pubkey, mp_int* a,
     mp_int* prime, mp_int* order);
 #endif
@@ -9107,7 +9108,7 @@ int wc_ecc_export_x963_ex(ecc_key* key, byte* out, word32* outLen,
 
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
     !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_SE050) && \
-    !defined(WOLF_CRYPTO_CB_ONLY_ECC)
+    !defined(WOLF_CRYPTO_CB_ONLY_ECC) && !defined(WOLFSSL_STM32_PKA)
 
 /* is ecc point on curve described by dp ? */
 int wc_ecc_is_point(ecc_point* ecp, mp_int* a, mp_int* b, mp_int* prime)
@@ -9592,7 +9593,7 @@ static int _ecc_validate_public_key(ecc_key* key, int partial, int priv)
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
     !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_SILABS_SE_ACCEL) && \
     !defined(WOLFSSL_SE050) && !defined(WOLF_CRYPTO_CB_ONLY_ECC) && \
-    !defined(WOLF_CRYPTO_CB_ONLY_ECC)
+    !defined(WOLF_CRYPTO_CB_ONLY_ECC) && !defined(WOLFSSL_STM32_PKA)
     mp_int* b = NULL;
     #ifdef USE_ECC_B_PARAM
         DECLARE_CURVE_SPECS(4);
@@ -9642,7 +9643,7 @@ static int _ecc_validate_public_key(ecc_key* key, int partial, int priv)
 #if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
     defined(WOLFSSL_CRYPTOCELL) || defined(WOLFSSL_SILABS_SE_ACCEL) || \
     defined(WOLFSSL_SE050) || defined(WOLF_CRYPTO_CB_ONLY_ECC) || \
-    defined(WOLFSSL_XILINX_CRYPT_VERSAL)
+    defined(WOLFSSL_XILINX_CRYPT_VERSAL) || defined(WOLFSSL_STM32_PKA)
 
     /* consider key check success on HW crypto
      * ex: ATECC508/608A, CryptoCell and Silabs

--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -732,46 +732,48 @@ static int stm32_get_ecc_specs(const uint8_t **prime, const uint8_t **coef,
     const uint8_t **GenPointX, const uint8_t **GenPointY, const uint8_t **order,
     int size)
 {
-    switch(size) {
+    switch (size) {
+#ifdef ECC256
     case 32:
-        *prime = stm32_ecc256_prime;
-        *coef = stm32_ecc256_coef;
+        if (prime) *prime = stm32_ecc256_prime;
+        if (coef) *coef = stm32_ecc256_coef;
         if (coefB) *coefB = stm32_ecc256_coefB;
-        *GenPointX = stm32_ecc256_pointX;
-        *GenPointY = stm32_ecc256_pointY;
-        *coef_sign = &stm32_ecc256_coef_sign;
+        if (GenPointX) *GenPointX = stm32_ecc256_pointX;
+        if (GenPointY) *GenPointY = stm32_ecc256_pointY;
+        if (coef_sign) *coef_sign = &stm32_ecc256_coef_sign;
         if (order) *order = stm32_ecc256_order;
         break;
+#endif
 #ifdef ECC224
     case 28:
-        *prime = stm32_ecc224_prime;
-        *coef = stm32_ecc224_coef;
+        if (prime) *prime = stm32_ecc224_prime;
+        if (coef) *coef = stm32_ecc224_coef;
         if (coefB) *coefB = stm32_ecc224_coefB;
-        *GenPointX = stm32_ecc224_pointX;
-        *GenPointY = stm32_ecc224_pointY;
-        *coef_sign = &stm32_ecc224_coef;
+        if (GenPointX) *GenPointX = stm32_ecc224_pointX;
+        if (GenPointY) *GenPointY = stm32_ecc224_pointY;
+        if (coef_sign) *coef_sign = &stm32_ecc224_coef_sign;
         if (order) *order = stm32_ecc224_order;
         break;
 #endif
 #ifdef ECC192
     case 24:
-        *prime = stm32_ecc192_prime;
-        *coef = stm32_ecc192_coef;
+        if (prime) *prime = stm32_ecc192_prime;
+        if (coef) *coef = stm32_ecc192_coef;
         if (coefB) *coefB = stm32_ecc192_coefB;
-        *GenPointX = stm32_ecc192_pointX;
-        *GenPointY = stm32_ecc192_pointY;
-        *coef_sign = &stm32_ecc192_coef;
+        if (GenPointX) *GenPointX = stm32_ecc192_pointX;
+        if (GenPointY) *GenPointY = stm32_ecc192_pointY;
+        if (coef_sign) *coef_sign = &stm32_ecc192_coef_sign;
         if (order) *order = stm32_ecc192_order;
         break;
 #endif
 #ifdef ECC384
     case 48:
-        *prime = stm32_ecc384_prime;
-        *coef = stm32_ecc384_coef;
+        if (prime) *prime = stm32_ecc384_prime;
+        if (coef) *coef = stm32_ecc384_coef;
         if (coefB) *coefB = stm32_ecc384_coefB;
-        *GenPointX = stm32_ecc384_pointX;
-        *GenPointY = stm32_ecc384_pointY;
-        *coef_sign = &stm32_ecc384_coef;
+        if (GenPointX) *GenPointX = stm32_ecc384_pointX;
+        if (GenPointY) *GenPointY = stm32_ecc384_pointY;
+        if (coef_sign) *coef_sign = &stm32_ecc384_coef_sign;
         if (order) *order = stm32_ecc384_order;
         break;
 #endif
@@ -809,8 +811,7 @@ int wc_ecc_mulmod_ex(const mp_int *k, ecc_point *G, ecc_point *R, mp_int* a,
     uint8_t PtYbin[STM32_MAX_ECC_SIZE];
     const uint8_t *prime, *coef, *coefB, *gen_x, *gen_y, *order;
     const uint32_t *coef_sign;
-    (void)a;
-    (void)heap;
+
     XMEMSET(&pka_mul, 0x00, sizeof(PKA_ECCMulInTypeDef));
     XMEMSET(&pka_mul_res, 0x00, sizeof(PKA_ECCMulOutTypeDef));
     pka_mul_res.ptX = PtXbin;
@@ -845,7 +846,7 @@ int wc_ecc_mulmod_ex(const mp_int *k, ecc_point *G, ecc_point *R, mp_int* a,
     pka_mul.modulus = prime;
     pka_mul.pointX = Gxbin;
     pka_mul.pointY = Gybin;
-    pka_mul.scalarMulSize = size;
+    pka_mul.scalarMulSize = szkbin;
     pka_mul.scalarMul = kbin;
 #ifdef WOLFSSL_STM32_PKA_V2
     pka_mul.coefB = coefB;
@@ -857,6 +858,7 @@ int wc_ecc_mulmod_ex(const mp_int *k, ecc_point *G, ecc_point *R, mp_int* a,
 
     status = HAL_PKA_ECCMul(&hpka, &pka_mul, HAL_MAX_DELAY);
     if (status != HAL_OK) {
+        HAL_PKA_RAMReset(&hpka);
         return WC_HW_E;
     }
     pka_mul_res.ptX = Gxbin;
@@ -875,6 +877,10 @@ int wc_ecc_mulmod_ex(const mp_int *k, ecc_point *G, ecc_point *R, mp_int* a,
     if (res == MP_OKAY)
         res = mp_set(R->z, 1);
     HAL_PKA_RAMReset(&hpka);
+
+    (void)heap;
+    (void)a; /* uses computed (absolute value, |a| < p) */
+
     return res;
 }
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -10797,7 +10797,9 @@ WOLFSSL_TEST_SUBROUTINE int aesgcm_test(void)
     int  result = 0;
     int ret;
 #ifdef WOLFSSL_AES_256
+	#if !(defined(WOLF_CRYPTO_CB) && defined(HAVE_INTEL_QA_SYNC))
     int  alen;
+	#endif
     #if !defined(WOLFSSL_AFALG_XILINX_AES) && !defined(WOLFSSL_XILINX_CRYPT)
     int  plen;
     #endif

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -10797,9 +10797,9 @@ WOLFSSL_TEST_SUBROUTINE int aesgcm_test(void)
     int  result = 0;
     int ret;
 #ifdef WOLFSSL_AES_256
-	#if !(defined(WOLF_CRYPTO_CB) && defined(HAVE_INTEL_QA_SYNC))
+    #if !(defined(WOLF_CRYPTO_CB) && defined(HAVE_INTEL_QA_SYNC))
     int  alen;
-	#endif
+    #endif
     #if !defined(WOLFSSL_AFALG_XILINX_AES) && !defined(WOLFSSL_XILINX_CRYPT)
     int  plen;
     #endif


### PR DESCRIPTION
# Description

* Fix for STM32 PKA with `coefSign` for non 256-bit curves. Don't check point for STM PKA.
* Improvements for AES GCM on STM32.
* Cleanups for STM32 example.

Fixes ZD14928

# Testing

STM32U5 and STM32F7

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
