### PR TITLE
Ecc ctx state fix

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -13053,7 +13053,7 @@ int wc_ecc_ctx_set_kdf_salt(ecEncCtx* ctx, const byte* salt, word32 len)
     ctx->kdfSaltSz = len;
 
     if (ctx->protocol == REQ_RESP_CLIENT) {
-        ctx->srvSt = ecSRV_SALT_SET;
+        ctx->cliSt = ecCLI_SALT_SET;
     }
     else if (ctx->protocol == REQ_RESP_SERVER) {
         ctx->srvSt = ecSRV_SALT_SET;


### PR DESCRIPTION
# Description

wc_ecc_ctx_set_kdf_salt was previously not setting the client state, only the server state. updated so client state is now set correctly and added a test that covers this function.

Fixes zd# 15618

# Testing

Customer provided an example and I wrote a test that covers this function

# Checklist

 - [*] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
