### PR TITLE
Support pthread_rwlock

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1109,9 +1109,7 @@ AS_IF([ test "x$ENABLED_SINGLETHREADED" = "xno" ],[
                    AS_CASE([$PTHREAD_CFLAGS],[-Qunused-arguments*],[PTHREAD_CFLAGS="-Xcompiler $PTHREAD_CFLAGS"])
                    AM_CFLAGS="$AM_CFLAGS $PTHREAD_CFLAGS"
                    LIBS="$LIBS $PTHREAD_LIBS"
-                   AC_CHECK_FUNC([pthread_rwlock_destroy], [
-                     AC_DEFINE([WOLFSSL_USE_RWLOCK], [1], [Define if you have a rwlock implementations])
-                   ])
+                   AC_CHECK_TYPES([pthread_rwlock_t])
                    ],[
                       ENABLED_SINGLETHREADED=yes
                       ])

--- a/configure.ac
+++ b/configure.ac
@@ -1109,6 +1109,7 @@ AS_IF([ test "x$ENABLED_SINGLETHREADED" = "xno" ],[
                    AS_CASE([$PTHREAD_CFLAGS],[-Qunused-arguments*],[PTHREAD_CFLAGS="-Xcompiler $PTHREAD_CFLAGS"])
                    AM_CFLAGS="$AM_CFLAGS $PTHREAD_CFLAGS"
                    LIBS="$LIBS $PTHREAD_LIBS"
+                   AC_CHECK_FUNCS([pthread_rwlock_destroy])
                    ],[
                       ENABLED_SINGLETHREADED=yes
                       ])

--- a/configure.ac
+++ b/configure.ac
@@ -1109,7 +1109,9 @@ AS_IF([ test "x$ENABLED_SINGLETHREADED" = "xno" ],[
                    AS_CASE([$PTHREAD_CFLAGS],[-Qunused-arguments*],[PTHREAD_CFLAGS="-Xcompiler $PTHREAD_CFLAGS"])
                    AM_CFLAGS="$AM_CFLAGS $PTHREAD_CFLAGS"
                    LIBS="$LIBS $PTHREAD_LIBS"
-                   AC_CHECK_FUNCS([pthread_rwlock_destroy])
+                   AC_CHECK_FUNC([pthread_rwlock_destroy], [
+                     AC_DEFINE([WOLFSSL_USE_RWLOCK], [1], [Define if you have a rwlock implementations])
+                   ])
                    ],[
                       ENABLED_SINGLETHREADED=yes
                       ])

--- a/src/crl.c
+++ b/src/crl.c
@@ -1342,13 +1342,14 @@ static int StartMonitorCRL(WOLFSSL_CRL* crl)
         return BAD_MUTEX_E;
     }
 
+#ifndef WOLFSSL_USE_RWLOCK
         while (crl->setup == 0) {
             if (pthread_cond_wait(&crl->cond, &crl->crlLock) != 0) {
                 ret = BAD_COND_E;
                 break;
             }
         }
-
+#endif
         if (crl->setup < 0)
             ret = crl->setup;  /* store setup error */
 

--- a/src/crl.c
+++ b/src/crl.c
@@ -1342,14 +1342,12 @@ static int StartMonitorCRL(WOLFSSL_CRL* crl)
         return BAD_MUTEX_E;
     }
 
-#ifndef WOLFSSL_USE_RWLOCK
         while (crl->setup == 0) {
             if (pthread_cond_wait(&crl->cond, &crl->crlLock) != 0) {
                 ret = BAD_COND_E;
                 break;
             }
         }
-#endif
         if (crl->setup < 0)
             ret = crl->setup;  /* store setup error */
 

--- a/src/dtls.c
+++ b/src/dtls.c
@@ -288,7 +288,7 @@ static int TlsSessionIdIsValid(WOLFSSL* ssl, WolfSSL_ConstVector sessionID,
             return 0;
     }
 #endif
-    ret = TlsSessionCacheGetAndLock(sessionID.elements, &sess, &sessRow);
+    ret = TlsSessionCacheGetAndLock(sessionID.elements, &sess, &sessRow, 1);
     if (ret == 0 && sess != NULL) {
         *isValid = 1;
         TlsSessionCacheUnlockRow(sessRow);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6162,8 +6162,8 @@ int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify)
     #if defined(TITAN_SESSION_CACHE)
         #define SESSIONS_PER_ROW 31
         #define SESSION_ROWS 64937
