### PR TITLE
rpmbuild: update with fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,15 @@ LT_INIT([disable-static win32-dll])
 
 AC_ARG_VAR(EXTRA_CFLAGS, [Extra CFLAGS to add to autoconf-computed arg list.  Can also supply directly to make.])
 
-#shared library versioning
+WOLFSSL_CONFIG_ARGS=$ac_configure_args
+AC_SUBST([WOLFSSL_CONFIG_ARGS])
+
+# shared library versioning
+# The three numbers in the libwolfssl.so.*.*.* file name. Unfortunately
+# these numbers don't always line up nicely with the library version.
+WOLFSSL_LIBRARY_VERSION_FIRST=35
+WOLFSSL_LIBRARY_VERSION_SECOND=1
+WOLFSSL_LIBRARY_VERSION_THIRD=0
 WOLFSSL_LIBRARY_VERSION=36:0:1
 #                        | | |
 #                 +------+ | +---+
@@ -50,6 +58,9 @@ WOLFSSL_LIBRARY_VERSION=36:0:1
 #                 |        +- increment if source code has changed
 #                 |           set to zero if current is incremented
 #                 +- increment if interfaces have been added, removed or changed
+AC_SUBST([WOLFSSL_LIBRARY_VERSION_FIRST])
+AC_SUBST([WOLFSSL_LIBRARY_VERSION_SECOND])
+AC_SUBST([WOLFSSL_LIBRARY_VERSION_THIRD])
 AC_SUBST([WOLFSSL_LIBRARY_VERSION])
 
 gl_VISIBILITY
