### PR TITLE
Port to RT1170 and expand CAAM driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1803,6 +1803,14 @@ if (WOLFSSL_TLSX)
 endif()
 
 
+add_option("WOLFSSL_CAAM"
+    "Enable use of CAAM with NXP (default: disabled)"
+    "no" "yes;no")
+if (WOLFSSL_CAAM)
+   list(APPEND WOLFSSL_DEFINITIONS  "-DWOLFSSL_CAAM")
+endif()
+
+
 # Generates the BUILD_* flags. These control what source files are included in
 # the library. A series of AM_CONDITIONALs handle this in configure.ac.
 generate_build_flags()
@@ -2208,7 +2216,7 @@ if(NOT BUILD_FIPS OR BUILD_FIPS_V1)
     "wolfssl/wolfcrypt/fips.h")
 endif()
 
-if(NOT BUILD_QNXCAAM)
+if(NOT BUILD_QNXCAAM OR BUILD_CAAM)
   list(APPEND HEADER_EXCLUDE
     "wolfssl/wolfcrypt/port/caam"
     )

--- a/IDE/MCUEXPRESSO/README.md
+++ b/IDE/MCUEXPRESSO/README.md
@@ -1,10 +1,33 @@
 
-- Open MCUEXPRESSO and set the workspace to wolfssl/IDE/MCUEXPRESSO
-- File -> Open Projects From File System... -> Directory : and set the browse to wolfssl/IDE/MCUEXPROSSO directory then click "select directory"
+- Open MCUEXPRESSO and set the workspace to wolfssl/IDE/MCUEXPRESSO or to wolfssl/IDE/MCUEXPRESSO/RT1170 (for RT1170)
+- File -> Open Projects From File System... -> Directory : and set the browse to wolfssl/IDE/MCUEXPRESSO directory then click "select directory"
+	- For RT1170 use the directory wolfssl/IDE/MCUEXPRESSO/RT1170
 - Select MCUEXPRESSO\wolfssl, MCUEXPRESSO\benchmark and MCUEXPRESSO\wolfcrypt_test then click "Finish"
+	- For RT1170 select wolfssl_cm7, wolfcrypt_test_cm7
 - Right click the projects -> SDK Management -> Refresh SDK Components and click "yes"
-- MCUEXPRESSO fails to generate the fils for wolfssl/MIMXRT685S, just copy the files from either benchmark or wolfcrypt_test into the directory
+- MCUEXPRESSO fails to generate the files for wolfssl/MIMXRT685S with RT685 build, just copy the files from either benchmark or wolfcrypt_test into the directory
 - increase the size of configTOTAL_HEAP_SIZE in FreeRTOSConfig.h to be 200000 for wolfcrypt_test and benchmark projects
 - (note board files need to be recreated .... this can be done by creating a new project that has the same settings and copying over the generated board/* files)
 - Build the projects
 
+
+### Expanding RT1170 CAAM Driver
+The files RT1170/fsl_caam_h.patch and RT1170/fsl_caam_c.patch include changes to
+the existing NXP CAAM driver for use with creating/opening Blobs and generating
+and using ECC black keys.
+
+To apply the patches first create a project that has the caam driver. This will
+generate the base fsl_caam.c and fsl_caam.h in the drivers directory. (i.e wolfcrypt_test_cm7/drivers/fls_caam.{c,h})
+. Once the base files are generated then 'cd' to the drivers directory and apply
+the patch. The following is an example of applying the patch to the PKCS7 example
+using Cygwin (cd wolfcrypt_test_cm7/drivers/ && /bin/patch < ../../fsl_caam_c.patch && /bin/patch < ../../fsl_caam_h.patch).
+
+In the patch for fsl_caam.h there are macros defined for both the ECC and Blob
+expansion (CAAM_ECC_EXPANSION and CAAM_BLOB_EXPANSION). When wolfSSL code finds
+that these macros are defined (the patch has been applied) then it tries to
+compile in use of the expanded driver.
+
+### CMake example
+
+See the cmake directory in https://github.com/wolfssl/wolfssl-examples for an example of
+building with CMake and CSR/PKCS7 examples.

--- a/IDE/MCUEXPRESSO/RT1170/fsl_caam_c.patch
+++ b/IDE/MCUEXPRESSO/RT1170/fsl_caam_c.patch
@@ -1,0 +1,465 @@
+--- fsl_caam-orig.c	2022-10-21 15:50:35.709951000 -0700
++++ fsl_caam.c	2022-12-28 06:30:34.788316189 -0800
+@@ -7872,3 +7872,462 @@
+     }
+     return status;
+ }
++
++
++#define CAAM_ECDSA_PD 0x00400000
++#define CAAM_ECDSA_KEYGEN_PD 0x02000000
++
++static const uint32_t templateKeyPairECC[] = {
++    /* 00 */ 0xB0840000u,  /* HEADER */
++    /* 01 */ 0x00000000u,  /* ECDSEL */
++    /* 02 */ 0x00000000u,  /* Private Key Address */
++    /* 03 */ 0x00000000u,  /* Public Key Address */
++    /* 04 */ 0x80140002u,  /* Operation */
++};
++
++
++static const uint32_t templateSignECC[] = {
++    /* 00 */ 0xB0870000u,  /* HEADER */
++    /* 01 */ 0x00000000u,  /* ECDSEL */
++    /* 02 */ 0x00000000u,  /* Private Key Address */
++    /* 03 */ 0x00000000u,  /* Message Address */
++    /* 04 */ 0x00000000u,  /* R of signature */
++    /* 05 */ 0x00000000u,  /* S of signature */
++    /* 06 */ 0x00000000u,  /* Message Size */
++    /* 07 */ 0x80150802u,  /* Operation */
++};
++
++
++static const uint32_t templateVerifyECC[] = {
++    /* 00 */ 0xB0880000u,  /* HEADER */
++    /* 01 */ 0x00000000u,  /* ECDSEL */
++    /* 02 */ 0x00000000u,  /* Public Key Address (X,Y) */
++    /* 03 */ 0x00000000u,  /* Message Address */
++    /* 04 */ 0x00000000u,  /* R of signature */
++    /* 05 */ 0x00000000u,  /* S of signature */
++    /* 06 */ 0x00000000u,  /* tmp buffer */
++    /* 07 */ 0x00000000u,  /* Message Size */
++    /* 08 */ 0x80160802u,  /* Operation */
++};
++
++
++static const uint32_t templateAgreeECC[] = {
++    /* 00 */ 0xB0850000u,  /* HEADER */
++    /* 01 */ 0x00000000u,  /* ECDSEL */
++    /* 02 */ 0x00000000u,  /* Public Key Address */
++    /* 03 */ 0x00000000u,  /* Private Key Address */
++    /* 04 */ 0x00000000u,  /* Shared Output */
++    /* 07 */ 0x80170002u,  /* Operation */
++};
++
++
++static int CheckSupportedKeyType(int keyType)
++{
++    int ret = 0;
++
++    switch (keyType) {
++        case CAAM_ECDSA_P256:
++            ret = 32;
++            break;
++
++        case CAAM_ECDSA_P384:
++            ret = 48;
++            break;
++
++        case CAAM_ECDSA_P521:
++            ret = 66;
++            break;
++    }
++    return ret;
++}
++
++
++/*!
++ * brief generate ECC Keypair.
++ *
++ * This function generates ECC private/public key pair.
++ *
++ * param base CAAM peripheral base address
++ * param[out] k private key
++ * param[in,out] sizeK pointer to size variable. On input it holds size of input k in bytes. On output it holds size of
++ *                of generated private key k in bytes.
++ * param[out] p public key
++ * param[in,out] sizeP pointer to size variable. On input it holds size of input p in bytes. On output it holds size of
++ *                of generated public key p in bytes.
++ * param keyType type of ECC key, i.e P256 / P384
++ * param enc option to create black key
++ * return Operation status.
++ */
++status_t CAAM_ECC_Keygen(CAAM_Type *base,
++                                      caam_handle_t *handle,
++                                      uint8_t *k,
++                                      size_t *sizeK,
++                                      uint8_t *p,
++                                      size_t *sizeP,
++                                      int keyType,
++                                      uint32_t enc)
++{
++    caam_desc_pkha_ecc_t descriptor;
++    status_t status = kStatus_InvalidArgument;
++    uint32_t descriptorSize = ARRAY_SIZE(templateKeyPairECC);
++    BUILD_ASSURE(sizeof(caam_desc_pkha_ecc_t) >= sizeof(templateKeyPairECC), caam_desc_pkha_ecc_t_size_too_low);
++
++    /* check if known type of key encryption */
++    if (enc != 0 && enc != CAAM_PKHA_ENC_PRI_AESECB) {
++        return status;
++    }
++
++    /* check is supported key type */
++    if (CheckSupportedKeyType(keyType) == 0) {
++        return status;
++    }
++
++    /* initialize descriptor from template */
++    (void)caam_memcpy(descriptor, templateKeyPairECC, sizeof(templateKeyPairECC));
++
++    /* add descriptor lenght in bytes to HEADER descriptor command */
++    DESC_HEADER_ADD_DESCLEN(descriptor[0], descriptorSize);
++
++    DESC_SET_ADDR(descriptor[1], (CAAM_ECDSA_KEYGEN_PD | keyType));
++    DESC_SET_ADDR(descriptor[2], k);
++    DESC_SET_ADDR(descriptor[3], p);
++
++    /* add in if is encrypted */
++    descriptor[4] |= enc;
++
++    /* schedule the job */
++    status = caam_in_job_ring_add(base, handle->jobRing, &descriptor[0]);
++    if (status == kStatus_Success) {
++        status = CAAM_Wait(base, handle, descriptor, kCAAM_Blocking);
++    }
++
++#if defined(CAAM_OUT_INVALIDATE) && (CAAM_OUT_INVALIDATE > 0u)
++    /* NOTE: DCACHE must be set to write-trough mode to safely invalidate cache!! */
++    /* Invalidate unaligned data can cause memory corruption in write-back mode   */
++    DCACHE_InvalidateByRange((uint32_t)k, *sizeK);
++    DCACHE_InvalidateByRange((uint32_t)p, *sizeP);
++#endif /* CAAM_OUT_INVALIDATE */
++    return status;
++}
++
++
++/*!
++ * brief generate ECC signature.
++ *
++ * This function creates an ECC signature.
++ *
++ * param base CAAM peripheral base address
++ * param[in] k private key
++ * param[in] sizeK holds size of input k in bytes.
++ * param[in] hash contains the hash to sign
++ * param[in] sizeHash is the size of 'hash' in bytes.
++ * param[out] sig signature output
++ * param[in,out] sizeSig pointer to size variable. On input it holds size of input sig in bytes. On output it holds size of
++ *                of generated signature in bytes.
++ * param keyType type of ECC key i.e P256 / P384
++ * param enc option to use black key
++ * return Operation status.
++ */
++status_t CAAM_ECC_Sign(CAAM_Type *base,
++                                      caam_handle_t *handle,
++                                      const uint8_t *k,
++                                      size_t sizeK,
++                                      const uint8_t *hash,
++                                      size_t sizeHash,
++                                      uint8_t *r,
++                                      size_t sizeR,
++                                      uint8_t *s,
++                                      size_t sizeS,
++                                      int keyType,
++                                      uint32_t enc)
++{
++    size_t keySz = 0;
++    caam_desc_pkha_ecc_t descriptor;
++    status_t status = kStatus_InvalidArgument;
++    uint32_t descriptorSize = ARRAY_SIZE(templateSignECC);
++    BUILD_ASSURE(sizeof(caam_desc_pkha_ecc_t) >= sizeof(templateSignECC), caam_desc_pkha_ecc_t_size_too_low);
++
++    /* check if known type of key encryption */
++    if (enc != 0 && enc != CAAM_PKHA_ENC_PRI_AESECB) {
++        return status;
++    }
++
++    /* check is supported key type */
++    keySz = CheckSupportedKeyType(keyType);
++    if (keySz == 0) {
++        return status;
++    }
++
++    /* sanity check on size of buffers passed in */
++    if (sizeR < keySz || sizeS < keySz) {
++        return status;
++    }
++
++    /* initialize descriptor from template */
++    (void)caam_memcpy(descriptor, templateSignECC, sizeof(templateSignECC));
++
++    /* add descriptor lenght in bytes to HEADER descriptor command */
++    DESC_HEADER_ADD_DESCLEN(descriptor[0], descriptorSize);
++
++    DESC_SET_ADDR(descriptor[1], (CAAM_ECDSA_PD | keyType));
++    DESC_SET_ADDR(descriptor[2], k);
++    DESC_SET_ADDR(descriptor[3], hash);
++    DESC_SET_ADDR(descriptor[4], r);
++    DESC_SET_ADDR(descriptor[5], s);
++    DESC_ADD_LEN(descriptor[6], sizeHash);
++
++    /* add in if is encrypted */
++    descriptor[7] |= enc;
++
++    /* schedule the job */
++    status = caam_in_job_ring_add(base, handle->jobRing, &descriptor[0]);
++    if (status == kStatus_Success) {
++        status = CAAM_Wait(base, handle, descriptor, kCAAM_Blocking);
++    }
++#if defined(CAAM_OUT_INVALIDATE) && (CAAM_OUT_INVALIDATE > 0u)
++    /* NOTE: DCACHE must be set to write-trough mode to safely invalidate cache!! */
++    /* Invalidate unaligned data can cause memory corruption in write-back mode   */
++    DCACHE_InvalidateByRange((uint32_t)r, sizeR);
++    DCACHE_InvalidateByRange((uint32_t)s, sizeS);
++#endif /* CAAM_OUT_INVALIDATE */
++    return status;
++}
++
++
++/*!
++ * brief do an ECC verify.
++ *
++ * This function verifies an ECC signature.
++ *
++ * param base CAAM peripheral base address
++ * param[in] p public key
++ * param[in] sizeP pointer to size variable. On input it holds size of input k in bytes. On output it holds size of
++ *                of generated private key k in bytes.
++ * param[in] sig signature to verify
++ * param[in] sizeSig size of signature in bytes
++ * param[in] hash contains the hash to sign
++ * param[in] sizeHash is the size of 'hash' in bytes.
++ * param keyType type of ECC key i.e P256 / P384
++ * param enc option to use black key
++ * return Operation status.
++ */
++status_t CAAM_ECC_Verify(CAAM_Type *base,
++                                      caam_handle_t *handle,
++                                      const uint8_t *p,
++                                      size_t sizeP,
++                                      const uint8_t *r,
++                                      size_t sizeR,
++                                      const uint8_t *s,
++                                      size_t sizeS,
++                                      const uint8_t *hash,
++                                      size_t sizeHash,
++                                      int keyType)
++{
++    size_t keySz = 0;
++    caam_desc_pkha_ecc_t descriptor;
++    status_t status = kStatus_InvalidArgument;
++    uint8_t tmp[256];
++    uint32_t descriptorSize = ARRAY_SIZE(templateVerifyECC);
++    BUILD_ASSURE(sizeof(caam_desc_pkha_ecc_t) >= sizeof(templateVerifyECC), caam_desc_pkha_ecc_t_size_too_low);
++
++    /* check is supported key type */
++    keySz = CheckSupportedKeyType(keyType);
++    if (keySz == 0 || sizeR < keySz || sizeS < keySz) {
++        return status;
++    }
++
++    /* initialize descriptor from template */
++    (void)caam_memcpy(descriptor, templateVerifyECC, sizeof(templateVerifyECC));
++
++    /* add descriptor lenght in bytes to HEADER descriptor command */
++    DESC_HEADER_ADD_DESCLEN(descriptor[0], descriptorSize);
++
++    DESC_SET_ADDR(descriptor[1], (CAAM_ECDSA_PD | keyType));
++    DESC_SET_ADDR(descriptor[2], p);
++    DESC_SET_ADDR(descriptor[3], hash);
++    DESC_SET_ADDR(descriptor[4], r);
++    DESC_SET_ADDR(descriptor[5], s);
++    DESC_SET_ADDR(descriptor[6], tmp);
++    DESC_ADD_LEN(descriptor[7], sizeHash);
++
++    /* schedule the job */
++    status = caam_in_job_ring_add(base, handle->jobRing, &descriptor[0]);
++    if (status == kStatus_Success) {
++        status = CAAM_Wait(base, handle, descriptor, kCAAM_Blocking);
++    }
++    return status;
++}
++
++
++/*!
++ * brief generate ECC shared secret.
++ *
++ * This function creates an ECC shared secret.
++ *
++ * param base CAAM peripheral base address
++ * param[in] k private key
++ * param[in] sizeK holds size of input k in bytes.
++ * param[in] pub contains the public key (x,y)
++ * param[in] sizePub is the size of 'pub' in bytes.
++ * param[out] out output buffer to hold shared secret
++ * param[in] sizeOut size of out buffer
++ * param keyType type of ECC key i.e P256 / P384
++ * param enc option to use black key
++ * return Operation status.
++ */
++status_t CAAM_ECC_ECDH(CAAM_Type *base,
++                                      caam_handle_t *handle,
++                                      const uint8_t *k,
++                                      size_t sizeK,
++                                      const uint8_t *pub,
++                                      size_t sizePub,
++                                      uint8_t *out,
++                                      size_t sizeOut,
++                                      int keyType,
++                                      uint32_t enc)
++{
++    size_t keySz = 0;
++    caam_desc_pkha_ecc_t descriptor;
++    status_t status = kStatus_InvalidArgument;
++    uint32_t descriptorSize = ARRAY_SIZE(templateAgreeECC);
++    BUILD_ASSURE(sizeof(caam_desc_pkha_ecc_t) >= sizeof(templateAgreeECC), caam_desc_pkha_ecc_t_size_too_low);
++
++    /* check if known type of key encryption */
++    if (enc != 0 && enc != CAAM_PKHA_ENC_PRI_AESECB) {
++        return status;
++    }
++
++    /* check is supported key type */
++    keySz = CheckSupportedKeyType(keyType);
++    if (keySz == 0 || sizeK > keySz || sizeOut != keySz) {
++        return status;
++    }
++
++    /* initialize descriptor from template */
++    (void)caam_memcpy(descriptor, templateAgreeECC, sizeof(templateAgreeECC));
++
++    /* add descriptor lenght in bytes to HEADER descriptor command */
++    DESC_HEADER_ADD_DESCLEN(descriptor[0], descriptorSize);
++
++    DESC_SET_ADDR(descriptor[1], (CAAM_ECDSA_KEYGEN_PD | keyType));
++    DESC_SET_ADDR(descriptor[2], pub);
++    DESC_SET_ADDR(descriptor[3], k);
++    DESC_SET_ADDR(descriptor[4], out);
++
++    /* add in if is encrypted */
++    descriptor[5] |= enc;
++
++    /* schedule the job */
++    status = caam_in_job_ring_add(base, handle->jobRing, &descriptor[0]);
++    if (status == kStatus_Success) {
++        status = CAAM_Wait(base, handle, descriptor, kCAAM_Blocking);
++    }
++
++#if defined(CAAM_OUT_INVALIDATE) && (CAAM_OUT_INVALIDATE > 0u)
++    /* NOTE: DCACHE must be set to write-trough mode to safely invalidate cache!! */
++    /* Invalidate unaligned data can cause memory corruption in write-back mode   */
++    DCACHE_InvalidateByRange((uint32_t)out, sizeOut);
++#endif /* CAAM_OUT_INVALIDATE */
++    return status;
++}
++
++
++/* Handle BLOB create and open */
++static const uint32_t templateBlob[] = {
++    /* 00 */ 0xB0800000u,  /* HEADER */
++    /* 01 */ 0x14400000u,  /* class */
++    /* 02 */ 0x00000000u,  /* key mod */
++    /* 03 */ 0xF0000000u,  /* SEQ input size */
++    /* 04 */ 0x00000000u,  /* input */
++    /* 05 */ 0xF8000000u,  /* SEQ output size */
++    /* 06 */ 0x00000000u,  /* output */
++    /* 07 */ 0x800D0000u,  /* Operation */
++};
++
++
++/*!
++ * brief generate ECC Keypair.
++ *
++ * This function generates ECC private/public key pair.
++ *
++ * param base CAAM peripheral base address
++ * param[out] k private key
++ * param[in,out] sizeK pointer to size variable. On input it holds size of input k in bytes. On output it holds size of
++ *                of generated private key k in bytes.
++ * param[out] p public key
++ * param[in,out] sizeP pointer to size variable. On input it holds size of input p in bytes. On output it holds size of
++ *                of generated public key p in bytes.
++ * param keyType type of ECC key, i.e P256 / P384
++ * param enc option to create black key
++ * return Operation status.
++ */
++status_t CAAM_Blob(CAAM_Type *base,
++                                      caam_handle_t *handle,
++                                      uint8_t *in,
++                                      size_t sizeIn,
++                                      uint8_t *out,
++                                      size_t sizeOut,
++                                      uint8_t *keyMod,
++                                      size_t keyModSz,
++                                      uint32_t dir,
++                                      uint32_t color)
++{
++    caam_desc_pkha_ecc_t descriptor;
++    status_t status = kStatus_InvalidArgument;
++    uint32_t descriptorSize = ARRAY_SIZE(templateBlob);
++    BUILD_ASSURE(sizeof(caam_desc_pkha_ecc_t) >= sizeof(templateBlob), caam_desc_pkha_ecc_t_size_too_low);
++
++    /* check if known type of key encryption */
++    if (color != CAAM_RED_BLOB && color != CAAM_BLACK_BLOB) {
++        return status;
++    }
++
++    if (dir != CAAM_ENCAP_BLOB && dir != CAAM_DECAP_BLOB) {
++        return status;
++    }
++
++    /* simple sanity check on output size to avoid invalidating more
++     * than wanted */
++    if (dir == CAAM_ENCAP_BLOB &&
++            (sizeOut > sizeIn + CAAM_PADDING_SIZE_BLOB)) {
++        return status;
++    }
++
++    if (dir == CAAM_DECAP_BLOB &&
++                (sizeOut > sizeIn - CAAM_PADDING_SIZE_BLOB)) {
++        return status;
++    }
++
++    /* initialize descriptor from template */
++    (void)caam_memcpy(descriptor, templateBlob, sizeof(templateBlob));
++
++    /* add descriptor lenght in bytes to HEADER descriptor command */
++    DESC_HEADER_ADD_DESCLEN(descriptor[0], descriptorSize);
++    descriptor[1] |= color; /* add color of blob */
++    DESC_SET_ADDR(descriptor[2], keyMod);
++    DESC_ADD_LEN(descriptor[3], sizeIn);
++    DESC_SET_ADDR(descriptor[4], in);
++    DESC_ADD_LEN(descriptor[5], sizeOut);
++    DESC_SET_ADDR(descriptor[6], out);
++    descriptor[7] |= dir; /* add in direction of blob (encap / decap) */
++
++    /* set black key flag */
++    if (color == CAAM_BLACK_BLOB) {
++        descriptor[7] |= 0x4; /* ECB black key */
++        /* additionally AES-CCM would have EXT (bit 8) hot */
++    }
++
++    /* schedule the job */
++    status = caam_in_job_ring_add(base, handle->jobRing, &descriptor[0]);
++    if (status == kStatus_Success) {
++        status = CAAM_Wait(base, handle, descriptor, kCAAM_Blocking);
++    }
++
++#if defined(CAAM_OUT_INVALIDATE) && (CAAM_OUT_INVALIDATE > 0u)
++    /* NOTE: DCACHE must be set to write-trough mode to safely invalidate cache!! */
++    /* Invalidate unaligned data can cause memory corruption in write-back mode   */
++    DCACHE_InvalidateByRange((uint32_t)out, sizeOut);
++#endif /* CAAM_OUT_INVALIDATE */
++    return status;
++}
++

--- a/IDE/MCUEXPRESSO/RT1170/fsl_caam_h.patch
+++ b/IDE/MCUEXPRESSO/RT1170/fsl_caam_h.patch
@@ -1,0 +1,165 @@
+--- fsl_caam-orig.h	2022-10-21 15:50:35.745560000 -0700
++++ fsl_caam.h	2022-12-28 08:10:29.413415216 -0800
+@@ -3038,6 +3038,162 @@
+  *@}
+  */ /* end of caam_driver_pkha */
+ 
++
++/* define for application to check for ECC CAAM additions */
++#define CAAM_ECC_EXPANSION
++#define CAAM_PKHA_ENC_PRI_AESECB 0x00000004
++#define CAAM_ECDSEL_SHIFT 7
++#define CAAM_ECDSA_P256 (0x02 << CAAM_ECDSEL_SHIFT)
++#define CAAM_ECDSA_P384 (0x03 << CAAM_ECDSEL_SHIFT)
++#define CAAM_ECDSA_P521 (0x04 << CAAM_ECDSEL_SHIFT)
++
++/*!
++ * brief generate ECC Keypair.
++ *
++ * This function generates ECC private/public key pair.
++ *
++ * param base CAAM peripheral base address
++ * param[out] k private key
++ * param[in,out] sizeK pointer to size variable. On input it holds size of input k in bytes. On output it holds size of
++ *                of generated private key k in bytes.
++ * param[out] p public key
++ * param[in,out] sizeP pointer to size variable. On input it holds size of input p in bytes. On output it holds size of
++ *                of generated public key p in bytes.
++ * param keyType type of ECC key, i.e P256 / P384
++ * param enc option to create black key
++ * return Operation status.
++ */
++status_t CAAM_ECC_Keygen(CAAM_Type *base,
++                                      caam_handle_t *handle,
++                                      uint8_t *k,
++                                      size_t *sizeK,
++                                      uint8_t *p,
++                                      size_t *sizeP,
++                                      int keyType,
++                                      uint32_t enc);
++
++/*!
++ * brief generate ECC signature.
++ *
++ * This function creates an ECC signature.
++ *
++ * param base CAAM peripheral base address
++ * param[in] k private key
++ * param[in] sizeK holds size of input k in bytes.
++ * param[in] hash contains the hash to sign
++ * param[in] sizeHash is the size of 'hash' in bytes.
++ * param[out] sig signature output
++ * param[in,out] sizeSig pointer to size variable. On input it holds size of input sig in bytes. On output it holds size of
++ *                of generated signature in bytes.
++ * param keyType type of ECC key i.e P256 / P384
++ * param enc option to use black key
++ * return Operation status.
++ */
++status_t CAAM_ECC_Sign(CAAM_Type *base,
++                                      caam_handle_t *handle,
++                                      const uint8_t *k,
++                                      size_t sizeK,
++                                      const uint8_t *hash,
++                                      size_t sizeHash,
++                                      uint8_t *r,
++                                      size_t sizeR,
++                                      uint8_t *s,
++                                      size_t sizeS,
++                                      int keyType,
++                                      uint32_t enc);
++
++/*!
++ * brief do an ECC verify.
++ *
++ * This function verifies an ECC signature.
++ *
++ * param base CAAM peripheral base address
++ * param[in] p public key
++ * param[in] sizeP pointer to size variable. On input it holds size of input k in bytes. On output it holds size of
++ *                of generated private key k in bytes.
++ * param[in] sig signature to verify
++ * param[in] sizeSig size of signature in bytes
++ * param[in] hash contains the hash to sign
++ * param[in] sizeHash is the size of 'hash' in bytes.
++ * param keyType type of ECC key i.e P256 / P384
++ * param enc option to use black key
++ * return Operation status.
++ */
++status_t CAAM_ECC_Verify(CAAM_Type *base,
++                                      caam_handle_t *handle,
++                                      const uint8_t *p,
++                                      size_t sizeP,
++                                      const uint8_t *r,
++                                      size_t sizeR,
++                                      const uint8_t *s,
++                                      size_t sizeS,
++                                      const uint8_t *hash,
++                                      size_t sizeHash,
++                                      int keyType);
++
++/*!
++ * brief generate ECC shared secret.
++ *
++ * This function creates an ECC shared secret.
++ *
++ * param base CAAM peripheral base address
++ * param[in] k private key
++ * param[in] sizeK holds size of input k in bytes.
++ * param[in] pub contains the public key (x,y)
++ * param[in] sizePub is the size of 'pub' in bytes.
++ * param[out] out output buffer to hold shared secret
++ * param[in] sizeOut size of out buffer
++ * param keyType type of ECC key i.e P256 / P384
++ * param enc option to use black key
++ * return Operation status.
++ */
++status_t CAAM_ECC_ECDH(CAAM_Type *base,
++                                      caam_handle_t *handle,
++                                      const uint8_t *k,
++                                      size_t sizeK,
++                                      const uint8_t *pub,
++                                      size_t sizePub,
++                                      uint8_t *out,
++                                      size_t sizeOut,
++                                      int keyType,
++                                      uint32_t enc);
++
++
++/* define for application to check for ECC CAAM additions */
++#define CAAM_BLOB_EXPANSION
++#define CAAM_RED_BLOB 0x00000C08
++#define CAAM_BLACK_BLOB 0x00000010
++#define CAAM_ENCAP_BLOB 0x07000000
++#define CAAM_DECAP_BLOB 0x06000000
++#define CAAM_PADDING_SIZE_BLOB 48
++
++/*!
++ * brief create or open a NXP blob.
++ *
++ * This function creates or opens a blob.
++ *
++ * param base CAAM peripheral base address
++ * param[in] in buffer to do operation on
++ * param[in] sizeIn holds size of input in in bytes.
++ * param[out] out buffer to hold the result of the operation
++ * param[in] sizeOut size in bytes of out buffer
++ * param[in] keyMod key that is used when creating or opening blob
++ * param[in] keyModSz size in bytes of keyMod
++ * param dir encap or decap of blob
++ * param color black or red blob type
++ * return Operation status.
++ */
++status_t CAAM_Blob(CAAM_Type *base,
++                                      caam_handle_t *handle,
++                                      uint8_t *in,
++                                      size_t sizeIn,
++                                      uint8_t *out,
++                                      size_t sizeOut,
++                                      uint8_t *keyMod,
++                                      size_t keyModSz,
++                                      uint32_t dir,
++                                      uint32_t color);
++
+ #if defined(__cplusplus)
+ }
+ #endif

--- a/IDE/MCUEXPRESSO/RT1170/user_settings.h
+++ b/IDE/MCUEXPRESSO/RT1170/user_settings.h
@@ -1,0 +1,90 @@
+#ifndef USER_SETTINGS_H
+#define USER_SETTINGS_H
+
+#define FREERTOS
+
+#define WOLFSSL_NO_REALLOC
+#define SINGLE_THREADED
+#define NO_FILESYSTEM
+#define WOLFSSL_LWIP
+#define HAVE_ECC
+
+#define WOLFSSL_SHA224
+#define WOLFSSL_SHA384
+#define WOLFSSL_SHA512
+
+#define WOLFSSL_AES_COUNTER
+#define OPENSSL_EXTRA
+#define WOLFSSL_NO_SOCK
+
+#define WOLFSSL_KEY_GEN
+#define WOLFSSL_CERT_GEN
+#define WOLFSSL_CERT_REQ
+#define WOLFSSL_CERT_EXT
+
+#define HAVE_PKCS7
+#ifdef HAVE_PKCS7
+    #define WOLFSSL_AES_DIRECT
+    #define HAVE_AES_KEYWRAP
+    #define HAVE_X963_KDF
+    #define HAVE_SMIME
+#endif
+
+#define WOLFCRYPT_ONLY
+#define USE_FAST_MATH
+
+/* harden options */
+#ifdef USE_FAST_MATH
+    #define TFM_TIMING_RESISTANT
+#endif
+#ifndef NO_RSA
+    #define WC_RSA_BLINDING
+#endif
+#ifdef HAVE_ECC
+    #define ECC_TIMING_RESISTANT
+#endif
+
+#define WOLFSSL_USE_ALIGN
+#define WOLFSSL_IMXRT1170_CAAM
+#define SIZEOF_LONG_LONG 8
+#define SIZEOF_LONG 4
+#define WOLF_CRYPTO_CB
+
+/* using the RTC */
+//#define NO_ASN_TIME
+#ifndef NO_ASN_TIME
+	#define FREESCALE_SNVS_RTC
+#endif
+
+#define NO_CRYPT_TEST
+#ifndef NO_CRYPT_TEST
+    #define NO_MAIN_DRIVER
+
+    #include <stdio.h>
+    #include <stdarg.h>
+    static void myPrintf(const char* fmt, ...)
+    {
+	    int ret;
+	    char line[150];
+	    va_list ap;
+
+	    va_start(ap, fmt);
+	    ret = vsnprintf(line, sizeof(line), fmt, ap);
+	    line[sizeof(line)-1] = '\0';
+
+	    DbgConsole_Printf("%s", line);
+
+	    /* add CR on newlines */
+	    if (ret > 0 && line[ret-1] == '\n') {
+	        DbgConsole_Printf("\r");
+        }
+    }
+    #define XPRINTF myPrintf
+    #define USE_CERT_BUFFERS_2048
+    #define USE_CERT_BUFFERS_1024
+    #define USE_CERT_BUFFERS_256
+    #define NO_WRITE_TEMP_FILES
+    #define BENCH_EMBEDDED
+#endif
+
+#endif /* USER_SETTINGS_H */

