### PR TITLE
Fix NULL dereference in TLSX_CSR_Parse

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -3218,6 +3218,10 @@ static int TLSX_CSR_Parse(WOLFSSL* ssl, const byte* input, word16 length,
 
     #if defined(WOLFSSL_TLS13)
         if (ssl->options.tls1_3) {
+            if (ssl->buffers.certificate == NULL) {
+                WOLFSSL_MSG("Certificate buffer not set!");
+                return BUFFER_ERROR;
+            }
             cert = (DecodedCert*)XMALLOC(sizeof(DecodedCert), ssl->heap,
                                          DYNAMIC_TYPE_DCERT);
             if (cert == NULL) {


### PR DESCRIPTION
# Description

`./configure --enable-static --enable-ocspstapling --enable-asn=original --enable-nullcipher`

Line 3226 in src/tls.c in the call to `InitDecodedCert()`, an attempt is made to access `ssl->buffers.certificate->buffer`, but `ssl->buffers.certificate` could be NULL at this point, so a NULL pointer dereference occurs.

Fixes zd15698

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
