### PR TITLE
Be more aggressive in killing processes

### DIFF
--- a/scripts/ocsp-stapling-with-ca-as-responder.test
+++ b/scripts/ocsp-stapling-with-ca-as-responder.test
@@ -154,7 +154,7 @@ cleanup()
     exit_status=$?
     for i in $(jobs -pr)
     do
-        kill -s HUP "$i"
+        kill -s kill "$i"
     done
     remove_ready_file
     rm $CERT_DIR/$test_cnf

--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -165,7 +165,7 @@ cleanup()
     exit_status=$?
     for i in $(jobs -pr)
     do
-        kill -s HUP "$i"
+        kill -s KILL "$i"
     done
     remove_ready_file
     rm $CERT_DIR/$test_cnf

--- a/scripts/ocsp-stapling2.test
+++ b/scripts/ocsp-stapling2.test
@@ -191,7 +191,7 @@ cleanup()
     exit_status=$?
     for i in $(jobs -pr)
     do
-        kill -s HUP "$i"
+        kill -s KILL "$i"
     done
     remove_ready_file
     rm $CERT_DIR/$test_cnf


### PR DESCRIPTION
# Description

Fixed issue with `make check` getting hung. The 'openssl' executables were never being shut down at the end of the script. The SIGHUP is not enough, we need to be more assertive with SIGKILL.