### PR TITLE
must have SP enabled with SP math

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6716,14 +6716,6 @@ if test "$ENABLED_SP_NONBLOCK" = "yes"; then
     AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_SP_NONBLOCK"
 fi
 
-# Check that we enable SP with RSA, DH or ECC.
-if test "$ENABLED_SP" = "no"; then
-    # Didn't need SP, don't need SP_MATH.
-    if test "$ENABLED_SP_MATH" = "yes"; then
-        ENABLED_SP_MATH=no
-    fi
-fi
-
 if test "$ENABLED_SP_MATH" = "yes"; then
     if test "$ENABLED_SP" = "no"; then
         AC_MSG_ERROR([Must have SP enabled with SP math: --enable-sp])


### PR DESCRIPTION
# Description

`./configuration --enable-sp-math` needs to have --enable-sp enabled as well. However, the lines sets SP math to "no" and causes compile error as a result.  To make the following lines, which is if condition, enabled, the lines needs to be removed so that user can know `enable-sp-math` needs `enable-sp`.

# Testing

Specify "--enable-sp-math" and confirm error during the configuration 

