### PR TITLE
fix for handling DEFAULT:... cipher suite list

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -24357,7 +24357,10 @@ int SetCipherList(WOLFSSL_CTX* ctx, Suites* suites, const char* list)
             haveRSA = 1;
             haveDH = 1;
             haveECC = 1;
-            haveStaticECC = 1;
+
+            /* having static ECC will disable all RSA use, do not set
+             * static ECC suites here
+             * haveStaticECC = 1; */
             haveStaticRSA = 1;
             haveRSAsig = 1;
             havePSK = 1;

--- a/tests/api.c
+++ b/tests/api.c
@@ -59364,7 +59364,6 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_EVP_blake2),
     TEST_DECL(test_EVP_MD_do_all),
     TEST_DECL(test_OBJ_NAME_do_all),
-    TEST_DECL(test_wolfSSL_CTX_set_cipher_list),
     TEST_DECL(test_wolfSSL_CTX_set_cipher_list_bytes),
     TEST_DECL(test_wolfSSL_CTX_use_certificate_file),
     TEST_DECL(test_wolfSSL_CTX_use_certificate_buffer),
@@ -59410,6 +59409,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_read_write),
     TEST_DECL(test_wolfSSL_reuse_WOLFSSLobj),
     TEST_DECL(test_wolfSSL_CTX_verifyDepth_ServerClient),
+    TEST_DECL(test_wolfSSL_CTX_set_cipher_list),
     TEST_DECL(test_wolfSSL_dtls_export),
     TEST_DECL(test_wolfSSL_tls_export),
 #endif


### PR DESCRIPTION
ZD15135

If using a cipher suite string like "DEFAULT:!NULL" then all RSA cipher suites where being removed from the list because of the check we have in internal.c for disabling haveRSA if haveStaticECC is set. This changes DEFAULT/ALL to not have static ECC cipher suites enabled. 