### PR TITLE
Detect SIZEOF_LONG in armclang and diab

### DIFF
--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -133,7 +133,10 @@ decouple library dependencies with standard string, memory and so on.
                 defined(_ARCH_PPC64) || defined(__mips64) || \
                 defined(__x86_64__)  || defined(__s390x__ ) || \
                 ((defined(sun) || defined(__sun)) && \
-                 (defined(LP64) || defined(_LP64))))
+                 (defined(LP64) || defined(_LP64))) || \
+                (defined(__riscv_xlen) && (__riscv_xlen == 64)) || \
+                defined(__aarch64__) || \
+                (defined(__DCC__) && (defined(__LP64) || defined(__LP64__))))
                 /* long should be 64bit */
                 #define SIZEOF_LONG 8
             #elif defined(__i386__) || defined(__CORTEX_M3__)
@@ -178,7 +181,9 @@ decouple library dependencies with standard string, memory and so on.
           (defined(_ABIO64) && (_MIPS_SIM == _ABIO64)))) || \
          defined(__x86_64__) || defined(_M_X64)) || \
          defined(__aarch64__) || defined(__sparc64__) || defined(__s390x__ ) || \
-        (defined(__riscv_xlen) && (__riscv_xlen == 64)) || defined(_M_ARM64)
+        (defined(__riscv_xlen) && (__riscv_xlen == 64)) || defined(_M_ARM64) || \
+        defined(__aarch64__) || \
+        (defined(__DCC__) && (defined(__LP64) || defined(__LP64__)))
         #define WC_64BIT_CPU
     #elif (defined(sun) || defined(__sun)) && \
           (defined(LP64) || defined(_LP64))


### PR DESCRIPTION
This PR improves the detection of the size of long so that users do not need to define `#define SIZEOF_LONG 8`

For example,
Instead of  `./configure --host=aarch64 CFLAGS="--target=aarch64-arm-none-eabi -mcpu=cortex-a53 -DSIZEOF_LONG=8"` 

You could just drop the `-DSIZEOF_LONG=8`