### PR TITLE
DtlsMsgPoolSend: Use correct sendSz

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -8857,9 +8857,8 @@ int DtlsMsgPoolSend(WOLFSSL* ssl, int sendOnlyFirstPacket)
 #endif
 
 
-                /* add back in header space from saved pool size */
-                sendSz += DTLS_HANDSHAKE_EXTRA;
-                sendSz += DTLS_RECORD_EXTRA;
+                /* add back in record header space from saved pool size */
+                sendSz += DTLS_RECORD_HEADER_SZ;
 
                 if ((ret = CheckAvailableSize(ssl, sendSz)) != 0) {
                     WOLFSSL_ERROR(ret);


### PR DESCRIPTION
ZD15346

pool->sz is the size without the record header. The handshake header is present already.

Reproducible with
  ./udp_proxy -p 12345 -s 127.0.0.1:11111 -x 1:3 -S server
or
  ./udp_proxy -p 12345 -s 127.0.0.1:11111 -x 1:3 -S client
and
  ./examples/server/server -l ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-CHACHA20-POLY1305 -u -i
  ./examples/client/client -l ECDHE-RSA-AES256-GCM-SHA384 -u -R -p 12345 -i
