### PR TITLE
20230412-WC_ASN_NAME_MAX-bump-for-MULTI_ATTRIB

### DIFF
--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -858,9 +858,17 @@ enum ECC_TYPES
 #ifndef WC_ASN_NAME_MAX
     #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || \
         defined(WOLFSSL_CERT_EXT)
-        #define WC_ASN_NAME_MAX 330
+        #ifdef WOLFSSL_MULTI_ATTRIB
+            #define WC_ASN_NAME_MAX 360
+        #else
+            #define WC_ASN_NAME_MAX 330
+        #endif
     #else
-        #define WC_ASN_NAME_MAX 256
+        #ifdef WOLFSSL_MULTI_ATTRIB
+            #define WC_ASN_NAME_MAX 330
+        #else
+            #define WC_ASN_NAME_MAX 256
+        #endif
     #endif
 #endif
 


### PR DESCRIPTION
`wolfssl/wolfcrypt/asn.h`: if `defined(WOLFSSL_MULTI_ATTRIB)`, bump predefined `WC_ASN_NAME_MAX`, to fix `rsa_certgen_test()` with config `--enable-testcert --enable-asn=original CPPFLAGS='-DWOLFSSL_CERT_GEN -DWOLFSSL_MULTI_ATTRIB'`.

tested with `wolfssl-multi-test.sh ...  check-self check-file-modes check-source-text check-shell-scripts all-gcc-c99 all-gcc-c89 all-g++ all-gcc-c99-asn-original sp-asn-template-asm-smallstack-sanitizer`
