### PR TITLE
Allow DTLS 1.3 to compile when FIPS is enabled

### DIFF
--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -250,7 +250,12 @@ static int Dtls13GetRnMask(WOLFSSL* ssl, const byte* ciphertext, byte* mask,
 
         if (c->aes == NULL)
             return BAD_STATE_E;
+#if !defined(HAVE_SELFTEST) && \
+    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
         return wc_AesEncryptDirect(c->aes, mask, ciphertext);
+#else
+        wc_AesEncryptDirect(c->aes, mask, ciphertext);
+#endif
     }
 #endif /* HAVE_AESGCM || HAVE_AESCCM */
 


### PR DESCRIPTION
# Description

DTLS 1.3 code fails to compile if FIPS is enabled - wc_AesEncryptDirect() should be protected with the same guards as elsewhere in the code.

Fixes zd#

# Testing

Compiling with --enable-fips=v2 --enable-dtls --enable-dtls13

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
