### PR TITLE
be more strict on CSR version number allowed

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -31162,12 +31162,14 @@ static int MakeCertReq(Cert* cert, byte* derBuffer, word32 derSz,
     DerCert der[1];
 #endif
 
+#ifndef WOLFSSL_NO_ASN_STRICT
     /* check that the cert. req. version matches rfc2986 sect. 4.1 */
     if (cert->version != 0) {
         WOLFSSL_MSG("Only version 0 for CSR supported");
         WOLFSSL_ERROR_VERBOSE(ASN_VERSION_E);
         return ASN_VERSION_E;
     }
+#endif
 
     if (eccKey)
         cert->keyType = ECC_KEY;
@@ -31256,12 +31258,14 @@ static int MakeCertReq(Cert* cert, byte* derBuffer, word32 derSz,
     (void)dilithiumKey;
     (void)sphincsKey;
 
+#ifndef WOLFSSL_NO_ASN_STRICT
     /* check that the cert. req. version matches rfc2986 sect. 4.1 */
     if (cert->version != 0) {
         WOLFSSL_MSG("Only version 0 for CSR supported");
         WOLFSSL_ERROR_VERBOSE(ASN_VERSION_E);
         return ASN_VERSION_E;
     }
+#endif
 
     CALLOC_ASNSETDATA(dataASN, certReqBodyASN_Length, ret, cert->heap);
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -31162,6 +31162,13 @@ static int MakeCertReq(Cert* cert, byte* derBuffer, word32 derSz,
     DerCert der[1];
 #endif
 
+    /* check that the cert. req. version matches rfc2986 sect. 4.1 */
+    if (cert->version != 0) {
+        WOLFSSL_MSG("Only version 0 for CSR supported");
+        WOLFSSL_ERROR_VERBOSE(ASN_VERSION_E);
+        return ASN_VERSION_E;
+    }
+
     if (eccKey)
         cert->keyType = ECC_KEY;
     else if (rsaKey)
@@ -31248,6 +31255,13 @@ static int MakeCertReq(Cert* cert, byte* derBuffer, word32 derSz,
     (void)falconKey;
     (void)dilithiumKey;
     (void)sphincsKey;
+
+    /* check that the cert. req. version matches rfc2986 sect. 4.1 */
+    if (cert->version != 0) {
+        WOLFSSL_MSG("Only version 0 for CSR supported");
+        WOLFSSL_ERROR_VERBOSE(ASN_VERSION_E);
+        return ASN_VERSION_E;
+    }
 
     CALLOC_ASNSETDATA(dataASN, certReqBodyASN_Length, ret, cert->heap);
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -21820,6 +21820,13 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_test(void)
     #endif /* WOLFSSL_EKU_OID */
     #endif /* WOLFSSL_CERT_EXT */
 
+        req->version = 2; /* test bad version fails */
+        derSz = wc_MakeCertReq(req, der, FOURK_BUF, key, NULL);
+        if (derSz >= 0) {
+            ERROR_OUT(-7976, exit_rsa);
+        }
+
+        req->version = 0;
         derSz = wc_MakeCertReq(req, der, FOURK_BUF, key, NULL);
         if (derSz < 0) {
             ERROR_OUT(WC_TEST_RET_ENC_EC(derSz), exit_rsa);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -21820,11 +21820,13 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_test(void)
     #endif /* WOLFSSL_EKU_OID */
     #endif /* WOLFSSL_CERT_EXT */
 
+    #ifndef WOLFSSL_NO_ASN_STRICT
         req->version = 2; /* test bad version fails */
         derSz = wc_MakeCertReq(req, der, FOURK_BUF, key, NULL);
         if (derSz >= 0) {
             ERROR_OUT(-7976, exit_rsa);
         }
+    #endif
 
         req->version = 0;
         derSz = wc_MakeCertReq(req, der, FOURK_BUF, key, NULL);


### PR DESCRIPTION
ZD15260

This impacts CSR creation and no longer allows making a CSR with a version other than 0. The only downside currently is that wc_InitCert defaults to version '2' for the typical X509 creation, which if a user does not explicitly update the default version after calling wc_InitCert they would now see a ASN_VERSION_E when creating CSR's. 