### PR TITLE
Add option to add library suffix, --with-libsuffix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7417,6 +7417,20 @@ if test -n "$MPI_MAX_KEY_BITS" -o -n "$WITH_MAX_ECC_BITS"; then
    fi
 fi
 
+# Library Suffix
+LIBSUFFIX=""
+AC_ARG_WITH([libsuffix],
+    [AS_HELP_STRING([--with-libsuffix=SUFFIX],[Library artifact SUFFIX, ie libwolfsslSUFFIX.so])],
+    [
+        if test "x$withval" != "xno" ; then
+            LIBSUFFIX=$withval
+        fi
+        if test "x$withval" = "xyes" ; then
+            AC_MSG_ERROR([Invalid argument to --with-libsuffix, no suffix given])
+        fi
+    ]
+)
+AC_SUBST(LIBSUFFIX)
 
 AC_ARG_ENABLE([context-extra-user-data],
     [AS_HELP_STRING([--enable-context-extra-user-data],[Enables option for storing user-defined data in TLS API contexts, with optional argument the number of slots to allocate (default: disabled)])],
@@ -8604,6 +8618,7 @@ echo "   * C++ Flags:                  $CXXFLAGS"
 echo "   * CPP Flags:                  $CPPFLAGS"
 echo "   * CCAS Flags:                 $CCASFLAGS"
 echo "   * LIB Flags:                  $LIB"
+echo "   * Library Suffix:             $LIBSUFFIX"
 
 test "$ENABLED_LINUXKM" = "yes" && \
 echo "   * Linux Kernel Build Root:    $KERNEL_ROOT" && \

--- a/examples/benchmark/include.am
+++ b/examples/benchmark/include.am
@@ -7,8 +7,8 @@ if BUILD_THREADED_EXAMPLES
 noinst_PROGRAMS += examples/benchmark/tls_bench
 noinst_HEADERS += examples/benchmark/tls_bench.h
 examples_benchmark_tls_bench_SOURCES      = examples/benchmark/tls_bench.c
-examples_benchmark_tls_bench_LDADD        = src/libwolfssl.la $(LIB_STATIC_ADD)
-examples_benchmark_tls_bench_DEPENDENCIES = src/libwolfssl.la
+examples_benchmark_tls_bench_LDADD        = src/libwolfssl@LIBSUFFIX@.la $(LIB_STATIC_ADD)
+examples_benchmark_tls_bench_DEPENDENCIES = src/libwolfssl@LIBSUFFIX@.la
 endif
 
 dist_example_DATA+= examples/benchmark/tls_bench.c

--- a/examples/client/include.am
+++ b/examples/client/include.am
@@ -5,8 +5,8 @@ if BUILD_EXAMPLE_CLIENTS
 noinst_PROGRAMS += examples/client/client
 noinst_HEADERS += examples/client/client.h
 examples_client_client_SOURCES      = examples/client/client.c
-examples_client_client_LDADD        = src/libwolfssl.la $(LIB_STATIC_ADD) $(WOLFSENTRY_LIB)
-examples_client_client_DEPENDENCIES = src/libwolfssl.la
+examples_client_client_LDADD        = src/libwolfssl@LIBSUFFIX@.la $(LIB_STATIC_ADD) $(WOLFSENTRY_LIB)
+examples_client_client_DEPENDENCIES = src/libwolfssl@LIBSUFFIX@.la
 examples_client_client_CFLAGS = $(WOLFSENTRY_INCLUDE) $(AM_CFLAGS)
 endif
 EXTRA_DIST += examples/client/client.sln

--- a/examples/echoclient/include.am
+++ b/examples/echoclient/include.am
@@ -7,8 +7,8 @@ if BUILD_EXAMPLE_CLIENTS
 noinst_PROGRAMS += examples/echoclient/echoclient
 noinst_HEADERS += examples/echoclient/echoclient.h
 examples_echoclient_echoclient_SOURCES      = examples/echoclient/echoclient.c
-examples_echoclient_echoclient_LDADD        = src/libwolfssl.la $(LIB_STATIC_ADD)
-examples_echoclient_echoclient_DEPENDENCIES = src/libwolfssl.la
+examples_echoclient_echoclient_LDADD        = src/libwolfssl@LIBSUFFIX@.la $(LIB_STATIC_ADD)
+examples_echoclient_echoclient_DEPENDENCIES = src/libwolfssl@LIBSUFFIX@.la
 endif
 EXTRA_DIST += examples/echoclient/echoclient.sln
 EXTRA_DIST += examples/echoclient/echoclient.vcproj

--- a/examples/echoserver/include.am
+++ b/examples/echoserver/include.am
@@ -7,8 +7,8 @@ if BUILD_EXAMPLE_SERVERS
 noinst_PROGRAMS += examples/echoserver/echoserver
 noinst_HEADERS += examples/echoserver/echoserver.h
 examples_echoserver_echoserver_SOURCES      = examples/echoserver/echoserver.c
-examples_echoserver_echoserver_LDADD        = src/libwolfssl.la $(LIB_STATIC_ADD)
-examples_echoserver_echoserver_DEPENDENCIES = src/libwolfssl.la
+examples_echoserver_echoserver_LDADD        = src/libwolfssl@LIBSUFFIX@.la $(LIB_STATIC_ADD)
+examples_echoserver_echoserver_DEPENDENCIES = src/libwolfssl@LIBSUFFIX@.la
 endif
 EXTRA_DIST += examples/echoserver/echoserver.sln
 EXTRA_DIST += examples/echoserver/echoserver.vcproj

--- a/examples/sctp/include.am
+++ b/examples/sctp/include.am
@@ -11,8 +11,8 @@ noinst_PROGRAMS += \
 examples_sctp_sctp_server_SOURCES      = examples/sctp/sctp-server.c
 examples_sctp_sctp_server_LDADD        = $(LIB_STATIC_ADD)
 examples_sctp_sctp_server_dtls_SOURCES      = examples/sctp/sctp-server-dtls.c
-examples_sctp_sctp_server_dtls_LDADD        = src/libwolfssl.la $(LIB_STATIC_ADD)
-examples_sctp_sctp_server_dtls_DEPENDENCIES = src/libwolfssl.la
+examples_sctp_sctp_server_dtls_LDADD        = src/libwolfssl@LIBSUFFIX@.la $(LIB_STATIC_ADD)
+examples_sctp_sctp_server_dtls_DEPENDENCIES = src/libwolfssl@LIBSUFFIX@.la
 endif
 if BUILD_EXAMPLE_CLIENTS
 noinst_PROGRAMS += \
@@ -21,8 +21,8 @@ noinst_PROGRAMS += \
 examples_sctp_sctp_client_SOURCES      = examples/sctp/sctp-client.c
 examples_sctp_sctp_client_LDADD        = $(LIB_STATIC_ADD)
 examples_sctp_sctp_client_dtls_SOURCES      = examples/sctp/sctp-client-dtls.c
-examples_sctp_sctp_client_dtls_LDADD        = src/libwolfssl.la $(LIB_STATIC_ADD)
-examples_sctp_sctp_client_dtls_DEPENDENCIES = src/libwolfssl.la
+examples_sctp_sctp_client_dtls_LDADD        = src/libwolfssl@LIBSUFFIX@.la $(LIB_STATIC_ADD)
+examples_sctp_sctp_client_dtls_DEPENDENCIES = src/libwolfssl@LIBSUFFIX@.la
 endif
 endif
 

--- a/examples/server/include.am
+++ b/examples/server/include.am
@@ -7,8 +7,8 @@ if BUILD_EXAMPLE_SERVERS
 noinst_PROGRAMS += examples/server/server
 noinst_HEADERS += examples/server/server.h
 examples_server_server_SOURCES      = examples/server/server.c
-examples_server_server_LDADD        = src/libwolfssl.la $(LIB_STATIC_ADD) $(WOLFSENTRY_LIB)
-examples_server_server_DEPENDENCIES = src/libwolfssl.la
+examples_server_server_LDADD        = src/libwolfssl@LIBSUFFIX@.la $(LIB_STATIC_ADD) $(WOLFSENTRY_LIB)
+examples_server_server_DEPENDENCIES = src/libwolfssl@LIBSUFFIX@.la
 examples_server_server_CFLAGS = $(WOLFSENTRY_INCLUDE) $(AM_CFLAGS)
 endif
 EXTRA_DIST += examples/server/server.sln

--- a/mcapi/include.am
+++ b/mcapi/include.am
@@ -7,8 +7,8 @@ check_PROGRAMS += mcapi/test
 noinst_PROGRAMS += mcapi/test
 mcapi_test_SOURCES = mcapi/crypto.c \
                      mcapi/mcapi_test.c
-mcapi_test_LDADD        = src/libwolfssl.la
-mcapi_test_DEPENDENCIES = src/libwolfssl.la
+mcapi_test_LDADD        = src/libwolfssl@LIBSUFFIX@.la
+mcapi_test_DEPENDENCIES = src/libwolfssl@LIBSUFFIX@.la
 endif
 
 noinst_HEADERS += mcapi/crypto.h

--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -50,7 +50,7 @@ fi
 %{__rm} -rf %{buildroot}
 %{__make} install  DESTDIR="%{buildroot}" AM_INSTALL_PROGRAM_FLAGS=""
 mkdir -p $RPM_BUILD_ROOT/
-%{__rm} -f %{buildroot}/%{_libdir}/libwolfssl.la
+%{__rm} -f %{buildroot}/%{_libdir}/libwolfssl@LIBSUFFIX@.la
 
 %check
 
@@ -78,9 +78,9 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_docdir}/wolfssl/README.txt
 %{_docdir}/wolfssl/QUIC.md
 
