### PR TITLE
Fix workflow concurrency

### DIFF
--- a/.github/workflows/docker-Espressif.yml
+++ b/.github/workflows/docker-Espressif.yml
@@ -1,13 +1,6 @@
 name: Espressif examples tests
-concurrency:
-  group: ${{ github.head_ref || github.run_id }}
-#  cancel-in-progress: true
-
 on:
-  push:
-    branches: [ 'master', 'main', 'release/**' ]
-  pull_request:
-    branches: [ '*' ]
+  workflow_call:
 
 jobs:
   espressif_latest:

--- a/.github/workflows/docker-OpenWrt.yml
+++ b/.github/workflows/docker-OpenWrt.yml
@@ -1,15 +1,9 @@
 # This workflow tests out new libraries with existing OpenWrt builds to check
 # there aren't any compatibility issues. Take a look at Docker/OpenWrt/README.md
 name: OpenWrt test
-concurrency:
-    group: ${{ github.head_ref || github.run_id }}
-#    cancel-in-progress: true
 
 on:
-    push:
-        branches: [ 'master', 'main', 'release/**' ]
-    pull_request:
-        branches: [ '*' ]
+    workflow_call:
 
 jobs:
     build_library:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,8 @@ on:
     branches: [ '*' ]
 
 jobs:
-    stategy:
-        matrix:
-            workflow: [ docker-Espressif docker-OpenWrt multi-compiler os-check ]
     call_workflow:
+        stategy:
+            matrix:
+                workflow: [ docker-Espressif docker-OpenWrt multi-compiler os-check ]
         uses: ./.github/workflows/${{ matrix.workflow }}.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: wolfSSL CI tests
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [ '*' ]
+#    branches: [ 'master', 'main', 'release/**' ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+    stategy:
+        matrix:
+            workflow: [ docker-Espressif docker-OpenWrt multi-compiler os-check ]
+    call_workflow:
+        uses: ./.github/workflows/${{ matrix.workflow }}.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,11 +11,8 @@ on:
     branches: [ '*' ]
 
 jobs:
-    call_docker-Espressif:
-        uses: ./.github/workflows/docker-Espressif.yml
-    call_multi-compiler:
-        uses: ./.github/workflows/multi-compiler.yml
-    call_docker-OpenWrt:
-        uses: ./.github/workflows/docker-OpenWrt.yml
-    call_os-check:
-        uses: ./.github/workflows/os-check.yml
+    call_workflows:
+        strategy:
+            matrix:
+                workflow: [ docker-Espressif, multi-compiler, docker-OpenWrt, os-check ]
+        uses: ./.github/workflows/${{ matrix.workflow }}.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,14 +5,16 @@ concurrency:
 
 on:
   push:
-    branches: [ '*' ]
-#    branches: [ 'master', 'main', 'release/**' ]
+    branches: [ 'master', 'main', 'release/**' ]
   pull_request:
     branches: [ '*' ]
 
 jobs:
-    call_workflows:
-        strategy:
-            matrix:
-                workflow: [ "docker-Espressif.yml", "multi-compiler.yml", "docker-OpenWrt.yml", "os-check.yml" ]
-        uses: ./.github/workflows/${{ matrix.workflow }}
+    call_docker-Espressif:
+        uses: ./.github/workflows/docker-Espressif.yml
+    call_multi-compiler:
+        uses: ./.github/workflows/multi-compiler.yml
+    call_docker-OpenWrt:
+        uses: ./.github/workflows/docker-OpenWrt.yml
+    call_os-check:
+        uses: ./.github/workflows/os-check.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,11 @@ on:
     branches: [ '*' ]
 
 jobs:
-    call_workflow:
-        stategy:
-            matrix:
-                workflow: [ docker-Espressif docker-OpenWrt multi-compiler os-check ]
-        uses: ./.github/workflows/${{ matrix.workflow }}.yml
+    call_docker-Espressif:
+        uses: ./.github/workflows/docker-Espressif.yml
+    call_multi-compiler:
+        uses: ./.github/workflows/multi-compiler.yml
+    call_docker-OpenWrt:
+        uses: ./.github/workflows/docker-OpenWrt.yml
+    call_os-check:
+        uses: ./.github/workflows/os-check.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,5 +14,5 @@ jobs:
     call_workflows:
         strategy:
             matrix:
-                workflow: [ docker-Espressif, multi-compiler, docker-OpenWrt, os-check ]
-        uses: ./.github/workflows/${{ matrix.workflow }}.yml
+                workflow: [ "docker-Espressif.yml", "multi-compiler.yml", "docker-OpenWrt.yml", "os-check.yml" ]
+        uses: ./.github/workflows/${{ matrix.workflow }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 #    branches: [ 'master', 'main', 'release/**' ]
   pull_request:
     branches: [ '*' ]
-
+# noop comment
 jobs:
     call_docker-Espressif:
         uses: ./.github/workflows/docker-Espressif.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 #    branches: [ 'master', 'main', 'release/**' ]
   pull_request:
     branches: [ '*' ]
-# noop comment
+
 jobs:
     call_docker-Espressif:
         uses: ./.github/workflows/docker-Espressif.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: wolfSSL CI tests
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/multi-compiler.yml
+++ b/.github/workflows/multi-compiler.yml
@@ -1,13 +1,7 @@
 name: Multiple compilers and versions
-concurrency:
-  group: ${{ github.head_ref || github.run_id }}
-#  cancel-in-progress: true
 
 on:
-  push:
-    branches: [ 'master', 'main', 'release/**' ]
-  pull_request:
-    branches: [ '*' ]
+  workflow_call:
 
 jobs:
   my_matrix:

--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -1,13 +1,7 @@
 name: Ubuntu-Macos-Windows Tests
-concurrency:
-  group: ${{ github.head_ref || github.run_id }}
-#  cancel-in-progress: true
 
 on:
-  push:
-    branches: [ 'master', 'main', 'release/**' ]
-  pull_request:
-    branches: [ '*' ]
+  workflow_call:
 
 jobs:
   make_check:


### PR DESCRIPTION
# Description

This should fix the issue with tests being cancelled randomly for PRs and ultimately Pushes to 'master'. The problem was that each workflow had the same concurrency name. In order to have all the workflows cancelled when a new one supersedes them it is better to put it in a master workflow that calls the sub-workflows. This also makes the visualization easier to navigate.