### PR TITLE
fix compile error due to Werro=undef on gcc-4.8

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -598,7 +598,7 @@ static WC_INLINE sp_int_digit sp_div_word(sp_int_digit hi, sp_int_digit lo,
         : "cc"
     );
     return lo;
-#elif _MSC_VER >= 1920
+#elif defined(_MSC_VER) && _MSC_VER >= 1920
     return _udiv128(hi, lo, d, NULL);
 #endif
 }


### PR DESCRIPTION
# Description
$ ./configure
$ make
....
  CC       wolfcrypt/src/src_libwolfssl_la-sha.lo
wolfcrypt/src/sp_int.c: In function ‘sp_div_word’:
wolfcrypt/src/sp_int.c:601:7: error: "_MSC_VER" is not defined [-Werror=undef]
 #elif _MSC_VER >= 1920

$ gcc --version
gcc (Ubuntu 4.8.5-4ubuntu2) 4.8.5
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

# Testing

 make && make check with gcc-7.5.0, gcc-8.4.0, gcc-9.4.0 and gcc-11.1.0
