### PR TITLE
Fix for CMake with USER_SETTINGS on Windows 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1660,6 +1660,10 @@ add_option("WOLFSSL_USER_SETTINGS"
     "Use your own user_settings.h and do not add Makefile CFLAGS (default: disabled)"
     "no" "yes;no")
 
+add_option("WOLFSSL_USER_SETTINGS_ASM"
+    "Enable use of user_settings_asm.h in assembly files (default: disabled)"
+    "no" "yes;no")
+
 add_option("WOLFSSL_OPTFLAGS"
     "Enable default optimization CFLAGS for the compiler (default: enabled)"
     "yes" "yes;no")
@@ -1822,14 +1826,23 @@ generate_build_flags()
 if(WOLFSSL_USER_SETTINGS)
     # Replace all options and just use WOLFSSL_USER_SETTINGS
     set(WOLFSSL_DEFINITIONS "-DWOLFSSL_USER_SETTINGS")
-    list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_USER_SETTINGS_ASM")
+endif()
 
-    # Create user_settings_asm.h for use in assembly files (e.g. .S files).
-    execute_process(COMMAND $ENV{SHELL} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/user_settings_asm.sh
-                            "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS}"
-                    RESULT_VARIABLE USER_SETTINGS_ASM_RET)
-    if (NOT USER_SETTINGS_ASM_RET EQUAL 0)
-        message(FATAL_ERROR "${CMAKE_CURRENT_SOURCE_DIR}/scripts/user_settings_asm.sh failed.")
+if(WOLFSSL_USER_SETTINGS_ASM)
+    if(WOLFSSL_USER_SETTINGS)
+        list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_USER_SETTINGS_ASM")
+        # Create user_settings_asm.h for use in assembly files (e.g. .S files).
+        execute_process(COMMAND
+        $ENV{SHELL} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/user_settings_asm.sh
+        "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS}"
+        RESULT_VARIABLE USER_SETTINGS_ASM_RET)
+        if (NOT USER_SETTINGS_ASM_RET EQUAL 0)
+            message(FATAL_ERROR
+            "${CMAKE_CURRENT_SOURCE_DIR}/scripts/user_settings_asm.sh failed.")
+        endif()
+    else()
+        message(FATAL_ERROR
+        "Must have WOLFSSL_USER_SETTINGS to enable WOLFSSL_USER_SETTINGS_ASM.")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1832,10 +1832,17 @@ if(WOLFSSL_USER_SETTINGS_ASM)
     if(WOLFSSL_USER_SETTINGS)
         list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_USER_SETTINGS_ASM")
         # Create user_settings_asm.h for use in assembly files (e.g. .S files).
-        execute_process(COMMAND
-        $ENV{SHELL} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/user_settings_asm.sh
-        "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS}"
-        RESULT_VARIABLE USER_SETTINGS_ASM_RET)
+        if(WIN32)
+            execute_process(COMMAND
+            $ENV{SHELL} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/user_settings_asm.sh
+            "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS}"
+            RESULT_VARIABLE USER_SETTINGS_ASM_RET)
+        else()
+            execute_process(COMMAND
+            ${CMAKE_CURRENT_SOURCE_DIR}/scripts/user_settings_asm.sh
+            "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS}"
+            RESULT_VARIABLE USER_SETTINGS_ASM_RET)
+        endif()
         if (NOT USER_SETTINGS_ASM_RET EQUAL 0)
             message(FATAL_ERROR
             "${CMAKE_CURRENT_SOURCE_DIR}/scripts/user_settings_asm.sh failed.")


### PR DESCRIPTION
# Description

First commit removes the requirement to run the `user_settings_asm.sh` shellscript when building with `CMake` + `WOLFSSL_USER_SETTINGS` unless specified by the CMake command.

Second commit lets the hashbang of the `user_settings_asm.sh` decide what shell to run on instead of using the default shell, letting the script run on the shell it was designed for.
 
Fixes zd#

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
