### PR TITLE
20221118-minor-fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -683,6 +683,7 @@ then
     test "$enable_eccencrypt" = "" && enable_eccencrypt=yes
     test "$enable_psk" = "" && enable_psk=yes
     test "$enable_cmac" = "" && enable_cmac=yes
+    test "$enable_siphash" = "" && enable_siphash=yes
     test "$enable_xts" = "" && enable_xts=yes
     test "$enable_ocsp" = "" && enable_ocsp=yes
     test "$enable_ocspstapling" = "" && enable_ocspstapling=yes
@@ -953,6 +954,9 @@ then
 
     # Store issuer name components when parsing certificates.
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_HAVE_ISSUER_NAMES"
+
+    # Enable Brainpool
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_ECC_BRAINPOOL"
 fi
 
 # liboqs

--- a/src/internal.c
+++ b/src/internal.c
@@ -32340,8 +32340,10 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             /* Try to establish a key share. */
             int ret = TLSX_KeyShare_Establish(ssl, &doHelloRetry);
 
-            if (ret != 0) {
-                return ret;
+            if (ret == MEMORY_E) {
+                WOLFSSL_MSG("TLSX_KeyShare_Establish() failed in "
+                            "VerifyServerSuite() with MEMORY_E");
+                return 0;
             }
             if (doHelloRetry) {
                 ssl->options.serverState = SERVER_HELLO_RETRY_REQUEST_COMPLETE;

--- a/wolfcrypt/src/siphash.c
+++ b/wolfcrypt/src/siphash.c
@@ -90,7 +90,7 @@
  * @param [out] a  Byte array to write into.
  * @param [in]  n  Number to encode.
  */
-#define SET_U64(a, n)   ((*(word64*)(a)) = n)
+#define SET_U64(a, n)   ((*(word64*)(a)) = (n))
 #else
 /**
  * Decode little-endian byte array to 64-bit number.
@@ -465,6 +465,12 @@ int wc_SipHash(const unsigned char* key, const unsigned char* in, word32 inSz,
         "orq    %%r12, %%r13\n\t"
         "L_siphash_n6:\n\t"
 
+    : [in] "+r" (in), [inSz] "+r" (inSz)
+    : [key] "r" (key), [out] "r" (out) , [outSz] "r" (outSz)
+    : "memory", "%r8", "%r9", "%r10", "%r11", "%r12", "%r13"
+    );
+
+    __asm__ __volatile__ (
         "cmp    $5, %[inSz]\n\t"
         "jl     L_siphash_n5\n\t"
         "movzbq 4(%[in]), %%r12\n\t"
@@ -510,6 +516,12 @@ int wc_SipHash(const unsigned char* key, const unsigned char* in, word32 inSz,
         "cmp    $8, %[outSz]\n\t"
         "je     L_siphash_8_end\n\t"
 
+    : [in] "+r" (in), [inSz] "+r" (inSz)
+    : [key] "r" (key), [out] "r" (out) , [outSz] "r" (outSz)
+    : "memory", "%r8", "%r9", "%r10", "%r11", "%r12", "%r13"
+    );
+
+    __asm__ __volatile__ (
         "xor    $0xee, %%r10b\n\t"
 #if WOLFSSL_SIPHASH_DROUNDS == 2
         SIPHASH_ROUND(%%r8, %%r9, %%r10, %%r11)


### PR DESCRIPTION
`configure.ac`: mutually harmonize `--enable-all` and `--enable-all-crypto`: add `enable-siphash` to `enable-all`, and add Brainpool to `enable-all-crypto`.

`src/internal.c`: in `VerifyServerSuite()`, narrow condition and fix return value in error check added in 647ce794dd.

`wolfcrypt/src/siphash.c`: fix `bugprone-macro-parentheses`, and in `wc_SipHash()`, fix `clang-diagnostic-overlength-strings` around inline asm.

tested with `wolfssl-multi-test.sh ... super-quick-check benchmark-wolfcrypt-intelasm-all benchmark-wolfcrypt-noasm-all`
