### PR TITLE
Fix API test `test_wc_ecc_import_raw` with SP math

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -25479,9 +25479,11 @@ static int test_wc_ecc_import_raw(void)
 
     ret = wc_ecc_init(&key);
 
+    /* Test good import */
     if (ret == 0) {
         ret = wc_ecc_import_raw(&key, qx, qy, d, curveName);
     }
+
     /* Test bad args. */
     if (ret == 0) {
         ret = wc_ecc_import_raw(NULL, qx, qy, d, curveName);
@@ -25510,14 +25512,23 @@ static int test_wc_ecc_import_raw(void)
             wc_ecc_free(&key);
         #endif
             ret = wc_ecc_import_raw(&key, "0", qy, d, curveName);
+            /* Note: SP math "is point" failure returns MP_VAL */
+            if (ret == ECC_INF_E || ret == MP_VAL) {
+                ret = BAD_FUNC_ARG; /* This is expected by other tests */
+            }
         }
         if (ret == BAD_FUNC_ARG) {
         #if !defined(USE_FAST_MATH) && !defined(WOLFSSL_SP_MATH)
             wc_ecc_free(&key);
         #endif
             ret = wc_ecc_import_raw(&key, qx, "0", d, curveName);
+            /* Note: SP math "is point" failure returns MP_VAL */
+            if (ret == ECC_INF_E || ret == MP_VAL) {
+                ret = BAD_FUNC_ARG; /* This is expected by other tests */
+            }
         }
     #endif
+
         if (ret == BAD_FUNC_ARG) {
             ret = 0;
         }

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -684,7 +684,7 @@ int wc_ERR_remove_state(void)
  * In case all entries are ignored, the ERR queue will be empty afterwards.
  * For an empty ERR queue  0 is returned.
  *
- * ìgnore_err` may be NULL, in which case this returns the HEAD values.
+ * `ignore_err` may be NULL, in which case this returns the HEAD values.
  *
  * `flags` is present for OpenSSL compatibility, but will always be
  * set to 0, since we do not keep flags at ERR entries.


### PR DESCRIPTION
# Description

* Fix `test_wc_ecc_import_raw` to handle `ECC_INF_E` or `MP_VAL` on point failures. SP math returns `MP_VAL` in `sp_256_ecc_is_point_4`.
* Fix unicode char in logging.c.

# Testing

```
./configure CC="clang -fsanitize=address,undefined" --enable-all --enable-intelasm --enable-sp-math-all --enable-sp-asm CFLAGS="-DWOLFSSL_VALIDATE_ECC_IMPORT -DWOLFSSL_VALIDATE_ECC_KEYGEN" --enable-debug --disable-shared && make
./tests/unit.test -725
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