-        #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
-        #define ENABLE_SESSION_CACHE_ROW_LOCK
+        #ifndef ENABLE_SESSION_CACHE_ROW_LOCK
+            #define ENABLE_SESSION_CACHE_ROW_LOCK
         #endif
     #elif defined(HUGE_SESSION_CACHE)
         #define SESSIONS_PER_ROW 11

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -10272,7 +10272,7 @@ static int SendTls13NewSessionTicket(WOLFSSL* ssl)
 
     ssl->options.haveSessionId = 1;
 
-#ifndef NO_SESSION_CACHE
+#if !defined(NO_SESSION_CACHE) && defined(WOLFSSL_TICKET_HAVE_ID)
     AddSession(ssl);
 #endif
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -10272,6 +10272,9 @@ static int SendTls13NewSessionTicket(WOLFSSL* ssl)
 
     ssl->options.haveSessionId = 1;
 
+    /* Only add to cache when suppport built in and when the ticket contains
+     * an ID. Otherwise we have no way to actually retrieve the ticket from the
+     * cache. */
 #if !defined(NO_SESSION_CACHE) && defined(WOLFSSL_TICKET_HAVE_ID)
     AddSession(ssl);
 #endif

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -1560,7 +1560,7 @@ int wolfSSL_CryptHwMutexUnLock(void)
 
 #elif defined(WOLFSSL_PTHREADS)
     #ifdef WOLFSSL_USE_RWLOCK
-        int wc_InitMutex(wolfSSL_Mutex* m)
+        int wc_InitRwLock(wolfSSL_RwLock* m)
         {
             if (pthread_rwlock_init(m, 0) == 0)
                 return 0;
@@ -1569,7 +1569,7 @@ int wolfSSL_CryptHwMutexUnLock(void)
         }
 
 
-        int wc_FreeMutex(wolfSSL_Mutex* m)
+        int wc_FreeRwLock(wolfSSL_RwLock* m)
         {
             if (pthread_rwlock_destroy(m) == 0)
                 return 0;
@@ -1578,7 +1578,7 @@ int wolfSSL_CryptHwMutexUnLock(void)
         }
 
 
-        int wc_LockMutex(wolfSSL_Mutex* m)
+        int wc_LockRwLock_Wr(wolfSSL_RwLock* m)
         {
             if (pthread_rwlock_wrlock(m) == 0)
                 return 0;
@@ -1586,7 +1586,7 @@ int wolfSSL_CryptHwMutexUnLock(void)
                 return BAD_MUTEX_E;
         }
 
-        int wc_RD_Lock(wolfSSL_Mutex* m)
+        int wc_LockRwLock_Rd(wolfSSL_RwLock* m)
         {
             if (pthread_rwlock_rdlock(m) == 0)
                 return 0;
@@ -1594,49 +1594,48 @@ int wolfSSL_CryptHwMutexUnLock(void)
                 return BAD_MUTEX_E;
         }
 
-        int wc_UnLockMutex(wolfSSL_Mutex* m)
+        int wc_UnLockRwLock(wolfSSL_RwLock* m)
         {
             if (pthread_rwlock_unlock(m) == 0)
                 return 0;
             else
                 return BAD_MUTEX_E;
         }
-    #else
-        int wc_InitMutex(wolfSSL_Mutex* m)
-        {
-            if (pthread_mutex_init(m, 0) == 0)
-                return 0;
-            else
-                return BAD_MUTEX_E;
-        }
-
-
-        int wc_FreeMutex(wolfSSL_Mutex* m)
-        {
-            if (pthread_mutex_destroy(m) == 0)
-                return 0;
-            else
-                return BAD_MUTEX_E;
-        }
-
-
-        int wc_LockMutex(wolfSSL_Mutex* m)
-        {
-            if (pthread_mutex_lock(m) == 0)
-                return 0;
-            else
-                return BAD_MUTEX_E;
-        }
-
-
-        int wc_UnLockMutex(wolfSSL_Mutex* m)
-        {
-            if (pthread_mutex_unlock(m) == 0)
-                return 0;
-            else
-                return BAD_MUTEX_E;
-        }
     #endif
