### PR TITLE
Fix not ignoring date errors when VERIFY_SKIP_DATE is set

### DIFF
--- a/certs/client-absolute-urn.pem
+++ b/certs/client-absolute-urn.pem
@@ -1,0 +1,91 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            69:47:62:4d:e0:35:e0:a0:bb:c5:b4:2d:33:e4:05:d1:02:16:bc:81
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, ST = Montana, L = Bozeman, O = wolfSSL_2048, OU = ABSOLUTE_URN, CN = www.wolfssl.com, emailAddress = info@wolfssl.com
+        Validity
+            Not Before: Mar 16 21:46:10 2023 GMT
+            Not After : Dec 10 21:46:10 2025 GMT
+        Subject: C = US, ST = Montana, L = Bozeman, O = wolfSSL_2048, OU = ABSOLUTE_URN, CN = www.wolfssl.com, emailAddress = info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c3:03:d1:2b:fe:39:a4:32:45:3b:53:c8:84:2b:
+                    2a:7c:74:9a:bd:aa:2a:52:07:47:d6:a6:36:b2:07:
+                    32:8e:d0:ba:69:7b:c6:c3:44:9e:d4:81:48:fd:2d:
+                    68:a2:8b:67:bb:a1:75:c8:36:2c:4a:d2:1b:f7:8b:
+                    ba:cf:0d:f9:ef:ec:f1:81:1e:7b:9b:03:47:9a:bf:
+                    65:cc:7f:65:24:69:a6:e8:14:89:5b:e4:34:f7:c5:
+                    b0:14:93:f5:67:7b:3a:7a:78:e1:01:56:56:91:a6:
+                    13:42:8d:d2:3c:40:9c:4c:ef:d1:86:df:37:51:1b:
+                    0c:a1:3b:f5:f1:a3:4a:35:e4:e1:ce:96:df:1b:7e:
+                    bf:4e:97:d0:10:e8:a8:08:30:81:af:20:0b:43:14:
+                    c5:74:67:b4:32:82:6f:8d:86:c2:88:40:99:36:83:
+                    ba:1e:40:72:22:17:d7:52:65:24:73:b0:ce:ef:19:
+                    cd:ae:ff:78:6c:7b:c0:12:03:d4:4e:72:0d:50:6d:
+                    3b:a3:3b:a3:99:5e:9d:c8:d9:0c:85:b3:d9:8a:d9:
+                    54:26:db:6d:fa:ac:bb:ff:25:4c:c4:d1:79:f4:71:
+                    d3:86:40:18:13:b0:63:b5:72:4e:30:c4:97:84:86:
+                    2d:56:2f:d7:15:f7:7f:c0:ae:f5:fc:5b:e5:fb:a1:
+                    ba:d3
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                33:D8:45:66:D7:68:87:18:7E:54:0D:70:27:91:C7:26:D7:85:65:C0
+            X509v3 Authority Key Identifier: 
+                keyid:33:D8:45:66:D7:68:87:18:7E:54:0D:70:27:91:C7:26:D7:85:65:C0
+                DirName:/C=US/ST=Montana/L=Bozeman/O=wolfSSL_2048/OU=ABSOLUTE_URN/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:69:47:62:4D:E0:35:E0:A0:BB:C5:B4:2D:33:E4:05:D1:02:16:BC:81
+            X509v3 Basic Constraints: 
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                URI:urn:example:test
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        79:d1:97:51:a7:36:84:1b:35:b0:e0:e9:00:b4:af:8c:d1:1f:
+        8e:d0:db:37:9f:fe:7e:93:d0:0a:55:34:a3:70:8d:f0:de:84:
+        3a:94:f0:e1:a8:6c:4b:9c:fc:19:84:aa:d9:80:81:71:10:a6:
+        73:80:60:7b:9b:0a:4b:df:e9:85:c2:f5:03:1a:54:99:4d:21:
+        88:aa:f7:8f:fc:39:6e:a6:2e:70:39:57:0c:f2:8d:04:ec:54:
+        f7:18:f7:4c:86:e8:34:a6:63:7c:c0:d3:d5:99:44:38:64:30:
+        0c:c6:cc:0a:a4:8e:4c:dd:9b:c4:12:11:f9:04:c5:a9:f5:db:
+        9a:bb:39:29:cf:cd:b0:ab:1e:9a:5b:90:56:30:6f:01:75:87:
+        c8:ce:df:2a:43:db:5d:6c:1c:52:3b:69:23:d4:2d:8a:c5:90:
+        9f:f9:06:c1:df:d0:7e:28:52:2d:2b:ec:5d:d2:a0:5c:e3:7f:
+        18:cc:65:8a:8a:c2:1e:8b:c7:8e:2c:05:19:49:72:f4:3e:43:
+        d8:43:9f:b5:fa:53:8b:b1:f7:9c:c5:a4:8e:db:7c:da:05:0c:
+        cc:e2:7f:42:4b:8f:90:49:98:73:b0:96:1a:98:33:d4:18:7e:
+        0d:89:55:70:9f:51:6b:8e:91:27:32:55:38:e7:5b:99:71:15:
+        5e:a1:10:38
+-----BEGIN CERTIFICATE-----
+MIIE7jCCA9agAwIBAgIUaUdiTeA14KC7xbQtM+QF0QIWvIEwDQYJKoZIhvcNAQEL
+BQAwgZoxCzAJBgNVBAYTAlVTMRAwDgYDVQQIDAdNb250YW5hMRAwDgYDVQQHDAdC
+b3plbWFuMRUwEwYDVQQKDAx3b2xmU1NMXzIwNDgxFTATBgNVBAsMDEFCU09MVVRF
+X1VSTjEYMBYGA1UEAwwPd3d3LndvbGZzc2wuY29tMR8wHQYJKoZIhvcNAQkBFhBp
+bmZvQHdvbGZzc2wuY29tMB4XDTIzMDMxNjIxNDYxMFoXDTI1MTIxMDIxNDYxMFow
+gZoxCzAJBgNVBAYTAlVTMRAwDgYDVQQIDAdNb250YW5hMRAwDgYDVQQHDAdCb3pl
+bWFuMRUwEwYDVQQKDAx3b2xmU1NMXzIwNDgxFTATBgNVBAsMDEFCU09MVVRFX1VS
+TjEYMBYGA1UEAwwPd3d3LndvbGZzc2wuY29tMR8wHQYJKoZIhvcNAQkBFhBpbmZv
+QHdvbGZzc2wuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwwPR
+K/45pDJFO1PIhCsqfHSavaoqUgdH1qY2sgcyjtC6aXvGw0Se1IFI/S1oootnu6F1
+yDYsStIb94u6zw357+zxgR57mwNHmr9lzH9lJGmm6BSJW+Q098WwFJP1Z3s6enjh
+AVZWkaYTQo3SPECcTO/Rht83URsMoTv18aNKNeThzpbfG36/TpfQEOioCDCBryAL
+QxTFdGe0MoJvjYbCiECZNoO6HkByIhfXUmUkc7DO7xnNrv94bHvAEgPUTnINUG07
+ozujmV6dyNkMhbPZitlUJttt+qy7/yVMxNF59HHThkAYE7BjtXJOMMSXhIYtVi/X
+Ffd/wK71/Fvl+6G60wIDAQABo4IBKDCCASQwHQYDVR0OBBYEFDPYRWbXaIcYflQN
+cCeRxybXhWXAMIHaBgNVHSMEgdIwgc+AFDPYRWbXaIcYflQNcCeRxybXhWXAoYGg
+pIGdMIGaMQswCQYDVQQGEwJVUzEQMA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwH
+Qm96ZW1hbjEVMBMGA1UECgwMd29sZlNTTF8yMDQ4MRUwEwYDVQQLDAxBQlNPTFVU
+RV9VUk4xGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEfMB0GCSqGSIb3DQEJARYQ
+aW5mb0B3b2xmc3NsLmNvbYIUaUdiTeA14KC7xbQtM+QF0QIWvIEwCQYDVR0TBAIw
+ADAbBgNVHREEFDAShhB1cm46ZXhhbXBsZTp0ZXN0MA0GCSqGSIb3DQEBCwUAA4IB
+AQB50ZdRpzaEGzWw4OkAtK+M0R+O0Ns3n/5+k9AKVTSjcI3w3oQ6lPDhqGxLnPwZ
+hKrZgIFxEKZzgGB7mwpL3+mFwvUDGlSZTSGIqveP/Dlupi5wOVcM8o0E7FT3GPdM
+hug0pmN8wNPVmUQ4ZDAMxswKpI5M3ZvEEhH5BMWp9duauzkpz82wqx6aW5BWMG8B
+dYfIzt8qQ9tdbBxSO2kj1C2KxZCf+QbB39B+KFItK+xd0qBc438YzGWKisIei8eO
+LAUZSXL0PkPYQ5+1+lOLsfecxaSO23zaBQzM4n9CS4+QSZhzsJYamDPUGH4NiVVw
+n1FrjpEnMlU451uZcRVeoRA4
+-----END CERTIFICATE-----

