### PR TITLE
20230421-configure-fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -186,10 +186,10 @@ AC_ARG_ENABLE([harden-tls],
 
 if test "x$ENABLED_HARDEN_TLS" != "xno"
 then
-    if test "x$ENABLED_HARDEN_TLS" == "xyes" || test "x$ENABLED_HARDEN_TLS" == "x112"
+    if test "x$ENABLED_HARDEN_TLS" = "xyes" || test "x$ENABLED_HARDEN_TLS" = "x112"
     then
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_HARDEN_TLS=112"
-    elif test "x$ENABLED_HARDEN_TLS" == "x128"
+    elif test "x$ENABLED_HARDEN_TLS" = "x128"
     then
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_HARDEN_TLS=128"
     else
@@ -1616,7 +1616,7 @@ then
 fi
 
 if test "x$ENABLED_PSA" != "xyes" && \
-    (test "x$PSA_LIB"! = "x" || test "x$PSA_INCLUDE" != "x" || test "x$PSA_LIB_NAME" != "x" )
+    (test "x$PSA_LIB" != "x" || test "x$PSA_INCLUDE" != "x" || test "x$PSA_LIB_NAME" != "x" )
 then
     AC_MSG_ERROR([to use PSA you need to enable it with --enable-psa])
 fi
@@ -4006,7 +4006,7 @@ fi
 if test "$ENABLED_ASN" = "no" && test "$ENABLED_DSA" = "no" && \
    test "$ENABLED_DH" = "no" && test "$ENABLED_ECC" = "no" && \
    test "$ENABLED_RSA" = "no" && test "$ENABLED_OPENSSLEXTRA" = "no" && \
-   test "$ENABLED_OPENSSLALL" ="yes"
+   test "$ENABLED_OPENSSLALL" = "yes"
 then
     ENABLED_SP_MATH_ALL="no"
     ENABLED_FASTMATH="no"
@@ -4068,7 +4068,7 @@ then
         then
                 AC_MSG_ERROR([You need to enable both DTLS and TLSv1.3 to use DTLSv1.3])
         fi
-        if test "x$ENABLED_SEND_HRR_COOKIE" == "xundefined"
+        if test "x$ENABLED_SEND_HRR_COOKIE" = "xundefined"
         then
                 AC_MSG_NOTICE([DTLSv1.3 is enabled, enabling HRR cookie])
                 AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SEND_HRR_COOKIE"
@@ -5221,7 +5221,7 @@ then
 fi
 if test "$ENABLED_TLS13_EARLY_DATA" = "yes"
 then
-    if test "x$ENABLED_TLS13" = "xno" && test "X$ENABLED_ALL" = "xno"
+    if test "x$ENABLED_TLS13" = "xno" && test "x$ENABLED_ALL" = "xno"
     then
         AC_MSG_ERROR([cannot enable earlydata without enabling tls13.])
     fi
@@ -6072,7 +6072,7 @@ then
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALT_CERT_CHAINS"
     fi
 
-    if test "xENABLE_IP_ALT_NAME" = "xno"
+    if test "x$ENABLE_IP_ALT_NAME" = "xno"
     then
         ENABLE_IP_ALT_NAME="yes"
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_IP_ALT_NAME"
@@ -7525,7 +7525,7 @@ fi
 
 if test -n "$MPI_MAX_KEY_BITS" -o -n "$WITH_MAX_ECC_BITS"; then
    if test -n "$MAX_MPI_KEY_BITS" -a -n "$WITH_MAX_ECC_BITS"; then
-       if test -n "$MAX_MPI_KEY_BITS" -lt "$WITH_MAX_ECC_BITS"; then
+       if test "$MAX_MPI_KEY_BITS" -lt "$WITH_MAX_ECC_BITS"; then
            MPI_MAX_KEY_BITS="$WITH_MAX_ECC_BITS"
        fi
    elif test -n "$WITH_MAX_ECC_BITS"; then
@@ -8668,9 +8668,9 @@ echo "#endif" >> $OPTION_FILE
 echo "" >> $OPTION_FILE
 
 # check for supported command to trim option with
-if colrm &> /dev/null; then
+if colrm >/dev/null 2>&1 </dev/null; then
     TRIM="colrm 3"
-elif cut &> /dev/null; then
+elif cut >/dev/null 2>&1 </dev/null; then
     TRIM="cut -c1-2"
 else
     AC_MSG_ERROR([Could not find colrm or cut to make options file])
@@ -8896,7 +8896,6 @@ echo "   * wolfCrypt Only:             $ENABLED_CRYPTONLY"
 echo "   * HKDF:                       $ENABLED_HKDF"
 echo "   * HPKE:                       $ENABLED_HPKE"
 echo "   * X9.63 KDF:                  $ENABLED_X963KDF"
-echo "   * MD4:                        $ENABLED_MD4"
 echo "   * PSK:                        $ENABLED_PSK"
 echo "   * Poly1305:                   $ENABLED_POLY1305"
 echo "   * LEANPSK:                    $ENABLED_LEANPSK"

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2735,12 +2735,6 @@ extern void uITRON4_free(void *p) ;
     #define WOLFSSL_HAVE_PRF
 #endif
 
-#if defined(NO_AES) && defined(NO_DES3) && !defined(HAVE_CAMELLIA) && \
-       !defined(WOLFSSL_HAVE_PRF) && defined(NO_PWDBASED)
-    #undef  WOLFSSL_NO_XOR_OPS
-    #define WOLFSSL_NO_XOR_OPS
-#endif
-
 #if defined(NO_ASN) && defined(WOLFCRYPT_ONLY) && !defined(WOLFSSL_WOLFSSH)
     #undef  WOLFSSL_NO_INT_ENCODE
     #define WOLFSSL_NO_INT_ENCODE


### PR DESCRIPTION
remove buggy+bug-prone `WOLFSSL_NO_XOR_OPS` setup in `settings.h`;

fix typos in `configure.ac` (from `shellcheck --severity=warning`).

tested with `wolfssl-multi-test.sh ... super-quick-check check-configure linuxkm-plus-wireguard  wolfssl-plus-wireguard` with revised+extended `check-configure`.

(@SparkiDev  note that 0bae919a9c0b23a8463a12c8ec1cf0101b6268e1 introduced a new `clang-analyzer-core.UndefinedBinaryOperatorResult` bug in `sp_int.c`)
