### PR TITLE
implement ShowExtendedSystemInfo() in version.c

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6615,6 +6615,18 @@ AS_IF([test "x$ENABLED_INTEL_QA" = "xyes" || test "x$ENABLED_INTEL_QA_SYNC" = "x
      CPPFLAGS="$OLD_CPPFLAGS"
 ])
 
+# Extended Version Info
+AC_ARG_ENABLE([version-extended-info],
+    [AS_HELP_STRING([--enable-version-extended-info],[Enable extended version info (default: enabled)])],
+    [ ENABLED_VERSION_EXTENDED_INFO=$enableval ],
+    [ ENABLED_VERSION_EXTENDED_INFO=yes ]
+    )
+
+if test "$VERSION_EXTENDED_INFO" = "no"
+then
+    AM_CFLAGS="$AM_CFLAGS -DNO_VERSION_EXTENDED_INFO"
+fi
+
 ################################################################################
 # Single Precision option handling                                             #
 ################################################################################
@@ -8166,6 +8178,10 @@ AS_IF([test "x$ENABLED_NULL_CIPHER" = "xno" && \
       [AM_CFLAGS="$AM_CFLAGS -DHAVE_NULL_CIPHER"
        ENABLED_NULL_CIPHER=yes])
 
+# Extended information (see version.c)
+AS_IF([test "x$ENABLED_VERSION_EXTENDED_INFO" = "xyes"],
+      [AM_CFLAGS="$AM_CFLAGS -DHAVE_VERSION_EXTENDED_INFO"])
+
 # wolfSSH and WPA Supplicant both need Public MP, only enable once.
 # This will let you know if you enabled wolfSSH but have any of the prereqs
 # disabled. Some of these options, disabling them adds things to the FLAGS and
@@ -8532,6 +8548,7 @@ AM_CONDITIONAL([BUILD_DTLS_CID],[test "x$ENABLED_DTLS_CID" = "xyes"])
 AM_CONDITIONAL([BUILD_HPKE],[test "x$ENABLED_HPKE" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_DTLS],[test "x$ENABLED_DTLS" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_MAXQ10XX],[test "x$ENABLED_MAXQ10XX" = "xyes"])
+AM_CONDITIONAL([BUILD_VERSION_EXTENDED_INFO],[test "x$VERSION_EXTENDED_INFO" != "xno" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 
 if test "$ENABLED_REPRODUCIBLE_BUILD" != "yes" &&
    (test "$ax_enable_debug" = "yes" ||
@@ -8987,6 +9004,7 @@ echo "   * PKCS#12:                    $ENABLED_PKCS12"
 echo "   * Cavium Nitrox:              $ENABLED_CAVIUM"
 echo "   * Cavium Octeon (Sync):       $ENABLED_OCTEON_SYNC"
 echo "   * Intel Quick Assist:         $ENABLED_INTEL_QA"
+echo "   * Extended Version Info       $ENABLED_VERSION_EXTENDED_INFO"
 if test "$ENABLED_ARMASM_INLINE" = "yes"
 then
     ENABLED_ARMASM="inline C"

--- a/src/include.am
+++ b/src/include.am
@@ -22,6 +22,7 @@ EXTRA_DIST += src/pk.c
 EXTRA_DIST += src/ssl_asn1.c
 EXTRA_DIST += src/ssl_bn.c
 EXTRA_DIST += src/ssl_misc.c
+EXTRA_DIST += src/version.c
 EXTRA_DIST += src/x509.c
 EXTRA_DIST += src/x509_str.c
 
@@ -763,6 +764,10 @@ endif
 
 if BUILD_DTLS
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += src/dtls.c
+endif
+
+if BUILD_VERSION_EXTENDED_INFO
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += src/version.c
 endif
 
 endif !BUILD_CRYPTONLY

--- a/src/version.c
+++ b/src/version.c
@@ -1,0 +1,288 @@
+/* version.c
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+#include <wolfssl/version.h>
+
+
+/*
+** NOTICE: HAVE_WC_INTROSPECTION requires that the configuration and build time
+** artifacts, particularly the date/time of build and git parameters, be
+** excluded from the build. See #ifdef HAVE_WC_INTROSPECTION, below.
+**
+** Fundamentally: the object code needs to be maximally bitwise-invariant.
+**
+** Edit extended version information with care.
+*/
+
+#ifdef HAVE_VERSION_EXTENDED_INFO
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+
+#if defined(WOLFSSL_ESPIDF)
+    #include <esp_log.h>
+    #include "sdkconfig.h"
+    const char* TAG = "Version Info";
+    #define WOLFSSL_VERSION_PRINTF(...) ESP_LOGI(TAG, __VA_ARGS__)
+
+    static int ShowExtendedSystemInfo_platform_espressif(void);
+#else
+    #include <stdio.h>
+    #define WOLFSSL_VERSION_PRINTF(...) { printf(__VA_ARGS__); printf("\n"); }
+#endif
+
+static int ShowExtendedSystemInfo_git(void); /* may be limited during active introspection */
+
+static int ShowExtendedSystemInfo_thread(void);
+static int ShowExtendedSystemInfo_platform(void);
+
+/*
+*******************************************************************************
+** Specific Platforms
+*******************************************************************************
+*/
+
+/*
+** Specific platforms: Espressif
+*/
+#if defined(WOLFSSL_ESPIDF)
+static int ShowExtendedSystemInfo_platform_espressif(void)
+{
+#if defined(CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ)
+    WOLFSSL_VERSION_PRINTF("CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ: %u MHz",
+                            CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ);
+#endif
+
+#if CONFIG_IDF_TARGET_ESP32
+
+    WOLFSSL_VERSION_PRINTF("Xthal_have_ccount: %u",
+                            Xthal_have_ccount);
+
+    /* this is the legacy stack size */
+    #if defined(CONFIG_MAIN_TASK_STACK_SIZE)
+       WOLFSSL_VERSION_PRINTF("CONFIG_MAIN_TASK_STACK_SIZE: %d",
+                               CONFIG_MAIN_TASK_STACK_SIZE);
+    #endif
+
+    /* this is the modern stack size */
+    #if defined(CONFIG_ESP_MAIN_TASK_STACK_SIZE)
+       WOLFSSL_VERSION_PRINTF("CONFIG_ESP_MAIN_TASK_STACK_SIZE: %d",
+                               CONFIG_ESP_MAIN_TASK_STACK_SIZE);
+    #endif
+
+    #if defined(CONFIG_TIMER_TASK_STACK_SIZE)
+       WOLFSSL_VERSION_PRINTF("CONFIG_TIMER_TASK_STACK_SIZE: %d",
+                               CONFIG_TIMER_TASK_STACK_SIZE);
+    #endif
+
+    #if defined(CONFIG_TIMER_TASK_STACK_DEPTH)
+       WOLFSSL_VERSION_PRINTF("CONFIG_TIMER_TASK_STACK_DEPTH: %d",
+                               CONFIG_TIMER_TASK_STACK_DEPTH);
+    #endif
+
+    #if defined(SINGLE_THREADED)
+        /* see also HAVE_STACK_SIZE_VERBOSE */
+       char thisHWM = 0;
+       WOLFSSL_VERSION_PRINTF("Stack HWM: %x", (size_t) &thisHWM);
+    #else
+        WOLFSSL_VERSION_PRINTF("Stack HWM: %d",
+                               uxTaskGetStackHighWaterMark(NULL));
+    #endif
+
+#elif CONFIG_IDF_TARGET_ESP32S2
+    WOLFSSL_VERSION_PRINTF("Xthal_have_ccount = %u",
+                            Xthal_have_ccount);
+#elif CONFIG_IDF_TARGET_ESP32C6
+    /* not supported at this time */
+#elif CONFIG_IDF_TARGET_ESP32C3
+    /* not supported at this time */
+#elif CONFIG_IDF_TARGET_ESP32S3
+    WOLFSSL_VERSION_PRINTF("Xthal_have_ccount = %u",
+                            Xthal_have_ccount);
+#elif CONFIG_IDF_TARGET_ESP32H2
+    /* not supported at this time */
+#elif CONFIG_IDF_TARGET_ESP32C2
+    /* not supported at this time */
+#else
+    /* not supported at this time */
+#endif
+
+    /* check to see if we are using hardware encryption */
+#if defined(NO_ESP32WROOM32_CRYPT)
+    WOLFSSL_VERSION_PRINTF("NO_ESP32WROOM32_CRYPT defined! "
+                           "HW acceleration DISABLED.");
+#else
+    /* first show what platform hardware acceleration is enabled
+    ** (some new platforms may not be supported yet) */
+    #if defined(CONFIG_IDF_TARGET_ESP32)
+        WOLFSSL_VERSION_PRINTF("ESP32WROOM32_CRYPT is enabled for ESP32.");
+    #elif defined(CONFIG_IDF_TARGET_ESP32S2)
+        WOLFSSL_VERSION_PRINTF("ESP32WROOM32_CRYPT is enabled for ESP32-S2.");
+    #elif defined(CONFIG_IDF_TARGET_ESP32S3)
+        WOLFSSL_VERSION_PRINTF("ESP32WROOM32_CRYPT is enabled for ESP32-S3.");
+    #else
+        #error "ESP32WROOM32_CRYPT not yet supported on this IDF TARGET"
+    #endif
+
+    /* Even though enabled, some specifics may be disabled */
+    #if defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+        WOLFSSL_VERSION_PRINTF("NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH is defined!"
+                               "(disabled HW SHA).");
+    #endif
+
+    #if defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_AES)
+        WOLFSSL_VERSION_PRINTF("NO_WOLFSSL_ESP32WROOM32_CRYPT_AES is defined!"
+                               "(disabled HW AES).");
+    #endif
+
+    #if defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI)
+        WOLFSSL_VERSION_PRINTF("NO_WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI defined!"
+                               "(disabled HW RSA)");
+    #endif
+#endif
+
+    return 0;
+}
+#endif
+
+/*
+*******************************************************************************
+** All Platforms
+*******************************************************************************
+*/
+
+/*
+** All platforms: git details
+*/
+static int ShowExtendedSystemInfo_git(void)
+{
+#ifdef HAVE_WC_INTROSPECTION
+    WOLFSSL_VERSION_PRINTF("HAVE_WC_INTROSPECTION enabled. "
+                           "Some extended system details not available.");
+#else
+/* Display some interesting git values that may change,
+** but not desired for introspection which requires object code to be
+** maximally bitwise-invariant.
+*/
+#if defined(LIBWOLFSSL_VERSION_GIT_ORIGIN)
+    /* git config --get remote.origin.url */
+    WOLFSSL_VERSION_PRINTF("LIBWOLFSSL_VERSION_GIT_ORIGIN = %s",
+                            LIBWOLFSSL_VERSION_GIT_ORIGIN);
+#endif
+
+#if defined(LIBWOLFSSL_VERSION_GIT_BRANCH)
+    /* git rev-parse --abbrev-ref HEAD */
+    WOLFSSL_VERSION_PRINTF("LIBWOLFSSL_VERSION_GIT_BRANCH = %s",
+                            LIBWOLFSSL_VERSION_GIT_BRANCH);
+#endif
+
+#if defined(LIBWOLFSSL_VERSION_GIT_HASH)
+    WOLFSSL_VERSION_PRINTF("LIBWOLFSSL_VERSION_GIT_HASH = %s",
+                            LIBWOLFSSL_VERSION_GIT_HASH);
+#endif
+
+#if defined(LIBWOLFSSL_VERSION_GIT_SHORT_HASH )
+    WOLFSSL_VERSION_PRINTF("LIBWOLFSSL_VERSION_GIT_SHORT_HASH = %s",
+                            LIBWOLFSSL_VERSION_GIT_SHORT_HASH);
+#endif
+
+#if defined(LIBWOLFSSL_VERSION_GIT_HASH_DATE)
+    WOLFSSL_VERSION_PRINTF("LIBWOLFSSL_VERSION_GIT_HASH_DATE = %s",
+                            LIBWOLFSSL_VERSION_GIT_HASH_DATE);
+#endif
+
+#endif /* else not HAVE_WC_INTROSPECTION */
+    return 0;
+}
+
+/*
+** All platforms: thread details
+*/
+static int ShowExtendedSystemInfo_thread(void)
+{
+    /* all platforms: stack high water mark check */
+#if defined(SINGLE_THREADED)
+    WOLFSSL_VERSION_PRINTF("SINGLE_THREADED");
+#else
+    WOLFSSL_VERSION_PRINTF("NOT SINGLE_THREADED");
+#endif
+    return 0;
+}
+
+/*
+** All Platforms: platform details
+*/
+static int ShowExtendedSystemInfo_platform(void)
+{
+#if defined(WOLFSSL_ESPIDF)
+    #if defined(CONFIG_IDF_TARGET)
+        WOLFSSL_VERSION_PRINTF("CONFIG_IDF_TARGET = %s",
+                                CONFIG_IDF_TARGET);
+        ShowExtendedSystemInfo_platform_espressif(void);
+    #endif
+#endif
+    return 0;
+}
+
+/*
+*******************************************************************************
+** The public ShowExtendedSystemInfo()
+*******************************************************************************
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int ShowExtendedSystemInfo(void)
+{
+    WOLFSSL_VERSION_PRINTF("Extended Version and Platform Information.");
+
+#if defined(LIBWOLFSSL_VERSION_STRING)
+    WOLFSSL_VERSION_PRINTF("LIBWOLFSSL_VERSION_STRING = %s",
+                            LIBWOLFSSL_VERSION_STRING);
+#endif
+
+#if defined(LIBWOLFSSL_VERSION_HEX)
+    WOLFSSL_VERSION_PRINTF("LIBWOLFSSL_VERSION_HEX = %x",
+                            LIBWOLFSSL_VERSION_HEX);
+#endif
+
+#if defined(WOLFSSL_MULTI_INSTALL_WARNING)
+    /* CMake may have detected undesired multiple installs, so give warning. */
+    WOLFSSL_VERSION_PRINTF("");
+    WOLFSSL_VERSION_PRINTF("WARNING: Multiple wolfSSL installs found.");
+    WOLFSSL_VERSION_PRINTF("Check ESP-IDF and local project [components] directory.");
+    WOLFSSL_VERSION_PRINTF("");
+#endif
+
+    ShowExtendedSystemInfo_git(); /* may be limited during active introspection */
+    ShowExtendedSystemInfo_platform();
+    ShowExtendedSystemInfo_thread();
+    return 0;
+}
+
+#endif /* NO_VERSION_EXTENDED_INFO */
+
+#ifdef __cplusplus
+}
+#endif

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -28,9 +28,10 @@
 #endif
 #include <wolfssl/wolfcrypt/settings.h>
 
+#include <wolfssl/version.h>
+
 #ifndef NO_CRYPT_TEST
 
-#include <wolfssl/version.h>
 #include <wolfssl/wolfcrypt/types.h>
 #include <wolfssl/wolfcrypt/wc_port.h>
 #include <wolfssl/wolfcrypt/mem_track.h>
@@ -118,9 +119,14 @@
     #endif
     #include "os/os_time.h"
 #elif defined(WOLFSSL_ESPIDF)
+
     #include <time.h>
     #include <sys/time.h>
     #include <esp_log.h>
+
+    /* there's a conflict with the TAG in sha256.c,
+    ** so we call this one TEST_TAG */
+    static const char* TEST_TAG = "wolfcrypt_test"; /* ESP_LOG() breadcrumb */
 #elif defined(WOLFSSL_ZEPHYR)
     #include <stdio.h>
 
@@ -1736,10 +1742,17 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
             printf("wolfCrypt_Init failed %d\n", ret);
             err_sys("Error with wolfCrypt_Init!\n", WC_TEST_RET_ENC_EC(ret));
         }
