### PR TITLE
cppcheck fixes

### DIFF
--- a/IDE/Espressif/ESP-IDF/test/test_wolfssl.c
+++ b/IDE/Espressif/ESP-IDF/test/test_wolfssl.c
@@ -1125,7 +1125,7 @@ TEST_CASE("wolfssl aes sha256 rsa multi-thread test ", "[wolfssl]")
     exit_loop = true;
 
     /* wait until rsa test finishes */
-    while(rsa_elapsedTime<=0){ vTaskDelay(1); }
+    while(rsa_elapsedTime==0){ vTaskDelay(1); }
 
     ESP_LOGI(TAG, "Waiting another %llu s. rsa test would take more time to finish.",
                (rsa_elapsedTime+3000)/portTICK_PERIOD_MS);

--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -1269,12 +1269,10 @@ static int SocketWaitClient(info_t* info)
     int connd;
     struct sockaddr_in clientAddr;
     socklen_t size = sizeof(clientAddr);
-#ifdef WOLFSSL_DTLS
-    char msg[64];
-#endif
 
 #ifdef WOLFSSL_DTLS
     if (info->doDTLS) {
+        char msg[64];
 #ifdef HAVE_PTHREAD
         if (!info->clientOrserverOnly) {
             PTHREAD_CHECK_RET(pthread_mutex_lock(&info->dtls_mutex));

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -782,8 +782,8 @@ static int ClientBenchmarkThroughput(WOLFSSL_CTX* ctx, char* host, word16 port,
             err_sys("Client buffer malloc failed");
         }
 doExit:
-        if (tx_buffer) XFREE(tx_buffer, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        if (rx_buffer) XFREE(rx_buffer, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(tx_buffer, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(rx_buffer, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     }
     else {
         err_sys("wolfSSL_connect failed");
@@ -953,7 +953,6 @@ static int ClientWrite(WOLFSSL* ssl, const char* msg, int msgSz, const char* str
     int exitWithRet)
 {
     int ret, err;
-    char buffer[WOLFSSL_MAX_ERROR_SZ];
 
     do {
         err = 0; /* reset error */
@@ -974,6 +973,7 @@ static int ClientWrite(WOLFSSL* ssl, const char* msg, int msgSz, const char* str
     #endif
     );
     if (ret != msgSz) {
+        char buffer[WOLFSSL_MAX_ERROR_SZ];
         fprintf(stderr, "SSL_write%s msg error %d, %s\n", str, err,
                                         wolfSSL_ERR_error_string(err, buffer));
         if (!exitWithRet) {
@@ -4311,9 +4311,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
 #if !defined(NO_SESSION_CACHE) && (defined(OPENSSL_EXTRA) || \
         defined(HAVE_EXT_CACHE))
-        if (flatSession) {
-            XFREE(flatSession, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        }
+        XFREE(flatSession, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         wolfSSL_SESSION_free(session);
         session = NULL;

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -298,7 +298,6 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
         CYASSL* ssl = NULL;
         CYASSL* write_ssl = NULL;   /* may have separate w/ HAVE_WRITE_DUP */
         char    command[SVR_COMMAND_SIZE+1];
-        int     echoSz = 0;
         int     clientfd;
         int     firstRead = 1;
         int     gotFirstG = 0;
@@ -374,6 +373,8 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
 #endif
 
         while (1) {
+            int echoSz;
+
             do {
                 err = 0; /* reset error */
                 ret = CyaSSL_read(ssl, command, sizeof(command)-1);

--- a/src/bio.c
+++ b/src/bio.c
@@ -2057,11 +2057,10 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
     WOLFSSL_BIO *wolfSSL_BIO_new_connect(const char *str)
     {
         WOLFSSL_BIO *bio;
-        const char* port;
         WOLFSSL_ENTER("wolfSSL_BIO_new_connect");
         bio = wolfSSL_BIO_new(wolfSSL_BIO_s_socket());
         if (bio) {
-            port = XSTRSTR(str, ":");
+            const char* port = XSTRSTR(str, ":");
 
             if (port != NULL)
                 bio->port = (word16)XATOI(port + 1);
@@ -2261,8 +2260,6 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
 
     void wolfSSL_BIO_ssl_shutdown(WOLFSSL_BIO* b)
     {
-        int rc;
-
         WOLFSSL_ENTER("wolfSSL_BIO_ssl_shutdown");
 
         if (b == NULL) {
@@ -2279,7 +2276,7 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
         }
 
         if (b->ptr != NULL) {
-            rc = wolfSSL_shutdown((WOLFSSL*)b->ptr);
+            int rc = wolfSSL_shutdown((WOLFSSL*)b->ptr);
             if (rc == SSL_SHUTDOWN_NOT_DONE) {
                 /* In this case, call again to give us a chance to read the
                  * close notify alert from the other end. */
@@ -2386,7 +2383,6 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
 
     long wolfSSL_BIO_set_conn_hostname(WOLFSSL_BIO* b, char* name)
     {
-        size_t currLen = 0;
         size_t newLen = 0;
 
         WOLFSSL_ENTER("wolfSSL_BIO_set_conn_hostname");
@@ -2414,7 +2410,7 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
             }
         }
         else {
-            currLen = XSTRLEN(b->ip);
+            size_t currLen = XSTRLEN(b->ip);
             if (currLen != newLen) {
                 b->ip = (char*)XREALLOC(b->ip, newLen + 1, b->heap,
                     DYNAMIC_TYPE_OPENSSL);

--- a/src/conf.c
+++ b/src/conf.c
@@ -158,7 +158,6 @@ long wolfSSL_TXT_DB_write(WOLFSSL_BIO *out, WOLFSSL_TXT_DB *db)
     long totalLen = 0;
     char buf[512]; /* Should be more than enough for a single row */
     char* bufEnd = buf + sizeof(buf);
-    int sz;
     int i;
 
     WOLFSSL_ENTER("wolfSSL_TXT_DB_write");
@@ -172,6 +171,7 @@ long wolfSSL_TXT_DB_write(WOLFSSL_BIO *out, WOLFSSL_TXT_DB *db)
     while (data) {
         char** fields = (char**)data->data.string;
         char* idx = buf;
+        int sz;
 
         if (!fields) {
             WOLFSSL_MSG("Missing row");
@@ -1499,10 +1499,9 @@ static const conf_cmd_tbl* wolfssl_conf_find_cmd(WOLFSSL_CONF_CTX* cctx,
                                          const char* cmd)
 {
     size_t i = 0;
-    size_t cmdlen = 0;
 
     if (cctx->flags & WOLFSSL_CONF_FLAG_CMDLINE) {
-        cmdlen = XSTRLEN(cmd);
+        size_t cmdlen = XSTRLEN(cmd);
 
         if (cmdlen < 2) {
             WOLFSSL_MSG("bad cmdline command");

--- a/src/keys.c
+++ b/src/keys.c
@@ -3326,7 +3326,7 @@ int DeriveKeys(WOLFSSL* ssl)
     int    length = 2 * ssl->specs.hash_size +
                     2 * ssl->specs.key_size  +
                     2 * ssl->specs.iv_size;
-    int    rounds = (length + WC_MD5_DIGEST_SIZE - 1 ) / WC_MD5_DIGEST_SIZE, i;
+    int    rounds = (length + WC_MD5_DIGEST_SIZE - 1 ) / WC_MD5_DIGEST_SIZE;
     int    ret = 0;
 
 #ifdef WOLFSSL_SMALL_STACK
@@ -3375,6 +3375,8 @@ int DeriveKeys(WOLFSSL* ssl)
         ret = wc_InitSha(sha);
     }
     if (ret == 0) {
+        int i;
+
         XMEMCPY(md5Input, ssl->arrays->masterSecret, SECRET_LEN);
 
         for (i = 0; i < rounds; ++i) {

--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -1260,9 +1260,6 @@ int wolfSSL_OCSP_id_get0_info(WOLFSSL_ASN1_STRING **name,
   WOLFSSL_ASN1_OBJECT **pmd, WOLFSSL_ASN1_STRING **keyHash,
   WOLFSSL_ASN1_INTEGER **serial, WOLFSSL_OCSP_CERTID *cid)
 {
-    int i = 0;
-    WOLFSSL_ASN1_INTEGER* ser;
-
     WOLFSSL_ENTER("wolfSSL_OCSP_id_get0_info");
 
     if (cid == NULL)
@@ -1270,6 +1267,9 @@ int wolfSSL_OCSP_id_get0_info(WOLFSSL_ASN1_STRING **name,
 
     /* build up ASN1_INTEGER for serial */
     if (serial != NULL) {
+        int i = 0;
+        WOLFSSL_ASN1_INTEGER* ser;
+
         ser = wolfSSL_ASN1_INTEGER_new();
         if (ser == NULL)
             return 0;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1817,14 +1817,13 @@ int wolfSSL_get_ciphers(char* buf, int len)
     const CipherSuiteInfo* ciphers = GetCipherNames();
     int ciphersSz = GetCipherNamesSize();
     int i;
-    int cipherNameSz;
 
     if (buf == NULL || len <= 0)
         return BAD_FUNC_ARG;
 
     /* Add each member to the buffer delimited by a : */
     for (i = 0; i < ciphersSz; i++) {
-        cipherNameSz = (int)XSTRLEN(ciphers[i].name);
+        int cipherNameSz = (int)XSTRLEN(ciphers[i].name);
         if (cipherNameSz + 1 < len) {
             XSTRNCPY(buf, ciphers[i].name, len);
             buf += cipherNameSz;
@@ -4563,14 +4562,13 @@ int wolfSSL_want_write(WOLFSSL* ssl)
 
 char* wolfSSL_ERR_error_string(unsigned long errNumber, char* data)
 {
-    static char tmp[WOLFSSL_MAX_ERROR_SZ] = {0};
-
     WOLFSSL_ENTER("wolfSSL_ERR_error_string");
     if (data) {
         SetErrorString((int)errNumber, data);
         return data;
     }
     else {
+        static char tmp[WOLFSSL_MAX_ERROR_SZ] = {0};
         SetErrorString((int)errNumber, tmp);
         return tmp;
     }
@@ -4583,10 +4581,9 @@ void wolfSSL_ERR_error_string_n(unsigned long e, char* buf, unsigned long len)
     if (len >= WOLFSSL_MAX_ERROR_SZ)
         wolfSSL_ERR_error_string(e, buf);
     else {
-        char tmp[WOLFSSL_MAX_ERROR_SZ];
-
         WOLFSSL_MSG("Error buffer too short, truncating");
         if (len) {
+            char tmp[WOLFSSL_MAX_ERROR_SZ];
             wolfSSL_ERR_error_string(e, tmp);
             XMEMCPY(buf, tmp, len-1);
             buf[len-1] = '\0';
@@ -5102,11 +5099,12 @@ WOLFSSL_CERT_MANAGER* wolfSSL_CertManagerNew(void)
 
 void wolfSSL_CertManagerFree(WOLFSSL_CERT_MANAGER* cm)
 {
-    int doFree = 0;
-    int ret;
     WOLFSSL_ENTER("wolfSSL_CertManagerFree");
 
     if (cm) {
+        int doFree = 0;
+        int ret;
+
         wolfSSL_RefDec(&cm->ref, &doFree, &ret);
     #ifdef WOLFSSL_REFCNT_ERROR_RETURN
         if (ret != 0) {
@@ -6495,9 +6493,6 @@ static int ProcessUserChain(WOLFSSL_CTX* ctx, const unsigned char* buff,
 {
     int ret = 0;
     void* heap = wolfSSL_CTX_GetHeap(ctx, ssl);
-#ifdef WOLFSSL_TLS13
-    int cnt = 0;
-#endif
 
     if ((type == CA_TYPE) && (ctx == NULL)) {
         WOLFSSL_MSG("Need context for CA load");
@@ -6517,6 +6512,9 @@ static int ProcessUserChain(WOLFSSL_CTX* ctx, const unsigned char* buff,
         long   consumed = info->consumed;
         word32 idx = 0;
         int    gotOne = 0;
+    #ifdef WOLFSSL_TLS13
+        int cnt = 0;
+    #endif
 
         /* Calculate max possible size, including max headers */
         bufferSz = (word32)(sz - consumed) + (CERT_HEADER_SZ * MAX_CHAIN_DEPTH);
@@ -8709,9 +8707,7 @@ int wolfSSL_CTX_load_verify_locations_ex(WOLFSSL_CTX* ctx, const char* file,
 {
     int ret = WOLFSSL_SUCCESS;
 #ifndef NO_WOLFSSL_DIR
-    int fileRet;
     int successCount = 0;
-    int failCount = 0;
 #endif
     int verify;
 
@@ -8743,6 +8739,8 @@ int wolfSSL_CTX_load_verify_locations_ex(WOLFSSL_CTX* ctx, const char* file,
     if (ret == WOLFSSL_SUCCESS && path) {
 #ifndef NO_WOLFSSL_DIR
         char* name = NULL;
+        int fileRet;
+        int failCount = 0;
     #ifdef WOLFSSL_SMALL_STACK
         ReadDirCtx* readCtx;
         readCtx = (ReadDirCtx*)XMALLOC(sizeof(ReadDirCtx), ctx->heap,
@@ -10099,7 +10097,6 @@ static WOLFSSL_EVP_PKEY* d2iGenericKey(WOLFSSL_EVP_PKEY** out,
         word32  keyIdx = 0;
         DhKey*  key = NULL;
         int ret;
-        int elements;
     #ifdef WOLFSSL_SMALL_STACK
         DhKey* dh = (DhKey*)XMALLOC(sizeof(DhKey), NULL, DYNAMIC_TYPE_DH);
         if (dh == NULL)
@@ -10147,7 +10144,8 @@ static WOLFSSL_EVP_PKEY* d2iGenericKey(WOLFSSL_EVP_PKEY** out,
                 keyIdx = 0;
                 if (wc_DhKeyDecode(mem, &keyIdx, key, (word32)memSz) == 0)
                 {
-                    elements = ELEMENT_P | ELEMENT_G | ELEMENT_Q | ELEMENT_PUB;
+                    int elements = ELEMENT_P | ELEMENT_G | ELEMENT_Q |
+                                   ELEMENT_PUB;
                     if (priv)
                         elements |= ELEMENT_PRV;
                     if(SetDhExternal_ex(pkey->dh, elements)
@@ -10480,7 +10478,6 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PUBKEY(WOLFSSL_EVP_PKEY** out,
 /* helper function to get raw pointer to DER buffer from WOLFSSL_EVP_PKEY */
 static int wolfSSL_EVP_PKEY_get_der(const WOLFSSL_EVP_PKEY* key, unsigned char** der)
 {
-    unsigned char* pt;
     int sz;
     word16 pkcs8HeaderSz;
 
@@ -10494,7 +10491,7 @@ static int wolfSSL_EVP_PKEY_get_der(const WOLFSSL_EVP_PKEY* key, unsigned char**
         pkcs8HeaderSz = key->pkcs8HeaderSz;
     sz = key->pkey_sz - pkcs8HeaderSz;
     if (der) {
-        pt = (unsigned char*)key->pkey.ptr;
+        unsigned char* pt = (unsigned char*)key->pkey.ptr;
         if (*der) {
             /* since this function signature has no size value passed in it is
              * assumed that the user has allocated a large enough buffer */
@@ -15014,7 +15011,7 @@ ClientSession* AddSessionToClientCache(int side, int row, int idx, byte* serverI
                             word16 useTicket)
 {
     int error = -1;
-    word32 clientRow = 0, clientIdx = 0, sessionIDHash = 0;
+    word32 clientRow = 0, clientIdx = 0;
     (void)useTicket;
     if (side == WOLFSSL_CLIENT_END
             && row != INVALID_SESSION_ROW
@@ -15046,7 +15043,8 @@ ClientSession* AddSessionToClientCache(int side, int row, int idx, byte* serverI
                 ClientCache[clientRow].Clients[clientIdx].serverIdx =
                                                                 (word16)idx;
                 if (sessionID != NULL) {
-                    sessionIDHash = HashObject(sessionID, ID_LEN, &error);
+                    word32 sessionIDHash = HashObject(sessionID, ID_LEN,
+                                                      &error);
                     if (error == 0) {
                         ClientCache[clientRow].Clients[clientIdx].sessionIDHash
                             = sessionIDHash;
@@ -15477,9 +15475,6 @@ void AddSession(WOLFSSL* ssl)
     const byte* id = NULL;
     byte idSz = 0;
     WOLFSSL_SESSION* session = ssl->session;
-#ifdef HAVE_EXT_CACHE
-    int cbRet = 0;
-#endif
 
     (void)error;
 
@@ -15592,6 +15587,7 @@ void AddSession(WOLFSSL* ssl)
 
 #ifdef HAVE_EXT_CACHE
     if (error == 0 && ssl->ctx->new_sess_cb != NULL) {
+        int cbRet = 0;
         wolfSSL_SESSION_up_ref(session);
         cbRet = ssl->ctx->new_sess_cb(ssl, session);
         if (cbRet == 0)
@@ -21312,8 +21308,6 @@ WOLFSSL_SESSION* wolfSSL_SESSION_dup(WOLFSSL_SESSION* session)
 
 void wolfSSL_FreeSession(WOLFSSL_CTX* ctx, WOLFSSL_SESSION* session)
 {
-    int isZero;
-
     session = ClientSessionToSession(session);
     if (session == NULL)
         return;
@@ -21322,6 +21316,7 @@ void wolfSSL_FreeSession(WOLFSSL_CTX* ctx, WOLFSSL_SESSION* session)
 
     if (session->ref.count > 0) {
         int ret;
+        int isZero;
         wolfSSL_RefDec(&session->ref, &isZero, &ret);
         (void)ret;
         if (!isZero) {
@@ -21851,7 +21846,6 @@ int wolfSSL_CIPHER_get_auth_nid(const WOLFSSL_CIPHER* cipher)
         {NULL,      NID_undef}
     };
 
-    const struct authnid* sa;
     const char* authStr;
     char n[MAX_SEGMENTS][MAX_SEGMENT_SZ] = {{0}};
 
@@ -21863,6 +21857,7 @@ int wolfSSL_CIPHER_get_auth_nid(const WOLFSSL_CIPHER* cipher)
     authStr = GetCipherAuthStr(n);
 
     if (authStr != NULL) {
+        const struct authnid* sa;
         for(sa = authnid_tbl; sa->alg_name != NULL; sa++) {
             if (XSTRCMP(sa->alg_name, authStr) == 0) {
                 return sa->nid;
@@ -21896,7 +21891,6 @@ int wolfSSL_CIPHER_get_cipher_nid(const WOLFSSL_CIPHER* cipher)
         {NULL,                      NID_undef}
     };
 
-    const struct ciphernid* c;
     const char* encStr;
     char n[MAX_SEGMENTS][MAX_SEGMENT_SZ] = {{0}};
 
@@ -21910,6 +21904,7 @@ int wolfSSL_CIPHER_get_cipher_nid(const WOLFSSL_CIPHER* cipher)
     encStr = GetCipherEncStr(n);
 
     if (encStr != NULL) {
+        const struct ciphernid* c;
         for(c = ciphernid_tbl; c->alg_name != NULL; c++) {
             if (XSTRCMP(c->alg_name, encStr) == 0) {
                 return c->nid;
@@ -21935,7 +21930,6 @@ int wolfSSL_CIPHER_get_digest_nid(const WOLFSSL_CIPHER* cipher)
         {NULL,      NID_undef}
     };
 
-    const struct macnid* mc;
     const char* name;
     const char* macStr;
     char n[MAX_SEGMENTS][MAX_SEGMENT_SZ] = {{0}};
@@ -21956,6 +21950,7 @@ int wolfSSL_CIPHER_get_digest_nid(const WOLFSSL_CIPHER* cipher)
     macStr = GetCipherMacStr(n);
 
     if (macStr != NULL) {
+        const struct macnid* mc;
         for(mc = macnid_tbl; mc->alg_name != NULL; mc++) {
             if (XSTRCMP(mc->alg_name, macStr) == 0) {
                 return mc->nid;
@@ -21986,7 +21981,6 @@ int wolfSSL_CIPHER_get_kx_nid(const WOLFSSL_CIPHER* cipher)
         {NULL,        NID_undef}
     };
 
-    const struct kxnid* k;
     const char* keaStr;
     char n[MAX_SEGMENTS][MAX_SEGMENT_SZ] = {{0}};
 
@@ -22005,6 +21999,7 @@ int wolfSSL_CIPHER_get_kx_nid(const WOLFSSL_CIPHER* cipher)
     keaStr = GetCipherKeaStr(n);
 
     if (keaStr != NULL) {
+        const struct kxnid* k;
         for(k = kxnid_table; k->name != NULL; k++) {
             if (XSTRCMP(k->name, keaStr) == 0) {
                 return k->nid;
@@ -22558,7 +22553,7 @@ int wolfSSL_i2d_PublicKey(const WOLFSSL_EVP_PKEY *key, unsigned char **der)
     word32 inOutIdx = 0;
 #endif
     word32 pub_derSz = 0;
-    int ret = 0;
+    int ret;
     int key_type = 0;
 
     if (key == NULL) {
@@ -22567,7 +22562,7 @@ int wolfSSL_i2d_PublicKey(const WOLFSSL_EVP_PKEY *key, unsigned char **der)
 
     key_type = key->type;
     if ((key_type != EVP_PKEY_EC) && (key_type != EVP_PKEY_RSA)) {
-        ret = WOLFSSL_FATAL_ERROR;
+        return WOLFSSL_FATAL_ERROR;
     }
 
 #ifndef NO_RSA
@@ -22583,20 +22578,18 @@ int wolfSSL_i2d_PublicKey(const WOLFSSL_EVP_PKEY *key, unsigned char **der)
     /* We need to get the DER, then convert it to a public key. But what we get
      * might be a buffered private key so we need to decode it and then encode
      * the public part. */
-    if (ret == 0) {
-        ret = wolfSSL_EVP_PKEY_get_der(key, &local_der);
-        if (ret <= 0) {
-            /* In this case, there was no buffered DER at all. This could be the
-             * case where the key that was passed in was generated. So now we
-             * have to create the local DER. */
-            local_derSz = wolfSSL_i2d_ECPrivateKey(key->ecc, &local_der);
-            if (local_derSz == 0) {
-                ret = WOLFSSL_FATAL_ERROR;
-            }
-        } else {
-            local_derSz = ret;
-            ret = 0;
+    ret = wolfSSL_EVP_PKEY_get_der(key, &local_der);
+    if (ret <= 0) {
+        /* In this case, there was no buffered DER at all. This could be the
+         * case where the key that was passed in was generated. So now we
+         * have to create the local DER. */
+        local_derSz = wolfSSL_i2d_ECPrivateKey(key->ecc, &local_der);
+        if (local_derSz == 0) {
+            ret = WOLFSSL_FATAL_ERROR;
         }
+    } else {
+        local_derSz = ret;
+        ret = 0;
     }
 
     if (ret == 0) {
@@ -22621,7 +22614,7 @@ int wolfSSL_i2d_PublicKey(const WOLFSSL_EVP_PKEY *key, unsigned char **der)
 
     if (ret == 0) {
         pub_derSz = wc_EccPublicKeyDerSize(eccKey, 0);
-        if (pub_derSz <= 0) {
+        if ((int)pub_derSz <= 0) {
             ret = WOLFSSL_FAILURE;
         }
     }
@@ -22637,7 +22630,7 @@ int wolfSSL_i2d_PublicKey(const WOLFSSL_EVP_PKEY *key, unsigned char **der)
 
     if (ret == 0) {
         pub_derSz = wc_EccPublicKeyToDer(eccKey, pub_der, pub_derSz, 0);
-        if (pub_derSz <= 0) {
+        if ((int)pub_derSz <= 0) {
             ret = WOLFSSL_FATAL_ERROR;
         }
     }
@@ -23234,13 +23227,12 @@ const char* wolfSSL_state_string_long(const WOLFSSL* ssl)
  */
 int wolfSSL_PEM_def_callback(char* name, int num, int w, void* key)
 {
-    int sz;
     (void)w;
     WOLFSSL_ENTER("wolfSSL_PEM_def_callback");
 
     /* We assume that the user passes a default password as userdata */
     if (key) {
-        sz = (int)XSTRLEN((const char*)key);
+        int sz = (int)XSTRLEN((const char*)key);
         sz = (sz > num) ? num : sz;
         XMEMCPY(name, key, sz);
         return sz;
@@ -23891,11 +23883,9 @@ long wolfSSL_CTX_sess_number(WOLFSSL_CTX* ctx)
 long wolfSSL_CTX_add_extra_chain_cert(WOLFSSL_CTX* ctx, WOLFSSL_X509* x509)
 {
     byte* chain = NULL;
-    long  chainSz = 0;
     int   derSz;
     const byte* der;
     int   ret;
-    int   idx = 0;
     DerBuffer *derBuffer = NULL;
 
     WOLFSSL_ENTER("wolfSSL_CTX_add_extra_chain_cert");
@@ -23923,6 +23913,9 @@ long wolfSSL_CTX_add_extra_chain_cert(WOLFSSL_CTX* ctx, WOLFSSL_X509* x509)
         }
     }
     else {
+        long chainSz = 0;
+        int  idx = 0;
+
         /* TODO: Do this elsewhere. */
         ret = AllocDer(&derBuffer, derSz, CERT_TYPE, ctx->heap);
         if (ret != 0) {
@@ -25187,7 +25180,6 @@ int wolfSSL_i2d_SSL_SESSION(WOLFSSL_SESSION* sess, unsigned char** p)
 #ifdef SESSION_CERTS
     int i;
 #endif
-    unsigned char *data;
 
     WOLFSSL_ENTER("wolfSSL_i2d_SSL_SESSION");
 
@@ -25256,6 +25248,8 @@ int wolfSSL_i2d_SSL_SESSION(WOLFSSL_SESSION* sess, unsigned char** p)
 #endif
 
     if (p != NULL) {
+        unsigned char *data;
+
         if (*p == NULL)
             *p = (unsigned char*)XMALLOC(size, NULL, DYNAMIC_TYPE_OPENSSL);
         if (*p == NULL)
@@ -26562,8 +26556,6 @@ int wolfSSL_HMAC_Init(WOLFSSL_HMAC_CTX* ctx, const void* key, int keylen,
 int wolfSSL_HMAC_Update(WOLFSSL_HMAC_CTX* ctx, const unsigned char* data,
                     int len)
 {
-    int hmac_error = 0;
-
     WOLFSSL_MSG("wolfSSL_HMAC_Update");
 
     if (ctx == NULL) {
@@ -26572,6 +26564,8 @@ int wolfSSL_HMAC_Update(WOLFSSL_HMAC_CTX* ctx, const unsigned char* data,
     }
 
     if (data) {
+        int hmac_error = 0;
+
         WOLFSSL_MSG("updating hmac");
         hmac_error = wc_HmacUpdate(&ctx->hmac, data, (word32)len);
         if (hmac_error < 0){
@@ -27392,7 +27386,6 @@ int wolfSSL_get_signature_nid(WOLFSSL *ssl, int* nid)
 static int populate_groups(int* groups, int max_count, char *list)
 {
     char *end;
-    int len;
     int count = 0;
     const WOLF_EC_NIST_NAME* nist_name;
 
@@ -27401,6 +27394,8 @@ static int populate_groups(int* groups, int max_count, char *list)
     }
 
     for (end = list; ; list = ++end) {
+        int len;
+
         if (count > max_count) {
             WOLFSSL_MSG("Too many curves in list");
             return -1;
@@ -27476,7 +27471,6 @@ WOLFSSL_EVP_PKEY* wolfSSL_PEM_read_bio_PrivateKey(WOLFSSL_BIO* bio,
     WOLFSSL_EVP_PKEY* pkey = NULL;
     DerBuffer*         der = NULL;
     int             keyFormat = 0;
-    int                 type = -1;
 
     WOLFSSL_ENTER("wolfSSL_PEM_read_bio_PrivateKey");
 
@@ -27486,6 +27480,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_PEM_read_bio_PrivateKey(WOLFSSL_BIO* bio,
     if (pem_read_bio_key(bio, cb, pass, PRIVATEKEY_TYPE, &keyFormat, &der)
             >= 0) {
         const unsigned char* ptr = der->buffer;
+        int                  type = -1;
 
         if (keyFormat) {
             /* keyFormat is Key_Sum enum */
@@ -28418,13 +28413,13 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
         WOLFSSL_EVP_PKEY* pkey = NULL;
         DerBuffer*         der = NULL;
         int             keyFormat = 0;
-        int                 type = -1;
 
         WOLFSSL_ENTER("wolfSSL_PEM_read_PrivateKey");
 
         if (pem_read_file_key(fp, cb, pass, PRIVATEKEY_TYPE, &keyFormat,
                                                                    &der) >= 0) {
             const unsigned char* ptr = der->buffer;
+            int                  type = -1;
 
             if (keyFormat) {
                 /* keyFormat is Key_Sum enum */
@@ -28490,7 +28485,6 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
         char* nameStr = NULL;
         int nameLen = 0;
         char* headerStr = NULL;
-        int headerLen;
         int headerFound = 0;
         unsigned char* der = NULL;
         word32 derLen = 0;
@@ -28528,6 +28522,8 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
                 ret = WOLFSSL_FAILURE;
         }
         if (ret == WOLFSSL_SUCCESS) {
+            int headerLen;
+
             XSTRNCPY(nameStr, pem + PEM_BEGIN_SZ, nameLen);
             nameStr[nameLen] = '\0';
 
@@ -29461,7 +29457,7 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
     int wolfSSL_OBJ_ln2nid(const char *ln)
     {
         const WOLFSSL_ObjectInfo *obj_info = wolfssl_object_info;
-        size_t i, lnlen;
+        size_t lnlen;
         WOLFSSL_ENTER("wolfSSL_OBJ_ln2nid");
         if (ln && (lnlen = XSTRLEN(ln)) > 0) {
             /* Accept input like "/commonName=" */
@@ -29470,6 +29466,8 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
                 lnlen--;
             }
             if (lnlen) {
+                size_t i;
+
                 if (ln[lnlen-1] == '=') {
                     lnlen--;
                 }
@@ -30465,10 +30463,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PrivateKey_bio(WOLFSSL_BIO* bio,
     unsigned char* mem = NULL;
     int memSz = 0;
     WOLFSSL_EVP_PKEY* key = NULL;
-    int i = 0, j = 0;
     unsigned char* extraBioMem = NULL;
-    int extraBioMemSz = 0;
-    int derLength = 0;
 
     WOLFSSL_ENTER("wolfSSL_d2i_PrivateKey_bio");
 
@@ -30490,6 +30485,9 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PrivateKey_bio(WOLFSSL_BIO* bio,
     }
 
     if (wolfSSL_BIO_read(bio, (unsigned char*)mem, memSz) == memSz) {
+        int extraBioMemSz;
+        int derLength;
+
         /* Determines key type and returns the new private EVP_PKEY object */
         if ((key = wolfSSL_d2i_PrivateKey_EVP(NULL, &mem, (long)memSz)) == NULL) {
             WOLFSSL_MSG("wolfSSL_d2i_PrivateKey_EVP() failure");
@@ -30501,6 +30499,9 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PrivateKey_bio(WOLFSSL_BIO* bio,
         derLength = key->pkey_sz;
         extraBioMemSz = (memSz - derLength);
         if (extraBioMemSz > 0) {
+            int i;
+            int j = 0;
+
             extraBioMem = (unsigned char *)XMALLOC(extraBioMemSz, NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
             if (extraBioMem == NULL) {
@@ -30589,7 +30590,6 @@ static void SESSION_ex_data_cache_update(WOLFSSL_SESSION* session, int idx,
     int i;
     int error = 0;
     SessionRow* sessRow = NULL;
-    WOLFSSL_SESSION* cacheSession = NULL;
     const byte* id;
     byte foundCache = 0;
 
@@ -30619,6 +30619,7 @@ static void SESSION_ex_data_cache_update(WOLFSSL_SESSION* session, int idx,
     }
 
     for (i = 0; i < SESSIONS_PER_ROW && i < sessRow->totalCount; i++) {
+        WOLFSSL_SESSION* cacheSession;
 #ifdef SESSION_CACHE_DYNAMIC_MEM
         cacheSession = sessRow->Sessions[i];
 #else
@@ -34411,10 +34412,8 @@ int wolfSSL_PEM_write_bio_PKCS8PrivateKey(WOLFSSL_BIO* bio,
     byte* pem = NULL;
     int pemSz = 0;
     int type = PKCS8_PRIVATEKEY_TYPE;
-    int algId;
     const byte* curveOid;
     word32 oidSz;
-    int encAlgId = 0;
 
     if (bio == NULL || pkey == NULL)
         return -1;
@@ -34435,6 +34434,7 @@ int wolfSSL_PEM_write_bio_PKCS8PrivateKey(WOLFSSL_BIO* bio,
         WC_RNG rng;
         ret = wc_InitRng(&rng);
         if (ret == 0) {
+            int encAlgId = 0;
         #ifndef NO_DES3
             if (enc == EVP_DES_CBC)
                 encAlgId = DESb;
@@ -34465,6 +34465,7 @@ int wolfSSL_PEM_write_bio_PKCS8PrivateKey(WOLFSSL_BIO* bio,
         type = PKCS8_ENC_PRIVATEKEY_TYPE;
     }
     if (ret == 0 && enc == NULL) {
+        int algId;
         type = PKCS8_PRIVATEKEY_TYPE;
     #ifdef HAVE_ECC
         if (pkey->type == EVP_PKEY_EC) {
@@ -34627,9 +34628,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_AutoPrivateKey(WOLFSSL_EVP_PKEY** pkey,
     const byte* der = *pp;
     word32 idx = 0;
     int len = 0;
-    word32 end = 0;
     int cnt = 0;
-    int type;
     word32 algId;
     word32 keyLen = (word32)length;
 
@@ -34645,7 +34644,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_AutoPrivateKey(WOLFSSL_EVP_PKEY** pkey,
      */
     ret = GetSequence(der, &idx, &len, keyLen);
     if (ret >= 0) {
-        end = idx + len;
+        word32 end = idx + len;
         while (ret >= 0 && idx < end) {
             /* Skip type */
             idx++;
@@ -34664,6 +34663,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_AutoPrivateKey(WOLFSSL_EVP_PKEY** pkey,
     }
 
     if (ret >= 0) {
+        int type;
         /* ECC includes version, private[, curve][, public key] */
         if (cnt >= 2 && cnt <= 4)
             type = EVP_PKEY_EC;
@@ -35917,7 +35917,6 @@ int wolfSSL_RAND_bytes(unsigned char* buf, int num)
     WC_RNG  tmpRNG[1];
 #endif
     int initTmpRng = 0;
-    int blockCount = 0;
 #ifdef HAVE_GLOBAL_RNG
     int used_global = 0;
 #endif
@@ -35964,7 +35963,7 @@ int wolfSSL_RAND_bytes(unsigned char* buf, int num)
     }
     if (rng) {
         /* handles size greater than RNG_MAX_BLOCK_LEN */
-        blockCount = num / RNG_MAX_BLOCK_LEN;
+        int blockCount = num / RNG_MAX_BLOCK_LEN;
 
         while (blockCount--) {
             ret = wc_RNG_GenerateBlock(rng, buf, RNG_MAX_BLOCK_LEN);
@@ -38087,13 +38086,14 @@ WC_PKCS12* wolfSSL_PKCS12_create(char* pass, char* name, WOLFSSL_EVP_PKEY* pkey,
     }
 
     if (ca != NULL) {
-        WC_DerCertList* cur;
         unsigned long numCerts = ca->num;
-        byte* curDer;
-        int   curDerSz = 0;
         WOLFSSL_STACK* sk = ca;
 
         while (numCerts > 0 && sk != NULL) {
+            byte* curDer;
+            WC_DerCertList* cur;
+            int   curDerSz = 0;
+
             cur = (WC_DerCertList*)XMALLOC(sizeof(WC_DerCertList), NULL,
                     DYNAMIC_TYPE_PKCS);
             if (cur == NULL) {

--- a/src/ssl_bn.c
+++ b/src/ssl_bn.c
@@ -1273,7 +1273,6 @@ static int wolfssl_bn_add_word_int(WOLFSSL_BIGNUM *bn, WOLFSSL_BN_ULONG w,
     int sub)
 {
     int ret = 1;
-    int rc = 0;
 #if DIGIT_BIT < (SIZEOF_LONG * CHAR_BIT)
 #ifdef WOLFSSL_SMALL_STACK
     mp_int* w_mp = NULL;
@@ -1304,6 +1303,7 @@ static int wolfssl_bn_add_word_int(WOLFSSL_BIGNUM *bn, WOLFSSL_BN_ULONG w,
     }
 
     if (ret == 1) {
+        int rc = 0;
 #if DIGIT_BIT < (SIZEOF_LONG * CHAR_BIT)
         if (w > (WOLFSSL_BN_ULONG)MP_MASK) {
             /* Initialize temporary MP integer. */

--- a/src/tls.c
+++ b/src/tls.c
@@ -1030,7 +1030,7 @@ static int Hmac_UpdateFinal(Hmac* hmac, byte* digest, const byte* in,
     byte       dummy[WC_MAX_BLOCK_SIZE] = {0};
     int        ret;
     word32     msgSz, blockSz, macSz, padSz, maxSz, realSz;
-    word32     currSz, offset = 0;
+    word32     offset = 0;
     int        msgBlocks, blocks, blockBits;
     int        i;
 
@@ -1102,7 +1102,7 @@ static int Hmac_UpdateFinal(Hmac* hmac, byte* digest, const byte* in,
     ret = wc_HmacUpdate(hmac, header, WOLFSSL_TLS_HMAC_INNER_SZ);
     if (ret == 0) {
         /* Fill the rest of the block with any available data. */
-        currSz = ctMaskLT(msgSz, blockSz) & msgSz;
+        word32 currSz = ctMaskLT(msgSz, blockSz) & msgSz;
         currSz |= ctMaskGTE(msgSz, blockSz) & blockSz;
         currSz -= WOLFSSL_TLS_HMAC_INNER_SZ;
         currSz &= ~(0 - (currSz >> 31));
@@ -2027,7 +2027,6 @@ static int TLSX_SNI_Parse(WOLFSSL* ssl, const byte* input, word16 length,
     int cacheOnly = 0;
     SNI *sni = NULL;
     byte type;
-    int matchStat;
     byte matched;
 #if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
     WOLFSSL_ECH* ech = NULL;
@@ -2144,6 +2143,7 @@ static int TLSX_SNI_Parse(WOLFSSL* ssl, const byte* input, word16 length,
 #endif
 
     if (matched || sni->options & WOLFSSL_SNI_ANSWER_ON_MISMATCH) {
+        int matchStat;
         int r = TLSX_UseSNI(&ssl->extensions, type, input + offset, size,
                                                                      ssl->heap);
         if (r != WOLFSSL_SUCCESS)
@@ -4443,7 +4443,6 @@ int TLSX_SupportedFFDHE_Set(WOLFSSL* ssl)
     TLSX* ext = NULL;
     TLSX* extension;
     SupportedCurve* clientGroup;
-    SupportedCurve* serverGroup;
     SupportedCurve* group;
     int found = 0;
 
@@ -4476,6 +4475,8 @@ int TLSX_SupportedFFDHE_Set(WOLFSSL* ssl)
 
     ret = TLSX_PopulateSupportedGroups(ssl, &priority);
     if (ret == WOLFSSL_SUCCESS) {
+        SupportedCurve* serverGroup;
+
         ext = TLSX_Find(priority, TLSX_SUPPORTED_GROUPS);
         serverGroup = (SupportedCurve*)ext->data;
 
@@ -5933,8 +5934,6 @@ static int TLSX_SupportedVersions_Write(void* data, byte* output,
                                         byte msgType, word16* pSz)
 {
     WOLFSSL* ssl = (WOLFSSL*)data;
-    byte major;
-    byte* cnt;
     byte tls13minor, tls12minor, tls11minor, isDtls = 0;
 
     tls13minor = (byte)TLSv1_3_MINOR;
@@ -5955,9 +5954,9 @@ static int TLSX_SupportedVersions_Write(void* data, byte* output,
 #endif /* WOLFSSL_DTLS13 */
 
     if (msgType == client_hello) {
-        major = ssl->ctx->method->version.major;
+        byte major = ssl->ctx->method->version.major;
 
-        cnt = output++;
+        byte* cnt = output++;
         *cnt = 0;
 
         if (versionIsLessEqual(isDtls, ssl->options.minDowngrade, tls13minor)
@@ -6049,11 +6048,8 @@ int TLSX_SupportedVersions_Parse(const WOLFSSL* ssl, const byte* input,
         word16 length, byte msgType, ProtocolVersion* pv, Options* opts,
         TLSX** exts)
 {
-    int i;
-    int len;
     /* The client's greatest minor version that we support */
     byte clientGreatestMinor = SSLv3_MINOR;
-    int set = 0;
     int ret;
     byte major, minor;
     byte tls13minor, tls12minor;
@@ -6072,6 +6068,10 @@ int TLSX_SupportedVersions_Parse(const WOLFSSL* ssl, const byte* input,
 #endif /* WOLFSSL_DTLS13 */
 
     if (msgType == client_hello) {
+        int i;
+        int len;
+        int set = 0;
+
         /* Must contain a length and at least one version. */
         if (length < OPAQUE8_LEN + OPAQUE16_LEN || (length & 1) != 1)
             return BUFFER_ERROR;
@@ -9655,8 +9655,6 @@ int TLSX_PreSharedKey_Parse_ClientHello(TLSX** extensions, const byte* input,
 static int TLSX_PreSharedKey_Parse(WOLFSSL* ssl, const byte* input,
                                    word16 length, byte msgType)
 {
-    TLSX*         extension;
-    PreSharedKey* list;
 
     if (msgType == client_hello) {
         return TLSX_PreSharedKey_Parse_ClientHello(&ssl->extensions, input,
@@ -9665,6 +9663,8 @@ static int TLSX_PreSharedKey_Parse(WOLFSSL* ssl, const byte* input,
 
     if (msgType == server_hello) {
         word16 idx;
+        PreSharedKey* list;
+        TLSX*         extension;
 
         /* Index of identity chosen by server. */
         if (length != OPAQUE16_LEN)

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -2647,13 +2647,12 @@ void wolfSSL_SetIO_Mynewt(WOLFSSL* ssl, struct mn_socket* mnSocket, struct mn_so
 int uIPSend(WOLFSSL* ssl, char* buf, int sz, void* _ctx)
 {
     uip_wolfssl_ctx *ctx = (struct uip_wolfssl_ctx *)_ctx;
-    int ret;
-    unsigned int max_sendlen;
     int total_written = 0;
     (void)ssl;
     do {
+        int ret;
         unsigned int bytes_left = sz - total_written;
-        max_sendlen = tcp_socket_max_sendlen(&ctx->conn.tcp);
+        unsigned int max_sendlen = tcp_socket_max_sendlen(&ctx->conn.tcp);
         if (bytes_left > max_sendlen) {
             fprintf(stderr, "uIPSend: Send limited by buffer\r\n");
             bytes_left = max_sendlen;

--- a/src/x509.c
+++ b/src/x509.c
@@ -12114,7 +12114,6 @@ static int wolfSSL_EscapeString_RFC2253(char* in, word32 inSz,
 {
     word32 inIdx = 0;
     word32 outIdx = 0;
-    char c = 0;
 
     if (in == NULL || out == NULL || inSz == 0 || outSz == 0) {
         return BAD_FUNC_ARG;
@@ -12122,7 +12121,7 @@ static int wolfSSL_EscapeString_RFC2253(char* in, word32 inSz,
 
     for (inIdx = 0; inIdx < inSz; inIdx++) {
 
-        c = in[inIdx];
+        char c = in[inIdx];
 
         if (((inIdx == 0) && (c == ' ' || c == '#')) ||
             ((inIdx == (inSz-1)) && (c == ' ')) ||
@@ -12169,7 +12168,7 @@ static int wolfSSL_EscapeString_RFC2253(char* in, word32 inSz,
 int wolfSSL_X509_NAME_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509_NAME* name,
                 int indent, unsigned long flags)
 {
-    int i, count = 0, len = 0, tmpSz = 0, nameStrSz = 0, escapeSz = 0;
+    int i, count = 0, nameStrSz = 0, escapeSz = 0;
     char* tmp = NULL;
     char* nameStr = NULL;
     const char *buf = NULL;
@@ -12190,6 +12189,9 @@ int wolfSSL_X509_NAME_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509_NAME* name,
     count = wolfSSL_X509_NAME_entry_count(name);
 
     for (i = 0; i < count; i++) {
+        int len;
+        int tmpSz;
+
         /* reverse name order for RFC2253 and DN_REV */
         if ((flags & XN_FLAG_RFC2253) || (flags & XN_FLAG_DN_REV)) {
             ne = wolfSSL_X509_NAME_get_entry(name, count - i - 1);
@@ -12913,7 +12915,6 @@ int wolfSSL_sk_X509_OBJECT_push(WOLFSSL_STACK* sk, WOLFSSL_X509_OBJECT* obj)
 int wolfSSL_X509_NAME_copy(WOLFSSL_X509_NAME* from, WOLFSSL_X509_NAME* to)
 {
     int i;
-    WOLFSSL_X509_NAME_ENTRY* ne;
 
     WOLFSSL_ENTER("wolfSSL_X509_NAME_copy");
 
@@ -12943,7 +12944,7 @@ int wolfSSL_X509_NAME_copy(WOLFSSL_X509_NAME* from, WOLFSSL_X509_NAME* to)
     to->sz = from->sz;
 
     for (i = 0; i < MAX_NAME_ENTRIES; i++) {
-        ne = wolfSSL_X509_NAME_get_entry(from, i);
+        WOLFSSL_X509_NAME_ENTRY* ne = wolfSSL_X509_NAME_get_entry(from, i);
         if (ne != NULL)
             wolfSSL_X509_NAME_add_entry(to, ne, i, 1);
     }

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1621,10 +1621,9 @@ typedef enum bench_stat_type {
     void bench_stats_print(void)
     {
         int i;
-        bench_stats_t* bstat;
 
         for (i=0; i<gStatsCount; i++) {
-            bstat = &gStats[i];
+            bench_stats_t* bstat = &gStats[i];
             if (bstat->type == BENCH_STAT_SYM) {
                 printf("%-16s %8.3f %s/s\n", bstat->desc, bstat->perfsec,
                     base2 ? "MB" : "mB");
@@ -6209,7 +6208,7 @@ exit:
 
 void bench_rsaKeyGen(int useDeviceID)
 {
-    int    k, keySz;
+    int    k;
 #if !defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
     const int  keySizes[2] = {1024, 2048};
 #else
@@ -6217,7 +6216,7 @@ void bench_rsaKeyGen(int useDeviceID)
 #endif
 
     for (k = 0; k < (int)(sizeof(keySizes)/sizeof(int)); k++) {
-        keySz = keySizes[k];
+        int keySz = keySizes[k];
         bench_rsaKeyGen_helper(useDeviceID, keySz);
     }
 }

--- a/wolfcrypt/src/coding.c
+++ b/wolfcrypt/src/coding.c
@@ -558,7 +558,6 @@ int Base16_Encode(const byte* in, word32 inLen, byte* out, word32* outLen)
 {
     word32 outIdx = 0;
     word32 i;
-    byte   hb, lb;
 
     if (in == NULL || out == NULL || outLen == NULL)
         return BAD_FUNC_ARG;
@@ -567,8 +566,8 @@ int Base16_Encode(const byte* in, word32 inLen, byte* out, word32* outLen)
         return BAD_FUNC_ARG;
 
     for (i = 0; i < inLen; i++) {
-        hb = in[i] >> 4;
-        lb = in[i] & 0x0f;
+        byte hb = in[i] >> 4;
+        byte lb = in[i] & 0x0f;
 
         /* ASCII value */
         hb += '0';

--- a/wolfcrypt/src/curve25519.c
+++ b/wolfcrypt/src/curve25519.c
@@ -83,8 +83,8 @@ static WC_INLINE int curve25519_priv_clamp_check(const byte* priv)
 static WC_INLINE void curve25519_copy_point(byte* out, const byte* point,
     int endian)
 {
-    int i;
     if (endian == EC25519_BIG_ENDIAN) {
+        int i;
         /* put shared secret key in Big Endian format */
         for (i = 0; i < CURVE25519_KEYSIZE; i++) {
             out[i] = point[CURVE25519_KEYSIZE - i -1];

--- a/wolfcrypt/src/curve448.c
+++ b/wolfcrypt/src/curve448.c
@@ -236,7 +236,6 @@ int wc_curve448_export_public_ex(curve448_key* key, byte* out, word32* outLen,
                                  int endian)
 {
     int ret = 0;
-    int i;
 
     if ((key == NULL) || (out == NULL) || (outLen == NULL)) {
         ret = BAD_FUNC_ARG;
@@ -258,6 +257,7 @@ int wc_curve448_export_public_ex(curve448_key* key, byte* out, word32* outLen,
     if (ret == 0) {
         *outLen = CURVE448_PUB_KEY_SIZE;
         if (endian == EC448_BIG_ENDIAN) {
+            int i;
             /* read keys in Big Endian format */
             for (i = 0; i < CURVE448_PUB_KEY_SIZE; i++) {
                 out[i] = key->p[CURVE448_PUB_KEY_SIZE - i - 1];
@@ -304,7 +304,6 @@ int wc_curve448_import_public_ex(const byte* in, word32 inLen,
                                  curve448_key* key, int endian)
 {
     int ret = 0;
-    int i;
 
     /* sanity check */
     if ((key == NULL) || (in == NULL)) {
@@ -318,6 +317,7 @@ int wc_curve448_import_public_ex(const byte* in, word32 inLen,
 
     if (ret == 0) {
         if (endian == EC448_BIG_ENDIAN) {
+            int i;
             /* read keys in Big Endian format */
             for (i = 0; i < CURVE448_PUB_KEY_SIZE; i++) {
                 key->p[i] = in[CURVE448_PUB_KEY_SIZE - i - 1];
@@ -345,7 +345,6 @@ int wc_curve448_import_public_ex(const byte* in, word32 inLen,
 int wc_curve448_check_public(const byte* pub, word32 pubSz, int endian)
 {
     int ret = 0;
-    word32 i;
 
     if (pub == NULL) {
         ret = BAD_FUNC_ARG;
@@ -362,6 +361,8 @@ int wc_curve448_check_public(const byte* pub, word32 pubSz, int endian)
     }
 
     if (ret == 0) {
+        word32 i;
+
         if (endian == EC448_LITTLE_ENDIAN) {
             /* Check for value of zero or one */
             for (i = CURVE448_PUB_KEY_SIZE - 1; i > 0; i--) {
@@ -465,7 +466,6 @@ int wc_curve448_export_private_raw_ex(curve448_key* key, byte* out,
                                       word32* outLen, int endian)
 {
     int ret = 0;
-    int i;
 
     /* sanity check */
     if ((key == NULL) || (out == NULL) || (outLen == NULL)) {
@@ -481,6 +481,7 @@ int wc_curve448_export_private_raw_ex(curve448_key* key, byte* out,
         *outLen = CURVE448_KEY_SIZE;
 
         if (endian == EC448_BIG_ENDIAN) {
+            int i;
             /* put the key in Big Endian format */
             for (i = 0; i < CURVE448_KEY_SIZE; i++) {
                 out[i] = key->k[CURVE448_KEY_SIZE - i - 1];
@@ -630,7 +631,6 @@ int wc_curve448_import_private_ex(const byte* priv, word32 privSz,
                                   curve448_key* key, int endian)
 {
     int ret = 0;
-    int i;
 
     /* sanity check */
     if ((key == NULL) || (priv == NULL)) {
@@ -644,6 +644,7 @@ int wc_curve448_import_private_ex(const byte* priv, word32 privSz,
 
     if (ret == 0) {
         if (endian == EC448_BIG_ENDIAN) {
+            int i;
             /* read the key in Big Endian format */
             for (i = 0; i < CURVE448_KEY_SIZE; i++) {
                 key->k[i] = priv[CURVE448_KEY_SIZE - i - 1];

--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -2375,14 +2375,13 @@ int wc_DhExportKeyPair(DhKey* key, byte* priv, word32* pPrivSz,
     byte* pub, word32* pPubSz)
 {
     int ret = 0;
-    word32 pubSz, privSz;
 
     if (key == NULL || (priv && pPrivSz == NULL) || (pub && pPubSz == NULL)) {
         return BAD_FUNC_ARG;
     }
 
     if (priv) {
-        privSz = mp_unsigned_bin_size(&key->priv);
+        word32 privSz = mp_unsigned_bin_size(&key->priv);
         if (privSz > *pPrivSz) {
             return BUFFER_E;
         }
@@ -2391,7 +2390,7 @@ int wc_DhExportKeyPair(DhKey* key, byte* priv, word32* pPrivSz,
     }
 
     if (pub) {
-        pubSz = mp_unsigned_bin_size(&key->pub);
+        word32 pubSz = mp_unsigned_bin_size(&key->pub);
         if (pubSz > *pPubSz) {
             return BUFFER_E;
         }

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -767,7 +767,7 @@ int wc_SSH_KDF(byte hashId, byte keyId, byte* key, word32 keySz,
     }
 
     digestSz = wc_HmacSizeByType(enmhashId);
-    if (digestSz < 0) {
+    if (digestSz <= 0) {
         return BAD_FUNC_ARG;
     }
 

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -358,7 +358,7 @@ void WOLFSSL_MSG(const char* msg)
 #endif
 void WOLFSSL_BUFFER(const byte* buffer, word32 length)
 {
-    int i, buflen = (int)length, bufidx;
+    int i, buflen = (int)length;
     char line[(LINE_LEN * 4) + 3]; /* \t00..0F | chars...chars\0 */
 
     if (!loggingEnabled) {
@@ -371,7 +371,7 @@ void WOLFSSL_BUFFER(const byte* buffer, word32 length)
     }
 
     while (buflen > 0) {
-        bufidx = 0;
+        int bufidx = 0;
         XSNPRINTF(&line[bufidx], sizeof(line)-bufidx, "\t");
         bufidx++;
 
@@ -621,10 +621,10 @@ int wc_AddErrorNode(int error, int line, char* reason, char* file)
  */
 void wc_RemoveErrorNode(int relative_idx)
 {
-    int last_idx, abs_idx = get_abs_idx(relative_idx);
-    size_t move_count;
+    int abs_idx = get_abs_idx(relative_idx);
 
     if (abs_idx >= 0) {
+        size_t move_count;
         if (abs_idx >= (int)wc_errors.head_idx) {
             /* removed entry sits "above" head (or is head),
              * move entries below it "up" */
@@ -640,7 +640,7 @@ void wc_RemoveErrorNode(int relative_idx)
         else {
             /* removed entry sits "below" head (wrap around),
              * move entries above it "down" */
-            last_idx = get_abs_idx(-1);
+            int last_idx = get_abs_idx(-1);
             if (last_idx >= abs_idx) {  /* this SHOULD always be true */
                 move_count = (last_idx - abs_idx);
                 if (move_count > 0) {
@@ -693,8 +693,6 @@ unsigned long wc_PeekErrorNodeLineData(const char **file, int *line,
                                        const char **data, int *flags,
                                        int (*ignore_err)(int err))
 {
-    int ret = 0;
-
     WOLFSSL_ENTER("wc_PeekErrorNodeLineData");
 
     /* No data or flags stored - error display only in Nginx. */
@@ -706,7 +704,7 @@ unsigned long wc_PeekErrorNodeLineData(const char **file, int *line,
     }
 
     while (1) {
-        ret = wc_PeekErrorNode(0, file, NULL, line);
+        int ret = wc_PeekErrorNode(0, file, NULL, line);
         if (ret == BAD_STATE_E) {
             WOLFSSL_MSG("Issue peeking at error node in queue");
             return 0;
@@ -757,7 +755,6 @@ unsigned long wc_GetErrorNodeErr(void)
 void wc_ERR_print_errors_cb(int (*cb)(const char *str, size_t len, void *u),
                             void *u)
 {
-    struct wc_error_entry *entry;
     size_t i;
 
     WOLFSSL_ENTER("wc_ERR_print_errors_cb");
@@ -768,7 +765,7 @@ void wc_ERR_print_errors_cb(int (*cb)(const char *str, size_t len, void *u),
     }
 
     for (i = 0; i < wc_errors.count; ++i) {
-        entry = get_entry((int)i);
+        struct wc_error_entry *entry = get_entry((int)i);
         if (entry == NULL)
             break;
         cb(entry->reason, XSTRLEN(entry->reason), u);
@@ -1200,7 +1197,6 @@ unsigned long wc_PeekErrorNodeLineData(const char **file, int *line,
                                        const char **data, int *flags,
                                        int (*ignore_err)(int err))
 {
-    int ret = 0;
     int idx;
 
     WOLFSSL_ENTER("wc_PeekErrorNodeLineData");
@@ -1220,7 +1216,7 @@ unsigned long wc_PeekErrorNodeLineData(const char **file, int *line,
 
     idx = getErrorNodeCurrentIdx();
     while (1) {
-        ret = peekErrorNode(idx, file, NULL, line);
+        int ret = peekErrorNode(idx, file, NULL, line);
         if (ret == BAD_MUTEX_E || ret == BAD_FUNC_ARG || ret == BAD_STATE_E) {
             WOLFSSL_MSG("Issue peeking at error node in queue");
             return 0;

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -242,7 +242,6 @@ void wc_MemZero_Check(void* addr, size_t len)
                     memZero[i].name, memZero[i].addr, j);
                 fprintf(stderr, "[MEM_ZERO] Checking %p:%ld\n", addr, len);
                 abort();
-                break;
             }
         }
         /* Update next index to write to. */
@@ -602,7 +601,6 @@ int wolfSSL_load_static_memory(byte* buffer, word32 sz, int flag,
 
     /* divide into chunks of memory and add them to available list */
     while (ava >= (heap->sizeList[0] + padSz + memSz)) {
-        int i;
         /* creating only IO buffers from memory passed in, max TLS is 16k */
         if (flag & WOLFMEM_IO_POOL || flag & WOLFMEM_IO_POOL_FIXED) {
             if ((ret = create_memory_buckets(pt, ava,
@@ -622,6 +620,7 @@ int wolfSSL_load_static_memory(byte* buffer, word32 sz, int flag,
             ava -= ret;
         }
         else {
+            int i;
             /* start at largest and move to smaller buckets */
             for (i = (WOLFMEM_MAX_BUCKETS - 1); i >= 0; i--) {
                 if ((heap->sizeList[i] + padSz + memSz) <= ava) {
@@ -1054,7 +1053,6 @@ void* wolfSSL_Realloc(void *ptr, size_t size, void* heap, int type)
 {
     void* res = 0;
     wc_Memory* pt = NULL;
-    word32 prvSz;
     int    i;
 
     /* check for testing heap hint was set */
@@ -1120,7 +1118,7 @@ void* wolfSSL_Realloc(void *ptr, size_t size, void* heap, int type)
                 res = pt->buffer;
 
                 /* copy over original information and free ptr */
-                prvSz = ((wc_Memory*)((byte*)ptr - padSz -
+                word32 prvSz = ((wc_Memory*)((byte*)ptr - padSz -
                                                sizeof(wc_Memory)))->sz;
                 prvSz = (prvSz > pt->sz)? pt->sz: prvSz;
                 XMEMCPY(pt->buffer, ptr, prvSz);

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -181,18 +181,18 @@ WC_MISC_STATIC WC_INLINE word32 ByteReverseWord32(word32 value)
 WC_MISC_STATIC WC_INLINE void ByteReverseWords(word32* out, const word32* in,
                                     word32 byteCount)
 {
-    word32 count, i;
+    word32 i;
 
 #ifdef WOLFSSL_USE_ALIGN
     if ((((size_t)in & 0x3) == 0) &&
         (((size_t)out & 0x3) == 0))
-    {
 #endif
-        count = byteCount/(word32)sizeof(word32);
+    {
+        word32 count = byteCount/(word32)sizeof(word32);
         for (i = 0; i < count; i++)
             out[i] = ByteReverseWord32(in[i]);
-#ifdef WOLFSSL_USE_ALIGN
     }
+#ifdef WOLFSSL_USE_ALIGN
     else {
         byte *in_bytes = (byte *)in;
         byte *out_bytes = (byte *)out;

--- a/wolfcrypt/src/port/Renesas/renesas_sce_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_sce_util.c
@@ -291,7 +291,7 @@ WOLFSSL_LOCAL int wc_SCE_EccVerify(WOLFSSL* ssl, const uint8_t* sig,
         return MEMORY_E;
     }
     /* initialization */
-    XMEMCPY(sigforSCE, 0, HW_SCE_ECDSA_DATA_BYTE_SIZE);
+    XMEMSET(sigforSCE, 0, HW_SCE_ECDSA_DATA_BYTE_SIZE);
 
     /* r */
     if (sig[offset] == 0x20) {
@@ -945,7 +945,7 @@ WOLFSSL_LOCAL int wc_sce_tls_CertVerify(
         return MEMORY_E;
       }
       /* initialization */
-      XMEMCPY(sigforSCE, 0, HW_SCE_ECDSA_DATA_BYTE_SIZE);
+      XMEMSET(sigforSCE, 0, HW_SCE_ECDSA_DATA_BYTE_SIZE);
 
       if (signature[offset] == 0x20) {
         XMEMCPY(sigforSCE, &signature[offset+1], rs_size);

--- a/wolfcrypt/src/port/caam/caam_aes.c
+++ b/wolfcrypt/src/port/caam/caam_aes.c
@@ -58,7 +58,6 @@ int  wc_AesSetKey(Aes* aes, const byte* key, word32 len,
     if (len > 32) {
         byte out[32]; /* max AES key size */
         word32 outSz;
-        int ret;
 
         if (len != 64 && len != 72 && len != 80) {
             return BAD_FUNC_ARG;

--- a/wolfcrypt/src/port/caam/caam_driver.c
+++ b/wolfcrypt/src/port/caam/caam_driver.c
@@ -1163,7 +1163,7 @@ int caamECDSAMake(DESCSTRUCT* desc, CAAM_BUFFER* buf, unsigned int args[4])
 
         /* create secure partition for private key out */
         part = caamFindUnusedPartition();
-        if (part < 0) {
+        if ((int)part < 0) {
             WOLFSSL_MSG("error finding an unused partition for new key");
             return -1;
         }

--- a/wolfcrypt/src/port/cypress/psoc6_crypto.c
+++ b/wolfcrypt/src/port/cypress/psoc6_crypto.c
@@ -101,7 +101,6 @@ int wc_Sha512GetHash(wc_Sha512* sha, byte* hash)
 
 int wc_Sha512Copy(wc_Sha512* src, wc_Sha512* dst)
 {
-    cy_en_crypto_status_t res;
     if ((!dst) || (!src))
         return BAD_FUNC_ARG;
     Cy_Crypto_Core_MemCpy(crypto_base, dst, src, sizeof(wc_Sha512));
@@ -158,7 +157,6 @@ int wc_Sha256GetHash(wc_Sha256* sha, byte* hash)
 
 int wc_Sha256Copy(wc_Sha256* src, wc_Sha256* dst)
 {
-    cy_en_crypto_status_t res;
     if ((!dst) || (!src))
         return BAD_FUNC_ARG;
     Cy_Crypto_Core_MemCpy(crypto_base, dst, src, sizeof(wc_Sha256));

--- a/wolfcrypt/src/port/xilinx/xil-sha3.c
+++ b/wolfcrypt/src/port/xilinx/xil-sha3.c
@@ -202,7 +202,9 @@ void wc_Sha3_384_Free(wc_Sha3* sha)
  */
 int wc_Sha3_384_GetHash(wc_Sha3* sha, byte* out)
 {
+#ifdef WOLFSSL_XILINX_CRYPTO_OLD
     wc_Sha3 s;
+#endif
 
     if (sha == NULL || out == NULL) {
         return BAD_FUNC_ARG;

--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -51,7 +51,7 @@ int wc_PBKDF1_ex(byte* key, int keyLen, byte* iv, int ivLen,
 {
     int  err;
     int  keyLeft, ivLeft, i;
-    int  digestLeft, store;
+    int  store;
     int  keyOutput = 0;
     int  diestLen;
     byte digest[WC_MAX_DIGEST_SIZE];
@@ -96,7 +96,7 @@ int wc_PBKDF1_ex(byte* key, int keyLen, byte* iv, int ivLen,
     keyLeft = keyLen;
     ivLeft  = ivLen;
     while (keyOutput < (keyLen + ivLen)) {
-        digestLeft = diestLen;
+        int digestLeft = diestLen;
         /* D_(i - 1) */
         if (keyOutput) { /* first time D_0 is empty */
             err = wc_HashUpdate(hash, hashT, digest, diestLen);
@@ -176,9 +176,8 @@ int wc_PBKDF1(byte* output, const byte* passwd, int pLen, const byte* salt,
 int wc_PBKDF2_ex(byte* output, const byte* passwd, int pLen, const byte* salt,
            int sLen, int iterations, int kLen, int hashType, void* heap, int devId)
 {
-    word32 i = 1;
     int    hLen;
-    int    j, ret;
+    int    ret;
 #ifdef WOLFSSL_SMALL_STACK
     byte*  buffer;
     Hmac*  hmac;
@@ -213,11 +212,13 @@ int wc_PBKDF2_ex(byte* output, const byte* passwd, int pLen, const byte* salt,
 
     ret = wc_HmacInit(hmac, heap, devId);
     if (ret == 0) {
+        word32 i = 1;
         /* use int hashType here, since HMAC FIPS uses the old unique value */
         ret = wc_HmacSetKey(hmac, hashType, passwd, pLen);
 
         while (ret == 0 && kLen) {
             int currentLen;
+            int j;
 
             ret = wc_HmacUpdate(hmac, salt, sLen);
             if (ret != 0)

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -617,10 +617,9 @@ static int Hash_gen(DRBG_internal* drbg, byte* out, word32 outSz, const byte* V)
 
 static WC_INLINE void array_add(byte* d, word32 dLen, const byte* s, word32 sLen)
 {
-    word16 carry = 0;
-
     if (dLen > 0 && sLen > 0 && dLen >= sLen) {
         int sIdx, dIdx;
+        word16 carry = 0;
 
         dIdx = dLen - 1;
         for (sIdx = sLen - 1; sIdx >= 0; sIdx--) {
@@ -3164,7 +3163,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     #include "nrf_drv_rng.h"
     int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     {
-        int remaining = sz, length, pos = 0;
+        int remaining = sz, pos = 0;
         word32 err_code;
         byte available;
         static byte initialized = 0;
@@ -3185,6 +3184,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         }
 
         while (remaining > 0) {
+            int length;
             available = 0;
             nrf_drv_rng_bytes_available(&available); /* void func */
             length = (remaining < available) ? remaining : available;
@@ -3798,14 +3798,13 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 int wc_hwrng_generate_block(byte *output, word32 sz)
 {
     int fd;
-    int len;
     int ret = 0;
     fd = open("/dev/hwrng", O_RDONLY);
     if (fd == -1)
         return OPEN_RAN_E;
     while(sz)
     {
-        len = (int)read(fd, output, sz);
+        int len = (int)read(fd, output, sz);
         if (len == -1)
         {
             ret = READ_RAN_E;

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -1888,9 +1888,6 @@ static int RsaUnPad(const byte *pkcsBlock, unsigned int pkcsBlockLen,
 {
     int    ret = BAD_FUNC_ARG;
     word16 i;
-#ifndef WOLFSSL_RSA_VERIFY_ONLY
-    byte   invalid = 0;
-#endif
 
     if (output == NULL || pkcsBlockLen < 2 || pkcsBlockLen > 0xFFFF) {
         return BAD_FUNC_ARG;
@@ -1923,6 +1920,7 @@ static int RsaUnPad(const byte *pkcsBlock, unsigned int pkcsBlockLen,
     else {
         unsigned int j;
         word16 pastSep = 0;
+        byte   invalid = 0;
 
         i = 0;
         /* Decrypted with private key - unpad must be constant time. */
@@ -3579,11 +3577,6 @@ static int RsaPrivateDecryptEx(const byte* in, word32 inLen, byte* out,
         if (rsa_type == RSA_PUBLIC_DECRYPT && ret > (int)outLen)
             ret = RSA_BUFFER_E;
         else if (ret >= 0 && pad != NULL) {
-#if !defined(WOLFSSL_RSA_VERIFY_ONLY) && !defined(WOLFSSL_RSA_VERIFY_INLINE) && \
-    !defined(WOLFSSL_NO_MALLOC)
-            signed char c;
-#endif
-
             /* only copy output if not inline */
             if (outPtr == NULL) {
 #if !defined(WOLFSSL_RSA_VERIFY_ONLY) && !defined(WOLFSSL_RSA_VERIFY_INLINE) && \
@@ -3594,6 +3587,7 @@ static int RsaPrivateDecryptEx(const byte* in, word32 inLen, byte* out,
                     int start = (int)((size_t)pad - (size_t)key->data);
 
                     for (j = 0; j < key->dataLen; j++) {
+                        signed char c;
                         out[i] = key->data[j];
                         c  = ctMaskGTE(j, start);
                         c &= ctMaskLT(i, outLen);

--- a/wolfcrypt/src/sha3.c
+++ b/wolfcrypt/src/sha3.c
@@ -641,12 +641,11 @@ static int InitSha3(wc_Sha3* sha3)
 static int Sha3Update(wc_Sha3* sha3, const byte* data, word32 len, byte p)
 {
     word32 i;
-    byte l;
-    byte *t;
     word32 blocks;
 
     if (sha3->i > 0) {
-        l = p * 8 - sha3->i;
+        byte *t;
+        byte l = p * 8 - sha3->i;
         if (l > len) {
             l = (byte)len;
         }
@@ -1300,10 +1299,10 @@ int wc_Shake128_Final(wc_Shake* shake, byte* hash, word32 hashLen)
 int wc_Shake128_Absorb(wc_Shake* shake, const byte* data, word32 len)
 {
     int ret;
-    byte hash[1];
 
     ret = Sha3Update(shake, data, len, WC_SHA3_128_COUNT);
     if (ret == 0) {
+        byte hash[1];
         ret = Sha3Final(shake, 0x1f, hash, WC_SHA3_128_COUNT, 0);
     }
     /* No partial data. */
@@ -1429,10 +1428,10 @@ int wc_Shake256_Final(wc_Shake* shake, byte* hash, word32 hashLen)
 int wc_Shake256_Absorb(wc_Shake* shake, const byte* data, word32 len)
 {
     int ret;
-    byte hash[1];
 
     ret = Sha3Update(shake, data, len, WC_SHA3_256_COUNT);
     if (ret == 0) {
+        byte hash[1];
         ret = Sha3Final(shake, 0x1f, hash, WC_SHA3_256_COUNT, 0);
     }
     /* No partial data. */

--- a/wolfcrypt/src/wolfmath.c
+++ b/wolfcrypt/src/wolfmath.c
@@ -76,7 +76,6 @@
 void mp_reverse(unsigned char *s, int len)
 {
     int ix, iy;
-    unsigned char t;
 
     if (s == NULL)
         return;
@@ -84,7 +83,7 @@ void mp_reverse(unsigned char *s, int len)
     ix = 0;
     iy = len - 1;
     while (ix < iy) {
-        t = s[ix];
+        unsigned char t = s[ix];
         s[ix] = s[iy];
         s[iy] = t;
         ++ix;
@@ -120,11 +119,6 @@ mp_digit get_digit(const mp_int* a, int n)
 int mp_cond_copy(mp_int* a, int copy, mp_int* b)
 {
     int err = MP_OKAY;
-#if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
-    unsigned int i;
-#else
-    int i;
-#endif
 #if defined(SP_WORD_SIZE) && SP_WORD_SIZE == 8
     unsigned int mask = (unsigned int)0 - copy;
 #else
@@ -138,6 +132,11 @@ int mp_cond_copy(mp_int* a, int copy, mp_int* b)
     if (err == MP_OKAY)
         err = mp_grow(b, a->used + 1);
     if (err == MP_OKAY) {
+    #if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
+        unsigned int i;
+    #else
+        int i;
+    #endif
         /* When mask 0, b is unchanged2
          * When mask all set, b ^ b ^ a = a
          */
@@ -173,9 +172,6 @@ int mp_rand(mp_int* a, int digits, WC_RNG* rng)
 {
     int ret = 0;
     int cnt = digits * sizeof(mp_digit);
-#ifdef USE_INTEGER_HEAP_MATH
-    int i;
-#endif
 
     if (rng == NULL) {
         ret = MISSING_RNG_E;
@@ -208,6 +204,7 @@ int mp_rand(mp_int* a, int digits, WC_RNG* rng)
     }
     if (ret == MP_OKAY) {
 #ifdef USE_INTEGER_HEAP_MATH
+        int i;
         /* Mask down each digit to only bits used */
         for (i = 0; i < a->used; i++) {
             a->dp[i] &= MP_MASK;
@@ -374,7 +371,7 @@ void wc_bigint_free(WC_BIGINT* a)
 int wc_mp_to_bigint_sz(mp_int* src, WC_BIGINT* dst, word32 sz)
 {
     int err;
-    word32 x, y;
+    word32 x;
 
     if (src == NULL || dst == NULL)
         return BAD_FUNC_ARG;
@@ -388,7 +385,7 @@ int wc_mp_to_bigint_sz(mp_int* src, WC_BIGINT* dst, word32 sz)
     err = wc_bigint_alloc(dst, sz);
     if (err == MP_OKAY && sz > 0) {
         /* leading zero pad */
-        y = sz - x;
+        word32 y = sz - x;
         XMEMSET(dst->buf, 0, y);
 
         /* export src as unsigned bin to destination buf */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -19981,7 +19981,7 @@ WOLFSSL_TEST_SUBROUTINE int openssl_test(void)
     EVP_MD_CTX_cleanup(&md_ctx);
     if (ret != WOLFSSL_SUCCESS)
         return WC_TEST_RET_ENC_NC;
-    if (XMEMCMP(hash, b.output, WC_SHA_DIGEST_SIZE) != 0)
+    if (XMEMCMP(hash, b.output, b.outLen) != 0)
         return WC_TEST_RET_ENC_NC;
 #endif /* NO_SHA */
 
@@ -20001,8 +20001,7 @@ WOLFSSL_TEST_SUBROUTINE int openssl_test(void)
             ret = EVP_DigestFinal(&md_ctx, hash, 0);
     }
     EVP_MD_CTX_cleanup(&md_ctx);
-    if (ret != WOLFSSL_SUCCESS ||
-            XMEMCMP(hash, e.output, WC_SHA224_DIGEST_SIZE) != 0) {
+    if (ret != WOLFSSL_SUCCESS || XMEMCMP(hash, e.output, e.outLen) != 0) {
         return WC_TEST_RET_ENC_NC;
     }
 #endif /* WOLFSSL_SHA224 */
@@ -20023,8 +20022,7 @@ WOLFSSL_TEST_SUBROUTINE int openssl_test(void)
             ret = EVP_DigestFinal(&md_ctx, hash, 0);
     }
     EVP_MD_CTX_cleanup(&md_ctx);
-    if (ret != WOLFSSL_SUCCESS ||
-            XMEMCMP(hash, d.output, WC_SHA256_DIGEST_SIZE) != 0) {
+    if (ret != WOLFSSL_SUCCESS || XMEMCMP(hash, d.output, d.outLen) != 0) {
         return WC_TEST_RET_ENC_NC;
     }
 #endif /* !NO_SHA256 */
@@ -20047,8 +20045,7 @@ WOLFSSL_TEST_SUBROUTINE int openssl_test(void)
             ret = EVP_DigestFinal(&md_ctx, hash, 0);
     }
     EVP_MD_CTX_cleanup(&md_ctx);
-    if (ret != WOLFSSL_SUCCESS ||
-            XMEMCMP(hash, e.output, WC_SHA384_DIGEST_SIZE) != 0) {
+    if (ret != WOLFSSL_SUCCESS || XMEMCMP(hash, e.output, e.outLen) != 0) {
         return WC_TEST_RET_ENC_NC;
     }
 #endif /* WOLFSSL_SHA384 */
@@ -20072,8 +20069,7 @@ WOLFSSL_TEST_SUBROUTINE int openssl_test(void)
             ret = EVP_DigestFinal(&md_ctx, hash, 0);
     }
     EVP_MD_CTX_cleanup(&md_ctx);
-    if (ret != WOLFSSL_SUCCESS ||
-            XMEMCMP(hash, f.output, WC_SHA512_DIGEST_SIZE) != 0) {
+    if (ret != WOLFSSL_SUCCESS || XMEMCMP(hash, f.output, f.outLen) != 0) {
         return WC_TEST_RET_ENC_NC;
     }
 
@@ -20095,8 +20091,7 @@ WOLFSSL_TEST_SUBROUTINE int openssl_test(void)
             ret = EVP_DigestFinal(&md_ctx, hash, 0);
     }
     EVP_MD_CTX_cleanup(&md_ctx);
-    if (ret != WOLFSSL_SUCCESS ||
-            XMEMCMP(hash, f.output, WC_SHA512_224_DIGEST_SIZE) != 0) {
+    if (ret != WOLFSSL_SUCCESS || XMEMCMP(hash, f.output, f.outLen) != 0) {
         return WC_TEST_RET_ENC_NC;
     }
 #endif /* !WOLFSSL_NOSHA512_224 && !FIPS ... */
@@ -20119,8 +20114,7 @@ WOLFSSL_TEST_SUBROUTINE int openssl_test(void)
             ret = EVP_DigestFinal(&md_ctx, hash, 0);
     }
     EVP_MD_CTX_cleanup(&md_ctx);
-    if (ret != WOLFSSL_SUCCESS ||
-            XMEMCMP(hash, f.output, WC_SHA512_256_DIGEST_SIZE) != 0) {
+    if (ret != WOLFSSL_SUCCESS || XMEMCMP(hash, f.output, f.outLen) != 0) {
         return WC_TEST_RET_ENC_NC;
     }
 #endif /* !WOLFSSL_NOSHA512_224 && !FIPS ... */
@@ -20143,8 +20137,7 @@ WOLFSSL_TEST_SUBROUTINE int openssl_test(void)
             ret = EVP_DigestFinal(&md_ctx, hash, 0);
     }
     EVP_MD_CTX_cleanup(&md_ctx);
-    if (ret != WOLFSSL_SUCCESS ||
-            XMEMCMP(hash, e.output, WC_SHA3_224_DIGEST_SIZE) != 0) {
+    if (ret != WOLFSSL_SUCCESS || XMEMCMP(hash, e.output, e.outLen) != 0) {
         return WC_TEST_RET_ENC_NC;
     }
 #endif /* WOLFSSL_NOSHA3_224 */
@@ -20166,8 +20159,7 @@ WOLFSSL_TEST_SUBROUTINE int openssl_test(void)
             ret = EVP_DigestFinal(&md_ctx, hash, 0);
     }
     EVP_MD_CTX_cleanup(&md_ctx);
-    if (ret != WOLFSSL_SUCCESS ||
-            XMEMCMP(hash, d.output, WC_SHA3_256_DIGEST_SIZE) != 0) {
+    if (ret != WOLFSSL_SUCCESS || XMEMCMP(hash, d.output, d.outLen) != 0) {
         return WC_TEST_RET_ENC_NC;
     }
 #endif /* WOLFSSL_NOSHA3_256 */
@@ -20189,8 +20181,7 @@ WOLFSSL_TEST_SUBROUTINE int openssl_test(void)
             ret = EVP_DigestFinal(&md_ctx, hash, 0);
     }
     EVP_MD_CTX_cleanup(&md_ctx);
-    if (ret != WOLFSSL_SUCCESS ||
-            XMEMCMP(hash, e.output, WC_SHA3_384_DIGEST_SIZE) != 0) {
+    if (ret != WOLFSSL_SUCCESS || XMEMCMP(hash, e.output, e.outLen) != 0) {
         return WC_TEST_RET_ENC_NC;
     }
 
@@ -20214,7 +20205,7 @@ WOLFSSL_TEST_SUBROUTINE int openssl_test(void)
     }
     EVP_MD_CTX_cleanup(&md_ctx);
     if (ret != WOLFSSL_SUCCESS ||
-            XMEMCMP(hash, f.output, WC_SHA3_512_DIGEST_SIZE) != 0) {
+            XMEMCMP(hash, f.output, f.outLen) != 0) {
         return WC_TEST_RET_ENC_NC;
     }
 #endif /* WOLFSSL_NOSHA3_512 */
@@ -20239,7 +20230,7 @@ WOLFSSL_TEST_SUBROUTINE int openssl_test(void)
 #else
     if (HMAC(EVP_md5(), "JefeJefeJefeJefe", 16, (byte*)c.input, (int)c.inLen,
             hash, 0) == NULL ||
-        XMEMCMP(hash, c.output, WC_MD5_DIGEST_SIZE) != 0)
+        XMEMCMP(hash, c.output, c.outLen) != 0)
 #endif
     {
         return WC_TEST_RET_ENC_NC;
@@ -21238,8 +21229,11 @@ WOLFSSL_TEST_SUBROUTINE int openssl_pkey0_test(void)
     }
     prvBytes = (int)XFREAD(prvTmp, 1, (int)FOURK_BUFF, keyFile);
     XFCLOSE(keyFile);
-    if (prvBytes == 0)
+    if (prvBytes == 0) {
+        XFREE(prvTmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(pubTmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         return WC_TEST_RET_ENC_ERRNO;
+    }
     keypubFile = XFOPEN(cliKeypub, "rb");
     if (!keypubFile) {
         XFREE(prvTmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -21250,8 +21244,11 @@ WOLFSSL_TEST_SUBROUTINE int openssl_pkey0_test(void)
     }
     pubBytes = (int)XFREAD(pubTmp, 1, (int)FOURK_BUFF, keypubFile);
     XFCLOSE(keypubFile);
-    if (pubBytes == 0)
+    if (pubBytes == 0) {
+        XFREE(prvTmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(pubTmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         return WC_TEST_RET_ENC_ERRNO;
+    }
 #endif /* USE_CERT_BUFFERS */
 
         prvRsa = wolfSSL_RSA_new();
@@ -21657,8 +21654,11 @@ WOLFSSL_TEST_SUBROUTINE int openssl_evpSig_test(void)
     }
     prvBytes = (int)XFREAD(prvTmp, 1, (int)FOURK_BUFF, keyFile);
     XFCLOSE(keyFile);
-    if (prvBytes == 0)
+    if (prvBytes == 0) {
+        XFREE(prvTmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(pubTmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         return WC_TEST_RET_ENC_ERRNO;
+    }
     keypubFile = XFOPEN(cliKeypub, "rb");
     if (!keypubFile) {
         XFREE(pubTmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -21669,8 +21669,11 @@ WOLFSSL_TEST_SUBROUTINE int openssl_evpSig_test(void)
     }
     pubBytes = (int)XFREAD(pubTmp, 1, (int)FOURK_BUFF, keypubFile);
     XFCLOSE(keypubFile);
-    if (pubBytes == 0)
+    if (pubBytes == 0) {
+        XFREE(prvTmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(pubTmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         return WC_TEST_RET_ENC_ERRNO;
+    }
     #endif /* USE_CERT_BUFFERS */
 
     prvRsa = wolfSSL_RSA_new();
@@ -24737,7 +24740,9 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
     WC_DECLARE_VAR(exportBuf, byte, ECC_KEY_EXPORT_BUF_SIZE, HEAP_HINT);
 #endif
     word32  x = 0;
-#if defined(HAVE_ECC_SIGN) && !defined(WOLFSSL_KCAPI_ECC)
+#if !defined(ECC_TIMING_RESISTANT) || (defined(ECC_TIMING_RESISTANT) && \
+    !defined(WC_NO_RNG) && !defined(WOLFSSL_KCAPI_ECC)) && \
+    defined(HAVE_ECC_SIGN)
     WC_DECLARE_VAR(sig, byte, ECC_SIG_SIZE, HEAP_HINT);
     WC_DECLARE_VAR(digest, byte, ECC_DIGEST_SIZE, HEAP_HINT);
     int     i;
@@ -24771,7 +24776,9 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
         ERROR_OUT(WC_TEST_RET_ENC_ERRNO, done);
 #endif
 
-#if defined(HAVE_ECC_SIGN) && !defined(WOLFSSL_KCAPI_ECC)
+#if !defined(ECC_TIMING_RESISTANT) || (defined(ECC_TIMING_RESISTANT) && \
+    !defined(WC_NO_RNG) && !defined(WOLFSSL_KCAPI_ECC)) && \
+    defined(HAVE_ECC_SIGN)
     if (sig == NULL || digest == NULL)
         ERROR_OUT(WC_TEST_RET_ENC_ERRNO, done);
 #endif
@@ -44228,11 +44235,13 @@ static int ecc_onlycb_test(myCryptoDevCtx *ctx)
     #ifdef OPENSSL_EXTRA
     EVP_PKEY* privKey = NULL;
     EVP_PKEY* pubKey = NULL;
+    #ifdef USE_CERT_BUFFERS_256
     ecc_key* pkey;
+    const unsigned char* cp;
+    #endif
     EVP_MD_CTX mdCtx;
     const char testData[] = "Hi There";
     size_t checkSz = -1;
-    const unsigned char* cp;
     const unsigned char* p;
     const unsigned char check_v[256] = {
         0x30,0x45,0x02,0x20,0x1b,0x5c,0x2a,0xf0,0x18,0x09,

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1219,7 +1219,6 @@ static WC_INLINE void build_addr(SOCKADDR_IN_T* addr, const char* peer,
         if ((XSTRCMP(peer, "localhost") != 0) &&
             (XSTRCMP(peer, "127.0.0.1") != 0)) {
             FILE* fp;
-            char host_out[100];
             char cmd[100];
 
             XSTRNCPY(cmd, "host ", 6);
@@ -1227,6 +1226,7 @@ static WC_INLINE void build_addr(SOCKADDR_IN_T* addr, const char* peer,
             found = 0;
             fp = popen(cmd, "r");
             if (fp != NULL) {
+                char host_out[100];
                 while (fgets(host_out, sizeof(host_out), fp) != NULL) {
                     int i;
                     int j = 0;
@@ -2455,7 +2455,6 @@ static WC_INLINE int my_psk_use_session_cb(WOLFSSL* ssl,
 #if defined(OPENSSL_ALL) && !defined(NO_CERTS) && \
        !defined(NO_FILESYSTEM)
     int i;
-    int b = 0x01;
     WOLFSSL_SESSION* lsess;
     char buf[256];
     const char* cipher_id = "TLS13-AES128-GCM-SHA256";
@@ -2486,8 +2485,9 @@ static WC_INLINE int my_psk_use_session_cb(WOLFSSL* ssl,
     }
 
     if (i != numCiphers) {
+        int b = 0x01;
         SSL_SESSION_set_cipher(lsess, cipher);
-            for (i = 0; i < 32; i++, b += 0x22) {
+        for (i = 0; i < 32; i++, b += 0x22) {
             if (b >= 0x100)
                 b = 0x01;
             local_psk[i] = b;
@@ -2857,7 +2857,6 @@ static WC_INLINE int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
     WOLFSSL_BIO* bio = NULL;
     WOLFSSL_STACK* sk = NULL;
     X509* x509 = NULL;
-    int i = 0;
 #endif
 #endif
 
@@ -2900,6 +2899,7 @@ static WC_INLINE int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
 #if defined(SHOW_CERTS) && !defined(NO_FILESYSTEM)
         /* avoid printing duplicate certs */
         if (store->depth == 1) {
+            int i;
             /* retrieve x509 certs and display them on stdout */
             sk = wolfSSL_X509_STORE_GetCerts(store);
 
@@ -3074,10 +3074,10 @@ static WC_INLINE void CaCb(unsigned char* der, int sz, int type)
     {
         #if !defined(NO_FILESYSTEM) || defined(FORCE_BUFFER_TEST) && \
             !defined(NETOS)
-            int depth, res;
-            XFILE keyFile;
+            int depth;
             for(depth = 0; depth <= MAX_WOLF_ROOT_DEPTH; depth++) {
-                keyFile = XFOPEN(dhParamFile, "rb");
+                int res;
+                XFILE keyFile = XFOPEN(dhParamFile, "rb");
                 if (keyFile != NULL) {
                     fclose(keyFile);
                     return depth;
@@ -4814,13 +4814,13 @@ static WC_INLINE int SimulateWantWriteIOSendCb(WOLFSSL *ssl, char *buf, int sz, 
 {
     static int wantWriteFlag = 1;
 
-    int sent;
     int sd = *(int*)ctx;
 
     (void)ssl;
 
     if (!wantWriteFlag)
     {
+        int sent;
         wantWriteFlag = 1;
 
         sent = wolfIO_Send(sd, buf, sz, 0);
@@ -5164,7 +5164,6 @@ static WC_INLINE void EarlyDataStatus(WOLFSSL* ssl)
 static WC_INLINE int process_handshake_messages(WOLFSSL* ssl, int blocking,
     int* zero_return)
 {
-    int timeout = DEFAULT_TIMEOUT_SEC;
     char foo[1];
     int ret = 0;
     int dtls;
@@ -5177,6 +5176,8 @@ static WC_INLINE int process_handshake_messages(WOLFSSL* ssl, int blocking,
     *zero_return = 0;
 
     if (!blocking) {
+        int timeout = DEFAULT_TIMEOUT_SEC;
+
 #ifdef WOLFSSL_DTLS
         if (dtls) {
             timeout = wolfSSL_dtls_get_current_timeout(ssl);


### PR DESCRIPTION
# Description

Fix checking of negative with unsigned variables.
Check digestSz for 0 in wc_SSH_KDF() so that no possibility of dividing by zero.
Change XMEMCPY to XMEMSET in renesas_sce_util.c.
Fix test.c to free prvTmp and pubTmp on read error. Remove unused variables.
XFREE checks for NULL so don't check before call.
Move variable declarations to reduce scope.

# Testing

cppcheck

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
