### PR TITLE
Update README link

### DIFF
--- a/IDE/zephyr/README.md
+++ b/IDE/zephyr/README.md
@@ -1,3 +1,3 @@
 # Zephyr
 
-Zephyr Project Port has been moved to [wolfssl/RTOS/zephyr](../../RTOS/zephyr/README.md)
+Zephyr Project Port has been moved to [wolfssl/zephyr](https://github.com/wolfSSL/wolfssl/tree/master/zephyr)


### PR DESCRIPTION
fix link that's currently 404

See [IDE/zephyr](https://github.com/wolfSSL/wolfssl/tree/master/IDE/zephyr)