### PR TITLE
Fix mingw-w64 build issues on windows.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8123,8 +8123,9 @@ AX_HARDEN_CC_COMPILER_FLAGS
 
 case $host_os in
     mingw*)
-        # if mingw then link to ws2_32 for sockets
+        # if mingw then link to ws2_32 for sockets, and crypt32
         LDFLAGS="$LDFLAGS -lws2_32"
+        LIB_ADD="$LIB_ADD -lcrypt32"
         if test "$enable_shared" = "yes"
         then
             AC_DEFINE([WOLFSSL_DLL], [1], [Use __declspec(dllexport) when building library])

--- a/src/bio.c
+++ b/src/bio.c
@@ -2144,7 +2144,7 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
             return WOLFSSL_FAILURE;
         }
 
-        b->num = (int) sfd;
+        b->num = (int)sfd;
         b->shutdown = BIO_CLOSE;
         return WOLFSSL_SUCCESS;
     }
@@ -2173,7 +2173,7 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
                 WOLFSSL_ENTER("wolfIO_TcpBind error");
                 return WOLFSSL_FAILURE;
             }
-            b->num = (int) sfd;
+            b->num = (int)sfd;
             b->shutdown = BIO_CLOSE;
         }
         else {

--- a/src/bio.c
+++ b/src/bio.c
@@ -2144,7 +2144,7 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
             return WOLFSSL_FAILURE;
         }
 
-        b->num = sfd;
+        b->num = (int) sfd;
         b->shutdown = BIO_CLOSE;
         return WOLFSSL_SUCCESS;
     }
@@ -2173,7 +2173,7 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
                 WOLFSSL_ENTER("wolfIO_TcpBind error");
                 return WOLFSSL_FAILURE;
             }
-            b->num = sfd;
+            b->num = (int) sfd;
             b->shutdown = BIO_CLOSE;
         }
         else {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -165,9 +165,14 @@
 #ifdef WOLFSSL_SYS_CA_CERTS
 
 #ifdef _WIN32
-#include <windows.h>
-#include <Wincrypt.h>
-#pragma comment(lib, "crypt32")
+  #include <windows.h>
+  #include <Wincrypt.h>
+
+  /* mingw gcc does not support pragma comment, and the
+   * linking with crypt32 is handled in configure.ac */
+  #if !defined(__MINGW32__) && !defined(__MINGW64__)
+    #pragma comment(lib, "crypt32")
+  #endif
 #endif
 
 #if defined(__APPLE__) && defined(HAVE_SECURITY_SECTRUSTSETTINGS_H)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -165,14 +165,14 @@
 #ifdef WOLFSSL_SYS_CA_CERTS
 
 #ifdef _WIN32
-  #include <windows.h>
-  #include <Wincrypt.h>
+    #include <windows.h>
+    #include <Wincrypt.h>
 
-  /* mingw gcc does not support pragma comment, and the
-   * linking with crypt32 is handled in configure.ac */
-  #if !defined(__MINGW32__) && !defined(__MINGW64__)
-    #pragma comment(lib, "crypt32")
-  #endif
+    /* mingw gcc does not support pragma comment, and the
+     * linking with crypt32 is handled in configure.ac */
+    #if !defined(__MINGW32__) && !defined(__MINGW64__)
+        #pragma comment(lib, "crypt32")
+    #endif
 #endif
 
 #if defined(__APPLE__) && defined(HAVE_SECURITY_SECTRUSTSETTINGS_H)

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -837,7 +837,7 @@ int wolfIO_Recv(SOCKET_T sd, char *buf, int sz, int rdFlags)
     int recvd;
 
     recvd = (int)RECV_FUNCTION(sd, buf, sz, rdFlags);
-    recvd = TranslateReturnCode(recvd, (int) sd);
+    recvd = TranslateReturnCode(recvd, (int)sd);
 
     return recvd;
 }
@@ -847,7 +847,7 @@ int wolfIO_Send(SOCKET_T sd, char *buf, int sz, int wrFlags)
     int sent;
 
     sent = (int)SEND_FUNCTION(sd, buf, sz, wrFlags);
-    sent = TranslateReturnCode(sent, (int) sd);
+    sent = TranslateReturnCode(sent, (int)sd);
 
     return sent;
 }
@@ -1800,7 +1800,7 @@ int EmbedOcspLookup(void* ctx, const char* url, int urlSz,
                 WOLFSSL_MSG("OCSP ocsp request failed");
             }
             else {
-                ret = wolfIO_HttpProcessResponseOcsp((int) sfd, ocspRespBuf, httpBuf,
+                ret = wolfIO_HttpProcessResponseOcsp((int)sfd, ocspRespBuf, httpBuf,
                                                  HTTP_SCRATCH_BUFFER_SIZE, ctx);
             }
             if (sfd != SOCKET_INVALID)

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -837,7 +837,7 @@ int wolfIO_Recv(SOCKET_T sd, char *buf, int sz, int rdFlags)
     int recvd;
 
     recvd = (int)RECV_FUNCTION(sd, buf, sz, rdFlags);
-    recvd = TranslateReturnCode(recvd, sd);
+    recvd = TranslateReturnCode(recvd, (int) sd);
 
     return recvd;
 }
@@ -847,7 +847,7 @@ int wolfIO_Send(SOCKET_T sd, char *buf, int sz, int wrFlags)
     int sent;
 
     sent = (int)SEND_FUNCTION(sd, buf, sz, wrFlags);
-    sent = TranslateReturnCode(sent, sd);
+    sent = TranslateReturnCode(sent, (int) sd);
 
     return sent;
 }
@@ -1142,6 +1142,7 @@ int wolfIO_TcpConnect(SOCKET_T* sockfd, const char* ip, word16 port, int to_sec)
 #endif
     {
         WOLFSSL_MSG("bad socket fd, out of fds?");
+        *sockfd = SOCKET_INVALID;
         return -1;
     }
 
