### PR TITLE
20230216-readability-redundant-preprocessor

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5562,7 +5562,7 @@ static int FindPsk(WOLFSSL* ssl, PreSharedKey* psk, const byte* suite, int* err)
     *err = ret;
     return found;
 }
-#endif
+#endif /* !NO_PSK */
 
 /* Handle any Pre-Shared Key (PSK) extension.
  * Find a PSK that supports the cipher suite passed in.
@@ -5710,7 +5710,7 @@ static int DoPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 inputSz,
                 return ret;
         }
         else
-    #endif
+    #endif /* HAVE_SESSION_TICKET */
     #ifndef NO_PSK
         if (FindPsk(ssl, current, suite, &ret)) {
             if (ret != 0)
@@ -5918,7 +5918,6 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
         }
         modes = ext->val;
 
-#if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
     #ifdef HAVE_SUPPORTED_CURVES
         ext = TLSX_Find(ssl->extensions, TLSX_KEY_SHARE);
         /* Use (EC)DHE for forward-security if possible. */
@@ -5945,7 +5944,6 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
 
             *usingPSK = 1;
         }
-#endif
     }
 #ifdef WOLFSSL_PSK_ID_PROTECTION
     else {


### PR DESCRIPTION
`src/tls13.c`: fix a `readability-redundant-preprocessor` in `CheckPreSharedKeys()`.
