### PR TITLE
Fix malloc of zero size in fast_s_mp_sqr and fast_s_mp_mul_digs.

### DIFF
--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -3335,6 +3335,12 @@ int fast_s_mp_sqr (mp_int * a, mp_int * b)
   if (pa > (int)MP_WARRAY)
     return MP_RANGE;  /* TAO range check */
 
+  if (pa == 0) {
+    /* Nothing to do. Zero result and return. */
+    mp_zero(b);
+    return MP_OKAY;
+  }
+
 #ifdef WOLFSSL_SMALL_STACK
   W = (mp_digit*)XMALLOC(sizeof(mp_digit) * pa, NULL, DYNAMIC_TYPE_BIGINT);
   if (W == NULL)
@@ -3453,6 +3459,12 @@ int fast_s_mp_mul_digs (mp_int * a, mp_int * b, mp_int * c, int digs)
   pa = MIN(digs, a->used + b->used);
   if (pa > (int)MP_WARRAY)
     return MP_RANGE;  /* TAO range check */
+
+  if (pa == 0) {
+    /* Nothing to do. Zero result and return. */
+    mp_zero(c);
+    return MP_OKAY;
+  }
 
 #ifdef WOLFSSL_SMALL_STACK
   W = (mp_digit*)XMALLOC(sizeof(mp_digit) * pa, NULL, DYNAMIC_TYPE_BIGINT);


### PR DESCRIPTION
# Description

A malloc of size zero was happening in `fast_s_mp_sqr()` and `fast_s_mp_mul_digs()` from the call `wc_ecc_check_key()`.

This fix zeros the result and returns early, instead of calling `malloc(0)`.

Fixes zd#15662

# Testing

Tested with reproducer in ticket.
