### PR TITLE
PKCS#11: add initialization API that returns PKCS#11 return value

### DIFF
--- a/wolfssl/wolfcrypt/wc_pkcs11.h
+++ b/wolfssl/wolfcrypt/wc_pkcs11.h
@@ -72,6 +72,8 @@ enum Pkcs11KeyType {
 
 WOLFSSL_API int wc_Pkcs11_Initialize(Pkcs11Dev* dev, const char* library,
                                      void* heap);
+WOLFSSL_API int wc_Pkcs11_Initialize_ex(Pkcs11Dev* dev, const char* library,
+                                        void* heap, CK_RV* rvp);
 WOLFSSL_API void wc_Pkcs11_Finalize(Pkcs11Dev* dev);
 
 WOLFSSL_API int wc_Pkcs11Token_Init(Pkcs11Token* token, Pkcs11Dev* dev,


### PR DESCRIPTION
# Description

Add PKCS#11 initialization wolfCrypt API that returns the PKCS#11 return value.

Fixes zd#15225

# Testing

Builds with --enable-pkcs11

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
