### PR TITLE
fix for creating options.h with cmake and WOLFSSL_USER_SETTINGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1821,8 +1821,8 @@ generate_build_flags()
 # USER SETTINGS
 if(WOLFSSL_USER_SETTINGS)
     # Replace all options and just use WOLFSSL_USER_SETTINGS
-    set(WOLFSSL_DEFINITIONS "-DWOLFSSL_USER_SETTINGS
-        -DWOLFSSL_USER_SETTINGS_ASM")
+    set(WOLFSSL_DEFINITIONS "-DWOLFSSL_USER_SETTINGS")
+    list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_USER_SETTINGS_ASM")
 
     # Create user_settings_asm.h for use in assembly files (e.g. .S files).
     execute_process(COMMAND $ENV{SHELL} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/user_settings_asm.sh


### PR DESCRIPTION
# Description

Before cmake builds out of tree with user_settings.h was creating the following options.h:

```
17 
 18 #undef  WOLFSSL_USER_SETTINGS
 19         -DWOLFSSL_USER_SETTINGS_ASM
 20 #define WOLFSSL_USER_SETTINGS
 21         -DWOLFSSL_USER_SETTINGS_ASM

```

This adds in the separation between defines which helps the generation function.