### PR TITLE
New wolfcrypt Hardware Acceleration SHA Copy Tests

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -2977,6 +2977,9 @@ WOLFSSL_TEST_SUBROUTINE int sha512_test(void)
         if (ret != 0)
             ERROR_OUT(-2405 - i, exit);
         wc_Sha512Free(&shaCopy);
+        wc_Sha512Free(&shaRawCopy); /* this is a local variable, surely does
+                                    ** not actually need to be free'd? */
+       /* see https://cloud.wolfssl-test.com/jenkins/job/PRB-valgrind-check-v2/4286/console */
 
         if (XMEMCMP(hash, test_sha[i].output, WC_SHA512_DIGEST_SIZE) != 0)
             ERROR_OUT(-2406 - i, exit);


### PR DESCRIPTION
# Description

As noted in https://github.com/wolfSSL/wolfssl/issues/5989, there are some wolfcrypt tests that are missing. These are tests that in a software-only solution, would likely be not very interesting. However - given the common _single current use_ of hardware acceleration, these new tests ensure the hardware state of a given SHA `ctx` is properly handled when _copied_. In particular, if the `ctx` is copied, and then processed, does it interfere with current hardware calculations in progress? It should not.

Note making the attached change will result in failure the ESP32 tests to fail unless `#define NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH` is defined, turning off HW and using only wolfcrypt software.

My next version of the hardware acceleration in my [ED25519_SHA2_fix branch](https://github.com/gojimmypi/wolfssl/tree/ED25519_SHA2_fix) has a much more robust implementation that handles the copy gracefully. I prefer to have the tests in place prior to that PR to better illustrate before & after results.

I'd like to get some feedback before I go and implement this for all of the tests. For now this is a draft PR.

There's a slight chance that other hardware acceleration implementations might fail.  

See also https://github.com/wolfSSL/wolfssl/issues/5948


Fixes zd# n/a

# Testing

Use [wolfcrypt/test](https://github.com/wolfSSL/wolfssl/tree/master/wolfcrypt/test) for both software-only, and hardware-accelerated SHA calculations.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
