### PR TITLE
fix WOLFSSL_SHA_CTX for OpenSSL w/Espressif HW hash

### DIFF
--- a/wolfssl/openssl/sha.h
+++ b/wolfssl/openssl/sha.h
@@ -42,6 +42,8 @@ typedef struct WOLFSSL_SHA_CTX {
 #if defined(STM32_HASH)
     void* holder[(112 + WC_ASYNC_DEV_SIZE + sizeof(STM32_HASH_Context)) /
         sizeof(void*)];
+#elif defined(WOLFSSL_ESPWROOM32) && !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+    void* holder[(112 + WC_ASYNC_DEV_SIZE + sizeof(WC_ESP32SHA)) / sizeof(void*)];
 #elif defined(WOLFSSL_IMXRT1170_CAAM)
     void* holder[(112 + WC_ASYNC_DEV_SIZE + sizeof(caam_hash_ctx_t) +
         sizeof(caam_handle_t)) / sizeof(void*)];
@@ -334,4 +336,3 @@ WOLFSSL_API int wolfSSL_SHA512_256_Transform(WOLFSSL_SHA512_CTX* sha512,
 
 
 #endif /* WOLFSSL_SHA_H_ */
-

--- a/wolfssl/openssl/sha.h
+++ b/wolfssl/openssl/sha.h
@@ -36,20 +36,23 @@
     extern "C" {
 #endif
 
+/* adder for HW crypto */
+#if defined(STM32_HASH)
+    #define CTX_SHA_HW_ADDER sizeof(STM32_HASH_Context)
+#elif defined(WOLFSSL_IMXRT1170_CAAM)
+    #define CTX_SHA_HW_ADDER (sizeof(caam_hash_ctx_t) + sizeof(caam_handle_t))
+#elif defined(WOLFSSL_ESPWROOM32) && \
+     !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+    #define CTX_SHA_HW_ADDER sizeof(WC_ESP32SHA)
+#else
+    #define CTX_SHA_HW_ADDER 0
+#endif
+
+
 #ifndef NO_SHA
 typedef struct WOLFSSL_SHA_CTX {
     /* big enough to hold wolfcrypt Sha, but check on init */
-#if defined(STM32_HASH)
-    void* holder[(112 + WC_ASYNC_DEV_SIZE + sizeof(STM32_HASH_Context)) /
-        sizeof(void*)];
-#elif defined(WOLFSSL_ESPWROOM32) && !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
-    void* holder[(112 + WC_ASYNC_DEV_SIZE + sizeof(WC_ESP32SHA)) / sizeof(void*)];
-#elif defined(WOLFSSL_IMXRT1170_CAAM)
-    void* holder[(112 + WC_ASYNC_DEV_SIZE + sizeof(caam_hash_ctx_t) +
-        sizeof(caam_handle_t)) / sizeof(void*)];
-#else
-    void* holder[(112 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
-#endif
+    void* holder[(112 + WC_ASYNC_DEV_SIZE + CTX_SHA_HW_ADDER) / sizeof(void*)];
 #if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
     void* keephash_holder[sizeof(void*) + (2 * sizeof(unsigned int))];
 #endif
@@ -99,16 +102,6 @@ typedef WOLFSSL_SHA_CTX SHA_CTX;
 #endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
 #endif /* !NO_SHA */
 
-/* adder for HW crypto */
-#ifdef STM32_HASH
-    #define CTX_SHA2_HW_ADDER 34
-#elif defined(WOLFSSL_IMXRT1170_CAAM)
-    #define CTX_SHA2_HW_ADDER sizeof(caam_hash_ctx_t) + sizeof(caam_handle_t)
-#elif defined(WOLFSSL_ESPWROOM32)
-    #define CTX_SHA2_HW_ADDER sizeof(WC_ESP32SHA)
-#else
-    #define CTX_SHA2_HW_ADDER 0
-#endif
 
 #ifdef WOLFSSL_SHA224
 
@@ -117,7 +110,7 @@ typedef WOLFSSL_SHA_CTX SHA_CTX;
  * to Sha224, is expected to also be 16 byte aligned addresses.  */
 typedef struct WOLFSSL_SHA224_CTX {
     /* big enough to hold wolfcrypt Sha224, but check on init */
-    ALIGN16 void* holder[(274 + CTX_SHA2_HW_ADDER + WC_ASYNC_DEV_SIZE) /
+    ALIGN16 void* holder[(274 + CTX_SHA_HW_ADDER + WC_ASYNC_DEV_SIZE) /
         sizeof(void*)];
 #if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
     ALIGN16 void* keephash_holder[sizeof(void*) + (2 * sizeof(unsigned int))];
@@ -158,7 +151,7 @@ typedef WOLFSSL_SHA224_CTX SHA224_CTX;
  * to Sha256, is expected to also be 16 byte aligned addresses.  */
 typedef struct WOLFSSL_SHA256_CTX {
     /* big enough to hold wolfcrypt Sha256, but check on init */
-    ALIGN16 void* holder[(274 + CTX_SHA2_HW_ADDER + WC_ASYNC_DEV_SIZE) /
+    ALIGN16 void* holder[(274 + CTX_SHA_HW_ADDER + WC_ASYNC_DEV_SIZE) /
         sizeof(void*)];
 #if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
     ALIGN16 void* keephash_holder[sizeof(void*) + (2 * sizeof(unsigned int))];
@@ -209,7 +202,7 @@ typedef WOLFSSL_SHA256_CTX SHA256_CTX;
 #ifdef WOLFSSL_SHA384
 typedef struct WOLFSSL_SHA384_CTX {
     /* big enough to hold wolfCrypt Sha384, but check on init */
-    void* holder[(268 + CTX_SHA2_HW_ADDER + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
+    void* holder[(268 + CTX_SHA_HW_ADDER + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
 #if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
     void* keephash_holder[sizeof(void*) + (2 * sizeof(unsigned int))];
 #endif
@@ -244,7 +237,7 @@ typedef WOLFSSL_SHA384_CTX SHA384_CTX;
 #ifdef WOLFSSL_SHA512
 typedef struct WOLFSSL_SHA512_CTX {
     /* big enough to hold wolfCrypt Sha384, but check on init */
-    void* holder[(288 + CTX_SHA2_HW_ADDER + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
+    void* holder[(288 + CTX_SHA_HW_ADDER + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
 #if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
     void* keephash_holder[sizeof(void*) + (2 * sizeof(unsigned int))];
 #endif


### PR DESCRIPTION
# Description

Improve the "adder" for compatibility layer SHA context when hardware acceleration is used.

This is a duplicate of https://github.com/wolfSSL/wolfssl/pull/6121 that was closed but could not be reopened. Please see comment thread there.

This PR takes into account the size of the `WC_ESP32SHA` struct that is added to the wolfSSL `WOLFSSL_SHA_CTX` struct for the openSSL `holder[]` in [openssl/sha.h](https://github.com/wolfSSL/wolfssl/blob/b81759173a87dae62fcc23affdc4d9b1e0e406d2/wolfssl/openssl/sha.h#L40) for the Espressif ESP-IDF, fixing https://github.com/wolfSSL/wolfssl/issues/6028.

Note that there are currently other errors when enabling OpenSSL and hardware acceleration on the ESP32, specifically the SHA224 failure noted in https://github.com/wolfSSL/wolfssl/issues/6059 as well as SHA512/224 noted in https://github.com/wolfSSL/wolfssl/issues/6028#issuecomment-1433086389. I have a fix for those as well, but the days have turned into weeks for my major update in my [ED25519_SHA2_fix](https://github.com/gojimmypi/wolfssl/tree/ED25519_SHA2_fix) branch, so I'm creating this separate PR now to address this specific compile issue.

# Testing

Confirmed operational in ESP-IDF with OpenSSL enabled and passing tests & successful benchmark:

```
./configure CC=clang --enable-trackmemory CFLAGS=-DHAVE_STACK_SIZE && make && ./wolfcrypt/test/testwolfcrypt
./wolfcrypt/benchmar/benchmark
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
