### PR TITLE
fix warning if ltime is unsigned

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -13777,7 +13777,7 @@ int wc_ValidateDate(const byte* date, byte format, int dateType)
     (void)tmpTime;
 
     ltime = wc_Time(0);
-    if (ltime < 0){
+    if (sizeof(ltime) == sizeof(word32) && (int)ltime < 0){
         /* A negative response here could be due to a 32-bit time_t
          * where the year is 2038 or later. */
         WOLFSSL_MSG("wc_Time failed to return a valid value");


### PR DESCRIPTION
Resolves

```
  CC       wolfcrypt/src/src_libwolfssl_la-cryptocb.lo
wolfcrypt/src/asn.c: In function 'wc_ValidateDate':

wolfcrypt/src/asn.c:13780:15: error: comparison of unsigned expression < 0 is always false [-Werror=type-limits]
     if (ltime < 0){
               ^

  CC       wolfcrypt/test/test.o
  ```