-%{_libdir}/libwolfssl.so
-%{_libdir}/libwolfssl.so.@WOLFSSL_LIBRARY_VERSION_FIRST@
-%{_libdir}/libwolfssl.so.@WOLFSSL_LIBRARY_VERSION_FIRST@.@WOLFSSL_LIBRARY_VERSION_SECOND@.@WOLFSSL_LIBRARY_VERSION_THIRD@
+%{_libdir}/libwolfssl@LIBSUFFIX@.so
+%{_libdir}/libwolfssl@LIBSUFFIX@.so.@WOLFSSL_LIBRARY_VERSION_FIRST@
+%{_libdir}/libwolfssl@LIBSUFFIX@.so.@WOLFSSL_LIBRARY_VERSION_FIRST@.@WOLFSSL_LIBRARY_VERSION_SECOND@.@WOLFSSL_LIBRARY_VERSION_THIRD@
 
 %files devel
 %defattr(-,root,root,-)

--- a/src/include.am
+++ b/src/include.am
@@ -27,13 +27,13 @@ $(FIPS_FILES):
 	$(AM_V_at)touch $(srcdir)/$@
 
 if !BUILD_NO_LIBRARY
-lib_LTLIBRARIES+= src/libwolfssl.la
+lib_LTLIBRARIES+= src/libwolfssl@LIBSUFFIX@.la
 endif
-src_libwolfssl_la_SOURCES =
-src_libwolfssl_la_LDFLAGS = ${AM_LDFLAGS} -no-undefined -version-info ${WOLFSSL_LIBRARY_VERSION}
-src_libwolfssl_la_LIBADD = $(LIBM) $(LIB_ADD) $(LIB_STATIC_ADD)
-src_libwolfssl_la_CFLAGS = -DBUILDING_WOLFSSL $(AM_CFLAGS) -DLIBWOLFSSL_GLOBAL_EXTRA_CFLAGS="\" $(EXTRA_CFLAGS)\""
-src_libwolfssl_la_CPPFLAGS = -DBUILDING_WOLFSSL $(AM_CPPFLAGS)
+src_libwolfssl@LIBSUFFIX@_la_SOURCES =
+src_libwolfssl@LIBSUFFIX@_la_LDFLAGS = ${AM_LDFLAGS} -no-undefined -version-info ${WOLFSSL_LIBRARY_VERSION}
+src_libwolfssl@LIBSUFFIX@_la_LIBADD = $(LIBM) $(LIB_ADD) $(LIB_STATIC_ADD)
+src_libwolfssl@LIBSUFFIX@_la_CFLAGS = -DBUILDING_WOLFSSL $(AM_CFLAGS) -DLIBWOLFSSL_GLOBAL_EXTRA_CFLAGS="\" $(EXTRA_CFLAGS)\""
+src_libwolfssl@LIBSUFFIX@_la_CPPFLAGS = -DBUILDING_WOLFSSL $(AM_CPPFLAGS)
 
 # install the packaged IPP libraries
 if BUILD_FAST_RSA
