### PR TITLE
Fixups for problems discovered while testing for DTLS 1.3

### DIFF
--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -117,6 +117,7 @@ typedef struct Dtls13RecordPlaintextHeader {
 #define DTLS13_MIN_CIPHERTEXT 16
 #define DTLS13_MIN_RTX_INTERVAL 1
 
+#ifndef NO_WOLFSSL_CLIENT
 WOLFSSL_METHOD* wolfDTLSv1_3_client_method_ex(void* heap)
 {
     WOLFSSL_METHOD* method;
@@ -131,6 +132,14 @@ WOLFSSL_METHOD* wolfDTLSv1_3_client_method_ex(void* heap)
     return method;
 }
 
+WOLFSSL_METHOD* wolfDTLSv1_3_client_method(void)
+{
+    return wolfDTLSv1_3_client_method_ex(NULL);
+}
+#endif /* !NO_WOLFSSL_CLIENT */
+
+
+#ifndef NO_WOLFSSL_SERVER
 WOLFSSL_METHOD* wolfDTLSv1_3_server_method_ex(void* heap)
 {
     WOLFSSL_METHOD* method;
@@ -147,15 +156,11 @@ WOLFSSL_METHOD* wolfDTLSv1_3_server_method_ex(void* heap)
     return method;
 }
 
-WOLFSSL_METHOD* wolfDTLSv1_3_client_method(void)
-{
-    return wolfDTLSv1_3_client_method_ex(NULL);
-}
-
 WOLFSSL_METHOD* wolfDTLSv1_3_server_method(void)
 {
     return wolfDTLSv1_3_server_method_ex(NULL);
 }
+#endif /* !NO_WOLFSSL_SERVER */
 
 int Dtls13RlAddPlaintextHeader(WOLFSSL* ssl, byte* out,
     enum ContentType content_type, word16 length)

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -1184,10 +1184,11 @@ static void TraceSequence(word32 seq, int len)
 
 
 /* Show sequence and payload length for Trace */
-static void TraceAck(word32 ack, word32 expected)
+static void TraceAck(word32 acknowledgement, word32 expected)
 {
     if (TraceOn) {
-        XFPRINTF(TraceFile, "\tAck:%u Expected:%u\n", ack, expected);
+        XFPRINTF(TraceFile, "\tAck:%u Expected:%u\n", acknowledgement,
+                 expected);
     }
 }
 
@@ -6258,6 +6259,10 @@ doPart:
             sslFrame += rhSize;
             sslBytes -= rhSize;
             break;
+#ifdef WOLFSSL_DTLS13
+        case ack:
+            /* TODO */
+#endif /* WOLFSSL_DTLS13 */
         case no_type:
         default:
             SetError(GOT_UNKNOWN_RECORD_STR, error, session, FATAL_ERROR_STATE);

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -10479,7 +10479,8 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         ret = DoTls13KeyUpdate(ssl, input, inOutIdx, size);
         break;
 
-#if defined(WOLFSSL_DTLS13) && !defined(WOLFSSL_NO_TLS12)
+#if defined(WOLFSSL_DTLS13) && !defined(WOLFSSL_NO_TLS12) && \
+    !defined(NO_WOLFSSL_CLIENT)
     case hello_verify_request:
         WOLFSSL_MSG("processing hello verify request");
         ret = DoHelloVerifyRequest(ssl, input, inOutIdx, size);
@@ -11229,7 +11230,7 @@ int wolfSSL_disable_hrr_cookie(WOLFSSL* ssl)
         return BAD_FUNC_ARG;
 
 #ifdef NO_WOLFSSL_SERVER
-    return SIDE_ERROR
+    return SIDE_ERROR;
 #else
     if (ssl->options.side == WOLFSSL_CLIENT_END)
         return SIDE_ERROR;

--- a/tests/api.c
+++ b/tests/api.c
@@ -56041,7 +56041,9 @@ static int test_wolfSSL_dtls_bad_record(void) {
 }
 #endif
 
-#if defined(WOLFSSL_DTLS13) && !defined(WOLFSSL_TLS13_IGNORE_AEAD_LIMITS)
+#if defined(WOLFSSL_DTLS13) && !defined(WOLFSSL_TLS13_IGNORE_AEAD_LIMITS) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    defined(HAVE_IO_TESTS_DEPENDENCIES)
 static byte test_AEAD_fail_decryption = 0;
 static byte test_AEAD_seq_num = 0;
 static byte test_AEAD_done = 0;


### PR DESCRIPTION
The problems were found with the following configurations: 

```
./configure --enable-dtls --enable-dtls13 CFLAGS="-DNO_WOLFSSL_CLIENT"
./configure --enable-dtls --enable-dtls13 CFLAGS="-DNO_WOLFSSL_SERVER"
./configure --enable-tls13 --disable-oldtls --enable-static --enable-singlethreaded --enable-dtls --enable-dtls13 --enable-sp=yes,4096 --disable-shared --enable-dtls-mtu --disable-sha3 --disable-dh --enable-curve25519 --enable-secure-renegotiation C_EXTRA_FLAGS="-DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DFP_MAX_BITS=8192 -fomit-frame-pointer"
```