### PR TITLE
20230125-various-fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,10 @@ SUBDIRS_OPT =
 DIST_SUBDIRS_OPT =
 
 # allow supplementary or override flags to be passed at make time:
+AM_CPPFLAGS += $(EXTRA_CPPFLAGS)
 AM_CFLAGS += $(EXTRA_CFLAGS)
+AM_CCASFLAGS += $(EXTRA_CCASFLAGS)
+AM_LDFLAGS += $(EXTRA_LDFLAGS)
 
 #includes additional rules from aminclude.am
 @INC_AMINCLUDE@
@@ -201,13 +204,15 @@ include scripts/include.am
 
 if BUILD_LINUXKM
     # rather than setting $SUBDIRS here directly, we set an auxiliary variable.
-    # autotools see the SUBDIRS assignment here even if BUILD_LINUXKM is false,
+    # autotools sees the SUBDIRS assignment here even if BUILD_LINUXKM is false,
     # at least for purposes of recursing for "make distdir", which we don't want to happen.
     SUBDIRS_OPT += linuxkm
     DIST_SUBDIRS_OPT += linuxkm
 
-    export KERNEL_ROOT KERNEL_ARCH KERNEL_EXTRA_CFLAGS AM_CPPFLAGS CPPFLAGS \
-        AM_CFLAGS CFLAGS AM_CCASFLAGS CCASFLAGS \
+    export KERNEL_ROOT KERNEL_ARCH KERNEL_EXTRA_CFLAGS \
+        EXTRA_CFLAGS EXTRA_CPPFLAGS EXTRA_CCASFLAGS EXTRA_LDFLAGS \
+	AM_CPPFLAGS CPPFLAGS AM_CFLAGS CFLAGS \
+        AM_CCASFLAGS CCASFLAGS \
         src_libwolfssl_la_OBJECTS ENABLED_CRYPT_TESTS ENABLED_LINUXKM_PIE ENABLED_ASM \
         CFLAGS_FPU_DISABLE CFLAGS_FPU_ENABLE CFLAGS_SIMD_DISABLE CFLAGS_SIMD_ENABLE \
         CFLAGS_AUTO_VECTORIZE_DISABLE CFLAGS_AUTO_VECTORIZE_ENABLE \

--- a/configure.ac
+++ b/configure.ac
@@ -8571,9 +8571,11 @@ fi
 
 if test "$ENABLED_REPRODUCIBLE_BUILD" != "yes"
 then
-    echo "#define LIBWOLFSSL_CONFIGURE_ARGS \"$ac_configure_args\"" > ${output_objdir}/.build_params &&
-        echo "#define LIBWOLFSSL_GLOBAL_CFLAGS \"$CPPFLAGS $AM_CPPFLAGS $CFLAGS $AM_CFLAGS\" LIBWOLFSSL_GLOBAL_EXTRA_CFLAGS" >> ${output_objdir}/.build_params ||
+    echo "#define LIBWOLFSSL_CONFIGURE_ARGS \"$ac_configure_args\"" > "${output_objdir}/.build_params" &&
+        echo "#define LIBWOLFSSL_GLOBAL_CFLAGS \"$CPPFLAGS $AM_CPPFLAGS $CFLAGS $AM_CFLAGS\" LIBWOLFSSL_GLOBAL_EXTRA_CFLAGS" >> "${output_objdir}/.build_params" ||
         AC_MSG_ERROR([Couldn't create ${output_objdir}/.build_params.])
+else
+    rm -f "${output_objdir}/.build_params"
 fi
 
 # generate user options header
@@ -8602,7 +8604,7 @@ echo "extern \"C\" {" >> $OPTION_FILE
 echo "#endif" >> $OPTION_FILE
 echo "" >> $OPTION_FILE
 
-for option in $AM_CPPFLAGS $AM_CFLAGS; do
+for option in $CPPFLAGS $AM_CPPFLAGS $CFLAGS $AM_CFLAGS; do
     opt_type=$(echo $option | colrm 3)
     case "$opt_type" in
     -D)

--- a/configure.ac
+++ b/configure.ac
@@ -35,7 +35,10 @@ AC_CONFIG_HEADERS([config.h:config.in])
 LT_PREREQ([2.4.2])
 LT_INIT([disable-static win32-dll])
 
-AC_ARG_VAR(EXTRA_CFLAGS, [Extra CFLAGS to add to autoconf-computed arg list.  Can also supply directly to make.])
+AC_ARG_VAR(EXTRA_CPPFLAGS, [Extra CPPFLAGS to add to end of autoconf-computed arg list.  Can also supply directly to make.])
+AC_ARG_VAR(EXTRA_CFLAGS, [Extra CFLAGS to add to end of autoconf-computed arg list.  Can also supply directly to make.])
+AC_ARG_VAR(EXTRA_CCASFLAGS, [Extra CCASFLAGS to add to end of autoconf-computed arg list.  Can also supply directly to make.])
+AC_ARG_VAR(EXTRA_LDFLAGS, [Extra LDFLAGS to add to end of autoconf-computed arg list.  Can also supply directly to make.])
 
 WOLFSSL_CONFIG_ARGS=$ac_configure_args
 AC_SUBST([WOLFSSL_CONFIG_ARGS])
@@ -65,7 +68,7 @@ AC_SUBST([WOLFSSL_LIBRARY_VERSION])
 
 gl_VISIBILITY
 AS_IF([ test -n "$CFLAG_VISIBILITY" ], [
-       AM_CFLAGS="$AM_CPPFLAGS $CFLAG_VISIBILITY"
+       AM_CFLAGS="$AM_CFLAGS $CFLAG_VISIBILITY"
        ])
 
 
@@ -981,7 +984,6 @@ AC_ARG_WITH([liboqs],
     [AS_HELP_STRING([--with-liboqs=PATH],[Path to liboqs install (default /usr/local) EXPERIMENTAL!])],
     [
         AC_MSG_CHECKING([for liboqs])
-        CPPFLAGS="$CPPFLAGS -DHAVE_LIBOQS -DHAVE_TLS_EXTENSIONS"
         LIBS="$LIBS -loqs"
 
         AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <oqs/common.h>]], [[ OQS_init(); ]])], [ liboqs_linked=yes ],[ liboqs_linked=no ])