@@ -53,114 +53,114 @@ if BUILD_FIPS
 
 if BUILD_FIPS_V1
 # fips first  file
-src_libwolfssl_la_SOURCES += ctaocrypt/src/wolfcrypt_first.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += ctaocrypt/src/wolfcrypt_first.c
 
-src_libwolfssl_la_SOURCES += \
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += \
                ctaocrypt/src/hmac.c \
                ctaocrypt/src/random.c \
                ctaocrypt/src/sha256.c
 
 if BUILD_RSA
-src_libwolfssl_la_SOURCES += ctaocrypt/src/rsa.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += ctaocrypt/src/rsa.c
 endif
 
 if BUILD_AES
-src_libwolfssl_la_SOURCES += ctaocrypt/src/aes.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += ctaocrypt/src/aes.c
 endif
 
 if BUILD_DES3
-src_libwolfssl_la_SOURCES += ctaocrypt/src/des3.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += ctaocrypt/src/des3.c
 endif
 
 if BUILD_SHA
-src_libwolfssl_la_SOURCES += ctaocrypt/src/sha.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += ctaocrypt/src/sha.c
 endif
 
 if BUILD_SHA512
-src_libwolfssl_la_SOURCES += ctaocrypt/src/sha512.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += ctaocrypt/src/sha512.c
 endif
 
-src_libwolfssl_la_SOURCES += ctaocrypt/src/fips.c
-src_libwolfssl_la_SOURCES += ctaocrypt/src/fips_test.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += ctaocrypt/src/fips.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += ctaocrypt/src/fips_test.c
 
 # fips last file
-src_libwolfssl_la_SOURCES += ctaocrypt/src/wolfcrypt_last.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += ctaocrypt/src/wolfcrypt_last.c
 endif BUILD_FIPS_V1
 
 if BUILD_FIPS_V2
 # FIPSv2 first file
-src_libwolfssl_la_SOURCES += \
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += \
                wolfcrypt/src/wolfcrypt_first.c
 
-src_libwolfssl_la_SOURCES += \
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += \
                wolfcrypt/src/hmac.c \
                wolfcrypt/src/random.c \
                wolfcrypt/src/sha256.c
 
 if BUILD_RSA
-src_libwolfssl_la_SOURCES += wolfcrypt/src/rsa.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/rsa.c
 endif
 
 if BUILD_ECC
-src_libwolfssl_la_SOURCES += wolfcrypt/src/ecc.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/ecc.c
 endif
 
 if BUILD_AES
-src_libwolfssl_la_SOURCES += wolfcrypt/src/aes.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/aes.c
 endif
 
 if BUILD_AESNI
-src_libwolfssl_la_SOURCES += wolfcrypt/src/aes_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/aes_asm.S
 if BUILD_X86_ASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/aes_gcm_x86_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/aes_gcm_x86_asm.S
 else
-src_libwolfssl_la_SOURCES += wolfcrypt/src/aes_gcm_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/aes_gcm_asm.S
 endif
 endif
 
 if BUILD_DES3
-src_libwolfssl_la_SOURCES += wolfcrypt/src/des3.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/des3.c
 endif
 
 if BUILD_SHA
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sha.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha.c
 endif
 
 if BUILD_INTELASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sha256_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha256_asm.S
 endif
 
 if BUILD_SHA512
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sha512.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha512.c
 if BUILD_INTELASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sha512_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha512_asm.S
 endif
 endif
 
 if BUILD_SHA3
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sha3.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha3.c
 if BUILD_INTELASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sha3_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha3_asm.S
 endif
 endif
 
 if BUILD_DH
-src_libwolfssl_la_SOURCES += wolfcrypt/src/dh.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/dh.c
 endif
 
 if BUILD_CMAC
-src_libwolfssl_la_SOURCES += wolfcrypt/src/cmac.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/cmac.c
 endif
 
-src_libwolfssl_la_SOURCES += wolfcrypt/src/fips.c \
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/fips.c \
                              wolfcrypt/src/fips_test.c
 
 # fips last file
-src_libwolfssl_la_SOURCES += wolfcrypt/src/wolfcrypt_last.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/wolfcrypt_last.c
 endif BUILD_FIPS_V2
 
 if BUILD_FIPS_RAND
-src_libwolfssl_la_SOURCES += \
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += \
                wolfcrypt/src/wolfcrypt_first.c \
                wolfcrypt/src/hmac.c \
                wolfcrypt/src/random.c \
@@ -173,105 +173,105 @@ endif BUILD_FIPS_RAND
 
 if BUILD_FIPS_V5
 # FIPS 140-3 first file
-src_libwolfssl_la_SOURCES += \
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += \
                wolfcrypt/src/wolfcrypt_first.c
 
-src_libwolfssl_la_SOURCES += \
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += \
                wolfcrypt/src/hmac.c \
                wolfcrypt/src/random.c
 
-src_libwolfssl_la_SOURCES += wolfcrypt/src/kdf.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/kdf.c
 
 if BUILD_RSA
-src_libwolfssl_la_SOURCES += wolfcrypt/src/rsa.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/rsa.c
 endif
 
 if BUILD_ECC
-src_libwolfssl_la_SOURCES += wolfcrypt/src/ecc.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/ecc.c
 endif
 
 if BUILD_AES
-src_libwolfssl_la_SOURCES += wolfcrypt/src/aes.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/aes.c
 if BUILD_ARMASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-aes.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-aes.c
 if !BUILD_ARMASM_CRYPTO
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-aes-asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-aes-asm.S
 endif
 endif
 endif
 
 if BUILD_AESNI
-src_libwolfssl_la_SOURCES += wolfcrypt/src/aes_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/aes_asm.S
 if BUILD_X86_ASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/aes_gcm_x86_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/aes_gcm_x86_asm.S
 else
