### PR TITLE
Fix for `test_wolfSSL_sk_CIPHER_description` incorrectly failing

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -23940,6 +23940,8 @@ const char* GetCipherKeaStr(char n[][MAX_SEGMENT_SZ]) {
              (XSTRCMP(n[2],"RSA") == 0) || (XSTRCMP(n[0],"AES128") == 0) ||
              (XSTRCMP(n[0],"AES256") == 0) || (XSTRCMP(n[1],"MD5") == 0))
         keaStr = "RSA";
+    else if (XSTRCMP(n[0],"NULL") == 0)
+        keaStr = "None";
     else
         keaStr = "unknown";
 
@@ -23967,7 +23969,7 @@ const char* GetCipherAuthStr(char n[][MAX_SEGMENT_SZ]) {
         authStr = "SRP";
     else if (XSTRCMP(n[1],"ECDSA") == 0)
         authStr = "ECDSA";
-    else if (XSTRCMP(n[0],"ADH") == 0)
+    else if (XSTRCMP(n[0],"ADH") == 0 || XSTRCMP(n[0],"NULL") == 0)
         authStr = "None";
     else
         authStr = "unknown";


### PR DESCRIPTION
# Description

Fix for `test_wolfSSL_sk_CIPHER_description` incorrectly failing with TLS v1.3 NULL cipher.

# Testing

Fails with:

```
./configure --enable-all --enable-sniffer && make && ./tests/unit.test
...
 wolfSSL_sk_CIPHER_description:
ERROR - tests/api.c line 45089 failed with:
    expected: test_str != badStr
    result:   "unknown" == "unknown"
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
