### PR TITLE
Improve sniffer so ServerList is shared by threads

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -573,13 +573,13 @@ static WOLFSSL_GLOBAL wolfSSL_Mutex ServerListMutex;
 #endif
 
 #ifndef WC_NO_ASYNC_THREADING
-THREAD_LS_T 
+THREAD_LS_T
 #endif
 static WOLFSSL_GLOBAL SnifferCtx* CtxList = NULL;
 
 #ifndef WC_NO_ASYNC_THREADING
 /* Session Hash Table, mutex, and count */
-THREAD_LS_T 
+THREAD_LS_T
 #endif
 static WOLFSSL_GLOBAL SnifferSession* SessionTable[HASH_SIZE];
 

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -138,7 +138,7 @@
     /* Cache unclosed Sessions for 15 minutes since last used */
 #endif
 
-#if defined(HAVE_C___ATOMIC) && !defined(WC_NO_ASYNC_THREADING)
+#if defined(HAVE_C___ATOMIC) && !defined(NO_SNIFFER_THREADING)
     #define USE_ATOMIC
 #endif
 
@@ -572,25 +572,21 @@ static WOLFSSL_GLOBAL SnifferServer* ServerList = NULL;
 static WOLFSSL_GLOBAL wolfSSL_Mutex ServerListMutex;
 #endif
 
-#ifndef WC_NO_ASYNC_THREADING
-THREAD_LS_T
-#endif
-static WOLFSSL_GLOBAL SnifferCtx* CtxList = NULL;
-
-#ifndef WC_NO_ASYNC_THREADING
+#ifndef NO_SNIFFER_THREADING
+/* Struct containing sniffer WOLFSSL_CTX */
+static THREAD_LS_T WOLFSSL_GLOBAL SnifferCtx* CtxList = NULL;
 /* Session Hash Table, mutex, and count */
-THREAD_LS_T
-#endif
+static THREAD_LS_T WOLFSSL_GLOBAL SnifferSession* SessionTable[HASH_SIZE];
+static THREAD_LS_T WOLFSSL_GLOBAL int SessionCount = 0;
+#else
+static WOLFSSL_GLOBAL SnifferCtx* CtxList = NULL;
 static WOLFSSL_GLOBAL SnifferSession* SessionTable[HASH_SIZE];
+static WOLFSSL_GLOBAL int SessionCount = 0;
+#endif
 
 #ifndef USE_ATOMIC
 static WOLFSSL_GLOBAL wolfSSL_Mutex SessionMutex;
 #endif
-
-#ifndef WC_NO_ASYNC_THREADING
-THREAD_LS_T
-#endif
-static WOLFSSL_GLOBAL int SessionCount = 0;
 
 static WOLFSSL_GLOBAL int RecoveryEnabled    = 0;  /* global switch */
 static WOLFSSL_GLOBAL int MaxRecoveryMemory  = -1;

--- a/wolfssl/sniffer.h
+++ b/wolfssl/sniffer.h
@@ -145,7 +145,7 @@ SSL_SNIFFER_API void ssl_InitSniffer(void);
 WOLFSSL_API
 SSL_SNIFFER_API void ssl_InitSniffer_ex(int devId);
 WOLFSSL_API
-SSL_SNIFFER_API void ssl_InitSniffer_ex2(int threadNum);
+SSL_SNIFFER_API void ssl_InitSniffer_thread(int threadNum);
 
 WOLFSSL_API
 SSL_SNIFFER_API void ssl_FreeSniffer(void);

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -970,6 +970,7 @@ typedef struct w64wrapper {
         DYNAMIC_TYPE_SNIFFER_TICKET_ID  = 1004,
         DYNAMIC_TYPE_SNIFFER_NAMED_KEY  = 1005,
         DYNAMIC_TYPE_SNIFFER_KEY        = 1006,
+        DYNAMIC_TYPE_SNIFFER_CONTEXT    = 1007,
     };
 
     /* max error buffer string size */


### PR DESCRIPTION
# Description

Adds the `SnifferCtx` struct to allow for a per-thread sniffer ctx (fix for `wolfSSL_CTX_AsyncPoll()` issue)

Adds the ability for the multithreaded sniffer to have list of keys shared by threads. 

Allows to gate out sniffer threading with `WC_NO_ASYNC_THREADING`.

Fixes zd#14597

# Testing

Tested with

```
./configure --enable-sniffer && make check
./configure --enable-sniffer --enable-asynccrypt && make check
./configure --enable-sniffer --enable-asynccrypt CFLAGS=-"DWOLFSSL_SNIFFER_CHAIN_INPUT -DWOLFSSL_SNIFFER_WATCH -DTHREADED_SNIFFTEST" && make check
./configure --enable-sniffer CFLAGS=-DTHREADED_SNIFFTEST && make check
./configure --enable-sniffer --enable-asynccrypt CFLAGS=-DTHREADED_SNIFFTEST && make check
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
