### PR TITLE
Remove expectation for an argument to be passed

### DIFF
--- a/certs/renewcerts.sh
+++ b/certs/renewcerts.sh
@@ -98,20 +98,20 @@ run_renewcerts(){
     ############################################################
     # Public Versions of client-key.pem
     ############################################################
-    openssl rsa -inform pem -in certs/client-key.pem -outform der -out certs/client-keyPub.der -pubout
-    openssl rsa -inform pem -in certs/client-key.pem -outform pem -out certs/client-keyPub.pem -pubout
+    openssl rsa -inform pem -in client-key.pem -outform der -out client-keyPub.der -pubout
+    openssl rsa -inform pem -in client-key.pem -outform pem -out client-keyPub.pem -pubout
 
     ############################################################
     # Public Versions of server-key.pem
     ############################################################
-    #openssl rsa -inform pem -in certs/server-key.pem -outform der -out certs/server-keyPub.der -pubout
-    openssl rsa -inform pem -in certs/server-key.pem -outform pem -out certs/server-keyPub.pem -pubout
+    #openssl rsa -inform pem -in server-key.pem -outform der -out server-keyPub.der -pubout
+    openssl rsa -inform pem -in server-key.pem -outform pem -out server-keyPub.pem -pubout
 
     ############################################################
     # Public Versions of ecc-key.pem
     ############################################################
-    #openssl ec -inform pem -in certs/ecc-key.pem -outform der -out certs/ecc-keyPub.der -pubout
-    openssl ec -inform pem -in certs/ecc-key.pem -outform pem -out certs/ecc-keyPub.pem -pubout
+    #openssl ec -inform pem -in ecc-key.pem -outform der -out ecc-keyPub.der -pubout
+    openssl ec -inform pem -in ecc-key.pem -outform pem -out ecc-keyPub.pem -pubout
 
     ############################################################
     #### update the self-signed (2048-bit) client-absolute-urn.pem

--- a/certs/renewcerts.sh
+++ b/certs/renewcerts.sh
@@ -48,7 +48,7 @@ check_result(){
         echo "Failed at \"$2\", Abort"
         exit 1
     else
-        echo "Step Succeeded!"
+        echo "$2 Succeeded!"
     fi
 }
 
@@ -859,6 +859,21 @@ echo "Running make clean"
 echo ""
 make clean
 check_result $? "make clean"
+
+RANDFILE=/var/lib/jenkins/.rnd
+RANDFILE2=/home/jenkins/.rnd
+
+# Test for OpenSSL .rnd file:
+echo "RANDFILE = $RANDFILE"
+echo "RANDFILE2 = $RANDFILE2"
+if [ ! -f "$RANDFILE" ]; then
+    echo "We should touch $RANDFILE"
+    mkdir -p $(dirname $RANDFILE) && touch "$RANDFILE" || exit 1
+fi
+if [ ! -f "$RANDFILE2" ]; then
+    echo "We should touch $RANDFILE2"
+    mkdir -p $(dirname $RANDFILE2) && touch "$RANDFILE2" || exit 1
+fi
 
 run_renewcerts
 cd ../ || exit 1

--- a/certs/renewcerts.sh
+++ b/certs/renewcerts.sh
@@ -43,14 +43,6 @@
 ######################## FUNCTIONS SECTION ####################################
 ###############################################################################
 
-#function for restoring a previous configure state
-restore_config(){
-    mv tmp.status config.status
-    mv tmp.options.h wolfssl/options.h
-    make clean
-    make -j 8
-}
-
 check_result(){
     if [ $1 -ne 0 ]; then
         echo "Failed at \"$2\", Abort"
@@ -863,11 +855,6 @@ if [ ! -z "$1" ]; then
     exit 1
 fi
 
-echo "Saving the configure state"
-echo ""
-cp config.status tmp.status || exit 1
-cp wolfssl/options.h tmp.options.h || exit 1
-
 echo "Running make clean"
 echo ""
 make clean
@@ -876,9 +863,5 @@ check_result $? "make clean"
 run_renewcerts
 cd ../ || exit 1
 rm ./certs/wolfssl.cnf
-
-# restore previous configure state
-restore_config
-check_result $? "restoring old configuration"
 
 exit 0

--- a/certs/renewcerts.sh
+++ b/certs/renewcerts.sh
@@ -860,20 +860,7 @@ echo ""
 make clean
 check_result $? "make clean"
 
-RANDFILE=/var/lib/jenkins/.rnd
-RANDFILE2=/home/jenkins/.rnd
-
-# Test for OpenSSL .rnd file:
-echo "RANDFILE = $RANDFILE"
-echo "RANDFILE2 = $RANDFILE2"
-if [ ! -f "$RANDFILE" ]; then
-    echo "We should touch $RANDFILE"
-    mkdir -p $(dirname $RANDFILE) && touch "$RANDFILE" || exit 1
-fi
-if [ ! -f "$RANDFILE2" ]; then
-    echo "We should touch $RANDFILE2"
-    mkdir -p $(dirname $RANDFILE2) && touch "$RANDFILE2" || exit 1
-fi
+touch certs/.rnd || exit 1
 
 run_renewcerts
 cd ../ || exit 1

--- a/certs/renewcerts.sh
+++ b/certs/renewcerts.sh
@@ -858,42 +858,27 @@ run_renewcerts(){
 #start in root.
 cd ../ || exit 1
 
-#if there was an argument given, check it for validity or print out error
 if [ ! -z "$1" ]; then
-    #valid argument print out other valid arguments
-    if [ "$1" == "-h" ] || [ "$1" == "-help" ]; then
-        echo ""
-        echo "\"no argument\"        will attempt to update all certificates"
-        echo "-h or -help          display this menu"
-        echo ""
-        echo ""
-    #else the argument was invalid, tell user to use -h or -help
-    else
-        echo ""
-        echo "That is not a valid option."
-        echo ""
-        echo "use -h or -help for a list of available options."
-        echo ""
-    fi
-else
-    echo "Saving the configure state"
-    echo ""
-    cp config.status tmp.status || exit 1
-    cp wolfssl/options.h tmp.options.h || exit 1
+    echo "No arguments expected"
+    exit 1
+fi
 
-    echo "Running make clean"
-    echo ""
-    make clean
-    check_result $? "make clean"
+echo "Saving the configure state"
+echo ""
+cp config.status tmp.status || exit 1
+cp wolfssl/options.h tmp.options.h || exit 1
 
-    run_renewcerts
-    cd ../ || exit 1
-    rm ./certs/wolfssl.cnf
+echo "Running make clean"
+echo ""
+make clean
+check_result $? "make clean"
 
-    # restore previous configure state
-    restore_config
-    check_result $? "restoring old configuration"
+run_renewcerts
+cd ../ || exit 1
+rm ./certs/wolfssl.cnf
 
-fi #END already defined
+# restore previous configure state
+restore_config
+check_result $? "restoring old configuration"
 
 exit 0

--- a/certs/renewcerts/wolfssl.cnf
+++ b/certs/renewcerts/wolfssl.cnf
@@ -2,7 +2,6 @@
 # wolfssl configuration file
 #
 HOME        = .
-RANDFILE    = $ENV::HOME/.rnd
 
 oid_section = new_oids
 
@@ -37,7 +36,7 @@ crlnumber        = $dir/certs/crl/crlnumber   # the current crl number
 
 crl              = $dir/certs/crl/crl.pem     # The current CRL
 private_key      = $dir/certs/ca-key.pem      # The private key
-RANDFILE         = $dir/certs/private/.rand   # private random number file
+RANDFILE         = $dir/certs/.rnd            # private random number file
 
 x509_extensions  = usr_cert                   # The extensions to add to the cert
 


### PR DESCRIPTION
Added in a failing return value to flush out tests/scripts that may be calling this script multiple times with various arguments