--- a/certs/include.am
+++ b/certs/include.am
@@ -10,6 +10,7 @@ EXTRA_DIST += \
 	     certs/client-keyEnc.pem \
 	     certs/client-key.pem \
 	     certs/client-uri-cert.pem \
+	     certs/client-absolute-urn.pem \
 	     certs/client-relative-uri.pem \
 	     certs/client-crl-dist.pem \
 	     certs/client-crl-dist.der \

--- a/certs/renewcerts.sh
+++ b/certs/renewcerts.sh
@@ -24,6 +24,7 @@
 #                       test/digsigku.pem
 #                       ecc-privOnlyCert.pem
 #                       client-uri-cert.pem
+#                       client-absolute-uri.pem
 #                       client-relative-uri.pem
 #                       client-crl-dist.pem
 #                       entity-no-ca-bool-cert.pem
@@ -111,6 +112,26 @@ run_renewcerts(){
     ############################################################
     #openssl ec -inform pem -in certs/ecc-key.pem -outform der -out certs/ecc-keyPub.der -pubout
     openssl ec -inform pem -in certs/ecc-key.pem -outform pem -out certs/ecc-keyPub.pem -pubout
+
+    ############################################################
+    #### update the self-signed (2048-bit) client-absolute-urn.pem
+    ############################################################
+    echo "Updating 2048-bit client-absolute-urn.pem"
+    echo ""
+    #pipe the following arguments to openssl req...
+    echo -e "US\\nMontana\\nBozeman\\nwolfSSL_2048\\nABSOLUTE_URN\\nwww.wolfssl.com\\ninfo@wolfssl.com\\n.\\n.\\n" | openssl req -new -key client-key.pem -config ./wolfssl.cnf -nodes -out client-cert.csr
+    check_result $? "Step 1"
+
+
+    openssl x509 -req -in client-cert.csr -days 1000 -extfile wolfssl.cnf -extensions absolute_urn -signkey client-key.pem -out client-absolute-urn.pem
+    check_result $? "Step 2"
+    rm client-cert.csr
+
+    openssl x509 -in client-absolute-urn.pem -text > tmp.pem
+    check_result $? "Step 3"
+    mv tmp.pem client-absolute-urn.pem
+    echo "End of section"
+    echo "---------------------------------------------------------------------"
 
     ############################################################
     #### update the self-signed (2048-bit) client-relative-uri.pem

--- a/certs/renewcerts/wolfssl.cnf
+++ b/certs/renewcerts/wolfssl.cnf
@@ -296,6 +296,13 @@ authorityKeyIdentifier=keyid:always,issuer:always
 basicConstraints=CA:false
 subjectAltName=URI:https://www.wolfssl.com
 
+# test parsing absolute URN
+[ absolute_urn ]
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid:always,issuer:always
+basicConstraints=CA:false
+subjectAltName=URI:urn:example:test
+
 # test parsing relative URI
 [ relative_uri ]
 subjectKeyIdentifier=hash

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6398,7 +6398,7 @@ int wolfSSL_Init(void)
     #endif
         if ((ret == WOLFSSL_SUCCESS) &&
             (wolfSSL_RAND_seed(NULL, 0) != WOLFSSL_SUCCESS)) {
-            WOLFSSL_MSG("wolfSSL_RAND_Seed failed");
+            WOLFSSL_MSG("wolfSSL_RAND_seed failed");
             ret = WC_INIT_E;
         }
 #endif

--- a/tests/api.c
+++ b/tests/api.c
@@ -42305,11 +42305,13 @@ static int test_wolfSSL_SESSION(void)
     WOLFSSL_SESSION* sess;
     WOLFSSL_SESSION* sess_copy;
 #ifdef OPENSSL_EXTRA
+#ifdef HAVE_EXT_CACHE
     unsigned char* sessDer = NULL;
     unsigned char* ptr     = NULL;
+    int sz;
+#endif
     const unsigned char context[] = "user app context";
     unsigned int contextSz = (unsigned int)sizeof(context);
-    int sz;
 #endif
     int ret, err;
     SOCKET_T sockfd;
@@ -42478,7 +42480,7 @@ static int test_wolfSSL_SESSION(void)
     sess_copy = NULL;
 #endif
 
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) && defined(HAVE_EXT_CACHE)
     /* get session from DER and update the timeout */
     AssertIntEQ(wolfSSL_i2d_SSL_SESSION(NULL, &sessDer), BAD_FUNC_ARG);
     AssertIntGT((sz = wolfSSL_i2d_SSL_SESSION(sess, &sessDer)), 0);

