### PR TITLE
Fix StartTLS_Init

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -834,18 +834,17 @@ const char* starttlsCmd[6] = {
 static int StartTLS_Init(SOCKET_T* sockfd)
 {
     char tmpBuf[512];
-    char buf[4];
 
     if (sockfd == NULL)
         return BAD_FUNC_ARG;
-    
+
     /* S: 220 <host> SMTP service ready */
     XMEMSET(tmpBuf, 0, sizeof(tmpBuf));
     if (recv(*sockfd, tmpBuf, sizeof(tmpBuf)-1, 0) < 0)
         err_sys("failed to read STARTTLS command\n");
 
-    XMEMCPY(buf,tmpBuf,XSTRLEN(starttlsCmd[0]));
-    if (!XSTRCMP(tmpBuf, starttlsCmd[0])) {
+    if ((!XSTRNCMP(tmpBuf, starttlsCmd[0], XSTRLEN(starttlsCmd[0]))) &&
+        (tmpBuf[XSTRLEN(starttlsCmd[0])] == ' ')) {
         printf("%s\n", tmpBuf);
     } else {
         err_sys("incorrect STARTTLS command received");
@@ -861,8 +860,8 @@ static int StartTLS_Init(SOCKET_T* sockfd)
     if (recv(*sockfd, tmpBuf, sizeof(tmpBuf)-1, 0) < 0)
         err_sys("failed to read STARTTLS command\n");
 
-    XMEMCPY(buf,tmpBuf,XSTRLEN(starttlsCmd[2]));
-    if (!XSTRCMP(tmpBuf, starttlsCmd[2])) {
+    if ((!XSTRNCMP(tmpBuf, starttlsCmd[2], XSTRLEN(starttlsCmd[2]))) &&
+        (tmpBuf[XSTRLEN(starttlsCmd[2])] == '-')) {
         printf("%s\n", tmpBuf);
     } else {
         err_sys("incorrect STARTTLS command received");
@@ -880,8 +879,8 @@ static int StartTLS_Init(SOCKET_T* sockfd)
         err_sys("failed to read STARTTLS command\n");
     tmpBuf[sizeof(tmpBuf)-1] = '\0';
 
-    XMEMCPY(buf,tmpBuf,XSTRLEN(starttlsCmd[4]));
-    if (!XSTRCMP(tmpBuf, starttlsCmd[4])) {
+    if ((!XSTRNCMP(tmpBuf, starttlsCmd[4], XSTRLEN(starttlsCmd[4]))) &&
+        (tmpBuf[XSTRLEN(starttlsCmd[4])] == ' ')) {
         printf("%s\n", tmpBuf);
     } else {
         err_sys("incorrect STARTTLS command received, expected 220");

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -834,16 +834,18 @@ const char* starttlsCmd[6] = {
 static int StartTLS_Init(SOCKET_T* sockfd)
 {
     char tmpBuf[512];
+    char buf[4];
 
     if (sockfd == NULL)
         return BAD_FUNC_ARG;
-
+    
     /* S: 220 <host> SMTP service ready */
     XMEMSET(tmpBuf, 0, sizeof(tmpBuf));
     if (recv(*sockfd, tmpBuf, sizeof(tmpBuf)-1, 0) < 0)
         err_sys("failed to read STARTTLS command\n");
 
-    if (!XSTRNCMP(tmpBuf, starttlsCmd[0],XSTRLEN(starttlsCmd[0]))) {
+    XMEMCPY(buf,tmpBuf,XSTRLEN(starttlsCmd[0]));
+    if (!XSTRCMP(tmpBuf, starttlsCmd[0])) {
         printf("%s\n", tmpBuf);
     } else {
         err_sys("incorrect STARTTLS command received");
@@ -859,7 +861,8 @@ static int StartTLS_Init(SOCKET_T* sockfd)
     if (recv(*sockfd, tmpBuf, sizeof(tmpBuf)-1, 0) < 0)
         err_sys("failed to read STARTTLS command\n");
 
-    if (!XSTRNCMP(tmpBuf, starttlsCmd[2],XSTRLEN(starttlsCmd[2]))) {
+    XMEMCPY(buf,tmpBuf,XSTRLEN(starttlsCmd[2]));
+    if (!XSTRCMP(tmpBuf, starttlsCmd[2])) {
         printf("%s\n", tmpBuf);
     } else {
         err_sys("incorrect STARTTLS command received");
@@ -876,7 +879,9 @@ static int StartTLS_Init(SOCKET_T* sockfd)
     if (recv(*sockfd, tmpBuf, sizeof(tmpBuf)-1, 0) < 0)
         err_sys("failed to read STARTTLS command\n");
     tmpBuf[sizeof(tmpBuf)-1] = '\0';
-    if (!XSTRNCMP(tmpBuf, starttlsCmd[4],XSTRLEN(starttlsCmd[4]))) {
+
+    XMEMCPY(buf,tmpBuf,XSTRLEN(starttlsCmd[4]));
+    if (!XSTRCMP(tmpBuf, starttlsCmd[4])) {
         printf("%s\n", tmpBuf);
     } else {
         err_sys("incorrect STARTTLS command received, expected 220");

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -843,7 +843,7 @@ static int StartTLS_Init(SOCKET_T* sockfd)
     if (recv(*sockfd, tmpBuf, sizeof(tmpBuf)-1, 0) < 0)
         err_sys("failed to read STARTTLS command\n");
 
-    if (!XSTRCMP(tmpBuf, starttlsCmd[0])) {
+    if (!XSTRNCMP(tmpBuf, starttlsCmd[0],XSTRLEN(starttlsCmd[0]))) {
         printf("%s\n", tmpBuf);
     } else {
         err_sys("incorrect STARTTLS command received");
@@ -859,7 +859,7 @@ static int StartTLS_Init(SOCKET_T* sockfd)
     if (recv(*sockfd, tmpBuf, sizeof(tmpBuf)-1, 0) < 0)
         err_sys("failed to read STARTTLS command\n");
 
-    if (!XSTRCMP(tmpBuf, starttlsCmd[2])) {
+    if (!XSTRNCMP(tmpBuf, starttlsCmd[2],XSTRLEN(starttlsCmd[2]))) {
         printf("%s\n", tmpBuf);
     } else {
         err_sys("incorrect STARTTLS command received");
@@ -876,7 +876,7 @@ static int StartTLS_Init(SOCKET_T* sockfd)
     if (recv(*sockfd, tmpBuf, sizeof(tmpBuf)-1, 0) < 0)
         err_sys("failed to read STARTTLS command\n");
     tmpBuf[sizeof(tmpBuf)-1] = '\0';
-    if (!XSTRCMP(tmpBuf, starttlsCmd[4])) {
+    if (!XSTRNCMP(tmpBuf, starttlsCmd[4],XSTRLEN(starttlsCmd[4]))) {
         printf("%s\n", tmpBuf);
     } else {
         err_sys("incorrect STARTTLS command received, expected 220");


### PR DESCRIPTION
Fixed `starttlsCmd` comparison inside the `StartTLS_Init` function

When using smtp STARTTLS, tmpBuf would be like `220 smtp.gmail.com ESMTP 13-20020a170902c24d00b00189348ab156sm5773120plg.283 - gsmtp`. `tmpBuf` won't match with `starttlsCmd`. I added memcpy to avoid the use of strncmp.