### PR TITLE
Adding support for indefinite length PKCS12

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -9672,6 +9672,9 @@ static int test_wolfSSL_PKCS12(void)
     AssertNotNull(pkey);
     AssertNotNull(cert);
 
+    wolfSSL_EVP_PKEY_free(pkey);
+    wolfSSL_X509_free(cert);
+
     /* check parse with extra certs kept */
     ret = PKCS12_parse(pkcs12, "wolfSSL test", &pkey, &cert, &ca);
     AssertIntEQ(ret, WOLFSSL_SUCCESS);

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -156,11 +156,14 @@ static void freeSafe(AuthenticatedSafe* safe, void* heap)
         ContentInfo* ci = safe->CI;
         safe->CI = ci->next;
         XFREE(ci, heap, DYNAMIC_TYPE_PKCS);
+        ci = NULL;
     }
     if (safe->data != NULL) {
         XFREE(safe->data, heap, DYNAMIC_TYPE_PKCS);
+        safe->data = NULL;
     }
     XFREE(safe, heap, DYNAMIC_TYPE_PKCS);
+    safe = NULL;
 
     (void)heap;
 }
@@ -207,6 +210,7 @@ void wc_PKCS12_free(WC_PKCS12* pkcs12)
 #endif
 
     XFREE(pkcs12, NULL, DYNAMIC_TYPE_PKCS);
+    pkcs12 = NULL;
 }
 
 


### PR DESCRIPTION
# Description

Adds the ability to parse indefinite length PKCS12 with `--enable-indef`.

Fixes zd#15355

# Testing

Tested using various BER encoded pfx files customers have provided to zendesk.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
