### PR TITLE
Fix compilation error in CC-RX and remove unnecessary public key import

### DIFF
--- a/IDE/Renesas/e2studio/RX65N/GR-ROSE/common/user_settings.h
+++ b/IDE/Renesas/e2studio/RX65N/GR-ROSE/common/user_settings.h
@@ -61,6 +61,17 @@
   #define SINGLE_THREADED 
 /*#define FREERTOS*/
 
+/*-- Compiler related definitions  ---------------------------------------------
+ *
+ *  CC-RX is C99 compliant, but may not provide the features wolfSSL requires.
+ *  This section defines macros for such cases to avoid build-time or run-time
+ *  failures.
+ *
+ *----------------------------------------------------------------------------*/
+
+/* CC-RX does not support variable length array */
+#define WOLFSSL_SP_NO_DYN_STACK
+
 
 /*-- Cipher related definitions  -----------------------------------------------
  *

--- a/IDE/Renesas/e2studio/RX65N/RSK/wolfssl_demo/user_settings.h
+++ b/IDE/Renesas/e2studio/RX65N/RSK/wolfssl_demo/user_settings.h
@@ -63,6 +63,17 @@
 #define FREERTOS_TCP
 
 
+/*-- Compiler related definitions  ---------------------------------------------
+ *
+ *  CC-RX is C99 compliant, but may not provide the features wolfSSL requires.
+ *  This section defines macros for such cases to avoid build-time or run-time
+ *  failures.
+ *
+ *----------------------------------------------------------------------------*/
+
+/* CC-RX does not support variable length array */
+#define WOLFSSL_SP_NO_DYN_STACK
+
 
 
 /*-- Cipher related definitions  -----------------------------------------------

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/user_settings.h
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/user_settings.h
@@ -77,6 +77,18 @@
     #define WOLFSSL_USER_IO
 #endif
 
+/*-- Compiler related definitions  ---------------------------------------------
+ *
+ *  CC-RX is C99 compliant, but may not provide the features wolfSSL requires.
+ *  This section defines macros for such cases to avoid build-time or run-time
+ *  failures.
+ *
+ *----------------------------------------------------------------------------*/
+
+/* CC-RX does not support variable length array */
+#define WOLFSSL_SP_NO_DYN_STACK
+
+
 /*-- Cipher related definitions  -----------------------------------------------
  *
  *

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_util.c
@@ -1913,7 +1913,14 @@ WOLFSSL_LOCAL int tsip_Tls13SendCertVerify(WOLFSSL* ssl)
     }
 
     if (ret == 0) {
-        ret = tsipImportPublicKey(tuc, tuc->wrappedKeyType);
+        if (isRsa) {
+            ret = tsipImportPublicKey(tuc, tuc->wrappedKeyType);
+        }
+        else {
+#if defined(WOLFSSL_CHECK_SIG_FAULTS)
+            ret = tsipImportPublicKey(tuc, tuc->wrappedKeyType);
+#endif
+        }
     }
 
     if (ret == 0) {


### PR DESCRIPTION
# Description

This PR is addressing following issues:

-Renesas CC-RX compiler is C99 compliant but does not support vla(variable length array) feature. This limitation causes compilation errors for that recently added the feature to the SP math code.
To disable the use of the feature, added WOLFSSL_SP_NO_DYN_STACK macro to user_settings.h in some example programs.

-When using ECDSA certificates, the public key should only be imported if WOLFSSL_CHECK_SIG_FAULTS is defined.

# Testing

Build an example with CC-RX compiler then run it on a Renesas board.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
