### PR TITLE
- fix ECC performance regression

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -8176,6 +8176,7 @@ static int ecc_verify_hash_sp(mp_int *r, mp_int *s, const byte* hash,
     #if defined(WC_ECC_NONBLOCK) && defined(WC_ECC_NONBLOCK_ONLY)
         /* perform blocking call to non-blocking function */
         ecc_nb_ctx_t nb_ctx;
+        int err;
         XMEMSET(&nb_ctx, 0, sizeof(nb_ctx));
         err = NOT_COMPILED_IN; /* set default error */
     #endif
@@ -8269,7 +8270,7 @@ static int ecc_verify_hash_sp(mp_int *r, mp_int *s, const byte* hash,
     }
 #endif
 
-    return 0;
+    return NOT_COMPILED_IN;
 }
 
 #if !defined(WOLFSSL_SP_MATH) || defined(FREESCALE_LTC_ECC)
@@ -8710,7 +8711,7 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
   }
 
   err = ecc_verify_hash_sp(r, s, hash, hashlen, res, key);
-  if (err != 0) {
+  if (err != NOT_COMPILED_IN) {
       if (curveLoaded) {
            wc_ecc_curve_free(curve);
            FREE_CURVE_SPECS();
@@ -8720,6 +8721,7 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
 
 #if !defined(WOLFSSL_SP_MATH) || defined(FREESCALE_LTC_ECC)
    if (!curveLoaded) {
+       err = 0; /* potential for NOT_COMPILED_IN error from SP attempt */
        ALLOC_CURVE_SPECS(ECC_CURVE_FIELD_COUNT, err);
        if (err != 0) {
           return err;

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -6634,6 +6634,9 @@ static int ecc_sign_hash_sp(const byte* in, word32 inlen, WC_RNG* rng,
     #ifndef WOLFSSL_SP_NO_256
         if (ecc_sets[key->idx].id == ECC_SECP256R1) {
         #ifdef WC_ECC_NONBLOCK
+            #ifdef WC_ECC_NONBLOCK_ONLY
+            int err;
+            #endif
             if (key->nb_ctx) {
                 return sp_ecc_sign_256_nb(&key->nb_ctx->sp_ctx, in, inlen, rng,
                     &key->k, r, s, sign_k, key->heap);
@@ -6661,6 +6664,9 @@ static int ecc_sign_hash_sp(const byte* in, word32 inlen, WC_RNG* rng,
     #ifdef WOLFSSL_SP_384
         if (ecc_sets[key->idx].id == ECC_SECP384R1) {
         #ifdef WC_ECC_NONBLOCK
+            #ifdef WC_ECC_NONBLOCK_ONLY
+            int err;
+            #endif
             if (key->nb_ctx) {
                 return sp_ecc_sign_384_nb(&key->nb_ctx->sp_ctx, in, inlen, rng,
                     &key->k, r, s, sign_k, key->heap);
@@ -6688,6 +6694,9 @@ static int ecc_sign_hash_sp(const byte* in, word32 inlen, WC_RNG* rng,
     #ifdef WOLFSSL_SP_521
         if (ecc_sets[key->idx].id == ECC_SECP521R1) {
         #ifdef WC_ECC_NONBLOCK
+            #ifdef WC_ECC_NONBLOCK_ONLY
+            int err;
+            #endif
             if (key->nb_ctx) {
                 return sp_ecc_sign_521_nb(&key->nb_ctx->sp_ctx, in, inlen, rng,
                     &key->k, r, s, sign_k, key->heap);


### PR DESCRIPTION
Fix for ECC verify performance regression with `./configure --enable-sp-asm`