### PR TITLE
Fix RPM build

### DIFF
--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -282,6 +282,7 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_includedir}/wolfssl/wolfcrypt/ge_operations.h
 %{_includedir}/wolfssl/wolfcrypt/hash.h
 %{_includedir}/wolfssl/wolfcrypt/hmac.h
+%{_includedir}/wolfssl/wolfcrypt/hpke.h
 %{_includedir}/wolfssl/wolfcrypt/integer.h
 %{_includedir}/wolfssl/wolfcrypt/kdf.h
 %{_includedir}/wolfssl/wolfcrypt/kyber.h


### PR DESCRIPTION
# Description

This PR corrects a  `make rpm` build error:

```
Checking for unpackaged file(s): /usr/lib/rpm/check-files /home/vagrant/rpmbuild/BUILDROOT/wolfssl-5.5.4-1.x86_64
error: Installed (but unpackaged) file(s) found:
   /usr/include/wolfssl/wolfcrypt/hpke.h


RPM build errors:
    Installed (but unpackaged) file(s) found:
   /usr/include/wolfssl/wolfcrypt/hpke.h
make: *** [Makefile:8477: rpm-build] Error 1
```

# Testing

`make rpm` passes with the fix.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
