### PR TITLE
RIOT-OS does support writev

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -675,7 +675,6 @@
 #endif
 
 #ifdef WOLFSSL_RIOT_OS
-    #define NO_WRITEV
     #define TFM_NO_ASM
     #define NO_FILESYSTEM
     #define USE_CERT_BUFFERS_2048


### PR DESCRIPTION
# Description

RIOT-OS does support `writev`, so `NO_WRITEV` is not necessary

Fixes #6211 

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
