### PR TITLE
20221110-wc_DhAgree_Sync-uninited-use

### DIFF
--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -2038,7 +2038,9 @@ static int wc_DhAgree_Sync(DhKey* key, byte* agree, word32* agreeSz,
         RESTORE_VECTOR_REGISTERS();
 
         /* make sure agree is > 1 (SP800-56A, 5.7.1.1) */
-        if ((*agreeSz == 0) || ((*agreeSz == 1) && (agree[0] == 1))) {
+        if ((ret == 0) &&
+            ((*agreeSz == 0) || ((*agreeSz == 1) && (agree[0] == 1))))
+        {
             ret = MP_VAL;
         }
 
@@ -2070,7 +2072,9 @@ static int wc_DhAgree_Sync(DhKey* key, byte* agree, word32* agreeSz,
         RESTORE_VECTOR_REGISTERS();
 
         /* make sure agree is > 1 (SP800-56A, 5.7.1.1) */
-        if ((*agreeSz == 0) || ((*agreeSz == 1) && (agree[0] == 1))) {
+        if ((ret == 0) &&
+            ((*agreeSz == 0) || ((*agreeSz == 1) && (agree[0] == 1))))
+        {
             ret = MP_VAL;
         }
 
@@ -2102,7 +2106,9 @@ static int wc_DhAgree_Sync(DhKey* key, byte* agree, word32* agreeSz,
         RESTORE_VECTOR_REGISTERS();
 
         /* make sure agree is > 1 (SP800-56A, 5.7.1.1) */
-        if ((*agreeSz == 0) || ((*agreeSz == 1) && (agree[0] == 1))) {
+        if ((ret == 0) &&
+            ((*agreeSz == 0) || ((*agreeSz == 1) && (agree[0] == 1))))
+        {
             ret = MP_VAL;
         }
 


### PR DESCRIPTION
`wolfcrypt/src/dh.c`: fix benign use of uninited var in `wc_DhAgree_Sync()`, introduced in #5782 -- see oss-fuzz #53177.

tested with `wolfssl-mult-test.sh ... super-quick-check all-clang-sp-all-Os all-sp-all-Os-sanitizer`
