### PR TITLE
Allow disabling SHA1 cipher suites without disabling wolfCrypt SHA1 support by defining NO_TLS_SHA1.  

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -35982,7 +35982,7 @@ int wolfSSL_BN_is_word(const WOLFSSL_BIGNUM* bn, WOLFSSL_BN_ULONG w)
         return WOLFSSL_FAILURE;
     }
 
-    if (w <= (WOLFSSL_BN_ULONG)MP_MASK) {
+    if (w <= MP_MASK) {
         if (mp_isword((mp_int*)bn->internal, (mp_digit)w) == MP_YES) {
             return WOLFSSL_SUCCESS;
         }
@@ -36640,7 +36640,7 @@ static int wolfSSL_BN_add_word_int(WOLFSSL_BIGNUM *bn, WOLFSSL_BN_ULONG w,
     }
 
     if (ret == WOLFSSL_SUCCESS) {
-        if (w <= (WOLFSSL_BN_ULONG)MP_MASK) {
+        if (w <= MP_MASK) {
             if (sub == 1) {
                 rc = mp_sub_d((mp_int*)bn->internal, (mp_digit)w,
                               (mp_int*)bn->internal);
@@ -36952,7 +36952,7 @@ WOLFSSL_BN_ULONG wolfSSL_BN_mod_word(const WOLFSSL_BIGNUM *bn,
         return (WOLFSSL_BN_ULONG)WOLFSSL_FATAL_ERROR;
     }
 
-    if (w <= (WOLFSSL_BN_ULONG)MP_MASK) {
+    if (w <= MP_MASK) {
         mp_digit bn_ret;
         if (mp_mod_d((mp_int*)bn->internal, (mp_digit)w, &bn_ret) != MP_OKAY) {
             WOLFSSL_MSG("mp_add_d error");

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -281,6 +281,12 @@
    CHACHA-POLY.
 */
 
+/* Allow disabling SHA1 cipher suites without disabling wolfCrypt SHA1 by
+ * defining NO_TLS_SHA1 */
+#ifdef NO_SHA
+    #define NO_TLS_SHA1
+#endif
+
 /* Check that if WOLFSSL_MAX_STRENGTH is set that all the required options are
  * not turned off. */
 #if defined(WOLFSSL_MAX_STRENGTH) && \
@@ -305,7 +311,7 @@
 #ifndef WOLFSSL_AEAD_ONLY
     #if !defined(NO_RSA) && !defined(NO_RC4)
         #if defined(WOLFSSL_STATIC_RSA)
-            #if !defined(NO_SHA)
+            #if !defined(NO_TLS_SHA1)
                 #define BUILD_SSL_RSA_WITH_RC4_128_SHA
             #endif
             #if !defined(NO_MD5)
@@ -315,7 +321,7 @@
     #endif
 
     #if !defined(NO_RSA) && !defined(NO_DES3)
-        #if !defined(NO_SHA)
+        #if !defined(NO_TLS_SHA1)
             #if defined(WOLFSSL_STATIC_RSA)
                 #define BUILD_SSL_RSA_WITH_3DES_EDE_CBC_SHA
             #endif
@@ -324,7 +330,7 @@
 #endif /* !WOLFSSL_AEAD_ONLY */
 
     #if !defined(NO_RSA) && !defined(NO_AES) && !defined(NO_TLS)
-        #if !defined(NO_SHA) && defined(HAVE_AES_CBC)
+        #if !defined(NO_TLS_SHA1) && defined(HAVE_AES_CBC)
             #if defined(WOLFSSL_STATIC_RSA)
                 #ifdef WOLFSSL_AES_128
                     #define BUILD_TLS_RSA_WITH_AES_128_CBC_SHA
@@ -365,7 +371,7 @@
     #if defined(HAVE_CAMELLIA) && !defined(NO_TLS) && !defined(NO_CAMELLIA_CBC)
         #ifndef NO_RSA
           #if defined(WOLFSSL_STATIC_RSA)
-            #if !defined(NO_SHA)
+            #if !defined(NO_TLS_SHA1)
                 #define BUILD_TLS_RSA_WITH_CAMELLIA_128_CBC_SHA
                 #define BUILD_TLS_RSA_WITH_CAMELLIA_256_CBC_SHA
             #endif
@@ -375,7 +381,7 @@
             #endif
           #endif
             #if !defined(NO_DH)
-              #if !defined(NO_SHA)
+              #if !defined(NO_TLS_SHA1)
                 #define BUILD_TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA
                 #define BUILD_TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA
               #endif
@@ -389,7 +395,7 @@
 
 #if defined(WOLFSSL_STATIC_PSK)
     #if !defined(NO_PSK) && !defined(NO_AES) && !defined(NO_TLS)
-        #if !defined(NO_SHA)
+        #if !defined(NO_TLS_SHA1)
             #ifdef WOLFSSL_AES_128
                 #define BUILD_TLS_PSK_WITH_AES_128_CBC_SHA
             #endif
@@ -434,7 +440,7 @@
                 #ifndef NO_MD5
                     #define BUILD_TLS_RSA_WITH_NULL_MD5
                 #endif
-                #if !defined(NO_SHA)
+                #if !defined(NO_TLS_SHA1)
                     #define BUILD_TLS_RSA_WITH_NULL_SHA
                 #endif
                 #ifndef NO_SHA256
@@ -443,7 +449,7 @@
             #endif
         #endif
         #if !defined(NO_PSK) && defined(WOLFSSL_STATIC_PSK)
-            #if !defined(NO_SHA)
+            #if !defined(NO_TLS_SHA1)
                 #define BUILD_TLS_PSK_WITH_NULL_SHA
             #endif
             #ifndef NO_SHA256
@@ -458,7 +464,7 @@
     #if !defined(NO_DH) && !defined(NO_AES) && !defined(NO_TLS) && \
         !defined(NO_RSA)
 
-        #if !defined(NO_SHA)
+        #if !defined(NO_TLS_SHA1)
             #if defined(WOLFSSL_AES_128) && defined(HAVE_AES_CBC)
                 #define BUILD_TLS_DHE_RSA_WITH_AES_128_CBC_SHA
             #endif
@@ -480,7 +486,7 @@
     #endif
 
     #if defined(HAVE_ANON) && !defined(NO_TLS) && !defined(NO_DH) && \
-        !defined(NO_AES) && !defined(NO_SHA) && defined(WOLFSSL_AES_128)
+        !defined(NO_AES) && !defined(NO_TLS_SHA1) && defined(WOLFSSL_AES_128)
         #ifdef HAVE_AES_CBC
             #define BUILD_TLS_DH_anon_WITH_AES_128_CBC_SHA
         #endif
@@ -514,7 +520,7 @@
     #if (defined(HAVE_ECC) || defined(HAVE_CURVE25519) || \
                                      defined(HAVE_CURVE448)) && !defined(NO_TLS)
         #if !defined(NO_AES)
-            #if !defined(NO_SHA) && defined(HAVE_AES_CBC)
+            #if !defined(NO_TLS_SHA1) && defined(HAVE_AES_CBC)
                 #if !defined(NO_RSA)
                     #ifdef WOLFSSL_AES_128
                         #define BUILD_TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
@@ -551,7 +557,7 @@
                         #define BUILD_TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA
                     #endif
                 #endif
-            #endif /* NO_SHA */
+            #endif /* NO_TLS_SHA1 */
             #if !defined(NO_SHA256) && defined(WOLFSSL_AES_128) && \
                                                            defined(HAVE_AES_CBC)
                 #if !defined(NO_RSA)
@@ -618,7 +624,7 @@
             #endif
         #endif /* NO_AES */
         #if !defined(NO_RC4)
-            #if !defined(NO_SHA)
+            #if !defined(NO_TLS_SHA1)
                 #if !defined(NO_RSA)
                     #ifndef WOLFSSL_AEAD_ONLY
                         #define BUILD_TLS_ECDHE_RSA_WITH_RC4_128_SHA
@@ -641,7 +647,7 @@
             #endif
         #endif
         #if !defined(NO_DES3)
-            #ifndef NO_SHA
+            #ifndef NO_TLS_SHA1
                 #if !defined(NO_RSA)
                     #define BUILD_TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
                     #if defined(WOLFSSL_STATIC_DH) && defined(HAVE_ECC)
@@ -657,10 +663,10 @@
                 #if defined(WOLFSSL_STATIC_DH) && defined(HAVE_ECC)
                     #define BUILD_TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA
                 #endif
-            #endif /* NO_SHA */
+            #endif /* NO_TLS_SHA1 */
         #endif
         #if defined(HAVE_NULL_CIPHER)
-            #if !defined(NO_SHA)
+            #if !defined(NO_TLS_SHA1)
                 #if defined(HAVE_ECC) || \
                         (defined(HAVE_CURVE25519) && defined(HAVE_ED25519)) || \
                         (defined(HAVE_CURVE448) && defined(HAVE_ED448))


### PR DESCRIPTION
# Description

Allow disabling SHA1 cipher suites without disabling wolfCrypt SHA1 support by defining NO_TLS_SHA1. 
Remove incorrect cast of MP_MASK comparison in BN functions.

Fixes ZD#14878, ZD#14935