### PR TITLE
TLS v1.3: Support a stateful ticket and test HAVE_EXT_CACHE

### DIFF
--- a/.github/workflows/async.yml
+++ b/.github/workflows/async.yml
@@ -23,3 +23,9 @@ jobs:
           ./configure ${{ matrix.config }}
           make check
 
+      - name: Print errors 
+        if: ${{ failure() }}
+        run: |
+          if [ -f test-suite.log ] ; then
+            cat test-suite.log
+          fi

--- a/.github/workflows/hostap.yml
+++ b/.github/workflows/hostap.yml
@@ -99,6 +99,15 @@ jobs:
           ${{ toJSON(matrix) }}
           EOF
 
+      - name: Print computed job run ID
+        run: |
+          SHA_SUM=$(sha256sum << 'END_OF_HEREDOC' | cut -d " " -f 1
+          ${{ toJSON(github) }}
+          END_OF_HEREDOC
+          )
+          echo "our_job_run_id=$SHA_SUM" >> $GITHUB_ENV
+          echo Our job run ID is $SHA_SUM
+
       - name: Checkout wolfSSL
         uses: actions/checkout@v3
         with:
@@ -264,7 +273,7 @@ jobs:
         if: ${{ failure() && steps.testing.outcome == 'failure' }}
         uses: actions/upload-artifact@v3
         with:
-          name: hostap-logs
+          name: hostap-logs-${{ env.our_job_run_id }}
           path: hostap/tests/hwsim/logs.zip
           retention-days: 5
 

--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -15,6 +15,10 @@ jobs:
           '--enable-all --enable-asn=template',
           '--enable-all --enable-asn=original',
           '--enable-harden-tls',
+          '--enable-tls13 --enable-session-ticket --enable-dtls --enable-dtls13
+           --enable-opensslextra --enable-sessioncerts 
+           CPPFLAGS=''-DWOLFSSL_DTLS_NO_HVR_ON_RESUME -DHAVE_EXT_CACHE 
+           -DWOLFSSL_TICKET_HAVE_ID -DHAVE_EX_DATA -DSESSION_CACHE_DYNAMIC_MEM'' ',
         ]
     name: make check
     runs-on: ${{ matrix.os }}

--- a/src/dtls.c
+++ b/src/dtls.c
@@ -377,22 +377,17 @@ static int TlsSessionIdIsValid(const WOLFSSL* ssl, WolfSSL_ConstVector sessionID
             if (extSess != NULL) {
 #if defined(SESSION_CERTS) || (defined(WOLFSSL_TLS13) && \
                                defined(HAVE_SESSION_TICKET))
-                /* This logic is only for TLS <= 1.2 tickets. Don't accept
-                 * TLS 1.3. */
-                if (IsAtLeastTLSv1_3(extSess->version)) {
-                    if (!copy)
-                        wolfSSL_FreeSession(ssl->ctx, extSess);
-                }
-                else
+        /* This logic is only for TLS <= 1.2 tickets. Don't accept
+         * TLS 1.3. */
+        if (!IsAtLeastTLSv1_3(extSess->version))
 #endif
-                {
-                    *resume = 1;
-                    if (!copy)
-                        wolfSSL_FreeSession(ssl->ctx, extSess);
-                    return 0;
-                }
-            }
+        {
+            if (!copy)
+                wolfSSL_FreeSession(ssl->ctx, extSess);
+            *resume = 1;
+            return 0;
         }
+
         if (ssl->ctx->internalCacheLookupOff)
             return 0;
     }

