### PR TITLE
OCSP_CERT_UNKNOWN

### DIFF
--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -398,7 +398,7 @@ end:
     } else if ((ret == ocsp->error) && (ocspResponse->single->status->status == CERT_UNKNOWN)) {
         WOLFSSL_MSG("OCSP unknown");
         ret = OCSP_CERT_UNKNOWN;
-    } else if ((ret != OCSP_CERT_REVOKED) && (ret != ocsp->error)) {
+    } else if (ret != OCSP_CERT_REVOKED) {
         WOLFSSL_MSG("OCSP lookup failure");
         ret = OCSP_LOOKUP_FAIL;
     }

--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -395,7 +395,11 @@ int CheckOcspResponse(WOLFSSL_OCSP *ocsp, byte *response, int responseSz,
 end:
     if (ret == 0 && validated == 1) {
         WOLFSSL_MSG("New OcspResponse validated");
-    } else if (ret != OCSP_CERT_REVOKED) {
+    } else if ((ret == ocsp->error) && (ocspResponse->single->status->status == CERT_UNKNOWN)) {
+        WOLFSSL_MSG("OCSP unknown");
+        ret = OCSP_CERT_UNKNOWN;
+    } else if ((ret != OCSP_CERT_REVOKED) && (ret != ocsp->error)) {
+        WOLFSSL_MSG("OCSP lookup failure");
         ret = OCSP_LOOKUP_FAIL;
     }
 

--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -467,7 +467,7 @@ int CheckOcspRequest(WOLFSSL_OCSP* ocsp, OcspRequest* ocspRequest,
             return ret;
         }
         WOLFSSL_LEAVE("CheckOcspRequest", ocsp->error);
-        return ocsp->error;
+        return ret;
     }
 #endif
 

--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -467,7 +467,7 @@ int CheckOcspRequest(WOLFSSL_OCSP* ocsp, OcspRequest* ocspRequest,
             return ret;
         }
         WOLFSSL_LEAVE("CheckOcspRequest", ocsp->error);
-        return OCSP_LOOKUP_FAIL;
+        return ocsp->error;
     }
 #endif
 


### PR DESCRIPTION
# Description

We needed to get OCSP_CERT_UNKNOWN up as a response code when the OCSP server does not recognize the CA chain.

Fixes zd#15783

# Testing

Created a hacked up version of the wolfssl-examples/ocsp/ocsp_nonblock that uses a specially crafted cert chain to look up via an OCSP server.