### PR TITLE
Wolf entropy 64bit refresh

### DIFF
--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1109,7 +1109,7 @@ static word64 Entropy_GetSample(void)
  * @param [out] noise    Buffer to hold samples.
  * @param [in]  samples  Number of one byte samples to get.
  */
-static void Entropy_GetNoise(unsigned char* noise, int samples)
+static void Entropy_GetNoise(word64* noise, int samples)
 {
     int i;
 
@@ -1118,7 +1118,7 @@ static void Entropy_GetNoise(unsigned char* noise, int samples)
 
     /* Get as many samples as required. */
     for (i = 0; i < samples; i++) {
-       noise[i] = (byte)Entropy_GetSample();
+       noise[i] = Entropy_GetSample();
     }
 }
 
@@ -1130,7 +1130,7 @@ static void Entropy_GetNoise(unsigned char* noise, int samples)
  * @return  Negative when creating a thread fails - when no high resolution
  * clock available.
  */
-int wc_Entropy_GetRawEntropy(unsigned char* raw, int cnt)
+int wc_Entropy_GetRawEntropy(word64* raw, int cnt)
 {
     int ret = 0;
 
@@ -1330,7 +1330,7 @@ static int Entropy_HealthTest_Proportion(byte noise)
 static int Entropy_HealthTest_Startup(void)
 {
     int ret = 0;
-    byte initial[ENTROPY_INITIAL_COUNT];
+    word64 initial[ENTROPY_INITIAL_COUNT];
     int i;
 
 #ifdef WOLFSSL_DEBUG_ENTROPY_MEMUSE
@@ -1417,7 +1417,7 @@ static wolfSSL_Mutex entropy_mutex;
 int wc_Entropy_Get(int bits, unsigned char* entropy, word32 len)
 {
     int ret = 0;
-    byte noise[MAX_NOISE_CNT];
+    word64 noise[MAX_NOISE_CNT];
     /* Noise length is the number of 8 byte samples required to get the bits of
      * entropy requested. */
     int noise_len = (bits + ENTROPY_EXTRA) / ENTROPY_MIN;
@@ -1462,7 +1462,8 @@ int wc_Entropy_Get(int bits, unsigned char* entropy, word32 len)
 
         if (ret == 0) {
             /* Condition noise value down to 32-bytes or less. */
-            ret = Entropy_Condition(entropy, entropy_len, noise, noise_len);
+            ret = Entropy_Condition(entropy, entropy_len, (byte*) noise,
+                                    noise_len);
         }
         if (ret == 0) {
             /* Update buffer pointer and count of bytes left to generate. */

--- a/wolfssl/wolfcrypt/random.h
+++ b/wolfssl/wolfcrypt/random.h
@@ -263,7 +263,7 @@ WOLFSSL_API int  wc_FreeRng(WC_RNG* rng);
 #define MAX_ENTROPY_BITS    256
 
 /* For generating data for assessment. */
-WOLFSSL_API int wc_Entropy_GetRawEntropy(unsigned char* raw, int cnt);
+WOLFSSL_API int wc_Entropy_GetRawEntropy(unsigned long* raw, int cnt);
 WOLFSSL_API int wc_Entropy_Get(int bits, unsigned char* entropy, word32 len);
 WOLFSSL_API int wc_Entropy_OnDemandTest(void);
 


### PR DESCRIPTION
# Description

SP800-90B: Data cannot be shifted, discarded, XORed, or processed in any way
Truncating from 64-bit to 8-bit samples via a type cast denotes `discarded` data and may be problematic in submission. Instead we will type-cast 8-bit to 64-bit in normal operation which does not result in data being truncated or discarded. Samples will be 64-bit samples instead of 8-bit samples in `entropy-data-8bits.dat` and the name will be updated to `entropy-data-64bits.dat`

Fixes to gather raw 64-bit data. Will modify analyse.c to only evaluate the final 8-bit samples while the raw data remains in-tact at 64-bits for gather.c.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [X] updated appropriate READMEs (See fips repo)
 - [X] Updated manual and documentation (See fips repo)
