### PR TITLE
20221226-minor-fixes

### DIFF
--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -1,9 +1,14 @@
-echo "Running with \"${@}\"..."
+#!/bin/bash
+
+echo "Running with \"${*}\"..."
 
 # Assume we're in wolfssl/Docker
 WOLFSSL_DIR=$(builtin cd ${BASH_SOURCE%/*}/..; pwd)
 
-docker build -t wolfssl --build-arg UID=$(id -u) --build-arg GID=$(id -g) ${WOLFSSL_DIR}/Docker && \
-docker run -it -v ${WOLFSSL_DIR}:/tmp/wolfssl -w /tmp/wolfssl wolfssl /bin/bash -c "./autogen.sh && ./configure $(echo ${@}) && make && ./testsuite/testsuite.test" && \
-docker run -it -v ${WOLFSSL_DIR}:/tmp/wolfssl -w /tmp/wolfssl wolfssl /bin/bash
-echo "Exited with error code $?"
+docker build -t wolfssl --build-arg UID=$(id -u) --build-arg GID=$(id -g) "${WOLFSSL_DIR}/Docker" && \
+  docker run -it -v "${WOLFSSL_DIR}:/tmp/wolfssl" -w /tmp/wolfssl wolfssl /bin/bash -c "./autogen.sh && ./configure ${*@Q} && make && ./testsuite/testsuite.test" && \
+  docker run -it -v "${WOLFSSL_DIR}:/tmp/wolfssl" -w /tmp/wolfssl wolfssl /bin/bash
+
+exitval=$?
+echo "Exited with error code $exitval"
+exit $exitval

--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -322,7 +322,11 @@
              */
             #endif
         #endif
-        typeof(cpu_number) *cpu_number;
+        #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+            typeof(cpu_number) *cpu_number;
+        #else
+            typeof(pcpu_hot) *pcpu_hot;
+        #endif
         typeof(nr_cpu_ids) *nr_cpu_ids;
 
         #endif /* WOLFSSL_LINUXKM_SIMD_X86 */
@@ -459,7 +463,11 @@
              */
             #endif
         #endif
-        #define cpu_number (*(wolfssl_linuxkm_get_pie_redirect_table()->cpu_number))
+        #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+            #define cpu_number (*(wolfssl_linuxkm_get_pie_redirect_table()->cpu_number))
+        #else
+            #define pcpu_hot (*(wolfssl_linuxkm_get_pie_redirect_table()->pcpu_hot))
+        #endif
         #define nr_cpu_ids (*(wolfssl_linuxkm_get_pie_redirect_table()->nr_cpu_ids))
     #endif
 

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -445,7 +445,11 @@ static int set_up_wolfssl_linuxkm_pie_redirect_table(void) {
          */
         #endif
     #endif
-    wolfssl_linuxkm_pie_redirect_table.cpu_number = &cpu_number;
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+        wolfssl_linuxkm_pie_redirect_table.cpu_number = &cpu_number;
+    #else
+        wolfssl_linuxkm_pie_redirect_table.pcpu_hot = &pcpu_hot;
+    #endif
     wolfssl_linuxkm_pie_redirect_table.nr_cpu_ids = &nr_cpu_ids;
 #endif
 

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1888,14 +1888,12 @@ static void bench_stats_sym_finish(const char* desc, int useDeviceID,
 
 #ifdef GENERATE_MACHINE_PARSEABLE_REPORT
     #ifdef WOLFSSL_ESPIDF
-        unsigned long bytes_processed = (unsigned long)blocks;
+        unsigned long bytes_processed =
+            (unsigned long)count * (unsigned long)countSz;
     #else
-        word64 bytes_processed = (word64)blocks;
+        word64 bytes_processed = (word64)count * (word64)countSz;
     #endif
-#endif
 
-
-#ifdef GENERATE_MACHINE_PARSEABLE_REPORT
     /* note this codepath brings in all the fields from the non-CSV case. */
     #ifdef WOLFSSL_ESPIDF
         #ifdef HAVE_GET_CYCLES


### PR DESCRIPTION
`Docker/run.sh`: mollify `shellcheck`, and prevent splitting on whitespace passing args through to `configure`.

`wolfcrypt/benchmark/benchmark.c`: fix `bench_stats_sym_finish()` in `GENERATE_MACHINE_PARSEABLE_REPORT` mode to properly render "bytes_total" column in bytes, not the unit selected by `WOLFSSL_BENCHMARK_FIXED_UNITS_*`.

`linuxkm/`: accommodate refactoring in kernel 6.2+ of `cpu_number` to be an element of the `pcpu_hot`structure.
