### PR TITLE
Fix leak in wolfSSL_X509_NAME_ENTRY_get_object.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -30894,18 +30894,16 @@ int wolfSSL_ASN1_STRING_canon(WOLFSSL_ASN1_STRING* asn_out,
     defined(HAVE_POCO_LIB) || defined(WOLFSSL_HAPROXY)
     WOLFSSL_ASN1_OBJECT * wolfSSL_X509_NAME_ENTRY_get_object(WOLFSSL_X509_NAME_ENTRY *ne)
     {
-        WOLFSSL_ASN1_OBJECT* obj = NULL;
-
 #ifdef WOLFSSL_DEBUG_OPENSSL
         WOLFSSL_ENTER("wolfSSL_X509_NAME_ENTRY_get_object");
 #endif
-        if (ne == NULL) return NULL;
-        obj = wolfSSL_OBJ_nid2obj_ex(ne->nid, ne->object);
-        if (obj != NULL) {
-            obj->nid = ne->nid;
-            return obj;
+        if (ne == NULL) {
+            return NULL;
         }
-        return NULL;
+
+        ne->object = wolfSSL_OBJ_nid2obj_ex(ne->nid, ne->object);
+
+        return ne->object;
     }
 
 


### PR DESCRIPTION
# Description

This fixes a memory leak in `wolfSSL_X509_NAME_ENTRY_get_object()` in the OpenSSL compatibility layer.

The `WOLFSSL_ASN1_OBJECT` pointer returned by `wolfSSL_OBJ_nid2obj_ex()` was not being saved in the struct `WOLFSSL_X509_NAME_ENTRY` object member, which meant the name entry cleanup code was not calling `wolfSSL_ASN1_OBJECT_free()` to free the ASN1 object and its `obj` member if the ASN1 object was dynamically allocated.

Also, cleaned up some redundant lines in `wolfSSL_X509_NAME_ENTRY_get_object()` that weren't necessary because the logic was already handled in `wolfSSL_OBJ_nid2obj_ex()`.

Fixes zd#15172

# Testing

Testing info in ZD ticket.
