### PR TITLE
Minor fixes

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -9065,7 +9065,7 @@ int EncryptContent(byte* input, word32 inputSz, byte* out, word32* outSz,
     int ret = 0;
     int sz = 0;
     int version;
-    int id;
+    int id = -1;
     int blockSz = 0;
     word32 pkcs8Sz = 0;
 

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -274,7 +274,7 @@ while (0)
                 int n##ii;                                                     \
                 (n)[0] = (sp_int*)n##d;                                        \
                 ((sp_int_minimal*)(n)[0])->size = (s);                         \
-                for (n##ii = 1; n##ii < (c); n##ii++) {                        \
+                for (n##ii = 1; n##ii < (int)(c); n##ii++) {                   \
                     (n)[n##ii] = MP_INT_NEXT((n)[n##ii-1], s);                 \
                     ((sp_int_minimal*)(n)[n##ii])->size = (s);                 \
                 }                                                              \
@@ -292,7 +292,7 @@ while (0)
             }                                                                  \
             if ((err) == MP_OKAY) {                                            \
                 int n##ii;                                                     \
-                for (n##ii = 0; n##ii < (c); n##ii++) {                        \
+                for (n##ii = 0; n##ii < (int)(c); n##ii++) {                   \
                     (n)[n##ii] = &n##d[n##ii];                                 \
                     (n)[n##ii]->size = (s);                                    \
                 }                                                              \


### PR DESCRIPTION
# Description

EncryptContent() - id not initialized
sp_int.c: cast count to int to ensure same type comparison with i.

# Testing

Standard

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
