### PR TITLE
20230208-fixes

### DIFF
--- a/src/pk.c
+++ b/src/pk.c
@@ -12659,7 +12659,7 @@ point_conversion_form_t wolfSSL_EC_KEY_get_conv_form(const WOLFSSL_EC_KEY* key)
     int ret = -1;
 
     if (key != NULL) {
-        ret = (int)(unsigned char)key->form;
+        ret = key->form;
     }
 
     return ret;

--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -581,8 +581,7 @@ static void scryptSalsa(word32* out, word32* in)
     word32 x[16];
 
 #ifdef LITTLE_ENDIAN_ORDER
-    for (i = 0; i < 16; ++i)
-        x[i] = in[i];
+    XMEMCPY(x, in, sizeof(x));
 #else
     for (i = 0; i < 16; i++)
         x[i] = ByteReverseWord32(in[i]);
@@ -623,15 +622,14 @@ static void scryptSalsa(word32* out, word32* in)
  */
 static void scryptBlockMix(byte* b, byte* y, int r)
 {
-    byte x[64];
 #ifdef WORD64_AVAILABLE
+    word64  x[8];
     word64* b64 = (word64*)b;
     word64* y64 = (word64*)y;
-    word64* x64 = (word64*)x;
 #else
+    word32  x[16];
     word32* b32 = (word32*)b;
     word32* y32 = (word32*)y;
-    word32* x32 = (word32*)x;
 #endif
     int  i;
     int  j;
@@ -643,10 +641,11 @@ static void scryptBlockMix(byte* b, byte* y, int r)
     {
 #ifdef WORD64_AVAILABLE
         for (j = 0; j < 8; j++)
-            x64[j] ^= b64[i * 8 + j];
+            x[j] ^= b64[i * 8 + j];
+
 #else
         for (j = 0; j < 16; j++)
-            x32[j] ^= b32[i * 16 + j];
+            x[j] ^= b32[i * 16 + j];
 #endif
         scryptSalsa((word32*)x, (word32*)x);
         XMEMCPY(y + i * 64, x, sizeof(x));

--- a/wolfssl/openssl/ec.h
+++ b/wolfssl/openssl/ec.h
@@ -116,7 +116,7 @@ struct WOLFSSL_EC_KEY {
 
     void*          internal;     /* our ECC Key */
     void*          heap;
-    char           form;         /* Either POINT_CONVERSION_UNCOMPRESSED or
+    unsigned char  form;         /* Either POINT_CONVERSION_UNCOMPRESSED or
                                   * POINT_CONVERSION_COMPRESSED */
     word16 pkcs8HeaderSz;
 


### PR DESCRIPTION
`src/pk.c` and `wolfssl/openssl/ec.h`: cleaner fix for `bugprone-signed-char-misuse` first addressed in 38c057a084 .

`src/ssl.c`: fix PK object on stack in `wolfSSL_i2d_PublicKey()`.

`wolfcrypt/src/pwdbased.c`: refactor copy in `scryptSalsa()` as a `memcpy()`, for efficiency and to work around a bug in clang-17; also fix scratch buffer `x` in `scryptBlockMix()` to have correct alignment.

tested with `wolfssl-multi-test.sh ... '.*all.*clang.*' '.*clang.*all.*' super-quick-check` with clang-17.
