### PR TITLE
Check final SHA buffer blocksize

### DIFF
--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -719,6 +719,14 @@ int wc_ShaFinal(wc_Sha* sha, byte* hash)
         return BAD_FUNC_ARG;
     }
 
+#ifndef WC_NO_HARDEN
+    /* We'll add a 0x80 byte at the end,
+    ** so make sure we have appropriate buffer length. */
+    if ((sha->buffLen < 0) || (sha->buffLen > WC_SHA_BLOCK_SIZE - 1)) {
+        return BAD_FUNC_ARG;
+    }
+#endif
+
     local = (byte*)sha->buffer;
 
 #ifdef WOLF_CRYPTO_CB

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -722,7 +722,7 @@ int wc_ShaFinal(wc_Sha* sha, byte* hash)
 #ifndef WC_NO_HARDEN
     /* We'll add a 0x80 byte at the end,
     ** so make sure we have appropriate buffer length. */
-    if ((sha->buffLen < 0) || (sha->buffLen > WC_SHA_BLOCK_SIZE - 1)) {
+    if (sha->buffLen > WC_SHA_BLOCK_SIZE - 1) {
         return BAD_FUNC_ARG;
     }
 #endif

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -1246,8 +1246,7 @@ static int InitSha256(wc_Sha256* sha256)
 #ifndef WC_NO_HARDEN
         /* We'll add a 0x80 byte at the end,
         ** so make sure we have appropriate buffer length. */
-        if ((sha256->buffLen < 0) ||
-            (sha256->buffLen > WC_SHA256_BLOCK_SIZE - 1)) {
+        if (sha256->buffLen > WC_SHA256_BLOCK_SIZE - 1) {
             return BAD_FUNC_ARG;
         }
 #endif

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -1243,6 +1243,15 @@ static int InitSha256(wc_Sha256* sha256)
             return BAD_FUNC_ARG;
         }
 
+#ifndef WC_NO_HARDEN
+        /* We'll add a 0x80 byte at the end,
+        ** so make sure we have appropriate buffer length. */
+        if ((sha256->buffLen < 0) ||
+            (sha256->buffLen > WC_SHA256_BLOCK_SIZE - 1)) {
+            return BAD_FUNC_ARG;
+        }
+#endif
+
         local = (byte*)sha256->buffer;
         local[sha256->buffLen++] = 0x80; /* add 1 */
 

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -969,8 +969,7 @@ static WC_INLINE int Sha512Final(wc_Sha512* sha512)
 #ifndef WC_NO_HARDEN
     /* We'll add a 0x80 byte at the end,
     ** so make sure we have appropriate buffer length. */
-    if ((sha512->buffLen < 0) ||
-        (sha512->buffLen > WC_SHA512_BLOCK_SIZE - 1)) {
+    if (sha512->buffLen > WC_SHA512_BLOCK_SIZE - 1) {
         return BAD_FUNC_ARG;
     }
 #endif

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -966,6 +966,15 @@ static WC_INLINE int Sha512Final(wc_Sha512* sha512)
         return BAD_FUNC_ARG;
     }
 
+#ifndef WC_NO_HARDEN
+    /* We'll add a 0x80 byte at the end,
+    ** so make sure we have appropriate buffer length. */
+    if ((sha512->buffLen < 0) ||
+        (sha512->buffLen > WC_SHA512_BLOCK_SIZE - 1)) {
+        return BAD_FUNC_ARG;
+    }
+#endif
+
     local = (byte*)sha512->buffer;
 
     local[sha512->buffLen++] = 0x80;  /* add 1 */


### PR DESCRIPTION
# Description

During the final block processing of the SHA2 hash, there's an `0x80` byte value added to the buffer and the remaining buffer bytes are set to zero. This PR ensures a reasonable `buffLen` is passed for `wc_ShaFinal()`, `Sha256Final()`, and `Sha512Final()`.

If a valid `buffLen`  value is not found, the function will return with `BAD_FUNC_ARG`.

It should be relatively unlikely that the wrong size would be encountered. This check should have relatively small impact. However, if every possible bit of performance is desired, this feature can be disabled with `#define WC_NO_HARDEN`.

The length was problematic while testing a variety of scenarios related to https://github.com/wolfSSL/wolfssl/issues/5948 and https://github.com/wolfSSL/wolfssl/pull/5997, thus this PR was created for a more graceful handling of a bad buffer length.  

Fixes zd# n/a

# Testing

Confirmed [wolfcrypt/test](https://github.com/wolfSSL/wolfssl/tree/master/wolfcrypt/test) completed with success. (In my case on the ESP32, but expected to pass on other platforms as well)

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
