### PR TITLE
X509 RSA PSS: fixes for OpenSSL compat layer

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -27423,6 +27423,9 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
                                                      "sha3-512WithRSAEncryption"},
         #endif
         #endif
+        #ifdef WC_RSA_PSS
+        { NID_rsassaPss, CTC_RSASSAPSS, oidSigType, "RSASSA-PSS", "rsassaPss" },
+        #endif
     #endif /* NO_RSA */
     #ifdef HAVE_ECC
         #ifndef NO_SHA
@@ -27466,6 +27469,9 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
     #endif /* NO_DSA */
     #ifndef NO_RSA
         { NID_rsaEncryption, RSAk, oidKeyType, "rsaEncryption", "rsaEncryption"},
+    #ifdef WC_RSA_PSS
+        { NID_rsassaPss, RSAPSSk, oidKeyType, "RSASSA-PSS", "rsassaPss"},
+    #endif
     #endif /* NO_RSA */
     #ifdef HAVE_ECC
         { NID_X9_62_id_ecPublicKey, ECDSAk, oidKeyType, "id-ecPublicKey",
@@ -35923,6 +35929,10 @@ int oid2nid(word32 oid, int grp)
                 case CTC_SHA3_512wRSA:
                     return NID_RSA_SHA3_512;
                 #endif
+                #ifdef WC_RSA_PSS
+                case CTC_RSASSAPSS:
+                    return NID_rsassaPss;
+                #endif
             #endif /* NO_RSA */
             #ifdef HAVE_ECC
                 case CTC_SHAwECDSA:
@@ -35959,6 +35969,10 @@ int oid2nid(word32 oid, int grp)
             #ifndef NO_RSA
                 case RSAk:
                     return NID_rsaEncryption;
+                #ifdef WC_RSA_PSS
+                case RSAPSSk:
+                    return NID_rsassaPss;
+                #endif
             #endif /* NO_RSA */
             #ifdef HAVE_ECC
                 case ECDSAk:

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -9360,7 +9360,6 @@ int wc_RsaPublicKeyDecode_ex(const byte* input, word32* inOutIdx, word32 inSz,
 int wc_RsaPublicKeyDecode(const byte* input, word32* inOutIdx, RsaKey* key,
                        word32 inSz)
 {
-#ifndef WOLFSSL_ASN_TEMPLATE
     int ret;
     const byte *n = NULL, *e = NULL;
     word32 nSz = 0, eSz = 0;
@@ -9374,44 +9373,6 @@ int wc_RsaPublicKeyDecode(const byte* input, word32* inOutIdx, RsaKey* key,
     }
 
     return ret;
-#else
-    DECL_ASNGETDATA(dataASN, rsaPublicKeyASN_Length);
-    int ret = 0;
-
-    /* Check validity of parameters. */
-    if ((input == NULL) || (inOutIdx == NULL) || (key == NULL)) {
-        ret = BAD_FUNC_ARG;
-    }
-
-    CALLOC_ASNGETDATA(dataASN, rsaPublicKeyASN_Length, ret, NULL);
-
-    if (ret == 0) {
-        /* Set mp_ints to fill with modulus and exponent data. */
-        GetASN_MP(&dataASN[RSAPUBLICKEYASN_IDX_PUBKEY_RSA_N], &key->n);
-        GetASN_MP(&dataASN[RSAPUBLICKEYASN_IDX_PUBKEY_RSA_E], &key->e);
-        /* Try decoding PKCS #1 public key by ignoring rest of ASN.1. */
-        ret = GetASN_Items(&rsaPublicKeyASN[RSAPUBLICKEYASN_IDX_PUBKEY_RSA_SEQ],
-               &dataASN[RSAPUBLICKEYASN_IDX_PUBKEY_RSA_SEQ],
-               (int)(rsaPublicKeyASN_Length - RSAPUBLICKEYASN_IDX_PUBKEY_RSA_SEQ),
-               0, input, inOutIdx, inSz);
-        if (ret != 0) {
-            mp_free(&key->n);
-            mp_free(&key->e);
-
-            /* Didn't work - try whole SubjectKeyInfo instead. */
-            /* Set the OID to expect. */
-            GetASN_ExpBuffer(&dataASN[RSAPUBLICKEYASN_IDX_ALGOID_OID],
-                    keyRsaOid, sizeof(keyRsaOid));
-            /* Decode SubjectKeyInfo. */
-            ret = GetASN_Items(rsaPublicKeyASN, dataASN,
-                               rsaPublicKeyASN_Length, 1, input, inOutIdx,
-                               inSz);
-        }
-    }
-
-    FREE_ASNGETDATA(dataASN, NULL);
-    return ret;
-#endif
 }
 
 /* import RSA public key elements (n, e) into RsaKey structure (key) */

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -281,6 +281,7 @@ typedef union {
 #define NID_RSA_SHA3_256                1117
 #define NID_RSA_SHA3_384                1118
 #define NID_RSA_SHA3_512                1119
+#define NID_rsassaPss                   912
 #define NID_ecdsa_with_SHA1             416
 #define NID_ecdsa_with_SHA224           793
 #define NID_ecdsa_with_SHA256           794


### PR DESCRIPTION
# Description

Add NIDs for RSA-PSS to OpenSSL compat layer.
Have wc_RsaPublicKeyDecode call wc_RsaPublicKeyDecode_ex where logic for RSA-PSS handling is already done.

Fixes zd#15575

# Testing

POC

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
