### PR TITLE
20230223-refactor-test-c-error-codes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -688,6 +688,8 @@ then
     test "$enable_camellia" = "" && enable_camellia=yes
     test "$enable_ripemd" = "" && enable_ripemd=yes
     test "$enable_sha224" = "" && enable_sha224=yes
+    test "$enable_shake128" = "" && enable_shake128=yes
+    test "$enable_shake256" = "" && enable_shake256=yes
     test "$enable_sessioncerts" = "" && enable_sessioncerts=yes
     test "$enable_keygen" = "" && enable_keygen=yes
     test "$enable_certgen" = "" && enable_certgen=yes
@@ -872,6 +874,8 @@ then
     test "$enable_camellia" = "" && enable_camellia=yes
     test "$enable_ripemd" = "" && enable_ripemd=yes
     test "$enable_sha224" = "" && enable_sha224=yes
+    test "$enable_shake128" = "" && enable_shake128=yes
+    test "$enable_shake256" = "" && enable_shake256=yes
     test "$enable_sessioncerts" = "" && enable_sessioncerts=yes
     test "$enable_keygen" = "" && enable_keygen=yes
     test "$enable_certgen" = "" && enable_certgen=yes

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -5439,7 +5439,7 @@ exit:
 }
 #endif /* WOLFSSL_NOSHA3_512 */
 
-#ifndef WOLFSSL_NO_SHAKE128
+#ifdef WOLFSSL_SHAKE128
 void bench_shake128(int useDeviceID)
 {
     wc_Shake hash[BENCH_MAX_PENDING];
@@ -5532,7 +5532,7 @@ exit:
 
     WC_FREE_ARRAY(digest, BENCH_MAX_PENDING, HEAP_HINT);
 }
-#endif /* WOLFSSL_NO_SHAKE128 */
+#endif /* WOLFSSL_SHAKE128 */
 
 #ifdef WOLFSSL_SHAKE256
 void bench_shake256(int useDeviceID)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -18472,17 +18472,17 @@ WOLFSSL_TEST_SUBROUTINE int dh_test(void)
 #ifndef WC_NO_RNG
     ret = dh_generate_test(&rng);
     if (ret != 0)
-        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
+        ERROR_OUT(ret, done);
 
     ret = dh_fips_generate_test(&rng);
     if (ret != 0)
-        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
+        ERROR_OUT(ret, done);
 #endif /* !WC_NO_RNG */
 
 #if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
     ret = dh_test_check_pubvalue();
     if (ret != 0)
-        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
+        ERROR_OUT(ret, done);
 #endif
 
 #if !(defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION == 2) && \
