### PR TITLE
Regression testing fixes

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -2404,7 +2404,7 @@ void wolfSSL_CRYPTO_cleanup_ex_data(WOLFSSL_CRYPTO_EX_DATA* ex_data)
 }
 #endif /* HAVE_EX_DATA_CLEANUP_HOOKS */
 
-#if defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
 /* free all ech configs in the list */
 static void FreeEchConfigs(WOLFSSL_EchConfig* configs, void* heap)
 {
@@ -2591,7 +2591,7 @@ void SSL_CtxResourceFree(WOLFSSL_CTX* ctx)
     }
     #endif
 #endif
-#if defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
     FreeEchConfigs(ctx->echConfigs, ctx->heap);
     ctx->echConfigs = NULL;
 #endif
@@ -6934,8 +6934,10 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
     #endif
     #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
         ssl->options.noPskDheKe = ctx->noPskDheKe;
+    #ifdef HAVE_SUPPORTED_CURVES
         ssl->options.onlyPskDheKe = ctx->onlyPskDheKe;
-    #endif
+    #endif /* HAVE_SUPPORTED_CURVES */
+    #endif /* HAVE_SESSION_TICKET || !NO_PSK */
     #if defined(WOLFSSL_POST_HANDSHAKE_AUTH)
         ssl->options.postHandshakeAuth = ctx->postHandshakeAuth;
         ssl->options.verifyPostHandshake = ctx->verifyPostHandshake;
@@ -7612,8 +7614,8 @@ void SSL_ResourceFree(WOLFSSL* ssl)
         FreeHandshakeHashes(ssl);
         ssl->options.useEch = 0;
     }
-#endif
-#endif
+#endif /* HAVE_ECH */
+#endif /* WOLFSSL_TLS13 */
 #ifdef WOLFSSL_HAVE_TLS_UNIQUE
     ForceZero(&ssl->clientFinished, TLS_FINISHED_SZ_MAX);
     ForceZero(&ssl->serverFinished, TLS_FINISHED_SZ_MAX);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -450,7 +450,7 @@ const WOLF_EC_NIST_NAME kNistCurves[] = {
 };
 #endif
 
-#if defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
 /* create the hpke key and ech config to send to clients */
 int wolfSSL_CTX_GenerateEchConfig(WOLFSSL_CTX* ctx, const char* publicName,
     word16 kemId, word16 kdfId, word16 aeadId)
@@ -1039,7 +1039,7 @@ int GetEchConfigsEx(WOLFSSL_EchConfig* configs, byte* output, word32* outputLen)
 
     return WOLFSSL_SUCCESS;
 }
-#endif /* HAVE_ECH */
+#endif /* WOLFSSL_TLS13 && HAVE_ECH */
 
 
 #if defined(WOLFSSL_RENESAS_TSIP_TLS) || defined(WOLFSSL_RENESAS_SCEPROTECT)

--- a/src/tls.c
+++ b/src/tls.c
@@ -1268,7 +1268,7 @@ static WC_INLINE word16 TLSX_ToSemaphore(word16 type)
         case TLSX_KEY_QUIC_TP_PARAMS_DRAFT: /* 0xffa5 */
             return 64;
 #endif
-#if defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
         case TLSX_ECH: /* 0xfe0d */
             return 65;
 #endif
@@ -2029,7 +2029,7 @@ static int TLSX_SNI_Parse(WOLFSSL* ssl, const byte* input, word16 length,
     byte type;
     int matchStat;
     byte matched;
-#if defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
     WOLFSSL_ECH* ech = NULL;
     WOLFSSL_EchConfig* workingConfig;
     TLSX* echX;
@@ -2122,7 +2122,7 @@ static int TLSX_SNI_Parse(WOLFSSL* ssl, const byte* input, word16 length,
     matched = cacheOnly || (XSTRLEN(sni->data.host_name) == size &&
          XSTRNCMP(sni->data.host_name, (const char*)input + offset, size) == 0);
 
-#if defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
     echX = TLSX_Find(ssl->extensions, TLSX_ECH);
     if (echX != NULL)
         ech = (WOLFSSL_ECH*)(echX->data);
@@ -10430,7 +10430,7 @@ void TLSX_Remove(TLSX** list, TLSX_Type type, void* heap)
     }
 }
 