--- a/IDE/MCUEXPRESSO/RT1170/wolfcrypt_test_cm7/.cproject
+++ b/IDE/MCUEXPRESSO/RT1170/wolfcrypt_test_cm7/.cproject
@@ -1,0 +1,784 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="com.crt.advproject.config.exe.debug.592940767">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.debug.592940767" moduleId="org.eclipse.cdt.core.settings" name="Debug">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GNU_ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactExtension="axf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" cleanCommand="rm -rf" description="Debug build" errorParsers="org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.GASErrorParser" id="com.crt.advproject.config.exe.debug.592940767" name="Debug" parent="com.crt.advproject.config.exe.debug" postannouncebuildStep="Performing post-build steps" postbuildStep="arm-none-eabi-size &quot;${BuildArtifactFileName}&quot;; # arm-none-eabi-objcopy -v -O binary &quot;${BuildArtifactFileName}&quot; &quot;${BuildArtifactFileBaseName}.bin&quot; ; # checksum -p ${TargetChip} -d &quot;${BuildArtifactFileBaseName}.bin&quot;;  ">
+					<folderInfo id="com.crt.advproject.config.exe.debug.592940767." name="/" resourcePath="">
+						<toolChain id="com.crt.advproject.toolchain.exe.debug.1116314871" name="NXP MCU Tools" superClass="com.crt.advproject.toolchain.exe.debug">
+							<targetPlatform binaryParser="org.eclipse.cdt.core.ELF;org.eclipse.cdt.core.GNU_ELF" id="com.crt.advproject.platform.exe.debug.896361" name="ARM-based MCU (Debug)" superClass="com.crt.advproject.platform.exe.debug"/>
+							<builder buildPath="${workspace_loc:/wolfcrypt_test_cm7}/Debug" id="com.crt.advproject.builder.exe.debug.209618151" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="Gnu Make Builder" superClass="com.crt.advproject.builder.exe.debug"/>
+							<tool id="com.crt.advproject.cpp.exe.debug.2025515024" name="MCU C++ Compiler" superClass="com.crt.advproject.cpp.exe.debug">
+								<option id="com.crt.advproject.cpp.hdrlib.552440640" name="Library headers" superClass="com.crt.advproject.cpp.hdrlib" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.fpu.1998131864" name="Floating point" superClass="com.crt.advproject.cpp.fpu" useByScannerDiscovery="true" value="com.crt.advproject.cpp.fpu.fpv5sp.hard" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.preprocessor.def.1558952924" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.arch.733387696" name="Architecture" superClass="com.crt.advproject.cpp.arch" useByScannerDiscovery="true" value="com.crt.advproject.cpp.target.cm7" valueType="enumerated"/>
+								<option id="com.crt.advproject.cpp.misc.dialect.1188332944" name="Language standard" superClass="com.crt.advproject.cpp.misc.dialect" useByScannerDiscovery="true"/>
+								<option id="gnu.cpp.compiler.option.dialect.flags.60098929" name="Other dialect flags" superClass="gnu.cpp.compiler.option.dialect.flags" useByScannerDiscovery="true"/>
+								<option id="gnu.cpp.compiler.option.preprocessor.nostdinc.1618439787" name="Do not search system directories (-nostdinc)" superClass="gnu.cpp.compiler.option.preprocessor.nostdinc" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.preprocessor.preprocess.1253851702" name="Preprocess only (-E)" superClass="gnu.cpp.compiler.option.preprocessor.preprocess" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.preprocessor.undef.951428639" name="Undefined symbols (-U)" superClass="gnu.cpp.compiler.option.preprocessor.undef" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.include.paths.2130369136" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.include.files.1235461866" name="Include files (-include)" superClass="gnu.cpp.compiler.option.include.files" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.exe.debug.option.optimization.level.1740796970" name="Optimization Level" superClass="com.crt.advproject.cpp.exe.debug.option.optimization.level" useByScannerDiscovery="true"/>
+								<option id="gnu.cpp.compiler.option.optimization.flags.342133511" name="Other optimization flags" superClass="gnu.cpp.compiler.option.optimization.flags" useByScannerDiscovery="false" value="-fno-common" valueType="string"/>
+								<option id="com.crt.advproject.cpp.exe.debug.option.debugging.level.270753064" name="Debug Level" superClass="com.crt.advproject.cpp.exe.debug.option.debugging.level" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.other.509294129" name="Other debugging flags" superClass="gnu.cpp.compiler.option.debugging.other" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.prof.1844872024" name="Generate prof information (-p)" superClass="gnu.cpp.compiler.option.debugging.prof" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.gprof.311997386" name="Generate gprof information (-pg)" superClass="gnu.cpp.compiler.option.debugging.gprof" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.codecov.471281162" name="Generate gcov information (-ftest-coverage -fprofile-arcs)" superClass="gnu.cpp.compiler.option.debugging.codecov" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.sanitaddress.969114271" name="Sanitize address (-fsanitize=address)" superClass="gnu.cpp.compiler.option.debugging.sanitaddress" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.sanitpointers.1246058259" name="Sanitize pointer operations (-fsanitize=pointer-compare -fsanitize=pointer-subtract)" superClass="gnu.cpp.compiler.option.debugging.sanitpointers" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.sanitthread.15998176" name="Sanitize data race in multi-thread (-fsanitize=thread)" superClass="gnu.cpp.compiler.option.debugging.sanitthread" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.sanitleak.119060320" name="Sanitize memory leak (-fsanitize=leak)" superClass="gnu.cpp.compiler.option.debugging.sanitleak" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.sanitundef.2087287524" name="Sanitize undefined behavior (-fsanitize=undefined)" superClass="gnu.cpp.compiler.option.debugging.sanitundef" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.syntax.1104078297" name="Check syntax only (-fsyntax-only)" superClass="gnu.cpp.compiler.option.warnings.syntax" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.pedantic.550299946" name="Pedantic (-pedantic)" superClass="gnu.cpp.compiler.option.warnings.pedantic" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.pedantic.error.1802958673" name="Pedantic warnings as errors (-pedantic-errors)" superClass="gnu.cpp.compiler.option.warnings.pedantic.error" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.nowarn.970237207" name="Inhibit all warnings (-w)" superClass="gnu.cpp.compiler.option.warnings.nowarn" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.allwarn.2117446955" name="All warnings (-Wall)" superClass="gnu.cpp.compiler.option.warnings.allwarn" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.extrawarn.1089016331" name="Extra warnings (-Wextra)" superClass="gnu.cpp.compiler.option.warnings.extrawarn" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.toerrors.68675542" name="Warnings as errors (-Werror)" superClass="gnu.cpp.compiler.option.warnings.toerrors" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wconversion.1694929778" name="Implicit conversion warnings (-Wconversion)" superClass="gnu.cpp.compiler.option.warnings.wconversion" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wcastalign.578098009" name="Pointer cast with different alignment (-Wcast-align)" superClass="gnu.cpp.compiler.option.warnings.wcastalign" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wcastqual.998676886" name="Removing type qualifier from cast target type (-Wcast-qual)" superClass="gnu.cpp.compiler.option.warnings.wcastqual" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wctordtorprivacy.303002438" name="All ctor and dtor private (-Wctor-dtor-privacy)" superClass="gnu.cpp.compiler.option.warnings.wctordtorprivacy" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wdisabledopt.1127683931" name="Requested optimization pass is disabled (-Wdisabled-optimization)" superClass="gnu.cpp.compiler.option.warnings.wdisabledopt" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wlogicalop.740253860" name="Suspicious uses of logical operators (-Wlogical-op)" superClass="gnu.cpp.compiler.option.warnings.wlogicalop" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wmissingdecl.391380854" name="Global function without previous declaration (-Wmissing-declarations)" superClass="gnu.cpp.compiler.option.warnings.wmissingdecl" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wmissingincdir.1438890948" name="User-supplied include directory does not exist (-Wmissing-include-dirs)" superClass="gnu.cpp.compiler.option.warnings.wmissingincdir" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wnoexccept.1355123158" name="Noexcept false but never throw exception (-Wnoexcept)" superClass="gnu.cpp.compiler.option.warnings.wnoexccept" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.woldstylecast.555573898" name="C-style cast used (-Wold-style-cast)" superClass="gnu.cpp.compiler.option.warnings.woldstylecast" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.woverloadedvirtual.621930482" name="Function hides virtual functions from base class (-Woverloaded-virtual)" superClass="gnu.cpp.compiler.option.warnings.woverloadedvirtual" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wredundantdecl.1713159173" name="More than one declaration in the same scope (-Wredundant-decls)" superClass="gnu.cpp.compiler.option.warnings.wredundantdecl" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wshadow.1879104488" name="Local symbol shadows upper scope symbol (-Wshadow)" superClass="gnu.cpp.compiler.option.warnings.wshadow" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wsignconv.381234207" name="Implicit conversions that may change the sign (-Wsign-conversion)" superClass="gnu.cpp.compiler.option.warnings.wsignconv" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wsignpromo.66144049" name="Overload resolution promotes unsigned to signed type (-Wsign-promo)" superClass="gnu.cpp.compiler.option.warnings.wsignpromo" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wstrictnullsent.1938641394" name="Use of an uncasted NULL as sentinel (-Wstrict-null-sentinel)" superClass="gnu.cpp.compiler.option.warnings.wstrictnullsent" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wswitchdef.1919317917" name="A switch statement does not have a default case (-Wswitch-default)" superClass="gnu.cpp.compiler.option.warnings.wswitchdef" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wundef.102984386" name="An undefined identifier is evaluated in an #if directive (-Wundef)" superClass="gnu.cpp.compiler.option.warnings.wundef" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.weffcpp.154014154" name="Effective C++ guidelines (-Weffc++)" superClass="gnu.cpp.compiler.option.warnings.weffcpp" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wfloatequal.659760562" name="Direct float equal check (-Wfloat-equal)" superClass="gnu.cpp.compiler.option.warnings.wfloatequal" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.other.other.1717243812" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.other.verbose.459188593" name="Verbose (-v)" superClass="gnu.cpp.compiler.option.other.verbose" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.other.pic.1169941255" name="Position Independent Code (-fPIC)" superClass="gnu.cpp.compiler.option.other.pic" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.misc.hardening.2097628040" name="Hardening options (-fstack-protector-all -Wformat=2 -Wformat-security -Wstrict-overflow)" superClass="gnu.cpp.compiler.option.misc.hardening" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.misc.randomization.291341545" name="Address randomization (-fPIE)" superClass="gnu.cpp.compiler.option.misc.randomization" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.lto.1419236168" name="Enable Link-time optimization (-flto)" superClass="com.crt.advproject.cpp.lto" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.lto.fat.2098496124" name="Fat lto objects (-ffat-lto-objects)" superClass="com.crt.advproject.cpp.lto.fat" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.merge.constants.110028254" name="Merge Identical Constants (-fmerge-constants)" superClass="com.crt.advproject.cpp.merge.constants" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.prefixmap.1824473869" name="Remove path from __FILE__ (-fmacro-prefix-map)" superClass="com.crt.advproject.cpp.prefixmap" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.thumb.1337177409" name="Thumb mode" superClass="com.crt.advproject.cpp.thumb" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.thumbinterwork.453691530" name="Enable Thumb interworking" superClass="com.crt.advproject.cpp.thumbinterwork" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.securestate.812279583" name="TrustZone Project Type" superClass="com.crt.advproject.cpp.securestate" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.stackusage.1025920949" name="Generate Stack Usage Info (-fstack-usage)" superClass="com.crt.advproject.cpp.stackusage" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.specs.1033392924" name="Specs" superClass="com.crt.advproject.cpp.specs" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.config.90857407" name="Obsolete (Config)" superClass="com.crt.advproject.cpp.config" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.store.1418957724" name="Obsolete (Store)" superClass="com.crt.advproject.cpp.store" useByScannerDiscovery="false"/>
+							</tool>
+							<tool id="com.crt.advproject.gcc.exe.debug.1589119815" name="MCU C Compiler" superClass="com.crt.advproject.gcc.exe.debug">
+								<option id="com.crt.advproject.gcc.hdrlib.1817186243" name="Library headers" superClass="com.crt.advproject.gcc.hdrlib" useByScannerDiscovery="false"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.821617417" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="__REDLIB__"/>
+									<listOptionValue builtIn="false" value="CRYPTO_USE_DRIVER_CAAM"/>
+									<listOptionValue builtIn="false" value="CACHE_MODE_WRITE_THROUGH=1"/>
+									<listOptionValue builtIn="false" value="WOLFSSL_USER_SETTINGS"/>
+									<listOptionValue builtIn="false" value="CPU_MIMXRT1176DVMAA"/>
+									<listOptionValue builtIn="false" value="CPU_MIMXRT1176DVMAA_cm7"/>
+									<listOptionValue builtIn="false" value="SDK_OS_BAREMETAL"/>
+									<listOptionValue builtIn="false" value="XIP_EXTERNAL_FLASH=1"/>
+									<listOptionValue builtIn="false" value="XIP_BOOT_HEADER_ENABLE=1"/>
+									<listOptionValue builtIn="false" value="SERIAL_PORT_TYPE_UART=1"/>
+									<listOptionValue builtIn="false" value="XIP_BOOT_HEADER_DCD_ENABLE=0"/>
+									<listOptionValue builtIn="false" value="XIP_BOOT_HEADER_XMCD_ENABLE=1"/>
+									<listOptionValue builtIn="false" value="SDK_DEBUGCONSOLE=1"/>
+									<listOptionValue builtIn="false" value="CR_INTEGER_PRINTF"/>
+									<listOptionValue builtIn="false" value="PRINTF_FLOAT_ENABLE=0"/>
+									<listOptionValue builtIn="false" value="SDK_OS_FREE_RTOS"/>
+									<listOptionValue builtIn="false" value="__MCUXPRESSO"/>
+									<listOptionValue builtIn="false" value="__USE_CMSIS"/>
+									<listOptionValue builtIn="false" value="DEBUG"/>
+								</option>
+								<option id="com.crt.advproject.gcc.fpu.1429294159" name="Floating point" superClass="com.crt.advproject.gcc.fpu" useByScannerDiscovery="true" value="com.crt.advproject.gcc.fpu.fpv5sp.hard" valueType="enumerated"/>
+								<option id="com.crt.advproject.gcc.thumb.1512583948" name="Thumb mode" superClass="com.crt.advproject.gcc.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.gcc.arch.927644352" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="true" value="com.crt.advproject.gcc.target.cm7" valueType="enumerated"/>
+								<option id="com.crt.advproject.c.misc.dialect.1849209338" name="Language standard" superClass="com.crt.advproject.c.misc.dialect" useByScannerDiscovery="true"/>
+								<option id="gnu.c.compiler.option.dialect.flags.1152620620" name="Other dialect flags" superClass="gnu.c.compiler.option.dialect.flags" useByScannerDiscovery="true"/>
+								<option id="gnu.c.compiler.option.preprocessor.nostdinc.1013981181" name="Do not search system directories (-nostdinc)" superClass="gnu.c.compiler.option.preprocessor.nostdinc" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.preprocessor.preprocess.324178068" name="Preprocess only (-E)" superClass="gnu.c.compiler.option.preprocessor.preprocess" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.preprocessor.undef.symbol.1998361477" name="Undefined symbols (-U)" superClass="gnu.c.compiler.option.preprocessor.undef.symbol" useByScannerDiscovery="false"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.2710953" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/portable/GCC/ARM_CM4F}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/xip}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/startup}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/portable/GCC/ARM_CM4F}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/xip}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/startup}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc}/&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc}/../../../&quot;"/>
+								</option>
+								<option id="gnu.c.compiler.option.include.files.324922763" name="Include files (-include)" superClass="gnu.c.compiler.option.include.files" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.exe.debug.option.optimization.level.1754888504" name="Optimization Level" superClass="com.crt.advproject.gcc.exe.debug.option.optimization.level" useByScannerDiscovery="true"/>
+								<option id="gnu.c.compiler.option.optimization.flags.1716151220" name="Other optimization flags" superClass="gnu.c.compiler.option.optimization.flags" useByScannerDiscovery="false" value="-fno-common" valueType="string"/>
+								<option id="com.crt.advproject.gcc.exe.debug.option.debugging.level.594934719" name="Debug Level" superClass="com.crt.advproject.gcc.exe.debug.option.debugging.level" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.other.1916261785" name="Other debugging flags" superClass="gnu.c.compiler.option.debugging.other" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.prof.987707101" name="Generate prof information (-p)" superClass="gnu.c.compiler.option.debugging.prof" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.gprof.354936739" name="Generate gprof information (-pg)" superClass="gnu.c.compiler.option.debugging.gprof" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.codecov.1257673335" name="Generate gcov information (-ftest-coverage -fprofile-arcs)" superClass="gnu.c.compiler.option.debugging.codecov" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.sanitaddress.853643904" name="Sanitize address (-fsanitize=address)" superClass="gnu.c.compiler.option.debugging.sanitaddress" useByScannerDiscovery="false" value="false" valueType="boolean"/>
+								<option id="gnu.c.compiler.option.debugging.sanitpointers.1917822180" name="Sanitize pointer operations (-fsanitize=pointer-compare -fsanitize=pointer-subtract)" superClass="gnu.c.compiler.option.debugging.sanitpointers" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.sanitthread.2040763043" name="Sanitize data race in multi-thread (-fsanitize=thread)" superClass="gnu.c.compiler.option.debugging.sanitthread" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.sanitleak.1533286294" name="Sanitize memory leak (-fsanitize=leak)" superClass="gnu.c.compiler.option.debugging.sanitleak" useByScannerDiscovery="false" value="false" valueType="boolean"/>
+								<option id="gnu.c.compiler.option.debugging.sanitundef.542435984" name="Sanitize undefined behavior (-fsanitize=undefined)" superClass="gnu.c.compiler.option.debugging.sanitundef" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.syntax.882925946" name="Check syntax only (-fsyntax-only)" superClass="gnu.c.compiler.option.warnings.syntax" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.pedantic.795828728" name="Pedantic (-pedantic)" superClass="gnu.c.compiler.option.warnings.pedantic" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.pedantic.error.233555180" name="Pedantic warnings as errors (-pedantic-errors)" superClass="gnu.c.compiler.option.warnings.pedantic.error" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.nowarn.1158525395" name="Inhibit all warnings (-w)" superClass="gnu.c.compiler.option.warnings.nowarn" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.allwarn.145549853" name="All warnings (-Wall)" superClass="gnu.c.compiler.option.warnings.allwarn" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.extrawarn.1276510928" name="Extra warnings (-Wextra)" superClass="gnu.c.compiler.option.warnings.extrawarn" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.c.compiler.option.warnings.toerrors.1764706250" name="Warnings as errors (-Werror)" superClass="gnu.c.compiler.option.warnings.toerrors" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wconversion.2111153414" name="Implicit conversion warnings (-Wconversion)" superClass="gnu.c.compiler.option.warnings.wconversion" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.c.compiler.option.warnings.wcastalign.1220489714" name="Pointer cast with different alignment (-Wcast-align)" superClass="gnu.c.compiler.option.warnings.wcastalign" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.c.compiler.option.warnings.wcastqual.981601732" name="Removing type qualifier from cast target type (-Wcast-qual)" superClass="gnu.c.compiler.option.warnings.wcastqual" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wdisabledopt.1985229606" name="Requested optimization pass is disabled (-Wdisabled-optimization)" superClass="gnu.c.compiler.option.warnings.wdisabledopt" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wlogicalop.834955272" name="Suspicious uses of logical operators (-Wlogical-op)" superClass="gnu.c.compiler.option.warnings.wlogicalop" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wmissingdecl.1529294437" name="Global function without previous declaration (-Wmissing-declarations)" superClass="gnu.c.compiler.option.warnings.wmissingdecl" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wmissingincdir.751208509" name="User-supplied include directory does not exist (-Wmissing-include-dirs)" superClass="gnu.c.compiler.option.warnings.wmissingincdir" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wredundantdecl.2140214330" name="More than one declaration in the same scope (-Wredundant-decls)" superClass="gnu.c.compiler.option.warnings.wredundantdecl" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wshadow.975679026" name="Local symbol shadows upper scope symbol (-Wshadow)" superClass="gnu.c.compiler.option.warnings.wshadow" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wsignconv.814656054" name="Implicit conversions that may change the sign (-Wsign-conversion)" superClass="gnu.c.compiler.option.warnings.wsignconv" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wswitchdef.290163542" name="A switch statement does not have a default case (-Wswitch-default)" superClass="gnu.c.compiler.option.warnings.wswitchdef" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wundef.886515866" name="An undefined identifier is evaluated in an #if directive (-Wundef)" superClass="gnu.c.compiler.option.warnings.wundef" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wwritestrings.2129469496" name="Treat strings always as const (-Wwrite-strings)" superClass="gnu.c.compiler.option.warnings.wwritestrings" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wfloatequal.256149809" name="Direct float equal check (-Wfloat-equal)" superClass="gnu.c.compiler.option.warnings.wfloatequal" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.misc.other.1097848913" name="Other flags" superClass="gnu.c.compiler.option.misc.other" useByScannerDiscovery="false" value="-c -ffunction-sections -fdata-sections -ffreestanding -fno-builtin" valueType="string"/>
+								<option id="gnu.c.compiler.option.misc.verbose.1422155505" name="Verbose (-v)" superClass="gnu.c.compiler.option.misc.verbose" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.misc.ansi.777123365" name="Support ANSI programs (-ansi)" superClass="gnu.c.compiler.option.misc.ansi" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.misc.pic.1915230266" name="Position Independent Code (-fPIC)" superClass="gnu.c.compiler.option.misc.pic" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.misc.hardening.2125564880" name="Hardening options (-fstack-protector-all -Wformat=2 -Wformat-security -Wstrict-overflow)" superClass="gnu.c.compiler.option.misc.hardening" useByScannerDiscovery="false" value="false" valueType="boolean"/>
+								<option id="gnu.c.compiler.option.misc.randomization.208519829" name="Address randomization (-fPIE)" superClass="gnu.c.compiler.option.misc.randomization" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.lto.460806909" name="Enable Link-time optimization (-flto)" superClass="com.crt.advproject.gcc.lto" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.lto.fat.1186465760" name="Fat lto objects (-ffat-lto-objects)" superClass="com.crt.advproject.gcc.lto.fat" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.merge.constants.519387887" name="Merge Identical Constants (-fmerge-constants)" superClass="com.crt.advproject.gcc.merge.constants" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.prefixmap.636802338" name="Remove path from __FILE__ (-fmacro-prefix-map)" superClass="com.crt.advproject.gcc.prefixmap" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.thumbinterwork.1044216481" name="Enable Thumb interworking" superClass="com.crt.advproject.gcc.thumbinterwork" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.securestate.1398006667" name="TrustZone Project Type" superClass="com.crt.advproject.gcc.securestate" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.stackusage.1416047635" name="Generate Stack Usage Info (-fstack-usage)" superClass="com.crt.advproject.gcc.stackusage" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.specs.1248598339" name="Specs" superClass="com.crt.advproject.gcc.specs" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.config.1088714055" name="Obsolete (Config)" superClass="com.crt.advproject.gcc.config" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.store.1751985505" name="Obsolete (Store)" superClass="com.crt.advproject.gcc.store" useByScannerDiscovery="false"/>
+								<inputType id="com.crt.advproject.compiler.input.1138321445" superClass="com.crt.advproject.compiler.input"/>
+							</tool>
+							<tool id="com.crt.advproject.gas.exe.debug.1368940667" name="MCU Assembler" superClass="com.crt.advproject.gas.exe.debug">
+								<option id="com.crt.advproject.gas.hdrlib.781408079" name="Library headers" superClass="com.crt.advproject.gas.hdrlib"/>
+								<option id="com.crt.advproject.gas.fpu.569784574" name="Floating point" superClass="com.crt.advproject.gas.fpu" value="com.crt.advproject.gas.fpu.fpv5sp.hard" valueType="enumerated"/>
+								<option id="com.crt.advproject.gas.thumb.7258901" name="Thumb mode" superClass="com.crt.advproject.gas.thumb" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.gas.arch.465828202" name="Architecture" superClass="com.crt.advproject.gas.arch" value="com.crt.advproject.gas.target.cm7" valueType="enumerated"/>
+								<option id="gnu.both.asm.option.flags.crt.1347984440" name="Assembler flags" superClass="gnu.both.asm.option.flags.crt" value="-c -x assembler-with-cpp -D__REDLIB__" valueType="string"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.both.asm.option.include.paths.2069167740" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
+								</option>
+								<option id="gnu.both.asm.option.warnings.nowarn.1389673236" name="Suppress warnings (-W)" superClass="gnu.both.asm.option.warnings.nowarn"/>
+								<option id="gnu.both.asm.option.version.1102709392" name="Announce version (-v)" superClass="gnu.both.asm.option.version"/>
+								<option id="com.crt.advproject.gas.exe.debug.option.debugging.level.670066706" name="Debug level" superClass="com.crt.advproject.gas.exe.debug.option.debugging.level"/>
+								<option id="com.crt.advproject.gas.thumbinterwork.1069131776" name="Enable Thumb interworking" superClass="com.crt.advproject.gas.thumbinterwork"/>
+								<option id="com.crt.advproject.gas.specs.482962383" name="Specs" superClass="com.crt.advproject.gas.specs"/>
+								<option id="com.crt.advproject.gas.config.446951185" name="Obsolete (Config)" superClass="com.crt.advproject.gas.config"/>
+								<option id="com.crt.advproject.gas.store.1137142632" name="Obsolete (Store)" superClass="com.crt.advproject.gas.store"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.1325357723" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+								<inputType id="com.crt.advproject.assembler.input.2037915685" name="Additional Assembly Source Files" superClass="com.crt.advproject.assembler.input"/>
+							</tool>
+							<tool id="com.crt.advproject.link.cpp.exe.debug.1938197978" name="MCU C++ Linker" superClass="com.crt.advproject.link.cpp.exe.debug">
+								<option id="com.crt.advproject.link.cpp.hdrlib.1685720102" name="Library" superClass="com.crt.advproject.link.cpp.hdrlib"/>
+								<option id="com.crt.advproject.link.cpp.fpu.1076032018" name="Floating point" superClass="com.crt.advproject.link.cpp.fpu" value="com.crt.advproject.link.cpp.fpu.fpv5sp.hard" valueType="enumerated"/>
+								<option id="com.crt.advproject.link.cpp.arch.1658506588" name="Architecture" superClass="com.crt.advproject.link.cpp.arch" value="com.crt.advproject.link.cpp.target.cm7" valueType="enumerated"/>
+								<option id="com.crt.advproject.link.cpp.multicore.slave.838545189" name="Multicore configuration" superClass="com.crt.advproject.link.cpp.multicore.slave"/>
+								<option id="gnu.cpp.link.option.nostart.1224059604" name="Do not use standard start files (-nostartfiles)" superClass="gnu.cpp.link.option.nostart"/>
+								<option id="gnu.cpp.link.option.nodeflibs.144307743" name="Do not use default libraries (-nodefaultlibs)" superClass="gnu.cpp.link.option.nodeflibs"/>
+								<option id="gnu.cpp.link.option.nostdlibs.1597324345" name="No startup or default libs (-nostdlib)" superClass="gnu.cpp.link.option.nostdlibs" value="true" valueType="boolean"/>
+								<option id="gnu.cpp.link.option.strip.793103083" name="Omit all symbol information (-s)" superClass="gnu.cpp.link.option.strip"/>
+								<option id="gnu.cpp.link.option.libs.1121093850" name="Libraries (-l)" superClass="gnu.cpp.link.option.libs"/>
+								<option id="gnu.cpp.link.option.paths.1025292173" name="Library search path (-L)" superClass="gnu.cpp.link.option.paths"/>
+								<option id="gnu.cpp.link.option.flags.602774112" name="Linker flags" superClass="gnu.cpp.link.option.flags"/>
+								<option id="gnu.cpp.link.option.other.992530672" name="Other options (-Xlinker [option])" superClass="gnu.cpp.link.option.other"/>
+								<option id="gnu.cpp.link.option.userobjs.652007182" name="Other objects" superClass="gnu.cpp.link.option.userobjs"/>
+								<option id="gnu.cpp.link.option.shared.1505123716" name="Shared (-shared)" superClass="gnu.cpp.link.option.shared"/>
+								<option id="gnu.cpp.link.option.soname.165197391" name="Shared object name (-Wl,-soname=)" superClass="gnu.cpp.link.option.soname"/>
+								<option id="gnu.cpp.link.option.implname.287025673" name="Import Library name (-Wl,--out-implib=)" superClass="gnu.cpp.link.option.implname"/>
+								<option id="gnu.cpp.link.option.defname.936070851" name="DEF file name (-Wl,--output-def=)" superClass="gnu.cpp.link.option.defname"/>
+								<option id="gnu.cpp.link.option.debugging.prof.790451973" name="Generate prof information (-p)" superClass="gnu.cpp.link.option.debugging.prof"/>
+								<option id="gnu.cpp.link.option.debugging.gprof.1978302882" name="Generate gprof information (-pg)" superClass="gnu.cpp.link.option.debugging.gprof"/>
+								<option id="gnu.cpp.link.option.debugging.codecov.1382936177" name="Generate gcov information (-ftest-coverage -fprofile-arcs)" superClass="gnu.cpp.link.option.debugging.codecov"/>
+								<option id="com.crt.advproject.link.cpp.lto.249983713" name="Enable Link-time optimization (-flto)" superClass="com.crt.advproject.link.cpp.lto"/>
+								<option id="com.crt.advproject.link.cpp.lto.optmization.level.1471637940" name="Link-time optimization level" superClass="com.crt.advproject.link.cpp.lto.optmization.level"/>
+								<option id="com.crt.advproject.link.cpp.thumb.1785265129" name="Thumb mode" superClass="com.crt.advproject.link.cpp.thumb"/>
+								<option id="com.crt.advproject.link.cpp.manage.1555100689" name="Manage linker script" superClass="com.crt.advproject.link.cpp.manage"/>
+								<option id="com.crt.advproject.link.cpp.script.1487962953" name="Linker script" superClass="com.crt.advproject.link.cpp.script"/>
+								<option id="com.crt.advproject.link.cpp.scriptdir.423945143" name="Script path" superClass="com.crt.advproject.link.cpp.scriptdir"/>
+								<option id="com.crt.advproject.link.cpp.crpenable.368887664" name="Enable automatic placement of Code Read Protection field in image" superClass="com.crt.advproject.link.cpp.crpenable"/>
+								<option id="com.crt.advproject.link.cpp.flashconfigenable.320147616" name="Enable automatic placement of Flash Configuration field in image" superClass="com.crt.advproject.link.cpp.flashconfigenable" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.link.cpp.ecrp.1284686481" name="Enhanced CRP" superClass="com.crt.advproject.link.cpp.ecrp"/>
+								<option id="com.crt.advproject.link.cpp.nanofloat.95488066" name="Enable printf float " superClass="com.crt.advproject.link.cpp.nanofloat"/>
+								<option id="com.crt.advproject.link.cpp.nanofloat.scanf.1155602689" name="Enable scanf float " superClass="com.crt.advproject.link.cpp.nanofloat.scanf"/>
+								<option id="com.crt.advproject.link.cpp.toram.144563699" name="Link application to RAM" superClass="com.crt.advproject.link.cpp.toram"/>
+								<option id="com.crt.advproject.link.memory.load.image.cpp.1040587190" name="Plain load image" superClass="com.crt.advproject.link.memory.load.image.cpp"/>
+								<option id="com.crt.advproject.link.memory.heapAndStack.style.cpp.1662568957" name="Heap and Stack placement" superClass="com.crt.advproject.link.memory.heapAndStack.style.cpp"/>
+								<option id="com.crt.advproject.link.cpp.stackOffset.1907310477" name="Stack offset" superClass="com.crt.advproject.link.cpp.stackOffset"/>
+								<option id="com.crt.advproject.link.memory.heapAndStack.cpp.1693830087" name="Heap and Stack options" superClass="com.crt.advproject.link.memory.heapAndStack.cpp"/>
+								<option id="com.crt.advproject.link.memory.data.cpp.163974485" name="Global data placement" superClass="com.crt.advproject.link.memory.data.cpp"/>
+								<option id="com.crt.advproject.link.memory.sections.cpp.1347026831" name="Extra linker script input sections" superClass="com.crt.advproject.link.memory.sections.cpp"/>
+								<option id="com.crt.advproject.link.cpp.multicore.master.1659926426" name="Multicore master" superClass="com.crt.advproject.link.cpp.multicore.master"/>
+								<option id="com.crt.advproject.link.cpp.multicore.empty.1464841905" name="No Multicore options for this project" superClass="com.crt.advproject.link.cpp.multicore.empty"/>
+								<option id="com.crt.advproject.link.cpp.multicore.master.userobjs.1260807173" name="Slave Objects (not visible)" superClass="com.crt.advproject.link.cpp.multicore.master.userobjs"/>
+								<option id="com.crt.advproject.link.cpp.config.1178890565" name="Obsolete (Config)" superClass="com.crt.advproject.link.cpp.config"/>
+								<option id="com.crt.advproject.link.cpp.store.844724751" name="Obsolete (Store)" superClass="com.crt.advproject.link.cpp.store"/>
+								<option id="com.crt.advproject.link.cpp.securestate.2000901640" name="TrustZone Project Type" superClass="com.crt.advproject.link.cpp.securestate"/>
+								<option id="com.crt.advproject.link.cpp.sgstubs.placement.1240898909" name="Secure Gateway Placement" superClass="com.crt.advproject.link.cpp.sgstubs.placement"/>
+								<option id="com.crt.advproject.link.cpp.sgstubenable.977322364" name="Enable generation of Secure Gateway Import Library" superClass="com.crt.advproject.link.cpp.sgstubenable"/>
+								<option id="com.crt.advproject.link.cpp.nonsecureobject.1457255133" name="Secure Gateway Import Library" superClass="com.crt.advproject.link.cpp.nonsecureobject"/>
+								<option id="com.crt.advproject.link.cpp.inimplib.1961311825" name="Input Secure Gateway Import Library" superClass="com.crt.advproject.link.cpp.inimplib"/>
+							</tool>
+							<tool id="com.crt.advproject.link.exe.debug.1641528280" name="MCU Linker" superClass="com.crt.advproject.link.exe.debug">
+								<option id="com.crt.advproject.link.gcc.hdrlib.1134231796" name="Library" superClass="com.crt.advproject.link.gcc.hdrlib" value="com.crt.advproject.gcc.link.hdrlib.codered.nohost_nf" valueType="enumerated"/>
+								<option id="com.crt.advproject.link.fpu.1159476183" name="Floating point" superClass="com.crt.advproject.link.fpu" value="com.crt.advproject.link.fpu.fpv5sp.hard" valueType="enumerated"/>
+								<option id="com.crt.advproject.link.thumb.1076923700" name="Thumb mode" superClass="com.crt.advproject.link.thumb" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.link.memory.load.image.494299726" name="Plain load image" superClass="com.crt.advproject.link.memory.load.image" useByScannerDiscovery="false" value="false;" valueType="string"/>
+								<option defaultValue="com.crt.advproject.heapAndStack.mcuXpressoStyle" id="com.crt.advproject.link.memory.heapAndStack.style.21699413" name="Heap and Stack placement" superClass="com.crt.advproject.link.memory.heapAndStack.style" useByScannerDiscovery="false" valueType="enumerated"/>
+								<option id="com.crt.advproject.link.memory.heapAndStack.1165469341" name="Heap and Stack options" superClass="com.crt.advproject.link.memory.heapAndStack" useByScannerDiscovery="false" value="&amp;Heap:SRAM_OC1;Post Data;0x1d4c0&amp;Stack:SRAM_OC2;End;0x1d4c0" valueType="string"/>
+								<option id="com.crt.advproject.link.memory.data.585848575" name="Global data placement" superClass="com.crt.advproject.link.memory.data" useByScannerDiscovery="false" value="Default" valueType="string"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.crt.advproject.link.memory.sections.1717508037" name="Extra linker script input sections" superClass="com.crt.advproject.link.memory.sections" useByScannerDiscovery="false" valueType="stringList"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.crt.advproject.link.gcc.multicore.master.userobjs.26488820" name="Slave Objects (not visible)" superClass="com.crt.advproject.link.gcc.multicore.master.userobjs" useByScannerDiscovery="false" valueType="userObjs"/>
+								<option id="com.crt.advproject.link.gcc.multicore.slave.1299895005" name="Multicore configuration" superClass="com.crt.advproject.link.gcc.multicore.slave"/>
+								<option id="com.crt.advproject.link.arch.302195885" name="Architecture" superClass="com.crt.advproject.link.arch" value="com.crt.advproject.link.target.cm7" valueType="enumerated"/>
+								<option id="gnu.c.link.option.nostart.145758227" name="Do not use standard start files (-nostartfiles)" superClass="gnu.c.link.option.nostart"/>
+								<option id="gnu.c.link.option.nodeflibs.2010771596" name="Do not use default libraries (-nodefaultlibs)" superClass="gnu.c.link.option.nodeflibs"/>
+								<option id="gnu.c.link.option.nostdlibs.1524142635" name="No startup or default libs (-nostdlib)" superClass="gnu.c.link.option.nostdlibs" value="true" valueType="boolean"/>
+								<option id="gnu.c.link.option.strip.1701430410" name="Omit all symbol information (-s)" superClass="gnu.c.link.option.strip"/>
+								<option id="gnu.c.link.option.noshared.1656548622" name="No shared libraries (-static)" superClass="gnu.c.link.option.noshared"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.link.option.libs.1592322698" name="Libraries (-l)" superClass="gnu.c.link.option.libs" useByScannerDiscovery="false" valueType="libs">
+									<listOptionValue builtIn="false" value="wolfssl_cm7"/>
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.link.option.paths.1119424289" name="Library search path (-L)" superClass="gnu.c.link.option.paths" valueType="libPaths">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfssl_cm7/Debug}&quot;"/>
+								</option>
+								<option id="gnu.c.link.option.ldflags.2061279777" name="Linker flags" superClass="gnu.c.link.option.ldflags"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.link.option.other.1121537571" name="Other options (-Xlinker [option])" superClass="gnu.c.link.option.other" valueType="stringList">
+									<listOptionValue builtIn="false" value="-Map=&quot;${BuildArtifactFileBaseName}.map&quot;"/>
+									<listOptionValue builtIn="false" value="--gc-sections"/>
+									<listOptionValue builtIn="false" value="-print-memory-usage"/>
+									<listOptionValue builtIn="false" value="--sort-section=alignment"/>
+									<listOptionValue builtIn="false" value="--cref"/>
+								</option>
+								<option id="gnu.c.link.option.userobjs.2103680478" name="Other objects" superClass="gnu.c.link.option.userobjs"/>
+								<option id="gnu.c.link.option.shared.211578762" name="Shared (-shared)" superClass="gnu.c.link.option.shared"/>
+								<option id="gnu.c.link.option.soname.1327810829" name="Shared object name (-Wl,-soname=)" superClass="gnu.c.link.option.soname"/>
+								<option id="gnu.c.link.option.implname.46641608" name="Import Library name (-Wl,--out-implib=)" superClass="gnu.c.link.option.implname"/>
+								<option id="gnu.c.link.option.defname.879932538" name="DEF file name (-Wl,--output-def=)" superClass="gnu.c.link.option.defname"/>
+								<option id="gnu.c.link.option.debugging.prof.466869792" name="Generate prof information (-p)" superClass="gnu.c.link.option.debugging.prof"/>
+								<option id="gnu.c.link.option.debugging.gprof.378033584" name="Generate gprof information (-pg)" superClass="gnu.c.link.option.debugging.gprof"/>
+								<option id="gnu.c.link.option.debugging.codecov.752390178" name="Generate gcov information (-ftest-coverage -fprofile-arcs)" superClass="gnu.c.link.option.debugging.codecov"/>
+								<option id="com.crt.advproject.link.gcc.lto.1195006355" name="Enable Link-time optimization (-flto)" superClass="com.crt.advproject.link.gcc.lto"/>
+								<option id="com.crt.advproject.link.gcc.lto.optmization.level.1015906169" name="Link-time optimization level" superClass="com.crt.advproject.link.gcc.lto.optmization.level"/>
+								<option id="com.crt.advproject.link.manage.470366572" name="Manage linker script" superClass="com.crt.advproject.link.manage" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.link.script.1211168190" name="Linker script" superClass="com.crt.advproject.link.script" useByScannerDiscovery="false" value="wolfcrypt_test_cm7_Debug.ld" valueType="string"/>
+								<option id="com.crt.advproject.link.scriptdir.1870287400" name="Script path" superClass="com.crt.advproject.link.scriptdir" useByScannerDiscovery="false" value="" valueType="string"/>
+								<option id="com.crt.advproject.link.crpenable.180265796" name="Enable automatic placement of Code Read Protection field in image" superClass="com.crt.advproject.link.crpenable"/>
+								<option id="com.crt.advproject.link.flashconfigenable.1765767644" name="Enable automatic placement of Flash Configuration field in image" superClass="com.crt.advproject.link.flashconfigenable" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.link.ecrp.1964957278" name="Enhanced CRP" superClass="com.crt.advproject.link.ecrp"/>
+								<option id="com.crt.advproject.link.gcc.nanofloat.732746371" name="Enable printf float " superClass="com.crt.advproject.link.gcc.nanofloat"/>
+								<option id="com.crt.advproject.link.gcc.nanofloat.scanf.1377559434" name="Enable scanf float " superClass="com.crt.advproject.link.gcc.nanofloat.scanf"/>
+								<option id="com.crt.advproject.link.toram.872745945" name="Link application to RAM" superClass="com.crt.advproject.link.toram"/>
+								<option id="com.crt.advproject.link.stackOffset.1258770682" name="Stack offset" superClass="com.crt.advproject.link.stackOffset"/>
+								<option id="com.crt.advproject.link.gcc.multicore.master.226637787" name="Multicore master" superClass="com.crt.advproject.link.gcc.multicore.master"/>
+								<option id="com.crt.advproject.link.gcc.multicore.empty.974734614" name="No Multicore options for this project" superClass="com.crt.advproject.link.gcc.multicore.empty"/>
+								<option id="com.crt.advproject.link.config.92855557" name="Obsolete (Config)" superClass="com.crt.advproject.link.config"/>
+								<option id="com.crt.advproject.link.store.562089393" name="Obsolete (Store)" superClass="com.crt.advproject.link.store"/>
+								<option id="com.crt.advproject.link.securestate.806513578" name="TrustZone Project Type" superClass="com.crt.advproject.link.securestate"/>
+								<option id="com.crt.advproject.link.sgstubs.placement.854426889" name="Secure Gateway Placement" superClass="com.crt.advproject.link.sgstubs.placement"/>
+								<option id="com.crt.advproject.link.sgstubenable.499223201" name="Enable generation of Secure Gateway Import Library" superClass="com.crt.advproject.link.sgstubenable"/>
+								<option id="com.crt.advproject.link.nonsecureobject.1975986184" name="Secure Gateway Import Library" superClass="com.crt.advproject.link.nonsecureobject"/>
+								<option id="com.crt.advproject.link.inimplib.1240275550" name="Input Secure Gateway Import Library" superClass="com.crt.advproject.link.inimplib"/>
+								<inputType id="cdt.managedbuild.tool.gnu.c.linker.input.165044330" superClass="cdt.managedbuild.tool.gnu.c.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="com.crt.advproject.tool.debug.debug.1801192446" name="MCU Debugger" superClass="com.crt.advproject.tool.debug.debug">
+								<option id="com.crt.advproject.linkserver.debug.prevent.debug.501959861" name="Prevent Debugging" superClass="com.crt.advproject.linkserver.debug.prevent.debug"/>
+								<option id="com.crt.advproject.miscellaneous.end_of_heap.1624148054" name="Last used address of the heap" superClass="com.crt.advproject.miscellaneous.end_of_heap"/>
+								<option id="com.crt.advproject.miscellaneous.pvHeapStart.1122491856" name="First address of the heap" superClass="com.crt.advproject.miscellaneous.pvHeapStart"/>
+								<option id="com.crt.advproject.miscellaneous.pvHeapLimit.1018688051" name="Maximum extent of heap" superClass="com.crt.advproject.miscellaneous.pvHeapLimit"/>
+								<option id="com.crt.advproject.debugger.security.nonsecureimageenable.359109591" name="Enable pre-programming of Non-Secure Image" superClass="com.crt.advproject.debugger.security.nonsecureimageenable"/>
+								<option id="com.crt.advproject.debugger.security.nonsecureimage.621794638" name="Non-Secure Project" superClass="com.crt.advproject.debugger.security.nonsecureimage"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="component"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="startup"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="CMSIS"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="source"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="utilities"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="drivers"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="device"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="board"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="xip"/>
+						<entry excluding="freertos_kernel/portable/MemMang/heap_1.c|freertos_kernel/portable/MemMang/heap_2.c|freertos_kernel/portable/MemMang/heap_3.c|freertos_kernel/portable/MemMang/heap_5.c" flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="freertos"/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
+		<cconfiguration id="com.crt.advproject.config.exe.release.981396926">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.981396926" moduleId="org.eclipse.cdt.core.settings" name="Release">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GNU_ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactExtension="axf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" cleanCommand="rm -rf" description="Release build" errorParsers="org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.GASErrorParser" id="com.crt.advproject.config.exe.release.981396926" name="Release" parent="com.crt.advproject.config.exe.release" postannouncebuildStep="Performing post-build steps" postbuildStep="arm-none-eabi-size &quot;${BuildArtifactFileName}&quot;; # arm-none-eabi-objcopy -v -O binary &quot;${BuildArtifactFileName}&quot; &quot;${BuildArtifactFileBaseName}.bin&quot; ; # checksum -p ${TargetChip} -d &quot;${BuildArtifactFileBaseName}.bin&quot;;  ">
+					<folderInfo id="com.crt.advproject.config.exe.release.981396926." name="/" resourcePath="">
+						<toolChain id="com.crt.advproject.toolchain.exe.release.1032350212" name="NXP MCU Tools" superClass="com.crt.advproject.toolchain.exe.release">
+							<targetPlatform binaryParser="org.eclipse.cdt.core.ELF;org.eclipse.cdt.core.GNU_ELF" id="com.crt.advproject.platform.exe.release.122533371" name="ARM-based MCU (Release)" superClass="com.crt.advproject.platform.exe.release"/>
+							<builder buildPath="${workspace_loc:/wolfcrypt_test_cm7}/Release" id="com.crt.advproject.builder.exe.release.1134159776" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="Gnu Make Builder" superClass="com.crt.advproject.builder.exe.release"/>
+							<tool id="com.crt.advproject.cpp.exe.release.548617036" name="MCU C++ Compiler" superClass="com.crt.advproject.cpp.exe.release">
+								<option id="com.crt.advproject.cpp.arch.1634552280" name="Architecture" superClass="com.crt.advproject.cpp.arch" useByScannerDiscovery="true" value="com.crt.advproject.cpp.target.cm7" valueType="enumerated"/>
+								<option id="com.crt.advproject.cpp.misc.dialect.2135129068" name="Language standard" superClass="com.crt.advproject.cpp.misc.dialect" useByScannerDiscovery="true"/>
+								<option id="gnu.cpp.compiler.option.dialect.flags.523636334" name="Other dialect flags" superClass="gnu.cpp.compiler.option.dialect.flags" useByScannerDiscovery="true"/>
+								<option id="gnu.cpp.compiler.option.preprocessor.nostdinc.1313253644" name="Do not search system directories (-nostdinc)" superClass="gnu.cpp.compiler.option.preprocessor.nostdinc" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.preprocessor.preprocess.1298836993" name="Preprocess only (-E)" superClass="gnu.cpp.compiler.option.preprocessor.preprocess" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.preprocessor.def.176716357" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.preprocessor.undef.1045061174" name="Undefined symbols (-U)" superClass="gnu.cpp.compiler.option.preprocessor.undef" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.include.paths.761185863" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.include.files.483813264" name="Include files (-include)" superClass="gnu.cpp.compiler.option.include.files" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.optimization.flags.761857513" name="Other optimization flags" superClass="gnu.cpp.compiler.option.optimization.flags" useByScannerDiscovery="false" value="-fno-common" valueType="string"/>
+								<option id="gnu.cpp.compiler.option.debugging.other.1127025586" name="Other debugging flags" superClass="gnu.cpp.compiler.option.debugging.other" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.prof.859685052" name="Generate prof information (-p)" superClass="gnu.cpp.compiler.option.debugging.prof" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.gprof.1011130005" name="Generate gprof information (-pg)" superClass="gnu.cpp.compiler.option.debugging.gprof" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.codecov.874061296" name="Generate gcov information (-ftest-coverage -fprofile-arcs)" superClass="gnu.cpp.compiler.option.debugging.codecov" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.sanitaddress.391028131" name="Sanitize address (-fsanitize=address)" superClass="gnu.cpp.compiler.option.debugging.sanitaddress" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.sanitpointers.1350431734" name="Sanitize pointer operations (-fsanitize=pointer-compare -fsanitize=pointer-subtract)" superClass="gnu.cpp.compiler.option.debugging.sanitpointers" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.sanitthread.378214489" name="Sanitize data race in multi-thread (-fsanitize=thread)" superClass="gnu.cpp.compiler.option.debugging.sanitthread" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.sanitleak.435830882" name="Sanitize memory leak (-fsanitize=leak)" superClass="gnu.cpp.compiler.option.debugging.sanitleak" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.sanitundef.987959855" name="Sanitize undefined behavior (-fsanitize=undefined)" superClass="gnu.cpp.compiler.option.debugging.sanitundef" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.syntax.1726838268" name="Check syntax only (-fsyntax-only)" superClass="gnu.cpp.compiler.option.warnings.syntax" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.pedantic.114025943" name="Pedantic (-pedantic)" superClass="gnu.cpp.compiler.option.warnings.pedantic" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.pedantic.error.277419512" name="Pedantic warnings as errors (-pedantic-errors)" superClass="gnu.cpp.compiler.option.warnings.pedantic.error" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.nowarn.1222799990" name="Inhibit all warnings (-w)" superClass="gnu.cpp.compiler.option.warnings.nowarn" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.allwarn.462961954" name="All warnings (-Wall)" superClass="gnu.cpp.compiler.option.warnings.allwarn" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.extrawarn.1319555867" name="Extra warnings (-Wextra)" superClass="gnu.cpp.compiler.option.warnings.extrawarn" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.toerrors.1993944490" name="Warnings as errors (-Werror)" superClass="gnu.cpp.compiler.option.warnings.toerrors" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wconversion.728340041" name="Implicit conversion warnings (-Wconversion)" superClass="gnu.cpp.compiler.option.warnings.wconversion" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wcastalign.412657889" name="Pointer cast with different alignment (-Wcast-align)" superClass="gnu.cpp.compiler.option.warnings.wcastalign" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wcastqual.724890297" name="Removing type qualifier from cast target type (-Wcast-qual)" superClass="gnu.cpp.compiler.option.warnings.wcastqual" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wctordtorprivacy.1358477498" name="All ctor and dtor private (-Wctor-dtor-privacy)" superClass="gnu.cpp.compiler.option.warnings.wctordtorprivacy" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wdisabledopt.1280687657" name="Requested optimization pass is disabled (-Wdisabled-optimization)" superClass="gnu.cpp.compiler.option.warnings.wdisabledopt" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wlogicalop.630396261" name="Suspicious uses of logical operators (-Wlogical-op)" superClass="gnu.cpp.compiler.option.warnings.wlogicalop" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wmissingdecl.284480756" name="Global function without previous declaration (-Wmissing-declarations)" superClass="gnu.cpp.compiler.option.warnings.wmissingdecl" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wmissingincdir.802286390" name="User-supplied include directory does not exist (-Wmissing-include-dirs)" superClass="gnu.cpp.compiler.option.warnings.wmissingincdir" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wnoexccept.365034741" name="Noexcept false but never throw exception (-Wnoexcept)" superClass="gnu.cpp.compiler.option.warnings.wnoexccept" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.woldstylecast.2022322140" name="C-style cast used (-Wold-style-cast)" superClass="gnu.cpp.compiler.option.warnings.woldstylecast" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.woverloadedvirtual.1446848580" name="Function hides virtual functions from base class (-Woverloaded-virtual)" superClass="gnu.cpp.compiler.option.warnings.woverloadedvirtual" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wredundantdecl.110695152" name="More than one declaration in the same scope (-Wredundant-decls)" superClass="gnu.cpp.compiler.option.warnings.wredundantdecl" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wshadow.2129799174" name="Local symbol shadows upper scope symbol (-Wshadow)" superClass="gnu.cpp.compiler.option.warnings.wshadow" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wsignconv.2000237188" name="Implicit conversions that may change the sign (-Wsign-conversion)" superClass="gnu.cpp.compiler.option.warnings.wsignconv" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wsignpromo.2089350353" name="Overload resolution promotes unsigned to signed type (-Wsign-promo)" superClass="gnu.cpp.compiler.option.warnings.wsignpromo" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wstrictnullsent.2065686869" name="Use of an uncasted NULL as sentinel (-Wstrict-null-sentinel)" superClass="gnu.cpp.compiler.option.warnings.wstrictnullsent" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wswitchdef.43207042" name="A switch statement does not have a default case (-Wswitch-default)" superClass="gnu.cpp.compiler.option.warnings.wswitchdef" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wundef.90829574" name="An undefined identifier is evaluated in an #if directive (-Wundef)" superClass="gnu.cpp.compiler.option.warnings.wundef" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.weffcpp.2001728318" name="Effective C++ guidelines (-Weffc++)" superClass="gnu.cpp.compiler.option.warnings.weffcpp" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wfloatequal.1851034992" name="Direct float equal check (-Wfloat-equal)" superClass="gnu.cpp.compiler.option.warnings.wfloatequal" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.other.other.934861066" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.other.verbose.864780220" name="Verbose (-v)" superClass="gnu.cpp.compiler.option.other.verbose" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.other.pic.1813206315" name="Position Independent Code (-fPIC)" superClass="gnu.cpp.compiler.option.other.pic" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.misc.hardening.1767210688" name="Hardening options (-fstack-protector-all -Wformat=2 -Wformat-security -Wstrict-overflow)" superClass="gnu.cpp.compiler.option.misc.hardening" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.misc.randomization.1458004355" name="Address randomization (-fPIE)" superClass="gnu.cpp.compiler.option.misc.randomization" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.lto.173819421" name="Enable Link-time optimization (-flto)" superClass="com.crt.advproject.cpp.lto" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.lto.fat.766268627" name="Fat lto objects (-ffat-lto-objects)" superClass="com.crt.advproject.cpp.lto.fat" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.merge.constants.458229141" name="Merge Identical Constants (-fmerge-constants)" superClass="com.crt.advproject.cpp.merge.constants" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.prefixmap.1215285379" name="Remove path from __FILE__ (-fmacro-prefix-map)" superClass="com.crt.advproject.cpp.prefixmap" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.fpu.1040164601" name="Floating point" superClass="com.crt.advproject.cpp.fpu" useByScannerDiscovery="true" value="com.crt.advproject.cpp.fpu.fpv5sp.hard" valueType="enumerated"/>
+								<option id="com.crt.advproject.cpp.thumb.888407265" name="Thumb mode" superClass="com.crt.advproject.cpp.thumb" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.thumbinterwork.1836031770" name="Enable Thumb interworking" superClass="com.crt.advproject.cpp.thumbinterwork" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.securestate.1913538802" name="TrustZone Project Type" superClass="com.crt.advproject.cpp.securestate" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.hdrlib.477549642" name="Library headers" superClass="com.crt.advproject.cpp.hdrlib" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.stackusage.736571328" name="Generate Stack Usage Info (-fstack-usage)" superClass="com.crt.advproject.cpp.stackusage" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.specs.977330608" name="Specs" superClass="com.crt.advproject.cpp.specs" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.config.2042660567" name="Obsolete (Config)" superClass="com.crt.advproject.cpp.config" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.store.1438666811" name="Obsolete (Store)" superClass="com.crt.advproject.cpp.store" useByScannerDiscovery="false"/>
+							</tool>
+							<tool id="com.crt.advproject.gcc.exe.release.1253109259" name="MCU C Compiler" superClass="com.crt.advproject.gcc.exe.release">
+								<option id="com.crt.advproject.gcc.thumb.1582439077" name="Thumb mode" superClass="com.crt.advproject.gcc.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.gcc.arch.418257434" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="true" value="com.crt.advproject.gcc.target.cm7" valueType="enumerated"/>
+								<option id="com.crt.advproject.c.misc.dialect.354972302" name="Language standard" superClass="com.crt.advproject.c.misc.dialect" useByScannerDiscovery="true"/>
+								<option id="gnu.c.compiler.option.dialect.flags.863099956" name="Other dialect flags" superClass="gnu.c.compiler.option.dialect.flags" useByScannerDiscovery="true"/>
+								<option id="gnu.c.compiler.option.preprocessor.nostdinc.541966655" name="Do not search system directories (-nostdinc)" superClass="gnu.c.compiler.option.preprocessor.nostdinc" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.preprocessor.preprocess.1784946048" name="Preprocess only (-E)" superClass="gnu.c.compiler.option.preprocessor.preprocess" useByScannerDiscovery="false"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.1615209320" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="__REDLIB__"/>
+									<listOptionValue builtIn="false" value="WOLFSSL_USER_SETTINGS"/>
+									<listOptionValue builtIn="false" value="CPU_MIMXRT1176DVMAA"/>
+									<listOptionValue builtIn="false" value="CPU_MIMXRT1176DVMAA_cm7"/>
+									<listOptionValue builtIn="false" value="SDK_OS_BAREMETAL"/>
+									<listOptionValue builtIn="false" value="XIP_EXTERNAL_FLASH=1"/>
+									<listOptionValue builtIn="false" value="XIP_BOOT_HEADER_ENABLE=1"/>
+									<listOptionValue builtIn="false" value="SERIAL_PORT_TYPE_UART=1"/>
+									<listOptionValue builtIn="false" value="XIP_BOOT_HEADER_DCD_ENABLE=0"/>
+									<listOptionValue builtIn="false" value="XIP_BOOT_HEADER_XMCD_ENABLE=1"/>
+									<listOptionValue builtIn="false" value="SDK_DEBUGCONSOLE=1"/>
+									<listOptionValue builtIn="false" value="CR_INTEGER_PRINTF"/>
+									<listOptionValue builtIn="false" value="PRINTF_FLOAT_ENABLE=0"/>
+									<listOptionValue builtIn="false" value="SDK_OS_FREE_RTOS"/>
+									<listOptionValue builtIn="false" value="__MCUXPRESSO"/>
+									<listOptionValue builtIn="false" value="__USE_CMSIS"/>
+									<listOptionValue builtIn="false" value="DEBUG"/>
+								</option>
+								<option id="gnu.c.compiler.option.preprocessor.undef.symbol.410116226" name="Undefined symbols (-U)" superClass="gnu.c.compiler.option.preprocessor.undef.symbol" useByScannerDiscovery="false"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.292811755" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/portable/GCC/ARM_CM4F}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/xip}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/startup}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/portable/GCC/ARM_CM4F}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/xip}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/startup}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc}/&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc}/../../../&quot;"/>
+								</option>
+								<option id="gnu.c.compiler.option.include.files.197059746" name="Include files (-include)" superClass="gnu.c.compiler.option.include.files" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.optimization.flags.2145570534" name="Other optimization flags" superClass="gnu.c.compiler.option.optimization.flags" useByScannerDiscovery="false" value="-fno-common" valueType="string"/>
+								<option id="gnu.c.compiler.option.debugging.other.1438562203" name="Other debugging flags" superClass="gnu.c.compiler.option.debugging.other" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.prof.474544184" name="Generate prof information (-p)" superClass="gnu.c.compiler.option.debugging.prof" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.gprof.577122371" name="Generate gprof information (-pg)" superClass="gnu.c.compiler.option.debugging.gprof" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.codecov.1629462010" name="Generate gcov information (-ftest-coverage -fprofile-arcs)" superClass="gnu.c.compiler.option.debugging.codecov" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.sanitaddress.1192024536" name="Sanitize address (-fsanitize=address)" superClass="gnu.c.compiler.option.debugging.sanitaddress" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.sanitpointers.2069014006" name="Sanitize pointer operations (-fsanitize=pointer-compare -fsanitize=pointer-subtract)" superClass="gnu.c.compiler.option.debugging.sanitpointers" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.sanitthread.18177326" name="Sanitize data race in multi-thread (-fsanitize=thread)" superClass="gnu.c.compiler.option.debugging.sanitthread" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.sanitleak.640075524" name="Sanitize memory leak (-fsanitize=leak)" superClass="gnu.c.compiler.option.debugging.sanitleak" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.sanitundef.73596165" name="Sanitize undefined behavior (-fsanitize=undefined)" superClass="gnu.c.compiler.option.debugging.sanitundef" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.syntax.419727656" name="Check syntax only (-fsyntax-only)" superClass="gnu.c.compiler.option.warnings.syntax" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.pedantic.201665174" name="Pedantic (-pedantic)" superClass="gnu.c.compiler.option.warnings.pedantic" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.pedantic.error.1994153305" name="Pedantic warnings as errors (-pedantic-errors)" superClass="gnu.c.compiler.option.warnings.pedantic.error" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.nowarn.562064792" name="Inhibit all warnings (-w)" superClass="gnu.c.compiler.option.warnings.nowarn" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.allwarn.1621339306" name="All warnings (-Wall)" superClass="gnu.c.compiler.option.warnings.allwarn" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.extrawarn.448848044" name="Extra warnings (-Wextra)" superClass="gnu.c.compiler.option.warnings.extrawarn" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.toerrors.1481224808" name="Warnings as errors (-Werror)" superClass="gnu.c.compiler.option.warnings.toerrors" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wconversion.1442257315" name="Implicit conversion warnings (-Wconversion)" superClass="gnu.c.compiler.option.warnings.wconversion" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wcastalign.2109399214" name="Pointer cast with different alignment (-Wcast-align)" superClass="gnu.c.compiler.option.warnings.wcastalign" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wcastqual.395409395" name="Removing type qualifier from cast target type (-Wcast-qual)" superClass="gnu.c.compiler.option.warnings.wcastqual" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wdisabledopt.191892212" name="Requested optimization pass is disabled (-Wdisabled-optimization)" superClass="gnu.c.compiler.option.warnings.wdisabledopt" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wlogicalop.1427257670" name="Suspicious uses of logical operators (-Wlogical-op)" superClass="gnu.c.compiler.option.warnings.wlogicalop" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wmissingdecl.487878280" name="Global function without previous declaration (-Wmissing-declarations)" superClass="gnu.c.compiler.option.warnings.wmissingdecl" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wmissingincdir.456752900" name="User-supplied include directory does not exist (-Wmissing-include-dirs)" superClass="gnu.c.compiler.option.warnings.wmissingincdir" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wredundantdecl.2076203856" name="More than one declaration in the same scope (-Wredundant-decls)" superClass="gnu.c.compiler.option.warnings.wredundantdecl" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wshadow.1437591820" name="Local symbol shadows upper scope symbol (-Wshadow)" superClass="gnu.c.compiler.option.warnings.wshadow" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wsignconv.2080763052" name="Implicit conversions that may change the sign (-Wsign-conversion)" superClass="gnu.c.compiler.option.warnings.wsignconv" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wswitchdef.1967828107" name="A switch statement does not have a default case (-Wswitch-default)" superClass="gnu.c.compiler.option.warnings.wswitchdef" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wundef.137676123" name="An undefined identifier is evaluated in an #if directive (-Wundef)" superClass="gnu.c.compiler.option.warnings.wundef" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wwritestrings.482855102" name="Treat strings always as const (-Wwrite-strings)" superClass="gnu.c.compiler.option.warnings.wwritestrings" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wfloatequal.275352908" name="Direct float equal check (-Wfloat-equal)" superClass="gnu.c.compiler.option.warnings.wfloatequal" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.misc.other.1430311054" name="Other flags" superClass="gnu.c.compiler.option.misc.other" useByScannerDiscovery="false" value="-c -ffunction-sections -fdata-sections -ffreestanding -fno-builtin" valueType="string"/>
+								<option id="gnu.c.compiler.option.misc.verbose.341071121" name="Verbose (-v)" superClass="gnu.c.compiler.option.misc.verbose" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.misc.ansi.200522523" name="Support ANSI programs (-ansi)" superClass="gnu.c.compiler.option.misc.ansi" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.misc.pic.2026153867" name="Position Independent Code (-fPIC)" superClass="gnu.c.compiler.option.misc.pic" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.misc.hardening.1383146914" name="Hardening options (-fstack-protector-all -Wformat=2 -Wformat-security -Wstrict-overflow)" superClass="gnu.c.compiler.option.misc.hardening" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.misc.randomization.778773946" name="Address randomization (-fPIE)" superClass="gnu.c.compiler.option.misc.randomization" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.lto.626240431" name="Enable Link-time optimization (-flto)" superClass="com.crt.advproject.gcc.lto" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.lto.fat.1658622320" name="Fat lto objects (-ffat-lto-objects)" superClass="com.crt.advproject.gcc.lto.fat" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.merge.constants.1713326248" name="Merge Identical Constants (-fmerge-constants)" superClass="com.crt.advproject.gcc.merge.constants" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.prefixmap.230066719" name="Remove path from __FILE__ (-fmacro-prefix-map)" superClass="com.crt.advproject.gcc.prefixmap" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.fpu.602462846" name="Floating point" superClass="com.crt.advproject.gcc.fpu" useByScannerDiscovery="true" value="com.crt.advproject.gcc.fpu.fpv5sp.hard" valueType="enumerated"/>
+								<option id="com.crt.advproject.gcc.thumbinterwork.1425914084" name="Enable Thumb interworking" superClass="com.crt.advproject.gcc.thumbinterwork" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.securestate.914361915" name="TrustZone Project Type" superClass="com.crt.advproject.gcc.securestate" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.hdrlib.746671010" name="Library headers" superClass="com.crt.advproject.gcc.hdrlib" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.stackusage.1908055069" name="Generate Stack Usage Info (-fstack-usage)" superClass="com.crt.advproject.gcc.stackusage" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.specs.869038679" name="Specs" superClass="com.crt.advproject.gcc.specs" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.config.1815840874" name="Obsolete (Config)" superClass="com.crt.advproject.gcc.config" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.store.1813543951" name="Obsolete (Store)" superClass="com.crt.advproject.gcc.store" useByScannerDiscovery="false"/>
+								<inputType id="com.crt.advproject.compiler.input.1285793863" superClass="com.crt.advproject.compiler.input"/>
+							</tool>
+							<tool id="com.crt.advproject.gas.exe.release.108601968" name="MCU Assembler" superClass="com.crt.advproject.gas.exe.release">
+								<option id="com.crt.advproject.gas.thumb.745990435" name="Thumb mode" superClass="com.crt.advproject.gas.thumb" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.gas.arch.1237513635" name="Architecture" superClass="com.crt.advproject.gas.arch" value="com.crt.advproject.gas.target.cm7" valueType="enumerated"/>
+								<option id="gnu.both.asm.option.flags.crt.1477003050" name="Assembler flags" superClass="gnu.both.asm.option.flags.crt" value="-c -x assembler-with-cpp -D__REDLIB__" valueType="string"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.both.asm.option.include.paths.658219719" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
+								</option>
+								<option id="gnu.both.asm.option.warnings.nowarn.48289479" name="Suppress warnings (-W)" superClass="gnu.both.asm.option.warnings.nowarn"/>
+								<option id="gnu.both.asm.option.version.2013721824" name="Announce version (-v)" superClass="gnu.both.asm.option.version"/>
+								<option id="com.crt.advproject.gas.fpu.522157465" name="Floating point" superClass="com.crt.advproject.gas.fpu" value="com.crt.advproject.gas.fpu.fpv5sp.hard" valueType="enumerated"/>
+								<option id="com.crt.advproject.gas.thumbinterwork.1594404520" name="Enable Thumb interworking" superClass="com.crt.advproject.gas.thumbinterwork"/>
+								<option id="com.crt.advproject.gas.hdrlib.1633015462" name="Library headers" superClass="com.crt.advproject.gas.hdrlib"/>
+								<option id="com.crt.advproject.gas.specs.299786548" name="Specs" superClass="com.crt.advproject.gas.specs"/>
+								<option id="com.crt.advproject.gas.config.33183147" name="Obsolete (Config)" superClass="com.crt.advproject.gas.config"/>
+								<option id="com.crt.advproject.gas.store.1747591743" name="Obsolete (Store)" superClass="com.crt.advproject.gas.store"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.98214154" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+								<inputType id="com.crt.advproject.assembler.input.1088043010" name="Additional Assembly Source Files" superClass="com.crt.advproject.assembler.input"/>
+							</tool>
+							<tool id="com.crt.advproject.link.cpp.exe.release.1077999801" name="MCU C++ Linker" superClass="com.crt.advproject.link.cpp.exe.release">
+								<option id="com.crt.advproject.link.cpp.arch.2112799646" name="Architecture" superClass="com.crt.advproject.link.cpp.arch" value="com.crt.advproject.link.cpp.target.cm7" valueType="enumerated"/>
+								<option id="com.crt.advproject.link.cpp.multicore.slave.343640029" name="Multicore configuration" superClass="com.crt.advproject.link.cpp.multicore.slave"/>
+								<option id="gnu.cpp.link.option.nostart.1144465751" name="Do not use standard start files (-nostartfiles)" superClass="gnu.cpp.link.option.nostart"/>
+								<option id="gnu.cpp.link.option.nodeflibs.882403911" name="Do not use default libraries (-nodefaultlibs)" superClass="gnu.cpp.link.option.nodeflibs"/>
+								<option id="gnu.cpp.link.option.nostdlibs.1106482768" name="No startup or default libs (-nostdlib)" superClass="gnu.cpp.link.option.nostdlibs" value="true" valueType="boolean"/>
+								<option id="gnu.cpp.link.option.strip.1027443640" name="Omit all symbol information (-s)" superClass="gnu.cpp.link.option.strip"/>
+								<option id="gnu.cpp.link.option.libs.1146803255" name="Libraries (-l)" superClass="gnu.cpp.link.option.libs"/>
+								<option id="gnu.cpp.link.option.paths.158962818" name="Library search path (-L)" superClass="gnu.cpp.link.option.paths"/>
+								<option id="gnu.cpp.link.option.flags.1726413165" name="Linker flags" superClass="gnu.cpp.link.option.flags"/>
+								<option id="gnu.cpp.link.option.other.524183013" name="Other options (-Xlinker [option])" superClass="gnu.cpp.link.option.other"/>
+								<option id="gnu.cpp.link.option.userobjs.1299836702" name="Other objects" superClass="gnu.cpp.link.option.userobjs"/>
+								<option id="gnu.cpp.link.option.shared.1670909776" name="Shared (-shared)" superClass="gnu.cpp.link.option.shared"/>
+								<option id="gnu.cpp.link.option.soname.2132704049" name="Shared object name (-Wl,-soname=)" superClass="gnu.cpp.link.option.soname"/>
+								<option id="gnu.cpp.link.option.implname.750247924" name="Import Library name (-Wl,--out-implib=)" superClass="gnu.cpp.link.option.implname"/>
+								<option id="gnu.cpp.link.option.defname.272116967" name="DEF file name (-Wl,--output-def=)" superClass="gnu.cpp.link.option.defname"/>
+								<option id="gnu.cpp.link.option.debugging.prof.605841421" name="Generate prof information (-p)" superClass="gnu.cpp.link.option.debugging.prof"/>
+								<option id="gnu.cpp.link.option.debugging.gprof.1235218857" name="Generate gprof information (-pg)" superClass="gnu.cpp.link.option.debugging.gprof"/>
+								<option id="gnu.cpp.link.option.debugging.codecov.927341957" name="Generate gcov information (-ftest-coverage -fprofile-arcs)" superClass="gnu.cpp.link.option.debugging.codecov"/>
+								<option id="com.crt.advproject.link.cpp.lto.564273070" name="Enable Link-time optimization (-flto)" superClass="com.crt.advproject.link.cpp.lto"/>
+								<option id="com.crt.advproject.link.cpp.lto.optmization.level.1087990528" name="Link-time optimization level" superClass="com.crt.advproject.link.cpp.lto.optmization.level"/>
+								<option id="com.crt.advproject.link.cpp.fpu.1362580348" name="Floating point" superClass="com.crt.advproject.link.cpp.fpu" value="com.crt.advproject.link.cpp.fpu.fpv5sp.hard" valueType="enumerated"/>
+								<option id="com.crt.advproject.link.cpp.thumb.1009740252" name="Thumb mode" superClass="com.crt.advproject.link.cpp.thumb"/>
+								<option id="com.crt.advproject.link.cpp.manage.1630620552" name="Manage linker script" superClass="com.crt.advproject.link.cpp.manage"/>
+								<option id="com.crt.advproject.link.cpp.script.69851927" name="Linker script" superClass="com.crt.advproject.link.cpp.script"/>
+								<option id="com.crt.advproject.link.cpp.scriptdir.1140341032" name="Script path" superClass="com.crt.advproject.link.cpp.scriptdir"/>
+								<option id="com.crt.advproject.link.cpp.crpenable.807841036" name="Enable automatic placement of Code Read Protection field in image" superClass="com.crt.advproject.link.cpp.crpenable"/>
+								<option id="com.crt.advproject.link.cpp.flashconfigenable.976345114" name="Enable automatic placement of Flash Configuration field in image" superClass="com.crt.advproject.link.cpp.flashconfigenable" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.link.cpp.ecrp.792366889" name="Enhanced CRP" superClass="com.crt.advproject.link.cpp.ecrp"/>
+								<option id="com.crt.advproject.link.cpp.hdrlib.2061520875" name="Library" superClass="com.crt.advproject.link.cpp.hdrlib"/>
+								<option id="com.crt.advproject.link.cpp.nanofloat.827817179" name="Enable printf float " superClass="com.crt.advproject.link.cpp.nanofloat"/>
+								<option id="com.crt.advproject.link.cpp.nanofloat.scanf.27949447" name="Enable scanf float " superClass="com.crt.advproject.link.cpp.nanofloat.scanf"/>
+								<option id="com.crt.advproject.link.cpp.toram.1802654861" name="Link application to RAM" superClass="com.crt.advproject.link.cpp.toram"/>
+								<option id="com.crt.advproject.link.memory.load.image.cpp.1050674507" name="Plain load image" superClass="com.crt.advproject.link.memory.load.image.cpp"/>
+								<option id="com.crt.advproject.link.memory.heapAndStack.style.cpp.2004867564" name="Heap and Stack placement" superClass="com.crt.advproject.link.memory.heapAndStack.style.cpp"/>
+								<option id="com.crt.advproject.link.cpp.stackOffset.667325380" name="Stack offset" superClass="com.crt.advproject.link.cpp.stackOffset"/>
+								<option id="com.crt.advproject.link.memory.heapAndStack.cpp.384333879" name="Heap and Stack options" superClass="com.crt.advproject.link.memory.heapAndStack.cpp"/>
+								<option id="com.crt.advproject.link.memory.data.cpp.1503285530" name="Global data placement" superClass="com.crt.advproject.link.memory.data.cpp"/>
+								<option id="com.crt.advproject.link.memory.sections.cpp.225139885" name="Extra linker script input sections" superClass="com.crt.advproject.link.memory.sections.cpp"/>
+								<option id="com.crt.advproject.link.cpp.multicore.master.154448524" name="Multicore master" superClass="com.crt.advproject.link.cpp.multicore.master"/>
+								<option id="com.crt.advproject.link.cpp.multicore.empty.1594356236" name="No Multicore options for this project" superClass="com.crt.advproject.link.cpp.multicore.empty"/>
+								<option id="com.crt.advproject.link.cpp.multicore.master.userobjs.774231706" name="Slave Objects (not visible)" superClass="com.crt.advproject.link.cpp.multicore.master.userobjs"/>
+								<option id="com.crt.advproject.link.cpp.config.1062774242" name="Obsolete (Config)" superClass="com.crt.advproject.link.cpp.config"/>
+								<option id="com.crt.advproject.link.cpp.store.831631108" name="Obsolete (Store)" superClass="com.crt.advproject.link.cpp.store"/>
+								<option id="com.crt.advproject.link.cpp.securestate.1285883072" name="TrustZone Project Type" superClass="com.crt.advproject.link.cpp.securestate"/>
+								<option id="com.crt.advproject.link.cpp.sgstubs.placement.1968895673" name="Secure Gateway Placement" superClass="com.crt.advproject.link.cpp.sgstubs.placement"/>
+								<option id="com.crt.advproject.link.cpp.sgstubenable.23519419" name="Enable generation of Secure Gateway Import Library" superClass="com.crt.advproject.link.cpp.sgstubenable"/>
+								<option id="com.crt.advproject.link.cpp.nonsecureobject.1663215217" name="Secure Gateway Import Library" superClass="com.crt.advproject.link.cpp.nonsecureobject"/>
+								<option id="com.crt.advproject.link.cpp.inimplib.1812780441" name="Input Secure Gateway Import Library" superClass="com.crt.advproject.link.cpp.inimplib"/>
+							</tool>
+							<tool id="com.crt.advproject.link.exe.release.1113864660" name="MCU Linker" superClass="com.crt.advproject.link.exe.release">
+								<option id="com.crt.advproject.link.thumb.79432485" name="Thumb mode" superClass="com.crt.advproject.link.thumb" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.link.memory.load.image.630682221" name="Plain load image" superClass="com.crt.advproject.link.memory.load.image" useByScannerDiscovery="false" value="" valueType="string"/>
+								<option defaultValue="com.crt.advproject.heapAndStack.mcuXpressoStyle" id="com.crt.advproject.link.memory.heapAndStack.style.1854528716" name="Heap and Stack placement" superClass="com.crt.advproject.link.memory.heapAndStack.style" useByScannerDiscovery="false" valueType="enumerated"/>
+								<option id="com.crt.advproject.link.memory.heapAndStack.77129555" name="Heap and Stack options" superClass="com.crt.advproject.link.memory.heapAndStack" value="&amp;Heap:Default;Post Data;Default&amp;Stack:Default;End;Default" valueType="string"/>
+								<option id="com.crt.advproject.link.memory.data.490922553" name="Global data placement" superClass="com.crt.advproject.link.memory.data" useByScannerDiscovery="false" value="" valueType="string"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.crt.advproject.link.memory.sections.946589054" name="Extra linker script input sections" superClass="com.crt.advproject.link.memory.sections" useByScannerDiscovery="false" valueType="stringList"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.crt.advproject.link.gcc.multicore.master.userobjs.63521906" name="Slave Objects (not visible)" superClass="com.crt.advproject.link.gcc.multicore.master.userobjs" useByScannerDiscovery="false" valueType="userObjs"/>
+								<option id="com.crt.advproject.link.gcc.multicore.slave.568800844" name="Multicore configuration" superClass="com.crt.advproject.link.gcc.multicore.slave"/>
+								<option id="com.crt.advproject.link.arch.1970200507" name="Architecture" superClass="com.crt.advproject.link.arch" value="com.crt.advproject.link.target.cm7" valueType="enumerated"/>
+								<option id="gnu.c.link.option.nostart.1857477863" name="Do not use standard start files (-nostartfiles)" superClass="gnu.c.link.option.nostart"/>
+								<option id="gnu.c.link.option.nodeflibs.1186749327" name="Do not use default libraries (-nodefaultlibs)" superClass="gnu.c.link.option.nodeflibs"/>
+								<option id="gnu.c.link.option.nostdlibs.1504277783" name="No startup or default libs (-nostdlib)" superClass="gnu.c.link.option.nostdlibs" value="true" valueType="boolean"/>
+								<option id="gnu.c.link.option.strip.1451192255" name="Omit all symbol information (-s)" superClass="gnu.c.link.option.strip"/>
+								<option id="gnu.c.link.option.noshared.571432416" name="No shared libraries (-static)" superClass="gnu.c.link.option.noshared"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.link.option.libs.591885426" name="Libraries (-l)" superClass="gnu.c.link.option.libs" useByScannerDiscovery="false" valueType="libs">
+									<listOptionValue builtIn="false" value="wolfssl_cm7"/>
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.link.option.paths.1612103643" name="Library search path (-L)" superClass="gnu.c.link.option.paths" useByScannerDiscovery="false" valueType="libPaths">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfssl_cm7/Release}&quot;"/>
+								</option>
+								<option id="gnu.c.link.option.ldflags.1586520376" name="Linker flags" superClass="gnu.c.link.option.ldflags"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.link.option.other.1791022797" name="Other options (-Xlinker [option])" superClass="gnu.c.link.option.other" valueType="stringList">
+									<listOptionValue builtIn="false" value="-Map=&quot;${BuildArtifactFileBaseName}.map&quot;"/>
+									<listOptionValue builtIn="false" value="--gc-sections"/>
+									<listOptionValue builtIn="false" value="-print-memory-usage"/>
+									<listOptionValue builtIn="false" value="--sort-section=alignment"/>
+									<listOptionValue builtIn="false" value="--cref"/>
+								</option>
+								<option id="gnu.c.link.option.userobjs.560142425" name="Other objects" superClass="gnu.c.link.option.userobjs"/>
+								<option id="gnu.c.link.option.shared.677493024" name="Shared (-shared)" superClass="gnu.c.link.option.shared"/>
+								<option id="gnu.c.link.option.soname.576359436" name="Shared object name (-Wl,-soname=)" superClass="gnu.c.link.option.soname"/>
+								<option id="gnu.c.link.option.implname.1740292143" name="Import Library name (-Wl,--out-implib=)" superClass="gnu.c.link.option.implname"/>
+								<option id="gnu.c.link.option.defname.791356407" name="DEF file name (-Wl,--output-def=)" superClass="gnu.c.link.option.defname"/>
+								<option id="gnu.c.link.option.debugging.prof.1636924415" name="Generate prof information (-p)" superClass="gnu.c.link.option.debugging.prof"/>
+								<option id="gnu.c.link.option.debugging.gprof.1835720027" name="Generate gprof information (-pg)" superClass="gnu.c.link.option.debugging.gprof"/>
+								<option id="gnu.c.link.option.debugging.codecov.1042489081" name="Generate gcov information (-ftest-coverage -fprofile-arcs)" superClass="gnu.c.link.option.debugging.codecov"/>
+								<option id="com.crt.advproject.link.gcc.lto.1205218229" name="Enable Link-time optimization (-flto)" superClass="com.crt.advproject.link.gcc.lto"/>
+								<option id="com.crt.advproject.link.gcc.lto.optmization.level.654306976" name="Link-time optimization level" superClass="com.crt.advproject.link.gcc.lto.optmization.level"/>
+								<option id="com.crt.advproject.link.fpu.553312232" name="Floating point" superClass="com.crt.advproject.link.fpu" value="com.crt.advproject.link.fpu.fpv5sp.hard" valueType="enumerated"/>
+								<option id="com.crt.advproject.link.manage.215045893" name="Manage linker script" superClass="com.crt.advproject.link.manage" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.link.script.356131206" name="Linker script" superClass="com.crt.advproject.link.script" value="wolfcrypt_test_cm7_Release.ld" valueType="string"/>
+								<option id="com.crt.advproject.link.scriptdir.569481368" name="Script path" superClass="com.crt.advproject.link.scriptdir"/>
+								<option id="com.crt.advproject.link.crpenable.1216809942" name="Enable automatic placement of Code Read Protection field in image" superClass="com.crt.advproject.link.crpenable"/>
+								<option id="com.crt.advproject.link.flashconfigenable.2020549364" name="Enable automatic placement of Flash Configuration field in image" superClass="com.crt.advproject.link.flashconfigenable" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.link.ecrp.397783694" name="Enhanced CRP" superClass="com.crt.advproject.link.ecrp"/>
+								<option id="com.crt.advproject.link.gcc.hdrlib.390212430" name="Library" superClass="com.crt.advproject.link.gcc.hdrlib" value="com.crt.advproject.gcc.link.hdrlib.codered.nohost_nf" valueType="enumerated"/>
+								<option id="com.crt.advproject.link.gcc.nanofloat.317049663" name="Enable printf float " superClass="com.crt.advproject.link.gcc.nanofloat"/>
+								<option id="com.crt.advproject.link.gcc.nanofloat.scanf.207075418" name="Enable scanf float " superClass="com.crt.advproject.link.gcc.nanofloat.scanf"/>
+								<option id="com.crt.advproject.link.toram.1430606350" name="Link application to RAM" superClass="com.crt.advproject.link.toram"/>
+								<option id="com.crt.advproject.link.stackOffset.882073342" name="Stack offset" superClass="com.crt.advproject.link.stackOffset"/>
+								<option id="com.crt.advproject.link.gcc.multicore.master.882020552" name="Multicore master" superClass="com.crt.advproject.link.gcc.multicore.master"/>
+								<option id="com.crt.advproject.link.gcc.multicore.empty.530355296" name="No Multicore options for this project" superClass="com.crt.advproject.link.gcc.multicore.empty"/>
+								<option id="com.crt.advproject.link.config.2015066537" name="Obsolete (Config)" superClass="com.crt.advproject.link.config"/>
+								<option id="com.crt.advproject.link.store.784988329" name="Obsolete (Store)" superClass="com.crt.advproject.link.store"/>
+								<option id="com.crt.advproject.link.securestate.241299522" name="TrustZone Project Type" superClass="com.crt.advproject.link.securestate"/>
+								<option id="com.crt.advproject.link.sgstubs.placement.2055313018" name="Secure Gateway Placement" superClass="com.crt.advproject.link.sgstubs.placement"/>
+								<option id="com.crt.advproject.link.sgstubenable.1628213330" name="Enable generation of Secure Gateway Import Library" superClass="com.crt.advproject.link.sgstubenable"/>
+								<option id="com.crt.advproject.link.nonsecureobject.865561319" name="Secure Gateway Import Library" superClass="com.crt.advproject.link.nonsecureobject"/>
+								<option id="com.crt.advproject.link.inimplib.1805360605" name="Input Secure Gateway Import Library" superClass="com.crt.advproject.link.inimplib"/>
+								<inputType id="cdt.managedbuild.tool.gnu.c.linker.input.1480900130" superClass="cdt.managedbuild.tool.gnu.c.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="com.crt.advproject.tool.debug.release.843067472" name="MCU Debugger" superClass="com.crt.advproject.tool.debug.release">
+								<option id="com.crt.advproject.miscellaneous.end_of_heap.1692271803" name="Last used address of the heap" superClass="com.crt.advproject.miscellaneous.end_of_heap"/>
+								<option id="com.crt.advproject.miscellaneous.pvHeapStart.866756572" name="First address of the heap" superClass="com.crt.advproject.miscellaneous.pvHeapStart"/>
+								<option id="com.crt.advproject.miscellaneous.pvHeapLimit.1441986525" name="Maximum extent of heap" superClass="com.crt.advproject.miscellaneous.pvHeapLimit"/>
+								<option id="com.crt.advproject.debugger.security.nonsecureimageenable.1065009724" name="Enable pre-programming of Non-Secure Image" superClass="com.crt.advproject.debugger.security.nonsecureimageenable"/>
+								<option id="com.crt.advproject.debugger.security.nonsecureimage.2006619134" name="Non-Secure Project" superClass="com.crt.advproject.debugger.security.nonsecureimage"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="component"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="startup"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="CMSIS"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="source"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="utilities"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="drivers"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="device"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="board"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="xip"/>
+						<entry excluding="freertos_kernel/portable/MemMang/heap_1.c|freertos_kernel/portable/MemMang/heap_2.c|freertos_kernel/portable/MemMang/heap_3.c|freertos_kernel/portable/MemMang/heap_5.c" flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="freertos"/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="wolfcrypt_test_cm7.null.191929271" name="wolfcrypt_test_cm7" projectType="com.crt.advproject.projecttype.exe"/>
+	</storageModule>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="com.crt.advproject.config.exe.release.981396926;com.crt.advproject.config.exe.release.981396926.;com.crt.advproject.gas.exe.release.108601968;com.crt.advproject.assembler.input.1088043010">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="com.crt.advproject.config.exe.debug.592940767;com.crt.advproject.config.exe.debug.592940767.;com.crt.advproject.gas.exe.debug.1368940667;com.crt.advproject.assembler.input.2037915685">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="com.crt.advproject.config.exe.debug.592940767;com.crt.advproject.config.exe.debug.592940767.;com.crt.advproject.gcc.exe.debug.1589119815;com.crt.advproject.compiler.input.1138321445">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="com.crt.advproject.config.exe.release.981396926;com.crt.advproject.config.exe.release.981396926.;com.crt.advproject.gcc.exe.release.1253109259;com.crt.advproject.compiler.input.1285793863">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="com.nxp.mcuxpresso.core.datamodels">
+		<sdkName>SDK_2.x_MIMXRT1170-EVK</sdkName>
+		<sdkVersion>2.12.1</sdkVersion>
+		<sdkComponents>middleware.freertos-kernel.MIMXRT1176;platform.drivers.clock.MIMXRT1176;platform.drivers.pmu_1.MIMXRT1176;platform.drivers.common.MIMXRT1176;platform.drivers.anatop_ai.MIMXRT1176;platform.drivers.xip_device.MIMXRT1176;platform.drivers.igpio.MIMXRT1176;platform.drivers.lpuart.MIMXRT1176;platform.drivers.nic301.MIMXRT1176;platform.drivers.dcdc_soc.MIMXRT1176;platform.drivers.iomuxc.MIMXRT1176;platform.drivers.caam.MIMXRT1176;platform.drivers.memory.MIMXRT1176;platform.drivers.cache_armv7_m7.MIMXRT1176;platform.devices.MIMXRT1176_system.MIMXRT1176;platform.devices.MIMXRT1176_CMSIS.MIMXRT1176;CMSIS_Include_core_cm.MIMXRT1176;component.serial_manager_uart.MIMXRT1176;component.lpuart_adapter.MIMXRT1176;component.serial_manager.MIMXRT1176;utility.debug_console.MIMXRT1176;platform.utilities.assert.MIMXRT1176;platform.drivers.xmcd.evkmimxrt1170.MIMXRT1176;platform.drivers.xip_board.evkmimxrt1170.MIMXRT1176;component.lists.MIMXRT1176;project_template.evkmimxrt1170.MIMXRT1176;middleware.freertos-kernel.template.MIMXRT1176;platform.devices.MIMXRT1176_startup.MIMXRT1176;middleware.freertos-kernel.extension.MIMXRT1176;platform.drivers.snvs_hp.MIMXRT1176;</sdkComponents>
+		<boardId>evkmimxrt1170</boardId>
+		<package>MIMXRT1176DVMAA</package>
+		<core>cm7</core>
+		<coreId>cm7_MIMXRT1176xxxxx</coreId>
+	</storageModule>
+	<storageModule moduleId="com.crt.config">
+		<projectStorage>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&#13;
+&lt;TargetConfig&gt;&#13;
+&lt;Properties property_3="NXP" property_4="MIMXRT1176xxxxx" property_count="5" version="100300"/&gt;&#13;
+&lt;infoList vendor="NXP"&gt;&#13;
+&lt;info chip="MIMXRT1176xxxxx" name="MIMXRT1176xxxxx"&gt;&#13;
+&lt;chip&gt;&#13;
+&lt;name&gt;MIMXRT1176xxxxx&lt;/name&gt;&#13;
+&lt;family&gt;MIMXRT1170&lt;/family&gt;&#13;
+&lt;vendor&gt;NXP&lt;/vendor&gt;&#13;
+&lt;memory can_program="true" id="Flash" is_ro="true" size="0" type="Flash"/&gt;&#13;
+&lt;memory id="RAM" size="2048" type="RAM"/&gt;&#13;
+&lt;memoryInstance derived_from="Flash" driver="MIMXRT1170_SFDP_QSPI.cfx" edited="true" id="BOARD_FLASH" location="0x30000000" size="0x4000000"/&gt;&#13;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_DTC_cm7" location="0x20000000" size="0x40000"/&gt;&#13;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_ITC_cm7" location="0x0" size="0x40000"/&gt;&#13;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC1" location="0x20240000" size="0x80000"/&gt;&#13;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC2" location="0x202c0000" size="0x80000"/&gt;&#13;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC_ECC1" location="0x20340000" size="0x10000"/&gt;&#13;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC_ECC2" location="0x20350000" size="0x10000"/&gt;&#13;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC_cm7" location="0x20360000" size="0x20000"/&gt;&#13;
+&lt;memoryInstance derived_from="RAM" edited="true" id="BOARD_SDRAM" location="0x80000000" size="0x3000000"/&gt;&#13;
+&lt;memoryInstance derived_from="RAM" edited="true" id="NCACHE_REGION" location="0x83000000" size="0x1000000"/&gt;&#13;
+&lt;/chip&gt;&#13;
+&lt;processor&gt;&#13;
+&lt;name gcc_name="cortex-m4"&gt;Cortex-M4&lt;/name&gt;&#13;
+&lt;family&gt;Cortex-M&lt;/family&gt;&#13;
+&lt;/processor&gt;&#13;
+&lt;processor&gt;&#13;
+&lt;name gcc_name="cortex-m7"&gt;Cortex-M7&lt;/name&gt;&#13;
+&lt;family&gt;Cortex-M&lt;/family&gt;&#13;
+&lt;/processor&gt;&#13;
+&lt;/info&gt;&#13;
+&lt;/infoList&gt;&#13;
+&lt;/TargetConfig&gt;</projectStorage>
+	</storageModule>
+	<storageModule moduleId="refreshScope"/>
+</cproject>

