### PR TITLE
Linux is case sensitive.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -164,7 +164,7 @@
 
 #ifdef _WIN32
     #include <windows.h>
-    #include <Wincrypt.h>
+    #include <wincrypt.h>
 
     /* mingw gcc does not support pragma comment, and the
      * linking with crypt32 is handled in configure.ac */


### PR DESCRIPTION
# Description
Was building WolfSSL on Linux via `mingw`. One of the header files used by *ssl.c* is `wincrypt.h` but is included as `Wincrypt.h`. Because Linux is case sensitive, this caused a *file not found* error. 

Please describe the scope of the fix or feature addition.
Changed the include from `Wincrypt.h` to `wincrypt.h`.

Fixes zd#

# Testing

How did you test?
I compiled the client program, copied to a Windows machine (with required cert), and executed it against one of my servers.
 
# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
