### PR TITLE
20221129-ecb-benchmark-throughput

### DIFF
--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -2040,7 +2040,9 @@ int bench_tls(void* args)
 
     /* parse by : */
     while ((cipher != NULL) && (cipher[0] != '\0')) {
+#if ! (defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES))
         const char *gname = "N/A";
+#endif
         next_cipher = strchr(cipher, ':');
         if (next_cipher != NULL) {
             cipher[next_cipher - cipher] = '\0';
@@ -2052,7 +2054,8 @@ int bench_tls(void* args)
 
 #if defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES)
         for (group_index = 0; groups[group_index].name != NULL; group_index++) {
-            gname = theadInfo[0].group == 0 ? "N/A" : groups[group_index].name;
+            const char *gname = theadInfo[0].group == 0 ? "N/A"
+                : groups[group_index].name;
 
             if (argDoGroups && groups[group_index].group == 0) {
                 /* Skip unsupported group. */

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -3302,7 +3302,7 @@ static void bench_aesecb_internal(int useDeviceID, const byte* key, word32 keySz
 
     bench_stats_start(&count, &start);
     do {
-        int outer_loop_limit = (bench_size / AES_BLOCK_SIZE) + 1;
+        int outer_loop_limit = ((bench_size / AES_BLOCK_SIZE) * 10) + 1;
         for (times = 0;
              times < outer_loop_limit /* numBlocks */ || pending > 0;
             ) {
@@ -3344,7 +3344,7 @@ exit_aes_enc:
 
     bench_stats_start(&count, &start);
     do {
-        int outer_loop_limit = (bench_size / AES_BLOCK_SIZE) + 1;
+        int outer_loop_limit = (10 * (bench_size / AES_BLOCK_SIZE)) + 1;
         for (times = 0; times < outer_loop_limit || pending > 0; ) {
             bench_async_poll(&pending);
 


### PR DESCRIPTION
`wolfcrypt/benchmark/benchmark.c`: make iteration increment in `bench_aesecb_internal()` even lumpier (by a factor of 10) to further reduce false positives in `benchmark-wolfcrypt-{intelasm,noasm}-all` from iteration overhead.

`examples/benchmark/tls_bench.c`: fix for `clang-analyzer-deadcode.DeadStores` in `bench_tls()`.

tested with `wolfssl-multi-test.sh ... super-quick-check benchmark-wolfcrypt-intelasm-all benchmark-wolfcrypt-noasm-all`
