### PR TITLE
Used codespell and fixed obvious typos in src and wolfssl.

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -1137,7 +1137,7 @@ void wolfSSL_CONF_CTX_set_ssl_ctx(WOLFSSL_CONF_CTX* cctx, WOLFSSL_CTX *ctx)
 /**
  * set flag value into WOLFSSL_CONF_CTX
  * @param cctx  a pointer to WOLFSSL_CONF_CTX structure to be set
- * @param flags falg value to be OR'd
+ * @param flags flag value to be OR'd
  * @return OR'd flag value, otherwise 0
  */
 unsigned int wolfSSL_CONF_CTX_set_flags(WOLFSSL_CONF_CTX* cctx,
@@ -1579,7 +1579,7 @@ int wolfSSL_CONF_cmd(WOLFSSL_CONF_CTX* cctx, const char* cmd, const char* value)
  * @param cctx a pointer to WOLFSSL_CONF_CTX structure
  * @param cmd  configuration command
  * @return The SSL_CONF_TYPE_* type or SSL_CONF_TYPE_UNKNOWN if an
- *         unvalid command
+ *         invalid command
  */
 int wolfSSL_CONF_cmd_value_type(WOLFSSL_CONF_CTX *cctx, const char *cmd)
 {

--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -92,9 +92,9 @@ typedef struct Dtls13RecordPlaintextHeader {
 #define DTLS13_LEN_SIZE 2
 /* size of the flags in the unified header */
 #define DTLS13_HDR_FLAGS_SIZE 1
-/* size of the sequence number wher SEQ_LEN_BIT is present */
+/* size of the sequence number where SEQ_LEN_BIT is present */
 #define DTLS13_SEQ_16_LEN 2
-/* size of the sequence number wher SEQ_LEN_BIT is not present */
+/* size of the sequence number where SEQ_LEN_BIT is not present */
 #define DTLS13_SEQ_8_LEN 1
 
 /* fixed bits mask to detect unified header  */
@@ -432,7 +432,7 @@ static int Dtls13SendNow(WOLFSSL* ssl, enum HandShakeType handshakeType)
     return 0;
 }
 
-/* Handshake header DTLS only fields are not inlcuded in the transcript hash */
+/* Handshake header DTLS only fields are not included in the transcript hash */
 int Dtls13HashHandshake(WOLFSSL* ssl, const byte* output, word16 length)
 {
     int ret;
@@ -1186,7 +1186,7 @@ word16 Dtls13GetRlHeaderLength(WOLFSSL* ssl, byte isEncrypted)
 
 /**
  * Dtls13GetHeadersLength() - return length of record + handshake header
- * @ssl: ssl oject
+ * @ssl: ssl object
  * @type: type of handshake in the message
  */
 word16 Dtls13GetHeadersLength(WOLFSSL* ssl, enum HandShakeType type)
@@ -1941,7 +1941,7 @@ int Dtls13GetSeq(WOLFSSL* ssl, int order, word32* seq, byte increment)
 
     if (order == PEER_ORDER) {
         nativeSeq = &ssl->keys.curSeq;
-        /* never increment seq number for curent record. In DTLS seq number are
+        /* never increment seq number for current record. In DTLS seq number are
            explicit */
         increment = 0;
     }
@@ -2435,7 +2435,7 @@ int Dtls13RtxTimeout(WOLFSSL* ssl)
 
     /* we have two timeouts, a shorter (dtls13FastTimeout = 1) and a longer
        one. When the shorter expires we only send ACKs, as it normally means
-       that some messages we are waiting for dont't arrive yet. But we
+       that some messages we are waiting for don't arrive yet. But we
        retransmit our buffered messages only if the longer timeout
        expires. fastTimeout is 1/4 of the longer timeout */
     if (ssl->dtls13FastTimeout) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -19718,7 +19718,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
             }
        #if defined(HAVE_ENCRYPT_THEN_MAC) && !defined(WOLFSSL_AEAD_ONLY)
             if (IsEncryptionOn(ssl, 0) && ssl->options.startedETMRead) {
-                /* For TLS v1.1 the block size and explcit IV are added to idx,
+                /* For TLS v1.1 the block size and explicit IV are added to idx,
                  * so it needs to be included in this limit check */
                 if ((ssl->curSize - ssl->keys.padSz -
                         (ssl->buffers.inputBuffer.idx - startIdx) -
@@ -19739,7 +19739,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
             else
        #endif
                 /* TLS13 plaintext limit is checked earlier before decryption */
-                /* For TLS v1.1 the block size and explcit IV are added to idx,
+                /* For TLS v1.1 the block size and explicit IV are added to idx,
                  * so it needs to be included in this limit check */
                 if (!IsAtLeastTLSv1_3(ssl->version)
                         && ssl->curSize - ssl->keys.padSz -
@@ -22760,7 +22760,7 @@ startScr:
     #ifdef WOLFSSL_TLS13
         if (IsAtLeastTLSv1_3(ssl->version) && ssl->options.handShakeDone &&
                                          ssl->curRL.type == handshake && peek) {
-            WOLFSSL_MSG("Got Handshake Messge in APP data");
+            WOLFSSL_MSG("Got Handshake Message in APP data");
             if (ssl->buffers.inputBuffer.length == 0) {
                 ssl->error = WOLFSSL_ERROR_WANT_READ;
                 return 0;
@@ -23149,7 +23149,7 @@ const char* wolfSSL_ERR_reason_error_string(unsigned long e)
         return "record layer length error";
 
     case PEER_KEY_ERROR:
-        return "cant decode peer key";
+        return "can't decode peer key";
 
     case ZERO_RETURN:
     case WOLFSSL_ERROR_ZERO_RETURN:
@@ -24252,7 +24252,7 @@ int IsCipherAEAD(char n[][MAX_SEGMENT_SZ])
     WOLFSSL_ENTER("IsCipherAEAD");
 
     if (n == NULL) {
-        WOLFSSL_MSG("bad function argumet. n is NULL.");
+        WOLFSSL_MSG("bad function argument. n is NULL.");
         return 0;
     }
 
@@ -25271,7 +25271,7 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
             if (CmpEccStrength(hashAlgo, ssl->buffers.keySz) != 0)
                 continue;
 
-            /* Matched ECDSA exaclty - set chosen and finished. */
+            /* Matched ECDSA exactly - set chosen and finished. */
             ssl->options.hashAlgo = hashAlgo;
             ssl->options.sigAlgo = sigAlgo;
             ret = 0;
@@ -30129,7 +30129,7 @@ int SendCertificateVerify(WOLFSSL* ssl)
         #ifndef NO_OLD_TLS
             else {
                 /* if old TLS load MD5 and SHA hash as value to sign
-                 * MD5 and SHA must be first two buffers in stucture */
+                 * MD5 and SHA must be first two buffers in structure */
                 XMEMCPY(ssl->buffers.sig.buffer,
                                 (byte*)&ssl->hsHashes->certHashes, FINISHED_SZ);
             }
@@ -36968,8 +36968,8 @@ WOLFSSL_BY_DIR_HASH* wolfSSL_sk_BY_DIR_HASH_pop(
     return hash;
 }
 /* release all contents in stack, and then release stack itself. */
-/* Second argument is a function pointer to release resouces.    */
-/* It calls the function to release resouces when t is passed    */
+/* Second argument is a function pointer to release resources.   */
+/* It calls the function to release resources when it is passed  */
 /* instead of wolfSSL_BY_DIR_HASH_free().                        */
 void wolfSSL_sk_BY_DIR_HASH_pop_free(WOLF_STACK_OF(BY_DIR_HASH)* sk,
     void (*f) (WOLFSSL_BY_DIR_HASH*))
@@ -37153,8 +37153,8 @@ WOLFSSL_BY_DIR_entry* wolfSSL_sk_BY_DIR_entry_pop(
     return entry;
 }
 /* release all contents in stack, and then release stack itself. */
-/* Second argument is a function pointer to release resouces.    */
-/* It calls the function to release resouces when t is passed    */
+/* Second argument is a function pointer to release resources.   */
+/* It calls the function to release resources when it is passed  */
 /* instead of wolfSSL_BY_DIR_entry_free().                       */
 void wolfSSL_sk_BY_DIR_entry_pop_free(WOLF_STACK_OF(WOLFSSL_BY_DIR_entry)* sk,
     void (*f) (WOLFSSL_BY_DIR_entry*))

--- a/src/pk.c
+++ b/src/pk.c
@@ -11475,7 +11475,7 @@ static int wolfssl_ec_key_int_copy(ecc_key* dst, const ecc_key* src)
 
 /* Copies ecc_key into new WOLFSSL_EC_KEY object
  *
- * Copies the internal represention as well.
+ * Copies the internal representation as well.
  *
  * @param [in] src  EC key to duplicate.
  *
@@ -13312,8 +13312,8 @@ int wolfSSL_i2d_ECDSA_SIG(const WOLFSSL_ECDSA_SIG *sig, unsigned char **pp)
  * r and s untouched when sig is NULL.
  *
  * @param [in]  sig  ECDSA signature object.
- * @param [out] r    R field of ECDSA siganture as a BN. May be NULL.
- * @param [out] s    S field of ECDSA siganture as a BN. May be NULL.
+ * @param [out] r    R field of ECDSA signature as a BN. May be NULL.
+ * @param [out] s    S field of ECDSA signature as a BN. May be NULL.
  */
 void wolfSSL_ECDSA_SIG_get0(const WOLFSSL_ECDSA_SIG* sig,
     const WOLFSSL_BIGNUM** r, const WOLFSSL_BIGNUM** s)
@@ -13334,8 +13334,8 @@ void wolfSSL_ECDSA_SIG_get0(const WOLFSSL_ECDSA_SIG* sig,
 /* Set the pointers to the fields of the ECDSA signature.
  *
  * @param [in, out] sig  ECDSA signature object to update.
- * @param [in]      r    R field of ECDSA siganture as a BN.
- * @param [in]      s    S field of ECDSA siganture as a BN.
+ * @param [in]      r    R field of ECDSA signature as a BN.
+ * @param [in]      s    S field of ECDSA signature as a BN.
  * @return  1 on success.
  * @return  0 on error.
  */

--- a/src/quic.c
+++ b/src/quic.c
@@ -120,7 +120,7 @@ static int quic_record_append(WOLFSSL *ssl, QuicRecord *qr, const uint8_t *data,
             XMEMCPY(qr->data + qr->end, data, len);
             qr->end += len;
             consumed = len;
-            goto cleanup; /* len consumed, but qr->len still unkown */
+            goto cleanup; /* len consumed, but qr->len still unknown */
         }
         XMEMCPY(qr->data + qr->end, data, missing);
         qr->end += missing;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -7124,7 +7124,7 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
             if (GetSequence(buff, &inOutIdx, &length, (word32)sz) >= 0) {
                 length += inOutIdx; /* include leading sequence */
             }
-            /* get length using octect string (allowed for private key types) */
+            /* get length using octet string (allowed for private key types) */
             else if (type == PRIVATEKEY_TYPE &&
                     GetOctetString(buff, &inOutIdx, &length, (word32)sz) >= 0) {
                 length += inOutIdx; /* include leading oct string */
@@ -23147,7 +23147,7 @@ int wolfSSL_i2d_PublicKey(const WOLFSSL_EVP_PKEY *key, unsigned char **der)
 #ifdef HAVE_ECC
 
     /* We need to get the DER, then convert it to a public key. But what we get
-     * might be a buffereed private key so we need to decode it and then encode
+     * might be a buffered private key so we need to decode it and then encode
      * the public part. */
     if (ret == 0) {
         ret = wolfSSL_EVP_PKEY_get_der(key, &local_der);

--- a/src/tls.c
+++ b/src/tls.c
@@ -7299,7 +7299,7 @@ static int TLSX_KeyShare_GenPqcKey(WOLFSSL *ssl, KeyShareEntry* kse)
     if (ret == 0) {
         ret = wc_KyberKey_Init(type, kem, ssl->heap, ssl->devId);
         if (ret != 0) {
-            WOLFSSL_MSG("Failed to intialize Kyber Key.");
+            WOLFSSL_MSG("Failed to initialize Kyber Key.");
         }
     }
 
@@ -11531,7 +11531,7 @@ static int TLSX_Write(TLSX* list, byte* output, byte* semaphore,
         /* extensions don't overlap with ssl level ones. */
         TURN_ON(semaphore, TLSX_ToSemaphore(extension->type));
 
-        /* if we encountered an error propigate it */
+        /* if we encountered an error propagate it */
         if (ret != 0)
             break;
     }

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -8855,7 +8855,7 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
             }
         #endif
             if (!validSigAlgo) {
-                WOLFSSL_MSG("Sig algo doesn't correspond to certficate");
+                WOLFSSL_MSG("Sig algo doesn't correspond to certificate");
                 ERROR_OUT(SIG_VERIFY_E, exit_dcv);
             }
 
@@ -9376,7 +9376,7 @@ static int SendTls13Finished(WOLFSSL* ssl)
     if (ssl->options.dtls) {
         headerSz = DTLS_HANDSHAKE_HEADER_SZ;
         /* using isDtls instead of ssl->options.dtls will abide clang static
-           analyzer on unsing an uninitialized value */
+           analyzer on using an uninitialized value */
         isDtls = 1;
     }
 #endif /* WOLFSSL_DTLS13 */
@@ -10294,7 +10294,7 @@ static int SendTls13NewSessionTicket(WOLFSSL* ssl)
 
     ssl->options.haveSessionId = 1;
 
-    /* Only add to cache when suppport built in and when the ticket contains
+    /* Only add to cache when support built in and when the ticket contains
      * an ID. Otherwise we have no way to actually retrieve the ticket from the
      * cache. */
 #if !defined(NO_SESSION_CACHE) && defined(WOLFSSL_TICKET_HAVE_ID)
@@ -10814,14 +10814,14 @@ static int SanityCheckTls13MsgReceived(WOLFSSL* ssl, byte type)
                 return OUT_OF_ORDER_E;
             }
             if (ssl->options.side == WOLFSSL_SERVER_END) {
-                WOLFSSL_MSG("HelloVerifyRequest recevied on the server");
+                WOLFSSL_MSG("HelloVerifyRequest received on the server");
                 WOLFSSL_ERROR_VERBOSE(SIDE_ERROR);
                 return SIDE_ERROR;
             }
             if (!ssl->options.downgrade ||
                 ssl->options.minDowngrade < DTLSv1_2_MINOR) {
                 WOLFSSL_MSG(
-                    "HelloVerifyRequest recevied but not DTLSv1.2 allowed");
+                    "HelloVerifyRequest received but not DTLSv1.2 allowed");
                 WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
                 return VERSION_ERROR;
             }
@@ -10982,7 +10982,7 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     &echInOutIdx,
                     ((WOLFSSL_ECH*)echX->data)->innerClientHelloLen);
 
-                /* if the inner ech parsed successfully we have sucessfully
+                /* if the inner ech parsed successfully we have successfully
                  * handled the hello and can skip the whole message */
                 if (ret == 0)
                     *inOutIdx += size;

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -2877,7 +2877,7 @@ int LwIPNativeReceive(WOLFSSL* ssl, char* buf, int sz, void* ctx)
             /* read enough break out */
             if (read >= sz) {
                 /* if more pbuf's are left in the chain then increment the
-                 * ref count for next in chain and free all from begining till
+                 * ref count for next in chain and free all from beginning till
                  * next */
                 if (current != NULL) {
                     pbuf_ref(current);

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -195,7 +195,7 @@ enum wolfSSL_ErrorCodes {
     /* end negotiation parameter errors only 10 for now */
     /* add strings to wolfSSL_ERR_reason_error_string in internal.c !!!!! */
 
-    /* no error stings go down here, add above negotiation errors !!!! */
+    /* no error strings go down here, add above negotiation errors !!!! */
 };
 
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2253,7 +2253,7 @@ struct CRL_Entry {
     RevokedCert* certs;             /* revoked cert list  */
 #endif
     int     totalCerts;             /* number on list     */
-    int     version;                /* version of certficate */
+    int     version;                /* version of certificate */
     int     verified;
     byte*   toBeSigned;
     word32  tbsSz;

--- a/wolfssl/openssl/asn1.h
+++ b/wolfssl/openssl/asn1.h
@@ -96,7 +96,7 @@
 #define ASN1_STRING_FLAG_EMBED           0x080
 
 /* X.509 PKI size limits from RFC2459 (appendix A) */
-/* internally our limit is CTC_NAME_SIZE (64) - overriden with WC_CTC_NAME_SIZE */
+/* internally our limit is CTC_NAME_SIZE (64) - overridden with WC_CTC_NAME_SIZE */
 #define ub_name                    CTC_NAME_SIZE /* 32768 */
 #define ub_common_name             CTC_NAME_SIZE /* 64 */
 #define ub_locality_name           CTC_NAME_SIZE /* 128 */

--- a/wolfssl/openssl/rsa.h
+++ b/wolfssl/openssl/rsa.h
@@ -69,7 +69,7 @@ typedef struct WOLFSSL_RSA_METHOD {
 
 #ifndef WOLFSSL_RSA_TYPE_DEFINED /* guard on redeclaration */
 #define WOLFSSL_RSA_TYPE_DEFINED
-/* RSA key compatable with OpenSSL. */
+/* RSA key compatible with OpenSSL. */
 typedef struct WOLFSSL_RSA {
     WOLFSSL_BIGNUM* n;              /* Modulus. */
     WOLFSSL_BIGNUM* e;              /* Public exponent. */

--- a/wolfssl/quic.h
+++ b/wolfssl/quic.h
@@ -71,7 +71,7 @@ struct wolfssl_quic_method_t {
      */
     int (*flush_flight)(WOLFSSL* ssl);
     /**
-     * Send a TLS alert that happend during handshake. In QUIC, such alerts
+     * Send a TLS alert that happened during handshake. In QUIC, such alerts
      * lead to connection shutdown.
      */
     int (*send_alert)(WOLFSSL* ssl, WOLFSSL_ENCRYPTION_LEVEL level,
@@ -88,7 +88,7 @@ WOLFSSL_API
 int wolfSSL_CTX_set_quic_method(WOLFSSL_CTX* ctx,
                                 const WOLFSSL_QUIC_METHOD* quic_method);
 /**
- * Mark extactly this SSL instance for QUIC protocol handling.
+ * Mark exactly this SSL instance for QUIC protocol handling.
  * Provides all callbacks to the QUIC application the SSL stack needs.
  */
 WOLFSSL_API
@@ -168,7 +168,7 @@ WOLFSSL_API void wolfSSL_set_quic_early_data_enabled(WOLFSSL* ssl, int enabled);
 
 /**
  * Advisory amount of the maximum data a QUIC protocol handler should have
- * in flight. This varies during handshake processing, for example certficate
+ * in flight. This varies during handshake processing, for example certificate
  * exchange will increase the limit.
  */
 WOLFSSL_API

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -269,7 +269,7 @@ typedef struct ASNGetData {
             /* Maximum length of buffer. */
             word32* length;
         } buffer;
-        /* Refernce to ASN.1 item's data. */
+        /* Reference to ASN.1 item's data. */
         struct {
             /* Pointer reference into input buffer. */
             const byte* data;
@@ -881,7 +881,7 @@ enum Misc_ASN {
 #else
     RSA_INTS            =   2,     /* RSA ints in private key */
 #endif
-    DSA_PARAM_INTS      =   3,     /* DSA paramater ints */
+    DSA_PARAM_INTS      =   3,     /* DSA parameter ints */
     RSA_PUB_INTS        =   2,     /* RSA ints in public key */
     DSA_PUB_INTS        =   4,     /* DSA ints in public key */
     DSA_INTS            =   5,     /* DSA ints in private key */
@@ -1211,7 +1211,7 @@ enum ExtKeyUsage_Sum { /* From RFC 5280 */
     EKU_TIMESTAMP_OID   = 78,  /* 1.3.6.1.5.5.7.3.8, id-kp-timeStamping    */
     EKU_OCSP_SIGN_OID   = 79,  /* 1.3.6.1.5.5.7.3.9, id-kp-OCSPSigning     */
 
-    /* From RFC 6187: X.509v3 Certificates for Secure Shell Authenticaiton */
+    /* From RFC 6187: X.509v3 Certificates for Secure Shell Authentication */
     EKU_SSH_CLIENT_AUTH_OID    = ID_KP(21), /* id-kp-secureShellClient */
     EKU_SSH_MSCL_OID           = 264,
         /* 1.3.6.1.4.1.311.20.2.2, MS Smart Card Logon */

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -503,7 +503,7 @@ typedef struct Cert {
     void*   decodedCert;      /* internal DecodedCert allocated from heap */
     byte*   der;              /* Pointer to buffer of current DecodedCert cache */
     void*   heap;             /* heap hint */
-    byte    basicConstSet:1;  /* Indicator for when Basic Constaint is set */
+    byte    basicConstSet:1;  /* Indicator for when Basic Constraint is set */
     byte    pathLenSet:1;     /* Indicator for when path length is set */
 #ifdef WOLFSSL_ALT_NAMES
     byte    altNamesCrit:1;   /* Indicator of criticality of SAN extension */

--- a/wolfssl/wolfcrypt/dsa.h
+++ b/wolfssl/wolfcrypt/dsa.h
@@ -56,8 +56,8 @@ enum {
     /* 160 bit q length */
     DSA_160_HALF_SIZE = 20,            /* r and s size  */
     DSA_160_SIG_SIZE  = 40,            /* signature size */
-    DSA_HALF_SIZE = DSA_160_HALF_SIZE, /* kept for compatiblity  */
-    DSA_SIG_SIZE = DSA_160_SIG_SIZE,   /* kept for compatiblity */
+    DSA_HALF_SIZE = DSA_160_HALF_SIZE, /* kept for compatibility  */
+    DSA_SIG_SIZE = DSA_160_SIG_SIZE,   /* kept for compatibility */
     /* 256 bit q length */
     DSA_256_HALF_SIZE = 32,            /* r and s size  */
     DSA_256_SIG_SIZE  = 64,            /* signature size */

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2697,7 +2697,7 @@ extern void uITRON4_free(void *p) ;
     #define NO_SESSION_CACHE
 #endif
 
-/* Use static ECC structs for Position Independant Code (PIC) */
+/* Use static ECC structs for Position Independent Code (PIC) */
 #if defined(__IAR_SYSTEMS_ICC__) && defined(__ROPI__)
     #define WOLFSSL_ECC_CURVE_STATIC
     #define WOLFSSL_NAMES_STATIC
@@ -2914,7 +2914,7 @@ extern void uITRON4_free(void *p) ;
 
 
 /* ---------------------------------------------------------------------------
- * Depricated Algorithm Handling
+ * Deprecated Algorithm Handling
  *   Unless allowed via a build macro, disable support
  * ---------------------------------------------------------------------------*/
 

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -449,7 +449,7 @@ typedef struct sp_ecc_ctx {
     /* Maximum value of partial in mul/sqr. */
     #define SP_MUL_SQR_MAX_PARTIAL  \
                                  (SP_MUL_SQR_DIGITS * ((1 << SP_WORD_SIZE) - 1))
-    /* Maximim value in an sp_int_word. */
+    /* Maximum value in an sp_int_word. */
     #define SP_INT_WORD_MAX         ((1 << (SP_WORD_SIZE * 2)) - 1)
 
     #if SP_MUL_SQR_MAX_PARTIAL > SP_INT_WORD_MAX
@@ -732,9 +732,9 @@ typedef struct sp_ecc_ctx {
  * completion.
  */
 #define FP_WOULDBLOCK   (-4)
-/* Unused error. Defined for backward compatability. */
+/* Unused error. Defined for backward compatibility. */
 #define MP_NOT_INF      (-5)
-/* Unused error. Defined for backward compatability. */
+/* Unused error. Defined for backward compatibility. */
 #define MP_RANGE        MP_NOT_INF
 
 #ifdef USE_FAST_MATH


### PR DESCRIPTION
# Description

Spelling cleanup for obvious typos in `src/*` and `wolfssl/*`.
