### PR TITLE
Fixes SP math all build issue with small-stack and no hardening

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -12692,7 +12692,11 @@ static int _sp_exptmod_base_2(const sp_int* e, int digits, const sp_int* m,
     sp_print(r, "rme");
 #endif
 
+#ifndef WC_NO_HARDEN
     FREE_SP_INT_ARRAY(d, NULL);
+#else
+    FREE_SP_INT(tr, m->used * 2 + 1);
+#endif
     return err;
 }
 #endif


### PR DESCRIPTION
# Description

Fixes SP math all build issue with small-stack and no hardening.

Fixes ZD 15388

# Testing

```
./configure --disable-harden --enable-smallstack && make
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
