### PR TITLE
AES XTS: encrypt not handling in-place properly

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -12014,8 +12014,17 @@ int wc_AesXtsEncrypt(XtsAes* xaes, byte* out, const byte* in, word32 sz,
                 RESTORE_VECTOR_REGISTERS();
                 return BUFFER_E;
             }
-            XMEMCPY(out, buf, sz);
-            XMEMCPY(buf, in, sz);
+            if (in != out) {
+                XMEMCPY(out, buf, sz);
+                XMEMCPY(buf, in, sz);
+            }
+            else {
+                byte buf2[AES_BLOCK_SIZE];
+
+                XMEMCPY(buf2, buf, sz);
+                XMEMCPY(buf, in, sz);
+                XMEMCPY(out, buf2, sz);
+            }
 
             xorbuf(buf, tmp, AES_BLOCK_SIZE);
             ret = wc_AesEncryptDirect(aes, out - AES_BLOCK_SIZE, buf);


### PR DESCRIPTION
# Description

Fix AES XTS in-place encrypt to work when ciphertext stealing.

Fixes zd#15486

# Testing

POC and added test case for in-place AES XTS encryption with cipher-text stealing.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
