### PR TITLE
Improve logic for enabling system CA certs on Apple devices.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,18 +66,6 @@ if(CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
     set(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
 endif()
 
-if(APPLE)
-    find_library(CORE_FOUNDATION_FRAMEWORK CoreFoundation)
-    if(NOT CORE_FOUNDATION_FRAMEWORK)
-        message(FATAL_ERROR "Couldn't find CoreFoundation framework.")
-    endif()
-
-    find_library(SECURITY_FRAMEWORK Security)
-    if(NOT SECURITY_FRAMEWORK)
-        message(FATAL_ERROR "Couldn't find Security framework.")
-    endif()
-endif()
-
 include(CheckIncludeFile)
 
 check_include_file("arpa/inet.h" HAVE_ARPA_INET_H)
@@ -1673,10 +1661,33 @@ add_option("WOLFSSL_OPTFLAGS"
 add_option("WOLFSSL_SYS_CA_CERTS"
     "Enable ability to load CA certs from OS (default: enabled)"
     "yes" "yes;no")
+
 if(WOLFSSL_SYS_CA_CERTS)
     if(NOT WOLFSSL_FILESYSTEM)
-        message(FATAL_ERROR "Cannot use system CA certs without a filesystem.")
-    else()
+        message("Can't enable system CA certs without a filesystem.")
+        override_cache(WOLFSSL_SYS_CA_CERTS "no")
+    elseif(APPLE)
+        check_include_file("Security/SecTrustSettings.h" HAVE_SECURITY_SECTRUSTSETTINGS_H)
+        if(NOT HAVE_SECURITY_SECTRUSTSETTINGS_H)
+            message("Can't enable system CA certs without Security/SecTrustSettings.h.")
+            override_cache(WOLFSSL_SYS_CA_CERTS "no")
+        else()
+            find_library(CORE_FOUNDATION_FRAMEWORK CoreFoundation)
+            if(NOT CORE_FOUNDATION_FRAMEWORK)
+                message("Can't enable system CA certs without CoreFoundation framework.")
+                override_cache(WOLFSSL_SYS_CA_CERTS "no")
+            else()
+                find_library(SECURITY_FRAMEWORK Security)
+                if(NOT SECURITY_FRAMEWORK)
+                    message("Can't enable system CA certs without Security framework.")
+                    override_cache(WOLFSSL_SYS_CA_CERTS "no")
+                endif()
+            endif()
+        endif()
+    endif()
+
+
+    if(WOLFSSL_SYS_CA_CERTS)
         list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_SYS_CA_CERTS")
     endif()
 endif()
@@ -1931,9 +1942,11 @@ if(WIN32)
     target_link_libraries(wolfssl PUBLIC
         $<$<PLATFORM_ID:Windows>:ws2_32>)
 elseif(APPLE)
-    target_link_libraries(wolfssl PUBLIC
-        ${CORE_FOUNDATION_FRAMEWORK}
-        ${SECURITY_FRAMEWORK})
+    if(WOLFSSL_SYS_CA_CERTS)
+        target_link_libraries(wolfssl PUBLIC
+            ${CORE_FOUNDATION_FRAMEWORK}
+            ${SECURITY_FRAMEWORK})
+    endif()
 else()
     # DH requires math (m) library
     target_link_libraries(wolfssl

--- a/cmake/config.in
+++ b/cmake/config.in
@@ -34,6 +34,9 @@
 /* Define to 1 if you have the <sys/time.h> header file. */
 #cmakedefine HAVE_SYS_TIME_H @HAVE_SYS_TIME_H@
 
+/* Define to 1 if you have the <Security/SecTrustSettings.h> header file. */
+#cmakedefine HAVE_SECURITY_SECTRUSTSETTINGS_H @HAVE_SECURITY_SECTRUSTSETTINGS_H@
+
 /* Define to 1 if the system has the type `__uint128_t'. */
 #cmakedefine HAVE___UINT128_T @HAVE___UINT128_T@
 

--- a/configure.ac
+++ b/configure.ac
@@ -7443,6 +7443,21 @@ then
     then
         ENABLED_SYS_CA_CERTS="no"
     fi
+
+    case $host_os in
+        *darwin*)
+            AC_CHECK_HEADERS([Security/SecTrustSettings.h],
+                [
+                    # For Mac we need these frameworks to load system CA certs
+                    LDFLAGS="$LDFLAGS -framework CoreFoundation -framework Security"
+                ],
+                [
+                    AC_MSG_NOTICE([Can't enable system CA certs without Security/SecTrustSettings.h])
+                    ENABLED_SYS_CA_CERTS="no"
+                ]
+            )
+            ;;
+    esac
 fi
 
 if test "x$ENABLED_WOLFCLU" = "xyes"
@@ -8059,10 +8074,6 @@ case $host_os in
                 MINGW_LIB_WARNING="yes"
             fi
         fi ;;
-    *darwin*)
-        # For Mac we need these frameworks to load system CA certs
-        LDFLAGS="$LDFLAGS -framework CoreFoundation -framework Security"
-        ;;
 esac
 
 if test "$enable_shared" = "no"; then

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -162,15 +162,19 @@
 #endif
 #endif /* !WOLFCRYPT_ONLY || OPENSSL_EXTRA */
 
+#ifdef WOLFSSL_SYS_CA_CERTS
+
 #ifdef _WIN32
 #include <windows.h>
 #include <Wincrypt.h>
 #pragma comment(lib, "crypt32")
 #endif
 
-#ifdef __APPLE__
-# include <Security/SecTrustSettings.h>
+#if defined(__APPLE__) && defined(HAVE_SECURITY_SECTRUSTSETTINGS_H)
+#include <Security/SecTrustSettings.h>
 #endif
+
+#endif /* WOLFSSL_SYS_CA_CERTS */
 
 /*
  * OPENSSL_COMPATIBLE_DEFAULTS:

--- a/wolfcrypt/src/port/arm/armv8-32-curve25519.S
+++ b/wolfcrypt/src/port/arm/armv8-32-curve25519.S
@@ -24,6 +24,9 @@
  *   ruby ./x25519/x25519.rb arm32 ../wolfssl/wolfcrypt/src/port/arm/armv8-32-curve25519.S
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif /* HAVE_CONFIG_H */
 #include <wolfssl/wolfcrypt/settings.h>
 
 #ifdef WOLFSSL_ARMASM

--- a/wolfcrypt/src/port/arm/armv8-32-curve25519_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-curve25519_c.c
@@ -24,6 +24,9 @@
  *   ruby ./x25519/x25519.rb arm32 ../wolfssl/wolfcrypt/src/port/arm/armv8-32-curve25519.c
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif /* HAVE_CONFIG_H */
 #include <wolfssl/wolfcrypt/settings.h>
 
 #ifdef WOLFSSL_ARMASM

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2862,17 +2862,17 @@ extern void uITRON4_free(void *p) ;
 
 #ifdef WOLFSSL_SYS_CA_CERTS
     #ifdef NO_FILESYSTEM
-        #warning "Turning off WOLFSSL_SYS_CA_CERTS b/c NO_FILESYSTEM is defined."
+        /* Turning off WOLFSSL_SYS_CA_CERTS b/c NO_FILESYSTEM is defined */
         #undef WOLFSSL_SYS_CA_CERTS
     #endif
 
     #ifdef NO_CERTS
-        #warning "Turning off WOLFSSL_SYS_CA_CERTS b/c NO_CERTS is defined."
+        /* Turning off WOLFSSL_SYS_CA_CERTS b/c NO_CERTS is defined */
         #undef WOLFSSL_SYS_CA_CERTS
     #endif
 
     #if defined(__APPLE__) && !defined(HAVE_SECURITY_SECTRUSTSETTINGS_H)
-        #warning "Turning off WOLFSSL_SYS_CA_CERTS b/c no Security/SecTrustSettings.h header."
+        /* Turning off WOLFSSL_SYS_CA_CERTS b/c no Security/SecTrustSettings.h header */
         #undef WOLFSSL_SYS_CA_CERTS
     #endif
 #endif /* WOLFSSL_SYS_CA_CERTS */

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2865,8 +2865,14 @@ extern void uITRON4_free(void *p) ;
         #warning "Turning off WOLFSSL_SYS_CA_CERTS b/c NO_FILESYSTEM is defined."
         #undef WOLFSSL_SYS_CA_CERTS
     #endif
+
     #ifdef NO_CERTS
         #warning "Turning off WOLFSSL_SYS_CA_CERTS b/c NO_CERTS is defined."
+        #undef WOLFSSL_SYS_CA_CERTS
+    #endif
+
+    #if defined(__APPLE__) && !defined(HAVE_SECURITY_SECTRUSTSETTINGS_H)
+        #warning "Turning off WOLFSSL_SYS_CA_CERTS b/c no Security/SecTrustSettings.h header."
         #undef WOLFSSL_SYS_CA_CERTS
     #endif
 #endif /* WOLFSSL_SYS_CA_CERTS */


### PR DESCRIPTION
# Description

In configure.ac and CMakeLists.txt, check for the header Security/SecTrustSettings.h. If this header is found, enable the feature. If it isn't, disable it. For non-configure/non-CMake builds, require the user to explicitly define HAVE_SECURITY_SECTRUSTSETTINGS_H if they want to use system CA certs (handled in settings.h).

Fixes ZD #15112.

# Testing

Local testing with CMake and configure on my Mac.