### PR TITLE
Fix for variable server startup time

### DIFF
--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -401,7 +401,15 @@ generate_port() {
 generate_port
 openssl s_server $V4V6_FLAG -cert ./certs/server-cert.pem -key certs/server-key.pem -www -port $port &
 openssl_pid=$!
-sleep 0.1
+MAX_TIMEOUT=10
+until nc -z localhost $port # Wait for openssl to be ready
+do
+    sleep 0.05
+    if [ "$MAX_TIMEOUT" == "0" ]; then
+        break
+    fi
+    ((MAX_TIMEOUT--))
+done
 
 printf '%s\n\n' "------------- TEST CASE 6 SHOULD PASS ----------------------"
 # client asks for OCSP staple but doesn't fail when none returned

--- a/scripts/ocsp-stapling2.test
+++ b/scripts/ocsp-stapling2.test
@@ -466,7 +466,15 @@ generate_port() {
 generate_port
 openssl s_server -cert ./certs/server-cert.pem -key certs/server-key.pem -www -port $port &
 openssl_pid=$!
-sleep 0.1
+MAX_TIMEOUT=10
+until nc -z localhost $port # Wait for openssl to be ready
+do
+    sleep 0.05
+    if [ "$MAX_TIMEOUT" == "0" ]; then
+        break
+    fi
+    ((MAX_TIMEOUT--))
+done
 
 printf '%s\n\n' "------------- TEST CASE 9 SHOULD PASS ----------------------"
 # client asks for OCSP staple but doesn't fail when none returned


### PR DESCRIPTION
# Description

When running in a container that uses emulation, startup times for openssl take a bit longer. To avoid unnecessary delays on non-emulation tests I've put in a dynamic delay.