@@ -38621,26 +38621,26 @@ WOLFSSL_TEST_SUBROUTINE int pkcs7callback_test(byte* cert, word32 certSz, byte* 
 
     ret = verifyBundle(derBuf, derSz, 0);
     if (ret != 0)
-        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+        ERROR_OUT(ret, out);
 
     /* test choosing other key with keyID */
     derSz = FOURK_BUF;
     ret = generateBundle(derBuf, &derSz, p7AltKey, sizeof(p7AltKey), 1,
             cert, certSz, key, keySz);
     if (ret <= 0) {
-        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+        ERROR_OUT(ret, out);
     }
 
     ret = verifyBundle(derBuf, derSz, 1);
     if (ret != 0)
-        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+        ERROR_OUT(ret, out);
 
     /* test fail case with wrong keyID */
     derSz = FOURK_BUF;
     ret = generateBundle(derBuf, &derSz, p7DefKey, sizeof(p7DefKey), 1,
             cert, certSz, key, keySz);
     if (ret <= 0) {
-        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+        ERROR_OUT(ret, out);
     }
 
     ret = verifyBundle(derBuf, derSz, 1);
@@ -43286,14 +43286,28 @@ static int GenerateNextP(mp_int* p1, mp_int* p2, int k)
 #endif
 
     ret = mp_init(ki);
-    if (ret == 0)
+    if (ret != 0)
+        ret = WC_TEST_RET_ENC_EC(ret);
+    if (ret == 0) {
         ret = mp_set(ki, k);
-    if (ret == 0)
+        if (ret != 0)
+            ret = WC_TEST_RET_ENC_EC(ret);
+    }
+    if (ret == 0) {
         ret = mp_sub_d(p1, 1, p2);
-    if (ret == 0)
+        if (ret != 0)
+            ret = WC_TEST_RET_ENC_EC(ret);
+    }
+    if (ret == 0) {
         ret = mp_mul(p2, ki, p2);
-    if (ret == 0)
+        if (ret != 0)
+            ret = WC_TEST_RET_ENC_EC(ret);
+    }
+    if (ret == 0) {
         ret = mp_add_d(p2, 1, p2);
+        if (ret != 0)
+            ret = WC_TEST_RET_ENC_EC(ret);
+    }
     mp_clear(ki);
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
@@ -43325,20 +43339,33 @@ static int GenerateP(mp_int* p1, mp_int* p2, mp_int* p3,
 
     ret = mp_init_multi(x, y, NULL, NULL, NULL, NULL);
     if (ret != 0) {
-        ret = MP_MEM;
+        ret = WC_TEST_RET_ENC_EC(ret);
         goto out;
     }
     for (i = 0; ret == 0 && i < ecPairsSz; i++) {
         ret = mp_read_unsigned_bin(x, ecPairs[i].coeff, ecPairs[i].coeffSz);
+        if (ret != 0) {
+            ret = WC_TEST_RET_ENC_EC(ret);
+            break;
+        }
         /* p1 = 2^exp */
-        if (ret == 0)
-            ret = mp_2expt(y, ecPairs[i].exp);
+        ret = mp_2expt(y, ecPairs[i].exp);
+        if (ret != 0) {
+            ret = WC_TEST_RET_ENC_EC(ret);
+            break;
+        }
         /* p1 = p1 * m */
-        if (ret == 0)
-            ret = mp_mul(x, y, x);
+        ret = mp_mul(x, y, x);
+        if (ret != 0) {
+            ret = WC_TEST_RET_ENC_EC(ret);
+            break;
+        }
         /* p1 +=  */
-        if (ret == 0)
-            ret = mp_add(p1, x, p1);
+        ret = mp_add(p1, x, p1);
+        if (ret != 0) {
+            ret = WC_TEST_RET_ENC_EC(ret);
+            break;
+        }
         mp_zero(x);
         mp_zero(y);
     }
@@ -43392,17 +43419,28 @@ WOLFSSL_TEST_SUBROUTINE int prime_test(void)
 #endif
 
     ret = wc_InitRng(&rng);
-    if (ret == 0)
+    if (ret != 0)
+        ret = WC_TEST_RET_ENC_EC(ret);
+    if (ret == 0) {
         ret = mp_init_multi(n, p1, p2, p3, NULL, NULL);
+        if (ret != 0)
+            ret = WC_TEST_RET_ENC_EC(ret);
+    }
     if (ret == 0)
         ret = GenerateP(p1, p2, p3,
                 ecPairsA, sizeof(ecPairsA) / sizeof(ecPairsA[0]), kA);
-    if (ret == 0)
+    if (ret == 0) {
         ret = mp_mul(p1, p2, n);
-    if (ret == 0)
+        if (ret != 0)
+            ret = WC_TEST_RET_ENC_EC(ret);
+    }
+    if (ret == 0) {
         ret = mp_mul(n, p3, n);
+        if (ret != 0)
+            ret = WC_TEST_RET_ENC_EC(ret);
+    }
     if (ret != 0)
-        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+        ERROR_OUT(ret, out);
 
     /* Check the old prime test using the number that false positives.
      * This test result should indicate as not prime. */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -633,31 +633,40 @@ static void render_error_message(const char* msg, int es)
         break;
     case WC_TEST_RET_TAG_EC:
 #ifdef NO_ERROR_STRINGS
-        err_sys_printf("%s error L=%d code=%d\n", msg, WC_TEST_RET_DEC_LN(es), -WC_TEST_RET_DEC_I(es));
+        err_sys_printf("%s error L=%d code=%d\n", msg,
+                       WC_TEST_RET_DEC_LN(es), -WC_TEST_RET_DEC_I(es));
 #else
         err_sys_printf("%s error L=%d code=%d (%s)\n", msg,
-                       WC_TEST_RET_DEC_LN(es), -WC_TEST_RET_DEC_I(es), wc_GetErrorString(-WC_TEST_RET_DEC_I(es)));
+                       WC_TEST_RET_DEC_LN(es), -WC_TEST_RET_DEC_I(es),
+                       wc_GetErrorString(-WC_TEST_RET_DEC_I(es)));
 #endif
         break;
     case WC_TEST_RET_TAG_ERRNO:
     {
-#if defined(_GNU_SOURCE) || (defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200112L))
+#if defined(_GNU_SOURCE) || \
+    (defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200112L))
         char errno_buf[64], *errno_string;
 #if defined(_GNU_SOURCE)
-        errno_string = strerror_r(WC_TEST_RET_DEC_I(es), errno_buf, sizeof(errno_buf));
+        errno_string = strerror_r(WC_TEST_RET_DEC_I(es),
+                                  errno_buf, sizeof(errno_buf));
 #else
-        if (strerror_r(WC_TEST_RET_DEC_I(es), errno_buf, sizeof(errno_buf)) != 0)
+        if (strerror_r(WC_TEST_RET_DEC_I(es),
+                       errno_buf, sizeof(errno_buf)) != 0)
             XSTRLCPY(errno_buf, "?", sizeof(errno_buf));
         errno_string = errno_buf;
 #endif
-        err_sys_printf("%s error L=%d errno=%d (%s)\n", msg, WC_TEST_RET_DEC_LN(es), WC_TEST_RET_DEC_I(es), errno_string);
+        err_sys_printf("%s error L=%d errno=%d (%s)\n", msg,
+                       WC_TEST_RET_DEC_LN(es), WC_TEST_RET_DEC_I(es),
+                       errno_string);
 #else
-        err_sys_printf("%s error L=%d errno=%d\n", msg, WC_TEST_RET_DEC_LN(es), WC_TEST_RET_DEC_I(es));
+        err_sys_printf("%s error L=%d errno=%d\n", msg,
+                       WC_TEST_RET_DEC_LN(es), WC_TEST_RET_DEC_I(es));
 #endif
         break;
     }
     case WC_TEST_RET_TAG_I:
