### PR TITLE
Include sys/time.h for WOLFSSL_RIOT_OS

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -105,9 +105,11 @@
     #include <errno.h>
 #endif
 
-#if defined(__MACH__) || defined(__FreeBSD__) || defined(__INCLUDE_NUTTX_CONFIG_H)
+#if defined(__MACH__) || defined(__FreeBSD__) || \
+    defined(__INCLUDE_NUTTX_CONFIG_H) || defined(WOLFSSL_RIOT_OS)
 #include <sys/time.h>
-#endif /* __MACH__ || __FreeBSD__ || __INCLUDE_NUTTX_CONFIG_H */
+#endif /* __MACH__ || __FreeBSD__ ||
+          __INCLUDE_NUTTX_CONFIG_H || WOLFSSL_RIOT_OS */
 
 
 #include <wolfssl/internal.h>


### PR DESCRIPTION
# Description

Include `sys/time.h` for `WOLFSSL_RIOT_OS`

Fixes #6007

# Testing

Customer review

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
