### PR TITLE
Fix out of bound memset to 0

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -2030,7 +2030,7 @@ int wolfSSL_session_export_internal(WOLFSSL* ssl, byte* buf, word32* sz,
         }
     }
 
-    if (ret != 0 && buf != NULL) {
+    if (ret != 0 && ret != LENGTH_ONLY_E && buf != NULL) {
         /*in a fail case clear the buffer which could contain partial key info*/
         XMEMSET(buf, 0, *sz);
     }


### PR DESCRIPTION
# Description

In case buf size sz is too small it will get updated to the larger required value and can't be used anymore to clear the buffer.

As the buffer is untouched don't need to clear it anyway.

# Testing

No testing done as this fixes undefined behaviour and there are no expected behaviour change.

# Checklist

 - [ NA ] added tests
 - [ NA ] updated/added doxygen
 - [ NA ] updated appropriate READMEs
 - [ NA ] Updated manual and documentation
