### PR TITLE
Build Fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3956,6 +3956,11 @@ then
     AC_MSG_ERROR([please disable dsa if disabling asn.])
 fi
 
+if test "x$ENABLED_ECC" != "xno" && test "x$ENABLED_ASN" = "xno"
+then
+    AC_MSG_ERROR([please disable ecc if disabling asn.])
+fi
+
 # No Big Int (ASN, DSA, RSA, DH and ECC need bigint)
 if test "$ENABLED_ASN" = "no" && test "$ENABLED_DSA" = "no" && \
    test "$ENABLED_DH" = "no" && test "$ENABLED_ECC" = "no" && \
@@ -6287,11 +6292,6 @@ then
     if test "x$ENABLED_PSK" = "xno" && test "x$ENABLED_ASN" = "xno"
     then
         AC_MSG_ERROR([please enable psk if disabling asn.])
-    fi
-
-    if test "x$ENABLED_ECC" != "xno" && test "x$ENABLED_ASN" = "xno"
-    then
-        AC_MSG_ERROR([please disable ecc if disabling asn.])
     fi
 
     if test "$ENABLED_AFALG" = "yes"

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2605,9 +2605,12 @@ extern void uITRON4_free(void *p) ;
     #define WOLFSSL_NO_XOR_OPS
 #endif
 
-#if defined(NO_ASN) && defined(WOLFCRYPT_ONLY)
+#if defined(NO_ASN) && defined(WOLFCRYPT_ONLY) && !defined(WOLFSSL_WOLFSSH)
     #undef  WOLFSSL_NO_INT_ENCODE
     #define WOLFSSL_NO_INT_ENCODE
+#endif
+
+#if defined(NO_ASN) && defined(WOLFCRYPT_ONLY)
     #undef  WOLFSSL_NO_INT_DECODE
     #define WOLFSSL_NO_INT_DECODE
 #endif


### PR DESCRIPTION
# Description

1. Fails compiling the KDF file, can't find c32toa inline function.
2. In configure, move the check for ECC when ASN is disabled up to the other ASN checks. It also needs to be checked with cryptonly is disabled.

# Testing

./configure --enable-wolfssh --enable-cryptonly --disable-asn --disable-rsa --disable-ecc
./configure --disable-asn --disable-rsa --disable-ecc --enable-psk
./configure --enable-cryptonly --disable-asn --disable-rsa --disable-ecc

I removed some of the expected disables and it complained during configure.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