@@ -8184,6 +8195,7 @@ AM_CONDITIONAL([BUILD_RC4],[test "x$ENABLED_ARC4" = "xyes" || test "x$ENABLED_US
 AM_CONDITIONAL([BUILD_MD5],[test "x$ENABLED_MD5" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_SHA],[test "x$ENABLED_SHA" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_FIPS],[test "x$ENABLED_FIPS" = "xyes"])
+AC_SUBST([ENABLED_FIPS])
 AM_CONDITIONAL([BUILD_FIPS_V1],[test "$HAVE_FIPS_VERSION" = 1])
 AM_CONDITIONAL([BUILD_FIPS_V2],[test "$HAVE_FIPS_VERSION" = 2 && test "$HAVE_FIPS_VERSION_MINOR" = 0])
 AM_CONDITIONAL([BUILD_FIPS_RAND],[test "$HAVE_FIPS_VERSION" = 2 && test "$HAVE_FIPS_VERSION_MINOR" = 1])
@@ -8231,6 +8243,7 @@ AM_CONDITIONAL([BUILD_CAVIUM_V],[test "x$ENABLED_CAVIUM_V" = "xyes"])
 AM_CONDITIONAL([BUILD_OCTEON_SYNC],[test "x$ENABLED_OCTEON_SYNC" = "xyes"])
 AM_CONDITIONAL([BUILD_INTEL_QA],[test "x$ENABLED_INTEL_QA" = "xyes"])
 AM_CONDITIONAL([BUILD_INTEL_QA_SYNC],[test "x$ENABLED_INTEL_QA_SYNC" = "xyes"])
+INCLUDE_SP_INT="no"
 AM_CONDITIONAL([BUILD_SP],[test "x$ENABLED_SP" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_SP_C32],[ ( ( (test "$ENABLED_SP_RSA" = "yes" || test "$ENABLED_SP_DH" = "yes" \
                                || test "$ENABLED_SP_ECC" = "yes") && test "x$ENABLED_SP_ASM" = "xno") \
@@ -8244,6 +8257,9 @@ AM_CONDITIONAL([BUILD_SP_ARM_THUMB],[test "x$ENABLED_SP_ARM_THUMB_ASM" = "xyes" 
 AM_CONDITIONAL([BUILD_SP_ARM_CORTEX],[test "x$ENABLED_SP_ARM_CORTEX_ASM" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_SP_X86_64],[test "x$ENABLED_SP_X86_64_ASM" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_SP_INT],[test "x$ENABLED_SP_MATH" = "xyes" || test "x$ENABLED_SP_MATH_ALL" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
+AM_COND_IF([BUILD_SP], [INCLUDE_SP_INT="yes"])
+AM_COND_IF([BUILD_SP_INT], [INCLUDE_SP_INT="yes"])
+AC_SUBST([INCLUDE_SP_INT])
 AM_CONDITIONAL([BUILD_FAST_RSA],[test "x$ENABLED_FAST_RSA" = "xyes"])
 AM_CONDITIONAL([BUILD_MCAPI],[test "x$ENABLED_MCAPI" = "xyes"])
 AM_CONDITIONAL([BUILD_ASYNCCRYPT],[test "x$ENABLED_ASYNCCRYPT" = "xyes"])

--- a/rpm/include.am
+++ b/rpm/include.am
@@ -2,21 +2,13 @@
 
 rpm-build: rpm/spec dist
 	@rm -f *.rpm
-	@rm -f ~/rpmbuild/RPMS/x86_64/$(PACKAGE)-$(VERSION)*.rpm
-	@rm -f ~/rpmbuild/SRPMS/$(PACKAGE)-$(VERSION)*.rpm
-	@mkdir -p ~/rpmbuild/BUILD/
-	@mkdir -p ~/rpmbuild/RPMS/i386/
-	@mkdir -p ~/rpmbuild/RPMS/i686/
-	@mkdir -p ~/rpmbuild/RPMS/noarch/
-	@mkdir -p ~/rpmbuild/RPMS/x86_64/
-	@mkdir -p ~/rpmbuild/SOURCES/
-	@mkdir -p ~/rpmbuild/SPECS/
-	@mkdir -p ~/rpmbuild/SRPMS/
+	rpmdev-setuptree
+	find ~/rpmbuild/RPMS ~/rpmbuild/SRPMS -name "$(PACKAGE)-$(VERSION)*.rpm" | xargs rm -f
 	@cp $(PACKAGE)-$(VERSION).tar.gz ~/rpmbuild/SOURCES/
 	@rpmbuild -ba --clean rpm/spec
-	@cp ~/rpmbuild/RPMS/x86_64/$(PACKAGE)-$(VERSION)*.rpm .
-	@cp ~/rpmbuild/RPMS/x86_64/$(PACKAGE)-devel-$(VERSION)*.rpm .
-	@cp ~/rpmbuild/RPMS/x86_64/$(PACKAGE)-debuginfo-$(VERSION)*.rpm .
+	@cp ~/rpmbuild/RPMS/*/$(PACKAGE)-$(VERSION)*.rpm .
+	@cp ~/rpmbuild/RPMS/*/$(PACKAGE)-devel-$(VERSION)*.rpm .
+	@cp ~/rpmbuild/RPMS/*/$(PACKAGE)-debuginfo-$(VERSION)*.rpm .
 	@cp ~/rpmbuild/SRPMS/$(PACKAGE)-$(VERSION)*.rpm .
 
 rpm-sign: rpm-build

--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -36,16 +36,21 @@ you will need to install %{name}-devel.
 %prep
 %setup -q
 
-%configure
-
-
 %build
+%configure @WOLFSSL_CONFIG_ARGS@
 %{__make} %{?_smp_mflags}
+if [ "@ENABLED_FIPS@" = "yes" ]
+then
+echo Updating wolfSSL FIPS hash
+./fips-hash.sh
+%{__make} %{?_smp_mflags}
+fi
 
 %install
 %{__rm} -rf %{buildroot}
 %{__make} install  DESTDIR="%{buildroot}" AM_INSTALL_PROGRAM_FLAGS=""
 mkdir -p $RPM_BUILD_ROOT/
+%{__rm} -f %{buildroot}/%{_libdir}/libwolfssl.la
 
 %check
 
@@ -73,10 +78,9 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_docdir}/wolfssl/README.txt
 %{_docdir}/wolfssl/QUIC.md
 
-%{_libdir}/libwolfssl.la
 %{_libdir}/libwolfssl.so
-%{_libdir}/libwolfssl.so.35
-%{_libdir}/libwolfssl.so.35.1.0
+%{_libdir}/libwolfssl.so.@WOLFSSL_LIBRARY_VERSION_FIRST@
+%{_libdir}/libwolfssl.so.@WOLFSSL_LIBRARY_VERSION_FIRST@.@WOLFSSL_LIBRARY_VERSION_SECOND@.@WOLFSSL_LIBRARY_VERSION_THIRD@
 
 %files devel
 %defattr(-,root,root,-)
@@ -306,7 +310,9 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_includedir}/wolfssl/wolfcrypt/sha512.h
 %{_includedir}/wolfssl/wolfcrypt/siphash.h
 %{_includedir}/wolfssl/wolfcrypt/signature.h
+%if "@INCLUDE_SP_INT@" != "no"
 %{_includedir}/wolfssl/wolfcrypt/sp_int.h
+%endif
 %{_includedir}/wolfssl/wolfcrypt/srp.h
 %{_includedir}/wolfssl/wolfcrypt/tfm.h
 %{_includedir}/wolfssl/wolfcrypt/types.h
@@ -318,8 +324,13 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_includedir}/wolfssl/wolfcrypt/wolfmath.h
 %{_includedir}/wolfssl/wolfio.h
 %{_libdir}/pkgconfig/wolfssl.pc
+%if "@ENABLED_FIPS@" != "no"
+%{_includedir}/wolfssl/wolfcrypt/fips.h
+%endif
 
 %changelog
+* Mon Oct 17 2022 Juliusz Sosinowicz <juliusz@wolfssl.com>
+- Updates for building FIPS packages and general maintenance
 * Tue Sep 27 2022 Jacob Barthelmeh <jacob@wolfssl.com>
 - Add include of kyber headers
 * Tue Aug 30 2022 Jacob Barthelmeh <jacob@wolfssl.com>


### PR DESCRIPTION
- Pass in the build configuration to the output rpm package
- Compiler test fails in %configure step in %prep due to missing linker script (injected by rpmbuild). Moving to %build section.
- .la files not wanted in rpm package and delete .la file after install step
- Compiler test fails due to missing linker script (injected by rpmbuild)
https://fedoraproject.org/wiki/Changes/RemoveLaFiles#Upgrade.2Fcompatibility_impact
- Conditional include sp_int.h
- FIPS header and hash update