### PR TITLE
Fix overflow in fp_to_unsigned_bin_len length check.

### DIFF
--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -3837,6 +3837,9 @@ int fp_to_unsigned_bin_len(fp_int *a, unsigned char *b, int c)
   if (i < a->used - 1) {
       return FP_VAL;
   }
+  if ((i == a->used - 1) && ((a->dp[i] >> j) != 0)) {
+      return FP_VAL;
+  }
 
   return FP_OKAY;
 #else

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -3834,7 +3834,7 @@ int fp_to_unsigned_bin_len(fp_int *a, unsigned char *b, int c)
   for (; x >= 0; x--) {
      b[x] = 0;
   }
-  if ((i < a->used - 1) || ((a->dp[i] >> j) != 0)) {
+  if (i < a->used - 1) {
       return FP_VAL;
   }
 


### PR DESCRIPTION
# Description

The second expression in this length check
```
if ((i < a->used - 1) || ((a->dp[i] >> j) != 0)) {
```
resulted in a memory overrun, because if the first expression evaluated false then the second expression could index beyond the array.

Instead, only check the second expression if `(i == a->used - 1)`
```
  if (i < a->used - 1) {
      return FP_VAL;
  }
  if ((i == a->used - 1) && ((a->dp[i] >> j) != 0)) {
      return FP_VAL;
  }
```

Fixes zd#15564

# Testing

Tested with reproducer in ticket.
