### PR TITLE
ECCSI: hash function must have output size as curve size

### DIFF
--- a/wolfcrypt/src/eccsi.c
+++ b/wolfcrypt/src/eccsi.c
@@ -1618,6 +1618,7 @@ int wc_ValidateEccsiPvt(EccsiKey* key, const ecc_point* pvt, int* valid)
  * @param  [out]  hashSz    Length of hash data in bytes.
  * @return  0 on success.
  * @return  BAD_FUNC_ARG when key, id, pvt, hash or hashSz is NULL.
+ * @return  BAD_FUNC_ARG when hash size doesn't match curve size.
  * @return  BAD_STATE_E when public key not set.
  * @return  MEMORY_E when dynamic memory allocation fails.
  * @return  Other -ve value when an internal operation fails.
@@ -1626,6 +1627,8 @@ int wc_HashEccsiId(EccsiKey* key, enum wc_HashType hashType, const byte* id,
         word32 idSz, ecc_point* pvt, byte* hash, byte* hashSz)
 {
     int err = 0;
+    int dgstSz = -1;
+    int curveSz = -1;
 
     if ((key == NULL) || (id == NULL) || (pvt == NULL) || (hash == NULL) ||
             (hashSz == NULL)) {
@@ -1634,6 +1637,22 @@ int wc_HashEccsiId(EccsiKey* key, enum wc_HashType hashType, const byte* id,
     if ((err == 0) && (key->ecc.type != ECC_PRIVATEKEY) &&
             (key->ecc.type != ECC_PUBLICKEY)) {
         err = BAD_STATE_E;
+    }
+    /* Ensure digest output size matches curve size (RFC 6507 4.1). */
+    if (err == 0) {
+        dgstSz = wc_HashGetDigestSize(hashType);
+        if (dgstSz < 0) {
+            err = dgstSz;
+        }
+    }
+    if (err == 0) {
+        curveSz = wc_ecc_get_curve_size_from_id(key->ecc.dp->id);
+        if (curveSz < 0) {
+            err = curveSz;
+        }
+    }
+    if ((err == 0) && (dgstSz != curveSz)) {
+        err = BAD_FUNC_ARG;
     }
     /* Load the curve parameters for operations */
     if (err == 0) {

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -33130,6 +33130,12 @@ static int eccsi_sign_verify_test(EccsiKey* priv, EccsiKey* pub, WC_RNG* rng,
     byte msg[] = { 0x00 };
     word32 msgSz = sizeof(msg);
 
+#ifdef WOLFSSL_SHA384
+    ret = wc_HashEccsiId(priv, WC_HASH_TYPE_SHA384, id, idSz, pvt, hashPriv,
+            &hashSz);
+    if (ret != BAD_FUNC_ARG)
+        return -10174;
+#endif
     ret = wc_HashEccsiId(priv, WC_HASH_TYPE_SHA256, id, idSz, pvt, hashPriv,
             &hashSz);
     if (ret != 0)


### PR DESCRIPTION
# Description

ECCSI wan't validating the hash is appropriate for the curve.

Fixes zd#15447

# Testing

POC and added test case.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
