### PR TITLE
20230418-more-Wconversion-fixes

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -809,7 +809,7 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
         static WARN_UNUSED_RESULT int AES_set_decrypt_key(
             const unsigned char* userKey, const int bits, Aes* aes)
         {
-            int nr;
+            word32 nr;
 #ifdef WOLFSSL_SMALL_STACK
             Aes *temp_key;
 #else
@@ -1795,7 +1795,7 @@ static WARN_UNUSED_RESULT int wc_AesEncrypt(
 
             XMEMCPY(tmp_align, inBlock, AES_BLOCK_SIZE);
             AES_ECB_encrypt(tmp_align, tmp_align, AES_BLOCK_SIZE,
-                    (byte*)aes->key, aes->rounds);
+                    (byte*)aes->key, (int)aes->rounds);
             XMEMCPY(outBlock, tmp_align, AES_BLOCK_SIZE);
             XFREE(tmp, aes->heap, DYNAMIC_TYPE_TMP_BUFFER);
             return 0;
@@ -1807,7 +1807,7 @@ static WARN_UNUSED_RESULT int wc_AesEncrypt(
         }
 
         AES_ECB_encrypt(inBlock, outBlock, AES_BLOCK_SIZE, (byte*)aes->key,
-                        aes->rounds);
+                        (int)aes->rounds);
 
         return 0;
     }
@@ -2150,7 +2150,7 @@ static WARN_UNUSED_RESULT int wc_AesDecrypt(
         if ((const byte*)aes->tmp != inBlock)
             XMEMCPY(aes->tmp, inBlock, AES_BLOCK_SIZE);
         AES_ECB_decrypt(inBlock, outBlock, AES_BLOCK_SIZE, (byte*)aes->key,
-                        aes->rounds);
+                        (int)aes->rounds);
         return 0;
     }
     else {
@@ -2927,10 +2927,10 @@ static WARN_UNUSED_RESULT int wc_AesDecrypt(
             else
                 XMEMSET(aes->reg, 0, AES_BLOCK_SIZE);
             if (dir == AES_ENCRYPTION)
-                return AES_set_encrypt_key(userKey, keylen * 8, aes);
+                return AES_set_encrypt_key(userKey, (int)keylen * 8, aes);
         #ifdef HAVE_AES_DECRYPT
             else
-                return AES_set_decrypt_key(userKey, keylen * 8, aes);
+                return AES_set_decrypt_key(userKey, (int)keylen * 8, aes);
         #endif
         }
     #endif /* WOLFSSL_AESNI */
@@ -4073,7 +4073,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
                 XMEMCPY(tmp_align, in, sz);
                 SAVE_VECTOR_REGISTERS(XFREE(tmp, aes->heap, DYNAMIC_TYPE_TMP_BUFFER); return _svr_ret;);
                 AES_CBC_encrypt(tmp_align, tmp_align, (byte*)aes->reg, sz,
-                                                  (byte*)aes->key, aes->rounds);
+                                             (byte*)aes->key, (int)aes->rounds);
                 RESTORE_VECTOR_REGISTERS();
                 /* store iv for next call */
                 XMEMCPY(aes->reg, tmp_align + sz - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
@@ -4090,7 +4090,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
 
             SAVE_VECTOR_REGISTERS(return _svr_ret;);
             AES_CBC_encrypt(in, out, (byte*)aes->reg, sz, (byte*)aes->key,
-                            aes->rounds);
+                            (int)aes->rounds);
             RESTORE_VECTOR_REGISTERS();
             /* store iv for next call */
             XMEMCPY(aes->reg, out + sz - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
@@ -4205,7 +4205,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
                             aes->rounds);
             #else /* WOLFSSL_AESNI_BYx */
             AES_CBC_decrypt_by8(in, out, (byte*)aes->reg, sz, (byte*)aes->key,
-                            aes->rounds);
+                            (int)aes->rounds);
             #endif /* WOLFSSL_AESNI_BYx */
             /* store iv for next call */
             RESTORE_VECTOR_REGISTERS();
@@ -5305,7 +5305,7 @@ static WC_INLINE void GMULT(byte *x, byte m[32][AES_BLOCK_SIZE])
         z8[0] ^= m8[0]; z8[1] ^= m8[1]; z8[2] ^= m8[2]; z8[3] ^= m8[3];
 
         /* Cache top byte for remainder calculations - lost in rotate. */
-        a = z8[3] >> 24;
+        a = (byte)(z8[3] >> 24);
 
         /* Rotate Z by 8-bits */
         z8[3] = (z8[2] >> 24) | (z8[3] << 8);
@@ -6720,7 +6720,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     if (IS_INTEL_AVX2(intel_flags)) {
         SAVE_VECTOR_REGISTERS(return _svr_ret;);
         AES_GCM_encrypt_avx2(in, out, authIn, iv, authTag, sz, authInSz, ivSz,
-                                 authTagSz, (const byte*)aes->key, aes->rounds);
+                            authTagSz, (const byte*)aes->key, (int)aes->rounds);
         RESTORE_VECTOR_REGISTERS();
         return 0;
     }
@@ -6730,7 +6730,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     if (IS_INTEL_AVX1(intel_flags)) {
         SAVE_VECTOR_REGISTERS(return _svr_ret;);
         AES_GCM_encrypt_avx1(in, out, authIn, iv, authTag, sz, authInSz, ivSz,
-                                 authTagSz, (const byte*)aes->key, aes->rounds);
+                            authTagSz, (const byte*)aes->key, (int)aes->rounds);
         RESTORE_VECTOR_REGISTERS();
         return 0;
     }
@@ -6738,7 +6738,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     #endif
     if (haveAESNI) {
         AES_GCM_encrypt(in, out, authIn, iv, authTag, sz, authInSz, ivSz,
-                                 authTagSz, (const byte*)aes->key, aes->rounds);
+                            authTagSz, (const byte*)aes->key, (int)aes->rounds);
         return 0;
     }
     else
@@ -7276,7 +7276,7 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     if (IS_INTEL_AVX2(intel_flags)) {
         SAVE_VECTOR_REGISTERS(return _svr_ret;);
         AES_GCM_decrypt_avx2(in, out, authIn, iv, authTag, sz, authInSz, ivSz,
-                                 authTagSz, (byte*)aes->key, aes->rounds, &res);
+                            authTagSz, (byte*)aes->key, (int)aes->rounds, &res);
         RESTORE_VECTOR_REGISTERS();
         if (res == 0)
             return AES_GCM_AUTH_E;
@@ -7288,7 +7288,7 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     if (IS_INTEL_AVX1(intel_flags)) {
         SAVE_VECTOR_REGISTERS(return _svr_ret;);
         AES_GCM_decrypt_avx1(in, out, authIn, iv, authTag, sz, authInSz, ivSz,
-                                 authTagSz, (byte*)aes->key, aes->rounds, &res);
+                            authTagSz, (byte*)aes->key, (int)aes->rounds, &res);
         RESTORE_VECTOR_REGISTERS();
         if (res == 0)
             return AES_GCM_AUTH_E;
@@ -7298,7 +7298,7 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     #endif
     if (haveAESNI) {
         AES_GCM_decrypt(in, out, authIn, iv, authTag, sz, authInSz, ivSz,
-                                 authTagSz, (byte*)aes->key, aes->rounds, &res);
+                            authTagSz, (byte*)aes->key, (int)aes->rounds, &res);
         if (res == 0)
             return AES_GCM_AUTH_E;
         return 0;
