### PR TITLE
Add check for 64-bit ABI on MIPS64 before declaring a 64-bit CPU

### DIFF
--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -173,7 +173,10 @@ decouple library dependencies with standard string, memory and so on.
 #if defined(WORD64_AVAILABLE) && !defined(WC_16BIT_CPU)
     /* These platforms have 64-bit CPU registers.  */
     #if (defined(__alpha__) || defined(__ia64__) || defined(_ARCH_PPC64) || \
-         defined(__mips64)  || defined(__x86_64__) || defined(_M_X64)) || \
+        (defined(__mips64) && \
+         ((defined(_ABI64) && (_MIPS_SIM == _ABI64)) || \
+          (defined(_ABIO64) && (_MIPS_SIM == _ABIO64)))) || \
+         defined(__x86_64__) || defined(_M_X64)) || \
          defined(__aarch64__) || defined(__sparc64__) || defined(__s390x__ ) || \
         (defined(__riscv_xlen) && (__riscv_xlen == 64)) || defined(_M_ARM64)
         #define WC_64BIT_CPU


### PR DESCRIPTION
# Description

Addresses building for a 32-bit ABI in a MIPS 64-bit architecture by ensuring that the CPU is identified as 64-bit only when both the architecture and API are 64-bit.

Fixes a problem reported as PR #5754 

# Testing

Build using MIPS cross-compile tool-chain providing various MIPS architecture and ABI options.
