### PR TITLE
SP int: guess 64-bit type

### DIFF
--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -146,6 +146,11 @@ extern "C" {
     #else
         #error "Size of unsigned long long not detected"
     #endif
+#elif SP_ULONG_BITS == 32
+    /* Speculatively use long long as the 64-bit type as we don't have one
+     * otherwise. */
+    typedef unsigned long long sp_uint64;
+    typedef          long long  sp_int64;
 #else
     #define SP_ULLONG_BITS    0
 #endif


### PR DESCRIPTION
# Description

When ULLONG_MAX not defined and long is the 32-bit type, speculatively use long long as the 64-bit type.

Fixes zd#15070

# Testing

x86 32-bit build and forced ULLONG_MAX to be undefined.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
