### PR TITLE
zd15423 - Update AES-GCM stream initialization to support long IV values

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -470,7 +470,6 @@ static int testDevId = INVALID_DEVID;
 /*----------------------------------------------------------------------------*
  | Setup
  *----------------------------------------------------------------------------*/
-
 static int test_wolfSSL_Init(void)
 {
     int result;
@@ -1058,7 +1057,6 @@ static int test_wolfSSL_CTX_set_cipher_list_bytes(void)
 
     return res;
 }
-
 
 static int test_wolfSSL_CTX_use_certificate_file(void)
 {
@@ -18350,10 +18348,12 @@ static int test_wc_AesGcmMixedEncDecLongIV(void)
     };
 
     Aes     aesEnc, aesDec;
-    byte    iv[]  = "1234567890abcdefghij";
+    byte    iv[]  = "123456789abcdefghij"; /* 160-bit IV (string+NULL) */
     byte    out[sizeof(in)];
     byte    plain[sizeof(in)];
     byte    tag[AES_BLOCK_SIZE];
+    int     i;
+    int     incSz = 2;
 
     XMEMSET(out, 0, sizeof(out));
     XMEMSET(plain, 0, sizeof(plain));
@@ -18368,8 +18368,14 @@ static int test_wc_AesGcmMixedEncDecLongIV(void)
     /* Perform streaming decryption using long IV */
     AssertIntEQ(wc_AesInit(&aesDec, NULL, INVALID_DEVID), 0);
     AssertIntEQ(wc_AesGcmInit(&aesDec, key, sizeof(key), iv, sizeof(iv)), 0);
-    AssertIntEQ(wc_AesGcmDecryptUpdate(&aesDec, plain, out, sizeof(out), aad,
-                                       sizeof(aad)), 0);
+    for (i = 0; i < (int)sizeof(aad); i += incSz) {
+        AssertIntEQ(wc_AesGcmDecryptUpdate(&aesDec, NULL, NULL, 0, aad + i, incSz),
+            0);
+    }
+    for (i = 0; i < (int)sizeof(out); i += incSz) {
+        AssertIntEQ(wc_AesGcmDecryptUpdate(&aesDec, plain + i, out + i, incSz, NULL,
+                                           0), 0);
+    }
     AssertIntEQ(wc_AesGcmDecryptFinal(&aesDec, tag, sizeof(tag)), 0);
     AssertIntEQ(XMEMCMP(plain, in, sizeof(in)), 0);
 
@@ -18384,6 +18390,80 @@ static int test_wc_AesGcmMixedEncDecLongIV(void)
     return ret;
 
 } /* END wc_AesGcmMixedEncDecLongIV */
