### PR TITLE
20230331-fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8642,18 +8642,12 @@ echo "#endif" >> $OPTION_FILE
 echo "" >> $OPTION_FILE
 
 # check for supported command to trim option with
-which colrm &> /dev/null
-RESULT=$?
-if test "$RESULT" = "0"; then
+if colrm &> /dev/null; then
     TRIM="colrm 3"
+elif cut &> /dev/null; then
+    TRIM="cut -c1-2"
 else
-    which cut &> /dev/null
-    RESULT=$?
-    if test "$RESULT" = "0"; then
-        TRIM="cut -c1-2"
-    else
-        AC_MSG_ERROR([Could not find colrm or cut to make options file])
-    fi
+    AC_MSG_ERROR([Could not find colrm or cut to make options file])
 fi
 
 for option in $CPPFLAGS $AM_CPPFLAGS $CFLAGS $AM_CFLAGS; do
@@ -8724,7 +8718,7 @@ done < $OPTION_FILE
 # switch ifdef protection in cyassl/option.h to CYASSL_OPTONS_H, remove bak
 sed -i.bak 's/WOLFSSL_OPTIONS_H/CYASSL_OPTIONS_H/g' cyassl/options.h
 
-# workaround for mingw sed that may get "Permission denied" trying to preserver permissions
+# workaround for mingw sed that may get "Permission denied" trying to preserve permissions
 case $host_os in
     mingw*)
         chmod u+w cyassl/options.h ;;
@@ -8735,7 +8729,7 @@ rm cyassl/options.h.bak
 if test "$ENABLED_OPENSSLEXTRA" = "yes" && test "$ENABLED_LINUXKM" = "no"
 then
     SAVE_CFLAGS=$CFLAGS
-    CFLAGS="$CFLAGS -I$srcdir"
+    CFLAGS="$CFLAGS -I. -I$srcdir"
     if test "$ENABLED_INTEL_QA" = "yes"
     then
         CFLAGS="$CFLAGS $QAT_FLAGS"

--- a/linuxkm/module_exports.c.template
+++ b/linuxkm/module_exports.c.template
@@ -51,6 +51,7 @@
 #include <wolfssl/wolfcrypt/wc_port.h>
 #include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/types.h>
+#include <wolfssl/wolfcrypt/wolfmath.h>
 #include <wolfssl/wolfcrypt/asn.h>
 #include <wolfssl/wolfcrypt/md2.h>
 #include <wolfssl/wolfcrypt/md5.h>

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -393,9 +393,6 @@ WC_RNG* wolfssl_make_rng(WC_RNG* rng, int* local)
 #endif
 
 #ifdef OPENSSL_EXTRA
-    /* Global pointer to constant BN on */
-    static WOLFSSL_BIGNUM* bn_one = NULL;
-
     /* WOLFSSL_NO_OPENSSL_RAND_CB: Allows way to reduce code size for
      *                OPENSSL_EXTRA where RAND callbacks are not used */
     #ifndef WOLFSSL_NO_OPENSSL_RAND_CB
@@ -14180,10 +14177,7 @@ int wolfSSL_Cleanup(void)
         return ret;
 
 #ifdef OPENSSL_EXTRA
-    if (bn_one) {
-        wolfSSL_BN_free(bn_one);
-        bn_one = NULL;
-    }
+    wolfSSL_BN_free_one();
 #endif
 
 #ifndef NO_SESSION_CACHE

--- a/src/ssl_asn1.c
+++ b/src/ssl_asn1.c
@@ -155,7 +155,7 @@ void wolfSSL_ASN1_item_free(void *items, const WOLFSSL_ASN1_ITEM *tpl)
 }
 
 /* Offset buf if not NULL or NULL. */
