### PR TITLE
Fix OOB read in DecodeAltNames

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -17146,7 +17146,7 @@ static int DecodeAltNames(const byte* input, int sz, DecodedCert* cert)
                 }
 
                 /* test if scheme is missing or hier-part is empty */
-                if (input[idx + i] != ':' || i == 0 || i == strLen) {
+                if (i == 0 || i == strLen || input[idx + i] != ':') {
                     WOLFSSL_MSG("\tAlt Name must be absolute URI");
                     WOLFSSL_ERROR_VERBOSE(ASN_ALT_NAME_E);
                     return ASN_ALT_NAME_E;


### PR DESCRIPTION
# Description

Ordering of logic allowed OOB read before index validation.

Fixes zd15869

# Testing

Reproduced with customer test

`./configure --enable-tls13 --enable-ocsp --enable-dtls --enable-sni --enable-blake2 --enable-blake2s --enable-curve25519 --enable-session-ticket --enable-nullcipher --enable-crl --enable-ed25519 --enable-psk --enable-earlydata --enable-postauth --enable-hrrcookie --enable-opensslextra --enable-certext --enable-tlsx --enable-oldtls --enable-tlsv10 --enable-indef --enable-psk --enable-ecccustcurves=all --enable-secure-renegotiation --enable-curve25519 --enable-curve448 --enable-ed25519 --enable-ed448 --enable-ocspstapling --enable-srp --enable-dtls13 --enable-dtlscid --enable-dsa --enable-sslv3 --enable-asn=original --enable-opensslall --enable-static --enable-debug CFLAGS="-fsanitize=address" CC=clang && make
`
# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
