### PR TITLE
Initialize variable causing failures with gcc-11 and gcc-12

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -17146,7 +17146,7 @@ int sp_todecimal(sp_int* a, char* str)
     int err = MP_OKAY;
     int i;
     int j;
-    sp_int_digit d;
+    sp_int_digit d = 0;
 
     /* Validate parameters. */
     if ((a == NULL) || (str == NULL)) {
@@ -17178,7 +17178,7 @@ int sp_todecimal(sp_int* a, char* str)
             /* Write out little endian. */
             i = 0;
             do {
-                /* Divide by 10 and and get remainder of division. */
+                /* Divide by 10 and get remainder of division. */
                 (void)sp_div_d(t, 10, t, &d);
                 /* Write out remainder as a character. */
                 str[i++] = (char)('0' + d);


### PR DESCRIPTION
# Description
Found in PRB tests, reported by @rizlik 

Fixes report in #jenkins

reproduce with:

```
./configure --disable-asm --enable-tls13 --disable-oldtls --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --disable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --disable-intelasm --disable-dh --enable-curve25519 --enable-chacha=noasm --enable-secure-renegotiation --disable-examples CFLAGS="-O3 -fPIC -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -m32 -DUSE_CERT_BUFFERS_4096 -DUSE_CERT_BUFFERS_256" LDFLAGS="-m32" --enable-opensslextra CC="gcc-11"

./configure --disable-asm --enable-tls13 --disable-oldtls --enable-static --enable-singlethreaded --enable-dtls --enable-sp=yes,4096 --disable-sp-asm --disable-shared --enable-dtls-mtu --disable-sha3 --disable-intelasm --disable-dh --enable-curve25519 --enable-chacha=noasm --enable-secure-renegotiation --disable-examples CFLAGS="-O3 -fPIC -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -m32 -DUSE_CERT_BUFFERS_4096 -DUSE_CERT_BUFFERS_256" LDFLAGS="-m32" --enable-opensslextra CC="gcc-12"
```

# Testing

Tested with:

```
gcc version 11.3.0 (Ubuntu 11.3.0-1ubuntu1~22.04) 
gcc version 12.1.0 (Ubuntu 12.1.0-2ubuntu1~22.04)
```

# Checklist

 - [X] added tests - cloud slaves running gcc version 11.2.0 (Ubuntu 11.2.0-19ubuntu1) which will catch this
 - [N/A] updated/added doxygen
 - [N/A] updated appropriate READMEs
 - [N/A] Updated manual and documentation
