### PR TITLE
Fix unguarded XFPRINTF calls

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4529,7 +4529,8 @@ int wolfSSL_CertManagerUnload_trust_peers(WOLFSSL_CERT_MANAGER* cm)
 
 #endif /* NO_CERTS */
 
-#if !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)
+#if !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM) \
+    && defined(XFPRINTF)
 
 void wolfSSL_ERR_print_errors_fp(XFILE fp, int err)
 {
@@ -4553,7 +4554,7 @@ void wolfSSL_ERR_print_errors_cb (int (*cb)(const char *str, size_t len,
     wc_ERR_print_errors_cb(cb, u);
 }
 #endif
-#endif
+#endif /* !NO_FILESYSTEM && !NO_STDIO_FILESYSTEM && XFPRINTF */
 
 /*
  * TODO This ssl parameter needs to be changed to const once our ABI checker
@@ -36937,7 +36938,7 @@ char *wolfSSL_BN_bn2hex(const WOLFSSL_BIGNUM *bn)
     return buf;
 }
 
-#ifndef NO_FILESYSTEM
+#if !defined(NO_FILESYSTEM) && defined(XFPRINTF)
 /* return code compliant with OpenSSL :
  *   1 if success, 0 if error
  */
@@ -36968,7 +36969,7 @@ int wolfSSL_BN_print_fp(XFILE fp, const WOLFSSL_BIGNUM *bn)
 
     return ret;
 }
-#endif /* !NO_FILESYSTEM */
+#endif /* !NO_FILESYSTEM && XFPRINTF */
 
 
 WOLFSSL_BIGNUM *wolfSSL_BN_CTX_get(WOLFSSL_BN_CTX *ctx)

--- a/tests/api.c
+++ b/tests/api.c
@@ -3875,7 +3875,7 @@ static int test_wolfSSL_EC(void)
     /* check bn2hex */
     hexStr = BN_bn2hex(k);
     AssertStrEQ(hexStr, kTest);
-#ifndef NO_FILESYSTEM
+#if !defined(NO_FILESYSTEM) && defined(XFPRINTF)
     BN_print_fp(stderr, k);
     fprintf(stderr, "\n");
 #endif
@@ -3883,7 +3883,7 @@ static int test_wolfSSL_EC(void)
 
     hexStr = BN_bn2hex(Gx);
     AssertStrEQ(hexStr, kGx);
-#ifndef NO_FILESYSTEM
+#if !defined(NO_FILESYSTEM) && defined(XFPRINTF)
     BN_print_fp(stderr, Gx);
     fprintf(stderr, "\n");
 #endif
@@ -3891,7 +3891,7 @@ static int test_wolfSSL_EC(void)
 
     hexStr = BN_bn2hex(Gy);
     AssertStrEQ(hexStr, kGy);
-#ifndef NO_FILESYSTEM
+#if !defined(NO_FILESYSTEM) && defined(XFPRINTF)
     BN_print_fp(stderr, Gy);
     fprintf(stderr, "\n");
 #endif
@@ -53327,7 +53327,7 @@ static int test_wolfSSL_RSA_print(void)
     int res = TEST_SKIPPED;
 #if defined(OPENSSL_EXTRA) && !defined(NO_FILESYSTEM) && \
    !defined(NO_RSA) && !defined(HAVE_FAST_RSA) && defined(WOLFSSL_KEY_GEN) && \
-   !defined(HAVE_FAST_RSA) && !defined(NO_BIO)
+   !defined(HAVE_FAST_RSA) && !defined(NO_BIO) && defined(XFPRINTF)
     BIO *bio;
     WOLFSSL_RSA* rsa = NULL;
 


### PR DESCRIPTION
# Description

Fixes build errors for environment without `fprintf`

Fixes zd15400

# Testing

Customer confirmed.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
