### PR TITLE
Fix ASN1_STRING leak in create_by_NID and create_by_txt

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -11125,6 +11125,11 @@ err:
                                             dataSz) == WOLFSSL_SUCCESS) {
                     ne->set = 1;
                 }
+                else {
+                    /* Free the ASN1_STRING if it is not set. */
+                    wolfSSL_ASN1_STRING_free(ne->value);
+                    ne->value = NULL;
+                }
             }
         }
 
@@ -11173,6 +11178,11 @@ err:
             if (wolfSSL_ASN1_STRING_set(ne->value, (const void*)data, dataSz)
                     == WOLFSSL_SUCCESS) {
                 ne->set = 1;
+            }
+            else {
+                /* Free the ASN1_STRING if it is not set. */
+                wolfSSL_ASN1_STRING_free(ne->value);
+                ne->value = NULL;
             }
         }
 


### PR DESCRIPTION
# Description

The functions `wolfSSL_X509_NAME_ENTRY_create_by_NID()` and `wolfSSL_X509_NAME_ENTRY_create_by_txt()` could leak an `ASN1_STRING`.

If `wolfSSL_ASN1_STRING_set()` failed, the name entry would not be set, but `ne->value` wouldn't be freed either. This meant subsequent calls would find the unset entry and overwrite the `ASN1_STRING` pointer with
```
ne->value = wolfSSL_ASN1_STRING_type_new(type);
```

This commit frees the `ASN1_STRING` if setting the string fails.

Fixes zd#15693

# Testing

Tested with reproducer in zd ticket, which used custom memory allocators to simulate random malloc failures.
