### PR TITLE
AES-GCM streaming: EVP needs to set IV with wc_AesGcmInit

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -8169,6 +8169,11 @@ int wc_AesGcmInit(Aes* aes, const byte* key, word32 len, const byte* iv,
     }
 
     if (ret == 0) {
+        /* Set the IV passed in if it is smaller than a block. */
+        if ((iv != NULL) && (ivSz <= AES_BLOCK_SIZE)) {
+            XMEMCPY((byte*)aes->reg, iv, ivSz);
+            aes->nonceSz = ivSz;
+        }
         /* No IV passed in, check for cached IV. */
         if ((iv == NULL) && (aes->nonceSz != 0)) {
             /* Use the cached copy. */


### PR DESCRIPTION
# Description

Store IV if it is small enough to fit in aes->reg - was a copy of the aes->reg in the first place.

# Testing

./configure --enable-quic --enable-aesgcm-stream

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