-src_libwolfssl_la_SOURCES += wolfcrypt/src/aes_gcm_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/aes_gcm_asm.S
 endif
 endif
 
 if BUILD_SHA
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sha.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha.c
 endif
 
 if BUILD_ARMASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha256.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha256.c
 if BUILD_ARMASM_INLINE
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha256-asm_c.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha256-asm_c.c
 else
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha256-asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha256-asm.S
 endif
 else
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sha256.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha256.c
 if BUILD_INTELASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sha256_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha256_asm.S
 endif
 endif
 
 if BUILD_SHA512
 if BUILD_ARMASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha512.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha512.c
 if BUILD_ARMASM_INLINE
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha512-asm_c.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha512-asm_c.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha512-asm_c.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha512-asm_c.c
 else
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha512-asm.S
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha512-asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha512-asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha512-asm.S
 endif
 else
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sha512.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha512.c
 if BUILD_INTELASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sha512_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha512_asm.S
 endif
 endif
 endif
 
 if BUILD_SHA3
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sha3.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha3.c
 if BUILD_ARMASM
 if BUILD_ARMASM_INLINE
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha3-asm_c.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha3-asm_c.c
 else
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha3-asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha3-asm.S
 endif
 endif
 if BUILD_INTELASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sha3_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha3_asm.S
 endif
 endif
 
 if BUILD_DH
-src_libwolfssl_la_SOURCES += wolfcrypt/src/dh.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/dh.c
 endif
 
 if BUILD_CMAC
-src_libwolfssl_la_SOURCES += wolfcrypt/src/cmac.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/cmac.c
 endif
 
-src_libwolfssl_la_SOURCES += wolfcrypt/src/fips.c \
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/fips.c \
                              wolfcrypt/src/fips_test.c
 
 # fips last file
-src_libwolfssl_la_SOURCES += wolfcrypt/src/wolfcrypt_last.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/wolfcrypt_last.c
 endif BUILD_FIPS_V5
 
 endif BUILD_FIPS
@@ -285,171 +285,171 @@ if !BUILD_FIPS_RAND
 # CtaoCrypt files included above.
 if !BUILD_FIPS_CURRENT
 if BUILD_HMAC
-src_libwolfssl_la_SOURCES += wolfcrypt/src/hmac.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/hmac.c
 endif
 endif !BUILD_FIPS_CURRENT
 
 # CAVP self test
 if BUILD_SELFTEST
-src_libwolfssl_la_SOURCES += wolfcrypt/src/selftest.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/selftest.c
 endif
 
 endif !BUILD_FIPS_RAND
 
-src_libwolfssl_la_SOURCES += wolfcrypt/src/hash.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/hash.c
 
 if !BUILD_DO178
-src_libwolfssl_la_SOURCES += wolfcrypt/src/cpuid.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/cpuid.c
 endif !BUILD_DO178
 
 if !BUILD_FIPS_RAND
 
 if !BUILD_FIPS_V5
 if BUILD_KDF
-src_libwolfssl_la_SOURCES += wolfcrypt/src/kdf.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/kdf.c
 endif
 endif !BUILD_FIPS_V5
 
 if !BUILD_FIPS_CURRENT
 if BUILD_RNG
-src_libwolfssl_la_SOURCES += wolfcrypt/src/random.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/random.c
 endif
 endif !BUILD_FIPS_CURRENT
 
 if !BUILD_FIPS_CURRENT
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sha256.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha256.c
 if BUILD_ARMASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha256.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha256.c
 if BUILD_ARMASM_INLINE
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha256-asm_c.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha256-asm_c.c
 else
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha256-asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha256-asm.S
 endif
 else
 if BUILD_INTELASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sha256_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha256_asm.S
 endif
 endif
 endif !BUILD_FIPS_CURRENT
 
 if BUILD_AFALG
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/af_alg/afalg_hash.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/af_alg/afalg_hash.c
 endif
 
 if BUILD_KCAPI
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/kcapi/kcapi_aes.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/kcapi/kcapi_hash.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/kcapi/kcapi_hmac.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/kcapi/kcapi_ecc.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/kcapi/kcapi_rsa.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/kcapi/kcapi_dh.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/kcapi/kcapi_aes.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/kcapi/kcapi_hash.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/kcapi/kcapi_hmac.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/kcapi/kcapi_ecc.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/kcapi/kcapi_rsa.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/kcapi/kcapi_dh.c
 endif
 
 if BUILD_WOLFEVENT
-src_libwolfssl_la_SOURCES += wolfcrypt/src/wolfevent.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/wolfevent.c
 endif
 
 if BUILD_ASYNCCRYPT
-src_libwolfssl_la_SOURCES += wolfcrypt/src/async.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/async.c
 endif
 
 if !BUILD_USER_RSA
 if BUILD_RSA
 if BUILD_FAST_RSA
-src_libwolfssl_la_SOURCES += wolfcrypt/user-crypto/src/rsa.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/user-crypto/src/rsa.c
 else
 if !BUILD_FIPS_CURRENT
-src_libwolfssl_la_SOURCES += wolfcrypt/src/rsa.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/rsa.c
 endif !BUILD_FIPS_CURRENT
 endif
 endif
 endif
 
 if BUILD_RC2
-src_libwolfssl_la_SOURCES += wolfcrypt/src/rc2.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/rc2.c
 endif
 
 if BUILD_SP
 if BUILD_SP_C32
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sp_c32.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sp_c32.c
 endif
 if BUILD_SP_C64
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sp_c64.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sp_c64.c
 endif
 
 if BUILD_SP_X86_64
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sp_x86_64.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sp_x86_64_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sp_x86_64.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sp_x86_64_asm.S
 endif
 if !BUILD_FIPS_V2
 if BUILD_SP_ARM32
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sp_arm32.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sp_arm32.c
 endif
 endif
 if BUILD_SP_ARM_THUMB
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sp_armthumb.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sp_armthumb.c
 endif
 if !BUILD_FIPS_V2
 if BUILD_SP_ARM64
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sp_arm64.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sp_arm64.c
 endif
 endif
 if BUILD_SP_ARM_CORTEX
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sp_cortexm.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sp_cortexm.c
 endif
 endif BUILD_SP
 if BUILD_SP_INT
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sp_int.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sp_int.c
 endif
 
 if !BUILD_FIPS_CURRENT
 if BUILD_AES
