### PR TITLE
20230405-fixes

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -1429,8 +1429,10 @@ int wolfSSL_BIO_reset(WOLFSSL_BIO *bio)
     switch (bio->type) {
         #ifndef NO_FILESYSTEM
         case WOLFSSL_BIO_FILE:
-            XREWIND((XFILE)bio->ptr);
-            return 0;
+            if (XFSEEK((XFILE)bio->ptr, 0, XSEEK_SET) != 0)
+                return WOLFSSL_BIO_ERROR;
+            else
+                return 0;
         #endif
 
         case WOLFSSL_BIO_BIO:

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -1627,7 +1627,10 @@ static int LoadKeyFile(byte** keyBuf, word32* keyBufSz,
             XFCLOSE(file);
             return -1;
         }
-        XREWIND(file);
+        if(XFSEEK(file, 0, XSEEK_SET) != 0) {
+            XFCLOSE(file);
+            return -1;
+        }
 
         loadBuf = (byte*)XMALLOC(fileSz, NULL, DYNAMIC_TYPE_FILE);
         if (loadBuf == NULL) {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -8629,7 +8629,10 @@ int ProcessFile(WOLFSSL_CTX* ctx, const char* fname, int format, int type,
         return WOLFSSL_BAD_FILE;
     }
     sz = XFTELL(file);
-    XREWIND(file);
+    if (XFSEEK(file, 0, XSEEK_SET) != 0) {
+        XFCLOSE(file);
+        return WOLFSSL_BAD_FILE;
+    }
 
     if (sz > MAX_WOLFSSL_FILE_SIZE || sz <= 0) {
         WOLFSSL_MSG("ProcessFile file size error");
@@ -9102,7 +9105,10 @@ int wolfSSL_CertManagerVerify(WOLFSSL_CERT_MANAGER* cm, const char* fname,
         return WOLFSSL_BAD_FILE;
     }
     sz = XFTELL(file);
-    XREWIND(file);
+    if(XFSEEK(file, 0, XSEEK_SET) != 0) {
+        XFCLOSE(file);
+        return WOLFSSL_BAD_FILE;
+    }
 
     if (sz > MAX_WOLFSSL_FILE_SIZE || sz <= 0) {
         WOLFSSL_MSG("CertManagerVerify file size error");
@@ -9564,7 +9570,10 @@ static int wolfSSL_SetTmpDH_file_wrapper(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
         return WOLFSSL_BAD_FILE;
     }
     sz = XFTELL(file);
-    XREWIND(file);
+    if(XFSEEK(file, 0, XSEEK_SET) != 0) {
+        XFCLOSE(file);
+        return WOLFSSL_BAD_FILE;
+    }
 
     if (sz > MAX_WOLFSSL_FILE_SIZE || sz <= 0) {
         WOLFSSL_MSG("SetTmpDH file size error");
@@ -12245,7 +12254,10 @@ int CM_RestoreCertCache(WOLFSSL_CERT_MANAGER* cm, const char* fname)
         return WOLFSSL_BAD_FILE;
     }
     memSz = (int)XFTELL(file);
-    XREWIND(file);
+    if(XFSEEK(file, 0, XSEEK_SET) != 0) {
+        XFCLOSE(file);
+        return WOLFSSL_BAD_FILE;
+    }
 
     if (memSz > MAX_WOLFSSL_FILE_SIZE || memSz <= 0) {
         WOLFSSL_MSG("CM_RestoreCertCache file size error");
@@ -25746,7 +25758,10 @@ int wolfSSL_cmp_peer_cert_to_file(WOLFSSL* ssl, const char *fname)
             return WOLFSSL_BAD_FILE;
         }
         sz = XFTELL(file);
-        XREWIND(file);
+        if (XFSEEK(file, 0, XSEEK_SET) != 0) {
+            XFCLOSE(file);
+            return WOLFSSL_BAD_FILE;
+        }
 
         if (sz > MAX_WOLFSSL_FILE_SIZE || sz < 0) {
             WOLFSSL_MSG("cmp_peer_cert_to_file size error");

--- a/tests/api.c
+++ b/tests/api.c
@@ -601,7 +601,7 @@ static int test_fileAccess(void)
     AssertTrue((f = XFOPEN(derfile, "rb")) != XBADFILE);
     AssertTrue(XFSEEK(f, 0, XSEEK_END) == 0);
     sz = (size_t) XFTELL(f);
-    XREWIND(f);
+    AssertTrue(XFSEEK(f, 0, XSEEK_SET) == 0);
     AssertTrue(sz == sizeof_server_cert_der_2048);
     AssertTrue((buff = (byte*)XMALLOC(sz, NULL, DYNAMIC_TYPE_FILE)) != NULL) ;
     AssertTrue(XFREAD(buff, 1, sz, f) == sz);
@@ -34754,7 +34754,7 @@ static int test_wolfSSL_PEM_PrivateKey(void)
         AssertTrue((file != XBADFILE));
         AssertTrue(XFSEEK(file, 0, XSEEK_END) == 0);
         sz = XFTELL(file);
-        XREWIND(file);
+        AssertTrue(XFSEEK(file, 0, XSEEK_SET) == 0);
         AssertNotNull(buf = (byte*)XMALLOC(sz, NULL, DYNAMIC_TYPE_FILE));
         if (buf) {
             AssertIntEQ(XFREAD(buf, 1, sz, file), sz);
@@ -34781,7 +34781,7 @@ static int test_wolfSSL_PEM_PrivateKey(void)
         AssertTrue((file != XBADFILE));
         AssertTrue(XFSEEK(file, 0, XSEEK_END) == 0);
         sz = XFTELL(file);
-        XREWIND(file);
+        AssertTrue(XFSEEK(file, 0, XSEEK_SET) == 0);
         AssertNotNull(buf = (byte*)XMALLOC(sz, NULL, DYNAMIC_TYPE_FILE));
         if (buf)
             AssertIntEQ(XFREAD(buf, 1, sz, file), sz);
@@ -34828,7 +34828,7 @@ static int test_wolfSSL_PEM_PrivateKey(void)
         AssertTrue((file != XBADFILE));
         AssertTrue(XFSEEK(file, 0, XSEEK_END) == 0);
         sz = XFTELL(file);
-        XREWIND(file);
+        AssertTrue(XFSEEK(file, 0, XSEEK_SET) == 0);
         AssertNotNull(buf = (byte*)XMALLOC(sz, NULL, DYNAMIC_TYPE_FILE));
         if (buf)
             AssertIntEQ(XFREAD(buf, 1, sz, file), sz);
@@ -34867,7 +34867,7 @@ static int test_wolfSSL_PEM_PrivateKey(void)
         AssertTrue((file != XBADFILE));
         AssertTrue(XFSEEK(file, 0, XSEEK_END) == 0);
         sz = XFTELL(file);
-        XREWIND(file);
+        AssertTrue(XFSEEK(file, 0, XSEEK_SET) == 0);
         AssertNotNull(buf = (byte*)XMALLOC(sz, NULL, DYNAMIC_TYPE_FILE));
         if (buf)
             AssertIntEQ(XFREAD(buf, 1, sz, file), sz);
@@ -35473,9 +35473,9 @@ static int test_wolfSSL_PEM_PUBKEY(void)
 
         file = XFOPEN(fname, "rb");
         AssertTrue((file != XBADFILE));
-        AssertIntGE(XFSEEK(file, 0, XSEEK_END), 0);
+        AssertIntEQ(XFSEEK(file, 0, XSEEK_END), 0);
         sz = XFTELL(file);
-        XREWIND(file);
+        AssertIntEQ(XFSEEK(file, 0, XSEEK_SET), 0);
         AssertNotNull(buf = (byte*)XMALLOC(sz, NULL, DYNAMIC_TYPE_FILE));
         if (buf)
             AssertIntEQ(XFREAD(buf, 1, sz, file), sz);
@@ -44934,7 +44934,7 @@ static int test_wolfSSL_d2i_PrivateKeys_bio(void)
         AssertTrue((file != XBADFILE));
         AssertTrue(XFSEEK(file, 0, XSEEK_END) == 0);
         sz = XFTELL(file);
-        XREWIND(file);
+        AssertTrue(XFSEEK(file, 0, XSEEK_SET) == 0);
         AssertNotNull(buf = (byte*)XMALLOC(sz, HEAP_HINT, DYNAMIC_TYPE_FILE));
         AssertIntEQ(XFREAD(buf, 1, sz, file), sz);
         XFCLOSE(file);
@@ -44962,7 +44962,7 @@ static int test_wolfSSL_d2i_PrivateKeys_bio(void)
         AssertTrue((file != XBADFILE));
         AssertTrue(XFSEEK(file, 0, XSEEK_END) == 0);
         sz = XFTELL(file);
-        XREWIND(file);
+        AssertTrue(XFSEEK(file, 0, XSEEK_SET) == 0);
         AssertNotNull(buf = (byte*)XMALLOC(sz, HEAP_HINT, DYNAMIC_TYPE_FILE));
         AssertIntEQ(XFREAD(buf, 1, sz, file), sz);
         XFCLOSE(file);
@@ -50129,7 +50129,7 @@ static int test_wolfSSL_d2i_and_i2d_DSAparams(void)
     AssertTrue(f != XBADFILE);
     AssertTrue(XFSEEK(f, 0, XSEEK_END) == 0);
     derInLen = (int)XFTELL(f);
-    XREWIND(f);
+    AssertTrue(XFSEEK(f, 0, XSEEK_SET) == 0);
     AssertNotNull(derIn = (byte*)XMALLOC(derInLen, HEAP_HINT,
         DYNAMIC_TYPE_TMP_BUFFER));
     AssertIntEQ(XFREAD(derIn, 1, derInLen, f), derInLen);
@@ -56349,9 +56349,9 @@ static int test_wolfSSL_RSA_verify(void)
     /* read privete key file */
     fp = XFOPEN(svrKeyFile, "rb");
     AssertTrue((fp != XBADFILE));
-    AssertIntGE(XFSEEK(fp, 0, XSEEK_END), 0);
+    AssertIntEQ(XFSEEK(fp, 0, XSEEK_END), 0);
     sz = XFTELL(fp);
-    XREWIND(fp);
+    AssertIntEQ(XFSEEK(fp, 0, XSEEK_SET), 0);
     AssertNotNull(buf = (byte*)XMALLOC(sz, NULL, DYNAMIC_TYPE_FILE));
     AssertIntEQ(XFREAD(buf, 1, sz, fp), sz);
     XFCLOSE(fp);

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -648,7 +648,12 @@ static void test_harness(void* vargs)
         args->return_code = 1;
         return;
     }
-    rewind(file);
+    if (fseek(file, 0, SEEK_SET) < 0) {
+        fprintf(stderr, "error %d fseeking %s\n", errno, fname);
+        fclose(file);
+        args->return_code = 1;
+        return;
+    }
 
     script = (char*)malloc(sz+1);
     if (script == 0) {

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1796,19 +1796,20 @@ static void bench_stats_sym_finish(const char* desc, int useDeviceID,
     #endif
 #else
     /* normal CSV */
+    #ifdef BENCH_DEVID
+        #define BENCH_DEVID_COLUMN_HEADER "HW/SW,"
+    #else
+        #define BENCH_DEVID_COLUMN_HEADER
+    #endif
     #ifdef HAVE_GET_CYCLES
             printf("\n\nSymmetric Ciphers:\n\n");
             printf("Algorithm,"
-            #ifdef BENCH_DEVID
-                   "HW/SW,"
-            #endif
+               BENCH_DEVID_COLUMN_HEADER
                WOLFSSL_FIXED_UNITS_PER_SEC ",Cycles per byte,\n");
     #else
             printf("\n\nSymmetric Ciphers:\n\n");
             printf("Algorithm,"
-            #ifdef BENCH_DEVID
-                   "HW/SW,"
-            #endif
+               BENCH_DEVID_COLUMN_HEADER
                WOLFSSL_FIXED_UNITS_PER_SEC ", \n");
     #endif
 #endif

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -23421,9 +23421,14 @@ int wc_PemCertToDer_ex(const char* fileName, DerBuffer** der)
             ret = BUFFER_E;
         }
         sz = XFTELL(file);
-        XREWIND(file);
+        if (XFSEEK(file, 0, XSEEK_SET) != 0) {
+            ret = BUFFER_E;
+        }
 
-        if (sz <= 0) {
+        if (ret < 0) {
+            /* intentionally left empty. */
+        }
+        else if (sz <= 0) {
             ret = BUFFER_E;
         }
         else if (sz > (long)sizeof(staticBuffer)) {
@@ -23501,9 +23506,14 @@ int wc_PemPubKeyToDer_ex(const char* fileName, DerBuffer** der)
         if (XFSEEK(file, 0, XSEEK_END) != 0) {
             ret = BUFFER_E;
         }
+    }
+    if (ret == 0) {
         sz = XFTELL(file);
-        XREWIND(file);
-
+        if (XFSEEK(file, 0, XSEEK_SET) != 0) {
+            ret = BUFFER_E;
+        }
+    }
+    if (ret == 0) {
         if (sz <= 0) {
             ret = BUFFER_E;
         }
@@ -23514,21 +23524,21 @@ int wc_PemPubKeyToDer_ex(const char* fileName, DerBuffer** der)
             else
                 dynamic = 1;
         }
-        if (ret == 0) {
-            if ((size_t)XFREAD(fileBuf, 1, sz, file) != (size_t)sz) {
-                ret = BUFFER_E;
-            }
-            else {
-                ret = PemToDer(fileBuf, sz, PUBLICKEY_TYPE, der,
-                               0, NULL, NULL);
-            }
+    }
+    if (ret == 0) {
+        if ((size_t)XFREAD(fileBuf, 1, sz, file) != (size_t)sz) {
+            ret = BUFFER_E;
         }
-
-        XFCLOSE(file);
-        if (dynamic) {
-            XFREE(fileBuf, NULL, DYNAMIC_TYPE_FILE);
+        else {
+            ret = PemToDer(fileBuf, sz, PUBLICKEY_TYPE, der,
+                           0, NULL, NULL);
         }
     }
+
+    if (file != XBADFILE)
+        XFCLOSE(file);
+    if (dynamic)
+        XFREE(fileBuf, NULL, DYNAMIC_TYPE_FILE);
 
     return ret;
 }

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -512,7 +512,11 @@ int wc_FileLoad(const char* fname, unsigned char** buf, size_t* bufLen,
         return BAD_PATH_ERROR;
     }
     fileSz = XFTELL(f);
-    XREWIND(f);
+    if (XFSEEK(f, 0, XSEEK_SET) != 0) {
+        WOLFSSL_MSG("wc_LoadFile file seek error");
+        XFCLOSE(f);
+        return BAD_PATH_ERROR;
+    }
     if (fileSz > 0) {
         *bufLen = fileSz;
         *buf = (byte*)XMALLOC(*bufLen, heap, DYNAMIC_TYPE_TMP_BUFFER);

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -2685,9 +2685,9 @@ static WC_INLINE void OCSPRespFreeCb(void* ioCtx, unsigned char* response)
             return BAD_PATH_ERROR;
         }
 
-        LIBCALL_CHECK_RET(fseek(lFile, 0, SEEK_END));
+        LIBCALL_CHECK_RET(XFSEEK(lFile, 0, XSEEK_END));
         fileSz = (int)ftell(lFile);
-        rewind(lFile);
+        LIBCALL_CHECK_RET(XFSEEK(lFile, 0, XSEEK_SET));
         if (fileSz  > 0) {
             *bufLen = (size_t)fileSz;
             *buf = (byte*)malloc(*bufLen);

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -427,10 +427,10 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XFOPEN(NAME, MODE)       vf_open((const char *)NAME, VO_RDONLY, 0)
     #define XFSEEK                   ebsnet_fseek
     #define XFTELL                   vf_tell
-    #define XREWIND                  vf_rewind
     #define XFREAD(BUF, SZ, AMT, FD) vf_read(FD, BUF, SZ*AMT)
     #define XFWRITE(BUF, SZ, AMT, FD) vf_write(FD, BUF, SZ*AMT)
     #define XFCLOSE                  vf_close
+    #define XSEEK_SET                VSEEK_SET
     #define XSEEK_END                VSEEK_END
     #define XBADFILE                 -1
     #define XFGETS(b,s,f)            -2 /* Not ported yet */
@@ -441,10 +441,10 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XFOPEN(NAME, MODE)      fs_open((char*)NAME)
     #define XFSEEK(F, O, W)         (void)F
     #define XFTELL(F)               (F)->len
-    #define XREWIND(F)              (void)F
     #define XFREAD(BUF, SZ, AMT, F) fs_read(F, (char*)BUF, SZ*AMT)
     #define XFWRITE(BUF, SZ, AMT, F) fs_write(F, (char*)BUF, SZ*AMT)
     #define XFCLOSE                 fs_close
+    #define XSEEK_SET               0
     #define XSEEK_END               0
     #define XBADFILE                NULL
     #define XFGETS(b,s,f)           -2 /* Not ported yet */
@@ -454,10 +454,10 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XFOPEN                  fopen
     #define XFSEEK                  fseek
     #define XFTELL                  ftell
-    #define XREWIND(F)              fseek(F, 0, IO_SEEK_SET)
     #define XFREAD                  fread
     #define XFWRITE                 fwrite
     #define XFCLOSE                 fclose
+    #define XSEEK_SET               IO_SEEK_SET
     #define XSEEK_END               IO_SEEK_END
     #define XBADFILE                NULL
     #define XFGETS                  fgets
@@ -471,10 +471,10 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XFOPEN     fs_fopen
     #define XFSEEK     fs_fseek
     #define XFTELL     fs_ftell
-    #define XREWIND    fs_rewind
     #define XFREAD     fs_fread
     #define XFWRITE    fs_fwrite
     #define XFCLOSE    fs_fclose
+    #define XSEEK_SET  FS_SEEK_SET
     #define XSEEK_END  FS_SEEK_END
     #define XBADFILE   NULL
     #define XFGETS(b,s,f) -2 /* Not ported yet */
@@ -485,10 +485,10 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XFOPEN     fopen
     #define XFSEEK     fseek
     #define XFTELL     ftell
-    #define XREWIND    rewind
     #define XFREAD     fread
     #define XFWRITE    fwrite
     #define XFCLOSE    fclose
+    #define XSEEK_SET  PSEEK_SET
     #define XSEEK_END  PSEEK_END
     #define XBADFILE   NULL
 
@@ -499,10 +499,10 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XFOPEN     mynewt_fopen
     #define XFSEEK     mynewt_fseek
     #define XFTELL     mynewt_ftell
-    #define XREWIND    mynewt_rewind
     #define XFREAD     mynewt_fread
     #define XFWRITE    mynewt_fwrite
     #define XFCLOSE    mynewt_fclose
+    #define XSEEK_SET  0
     #define XSEEK_END  2
     #define XBADFILE   NULL
     #define XFGETS(b,s,f) -2 /* Not ported yet */
@@ -521,9 +521,9 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XFSEEK              fs_seek
     #define XFTELL              fs_tell
     #define XFREWIND            fs_rewind
-    #define XREWIND(F)          fs_seek(F, 0, FS_SEEK_SET)
     #define XFREAD(P,S,N,F)     fs_read(F, P, S*N)
     #define XFWRITE(P,S,N,F)    fs_write(F, P, S*N)
+    #define XSEEK_SET           FS_SEEK_SET
     #define XSEEK_END           FS_SEEK_END
     #define XBADFILE            NULL
     #define XFGETS(b,s,f)       -2 /* Not ported yet */
@@ -533,10 +533,10 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XFOPEN(NAME, MODE)       m2mb_fs_open((NAME), 0, (MODE))
     #define XFSEEK(F, O, W)          m2mb_fs_lseek((F), (O), (W))
     #define XFTELL(F)                m2mb_fs_lseek((F), 0, M2MB_SEEK_END)
-    #define XREWIND(F)               (void)F
     #define XFREAD(BUF, SZ, AMT, F)  m2mb_fs_read((F), (BUF), (SZ)*(AMT))
     #define XFWRITE(BUF, SZ, AMT, F) m2mb_fs_write((F), (BUF), (SZ)*(AMT))
     #define XFCLOSE                  m2mb_fs_close
+    #define XSEEK_SET                M2MB_SEEK_SET
     #define XSEEK_END                M2MB_SEEK_END
     #define XBADFILE                 -1
     #define XFGETS(b,s,f)            -2 /* Not ported yet */
@@ -550,10 +550,10 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XFOPEN(NAME, MODE)       ({ FRESULT res; res = f_open(&curFile, (NAME), (FA_OPEN_ALWAYS | FA_WRITE | FA_READ)); (res == FR_OK) ? &curFile : NULL; })
     #define XFSEEK(F, O, W)          f_lseek((F), (O))
     #define XFTELL(F)                f_tell((F))
-    #define XREWIND(F)               f_rewind((F))
     #define XFREAD(BUF, SZ, AMT, F)  ({ FRESULT res; UINT br; res = f_read((F), (BUF), (SZ)*(AMT), &br); (void)br; res; })
     #define XFWRITE(BUF, SZ, AMT, F) ({ FRESULT res; UINT written; res = f_write((F), (BUF), (SZ)*(AMT), &written); (void)written; res; })
     #define XFCLOSE(F)               f_close((F))
+    #define XSEEK_SET                0
     #define XSEEK_END                0
     #define XBADFILE                 NULL
     #define XFGETS(b,s,f)            f_gets((b), (s), (f))
@@ -565,10 +565,10 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XFDOPEN    fdopen
     #define XFSEEK     fseek
     #define XFTELL     ftell
-    #define XREWIND(F) XFSEEK(F, 0, SEEK_SET)
     #define XFREAD     fread
     #define XFWRITE    fwrite
     #define XFCLOSE    fclose
+    #define XSEEK_END  SEEK_SET
     #define XSEEK_END  SEEK_END
     #define XBADFILE   NULL
     #define XFGETS     fgets
@@ -585,10 +585,10 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XFOPEN    FCL_FOPEN
     #define XFSEEK    FCL_FSEEK
     #define XFTELL    FCL_FTELL
-    #define XREWIND   FCL_REWIND
     #define XFREAD    FCL_FREAD
     #define XFWRITE   FCL_FWRITE
     #define XFCLOSE   FCL_FCLOSE
+    #define XSEEK_SET SEEK_SET
     #define XSEEK_END SEEK_END
     #define XBADFILE  NULL
     #define XFGETS    FCL_FGETS
@@ -624,10 +624,10 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XFDOPEN    fdopen
     #define XFSEEK     fseek
     #define XFTELL     ftell
-    #define XREWIND    rewind
     #define XFREAD     fread
     #define XFWRITE    fwrite
     #define XFCLOSE    fclose
+    #define XSEEK_SET  SEEK_SET
     #define XSEEK_END  SEEK_END
     #define XBADFILE   NULL
     #define XFGETS     fgets


### PR DESCRIPTION
eliminate `XREWIND()` macro, add `XSEEK_SET` definitions, and refactor all `XREWIND()`s to `XFSEEK()`s, to fix `clang-tidy`-17 `bugprone-unsafe-functions` warning on `rewind()`;

add `BENCH_DEVID_COLUMN_HEADER` in `wolfcrypt/benchmark/benchmark.c`:`bench_stats_sym_finish()` to resolve c`lang-diagnostic-embedded-directive`.

tested with `wolfssl-multi-test.sh ... super-quick-check`