--- a/tests/api.c
+++ b/tests/api.c
@@ -10132,9 +10132,14 @@ static int test_wolfSSL_URI(void)
     defined(OPENSSL_EXTRA))
     WOLFSSL_X509* x509;
     const char uri[] = "./certs/client-uri-cert.pem";
+    const char urn[] = "./certs/client-absolute-urn.pem";
     const char badUri[] = "./certs/client-relative-uri.pem";
 
     x509 = wolfSSL_X509_load_certificate_file(uri, WOLFSSL_FILETYPE_PEM);
+    AssertNotNull(x509);
+    wolfSSL_FreeX509(x509);
+
+    x509 = wolfSSL_X509_load_certificate_file(urn, WOLFSSL_FILETYPE_PEM);
     AssertNotNull(x509);
     wolfSSL_FreeX509(x509);
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -21266,8 +21266,11 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
         cert->badDate = 0;
         cert->criticalExt = 0;
         if ((ret = DecodeToKey(cert, verify)) < 0) {
-            if (ret == ASN_BEFORE_DATE_E || ret == ASN_AFTER_DATE_E)
+            if (ret == ASN_BEFORE_DATE_E || ret == ASN_AFTER_DATE_E) {
                 cert->badDate = ret;
+                if (verify == VERIFY_SKIP_DATE)
+                    ret = 0;
+            }
             else
                 return ret;
         }
