### PR TITLE
ssl->suites: use ssl->ctx->suites when possible

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -8243,6 +8243,7 @@ static DtlsFragBucket* DtlsMsgCreateFragBucket(word32 offset, const byte* data,
         if (data != NULL)
             XMEMCPY(bucket->buf, data, dataSz);
     }
+    (void)heap;
     return bucket;
 }
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -2784,11 +2784,11 @@ static int GetMacDigestSize(byte macAlgo)
 
 #define ADD_HASH_SIG_ALGO(out, inOutIdx, major, minor)  \
     do {                                                \
-        if (out != NULL) {                              \
-            out[*inOutIdx    ] = major;                 \
-            out[*inOutIdx + 1] = minor;                 \
+        if ((out) != NULL) {                            \
+            (out)[*(inOutIdx)    ] = (major);           \
+            (out)[*(inOutIdx) + 1] = (minor);           \
         }                                               \
-        *inOutIdx += 2;                                 \
+        *(inOutIdx) += 2;                               \
     } while (0)
 
 static WC_INLINE void AddSuiteHashSigAlgo(byte* hashSigAlgo, byte macAlgo,
@@ -2811,38 +2811,45 @@ static WC_INLINE void AddSuiteHashSigAlgo(byte* hashSigAlgo, byte macAlgo,
     if (addSigAlgo) {
     #ifdef HAVE_ED25519
         if (sigAlgo == ed25519_sa_algo) {
-            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx, ED25519_SA_MAJOR, ED25519_SA_MINOR);
+            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx,
+                ED25519_SA_MAJOR, ED25519_SA_MINOR);
         }
         else
     #endif
     #ifdef HAVE_ED448
         if (sigAlgo == ed448_sa_algo) {
-            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx, ED448_SA_MAJOR, ED448_SA_MINOR);
+            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx,
+                ED448_SA_MAJOR, ED448_SA_MINOR);
         }
         else
     #endif
     #ifdef HAVE_PQC
     #ifdef HAVE_FALCON
         if (sigAlgo == falcon_level1_sa_algo) {
-            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx, FALCON_LEVEL1_SA_MAJOR, FALCON_LEVEL1_SA_MINOR);
+            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx,
+                FALCON_LEVEL1_SA_MAJOR, FALCON_LEVEL1_SA_MINOR);
         }
         else
         if (sigAlgo == falcon_level5_sa_algo) {
-            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx, FALCON_LEVEL5_SA_MAJOR, FALCON_LEVEL5_SA_MINOR);
+            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx,
+                FALCON_LEVEL5_SA_MAJOR, FALCON_LEVEL5_SA_MINOR);
         }
         else
     #endif /* HAVE_FALCON */
     #ifdef HAVE_DILITHIUM
         if (sigAlgo == dilithium_level2_sa_algo) {
-            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx, DILITHIUM_LEVEL2_SA_MAJOR, DILITHIUM_LEVEL2_SA_MINOR);
+            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx,
+                DILITHIUM_LEVEL2_SA_MAJOR, DILITHIUM_LEVEL2_SA_MINOR);
         }
         else
         if (sigAlgo == dilithium_level3_sa_algo) {
-            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx, DILITHIUM_LEVEL3_SA_MAJOR, DILITHIUM_LEVEL3_SA_MINOR);
+            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx,
+                DILITHIUM_LEVEL3_SA_MAJOR, DILITHIUM_LEVEL3_SA_MINOR);
         }
         else
         if (sigAlgo == dilithium_level5_sa_algo) {
-            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx, DILITHIUM_LEVEL5_SA_MAJOR, DILITHIUM_LEVEL5_SA_MINOR);
+            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx,
+                DILITHIUM_LEVEL5_SA_MAJOR, DILITHIUM_LEVEL5_SA_MINOR);
         }
         else
     #endif /* HAVE_DILITHIUM */
@@ -2853,7 +2860,8 @@ static WC_INLINE void AddSuiteHashSigAlgo(byte* hashSigAlgo, byte macAlgo,
             ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx, sigAlgo, macAlgo);
     #ifdef WOLFSSL_TLS13
             /* Add the certificate algorithm as well */
-            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx, sigAlgo, PSS_RSAE_TO_PSS_PSS(macAlgo));
+            ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx, sigAlgo,
+                PSS_RSAE_TO_PSS_PSS(macAlgo));
     #endif
         }
         else
@@ -2864,19 +2872,18 @@ static WC_INLINE void AddSuiteHashSigAlgo(byte* hashSigAlgo, byte macAlgo,
     }
 }
 
