### PR TITLE
Update AES-GCM stream decryption to allow long IVs (ZenDesk #15423)

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -9287,7 +9287,7 @@ int wc_AesGcmInit(Aes* aes, const byte* key, word32 len, const byte* iv,
 
     /* Check validity of parameters. */
     if ((aes == NULL) || ((len > 0) && (key == NULL)) ||
-            ((ivSz == 0) && (iv != NULL)) || (ivSz > AES_BLOCK_SIZE) ||
+            ((ivSz == 0) && (iv != NULL)) ||
             ((ivSz > 0) && (iv == NULL))) {
         ret = BAD_FUNC_ARG;
     }

--- a/wolfcrypt/src/port/arm/armv8-aes.c
+++ b/wolfcrypt/src/port/arm/armv8-aes.c
@@ -4839,7 +4839,7 @@ int wc_AesGcmInit(Aes* aes, const byte* key, word32 len, const byte* iv,
 
     /* Check validity of parameters. */
     if ((aes == NULL) || ((len > 0) && (key == NULL)) ||
-            ((ivSz == 0) && (iv != NULL)) || (ivSz > AES_BLOCK_SIZE) ||
+            ((ivSz == 0) && (iv != NULL)) ||
             ((ivSz > 0) && (iv == NULL))) {
         ret = BAD_FUNC_ARG;
     }


### PR DESCRIPTION
# Description

**Fixes ZenDesk #15423**

It was discovered that the parameter checking for the AES-GCM encryption/decryption APIs was not consistent.  It was possible to encrypt using a long IV value (i.e. larger than `AES_BLOCK_SIZE`), but not decrypt.  This scenario involved using one-shot encryption with streaming decryption.  Currently, wolfSSL supports use of long IVs in non-FIPS configurations, so the fix was to update the parameter checking in the (streaming) decryption.

# Testing

Created new API test (part of the `wolfssl/tests/unit.test`) to reproduce the error.  Tested fix on:
* x86/x64 system, with wolfSSL configuration provided on ZenDesk #15423
* ARMv8-A system with AES cryptography extensions, with wolfSSL configuration including AES-GCM streaming