### PR TITLE
20230406-XREWIND-fixes-contd

### DIFF
--- a/src/pk.c
+++ b/src/pk.c
@@ -4456,12 +4456,7 @@ int wolfSSL_RSA_GenAdd(WOLFSSL_RSA* rsa)
     int     err;
     mp_int* t = NULL;
 #ifdef WOLFSSL_SMALL_STACK
-    mp_int  *tmp = (mp_int *)XMALLOC(sizeof(*tmp), rsa->heap,
-                                     DYNAMIC_TYPE_TMP_BUFFER);
-    if (tmp == NULL) {
-        WOLFSSL_ERROR_MSG("Memory allocation failure");
-        return -1;
-    }
+    mp_int  *tmp = NULL;
 #else
     mp_int  tmp[1];
 #endif
@@ -4474,6 +4469,17 @@ int wolfSSL_RSA_GenAdd(WOLFSSL_RSA* rsa)
         WOLFSSL_ERROR_MSG("rsa no init error");
         ret = -1;
     }
+
+#ifdef WOLFSSL_SMALL_STACK
+    if (ret == 1) {
+        tmp = (mp_int *)XMALLOC(sizeof(*tmp), rsa->heap,
+                                     DYNAMIC_TYPE_TMP_BUFFER);
+        if (tmp == NULL) {
+            WOLFSSL_ERROR_MSG("Memory allocation failure");
+            ret = -1;
+        }
+    }
+#endif
 
     if (ret == 1) {
         /* Initialize temp MP integer. */
@@ -4523,7 +4529,8 @@ int wolfSSL_RSA_GenAdd(WOLFSSL_RSA* rsa)
     mp_clear(t);
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(tmp, rsa->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    if (tmp != NULL)
+        XFREE(tmp, rsa->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return ret;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -33285,7 +33285,7 @@ static int set_curves_list(WOLFSSL* ssl, WOLFSSL_CTX *ctx, const char* names)
     char name[MAX_CURVE_NAME_SZ];
     byte groups_len = 0;
 #ifdef WOLFSSL_SMALL_STACK
-    void *heap = ssl? ssl->heap : ctx->heap;
+    void *heap = ssl? ssl->heap : ctx ? ctx->heap : NULL;
     int *groups;
 #else
     int groups[WOLFSSL_MAX_GROUP_COUNT];

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -23395,7 +23395,7 @@ int wc_PemCertToDer_ex(const char* fileName, DerBuffer** der)
 #ifndef WOLFSSL_SMALL_STACK
     byte   staticBuffer[FILE_BUFFER_SIZE];
 #endif
-    byte*  fileBuf;
+    byte*  fileBuf = NULL;
     int    ret     = 0;
     XFILE  file    = XBADFILE;
     int    dynamic = 0;
@@ -23486,7 +23486,7 @@ int wc_PemPubKeyToDer_ex(const char* fileName, DerBuffer** der)
 #ifndef WOLFSSL_SMALL_STACK
     byte   staticBuffer[FILE_BUFFER_SIZE];
 #endif
-    byte*  fileBuf;
+    byte*  fileBuf = NULL;
     int    dynamic = 0;
     int    ret     = 0;
     long   sz      = 0;


### PR DESCRIPTION
`wolfcrypt/src/asn.c`:
 * refactor error-checking cascade in `wc_PemCertToDer_ex()` as in `wc_PemPubKeyToDer_ex()`,
 * refactor `staticBuffer` gating/dynamics in `wc_PemPubKeyToDer_ex()` as in `wc_PemCertToDer_ex()`,
 * and use `IO_FAILED_E`, not `BUFFER_E`, for I/O errors on the file handles, in both routines;

fix smallstack null pointer dereferences in `src/pk.c`:`wolfSSL_RSA_GenAdd()` and `src/ssl.c`:`set_curves_list()`.

tested with `wolfssl-multi-test.sh ... super-quick-check cppcheck-all cppcheck-all-smallstack`