--- a/IDE/MCUEXPRESSO/RT1170/wolfcrypt_test_cm7/.project
+++ b/IDE/MCUEXPRESSO/RT1170/wolfcrypt_test_cm7/.project
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>wolfcrypt_test_cm7</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>com.nxp.mcuxpresso.core.datamodels.sdkNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+	<linkedResources>
+		<link>
+			<name>source/test.c</name>
+			<type>1</type>
+			<locationURI>$%7BPARENT-4-PROJECT_LOC%7D/wolfcrypt/test/test.c</locationURI>
+		</link>
+		<link>
+			<name>source/wolfcrypt_test.c</name>
+			<type>1</type>
+			<locationURI>$%7BPARENT-2-PROJECT_LOC%7D/wolfcrypt_test.c</locationURI>
+		</link>
+	</linkedResources>
+</projectDescription>

--- a/IDE/MCUEXPRESSO/RT1170/wolfssl_cm7/.cproject
+++ b/IDE/MCUEXPRESSO/RT1170/wolfssl_cm7/.cproject
@@ -1,0 +1,568 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="com.crt.advproject.config.lib.debug.660509326">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.lib.debug.660509326" moduleId="org.eclipse.cdt.core.settings" name="Debug">
+				<externalSettings>
+					<externalSetting>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/wolfssl_cm7"/>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/wolfssl_cm7/Debug"/>
+						<entry flags="RESOLVED" kind="libraryFile" name="wolfssl_cm7" srcPrefixMapping="" srcRootPath=""/>
+					</externalSetting>
+				</externalSettings>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GNU_ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactExtension="a" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.staticLib" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.staticLib" cleanCommand="rm -rf" description="Debug build" errorParsers="org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.GASErrorParser" id="com.crt.advproject.config.lib.debug.660509326" name="Debug" parent="com.crt.advproject.config.lib.debug" postannouncebuildStep="Performing post-build steps" postbuildStep="arm-none-eabi-size &quot;lib${BuildArtifactFileName}&quot; ; # arm-none-eabi-objdump -h -S &quot;lib${BuildArtifactFileName}&quot; &gt;&quot;${BuildArtifactFileBaseName}.lss&quot;">
+					<folderInfo id="com.crt.advproject.config.lib.debug.660509326." name="/" resourcePath="">
+						<toolChain id="com.crt.advproject.toolchain.lib.debug.2134482499" name="NXP MCU Tools" superClass="com.crt.advproject.toolchain.lib.debug">
+							<targetPlatform binaryParser="org.eclipse.cdt.core.ELF;org.eclipse.cdt.core.GNU_ELF" id="com.crt.advproject.platform.lib.debug.910647871" name="ARM-based MCU (Debug)" superClass="com.crt.advproject.platform.lib.debug"/>
+							<builder buildPath="${workspace_loc:/wolfssl_cm7}/Debug" id="com.crt.advproject.builder.lib.debug.1000419719" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="Gnu Make Builder" superClass="com.crt.advproject.builder.lib.debug"/>
+							<tool id="com.crt.advproject.cpp.lib.debug.459834561" name="MCU C++ Compiler" superClass="com.crt.advproject.cpp.lib.debug">
+								<option id="com.crt.advproject.cpp.hdrlib.2100553326" name="Library headers" superClass="com.crt.advproject.cpp.hdrlib" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.fpu.963953115" name="Floating point" superClass="com.crt.advproject.cpp.fpu" useByScannerDiscovery="true" value="com.crt.advproject.cpp.fpu.fpv5sp.hard" valueType="enumerated"/>
+								<option id="com.crt.advproject.cpp.arch.2129896267" name="Architecture" superClass="com.crt.advproject.cpp.arch" useByScannerDiscovery="true" value="com.crt.advproject.cpp.target.cm7" valueType="enumerated"/>
+								<option id="com.crt.advproject.cpp.misc.dialect.687101470" name="Language standard" superClass="com.crt.advproject.cpp.misc.dialect" useByScannerDiscovery="true"/>
+								<option id="gnu.cpp.compiler.option.dialect.flags.263605232" name="Other dialect flags" superClass="gnu.cpp.compiler.option.dialect.flags" useByScannerDiscovery="true"/>
+								<option id="gnu.cpp.compiler.option.preprocessor.nostdinc.561199820" name="Do not search system directories (-nostdinc)" superClass="gnu.cpp.compiler.option.preprocessor.nostdinc" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.preprocessor.preprocess.614495568" name="Preprocess only (-E)" superClass="gnu.cpp.compiler.option.preprocessor.preprocess" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.preprocessor.def.214116909" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.preprocessor.undef.431358945" name="Undefined symbols (-U)" superClass="gnu.cpp.compiler.option.preprocessor.undef" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.include.paths.1440023715" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.include.files.819203263" name="Include files (-include)" superClass="gnu.cpp.compiler.option.include.files" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.optimization.flags.1185576695" name="Other optimization flags" superClass="gnu.cpp.compiler.option.optimization.flags" useByScannerDiscovery="false" value="-fno-common" valueType="string"/>
+								<option id="gnu.cpp.compiler.option.debugging.other.318773250" name="Other debugging flags" superClass="gnu.cpp.compiler.option.debugging.other" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.prof.1244192698" name="Generate prof information (-p)" superClass="gnu.cpp.compiler.option.debugging.prof" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.gprof.1594281194" name="Generate gprof information (-pg)" superClass="gnu.cpp.compiler.option.debugging.gprof" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.codecov.1474134306" name="Generate gcov information (-ftest-coverage -fprofile-arcs)" superClass="gnu.cpp.compiler.option.debugging.codecov" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.sanitaddress.2017172795" name="Sanitize address (-fsanitize=address)" superClass="gnu.cpp.compiler.option.debugging.sanitaddress" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.sanitpointers.1004529704" name="Sanitize pointer operations (-fsanitize=pointer-compare -fsanitize=pointer-subtract)" superClass="gnu.cpp.compiler.option.debugging.sanitpointers" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.sanitthread.968484722" name="Sanitize data race in multi-thread (-fsanitize=thread)" superClass="gnu.cpp.compiler.option.debugging.sanitthread" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.sanitleak.1706298916" name="Sanitize memory leak (-fsanitize=leak)" superClass="gnu.cpp.compiler.option.debugging.sanitleak" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.sanitundef.1598863713" name="Sanitize undefined behavior (-fsanitize=undefined)" superClass="gnu.cpp.compiler.option.debugging.sanitundef" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.syntax.316885306" name="Check syntax only (-fsyntax-only)" superClass="gnu.cpp.compiler.option.warnings.syntax" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.pedantic.1455197794" name="Pedantic (-pedantic)" superClass="gnu.cpp.compiler.option.warnings.pedantic" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.pedantic.error.890111260" name="Pedantic warnings as errors (-pedantic-errors)" superClass="gnu.cpp.compiler.option.warnings.pedantic.error" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.nowarn.469274586" name="Inhibit all warnings (-w)" superClass="gnu.cpp.compiler.option.warnings.nowarn" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.allwarn.599596050" name="All warnings (-Wall)" superClass="gnu.cpp.compiler.option.warnings.allwarn" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.extrawarn.515774781" name="Extra warnings (-Wextra)" superClass="gnu.cpp.compiler.option.warnings.extrawarn" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.toerrors.1855920289" name="Warnings as errors (-Werror)" superClass="gnu.cpp.compiler.option.warnings.toerrors" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wconversion.1420821502" name="Implicit conversion warnings (-Wconversion)" superClass="gnu.cpp.compiler.option.warnings.wconversion" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wcastalign.494492826" name="Pointer cast with different alignment (-Wcast-align)" superClass="gnu.cpp.compiler.option.warnings.wcastalign" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wcastqual.607634261" name="Removing type qualifier from cast target type (-Wcast-qual)" superClass="gnu.cpp.compiler.option.warnings.wcastqual" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wctordtorprivacy.1769638893" name="All ctor and dtor private (-Wctor-dtor-privacy)" superClass="gnu.cpp.compiler.option.warnings.wctordtorprivacy" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wdisabledopt.1375401202" name="Requested optimization pass is disabled (-Wdisabled-optimization)" superClass="gnu.cpp.compiler.option.warnings.wdisabledopt" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wlogicalop.209974854" name="Suspicious uses of logical operators (-Wlogical-op)" superClass="gnu.cpp.compiler.option.warnings.wlogicalop" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wmissingdecl.1116139116" name="Global function without previous declaration (-Wmissing-declarations)" superClass="gnu.cpp.compiler.option.warnings.wmissingdecl" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wmissingincdir.1272288561" name="User-supplied include directory does not exist (-Wmissing-include-dirs)" superClass="gnu.cpp.compiler.option.warnings.wmissingincdir" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wnoexccept.1522368041" name="Noexcept false but never throw exception (-Wnoexcept)" superClass="gnu.cpp.compiler.option.warnings.wnoexccept" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.woldstylecast.2052828644" name="C-style cast used (-Wold-style-cast)" superClass="gnu.cpp.compiler.option.warnings.woldstylecast" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.woverloadedvirtual.397290906" name="Function hides virtual functions from base class (-Woverloaded-virtual)" superClass="gnu.cpp.compiler.option.warnings.woverloadedvirtual" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wredundantdecl.1720110353" name="More than one declaration in the same scope (-Wredundant-decls)" superClass="gnu.cpp.compiler.option.warnings.wredundantdecl" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wshadow.908722553" name="Local symbol shadows upper scope symbol (-Wshadow)" superClass="gnu.cpp.compiler.option.warnings.wshadow" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wsignconv.406581147" name="Implicit conversions that may change the sign (-Wsign-conversion)" superClass="gnu.cpp.compiler.option.warnings.wsignconv" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wsignpromo.1146811456" name="Overload resolution promotes unsigned to signed type (-Wsign-promo)" superClass="gnu.cpp.compiler.option.warnings.wsignpromo" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wstrictnullsent.862209807" name="Use of an uncasted NULL as sentinel (-Wstrict-null-sentinel)" superClass="gnu.cpp.compiler.option.warnings.wstrictnullsent" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wswitchdef.213601760" name="A switch statement does not have a default case (-Wswitch-default)" superClass="gnu.cpp.compiler.option.warnings.wswitchdef" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wundef.546225197" name="An undefined identifier is evaluated in an #if directive (-Wundef)" superClass="gnu.cpp.compiler.option.warnings.wundef" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.weffcpp.1767860160" name="Effective C++ guidelines (-Weffc++)" superClass="gnu.cpp.compiler.option.warnings.weffcpp" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wfloatequal.1293355041" name="Direct float equal check (-Wfloat-equal)" superClass="gnu.cpp.compiler.option.warnings.wfloatequal" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.other.other.953501408" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.other.verbose.684426060" name="Verbose (-v)" superClass="gnu.cpp.compiler.option.other.verbose" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.other.pic.197436270" name="Position Independent Code (-fPIC)" superClass="gnu.cpp.compiler.option.other.pic" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.misc.hardening.1080152144" name="Hardening options (-fstack-protector-all -Wformat=2 -Wformat-security -Wstrict-overflow)" superClass="gnu.cpp.compiler.option.misc.hardening" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.misc.randomization.2038894476" name="Address randomization (-fPIE)" superClass="gnu.cpp.compiler.option.misc.randomization" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.lto.389677214" name="Enable Link-time optimization (-flto)" superClass="com.crt.advproject.cpp.lto" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.lto.fat.2020827070" name="Fat lto objects (-ffat-lto-objects)" superClass="com.crt.advproject.cpp.lto.fat" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.merge.constants.512400878" name="Merge Identical Constants (-fmerge-constants)" superClass="com.crt.advproject.cpp.merge.constants" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.prefixmap.1850212558" name="Remove path from __FILE__ (-fmacro-prefix-map)" superClass="com.crt.advproject.cpp.prefixmap" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.thumb.181857645" name="Thumb mode" superClass="com.crt.advproject.cpp.thumb" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.thumbinterwork.336648862" name="Enable Thumb interworking" superClass="com.crt.advproject.cpp.thumbinterwork" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.securestate.1154769768" name="TrustZone Project Type" superClass="com.crt.advproject.cpp.securestate" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.stackusage.1250864389" name="Generate Stack Usage Info (-fstack-usage)" superClass="com.crt.advproject.cpp.stackusage" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.specs.1514056701" name="Specs" superClass="com.crt.advproject.cpp.specs" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.config.114505987" name="Obsolete (Config)" superClass="com.crt.advproject.cpp.config" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.store.1949387593" name="Obsolete (Store)" superClass="com.crt.advproject.cpp.store" useByScannerDiscovery="false"/>
+							</tool>
+							<tool id="com.crt.advproject.gcc.lib.debug.1152720193" name="MCU C Compiler" superClass="com.crt.advproject.gcc.lib.debug">
+								<option id="com.crt.advproject.gcc.hdrlib.220030808" name="Library headers" superClass="com.crt.advproject.gcc.hdrlib" useByScannerDiscovery="false"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.767152025" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="__REDLIB__"/>
+									<listOptionValue builtIn="false" value="CACHE_MODE_WRITE_THROUGH=1"/>
+									<listOptionValue builtIn="false" value="CRYPTO_USE_DRIVER_CAAM"/>
+									<listOptionValue builtIn="false" value="WOLFSSL_USER_SETTINGS"/>
+									<listOptionValue builtIn="false" value="CPU_MIMXRT1176DVMAA"/>
+									<listOptionValue builtIn="false" value="CPU_MIMXRT1176DVMAA_cm7"/>
+									<listOptionValue builtIn="false" value="SDK_OS_BAREMETAL"/>
+									<listOptionValue builtIn="false" value="XIP_EXTERNAL_FLASH=1"/>
+									<listOptionValue builtIn="false" value="XIP_BOOT_HEADER_ENABLE=1"/>
+									<listOptionValue builtIn="false" value="SERIAL_PORT_TYPE_UART=1"/>
+									<listOptionValue builtIn="false" value="XIP_BOOT_HEADER_DCD_ENABLE=0"/>
+									<listOptionValue builtIn="false" value="XIP_BOOT_HEADER_XMCD_ENABLE=1"/>
+									<listOptionValue builtIn="false" value="SDK_DEBUGCONSOLE=1"/>
+									<listOptionValue builtIn="false" value="CR_INTEGER_PRINTF"/>
+									<listOptionValue builtIn="false" value="PRINTF_FLOAT_ENABLE=0"/>
+									<listOptionValue builtIn="false" value="SDK_OS_FREE_RTOS"/>
+									<listOptionValue builtIn="false" value="__MCUXPRESSO"/>
+									<listOptionValue builtIn="false" value="__USE_CMSIS"/>
+									<listOptionValue builtIn="false" value="DEBUG"/>
+								</option>
+								<option id="com.crt.advproject.gcc.fpu.612591090" name="Floating point" superClass="com.crt.advproject.gcc.fpu" useByScannerDiscovery="true" value="com.crt.advproject.gcc.fpu.fpv5sp.hard" valueType="enumerated"/>
+								<option id="com.crt.advproject.gcc.thumb.1562709377" name="Thumb mode" superClass="com.crt.advproject.gcc.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.gcc.arch.358086668" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="true" value="com.crt.advproject.gcc.target.cm7" valueType="enumerated"/>
+								<option id="com.crt.advproject.c.misc.dialect.133711888" name="Language standard" superClass="com.crt.advproject.c.misc.dialect" useByScannerDiscovery="true"/>
+								<option id="gnu.c.compiler.option.dialect.flags.365811475" name="Other dialect flags" superClass="gnu.c.compiler.option.dialect.flags" useByScannerDiscovery="true"/>
+								<option id="gnu.c.compiler.option.preprocessor.nostdinc.1874712935" name="Do not search system directories (-nostdinc)" superClass="gnu.c.compiler.option.preprocessor.nostdinc" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.preprocessor.preprocess.1376500109" name="Preprocess only (-E)" superClass="gnu.c.compiler.option.preprocessor.preprocess" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.preprocessor.undef.symbol.1093754962" name="Undefined symbols (-U)" superClass="gnu.c.compiler.option.preprocessor.undef.symbol" useByScannerDiscovery="false"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.302230714" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/portable/GCC/ARM_CM4F}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/xip}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/startup}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/template}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/portable/GCC/ARM_CM4F}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/xip}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/startup}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/template}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc}/&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc}/../../../&quot;"/>
+								</option>
+								<option id="gnu.c.compiler.option.include.files.1789513278" name="Include files (-include)" superClass="gnu.c.compiler.option.include.files" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.optimization.flags.451064375" name="Other optimization flags" superClass="gnu.c.compiler.option.optimization.flags" useByScannerDiscovery="false" value="-fno-common" valueType="string"/>
+								<option id="gnu.c.compiler.option.debugging.other.1119518893" name="Other debugging flags" superClass="gnu.c.compiler.option.debugging.other" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.prof.690821013" name="Generate prof information (-p)" superClass="gnu.c.compiler.option.debugging.prof" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.gprof.832006522" name="Generate gprof information (-pg)" superClass="gnu.c.compiler.option.debugging.gprof" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.codecov.1545691630" name="Generate gcov information (-ftest-coverage -fprofile-arcs)" superClass="gnu.c.compiler.option.debugging.codecov" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.sanitaddress.585726991" name="Sanitize address (-fsanitize=address)" superClass="gnu.c.compiler.option.debugging.sanitaddress" useByScannerDiscovery="false" value="false" valueType="boolean"/>
+								<option id="gnu.c.compiler.option.debugging.sanitpointers.234293262" name="Sanitize pointer operations (-fsanitize=pointer-compare -fsanitize=pointer-subtract)" superClass="gnu.c.compiler.option.debugging.sanitpointers" useByScannerDiscovery="false" value="false" valueType="boolean"/>
+								<option id="gnu.c.compiler.option.debugging.sanitthread.1916215472" name="Sanitize data race in multi-thread (-fsanitize=thread)" superClass="gnu.c.compiler.option.debugging.sanitthread" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.sanitleak.851974951" name="Sanitize memory leak (-fsanitize=leak)" superClass="gnu.c.compiler.option.debugging.sanitleak" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.sanitundef.694689494" name="Sanitize undefined behavior (-fsanitize=undefined)" superClass="gnu.c.compiler.option.debugging.sanitundef" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.syntax.1570777246" name="Check syntax only (-fsyntax-only)" superClass="gnu.c.compiler.option.warnings.syntax" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.pedantic.1933782937" name="Pedantic (-pedantic)" superClass="gnu.c.compiler.option.warnings.pedantic" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.pedantic.error.1765068526" name="Pedantic warnings as errors (-pedantic-errors)" superClass="gnu.c.compiler.option.warnings.pedantic.error" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.nowarn.744350707" name="Inhibit all warnings (-w)" superClass="gnu.c.compiler.option.warnings.nowarn" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.allwarn.1045927981" name="All warnings (-Wall)" superClass="gnu.c.compiler.option.warnings.allwarn" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.extrawarn.787029645" name="Extra warnings (-Wextra)" superClass="gnu.c.compiler.option.warnings.extrawarn" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.toerrors.425916028" name="Warnings as errors (-Werror)" superClass="gnu.c.compiler.option.warnings.toerrors" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wconversion.1567575837" name="Implicit conversion warnings (-Wconversion)" superClass="gnu.c.compiler.option.warnings.wconversion" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wcastalign.1843959555" name="Pointer cast with different alignment (-Wcast-align)" superClass="gnu.c.compiler.option.warnings.wcastalign" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wcastqual.910485523" name="Removing type qualifier from cast target type (-Wcast-qual)" superClass="gnu.c.compiler.option.warnings.wcastqual" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wdisabledopt.517885289" name="Requested optimization pass is disabled (-Wdisabled-optimization)" superClass="gnu.c.compiler.option.warnings.wdisabledopt" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wlogicalop.2003098935" name="Suspicious uses of logical operators (-Wlogical-op)" superClass="gnu.c.compiler.option.warnings.wlogicalop" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wmissingdecl.966833858" name="Global function without previous declaration (-Wmissing-declarations)" superClass="gnu.c.compiler.option.warnings.wmissingdecl" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wmissingincdir.150182090" name="User-supplied include directory does not exist (-Wmissing-include-dirs)" superClass="gnu.c.compiler.option.warnings.wmissingincdir" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wredundantdecl.1471477634" name="More than one declaration in the same scope (-Wredundant-decls)" superClass="gnu.c.compiler.option.warnings.wredundantdecl" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wshadow.1807466768" name="Local symbol shadows upper scope symbol (-Wshadow)" superClass="gnu.c.compiler.option.warnings.wshadow" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wsignconv.1096885110" name="Implicit conversions that may change the sign (-Wsign-conversion)" superClass="gnu.c.compiler.option.warnings.wsignconv" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wswitchdef.1115312387" name="A switch statement does not have a default case (-Wswitch-default)" superClass="gnu.c.compiler.option.warnings.wswitchdef" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wundef.247342796" name="An undefined identifier is evaluated in an #if directive (-Wundef)" superClass="gnu.c.compiler.option.warnings.wundef" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wwritestrings.2086090483" name="Treat strings always as const (-Wwrite-strings)" superClass="gnu.c.compiler.option.warnings.wwritestrings" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wfloatequal.773042988" name="Direct float equal check (-Wfloat-equal)" superClass="gnu.c.compiler.option.warnings.wfloatequal" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.misc.other.1460609361" name="Other flags" superClass="gnu.c.compiler.option.misc.other" useByScannerDiscovery="false" value="-c -ffunction-sections -fdata-sections -ffreestanding -fno-builtin" valueType="string"/>
+								<option id="gnu.c.compiler.option.misc.verbose.17003853" name="Verbose (-v)" superClass="gnu.c.compiler.option.misc.verbose" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.misc.ansi.710379046" name="Support ANSI programs (-ansi)" superClass="gnu.c.compiler.option.misc.ansi" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.misc.pic.1744689431" name="Position Independent Code (-fPIC)" superClass="gnu.c.compiler.option.misc.pic" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.misc.hardening.977387458" name="Hardening options (-fstack-protector-all -Wformat=2 -Wformat-security -Wstrict-overflow)" superClass="gnu.c.compiler.option.misc.hardening" useByScannerDiscovery="false" value="false" valueType="boolean"/>
+								<option id="gnu.c.compiler.option.misc.randomization.384445971" name="Address randomization (-fPIE)" superClass="gnu.c.compiler.option.misc.randomization" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.lto.1039738915" name="Enable Link-time optimization (-flto)" superClass="com.crt.advproject.gcc.lto" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.lto.fat.1591885229" name="Fat lto objects (-ffat-lto-objects)" superClass="com.crt.advproject.gcc.lto.fat" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.merge.constants.782243715" name="Merge Identical Constants (-fmerge-constants)" superClass="com.crt.advproject.gcc.merge.constants" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.prefixmap.2125090610" name="Remove path from __FILE__ (-fmacro-prefix-map)" superClass="com.crt.advproject.gcc.prefixmap" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.thumbinterwork.497019526" name="Enable Thumb interworking" superClass="com.crt.advproject.gcc.thumbinterwork" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.securestate.963494315" name="TrustZone Project Type" superClass="com.crt.advproject.gcc.securestate" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.stackusage.1019397991" name="Generate Stack Usage Info (-fstack-usage)" superClass="com.crt.advproject.gcc.stackusage" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.specs.1698445153" name="Specs" superClass="com.crt.advproject.gcc.specs" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.config.1147702821" name="Obsolete (Config)" superClass="com.crt.advproject.gcc.config" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.store.119918017" name="Obsolete (Store)" superClass="com.crt.advproject.gcc.store" useByScannerDiscovery="false"/>
+								<inputType id="com.crt.advproject.compiler.input.844879104" superClass="com.crt.advproject.compiler.input"/>
+							</tool>
+							<tool id="com.crt.advproject.gas.lib.debug.171854801" name="MCU Assembler" superClass="com.crt.advproject.gas.lib.debug">
+								<option id="com.crt.advproject.gas.hdrlib.920076413" name="Library headers" superClass="com.crt.advproject.gas.hdrlib"/>
+								<option id="com.crt.advproject.gas.fpu.1824804057" name="Floating point" superClass="com.crt.advproject.gas.fpu" value="com.crt.advproject.gas.fpu.fpv5sp.hard" valueType="enumerated"/>
+								<option id="com.crt.advproject.gas.thumb.1488347708" name="Thumb mode" superClass="com.crt.advproject.gas.thumb" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.gas.arch.1533167305" name="Architecture" superClass="com.crt.advproject.gas.arch" value="com.crt.advproject.gas.target.cm7" valueType="enumerated"/>
+								<option id="gnu.both.asm.option.flags.crt.1090764721" name="Assembler flags" superClass="gnu.both.asm.option.flags.crt" value="-c -x assembler-with-cpp -D__REDLIB__" valueType="string"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.both.asm.option.include.paths.1880841114" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
+								</option>
+								<option id="gnu.both.asm.option.warnings.nowarn.1228751868" name="Suppress warnings (-W)" superClass="gnu.both.asm.option.warnings.nowarn"/>
+								<option id="gnu.both.asm.option.version.683152087" name="Announce version (-v)" superClass="gnu.both.asm.option.version"/>
+								<option id="com.crt.advproject.gas.thumbinterwork.555532609" name="Enable Thumb interworking" superClass="com.crt.advproject.gas.thumbinterwork"/>
+								<option id="com.crt.advproject.gas.specs.102398662" name="Specs" superClass="com.crt.advproject.gas.specs"/>
+								<option id="com.crt.advproject.gas.config.145007414" name="Obsolete (Config)" superClass="com.crt.advproject.gas.config"/>
+								<option id="com.crt.advproject.gas.store.1034406628" name="Obsolete (Store)" superClass="com.crt.advproject.gas.store"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.1439140546" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+								<inputType id="com.crt.advproject.assembler.input.2019759218" name="Additional Assembly Source Files" superClass="com.crt.advproject.assembler.input"/>
+							</tool>
+							<tool id="com.crt.advproject.ar.lib.debug.1567626354" name="MCU Archiver" superClass="com.crt.advproject.ar.lib.debug"/>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="CMSIS"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="board"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="component"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="device"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="drivers"/>
+						<entry excluding="freertos_kernel/portable/MemMang/heap_1.c|freertos_kernel/portable/MemMang/heap_2.c|freertos_kernel/portable/MemMang/heap_3.c|freertos_kernel/portable/MemMang/heap_5.c" flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="freertos"/>
+						<entry excluding="src/netif/ppp/polarssl/arc4.c|src/netif/ppp/polarssl/des.c|src/netif/ppp/polarssl/md4.c|src/netif/ppp/polarssl/md5.c|src/netif/ppp/polarssl/sha1.c" flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="lwip"/>
+						<entry excluding="wolfcrypt/src/misc.c|src/x509.c|src/x509_str.c|wolfcrypt/src/evp.c|src/conf.c|src/pk.c|src/bio.c|wolfcrypt/src/wc_kyber_asm.S|wolfcrypt/src/sp_x86_64_asm.S|wolfcrypt/src/sp_x86_64_asm.asm|wolfcrypt/src/sha512_asm.S|wolfcrypt/src/sha3_asm.S|wolfcrypt/src/sha256_asm.S|wolfcrypt/src/poly1305_asm.S|wolfcrypt/src/fe_x25519_asm.S|wolfcrypt/src/port|wolfcrypt/src/chacha_asm.S|wolfcrypt/src/aes_gcm_x86_asm.S|wolfcrypt/src/aes_gcm_asm.S|wolfcrypt/src/aes_asm.S|wolfcrypt/src/aes_asm.asm|wolfcrypt/user-crypto|wolfcrypt/test|wolfcrypt/benchmark" flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="source"/>
+						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="source/wolfcrypt/src/port/caam"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="startup"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="utilities"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="xip"/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
+		<cconfiguration id="com.crt.advproject.config.lib.release.239942709">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.lib.release.239942709" moduleId="org.eclipse.cdt.core.settings" name="Release">
+				<externalSettings>
+					<externalSetting>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/wolfssl_cm7"/>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/wolfssl_cm7/Release"/>
+						<entry flags="RESOLVED" kind="libraryFile" name="wolfssl_cm7" srcPrefixMapping="" srcRootPath=""/>
+					</externalSetting>
+				</externalSettings>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GNU_ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactExtension="a" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.staticLib" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.staticLib" cleanCommand="rm -rf" description="Release build" errorParsers="org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.GASErrorParser" id="com.crt.advproject.config.lib.release.239942709" name="Release" parent="com.crt.advproject.config.lib.release" postannouncebuildStep="Performing post-build steps" postbuildStep="arm-none-eabi-size &quot;lib${BuildArtifactFileName}&quot; ; # arm-none-eabi-objdump -h -S &quot;lib${BuildArtifactFileName}&quot; &gt;&quot;${BuildArtifactFileBaseName}.lss&quot;">
+					<folderInfo id="com.crt.advproject.config.lib.release.239942709." name="/" resourcePath="">
+						<toolChain id="com.crt.advproject.toolchain.lib.release.1648326413" name="NXP MCU Tools" superClass="com.crt.advproject.toolchain.lib.release">
+							<targetPlatform binaryParser="org.eclipse.cdt.core.ELF;org.eclipse.cdt.core.GNU_ELF" id="com.crt.advproject.platform.lib.release.1400359171" name="ARM-based MCU (Debug)" superClass="com.crt.advproject.platform.lib.release"/>
+							<builder buildPath="${workspace_loc:/wolfssl_cm7}/Release" id="com.crt.advproject.builder.lib.release.519882194" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="Gnu Make Builder" superClass="com.crt.advproject.builder.lib.release"/>
+							<tool id="com.crt.advproject.cpp.lib.release.625867485" name="MCU C++ Compiler" superClass="com.crt.advproject.cpp.lib.release">
+								<option id="com.crt.advproject.cpp.arch.1833209608" name="Architecture" superClass="com.crt.advproject.cpp.arch" useByScannerDiscovery="true" value="com.crt.advproject.cpp.target.cm7" valueType="enumerated"/>
+								<option id="com.crt.advproject.cpp.misc.dialect.1160819554" name="Language standard" superClass="com.crt.advproject.cpp.misc.dialect" useByScannerDiscovery="true"/>
+								<option id="gnu.cpp.compiler.option.dialect.flags.247651663" name="Other dialect flags" superClass="gnu.cpp.compiler.option.dialect.flags" useByScannerDiscovery="true"/>
+								<option id="gnu.cpp.compiler.option.preprocessor.nostdinc.537651818" name="Do not search system directories (-nostdinc)" superClass="gnu.cpp.compiler.option.preprocessor.nostdinc" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.preprocessor.preprocess.1522803765" name="Preprocess only (-E)" superClass="gnu.cpp.compiler.option.preprocessor.preprocess" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.preprocessor.def.1673290116" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.preprocessor.undef.1725720101" name="Undefined symbols (-U)" superClass="gnu.cpp.compiler.option.preprocessor.undef" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.include.paths.1040487869" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.include.files.1046336636" name="Include files (-include)" superClass="gnu.cpp.compiler.option.include.files" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.optimization.flags.1552487828" name="Other optimization flags" superClass="gnu.cpp.compiler.option.optimization.flags" useByScannerDiscovery="false" value="-fno-common" valueType="string"/>
+								<option id="gnu.cpp.compiler.option.debugging.other.1009181026" name="Other debugging flags" superClass="gnu.cpp.compiler.option.debugging.other" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.prof.929772896" name="Generate prof information (-p)" superClass="gnu.cpp.compiler.option.debugging.prof" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.gprof.1468571704" name="Generate gprof information (-pg)" superClass="gnu.cpp.compiler.option.debugging.gprof" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.codecov.1798309027" name="Generate gcov information (-ftest-coverage -fprofile-arcs)" superClass="gnu.cpp.compiler.option.debugging.codecov" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.sanitaddress.1364040588" name="Sanitize address (-fsanitize=address)" superClass="gnu.cpp.compiler.option.debugging.sanitaddress" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.sanitpointers.1037703059" name="Sanitize pointer operations (-fsanitize=pointer-compare -fsanitize=pointer-subtract)" superClass="gnu.cpp.compiler.option.debugging.sanitpointers" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.sanitthread.122618216" name="Sanitize data race in multi-thread (-fsanitize=thread)" superClass="gnu.cpp.compiler.option.debugging.sanitthread" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.sanitleak.95121396" name="Sanitize memory leak (-fsanitize=leak)" superClass="gnu.cpp.compiler.option.debugging.sanitleak" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.debugging.sanitundef.22097213" name="Sanitize undefined behavior (-fsanitize=undefined)" superClass="gnu.cpp.compiler.option.debugging.sanitundef" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.syntax.1971328161" name="Check syntax only (-fsyntax-only)" superClass="gnu.cpp.compiler.option.warnings.syntax" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.pedantic.921159241" name="Pedantic (-pedantic)" superClass="gnu.cpp.compiler.option.warnings.pedantic" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.pedantic.error.183004879" name="Pedantic warnings as errors (-pedantic-errors)" superClass="gnu.cpp.compiler.option.warnings.pedantic.error" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.nowarn.769523540" name="Inhibit all warnings (-w)" superClass="gnu.cpp.compiler.option.warnings.nowarn" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.allwarn.1495235412" name="All warnings (-Wall)" superClass="gnu.cpp.compiler.option.warnings.allwarn" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.extrawarn.1182257988" name="Extra warnings (-Wextra)" superClass="gnu.cpp.compiler.option.warnings.extrawarn" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.toerrors.1326817575" name="Warnings as errors (-Werror)" superClass="gnu.cpp.compiler.option.warnings.toerrors" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wconversion.1113636698" name="Implicit conversion warnings (-Wconversion)" superClass="gnu.cpp.compiler.option.warnings.wconversion" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wcastalign.1248304429" name="Pointer cast with different alignment (-Wcast-align)" superClass="gnu.cpp.compiler.option.warnings.wcastalign" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wcastqual.417345370" name="Removing type qualifier from cast target type (-Wcast-qual)" superClass="gnu.cpp.compiler.option.warnings.wcastqual" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wctordtorprivacy.1362038340" name="All ctor and dtor private (-Wctor-dtor-privacy)" superClass="gnu.cpp.compiler.option.warnings.wctordtorprivacy" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wdisabledopt.2061285182" name="Requested optimization pass is disabled (-Wdisabled-optimization)" superClass="gnu.cpp.compiler.option.warnings.wdisabledopt" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wlogicalop.565878104" name="Suspicious uses of logical operators (-Wlogical-op)" superClass="gnu.cpp.compiler.option.warnings.wlogicalop" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wmissingdecl.714731573" name="Global function without previous declaration (-Wmissing-declarations)" superClass="gnu.cpp.compiler.option.warnings.wmissingdecl" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wmissingincdir.990634286" name="User-supplied include directory does not exist (-Wmissing-include-dirs)" superClass="gnu.cpp.compiler.option.warnings.wmissingincdir" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wnoexccept.1871257788" name="Noexcept false but never throw exception (-Wnoexcept)" superClass="gnu.cpp.compiler.option.warnings.wnoexccept" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.woldstylecast.1119159257" name="C-style cast used (-Wold-style-cast)" superClass="gnu.cpp.compiler.option.warnings.woldstylecast" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.woverloadedvirtual.2044743081" name="Function hides virtual functions from base class (-Woverloaded-virtual)" superClass="gnu.cpp.compiler.option.warnings.woverloadedvirtual" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wredundantdecl.896992527" name="More than one declaration in the same scope (-Wredundant-decls)" superClass="gnu.cpp.compiler.option.warnings.wredundantdecl" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wshadow.758370568" name="Local symbol shadows upper scope symbol (-Wshadow)" superClass="gnu.cpp.compiler.option.warnings.wshadow" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wsignconv.1030531339" name="Implicit conversions that may change the sign (-Wsign-conversion)" superClass="gnu.cpp.compiler.option.warnings.wsignconv" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wsignpromo.929930941" name="Overload resolution promotes unsigned to signed type (-Wsign-promo)" superClass="gnu.cpp.compiler.option.warnings.wsignpromo" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wstrictnullsent.2114443862" name="Use of an uncasted NULL as sentinel (-Wstrict-null-sentinel)" superClass="gnu.cpp.compiler.option.warnings.wstrictnullsent" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wswitchdef.83804802" name="A switch statement does not have a default case (-Wswitch-default)" superClass="gnu.cpp.compiler.option.warnings.wswitchdef" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wundef.1670304203" name="An undefined identifier is evaluated in an #if directive (-Wundef)" superClass="gnu.cpp.compiler.option.warnings.wundef" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.weffcpp.1136346557" name="Effective C++ guidelines (-Weffc++)" superClass="gnu.cpp.compiler.option.warnings.weffcpp" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.warnings.wfloatequal.1571892795" name="Direct float equal check (-Wfloat-equal)" superClass="gnu.cpp.compiler.option.warnings.wfloatequal" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.other.other.1791730747" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.other.verbose.980821976" name="Verbose (-v)" superClass="gnu.cpp.compiler.option.other.verbose" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.other.pic.964620530" name="Position Independent Code (-fPIC)" superClass="gnu.cpp.compiler.option.other.pic" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.misc.hardening.1295744080" name="Hardening options (-fstack-protector-all -Wformat=2 -Wformat-security -Wstrict-overflow)" superClass="gnu.cpp.compiler.option.misc.hardening" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.misc.randomization.96116220" name="Address randomization (-fPIE)" superClass="gnu.cpp.compiler.option.misc.randomization" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.lto.1918658353" name="Enable Link-time optimization (-flto)" superClass="com.crt.advproject.cpp.lto" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.lto.fat.1966263117" name="Fat lto objects (-ffat-lto-objects)" superClass="com.crt.advproject.cpp.lto.fat" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.merge.constants.1975417933" name="Merge Identical Constants (-fmerge-constants)" superClass="com.crt.advproject.cpp.merge.constants" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.prefixmap.345999428" name="Remove path from __FILE__ (-fmacro-prefix-map)" superClass="com.crt.advproject.cpp.prefixmap" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.fpu.126216763" name="Floating point" superClass="com.crt.advproject.cpp.fpu" useByScannerDiscovery="true" value="com.crt.advproject.cpp.fpu.fpv5sp.hard" valueType="enumerated"/>
+								<option id="com.crt.advproject.cpp.thumb.1212100109" name="Thumb mode" superClass="com.crt.advproject.cpp.thumb" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.thumbinterwork.279670760" name="Enable Thumb interworking" superClass="com.crt.advproject.cpp.thumbinterwork" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.securestate.316255578" name="TrustZone Project Type" superClass="com.crt.advproject.cpp.securestate" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.hdrlib.855679860" name="Library headers" superClass="com.crt.advproject.cpp.hdrlib" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.stackusage.746901584" name="Generate Stack Usage Info (-fstack-usage)" superClass="com.crt.advproject.cpp.stackusage" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.specs.1226381" name="Specs" superClass="com.crt.advproject.cpp.specs" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.config.663156806" name="Obsolete (Config)" superClass="com.crt.advproject.cpp.config" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.store.436480413" name="Obsolete (Store)" superClass="com.crt.advproject.cpp.store" useByScannerDiscovery="false"/>
+							</tool>
+							<tool id="com.crt.advproject.gcc.lib.release.1132876870" name="MCU C Compiler" superClass="com.crt.advproject.gcc.lib.release">
+								<option id="com.crt.advproject.gcc.thumb.1707583760" name="Thumb mode" superClass="com.crt.advproject.gcc.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.gcc.arch.125368482" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="true" value="com.crt.advproject.gcc.target.cm7" valueType="enumerated"/>
+								<option id="com.crt.advproject.c.misc.dialect.1035034812" name="Language standard" superClass="com.crt.advproject.c.misc.dialect" useByScannerDiscovery="true"/>
+								<option id="gnu.c.compiler.option.dialect.flags.1611695577" name="Other dialect flags" superClass="gnu.c.compiler.option.dialect.flags" useByScannerDiscovery="true"/>
+								<option id="gnu.c.compiler.option.preprocessor.nostdinc.408350891" name="Do not search system directories (-nostdinc)" superClass="gnu.c.compiler.option.preprocessor.nostdinc" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.preprocessor.preprocess.1342999385" name="Preprocess only (-E)" superClass="gnu.c.compiler.option.preprocessor.preprocess" useByScannerDiscovery="false"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.1355047562" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="__REDLIB__"/>
+									<listOptionValue builtIn="false" value="WOLFSSL_USER_SETTINGS"/>
+									<listOptionValue builtIn="false" value="CPU_MIMXRT1176DVMAA"/>
+									<listOptionValue builtIn="false" value="CPU_MIMXRT1176DVMAA_cm7"/>
+									<listOptionValue builtIn="false" value="SDK_OS_BAREMETAL"/>
+									<listOptionValue builtIn="false" value="XIP_EXTERNAL_FLASH=1"/>
+									<listOptionValue builtIn="false" value="XIP_BOOT_HEADER_ENABLE=1"/>
+									<listOptionValue builtIn="false" value="SERIAL_PORT_TYPE_UART=1"/>
+									<listOptionValue builtIn="false" value="XIP_BOOT_HEADER_DCD_ENABLE=0"/>
+									<listOptionValue builtIn="false" value="XIP_BOOT_HEADER_XMCD_ENABLE=1"/>
+									<listOptionValue builtIn="false" value="SDK_DEBUGCONSOLE=1"/>
+									<listOptionValue builtIn="false" value="CR_INTEGER_PRINTF"/>
+									<listOptionValue builtIn="false" value="PRINTF_FLOAT_ENABLE=0"/>
+									<listOptionValue builtIn="false" value="SDK_OS_FREE_RTOS"/>
+									<listOptionValue builtIn="false" value="__MCUXPRESSO"/>
+									<listOptionValue builtIn="false" value="__USE_CMSIS"/>
+									<listOptionValue builtIn="false" value="DEBUG"/>
+								</option>
+								<option id="gnu.c.compiler.option.preprocessor.undef.symbol.1669159764" name="Undefined symbols (-U)" superClass="gnu.c.compiler.option.preprocessor.undef.symbol" useByScannerDiscovery="false"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.621266527" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/portable/GCC/ARM_CM4F}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/xip}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/startup}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/template}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/freertos/freertos_kernel/portable/GCC/ARM_CM4F}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/xip}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/startup}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/template}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc}/&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc}/../../../&quot;"/>
+								</option>
+								<option id="gnu.c.compiler.option.include.files.1717164921" name="Include files (-include)" superClass="gnu.c.compiler.option.include.files" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.optimization.flags.2007907620" name="Other optimization flags" superClass="gnu.c.compiler.option.optimization.flags" useByScannerDiscovery="false" value="-fno-common" valueType="string"/>
+								<option id="gnu.c.compiler.option.debugging.other.1541231845" name="Other debugging flags" superClass="gnu.c.compiler.option.debugging.other" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.prof.1834530940" name="Generate prof information (-p)" superClass="gnu.c.compiler.option.debugging.prof" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.gprof.2069205534" name="Generate gprof information (-pg)" superClass="gnu.c.compiler.option.debugging.gprof" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.codecov.296563773" name="Generate gcov information (-ftest-coverage -fprofile-arcs)" superClass="gnu.c.compiler.option.debugging.codecov" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.sanitaddress.658837286" name="Sanitize address (-fsanitize=address)" superClass="gnu.c.compiler.option.debugging.sanitaddress" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.sanitpointers.2141989705" name="Sanitize pointer operations (-fsanitize=pointer-compare -fsanitize=pointer-subtract)" superClass="gnu.c.compiler.option.debugging.sanitpointers" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.sanitthread.1704289832" name="Sanitize data race in multi-thread (-fsanitize=thread)" superClass="gnu.c.compiler.option.debugging.sanitthread" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.sanitleak.824573371" name="Sanitize memory leak (-fsanitize=leak)" superClass="gnu.c.compiler.option.debugging.sanitleak" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.debugging.sanitundef.145799824" name="Sanitize undefined behavior (-fsanitize=undefined)" superClass="gnu.c.compiler.option.debugging.sanitundef" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.syntax.1855797626" name="Check syntax only (-fsyntax-only)" superClass="gnu.c.compiler.option.warnings.syntax" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.pedantic.685150842" name="Pedantic (-pedantic)" superClass="gnu.c.compiler.option.warnings.pedantic" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.pedantic.error.176104783" name="Pedantic warnings as errors (-pedantic-errors)" superClass="gnu.c.compiler.option.warnings.pedantic.error" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.nowarn.679726547" name="Inhibit all warnings (-w)" superClass="gnu.c.compiler.option.warnings.nowarn" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.allwarn.793652609" name="All warnings (-Wall)" superClass="gnu.c.compiler.option.warnings.allwarn" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.extrawarn.1707051763" name="Extra warnings (-Wextra)" superClass="gnu.c.compiler.option.warnings.extrawarn" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.toerrors.1203275791" name="Warnings as errors (-Werror)" superClass="gnu.c.compiler.option.warnings.toerrors" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wconversion.1236879761" name="Implicit conversion warnings (-Wconversion)" superClass="gnu.c.compiler.option.warnings.wconversion" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wcastalign.1960526444" name="Pointer cast with different alignment (-Wcast-align)" superClass="gnu.c.compiler.option.warnings.wcastalign" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wcastqual.957972874" name="Removing type qualifier from cast target type (-Wcast-qual)" superClass="gnu.c.compiler.option.warnings.wcastqual" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wdisabledopt.347420749" name="Requested optimization pass is disabled (-Wdisabled-optimization)" superClass="gnu.c.compiler.option.warnings.wdisabledopt" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wlogicalop.1127709174" name="Suspicious uses of logical operators (-Wlogical-op)" superClass="gnu.c.compiler.option.warnings.wlogicalop" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wmissingdecl.1255285063" name="Global function without previous declaration (-Wmissing-declarations)" superClass="gnu.c.compiler.option.warnings.wmissingdecl" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wmissingincdir.1063505434" name="User-supplied include directory does not exist (-Wmissing-include-dirs)" superClass="gnu.c.compiler.option.warnings.wmissingincdir" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wredundantdecl.1309275051" name="More than one declaration in the same scope (-Wredundant-decls)" superClass="gnu.c.compiler.option.warnings.wredundantdecl" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wshadow.891795222" name="Local symbol shadows upper scope symbol (-Wshadow)" superClass="gnu.c.compiler.option.warnings.wshadow" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wsignconv.173764719" name="Implicit conversions that may change the sign (-Wsign-conversion)" superClass="gnu.c.compiler.option.warnings.wsignconv" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wswitchdef.210773064" name="A switch statement does not have a default case (-Wswitch-default)" superClass="gnu.c.compiler.option.warnings.wswitchdef" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wundef.1256939913" name="An undefined identifier is evaluated in an #if directive (-Wundef)" superClass="gnu.c.compiler.option.warnings.wundef" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wwritestrings.632103444" name="Treat strings always as const (-Wwrite-strings)" superClass="gnu.c.compiler.option.warnings.wwritestrings" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.warnings.wfloatequal.156707842" name="Direct float equal check (-Wfloat-equal)" superClass="gnu.c.compiler.option.warnings.wfloatequal" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.misc.other.1353278998" name="Other flags" superClass="gnu.c.compiler.option.misc.other" useByScannerDiscovery="false" value="-c -ffunction-sections -fdata-sections -ffreestanding -fno-builtin" valueType="string"/>
+								<option id="gnu.c.compiler.option.misc.verbose.770612554" name="Verbose (-v)" superClass="gnu.c.compiler.option.misc.verbose" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.misc.ansi.828558018" name="Support ANSI programs (-ansi)" superClass="gnu.c.compiler.option.misc.ansi" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.misc.pic.1382295786" name="Position Independent Code (-fPIC)" superClass="gnu.c.compiler.option.misc.pic" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.misc.hardening.1946463823" name="Hardening options (-fstack-protector-all -Wformat=2 -Wformat-security -Wstrict-overflow)" superClass="gnu.c.compiler.option.misc.hardening" useByScannerDiscovery="false"/>
+								<option id="gnu.c.compiler.option.misc.randomization.1855739181" name="Address randomization (-fPIE)" superClass="gnu.c.compiler.option.misc.randomization" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.lto.915147305" name="Enable Link-time optimization (-flto)" superClass="com.crt.advproject.gcc.lto" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.lto.fat.838394078" name="Fat lto objects (-ffat-lto-objects)" superClass="com.crt.advproject.gcc.lto.fat" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.merge.constants.725346079" name="Merge Identical Constants (-fmerge-constants)" superClass="com.crt.advproject.gcc.merge.constants" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.prefixmap.1579615629" name="Remove path from __FILE__ (-fmacro-prefix-map)" superClass="com.crt.advproject.gcc.prefixmap" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.fpu.773496224" name="Floating point" superClass="com.crt.advproject.gcc.fpu" useByScannerDiscovery="true" value="com.crt.advproject.gcc.fpu.fpv5sp.hard" valueType="enumerated"/>
+								<option id="com.crt.advproject.gcc.thumbinterwork.1185300522" name="Enable Thumb interworking" superClass="com.crt.advproject.gcc.thumbinterwork" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.securestate.70193237" name="TrustZone Project Type" superClass="com.crt.advproject.gcc.securestate" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.hdrlib.251671447" name="Library headers" superClass="com.crt.advproject.gcc.hdrlib" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.stackusage.321578096" name="Generate Stack Usage Info (-fstack-usage)" superClass="com.crt.advproject.gcc.stackusage" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.specs.1303423107" name="Specs" superClass="com.crt.advproject.gcc.specs" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.config.262178595" name="Obsolete (Config)" superClass="com.crt.advproject.gcc.config" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.store.628497258" name="Obsolete (Store)" superClass="com.crt.advproject.gcc.store" useByScannerDiscovery="false"/>
+								<inputType id="com.crt.advproject.compiler.input.1310027785" superClass="com.crt.advproject.compiler.input"/>
+							</tool>
+							<tool id="com.crt.advproject.gas.lib.release.1061690888" name="MCU Assembler" superClass="com.crt.advproject.gas.lib.release">
+								<option id="com.crt.advproject.gas.thumb.287642586" name="Thumb mode" superClass="com.crt.advproject.gas.thumb" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.gas.arch.1262851133" name="Architecture" superClass="com.crt.advproject.gas.arch" value="com.crt.advproject.gas.target.cm7" valueType="enumerated"/>
+								<option id="gnu.both.asm.option.flags.crt.1622844346" name="Assembler flags" superClass="gnu.both.asm.option.flags.crt" value="-c -x assembler-with-cpp -D__REDLIB__" valueType="string"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.both.asm.option.include.paths.2091075857" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
+								</option>
+								<option id="gnu.both.asm.option.warnings.nowarn.603769276" name="Suppress warnings (-W)" superClass="gnu.both.asm.option.warnings.nowarn"/>
+								<option id="gnu.both.asm.option.version.1950743218" name="Announce version (-v)" superClass="gnu.both.asm.option.version"/>
+								<option id="com.crt.advproject.gas.fpu.766332852" name="Floating point" superClass="com.crt.advproject.gas.fpu" value="com.crt.advproject.gas.fpu.fpv5sp.hard" valueType="enumerated"/>
+								<option id="com.crt.advproject.gas.thumbinterwork.1417335195" name="Enable Thumb interworking" superClass="com.crt.advproject.gas.thumbinterwork"/>
+								<option id="com.crt.advproject.gas.hdrlib.321813953" name="Library headers" superClass="com.crt.advproject.gas.hdrlib"/>
+								<option id="com.crt.advproject.gas.specs.264210339" name="Specs" superClass="com.crt.advproject.gas.specs"/>
+								<option id="com.crt.advproject.gas.config.312066026" name="Obsolete (Config)" superClass="com.crt.advproject.gas.config"/>
+								<option id="com.crt.advproject.gas.store.1868278876" name="Obsolete (Store)" superClass="com.crt.advproject.gas.store"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.790399076" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+								<inputType id="com.crt.advproject.assembler.input.1852831511" name="Additional Assembly Source Files" superClass="com.crt.advproject.assembler.input"/>
+							</tool>
+							<tool id="com.crt.advproject.ar.lib.release.562349542" name="MCU Archiver" superClass="com.crt.advproject.ar.lib.release"/>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="CMSIS"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="board"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="component"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="device"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="drivers"/>
+						<entry excluding="freertos_kernel/portable/MemMang/heap_1.c|freertos_kernel/portable/MemMang/heap_2.c|freertos_kernel/portable/MemMang/heap_3.c|freertos_kernel/portable/MemMang/heap_5.c" flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="freertos"/>
+						<entry excluding="src/netif/ppp/polarssl/arc4.c|src/netif/ppp/polarssl/des.c|src/netif/ppp/polarssl/md4.c|src/netif/ppp/polarssl/md5.c|src/netif/ppp/polarssl/sha1.c" flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="lwip"/>
+						<entry excluding="wolfcrypt/src/misc.c|src/x509.c|src/x509_str.c|wolfcrypt/src/evp.c|src/conf.c|src/pk.c|src/bio.c|wolfcrypt/src/wc_kyber_asm.S|wolfcrypt/src/sp_x86_64_asm.S|wolfcrypt/src/sp_x86_64_asm.asm|wolfcrypt/src/sha512_asm.S|wolfcrypt/src/sha3_asm.S|wolfcrypt/src/sha256_asm.S|wolfcrypt/src/poly1305_asm.S|wolfcrypt/src/fe_x25519_asm.S|wolfcrypt/src/port|wolfcrypt/src/chacha_asm.S|wolfcrypt/src/aes_gcm_x86_asm.S|wolfcrypt/src/aes_gcm_asm.S|wolfcrypt/src/aes_asm.S|wolfcrypt/src/aes_asm.asm|wolfcrypt/user-crypto|wolfcrypt/test|wolfcrypt/benchmark" flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="source"/>
+						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="source/wolfcrypt/src/port/caam"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="startup"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="utilities"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="xip"/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="wolfssl_cm7.null.154511245" name="wolfssl_cm7" projectType="com.crt.advproject.projecttype.lib"/>
+	</storageModule>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="com.crt.advproject.config.lib.debug.660509326;com.crt.advproject.config.lib.debug.660509326.;com.crt.advproject.gas.lib.debug.171854801;com.crt.advproject.assembler.input.2019759218">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="com.crt.advproject.config.lib.release.239942709;com.crt.advproject.config.lib.release.239942709.;com.crt.advproject.gas.lib.release.1061690888;com.crt.advproject.assembler.input.1852831511">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="com.crt.advproject.config.lib.debug.660509326;com.crt.advproject.config.lib.debug.660509326.;com.crt.advproject.gcc.lib.debug.1152720193;com.crt.advproject.compiler.input.844879104">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="com.crt.advproject.config.lib.release.239942709;com.crt.advproject.config.lib.release.239942709.;com.crt.advproject.gcc.lib.release.1132876870;com.crt.advproject.compiler.input.1310027785">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="com.nxp.mcuxpresso.core.datamodels">
+		<sdkName>SDK_2.x_MIMXRT1170-EVK</sdkName>
+		<sdkVersion>2.12.1</sdkVersion>
+		<sdkComponents>middleware.freertos-kernel.MIMXRT1176;platform.drivers.clock.MIMXRT1176;platform.drivers.pmu_1.MIMXRT1176;platform.drivers.common.MIMXRT1176;platform.drivers.anatop_ai.MIMXRT1176;platform.drivers.xip_device.MIMXRT1176;platform.drivers.igpio.MIMXRT1176;platform.drivers.lpuart.MIMXRT1176;platform.drivers.nic301.MIMXRT1176;platform.drivers.dcdc_soc.MIMXRT1176;platform.drivers.iomuxc.MIMXRT1176;platform.drivers.caam.MIMXRT1176;platform.drivers.memory.MIMXRT1176;platform.drivers.cache_armv7_m7.MIMXRT1176;platform.devices.MIMXRT1176_system.MIMXRT1176;platform.devices.MIMXRT1176_CMSIS.MIMXRT1176;CMSIS_Include_core_cm.MIMXRT1176;component.serial_manager_uart.MIMXRT1176;component.lpuart_adapter.MIMXRT1176;component.serial_manager.MIMXRT1176;utility.debug_console.MIMXRT1176;platform.utilities.assert.MIMXRT1176;platform.drivers.xmcd.evkmimxrt1170.MIMXRT1176;platform.drivers.xip_board.evkmimxrt1170.MIMXRT1176;component.lists.MIMXRT1176;project_template.evkmimxrt1170.MIMXRT1176;middleware.freertos-kernel.template.MIMXRT1176;platform.devices.MIMXRT1176_startup.MIMXRT1176;middleware.freertos-kernel.extension.MIMXRT1176;middleware.lwip.MIMXRT1176;middleware.lwip.empty_ethernetif.MIMXRT1176;middleware.lwip.template.MIMXRT1176;platform.drivers.snvs_hp.MIMXRT1176;</sdkComponents>
+		<boardId>evkmimxrt1170</boardId>
+		<package>MIMXRT1176DVMAA</package>
+		<core>cm7</core>
+		<coreId>cm7_MIMXRT1176xxxxx</coreId>
+	</storageModule>
+	<storageModule moduleId="com.crt.config">
+		<projectStorage>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&#13;
+&lt;TargetConfig&gt;&#13;
+&lt;Properties property_3="NXP" property_4="MIMXRT1176xxxxx" property_count="5" version="100300"/&gt;&#13;
+&lt;infoList vendor="NXP"&gt;&#13;
+&lt;info chip="MIMXRT1176xxxxx" name="MIMXRT1176xxxxx"&gt;&#13;
+&lt;chip&gt;&#13;
+&lt;name&gt;MIMXRT1176xxxxx&lt;/name&gt;&#13;
+&lt;family&gt;MIMXRT1170&lt;/family&gt;&#13;
+&lt;vendor&gt;NXP&lt;/vendor&gt;&#13;
+&lt;memory can_program="true" id="Flash" is_ro="true" size="0" type="Flash"/&gt;&#13;
+&lt;memory id="RAM" size="2048" type="RAM"/&gt;&#13;
+&lt;memoryInstance derived_from="Flash" driver="MIMXRT1170_SFDP_QSPI.cfx" edited="true" id="BOARD_FLASH" location="0x30000000" size="0x4000000"/&gt;&#13;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_DTC_cm7" location="0x20000000" size="0x40000"/&gt;&#13;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_ITC_cm7" location="0x0" size="0x40000"/&gt;&#13;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC1" location="0x20240000" size="0x80000"/&gt;&#13;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC2" location="0x202c0000" size="0x80000"/&gt;&#13;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC_ECC1" location="0x20340000" size="0x10000"/&gt;&#13;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC_ECC2" location="0x20350000" size="0x10000"/&gt;&#13;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC_cm7" location="0x20360000" size="0x20000"/&gt;&#13;
+&lt;memoryInstance derived_from="RAM" edited="true" id="BOARD_SDRAM" location="0x80000000" size="0x3000000"/&gt;&#13;
+&lt;memoryInstance derived_from="RAM" edited="true" id="NCACHE_REGION" location="0x83000000" size="0x1000000"/&gt;&#13;
+&lt;/chip&gt;&#13;
+&lt;processor&gt;&#13;
+&lt;name gcc_name="cortex-m4"&gt;Cortex-M4&lt;/name&gt;&#13;
+&lt;family&gt;Cortex-M&lt;/family&gt;&#13;
+&lt;/processor&gt;&#13;
+&lt;processor&gt;&#13;
+&lt;name gcc_name="cortex-m7"&gt;Cortex-M7&lt;/name&gt;&#13;
+&lt;family&gt;Cortex-M&lt;/family&gt;&#13;
+&lt;/processor&gt;&#13;
+&lt;/info&gt;&#13;
+&lt;/infoList&gt;&#13;
+&lt;/TargetConfig&gt;</projectStorage>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
+	<storageModule moduleId="refreshScope"/>
+</cproject>

