### PR TITLE
Added extended LoadCA for the manager on the API.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -7118,10 +7118,19 @@ static WC_INLINE WOLFSSL_METHOD* cm_pick_method(void)
 int wolfSSL_CertManagerLoadCABuffer(WOLFSSL_CERT_MANAGER* cm,
                                    const unsigned char* in, long sz, int format)
 {
+    return wolfSSL_CertManagerLoadCABuffer_ex(cm, in, sz, format, 0,
+                                             WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS);
+}
+
+
+int wolfSSL_CertManagerLoadCABuffer_ex(WOLFSSL_CERT_MANAGER* cm,
+                                       const unsigned char* in, long sz,
+                                       int format, int userChain, word32 flags)
+{
     int ret = WOLFSSL_FATAL_ERROR;
     WOLFSSL_CTX* tmp;
 
-    WOLFSSL_ENTER("wolfSSL_CertManagerLoadCABuffer");
+    WOLFSSL_ENTER("wolfSSL_CertManagerLoadCABuffer_ex");
 
     if (cm == NULL) {
         WOLFSSL_MSG("No CertManager error");
@@ -7138,7 +7147,8 @@ int wolfSSL_CertManagerLoadCABuffer(WOLFSSL_CERT_MANAGER* cm,
     wolfSSL_CertManagerFree(tmp->cm);
     tmp->cm = cm;
 
-    ret = wolfSSL_CTX_load_verify_buffer(tmp, in, sz, format);
+    ret = wolfSSL_CTX_load_verify_buffer_ex(tmp, in, sz, format,
+                                            userChain, flags);
 
     /* don't loose our good one */
     tmp->cm = NULL;

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3570,6 +3570,10 @@ WOLFSSL_API void wolfSSL_CTX_SetPerformTlsRecordProcessingCb(WOLFSSL_CTX* ctx,
                                                                  const char* d);
     WOLFSSL_API int wolfSSL_CertManagerLoadCABuffer(WOLFSSL_CERT_MANAGER* cm,
                                   const unsigned char* in, long sz, int format);
+    WOLFSSL_API int wolfSSL_CertManagerLoadCABuffer_ex(WOLFSSL_CERT_MANAGER* cm,
+                                       const unsigned char* in, long sz,
+                                       int format, int userChain, word32 flags);
+
     WOLFSSL_API int wolfSSL_CertManagerUnloadCAs(WOLFSSL_CERT_MANAGER* cm);
 #ifdef WOLFSSL_TRUST_PEER_CERT
     WOLFSSL_API int wolfSSL_CertManagerUnload_trust_peers(WOLFSSL_CERT_MANAGER* cm);


### PR DESCRIPTION
# Description

Context has an extended variant where you can e.g. load an expired CA certificate and then use it to validate a user certificate.
This is needed for strategies where you want to e.g. suppress the time validity but have the possibility to check everything else. e.g. the CA is expired but it has an actual CRL available.
Therefore the manager could have a similar function on the API that could do that.

It's not exactly a fix, however there was some communication in ZD 15414 and 14880

# Testing

I only tested locally on Windows Visual Studio 2022.

# Checklist

 - [ ] added tests
 I don't know where?
 - [ ] updated/added doxygen
No.
 - [ ] updated appropriate READMEs
No.
 - [ ] Updated manual and documentation
No.