### PR TITLE
20221025-fixes-wolfsentry-and-armv7a

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2191,7 +2191,7 @@ then
             # Include options.h
             AM_CCASFLAGS="$AM_CCASFLAGS -DEXTERNAL_OPTS_OPENVPN"
             ENABLED_ARMASM_CRYPTO=no
-	    ENABLED_AESGCM_STREAM=no # not yet implemented
+            ENABLED_AESGCM_STREAM=no # not yet implemented
             AC_MSG_NOTICE([32bit ARMv7-a found, setting mfpu to neon])
             ;;
         *)

--- a/tests/api.c
+++ b/tests/api.c
@@ -48490,15 +48490,12 @@ static int test_wolfSSL_d2i_OCSP_CERTID(void)
 
     /* The below tests should fail when passed bad parameters. NULL should
      * always be returned. */
-    certIdBad = (WOLFSSL_OCSP_CERTID*) 1;
     certIdBad = wolfSSL_d2i_OCSP_CERTID(NULL, &rawCertIdPtr, sizeof(rawCertId));
     AssertNull(certIdBad);
 
-    certIdBad = (WOLFSSL_OCSP_CERTID*) 1;
     certIdBad = wolfSSL_d2i_OCSP_CERTID(&certId, NULL, sizeof(rawCertId));
     AssertNull(certIdBad);
 
-    certIdBad = (WOLFSSL_OCSP_CERTID*) 1;
     certIdBad = wolfSSL_d2i_OCSP_CERTID(&certId, &rawCertIdPtr, 0);
     AssertNull(certIdBad);
 

--- a/wolfcrypt/src/port/arm/armv8-aes.c
+++ b/wolfcrypt/src/port/arm/armv8-aes.c
@@ -33,11 +33,12 @@
 #include <wolfssl/wolfcrypt/settings.h>
 
 #if !defined(NO_AES) && defined(WOLFSSL_ARMASM)
-#ifndef WOLFSSL_ARMASM_NO_HW_CRYPTO
 
-#ifdef HAVE_FIPS
-#undef HAVE_FIPS
+#if defined(HAVE_FIPS) && !defined(FIPS_NO_WRAPPERS)
+#define FIPS_NO_WRAPPERS
 #endif
+
+#ifndef WOLFSSL_ARMASM_NO_HW_CRYPTO
 
 #include <wolfssl/wolfcrypt/aes.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1585,7 +1585,8 @@ static int wolfsentry_setup(
 
 #if !defined(NO_FILESYSTEM) && !defined(WOLFSENTRY_NO_JSON)
     if (_wolfsentry_config_path != NULL) {
-        char buf[512], err_buf[512];
+        unsigned char buf[512];
+        char err_buf[512];
         struct wolfsentry_json_process_state *jps;
 
         FILE *f = fopen(_wolfsentry_config_path, "r");


### PR DESCRIPTION
wolfssl/test.h: add unsigned attribute to type of buffer passed to `wolfsentry_config_json_feed()` (sync with wolfssl/wolfsentry#25).

fix whitespace.

wolfcrypt/src/port/arm/armv8-aes.c: define `FIPS_NO_WRAPPERS`, rather than undefine `HAVE_FIPS`, to fix FIPS builds.
