### PR TITLE
userPin should be NULL_PTR for CKR_PROTECTED_AUTHENTICATION_PATH

### DIFF
--- a/wolfcrypt/src/wc_pkcs11.c
+++ b/wolfcrypt/src/wc_pkcs11.c
@@ -687,7 +687,7 @@ static int Pkcs11OpenSession(Pkcs11Token* token, Pkcs11Session* session,
             if (rv != CKR_OK) {
                 ret = WC_HW_E;
             }
-            if (ret == 0 && token->userPin != NULL) {
+            if (ret == 0) {
                 rv = token->func->C_Login(session->handle, CKU_USER,
                                               token->userPin, token->userPinSz);
                 PKCS11_RV("C_Login", rv);


### PR DESCRIPTION
# Description

I use an Nvidia HSM which does not use PIN for logging in. It uses DAC (Distributed Acces Control) implemented by the platform. This implies CKR_PROTECTED_AUTHENTICATION_PATH which requires the userPin to be NULL_PTR.

Fixes zd#

# Testing

Manually on a physical board.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
