### PR TITLE
SP int: check NO_64BIT before speculative using long long

### DIFF
--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -96,7 +96,7 @@ extern "C" {
     #error "Size of unsigned int not detected"
 #endif
 
-#if ULONG_MAX == 18446744073709551615ULL && \
+#if !defined(NO_64BIT) && ULONG_MAX == 18446744073709551615ULL && \
         4294967295UL != 18446744073709551615ULL /* verify pre-processor supports
                                                 * 64-bit ULL types */
     #define SP_ULONG_BITS    64
@@ -146,7 +146,7 @@ extern "C" {
     #else
         #error "Size of unsigned long long not detected"
     #endif
-#elif SP_ULONG_BITS == 32
+#elif (SP_ULONG_BITS == 32) && !defined(NO_64BIT)
     /* Speculatively use long long as the 64-bit type as we don't have one
      * otherwise. */
     typedef unsigned long long sp_uint64;


### PR DESCRIPTION
# Description

ULLONG_MAX is not defined for old versions of C compiler. An unsigned long long type may still be available though. Don't use unsigned long long for a 64-bit type when NO_64BIT is defined.

# Testing

Standard

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