-void InitSuitesHashSigAlgo(Suites* suites, int haveECDSAsig,
-                           int haveRSAsig, int haveFalconSig,
-                           int haveDilithiumSig, int haveAnon,
-                           int tls1_2, int keySz)
+void InitSuitesHashSigAlgo(Suites* suites, int haveECDSAsig, int haveRSAsig,
+    int haveFalconSig, int haveDilithiumSig, int haveAnon, int tls1_2,
+    int keySz)
 {
     InitSuitesHashSigAlgo_ex(suites->hashSigAlgo, haveECDSAsig, haveRSAsig,
             haveFalconSig, haveDilithiumSig, haveAnon, tls1_2, keySz,
             &suites->hashSigAlgoSz);
 }
 
-void InitSuitesHashSigAlgo_ex(byte* hashSigAlgo, int haveECDSAsig, int haveRSAsig,
-                              int haveFalconSig, int haveDilithiumSig,
-                              int haveAnon, int tls1_2, int keySz, word16* len)
+void InitSuitesHashSigAlgo_ex(byte* hashSigAlgo, int haveECDSAsig,
+    int haveRSAsig, int haveFalconSig, int haveDilithiumSig, int haveAnon,
+    int tls1_2, int keySz, word16* len)
 {
     word16 idx = 0;
 
@@ -2887,13 +2894,16 @@ void InitSuitesHashSigAlgo_ex(byte* hashSigAlgo, int haveECDSAsig, int haveRSAsi
     if (haveECDSAsig) {
 #ifdef HAVE_ECC
     #ifdef WOLFSSL_SHA512
-        AddSuiteHashSigAlgo(hashSigAlgo, sha512_mac, ecc_dsa_sa_algo, keySz, &idx);
+        AddSuiteHashSigAlgo(hashSigAlgo, sha512_mac, ecc_dsa_sa_algo, keySz,
+            &idx);
     #endif
     #ifdef WOLFSSL_SHA384
-        AddSuiteHashSigAlgo(hashSigAlgo, sha384_mac, ecc_dsa_sa_algo, keySz, &idx);
+        AddSuiteHashSigAlgo(hashSigAlgo, sha384_mac, ecc_dsa_sa_algo, keySz,
+            &idx);
     #endif
     #ifndef NO_SHA256
-        AddSuiteHashSigAlgo(hashSigAlgo, sha256_mac, ecc_dsa_sa_algo, keySz, &idx);
+        AddSuiteHashSigAlgo(hashSigAlgo, sha256_mac, ecc_dsa_sa_algo, keySz,
+            &idx);
     #endif
     #if !defined(NO_SHA) && (!defined(NO_OLD_TLS) || \
                                             defined(WOLFSSL_ALLOW_TLS_SHA1))
@@ -2911,20 +2921,22 @@ void InitSuitesHashSigAlgo_ex(byte* hashSigAlgo, int haveECDSAsig, int haveRSAsi
     if (haveFalconSig) {
 #if defined(HAVE_PQC)
 #ifdef HAVE_FALCON
-        AddSuiteHashSigAlgo(hashSigAlgo, no_mac, falcon_level1_sa_algo, keySz, &idx);
-        AddSuiteHashSigAlgo(hashSigAlgo, no_mac, falcon_level5_sa_algo, keySz, &idx);
+        AddSuiteHashSigAlgo(hashSigAlgo, no_mac, falcon_level1_sa_algo, keySz,
+            &idx);
+        AddSuiteHashSigAlgo(hashSigAlgo, no_mac, falcon_level5_sa_algo, keySz,
+            &idx);
 #endif /* HAVE_FALCON */
 #endif /* HAVE_PQC */
     }
     if (haveDilithiumSig) {
 #if defined(HAVE_PQC)
 #ifdef HAVE_DILITHIUM
-        AddSuiteHashSigAlgo(hashSigAlgo, no_mac, dilithium_level2_sa_algo, keySz,
-                            &idx);
-        AddSuiteHashSigAlgo(hashSigAlgo, no_mac, dilithium_level3_sa_algo, keySz,
-                            &idx);
-        AddSuiteHashSigAlgo(hashSigAlgo, no_mac, dilithium_level5_sa_algo, keySz,
-                            &idx);
+        AddSuiteHashSigAlgo(hashSigAlgo, no_mac, dilithium_level2_sa_algo,
+            keySz, &idx);
+        AddSuiteHashSigAlgo(hashSigAlgo, no_mac, dilithium_level3_sa_algo,
+            keySz, &idx);
+        AddSuiteHashSigAlgo(hashSigAlgo, no_mac, dilithium_level5_sa_algo,
+            keySz, &idx);
 #endif /* HAVE_DILITHIUM */
 #endif /* HAVE_PQC */
     }
@@ -2933,15 +2945,15 @@ void InitSuitesHashSigAlgo_ex(byte* hashSigAlgo, int haveECDSAsig, int haveRSAsi
         if (tls1_2) {
         #ifdef WOLFSSL_SHA512
             AddSuiteHashSigAlgo(hashSigAlgo, sha512_mac, rsa_pss_sa_algo, keySz,
-                                                                          &idx);
+                &idx);
         #endif
         #ifdef WOLFSSL_SHA384
             AddSuiteHashSigAlgo(hashSigAlgo, sha384_mac, rsa_pss_sa_algo, keySz,
-                                                                          &idx);
+                &idx);
         #endif
         #ifndef NO_SHA256
             AddSuiteHashSigAlgo(hashSigAlgo, sha256_mac, rsa_pss_sa_algo, keySz,
-                                                                          &idx);
+                &idx);
         #endif
         }
     #endif
@@ -2965,7 +2977,8 @@ void InitSuitesHashSigAlgo_ex(byte* hashSigAlgo, int haveECDSAsig, int haveRSAsi
 
 #ifdef HAVE_ANON
     if (haveAnon) {
-        AddSuiteHashSigAlgo(hashSigAlgo, sha_mac, anonymous_sa_algo, keySz, &idx);
+        AddSuiteHashSigAlgo(hashSigAlgo, sha_mac, anonymous_sa_algo, keySz,
+            &idx);
     }
 #endif
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -2789,7 +2789,7 @@ static int GetMacDigestSize(byte macAlgo)
             out[*inOutIdx + 1] = minor;                 \
         }                                               \
         *inOutIdx += 2;                                 \
-    } while(0)
+    } while (0)
 
 static WC_INLINE void AddSuiteHashSigAlgo(byte* hashSigAlgo, byte macAlgo,
     byte sigAlgo, int keySz, word16* inOutIdx)
