### PR TITLE
20230214-mollify-iso-c-pedantic

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -31868,14 +31868,16 @@ void* wolfSSL_CTX_get_ex_data(const WOLFSSL_CTX* ctx, int idx)
     return NULL;
 }
 
-int wolfSSL_CTX_get_ex_new_index(long idx, void* arg, void* a, void* b,
-                                void* c)
+int wolfSSL_CTX_get_ex_new_index(long idx, void* arg,
+                                 WOLFSSL_CRYPTO_EX_new* new_func,
+                                 WOLFSSL_CRYPTO_EX_dup* dup_func,
+                                 WOLFSSL_CRYPTO_EX_free* free_func)
 {
 
     WOLFSSL_ENTER("wolfSSL_CTX_get_ex_new_index");
 
-    return wolfssl_get_ex_new_index(WOLF_CRYPTO_EX_INDEX_SSL_CTX, idx, arg, a,
-            b, c);
+    return wolfssl_get_ex_new_index(WOLF_CRYPTO_EX_INDEX_SSL_CTX, idx, arg,
+                                    new_func, dup_func, free_func);
 }
 
 /* Return the index that can be used for the WOLFSSL structure to store

--- a/src/x509.c
+++ b/src/x509.c
@@ -12368,11 +12368,15 @@ int wolfSSL_sk_X509_num(const WOLF_STACK_OF(WOLFSSL_X509) *s)
      || defined(WOLFSSL_HAPROXY) || defined(OPENSSL_EXTRA)                   \
      || defined(HAVE_LIGHTY))
 
-int wolfSSL_X509_get_ex_new_index(int idx, void *arg, void *a, void *b, void *c)
+int wolfSSL_X509_get_ex_new_index(int idx, void *arg,
+                                  WOLFSSL_CRYPTO_EX_new* new_func,
+                                  WOLFSSL_CRYPTO_EX_dup* dup_func,
+                                  WOLFSSL_CRYPTO_EX_free* free_func)
 {
     WOLFSSL_ENTER("wolfSSL_X509_get_ex_new_index");
 
-    return wolfssl_get_ex_new_index(CRYPTO_EX_INDEX_X509, idx, arg, a, b, c);
+    return wolfssl_get_ex_new_index(CRYPTO_EX_INDEX_X509, idx, arg,
+                                    new_func, dup_func, free_func);
 }
 #endif
 

--- a/wolfssl/openssl/compat_types.h
+++ b/wolfssl/openssl/compat_types.h
@@ -63,14 +63,4 @@ typedef WOLFSSL_ENGINE         ENGINE;
 typedef WOLFSSL_EVP_PKEY_CTX   EVP_PKEY_CTX;
 #endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
 
-#ifdef HAVE_EX_DATA
-typedef void (WOLFSSL_CRYPTO_EX_new)(void* p, void* ptr,
-        WOLFSSL_CRYPTO_EX_DATA* a, int idx, long argValue, void* arg);
-typedef int  (WOLFSSL_CRYPTO_EX_dup)(WOLFSSL_CRYPTO_EX_DATA* out,
-        const WOLFSSL_CRYPTO_EX_DATA* in, void* inPtr, int idx, long argV,
-        void* arg);
-typedef void (WOLFSSL_CRYPTO_EX_free)(void* p, void* ptr,
-        WOLFSSL_CRYPTO_EX_DATA* a, int idx, long argValue, void* arg);
-#endif
-
 #endif /* !WOLFSSL_OPENSSL_COMPAT_TYPES_H_ */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1289,6 +1289,7 @@ typedef void (CallbackInfoState)(const WOLFSSL* ssl, int, int);
 #define WOLF_CRYPTO_EX_INDEX__COUNT          16
 
 #ifdef HAVE_EX_DATA
+
 /* Helper macro to log that input arguments should not be used */
 #define WOLFSSL_CRYPTO_EX_DATA_IGNORE_PARAMS(a1, a2, a3, a4, a5) \
     (void)(a1);                                                  \
@@ -2751,7 +2752,12 @@ WOLFSSL_API unsigned long wolfSSL_SESSION_get_ticket_lifetime_hint(
                               const WOLFSSL_SESSION* sess);
 WOLFSSL_API long wolfSSL_SESSION_get_timeout(const WOLFSSL_SESSION* session);
 WOLFSSL_API long wolfSSL_SESSION_get_time(const WOLFSSL_SESSION* session);
