### PR TITLE
Support static memory with sp-math

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2290,6 +2290,10 @@ extern void uITRON4_free(void *p) ;
     #if defined(HAVE_IO_POOL) || defined(XMALLOC_USER) || defined(NO_WOLFSSL_MEMORY)
          #error static memory cannot be used with HAVE_IO_POOL, XMALLOC_USER or NO_WOLFSSL_MEMORY
     #endif
+    #if !defined(WOLFSSL_SP_MATH_ALL) && !defined(USE_FAST_MATH) && \
+        !defined(WOLFSSL_SP_MATH) && !defined(NO_BIG_INT)
+         #error The static memory option is only supported for fast math or SP Math
+    #endif
     #ifdef WOLFSSL_SMALL_STACK
         #error static memory does not support small stack please undefine
     #endif

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2290,10 +2290,6 @@ extern void uITRON4_free(void *p) ;
     #if defined(HAVE_IO_POOL) || defined(XMALLOC_USER) || defined(NO_WOLFSSL_MEMORY)
          #error static memory cannot be used with HAVE_IO_POOL, XMALLOC_USER or NO_WOLFSSL_MEMORY
     #endif
-    #if !defined(WOLFSSL_SP_MATH_ALL) && !defined(USE_FAST_MATH) && \
-        !defined(NO_BIG_INT)
-         #error The static memory option is only supported for fast math or SP Math
-    #endif
     #ifdef WOLFSSL_SMALL_STACK
         #error static memory does not support small stack please undefine
     #endif


### PR DESCRIPTION
This PR enables the support of static memory configuration `--enable-staticmemory` with `--enable-sp-math`.

Without the proposed changes, you will get the following build error.

`./configure --enable-sp --enable-sp-math --enable-staticmemory && make`
./wolfssl/wolfcrypt/settings.h:2295:11: error: #error The static memory option is only supported for fast math or SP Math
 2295 |          #error The static memory option is only supported for fast math or SP Math
      |           ^~~~~

