### PR TITLE
Nucleus Thread Types

### DIFF
--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1247,6 +1247,10 @@ typedef struct w64wrapper {
         typedef unsigned int  THREAD_RETURN;
         typedef int           THREAD_TYPE;
         #define WOLFSSL_THREAD
+    #elif defined(WOLFSSL_NUCLEUS)
+        typedef unsigned int  THREAD_RETURN;
+        typedef intptr_t      THREAD_TYPE;
+        #define WOLFSSL_THREAD
     #elif defined(WOLFSSL_TIRTOS)
         typedef void          THREAD_RETURN;
         typedef Task_Handle   THREAD_TYPE;


### PR DESCRIPTION
# Description

Add a type block for Nucleus RTOS's thread types. These came from wolfSSH.

# Testing

    % ./configure CFLAGS=-DWOLFSSL_NUCLEUS && make examples/echoserver/echoserver.o

I added an `#error` preprocessor directive to the new case, and the code was included into the build.