### PR TITLE
Esp32s3 support

### DIFF
--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/wifi_connect.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/wifi_connect.c
@@ -29,18 +29,16 @@
 #include "nvs_flash.h"
 #if ESP_IDF_VERSION_MAJOR >= 4
 #include "protocol_examples_common.h"
-#endif
-
+#else
 const static int CONNECTED_BIT = BIT0;
 static EventGroupHandle_t wifi_event_group;
+#endif
+
 /* proto-type */
 extern void tls_smp_client_task();
 static void tls_smp_client_init();
 
 const static char *TAG = "tls_client";
-
-static EventGroupHandle_t wifi_event_group;
-extern void tls_smp_client_task();
 
 static void set_time()
 {
@@ -80,7 +78,11 @@ static void set_time()
 static void tls_smp_client_init(void)
 {
     int ret;
-    xTaskHandle _handle;
+#if ESP_IDF_VERSION_MAJOR >= 4
+        TaskHandle_t _handle;
+#else
+        xTaskHandle _handle;
+#endif
     /* http://esp32.info/docs/esp_idf/html/dd/d3c/group__xTaskCreate.html */
     ret = xTaskCreate(tls_smp_client_task,
                       TLS_SMP_CLIENT_TASK_NAME,
@@ -93,6 +95,7 @@ static void tls_smp_client_init(void)
         ESP_LOGI(TAG, "create thread %s failed", TLS_SMP_CLIENT_TASK_NAME);
     }
 }
+#if ESP_IDF_VERSION_MAJOR < 4
 /* event handler for wifi events */
 static esp_err_t wifi_event_handler(void *ctx, system_event_t *event)
 {
@@ -121,6 +124,7 @@ static esp_err_t wifi_event_handler(void *ctx, system_event_t *event)
     }
     return ESP_OK;
 }
+#endif
 /* entry point */
 void app_main(void)
 {
@@ -137,7 +141,6 @@ void app_main(void)
 
     /* */
 #if ESP_IDF_VERSION_MAJOR >= 4
-    (void) wifi_event_handler;
    ESP_ERROR_CHECK(esp_event_loop_create_default());
    /* This helper function configures Wi-Fi or Ethernet, as selected in menuconfig.
    * Read "Establishing Wi-Fi or Ethernet Connection" section in

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/wifi_connect.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/wifi_connect.c
@@ -29,10 +29,11 @@
 #include "nvs_flash.h"
 #if ESP_IDF_VERSION_MAJOR >= 4
 #include "protocol_examples_common.h"
-#endif
-
+#else
 const static int CONNECTED_BIT = BIT0;
 static EventGroupHandle_t wifi_event_group;
+#endif
+
 /* prefix for logging */
 const static char *TAG = "tls_server";
 /* proto-type definition */
@@ -77,7 +78,11 @@ static void set_time()
 static void tls_smp_server_init(void)
 {
     int ret;
-    xTaskHandle _handle;
+#if ESP_IDF_VERSION_MAJOR >= 4
+        TaskHandle_t _handle;
+#else
+        xTaskHandle _handle;
+#endif
     /* http://esp32.info/docs/esp_idf/html/dd/d3c/group__xTaskCreate.html */
     ret = xTaskCreate(tls_smp_server_task,
                       TLS_SMP_SERVER_TASK_NAME,
@@ -90,6 +95,7 @@ static void tls_smp_server_init(void)
         ESP_LOGI(TAG, "create thread %s failed", TLS_SMP_SERVER_TASK_NAME);
     }
 }
+#if ESP_IDF_VERSION_MAJOR < 4
 /* event handler for wifi events */
 static esp_err_t wifi_event_handler(void *ctx, system_event_t *event)
 {
@@ -118,6 +124,7 @@ static esp_err_t wifi_event_handler(void *ctx, system_event_t *event)
     }
     return ESP_OK;
 }
