### PR TITLE
update hpke to not use rng with ecc when hardening is off

### DIFF
--- a/wolfcrypt/src/hpke.c
+++ b/wolfcrypt/src/hpke.c
@@ -736,6 +736,7 @@ static int wc_HpkeEncap(Hpke* hpke, void* ephemeralKey, void* receiverKey,
     byte* sharedSecret)
 {
     int ret;
+    WC_RNG* rng;
     word32 dh_len;
     word16 receiverPubKeySz;
     word16 ephemeralPubKeySz;
@@ -775,12 +776,17 @@ static int wc_HpkeEncap(Hpke* hpke, void* ephemeralKey, void* receiverKey,
         case DHKEM_P256_HKDF_SHA256:
         case DHKEM_P384_HKDF_SHA384:
         case DHKEM_P521_HKDF_SHA512:
-            ((ecc_key*)ephemeralKey)->rng = wc_rng_new(NULL, 0, hpke->heap);
+#ifdef ECC_TIMING_RESISTANT
+            rng = wc_rng_new(NULL, 0, hpke->heap);
+            wc_ecc_set_rng((ecc_key*)ephemeralKey, rng);
+#endif
 
             ret = wc_ecc_shared_secret((ecc_key*)ephemeralKey,
                 (ecc_key*)receiverKey, dh, &dh_len);
 
-            wc_rng_free(((ecc_key*)ephemeralKey)->rng);
+#ifdef ECC_TIMING_RESISTANT
+            wc_rng_free(rng);
+#endif
             break;
 #endif
 #if defined(HAVE_CURVE25519)
@@ -951,6 +957,7 @@ static int wc_HpkeDecap(Hpke* hpke, void* receiverKey, const byte* pubKey,
     word16 pubKeySz, byte* sharedSecret)
 {
     int ret;
+    WC_RNG* rng;
     word32 dh_len;
     word16 receiverPubKeySz;
     void* ephemeralKey = NULL;
@@ -992,12 +999,17 @@ static int wc_HpkeDecap(Hpke* hpke, void* receiverKey, const byte* pubKey,
             case DHKEM_P256_HKDF_SHA256:
             case DHKEM_P384_HKDF_SHA384:
             case DHKEM_P521_HKDF_SHA512:
-                ((ecc_key*)receiverKey)->rng = wc_rng_new(NULL, 0, hpke->heap);
+#ifdef ECC_TIMING_RESISTANT
+                rng = wc_rng_new(NULL, 0, hpke->heap);
+                wc_ecc_set_rng((ecc_key*)receiverKey, rng);
+#endif
 
                 ret = wc_ecc_shared_secret((ecc_key*)receiverKey,
                     (ecc_key*)ephemeralKey, dh, &dh_len);
 
-                wc_rng_free(((ecc_key*)receiverKey)->rng);
+#ifdef ECC_TIMING_RESISTANT
+                wc_rng_free(rng);
+#endif
                 break;
 #endif
 #if defined(HAVE_CURVE25519)

--- a/wolfcrypt/src/hpke.c
+++ b/wolfcrypt/src/hpke.c
@@ -736,7 +736,9 @@ static int wc_HpkeEncap(Hpke* hpke, void* ephemeralKey, void* receiverKey,
     byte* sharedSecret)
 {
     int ret;
+#ifdef ECC_TIMING_RESISTANT
     WC_RNG* rng;
+#endif
     word32 dh_len;
     word16 receiverPubKeySz;
     word16 ephemeralPubKeySz;
@@ -778,6 +780,10 @@ static int wc_HpkeEncap(Hpke* hpke, void* ephemeralKey, void* receiverKey,
         case DHKEM_P521_HKDF_SHA512:
 #ifdef ECC_TIMING_RESISTANT
             rng = wc_rng_new(NULL, 0, hpke->heap);
+
+            if (rng == NULL)
+                return RNG_FAILURE_E;
+
             wc_ecc_set_rng((ecc_key*)ephemeralKey, rng);
 #endif
 
@@ -957,7 +963,9 @@ static int wc_HpkeDecap(Hpke* hpke, void* receiverKey, const byte* pubKey,
     word16 pubKeySz, byte* sharedSecret)
 {
     int ret;
+#ifdef ECC_TIMING_RESISTANT
     WC_RNG* rng;
+#endif
     word32 dh_len;
     word16 receiverPubKeySz;
     void* ephemeralKey = NULL;
@@ -1001,6 +1009,10 @@ static int wc_HpkeDecap(Hpke* hpke, void* receiverKey, const byte* pubKey,
             case DHKEM_P521_HKDF_SHA512:
 #ifdef ECC_TIMING_RESISTANT
                 rng = wc_rng_new(NULL, 0, hpke->heap);
+
+                if (rng == NULL)
+                    return RNG_FAILURE_E;
+
                 wc_ecc_set_rng((ecc_key*)receiverKey, rng);
 #endif
 


### PR DESCRIPTION
# Description

update hpke to not use rng with ecc when hardening is off

# Testing

Commit test

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
