### PR TITLE
Don't allow aesgcm-stream option with kcapi

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2567,6 +2567,11 @@ then
     then
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_AES_DIRECT"
     fi
+
+    if test "$ENABLED_AESGCM_STREAM" = "yes"
+    then
+        AC_MSG_ERROR([--enable-aesgcm-stream is incompatible with --enable-kcapi.])
+    fi
 fi
 
 if test "$ENABLED_KCAPI_RSA" = "yes"


### PR DESCRIPTION
# Description

The build options `--enable-aesgcm-stream` and `--enable-kcapi` were being allowed in `configure.ac`, but they are not compatible and will not build successfully.

This commit adds a check to `configure.ac` that will error out with a helpful error message:

```
configure: error: --enable-aesgcm-stream is incompatible with --enable-kcapi.
```


Fixes #5982.

# Testing

```
./configure --enable-aesgcm-stream --enable-kcapi && make
```


