### PR TITLE
Fix getting key size in stm32_ecc_sign_hash_ex.

### DIFF
--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -1012,7 +1012,7 @@ int stm32_ecc_sign_hash_ex(const byte* hash, word32 hashlen, WC_RNG* rng,
     mp_init(&gen_k);
     mp_init(&order_mp);
 
-    size = mp_unsigned_bin_size(key->pubkey.x);
+    size = wc_ecc_size(key);
 
     status = stm32_get_from_mp_int(Keybin, &key->k, size);
     if (status != MP_OKAY)


### PR DESCRIPTION
# Description

Fixes zd# 16035
Allows stm32_ecc_sign_hash_ex to be called for an ecc_key only containing the private key.  Also guard against a key component with a leading 0 affecting the size, as it would with mp_unsigned_bin_size.