@@ -2864,9 +2864,19 @@ static WC_INLINE void AddSuiteHashSigAlgo(byte* hashSigAlgo, byte macAlgo,
     }
 }
 
-void InitSuitesHashSigAlgo(byte* hashSigAlgo, int haveECDSAsig, int haveRSAsig,
-                           int haveFalconSig, int haveDilithiumSig,
-                           int haveAnon, int tls1_2, int keySz, word16* len)
+void InitSuitesHashSigAlgo(Suites* suites, int haveECDSAsig,
+                           int haveRSAsig, int haveFalconSig,
+                           int haveDilithiumSig, int haveAnon,
+                           int tls1_2, int keySz)
+{
+    InitSuitesHashSigAlgo_ex(suites->hashSigAlgo, haveECDSAsig, haveRSAsig,
+            haveFalconSig, haveDilithiumSig, haveAnon, tls1_2, keySz,
+            &suites->hashSigAlgoSz);
+}
+
+void InitSuitesHashSigAlgo_ex(byte* hashSigAlgo, int haveECDSAsig, int haveRSAsig,
+                              int haveFalconSig, int haveDilithiumSig,
+                              int haveAnon, int tls1_2, int keySz, word16* len)
 {
     word16 idx = 0;
 
@@ -2986,7 +2996,7 @@ int AllocateSuites(WOLFSSL* ssl)
                                        DYNAMIC_TYPE_SUITES);
         if (ssl->suites == NULL) {
             WOLFSSL_MSG("Suites Memory error");
-            return MEMORY_E;
+            return MEMORY_ERROR;
         }
         if (ssl->ctx != NULL && ssl->ctx->suites != NULL)
             XMEMCPY(ssl->suites, ssl->ctx->suites, sizeof(Suites));
@@ -3959,10 +3969,9 @@ void InitSuites(Suites* suites, ProtocolVersion pv, int keySz, word16 haveRSA,
     suites->suiteSz = idx;
 
     if (suites->hashSigAlgoSz == 0) {
-        InitSuitesHashSigAlgo(suites->hashSigAlgo, haveECDSAsig | haveECC,
+        InitSuitesHashSigAlgo(suites, haveECDSAsig | haveECC,
                               haveRSAsig | haveRSA, haveFalconSig,
-                              haveDilithiumSig, 0, tls1_2, keySz,
-                              &suites->hashSigAlgoSz);
+                              haveDilithiumSig, 0, tls1_2, keySz);
     }
 }
 
@@ -24624,9 +24633,9 @@ int SetCipherList(WOLFSSL_CTX* ctx, Suites* suites, const char* list)
     #endif
         {
             suites->suiteSz   = (word16)idx;
-            InitSuitesHashSigAlgo(suites->hashSigAlgo, haveECDSAsig, haveRSAsig,
+            InitSuitesHashSigAlgo(suites, haveECDSAsig, haveRSAsig,
                                   haveFalconSig, haveDilithiumSig, haveAnon,
-                                  1, keySz, &suites->hashSigAlgoSz);
+                                  1, keySz);
         }
         suites->setSuites = 1;
     }
