### PR TITLE
Fix for including integer.h when heap math is not used

### DIFF
--- a/wolfssl/wolfcrypt/integer.h
+++ b/wolfssl/wolfcrypt/integer.h
@@ -34,9 +34,13 @@
  * designs.
  */
 
-#include <wolfssl/wolfcrypt/wolfmath.h>
+#ifndef USE_INTEGER_HEAP_MATH
 
-#ifdef USE_INTEGER_HEAP_MATH
+    /* Some platforms (like FIPS) may only include integer.h for math. */
+    /* Handle variations of fast math, integer and sp math */
+    #include <wolfssl/wolfcrypt/wolfmath.h>
+
+#else
 
 #include <wolfssl/wolfcrypt/random.h>
 


### PR DESCRIPTION
# Description

Fix for building with heap math and including integer.h only.
Fixes https://github.com/wolfSSL/wolfssl/issues/6280

# Testing

```
./configure --enable-heapmath CFLAGS="-DWOLFSSL_PUBLIC_MP" && make && sudo make install
cd ../wolfssl-examples/ecc
make clean && make
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
