### PR TITLE
PKCS#11: compile time check in finding keys

### DIFF
--- a/wolfcrypt/src/wc_pkcs11.c
+++ b/wolfcrypt/src/wc_pkcs11.c
@@ -1464,8 +1464,10 @@ static int Pkcs11FindKeyById(CK_OBJECT_HANDLE* key, CK_OBJECT_CLASS keyClass,
     int             ret = 0;
     CK_ULONG        count;
     CK_ATTRIBUTE    keyTemplate[] = {
+#ifndef WC_PKCS11_FIND_WITH_ID_ONLY
         { CKA_CLASS,           &keyClass, sizeof(keyClass) },
         { CKA_KEY_TYPE,        &keyType,  sizeof(keyType)  },
+#endif
         { CKA_ID,              id,        (CK_ULONG)idLen  }
     };
     CK_ULONG        keyTmplCnt = sizeof(keyTemplate) / sizeof(*keyTemplate);


### PR DESCRIPTION
# Description

When WC_PKCS11_FIND_WITH_ID_ONLY defined, don't add key class and type to attributes of search.

Fixes zd#15094

# Testing

Compiled.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
