### PR TITLE
Fix issue with async and `WOLFSSL_CHECK_ALERT_ON_ERR`

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -19124,6 +19124,16 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
         return ssl->error;
     }
 
+    /* If checking alert on error (allowSocketErr == 1) do not try and
+     * process alerts for async or ocsp non blocking */
+#if defined(WOLFSSL_CHECK_ALERT_ON_ERR) && \
+    (defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP))
+    if (allowSocketErr == 1 && \
+        (ssl->error == WC_PENDING_E || ssl->error == OCSP_WANT_READ)) {
+        return ssl->error;
+    }
+#endif
+
 #if defined(WOLFSSL_DTLS) && defined(WOLFSSL_ASYNC_CRYPT)
     /* process any pending DTLS messages - this flow can happen with async */
     if (ssl->dtls_rx_msg_list != NULL) {

--- a/tests/api.c
+++ b/tests/api.c
@@ -62942,6 +62942,15 @@ void ApiTest(void)
     printf(" Begin API Tests\n");
     fflush(stdout);
 
+    /* we must perform init and cleanup if not all tests are running */
+    if (!testAll) {
+    #ifdef WOLFCRYPT_ONLY
+        wolfCrypt_Init();
+    #else
+        wolfSSL_Init();
+    #endif
+    }
+
     for (i = 0; i < TEST_CASE_CNT; ++i) {
         /* When not testing all cases then skip if not marked for running. */
         if (!testAll && !testCases[i].run) {
@@ -62983,7 +62992,13 @@ void ApiTest(void)
     wc_ecc_fp_free();  /* free per thread cache */
 #endif
 
-    wolfSSL_Cleanup();
+    if (!testAll) {
+    #ifdef WOLFCRYPT_ONLY
+        wolfCrypt_Cleanup();
+    #else
+        wolfSSL_Cleanup();
+    #endif
+    }
 
     (void)testDevId;
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -5290,10 +5290,10 @@ static THREAD_RETURN WOLFSSL_THREAD test_server_nofail(void* args)
     }
 #endif
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_EITHER_SIDE)
-    if (sharedCtx && wolfSSL_use_certificate_file(ssl, svrCertFile,
+    if (sharedCtx && wolfSSL_use_certificate_file(ssl, certFile,
                                      WOLFSSL_FILETYPE_PEM) != WOLFSSL_SUCCESS) {
 #else
-    if (wolfSSL_use_certificate_file(ssl, svrCertFile,
+    if (wolfSSL_use_certificate_file(ssl, certFile,
                                      WOLFSSL_FILETYPE_PEM) != WOLFSSL_SUCCESS) {
 #endif
         /*err_sys("can't load server cert chain file, "
@@ -5301,10 +5301,10 @@ static THREAD_RETURN WOLFSSL_THREAD test_server_nofail(void* args)
         goto done;
     }
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_EITHER_SIDE)
-    if (sharedCtx && wolfSSL_use_PrivateKey_file(ssl, svrKeyFile,
+    if (sharedCtx && wolfSSL_use_PrivateKey_file(ssl, keyFile,
                                      WOLFSSL_FILETYPE_PEM) != WOLFSSL_SUCCESS) {
 #else
-    if (wolfSSL_use_PrivateKey_file(ssl, svrKeyFile,
+    if (wolfSSL_use_PrivateKey_file(ssl, keyFile,
                                      WOLFSSL_FILETYPE_PEM) != WOLFSSL_SUCCESS) {
 #endif
         /*err_sys("can't load server key file, "


### PR DESCRIPTION
# Description

* Fix for async with `WOLFSSL_CHECK_ALERT_ON_ERR`. Uncovered with stunnel PR #6020 when `WOLFSSL_CHECK_ALERT_ON_ERR` was added to the build options. Broken since `WOLFSSL_CHECK_ALERT_ON_ERR` was added back in 2021.
* Fix to use the right cert/key in the API unit test if overridden.
* Fix to make sure API unit test always calls init/cleanup when not running all tests.

# Testing

```
./configure --enable-all --enable-asynccrypt && make check
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
