### PR TITLE
Try to XOR as many words as possible in xorbuf APIs - speeds up ChaCha20

### DIFF
--- a/wolfcrypt/src/chacha.c
+++ b/wolfcrypt/src/chacha.c
@@ -202,15 +202,12 @@ int wc_Chacha_SetKey(ChaCha* ctx, const byte* key, word32 keySz)
 /**
   * Converts word into bytes with rotations having been done.
   */
-static WC_INLINE void wc_Chacha_wordtobyte(word32 output[CHACHA_CHUNK_WORDS],
-    const word32 input[CHACHA_CHUNK_WORDS])
+static WC_INLINE void wc_Chacha_wordtobyte(word32 x[CHACHA_CHUNK_WORDS],
+        word32 state[CHACHA_CHUNK_WORDS])
 {
-    word32 x[CHACHA_CHUNK_WORDS];
     word32 i;
 
-    for (i = 0; i < CHACHA_CHUNK_WORDS; i++) {
-        x[i] = input[i];
-    }
+    XMEMCPY(x, state, CHACHA_CHUNK_BYTES);
 
     for (i = (ROUNDS); i > 0; i -= 2) {
         QUARTERROUND(0, 4,  8, 12)
@@ -224,11 +221,8 @@ static WC_INLINE void wc_Chacha_wordtobyte(word32 output[CHACHA_CHUNK_WORDS],
     }
 
     for (i = 0; i < CHACHA_CHUNK_WORDS; i++) {
-        x[i] = PLUS(x[i], input[i]);
-    }
-
-    for (i = 0; i < CHACHA_CHUNK_WORDS; i++) {
-        output[i] = LITTLE32(x[i]);
+        x[i] = PLUS(x[i], state[i]);
+        x[i] = LITTLE32(x[i]);
     }
 }
 
@@ -334,36 +328,33 @@ extern void chacha_encrypt_avx2(ChaCha* ctx, const byte* m, byte* c,
 static void wc_Chacha_encrypt_bytes(ChaCha* ctx, const byte* m, byte* c,
                                     word32 bytes)
 {
-    byte*  output;
-    word32 temp[CHACHA_CHUNK_WORDS]; /* used to make sure aligned */
-    word32 i;
+    union {
+        byte state[CHACHA_CHUNK_BYTES];
+        word32 state32[CHACHA_CHUNK_WORDS];
+        wolfssl_word align_word; /* align for xorbufout */
+    } tmp;
 
     /* handle left overs */
     if (bytes > 0 && ctx->left > 0) {
-        wc_Chacha_wordtobyte(temp, ctx->X); /* recreate the stream */
-        output = (byte*)temp + CHACHA_CHUNK_BYTES - ctx->left;
-        for (i = 0; i < bytes && i < ctx->left; i++) {
-            c[i] = (byte)(m[i] ^ output[i]);
-        }
-        ctx->left -= i;
+        word32 processed = min(bytes, ctx->left);
+        wc_Chacha_wordtobyte(tmp.state32, ctx->X); /* recreate the stream */
+        xorbufout(c, m, tmp.state + CHACHA_CHUNK_BYTES - ctx->left, processed);
+        ctx->left -= processed;
 
         /* Used up all of the stream that was left, increment the counter */
         if (ctx->left == 0) {
             ctx->X[CHACHA_MATRIX_CNT_IV] =
                                           PLUSONE(ctx->X[CHACHA_MATRIX_CNT_IV]);
         }
-        bytes -= i;
-        c += i;
-        m += i;
+        bytes -= processed;
+        c += processed;
+        m += processed;
     }
 
-    output = (byte*)temp;
     while (bytes >= CHACHA_CHUNK_BYTES) {
-        wc_Chacha_wordtobyte(temp, ctx->X);
+        wc_Chacha_wordtobyte(tmp.state32, ctx->X);
         ctx->X[CHACHA_MATRIX_CNT_IV] = PLUSONE(ctx->X[CHACHA_MATRIX_CNT_IV]);
-        for (i = 0; i < CHACHA_CHUNK_BYTES; ++i) {
-            c[i] = (byte)(m[i] ^ output[i]);
-        }
+        xorbufout(c, m, tmp.state, CHACHA_CHUNK_BYTES);
         bytes -= CHACHA_CHUNK_BYTES;
         c += CHACHA_CHUNK_BYTES;
         m += CHACHA_CHUNK_BYTES;
@@ -373,11 +364,9 @@ static void wc_Chacha_encrypt_bytes(ChaCha* ctx, const byte* m, byte* c,
         /* in this case there will always be some left over since bytes is less
          * than CHACHA_CHUNK_BYTES, so do not increment counter after getting
          * stream in order for the stream to be recreated on next call */
-        wc_Chacha_wordtobyte(temp, ctx->X);
-        for (i = 0; i < bytes; ++i) {
-            c[i] = m[i] ^ output[i];
-        }
-        ctx->left = CHACHA_CHUNK_BYTES - i;
+        wc_Chacha_wordtobyte(tmp.state32, ctx->X);
+        xorbufout(c, m, tmp.state, bytes);
+        ctx->left = CHACHA_CHUNK_BYTES - bytes;
     }
 }
 
@@ -394,17 +383,14 @@ int wc_Chacha_Process(ChaCha* ctx, byte* output, const byte* input,
     /* handle left overs */
     if (msglen > 0 && ctx->left > 0) {
         byte*  out;
-        word32 i;
+        word32 processed = min(msglen, ctx->left);
 
         out = (byte*)ctx->over + CHACHA_CHUNK_BYTES - ctx->left;
-        for (i = 0; i < msglen && i < ctx->left; i++) {
-            output[i] = (byte)(input[i] ^ out[i]);
-        }
-        ctx->left -= i;
-
-        msglen -= i;
-        output += i;
-        input += i;
+        xorbufout(output, input, out, processed);
+        ctx->left -= processed;
+        msglen -= processed;
+        output += processed;
+        input += processed;
     }
 
     if (msglen == 0) {

--- a/wolfcrypt/src/des3.c
+++ b/wolfcrypt/src/des3.c
@@ -941,8 +941,7 @@
             XMEMCPY(temp_block, in + offset, DES_BLOCK_SIZE);
 
             /* XOR block with IV for CBC */
-            for (i = 0; i < DES_BLOCK_SIZE; i++)
-                temp_block[i] ^= iv[i];
+            xorbuf(temp_block, iv, DES_BLOCK_SIZE);
 
             ret = wolfSSL_CryptHwMutexLock();
             if(ret != 0) {
@@ -1000,8 +999,7 @@
             wolfSSL_CryptHwMutexUnLock();
 
             /* XOR block with IV for CBC */
-            for (i = 0; i < DES_BLOCK_SIZE; i++)
-                (out + offset)[i] ^= iv[i];
+            xorbuf(out + offset, iv, DES_BLOCK_SIZE);
 
             /* store IV for next block */
             XMEMCPY(iv, temp_block, DES_BLOCK_SIZE);
@@ -1037,8 +1035,7 @@
             XMEMCPY(temp_block, in + offset, DES_BLOCK_SIZE);
 
             /* XOR block with IV for CBC */
-            for (i = 0; i < DES_BLOCK_SIZE; i++)
-                temp_block[i] ^= iv[i];
+            xorbuf(temp_block, iv, DES_BLOCK_SIZE);
 
             ret = wolfSSL_CryptHwMutexLock();
             if(ret != 0) {
@@ -1104,8 +1101,7 @@
             wolfSSL_CryptHwMutexUnLock();
 
             /* XOR block with IV for CBC */
-            for (i = 0; i < DES_BLOCK_SIZE; i++)
-                (out + offset)[i] ^= iv[i];
+            xorbuf(out + offset, iv, DES_BLOCK_SIZE);
 
             /* store IV for next block */
             XMEMCPY(iv, temp_block, DES_BLOCK_SIZE);

--- a/wolfcrypt/src/hpke.c
+++ b/wolfcrypt/src/hpke.c
@@ -43,6 +43,13 @@
 #include <wolfssl/wolfcrypt/aes.h>
 #include <wolfssl/wolfcrypt/hpke.h>
 
+#ifdef NO_INLINE
+    #include <wolfssl/wolfcrypt/misc.h>
+#else
+    #define WOLFSSL_MISC_INCLUDED
+    #include <wolfcrypt/src/misc.c>
+#endif
+
 const int hpkeSupportedKem[HPKE_SUPPORTED_KEM_LEN] = {
     DHKEM_P256_HKDF_SHA256,
     DHKEM_P384_HKDF_SHA384,
@@ -581,7 +588,6 @@ static int wc_HpkeLabeledExpand(Hpke* hpke, byte* suite_id, word32 suite_id_len,
 static int wc_HpkeContextComputeNonce(Hpke* hpke, HpkeBaseContext* context,
     byte* out)
 {
-    int i;
     int ret;
     byte seq_bytes[HPKE_Nn_MAX];
 
@@ -589,9 +595,7 @@ static int wc_HpkeContextComputeNonce(Hpke* hpke, HpkeBaseContext* context,
      * nonce */
     ret = I2OSP(context->seq, hpke->Nn, seq_bytes);
     if (ret == 0) {
-        for (i = 0; i < (int)hpke->Nn; i++) {
-            out[i] = (context->base_nonce[i] ^ seq_bytes[i]);
-        }
+        xorbufout(out, context->base_nonce, seq_bytes, hpke->Nn);
     }
 
     return ret;

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -256,42 +256,50 @@ WC_MISC_STATIC WC_INLINE void ByteReverseWords64(word64* out, const word64* in,
 #ifndef WOLFSSL_NO_XOR_OPS
 /* This routine performs a bitwise XOR operation of <*r> and <*a> for <n> number
 of wolfssl_words, placing the result in <*r>. */
-WC_MISC_STATIC WC_INLINE void XorWordsOut(wolfssl_word* r,
-                         const wolfssl_word* a, const wolfssl_word* b, word32 n)
+WC_MISC_STATIC WC_INLINE void XorWordsOut(wolfssl_word** r,
+                       const wolfssl_word** a, const wolfssl_word** b, word32 n)
 {
     word32 i;
 
-    for (i = 0; i < n; i++) r[i] = a[i] ^ b[i];
+    for (i = 0; i < n; i++)
+        *(*r)++ = *(*a)++ ^ *(*b)++;
 }
 
 /* This routine performs a bitwise XOR operation of <*buf> and <*mask> of n
 counts, placing the result in <*buf>. */
 
-WC_MISC_STATIC WC_INLINE void xorbufout(void*out, const void* buf,
+WC_MISC_STATIC WC_INLINE void xorbufout(void* out, const void* buf,
                                         const void* mask, word32 count)
 {
-    if (((wc_ptr_t)out | (wc_ptr_t)buf | (wc_ptr_t)mask | count) %
-                                                         WOLFSSL_WORD_SIZE == 0)
-        XorWordsOut( (wolfssl_word*)out, (wolfssl_word*)buf,
-                     (const wolfssl_word*)mask, count / WOLFSSL_WORD_SIZE);
-    else {
-        word32 i;
-        byte*       o = (byte*)out;
-        byte*       b = (byte*)buf;
-        const byte* m = (const byte*)mask;
+    word32      i;
+    byte*       o;
+    byte*       b;
+    const byte* m;
 
-        for (i = 0; i < count; i++) o[i] = b[i] ^ m[i];
+    if (((wc_ptr_t)buf | (wc_ptr_t)mask) % WOLFSSL_WORD_SIZE == 0) {
+        /* Alignment checks out. Possible to XOR words. */
+        XorWordsOut( (wolfssl_word**)&out, (const wolfssl_word**)&buf,
+                     (const wolfssl_word**)&mask, count / WOLFSSL_WORD_SIZE);
+        count %= WOLFSSL_WORD_SIZE;
     }
+
+    o = (byte*)out;
+    b = (byte*)buf;
+    m = (const byte*)mask;
+
+    for (i = 0; i < count; i++)
+        o[i] = b[i] ^ m[i];
 }
 
 /* This routine performs a bitwise XOR operation of <*r> and <*a> for <n> number
 of wolfssl_words, placing the result in <*r>. */
-WC_MISC_STATIC WC_INLINE void XorWords(wolfssl_word* r, const wolfssl_word* a,
+WC_MISC_STATIC WC_INLINE void XorWords(wolfssl_word** r, const wolfssl_word** a,
                                        word32 n)
 {
     word32 i;
 
-    for (i = 0; i < n; i++) r[i] ^= a[i];
+    for (i = 0; i < n; i++)
+        *(*r)++ ^= *(*a)++;
 }
 
 /* This routine performs a bitwise XOR operation of <*buf> and <*mask> of n
@@ -299,16 +307,22 @@ counts, placing the result in <*buf>. */
 
 WC_MISC_STATIC WC_INLINE void xorbuf(void* buf, const void* mask, word32 count)
 {
-    if (((wc_ptr_t)buf | (wc_ptr_t)mask | count) % WOLFSSL_WORD_SIZE == 0)
-        XorWords( (wolfssl_word*)buf,
-                  (const wolfssl_word*)mask, count / WOLFSSL_WORD_SIZE);
-    else {
-        word32 i;
-        byte*       b = (byte*)buf;
-        const byte* m = (const byte*)mask;
+    word32      i;
+    byte*       b;
+    const byte* m;
 
-        for (i = 0; i < count; i++) b[i] ^= m[i];
+    if (((wc_ptr_t)buf | (wc_ptr_t)mask) % WOLFSSL_WORD_SIZE == 0) {
+        /* Alignment checks out. Possible to XOR words. */
+        XorWords( (wolfssl_word**)&buf,
+                  (const wolfssl_word**)&mask, count / WOLFSSL_WORD_SIZE);
+        count %= WOLFSSL_WORD_SIZE;
     }
+
+    b = (byte*)buf;
+    m = (const byte*)mask;
+
+    for (i = 0; i < count; i++)
+        b[i] ^= m[i];
 }
 #endif
 

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -599,7 +599,7 @@ WC_MISC_STATIC WC_INLINE void ctMaskCopy(byte mask, byte* dst, byte* src,
 {
     int i;
     for (i = 0; i < size; ++i) {
-        *(dst + i) ^= (*(dst + i) ^ *(src + i)) & mask;
+        dst[i] ^= (dst[i] ^ src[i]) & mask;
     }
 }
 

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -1157,6 +1157,8 @@ static byte* PKCS12_ConcatonateContent(WC_PKCS12* pkcs12,byte* mergedData,
     byte* oldContent;
     word32 oldContentSz;
 
+    (void)pkcs12;
+
     if (mergedData == NULL || in == NULL)
         return NULL;
 

--- a/wolfcrypt/src/sakke.c
+++ b/wolfcrypt/src/sakke.c
@@ -6136,9 +6136,7 @@ static void sakke_xor_in_v(const byte* v, word32 hashSz, byte* out, int idx,
         i = 0;
     }
     o = i;
-    for (; i < hashSz; i++) {
-        out[idx + i - o] ^= v[i];
-    }
+    xorbuf(out + idx + i - o, v + i, hashSz - i);
 }
 
 /*

--- a/wolfssl/wolfcrypt/misc.h
+++ b/wolfssl/wolfcrypt/misc.h
@@ -59,12 +59,12 @@ WOLFSSL_LOCAL
 void   ByteReverseWords(word32* out, const word32* in, word32 byteCount);
 
 WOLFSSL_LOCAL
-void XorWordsOut(wolfssl_word* r, const wolfssl_word* a, const wolfssl_word* b,
-                 word32 n);
+void XorWordsOut(wolfssl_word** r, const wolfssl_word** a,
+        const wolfssl_word** b, word32 n);
 WOLFSSL_LOCAL
 void xorbufout(void* out, const void* buf, const void* mask, word32 count);
 WOLFSSL_LOCAL
-void XorWords(wolfssl_word* r, const wolfssl_word* a, word32 n);
+void XorWords(wolfssl_word** r, const wolfssl_word** a, word32 n);
 WOLFSSL_LOCAL
 void xorbuf(void* buf, const void* mask, word32 count);
 


### PR DESCRIPTION
Use xorbufout in chacha. Ran benchmarks for Chacha with a `./configure` build on my x86_64 machine.

Without this pull request:

```
$ ./wolfcrypt/benchmark/benchmark -chacha20
------------------------------------------------------------------------------
 wolfSSL version 5.5.4
------------------------------------------------------------------------------
wolfCrypt Benchmark (block bytes 1048576, min 1.0 sec each)
CHACHA                     294 MB took 1.016 seconds,  288.985 MB/s Cycles per byte =  11.77
Benchmark complete
$ ./wolfcrypt/benchmark/benchmark -chacha20
------------------------------------------------------------------------------
 wolfSSL version 5.5.4
------------------------------------------------------------------------------
wolfCrypt Benchmark (block bytes 1048576, min 1.0 sec each)
CHACHA                     278 MB took 1.017 seconds,  273.204 MB/s Cycles per byte =  12.45
Benchmark complete
$ ./wolfcrypt/benchmark/benchmark -chacha20
------------------------------------------------------------------------------
 wolfSSL version 5.5.4
------------------------------------------------------------------------------
wolfCrypt Benchmark (block bytes 1048576, min 1.0 sec each)
CHACHA                     299 MB took 1.006 seconds,  297.137 MB/s Cycles per byte =  11.44
Benchmark complete
```

With this pull request:

```
$ ./wolfcrypt/benchmark/benchmark -chacha20
------------------------------------------------------------------------------
 wolfSSL version 5.5.4
------------------------------------------------------------------------------
wolfCrypt Benchmark (block bytes 1048576, min 1.0 sec each)
CHACHA                     451 MB took 1.010 seconds,  446.210 MB/s Cycles per byte =   7.62
Benchmark complete
$ ./wolfcrypt/benchmark/benchmark -chacha20
------------------------------------------------------------------------------
 wolfSSL version 5.5.4
------------------------------------------------------------------------------
wolfCrypt Benchmark (block bytes 1048576, min 1.0 sec each)
CHACHA                     472 MB took 1.003 seconds,  470.584 MB/s Cycles per byte =   7.23
Benchmark complete
$ ./wolfcrypt/benchmark/benchmark -chacha20
------------------------------------------------------------------------------
 wolfSSL version 5.5.4
------------------------------------------------------------------------------
wolfCrypt Benchmark (block bytes 1048576, min 1.0 sec each)
CHACHA                     472 MB took 1.004 seconds,  470.026 MB/s Cycles per byte =   7.23
Benchmark complete
```