### PR TITLE
Async sniffer: don't retry if seeing non-pending error

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -831,6 +831,7 @@ static void FreeSnifferSession(SnifferSession* session)
 #endif
     }
     XFREE(session, NULL, DYNAMIC_TYPE_SNIFFER_SESSION);
+    XMEMSET(session, 0, sizeof(SnifferSession));
 }
 
 
@@ -855,6 +856,7 @@ void ssl_FreeSniffer(void)
             FreeSnifferSession(removeSession);
         }
     }
+    XMEMSET(SessionTable, 0, sizeof(SessionTable));
     SessionCount = 0;
 
     /* Then server (wolfSSL_CTX) */

--- a/sslSniffer/sslSnifferTest/snifftest.c
+++ b/sslSniffer/sslSnifferTest/snifftest.c
@@ -573,11 +573,15 @@ static int SnifferAsyncPollQueue(byte** data, char* err, SSLInfo* sslInfo,
                     asyncQueue[i].length, 0, data, err, sslInfo, NULL);
                 asyncQueue[i].lastRet = ret;
                 if (ret != WC_PENDING_E) {
+                    if (ret < 0) {
+                        printf("ssl_Decode ret = %d, %s on packet number %d\n",
+                                ret, err, asyncQueue[i].packetNumber);
+                    }
                     /* done, so free and break to process below */
                     XFREE(asyncQueue[i].packet, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                     asyncQueue[i].packet = NULL;
-                    if (ret > 0) {
-                        /* decrypted some data, so return */
+                    if (ret != 0) {
+                        /* decrypted some data or found error, so return */
                         break;
                     }
                 }

--- a/sslSniffer/sslSnifferTest/snifftest.c
+++ b/sslSniffer/sslSnifferTest/snifftest.c
@@ -572,7 +572,7 @@ static int SnifferAsyncPollQueue(byte** data, char* err, SSLInfo* sslInfo,
                 ret = ssl_DecodePacketAsync(asyncQueue[i].packet,
                     asyncQueue[i].length, 0, data, err, sslInfo, NULL);
                 asyncQueue[i].lastRet = ret;
-                if (ret >= 0) {
+                if (ret != WC_PENDING_E) {
                     /* done, so free and break to process below */
                     XFREE(asyncQueue[i].packet, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                     asyncQueue[i].packet = NULL;


### PR DESCRIPTION
# Description

In async mode, don't retry decrypting if a valid error is encountered on a packet parse attempt.
Fixes zd#15867

# Testing

Using test case provided by customer.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
