### PR TITLE
SP int: sp_mod check sp_div error before adding and replacing error

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -8434,7 +8434,7 @@ int sp_mod(const sp_int* a, const sp_int* m, sp_int* r)
 #else
     if ((err == MP_OKAY) && (r != m)) {
         err = sp_div(a, m, NULL, r);
-        if ((!sp_iszero(r)) && (r->sign != m->sign)) {
+        if ((err == MP_OKAY) && (!sp_iszero(r)) && (r->sign != m->sign)) {
             err = sp_add(r, m, r);
         }
     }


### PR DESCRIPTION
# Description

Fix to not overwrite error when sp_div fails in sp_mod.

Fixes zd#16007

# Testing

Standard.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
