### PR TITLE
20230425-analyzer-coddling

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -20112,6 +20112,12 @@ static int DecodeCertInternal(DecodedCert* cert, int verify, int* criticalExt,
         /* Parse the X509 certificate. */
         ret = GetASN_Items(x509CertASN, dataASN, x509CertASN_Length, 1,
                            cert->source, &cert->srcIdx, cert->maxIdx);
+#ifdef WOLFSSL_CLANG_TIDY
+        /* work around clang-tidy false positive re cert->source. */
+        if ((ret == 0) && (cert->source == NULL)) {
+            ret = ASN_PARSE_E;
+        }
+#endif
     }
     /* Check version is valid/supported - can't be negative. */
     if ((ret == 0) && (version > MAX_X509_VERSION)) {
@@ -20304,7 +20310,7 @@ static int DecodeCertInternal(DecodedCert* cert, int verify, int* criticalExt,
                                         KEYID_SIZE) == 0);
         }
         if (stopAtPubKey) {
-            ret = pubKeyOffset;
+            ret = (int)pubKeyOffset;
         }
     }
 

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -764,7 +764,7 @@ typedef struct sp_ecc_ctx {
  * Must have at least one digit.
  */
 #define MP_INT_SIZEOF(cnt)                                              \
-    (sizeof(sp_int) - (SP_INT_DIGITS - (((cnt) == 0) ? 1 : (cnt))) *    \
+    (sizeof(sp_int_minimal) + (((cnt) <= 1) ? 0 : ((cnt) - 1)) *        \
      sizeof(sp_int_digit))
 /* The address of the next sp_int after one with 'cnt' digits. */
 #define MP_INT_NEXT(t, cnt) \


### PR DESCRIPTION
`wolfcrypt/src/asn.c`: add to `DecodeCertInternal()` a workaround for an apparent `clang-tidy` bug, gated on `WOLFSSL_CLANG_TIDY`, and add a missing cast to mollify `-Wconversion`;

`wolfssl/wolfcrypt/sp_int.h`: refactor `MP_INT_SIZEOF()` using `sizeof(sp_int_minimal)` and addition, rather than `sizeof(sp_int)` and subtraction, for clarity and analyzer mollification.

tested with `wolfssl-multi-test.sh ... super-quick-check clang-tidy-defaults all-gcc-c89-clang-tidy allcryptonly-Wconversion-intelasm-build allcryptonly-c89-Wconversion-m32-build`

(note `wolfssl-multi-test.sh` tweaked with
```
CLANG_TIDY_CPPFLAGS=('-DSP_ALLOC -DWOLFSSL_CLANG_TIDY')
```
)
