### PR TITLE
clean up NO_BIG_INT build, removing WOLFSSL_SP_MATH macro and heapmath compile

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -536,6 +536,25 @@ fi
 
 
 # MATH LIBRARY SELECTION
+
+# no math library
+AC_ARG_ENABLE([nomath],
+    [AS_HELP_STRING([--enable-nomath],[Enable no math library (default: disabled)])],
+    [ ENABLED_NOMATH=$enableval ],
+    [ ENABLED_NOMATH="no" ]
+    )
+
+if test "$ENABLED_NOMATH" = "yes"
+then
+    DEF_SP_MATH="no"
+    DEF_FAST_MATH="no"
+    ENABLED_SP_MATH_DEFAULT=no
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_NO_MATH"
+    ENABLED_HEAPMATH="no"
+    ENABLED_SP="no"
+    ENABLED_SP_MATH_ALL="no"
+fi
+
 # Single Precision maths implementation
 AC_ARG_ENABLE([sp],
     [AS_HELP_STRING([--enable-sp],[Enable Single Precision maths implementation (default: disabled)])],
@@ -671,7 +690,7 @@ AC_ARG_ENABLE([heapmath],
     [ ENABLED_HEAPMATH=$enableval ],
     [ ENABLED_HEAPMATH=no]
     )
-if test "x$ENABLED_HEAPMATH" = "xyes" || (test "x$ENABLED_SP_MATH_ALL" = "xno" && test "x$ENABLED_FASTMATH" = "xno" && test "x$ENABLED_SP_MATH" = "xno")
+if test "x$ENABLED_HEAPMATH" = "xyes" || (test "x$ENABLED_NOMATH" = "xno" && test "x$ENABLED_SP_MATH_ALL" = "xno" && test "x$ENABLED_FASTMATH" = "xno" && test "x$ENABLED_SP_MATH" = "xno")
 then
     AM_CFLAGS="$AM_CFLAGS -DUSE_INTEGER_HEAP_MATH"
     ENABLED_HEAPMATH="yes"

--- a/configure.ac
+++ b/configure.ac
@@ -537,24 +537,6 @@ fi
 
 # MATH LIBRARY SELECTION
 
-# no math library
-AC_ARG_ENABLE([nomath],
-    [AS_HELP_STRING([--enable-nomath],[Enable no math library (default: disabled)])],
-    [ ENABLED_NOMATH=$enableval ],
-    [ ENABLED_NOMATH="no" ]
-    )
-
-if test "$ENABLED_NOMATH" = "yes"
-then
-    DEF_SP_MATH="no"
-    DEF_FAST_MATH="no"
-    ENABLED_SP_MATH_DEFAULT=no
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_NO_MATH"
-    ENABLED_HEAPMATH="no"
-    ENABLED_SP="no"
-    ENABLED_SP_MATH_ALL="no"
-fi
-
 # Single Precision maths implementation
 AC_ARG_ENABLE([sp],
     [AS_HELP_STRING([--enable-sp],[Enable Single Precision maths implementation (default: disabled)])],
@@ -690,7 +672,7 @@ AC_ARG_ENABLE([heapmath],
     [ ENABLED_HEAPMATH=$enableval ],
     [ ENABLED_HEAPMATH=no]
     )
-if test "x$ENABLED_HEAPMATH" = "xyes" || (test "x$ENABLED_NOMATH" = "xno" && test "x$ENABLED_SP_MATH_ALL" = "xno" && test "x$ENABLED_FASTMATH" = "xno" && test "x$ENABLED_SP_MATH" = "xno")
+if test "x$ENABLED_HEAPMATH" = "xyes"
 then
     AM_CFLAGS="$AM_CFLAGS -DUSE_INTEGER_HEAP_MATH"
     ENABLED_HEAPMATH="yes"
@@ -7946,6 +7928,10 @@ AS_IF([test "x$ENABLED_16BIT" = "xyes" && \
 ################################################################################
 # Update CFLAGS based on options                                               #
 ################################################################################
+AS_IF([test "x$ENABLED_SP_MATH_ALL" = "xno" && test "x$ENABLED_FASTMATH" = "xno" &&
+    test "x$ENABLED_HEAPMATH" = "xno"],
+      [AM_CFLAGS="$AM_CFLAGS -DNO_BIG_INT"])
+
 AS_IF([test "x$ENABLED_CERTS" = "xno"],
       [AM_CFLAGS="$AM_CFLAGS -DNO_CERTS"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -3960,11 +3960,6 @@ if test "$ENABLED_ASN" = "no"
 then
     AM_CFLAGS="$AM_CFLAGS -DNO_ASN -DNO_ASN_CRYPT"
     enable_pwdbased=no
-    if test "$ENABLED_DH" = "no" && test "$ENABLED_ECC" = "no"
-    then
-        # DH and ECC need bigint
-        AM_CFLAGS="$AM_CFLAGS -DNO_BIG_INT"
-    fi
 else
     if test "$ENABLED_ASN" = "template"; then
         ENABLED_ASN="yes"
@@ -4007,10 +4002,11 @@ then
     AC_MSG_ERROR([please disable ecc if disabling asn.])
 fi
 
-# No Big Int (ASN, DSA, RSA, DH and ECC need bigint)
+# No Big Int (ASN, DSA, RSA, DH, ECC and compatibility layer need bigint)
 if test "$ENABLED_ASN" = "no" && test "$ENABLED_DSA" = "no" && \
    test "$ENABLED_DH" = "no" && test "$ENABLED_ECC" = "no" && \
-   test "$ENABLED_RSA" = "no"
+   test "$ENABLED_RSA" = "no" && test "$ENABLED_OPENSSLEXTRA" = "no" && \
+   test "$ENABLED_OPENSSLALL" ="yes"
 then
     ENABLED_SP_MATH_ALL="no"
     ENABLED_FASTMATH="no"

--- a/tests/api.c
+++ b/tests/api.c
@@ -53065,6 +53065,7 @@ static int test_tls13_apis(void)
     wolfSSL_CTX_use_PrivateKey_file(serverCtx, ourKey, WOLFSSL_FILETYPE_PEM);
 #endif
     serverSsl = wolfSSL_new(serverCtx);
+    AssertNotNull(serverSsl);
 #endif
 
 #ifdef WOLFSSL_SEND_HRR_COOKIE

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2142,8 +2142,9 @@ extern void uITRON4_free(void *p) ;
         #undef HAVE_ECC_KEY_IMPORT
         #define HAVE_ECC_KEY_IMPORT
     #endif
-    /* The ECC key export requires mp_int */
-    #if !defined(NO_ECC_KEY_EXPORT) && !defined(NO_BIG_INT)
+    /* The ECC key export requires mp_int or SP */
+    #if (!defined(NO_ECC_KEY_EXPORT) && defined(WOLFSSL_SP_MATH)) || \
+        (!defined(NO_ECC_KEY_EXPORT) && !defined(NO_BIG_INT))
         #undef HAVE_ECC_KEY_EXPORT
         #define HAVE_ECC_KEY_EXPORT
     #endif

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2036,10 +2036,8 @@ extern void uITRON4_free(void *p) ;
          *      Constant time: Not supported
          *      Enable:        USE_INTEGER_HEAP_MATH
          */
-    #elif defined(WOLFSSL_NO_MATH)
-        /*  5) No math library compiled in
-         *      Does not support any public key operations or algorithms that
-         *      require the math library.
+    #elif defined(NO_BIG_INT)
+        /*  5) No big integer math libraries
          */
     #else
         /* default is SP Math. */

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2036,6 +2036,11 @@ extern void uITRON4_free(void *p) ;
          *      Constant time: Not supported
          *      Enable:        USE_INTEGER_HEAP_MATH
          */
+    #elif defined(WOLFSSL_NO_MATH)
+        /*  5) No math library compiled in
+         *      Does not support any public key operations or algorithms that
+         *      require the math library.
+         */
     #else
         /* default is SP Math. */
         #define WOLFSSL_SP_MATH_ALL


### PR DESCRIPTION
# Description

Enable option for building in no math library. Can be used in configurations like the following:

```
./configure --disable-fastmath --disable-heapmath --disable-sp-math-all --enable-cryptonly --disable-ecc --disable-rsa --disable-dh --disable-asn 
```
