### PR TITLE
SRTP Marshaling

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -5698,12 +5698,13 @@ static word16 TLSX_UseSRTP_Write(TlsxSrtp* srtp, byte* output)
     word16 offset = 0;
     int i, j;
 
-    c16toa(srtp->profileCount*2, output+offset);
+    c16toa(srtp->profileCount * 2, output + offset);
     offset += OPAQUE16_LEN;
-    for (i=0; i< srtp->profileCount; i+=2) {
-        for (j=0; j<16; j++) {
+    j = 0;
+    for (i = 0; i < srtp->profileCount; i++) {
+        for (; j < 16; j++) {
             if (srtp->ids & (1 << j)) {
-                c16toa(j, output+offset);
+                c16toa(j, output + offset);
                 offset += OPAQUE16_LEN;
             }
         }


### PR DESCRIPTION
# Description

Changed the loop over the SRTP setting bitfield when it is encoded for the TLS extension. Fixes issue #6044.

# Testing

    % ./configure --enable-srtp --enable-dtls --enable-dtls13
    % ./examples/server/server -u -d -l ECDHE-RSA-AES256-GCM-SHA384 --srtp SRTP_AES128_CM_SHA1_32:SRTP_NULL_SHA1_80:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM -2
    % ./examples/client/client -u -x --srtp SRTP_AES128_CM_SHA1_32:SRTP_NULL_SHA1_80:SRTP_AEAD_AES_128_GCM:SRTP_AEAD_AES_256_GCM -l ECDHE-RSA-AES256-GCM-SHA384 -2

On top of that, I added some print statements to verify everything is copacetic. In TLSX_UseSRTP_GetSize() I printed out the calculated size. In TLSX_UseSRTP_Write() I printed the final offset value and the actual output. The output was checked before and after the fix.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
