### PR TITLE
Fixes and cleanups for STM32

### DIFF
--- a/IDE/STM32Cube/default_conf.ftl
+++ b/IDE/STM32Cube/default_conf.ftl
@@ -64,8 +64,12 @@ extern ${variable.value} ${variable.name};
 /* ------------------------------------------------------------------------- */
 /* Hardware platform */
 /* ------------------------------------------------------------------------- */
+/* Setup default (No crypto hardware acceleration or TLS UART test).
+ * Use undef in platform section to enable it.
+ */
 #define NO_STM32_HASH
 #define NO_STM32_CRYPTO
+#define NO_TLS_UART_TEST
 
 #if defined(STM32WB55xx)
     #define WOLFSSL_STM32WB
@@ -97,6 +101,9 @@ extern ${variable.value} ${variable.name};
     #define WOLFSSL_STM32H7
     #undef  NO_STM32_HASH
     #undef  NO_STM32_CRYPTO
+    #define HAL_CONSOLE_UART huart3
+#elif defined(STM32H723xx)
+    #define WOLFSSL_STM32H7
     #define HAL_CONSOLE_UART huart3
 #elif defined(STM32L4A6xx)
     #define WOLFSSL_STM32L4
@@ -130,12 +137,12 @@ extern ${variable.value} ${variable.name};
     #define WOLFSSL_STM32F4
     #define HAL_CONSOLE_UART huart2
     #define NO_STM32_RNG
-    #define WOLFSSL_GENSEED_FORTEST
+    #define WOLFSSL_GENSEED_FORTEST /* no HW RNG is available use test seed */
 #elif defined(STM32G071xx)
     #define WOLFSSL_STM32G0
     #define HAL_CONSOLE_UART huart2
     #define NO_STM32_RNG
-    #define WOLFSSL_GENSEED_FORTEST
+    #define WOLFSSL_GENSEED_FORTEST /* no HW RNG is available use test seed */
 #elif defined(STM32U575xx) || defined(STM32U585xx)
     #define HAL_CONSOLE_UART huart1
     #define WOLFSSL_STM32U5

--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -306,13 +306,15 @@ int wc_Stm32_Hash_Update(STM32_HASH_Context* stmCtx, word32 algo,
     }
 
     if (wroteToFifo) {
-        /* If we wrote a block send one more 32-bit to FIFO to trigger
-         * start. We cannot leave 16 deep FIFO filled before saving off
-         * context */
+    #if defined(STM32_HASH_FIFO_SIZE) && STM32_HASH_FIFO_SIZE > 1
+        /* If FIFO depth > 1 and we wrote a block send one more 32-bit to
+         * FIFO to trigger start. We cannot leave 16 deep FIFO filled before
+         * saving off context */
         wc_Stm32_Hash_Data(stmCtx, 4);
         stmCtx->fifoBytes += 4;
 
         (void)wc_Stm32_Hash_WaitDone(stmCtx);
+    #endif
 
         /* save hash state for next operation */
         wc_Stm32_Hash_SaveContext(stmCtx);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -13065,7 +13065,7 @@ WOLFSSL_TEST_SUBROUTINE int memory_test(void)
     }
 #endif
 
-#if !defined(USE_FAST_MATH) && !defined(WOLFSSL_NO_MALLOC)
+#if !defined(USE_FAST_MATH) && !defined(WOLFSSL_NO_MALLOC) && defined(XREALLOC)
     /* realloc test */
     {
         byte *c = NULL;

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -806,12 +806,11 @@ extern void uITRON4_free(void *p) ;
         #define XMALLOC(s, h, type)  pvPortMalloc((s))
         #define XFREE(p, h, type)    vPortFree((p))
         /* FreeRTOS pvPortRealloc() implementation can be found here:
-            https://github.com/wolfSSL/wolfssl-freertos/pull/3/files */
-        #if !defined(USE_FAST_MATH) || defined(HAVE_ED25519) || \
-            defined(HAVE_ED448)
+         * https://github.com/wolfSSL/wolfssl-freertos/pull/3/files */
+        #if defined(USE_INTEGER_HEAP_MATH) || defined(OPENSSL_EXTRA)
             #if defined(WOLFSSL_ESPIDF)
-                /*In IDF, realloc(p, n) is equivalent to
-                heap_caps_realloc(p, s, MALLOC_CAP_8BIT) */
+                /* In IDF, realloc(p, n) is equivalent to
+                 * heap_caps_realloc(p, s, MALLOC_CAP_8BIT) */
                 #define XREALLOC(p, n, h, t) realloc((p), (n))
             #else
                 #define XREALLOC(p, n, h, t) pvPortRealloc((p), (n))
@@ -2884,6 +2883,10 @@ extern void uITRON4_free(void *p) ;
     #define HAVE_HPKE
 #endif
 
+/* Provide way to forcefully disable use of XREALLOC */
+#ifdef WOLFSSL_NO_REALLOC
+    #undef XREALLOC
+#endif
 
 
 /* ---------------------------------------------------------------------------


### PR DESCRIPTION
# Description

Fixes and cleanups for STM32:
* Fix for STM32 Hash peripherals (like on F437) with FIFO depth = 1. Broken in 
* Cleanups for `XREALLOC` and new `WOLFSSL_NO_REALLOC` to force undef of `XREALLOC`.
* Change STM32 Cube to default to `NO_TLS_UART_TEST`.

Fixes ZD 15451

# Testing

On STM32F437

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
