### PR TITLE
Add SECP384 and SECP521 to bench

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -2377,6 +2377,10 @@ static void* benchmarks_do(void* args)
         else {
             #ifndef NO_ECC256
             bench_ecc_curve((int)ECC_SECP256R1);
+            #elif HAVE_ECC384
+            bench_ecc_curve((int)ECC_SECP384R1);
+            #elif HAVE_ECC521
+            bench_ecc_curve((int)ECC_SECP521R1);
             #endif
             #ifdef HAVE_ECC_BRAINPOOL
             bench_ecc_curve((int)ECC_BRAINPOOLP256R1);


### PR DESCRIPTION
# Description

Add spec384 and spec521 to benchmark for embedded (no args)

Fixes zd#

# Testing

Tested on Aurix platform via benchmark

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
