### PR TITLE
Private Key ID: change to always set priv key type and size

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -7671,11 +7671,11 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
         }
 
     #ifdef WOLF_PRIVATE_KEY_ID
-        if (ssl != NULL && ssl->buffers.keyType == 0) {
+        if (ssl != NULL) {
             ssl->buffers.keyType = keyType;
             ssl->buffers.keySz = keySz;
         }
-        else if (ctx != NULL && ctx->privateKeyType == 0) {
+        else if (ctx != NULL) {
             ctx->privateKeyType = keyType;
             ctx->privateKeySz = keySz;
         }


### PR DESCRIPTION
# Description

When a certificate is loaded then the private key type and size is set based on the public key.
Always set, even if previously set.
Use case is setting an RSA certificate against ctx and then setting EC certificate against ssl.

Fixes zd#15637

# Testing

Standard.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
