### PR TITLE
EVP_EncryptUpdate should update outl on empty input

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -42856,6 +42856,32 @@ static int test_wolfSSL_EVP_Cipher_extra(void)
         AssertTrue(ret);
     }
 
+
+    EVP_CIPHER_CTX_free(evp);
+
+    /* Do an extra test to verify correct behavior with empty input. */
+
+    AssertNotNull(evp = EVP_CIPHER_CTX_new());
+    AssertIntNE((ret = EVP_CipherInit(evp, type, NULL, iv, 0)), 0);
+
+    AssertIntEQ(EVP_CIPHER_CTX_nid(evp), NID_aes_128_cbc);
+
+    klen = EVP_CIPHER_CTX_key_length(evp);
+    if (klen > 0 && keylen != klen) {
+        AssertIntNE(EVP_CIPHER_CTX_set_key_length(evp, keylen), 0);
+    }
+    ilen = EVP_CIPHER_CTX_iv_length(evp);
+    if (ilen > 0 && ivlen != ilen) {
+        AssertIntNE(EVP_CIPHER_CTX_set_iv_length(evp, ivlen), 0);
+    }
+
+    AssertIntNE((ret = EVP_CipherInit(evp, NULL, key, iv, 1)), 0);
+
+    /* outl should be set to 0 after passing NULL, 0 for input args. */
+    outl = -1;
+    AssertIntNE((ret = EVP_CipherUpdate(evp, outb, &outl, NULL, 0)), 0);
+    AssertIntEQ(outl, 0);
+
     EVP_CIPHER_CTX_free(evp);
 
     res = TEST_RES_CHECK(1);

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -740,7 +740,8 @@ int wolfSSL_EVP_CipherUpdate(WOLFSSL_EVP_CIPHER_CTX *ctx,
 
     WOLFSSL_ENTER("wolfSSL_EVP_CipherUpdate");
     if (inl == 0 && in == NULL ) {
-        /* Nothing to do in this case. Just return. */
+        /* Nothing to do in this case. Just set outl to zero and return. */
+        if (outl != NULL) { *outl = 0; }
         return WOLFSSL_SUCCESS;
     }
 

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -739,18 +739,22 @@ int wolfSSL_EVP_CipherUpdate(WOLFSSL_EVP_CIPHER_CTX *ctx,
     int fill;
 
     WOLFSSL_ENTER("wolfSSL_EVP_CipherUpdate");
-    if (inl == 0 && in == NULL ) {
-        /* Nothing to do in this case. Just set outl to zero and return. */
-        if (outl != NULL) { *outl = 0; }
-        return WOLFSSL_SUCCESS;
-    }
-
-    if ((ctx == NULL) || (inl < 0) || (outl == NULL) || (in == NULL)) {
+    if ((ctx == NULL) || (outl == NULL)) {
         WOLFSSL_MSG("Bad argument");
         return WOLFSSL_FAILURE;
     }
 
     *outl = 0;
+
+    if ((inl == 0) && (in == NULL)) {
+        /* Nothing to do in this case. Just return. */
+        return WOLFSSL_SUCCESS;
+    }
+
+    if ((inl < 0) || (in == NULL)) {
+        WOLFSSL_MSG("Bad argument");
+        return WOLFSSL_FAILURE;
+    }
 
     switch (ctx->cipherType) {
 #if !defined(NO_AES) && defined(HAVE_AESGCM)


### PR DESCRIPTION
# Description

`wolfSSL_EVP_CipherUpdate()` would return success for empty input, but without setting `outl` to zero. This broke from openssl behavior, and also caused memory overruns.

Fixes zd#15445

# Testing

Updated api test `test_wolfSSL_EVP_Cipher_extra()` to do an extra test for empty input, verify outl is set to 0.

Also tested example from ZD ticket against openssl and wolfssl, and verified behavior matched.

