### PR TITLE
fix overwriting serialNumber by favouriteDrink when generating Cert

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -45103,6 +45103,14 @@ static int test_wolfSSL_make_cert(void)
     AssertIntEQ(ASN1_STRING_length(entryValue), 2);
     AssertStrEQ((const char*)ASN1_STRING_data(entryValue), "US");
 
+    /* compare Serial Number */
+    AssertIntEQ((idx = X509_NAME_get_index_by_NID(x509name, NID_serialNumber,
+                    -1)), 7);
+    AssertNotNull(entry = X509_NAME_get_entry(x509name, idx));
+    AssertNotNull(entryValue = X509_NAME_ENTRY_get_data(entry));
+    AssertIntEQ(ASN1_STRING_length(entryValue), XSTRLEN("wolfSSL12345"));
+    AssertStrEQ((const char*)ASN1_STRING_data(entryValue), "wolfSSL12345");
+
 #ifdef WOLFSSL_MULTI_ATTRIB
     /* get first and second DC and compare result */
     AssertIntEQ((idx = X509_NAME_get_index_by_NID(x509name, NID_domainComponent,

--- a/tests/api.c
+++ b/tests/api.c
@@ -45103,6 +45103,7 @@ static int test_wolfSSL_make_cert(void)
     AssertIntEQ(ASN1_STRING_length(entryValue), 2);
     AssertStrEQ((const char*)ASN1_STRING_data(entryValue), "US");
 
+#ifndef WOLFSSL_MULTI_ATTRIB
     /* compare Serial Number */
     AssertIntEQ((idx = X509_NAME_get_index_by_NID(x509name, NID_serialNumber,
                     -1)), 7);
@@ -45110,6 +45111,7 @@ static int test_wolfSSL_make_cert(void)
     AssertNotNull(entryValue = X509_NAME_ENTRY_get_data(entry));
     AssertIntEQ(ASN1_STRING_length(entryValue), XSTRLEN("wolfSSL12345"));
     AssertStrEQ((const char*)ASN1_STRING_data(entryValue), "wolfSSL12345");
+#endif
 
 #ifdef WOLFSSL_MULTI_ATTRIB
     /* get first and second DC and compare result */

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -686,7 +686,7 @@ enum DN_Tags {
 
     /* pilot attribute types
      * OID values of 0.9.2342.19200300.100.1.* */
-    ASN_FAVOURITE_DRINK  = 0x05, /* favouriteDrink */
+    ASN_FAVOURITE_DRINK  = 0x13, /* favouriteDrink */
     ASN_DOMAIN_COMPONENT = 0x19  /* DC */
 };
 


### PR DESCRIPTION
# Description
Fix overwriting serialNumber attribute by favouriteDrink due to the same DN_Tags

Fixes zd#15903

# Testing

Added a unit test to check not to overwrite the attribute 

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
