### PR TITLE
Add support for enabling and disabling CRLs.

### DIFF
--- a/scripts/crl-revoked.test
+++ b/scripts/crl-revoked.test
@@ -22,6 +22,7 @@ cp -rp . $RUNNING_DIR/.
 cd $RUNNING_DIR
 
 revocation_code="-361"
+revocation_code_openssl="23"
 exit_code=1
 counter=0
 # need a unique resume port since may run the same time as testsuite
@@ -112,7 +113,7 @@ run_test() {
     server_result=$?
 
     case  "$capture_out" in
-    *$revocation_code*)
+    *"$revocation_code"*|*"$revocation_code_openssl"*)
         # only exit with zero on detection of the expected error code
         echo ""
         echo "Successful Revocation!!!!"
@@ -178,7 +179,7 @@ run_hashdir_test() {
   server_result=$?
 
   case  "$capture_out" in
-    *$revocation_code*)
+    *"$revocation_code"*|*"$revocation_code_openssl"*)
         # only exit with zero on detection of the expected error code
         echo ""
         echo "Successful Revocation!!!! with hash dir"

--- a/src/internal.c
+++ b/src/internal.c
@@ -6238,8 +6238,18 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
     /* Don't change version on a SSL object that has already started a
      * handshake */
 #if defined(WOLFSSL_HAPROXY)
-    ssl->initial_ctx     = ctx; /* Save access to session key materials */
-    wolfSSL_CTX_up_ref(ctx);
+    ret = wolfSSL_CTX_up_ref(ctx);
+    if (ret == WOLFSSL_SUCCESS) {
+        ssl->initial_ctx = ctx; /* Save access to session key materials */
+    }
+    else {
+    #ifdef WOLFSSL_REFCNT_ERROR_RETURN
+        return ret;
+    #else
+        (void)ret;
+    #endif
+    }
+
 #endif
     if (!ssl->msgsReceived.got_client_hello &&
             !ssl->msgsReceived.got_server_hello)

--- a/src/internal.c
+++ b/src/internal.c
@@ -185,8 +185,13 @@ WOLFSSL_CALLBACKS needs LARGE_STATIC_BUFFERS, please add LARGE_STATIC_BUFFERS
 
 #endif /* !WOLFSSL_NO_TLS12 */
 
-#ifndef NO_WOLFSSL_SERVER
-    #if defined(HAVE_SESSION_TICKET) && !defined(WOLFSSL_NO_DEF_TICKET_ENC_CB)
+#if !defined(NO_WOLFSSL_SERVER) && defined(HAVE_SESSION_TICKET)
+    #if defined(WOLFSSL_HAPROXY)
+        #define SSL_TICKET_CTX(ssl) ssl->initial_ctx->ticketEncCtx
+    #else
+        #define SSL_TICKET_CTX(ssl) ssl->ctx->ticketEncCtx
+    #endif
+    #if !defined(WOLFSSL_NO_DEF_TICKET_ENC_CB)
         static int TicketEncCbCtx_Init(WOLFSSL_CTX* ctx,
                                        TicketEncCbCtx* keyCtx);
         static void TicketEncCbCtx_Free(TicketEncCbCtx* keyCtx);
@@ -6213,6 +6218,9 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
     if (!newSSL) {
         WOLFSSL_MSG("freeing old ctx to decrement reference count. Switching ctx.");
         wolfSSL_CTX_free(ssl->ctx);
+#if defined(WOLFSSL_HAPROXY)
+        wolfSSL_CTX_free(ssl->initial_ctx);
+#endif
     }
 
     /* increment CTX reference count */
@@ -6229,6 +6237,10 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
     ssl->ctx     = ctx; /* only for passing to calls, options could change */
     /* Don't change version on a SSL object that has already started a
      * handshake */
+#if defined(WOLFSSL_HAPROXY)
+    ssl->initial_ctx     = ctx; /* Save access to session key materials */
+    wolfSSL_CTX_up_ref(ctx);
+#endif
     if (!ssl->msgsReceived.got_client_hello &&
             !ssl->msgsReceived.got_server_hello)
         ssl->version = ctx->method->version;
@@ -23135,6 +23147,8 @@ const char* wolfSSL_ERR_reason_error_string(unsigned long e)
 #ifdef OPENSSL_EXTRA
     case 0 :
         return "ok";