+#endif
 /* entry point */
 void app_main(void)
 {
@@ -134,7 +141,6 @@ void app_main(void)
 #endif
     /* */
 #if ESP_IDF_VERSION_MAJOR >= 4
-    (void) wifi_event_handler;
    ESP_ERROR_CHECK(esp_event_loop_create_default());
    /* This helper function configures Wi-Fi or Ethernet, as selected in menuconfig.
    * Read "Establishing Wi-Fi or Ethernet Connection" section in

--- a/IDE/Espressif/ESP-IDF/setup_win.bat
+++ b/IDE/Espressif/ESP-IDF/setup_win.bat
@@ -245,8 +245,8 @@ if %errorlevel% NEQ 0 SET COPYERROR=true
 
 :: echo Creating new config file: %WOLFSSLLIB_TRG_DIR%\include\config.h (default, may be overwritten by prior file)
 :: using copy instead of copy to avoid file/directory prompt for files without extension
-echo new config                                            > %WOLFSSLLIB_TRG_DIR%\include\config.h
-copy  "%WOLFSSL_ESPIDFDIR%\dummy_config_h"                   "%WOLFSSLLIB_TRG_DIR%\include\config.h"             /Y 
+echo new config                                            > "%WOLFSSLLIB_TRG_DIR%\include\config.h"
+xcopy  "%WOLFSSL_ESPIDFDIR%\dummy_config_h"                   "%WOLFSSLLIB_TRG_DIR%\include\config.h"             /F /Y 
 if %errorlevel% NEQ 0 SET COPYERROR=true
 
 :: Check if operator wants to keep prior config.h

--- a/IDE/Espressif/ESP-IDF/setup_win.bat
+++ b/IDE/Espressif/ESP-IDF/setup_win.bat
@@ -28,15 +28,19 @@ if NOT EXIST "user_settings.h" (
   goto :ERR
 )
 
+:: Get argument 1 sans quotes
+set Arg1=%~1
+
 :: see if there was a parameter passed for a specific EDP-IDF directory
 :: this may be different than the standard ESP-IDF environment (e.g. VisualGDB)
-if not "%1" == "" (
-	if not exist "%1" (
+if not "%Arg1%" == "" (
+echo %Arg1%
+	if not exist "%Arg1%" (
 		echo "ERROR: optional directory was specified, but not found: %1"
 		goto :ERR
 	)
-
-	SET IDF_PATH=%1
+  echo "Setting IDF path"
+	SET IDF_PATH=%Arg1%
 	echo Using specified IDF_PATH: %IDF_PATH%
 )
 
@@ -69,14 +73,14 @@ echo Using WOLFSSLEXP_TRG_DIR = %WOLFSSLEXP_TRG_DIR%
 
 echo;
 echo Equivalalent destination path:
-dir %WOLFSSL_ESPIDFDIR%\*.xyzzy 2> nul | findstr  \
+dir "%WOLFSSL_ESPIDFDIR%\*.xyzzy" 2> nul | findstr  \
 
 echo;
 echo Equivalalent source directory paths:
 :: show the path of the equivalent  %VALUE% (search for files that don't exist, supress error, and look for string with "\")
-dir %BASEDIR%\*.xyzzy 2> nul | findstr  \
-dir %WOLFSSLLIB_TRG_DIR%\*.xyzzy 2> nul | findstr  \
-dir %WOLFSSLEXP_TRG_DIR%\*.xyzzy 2> nul | findstr  \
+dir "%BASEDIR%\*.xyzzy" 2> nul | findstr  \
+dir "%WOLFSSLLIB_TRG_DIR%\*.xyzzy" 2> nul | findstr  \
+dir "%WOLFSSLEXP_TRG_DIR%\*.xyzzy" 2> nul | findstr  \
 
 :: set the FileStamp variable to the current date:  YYMMYY_HHMMSS
 :: the simplest method, to use existing TIME ad DATE variables:
@@ -92,18 +96,18 @@ if     "%TIME:~0,1%" == " "  set FileStamp=%DATE:~12,2%%DATE:~7,2%%DATE:~4,2%_0%
 if NOT "%TIME:~0,1%" == " "  set FileStamp=%DATE:~12,2%%DATE:~7,2%%DATE:~4,2%_%TIME:~0,2%%TIME:~3,2%%TIME:~6,2%
 
 :: Backup existing user settings
-if exist %WOLFSSLLIB_TRG_DIR%\include\config.h (
+if exist "%WOLFSSLLIB_TRG_DIR%\include\config.h" (
   echo;
   echo Saving: %WOLFSSLLIB_TRG_DIR%\include\config.h
   echo     to: %SCRIPTDIR%\config_h_%FileStamp%.bak
-  copy         %WOLFSSLLIB_TRG_DIR%\include\config.h      %SCRIPTDIR%\config_h_%FileStamp%.bak
+  copy         "%WOLFSSLLIB_TRG_DIR%\include\config.h"      "%SCRIPTDIR%\config_h_%FileStamp%.bak"
   echo;
 )
 
-if exist %WOLFSSL_ESPIDFDIR%\user_settings.h (
+if exist "%WOLFSSL_ESPIDFDIR%\user_settings.h" (
   echo Saving: %WOLFSSLLIB_TRG_DIR%\include\user_settings.h
   echo     to: %SCRIPTDIR%\user_settings_h_%FileStamp%.bak
-  copy         %WOLFSSLLIB_TRG_DIR%\include\user_settings.h      %SCRIPTDIR%\user_settings_h_%FileStamp%.bak
+  copy         "%WOLFSSLLIB_TRG_DIR%\include\user_settings.h"      "%SCRIPTDIR%\user_settings_h_%FileStamp%.bak"
   echo;
 )
 
@@ -111,7 +115,7 @@ if exist %WOLFSSL_ESPIDFDIR%\user_settings.h (
 ::******************************************************************************************************
 :: check if there's already an existing %WOLFSSLLIB_TRG_DIR% and confirm removal
 ::******************************************************************************************************
-if exist %WOLFSSLLIB_TRG_DIR% (
+if exist "%WOLFSSLLIB_TRG_DIR%" (
     echo;
     echo WARNING: Existing files found in %WOLFSSLLIB_TRG_DIR%
     echo;
@@ -144,11 +148,11 @@ if exist %WOLFSSLLIB_TRG_DIR% (
 ::******************************************************************************************************
 :: purge existing directory
 
-if exist %WOLFSSLLIB_TRG_DIR% (
+if exist "%WOLFSSLLIB_TRG_DIR%" (
     echo;
     echo Removing %WOLFSSLLIB_TRG_DIR%
-    rmdir %WOLFSSLLIB_TRG_DIR% /S /Q
-    if exist %WOLFSSLLIB_TRG_DIR% (
+    rmdir "%WOLFSSLLIB_TRG_DIR%" /S /Q
+    if exist "%WOLFSSLLIB_TRG_DIR%" (
         SET COPYERROR=true
         echo;
 	    echo WARNING: Failed to remove %WOLFSSLLIB_TRG_DIR%
@@ -166,67 +170,67 @@ if exist %WOLFSSLLIB_TRG_DIR% (
 ::******************************************************************************************************
 :REFRESH
 ::******************************************************************************************************
-if not exist %WOLFSSLLIB_TRG_DIR%                 mkdir      %WOLFSSLLIB_TRG_DIR%
-if not exist %WOLFSSLLIB_TRG_DIR%\src             mkdir      %WOLFSSLLIB_TRG_DIR%\src
-if not exist %WOLFSSLLIB_TRG_DIR%\wolfcrypt\src   mkdir      %WOLFSSLLIB_TRG_DIR%\wolfcrypt\src
-if not exist %WOLFSSLLIB_TRG_DIR%\wolfssl         mkdir      %WOLFSSLLIB_TRG_DIR%\wolfssl
-if not exist %WOLFSSLLIB_TRG_DIR%\wolfssl\openssl mkdir      %WOLFSSLLIB_TRG_DIR%\wolfssl\openssl
-if not exist %WOLFSSLLIB_TRG_DIR%\test            mkdir      %WOLFSSLLIB_TRG_DIR%\test
-if not exist %WOLFSSLLIB_TRG_DIR%\include         mkdir      %WOLFSSLLIB_TRG_DIR%\include
+if not exist "%WOLFSSLLIB_TRG_DIR%"                 mkdir      "%WOLFSSLLIB_TRG_DIR%"
+if not exist "%WOLFSSLLIB_TRG_DIR%\src"             mkdir      "%WOLFSSLLIB_TRG_DIR%\src"
+if not exist "%WOLFSSLLIB_TRG_DIR%\wolfcrypt\src"   mkdir      "%WOLFSSLLIB_TRG_DIR%\wolfcrypt\src"
+if not exist "%WOLFSSLLIB_TRG_DIR%\wolfssl"         mkdir      "%WOLFSSLLIB_TRG_DIR%\wolfssl"
+if not exist "%WOLFSSLLIB_TRG_DIR%\wolfssl\openssl" mkdir      "%WOLFSSLLIB_TRG_DIR%\wolfssl\openssl"
+if not exist "%WOLFSSLLIB_TRG_DIR%\test"            mkdir      "%WOLFSSLLIB_TRG_DIR%\test""
+if not exist "%WOLFSSLLIB_TRG_DIR%\include"         mkdir      "%WOLFSSLLIB_TRG_DIR%\include"
 
 
 rem copying ... files in src/ into $WOLFSSLLIB_TRG_DIR%/src
 echo;
 echo Copying files to %WOLFSSLLIB_TRG_DIR%\src\
-xcopy %BASEDIR%\src\*.c                                      %WOLFSSLLIB_TRG_DIR%\src\                        /S /E /Q /Y
+xcopy "%BASEDIR%\src\*.c"                                      "%WOLFSSLLIB_TRG_DIR%\src\"                        /S /E /Q /Y
 if %errorlevel% NEQ 0 SET COPYERROR=true
 
 echo;
 echo Copying src\*.c files to %WOLFSSLLIB_TRG_DIR%\wolfcrypt\src
-xcopy %BASEDIR%\wolfcrypt\src\*.c                            %WOLFSSLLIB_TRG_DIR%\wolfcrypt\src               /S /E /Q /Y
+xcopy "%BASEDIR%\wolfcrypt\src\*.c"                            "%WOLFSSLLIB_TRG_DIR%\wolfcrypt\src"               /S /E /Q /Y
 if %errorlevel% NEQ 0 SET COPYERROR=true
 
 echo;
 echo Copying src\*.i files to %WOLFSSLLIB_TRG_DIR%\wolfcrypt\src
-xcopy %BASEDIR%\wolfcrypt\src\*.i                            %WOLFSSLLIB_TRG_DIR%\wolfcrypt\src               /S /E /Q /Y
+xcopy "%BASEDIR%\wolfcrypt\src\*.i"                            "%WOLFSSLLIB_TRG_DIR%\wolfcrypt\src"               /S /E /Q /Y
 if %errorlevel% NEQ 0 SET COPYERROR=true
 
 echo;
 echo Copying files to %WOLFSSLLIB_TRG_DIR%\wolfcrypt\src\port\
-xcopy %BASEDIR%\wolfcrypt\src\port                           %WOLFSSLLIB_TRG_DIR%\wolfcrypt\src\port\         /S /E /Q /Y
+xcopy "%BASEDIR%\wolfcrypt\src\port"                           "%WOLFSSLLIB_TRG_DIR%\wolfcrypt\src\port\"         /S /E /Q /Y
 if %errorlevel% NEQ 0 SET COPYERROR=true
 
 echo;
 echo Copying files to %WOLFSSLLIB_TRG_DIR%\wolfcrypt\test\
-xcopy %BASEDIR%\wolfcrypt\test                               %WOLFSSLLIB_TRG_DIR%\wolfcrypt\test\             /S /E /Q /Y
+xcopy "%BASEDIR%\wolfcrypt\test"                               "%WOLFSSLLIB_TRG_DIR%\wolfcrypt\test\"             /S /E /Q /Y
 if %errorlevel% NEQ 0 SET COPYERROR=true
 
 :: Copy dummy test_paths.h to handle the case configure hasn't yet executed
 echo;
 echo Copying dummy_test_paths.h to %WOLFSSLLIB_TRG_DIR%\wolfcrypt\test\test_paths.h
-echo new config                                            > %WOLFSSLLIB_TRG_DIR%\wolfcrypt\test\test_paths.h
+echo new config                                            > "%WOLFSSLLIB_TRG_DIR%\wolfcrypt\test\test_paths.h"
 if %errorlevel% NEQ 0 SET COPYERROR=true
-xcopy %WOLFSSL_ESPIDFDIR%\dummy_test_paths.h                 %WOLFSSLLIB_TRG_DIR%\wolfcrypt\test\test_paths.h  /S /E /Y
+xcopy "%WOLFSSL_ESPIDFDIR%\dummy_test_paths.h"                 "%WOLFSSLLIB_TRG_DIR%\wolfcrypt\test\test_paths.h"  /S /E /Y
 if %errorlevel% NEQ 0 SET COPYERROR=true
 
 echo;
 echo Copying files to %WOLFSSLLIB_TRG_DIR%\wolfcrypt\benchmark\
-xcopy %BASEDIR%\wolfcrypt\benchmark                          %WOLFSSLLIB_TRG_DIR%\wolfcrypt\benchmark\          /S /E /Q /Y
+xcopy "%BASEDIR%\wolfcrypt\benchmark"                          "%WOLFSSLLIB_TRG_DIR%\wolfcrypt\benchmark\"          /S /E /Q /Y
 if %errorlevel% NEQ 0 SET COPYERROR=true
 
 echo;
 echo Copying files to %WOLFSSLLIB_TRG_DIR%\wolfssl\
-xcopy %BASEDIR%\wolfssl\*.h                                  %WOLFSSLLIB_TRG_DIR%\wolfssl\                    /S /E /Q /Y
+xcopy "%BASEDIR%\wolfssl\*.h"                                  "%WOLFSSLLIB_TRG_DIR%\wolfssl\"                    /S /E /Q /Y
 if %errorlevel% NEQ 0 SET COPYERROR=true
 
 echo;
 echo Copying files to%WOLFSSLLIB_TRG_DIR%\wolfssl\openssl\
-xcopy %BASEDIR%\wolfssl\openssl\*.h                          %WOLFSSLLIB_TRG_DIR%\wolfssl\openssl\            /S /E /Q /Y
+xcopy "%BASEDIR%\wolfssl\openssl\*.h"                          "%WOLFSSLLIB_TRG_DIR%\wolfssl\openssl\"            /S /E /Q /Y
 if %errorlevel% NEQ 0 SET COPYERROR=true
 
 echo;
 echo Copying files to %WOLFSSLLIB_TRG_DIR%\wolfssl\wolfcrypt\
-xcopy %BASEDIR%\wolfssl\wolfcrypt                            %WOLFSSLLIB_TRG_DIR%\wolfssl\wolfcrypt\            /S /E /Q /Y
+xcopy "%BASEDIR%\wolfssl\wolfcrypt"                            "%WOLFSSLLIB_TRG_DIR%\wolfssl\wolfcrypt\"            /S /E /Q /Y
 if %errorlevel% NEQ 0 SET COPYERROR=true
 
 
@@ -236,14 +240,14 @@ if %errorlevel% NEQ 0 SET COPYERROR=true
 :: user_settings.h (default, may be overwritten by prior file)
 echo;
 echo Copying default user_settings.h to %WOLFSSLLIB_TRG_DIR%\include\
-xcopy %WOLFSSL_ESPIDFDIR%\user_settings.h                    %WOLFSSLLIB_TRG_DIR%\include\                     /F
+xcopy "%WOLFSSL_ESPIDFDIR%\user_settings.h"                    "%WOLFSSLLIB_TRG_DIR%\include\"                     /F
 if %errorlevel% NEQ 0 SET COPYERROR=true
 
 :: echo Creating new config file: %WOLFSSLLIB_TRG_DIR%\include\config.h (default, may be overwritten by prior file)
+:: using copy instead of copy to avoid file/directory prompt for files without extension
 echo new config                                            > %WOLFSSLLIB_TRG_DIR%\include\config.h
-xcopy  %WOLFSSL_ESPIDFDIR%\dummy_config_h.                   %WOLFSSLLIB_TRG_DIR%\include\config.h             /F /Y
+copy  "%WOLFSSL_ESPIDFDIR%\dummy_config_h"                   "%WOLFSSLLIB_TRG_DIR%\include\config.h"             /Y 
 if %errorlevel% NEQ 0 SET COPYERROR=true
-
 
 :: Check if operator wants to keep prior config.h
 if EXIST config_h_%FileStamp%.bak (
@@ -252,7 +256,7 @@ if EXIST config_h_%FileStamp%.bak (
     call;
     choice /c YN /m "Use your prior config.h  "
     if errorlevel 2 GOTO :NO_CONFIG_RESTORE
-    xcopy config_h_%FileStamp%.bak   %WOLFSSLLIB_TRG_DIR%\include\config.h /Y
+    xcopy "config_h_%FileStamp%.bak"   "%WOLFSSLLIB_TRG_DIR%\include\config.h" /Y
     if %errorlevel% NEQ 0 SET COPYERROR=true
 
 ) else (
@@ -270,7 +274,7 @@ if EXIST user_settings_h_%FileStamp%.bak (
     call;
     choice /c YN /m "User your prior user_settings.h  "
     if errorlevel 2 GOTO :NO_USER_SETTINGS_RESTORE
-    xcopy user_settings_h_%FileStamp%.bak    %WOLFSSLLIB_TRG_DIR%\include\user_settings.h /Y
+    xcopy user_settings_h_%FileStamp%.bak    "%WOLFSSLLIB_TRG_DIR%\include\user_settings.h" /Y
     if %errorlevel% NEQ 0 SET COPYERROR=true
 
 ) else (
@@ -286,63 +290,63 @@ if EXIST user_settings_h_%FileStamp%.bak (
 :: unit test app
 echo;
 echo Copying unit files to %WOLFSSLLIB_TRG_DIR%\test\
-xcopy %WOLFSSL_ESPIDFDIR%\test                               %WOLFSSLLIB_TRG_DIR%\test\                        /S /E /Q /Y
+xcopy "%WOLFSSL_ESPIDFDIR%\test"                               "%WOLFSSLLIB_TRG_DIR%\test\"                        /S /E /Q /Y
 if %errorlevel% NEQ 0 GOTO :COPYERR
 
 echo;
 echo Copying CMakeLists.txt to %WOLFSSLLIB_TRG_DIR%\
-xcopy %WOLFSSL_ESPIDFDIR%\libs\CMakeLists.txt                %WOLFSSLLIB_TRG_DIR%\                             /F
+xcopy "%WOLFSSL_ESPIDFDIR%\libs\CMakeLists.txt"                "%WOLFSSLLIB_TRG_DIR%\"                             /F
 if %errorlevel% NEQ 0 GOTO :COPYERR
 
 echo;
 echo Copying component.mk to %WOLFSSLLIB_TRG_DIR%\
-xcopy %WOLFSSL_ESPIDFDIR%\libs\component.mk                  %WOLFSSLLIB_TRG_DIR%\                             /F
+xcopy "%WOLFSSL_ESPIDFDIR%\libs\component.mk"                  "%WOLFSSLLIB_TRG_DIR%\"                             /F
 if %errorlevel% NEQ 0 GOTO :COPYERR
 
 :: Benchmark program
 echo;
 echo Removing %WOLFSSLEXP_TRG_DIR%\wolfssl_benchmark\
-rmdir %WOLFSSLEXP_TRG_DIR%\wolfssl_benchmark\          /S /Q
+rmdir "%WOLFSSLEXP_TRG_DIR%\wolfssl_benchmark\"          /S /Q
 if %errorlevel% NEQ 0 GOTO :COPYERR
 
 echo;
 echo Copying %WOLFSSLEXP_TRG_DIR%\wolfssl_benchmark\main\
-mkdir %WOLFSSLEXP_TRG_DIR%\wolfssl_benchmark\main\
+mkdir "%WOLFSSLEXP_TRG_DIR%\wolfssl_benchmark\main\"
 
-xcopy %BASEDIR%\wolfcrypt\benchmark\benchmark.c              %WOLFSSLEXP_TRG_DIR%\wolfssl_benchmark\main\                                 /F /Y
+xcopy "%BASEDIR%\wolfcrypt\benchmark\benchmark.c"              "%WOLFSSLEXP_TRG_DIR%\wolfssl_benchmark\main\"                                 /F /Y
 if %errorlevel% NEQ 0 GOTO :COPYERR
 
-xcopy %WOLFSSL_ESPIDFDIR%\examples\wolfssl_benchmark         %WOLFSSLEXP_TRG_DIR%\wolfssl_benchmark\                                      /Q /Y
+xcopy "%WOLFSSL_ESPIDFDIR%\examples\wolfssl_benchmark"         "%WOLFSSLEXP_TRG_DIR%\wolfssl_benchmark\"                                      /Q /Y
 if %errorlevel% NEQ 0 GOTO :COPYERR
 
 :: Crypt Test program
 echo;
 echo Copying %WOLFSSLEXP_TRG_DIR%\wolfssl_test\
-rmdir %WOLFSSLEXP_TRG_DIR%\wolfssl_test\               /S /Q
-mkdir %WOLFSSLEXP_TRG_DIR%\wolfssl_test\main\
+rmdir "%WOLFSSLEXP_TRG_DIR%\wolfssl_test\"               /S /Q
+mkdir "%WOLFSSLEXP_TRG_DIR%\wolfssl_test\main\"
 
-xcopy %BASEDIR%\wolfcrypt\test\test.c                        %WOLFSSLEXP_TRG_DIR%\wolfssl_test\main\           /S /E /Q /Y
+xcopy "%BASEDIR%\wolfcrypt\test\test.c"                        "%WOLFSSLEXP_TRG_DIR%\wolfssl_test\main\"           /S /E /Q /Y
 if %errorlevel% NEQ 0 GOTO :COPYERR
 
-xcopy %WOLFSSL_ESPIDFDIR%\examples\wolfssl_test              %WOLFSSLEXP_TRG_DIR%\wolfssl_test\                /S /E /Q /Y
+xcopy "%WOLFSSL_ESPIDFDIR%\examples\wolfssl_test"              "%WOLFSSLEXP_TRG_DIR%\wolfssl_test\"                /S /E /Q /Y
 if %errorlevel% NEQ 0 GOTO :COPYERR
 
 :: TLS Client program
 echo;
 echo Copying %WOLFSSLEXP_TRG_DIR%\wolfssl_client\
-rmdir %WOLFSSLEXP_TRG_DIR%\wolfssl_client\            /S /Q
-mkdir %WOLFSSLEXP_TRG_DIR%\wolfssl_client\main\
+rmdir "%WOLFSSLEXP_TRG_DIR%\wolfssl_client\"            /S /Q
+mkdir "%WOLFSSLEXP_TRG_DIR%\wolfssl_client\main\"
 
-xcopy %WOLFSSL_ESPIDFDIR%\examples\wolfssl_client            %WOLFSSLEXP_TRG_DIR%\wolfssl_client\              /S /E /Q /Y
+xcopy "%WOLFSSL_ESPIDFDIR%\examples\wolfssl_client"            "%WOLFSSLEXP_TRG_DIR%\wolfssl_client\"              /S /E /Q /Y
 if %errorlevel% NEQ 0 GOTO :COPYERR
 
 :: TLS Server program
 echo;
 echo Copying %WOLFSSLEXP_TRG_DIR%\wolfssl_server\
-rmdir %WOLFSSLEXP_TRG_DIR%\wolfssl_server\            /S /Q
-mkdir %WOLFSSLEXP_TRG_DIR%\wolfssl_server\main\
+rmdir "%WOLFSSLEXP_TRG_DIR%\wolfssl_server\"            /S /Q
+mkdir "%WOLFSSLEXP_TRG_DIR%\wolfssl_server\main\"
 
-xcopy %WOLFSSL_ESPIDFDIR%\examples\wolfssl_server             %WOLFSSLEXP_TRG_DIR%\wolfssl_server\             /S /E /Q /Y
+xcopy "%WOLFSSL_ESPIDFDIR%\examples\wolfssl_server"             "%WOLFSSLEXP_TRG_DIR%\wolfssl_server\"             /S /E /Q /Y
 if %errorlevel% NEQ 0 GOTO :COPYERR
 
 goto :DONE
@@ -369,6 +373,7 @@ goto :ERR
 ::******************************************************************************************************
 :ERR
 ::******************************************************************************************************
+echo "ERROR"
 exit /B 1
 
 :: Success

--- a/IDE/Espressif/ESP-IDF/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/user_settings.h
@@ -38,6 +38,18 @@
 
 /* #define DEBUG_WOLFSSL_VERBOSE */
 
+// Enable key generation:
+// https://www.wolfssl.com/documentation/manuals/wolfssl/chapter07.html#rsa-key-generation
+#define WOLFSSL_KEY_GEN
+
+// Enable certificate generation: 
+// https://www.wolfssl.com/documentation/manuals/wolfssl/chapter07.html#certificate-generation
+#define WOLFSSL_CERT_GEN
+
+// Enable certificate request generation: 
+// https://www.wolfssl.com/documentation/manuals/wolfssl/chapter07.html#certificate-signing-request-csr-generation
+#define WOLFSSL_CERT_REQ
+
 #define BENCH_EMBEDDED
 #define USE_CERT_BUFFERS_2048
 
@@ -60,7 +72,13 @@
 #define HAVE_ECC
 #define HAVE_CURVE25519
 #define CURVE25519_SMALL
-#define HAVE_ED25519
+
+// ED25519 test fails on ESP32 & ESP32s3
+// #define HAVE_ED25519
+
+/* AES-192 is not supported on the ESP32s3; is available for ESP32
+ * and may be available for other devices. */
+#define NO_AES_192
 
 /* when you want to use pkcs7 */
 /* #define HAVE_PKCS7 */

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -8216,7 +8216,11 @@ void bench_sphincsKeySign(byte level, byte optim)
 #endif
     double current_time(int reset)
     {
+    #if ESP_IDF_VERSION_MAJOR >= 4
+        TickType_t tickCount;
+    #else
         portTickType tickCount;
+    #endif
 
         (void) reset;
 

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -2676,6 +2676,23 @@ static WARN_UNUSED_RESULT int wc_AesDecrypt(
             return BAD_FUNC_ARG;
         }
 
+#if !defined(WOLFSSL_AES_128)  
+        if (keylen == 16) {
+          return BAD_FUNC_ARG;
+        }
+#endif
+
+#if !defined(WOLFSSL_AES_192)  
+        if (keylen == 24) {
+          return BAD_FUNC_ARG;
+        }
+#endif
+#if !defined(WOLFSSL_AES_256)  
+        if (keylen == 32) {
+          return BAD_FUNC_ARG;
+        }
+#endif
+      
         aes->keylen = keylen;
         aes->rounds = keylen/4 + 6;
 

--- a/wolfcrypt/src/port/Espressif/README.md
+++ b/wolfcrypt/src/port/Espressif/README.md
@@ -1,6 +1,9 @@
 # ESP32 Port
 
 Support for the ESP32-WROOM-32 on-board crypto hardware acceleration for symmetric AES, SHA1/SHA256/SHA384/SHA512 and RSA primitive including mul, mulmod and exptmod.
+Supported hardware includes:
+* ESP32
+* ESP32s3
 
 ## ESP32 Acceleration
 

--- a/wolfcrypt/src/port/Espressif/esp32_aes.c
+++ b/wolfcrypt/src/port/Espressif/esp32_aes.c
@@ -157,7 +157,11 @@ static void esp_aes_hw_Set_KeyMode(Aes *ctx, ESP32_AESPROCESS mode)
 static void esp_aes_bk(const byte* in, byte* out)
 {
     const word32 *inwords = (const word32 *)in;
+#if ESP_IDF_VERSION_MAJOR >= 4
+    uint32_t *outwords      = (uint32_t *)out;
+#else
     word32 *outwords      = (word32 *)out;
+#endif
 
     ESP_LOGV(TAG, "enter esp_aes_bk");
 

--- a/wolfcrypt/src/port/Espressif/esp32_mp.c
+++ b/wolfcrypt/src/port/Espressif/esp32_mp.c
@@ -70,10 +70,20 @@ static int esp_mp_hw_wait_clean()
 {
     word32 timeout = 0;
 
+#if CONFIG_IDF_TARGET_ESP32S3
+  
+    while (!ESP_TIMEOUT(++timeout) && DPORT_REG_READ(RSA_QUERY_CLEAN_REG) != 1) 
+    {
+      /*  wait. expected delay 1 to 2 uS  */
+    }
+#else
+  /* RSA_CLEAN_REG is now called RSA_QUERY_CLEAN_REG. hwcrypto_reg.h maintains 
+   * RSA_CLEAN_REG for backwards compatibility so this block _might_ be not needed. */
     while(!ESP_TIMEOUT(++timeout) &&
                 DPORT_REG_READ(RSA_CLEAN_REG) != 1) {
         /*  wait. expected delay 1 to 2 uS  */
     }
+#endif
 
     if (ESP_TIMEOUT(timeout)) {
         ESP_LOGE(TAG, "waiting hw ready is timed out.");
@@ -131,12 +141,22 @@ static int esp_mp_hw_lock()
         return MP_NG;
     }
 
+
+#if CONFIG_IDF_TARGET_ESP32S3
+    /* Activate teh RSA accelerator. See §20.3 of ESP32-S3 technical manual.
+     * periph_module_enable doesn't seem to be documented and in private folder 
+     * with v5 release. Maybe it will be deprecated? */
+    DPORT_REG_SET_BIT(SYSTEM_CRYPTO_RSA_CLK_EN, SYSTEM_PERIP_CLK_EN1_REG);
+
+    /* clear bit to enable hardware operation; (set to disable) */
+    DPORT_REG_CLR_BIT(SYSTEM_RSA_PD_CTRL_REG, SYSTEM_RSA_MEM_PD);
+#else
     /* Enable RSA hardware */
     periph_module_enable(PERIPH_RSA_MODULE);
 
-    /* clear bit to enable hardware operation; (set to disable)
-     */
+    /* clear bit to enable hardware operation; (set to disable) */
     DPORT_REG_CLR_BIT(DPORT_RSA_PD_CTRL_REG, DPORT_RSA_PD);
+#endif
 
     /* remionder: wait until RSA_CLEAN_REG reads 1
      *  see esp_mp_hw_wait_clean()
@@ -150,13 +170,22 @@ static int esp_mp_hw_lock()
 */
 static void esp_mp_hw_unlock( void )
 {
+#if CONFIG_IDF_TARGET_ESP32S3
+    /* Deactivate teh RSA accelerator. See §20.3 of ESP32-S3 technical manual.
+     * periph_module_enable doesn't seem to be documented and in private folder 
+     * with v5 release. Maybe it will be deprecated? */
+    DPORT_REG_SET_BIT(SYSTEM_RSA_PD_CTRL_REG, SYSTEM_RSA_MEM_PD);
+    DPORT_REG_CLR_BIT(SYSTEM_CRYPTO_RSA_CLK_EN, SYSTEM_PERIP_CLK_EN1_REG);
+
+#else
     /* set bit to disabled hardware operation; (clear to enable)
      */
     DPORT_REG_SET_BIT(DPORT_RSA_PD_CTRL_REG, DPORT_RSA_PD);
 
     /* Disable RSA hardware */
     periph_module_disable(PERIPH_RSA_MODULE);
-
+#endif
+  
     /* unlock */
     esp_CryptHwMutexUnLock(&mp_mutex);
 }
@@ -199,7 +228,7 @@ static void process_start(word32 reg)
 }
 
 /* wait until done */
-static int wait_uitil_done(word32 reg)
+static int wait_until_done(word32 reg)
 {
     word32 timeout = 0;
     /* wait until done && not timeout */
@@ -208,9 +237,13 @@ static int wait_uitil_done(word32 reg)
         /* wait */
     }
 
+#if CONFIG_IDF_TARGET_ESP32S3
+    // ESP32S3 doesn't use interrupt register for completion. 
+#else
     /* clear interrupt */
     DPORT_REG_WRITE(RSA_INTERRUPT_REG, 1);
-
+#endif
+  
     if (ESP_TIMEOUT(timeout)) {
         ESP_LOGE(TAG, "rsa operation is timed out.");
         return MP_NG;
@@ -316,7 +349,66 @@ int esp_mp_mul(fp_int* X, fp_int* Y, fp_int* Z)
         ESP_LOGW(TAG, "exceeds max bit length(2048)");
         return -2;
     }
+  
+#if CONFIG_IDF_TARGET_ESP32S3
+    /* Steps to perform large number multiplication. Calculates Z = X x Y. The number of
+     * bits in the operands (X, Y) is N. N can be 32x, where x = {1,2,3,...64}, so the 
+     * maximum number of bits in the X and Y is 2048.
+     * See §20.3.3 of ESP32-S3 technical manual
+     *  1. Lock the hardware so no-one else uses it and wait until it is ready. 
+     *  2. Enable/disable interrupt that signals completion -- we don't use the interrupt.
+     *  3. Write (N_result_bits/32 - 1) to the RSA_MODE_REG (now called RSA_LENGTH_REG). 
+     *     Here N_result_bits is the number of bits in the multiplication result, which 
+     *     is 2x the number of bits in the operands.
+     *  4. Load X, Y operands to memory blocks. Note the Y value must be written to
+     *     offset of 4 x N_bits_Y
+     *  5. Start the operation by writing 1 to RSA_MULT_START_REG, then wait for it
+     *     to complete by monitoring RSA_IDLE_REG (which is now called RSA_QUERY_INTERRUPT_REG). 
+     *  6. Read the result out. 
+     *  7. Release the hardware lock so others can use it. 
+     *  x. Clear the interrupt flag, if you used it (we don't). */
+  
+    /* 1. lock hw for use & wait until it is ready. */
+    if ((ret = esp_mp_hw_lock()) != MP_OKAY 
+     || (ret = esp_mp_hw_wait_clean()) != MP_OKAY) 
+    {
+      return ret;
+    }
 
+    /* 2. Disable completion interrupt singal; we don't use. */
+    DPORT_REG_WRITE(RSA_INTERRUPT_REG, 0); // 0 => no interrupt; 1 => interrupt on completion. 
+
+    /* 3. Write (N_result_bits/32 - 1) to the RSA_MODE_REG. */
+    uint32_t uResultBits = max(Xs, Ys) * 2; 
+    if (uResultBits > ESP_HW_RSAMAX_BIT)
+    {
+      ESP_LOGW(TAG, "result exceeds max bit length");
+      return -2;
+    }
+    DPORT_REG_WRITE(RSA_LENGTH_REG, (uResultBits / 32) - 1);
+
+    /* 4. Load X, Y operands. Maximum is 64 words (64*8*4 = 2048 bits) */
+    esp_mpint_to_memblock(RSA_MEM_X_BLOCK_BASE, X, Xs, hwWords_sz);
+    esp_mpint_to_memblock(RSA_MEM_Z_BLOCK_BASE + (hwWords_sz << 2), Y, Ys, hwWords_sz);
+
+    /* 5. Start operation and wait until it completes. */
+    DPORT_REG_WRITE(RSA_MULT_START_REG, 1);
+    ret = wait_until_done(RSA_QUERY_INTERRUPT_REG);
+    if (MP_OKAY != ret)
+    {
+      return ret; 
+    }
+
+    /* 6. read the result form MEM_Z              */
+    esp_memblock_to_mpint(RSA_MEM_Z_BLOCK_BASE, Z, BITS_TO_WORDS(Zs));
+
+    /* 7. clear and release hw                    */
+    esp_mp_hw_unlock();
+
+    Z->sign = (Z->used > 0) ? neg : MP_ZPOS;
+
+    return ret;
+#else
     /*Steps to use hw in the following order:
     * 1. wait until clean hw engine
     * 2. Write(2*N/512bits - 1 + 8) to MULT_MODE_REG
@@ -356,7 +448,7 @@ int esp_mp_mul(fp_int* X, fp_int* Y, fp_int* Z)
     process_start(RSA_MULT_START_REG);
 
     /* step.4,5 wait until done                       */
-    ret = wait_uitil_done(RSA_INTERRUPT_REG);
+    ret = wait_until_done(RSA_INTERRUPT_REG);
     if (ret != MP_OKAY) {
         ESP_LOGE(TAG, "wait_uitil_done failed.");
         return ret;
@@ -370,6 +462,7 @@ int esp_mp_mul(fp_int* X, fp_int* Y, fp_int* Z)
     Z->sign = (Z->used > 0) ? neg : MP_ZPOS;
 
     return ret;
+#endif
 }
 
 /* Z = X * Y (mod M)                                  */
@@ -431,6 +524,74 @@ int esp_mp_mulmod(fp_int* X, fp_int* Y, fp_int* M, fp_int* Z)
         mp_clear(&r_inv);
         return -1;
     }
+  
+#if CONFIG_IDF_TARGET_ESP32S3
+    /* Steps to perform large number modular multiplication. Calculates Z = (X x Y) modulo M. 
+     * The number of bits in the operands (X, Y) is N. N can be 32x, where x = {1,2,3,...64}, so the 
+     * maximum number of bits in the X and Y is 2048.
+     * See §20.3.3 of ESP32-S3 technical manual
+     *  1. Wait until the hardware is ready. 
+     *  2. Enable/disable interrupt that signals completion -- we don't use the interrupt.
+     *  3. Write (N_bits/32 - 1) to the RSA_MODE_REG (now called RSA_LENGTH_REG). 
+     *     Here N_bits is the maximum number of bits in X, Y and M. 
+     *  4. Write M' value into RSA_M_PRIME_REG (now called RSA_M_DASH_REG).
+     *  5. Load X, Y, M, r' operands to memory blocks. 
+     *  6. Start the operation by writing 1 to RSA_MOD_MULT_START_REG, then wait for it
+     *     to complete by monitoring RSA_IDLE_REG (which is now called RSA_QUERY_INTERRUPT_REG). 
+     *  7. Read the result out. 
+     *  8. Release the hardware lock so others can use it. 
+     *  x. Clear the interrupt flag, if you used it (we don't). */
+  
+    /* 1. Wait until hardware is ready. */
+    if ((ret = esp_mp_hw_wait_clean()) != MP_OKAY) 
+    {
+      return ret;
+    }
+
+    /* 2. Disable completion interrupt singal; we don't use. */
+    DPORT_REG_WRITE(RSA_INTERRUPT_REG, 0); // 0 => no interrupt; 1 => interrupt on completion. 
+
+    /* 3. Write (N_result_bits/32 - 1) to the RSA_MODE_REG. */
+    uint32_t uOperandBits = max(max(Xs, Ys), Ms); 
+    if (uOperandBits > ESP_HW_MULTI_RSAMAX_BITS)
+    {
+      ESP_LOGW(TAG, "result exceeds max bit length");
+      return -2;
+    }
+    DPORT_REG_WRITE(RSA_LENGTH_REG, (uOperandBits / 32) - 1);
+  
+    /* 4. Write M' value into RSA_M_PRIME_REG (now called RSA_M_DASH_REG) */
+    DPORT_REG_WRITE(RSA_M_DASH_REG, mp);
+
+    /* 5. Load X, Y, M, r' operands. */
+    esp_mpint_to_memblock(RSA_MEM_X_BLOCK_BASE, X, Xs, hwWords_sz);
+    esp_mpint_to_memblock(RSA_MEM_Y_BLOCK_BASE, Y, Ys, hwWords_sz);
+    esp_mpint_to_memblock(RSA_MEM_M_BLOCK_BASE, M, Ms, hwWords_sz);
+    esp_mpint_to_memblock(RSA_MEM_Z_BLOCK_BASE, &r_inv, mp_count_bits(&r_inv), hwWords_sz);
+
+    /* 6. Start operation and wait until it completes. */
+    DPORT_REG_WRITE(RSA_MOD_MULT_START_REG, 1);
+    ret = wait_until_done(RSA_QUERY_INTERRUPT_REG);
+    if (MP_OKAY != ret)
+    {
+      return ret; 
+    }
+
+    /* 7. read the result form MEM_Z              */
+    esp_memblock_to_mpint(RSA_MEM_Z_BLOCK_BASE, &tmpZ, zwords);
+
+    /* 8. clear and release hw                    */
+    esp_mp_hw_unlock();
+
+    // todo: implement work-arounds for known issues with ESP32 version (see below) if needed. 
+
+    mp_copy(&tmpZ, Z);
+    mp_clear(&tmpZ);
+    mp_clear(&r_inv);
+
+    return ret;
+#else
+  
     /*Steps to use hw in the following order:
     * 1. wait until clean hw engine
     * 2. Write(N/512bits - 1) to MULT_MODE_REG
@@ -470,7 +631,7 @@ int esp_mp_mulmod(fp_int* X, fp_int* Y, fp_int* M, fp_int* Z)
     process_start(RSA_MULT_START_REG);
 
     /* step.5,6 wait until done                       */
-    wait_uitil_done(RSA_INTERRUPT_REG);
+    wait_until_done(RSA_INTERRUPT_REG);
     /* step.7 Y to MEM_X                              */
     esp_mpint_to_memblock(RSA_MEM_X_BLOCK_BASE, Y, Ys, hwWords_sz);
 
@@ -478,7 +639,7 @@ int esp_mp_mulmod(fp_int* X, fp_int* Y, fp_int* M, fp_int* Z)
     process_start(RSA_MULT_START_REG);
 
     /* step.9,11 wait until done                      */
-    wait_uitil_done(RSA_INTERRUPT_REG);
+    wait_until_done(RSA_INTERRUPT_REG);
 
     /* step.12 read the result from MEM_Z             */
     esp_memblock_to_mpint(RSA_MEM_Z_BLOCK_BASE, &tmpZ, zwords);
@@ -502,23 +663,25 @@ int esp_mp_mulmod(fp_int* X, fp_int* Y, fp_int* M, fp_int* Z)
     mp_clear(&r_inv);
 
     return ret;
+#endif
 }
 
 /* Large Number Modular Exponentiation
  *
  *    Z = X^Y mod M
  *
- * See Chapter 24:
- *  https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf
- *
+ * See:
+ *  ESP32, Chapter 24, https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf
+ *  ESP32s3, section 20.3.1, https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf
  * The operation is based on Montgomery multiplication. Aside from the
  * arguments X, Y , and M, two additional ones are needed —r and M′
 .* These arguments are calculated in advance by software.
 .*
 .* The RSA Accelerator supports operand lengths of N ∈ {512, 1024, 1536, 2048,
-.* 2560, 3072, 3584, 4096} bits. The bit length of arguments Z, X, Y , M,
-.* and r can be any one from the N set, but all numbers in a calculation must
-.* be of the same length. The bit length of M′ is always 32.
+.* 2560, 3072, 3584, 4096} bits on the ESP32 and N ∈ [32, 4096] bits on the ESP32s3. 
+.* The bit length of arguments Z, X, Y , M, and r can be any one from the N set, 
+.* but all numbers in a calculation must be of the same length. 
+.* The bit length of M′ is always 32.
 .*
 .* Note some DH references may use: Y = (G ^ X) mod P
  */
@@ -568,6 +731,69 @@ int esp_mp_exptmod(fp_int* X, fp_int* Y, word32 Ys, fp_int* M, fp_int* Z)
         return -1;
     }
 