@@ -24750,9 +24759,9 @@ int SetCipherListFromBytes(WOLFSSL_CTX* ctx, Suites* suites, const byte* list,
         keySz = ctx->privateKeySz;
     #endif
         suites->suiteSz = (word16)idx;
-        InitSuitesHashSigAlgo(suites->hashSigAlgo, haveECDSAsig, haveRSAsig,
+        InitSuitesHashSigAlgo(suites, haveECDSAsig, haveRSAsig,
                               haveFalconSig, haveDilithiumSig, haveAnon, 1,
-                              keySz, &suites->hashSigAlgoSz);
+                              keySz);
         suites->setSuites = 1;
     }
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6998,15 +6998,15 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
         word16 havePSK = 0;
         word16 haveRSA = 0;
 
-        #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
+    #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
         if (ssl->options.havePSK) {
             havePSK = 1;
         }
-        #endif
-        #ifndef NO_RSA
-            haveRSA = 1;
-        #endif
-            keySz = ssl->buffers.keySz;
+    #endif
+    #ifndef NO_RSA
+        haveRSA = 1;
+    #endif
+        keySz = ssl->buffers.keySz;
 
         if (AllocateSuites(ssl) != 0)
             return WOLFSSL_FAILURE;
@@ -7021,15 +7021,15 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
         word16 havePSK = 0;
         word16 haveRSA = 0;
 
-        #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
+    #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
         if (ctx->havePSK) {
             havePSK = 1;
         }
-        #endif
-        #ifndef NO_RSA
-            haveRSA = 1;
-        #endif
-            keySz = ctx->privateKeySz;
+    #endif
+    #ifndef NO_RSA
+        haveRSA = 1;
+    #endif
+        keySz = ctx->privateKeySz;
 
         if (AllocateCtxSuites(ctx) != 0)
             return WOLFSSL_FAILURE;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3249,16 +3249,6 @@ static int _Rehandshake(WOLFSSL* ssl)
             }
         }
 
-#ifndef NO_FORCE_SCR_SAME_SUITE
-        /* force same suite */
-        ret = AllocateSuites(ssl);
-        if (ret != 0)
-            return ret;
-        ssl->suites->suiteSz = SUITE_LEN;
-        ssl->suites->suites[0] = ssl->options.cipherSuite0;
-        ssl->suites->suites[1] = ssl->options.cipherSuite;
-#endif
-
         /* reset handshake states */
         ssl->options.sendVerify = 0;
         ssl->options.serverState = NULL_STATE;

