### PR TITLE
Allow reading ENC EC PRIVATE KEY as well via wolfSSL_PEM_read_bio_ECPrivateKey

### DIFF
--- a/src/pk.c
+++ b/src/pk.c
@@ -11988,7 +11988,7 @@ WOLFSSL_EC_KEY* wolfSSL_PEM_read_bio_ECPrivateKey(WOLFSSL_BIO* bio,
     DerBuffer*      der = NULL;
     int             keyFormat = 0;
 
-    WOLFSSL_ENTER("wolfSSL_PEM_read_bio_EC_PUBKEY");
+    WOLFSSL_ENTER("wolfSSL_PEM_read_bio_ECPrivateKey");
 
     /* Validate parameters. */
     if (bio == NULL) {
@@ -12002,9 +12002,12 @@ WOLFSSL_EC_KEY* wolfSSL_PEM_read_bio_ECPrivateKey(WOLFSSL_BIO* bio,
             err = 1;
         }
     }
-    /* Read a PEM key in to a new DER buffer. */
-    if ((!err) && (pem_read_bio_key(bio, cb, pass, ECC_PRIVATEKEY_TYPE,
-            &keyFormat, &der) <= 0)) {
+    /* Read a PEM key in to a new DER buffer.
+     * To check ENC EC PRIVATE KEY, it uses PRIVATEKEY_TYPE to call
+     * pem_read_bio_key(), and then check key format if it is EC.
+     */
+    if ((!err) && (pem_read_bio_key(bio, cb, pass, PRIVATEKEY_TYPE,
+            &keyFormat, &der) <= 0) && (keyFormat != ECDSAk)) {
         err = 1;
     }
     /* Load the EC key with the private key from the DER encoding. */

--- a/src/pk.c
+++ b/src/pk.c
@@ -12007,7 +12007,11 @@ WOLFSSL_EC_KEY* wolfSSL_PEM_read_bio_ECPrivateKey(WOLFSSL_BIO* bio,
      * pem_read_bio_key(), and then check key format if it is EC.
      */
     if ((!err) && (pem_read_bio_key(bio, cb, pass, PRIVATEKEY_TYPE,
-            &keyFormat, &der) <= 0) && (keyFormat != ECDSAk)) {
+            &keyFormat, &der) <= 0)) {
+        err = 1;
+    }
+    if (keyFormat != ECDSAk) {
+        WOLFSSL_ERROR_MSG("Error not EC key format");
         err = 1;
     }
     /* Load the EC key with the private key from the DER encoding. */


### PR DESCRIPTION
# Description

fix qt qsslkey unit test

Fixes zd# n/a

# Testing

Run Qt unit test

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
