### PR TITLE
AC_CHECK_DECLS for atexit needs stdlib.h on OSX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,6 +133,9 @@ fi
 #ifdef HAVE_TIME_H
     #include <time.h>
 #endif
+#ifdef HAVE_STDLIB_H
+    #include <stdlib.h>
+#endif
 ]])
 
 AC_PROG_INSTALL


### PR DESCRIPTION
# Description

Commit de22dbe61d0eb31d2669f6bd7bbde2d42b03e283 added `atexit` to `AC_CHECK_DECLS` in configure.ac.  OSX needs `stdlib.h` to find this correctly.  This showed up through configure with a sed error:

```
./configure --quiet
sed: illegal option -- -
usage: sed script [-Ealnru] [-i extension] [file ...]
	sed [-Ealnu] [-i extension] [-e script] ... [-f script_file] ... [file ...]
```

# Testing

Tested on OSX 12.6.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
