### PR TITLE
Cleanup function logging

### DIFF
--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -273,7 +273,7 @@ static int TestEmbedSendTo(WOLFSSL* ssl, char *buf, int sz, void *ctx)
 
     (void)ssl;
 
-    WOLFSSL_ENTER("TestEmbedSendTo()");
+    WOLFSSL_ENTER("TestEmbedSendTo");
 
     if (dtlsCtx->failOnce) {
         word32 seq = 0;

--- a/src/bio.c
+++ b/src/bio.c
@@ -1040,7 +1040,7 @@ WOLFSSL_BIO* wolfSSL_BIO_next(WOLFSSL_BIO* bio)
 /* BIO_wpending returns the number of bytes pending to be written. */
 size_t wolfSSL_BIO_wpending(const WOLFSSL_BIO *bio)
 {
-    WOLFSSL_ENTER("BIO_wpending");
+    WOLFSSL_ENTER("wolfSSL_BIO_wpending");
 
     if (bio == NULL)
         return 0;
@@ -1913,7 +1913,7 @@ int wolfSSL_BIO_pending(WOLFSSL_BIO* bio)
 
 int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
 {
-    WOLFSSL_ENTER("BIO_flush");
+    WOLFSSL_ENTER("wolfSSL_BIO_flush");
 
     if (bio == NULL)
         return WOLFSSL_FAILURE;
@@ -1962,7 +1962,7 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
     {
         static WOLFSSL_BIO_METHOD meth;
 
-        WOLFSSL_ENTER("BIO_f_buffer");
+        WOLFSSL_ENTER("wolfSSL_BIO_f_buffer");
         meth.type = WOLFSSL_BIO_BUFFER;
 
         return &meth;
@@ -1972,11 +1972,12 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
     long wolfSSL_BIO_set_write_buffer_size(WOLFSSL_BIO* bio, long size)
     {
         /* wolfSSL has internal buffer, compatibility only */
-        WOLFSSL_ENTER("BIO_set_write_buffer_size");
-        WOLFSSL_MSG("Buffer resize failed");
         WOLFSSL_STUB("BIO_set_write_buffer_size");
+
+        WOLFSSL_MSG("Buffer resize failed");
+
         (void)bio;
-        (void) size;
+        (void)size;
 
         /* Even though this is only a STUB at the moment many user applications
          * may attempt to use this. OpenSSL documentation specifies the return
@@ -2038,7 +2039,7 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
     {
         WOLFSSL_BIO* bio = wolfSSL_BIO_new(wolfSSL_BIO_s_socket());
 
-        WOLFSSL_ENTER("BIO_new_socket");
+        WOLFSSL_ENTER("wolfSSL_BIO_new_socket");
         if (bio) {
             bio->type  = WOLFSSL_BIO_SOCKET;
             bio->shutdown = (byte)closeF;
@@ -2107,13 +2108,13 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
         WOLFSSL_ENTER("wolfSSL_BIO_set_conn_port");
 
         if (!b || !port) {
-            WOLFSSL_ENTER("Bad parameter");
+            WOLFSSL_MSG("Bad parameter");
             return WOLFSSL_FAILURE;
         }
 
         p = XATOI(port);
         if (!p || p < 0) {
-            WOLFSSL_ENTER("Port parsing error");
+            WOLFSSL_MSG("Port parsing error");
             return WOLFSSL_FAILURE;
         }
 
@@ -2141,7 +2142,7 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
         WOLFSSL_ENTER("wolfSSL_BIO_do_connect");
 
         if (!b) {
-            WOLFSSL_ENTER("Bad parameter");
+            WOLFSSL_MSG("Bad parameter");
             return WOLFSSL_FAILURE;
         }
 
@@ -2149,12 +2150,12 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
             b = b->next;
 
         if (!b) {
-            WOLFSSL_ENTER("No socket BIO in chain");
+            WOLFSSL_MSG("No socket BIO in chain");
             return WOLFSSL_FAILURE;
         }
 
         if (wolfIO_TcpConnect(&sfd, b->ip, b->port, 0) < 0 ) {
-            WOLFSSL_ENTER("wolfIO_TcpConnect error");
+            WOLFSSL_MSG("wolfIO_TcpConnect error");
             return WOLFSSL_FAILURE;
         }
 
@@ -2178,13 +2179,13 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
             b = b->next;
 
         if (!b) {
-            WOLFSSL_ENTER("No socket BIO in chain");
+            WOLFSSL_MSG("No socket BIO in chain");
             return WOLFSSL_FAILURE;
         }
 
         if (b->num == WOLFSSL_BIO_ERROR) {
             if (wolfIO_TcpBind(&sfd, b->port) < 0) {
-                WOLFSSL_ENTER("wolfIO_TcpBind error");
+                WOLFSSL_MSG("wolfIO_TcpBind error");
                 return WOLFSSL_FAILURE;
             }
             b->num = (int)sfd;
@@ -2194,13 +2195,13 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
             WOLFSSL_BIO* new_bio;
             int newfd = wolfIO_TcpAccept(b->num, NULL, NULL);
             if (newfd < 0) {
-                WOLFSSL_ENTER("wolfIO_TcpBind error");
+                WOLFSSL_MSG("wolfIO_TcpBind error");
                 return WOLFSSL_FAILURE;
             }
             /* Create a socket BIO for using the accept'ed connection */
             new_bio = wolfSSL_BIO_new_socket(newfd, BIO_CLOSE);
             if (new_bio == NULL) {
-                WOLFSSL_ENTER("wolfSSL_BIO_new_socket error");
+                WOLFSSL_MSG("wolfSSL_BIO_new_socket error");
                 CloseSocket(newfd);
                 return WOLFSSL_FAILURE;
             }
@@ -2210,7 +2211,7 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
                     wolfSSL_BIO_get_callback_arg(b));
             /* Push onto bio chain for user retrieval */
             if (wolfSSL_BIO_push(b, new_bio) == NULL) {
-                WOLFSSL_ENTER("wolfSSL_BIO_push error");
+                WOLFSSL_MSG("wolfSSL_BIO_push error");
                 /* newfd is closed when bio is free'd */
                 wolfSSL_BIO_free(new_bio);
                 return WOLFSSL_FAILURE;
@@ -2225,7 +2226,7 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
     int wolfSSL_BIO_eof(WOLFSSL_BIO* b)
     {
         int ret = 0;
-        WOLFSSL_ENTER("BIO_eof");
+        WOLFSSL_ENTER("wolfSSL_BIO_eof");
 
         if (b == NULL)
             return 1; /* Undefined in OpenSSL. Let's signal we're done. */
@@ -2683,7 +2684,7 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
 
     void wolfSSL_BIO_free_all(WOLFSSL_BIO* bio)
     {
-        WOLFSSL_ENTER("BIO_free_all");
+        WOLFSSL_ENTER("wolfSSL_BIO_free_all");
         while (bio) {
             WOLFSSL_BIO* next = bio->next;
             wolfSSL_BIO_free(bio);
@@ -2694,7 +2695,7 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
 
     WOLFSSL_BIO* wolfSSL_BIO_push(WOLFSSL_BIO* top, WOLFSSL_BIO* append)
     {
-        WOLFSSL_ENTER("BIO_push");
+        WOLFSSL_ENTER("wolfSSL_BIO_push");
         top->next    = append;
         append->prev = top;
 
@@ -3120,7 +3121,7 @@ int wolfSSL_BIO_new_bio_pair(WOLFSSL_BIO **bio1_p, size_t writebuf1,
     WOLFSSL_BIO *bio1 = NULL, *bio2 = NULL;
     int ret = 1;
 
-    WOLFSSL_ENTER("wolfSSL_BIO_new_bio_pair()");
+    WOLFSSL_ENTER("wolfSSL_BIO_new_bio_pair");
 
     if (bio1_p == NULL || bio2_p == NULL) {
         WOLFSSL_MSG("Bad Function Argument");

--- a/src/crl.c
+++ b/src/crl.c
@@ -234,7 +234,7 @@ void FreeCRL(WOLFSSL_CRL* crl, int dynamic)
     {
         int _pthread_ret = pthread_cond_destroy(&crl->cond);
         if (_pthread_ret != 0)
-            WOLFSSL_MSG("pthread_cond_destroy failed in FreeCRL()");
+            WOLFSSL_MSG("pthread_cond_destroy failed in FreeCRL");
     }
 #endif
     wc_FreeMutex(&crl->crlLock);

--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -343,7 +343,7 @@ int Dtls13ProcessBufferedMessages(WOLFSSL* ssl)
     word32 idx = 0;
     int ret = 0;
 
-    WOLFSSL_ENTER("Dtls13ProcessBufferedMessages()");
+    WOLFSSL_ENTER("Dtls13ProcessBufferedMessages");
 
     while (msg != NULL) {
         idx = 0;

--- a/src/internal.c
+++ b/src/internal.c
@@ -8282,7 +8282,7 @@ void WriteSEQ(WOLFSSL* ssl, int verifyOrder, byte* out)
 DtlsMsg* DtlsMsgNew(word32 sz, byte tx, void* heap)
 {
     DtlsMsg* msg;
-    WOLFSSL_ENTER("DtlsMsgNew()");
+    WOLFSSL_ENTER("DtlsMsgNew");
 
     (void)heap;
     msg = (DtlsMsg*)XMALLOC(sizeof(DtlsMsg), heap, DYNAMIC_TYPE_DTLS_MSG);
@@ -8309,7 +8309,7 @@ DtlsMsg* DtlsMsgNew(word32 sz, byte tx, void* heap)
 void DtlsMsgDelete(DtlsMsg* item, void* heap)
 {
     (void)heap;
-    WOLFSSL_ENTER("DtlsMsgDelete()");
+    WOLFSSL_ENTER("DtlsMsgDelete");
 
     if (item != NULL) {
         while (item->fragBucketList != NULL) {
@@ -8327,7 +8327,7 @@ void DtlsMsgDelete(DtlsMsg* item, void* heap)
 void DtlsMsgListDelete(DtlsMsg* head, void* heap)
 {
     DtlsMsg* next;
-    WOLFSSL_ENTER("DtlsMsgListDelete()");
+    WOLFSSL_ENTER("DtlsMsgListDelete");
     while (head) {
         next = head->next;
         DtlsMsgDelete(head, heap);
@@ -8342,7 +8342,7 @@ void DtlsTxMsgListClean(WOLFSSL* ssl)
 {
     DtlsMsg* head = ssl->dtls_tx_msg_list;
     DtlsMsg* next;
-    WOLFSSL_ENTER("DtlsTxMsgListClean()");
+    WOLFSSL_ENTER("DtlsTxMsgListClean");
     while (head) {
         next = head->next;
         if (VerifyForTxDtlsMsgDelete(ssl, head))
@@ -8554,7 +8554,7 @@ int DtlsMsgSet(DtlsMsg* msg, word32 seq, word16 epoch, const byte* data, byte ty
 {
     word32 fragOffsetEnd = fragOffset + fragSz;
 
-    WOLFSSL_ENTER("DtlsMsgSet()");
+    WOLFSSL_ENTER("DtlsMsgSet");
 
     if (msg == NULL || data == NULL || msg->sz != totalLen ||
             fragOffsetEnd > totalLen) {
@@ -8667,7 +8667,7 @@ int DtlsMsgSet(DtlsMsg* msg, word32 seq, word16 epoch, const byte* data, byte ty
 
 DtlsMsg* DtlsMsgFind(DtlsMsg* head, word16 epoch, word32 seq)
 {
-    WOLFSSL_ENTER("DtlsMsgFind()");
+    WOLFSSL_ENTER("DtlsMsgFind");
     while (head != NULL && !(head->epoch == epoch && head->seq == seq)) {
         head = head->next;
     }
@@ -8696,7 +8696,7 @@ void DtlsMsgStore(WOLFSSL* ssl, word16 epoch, word32 seq, const byte* data,
      */
 
     DtlsMsg* head = ssl->dtls_rx_msg_list;
-    WOLFSSL_ENTER("DtlsMsgStore()");
+    WOLFSSL_ENTER("DtlsMsgStore");
 
     if (head != NULL) {
         DtlsMsg* cur = DtlsMsgFind(head, epoch, seq);
@@ -8738,7 +8738,7 @@ void DtlsMsgStore(WOLFSSL* ssl, word16 epoch, word32 seq, const byte* data,
 /* DtlsMsgInsert() is an in-order insert. */
 DtlsMsg* DtlsMsgInsert(DtlsMsg* head, DtlsMsg* item)
 {
-    WOLFSSL_ENTER("DtlsMsgInsert()");
+    WOLFSSL_ENTER("DtlsMsgInsert");
     if (head == NULL || (item->epoch <= head->epoch &&
                          item->seq   <  head->seq)) {
         item->next = head;
@@ -8780,7 +8780,7 @@ int DtlsMsgPoolSave(WOLFSSL* ssl, const byte* data, word32 dataSz,
     DtlsMsg* item;
     int ret = 0;
 
-    WOLFSSL_ENTER("DtlsMsgPoolSave()");
+    WOLFSSL_ENTER("DtlsMsgPoolSave");
 
     if (ssl->dtls_tx_msg_list_sz > DTLS_POOL_SZ) {
         WOLFSSL_ERROR(DTLS_POOL_SZ_E);
@@ -8818,7 +8818,7 @@ int DtlsMsgPoolSave(WOLFSSL* ssl, const byte* data, word32 dataSz,
 int DtlsMsgPoolTimeout(WOLFSSL* ssl)
 {
     int result = -1;
-    WOLFSSL_ENTER("DtlsMsgPoolTimeout()");
+    WOLFSSL_ENTER("DtlsMsgPoolTimeout");
     if (ssl->dtls_timeout <  ssl->dtls_timeout_max) {
         ssl->dtls_timeout *= DTLS_TIMEOUT_MULTIPLIER;
         result = 0;
@@ -8831,7 +8831,7 @@ int DtlsMsgPoolTimeout(WOLFSSL* ssl)
 /* DtlsMsgPoolReset() deletes the stored transmit list. */
 void DtlsMsgPoolReset(WOLFSSL* ssl)
 {
-    WOLFSSL_ENTER("DtlsMsgPoolReset()");
+    WOLFSSL_ENTER("DtlsMsgPoolReset");
     if (ssl->dtls_tx_msg_list) {
         DtlsMsgListDelete(ssl->dtls_tx_msg_list, ssl->heap);
         ssl->dtls_tx_msg_list = NULL;
@@ -8864,7 +8864,7 @@ int VerifyForDtlsMsgPoolSend(WOLFSSL* ssl, byte type, word32 fragOffset)
  */
 int VerifyForTxDtlsMsgDelete(WOLFSSL* ssl, DtlsMsg* item)
 {
-    WOLFSSL_ENTER("VerifyForTxDtlsMsgDelete()");
+    WOLFSSL_ENTER("VerifyForTxDtlsMsgDelete");
     if (item->epoch < ssl->keys.dtls_epoch - 1)
         /* Messages not from current or previous epoch can be deleted */
         return 1;
@@ -8902,7 +8902,7 @@ int DtlsMsgPoolSend(WOLFSSL* ssl, int sendOnlyFirstPacket)
     DtlsMsg* pool;
     int epochOrder;
 
-    WOLFSSL_ENTER("DtlsMsgPoolSend()");
+    WOLFSSL_ENTER("DtlsMsgPoolSend");
 
     pool = ssl->dtls_tx_msg == NULL ? ssl->dtls_tx_msg_list : ssl->dtls_tx_msg;
 
@@ -15053,7 +15053,7 @@ int DoFinished(WOLFSSL* ssl, const byte* input, word32* inOutIdx, word32 size,
         if (!ssl->options.resuming) {
 #ifdef OPENSSL_EXTRA
             if (ssl->CBIS != NULL) {
-                ssl->CBIS(ssl, SSL_CB_CONNECT_LOOP, SSL_SUCCESS);
+                ssl->CBIS(ssl, SSL_CB_CONNECT_LOOP, WOLFSSL_SUCCESS);
             }
 #endif
             ssl->options.handShakeState = HANDSHAKE_DONE;
@@ -15069,7 +15069,7 @@ int DoFinished(WOLFSSL* ssl, const byte* input, word32* inOutIdx, word32 size,
         if (ssl->options.resuming) {
 #ifdef OPENSSL_EXTRA
             if (ssl->CBIS != NULL) {
-                ssl->CBIS(ssl, SSL_CB_ACCEPT_LOOP, SSL_SUCCESS);
+                ssl->CBIS(ssl, SSL_CB_ACCEPT_LOOP, WOLFSSL_SUCCESS);
             }
 #endif
             ssl->options.handShakeState = HANDSHAKE_DONE;
@@ -15709,7 +15709,7 @@ static int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     if (ssl->CBIS != NULL){
         ssl->cbmode = SSL_CB_MODE_READ;
         ssl->cbtype = type;
-        ssl->CBIS(ssl, SSL_CB_ACCEPT_LOOP, SSL_SUCCESS);
+        ssl->CBIS(ssl, SSL_CB_ACCEPT_LOOP, WOLFSSL_SUCCESS);
     }
 #endif
 
@@ -15942,7 +15942,7 @@ static int DoHandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     int    ret = 0;
     word32 inputLength;
 
-    WOLFSSL_ENTER("DoHandShakeMsg()");
+    WOLFSSL_ENTER("DoHandShakeMsg");
 
     if (ssl->arrays == NULL) {
         byte   type;
@@ -16460,7 +16460,7 @@ int DtlsMsgDrain(WOLFSSL* ssl)
     DtlsMsg* item = ssl->dtls_rx_msg_list;
     int ret = 0;
 
-    WOLFSSL_ENTER("DtlsMsgDrain()");
+    WOLFSSL_ENTER("DtlsMsgDrain");
 
     /* While there is an item in the store list, and it is the expected
      * message, and it is complete, and there hasn't been an error in the
@@ -16505,7 +16505,7 @@ static int DoDtlsHandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     int ret = 0;
     int ignoreFinished = 0;
 
-    WOLFSSL_ENTER("DoDtlsHandShakeMsg()");
+    WOLFSSL_ENTER("DoDtlsHandShakeMsg");
 
     /* parse header */
     if (GetDtlsHandShakeHeader(ssl, input, inOutIdx, &type,
@@ -20201,13 +20201,13 @@ int SendChangeCipher(WOLFSSL* ssl)
     if (ssl->options.side == WOLFSSL_SERVER_END){
         ssl->options.serverState = SERVER_CHANGECIPHERSPEC_COMPLETE;
         if (ssl->CBIS != NULL)
-            ssl->CBIS(ssl, SSL_CB_ACCEPT_LOOP, SSL_SUCCESS);
+            ssl->CBIS(ssl, SSL_CB_ACCEPT_LOOP, WOLFSSL_SUCCESS);
     }
     else{
         ssl->options.clientState =
             CLIENT_CHANGECIPHERSPEC_COMPLETE;
         if (ssl->CBIS != NULL)
-            ssl->CBIS(ssl, SSL_CB_CONNECT_LOOP, SSL_SUCCESS);
+            ssl->CBIS(ssl, SSL_CB_CONNECT_LOOP, WOLFSSL_SUCCESS);
     }
     #endif
 
@@ -21217,7 +21217,7 @@ int SendFinished(WOLFSSL* ssl)
             ssl->options.serverState = SERVER_FINISHED_COMPLETE;
             ssl->cbmode = SSL_CB_MODE_WRITE;
             if (ssl->CBIS != NULL)
-                ssl->CBIS(ssl, SSL_CB_HANDSHAKE_DONE, SSL_SUCCESS);
+                ssl->CBIS(ssl, SSL_CB_HANDSHAKE_DONE, WOLFSSL_SUCCESS);
         #endif
             ssl->options.handShakeState = HANDSHAKE_DONE;
             ssl->options.handShakeDone  = 1;
@@ -21229,7 +21229,7 @@ int SendFinished(WOLFSSL* ssl)
             ssl->options.clientState = CLIENT_FINISHED_COMPLETE;
             ssl->cbmode = SSL_CB_MODE_WRITE;
             if (ssl->CBIS != NULL)
-                ssl->CBIS(ssl, SSL_CB_HANDSHAKE_DONE, SSL_SUCCESS);
+                ssl->CBIS(ssl, SSL_CB_HANDSHAKE_DONE, WOLFSSL_SUCCESS);
         #endif
             ssl->options.handShakeState = HANDSHAKE_DONE;
             ssl->options.handShakeDone  = 1;
@@ -22618,7 +22618,7 @@ int ReceiveData(WOLFSSL* ssl, byte* output, int sz, int peek)
 {
     int size;
 
-    WOLFSSL_ENTER("ReceiveData()");
+    WOLFSSL_ENTER("ReceiveData");
 
     /* reset error state */
     if (ssl->error == WANT_READ || ssl->error == WOLFSSL_ERROR_WANT_READ) {
@@ -26447,7 +26447,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
 #ifdef OPENSSL_EXTRA
         ssl->cbmode = SSL_CB_MODE_WRITE;
         if (ssl->CBIS != NULL)
-            ssl->CBIS(ssl, SSL_CB_CONNECT_LOOP, SSL_SUCCESS);
+            ssl->CBIS(ssl, SSL_CB_CONNECT_LOOP, WOLFSSL_SUCCESS);
 #endif
 
 #if defined(WOLFSSL_CALLBACKS) || defined(OPENSSL_EXTRA)
@@ -26579,7 +26579,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
 
         #ifdef OPENSSL_EXTRA
         if (ssl->CBIS != NULL) {
-            ssl->CBIS(ssl, SSL_CB_HANDSHAKE_START, SSL_SUCCESS);
+            ssl->CBIS(ssl, SSL_CB_HANDSHAKE_START, WOLFSSL_SUCCESS);
         }
         #endif
 
@@ -28707,7 +28707,7 @@ int SendClientKeyExchange(WOLFSSL* ssl)
     ssl->options.clientState = CLIENT_KEYEXCHANGE_COMPLETE;
     ssl->cbmode = SSL_CB_MODE_WRITE;
     if (ssl->CBIS != NULL)
-        ssl->CBIS(ssl, SSL_CB_CONNECT_LOOP, SSL_SUCCESS);
+        ssl->CBIS(ssl, SSL_CB_CONNECT_LOOP, WOLFSSL_SUCCESS);
 #endif
 
 #ifdef WOLFSSL_ASYNC_IO

--- a/src/pk.c
+++ b/src/pk.c
@@ -1472,7 +1472,7 @@ WOLFSSL_RSA* wolfSSL_d2i_RSAPrivateKey_bio(WOLFSSL_BIO *bio, WOLFSSL_RSA **out)
     int derLen = 0;
     int err;
 
-    WOLFSSL_ENTER("wolfSSL_d2i_RSAPrivateKey_bio()");
+    WOLFSSL_ENTER("wolfSSL_d2i_RSAPrivateKey_bio");
 
     /* Validate parameters. */
     err = (bio == NULL);
@@ -4120,7 +4120,7 @@ int wolfSSL_RSA_public_encrypt(int len, const unsigned char* from,
 #endif
     int outLen = 0;
 
-    WOLFSSL_ENTER("RSA_public_encrypt");
+    WOLFSSL_ENTER("wolfSSL_RSA_public_encrypt");
 
     /* Validate parameters. */
     if ((len < 0) || (rsa == NULL) || (rsa->internal == NULL) ||
@@ -4206,7 +4206,7 @@ int wolfSSL_RSA_public_encrypt(int len, const unsigned char* from,
     if (ret <= 0) {
         ret = -1;
     }
-    WOLFSSL_LEAVE("RSA_public_encrypt", ret);
+    WOLFSSL_LEAVE("wolfSSL_RSA_public_encrypt", ret);
     return ret;
 }
 
@@ -4233,7 +4233,7 @@ int wolfSSL_RSA_private_decrypt(int len, const unsigned char* from,
 #endif
     int outLen = 0;
 
-    WOLFSSL_ENTER("RSA_private_decrypt");
+    WOLFSSL_ENTER("wolfSSL_RSA_private_decrypt");
 
     /* Validate parameters. */
     if ((len < 0) || (rsa == NULL) || (rsa->internal == NULL) ||
@@ -4301,7 +4301,7 @@ int wolfSSL_RSA_private_decrypt(int len, const unsigned char* from,
     if (ret <= 0) {
         ret = -1;
     }
-    WOLFSSL_LEAVE("RSA_private_decrypt", ret);
+    WOLFSSL_LEAVE("wolfSSL_RSA_private_decrypt", ret);
     return ret;
 }
 
@@ -4324,7 +4324,7 @@ int wolfSSL_RSA_public_decrypt(int len, const unsigned char* from,
 #endif
     int outLen = 0;
 
-    WOLFSSL_ENTER("RSA_public_decrypt");
+    WOLFSSL_ENTER("wolfSSL_RSA_public_decrypt");
 
     /* Validate parameters. */
     if ((len < 0) || (rsa == NULL) || (rsa->internal == NULL) ||
@@ -4386,7 +4386,7 @@ int wolfSSL_RSA_public_decrypt(int len, const unsigned char* from,
     if (ret <= 0) {
         ret = -1;
     }
-    WOLFSSL_LEAVE("RSA_public_decrypt", ret);
+    WOLFSSL_LEAVE("wolfSSL_RSA_public_decrypt", ret);
     return ret;
 }
 
@@ -4924,7 +4924,7 @@ WOLFSSL_DSA* wolfSSL_DSA_generate_parameters(int bits, unsigned char* seed,
 {
     WOLFSSL_DSA* dsa;
 
-    WOLFSSL_ENTER("wolfSSL_DSA_generate_parameters()");
+    WOLFSSL_ENTER("wolfSSL_DSA_generate_parameters");
 
     (void)cb;
     (void)CBArg;
@@ -8743,7 +8743,7 @@ int wolfSSL_EC_METHOD_get_field_type(const WOLFSSL_EC_METHOD *meth)
  */
 int EccEnumToNID(int n)
 {
-    WOLFSSL_ENTER("EccEnumToNID()");
+    WOLFSSL_ENTER("EccEnumToNID");
 
     switch(n) {
         case ECC_SECP192R1:
@@ -8821,7 +8821,7 @@ int NIDToEccEnum(int nid)
     /* -1 on error. */
     int id = -1;
 
-    WOLFSSL_ENTER("NIDToEccEnum()");
+    WOLFSSL_ENTER("NIDToEccEnum");
 
     switch (nid) {
         case NID_X9_62_prime192v1:
@@ -9979,7 +9979,7 @@ size_t wolfSSL_EC_POINT_point2oct(const WOLFSSL_EC_GROUP *group,
     int compressed = ((form == POINT_CONVERSION_COMPRESSED) ? 1 : 0);
 #endif /* !HAVE_SELFTEST */
 
-    WOLFSSL_ENTER("EC_POINT_point2oct");
+    WOLFSSL_ENTER("wolfSSL_EC_POINT_point2oct");
 
     /* No BN operations performed. */
     (void)ctx;

--- a/src/quic.c
+++ b/src/quic.c
@@ -379,7 +379,7 @@ int wolfSSL_set_quic_transport_params(WOLFSSL* ssl,
     const QuicTransportParam* tp;
     int ret = WOLFSSL_SUCCESS;
 
-    WOLFSSL_ENTER("SSL_set_quic_transport_params");
+    WOLFSSL_ENTER("wolfSSL_set_quic_transport_params");
 
     if (!params || params_len == 0) {
         tp = NULL;
@@ -396,7 +396,7 @@ int wolfSSL_set_quic_transport_params(WOLFSSL* ssl,
     ssl->quic.transport_local = tp;
 
 cleanup:
-    WOLFSSL_LEAVE("SSL_set_quic_transport_params", ret);
+    WOLFSSL_LEAVE("wolfSSL_set_quic_transport_params", ret);
     return ret;
 }
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -244,14 +244,16 @@ int wc_OBJ_sn2nid(const char *sn)
     char curveName[ECC_MAXNAME + 1];
     int eccEnum;
 #endif
-    WOLFSSL_ENTER("OBJ_sn2nid");
+
+    WOLFSSL_ENTER("wc_OBJ_sn2nid");
+
     for(i=0; sn2nid[i].sn != NULL; i++) {
         if (XSTRCMP(sn, sn2nid[i].sn) == 0) {
             return sn2nid[i].nid;
         }
     }
-#ifdef HAVE_ECC
 
+#ifdef HAVE_ECC
     if (XSTRLEN(sn) > ECC_MAXNAME)
         return NID_undef;
 
@@ -1214,7 +1216,7 @@ WOLFSSL_CTX* wolfSSL_CTX_new_ex(WOLFSSL_METHOD* method, void* heap)
         int ret = wolfSSL_Init();
         if (ret != WOLFSSL_SUCCESS) {
             WOLFSSL_MSG("wolfSSL_Init failed");
-            WOLFSSL_LEAVE("WOLFSSL_CTX_new", 0);
+            WOLFSSL_LEAVE("wolfSSL_CTX_new_ex", 0);
             if (method != NULL) {
                 XFREE(method, heap, DYNAMIC_TYPE_METHOD);
             }
@@ -1276,7 +1278,7 @@ WOLFSSL_CTX* wolfSSL_CTX_new_ex(WOLFSSL_METHOD* method, void* heap)
     }
 #endif
 
-    WOLFSSL_LEAVE("WOLFSSL_CTX_new", 0);
+    WOLFSSL_LEAVE("wolfSSL_CTX_new_ex", 0);
     return ctx;
 }
 
@@ -1308,7 +1310,7 @@ int wolfSSL_CTX_up_ref(WOLFSSL_CTX* ctx)
 WOLFSSL_ABI
 void wolfSSL_CTX_free(WOLFSSL_CTX* ctx)
 {
-    WOLFSSL_ENTER("SSL_CTX_free");
+    WOLFSSL_ENTER("wolfSSL_CTX_free");
     if (ctx) {
 #if defined(OPENSSL_EXTRA) && defined(WOLFCRYPT_HAVE_SRP) \
 && !defined(NO_SHA256) && !defined(WC_NO_RNG)
@@ -1325,7 +1327,7 @@ void wolfSSL_CTX_free(WOLFSSL_CTX* ctx)
         FreeSSL_Ctx(ctx);
     }
 
-    WOLFSSL_LEAVE("SSL_CTX_free", 0);
+    WOLFSSL_LEAVE("wolfSSL_CTX_free", 0);
 }
 
 
@@ -1398,7 +1400,7 @@ WOLFSSL* wolfSSL_new(WOLFSSL_CTX* ctx)
     WOLFSSL* ssl = NULL;
     int ret = 0;
 
-    WOLFSSL_ENTER("SSL_new");
+    WOLFSSL_ENTER("wolfSSL_new");
 
     if (ctx == NULL)
         return ssl;
@@ -1410,7 +1412,7 @@ WOLFSSL* wolfSSL_new(WOLFSSL_CTX* ctx)
             ssl = 0;
         }
 
-    WOLFSSL_LEAVE("SSL_new", ret);
+    WOLFSSL_LEAVE("wolfSSL_new", ret);
     (void)ret;
 
     return ssl;
@@ -1420,10 +1422,10 @@ WOLFSSL* wolfSSL_new(WOLFSSL_CTX* ctx)
 WOLFSSL_ABI
 void wolfSSL_free(WOLFSSL* ssl)
 {
-    WOLFSSL_ENTER("SSL_free");
+    WOLFSSL_ENTER("wolfSSL_free");
     if (ssl)
         FreeSSL(ssl, ssl->ctx->heap);
-    WOLFSSL_LEAVE("SSL_free", 0);
+    WOLFSSL_LEAVE("wolfSSL_free", 0);
 }
 
 
@@ -1611,11 +1613,11 @@ int wolfSSL_use_old_poly(WOLFSSL* ssl, int value)
     (void)value;
 
 #ifndef WOLFSSL_NO_TLS12
-    WOLFSSL_ENTER("SSL_use_old_poly");
+    WOLFSSL_ENTER("wolfSSL_use_old_poly");
     WOLFSSL_MSG("Warning SSL connection auto detects old/new and this function"
             "is depreciated");
     ssl->options.oldPoly = (word16)value;
-    WOLFSSL_LEAVE("SSL_use_old_poly", 0);
+    WOLFSSL_LEAVE("wolfSSL_use_old_poly", 0);
 #endif
     return 0;
 }
@@ -1627,7 +1629,7 @@ int wolfSSL_set_fd(WOLFSSL* ssl, int fd)
 {
     int ret;
 
-    WOLFSSL_ENTER("SSL_set_fd");
+    WOLFSSL_ENTER("wolfSSL_set_fd");
 
     if (ssl == NULL) {
         return BAD_FUNC_ARG;
@@ -1646,7 +1648,7 @@ int wolfSSL_set_dtls_fd_connected(WOLFSSL* ssl, int fd)
 {
     int ret;
 
-    WOLFSSL_ENTER("SSL_set_dtls_fd_connected");
+    WOLFSSL_ENTER("wolfSSL_set_dtls_fd_connected");
 
     if (ssl == NULL) {
         return BAD_FUNC_ARG;
@@ -1663,7 +1665,7 @@ int wolfSSL_set_dtls_fd_connected(WOLFSSL* ssl, int fd)
 
 int wolfSSL_set_read_fd(WOLFSSL* ssl, int fd)
 {
-    WOLFSSL_ENTER("SSL_set_read_fd");
+    WOLFSSL_ENTER("wolfSSL_set_read_fd");
 
     if (ssl == NULL) {
         return BAD_FUNC_ARG;
@@ -1680,14 +1682,14 @@ int wolfSSL_set_read_fd(WOLFSSL* ssl, int fd)
         }
     #endif
 
-    WOLFSSL_LEAVE("SSL_set_read_fd", WOLFSSL_SUCCESS);
+    WOLFSSL_LEAVE("wolfSSL_set_read_fd", WOLFSSL_SUCCESS);
     return WOLFSSL_SUCCESS;
 }
 
 
 int wolfSSL_set_write_fd(WOLFSSL* ssl, int fd)
 {
-    WOLFSSL_ENTER("SSL_set_write_fd");
+    WOLFSSL_ENTER("wolfSSL_set_write_fd");
 
     if (ssl == NULL) {
         return BAD_FUNC_ARG;
@@ -1704,7 +1706,7 @@ int wolfSSL_set_write_fd(WOLFSSL* ssl, int fd)
         }
     #endif
 
-    WOLFSSL_LEAVE("SSL_set_write_fd", WOLFSSL_SUCCESS);
+    WOLFSSL_LEAVE("wolfSSL_set_write_fd", WOLFSSL_SUCCESS);
     return WOLFSSL_SUCCESS;
 }
 
@@ -1835,11 +1837,11 @@ const char* wolfSSL_get_shared_ciphers(WOLFSSL* ssl, char* buf, int len)
 int wolfSSL_get_fd(const WOLFSSL* ssl)
 {
     int fd = -1;
-    WOLFSSL_ENTER("SSL_get_fd");
+    WOLFSSL_ENTER("wolfSSL_get_fd");
     if (ssl) {
         fd = ssl->rfd;
     }
-    WOLFSSL_LEAVE("SSL_get_fd", fd);
+    WOLFSSL_LEAVE("wolfSSL_get_fd", fd);
     return fd;
 }
 
@@ -2043,7 +2045,7 @@ int wolfSSL_dtls_get_peer(WOLFSSL* ssl, void* peer, unsigned int* peerSz)
 
 int wolfSSL_CTX_dtls_set_sctp(WOLFSSL_CTX* ctx)
 {
-    WOLFSSL_ENTER("wolfSSL_CTX_dtls_set_sctp()");
+    WOLFSSL_ENTER("wolfSSL_CTX_dtls_set_sctp");
 
     if (ctx == NULL)
         return BAD_FUNC_ARG;
@@ -2055,7 +2057,7 @@ int wolfSSL_CTX_dtls_set_sctp(WOLFSSL_CTX* ctx)
 
 int wolfSSL_dtls_set_sctp(WOLFSSL* ssl)
 {
-    WOLFSSL_ENTER("wolfSSL_dtls_set_sctp()");
+    WOLFSSL_ENTER("wolfSSL_dtls_set_sctp");
 
     if (ssl == NULL)
         return BAD_FUNC_ARG;
@@ -2249,7 +2251,7 @@ int wolfSSL_dtls_get_drop_stats(WOLFSSL* ssl,
 {
     int ret;
 
-    WOLFSSL_ENTER("wolfSSL_dtls_get_drop_stats()");
+    WOLFSSL_ENTER("wolfSSL_dtls_get_drop_stats");
 
     if (ssl == NULL)
         ret = BAD_FUNC_ARG;
@@ -2261,7 +2263,7 @@ int wolfSSL_dtls_get_drop_stats(WOLFSSL* ssl,
             *replayDropCount = ssl->replayDropCount;
     }
 
-    WOLFSSL_LEAVE("wolfSSL_dtls_get_drop_stats()", ret);
+    WOLFSSL_LEAVE("wolfSSL_dtls_get_drop_stats", ret);
     return ret;
 }
 
@@ -2274,7 +2276,7 @@ int wolfSSL_CTX_mcast_set_member_id(WOLFSSL_CTX* ctx, word16 id)
 {
     int ret = 0;
 
-    WOLFSSL_ENTER("wolfSSL_CTX_mcast_set_member_id()");
+    WOLFSSL_ENTER("wolfSSL_CTX_mcast_set_member_id");
 
     if (ctx == NULL || id > 255)
         ret = BAD_FUNC_ARG;
@@ -2289,7 +2291,7 @@ int wolfSSL_CTX_mcast_set_member_id(WOLFSSL_CTX* ctx, word16 id)
 
         ret = WOLFSSL_SUCCESS;
     }
-    WOLFSSL_LEAVE("wolfSSL_CTX_mcast_set_member_id()", ret);
+    WOLFSSL_LEAVE("wolfSSL_CTX_mcast_set_member_id", ret);
     return ret;
 }
 
@@ -2323,7 +2325,7 @@ int wolfSSL_set_secret(WOLFSSL* ssl, word16 epoch,
 {
     int ret = 0;
 
-    WOLFSSL_ENTER("wolfSSL_set_secret()");
+    WOLFSSL_ENTER("wolfSSL_set_secret");
 
     if (ssl == NULL || preMasterSecret == NULL ||
         preMasterSz == 0 || preMasterSz > ENCRYPT_LEN ||
@@ -2396,7 +2398,7 @@ int wolfSSL_set_secret(WOLFSSL* ssl, word16 epoch,
             ssl->error = ret;
         ret = WOLFSSL_FATAL_ERROR;
     }
-    WOLFSSL_LEAVE("wolfSSL_set_secret()", ret);
+    WOLFSSL_LEAVE("wolfSSL_set_secret", ret);
     return ret;
 }
 
@@ -2409,7 +2411,7 @@ int wolfSSL_mcast_peer_add(WOLFSSL* ssl, word16 peerId, int sub)
     int ret = WOLFSSL_SUCCESS;
     int i;
 
-    WOLFSSL_ENTER("wolfSSL_mcast_peer_add()");
+    WOLFSSL_ENTER("wolfSSL_mcast_peer_add");
     if (ssl == NULL || peerId > 255)
         return BAD_FUNC_ARG;
 
@@ -2452,7 +2454,7 @@ int wolfSSL_mcast_peer_add(WOLFSSL* ssl, word16 peerId, int sub)
         }
     }
 
-    WOLFSSL_LEAVE("wolfSSL_mcast_peer_add()", ret);
+    WOLFSSL_LEAVE("wolfSSL_mcast_peer_add", ret);
     return ret;
 }
 
@@ -2464,7 +2466,7 @@ int wolfSSL_mcast_peer_known(WOLFSSL* ssl, unsigned short peerId)
     int known = 0;
     int i;
 
-    WOLFSSL_ENTER("wolfSSL_mcast_peer_known()");
+    WOLFSSL_ENTER("wolfSSL_mcast_peer_known");
 
     if (ssl == NULL || peerId > 255) {
         return BAD_FUNC_ARG;
@@ -2481,7 +2483,7 @@ int wolfSSL_mcast_peer_known(WOLFSSL* ssl, unsigned short peerId)
         }
     }
 
-    WOLFSSL_LEAVE("wolfSSL_mcast_peer_known()", known);
+    WOLFSSL_LEAVE("wolfSSL_mcast_peer_known", known);
     return known;
 }
 
@@ -3139,7 +3141,7 @@ int wolfSSL_write(WOLFSSL* ssl, const void* data, int sz)
 {
     int ret;
 
-    WOLFSSL_ENTER("SSL_write()");
+    WOLFSSL_ENTER("wolfSSL_write");
 
     if (ssl == NULL || data == NULL || sz < 0)
         return BAD_FUNC_ARG;
@@ -3200,7 +3202,7 @@ int wolfSSL_write(WOLFSSL* ssl, const void* data, int sz)
     #endif
     ret = SendData(ssl, data, sz);
 
-    WOLFSSL_LEAVE("SSL_write()", ret);
+    WOLFSSL_LEAVE("wolfSSL_write", ret);
 
     if (ret < 0)
         return WOLFSSL_FATAL_ERROR;
@@ -3212,7 +3214,7 @@ static int wolfSSL_read_internal(WOLFSSL* ssl, void* data, int sz, int peek)
 {
     int ret;
 
-    WOLFSSL_ENTER("wolfSSL_read_internal()");
+    WOLFSSL_ENTER("wolfSSL_read_internal");
 
     if (ssl == NULL || data == NULL || sz < 0)
         return BAD_FUNC_ARG;
@@ -3294,7 +3296,7 @@ static int wolfSSL_read_internal(WOLFSSL* ssl, void* data, int sz, int peek)
     }
 #endif
 
-    WOLFSSL_LEAVE("wolfSSL_read_internal()", ret);
+    WOLFSSL_LEAVE("wolfSSL_read_internal", ret);
 
     if (ret < 0)
         return WOLFSSL_FATAL_ERROR;
@@ -3305,7 +3307,7 @@ static int wolfSSL_read_internal(WOLFSSL* ssl, void* data, int sz, int peek)
 
 int wolfSSL_peek(WOLFSSL* ssl, void* data, int sz)
 {
-    WOLFSSL_ENTER("wolfSSL_peek()");
+    WOLFSSL_ENTER("wolfSSL_peek");
 
     return wolfSSL_read_internal(ssl, data, sz, TRUE);
 }
@@ -3314,7 +3316,7 @@ int wolfSSL_peek(WOLFSSL* ssl, void* data, int sz)
 WOLFSSL_ABI
 int wolfSSL_read(WOLFSSL* ssl, void* data, int sz)
 {
-    WOLFSSL_ENTER("wolfSSL_read()");
+    WOLFSSL_ENTER("wolfSSL_read");
 
     #ifdef OPENSSL_EXTRA
     if (ssl == NULL) {
@@ -3335,7 +3337,7 @@ int wolfSSL_mcast_read(WOLFSSL* ssl, word16* id, void* data, int sz)
 {
     int ret = 0;
 
-    WOLFSSL_ENTER("wolfSSL_mcast_read()");
+    WOLFSSL_ENTER("wolfSSL_mcast_read");
 
     if (ssl == NULL)
         return BAD_FUNC_ARG;
@@ -4303,7 +4305,7 @@ int wolfSSL_send(WOLFSSL* ssl, const void* data, int sz, int flags)
     int ret;
     int oldFlags;
 
-    WOLFSSL_ENTER("wolfSSL_send()");
+    WOLFSSL_ENTER("wolfSSL_send");
 
     if (ssl == NULL || data == NULL || sz < 0)
         return BAD_FUNC_ARG;
@@ -4314,7 +4316,7 @@ int wolfSSL_send(WOLFSSL* ssl, const void* data, int sz, int flags)
     ret = wolfSSL_write(ssl, data, sz);
     ssl->wflags = oldFlags;
 
-    WOLFSSL_LEAVE("wolfSSL_send()", ret);
+    WOLFSSL_LEAVE("wolfSSL_send", ret);
 
     return ret;
 }
@@ -4325,7 +4327,7 @@ int wolfSSL_recv(WOLFSSL* ssl, void* data, int sz, int flags)
     int ret;
     int oldFlags;
 
-    WOLFSSL_ENTER("wolfSSL_recv()");
+    WOLFSSL_ENTER("wolfSSL_recv");
 
     if (ssl == NULL || data == NULL || sz < 0)
         return BAD_FUNC_ARG;
@@ -4336,7 +4338,7 @@ int wolfSSL_recv(WOLFSSL* ssl, void* data, int sz, int flags)
     ret = wolfSSL_read(ssl, data, sz);
     ssl->rflags = oldFlags;
 
-    WOLFSSL_LEAVE("wolfSSL_recv()", ret);
+    WOLFSSL_LEAVE("wolfSSL_recv", ret);
 
     return ret;
 }
@@ -4348,7 +4350,7 @@ WOLFSSL_ABI
 int wolfSSL_shutdown(WOLFSSL* ssl)
 {
     int  ret = WOLFSSL_FATAL_ERROR;
-    WOLFSSL_ENTER("SSL_shutdown()");
+    WOLFSSL_ENTER("wolfSSL_shutdown");
 
     if (ssl == NULL)
         return WOLFSSL_FATAL_ERROR;
@@ -4373,7 +4375,7 @@ int wolfSSL_shutdown(WOLFSSL* ssl)
             }
             else {
                 ret = WOLFSSL_SHUTDOWN_NOT_DONE;
-                WOLFSSL_LEAVE("SSL_shutdown()", ret);
+                WOLFSSL_LEAVE("wolfSSL_shutdown", ret);
                 return ret;
             }
         }
@@ -4414,7 +4416,7 @@ int wolfSSL_shutdown(WOLFSSL* ssl)
     }
 #endif
 
-    WOLFSSL_LEAVE("SSL_shutdown()", ret);
+    WOLFSSL_LEAVE("wolfSSL_shutdown", ret);
 
     return ret;
 }
@@ -4434,14 +4436,14 @@ int wolfSSL_state(WOLFSSL* ssl)
 WOLFSSL_ABI
 int wolfSSL_get_error(WOLFSSL* ssl, int ret)
 {
-    WOLFSSL_ENTER("SSL_get_error");
+    WOLFSSL_ENTER("wolfSSL_get_error");
 
     if (ret > 0)
         return WOLFSSL_ERROR_NONE;
     if (ssl == NULL)
         return BAD_FUNC_ARG;
 
-    WOLFSSL_LEAVE("SSL_get_error", ssl->error);
+    WOLFSSL_LEAVE("wolfSSL_get_error", ssl->error);
 
     /* make sure converted types are handled in SetErrorString() too */
     if (ssl->error == WANT_READ)
@@ -4481,7 +4483,7 @@ int wolfSSL_want(WOLFSSL* ssl)
 /* return TRUE if current error is want read */
 int wolfSSL_want_read(WOLFSSL* ssl)
 {
-    WOLFSSL_ENTER("SSL_want_read");
+    WOLFSSL_ENTER("wolfSSL_want_read");
     if (ssl->error == WANT_READ)
         return 1;
 
@@ -4492,7 +4494,7 @@ int wolfSSL_want_read(WOLFSSL* ssl)
 /* return TRUE if current error is want write */
 int wolfSSL_want_write(WOLFSSL* ssl)
 {
-    WOLFSSL_ENTER("SSL_want_write");
+    WOLFSSL_ENTER("wolfSSL_want_write");
     if (ssl->error == WANT_WRITE)
         return 1;
 
@@ -4504,7 +4506,7 @@ char* wolfSSL_ERR_error_string(unsigned long errNumber, char* data)
 {
     static char tmp[WOLFSSL_MAX_ERROR_SZ] = {0};
 
-    WOLFSSL_ENTER("ERR_error_string");
+    WOLFSSL_ENTER("wolfSSL_ERR_error_string");
     if (data) {
         SetErrorString((int)errNumber, data);
         return data;
@@ -5296,7 +5298,7 @@ void wolfSSL_ERR_print_errors_cb (int (*cb)(const char *str, size_t len,
 WOLFSSL_ABI
 int wolfSSL_pending(WOLFSSL* ssl)
 {
-    WOLFSSL_ENTER("SSL_pending");
+    WOLFSSL_ENTER("wolfSSL_pending");
     if (ssl == NULL)
         return WOLFSSL_FAILURE;
 
@@ -10361,7 +10363,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PUBKEY_bio(WOLFSSL_BIO* bio,
     long memSz;
     WOLFSSL_EVP_PKEY* pkey = NULL;
 
-    WOLFSSL_ENTER("wolfSSL_d2i_PUBKEY_bio()");
+    WOLFSSL_ENTER("wolfSSL_d2i_PUBKEY_bio");
 
     if (bio == NULL) {
         return NULL;
@@ -11028,7 +11030,7 @@ int wolfSSL_SetTmpEC_DHE_Sz(WOLFSSL* ssl, word16 sz)
 int wolfSSL_CTX_use_RSAPrivateKey_file(WOLFSSL_CTX* ctx,const char* file,
                                    int format)
 {
-    WOLFSSL_ENTER("SSL_CTX_use_RSAPrivateKey_file");
+    WOLFSSL_ENTER("wolfSSL_CTX_use_RSAPrivateKey_file");
 
     return wolfSSL_CTX_use_PrivateKey_file(ctx, file, format);
 }
@@ -11152,7 +11154,7 @@ void wolfSSL_CTX_set_verify(WOLFSSL_CTX* ctx, int mode, VerifyCallback vc)
 void wolfSSL_CTX_set_cert_verify_callback(WOLFSSL_CTX* ctx,
     CertVerifyCallback cb, void* arg)
 {
-    WOLFSSL_ENTER("SSL_CTX_set_cert_verify_callback");
+    WOLFSSL_ENTER("wolfSSL_CTX_set_cert_verify_callback");
     if (ctx == NULL)
         return;
 
@@ -11336,7 +11338,7 @@ int wolfSSL_CTX_get_cert_cache_memsize(WOLFSSL_CTX* ctx)
 WOLFSSL_ABI
 WOLFSSL_SESSION* wolfSSL_get_session(WOLFSSL* ssl)
 {
-    WOLFSSL_ENTER("SSL_get_session");
+    WOLFSSL_ENTER("wolfSSL_get_session");
     if (ssl) {
 #ifdef NO_SESSION_CACHE_REF
         return ssl->session;
@@ -11385,7 +11387,7 @@ WOLFSSL_SESSION* wolfSSL_get_session(WOLFSSL* ssl)
 WOLFSSL_SESSION* wolfSSL_get1_session(WOLFSSL* ssl)
 {
     WOLFSSL_SESSION* sess = NULL;
-    WOLFSSL_ENTER("SSL_get1_session");
+    WOLFSSL_ENTER("wolfSSL_get1_session");
     if (ssl != NULL) {
         sess = ssl->session;
         if (sess != NULL) {
@@ -11421,7 +11423,7 @@ WOLFSSL_SESSION* wolfSSL_get1_session(WOLFSSL* ssl)
 WOLFSSL_ABI
 int wolfSSL_set_session(WOLFSSL* ssl, WOLFSSL_SESSION* session)
 {
-    WOLFSSL_ENTER("SSL_set_session");
+    WOLFSSL_ENTER("wolfSSL_set_session");
     if (session)
         return wolfSSL_SetSession(ssl, session);
 
@@ -11814,7 +11816,7 @@ void wolfSSL_load_error_strings(void)
 
 int wolfSSL_library_init(void)
 {
-    WOLFSSL_ENTER("SSL_library_init");
+    WOLFSSL_ENTER("wolfSSL_library_init");
     if (wolfSSL_Init() == WOLFSSL_SUCCESS)
         return WOLFSSL_SUCCESS;
     else
@@ -11850,7 +11852,7 @@ int wolfSSL_set_session_secret_cb(WOLFSSL* ssl, SessionSecretCb cb, void* ctx)
 WOLFSSL_ABI
 long wolfSSL_CTX_set_session_cache_mode(WOLFSSL_CTX* ctx, long mode)
 {
-    WOLFSSL_ENTER("SSL_CTX_set_session_cache_mode");
+    WOLFSSL_ENTER("wolfSSL_CTX_set_session_cache_mode");
 
     if (ctx == NULL)
         return WOLFSSL_FAILURE;
@@ -11881,7 +11883,7 @@ long wolfSSL_CTX_get_session_cache_mode(WOLFSSL_CTX* ctx)
 {
     long m = 0;
 
-    WOLFSSL_ENTER("SSL_CTX_set_session_cache_mode");
+    WOLFSSL_ENTER("wolfSSL_CTX_get_session_cache_mode");
 
     if (ctx == NULL) {
         return m;
@@ -12813,7 +12815,7 @@ int wolfSSL_dtls_get_current_timeout(WOLFSSL* ssl)
     if (ssl)
         timeout = ssl->dtls_timeout;
 
-    WOLFSSL_LEAVE("wolfSSL_dtls_get_current_timeout()", timeout);
+    WOLFSSL_LEAVE("wolfSSL_dtls_get_current_timeout", timeout);
     return timeout;
 }
 
@@ -12906,7 +12908,7 @@ int wolfSSL_dtls_set_timeout_max(WOLFSSL* ssl, int timeout)
 int wolfSSL_dtls_got_timeout(WOLFSSL* ssl)
 {
     int result = WOLFSSL_SUCCESS;
-    WOLFSSL_ENTER("wolfSSL_dtls_got_timeout()");
+    WOLFSSL_ENTER("wolfSSL_dtls_got_timeout");
 
     if (ssl == NULL)
         return WOLFSSL_FATAL_ERROR;
@@ -12943,7 +12945,7 @@ int wolfSSL_dtls_got_timeout(WOLFSSL* ssl)
         }
     }
 
-    WOLFSSL_LEAVE("wolfSSL_dtls_got_timeout()", result);
+    WOLFSSL_LEAVE("wolfSSL_dtls_got_timeout", result);
     return result;
 }
 
@@ -12951,7 +12953,7 @@ int wolfSSL_dtls_got_timeout(WOLFSSL* ssl)
 /* retransmit all the saves messages, WOLFSSL_SUCCESS on ok */
 int wolfSSL_dtls_retransmit(WOLFSSL* ssl)
 {
-    WOLFSSL_ENTER("wolfSSL_dtls_retransmit()");
+    WOLFSSL_ENTER("wolfSSL_dtls_retransmit");
 
     if (ssl == NULL)
         return WOLFSSL_FATAL_ERROR;
@@ -13047,7 +13049,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
     WOLFSSL_METHOD* wolfSSLv23_method_ex(void* heap)
     {
         WOLFSSL_METHOD* m = NULL;
-        WOLFSSL_ENTER("SSLv23_method");
+        WOLFSSL_ENTER("wolfSSLv23_method");
     #if !defined(NO_WOLFSSL_CLIENT)
         m = wolfSSLv23_client_method_ex(heap);
     #elif !defined(NO_WOLFSSL_SERVER)
@@ -13070,7 +13072,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
     WOLFSSL_METHOD* wolfSSLv3_method_ex(void* heap)
     {
         WOLFSSL_METHOD* m = NULL;
-        WOLFSSL_ENTER("SSLv3_method");
+        WOLFSSL_ENTER("wolfSSLv3_method_ex");
     #if !defined(NO_WOLFSSL_CLIENT)
         m = wolfSSLv3_client_method_ex(heap);
     #elif !defined(NO_WOLFSSL_SERVER)
@@ -13107,7 +13109,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
                               (WOLFSSL_METHOD*) XMALLOC(sizeof(WOLFSSL_METHOD),
                                                      heap, DYNAMIC_TYPE_METHOD);
         (void)heap;
-        WOLFSSL_ENTER("SSLv3_client_method_ex");
+        WOLFSSL_ENTER("wolfSSLv3_client_method_ex");
         if (method)
             InitSSL_Method(method, MakeSSLv3());
         return method;
@@ -13125,7 +13127,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
                               (WOLFSSL_METHOD*) XMALLOC(sizeof(WOLFSSL_METHOD),
                                                      heap, DYNAMIC_TYPE_METHOD);
         (void)heap;
-        WOLFSSL_ENTER("SSLv23_client_method_ex");
+        WOLFSSL_ENTER("wolfSSLv23_client_method_ex");
         if (method) {
     #if !defined(NO_SHA256) || defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512)
         #if defined(WOLFSSL_TLS13)
@@ -13192,7 +13194,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
             return wolfSSL_connect_TLSv13(ssl);
         #endif
 
-        WOLFSSL_ENTER("SSL_connect()");
+        WOLFSSL_ENTER("wolfSSL_connect");
 
         /* make sure this wolfSSL object has arrays and rng setup. Protects
          * case where the WOLFSSL object is re-used via wolfSSL_clear() */
@@ -13557,7 +13559,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
 
             ssl->error = 0; /* clear the error */
 
-            WOLFSSL_LEAVE("SSL_connect()", WOLFSSL_SUCCESS);
+            WOLFSSL_LEAVE("wolfSSL_connect", WOLFSSL_SUCCESS);
             return WOLFSSL_SUCCESS;
     #endif /* !WOLFSSL_NO_TLS12 || !NO_OLD_TLS */
 
@@ -13593,7 +13595,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
                               (WOLFSSL_METHOD*) XMALLOC(sizeof(WOLFSSL_METHOD),
                                                      heap, DYNAMIC_TYPE_METHOD);
         (void)heap;
-        WOLFSSL_ENTER("SSLv3_server_method_ex");
+        WOLFSSL_ENTER("wolfSSLv3_server_method_ex");
         if (method) {
             InitSSL_Method(method, MakeSSLv3());
             method->side = WOLFSSL_SERVER_END;
@@ -13613,7 +13615,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
                               (WOLFSSL_METHOD*) XMALLOC(sizeof(WOLFSSL_METHOD),
                                                      heap, DYNAMIC_TYPE_METHOD);
         (void)heap;
-        WOLFSSL_ENTER("SSLv23_server_method_ex");
+        WOLFSSL_ENTER("wolfSSLv23_server_method_ex");
         if (method) {
     #if !defined(NO_SHA256) || defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512)
         #ifdef WOLFSSL_TLS13
@@ -13673,7 +13675,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
         if (ssl->options.tls1_3)
             return wolfSSL_accept_TLSv13(ssl);
     #endif
-        WOLFSSL_ENTER("SSL_accept()");
+        WOLFSSL_ENTER("wolfSSL_accept");
 
         /* make sure this wolfSSL object has arrays and rng setup. Protects
          * case where the WOLFSSL object is re-used via wolfSSL_clear() */
@@ -14076,7 +14078,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
 #endif
             ssl->error = 0; /* clear the error */
 
-            WOLFSSL_LEAVE("SSL_accept()", WOLFSSL_SUCCESS);
+            WOLFSSL_LEAVE("wolfSSL_accept", WOLFSSL_SUCCESS);
             return WOLFSSL_SUCCESS;
 
         default :
@@ -14334,7 +14336,7 @@ WOLFSSL_SESSION* wolfSSL_GetSessionClient(WOLFSSL* ssl, const byte* id, int len)
     int             error = 0;
     ClientSession*  clSess;
 
-    WOLFSSL_ENTER("GetSessionClient");
+    WOLFSSL_ENTER("wolfSSL_GetSessionClient");
 
     if (ssl->ctx->sessionCacheOff) {
         WOLFSSL_MSG("Session Cache off");
@@ -16110,7 +16112,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
     void wolfSSL_CTX_set_psk_client_callback(WOLFSSL_CTX* ctx,
                                          wc_psk_client_callback cb)
     {
-        WOLFSSL_ENTER("SSL_CTX_set_psk_client_callback");
+        WOLFSSL_ENTER("wolfSSL_CTX_set_psk_client_callback");
 
         if (ctx == NULL)
             return;
@@ -16124,7 +16126,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         byte haveRSA = 1;
         int  keySz   = 0;
 
-        WOLFSSL_ENTER("SSL_set_psk_client_callback");
+        WOLFSSL_ENTER("wolfSSL_set_psk_client_callback");
 
         if (ssl == NULL)
             return;
@@ -16168,7 +16170,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
     void wolfSSL_CTX_set_psk_server_callback(WOLFSSL_CTX* ctx,
                                          wc_psk_server_callback cb)
     {
-        WOLFSSL_ENTER("SSL_CTX_set_psk_server_callback");
+        WOLFSSL_ENTER("wolfSSL_CTX_set_psk_server_callback");
         if (ctx == NULL)
             return;
         ctx->havePSK = 1;
@@ -16180,7 +16182,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         byte haveRSA = 1;
         int  keySz   = 0;
 
-        WOLFSSL_ENTER("SSL_set_psk_server_callback");
+        WOLFSSL_ENTER("wolfSSL_set_psk_server_callback");
         if (ssl == NULL)
             return;
 
@@ -16204,7 +16206,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
 
     const char* wolfSSL_get_psk_identity_hint(const WOLFSSL* ssl)
     {
-        WOLFSSL_ENTER("SSL_get_psk_identity_hint");
+        WOLFSSL_ENTER("wolfSSL_get_psk_identity_hint");
 
         if (ssl == NULL || ssl->arrays == NULL)
             return NULL;
@@ -16215,7 +16217,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
 
     const char* wolfSSL_get_psk_identity(const WOLFSSL* ssl)
     {
-        WOLFSSL_ENTER("SSL_get_psk_identity");
+        WOLFSSL_ENTER("wolfSSL_get_psk_identity");
 
         if (ssl == NULL || ssl->arrays == NULL)
             return NULL;
@@ -16225,7 +16227,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
 
     int wolfSSL_CTX_use_psk_identity_hint(WOLFSSL_CTX* ctx, const char* hint)
     {
-        WOLFSSL_ENTER("SSL_CTX_use_psk_identity_hint");
+        WOLFSSL_ENTER("wolfSSL_CTX_use_psk_identity_hint");
         if (hint == 0)
             ctx->server_hint[0] = '\0';
         else {
@@ -16241,7 +16243,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
 
     int wolfSSL_use_psk_identity_hint(WOLFSSL* ssl, const char* hint)
     {
-        WOLFSSL_ENTER("SSL_use_psk_identity_hint");
+        WOLFSSL_ENTER("wolfSSL_use_psk_identity_hint");
 
         if (ssl == NULL || ssl->arrays == NULL)
             return WOLFSSL_FAILURE;
@@ -16813,7 +16815,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
 
     void wolfSSL_set_quiet_shutdown(WOLFSSL* ssl, int mode)
     {
-        WOLFSSL_ENTER("wolfSSL_CTX_set_quiet_shutdown");
+        WOLFSSL_ENTER("wolfSSL_set_quiet_shutdown");
         if (mode)
             ssl->options.quietShutdown = 1;
     }
@@ -17155,7 +17157,7 @@ cleanup:
 
         WOLFSSL_ENTER("wolfSSL_CTX_set_srp_username");
         if (ctx == NULL || ctx->srp == NULL || username==NULL)
-            return SSL_FAILURE;
+            return WOLFSSL_FAILURE;
 
         if (ctx->method->side == WOLFSSL_SERVER_END){
             srp_side = SRP_SERVER_SIDE;
@@ -17163,20 +17165,20 @@ cleanup:
             srp_side = SRP_CLIENT_SIDE;
         } else {
             WOLFSSL_MSG("Init CTX failed");
-            return SSL_FAILURE;
+            return WOLFSSL_FAILURE;
         }
 
         if (wc_SrpInit(ctx->srp, SRP_TYPE_SHA256, srp_side) < 0) {
             WOLFSSL_MSG("Init SRP CTX failed");
             XFREE(ctx->srp, ctx->heap, DYNAMIC_TYPE_SRP);
             ctx->srp = NULL;
-            return SSL_FAILURE;
+            return WOLFSSL_FAILURE;
         }
         r = wc_SrpSetUsername(ctx->srp, (const byte*)username,
                               (word32)XSTRLEN(username));
         if (r < 0) {
             WOLFSSL_MSG("fail to set srp username.");
-            return SSL_FAILURE;
+            return WOLFSSL_FAILURE;
         }
 
         /* if wolfSSL_CTX_set_srp_password has already been called, */
@@ -17185,28 +17187,28 @@ cleanup:
             WC_RNG rng;
             if (wc_InitRng(&rng) < 0){
                 WOLFSSL_MSG("wc_InitRng failed");
-                return SSL_FAILURE;
+                return WOLFSSL_FAILURE;
             }
             XMEMSET(salt, 0, sizeof(salt)/sizeof(salt[0]));
             r = wc_RNG_GenerateBlock(&rng, salt, sizeof(salt)/sizeof(salt[0]));
             wc_FreeRng(&rng);
             if (r <  0) {
                 WOLFSSL_MSG("wc_RNG_GenerateBlock failed");
-                return SSL_FAILURE;
+                return WOLFSSL_FAILURE;
             }
 
             if (wc_SrpSetParams(ctx->srp, srp_N, sizeof(srp_N)/sizeof(srp_N[0]),
                                 srp_g, sizeof(srp_g)/sizeof(srp_g[0]),
                                 salt, sizeof(salt)/sizeof(salt[0])) < 0) {
                 WOLFSSL_MSG("wc_SrpSetParam failed");
-                return SSL_FAILURE;
+                return WOLFSSL_FAILURE;
             }
             r = wc_SrpSetPassword(ctx->srp,
                      (const byte*)ctx->srp_password,
                      (word32)XSTRLEN((char *)ctx->srp_password));
             if (r < 0) {
                 WOLFSSL_MSG("fail to set srp password.");
-                return SSL_FAILURE;
+                return WOLFSSL_FAILURE;
             }
 
             XFREE(ctx->srp_password, ctx->heap, DYNAMIC_TYPE_SRP);
@@ -17223,34 +17225,34 @@ cleanup:
 
         WOLFSSL_ENTER("wolfSSL_CTX_set_srp_password");
         if (ctx == NULL || ctx->srp == NULL || password == NULL)
-            return SSL_FAILURE;
+            return WOLFSSL_FAILURE;
 
         if (ctx->srp->user != NULL) {
             WC_RNG rng;
             if (wc_InitRng(&rng) < 0) {
                 WOLFSSL_MSG("wc_InitRng failed");
-                return SSL_FAILURE;
+                return WOLFSSL_FAILURE;
             }
             XMEMSET(salt, 0, sizeof(salt)/sizeof(salt[0]));
             r = wc_RNG_GenerateBlock(&rng, salt, sizeof(salt)/sizeof(salt[0]));
             wc_FreeRng(&rng);
             if (r <  0) {
                 WOLFSSL_MSG("wc_RNG_GenerateBlock failed");
-                return SSL_FAILURE;
+                return WOLFSSL_FAILURE;
             }
             if (wc_SrpSetParams(ctx->srp, srp_N, sizeof(srp_N)/sizeof(srp_N[0]),
                                 srp_g, sizeof(srp_g)/sizeof(srp_g[0]),
                                 salt, sizeof(salt)/sizeof(salt[0])) < 0){
                 WOLFSSL_MSG("wc_SrpSetParam failed");
                 wc_FreeRng(&rng);
-                return SSL_FAILURE;
+                return WOLFSSL_FAILURE;
             }
             r = wc_SrpSetPassword(ctx->srp, (const byte*)password,
                                   (word32)XSTRLEN(password));
             if (r < 0) {
                 WOLFSSL_MSG("wc_SrpSetPassword failed.");
                 wc_FreeRng(&rng);
-                return SSL_FAILURE;
+                return WOLFSSL_FAILURE;
             }
             if (ctx->srp_password != NULL){
                 XFREE(ctx->srp_password,NULL,
@@ -17267,7 +17269,7 @@ cleanup:
                                                DYNAMIC_TYPE_SRP);
             if (ctx->srp_password == NULL){
                 WOLFSSL_MSG("memory allocation error");
-                return SSL_FAILURE;
+                return WOLFSSL_FAILURE;
             }
             XMEMCPY(ctx->srp_password, password, XSTRLEN(password) + 1);
         }
@@ -17435,10 +17437,12 @@ cleanup:
         return ctx->mask;
     }
 
+    /* forward declaration */
     static long wolf_set_options(long old_op, long op);
+
     long wolfSSL_CTX_set_options(WOLFSSL_CTX* ctx, long opt)
     {
-        WOLFSSL_ENTER("SSL_CTX_set_options");
+        WOLFSSL_ENTER("wolfSSL_CTX_set_options");
 
         if (ctx == NULL)
             return BAD_FUNC_ARG;
@@ -17456,7 +17460,7 @@ cleanup:
 
     long wolfSSL_CTX_clear_options(WOLFSSL_CTX* ctx, long opt)
     {
-        WOLFSSL_ENTER("SSL_CTX_clear_options");
+        WOLFSSL_ENTER("wolfSSL_CTX_clear_options");
         if(ctx == NULL)
             return BAD_FUNC_ARG;
         ctx->mask &= ~opt;
@@ -17467,7 +17471,7 @@ cleanup:
 
     int wolfSSL_set_rfd(WOLFSSL* ssl, int rfd)
     {
-        WOLFSSL_ENTER("SSL_set_rfd");
+        WOLFSSL_ENTER("wolfSSL_set_rfd");
         ssl->rfd = rfd;      /* not used directly to allow IO callbacks */
 
         ssl->IOCB_ReadCtx  = &ssl->rfd;
@@ -17485,7 +17489,7 @@ cleanup:
 
     int wolfSSL_set_wfd(WOLFSSL* ssl, int wfd)
     {
-        WOLFSSL_ENTER("SSL_set_wfd");
+        WOLFSSL_ENTER("wolfSSL_set_wfd");
         ssl->wfd = wfd;      /* not used directly to allow IO callbacks */
 
         ssl->IOCB_WriteCtx  = &ssl->wfd;
@@ -17652,7 +17656,7 @@ cleanup:
     void wolfSSL_CTX_set_default_passwd_cb_userdata(WOLFSSL_CTX* ctx,
                                                    void* userdata)
     {
-        WOLFSSL_ENTER("SSL_CTX_set_default_passwd_cb_userdata");
+        WOLFSSL_ENTER("wolfSSL_CTX_set_default_passwd_cb_userdata");
         if (ctx)
             ctx->passwd_userdata = userdata;
     }
@@ -17661,7 +17665,7 @@ cleanup:
     void wolfSSL_CTX_set_default_passwd_cb(WOLFSSL_CTX* ctx, wc_pem_password_cb*
                                            cb)
     {
-        WOLFSSL_ENTER("SSL_CTX_set_default_passwd_cb");
+        WOLFSSL_ENTER("wolfSSL_CTX_set_default_passwd_cb");
         if (ctx)
             ctx->passwd_cb = cb;
     }
@@ -18660,7 +18664,7 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
     {
         int ret;
 
-        WOLFSSL_ENTER("wolfSSL_MD5_Update");
+        WOLFSSL_ENTER("MD5_Update");
         ret = wc_Md5Update((wc_Md5*)md5, (const byte*)input, (word32)sz);
 
         /* return 1 on success, 0 otherwise */
@@ -19637,7 +19641,7 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
         int  lb_sz;
         long  blk;
 
-        WOLFSSL_ENTER("DES_cbc_encrypt");
+        WOLFSSL_ENTER("wolfSSL_DES_cbc_encrypt");
 
         /* OpenSSL compat, no ret */
         if (wc_Des_SetKey(&myDes, (const byte*)schedule, (const byte*)ivec,
@@ -19748,7 +19752,7 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
         long idx = length;
         long blk;
 
-        WOLFSSL_ENTER("DES_ncbc_encrypt");
+        WOLFSSL_ENTER("wolfSSL_DES_ncbc_encrypt");
 
         /* OpenSSL compat, no ret */
         if (wc_Des_SetKey(&myDes, (const byte*)schedule,
@@ -19901,7 +19905,7 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
     {
         /* WOLFSSL_MODE_ACCEPT_MOVING_WRITE_BUFFER is wolfSSL default mode */
 
-        WOLFSSL_ENTER("SSL_CTX_set_mode");
+        WOLFSSL_ENTER("wolfSSL_CTX_set_mode");
         switch(mode) {
             case SSL_MODE_ENABLE_PARTIAL_WRITE:
                 ctx->partialWrite = 1;
@@ -19928,7 +19932,7 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
     {
         /* WOLFSSL_MODE_ACCEPT_MOVING_WRITE_BUFFER is wolfSSL default mode */
 
-        WOLFSSL_ENTER("SSL_CTX_set_mode");
+        WOLFSSL_ENTER("wolfSSL_CTX_clear_mode");
         switch(mode) {
             case SSL_MODE_ENABLE_PARTIAL_WRITE:
                 ctx->partialWrite = 0;
@@ -19993,17 +19997,17 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
      * sid_ctx     value of context to set
      * sid_ctx_len length of sid_ctx buffer
      *
-     * Returns WOLFSSL_SUCCESS in success case and SSL_FAILURE when failing
+     * Returns WOLFSSL_SUCCESS in success case and WOLFSSL_FAILURE when failing
      */
     int wolfSSL_CTX_set_session_id_context(WOLFSSL_CTX* ctx,
                                            const unsigned char* sid_ctx,
                                            unsigned int sid_ctx_len)
     {
-        WOLFSSL_ENTER("SSL_CTX_set_session_id_context");
+        WOLFSSL_ENTER("wolfSSL_CTX_set_session_id_context");
 
         /* No application specific context needed for wolfSSL */
         if (sid_ctx_len > ID_LEN || ctx == NULL || sid_ctx == NULL) {
-            return SSL_FAILURE;
+            return WOLFSSL_FAILURE;
         }
         XMEMCPY(ctx->sessionCtx, sid_ctx, sid_ctx_len);
         ctx->sessionCtxSz = (byte)sid_ctx_len;
@@ -20020,7 +20024,7 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
      * id   value of context to set
      * len  length of sid_ctx buffer
      *
-     * Returns WOLFSSL_SUCCESS in success case and SSL_FAILURE when failing
+     * Returns WOLFSSL_SUCCESS in success case and WOLFSSL_FAILURE when failing
      */
     int wolfSSL_set_session_id_context(WOLFSSL* ssl, const unsigned char* id,
                                    unsigned int len)
@@ -20028,7 +20032,7 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
         WOLFSSL_ENTER("wolfSSL_set_session_id_context");
 
         if (len > ID_LEN || ssl == NULL || id == NULL) {
-            return SSL_FAILURE;
+            return WOLFSSL_FAILURE;
         }
         XMEMCPY(ssl->sessionCtx, id, len);
         ssl->sessionCtxSz = (byte)len;
@@ -20246,7 +20250,7 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
     WOLFSSL_X509* wolfSSL_get_peer_certificate(WOLFSSL* ssl)
     {
         WOLFSSL_X509* ret = NULL;
-        WOLFSSL_ENTER("SSL_get_peer_certificate");
+        WOLFSSL_ENTER("wolfSSL_get_peer_certificate");
         if (ssl != NULL) {
             if (ssl->peerCert.issuer.sz)
                 ret = wolfSSL_X509_dup(&ssl->peerCert);
@@ -20259,7 +20263,7 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
             }
 #endif
         }
-        WOLFSSL_LEAVE("SSL_get_peer_certificate", ret != NULL);
+        WOLFSSL_LEAVE("wolfSSL_get_peer_certificate", ret != NULL);
         return ret;
     }
 
@@ -21744,7 +21748,7 @@ word32 wolfSSL_lib_version_hex(void)
 
 int wolfSSL_get_current_cipher_suite(WOLFSSL* ssl)
 {
-    WOLFSSL_ENTER("SSL_get_current_cipher_suite");
+    WOLFSSL_ENTER("wolfSSL_get_current_cipher_suite");
     if (ssl)
         return (ssl->options.cipherSuite0 << 8) | ssl->options.cipherSuite;
     return 0;
@@ -21752,7 +21756,7 @@ int wolfSSL_get_current_cipher_suite(WOLFSSL* ssl)
 
 WOLFSSL_CIPHER* wolfSSL_get_current_cipher(WOLFSSL* ssl)
 {
-    WOLFSSL_ENTER("SSL_get_current_cipher");
+    WOLFSSL_ENTER("wolfSSL_get_current_cipher");
     if (ssl) {
         ssl->cipher.cipherSuite0 = ssl->options.cipherSuite0;
         ssl->cipher.cipherSuite  = ssl->options.cipherSuite;
@@ -21785,7 +21789,7 @@ const char* wolfSSL_CIPHER_get_name(const WOLFSSL_CIPHER* cipher)
 
 const char*  wolfSSL_CIPHER_get_version(const WOLFSSL_CIPHER* cipher)
 {
-    WOLFSSL_ENTER("SSL_CIPHER_get_version");
+    WOLFSSL_ENTER("wolfSSL_CIPHER_get_version");
 
     if (cipher == NULL || cipher->ssl == NULL) {
         return NULL;
@@ -21885,7 +21889,7 @@ word32 wolfSSL_CIPHER_get_id(const WOLFSSL_CIPHER* cipher)
 {
     word16 cipher_id = 0;
 
-    WOLFSSL_ENTER("SSL_CIPHER_get_id");
+    WOLFSSL_ENTER("wolfSSL_CIPHER_get_id");
 
     if (cipher && cipher->ssl) {
         cipher_id = (cipher->ssl->options.cipherSuite0 << 8) |
@@ -21899,7 +21903,7 @@ const WOLFSSL_CIPHER* wolfSSL_get_cipher_by_value(word16 value)
 {
     const WOLFSSL_CIPHER* cipher = NULL;
     byte cipherSuite0, cipherSuite;
-    WOLFSSL_ENTER("SSL_get_cipher_by_value");
+    WOLFSSL_ENTER("wolfSSL_get_cipher_by_value");
 
     /* extract cipher id information */
     cipherSuite =   (value       & 0xFF);
@@ -23712,7 +23716,7 @@ long wolfSSL_ASN1_INTEGER_get(const WOLFSSL_ASN1_INTEGER* a)
     long ret = 1;
     WOLFSSL_BIGNUM* bn = NULL;
 
-    WOLFSSL_ENTER("ASN1_INTEGER_get");
+    WOLFSSL_ENTER("wolfSSL_ASN1_INTEGER_get");
 
     if (a == NULL) {
         /* OpenSSL returns 0 when a is NULL and -1 if there is an error. Quoting
@@ -23743,7 +23747,7 @@ long wolfSSL_ASN1_INTEGER_get(const WOLFSSL_ASN1_INTEGER* a)
         wolfSSL_BN_free(bn);
     }
 
-    WOLFSSL_LEAVE("ASN1_INTEGER_get", (int)ret);
+    WOLFSSL_LEAVE("wolfSSL_ASN1_INTEGER_get", (int)ret);
 
     return ret;
 }
@@ -24446,7 +24450,7 @@ int  wolfSSL_SSL_renegotiate_pending(WOLFSSL *s)
 
 long wolfSSL_clear_options(WOLFSSL* ssl, long opt)
 {
-    WOLFSSL_ENTER("SSL_clear_options");
+    WOLFSSL_ENTER("wolfSSL_clear_options");
     if(ssl == NULL)
         return WOLFSSL_FAILURE;
     ssl->options.mask &= ~opt;
@@ -24533,7 +24537,7 @@ long wolfSSL_set_tlsext_status_type(WOLFSSL *s, int type)
     } else {
         WOLFSSL_MSG(
        "SSL_set_tlsext_status_type only supports TLSEXT_STATUSTYPE_ocsp type.");
-        return SSL_FAILURE;
+        return WOLFSSL_FAILURE;
     }
 
 }
@@ -25021,7 +25025,7 @@ size_t wolfSSL_get_finished(const WOLFSSL *ssl, void *buf, size_t count)
 {
     byte len = 0;
 
-    WOLFSSL_ENTER("SSL_get_finished");
+    WOLFSSL_ENTER("wolfSSL_get_finished");
 
     if (!ssl || !buf || count < TLS_FINISHED_SZ) {
         WOLFSSL_MSG("Bad parameter");
@@ -25042,7 +25046,7 @@ size_t wolfSSL_get_finished(const WOLFSSL *ssl, void *buf, size_t count)
 size_t wolfSSL_get_peer_finished(const WOLFSSL *ssl, void *buf, size_t count)
 {
     byte len = 0;
-    WOLFSSL_ENTER("SSL_get_peer_finished");
+    WOLFSSL_ENTER("wolfSSL_get_peer_finished");
 
     if (!ssl || !buf || count < TLS_FINISHED_SZ) {
         WOLFSSL_MSG("Bad parameter");
@@ -26041,7 +26045,7 @@ size_t wolfSSL_CRYPTO_cts128_decrypt(const unsigned char *in,
 #ifndef NO_BIO
 int wolfSSL_ASN1_UTCTIME_print(WOLFSSL_BIO* bio, const WOLFSSL_ASN1_UTCTIME* a)
 {
-    WOLFSSL_ENTER("ASN1_UTCTIME_print");
+    WOLFSSL_ENTER("wolfSSL_ASN1_UTCTIME_print");
     if (bio == NULL || a == NULL) {
         return WOLFSSL_FAILURE;
     }
@@ -27879,7 +27883,7 @@ static int i2dProcessMembers(const void *src, byte *buf,
     const WOLFSSL_ASN1_TEMPLATE *member = NULL;
     int len = 0, ret;
     size_t i;
-    WOLFSSL_ENTER("processMembers");
+    WOLFSSL_ENTER("i2dProcessMembers");
     for (member = members, i = 0; i < mcount; member++, i++) {
         switch (member->type) {
             case WOLFSSL_X509_ALGOR_ASN1:
@@ -30773,7 +30777,7 @@ int wolfSSL_ASN1_STRING_canon(WOLFSSL_ASN1_STRING* asn_out,
         int i;
 
 #ifdef WOLFSSL_DEBUG_OPENSSL
-        WOLFSSL_ENTER("wolfSSL_OBJ_nid2obj()");
+        WOLFSSL_ENTER("wolfSSL_OBJ_nid2obj");
 #endif
 
         for (i = 0; i < (int)WOLFSSL_OBJECT_INFO_SZ; i++) {
@@ -30934,7 +30938,7 @@ int wolfSSL_ASN1_STRING_canon(WOLFSSL_ASN1_STRING* asn_out,
         const char* desc;
         const char* name;
 
-        WOLFSSL_ENTER("wolfSSL_OBJ_obj2txt()");
+        WOLFSSL_ENTER("wolfSSL_OBJ_obj2txt");
 
         if (buf == NULL || bufLen <= 1 || a == NULL) {
             WOLFSSL_MSG("Bad input argument");
@@ -31462,7 +31466,7 @@ int wolfSSL_ASN1_STRING_canon(WOLFSSL_ASN1_STRING* asn_out,
         unsigned char out[MAX_OID_SZ];
     #endif
 
-        WOLFSSL_ENTER("OBJ_txt2nid");
+        WOLFSSL_ENTER("wolfSSL_OBJ_txt2nid");
 
         if (s == NULL) {
             return NID_undef;
@@ -31582,7 +31586,7 @@ int wolfSSL_ASN1_STRING_canon(WOLFSSL_ASN1_STRING* asn_out,
      * own internal OID values and does not currently support OBJ_create. */
     void wolfSSL_OBJ_cleanup(void)
     {
-        WOLFSSL_ENTER("wolfSSL_OBJ_cleanup()");
+        WOLFSSL_ENTER("wolfSSL_OBJ_cleanup");
     }
 
     #ifndef NO_WOLFSSL_STUB
@@ -31954,7 +31958,7 @@ void* wolfSSL_get_app_data(const WOLFSSL *ssl)
  * ssl WOLFSSL struct to set app data in
  * arg data to be stored
  *
- * Returns WOLFSSL_SUCCESS on success and SSL_FAILURE on failure
+ * Returns WOLFSSL_SUCCESS on success and WOLFSSL_FAILURE on failure
  */
 int wolfSSL_set_app_data(WOLFSSL *ssl, void* arg) {
     WOLFSSL_ENTER("wolfSSL_set_app_data");
@@ -32075,7 +32079,7 @@ int wolfSSL_get_state(const WOLFSSL* ssl)
 
     if (ssl == NULL) {
         WOLFSSL_MSG("Null argument passed in");
-        return SSL_FAILURE;
+        return WOLFSSL_FAILURE;
     }
 
     return ssl->options.handShakeState;
@@ -32085,7 +32089,7 @@ int wolfSSL_get_state(const WOLFSSL* ssl)
 #ifdef OPENSSL_EXTRA
 void wolfSSL_certs_clear(WOLFSSL* ssl)
 {
-    WOLFSSL_ENTER("wolfSSL_certs_clear()");
+    WOLFSSL_ENTER("wolfSSL_certs_clear");
 
     if (ssl == NULL)
         return;
@@ -32306,7 +32310,7 @@ long wolfSSL_CTX_clear_extra_chain_certs(WOLFSSL_CTX* ctx)
 Returns NULL otherwise. */
 VerifyCallback wolfSSL_get_verify_callback(WOLFSSL* ssl)
 {
-    WOLFSSL_ENTER("wolfSSL_get_verify_callback()");
+    WOLFSSL_ENTER("wolfSSL_get_verify_callback");
     if (ssl) {
         return ssl->verifyCallback;
     }
@@ -32318,7 +32322,7 @@ Returns WOLFSSL_SUCCESS if no error, returns WOLFSSL_FAILURE otherwise.*/
 int wolfSSL_CTX_use_certificate_ASN1(WOLFSSL_CTX *ctx, int derSz,
                                                        const unsigned char *der)
 {
-    WOLFSSL_ENTER("wolfSSL_CTX_use_certificate_ASN1()");
+    WOLFSSL_ENTER("wolfSSL_CTX_use_certificate_ASN1");
     if (der != NULL && ctx != NULL) {
         if (wolfSSL_CTX_use_certificate_buffer(ctx, der, derSz,
                                       WOLFSSL_FILETYPE_ASN1) == WOLFSSL_SUCCESS) {
@@ -32341,7 +32345,7 @@ int wolfSSL_CTX_use_RSAPrivateKey(WOLFSSL_CTX* ctx, WOLFSSL_RSA* rsa)
     unsigned char *maxDerBuf;
     unsigned char* key = NULL;
 
-    WOLFSSL_ENTER("wolfSSL_CTX_use_RSAPrivateKey()");
+    WOLFSSL_ENTER("wolfSSL_CTX_use_RSAPrivateKey");
 
     if (ctx == NULL || rsa == NULL) {
         WOLFSSL_MSG("one or more inputs were NULL");
@@ -32387,7 +32391,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PrivateKey_bio(WOLFSSL_BIO* bio,
     int extraBioMemSz = 0;
     int derLength = 0;
 
-    WOLFSSL_ENTER("wolfSSL_d2i_PrivateKey_bio()");
+    WOLFSSL_ENTER("wolfSSL_d2i_PrivateKey_bio");
 
     if (bio == NULL) {
         return NULL;
@@ -32950,7 +32954,7 @@ int wolfSSL_CTX_set_servername_arg(WOLFSSL_CTX* ctx, void* arg)
 
 #ifndef NO_BIO
 void wolfSSL_ERR_load_BIO_strings(void) {
-    WOLFSSL_ENTER("ERR_load_BIO_strings");
+    WOLFSSL_ENTER("wolfSSL_ERR_load_BIO_strings");
     /* do nothing */
 }
 #endif
@@ -34484,7 +34488,7 @@ int wolfSSL_SSL_in_init(const WOLFSSL *ssl)
 int wolfSSL_SSL_in_init(WOLFSSL *ssl)
 #endif
 {
-    WOLFSSL_ENTER("SSL_in_init");
+    WOLFSSL_ENTER("wolfSSL_SSL_in_init");
 
     if (ssl == NULL)
         return WOLFSSL_FAILURE;
@@ -34497,7 +34501,7 @@ int wolfSSL_SSL_in_init(WOLFSSL *ssl)
 
 int wolfSSL_SSL_in_connect_init(WOLFSSL* ssl)
 {
-    WOLFSSL_ENTER("SSL_connect_init");
+    WOLFSSL_ENTER("wolfSSL_SSL_in_connect_init");
 
     if (ssl == NULL)
         return WOLFSSL_FAILURE;
@@ -35441,7 +35445,7 @@ int wolfSSL_set1_curves_list(WOLFSSL* ssl, const char* names)
  * ctx WOLFSSL_CTX structure to set callback in
  * cb  callback to use
  *
- * return WOLFSSL_SUCCESS on success and SSL_FAILURE with error case
+ * return WOLFSSL_SUCCESS on success and WOLFSSL_FAILURE with error case
  */
 int wolfSSL_CTX_set_msg_callback(WOLFSSL_CTX *ctx, SSL_Msg_Cb cb)
 {
@@ -35461,14 +35465,14 @@ int wolfSSL_CTX_set_msg_callback(WOLFSSL_CTX *ctx, SSL_Msg_Cb cb)
  * ssl WOLFSSL structure to set callback in
  * cb  callback to use
  *
- * return WOLFSSL_SUCCESS on success and SSL_FAILURE with error case
+ * return WOLFSSL_SUCCESS on success and WOLFSSL_FAILURE with error case
  */
 int wolfSSL_set_msg_callback(WOLFSSL *ssl, SSL_Msg_Cb cb)
 {
     WOLFSSL_ENTER("wolfSSL_set_msg_callback");
 
     if (ssl == NULL) {
-        return SSL_FAILURE;
+        return WOLFSSL_FAILURE;
     }
 
     if (cb != NULL) {
@@ -36718,7 +36722,7 @@ int wolfSSL_BN_mod_mul(WOLFSSL_BIGNUM *r, const WOLFSSL_BIGNUM *a,
     (void) ctx;
     if (r == NULL || a == NULL || p == NULL || m == NULL) {
         WOLFSSL_MSG("Bad Argument");
-        return SSL_FAILURE;
+        return WOLFSSL_FAILURE;
     }
 
     if ((ret = mp_mulmod((mp_int*)a->internal,(mp_int*)p->internal,
@@ -36729,7 +36733,7 @@ int wolfSSL_BN_mod_mul(WOLFSSL_BIGNUM *r, const WOLFSSL_BIGNUM *a,
     WOLFSSL_LEAVE("wolfSSL_BN_mod_mul", ret);
     (void)ret;
 
-    return SSL_FAILURE;
+    return WOLFSSL_FAILURE;
 }
 
 const WOLFSSL_BIGNUM* wolfSSL_BN_value_one(void)
@@ -36964,7 +36968,7 @@ int wolfSSL_mask_bits(WOLFSSL_BIGNUM* bn, int n)
     (void)n;
     WOLFSSL_ENTER("wolfSSL_BN_mask_bits");
     WOLFSSL_STUB("BN_mask_bits");
-    return SSL_FAILURE;
+    return WOLFSSL_FAILURE;
 }
 #endif
 
@@ -37448,7 +37452,7 @@ int wolfSSL_BN_dec2bn(WOLFSSL_BIGNUM** bn, const char* str)
 
     WOLFSSL_MSG("wolfSSL_BN_dec2bn");
     WOLFSSL_STUB("BN_dec2bn");
-    return SSL_FAILURE;
+    return WOLFSSL_FAILURE;
 }
 #endif
 
@@ -39755,10 +39759,10 @@ int wolfSSL_RAND_write_file(const char* fname)
 {
     int bytes = 0;
 
-    WOLFSSL_ENTER("RAND_write_file");
+    WOLFSSL_ENTER("wolfSSL_RAND_write_file");
 
     if (fname == NULL) {
-        return SSL_FAILURE;
+        return WOLFSSL_FAILURE;
     }
 
 #ifndef NO_FILESYSTEM
@@ -39770,7 +39774,7 @@ int wolfSSL_RAND_write_file(const char* fname)
                                                        DYNAMIC_TYPE_TMP_BUFFER);
         if (buf == NULL) {
             WOLFSSL_MSG("malloc failed");
-            return SSL_FAILURE;
+            return WOLFSSL_FAILURE;
         }
     #endif
         bytes = 1024; /* default size of buf */
@@ -39938,7 +39942,7 @@ int wolfSSL_RAND_egd(const char* nm)
 
     if (bytes > 0 && ret == WOLFSSL_SUCCESS) {
         /* call to check global RNG is created */
-        if (wolfSSL_RAND_Init() != SSL_SUCCESS) {
+        if (wolfSSL_RAND_Init() != WOLFSSL_SUCCESS) {
             WOLFSSL_MSG("Error with initializing global RNG structure");
             ret = WOLFSSL_FATAL_ERROR;
         }
@@ -41406,7 +41410,7 @@ int wolfSSL_PEM_write_bio_PKCS7(WOLFSSL_BIO* bio, PKCS7* p7)
     byte hashBuf[WC_MAX_DIGEST_SIZE];
     word32 hashSz = -1;
 
-    WOLFSSL_ENTER("wolfSSL_PEM_write_bio_PKCS7()");
+    WOLFSSL_ENTER("wolfSSL_PEM_write_bio_PKCS7");
 
     if (bio == NULL || p7 == NULL)
         return WOLFSSL_FAILURE;
@@ -42220,10 +42224,10 @@ WC_PKCS12* wolfSSL_PKCS12_create(char* pass, char* name, WOLFSSL_EVP_PKEY* pkey,
     byte* certDer;
     int certDerSz;
 
-    WOLFSSL_ENTER("wolfSSL_PKCS12_create()");
+    WOLFSSL_ENTER("wolfSSL_PKCS12_create");
 
     if (pass == NULL || pkey == NULL || cert == NULL) {
-        WOLFSSL_LEAVE("wolfSSL_PKCS12_create()", BAD_FUNC_ARG);
+        WOLFSSL_LEAVE("wolfSSL_PKCS12_create", BAD_FUNC_ARG);
         return NULL;
     }
     passSz = (word32)XSTRLEN(pass);

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5512,7 +5512,7 @@ static int FindPsk(WOLFSSL* ssl, PreSharedKey* psk, const byte* suite, int* err)
     }
     if (found) {
         if (sa->psk_keySz > MAX_PSK_KEY_LEN) {
-            WOLFSSL_MSG("Key len too long in FindPsk()");
+            WOLFSSL_MSG("Key len too long in FindPsk");
             ret = PSK_KEY_ERROR;
             WOLFSSL_ERROR_VERBOSE(ret);
         }
@@ -11176,7 +11176,7 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 #endif /* NO_WOLFSSL_SERVER */
     }
 
-    WOLFSSL_LEAVE("DoTls13HandShakeMsgType()", ret);
+    WOLFSSL_LEAVE("DoTls13HandShakeMsgType", ret);
     return ret;
 }
 
@@ -11198,7 +11198,7 @@ int DoTls13HandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     byte   type;
     word32 size = 0;
 
-    WOLFSSL_ENTER("DoTls13HandShakeMsg()");
+    WOLFSSL_ENTER("DoTls13HandShakeMsg");
 
     if (ssl->arrays == NULL) {
 
@@ -11290,7 +11290,7 @@ int DoTls13HandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         }
     }
 
-    WOLFSSL_LEAVE("DoTls13HandShakeMsg()", ret);
+    WOLFSSL_LEAVE("DoTls13HandShakeMsg", ret);
     return ret;
 }
 
@@ -11312,7 +11312,7 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
     int advanceState;
     int ret = 0;
 
-    WOLFSSL_ENTER("wolfSSL_connect_TLSv13()");
+    WOLFSSL_ENTER("wolfSSL_connect_TLSv13");
 
 #ifdef HAVE_ERRNO_H
     errno = 0;
@@ -11677,7 +11677,7 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
 
             ssl->error = 0; /* clear the error */
 
-            WOLFSSL_LEAVE("wolfSSL_connect_TLSv13()", WOLFSSL_SUCCESS);
+            WOLFSSL_LEAVE("wolfSSL_connect_TLSv13", WOLFSSL_SUCCESS);
             return WOLFSSL_SUCCESS;
 
         default:
@@ -12248,7 +12248,7 @@ int wolfSSL_set_groups(WOLFSSL* ssl, int* groups, int count)
 void wolfSSL_CTX_set_psk_client_cs_callback(WOLFSSL_CTX* ctx,
                                             wc_psk_client_cs_callback cb)
 {
-    WOLFSSL_ENTER("SSL_CTX_set_psk_client_cs_callback");
+    WOLFSSL_ENTER("wolfSSL_CTX_set_psk_client_cs_callback");
 
     if (ctx == NULL)
         return;
@@ -12269,7 +12269,7 @@ void wolfSSL_set_psk_client_cs_callback(WOLFSSL* ssl,
     byte haveRSA = 1;
     int  keySz   = 0;
 
-    WOLFSSL_ENTER("SSL_set_psk_client_cs_callback");
+    WOLFSSL_ENTER("wolfSSL_set_psk_client_cs_callback");
 
     if (ssl == NULL)
         return;
@@ -12301,7 +12301,7 @@ void wolfSSL_set_psk_client_cs_callback(WOLFSSL* ssl,
 void wolfSSL_CTX_set_psk_client_tls13_callback(WOLFSSL_CTX* ctx,
                                                wc_psk_client_tls13_callback cb)
 {
-    WOLFSSL_ENTER("SSL_CTX_set_psk_client_tls13_callback");
+    WOLFSSL_ENTER("wolfSSL_CTX_set_psk_client_tls13_callback");
 
     if (ctx == NULL)
         return;
@@ -12322,7 +12322,7 @@ void wolfSSL_set_psk_client_tls13_callback(WOLFSSL* ssl,
     byte haveRSA = 1;
     int  keySz   = 0;
 
-    WOLFSSL_ENTER("SSL_set_psk_client_tls13_callback");
+    WOLFSSL_ENTER("wolfSSL_set_psk_client_tls13_callback");
 
     if (ssl == NULL)
         return;
@@ -12354,7 +12354,7 @@ void wolfSSL_set_psk_client_tls13_callback(WOLFSSL* ssl,
 void wolfSSL_CTX_set_psk_server_tls13_callback(WOLFSSL_CTX* ctx,
                                                wc_psk_server_tls13_callback cb)
 {
-    WOLFSSL_ENTER("SSL_CTX_set_psk_server_tls13_callback");
+    WOLFSSL_ENTER("wolfSSL_CTX_set_psk_server_tls13_callback");
     if (ctx == NULL)
         return;
     ctx->havePSK = 1;
@@ -12373,7 +12373,7 @@ void wolfSSL_set_psk_server_tls13_callback(WOLFSSL* ssl,
     byte haveRSA = 1;
     int  keySz   = 0;
 
-    WOLFSSL_ENTER("SSL_set_psk_server_tls13_callback");
+    WOLFSSL_ENTER("wolfSSL_set_psk_server_tls13_callback");
     if (ssl == NULL)
         return;
 
@@ -12493,7 +12493,7 @@ int wolfSSL_accept_TLSv13(WOLFSSL* ssl)
     int advanceState;
     int ret = 0;
 
-    WOLFSSL_ENTER("SSL_accept_TLSv13()");
+    WOLFSSL_ENTER("wolfSSL_accept_TLSv13");
 
 #ifdef HAVE_ERRNO_H
     errno = 0;
@@ -12983,7 +12983,7 @@ int wolfSSL_accept_TLSv13(WOLFSSL* ssl)
 
             ssl->error = 0; /* clear the error */
 
-            WOLFSSL_LEAVE("SSL_accept()", WOLFSSL_SUCCESS);
+            WOLFSSL_LEAVE("wolfSSL_accept", WOLFSSL_SUCCESS);
             return WOLFSSL_SUCCESS;
 
         default :
@@ -13129,7 +13129,7 @@ int wolfSSL_write_early_data(WOLFSSL* ssl, const void* data, int sz, int* outSz)
 {
     int ret = 0;
 
-    WOLFSSL_ENTER("SSL_write_early_data()");
+    WOLFSSL_ENTER("wolfSSL_write_early_data");
 
     if (ssl == NULL || data == NULL || sz < 0 || outSz == NULL)
         return BAD_FUNC_ARG;
@@ -13170,7 +13170,7 @@ int wolfSSL_write_early_data(WOLFSSL* ssl, const void* data, int sz, int* outSz)
     return SIDE_ERROR;
 #endif
 
-    WOLFSSL_LEAVE("SSL_write_early_data()", ret);
+    WOLFSSL_LEAVE("wolfSSL_write_early_data", ret);
 
     if (ret < 0)
         ret = WOLFSSL_FATAL_ERROR;
@@ -13191,7 +13191,7 @@ int wolfSSL_read_early_data(WOLFSSL* ssl, void* data, int sz, int* outSz)
 {
     int ret = 0;
 
-    WOLFSSL_ENTER("wolfSSL_read_early_data()");
+    WOLFSSL_ENTER("wolfSSL_read_early_data");
 
 
     if (ssl == NULL || data == NULL || sz < 0 || outSz == NULL)
@@ -13239,7 +13239,7 @@ int wolfSSL_read_early_data(WOLFSSL* ssl, void* data, int sz, int* outSz)
     return SIDE_ERROR;
 #endif
 
-    WOLFSSL_LEAVE("wolfSSL_read_early_data()", ret);
+    WOLFSSL_LEAVE("wolfSSL_read_early_data", ret);
 
     if (ret < 0)
         ret = WOLFSSL_FATAL_ERROR;

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -401,7 +401,7 @@ int EmbedReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     SOCKADDR_S* peer;
     XSOCKLENT peerSz = 0;
 
-    WOLFSSL_ENTER("EmbedReceiveFrom()");
+    WOLFSSL_ENTER("EmbedReceiveFrom");
 
     if (dtlsCtx->connected) {
         peer = NULL;
@@ -561,7 +561,7 @@ int EmbedSendTo(WOLFSSL* ssl, char *buf, int sz, void *ctx)
     const SOCKADDR_S* peer = NULL;
     XSOCKLENT peerSz = 0;
 
-    WOLFSSL_ENTER("EmbedSendTo()");
+    WOLFSSL_ENTER("EmbedSendTo");
 
     if (!isDGramSock(sd)) {
         /* Probably a TCP socket. peer and peerSz MUST be NULL and 0 */
@@ -596,7 +596,7 @@ int EmbedReceiveFromMcast(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     int recvd;
     int sd = dtlsCtx->rfd;
 
-    WOLFSSL_ENTER("EmbedReceiveFromMcast()");
+    WOLFSSL_ENTER("EmbedReceiveFromMcast");
 
     recvd = (int)DTLS_RECVFROM_FUNCTION(sd, buf, sz, ssl->rflags, NULL, NULL);
 
@@ -2290,7 +2290,7 @@ int MicriumReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     NET_SOCK_RTN_CODE ret;
     NET_ERR err;
 
-    WOLFSSL_ENTER("MicriumReceiveFrom()");
+    WOLFSSL_ENTER("MicriumReceiveFrom");
 
 #ifdef WOLFSSL_DTLS
     {
@@ -2369,7 +2369,7 @@ int MicriumSendTo(WOLFSSL* ssl, char *buf, int sz, void *ctx)
     NET_SOCK_RTN_CODE ret;
     NET_ERR err;
 
-    WOLFSSL_ENTER("MicriumSendTo()");
+    WOLFSSL_ENTER("MicriumSendTo");
 
     ret = NetSock_TxDataTo(sd, buf, sz, ssl->wflags,
                            (NET_SOCK_ADDR*)dtlsCtx->peer.sa,

--- a/src/x509.c
+++ b/src/x509.c
@@ -128,7 +128,7 @@ int wolfSSL_X509_get_ext_count(const WOLFSSL_X509* passedCert)
     DecodedCert cert[1];
 #endif
 
-    WOLFSSL_ENTER("wolfSSL_X509_get_ext_count()");
+    WOLFSSL_ENTER("wolfSSL_X509_get_ext_count");
     if (passedCert == NULL) {
         WOLFSSL_MSG("\tNot passed a certificate");
         return WOLFSSL_FAILURE;
@@ -4168,7 +4168,7 @@ void wolfSSL_sk_GENERAL_NAME_pop_free(WOLFSSL_STACK* sk,
 
 void wolfSSL_sk_GENERAL_NAME_free(WOLFSSL_STACK* sk)
 {
-    WOLFSSL_ENTER("sk_GENERAL_NAME_free");
+    WOLFSSL_ENTER("wolfSSL_sk_GENERAL_NAME_free");
     wolfSSL_sk_X509_pop_free(sk, NULL);
 }
 #endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL */
@@ -4221,7 +4221,7 @@ WOLFSSL_DIST_POINT* wolfSSL_DIST_POINT_new(void)
     WOLFSSL_DIST_POINT* dp = NULL;
     WOLFSSL_DIST_POINT_NAME* dpn = NULL;
 
-    WOLFSSL_ENTER("DIST_POINT_new");
+    WOLFSSL_ENTER("wolfSSL_DIST_POINT_new");
 
     dp = (WOLFSSL_DIST_POINT*)XMALLOC(sizeof(WOLFSSL_DIST_POINT), NULL,
                                       DYNAMIC_TYPE_OPENSSL);
@@ -4322,7 +4322,7 @@ void wolfSSL_sk_DIST_POINT_pop_free(WOLFSSL_STACK* sk,
 
 void wolfSSL_sk_DIST_POINT_free(WOLFSSL_STACK* sk)
 {
-    WOLFSSL_ENTER("sk_DIST_POINT_free");
+    WOLFSSL_ENTER("wolfSSL_sk_DIST_POINT_free");
     wolfSSL_sk_free(sk);
 }
 
@@ -4856,7 +4856,7 @@ WOLFSSL_X509_NAME* wolfSSL_X509_get_subject_name(WOLFSSL_X509* cert)
 WOLFSSL_ABI
 WOLFSSL_X509_NAME* wolfSSL_X509_get_issuer_name(WOLFSSL_X509* cert)
 {
-    WOLFSSL_ENTER("X509_get_issuer_name");
+    WOLFSSL_ENTER("wolfSSL_X509_get_issuer_name");
     if (cert)
         return &cert->issuer;
     return NULL;
@@ -4986,7 +4986,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_X509_get_pubkey(WOLFSSL_X509* x509)
 
     (void)ret;
 
-    WOLFSSL_ENTER("X509_get_pubkey");
+    WOLFSSL_ENTER("wolfSSL_X509_get_pubkey");
     if (x509 != NULL) {
         key = wolfSSL_EVP_PKEY_new_ex(x509->heap);
         if (key != NULL) {
@@ -8679,7 +8679,7 @@ void wolfSSL_X509_ALGOR_free(WOLFSSL_X509_ALGOR *alg)
 /* Returns X509_ALGOR struct with signature algorithm */
 const WOLFSSL_X509_ALGOR* wolfSSL_X509_get0_tbs_sigalg(const WOLFSSL_X509 *x509)
 {
-    WOLFSSL_ENTER("X509_get0_tbs_sigalg");
+    WOLFSSL_ENTER("wolfSSL_X509_get0_tbs_sigalg");
 
     if (x509 == NULL) {
         WOLFSSL_MSG("x509 struct NULL error");
@@ -8693,7 +8693,7 @@ const WOLFSSL_X509_ALGOR* wolfSSL_X509_get0_tbs_sigalg(const WOLFSSL_X509 *x509)
 void wolfSSL_X509_ALGOR_get0(const WOLFSSL_ASN1_OBJECT **paobj, int *pptype,
                             const void **ppval, const WOLFSSL_X509_ALGOR *algor)
 {
-    WOLFSSL_ENTER("X509_ALGOR_get0");
+    WOLFSSL_ENTER("wolfSSL_X509_ALGOR_get0");
 
     if (!algor) {
         WOLFSSL_MSG("algor object is NULL");
@@ -8790,7 +8790,7 @@ void wolfSSL_X509_PUBKEY_free(WOLFSSL_X509_PUBKEY *x)
 /* Returns X509_PUBKEY structure containing X509_ALGOR and EVP_PKEY */
 WOLFSSL_X509_PUBKEY* wolfSSL_X509_get_X509_PUBKEY(const WOLFSSL_X509* x509)
 {
-    WOLFSSL_ENTER("X509_get_X509_PUBKEY");
+    WOLFSSL_ENTER("wolfSSL_X509_get_X509_PUBKEY");
 
     if (x509 == NULL) {
         WOLFSSL_MSG("x509 struct NULL error");
@@ -8806,7 +8806,7 @@ int wolfSSL_X509_PUBKEY_get0_param(WOLFSSL_ASN1_OBJECT **ppkalg,
      const unsigned char **pk, int *ppklen, WOLFSSL_X509_ALGOR **pa,
      WOLFSSL_X509_PUBKEY *pub)
 {
-    WOLFSSL_ENTER("X509_PUBKEY_get0_param");
+    WOLFSSL_ENTER("wolfSSL_X509_PUBKEY_get0_param");
 
     if (!pub || !pub->pubKeyOID) {
         WOLFSSL_MSG("X509_PUBKEY struct not populated");
@@ -9251,7 +9251,7 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_X509_chain_up_ref(
         int i;
         #endif
 
-        WOLFSSL_ENTER("wolfSSL_X509_to_Cert()");
+        WOLFSSL_ENTER("wolfSSL_X509_to_Cert");
 
         if (x509 == NULL || cert == NULL) {
             return BAD_FUNC_ARG;
@@ -11095,7 +11095,7 @@ err:
         int nid = -1;
         WOLFSSL_X509_NAME_ENTRY* ne = NULL;
 
-        WOLFSSL_ENTER("wolfSSL_X509_NAME_ENTRY_create_by_txt()");
+        WOLFSSL_ENTER("wolfSSL_X509_NAME_ENTRY_create_by_txt");
 
         if (txt == NULL) {
             return NULL;
@@ -11145,7 +11145,7 @@ err:
         WOLFSSL_X509_NAME_ENTRY* ne;
 
 #ifdef WOLFSSL_DEBUG_OPENSSL
-        WOLFSSL_ENTER("wolfSSL_X509_NAME_ENTRY_create_by_NID()");
+        WOLFSSL_ENTER("wolfSSL_X509_NAME_ENTRY_create_by_NID");
 #endif
 
         if (!data) {
@@ -11282,7 +11282,7 @@ err:
         int ret, i;
 
 #ifdef WOLFSSL_DEBUG_OPENSSL
-        WOLFSSL_ENTER("wolfSSL_X509_NAME_add_entry()");
+        WOLFSSL_ENTER("wolfSSL_X509_NAME_add_entry");
 #endif
 
         if (name == NULL || entry == NULL || entry->value == NULL) {
@@ -11530,7 +11530,7 @@ int wolfSSL_PEM_write_bio_X509_REQ(WOLFSSL_BIO *bp, WOLFSSL_X509 *x)
     int derSz;
     int ret;
 
-    WOLFSSL_ENTER("wolfSSL_PEM_write_bio_X509_REQ()");
+    WOLFSSL_ENTER("wolfSSL_PEM_write_bio_X509_REQ");
 
     if (x == NULL || bp == NULL) {
         return WOLFSSL_FAILURE;
@@ -11579,7 +11579,7 @@ int wolfSSL_PEM_write_bio_X509_AUX(WOLFSSL_BIO *bp, WOLFSSL_X509 *x)
     int derSz;
     int ret;
 
-    WOLFSSL_ENTER("wolfSSL_PEM_write_bio_X509_AUX()");
+    WOLFSSL_ENTER("wolfSSL_PEM_write_bio_X509_AUX");
 
     if (bp == NULL || x == NULL) {
         WOLFSSL_MSG("NULL argument passed in");
@@ -11624,7 +11624,7 @@ int wolfSSL_PEM_write_bio_X509(WOLFSSL_BIO *bio, WOLFSSL_X509 *cert)
     int derSz = X509_BUFFER_SZ;
     int ret;
 
-    WOLFSSL_ENTER("wolfSSL_PEM_write_bio_X509()");
+    WOLFSSL_ENTER("wolfSSL_PEM_write_bio_X509");
 
     if (bio == NULL || cert == NULL) {
         WOLFSSL_MSG("NULL argument passed in");
@@ -12791,7 +12791,7 @@ WOLFSSL_X509* wolfSSL_X509_dup(WOLFSSL_X509 *x)
 #if defined(OPENSSL_EXTRA)
 int wolfSSL_X509_check_ca(WOLFSSL_X509 *x509)
 {
-    WOLFSSL_ENTER("X509_check_ca");
+    WOLFSSL_ENTER("wolfSSL_X509_check_ca");
 
     if (x509 == NULL)
         return WOLFSSL_FAILURE;
@@ -12943,7 +12943,7 @@ int wolfSSL_X509_NAME_copy(WOLFSSL_X509_NAME* from, WOLFSSL_X509_NAME* to)
  * returns WOLFSSL_SUCCESS on success */
 int wolfSSL_X509_set_subject_name(WOLFSSL_X509 *cert, WOLFSSL_X509_NAME *name)
 {
-    WOLFSSL_ENTER("X509_set_subject_name");
+    WOLFSSL_ENTER("wolfSSL_X509_set_subject_name");
     if (cert == NULL || name == NULL)
         return WOLFSSL_FAILURE;
 
@@ -12964,7 +12964,7 @@ int wolfSSL_X509_set_subject_name(WOLFSSL_X509 *cert, WOLFSSL_X509_NAME *name)
  * returns WOLFSSL_SUCCESS on success */
 int wolfSSL_X509_set_issuer_name(WOLFSSL_X509 *cert, WOLFSSL_X509_NAME *name)
 {
-    WOLFSSL_ENTER("X509_set_issuer_name");
+    WOLFSSL_ENTER("wolfSSL_X509_set_issuer_name");
     if (cert == NULL || name == NULL)
         return WOLFSSL_FAILURE;
 

--- a/src/x509_str.c
+++ b/src/x509_str.c
@@ -45,7 +45,7 @@
 WOLFSSL_X509_STORE_CTX* wolfSSL_X509_STORE_CTX_new(void)
 {
     WOLFSSL_X509_STORE_CTX* ctx;
-    WOLFSSL_ENTER("X509_STORE_CTX_new");
+    WOLFSSL_ENTER("wolfSSL_X509_STORE_CTX_new");
 
     ctx = (WOLFSSL_X509_STORE_CTX*)XMALLOC(sizeof(WOLFSSL_X509_STORE_CTX), NULL,
                                     DYNAMIC_TYPE_X509_CTX);
@@ -122,7 +122,7 @@ int wolfSSL_X509_STORE_CTX_init(WOLFSSL_X509_STORE_CTX* ctx,
 /* free's extra data */
 void wolfSSL_X509_STORE_CTX_free(WOLFSSL_X509_STORE_CTX* ctx)
 {
-    WOLFSSL_ENTER("X509_STORE_CTX_free");
+    WOLFSSL_ENTER("wolfSSL_X509_STORE_CTX_free");
     if (ctx != NULL) {
 #ifdef HAVE_EX_DATA_CLEANUP_HOOKS
         wolfSSL_CRYPTO_cleanup_ex_data(&ctx->ex_data);
@@ -715,7 +715,7 @@ WOLFSSL_X509_STORE* wolfSSL_X509_STORE_new(void)
 {
     int ret;
     WOLFSSL_X509_STORE* store = NULL;
-    WOLFSSL_ENTER("SSL_X509_STORE_new");
+    WOLFSSL_ENTER("wolfSSL_X509_STORE_new");
 
     if ((store = (WOLFSSL_X509_STORE*)XMALLOC(sizeof(WOLFSSL_X509_STORE), NULL,
                                     DYNAMIC_TYPE_X509_STORE)) == NULL)
@@ -917,7 +917,7 @@ int wolfSSL_X509_STORE_set_ex_data_with_cleanup(
     void wolfSSL_X509_STORE_set_verify_cb(WOLFSSL_X509_STORE *st,
                                  WOLFSSL_X509_STORE_CTX_verify_cb verify_cb)
     {
-        WOLFSSL_ENTER("WOLFSSL_X509_STORE_set_verify_cb");
+        WOLFSSL_ENTER("wolfSSL_X509_STORE_set_verify_cb");
         if (st != NULL) {
             st->verify_cb = verify_cb;
         }
@@ -927,7 +927,7 @@ int wolfSSL_X509_STORE_set_ex_data_with_cleanup(
 WOLFSSL_X509_LOOKUP* wolfSSL_X509_STORE_add_lookup(WOLFSSL_X509_STORE* store,
                                                WOLFSSL_X509_LOOKUP_METHOD* m)
 {
-    WOLFSSL_ENTER("SSL_X509_STORE_add_lookup");
+    WOLFSSL_ENTER("wolfSSL_X509_STORE_add_lookup");
     if (store == NULL || m == NULL)
         return NULL;
 
@@ -1007,7 +1007,7 @@ WOLFSSL_API int wolfSSL_X509_STORE_load_locations(WOLFSSL_X509_STORE *str,
     ReadDirCtx  readCtx[1];
 #endif
 
-    WOLFSSL_ENTER("X509_STORE_load_locations");
+    WOLFSSL_ENTER("wolfSSL_X509_STORE_load_locations");
 
     if (str == NULL || str->cm == NULL || (file == NULL  && dir == NULL))
         return WOLFSSL_FAILURE;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -5779,7 +5779,7 @@ int GetObjectId(const byte* input, word32* inOutIdx, word32* oid,
 #ifndef WOLFSSL_ASN_TEMPLATE
     int ret, length;
 
-    WOLFSSL_ENTER("GetObjectId()");
+    WOLFSSL_ENTER("GetObjectId");
 
     ret = GetASNObjectId(input, inOutIdx, &length, maxIdx);
     if (ret != 0)
@@ -5790,7 +5790,7 @@ int GetObjectId(const byte* input, word32* inOutIdx, word32* oid,
     ASNGetData dataASN[objectIdASN_Length];
     int ret;
 
-    WOLFSSL_ENTER("GetObjectId()");
+    WOLFSSL_ENTER("GetObjectId");
 
     /* Clear dynamic data and set OID type expected. */
     XMEMSET(dataASN, 0, sizeof(dataASN));
@@ -6841,7 +6841,7 @@ int wc_CreatePKCS8Key(byte* out, word32* outSz, byte* key, word32 keySz,
         return LENGTH_ONLY_E;
     }
 
-    WOLFSSL_ENTER("wc_CreatePKCS8Key()");
+    WOLFSSL_ENTER("wc_CreatePKCS8Key");
 
     if (key == NULL || out == NULL || outSz == NULL) {
         return BAD_FUNC_ARG;
@@ -6914,7 +6914,7 @@ int wc_CreatePKCS8Key(byte* out, word32* outSz, byte* key, word32 keySz,
     word32 keyIdx = 0;
     word32 tmpAlgId = 0;
 
-    WOLFSSL_ENTER("wc_CreatePKCS8Key()");
+    WOLFSSL_ENTER("wc_CreatePKCS8Key");
 
     /* Check validity of parameters. */
     if (out == NULL && outSz != NULL) {
@@ -8785,7 +8785,7 @@ int EncryptContent(byte* input, word32 inputSz, byte* out, word32* outSz,
 
     (void)heap;
 
-    WOLFSSL_ENTER("EncryptContent()");
+    WOLFSSL_ENTER("EncryptContent");
 
     if (CheckAlgo(vPKCS, vAlgo, &id, &version, &blockSz) < 0)
         return ASN_INPUT_E;  /* Algo ID error */
@@ -8952,7 +8952,7 @@ int EncryptContent(byte* input, word32 inputSz, byte* out, word32* outSz,
 
     (void)heap;
 
-    WOLFSSL_ENTER("EncryptContent()");
+    WOLFSSL_ENTER("EncryptContent");
 
     /* Must have a output size to return or check. */
     if (outSz == NULL) {

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -5175,7 +5175,7 @@ int wc_ecc_make_pub(ecc_key* key, ecc_point* pubOut)
  */
 int wc_ecc_make_pub_ex(ecc_key* key, ecc_point* pubOut, WC_RNG* rng)
 {
-    WOLFSSL_ENTER("wc_ecc_make_pub");
+    WOLFSSL_ENTER("wc_ecc_make_pub_ex");
 
     return ecc_make_pub_ex(key, NULL, pubOut, rng);
 }

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -1739,7 +1739,7 @@ int wolfSSL_EVP_PKEY_CTX_free(WOLFSSL_EVP_PKEY_CTX *ctx)
 #else
      return 0;
 #endif
-    WOLFSSL_ENTER("EVP_PKEY_CTX_free");
+    WOLFSSL_ENTER("wolfSSL_EVP_PKEY_CTX_free");
     if (ctx->pkey != NULL)
         wolfSSL_EVP_PKEY_free(ctx->pkey);
     if (ctx->peerKey != NULL)
@@ -1764,7 +1764,7 @@ WOLFSSL_EVP_PKEY_CTX *wolfSSL_EVP_PKEY_CTX_new(WOLFSSL_EVP_PKEY *pkey, WOLFSSL_E
 
     if (pkey == NULL) return 0;
     if (e != NULL) return 0;
-    WOLFSSL_ENTER("EVP_PKEY_CTX_new");
+    WOLFSSL_ENTER("wolfSSL_EVP_PKEY_CTX_new");
 
     ctx = (WOLFSSL_EVP_PKEY_CTX*)XMALLOC(sizeof(WOLFSSL_EVP_PKEY_CTX), NULL,
             DYNAMIC_TYPE_PUBLIC_KEY);
@@ -1801,7 +1801,7 @@ WOLFSSL_EVP_PKEY_CTX *wolfSSL_EVP_PKEY_CTX_new(WOLFSSL_EVP_PKEY *pkey, WOLFSSL_E
 int wolfSSL_EVP_PKEY_CTX_set_rsa_padding(WOLFSSL_EVP_PKEY_CTX *ctx, int padding)
 {
     if (ctx == NULL) return 0;
-    WOLFSSL_ENTER("EVP_PKEY_CTX_set_rsa_padding");
+    WOLFSSL_ENTER("wolfSSL_EVP_PKEY_CTX_set_rsa_padding");
     ctx->padding = padding;
     return WOLFSSL_SUCCESS;
 }
@@ -1817,7 +1817,7 @@ int wolfSSL_EVP_PKEY_CTX_set_signature_md(WOLFSSL_EVP_PKEY_CTX *ctx,
     const EVP_MD* md)
 {
     if (ctx == NULL) return 0;
-    WOLFSSL_ENTER("EVP_PKEY_CTX_set_signature_md");
+    WOLFSSL_ENTER("wolfSSL_EVP_PKEY_CTX_set_signature_md");
 #ifndef NO_RSA
     ctx->md = md;
 #else
@@ -2254,7 +2254,7 @@ int wolfSSL_EVP_PKEY_decrypt(WOLFSSL_EVP_PKEY_CTX *ctx,
 {
     int len = 0;
 
-    WOLFSSL_ENTER("EVP_PKEY_decrypt");
+    WOLFSSL_ENTER("wolfSSL_EVP_PKEY_decrypt");
 
     if (ctx == NULL || ctx->pkey == NULL) {
         WOLFSSL_MSG("Bad parameter.");
@@ -2318,7 +2318,7 @@ int wolfSSL_EVP_PKEY_decrypt(WOLFSSL_EVP_PKEY_CTX *ctx,
 int wolfSSL_EVP_PKEY_decrypt_init(WOLFSSL_EVP_PKEY_CTX *ctx)
 {
     if (ctx == NULL) return WOLFSSL_FAILURE;
-    WOLFSSL_ENTER("EVP_PKEY_decrypt_init");
+    WOLFSSL_ENTER("wolfSSL_EVP_PKEY_decrypt_init");
     switch (ctx->pkey->type) {
     case EVP_PKEY_RSA:
         ctx->op = EVP_PKEY_OP_DECRYPT;
@@ -2351,7 +2351,7 @@ int wolfSSL_EVP_PKEY_encrypt(WOLFSSL_EVP_PKEY_CTX *ctx,
 {
     int len = 0;
 
-    WOLFSSL_ENTER("EVP_PKEY_encrypt");
+    WOLFSSL_ENTER("wolfSSL_EVP_PKEY_encrypt");
 
     if (ctx == NULL || ctx->pkey == NULL) {
         WOLFSSL_MSG("Bad parameter.");
@@ -2422,7 +2422,7 @@ int wolfSSL_EVP_PKEY_encrypt(WOLFSSL_EVP_PKEY_CTX *ctx,
 int wolfSSL_EVP_PKEY_encrypt_init(WOLFSSL_EVP_PKEY_CTX *ctx)
 {
     if (ctx == NULL) return WOLFSSL_FAILURE;
-    WOLFSSL_ENTER("EVP_PKEY_encrypt_init");
+    WOLFSSL_ENTER("wolfSSL_EVP_PKEY_encrypt_init");
 
     switch (ctx->pkey->type) {
     case EVP_PKEY_RSA:
@@ -2703,7 +2703,7 @@ int wolfSSL_EVP_PKEY_bits(const WOLFSSL_EVP_PKEY *pkey)
     int bytes;
 
     if (pkey == NULL) return 0;
-    WOLFSSL_ENTER("EVP_PKEY_bits");
+    WOLFSSL_ENTER("wolfSSL_EVP_PKEY_bits");
     if ((bytes = wolfSSL_EVP_PKEY_size((WOLFSSL_EVP_PKEY*)pkey)) ==0) return 0;
     return bytes*8;
 }
@@ -2923,7 +2923,7 @@ int wolfSSL_EVP_PKEY_keygen(WOLFSSL_EVP_PKEY_CTX *ctx,
 int wolfSSL_EVP_PKEY_size(WOLFSSL_EVP_PKEY *pkey)
 {
     if (pkey == NULL) return 0;
-    WOLFSSL_ENTER("EVP_PKEY_size");
+    WOLFSSL_ENTER("wolfSSL_EVP_PKEY_size");
 
     switch (pkey->type) {
 #ifndef NO_RSA
@@ -4841,7 +4841,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
     /* return a pointer to MD4 EVP type */
     const WOLFSSL_EVP_MD* wolfSSL_EVP_md4(void)
     {
-        WOLFSSL_ENTER("wolfSSL_EVP_md4");
+        WOLFSSL_ENTER("EVP_md4");
         return EVP_get_digestbyname("MD4");
     }
 
@@ -5675,7 +5675,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
     int wolfSSL_EVP_MD_CTX_cleanup(WOLFSSL_EVP_MD_CTX* ctx)
     {
         int ret = WOLFSSL_SUCCESS;
-        WOLFSSL_ENTER("EVP_MD_CTX_cleanup");
+        WOLFSSL_ENTER("wolfSSL_EVP_MD_CTX_cleanup");
         if (ctx->pctx != NULL)
             wolfSSL_EVP_PKEY_CTX_free(ctx->pctx);
 
@@ -5777,7 +5777,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
 
     void wolfSSL_EVP_CIPHER_CTX_init(WOLFSSL_EVP_CIPHER_CTX* ctx)
     {
-        WOLFSSL_ENTER("EVP_CIPHER_CTX_init");
+        WOLFSSL_ENTER("wolfSSL_EVP_CIPHER_CTX_init");
         if (ctx) {
             XMEMSET(ctx, 0, sizeof(WOLFSSL_EVP_CIPHER_CTX));
             ctx->cipherType = WOLFSSL_EVP_CIPH_TYPE_INIT;   /* not yet initialized */
@@ -5801,7 +5801,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
         (void)arg;
         (void)ptr;
 
-        WOLFSSL_ENTER("EVP_CIPHER_CTX_ctrl");
+        WOLFSSL_ENTER("wolfSSL_EVP_CIPHER_CTX_ctrl");
 
         switch(type) {
             case EVP_CTRL_INIT:
@@ -5987,7 +5987,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
     /* WOLFSSL_SUCCESS on ok */
     int wolfSSL_EVP_CIPHER_CTX_cleanup(WOLFSSL_EVP_CIPHER_CTX* ctx)
     {
-        WOLFSSL_ENTER("EVP_CIPHER_CTX_cleanup");
+        WOLFSSL_ENTER("wolfSSL_EVP_CIPHER_CTX_cleanup");
         if (ctx) {
 #if (!defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)) || \
     (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2))

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -2347,7 +2347,7 @@ WC_PKCS12* wc_PKCS12_create(char* pass, word32 passSz, char* name,
     word32 certCiSz;
     word32 keyCiSz;
 
-    WOLFSSL_ENTER("wc_PKCS12_create()");
+    WOLFSSL_ENTER("wc_PKCS12_create");
 
     if (wc_InitRng_ex(&rng, heap, INVALID_DEVID) != 0) {
         return NULL;

--- a/wolfcrypt/src/port/maxim/maxq10xx.c
+++ b/wolfcrypt/src/port/maxim/maxq10xx.c
@@ -1852,7 +1852,7 @@ static int maxq10xx_read_device_cert_der(byte* p_dest_buff, word32* p_len)
     int pk_offset = 0;
 #endif
 
-    WOLFSSL_ENTER("maxq10xx_read_device_cert_der()");
+    WOLFSSL_ENTER("maxq10xx_read_device_cert_der");
     if (!p_dest_buff || !p_len) {
         return BAD_FUNC_ARG;
     }
@@ -2025,7 +2025,7 @@ static int maxq10xx_tls12_ecc_shared_secret(WOLFSSL* ssl, ecc_key* otherKey,
     (void)outlen;
     (void)side;
 
-    WOLFSSL_ENTER("maxq10xx_ecc_shared_secret()");
+    WOLFSSL_ENTER("maxq10xx_ecc_shared_secret");
 
     if (ssl->specs.kea != ecc_diffie_hellman_kea) {
         WOLFSSL_MSG("MAXQ: key exchange algo not supported");
@@ -2215,7 +2215,7 @@ static int maxq10xx_create_dh_key(byte* p, word32 pSz, byte* g, word32 gSz,
     int rc;
     mxq_err_t mxq_rc;
 
-    WOLFSSL_ENTER("maxq10xx_create_dh_key()");
+    WOLFSSL_ENTER("maxq10xx_create_dh_key");
     if (!tls13active) {
         return NOT_COMPILED_IN;
     }
@@ -2278,7 +2278,7 @@ static int maxq10xx_dh_agree(WOLFSSL* ssl, struct DhKey* key,
     (void)priv;
     (void)privSz;
 
-    WOLFSSL_ENTER("maxq10xx_dh_agree()");
+    WOLFSSL_ENTER("maxq10xx_dh_agree");
 
     mxq_u2 csid_param = ssl->options.cipherSuite |
                         (ssl->options.cipherSuite0 << 8);
@@ -2330,7 +2330,7 @@ static int  maxq10xx_ecc_key_gen(WOLFSSL* ssl, ecc_key* key, word32 keySz,
     (void)ctx;
     (void)ssl;
 
-    WOLFSSL_ENTER("maxq10xx_ecc_key_gen()");
+    WOLFSSL_ENTER("maxq10xx_ecc_key_gen");
 
     if (tls13_ecc_obj_id == -1) {
         tls13_ecc_obj_id = alloc_temp_key_id();
@@ -2375,7 +2375,7 @@ static int maxq10xx_ecc_verify(WOLFSSL* ssl, const byte* sig,
     (void)keySz;
     (void)ctx;
 
-    WOLFSSL_ENTER("maxq10xx_ecc_verify()");
+    WOLFSSL_ENTER("maxq10xx_ecc_verify");
 
     if (!tls13active) {
         return CRYPTOCB_UNAVAILABLE;
@@ -2418,7 +2418,7 @@ static int maxq10xx_tls13_ecc_shared_secret(WOLFSSL* ssl, ecc_key* otherKey,
     (void)side;
     (void)pubKeySz;
 
-    WOLFSSL_ENTER("maxq10xx_ecc_shared_secret()");
+    WOLFSSL_ENTER("maxq10xx_ecc_shared_secret");
 
     rc = wc_ecc_export_public_raw(otherKey, qx, &qxLen, qy, &qyLen);
 
@@ -3331,7 +3331,7 @@ static int maxq10xx_perform_tls13_record_processing(WOLFSSL* ssl,
         return rc;
     }
 
-    WOLFSSL_MSG("MAXQ: MXQ_TLS13_Update_IV()");
+    WOLFSSL_MSG("MAXQ: MXQ_TLS13_Update_IV");
     mxq_rc = MXQ_TLS13_Update_IV( key_id, (mxq_u1 *)iv, ivSz);
     if (mxq_rc) {
         WOLFSSL_ERROR_MSG("MAXQ: MXQ_TLS13_Update_IV() failed");

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -14604,7 +14604,7 @@ static int rsa_nb_test(RsaKey* key, const byte* in, word32 inLen, byte* out,
     if (ret < 0) {
         return ret;
     }
-#ifdef DEBUG_WOLFSSL
+#if defined(DEBUG_WOLFSSL) || defined(WOLFSSL_DEBUG_NONBLOCK)
     printf("RSA non-block sign: %d times\n", count);
 #endif
     signSz = ret;
@@ -14622,7 +14622,7 @@ static int rsa_nb_test(RsaKey* key, const byte* in, word32 inLen, byte* out,
     if (ret < 0) {
         return ret;
     }
-#ifdef DEBUG_WOLFSSL
+#if defined(DEBUG_WOLFSSL) || defined(WOLFSSL_DEBUG_NONBLOCK)
     printf("RSA non-block verify: %d times\n", count);
 #endif
 
@@ -14642,7 +14642,7 @@ static int rsa_nb_test(RsaKey* key, const byte* in, word32 inLen, byte* out,
     if (ret < 0) {
         return ret;
     }
-#ifdef DEBUG_WOLFSSL
+#if defined(DEBUG_WOLFSSL) || defined(WOLFSSL_DEBUG_NONBLOCK)
     printf("RSA non-block inline verify: %d times\n", count);
 #endif
 
@@ -26474,7 +26474,7 @@ static int crypto_ecc_verify(const byte *key, uint32_t keySz,
 
             /* This is where real-time work could be called */
         } while (ret == FP_WOULDBLOCK);
-    #ifdef DEBUG_WOLFSSL
+    #if defined(DEBUG_WOLFSSL) || defined(WOLFSSL_DEBUG_NONBLOCK)
         printf("ECC non-block verify: %d times\n", count);
     #endif
         if (ret < 0)
@@ -26563,7 +26563,7 @@ static int crypto_ecc_sign(const byte *key, uint32_t keySz,
             /* This is where real-time work could be called */
         } while (ret == FP_WOULDBLOCK);
 
-    #ifdef DEBUG_WOLFSSL
+    #if defined(DEBUG_WOLFSSL) || defined(WOLFSSL_DEBUG_NONBLOCK)
         printf("ECC non-block sign: %d times\n", count);
     #endif
         if (ret < 0)
@@ -26629,7 +26629,7 @@ static int ecc_test_nonblock_dhe(int curveId, word32 curveSz,
         if (ret < 0)
             ret = -16120;
     }
-#ifdef DEBUG_WOLFSSL
+#if defined(DEBUG_WOLFSSL) || defined(WOLFSSL_DEBUG_NONBLOCK)
     fprintf(stderr, "ECC non-block key gen: %d times\n", count);
 #endif
     if (ret == 0) {
@@ -26652,7 +26652,7 @@ static int ecc_test_nonblock_dhe(int curveId, word32 curveSz,
         if (ret < 0)
             ret = -16123;
     }
-#ifdef DEBUG_WOLFSSL
+#if defined(DEBUG_WOLFSSL) || defined(WOLFSSL_DEBUG_NONBLOCK)
     fprintf(stderr, "ECC non-block shared secret: %d times\n", count);
 #endif
     if (ret == 0) {


### PR DESCRIPTION
# Description

* Update logging enter, exit, msg to match function names.
* Fix some name typos and improper use of "enter" where should be msg.
* Fix internal uses of `SSL_SUCCESS` and `SSL_FAILURE`.
* Add `WOLFSSL_DEBUG_NONBLOCK` option to allow printing iterations without debug enabled.

Fixes #6105

# Testing

```
./configure --enable-debug --enable-all && make check

./configure --enable-ecc=nonblock --enable-sp=yes,nonblock CFLAGS="-DWOLFSSL_PUBLIC_MP -DWOLFSSL_DEBUG_NONBLOCK" && make && ./wolfcrypt/test/testwolfcrypt

./configure --enable-fastmath CFLAGS="-DWC_RSA_NONBLOCK -DWC_RSA_NONBLOCK_TIME -DWOLFSSL_DEBUG_NONBLOCK" && make && ./wolfcrypt/test/testwolfcrypt

./configure --enable-opensslcoexist \
    CFLAGS="-I/usr/local/opt/openssl/include -DTEST_OPENSSL_COEXIST" \
    LDFLAGS="-L/usr/local/opt/openssl/lib -lcrypto"
make
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