-        err_sys_printf("%s error L=%d i=%d\n", msg, WC_TEST_RET_DEC_LN(es), WC_TEST_RET_DEC_I(es));
+        err_sys_printf("%s error L=%d i=%d\n", msg,
+                       WC_TEST_RET_DEC_LN(es), WC_TEST_RET_DEC_I(es));
         break;
     }
 
@@ -41819,6 +41828,8 @@ static int mp_test_set_is_bit(mp_int* a)
     #endif
     }
 #endif
+
+    (void)ret;
 
     return 0;
 }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -572,7 +572,8 @@ WOLFSSL_TEST_SUBROUTINE int  certext_test(void);
 WOLFSSL_TEST_SUBROUTINE int decodedCertCache_test(void);
 #endif
 WOLFSSL_TEST_SUBROUTINE int memory_test(void);
-#ifdef WOLFSSL_PUBLIC_MP
+#if defined(WOLFSSL_PUBLIC_MP) && \
+    (defined(WOLFSSL_SP_MATH_ALL) || defined(USE_FAST_MATH))
 WOLFSSL_TEST_SUBROUTINE int mp_test(void);
 #endif
 #if defined(WOLFSSL_PUBLIC_MP) && defined(WOLFSSL_KEY_GEN)
@@ -1521,7 +1522,8 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
     #endif
 #endif
 
-#ifdef WOLFSSL_PUBLIC_MP
+#if defined(WOLFSSL_PUBLIC_MP) && \
+    (defined(WOLFSSL_SP_MATH_ALL) || defined(USE_FAST_MATH))
     if ( (ret = mp_test()) != 0)
         return err_sys("mp       test failed!\n", ret);
     else
