### PR TITLE
DRBG OK

### DIFF
--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -848,20 +848,32 @@ static int _InitRng(WC_RNG* rng, byte* nonce, word32 nonceSz,
 #ifdef WOLFSSL_ASYNC_CRYPT
     ret = wolfAsync_DevCtxInit(&rng->asyncDev, WOLFSSL_ASYNC_MARKER_RNG,
                                                         rng->heap, rng->devId);
-    if (ret != 0)
+    if (ret != 0) {
+    #ifdef HAVE_HASHDRBG
+        rng->status = DRBG_OK;
+    #endif
         return ret;
+    }
 #endif
 
 #ifdef HAVE_INTEL_RDRAND
     /* if CPU supports RDRAND, use it directly and by-pass DRBG init */
-    if (IS_INTEL_RDRAND(intel_flags))
+    if (IS_INTEL_RDRAND(intel_flags)) {
+    #ifdef HAVE_HASHDRBG
+        rng->status = DRBG_OK;
+    #endif
         return 0;
+    }
 #endif
 
 #ifdef WOLFSSL_XILINX_CRYPT_VERSAL
     ret = wc_VersalTrngInit(nonce, nonceSz);
-    if (ret)
+    if (ret) {
+    #ifdef HAVE_HASHDRBG
+        rng->status = DRBG_OK;
+    #endif
         return ret;
+    }
 #endif
 
 #ifdef CUSTOM_RAND_GENERATE_BLOCK


### PR DESCRIPTION
# Description

When initializing the RNG and are using RDRAND, or one of the other replacement random number generators that could fall back to the Hash_DRBG if unavailable, set the status to DRBG_OK. This would fix a problem if someone assumes the DRBG status is meaningful.

Fixes issue #4239.

# Testing

    % ./configure --enable-intelrand --enable-debug --disable-shared

On an Intel based machine, run the wolfCrypt test in the debugger. Set a breakpoint on function `wc_RngInit_ex()`. Step through it to verify the DRBG `status` is set to `DRBG_OK`.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
