### PR TITLE
fix: propagate WOLFSSL_TICKET_RET_CREATE from DoDecryptTicket()

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -34495,7 +34495,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             return BAD_TICKET_KEY_CB_SZ;
         }
         *it = (InternalTicket*)et->enc_ticket;
-        return 0;
+        return ret;
     }
 
     /* Parse ticket sent by client, returns callback return value */
@@ -34508,7 +34508,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         WOLFSSL_ENTER("DoClientTicket");
 
         ret = DoDecryptTicket(ssl, input, len, &it);
-        if (ret != 0)
+        if (ret != WOLFSSL_TICKET_RET_OK && ret != WOLFSSL_TICKET_RET_CREATE)
             return ret;
     #ifdef WOLFSSL_CHECK_MEM_ZERO
         /* Internal ticket successfully decrypted. */

--- a/tests/api.c
+++ b/tests/api.c
@@ -61245,6 +61245,79 @@ static int test_ticket_nonce_malloc(void)
 
 #endif /* WOLFSSL_TICKET_NONCE_MALLOC */
 
+#if defined(HAVE_SESSION_TICKET) && !defined(WOLFSSL_NO_TLS12) && \
+    !defined(WOLFSSL_TICKET_DECRYPT_NO_CREATE) &&                 \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    !defined(WOLFSSL_NO_DEF_TICKET_ENC_CB)
+
+static int test_ticket_ret_create(void)
+{
+    WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
+    WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
+    byte ticket[SESSION_TICKET_LEN];
+    struct test_memio_ctx test_ctx;
+    WOLFSSL_SESSION *sess = NULL;
+    word16 ticketLen;
+    int ret;
+
+    XMEMSET(&test_ctx, 0, sizeof(test_ctx));
+    ret = test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
+        wolfTLSv1_2_client_method, wolfTLSv1_2_server_method);
+    if (ret != 0)
+        return TEST_FAIL;
+    wolfSSL_set_verify(ssl_s, WOLFSSL_VERIFY_NONE, 0);
+    wolfSSL_set_verify(ssl_c, WOLFSSL_VERIFY_NONE, 0);
+    wolfSSL_CTX_UseSessionTicket(ctx_c);
+
+    ret = test_memio_do_handshake(ssl_c, ssl_s, 10, NULL);
+    if (ret != 0)
+        return TEST_FAIL;
+
+    sess = wolfSSL_get1_session(ssl_c);
+    if (sess->ticketLen > SESSION_TICKET_LEN)
+        return TEST_FAIL;
+    ticketLen = sess->ticketLen;
+    XMEMCPY(ticket, sess->ticket, sess->ticketLen);
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+
+    ssl_s = wolfSSL_new(ctx_s);
+    if (ssl_s == NULL)
+        return TEST_FAIL;
+    wolfSSL_SetIOWriteCtx(ssl_s, &test_ctx);
+    wolfSSL_SetIOReadCtx(ssl_s, &test_ctx);
+    ssl_c = wolfSSL_new(ctx_c);
+    if (ssl_c == NULL)
+        return TEST_FAIL;
+    wolfSSL_SetIOWriteCtx(ssl_c, &test_ctx);
+    wolfSSL_SetIOReadCtx(ssl_c, &test_ctx);
+
+    wolfSSL_set_session(ssl_c, sess);
+    ret = test_memio_do_handshake(ssl_c, ssl_s, 10, NULL);
+    if (ret != 0)
+        return TEST_FAIL;
+    if (ssl_c->session->ticketLen > SESSION_TICKET_LEN)
+        return TEST_FAIL;
+    if (ssl_c->session->ticketLen != ticketLen)
+        return TEST_FAIL;
+    if (XMEMCMP(ssl_c->session->ticket, ticket, ticketLen) == 0)
+        return TEST_FAIL;
+
+    wolfSSL_SESSION_free(sess);
+    wolfSSL_free(ssl_c);
+    wolfSSL_free(ssl_s);
+    wolfSSL_CTX_free(ctx_c);
+    wolfSSL_CTX_free(ctx_s);
+
+    return TEST_SUCCESS;
+}
+#else
+static int test_ticket_ret_create(void)
+{
+    return TEST_SKIPPED;
+}
+#endif
+
 /*----------------------------------------------------------------------------*
  | Main
  *----------------------------------------------------------------------------*/
@@ -62236,6 +62309,7 @@ TEST_CASE testCases[] = {
                            !defined(WOLFSSL_NO_CLIENT_AUTH))
     TEST_DECL(test_various_pathlen_chains),
 #endif
+    TEST_DECL(test_ticket_ret_create),
     /* If at some point a stub get implemented this test should fail indicating
      * a need to implement a new test case
      */

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -5221,8 +5221,11 @@ void DEBUG_WRITE_DER(const byte* der, int derSz, const char* fileName);
             defined(HAVE_CHACHA) && defined(HAVE_POLY1305) &&                  \
             defined(WOLFSSL_SHA384) && defined(WOLFSSL_AES_256) &&             \
             defined(HAVE_AESGCM))                                              \
-    )
-
+     ) ||                                                                      \
+    (defined(HAVE_SESSION_TICKET)  && !defined(WOLFSSL_NO_TLS12) &&            \
+    !defined(WOLFSSL_TICKET_DECRYPT_NO_CREATE) &&                              \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) &&              \
+    !defined(WOLFSSL_NO_DEF_TICKET_ENC_CB))
 #define TEST_MEMIO_BUF_SZ (64 * 1024)
 struct test_memio_ctx
 {


### PR DESCRIPTION
# Description
Fix propagation of the DoDecryptTicket() return value. ZD 15386

# Testing

A new test is added in the same PR.

# Checklist

 - [X ] added tests

