### PR TITLE
Regresssion testing fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7423,13 +7423,6 @@ esac
 # Update ENABLE_* variables                                                    #
 ################################################################################
 
-if test "x$ENABLED_LEANPSK" = "xyes" || test "x$ENABLED_CERTS" = "xno" || \
-   test "x$ENABLED_ASN" = "xno"
-then
-   ENABLED_CERTS=no
-   ENABLED_ASN=no
-fi
-
 if test "x$ENABLED_SYS_CA_CERTS" = "xyes"
 then
     if test "x$ENABLED_FILESYSTEM" = "xno"
@@ -7544,6 +7537,11 @@ then
     ENABLED_CERTS=yes
 fi
 
+if test "$ENABLED_ED25519" != "no" || test "$ENABLED_ED448" != "no"
+then
+    ENABLED_CERTS=yes
+fi
+
 if test "$ENABLED_MD5" = "yes"
 then
     # turn off MD5 if leanpsk or leantls on
@@ -7551,6 +7549,13 @@ then
     then
         ENABLED_MD5=no
     fi
+fi
+
+if test "x$ENABLED_LEANPSK" = "xyes" || test "x$ENABLED_CERTS" = "xno" || \
+   test "x$ENABLED_ASN" = "xno"
+then
+   ENABLED_CERTS=no
+   ENABLED_ASN=no
 fi
 
 ################################################################################

--- a/tests/api.c
+++ b/tests/api.c
@@ -1350,7 +1350,8 @@ static int test_wolfSSL_CTX_load_system_CA_certs(void)
 {
     int ret = 0;
 
-#if defined(WOLFSSL_SYS_CA_CERTS) && !defined(NO_WOLFSSL_CLIENT)
+#if defined(WOLFSSL_SYS_CA_CERTS) && !defined(NO_WOLFSSL_CLIENT) && \
+    (!defined(NO_RSA) || defined(HAVE_ECC))
     WOLFSSL_CTX* ctx;
     byte dirValid = 0;
 

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -8326,8 +8326,9 @@ static void print_alg(const char* str, int* line)
 /* Display the usage options of the benchmark program. */
 static void Usage(void)
 {
+    int e = 0;
 #ifndef WOLFSSL_BENCHMARK_ALL
-    int i, e = 0;
+    int i;
     int line;
 #endif
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -215,13 +215,15 @@ extern int wc_InitRsaHw(RsaKey* key);
 
 /* Calculates the minimum number of bytes required to encode the value.
  *
+ * Only support up to 2^24-1.
+ *
  * @param [in] value  Value to be encoded.
  * @return  Number of bytes to encode value.
  */
 static word32 BytePrecision(word32 value)
 {
     word32 i;
-    for (i = (word32)sizeof(value); i; --i)
+    for (i = (word32)sizeof(value) - 1; i; --i)
         if (value >> ((i - 1) * WOLFSSL_BIT_SIZE))
             break;
 


### PR DESCRIPTION
# Description

Ed25519 and Ed448 need to enable certs.

If no system CA certs can't be parsed,
wolfSSL_CTX_load_system_CA_certs() will fail. Don't try test if RSA and ECC are not enabled.

Fix benchmark.c so that e is defined when WOLFSSL_BENCHMARK_ALL defined.

MAX_LENGTH_SZ is 4 and supports lengths up to 2^24 - one byte for length and 3 bytes of length.
(new gcc compiler fix)

# Testing

Regression testing.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
