### PR TITLE
Fix X509 subject and issuer name_hash mismatch

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -2993,7 +2993,8 @@ char* wolfSSL_X509_NAME_oneline(WOLFSSL_X509_NAME* name, char* in, int sz)
 /* Given an X509_NAME, convert it to canonical form and then hash
  * with the provided hash type. Returns the first 4 bytes of the hash
  * as unsigned long on success, and 0 otherwise. */
-static unsigned long X509NameHash(WOLFSSL_X509_NAME* name, int hashType)
+static unsigned long X509NameHash(WOLFSSL_X509_NAME* name,
+    enum wc_HashType hashType)
 {
     unsigned long  hash = 0;
     unsigned char* canonName = NULL;
@@ -3001,7 +3002,7 @@ static unsigned long X509NameHash(WOLFSSL_X509_NAME* name, int hashType)
     int            size = 0;
     int            rc;
 
-    WOLFSSL_ENTER("wolfSSL_X509_name_sha256hash");
+    WOLFSSL_ENTER("X509NameHash");
 
     if (name == NULL) {
         WOLFSSL_ERROR_MSG("WOLFSSL_X509_NAME pointer was NULL");

--- a/src/x509.c
+++ b/src/x509.c
@@ -4781,96 +4781,98 @@ WOLFSSL_X509_NAME* wolfSSL_X509_get_subject_name(WOLFSSL_X509* cert)
 */
 unsigned long wolfSSL_X509_subject_name_hash(const WOLFSSL_X509* x509)
 {
-    unsigned long ret = 0;
-    WOLFSSL_X509_NAME *subjectName = NULL;
-    unsigned char* canonName = NULL;
-    byte digest[WC_MAX_DIGEST_SIZE];
-    int size = 0;
+    unsigned long      hash = 0;
+    WOLFSSL_X509_NAME* subjectName = NULL;
+    unsigned char*     canonName = NULL;
+    byte               digest[WC_MAX_DIGEST_SIZE];
+    int                size = 0;
 
     if (x509 == NULL) {
-        return ret;
+        return 0;
     }
 
     subjectName = wolfSSL_X509_get_subject_name((WOLFSSL_X509*)x509);
 
     if (subjectName == NULL) {
-        return ret;
+        WOLFSSL_MSG("wolfSSL_X509_get_subject_name error");
+        return 0;
     }
 
     size = wolfSSL_i2d_X509_NAME_canon(subjectName, &canonName);
 
-    if (size <= 0){
+    if (size <= 0 || canonName == NULL){
         WOLFSSL_MSG("wolfSSL_i2d_X509_NAME_canon error");
-        return ret;
+        return 0;
     }
 
     #ifndef NO_SHA
     if (wc_ShaHash((const byte*)canonName, (word32)size, digest) != 0) {
         WOLFSSL_MSG("wc_ShaHash error");
-        return ret;
+        return 0;
     }
     #elif !defined(NO_SHA256)
     if (wc_Sha256Hash((const byte*)canonName, (word32)size, digest) != 0) {
         WOLFSSL_MSG("wc_Sha256Hash error");
-        return ret;
+        return 0;
     }
     #endif
 
-    ret  =  (unsigned long) digest[0];
-    ret |= ((unsigned long) digest[1]) << 8;
-    ret |= ((unsigned long) digest[2]) << 16;
-    ret |= ((unsigned long) digest[3]) << 24;
+    hash  =  (unsigned long) digest[0];
+    hash |= ((unsigned long) digest[1]) << 8;
+    hash |= ((unsigned long) digest[2]) << 16;
+    hash |= ((unsigned long) digest[3]) << 24;
 
     XFREE(canonName, NULL, DYNAMIC_TYPE_OPENSSL);
 
-    return ret;
+    return hash;
 }
 
 unsigned long wolfSSL_X509_issuer_name_hash(const WOLFSSL_X509* x509)
 {
-    unsigned long ret = 0;
-    WOLFSSL_X509_NAME *issuerName = NULL;
-    unsigned char* canonName = NULL;
-    byte digest[WC_MAX_DIGEST_SIZE];
-    int size = 0;
+    unsigned long      hash = 0;
+    WOLFSSL_X509_NAME* issuerName = NULL;
+    unsigned char*     canonName = NULL;
+    byte               digest[WC_MAX_DIGEST_SIZE];
+    int                size = 0;
 
     if (x509 == NULL) {
-        return ret;
+        return 0;
     }
 
     issuerName = wolfSSL_X509_get_issuer_name((WOLFSSL_X509*)x509);
 
     if (issuerName == NULL) {
-        return ret;
+        WOLFSSL_MSG("wolfSSL_X509_get_issuer_name error");
+        return 0;
     }
 
     size = wolfSSL_i2d_X509_NAME_canon(issuerName, &canonName);
 
-    if (size <= 0){
+    if (size <= 0 || canonName == NULL){
         WOLFSSL_MSG("wolfSSL_i2d_X509_NAME_canon error");
-        return ret;
+        return 0;
     }
 
     #ifndef NO_SHA
     if (wc_ShaHash((const byte*)canonName, (word32)size, digest) != 0) {
         WOLFSSL_MSG("wc_ShaHash error");
-        return ret;
+        return 0;
     }
     #elif !defined(NO_SHA256)
     if (wc_Sha256Hash((const byte*)canonName, (word32)size, digest) != 0) {
         WOLFSSL_MSG("wc_ShaHash error");
-        return ret;
+        return 0;
     }
     #endif
 
-    ret  =  (unsigned long) digest[0];
-    ret |= ((unsigned long) digest[1]) << 8;
-    ret |= ((unsigned long) digest[2]) << 16;
-    ret |= ((unsigned long) digest[3]) << 24;
+    hash  =  (unsigned long) digest[0];
+    hash |= ((unsigned long) digest[1]) << 8;
+    hash |= ((unsigned long) digest[2]) << 16;
+    hash |= ((unsigned long) digest[3]) << 24;
 
     XFREE(canonName, NULL, DYNAMIC_TYPE_OPENSSL);
 
-    return ret;
+    return hash;
 }
 #endif /* OPENSSL_EXTRA && (!NO_SHA || !NO_SHA256) */
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -31406,11 +31406,13 @@ static int test_wolfSSL_X509_subject_name_hash(void)
     ret1 = X509_subject_name_hash(x509);
     AssertIntNE(ret1, 0);
 
+#if !defined(NO_SHA)
     ret2 = X509_NAME_hash(X509_get_subject_name(x509));
     AssertIntNE(ret2, 0);
 
-#if !defined(NO_SHA)
     AssertIntEQ(ret1, ret2);
+#else
+    (void) ret2;
 #endif
 
     X509_free(x509);
@@ -31443,11 +31445,13 @@ static int test_wolfSSL_X509_issuer_name_hash(void)
     ret1 = X509_issuer_name_hash(x509);
     AssertIntNE(ret1, 0);
 
+#if !defined(NO_SHA)
     ret2 = X509_NAME_hash(X509_get_issuer_name(x509));
     AssertIntNE(ret2, 0);
 
-#if !defined(NO_SHA)
     AssertIntEQ(ret1, ret2);
+#else
+    (void) ret2;
 #endif
 
     X509_free(x509);

--- a/tests/api.c
+++ b/tests/api.c
@@ -31387,25 +31387,36 @@ static int test_wolfSSL_X509_subject_name_hash(void)
 {
 #if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && !defined(NO_FILESYSTEM) \
     && !defined(NO_RSA) && (!defined(NO_SHA) || !defined(NO_SHA256))
-
     X509* x509;
     X509_NAME* subjectName = NULL;
-    unsigned long ret = 0;
+    unsigned long ret1 = 0;
+    unsigned long ret2 = 0;
 
     printf(testingFmt, "wolfSSL_X509_subject_name_hash()");
 
     AssertNotNull(x509 = wolfSSL_X509_load_certificate_file(cliCertFile,
                 SSL_FILETYPE_PEM));
-
     AssertNotNull(subjectName = wolfSSL_X509_get_subject_name(x509));
-    ret = X509_subject_name_hash(x509);
-    AssertIntNE(ret, 0);
+
+    /* These two
+     *   - X509_subject_name_hash(x509)
+     *   - X509_NAME_hash(X509_get_subject_name(x509))
+     *  should give the same hash, if !defined(NO_SHA) is true. */
+
+    ret1 = X509_subject_name_hash(x509);
+    AssertIntNE(ret1, 0);
+
+    ret2 = X509_NAME_hash(X509_get_subject_name(x509));
+    AssertIntNE(ret2, 0);
+
+#if !defined(NO_SHA)
+    AssertIntEQ(ret1, ret2);
+#endif
 
     X509_free(x509);
     printf(resultFmt, passed);
 
 #endif
-
     return 0;
 }
 
@@ -31413,25 +31424,36 @@ static int test_wolfSSL_X509_issuer_name_hash(void)
 {
 #if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && !defined(NO_FILESYSTEM) \
     && !defined(NO_RSA) && (!defined(NO_SHA) || !defined(NO_SHA256))
-
     X509* x509;
     X509_NAME* issuertName = NULL;
-    unsigned long ret = 0;
+    unsigned long ret1 = 0;
+    unsigned long ret2 = 0;
 
     printf(testingFmt, "wolfSSL_X509_issuer_name_hash()");
 
     AssertNotNull(x509 = wolfSSL_X509_load_certificate_file(cliCertFile,
                 SSL_FILETYPE_PEM));
-
     AssertNotNull(issuertName = wolfSSL_X509_get_issuer_name(x509));
-    ret = X509_issuer_name_hash(x509);
-    AssertIntNE(ret, 0);
+
+    /* These two
+     *   - X509_issuer_name_hash(x509)
+     *   - X509_NAME_hash(X509_get_issuer_name(x509))
+     *  should give the same hash, if !defined(NO_SHA) is true. */
+
+    ret1 = X509_issuer_name_hash(x509);
+    AssertIntNE(ret1, 0);
+
+    ret2 = X509_NAME_hash(X509_get_issuer_name(x509));
+    AssertIntNE(ret2, 0);
+
+#if !defined(NO_SHA)
+    AssertIntEQ(ret1, ret2);
+#endif
 
     X509_free(x509);
     printf(resultFmt, passed);
 
 #endif
-
     return 0;
 }
 


### PR DESCRIPTION
# Description

Update name hash functions `wolfSSL_X509_subject_name_hash` and  `wolfSSL_X509_issuer_name_hash` to hash the canonical form of subject / issuer name so they are consistent with OpenSSL API, and with these wolfSSL combinations
`wolfSSL_X509_NAME_hash(wolfSSL_X509_get_subject_name(x509))`
`wolfSSL_X509_NAME_hash(wolfSSL_X509_get_issuer_name(x509))`

Fixes zd#15040

# Testing

Updated API test functions `test_wolfSSL_X509_subject_name_hash` and `test_wolfSSL_X509_issuer_name_hash` to verify that `X509_X_name_hash(x509)` and `X509_NAME_hash(X509_get_X_name(x509))` return the same values when SHA-1 is enabled.

Also, tested with OpenSSL API to verify same values are obtained.
