### PR TITLE
20230127-fixes

### DIFF
--- a/wolfcrypt/src/port/arm/armv8-aes.c
+++ b/wolfcrypt/src/port/arm/armv8-aes.c
@@ -55,7 +55,6 @@
     #pragma warning(disable: 4127)
 #endif
 
-
 static const byte rcon[] = {
     0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80,0x1B, 0x36
     /* for 128-bit blocks, Rijndael never uses more than 10 rcon values */
@@ -5231,8 +5230,8 @@ int wc_AesCcmEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
     word32 wordSz = (word32)sizeof(word32);
 
     /* sanity check on arguments */
-    if (aes == NULL || out == NULL || in == NULL || nonce == NULL
-            || authTag == NULL || nonceSz < 7 || nonceSz > 13)
+    if (aes == NULL || (inSz != 0 && (in == NULL || out == NULL)) ||
+        nonce == NULL || authTag == NULL || nonceSz < 7 || nonceSz > 13)
         return BAD_FUNC_ARG;
 
     if (wc_AesCcmCheckTagSize(authTagSz) != 0) {
@@ -5303,8 +5302,8 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
     word32 wordSz = (word32)sizeof(word32);
 
     /* sanity check on arguments */
-    if (aes == NULL || out == NULL || in == NULL || nonce == NULL
-            || authTag == NULL || nonceSz < 7 || nonceSz > 13)
+    if (aes == NULL || (inSz != 0 && (in == NULL || out == NULL)) ||
+        nonce == NULL || authTag == NULL || nonceSz < 7 || nonceSz > 13)
         return BAD_FUNC_ARG;
 
     if (wc_AesCcmCheckTagSize(authTagSz) != 0) {

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -8497,6 +8497,8 @@ static int aes_xts_128_test(void)
         0xff, 0x8d, 0xbc, 0x1d, 0x9f, 0x7f, 0xc8, 0x22
     };
 
+#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3)
+
     WOLFSSL_SMALL_STACK_STATIC unsigned char k3[] = {
         0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
         0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
@@ -8521,6 +8523,8 @@ static int aes_xts_128_test(void)
         0xA0, 0x85, 0xD2, 0x69, 0x6E, 0x87, 0x0A, 0xBF,
         0xB5, 0x5A, 0xDD, 0xCB, 0x80, 0xE0, 0xFC, 0xCD
     };
+
+#endif /* !HAVE_FIPS || FIPS_VERSION_GE(5,3) */
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     if ((aes = (XtsAes *)XMALLOC(sizeof *aes, HEAP_HINT, DYNAMIC_TYPE_AES)) == NULL)
@@ -8631,6 +8635,8 @@ static int aes_xts_128_test(void)
 
     wc_AesXtsFree(aes);
 
+#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3)
+
     /* Test ciphertext stealing in-place. */
     XMEMCPY(buf, p3, sizeof(p3));
     if (wc_AesXtsSetKey(aes, k3, sizeof(k3), AES_ENCRYPTION,
@@ -8661,6 +8667,8 @@ static int aes_xts_128_test(void)
         ERROR_OUT(-5421, out);
     if (XMEMCMP(p3, buf, sizeof(p3)))
         ERROR_OUT(-5422, out);
+
+#endif /* !HAVE_FIPS || FIPS_VERSION_GE(5,3) */
 
   out:
 
@@ -22673,7 +22681,8 @@ WOLFSSL_TEST_SUBROUTINE int hpke_test(void)
         return ret;
     #endif
 
-    #ifdef WOLFSSL_SHA384
+    #if defined(WOLFSSL_SHA384) && \
+        (defined(HAVE_ECC384) || defined(HAVE_ALL_CURVES))
     /* p384 */
     ret = wc_HpkeInit(hpke, DHKEM_P384_HKDF_SHA384, HKDF_SHA384,
         HPKE_AES_128_GCM, NULL);
@@ -22687,7 +22696,8 @@ WOLFSSL_TEST_SUBROUTINE int hpke_test(void)
         return ret;
     #endif
 
-    #if defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512)
+    #if (defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512)) && \
+        (defined(HAVE_ECC521) || defined(HAVE_ALL_CURVES))
     /* p521 */
     ret = wc_HpkeInit(hpke, DHKEM_P521_HKDF_SHA512, HKDF_SHA512,
         HPKE_AES_128_GCM, NULL);


### PR DESCRIPTION
`wolfcrypt/src/port/arm/armv8-aes.c`: harmonize arg validation in aarch64-armasm `wc_AesCcm{En,De}crypt()` with `aes.c` -- tolerate null `in`/`out` iff `inSz==0`.

`wolfcrypt/test/test.c`: in `aes_xts_128_test()`, gate in-place test on `!HAVE_FIPS || FIPS_VERSION_GE(5,3)`; in `hpke_test()`, gate tests on availability of relevant ECC curve, not just on relevant digest.

tested with `wolfssl-multi-test.sh ... super-quick-check all-afalg fips-140-3-all linuxkm-defaults-all-fips-140-3 fips-140-3-RC12 clang-tidy-fips-140-3-all cross-riscv64-sp-math-asm cross-aarch64-all-armasm-unittest-sanitizer`
