### PR TITLE
Server ID - long id, TLS 1.3 - cache client session for tickets

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -10016,6 +10016,10 @@ static int DoTls13NewSessionTicket(WOLFSSL* ssl, const byte* input,
 #endif
     const byte* nonce;
     byte        nonceLength;
+#ifndef NO_SESSION_CACHE
+    const byte* id;
+    byte idSz;
+#endif
 
     WOLFSSL_START(WC_FUNC_NEW_SESSION_TICKET_DO);
     WOLFSSL_ENTER("DoTls13NewSessionTicket");
@@ -10113,6 +10117,14 @@ static int DoTls13NewSessionTicket(WOLFSSL* ssl, const byte* input,
 
     #ifndef NO_SESSION_CACHE
     AddSession(ssl);
+    id = ssl->session->sessionID;
+    idSz = ssl->session->sessionIDSz;
+    if (ssl->session->haveAltSessionID) {
+        id = ssl->session->altSessionID;
+        idSz = ID_LEN;
+    }
+    AddSessionToCache(ssl->ctx, ssl->session, id, idSz, NULL,
+        ssl->session->side, 1, &ssl->clientSession);
     #endif
 
     /* Always encrypted. */

--- a/tests/api.c
+++ b/tests/api.c
@@ -42702,7 +42702,8 @@ static int clientSessRemCountFree = 0;
 static int serverSessRemCountFree = 0;
 static WOLFSSL_CTX* serverSessCtx = NULL;
 static WOLFSSL_SESSION* serverSess = NULL;
-#ifndef NO_SESSION_CACHE_REF
+#if (defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET)) || \
+        !defined(NO_SESSION_CACHE_REF)
 static WOLFSSL_CTX* clientSessCtx = NULL;
 static WOLFSSL_SESSION* clientSess = NULL;
 #endif
@@ -42744,7 +42745,8 @@ static void SessRemSslSetupCb(WOLFSSL* ssl)
     *mallocedData = SSL_is_server(ssl);
     if (!*mallocedData) {
         clientSessRemCountMalloc++;
-#ifndef NO_SESSION_CACHE_REF
+#if (defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET)) || \
+        !defined(NO_SESSION_CACHE_REF)
         AssertNotNull(clientSess = SSL_get1_session(ssl));
         AssertIntEQ(SSL_CTX_up_ref(clientSessCtx = SSL_get_SSL_CTX(ssl)),
                 SSL_SUCCESS);
@@ -42815,7 +42817,8 @@ static int test_wolfSSL_CTX_sess_set_remove_cb(void)
     /* Both should have been allocated */
     AssertIntEQ(clientSessRemCountMalloc, 1);
     AssertIntEQ(serverSessRemCountMalloc, 1);
-#ifdef NO_SESSION_CACHE_REF
+#if (!defined(WOLFSSL_TLS13) || !defined(HAVE_SESSION_TICKET)) && \
+        defined(NO_SESSION_CACHE_REF)
     /* Client session should not be added to cache so this should be free'd when
      * the SSL object was being free'd */
     AssertIntEQ(clientSessRemCountFree, 1);
@@ -42848,7 +42851,8 @@ static int test_wolfSSL_CTX_sess_set_remove_cb(void)
     /* Need to free the references that we kept */
     SSL_CTX_free(serverSessCtx);
     SSL_SESSION_free(serverSess);
-#ifndef NO_SESSION_CACHE_REF
+#if (defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET)) || \
+        !defined(NO_SESSION_CACHE_REF)
     SSL_CTX_free(clientSessCtx);
     SSL_SESSION_free(clientSess);
 #endif

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1449,7 +1449,11 @@ enum Misc {
     COMP_LEN     =  1,         /* compression length      */
     CURVE_LEN    =  2,         /* ecc named curve length  */
     KE_GROUP_LEN =  2,         /* key exchange group length */
-    SERVER_ID_LEN = 20,        /* server session id length  */
+#if defined(NO_SHA) && !defined(NO_SHA256)
+    SERVER_ID_LEN = WC_SHA256_DIGEST_SIZE,
+#else
+    SERVER_ID_LEN = WC_SHA_DIGEST_SIZE,
+#endif
 
     HANDSHAKE_HEADER_SZ   = 4,  /* type + length(3)        */
     RECORD_HEADER_SZ      = 5,  /* type + version + len(2) */


### PR DESCRIPTION
# Description

Long server IDs were being truncated. Hash long IDs instead. TLS 1.3 session ticket on client side no longer added session to client cache. Explicit call added.

Fixes #6172

# Testing

./examples/server/server -v 4 -C 6
./examples/client/client -v 4 -r -b 3
Didn't resume session. Now does.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
