### PR TITLE
ForceZero fix: encryption fail and not EtM

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -20813,8 +20813,16 @@ int BuildMessage(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
             #endif
                 {
                     /* Zeroize plaintext. */
-                    ForceZero(output + args->headerSz,
-                        (word16)(args->size - args->digestSz));
+            #if defined(HAVE_ENCRYPT_THEN_MAC) && !defined(WOLFSSL_AEAD_ONLY)
+                    if (ssl->options.startedETMWrite) {
+                        ForceZero(output + args->headerSz,
+                            (word16)(args->size - args->digestSz));
+                    }
+                    else
+            #endif
+                    {
+                        ForceZero(output + args->headerSz, (word16)args->size);
+                    }
                 }
                 goto exit_buildmsg;
             }


### PR DESCRIPTION
# Description

Zeroizing of plaintext on encryption failure will use wrong size when not using Encrypt-then-MAC. Size may go negative and cast to unsigned.

Fixes zd#15090

# Testing

PoC from Guido.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
