### PR TITLE
Check keyLen matches cipher in wolfSSL_CMAC_Init.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -28568,6 +28568,13 @@ int wolfSSL_CMAC_Init(WOLFSSL_CMAC_CTX* ctx, const void *key, size_t keyLen,
     }
 
     if (ret == WOLFSSL_SUCCESS) {
+        /* Check input keyLen matches input cipher. */
+        if ((int) keyLen != wolfSSL_EVP_Cipher_key_length(cipher)) {
+            ret = WOLFSSL_FAILURE;
+        }
+    }
+
+    if (ret == WOLFSSL_SUCCESS) {
         ret = wc_InitCmac((Cmac*)ctx->internal, (const byte*)key,
                           (word32)keyLen, WC_CMAC_AES, NULL);
         if (ret != 0) {

--- a/tests/api.c
+++ b/tests/api.c
@@ -39705,6 +39705,14 @@ static int test_wolfSSL_CMAC(void)
     AssertIntEQ(outLen, AES_BLOCK_SIZE);
     CMAC_CTX_free(cmacCtx);
 
+    /* give a key too small for the cipher, verify we get failure */
+    cmacCtx = NULL;
+    AssertNotNull(cmacCtx = CMAC_CTX_new());
+    AssertNotNull(CMAC_CTX_get0_cipher_ctx(cmacCtx));
+    AssertIntEQ(CMAC_Init(cmacCtx, key, AES_128_KEY_SIZE, EVP_aes_192_cbc(),
+        NULL), SSL_FAILURE);
+    CMAC_CTX_free(cmacCtx);
+
     res = TEST_RES_CHECK(1);
 #endif /* WOLFSSL_CMAC && OPENSSL_EXTRA && WOLFSSL_AES_DIRECT */
     return res;


### PR DESCRIPTION
# Description

`wolfSSL_CMAC_Init()` was succeeding when input `keyLen` and `cipher` did not match. This broke from OpenSSL behavior, and could cause memory overruns when the key was shorter than what the cipher specified.

This commit adds a check to verify the keylen and cipher match.

Fixes zd#15607.

# Testing

Tested with reproducer in ticket with wolfSSL and OpenSSL, verified behavior matches.

Also added test to `test_wolfSSL_CMAC()` that calls `CMAC_Init()` with too short of key for the cipher, and checks it correctly returns failure.
