### PR TITLE
TLS: detect duplicate known extensions

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -23355,6 +23355,9 @@ const char* wolfSSL_ERR_reason_error_string(unsigned long e)
     case DTLS_TOO_MANY_FRAGMENTS_E:
         return "Received too many fragmented messages from peer error";
 
+    case DUPLICATE_TLS_EXT_E:
+        return "Duplicate TLS extension in message.";
+
     default :
         return "unknown error number";
     }

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -181,6 +181,8 @@ enum wolfSSL_ErrorCodes {
     DTLS_CID_ERROR               = -454,   /* Wrong or missing CID */
     DTLS_TOO_MANY_FRAGMENTS_E    = -455,   /* Received too many fragments */
     QUIC_WRONG_ENC_LEVEL         = -456,   /* QUIC data received on wrong encryption level */
+
+    DUPLICATE_TLS_EXT_E          = -457,   /* Duplicate TLS extension in msg. */
     /* add strings to wolfSSL_ERR_reason_error_string in internal.c !!!!! */
 
     /* begin negotiation parameter errors */


### PR DESCRIPTION
# Description

TLS specification requires that there not be more than one extension of the same type in a given extension block. E.g. ClientHello

Fixes #5863

# Testing

Added test case test_tls_exr_duplicate().

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
