### PR TITLE
Fix for building with ASN template and `NO_ASN_TIME`

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -1950,7 +1950,7 @@ static int test_wolfSSL_CertManagerLoadCABuffer(void)
     AssertIntEQ(ret, ASN_UNKNOWN_OID_E);
     res = TEST_RES_CHECK(ret == ASN_UNKNOWN_OID_E);
 #elif !(WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS & WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY) && \
-    !defined(OPENSSL_COMPATIBLE_DEFAULTS)
+    !defined(OPENSSL_COMPATIBLE_DEFAULTS) && !defined(NO_ASN_TIME)
     AssertIntEQ(ret, ASN_AFTER_DATE_E);
     res = TEST_RES_CHECK(ret == ASN_AFTER_DATE_E);
 #else
@@ -3101,7 +3101,7 @@ static int test_wolfSSL_CTX_load_verify_locations_ex(void)
             WOLFSSL_LOAD_FLAG_NONE));
 
     /* test expired CA */
-#ifndef OPENSSL_COMPATIBLE_DEFAULTS
+#if !defined(OPENSSL_COMPATIBLE_DEFAULTS) && !defined(NO_ASN_TIME)
     AssertIntNE(wolfSSL_CTX_load_verify_locations_ex(ctx, ca_expired_cert, NULL,
             WOLFSSL_LOAD_FLAG_NONE), WOLFSSL_SUCCESS);
 #else
@@ -3155,7 +3155,7 @@ static int test_wolfSSL_CTX_load_verify_buffer_ex(void)
     /* test expired CA failure */
 
 
-#ifndef OPENSSL_COMPATIBLE_DEFAULTS
+#if !defined(OPENSSL_COMPATIBLE_DEFAULTS) && !defined(NO_ASN_TIME)
     AssertIntNE(wolfSSL_CTX_load_verify_buffer_ex(ctx, ca_expired_cert,
             sizeof_ca_expired_cert, WOLFSSL_FILETYPE_ASN1, 0,
             WOLFSSL_LOAD_FLAG_NONE), WOLFSSL_SUCCESS);

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -27093,6 +27093,7 @@ static int SetValidity(byte* output, int daysValid)
 #else
 static int SetValidity(byte* before, byte* after, int daysValid)
 {
+#ifndef NO_ASN_TIME
     int ret = 0;
     time_t now;
     time_t then;
@@ -27145,6 +27146,12 @@ static int SetValidity(byte* before, byte* after, int daysValid)
     }
 
     return ret;
+#else
+    (void)before;
+    (void)after;
+    (void)daysValid;
+    return NOT_COMPILED_IN;
+#endif
 }
 #endif /* WOLFSSL_ASN_TEMPLATE */
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -13166,13 +13166,15 @@ WOLFSSL_TEST_SUBROUTINE int memory_test(void)
             #ifndef NO_RSA
                 static const char* eccKeyPubFileDer = CERT_ROOT "ecc-keyPub.der";
             #endif
-            static const char* eccCaKeyFile  = CERT_ROOT "ca-ecc-key.der";
-            static const char* eccCaCertFile = CERT_ROOT "ca-ecc-cert.pem";
-            #ifdef ENABLE_ECC384_CERT_GEN_TEST
-                static const char* eccCaKey384File =
-                                               CERT_ROOT "ca-ecc384-key.der";
-                static const char* eccCaCert384File =
-                                               CERT_ROOT "ca-ecc384-cert.pem";
+            #ifndef NO_ASN_TIME
+                static const char* eccCaKeyFile  = CERT_ROOT "ca-ecc-key.der";
+                static const char* eccCaCertFile = CERT_ROOT "ca-ecc-cert.pem";
+                #ifdef ENABLE_ECC384_CERT_GEN_TEST
+                    static const char* eccCaKey384File =
+                                                CERT_ROOT "ca-ecc384-key.der";
+                    static const char* eccCaCert384File =
+                                                CERT_ROOT "ca-ecc384-cert.pem";
+                #endif
             #endif
         #endif
         #if defined(HAVE_PKCS7) && defined(HAVE_ECC)
@@ -13209,7 +13211,7 @@ WOLFSSL_TEST_SUBROUTINE int memory_test(void)
 
 #ifndef NO_WRITE_TEMP_FILES
 #ifdef HAVE_ECC
-    #ifdef WOLFSSL_CERT_GEN
+    #if defined(WOLFSSL_CERT_GEN) && !defined(NO_ASN_TIME)
          static const char* certEccPemFile =   CERT_WRITE_TEMP_DIR "certecc.pem";
          static const char* certEccDerFile = CERT_WRITE_TEMP_DIR "certecc.der";
     #endif
