### PR TITLE
wolfssl_make_global_rng() - Fix prototype to have void

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -321,7 +321,7 @@ WC_RNG* wolfssl_get_global_rng(void)
  * @return  Global RNG on success.
  * @return  NULL on error.
  */
-WC_RNG* wolfssl_make_global_rng()
+WC_RNG* wolfssl_make_global_rng(void)
 {
     WC_RNG* ret;
 


### PR DESCRIPTION
# Description

Missing void parameter in function wolfssl_make_global_rng.

# Testing

Standard

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
