### PR TITLE
Async build typos and miscellaneous fixes

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -16045,8 +16045,8 @@ void SendFatalAlertOnly(WOLFSSL *ssl, int error)
     case WANT_WRITE:
     case WANT_READ:
     case ZERO_RETURN:
-#ifdef WOLFSSL_ASYNC
-    case WC_PENGIND_E:
+#ifdef WOLFSSL_ASYNC_CRYPT
+    case WC_PENDING_E:
 #endif
         return;
     case BUFFER_ERROR:

--- a/wolfcrypt/src/siphash.c
+++ b/wolfcrypt/src/siphash.c
@@ -744,6 +744,12 @@ int wc_SipHash(const unsigned char* key, const unsigned char* in, word32 inSz,
         "cmp    %w[outSz], #8\n\t"
         "b.eq   L_siphash_8_end\n\t"
 
+    : [in] "+r" (in), [inSz] "+r" (inSz)
+    : [key] "r" (key), [out] "r" (out) , [outSz] "r" (outSz)
+    : "memory", "x8", "x9", "x10", "x11", "x12", "x13");
+
+    __asm__ __volatile__ (
+
         "mov    w13, #0xee\n\t"
         "eor    x10, x10, x13\n\t"
 #if WOLFSSL_SIPHASH_DROUNDS == 2

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -651,7 +651,8 @@ static void render_error_message(const char* msg, int es)
  * infelicitous...
  */
 #if !defined(STRING_USER) && !defined(NO_ERROR_STRINGS) &&      \
-    (defined(_GNU_SOURCE) || defined(__USE_GNU) ||              \
+    (defined(__STDC_VERSION__) && (__STDC_VERSION__ > 199901L)) &&      \
+    ((defined(__GLIBC__) && (__GLIBC__ >= 2)) ||                \
      (defined(__USE_XOPEN2K) &&                                 \
       defined(_POSIX_C_SOURCE) &&                               \
       (_POSIX_C_SOURCE >= 200112L)))


### PR DESCRIPTION
# Description
Fix for async build with enable all and the following warnings:

```
wolfcrypt/test/test.c:667:22: error: incompatible integer to pointer conversion assigning to 'char *' from 'int' [-Werror,-Wint-conversion]
        errno_string = strerror_r(WC_TEST_RET_DEC_I(es),
```

```
wolfcrypt/src/siphash.c:638:9: error: string literal of length 6770 exceeds maximum length 4095 that ISO C99 compilers are required to support [-Werror,-Woverlength-strings]
        "ldp    x12, x13, [%[key]]\n\t"
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

Fixes zd#

# Testing

Make check and multi test

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
