### PR TITLE
20230413-fixes

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -6455,8 +6455,6 @@ static int _RsaPrivateKeyDecode(const byte* input, word32* inOutIdx,
 #endif
     void*      heap = NULL;
 
-    (void)heap;
-
     /* Check validity of parameters. */
     if ((inOutIdx == NULL) || (input == NULL) || ((key == NULL) &&
             (keySz == NULL))) {
@@ -6476,6 +6474,7 @@ static int _RsaPrivateKeyDecode(const byte* input, word32* inOutIdx,
     }
 #endif
 
+    (void)heap;
     CALLOC_ASNGETDATA(dataASN, rsaKeyASN_Length, ret, heap);
 
     if (ret == 0) {

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -1441,7 +1441,7 @@ static int xil_mpi_import(mp_int *mpi,
 #ifdef WOLFSSL_SP_MATH_ALL
     #define DECLARE_CURVE_SPECS(intcount)                               \
         unsigned char spec_ints[MP_INT_SIZEOF(MP_BITS_CNT(              \
-            MAX_ECC_BITS_USE)) * intcount];                             \
+            MAX_ECC_BITS_USE)) * (intcount)];                           \
         ecc_curve_spec curve_lcl;                                       \
         ecc_curve_spec* curve = &curve_lcl;                             \
         XMEMSET(curve, 0, sizeof(ecc_curve_spec));                      \

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -11887,7 +11887,8 @@ WOLFSSL_API int wc_PKCS7_DecodeAuthEnvelopedData(PKCS7* pkcs7, byte* in,
                     if (expBlockSz < 0) {
                         ret = expBlockSz;
                         break;
-                    }
+                    } else if (expBlockSz == 0)
+                        expBlockSz = 1;
                 }
             }
 

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -127,7 +127,7 @@ This library provides single precision (SP) integer math functions.
         /* Declare a variable on the stack with the required data size. */
         #define DECL_SP_INT(n, s)               \
             byte    n##d[MP_INT_SIZEOF(s)];     \
-            sp_int* n = (sp_int*)n##d
+            sp_int* (n) = (sp_int*)n##d
     #else
         /* Declare a variable on the stack. */
         #define DECL_SP_INT(n, s)               \

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -796,7 +796,7 @@ while (0)
 /* Declare a dynamically allocated mp_int. */
 #define DECL_MP_INT_SIZE_DYN(name, bits, max)                   \
     unsigned char name##d[MP_INT_SIZEOF(MP_BITS_CNT(bits))];    \
-    sp_int* name = (sp_int*)name##d
+    sp_int* (name) = (sp_int*)name##d
 #else
 /* Declare a dynamically allocated mp_int. */
 #define DECL_MP_INT_SIZE_DYN(name, bits, max)                   \
@@ -806,7 +806,7 @@ while (0)
 /* Declare a statically allocated mp_int. */
 #define DECL_MP_INT_SIZE(name, bits)                            \
     unsigned char name##d[MP_INT_SIZEOF(MP_BITS_CNT(bits))];    \
-    sp_int* name = (sp_int*)name##d
+    sp_int* (name) = (sp_int*)name##d
 /* Zero out mp_int of minimal size. */
 #define NEW_MP_INT_SIZE(name, bits, heap, type) \
     XMEMSET(name, 0, MP_INT_SIZEOF(MP_BITS_CNT(bits)))


### PR DESCRIPTION
fix for `cppcheck`/`zerodivcond` in `wolfcrypt/src/pkcs7.c`:`wc_PKCS7_DecodeAuthEnvelopedData()`;

fixes for `clang-tidy`/`bugprone-macro-parentheses` in `wolfssl/wolfcrypt/sp_int.{c,h}` and `wolfcrypt/src/ecc.c`;

fix for `clang-analyzer-deadcode.DeadStores` in `wolfcrypt/src/asn.c`.

tested with `wolfssl-multi-test.sh ... super-quick-check all-WOLFSSL_CALLBACKS-clang-tidy`