--- a/src/dtls.c
+++ b/src/dtls.c
@@ -335,6 +335,8 @@ static int TlsTicketIsValid(const WOLFSSL* ssl, WolfSSL_ConstVector exts,
     int ret = 0;
     int tlsxFound;
 
+    *resume = FALSE;
+
     ret = FindExtByType(&tlsxSessionTicket, TLSX_SESSION_TICKET, exts,
                          &tlsxFound);
     if (ret != 0)
@@ -364,12 +366,14 @@ static int TlsSessionIdIsValid(const WOLFSSL* ssl, WolfSSL_ConstVector sessionID
     int ret;
     int copy;
 
+    *resume = FALSE;
+
     if (ssl->options.sessionCacheOff)
         return 0;
     if (sessionID.size != ID_LEN)
         return 0;
-#ifdef HAVE_EXT_CACHE
 
+#ifdef HAVE_EXT_CACHE
     if (ssl->ctx->get_sess_cb != NULL) {
         WOLFSSL_SESSION* extSess =
             ssl->ctx->get_sess_cb((WOLFSSL*)ssl, sessionID.elements, ID_LEN,
@@ -402,9 +406,7 @@ static int TlsSessionIdIsValid(const WOLFSSL* ssl, WolfSSL_ConstVector sessionID
          * TLS 1.3. */
         if (!IsAtLeastTLSv1_3(sess->version))
 #endif
-        {
-            *resume = 1;
-        }
+            *resume = TRUE;
         TlsSessionCacheUnlockRow(sessRow);
     }
 

--- a/src/dtls.c
+++ b/src/dtls.c
@@ -364,8 +364,9 @@ static int TlsSessionIdIsValid(const WOLFSSL* ssl, WolfSSL_ConstVector sessionID
     const WOLFSSL_SESSION* sess;
     word32 sessRow;
     int ret;
+#ifdef HAVE_EXT_CACHE
     int copy;
-
+#endif
     *resume = FALSE;
 
     if (ssl->options.sessionCacheOff)
@@ -392,10 +393,10 @@ static int TlsSessionIdIsValid(const WOLFSSL* ssl, WolfSSL_ConstVector sessionID
                 return 0;
         }
     }
-#endif
-
     if (ssl->ctx->internalCacheLookupOff)
         return 0;
+#endif
+
 
     ret = TlsSessionCacheGetAndRdLock(sessionID.elements, &sess, &sessRow,
             ssl->options.side);

--- a/src/dtls.c
+++ b/src/dtls.c
@@ -381,12 +381,11 @@ static int TlsSessionIdIsValid(const WOLFSSL* ssl, WolfSSL_ConstVector sessionID
              * TLS 1.3. */
             if (!IsAtLeastTLSv1_3(extSess->version))
 #endif
-            {
-                if (!copy)
-                    wolfSSL_FreeSession(ssl->ctx, extSess);
-                *resume = 1;
+                *resume = TRUE;
+            if (!copy)
+                wolfSSL_FreeSession(ssl->ctx, extSess);
+            if (*resume)
                 return 0;
-            }
         }
     }
 #endif

--- a/src/internal.c
+++ b/src/internal.c
@@ -21301,8 +21301,9 @@ int SendFinished(WOLFSSL* ssl)
         return BUILD_MSG_ERROR;
 
     if (!ssl->options.resuming) {
+        SetupSession(ssl);
 #ifndef NO_SESSION_CACHE
-        AddSession(ssl);    /* just try */
+        AddSession(ssl);
 #endif
         if (ssl->options.side == WOLFSSL_SERVER_END) {
         #ifdef OPENSSL_EXTRA
@@ -30622,6 +30623,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     *inOutIdx += length;
     if (length > 0) {
         ssl->timeout = lifetime;
+        SetupSession(ssl);
 #ifndef NO_SESSION_CACHE
         AddSession(ssl);
 #endif

--- a/src/internal.c
+++ b/src/internal.c
@@ -34836,8 +34836,10 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     void DoClientTicketFinalize(WOLFSSL* ssl, InternalTicket* it,
             const WOLFSSL_SESSION* sess)
     {
+#ifdef WOLFSSL_TICKET_HAVE_ID
         ssl->session->haveAltSessionID = 1;
         XMEMCPY(ssl->session->altSessionID, it->id, ID_LEN);
+#endif
         if (sess != NULL) {
             byte bogusID[ID_LEN];
             byte bogusIDSz = ssl->session->sessionIDSz;
@@ -34993,6 +34995,8 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     static void FreeSessionFromCacheOrExt(const WOLFSSL* ssl,
             const WOLFSSL_SESSION* sess, psk_sess_free_cb_ctx* freeCtx)
     {
+        (void)ssl;
+        (void)sess;
 #ifdef HAVE_EXT_CACHE
         if (freeCtx->extCache) {
             if (freeCtx->freeSess)

--- a/src/internal.c
+++ b/src/internal.c
@@ -34836,6 +34836,8 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     void DoClientTicketFinalize(WOLFSSL* ssl, InternalTicket* it,
             const WOLFSSL_SESSION* sess)
     {
+        ssl->session->haveAltSessionID = 1;
+        XMEMCPY(ssl->session->altSessionID, it->id, ID_LEN);
         if (sess != NULL) {
             byte bogusID[ID_LEN];
             byte bogusIDSz = ssl->session->sessionIDSz;
@@ -34850,8 +34852,6 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         }
 #ifdef WOLFSSL_TICKET_HAVE_ID
         else {
-            ssl->session->haveAltSessionID = 1;
-            XMEMCPY(ssl->session->altSessionID, it->id, ID_LEN);
             if (wolfSSL_GetSession(ssl, NULL, 1) != NULL) {
                 WOLFSSL_MSG("Found session matching the session id"
                             " found in the ticket");

--- a/src/internal.c
+++ b/src/internal.c
@@ -34837,10 +34837,16 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             const WOLFSSL_SESSION* sess)
     {
         if (sess != NULL) {
+            byte bogusID[ID_LEN];
+            byte bogusIDSz = ssl->session->sessionIDSz;
+            XMEMCPY(bogusID, ssl->session->sessionID, ID_LEN);
             /* Failure here should not interupt the resumption. We already have
              * all the cipher material we need in `it` */
             WOLFSSL_MSG("Copying in session from passed in arg");
             (void)wolfSSL_DupSession(sess, ssl->session, 1);
+            /* Restore the fake ID */
+            XMEMCPY(ssl->session->sessionID, bogusID, ID_LEN);
+            ssl->session->sessionIDSz= bogusIDSz;
         }
 #ifdef WOLFSSL_TICKET_HAVE_ID
         else {

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -3418,6 +3418,7 @@ static int ProcessSessionTicket(const byte* input, int* sslBytes,
             WOLFSSL_SESSION* sess = wolfSSL_GetSession(session->sslServer,
                 NULL, 0);
             if (sess == NULL) {
+                SetupSession(session->sslServer);
                 AddSession(session->sslServer); /* don't re add */
             #ifdef WOLFSSL_SNIFFER_STATS
                 INC_STAT(SnifferStats.sslResumptionInserts);
@@ -4345,6 +4346,7 @@ static int ProcessFinished(const byte* input, int size, int* sslBytes,
         #ifndef NO_SESSION_CACHE
             WOLFSSL_SESSION* sess = wolfSSL_GetSession(session->sslServer, NULL, 0);
             if (sess == NULL) {
+                SetupSession(session->sslServer);
                 AddSession(session->sslServer); /* don't re add */
             #ifdef WOLFSSL_SNIFFER_STATS
                 INC_STAT(SnifferStats.sslResumptionInserts);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -15140,8 +15140,8 @@ int wolfSSL_SetSession(WOLFSSL* ssl, WOLFSSL_SESSION* session)
 
     session = ClientSessionToSession(session);
 
-    if (ssl == NULL || session == NULL) {
-        WOLFSSL_MSG("ssl or session NULL");
+    if (ssl == NULL || session == NULL || !session->isSetup) {
+        WOLFSSL_MSG("ssl or session NULL or not set up");
         return WOLFSSL_FAILURE;
     }
 
@@ -15767,7 +15767,7 @@ void SetupSession(WOLFSSL* ssl)
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     session->peerVerifyRet = (byte)ssl->peerVerifyRet;
 #endif
-    /* Setup done */
+    session->isSetup = 1;
 }
 
 void AddSession(WOLFSSL* ssl)
@@ -25865,6 +25865,8 @@ WOLFSSL_SESSION* wolfSSL_d2i_SSL_SESSION(WOLFSSL_SESSION** sess,
     if (sess != NULL) {
         *sess = s;
     }
+
+    s->isSetup = 1;
 
     *p += idx;
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -15205,7 +15205,7 @@ int wolfSSL_SetSession(WOLFSSL* ssl, WOLFSSL_SESSION* session)
     /* Let's copy over the altSessionID for local cache purposes */
     if (ret == WOLFSSL_SUCCESS && session->haveAltSessionID) {
         ssl->session->haveAltSessionID = 1;
-        XMEMCPY(ssl->session->altSessionID, session->altSessionID, ID_LEN);
+        XMEMMOVE(ssl->session->altSessionID, session->altSessionID, ID_LEN);
     }
 
     if (sessRow != NULL) {
@@ -15583,7 +15583,8 @@ int AddSessionToCache(WOLFSSL_CTX* ctx, WOLFSSL_SESSION* addSession,
     }
 #endif
 
-    EvictSessionFromCache(cacheSession);
+    if (!overwrite)
+        EvictSessionFromCache(cacheSession);
 
     cacheSession->type = WOLFSSL_SESSION_TYPE_CACHE;
     cacheSession->cacheRow = row;
@@ -15834,8 +15835,13 @@ void AddSession(WOLFSSL* ssl)
 #else
             0,
 #endif
+#ifdef NO_SESSION_CACHE_REF
+            NULL
+#else
             (ssl->options.side == WOLFSSL_CLIENT_END) ?
-                    &ssl->clientSession : NULL);
+                    &ssl->clientSession : NULL
+#endif
+                    );
 
 #ifdef HAVE_EXT_CACHE
     if (error == 0 && ssl->ctx->new_sess_cb != NULL) {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -21193,6 +21193,8 @@ WOLFSSL_SESSION* wolfSSL_NewSession(void* heap)
 {
     WOLFSSL_SESSION* ret = NULL;
 
+    WOLFSSL_ENTER("wolfSSL_NewSession");
+
     ret = (WOLFSSL_SESSION*)XMALLOC(sizeof(WOLFSSL_SESSION), heap,
             DYNAMIC_TYPE_SESSION);
     if (ret != NULL) {
@@ -21579,6 +21581,7 @@ void wolfSSL_FreeSession(WOLFSSL_CTX* ctx, WOLFSSL_SESSION* session)
 
     (void)ctx;
 
+    WOLFSSL_ENTER("wolfSSL_FreeSession");
 
     if (session->ref.count > 0) {
         int ret;
@@ -21590,6 +21593,8 @@ void wolfSSL_FreeSession(WOLFSSL_CTX* ctx, WOLFSSL_SESSION* session)
         }
         wolfSSL_RefFree(&session->ref);
     }
+
+    WOLFSSL_MSG("wolfSSL_FreeSession full free");
 
 #ifdef HAVE_EX_DATA
     if (session->ownExData) {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -15177,7 +15177,6 @@ int wolfSSL_SetSession(WOLFSSL* ssl, WOLFSSL_SESSION* session)
 {
     SessionRow* sessRow = NULL;
     int ret = WOLFSSL_SUCCESS;
-    word32 now;
 
     session = ClientSessionToSession(session);
 
@@ -15257,9 +15256,7 @@ int wolfSSL_SetSession(WOLFSSL* ssl, WOLFSSL_SESSION* session)
     }
 #endif /* OPENSSL_EXTRA */
 
-    now = LowResTimer();
-
-    if (now >= (ssl->session->bornOn + ssl->session->timeout)) {
+    if (LowResTimer() >= (ssl->session->bornOn + ssl->session->timeout)) {
 #if !defined(OPENSSL_EXTRA) || !defined(WOLFSSL_ERROR_CODE_OPENSSL)
         return WOLFSSL_FAILURE;  /* session timed out */
 #else /* defined(OPENSSL_EXTRA) && defined(WOLFSSL_ERROR_CODE_OPENSSL) */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -32701,7 +32701,7 @@ int wolfSSL_SSL_CTX_set_tmp_ecdh(WOLFSSL_CTX *ctx, WOLFSSL_EC_KEY *ecdh)
     return WOLFSSL_SUCCESS;
 }
 #endif
-
+#ifndef NO_SESSION_CACHE
 int wolfSSL_SSL_CTX_remove_session(WOLFSSL_CTX *ctx, WOLFSSL_SESSION *s)
 {
 #if defined(HAVE_EXT_CACHE) || defined(HAVE_EX_DATA)
@@ -32775,7 +32775,7 @@ int wolfSSL_SSL_CTX_remove_session(WOLFSSL_CTX *ctx, WOLFSSL_SESSION *s)
 
     return 0;
 }
-
+#endif /* !NO_SESSION_CACHE */
 #ifndef NO_BIO
 BIO *wolfSSL_SSL_get_rbio(const WOLFSSL *s)
 {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -15163,6 +15163,10 @@ int wolfSSL_SetSession(WOLFSSL* ssl, WOLFSSL_SESSION* session)
     }
 
     if (ret == WOLFSSL_SUCCESS) {
+        if (ssl->session == session) {
+            WOLFSSL_MSG("ssl->session and session same");
+        }
+        else
 #ifdef HAVE_STUNNEL
         /* stunnel depends on the ex_data not being duplicated. Copy OpenSSL
          * behaviour for now. */
@@ -15184,9 +15188,10 @@ int wolfSSL_SetSession(WOLFSSL* ssl, WOLFSSL_SESSION* session)
     }
 
     /* Let's copy over the altSessionID for local cache purposes */
-    if (ret == WOLFSSL_SUCCESS && session->haveAltSessionID) {
+    if (ret == WOLFSSL_SUCCESS && session->haveAltSessionID &&
+            ssl->session != session) {
         ssl->session->haveAltSessionID = 1;
-        XMEMMOVE(ssl->session->altSessionID, session->altSessionID, ID_LEN);
+        XMEMCPY(ssl->session->altSessionID, session->altSessionID, ID_LEN);
     }
 
     if (sessRow != NULL) {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -15576,7 +15576,16 @@ int AddSessionToCache(WOLFSSL_CTX* ctx, WOLFSSL_SESSION* addSession,
 #endif
 
 #ifdef HAVE_EX_DATA
-    if (cacheSession->ownExData) {
+    if (overwrite) {
+        /* Figure out who owns the ex_data */
+        if (cacheSession->ownExData) {
+            /* Prioritize cacheSession copy */
+            XMEMCPY(&addSession->ex_data, &cacheSession->ex_data,
+                    sizeof(WOLFSSL_CRYPTO_EX_DATA));
+        }
+        /* else will be copied in wolfSSL_DupSession call */
+    }
+    else if (cacheSession->ownExData) {
         crypto_ex_cb_free_data(cacheSession, crypto_ex_cb_ctx_session,
                                &cacheSession->ex_data);
         cacheSession->ownExData = 0;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -14626,23 +14626,8 @@ WOLFSSL_SESSION* wolfSSL_GetSessionClient(WOLFSSL* ssl, const byte* id, int len)
 
     len = min(SERVER_ID_LEN, (word32)len);
 
-#ifdef HAVE_EXT_CACHE
-    if (ssl->ctx->get_sess_cb != NULL) {
-        int copy = 0;
-        WOLFSSL_MSG("Calling external session cache");
-        ret = ssl->ctx->get_sess_cb(ssl, (byte*)id, len, &copy);
-        if (ret != NULL) {
-            WOLFSSL_MSG("Session found in external cache");
-            return ret;
-        }
-        WOLFSSL_MSG("Session not found in external cache");
-    }
-
-    if (ssl->ctx->internalCacheLookupOff) {
-        WOLFSSL_MSG("Internal cache turned off");
-        return NULL;
-    }
-#endif
+    /* Do not access ssl->ctx->get_sess_cb from here. It is using a different
+     * set of ID's */
 
     row = HashObject(id, len, &error) % CLIENT_SESSION_ROWS;
     if (error != 0) {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -15155,11 +15155,6 @@ int wolfSSL_SetSession(WOLFSSL* ssl, WOLFSSL_SESSION* session)
         }
     }
 
-    if (ret == WOLFSSL_SUCCESS && SslSessionCacheOff(ssl, session)) {
-        WOLFSSL_MSG("Session cache off");
-        ret = WOLFSSL_FAILURE;
-    }
-
     if (ret == WOLFSSL_SUCCESS && ssl->options.side != WOLFSSL_NEITHER_END &&
             (byte)ssl->options.side != session->side) {
         WOLFSSL_MSG("Setting session for wrong role");

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -14963,7 +14963,7 @@ int wolfSSL_GetSessionFromCache(WOLFSSL* ssl, WOLFSSL_SESSION* output)
 
     /* init to avoid clang static analyzer false positive */
     row = 0;
-    error = TlsSessionCacheGetAndRdLock(id, &sess, &row, ssl->options.side);
+    error = TlsSessionCacheGetAndRdLock(id, &sess, &row, (byte)ssl->options.side);
     error = (error == 0) ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
     if (error != WOLFSSL_SUCCESS || sess == NULL) {
         WOLFSSL_MSG("Get Session from cache failed");
@@ -15548,8 +15548,8 @@ int AddSessionToCache(WOLFSSL_CTX* ctx, WOLFSSL_SESSION* addSession,
 #ifdef SESSION_CACHE_DYNAMIC_MEM
     cacheSession = sessRow->Sessions[idx];
     if (cacheSession == NULL) {
-        cacheSession = (WOLFSSL_SESSION*) XMALLOC(sizeof(WOLFSSL_SESSION), sessRow->heap,
-                                                  DYNAMIC_TYPE_SESSION);
+        cacheSession = (WOLFSSL_SESSION*) XMALLOC(sizeof(WOLFSSL_SESSION),
+                                         sessRow->heap, DYNAMIC_TYPE_SESSION);
         if (cacheSession == NULL) {
             return MEMORY_E;
         }
@@ -21665,11 +21665,13 @@ int wolfSSL_CTX_add_session(WOLFSSL_CTX* ctx, WOLFSSL_SESSION* session)
     /* Session cache is global */
     (void)ctx;
 
-    id = session->sessionID;
-    idSz = session->sessionIDSz;
     if (session->haveAltSessionID) {
         id = session->altSessionID;
         idSz = ID_LEN;
+    }
+    else {
+        id = session->sessionID;
+        idSz = session->sessionIDSz;
     }
 
     error = AddSessionToCache(ctx, session, id, idSz,

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -14495,7 +14495,7 @@ void wolfSSL_CTX_flush_sessions(WOLFSSL_CTX* ctx, long tm)
     XMEMSET(id, 0, ID_LEN);
     WOLFSSL_ENTER("wolfSSL_flush_sessions");
     for (i = 0; i < SESSION_ROWS; ++i) {
-        if (SESSION_ROW_WR_LOCK(i) != 0) {
+        if (SESSION_ROW_WR_LOCK(&SessionCache[i]) != 0) {
             WOLFSSL_MSG("Session cache mutex lock failed");
             return;
         }
@@ -14520,7 +14520,7 @@ void wolfSSL_CTX_flush_sessions(WOLFSSL_CTX* ctx, long tm)
 #endif
             }
         }
-        SESSION_ROW_UNLOCK(i);
+        SESSION_ROW_UNLOCK(&SessionCache[i]);
     }
 }
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -10025,10 +10025,6 @@ static int DoTls13NewSessionTicket(WOLFSSL* ssl, const byte* input,
 #endif
     const byte* nonce;
     byte        nonceLength;
-#ifndef NO_SESSION_CACHE
-    const byte* id;
-    byte idSz;
-#endif
 
     WOLFSSL_START(WC_FUNC_NEW_SESSION_TICKET_DO);
     WOLFSSL_ENTER("DoTls13NewSessionTicket");
@@ -10125,17 +10121,7 @@ static int DoTls13NewSessionTicket(WOLFSSL* ssl, const byte* input,
     *inOutIdx += length;
 
     #ifndef NO_SESSION_CACHE
-    AddSession(ssl);
-    if (!ssl->options.internalCacheOff) {
-        id = ssl->session->sessionID;
-        idSz = ssl->session->sessionIDSz;
-        if (ssl->session->haveAltSessionID) {
-            id = ssl->session->altSessionID;
-            idSz = ID_LEN;
-        }
-        AddSessionToCache(ssl->ctx, ssl->session, id, idSz, NULL,
-            ssl->session->side, 1, &ssl->clientSession, 0);
-    }
+    	AddSession(ssl);
     #endif
 
     /* Always encrypted. */
@@ -10392,7 +10378,7 @@ static int SendTls13NewSessionTicket(WOLFSSL* ssl)
     /* Only add to cache when support built in and when the ticket contains
      * an ID. Otherwise we have no way to actually retrieve the ticket from the
      * cache. */
-#if !defined(NO_SESSION_CACHE)
+#if !defined(NO_SESSION_CACHE) && defined(WOLFSSL_TICKET_HAVE_ID)
     AddSession(ssl);
 #endif
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -10134,6 +10134,7 @@ static int DoTls13NewSessionTicket(WOLFSSL* ssl, const byte* input,
     #endif
     *inOutIdx += length;
 
+    SetupSession(ssl);
     #ifndef NO_SESSION_CACHE
         AddSession(ssl);
     #endif
@@ -10388,6 +10389,7 @@ static int SendTls13NewSessionTicket(WOLFSSL* ssl)
 
     ssl->options.haveSessionId = 1;
 
+    SetupSession(ssl);
     /* Only add to cache when support built in and when the ticket contains
      * an ID. Otherwise we have no way to actually retrieve the ticket from the
      * cache. */

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -10363,7 +10363,10 @@ static int SendTls13NewSessionTicket(WOLFSSL* ssl)
     idx += LENGTH_SZ;
     /* ticket */
     if ((ssl->options.mask & WOLFSSL_OP_NO_TICKET) != 0) {
-        XMEMCPY(output + idx, ssl->session->altSessionID, ID_LEN);
+        if (ssl->session->haveAltSessionID)
+            XMEMCPY(output + idx, ssl->session->altSessionID, ID_LEN);
+        else
+            XMEMCPY(output + idx, ssl->session->sessionID, ID_LEN);
         idx += ID_LEN;
     }
     else {

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -10135,7 +10135,7 @@ static int DoTls13NewSessionTicket(WOLFSSL* ssl, const byte* input,
     *inOutIdx += length;
 
     #ifndef NO_SESSION_CACHE
-    	AddSession(ssl);
+        AddSession(ssl);
     #endif
 
     /* Always encrypted. */

--- a/tests/api.c
+++ b/tests/api.c
@@ -7842,6 +7842,9 @@ static int test_wolfSSL_CTX_add_session_ext(void)
             client_cb.method  = params[i].client_meth;
             server_cb.method  = params[i].server_meth;
 
+            if (dtls)
+                client_cb.doUdp = server_cb.doUdp = 1;
+
             /* Setup internal and external cache */
             switch (j) {
                 case 0:
@@ -7923,19 +7926,11 @@ static int test_wolfSSL_CTX_add_session_ext(void)
             switch (j) {
                 case 0:
                     if (tls13) {
-                        /* (D)TLSv1.3 case */
+                        /* (D)TLSv1.3 stateful case */
                         /* cache hit */
                         /* DTLS accesses cache once for stateless parsing and
                          * once for stateful parsing */
-#ifdef WOLFSSL_DTLS_NO_HVR_ON_RESUME
                         AssertIntEQ(twcase_get_session_called, !dtls ? 1 : 2);
-#else
-#ifndef WOLFSSL_ASYNC_CRYPT
-                        AssertIntEQ(twcase_get_session_called, 1);
-#else
-                        AssertIntEQ(twcase_get_session_called, !dtls ? 1 : 2);
-#endif
-#endif
 
                         /* (D)TLSv1.3 creates a new ticket,
                          * updates both internal and external cache */
@@ -7990,8 +7985,6 @@ static int test_wolfSSL_CTX_add_session_ext(void)
                     if (tls13) {
                         /* (D)TLSv1.3 case */
                         /* cache hit */
-                        /* DTLS accesses cache once for stateless parsing and
-                         * once for stateful parsing */
                         AssertIntEQ(twcase_get_session_called, 1);
                         /* (D)TLSv1.3 creates a new ticket,
                          * updates both internal and external cache */

--- a/tests/api.c
+++ b/tests/api.c
@@ -7907,7 +7907,11 @@ static int test_wolfSSL_CTX_add_session_ext(void)
                         /* cache hit */
                         /* DTLS accesses cache once for stateless parsing and
                          * once for stateful parsing */
+#ifdef WOLFSSL_DTLS_NO_HVR_ON_RESUME
                         AssertIntEQ(twcase_get_session_called, !dtls ? 1 : 2);
+#else
+                        AssertIntEQ(twcase_get_session_called, 1);
+#endif
 
                         /* (D)TLSv1.3 creates a new ticket,
                          * updates both internal and external cache */
@@ -7919,7 +7923,11 @@ static int test_wolfSSL_CTX_add_session_ext(void)
                         /* non (D)TLSv1.3 case, no update */
                         /* DTLS accesses cache once for stateless parsing and
                          * once for stateful parsing */
+#ifdef WOLFSSL_DTLS_NO_HVR_ON_RESUME
                         AssertIntEQ(twcase_get_session_called, !dtls ? 1 : 2);
+#else
+                        AssertIntEQ(twcase_get_session_called, 1);
+#endif
                         AssertIntEQ(twcase_new_session_called, 0);
                         /* Called on session added in
                          * twcase_server_sess_ctx_pre_shutdown */
@@ -7943,7 +7951,11 @@ static int test_wolfSSL_CTX_add_session_ext(void)
                         /* cache hit */
                         /* DTLS accesses cache once for stateless parsing and
                          * once for stateful parsing */
+#ifdef WOLFSSL_DTLS_NO_HVR_ON_RESUME
                         AssertIntEQ(twcase_get_session_called, !dtls ? 1 : 2);
+#else
+                        AssertIntEQ(twcase_get_session_called, 1);
+#endif
                         AssertIntEQ(twcase_new_session_called, 0);
                         /* Called on session added in
                          * twcase_server_sess_ctx_pre_shutdown */
@@ -7969,7 +7981,11 @@ static int test_wolfSSL_CTX_add_session_ext(void)
                         /* cache hit */
                         /* DTLS accesses cache once for stateless parsing and
                          * once for stateful parsing */
+#ifdef WOLFSSL_DTLS_NO_HVR_ON_RESUME
                         AssertIntEQ(twcase_get_session_called, !dtls ? 1 : 2);
+#else
+                        AssertIntEQ(twcase_get_session_called, 1);
+#endif
                         AssertIntEQ(twcase_new_session_called, 0);
                         /* Called on session added in
                          * twcase_server_sess_ctx_pre_shutdown */

--- a/tests/api.c
+++ b/tests/api.c
@@ -7912,7 +7912,11 @@ static int test_wolfSSL_CTX_add_session_ext(void)
 #ifdef WOLFSSL_DTLS_NO_HVR_ON_RESUME
                         AssertIntEQ(twcase_get_session_called, !dtls ? 1 : 2);
 #else
+#ifndef WOLFSSL_ASYNC_CRYPT
                         AssertIntEQ(twcase_get_session_called, 1);
+#else
+                        AssertIntEQ(twcase_get_session_called, !dtls ? 1 : 2);
+#endif
 #endif
 
                         /* (D)TLSv1.3 creates a new ticket,

--- a/tests/api.c
+++ b/tests/api.c
@@ -7533,12 +7533,12 @@ static void twcase_remove_sessionCb(WOLFSSL_CTX *ctx, WOLFSSL_SESSION *sess)
     if (sess == NULL)
         return;
     /*
-    This example uses a hash table.
-    Steps you should take for a non-demo code:
-    acquire a lock for the file named according to the session id
-    remove the file
-    release the lock
-    */
+     * This example uses a hash table.
+     * Steps you should take for a non-demo code:
+     * - acquire a lock for the file named according to the session id
+     * - remove the file
+     * - release the lock
+     */
     if (wc_LockMutex(&server_sessionCache.htLock) != 0) {
         return;
     }
@@ -7568,17 +7568,19 @@ static WOLFSSL_SESSION *twcase_get_sessionCb(WOLFSSL *ssl,
     int i;
 
     /*
-    This example uses a hash table.
-    Steps you should take for a non-demo code:
-    acquire a lock for the file named according to the session id in the 2nd arg
-    read and decrypt contents of file and create a new SSL_SESSION
-    object release the lock
-    set the integer referenced by the fourth parameter to 0
-    return the new session object
-    */
+     * This example uses a hash table.
+     * Steps you should take for a non-demo code:
+     * - acquire a lock for the file named according to the session id in the
+     *   2nd arg
+     * - read and decrypt contents of file and create a new SSL_SESSION
+     * - object release the lock
+     * - return the new session object
+     */
     fprintf(stderr, "\t\ttwcase_get_session_called %d\n",
             ++twcase_get_session_called);
-    *ref = 0;
+    /* This callback want to retain a copy of the object. If we want wolfSSL to
+     * be responsible for the pointer then set to 0. */
+    *ref = 1;
 
     for(i = 0; i < SESSION_CACHE_SIZE; i++) {
         if(server_sessionCache.entries[i].key != NULL &&

--- a/tests/api.c
+++ b/tests/api.c
@@ -7805,6 +7805,8 @@ static int test_wolfSSL_CTX_add_session_ext(void)
             callback_functions client_cb;
             callback_functions server_cb;
 
+            (void)dtls;
+
             /* Test five cache configurations */
             twcase_client_first_session_ptr = NULL;
             twcase_server_first_session_ptr = NULL;

--- a/tests/api.c
+++ b/tests/api.c
@@ -7910,9 +7910,7 @@ static int test_wolfSSL_CTX_add_session_ext(void)
                         /* (D)TLSv1.3 creates a new ticket,
                          * updates both internal and external cache */
                         AssertIntEQ(twcase_new_session_called, 1);
-                        /* Called on session added in
-                         * twcase_server_sess_ctx_pre_shutdown and by wolfSSL */
-                        AssertIntEQ(twcase_remove_session_called, 2);
+                        AssertIntEQ(twcase_remove_session_called, 1);
 
                     }
                     else {
@@ -7936,7 +7934,7 @@ static int test_wolfSSL_CTX_add_session_ext(void)
                         AssertIntEQ(twcase_new_session_called, 1);
                         /* Called on session added in
                          * twcase_server_sess_ctx_pre_shutdown and by wolfSSL */
-                        AssertIntEQ(twcase_remove_session_called, 2);
+                        AssertIntEQ(twcase_remove_session_called, 1);
                     }
                     else {
                         /* non (D)TLSv1.3 case */
@@ -7962,7 +7960,7 @@ static int test_wolfSSL_CTX_add_session_ext(void)
                         AssertIntEQ(twcase_new_session_called, 1);
                         /* Called on session added in
                          * twcase_server_sess_ctx_pre_shutdown and by wolfSSL */
-                        AssertIntEQ(twcase_remove_session_called, 2);
+                        AssertIntEQ(twcase_remove_session_called, 1);
                     }
                     else {
                         /* non (D)TLSv1.3 case */
@@ -45438,14 +45436,10 @@ static int test_wolfSSL_CTX_sess_set_remove_cb(void)
     /* Both should have been allocated */
     AssertIntEQ(clientSessRemCountMalloc, 1);
     AssertIntEQ(serverSessRemCountMalloc, 1);
-#if (!defined(WOLFSSL_TLS13) || !defined(HAVE_SESSION_TICKET)) && \
-        defined(NO_SESSION_CACHE_REF)
-    /* Client session should not be added to cache so this should be free'd when
-     * the SSL object was being free'd */
-    AssertIntEQ(clientSessRemCountFree, 1);
-#else
-    /* Client session is in cache due to requiring a persistent reference */
+    /* This should not be called yet. Session wasn't evicted from cache yet. */
     AssertIntEQ(clientSessRemCountFree, 0);
+#if (defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET)) || \
+        !defined(NO_SESSION_CACHE_REF)
     /* Force a cache lookup */
     AssertNotNull(SSL_SESSION_get_ex_data(clientSess, serverSessRemIdx));
     /* Force a cache update */

--- a/tests/api.c
+++ b/tests/api.c
@@ -7568,7 +7568,7 @@ static WOLFSSL_SESSION *twcase_get_sessionCb(WOLFSSL *ssl,
     return the new session object
     */
     fprintf(stderr, "get_session_called %d\n", ++get_session_called);
-    *ref = 1;
+    *ref = 0;
 
     for(i = 0; i < SESSION_CACHE_SIZE; i++) {
         if(server_sessionCache.entries[i].key != NULL &&
@@ -7697,7 +7697,7 @@ static void twcase_client_sess_ctx_pre_shutdown(WOLFSSL* ssl)
     WOLFSSL_SESSION** sess;
     sess = &twcase_client_first_session_ptr;
     if (*sess == NULL) {
-        AssertNotNull(*sess = wolfSSL_get_session(ssl));
+        AssertNotNull(*sess = wolfSSL_get1_session(ssl));
     }
     else {
         /* If we have a session retrieved then remaining connections should be
@@ -7725,6 +7725,8 @@ static void twcase_client_sess_ctx_pre_shutdown(WOLFSSL* ssl)
 static void twcase_client_set_sess_ssl_ready(WOLFSSL* ssl)
 {
     /* Set the session to reuse for the client */
+    AssertNotNull(ssl);
+    AssertNotNull(twcase_client_first_session_ptr);
     AssertIntEQ(wolfSSL_set_session(ssl,twcase_client_first_session_ptr),
                 WOLFSSL_SUCCESS);
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -7591,6 +7591,24 @@ static WOLFSSL_SESSION *twcase_get_sessionCb(WOLFSSL *ssl,
     }
     return NULL;
 }
+static void twcase_get_sessionCb_cleanup(void)
+{
+    int i;
+    int cnt = 0;
+
+    /* If  twcase_get_sessionCb sets *ref = 1, the application is responsible
+     * for freeing sessions */
+
+    for(i = 0; i < SESSION_CACHE_SIZE; i++) {
+        if(server_sessionCache.entries[i].value != NULL) {
+            wolfSSL_SESSION_free(server_sessionCache.entries[i].value);
+            cnt++;
+        }
+    }
+
+    fprintf(stderr, "\t\ttwcase_get_sessionCb_cleanup freed %d sessions\n",
+            cnt);
+}
 
 static void twcase_cache_intOff_extOff(WOLFSSL_CTX* ctx)
 {
@@ -8010,6 +8028,7 @@ static int test_wolfSSL_CTX_add_session_ext(void)
             wolfSSL_SESSION_free(twcase_server_first_session_ptr);
             wolfSSL_CTX_free(twcase_server_current_ctx_ptr);
         }
+        twcase_get_sessionCb_cleanup();
         XMEMSET(&server_sessionCache.entries, 0,
                 sizeof(server_sessionCache.entries));
         fprintf(stderr, "\tEnd %s\n", params[i].tls_version);

--- a/tests/api.c
+++ b/tests/api.c
@@ -342,7 +342,7 @@
     defined(HAVE_SESSION_TICKET) || (defined(OPENSSL_EXTRA) && \
     defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_CERT_GEN)) || \
     defined(WOLFSSL_TEST_STATIC_BUILD) || defined(WOLFSSL_DTLS) || \
-    defined(HAVE_ECH)
+    defined(HAVE_ECH) || defined(HAVE_EX_DATA)
     /* for testing SSL_get_peer_cert_chain, or SESSION_TICKET_HINT_DEFAULT,
      * for setting authKeyIdSrc in WOLFSSL_X509, or testing DTLS sequence
      * number tracking */

--- a/tests/api.c
+++ b/tests/api.c
@@ -7484,8 +7484,8 @@ static hashTable server_sessionCache;
 
 static int twcase_new_sessionCb(WOLFSSL *ssl, WOLFSSL_SESSION *sess)
 {
-    (void)ssl;
     int i;
+    (void)ssl;
     /*
      * This example uses a hash table.
      * Steps you should take for a non-demo code:
@@ -7505,8 +7505,8 @@ static int twcase_new_sessionCb(WOLFSSL *ssl, WOLFSSL_SESSION *sess)
     if (wc_LockMutex(&server_sessionCache.htLock) != 0) {
         return 0;
     }
-    for(i = 0; i < SESSION_CACHE_SIZE; i++) {
-        if(server_sessionCache.entries[i].value == NULL) {
+    for (i = 0; i < SESSION_CACHE_SIZE; i++) {
+        if (server_sessionCache.entries[i].value == NULL) {
             if (sess->haveAltSessionID == 1)
                 server_sessionCache.entries[i].key = sess->altSessionID;
             else
@@ -7526,9 +7526,9 @@ static int twcase_new_sessionCb(WOLFSSL *ssl, WOLFSSL_SESSION *sess)
 
 static void twcase_remove_sessionCb(WOLFSSL_CTX *ctx, WOLFSSL_SESSION *sess)
 {
+    int i;
     (void)ctx;
     (void)sess;
-    int i;
 
     if (sess == NULL)
         return;
@@ -7542,8 +7542,8 @@ static void twcase_remove_sessionCb(WOLFSSL_CTX *ctx, WOLFSSL_SESSION *sess)
     if (wc_LockMutex(&server_sessionCache.htLock) != 0) {
         return;
     }
-    for(i = 0; i < SESSION_CACHE_SIZE; i++) {
-        if(server_sessionCache.entries[i].key != NULL &&
+    for (i = 0; i < SESSION_CACHE_SIZE; i++) {
+        if (server_sessionCache.entries[i].key != NULL &&
            XMEMCMP(server_sessionCache.entries[i].key,
                    sess->sessionID, SSL_MAX_SSL_SESSION_ID_LENGTH) == 0) {
             wolfSSL_SESSION_free(server_sessionCache.entries[i].value);
@@ -7562,10 +7562,10 @@ static void twcase_remove_sessionCb(WOLFSSL_CTX *ctx, WOLFSSL_SESSION *sess)
 static WOLFSSL_SESSION *twcase_get_sessionCb(WOLFSSL *ssl,
                                   const unsigned char *id, int len, int *ref)
 {
+    int i;
     (void)ssl;
     (void)id;
     (void)len;
-    int i;
 
     /*
      * This example uses a hash table.
@@ -7582,8 +7582,8 @@ static WOLFSSL_SESSION *twcase_get_sessionCb(WOLFSSL *ssl,
      * be responsible for the pointer then set to 0. */
     *ref = 1;
 
-    for(i = 0; i < SESSION_CACHE_SIZE; i++) {
-        if(server_sessionCache.entries[i].key != NULL &&
+    for (i = 0; i < SESSION_CACHE_SIZE; i++) {
+        if (server_sessionCache.entries[i].key != NULL &&
            XMEMCMP(server_sessionCache.entries[i].key, id,
                    SSL_MAX_SSL_SESSION_ID_LENGTH) == 0) {
            return server_sessionCache.entries[i].value;
@@ -7599,8 +7599,8 @@ static void twcase_get_sessionCb_cleanup(void)
     /* If  twcase_get_sessionCb sets *ref = 1, the application is responsible
      * for freeing sessions */
 
-    for(i = 0; i < SESSION_CACHE_SIZE; i++) {
-        if(server_sessionCache.entries[i].value != NULL) {
+    for (i = 0; i < SESSION_CACHE_SIZE; i++) {
+        if (server_sessionCache.entries[i].value != NULL) {
             wolfSSL_SESSION_free(server_sessionCache.entries[i].value);
             cnt++;
         }

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -1157,6 +1157,8 @@ static byte* PKCS12_ConcatonateContent(WC_PKCS12* pkcs12,byte* mergedData,
     byte* oldContent;
     word32 oldContentSz;
 
+    (void)pkcs12;
+
     if (mergedData == NULL || in == NULL)
         return NULL;
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4171,6 +4171,7 @@ WOLFSSL_LOCAL int wolfSSL_RAND_Init(void);
 WOLFSSL_LOCAL WOLFSSL_SESSION* wolfSSL_NewSession(void* heap);
 WOLFSSL_LOCAL WOLFSSL_SESSION* wolfSSL_GetSession(
     WOLFSSL* ssl, byte* masterSecret, byte restoreSessionCerts);
+WOLFSSL_LOCAL void SetupSession(WOLFSSL* ssl);
 WOLFSSL_LOCAL void AddSession(WOLFSSL* ssl);
 /* use wolfSSL_API visibility to be able to test in tests/api.c */
 WOLFSSL_API int AddSessionToCache(WOLFSSL_CTX* ctx,

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4156,7 +4156,8 @@ WOLFSSL_LOCAL void AddSession(WOLFSSL* ssl);
 /* use wolfSSL_API visibility to be able to test in tests/api.c */
 WOLFSSL_API int AddSessionToCache(WOLFSSL_CTX* ssl,
     WOLFSSL_SESSION* addSession, const byte* id, byte idSz, int* sessionIndex,
-    int side, word16 useTicket, ClientSession** clientCacheEntry);
+    int side, word16 useTicket, ClientSession** clientCacheEntry,
+    int updateIntCacheOnly);
 #ifndef NO_CLIENT_CACHE
 WOLFSSL_LOCAL ClientSession* AddSessionToClientCache(int side, int row, int idx,
                       byte* serverID, word16 idLen, const byte* sessionID,

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3212,6 +3212,16 @@ enum PskDecryptReturn {
     PSK_DECRYPT_FAIL,
 };
 
+#ifdef HAVE_SESSION_TICKET
+typedef struct psk_sess_free_cb_ctx {
+    word32 row;
+    int extCache;
+    int freeSess;
+} psk_sess_free_cb_ctx;
+typedef void (psk_sess_free_cb)(const WOLFSSL* ssl, const WOLFSSL_SESSION* sess,
+        psk_sess_free_cb_ctx* freeCtx);
+#endif
+
 /* The PreSharedKey extension information - entry in a linked list. */
 typedef struct PreSharedKey {
     word16               identityLen;             /* Length of identity */
@@ -3224,6 +3234,11 @@ typedef struct PreSharedKey {
     byte                 hmac;                    /* HMAC algorithm     */
 #ifdef HAVE_SESSION_TICKET
     InternalTicket*      it;                      /* ptr to ticket      */
+    const WOLFSSL_SESSION* sess; /* ptr to session either from external cache or
+                                  * into SessionCache. Work around so that we
+                                  * don't call into the cache more than once */
+    psk_sess_free_cb* sess_free_cb;               /* callback to free sess */
+    psk_sess_free_cb_ctx sess_free_cb_ctx;        /* info for sess_free_cb */
 #endif
     byte                 resumption:1;            /* Resumption PSK     */
     byte                 chosen:1;                /* Server's choice    */
@@ -4063,6 +4078,8 @@ struct WOLFSSL_SESSION {
     byte               haveAltSessionID:1;
 #ifdef HAVE_EX_DATA
     byte               ownExData:1;
+#endif
+#if defined(HAVE_EXT_CACHE) || defined(HAVE_EX_DATA)
     Rem_Sess_Cb        rem_sess_cb;
 #endif
     void*              heap;
@@ -4154,10 +4171,9 @@ WOLFSSL_LOCAL WOLFSSL_SESSION* wolfSSL_GetSession(
     WOLFSSL* ssl, byte* masterSecret, byte restoreSessionCerts);
 WOLFSSL_LOCAL void AddSession(WOLFSSL* ssl);
 /* use wolfSSL_API visibility to be able to test in tests/api.c */
-WOLFSSL_API int AddSessionToCache(WOLFSSL_CTX* ssl,
+WOLFSSL_API int AddSessionToCache(WOLFSSL_CTX* ctx,
     WOLFSSL_SESSION* addSession, const byte* id, byte idSz, int* sessionIndex,
-    int side, word16 useTicket, ClientSession** clientCacheEntry,
-    int updateIntCacheOnly);
+    int side, word16 useTicket, ClientSession** clientCacheEntry);
 #ifndef NO_CLIENT_CACHE
 WOLFSSL_LOCAL ClientSession* AddSessionToClientCache(int side, int row, int idx,
                       byte* serverID, word16 idLen, const byte* sessionID,
@@ -4166,8 +4182,11 @@ WOLFSSL_LOCAL ClientSession* AddSessionToClientCache(int side, int row, int idx,
 WOLFSSL_LOCAL
 WOLFSSL_SESSION* ClientSessionToSession(const WOLFSSL_SESSION* session);
 WOLFSSL_LOCAL void TlsSessionCacheUnlockRow(word32 row);
-WOLFSSL_LOCAL int TlsSessionCacheGetAndLock(const byte *id,
-    WOLFSSL_SESSION **sess, word32 *lockedRow, byte readOnly);
+WOLFSSL_LOCAL int TlsSessionCacheGetAndRdLock(const byte *id,
+    const WOLFSSL_SESSION **sess, word32 *lockedRow, byte side);
+WOLFSSL_LOCAL int TlsSessionCacheGetAndWrLock(const byte *id,
+    WOLFSSL_SESSION **sess, word32 *lockedRow, byte side);
+WOLFSSL_LOCAL void EvictSessionFromCache(WOLFSSL_SESSION* session);
 /* WOLFSSL_API to test it in tests/api.c */
 WOLFSSL_API int wolfSSL_GetSessionFromCache(WOLFSSL* ssl, WOLFSSL_SESSION* output);
 WOLFSSL_LOCAL int wolfSSL_SetSession(WOLFSSL* ssl, WOLFSSL_SESSION* session);
@@ -5768,13 +5787,15 @@ WOLFSSL_LOCAL int SendTicket(WOLFSSL* ssl);
 WOLFSSL_LOCAL int DoDecryptTicket(const WOLFSSL* ssl, const byte* input,
         word32 len, InternalTicket **it);
 /* Return 0 when check successful. <0 on failure. */
-WOLFSSL_LOCAL void DoClientTicketFinalize(WOLFSSL* ssl, InternalTicket* it);
+WOLFSSL_LOCAL void DoClientTicketFinalize(WOLFSSL* ssl, InternalTicket* it,
+                                          const WOLFSSL_SESSION* sess);
 
 #ifdef WOLFSSL_TLS13
 WOLFSSL_LOCAL int DoClientTicketCheck(const WOLFSSL* ssl,
         const PreSharedKey* psk, sword64 timeout, const byte* suite);
 WOLFSSL_LOCAL void CleanupClientTickets(PreSharedKey* psk);
-WOLFSSL_LOCAL int DoClientTicket_ex(const WOLFSSL* ssl, PreSharedKey* psk);
+WOLFSSL_LOCAL int DoClientTicket_ex(const WOLFSSL* ssl, PreSharedKey* psk,
+                                    int retainSess);
 #endif
 
 WOLFSSL_LOCAL int DoClientTicket(WOLFSSL* ssl, const byte* input, word32 len);
@@ -6293,8 +6314,9 @@ typedef struct CRYPTO_EX_cb_ctx {
     WOLFSSL_CRYPTO_EX_dup* dup_func;
     struct CRYPTO_EX_cb_ctx* next;
 } CRYPTO_EX_cb_ctx;
-extern CRYPTO_EX_cb_ctx* crypto_ex_cb_ctx_session;
-WOLFSSL_LOCAL void crypto_ex_cb_free(CRYPTO_EX_cb_ctx* cb_ctx);
+/* use wolfSSL_API visibility to be able to clear in tests/api.c */
+WOLFSSL_API extern CRYPTO_EX_cb_ctx* crypto_ex_cb_ctx_session;
+WOLFSSL_API void crypto_ex_cb_free(CRYPTO_EX_cb_ctx* cb_ctx);
 WOLFSSL_LOCAL void crypto_ex_cb_setup_new_data(void *new_obj,
         CRYPTO_EX_cb_ctx* cb_ctx, WOLFSSL_CRYPTO_EX_DATA* ex_data);
 WOLFSSL_LOCAL void crypto_ex_cb_free_data(void *obj, CRYPTO_EX_cb_ctx* cb_ctx,

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4157,6 +4157,7 @@ struct WOLFSSL_SESSION {
 #ifdef HAVE_EX_DATA
     WOLFSSL_CRYPTO_EX_DATA ex_data;
 #endif
+    byte               isSetup:1;
 };
 
 #if defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET) &&                  \

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3215,8 +3215,10 @@ enum PskDecryptReturn {
 #ifdef HAVE_SESSION_TICKET
 typedef struct psk_sess_free_cb_ctx {
     word32 row;
+#ifdef HAVE_EXT_CACHE
     int extCache;
     int freeSess;
+#endif
 } psk_sess_free_cb_ctx;
 typedef void (psk_sess_free_cb)(const WOLFSSL* ssl, const WOLFSSL_SESSION* sess,
         psk_sess_free_cb_ctx* freeCtx);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1235,6 +1235,7 @@ WOLFSSL_ABI WOLFSSL_API int  wolfSSL_set_session(WOLFSSL* ssl, WOLFSSL_SESSION* 
 WOLFSSL_API long wolfSSL_SSL_SESSION_set_timeout(WOLFSSL_SESSION* ses, long t);
 WOLFSSL_ABI WOLFSSL_API WOLFSSL_SESSION* wolfSSL_get_session(WOLFSSL* ssl);
 WOLFSSL_ABI WOLFSSL_API void wolfSSL_flush_sessions(WOLFSSL_CTX* ctx, long tm);
+WOLFSSL_API void wolfSSL_CTX_flush_sessions(WOLFSSL_CTX* ctx, long tm);
 WOLFSSL_API int  wolfSSL_SetServerID(WOLFSSL* ssl, const unsigned char* id, int len, int newSession);
 
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_ASIO) || defined(WOLFSSL_HAPROXY) \
@@ -5166,6 +5167,7 @@ WOLFSSL_API int wolfSSL_dtls_cid_get_tx(WOLFSSL* ssl, unsigned char* buffer,
 #define TLS1_3_VERSION                   0x0304
 #define DTLS1_VERSION                    0xFEFF
 #define DTLS1_2_VERSION                  0xFEFD
+#define DTLS1_3_VERSION                  0xFEFC
 
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -4882,9 +4882,6 @@ WOLFSSL_API long wolfSSL_SSL_CTX_get_timeout(const WOLFSSL_CTX *ctx);
 WOLFSSL_API long wolfSSL_get_timeout(WOLFSSL* ssl);
 WOLFSSL_API int wolfSSL_SSL_CTX_set_tmp_ecdh(WOLFSSL_CTX *ctx,
     WOLFSSL_EC_KEY *ecdh);
-WOLFSSL_API int wolfSSL_SSL_CTX_remove_session(WOLFSSL_CTX* ctx,
-    WOLFSSL_SESSION *c);
-
 WOLFSSL_API WOLFSSL_BIO *wolfSSL_SSL_get_rbio(const WOLFSSL *s);
 WOLFSSL_API WOLFSSL_BIO *wolfSSL_SSL_get_wbio(const WOLFSSL *s);
 WOLFSSL_API int wolfSSL_SSL_do_handshake(WOLFSSL *s);
@@ -4900,6 +4897,8 @@ WOLFSSL_API int wolfSSL_SSL_in_init(WOLFSSL* ssl);
 WOLFSSL_API int wolfSSL_SSL_in_connect_init(WOLFSSL* ssl);
 
 #ifndef NO_SESSION_CACHE
+    WOLFSSL_API int wolfSSL_SSL_CTX_remove_session(WOLFSSL_CTX* ctx,
+        WOLFSSL_SESSION *c);
     WOLFSSL_API WOLFSSL_SESSION *wolfSSL_SSL_get0_session(const WOLFSSL *s);
 #endif
 


### PR DESCRIPTION
# Description

This PR adds support for TLSv1.3 stateful session tickets when using SSL_OP_NO_TICKET and corrects a couple of issues:

1) The callback set using `wolfSSL_CTX_sess_set_remove_cb` will only be called when a session is being evicted from cache or when the session times out
2) Cache miss
3) SessionCache leak

`AddSessionToCache() `was removing a session from the external cache. 
The internal `SessionCache` would get updated but the external cache wasn't being called again.

Additionally, when overwriting a session, AddSessionToCache() was incrementing the `totalCount` and the `nextIndx` where to place the next session item leading to a `SessionCache` leak


Fixes zd#15434

# Testing

With a new `test_wolfSSL_CTX_add_session_ext` to test the external session cache for TLSv1.1, v1.2, and v1.3 with various cache configurations.

```
./configure --enable-debug --disable-shared -enable-haproxy --enable-quic --enable-sp=yes,asm --enable-intelasm --enable-sp-math CFLAGS="-DENABLE_SESSION_CACHE_ROW_LOCK" && make check

cd $HOME/wolfssl
sed -E --in-place 's/wolfSSL_CTX_no_ticket_TLSv13\(ctx\);$/wolfSSL_CTX_set_options\(ctx, SSL_OP_NO_TICKET\);/' examples/server/server.c || exit $?
./configure --enable-session-ticket --enable-opensslextra && make
./examples/server/server -v 4 -T -i
./examples/client/client -v 4 
AND
openssl s_client -connect localhost:11111 -tls1_3 -cert ./certs/client-cert.pem -key ./certs/client-key.pem -CAfile ./certs/ca-cert.pem  < /dev/null
```
# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
