### PR TITLE
Fix for calling 'mp_clear(tmp)' without having called 'mp_init(tmp)'

### DIFF
--- a/wolfcrypt/src/dsa.c
+++ b/wolfcrypt/src/dsa.c
@@ -304,6 +304,9 @@ int wc_MakeDsaParameters(WC_RNG *rng, int modulus_size, DsaKey *dsa)
 
     if (err == MP_OKAY)
 #endif
+        err = mp_init(tmp);
+
+    if (err == MP_OKAY)
         err = mp_init_multi(tmp2, &dsa->p, &dsa->q, 0, 0, 0);
 
     if (err == MP_OKAY)
@@ -320,9 +323,6 @@ int wc_MakeDsaParameters(WC_RNG *rng, int modulus_size, DsaKey *dsa)
     /* p = random * q + 1, so q is a prime divisor of p-1 */
     if (err == MP_OKAY)
         err = mp_add_d(&dsa->p, 1, &dsa->p);
-
-    if (err == MP_OKAY)
-        err = mp_init(tmp);
 
     /* tmp = 2q  */
     if (err == MP_OKAY)

--- a/wolfcrypt/src/dsa.c
+++ b/wolfcrypt/src/dsa.c
@@ -304,10 +304,7 @@ int wc_MakeDsaParameters(WC_RNG *rng, int modulus_size, DsaKey *dsa)
 
     if (err == MP_OKAY)
 #endif
-        err = mp_init(tmp);
-
-    if (err == MP_OKAY)
-        err = mp_init_multi(tmp2, &dsa->p, &dsa->q, 0, 0, 0);
+        err = mp_init_multi(tmp, tmp2, &dsa->p, &dsa->q, 0, 0);
 
     if (err == MP_OKAY)
         err = mp_read_unsigned_bin(tmp2, buf, msize - qsize);


### PR DESCRIPTION
# Description

Fixes zd#15620