### PR TITLE
Update wolfCrypt porting layer for Mynewt OS to remove build warning.

### DIFF
--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -916,6 +916,8 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
 
 #elif defined(WOLFSSL_APACHE_MYNEWT)
     #include "os/os_time.h"
+    typedef long time_t;
+    extern time_t mynewt_time(time_t* timer);
     #define XTIME(t1)       mynewt_time((t1))
     #define WOLFSSL_GMTIME
     #define USE_WOLF_TM


### PR DESCRIPTION
# Description

Updated wolfCrypt porting layer for Mynewt OS to provide declarations needed to remove build warning for time API used for XTIME.

Relates to: https://github.com/wolfSSL/wolfssl-examples/pull/383 (fix build failures and warnings in wolfSSL Mynewt OS examples)

# Testing
 
Tested using the `wolfssl-examples/mynewt` client TLS example.
