### PR TITLE
fix shadows min and subscript by i486-netbsd-gcc

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -25287,8 +25287,8 @@ int wolfSSL_ASN1_TIME_check(const WOLFSSL_ASN1_TIME* a)
 /*
  * Convert time to Unix time (GMT).
  */
-static long long TimeToUnixTime(int sec, int min, int hour, int mday, int mon,
-                                int year)
+static long long TimeToUnixTime(int sec, int minute, int hour, int mday, 
+                                int mon, int year)
 {
     /* Number of cumulative days from the previous months, starting from
      * beginning of January. */
@@ -25304,8 +25304,8 @@ static long long TimeToUnixTime(int sec, int min, int hour, int mday, int mon,
                1969 / 100 - 1969 / 400;
 
     return ((((long long) (year - 1970) * 365 + leapDays +
-           monthDaysCumulative[mon] + mday - 1) * 24 + hour) * 60 + min) * 60 +
-           sec;
+           monthDaysCumulative[mon] + mday - 1) * 24 + hour) * 60 + minute) * 
+           60 + sec;
 }
 
 int wolfSSL_ASN1_TIME_diff(int *days, int *secs, const WOLFSSL_ASN1_TIME *from,
@@ -29544,10 +29544,10 @@ int wolfSSL_ASN1_STRING_canon(WOLFSSL_ASN1_STRING* asn_out,
 
     /* trimming spaces at the head and tail */
     dst--;
-    for (; (len > 0 && XISSPACE(*dst)); len--) {
+    for (; (len > 0 && XISSPACE((unsigned char)*dst)); len--) {
         dst--;
     }
-    for (; (len > 0 && XISSPACE(*src)); len--) {
+    for (; (len > 0 && XISSPACE((unsigned char)*src)); len--) {
         src++;
     }
 
@@ -29558,10 +29558,10 @@ int wolfSSL_ASN1_STRING_canon(WOLFSSL_ASN1_STRING* asn_out,
         if (!XISASCII(*src)) {
             /* keep non-ascii code */
             *dst = *src++;
-        } else if (XISSPACE(*src)) {
+        } else if ((*src) > 0 && XISSPACE((unsigned char)*src)) {
             *dst = 0x20; /* space */
             /* remove the rest of spaces */
-            while (XISSPACE(*++src) && i++ < len);
+            while (XISSPACE((unsigned char)*++src) && i++ < len);
         } else {
             *dst = (char)XTOLOWER((unsigned char)*src++);
         }


### PR DESCRIPTION
# Description

Fix compiler error when using i486--netbsdelf-gcc 4.5.3 :
src/ssl.c: In function 'TimeToUnixTime':
src/ssl.c:25290:46: error: declaration of 'min' shadows a global declaration
./wolfcrypt/src/misc.c:370:32: error: shadowed declaration is here
src/ssl.c: In function 'wolfSSL_ASN1_STRING_canon':
src/ssl.c:29547:5: error: array subscript has type 'char'
src/ssl.c:29550:5: error: array subscript has type 'char'
src/ssl.c:29561:9: error: array subscript has type 'char'
src/ssl.c:29564:13: error: array subscript has type 'char'

# Testing

Compile the changes by i486--netbsdelf-gcc (NetBSD nb2 20111202) 4.5.3

