### PR TITLE
20221203-sp-int-missing-const

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -16332,7 +16332,7 @@ static int _sp_mont_red(sp_int* a, const sp_int* m, sp_int_digit mp)
         sp_int_digit h;
         sp_int_digit o2;
         sp_int_digit* ad;
-        sp_int_digit* md;
+        const sp_int_digit* md;
 
         o = 0;
         o2 = 0;


### PR DESCRIPTION
`wolfcrypt/src/sp_int.c`: in `_sp_mont_red()`, add missing const in `SP_WORD_SIZE == 32` codepath.

tested with `wolfssl-multi-test.sh ... cross-armv7a-all-armasm-testsuite check-file-modes check-source-text check-shell-scripts all-gcc-c99`
