### PR TITLE
stop ech from using a recursive function call

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -10519,7 +10519,9 @@ static int TLSX_ECH_Write(WOLFSSL_ECH* ech, byte* writeBuf, word16* offset)
         if (ret != WOLFSSL_SUCCESS)
             return ret;
 
-        return configsLen;
+        *offset += configsLen;
+
+        return 0;
     }
 
 #ifdef WOLFSSL_SMALL_STACK

--- a/wolfcrypt/src/hpke.c
+++ b/wolfcrypt/src/hpke.c
@@ -501,8 +501,10 @@ static int wc_HpkeLabeledExtract(Hpke* hpke, byte* suite_id,
     }
 
     /* call extract */
+    PRIVATE_KEY_UNLOCK();
     ret = wc_HKDF_Extract(hpke->kdf_digest, salt, salt_len, labeled_ikm,
         (word32)(size_t)(labeled_ikm_p - labeled_ikm), out);
+    PRIVATE_KEY_LOCK();
 
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(labeled_ikm, hpke->heap, DYNAMIC_TYPE_TMP_BUFFER);
@@ -559,10 +561,12 @@ static int wc_HpkeLabeledExpand(Hpke* hpke, byte* suite_id, word32 suite_id_len,
         labeled_info_p += infoSz;
 
         /* call expand */
+        PRIVATE_KEY_UNLOCK();
         ret = wc_HKDF_Expand(hpke->kdf_digest,
             prk, prk_len,
             labeled_info, (word32)(size_t)(labeled_info_p - labeled_info),
             out, L);
+        PRIVATE_KEY_LOCK();
     }
 
 #ifdef WOLFSSL_SMALL_STACK


### PR DESCRIPTION

# Description

stop ech from using a recursive function call, update bad return value for when retry_configs is returned, add locks around hkdf functions for private key use

# Testing

Tested with wolfssl-multi-test.sh using fips-140-3-all

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
