### PR TITLE
account for 'pulled' error nodes

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -17076,10 +17076,22 @@ cleanup:
         }
         else {
             int idx = wc_GetCurrentIdx();
-            if (idx > 0) {
-                idx = idx -1;
+            if (idx < 0) {
+                WOLFSSL_MSG("Error with getting current index!");
+                ret = BAD_STATE_E;
+                WOLFSSL_LEAVE("wolfSSL_ERR_get_error", ret);
+
+                /* panic and try to clear out nodes and reset queue state */
+                wc_ClearErrorNodes();
             }
-            wc_RemoveErrorNode(idx);
+            else if (idx > 0) {
+                idx -= 1;
+                wc_RemoveErrorNode(idx);
+            }
+            else {
+                /* if current idx is 0 then the queue only had one node */
+                wc_RemoveErrorNode(idx);
+            }
         }
 
         return ret;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -17075,7 +17075,11 @@ cleanup:
             }
         }
         else {
-            wc_RemoveErrorNode(0);
+            int idx = wc_GetCurrentIdx();
+            if (idx > 0) {
+                idx = idx -1;
+            }
+            wc_RemoveErrorNode(idx);
         }
 
         return ret;
@@ -33241,9 +33245,10 @@ unsigned long wolfSSL_ERR_peek_error_line_data(const char **file, int *line,
 #ifdef WOLFSSL_HAVE_ERROR_QUEUE
     {
         int ret = 0;
+        int idx = wc_GetCurrentIdx();
 
         while (1) {
-            ret = wc_PeekErrorNode(0, file, NULL, line);
+            ret = wc_PeekErrorNode(idx, file, NULL, line);
             if (ret == BAD_MUTEX_E || ret == BAD_FUNC_ARG || ret == BAD_STATE_E) {
                 WOLFSSL_MSG("Issue peeking at error node in queue");
                 return 0;
@@ -33270,7 +33275,7 @@ unsigned long wolfSSL_ERR_peek_error_line_data(const char **file, int *line,
                     ret != -SOCKET_PEER_CLOSED_E && ret != -SOCKET_ERROR_E)
                 break;
 
-            wc_RemoveErrorNode(0);
+            wc_RemoveErrorNode(idx);
         }
 
         return (unsigned long)ret;

--- a/tests/api.c
+++ b/tests/api.c
@@ -39821,7 +39821,7 @@ static int test_wolfSSL_ERR_put_error(void)
     ERR_put_error(0,SYS_F_SOCKET, 15, "this file", 15);
     AssertIntEQ(ERR_get_error_line(&file, &line), 15);
 
-#ifdef WOLFSSL_PYTHON
+#if defined(OPENSSL_ALL) && defined(WOLFSSL_PYTHON)
     ERR_put_error(ERR_LIB_ASN1, SYS_F_ACCEPT, ASN1_R_HEADER_TOO_LONG,
             "this file", 100);
     AssertIntEQ(wolfSSL_ERR_peek_last_error_line(&file, &line),

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -812,8 +812,10 @@ int wc_AddErrorNode(int error, int line, char* buf, char* file)
 #endif
 }
 
-/* returns the current index into the queue, can be greater than zero in cases
- * where wc_PullErrorNode() has been callded. */
+/* returns the current index into the queue, which is the node that
+ * wc_current_node is pointing to. It can be greater than zero in cases
+ * where wc_PullErrorNode() has been called without the node having been
+ * removed. */
 int wc_GetCurrentIdx()
 {
     int ret = 0;

--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -122,6 +122,7 @@ WOLFSSL_API void wolfSSL_Debugging_OFF(void);
     WOLFSSL_LOCAL void wc_ClearErrorNodes(void);
     WOLFSSL_LOCAL int wc_PullErrorNode(const char **file, const char **reason,
                             int *line);
+    WOLFSSL_LOCAL int wc_GetCurrentIdx(void);
     WOLFSSL_API   int wc_SetLoggingHeap(void* h);
     WOLFSSL_API   int wc_ERR_remove_state(void);
     #if !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)


### PR DESCRIPTION
In the case that error nodes are pulled but not removed the node peaked at should be the 'current' node not the absolute head of the list. This adds an internal function to get the current nodes index and uses it when peeking.

./configure --enable-opensslall CPPFLAGS=-DWOLFSSL_PYTHON && make check

ZD15135