### PR TITLE
Minor optimize replaced strstr() -> strchr()

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -24163,7 +24163,7 @@ int GetCipherSuiteFromName(const char* name, byte* cipherSuite0,
     const char*   nameDelim;
 
     /* Support trailing : */
-    nameDelim = XSTRSTR(name, ":");
+    nameDelim = XSTRCHR(name, ':');
     if (nameDelim)
         len = (unsigned long)(nameDelim - name);
     else
@@ -24237,7 +24237,7 @@ int SetCipherList(WOLFSSL_CTX* ctx, Suites* suites, const char* list)
         int    allowing = 1;
     #endif
 
-        next = XSTRSTR(next, ":");
+        next = XSTRCHR(next, ':');
         length = MAX_SUITE_NAME;
         if (next != NULL) {
             word32 currLen = (word32)(next - current);

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -145,7 +145,7 @@ static int IsValidCipherSuite(const char* line, char *suite, size_t suite_spc)
     if (begin) {
         begin += 3;
 
-        end = XSTRSTR(begin, " ");
+        end = XSTRCHR(begin, ' ');
 
         if (end) {
             long len = end - begin;

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -627,6 +627,7 @@ typedef struct w64wrapper {
         #define XSTRNSTR(s1,s2,n) mystrnstr((s1),(s2),(n))
         #define XSTRNCMP(s1,s2,n) strncmp((s1),(s2),(n))
         #define XSTRCMP(s1,s2)    strcmp((s1),(s2))
+        #define XSTRCHR(s1,s2)    strchr((s1),(s2))
         #define XSTRNCAT(s1,s2,n) strncat((s1),(s2),(n))
 
         #ifdef USE_WOLF_STRSEP


### PR DESCRIPTION
# Description

A very minor micro-optimization that adds just one macro definition `XSTRCHR(s1,s2)`.
Perhaps even in future you will need this macro.