### PR TITLE
Allow building of sakke as external non-FIPS algorithm with wolfmikey product

### DIFF
--- a/src/include.am
+++ b/src/include.am
@@ -612,12 +612,13 @@ if !BUILD_FIPS_CURRENT
 if BUILD_ECC
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/ecc.c
 endif
+endif
+
 if BUILD_ECCSI
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/eccsi.c
 endif
 if BUILD_SAKKE
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sakke.c
-endif
 endif
 
 if !BUILD_FIPS_CURRENT


### PR DESCRIPTION
# Description

This modification allows for compiling the wolfmikey product w/ the FIPS 140-3 solution. Sakke is an external, non-FIPS certifiable algorithm and as such is beyond scope of the FIPS validated module (like ed/curve 25519). As such users of FIPS and wolfmikey should disclose to their customers that Sakke is a non-FIPS certified algorithm until such time as the CAVP adds testing for it.

This change is on behalf of customers that sell to U.S. and/or Canadian federal programs in addition to UK based programs or other programs that need to meet NCSC (National Cyber Security Centre) Mikey-Sakke requirements (https://www.ncsc.gov.uk/guidance/mikey-sakke-frequently-asked-questions)
 
# Testing

[How did you test?](https://github.com/wolfSSL/wolfmikey/pull/4)

# Checklist

 - [X] added tests
 - [ ] updated/added doxygen
 - [X] updated appropriate READMEs
 - [ ] Updated manual and documentation