@@ -13230,7 +13232,7 @@ WOLFSSL_TEST_SUBROUTINE int memory_test(void)
 #endif /* HAVE_ECC */
 
 #ifndef NO_RSA
-    #ifdef WOLFSSL_CERT_GEN
+    #if defined(WOLFSSL_CERT_GEN) && !defined(NO_ASN_TIME)
         static const char* otherCertDerFile = CERT_WRITE_TEMP_DIR "othercert.der";
         static const char* certDerFile = CERT_WRITE_TEMP_DIR "cert.der";
         static const char* otherCertPemFile = CERT_WRITE_TEMP_DIR "othercert.pem";
@@ -15320,7 +15322,7 @@ exit_rsa_even_mod:
 }
 #endif /* WOLFSSL_HAVE_SP_RSA */
 
-#ifdef WOLFSSL_CERT_GEN
+#if defined(WOLFSSL_CERT_GEN) && !defined(NO_ASN_TIME)
 static int rsa_certgen_test(RsaKey* key, RsaKey* keypub, WC_RNG* rng, byte* tmp)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
@@ -16805,7 +16807,7 @@ WOLFSSL_TEST_SUBROUTINE int rsa_test(void)
         goto exit_rsa;
 #endif
 
-#ifdef WOLFSSL_CERT_GEN
+#if defined(WOLFSSL_CERT_GEN) && !defined(NO_ASN_TIME)
     /* Make Cert / Sign example for RSA cert and RSA CA */
     ret = rsa_certgen_test(key, keypub, &rng, tmp);
     if (ret != 0)
@@ -25624,7 +25626,7 @@ static int ecc_test_custom_curves(WC_RNG* rng)
 }
 #endif /* WOLFSSL_CUSTOM_CURVES */
 
-#ifdef WOLFSSL_CERT_GEN
+#if defined(WOLFSSL_CERT_GEN) && !defined(NO_ASN_TIME)
 
 /* Make Cert / Sign example for ECC cert and ECC CA */
 static int ecc_test_cert_gen(WC_RNG* rng)
@@ -26515,7 +26517,7 @@ WOLFSSL_TEST_SUBROUTINE int ecc_test(void)
 #elif defined(HAVE_ECC_KEY_IMPORT)
     (void)ecc_test_make_pub; /* for compiler warning */
 #endif
-#ifdef WOLFSSL_CERT_GEN
+#if defined(WOLFSSL_CERT_GEN) && !defined(NO_ASN_TIME)
     ret = ecc_test_cert_gen(&rng);
     if (ret != 0) {
         printf("ecc_test_cert_gen failed!: %d\n", ret);

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -823,17 +823,19 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 
 #define sk_ASN1_OBJECT_free             wolfSSL_sk_ASN1_OBJECT_free
 
+#ifndef NO_ASN_TIME
 #define ASN1_TIME_new                   wolfSSL_ASN1_TIME_new
 #define ASN1_UTCTIME_new                wolfSSL_ASN1_TIME_new
 #define ASN1_TIME_free                  wolfSSL_ASN1_TIME_free
 #define ASN1_UTCTIME_free               wolfSSL_ASN1_TIME_free
 #define ASN1_TIME_adj                   wolfSSL_ASN1_TIME_adj
 #define ASN1_TIME_print                 wolfSSL_ASN1_TIME_print
-#define ASN1_TIME_to_generalizedtime    wolfSSL_ASN1_TIME_to_generalizedtime
-#define ASN1_TIME_set                   wolfSSL_ASN1_TIME_set
-#define ASN1_TIME_set_string            wolfSSL_ASN1_TIME_set_string
 #define ASN1_TIME_to_string             wolfSSL_ASN1_TIME_to_string
 #define ASN1_TIME_to_tm                 wolfSSL_ASN1_TIME_to_tm
+#define ASN1_TIME_to_generalizedtime    wolfSSL_ASN1_TIME_to_generalizedtime
+#endif
+#define ASN1_TIME_set                   wolfSSL_ASN1_TIME_set
+#define ASN1_TIME_set_string            wolfSSL_ASN1_TIME_set_string
 #define ASN1_GENERALIZEDTIME_print      wolfSSL_ASN1_GENERALIZEDTIME_print
 #define ASN1_GENERALIZEDTIME_free       wolfSSL_ASN1_GENERALIZEDTIME_free
 


### PR DESCRIPTION
# Description

Fix NO_ASN_TIME support for ASN template, also fix expired certificate unit tests with NO_ASN_TIME defined.
Allow compiling NO_ASN_TIME + asn template with no time_t definition.

Fixes ZD15544

# Testing

Reproduced error using:

```
./configure --enable-asn=template CFLAGS="-DNO_ASN_TIME" --enable-opensslextra --enable-certgen && make check
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
