### PR TITLE
ASN template, DSA: Clear the mp_int before re-reading data

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -44698,8 +44698,8 @@ static int test_wolfSSL_EVP_PKEY_set1_get1_DSA(void)
     AssertIntEQ(SHA1_Final(hash,&sha), WOLFSSL_SUCCESS);
 
     /* Initialize pkey with der format dsa key */
-    AssertNotNull(d2i_PrivateKey(EVP_PKEY_DSA, &pkey,
-                &dsaKeyDer ,(long)dsaKeySz));
+    AssertNotNull(d2i_PrivateKey(EVP_PKEY_DSA, &pkey, &dsaKeyDer,
+        (long)dsaKeySz));
 
     /* Test wolfSSL_EVP_PKEY_get1_DSA */
     /* Should Fail: NULL argument */
@@ -62379,7 +62379,7 @@ void ApiTest_PrintTestCases(void)
 {
     int i;
 
-    printf("All Test Cases:");
+    printf("All Test Cases:\n");
     for (i = 0; i < TEST_CASE_CNT; i++) {
         printf("%3d: %s\n", i + 1, testCases[i].name);
     }
@@ -62423,7 +62423,7 @@ int ApiTest_RunName(char* name)
     }
 
     printf("Test case name not found: %s\n", name);
-    printf("Use -list to see all test case names.\n");
+    printf("Use --list to see all test case names.\n");
     return BAD_FUNC_ARG;
 }
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -10496,7 +10496,9 @@ int wc_DsaPrivateKeyDecode(const byte* input, word32* inOutIdx, DsaKey* key,
             XMEMSET(dataASN, 0, sizeof(*dataASN) * dsaKeyASN_Length);
             GetASN_Int8Bit(&dataASN[DSAKEYASN_IDX_VER], &version);
             for (i = 0; i < DSA_INTS; i++) {
-                GetASN_MP(&dataASN[(int)DSAKEYASN_IDX_P + i], GetDsaInt(key, i));
+                mp_int* n = GetDsaInt(key, i);
+                mp_clear(n);
+                GetASN_MP(&dataASN[(int)DSAKEYASN_IDX_P + i], n);
             }
 
             /* Try simple OCTET_STRING form. */


### PR DESCRIPTION
# Description

Make sure the mp_int is cleared so that any exisiting bigint is freed. Tidy up api.c code.

# Testing

./configure '--disable-shared' 'CFLAGS=-DHAVE_WOLF_BIGINT' '--enable-debug' '--enable-all'
valgrind ./tests/unit.test
Shows up a memory leak.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