--- a/IDE/MCUEXPRESSO/RT1170/wolfssl_cm7/.project
+++ b/IDE/MCUEXPRESSO/RT1170/wolfssl_cm7/.project
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>wolfssl_cm7</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>com.nxp.mcuxpresso.core.datamodels.sdkNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+	<linkedResources>
+		<link>
+			<name>source/src</name>
+			<type>2</type>
+			<locationURI>$%7BPARENT-4-PROJECT_LOC%7D/src</locationURI>
+		</link>
+		<link>
+			<name>source/user_settings.h</name>
+			<type>1</type>
+			<locationURI>$%7BPARENT-1-PROJECT_LOC%7D/user_settings.h</locationURI>
+		</link>
+		<link>
+			<name>source/wolfcrypt</name>
+			<type>2</type>
+			<locationURI>$%7BPARENT-4-PROJECT_LOC%7D/wolfcrypt</locationURI>
+		</link>
+	</linkedResources>
+</projectDescription>

--- a/IDE/MCUEXPRESSO/include.am
+++ b/IDE/MCUEXPRESSO/include.am
@@ -9,10 +9,20 @@ EXTRA_DIST += IDE/MCUEXPRESSO/wolfssl/liblinks.xml
 
 EXTRA_DIST += IDE/MCUEXPRESSO/wolfcrypt_test/.cproject
 EXTRA_DIST += IDE/MCUEXPRESSO/wolfcrypt_test/.project
