### PR TITLE
Fix a typo in PP macro and add a ceiling to guard against implementation bugs

### DIFF
--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -991,8 +991,24 @@ static void Entropy_StopThread(void)
 #ifndef ENTROPY_NUM_WORDS_BITS
     /* Number of bits to count of 64-bit words in state. */
     #define ENTROPY_NUM_WORDS_BITS      14
-#elif ENTROPY_NUM_WORDS_BITS < 8
+#endif
+
+/* Floor of 8 yields pool of 256x 64-bit word samples
+ * 9  -> 512x 64-bit word samples
+ * 10 -> 1,024x 64-bit word samples
+ * 11 -> 2,048x 64-bit word samples
+ * 12 -> 4,096x 64-bit word samples
+ * 13 -> 8,192x 64-bit word samples
+ * 14 -> 16,384x 64-bit word samples
+ * 15 -> 32,768x 64-bit word samples
+ * ... doubling every time up to a maximum of:
+ * 30 -> 1,073,741,824x 64-bit word samples
+ * 1 billion+ samples should be more then sufficient for any use-case
+ */
+#if ENTROPY_NUM_WORDS_BITS < 8
     #error "ENTROPY_NUM_WORDS_BITS must be 8 or more"
+#elif ENTROPY_NUM_WORDS_BITS > 30
+    #error "ENTROPY_NUM_WORDS_BITS must be less than 31"
 #endif
 /* Number of 64-bit words in state. */
 #define ENTROPY_NUM_WORDS               (1 << ENTROPY_NUM_WORDS_BITS)
@@ -1010,7 +1026,7 @@ static void Entropy_StopThread(void)
     /* Upper round of log2(ENTROPY_NUM_UPDATES) */
     #define ENTROPY_NUM_UPDATES_BITS    5
 #elif !defined(ENTROPY_NUM_UPDATES_BITS)
-    #define ENTROP_NUM_UPDATES_BITS     ENTROPY_BLOCK_SZ
+    #define ENTROPY_NUM_UPDATES_BITS     ENTROPY_BLOCK_SZ
 #endif
 /* Amount to shift offset to get better coverage of a block */
 #define ENTROPY_OFFSET_SHIFTING          \


### PR DESCRIPTION
# Description

Prior to fixing the typo ENTROPY_OFFSET_SHIFTING computed to 0 since `ENTROPY_NUM_UPDATES_BITS` was never defined (instead value was assigned to `ENTROP_NUM_UPDATES_BITS`)

Prior to adding a ceiling users could achieve a negative sized array if value of ENTROPY_NUM_WORDS_BITS was defined to be 31, 63, 95 (repeating every 32 values) due to the left-shift on this value used to compute the array size of `entropy_state` buffer.  (caught at build time)

Furthermore users could achieve pools smaller then the desired 256 64-bit word samples by configuring to any value in the ranges 32-39, 64-71, 96-103... repeating every 32 for the 7 values following the rollover values. Imposing a floor of 8 and a ceiling of 30 grants users from 256, 512, 1024... doubling every increased value up to a maximum of 1,073,741,824 64-bit word samples at the ceiling value of 30 (should be more than sufficient for any use-case).

