### PR TITLE
ESP32 SHA384 fixes

### DIFF
--- a/wolfcrypt/src/port/Espressif/esp32_sha.c
+++ b/wolfcrypt/src/port/Espressif/esp32_sha.c
@@ -507,8 +507,7 @@ int wc_esp_digest_state(WC_ESP32SHA* ctx, byte* hash)
 
     #if defined(WOLFSSL_SHA384)
         case SHA2_384:
-            SHA_LOAD_REG = SHA_384_LOAD_REG;
-            SHA_BUSY_REG = SHA_384_BUSY_REG;
+            DPORT_REG_WRITE(SHA_384_LOAD_REG, 1);
             break;
     #endif
 

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -1306,7 +1306,7 @@ static int InitSha384(wc_Sha384* sha384)
     sha384->ctx.isfirstblock = 1;
     if(sha384->ctx.mode == ESP32_SHA_HW) {
         /* release hw */
-        esp_sha_hw_unlock(&(sha512->ctx));
+        esp_sha_hw_unlock(&(sha384->ctx));
     }
     /* always set mode as INIT
     *  whether using HW or SW is determined at first call of update()


### PR DESCRIPTION
# Description

This is a minor change to fix the (normally disabled) SHA384 Espressif ESP32 hardware acceleration code as noted in https://github.com/wolfSSL/wolfssl/issues/6026 and https://github.com/wolfSSL/wolfssl/issues/6024

Fixes zd# n/a

# Testing

Add `#define WOLFSSL_SHA384` to project `user_settings.h` and run [Espressif wolf_ssltest](https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/wolfssl_test). 

Confirm app compiles without error and observe output, note in particular new `SHA-384 test` passing:

```
ets Jun  8 2016 00:22:57

rst:0x3 (SW_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
configsip: 0, SPIWP:0xee
clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
mode:DIO, clock div:2
load:0x3fff0030,len:7000
load:0x40078000,len:15452
ho 0 tail 12 room 4
load:0x40080400,len:3840
entry 0x4008064c
I (28) boot: ESP-IDF v5.0-dirty 2nd stage bootloader
I (28) boot: compile time 17:08:28
I (28) boot: chip revision: v1.0
I (31) boot_comm: chip revision: 1, min. bootloader chip revision: 0
I (38) boot.esp32: SPI Speed      : 40MHz
I (43) boot.esp32: SPI Mode       : DIO
I (47) boot.esp32: SPI Flash Size : 2MB
I (52) boot: Enabling RNG early entropy source...
I (57) boot: Partition Table:
I (61) boot: ## Label            Usage          Type ST Offset   Length
I (68) boot:  0 nvs              WiFi data        01 02 00009000 00006000
I (76) boot:  1 phy_init         RF data          01 01 0000f000 00001000
I (83) boot:  2 factory          factory app      00 00 00010000 00177000
I (91) boot: End of partition table
I (95) boot_comm: chip revision: 1, min. application chip revision: 0
I (102) esp_image: segment 0: paddr=00010020 vaddr=3f400020 size=17180h ( 94592) map
I (145) esp_image: segment 1: paddr=000271a8 vaddr=3ffb0000 size=027d0h ( 10192) load
I (149) esp_image: segment 2: paddr=00029980 vaddr=40080000 size=06698h ( 26264) load
I (161) esp_image: segment 3: paddr=00030020 vaddr=400d0020 size=42fd4h (274388) map
I (261) esp_image: segment 4: paddr=00072ffc vaddr=40086698 size=05584h ( 21892) load
I (270) esp_image: segment 5: paddr=00078588 vaddr=50000000 size=00010h (    16) load
I (276) boot: Loaded app from partition at offset 0x10000
I (276) boot: Disabling RNG early entropy source...
I (292) cpu_start: Pro cpu up.
I (292) cpu_start: Starting app cpu, entry point is 0x4008112c
I (278) cpu_start: App cpu up.
I (306) cpu_start: Pro cpu start user code
I (306) cpu_start: cpu freq: 160000000 Hz
I (306) cpu_start: Application information:
I (311) cpu_start: Project name:     wolfssl_test
I (316) cpu_start: App version:      v4.8.0-stable-4470-g53d6e79f8-d
I (323) cpu_start: Compile time:     Jan 30 2023 17:09:49
I (329) cpu_start: ELF file SHA256:  4836b4da9b0ebf26...
I (335) cpu_start: ESP-IDF:          v5.0-dirty
I (341) heap_init: Initializing. RAM available for dynamic allocation:
I (348) heap_init: At 3FFAE6E0 len 00001920 (6 KiB): DRAM
I (354) heap_init: At 3FFB30E0 len 0002CF20 (179 KiB): DRAM
I (360) heap_init: At 3FFE0440 len 00003AE0 (14 KiB): D/IRAM
I (366) heap_init: At 3FFE4350 len 0001BCB0 (111 KiB): D/IRAM
I (373) heap_init: At 4008BC1C len 000143E4 (80 KiB): IRAM
I (381) spi_flash: detected chip: generic
I (384) spi_flash: flash io: dio
W (388) spi_flash: Detected size(4096k) larger than the size in the binary image header(2048k). Using the size in the binary i
mage header.
I (402) cpu_start: Starting scheduler on PRO CPU.
I (0) cpu_start: Starting scheduler on APP CPU.
I (412) wolfssl_test: --------------------------------------------------------
I (422) wolfssl_test: --------------------------------------------------------
I (432) wolfssl_test: ---------------------- BEGIN MAIN ----------------------
I (432) wolfssl_test: --------------------------------------------------------
I (442) wolfssl_test: --------------------------------------------------------
I (452) wolfssl_test: CONFIG_IDF_TARGET = esp32
I (452) wolfssl_test: LIBWOLFSSL_VERSION_STRING = 5.5.4
I (462) wolfssl_test: CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ = 160 MHz
I (472) wolfssl_test: Xthal_have_ccount = 1
I (472) wolfssl_test: Stack HWM: 53664

I (482) wolfssl_test: ESP32WROOM32_CRYPT is enabled.
------------------------------------------------------------------------------
 wolfSSL version 5.5.4
------------------------------------------------------------------------------
error    test passed!
MEMORY   test passed!
base64   test passed!
asn      test passed!
RANDOM   test passed!
MD5      test passed!
MD4      test passed!
SHA      test passed!
SHA-256  test passed!
SHA-384  test passed!
SHA-512  test passed!
Hash     test passed!
HMAC-MD5 test passed!
HMAC-SHA test passed!
HMAC-SHA256 test passed!
HMAC-SHA384 test passed!
HMAC-SHA512 test passed!
HMAC-KDF    test passed!
TLSv1.3 KDF test passed!
GMAC     test passed!
DES      test passed!
DES3     test passed!
AES      test passed!
AES192   test passed!
AES256   test passed!
AES-GCM  test passed!
RSA      test passed!
PWDBASED test passed!
ECC      test passed!
ECC buffer test passed!
CURVE25519 test passed!
ED25519  test passed!
logging  test passed!
time test passed!
mutex    test passed!
Test complete
I (114412) wolfcrypt_test: Exiting main with return code:  0

I (114412) wolfssl_test: wolf_test_task complete success result code = 0

```


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