-src_libwolfssl_la_SOURCES += wolfcrypt/src/aes.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/aes.c
 if BUILD_ARMASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-aes.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-aes.c
 if !BUILD_ARMASM_CRYPTO
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-aes-asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-aes-asm.S
 endif !BUILD_ARMASM_CRYPTO
 endif BUILD_ARMASM
 if BUILD_AFALG
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/af_alg/afalg_aes.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/af_alg/afalg_aes.c
 endif
 endif BUILD_AES
 endif !BUILD_FIPS_CURRENT
 
 if !BUILD_FIPS_CURRENT
 if BUILD_CMAC
-src_libwolfssl_la_SOURCES += wolfcrypt/src/cmac.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/cmac.c
 endif
 endif !BUILD_FIPS_CURRENT
 
 if !BUILD_FIPS_V2
 if BUILD_DES3
-src_libwolfssl_la_SOURCES += wolfcrypt/src/des3.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/des3.c
 endif BUILD_DES3
 endif !BUILD_FIPS_V2
 
 if !BUILD_FIPS_CURRENT
 if BUILD_SHA
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sha.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha.c
 endif
 endif !BUILD_FIPS_CURRENT
 
 if !BUILD_FIPS_CURRENT
 if BUILD_SHA512
 if BUILD_ARMASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha512.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha512.c
 if BUILD_ARMASM_INLINE
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha512-asm_c.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha512-asm_c.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha512-asm_c.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha512-asm_c.c
 else
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha512-asm.S
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha512-asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha512-asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha512-asm.S
 endif
 else
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sha512.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha512.c
 if BUILD_INTELASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sha512_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha512_asm.S
 endif
 endif
 endif
@@ -457,16 +457,16 @@ endif !BUILD_FIPS_CURRENT
 
 if !BUILD_FIPS_CURRENT
 if BUILD_SHA3
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sha3.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha3.c
 if BUILD_ARMASM
 if BUILD_ARMASM_INLINE
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha3-asm_c.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha3-asm_c.c
 else
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha3-asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha3-asm.S
 endif
 endif
 if BUILD_INTELASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sha3_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha3_asm.S
 endif
 endif
 endif !BUILD_FIPS_CURRENT
@@ -474,183 +474,183 @@ endif !BUILD_FIPS_CURRENT
 endif !BUILD_FIPS_RAND
 
 if BUILD_SIPHASH
-src_libwolfssl_la_SOURCES += wolfcrypt/src/siphash.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/siphash.c
 endif
 
-src_libwolfssl_la_SOURCES += \
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += \
                wolfcrypt/src/logging.c \
                wolfcrypt/src/wc_port.c
 
 if BUILD_ERROR_STRINGS
-src_libwolfssl_la_SOURCES += wolfcrypt/src/error.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/error.c
 endif
 
 if !BUILD_FIPS_RAND
 if !BUILD_DO178
-src_libwolfssl_la_SOURCES += \
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += \
                wolfcrypt/src/wc_encrypt.c \
                wolfcrypt/src/signature.c
 endif !BUILD_DO178
-src_libwolfssl_la_SOURCES += wolfcrypt/src/wolfmath.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/wolfmath.c
 endif !BUILD_FIPS_RAND
 
 if BUILD_MEMORY
-src_libwolfssl_la_SOURCES += wolfcrypt/src/memory.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/memory.c
 endif
 
 if !BUILD_FIPS_RAND
 if !BUILD_FIPS_CURRENT
 if BUILD_DH
-src_libwolfssl_la_SOURCES += wolfcrypt/src/dh.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/dh.c
 endif
 endif
 
 if BUILD_ASN
-src_libwolfssl_la_SOURCES += wolfcrypt/src/asn.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/asn.c
 endif
 
 endif !BUILD_FIPS_RAND
 
 if BUILD_CODING
-src_libwolfssl_la_SOURCES += wolfcrypt/src/coding.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/coding.c
 endif
 
 if !BUILD_FIPS_RAND
 
 if BUILD_POLY1305
 if BUILD_ARMASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-poly1305.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-poly1305.c
 endif
-src_libwolfssl_la_SOURCES += wolfcrypt/src/poly1305.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/poly1305.c
 if BUILD_INTELASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/poly1305_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/poly1305_asm.S
 endif
 endif
 
 if BUILD_RC4
-src_libwolfssl_la_SOURCES += wolfcrypt/src/arc4.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/arc4.c
 endif
 
 if BUILD_MD4
-src_libwolfssl_la_SOURCES += wolfcrypt/src/md4.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/md4.c
 endif
 
 if BUILD_MD5
-src_libwolfssl_la_SOURCES += wolfcrypt/src/md5.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/md5.c
 endif
 
 if BUILD_PWDBASED
-src_libwolfssl_la_SOURCES += wolfcrypt/src/pwdbased.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/pkcs12.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/pwdbased.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/pkcs12.c
 endif
 
 if BUILD_DSA
-src_libwolfssl_la_SOURCES += wolfcrypt/src/dsa.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/dsa.c
 endif
 
 if !BUILD_FIPS_CURRENT
 if BUILD_AESNI
-src_libwolfssl_la_SOURCES += wolfcrypt/src/aes_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/aes_asm.S
 if BUILD_X86_ASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/aes_gcm_x86_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/aes_gcm_x86_asm.S
 else
-src_libwolfssl_la_SOURCES += wolfcrypt/src/aes_gcm_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/aes_gcm_asm.S
 endif
 endif
 endif
 
 if BUILD_CAMELLIA
-src_libwolfssl_la_SOURCES += wolfcrypt/src/camellia.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/camellia.c
 endif
 
 if BUILD_MD2
-src_libwolfssl_la_SOURCES += wolfcrypt/src/md2.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/md2.c
 endif
 
 if BUILD_RIPEMD
-src_libwolfssl_la_SOURCES += wolfcrypt/src/ripemd.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/ripemd.c
 endif
 
 if BUILD_BLAKE2