@@ -994,8 +996,8 @@ AC_ARG_WITH([liboqs],
                 tryliboqsdir="/usr/local"
             fi
 
+            CPPFLAGS="$AM_CPPFLAGS -DHAVE_LIBOQS -DHAVE_TLS_EXTENSIONS -I$tryliboqsdir/include"
             LDFLAGS="$AM_LDFLAGS $LDFLAGS -L$tryliboqsdir/lib"
-            CPPFLAGS="$CPPFLAGS -I$tryliboqsdir/include"
 
             AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <oqs/common.h>]], [[ OQS_init(); ]])], [ liboqs_linked=yes ],[ liboqs_linked=no ])
 
@@ -1004,6 +1006,7 @@ AC_ARG_WITH([liboqs],
                 If it's already installed, specify its path using --with-liboqs=/dir/])
             fi
             AC_MSG_RESULT([yes])
+            AM_CPPFLAGS="$CPPFLAGS"
             AM_LDFLAGS="$AM_LDFLAGS -L$tryliboqsdir/lib"
         else
             AC_MSG_RESULT([yes])
@@ -4840,7 +4843,6 @@ AC_ARG_WITH([wnr],
     [AS_HELP_STRING([--with-wnr=PATH],[Path to Whitewood netRandom install (default /usr/local)])],
     [
         AC_MSG_CHECKING([for Whitewood netRandom])
-        CPPFLAGS="$CPPFLAGS -DHAVE_WNR"
         LIBS="$LIBS -lwnr"
 
         AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <wnr.h>]], [[ wnr_setup(0, 0); ]])], [ wnr_linked=yes ],[ wnr_linked=no ])
@@ -4853,8 +4855,8 @@ AC_ARG_WITH([wnr],
                 trywnrdir="/usr/local"
             fi
 
+            CPPFLAGS="$AM_CPPFLAGS -DHAVE_WNR -I$trywnrdir/include"
             LDFLAGS="$AM_LDFLAGS $LDFLAGS -L$trywnrdir/lib"
-            CPPFLAGS="$CPPFLAGS -I$trywnrdir/include"
 
             AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <wnr.h>]], [[ wnr_setup(0, 0); ]])], [ wnr_linked=yes ],[ wnr_linked=no ])
 
