### PR TITLE
20221026-fixes-QUIC-and-ALPN

### DIFF
--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -166,7 +166,7 @@ WOLFSSL_API void wolfSSL_Debugging_OFF(void);
     WOLFSSL_API void WOLFSSL_MSG_EX(const char* fmt, ...);
     #define HAVE_WOLFSSL_MSG_EX
 #else
-    #define WOLFSSL_MSG_EX(m, ...)
+    #define WOLFSSL_MSG_EX(...)
 #endif
     WOLFSSL_API void WOLFSSL_MSG(const char* msg);
     WOLFSSL_API void WOLFSSL_BUFFER(const byte* buffer, word32 length);
@@ -178,7 +178,7 @@ WOLFSSL_API void wolfSSL_Debugging_OFF(void);
     #define WOLFSSL_STUB(m)
     #define WOLFSSL_IS_DEBUG_ON() 0
 
-    #define WOLFSSL_MSG_EX(m, ...)    do{} while(0)
+    #define WOLFSSL_MSG_EX(...)    do{} while(0)
     #define WOLFSSL_MSG(m)            do{} while(0)
     #define WOLFSSL_BUFFER(b, l)      do{} while(0)
 


### PR DESCRIPTION
fixes for warnings and defects around QUIC and ALPN -- fixes for `clang-diagnostic-gnu-zero-variadic-macro-arguments`, `clang-analyzer-deadcode.DeadStores`, `clang-analyzer-core.UndefinedBinaryOperatorResult`, `clang-analyzer-security.insecureAPI.strcpy`, and an overrun prevention assert in `wolfSSL_ALPN_GetPeerProtocol()`.

tested with `wolfssl-multi-test.sh ... super-quick-check all-gcc-latest-c99-smallstack all-clang-sp-all-Os clang-tidy-asn-template-sp-all-small-stack all-WOLFSSL_CALLBACKS-clang-tidy clang-tidy-all-async-quic`
