### PR TITLE
build checks on mp_read_radix

### DIFF
--- a/src/ssl_bn.c
+++ b/src/ssl_bn.c
@@ -575,18 +575,6 @@ char* wolfSSL_BN_bn2hex(const WOLFSSL_BIGNUM *bn)
  */
 static int wolfssl_bn_radix2bn(WOLFSSL_BIGNUM** bn, const char* str, int radix)
 {
-#if defined(USE_FAST_MATH) && (!defined(OPENSSL_EXTRA) && defined(NO_DSA) && \
-        !defined(HAVE_ECC))
-    /* in this build case mp_read_radix is not available */
-    WOLFSSL_ENTER("wolfSSL_BN_bn2dec");
-    WOLFSSL_MSG("BN mp_read_radix not available");
-
-    (void)bn;
-    (void)str;
-    (void)radix;
-
-    return 0;
-#else
     int ret = 1;
     WOLFSSL_BIGNUM* a = NULL;
 
@@ -620,7 +608,6 @@ static int wolfssl_bn_radix2bn(WOLFSSL_BIGNUM** bn, const char* str, int radix)
         *bn = NULL;
     }
     return ret;
-#endif
 }
 
 /* Decode hex string into a big number.

--- a/src/ssl_bn.c
+++ b/src/ssl_bn.c
@@ -575,6 +575,18 @@ char* wolfSSL_BN_bn2hex(const WOLFSSL_BIGNUM *bn)
  */
 static int wolfssl_bn_radix2bn(WOLFSSL_BIGNUM** bn, const char* str, int radix)
 {
+#if defined(USE_FAST_MATH) && (!defined(OPENSSL_EXTRA) && defined(NO_DSA) && \
+        !defined(HAVE_ECC))
+    /* in this build case mp_read_radix is not available */
+    WOLFSSL_ENTER("wolfSSL_BN_bn2dec");
+    WOLFSSL_MSG("BN mp_read_radix not available");
+
+    (void)bn;
+    (void)str;
+    (void)radix;
+
+    return 0;
+#else
     int ret = 1;
     WOLFSSL_BIGNUM* a = NULL;
 
@@ -608,6 +620,7 @@ static int wolfssl_bn_radix2bn(WOLFSSL_BIGNUM** bn, const char* str, int radix)
         *bn = NULL;
     }
     return ret;
+#endif
 }
 
 /* Decode hex string into a big number.

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -5510,7 +5510,7 @@ static wcchar fp_s_rmap = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                     "abcdefghijklmnopqrstuvwxyz+/";
 #endif
 
-#if !defined(NO_DSA) || defined(HAVE_ECC)
+#if defined(OPENSSL_EXTRA) || !defined(NO_DSA) || defined(HAVE_ECC)
 #if DIGIT_BIT == 64 || DIGIT_BIT == 32
 static int fp_read_radix_16(fp_int *a, const char *str)
 {

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -812,7 +812,7 @@ MP_API int mp_radix_size (mp_int * a, int radix, int *size);
     #define mp_dump(desc, a, verbose)
 #endif
 
-#if !defined(NO_DSA) || defined(HAVE_ECC)
+#if defined(OPENSSL_EXTRA) || !defined(NO_DSA) || defined(HAVE_ECC)
     MP_API int mp_read_radix(mp_int* a, const char* str, int radix);
 #endif
 


### PR DESCRIPTION
For builds with --enable-opensslextra --disable-dsa --disable-ecc

```
./src/ssl_bn.c: In function ‘wolfssl_bn_radix2bn’:
./src/ssl_bn.c:598:24: warning: implicit declaration of function ‘mp_read_radix’; did you mean ‘mp_toradix’? [-Wimplicit-function-declaration]
  598 |     if ((ret == 1) && (mp_read_radix((mp_int*)(*bn)->internal, str, radix) !=
      |                        ^~~~~~~~~~~~~
      |                        mp_toradix
./src/ssl_bn.c:598:24: warning: nested extern declaration of ‘mp_read_radix’ [-Wnested-externs]
```