-#if defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
 #define GREASE_ECH_SIZE 160
 #define MAX_PUBLIC_NAME_SZ 256
 #define TLS_INFO_CONST_STRING "tls ech"
@@ -11243,7 +11243,7 @@ void TLSX_FreeAll(TLSX* list, void* heap)
             CID_FREE((byte*)extension->data, heap);
             break;
 #endif /* WOLFSSL_DTLS_CID */
-#if defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
         case TLSX_ECH:
             ECH_FREE((WOLFSSL_ECH*)extension->data, heap);
             break;
@@ -11416,7 +11416,7 @@ static int TLSX_GetSize(TLSX* list, byte* semaphore, byte msgType,
                 length += CID_GET_SIZE((byte*)extension->data);
                 break;
 #endif /* WOLFSSL_DTLS_CID */
-#if defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
             case TLSX_ECH:
                 length += ECH_GET_SIZE((WOLFSSL_ECH*)extension->data);
                 break;
@@ -11624,7 +11624,7 @@ static int TLSX_Write(TLSX* list, byte* output, byte* semaphore,
                 break;
 
 #endif /* WOLFSSL_DTLS_CID */
-#if defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
             case TLSX_ECH:
                 ret = ECH_WRITE((WOLFSSL_ECH*)extension->data,
                     output + offset, &offset);
@@ -12302,7 +12302,7 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
 
 #if defined(WOLFSSL_TLS13) || !defined(NO_WOLFSSL_CLIENT)
 
-#if defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
 /* because the size of ech depends on the size of other extensions we need to
  * get the size with ech special and process ech last, return status */
 static int TLSX_GetSizeWithEch(WOLFSSL* ssl, byte* semaphore, byte msgType,
@@ -12460,7 +12460,6 @@ int TLSX_GetRequestSize(WOLFSSL* ssl, byte msgType, word16* pLength)
          */
     }
     #endif
-#endif
 #if defined(HAVE_ECH)
     if (ssl->options.useEch == 1 && msgType == client_hello) {
         ret = TLSX_GetSizeWithEch(ssl, semaphore, msgType, &length);
@@ -12468,7 +12467,8 @@ int TLSX_GetRequestSize(WOLFSSL* ssl, byte msgType, word16* pLength)
             return ret;
     }
     else
-#endif
+#endif /* HAVE_ECH */
+#endif /* WOLFSSL_TLS13 */
     {
         if (ssl->extensions) {
             ret = TLSX_GetSize(ssl->extensions, semaphore, msgType, &length);
@@ -12498,7 +12498,7 @@ int TLSX_GetRequestSize(WOLFSSL* ssl, byte msgType, word16* pLength)
     return ret;
 }
 
-#if defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
 /* return status after writing the extensions with ech written last */
 static int TLSX_WriteWithEch(WOLFSSL* ssl, byte* output, byte* semaphore,
     byte msgType, word16* pOffset)
@@ -12692,7 +12692,7 @@ int TLSX_WriteRequest(WOLFSSL* ssl, byte* output, byte msgType, word16* pOffset)
     }
     #endif
 #endif
-#if defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
     if (ssl->options.useEch == 1 && msgType == client_hello) {
         ret = TLSX_WriteWithEch(ssl, output, semaphore,
                          msgType, &offset);
@@ -13663,7 +13663,7 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
                 break;
 
 #endif /* defined(WOLFSSL_DTLS_CID) */
-#if defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
             case TLSX_ECH:
                 ret = ECH_PARSE(ssl, input + offset, size, msgType);
                 break;

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5869,7 +5869,6 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
 #else
     ret = DoPreSharedKeys(ssl, input, helloSz - bindersLen, suite, usingPSK,
         &first);
-    CleanupClientTickets((PreSharedKey*)ext->data);
     if (ret != 0) {
         WOLFSSL_MSG_EX("DoPreSharedKeys: %d", ret);
         return ret;
@@ -12825,15 +12824,16 @@ int wolfSSL_accept_TLSv13(WOLFSSL* ssl)
             FALL_THROUGH;
 
         case TLS13_ACCEPT_THIRD_REPLY_DONE :
-#if defined(HAVE_SUPPORTED_CURVES) && (defined(HAVE_SESSION_TICKET) || \
-    !defined(NO_PSK))
+    #ifdef HAVE_SUPPORTED_CURVES
+        #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
             if (!ssl->options.noPskDheKe)
-#endif
+        #endif
             {
                 ssl->error = TLSX_KeyShare_DeriveSecret(ssl);
                 if (ssl->error != 0)
                     return WOLFSSL_FATAL_ERROR;
             }
+    #endif
 
             if ((ssl->error = SendTls13EncryptedExtensions(ssl)) != 0) {
                 WOLFSSL_ERROR(ssl->error);

--- a/tests/api.c
+++ b/tests/api.c
@@ -63272,7 +63272,7 @@ static int test_extra_alerts_wrong_cs(void)
 #endif
 
 #if !defined(WOLFSSL_NO_TLS12) && defined(WOLFSSL_EXTRA_ALERTS) &&             \
-    defined(HAVE_IO_TESTS_DEPENDENCIES)
+    defined(HAVE_IO_TESTS_DEPENDENCIES) && !defined(WOLFSSL_SP_MATH)
 
 static void test_remove_msg(byte *msg, int tail_len, int *len, int msg_length)
 {
@@ -63361,35 +63361,32 @@ static int test_remove_hs_message(byte hs_message_type,
     XMEMSET(&test_ctx, 0, sizeof(test_ctx));
     ret = test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
         wolfTLSv1_2_client_method, wolfTLSv1_2_server_method);
-    if (ret != 0)
-        return TEST_FAIL;
+    AssertIntEQ(ret, 0);
 
     ret = wolfSSL_connect(ssl_c);
     err = wolfSSL_get_error(ssl_c, ret);
-    if (ret == WOLFSSL_SUCCESS || err != WOLFSSL_ERROR_WANT_READ)
-        return TEST_FAIL;
+    AssertIntNE(ret, WOLFSSL_SUCCESS);
+    AssertIntEQ(err, WOLFSSL_ERROR_WANT_READ);
 
     ret = wolfSSL_accept(ssl_s);
     err = wolfSSL_get_error(ssl_s, ret);
-    if (ret == WOLFSSL_SUCCESS || err != WOLFSSL_ERROR_WANT_READ)
-        return TEST_FAIL;
+    AssertIntNE(ret, WOLFSSL_SUCCESS);
+    AssertIntEQ(err, WOLFSSL_ERROR_WANT_READ);
 
     if (extra_round) {
         ret = wolfSSL_connect(ssl_c);
         err = wolfSSL_get_error(ssl_c, ret);
-        if (ret == WOLFSSL_SUCCESS || err != WOLFSSL_ERROR_WANT_READ)
-            return TEST_FAIL;
+        AssertIntNE(ret, WOLFSSL_SUCCESS);
+        AssertIntEQ(err, WOLFSSL_ERROR_WANT_READ);
 
         /* this will complete handshake from server side */
         ret = wolfSSL_accept(ssl_s);
-        if (ret != WOLFSSL_SUCCESS)
-            return TEST_FAIL;
+        AssertIntEQ(ret, WOLFSSL_SUCCESS);
     }
 
     ret = test_remove_hs_msg_from_buffer(test_ctx.c_buff,
          &test_ctx.c_len, hs_message_type, &found);
-    if (ret != 0)
-        return TEST_FAIL;
+    AssertIntEQ(ret, 0);
 
     if (!found) {
         wolfSSL_free(ssl_c);
@@ -63401,11 +63398,10 @@ static int test_remove_hs_message(byte hs_message_type,
 
     ret = wolfSSL_connect(ssl_c);
     err = wolfSSL_get_error(ssl_c, ret);
-    if (ret == WOLFSSL_SUCCESS || err == WOLFSSL_ERROR_WANT_READ)
-        return TEST_FAIL;
+    AssertIntNE(ret, WOLFSSL_SUCCESS);
+    AssertIntNE(err, WOLFSSL_ERROR_WANT_READ);
     ret = wolfSSL_get_alert_history(ssl_c, &h);
-    if (ret != WOLFSSL_SUCCESS)
-        return TEST_FAIL;
+    AssertIntEQ(ret, WOLFSSL_SUCCESS);
     if (alert_type != 0xff && h.last_tx.code != alert_type)
         return TEST_FAIL;
     if (h.last_tx.level != alert_fatal)
@@ -63429,16 +63425,13 @@ static int test_extra_alerts_skip_hs(void)
     /* server_hello */
     ret = test_remove_hs_message(_server_hello, 0,
         unexpected_message);
-    if (ret == TEST_FAIL)
-        return ret;
+    AssertIntNE(ret, TEST_FAIL);
     ret = test_remove_hs_message(_certificate, 0,
         0xff);
-    if (ret == TEST_FAIL)
-        return ret;
+    AssertIntNE(ret, TEST_FAIL);
     ret = test_remove_hs_message(_server_key_exchange, 0,
         unexpected_message);
-    if (ret == TEST_FAIL)
-        return ret;
+    AssertIntNE(ret, TEST_FAIL);
 
     return TEST_SUCCESS;
 }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -33786,7 +33786,7 @@ static int DecodeResponseData(byte* source, word32* ioIndex,
     int ret = 0;
     byte version;
     word32 dateSz, idx = *ioIndex;
-    OcspEntry* single;
+    OcspEntry* single = NULL;
 
     WOLFSSL_ENTER("DecodeResponseData");
 

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -5240,7 +5240,7 @@ const char *mp_s_rmap = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                         "abcdefghijklmnopqrstuvwxyz+/";
 #endif
 
-#if !defined(NO_DSA) || defined(HAVE_ECC)
+#if !defined(NO_DSA) || defined(HAVE_ECC) || defined(OPENSSL_EXTRA)
 /* read a string [ASCII] in a given radix */
 int mp_read_radix (mp_int * a, const char *str, int radix)
 {

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -4529,16 +4529,6 @@ static int _CheckProbablePrime(mp_int* p, mp_int* q, mp_int* e, int nlen,
 
     *isPrime = MP_NO;
 
-    if (q != NULL) {
-        int valid = 0;
-        /* 5.4 - check that |p-q| <= (2^(1/2))(2^((nlen/2)-1)) */
-        ret = wc_CompareDiffPQ(p, q, nlen, &valid);
-        if ((ret != MP_OKAY) || (!valid)) goto notOkay;
-        prime = q;
-    }
-    else
-        prime = p;
-
 #ifdef WOLFSSL_SMALL_STACK
     if (((tmp1 = (mp_int *)XMALLOC(sizeof(*tmp1), NULL, DYNAMIC_TYPE_WOLF_BIGINT)) == NULL) ||
         ((tmp2 = (mp_int *)XMALLOC(sizeof(*tmp2), NULL, DYNAMIC_TYPE_WOLF_BIGINT)) == NULL)) {
@@ -4549,6 +4539,16 @@ static int _CheckProbablePrime(mp_int* p, mp_int* q, mp_int* e, int nlen,
 
     ret = mp_init_multi(tmp1, tmp2, NULL, NULL, NULL, NULL);
     if (ret != MP_OKAY) goto notOkay;
+
+    if (q != NULL) {
+        int valid = 0;
+        /* 5.4 - check that |p-q| <= (2^(1/2))(2^((nlen/2)-1)) */
+        ret = wc_CompareDiffPQ(p, q, nlen, &valid);
+        if ((ret != MP_OKAY) || (!valid)) goto notOkay;
+        prime = q;
+    }
+    else
+        prime = p;
 
     /* 4.4,5.5 - Check that prime >= (2^(1/2))(2^((nlen/2)-1))
      *           This is a comparison against lowerBound */

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -4607,6 +4607,12 @@ static void _sp_mont_setup(const sp_int* m, sp_int_digit* rho);
 #define WOLFSSL_SP_SUB_D
 #endif
 /* Determine when mp_read_radix with a radix of 10 is required. */
+#if (defined(WOLFSSL_SP_MATH_ALL) && !defined(NO_RSA) && \
+    !defined(WOLFSSL_RSA_VERIFY_ONLY)) || defined(HAVE_ECC) || \
+    !defined(NO_DSA) || defined(OPENSSL_EXTRA)
+#define WOLFSSL_SP_READ_RADIX_16
+#endif
+/* Determine when mp_read_radix with a radix of 10 is required. */
 #if defined(WOLFSSL_SP_MATH_ALL) && !defined(NO_RSA) && \
     !defined(WOLFSSL_RSA_VERIFY_ONLY)
 #define WOLFSSL_SP_READ_RADIX_10
@@ -17103,8 +17109,7 @@ int sp_to_unsigned_bin_at_pos(int o, const sp_int* a, unsigned char* out)
 }
 #endif /* WOLFSSL_SP_MATH_ALL && !NO_RSA && !WOLFSSL_RSA_VERIFY_ONLY */
 
-#if (defined(WOLFSSL_SP_MATH_ALL) && !defined(NO_RSA) && \
-    !defined(WOLFSSL_RSA_VERIFY_ONLY)) || defined(HAVE_ECC) || !defined(NO_DSA)
+#ifdef WOLFSSL_SP_READ_RADIX_16
 /* Convert hexadecimal number as string in big-endian format to a
  * multi-precision number.
  *
@@ -17172,8 +17177,7 @@ static int _sp_read_radix_16(sp_int* a, const char* in)
 
     return err;
 }
-#endif /* (WOLFSSL_SP_MATH_ALL && !NO_RSA && !WOLFSSL_RSA_VERIFY_ONLY) ||
-        * HAVE_ECC || !NO_DSA */
+#endif /* WOLFSSL_SP_READ_RADIX_16 */
 
 #ifdef WOLFSSL_SP_READ_RADIX_10
 /* Convert decimal number as string in big-endian format to a multi-precision
@@ -17228,8 +17232,7 @@ static int _sp_read_radix_10(sp_int* a, const char* in)
 }
 #endif /* WOLFSSL_SP_READ_RADIX_10 */
 
-#if (defined(WOLFSSL_SP_MATH_ALL) && !defined(NO_RSA) && \
-    !defined(WOLFSSL_RSA_VERIFY_ONLY)) || defined(HAVE_ECC) || !defined(NO_DSA)
+#if defined(WOLFSSL_SP_READ_RADIX_16) || defined(WOLFSSL_SP_READ_RADIX_10)
 /* Convert a number as string in big-endian format to a big number.
  * Only supports base-16 (hexadecimal) and base-10 (decimal).
  *
@@ -17302,8 +17305,7 @@ int sp_read_radix(sp_int* a, const char* in, int radix)
 
     return err;
 }
-#endif /* (WOLFSSL_SP_MATH_ALL && !NO_RSA && !WOLFSSL_RSA_VERIFY_ONLY) ||
-        * HAVE_ECC || !NO_DSA */
+#endif /* WOLFSSL_SP_READ_RADIX_16 || WOLFSSL_SP_READ_RADIX_10 */
 
 #if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
     defined(WC_MP_TO_RADIX)

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2606,12 +2606,12 @@ typedef enum {
 #ifdef WOLFSSL_QUIC
     TLSX_KEY_QUIC_TP_PARAMS_DRAFT   = 0xffa5, /* from draft-ietf-quic-tls-27 */
 #endif
-#if defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
     TLSX_ECH                        = 0xfe0d, /* from draft-ietf-tls-esni-13 */
 #endif
 } TLSX_Type;
 
-#if defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
 
 typedef enum {
     ECH_TYPE_OUTER = 0,
@@ -3623,7 +3623,7 @@ struct WOLFSSL_CTX {
         const WOLFSSL_QUIC_METHOD *method;
     } quic;
 #endif
-#if defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
     WOLFSSL_EchConfig* echConfigs;
 #endif
 };
@@ -4393,7 +4393,7 @@ typedef struct Options {
 #ifdef WOLFSSL_DTLS_CID
     word16            useDtlsCID:1;
 #endif /* WOLFSSL_DTLS_CID */
-#if defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
     word16            useEch:1;
 #endif
 #ifdef WOLFSSL_SEND_HRR_COOKIE
@@ -4459,7 +4459,7 @@ typedef struct Arrays {
     byte            psk_key[MAX_PSK_KEY_LEN];
 #endif
     byte            clientRandom[RAN_LEN];
-#if defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
     byte            clientRandomInner[RAN_LEN];
 #endif
     byte            serverRandom[RAN_LEN];
@@ -5027,7 +5027,7 @@ struct WOLFSSL {
     byte            serverSecret[SECRET_LEN];
 #endif
     HS_Hashes*      hsHashes;
-#if defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
     HS_Hashes*      hsHashesEch;
 #endif
     void*           IOCB_ReadCtx;
@@ -5489,7 +5489,7 @@ struct WOLFSSL {
                                           * content have not been handled yet by quic */
     } quic;
 #endif /* WOLFSSL_QUIC */
-#if defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
     WOLFSSL_EchConfig* echConfigs;
 #endif
 };

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -985,7 +985,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfSSLv23_method(void);
 
 #endif /* WOLFSSL_DTLS */
 
-#if defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
 WOLFSSL_API int wolfSSL_CTX_GenerateEchConfig(WOLFSSL_CTX* ctx,
     const char* publicName, word16 kemId, word16 kdfId, word16 aeadId);
 
@@ -1000,7 +1000,7 @@ WOLFSSL_API int wolfSSL_SetEchConfigs(WOLFSSL* ssl, const byte* echConfigs,
 
 WOLFSSL_API int wolfSSL_GetEchConfigs(WOLFSSL* ssl, byte* echConfigs,
     word32* echConfigsLen);
-#endif /* HAVE_ECH */
+#endif /* WOLFSSL_TLS13 && HAVE_ECH */
 
 #ifdef HAVE_POLY1305
     WOLFSSL_API int wolfSSL_use_old_poly(WOLFSSL* ssl, int value);

--- a/wolfssl/wolfcrypt/integer.h
+++ b/wolfssl/wolfcrypt/integer.h
@@ -388,7 +388,7 @@ MP_API int mp_radix_size (mp_int * a, int radix, int *size);
     !defined(NO_DSA) || !defined(NO_DH)
     MP_API int mp_sqrmod(mp_int* a, mp_int* b, mp_int* c);
 #endif
-#if !defined(NO_DSA) || defined(HAVE_ECC)
+#if !defined(NO_DSA) || defined(HAVE_ECC) || defined(OPENSSL_EXTRA)
     MP_API int mp_read_radix(mp_int* a, const char* str, int radix);
 #endif
 


### PR DESCRIPTION
# Description

HAVE_ECH only used by TLS 1.3 add protection around all code. ssl->options.onlyPskDheKe only available when HAVE_SUPPORTED_CURVES. CleanupClientTickets() defined when HAVE_SUPPORTED_CURVES. TLSX_KeyShare_DeriveSecret only defined when HAVE_SUPPORTED_CURVES. DecodeResponseData - initialize variable single.
New OpenSSL compatibility BN code requires mp_read_radix - turn on in integer.c, sp_int.c when OPENSSL_EXTRA defined.
rsa.c:_CheckProbablePrime - make sure tmp1 and tmp2 are initialized before error handling jumps to freeing them.

test_remove_hs_message uses 1024-bit DH key which is not supported when using SP math with SP.

# Testing

Regression testing.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
