### PR TITLE
Fix unused variable warning when configuring with --enable-apachehttpd

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5583,6 +5583,10 @@ static int DoPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 inputSz,
     byte          binder[WC_MAX_DIGEST_SIZE];
     word32        binderLen;
 
+    #ifdef NO_PSK
+        (void) suite; /* to avoid unused var warning when not used */
+    #endif
+
     WOLFSSL_ENTER("DoPreSharedKeys");
 
     ext = TLSX_Find(ssl->extensions, TLSX_PRE_SHARED_KEY);


### PR DESCRIPTION
# Description

Fixes build error, caught by @bandi13 in test work, compilers must have missed it in jenkins. Also reproducible on macOS w/ `Apple clang version 14.0.0 (clang-1400.0.29.202)`

```
src/tls13.c:5577:17: error: unused parameter 'suite' [-Werror,-Wunused-parameter]
    const byte* suite, int* usingPSK, int* first)
                ^
1 error generated.
make[2]: *** [src/libwolfssl_la-tls13.lo] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2
```

Stems from 0cedc4e1acc68c59a2f509c0da6a1786b6c85fd9