@@ -40268,9 +40270,8 @@ WOLFSSL_TEST_SUBROUTINE int pkcs7signed_test(void)
 
 #endif /* HAVE_PKCS7 */
 
-#ifdef WOLFSSL_PUBLIC_MP
-
-/* Need a static build to have access to symbols. */
+#if defined(WOLFSSL_PUBLIC_MP) && \
+    (defined(WOLFSSL_SP_MATH_ALL) || defined(USE_FAST_MATH))
 
 /* Maximum number of bytes in a number to test. */
 #define MP_MAX_TEST_BYTE_LEN      32
@@ -43200,7 +43201,7 @@ done:
     return ret;
 }
 
-#endif /* WOLFSSL_PUBLIC_MP */
+#endif /* WOLFSSL_PUBLIC_MP && (WOLFSSL_SP_MATH_ALL || USE_FAST_MATH) */
 
 
 #if defined(WOLFSSL_PUBLIC_MP) && defined(WOLFSSL_KEY_GEN)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -664,6 +664,8 @@ static void render_error_message(const char* msg, int es)
 #undef err_sys_printf
 }
 
+static void print_fiducials(void);
+
 #ifdef HAVE_STACK_SIZE
 static THREAD_RETURN err_sys(const char* msg, int es)
 #else
@@ -671,6 +673,7 @@ static int err_sys(const char* msg, int es)
 #endif
 {
     render_error_message(msg, es);
+    print_fiducials();
 #ifdef WOLFSSL_LINUXKM
     EXIT_TEST(es);
 #else
@@ -764,8 +767,6 @@ static int wolfssl_pb_print(const char* msg, ...)
     }
 #endif
 
-static void print_fiducials(void);
-
 #ifdef HAVE_STACK_SIZE
 THREAD_RETURN WOLFSSL_THREAD wolfcrypt_test(void* args)
 #else
@@ -787,7 +788,6 @@ int wolfcrypt_test(void* args)
 
     printf("------------------------------------------------------------------------------\n");
     printf(" wolfSSL version %s\n", LIBWOLFSSL_VERSION_STRING);