-#define bufLenOrNull(buf, len) ((buf != NULL) ? ((buf) + (len)) : NULL)
+#define bufLenOrNull(buf, len) (((buf) != NULL) ? ((buf) + (len)) : NULL)
 
 /* Encode X509 algorithm as DER.
  *
@@ -3246,7 +3246,7 @@ int wolfSSL_ASN1_TIME_diff(int *days, int *secs, const WOLFSSL_ASN1_TIME *from,
         *secs = 0;
     }
     else if (ret == 1) {
-        const int SECS_PER_DAY = 24 * 60 * 60;
+        const long long SECS_PER_DAY = 24 * 60 * 60;
         long long fromSecs;
         long long toSecs = 0;
 
@@ -3255,9 +3255,9 @@ int wolfSSL_ASN1_TIME_diff(int *days, int *secs, const WOLFSSL_ASN1_TIME *from,
             ret = wolfssl_asn1_time_to_secs(to, &toSecs);
         }
         if (ret == 1) {
-            double diffSecs = (double)(toSecs - fromSecs);
+            long long diffSecs = toSecs - fromSecs;
             *days = (int) (diffSecs / SECS_PER_DAY);
-            *secs = (int) (diffSecs - (((double)*days) * SECS_PER_DAY));
+            *secs = (int) (diffSecs - ((long long)*days * SECS_PER_DAY));
         }
     }
 
@@ -3672,16 +3672,20 @@ static int wolfssl_asn1_time_to_tm(const WOLFSSL_ASN1_TIME* asnTime,
 
         if (asnTime->type == V_ASN1_UTCTIME) {
             /* Get year from UTC TIME string. */
+            int tm_year;
             if ((ret = wolfssl_utctime_year(asn1TimeBuf, asn1TimeBufLen,
-                    &tm->tm_year)) == 1) {
+                    &tm_year)) == 1) {
+                tm->tm_year = tm_year;
                 /* Month starts after year - 2 characters. */
                 i = 2;
             }
         }
         else if (asnTime->type == V_ASN1_GENERALIZEDTIME) {
             /* Get year from GENERALIZED TIME string. */
+            int tm_year;
             if ((ret = wolfssl_gentime_year(asn1TimeBuf, asn1TimeBufLen,
-                    &tm->tm_year)) == 1) {
+                    &tm_year)) == 1) {
+                tm->tm_year = tm_year;
                 /* Month starts after year - 4 characters. */
                 i = 4;
             }
@@ -3998,7 +4002,7 @@ void wolfSSL_ASN1_TYPE_set(WOLFSSL_ASN1_TYPE *a, int type, void *value)
                     WOLFSSL_MSG("NULL tag meant to be always empty!");
                     /* No way to return error - value will not be used. */
                 }
-                /* fall-through */
+                FALL_THROUGH;
             case V_ASN1_OBJECT:
             case V_ASN1_UTCTIME:
             case V_ASN1_GENERALIZEDTIME:

--- a/src/ssl_bn.c
+++ b/src/ssl_bn.c
@@ -306,6 +306,9 @@ void wolfSSL_BN_clear(WOLFSSL_BIGNUM* bn)
 #endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
 
 #ifdef OPENSSL_EXTRA
+
+static WOLFSSL_BIGNUM* bn_one = NULL;
+
 /* Return a big number with the value of one.
  *
  * @return  A big number with the value one on success.
@@ -349,6 +352,10 @@ const WOLFSSL_BIGNUM* wolfSSL_BN_value_one(void)
     return one;
 }
 
+static void wolfSSL_BN_free_one(void) {
+    wolfSSL_BN_free(bn_one);
+    bn_one = NULL;
+}
 
 /* Create a new big number with the same value as the one passed in.
  *

--- a/tests/api.c
+++ b/tests/api.c
@@ -31070,7 +31070,8 @@ static int test_wolfSSL_d2i_ASN1_INTEGER(void)
         {positiveDer, sizeof(positiveDer), 65537},
         {primeDer, sizeof(primeDer), 0}
     };
-    static const size_t NUM_TEST_VECTORS = sizeof(testVectors)/sizeof(testVectors[0]);
+    static const size_t NUM_TEST_VECTORS =
+        sizeof(testVectors)/sizeof(testVectors[0]);
 
     /* Check d2i error conditions */
     /* NULL pointer to input. */
@@ -32492,8 +32493,8 @@ static int test_wolfSSL_ASN1_TIME_to_tm(void)
 {
     int res = TEST_SKIPPED;
 #if (defined(WOLFSSL_MYSQL_COMPATIBLE) || defined(WOLFSSL_NGINX) || \
-    defined(WOLFSSL_HAPROXY) || defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)) \
-    && !defined(NO_ASN_TIME)
+      defined(WOLFSSL_HAPROXY) || defined(OPENSSL_EXTRA) || \
+      defined(OPENSSL_ALL)) && !defined(NO_ASN_TIME)
     ASN1_TIME asnTime;
     struct tm tm;
 
@@ -32890,11 +32891,13 @@ static int test_wolfSSL_IMPLEMENT_ASN1_FUNCTIONS(void)
                                 V_ASN1_OBJECT, OBJ_nid2obj(nid)), 1);
     AssertIntEQ(EC_POINT_point2oct(group, point, 0, NULL, 0, NULL), 0);
 #ifdef HAVE_COMP_KEY
