### PR TITLE
gitignore old cmake, VisualGDB working & Espressif sdkconfig files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -404,3 +404,13 @@ async
 
 # Generated user_settings_asm.h.
 user_settings_asm.h
+
+# VisualGD
+**/.visualgdb
+
+# Espressif sdk config default should be saved in sdkconfig.defaults
+# we won't track the actual working sdkconfig files
+/IDE/Espressif/**/sdkconfig
+
+# auto-created CMake backups
+**/CMakeLists.txt.old


### PR DESCRIPTION
# Description

- Ignores VisualGDB working files found in any `.visualgdb` directory anywhere

- Ignores all `sdkconfig` files in any subdirectory of `/IDE/Espressif`

-  Ignores all `CMakeLists.txt.old` files found anywhere.

Fixes zd#  (n/a)

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
