### PR TITLE
Include <sys/time.h> on RIOT-OS

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -103,7 +103,7 @@
     #include <errno.h>
 #endif
 
-#if defined(__MACH__) || defined(__FreeBSD__)
+#if defined(__MACH__) || defined(__FreeBSD__) || defined(WOLFSSL_RIOT_OS)
 #include <sys/time.h>
 #endif /* __MACH__ || __FreeBSD__ */
 


### PR DESCRIPTION
# Description

On RIOT-OS compilation failed due to a missing include. This was added now.

# Testing

Compilation on RIOT-OS now succeeds.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
