### PR TITLE
Add Android CA certs path for wolfSSL_CTX_load_system_CA_certs()

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -8207,11 +8207,15 @@ static int LoadSystemCaCertsMac(WOLFSSL_CTX* ctx, byte* loaded)
 
 #else
 
-/* Potential system CA certs directories on Linux distros. */
+/* Potential system CA certs directories on Linux/Unix distros. */
 static const char* systemCaDirs[] = {
+#if defined(__ANDROID__) || defined(ANDROID)
+    "/system/etc/security/cacerts"      /* Android */
+#else
     "/etc/ssl/certs",                   /* Debian, Ubuntu, Gentoo, others */
     "/etc/pki/ca-trust/source/anchors", /* Fedora, RHEL */
     "/etc/pki/tls/certs"                /* Older RHEL */
+#endif
 };
 
 const char** wolfSSL_get_system_CA_dirs(word32* num)


### PR DESCRIPTION
# Description

This PR addresses a feature request to add support to `wolfSSL_CTX_load_system_CA_certs()` for Android's system CA certificates location. Re-use existing Linux/Unix logic, since file system pathing is similar.

Android stores system CA certs at: `/system/etc/security/cacerts`.

# Testing

Tested by the user with feature request.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
