### PR TITLE
Fix type conv error in logging

### DIFF
--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -1215,7 +1215,7 @@ unsigned long wc_PeekErrorNodeLineData(const char **file, int *line,
 
     if (ERRQ_LOCK() != 0) {
         WOLFSSL_MSG("Lock debug mutex failed");
-        return BAD_MUTEX_E;
+        return (unsigned long)(0 - BAD_MUTEX_E);
     }
 
     idx = getErrorNodeCurrentIdx();
@@ -1248,7 +1248,7 @@ unsigned long wc_GetErrorNodeErr(void)
 
     if (ERRQ_LOCK() != 0) {
         WOLFSSL_MSG("Lock debug mutex failed");
-        return BAD_MUTEX_E;
+        return (unsigned long)(0 - BAD_MUTEX_E);
     }
 
     ret = pullErrorNode(NULL, NULL, NULL);


### PR DESCRIPTION
# Description

Fixes type conversion compile errors in `wc_PeekErrorNodeLineData` and `wc_GetErrorNodeErr`.

Fixes zd15836

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