-EXTRA_DIST += IDE/MCUEXPRESSO/wolfcrypt_test/source/wolfcrypt_test.c
+EXTRA_DIST += IDE/MCUEXPRESSO/wolfcrypt_test.c
 
 EXTRA_DIST += IDE/MCUEXPRESSO/benchmark/.cproject
 EXTRA_DIST += IDE/MCUEXPRESSO/benchmark/.project
 EXTRA_DIST += IDE/MCUEXPRESSO/benchmark/source/run_benchmark.c
 
+EXTRA_DIST += IDE/MCUEXPRESSO/README.md
 EXTRA_DIST += IDE/MCUEXPRESSO/user_settings.h
+
+EXTRA_DIST += IDE/MCUEXPRESSO/RT1170/user_settings.h
+EXTRA_DIST += IDE/MCUEXPRESSO/RT1170/wolfssl_cm7/.cproject
+EXTRA_DIST += IDE/MCUEXPRESSO/RT1170/wolfssl_cm7/.project
+EXTRA_DIST += IDE/MCUEXPRESSO/RT1170/wolfcrypt_test_cm7/.cproject
+EXTRA_DIST += IDE/MCUEXPRESSO/RT1170/wolfcrypt_test_cm7/.project
+EXTRA_DIST += IDE/MCUEXPRESSO/RT1170/fsl_caam_h.patch
+EXTRA_DIST += IDE/MCUEXPRESSO/RT1170/fsl_caam_c.patch
+

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -301,6 +301,9 @@ function(generate_build_flags)
         set(BUILD_DEBUG "yes" PARENT_SCOPE)
     endif()
     set(BUILD_RC2 ${WOLFSSL_RC2} PARENT_SCOPE)
