### PR TITLE
Memory Usage fixes

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -5221,23 +5221,13 @@ int Ed25519CheckPubKey(WOLFSSL* ssl)
 
     /* Public key required for signing. */
     if (key != NULL && !key->pubKeySet) {
-        DerBuffer* leaf = ssl->buffers.certificate;
-        DecodedCert* cert = (DecodedCert*)XMALLOC(sizeof(*cert),
-                                     ssl->heap, DYNAMIC_TYPE_DCERT);
-        if (cert == NULL)
-            ret = MEMORY_E;
+        const unsigned char* pubKey;
+        word32 pubKeySz;
 
+        ret = wc_CertGetPubKey(ssl->buffers.certificate->buffer,
+            ssl->buffers.certificate->length, &pubKey, &pubKeySz);
         if (ret == 0) {
-            InitDecodedCert(cert, leaf->buffer, leaf->length, ssl->heap);
-            ret = DecodeToKey(cert, 0);
-        }
-        if (ret == 0) {
-            ret = wc_ed25519_import_public(cert->publicKey, cert->pubKeySize,
-                                                                           key);
-        }
-        if (cert != NULL) {
-            FreeDecodedCert(cert);
-            XFREE(cert, ssl->heap, DYNAMIC_TYPE_DCERT);
+            ret = wc_ed25519_import_public(pubKey, pubKeySz, key);
         }
     }
 
@@ -5555,23 +5545,13 @@ int Ed448CheckPubKey(WOLFSSL* ssl)
 
     /* Public key required for signing. */
     if (key != NULL && !key->pubKeySet) {
-        DerBuffer* leaf = ssl->buffers.certificate;
-        DecodedCert* cert = (DecodedCert*)XMALLOC(sizeof(*cert), ssl->heap,
-            DYNAMIC_TYPE_DCERT);
-        if (cert == NULL)
-            ret = MEMORY_E;
+        const unsigned char* pubKey;
+        word32 pubKeySz;
 
+        ret = wc_CertGetPubKey(ssl->buffers.certificate->buffer,
+            ssl->buffers.certificate->length, &pubKey, &pubKeySz);
         if (ret == 0) {
-            InitDecodedCert(cert, leaf->buffer, leaf->length, ssl->heap);
-            ret = DecodeToKey(cert, 0);
-        }
-        if (ret == 0) {
-            ret = wc_ed448_import_public(cert->publicKey, cert->pubKeySize,
-                key);
-        }
-        if (cert != NULL) {
-            FreeDecodedCert(cert);
-            XFREE(cert, ssl->heap, DYNAMIC_TYPE_DCERT);
+            ret = wc_ed448_import_public(pubKey, pubKeySz, key);
         }
     }
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1337,6 +1337,10 @@ enum {
         /* Integer/heap maths - support 4096-bit. */
         #define ENCRYPT_BASE_BITS  4096
     #endif
+#elif defined(HAVE_CURVE448)
+    #define ENCRYPT_BASE_BITS    (456 * 2)
+#elif defined(HAVE_CURVE25519)
+    #define ENCRYPT_BASE_BITS    (256 * 2)
 #else
     /* No secret from public key operation but PSK key plus length used. */
     #define ENCRYPT_BASE_BITS  ((MAX_PSK_ID_LEN + 2) * 8)

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -2045,6 +2045,11 @@ WOLFSSL_API int wc_CheckCertSigPubKey(const byte* cert, word32 certSz,
                                       void* heap, const byte* pubKey,
                                       word32 pubKeySz, int pubKeyOID);
 #endif
+#if (defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_IMPORT) || \
+    (defined(HAVE_ED448) && defined(HAVE_ED448_KEY_IMPORT)))
+WOLFSSL_LOCAL int wc_CertGetPubKey(const byte* cert, word32 certSz,
+    const unsigned char** pubKey, word32* pubKeySz);
+#endif
 
 #ifdef WOLFSSL_CERT_REQ
 WOLFSSL_LOCAL int CheckCSRSignaturePubKey(const byte* cert, word32 certSz,


### PR DESCRIPTION
# Description

Ed25519CheckPubKey/Ed448CheckPubKey: get the public key from certificate in a new function, wc_CertGetPubKey, that uses less memory. Set the ENCRYPT_BASE_BITS to minimal values when Curve448/Curve25519 are the largest public key algorithms.

# Testing

Memory usage testing.
Regression tested disabled algorithms.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
