### PR TITLE
20221124-wc_GetCurrentIdx-prototype

### DIFF
--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -816,7 +816,7 @@ int wc_AddErrorNode(int error, int line, char* buf, char* file)
  * wc_current_node is pointing to. It can be greater than zero in cases
  * where wc_PullErrorNode() has been called without the node having been
  * removed. */
-int wc_GetCurrentIdx()
+int wc_GetCurrentIdx(void)
 {
     int ret = 0;
 #ifdef WOLFSSL_HAVE_ERROR_QUEUE


### PR DESCRIPTION
wolfcrypt/src/logging.c: add missing void arg list to definition of `wc_GetCurrentIdx()`.

fixes
```
143dac64a3 (<jacob@wolfssl.com> 2022-11-17 14:51:37 -0800 819) int wc_GetCurrentIdx()
wolfcrypt/src/logging.c:819:21: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
int wc_GetCurrentIdx()
                    ^
                     void
```

tested with `wolfssl-multi-test.sh ... all-clang clang-tidy-all-async-quic`