-src_libwolfssl_la_SOURCES += wolfcrypt/src/blake2b.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/blake2b.c
 endif
 if BUILD_BLAKE2S
-src_libwolfssl_la_SOURCES += wolfcrypt/src/blake2s.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/blake2s.c
 endif
 
 if BUILD_CHACHA
 if BUILD_ARMASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-chacha.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-chacha.c
 else
-src_libwolfssl_la_SOURCES += wolfcrypt/src/chacha.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/chacha.c
 if BUILD_INTELASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/chacha_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/chacha_asm.S
 endif
 endif
 if BUILD_POLY1305
-src_libwolfssl_la_SOURCES += wolfcrypt/src/chacha20_poly1305.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/chacha20_poly1305.c
 endif
 endif
 
 if !BUILD_INLINE
-src_libwolfssl_la_SOURCES += wolfcrypt/src/misc.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/misc.c
 endif
 
 if BUILD_FASTMATH
-src_libwolfssl_la_SOURCES += wolfcrypt/src/tfm.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/tfm.c
 endif
 
 if BUILD_HEAPMATH
-src_libwolfssl_la_SOURCES += wolfcrypt/src/integer.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/integer.c
 endif
 
 if !BUILD_FIPS_CURRENT
 if BUILD_ECC
-src_libwolfssl_la_SOURCES += wolfcrypt/src/ecc.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/ecc.c
 endif
 if BUILD_ECCSI
-src_libwolfssl_la_SOURCES += wolfcrypt/src/eccsi.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/eccsi.c
 endif
 if BUILD_SAKKE
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sakke.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sakke.c
 endif
 endif
 
 if !BUILD_FIPS_CURRENT
 if BUILD_WC_KYBER
-src_libwolfssl_la_SOURCES += wolfcrypt/src/wc_kyber.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/wc_kyber_poly.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/wc_kyber.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/wc_kyber_poly.c
 if BUILD_INTELASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/wc_kyber_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/wc_kyber_asm.S
 endif
 endif
 endif
 
 if BUILD_CURVE25519
-src_libwolfssl_la_SOURCES += wolfcrypt/src/curve25519.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/curve25519.c
 endif
 
 if BUILD_ED25519
-src_libwolfssl_la_SOURCES += wolfcrypt/src/ed25519.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/ed25519.c
 endif
 
 if BUILD_FEMATH
 if BUILD_CURVE25519_SMALL
-src_libwolfssl_la_SOURCES += wolfcrypt/src/fe_low_mem.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/fe_low_mem.c
 else
 if BUILD_INTELASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/fe_x25519_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/fe_x25519_asm.S
 else
 if BUILD_ARMASM
 if BUILD_ARMASM_INLINE
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-curve25519_c.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-curve25519_c.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-curve25519_c.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-curve25519_c.c
 else
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-curve25519.S
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-curve25519.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-curve25519.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-curve25519.S
 endif
 else
-src_libwolfssl_la_SOURCES += wolfcrypt/src/fe_operations.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/fe_operations.c
 endif
 endif
 endif
@@ -658,21 +658,21 @@ endif
 
 if BUILD_GEMATH
 if BUILD_ED25519_SMALL
-src_libwolfssl_la_SOURCES += wolfcrypt/src/ge_low_mem.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/ge_low_mem.c
 else
-src_libwolfssl_la_SOURCES += wolfcrypt/src/ge_operations.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/ge_operations.c
 if !BUILD_FEMATH
 if BUILD_INTELASM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/fe_x25519_asm.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/fe_x25519_asm.S
 else
 if BUILD_ARMASM
 if BUILD_ARMASM_INLINE
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-curve25519_c.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-curve25519_c.c
 else
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-curve25519.S
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-curve25519.S
 endif
 else
-src_libwolfssl_la_SOURCES += wolfcrypt/src/fe_operations.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/fe_operations.c
 endif
 endif
 endif
@@ -680,50 +680,50 @@ endif
 endif
 
 if BUILD_CURVE448
-src_libwolfssl_la_SOURCES += wolfcrypt/src/curve448.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/curve448.c
 endif
 
 if BUILD_ED448
-src_libwolfssl_la_SOURCES += wolfcrypt/src/ed448.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/ed448.c
 endif
 
 if BUILD_FE448
-src_libwolfssl_la_SOURCES += wolfcrypt/src/fe_448.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/fe_448.c
 endif
 
 if BUILD_GE448
-src_libwolfssl_la_SOURCES += wolfcrypt/src/ge_448.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/ge_448.c
 if !BUILD_FE448
-src_libwolfssl_la_SOURCES += wolfcrypt/src/fe_448.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/fe_448.c
 endif
 endif
 
 if BUILD_LIBOQS
-src_libwolfssl_la_SOURCES += wolfcrypt/src/falcon.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/dilithium.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sphincs.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/ext_kyber.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/falcon.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/dilithium.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sphincs.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/ext_kyber.c
 endif
 
 if BUILD_LIBZ
-src_libwolfssl_la_SOURCES += wolfcrypt/src/compress.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/compress.c
 endif
 
 if BUILD_PKCS7
-src_libwolfssl_la_SOURCES += wolfcrypt/src/pkcs7.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/pkcs7.c
 endif
 
 if BUILD_SRP
-src_libwolfssl_la_SOURCES += wolfcrypt/src/srp.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/srp.c
 endif
 
 if BUILD_AFALG
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/af_alg/wc_afalg.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/af_alg/wc_afalg.c
 endif
 
 if !BUILD_CRYPTONLY
 # ssl files
-src_libwolfssl_la_SOURCES += \
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += \
                src/internal.c \
                src/wolfio.c \
                src/keys.c \
@@ -731,31 +731,31 @@ src_libwolfssl_la_SOURCES += \
                src/tls.c
 
 if BUILD_TLS13
-src_libwolfssl_la_SOURCES += src/tls13.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += src/tls13.c
 endif
 
 if BUILD_OCSP
-src_libwolfssl_la_SOURCES += src/ocsp.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += src/ocsp.c
 endif
 
 if BUILD_CRL
-src_libwolfssl_la_SOURCES += src/crl.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += src/crl.c
 endif
 
 if BUILD_SNIFFER
