### PR TITLE
Avoid pointless-comparison warnings (Pa084) with IAR for ARM tools

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -35907,7 +35907,8 @@ int wolfSSL_BN_is_word(const WOLFSSL_BIGNUM* bn, WOLFSSL_BN_ULONG w)
         return WOLFSSL_FAILURE;
     }
 
-    if (w <= (WOLFSSL_BN_ULONG)MP_MASK) {
+    /* Check operand sizes before value check to avoid pointless comparison */
+    if ((sizeof(w) <= sizeof(MP_MASK)) || (w <= (WOLFSSL_BN_ULONG)MP_MASK)) {
         if (mp_isword((mp_int*)bn->internal, (mp_digit)w) == MP_YES) {
             return WOLFSSL_SUCCESS;
         }
@@ -36565,7 +36566,8 @@ static int wolfSSL_BN_add_word_int(WOLFSSL_BIGNUM *bn, WOLFSSL_BN_ULONG w,
     }
 
     if (ret == WOLFSSL_SUCCESS) {
-        if (w <= (WOLFSSL_BN_ULONG)MP_MASK) {
+        /* Check operand sizes before value check to avoid pointless comparison */
+        if ((sizeof(w) <= sizeof(MP_MASK)) || (w <= (WOLFSSL_BN_ULONG)MP_MASK)) {
             if (sub == 1) {
                 rc = mp_sub_d((mp_int*)bn->internal, (mp_digit)w,
                               (mp_int*)bn->internal);
@@ -36877,7 +36879,8 @@ WOLFSSL_BN_ULONG wolfSSL_BN_mod_word(const WOLFSSL_BIGNUM *bn,
         return (WOLFSSL_BN_ULONG)WOLFSSL_FATAL_ERROR;
     }
 
-    if (w <= (WOLFSSL_BN_ULONG)MP_MASK) {
+    /* Check operand sizes before value check to avoid pointless comparison */
+    if ((sizeof(w) <= sizeof(MP_MASK)) || (w <= (WOLFSSL_BN_ULONG)MP_MASK)) {
         mp_digit bn_ret;
         if (mp_mod_d((mp_int*)bn->internal, (mp_digit)w, &bn_ret) != MP_OKAY) {
             WOLFSSL_MSG("mp_add_d error");


### PR DESCRIPTION
# Description

Update comparison of `WOLFSSL_BN_ULONG` value to `MP_MASK` to include check for potential type size differences which can lead to pointless-comparison warnings with IAR tools:

> Warning[Pa084]: pointless integer comparison, the result is always true

The problem manifests when the byte-size of the `WOLFSSL_BN_ULONG` type is less than or equal to the size of the `MP_MASK` (type).  In that situation, since both types are unsigned ('MP_MASK' define includes cast to unsigned type) and `MP_MASK` is the maximum value (i.e. it is an unsigned cast of `-1`), the value of the `WOLFSSL_BN_ULONG` will ALWAYS be less than or equal to `MP_MASK` (max value).

As the byte-size of `WOLFSSL_BN_ULONG` varies based on the configuration of wolfSSL (target used), there is the possibility that a meaningful comparison can be made when the byte-size of `WOLFSSL_BN_ULONG` is larger than that of `FP_MASK`.  Leveraging the left-to-right order of condition checks, a comparison of the two byte-sizes can be made BEFORE the original value-comparison, and when the byte-sizes would trigger the pointless-comparison warning, the condition is true, so the subsequent value-comparison is not performed, avoiding the pointless-comparison warning.  When the first condition detects that there is a meaningful comparison to be made based on the byte-sizes involved, it will fail, allowing the second condition (value-comparison) to proceed.

Fixes ZD 14935

# Testing

Tested in Windows 11 using IAR Embedded Workbench for ARM (EWARM) with source-code reproducing the error:
```
    {
        WOLFSSL_BN_ULONG w = 0;
        
        if  (w <= (WOLFSSL_BN_ULONG)MP_MASK)) { // Original - produces warning
        //if ((sizeof(w) <= sizeof(MP_MASK)) || (w <= (WOLFSSL_BN_ULONG)MP_MASK)) { // Fix - avoids warning
            return -1;
        }
    }
```
