### PR TITLE
Add introspection for math build and math cleanups

### DIFF
--- a/IDE/Espressif/ESP-IDF/test/test_wolfssl.c
+++ b/IDE/Espressif/ESP-IDF/test/test_wolfssl.c
@@ -21,7 +21,7 @@
 #include <wolfssl/wolfcrypt/wc_port.h>
 #include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/types.h>
-#include <wolfssl/wolfcrypt/integer.h>
+#include <wolfssl/wolfcrypt/wolfmath.h>
 
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -66,11 +66,8 @@ static const char *wolfsentry_config_path = NULL;
 #include <wolfssl/certs_test.h>
 #endif
 
-#ifdef USE_FAST_MATH
-    /* included to inspect the size of FP_MAX_BITS */
-    /* need integer.h header to make sure right math version used */
-    #include <wolfssl/wolfcrypt/integer.h>
-#endif
+#include <wolfssl/wolfcrypt/wolfmath.h> /* for max bits */
+
 #ifdef HAVE_ECC
     #include <wolfssl/wolfcrypt/ecc.h>
 #endif

--- a/tests/api.c
+++ b/tests/api.c
@@ -61817,7 +61817,7 @@ static void test_wolfSSL_CTX_StaticMemory_TLS(int tlsVer,
 }
 #endif /* WOLFSSL_STATIC_MEMORY && HAVE_IO_TESTS_DEPENDENCIES */
 
-#ifdef WOLFSSL_STATIC_MEMORY
+#if defined(WOLFSSL_STATIC_MEMORY) && !defined(WOLFCRYPT_ONLY)
 #if (defined(HAVE_ECC) && !defined(ALT_ECC_SIZE)) || \
         defined(SESSION_CERTS)
     #ifdef OPENSSL_EXTRA
@@ -61867,12 +61867,12 @@ static int test_wolfSSL_CTX_StaticMemory_SSL(WOLFSSL_CTX* ctx)
 
     return TEST_RES_CHECK(1);
 }
-#endif /* WOLFSSL_STATIC_MEMORY */
+#endif /* WOLFSSL_STATIC_MEMORY && !WOLFCRYPT_ONLY */
 
 static int test_wolfSSL_CTX_StaticMemory(void)
 {
     int res = TEST_SKIPPED;
-#ifdef WOLFSSL_STATIC_MEMORY
+#if defined(WOLFSSL_STATIC_MEMORY) && !defined(WOLFCRYPT_ONLY)
     wolfSSL_method_func method_func;
     WOLFSSL_CTX* ctx;
     const int kMaxCtxClients = 2;
@@ -61945,7 +61945,7 @@ static int test_wolfSSL_CTX_StaticMemory(void)
 #endif /* HAVE_IO_TESTS_DEPENDENCIES */
 
     res = TEST_RES_CHECK(1);
-#endif
+#endif /* WOLFSSL_STATIC_MEMORY && !WOLFCRYPT_ONLY */
     return res;
 }
 

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -63,6 +63,7 @@
 #include <wolfssl/version.h>
 #include <wolfssl/wolfcrypt/wc_port.h>
 #include <wolfssl/wolfcrypt/ecc.h>
+#include <wolfssl/wolfcrypt/wolfmath.h>
 
 #ifdef WOLFSSL_ESPIDF
     #include <xtensa/hal.h> /* reminder Espressif RISC-V not yet implemented */
@@ -2841,6 +2842,10 @@ int benchmark_init(void)
         printf("%swolfCrypt_Init failed %d\n", err_prefix, ret);
         return EXIT_FAILURE;
     }
+
+#ifdef HAVE_WC_INTROSPECTION
+    printf("Math: %s\n", wc_GetMathInfo());
+#endif
 
 #ifdef WOLFSSL_SECO_CAAM
     if (wc_SECO_OpenHSM(SECO_KEY_STORE_ID,

--- a/wolfcrypt/src/dsa.c
+++ b/wolfcrypt/src/dsa.c
@@ -29,7 +29,7 @@
 #ifndef NO_DSA
 
 #include <wolfssl/wolfcrypt/random.h>
-#include <wolfssl/wolfcrypt/integer.h>
+#include <wolfssl/wolfcrypt/wolfmath.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/sha.h>

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -45,7 +45,7 @@
 #include <wolfssl/openssl/ecdsa.h>
 #include <wolfssl/openssl/evp.h>
 #include <wolfssl/openssl/kdf.h>
-#include <wolfssl/wolfcrypt/integer.h>
+#include <wolfssl/wolfcrypt/wolfmath.h>
 
 #ifndef NO_AES
     #if defined(HAVE_AES_CBC) || defined(WOLFSSL_AES_DIRECT)

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -47,7 +47,7 @@
     #include <wolfcrypt/src/misc.c>
 #endif
 
-#include <wolfssl/wolfcrypt/integer.h>
+#include <wolfssl/wolfcrypt/wolfmath.h>
 
 #if defined(FREESCALE_LTC_TFM)
     #include <wolfssl/wolfcrypt/port/nxp/ksdk_port.h>

--- a/wolfcrypt/src/port/Espressif/esp32_mp.c
+++ b/wolfcrypt/src/port/Espressif/esp32_mp.c
@@ -39,7 +39,7 @@
     #define WOLFSSL_MISC_INCLUDED
     #include <wolfcrypt/src/misc.c>
 #endif
-#include <wolfssl/wolfcrypt/tfm.h>
+#include <wolfssl/wolfcrypt/wolfmath.h>
 
 static const char* const TAG = "wolfssl_mp";
 
@@ -115,12 +115,12 @@ static int esp_mp_hw_lock()
             espmp_CryptHwMutexInit = 1;
         }
         else {
-            ESP_LOGE(TAG, "mp mutx initialization failed.");
+            ESP_LOGE(TAG, "mp mutex initialization failed.");
             return MP_NG;
         }
     }
     else {
-        /* esp aes has already been iniitlized */
+        /* esp aes has already been initialized */
     }
 
     /* lock hardware */