+    int wc_InitMutex(wolfSSL_Mutex* m)
+    {
+        if (pthread_mutex_init(m, 0) == 0)
+            return 0;
+        else
+            return BAD_MUTEX_E;
+    }
+
+
+    int wc_FreeMutex(wolfSSL_Mutex* m)
+    {
+        if (pthread_mutex_destroy(m) == 0)
+            return 0;
+        else
+            return BAD_MUTEX_E;
+    }
+
+
+    int wc_LockMutex(wolfSSL_Mutex* m)
+    {
+        if (pthread_mutex_lock(m) == 0)
+            return 0;
+        else
+            return BAD_MUTEX_E;
+    }
+
+
+    int wc_UnLockMutex(wolfSSL_Mutex* m)
+    {
+        if (pthread_mutex_unlock(m) == 0)
+            return 0;
+        else
+            return BAD_MUTEX_E;
+    }
 #elif defined(WOLFSSL_LINUXKM)
 
     /* Linux kernel mutex routines are voids, alas. */
@@ -2589,9 +2588,31 @@ int wolfSSL_CryptHwMutexUnLock(void)
 
 #endif
 #ifndef WOLFSSL_USE_RWLOCK
-    int wc_RD_Lock(wolfSSL_Mutex* m)
+    int wc_InitRwLock(wolfSSL_RwLock* m)
+    {
+        return wc_InitMutex(m);
+    }
+
+
+    int wc_FreeRwLock(wolfSSL_RwLock* m)
+    {
+        return wc_FreeMutex(m);
+    }
+
+
+    int wc_LockRwLock_Wr(wolfSSL_RwLock* m)
     {
         return wc_LockMutex(m);
+    }
+
+    int wc_LockRwLock_Rd(wolfSSL_RwLock* m)
+    {
+        return wc_LockMutex(m);
+    }
+
+    int wc_UnLockRwLock(wolfSSL_RwLock* m)
+    {
+        return wc_UnLockMutex(m);
     }
 #endif
 

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -1559,42 +1559,77 @@ int wolfSSL_CryptHwMutexUnLock(void)
     }
 
 #elif defined(WOLFSSL_PTHREADS)
-
-    int wc_InitMutex(wolfSSL_Mutex* m)
-    {
-        if (pthread_mutex_init(m, 0) == 0)
-            return 0;
-        else
-            return BAD_MUTEX_E;
-    }
-
-
-    int wc_FreeMutex(wolfSSL_Mutex* m)
-    {
-        if (pthread_mutex_destroy(m) == 0)
-            return 0;
-        else
-            return BAD_MUTEX_E;
-    }
+    #ifdef WOLFSSL_USE_RWLOCK
+        int wc_InitMutex(wolfSSL_Mutex* m)
+        {
+            if (pthread_rwlock_init(m, 0) == 0)
+                return 0;
+            else
+                return BAD_MUTEX_E;
+        }
 
 
-    int wc_LockMutex(wolfSSL_Mutex* m)
-    {
-        if (pthread_mutex_lock(m) == 0)
-            return 0;
-        else
-            return BAD_MUTEX_E;
-    }
+        int wc_FreeMutex(wolfSSL_Mutex* m)
+        {
+            if (pthread_rwlock_destroy(m) == 0)
+                return 0;
+            else
+                return BAD_MUTEX_E;
+        }
 
 
-    int wc_UnLockMutex(wolfSSL_Mutex* m)
-    {
-        if (pthread_mutex_unlock(m) == 0)
-            return 0;
-        else
-            return BAD_MUTEX_E;
-    }
+        int wc_LockMutex(wolfSSL_Mutex* m)
+        {
+            if (pthread_rwlock_wrlock(m) == 0)
+                return 0;
+            else
+                return BAD_MUTEX_E;
+        }
 
+
+        int wc_UnLockMutex(wolfSSL_Mutex* m)
+        {
+            if (pthread_rwlock_unlock(m) == 0)
+                return 0;
+            else
+                return BAD_MUTEX_E;
+        }
+    #else
+        int wc_InitMutex(wolfSSL_Mutex* m)
+        {
+            if (pthread_mutex_init(m, 0) == 0)
+                return 0;
+            else
+                return BAD_MUTEX_E;
+        }
+
+
+        int wc_FreeMutex(wolfSSL_Mutex* m)
+        {
+            if (pthread_mutex_destroy(m) == 0)
+                return 0;
+            else
+                return BAD_MUTEX_E;
+        }
+
+
+        int wc_LockMutex(wolfSSL_Mutex* m)
+        {
+            if (pthread_mutex_lock(m) == 0)
+                return 0;
+            else
+                return BAD_MUTEX_E;
+        }
+
+
+        int wc_UnLockMutex(wolfSSL_Mutex* m)
+        {
+            if (pthread_mutex_unlock(m) == 0)
+                return 0;
+            else
+                return BAD_MUTEX_E;
+        }
+    #endif
 #elif defined(WOLFSSL_LINUXKM)
 
     /* Linux kernel mutex routines are voids, alas. */

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -1586,6 +1586,13 @@ int wolfSSL_CryptHwMutexUnLock(void)
                 return BAD_MUTEX_E;
         }
 