+#if defined(HAVE_VERSION_EXTENDED_INFO) && !defined(WOLFCRYPT_ONLY)
+        ShowExtendedSystemInfo();
+#endif
 
     #ifdef HAVE_WC_INTROSPECTION
         printf("Math: %s\n", wc_GetMathInfo());
     #endif
+
+#if defined(HAVE_VERSION_EXTENDED_INFO) && !defined(WOLFCRYPT_ONLY)
+        ShowExtendedSystemInfo();
+#endif
 
 #ifdef WC_RNG_SEED_CB
     wc_SetSeed_Cb(wc_GenerateSeed);
@@ -1771,7 +1784,8 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 
 #ifdef WOLFSSL_ESPIDF
         /* ESP_LOGI to print takes up a lot less memory than printf */
-        ESP_LOGI("wolfcrypt_test", "Exiting main with return code: % d\n", args.return_code);
+        ESP_LOGI(TEST_TAG, "Exiting main with return code: % d\n",
+                           args.return_code);
 #endif
 
 /* everything else will use printf */

--- a/wolfssl/version.h
+++ b/wolfssl/version.h
@@ -23,13 +23,21 @@
 #ifndef WOLFSSL_VERSION_H
 #define WOLFSSL_VERSION_H
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+#ifdef HAVE_CONFIG_H
+    #include "config.h"
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+
 #define LIBWOLFSSL_VERSION_STRING "5.6.0"
 #define LIBWOLFSSL_VERSION_HEX 0x05006000
