### PR TITLE
20230301-fix-async-and-mips-and-kcapi

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -29260,15 +29260,10 @@ static int SignCert(int requestSz, int sType, byte* buf, word32 buffSz,
 {
     int sigSz = 0;
     void* heap = NULL;
-    CertSignCtx* certSignCtx;
-#ifndef WOLFSSL_ASYNC_CRYPT
     CertSignCtx  certSignCtx_lcl;
+    CertSignCtx* certSignCtx = &certSignCtx_lcl;
 
-    certSignCtx = &certSignCtx_lcl;
-    XMEMSET(certSignCtx, 0, sizeof(CertSignCtx));
-#else
-    certSignCtx = NULL;
-#endif
+    XMEMSET(certSignCtx, 0, sizeof(*certSignCtx));
 
     if (requestSz < 0)
         return requestSz;
@@ -29294,12 +29289,6 @@ static int SignCert(int requestSz, int sType, byte* buf, word32 buffSz,
         return NOT_COMPILED_IN;
     #endif /* HAVE_ECC */
     }
-
-#ifdef WOLFSSL_ASYNC_CRYPT
-    if (certSignCtx == NULL) {
-        return BAD_FUNC_ARG;
-    }
-#endif
 
     if (certSignCtx->sig == NULL) {
         certSignCtx->sig = (byte*)XMALLOC(MAX_ENCODED_SIG_SZ, heap,

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -643,22 +643,35 @@ static void render_error_message(const char* msg, int es)
         break;
     case WC_TEST_RET_TAG_ERRNO:
     {
-#if defined(_GNU_SOURCE) || \
-    (defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200112L))
+
+/* strerror_r() comes in two mutually incompatible flavors, a native glibc
+ * flavor that always returns a non-null char pointer that must be used
+ * directly, and a POSIX flavor that returns an error int, and iff success,
+ * stores an error string in the supplied buffer.  this is all most
+ * infelicitous...
+ */
+#if !defined(STRING_USER) && !defined(NO_ERROR_STRINGS) &&      \
+    (defined(_GNU_SOURCE) || defined(__USE_GNU) ||              \
+     (defined(__USE_XOPEN2K) &&                                 \
+      defined(_POSIX_C_SOURCE) &&                               \
+      (_POSIX_C_SOURCE >= 200112L)))
+
         char errno_buf[64], *errno_string;
-#if defined(_GNU_SOURCE)
-        errno_string = strerror_r(WC_TEST_RET_DEC_I(es),
-                                  errno_buf, sizeof(errno_buf));
-#else
+        /* precisely mirror the gate used in glibc string.h */
+#if defined __USE_XOPEN2K && !defined __USE_GNU
         if (strerror_r(WC_TEST_RET_DEC_I(es),
                        errno_buf, sizeof(errno_buf)) != 0)
             XSTRLCPY(errno_buf, "?", sizeof(errno_buf));
         errno_string = errno_buf;
+#else
+        errno_string = strerror_r(WC_TEST_RET_DEC_I(es),
+                                  errno_buf, sizeof(errno_buf));
 #endif
         err_sys_printf("%s error L=%d errno=%d (%s)\n", msg,
                        WC_TEST_RET_DEC_LN(es), WC_TEST_RET_DEC_I(es),
                        errno_string);
-#else
+
+#else /* can't figure out how to strerror_r(), or don't want error strings */
         err_sys_printf("%s error L=%d errno=%d\n", msg,
                        WC_TEST_RET_DEC_LN(es), WC_TEST_RET_DEC_I(es));
 #endif

--- a/wolfssl/openssl/sha.h
+++ b/wolfssl/openssl/sha.h
@@ -202,7 +202,7 @@ typedef WOLFSSL_SHA256_CTX SHA256_CTX;
 #ifdef WOLFSSL_SHA384
 typedef struct WOLFSSL_SHA384_CTX {
     /* big enough to hold wolfCrypt Sha384, but check on init */
-    void* holder[(268 + CTX_SHA_HW_ADDER + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
+    void* holder[(288 + CTX_SHA_HW_ADDER + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
 #if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
     void* keephash_holder[sizeof(void*) + (2 * sizeof(unsigned int))];
 #endif

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1928,6 +1928,11 @@ extern void uITRON4_free(void *p) ;
     #define XGEN_ALIGN
 #endif
 
+#if defined(__mips) || defined(__mips64) || \
+    defined(WOLFSSL_SP_MIPS64) || defined(WOLFSSL_SP_MIPS)
+    #undef WOLFSSL_SP_INT_DIGIT_ALIGN
+    #define WOLFSSL_SP_INT_DIGIT_ALIGN
+#endif
 
 #ifdef __INTEL_COMPILER
     #pragma warning(disable:2259) /* explicit casts to smaller sizes, disable */


### PR DESCRIPTION
`wolfcrypt/test/test.c`: improve `strerror_r()` flavor sensing (simpler gate randomly provoked `cppcheck-all-async-quic)`.

`wolfcrypt/src/asn.c`: fix `WOLFSSL_ASYNC_CRYPT` codepath in `SignCert()` -- fall through to non-async `certSignCtx_lcl` for algs without async support.

`wolfssl/wolfcrypt/settings.h`: define `WOLFSSL_SP_INT_DIGIT_ALIGN` when target is MIPS, to fix a crash in `sp_read_unsigned_bin()`.

`wolfssl/openssl/sha.h`: fix undersized `WOLFSSL_SHA384_CTX` to have same size as `WOLFSSL_SHA512_CTX` (fixes failed assert in `fips-140-3-dev-kcapi-opensslextra-build`).

tested with `wolfssl-multi-test.sh ... super-quick-check cross-mips64-all-asm-sp-all cross-mips64-fips-140-3-ready-asm cross-mips-all-asm-sp-all`

(note, the mips scenarios in multi-test are new, but are going into nightly production now.)