+        int wc_RD_Lock(wolfSSL_Mutex* m)
+        {
+            if (pthread_rwlock_rdlock(m) == 0)
+                return 0;
+            else
+                return BAD_MUTEX_E;
+        }
 
         int wc_UnLockMutex(wolfSSL_Mutex* m)
         {
@@ -2580,6 +2587,12 @@ int wolfSSL_CryptHwMutexUnLock(void)
 #else
     #warning No mutex handling defined
 
+#endif
+#ifndef WOLFSSL_USE_RWLOCK
+    int wc_RD_Lock(wolfSSL_Mutex* m)
+    {
+        return wc_LockMutex(m);
+    }
 #endif
 
 #ifndef NO_ASN_TIME

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -2587,7 +2587,7 @@ int wolfSSL_CryptHwMutexUnLock(void)
     #warning No mutex handling defined
 
 #endif
-#ifndef WOLFSSL_USE_RWLOCK
+#if !defined(WOLFSSL_USE_RWLOCK) || defined(SINGLE_THREADED)
     int wc_InitRwLock(wolfSSL_RwLock* m)
     {
         return wc_InitMutex(m);

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -1559,6 +1559,7 @@ int wolfSSL_CryptHwMutexUnLock(void)
     }
 
 #elif defined(WOLFSSL_PTHREADS)
+
     #ifdef WOLFSSL_USE_RWLOCK
         int wc_InitRwLock(wolfSSL_RwLock* m)
         {
@@ -1568,7 +1569,6 @@ int wolfSSL_CryptHwMutexUnLock(void)
                 return BAD_MUTEX_E;
         }
 
-
         int wc_FreeRwLock(wolfSSL_RwLock* m)
         {
             if (pthread_rwlock_destroy(m) == 0)
@@ -1576,7 +1576,6 @@ int wolfSSL_CryptHwMutexUnLock(void)
             else
                 return BAD_MUTEX_E;
         }
-
 
         int wc_LockRwLock_Wr(wolfSSL_RwLock* m)
         {
@@ -1602,6 +1601,7 @@ int wolfSSL_CryptHwMutexUnLock(void)
                 return BAD_MUTEX_E;
         }
     #endif
+
     int wc_InitMutex(wolfSSL_Mutex* m)
     {
         if (pthread_mutex_init(m, 0) == 0)
@@ -2593,12 +2593,10 @@ int wolfSSL_CryptHwMutexUnLock(void)
         return wc_InitMutex(m);
     }
 
-
     int wc_FreeRwLock(wolfSSL_RwLock* m)
     {
         return wc_FreeMutex(m);
     }
-
 
     int wc_LockRwLock_Wr(wolfSSL_RwLock* m)
     {

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2295,8 +2295,6 @@ struct WOLFSSL_CRL {
     wolfSSL_Mutex         crlLock;       /* CRL list lock */
     CRL_Monitor           monitors[2];   /* PEM and DER possible */
 #ifdef HAVE_CRL_MONITOR
-    pthread_mutex_t       condLock;      /* Has to be a mutex for not rwlock
-                                          * pthread_cond_wait API */
     pthread_cond_t        cond;          /* condition to signal setup */
     pthread_t             tid;           /* monitoring thread */
     int                   mfd;           /* monitor fd, -1 if no init yet */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2295,6 +2295,10 @@ struct WOLFSSL_CRL {
     wolfSSL_Mutex         crlLock;       /* CRL list lock */
     CRL_Monitor           monitors[2];   /* PEM and DER possible */
 #ifdef HAVE_CRL_MONITOR
+#ifdef WOLFSSL_USE_RWLOCK
+    pthread_mutex_t       condLock;      /* Has to be a mutex for not rwlock
+                                          * pthread_cond_wait API */
+#endif
     pthread_cond_t        cond;          /* condition to signal setup */
     pthread_t             tid;           /* monitoring thread */
     int                   mfd;           /* monitor fd, -1 if no init yet */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2295,10 +2295,8 @@ struct WOLFSSL_CRL {
     wolfSSL_Mutex         crlLock;       /* CRL list lock */
     CRL_Monitor           monitors[2];   /* PEM and DER possible */
 #ifdef HAVE_CRL_MONITOR
-#ifdef WOLFSSL_USE_RWLOCK
     pthread_mutex_t       condLock;      /* Has to be a mutex for not rwlock
                                           * pthread_cond_wait API */
-#endif
     pthread_cond_t        cond;          /* condition to signal setup */
     pthread_t             tid;           /* monitoring thread */
     int                   mfd;           /* monitor fd, -1 if no init yet */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3999,7 +3999,7 @@ WOLFSSL_LOCAL
 WOLFSSL_SESSION* ClientSessionToSession(const WOLFSSL_SESSION* session);
 WOLFSSL_LOCAL void TlsSessionCacheUnlockRow(word32 row);
 WOLFSSL_LOCAL int TlsSessionCacheGetAndLock(const byte *id,
-    WOLFSSL_SESSION **sess, word32 *lockedRow);
+    WOLFSSL_SESSION **sess, word32 *lockedRow, byte readOnly);
 /* WOLFSSL_API to test it in tests/api.c */
 WOLFSSL_API int wolfSSL_GetSessionFromCache(WOLFSSL* ssl, WOLFSSL_SESSION* output);
 WOLFSSL_LOCAL int wolfSSL_SetSession(WOLFSSL* ssl, WOLFSSL_SESSION* session);

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -228,7 +228,11 @@
         typedef pthread_mutex_t wolfSSL_Mutex;
         int maxq_CryptHwMutexTryLock(void);
     #elif defined(WOLFSSL_PTHREADS)
-        typedef pthread_mutex_t wolfSSL_Mutex;
+        #ifdef WOLFSSL_USE_RWLOCK
+            typedef pthread_rwlock_t wolfSSL_Mutex;
+        #else
+            typedef pthread_mutex_t wolfSSL_Mutex;
+        #endif
     #elif defined(THREADX)
         typedef TX_MUTEX wolfSSL_Mutex;
     #elif defined(WOLFSSL_DEOS)

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -175,11 +175,15 @@
                 /* definitions are in linuxkm/linuxkm_wc_port.h */
             #else
                 #define WOLFSSL_PTHREADS
+                #ifdef HAVE_CONFIG_H
+                    /* Need to pull in config.h to get access to
+                     * HAVE_PTHREAD_RWLOCK_DESTROY */
+                    #include <config.h>
+                    #undef HAVE_CONFIG_H
+                #endif
                 #include <pthread.h>
-                /* Use PTHREAD_RWLOCK_INITIALIZER to detect if rwlocks are
-                 * supported in this pthreads lib. */
                 #if !defined(WOLFSSL_NO_RWLOCK) && \
-                    defined(PTHREAD_RWLOCK_INITIALIZER)
+                    defined(HAVE_PTHREAD_RWLOCK_DESTROY)
                     #undef WOLFSSL_USE_RWLOCK
                     #define WOLFSSL_USE_RWLOCK
                 #endif

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -175,18 +175,7 @@
                 /* definitions are in linuxkm/linuxkm_wc_port.h */
             #else
                 #define WOLFSSL_PTHREADS
-                #ifdef HAVE_CONFIG_H
-                    /* Need to pull in config.h to get access to
-                     * HAVE_PTHREAD_RWLOCK_DESTROY */
-                    #include <config.h>
-                    #undef HAVE_CONFIG_H
-                #endif
                 #include <pthread.h>
-                #if !defined(WOLFSSL_NO_RWLOCK) && \
-                    defined(HAVE_PTHREAD_RWLOCK_DESTROY)
-                    #undef WOLFSSL_USE_RWLOCK
-                    #define WOLFSSL_USE_RWLOCK
-                #endif
             #endif
         #endif
     #endif
@@ -300,7 +289,7 @@
     #endif /* USE_WINDOWS_API */
 
 #endif /* SINGLE_THREADED */
-#ifndef WOLFSSL_USE_RWLOCK
+#if !defined(WOLFSSL_USE_RWLOCK) || defined(SINGLE_THREADED)
     typedef wolfSSL_Mutex wolfSSL_RwLock;
 #endif
 

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -175,6 +175,10 @@
                 /* definitions are in linuxkm/linuxkm_wc_port.h */
             #else
                 #define WOLFSSL_PTHREADS
+                #ifdef HAVE_PTHREAD_RWLOCK_T
+                    #undef WOLFSSL_USE_RWLOCK
+                    #define WOLFSSL_USE_RWLOCK
+                #endif
                 #include <pthread.h>
             #endif
         #endif

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -176,6 +176,9 @@
             #else
                 #define WOLFSSL_PTHREADS
                 #include <pthread.h>
+                #ifndef WOLFSSL_NO_RWLOCK
+                    #define WOLFSSL_USE_RWLOCK
+                #endif
             #endif
         #endif
     #endif
@@ -385,6 +388,7 @@ WOLFSSL_API wolfSSL_Mutex* wc_InitAndAllocMutex(void);
 WOLFSSL_API int wc_FreeMutex(wolfSSL_Mutex* m);
 WOLFSSL_API int wc_LockMutex(wolfSSL_Mutex* m);
 WOLFSSL_API int wc_UnLockMutex(wolfSSL_Mutex* m);
+WOLFSSL_API int wc_RD_Lock(wolfSSL_Mutex* m);
 #if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER)
 /* dynamically set which mutex to use. unlock / lock is controlled by flag */
 typedef void (mutex_cb)(int flag, int type, const char* file, int line);

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -236,10 +236,9 @@
         int maxq_CryptHwMutexTryLock(void);
     #elif defined(WOLFSSL_PTHREADS)
         #ifdef WOLFSSL_USE_RWLOCK
-            typedef pthread_rwlock_t wolfSSL_Mutex;
-        #else
-            typedef pthread_mutex_t wolfSSL_Mutex;
+            typedef pthread_rwlock_t wolfSSL_RwLock;
         #endif
+        typedef pthread_mutex_t wolfSSL_Mutex;
     #elif defined(THREADX)
         typedef TX_MUTEX wolfSSL_Mutex;
     #elif defined(WOLFSSL_DEOS)
@@ -295,7 +294,11 @@
     #else
         #error Need a mutex type in multithreaded mode
     #endif /* USE_WINDOWS_API */
+
 #endif /* SINGLE_THREADED */
+#ifndef WOLFSSL_USE_RWLOCK
+    typedef wolfSSL_Mutex wolfSSL_RwLock;
+#endif
 
 /* Reference counting. */
 typedef struct wolfSSL_Ref {
@@ -392,7 +395,12 @@ WOLFSSL_API wolfSSL_Mutex* wc_InitAndAllocMutex(void);
 WOLFSSL_API int wc_FreeMutex(wolfSSL_Mutex* m);
 WOLFSSL_API int wc_LockMutex(wolfSSL_Mutex* m);
 WOLFSSL_API int wc_UnLockMutex(wolfSSL_Mutex* m);
-WOLFSSL_API int wc_RD_Lock(wolfSSL_Mutex* m);
+/* RwLock functions. Fallback to Mutex when not implemented explicitly. */
+WOLFSSL_API int wc_InitRwLock(wolfSSL_RwLock* m);
+WOLFSSL_API int wc_FreeRwLock(wolfSSL_RwLock* m);
+WOLFSSL_API int wc_LockRwLock_Wr(wolfSSL_RwLock* m);
+WOLFSSL_API int wc_LockRwLock_Rd(wolfSSL_RwLock* m);
+WOLFSSL_API int wc_UnLockRwLock(wolfSSL_RwLock* m);
 #if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER)
 /* dynamically set which mutex to use. unlock / lock is controlled by flag */
 typedef void (mutex_cb)(int flag, int type, const char* file, int line);

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -176,7 +176,11 @@
             #else
                 #define WOLFSSL_PTHREADS
                 #include <pthread.h>
-                #ifndef WOLFSSL_NO_RWLOCK
+                /* Use PTHREAD_RWLOCK_INITIALIZER to detect if rwlocks are
+                 * supported in this pthreads lib. */
+                #if !defined(WOLFSSL_NO_RWLOCK) && \
+                    defined(PTHREAD_RWLOCK_INITIALIZER)
+                    #undef WOLFSSL_USE_RWLOCK
                     #define WOLFSSL_USE_RWLOCK
                 #endif
             #endif


### PR DESCRIPTION
# Description

This PR adds read-write lock (`pthread_rwlock_t`) support in Linux with a build setting `WOLFSSL_USE_RWLOCK`  option. 

Fixes zd#15424

# Testing
`./configure CFLAGS="-DWOLFSSL_USE_RWLOCK" && make check`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
