### PR TITLE
Improvement for sniffer error messages

### DIFF
--- a/sslSniffer/sslSnifferTest/snifftest.c
+++ b/sslSniffer/sslSnifferTest/snifftest.c
@@ -363,7 +363,7 @@ static int load_key(const char* name, const char* server, int port,
 
         if (loadCount == 0) {
             printf("Failed loading private key %s: ret %d\n", keyFile, ret);
-            printf("Please run directly from sslSniffer/sslSnifferTest dir\n");
+            printf("Please run directly from wolfSSL root dir\n");
             ret = -1;
         }
         else {

--- a/wolfssl/sniffer_error.h
+++ b/wolfssl/sniffer_error.h
@@ -138,7 +138,10 @@
 #define CHAIN_INPUT_STR 93
 #define GOT_ENC_EXT_STR 94
 #define GOT_HELLO_RETRY_REQ_STR 95
+
 #define SNIFFER_KEY_SETUP_STR 96
+#define UNSUPPORTED_TLS_VER_STR 97
+#define KEY_MISMATCH_STR 98
 /* !!!! also add to msgTable in sniffer.c and .rc file !!!! */
 
 

--- a/wolfssl/sniffer_error.rc
+++ b/wolfssl/sniffer_error.rc
@@ -114,5 +114,8 @@ STRINGTABLE
     93, "Loading chain input"
     94, "Got encrypted extension"
     95, "Got Hello Retry Request"
+
     96, "Setting up keys"
+    97, "Unsupported TLS Version"
+    98, "Server Client Key Mismatch"
 }


### PR DESCRIPTION
# Description

Adding more informative error messages for cases like key mismatches, cipher setting errors, and enabled TLS versions instead of just the `Session in Fatal Error State` message.

Fixes zd15137

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
