### PR TITLE
SP int: div small static code analysis change

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -6377,7 +6377,7 @@ static void _sp_div_small(const sp_int* a, sp_int_digit d, sp_int* r,
             /* Get top digit after multipling. */
             tt = (t * m) >> SP_WORD_SIZE;
             /* Subtract trial division. */
-            tr = (sp_int_digit)(t - tt * d);
+            tr = (sp_int_digit)t - (sp_int_digit)(tt * d);
         #else
             /* Multiply digit. */
             SP_ASM_MUL(l, tt, a->dp[i], m);
@@ -6404,7 +6404,7 @@ static void _sp_div_small(const sp_int* a, sp_int_digit d, sp_int* r,
             /* Get top digit after multipling. */
             tt = (t * m) >> SP_WORD_SIZE;
             /* Subtract trial division. */
-            tr = (sp_int_digit)(t - tt * d);
+            tr = (sp_int_digit)t - (sp_int_digit)(tt * d);
         #else
             /* Multiply digit. */
             SP_ASM_MUL(l, tt, a->dp[i], m);


### PR DESCRIPTION
# Description

_sp_div_small: Make it explicit as possible that we only want the bottom digit of the product subtracted from the bottom word of t. Top digit is unnecessary and more cycles used if calculated.

# Testing

Standard

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
