### PR TITLE
Fix X509_get1_ocsp to set num of elements in stack

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -12702,6 +12702,7 @@ WOLF_STACK_OF(WOLFSSL_STRING) *wolfSSL_X509_get1_ocsp(WOLFSSL_X509 *x)
 
     list->data.string = url;
     list->next = NULL;
+    list->num = 1;
 
     return list;
 }


### PR DESCRIPTION
# Description

`wolfSSL_X509_get1_ocsp()` creates a stack, but fails to set the number of items in the stack, causing a bogus value to be returned when `wolfSSL_sk_WOLFSSL_STRING_num()` is applied to the returned stack.

Fixes zd15177

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
