### PR TITLE
append git version info during Espressif install

### DIFF
--- a/IDE/Espressif/ESP-IDF/append_wolfssl_git_version.sh
+++ b/IDE/Espressif/ESP-IDF/append_wolfssl_git_version.sh
@@ -43,18 +43,18 @@ fi
 # we plan to add lines like these:
 #
 #undef  LIBWOLFSSL_VERSION_GIT_HASH
-#define LIBWOLFSSL_VERSION_GIT_HASH adb406e1eebf05e452afca98fa9bf3ccd7abcfca
+#define LIBWOLFSSL_VERSION_GIT_HASH "adb406e1eebf05e452afca98fa9bf3ccd7abcfca"
 #undef  LIBWOLFSSL_VERSION_GIT_SHORT_HASH
-#define LIBWOLFSSL_VERSION_GIT_SHORT_HASH adb406e1e
+#define LIBWOLFSSL_VERSION_GIT_SHORT_HASH "adb406e1e"
 #undef  LIBWOLFSSL_VERSION_GIT_HASH_DATE
 #define LIBWOLFSSL_VERSION_GIT_HASH_DATE "Sat Jan 5 09:00:00 2013 +0100"
 #
-NEW_VERSION_LINES="{ print;                                                                             \
-                     print \"#undef  LIBWOLFSSL_VERSION_GIT_HASH\";                                     \
-                     print \"#define LIBWOLFSSL_VERSION_GIT_HASH $(git rev-parse HEAD)\";               \
-                     print \"#undef  LIBWOLFSSL_VERSION_GIT_SHORT_HASH\";                               \
-                     print \"#define LIBWOLFSSL_VERSION_GIT_SHORT_HASH $(git rev-parse --short HEAD)\"; \
-                     print \"#undef  LIBWOLFSSL_VERSION_GIT_HASH_DATE\";                                \
+NEW_VERSION_LINES="{ print;                                                                                     \
+                     print \"#undef  LIBWOLFSSL_VERSION_GIT_HASH\";                                             \
+                     print \"#define LIBWOLFSSL_VERSION_GIT_HASH \x22$(git rev-parse HEAD)\x22\";               \
+                     print \"#undef  LIBWOLFSSL_VERSION_GIT_SHORT_HASH\";                                       \
+                     print \"#define LIBWOLFSSL_VERSION_GIT_SHORT_HASH \x22$(git rev-parse --short HEAD)\x22\"; \
+                     print \"#undef  LIBWOLFSSL_VERSION_GIT_HASH_DATE\";                                        \
                      print \"#define LIBWOLFSSL_VERSION_GIT_HASH_DATE \x22$(git show --no-patch --no-notes --pretty='%cd'  $(git rev-parse HEAD))\x22\"; \
                      next }1"
 

--- a/IDE/Espressif/ESP-IDF/append_wolfssl_git_version.sh
+++ b/IDE/Espressif/ESP-IDF/append_wolfssl_git_version.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+# check if IDF_PATH is set
+if [ -z "$IDF_PATH" ]; then
+    # no IDP PATH found, perhaps set an explicit file in parameters
+    if [ "$1" == "" ]; then
+      # no IDDF_PATH and no parameter: nothing to do
+      echo "Please follows the instruction of ESP-IDF installation and set IDF_PATH."
+      echo " or "
+      echo "Please specify a version.h file to append git information."
+      exit 1
+    fi
+
+    # NO IDF path, but a non-blank parameter, does the parameter file exist?
+    if [ -f "$1" ]; then
+      echo "Adding git version info to file: $1"
+      WOLFSSL_VERSION_FILE="$1"
+    else
+      echo "File not found: $1"
+      exit 1
+    fi
+else
+    # we have an ESP-IDF path, but was thre a parameter to override?
+    if [ "$1" == "" ]; then
+        WOLFSSL_VERSION_FILE="$IDF_PATH"/components/wolfssl/wolfssl/version.h
+    else
+        WOLFSSL_VERSION_FILE="$1"
+    fi
+    # there's $IDF_PATH value, is wolfSSL installed?
+fi
+
+# check to ensure the file to update exists
+if [ -f "$WOLFSSL_VERSION_FILE" ]; then
+  echo "Adding git version info to file: $WOLFSSL_VERSION_FILE"
+else
+  echo "File not found: $WOLFSSL_VERSION_FILE"
+  exit 1
+fi
+
+
+
+# assemble a string of data to pass to awk that will contain the new git hash version info
+# we plan to add lines like these:
+#
+#undef  LIBWOLFSSL_VERSION_GIT_HASH
+#define LIBWOLFSSL_VERSION_GIT_HASH adb406e1eebf05e452afca98fa9bf3ccd7abcfca
+#undef  LIBWOLFSSL_VERSION_GIT_SHORT_HASH
+#define LIBWOLFSSL_VERSION_GIT_SHORT_HASH adb406e1e
+#undef  LIBWOLFSSL_VERSION_GIT_HASH_DATE
+#define LIBWOLFSSL_VERSION_GIT_HASH_DATE "Sat Jan 5 09:00:00 2013 +0100"
+#
+NEW_VERSION_LINES="{ print;                                                                             \
+                     print \"#undef  LIBWOLFSSL_VERSION_GIT_HASH\";                                     \
+                     print \"#define LIBWOLFSSL_VERSION_GIT_HASH $(git rev-parse HEAD)\";               \
+                     print \"#undef  LIBWOLFSSL_VERSION_GIT_SHORT_HASH\";                               \
+                     print \"#define LIBWOLFSSL_VERSION_GIT_SHORT_HASH $(git rev-parse --short HEAD)\"; \
+                     print \"#undef  LIBWOLFSSL_VERSION_GIT_HASH_DATE\";                                \
+                     print \"#define LIBWOLFSSL_VERSION_GIT_HASH_DATE \x22$(git show --no-patch --no-notes --pretty='%cd'  $(git rev-parse HEAD))\x22\"; \
+                     next }1"
+
+# save interim results in temp file that we create:
+NEW_VERSION_FILE="$WOLFSSL_VERSION_FILE".tmp
+cat "$WOLFSSL_VERSION_FILE" > "$NEW_VERSION_FILE"
+
+# remove any prior git hash defines
+sed -i.bak '/LIBWOLFSSL_VERSION_GIT_HASH/d'       "$NEW_VERSION_FILE"
+retVal=$?
+if [ $retVal -ne 0 ]; then
+    echo "Error during SED line deletion #1"
+    exit $retVal
+fi
+
+sed -i.bak '/LIBWOLFSSL_VERSION_GIT_SHORT_HASH/d' "$NEW_VERSION_FILE"
+retVal=$?
+if [ $retVal -ne 0 ]; then
+    echo "Error during SED line deletion #2"
+    exit $retVal
+fi
+
+sed -i.bak '/LIBWOLFSSL_VERSION_GIT_HASH_DATE/d' "$NEW_VERSION_FILE"
+retVal=$?
+if [ $retVal -ne 0 ]; then
+    echo "Error during SED line deletion #3"
+    exit $retVal
+fi
+
+
+# append the git hash values after the LIBWOLFSSL_VERSION_HEX
+# awk "/LIBWOLFSSL_VERSION_HEX/ $NEW_VERSION_LINES" "$NEW_VERSION_FILE" >  $WOLFSSL_VERSION_FILE"
+# awk "/LIBWOLFSSL_VERSION_HEX/ $NEW_VERSION_LINES" "$NEW_VERSION_FILE"
+
+awk "/LIBWOLFSSL_VERSION_HEX/ $NEW_VERSION_LINES" "$NEW_VERSION_FILE" > "$WOLFSSL_VERSION_FILE"
+retVal=$?
+if [ $retVal -ne 0 ]; then
+    echo "Error during awk replacement."
+    exit $retVal
+fi
+
+# cleanup
+if [ -f "$NEW_VERSION_FILE" ]; then
+  rm "$NEW_VERSION_FILE"
+fi
+
+if [ -f "$NEW_VERSION_FILE".bak ]; then
+  rm "$NEW_VERSION_FILE".bak
+fi
+
+echo "Update complete."

--- a/IDE/Espressif/ESP-IDF/setup.sh
+++ b/IDE/Espressif/ESP-IDF/setup.sh
@@ -155,8 +155,13 @@ ${CPDCMD} -r ${WOLFSSL_ESPIDFDIR}/examples/wolfssl_server/main/include/* ${WOLFS
 
 popd > /dev/null #
 
+if [ -f ./append_wolfssl_git_version.sh ]; then
+    ./append_wolfssl_git_version.sh "${WOLFSSLLIB_TRG_DIR}/wolfssl/version.h"
+fi
+
 if [ "${WOLFSSL_SETUP_VERBOSE}" == "true" ]; then
   echo "Copy complete!"
 fi
 
-exit 1
+# exit with success
+exit 0


### PR DESCRIPTION
# Description

As noted in https://github.com/wolfSSL/wolfssl/issues/5948#issuecomment-1370526871 there can be several Espressif wolfSSL component installs in multiple directories for various ESP-IDF versions.

As the installation is a file copy process, the GitHub version information is currently lost at install time. The user at runtime only has the `LIBWOLFSSL_VERSION_STRING` and `LIBWOLFSSL_VERSION_HEX` release values available.

This update will add a few `#DEFINE` values to the installed component wolfssl `version.h` file such as:

```
#undef  LIBWOLFSSL_VERSION_GIT_HASH
#define LIBWOLFSSL_VERSION_GIT_HASH adb406e1eebf05e452afca98fa9bf3ccd7abcfca
#undef  LIBWOLFSSL_VERSION_GIT_SHORT_HASH
#define LIBWOLFSSL_VERSION_GIT_SHORT_HASH adb406e1e
#undef  LIBWOLFSSL_VERSION_GIT_HASH_DATE
#define LIBWOLFSSL_VERSION_GIT_HASH_DATE "Sat Jan 5 09:00:00 2013 +0100"
```

The Espressif `./setup.sh` now exists with a value of `0` instead of `1` if all was successful.

Fixes zd# n/a

# Testing

Run the `./setup.sh` for Espressif component install as explained in the [Setup for Linux](https://github.com/wolfSSL/wolfssl/blob/master/IDE/Espressif/ESP-IDF/README.md#setup-for-linux) and observe the update to `version.h` as noted in the output.

The command can also be run manually as desired:

```
./append_wolfssl_git_version.sh
```

resulting in this example output:
```
Adding git version info to file: /mnt/c/SysGCC/esp32/esp-idf/v5.0/components/wolfssl/wolfssl/version.h
Update complete.
```  

Windows install does not yet have this feature at this time. WSL can be used as a substitute. 

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
