### PR TITLE
20221201-fix-kcapi

### DIFF
--- a/wolfcrypt/src/port/kcapi/kcapi_aes.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_aes.c
@@ -241,7 +241,9 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
 #endif
 
     /* argument checks */
-    if (aes == NULL || authTagSz > AES_BLOCK_SIZE) {
+    if ((aes == NULL) || ((sz != 0 && (in == NULL || out == NULL))) ||
+        (iv == NULL) || ((authTag == NULL) && (authTagSz > 0)) ||
+        (authTagSz > AES_BLOCK_SIZE) || ((authIn == NULL) && (authInSz > 0))) {
         ret = BAD_FUNC_ARG;
     }
 
@@ -352,8 +354,9 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
 #endif
 
     /* argument checks */
-    if (aes == NULL || (sz != 0 && (in == NULL || out == NULL)) ||
-                                                   authTagSz > AES_BLOCK_SIZE) {
+    if ((aes == NULL) || ((sz != 0 && (in == NULL || out == NULL))) ||
+        (iv == NULL) || ((authTag == NULL) && (authTagSz > 0)) ||
+        (authTagSz > AES_BLOCK_SIZE) || ((authIn == NULL) && (authInSz > 0))) {
         ret = BAD_FUNC_ARG;
     }
 


### PR DESCRIPTION
`wolfcrypt/src/port/kcapi/kcapi_aes.c`: fix error checking on KCAPI `wc_AesGcmEncrypt()` and `wc_AesGcmDecrypt()`.

tested with `wolfssl-multi-test.sh ... fips-140-3-dev-kcapi check-file-modes check-source-text check-shell-scripts all-gcc-c99`

fixes defect exposed by `unit.test` starting with commit e4e53ab7ca5031.
