### PR TITLE
20230303-fix-c89-etc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8716,7 +8716,7 @@ esac
 
 rm cyassl/options.h.bak
 
-if test "$ENABLED_OPENSSLEXTRA" = "yes"
+if test "$ENABLED_OPENSSLEXTRA" = "yes" && test "$ENABLED_LINUXKM" = "no"
 then
     SAVE_CFLAGS=$CFLAGS
     CFLAGS="$CFLAGS -I$srcdir"

--- a/configure.ac
+++ b/configure.ac
@@ -8721,7 +8721,7 @@ if test "$ENABLED_OPENSSLEXTRA" = "yes"
 then
     SAVE_CFLAGS=$CFLAGS
     CFLAGS="$CFLAGS -I$srcdir"
-    for header in wolfssl/openssl/*.h
+    for header in "${srcdir}"/wolfssl/openssl/*.h
     do
         AC_CHECK_HEADER([$header], [], [
                 AC_MSG_ERROR([Error including $header. Possible circular dependency introduced or missing include.])

--- a/configure.ac
+++ b/configure.ac
@@ -6348,7 +6348,6 @@ AC_ARG_ENABLE([examples],
     )
 
 AS_IF([test "x$ENABLED_FILESYSTEM" = "xno"], [ENABLED_EXAMPLES="no"])
-AS_IF([test "x$ENABLED_INLINE" = "xno"], [ENABLED_EXAMPLES="no"])
 AS_IF([test "x$ENABLED_CRYPTONLY" = "xyes"], [ENABLED_EXAMPLES="no"])
 
 

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -234,6 +234,16 @@ static int wolfssl_init(void)
             "] POST succeeded.\n");
 #endif /* HAVE_FIPS */
 
