### PR TITLE
SP int: missing brace

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -13068,7 +13068,7 @@ int sp_exptmod_ex(const sp_int* b, const sp_int* e, int digits, const sp_int* m,
 #if defined(WOLFSSL_SP_MATH_ALL) || !defined(NO_DH) || defined(OPENSSL_ALL)
 #if (defined(WOLFSSL_RSA_VERIFY_ONLY) || defined(WOLFSSL_RSA_PUBLIC_ONLY)) && \
     defined(NO_DH)
-    if ((!done) && (err == MP_OKAY))
+    if ((!done) && (err == MP_OKAY)) {
         /* Use non-constant time version - fastest. */
         err = sp_exptmod_nct(b, e, m, r);
     }


### PR DESCRIPTION
# Description

Missing a brace in sp_exptmod_ex().

Fixes #6317

# Testing

./configure '--disable-shared' '--disable-dh' '--enable-rsapub' '--enable-sp=smallrsa2048' '--disable-rsapss' '--enable-cryptonly' '--disable-crypttests'

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