@@ -4863,6 +4865,7 @@ AC_ARG_WITH([wnr],
                 If it's already installed, specify its path using --with-wnr=/dir/])
             fi
             AC_MSG_RESULT([yes])
+            AM_CPPFLAGS="$CPPFLAGS"
             AM_LDFLAGS="$AM_LDFLAGS -L$trywnrdir/lib"
         else
             AC_MSG_RESULT([yes])
@@ -6423,7 +6426,6 @@ AC_ARG_WITH([cavium],
     [  --with-cavium=PATH      PATH to cavium/software dir ],
     [
         AC_MSG_CHECKING([for cavium])
-        CPPFLAGS="$CPPFLAGS -DHAVE_CAVIUM"
         LIB_ADD="-lrt $LIB_ADD"
 
         if test "x$withval" = "xyes" ; then
@@ -6433,8 +6435,8 @@ AC_ARG_WITH([cavium],
             trycaviumdir=$withval
         fi
 
+        CPPFLAGS="$AM_CPPFLAGS -DHAVE_CAVIUM -I$trycaviumdir/include"
         LDFLAGS="$AM_LDFLAGS $trycaviumdir/api/cavium_common.o"
-        CPPFLAGS="$CPPFLAGS -I$trycaviumdir/include"
 
         AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include "cavium_common.h"]], [[ CspShutdown(CAVIUM_DEV_ID); ]])],[ cavium_linked=yes ],[ cavium_linked=no ])
 
@@ -6442,7 +6444,8 @@ AC_ARG_WITH([cavium],
             AC_MSG_ERROR([cavium isn't found.
             If it's already installed, specify its path using --with-cavium=/dir/])
         else
-            AM_CFLAGS="$AM_CFLAGS -DHAVE_CAVIUM"
+            AM_CPPFLAGS="$CPPFLAGS"
+            AM_LDFLAGS="$LDFLAGS"
         fi
         AC_MSG_RESULT([yes])
         enable_shared=no
@@ -8508,6 +8511,10 @@ then
     AM_CFLAGS="$AM_CFLAGS -include ${output_objdir}/.build_params"
 fi
 
+AM_CPPFLAGS="$AM_CPPFLAGS $EXTRA_CPPFLAGS"
+AM_CFLAGS="$AM_CFLAGS $EXTRA_CFLAGS"
+AM_CCASFLAGS="$AM_CCASFLAGS $EXTRA_CCASFLAGS"
+AM_LDFLAGS="$AM_LDFLAGS $EXTRA_LDFLAGS"
 
 CREATE_HEX_VERSION
 AC_SUBST([AM_CPPFLAGS])
@@ -8579,7 +8586,7 @@ rm -f $OPTION_FILE
 echo "/* wolfssl options.h" > $OPTION_FILE
 echo " * generated from configure options" >> $OPTION_FILE
 echo " *" >> $OPTION_FILE
-echo " * Copyright (C) 2006-2022 wolfSSL Inc." >> $OPTION_FILE
+echo " * Copyright (C) 2006-2023 wolfSSL Inc." >> $OPTION_FILE
 echo " *" >> $OPTION_FILE
 echo " * This file is part of wolfSSL. (formerly known as CyaSSL)" >> $OPTION_FILE
 echo " *" >> $OPTION_FILE
@@ -8595,11 +8602,12 @@ echo "extern \"C\" {" >> $OPTION_FILE
 echo "#endif" >> $OPTION_FILE
 echo "" >> $OPTION_FILE
 
-for option in $CPPFLAGS $AM_CPPFLAGS $CFLAGS $AM_CFLAGS $EXTRA_CFLAGS; do
-    defonly=`echo $option | sed 's/^-D//'`
-    if test "$defonly" != "$option"
-    then
-        noequalsign=`echo $defonly | sed 's/=/ /'`
+for option in $AM_CPPFLAGS $AM_CFLAGS; do
+    opt_type=$(echo $option | colrm 3)
+    case "$opt_type" in
+    -D)
+        RHS_only=$(echo $option | sed 's/^-D//')
+        noequalsign=$(echo $RHS_only | sed 's/=/ /')
         if test "$noequalsign" = "NDEBUG" || test "$noequalsign" = "DEBUG"
         then
             if test "$verbose" = "yes"; then
@@ -8615,7 +8623,7 @@ for option in $CPPFLAGS $AM_CPPFLAGS $CFLAGS $AM_CFLAGS $EXTRA_CFLAGS; do
             echo "#ifndef WOLFSSL_OPTIONS_IGNORE_SYS" >> $OPTION_FILE
         fi
 
-        noarg=`echo $defonly | sed 's/=.*//'`
+        noarg=$(echo "$RHS_only" | sed 's/=.*//')
         echo "#undef  $noarg" >> $OPTION_FILE
         echo "#define $noequalsign" >> $OPTION_FILE
 
@@ -8625,11 +8633,18 @@ for option in $CPPFLAGS $AM_CPPFLAGS $CFLAGS $AM_CFLAGS $EXTRA_CFLAGS; do
         fi
 
         echo "" >> $OPTION_FILE
-    else
+        ;;
+    -U)
+        RHS_only=$(echo $option | sed 's/^-U//')
+        echo "#undef  $RHS_only" >> $OPTION_FILE
+        echo "" >> $OPTION_FILE
+        ;;
+    *)
         if test "$verbose" = "yes"; then
