### PR TITLE
20230124-fix-HAVE_C___ATOMIC

### DIFF
--- a/m4/ax_atomic.m4
+++ b/m4/ax_atomic.m4
@@ -31,6 +31,6 @@ AC_DEFUN([AC_C___ATOMIC],
 if test $ac_cv_c___atomic = yes; then
   AC_DEFINE([HAVE_C___ATOMIC], 1,
            [Define to 1 if __atomic operations work.])
-  AM_CFLAGS="$AM_CFLAGS -DHAVE_C___ATOMIC"
+  AM_CFLAGS="$AM_CFLAGS -DHAVE_C___ATOMIC=1"
 fi
 ])# AC_C___ATOMIC

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -29102,7 +29102,7 @@ static int MakeCertReq(Cert* cert, byte* derBuffer, word32 derSz,
     int sz = 0;
     int ret = 0;
 #if defined(WOLFSSL_CERT_EXT) || defined(OPENSSL_EXTRA)
-    word32 sbjRawSz;
+    word32 sbjRawSz = 0;
 #endif
 
     /* Unused without OQS */


### PR DESCRIPTION
`m4/ax_atomic.m4`: fix conflicting macro definition for `HAVE_C___ATOMIC`.

`wolfcrypt/src/asn.c`: fix a `maybe-uninitialized` found by `clang` `--enable-asn=template`.

tested with `wolfssl-multi-test.sh ... super-quick-check '.*asn-template.*'`.