-WOLFSSL_API int  wolfSSL_CTX_get_ex_new_index(long idx, void* arg, void* a, void* b, void* c);
+#ifdef HAVE_EX_DATA
+WOLFSSL_API int wolfSSL_CTX_get_ex_new_index(long idx, void* arg,
+    WOLFSSL_CRYPTO_EX_new* new_func,
+    WOLFSSL_CRYPTO_EX_dup* dup_func,
+    WOLFSSL_CRYPTO_EX_free* free_func);
+#endif
 
 
 /* extra ends */
@@ -4848,8 +4854,12 @@ WOLFSSL_API int wolfSSL_X509_set_ex_data_with_cleanup(
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) \
     || defined(OPENSSL_EXTRA) || defined(HAVE_LIGHTY) || defined(HAVE_SECRET_CALLBACK)
 WOLFSSL_API WOLF_STACK_OF(WOLFSSL_CIPHER) *wolfSSL_get_ciphers_compat(const WOLFSSL *ssl);
-WOLFSSL_API int wolfSSL_X509_get_ex_new_index(int idx, void *arg, void *a,
-    void *b, void *c);
+#ifdef HAVE_EX_DATA
+WOLFSSL_API int wolfSSL_X509_get_ex_new_index(int idx, void *arg,
+    WOLFSSL_CRYPTO_EX_new* new_func,
+    WOLFSSL_CRYPTO_EX_dup* dup_func,
+    WOLFSSL_CRYPTO_EX_free* free_func);
+#endif
 WOLFSSL_API int wolfSSL_X509_NAME_digest(const WOLFSSL_X509_NAME *data,
     const WOLFSSL_EVP_MD *type, unsigned char *md, unsigned int *len);
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -48,12 +48,20 @@ decouple library dependencies with standard string, memory and so on.
         #ifdef HAVE_EX_DATA_CLEANUP_HOOKS
         typedef void (*wolfSSL_ex_data_cleanup_routine_t)(void *data);
         #endif
-    typedef struct WOLFSSL_CRYPTO_EX_DATA {
-        void* ex_data[MAX_EX_DATA];
-        #ifdef HAVE_EX_DATA_CLEANUP_HOOKS
-        wolfSSL_ex_data_cleanup_routine_t ex_data_cleanup_routines[MAX_EX_DATA];
-        #endif
-    } WOLFSSL_CRYPTO_EX_DATA;
+        typedef struct WOLFSSL_CRYPTO_EX_DATA {
+            void* ex_data[MAX_EX_DATA];
+            #ifdef HAVE_EX_DATA_CLEANUP_HOOKS
+            wolfSSL_ex_data_cleanup_routine_t
+                ex_data_cleanup_routines[MAX_EX_DATA];
+            #endif
+        } WOLFSSL_CRYPTO_EX_DATA;
+        typedef void (WOLFSSL_CRYPTO_EX_new)(void* p, void* ptr,
+                WOLFSSL_CRYPTO_EX_DATA* a, int idx, long argValue, void* arg);
+        typedef int  (WOLFSSL_CRYPTO_EX_dup)(WOLFSSL_CRYPTO_EX_DATA* out,
+                const WOLFSSL_CRYPTO_EX_DATA* in, void* inPtr, int idx,
+                long argV, void* arg);
+        typedef void (WOLFSSL_CRYPTO_EX_free)(void* p, void* ptr,
+                WOLFSSL_CRYPTO_EX_DATA* a, int idx, long argValue, void* arg);
     #endif
 
     #if defined(WORDS_BIGENDIAN)


### PR DESCRIPTION
`src/ssl.c` and `src/x509.c`: use the customary function pointers, not `void *`, in the arg lists of `wolfSSL_CTX_get_ex_new_index()` and `wolfSSL_X509_get_ex_new_index()`, to avoid "ISO C forbids passing argument ... between function pointer and ‘void *’";

also, move typedefs for `WOLFSSL_CRYPTO_EX_*()` from `wolfssl/openssl/compat_types.h` to `wolfssl/ssl.h`, as they are needed whenever `defined(HAVE_EX_DATA)` regardless of openssl compatness, and properly gate `wolfSSL_CTX_get_ex_new_index()` prototype on `defined(HAVE_EX_DATA)`.

tested with `wolfssl-multi-test.sh ... super-quick-check`
