### PR TITLE
Fix invalid PP macro logic, guard under same conditions as internal.h

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -19854,7 +19854,9 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
         ssl->options.tls1_1 = 0;
     #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
         ssl->options.noPskDheKe = 0;
+      #ifdef HAVE_SUPPORTED_CURVES
         ssl->options.onlyPskDheKe = 0;
+      #endif
     #endif
     #ifdef HAVE_SESSION_TICKET
         #ifdef WOLFSSL_TLS13


### PR DESCRIPTION
# Description
Guard the element of options using the correct preprocessor logic 

# Testing

[Caught in wolfCLU windows testing](https://github.com/wolfSSL/wolfCLU/actions/runs/4198000490/jobs/7281163341)

See:
https://github.com/wolfSSL/wolfssl/blob/master/wolfssl/internal.h#L3252-L3257