### PR TITLE
Allow Micrium to use STM32_RNG

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1555,7 +1555,8 @@ extern void uITRON4_free(void *p) ;
     #define NO_WOLFSSL_DIR
     #define NO_WRITEV
 
-    #if ! defined(WOLFSSL_SILABS_SE_ACCEL) && !defined(CUSTOM_RAND_GENERATE)
+    #if !defined(WOLFSSL_SILABS_SE_ACCEL) && !defined(STM32_RNG) && \
+        !defined(CUSTOM_RAND_GENERATE)
         #define CUSTOM_RAND_TYPE     RAND_NBR
         #define CUSTOM_RAND_GENERATE Math_Rand
     #endif


### PR DESCRIPTION
# Description

In case of Micrium platform, current configuration from settings.h (from wolfSSL v5.5.4) enforces usage of pseudo number generator available in Micrium uC-LIB stack even when RNG peripheral is available on hardware platform.

Fixes zd15969

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
