### PR TITLE
RSA padding - no pad length check fix

### DIFF
--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -1580,11 +1580,14 @@ int wc_RsaPad_ex(const byte* input, word32 inputLen, byte* pkcsBlock,
 
     #ifdef WC_RSA_NO_PADDING
         case WC_RSA_NO_PAD:
+        {
+            int bytes = (bits + WOLFSSL_BIT_SIZE - 1) / WOLFSSL_BIT_SIZE;
+
             WOLFSSL_MSG("wolfSSL Using NO padding");
 
             /* In the case of no padding being used check that input is exactly
              * the RSA key length */
-            if (bits <= 0 || inputLen != ((word32)bits/WOLFSSL_BIT_SIZE)) {
+            if ((bits <= 0) || (inputLen != (word32)bytes)) {
                 WOLFSSL_MSG("Bad input size");
                 ret = RSA_PAD_E;
             }
@@ -1593,6 +1596,7 @@ int wc_RsaPad_ex(const byte* input, word32 inputLen, byte* pkcsBlock,
                 ret = 0;
             }
             break;
+        }
     #endif
 
         default:


### PR DESCRIPTION
# Description

Perform correct length check of input bytes based on bits in key in wc_RsaPad_ex when no padding to be done.

Fixes zd#15731

# Testing

POC

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
