### PR TITLE
Fix issues in test_wolfSSL_dtls_fragments

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -60917,6 +60917,7 @@ static void test_wolfSSL_dtls12_fragments_spammer(WOLFSSL* ssl)
 #ifdef WOLFSSL_DTLS13
 static void test_wolfSSL_dtls13_fragments_spammer(WOLFSSL* ssl)
 {
+    const word16 sendCountMax = 100;
     byte b[150]; /* buffer for the messages to send */
     size_t idx = 0;
     size_t msg_offset = 0;
@@ -60944,7 +60945,7 @@ static void test_wolfSSL_dtls13_fragments_spammer(WOLFSSL* ssl)
     /* fragment contents */
     idx += 100;
 
-    for (; ret > 0; msg_number++) {
+    for (; ret > 0 && msg_number < sendCountMax; msg_number++) {
         byte sendBuf[150];
         int sendSz = sizeof(sendBuf);
         struct timespec delay;
@@ -60993,9 +60994,10 @@ static int test_wolfSSL_dtls_fragments(void)
         AssertFalse(func_cb_server.return_code);
 
         /* The socket should be closed by the server resulting in a
-         * socket error or reading a close notify alert */
+         * socket error, fatal error or reading a close notify alert */
         if (func_cb_client.last_err != SOCKET_ERROR_E &&
-                func_cb_client.last_err != WOLFSSL_ERROR_ZERO_RETURN) {
+                func_cb_client.last_err != WOLFSSL_ERROR_ZERO_RETURN &&
+                func_cb_client.last_err != FATAL_ERROR) {
             AssertIntEQ(func_cb_client.last_err, SOCKET_ERROR_E);
         }
         /* Check the server returned an error indicating the msg buffer


### PR DESCRIPTION
# Description

This PR is to address the issues in test case test_wolfSSL_dtls_fragments and the related function test_wolfSSL_dtls13_fragment_spammer.

# How to repro the issues

```
$./async-check.sh setup
$./configure --enable-asynccrypt --enable-all --enable-dtls13
$make
$./tests/unit.test -test_wolfSSL_dtls_fragments
```
the output is

```
starting unit tests...
 Begin API Tests
   200: test_wolfSSL_dtls_fragments                         :error = -455, Received too many fragmented messages from peer error
error = -313, received alert fatal error
	
ERROR - tests/api.c line 61000 failed with:
    expected: func_cb_client.last_err == SOCKET_ERROR_E
    result:   -313 != -308
	
Aborted (core dumped)
```

From the output we can see that we should also consider FATAL_ERROR(-313) as a return code.
The output the same test case after fixing the return code:

```
starting unit tests...
 Begin API Tests
   200: test_wolfSSL_dtls_fragments                         :error = -455, Received too many fragmented messages from peer error
error = -313, received alert fatal error
error = -455, Received too many fragmented messages from peer error
(hung up)
```
The test case was hung since test_wolfSSL_dtls13_fragment_spammer is looping in its for-loop. We need to take care this issue. 


Fixes zd#

# Testing

Run the unit test case as follwoing steps then confirmed it passes.
```
$./async-check.sh setup
$./configure --enable-asynccrypt --enable-all --enable-dtls13
$make
$./tests/unit.test -test_wolfSSL_dtls_fragments
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