@@ -138,7 +138,7 @@ static int esp_mp_hw_lock()
      */
     DPORT_REG_CLR_BIT(DPORT_RSA_PD_CTRL_REG, DPORT_RSA_PD);
 
-    /* remionder: wait until RSA_CLEAN_REG reads 1
+    /* reminder: wait until RSA_CLEAN_REG reads 1
      *  see esp_mp_hw_wait_clean()
      */
 
@@ -161,9 +161,9 @@ static void esp_mp_hw_unlock( void )
     esp_CryptHwMutexUnLock(&mp_mutex);
 }
 
-/* this is based on an article by Cetin Kaya Koc, A New Algorithm for Inversion*/
-/* mod p^k, June 28 2017.                                                     */
-static int esp_calc_Mdash(mp_int *M, word32 k, mp_digit* md)
+/* this is based on an article by Cetin Kaya Koc,
+ * A New Algorithm for Inversion: mod p^k, June 28 2017 */
+static int esp_calc_Mdash(MATH_INT_T *M, word32 k, mp_digit* md)
 {
     int i;
     int xi;
@@ -199,7 +199,7 @@ static void process_start(word32 reg)
 }
 
 /* wait until done */
-static int wait_uitil_done(word32 reg)
+static int wait_until_done(word32 reg)
 {
     word32 timeout = 0;
     /* wait until done && not timeout */
@@ -221,7 +221,7 @@ static int wait_uitil_done(word32 reg)
 
 /* read data from memory into mp_init          */
 static void esp_memblock_to_mpint(word32 mem_address,
-                                  mp_int* mp,
+                                  MATH_INT_T* mp,
                                   word32 numwords)
 {
     esp_dport_access_read_buffer((uint32_t*)mp->dp, mem_address, numwords);
@@ -230,7 +230,7 @@ static void esp_memblock_to_mpint(word32 mem_address,
 
 /* write mp_init into memory block
  */
-static void esp_mpint_to_memblock(word32 mem_address, const mp_int* mp,
+static void esp_mpint_to_memblock(word32 mem_address, const MATH_INT_T* mp,
                                                       const word32 bits,
                                                       const word32 hwords)
 {
@@ -271,7 +271,7 @@ static word32 bits2words(word32 bits)
 }
 
 /* get rinv */
-static int esp_get_rinv(mp_int *rinv, mp_int *M, word32 exp)
+static int esp_get_rinv(MATH_INT_T *rinv, MATH_INT_T *M, word32 exp)
 {
     int ret = 0;
 
@@ -291,16 +291,18 @@ static int esp_get_rinv(mp_int *rinv, mp_int *M, word32 exp)
 }
 
 /* Z = X * Y;  */
-int esp_mp_mul(fp_int* X, fp_int* Y, fp_int* Z)
+int esp_mp_mul(MATH_INT_T* X, MATH_INT_T* Y, MATH_INT_T* Z)
 {
     int ret = 0;
-    int neg = (X->sign == Y->sign)? MP_ZPOS : MP_NEG;
-
+    int neg;
     word32 Xs;
     word32 Ys;
     word32 Zs;
     word32 maxWords_sz;
     word32 hwWords_sz;
+
+    /* neg check - X*Y becomes negative */
+    neg = mp_isneg(X) != mp_isneg(Y) ? 1 : 0;
 
     /* ask bits number */
     Xs = mp_count_bits(X);
@@ -356,9 +358,9 @@ int esp_mp_mul(fp_int* X, fp_int* Y, fp_int* Z)
     process_start(RSA_MULT_START_REG);
 
     /* step.4,5 wait until done                       */
-    ret = wait_uitil_done(RSA_INTERRUPT_REG);
+    ret = wait_until_done(RSA_INTERRUPT_REG);
     if (ret != MP_OKAY) {
-        ESP_LOGE(TAG, "wait_uitil_done failed.");
+        ESP_LOGE(TAG, "wait_until_done failed.");
         return ret;
     }
     /* step.6 read the result form MEM_Z              */
@@ -367,16 +369,18 @@ int esp_mp_mul(fp_int* X, fp_int* Y, fp_int* Z)
     /* step.7 clear and release hw                    */
     esp_mp_hw_unlock();
 
-    Z->sign = (Z->used > 0) ? neg : MP_ZPOS;
+    if (!mp_iszero(Z) && neg) {
+        mp_setneg(mpi);
+    }
 
     return ret;
 }
 
 /* Z = X * Y (mod M)                                  */
-int esp_mp_mulmod(fp_int* X, fp_int* Y, fp_int* M, fp_int* Z)
+int esp_mp_mulmod(MATH_INT_T* X, MATH_INT_T* Y, MATH_INT_T* M, MATH_INT_T* Z)
 {
     int ret = 0;
-    int negcheck = 0;
+    int negcheck;
     word32 Xs;
     word32 Ys;
     word32 Ms;
@@ -384,15 +388,13 @@ int esp_mp_mulmod(fp_int* X, fp_int* Y, fp_int* M, fp_int* Z)
     word32 hwWords_sz;
     word32 zwords;
 
-    mp_int r_inv;
-    mp_int tmpZ;
+    MATH_INT_T r_inv;
+    MATH_INT_T tmpZ;
     mp_digit mp;
 
-    /* neg check */
-    if (X->sign != Y->sign) {
-        /* X*Y becomes negative */
-        negcheck = 1;
-    }
+    /* neg check - X*Y becomes negative */
+    negcheck = mp_isneg(X) != mp_isneg(Y) ? 1 : 0;
+
     /* ask bits number */
     Xs = mp_count_bits(X);
     Ys = mp_count_bits(Y);
@@ -470,7 +472,7 @@ int esp_mp_mulmod(fp_int* X, fp_int* Y, fp_int* M, fp_int* Z)
     process_start(RSA_MULT_START_REG);
 
     /* step.5,6 wait until done                       */
-    wait_uitil_done(RSA_INTERRUPT_REG);
+    wait_until_done(RSA_INTERRUPT_REG);
     /* step.7 Y to MEM_X                              */
     esp_mpint_to_memblock(RSA_MEM_X_BLOCK_BASE, Y, Ys, hwWords_sz);
 
@@ -478,7 +480,7 @@ int esp_mp_mulmod(fp_int* X, fp_int* Y, fp_int* M, fp_int* Z)
     process_start(RSA_MULT_START_REG);
 
     /* step.9,11 wait until done                      */
-    wait_uitil_done(RSA_INTERRUPT_REG);
+    wait_until_done(RSA_INTERRUPT_REG);
 
     /* step.12 read the result from MEM_Z             */
     esp_memblock_to_mpint(RSA_MEM_Z_BLOCK_BASE, &tmpZ, zwords);
@@ -488,7 +490,7 @@ int esp_mp_mulmod(fp_int* X, fp_int* Y, fp_int* M, fp_int* Z)
 
     /* additional steps                               */
     /* this needs for known issue when Z is greater than M */
-    if (mp_cmp(&tmpZ, M) == FP_GT) {
+    if (mp_cmp(&tmpZ, M) == MP_GT) {
         /*  Z -= M  */
         mp_sub(&tmpZ, M, &tmpZ);
     }
@@ -522,7 +524,7 @@ int esp_mp_mulmod(fp_int* X, fp_int* Y, fp_int* M, fp_int* Z)
 .*
 .* Note some DH references may use: Y = (G ^ X) mod P
  */
-int esp_mp_exptmod(fp_int* X, fp_int* Y, word32 Ys, fp_int* M, fp_int* Z)
+int esp_mp_exptmod(MATH_INT_T* X, MATH_INT_T* Y, word32 Ys, MATH_INT_T* M, MATH_INT_T* Z)
 {
     int ret = 0;
 
@@ -531,7 +533,7 @@ int esp_mp_exptmod(fp_int* X, fp_int* Y, word32 Ys, fp_int* M, fp_int* Z)
     word32 maxWords_sz;
     word32 hwWords_sz;
 
-    mp_int r_inv;
+    MATH_INT_T r_inv;
     mp_digit mp;
 
     /* ask bits number */
@@ -600,7 +602,7 @@ int esp_mp_exptmod(fp_int* X, fp_int* Y, word32 Ys, fp_int* M, fp_int* Z)
     process_start(RSA_START_MODEXP_REG);
 
     /* step.5 wait until done                         */
-    wait_uitil_done(RSA_INTERRUPT_REG);
+    wait_until_done(RSA_INTERRUPT_REG);
     /* step.6 read a result form memory               */
     esp_memblock_to_mpint(RSA_MEM_Z_BLOCK_BASE, Z, BITS_TO_WORDS(Ms));
     /* step.7 clear and release hw                    */
@@ -610,6 +612,8 @@ int esp_mp_exptmod(fp_int* X, fp_int* Y, word32 Ys, fp_int* M, fp_int* Z)
 
     return ret;
 }
-#endif /* !NO_RSA || HAVE_ECC */
 
-#endif /* (WOLFSS_ESP32WROOM32_CRYPT) && (NO_WOLFSSL_ESP32WROOM32_CRYPT_RES_PRI)*/
+#endif /* WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI) &&
+        * !NO_WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI */
+
+#endif /* !NO_RSA || HAVE_ECC */

--- a/wolfcrypt/src/port/cypress/psoc6_crypto.c
+++ b/wolfcrypt/src/port/cypress/psoc6_crypto.c
@@ -32,22 +32,16 @@
 #endif
 
 #if defined(WOLFSSL_PSOC6_CRYPTO)
-#if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
-    struct sp_int;
-    #define MATH_INT_T struct sp_int
-#elif defined(USE_FAST_MATH)
-    struct fp_int;
-    #define MATH_INT_T struct fp_int
-#else
-    struct mp_int;
-	#define MATH_INT_T struct mp_int
-#endif
 
 #include <wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h>
 #include <wolfssl/wolfcrypt/random.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/logging.h>
 #include <stdint.h>
+
+#ifdef HAVE_ECC
+#include <wolfssl/wolfcrypt/ecc.h>
+#endif
 
 static CRYPTO_Type *crypto_base = PSOC6_CRYPTO_BASE;
 
@@ -192,7 +186,7 @@ static cy_en_crypto_ecc_curve_id_t psoc6_get_curve_id(int size)
         case 32:
             return CY_CRYPTO_ECC_ECP_SECP256R1;
         case 48:
-            return CY_CRYPTO_ECC_ECP_SECP384R1; 
+            return CY_CRYPTO_ECC_ECP_SECP384R1;
         case 66:
             return CY_CRYPTO_ECC_ECP_SECP521R1;
         default:
@@ -200,7 +194,6 @@ static cy_en_crypto_ecc_curve_id_t psoc6_get_curve_id(int size)
     }
 }
 
-#include <wolfssl/wolfcrypt/ecc.h>
 int psoc6_ecc_verify_hash_ex(MATH_INT_T *r, MATH_INT_T *s, const byte* hash,
                     word32 hashlen, int* verif_res, ecc_key* key)
 {
@@ -214,7 +207,7 @@ int psoc6_ecc_verify_hash_ex(MATH_INT_T *r, MATH_INT_T *s, const byte* hash,
 
     if (!key || !verif_res || !r || !s || !hash)
         return -BAD_FUNC_ARG;
-    
+
     /* retrieve and check sizes */
     szModulus = mp_unsigned_bin_size(key->pubkey.x);
     szkbin = mp_unsigned_bin_size(r);

--- a/wolfcrypt/src/port/nxp/se050_port.c
+++ b/wolfcrypt/src/port/nxp/se050_port.c
@@ -29,7 +29,7 @@
 
 #ifdef WOLFSSL_SE050
 
-#include <wolfssl/wolfcrypt/types.h>
+#include <wolfssl/wolfcrypt/types.h> /* for MATH_INT_T */
 #include <wolfssl/wolfcrypt/wc_port.h>
 #include <wolfssl/wolfcrypt/aes.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
@@ -47,16 +47,6 @@
     #include "ex_sss_boot.h"
 #endif
 
-#if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
-    struct sp_int;
-    #define MATH_INT_T struct sp_int
-#elif defined(USE_FAST_MATH)
-    struct fp_int;
-    #define MATH_INT_T struct fp_int
-#else
-    struct mp_int;
-    #define MATH_INT_T struct mp_int
-#endif
 #ifdef HAVE_ECC
     #include <wolfssl/wolfcrypt/ecc.h>
     struct ecc_key;
@@ -1979,7 +1969,7 @@ int wc_se050_ecc_insert_private_key(word32 keyId, const byte* eccDer,
     return se050_ecc_insert_key(keyId, eccDer, eccDerSize, ECC_PRIVATEKEY);
 }
 
-int se050_ecc_sign_hash_ex(const byte* in, word32 inLen, mp_int* r, mp_int* s,
+int se050_ecc_sign_hash_ex(const byte* in, word32 inLen, MATH_INT_T* r, MATH_INT_T* s,
                            byte* out, word32 *outLen, struct ecc_key* key)
 {
     int                 ret = 0;
@@ -2151,8 +2141,8 @@ int se050_ecc_sign_hash_ex(const byte* in, word32 inLen, mp_int* r, mp_int* s,
     return ret;
 }
 
-int se050_ecc_verify_hash_ex(const byte* hash, word32 hashLen, mp_int* r,
-                             mp_int* s, struct ecc_key* key, int* res)
+int se050_ecc_verify_hash_ex(const byte* hash, word32 hashLen, MATH_INT_T* r,
+                             MATH_INT_T* s, struct ecc_key* key, int* res)
 {
     int                 ret = 0;
     sss_status_t        status;

--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -31,7 +31,7 @@
 #include <wolfssl/wolfcrypt/pwdbased.h>
 #include <wolfssl/wolfcrypt/hmac.h>
 #include <wolfssl/wolfcrypt/hash.h>
-#include <wolfssl/wolfcrypt/integer.h>
+#include <wolfssl/wolfcrypt/wolfmath.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef NO_INLINE

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -227,11 +227,10 @@
 #include <wolfssl/wolfcrypt/sha512.h>
 #include <wolfssl/wolfcrypt/rc2.h>
 #include <wolfssl/wolfcrypt/arc4.h>
-#if defined(WC_NO_RNG)
-    #include <wolfssl/wolfcrypt/integer.h>
-#else
+#if !defined(WC_NO_RNG)
     #include <wolfssl/wolfcrypt/random.h>
 #endif
+#include <wolfssl/wolfcrypt/wolfmath.h>
 #include <wolfssl/wolfcrypt/coding.h>
 #include <wolfssl/wolfcrypt/signature.h>
 #include <wolfssl/wolfcrypt/rsa.h>
@@ -1737,6 +1736,10 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
             printf("wolfCrypt_Init failed %d\n", ret);
             err_sys("Error with wolfCrypt_Init!\n", WC_TEST_RET_ENC_EC(ret));
         }
+
+    #ifdef HAVE_WC_INTROSPECTION
+        printf("Math: %s\n", wc_GetMathInfo());
+    #endif
 
 #ifdef WC_RNG_SEED_CB
     wc_SetSeed_Cb(wc_GenerateSeed);

--- a/wolfssl/openssl/bn.h
+++ b/wolfssl/openssl/bn.h
@@ -31,7 +31,7 @@
 #define WOLFSSL_BN_H_
 
 #include <wolfssl/wolfcrypt/settings.h>
-#include <wolfssl/wolfcrypt/integer.h>
+#include <wolfssl/wolfcrypt/wolfmath.h>
 
 #ifdef __cplusplus
     extern "C" {

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -43,7 +43,7 @@ that can be serialized and deserialized in a cross-platform way.
     #define NO_ASN_TIME /* backwards compatibility with NO_TIME_H */
 #endif
 
-#include <wolfssl/wolfcrypt/integer.h>
+#include <wolfssl/wolfcrypt/wolfmath.h>
 
 /* fips declare of RsaPrivateKeyDecode @wc_fips */
 #if defined(HAVE_FIPS) && !defined(NO_RSA) && \

--- a/wolfssl/wolfcrypt/dh.h
+++ b/wolfssl/wolfcrypt/dh.h
@@ -35,7 +35,7 @@
     #include <wolfssl/wolfcrypt/fips.h>
 #endif /* HAVE_FIPS_VERSION >= 2 */
 
-#include <wolfssl/wolfcrypt/integer.h>
+#include <wolfssl/wolfcrypt/wolfmath.h>
 #include <wolfssl/wolfcrypt/random.h>
 
 #ifdef WOLFSSL_KCAPI_DH

--- a/wolfssl/wolfcrypt/dsa.h
+++ b/wolfssl/wolfcrypt/dsa.h
@@ -30,7 +30,7 @@
 
 #ifndef NO_DSA
 
-#include <wolfssl/wolfcrypt/integer.h>
+#include <wolfssl/wolfcrypt/wolfmath.h>
 #include <wolfssl/wolfcrypt/random.h>
 
 /* for DSA reverse compatibility */

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -36,7 +36,7 @@
     #include <wolfssl/wolfcrypt/fips.h>
 #endif /* HAVE_FIPS_VERSION >= 2 */
 
-#include <wolfssl/wolfcrypt/integer.h>
+#include <wolfssl/wolfcrypt/wolfmath.h>
 #include <wolfssl/wolfcrypt/random.h>
 
 #ifdef HAVE_X963_KDF

--- a/wolfssl/wolfcrypt/eccsi.h
+++ b/wolfssl/wolfcrypt/eccsi.h
@@ -31,7 +31,7 @@
 
 #ifdef WOLFCRYPT_HAVE_ECCSI
 
-#include <wolfssl/wolfcrypt/integer.h>
+#include <wolfssl/wolfcrypt/wolfmath.h>
 #include <wolfssl/wolfcrypt/ecc.h>
 #include <wolfssl/wolfcrypt/hash.h>
 #include <wolfssl/wolfcrypt/hmac.h>

--- a/wolfssl/wolfcrypt/integer.h
+++ b/wolfssl/wolfcrypt/integer.h
@@ -29,15 +29,14 @@
 #ifndef WOLF_CRYPT_INTEGER_H
 #define WOLF_CRYPT_INTEGER_H
 
-/* may optionally use fast math instead, not yet supported on all platforms and
-   may not be faster on all
-*/
-#include <wolfssl/wolfcrypt/types.h>       /* will set MP_xxBIT if not default */
-#if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
-    #include <wolfssl/wolfcrypt/sp_int.h>
-#elif defined(USE_FAST_MATH)
-    #include <wolfssl/wolfcrypt/tfm.h>
-#else
+/* may optionally use SP math all or fast math instead. The heap math requires
+ * realloc and is not timing resistant. The SP math all is recommended for new
+ * designs.
+ */
+
+#include <wolfssl/wolfcrypt/wolfmath.h>
+
+#ifdef USE_INTEGER_HEAP_MATH
 
 #include <wolfssl/wolfcrypt/random.h>
 
@@ -411,7 +410,6 @@ MP_API int mp_mod_d(mp_int* a, mp_digit b, mp_digit* c);
 #endif
 
 
-#endif /* USE_FAST_MATH */
+#endif /* USE_INTEGER_HEAP_MATH */
 
 #endif  /* WOLF_CRYPT_INTEGER_H */
-

--- a/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
+++ b/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
@@ -23,6 +23,7 @@
 #define __ESP32_CRYPT_H__
 
 #include "wolfssl/wolfcrypt/settings.h"
+#include <wolfssl/wolfcrypt/types.h> /* for MATH_INT_T */
 
 #include "esp_idf_version.h"
 #include "esp_types.h"
@@ -174,13 +175,6 @@ int esp_CryptHwMutexUnLock(wolfSSL_Mutex* mutex);
         #define ESP_RSA_TIMEOUT_CNT     0x249F00
     #endif
 
-    /* operands can be up to 4096 bits long.
-     * here we store the bits in wolfSSL fp_int struct.
-     * see wolfCrypt tfm.h
-     */
-    struct fp_int;
-
-
     /*
      * The parameter names in the Espressif implementation are arbitrary.
      *
@@ -191,25 +185,25 @@ int esp_CryptHwMutexUnLock(wolfSSL_Mutex* mutex);
 
     /* Z = (X ^ Y) mod M   : Espressif generic notation    */
     /* Y = (G ^ X) mod P   : wolfSSL DH reference notation */
-    int esp_mp_exptmod(struct fp_int* X,    /* G  */
-                       struct fp_int* Y,    /* X  */
-                              word32 Xbits, /* Ys   typically = fp_count_bits (X) */
-                       struct fp_int* M,    /* P  */
-                       struct fp_int* Z);   /* Y  */
+    int esp_mp_exptmod(MATH_INT_T* X,    /* G  */
+                       MATH_INT_T* Y,    /* X  */
+                       word32 Xbits, /* Ys   typically = mp_count_bits (X) */
+                       MATH_INT_T* M,    /* P  */
+                       MATH_INT_T* Z);   /* Y  */
 
     /* Z = X * Y */
-    int esp_mp_mul(struct fp_int* X,
-                   struct fp_int* Y,
-                   struct fp_int* Z);
+    int esp_mp_mul(MATH_INT_T* X,
+                   MATH_INT_T* Y,
+                   MATH_INT_T* Z);
 
 
     /* Z = X * Y (mod M) */
-    int esp_mp_mulmod(struct fp_int* X,
-                      struct fp_int* Y,
-                      struct fp_int* M,
-                      struct fp_int* Z);
+    int esp_mp_mulmod(MATH_INT_T* X,
+                      MATH_INT_T* Y,
+                      MATH_INT_T* M,
+                      MATH_INT_T* Z);
 
-#endif /* NO_RSA || HAVE_ECC*/
+#endif /* !NO_RSA || HAVE_ECC*/
 
 /* end c++ wrapper */
 #ifdef __cplusplus

--- a/wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h
+++ b/wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h
@@ -23,6 +23,7 @@
 #define _PSOC6_CRYPTO_PORT_H_
 
 #include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/types.h> /* for MATH_INT_T */
 #include "cy_crypto_core_sha.h"
 #include "cy_device_headers.h"
 #include "psoc6_02_config.h"
@@ -42,7 +43,7 @@
 
 #ifdef HAVE_ECC
 #include <wolfssl/wolfcrypt/ecc.h>
-int psoc6_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
+int psoc6_ecc_verify_hash_ex(MATH_INT_T *r, MATH_INT_T *s, const byte* hash,
                     word32 hashlen, int* verif_res, ecc_key* key);
 #endif /* HAVE_ECC */
 

--- a/wolfssl/wolfcrypt/port/nxp/ksdk_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/ksdk_port.h
@@ -23,13 +23,7 @@
 #define _KSDK_PORT_H_
 
 #include <wolfssl/wolfcrypt/settings.h>
-#ifdef USE_FAST_MATH
-    #include <wolfssl/wolfcrypt/tfm.h>
-#elif defined WOLFSSL_SP_MATH
-    #include <wolfssl/wolfcrypt/sp_int.h>
-#else
-    #include <wolfssl/wolfcrypt/integer.h>
-#endif
+#include <wolfssl/wolfcrypt/wolfmath.h>
 #include <wolfssl/wolfcrypt/ecc.h>
 #include <wolfssl/wolfcrypt/curve25519.h>
 #include <wolfssl/wolfcrypt/ed25519.h>

--- a/wolfssl/wolfcrypt/port/nxp/se050_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/se050_port.h
@@ -24,6 +24,7 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/visibility.h>
+#include <wolfssl/wolfcrypt/types.h> /* for MATH_INT_T */
 
 #ifdef __GNUC__
 #pragma GCC diagnostic push
@@ -152,19 +153,6 @@ WOLFSSL_LOCAL void se050_aes_free(struct Aes* aes);
 #endif
 
 struct WC_RNG;
-#ifdef HAVE_ECC
-#if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
-    struct sp_int;
-    #define MATH_INT_T struct sp_int
-    typedef struct sp_int mp_int;
-#elif defined(USE_FAST_MATH)
-    struct fp_int;
-    #define MATH_INT_T struct fp_int
-    typedef struct fp_int mp_int;
-#else
-    struct mp_int;
-	#define MATH_INT_T struct mp_int
-#endif
 struct ecc_key;
 
 WOLFSSL_LOCAL int se050_ecc_use_key_id(struct ecc_key* key, word32 keyId);

--- a/wolfssl/wolfcrypt/port/st/stm32.h
+++ b/wolfssl/wolfcrypt/port/st/stm32.h
@@ -26,7 +26,7 @@
 /* Supports CubeMX HAL or Standard Peripheral Library */
 
 #include <wolfssl/wolfcrypt/settings.h>
-#include <wolfssl/wolfcrypt/types.h>
+#include <wolfssl/wolfcrypt/types.h> /* for MATH_INT_T */
 
 #ifdef STM32_HASH
 
@@ -50,7 +50,7 @@
     #define HASH_DATATYPE_8B HASH_DataType_8b
 #endif
 #ifndef HASH_STR_NBW
-	#define HASH_STR_NBW HASH_STR_NBLW
+    #define HASH_STR_NBW HASH_STR_NBLW
 #endif
 
 #ifndef STM32_HASH_TIMEOUT
@@ -95,7 +95,7 @@ int  wc_Stm32_Hash_Final(STM32_HASH_Context* stmCtx, word32 algo,
 #ifndef NO_AES
     #if !defined(STM32_CRYPTO_AES_GCM) && (defined(WOLFSSL_STM32F4) || \
             defined(WOLFSSL_STM32F7) || defined(WOLFSSL_STM32L4) || \
-			defined(WOLFSSL_STM32L5) || defined(WOLFSSL_STM32H7) || \
+            defined(WOLFSSL_STM32L5) || defined(WOLFSSL_STM32H7) || \
             defined(WOLFSSL_STM32U5))
         /* Hardware supports AES GCM acceleration */
         #define STM32_CRYPTO_AES_GCM
@@ -108,13 +108,13 @@ int  wc_Stm32_Hash_Final(STM32_HASH_Context* stmCtx, word32 algo,
     #endif
     #if defined(WOLFSSL_STM32L4) || defined(WOLFSSL_STM32L5) || \
         defined(WOLFSSL_STM32U5)
-		#if defined(WOLFSSL_STM32L4) || defined(WOLFSSL_STM32U5)
-        	#define STM32_CRYPTO_AES_ONLY /* crypto engine only supports AES */
-		#endif
+        #if defined(WOLFSSL_STM32L4) || defined(WOLFSSL_STM32U5)
+            #define STM32_CRYPTO_AES_ONLY /* crypto engine only supports AES */
+        #endif
         #define CRYP AES
-		#ifndef CRYP_AES_GCM
-			#define CRYP_AES_GCM CRYP_AES_GCM_GMAC
-		#endif
+        #ifndef CRYP_AES_GCM
+            #define CRYP_AES_GCM CRYP_AES_GCM_GMAC
+        #endif
     #endif
 
     /* Detect newer CubeMX crypto HAL (HAL_CRYP_Encrypt / HAL_CRYP_Decrypt) */
@@ -146,16 +146,6 @@ int  wc_Stm32_Hash_Final(STM32_HASH_Context* stmCtx, word32 algo,
 #endif /* STM32_CRYPTO */
 
 #if defined(WOLFSSL_STM32_PKA) && defined(HAVE_ECC)
-#if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
-    struct sp_int;
-    #define MATH_INT_T struct sp_int
-#elif defined(USE_FAST_MATH)
-    struct fp_int;
-    #define MATH_INT_T struct fp_int
-#else
-    struct mp_int;
-	#define MATH_INT_T struct mp_int
-#endif
 struct ecc_key;
 struct WC_RNG;
 

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -71,7 +71,7 @@ RSA keys can be used to encrypt, decrypt, sign and verify data.
     #define WOLFSSL_KEY_GEN
 #endif
 #else
-    #include <wolfssl/wolfcrypt/integer.h>
+    #include <wolfssl/wolfcrypt/wolfmath.h>
     #include <wolfssl/wolfcrypt/random.h>
 #endif /* HAVE_FIPS && HAVE_FIPS_VERION 1 */
 #if defined(HAVE_FIPS) && \

--- a/wolfssl/wolfcrypt/sakke.h
+++ b/wolfssl/wolfcrypt/sakke.h
@@ -31,7 +31,7 @@
 
 #ifdef WOLFCRYPT_HAVE_SAKKE
 
-#include <wolfssl/wolfcrypt/integer.h>
+#include <wolfssl/wolfcrypt/wolfmath.h>
 #include <wolfssl/wolfcrypt/ecc.h>
 #include <wolfssl/wolfcrypt/hash.h>
 #include <wolfssl/wolfcrypt/hmac.h>

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -350,7 +350,6 @@
         #if defined(ESP32_USE_RSA_PRIMITIVE) && \
             !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI)
             #define WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI
-            #define USE_FAST_MATH
             #define WOLFSSL_SMALL_STACK
         #endif
    #endif
@@ -449,7 +448,6 @@
     #define NO_WRITEV
     #define NO_DEV_RANDOM
     #define NO_FILESYSTEM
-    #define USE_FAST_MATH
     #define TFM_TIMING_RESISTANT
     #define NO_BIG_INT
 #endif
@@ -554,7 +552,6 @@
 
 #ifdef WOLFSSL_PICOTCP_DEMO
     #define WOLFSSL_STM32
-    #define USE_FAST_MATH
     #define TFM_TIMING_RESISTANT
     #define XMALLOC(s, h, type)  PICO_ZALLOC((s))
     #define XFREE(p, h, type)    PICO_FREE((p))
@@ -621,7 +618,6 @@
 
     #define HAVE_ECC
     #define ALT_ECC_SIZE
-    #define USE_FAST_MATH
     #define TFM_TIMING_RESISTANT
     #define ECC_TIMING_RESISTANT
 
@@ -723,7 +719,6 @@
         #define NO_MAIN_DRIVER
         #define NO_WRITEV
         #define SINGLE_THREADED
-        #define USE_FAST_MATH
         #define TFM_TIMING_RESISTANT
         #define WOLFSSL_NRF51
         #define WOLFSSL_USER_IO
@@ -857,7 +852,6 @@ extern void uITRON4_free(void *p) ;
 
     #define NO_WOLFSSL_DIR
     #define NO_WRITEV
-    #define USE_FAST_MATH
     #define TFM_TIMING_RESISTANT
     #define NO_MAIN_DRIVER
 #endif
@@ -873,12 +867,10 @@ extern void uITRON4_free(void *p) ;
     #define NO_WRITEV
     #define NO_WOLFSSL_DIR
 
-    /* Use SP_MATH by default, unless
+    /* Enable SP math by default, unless fast math
      * specified in user_settings.
      */
     #ifndef USE_FAST_MATH
-        #define USE_SP_MATH
-        #define SP_MATH_ALL
         #define WOLFSSL_HAVE_SP_ECC
         #define SP_WORD_SIZE 32
         #define WOLFSSL_HAVE_SP_RSA
@@ -954,7 +946,6 @@ extern void uITRON4_free(void *p) ;
     #define WOLFSSL_HAVE_MAX
     #define WOLFSSL_HAVE_MIN
 
-    #define USE_FAST_MATH
     #define TFM_TIMING_RESISTANT
     #define WC_RSA_BLINDING
     #define ECC_TIMING_RESISTANT
@@ -1154,9 +1145,6 @@ extern void uITRON4_free(void *p) ;
     #define NO_RC4
 
     /* enable features */
-    #undef  USE_FAST_MATH
-    #define USE_FAST_MATH
-
     #define USE_CERT_BUFFERS_2048
     #define BENCH_EMBEDDED
 
@@ -1500,7 +1488,6 @@ extern void uITRON4_free(void *p) ;
         #define NO_WRITEV
     #endif
 
-    #define USE_FAST_MATH
     #define TFM_TIMING_RESISTANT
     #define ECC_TIMING_RESISTANT
     #define WC_RSA_BLINDING
@@ -1540,7 +1527,6 @@ extern void uITRON4_free(void *p) ;
     #include  <stdio.h>
     #include <string.h>
 
-    #define USE_FAST_MATH
     #define TFM_TIMING_RESISTANT
     #define ECC_TIMING_RESISTANT
     #define WC_RSA_BLINDING
@@ -1893,7 +1879,6 @@ extern void uITRON4_free(void *p) ;
     #define NO_ASN_TIME /* can not use headers such as windows.h */
     #define HAVE_AESGCM
     #define USE_CERT_BUFFERS_2048
-    #define USE_FAST_MATH
 #endif /* WOLFSSL_SGX */
 
 /* FreeScale MMCAU hardware crypto has 4 byte alignment.
@@ -1988,6 +1973,13 @@ extern void uITRON4_free(void *p) ;
         #endif
     #endif
 #endif
+
+/* Verify that only one of the above multi-precision math libraries is enabled */
+#if (defined(WOLFSSL_SP_MATH_ALL) && \
+        (defined(USE_FAST_MATH) || defined(USE_INTEGER_HEAP_MATH))) || \
+    (defined(USE_FAST_MATH) && defined(USE_INTEGER_HEAP_MATH))
+    #error Cannot enable more than one multiple precision math library!
+#endif
 /*----------------------------------------------------------------------------*/
 
 
@@ -2050,7 +2042,8 @@ extern void uITRON4_free(void *p) ;
         #undef HAVE_ECC_KEY_IMPORT
         #define HAVE_ECC_KEY_IMPORT
     #endif
-    #ifndef NO_ECC_KEY_EXPORT
+    /* The ECC key export requires mp_int */
+    #if !defined(NO_ECC_KEY_EXPORT) && !defined(NO_BIG_INT)
         #undef HAVE_ECC_KEY_EXPORT
         #define HAVE_ECC_KEY_EXPORT
     #endif
@@ -2523,7 +2516,8 @@ extern void uITRON4_free(void *p) ;
 #endif
 
 /* warning for not using harden build options (default with ./configure) */
-#ifndef WC_NO_HARDEN
+/* do not warn if big integer support is disabled */
+#if !defined(WC_NO_HARDEN) && !defined(NO_BIG_INT)
     #if (defined(USE_FAST_MATH) && !defined(TFM_TIMING_RESISTANT)) || \
         (defined(HAVE_ECC) && !defined(ECC_TIMING_RESISTANT)) || \
         (!defined(NO_RSA) && !defined(WC_RSA_BLINDING) && !defined(HAVE_FIPS) && \

--- a/wolfssl/wolfcrypt/sp.h
+++ b/wolfssl/wolfcrypt/sp.h
@@ -38,7 +38,7 @@
     #include <stdint.h>
 #endif
 
-#include <wolfssl/wolfcrypt/integer.h>
+#include <wolfssl/wolfcrypt/wolfmath.h>
 #include <wolfssl/wolfcrypt/sp_int.h>
 
 #include <wolfssl/wolfcrypt/ecc.h>

--- a/wolfssl/wolfcrypt/srp.h
+++ b/wolfssl/wolfcrypt/srp.h
@@ -32,7 +32,7 @@
 #include <wolfssl/wolfcrypt/sha.h>
 #include <wolfssl/wolfcrypt/sha256.h>
 #include <wolfssl/wolfcrypt/sha512.h>
-#include <wolfssl/wolfcrypt/integer.h>
+#include <wolfssl/wolfcrypt/wolfmath.h>
 
 #ifdef __cplusplus
     extern "C" {

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1468,6 +1468,19 @@ typedef struct w64wrapper {
     #endif
 
 
+    /* opaque math variable type */
+    #if defined(USE_FAST_MATH)
+        struct fp_int;
+        #define MATH_INT_T struct fp_int
+    #elif defined(USE_INTEGER_HEAP_MATH)
+        struct mp_int;
+        #define MATH_INT_T struct mp_int
+    #else
+        struct sp_int;
+        #define MATH_INT_T struct sp_int
+    #endif
+
+
     #ifdef __cplusplus
         }   /* extern "C" */
     #endif

--- a/wolfssl/wolfcrypt/wolfmath.h
+++ b/wolfssl/wolfcrypt/wolfmath.h
@@ -31,10 +31,25 @@ This library provides big integer math functions.
     extern "C" {
 #endif
 
+#include <wolfssl/wolfcrypt/types.h>
+
 #ifdef WOLFSSL_PUBLIC_MP
     #define MP_API   WOLFSSL_API
 #else
     #define MP_API   WOLFSSL_LOCAL
+#endif
+
+
+#if defined(USE_FAST_MATH)
+    #include <wolfssl/wolfcrypt/tfm.h>
+#elif defined(USE_INTEGER_HEAP_MATH)
+    #include <wolfssl/wolfcrypt/integer.h>
+#else
+    #include <wolfssl/wolfcrypt/sp_int.h>
+#endif
+
+#if !defined(NO_BIG_INT) || defined(WOLFSSL_SP_MATH)
+    #include <wolfssl/wolfcrypt/random.h>
 #endif
 
 #ifndef MIN
@@ -53,7 +68,7 @@ This library provides big integer math functions.
     extern const wc_ptr_t wc_off_on_addr[2];
 #endif
 
-
+#if !defined(NO_BIG_INT) || defined(WOLFSSL_SP_MATH)
 /* common math functions */
 MP_API int get_digit_count(const mp_int* a);
 MP_API mp_digit get_digit(const mp_int* a, int n);
@@ -62,6 +77,7 @@ WOLFSSL_LOCAL void mp_reverse(unsigned char *s, int len);
 
 WOLFSSL_API int mp_cond_copy(mp_int* a, int copy, mp_int* b);
 WOLFSSL_API int mp_rand(mp_int* a, int digits, WC_RNG* rng);
+#endif
 
 #define WC_TYPE_HEX_STR 1
 #define WC_TYPE_UNSIGNED_BIN 2
@@ -69,8 +85,10 @@ WOLFSSL_API int mp_rand(mp_int* a, int digits, WC_RNG* rng);
     #define WC_TYPE_BLACK_KEY 3
 #endif
 
+#if defined(HAVE_ECC) || defined(WOLFSSL_EXPORT_INT)
 WOLFSSL_API int wc_export_int(mp_int* mp, byte* buf, word32* len,
     word32 keySz, int encType);
+#endif
 
 #ifdef HAVE_WOLF_BIGINT
     #if !defined(WOLF_BIGINT_DEFINED)
@@ -95,6 +113,10 @@ WOLFSSL_API int wc_export_int(mp_int* mp, byte* buf, word32* len,
     WOLFSSL_LOCAL int wc_bigint_to_mp(WC_BIGINT* src, mp_int* dst);
 #endif /* HAVE_WOLF_BIGINT */
 
+
+#ifdef HAVE_WC_INTROSPECTION
+    WOLFSSL_API const char *wc_GetMathInfo(void);
+#endif
 
 #ifdef __cplusplus
     } /* extern "C" */


### PR DESCRIPTION
# Description

* Add introspection for math build.
* Raise build error if more than one math library used.
* Cleanups for building with `WOLFCRYPT_ONLY` and `NO_BIG_INT`.
* Refactor math headers to use `wolfmath.h`
* Fix ESP32 to support using any multi-precision math option.
* Refactor of the opaque math variable type `MATH_INT_T` used by crypto hardware (QuickAssist, SE050, ESP32 and STM32).
* Stop forcing use of fast math by default for platforms in `settings.h`.

Note: For users that still want to use fast math (`tfm.c`) they will need to add `USE_FAST_MATH` to their build settings.
Applies To:
```
WOLFSSL_ESPWROOM32
WOLFSSL_ESPWROOM32SE
MICROCHIP_PIC32
WOLFSSL_PICOTCP_DEMO
WOLFSSL_UTASKER
WOLFSSL_NRF5x
FREERTOS_TCP
WOLFSSL_TIRTOS
EBSNET
FREESCALE_COMMON
FREESCALE_KSDK_BM
WOLFSSL_DEOS
MICRIUM
WOLFSSL_SGX
```

Example Output:

```
Math: 	Multi-Precision: Wolf(SP) word-size=64 bits=4096 sp_int.c
	Single Precision: ecc 256 384 521 rsa/dh 2048 3072 4096 asm sp_x86_64.c

Math: 	Multi-Precision: Disabled
	Single Precision: ecc 256 2048 3072 sp_c64.c

Math: 	Multi-Precision: Fast max-bits=4096 not-constant-time tfm.c
	Single Precision: ecc 256 2048 3072 sp_c64.c

Math: 	Multi-Precision: Fast max-bits=4096 not-constant-time tfm.c

Math: 	Multi-Precision: Wolf(SP) word-size=64 bits=4096 sp_int.c
	Single Precision: ecc 256 384 521 rsa/dh 2048 3072 4096 sp_c64.c small
```

# Testing

```
./configure --enable-usersettings --disable-examples && make
./wolfcrypt/test/testwolfcrypt

/* Place into user_settings.h */
/* Configuration example for ECC SP math only */
#define NO_BIG_INT
#define NO_RSA
#define NO_DSA
#define NO_DH
#define WOLFCRYPT_ONLY
#define HAVE_ECC
#define WOLFSSL_SP_MATH
#define WOLFSSL_HAVE_SP_ECC
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
