### PR TITLE
Fixes for various tests that do not properly handle `WC_PENDING_E`

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -6452,10 +6452,9 @@ static THREAD_RETURN WOLFSSL_THREAD run_wolfssl_server(void* args)
     if (callbacks->ssl_ready)
         callbacks->ssl_ready(ssl);
 
-
-    #ifdef WOLFSSL_ASYNC_CRYPT
+#ifdef WOLFSSL_ASYNC_CRYPT
     err = 0; /* Reset error */
-    #endif
+#endif
     do {
     #ifdef WOLFSSL_ASYNC_CRYPT
         if (err == WC_PENDING_E) {
@@ -6464,20 +6463,48 @@ static THREAD_RETURN WOLFSSL_THREAD run_wolfssl_server(void* args)
         }
     #endif
         ret = wolfSSL_accept(ssl);
-        err = wolfSSL_get_error(ssl, 0);
+        err = wolfSSL_get_error(ssl, ret);
     } while (err == WC_PENDING_E);
     if (ret != WOLFSSL_SUCCESS) {
         char buff[WOLFSSL_MAX_ERROR_SZ];
-        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buff));
+        printf("accept error = %d, %s\n",
+            err, wolfSSL_ERR_error_string(err, buff));
         /*err_sys("SSL_accept failed");*/
     }
     else {
-        if (0 < (idx = wolfSSL_read(ssl, input, sizeof(input)-1))) {
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        err = 0; /* Reset error */
+    #endif
+        do {
+        #ifdef WOLFSSL_ASYNC_CRYPT
+            if (err == WC_PENDING_E) {
+                ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
+                if (ret < 0) { break; } else if (ret == 0) { continue; }
+            }
+        #endif
+            idx = wolfSSL_read(ssl, input, sizeof(input)-1);
+            err = wolfSSL_get_error(ssl, idx);
+        } while (err == WC_PENDING_E);
+        if (idx > 0) {
             input[idx] = 0;
             printf("Client message: %s\n", input);
         }
 
-        AssertIntEQ(len, wolfSSL_write(ssl, msg, len));
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        err = 0; /* Reset error */
+    #endif
+        do {
+        #ifdef WOLFSSL_ASYNC_CRYPT
+            if (err == WC_PENDING_E) {
+                ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
+                if (ret < 0) { break; } else if (ret == 0) { continue; }
+            }
+        #endif
+            ret = wolfSSL_write(ssl, msg, len);
+            err = wolfSSL_get_error(ssl, ret);
+        } while (err == WC_PENDING_E);
+        AssertIntEQ(len, ret);
+
 #if defined(WOLFSSL_SESSION_EXPORT) && !defined(HAVE_IO_POOL) && \
         defined(WOLFSSL_DTLS)
         if (wolfSSL_dtls(ssl)) {
@@ -6631,7 +6658,7 @@ static void run_wolfssl_client(void* args)
         }
     #endif
         ret = wolfSSL_connect(ssl);
-        err = wolfSSL_get_error(ssl, 0);
+        err = wolfSSL_get_error(ssl, ret);
     } while (err == WC_PENDING_E);
     if (ret != WOLFSSL_SUCCESS) {
         char buff[WOLFSSL_MAX_ERROR_SZ];
@@ -6650,7 +6677,7 @@ static void run_wolfssl_client(void* args)
             }
         #endif
             ret = wolfSSL_write(ssl, msg, len);
-            err = wolfSSL_get_error(ssl, 0);
+            err = wolfSSL_get_error(ssl, ret);
         } while (err == WC_PENDING_E);
         AssertIntEQ(len, ret);
 
@@ -6665,7 +6692,7 @@ static void run_wolfssl_client(void* args)
             }
         #endif
             ret = wolfSSL_read(ssl, input, sizeof(input)-1);
-            err = wolfSSL_get_error(ssl, 0);
+            err = wolfSSL_get_error(ssl, ret);
         } while (err == WC_PENDING_E);
         if (ret > 0) {
             input[ret] = '\0'; /* null term */

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -122,7 +122,7 @@ This library provides single precision (SP) integer math functions.
     #endif
 #endif
 
-/* ALLOC_SP_INT: Allocate an 'sp_int' of reqired size. */
+/* ALLOC_SP_INT: Allocate an 'sp_int' of required size. */
 #if (defined(WOLFSSL_SMALL_STACK) || defined(SP_ALLOC)) && \
     !defined(WOLFSSL_SP_NO_MALLOC)
     /* Dynamically allocate just enough data to support size. */
@@ -193,7 +193,7 @@ This library provides single precision (SP) integer math functions.
     #endif
 #endif
 
-/* ALLOC_SP_INT_ARRAY: Allocate an array of 'sp_int's of reqired size. */
+/* ALLOC_SP_INT_ARRAY: Allocate an array of 'sp_int's of required size. */
 #if (defined(WOLFSSL_SMALL_STACK) || defined(SP_ALLOC)) && \
     !defined(WOLFSSL_SP_NO_MALLOC)
     /* Dynamically allocate just enough data to support multiple sp_ints of the


### PR DESCRIPTION
# Description

Fixes for various tests that do not properly handle `WC_PENDING_E`

For async v5.5.3 release

# Testing

```
./configure --enable-asynccrypt && make check
./configure --enable-asynccrypt CFLAGS="-DWC_ASYNC_THRESH_NONE" && make check
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
