### PR TITLE
Fixes for sniffer with enable all

### DIFF
--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -16,6 +16,11 @@ if ! ./examples/client/client -V | grep -q 3; then
     exit 77
 fi
 
+if ./examples/client/client '-#' | fgrep -q -e ' -DWOLFSSL_SNIFFER '; then
+    echo 'skipping oscp-stapling.test because WOLFSSL_SNIFFER defined.'
+    exit 77
+fi
+
 if openssl s_server -help 2>&1 | fgrep -q -i ipv6 && nc -h 2>&1 | fgrep -q -i ipv6; then
     IPV6_SUPPORTED=yes
 else

--- a/scripts/ocsp-stapling2.test
+++ b/scripts/ocsp-stapling2.test
@@ -29,6 +29,11 @@ if ! ./examples/client/client -V | grep -q 3; then
     exit 77
 fi
 
+if ./examples/client/client '-#' | fgrep -q -e ' -DWOLFSSL_SNIFFER '; then
+    echo 'skipping oscp-stapling2.test because WOLFSSL_SNIFFER defined.'
+    exit 77
+fi
+
 if openssl s_server -help 2>&1 | fgrep -q -i ipv6 && nc -h 2>&1 | fgrep -q -i ipv6; then
     IPV6_SUPPORTED=yes
 else

--- a/src/internal.c
+++ b/src/internal.c
@@ -24206,8 +24206,8 @@ const char* GetCipherKeaStr(char n[][MAX_SEGMENT_SZ]) {
         keaStr = "PSK";
     else if (XSTRCMP(n[0],"EDH") == 0)
         keaStr = "EDH";
-    else if ((XSTRCMP(n[1],"SHA") == 0) || (XSTRCMP(n[2],"SHA") == 0) ||
-             (XSTRCMP(n[3],"SHA") == 0) || (XSTRCMP(n[4],"SHA") == 0) ||
+    else if ((XSTRNCMP(n[1],"SHA", 3) == 0) || (XSTRNCMP(n[2],"SHA", 3) == 0) ||
+             (XSTRNCMP(n[3],"SHA", 3) == 0) || (XSTRNCMP(n[4],"SHA", 3) == 0) ||
              (XSTRCMP(n[2],"RSA") == 0) || (XSTRCMP(n[0],"AES128") == 0) ||
              (XSTRCMP(n[0],"AES256") == 0) || (XSTRCMP(n[1],"MD5") == 0))
         keaStr = "RSA";
@@ -24231,7 +24231,7 @@ const char* GetCipherAuthStr(char n[][MAX_SEGMENT_SZ]) {
         ((XSTRCMP(n[0],"TLS13") == 0) && ((XSTRCMP(n[1],"AES128") == 0) ||
          (XSTRCMP(n[1],"AES256") == 0) || (XSTRCMP(n[1],"CHACHA20") == 0))) ||
         (XSTRCMP(n[0],"RSA") == 0) || (XSTRCMP(n[1],"RSA") == 0) ||
-        (XSTRCMP(n[1],"SHA") == 0) || (XSTRCMP(n[2],"SHA") == 0) ||
+        (XSTRNCMP(n[1],"SHA", 3) == 0) || (XSTRNCMP(n[2],"SHA", 3) == 0) ||
         (XSTRCMP(n[1],"MD5") == 0))
         authStr = "RSA";
     else if (XSTRCMP(n[0],"PSK") == 0 || XSTRCMP(n[1],"PSK") == 0)


### PR DESCRIPTION
# Description

Fixes for `./configure --enable-all --enable-sniffer && make check`.

Changes:
- src/internal.c: Use `XSTRNCMP` instead of `XSTRCMP` in certain cases. Instead of expecting just `SHA`, expect `SHA256`, `SHA384`, etc
- ocsp tests: Skip running whenever with sniffer enabled.

# Testing

Make check.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
