### PR TITLE
OpenSSL EC API: fix setting private key

### DIFF
--- a/src/pk.c
+++ b/src/pk.c
@@ -12753,7 +12753,7 @@ WOLFSSL_BIGNUM *wolfSSL_EC_KEY_get0_private_key(const WOLFSSL_EC_KEY *key)
  * @return  0 on failure.
  */
 int wolfSSL_EC_KEY_set_private_key(WOLFSSL_EC_KEY *key,
-                                   const WOLFSSL_BIGNUM *priv_key)
+    const WOLFSSL_BIGNUM *priv_key)
 {
     int ret = 1;
 
@@ -12762,6 +12762,13 @@ int wolfSSL_EC_KEY_set_private_key(WOLFSSL_EC_KEY *key,
     /* Validate parameters. */
     if ((key == NULL) || (priv_key == NULL)) {
         WOLFSSL_MSG("Bad arguments");
+        ret = 0;
+    }
+
+    /* Check for obvious invalid values. */
+    if (wolfSSL_BN_is_negative(priv_key) || wolfSSL_BN_is_zero(priv_key) ||
+            wolfSSL_BN_is_one(priv_key)) {
+        WOLFSSL_MSG("Invalid private key value");
         ret = 0;
     }
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -59980,8 +59980,8 @@ static int test_wolfSSL_EC_KEY_private_key(void)
     AssertNotNull(key = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1));
     AssertNotNull(priv = wolfSSL_BN_new());
     AssertNotNull(priv2 = wolfSSL_BN_new());
-    AssertIntNE(BN_set_word(priv, 1), 0);
-    AssertIntNE(BN_set_word(priv2, 1), 0);
+    AssertIntNE(BN_set_word(priv, 2), 0);
+    AssertIntNE(BN_set_word(priv2, 2), 0);
 
     AssertNull(wolfSSL_EC_KEY_get0_private_key(NULL));
     /* No private key set. */


### PR DESCRIPTION
# Description

wolfSSL_EC_KEY_set_private_key() should fail on obvious bad private key values.

Fixes zd#16044

# Testing

POC

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