+    if(WOLFSSL_CAAM)
+        set(BUILD_CAAM "yes" PARENT_SCOPE)
+    endif()
 
     set(BUILD_FLAGS_GENERATED "yes" PARENT_SCOPE)
 endfunction()
@@ -889,6 +892,21 @@ function(generate_lib_src_list LIB_SOURCES)
 
     if(BUILD_CRYPTOAUTHLIB)
         list(APPEND LIB_SOURCES wolfcrypt/src/port/atmel/atmel.c)
+    endif()
+
+    if(BUILD_CAAM)
+        list(APPEND LIB_SOURCES
+            wolfcrypt/src/port/caam/wolfcaam_init.c
+            wolfcrypt/src/port/caam/wolfcaam_qnx.c
+            wolfcrypt/src/port/caam/wolfcaam_seco.c
+            wolfcrypt/src/port/caam/wolfcaam_fsl_nxp.c
+            wolfcrypt/src/port/caam/wolfcaam_x25519.c
+            wolfcrypt/src/port/caam/wolfcaam_ecdsa.c
+            wolfcrypt/src/port/caam/wolfcaam_cmac.c
+            wolfcrypt/src/port/caam/wolfcaam_aes.c
+            wolfcrypt/src/port/caam/wolfcaam_hash.c
+            wolfcrypt/src/port/caam/wolfcaam_rsa.c
+            wolfcrypt/src/port/caam/wolfcaam_hmac.c)
     endif()
 
     set(LIB_SOURCES ${LIB_SOURCES} PARENT_SCOPE)

--- a/wolfcrypt/src/include.am
+++ b/wolfcrypt/src/include.am
@@ -88,6 +88,7 @@ EXTRA_DIST += wolfcrypt/src/port/ti/ti-aes.c \
               wolfcrypt/src/port/caam/wolfcaam_rsa.c \
               wolfcrypt/src/port/caam/wolfcaam_hmac.c \
               wolfcrypt/src/port/caam/wolfcaam_aes.c \
+              wolfcrypt/src/port/caam/wolfcaam_fsl_nxp.c \
               wolfcrypt/src/port/silabs/silabs_aes.c \
               wolfcrypt/src/port/silabs/silabs_ecc.c \
               wolfcrypt/src/port/silabs/silabs_hash.c \

