### PR TITLE
compiler appeasement initialization

### DIFF
--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -643,7 +643,8 @@ int fp_div(fp_int *a, fp_int *b, fp_int *c, fp_int *d)
     return FP_OKAY;
   }
 
-#ifdef WOLFSSL_SMALL_STACK
+#ifdef WOLFSSL_SMALL_STACK          /* 0  1  2  3   4  */
+  /* allocate 5 elements of fp_int for q, x, y, t1, t2 */
   q = (fp_int*)XMALLOC(sizeof(fp_int) * 5, NULL, DYNAMIC_TYPE_BIGINT);
   if (q == NULL) {
       return FP_MEM;
@@ -657,8 +658,18 @@ int fp_div(fp_int *a, fp_int *b, fp_int *c, fp_int *d)
 
   fp_init(t1);
   fp_init(t2);
-  fp_init_copy(x, a);
-  fp_init_copy(y, b);
+
+  /* Init a copy (y) of the input (b) and
+  ** Init a copy (x) of the input (a)
+  **
+  ** ALERT: Not calling fp_init_copy() as some compiler optimization settings
+  ** such as -O2 will complain that (x) or (y) "may be used uninitialized".
+  ** The fp_init() is here only to appease the compiler.  */
+  fp_init(x);
+  fp_copy(a, x); /* copy (src = a) to (dst = x) */
+
+  fp_init(y);
+  fp_copy(b, y); /* copy (src = b) to (dst = y) */
 
   /* fix the sign */
   neg = (a->sign == b->sign) ? FP_ZPOS : FP_NEG;
@@ -4457,6 +4468,7 @@ int mp_div_2d(fp_int* a, int b, fp_int* c, fp_int* d)
   return MP_OKAY;
 }
 
+/* copy (src = a) to (dst = b) */
 void fp_copy(const fp_int *a, fp_int *b)
 {
     /* if source and destination are different */
@@ -4494,11 +4506,13 @@ int mp_init_copy(fp_int * a, fp_int * b)
     return MP_OKAY;
 }
 
+/* Copy (dst = a) from (src = b) */
 void fp_init_copy(fp_int *a, fp_int* b)
 {
     if (a != b) {
         fp_init(a);
-        fp_copy(b, a);
+        /* Note reversed parameter order! */
+        fp_copy(b, a); /* copy (src = b) to (dst = a) */
     }
 }
 
@@ -5737,8 +5751,13 @@ int mp_radix_size (mp_int *a, int radix, int *size)
         return FP_MEM;
 #endif
 
-    /* init a copy of the input */
-    fp_init_copy (t, a);
+    /* Init a copy (t) of the input (a)
+    **
+    ** ALERT: Not calling fp_init_copy() as some compiler optimization settings
+    ** such as -O2 will complain that (t) "may be used uninitialized"
+    ** The fp_init() is here only to appease the compiler.  */
+    fp_init(t);
+    fp_copy(a, t); /* copy (src = a) to (dst = t)*/
 
     /* force temp to positive */
     t->sign = FP_ZPOS;
@@ -5810,8 +5829,13 @@ int mp_toradix (mp_int *a, char *str, int radix)
         return FP_MEM;
 #endif
 
-    /* init a copy of the input */
-    fp_init_copy (t, a);
+    /* Init a copy (t) of the input (a)
+    **
+    ** ALERT: Not calling fp_init_copy() as some compiler optimization settings
+    ** such as -O2 will complain that (t) "may be used uninitialized"
+    ** The fp_init() is here only to appease the compiler.  */
+    fp_init(t);
+    fp_copy(a, t); /* copy (src = a) to (dst = t) */
 
     /* if it is negative output a - */
     if (t->sign == FP_NEG) {


### PR DESCRIPTION
# Description

Fixes https://github.com/wolfSSL/wolfssl/issues/6148. 

This is an Espressif compiler optimization level specific appeasement, as the source of the lines being complained about do have the variables initialized in the `fp_init_copy`. 

Rather than give everyone a performance hit, the initialization is gated with `CONFIG_COMPILER_OPTIMIZATION_PERF`.

To activate the interesting code, turn on Espressif hardware acceleration (the default) or manually set `#define USE_FAST_MATH` and `#define WOLFSSL_SMALL_STACK`

Note that some wolfSSL tests are still failing on the ESP32, such as https://github.com/wolfSSL/wolfssl/issues/6059 and https://github.com/wolfSSL/wolfssl/issues/5948 that are fixed in my [ED25519_SHA2_fix](https://github.com/gojimmypi/wolfssl/tree/ED25519_SHA2_fix) branch. PR coming soon.

Fixes zd#  n/a

# Testing

How did you test?


```
git clone https://github.com/gojimmypi/wolfssl.git Espressif_fix_6148  
cd Espressif_fix_6148

# optional Linux test
./autogen.sh

./configure CC=clang --enable-trackmemory --enable-ed25519 --enable-smallstack CFLAGS=-DHAVE_STACK_SIZE && make && ./wolfcrypt/test/testwolfcrypt



# Espressif test
. /mnt/c/SysGCC/esp32/esp-idf/v5.0/export.sh


cd ./IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark
idf.py menuconfig
# set performance optimization: Compiler Options: --> Optimization Level --> Optimize for Performance

idf.py build

# observe compiler error

git checkout Espressif_fix_6148

idf.py build
# observe no compiler error

cd ../wolfssl_test

idf.py menuconfig
# set performance optimization: Compiler Options: --> Optimization Level --> Optimize for Performance

idf.py build

# optionally
idf.py  -b 112000  -p /dev/ttyS20  build flash monitor
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
