### PR TITLE
fix for wpas build with x509 small

### DIFF
--- a/src/pk.c
+++ b/src/pk.c
@@ -1704,7 +1704,7 @@ int wolfSSL_RSA_LoadDer_ex(WOLFSSL_RSA* rsa, const unsigned char* derBuf,
 
 #endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
 
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)
 
 #if !defined(NO_BIO) || !defined(NO_FILESYSTEM)
 /* Load DER encoded data into WOLFSSL_RSA object.
@@ -1748,7 +1748,7 @@ static WOLFSSL_RSA* wolfssl_rsa_d2i(WOLFSSL_RSA** rsa, const unsigned char* in,
 }
 #endif
 
-#endif /* OPENSSL_EXTRA */
+#endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL */
 
 /*
  * RSA PEM APIs

--- a/src/ssl_asn1.c
+++ b/src/ssl_asn1.c
@@ -550,6 +550,7 @@ void wolfSSL_ASN1_INTEGER_free(WOLFSSL_ASN1_INTEGER* in)
     XFREE(in, NULL, DYNAMIC_TYPE_OPENSSL);
 }
 
+#if defined(OPENSSL_EXTRA)
 /* Reset the data of ASN.1 INTEGER object back to empty fixed array.
  *
  * @param [in] a  ASN.1 INTEGER object.
@@ -578,6 +579,7 @@ static void wolfssl_asn1_integer_reset_data(WOLFSSL_ASN1_INTEGER* a)
     /* Set type to positive INTEGER. */
     a->type = V_ASN1_INTEGER;
 }
+#endif /* OPENSSL_EXTRA */
 
 /* Setup ASN.1 INTEGER object to handle data of required length.
  *
@@ -1924,7 +1926,7 @@ int wolfSSL_i2a_ASN1_OBJECT(WOLFSSL_BIO *bp, WOLFSSL_ASN1_OBJECT *a)
  * ASN1_SK_OBJECT APIs
  ******************************************************************************/
 
-#if defined(OPENSSL_EXTRA) && !defined(NO_ASN)
+#if (defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)) && !defined(NO_ASN)
 /* Create a new WOLFSSL_ASN1_OBJECT stack.
  *
  * @return  New WOLFSSL_ASN1_OBJECT stack on success.
@@ -1997,7 +1999,7 @@ WOLFSSL_ASN1_OBJECT* wolfSSL_sk_ASN1_OBJECT_pop(
     return (WOLFSSL_ASN1_OBJECT*)wolfssl_sk_pop_type(sk, STACK_TYPE_OBJ);
 }
 
-#endif /* OPENSSL_EXTRA && !NO_ASN */
+#endif /* (OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL) && !NO_ASN */
 
 /*******************************************************************************
  * ASN1_STRING APIs

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -9598,7 +9598,7 @@ void wolfSSL_EVP_PKEY_free(WOLFSSL_EVP_PKEY* key)
                     break;
                 #endif /* HAVE_HKDF */
 
-                #if defined(WOLFSSL_CMAC) && !defined(NO_AES) && \
+                #if defined(WOLFSSL_CMAC) && defined(OPENSSL_EXTRA) && \
                     defined(WOLFSSL_AES_DIRECT)
                 case EVP_PKEY_CMAC:
                     if (key->cmacCtx != NULL) {

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -228,7 +228,7 @@ typedef struct WOLFSSL_DIST_POINT WOLFSSL_DIST_POINT;
 
 typedef struct WOLFSSL_CONF_CTX     WOLFSSL_CONF_CTX;
 
-#if defined(OPENSSL_EXTRA)
+#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)
 
 struct WOLFSSL_OBJ_NAME {
     int type;
@@ -2862,6 +2862,8 @@ WOLFSSL_API WOLFSSL_X509_NAME* wolfSSL_X509_CRL_get_issuer_name(
                                                         WOLFSSL_X509_CRL *crl);
 WOLFSSL_API int wolfSSL_X509_REVOKED_get_serial_number(RevokedCert* rev,
                                                        byte* in, int* inOutSz);
+#endif
+#if defined(HAVE_CRL) && (defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL))
 WOLFSSL_API void wolfSSL_X509_CRL_free(WOLFSSL_X509_CRL *crl);
 #endif
 


### PR DESCRIPTION
Fixes build:

```
./configure --enable-static --enable-tlsx --enable-supportedcurves --enable-ocspstapling --enable-secure-renegotiation --enable-certgen --enable-pkcallbacks --enable-cmac --enable-keygen --disable-oldtls --enable-opensslextra=x509small --enable-des3 --enable-crl --enable-wpas=small && make
```