### PR TITLE
Link newly created x509 store's certificate manager to self by default

### DIFF
--- a/certs/crl/0fdb2da4.r0
+++ b/certs/crl/0fdb2da4.r0
@@ -1,0 +1,41 @@
+Certificate Revocation List (CRL):
+        Version 2 (0x1)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, ST = Montana, L = Bozeman, O = Sawtooth, OU = Consulting, CN = www.wolfssl.com, emailAddress = info@wolfssl.com
+        Last Update: Feb 15 12:50:27 2022 GMT
+        Next Update: Nov 11 12:50:27 2024 GMT
+        CRL extensions:
+            X509v3 CRL Number: 
+                2
+Revoked Certificates:
+    Serial Number: 02
+        Revocation Date: Feb 15 12:50:27 2022 GMT
+    Signature Algorithm: sha256WithRSAEncryption
+         43:e6:3b:30:0e:32:53:32:a4:08:3c:e5:d5:2e:f1:ce:e9:95:
+         ff:ba:d6:fe:2e:59:80:f8:0a:2f:cf:1e:e0:37:fe:ca:cc:33:
+         66:8b:ed:65:50:7d:44:92:d3:5c:52:9a:95:a5:9d:a5:4e:77:
+         8b:b4:7f:59:c8:7a:e0:eb:34:32:ae:a1:03:99:d2:3c:c0:f4:
+         7e:1c:87:4c:6c:5a:ba:0a:95:e8:a1:44:01:7b:8f:3e:a4:e3:
+         e8:1e:07:19:f0:09:7a:85:8f:f3:82:62:f8:1e:08:51:a3:60:
+         30:5b:06:c8:a2:b3:ff:aa:28:66:ad:fe:4b:81:49:30:ef:5f:
+         5d:ac:d9:ad:17:9f:2a:b6:22:d6:35:cc:9f:d9:11:26:dd:7a:
+         06:35:d0:d5:c7:41:6c:52:97:8c:aa:82:5a:e5:a8:58:d4:b7:
+         2b:31:84:34:15:bd:08:e4:9e:71:9e:c5:40:f8:02:a3:a0:1e:
+         4f:98:72:2b:eb:9e:8a:4e:01:83:88:e5:cb:6e:3b:52:e3:a9:
+         34:a1:7c:e4:79:2c:d1:e0:0b:74:22:ba:6d:cb:c3:a1:56:f9:
+         c9:f4:20:bf:00:49:df:6b:59:49:18:c7:75:27:8e:a1:5a:a6:
+         ff:f2:be:34:4a:c9:6d:6e:24:a3:1f:15:7e:34:90:b6:81:bf:
+         15:80:c3:ac
+-----BEGIN X509 CRL-----
+MIICBDCB7QIBATANBgkqhkiG9w0BAQsFADCBlDELMAkGA1UEBhMCVVMxEDAOBgNV
+BAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNhd3Rvb3Ro
+MRMwEQYDVQQLDApDb25zdWx0aW5nMRgwFgYDVQQDDA93d3cud29sZnNzbC5jb20x
+HzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20XDTIyMDIxNTEyNTAyN1oX
+DTI0MTExMTEyNTAyN1owFDASAgECFw0yMjAyMTUxMjUwMjdaoA4wDDAKBgNVHRQE
+AwIBAjANBgkqhkiG9w0BAQsFAAOCAQEAQ+Y7MA4yUzKkCDzl1S7xzumV/7rW/i5Z
+gPgKL88e4Df+yswzZovtZVB9RJLTXFKalaWdpU53i7R/Wch64Os0Mq6hA5nSPMD0
+fhyHTGxaugqV6KFEAXuPPqTj6B4HGfAJeoWP84Ji+B4IUaNgMFsGyKKz/6ooZq3+
+S4FJMO9fXazZrRefKrYi1jXMn9kRJt16BjXQ1cdBbFKXjKqCWuWoWNS3KzGENBW9
+COSecZ7FQPgCo6AeT5hyK+ueik4Bg4jly247UuOpNKF85Hks0eALdCK6bcvDoVb5
+yfQgvwBJ32tZSRjHdSeOoVqm//K+NErJbW4kox8VfjSQtoG/FYDDrA==
+-----END X509 CRL-----

--- a/certs/crl/include.am
+++ b/certs/crl/include.am
@@ -3,6 +3,7 @@
 #
 
 EXTRA_DIST += \
+	     certs/crl/0fdb2da4.r0 \
 	     certs/crl/crl.pem \
 	     certs/crl/cliCrl.pem \
 	     certs/crl/eccSrvCRL.pem \

--- a/src/x509_str.c
+++ b/src/x509_str.c
@@ -736,6 +736,10 @@ WOLFSSL_X509_STORE* wolfSSL_X509_STORE_new(void)
 #endif
 
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)
+
+    /* Link store's new Certificate Manager to self by default */
+    store->cm->x509_store_p = store;
+
     if ((store->param = (WOLFSSL_X509_VERIFY_PARAM*)XMALLOC(
                            sizeof(WOLFSSL_X509_VERIFY_PARAM),
                            NULL, DYNAMIC_TYPE_OPENSSL)) == NULL) {


### PR DESCRIPTION
# Description

When an x509 certificate store is created outside a SSL context the newly created credential manager's pointer to the owning/parent cert store is left NULL.  In wolfSSL, when the x509 cert store is used *in* a SSL context, the certificate manager adopts the store provided by the SSL context, and the pointer is set.  When the x509 cert store is used *outside* an SSL context, for example to perform verification, the NULL pointer causes an error.  OpenSSL behavior is to allow verification outside of a SSL context.  This fix makes wolfSSL behavior match OpenSSL for the use case.

Fixes [zd# 15084](https://wolfssl.zendesk.com/agent/tickets/15084)

# Testing

ZenDesk ticket included customer-provided reproduction source-code and steps.  Verified expected failure using master, then correct result using fix branch.
