### PR TITLE
Cert name encoding fix

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -26078,6 +26078,9 @@ static int SetNameRdnItems(ASNSetData* dataASN, ASNItem* namesASN,
         j = -1;
         /* Put DomainComponents before OrgUnitName. */
         while (FindMultiAttrib(name, type, &j)) {
+            if (GetCertNameId(i) != ASN_DOMAIN_COMPONENT) {
+                continue;
+            }
             if (dataASN != NULL && namesASN != NULL) {
                 if (idx > maxIdx - (int)rdnASN_Length) {
                     WOLFSSL_MSG("Wanted to write more ASN than allocated");
@@ -26136,6 +26139,9 @@ static int SetNameRdnItems(ASNSetData* dataASN, ASNItem* namesASN,
         j = -1;
         /* Write all other attributes of this type. */
         while (FindMultiAttrib(name, type, &j)) {
+            if (GetCertNameId(i) == ASN_DOMAIN_COMPONENT) {
+                continue;
+            }
             if (dataASN != NULL && namesASN != NULL) {
                 if (idx > maxIdx - (int)rdnASN_Length) {
                     WOLFSSL_MSG("Wanted to write more ASN than allocated");

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -13837,20 +13837,20 @@ static void initDefaultName(void)
     n = &certDefaultName.name[0];
     n->id   = ASN_ORGUNIT_NAME;
     n->type = CTC_UTF8;
-    n->sz   = sizeof("Development-2");
+    n->sz   = XSTRLEN("Development-2");
     XMEMCPY(n->value, "Development-2", sizeof("Development-2"));
 
     #if CTC_MAX_ATTRIB > 3
     n = &certDefaultName.name[1];
     n->id   = ASN_DOMAIN_COMPONENT;
     n->type = CTC_UTF8;
-    n->sz   = sizeof("com");
+    n->sz   = XSTRLEN("com");
     XMEMCPY(n->value, "com", sizeof("com"));
 
     n = &certDefaultName.name[2];
     n->id   = ASN_DOMAIN_COMPONENT;
     n->type = CTC_UTF8;
-    n->sz   = sizeof("wolfssl");
+    n->sz   = XSTRLEN("wolfssl");
     XMEMCPY(n->value, "wolfssl", sizeof("wolfssl"));
     #endif
 #endif /* WOLFSSL_MULTI_ATTRIB && WOLFSSL_TEST_CERT */


### PR DESCRIPTION
# Description

Only include extra name entries once when encoding.
Fix certDefaultName to not have \0 on strings of extra names.

# Testing
```
./configure --enable-all CFLAGS=-DWOLFSSL_TEST_CERT
make
./wolfcrypt/test/testwolfcrypt
```

```
RSA      test failed!
 error = -7828
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
