### PR TITLE
fix WOLFSSL_SHA_CTX for OpenSSL w/Espressif HW hash

### DIFF
--- a/wolfssl/openssl/sha.h
+++ b/wolfssl/openssl/sha.h
@@ -41,6 +41,8 @@ typedef struct WOLFSSL_SHA_CTX {
     /* big enough to hold wolfcrypt Sha, but check on init */
 #if defined(STM32_HASH)
     void* holder[(112 + WC_ASYNC_DEV_SIZE + sizeof(STM32_HASH_Context)) / sizeof(void*)];
+#elif defined(WOLFSSL_ESPWROOM32) && !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+    void* holder[(112 + WC_ASYNC_DEV_SIZE + sizeof(WC_ESP32SHA)) / sizeof(void*)];
 #else
     void* holder[(112 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
 #endif


### PR DESCRIPTION
# Description

This PR takes into account the size of the `WC_ESP32SHA` struct that is added to the wolfSSL `WOLFSSL_SHA_CTX` struct for the openSSL `holder[]` in [openssl/sha.h](https://github.com/wolfSSL/wolfssl/blob/b81759173a87dae62fcc23affdc4d9b1e0e406d2/wolfssl/openssl/sha.h#L40) for the Espressif ESP-IDF, fixing https://github.com/wolfSSL/wolfssl/issues/6028.

Note that there are currently other errors when enabling OpenSSL and hardware acceleration on the ESP32, specifically the SHA224 failure noted in https://github.com/wolfSSL/wolfssl/issues/6059 as well as SHA512/224 noted in https://github.com/wolfSSL/wolfssl/issues/6028#issuecomment-1433086389. I have a fix for those as well, but the days have turned into weeks for my major update in my [ED25519_SHA2_fix](https://github.com/gojimmypi/wolfssl/tree/ED25519_SHA2_fix) branch, so I'm creating this separate PR now to address this specific compile issue.

Fixes zd# n/a

# Testing

Successful benchmark and wolfssl_test when See https://github.com/wolfSSL/wolfssl/issues/6028#issuecomment-1410214245

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