+#if CONFIG_IDF_TARGET_ESP32S3
+    /* Steps to perform large number modular exponentiation. Calculates Z = (X ^ Y) modulo M. 
+     * The number of bits in the operands (X, Y) is N. N can be 32x, where x = {1,2,3,...64}, so the 
+     * maximum number of bits in the X and Y is 2048.
+     * See §20.3.3 of ESP32-S3 technical manual
+     *  1. Wait until the hardware is ready. 
+     *  2. Enable/disable interrupt that signals completion -- we don't use the interrupt.
+     *  3. Write (N_bits/32 - 1) to the RSA_MODE_REG (now called RSA_LENGTH_REG). 
+     *     Here N_bits is the maximum number of bits in X, Y and M. 
+     *  4. Write M' value into RSA_M_PRIME_REG (now called RSA_M_DASH_REG).
+     *  5. Load X, Y, M, r' operands to memory blocks. 
+     *  6. Start the operation by writing 1 to RSA_MODEXP_START_REG, then wait for it
+     *     to complete by monitoring RSA_IDLE_REG (which is now called RSA_QUERY_INTERRUPT_REG). 
+     *  7. Read the result out. 
+     *  8. Release the hardware lock so others can use it. 
+     *  x. Clear the interrupt flag, if you used it (we don't). */
+  
+    /* 1. Wait until hardware is ready. */
+    if ((ret = esp_mp_hw_wait_clean()) != MP_OKAY) 
+    {
+      return ret;
+    }
+
+    /* 2. Disable completion interrupt singal; we don't use. */
+    DPORT_REG_WRITE(RSA_INTERRUPT_REG, 0); // 0 => no interrupt; 1 => interrupt on completion. 
+
+    /* 3. Write (N_result_bits/32 - 1) to the RSA_MODE_REG. */
+    uint32_t uOperandBits = max(max(Xs, Ys), Ms); 
+    if (uOperandBits > ESP_HW_MULTI_RSAMAX_BITS)
+    {
+      ESP_LOGW(TAG, "result exceeds max bit length");
+      return -2;
+    }
+    DPORT_REG_WRITE(RSA_LENGTH_REG, (uOperandBits / 32) - 1);
+  
+    /* 4. Write M' value into RSA_M_PRIME_REG (now called RSA_M_DASH_REG) */
+    DPORT_REG_WRITE(RSA_M_DASH_REG, mp);
+
+    /* 5. Load X, Y, M, r' operands. */
+    esp_mpint_to_memblock(RSA_MEM_X_BLOCK_BASE, X, Xs, hwWords_sz);
+    esp_mpint_to_memblock(RSA_MEM_Y_BLOCK_BASE, Y, Ys, hwWords_sz);
+    esp_mpint_to_memblock(RSA_MEM_M_BLOCK_BASE, M, Ms, hwWords_sz);
+    esp_mpint_to_memblock(RSA_MEM_Z_BLOCK_BASE, &r_inv, mp_count_bits(&r_inv), hwWords_sz);
+
+    /* 6. Start operation and wait until it completes. */
+    DPORT_REG_WRITE(RSA_MODEXP_START_REG, 1);
+    ret = wait_until_done(RSA_QUERY_INTERRUPT_REG);
+    if (MP_OKAY != ret)
+    {
+      return ret; 
+    }
+
+    /* 7. read the result form MEM_Z              */
+    esp_memblock_to_mpint(RSA_MEM_Z_BLOCK_BASE, Z, BITS_TO_WORDS(Ms));
+
+    /* 8. clear and release hw                    */
+    esp_mp_hw_unlock();
+
+    mp_clear(&r_inv);
+
+    return ret;
+#else
+
     /*Steps to use hw in the following order:
     * 1. Write(N/512bits - 1) to MODEXP_MODE_REG
     * 2. Write X, Y, M and r_inv to memory blocks
@@ -600,7 +826,7 @@ int esp_mp_exptmod(fp_int* X, fp_int* Y, word32 Ys, fp_int* M, fp_int* Z)
     process_start(RSA_START_MODEXP_REG);
 
     /* step.5 wait until done                         */
