### PR TITLE
Fix for benchmarking shake with custom block size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -393,6 +393,8 @@ cmake_install.cmake
 # GDB Settings
 \.gdbinit
 
+libFuzzer
+
 # Pycharm and other IDEs
 \.idea
 

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -5112,7 +5112,7 @@ void bench_shake128(int useDeviceID)
                     if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
                                           0, &times, numBlocks, &pending)) {
                         ret = wc_Shake128_Update(&hash[i], bench_plain,
-                            BENCH_SIZE);
+                            bench_size);
                         if (!bench_async_handle(&ret,
                             BENCH_ASYNC_GET_DEV(&hash[i]), 0,
                                                 &times, &pending)) {
@@ -5148,7 +5148,7 @@ void bench_shake128(int useDeviceID)
                 ret = wc_InitShake128(hash, HEAP_HINT,
                     useDeviceID ? devId : INVALID_DEVID);
                 if (ret == 0)
-                    ret = wc_Shake128_Update(hash, bench_plain, BENCH_SIZE);
+                    ret = wc_Shake128_Update(hash, bench_plain, bench_size);
                 if (ret == 0)
                     ret = wc_Shake128_Final(hash, digest[0],
                         WC_SHA3_128_BLOCK_SIZE);
@@ -5207,7 +5207,7 @@ void bench_shake256(int useDeviceID)
                     if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
                                           0, &times, numBlocks, &pending)) {
                         ret = wc_Shake256_Update(&hash[i], bench_plain,
-                            BENCH_SIZE);
+                            bench_size);
                         if (!bench_async_handle(&ret,
                             BENCH_ASYNC_GET_DEV(&hash[i]), 0,
                                                 &times, &pending)) {
@@ -5243,7 +5243,7 @@ void bench_shake256(int useDeviceID)
                 ret = wc_InitShake256(hash, HEAP_HINT,
                     useDeviceID ? devId : INVALID_DEVID);
                 if (ret == 0)
-                    ret = wc_Shake256_Update(hash, bench_plain, BENCH_SIZE);
+                    ret = wc_Shake256_Update(hash, bench_plain, bench_size);
                 if (ret == 0)
                     ret = wc_Shake256_Final(hash, digest[0],
                         WC_SHA3_256_BLOCK_SIZE);


### PR DESCRIPTION
# Description

Fix for benchmarking shake with custom block size.

# Testing

Using `./benchmark -shake 1024` caused seg fault.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