--- a/src/tls.c
+++ b/src/tls.c
@@ -6497,6 +6497,7 @@ static int TLSX_SetSignatureAlgorithms(TLSX** extensions, WOLFSSL* ssl,
                                        void* heap)
 {
     SignatureAlgorithms* sa;
+    int ret;
 
     if (extensions == NULL)
         return BAD_FUNC_ARG;
@@ -6509,7 +6510,10 @@ static int TLSX_SetSignatureAlgorithms(TLSX** extensions, WOLFSSL* ssl,
     if (sa == NULL)
         return MEMORY_ERROR;
 
-    return TLSX_Push(extensions, TLSX_SIGNATURE_ALGORITHMS, sa, heap);
+    ret = TLSX_Push(extensions, TLSX_SIGNATURE_ALGORITHMS, sa, heap);
+    if (ret != 0)
+        TLSX_SignatureAlgorithms_FreeAll(sa, heap);
+    return ret;
 }
 
 SignatureAlgorithms* TLSX_SignatureAlgorithms_New(WOLFSSL* ssl,

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -6632,13 +6632,13 @@ static int SendTls13CertificateRequest(WOLFSSL* ssl, byte* reqCtx,
         return SIDE_ERROR;
 
     /* Get the length of the hashSigAlgo buffer */
-    InitSuitesHashSigAlgo(NULL, 1, 1, 1, 1, 0, 1, ssl->buffers.keySz,
-                          &hashSigAlgoSz);
+    InitSuitesHashSigAlgo_ex(NULL, 1, 1, 1, 1, 0, 1, ssl->buffers.keySz,
+                             &hashSigAlgoSz);
     sa = TLSX_SignatureAlgorithms_New(ssl, hashSigAlgoSz, ssl->heap);
     if (sa == NULL)
         return MEMORY_ERROR;
-    InitSuitesHashSigAlgo(sa->hashSigAlgo, 1, 1, 1, 1, 0, 1, ssl->buffers.keySz,
-                          &sa->hashSigAlgoSz);
+    InitSuitesHashSigAlgo_ex(sa->hashSigAlgo, 1, 1, 1, 1, 0, 1, ssl->buffers.keySz,
+                             &sa->hashSigAlgoSz);
     ret = TLSX_Push(&ssl->extensions, TLSX_SIGNATURE_ALGORITHMS, sa, ssl->heap);
     if (ret != 0) {
         TLSX_SignatureAlgorithms_FreeAll(sa, ssl->heap);

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -6637,8 +6637,8 @@ static int SendTls13CertificateRequest(WOLFSSL* ssl, byte* reqCtx,
     sa = TLSX_SignatureAlgorithms_New(ssl, hashSigAlgoSz, ssl->heap);
     if (sa == NULL)
         return MEMORY_ERROR;
-    InitSuitesHashSigAlgo_ex(sa->hashSigAlgo, 1, 1, 1, 1, 0, 1, ssl->buffers.keySz,
-                             &sa->hashSigAlgoSz);
+    InitSuitesHashSigAlgo_ex(sa->hashSigAlgo, 1, 1, 1, 1, 0, 1,
+                             ssl->buffers.keySz, &sa->hashSigAlgoSz);
     ret = TLSX_Push(&ssl->extensions, TLSX_SIGNATURE_ALGORITHMS, sa, ssl->heap);
     if (ret != 0) {
         TLSX_SignatureAlgorithms_FreeAll(sa, ssl->heap);

--- a/tests/api.c
+++ b/tests/api.c
@@ -9389,7 +9389,8 @@ static int test_wolfSSL_SCR_Reconnect(void)
 
     XMEMSET(&test_ctx, 0, sizeof(test_ctx));
     test_ctx.c_ciphers = "ECDHE-RSA-AES256-GCM-SHA384";
-    test_ctx.s_ciphers = "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305";
+    test_ctx.s_ciphers =
+        "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305";
     AssertIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
         wolfTLSv1_2_client_method, wolfTLSv1_2_server_method), 0);
     AssertIntEQ(WOLFSSL_SUCCESS, wolfSSL_CTX_UseSecureRenegotiation(ctx_c));

--- a/tests/api.c
+++ b/tests/api.c
@@ -50862,10 +50862,13 @@ static int test_tls13_cipher_suites(void)
     wolfSSL_SetIOReadCtx(ssl, &msg);
     /* Force server to have as many occurrences of same cipher suite as
      * possible. */
-    ssl->suites->suiteSz = WOLFSSL_MAX_SUITE_SZ;
-    for (i = 0; i < ssl->suites->suiteSz; i += 2) {
-        ssl->suites->suites[i + 0] = TLS13_BYTE;
-        ssl->suites->suites[i + 1] = TLS_AES_128_GCM_SHA256;
+    {
+        Suites* suites = (Suites*)WOLFSSL_SUITES(ssl);
+        suites->suiteSz = WOLFSSL_MAX_SUITE_SZ;
+        for (i = 0; i < suites->suiteSz; i += 2) {
+            suites->suites[i + 0] = TLS13_BYTE;
+            suites->suites[i + 1] = TLS_AES_128_GCM_SHA256;
+        }
     }
     /* Test multiple occurrences of same cipher suite. */
     wolfSSL_accept_TLSv13(ssl);

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -7513,7 +7513,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
         WOLFSSL_ENTER("wolfSSL_EVP_Cipher");
 
         if (ctx == NULL || ((src == NULL || dst == NULL) &&
-            (TRUE 
+            (TRUE
         #ifdef HAVE_AESGCM
             && ctx->cipherType != AES_128_GCM_TYPE &&
              ctx->cipherType != AES_192_GCM_TYPE &&

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1924,6 +1924,7 @@ typedef struct Suites Suites;
 /* defaults to client */
 WOLFSSL_LOCAL void InitSSL_Method(WOLFSSL_METHOD* method, ProtocolVersion pv);
 
+WOLFSSL_LOCAL void InitSSL_CTX_Suites(WOLFSSL_CTX* ctx);
 WOLFSSL_LOCAL int InitSSL_Suites(WOLFSSL* ssl);
 WOLFSSL_LOCAL int InitSSL_Side(WOLFSSL* ssl, word16 side);
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4868,7 +4868,9 @@ typedef struct CIDInfo CIDInfo;
 /* The idea is to re-use the context suites object whenever possible to save
  * space. */
 #define WOLFSSL_SUITES(ssl) \
-    ((const Suites*) (ssl->suites != NULL ? ssl->suites : ssl->ctx->suites))
+    ((const Suites*) ((ssl)->suites != NULL ? \
+        (ssl)->suites : \
+        (ssl)->ctx->suites))
 
 /* wolfSSL ssl type */
 struct WOLFSSL {
@@ -4878,7 +4880,8 @@ struct WOLFSSL {
                              * object needs separate instance of suites use
                              * AllocateSuites(). */
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
-    WOLF_STACK_OF(WOLFSSL_CIPHER)* suitesStack; /* stack of available cipher suites */
+    WOLF_STACK_OF(WOLFSSL_CIPHER)* suitesStack; /* stack of available cipher
+                                                 * suites */
 #endif
     Arrays*         arrays;
 #ifdef WOLFSSL_TLS13
@@ -4898,7 +4901,8 @@ struct WOLFSSL {
     byte            dupSide;            /* write side or read side */
 #endif
 #ifdef OPENSSL_EXTRA
-    byte              cbioFlag;  /* WOLFSSL_CBIO_RECV/SEND: CBIORecv/Send is set */
+    byte              cbioFlag;         /* WOLFSSL_CBIO_RECV/SEND:
+                                         * CBIORecv/Send is set */
 #endif
 #ifdef WOLFSSL_WOLFSENTRY_HOOKS
     NetworkFilterCallback_t AcceptFilter;
@@ -4928,7 +4932,8 @@ struct WOLFSSL {
      * to encounter encryption blocking or fragment the message. */
     struct WOLFSSL_ASYNC* async;
 #endif
-    void*           hsKey;              /* Handshake key (RsaKey or ecc_key) allocated from heap */
+    void*           hsKey;              /* Handshake key (RsaKey or ecc_key)
+                                         * allocated from heap */
     word32          hsType;             /* Type of Handshake key (hsKey) */
     WOLFSSL_CIPHER  cipher;
 #ifndef WOLFSSL_AEAD_ONLY

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2121,10 +2121,14 @@ struct Suites {
     byte   setSuites;               /* user set suites from default */
 };
 
-WOLFSSL_LOCAL void InitSuitesHashSigAlgo(byte* hashSigAlgo, int haveECDSAsig,
+WOLFSSL_LOCAL void InitSuitesHashSigAlgo(Suites* suites, int haveECDSAsig,
                                          int haveRSAsig, int haveFalconSig,
                                          int haveDilithiumSig, int haveAnon,
-                                         int tls1_2, int keySz, word16* len);
+                                         int tls1_2, int keySz);
+WOLFSSL_LOCAL void InitSuitesHashSigAlgo_ex(byte* hashSigAlgo, int haveECDSAsig,
+                                            int haveRSAsig, int haveFalconSig,
+                                            int haveDilithiumSig, int haveAnon,
+                                            int tls1_2, int keySz, word16* len);
 WOLFSSL_LOCAL int AllocateCtxSuites(WOLFSSL_CTX* ctx);
 WOLFSSL_LOCAL int AllocateSuites(WOLFSSL* ssl);
 WOLFSSL_LOCAL void InitSuites(Suites* suites, ProtocolVersion pv, int keySz,

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2120,7 +2120,7 @@ struct Suites {
     byte   setSuites;               /* user set suites from default */
 };
 
-WOLFSSL_LOCAL void InitSuitesHashSigAlgo(Suites* suites, int haveECDSAsig,
+WOLFSSL_LOCAL void InitSuitesHashSigAlgo(byte* hashSigAlgo, int haveECDSAsig,
                                          int haveRSAsig, int haveFalconSig,
                                          int haveDilithiumSig, int haveAnon,
                                          int tls1_2, int keySz, word16* len);
@@ -2776,6 +2776,25 @@ typedef int (*CallbackProcessPeerCert)(WOLFSSL* ssl, DecodedCert* p_cert);
 WOLFSSL_API void wolfSSL_CTX_SetProcessPeerCertCb(WOLFSSL_CTX* ctx,
        CallbackProcessPeerCert cb);
 #endif /* DecodedCert && HAVE_PK_CALLBACKS */
+
+#if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
+typedef struct SignatureAlgorithms {
+    /* Not const since it is modified in TLSX_SignatureAlgorithms_MapPss */
+    WOLFSSL*    ssl;
+    word16      hashSigAlgoSz; /* SigAlgo extension length in bytes */
+    /* Ignore "nonstandard extension used : zero-sized array in struct/union"
+     * MSVC warning */
+    #ifdef _MSC_VER
+    #pragma warning(disable: 4200)
+    #endif
+    byte        hashSigAlgo[]; /* sig/algo to offer */
+} SignatureAlgorithms;
+
+WOLFSSL_LOCAL SignatureAlgorithms* TLSX_SignatureAlgorithms_New(
+        WOLFSSL* ssl, word16 hashSigAlgoSz, void* heap);
+WOLFSSL_LOCAL void TLSX_SignatureAlgorithms_FreeAll(SignatureAlgorithms* sa,
+                                                    void* heap);
+#endif
 
 /** Supported Elliptic Curves - RFC 4492 (session 4) */
 #ifdef HAVE_SUPPORTED_CURVES

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -5208,18 +5208,19 @@ void DEBUG_WRITE_DER(const byte* der, int derSz, const char* fileName);
 
 #define DTLS_CID_BUFFER_SIZE 256
 
-#if !defined(NO_FILESYSTEM) && (                                                   \
-    defined(WOLFSSL_TICKET_NONCE_MALLOC) && defined(HAVE_SESSION_TICKET)           \
-    && defined(WOLFSSL_TLS13) &&                                                   \
-    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))    \
-    ||                                                                             \
-    (defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12) &&                        \
-     !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER))                   \
-    ||                                                                             \
-        (defined(HAVE_SECURE_RENEGOTIATION) &&                                     \
-            !defined(NO_RSA) && defined(HAVE_CHACHA) && defined(HAVE_POLY1305) &&  \
-            defined(WOLFSSL_SHA384) && defined(WOLFSSL_AES_256) &&                 \
-            defined(HAVE_AESGCM))                                                  \
+#if !defined(NO_FILESYSTEM) && (                                               \
+    defined(WOLFSSL_TICKET_NONCE_MALLOC) && defined(HAVE_SESSION_TICKET)       \
+    && defined(WOLFSSL_TLS13) &&                                               \
+    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))\
+    ||                                                                         \
+    (defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12) &&                    \
+     !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER))               \
+    ||                                                                         \
+        (defined(HAVE_SECURE_RENEGOTIATION) &&                                 \
+            !defined(NO_RSA) &&                                                \
+            defined(HAVE_CHACHA) && defined(HAVE_POLY1305) &&                  \
+            defined(WOLFSSL_SHA384) && defined(WOLFSSL_AES_256) &&             \
+            defined(HAVE_AESGCM))                                              \
     )
 
 #define TEST_MEMIO_BUF_SZ (64 * 1024)

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -5208,21 +5208,29 @@ void DEBUG_WRITE_DER(const byte* der, int derSz, const char* fileName);
 
 #define DTLS_CID_BUFFER_SIZE 256
 
-#if !defined(NO_FILESYSTEM) && (                                               \
-    defined(WOLFSSL_TICKET_NONCE_MALLOC) && defined(HAVE_SESSION_TICKET)       \
-    && defined(WOLFSSL_TLS13) &&                                               \
-    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))\
-    ||                                                                         \
-    (defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12) &&                    \
-     !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER)))
+#if !defined(NO_FILESYSTEM) && (                                                   \
+    defined(WOLFSSL_TICKET_NONCE_MALLOC) && defined(HAVE_SESSION_TICKET)           \
+    && defined(WOLFSSL_TLS13) &&                                                   \
+    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))    \
+    ||                                                                             \
+    (defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12) &&                        \
+     !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER))                   \
+    ||                                                                             \
+        (defined(HAVE_SECURE_RENEGOTIATION) &&                                     \
+            !defined(NO_RSA) && defined(HAVE_CHACHA) && defined(HAVE_POLY1305) &&  \
+            defined(WOLFSSL_SHA384) && defined(WOLFSSL_AES_256) &&                 \
+            defined(HAVE_AESGCM))                                                  \
+    )
 
 #define TEST_MEMIO_BUF_SZ (64 * 1024)
 struct test_memio_ctx
 {
     byte c_buff[TEST_MEMIO_BUF_SZ];
     int c_len;
+    const char* c_ciphers;
     byte s_buff[TEST_MEMIO_BUF_SZ];
     int s_len;
+    const char* s_ciphers;
 };
 
 static WC_INLINE int test_memio_write_cb(WOLFSSL *ssl, char *data, int sz,
@@ -5311,7 +5319,7 @@ static WC_INLINE int test_memio_do_handshake(WOLFSSL *ssl_c, WOLFSSL *ssl_s,
                 hs_s = 1;
             }
             else {
-                err = wolfSSL_get_error(ssl_c, ret);
+                err = wolfSSL_get_error(ssl_s, ret);
                 if (err != WOLFSSL_ERROR_WANT_READ &&
                     err != WOLFSSL_ERROR_WANT_WRITE)
                     return -1;
@@ -5335,37 +5343,58 @@ static WC_INLINE int test_memio_setup(struct test_memio_ctx *ctx,
 {
     int ret;
 
-    *ctx_c = wolfSSL_CTX_new(method_c());
-    *ctx_s = wolfSSL_CTX_new(method_s());
-    if (*ctx_c == NULL || *ctx_s == NULL)
-        return -1;
+    if (*ctx_c == NULL) {
+        *ctx_c = wolfSSL_CTX_new(method_c());
+        if (*ctx_c == NULL)
+            return -1;
+        ret = wolfSSL_CTX_load_verify_locations(*ctx_c, caCertFile, 0);
+        if (ret != WOLFSSL_SUCCESS)
+            return -1;
+        wolfSSL_SetIORecv(*ctx_c, test_memio_read_cb);
+        wolfSSL_SetIOSend(*ctx_c, test_memio_write_cb);
+        if (ctx->c_ciphers != NULL) {
+            ret = wolfSSL_CTX_set_cipher_list(*ctx_c, ctx->c_ciphers);
+            if (ret != WOLFSSL_SUCCESS)
+                return -1;
+        }
+    }
 
-    ret = wolfSSL_CTX_use_PrivateKey_file(*ctx_s, svrKeyFile,
-        WOLFSSL_FILETYPE_PEM);
-    if (ret != WOLFSSL_SUCCESS)
-        return- -1;
+    if (*ctx_s == NULL) {
+        *ctx_s = wolfSSL_CTX_new(method_s());
+        if (*ctx_s == NULL)
+            return -1;
+        ret = wolfSSL_CTX_use_PrivateKey_file(*ctx_s, svrKeyFile,
+            WOLFSSL_FILETYPE_PEM);
+        if (ret != WOLFSSL_SUCCESS)
+            return- -1;
+        ret = wolfSSL_CTX_use_certificate_file(*ctx_s, svrCertFile,
+                                               WOLFSSL_FILETYPE_PEM);
+        if (ret != WOLFSSL_SUCCESS)
+            return -1;
+        wolfSSL_SetIORecv(*ctx_s, test_memio_read_cb);
+        wolfSSL_SetIOSend(*ctx_s, test_memio_write_cb);
+        if (ctx->s_ciphers != NULL) {
+            ret = wolfSSL_CTX_set_cipher_list(*ctx_s, ctx->s_ciphers);
+            if (ret != WOLFSSL_SUCCESS)
+                return -1;
+        }
+    }
 
-    ret = wolfSSL_CTX_use_certificate_file(*ctx_s, svrCertFile,
-                                           WOLFSSL_FILETYPE_PEM);
-    if (ret != WOLFSSL_SUCCESS)
-        return -1;
-    ret = wolfSSL_CTX_load_verify_locations(*ctx_c, caCertFile, 0);
-    if (ret != WOLFSSL_SUCCESS)
-        return -1;
-    wolfSSL_SetIORecv(*ctx_c, test_memio_read_cb);
-    wolfSSL_SetIOSend(*ctx_c, test_memio_write_cb);
-    wolfSSL_SetIORecv(*ctx_s, test_memio_read_cb);
-    wolfSSL_SetIOSend(*ctx_s, test_memio_write_cb);
+    if (ssl_c != NULL) {
+        *ssl_c = wolfSSL_new(*ctx_c);
+        if (*ssl_c == NULL)
+            return -1;
+        wolfSSL_SetIOWriteCtx(*ssl_c, ctx);
+        wolfSSL_SetIOReadCtx(*ssl_c, ctx);
+    }
+    if (ssl_s != NULL) {
+        *ssl_s = wolfSSL_new(*ctx_s);
+        if (*ssl_s == NULL)
+            return -1;
+        wolfSSL_SetIOWriteCtx(*ssl_s, ctx);
+        wolfSSL_SetIOReadCtx(*ssl_s, ctx);
+    }
 
-    *ssl_c = wolfSSL_new(*ctx_c);
-    *ssl_s = wolfSSL_new(*ctx_s);
-    if (*ssl_c == NULL || *ssl_s == NULL)
-        return -1;
-
-    wolfSSL_SetIOWriteCtx(*ssl_c, ctx);
-    wolfSSL_SetIOReadCtx(*ssl_c, ctx);
-    wolfSSL_SetIOWriteCtx(*ssl_s, ctx);
-    wolfSSL_SetIOReadCtx(*ssl_s, ctx);
     return 0;
 }
 #endif


### PR DESCRIPTION
- Allocate ssl->suites when necessary for the WOLFSSL object to have its own instance. Use AllocateSuites() to allocate the object.
- Move cipher negotiation options from Suites into Options

ZD15346