-            AC_MSG_NOTICE([option w/o begin -D is $option, not saving to $OPTION_FILE])
+            AC_MSG_NOTICE([option "$option" is not a preprocessor directive -- not saving to $OPTION_FILE])
         fi
-    fi
+        ;;
+    esac
 done
 
 echo "" >> $OPTION_FILE
@@ -8678,6 +8693,7 @@ echo "   * C++ Compiler:               $CXX"
 echo "   * C++ Flags:                  $CXXFLAGS"
 echo "   * CPP Flags:                  $CPPFLAGS"
 echo "   * CCAS Flags:                 $CCASFLAGS"
+echo "   * LD Flags:                   $LDFLAGS"
 echo "   * LIB Flags:                  $LIB"
 echo "   * Library Suffix:             $LIBSUFFIX"
 

--- a/linuxkm/module_exports.c.template
+++ b/linuxkm/module_exports.c.template
@@ -88,6 +88,9 @@
 #ifdef HAVE_ECC
     #include <wolfssl/wolfcrypt/ecc.h>
 #endif
+#ifdef HAVE_HPKE
+    #include <wolfssl/wolfcrypt/hpke.h>
+#endif
 #ifdef HAVE_CURVE25519
     #include <wolfssl/wolfcrypt/curve25519.h>
 #endif

--- a/tests/api.c
+++ b/tests/api.c
@@ -50956,7 +50956,11 @@ static int test_tls13_apis(void)
 #endif
 #endif
 #ifndef OPENSSL_EXTRA
+#ifdef WOLFSSL_ERROR_CODE_OPENSSL
+    AssertIntEQ(wolfSSL_CTX_set_max_early_data(serverCtx, 32), WOLFSSL_SUCCESS);
+#else
     AssertIntEQ(wolfSSL_CTX_set_max_early_data(serverCtx, 32), 0);
+#endif
     AssertIntEQ(wolfSSL_CTX_get_max_early_data(serverCtx), 32);
 #else
     AssertIntEQ(SSL_CTX_set_max_early_data(serverCtx, 32), 1);
@@ -50973,7 +50977,11 @@ static int test_tls13_apis(void)
 #endif
 #ifndef NO_WOLFSSL_CLIENT
 #ifndef OPENSSL_EXTRA
+#ifdef WOLFSSL_ERROR_CODE_OPENSSL
+    AssertIntEQ(wolfSSL_set_max_early_data(clientSsl, 17), WOLFSSL_SUCCESS);
+#else
     AssertIntEQ(wolfSSL_set_max_early_data(clientSsl, 17), 0);
+#endif
     AssertIntEQ(wolfSSL_get_max_early_data(clientSsl), 17);
 #else
     AssertIntEQ(SSL_set_max_early_data(clientSsl, 17), WOLFSSL_SUCCESS);
@@ -50991,7 +50999,11 @@ static int test_tls13_apis(void)
 #endif
 #endif
 #ifndef OPENSSL_EXTRA
+#ifdef WOLFSSL_ERROR_CODE_OPENSSL
+    AssertIntEQ(wolfSSL_set_max_early_data(serverSsl, 16), WOLFSSL_SUCCESS);
+#else
     AssertIntEQ(wolfSSL_set_max_early_data(serverSsl, 16), 0);
+#endif
     AssertIntEQ(wolfSSL_get_max_early_data(serverSsl), 16);
 #else
     AssertIntEQ(SSL_set_max_early_data(serverSsl, 16), 1);

--- a/wolfcrypt/src/hpke.c
+++ b/wolfcrypt/src/hpke.c
@@ -942,14 +942,19 @@ int wc_HpkeSealBase(Hpke* hpke, void* ephemeralKey, void* receiverKey,
     }
 #endif
 
+    PRIVATE_KEY_UNLOCK();
+
     /* setup the context and pubKey */
     ret = wc_HpkeSetupBaseSender(hpke, context, ephemeralKey, receiverKey, info,
         infoSz);
 
     /* run seal using the context */
-    if (ret == 0)
+    if (ret == 0) {
         ret = wc_HpkeContextSealBase(hpke, context, aad, aadSz, plaintext,
             ptSz, ciphertext);
+    }
+
+    PRIVATE_KEY_LOCK();
 
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(context, hpke->heap, DYNAMIC_TYPE_TMP_BUFFER);
@@ -1174,6 +1179,8 @@ int wc_HpkeOpenBase(Hpke* hpke, void* receiverKey, const byte* pubKey,
     }
 #endif
 
