### PR TITLE
Revert "Fix for sniffer to decode out of order packets"

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -5753,11 +5753,7 @@ static int CheckSequence(IpInfo* ipInfo, TcpInfo* tcpInfo,
                 *ackFault = 1;
                 UpdateMissedDataSessions();
             }
-            if (FixSequence(tcpInfo, session) != 1)
-                return -1;
-            else
-                return CheckSequence(ipInfo, tcpInfo, session, sslBytes,
-                                     sslFrame, error);
+            return FixSequence(tcpInfo, session);
         }
     }
 


### PR DESCRIPTION
Reverts wolfSSL/wolfssl#5622
Will go into the v5.5.2 async release only.
This change introduced a possible recursive call, which can cause issues with some out of order packets in the sniffer.
ZD 14846.