### PR TITLE
ASN original, OCSP: fix maximum size calc to GetDateInfo

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -33759,7 +33759,7 @@ static int DecodeSingleResponse(byte* source, word32* ioIndex, word32 size,
     localIdx = 0;
     if (GetDateInfo(single->status->thisDateAsn, &localIdx, NULL,
                     (byte*)&single->status->thisDateParsed.type,
-                    &single->status->thisDateParsed.length, size) < 0)
+                    &single->status->thisDateParsed.length, size - idx) < 0)
         return ASN_PARSE_E;
 
     if (idx + localIdx >= size)
@@ -33795,7 +33795,7 @@ static int DecodeSingleResponse(byte* source, word32* ioIndex, word32 size,
         localIdx = 0;
         if (GetDateInfo(single->status->nextDateAsn, &localIdx, NULL,
                         (byte*)&single->status->nextDateParsed.type,
-                        &single->status->nextDateParsed.length, size) < 0)
+                        &single->status->nextDateParsed.length, size - idx) < 0)
             return ASN_PARSE_E;
 
         if (idx + localIdx >= size)


### PR DESCRIPTION
# Description

GetDateInfo called with a local index (reset to 0) but size is of original buffer. Subtract the index into original buffer from size to get size available for parsing.

Fixes zd#16034

# Testing

POC from fuzzing

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
