### PR TITLE
SP int: sp_invmod_mont_ct check err before setting

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -12013,7 +12013,9 @@ int sp_invmod_mont_ct(const sp_int* a, const sp_int* m, sp_int* r,
                 s = bit;
 
                 /* 6.4.4. t = (t * pre[j-1]) mod m */
-                err = sp_mul(t, pre[j-1], t);
+                if (err == MP_OKAY) {
+                    err = sp_mul(t, pre[j-1], t);
+                }
                 if (err == MP_OKAY) {
                     err = _sp_mont_red(t, m, mp);
                 }
@@ -12034,6 +12036,8 @@ int sp_invmod_mont_ct(const sp_int* a, const sp_int* m, sp_int* r,
                 err = _sp_mont_red(t, m, mp);
             }
         }
+    }
+    if (err == MP_OKAY) {
         /* 8. If j > 0 then r = (t * pre[j-1]) mod m */
         if (j > 0) {
             err = sp_mul(t, pre[j-1], r);


### PR DESCRIPTION
# Description

Two places in sp_invmod_mont_ct were not checking err is set before performing a new operation and setting err. Change to check error before performing operation.

Fixes zd#15574

# Testing

Standard

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