@@ -1206,7 +1207,12 @@ int wolfIO_TcpBind(SOCKET_T* sockfd, word16 port)
     sin->sin_port = XHTONS(port);
     *sockfd = (SOCKET_T)socket(AF_INET, SOCK_STREAM, 0);
 
-    if (*sockfd < 0) {
+#ifdef USE_WINDOWS_API
+    if (*sockfd == SOCKET_INVALID)
+#else
+    if (*sockfd <= SOCKET_INVALID)
+#endif
+    {
         WOLFSSL_MSG("socket failed");
         *sockfd = SOCKET_INVALID;
         return -1;
@@ -1794,7 +1800,7 @@ int EmbedOcspLookup(void* ctx, const char* url, int urlSz,
                 WOLFSSL_MSG("OCSP ocsp request failed");
             }
             else {
-                ret = wolfIO_HttpProcessResponseOcsp(sfd, ocspRespBuf, httpBuf,
+                ret = wolfIO_HttpProcessResponseOcsp((int) sfd, ocspRespBuf, httpBuf,
                                                  HTTP_SCRATCH_BUFFER_SIZE, ctx);
             }
             if (sfd != SOCKET_INVALID)

--- a/tests/api.c
+++ b/tests/api.c
@@ -36310,8 +36310,8 @@ static int test_wolfSSL_set_options(void)
                WOLFSSL_OP_NO_COMPRESSION) == WOLFSSL_OP_NO_COMPRESSION);
 
 #ifdef OPENSSL_EXTRA
-    AssertNull((wolfSSL_clear_options(ssl, WOLFSSL_OP_NO_COMPRESSION) &
-                                      WOLFSSL_OP_NO_COMPRESSION));
+    AssertFalse((wolfSSL_clear_options(ssl, WOLFSSL_OP_NO_COMPRESSION) &
+                                       WOLFSSL_OP_NO_COMPRESSION));
 #endif
 
 #ifdef OPENSSL_EXTRA

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -451,7 +451,12 @@ void wait_tcp_ready(func_args* args)
     (void)tx_mutex_put(&args->signal->mutex);
 #elif defined(USE_WINDOWS_API)
     /* Give peer a moment to get running */
-    _sleep(500);
+    #if defined(__MINGW32__) || defined(__MINGW64__)
+        Sleep(500);
+    #else
+        _sleep(500);
+    #endif
+    (void)args;
 #else
     (void)args;
 #endif

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -358,7 +358,11 @@
 #endif
 
 #ifdef USE_WINDOWS_API
-    typedef unsigned int SOCKET_T;
+    #if defined(__MINGW64__)
+        typedef size_t SOCKET_T;
+    #else
+        typedef unsigned int SOCKET_T;
+    #endif
     #ifndef SOCKET_INVALID
         #define SOCKET_INVALID INVALID_SOCKET
     #endif
@@ -745,7 +749,11 @@ WOLFSSL_API void wolfSSL_SetIOWriteFlags(WOLFSSL* ssl, int flags);
     #define XINET_PTON(a,b,c)   inet_pton((a),(b),(c))
     #ifdef USE_WINDOWS_API /* Windows-friendly definition */
         #undef  XINET_PTON
-        #define XINET_PTON(a,b,c)   InetPton((a),(PCWSTR)(b),(c))
+        #if defined(__MINGW64__) && !defined(UNICODE)
+            #define XINET_PTON(a,b,c)   InetPton((a),(b),(c))
+        #else
+            #define XINET_PTON(a,b,c)   InetPton((a),(PCWSTR)(b),(c))
+        #endif
     #endif
 #endif
 


### PR DESCRIPTION
# Description

Fix mingw-w64 build errors and warnings on windows 64.

Fixes github issue #5775.

warnings and errors fixed:
- unsupported `#pragma comment(lib, "crypt32")`.
- crypt32 wasn't being linked.
- mingw-w64 64bit `SOCKET_INVALID` was overflowing `'SOCKET_T' (aka 'unsigned int') `.
- a few places where sockfd was checked like Unix sockets instead of Windows.
- misc casting fixes/cleanup for errors with clang on mingw-w64.
- `_sleep()` is deprecated on mingw, use alternative `Sleep()` instead.


# Testing

Tested variety of configure options with mingw64 gcc and clang, and verified all built without warnings or errors.

Configure options:

```
 ./configure --host=x86_64-w64-mingw32 --enable-fastmath --enable-tls13 \
   --disable-errorstrings --disable-oldtls --enable-static \
   --disable-crypttests --disable-examples \
   || exit 1
```

```
 ./configure CC="/mingw64/bin/clang.exe" --host=x86_64-w64-mingw32 --enable-fastmath --enable-tls13 \
   --disable-errorstrings --disable-oldtls --enable-static \
   --enable-opensslall --enable-opensslextra --enable-rsa \
   --disable-crypttests --disable-examples \
   || exit 1
```
   
```
 ./configure --host=x86_64-w64-mingw32 --enable-tls13 \
   --disable-errorstrings --disable-oldtls --enable-static \
   --enable-opensslall --enable-opensslextra --enable-rsa \
   --disable-crypttests --disable-examples \
   || exit 1
 ```

```
./configure \
  --build=x86_64-w64-mingw32 --host=x86_64-w64-mingw32 --disable-crl-monitor \
  --enable-opensslall --enable-opensslextra --enable-rsa \
  || exit 1
```

clang and gcc used:

```
clang version 15.0.3
Target: x86_64-w64-windows-gnu
Thread model: posix
```

```
gcc.exe (Rev4, Built by MSYS2 project) 12.2.0
```