### PR TITLE
dtls13: support Authentication and Integrity-Only Cipher Suites

### DIFF
--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -301,6 +301,12 @@ static int Dtls13EncryptDecryptRecordNumber(WOLFSSL* ssl, byte* seq,
     byte mask[DTLS13_RN_MASK_SIZE];
     int ret;
 
+#ifdef HAVE_NULL_CIPHER
+    /* Do not encrypt record numbers with null cipher. See RFC 9150 Sec 9 */
+    if (ssl->specs.bulk_cipher_algorithm == wolfssl_cipher_null)
+        return 0;
+#endif /*HAVE_NULL_CIPHER */
+
     ret = Dtls13GetRnMask(ssl, ciphertext, mask, dir);
     if (ret != 0)
         return ret;
@@ -2265,6 +2271,15 @@ int Dtls13SetRecordNumberKeys(WOLFSSL* ssl, enum encrypt_side side)
         return 0;
     }
 #endif /* HAVE_CHACHA */
+
+#ifdef HAVE_NULL_CIPHER
+    if (ssl->specs.bulk_cipher_algorithm == wolfssl_cipher_null) {
+#ifdef WOLFSSL_DEBUG_TLS
+        WOLFSSL_MSG("Skipping Record Number key provisioning with null cipher");
+#endif /* WOLFSSL_DEBUG_TLS */
+        return 0;
+    }
+#endif /* HAVE_NULL_CIPHER */
 
     return NOT_COMPILED_IN;
 }

--- a/tests/test-dtls13.conf
+++ b/tests/test-dtls13.conf
@@ -270,3 +270,23 @@
 -u
 -v 4
 -l TLS_AES_128_GCM_SHA256
+
+# server DTLSv1.3 Integrity-only SHA256
+-u
+-v 4
+-l TLS13-SHA256-SHA256
+
+# client DTLSv1.3 Integrity-only SHA256
+-u
+-v 4
+-l TLS13-SHA256-SHA256
+
+# server DTSv1.3 Integrity-only SHA384
+-u
+-v 4
+-l TLS13-SHA384-SHA384
+
+# client DTLSv1.3 Integrity-only SHA384
+-u
+-v 4
+-l TLS13-SHA384-SHA384


### PR DESCRIPTION
# Description

Support Authentication and Integrity-Only Cipher Suites (TLS13-SHA256-SHA256 and TLS13-SHA384-SHA384) in DTLSv1.3 (see RFC 9150)


# Testing
A new test was added, also it can be tested using `-v4 -u -l TLS13-SHA256-SHA256` options for `./examples/server/server` and `./examples/client/client` 


