### PR TITLE
Propagate malloc returning NULL up the call stack

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -76,6 +76,9 @@ int InitCRL(WOLFSSL_CRL* crl, WOLFSSL_CERT_MANAGER* cm)
         return BAD_COND_E;
     }
 #endif
+#ifdef HAVE_CRL_IO
+    crl->crlIOCb = NULL;
+#endif
     if (wc_InitMutex(&crl->crlLock) != 0) {
         WOLFSSL_MSG("Init Mutex failed");
         return BAD_MUTEX_E;

--- a/src/internal.c
+++ b/src/internal.c
@@ -32373,10 +32373,9 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             ssl->suites->suites[i+1] == peerSuites->suites[j+1] ) {
 
             int ret = VerifyServerSuite(ssl, i);
-            #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E)
+            if (ret < 0) {
                 return ret;
-            #endif
+            }
             if (ret) {
                 WOLFSSL_MSG("Verified suite validity");
                 ssl->options.cipherSuite0 = ssl->suites->suites[i];
@@ -32390,10 +32389,6 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             }
             else {
                 WOLFSSL_MSG("Could not verify suite validity, continue");
-                if (ret == MEMORY_E) {
-                    WOLFSSL_MSG("Out of memory error");
-                    return ret;
-                }
             }
         }
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -32339,6 +32339,10 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             int doHelloRetry = 0;
             /* Try to establish a key share. */
             int ret = TLSX_KeyShare_Establish(ssl, &doHelloRetry);
+
+            if (ret != 0) {
+                return ret;
+            }
             if (doHelloRetry) {
                 ssl->options.serverState = SERVER_HELLO_RETRY_REQUEST_COMPLETE;
             }
@@ -32386,6 +32390,10 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             }
             else {
                 WOLFSSL_MSG("Could not verify suite validity, continue");
+                if (ret == MEMORY_E) {
+                    WOLFSSL_MSG("Out of memory error");
+                    return ret;
+                }
             }
         }
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -35538,6 +35538,7 @@ static int GetRevoked(RevokedCert* rcert, const byte* buff, word32* idx,
     ret = wc_GetSerialNumber(buff, idx, rc->serialNumber, &rc->serialSz,maxIdx);
     if (ret < 0) {
         WOLFSSL_MSG("wc_GetSerialNumber error");
+        XFREE(rc, dcrl->heap, DYNAMIC_TYPE_REVOKED);
         return ret;
     }
     /* add to list */


### PR DESCRIPTION
This PR addresses the following:
-  Don't ignore `MEMORY_E` and overwrite the error when malloc returns NULL. Instead, propagate the error up the call stack
-  Initialize `crl->crlIOCb` to NULL to prevent unknown errors
-  Prevent a possible memory leak in crl if wc_GetSerialNumber() fails.
-  Update function header comment for `wc_ecc_verify_hash_ex() `