### PR TITLE
Fix for misc `HashObject` to be excluded for `WOLFCRYPT_ONLY`

### DIFF
--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -834,7 +834,7 @@ WC_STATIC WC_INLINE word32 MakeWordFromHash(const byte* hashID)
 #endif /* HAVE_SESSION_TICKET || !NO_CERTS || !NO_SESSION_CACHE */
 
 
-#if !defined(NO_SESSION_CACHE) || defined(HAVE_SESSION_TICKET)
+#if !defined(WOLFCRYPT_ONLY) && (!defined(NO_SESSION_CACHE) || defined(HAVE_SESSION_TICKET))
 
 #include <wolfssl/wolfcrypt/hash.h>
 
@@ -855,7 +855,7 @@ WC_STATIC WC_INLINE word32 HashObject(const byte* o, word32 len, int* error)
 
     return *error == 0 ? MakeWordFromHash(digest) : 0; /* 0 on failure */
 }
-#endif /* !NO_SESSION_CACHE || HAVE_SESSION_TICKET */
+#endif /* WOLFCRYPT_ONLY && (!NO_SESSION_CACHE || HAVE_SESSION_TICKET) */
 
 #undef WC_STATIC
 

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -422,20 +422,25 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
             typeH = WC_SHA;
             derivedLen = 16;           /* may need iv for v1.5 */
             break;
-
+        #endif /* !NO_SHA */
+        #if !defined(NO_SHA) || !defined(NO_SHA256)
         case PBE_SHA1_DES3:
-            switch(shaOid) {
+            switch (shaOid) {
+            #ifndef NO_SHA256
                 case HMAC_SHA256_OID:
                     typeH = WC_SHA256;
                     derivedLen = 32;
                     break;
+            #endif
+            #ifndef NO_SHA
                 default:
                     typeH = WC_SHA;
                     derivedLen = 32;           /* may need iv for v1.5 */
                     break;
+            #endif
             }
         break;
-        #endif /* !NO_SHA */
+        #endif
     #endif /* !NO_DES3 */
     #if !defined(NO_SHA) && !defined(NO_RC4)
         case PBE_SHA1_RC4_128:


### PR DESCRIPTION
# Description

* Fix for misc `HashObject` to be excluded for `WOLFCRYPT_ONLY`.
* Fix for build error with SHA2-256 disabled.

# Testing

Building without MD5, SHA1 and SHA2-256 with wolfCrypt only.

```
./configure --disable-md5 --disable-sha --disable-sha224 CFLAGS="-DNO_SHA256 -DWC_NO_RNG" --enable-cryptonly --disable-hashdrbg --disable-rsa --disable-dh --disable-ecc && make
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
