### PR TITLE
Remove XMEMSET after XFREE in sniffer.c

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -831,7 +831,6 @@ static void FreeSnifferSession(SnifferSession* session)
 #endif
     }
     XFREE(session, NULL, DYNAMIC_TYPE_SNIFFER_SESSION);
-    XMEMSET(session, 0, sizeof(SnifferSession));
 }
 
 


### PR DESCRIPTION
# Description

Fix a use after free caused by https://github.com/wolfSSL/wolfssl/pull/6220

Fixes zd#

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