+    PRIVATE_KEY_UNLOCK();
+
     /* setup receiver */
     ret = wc_HpkeSetupBaseReceiver(hpke, context, receiverKey, pubKey,
         pubKeySz, info, infoSz);
@@ -1183,6 +1190,8 @@ int wc_HpkeOpenBase(Hpke* hpke, void* receiverKey, const byte* pubKey,
         ret = wc_HpkeContextOpenBase(hpke, context, aad, aadSz, ciphertext,
             ctSz, plaintext);
     }
+
+    PRIVATE_KEY_LOCK();
 
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(context, hpke->heap, DYNAMIC_TYPE_TMP_BUFFER);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -22540,24 +22540,30 @@ static int hpke_test_single(Hpke* hpke)
         ret = wc_HpkeGenerateKeyPair(hpke, &receiverKey, rng);
 
     /* seal */
-    if (ret == 0)
+    if (ret == 0) {
+        PRIVATE_KEY_UNLOCK();
         ret = wc_HpkeSealBase(hpke, ephemeralKey, receiverKey,
             (byte*)info_text, (word32)XSTRLEN(info_text),
             (byte*)aad_text, (word32)XSTRLEN(aad_text),
             (byte*)start_text, (word32)XSTRLEN(start_text),
             ciphertext);
+        PRIVATE_KEY_LOCK();
+    }
 
     /* export ephemeral key */
     if (ret == 0)
         ret = wc_HpkeSerializePublicKey(hpke, ephemeralKey, pubKey, &pubKeySz);
 
     /* open with exported ephemeral key */
-    if (ret == 0)
+    if (ret == 0) {
+        PRIVATE_KEY_UNLOCK();
         ret = wc_HpkeOpenBase(hpke, receiverKey, pubKey, pubKeySz,
             (byte*)info_text, (word32)XSTRLEN(info_text),
             (byte*)aad_text, (word32)XSTRLEN(aad_text),
             ciphertext, (word32)XSTRLEN(start_text),
             plaintext);
+        PRIVATE_KEY_LOCK();
+    }
 
     if (ret == 0)
         ret = XMEMCMP(plaintext, start_text, XSTRLEN(start_text));


### PR DESCRIPTION
`wolfcrypt/test/test.c`: add missing `PRIVATE_KEY_UNLOCK()`/`PRIVATE_KEY_LOCK()` in `hpke_test_single()`.

`wolfcrypt/src/port/af_alg/afalg_aes.c`: in `wc_AesCbc{En,De}crypt()`, handle `WOLFSSL_AES_CBC_LENGTH_CHECKS` as in `wolfcrypt/aes.c`; in `wc_AesGcm{En,De}crypt()`, truncate `ivSz` to `WC_SYSTEM_AESGCM_IV` if necessary.

(with these changes, `--enable-afalg` now passes `make check`.)

`linuxkm/module_exports.c.template`: include `hpke.h` if `HAVE_HPKE`.

`configure.ac/Makefile.am`:
    
add support for `EXTRA_CPPFLAGS`, `EXTRA_CCASFLAGS`, and `EXTRA_LDFLAGS`;

fix typo in setup for `CFLAG_VISIBILITY`;

lightly refactor handling of `CPPFLAGS`/`AM_CPPFLAGS` in handlers for `--with-liboqs`, `--with-wnr`, and `--with-
cavium`;

refactor+enhance `options.h` generation to handle `-U` directives.


tested with `wolfssl-multi-test.sh ... super-quick-check  '.*-afalg' benchmark-wolfcrypt-noasm-all all-linuxkm-defaults-max-total-stack-8k-fips linuxkm-all-asm-cryptonly-opensslextra-pie`

the `*-afalg` scenarios are new:
```
all-afalg)
    scenario_depends_on have_addressfamily ALG || continue
    do_scenario "$scenario" "${ENABLE_ALL_TEST_FLAGS[@]}" --enable-afalg --disable-sha224 --disable-hashflags --disable-cryptocb --disable-aesgcm-stream EXTRA_CFLAGS='-UHAVE_AES_ECB' CPPFLAGS="${ABBREV_TEST_FLAGS[*]} ${PEDANTIC[*]}"
;;

defaults-afalg)
    scenario_depends_on have_addressfamily ALG || continue
    do_scenario "$scenario" --enable-afalg  CPPFLAGS="${PEDANTIC[*]}"
;;
```

Note the finagling to get `--enable-all` and `--enable-afalg` to coexist.  If properly motivated we can fix things so that isn't needed, but it's fine as-is for now I think.
