### PR TITLE
TLS performance fix: ForceZero minimization

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -3008,6 +3008,15 @@ int BuildTls13Message(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
                 output += args->headerSz;
                 ret = EncryptTls13(ssl, output, output, args->size, aad,
                                    (word16)args->headerSz, asyncOkay);
+                if (ret != 0) {
+                #ifdef WOLFSSL_ASYNC_CRYPT
+                    if (ret != WC_PENDING_E)
+                #endif
+                    {
+                        /* Zeroize plaintext. */
+                        ForceZero(output, args->size);
+                    }
+                }
 #ifdef WOLFSSL_DTLS13
                 if (ret == 0 && ssl->options.dtls) {
                     /* AAD points to the header. Reuse the variable  */

--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -1161,6 +1161,8 @@ static int GeneratePrivateDh186(DhKey* key, WC_RNG* rng, byte* priv,
     ForceZero(cBuf, cSz);
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     XFREE(cBuf, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+    wc_MemZero_Check(cBuf, cSz);
 #endif
 
     /* tmpQ: M = min(2^N,q) - 1 */

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -4687,7 +4687,7 @@ void sp_forcezero(sp_int* a)
 {
     if (a != NULL) {
         /* Ensure all data zeroized - data not zeroed when used decreases. */
-        ForceZero(a->dp, a->used * sizeof(sp_int_digit));
+        ForceZero(a->dp, a->size * sizeof(sp_int_digit));
         _sp_zero(a);
     #ifdef HAVE_WOLF_BIGINT
         wc_bigint_zero(&a->raw);


### PR DESCRIPTION
# Description

Don't ForceZero the output buffer before free.
ForceZero it when encryption fails.

ShrinkInputBuffer needs to zeroize input buffer even if not currently encrypting as it may be using the buffer on wolfSSL object reuse.

Fix SP to zeroize the whole buffer.

Fix DH to check cBuf when WOLFSSL_CHECK_MEM_ZERO defined.

# Testing

./configure '--disable-shared' 'CFLAGS=-DWOLFSSL_CHECK_MEM_ZERO'

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
