### PR TITLE
Fix WOLFSSL_ENTER message for wolfSSL_set_quiet_shutdown

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -16813,7 +16813,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
 
     void wolfSSL_set_quiet_shutdown(WOLFSSL* ssl, int mode)
     {
-        WOLFSSL_ENTER("wolfSSL_CTX_set_quiet_shutdown");
+        WOLFSSL_ENTER("wolfSSL_set_quiet_shutdown");
         if (mode)
             ssl->options.quietShutdown = 1;
     }


### PR DESCRIPTION
# Description

The WOLFSSL_ENTER message for the function wolfSSL_set_quiet_shutdown was fixed. (extra CTX_ was removed)

Fixes zd#

# Testing

as this is just a debugging aid, and no functional differences are to be expected, no systematic testing was performed.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
