### PR TITLE
DSA sign: use mp_to_unsigned_bin_len

### DIFF
--- a/wolfcrypt/src/dsa.c
+++ b/wolfcrypt/src/dsa.c
@@ -662,7 +662,6 @@ int wc_DsaSign(const byte* digest, byte* out, DsaKey* key, WC_RNG* rng)
 #endif
     mp_int* qMinus1;
     int     ret = 0, halfSz = 0;
-    byte*   tmp;  /* initial output pointer */
 
     if (digest == NULL || out == NULL || key == NULL || rng == NULL)
         return BAD_FUNC_ARG;
@@ -720,7 +719,6 @@ int wc_DsaSign(const byte* digest, byte* out, DsaKey* key, WC_RNG* rng)
             break;
         }
 
-        tmp = out;
         qMinus1 = kInv;
 
         /* NIST FIPS 186-4: B.2.2
@@ -904,21 +902,11 @@ int wc_DsaSign(const byte* digest, byte* out, DsaKey* key, WC_RNG* rng)
 
         /* write out */
         {
-            int rSz = mp_unsigned_bin_size(r);
-            int sSz = mp_unsigned_bin_size(s);
-
-            while (rSz++ < halfSz) {
-                *out++ = 0x00;  /* pad front with zeros */
-            }
-
-            if (mp_to_unsigned_bin(r, out) != MP_OKAY)
+            if (mp_to_unsigned_bin_len(r, out, halfSz) != MP_OKAY)
                 ret = MP_TO_E;
             else {
-                out = tmp + halfSz;  /* advance to s in output */
-                while (sSz++ < halfSz) {
-                    *out++ = 0x00;  /* pad front with zeros */
-                }
-                ret = mp_to_unsigned_bin(s, out);
+                out += halfSz;  /* advance to s in output */
+                ret = mp_to_unsigned_bin_len(s, out, halfSz);
             }
         }
     } while (0);

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -34,7 +34,6 @@ This library provides single precision (SP) integer math functions.
 
 #if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>
 #else
@@ -16972,7 +16971,7 @@ int sp_to_unsigned_bin_len(const sp_int* a, byte* out, int outSz)
                     /* Stop if the output buffer is filled. */
                     if (j < 0) {
                         if ((i < a->used - 1) || (d > 0)) {
-                            err = BUFFER_E;
+                            err = MP_VAL;
                         }
                         break;
                     }
@@ -16986,7 +16985,7 @@ int sp_to_unsigned_bin_len(const sp_int* a, byte* out, int outSz)
     }
 #else
     if ((err == MP_OKAY) && (outSz < a->used)) {
-        err = BUFFER_E;
+        err = MP_VAL;
     }
     if (err == MP_OKAY) {
         int i;

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -3820,7 +3820,7 @@ int fp_to_unsigned_bin(fp_int *a, unsigned char *b)
 
 int fp_to_unsigned_bin_len(fp_int *a, unsigned char *b, int c)
 {
-#if DIGIT_BIT == 64 || DIGIT_BIT == 32
+#if DIGIT_BIT == 64 || DIGIT_BIT == 32 || DIGIT_BIT == 16
   int i = 0;
   int j = 0;
   int x;
@@ -3833,6 +3833,9 @@ int fp_to_unsigned_bin_len(fp_int *a, unsigned char *b, int c)
   }
   for (; x >= 0; x--) {
      b[x] = 0;
+  }
+  if ((i < a->used - 1) || ((a->dp[i] >> j) != 0)) {
+      return FP_VAL;
   }
 
   return FP_OKAY;
@@ -3861,6 +3864,9 @@ int fp_to_unsigned_bin_len(fp_int *a, unsigned char *b, int c)
 #ifdef WOLFSSL_SMALL_STACK
   XFREE(t, NULL, DYNAMIC_TYPE_BIGINT);
 #endif
+  if (!fp_iszero(t)) {
+      return FP_VAL;
+  }
   return FP_OKAY;
 #endif
 }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -39776,6 +39776,11 @@ static int mp_test_read_to_bin(mp_int* a)
         }
     }
 
+    /* Length too small. */
+    ret = mp_to_unsigned_bin_len(a, out, 1);
+    if (ret != MP_VAL)
+        return -12716;
+
     ret = mp_read_unsigned_bin(a, NULL, 0);
     if (ret != 0)
         return -12714;


### PR DESCRIPTION
# Description

mp_to_unsigned_len checks length and front pads with zeros.

Return MP_VAL when length is too small in all implemenations. Make TFM implementation check length.
Add test case.

Fixes zd#15513

# Testing

POC and added mp_to_unsigned_bin_len test.

# Checklist

 - [x added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