+    case -WOLFSSL_X509_V_ERR_CERT_REVOKED :
+        return "certificate revoked";
 #endif
 
     case UNSUPPORTED_SUITE :
@@ -34650,7 +34664,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             if (error == 0) {
                 ret = ssl->ctx->ticketEncCb(ssl, et->key_name, et->iv, et->mac,
                         1, et->enc_ticket, sizeof(InternalTicket), &encLen,
-                        ssl->ctx->ticketEncCtx);
+                        SSL_TICKET_CTX(ssl));
             }
             else {
                 ret = WOLFSSL_TICKET_RET_FATAL;
@@ -34775,7 +34789,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             ret = ssl->ctx->ticketEncCb((WOLFSSL*)ssl, et->key_name, et->iv,
                                     et->enc_ticket + inLen, 0,
                                     et->enc_ticket, inLen, &outLen,
-                                    ssl->ctx->ticketEncCtx);
+                                    SSL_TICKET_CTX(ssl));
         }
         if (ret != WOLFSSL_TICKET_RET_OK) {
         #ifdef WOLFSSL_ASYNC_CRYPT

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -8212,15 +8212,18 @@ int wolfSSL_CertManagerEnableCRL(WOLFSSL_CERT_MANAGER* cm, int options)
     WOLFSSL_ENTER("wolfSSL_CertManagerEnableCRL");
     if (cm == NULL)
         return BAD_FUNC_ARG;
-    if (options == 0) {
 #if defined(OPENSSL_COMPATIBLE_DEFAULTS)
+    if (options == 0) {
+
         /* Turn off doing Leaf CRL check */
         cm->crlEnabled = 0;
         /* Turn off all checks */
         cm->crlCheckAll = 0;
-#endif
         return ret;
     }
+#else
+    (void)options;
+#endif
 
     #ifdef HAVE_CRL
         if (cm->crl == NULL) {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4511,8 +4511,9 @@ int wolfSSL_get_error(WOLFSSL* ssl, int ret)
         return WOLFSSL_ERROR_ZERO_RETURN;       /* convert to OpenSSL type */
 #if defined(WOLFSSL_HAPROXY)
     return GetX509Error(ssl->error);
-#endif
+#else
     return (ssl->error);
+#endif
 }
 
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -8208,19 +8208,19 @@ int wolfSSL_CertManagerEnableCRL(WOLFSSL_CERT_MANAGER* cm, int options)
 {
     int ret = WOLFSSL_SUCCESS;
 
-    (void)options;
-
     WOLFSSL_ENTER("wolfSSL_CertManagerEnableCRL");
     if (cm == NULL)
         return BAD_FUNC_ARG;
-#if defined(OPENSSL_COMPATIBLE_DEFAULTS)
     if (options == 0) {
+#if defined(OPENSSL_COMPATIBLE_DEFAULTS)
         /* Turn off doing Leaf CRL check */
         cm->crlEnabled = 0;
         /* Turn off all checks */
         cm->crlCheckAll = 0;
-    }
 #endif
+        return ret;
+    }
+
     #ifdef HAVE_CRL
         if (cm->crl == NULL) {
             cm->crl = (WOLFSSL_CRL*)XMALLOC(sizeof(WOLFSSL_CRL), cm->heap,

--- a/src/x509.c
+++ b/src/x509.c
@@ -7028,7 +7028,8 @@ int wolfSSL_X509_LOOKUP_load_file(WOLFSSL_X509_LOOKUP* lookup,
             WOLFSSL_CERT_MANAGER* cm = lookup->store->cm;
 
             if (cm->crl == NULL) {
-                if (wolfSSL_CertManagerEnableCRL(cm, 0) != WOLFSSL_SUCCESS) {
+                if (wolfSSL_CertManagerEnableCRL(cm, WOLFSSL_CRL_CHECK)
+                    != WOLFSSL_SUCCESS) {
                     WOLFSSL_MSG("Enable CRL failed");
                     goto end;
                 }
@@ -12440,7 +12441,7 @@ WOLF_STACK_OF(WOLFSSL_X509_NAME) *wolfSSL_dup_CA_list(
 
     for (i = 0; i < num; i++) {
         name = wolfSSL_X509_NAME_dup(wolfSSL_sk_X509_NAME_value(sk, i));
-        if (name == NULL || 0 != wolfSSL_sk_X509_NAME_push(copy, name)) {
+        if (name == NULL || WOLFSSL_SUCCESS != wolfSSL_sk_X509_NAME_push(copy, name)) {
             WOLFSSL_MSG("Memory error");
             wolfSSL_sk_X509_NAME_pop_free(copy, wolfSSL_X509_NAME_free);
             return NULL;

--- a/src/x509_str.c
+++ b/src/x509_str.c
@@ -982,10 +982,11 @@ int wolfSSL_X509_STORE_set_flags(WOLFSSL_X509_STORE* store, unsigned long flag)
     if ((flag & WOLFSSL_CRL_CHECKALL) || (flag & WOLFSSL_CRL_CHECK)) {
         ret = wolfSSL_CertManagerEnableCRL(store->cm, (int)flag);
     }
+#if defined(OPENSSL_COMPATIBLE_DEFAULTS)
     else if (flag == 0) {
         ret = wolfSSL_CertManagerDisableCRL(store->cm);
     }
-
+#endif
     return ret;
 }
 

--- a/src/x509_str.c
+++ b/src/x509_str.c
@@ -979,7 +979,10 @@ int wolfSSL_X509_STORE_set_flags(WOLFSSL_X509_STORE* store, unsigned long flag)
     if (store == NULL)
         return WOLFSSL_FAILURE;
 
-    ret = wolfSSL_CertManagerEnableCRL(store->cm, (int)flag);
+    if ((flag & WOLFSSL_CRL_CHECKALL) || (flag & WOLFSSL_CRL_CHECK) ||
+         flag == 0 ) {
+        ret = wolfSSL_CertManagerEnableCRL(store->cm, (int)flag);
+    }
 
     return ret;
 }

--- a/src/x509_str.c
+++ b/src/x509_str.c
@@ -979,9 +979,11 @@ int wolfSSL_X509_STORE_set_flags(WOLFSSL_X509_STORE* store, unsigned long flag)
     if (store == NULL)
         return WOLFSSL_FAILURE;
 
-    if ((flag & WOLFSSL_CRL_CHECKALL) || (flag & WOLFSSL_CRL_CHECK) ||
-         flag == 0 ) {
+    if ((flag & WOLFSSL_CRL_CHECKALL) || (flag & WOLFSSL_CRL_CHECK)) {
         ret = wolfSSL_CertManagerEnableCRL(store->cm, (int)flag);
+    }
+    else if (flag == 0) {
+        ret = wolfSSL_CertManagerDisableCRL(store->cm);
     }
 
     return ret;

--- a/tests/api.c
+++ b/tests/api.c
@@ -50277,7 +50277,43 @@ static int test_wolfSSL_X509_STORE_get1_certs(void)
 #endif /* OPENSSL_EXTRA && WOLFSSL_SIGNER_DER_CERT && !NO_FILESYSTEM */
     return EXPECT_RESULT();
 }
+static int test_wolfSSL_dup_CA_list(void)
+{
+    int res = TEST_SKIPPED;
+#if defined(OPENSSL_ALL)
+    EXPECT_DECLS;
+    STACK_OF(X509_NAME) *originalStack = NULL;
+    STACK_OF(X509_NAME) *copyStack = NULL;
+    int originalCount = 0;
+    int copyCount = 0;
+    X509_NAME *name = NULL;
+    int i;
 
+    originalStack = sk_X509_NAME_new_null();
+    ExpectNotNull(originalStack);
+
+    for (i = 0; i < 3; i++) {
+        name = X509_NAME_new();
+        ExpectNotNull(name);
+        AssertIntEQ(sk_X509_NAME_push(originalStack, name), WOLFSSL_SUCCESS);
+    }
+
+    copyStack = SSL_dup_CA_list(originalStack);
+    ExpectNotNull(copyStack);
+    originalCount = sk_X509_NAME_num(originalStack);
+    copyCount = sk_X509_NAME_num(copyStack);
+
+    AssertIntEQ(originalCount, copyCount);
+    sk_X509_NAME_pop_free(originalStack, X509_NAME_free);
+    sk_X509_NAME_pop_free(copyStack, X509_NAME_free);
+
+    originalStack = NULL;
+    copyStack = NULL;
+
+    res = EXPECT_RESULT();
+#endif /* OPENSSL_ALL */
+    return res;
+}
 /* include misc.c here regardless of NO_INLINE, because misc.c implementations
  * have default (hidden) visibility, and in the absence of visibility, it's
  * benign to mask out the library implementation.
@@ -60385,7 +60421,7 @@ TEST_CASE testCases[] = {
 
     TEST_DECL(test_GENERAL_NAME_set0_othername),
     TEST_DECL(test_othername_and_SID_ext),
-
+    TEST_DECL(test_wolfSSL_dup_CA_list),
     /* OpenSSL sk_X509 API test */
     TEST_DECL(test_sk_X509),
     /* OpenSSL sk_X509_CRL API test */

--- a/tests/api.c
+++ b/tests/api.c
@@ -7820,7 +7820,9 @@ static hashTable server_sessionCache;
 static int twcase_new_sessionCb(WOLFSSL *ssl, WOLFSSL_SESSION *sess)
 {
     int i;
+    unsigned int len;
     (void)ssl;
+
     /*
      * This example uses a hash table.
      * Steps you should take for a non-demo code:
@@ -7842,11 +7844,7 @@ static int twcase_new_sessionCb(WOLFSSL *ssl, WOLFSSL_SESSION *sess)
     }
     for (i = 0; i < SESSION_CACHE_SIZE; i++) {
         if (server_sessionCache.entries[i].value == NULL) {
-            if (sess->haveAltSessionID == 1)
-                server_sessionCache.entries[i].key = sess->altSessionID;
-            else
-                server_sessionCache.entries[i].key = sess->sessionID;
-
+            server_sessionCache.entries[i].key = SSL_SESSION_get_id(sess, &len);
             server_sessionCache.entries[i].value = sess;
             server_sessionCache.length++;
             break;
@@ -33083,7 +33081,8 @@ static int test_wolfSSL_X509_STORE(void)
                     SSL_FILETYPE_PEM)));
     ExpectIntEQ(X509_STORE_CTX_init(storeCtx, store, cert, NULL), SSL_SUCCESS);
     ExpectIntNE(X509_verify_cert(storeCtx), SSL_SUCCESS);
-    ExpectIntEQ(X509_STORE_CTX_get_error(storeCtx), CRL_CERT_REVOKED);
+    ExpectIntEQ(X509_STORE_CTX_get_error(storeCtx),
+                WOLFSSL_X509_V_ERR_CERT_REVOKED);
     X509_CRL_free(crl);
     crl = NULL;
     X509_STORE_free(store);

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -5156,6 +5156,9 @@ typedef struct CIDInfo CIDInfo;
 /* wolfSSL ssl type */
 struct WOLFSSL {
     WOLFSSL_CTX*    ctx;
+#if defined(WOLFSSL_HAPROXY)
+    WOLFSSL_CTX*    initial_ctx; /* preserve session key materials */
+#endif
     Suites*         suites; /* Only need during handshake. Can be NULL when
                              * re-using the context's object. When WOLFSSL
                              * object needs separate instance of suites use

--- a/wolfssl/openssl/x509.h
+++ b/wolfssl/openssl/x509.h
@@ -74,47 +74,41 @@
  * satisfy OpenSSL compatibility consumers to prevent compilation errors.
  * The list was taken from
  * https://github.com/openssl/openssl/blob/master/include/openssl/x509_vfy.h.in
+ * One requirement for HAProxy is that the values should be literal constants.
  */
 
-#define X509_V_OK                       WOLFSSL_X509_V_OK
+#define X509_V_OK                                       0
 #define X509_V_ERR_UNSPECIFIED                          1
 #define X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT            2
 #define X509_V_ERR_UNABLE_TO_GET_CRL                    3
 #define X509_V_ERR_UNABLE_TO_DECRYPT_CERT_SIGNATURE     4
 #define X509_V_ERR_UNABLE_TO_DECRYPT_CRL_SIGNATURE      5
 #define X509_V_ERR_UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY   6
-#define X509_V_ERR_CERT_SIGNATURE_FAILURE               \
-                            WOLFSSL_X509_V_ERR_CERT_SIGNATURE_FAILURE
+#define X509_V_ERR_CERT_SIGNATURE_FAILURE               7
 #define X509_V_ERR_CRL_SIGNATURE_FAILURE                8
-#define X509_V_ERR_CERT_NOT_YET_VALID   WOLFSSL_X509_V_ERR_CERT_NOT_YET_VALID
-#define X509_V_ERR_CERT_HAS_EXPIRED     WOLFSSL_X509_V_ERR_CERT_HAS_EXPIRED
+#define X509_V_ERR_CERT_NOT_YET_VALID                   9
+#define X509_V_ERR_CERT_HAS_EXPIRED                     10
 #define X509_V_ERR_CRL_NOT_YET_VALID                    11
 #define X509_V_ERR_CRL_HAS_EXPIRED                      12
-#define X509_V_ERR_ERROR_IN_CERT_NOT_BEFORE_FIELD       \
-                            WOLFSSL_X509_V_ERR_ERROR_IN_CERT_NOT_BEFORE_FIELD
-#define X509_V_ERR_ERROR_IN_CERT_NOT_AFTER_FIELD        \
-                            WOLFSSL_X509_V_ERR_ERROR_IN_CERT_NOT_AFTER_FIELD
+#define X509_V_ERR_ERROR_IN_CERT_NOT_BEFORE_FIELD       13
+#define X509_V_ERR_ERROR_IN_CERT_NOT_AFTER_FIELD        14
 #define X509_V_ERR_ERROR_IN_CRL_LAST_UPDATE_FIELD       15
 #define X509_V_ERR_ERROR_IN_CRL_NEXT_UPDATE_FIELD       16
 #define X509_V_ERR_OUT_OF_MEM                           17
-#define X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT          \
-                            WOLFSSL_X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT
+#define X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT          18
 #define X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN            19
-#define X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY    \
-                            WOLFSSL_X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY
-#define X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE      \
-                            WOLFSSL_X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE
-#define X509_V_ERR_CERT_CHAIN_TOO_LONG  WOLFSSL_X509_V_ERR_CERT_CHAIN_TOO_LONG
-#define X509_V_ERR_CERT_REVOKED         WOLFSSL_X509_V_ERR_CERT_REVOKED
-#define X509_V_ERR_NO_ISSUER_PUBLIC_KEY WOLFSSL_X509_V_ERR_INVALID_CA
-#define X509_V_ERR_PATH_LENGTH_EXCEEDED WOLFSSL_X509_V_ERR_PATH_LENGTH_EXCEEDED
+#define X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY    20
+#define X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE      21
+#define X509_V_ERR_CERT_CHAIN_TOO_LONG                  22
+#define X509_V_ERR_CERT_REVOKED                         23
+#define X509_V_ERR_NO_ISSUER_PUBLIC_KEY                 24
+#define X509_V_ERR_PATH_LENGTH_EXCEEDED                 25
 #define X509_V_ERR_INVALID_PURPOSE                      26
 #define X509_V_ERR_CERT_UNTRUSTED                       27
-#define X509_V_ERR_CERT_REJECTED        WOLFSSL_X509_V_ERR_CERT_REJECTED
+#define X509_V_ERR_CERT_REJECTED                        28
 
 /* These are 'informational' when looking for issuer cert */
-#define X509_V_ERR_SUBJECT_ISSUER_MISMATCH              \
-                             WOLFSSL_X509_V_ERR_SUBJECT_ISSUER_MISMATCH
+#define X509_V_ERR_SUBJECT_ISSUER_MISMATCH              29
 #define X509_V_ERR_AKID_SKID_MISMATCH                   30
 #define X509_V_ERR_AKID_ISSUER_SERIAL_MISMATCH          31
 #define X509_V_ERR_KEYUSAGE_NO_CERTSIGN                 32

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2386,8 +2386,8 @@ enum {
                               * limit the possibility of an infinite retry loop
                               */
     SSL_MODE_RELEASE_BUFFERS = -1, /* For libwebsockets build. No current use. */
-    /* Errors used in wolfSSL.
-     * Should map the defines in wolfssl/openssl/x509.h
+    /* Errors used in wolfSSL. utilize the values from the defines in
+     * wolfssl/openssl/x509.h, but without the WOLFSSL_ prefix.
      */
     WOLFSSL_X509_V_OK                                    = 0,
     WOLFSSL_X509_V_ERR_CERT_SIGNATURE_FAILURE            = 7,


### PR DESCRIPTION
# Description

This PR adds the ability to turn CRL checks on or off from X509_STORE during runtime. This functionality would be consistent with OpenSSL. By default, the CRL check is enabled when wolfSSL is configured with HAVE_CRL. `wolfSSL_DisableCRL`() can be used to disable CRL check on SSL object but we are missing an ability to turn it off for a WOLFSSL_X509_STORE object. 

Fixes zd#15424

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