-src_libwolfssl_la_SOURCES += src/sniffer.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += src/sniffer.c
 endif
 
 if BUILD_DTLS13
-src_libwolfssl_la_SOURCES += src/dtls13.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += src/dtls13.c
 endif
 
 if BUILD_QUIC
-src_libwolfssl_la_SOURCES += src/quic.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += src/quic.c
 endif
 
 if BUILD_DTLS
-src_libwolfssl_la_SOURCES += src/dtls.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += src/dtls.c
 endif
 
 endif !BUILD_CRYPTONLY

--- a/sslSniffer/sslSnifferTest/include.am
+++ b/sslSniffer/sslSnifferTest/include.am
@@ -5,8 +5,8 @@
 if BUILD_SNIFFTEST
 noinst_PROGRAMS += sslSniffer/sslSnifferTest/snifftest
 sslSniffer_sslSnifferTest_snifftest_SOURCES = sslSniffer/sslSnifferTest/snifftest.c
-sslSniffer_sslSnifferTest_snifftest_LDADD        = src/libwolfssl.la -lpcap $(LIB_STATIC_ADD)
-sslSniffer_sslSnifferTest_snifftest_DEPENDENCIES = src/libwolfssl.la
+sslSniffer_sslSnifferTest_snifftest_LDADD        = src/libwolfssl@LIBSUFFIX@.la -lpcap $(LIB_STATIC_ADD)
+sslSniffer_sslSnifferTest_snifftest_DEPENDENCIES = src/libwolfssl@LIBSUFFIX@.la
 endif
 EXTRA_DIST += sslSniffer/README.md
 EXTRA_DIST += sslSniffer/sslSniffer.vcproj

--- a/tests/include.am
+++ b/tests/include.am
@@ -16,8 +16,8 @@ tests_unit_test_SOURCES = \
                   examples/client/client.c \
                   examples/server/server.c
 tests_unit_test_CFLAGS       = -DNO_MAIN_DRIVER $(AM_CFLAGS) $(WOLFSENTRY_INCLUDE)
-tests_unit_test_LDADD        = src/libwolfssl.la $(LIB_STATIC_ADD) $(WOLFSENTRY_LIB)
-tests_unit_test_DEPENDENCIES = src/libwolfssl.la
+tests_unit_test_LDADD        = src/libwolfssl@LIBSUFFIX@.la $(LIB_STATIC_ADD) $(WOLFSENTRY_LIB)
+tests_unit_test_DEPENDENCIES = src/libwolfssl@LIBSUFFIX@.la
 endif
 EXTRA_DIST += tests/unit.h \
               tests/test.conf \

--- a/testsuite/include.am
+++ b/testsuite/include.am
@@ -14,8 +14,8 @@ testsuite_testsuite_test_SOURCES = \
 			      examples/server/server.c \
 			      testsuite/testsuite.c
 testsuite_testsuite_test_CFLAGS       = -DNO_MAIN_DRIVER $(AM_CFLAGS) $(WOLFSENTRY_INCLUDE)
-testsuite_testsuite_test_LDADD        = src/libwolfssl.la $(LIB_STATIC_ADD) $(WOLFSENTRY_LIB)
-testsuite_testsuite_test_DEPENDENCIES = src/libwolfssl.la
+testsuite_testsuite_test_LDADD        = src/libwolfssl@LIBSUFFIX@.la $(LIB_STATIC_ADD) $(WOLFSENTRY_LIB)
+testsuite_testsuite_test_DEPENDENCIES = src/libwolfssl@LIBSUFFIX@.la
 endif
 EXTRA_DIST += testsuite/testsuite.sln
 EXTRA_DIST += testsuite/testsuite.vcproj

--- a/wolfcrypt/benchmark/include.am
+++ b/wolfcrypt/benchmark/include.am
@@ -6,8 +6,8 @@ if BUILD_BENCHMARK
 
 noinst_PROGRAMS += wolfcrypt/benchmark/benchmark
 wolfcrypt_benchmark_benchmark_SOURCES      = wolfcrypt/benchmark/benchmark.c
-wolfcrypt_benchmark_benchmark_LDADD        = src/libwolfssl.la $(LIB_STATIC_ADD)
-wolfcrypt_benchmark_benchmark_DEPENDENCIES = src/libwolfssl.la
+wolfcrypt_benchmark_benchmark_LDADD        = src/libwolfssl@LIBSUFFIX@.la $(LIB_STATIC_ADD)
+wolfcrypt_benchmark_benchmark_DEPENDENCIES = src/libwolfssl@LIBSUFFIX@.la
 noinst_HEADERS += wolfcrypt/benchmark/benchmark.h
 
 endif
@@ -17,8 +17,8 @@ if BUILD_WOLFCRYPT_TESTS_LIBS
 lib_LTLIBRARIES += wolfcrypt/benchmark/libwolfcryptbench.la
 wolfcrypt_benchmark_libwolfcryptbench_la_SOURCES      = wolfcrypt/benchmark/benchmark.c
 wolfcrypt_benchmark_libwolfcryptbench_la_CPPFLAGS     = -DNO_MAIN_DRIVER
-wolfcrypt_benchmark_libwolfcryptbench_la_LIBADD       = src/libwolfssl.la
-wolfcrypt_benchmark_libwolfcryptbench_la_DEPENDENCIES = src/libwolfssl.la
+wolfcrypt_benchmark_libwolfcryptbench_la_LIBADD       = src/libwolfssl@LIBSUFFIX@.la
+wolfcrypt_benchmark_libwolfcryptbench_la_DEPENDENCIES = src/libwolfssl@LIBSUFFIX@.la
 endif
 
 EXTRA_DIST += wolfcrypt/benchmark/benchmark.sln

--- a/wolfcrypt/src/include.am
+++ b/wolfcrypt/src/include.am
@@ -130,78 +130,78 @@ $(ASYNC_FILES):
 	$(AM_V_at)touch $(srcdir)/$@
 
 if BUILD_CRYPTOCB
-src_libwolfssl_la_SOURCES += wolfcrypt/src/cryptocb.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/cryptocb.c
 endif
 
 if BUILD_PKCS11
