### PR TITLE
wolfcrypt/settings.h: use default realloc on EspressIf

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -813,16 +813,14 @@ extern void uITRON4_free(void *p) ;
         !defined(WOLFSSL_STATIC_MEMORY) && !defined(WOLFSSL_TRACK_MEMORY)
         #define XMALLOC(s, h, type)  pvPortMalloc((s))
         #define XFREE(p, h, type)    vPortFree((p))
-        /* FreeRTOS pvPortRealloc() implementation can be found here:
-         * https://github.com/wolfSSL/wolfssl-freertos/pull/3/files */
-        #if defined(USE_INTEGER_HEAP_MATH) || defined(OPENSSL_EXTRA)
-            #if defined(WOLFSSL_ESPIDF)
+        #if defined(WOLFSSL_ESPIDF)
                 /* In IDF, realloc(p, n) is equivalent to
                  * heap_caps_realloc(p, s, MALLOC_CAP_8BIT) */
                 #define XREALLOC(p, n, h, t) realloc((p), (n))
-            #else
+        /* FreeRTOS pvPortRealloc() implementation can be found here:
+         * https://github.com/wolfSSL/wolfssl-freertos/pull/3/files */
+        #elif defined(USE_INTEGER_HEAP_MATH) || defined(OPENSSL_EXTRA)
                 #define XREALLOC(p, n, h, t) pvPortRealloc((p), (n))
-            #endif
         #endif
     #endif
 


### PR DESCRIPTION
# Description
use default realloc on EspressIf

Fixes: #6201 