### PR TITLE
Add macro to handle AES/Crypto clock enable/disable for STM32

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -2941,6 +2941,11 @@ int benchmark_init(void)
 
     benchmark_static_init(0);
 
+#ifdef WOLFSSL_STM32_CUBEMX
+    /* enable the peripheral clock */
+    __HAL_RCC_CRYP_CLK_ENABLE();
+#endif
+
 #ifdef WOLFSSL_STATIC_MEMORY
     ret = wc_LoadStaticMemory(&HEAP_HINT, gBenchMemory,
                               sizeof(gBenchMemory), WOLFMEM_GENERAL, 1);
@@ -3048,6 +3053,11 @@ int benchmark_free(void)
     if ((ret = wolfCrypt_Cleanup()) != 0) {
         printf("%serror %d with wolfCrypt_Cleanup\n", err_prefix, ret);
     }
+
+#ifdef WOLFSSL_STM32_CUBEMX
+    /* disable the peripheral clock */
+    __HAL_RCC_CRYP_CLK_DISABLE();
+#endif
 
     return ret;
 }

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -2941,11 +2941,6 @@ int benchmark_init(void)
 
     benchmark_static_init(0);
 
-#ifdef WOLFSSL_STM32_CUBEMX
-    /* enable the peripheral clock */
-    __HAL_RCC_CRYP_CLK_ENABLE();
-#endif
-
 #ifdef WOLFSSL_STATIC_MEMORY
     ret = wc_LoadStaticMemory(&HEAP_HINT, gBenchMemory,
                               sizeof(gBenchMemory), WOLFMEM_GENERAL, 1);
@@ -3053,11 +3048,6 @@ int benchmark_free(void)
     if ((ret = wolfCrypt_Cleanup()) != 0) {
         printf("%serror %d with wolfCrypt_Cleanup\n", err_prefix, ret);
     }
-
-#ifdef WOLFSSL_STM32_CUBEMX
-    /* disable the peripheral clock */
-    __HAL_RCC_CRYP_CLK_DISABLE();
-#endif
 
     return ret;
 }

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -417,6 +417,7 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
         CRYP_Cmd(DISABLE);
     #endif /* WOLFSSL_STM32_CUBEMX */
         wolfSSL_CryptHwMutexUnLock();
+        wc_Stm32_Aes_Cleanup();
 
         return ret;
     }
@@ -520,6 +521,7 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
         CRYP_Cmd(DISABLE);
     #endif /* WOLFSSL_STM32_CUBEMX */
         wolfSSL_CryptHwMutexUnLock();
+        wc_Stm32_Aes_Cleanup();
 
         return ret;
     }
@@ -3562,6 +3564,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
         HAL_CRYP_DeInit(&hcryp);
 
         wolfSSL_CryptHwMutexUnLock();
+        wc_Stm32_Aes_Cleanup();
 
         return ret;
     }
@@ -3624,6 +3627,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
 
         HAL_CRYP_DeInit(&hcryp);
         wolfSSL_CryptHwMutexUnLock();
+        wc_Stm32_Aes_Cleanup();
 
         return ret;
     }
@@ -3708,6 +3712,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
         /* disable crypto processor */
         CRYP_Cmd(DISABLE);
         wolfSSL_CryptHwMutexUnLock();
+        wc_Stm32_Aes_Cleanup();
 
         return ret;
     }
@@ -3802,6 +3807,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
         /* disable crypto processor */
         CRYP_Cmd(DISABLE);
         wolfSSL_CryptHwMutexUnLock();
+        wc_Stm32_Aes_Cleanup();
 
         return ret;
     }
@@ -4562,6 +4568,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
         #endif /* WOLFSSL_STM32_CUBEMX */
 
             wolfSSL_CryptHwMutexUnLock();
+            wc_Stm32_Aes_Cleanup();
             return ret;
         }
 
@@ -6708,6 +6715,7 @@ static WARN_UNUSED_RESULT int wc_AesGcmEncrypt_STM32(
         ret = AES_GCM_AUTH_E;
 #endif /* WOLFSSL_STM32_CUBEMX */
     wolfSSL_CryptHwMutexUnLock();
+    wc_Stm32_Aes_Cleanup();
 
     if (ret == 0) {
         /* return authTag */
@@ -7242,6 +7250,7 @@ static WARN_UNUSED_RESULT int wc_AesGcmDecrypt_STM32(
         XMEMCPY(tag, partialBlock, authTagSz);
 #endif /* WOLFSSL_STM32_CUBEMX */
     wolfSSL_CryptHwMutexUnLock();
+    wc_Stm32_Aes_Cleanup();
 
     /* Check authentication tag */
     if (ConstantCompare((const byte*)tagExpected, (byte*)tag, authTagSz) != 0) {

--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -394,6 +394,10 @@ int wc_Stm32_Aes_Init(Aes* aes, CRYP_HandleTypeDef* hcryp)
 {
     int ret;
     word32 keySize;
+#ifdef STM32_HW_CLOCK_AUTO
+    /* enable the peripheral clock */
+    __HAL_RCC_CRYP_CLK_ENABLE();
+#endif
 
     ret = wc_AesGetKeySize(aes, &keySize);
     if (ret != 0)
@@ -428,6 +432,13 @@ int wc_Stm32_Aes_Init(Aes* aes, CRYP_HandleTypeDef* hcryp)
     return 0;
 }
 
+void wc_Stm32_Aes_Cleanup(void)
+{
+#ifdef STM32_HW_CLOCK_AUTO
+    /* disable the peripheral clock */
+    __HAL_RCC_CRYP_CLK_DISABLE();
+#endif
+}
 #else /* Standard Peripheral Library */
 
 int wc_Stm32_Aes_Init(Aes* aes, CRYP_InitTypeDef* cryptInit,
@@ -485,6 +496,10 @@ int wc_Stm32_Aes_Init(Aes* aes, CRYP_InitTypeDef* cryptInit,
     cryptInit->CRYP_DataType = CRYP_DataType_8b;
 
     return 0;
+}
+
+void wc_Stm32_Aes_Cleanup(void)
+{
 }
 #endif /* WOLFSSL_STM32_CUBEMX */
 #endif /* !NO_AES */

--- a/wolfssl/wolfcrypt/port/st/stm32.h
+++ b/wolfssl/wolfcrypt/port/st/stm32.h
@@ -168,9 +168,11 @@ int  wc_Stm32_Hash_Final(STM32_HASH_Context* stmCtx, word32 algo,
     struct Aes;
     #ifdef WOLFSSL_STM32_CUBEMX
         int wc_Stm32_Aes_Init(struct Aes* aes, CRYP_HandleTypeDef* hcryp);
+        void wc_Stm32_Aes_Cleanup(void);
     #else /* Standard Peripheral Library */
         int wc_Stm32_Aes_Init(struct Aes* aes, CRYP_InitTypeDef* cryptInit,
             CRYP_KeyInitTypeDef* keyInit);
+        void wc_Stm32_Aes_Cleanup(void);
     #endif /* WOLFSSL_STM32_CUBEMX */
 #endif /* !NO_AES */
 


### PR DESCRIPTION
# Description

Add calls to the function macros `__HAL_RCC_CRYP_CLK_ENABLE` and `__HAL_RCC_CRYP_CLK_DISABLE` calls to the stm32 aes init code so it can use the hardware acceleration on stm32 platforms. Requires defining `STM32_HW_CLOCK_AUTO` in settings.

# Testing

Ran the benchmark on the NUCLEO-H753ZI board

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
