### PR TITLE
SP int: fix which APIs are public available wiht WOLFSSL_SP_MATH

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -7661,8 +7661,7 @@ void sp_rshd(sp_int* a, int c)
         }
     }
 }
-#endif /* (WOLFSSL_SP_MATH_ALL && !WOLFSSL_RSA_VERIFY_ONLY) || !NO_DH ||
-        * HAVE_ECC || (!NO_RSA && !WOLFSSL_RSA_VERIFY_ONLY) */
+#endif /* WOLFSSL_SP_MATH_ALL */
 
 #if defined(WOLFSSL_SP_MATH_ALL) || !defined(NO_DH) || defined(HAVE_ECC) || \
     (!defined(NO_RSA) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
@@ -7955,9 +7954,6 @@ static int _sp_div(sp_int* a, sp_int* d, sp_int* r, sp_int* trial)
  * @return  MP_VAL when a or d is NULL, r and rem are NULL, or d is 0.
  * @return  MP_MEM when dynamic memory allocation fails.
  */
-#ifndef WOLFSSL_SP_MATH_ALL
-static
-#endif
 int sp_div(sp_int* a, sp_int* d, sp_int* r, sp_int* rem)
 {
     int err = MP_OKAY;

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -881,10 +881,14 @@ MP_API int sp_addmod_ct (sp_int* a, sp_int* b, sp_int* c, sp_int* d);
 #endif
 
 MP_API int sp_lshd(sp_int* a, int s);
+#ifdef WOLFSSL_SP_MATH_ALL
 MP_API void sp_rshd(sp_int* a, int c);
+#endif
 MP_API int sp_rshb(sp_int* a, int n, sp_int* r);
 
-#ifdef WOLFSSL_SP_MATH_ALL
+#if defined(WOLFSSL_SP_MATH_ALL) || !defined(NO_DH) || defined(HAVE_ECC) || \
+    (!defined(NO_RSA) && !defined(WOLFSSL_RSA_VERIFY_ONLY) && \
+     !defined(WOLFSSL_RSA_PUBLIC_ONLY))
 MP_API int sp_div(sp_int* a, sp_int* d, sp_int* r, sp_int* rem);
 #endif
 MP_API int sp_mod(sp_int* a, sp_int* m, sp_int* r);


### PR DESCRIPTION
# Description

Make sp_rshd not available when WOLFSSL_SP_MATH in header. sp_rshd is not required by any wolfCrypt code.
Fix sp_rshd comment on #endif
Make sp_div publicly available in some WOLFSSL_SP_MATH builds. Delare sp_div for some WOLFSSL_SP_MATH builds.
Fix test.c to compile with WOLFSL_SP_MATH and HAVE_VALGRIND.

# Testing

./configure '--enable-sp' '--enable-sp-math' '--enable-valgrind'

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
