### PR TITLE
Warn that renegotiation in TLS 1.3 requires session ticket.

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -4274,12 +4274,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         }
 #endif
 
-        if (wolfSSL_set_session(sslResume, session) != WOLFSSL_SUCCESS) {
-            wolfSSL_free(sslResume); sslResume = NULL;
-            wolfSSL_CTX_free(ctx); ctx = NULL;
-            err_sys("error setting the session for resumption");
-        }
-
+        wolfSSL_set_session(sslResume, session);
 
 #if defined(OPENSSL_EXTRA) && defined(HAVE_EXT_CACHE)
         if (flatSession) {

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -2302,6 +2302,12 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
         }
     }
 
+#ifndef HAVE_SESSION_TICKET
+    if ((version >= 4) && resume) {
+        fprintf(stderr, "Can't do TLS 1.3 resumption; need session tickets!\n");
+    }
+#endif
+
 #ifdef HAVE_WNR
     if (wc_InitNetRandom(wnrConfigFile, NULL, 5000) != 0)
         err_sys_ex(runWithErrors, "can't load whitewood net random config "


### PR DESCRIPTION
The following command doesn't actually do re-negotiation (Missing `--enable-session-ticket`)
```
./configure
./examples/server/server -v 4 -r
./examples/client/client -v 4 -r 
```
...but doesn't fail either. Added message that session ticket needs to be enabled.