### PR TITLE
Fix SE050 RSA public key loading and RSA/ECC SE050 TLS Compatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2024,8 +2024,9 @@ AC_ARG_WITH([se050],
             CPPFLAGS="$CPPFLAGS -I$trylibse050dir/sss/ex/inc"
             CPPFLAGS="$CPPFLAGS -I$trylibse050dir/sss/port/default"
             CPPFLAGS="$CPPFLAGS -I$trylibse050dir/hostlib/hostLib/inc"
-            CPPFLAGS="$CPPFLAGS -I$trylibse050dir/hostlib/hostLib/libCommon/log/"
+            CPPFLAGS="$CPPFLAGS -I$trylibse050dir/hostlib/hostLib/libCommon/log"
             CPPFLAGS="$CPPFLAGS -I$trylibse050dir/hostlib/hostLib/libCommon/infra"
+            CPPFLAGS="$CPPFLAGS -I$trylibse050dir/hostlib/hostLib/se05x_03_xx_xx"
 
             if test -e "$trylibse050dir/build/sss/libSSS_APIs.a"; then
                 SE050_STATIC=yes
@@ -2924,7 +2925,7 @@ AC_ARG_ENABLE([keygen],
 if test "$ENABLED_BIND" = "yes" || test "$ENABLED_NTP" = "yes" || \
    test "$ENABLED_LIBSSH2" = "yes" || test "$ENABLED_OPENRESTY" = "yes" || \
    test "$ENABLED_NGINX" = "yes" || test "$ENABLED_WOLFENGINE" = "yes" || \
-   test "$ENABLED_STRONGSWAN" = "yes"
+   test "$ENABLED_STRONGSWAN" = "yes" || test "$ENABLED_SE050" = "yes"
 then
     ENABLED_KEYGEN=yes
 fi

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -5784,6 +5784,10 @@ int wc_ecc_init_id(ecc_key* key, unsigned char* id, int len, void* heap,
                    int devId)
 {
     int ret = 0;
+#ifdef WOLFSSL_SE050
+    /* SE050 TLS users store a word32 at id, need to cast back */
+    word32* keyPtr = NULL;
+#endif
 
     if (key == NULL)
         ret = BAD_FUNC_ARG;
@@ -5795,6 +5799,13 @@ int wc_ecc_init_id(ecc_key* key, unsigned char* id, int len, void* heap,
     if (ret == 0 && id != NULL && len != 0) {
         XMEMCPY(key->id, id, len);
         key->idLen = len;
+    #ifdef WOLFSSL_SE050
+        /* Set SE050 ID from word32, populate ecc_key with public from SE050 */
+        if (len == (int)sizeof(word32)) {
+            keyPtr = (word32*)key->id;
+            ret = wc_ecc_use_key_id(key, *keyPtr, 0);
+        }
+    #endif
     }
 
     return ret;

--- a/wolfcrypt/src/port/nxp/README_SE050.md
+++ b/wolfcrypt/src/port/nxp/README_SE050.md
@@ -96,6 +96,8 @@ $ make
 If no installation path is provided to `--with-se05x`, wolfSSL will use the
 default installation locations above.
 
+Example: `--with-se050=/home/pi/se_mw/simw-top/`
+
 If the SE05x middleware libraries have been linked against OpenSSL (on Linux),
 and you run into compiler errors in wolfSSL due to conflicts with the wolfSSL
 compatibility layer headers when compiling wolfSSL's examples and test apps,
@@ -115,7 +117,7 @@ wolfSSL can generate RSA and ECC keys inside the SE050. To include that support,
 wolfSSL should be configured with `--enable-keygen` or `-DWOLFSSL_KEY_GEN`.
 
 ```sh
-$ ./configure --with-se0500 --enable-keygen
+$ ./configure --with-se050 --enable-keygen
 ```
 
 ### wolfSSL HostCrypto support for SCP03 Authentication

--- a/wolfcrypt/src/port/nxp/se050_port.c
+++ b/wolfcrypt/src/port/nxp/se050_port.c
@@ -657,8 +657,8 @@ int wc_se050_get_binary_object(word32 keyId, byte* out, word32* outSz)
     }
     if (status == kStatus_SSS_Success) {
         outBitSz = (*outSz) * 8;
-        status = sss_key_store_get_key(&host_keystore, &object, out, outSz,
-                                       &outBitSz);
+        status = sss_key_store_get_key(&host_keystore, &object, out,
+                                       (size_t*)outSz, &outBitSz);
     }
     wolfSSL_CryptHwMutexUnLock();
 
@@ -1365,7 +1365,7 @@ int se050_rsa_verify(const byte* in, word32 inLen, byte* out, word32 outLen,
         if (key->keyIdSet == 0) {
             /* key was not generated in SE050, export RsaKey to DER
              * and use that to store into SE050 keystore */
-            derSz = wc_RsaKeyToDer(key, NULL, 0);
+            derSz = wc_RsaKeyToPublicDer(key, NULL, 0);
             if (derSz < 0) {
                 status = kStatus_SSS_Fail;
                 ret = derSz;
@@ -1380,7 +1380,7 @@ int se050_rsa_verify(const byte* in, word32 inLen, byte* out, word32 outLen,
                 }
             }
             if (status == kStatus_SSS_Success) {
-                derSz = wc_RsaKeyToDer(key, derBuf, derSz);
+                derSz = wc_RsaKeyToPublicDer(key, derBuf, derSz);
                 if (derSz < 0) {
                     status = kStatus_SSS_Fail;
                     ret = derSz;
@@ -1389,7 +1389,7 @@ int se050_rsa_verify(const byte* in, word32 inLen, byte* out, word32 outLen,
             if (status == kStatus_SSS_Success) {
                 keyId = se050_allocate_key(SE050_RSA_KEY);
                 status = sss_key_object_allocate_handle(&newKey, keyId,
-                    kSSS_KeyPart_Pair, kSSS_CipherType_RSA, keySz,
+                    kSSS_KeyPart_Public, kSSS_CipherType_RSA, keySz,
                     kKeyObject_Mode_Persistent);
             }
             if (status == kStatus_SSS_Success) {
@@ -1548,7 +1548,7 @@ int se050_rsa_public_encrypt(const byte* in, word32 inLen, byte* out,
         if (key->keyIdSet == 0) {
             /* key was not generated in SE050, export RsaKey to DER
              * and use that to store into SE050 keystore */
-            derSz = wc_RsaKeyToDer(key, NULL, 0);
+            derSz = wc_RsaKeyToPublicDer(key, NULL, 0);
             if (derSz < 0) {
                 status = kStatus_SSS_Fail;
                 ret = derSz;
@@ -1563,7 +1563,7 @@ int se050_rsa_public_encrypt(const byte* in, word32 inLen, byte* out,
                 }
             }
             if (status == kStatus_SSS_Success) {
-                derSz = wc_RsaKeyToDer(key, derBuf, derSz);
+                derSz = wc_RsaKeyToPublicDer(key, derBuf, derSz);
                 if (derSz < 0) {
                     status = kStatus_SSS_Fail;
                     ret = derSz;
@@ -1572,7 +1572,7 @@ int se050_rsa_public_encrypt(const byte* in, word32 inLen, byte* out,
             if (status == kStatus_SSS_Success) {
                 keyId = se050_allocate_key(SE050_RSA_KEY);
                 status = sss_key_object_allocate_handle(&newKey, keyId,
-                    kSSS_KeyPart_Pair, kSSS_CipherType_RSA, keySz,
+                    kSSS_KeyPart_Public, kSSS_CipherType_RSA, keySz,
                     kKeyObject_Mode_Persistent);
             }
             if (status == kStatus_SSS_Success) {

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -360,6 +360,10 @@ int wc_InitRsaKey_Id(RsaKey* key, unsigned char* id, int len, void* heap,
                      int devId)
 {
     int ret = 0;
+#ifdef WOLFSSL_SE050
+    /* SE050 TLS users store a word32 at id, need to cast back */
+    word32* keyPtr = NULL;
+#endif
 
     if (key == NULL)
         ret = BAD_FUNC_ARG;
@@ -371,6 +375,13 @@ int wc_InitRsaKey_Id(RsaKey* key, unsigned char* id, int len, void* heap,
     if (ret == 0 && id != NULL && len != 0) {
         XMEMCPY(key->id, id, len);
         key->idLen = len;
+    #ifdef WOLFSSL_SE050
+        /* Set SE050 ID from word32, populate RsaKey with public from SE050 */
+        if (len == (int)sizeof(word32)) {
+            keyPtr = (word32*)key->id;
+            ret = wc_RsaUseKeyId(key, *keyPtr, 0);
+        }
+    #endif
     }
 
     return ret;


### PR DESCRIPTION
# Description

This PR fixes a few issues with SE050 and TLS usage compatibility:

1. Calls in `se050_port.c` to `wc_RsaKeyToDer()` when using an RSA public key need to be calling `wc_RsaKeyToPublicDer()` instead.

2. SE050 can be used underneath a wolfSSL SSL/TLS client when using wolfSSL's `-DWOLF_PRIVATE_KEY_ID` option. With this, users can call `wolfSSL_CTX_use_PrivateKey_Id()` to pass the word32 SE050 key ID into the WOLFSSL_CTX. Since this API is set up to accept a `const unsigned char*`, we need to introduce some casting back to word32 in the case for RSA and ECC.

# Testing

Tested on a Raspberry Pi with NXP SE050 EdgeLock dev kit installed. Examples have been created and submitted in https://github.com/wolfSSL/wolfssl-examples/pull/363.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
