### PR TITLE
dtls: improve different peer recvfrom and better error reporting on ipv6

### DIFF
--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -346,7 +346,7 @@ static int sockAddrEqual(
     if (a->ss_family != b->ss_family)
         return 0;
 
-    if (a->ss_family == AF_INET) {
+    if (a->ss_family == WOLFSSL_IP4) {
 
         if (aLen < (XSOCKLENT)sizeof(SOCKADDR_IN))
             return 0;
@@ -362,7 +362,7 @@ static int sockAddrEqual(
     }
 
 #ifdef WOLFSSL_IPV6
-    if (a->ss_family == AF_INET6) {
+    if (a->ss_family == WOLFSSL_IP6) {
         SOCKADDR_IN6 *a6, *b6;
 
         if (aLen < (XSOCKLENT)sizeof(SOCKADDR_IN6))
@@ -380,7 +380,7 @@ static int sockAddrEqual(
 
         return 1;
     }
-#endif /* WOLFSSL_HAVE_IPV6 */
+#endif /* WOLFSSL_IPV6 */
 
     return 0;
 }

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -51,6 +51,14 @@ Possible IO enable options:
  * HAVE_HTTP_CLIENT:    Enables HTTP client API's                 default: off
                                      (unless HAVE_OCSP or HAVE_CRL_IO defined)
  * HAVE_IO_TIMEOUT:     Enables support for connect timeout       default: off
+ *
+ * DTLS_RECEIVEFROM_NO_TIMEOUT_ON_INVALID_PEER: This flag has effect only if
+ * ASN_NO_TIME is enabled. If enabled invalid peers messages are ignored
+ * indefinetely. If not enabled EmbedReceiveFrom will return timeout after
+ * DTLS_RECEIVEFROM_MAX_INVALID_PEER number of packets from invalid peers. When
+ * enabled, without a timer, EmbedReceivefrom can't check if the timeout is
+ * expired and it may never return under a continous flow of invalid packets.
+ *                                                                default: off
  */
 
 
@@ -58,6 +66,11 @@ Possible IO enable options:
    automatic setting of default I/O functions EmbedSend() and EmbedReceive()
    but they'll still need SetCallback xxx() at end of file
 */
+
+#if defined(NO_ASN_TIME) && !defined(DTLS_RECEIVEFROM_NO_TIMEOUT_ON_INVALID_PEER) \
+  && !defined(DTLS_RECEIVEFROM_MAX_INVALID_PEER)
+#define DTLS_RECEIVEFROM_MAX_INVALID_PEER 10
+#endif
 
 #if defined(USE_WOLFSSL_IO) || defined(HAVE_HTTP_CLIENT)
 
@@ -400,6 +413,11 @@ int EmbedReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     SOCKADDR_S lclPeer;
     SOCKADDR_S* peer;
     XSOCKLENT peerSz = 0;
+#ifndef NO_ASN_TIME
+    word32 start = 0;
+#elif !defined(DTLS_RECEIVEFROM_NO_TIMEOUT_ON_INVALID_PEER)
+    word32 invalidPeerPackets = 0;
+#endif
 
     WOLFSSL_ENTER("EmbedReceiveFrom");
 
@@ -438,10 +456,26 @@ int EmbedReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     }
 #endif /* WOLFSSL_DTLS13 */
 
-    if (!doDtlsTimeout)
-        dtls_timeout = 0;
+    do {
 
-    if (!wolfSSL_get_using_nonblock(ssl)) {
+        if (!doDtlsTimeout) {
+            dtls_timeout = 0;
+        }
+        else {
+#ifndef NO_ASN_TIME
+            if (start == 0) {
+                start = LowResTimer();
+            }
+            else {
+                dtls_timeout -= LowResTimer() - start;
+                start = LowResTimer();
+                if (dtls_timeout < 0 || dtls_timeout > DTLS_TIMEOUT_MAX)
+                    return WOLFSSL_CBIO_ERR_TIMEOUT;
+            }
+#endif
+        }
+
+        if (!wolfSSL_get_using_nonblock(ssl)) {
         #ifdef USE_WINDOWS_API
             DWORD timeout = dtls_timeout * 1000;
             #ifdef WOLFSSL_DTLS13
@@ -464,87 +498,101 @@ int EmbedReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
             #endif /* WOLFSSL_DTLS13 */
                 timeout.tv_sec = dtls_timeout;
         #endif
-        if (setsockopt(sd, SOL_SOCKET, SO_RCVTIMEO, (char*)&timeout,
-                       sizeof(timeout)) != 0) {
+            if (setsockopt(sd, SOL_SOCKET, SO_RCVTIMEO, (char*)&timeout,
+                    sizeof(timeout)) != 0) {
                 WOLFSSL_MSG("setsockopt rcvtimeo failed");
+            }
         }
-    }
 #ifndef NO_ASN_TIME
-    else if(IsSCR(ssl)) {
-        if (ssl->dtls_start_timeout &&
-                LowResTimer() - ssl->dtls_start_timeout > (word32)dtls_timeout) {
-            ssl->dtls_start_timeout = 0;
-            return WOLFSSL_CBIO_ERR_TIMEOUT;
+        else if (IsSCR(ssl)) {
+            if (ssl->dtls_start_timeout &&
+                LowResTimer() - ssl->dtls_start_timeout >
+                    (word32)dtls_timeout) {
+                ssl->dtls_start_timeout = 0;
+                return WOLFSSL_CBIO_ERR_TIMEOUT;
+            }
+            else if (!ssl->dtls_start_timeout) {
+                ssl->dtls_start_timeout = LowResTimer();
+            }
         }
-        else if (!ssl->dtls_start_timeout) {
-            ssl->dtls_start_timeout = LowResTimer();
-        }
-    }
 #endif /* !NO_ASN_TIME */
 
-    recvd = (int)DTLS_RECVFROM_FUNCTION(sd, buf, sz, ssl->rflags,
-                      (SOCKADDR*)peer, peer != NULL ? &peerSz : NULL);
+        recvd = (int)DTLS_RECVFROM_FUNCTION(sd, buf, sz, ssl->rflags,
+            (SOCKADDR*)peer, peer != NULL ? &peerSz : NULL);
 
-    /* From the RECV(2) man page
-     * The returned address is truncated if the buffer provided is too small; in
-     * this case, addrlen will return a value greater than was supplied to the
-     * call.
-     */
-    if (dtlsCtx->connected) {
-        /* No need to sanitize the value of peerSz */
-    }
-    else if (dtlsCtx->userSet) {
-        /* Truncate peer size */
-        if (peerSz > (XSOCKLENT)sizeof(lclPeer))
-            peerSz = (XSOCKLENT)sizeof(lclPeer);
-    }
-    else {
-        /* Truncate peer size */
-        if (peerSz > (XSOCKLENT)dtlsCtx->peer.bufSz)
-            peerSz = (XSOCKLENT)dtlsCtx->peer.bufSz;
-    }
-
-    recvd = TranslateReturnCode(recvd, sd);
-
-    if (recvd < 0) {
-        WOLFSSL_MSG("Embed Receive From error");
-        recvd = TranslateIoError(recvd);
-        if (recvd == WOLFSSL_CBIO_ERR_WANT_READ &&
-            !wolfSSL_dtls_get_using_nonblock(ssl)) {
-            recvd = WOLFSSL_CBIO_ERR_TIMEOUT;
+        /* From the RECV(2) man page
+         * The returned address is truncated if the buffer provided is too
+         * small; in this case, addrlen will return a value greater than was
+         * supplied to the call.
+         */
+        if (dtlsCtx->connected) {
+            /* No need to sanitize the value of peerSz */
         }
-        return recvd;
-    }
-    else if (recvd == 0) {
-        if (!isDGramSock(sd)) {
-            /* Closed TCP connection */
-            recvd = WOLFSSL_CBIO_ERR_CONN_CLOSE;
+        else if (dtlsCtx->userSet) {
+            /* Truncate peer size */
+            if (peerSz > (XSOCKLENT)sizeof(lclPeer))
+                peerSz = (XSOCKLENT)sizeof(lclPeer);
         }
         else {
-            WOLFSSL_MSG("Ignoring 0-length datagram");
+            /* Truncate peer size */
+            if (peerSz > (XSOCKLENT)dtlsCtx->peer.bufSz)
+                peerSz = (XSOCKLENT)dtlsCtx->peer.bufSz;
         }
-        return recvd;
-    }
-    else if (dtlsCtx->connected) {
-        /* Nothing to do */
-    }
-    else if (dtlsCtx->userSet) {
-        /* Check we received the packet from the correct peer */
-        if (dtlsCtx->peer.sz > 0 &&
-            (peerSz != (XSOCKLENT)dtlsCtx->peer.sz ||
-                !sockAddrEqual(peer, peerSz, (SOCKADDR_S*)dtlsCtx->peer.sa,
-                    dtlsCtx->peer.sz))) {
-            WOLFSSL_MSG("    Ignored packet from invalid peer");
-            return WOLFSSL_CBIO_ERR_WANT_READ;
+
+        recvd = TranslateReturnCode(recvd, sd);
+
+        if (recvd < 0) {
+            WOLFSSL_MSG("Embed Receive From error");
+            recvd = TranslateIoError(recvd);
+            if (recvd == WOLFSSL_CBIO_ERR_WANT_READ &&
+                !wolfSSL_dtls_get_using_nonblock(ssl)) {
+                recvd = WOLFSSL_CBIO_ERR_TIMEOUT;
+            }
+            return recvd;
         }
-    }
-    else {
-        /* Store size of saved address */
-        dtlsCtx->peer.sz = peerSz;
-    }
+        else if (recvd == 0) {
+            if (!isDGramSock(sd)) {
+                /* Closed TCP connection */
+                recvd = WOLFSSL_CBIO_ERR_CONN_CLOSE;
+            }
+            else {
+                WOLFSSL_MSG("Ignoring 0-length datagram");
+                continue;
+            }
+            return recvd;
+        }
+        else if (dtlsCtx->connected) {
+            /* Nothing to do */
+        }
+        else if (dtlsCtx->userSet) {
+            /* Check we received the packet from the correct peer */
+            if (dtlsCtx->peer.sz > 0 &&
+                (peerSz != (XSOCKLENT)dtlsCtx->peer.sz ||
+                    !sockAddrEqual(peer, peerSz, (SOCKADDR_S*)dtlsCtx->peer.sa,
+                        dtlsCtx->peer.sz))) {
+                WOLFSSL_MSG("    Ignored packet from invalid peer");
+#if defined(NO_ASN_TIME) &&                                                    \
+    !defined(DTLS_RECEIVEFROM_NO_TIMEOUT_ON_INVALID_PEER)
+                if (doDtlsTimeout) {
+                    invalidPeerPackets++;
+                    if (invalidPeerPackets > DTLS_RECEIVEFROM_MAX_INVALID_PEER)
+                        return wolfSSL_dtls_get_using_nonblock(ssl)
+                                   ? WOLFSSL_CBIO_ERR_WANT_READ
+                                   : WOLFSSL_CBIO_ERR_TIMEOUT;
+                }
+#endif /* NO_ASN_TIME && !DTLS_RECEIVEFROM_NO_TIMEOUT_ON_INVALID_PEER */
+                continue;
+            }
+        }
+        else {
+            /* Store size of saved address */
+            dtlsCtx->peer.sz = peerSz;
+        }
 #ifndef NO_ASN_TIME
-    ssl->dtls_start_timeout = 0;
+        ssl->dtls_start_timeout = 0;
 #endif /* !NO_ASN_TIME */
+        break;
+    } while (1);
 
     return recvd;
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -5435,6 +5435,9 @@ static THREAD_RETURN WOLFSSL_THREAD test_server_nofail(void* args)
         input[idx] = '\0';
         fprintf(stderr, "Client message: %s\n", input);
     }
+    else if (idx < 0) {
+        goto done;
+    }
 
     if (wolfSSL_write(ssl, msg, sizeof(msg)) != sizeof(msg)) {
         /*err_sys("SSL_write failed");*/

--- a/tests/api.c
+++ b/tests/api.c
@@ -5687,8 +5687,6 @@ done:
 }
 #endif /* defined(OPENSSL_EXTRA) && !defined(NO_SESSION_CACHE) && !defined(WOLFSSL_TLS13) */
 
-typedef int (*cbType)(WOLFSSL_CTX *ctx, WOLFSSL *ssl);
-
 static int test_client_nofail(void* args, cbType cb)
 {
 #if !defined(NO_WOLFSSL_CLIENT)
@@ -5931,8 +5929,8 @@ done:
     return 0;
 }
 
-void test_wolfSSL_client_server_nofail(callback_functions* client_cb,
-                                       callback_functions* server_cb)
+void test_wolfSSL_client_server_nofail_ex(callback_functions* client_cb,
+    callback_functions* server_cb, cbType client_on_handshake)
 {
     func_args client_args;
     func_args server_args;
@@ -5961,7 +5959,7 @@ void test_wolfSSL_client_server_nofail(callback_functions* client_cb,
 
     start_thread(test_server_nofail, &server_args, &serverThread);
     wait_tcp_ready(&server_args);
-    test_client_nofail(&client_args, NULL);
+    test_client_nofail(&client_args, client_on_handshake);
     join_thread(serverThread);
 
     client_cb->return_code = client_args.return_code;
@@ -5973,6 +5971,13 @@ void test_wolfSSL_client_server_nofail(callback_functions* client_cb,
     fdOpenSession(Task_self());
 #endif
 }
+
+void test_wolfSSL_client_server_nofail(callback_functions* client_cb,
+    callback_functions* server_cb)
+{
+    test_wolfSSL_client_server_nofail_ex(client_cb, server_cb, NULL);
+}
+
 
 #if defined(OPENSSL_EXTRA) && !defined(NO_SESSION_CACHE) && \
    !defined(WOLFSSL_TLS13) && !defined(NO_WOLFSSL_CLIENT)

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -636,6 +636,10 @@ typedef THREAD_RETURN WOLFSSL_THREAD THREAD_FUNC(void*);
 void start_thread(THREAD_FUNC fun, func_args* args, THREAD_TYPE* thread);
 void join_thread(THREAD_TYPE thread);
 
+typedef int (*cbType)(WOLFSSL_CTX *ctx, WOLFSSL *ssl);
+
+void test_wolfSSL_client_server_nofail_ex(callback_functions* client_cb,
+    callback_functions* server_cb, cbType client_on_handshake);
 void test_wolfSSL_client_server_nofail(callback_functions* client_cb,
                                        callback_functions* server_cb);
 


### PR DESCRIPTION
# Description

* Ignore messages from a different ip/src-port instead of returning `WANT_READ` which will bother blocking sockets
* Return error if `wolfSSL_dtls_set_peer` is invoked with an IPv6 address when IPv6 support is disabled

Fixes https://github.com/wolfSSL/wolfssl/issues/5999

# Testing

A test was added to the test suite