@@ -21510,6 +21513,8 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
             ret = DecodeCert(cert, verify, &cert->criticalExt);
             if (ret == ASN_BEFORE_DATE_E || ret == ASN_AFTER_DATE_E) {
                 cert->badDate = ret;
+                if (verify == VERIFY_SKIP_DATE)
+                    ret = 0;
             }
             else if (ret < 0) {
                 WOLFSSL_ERROR_VERBOSE(ret);

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -16684,8 +16684,7 @@ static int DecodeGeneralName(const byte* input, word32* inOutIdx, byte tag,
 
             /* test if no ':' char was found and test that the next two
              * chars are "//" to match the pattern "://" */
-            if (i >= len - 2 || (input[idx + i + 1] != '/' ||
-                                 input[idx + i + 2] != '/')) {
+            if (input[idx + i] != ':' || i == 0 || i == len) {
                 WOLFSSL_MSG("\tAlt Name must be absolute URI");
                 WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
                 return ASN_ALT_NAME_E;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -16666,7 +16666,11 @@ static int DecodeGeneralName(const byte* input, word32* inOutIdx, byte tag,
 
     #if !defined(WOLFSSL_NO_ASN_STRICT) && !defined(WOLFSSL_FPKI)
         /* Verify RFC 5280 Sec 4.2.1.6 rule:
-            "The name MUST NOT be a relative URI" */
+            "The name MUST NOT be a relative URI"
+            As per RFC 3986 Sec 4.3, an absolute URI is only required to contain
+            a scheme and hier-part.  So the only strict requirement is a ':'
+            being present after the scheme.  If a '/' is present as part of the
+            hier-part, it must come after the ':' (see RFC 3986 Sec 3). */
         {
             int i;
 
@@ -16682,8 +16686,7 @@ static int DecodeGeneralName(const byte* input, word32* inOutIdx, byte tag,
                 }
             }
 
-            /* test if no ':' char was found and test that the next two
-             * chars are "//" to match the pattern "://" */
+            /* test if scheme is missing or hier-part is empty */
             if (input[idx + i] != ':' || i == 0 || i == len) {
                 WOLFSSL_MSG("\tAlt Name must be absolute URI");
                 WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
@@ -17121,7 +17124,11 @@ static int DecodeAltNames(const byte* input, int sz, DecodedCert* cert)
 
         #if !defined(WOLFSSL_NO_ASN_STRICT) && !defined(WOLFSSL_FPKI)
             /* Verify RFC 5280 Sec 4.2.1.6 rule:
-                "The name MUST NOT be a relative URI" */
+                "The name MUST NOT be a relative URI"
+                As per RFC 3986 Sec 4.3, an absolute URI is only required to contain
+                a scheme and hier-part.  So the only strict requirement is a ':'
+                being present after the scheme.  If a '/' is present as part of the
+                hier-part, it must come after the ':' (see RFC 3986 Sec 3). */
 
             {
                 int i;
@@ -17138,10 +17145,8 @@ static int DecodeAltNames(const byte* input, int sz, DecodedCert* cert)
                     }
                 }
 
-                /* test if no ':' char was found and test that the next two
-                 * chars are "//" to match the pattern "://" */
-                if (i >= strLen - 2 || (input[idx + i + 1] != '/' ||
-                                        input[idx + i + 2] != '/')) {
+                /* test if scheme is missing or hier-part is empty */
+                if (input[idx + i] != ':' || i == 0 || i == strLen) {
                     WOLFSSL_MSG("\tAlt Name must be absolute URI");
                     WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
                     return ASN_ALT_NAME_E;


### PR DESCRIPTION
# Description
Fix not ignoring date errors when VERIFY_SKIP_DATE is set
Fix unit test failure when building OPENSSL_EXTRA without HAVE_EXT_CACHE.
Allow alternative absolute URI syntax in certificate general name.

Fixes zd# 15767 15773 15751

# Testing

Built in tests

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