-    AssertIntGT((len = EC_POINT_point2oct(group, point, POINT_CONVERSION_COMPRESSED,
-                                          NULL, 0, NULL)), 0);
+    AssertIntGT((len = EC_POINT_point2oct(
+                                   group, point, POINT_CONVERSION_COMPRESSED,
+                                   NULL, 0, NULL)), 0);
 #else
-    AssertIntGT((len = EC_POINT_point2oct(group, point, POINT_CONVERSION_UNCOMPRESSED,
-                                          NULL, 0, NULL)), 0);
+    AssertIntGT((len = EC_POINT_point2oct(
+                                   group, point, POINT_CONVERSION_UNCOMPRESSED,
+                                   NULL, 0, NULL)), 0);
 #endif
     AssertNotNull(der = (unsigned char*)XMALLOC(len, NULL, DYNAMIC_TYPE_ASN1));
 #ifdef HAVE_COMP_KEY

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -7669,10 +7669,9 @@ int ecc_mul2add(ecc_point* A, mp_int* kA,
     mu = (mp_int*)XMALLOC(sizeof(mp_int), heap, DYNAMIC_TYPE_ECC);
     if (mu == NULL)
         err = MEMORY_E;
+    else
   #endif
-    if (err == MP_OKAY) {
         err = mp_init(mu);
-    }
     if (err == MP_OKAY) {
       err = mp_montgomery_calc_normalization(mu, modulus);
 

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -423,7 +423,7 @@ int mp_grow (mp_int * a, int size)
      * in case the operation failed we don't want
      * to overwrite the dp member of a.
      */
-    tmp = OPT_CAST(mp_digit) XREALLOC (a->dp, sizeof (mp_digit) * size, NULL,
+    tmp = (mp_digit *)XREALLOC (a->dp, sizeof (mp_digit) * size, NULL,
                                                            DYNAMIC_TYPE_BIGINT);
     if (tmp == NULL) {
       /* reallocation failed but "a" is still valid [can be freed] */
@@ -3280,7 +3280,7 @@ int mp_init_size (mp_int * a, int size)
   size += (MP_PREC * 2) - (size % MP_PREC);
 
   /* alloc mem */
-  a->dp = OPT_CAST(mp_digit) XMALLOC (sizeof (mp_digit) * size, NULL,
+  a->dp = (mp_digit *)XMALLOC (sizeof (mp_digit) * size, NULL,
                                       DYNAMIC_TYPE_BIGINT);
   if (a->dp == NULL) {
     return MP_MEM;


### PR DESCRIPTION
`configure.ac`: include both `-I.` and `-I$srcdir` for "circular dependency" test, so that `${build_pwd}/wolfssl/options.h` is found in out-of-tree builds; streamline scripting that dynamically sets `$TRIM`;

`linuxkm/module_exports.c.template`: include `wolfssl/wolfcrypt/wolfmath.h`, to bring in `wc_GetMathInfo()` prototype;

`src/ssl.c`: move "Global pointer to constant BN on" to `src/ssl_bn.c`; and in `wolfSSL_Cleanup()`, call the new `wolfSSL_BN_free_one()` rather than using ad hoc cleanup logic;

`src/ssl_bn.c`: add `bn_one` and `wolfSSL_BN_free_one()`;

`src/ssl_asn1.c`: fix `bugprone-macro-parentheses` in `bufLenOrNull()`; refactor `wolfSSL_ASN1_TIME_diff()` to avoid floating point math; use intermediate `tm_year` variable in `wolfssl_asn1_time_to_tm()` to avoid target-specific type conflicts on `tm->tm_year`; use `FALL_THROUGH`, not `/* fall-through */`, in `wolfSSL_ASN1_TYPE_set` (`clang-diagnostic-implicit-fallthrough`);

`wolfcrypt/src/ecc.c`: fix `identicalInnerCondition` in `ecc_mul2add()`;

`wolfcrypt/src/integer.c`: refactor `OPT_CAST()`s in `mp_grow()` to unconditional casts as elsewhere, to mollify a confused `cppcheck-all-intmath`;

`tests/api.c`: reformat some overlong lines.

tested with `wolfssl-multi-test.sh ... super-quick-check linuxkm-all-asm-cryptonly-opensslextra-pie all-sp-asm-cipher-suite linuxkm-plus-wireguard`
