### PR TITLE
Benchmark: fix reporting of base10

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1665,8 +1665,8 @@ static WC_INLINE int bench_stats_check(double start)
     return ((current_time(0) - start) < BENCH_MIN_RUNTIME_SEC);
 }
 
-/* return text for units and scale the value of blocks as needed for base2 */
-static const char* get_blocktype_base10(double* blocks)
+/* return text for units and scale the value of blocks as needed */
+static const char* get_blocktype(double* blocks)
 {
     const char* rt;
 
@@ -1674,7 +1674,7 @@ static const char* get_blocktype_base10(double* blocks)
        defined(WOLFSSL_BENCHMARK_FIXED_UNITS_GB))
     #undef  WOLFSSL_FIXED_UNITS_PER_SEC
     #define WOLFSSL_FIXED_UNITS_PER_SEC "GB/s"
-    *blocks /= (1000UL * 1000UL * 1000UL);
+    *blocks /= (1024UL * 1024UL * 1024UL);
     rt = "GiB";
 #elif (defined(WOLFSSL_BENCHMARK_FIXED_UNITS_M) || \
        defined(WOLFSSL_BENCHMARK_FIXED_UNITS_MB))
@@ -1712,8 +1712,8 @@ static const char* get_blocktype_base10(double* blocks)
     return rt;
 }
 
-/* return text for units and scale the value of blocks as needed */
-static const char* get_blocktype(double* blocks)
+/* return text for units and scale the value of blocks as needed for base2 */
+static const char* get_blocktype_base10(double* blocks)
 {
     const char* rt;
 


### PR DESCRIPTION
# Description

Benchmark wasn't reporting GiB/GB and MiB/MB correctly.
GiB is GibiByte = 2^30
GB is GigaByte = 10^9.
MiB is MebiByte = 2^20
MB is MegaByte = 10^6.

Was using base2 for base10 and vice-versa.
GiB wasn't being calculated correctly (using 10^9)

# Testing

Run with and without -base10.
When -base10, the amount processed should be larger as we are dividing by a smaller number.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
