### PR TITLE
Added required config option and return value for HaProxy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5469,6 +5469,12 @@ then
         AM_CFLAGS="$AM_CFLAGS -DSESSION_CERTS"
     fi
 
+    # Requires key gen make sure on
+    if test "x$ENABLED_KEYGEN" = "xno"
+    then
+        ENABLED_KEYGEN="yes"
+        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_KEY_GEN"
+    fi
 fi
 
 if test "$ENABLED_NETSNMP" = "yes"

--- a/src/x509.c
+++ b/src/x509.c
@@ -10336,7 +10336,11 @@ cleanup:
 
         if ((l = wolfSSL_BIO_get_len(bp)) <= 0) {
             /* No certificate in buffer */
+#if defined (WOLFSSL_HAPROXY)
+            WOLFSSL_ERROR(PEM_R_NO_START_LINE);
+#else
             WOLFSSL_ERROR(ASN_NO_PEM_HEADER);
+#endif
             return NULL;
         }
 


### PR DESCRIPTION
# Description

keygen needs to be enabled for HaProxy so it has been added to the existing --enable-haproxy option. An HaProxy hook was added so that the expected return value is returned when building for HaProxy.

# Testing

Tested with application provided by HaProxy.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
