### PR TITLE
WOLFSSL_OP_NO_TICKET fix for TLSv1.2

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -34194,7 +34194,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         if (ssl->ctx->ticketEncCb == NULL
 #if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER) || defined(WOLFSSL_WPAS_SMALL)
                 ||
-                /* SSL_OP_NO_TICKET turns off tickets in < 1.2. Forces
+                /* SSL_OP_NO_TICKET turns off tickets in <= 1.2. Forces
                  * "stateful" tickets for 1.3 so just use the regular
                  * stateless ones. */
                 (!IsAtLeastTLSv1_3(ssl->version) &&

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -13354,6 +13354,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
 #ifdef HAVE_SESSION_TICKET
             if (ssl->options.createTicket && !ssl->options.noTicketTls12) {
                 if ( (ssl->error = SendTicket(ssl)) != 0) {
+                    WOLFSSL_MSG("Thought we need ticket but failed");
                     WOLFSSL_ERROR(ssl->error);
                     return WOLFSSL_FATAL_ERROR;
                 }
@@ -16770,6 +16771,12 @@ cleanup:
             return BAD_FUNC_ARG;
 
         ctx->mask = wolf_set_options(ctx->mask, opt);
+
+#if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER) || defined(WOLFSSL_WPAS_SMALL)
+        if ((ctx->mask & WOLFSSL_OP_NO_TICKET) == WOLFSSL_OP_NO_TICKET) {
+          ctx->noTicketTls12 = 1;
+        }
+#endif
 
         return ctx->mask;
     }
@@ -23551,6 +23558,13 @@ long wolfSSL_set_options(WOLFSSL* ssl, long op)
         ssl->options.usingCompression = 0;
     #endif
     }
+
+#if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER) || defined(WOLFSSL_WPAS_SMALL)
+    if ((ssl->options.mask & WOLFSSL_OP_NO_TICKET) == WOLFSSL_OP_NO_TICKET) {
+      ssl->options.noTicketTls12 = 1;
+    }
+#endif
+
 
     /* in the case of a version change the cipher suites should be reset */
 #ifndef NO_PSK

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -16771,8 +16771,8 @@ cleanup:
             return BAD_FUNC_ARG;
 
         ctx->mask = wolf_set_options(ctx->mask, opt);
-
-#if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER) || defined(WOLFSSL_WPAS_SMALL)
+#if defined(HAVE_SESSION_TICKET) && (defined(OPENSSL_EXTRA) \
+        || defined(HAVE_WEBSERVER) || defined(WOLFSSL_WPAS_SMALL))
         if ((ctx->mask & WOLFSSL_OP_NO_TICKET) == WOLFSSL_OP_NO_TICKET) {
           ctx->noTicketTls12 = 1;
         }
@@ -23559,7 +23559,8 @@ long wolfSSL_set_options(WOLFSSL* ssl, long op)
     #endif
     }
 
-#if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER) || defined(WOLFSSL_WPAS_SMALL)
+#if defined(HAVE_SESSION_TICKET) && (defined(OPENSSL_EXTRA) \
+        || defined(HAVE_WEBSERVER) || defined(WOLFSSL_WPAS_SMALL))
     if ((ssl->options.mask & WOLFSSL_OP_NO_TICKET) == WOLFSSL_OP_NO_TICKET) {
       ssl->options.noTicketTls12 = 1;
     }


### PR DESCRIPTION
# Description

Disabling TLSv1.2 session tickets when WOLFSSL_OP_NO_TICKET is being set.

There seems to have been a misunderstanding that WOLFSSL_OP_NO_TICKET would only disable tickets for TLS version lower than 1.2. But it includes 1.2 as well.

# Testing

via my [haproxy+wolfssl test suite](https://github.com/icing/haproxy-quic-tests)

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
