### PR TITLE
Spelling cleanup: configure.ac, ssl.c, ssl.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -577,7 +577,7 @@ if test "$ENABLED_SP_ASM" != "no"
 then
     if test "$ENABLED_SP" = "no"
     then
-        AC_MSG_ERROR([--enable-sp-asm requries SP to be enabled.])
+        AC_MSG_ERROR([--enable-sp-asm requires SP to be enabled.])
     fi
     if test "$ENABLED_SP" = ""
     then
@@ -4844,7 +4844,7 @@ AC_ARG_WITH([user-crypto],
 
 if test "$ENABLED_USER_CRYPTO" = "yes" && test "$ENABLED_FIPS" = "yes"
 then
-    AC_MSG_ERROR([cannot enable user crypto and fips, user crypto posibility of using code in fips boundary.])
+    AC_MSG_ERROR([cannot enable user crypto and fips, user crypto possibility of using code in fips boundary.])
 fi
 
 # Whitewood netRandom client library
@@ -5325,7 +5325,7 @@ then
     AM_CFLAGS="$AM_CFLAGS -DASN_BER_TO_DER"
 fi
 
-# Alternate certification chains, as oppossed to requiring full chain validataion.
+# Alternate certification chains, as opposed to requiring full chain validation.
 # Certificate validation behavior is relaxed, similar to openssl and
 # browsers. Only the peer certificate must validate to a trusted
 # certificate. Without this, all certificates sent by a peer must be
@@ -7142,7 +7142,7 @@ if test "$ENABLED_FAST_RSA" = "yes"; then
         esac
 
         if test "$fastRSA_found" = "yes"; then
-            # was succesfull so add tested LDFLAGS to AM_ flags
+            # was successful so add tested LDFLAGS to AM_ flags
             AM_LDFLAGS="${AM_LDFLAGS} ${LDFLAGS}"
             AM_CPPFLAGS="${AM_CPPFLAGS} ${CPPFLAGS}"
             IPPHEADERS="${srcdir}/IPP/include/*.h"
@@ -7574,7 +7574,7 @@ then
     ENABLED_TRUSTED_PEER_CERT=yes
 fi
 
-# dertermine if we have key validation mechanism
+# determine if we have key validation mechanism
 if test "x$ENABLED_ECC" != "xno" || test "x$ENABLED_RSA" = "xyes"
 then
     if test "x$ENABLED_ASN" = "xyes"

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -206,7 +206,7 @@
     !defined(WOLFCRYPT_ONLY)
 /* Convert shortname to NID.
  *
- * For OpenSSL compatability.
+ * For OpenSSL compatibility.
  *
  * This function shouldn't exist!
  * Uses defines in wolfssl/openssl/evp.h.
@@ -6228,7 +6228,7 @@ int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify)
             #else
                 /* ClientSession objects are lightweight (compared to
                  * WOLFSSL_SESSION) so to decrease chance that user will reuse
-                 * thse wrong session, increase the ClientCache size. This will
+                 * the wrong session, increase the ClientCache size. This will
                  * make the entire ClientCache about the size of one
                  * WOLFSSL_SESSION object. */
                 #define CLIENT_SESSIONS_MULTIPLIER 8
@@ -11331,7 +11331,7 @@ WOLFSSL_SESSION* wolfSSL_get_session(WOLFSSL* ssl)
         return ssl->session;
 #else
         if (ssl->options.side == WOLFSSL_CLIENT_END) {
-            /* On the client side we want to return a persistant reference for
+            /* On the client side we want to return a persistent reference for
              * backwards compatibility. */
 #ifndef NO_CLIENT_CACHE
             if (ssl->clientSession) {
@@ -15023,7 +15023,7 @@ ClientSession* AddSessionToClientCache(int side, int row, int idx, byte* serverI
             }
             else {
                 error = -1;
-                ClientCache[clientRow].nextIdx = 0; /* reset index as saftey */
+                ClientCache[clientRow].nextIdx = 0; /* reset index as safety */
                 WOLFSSL_MSG("Invalid client cache index! "
                             "Possible corrupted memory");
             }
@@ -15353,7 +15353,7 @@ int AddSessionToCache(WOLFSSL_CTX* ctx, WOLFSSL_SESSION* addSession,
     }
 #ifdef HAVE_SESSION_TICKET
     else if (ticBuffUsed) {
-        /* Error occured. Need to clean up the ticket buffer. */
+        /* Error occurred. Need to clean up the ticket buffer. */
         cacheSession->ticket = cacheSession->staticTicket;
         cacheSession->ticketLenAlloc = 0;
         cacheSession->ticketLen = 0;
@@ -16777,7 +16777,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         /* This function is currently the same as
         wolfSSL_OpenSSL_add_all_algorithms_noconf since we do not employ
         the use of a wolfssl.cnf type configuration file and is only used for
-        OpenSSL compatability. */
+        OpenSSL compatibility. */
 
         if (wolfSSL_add_all_algorithms() == WOLFSSL_FATAL_ERROR) {
             return WOLFSSL_FATAL_ERROR;
@@ -17587,7 +17587,7 @@ cleanup:
         ctx->x509_store.cache = str->cache;
         ctx->x509_store_pt    = str; /* take ownership of store and free it
                                         with CTX free */
-        ctx->cm->x509_store_p = ctx->x509_store_pt;/* CTX has onwership
+        ctx->cm->x509_store_p = ctx->x509_store_pt;/* CTX has ownership
                                                     and free it with CTX free*/
     }
 
@@ -38923,7 +38923,7 @@ void wolfSSL_THREADID_current(WOLFSSL_CRYPTO_THREADID* id)
     return;
 }
 /* wolfSSL_THREADID_hash is provided as a compatible API with
- * CRYPTO_THREADID_hash which returns a hash value calcurated from the
+ * CRYPTO_THREADID_hash which returns a hash value calculated from the
  * specified thread id. However, CRYPTO_THREADID_hash API has been
  * deprecated and no longer exists in the OpenSSL 1.0.0 or later.
  * This API only works as a stub to returns 0. This behavior is
@@ -39049,7 +39049,7 @@ int wolfSSL_CRYPTO_set_mem_ex_functions(void *(*m) (size_t, const char *, int),
 #if defined(OPENSSL_EXTRA)
 
 /**
- * free allocated memory resouce
+ * free allocated memory resource
  * @param str  a pointer to resource to be freed
  * @param file dummy argument
  * @param line dummy argument
@@ -39642,7 +39642,7 @@ int wolfSSL_RAND_egd(const char* nm)
             ret = WOLFSSL_FATAL_ERROR;
         }
         #ifdef SHOW_SECRETS
-        else { /* print out entropy found only when no error occured */
+        else { /* print out entropy found only when no error occurred */
             word32 i;
             printf("EGD Entropy = ");
             for (i = 0; i < bytes; i++) {
@@ -39706,7 +39706,7 @@ int wolfSSL_RAND_pseudo_bytes(unsigned char* buf, int num)
 {
     int ret;
     int hash;
-    byte secret[DRBG_SEED_LEN]; /* secret length arbitraily choosen */
+    byte secret[DRBG_SEED_LEN]; /* secret length arbitrarily chosen */
 
 #ifndef WOLFSSL_NO_OPENSSL_RAND_CB
     if (wolfSSL_RAND_InitMutex() == 0 && wc_LockMutex(&gRandMethodMutex) == 0) {
@@ -42396,7 +42396,7 @@ int wolfSSL_FIPS_drbg_uninstantiate(WOLFSSL_DRBG_CTX *ctx)
 void wolfSSL_FIPS_drbg_free(WOLFSSL_DRBG_CTX *ctx)
 {
     if (ctx != NULL) {
-        /* As saftey check if free'ing the default drbg, then mark global NULL.
+        /* As safety check if free'ing the default drbg, then mark global NULL.
          * Technically the user should not call free on the default drbg. */
         if (ctx == gDrbgDefCtx) {
             gDrbgDefCtx = NULL;

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3902,8 +3902,8 @@ enum {
      * beside the group number. Please see the NIST PQC Competition's submitted
      * papers for more details.
      *
-     * LEVEL1 means that an attack on that parameter set would reqire the same
-     * or more resources as a key search on AES 128. LEVEL3 would reqire the
+     * LEVEL1 means that an attack on that parameter set would require the same
+     * or more resources as a key search on AES 128. LEVEL3 would require the
      * same or more resources as a key search on AES 192. LEVEL5 would require
      * the same or more resources as a key search on AES 256. None of the
      * algorithms have LEVEL2 and LEVEL4 because none of these submissions


### PR DESCRIPTION
# Description

Used codespell and fixed obvious typos in `configure.ac`, `src/ssl.c`, and `wolfssl/ssl.h`.

