### PR TITLE
Async Sniffer: Fix for decryption after second handshake

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -4692,15 +4692,17 @@ static int DecryptTls(WOLFSSL* ssl, byte* plain, const byte* input,
     int ret = 0;
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    ret = wolfSSL_AsyncPop(ssl, &ssl->decrypt.state);
-    if (ret != WC_NOT_PENDING_E) {
-        /* check for still pending */
-        if (ret == WC_PENDING_E)
-            return ret;
+    if (ssl->decrypt.state != CIPHER_STATE_BEGIN) {
+        ret = wolfSSL_AsyncPop(ssl, &ssl->decrypt.state);
+        if (ret != WC_NOT_PENDING_E) {
+            /* check for still pending */
+            if (ret == WC_PENDING_E)
+                return ret;
 
-        ssl->error = 0; /* clear async */
+            ssl->error = 0; /* clear async */
 
-        /* let failures through so CIPHER_STATE_END logic is run */
+            /* let failures through so CIPHER_STATE_END logic is run */
+        }
     }
     else
 #endif

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -1444,7 +1444,10 @@ static SnifferServer* GetSnifferServer(IpInfo* ipInfo, TcpInfo* tcpInfo)
                 MatchAddr(sniffer->server, ipInfo->dst))
             break;
 
-        sniffer = sniffer->next;
+        if (sniffer->next)
+            sniffer = sniffer->next;
+        else
+           break;
     }
 #else
     (void)ipInfo;


### PR DESCRIPTION
# Description

Fixes an infinite loop that can occur after a second handshake after initial decryption. `wolfSSL_Async_Push()` in `SetupKeys()` doesn't get to `wolfSSL_Async_Pop()` in `SetupKeys()`, instead it is popped at `DecryptTls()` causing an infinite loop.

Fixes zd#15184

# Testing

How did you test? 

On QAT hardware with the testfiles provided by customer.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