-    wait_uitil_done(RSA_INTERRUPT_REG);
+    wait_until_done(RSA_INTERRUPT_REG);
     /* step.6 read a result form memory               */
     esp_memblock_to_mpint(RSA_MEM_Z_BLOCK_BASE, Z, BITS_TO_WORDS(Ms));
     /* step.7 clear and release hw                    */
@@ -609,6 +835,7 @@ int esp_mp_exptmod(fp_int* X, fp_int* Y, word32 Ys, fp_int* M, fp_int* Z)
     mp_clear(&r_inv);
 
     return ret;
+#endif
 }
 #endif /* !NO_RSA || HAVE_ECC */
 

--- a/wolfcrypt/src/port/Espressif/esp32_sha.c
+++ b/wolfcrypt/src/port/Espressif/esp32_sha.c
@@ -551,7 +551,11 @@ int wc_esp_digest_state(WC_ESP32SHA* ctx, byte* hash)
      *    DPORT_SEQUENCE_REG_READ(address + i * 4);
      */
     esp_dport_access_read_buffer(
+#if ESP_IDF_VERSION_MAJOR >= 4
+        (uint32_t*)(hash), /* the result will be found in hash upon exit     */
+#else
         (word32*)(hash), /* the result will be found in hash upon exit     */
+#endif
         SHA_TEXT_BASE,   /* there's a fixed reg addy for all SHA           */
         wc_esp_sha_digest_size(ctx->sha_type) / sizeof(word32) /* # 4-byte */
     );

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -3397,6 +3397,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 
         /* Espressif ESP32 */
         #include <esp_system.h>
