### PR TITLE
Initialize `OPENSSL_ALL` local size / length / type vars

### DIFF
--- a/src/pk.c
+++ b/src/pk.c
@@ -3372,9 +3372,9 @@ int wolfSSL_RSA_padding_add_PKCS1_PSS(WOLFSSL_RSA *rsa, unsigned char *em,
 {
     int ret = 1;
     enum wc_HashType hashType;
-    int hashLen;
-    int emLen;
-    int mgf;
+    int hashLen = 0;
+    int emLen = 0;
+    int mgf = 0;
     int initTmpRng = 0;
     WC_RNG *rng = NULL;
 #ifdef WOLFSSL_SMALL_STACK
@@ -3504,11 +3504,11 @@ int wolfSSL_RSA_verify_PKCS1_PSS(WOLFSSL_RSA *rsa, const unsigned char *mHash,
                                  const unsigned char *em, int saltLen)
 {
     int ret = 1;
-    int hashLen;
-    int mgf;
-    int emLen;
-    int mPrimeLen;
-    enum wc_HashType hashType;
+    int hashLen = 0;
+    int mgf = 0;
+    int emLen = 0;
+    int mPrimeLen = 0;
+    enum wc_HashType hashType = WC_HASH_TYPE_NONE;
     byte *mPrime = NULL;
     byte *buf = NULL;
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -38119,7 +38119,7 @@ int wolfSSL_PEM_write_bio_PKCS8PrivateKey(WOLFSSL_BIO* bio,
     byte* key = NULL;
     word32 keySz;
     byte* pem = NULL;
-    int pemSz;
+    int pemSz = 0;
     int type = PKCS8_PRIVATEKEY_TYPE;
     int algId;
     const byte* curveOid;


### PR DESCRIPTION
# Description

Related to https://github.com/wolfSSL/wolfssl/issues/6025 and first observed in https://github.com/wolfSSL/wolfssl/issues/6028 when turning on `#define OPENSSL_ALL` on the Espressif ESP32, this PR initializes some variables to appease the compiler that otherwise complains and fails.

Fixes zd# n/a

# Testing

I do not yet have OpenSSL layer working on the ESP32. Changes in this PR were not tested locally. Relying on Jenkins.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
