### PR TITLE
Ref counting: rework for static analysers

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -2155,12 +2155,16 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
     }
 
     wolfSSL_RefInit(&ctx->ref, &ret);
+#ifdef WOLFSSL_REFCNT_ERROR_RETURN
     if (ret < 0) {
         WOLFSSL_MSG("Mutex error on CTX init");
         ctx->err = CTX_INIT_MUTEX_E;
         WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
         return BAD_MUTEX_E;
     }
+#else
+    (void)ret;
+#endif
 
 #ifndef NO_CERTS
     ctx->privateKeyDevId = INVALID_DEVID;
@@ -2621,6 +2625,7 @@ void FreeSSL_Ctx(WOLFSSL_CTX* ctx)
 
     /* decrement CTX reference count */
     wolfSSL_RefDec(&ctx->ref, &isZero, &ret);
+#ifdef WOLFSSL_REFCNT_ERROR_RETURN
     if (ret < 0) {
         /* check error state, if mutex error code then mutex init failed but
          * CTX was still malloc'd */
@@ -2633,6 +2638,9 @@ void FreeSSL_Ctx(WOLFSSL_CTX* ctx)
         }
         return;
     }
+#else
+    (void)ret;
+#endif
 
     if (isZero) {
         WOLFSSL_MSG("CTX ref count down to 0, doing full free");
@@ -6188,9 +6196,13 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
 
     /* increment CTX reference count */
     wolfSSL_RefInc(&ctx->ref, &ret);
+#ifdef WOLFSSL_REFCNT_ERROR_RETURN
     if (ret < 0) {
         return ret;
     }
+#else
+    (void)ret;
+#endif
     ret = WOLFSSL_SUCCESS; /* set default ret */
 
     ssl->ctx     = ctx; /* only for passing to calls, options could change */

--- a/src/x509_str.c
+++ b/src/x509_str.c
@@ -725,8 +725,12 @@ WOLFSSL_X509_STORE* wolfSSL_X509_STORE_new(void)
     store->isDynamic = 1;
 
     wolfSSL_RefInit(&store->ref, &ret);
+#ifdef WOLFSSL_REFCNT_ERROR_RETURN
     if (ret != 0)
         goto err_exit;
+#else
+    (void)ret;
+#endif
 
     if ((store->cm = wolfSSL_CertManagerNew()) == NULL)
         goto err_exit;
@@ -775,9 +779,13 @@ void wolfSSL_X509_STORE_free(WOLFSSL_X509_STORE* store)
     if (store != NULL && store->isDynamic) {
         int ret;
         wolfSSL_RefDec(&store->ref, &doFree, &ret);
+    #ifdef WOLFSSL_REFCNT_ERROR_RETURN
         if (ret != 0) {
             WOLFSSL_MSG("Couldn't lock store mutex");
         }
+    #else
+        (void)ret;
+    #endif
 
         if (doFree) {
 #ifdef HAVE_EX_DATA_CLEANUP_HOOKS
@@ -839,10 +847,14 @@ int wolfSSL_X509_STORE_up_ref(WOLFSSL_X509_STORE* store)
     if (store) {
         int ret;
         wolfSSL_RefInc(&store->ref, &ret);
+    #ifdef WOLFSSL_REFCNT_ERROR_RETURN
         if (ret != 0) {
             WOLFSSL_MSG("Failed to lock store mutex");
             return WOLFSSL_FAILURE;
         }
+    #else
+        (void)ret;
+    #endif
 
         return WOLFSSL_SUCCESS;
     }

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -9386,9 +9386,13 @@ int wolfSSL_EVP_PKEY_up_ref(WOLFSSL_EVP_PKEY* pkey)
     if (pkey) {
         int ret;
         wolfSSL_RefInc(&pkey->ref, &ret);
+    #ifdef WOLFSSL_REFCNT_ERROR_RETURN
         if (ret != 0) {
             WOLFSSL_MSG("Failed to lock pkey mutex");
         }
+    #else
+        (void)ret;
+    #endif
 
         return WOLFSSL_SUCCESS;
     }
@@ -9498,12 +9502,15 @@ WOLFSSL_EVP_PKEY* wolfSSL_EVP_PKEY_new_ex(void* heap)
         }
 
         wolfSSL_RefInit(&pkey->ref, &ret);
+    #ifdef WOLFSSL_REFCNT_ERROR_RETURN
         if (ret != 0){
             wolfSSL_EVP_PKEY_free(pkey);
             WOLFSSL_MSG("Issue initializing mutex");
             return NULL;
         }
-
+    #else
+        (void)ret;
+    #endif
     }
     else {
         WOLFSSL_MSG("memory failure");
@@ -9519,9 +9526,13 @@ void wolfSSL_EVP_PKEY_free(WOLFSSL_EVP_PKEY* key)
     if (key != NULL) {
         int ret;
         wolfSSL_RefDec(&key->ref, &doFree, &ret);
+    #ifdef WOLFSSL_REFCNT_ERROR_RETURN
         if (ret != 0) {
             WOLFSSL_MSG("Couldn't lock pkey mutex");
         }
+    #else
+        (void)ret;
+    #endif
 
         if (doFree) {
             wc_FreeRng(&key->rng);

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -1098,6 +1098,8 @@ void wolfSSL_RefDec(wolfSSL_Ref* ref, int* isZero, int* err)
     int ret = wc_LockMutex(&ref->mutex);
     if (ret != 0) {
         WOLFSSL_MSG("Failed to lock mutex for reference decrement!");
+        /* Can't say count is zero. */
+        *isZero = 0;
     }
     else {
         if (ref->count > 0) {

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -295,6 +295,7 @@ typedef struct wolfSSL_Ref {
 } wolfSSL_Ref;
 
 #ifdef SINGLE_THREADED
+
 #define wolfSSL_RefInit(ref, err)            \
     do {                                     \
         (ref)->count = 1;                    \
@@ -312,7 +313,9 @@ typedef struct wolfSSL_Ref {
         *(isZero) = ((ref)->count == 0);     \
         *(err) = 0;                          \
     } while(0)
+
 #elif defined(HAVE_C___ATOMIC)
+
 #define wolfSSL_RefInit(ref, err)            \
     do {                                     \
         (ref)->count = 1;                    \
@@ -332,11 +335,16 @@ typedef struct wolfSSL_Ref {
         *(isZero) = ((ref)->count == 0);     \
         *(err) = 0;                          \
     } while(0)
+
 #else
+
+#define WOLFSSL_REFCNT_ERROR_RETURN
+
 WOLFSSL_LOCAL void wolfSSL_RefInit(wolfSSL_Ref* ref, int* err);
 WOLFSSL_LOCAL void wolfSSL_RefFree(wolfSSL_Ref* ref);
 WOLFSSL_LOCAL void wolfSSL_RefInc(wolfSSL_Ref* ref, int* err);
 WOLFSSL_LOCAL void wolfSSL_RefDec(wolfSSL_Ref* ref, int* isZero, int* err);
+
 #endif
 
 


### PR DESCRIPTION
# Description

When always reference counting APIs always return 0 don't check return value for error.
Reference decrement set isZero to false on error.

# Testing

Standard testing

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
