### PR TITLE
Remove incomplete doxygen in JP asn_public.h

### DIFF
--- a/doc/dox_comments/header_files-ja/asn_public.h
+++ b/doc/dox_comments/header_files-ja/asn_public.h
@@ -134,10 +134,3 @@ int  wc_SignCert(int requestSz, int sigType, byte* derBuffer,
 */
 int  wc_MakeSelfCert(Cert* cert, byte* derBuffer, word32 derSz, RsaKey* key,
                              WC_RNG* rng);
-
-/*!
-    \ingroup ASN 
-    \brief  この関数は、提供されたPEM ISSUERFILE内の証明書の発行者を発行者に設定します。また、証明書の自己署名属性をfalseに変更します。ISSUERFILEで指定された発行者は、CERT発行者を設定する前に確認されます。このメソッドは、署名の前にフィールドを設定するために使用されます。
-    \return 0  証明書の発行者を正常に設定した
-    \return MEMORY_E  xmallocでメモリを割り当てるエラーがある場合
-    \return ASN_PARSE_E  CERTヘッダーファイルの解析中にエラーがある場合は返されます。


### PR DESCRIPTION
# Description

Looks like an incomplete doxygen section got into the JP doxygen for `asn_public.h`.  This causes issues with the auto-generated HTML/PDF manuals.

# Testing

Tested with automated nightly Jenkins job.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