+        #include <esp_random.h>
 
         int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         {

--- a/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
+++ b/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
@@ -27,6 +27,7 @@
 #include "esp_idf_version.h"
 #include "esp_types.h"
 #include "esp_log.h"
+#include "esp_random.h"
 
 #ifdef WOLFSSL_ESP32WROOM32_CRYPT_DEBUG
     #undef LOG_LOCAL_LEVEL

--- a/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
+++ b/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
@@ -51,7 +51,9 @@
     #include "driver/periph_ctrl.h"
 #endif
 
-#if ESP_IDF_VERSION_MAJOR >= 4
+#if ESP_IDF_VERSION_MAJOR >= 5
+    // ets_sys.h isn't required for ESP32; breaks ESP32s3 build. 
+#elif ESP_IDF_VERSION_MAJOR >= 4
     #include <esp32/rom/ets_sys.h>
 #else
     #include <rom/ets_sys.h>

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -202,7 +202,11 @@
 #else /* MULTI_THREADED */
     /* FREERTOS comes first to enable use of FreeRTOS Windows simulator only */
     #if defined(FREERTOS)
-        typedef xSemaphoreHandle wolfSSL_Mutex;
+        #if ESP_IDF_VERSION_MAJOR >= 4
+            typedef SemaphoreHandle_t wolfSSL_Mutex;
+        #else
+            typedef xSemaphoreHandle wolfSSL_Mutex;
+        #endif
     #elif defined(FREERTOS_TCP)
         #include "FreeRTOS.h"
         #include "semphr.h"


### PR DESCRIPTION
# Description

Added support for ESP32s3 hardware acceleration. Addresses part of #5215 . Note: ESP32s3 doesn't support hardware acceleration of AES-192, so this is now disabled in `user_settings.h`. 

# Testing

* Ran `wolf_test_task();` on both ESP32s3 and ESP32. All tests passing. 
* Tests for ED25519 fail on both ESP32 (existing code prior to this PR) and ESP32s3, so `HAVE_ED25519` is commented out in `user_settings.h`. 
* only options in standard `user_settings.h` have been tested plus `WOLFSSL_KEY_GEN`, `WOLFSSL_CERT_GEN`, `WOLFSSL_CERT_REQ`. 
* only ESPWROOM32 hardware target ESP32 and ESP32s3 tested as I don't have the other hardware. 

# Checklist

 - [na] added tests
 - [na] updated/added doxygen
 - [y] updated appropriate READMEs
 - [y] Updated manual and documentation
