### PR TITLE
20230306-fix-header-loop-test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8720,7 +8720,11 @@ if test "$ENABLED_OPENSSLEXTRA" = "yes" && test "$ENABLED_LINUXKM" = "no"
 then
     SAVE_CFLAGS=$CFLAGS
     CFLAGS="$CFLAGS -I$srcdir"
-    for header in "${srcdir}"/wolfssl/openssl/*.h
+    build_pwd="$(pwd)"
+    cd "$srcdir"
+    openssl_headers=$(echo wolfssl/openssl/*.h)
+    cd "$build_pwd"
+    for header in $openssl_headers
     do
         AC_CHECK_HEADER([$header], [], [
                 AC_MSG_ERROR([Error including $header. Possible circular dependency introduced or missing include.])

--- a/wolfssl/openssl/bn.h
+++ b/wolfssl/openssl/bn.h
@@ -66,7 +66,7 @@ typedef struct WOLFSSL_BIGNUM {
     #endif
 #endif
 
-#define WOLFSSL_BN_RAND_TOP_ANY     -1
+#define WOLFSSL_BN_RAND_TOP_ANY     (-1)
 #define WOLFSSL_BN_RAND_TOP_ONE     0
 #define WOLFSSL_BN_RAND_TOP_TWO     1
 


### PR DESCRIPTION
`configure.ac`: further fix for header loop check -- construct header list while in `$srcdir`, so that `-I${srcdir}` works as expected.  see earlier commits 7baddb04f8 a7d9ea7550 b3a1ac80dc .

`wolfssl/openssl/bn.h`: fix `bugprone-macro-parentheses`.

tested with `wolfssl-multi-test.sh ... super-quick-check all-sp-asm-cipher-suite`
