### PR TITLE
don't call external implemenation of kyber from benchmark anymore.

### DIFF
--- a/wolfcrypt/benchmark/benchmark.h
+++ b/wolfcrypt/benchmark/benchmark.h
@@ -116,8 +116,6 @@ void bench_pbkdf2(void);
 void bench_falconKeySign(byte level);
 void bench_dilithiumKeySign(byte level);
 void bench_sphincsKeySign(byte level, byte optim);
-void bench_pqcKemKeygen(word32 alg);
-void bench_pqcKemEncapDecap(word32 alg);
 
 void bench_stats_print(void);
 


### PR DESCRIPTION
Tested with: 
```
./configure --with-liboqs --enable-intelasm
make all 
./wolfcrypt/benchmark/benchmark
```
...and...
```
./configure --enable-kyber=wolfssl,512,768,1024 --enable-intelasm
make all 
./wolfcrypt/benchmark/benchmark
```
