### PR TITLE
Fix for STM32 hashing hardware

### DIFF
--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -306,15 +306,8 @@ int wc_Stm32_Hash_Update(STM32_HASH_Context* stmCtx, word32 algo,
     }
 
     if (wroteToFifo) {
-    #if defined(STM32_HASH_FIFO_SIZE) && STM32_HASH_FIFO_SIZE > 1
-        /* If FIFO depth > 1 and we wrote a block send one more 32-bit to
-         * FIFO to trigger start. We cannot leave 16 deep FIFO filled before
-         * saving off context */
-        wc_Stm32_Hash_Data(stmCtx, 4);
-        stmCtx->fifoBytes += 4;
-
-        (void)wc_Stm32_Hash_WaitDone(stmCtx);
-    #endif
+        /* make sure hash operation is done */
+        ret = wc_Stm32_Hash_WaitDone(stmCtx);
 
         /* save hash state for next operation */
         wc_Stm32_Hash_SaveContext(stmCtx);

--- a/wolfssl/wolfcrypt/port/st/stm32.h
+++ b/wolfssl/wolfcrypt/port/st/stm32.h
@@ -60,14 +60,8 @@
 
 /* STM32 register size in bytes */
 #define STM32_HASH_REG_SIZE  4
-#if defined(WOLFSSL_STM32F4) || defined(WOLFSSL_STM32F7) || \
-    defined(WOLFSSL_STM32L4) || defined(WOLFSSL_STM32L5) || \
-    defined(WOLFSSL_STM32H7) || defined(WOLFSSL_STM32U5) || \
-    defined(WOLFSSL_STM32WB)
 #define STM32_HASH_FIFO_SIZE 16 /* FIFO is 16 deep 32-bits wide */
-#else
-#define STM32_HASH_FIFO_SIZE 1
-#endif
+
 
 /* STM32 Hash Context */
 typedef struct {


### PR DESCRIPTION
# Description

Proper fix for STM32 hashing. FIFO is always 32 bytes.

The original fix for U5/H7 (https://github.com/wolfSSL/wolfssl/pull/5223) just needed the check for hash "done" before saving state.

Fixes ZD15658

# Testing

To reproduce:

```
wc_Sha256 sha;
char data[66];        /* issue occurs greater or equal to 66 bytes */
char digest[32];
wc_InitSha256(&sha)
wc_Sha256Update(&sha, &data[0], 65);
wc_Sha256Update(&sha, &data[65], 1);
wc_Sha256Final(&sha, &digest[0]);
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