+#ifdef WC_RNG_SEED_CB
+    ret = wc_SetSeed_Cb(wc_GenerateSeed);
+    if (ret < 0) {
+        pr_err("wc_SetSeed_Cb() failed with return code %d.\n", ret);
+        (void)libwolfssl_cleanup();
+        msleep(10);
+        return -ECANCELED;
+    }
+#endif
+
 #ifdef WOLFCRYPT_ONLY
     ret = wolfCrypt_Init();
     if (ret != 0) {
@@ -249,14 +259,7 @@ static int wolfssl_init(void)
 #endif
 
 #ifndef NO_CRYPT_TEST
-
-#ifdef WC_RNG_SEED_CB
-    ret = wc_SetSeed_Cb(wc_GenerateSeed);
-    if (ret == 0)
-#endif
-    {
-        ret = wolfcrypt_test(NULL);
-    }
+    ret = wolfcrypt_test(NULL);
     if (ret < 0) {
         pr_err("wolfcrypt self-test failed with return code %d.\n", ret);
         (void)libwolfssl_cleanup();

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -10728,7 +10728,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PrivateKey_id(int type, WOLFSSL_EVP_PKEY** out,
 }
 #endif /* WOLF_PRIVATE_KEY_ID */
 
-#ifndef NO_CERTS // NOLINT(readability-redundant-preprocessor)
+#ifndef NO_CERTS /* // NOLINT(readability-redundant-preprocessor) */
 
 #ifndef NO_CHECK_PRIVATE_KEY
 /* Check private against public in certificate for match
@@ -40933,7 +40933,8 @@ int wolfSSL_i2d_PKCS7(PKCS7 *p7, unsigned char **out)
             WOLFSSL_MSG("wc_InitRng error");
             return WOLFSSL_FAILURE;
         }
-        p7->rng = &rng; // cppcheck-suppress autoVariables
+        p7->rng = &rng; /* cppcheck-suppress autoVariables
+                         */
     }
 
     if ((len = wc_PKCS7_EncodeSignedData(p7, NULL, 0)) < 0) {

--- a/tests/api.c
+++ b/tests/api.c
@@ -53420,12 +53420,12 @@ static int test_wolfSSL_i2c_ASN1_INTEGER(void)
     return res;
 }
 
-#ifndef NO_INLINE
+/* include misc.c here regardless of NO_INLINE, because misc.c implementations
+ * have default (hidden) visibility, and in the absence of visibility, it's
+ * benign to mask out the library implementation.
+ */
 #define WOLFSSL_MISC_INCLUDED
 #include <wolfcrypt/src/misc.c>
-#else
-#include <wolfssl/wolfcrypt/misc.h>
-#endif
 
 static int test_ForceZero(void)
 {

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -43,12 +43,6 @@ masking and clearing memory logic.
    a source header
  */
 
-#ifdef NO_INLINE
-    #define WC_STATIC
-#else
-    #define WC_STATIC static
-#endif
-
 /* Check for if compiling misc.c when not needed. */
 #if !defined(WOLFSSL_MISC_INCLUDED) && !defined(NO_INLINE)
     #ifndef WOLFSSL_IGNORE_FILE_WARN
@@ -71,12 +65,12 @@ masking and clearing memory logic.
      * i.e., _rotl and _rotr */
     #pragma intrinsic(_lrotl, _lrotr)
 
-    WC_STATIC WC_INLINE word32 rotlFixed(word32 x, word32 y)
+    WC_MISC_STATIC WC_INLINE word32 rotlFixed(word32 x, word32 y)
     {
         return y ? _lrotl(x, y) : x;
     }
 
-    WC_STATIC WC_INLINE word32 rotrFixed(word32 x, word32 y)
+    WC_MISC_STATIC WC_INLINE word32 rotrFixed(word32 x, word32 y)
     {
         return y ? _lrotr(x, y) : x;
     }
@@ -93,12 +87,12 @@ masking and clearing memory logic.
 
     #else /* create real function */
 
-    WC_STATIC WC_INLINE word32 rotlFixed(word32 x, word32 y)
+    WC_MISC_STATIC WC_INLINE word32 rotlFixed(word32 x, word32 y)
     {
         return _builtin_rotl(x, y);
     }
 
-    WC_STATIC WC_INLINE word32 rotrFixed(word32 x, word32 y)
+    WC_MISC_STATIC WC_INLINE word32 rotrFixed(word32 x, word32 y)
     {
         return _builtin_rotr(x, y);
     }
@@ -108,13 +102,13 @@ masking and clearing memory logic.
 #else /* generic */
 /* This routine performs a left circular arithmetic shift of <x> by <y> value. */
 
-    WC_STATIC WC_INLINE word32 rotlFixed(word32 x, word32 y)
+    WC_MISC_STATIC WC_INLINE word32 rotlFixed(word32 x, word32 y)
     {
         return (x << y) | (x >> (sizeof(y) * 8 - y));
     }
 
 /* This routine performs a right circular arithmetic shift of <x> by <y> value. */
-    WC_STATIC WC_INLINE word32 rotrFixed(word32 x, word32 y)
+    WC_MISC_STATIC WC_INLINE word32 rotrFixed(word32 x, word32 y)
     {
         return (x >> y) | (x << (sizeof(y) * 8 - y));
     }
@@ -124,14 +118,14 @@ masking and clearing memory logic.
 #ifdef WC_RC2
 
 /* This routine performs a left circular arithmetic shift of <x> by <y> value */
-WC_STATIC WC_INLINE word16 rotlFixed16(word16 x, word16 y)
+WC_MISC_STATIC WC_INLINE word16 rotlFixed16(word16 x, word16 y)
 {
     return (x << y) | (x >> (sizeof(y) * 8 - y));
 }
 
 
 /* This routine performs a right circular arithmetic shift of <x> by <y> value */
-WC_STATIC WC_INLINE word16 rotrFixed16(word16 x, word16 y)
+WC_MISC_STATIC WC_INLINE word16 rotrFixed16(word16 x, word16 y)
 {
     return (x >> y) | (x << (sizeof(y) * 8 - y));
 }
@@ -142,7 +136,7 @@ WC_STATIC WC_INLINE word16 rotrFixed16(word16 x, word16 y)
 #if defined(__CCRX__) && !defined(NO_INLINE) /* shortest version for CC-RX */
     #define ByteReverseWord32(value) _builtin_revl(value)
 #else
-WC_STATIC WC_INLINE word32 ByteReverseWord32(word32 value)
+WC_MISC_STATIC WC_INLINE word32 ByteReverseWord32(word32 value)
 {
 #ifdef PPC_INTRINSICS
     /* PPC: load reverse indexed instruction */
@@ -184,7 +178,7 @@ WC_STATIC WC_INLINE word32 ByteReverseWord32(word32 value)
 }
 #endif /* __CCRX__ */
 /* This routine performs a byte swap of words array of a given count. */
-WC_STATIC WC_INLINE void ByteReverseWords(word32* out, const word32* in,
+WC_MISC_STATIC WC_INLINE void ByteReverseWords(word32* out, const word32* in,
                                     word32 byteCount)
 {
     word32 count, i;
@@ -218,19 +212,19 @@ WC_STATIC WC_INLINE void ByteReverseWords(word32* out, const word32* in,
 #if defined(WORD64_AVAILABLE) && !defined(WOLFSSL_NO_WORD64_OPS)
 
 
-WC_STATIC WC_INLINE word64 rotlFixed64(word64 x, word64 y)
+WC_MISC_STATIC WC_INLINE word64 rotlFixed64(word64 x, word64 y)
 {
     return (x << y) | (x >> (sizeof(y) * 8 - y));
 }
 
 
-WC_STATIC WC_INLINE word64 rotrFixed64(word64 x, word64 y)
+WC_MISC_STATIC WC_INLINE word64 rotrFixed64(word64 x, word64 y)
 {
     return (x >> y) | (x << (sizeof(y) * 8 - y));
 }
 
 
-WC_STATIC WC_INLINE word64 ByteReverseWord64(word64 value)
+WC_MISC_STATIC WC_INLINE word64 ByteReverseWord64(word64 value)
 {
 #if defined(WOLF_ALLOW_BUILTIN) && defined(__GNUC_PREREQ) && __GNUC_PREREQ(4, 3)
     return (word64)__builtin_bswap64(value);
@@ -247,7 +241,7 @@ WC_STATIC WC_INLINE word64 ByteReverseWord64(word64 value)
 }
 
 
-WC_STATIC WC_INLINE void ByteReverseWords64(word64* out, const word64* in,
+WC_MISC_STATIC WC_INLINE void ByteReverseWords64(word64* out, const word64* in,
                                       word32 byteCount)
 {
     word32 count = byteCount/(word32)sizeof(word64), i;
@@ -262,8 +256,8 @@ WC_STATIC WC_INLINE void ByteReverseWords64(word64* out, const word64* in,
 #ifndef WOLFSSL_NO_XOR_OPS
 /* This routine performs a bitwise XOR operation of <*r> and <*a> for <n> number
 of wolfssl_words, placing the result in <*r>. */
-WC_STATIC WC_INLINE void XorWordsOut(wolfssl_word* r, const wolfssl_word* a,
-                                     const wolfssl_word* b, word32 n)
+WC_MISC_STATIC WC_INLINE void XorWordsOut(wolfssl_word* r,
+                         const wolfssl_word* a, const wolfssl_word* b, word32 n)
 {
     word32 i;
 
@@ -273,8 +267,8 @@ WC_STATIC WC_INLINE void XorWordsOut(wolfssl_word* r, const wolfssl_word* a,
 /* This routine performs a bitwise XOR operation of <*buf> and <*mask> of n
 counts, placing the result in <*buf>. */
 
-WC_STATIC WC_INLINE void xorbufout(void*out, const void* buf, const void* mask,
-                                   word32 count)
+WC_MISC_STATIC WC_INLINE void xorbufout(void*out, const void* buf,
+                                        const void* mask, word32 count)
 {
     if (((wc_ptr_t)out | (wc_ptr_t)buf | (wc_ptr_t)mask | count) %
                                                          WOLFSSL_WORD_SIZE == 0)
@@ -292,7 +286,8 @@ WC_STATIC WC_INLINE void xorbufout(void*out, const void* buf, const void* mask,
 
 /* This routine performs a bitwise XOR operation of <*r> and <*a> for <n> number
 of wolfssl_words, placing the result in <*r>. */
-WC_STATIC WC_INLINE void XorWords(wolfssl_word* r, const wolfssl_word* a, word32 n)
+WC_MISC_STATIC WC_INLINE void XorWords(wolfssl_word* r, const wolfssl_word* a,
+                                       word32 n)
 {
     word32 i;
 
@@ -302,7 +297,7 @@ WC_STATIC WC_INLINE void XorWords(wolfssl_word* r, const wolfssl_word* a, word32
 /* This routine performs a bitwise XOR operation of <*buf> and <*mask> of n
 counts, placing the result in <*buf>. */
 
-WC_STATIC WC_INLINE void xorbuf(void* buf, const void* mask, word32 count)
+WC_MISC_STATIC WC_INLINE void xorbuf(void* buf, const void* mask, word32 count)
 {
     if (((wc_ptr_t)buf | (wc_ptr_t)mask | count) % WOLFSSL_WORD_SIZE == 0)
         XorWords( (wolfssl_word*)buf,
@@ -320,7 +315,7 @@ WC_STATIC WC_INLINE void xorbuf(void* buf, const void* mask, word32 count)
 #ifndef WOLFSSL_NO_FORCE_ZERO
 /* This routine fills the first len bytes of the memory area pointed by mem
    with zeros. It ensures compiler optimizations doesn't skip it  */
-WC_STATIC WC_INLINE void ForceZero(void* mem, word32 len)
+WC_MISC_STATIC WC_INLINE void ForceZero(void* mem, word32 len)
 {
     volatile byte* z = (volatile byte*)mem;
 
@@ -347,7 +342,8 @@ WC_STATIC WC_INLINE void ForceZero(void* mem, word32 len)
 
 #ifndef WOLFSSL_NO_CONST_CMP
 /* check all length bytes for equality, return 0 on success */
-WC_STATIC WC_INLINE int ConstantCompare(const byte* a, const byte* b, int length)
+WC_MISC_STATIC WC_INLINE int ConstantCompare(const byte* a, const byte* b,
+                                             int length)
 {
     int i;
     int compareSum = 0;
@@ -367,7 +363,7 @@ WC_STATIC WC_INLINE int ConstantCompare(const byte* a, const byte* b, int length
         #define min min
     #endif
     /* returns the smaller of a and b */
-    WC_STATIC WC_INLINE word32 min(word32 a, word32 b)
+    WC_MISC_STATIC WC_INLINE word32 min(word32 a, word32 b)
     {
         return a > b ? b : a;
     }
@@ -378,7 +374,7 @@ WC_STATIC WC_INLINE int ConstantCompare(const byte* a, const byte* b, int length
     #if defined(HAVE_FIPS) && !defined(max) /* so ifdef check passes */
         #define max max
     #endif
-    WC_STATIC WC_INLINE word32 max(word32 a, word32 b)
+    WC_MISC_STATIC WC_INLINE word32 max(word32 a, word32 b)
     {
         return a > b ? a : b;
     }
@@ -386,7 +382,7 @@ WC_STATIC WC_INLINE int ConstantCompare(const byte* a, const byte* b, int length
 
 #ifndef WOLFSSL_NO_INT_ENCODE
 /* converts a 32 bit integer to 24 bit */
-WC_STATIC WC_INLINE void c32to24(word32 in, word24 out)
+WC_MISC_STATIC WC_INLINE void c32to24(word32 in, word24 out)
 {
     out[0] = (in >> 16) & 0xff;
     out[1] = (in >>  8) & 0xff;
@@ -394,14 +390,14 @@ WC_STATIC WC_INLINE void c32to24(word32 in, word24 out)
 }
 
 /* convert 16 bit integer to opaque */
-WC_STATIC WC_INLINE void c16toa(word16 wc_u16, byte* c)
+WC_MISC_STATIC WC_INLINE void c16toa(word16 wc_u16, byte* c)
 {
     c[0] = (wc_u16 >> 8) & 0xff;
     c[1] =  wc_u16 & 0xff;
 }
 
 /* convert 32 bit integer to opaque */
-WC_STATIC WC_INLINE void c32toa(word32 wc_u32, byte* c)
+WC_MISC_STATIC WC_INLINE void c32toa(word32 wc_u32, byte* c)
 {
     c[0] = (wc_u32 >> 24) & 0xff;
     c[1] = (wc_u32 >> 16) & 0xff;
@@ -412,38 +408,38 @@ WC_STATIC WC_INLINE void c32toa(word32 wc_u32, byte* c)
 
 #ifndef WOLFSSL_NO_INT_DECODE
 /* convert a 24 bit integer into a 32 bit one */
-WC_STATIC WC_INLINE void c24to32(const word24 wc_u24, word32* wc_u32)
+WC_MISC_STATIC WC_INLINE void c24to32(const word24 wc_u24, word32* wc_u32)
 {
     *wc_u32 = ((word32)wc_u24[0] << 16) | (wc_u24[1] << 8) | wc_u24[2];
 }
 
 
 /* convert opaque to 24 bit integer */
-WC_STATIC WC_INLINE void ato24(const byte* c, word32* wc_u24)
+WC_MISC_STATIC WC_INLINE void ato24(const byte* c, word32* wc_u24)
 {
     *wc_u24 = ((word32)c[0] << 16) | (c[1] << 8) | c[2];
 }
 
 /* convert opaque to 16 bit integer */
-WC_STATIC WC_INLINE void ato16(const byte* c, word16* wc_u16)
+WC_MISC_STATIC WC_INLINE void ato16(const byte* c, word16* wc_u16)
 {
     *wc_u16 = (word16) ((c[0] << 8) | (c[1]));
 }
 
 /* convert opaque to 32 bit integer */
-WC_STATIC WC_INLINE void ato32(const byte* c, word32* wc_u32)
+WC_MISC_STATIC WC_INLINE void ato32(const byte* c, word32* wc_u32)
 {
     *wc_u32 = ((word32)c[0] << 24) | ((word32)c[1] << 16) | (c[2] << 8) | c[3];
 }
 
 
-WC_STATIC WC_INLINE word32 btoi(byte b)
+WC_MISC_STATIC WC_INLINE word32 btoi(byte b)
 {
     return (word32)(b - 0x30);
 }
 #endif
 
-WC_STATIC WC_INLINE signed char HexCharToByte(char ch)
+WC_MISC_STATIC WC_INLINE signed char HexCharToByte(char ch)
 {
     signed char ret = (signed char)ch;
     if (ret >= '0' && ret <= '9')
@@ -457,14 +453,14 @@ WC_STATIC WC_INLINE signed char HexCharToByte(char ch)
     return ret;
 }
 
-WC_STATIC WC_INLINE char ByteToHex(byte in)
+WC_MISC_STATIC WC_INLINE char ByteToHex(byte in)
 {
     static const char kHexChar[] = { '0', '1', '2', '3', '4', '5', '6', '7',
                                      '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
     return (char)(kHexChar[in & 0xF]);
 }
 
-WC_STATIC WC_INLINE int ByteToHexStr(byte in, char* out)
+WC_MISC_STATIC WC_INLINE int ByteToHexStr(byte in, char* out)
 {
     if (out == NULL)
         return -1;
@@ -476,99 +472,99 @@ WC_STATIC WC_INLINE int ByteToHexStr(byte in, char* out)
 
 #ifndef WOLFSSL_NO_CT_OPS
 /* Constant time - mask set when a > b. */
-WC_STATIC WC_INLINE byte ctMaskGT(int a, int b)
+WC_MISC_STATIC WC_INLINE byte ctMaskGT(int a, int b)
 {
     return (byte)((((word32)a - b - 1) >> 31) - 1);
 }
 
 /* Constant time - mask set when a >= b. */
-WC_STATIC WC_INLINE byte ctMaskGTE(int a, int b)
+WC_MISC_STATIC WC_INLINE byte ctMaskGTE(int a, int b)
 {
     return (byte)((((word32)a - b    ) >> 31) - 1);
 }
 
 /* Constant time - mask set when a >= b. */
-WC_STATIC WC_INLINE int ctMaskIntGTE(int a, int b)
+WC_MISC_STATIC WC_INLINE int ctMaskIntGTE(int a, int b)
 {
     return (int)((((word32)a - b    ) >> 31) - 1);
 }
 
 /* Constant time - mask set when a < b. */
-WC_STATIC WC_INLINE byte ctMaskLT(int a, int b)
+WC_MISC_STATIC WC_INLINE byte ctMaskLT(int a, int b)
 {
     return (byte)((((word32)b - a - 1) >> 31) - 1);
 }
 
 /* Constant time - mask set when a <= b. */
-WC_STATIC WC_INLINE byte ctMaskLTE(int a, int b)
+WC_MISC_STATIC WC_INLINE byte ctMaskLTE(int a, int b)
 {
     return (byte)((((word32)b - a    ) >> 31) - 1);
 }
 
 /* Constant time - mask set when a == b. */
-WC_STATIC WC_INLINE byte ctMaskEq(int a, int b)
+WC_MISC_STATIC WC_INLINE byte ctMaskEq(int a, int b)
 {
     return (byte)(~ctMaskGT(a, b)) & (byte)(~ctMaskLT(a, b));
 }
 
 /* Constant time - sets 16 bit integer mask when a > b */
-WC_STATIC WC_INLINE word16 ctMask16GT(int a, int b)
+WC_MISC_STATIC WC_INLINE word16 ctMask16GT(int a, int b)
 {
     return (word16)((((word32)a - b - 1) >> 31) - 1);
 }
 
 /* Constant time - sets 16 bit integer mask when a >= b */
-WC_STATIC WC_INLINE word16 ctMask16GTE(int a, int b)
+WC_MISC_STATIC WC_INLINE word16 ctMask16GTE(int a, int b)
 {
     return (word16)((((word32)a - b    ) >> 31) - 1);
 }
 
 /* Constant time - sets 16 bit integer mask when a < b. */
-WC_STATIC WC_INLINE word16 ctMask16LT(int a, int b)
+WC_MISC_STATIC WC_INLINE word16 ctMask16LT(int a, int b)
 {
     return (word16)((((word32)b - a - 1) >> 31) - 1);
 }
 
 /* Constant time - sets 16 bit integer mask when a <= b. */
-WC_STATIC WC_INLINE word16 ctMask16LTE(int a, int b)
+WC_MISC_STATIC WC_INLINE word16 ctMask16LTE(int a, int b)
 {
     return (word16)((((word32)b - a    ) >> 31) - 1);
 }
 
 /* Constant time - sets 16 bit integer mask when a == b. */
-WC_STATIC WC_INLINE word16 ctMask16Eq(int a, int b)
+WC_MISC_STATIC WC_INLINE word16 ctMask16Eq(int a, int b)
 {
     return (word16)(~ctMask16GT(a, b)) & (word16)(~ctMask16LT(a, b));
 }
 
 /* Constant time - mask set when a != b. */
-WC_STATIC WC_INLINE byte ctMaskNotEq(int a, int b)
+WC_MISC_STATIC WC_INLINE byte ctMaskNotEq(int a, int b)
 {
     return (byte)ctMaskGT(a, b) | (byte)ctMaskLT(a, b);
 }
 
 /* Constant time - select a when mask is set and b otherwise. */
-WC_STATIC WC_INLINE byte ctMaskSel(byte m, byte a, byte b)
+WC_MISC_STATIC WC_INLINE byte ctMaskSel(byte m, byte a, byte b)
 {
     return (byte)((b & ((byte)~(word32)m)) | (a & m));
 }
 
 /* Constant time - select integer a when mask is set and integer b otherwise. */
-WC_STATIC WC_INLINE int ctMaskSelInt(byte m, int a, int b)
+WC_MISC_STATIC WC_INLINE int ctMaskSelInt(byte m, int a, int b)
 {
     return (b & (~(signed int)(signed char)m)) |
            (a & ( (signed int)(signed char)m));
 }
 
 /* Constant time - bit set when a <= b. */
-WC_STATIC WC_INLINE byte ctSetLTE(int a, int b)
+WC_MISC_STATIC WC_INLINE byte ctSetLTE(int a, int b)
 {
     return (byte)(((word32)a - b - 1) >> 31);
 }
 
 /* Constant time - conditionally copy size bytes from src to dst if mask is set
  */
-WC_STATIC WC_INLINE void ctMaskCopy(byte mask, byte* dst, byte* src,
+WC_MISC_STATIC WC_INLINE void ctMaskCopy(byte mask, byte* dst, byte* src,
     word16 size)
 {
     int i;
@@ -581,31 +577,32 @@ WC_STATIC WC_INLINE void ctMaskCopy(byte mask, byte* dst, byte* src,
 
 #if defined(WOLFSSL_W64_WRAPPER)
 #if defined(WORD64_AVAILABLE) && !defined(WOLFSSL_W64_WRAPPER_TEST)
-WC_STATIC WC_INLINE void w64Increment(w64wrapper *n) {
+WC_MISC_STATIC WC_INLINE void w64Increment(w64wrapper *n) {
     n->n++;
 }
 
-WC_STATIC WC_INLINE void w64Decrement(w64wrapper *n) {
+WC_MISC_STATIC WC_INLINE void w64Decrement(w64wrapper *n) {
     n->n--;
 }
 
-WC_STATIC WC_INLINE byte w64Equal(w64wrapper a, w64wrapper b) {
+WC_MISC_STATIC WC_INLINE byte w64Equal(w64wrapper a, w64wrapper b) {
     return (a.n == b.n);
 }
 
-WC_STATIC WC_INLINE word32 w64GetLow32(w64wrapper n) {
+WC_MISC_STATIC WC_INLINE word32 w64GetLow32(w64wrapper n) {
     return (word32)n.n;
 }
 
-WC_STATIC WC_INLINE word32 w64GetHigh32(w64wrapper n) {
+WC_MISC_STATIC WC_INLINE word32 w64GetHigh32(w64wrapper n) {
     return (word32)(n.n >> 32);
 }
 
-WC_STATIC WC_INLINE void w64SetLow32(w64wrapper *n, word32 low) {
+WC_MISC_STATIC WC_INLINE void w64SetLow32(w64wrapper *n, word32 low) {
     n->n = (n->n & (~(word64)(0xffffffff))) | low;
 }
 
-WC_STATIC WC_INLINE w64wrapper w64Add32(w64wrapper a, word32 b, byte *wrap) {
+WC_MISC_STATIC WC_INLINE w64wrapper w64Add32(w64wrapper a, word32 b, byte *wrap)
+{
     a.n = a.n + b;
     if (a.n < b && wrap != NULL)
         *wrap = 1;
@@ -613,7 +610,7 @@ WC_STATIC WC_INLINE w64wrapper w64Add32(w64wrapper a, word32 b, byte *wrap) {
     return a;
 }
 
-WC_STATIC WC_INLINE w64wrapper w64Sub32(w64wrapper a, word32 b, byte *wrap)
+WC_MISC_STATIC WC_INLINE w64wrapper w64Sub32(w64wrapper a, word32 b, byte *wrap)
 {
     if (a.n < b && wrap != NULL)
         *wrap = 1;
@@ -621,17 +618,17 @@ WC_STATIC WC_INLINE w64wrapper w64Sub32(w64wrapper a, word32 b, byte *wrap)
     return a;
 }
 
-WC_STATIC WC_INLINE byte w64GT(w64wrapper a, w64wrapper b)
+WC_MISC_STATIC WC_INLINE byte w64GT(w64wrapper a, w64wrapper b)
 {
     return a.n > b.n;
 }
 
-WC_STATIC WC_INLINE byte w64IsZero(w64wrapper a)
+WC_MISC_STATIC WC_INLINE byte w64IsZero(w64wrapper a)
 {
     return a.n == 0;
 }
 
-WC_STATIC WC_INLINE void c64toa(const w64wrapper *a, byte *out)
+WC_MISC_STATIC WC_INLINE void c64toa(const w64wrapper *a, byte *out)
 {
 #ifdef BIG_ENDIAN_ORDER
     XMEMCPY(out, &a->n, sizeof(a->n));
@@ -642,7 +639,7 @@ WC_STATIC WC_INLINE void c64toa(const w64wrapper *a, byte *out)
 #endif /* BIG_ENDIAN_ORDER */
 }
 
-WC_STATIC WC_INLINE void ato64(const byte *in, w64wrapper *w64)
+WC_MISC_STATIC WC_INLINE void ato64(const byte *in, w64wrapper *w64)
 {
 #ifdef BIG_ENDIAN_ORDER
     XMEMCPY(&w64->n, in, sizeof(w64->n));
@@ -653,67 +650,67 @@ WC_STATIC WC_INLINE void ato64(const byte *in, w64wrapper *w64)
 #endif /* BIG_ENDIAN_ORDER */
 }
 
-WC_STATIC WC_INLINE w64wrapper w64From32(word32 hi, word32 lo)
+WC_MISC_STATIC WC_INLINE w64wrapper w64From32(word32 hi, word32 lo)
 {
     w64wrapper ret;
     ret.n = ((word64)hi << 32) | lo;
     return ret;
 }
 
-WC_STATIC WC_INLINE byte w64GTE(w64wrapper a, w64wrapper b)
+WC_MISC_STATIC WC_INLINE byte w64GTE(w64wrapper a, w64wrapper b)
 {
     return a.n >= b.n;
 }
 
-WC_STATIC WC_INLINE byte w64LT(w64wrapper a, w64wrapper b)
+WC_MISC_STATIC WC_INLINE byte w64LT(w64wrapper a, w64wrapper b)
 {
     return a.n < b.n;
 }
 
-WC_STATIC WC_INLINE w64wrapper w64Sub(w64wrapper a, w64wrapper b)
+WC_MISC_STATIC WC_INLINE w64wrapper w64Sub(w64wrapper a, w64wrapper b)
 {
     a.n -= b.n;
     return a;
 }
 
-WC_STATIC WC_INLINE void w64Zero(w64wrapper *a)
+WC_MISC_STATIC WC_INLINE void w64Zero(w64wrapper *a)
 {
     a->n = 0;
 }
 
 #else
-WC_STATIC WC_INLINE void w64Increment(w64wrapper *n)
+WC_MISC_STATIC WC_INLINE void w64Increment(w64wrapper *n)
 {
     n->n[1]++;
     if (n->n[1] == 0)
         n->n[0]++;
 }
 
-WC_STATIC WC_INLINE void w64Decrement(w64wrapper *n) {
+WC_MISC_STATIC WC_INLINE void w64Decrement(w64wrapper *n) {
     if (n->n[1] == 0)
         n->n[0]--;
     n->n[1]--;
 }
 
-WC_STATIC WC_INLINE byte w64Equal(w64wrapper a, w64wrapper b)
+WC_MISC_STATIC WC_INLINE byte w64Equal(w64wrapper a, w64wrapper b)
 {
     return (a.n[0] == b.n[0] && a.n[1] == b.n[1]);
 }
 
-WC_STATIC WC_INLINE word32 w64GetLow32(w64wrapper n) {
+WC_MISC_STATIC WC_INLINE word32 w64GetLow32(w64wrapper n) {
     return n.n[1];
 }
 
-WC_STATIC WC_INLINE word32 w64GetHigh32(w64wrapper n) {
+WC_MISC_STATIC WC_INLINE word32 w64GetHigh32(w64wrapper n) {
     return n.n[0];
 }
 
-WC_STATIC WC_INLINE void w64SetLow32(w64wrapper *n, word32 low)
+WC_MISC_STATIC WC_INLINE void w64SetLow32(w64wrapper *n, word32 low)
 {
     n->n[1] = low;
 }
 
-WC_STATIC WC_INLINE w64wrapper w64Add32(w64wrapper a, word32 b, byte *wrap)
+WC_MISC_STATIC WC_INLINE w64wrapper w64Add32(w64wrapper a, word32 b, byte *wrap)
 {
     a.n[1] = a.n[1] + b;
     if (a.n[1] < b) {
@@ -725,7 +722,7 @@ WC_STATIC WC_INLINE w64wrapper w64Add32(w64wrapper a, word32 b, byte *wrap)
     return a;
 }
 
-WC_STATIC WC_INLINE w64wrapper w64Sub32(w64wrapper a, word32 b, byte *wrap)
+WC_MISC_STATIC WC_INLINE w64wrapper w64Sub32(w64wrapper a, word32 b, byte *wrap)
 {
     byte _underflow = 0;
     if (a.n[1] < b)
@@ -741,7 +738,7 @@ WC_STATIC WC_INLINE w64wrapper w64Sub32(w64wrapper a, word32 b, byte *wrap)
     return a;
 }
 
-WC_STATIC WC_INLINE w64wrapper w64Sub(w64wrapper a, w64wrapper b)
+WC_MISC_STATIC WC_INLINE w64wrapper w64Sub(w64wrapper a, w64wrapper b)
 {
     if (a.n[1] < b.n[1])
         a.n[0]--;
@@ -750,12 +747,12 @@ WC_STATIC WC_INLINE w64wrapper w64Sub(w64wrapper a, w64wrapper b)
     return a;
 }
 
-WC_STATIC WC_INLINE void w64Zero(w64wrapper *a)
+WC_MISC_STATIC WC_INLINE void w64Zero(w64wrapper *a)
 {
     a->n[0] = a->n[1] = 0;
 }
 
-WC_STATIC WC_INLINE byte w64GT(w64wrapper a, w64wrapper b)
+WC_MISC_STATIC WC_INLINE byte w64GT(w64wrapper a, w64wrapper b)
 {
     if (a.n[0] > b.n[0])
         return 1;
@@ -764,7 +761,7 @@ WC_STATIC WC_INLINE byte w64GT(w64wrapper a, w64wrapper b)
     return 0;
 }
 
-WC_STATIC WC_INLINE byte w64GTE(w64wrapper a, w64wrapper b)
+WC_MISC_STATIC WC_INLINE byte w64GTE(w64wrapper a, w64wrapper b)
 {
     if (a.n[0] > b.n[0])
         return 1;
@@ -773,12 +770,12 @@ WC_STATIC WC_INLINE byte w64GTE(w64wrapper a, w64wrapper b)
     return 0;
 }
 
-WC_STATIC WC_INLINE byte w64IsZero(w64wrapper a)
+WC_MISC_STATIC WC_INLINE byte w64IsZero(w64wrapper a)
 {
     return a.n[0] == 0 && a.n[1] == 0;
 }
 
-WC_STATIC WC_INLINE void c64toa(w64wrapper *a, byte *out)
+WC_MISC_STATIC WC_INLINE void c64toa(w64wrapper *a, byte *out)
 {
 #ifdef BIG_ENDIAN_ORDER
     word32 *_out = (word32*)(out);
@@ -790,7 +787,7 @@ WC_STATIC WC_INLINE void c64toa(w64wrapper *a, byte *out)
 #endif /* BIG_ENDIAN_ORDER */
 }
 
-WC_STATIC WC_INLINE void ato64(const byte *in, w64wrapper *w64)
+WC_MISC_STATIC WC_INLINE void ato64(const byte *in, w64wrapper *w64)
 {
 #ifdef BIG_ENDIAN_ORDER
     const word32 *_in = (const word32*)(in);
@@ -802,7 +799,7 @@ WC_STATIC WC_INLINE void ato64(const byte *in, w64wrapper *w64)
 #endif /* BIG_ENDIAN_ORDER */
 }
 
-WC_STATIC WC_INLINE w64wrapper w64From32(word32 hi, word32 lo)
+WC_MISC_STATIC WC_INLINE w64wrapper w64From32(word32 hi, word32 lo)
 {
     w64wrapper w64;
     w64.n[0] = hi;
@@ -810,7 +807,7 @@ WC_STATIC WC_INLINE w64wrapper w64From32(word32 hi, word32 lo)
     return w64;
 }
 
-WC_STATIC WC_INLINE byte w64LT(w64wrapper a, w64wrapper b)
+WC_MISC_STATIC WC_INLINE byte w64LT(w64wrapper a, w64wrapper b)
 {
     if (a.n[0] < b.n[0])
         return 1;
@@ -826,7 +823,7 @@ WC_STATIC WC_INLINE byte w64LT(w64wrapper a, w64wrapper b)
 #if defined(HAVE_SESSION_TICKET) || !defined(NO_CERTS) || \
     !defined(NO_SESSION_CACHE)
 /* Make a word from the front of random hash */
-WC_STATIC WC_INLINE word32 MakeWordFromHash(const byte* hashID)
+WC_MISC_STATIC WC_INLINE word32 MakeWordFromHash(const byte* hashID)
 {
     return ((word32)hashID[0] << 24) | ((word32)hashID[1] << 16) |
            ((word32)hashID[2] <<  8) |  (word32)hashID[3];
@@ -840,7 +837,8 @@ WC_STATIC WC_INLINE word32 MakeWordFromHash(const byte* hashID)
 #include <wolfssl/wolfcrypt/hash.h>
 
 /* some session IDs aren't random after all, let's make them random */
-WC_STATIC WC_INLINE word32 HashObject(const byte* o, word32 len, int* error)
+WC_MISC_STATIC WC_INLINE word32 HashObject(const byte* o, word32 len,
+                                           int* error)
 {
     byte digest[WC_MAX_DIGEST_SIZE];
 
@@ -858,8 +856,6 @@ WC_STATIC WC_INLINE word32 HashObject(const byte* o, word32 len, int* error)
 }
 #endif /* WOLFCRYPT_ONLY && !NO_HASH_WRAPPER &&
         * (!NO_SESSION_CACHE || HAVE_SESSION_TICKET) */
-
-#undef WC_STATIC
 
 #endif /* !WOLFSSL_MISC_INCLUDED && !NO_INLINE */
 

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -232,6 +232,9 @@
 
 #ifndef WOLFSSL_HAVE_MIN
     #define WOLFSSL_HAVE_MIN
+    #ifdef NO_INLINE
+        #define min no_inline_min
+    #endif
     static WC_INLINE word32 min(word32 a, word32 b)
     {
         return a > b ? b : a;

--- a/wolfssl/wolfcrypt/mem_track.h
+++ b/wolfssl/wolfcrypt/mem_track.h
@@ -133,29 +133,11 @@ static memoryStats ourMemStats;
 #endif
 #endif
 
-
-/* if defined to not using inline then declare function prototypes */
-#ifdef NO_INLINE
-    #define WC_STATIC
-    #ifdef WOLFSSL_DEBUG_MEMORY
-            WOLFSSL_LOCAL void* TrackMalloc(size_t sz, const char* func, unsigned int line);
-            WOLFSSL_LOCAL void TrackFree(void* ptr, const char* func, unsigned int line);
-            WOLFSSL_LOCAL void* TrackRealloc(void* ptr, size_t sz, const char* func, unsigned int line);
-    #else
-            WOLFSSL_LOCAL void* TrackMalloc(size_t sz);
-            WOLFSSL_LOCAL void TrackFree(void* ptr);
-            WOLFSSL_LOCAL void* TrackRealloc(void* ptr, size_t sz);
-    #endif
-    WOLFSSL_LOCAL int InitMemoryTracker(void);
-    WOLFSSL_LOCAL void ShowMemoryTracker(void);
-#else
-    #define WC_STATIC static
-#endif
-
 #ifdef WOLFSSL_DEBUG_MEMORY
-WC_STATIC WC_INLINE void* TrackMalloc(size_t sz, const char* func, unsigned int line)
+static WC_INLINE void* TrackMalloc(size_t sz, const char* func,
+                                   unsigned int line)
 #else
-WC_STATIC WC_INLINE void* TrackMalloc(size_t sz)
+static WC_INLINE void* TrackMalloc(size_t sz)
 #endif
 {
     memoryTrack* mt;
@@ -230,9 +212,9 @@ WC_STATIC WC_INLINE void* TrackMalloc(size_t sz)
 
 
 #ifdef WOLFSSL_DEBUG_MEMORY
-WC_STATIC WC_INLINE void TrackFree(void* ptr, const char* func, unsigned int line)
+static WC_INLINE void TrackFree(void* ptr, const char* func, unsigned int line)
 #else
-WC_STATIC WC_INLINE void TrackFree(void* ptr)
+static WC_INLINE void TrackFree(void* ptr)
 #endif
 {
     memoryTrack* mt;
@@ -303,9 +285,10 @@ WC_STATIC WC_INLINE void TrackFree(void* ptr)
 
 
 #ifdef WOLFSSL_DEBUG_MEMORY
-WC_STATIC WC_INLINE void* TrackRealloc(void* ptr, size_t sz, const char* func, unsigned int line)
+static WC_INLINE void* TrackRealloc(void* ptr, size_t sz, const char* func,
+                                    unsigned int line)
 #else
-WC_STATIC WC_INLINE void* TrackRealloc(void* ptr, size_t sz)
+static WC_INLINE void* TrackRealloc(void* ptr, size_t sz)
 #endif
 {
 #ifdef WOLFSSL_DEBUG_MEMORY
@@ -345,7 +328,7 @@ static wolfSSL_Malloc_cb mfDefault = NULL;
 static wolfSSL_Free_cb ffDefault = NULL;
 static wolfSSL_Realloc_cb rfDefault = NULL;
 
-WC_STATIC WC_INLINE int InitMemoryTracker(void)
+static WC_INLINE int InitMemoryTracker(void)
 {
     int ret;
 
@@ -386,7 +369,7 @@ WC_STATIC WC_INLINE int InitMemoryTracker(void)
     return ret;
 }
 
-WC_STATIC WC_INLINE void ShowMemoryTracker(void)
+static WC_INLINE void ShowMemoryTracker(void)
 {
 #ifdef DO_MEM_LIST
     if (pthread_mutex_lock(&memLock) == 0)
@@ -424,7 +407,7 @@ WC_STATIC WC_INLINE void ShowMemoryTracker(void)
 #endif
 }
 
-WC_STATIC WC_INLINE int CleanupMemoryTracker(void)
+static WC_INLINE int CleanupMemoryTracker(void)
 {
     /* restore default allocators */
     return wolfSSL_SetAllocators(mfDefault, ffDefault, rfDefault);

--- a/wolfssl/wolfcrypt/misc.h
+++ b/wolfssl/wolfcrypt/misc.h
@@ -38,6 +38,9 @@ masking and clearing memory logic.
 
 
 #ifdef NO_INLINE
+
+#define WC_MISC_STATIC
+
 WOLFSSL_LOCAL
 word32 rotlFixed(word32, word32);
 WOLFSSL_LOCAL
@@ -147,6 +150,10 @@ WOLFSSL_LOCAL byte w64GTE(w64wrapper a, w64wrapper b);
 WOLFSSL_LOCAL byte w64LT(w64wrapper a, w64wrapper b);
 WOLFSSL_LOCAL w64wrapper w64Sub(w64wrapper a, w64wrapper b);
 WOLFSSL_LOCAL void w64Zero(w64wrapper *a);
+
+#else /* !NO_INLINE */
+
+#define WC_MISC_STATIC static
 
 #endif /* NO_INLINE */
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -266,6 +266,24 @@ typedef struct w64wrapper {
     #define WOLFSSL_MAX_16BIT 0xffffU
     #define WOLFSSL_MAX_32BIT 0xffffffffU
 
+    #ifndef WARN_UNUSED_RESULT
+        #if defined(WOLFSSL_LINUXKM) && defined(__must_check)
+            #define WARN_UNUSED_RESULT __must_check
+        #elif defined(__GNUC__) && (__GNUC__ >= 4)
+            #define WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+        #else
+            #define WARN_UNUSED_RESULT
+        #endif
+    #endif /* WARN_UNUSED_RESULT */
+
+    #ifndef WC_MAYBE_UNUSED
+        #if (defined(__GNUC__) && (__GNUC__ >= 4)) || defined(__clang__)
+            #define WC_MAYBE_UNUSED __attribute__((unused))
+        #else
+            #define WC_MAYBE_UNUSED
+        #endif
+    #endif /* WC_MAYBE_UNUSED */
+
     /* use inlining if compiler allows */
     #ifndef WC_INLINE
     #ifndef NO_INLINE
@@ -299,18 +317,13 @@ typedef struct w64wrapper {
             #define WC_INLINE
         #endif
     #else
-        #ifdef __GNUC__
-            #define WC_INLINE __attribute__((unused))
-        #else
-            #define WC_INLINE
-        #endif
+        #define WC_INLINE WC_MAYBE_UNUSED
     #endif
     #endif
 
     #if defined(HAVE_FIPS) || defined(HAVE_SELFTEST)
         #define INLINE WC_INLINE
     #endif
-
 
     /* set up rotate style */
     #if (defined(_MSC_VER) || defined(__BCPLUSPLUS__)) && \
@@ -327,7 +340,6 @@ typedef struct w64wrapper {
            instructions  */
         #define FAST_ROTATE
     #endif
-
 
     /* set up thread local storage if available */
     #ifdef HAVE_THREAD_LS
@@ -362,24 +374,6 @@ typedef struct w64wrapper {
         #undef  FALL_THROUGH
         #define FALL_THROUGH
     #endif
-
-    #ifndef WARN_UNUSED_RESULT
-        #if defined(WOLFSSL_LINUXKM) && defined(__must_check)
-            #define WARN_UNUSED_RESULT __must_check
-        #elif defined(__GNUC__) && (__GNUC__ >= 4)
-            #define WARN_UNUSED_RESULT __attribute__((warn_unused_result))
-        #else
-            #define WARN_UNUSED_RESULT
-        #endif
-    #endif /* WARN_UNUSED_RESULT */
-
-    #ifndef WC_MAYBE_UNUSED
-        #if (defined(__GNUC__) && (__GNUC__ >= 4)) || defined(__clang__)
-            #define WC_MAYBE_UNUSED __attribute__((unused))
-        #else
-            #define WC_MAYBE_UNUSED
-        #endif
-    #endif /* WC_MAYBE_UNUSED */
 
     /* Micrium will use Visual Studio for compilation but not the Win32 API */
     #if defined(_WIN32) && !defined(MICRIUM) && !defined(FREERTOS) && \


### PR DESCRIPTION
extend C89 clean-build-ability to whole codebase including examples:

`configure.ac`: remove implied `--disable-examples` when `--disable-inline`;

`tests/api.c`: always include `wolfcrypt/src/misc.c`;

`wolfcrypt/src/misc.c`: use `WC_MISC_STATIC` to designate `static`ness of the misc functions;

`wolfssl/wolfcrypt/misc.h`: define `WC_MISC_STATIC` to empty or static depending on `#ifdef NO_INLINE` or not (respectively);

`wolfssl/wolfcrypt/types.h`: `#ifdef NO_INLINE`, `#define WC_INLINE WC_MAYBE_UNUSED`, and move the definitions of `WARN_UNUSED_RESULT` and `WC_MAYBE_UNUSED` above the definition of `WC_INLINE` for clarity;

`wolfssl/wolfcrypt/mem_track.h`: always declare `TrackMalloc()` et al `static` (no functional change, because the state and callback bindings were and remain unconditionally `static`, but previously `#ifdef NO_INLINE` the functions were globals, leading to multiple definitions.

`src/ssl.c`: fix a couple suppressions to use C comment syntax, for C89 goodness.

---------

`configure.ac`: fix openssl header circular dependency detector to work on out-of-tree builds.

`linuxkm/module_hooks.c`: `wc_SetSeed_Cb(wc_GenerateSeed)` in `wolfssl_init()` `#ifdef WC_RNG_SEED`, regardless of whether `wolfcrypt_test()` will be called.


tested with `wolfssl-multi-test ... super-quick-check` with the new `all-gcc-c89` scenario in it, and tested the kernel module change with test loads, with and without `--enable-crypttests`, into a `qemu-system`-hosted Linux host.
