### PR TITLE
add pragram around sanity check for vcpkg build warning

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -12781,9 +12781,17 @@ static int ProcessPeerCertParse(WOLFSSL* ssl, ProcPeerCertArgs* args,
         return BAD_FUNC_ARG;
     }
 
+PRAGMA_GCC_DIAG_PUSH
+PRAGMA_GCC("GCC diagnostic ignored \"-Wstrict-overflow\"")
+    /* Surrounded in gcc pragma to avoid -Werror=strict-overflow when the
+     * compiler optimizes out the check and assumes no underflow. Keeping the
+     * check in place to handle multiple build configurations and future
+     * changes. */
+
     /* check to make sure certificate index is valid */
     if (args->certIdx > args->count)
         return BUFFER_E;
+PRAGMA_GCC_DIAG_POP
 
     /* check if returning from non-blocking OCSP */
     /* skip this section because cert is already initialized and parsed */

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -4822,6 +4822,10 @@ int sp_copy(const sp_int* a, sp_int* r)
     }
     /* Only copy if different pointers. */
     else if (a != r) {
+    PRAGMA_GCC_DIAG_PUSH
+    PRAGMA_GCC("GCC diagnostic ignored \"-Wstrict-overflow\"")
+    /* Surrounded in gcc pragma to avoid -Werror=strict-overflow when the
+     * compiler optimizes out the check and assumes no overflow. */
         /* Validated space in result. */
         if (a->used > r->size) {
             err = MP_VAL;
@@ -4841,6 +4845,7 @@ int sp_copy(const sp_int* a, sp_int* r)
             r->sign = a->sign;
         #endif
         }
+    PRAGMA_GCC_DIAG_POP
     }
 
     return err;


### PR DESCRIPTION
avoids compiler warning :

```
 clean/src/internal.c:12584:8: error: assuming signed overflow does not occur     when assuming that (X - c) > X is always false [-Werror=strict-overflow]
 57      if (args->certIdx > args->count)
 58         ^
 59 cc1: all warnings being treated as errors
```


and 

```
 53 /home/jak/Documents/vcpkg-fork/buildtrees/wolfssl/src/5.4-stable-18b1b2bae6.    clean/wolfcrypt/src/sp_int.c:4826:12: error: assuming signed overflow does n    ot occur when assuming that (X + c) < X is always false [-Werror=strict-over    flow]
 54          if (a->used > r->size) {
 55             ^
 56 /home/jak/Documents/vcpkg-fork/buildtrees/wolfssl/src/5.4-stable-18b1b2bae6.    clean/wolfcrypt/src/sp_int.c: In function ‘sp_radix_size’:
 57 /home/jak/Documents/vcpkg-fork/buildtrees/wolfssl/src/5.4-stable-18b1b2bae6.    clean/wolfcrypt/src/sp_int.c:4826:12: error: assuming signed overflow does n    ot occur when assuming that (X + c) < X is always false [-Werror=strict-over    flow]
 58          if (a->used > r->size) {
 59             ^
 60 cc1: all warnings being treated as errors

```

with vcpkg build.