### PR TITLE
Add alt case for unsupported static memory API

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -42506,7 +42506,19 @@ WOLFSSL_TEST_SUBROUTINE int mutex_test(void)
     wolfSSL_Mutex m;
 #endif
 #if !defined(WOLFSSL_NO_MALLOC) && !defined(WOLFSSL_USER_MUTEX)
+  #ifndef WOLFSSL_STATIC_MEMORY
     wolfSSL_Mutex *mm = wc_InitAndAllocMutex();
+  #else
+    wolfSSL_Mutex *mm = (wolfSSL_Mutex*) XMALLOC(sizeof(wolfSSL_Mutex),
+                                                 HEAP_HINT, DYNAMIC_TYPE_MUTEX);
+    if (mm != NULL) {
+        if (wc_InitMutex(mm) != 0) {
+            WOLFSSL_MSG("Init Mutex failed");
+            XFREE(mm, HEAP_HINT, DYNAMIC_TYPE_MUTEX);
+            mm = NULL;
+        }
+    }
+  #endif
     if (mm == NULL)
         return -13700;
     wc_FreeMutex(mm);


### PR DESCRIPTION
# Description

Fixes a case in the test app that was calling an API that did not support the HEAP_HINT when static memory was enabled.
Adds an alternate code path to simply allocate locally using the HEAP_HINT when static memory enabled and leave the other case in tact for all other conditions.

Caught by internal testing.

# Testing

https://cloud.wolfssl-test.com/jenkins/view/master-PRBs/job/PRB-dtls-options-fsanitize-D-v2/

# Checklist

 - [X] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
