### PR TITLE
Don't create a key if we don't support the curve.

### DIFF
--- a/src/pk.c
+++ b/src/pk.c
@@ -9168,12 +9168,19 @@ WOLFSSL_EC_KEY *wolfSSL_EC_KEY_new_by_curve_name(int nid)
 
     if (eccEnum != -1) {
         /* search and set the corresponding internal curve idx */
-        for (x = 0; ecc_sets[x].size != 0; x++)
+        for (x = 0; ecc_sets[x].size != 0; x++) {
             if (ecc_sets[x].id == eccEnum) {
                 key->group->curve_idx = x;
                 key->group->curve_oid = ecc_sets[x].oidSum;
                 break;
             }
+        }
+
+        /* if not found, we don't support this curve. */
+        if (ecc_sets[x].size == 0) {
+            wolfSSL_EC_KEY_free(key);
+            key = NULL;
+        }
     }
 
     return key;

--- a/tests/api.c
+++ b/tests/api.c
@@ -46165,7 +46165,7 @@ static int test_wolfSSL_EC_KEY_print_fp(void)
 {
     int res = TEST_SKIPPED;
 #if defined(HAVE_ECC) && ((defined(HAVE_ECC224) && defined(HAVE_ECC256)) || \
-    defined(HAVE_ALL_CURVES)) && ECC_MIN_KEY_SZ <= 256 && \
+    defined(HAVE_ALL_CURVES)) && ECC_MIN_KEY_SZ <= 224 && \
     defined(OPENSSL_EXTRA) && defined(XFPRINTF) && !defined(NO_FILESYSTEM) && \
     !defined(NO_STDIO_FILESYSTEM)
     EC_KEY* key = NULL;


### PR DESCRIPTION
Found with the following configuration:

./configure --enable-tls13 --disable-oldtls --enable-static --enable-singlethreaded --enable-dtls --enable-dtls13 --enable-dtls-mtu --enable-sp=yes,4096 --disable-shared --disable-sha3 --disable-dh --enable-curve25519 --enable-secure-renegotiation --enable-debug --enable-opensslextra 'CFLAGS=-DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DFP_MAX_BITS=8192 -fomit-frame-pointer'

