### PR TITLE
PKCS#11: User PIN can be NULL_PTR

### DIFF
--- a/wolfssl/wolfcrypt/wc_pkcs11.h
+++ b/wolfssl/wolfcrypt/wc_pkcs11.h
@@ -52,6 +52,7 @@ typedef struct Pkcs11Token {
     CK_SESSION_HANDLE handle;           /* Handle to active session           */
     CK_UTF8CHAR_PTR   userPin;          /* User's PIN to login with           */
     CK_ULONG          userPinSz;        /* Size of user's PIN in bytes        */
+    byte              userPinLogin:1;   /* Login with User's PIN              */
 } Pkcs11Token;
 
 typedef struct Pkcs11Session {
@@ -76,9 +77,13 @@ WOLFSSL_API void wc_Pkcs11_Finalize(Pkcs11Dev* dev);
 WOLFSSL_API int wc_Pkcs11Token_Init(Pkcs11Token* token, Pkcs11Dev* dev,
     int slotId, const char* tokenName, const unsigned char *userPin,
     int userPinSz);
+WOLFSSL_API int wc_Pkcs11Token_Init_NoLogin(Pkcs11Token* token, Pkcs11Dev* dev,
+    int slotId, const char* tokenName);
 WOLFSSL_API int wc_Pkcs11Token_InitName(Pkcs11Token* token, Pkcs11Dev* dev,
     const char* tokenName, int tokenSz,
     const unsigned char* userPin, int userPinSz);
+WOLFSSL_API int wc_Pkcs11Token_InitName_NoLogin(Pkcs11Token* token,
+    Pkcs11Dev* dev, const char* tokenName, int tokenSz);
 
 WOLFSSL_API void wc_Pkcs11Token_Final(Pkcs11Token* token);
 WOLFSSL_API int wc_Pkcs11Token_Open(Pkcs11Token* token, int readWrite);


### PR DESCRIPTION
# Description

Allow TokenInit to store NULL for User Pin.
New APIs to handle not setting User PIN.

Fixes zd#15985

# Testing

Tested with wolfss-examples/pkcs11

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
