### PR TITLE
Various cleanups (STM docs, include case, make dist small script)

### DIFF
--- a/IDE/STM32Cube/README.md
+++ b/IDE/STM32Cube/README.md
@@ -100,7 +100,8 @@ The section for "Hardware platform" may need to be adjusted depending on your pr
 
 To use the STM32 Cube HAL support make sure `WOLFSSL_STM32_CUBEMX` is defined.
 
-The L5 and WB55 support ECC PKA acceleration, which is enabled with `WOLFSSL_STM32_PKA`.
+The PKA acceleration for ECC is avaialble on some U5, L5 and WB55 chips.
+This is enabled with `WOLFSSL_STM32_PKA`. You can see some of the benchmarks [here](STM32_Benchmarks.md).
 
 To disable hardware crypto acceleration you can define:
 

--- a/scripts/makedistsmall.sh
+++ b/scripts/makedistsmall.sh
@@ -44,6 +44,7 @@ rm -rf ./certs
 rm -rf ./ctaocrypt
 rm -rf ./cyassl
 rm -rf ./doc
+rm -rf ./Docker
 # these use test.h, which are not portable
 rm -rf ./examples
 rm -rf ./IDE
@@ -55,6 +56,7 @@ rm -rf ./mcapi
 rm -rf ./mplabx
 rm -rf ./mqx
 rm -rf ./rpm
+rm -rf ./RTOS
 rm -rf ./scripts
 rm -rf ./sslSniffer
 rm -rf ./swig
@@ -63,7 +65,6 @@ rm -rf ./testsuite
 rm -rf ./tirtos
 rm -rf ./wolfcrypt/user-crypto
 rm -rf ./wrapper
-rm -rf ./zephyr
 rm -f -- *.rc *.supp *.ac *.am *.conf *.sh *.cproject *.project *.pl
 rm -f Vagrantfile SCRIPTS-LIST quit input resource.h
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -164,7 +164,7 @@
 
 #ifdef _WIN32
     #include <windows.h>
-    #include <Wincrypt.h>
+    #include <wincrypt.h>
 
     /* mingw gcc does not support pragma comment, and the
      * linking with crypt32 is handled in configure.ac */


### PR DESCRIPTION
# Description

* Fix `./scripts/makedistsmall.sh` for `Docker` and `RTOS`.
* Improve documentation for STM32 PKA support.
* Fix `wincrypt.h` include header case when used with case sensitive file system.

# Testing


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
