### PR TITLE
Test for writev in buildsystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ check_function_exists("inet_ntoa" HAVE_INET_NTOA)
 check_function_exists("memset" HAVE_MEMSET)
 check_function_exists("socket" HAVE_SOCKET)
 check_function_exists("strftime" HAVE_STRFTIME)
+check_function_exists("writev" HAVE_WRITEV)
 
 include(CheckTypeSize)
 

--- a/cmake/config.in
+++ b/cmake/config.in
@@ -34,6 +34,9 @@
 /* Define to 1 if you have the <sys/time.h> header file. */
 #cmakedefine HAVE_SYS_TIME_H @HAVE_SYS_TIME_H@
 
+/* Define to 1 if you have the `writev' function. */
+#cmakedefine HAVE_WRITEV @HAVE_WRITEV@
+
 /* Define to 1 if the system has the type `__uint128_t'. */
 #cmakedefine HAVE___UINT128_T @HAVE___UINT128_T@
 

--- a/configure.ac
+++ b/configure.ac
@@ -104,7 +104,7 @@ AC_C_BIGENDIAN
 # check if functions of interest are linkable, but also check if
 # they're declared by the expected headers, and if not, supersede the
 # unusable positive from AC_CHECK_FUNCS().
-AC_CHECK_FUNCS([gethostbyname getaddrinfo gettimeofday gmtime_r gmtime_s inet_ntoa memset socket strftime atexit])
+AC_CHECK_FUNCS([gethostbyname getaddrinfo gettimeofday gmtime_r gmtime_s inet_ntoa memset socket strftime writev atexit])
 AC_CHECK_DECLS([gethostbyname, getaddrinfo, gettimeofday, gmtime_r, gmtime_s, inet_ntoa, memset, socket, strftime], [], [
 if test "$(eval echo \$"$(eval 'echo ac_cv_func_${as_decl_name}')")" = "yes"
 then

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3014,6 +3014,9 @@ WOLFSSL_API int wolfSSL_make_eap_keys(WOLFSSL* ssl, void* key, unsigned int len,
 
 
 #ifndef _WIN32
+    #if defined(HAVE_CONFIG_H) && !defined(HAVE_WRITEV) && !defined(NO_WRITEV)
+        #define NO_WRITEV
+    #endif
     #ifndef NO_WRITEV
         #ifdef __PPU
             #include <sys/types.h>


### PR DESCRIPTION
# Description

Add checks for the `writev` function in the autotools and CMake buildsystems, and disables the related functionality by defining `NO_WRITEV` if the `writev` function is not found.  

This allows building using the autotools and CMake buildsystems on platforms where `writev` is not implemented.  

# Testing

Tested by compiling on my system.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
