### PR TITLE
Ensure the keyshare is generated on resumption.

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -4227,7 +4227,12 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             SetupPkCallbackContexts(sslResume, &pkCbInfo);
         }
 #endif
-
+#if defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES)
+        if (version >= 4) {
+            SetKeyShare(sslResume, onlyKeyShare, useX25519, useX448, usePqc,
+                        pqcAlg, 1);
+        }
+#endif
         if (dtlsUDP) {
             TEST_DELAY();
         }


### PR DESCRIPTION
Found with the following commands: 

```
./configure --with-liboqs
./examples/server/server -v 4 -r --pqc P521_KYBER_LEVEL5
./examples/client/client -v 4 -r --pqc P521_KYBER_LEVEL5
```