+
+/*
+ * test function for mixed (one-shot encrpytion + stream decryption) AES GCM
+ * using a short IV.
+ */
+static int test_wc_AesGcmMixedEncDecShortIV(void)
+{
+    int ret = TEST_SKIPPED;
+
+#if  (!defined(HAVE_FIPS) || \
+      (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2))) && \
+     !defined(NO_AES) && defined(HAVE_AESGCM) && defined(WOLFSSL_AESGCM_STREAM)
+
+    const byte key[] = {
+        0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+        0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66,
+        0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+        0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66
+    };
+
+    const byte in[] = {
+        0x4e,0x6f,0x77,0x20,0x69,0x73,0x20,0x74,
+        0x68,0x65,0x20,0x74,0x69,0x6d,0x65,0x20,
+        0x66,0x6f,0x72,0x20,0x61,0x6c,0x6c,0x20
+    };
+
+    const byte aad[] = {
+        0xfe, 0xed, 0xfa, 0xce, 0xde, 0xad, 0xbe, 0xef,
+        0xfe, 0xed, 0xfa, 0xce, 0xde, 0xad, 0xbe, 0xef,
+        0xab, 0xad, 0xda, 0xd2
+    };
+
+    Aes     aesEnc, aesDec;
+    byte    iv[]  = "1234567"; /* 64-bit IV (string+NULL) */
+    byte    out[sizeof(in)];
+    byte    plain[sizeof(in)];
+    byte    tag[AES_BLOCK_SIZE];
+    int     i;
+
+    XMEMSET(out, 0, sizeof(out));
+    XMEMSET(plain, 0, sizeof(plain));
+    XMEMSET(tag, 0, sizeof(tag));
+
+    /* Perform one-shot encryption using short IV */
+    AssertIntEQ(wc_AesInit(&aesEnc, NULL, INVALID_DEVID), 0);
+    AssertIntEQ(wc_AesGcmSetKey(&aesEnc, key, sizeof(key)), 0);
+    AssertIntEQ(wc_AesGcmEncrypt(&aesEnc, out, in, sizeof(in), iv, sizeof(iv),
+                                 tag, sizeof(tag), aad, sizeof(aad)), 0);
+
+    /* Perform streaming decryption using short IV */
+    AssertIntEQ(wc_AesInit(&aesDec, NULL, INVALID_DEVID), 0);
+    AssertIntEQ(wc_AesGcmInit(&aesDec, key, sizeof(key), iv, sizeof(iv)), 0);
+    for (i = 0; i < (int)sizeof(aad); i++) {
+        AssertIntEQ(wc_AesGcmDecryptUpdate(&aesDec, NULL, NULL, 0, aad + i, 1),
+            0);
+    }
+    for (i = 0; i < (int)sizeof(out); i++) {
+        AssertIntEQ(wc_AesGcmDecryptUpdate(&aesDec, plain + i, out + i, 1, NULL,
+                                           0), 0);
+    }
+    AssertIntEQ(wc_AesGcmDecryptFinal(&aesDec, tag, sizeof(tag)), 0);
+    AssertIntEQ(XMEMCMP(plain, in, sizeof(in)), 0);
+
+    /* Free resources */
+    wc_AesFree(&aesEnc);
+    wc_AesFree(&aesDec);
+
+    ret = TEST_SUCCESS;
+
+#endif
+
+    return ret;
+
+} /* END wc_AesGcmMixedEncDecShortIV */
 
 /*
  * unit test for wc_GmacSetKey()
@@ -62713,6 +62793,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wc_AesGcmSetKey),
     TEST_DECL(test_wc_AesGcmEncryptDecrypt),
     TEST_DECL(test_wc_AesGcmMixedEncDecLongIV),
+    TEST_DECL(test_wc_AesGcmMixedEncDecShortIV),
     TEST_DECL(test_wc_GmacSetKey),
     TEST_DECL(test_wc_GmacUpdate),
     TEST_DECL(test_wc_InitRsaKey),


### PR DESCRIPTION
# **NOTE:** This PR is for WIP code to solicit feedback on the solution!  It contains development code (marked with `TWW`) which will be removed or properly integrated before the solution is opened as an official PR!

# Description

**Fixes** [zd#15423](https://wolfssl.zendesk.com/agent/tickets/15423)

Update the `wc_AesGcmInit()` function to accept long (more than 16-byte) IV values. 

# Testing
The following tests pass/run successfully:
* `unit.tests` (with added testing related to the zd15423 use case)
* `testwolfcrypt`
* `wolfcrypt/benchmark/benchmark`
... Built and run in the following configurations:
* zd15423 config (derived from crypto-fuzz test which found the problem):
```
./configure --enable-static --enable-md2 --enable-md4 --enable-ripemd \      
                   --enable-blake2 --enable-blake2s --enable-pwdbased --enable-scrypt \
                   --enable-hkdf --enable-cmac --enable-arc4 --enable-camellia \    
                   --enable-aesccm --enable-aesctr --enable-xts --enable-des3 \     
                  --enable-x963kdf --enable-harden --enable-aescfb --enable-aesofb \
                  --enable-aeskeywrap --enable-aessiv --enable-aesgcm-stream \     
                  --enable-keygen --enable-curve25519 --enable-curve448 \          
                  --enable-shake256 --enable-shake128 --disable-crypttests \       
                  --disable-examples --enable-compkey --enable-ed448 \             
                  --enable-ed25519 --enable-ecccustcurves --enable-xchacha \       
                  --enable-siphash --enable-cryptocb --enable-eccencrypt \         
                  --enable-smallstack --enable-ed25519-stream --enable-ed448-stream \
                  --enable-examples --enable-crypttests --enable-debug \           
                  CFLAGS="$CFLAGS -O0 -g -DHAVE_AES_ECB -DWOLFSSL_DES_ECB -DHAVE_ECC_SECPR2 -DHAVE_ECC_SECPR3 -DHAVE_ECC_BRAINPOOL -DHAVE_ECC_KOBLITZ -DWOLFSSL_ECDSA_SET_K -DWOLFSSL_ECDSA_SET_K_ONE_LOOP
```
* AESNI configuration on x64 target:
```
./configure --enable-aesgcm --enable-aesgcm-stream --enable-intelasm \       
                  --enable-aesni --enable-sp-math-all --enable-sp-asm --enable-debug \
                  CFLAGS="$CFLAGS -O0 -g"    
```


