### PR TITLE
Adding NO_ASN_TIME_CHECK build option

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -42,6 +42,8 @@
 
 /*
 ASN Options:
+ * NO_ASN_TIME_CHECK: Disables ASN time checks (avoiding the ASN_BEFORE_DATE_E
+ * and ASN_AFTER_DATE_E errors).
  * NO_ASN_TIME: Disables time parts of the ASN code for systems without an RTC
     or wishing to save space.
  * IGNORE_NAME_CONSTRAINTS: Skip ASN name checks.
@@ -14153,7 +14155,7 @@ static int GetDate(DecodedCert* cert, int dateType, int verify, int maxIdx)
     else
         cert->afterDateLen  = (int)(cert->srcIdx - startIdx);
 
-#ifndef NO_ASN_TIME
+#ifndef NO_ASN_TIME_CHECK
     if (verify != NO_VERIFY && verify != VERIFY_SKIP_DATE &&
             !XVALIDATE_DATE(date, format, dateType)) {
         if (dateType == BEFORE) {
@@ -20028,7 +20030,7 @@ static int CheckDate(ASNGetData *dataASN, int dateType)
         ret = ASN_DATE_SZ_E;
     }
 
-#ifndef NO_ASN_TIME
+#ifndef NO_ASN_TIME_CHECK
     /* Check date is a valid string and BEFORE or AFTER now. */
     if ((ret == 0) &&
             (!XVALIDATE_DATE(dataASN->data.ref.data, dataASN->tag, dateType))) {
@@ -33631,7 +33633,7 @@ static int DecodeSingleResponse(byte* source, word32* ioIndex, word32 size,
                                                 &single->status->thisDateFormat, size) < 0)
         return ASN_PARSE_E;
 
-#ifndef NO_ASN_TIME
+#ifndef NO_ASN_TIME_CHECK
 #ifndef WOLFSSL_NO_OCSP_DATE_CHECK
     if (!XVALIDATE_DATE(single->status->thisDate, single->status->thisDateFormat, BEFORE))
         return ASN_BEFORE_DATE_E;
@@ -33667,7 +33669,7 @@ static int DecodeSingleResponse(byte* source, word32* ioIndex, word32 size,
                                                 &single->status->nextDateFormat, size) < 0)
             return ASN_PARSE_E;
 
-#ifndef NO_ASN_TIME
+#ifndef NO_ASN_TIME_CHECK
 #ifndef WOLFSSL_NO_OCSP_DATE_CHECK
         if (!XVALIDATE_DATE(single->status->nextDate, single->status->nextDateFormat, AFTER))
             return ASN_AFTER_DATE_E;
@@ -33764,7 +33766,7 @@ static int DecodeSingleResponse(byte* source, word32* ioIndex, word32 size,
 
         /* Store the thisDate format - only one possible. */
         cs->thisDateFormat = ASN_GENERALIZED_TIME;
-    #if !defined(NO_ASN_TIME) && !defined(WOLFSSL_NO_OCSP_DATE_CHECK)
+    #if !defined(NO_ASN_TIME_CHECK) && !defined(WOLFSSL_NO_OCSP_DATE_CHECK)
         /* Check date is a valid string and BEFORE now. */
         if (!XVALIDATE_DATE(cs->thisDate, ASN_GENERALIZED_TIME, BEFORE)) {
             ret = ASN_BEFORE_DATE_E;
@@ -33787,7 +33789,7 @@ static int DecodeSingleResponse(byte* source, word32* ioIndex, word32 size,
             (dataASN[SINGLERESPONSEASN_IDX_NEXTUPDATE_GT].tag != 0)) {
         /* Store the nextDate format - only one possible. */
         cs->nextDateFormat = ASN_GENERALIZED_TIME;
-    #if !defined(NO_ASN_TIME) && !defined(WOLFSSL_NO_OCSP_DATE_CHECK)
+    #if !defined(NO_ASN_TIME_CHECK) && !defined(WOLFSSL_NO_OCSP_DATE_CHECK)
         /* Check date is a valid string and AFTER now. */
         if (!XVALIDATE_DATE(cs->nextDate, ASN_GENERALIZED_TIME, AFTER)) {
             ret = ASN_AFTER_DATE_E;
@@ -36319,6 +36321,7 @@ end:
         ret = PaseCRL_CheckSignature(dcrl, buff, cm);
     }
 
+    (void)verify;
     FREE_ASNGETDATA(dataASN, dcrl->heap);
     return ret;
 #endif /* WOLFSSL_ASN_TEMPLATE */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -36325,7 +36325,6 @@ end:
         ret = PaseCRL_CheckSignature(dcrl, buff, cm);
     }
 
-    (void)verify;
     FREE_ASNGETDATA(dataASN, dcrl->heap);
     return ret;
 #endif /* WOLFSSL_ASN_TEMPLATE */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -43,7 +43,11 @@
 /*
 ASN Options:
  * NO_ASN_TIME_CHECK: Disables ASN time checks (avoiding the ASN_BEFORE_DATE_E
- * and ASN_AFTER_DATE_E errors).
+ * and ASN_AFTER_DATE_E errors). Safer ways to avoid date errors would be to
+ * set the WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY flag when calling the _ex versions of
+ * cert loading functions or to define the WOLFSSL_NO_OCSP_DATE_CHECK macro to
+ * skip OCSP date errors. Defining NO_ASN_TIME_CHECK will skip ALL date checks
+ * and could pose a security risk.
  * NO_ASN_TIME: Disables time parts of the ASN code for systems without an RTC
     or wishing to save space.
  * IGNORE_NAME_CONSTRAINTS: Skip ASN name checks.

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2607,6 +2607,11 @@ extern void uITRON4_free(void *p) ;
     #define SSL_CTRL_SET_TLSEXT_HOSTNAME 55
 #endif
 
+/* Disable time checking if no timer */
+#if defined(NO_ASN_TIME)
+    #define NO_ASN_TIME_CHECK
+#endif
+
 /* both CURVE and ED small math should be enabled */
 #ifdef CURVED25519_SMALL
     #define CURVE25519_SMALL


### PR DESCRIPTION
# Description

Skip all time checking without having to define `NO_ASN_TIME`. Originally developed as workaround for the issue addressed by #6181, but still a nice feature to have.

Fixes zd#15790

# Testing

Tested with certs in `certs/test/expired/`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