-    print_fiducials();
     printf("------------------------------------------------------------------------------\n");
 
     if (args) {
@@ -4161,6 +4161,7 @@ exit:
 WOLFSSL_TEST_SUBROUTINE int shake128_test(void)
 {
     wc_Shake  sha;
+    byte  hash[250];
 
     testVector a, b, c, d, e;
     testVector test_sha[5];
@@ -4183,7 +4184,6 @@ WOLFSSL_TEST_SUBROUTINE int shake128_test(void)
         "\xa3\x66\x6c\x9b\x11\x84\x9d\x4a\x36\xbc\x8a\x0d\x4c\xe3\x39\xfa"
         "\xfa\x1b";
 
-    byte  hash[sizeof(large_digest) - 1];
 
     /*
     ** https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/SHAKE128_Msg0.pdf
@@ -4309,7 +4309,7 @@ WOLFSSL_TEST_SUBROUTINE int shake128_test(void)
     ret = wc_Shake128_Final(&sha, hash, (word32)sizeof(hash));
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit);
-    if (XMEMCMP(hash, large_digest, sizeof(hash)) != 0)
+    if (XMEMCMP(hash, large_digest, sizeof(large_digest) - 1) != 0)
         ERROR_OUT(WC_TEST_RET_ENC_NC, exit);
     } /* END LARGE HASH TEST */
 #endif /* NO_LARGE_HASH_TEST */
@@ -45419,7 +45419,7 @@ static const int fiducial4 = WC_TEST_RET_LN;
  * source code version match when in doubt.
  */
 static void print_fiducials(void) {
-    printf(" fiducial line numbers: %d %d %d %d\n",
+    printf(" [fiducial line numbers: %d %d %d %d]\n",
            fiducial1, fiducial2, fiducial3, fiducial4);
 }
 

--- a/wolfcrypt/test/test.h
+++ b/wolfcrypt/test/test.h
@@ -42,54 +42,49 @@ int wolfcrypt_test_main(int argc, char** argv);
 int wolf_test_task(void);
 #endif
 
-#ifndef WC_TEST_RET_ENC
-#define WC_TEST_RET_ENC(line, i) \
-        (-((line) + ((int)((unsigned)(i) & 0x7ff) * 1000000)))
-#endif
+#ifndef WC_TEST_RET_HAVE_CUSTOM_MACROS
+
+#define WC_TEST_RET_TAG_NC     0
+#define WC_TEST_RET_TAG_EC     1
+#define WC_TEST_RET_TAG_ERRNO  2
+#define WC_TEST_RET_TAG_I      3
+
+#define WC_TEST_RET_ENC(line, i, tag)                           \
+        (-((line) + ((int)((unsigned)(i) & 0x7ff) * 100000) + ((tag) << 29)))
 
 #ifndef WC_TEST_RET_LN
 #define WC_TEST_RET_LN __LINE__
 #endif
 
-#ifndef WC_TEST_RET_ENC_I
-/* encode positive integer */
-#define WC_TEST_RET_ENC_I(i) WC_TEST_RET_ENC(WC_TEST_RET_LN, i)
-#endif
-
-#ifndef WC_TEST_RET_ENC_EC
-/* encode error code (negative integer) */
-#define WC_TEST_RET_ENC_EC(ec) WC_TEST_RET_ENC(WC_TEST_RET_LN, -(ec))
-#endif
-
-#ifndef WC_TEST_RET_ENC_NC
 /* encode no code */
-#define WC_TEST_RET_ENC_NC (-WC_TEST_RET_LN)
-#endif
+#define WC_TEST_RET_ENC_NC WC_TEST_RET_ENC(WC_TEST_RET_LN, 0, WC_TEST_RET_TAG_NC)
 
-#ifndef WC_TEST_RET_ENC_ERRNO
+/* encode positive integer */
+#define WC_TEST_RET_ENC_I(i) WC_TEST_RET_ENC(WC_TEST_RET_LN, i, WC_TEST_RET_TAG_I)
+
+/* encode error code (negative integer) */
+#define WC_TEST_RET_ENC_EC(ec) WC_TEST_RET_ENC(WC_TEST_RET_LN, -(ec), WC_TEST_RET_TAG_EC)
+
 /* encode system/libc error code */
 #if defined(HAVE_ERRNO_H) && !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM) && !defined(WOLFSSL_USER_IO)
 #include <errno.h>
-#define WC_TEST_RET_ENC_ERRNO WC_TEST_RET_ENC_I(errno)
+#define WC_TEST_RET_ENC_ERRNO WC_TEST_RET_ENC(WC_TEST_RET_LN, errno, WC_TEST_RET_TAG_ERRNO)
 #else
 #define WC_TEST_RET_ENC_ERRNO WC_TEST_RET_ENC_NC
 #endif
-#endif
 
-#ifndef WC_TEST_RET_DEC_LN
+#define WC_TEST_RET_DEC_TAG(x) ((-(x)) >> 29)
+
 /* decode line number */
-#define WC_TEST_RET_DEC_LN(x) ((-(x)) % 1000000)
-#endif
+#define WC_TEST_RET_DEC_LN(x) (((-(x)) & ~(3 << 29)) % 100000)
 
-#ifndef WC_TEST_RET_DEC_I
 /* decode integer or errno */
-#define WC_TEST_RET_DEC_I(x) ((-(x)) / 1000000)
-#endif
+#define WC_TEST_RET_DEC_I(x) (((-(x)) & ~(3 << 29)) / 100000)
 
-#ifndef WC_TEST_RET_DEC_EC
 /* decode error code */
 #define WC_TEST_RET_DEC_EC(x) (-WC_TEST_RET_DEC_I(x))
-#endif
+
+#endif /* !WC_TEST_RET_HAVE_CUSTOM_MACROS */
 
 #ifdef __cplusplus
     }  /* extern "C" */
@@ -97,4 +92,3 @@ int wolf_test_task(void);
 
 
 #endif /* WOLFCRYPT_TEST_H */
-

--- a/wolfcrypt/test/test.h
+++ b/wolfcrypt/test/test.h
@@ -42,6 +42,55 @@ int wolfcrypt_test_main(int argc, char** argv);
 int wolf_test_task(void);
 #endif
 
+#ifndef WC_TEST_RET_ENC
+#define WC_TEST_RET_ENC(line, i) \
+        (-((line) + (((unsigned)(i) & 0x7ff) * 1000000)))
+#endif
+
+#ifndef WC_TEST_RET_LN
+#define WC_TEST_RET_LN __LINE__
+#endif
+
+#ifndef WC_TEST_RET_ENC_I
+/* encode positive integer */
+#define WC_TEST_RET_ENC_I(i) WC_TEST_RET_ENC(WC_TEST_RET_LN, i)
+#endif
+
+#ifndef WC_TEST_RET_ENC_EC
+/* encode error code (negative integer) */
+#define WC_TEST_RET_ENC_EC(ec) WC_TEST_RET_ENC(WC_TEST_RET_LN, -(ec))
+#endif
+
+#ifndef WC_TEST_RET_ENC_NC
+/* encode no code */
+#define WC_TEST_RET_ENC_NC (-WC_TEST_RET_LN)
+#endif
+
+#ifndef WC_TEST_RET_ENC_ERRNO
+/* encode system/libc error code */
+#if defined(HAVE_ERRNO_H) && !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM) && !defined(WOLFSSL_USER_IO)
+#include <errno.h>
+#define WC_TEST_RET_ENC_ERRNO WC_TEST_RET_ENC_I(errno)
+#else
+#define WC_TEST_RET_ENC_ERRNO WC_TEST_RET_ENC_NC
+#endif
+#endif
+
+#ifndef WC_TEST_RET_DEC_LN
+/* decode line number */
+#define WC_TEST_RET_DEC_LN(x) ((-(x)) % 1000000)
+#endif
+
+#ifndef WC_TEST_RET_DEC_I
+/* decode integer or errno */
+#define WC_TEST_RET_DEC_I(x) ((-(x)) / 1000000)
+#endif
+
+#ifndef WC_TEST_RET_DEC_EC
+/* decode error code */
+#define WC_TEST_RET_DEC_EC(x) (-WC_TEST_RET_DEC_I(x))
+#endif
+
 #ifdef __cplusplus
     }  /* extern "C" */
 #endif

--- a/wolfcrypt/test/test.h
+++ b/wolfcrypt/test/test.h
@@ -66,7 +66,8 @@ int wolf_test_task(void);
 #define WC_TEST_RET_ENC_EC(ec) WC_TEST_RET_ENC(WC_TEST_RET_LN, -(ec), WC_TEST_RET_TAG_EC)
 
 /* encode system/libc error code */
-#if defined(HAVE_ERRNO_H) && !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM) && !defined(WOLFSSL_USER_IO)
+#if defined(HAVE_ERRNO_H) && !defined(NO_FILESYSTEM) && \
+    !defined(NO_STDIO_FILESYSTEM) && !defined(WOLFSSL_USER_IO)
 #include <errno.h>
 #define WC_TEST_RET_ENC_ERRNO WC_TEST_RET_ENC(WC_TEST_RET_LN, errno, WC_TEST_RET_TAG_ERRNO)
 #else

--- a/wolfcrypt/test/test.h
+++ b/wolfcrypt/test/test.h
@@ -44,7 +44,7 @@ int wolf_test_task(void);
 
 #ifndef WC_TEST_RET_ENC
 #define WC_TEST_RET_ENC(line, i) \
-        (-((line) + (((unsigned)(i) & 0x7ff) * 1000000)))
+        (-((line) + ((int)((unsigned)(i) & 0x7ff) * 1000000)))
 #endif
 
 #ifndef WC_TEST_RET_LN


### PR DESCRIPTION
`wolfcrypt/test/test.{c,h}`: refactor to capture and encode error retvals using `WC_TEST_RET_*()` macros (based on line numbers), and print line and return code in `err_sys()`.

tested with `wolfssl-multi-test.sh ... super-quick-check`
