### PR TITLE
Fix out-of-bounds write in fp_mod_2d.

### DIFF
--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -1010,6 +1010,13 @@ void fp_mod_2d(fp_int *a, int b, fp_int *c)
    }
 
    bmax = ((unsigned int)b + DIGIT_BIT - 1) / DIGIT_BIT;
+
+   /* If a is negative and bmax is larger than FP_SIZE, then the
+    * result can't fit within c. Just return. */
+   if (c->sign == FP_NEG && bmax > FP_SIZE) {
+      return;
+   }
+
   /* zero digits above the last digit of the modulus */
    for (x = bmax; x < (unsigned int)c->used; x++) {
     c->dp[x] = 0;


### PR DESCRIPTION
# Description

The function `fp_mod_2d()` could do an out of bounds write when `a` was negative and `b` was larger than `FP_SIZE`.

Instead, just return early per discussion with Sean.

Fixes zd#15961.

# Testing

Tested with reproducer in ticket.
