### PR TITLE
fix DTLS test case for when able to read peers close notify alert

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -57831,8 +57831,11 @@ static int test_wolfSSL_dtls_fragments(void)
         AssertFalse(func_cb_server.return_code);
 
         /* The socket should be closed by the server resulting in a
-         * socket error */
-        AssertIntEQ(func_cb_client.last_err, SOCKET_ERROR_E);
+         * socket error or reading a close notify alert */
+        if (func_cb_client.last_err != SOCKET_ERROR_E &&
+                func_cb_client.last_err != WOLFSSL_ERROR_ZERO_RETURN) {
+            AssertIntEQ(func_cb_client.last_err, SOCKET_ERROR_E);
+        }
         /* Check the server returned an error indicating the msg buffer
          * was full */
         AssertIntEQ(func_cb_server.last_err, DTLS_TOO_MANY_FRAGMENTS_E);


### PR DESCRIPTION
On FreeBSD the DTLS test case was going on to process the peers close notify alert and not hitting the closed socket error case. This adds a check to the test for if having processed the peers close notify alert.