### PR TITLE
Fix out-of-bounds read in CRL parsing

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -35655,7 +35655,7 @@ static int ParseCRL_Extensions(DecodedCRL* dcrl, const byte* buf,
                         if (ret != 0)
                             return ret;
                     }
-                    else {
+                    else if (length == 1) {
                         dcrl->crlNumber = buf[idx];
                     }
                 }


### PR DESCRIPTION
# Description

An out of bounds read of size 1 could happen in `ParseCRL_Extensions()` with `--enable-asn=original`. `GetASNInt()` was returning a length of zero, but the code was assuming length was 1 and trying to read 1 byte beyond a buffer. This fix adds an additional check for `length == 1`.

Fixes zd#15807

# Testing

Tested with reproducer in ticket.