@@ -7560,7 +7560,7 @@ static WARN_UNUSED_RESULT int AesGcmInit_aesni(
 #ifdef HAVE_INTEL_AVX2
     if (IS_INTEL_AVX2(intel_flags)) {
         SAVE_VECTOR_REGISTERS(return _svr_ret;);
-        AES_GCM_init_avx2((byte*)aes->key, aes->rounds, iv, ivSz, aes->H,
+        AES_GCM_init_avx2((byte*)aes->key, (int)aes->rounds, iv, ivSz, aes->H,
                           AES_COUNTER(aes), AES_INITCTR(aes));
         RESTORE_VECTOR_REGISTERS();
     }
@@ -7569,7 +7569,7 @@ static WARN_UNUSED_RESULT int AesGcmInit_aesni(
 #ifdef HAVE_INTEL_AVX1
     if (IS_INTEL_AVX1(intel_flags)) {
         SAVE_VECTOR_REGISTERS(return _svr_ret;);
-        AES_GCM_init_avx1((byte*)aes->key, aes->rounds, iv, ivSz, aes->H,
+        AES_GCM_init_avx1((byte*)aes->key, (int)aes->rounds, iv, ivSz, aes->H,
                           AES_COUNTER(aes), AES_INITCTR(aes));
         RESTORE_VECTOR_REGISTERS();
     }
@@ -7577,7 +7577,7 @@ static WARN_UNUSED_RESULT int AesGcmInit_aesni(
 #endif
     {
         SAVE_VECTOR_REGISTERS(return _svr_ret;);
-        AES_GCM_init_aesni((byte*)aes->key, aes->rounds, iv, ivSz, aes->H,
+        AES_GCM_init_aesni((byte*)aes->key, (int)aes->rounds, iv, ivSz, aes->H,
                            AES_COUNTER(aes), AES_INITCTR(aes));
         RESTORE_VECTOR_REGISTERS();
     }
@@ -7609,7 +7609,7 @@ static WARN_UNUSED_RESULT int AesGcmAadUpdate_aesni(
             /* Calculate amount we can use - fill up the block. */
             byte sz = AES_BLOCK_SIZE - aes->aOver;
             if (sz > aSz) {
-                sz = aSz;
+                sz = (byte)aSz;
             }
             /* Copy extra into last GHASH block array and update count. */
             XMEMCPY(AES_LASTGBLOCK(aes) + aes->aOver, a, sz);
@@ -7670,7 +7670,7 @@ static WARN_UNUSED_RESULT int AesGcmAadUpdate_aesni(
         }
         if (partial != 0) {
             /* Cache the partial block. */
-            XMEMCPY(AES_LASTGBLOCK(aes), a, partial);
+            XMEMCPY(AES_LASTGBLOCK(aes), a, (size_t)partial);
             aes->aOver = (byte)partial;
         }
     }
@@ -7735,7 +7735,7 @@ static WARN_UNUSED_RESULT int AesGcmEncryptUpdate_aesni(
             /* Calculate amount we can use - fill up the block. */
             byte sz = AES_BLOCK_SIZE - aes->cOver;
             if (sz > cSz) {
-                sz = cSz;
+                sz = (byte)cSz;
             }
             /* Encrypt some of the plaintext. */
             xorbuf(AES_LASTGBLOCK(aes) + aes->cOver, p, sz);
@@ -7778,23 +7778,23 @@ static WARN_UNUSED_RESULT int AesGcmEncryptUpdate_aesni(
             /* Encrypt and GHASH full blocks now. */
         #ifdef HAVE_INTEL_AVX2
             if (IS_INTEL_AVX2(intel_flags)) {
-                AES_GCM_encrypt_update_avx2((byte*)aes->key, aes->rounds, c, p,
-                    blocks * AES_BLOCK_SIZE, AES_TAG(aes), aes->H,
+                AES_GCM_encrypt_update_avx2((byte*)aes->key, (int)aes->rounds,
+                    c, p, blocks * AES_BLOCK_SIZE, AES_TAG(aes), aes->H,
                     AES_COUNTER(aes));
             }
             else
         #endif
         #ifdef HAVE_INTEL_AVX1
             if (IS_INTEL_AVX1(intel_flags)) {
-                AES_GCM_encrypt_update_avx1((byte*)aes->key, aes->rounds, c, p,
-                    blocks * AES_BLOCK_SIZE, AES_TAG(aes), aes->H,
+                AES_GCM_encrypt_update_avx1((byte*)aes->key, (int)aes->rounds,
+                    c, p, blocks * AES_BLOCK_SIZE, AES_TAG(aes), aes->H,
                     AES_COUNTER(aes));
             }
             else
         #endif
             {
-                AES_GCM_encrypt_update_aesni((byte*)aes->key, aes->rounds, c, p,
-                    blocks * AES_BLOCK_SIZE, AES_TAG(aes), aes->H,
+                AES_GCM_encrypt_update_aesni((byte*)aes->key, (int)aes->rounds,
+                    c, p, blocks * AES_BLOCK_SIZE, AES_TAG(aes), aes->H,
                     AES_COUNTER(aes));
             }
             /* Skip over to end of blocks. */
@@ -7806,27 +7806,27 @@ static WARN_UNUSED_RESULT int AesGcmEncryptUpdate_aesni(
             XMEMSET(AES_LASTGBLOCK(aes), 0, AES_BLOCK_SIZE);
         #ifdef HAVE_INTEL_AVX2
             if (IS_INTEL_AVX2(intel_flags)) {
-                AES_GCM_encrypt_block_avx2((byte*)aes->key, aes->rounds,
+                AES_GCM_encrypt_block_avx2((byte*)aes->key, (int)aes->rounds,
                     AES_LASTGBLOCK(aes), AES_LASTGBLOCK(aes), AES_COUNTER(aes));
             }
             else
         #endif
         #ifdef HAVE_INTEL_AVX1
             if (IS_INTEL_AVX1(intel_flags)) {
-                AES_GCM_encrypt_block_avx1((byte*)aes->key, aes->rounds,
+                AES_GCM_encrypt_block_avx1((byte*)aes->key, (int)aes->rounds,
                     AES_LASTGBLOCK(aes), AES_LASTGBLOCK(aes), AES_COUNTER(aes));
             }
             else
         #endif
             {
-                AES_GCM_encrypt_block_aesni((byte*)aes->key, aes->rounds,
+                AES_GCM_encrypt_block_aesni((byte*)aes->key, (int)aes->rounds,
                     AES_LASTGBLOCK(aes), AES_LASTGBLOCK(aes), AES_COUNTER(aes));
             }
             /* XOR the remaining plaintext to calculate cipher text.
              * Keep cipher text for GHASH of last partial block.
              */
-            xorbuf(AES_LASTGBLOCK(aes), p, partial);
-            XMEMCPY(c, AES_LASTGBLOCK(aes), partial);
+            xorbuf(AES_LASTGBLOCK(aes), p, (word32)partial);
+            XMEMCPY(c, AES_LASTGBLOCK(aes), (size_t)partial);
             /* Update count of the block used. */
             aes->cOver = (byte)partial;
         }
@@ -7963,7 +7963,7 @@ static WARN_UNUSED_RESULT int AesGcmDecryptUpdate_aesni(
             /* Calculate amount we can use - fill up the block. */
             byte sz = AES_BLOCK_SIZE - aes->cOver;
             if (sz > cSz) {
-                sz = cSz;
+                sz = (byte)cSz;
             }
             /* Keep a copy of the cipher text for GHASH. */
             XMEMCPY(AES_LASTBLOCK(aes) + aes->cOver, c, sz);
@@ -8008,23 +8008,23 @@ static WARN_UNUSED_RESULT int AesGcmDecryptUpdate_aesni(
             /* Decrypt and GHASH full blocks now. */
         #ifdef HAVE_INTEL_AVX2
             if (IS_INTEL_AVX2(intel_flags)) {
-                AES_GCM_decrypt_update_avx2((byte*)aes->key, aes->rounds, p, c,
-                    blocks * AES_BLOCK_SIZE, AES_TAG(aes), aes->H,
+                AES_GCM_decrypt_update_avx2((byte*)aes->key, (int)aes->rounds,
+                    p, c, blocks * AES_BLOCK_SIZE, AES_TAG(aes), aes->H,
                     AES_COUNTER(aes));
             }
             else
         #endif
         #ifdef HAVE_INTEL_AVX1
             if (IS_INTEL_AVX1(intel_flags)) {
-                AES_GCM_decrypt_update_avx1((byte*)aes->key, aes->rounds, p, c,
-                    blocks * AES_BLOCK_SIZE, AES_TAG(aes), aes->H,
+                AES_GCM_decrypt_update_avx1((byte*)aes->key, (int)aes->rounds,
+                    p, c, blocks * AES_BLOCK_SIZE, AES_TAG(aes), aes->H,
                     AES_COUNTER(aes));
             }
             else
         #endif
             {
-                AES_GCM_decrypt_update_aesni((byte*)aes->key, aes->rounds, p, c,
-                    blocks * AES_BLOCK_SIZE, AES_TAG(aes), aes->H,
+                AES_GCM_decrypt_update_aesni((byte*)aes->key, (int)aes->rounds,
+                    p, c, blocks * AES_BLOCK_SIZE, AES_TAG(aes), aes->H,
                     AES_COUNTER(aes));
             }
             /* Skip over to end of blocks. */
@@ -8036,27 +8036,27 @@ static WARN_UNUSED_RESULT int AesGcmDecryptUpdate_aesni(
             XMEMSET(AES_LASTGBLOCK(aes), 0, AES_BLOCK_SIZE);
         #ifdef HAVE_INTEL_AVX2
             if (IS_INTEL_AVX2(intel_flags)) {
-                AES_GCM_encrypt_block_avx2((byte*)aes->key, aes->rounds,
+                AES_GCM_encrypt_block_avx2((byte*)aes->key, (int)aes->rounds,
                     AES_LASTGBLOCK(aes), AES_LASTGBLOCK(aes), AES_COUNTER(aes));
             }
             else
         #endif
         #ifdef HAVE_INTEL_AVX1
             if (IS_INTEL_AVX1(intel_flags)) {
-                AES_GCM_encrypt_block_avx1((byte*)aes->key, aes->rounds,
+                AES_GCM_encrypt_block_avx1((byte*)aes->key, (int)aes->rounds,
                     AES_LASTGBLOCK(aes), AES_LASTGBLOCK(aes), AES_COUNTER(aes));
             }
             else
         #endif
             {
-                AES_GCM_encrypt_block_aesni((byte*)aes->key, aes->rounds,
+                AES_GCM_encrypt_block_aesni((byte*)aes->key, (int)aes->rounds,
                     AES_LASTGBLOCK(aes), AES_LASTGBLOCK(aes), AES_COUNTER(aes));
             }
             /* Keep cipher text for GHASH of last partial block. */
-            XMEMCPY(AES_LASTBLOCK(aes), c, partial);
+            XMEMCPY(AES_LASTBLOCK(aes), c, (size_t)partial);
             /* XOR the remaining cipher text to calculate plaintext. */
-            xorbuf(AES_LASTGBLOCK(aes), c, partial);
-            XMEMCPY(p, AES_LASTGBLOCK(aes), partial);
+            xorbuf(AES_LASTGBLOCK(aes), c, (word32)partial);
+            XMEMCPY(p, AES_LASTGBLOCK(aes), (size_t)partial);
             /* Update count of the block used. */
             aes->cOver = (byte)partial;
         }
@@ -9190,7 +9190,7 @@ int wc_AesCcmEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
             AesCcmCtrIncSet4(B, lenSz);
 
             AES_ECB_encrypt(B, A, AES_BLOCK_SIZE * 4, (byte*)aes->key,
-                            aes->rounds);
+                            (int)aes->rounds);
 
             xorbuf(A, in, AES_BLOCK_SIZE * 4);
             XMEMCPY(out, A, AES_BLOCK_SIZE * 4);
@@ -9315,7 +9315,7 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
             AesCcmCtrIncSet4(B, lenSz);
 
             AES_ECB_encrypt(B, A, AES_BLOCK_SIZE * 4, (byte*)aes->key,
-                            aes->rounds);
+                            (int)aes->rounds);
 
             xorbuf(A, in, AES_BLOCK_SIZE * 4);
             XMEMCPY(o, A, AES_BLOCK_SIZE * 4);
@@ -9815,7 +9815,7 @@ static WARN_UNUSED_RESULT int _AesEcbEncrypt(
 #ifdef WOLFSSL_AESNI
     if (haveAESNI && aes->use_aesni) {
         SAVE_VECTOR_REGISTERS(return _svr_ret;);
-        AES_ECB_encrypt(in, out, sz, (byte*)aes->key, aes->rounds);
+        AES_ECB_encrypt(in, out, sz, (byte*)aes->key, (int)aes->rounds);
         RESTORE_VECTOR_REGISTERS();
         blocks = 0;
     }
@@ -9851,7 +9851,7 @@ static WARN_UNUSED_RESULT int _AesEcbDecrypt(
 #ifdef WOLFSSL_AESNI
     if (haveAESNI && aes->use_aesni) {
         SAVE_VECTOR_REGISTERS(return _svr_ret;);
-        AES_ECB_decrypt(in, out, sz, (byte*)aes->key, aes->rounds);
+        AES_ECB_decrypt(in, out, sz, (byte*)aes->key, (int)aes->rounds);
         RESTORE_VECTOR_REGISTERS();
         blocks = 0;
     }

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -9914,21 +9914,12 @@ static WARN_UNUSED_RESULT int wc_AesFeedbackEncrypt(
     Aes* aes, byte* out, const byte* in, word32 sz, byte mode)
 {
     byte*  tmp = NULL;
-#ifdef WOLFSSL_AES_CFB
-    byte*  reg = NULL;
-#endif
     int ret = 0;
     word32 processed;
 
     if (aes == NULL || out == NULL || in == NULL) {
         return BAD_FUNC_ARG;
     }
-
-#ifdef WOLFSSL_AES_CFB
-    if (aes->left && sz) {
-        reg = (byte*)aes->reg + AES_BLOCK_SIZE - aes->left;
-    }
-#endif
 
     /* consume any unused bytes left in aes->tmp */
     processed = min(aes->left, sz);
@@ -9980,14 +9971,11 @@ static WARN_UNUSED_RESULT int wc_AesFeedbackEncrypt(
             XMEMCPY(aes->reg, aes->tmp, AES_BLOCK_SIZE);
         }
     #endif
-    #ifdef WOLFSSL_AES_CFB
-        reg = (byte*)aes->reg;
-    #endif
 
         xorbufout(out, in, tmp, sz);
     #ifdef WOLFSSL_AES_CFB
         if (mode == AES_CFB_MODE) {
-            XMEMCPY(reg, out, sz);
+            XMEMCPY(aes->reg, out, sz);
         }
     #endif
         aes->left -= sz;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -3111,7 +3111,8 @@ int GetShortInt(const byte* input, word32* inOutIdx, int* number, word32 maxIdx)
 }
 
 
-#if !defined(WOLFSSL_ASN_TEMPLATE) || defined(HAVE_PKCS12)
+#if !defined(WOLFSSL_ASN_TEMPLATE) || defined(HAVE_PKCS8) || \
+     defined(HAVE_PKCS12)
 /* Set small integer, 32 bits or less. DER encoding with no leading 0s
  * returns total amount written including ASN tag and length byte on success */
 int SetShortInt(byte* input, word32* inOutIdx, word32 number, word32 maxIdx)
@@ -3155,7 +3156,7 @@ int SetShortInt(byte* input, word32* inOutIdx, word32 number, word32 maxIdx)
 
     return len + 2; /* size of integer bytes plus ASN TAG and length byte */
 }
-#endif /* !WOLFSSL_ASN_TEMPLATE */
+#endif /* !WOLFSSL_ASN_TEMPLATE || HAVE_PKCS8 || HAVE_PKCS12 */
 #endif /* !NO_PWDBASED */
 
 #ifndef WOLFSSL_ASN_TEMPLATE
@@ -11762,7 +11763,7 @@ static int GetCertKey(DecodedCert* cert, const byte* source, word32* inOutIdx,
                 }
                 /* Get the pubic key parameters. */
                 ret = DecodeRsaPssParams(source + seqIdx,
-                    seqLen + srcIdx - seqIdx, &hash, &mgf, &saltLen);
+                    (word32)seqLen + srcIdx - seqIdx, &hash, &mgf, &saltLen);
                 if (ret != 0) {
                     return ASN_PARSE_E;
                 }
@@ -11785,7 +11786,7 @@ static int GetCertKey(DecodedCert* cert, const byte* source, word32* inOutIdx,
                     WOLFSSL_MSG("RSA PSS: sig salt length too small");
                     return ASN_PARSE_E;
                 }
-                srcIdx += seqLen;
+                srcIdx += (word32)seqLen;
             }
             FALL_THROUGH;
     #endif /* WC_RSA_PSS */
@@ -16104,7 +16105,7 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
                         sigCtx->saltLen, 0);
                 #else
                     ret = wc_RsaPSS_CheckPadding_ex2(sigCtx->digest,
-                        sigCtx->digestSz, sigCtx->out, ret, sigCtx->hash,
+                        (word32)sigCtx->digestSz, sigCtx->out, (word32)ret, sigCtx->hash,
                         sigCtx->saltLen, wc_RsaEncryptSize(sigCtx->key.rsa) * 8,
                         sigCtx->heap);
                 #endif

--- a/wolfcrypt/src/blake2b.c
+++ b/wolfcrypt/src/blake2b.c
@@ -219,7 +219,7 @@ static WC_INLINE int blake2b_compress(
     word64* m,
     word64* v)
 {
-  int i;
+  word64 i;
 
   for( i = 0; i < 16; ++i )
     m[i] = load64( block + i * sizeof( m[i] ) );
@@ -339,7 +339,7 @@ int blake2b_final( blake2b_state *S, byte *out, byte outlen )
 {
   int ret = 0;
   byte buffer[BLAKE2B_OUTBYTES];
-  int     i;
+  word64    i;
 #ifdef WOLFSSL_SMALL_STACK
   word64* m;
   word64* v;

--- a/wolfcrypt/src/blake2s.c
+++ b/wolfcrypt/src/blake2s.c
@@ -69,7 +69,7 @@ static const byte blake2s_sigma[10][16] =
 
 static WC_INLINE int blake2s_set_lastnode( blake2s_state *S )
 {
-  S->f[1] = ~0;
+  S->f[1] = ~0U;
   return 0;
 }
 
@@ -78,7 +78,7 @@ static WC_INLINE int blake2s_set_lastblock( blake2s_state *S )
 {
   if( S->last_node ) blake2s_set_lastnode( S );
 
-  S->f[0] = ~0;
+  S->f[0] = ~0U;
   return 0;
 }
 
@@ -215,7 +215,7 @@ static WC_INLINE int blake2s_compress(
     word32* m,
     word32* v)
 {
-  int i;
+  word32 i;
 
   for( i = 0; i < 16; ++i )
     m[i] = load32( block + i * sizeof( m[i] ) );
@@ -332,7 +332,7 @@ int blake2s_update( blake2s_state *S, const byte *in, word32 inlen )
 int blake2s_final( blake2s_state *S, byte *out, byte outlen )
 {
   int ret = 0;
-  int     i;
+  word32    i;
   byte buffer[BLAKE2S_BLOCKBYTES];
 #ifdef WOLFSSL_SMALL_STACK
   word32* m;

--- a/wolfcrypt/src/chacha.c
+++ b/wolfcrypt/src/chacha.c
@@ -77,7 +77,7 @@ Public domain.
     #endif
 
     static int cpuidFlagsSet = 0;
-    static int cpuidFlags = 0;
+    static word32 cpuidFlags = 0;
 #endif
 
 #ifdef BIG_ENDIAN_ORDER
@@ -234,7 +234,7 @@ static WC_INLINE void wc_Chacha_wordtobyte(word32 x[CHACHA_CHUNK_WORDS],
  *
  * see https://tools.ietf.org/html/draft-arciszewski-xchacha-03
  */
-static WC_INLINE void wc_HChacha_block(ChaCha* ctx, word32 stream[CHACHA_CHUNK_WORDS/2], int nrounds)
+static WC_INLINE void wc_HChacha_block(ChaCha* ctx, word32 stream[CHACHA_CHUNK_WORDS/2], word32 nrounds)
 {
     word32 x[CHACHA_CHUNK_WORDS];
     word32 i;

--- a/wolfcrypt/src/chacha.c
+++ b/wolfcrypt/src/chacha.c
@@ -222,7 +222,9 @@ static WC_INLINE void wc_Chacha_wordtobyte(word32 x[CHACHA_CHUNK_WORDS],
 
     for (i = 0; i < CHACHA_CHUNK_WORDS; i++) {
         x[i] = PLUS(x[i], state[i]);
+#ifdef BIG_ENDIAN_ORDER
         x[i] = LITTLE32(x[i]);
+#endif
     }
 }
 

--- a/wolfcrypt/src/chacha20_poly1305.c
+++ b/wolfcrypt/src/chacha20_poly1305.c
@@ -149,7 +149,7 @@ int wc_ChaCha20Poly1305_Init(ChaChaPoly_Aead* aead,
     /* setup aead context */
     XMEMSET(aead, 0, sizeof(ChaChaPoly_Aead));
     XMEMSET(authKey, 0, sizeof(authKey));
-    aead->isEncrypt = (byte)isEncrypt;
+    aead->isEncrypt = isEncrypt ? 1 : 0;
 
     /* Initialize the ChaCha20 context (key and iv) */
     ret = wc_Chacha_SetKey(&aead->chacha, inKey,
@@ -340,7 +340,7 @@ int wc_XChaCha20Poly1305_Init(
     if ((ret = wc_Poly1305_Pad(&aead->poly, (word32)ad_len)) < 0)
         return ret;
 
-    aead->isEncrypt = (byte)isEncrypt;
+    aead->isEncrypt = isEncrypt ? 1 : 0;
     aead->state = CHACHA20_POLY1305_STATE_AAD;
 
     return 0;

--- a/wolfcrypt/src/curve25519.c
+++ b/wolfcrypt/src/curve25519.c
@@ -200,7 +200,7 @@ int wc_curve25519_make_priv(WC_RNG* rng, int keysize, byte* key)
         return ECC_BAD_ARG_E;
 
     /* random number for private key */
-    ret = wc_RNG_GenerateBlock(rng, key, keysize);
+    ret = wc_RNG_GenerateBlock(rng, key, (word32)keysize);
     if (ret == 0) {
         /* Clamp the private key */
         ret = curve25519_priv_clamp(key);

--- a/wolfcrypt/src/curve448.c
+++ b/wolfcrypt/src/curve448.c
@@ -89,7 +89,7 @@ int wc_curve448_make_key(WC_RNG* rng, int keysize, curve448_key* key)
 
     if (ret == 0) {
         /* random number for private key */
-        ret = wc_RNG_GenerateBlock(rng, key->k, keysize);
+        ret = wc_RNG_GenerateBlock(rng, key->k, (word32)keysize);
     }
     if (ret == 0) {
         key->privSet = 1;

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -9612,7 +9612,7 @@ static int ecc_check_privkey_gen_helper(ecc_key* key)
 static int _ecc_pairwise_consistency_test(ecc_key* key, WC_RNG* rng)
 {
     int err = 0;
-    int flags = key->flags;
+    word32 flags = key->flags;
 
     /* If flags not set default to cofactor and dec/sign */
     if ((flags & (WC_ECC_FLAG_COFACTOR | WC_ECC_FLAG_DEC_SIGN)) == 0) {
@@ -9629,7 +9629,7 @@ static int _ecc_pairwise_consistency_test(ecc_key* key, WC_RNG* rng)
         word32 sigLen, digestLen;
         int dynRng = 0, res = 0;
 
-        sigLen = wc_ecc_sig_size(key);
+        sigLen = (word32)wc_ecc_sig_size(key);
         digestLen = WC_SHA256_DIGEST_SIZE;
         sig = (byte*)XMALLOC(sigLen + digestLen, NULL, DYNAMIC_TYPE_ECC);
         if (sig == NULL)

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -152,7 +152,7 @@ static void freeSafe(AuthenticatedSafe* safe, void* heap)
     }
 
     /* free content info structs */
-    for (i = safe->numCI; i > 0; i--) {
+    for (i = (int)safe->numCI; i > 0; i--) {
         ContentInfo* ci = safe->CI;
         safe->CI = ci->next;
         XFREE(ci, heap, DYNAMIC_TYPE_PKCS);
@@ -207,13 +207,13 @@ void wc_PKCS12_free(WC_PKCS12* pkcs12)
 
 /* return 0 on success */
 static int GetSafeContent(WC_PKCS12* pkcs12, const byte* input,
-                          word32* idx, int maxIdx)
+                          word32* idx, word32 maxIdx)
 {
     AuthenticatedSafe* safe;
     word32 oid;
     word32 localIdx = *idx;
     int ret;
-    int size = 0;
+    word32 size = 0;
     byte tag;
 
     safe = (AuthenticatedSafe*)XMALLOC(sizeof(AuthenticatedSafe), pkcs12->heap,
@@ -242,7 +242,7 @@ static int GetSafeContent(WC_PKCS12* pkcs12, const byte* input,
         freeSafe(safe, pkcs12->heap);
         return ASN_PARSE_E;
     }
-    if (GetLength(input, &localIdx, &size, maxIdx) <= 0) {
+    if (GetLength(input, &localIdx, (int *)&size, maxIdx) <= 0) {
         freeSafe(safe, pkcs12->heap);
         return ASN_PARSE_E;
     }
@@ -265,7 +265,7 @@ static int GetSafeContent(WC_PKCS12* pkcs12, const byte* input,
                 freeSafe(safe, pkcs12->heap);
                 return ASN_PARSE_E;
             }
-            if (GetLength(input, &localIdx, &size, maxIdx) <= 0) {
+            if (GetLength(input, &localIdx, (int *)&size, maxIdx) <= 0) {
                 freeSafe(safe, pkcs12->heap);
                 return ASN_PARSE_E;
             }
@@ -316,15 +316,15 @@ static int GetSafeContent(WC_PKCS12* pkcs12, const byte* input,
      * through the ContentInfo's and add them to our
      * AuthenticatedSafe struct */
     {
-        int CISz;
-        ret = GetSequence(input, &localIdx, &CISz, size);
+        word32 CISz;
+        ret = GetSequence(input, &localIdx, (int *)&CISz, size);
         if (ret < 0) {
             freeSafe(safe, pkcs12->heap);
             return ASN_PARSE_E;
         }
         CISz += localIdx;
-        while ((int)localIdx < CISz) {
-            int curSz = 0;
+        while (localIdx < CISz) {
+            word32 curSz = 0;
             word32 curIdx;
             ContentInfo* ci = NULL;
 
@@ -332,7 +332,7 @@ static int GetSafeContent(WC_PKCS12* pkcs12, const byte* input,
             printf("\t\tlooking for Content Info.... ");
         #endif
 
-            if ((ret = GetSequence(input, &localIdx, &curSz, size)) < 0) {
+            if ((ret = GetSequence(input, &localIdx, (int *)&curSz, size)) < 0) {
                 freeSafe(safe, pkcs12->heap);
                 return ret;
             }
@@ -359,7 +359,7 @@ static int GetSafeContent(WC_PKCS12* pkcs12, const byte* input,
                 return MEMORY_E;
             }
 
-            ci->type   = oid;
+            ci->type   = (int)oid;
             ci->dataSz = curSz - (localIdx-curIdx);
             ci->data   = (byte*)input + localIdx;
             localIdx  += ci->dataSz;
@@ -450,7 +450,7 @@ static int GetSignData(WC_PKCS12* pkcs12, const byte* mem, word32* idx,
         XFREE(mac, pkcs12->heap, DYNAMIC_TYPE_PKCS);
         return ASN_PARSE_E;
     }
-    mac->digestSz = size;
+    mac->digestSz = (word32)size;
     mac->digest = (byte*)XMALLOC(mac->digestSz, pkcs12->heap,
                                  DYNAMIC_TYPE_DIGEST);
     if (mac->digest == NULL || mac->digestSz + curIdx > totalSz) {
@@ -483,7 +483,7 @@ static int GetSignData(WC_PKCS12* pkcs12, const byte* mem, word32* idx,
     if ((ret = GetLength(mem, &curIdx, &size, totalSz)) < 0) {
         goto exit_gsd;
     }
-    mac->saltSz = size;
+    mac->saltSz = (word32)size;
     mac->salt = (byte*)XMALLOC(mac->saltSz, pkcs12->heap, DYNAMIC_TYPE_SALT);
     if (mac->salt == NULL || mac->saltSz + curIdx > totalSz) {
         ERROR_OUT(MEMORY_E, exit_gsd);
@@ -575,7 +575,7 @@ static int wc_PKCS12_create_mac(WC_PKCS12* pkcs12, byte* data, word32 dataSz,
     unicodePasswd[idx++] = 0x00;
 
     /* get hash type used and resulting size of HMAC key */
-    hashT = wc_OidGetHash(mac->oid);
+    hashT = wc_OidGetHash((int)mac->oid);
     if (hashT == WC_HASH_TYPE_NONE) {
         ForceZero(unicodePasswd, MAX_UNICODE_SZ);
         WOLFSSL_MSG("Unsupported hash used");
@@ -590,7 +590,7 @@ static int wc_PKCS12_create_mac(WC_PKCS12* pkcs12, byte* data, word32 dataSz,
     }
 
     /* idx contains size of unicodePasswd */
-    ret = wc_PKCS12_PBKDF_ex(key, unicodePasswd, idx, mac->salt, mac->saltSz,
+    ret = wc_PKCS12_PBKDF_ex(key, unicodePasswd, idx, mac->salt, (int)mac->saltSz,
                                   mac->itt, kLen, (int)hashT, id, pkcs12->heap);
     ForceZero(unicodePasswd, MAX_UNICODE_SZ);
     if (ret < 0) {
@@ -601,7 +601,7 @@ static int wc_PKCS12_create_mac(WC_PKCS12* pkcs12, byte* data, word32 dataSz,
     if ((ret = wc_HmacInit(&hmac, pkcs12->heap, INVALID_DEVID)) != 0) {
         return ret;
     }
-    ret = wc_HmacSetKey(&hmac, (int)hashT, key, kLen);
+    ret = wc_HmacSetKey(&hmac, (int)hashT, key, (word32)kLen);
     if (ret == 0)
         ret = wc_HmacUpdate(&hmac, data, dataSz);
     if (ret == 0)
@@ -708,7 +708,7 @@ int wc_d2i_PKCS12(const byte* der, word32 derSz, WC_PKCS12* pkcs12)
              return ASN_PARSE_E;
          }
 
-         pkcs12->der = (byte*)XMALLOC(size, pkcs12->heap, DYNAMIC_TYPE_PKCS);
+         pkcs12->der = (byte*)XMALLOC((size_t)size, pkcs12->heap, DYNAMIC_TYPE_PKCS);
          if (pkcs12->der == NULL)
              return MEMORY_E;
          ret = wc_BerToDer(der, derSz, pkcs12->der, (word32*)&size);
@@ -717,8 +717,8 @@ int wc_d2i_PKCS12(const byte* der, word32 derSz, WC_PKCS12* pkcs12)
          }
 
          der  = pkcs12->der;
-         pkcs12->derSz = size;
-         totalSz = size;
+         pkcs12->derSz = (word32)size;
+         totalSz = (word32)size;
          idx = 0;
 
          if (GetSequence(der, &idx, &size, totalSz) < 0) {
@@ -759,7 +759,7 @@ int wc_d2i_PKCS12(const byte* der, word32 derSz, WC_PKCS12* pkcs12)
     printf("\tSEQUENCE: AuthenticatedSafe size = %d\n", size);
 #endif
 
-    if ((ret = GetSafeContent(pkcs12, der, &idx, size + idx)) < 0) {
+    if ((ret = GetSafeContent(pkcs12, der, &idx, (word32)size + idx)) < 0) {
         WOLFSSL_MSG("GetSafeContent error");
         return ret;
     }
@@ -895,7 +895,7 @@ int wc_i2d_PKCS12(WC_PKCS12* pkcs12, byte** der, int* derSz)
             word32 tmpIdx = 0;
 
             /* algo id */
-            innerSz += SetAlgoID(mac->oid, ASNALGO, oidHashType, 0);
+            innerSz += SetAlgoID((int)mac->oid, ASNALGO, oidHashType, 0);
 
             /* Octet string holding digest */
             innerSz += ASN_TAG_SZ;
@@ -908,9 +908,9 @@ int wc_i2d_PKCS12(WC_PKCS12* pkcs12, byte** der, int* derSz)
             outerSz += mac->saltSz;
 
             /* MAC iterations */
-            ret = SetShortInt(ASNSHORT, &tmpIdx, mac->itt, MAX_SHORT_SZ);
+            ret = SetShortInt(ASNSHORT, &tmpIdx, (word32)mac->itt, MAX_SHORT_SZ);
             if (ret >= 0) {
-                outerSz += ret;
+                outerSz += (word32)ret;
                 ret = 0;
             }
             else {
@@ -935,7 +935,7 @@ int wc_i2d_PKCS12(WC_PKCS12* pkcs12, byte** der, int* derSz)
             {
                 word32 algoIdSz;
 
-                algoIdSz = SetAlgoID(mac->oid, &sdBuf[idx], oidHashType, 0);
+                algoIdSz = SetAlgoID((int)mac->oid, &sdBuf[idx], oidHashType, 0);
                 if (algoIdSz == 0) {
                     ret = ALGO_ID_E;
                 }
@@ -963,12 +963,12 @@ int wc_i2d_PKCS12(WC_PKCS12* pkcs12, byte** der, int* derSz)
                 int tmpSz;
                 word32 tmpIdx = 0;
                 byte ar[MAX_SHORT_SZ];
-                tmpSz = SetShortInt(ar, &tmpIdx, mac->itt, MAX_SHORT_SZ);
+                tmpSz = SetShortInt(ar, &tmpIdx, (word32)mac->itt, MAX_SHORT_SZ);
                 if (tmpSz < 0) {
                     ret = tmpSz;
                 }
                 else {
-                    XMEMCPY(&sdBuf[idx], ar, tmpSz);
+                    XMEMCPY(&sdBuf[idx], ar, (size_t)tmpSz);
                 }
             }
             totalSz += sdBufSz;
@@ -998,7 +998,7 @@ int wc_i2d_PKCS12(WC_PKCS12* pkcs12, byte** der, int* derSz)
 
             /* check if getting length only */
             if (der == NULL && derSz != NULL) {
-                *derSz = totalSz;
+                *derSz = (int)totalSz;
                 XFREE(sdBuf, pkcs12->heap, DYNAMIC_TYPE_PKCS);
                 return LENGTH_ONLY_E;
             }
@@ -1040,7 +1040,7 @@ int wc_i2d_PKCS12(WC_PKCS12* pkcs12, byte** der, int* derSz)
         idx += seqSz;
 
         /* OID */
-        idx += SetObjectId(sizeof(WC_PKCS12_DATA_OID), &buf[idx]);
+        idx += (word32)SetObjectId(sizeof(WC_PKCS12_DATA_OID), &buf[idx]);
         XMEMCPY(&buf[idx], WC_PKCS12_DATA_OID, sizeof(WC_PKCS12_DATA_OID));
         idx += sizeof(WC_PKCS12_DATA_OID);
 
@@ -1068,7 +1068,7 @@ int wc_i2d_PKCS12(WC_PKCS12* pkcs12, byte** der, int* derSz)
         }
 
         /* Return size of der */
-        ret = totalSz;
+        ret = (int)totalSz;
     }
 
     XFREE(sdBuf, pkcs12->heap, DYNAMIC_TYPE_PKCS);
@@ -1206,7 +1206,7 @@ static int PKCS12_CheckConstructedZero(byte* data, word32 dataSz, word32* idx)
         ret = ASN_PARSE_E;
     }
 
-    *idx += size;
+    *idx += (word32)size;
     if (ret == 0 && GetShortInt(data, idx, &number, dataSz) < 0) {
         ret = ASN_PARSE_E;
     }
@@ -1234,7 +1234,7 @@ static int PKCS12_CoalesceOctetStrings(WC_PKCS12* pkcs12, byte* data,
     int    encryptedContentSz = 0;
     int    originalEncSz = 0;
     int    ret = 0;
-    int    saveIdx;
+    word32 saveIdx;
     byte   tag;
 
     saveIdx = *idx;
@@ -1258,14 +1258,14 @@ static int PKCS12_CoalesceOctetStrings(WC_PKCS12* pkcs12, byte* data,
         }
         if (ret == 0) {
             if (mergedData == NULL) {
-                mergedData = (byte*)XMALLOC(encryptedContentSz,
+                mergedData = (byte*)XMALLOC((size_t)encryptedContentSz,
                             pkcs12->heap, DYNAMIC_TYPE_PKCS);
                 if (mergedData == NULL) {
                     ret = MEMORY_E;
                 }
             }
             mergedData = PKCS12_ConcatonateContent(pkcs12, mergedData,
-                    &mergedSz, &data[*idx], encryptedContentSz);
+                    &mergedSz, &data[*idx], (word32)encryptedContentSz);
             if (mergedData == NULL) {
                 ret = MEMORY_E;
             }
@@ -1273,7 +1273,7 @@ static int PKCS12_CoalesceOctetStrings(WC_PKCS12* pkcs12, byte* data,
         if (ret != 0) {
             break;
         }
-        *idx += encryptedContentSz;
+        *idx += (word32)encryptedContentSz;
     }
 
     *idx = saveIdx;
@@ -1335,7 +1335,7 @@ int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
     /* if there is sign data then verify the MAC */
     if (pkcs12->signData != NULL ) {
         if ((ret = wc_PKCS12_verify(pkcs12, pkcs12->safe->data,
-                               pkcs12->safe->dataSz, (byte*)psw, pswSz)) != 0) {
+                               pkcs12->safe->dataSz, (byte*)psw, (word32)pswSz)) != 0) {
             WOLFSSL_MSG("PKCS12 Bad MAC on verify");
             WOLFSSL_LEAVE("wc_PKCS12_parse verify ", ret);
             (void)ret;
@@ -1397,7 +1397,7 @@ int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
 
 
 #ifdef ASN_BER_TO_DER
-            curIdx = idx;
+            curIdx = (int)idx;
             /* If indefinite length format, ensure it is in the ASN format
              * the DecryptContent() expects */
             if (pkcs12->indefinite && PKCS12_CheckConstructedZero(data,
@@ -1409,18 +1409,18 @@ int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
                     goto exit_pk12par;
                 }
             }
-            idx = curIdx;
+            idx = (word32)curIdx;
 #endif
 
         /* decrypted content overwrites input buffer */
-            size = ci->dataSz - idx;
-            buf = (byte*)XMALLOC(size, pkcs12->heap, DYNAMIC_TYPE_PKCS);
+            size = (int)(ci->dataSz - idx);
+            buf = (byte*)XMALLOC((size_t)size, pkcs12->heap, DYNAMIC_TYPE_PKCS);
             if (buf == NULL) {
                 ERROR_OUT(MEMORY_E, exit_pk12par);
             }
-            XMEMCPY(buf, data + idx, size);
+            XMEMCPY(buf, data + idx, (size_t)size);
 
-            if ((ret = DecryptContent(buf, size, psw, pswSz)) < 0) {
+            if ((ret = DecryptContent(buf, (word32)size, psw, pswSz)) < 0) {
                 WOLFSSL_MSG("Decryption failed, algorithm not compiled in?");
                 goto exit_pk12par;
             }
@@ -1467,14 +1467,14 @@ int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
         if ((ret = GetSequence(data, &idx, &totalSz, ci->dataSz)) < 0) {
             goto exit_pk12par;
         }
-        totalSz += idx;
+        totalSz += (int)idx;
 
         while ((int)idx < totalSz) {
             int bagSz;
             if ((ret = GetSequence(data, &idx, &bagSz, ci->dataSz)) < 0) {
                 goto exit_pk12par;
             }
-            bagSz += idx;
+            bagSz += (int)idx;
 
             if ((ret = GetObjectId(data, &idx, &oid, oidIgnoreType,
                                                              ci->dataSz)) < 0) {
@@ -1496,13 +1496,13 @@ int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
                         goto exit_pk12par;
                     }
                     if (*pkey == NULL) {
-                        *pkey = (byte*)XMALLOC(size, pkcs12->heap,
+                        *pkey = (byte*)XMALLOC((size_t)size, pkcs12->heap,
                                                        DYNAMIC_TYPE_PUBLIC_KEY);
                         if (*pkey == NULL) {
                             ERROR_OUT(MEMORY_E, exit_pk12par);
                         }
-                        XMEMCPY(*pkey, data + idx, size);
-                        *pkeySz =  ToTraditional_ex(*pkey, size, &algId);
+                        XMEMCPY(*pkey, data + idx, (size_t)size);
+                        *pkeySz = (word32)ToTraditional_ex(*pkey, (word32)size, &algId);
                     }
 
                 #ifdef WOLFSSL_DEBUG_PKCS12
@@ -1514,7 +1514,7 @@ int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
                         printf("\n");
                     }
                 #endif
-                    idx += size;
+                    idx += (word32)size;
                     break;
 
                 case WC_PKCS12_ShroudedKeyBag: /* 668 */
@@ -1533,15 +1533,15 @@ int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
                             goto exit_pk12par;
                         }
 
-                        k = (byte*)XMALLOC(size, pkcs12->heap,
+                        k = (byte*)XMALLOC((size_t)size, pkcs12->heap,
                                                        DYNAMIC_TYPE_PUBLIC_KEY);
                         if (k == NULL) {
                             ERROR_OUT(MEMORY_E, exit_pk12par);
                         }
-                        XMEMCPY(k, data + idx, size);
+                        XMEMCPY(k, data + idx, (size_t)size);
 
                         /* overwrites input, be warned */
-                        if ((ret = ToTraditionalEnc(k, size, psw, pswSz,
+                        if ((ret = ToTraditionalEnc(k, (word32)size, psw, pswSz,
                                                                  &algId)) < 0) {
                             XFREE(k, pkcs12->heap, DYNAMIC_TYPE_PUBLIC_KEY);
                             goto exit_pk12par;
@@ -1549,13 +1549,13 @@ int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
 
                         if (ret < size) {
                             /* shrink key buffer */
-                            byte* tmp = (byte*)XMALLOC(ret, pkcs12->heap,
+                            byte* tmp = (byte*)XMALLOC((size_t)ret, pkcs12->heap,
                                                  DYNAMIC_TYPE_PUBLIC_KEY);
                             if (tmp == NULL) {
                                 XFREE(k, pkcs12->heap, DYNAMIC_TYPE_PUBLIC_KEY);
                                 ERROR_OUT(MEMORY_E, exit_pk12par);
                             }
-                            XMEMCPY(tmp, k, ret);
+                            XMEMCPY(tmp, k, (size_t)ret);
                             XFREE(k, pkcs12->heap, DYNAMIC_TYPE_PUBLIC_KEY);
                             k = tmp;
                         }
@@ -1563,12 +1563,12 @@ int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
 
                         if (*pkey == NULL) {
                             *pkey = k;
-                            *pkeySz = size;
+                            *pkeySz = (word32)size;
                         }
                         else { /* only expecting one key */
                             XFREE(k, pkcs12->heap, DYNAMIC_TYPE_PUBLIC_KEY);
                         }
-                        idx += size;
+                        idx += (word32)size;
 
                     #ifdef WOLFSSL_DEBUG_PKCS12
                         {
@@ -1639,7 +1639,7 @@ int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
                             WOLFSSL_MSG("Unknown PKCS12 cert bag type");
                     }
 
-                    if (size + idx > (word32)bagSz) {
+                    if (size + (int)idx > bagSz) {
                         ERROR_OUT(ASN_PARSE_E, exit_pk12par);
                     }
 
@@ -1651,14 +1651,14 @@ int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
                     }
                     XMEMSET(node, 0, sizeof(WC_DerCertList));
 
-                    node->buffer = (byte*)XMALLOC(size, pkcs12->heap,
+                    node->buffer = (byte*)XMALLOC((size_t)size, pkcs12->heap,
                                                              DYNAMIC_TYPE_PKCS);
                     if (node->buffer == NULL) {
                         XFREE(node, pkcs12->heap, DYNAMIC_TYPE_PKCS);
                         ERROR_OUT(MEMORY_E, exit_pk12par);
                     }
-                    XMEMCPY(node->buffer, data + idx, size);
-                    node->bufferSz = size;
+                    XMEMCPY(node->buffer, data + idx, (size_t)size);
+                    node->bufferSz = (word32)size;
 
                     /* put the new node into the list */
                     if (certList != NULL) {
@@ -1672,7 +1672,7 @@ int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
                     }
 
                     /* on to next */
-                    idx += size;
+                    idx += (word32)size;
                 }
                     break;
 
@@ -1694,7 +1694,7 @@ int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
 
             /* Attribute, unknown bag or unsupported */
             if ((int)idx < bagSz) {
-                idx = bagSz; /* skip for now */
+                idx = (word32)bagSz; /* skip for now */
             }
         }
 
@@ -1826,7 +1826,7 @@ static int wc_PKCS12_shroud_key(WC_PKCS12* pkcs12, WC_RNG* rng,
         return ret;
     }
 
-    totalSz += ret;
+    totalSz += (word32)ret;
 
     /* out should not be null at this point but check before writing */
     if (out == NULL) {
@@ -1835,11 +1835,11 @@ static int wc_PKCS12_shroud_key(WC_PKCS12* pkcs12, WC_RNG* rng,
 
     /* rewind index and set tag and length */
     tmpIdx -= MAX_LENGTH_SZ + 1;
-    sz = SetExplicit(0, ret, out + tmpIdx);
+    sz = (word32)SetExplicit(0, (word32)ret, out + tmpIdx);
     tmpIdx += sz; totalSz += sz;
-    XMEMMOVE(out + tmpIdx, out + MAX_LENGTH_SZ + 1, ret);
+    XMEMMOVE(out + tmpIdx, out + MAX_LENGTH_SZ + 1, (size_t)ret);
 
-    return totalSz;
+    return (int)totalSz;
 }
 
 
@@ -1919,8 +1919,8 @@ static int wc_PKCS12_create_key_bag(WC_PKCS12* pkcs12, WC_RNG* rng,
         XFREE(tmp, heap, DYNAMIC_TYPE_TMP_BUFFER);
         return ret;
     }
-    length = ret;
-    XMEMCPY(out + idx, tmp, length);
+    length = (word32)ret;
+    XMEMCPY(out + idx, tmp, (size_t)length);
     XFREE(tmp, heap, DYNAMIC_TYPE_TMP_BUFFER);
     totalSz += length;
 
@@ -1929,7 +1929,7 @@ static int wc_PKCS12_create_key_bag(WC_PKCS12* pkcs12, WC_RNG* rng,
     XMEMMOVE(out + tmpSz, out + MAX_SEQ_SZ, totalSz);
 
     (void)heap;
-    return totalSz + tmpSz;
+    return (int)(totalSz + tmpSz);
 }
 
 
@@ -1956,16 +1956,16 @@ static int wc_PKCS12_create_cert_bag(WC_PKCS12* pkcs12,
     word32 tmpSz;
 
     if (out == NULL) {
-        *outSz = MAX_SEQ_SZ + WC_CERTBAG_OBJECT_ID + 1 + MAX_LENGTH_SZ +
+        *outSz = (word32)(MAX_SEQ_SZ + WC_CERTBAG_OBJECT_ID + 1 + MAX_LENGTH_SZ +
             MAX_SEQ_SZ + WC_CERTBAG1_OBJECT_ID + 1 + MAX_LENGTH_SZ + 1 +
-            MAX_LENGTH_SZ + certSz;
+            MAX_LENGTH_SZ + (int)certSz);
         return LENGTH_ONLY_E;
     }
 
     /* check buffer size able to handle max size */
-    if (*outSz < (MAX_SEQ_SZ + WC_CERTBAG_OBJECT_ID + 1 + MAX_LENGTH_SZ +
+    if (*outSz < (word32)(MAX_SEQ_SZ + WC_CERTBAG_OBJECT_ID + 1 + MAX_LENGTH_SZ +
             MAX_SEQ_SZ + WC_CERTBAG1_OBJECT_ID + 1 + MAX_LENGTH_SZ + 1 +
-            MAX_LENGTH_SZ + certSz)) {
+            MAX_LENGTH_SZ + (int)certSz)) {
         return BUFFER_E;
     }
 
@@ -2031,7 +2031,7 @@ static int wc_PKCS12_create_cert_bag(WC_PKCS12* pkcs12,
 
     (void)pkcs12;
 
-    return totalSz + tmpSz;
+    return (int)(totalSz + tmpSz);
 }
 
 
@@ -2090,12 +2090,12 @@ static int wc_PKCS12_encrypt_content(WC_PKCS12* pkcs12, WC_RNG* rng,
         }
 
         /* calculate size */
-        totalSz  = SetObjectId(sizeof(WC_PKCS12_ENCRYPTED_OID), seq);
+        totalSz  = (word32)SetObjectId(sizeof(WC_PKCS12_ENCRYPTED_OID), seq);
         totalSz += sizeof(WC_PKCS12_ENCRYPTED_OID);
         totalSz += ASN_TAG_SZ;
 
-        length  = SetMyVersion(0, seq, 0);
-        tmpSz   = SetObjectId(sizeof(WC_PKCS12_DATA_OID), seq);
+        length  = (word32)SetMyVersion(0, seq, 0);
+        tmpSz   = (word32)SetObjectId(sizeof(WC_PKCS12_DATA_OID), seq);
         tmpSz  += sizeof(WC_PKCS12_DATA_OID);
         tmpSz  += encSz;
         length += SetSequence(tmpSz, seq) + tmpSz;
@@ -2113,7 +2113,7 @@ static int wc_PKCS12_encrypt_content(WC_PKCS12* pkcs12, WC_RNG* rng,
 
         idx = 0;
         idx += SetSequence(totalSz, out + idx);
-        idx += SetObjectId(sizeof(WC_PKCS12_ENCRYPTED_OID), out + idx);
+        idx += (word32)SetObjectId(sizeof(WC_PKCS12_ENCRYPTED_OID), out + idx);
         if (idx + sizeof(WC_PKCS12_ENCRYPTED_OID) > *outSz){
             return BUFFER_E;
         }
@@ -2128,7 +2128,7 @@ static int wc_PKCS12_encrypt_content(WC_PKCS12* pkcs12, WC_RNG* rng,
         idx += SetLength(outerSz, out + idx);
 
         idx += SetSequence(length, out + idx);
-        idx += SetMyVersion(0, out + idx, 0);
+        idx += (word32)SetMyVersion(0, out + idx, 0);
         tmp = (byte*)XMALLOC(encSz, heap, DYNAMIC_TYPE_TMP_BUFFER);
         if (tmp == NULL) {
             return MEMORY_E;
@@ -2139,7 +2139,7 @@ static int wc_PKCS12_encrypt_content(WC_PKCS12* pkcs12, WC_RNG* rng,
             XFREE(tmp, heap, DYNAMIC_TYPE_TMP_BUFFER);
             return ret;
         }
-        encSz = ret;
+        encSz = (word32)ret;
 
         #ifdef WOLFSSL_DEBUG_PKCS12
         {
@@ -2153,7 +2153,7 @@ static int wc_PKCS12_encrypt_content(WC_PKCS12* pkcs12, WC_RNG* rng,
         #endif
 
         idx += SetSequence(WC_PKCS12_DATA_OBJ_SZ + encSz, out + idx);
-        idx += SetObjectId(sizeof(WC_PKCS12_DATA_OID), out + idx);
+        idx += (word32)SetObjectId(sizeof(WC_PKCS12_DATA_OID), out + idx);
         if (idx + sizeof(WC_PKCS12_DATA_OID) > *outSz){
             WOLFSSL_MSG("Buffer not large enough for DATA OID");
             XFREE(tmp, heap, DYNAMIC_TYPE_TMP_BUFFER);
@@ -2170,7 +2170,7 @@ static int wc_PKCS12_encrypt_content(WC_PKCS12* pkcs12, WC_RNG* rng,
         XMEMCPY(out + idx, tmp, encSz);
         XFREE(tmp, heap, DYNAMIC_TYPE_TMP_BUFFER);
         idx += encSz;
-        return idx;
+        return (int)idx;
     }
 
     /* DATA
@@ -2181,7 +2181,7 @@ static int wc_PKCS12_encrypt_content(WC_PKCS12* pkcs12, WC_RNG* rng,
      * sequence containing all bags */
     if (type == WC_PKCS12_DATA) {
         /* calculate size */
-        totalSz = SetObjectId(sizeof(WC_PKCS12_DATA_OID), seq);
+        totalSz = (word32)SetObjectId(sizeof(WC_PKCS12_DATA_OID), seq);
         totalSz += sizeof(WC_PKCS12_DATA_OID);
         totalSz += ASN_TAG_SZ;
 
@@ -2202,7 +2202,7 @@ static int wc_PKCS12_encrypt_content(WC_PKCS12* pkcs12, WC_RNG* rng,
         /* place data in output buffer */
         idx  = 0;
         idx += SetSequence(totalSz, out);
-        idx += SetObjectId(sizeof(WC_PKCS12_DATA_OID), out + idx);
+        idx += (word32)SetObjectId(sizeof(WC_PKCS12_DATA_OID), out + idx);
         if (idx + sizeof(WC_PKCS12_DATA_OID) > *outSz){
             WOLFSSL_MSG("Buffer not large enough for DATA OID");
             return BUFFER_E;
@@ -2223,7 +2223,7 @@ static int wc_PKCS12_encrypt_content(WC_PKCS12* pkcs12, WC_RNG* rng,
         XMEMCPY(out + idx, content, contentSz);
         idx += contentSz;
 
-        return idx;
+        return (int)idx;
     }
 
     WOLFSSL_MSG("Unknown/Unsupported content type");
@@ -2273,7 +2273,7 @@ static byte* PKCS12_create_key_content(WC_PKCS12* pkcs12, int nidKey,
 
     /* get max size for key bag */
     ret = wc_PKCS12_create_key_bag(pkcs12, rng, NULL, &keyBufSz, key, keySz,
-            algo, iter, pass, passSz);
+            algo, iter, pass, (int)passSz);
     if (ret != LENGTH_ONLY_E && ret < 0) {
         WOLFSSL_MSG("Error getting key bag size");
         return NULL;
@@ -2288,13 +2288,13 @@ static byte* PKCS12_create_key_content(WC_PKCS12* pkcs12, int nidKey,
     }
 
     ret = wc_PKCS12_create_key_bag(pkcs12, rng, keyBuf + MAX_SEQ_SZ, &keyBufSz,
-            key, keySz, algo, iter, pass, passSz);
+            key, keySz, algo, iter, pass, (int)passSz);
     if (ret < 0) {
         XFREE(keyBuf, heap, DYNAMIC_TYPE_TMP_BUFFER);
         WOLFSSL_MSG("Error creating key bag");
         return NULL;
     }
-    keyBufSz = ret;
+    keyBufSz = (word32)ret;
 
     tmpSz = SetSequence(keyBufSz, keyBuf);
     XMEMMOVE(keyBuf + tmpSz, keyBuf + MAX_SEQ_SZ, keyBufSz);
@@ -2310,7 +2310,7 @@ static byte* PKCS12_create_key_content(WC_PKCS12* pkcs12, int nidKey,
     }
     #endif
     ret = wc_PKCS12_encrypt_content(pkcs12, rng, NULL, keyCiSz,
-            NULL, keyBufSz, algo, pass, passSz, iter, WC_PKCS12_DATA);
+            NULL, keyBufSz, algo, pass, (int)passSz, iter, WC_PKCS12_DATA);
     if (ret != LENGTH_ONLY_E) {
         XFREE(keyBuf, heap, DYNAMIC_TYPE_TMP_BUFFER);
         WOLFSSL_MSG("Error getting key encrypt content size");
@@ -2323,14 +2323,14 @@ static byte* PKCS12_create_key_content(WC_PKCS12* pkcs12, int nidKey,
     }
 
     ret = wc_PKCS12_encrypt_content(pkcs12, rng, keyCi, keyCiSz,
-            keyBuf, keyBufSz, algo, pass, passSz, iter, WC_PKCS12_DATA);
+            keyBuf, keyBufSz, algo, pass, (int)passSz, iter, WC_PKCS12_DATA);
     XFREE(keyBuf, heap, DYNAMIC_TYPE_TMP_BUFFER);
     if (ret < 0 ) {
         XFREE(keyCi, heap, DYNAMIC_TYPE_TMP_BUFFER);
         WOLFSSL_MSG("Error creating key encrypt content");
         return NULL;
     }
-    *keyCiSz = ret;
+    *keyCiSz = (word32)ret;
 
     #ifdef WOLFSSL_DEBUG_PKCS12
     {
@@ -2435,7 +2435,7 @@ static byte* PKCS12_create_cert_content(WC_PKCS12* pkcs12, int nidCert,
         XFREE(certBuf, heap, DYNAMIC_TYPE_TMP_BUFFER);
         return NULL;
     }
-    idx += ret;
+    idx += (word32)ret;
 
     if (ca != NULL) {
         WC_DerCertList* current = ca;
@@ -2447,7 +2447,7 @@ static byte* PKCS12_create_cert_content(WC_PKCS12* pkcs12, int nidCert,
                 XFREE(certBuf, heap, DYNAMIC_TYPE_TMP_BUFFER);
                 return NULL;
             }
-            idx    += ret;
+            idx += (word32)ret;
             current = current->next;
         }
     }
@@ -2459,7 +2459,7 @@ static byte* PKCS12_create_cert_content(WC_PKCS12* pkcs12, int nidCert,
 
     /* get buffer size needed for content info */
     ret = wc_PKCS12_encrypt_content(pkcs12, rng, NULL, certCiSz,
-            NULL, certBufSz, algo, pass, passSz, iter, type);
+            NULL, certBufSz, algo, pass, (int)passSz, iter, type);
     if (ret != LENGTH_ONLY_E) {
         XFREE(certBuf, heap, DYNAMIC_TYPE_TMP_BUFFER);
         WOLFSSL_LEAVE("wc_PKCS12_create()", ret);
@@ -2472,14 +2472,14 @@ static byte* PKCS12_create_cert_content(WC_PKCS12* pkcs12, int nidCert,
     }
 
     ret = wc_PKCS12_encrypt_content(pkcs12, rng, certCi, certCiSz,
-            certBuf, certBufSz, algo, pass, passSz, iter, type);
+            certBuf, certBufSz, algo, pass, (int)passSz, iter, type);
     XFREE(certBuf, heap, DYNAMIC_TYPE_TMP_BUFFER);
     if (ret < 0) {
         WOLFSSL_LEAVE("wc_PKCS12_create()", ret);
         XFREE(certCi, heap, DYNAMIC_TYPE_TMP_BUFFER);
         return NULL;
     }
-    *certCiSz = ret;
+    *certCiSz = (word32)ret;
 
     #ifdef WOLFSSL_DEBUG_PKCS12
     {
@@ -2539,7 +2539,7 @@ static int PKCS12_create_safe(WC_PKCS12* pkcs12, byte* certCi, word32 certCiSz,
     XMEMCPY(innerData + idx + certCiSz, keyCi, keyCiSz);
 
     ret = wc_PKCS12_encrypt_content(pkcs12, rng, safeData, &safeDataSz,
-            innerData, innerDataSz, 0, pass, passSz, iter, WC_PKCS12_DATA);
+            innerData, innerDataSz, 0, pass, (int)passSz, iter, WC_PKCS12_DATA);
     XFREE(innerData, pkcs12->heap, DYNAMIC_TYPE_PKCS);
     if (ret < 0 ) {
         WOLFSSL_MSG("Error setting data type for safe contents");
@@ -2713,8 +2713,8 @@ WC_PKCS12* wc_PKCS12_create(char* pass, word32 passSz, char* name,
             return NULL;
         }
 
-        mac->digestSz = ret;
-        mac->digest = (byte*)XMALLOC(ret, heap, DYNAMIC_TYPE_PKCS);
+        mac->digestSz = (word32)ret;
+        mac->digest = (byte*)XMALLOC((size_t)ret, heap, DYNAMIC_TYPE_PKCS);
         if (mac->digest == NULL) {
             WOLFSSL_MSG("Error malloc'ing mac digest buffer");
             wc_PKCS12_free(pkcs12);

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -879,7 +879,11 @@ int wc_ShaFinal(wc_Sha* sha, byte* hash)
 
     XMEMCPY(hash, (byte *)&sha->digest[0], WC_SHA_DIGEST_SIZE);
 
-    ret = InitSha(sha); /* reset state */
+    {
+        int initret = InitSha(sha); /* reset state */
+        if (initret < 0)
+            ret = initret;
+    }
 
     return ret;
 }

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -879,11 +879,7 @@ int wc_ShaFinal(wc_Sha* sha, byte* hash)
 
     XMEMCPY(hash, (byte *)&sha->digest[0], WC_SHA_DIGEST_SIZE);
 
-    {
-        int initret = InitSha(sha); /* reset state */
-        if (initret < 0)
-            ret = initret;
-    }
+    (void)InitSha(sha); /* reset state */
 
     return ret;
 }

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -1134,7 +1134,7 @@ static int InitSha256(wc_Sha256* sha256)
             /* get number of blocks */
             /* 64-1 = 0x3F (~ Inverted = 0xFFFFFFC0) */
             /* len (masked by 0xFFFFFFC0) returns block aligned length */
-            blocksLen = len & ~(WC_SHA256_BLOCK_SIZE-1);
+            blocksLen = len & ~((word32)WC_SHA256_BLOCK_SIZE-1);
             if (blocksLen > 0) {
                 /* Byte reversal and alignment handled in function if required */
                 XTRANSFORM_LEN(sha256, data, blocksLen);

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -498,7 +498,7 @@ static int InitSha512_256(wc_Sha512* sha512)
     static int (*Transform_Sha512_p)(wc_Sha512* sha512) = _Transform_Sha512;
     static int (*Transform_Sha512_Len_p)(wc_Sha512* sha512, word32 len) = NULL;
     static int transform_check = 0;
-    static int intel_flags;
+    static word32 intel_flags;
     static int Transform_Sha512_is_vectorized = 0;
 
     static WC_INLINE int Transform_Sha512(wc_Sha512 *sha512) {
@@ -866,7 +866,7 @@ static WC_INLINE int Sha512Update(wc_Sha512* sha512, const byte* data, word32 le
 #if defined(USE_INTEL_SPEEDUP) && \
     (defined(HAVE_INTEL_AVX1) || defined(HAVE_INTEL_AVX2))
     if (Transform_Sha512_Len_p != NULL) {
-        word32 blocksLen = len & ~(WC_SHA512_BLOCK_SIZE-1);
+        word32 blocksLen = len & ~((word32)WC_SHA512_BLOCK_SIZE-1);
 
         if (blocksLen > 0) {
             sha512->data = data;

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -8157,8 +8157,8 @@ int sp_div(const sp_int* a, const sp_int* d, sp_int* r, sp_int* rem)
     sp_int* tr = NULL;
     sp_int* trial = NULL;
 #ifdef WOLFSSL_SP_INT_NEGATIVE
-    word32 signA = MP_ZPOS;
-    word32 signD = MP_ZPOS;
+    unsigned int signA = MP_ZPOS;
+    unsigned int signD = MP_ZPOS;
 #endif /* WOLFSSL_SP_INT_NEGATIVE */
     /* Intermediates will always be less than or equal to dividend. */
     DECL_SP_INT_ARRAY(td, (a == NULL) ? 1 : a->used + 1, 4);
@@ -11320,7 +11320,7 @@ int sp_mul(const sp_int* a, const sp_int* b, sp_int* r)
 {
     int err = MP_OKAY;
 #ifdef WOLFSSL_SP_INT_NEGATIVE
-    word32 sign = MP_ZPOS;
+    unsigned int sign = MP_ZPOS;
 #endif
 
     if ((a == NULL) || (b == NULL) || (r == NULL)) {
@@ -17321,7 +17321,7 @@ int sp_read_radix(sp_int* a, const char* in, int radix)
 {
     int err = MP_OKAY;
 #ifdef WOLFSSL_SP_INT_NEGATIVE
-    word32 sign = MP_ZPOS;
+    unsigned int sign = MP_ZPOS;
 #endif
 
     if ((a == NULL) || (in == NULL)) {
@@ -18538,7 +18538,7 @@ int sp_lcm(const sp_int* a, const sp_int* b, sp_int* r)
 {
     int err = MP_OKAY;
     /* Determine maximum digit length numbers will reach. */
-    word32 used = ((a == NULL) || (b == NULL)) ? 1 :
+    unsigned int used = ((a == NULL) || (b == NULL)) ? 1 :
         (a->used >= b->used ? a->used + 1: b->used + 1);
     DECL_SP_INT_ARRAY(t, used, 2);
 

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -5031,7 +5031,7 @@ int sp_cond_swap_ct(sp_int* a, sp_int* b, int cnt, int swap)
     unsigned int i;
     int err = MP_OKAY;
     sp_int_digit mask = (sp_int_digit)0 - (sp_int_digit)swap;
-    DECL_SP_INT(t, cnt);
+    DECL_SP_INT(t, (size_t)cnt);
 
     /* Allocate temporary to hold masked xor of a and b. */
     ALLOC_SP_INT(t, cnt, err, NULL);
@@ -6251,7 +6251,7 @@ static void _sp_div_3(const sp_int* a, sp_int* r, sp_int_digit* rem)
         /* Sum digits of sum. */
         t = (t >> SP_WORD_SIZE) + (t & SP_MASK);
         /* Get top digit after multipling by (2^SP_WORD_SIZE) / 3. */
-        tt = (t * SP_DIV_3_CONST) >> SP_WORD_SIZE;
+        tt = (sp_int_digit)((t * SP_DIV_3_CONST) >> SP_WORD_SIZE);
         /* Subtract trial division. */
         tr = (sp_int_digit)(t - (sp_int_word)tt * 3);
     #else
@@ -6283,7 +6283,7 @@ static void _sp_div_3(const sp_int* a, sp_int* r, sp_int_digit* rem)
             /* Combine remainder from last operation with this word. */
             t = ((sp_int_word)tr << SP_WORD_SIZE) | a->dp[i];
             /* Get top digit after multipling by (2^SP_WORD_SIZE) / 3. */
-            tt = (t * SP_DIV_3_CONST) >> SP_WORD_SIZE;
+            tt = (sp_int_digit)((t * SP_DIV_3_CONST) >> SP_WORD_SIZE);
             /* Subtract trial division. */
             tr = (sp_int_digit)(t - (sp_int_word)tt * 3);
     #else
@@ -6344,7 +6344,7 @@ static void _sp_div_10(const sp_int* a, sp_int* r, sp_int_digit* rem)
             /* Combine remainder from last operation with this word. */
             t = ((sp_int_word)tr << SP_WORD_SIZE) | a->dp[i];
             /* Get top digit after multipling by (2^SP_WORD_SIZE) / 10. */
-            tt = (t * SP_DIV_10_CONST) >> SP_WORD_SIZE;
+            tt = (sp_int_digit)((t * SP_DIV_10_CONST) >> SP_WORD_SIZE);
             /* Subtract trial division. */
             tr = (sp_int_digit)(t - (sp_int_word)tt * 10);
     #else
@@ -6370,7 +6370,7 @@ static void _sp_div_10(const sp_int* a, sp_int* r, sp_int_digit* rem)
             /* Combine remainder from last operation with this word. */
             t = ((sp_int_word)tr << SP_WORD_SIZE) | a->dp[i];
             /* Get top digit after multipling by (2^SP_WORD_SIZE) / 10. */
-            tt = (t * SP_DIV_10_CONST) >> SP_WORD_SIZE;
+            tt = (sp_int_digit)((t * SP_DIV_10_CONST) >> SP_WORD_SIZE);
             /* Subtract trial division. */
             tr = (sp_int_digit)(t - (sp_int_word)tt * 10);
     #else
@@ -6434,7 +6434,7 @@ static void _sp_div_small(const sp_int* a, sp_int_digit d, sp_int* r,
             /* Combine remainder from last operation with this word. */
             t = ((sp_int_word)tr << SP_WORD_SIZE) | a->dp[i];
             /* Get top digit after multipling. */
-            tt = (t * m) >> SP_WORD_SIZE;
+            tt = (sp_int_digit)((t * m) >> SP_WORD_SIZE);
             /* Subtract trial division. */
             tr = (sp_int_digit)t - (sp_int_digit)(tt * d);
         #else
@@ -6461,7 +6461,7 @@ static void _sp_div_small(const sp_int* a, sp_int_digit d, sp_int* r,
             /* Combine remainder from last operation with this word. */
             t = ((sp_int_word)tr << SP_WORD_SIZE) | a->dp[i];
             /* Get top digit after multipling. */
-            tt = (t * m) >> SP_WORD_SIZE;
+            tt = (sp_int_digit)((t * m) >> SP_WORD_SIZE);
             /* Subtract trial division. */
             tr = (sp_int_digit)t - (sp_int_digit)(tt * d);
         #else
@@ -8157,8 +8157,8 @@ int sp_div(const sp_int* a, const sp_int* d, sp_int* r, sp_int* rem)
     sp_int* tr = NULL;
     sp_int* trial = NULL;
 #ifdef WOLFSSL_SP_INT_NEGATIVE
-    int signA = MP_ZPOS;
-    int signD = MP_ZPOS;
+    word32 signA = MP_ZPOS;
+    word32 signD = MP_ZPOS;
 #endif /* WOLFSSL_SP_INT_NEGATIVE */
     /* Intermediates will always be less than or equal to dividend. */
     DECL_SP_INT_ARRAY(td, (a == NULL) ? 1 : a->used + 1, 4);
@@ -11320,7 +11320,7 @@ int sp_mul(const sp_int* a, const sp_int* b, sp_int* r)
 {
     int err = MP_OKAY;
 #ifdef WOLFSSL_SP_INT_NEGATIVE
-    int sign = MP_ZPOS;
+    word32 sign = MP_ZPOS;
 #endif
 
     if ((a == NULL) || (b == NULL) || (r == NULL)) {
@@ -17321,7 +17321,7 @@ int sp_read_radix(sp_int* a, const char* in, int radix)
 {
     int err = MP_OKAY;
 #ifdef WOLFSSL_SP_INT_NEGATIVE
-    int sign = MP_ZPOS;
+    word32 sign = MP_ZPOS;
 #endif
 
     if ((a == NULL) || (in == NULL)) {
@@ -18538,7 +18538,7 @@ int sp_lcm(const sp_int* a, const sp_int* b, sp_int* r)
 {
     int err = MP_OKAY;
     /* Determine maximum digit length numbers will reach. */
-    int used = ((a == NULL) || (b == NULL)) ? 1 :
+    word32 used = ((a == NULL) || (b == NULL)) ? 1 :
         (a->used >= b->used ? a->used + 1: b->used + 1);
     DECL_SP_INT_ARRAY(t, used, 2);
 

--- a/wolfssl/wolfcrypt/chacha.h
+++ b/wolfssl/wolfcrypt/chacha.h
@@ -61,7 +61,7 @@ Block counter is located at index 12.
 
 /* Size of ChaCha chunks */
 #define CHACHA_CHUNK_WORDS 16
-#define CHACHA_CHUNK_BYTES (CHACHA_CHUNK_WORDS * sizeof(word32))
+#define CHACHA_CHUNK_BYTES (CHACHA_CHUNK_WORDS * (word32)sizeof(word32))
 
 #ifdef WOLFSSL_X86_64_BUILD
 #if defined(USE_INTEL_SPEEDUP) && !defined(NO_CHACHA_ASM)


### PR DESCRIPTION
more `-Wconversion` fixes, now covering everything inside the 140-3 boundary with default build options, everything in wolfcrypt with default build options, all modes of AES, builds with/without intelasm, all permutations of c89/c99 32/64 bit, and much of the crypto-all-cryptonly boundary;

a gating fix for `asn.c`:`SetShortInt()` (needed for PKCS8, not just for PKCS12);

fix for retval overwrite (warned by `clang-analyzer-deadcode.DeadStores`) in `sha.c`:`wc_ShaFinal()`;

fix for benign `clang-analyzer-deadcode.DeadStores` in `aes.c`:`wc_AesFeedbackEncrypt()`;

fix for `cppcheck`:`selfAssignment` in `chacha.c`:`wc_Chacha_wordtobyte()`.

tested with `wolfssl-multi-test.sh ... '.*Wconversion.*' super-quick-check sp-asn-template-asm-sanitizer`