--- a/wolfcrypt/src/port/caam/wolfcaam_ecdsa.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_ecdsa.c
@@ -240,6 +240,7 @@ static int wc_CAAM_DevMakeEccKey(WC_RNG* rng, int keySize, ecc_key* key,
 
 #endif /* WOLFSSL_DEVCRYPTO_ECDSA */
 
+#ifndef WOLFSSL_IMXRT1170_CAAM
 /* helper function get the ECDSEL value, this is a value that signals the
  * hardware to use preloaded curve parameters
  */
@@ -743,7 +744,7 @@ int wc_CAAM_MakeEccKey(WC_RNG* rng, int keySize, ecc_key* key, int curveId,
     return -1;
 }
 #endif /* WOLFSSL_KEY_GEN */
-
+#endif /* WOLFSSL_IMXRT1170_CAAM */
 
 /* if dealing with a black encrypted key then it can not be checked */
 int wc_CAAM_EccCheckPrivKey(ecc_key* key, const byte* pubKey, word32 pubKeySz) {

--- a/wolfcrypt/src/port/caam/wolfcaam_fsl_nxp.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_fsl_nxp.c
@@ -1,0 +1,860 @@
+/* wolfcaam_fsl_nxp.c
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/wolfcrypt/settings.h>
+
+#if defined(WOLFSSL_IMXRT1170_CAAM)
+
+#include <wolfssl/wolfcrypt/logging.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+#include <wolfssl/wolfcrypt/port/caam/wolfcaam.h>
+
+#if defined(FSL_FEATURE_HAS_L1CACHE) || defined(__DCACHE_PRESENT)
+/* Setup for if memory is cached */
+AT_NONCACHEABLE_SECTION(static caam_job_ring_interface_t jr0);
+AT_NONCACHEABLE_SECTION(static caam_job_ring_interface_t jr1);
+AT_NONCACHEABLE_SECTION(static caam_job_ring_interface_t jr2);
+AT_NONCACHEABLE_SECTION(static caam_job_ring_interface_t jr3);
+#else
+/* If not cached */
+static caam_job_ring_interface_t jr0;
+static caam_job_ring_interface_t jr1;
+static caam_job_ring_interface_t jr2;
+static caam_job_ring_interface_t jr3;
+#endif
+
+wolfSSL_Mutex caamMutex;
+
+/* Initialize CAAM resources.
+ * return 0 on success */
+int wc_CAAMInitInterface()
+{
+    CAAM_Type *base = CAAM;
+    caam_config_t caamConfig;
+
+    if (wc_InitMutex(&caamMutex) != 0) {
+        WOLFSSL_MSG("Could not init mutex");
+        return -1;
+    }
+
+    /* Get default configuration. */
+    CAAM_GetDefaultConfig(&caamConfig);
+
+    /* set the job rings */
+    caamConfig.jobRingInterface[0] = &jr0;
+    caamConfig.jobRingInterface[1] = &jr1;
+    caamConfig.jobRingInterface[2] = &jr2;
+    caamConfig.jobRingInterface[3] = &jr3;
+
+    /* Init CAAM driver, including CAAM's internal RNG */
+    if (CAAM_Init(base, &caamConfig) != kStatus_Success) {
+        return -1;
+    }
+
+    return 0;
+}
+
+
+/* free up CAAM resources */
+void wc_CAAMFreeInterface()
+{
+    wc_FreeMutex(&caamMutex);
+    if (CAAM_Deinit(CAAM) != kStatus_Success) {
+        WOLFSSL_MSG("Failed to deinit CAAM!");
+    }
+}
+
+
+#if !defined(NO_SHA) || defined(WOLFSSL_SHA224) || !defined(NO_SHA256) \
+    || defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512)
+/* convert the wolfCrypt hash type to NXP enum */
+static caam_hash_algo_t WC2NXP(int type)
+{
+    switch (type) {
+        case WC_HASH_TYPE_SHA:
+            return kCAAM_Sha1;
+        case WC_HASH_TYPE_SHA224:
+            return kCAAM_Sha224;
+        case WC_HASH_TYPE_SHA256:
+            return kCAAM_Sha256;
+        case WC_HASH_TYPE_SHA384:
+            return kCAAM_Sha384;
+        case WC_HASH_TYPE_SHA512:
+            return kCAAM_Sha512;
+        default:
+            return -1;
+    }
+}
+
+/* Common init code for hash algorithms.
+ * returns 0 on success
+ */
+int wc_CAAM_HashInit(caam_handle_t* hndl, caam_hash_ctx_t* ctx, int type)
+{
+    if (hndl == NULL || ctx == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    /* only using job ring0 for now */
+    hndl->jobRing = kCAAM_JobRing0;
+    if (CAAM_HASH_Init(CAAM, hndl, ctx, WC2NXP(type), NULL, 0u)
+            != kStatus_Success) {
+        return WC_HW_E;
+    }
+    return 0;
+}
+
+
+/* All hashing algorithms have common code except the 'type' to perform.
+ * This helper function implements the common code.
+ * returns 0 on success
+ */
+static int wc_CAAM_CommonHash(caam_handle_t* hndl, caam_hash_ctx_t *ctx,
+    const byte* in, int inSz, byte* digest, size_t digestSz, int hashType)
+{
+    int ret = 0;
+    status_t status;
+
+    if (in != NULL && inSz > 0) {
+        byte *alignedIn  = NULL;
+        byte *tmpIn  = NULL;
+
+        if ((wc_ptr_t)in % CAAM_BUFFER_ALIGN) {
+            /* input not alligned */
+            tmpIn = (byte*)XMALLOC(inSz + CAAM_BUFFER_ALIGN, NULL,
+                DYNAMIC_TYPE_TMP_BUFFER);
+            alignedIn = tmpIn + (CAAM_BUFFER_ALIGN -
+                ((wc_ptr_t)tmpIn % CAAM_BUFFER_ALIGN));
+            XMEMCPY(alignedIn, in, inSz);
+        }
+        else {
+            alignedIn = (byte*)in;
+        }
+
+        status = CAAM_HASH_Update(ctx, alignedIn, inSz);
+        if (tmpIn != NULL) {
+            XFREE(tmpIn, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        }
+        if (status != kStatus_Success) {
+            return WC_HW_E;
+        }
+    }
+
+    if (digest != NULL) {
+        byte *tmpOut = NULL;
+
+        byte *alignedOut = NULL;
+        size_t sz = digestSz;
+
+        if ((wc_ptr_t)digest % CAAM_BUFFER_ALIGN) {
+            /* input not alligned */
+            tmpOut = (byte*)XMALLOC(sz + CAAM_BUFFER_ALIGN, NULL,
+                DYNAMIC_TYPE_TMP_BUFFER);
+            alignedOut = tmpOut + (CAAM_BUFFER_ALIGN -
+                ((wc_ptr_t)tmpOut % CAAM_BUFFER_ALIGN));
+        }
+        else {
+            alignedOut = digest;
+        }
+
+        status = CAAM_HASH_Finish(ctx, alignedOut, &sz);
+        if (tmpOut != NULL) {
+            XMEMCPY(digest, alignedOut, sz);
+            XFREE(tmpOut, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        }
+        if (status != kStatus_Success) {
+             WOLFSSL_MSG("Failed on CAAM_HASH_Finish");
+             return WC_HW_E;
+         }
+        else {
+             ret = wc_CAAM_HashInit(hndl, ctx, hashType);
+        }
+    }
+
+    return ret;
+}
+#endif
+
+
+#if !defined(NO_SHA)
+/* SHA returns 0 on success */
+int wc_CAAM_ShaHash(wc_Sha* sha, const byte* in, word32 inSz, byte* digest)
+{
+    return wc_CAAM_CommonHash(&sha->hndl, &sha->ctx, in, inSz, digest,
+        WC_SHA_DIGEST_SIZE, WC_HASH_TYPE_SHA);
+
+}
+#endif
+
+#ifdef WOLFSSL_SHA224
+/* SHA224 returns 0 on success */
+int wc_CAAM_Sha224Hash(wc_Sha224* sha, const byte* in, word32 inSz,
+    byte* digest)
+{
+    return wc_CAAM_CommonHash(&sha->hndl, &sha->ctx, in, inSz, digest,
+        WC_SHA224_DIGEST_SIZE, WC_HASH_TYPE_SHA224);
+}
+#endif
+
+#if !defined(NO_SHA256)
+/* SHA256 returns 0 on success */
+int wc_CAAM_Sha256Hash(wc_Sha256* sha, const byte* in, word32 inSz,
+    byte* digest)
+{
+    return wc_CAAM_CommonHash(&sha->hndl, &sha->ctx, in, inSz, digest,
+        WC_SHA256_DIGEST_SIZE, WC_HASH_TYPE_SHA256);
+}
+#endif
+
+#ifdef WOLFSSL_SHA384
+/* SHA384 returns 0 on success */
+int wc_CAAM_Sha384Hash(wc_Sha384* sha, const byte* in, word32 inSz,
+    byte* digest)
+{
+    return wc_CAAM_CommonHash(&sha->hndl, &sha->ctx, in, inSz, digest,
+        WC_SHA384_DIGEST_SIZE, WC_HASH_TYPE_SHA384);
+
+}
+#endif
+
+#ifdef WOLFSSL_SHA512
+/* SHA512 returns 0 on success */
+int wc_CAAM_Sha512Hash(wc_Sha512* sha, const byte* in, word32 inSz,
+    byte* digest)
+{
+    return wc_CAAM_CommonHash(&sha->hndl, &sha->ctx, in, inSz, digest,
+        WC_SHA512_DIGEST_SIZE, WC_HASH_TYPE_SHA512);
+}
+#endif
+
+#ifndef NO_AES_CBC
+/* AES-CBC returns 0 on success */
+static int DoAesCBC(unsigned int args[4], CAAM_BUFFER *buf, int sz)
+{
+    status_t status;
+    caam_handle_t hndl;
+
+    /* @TODO running on alternate job rings - performance enhancement */
+    hndl.jobRing = kCAAM_JobRing0;
+
+    if (args[0] == CAAM_DEC) {
+        status = CAAM_AES_DecryptCbc(CAAM, &hndl,
+            (const uint8_t*)buf[2].TheAddress, (uint8_t*)buf[3].TheAddress,
+            buf[3].Length, (const uint8_t*)buf[4].TheAddress,
+            (const uint8_t*)buf[0].TheAddress, buf[0].Length);
+
+        /* store updated CBC state */
+        XMEMCPY((byte*)buf[4].TheAddress,
+                (byte*)buf[2].TheAddress + buf[2].Length - AES_BLOCK_SIZE,
+                AES_BLOCK_SIZE);
+    }
+    else {
+        status = CAAM_AES_EncryptCbc(CAAM, &hndl,
+            (const uint8_t*)buf[2].TheAddress, (uint8_t*)buf[3].TheAddress,
+            buf[3].Length, (const uint8_t*)buf[4].TheAddress,
+            (const uint8_t*)buf[0].TheAddress, buf[0].Length);
+
+        /* store updated CBC state */
+        XMEMCPY((byte*)buf[4].TheAddress,
+            (byte*)buf[3].TheAddress + buf[3].Length - AES_BLOCK_SIZE,
+            AES_BLOCK_SIZE);
+    }
+
+    if (status != kStatus_Success) {
+        return -1;
+    }
+   return 0;
+}
+#endif
+
+#ifdef WOLFSSL_AES_COUNTER
+/* AES-CTR returns 0 on success */
+static int DoAesCTR(unsigned int args[4], CAAM_BUFFER *buf, int sz)
+{
+    status_t status;
+    caam_handle_t hndl;
+    byte *tmpIn  = NULL;
+    byte *tmpOut = NULL;
+    byte *alignedIn  = NULL;
+    byte *alignedOut = NULL;
+
+    if (buf[2].TheAddress % CAAM_BUFFER_ALIGN) {
+        /* input not alligned */
+        tmpIn = (byte*)XMALLOC(buf[2].Length + CAAM_BUFFER_ALIGN, NULL,
+            DYNAMIC_TYPE_TMP_BUFFER);
+        alignedIn = tmpIn + (CAAM_BUFFER_ALIGN -
+            ((wc_ptr_t)tmpIn % CAAM_BUFFER_ALIGN));
+        XMEMCPY(alignedIn, (byte*)buf[2].TheAddress, buf[2].Length);
+    }
+    else {
+        alignedIn = (byte*)buf[2].TheAddress;
+    }
+
+    if (buf[3].TheAddress % CAAM_BUFFER_ALIGN) {
+        /* output not alligned */
+        tmpOut = (byte*)XMALLOC(buf[3].Length + CAAM_BUFFER_ALIGN, NULL,
+            DYNAMIC_TYPE_TMP_BUFFER);
+        alignedOut = tmpOut + (CAAM_BUFFER_ALIGN -
+            ((wc_ptr_t)tmpOut % CAAM_BUFFER_ALIGN));
+    }
+    else {
+        alignedOut = (byte*)buf[3].TheAddress;
+    }
+
+    /* @TODO running on alternate job rings - performance enhancement */
+    hndl.jobRing = kCAAM_JobRing0;
+
+    status = CAAM_AES_CryptCtr(CAAM, &hndl, alignedIn, alignedOut,
+        buf[3].Length, (byte*)buf[4].TheAddress, (byte*)buf[0].TheAddress,
+        buf[0].Length, (byte*)buf[2].TheAddress, NULL);
+    if (tmpOut != NULL) {
+        XMEMCPY((byte*)buf[3].TheAddress, alignedOut, buf[3].Length);
+        XFREE(tmpOut, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+    if (tmpIn != NULL) {
+        XFREE(tmpIn, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+    if (status != kStatus_Success) {
+        return -1;
+    }
+   return 0;
+}
+#endif
+
+
+#if defined(HAVE_ECC) && defined(WOLFSSL_CAAM_ECC)
+#include <wolfssl/wolfcrypt/asn.h>
+
+/* helper function get the ECDSEL value, this is a value that signals the
+ * hardware to use preloaded curve parameters
+ */
+static word32 GetECDSEL(int curveId)
+{
+    word32 ecdsel = 0;
+
+    switch (curveId) {
+        case ECC_SECP192R1:
+            ecdsel = CAAM_ECDSA_P192;
+            break;
+
+        case ECC_SECP224R1:
+            ecdsel = CAAM_ECDSA_P224;
+            break;
+
+        case ECC_CURVE_DEF:
+        case ECC_SECP256R1:
+            ecdsel = CAAM_ECDSA_P256;
+            break;
+
+        case ECC_SECP384R1:
+            ecdsel = CAAM_ECDSA_P384;
+            break;
+
+        case ECC_SECP521R1:
+            ecdsel = CAAM_ECDSA_P521;
+            break;
+
+        default:
+            WOLFSSL_MSG("not using preset curve parameters");
+    }
+
+    return ecdsel;
+}
+
+
+/* ECC sign operation on hardware, can handle black keys
+ * returns 0 on success
+ */
+int wc_CAAM_EccSign(const byte* in, int inlen, byte* out, word32* outlen,
+        WC_RNG *rng, ecc_key *key, int devId)
+{
+    const ecc_set_type* dp;
+    int ret = 0;
+    ALIGN16 byte k[MAX_ECC_BYTES + WC_CAAM_MAC_SZ];
+    word32 kSz = MAX_ECC_BYTES + WC_CAAM_MAC_SZ;
+
+    /* input needs to be aligned */
+    byte *alignedIn  = NULL;
+    byte *tmpIn  = NULL;
+
+    ALIGN16 byte r[MAX_ECC_BYTES] = {0};
+    ALIGN16 byte s[MAX_ECC_BYTES] = {0};
+    word32 rSz = MAX_ECC_BYTES;
+    word32 sSz = MAX_ECC_BYTES;
+    int keySz;
+    word32 ecdsel;
+    word32 enc;
+    status_t status;
+    caam_handle_t hndl;
+
+    /* @TODO running on alternate job rings - performance enhancement */
+    hndl.jobRing = kCAAM_JobRing0;
+
+    (void)rng;
+    if (key->dp != NULL) {
+        dp = key->dp;
+    }
+    else {
+        dp = wc_ecc_get_curve_params(key->idx);
+    }
+
+    if (dp->id != ECC_SECP256R1 && dp->id != ECC_SECP384R1) {
+        WOLFSSL_MSG("Limiting CAAM to P256/P384 for now");
+        return CRYPTOCB_UNAVAILABLE;
+    }
+
+    /* check for known predetermined parameters */
+    ecdsel = GetECDSEL(dp->id);
+    if (ecdsel == 0) {
+        WOLFSSL_MSG("Unsupported curve type");
+        return BAD_FUNC_ARG;
+    }
+    keySz = kSz = wc_ecc_size(key);
+
+    /* private key */
+    if (key->blackKey == CAAM_BLACK_KEY_SM) {
+        ret = -1; /* only handling black keys not SM (secure memory) ones */
+    }
+    else {
+        if (key->blackKey == CAAM_BLACK_KEY_CCM) {
+            if (mp_to_unsigned_bin_len(&key->k, k, kSz + WC_CAAM_MAC_SZ)
+                != MP_OKAY) {
+                return MP_TO_E;
+            }
+        }
+        else {
+            if (mp_to_unsigned_bin_len(&key->k, k, kSz) != MP_OKAY) {
+                return MP_TO_E;
+            }
+        }
+    }
+
+    ecdsel = GetECDSEL(dp->id);
+    if (ecdsel == 0) {
+        WOLFSSL_MSG("unknown key type or size");
+        return CRYPTOCB_UNAVAILABLE;
+    }
+
+    switch (key->blackKey) {
+        case 0:
+            enc = 0;
+            break;
+        case CAAM_BLACK_KEY_ECB:
+            enc = CAAM_PKHA_ENC_PRI_AESECB;
+            break;
+    }
+
+    if ((wc_ptr_t)in % CAAM_BUFFER_ALIGN) {
+        /* input not alligned */
+        tmpIn = (byte*)XMALLOC(inlen + CAAM_BUFFER_ALIGN, NULL,
+            DYNAMIC_TYPE_TMP_BUFFER);
+        alignedIn = tmpIn + (CAAM_BUFFER_ALIGN -
+            ((wc_ptr_t)tmpIn % CAAM_BUFFER_ALIGN));
+        XMEMCPY(alignedIn, in, inlen);
+    }
+    else {
+        alignedIn = (byte*)in;
+    }
+
+
+    status = CAAM_ECC_Sign(CAAM, &hndl, k, kSz, alignedIn, inlen, r, rSz, s,
+        sSz, ecdsel, enc);
+    if (tmpIn != NULL) {
+        XFREE(tmpIn, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+
+    if (status != kStatus_Success) {
+        ret = -1;
+    }
+
+    /* convert signature from raw bytes to signature format */
+    if (ret == 0) {
+        mp_int mpr, mps;
+
+        mp_init(&mpr);
+        mp_init(&mps);
+
+        mp_read_unsigned_bin(&mpr, r, keySz);
+        mp_read_unsigned_bin(&mps, s, keySz);
+
+        ret = StoreECC_DSA_Sig(out, outlen, &mpr, &mps);
+        mp_free(&mpr);
+        mp_free(&mps);
+        if (ret != 0) {
+            WOLFSSL_MSG("Issue converting to signature");
+            return -1;
+        }
+    }
+
+    return ret;
+}
+
+
+/* helper function to handle r/s with verify
+ * returns 0 on success
+ */
+static int wc_CAAM_EccVerify_ex(mp_int* r, mp_int *s, const byte* hash,
+        word32 hashlen, int* res, ecc_key* key)
+{
+    const ecc_set_type* dp;
+    int keySz;
+    word32 ecdsel = 0;
+
+    /* input needs to be aligned */
+    byte *alignedIn  = NULL;
+    byte *tmpIn  = NULL;
+
+    ALIGN16 byte rbuf[MAX_ECC_BYTES] = {0};
+    ALIGN16 byte sbuf[MAX_ECC_BYTES] = {0};
+
+    ALIGN16 byte qx[MAX_ECC_BYTES] = {0};
+    ALIGN16 byte qy[MAX_ECC_BYTES] = {0};
+    ALIGN16 byte qxy[MAX_ECC_BYTES * 2] = {0};
+    word32 qxLen, qyLen;
+
+    status_t status;
+    caam_handle_t hndl;
+
+    /* @TODO running on alternate job rings - performance enhancement */
+    hndl.jobRing = kCAAM_JobRing0;
+
+    if (key->dp != NULL) {
+        dp = key->dp;
+    }
+    else {
+        dp = wc_ecc_get_curve_params(key->idx);
+    }
+
+    /* right now only support P256/P384 @TODO */
+    if (dp->id != ECC_SECP256R1 && dp->id != ECC_SECP384R1) {
+        WOLFSSL_MSG("Only support P256 and P384 verify with CAAM for now");
+        return CRYPTOCB_UNAVAILABLE;
+    }
+
+    /* check for known predetermined parameters */
+    ecdsel = GetECDSEL(dp->id);
+
+    if (ecdsel == 0) {
+        WOLFSSL_MSG("Curve parameters not supported");
+        return CRYPTOCB_UNAVAILABLE;
+    }
+
+    /* Wx,y public key */
+    keySz = wc_ecc_size(key);
+    qxLen = qyLen = MAX_ECC_BYTES;
+
+    if (wc_ecc_export_public_raw(key, qx, &qxLen, qy, &qyLen) != 0) {
+        WOLFSSL_MSG("Issue exporting public key part");
+        return -1;
+    }
+    XMEMCPY(qxy, qx, qxLen);
+    XMEMCPY(qxy+qxLen, qy, qyLen);
+
+    if (mp_to_unsigned_bin_len(r, rbuf, keySz) != MP_OKAY) {
+        return MP_TO_E;
+    }
+
+    if (mp_to_unsigned_bin_len(s, sbuf, keySz) != MP_OKAY) {
+        return MP_TO_E;
+    }
+
+    if ((wc_ptr_t)hash % CAAM_BUFFER_ALIGN) {
+        /* input not alligned */
+        tmpIn = (byte*)XMALLOC(hashlen + CAAM_BUFFER_ALIGN, NULL,
+            DYNAMIC_TYPE_TMP_BUFFER);
+        alignedIn = tmpIn + (CAAM_BUFFER_ALIGN -
+            ((wc_ptr_t)tmpIn % CAAM_BUFFER_ALIGN));
+        XMEMCPY(alignedIn, hash, hashlen);
+    }
+    else {
+        alignedIn = (byte*)hash;
+    }
+
+    status = CAAM_ECC_Verify(CAAM, &hndl, qxy, qxLen+qyLen, rbuf,
+        keySz, sbuf, keySz, alignedIn, hashlen, ecdsel);
+    if (tmpIn != NULL) {
+        XFREE(tmpIn, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+    *res = 0;
+    if (status == kStatus_Success) {
+        *res = 1;
+    }
+
+    return MP_OKAY;
+}
+
+
+/* ECC verify operation using hardware
+ * returns 0 on success, and sets "res" with verify result (1 for verify ok)
+ */
+int wc_CAAM_EccVerify(const byte* sig, word32 siglen, const byte* hash,
+        word32 hashlen, int* res, ecc_key* key, int devId)
+{
+    int ret;
+    mp_int r, s;
+
+    ret = DecodeECC_DSA_Sig(sig, siglen, &r, &s);
+    if (ret == 0) {
+        ret = wc_CAAM_EccVerify_ex(&r, &s, hash, hashlen, res, key);
+        mp_free(&r);
+        mp_free(&s);
+    }
+
+    (void)devId;
+    return ret;
+}
+
+
+/* ECDH operation using hardware, can handle black keys
+ * returns 0 on success
+ */
+int wc_CAAM_Ecdh(ecc_key* private_key, ecc_key* public_key, byte* out,
+        word32* outlen, int devId)
+{
+    const ecc_set_type* dp;
+    int keySz;
+    word32 ecdsel = 0; /* ecc parameters in hardware */
+    int enc;
+    status_t status;
+
+    ALIGN16 byte k[MAX_ECC_BYTES + WC_CAAM_MAC_SZ] = {0};
+    ALIGN16 byte qx[MAX_ECC_BYTES] = {0};
+    ALIGN16 byte qy[MAX_ECC_BYTES] = {0};
+    ALIGN16 byte qxy[MAX_ECC_BYTES * 2] = {0};
+    word32 qxSz, qySz;
+    caam_handle_t hndl;
+
+    /* @TODO running on alternate job rings - performance enhancement */
+    hndl.jobRing = kCAAM_JobRing0;
+
+    if (private_key->dp != NULL) {
+        dp = private_key->dp;
+    }
+    else {
+        dp = wc_ecc_get_curve_params(private_key->idx);
+    }
+
+    if (dp->id != ECC_SECP256R1 && dp->id != ECC_SECP384R1) {
+        return CRYPTOCB_UNAVAILABLE;
+    }
+
+    /* check for known predetermined parameters */
+    ecdsel = GetECDSEL(dp->id);
+    if (ecdsel == 0) { /* predefined value not known, loading all parameters */
+        WOLFSSL_MSG("Unsupported curve parameters");
+        return CRYPTOCB_UNAVAILABLE;
+    }
+
+    keySz = wc_ecc_size(private_key);
+    if (*outlen < (word32)keySz) {
+        WOLFSSL_MSG("out buffer is to small");
+        return BUFFER_E;
+    }
+
+    /* public key */
+    qxSz = qySz = MAX_ECC_BYTES;
+    if (wc_ecc_export_public_raw(public_key, qx, &qxSz, qy, &qySz) != 0) {
+        WOLFSSL_MSG("Issue exporting public key part");
+        return -1;
+    }
+    XMEMCPY(qxy, qx, qxSz);
+    XMEMCPY(qxy+qxSz, qy, qySz);
+
+    /* private key */
+    if (keySz > MAX_ECC_BYTES) {
+        return BUFFER_E;
+    }
+
+    enc = 0;
+    if (private_key->blackKey == CAAM_BLACK_KEY_ECB) {
+        enc = CAAM_PKHA_ENC_PRI_AESECB;
+    }
+
+    if (private_key->blackKey == CAAM_BLACK_KEY_CCM) {
+        if (mp_to_unsigned_bin_len(&private_key->k, k,
+                keySz + WC_CAAM_MAC_SZ) != MP_OKAY) {
+            return MP_TO_E;
+        }
+    }
+    else {
+        if (mp_to_unsigned_bin_len(&private_key->k, k, keySz) != MP_OKAY) {
+            return MP_TO_E;
+        }
+    }
+
+    if (*outlen < (word32)keySz) {
+        return -1;
+    }
+
+    status = CAAM_ECC_ECDH(CAAM, &hndl, k, keySz, qxy, keySz*2, out, keySz,
+        ecdsel, enc);
+    if (status == kStatus_Success) {
+        *outlen = keySz;
+        return MP_OKAY;
+    }
+    else {
+        return -1;
+    }
+}
+
+#ifdef WOLFSSL_KEY_GEN
+/* creates a [ private black key ] [ x , y ]
+ * returns 0 on success
+ */
+int wc_CAAM_MakeEccKey(WC_RNG* rng, int keySize, ecc_key* key, int curveId,
+    int devId)
+{
+    int ret = 0;
+    ALIGN16 byte xy[MAX_ECC_BYTES * 2];
+    ALIGN16 byte k[MAX_ECC_BYTES];
+    word32 kSz = MAX_ECC_BYTES;
+    word32 xySz = MAX_ECC_BYTES * 2;
+    word32 ecdsel;
+    word32 enc;
+    status_t status;
+    caam_handle_t hndl;
+
+    XMEMSET(xy, 0, MAX_ECC_BYTES * 2);
+    XMEMSET(k, 0, MAX_ECC_BYTES);
+
+    /* @TODO running on alternate job rings - performance enhancement */
+    hndl.jobRing = kCAAM_JobRing0;
+
+    key->type = ECC_PRIVATEKEY;
+
+    /* if set to default curve then assume SECP256R1 */
+    if (keySize == 32 && curveId == ECC_CURVE_DEF) curveId = ECC_SECP256R1;
+    if (keySize == 48 && curveId == ECC_CURVE_DEF) curveId = ECC_SECP384R1;
+
+    if (curveId != ECC_SECP256R1 && curveId != ECC_SECP384R1) {
+        /* currently only implemented P256/P384 support */
+        return CRYPTOCB_UNAVAILABLE;
+    }
+
+    ecdsel = GetECDSEL(curveId);
+    if (ecdsel == 0) {
+        WOLFSSL_MSG("unknown key type or size");
+        return CRYPTOCB_UNAVAILABLE;
+    }
+
+    if (key->blackKey == CAAM_BLACK_KEY_ECB) {
+        enc = CAAM_PKHA_ENC_PRI_AESECB;
+    }
+
+    if (key->blackKey == 0) {
+    #ifdef WOLFSSL_CAAM_NO_BLACK_KEY
+        enc = 0;
+    #else
+        key->blackKey = CAAM_BLACK_KEY_ECB;
+        enc = CAAM_PKHA_ENC_PRI_AESECB;
+    #endif
+    }
+
+    status = CAAM_ECC_Keygen(CAAM, &hndl, k, &kSz, xy, &xySz, ecdsel,
+        enc);
+    if (status != kStatus_Success) {
+        ret = -1;
+    }
+
+    if (ret == 0 &&
+            wc_ecc_import_unsigned(key, xy, xy + keySize, k, curveId) != 0) {
+        WOLFSSL_MSG("issue importing key");
+        ret = -1;
+    }
+
+    return ret;
+}
+#endif /* WOLFSSL_KEY_GEN */
+#endif /* HAVE_ECC */
+
+
+/* Do a synchronous operations and block till done
+ * returns 0 on success */
+int SynchronousSendRequest(int type, unsigned int args[4], CAAM_BUFFER *buf,
+        int sz)
+{
+    int ret = 0;
+
+    caam_handle_t hndl;
+    hndl.jobRing = kCAAM_JobRing0;
+
+    switch (type) {
+    case CAAM_ENTROPY:
+        if (CAAM_RNG_GetRandomData(CAAM, &hndl, kCAAM_RngStateHandle0,
+                (uint8_t *)buf[0].TheAddress, buf[0].Length,
+                kCAAM_RngDataAny, NULL) != kStatus_Success) {
+            ret = WC_HW_E;
+        }
+        break;
+
+#ifndef NO_AES_CBC
+    case CAAM_AESCBC:
+        ret = DoAesCBC(args, buf, sz);
+        break;
+#endif
+
+#ifdef WOLFSSL_AES_COUNTER
+    case CAAM_AESCTR:
+        ret = DoAesCTR(args, buf, sz);
+        break;
+#endif
+
+#ifdef CAAM_BLOB_EXPANSION
+    case CAAM_BLOB_ENCAP:
+        if (CAAM_Blob(CAAM, &hndl, (byte*)buf[1].TheAddress,
+                buf[1].Length, (byte*)buf[2].TheAddress,
+                buf[2].Length, (byte*)buf[0].TheAddress,
+                buf[0].Length, CAAM_ENCAP_BLOB,
+                (args[0] = 0)? CAAM_RED_BLOB : CAAM_BLACK_BLOB)
+                != kStatus_Success) {
+            ret = WC_HW_E;
+        }
+        break;
+
+    case CAAM_BLOB_DECAP:
+        if (CAAM_Blob(CAAM, &hndl, (byte*)buf[1].TheAddress, buf[1].Length,
+                (byte*)buf[2].TheAddress, buf[2].Length,
+                (byte*)buf[0].TheAddress, buf[0].Length,
+                CAAM_DECAP_BLOB,
+                (args[0] = 0)? CAAM_RED_BLOB : CAAM_BLACK_BLOB)
+                != kStatus_Success) {
+            ret = WC_HW_E;
+        }
+        break;
+#endif
+
+    default:
+        WOLFSSL_MSG("Unknown/unsupported type");
+        return -1;
+    }
+
+    if (ret != 0) {
+        return -1;
+    }
+
+    return Success;
+}
+
+#endif /* WOLFSSL_IMXRT1170_CAAM */

--- a/wolfcrypt/src/port/caam/wolfcaam_fsl_nxp.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_fsl_nxp.c
@@ -45,7 +45,7 @@ static caam_job_ring_interface_t jr2;
 static caam_job_ring_interface_t jr3;
 #endif
 
-wolfSSL_Mutex caamMutex;
+static wolfSSL_Mutex caamMutex;
 
 /* Initialize CAAM resources.
  * return 0 on success */
@@ -142,7 +142,7 @@ static int wc_CAAM_CommonHash(caam_handle_t* hndl, caam_hash_ctx_t *ctx,
         byte *tmpIn  = NULL;
 
         if ((wc_ptr_t)in % CAAM_BUFFER_ALIGN) {
-            /* input not alligned */
+            /* input not aligned */
             tmpIn = (byte*)XMALLOC(inSz + CAAM_BUFFER_ALIGN, NULL,
                 DYNAMIC_TYPE_TMP_BUFFER);
             alignedIn = tmpIn + (CAAM_BUFFER_ALIGN -
@@ -169,7 +169,7 @@ static int wc_CAAM_CommonHash(caam_handle_t* hndl, caam_hash_ctx_t *ctx,
         size_t sz = digestSz;
 
         if ((wc_ptr_t)digest % CAAM_BUFFER_ALIGN) {
-            /* input not alligned */
+            /* input not aligned */
             tmpOut = (byte*)XMALLOC(sz + CAAM_BUFFER_ALIGN, NULL,
                 DYNAMIC_TYPE_TMP_BUFFER);
             alignedOut = tmpOut + (CAAM_BUFFER_ALIGN -
@@ -301,7 +301,7 @@ static int DoAesCTR(unsigned int args[4], CAAM_BUFFER *buf, int sz)
     byte *alignedOut = NULL;
 
     if (buf[2].TheAddress % CAAM_BUFFER_ALIGN) {
-        /* input not alligned */
+        /* input not aligned */
         tmpIn = (byte*)XMALLOC(buf[2].Length + CAAM_BUFFER_ALIGN, NULL,
             DYNAMIC_TYPE_TMP_BUFFER);
         alignedIn = tmpIn + (CAAM_BUFFER_ALIGN -
@@ -313,7 +313,7 @@ static int DoAesCTR(unsigned int args[4], CAAM_BUFFER *buf, int sz)
     }
 
     if (buf[3].TheAddress % CAAM_BUFFER_ALIGN) {
-        /* output not alligned */
+        /* output not aligned */
         tmpOut = (byte*)XMALLOC(buf[3].Length + CAAM_BUFFER_ALIGN, NULL,
             DYNAMIC_TYPE_TMP_BUFFER);
         alignedOut = tmpOut + (CAAM_BUFFER_ALIGN -
@@ -467,7 +467,7 @@ int wc_CAAM_EccSign(const byte* in, int inlen, byte* out, word32* outlen,
     }
 
     if ((wc_ptr_t)in % CAAM_BUFFER_ALIGN) {
-        /* input not alligned */
+        /* input not aligned */
         tmpIn = (byte*)XMALLOC(inlen + CAAM_BUFFER_ALIGN, NULL,
             DYNAMIC_TYPE_TMP_BUFFER);
         alignedIn = tmpIn + (CAAM_BUFFER_ALIGN -
@@ -581,7 +581,7 @@ static int wc_CAAM_EccVerify_ex(mp_int* r, mp_int *s, const byte* hash,
     }
 
     if ((wc_ptr_t)hash % CAAM_BUFFER_ALIGN) {
-        /* input not alligned */
+        /* input not aligned */
         tmpIn = (byte*)XMALLOC(hashlen + CAAM_BUFFER_ALIGN, NULL,
             DYNAMIC_TYPE_TMP_BUFFER);
         alignedIn = tmpIn + (CAAM_BUFFER_ALIGN -

--- a/wolfcrypt/src/port/caam/wolfcaam_hash.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_hash.c
@@ -25,7 +25,8 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
-#if defined(WOLFSSL_CAAM) && defined(WOLFSSL_CAAM_HASH)
+#if defined(WOLFSSL_CAAM) && defined(WOLFSSL_CAAM_HASH) \
+	&& !defined(WOLFSSL_IMXRT1170_CAAM)
 
 #include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
@@ -84,7 +85,7 @@ static int _InitSha(byte* ctx, word32 ctxSz, void* heap, int devId,
     arg[1] = ctxSz + WC_CAAM_CTXLEN;
     arg[2] = (word32)devId;
 
-    if ((ret = wc_caamAddAndWait(buf, arg, type)) != 0) {
+    if ((ret = wc_caamAddAndWait(buf, 1, arg, type)) != 0) {
         WOLFSSL_MSG("Error with CAAM SHA init");
         return ret;
     }
@@ -137,7 +138,7 @@ static int _ShaUpdate(wc_Sha* sha, const byte* data, word32 len, word32 digestSz
             arg[0] = CAAM_ALG_UPDATE;
             arg[1] = digestSz + WC_CAAM_CTXLEN;
 
-            if ((ret = wc_caamAddAndWait(buf, arg, type)) != 0) {
+            if ((ret = wc_caamAddAndWait(buf, 2, arg, type)) != 0) {
                 WOLFSSL_MSG("Error with CAAM SHA update");
                 return ret;
             }
@@ -169,7 +170,7 @@ static int _ShaUpdate(wc_Sha* sha, const byte* data, word32 len, word32 digestSz
         arg[0] = CAAM_ALG_UPDATE;
         arg[1] = digestSz + WC_CAAM_CTXLEN;
 
-        if ((ret = wc_caamAddAndWait(buf, arg, type)) != 0) {
+        if ((ret = wc_caamAddAndWait(buf, 2, arg, type)) != 0) {
             WOLFSSL_MSG("Error with CAAM SHA update");
             return ret;
         }
@@ -244,7 +245,7 @@ int wc_CAAM_ShaHash(wc_Sha* sha, const byte* in, word32 inSz, byte* digest)
         ret = _wc_Hash_Grow(&(sha->msg), &(sha->used), &(sha->len), in,
                         inSz, sha->heap);
     #else
-        ret = _ShaUpdate(sha, data, len, SHA_DIGEST_SIZE, CAAM_SHA);
+        ret = _ShaUpdate(sha, in, inSz, SHA_DIGEST_SIZE, CAAM_SHA);
     #endif
     }
 
@@ -319,7 +320,7 @@ int wc_CAAM_Sha256Hash(wc_Sha256* sha256, const byte* in, word32 inSz,
     #ifdef WOLFSSL_HASH_KEEP
         ret = wc_Sha256_Grow(sha256, in, inSz);
     #else
-        ret = _ShaUpdate(sha256, data, len, SHA256_DIGEST_SIZE, CAAM_SHA256);
+        ret = _ShaUpdate(sha256, in, inSz, SHA256_DIGEST_SIZE, CAAM_SHA256);
     #endif
     }
 

--- a/wolfcrypt/src/port/caam/wolfcaam_hash.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_hash.c
@@ -71,21 +71,22 @@ static int _InitSha(byte* ctx, word32 ctxSz, void* heap, int devId,
 {
     CAAM_BUFFER buf[1];
     word32 arg[4];
-    int ret;
+    int ret, idx = 0;
 
     /* Set buffer for context */
-    buf[0].BufferType = DataBuffer | LastBuffer;
-    buf[0].TheAddress = (CAAM_ADDRESS)ctx;
-    buf[0].Length     = ctxSz + WC_CAAM_CTXLEN;
+    buf[idx].BufferType = DataBuffer | LastBuffer;
+    buf[idx].TheAddress = (CAAM_ADDRESS)ctx;
+    buf[idx].Length     = ctxSz + WC_CAAM_CTXLEN;
 #if defined(__INTEGRITY) || defined(INTEGRITY)
-    buf[0].Transferred = 0;
+    buf[idx].Transferred = 0;
 #endif
+    idx++;
 
     arg[0] = CAAM_ALG_INIT;
     arg[1] = ctxSz + WC_CAAM_CTXLEN;
     arg[2] = (word32)devId;
 
-    if ((ret = wc_caamAddAndWait(buf, 1, arg, type)) != 0) {
+    if ((ret = wc_caamAddAndWait(buf, idx, arg, type)) != 0) {
         WOLFSSL_MSG("Error with CAAM SHA init");
         return ret;
     }
@@ -99,7 +100,7 @@ static int _ShaUpdate(wc_Sha* sha, const byte* data, word32 len, word32 digestSz
 {
     CAAM_BUFFER buf[2];
     word32 arg[4];
-    int ret;
+    int ret, idx = 0;
     byte* local;
 
     if (sha == NULL ||(data == NULL && len > 0)) {
@@ -120,25 +121,27 @@ static int _ShaUpdate(wc_Sha* sha, const byte* data, word32 len, word32 digestSz
 
         if (sha->buffLen == WC_CAAM_HASH_BLOCK) {
             /* Set buffer for context */
-            buf[0].BufferType = DataBuffer;
-            buf[0].TheAddress = (CAAM_ADDRESS)sha->ctx;
-            buf[0].Length     = digestSz + WC_CAAM_CTXLEN;
+            buf[idx].BufferType = DataBuffer;
+            buf[idx].TheAddress = (CAAM_ADDRESS)sha->ctx;
+            buf[idx].Length     = digestSz + WC_CAAM_CTXLEN;
         #if defined(__INTEGRITY) || defined(INTEGRITY)
-            buf[0].Transferred = 0;
+            buf[idx].Transferred = 0;
         #endif
+            idx++;
 
             /* data to update with */
-            buf[1].BufferType = DataBuffer | LastBuffer;
-            buf[1].TheAddress = (CAAM_ADDRESS)sha->buffer;
-            buf[1].Length     = sha->buffLen;
+            buf[idx].BufferType = DataBuffer | LastBuffer;
+            buf[idx].TheAddress = (CAAM_ADDRESS)sha->buffer;
+            buf[idx].Length     = sha->buffLen;
         #if defined(__INTEGRITY) || defined(INTEGRITY)
-            buf[1].Transferred = 0;
+            buf[idx].Transferred = 0;
         #endif
+            idx++;
 
             arg[0] = CAAM_ALG_UPDATE;
             arg[1] = digestSz + WC_CAAM_CTXLEN;
 
-            if ((ret = wc_caamAddAndWait(buf, 2, arg, type)) != 0) {
+            if ((ret = wc_caamAddAndWait(buf, idx, arg, type)) != 0) {
                 WOLFSSL_MSG("Error with CAAM SHA update");
                 return ret;
             }
@@ -150,27 +153,30 @@ static int _ShaUpdate(wc_Sha* sha, const byte* data, word32 len, word32 digestSz
     if (len >= WC_CAAM_HASH_BLOCK) {
         word32 sz = len / WC_CAAM_HASH_BLOCK;
         sz = sz * WC_CAAM_HASH_BLOCK;
+        idx = 0;
 
         /* Set buffer for context */
-        buf[0].BufferType = DataBuffer;
-        buf[0].TheAddress = (CAAM_ADDRESS)sha->ctx;
-        buf[0].Length     = digestSz + WC_CAAM_CTXLEN;
+        buf[idx].BufferType = DataBuffer;
+        buf[idx].TheAddress = (CAAM_ADDRESS)sha->ctx;
+        buf[idx].Length     = digestSz + WC_CAAM_CTXLEN;
     #if defined(__INTEGRITY) || defined(INTEGRITY)
-        buf[0].Transferred = 0;
+        buf[idx].Transferred = 0;
     #endif
+        idx++;
 
         /* data to update with */
-        buf[1].BufferType = DataBuffer | LastBuffer;
-        buf[1].TheAddress = (CAAM_ADDRESS)data;
-        buf[1].Length     = sz;
+        buf[idx].BufferType = DataBuffer | LastBuffer;
+        buf[idx].TheAddress = (CAAM_ADDRESS)data;
+        buf[idx].Length     = sz;
     #if defined(__INTEGRITY) || defined(INTEGRITY)
-        buf[1].Transferred = 0;
+        buf[idx].Transferred = 0;
     #endif
+        idx++;
 
         arg[0] = CAAM_ALG_UPDATE;
         arg[1] = digestSz + WC_CAAM_CTXLEN;
 
-        if ((ret = wc_caamAddAndWait(buf, 2, arg, type)) != 0) {
+        if ((ret = wc_caamAddAndWait(buf, idx, arg, type)) != 0) {
             WOLFSSL_MSG("Error with CAAM SHA update");
             return ret;
         }
@@ -196,32 +202,34 @@ static int _ShaFinal(byte* ctx, word32 ctxSz, byte* in, word32 inSz, byte* out,
 {
     CAAM_BUFFER buf[2];
     word32 arg[4];
-    int ret;
+    int ret, idx = 0;
 
     if (ctx == NULL || out == NULL) {
         return BAD_FUNC_ARG;
     }
 
     /* Set buffer for context */
-    buf[0].BufferType = DataBuffer;
-    buf[0].TheAddress = (CAAM_ADDRESS)ctx;
-    buf[0].Length     = ctxSz;
+    buf[idx].BufferType = DataBuffer;
+    buf[idx].TheAddress = (CAAM_ADDRESS)ctx;
+    buf[idx].Length     = ctxSz;
 #if defined(__INTEGRITY) || defined(INTEGRITY)
-    buf[0].Transferred = 0;
+    buf[idx].Transferred = 0;
 #endif
+    idx++;
 
     /* add any potential left overs */
-    buf[1].BufferType = DataBuffer | LastBuffer;
-    buf[1].TheAddress = (CAAM_ADDRESS)in;
-    buf[1].Length     = inSz;
+    buf[idx].BufferType = DataBuffer | LastBuffer;
+    buf[idx].TheAddress = (CAAM_ADDRESS)in;
+    buf[idx].Length     = inSz;
 #if defined(__INTEGRITY) || defined(INTEGRITY)
-    buf[1].Transferred = 0;
+    buf[idx].Transferred = 0;
 #endif
+    idx++;
 
     arg[0] = CAAM_ALG_FINAL;
     arg[1] = ctxSz + WC_CAAM_CTXLEN;
 
-    if ((ret = wc_caamAddAndWait(buf, 2, arg, type)) != 0) {
+    if ((ret = wc_caamAddAndWait(buf, idx, arg, type)) != 0) {
         WOLFSSL_MSG("Error with CAAM SHA Final");
         return ret;
     }

--- a/wolfcrypt/src/port/caam/wolfcaam_init.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_init.c
@@ -22,11 +22,21 @@
     #include <config.h>
 #endif
 
+
+/*
+ * WOLFSSL_CAAM is used to enable CAAM support
+ *
+ * Different Hardware Ports
+ * WOLFSSL_IMX6_CAAM build for QNX + IMX6
+ * WOLFSSL_SECO_CAAM make use of NXP's SECO HSM library on i.MX8
+ * WOLFSSL_IMXRT1170_CAAM make use of NXP's CAAM driver for RT1170 series boards
+ *
+ */
 #include <wolfssl/wolfcrypt/settings.h>
 
 #if defined(WOLFSSL_IMX6_CAAM) || defined(WOLFSSL_IMX6_CAAM_RNG) || \
     defined(WOLFSSL_IMX6UL_CAAM) || defined(WOLFSSL_IMX6_CAAM_BLOB) || \
-    defined(WOLFSSL_SECO_CAAM)
+    defined(WOLFSSL_SECO_CAAM) || defined(WOLFSSL_IMXRT1170_CAAM)
 
 #include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
@@ -175,7 +185,6 @@ static int wc_CAAM_router(int devId, wc_CryptoInfo* info, void* ctx)
 
         case WC_ALGO_TYPE_HASH:
         #ifdef WOLFSSL_CAAM_HASH
-        #ifdef WOLFSSL_SECO_CAAM
             switch(info->hash.type) {
                 #ifdef WOLFSSL_SHA224
                 case WC_HASH_TYPE_SHA224:
@@ -213,7 +222,6 @@ static int wc_CAAM_router(int devId, wc_CryptoInfo* info, void* ctx)
                     WOLFSSL_MSG("Unknown or unsupported hash type");
                     ret = CRYPTOCB_UNAVAILABLE;
             }
-        #endif
         #endif /* WOLFSSL_CAAM_HASH */
         break;
 

--- a/wolfcrypt/src/port/caam/wolfcaam_qnx.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_qnx.c
@@ -36,7 +36,7 @@
 
 /* for devctl use */
 int caamFd = -1;
-wolfSSL_Mutex caamMutex;
+static wolfSSL_Mutex caamMutex;
 
 /* return 0 on success */
 int wc_CAAMInitInterface()

--- a/wolfcrypt/src/port/caam/wolfcaam_seco.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_seco.c
@@ -39,7 +39,7 @@
 
 #define MAX_SECO_TIMEOUT 1000
 
-wolfSSL_Mutex caamMutex;
+static wolfSSL_Mutex caamMutex;
 static pthread_t tid;
 static uint32_t nvm_status = 0;
 static hsm_hdl_t hsm_session;

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -170,6 +170,7 @@ int wc_RNG_GenerateByte(WC_RNG* rng, byte* b)
 #elif defined(WOLFSSL_ZEPHYR)
 #elif defined(WOLFSSL_TELIT_M2MB)
 #elif defined(WOLFSSL_SCE) && !defined(WOLFSSL_SCE_NO_TRNG)
+#elif defined(WOLFSSL_IMXRT1170_CAAM)
 #elif defined(WOLFSSL_GETRANDOM)
     #include <errno.h>
     #include <sys/random.h>
@@ -3321,7 +3322,8 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     }
 
 #elif (defined(WOLFSSL_IMX6_CAAM) || defined(WOLFSSL_IMX6_CAAM_RNG) || \
-       defined(WOLFSSL_SECO_CAAM) || defined(WOLFSSL_QNX_CAAM))
+       defined(WOLFSSL_SECO_CAAM) || defined(WOLFSSL_QNX_CAAM) || \
+       defined(WOLFSSL_IMXRT1170_CAAM))
 
     #include <wolfssl/wolfcrypt/port/caam/wolfcaam.h>
 
@@ -3358,7 +3360,9 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
             if (ret != RAN_BLOCK_E && ret != 0) {
                 return ret;
             }
+#ifndef WOLFSSL_IMXRT1170_CAAM
             usleep(100);
+#endif
         }
 
         if (i == times && ret != 0) {

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -46,6 +46,10 @@
     #include <wolfssl/wolfcrypt/cryptocb.h>
 #endif
 
+#ifdef WOLFSSL_IMXRT1170_CAAM
+#include <wolfssl/wolfcrypt/port/caam/wolfcaam_fsl_nxp.h>
+#endif
+
 /* fips wrapper calls, user can call direct */
 #if defined(HAVE_FIPS) && \
     (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 2))
@@ -549,6 +553,9 @@ int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
 #else
     (void)devId;
 #endif /* WOLFSSL_ASYNC_CRYPT */
+#ifdef WOLFSSL_IMXRT1170_CAAM
+   ret = wc_CAAM_HashInit(&sha->hndl, &sha->ctx, WC_HASH_TYPE_SHA);
+#endif
 
     return ret;
 }

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -84,6 +84,11 @@ on the specific device platform.
     #include <wolfssl/wolfcrypt/cryptocb.h>
 #endif
 
+#ifdef WOLFSSL_IMXRT1170_CAAM
+    #include <wolfssl/wolfcrypt/port/caam/wolfcaam_fsl_nxp.h>
+#endif
+
+
 /* determine if we are using Espressif SHA hardware acceleration */
 #undef WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW
 #if defined(WOLFSSL_ESP32WROOM32_CRYPT) && \
@@ -840,6 +845,9 @@ static int InitSha256(wc_Sha256* sha256)
     #else
         (void)devId;
     #endif /* WOLFSSL_ASYNC_CRYPT */
+    #ifdef WOLFSSL_IMXRT1170_CAAM
+         ret = wc_CAAM_HashInit(&sha256->hndl, &sha256->ctx, WC_HASH_TYPE_SHA256);
+    #endif
 
         return ret;
     }
@@ -1585,7 +1593,9 @@ static int InitSha256(wc_Sha256* sha256)
     #else
         (void)devId;
     #endif /* WOLFSSL_ASYNC_CRYPT */
-
+#ifdef WOLFSSL_IMXRT1170_CAAM
+     ret = wc_CAAM_HashInit(&sha224->hndl, &sha224->ctx, WC_HASH_TYPE_SHA224);
+#endif
         return ret;
     }
 

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -47,6 +47,10 @@
     #include <wolfssl/wolfcrypt/cryptocb.h>
 #endif
 
+#ifdef WOLFSSL_IMXRT1170_CAAM
+    #include <wolfssl/wolfcrypt/port/caam/wolfcaam_fsl_nxp.h>
+#endif
+
 /* deprecated USE_SLOW_SHA2 (replaced with USE_SLOW_SHA512) */
 #if defined(USE_SLOW_SHA2) && !defined(USE_SLOW_SHA512)
     #define USE_SLOW_SHA512
@@ -606,7 +610,9 @@ static int InitSha512_Family(wc_Sha512* sha512, void* heap, int devId,
 #else
     (void)devId;
 #endif /* WOLFSSL_ASYNC_CRYPT */
-
+#ifdef WOLFSSL_IMXRT1170_CAAM
+     ret = wc_CAAM_HashInit(&sha512->hndl, &sha512->ctx, WC_HASH_TYPE_SHA512);
+#endif
     return ret;
 }
 
@@ -1436,7 +1442,9 @@ int wc_InitSha384_ex(wc_Sha384* sha384, void* heap, int devId)
 #else
     (void)devId;
 #endif /* WOLFSSL_ASYNC_CRYPT */
-
+#ifdef WOLFSSL_IMXRT1170_CAAM
+     ret = wc_CAAM_HashInit(&sha384->hndl, &sha384->ctx, WC_HASH_TYPE_SHA384);
+#endif
     return ret;
 }
 

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -80,7 +80,7 @@
 
 #if defined(WOLFSSL_IMX6_CAAM) || defined(WOLFSSL_IMX6_CAAM_RNG) || \
     defined(WOLFSSL_IMX6UL_CAAM) || defined(WOLFSSL_IMX6_CAAM_BLOB) || \
-    defined(WOLFSSL_SECO_CAAM)
+    defined(WOLFSSL_SECO_CAAM) || defined(WOLFSSL_IMXRT1170_CAAM)
     #include <wolfssl/wolfcrypt/port/caam/wolfcaam.h>
 #endif
 #if defined(WOLFSSL_DEVCRYPTO)
@@ -347,7 +347,7 @@ int wolfCrypt_Init(void)
 
 #if defined(WOLFSSL_IMX6_CAAM) || defined(WOLFSSL_IMX6_CAAM_RNG) || \
     defined(WOLFSSL_IMX6UL_CAAM) || defined(WOLFSSL_IMX6_CAAM_BLOB) || \
-    defined(WOLFSSL_SECO_CAAM)
+    defined(WOLFSSL_SECO_CAAM) || defined(WOLFSSL_IMXRT1170_CAAM)
         if ((ret = wc_caamInit()) != 0) {
             return ret;
         }
@@ -433,7 +433,7 @@ int wolfCrypt_Cleanup(void)
 
     #if defined(WOLFSSL_IMX6_CAAM) || defined(WOLFSSL_IMX6_CAAM_RNG) || \
         defined(WOLFSSL_IMX6_CAAM_BLOB)  || \
-        defined(WOLFSSL_SECO_CAAM)
+        defined(WOLFSSL_SECO_CAAM) || defined(WOLFSSL_IMXRT1170_CAAM)
         wc_caamFree();
     #endif
     #if defined(WOLFSSL_CRYPTOCELL)
@@ -2785,6 +2785,34 @@ time_t fsl_time(time_t* t)
 {
     *t = RTC_GetSecondsTimerCount(RTC);
     return *t;
+}
+#endif
+
+#if defined(FREESCALE_SNVS_RTC)
+time_t fsl_time(time_t* t)
+{
+    struct tm tm_time;
+    time_t ret;
+
+    snvs_hp_rtc_datetime_t rtcDate;
+    snvs_hp_rtc_config_t snvsRtcConfig;
+
+    SNVS_HP_RTC_GetDefaultConfig(&snvsRtcConfig);
+    SNVS_HP_RTC_Init(SNVS, &snvsRtcConfig);
+
+    SNVS_HP_RTC_GetDatetime(SNVS, &rtcDate);
+
+    tm_time.tm_year  = rtcDate.year;
+    tm_time.tm_mon   = rtcDate.month;
+    tm_time.tm_mday  = rtcDate.day;
+    tm_time.tm_hour  = rtcDate.hour;
+    tm_time.tm_min   = rtcDate.minute;
+    tm_time.tm_sec   = rtcDate.second;
+
+    ret = mktime(&tm_time);
+    if (t != NULL)
+        *t = ret;
+    return ret;
 }
 #endif
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -593,7 +593,7 @@ WOLFSSL_TEST_SUBROUTINE int mutex_test(void);
 #if defined(USE_WOLFSSL_MEMORY) && !defined(FREERTOS)
 WOLFSSL_TEST_SUBROUTINE int memcb_test(void);
 #endif
-#ifdef WOLFSSL_IMX6_CAAM_BLOB
+#ifdef WOLFSSL_CAAM_BLOB
 WOLFSSL_TEST_SUBROUTINE int blob_test(void);
 #endif
 
@@ -1523,7 +1523,7 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
         TEST_PASS("memcb    test passed!\n");
 #endif
 
-#ifdef WOLFSSL_IMX6_CAAM_BLOB
+#ifdef WOLFSSL_CAAM_BLOB
     if ( (ret = blob_test()) != 0)
         return err_sys("blob     test failed!\n", ret);
     else
@@ -13433,15 +13433,21 @@ WOLFSSL_TEST_SUBROUTINE int memory_test(void)
         byte *c = NULL;
         byte *b = (byte*)XMALLOC(MEM_TEST_SZ, HEAP_HINT,
                                  DYNAMIC_TYPE_TMP_BUFFER);
+        #ifndef WOLFSSL_NO_REALLOC
         if (b) {
             c = (byte*)XREALLOC(b, MEM_TEST_SZ+sizeof(word32), HEAP_HINT,
                                 DYNAMIC_TYPE_TMP_BUFFER);
             if (c)
                 b = c;
         }
+        #endif
         if (b)
             XFREE(b, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-        if ((b == NULL) || (c == NULL)) {
+        if ((b == NULL)
+        #ifndef WOLFSSL_NO_REALLOC
+                || (c == NULL)
+        #endif
+        ) {
             return -7217;
         }
     }
@@ -24212,7 +24218,7 @@ static int ecc_test_make_pub(WC_RNG* rng)
     /* create a new key since above test for loading key is not supported */
 #if defined(WOLFSSL_CRYPTOCELL) || defined(NO_ECC256) || \
     defined(WOLFSSL_QNX_CAAM) || defined(WOLFSSL_SE050) || \
-    defined(WOLFSSL_SECO_CAAM)
+    defined(WOLFSSL_SECO_CAAM) || defined(WOLFSSL_IMXRT1170_CAAM)
     ret  = wc_ecc_make_key(rng, ECC_KEYGEN_SIZE, key);
     if (ret != 0) {
         ERROR_OUT(-9861, done);
@@ -43534,7 +43540,7 @@ exit_memcb:
 #endif /* USE_WOLFSSL_MEMORY && !WOLFSSL_NO_MALLOC */
 
 
-#ifdef WOLFSSL_IMX6_CAAM_BLOB
+#if defined(WOLFSSL_CAAM_BLOB)
 WOLFSSL_TEST_SUBROUTINE int blob_test(void)
 {
     int ret = 0;

--- a/wolfssl/openssl/sha.h
+++ b/wolfssl/openssl/sha.h
@@ -99,9 +99,13 @@ typedef WOLFSSL_SHA_CTX SHA_CTX;
 
 /* adder for HW crypto */
 #ifdef STM32_HASH
-#define CTX_SHA2_HW_ADDER 34
+    #define CTX_SHA2_HW_ADDER 34
+#elif defined(WOLFSSL_IMXRT1170_CAAM)
+    #define CTX_SHA2_HW_ADDER sizeof(caam_hash_ctx_t) + sizeof(caam_handle_t)
+#elif defined(WOLFSSL_ESPWROOM32)
+    #define CTX_SHA2_HW_ADDER sizeof(WC_ESP32SHA)
 #else
-#define CTX_SHA2_HW_ADDER 0
+    #define CTX_SHA2_HW_ADDER 0
 #endif
 
 #ifdef WOLFSSL_SHA224
@@ -111,13 +115,8 @@ typedef WOLFSSL_SHA_CTX SHA_CTX;
  * to Sha224, is expected to also be 16 byte aligned addresses.  */
 typedef struct WOLFSSL_SHA224_CTX {
     /* big enough to hold wolfcrypt Sha224, but check on init */
-#if defined(WOLFSSL_IMXRT1170_CAAM)
-    ALIGN16 void* holder[(274 + CTX_SHA2_HW_ADDER + WC_ASYNC_DEV_SIZE +
-        sizeof(caam_hash_ctx_t) + sizeof(caam_handle_t)) / sizeof(void*)];
-#else
     ALIGN16 void* holder[(274 + CTX_SHA2_HW_ADDER + WC_ASYNC_DEV_SIZE) /
         sizeof(void*)];
-#endif
 #if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
     ALIGN16 void* keephash_holder[sizeof(void*) + (2 * sizeof(unsigned int))];
 #endif
@@ -157,13 +156,8 @@ typedef WOLFSSL_SHA224_CTX SHA224_CTX;
  * to Sha256, is expected to also be 16 byte aligned addresses.  */
 typedef struct WOLFSSL_SHA256_CTX {
     /* big enough to hold wolfcrypt Sha256, but check on init */
-#if defined(WOLFSSL_IMXRT1170_CAAM)
-    ALIGN16 void* holder[(274 + CTX_SHA2_HW_ADDER + WC_ASYNC_DEV_SIZE +
-        sizeof(caam_hash_ctx_t) + sizeof(caam_handle_t)) / sizeof(void*)];
-#else
     ALIGN16 void* holder[(274 + CTX_SHA2_HW_ADDER + WC_ASYNC_DEV_SIZE) /
         sizeof(void*)];
-#endif
 #if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
     ALIGN16 void* keephash_holder[sizeof(void*) + (2 * sizeof(unsigned int))];
 #endif
@@ -213,12 +207,7 @@ typedef WOLFSSL_SHA256_CTX SHA256_CTX;
 #ifdef WOLFSSL_SHA384
 typedef struct WOLFSSL_SHA384_CTX {
     /* big enough to hold wolfCrypt Sha384, but check on init */
-#if defined(WOLFSSL_IMXRT1170_CAAM)
-    void* holder[(268 + WC_ASYNC_DEV_SIZE +
-            sizeof(caam_hash_ctx_t) + sizeof(caam_handle_t)) / sizeof(void*)];
-#else
-    void* holder[(268 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
-#endif
+    void* holder[(268 + CTX_SHA2_HW_ADDER + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
 #if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
     void* keephash_holder[sizeof(void*) + (2 * sizeof(unsigned int))];
 #endif
@@ -253,12 +242,7 @@ typedef WOLFSSL_SHA384_CTX SHA384_CTX;
 #ifdef WOLFSSL_SHA512
 typedef struct WOLFSSL_SHA512_CTX {
     /* big enough to hold wolfCrypt Sha384, but check on init */
-#if defined(WOLFSSL_IMXRT1170_CAAM)
-    void* holder[(288 + WC_ASYNC_DEV_SIZE +
-            sizeof(caam_hash_ctx_t) + sizeof(caam_handle_t)) / sizeof(void*)];
-#else
-    void* holder[(288 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
-#endif
+    void* holder[(288 + CTX_SHA2_HW_ADDER + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
 #if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
     void* keephash_holder[sizeof(void*) + (2 * sizeof(unsigned int))];
 #endif

--- a/wolfssl/openssl/sha.h
+++ b/wolfssl/openssl/sha.h
@@ -40,16 +40,20 @@
 typedef struct WOLFSSL_SHA_CTX {
     /* big enough to hold wolfcrypt Sha, but check on init */
 #if defined(STM32_HASH)
-    void* holder[(112 + WC_ASYNC_DEV_SIZE + sizeof(STM32_HASH_Context)) / sizeof(void*)];
+    void* holder[(112 + WC_ASYNC_DEV_SIZE + sizeof(STM32_HASH_Context)) /
+        sizeof(void*)];
+#elif defined(WOLFSSL_IMXRT1170_CAAM)
+    void* holder[(112 + WC_ASYNC_DEV_SIZE + sizeof(caam_hash_ctx_t) +
+        sizeof(caam_handle_t)) / sizeof(void*)];
 #else
     void* holder[(112 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
 #endif
-    #if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
+#if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
     void* keephash_holder[sizeof(void*) + (2 * sizeof(unsigned int))];
-    #endif
-    #ifdef WOLF_CRYPTO_CB
+#endif
+#ifdef WOLF_CRYPTO_CB
     void* cryptocb_holder[(sizeof(int) + sizeof(void*) + 4) / sizeof(void*)];
-    #endif
+#endif
 } WOLFSSL_SHA_CTX;
 
 WOLFSSL_API int wolfSSL_SHA_Init(WOLFSSL_SHA_CTX* sha);
@@ -107,8 +111,20 @@ typedef WOLFSSL_SHA_CTX SHA_CTX;
  * to Sha224, is expected to also be 16 byte aligned addresses.  */
 typedef struct WOLFSSL_SHA224_CTX {
     /* big enough to hold wolfcrypt Sha224, but check on init */
+#if defined(WOLFSSL_IMXRT1170_CAAM)
+    ALIGN16 void* holder[(274 + CTX_SHA2_HW_ADDER + WC_ASYNC_DEV_SIZE +
+        sizeof(caam_hash_ctx_t) + sizeof(caam_handle_t)) / sizeof(void*)];
+#else
     ALIGN16 void* holder[(274 + CTX_SHA2_HW_ADDER + WC_ASYNC_DEV_SIZE) /
-                                                                 sizeof(void*)];
+        sizeof(void*)];
+#endif
+#if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
+    ALIGN16 void* keephash_holder[sizeof(void*) + (2 * sizeof(unsigned int))];
+#endif
+#ifdef WOLF_CRYPTO_CB
+    ALIGN16 void* cryptocb_holder[(sizeof(int) + sizeof(void*) + 4) /
+        sizeof(void*)];
+#endif
 } WOLFSSL_SHA224_CTX;
 
 WOLFSSL_API int wolfSSL_SHA224_Init(WOLFSSL_SHA224_CTX* sha);
@@ -141,8 +157,20 @@ typedef WOLFSSL_SHA224_CTX SHA224_CTX;
  * to Sha256, is expected to also be 16 byte aligned addresses.  */
 typedef struct WOLFSSL_SHA256_CTX {
     /* big enough to hold wolfcrypt Sha256, but check on init */
+#if defined(WOLFSSL_IMXRT1170_CAAM)
+    ALIGN16 void* holder[(274 + CTX_SHA2_HW_ADDER + WC_ASYNC_DEV_SIZE +
+        sizeof(caam_hash_ctx_t) + sizeof(caam_handle_t)) / sizeof(void*)];
+#else
     ALIGN16 void* holder[(274 + CTX_SHA2_HW_ADDER + WC_ASYNC_DEV_SIZE) /
-                                                                 sizeof(void*)];
+        sizeof(void*)];
+#endif
+#if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
+    ALIGN16 void* keephash_holder[sizeof(void*) + (2 * sizeof(unsigned int))];
+#endif
+#ifdef WOLF_CRYPTO_CB
+    ALIGN16 void* cryptocb_holder[(sizeof(int) + sizeof(void*) + 4) /
+        sizeof(void*)];
+#endif
 } WOLFSSL_SHA256_CTX;
 
 WOLFSSL_API int wolfSSL_SHA256_Init(WOLFSSL_SHA256_CTX* sha256);
@@ -185,7 +213,18 @@ typedef WOLFSSL_SHA256_CTX SHA256_CTX;
 #ifdef WOLFSSL_SHA384
 typedef struct WOLFSSL_SHA384_CTX {
     /* big enough to hold wolfCrypt Sha384, but check on init */
-    void* holder[(288 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
+#if defined(WOLFSSL_IMXRT1170_CAAM)
+    void* holder[(268 + WC_ASYNC_DEV_SIZE +
+            sizeof(caam_hash_ctx_t) + sizeof(caam_handle_t)) / sizeof(void*)];
+#else
+    void* holder[(268 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
+#endif
+#if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
+    void* keephash_holder[sizeof(void*) + (2 * sizeof(unsigned int))];
+#endif
+#ifdef WOLF_CRYPTO_CB
+    void* cryptocb_holder[(sizeof(int) + sizeof(void*) + 4) / sizeof(void*)];
+#endif
 } WOLFSSL_SHA384_CTX;
 
 WOLFSSL_API int wolfSSL_SHA384_Init(WOLFSSL_SHA384_CTX* sha);
@@ -214,7 +253,18 @@ typedef WOLFSSL_SHA384_CTX SHA384_CTX;
 #ifdef WOLFSSL_SHA512
 typedef struct WOLFSSL_SHA512_CTX {
     /* big enough to hold wolfCrypt Sha384, but check on init */
+#if defined(WOLFSSL_IMXRT1170_CAAM)
+    void* holder[(288 + WC_ASYNC_DEV_SIZE +
+            sizeof(caam_hash_ctx_t) + sizeof(caam_handle_t)) / sizeof(void*)];
+#else
     void* holder[(288 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
+#endif
+#if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
+    void* keephash_holder[sizeof(void*) + (2 * sizeof(unsigned int))];
+#endif
+#ifdef WOLF_CRYPTO_CB
+    void* cryptocb_holder[(sizeof(int) + sizeof(void*) + 4) / sizeof(void*)];
+#endif
 } WOLFSSL_SHA512_CTX;
 
 WOLFSSL_API int wolfSSL_SHA512_Init(WOLFSSL_SHA512_CTX* sha);

--- a/wolfssl/wolfcrypt/include.am
+++ b/wolfssl/wolfcrypt/include.am
@@ -182,7 +182,8 @@ nobase_include_HEADERS+= wolfssl/wolfcrypt/port/caam/wolfcaam.h \
                          wolfssl/wolfcrypt/port/caam/wolfcaam_cmac.h \
                          wolfssl/wolfcrypt/port/caam/wolfcaam_aes.h \
                          wolfssl/wolfcrypt/port/caam/wolfcaam_qnx.h \
-                         wolfssl/wolfcrypt/port/caam/wolfcaam_seco.h
+                         wolfssl/wolfcrypt/port/caam/wolfcaam_seco.h \
+                         wolfssl/wolfcrypt/port/caam/wolfcaam_fsl_nxp.h
 endif
 
 if BUILD_IOTSAFE

--- a/wolfssl/wolfcrypt/port/caam/wolfcaam.h
+++ b/wolfssl/wolfcrypt/port/caam/wolfcaam.h
@@ -30,10 +30,13 @@
     #include <wolfssl/wolfcrypt/port/caam/wolfcaam_qnx.h>
 #elif defined(WOLFSSL_SECO_CAAM)
     #include <wolfssl/wolfcrypt/port/caam/wolfcaam_seco.h>
+#elif defined(WOLFSSL_IMXRT1170_CAAM)
+    #include <wolfssl/wolfcrypt/port/caam/wolfcaam_fsl_nxp.h>
 #endif
 
 #if defined(WOLFSSL_IMX6_CAAM) || defined(WOLFSSL_IMX6_CAAM_RNG) || \
-    defined(WOLFSSL_QNX_CAAM) || defined(WOLFSSL_SECO_CAAM)
+    defined(WOLFSSL_QNX_CAAM) || defined(WOLFSSL_SECO_CAAM) || \
+	defined(WOLFSSL_IMXRT1170_CAAM)
 
 
 /* unique devId for CAAM use on crypto callbacks */
@@ -92,7 +95,8 @@ WOLFSSL_API int wc_caamCoverKey(byte* in, word32 inSz, byte* out, word32* outSz,
 #define WC_CAAM_BLACK_KEYMOD_SZ 16
 #define WC_CAAM_MAX_ENTROPY 44
 
-#if !defined(WOLFSSL_QNX_CAAM) && !defined(WOLFSSL_SECO_CAAM)
+#if !defined(WOLFSSL_QNX_CAAM) && !defined(WOLFSSL_SECO_CAAM) && \
+	!defined(WOLFSSL_IMXRT1170_CAAM)
     WOLFSSL_API int wc_caamSetResource(IODevice ioDev);
     #ifndef WC_CAAM_READ
         #define WC_CAAM_READ(reg)      wc_caamReadRegister((reg))

--- a/wolfssl/wolfcrypt/port/caam/wolfcaam_fsl_nxp.h
+++ b/wolfssl/wolfcrypt/port/caam/wolfcaam_fsl_nxp.h
@@ -1,0 +1,91 @@
+/* wolfcaam_fsl_nxp.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+
+/* This file is for interacting with the driver code */
+#ifndef WOLFCAAM_FSL_NXP_H
+#define WOLFCAAM_FSL_NXP_H
+
+#include <wolfssl/wolfcrypt/settings.h>
+
+#ifdef WOLFSSL_IMXRT1170_CAAM
+
+#include "fsl_device_registers.h"
+#include "fsl_caam.h"
+
+/* check for patched version of fsl_caam */
+#ifdef CAAM_ECC_EXPANSION
+    #define WOLFSSL_CAAM_ECC
+#endif
+#ifdef CAAM_BLOB_EXPANSION
+    #define WOLFSSL_CAAM_BLOB
+#endif
+
+#define Error int
+#define Value int
+#define Boolean int
+#define Success 1
+#define Failure 0
+#define INTERRUPT_Panic()
+#define MemoryMapMayNotBeEmpty -1
+#define CAAM_WAITING -2
+#define NoActivityReady -1
+#define MemoryOperationNotPerformed -1
+
+#define CAAM_ADDRESS uintptr_t
+#ifndef WOLFSSL_CAAM_BUFFER
+#define WOLFSSL_CAAM_BUFFER
+    typedef struct CAAM_BUFFER {
+        int BufferType;
+        CAAM_ADDRESS TheAddress;
+        int Length;
+    } CAAM_BUFFER;
+#endif
+
+#define DataBuffer 0
+#define LastBuffer 0
+#define Success 1
+
+/* unique devId for CAAM use on crypto callbacks */
+#define WOLFSSL_CAAM_DEVID 7
+
+#include <wolfssl/wolfcrypt/port/caam/wolfcaam_ecdsa.h>
+#include <wolfssl/wolfcrypt/port/caam/wolfcaam_aes.h>
+#include <wolfssl/wolfcrypt/port/caam/wolfcaam_hash.h>
+#include <wolfssl/wolfcrypt/cryptocb.h>
+
+#define ResourceNotAvailable -3
+#define CAAM_WAITING -2
+
+WOLFSSL_LOCAL int SynchronousSendRequest(int type, unsigned int args[4],
+        CAAM_BUFFER *buf, int sz);
+WOLFSSL_LOCAL int wc_CAAMInitInterface(void);
+WOLFSSL_LOCAL void wc_CAAMFreeInterface(void);
+
+#define CAAM_SEND_REQUEST(type, sz, arg, buf) \
+        SynchronousSendRequest((type), (arg), (buf), (sz))
+#define CAAM_INIT_INTERFACE wc_CAAMInitInterface
+#define CAAM_FREE_INTERFACE wc_CAAMFreeInterface
+#endif
+
+#define CAAM_BUFFER_ALIGN 16
+
+#endif /* WOLFCAAM_QNX_H */

--- a/wolfssl/wolfcrypt/port/caam/wolfcaam_hash.h
+++ b/wolfssl/wolfcrypt/port/caam/wolfcaam_hash.h
@@ -26,6 +26,10 @@
 
 #include <wolfssl/wolfcrypt/sha256.h>
 
+#ifdef WOLFSSL_IMXRT1170_CAAM
+WOLFSSL_LOCAL int wc_CAAM_HashInit(caam_handle_t* hndl, caam_hash_ctx_t* ctx, int type);
+#endif
+
 #ifndef NO_SHA
 WOLFSSL_LOCAL int wc_CAAM_ShaHash(wc_Sha* sha, const byte* in, word32 inSz,
     byte* digest);

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1803,6 +1803,12 @@ extern void uITRON4_free(void *p) ;
 #endif
 #endif
 
+#ifdef WOLFSSL_IMXRT1170_CAAM
+    #define WOLFSSL_CAAM
+    #define WOLFSSL_CAAM_HASH
+    #define WOLFSSL_CAAM_CIPHER
+#endif
+
 /* If DCP is used without SINGLE_THREADED, enforce WOLFSSL_CRYPT_HW_MUTEX */
 #if defined(WOLFSSL_IMXRT_DCP) && !defined(SINGLE_THREADED)
     #undef WOLFSSL_CRYPT_HW_MUTEX

--- a/wolfssl/wolfcrypt/sha.h
+++ b/wolfssl/wolfcrypt/sha.h
@@ -52,6 +52,11 @@
     #include "fsl_ltc.h"
 #endif
 
+#if defined(WOLFSSL_IMXRT1170_CAAM)
+    #include "fsl_device_registers.h"
+    #include "fsl_caam.h"
+#endif
+
 #ifdef WOLFSSL_IMXRT_DCP
     #include "fsl_dcp.h"
 #endif
@@ -155,6 +160,10 @@ struct wc_Sha {
     #ifdef WOLF_CRYPTO_CB
         int    devId;
         void*  devCtx; /* generic crypto callback context */
+    #endif
+    #ifdef WOLFSSL_IMXRT1170_CAAM
+        caam_hash_ctx_t ctx;
+        caam_handle_t hndl;
     #endif
     #if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
         byte*  msg;

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -61,6 +61,11 @@
     #include "fsl_ltc.h"
 #endif
 
+#if defined(WOLFSSL_IMXRT1170_CAAM)
+    #include "fsl_device_registers.h"
+    #include "fsl_caam.h"
+#endif
+
 #ifdef WOLFSSL_IMXRT_DCP
     #include "fsl_dcp.h"
 #endif
@@ -222,6 +227,10 @@ struct wc_Sha256 {
 #ifdef WOLF_CRYPTO_CB
     int    devId;
     void*  devCtx; /* generic crypto callback context */
+#endif
+#ifdef WOLFSSL_IMXRT1170_CAAM
+    caam_hash_ctx_t ctx;
+    caam_handle_t hndl;
 #endif
 #ifdef WOLFSSL_HASH_FLAGS
     word32 flags; /* enum wc_HashFlags in hash.h */

--- a/wolfssl/wolfcrypt/sha512.h
+++ b/wolfssl/wolfcrypt/sha512.h
@@ -91,6 +91,11 @@
     #include <wolfssl/wolfcrypt/port/kcapi/kcapi_hash.h>
 #endif
 
+#if defined(WOLFSSL_IMXRT1170_CAAM)
+    #include "fsl_device_registers.h"
+    #include "fsl_caam.h"
+#endif
+
 #if defined(_MSC_VER)
     #define SHA512_NOINLINE __declspec(noinline)
 #elif defined(__IAR_SYSTEMS_ICC__) || defined(__GNUC__)
@@ -191,6 +196,10 @@ struct wc_Sha512 {
 #endif
 #ifdef WOLFSSL_HASH_FLAGS
     word32 flags; /* enum wc_HashFlags in hash.h */
+#endif
+#ifdef WOLFSSL_IMXRT1170_CAAM
+    caam_hash_ctx_t ctx;
+    caam_handle_t hndl;
 #endif
 #endif /* WOLFSSL_PSOC6_CRYPTO */
 };

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -833,7 +833,13 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
         #ifndef XTIME
         #define XTIME(t1) fsl_time((t1))
     #endif
-
+#elif defined(FREESCALE_SNVS_RTC)
+    #include <time.h>
+    #include "fsl_snvs_hp.h"
+    time_t fsl_time(time_t* t);
+    #ifndef XTIME
+        #define XTIME(t1) fsl_time((t1))
+    #endif
 #elif defined(FREESCALE_MQX) || defined(FREESCALE_KSDK_MQX)
     #ifdef FREESCALE_MQX_4_0
         #include <time.h>

--- a/wolfssl/wolfcrypt/wolfmath.h
+++ b/wolfssl/wolfcrypt/wolfmath.h
@@ -65,7 +65,7 @@ WOLFSSL_API int mp_rand(mp_int* a, int digits, WC_RNG* rng);
 
 #define WC_TYPE_HEX_STR 1
 #define WC_TYPE_UNSIGNED_BIN 2
-#if defined(WOLFSSL_QNX_CAAM)
+#if defined(WOLFSSL_QNX_CAAM) || defined(WOLFSSL_IMXRT1170_CAAM)
     #define WC_TYPE_BLACK_KEY 3
 #endif
 


### PR DESCRIPTION
Contains MCUExpresso project for building on RT1170 and patches to expand the existing NXP CAAM driver for ECC and Blobs.