+
+#ifdef HAVE_VERSION_EXTENDED_INFO
+WOLFSSL_API int ShowExtendedSystemInfo(void);
+#endif
 
 #ifdef __cplusplus
 }

--- a/wolfssl/version.h.in
+++ b/wolfssl/version.h.in
@@ -23,13 +23,21 @@
 #ifndef WOLFSSL_VERSION_H
 #define WOLFSSL_VERSION_H
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+#ifdef HAVE_CONFIG_H
+    #include "config.h"
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+
 #define LIBWOLFSSL_VERSION_STRING "@VERSION@"
 #define LIBWOLFSSL_VERSION_HEX @HEX_VERSION@
+
+#ifdef HAVE_VERSION_EXTENDED_INFO
+WOLFSSL_API int ShowExtendedSystemInfo(void);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
# Description

Adds a platform-specific `ShowExtendedSystemInfo()` function.

This code is otherwise duplicated among many examples, cluttering up  `main` in each.

The version details are expected to be generated from CMake tasks, such as the [benchmark example](https://github.com/gojimmypi/wolfssl/blob/6dfd9506fad46aef391f8d0ba842d8f676659efe/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/components/wolfssl/CMakeLists.txt#L290). 

I plan to add additional "interesting" application information as appropriate.

Allows displaying of build-time info like this at runtime:

```
I (421) Version: Extended Version and Platform Information
I (428) Version: CONFIG_IDF_TARGET = esp32
I (432) Version: LIBWOLFSSL_VERSION_STRING = 5.5.4
I (438) Version: LIBWOLFSSL_VERSION_GIT_HASH = 6dfd9506fad46aef391f8d0ba842d8f676659efe
I (446) Version: LIBWOLFSSL_VERSION_GIT_SHORT_HASH = 6dfd9506f
I (453) Version: LIBWOLFSSL_VERSION_GIT_HASH_DATE = 'Tue Feb 28 17:57:16 2023 -0800'
I (461) Version: CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ = 160 MHz
I (468) Version: Xthal_have_ccount = 1
I (472) Version: ESP32WROOM32_CRYPT is enabled.
```

Fixes zd#

# Testing

Tested in Espressif ESP-IDF. Linux apps will compile, but the `version.c` is not yet included in the makefiles and otherwise has no additional information for that platform. Future PRs are expected to add platform and environment-specific details.

#### Edit 3/14/23:

A [script](https://github.com/gojimmypi/wolfssl/blob/ED25519_SHA2_fix/version_test.sh) to fully test:

```
make clean
make distclean
./autogen.sh

# enable-all test  (`version-extended-info` is enabled by default)
#./configure CC=clang  --enable-all CFLAGS=-DHAVE_STACK_SIZE && make && ./wolfcrypt/test/testwolfcrypt

# Sample  --disable-version-extended-info
./configure CC=clang --enable-trackmemory --enable-ed25519 --disable-version-extended-info CFLAGS=-DHAVE_STACK_SIZE && make && ./wolfcrypt/test/testwolfcrypt

# Sample -enable-version-extended-info
# ./configure CC=clang --enable-trackmemory --enable-ed25519 --enable-version-extended-info CFLAGS=-DHAVE_STACK_SIZE && make && ./wolfcrypt/test/testwolfcrypt

echo "nm ./src/.libs/libwolfssl_la-version.o"
nm ./src/.libs/libwolfssl_la-version.o
```

Now includes the options `--disable-version-extended-info` or ` --enable-version-extended-info` for non-embedded builds.

#### Disabled

Commandline version will look like this for `testwolfcrypt` output with `--disable-version-extended-info`

```
[... snip ...]
  CCLD     examples/server/server
  CCLD     testsuite/testsuite.test
  CCLD     tests/unit.test
make[2]: Leaving directory '/mnt/c/workspace/wolfssl-gojimmypi'
make[1]: Leaving directory '/mnt/c/workspace/wolfssl-gojimmypi'
------------------------------------------------------------------------------
 wolfSSL version 5.5.4
------------------------------------------------------------------------------
error    test passed!
MEMORY   test passed!
base64   test passed!
asn      test passed!
[... snip ...]
```

#### Enabled

Commandline version will look like this for `testwolfcrypt` output with `--enable-version-extended-info` 

```
[... snip ...]
  CCLD     examples/echoserver/echoserver
  CCLD     examples/server/server
  CCLD     testsuite/testsuite.test
  CCLD     tests/unit.test
make[2]: Leaving directory '/mnt/c/workspace/wolfssl-gojimmypi'
make[1]: Leaving directory '/mnt/c/workspace/wolfssl-gojimmypi'
Extended Version and Platform Information.
LIBWOLFSSL_VERSION_STRING = 5.5.4
LIBWOLFSSL_VERSION_HEX = 5005004
NOT SINGLE_THREADED
------------------------------------------------------------------------------
 wolfSSL version 5.5.4
------------------------------------------------------------------------------
error    test passed!
MEMORY   test passed!
base64   test passed!
asn      test passed!
[... snip ...]
```
and the usual:

```
./configure CC=clang --enable-trackmemory CFLAGS=-DHAVE_STACK_SIZE && make && ./wolfcrypt/test/testwolfcrypt
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
