### PR TITLE
Add WOLFSSL_IP_ALT_NAME to --enable-curl; fix unused error in FindPsk

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6025,6 +6025,12 @@ then
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALT_CERT_CHAINS"
     fi
 
+    if test "xENABLE_IP_ALT_NAME" = "xno"
+    then
+        ENABLE_IP_ALT_NAME="yes"
+        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_IP_ALT_NAME"
+    fi
+
     if test "x$ENABLED_SESSION_TICKET" = "xno"
     then
         ENABLED_SESSION_TICKET="yes"

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5507,6 +5507,7 @@ static int FindPsk(WOLFSSL* ssl, PreSharedKey* psk, const byte* suite, int* err)
             /* Check whether PSK ciphersuite is in SSL. */
             found = (suite[0] == cipherSuite0) && (suite[1] == cipherSuite);
         #else
+            (void)suite;
             /* Check whether PSK ciphersuite is in SSL. */
             {
                 byte s[2] = {


### PR DESCRIPTION
# Description

* Add WOLFSSL_IP_ALT_NAME to --enable-curl
* Fix unused error in FindPsk

Fixes #6063 

# Testing

Instructions in #6063 

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
