### PR TITLE
Fix incorrect self signed error return.

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -13609,6 +13609,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     (defined(WOLFSSL_CERT_REQ) || defined(WOLFSSL_CERT_EXT)) && \
     !defined(NO_FILESYSTEM) && !defined(NO_WOLFSSL_DIR)
                     if (ret == ASN_NO_SIGNER_E || ret == ASN_SELF_SIGNED_E) {
+                        args->lastErr = ret; /* save error from last time */
                         WOLFSSL_MSG("try to load certificate if hash dir is set");
                         ret = LoadCertByIssuer(SSL_STORE(ssl),
                            (WOLFSSL_X509_NAME*)args->dCert->issuerName,
@@ -13622,7 +13623,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                 &subjectHash, &alreadySigner);
                         }
                         else {
-                            ret = ASN_NO_SIGNER_E;
+                            ret = args->lastErr; /* restore error */
                             WOLFSSL_ERROR_VERBOSE(ret);
                         }
                     }

--- a/src/internal.c
+++ b/src/internal.c
@@ -13609,7 +13609,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     (defined(WOLFSSL_CERT_REQ) || defined(WOLFSSL_CERT_EXT)) && \
     !defined(NO_FILESYSTEM) && !defined(NO_WOLFSSL_DIR)
                     if (ret == ASN_NO_SIGNER_E || ret == ASN_SELF_SIGNED_E) {
-                        args->lastErr = ret; /* save error from last time */
+                        int lastErr = ret; /* save error from last time */
                         WOLFSSL_MSG("try to load certificate if hash dir is set");
                         ret = LoadCertByIssuer(SSL_STORE(ssl),
                            (WOLFSSL_X509_NAME*)args->dCert->issuerName,
@@ -13623,7 +13623,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                 &subjectHash, &alreadySigner);
                         }
                         else {
-                            ret = args->lastErr; /* restore error */
+                            ret = lastErr; /* restore error */
                             WOLFSSL_ERROR_VERBOSE(ret);
                         }
                     }


### PR DESCRIPTION
# Description

ASN_SELF_SIGNED_E was being overwritten with ASN_NO_SIGNER_E when compiled with certreq and certgen.

Fixes zd#15125

# Testing
Test with `examples/server/server` and `examples/client/client`, with the self signed certs in `certs/1024/`, `certs/3072/`, and `certs/4096/`.

When built with certreq/certgen disabled, this client server example gives error -275:

```
./configure --disable-certreq --disable-certgen --enable-opensslall --enable-opensslextra --enable-rsa
make
```

```
./examples/server/server -k certs/3072/client-key.pem -c certs/3072/client-cert.pem
```

```
./examples/client/client -k certs/3072/client-key.pem -c certs/3072/client-cert.pem
wolfSSL_connect error -275, ASN self-signed certificate error
wolfSSL error: wolfSSL_connect failed
```

Error -275 is:

```
wolfssl/wolfcrypt/error-crypt.h

    ASN_SELF_SIGNED_E   = -275,  /* ASN self-signed certificate error */
```
This is returned as `X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT` in `GetX509Error()`.

This correctly matches openssl s_client and s_server:

```
openssl s_client -key client-key.pem -cert client-cert.pem
...
verify error:num=18:self-signed certificate
...
```
```
include/openssl/x509_vfy.h

# define         X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT          18
```

However, when built with certreq and certgen enabled, the client server example incorrectly gives error -188:
```
./configure --enable-certreq --enable-certgen --enable-opensslall --enable-opensslextra --enable-rsa
make
```

```
./examples/server/server -k certs/3072/client-key.pem -c certs/3072/client-cert.pem
```

```
./examples/client/client -k certs/3072/client-key.pem -c certs/3072/client-cert.pem
wolfSSL_connect error -188, certificate verify failed
wolfSSL error: wolfSSL_connect failed
```

Error -188 is:
```
    ASN_NO_SIGNER_E     = -188,  /* ASN no signer to confirm failure */
```

After the fix, both cases give -275, ASN self-signed certificate error.