### PR TITLE
Fix when a base image leaves non-root user

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,11 +1,13 @@
 ARG DOCKER_BASE_IMAGE=ubuntu:22.04
 FROM $DOCKER_BASE_IMAGE
 
+USER root
+
 RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y build-essential autoconf libtool git gdb iputils-ping
 
 ARG USER=docker
 ARG UID=1000
 ARG GID=1000
-RUN groupadd -f -g ${GID} docker && useradd -ms /bin/bash ${USER} -u ${UID} -g ${GID}
+RUN groupadd -f -g ${GID} docker && ( getent passwd ${UID} || useradd -ms /bin/bash ${USER} -u ${UID} -g ${GID} )
 
 USER ${UID}:${GID}


### PR DESCRIPTION
# Description

Small change to be able to use containers which have set a user as non-root.