### PR TITLE
Fix memory leak

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -12220,6 +12220,8 @@ static int ProcessCSR(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 
     *inOutIdx += status_length;
 
+    FreeOcspResponse(response);
+
     #ifdef WOLFSSL_SMALL_STACK
         XFREE(status,   ssl->heap, DYNAMIC_TYPE_OCSP_STATUS);
         XFREE(single,   ssl->heap, DYNAMIC_TYPE_OCSP_ENTRY);


### PR DESCRIPTION
# Description
There was a memory leak when we don't clean up locally allocated variables from the heap. This is a solution to https://wolfssl.zendesk.com/agent/tickets/15705.