-src_libwolfssl_la_SOURCES += wolfcrypt/src/wc_pkcs11.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/wc_pkcs11.c
 endif
 
 if BUILD_DEVCRYPTO
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/devcrypto/devcrypto_ecdsa.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/devcrypto/devcrypto_x25519.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/devcrypto/devcrypto_rsa.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/devcrypto/devcrypto_hmac.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/devcrypto/devcrypto_hash.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/devcrypto/devcrypto_aes.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/devcrypto/wc_devcrypto.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/devcrypto/devcrypto_ecdsa.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/devcrypto/devcrypto_x25519.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/devcrypto/devcrypto_rsa.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/devcrypto/devcrypto_hmac.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/devcrypto/devcrypto_hash.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/devcrypto/devcrypto_aes.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/devcrypto/wc_devcrypto.c
 endif
 
 if BUILD_CAVIUM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/cavium/cavium_nitrox.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/cavium/cavium_nitrox.c
 endif
 EXTRA_DIST += wolfcrypt/src/port/cavium/README.md
 
 if BUILD_OCTEON_SYNC
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/cavium/cavium_octeon_sync.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/cavium/cavium_octeon_sync.c
 endif
 EXTRA_DIST += wolfcrypt/src/port/cavium/README_Octeon.md
 
 if BUILD_INTEL_QA
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/intel/quickassist.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/intel/quickassist_mem.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/intel/quickassist.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/intel/quickassist_mem.c
 endif
 EXTRA_DIST += wolfcrypt/src/port/intel/README.md
 
 if BUILD_INTEL_QA_SYNC
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/intel/quickassist_sync.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/intel/quickassist_sync.c
 endif
 
 if BUILD_CRYPTOAUTHLIB
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/atmel/atmel.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/atmel/atmel.c
 endif
 
 if BUILD_IOTSAFE
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/iotsafe/iotsafe.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/iotsafe/iotsafe.c
 endif
 
 
 if BUILD_CAAM
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/caam/wolfcaam_init.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/caam/wolfcaam_qnx.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/caam/wolfcaam_seco.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/caam/wolfcaam_x25519.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/caam/wolfcaam_ecdsa.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/caam/wolfcaam_cmac.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/caam/wolfcaam_aes.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/caam/wolfcaam_hash.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/caam/wolfcaam_rsa.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/caam/wolfcaam_hmac.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/caam/wolfcaam_init.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/caam/wolfcaam_qnx.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/caam/wolfcaam_seco.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/caam/wolfcaam_x25519.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/caam/wolfcaam_ecdsa.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/caam/wolfcaam_cmac.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/caam/wolfcaam_aes.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/caam/wolfcaam_hash.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/caam/wolfcaam_rsa.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/caam/wolfcaam_hmac.c
 endif
 
 if BUILD_SE050
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/nxp/se050_port.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/nxp/se050_port.c
 endif
 
 if BUILD_PSA
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/psa/psa.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/psa/psa_hash.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/psa/psa_aes.c
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/psa/psa_pkcbs.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/psa/psa.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/psa/psa_hash.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/psa/psa_aes.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/psa/psa_pkcbs.c
 endif
 EXTRA_DIST += wolfcrypt/src/port/psa/README.md
 
 if BUILD_MAXQ10XX
-src_libwolfssl_la_SOURCES += wolfcrypt/src/port/maxim/maxq10xx.c
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/maxim/maxq10xx.c
 endif
 EXTRA_DIST += wolfcrypt/src/port/maxim/README.md

--- a/wolfcrypt/test/include.am
+++ b/wolfcrypt/test/include.am
@@ -10,8 +10,8 @@ check_PROGRAMS+= wolfcrypt/test/testwolfcrypt
 endif
 noinst_PROGRAMS+= wolfcrypt/test/testwolfcrypt
 wolfcrypt_test_testwolfcrypt_SOURCES      = wolfcrypt/test/test.c
-wolfcrypt_test_testwolfcrypt_LDADD        = src/libwolfssl.la $(LIB_STATIC_ADD)
-wolfcrypt_test_testwolfcrypt_DEPENDENCIES = src/libwolfssl.la
+wolfcrypt_test_testwolfcrypt_LDADD        = src/libwolfssl@LIBSUFFIX@.la $(LIB_STATIC_ADD)
+wolfcrypt_test_testwolfcrypt_DEPENDENCIES = src/libwolfssl@LIBSUFFIX@.la
 noinst_HEADERS += wolfcrypt/test/test.h wolfcrypt/test/test_paths.h.in
 endif
 endif
@@ -20,8 +20,8 @@ if BUILD_WOLFCRYPT_TESTS_LIBS
 lib_LTLIBRARIES += wolfcrypt/test/libwolfcrypttest.la
 wolfcrypt_test_libwolfcrypttest_la_SOURCES      = wolfcrypt/test/test.c
 wolfcrypt_test_libwolfcrypttest_la_CPPFLAGS     = -DNO_MAIN_DRIVER
-wolfcrypt_test_libwolfcrypttest_la_LIBADD       = src/libwolfssl.la
-wolfcrypt_test_libwolfcrypttest_la_DEPENDENCIES = src/libwolfssl.la
+wolfcrypt_test_libwolfcrypttest_la_LIBADD       = src/libwolfssl@LIBSUFFIX@.la
+wolfcrypt_test_libwolfcrypttest_la_DEPENDENCIES = src/libwolfssl@LIBSUFFIX@.la
 endif
 
 EXTRA_DIST += wolfcrypt/test/test.sln


### PR DESCRIPTION
# Description

This PR adds a configure option, `--with-libsuffix`, to allow users to add a suffix to the generated wolfSSL library artifact name.  For example, `--with-libsuffix=abc` would result in `libwolfsslabc.so`.

Primary use case of this currently will be users who need to maintain multiple wolfSSL library versions/builds, but don't want to manage library conflicts via library search paths.

One common example is users of both `--enable-opensslextra` and `--enable-engine`.  `--enable-engine` is incompatible with the OpenSSL compatibility layer.  Therefore, users who want to build some OSP packages (or wolfJSSE) with the compatibility layer in addition to building wolfEngine may run into this limitation, and need to maintain two separate wolfSSL library builds.

Addresses ZD #14790.

# Testing

Tested on OSX and Ubuntu with varying configure options.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
