### PR TITLE
20221120-enable-brainpool

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -745,6 +745,7 @@ then
     then
         test "$enable_dsa" = "" && enable_dsa=yes
         test "$enable_ecccustcurves" = "" && enable_ecccustcurves=yes
+        test "$enable_brainpool" = "" && enable_brainpool=yes
         test "$enable_srp" = "" && enable_srp=yes
         # linuxkm is incompatible with opensslextra and its dependents.
         if test "$ENABLED_LINUXKM_DEFAULTS" != "yes"
@@ -909,6 +910,7 @@ then
     then
         test "$enable_dsa" = "" && enable_dsa=yes
         test "$enable_ecccustcurves" = "" && enable_ecccustcurves=yes
+        test "$enable_brainpool" = "" && enable_brainpool=yes
         test "$enable_srp" = "" && enable_srp=yes
     fi
 
@@ -954,9 +956,6 @@ then
 
     # Store issuer name components when parsing certificates.
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_HAVE_ISSUER_NAMES"
-
-    # Enable Brainpool
-    AM_CFLAGS="$AM_CFLAGS -DHAVE_ECC_BRAINPOOL"
 fi
 
 # liboqs
@@ -3047,7 +3046,6 @@ then
     fi
 fi
 
-
 # ECC Minimum Key Size
 ENABLED_ECCMINSZ=224
 AC_ARG_WITH([eccminsz],
@@ -3068,6 +3066,30 @@ AC_ARG_ENABLE([compkey],
 if test "$ENABLED_WPAS" = "yes"
 then
     ENABLED_COMPKEY=yes
+fi
+
+
+# Brainpool (depends on _ECCCUSTCURVES)
+if test "$ENABLED_ECCCUSTCURVES" != "no"
+then
+    BRAINPOOL_DEFAULT=yes
+else
+    BRAINPOOL_DEFAULT=no
+fi
+
+AC_ARG_ENABLE([brainpool],
+    [AS_HELP_STRING([--enable-brainpool],[Enable Brainpool ECC curves (default: ${BRAINPOOL_DEFAULT})])],
+    [ ENABLED_BRAINPOOL=$enableval ],
+    [ ENABLED_BRAINPOOL="$BRAINPOOL_DEFAULT" ]
+    )
+
+if test "$ENABLED_BRAINPOOL" != "no"
+then
+    if test "$ENABLED_ECCCUSTCURVES" = "no"
+    then
+        AC_MSG_ERROR([cannot enable Brainpool without enabling ecccustcurves.])
+    fi
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_ECC_BRAINPOOL"
 fi
 
 
@@ -8624,6 +8646,7 @@ echo "   * ECC Custom Curves:          $ENABLED_ECCCUSTCURVES"
 echo "   * ECC Minimum Bits:           $ENABLED_ECCMINSZ"
 echo "   * FPECC:                      $ENABLED_FPECC"
 echo "   * ECC_ENCRYPT:                $ENABLED_ECC_ENCRYPT"
+echo "   * Brainpool:                  $ENABLED_BRAINPOOL"
 echo "   * CURVE25519:                 $ENABLED_CURVE25519"
 echo "   * ED25519:                    $ENABLED_ED25519"
 echo "   * ED25519 streaming:          $ENABLED_ED25519_STREAM"


### PR DESCRIPTION
configure.ac: add `--enable-brainpool`, default on unless `disable-ecccustcurves`, and use it to enable brainpool in `enable-all` and `enable-all-crypto`, subject to override.

This is a followup to #5802 , to address a build failure in `wolfssl-multi-test.sh ... all-crypt-sp-math-vector-register-access`:
```
all-crypt-sp-math-vector-register-access] [46 of 139] [ba8731dc69]
    configure...   real 0m6.829s  user 0m3.576s  sys 0m3.907s
    build...7a1acc7e56 (<david@wolfssl.com> 2016-07-07 10:59:45 -0700 130)     #error Brainpool and Koblitz curves requires WOLFSSL_CUSTOM_CURVES
wolfcrypt/src/ecc.c:130:6: error: #error Brainpool and Koblitz curves requires WOLFSSL_CUSTOM_CURVES
  130 |     #error Brainpool and Koblitz curves requires WOLFSSL_CUSTOM_CURVES
      |      ^~~~~
```

(There are corresponding tweaks to `wolfssl-multi-test.sh` that will go into a PR after this stabilizes.)

tested with `wolfssl-multi-test.sh ... all-crypt-sp-math-vector-register-access super-quick-check allcryptonly-gcc-c89 benchmark-wolfcrypt-intelasm-all benchmark-wolfcrypt-noasm-all all-crypto-linuxkm-defaults-max-func-stack-2k-build all-crypto-linuxkm-defaults-max-func-stack-2k-build-fips all-crypto-sp-m32 linuxkm-pie-cryptonly-no-asm`
