### PR TITLE
Fix wolfssl/wolfcrypt/sp_int.h for Windows 64-bit

### DIFF
--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -274,6 +274,9 @@ extern "C" {
     !defined(_WIN64) && defined(WOLFSSL_UINT128_T_DEFINED)
     typedef sp_uint128  sp_int_word;
     typedef  sp_int128  sp_int_sword;
+#else
+    typedef  sp_uint64  sp_int_word;
+    typedef   sp_int64  sp_int_sword;
 #endif
 
     #define SP_MASK         0xffffffffffffffffUL


### PR DESCRIPTION
Fix undefined `sp_int_word`/`sp_int_sword` for MinGW-w64 (64-bit Windows target) in version 5.5.2

# Description

Fixes issue building version 5.5.2 for Windows 64-bit with MinGW-w64.

# Testing

Build succeeds after applying this fix, after I also manually added linker flag `-lcrypt32`.
