### PR TITLE
AES ARMASM <ARMV7: fix load order

### DIFF
--- a/wolfcrypt/src/port/arm/armv8-32-aes-asm.S
+++ b/wolfcrypt/src/port/arm/armv8-32-aes-asm.S
@@ -704,8 +704,8 @@ L_AES_set_encrypt_key_start_192:
 	ldrd	r6, r7, [r0, #8]
 #endif
 #if defined(WOLFSSL_SP_ARM_ARCH) && (WOLFSSL_SP_ARM_ARCH < 7)
-	ldr	r0, [r0, #16]
 	ldr	r1, [r0, #20]
+	ldr	r0, [r0, #16]
 #else
 	ldrd	r0, r1, [r0, #16]
 #endif


### PR DESCRIPTION
# Description

Loading from memory based on register that is overwritten in ldrd. When ldrd split out for older processors, register overwritten before second load.
Switch order of loads in this case.

Fixes: zd#15723

# Testing

Forced ldrd instructions not to be used with aes-32-armv8-asm.S file compiled in.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
