### PR TITLE
no math library with pk callbacks and TLS connections

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8231,8 +8231,7 @@ then
     fi
 fi
 
-if test "x$ENABLED_LEANPSK" = "xyes" || test "x$ENABLED_CERTS" = "xno" || \
-   test "x$ENABLED_ASN" = "xno"
+if test "x$ENABLED_LEANPSK" = "xyes" ||  test "x$ENABLED_ASN" = "xno"
 then
    ENABLED_CERTS=no
    ENABLED_ASN=no

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -93,7 +93,7 @@ static const char *wolfsentry_config_path = NULL;
 #endif
 
 static const char kHelloMsg[] = "hello wolfssl!" TEST_STR_TERM;
-#ifndef NO_SESSION_CACHE
+#if !defined(NO_SESSION_CACHE) && !defined(NO_BIG_INT)
 static const char kResumeMsg[] = "resuming wolfssl!" TEST_STR_TERM;
 #endif
 
@@ -1148,7 +1148,7 @@ static const char* client_usage_msg[][70] = {
         "-m          Match domain name in cert\n",                      /* 23 */
 #endif
         "-N          Use Non-blocking sockets\n",                       /* 24 */
-#ifndef NO_SESSION_CACHE
+#if !defined(NO_SESSION_CACHE) && !defined(NO_BIG_INT)
         "-r          Resume session\n",                                 /* 25 */
 #endif
         "-w          Wait for bidirectional shutdown\n",                /* 26 */
@@ -1624,7 +1624,7 @@ static void Usage(void)
     printf("%s", msg[++msgid]); /* -m */
 #endif
     printf("%s", msg[++msgid]); /* -N */
-#ifndef NO_SESSION_CACHE
+#if !defined(NO_SESSION_CACHE) && !defined(NO_BIG_INT)
     printf("%s", msg[++msgid]); /* -r */
 #endif
     printf("%s", msg[++msgid]); /* -w */
@@ -4237,7 +4237,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     }
 #endif
 
-#ifndef NO_SESSION_CACHE
+#if !defined(NO_SESSION_CACHE) && !defined(NO_BIG_INT)
     if (resumeSession) {
         session = wolfSSL_get1_session(ssl);
     }
@@ -4297,7 +4297,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     wolfSSL_free(ssl); ssl = NULL;
     CloseSocket(sockfd);
 
-#ifndef NO_SESSION_CACHE
+#if !defined(NO_SESSION_CACHE) && !defined(NO_BIG_INT)
     if (resumeSession) {
         sslResume = wolfSSL_new(ctx);
         if (sslResume == NULL) {

--- a/scripts/resume.test
+++ b/scripts/resume.test
@@ -139,9 +139,13 @@ if [ $? -ne 0 ]; then
     fi
 fi
 
-./examples/client/client '-?' 2>&1 | grep -- 'Resume session'
-if [ $? -ne 0 ]; then
-    RUN_TEST="Y"
+if [ "$RUN_TEST" = "Y" ]; then
+    ./examples/client/client '-?' 2>&1 | grep -- 'Resume session'
+    if [ $? -ne 0 ]; then
+        RUN_TEST="N"
+    else
+        RUN_TEST="Y"
+    fi
 fi
 
 if [ "$RUN_TEST" = "Y" ]; then
@@ -161,4 +165,8 @@ fi
 
 echo -e "\nSuccess!\n"
 
-exit 0
+if [ "$RUN_TEST" = "Y" ]; then
+    exit 0
+else
+    exit 77
+fi

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -8926,7 +8926,7 @@ int wolfSSL_CTX_SetTmpDH_file(WOLFSSL_CTX* ctx, const char* fname, int format)
 
 #endif /* NO_FILESYSTEM */
 
-#ifndef NO_CHECK_PRIVATE_KEY
+#if !defined(NO_CHECK_PRIVATE_KEY) && !defined(NO_BIG_INT)
 /* Check private against public in certificate for match
  *
  * Returns WOLFSSL_SUCCESS on good private key

--- a/tests/api.c
+++ b/tests/api.c
@@ -11427,7 +11427,7 @@ static int test_wolfSSL_PKCS8(void)
 {
     EXPECT_DECLS;
 #if !defined(NO_FILESYSTEM) && !defined(NO_ASN) && defined(HAVE_PKCS8) && \
-    !defined(WOLFCRYPT_ONLY)
+    !defined(WOLFCRYPT_ONLY) && !defined(NO_CERTS)
 #if !defined(NO_WOLFSSL_CLIENT) || !defined(NO_WOLFSSL_SERVER)
     byte buff[FOURK_BUF];
     byte der[FOURK_BUF];
@@ -21689,9 +21689,9 @@ static int test_wc_curve448_size(void)
 static int test_wc_ecc_make_key(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_ECC) && !defined(WC_NO_RNG)
-    ecc_key key;
+#if defined(HAVE_ECC) && !defined(WC_NO_RNG) && !defined(NO_BIG_INT)
     WC_RNG  rng;
+    ecc_key key;
     int     ret;
 
     XMEMSET(&key, 0, sizeof(ecc_key));
@@ -21746,10 +21746,10 @@ static int test_wc_ecc_init(void)
 static int test_wc_ecc_check_key(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_ECC) && !defined(WC_NO_RNG)
-    ecc_key key;
-    WC_RNG  rng;
-    int     ret;
+#if defined(HAVE_ECC) && !defined(WC_NO_RNG) && !defined(NO_BIG_INT)
+    WC_RNG      rng;
+    ecc_key     key;
+    int         ret;
 
     XMEMSET(&rng, 0, sizeof(rng));
     XMEMSET(&key, 0, sizeof(key));
@@ -21812,7 +21812,7 @@ static int test_wc_ecc_get_generator(void)
 static int test_wc_ecc_size(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_ECC) && !defined(WC_NO_RNG)
+#if defined(HAVE_ECC) && !defined(WC_NO_RNG) && !defined(NO_BIG_INT)
     WC_RNG      rng;
     ecc_key     key;
     int         ret;
@@ -21868,7 +21868,8 @@ static int test_wc_ecc_params(void)
 static int test_wc_ecc_signVerify_hash(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_ECC) && defined(HAVE_ECC_SIGN) && !defined(NO_ASN) && !defined(WC_NO_RNG)
+#if defined(HAVE_ECC) && defined(HAVE_ECC_SIGN) && !defined(NO_ASN) && \
+    !defined(WC_NO_RNG) && !defined(NO_BIG_INT)
     ecc_key key;
     WC_RNG  rng;
     int     ret;
@@ -21957,7 +21958,8 @@ static int test_wc_ecc_signVerify_hash(void)
 static int test_wc_ecc_shared_secret(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_ECC) && defined(HAVE_ECC_DHE) && !defined(WC_NO_RNG)
+#if defined(HAVE_ECC) && defined(HAVE_ECC_DHE) && !defined(WC_NO_RNG) && \
+    !defined(NO_BIG_INT)
     ecc_key     key;
     ecc_key     pubKey;
     WC_RNG      rng;
@@ -22058,7 +22060,8 @@ static int test_wc_ecc_shared_secret(void)
 static int test_wc_ecc_export_x963(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_ECC) && defined(HAVE_ECC_KEY_EXPORT) && !defined(WC_NO_RNG)
+#if defined(HAVE_ECC) && defined(HAVE_ECC_KEY_EXPORT) && \
+    !defined(WC_NO_RNG) && !defined(NO_BIG_INT)
     ecc_key key;
     WC_RNG  rng;
     byte    out[ECC_ASN963_MAX_BUF_SZ];
@@ -22108,7 +22111,8 @@ static int test_wc_ecc_export_x963(void)
 static int test_wc_ecc_export_x963_ex(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_ECC) && defined(HAVE_ECC_KEY_EXPORT) && !defined(WC_NO_RNG)
+#if defined(HAVE_ECC) && defined(HAVE_ECC_KEY_EXPORT) && \
+    !defined(WC_NO_RNG) && !defined(NO_BIG_INT)
     ecc_key key;
     WC_RNG  rng;
     int     ret;
@@ -22180,7 +22184,8 @@ static int test_wc_ecc_import_x963(void)
 {
     EXPECT_DECLS;
 #if defined(HAVE_ECC) && defined(HAVE_ECC_KEY_IMPORT) && \
-    defined(HAVE_ECC_KEY_EXPORT) && !defined(WC_NO_RNG)
+    defined(HAVE_ECC_KEY_EXPORT) && !defined(WC_NO_RNG) && \
+    !defined(NO_BIG_INT)
     ecc_key pubKey;
     ecc_key key;
     WC_RNG  rng;
@@ -22232,7 +22237,8 @@ static int test_wc_ecc_import_private_key(void)
 {
     EXPECT_DECLS;
 #if defined(HAVE_ECC) && defined(HAVE_ECC_KEY_IMPORT) && \
-    defined(HAVE_ECC_KEY_EXPORT) && !defined(WC_NO_RNG)
+    defined(HAVE_ECC_KEY_EXPORT) && !defined(WC_NO_RNG) && \
+    !defined(NO_BIG_INT)
     ecc_key key;
     ecc_key keyImp;
     WC_RNG  rng;
@@ -22289,7 +22295,8 @@ static int test_wc_ecc_import_private_key(void)
 static int test_wc_ecc_export_private_only(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_ECC) && defined(HAVE_ECC_KEY_EXPORT) && !defined(WC_NO_RNG)
+#if defined(HAVE_ECC) && defined(HAVE_ECC_KEY_EXPORT) && \
+    !defined(WC_NO_RNG) && !defined(NO_BIG_INT)
     ecc_key key;
     WC_RNG  rng;
     byte    out[ECC_PRIV_KEY_BUF];
@@ -22332,7 +22339,7 @@ static int test_wc_ecc_export_private_only(void)
 static int test_wc_ecc_rs_to_sig(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_ECC) && !defined(NO_ASN)
+#if defined(HAVE_ECC) && !defined(NO_ASN) && !defined(NO_BIG_INT)
     /* first [P-192,SHA-1] vector from FIPS 186-3 NIST vectors */
     const char* R = "6994d962bdd0d793ffddf855ec5bf2f91a9698b46258a63e";
     const char* S = "02ba6465a234903744ab02bc8521405b73cf5fc00e1a9f41";
@@ -22377,7 +22384,7 @@ static int test_wc_ecc_rs_to_sig(void)
 static int test_wc_ecc_import_raw(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_ECC) && !defined(NO_ECC256)
+#if defined(HAVE_ECC) && !defined(NO_ECC256) && !defined(NO_BIG_INT)
     ecc_key     key;
     const char* qx =
         "bb33ac4c27504ac64aa504c33cde9f36db722dce94ea2bfacb2009392c16e861";
@@ -22445,8 +22452,9 @@ static int test_wc_ecc_import_unsigned(void)
 {
     EXPECT_DECLS;
 #if defined(HAVE_ECC) && !defined(NO_ECC256) && !defined(HAVE_SELFTEST) && \
-    (!defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && \
-     HAVE_FIPS_VERSION >= 2))
+    (!defined(HAVE_FIPS) || \
+    (defined(HAVE_FIPS_VERSION) && HAVE_FIPS_VERSION >= 2)) && \
+    !defined(NO_BIG_INT)
     ecc_key    key;
     const byte qx[] = {
         0xbb, 0x33, 0xac, 0x4c, 0x27, 0x50, 0x4a, 0xc6,
@@ -22505,7 +22513,7 @@ static int test_wc_ecc_import_unsigned(void)
 static int test_wc_ecc_sig_size(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_ECC) && !defined(WC_NO_RNG)
+#if defined(HAVE_ECC) && !defined(WC_NO_RNG) && !defined(NO_BIG_INT)
     ecc_key key;
     WC_RNG  rng;
     int     keySz = KEY16;
@@ -22666,7 +22674,7 @@ static int test_wc_ecc_encryptDecrypt(void)
 {
     EXPECT_DECLS;
 #if defined(HAVE_ECC) && defined(HAVE_ECC_ENCRYPT) && !defined(WC_NO_RNG) && \
-    defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_128)
+    defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_128) && !defined(NO_BIG_INT)
     ecc_key     srvKey;
     ecc_key     cliKey;
     ecc_key     tmpKey;
@@ -22772,7 +22780,7 @@ static int test_wc_ecc_encryptDecrypt(void)
 static int test_wc_ecc_del_point(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_ECC)
+#if defined(HAVE_ECC) && !defined(NO_BIG_INT)
     ecc_point* pt = NULL;
 
     ExpectNotNull(pt = wc_ecc_new_point());
@@ -22791,7 +22799,7 @@ static int test_wc_ecc_pointFns(void)
     EXPECT_DECLS;
 #if defined(HAVE_ECC) && defined(HAVE_ECC_KEY_EXPORT) && \
     !defined(WC_NO_RNG) && !defined(WOLFSSL_ATECC508A) && \
-    !defined(WOLFSSL_ATECC608A)
+    !defined(WOLFSSL_ATECC608A) && !defined(NO_BIG_INT)
     ecc_key    key;
     WC_RNG     rng;
     int        ret;
@@ -22891,7 +22899,7 @@ static int test_wc_ecc_shared_secret_ssh(void)
     EXPECT_DECLS;
 #if defined(HAVE_ECC) && defined(HAVE_ECC_DHE) && \
     !defined(WC_NO_RNG) && !defined(WOLFSSL_ATECC508A) && \
-    !defined(WOLFSSL_ATECC608A)
+    !defined(WOLFSSL_ATECC608A) && !defined(NO_BIG_INT)
     ecc_key key;
     ecc_key key2;
     WC_RNG  rng;
@@ -23058,7 +23066,7 @@ static int test_wc_ecc_verify_hash_ex(void)
 static int test_wc_ecc_mulmod(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_ECC) && !defined(WC_NO_RNG) && \
+#if defined(HAVE_ECC) && !defined(WC_NO_RNG) && !defined(NO_BIG_INT) && \
     !(defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
       defined(WOLFSSL_VALIDATE_ECC_IMPORT))
     ecc_key     key1;
@@ -23122,7 +23130,7 @@ static int test_wc_ecc_mulmod(void)
 static int test_wc_ecc_is_valid_idx(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_ECC) && !defined(WC_NO_RNG)
+#if defined(HAVE_ECC) && !defined(WC_NO_RNG) && !defined(NO_BIG_INT)
     ecc_key key;
     WC_RNG  rng;
     int     ret;
@@ -23181,7 +23189,8 @@ static int test_wc_ecc_get_curve_id_from_oid(void)
 static int test_wc_ecc_sig_size_calc(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_ECC) && !defined(WC_NO_RNG) && !defined(HAVE_SELFTEST)
+#if defined(HAVE_ECC) && !defined(WC_NO_RNG) && !defined(HAVE_SELFTEST) && \
+    !defined(NO_BIG_INT)
     ecc_key key;
     WC_RNG  rng;
     int     sz = 0;
@@ -23852,7 +23861,8 @@ static int test_ToTraditional(void)
 static int test_wc_EccPrivateKeyToDer(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_ECC) && defined(HAVE_ECC_KEY_EXPORT) && !defined(WC_NO_RNG)
+#if defined(HAVE_ECC) && defined(HAVE_ECC_KEY_EXPORT) && \
+    !defined(WC_NO_RNG) && !defined(NO_BIG_INT)
     byte    output[ONEK_BUF];
     ecc_key eccKey;
     WC_RNG  rng;
@@ -47601,7 +47611,8 @@ static int test_wc_CreateEncryptedPKCS8Key(void)
 static int test_wc_GetPkcs8TraditionalOffset(void)
 {
     EXPECT_DECLS;
-#if !defined(NO_ASN) && !defined(NO_FILESYSTEM) && defined(HAVE_PKCS8)
+#if !defined(NO_ASN) && !defined(NO_FILESYSTEM) && defined(HAVE_PKCS8) && \
+    !defined(NO_CERTS)
     int length;
     int derSz = 0;
     word32 inOutIdx;
@@ -48059,7 +48070,7 @@ static int test_wc_ecc_get_curve_id_from_dp_params(void)
 static int test_wc_ecc_get_curve_id_from_params(void)
 {
     EXPECT_DECLS;
-#ifdef HAVE_ECC
+#if defined(HAVE_ECC) && !defined(NO_BIG_INT)
     const byte prime[] =
     {
         0xFF,0xFF,0xFF,0xFF,0x00,0x00,0x00,0x01,

--- a/tests/api.c
+++ b/tests/api.c
@@ -49941,7 +49941,7 @@ static int test_EccSigFailure_cm(void)
 #endif /* !NO_FILESYSTEM */
 #endif /* NO_CERTS */
 
-#ifdef WOLFSSL_TLS13
+#if defined(WOLFSSL_TLS13) && !defined(NO_BIG_INT)
 #if defined(WOLFSSL_SEND_HRR_COOKIE) && !defined(NO_WOLFSSL_SERVER)
 #ifdef WC_SHA384_DIGEST_SIZE
     static byte fixedKey[WC_SHA384_DIGEST_SIZE] = { 0, };
@@ -63949,7 +63949,7 @@ TEST_CASE testCases[] = {
 #endif
     TEST_DECL(test_wolfSSL_set_options),
 
-#ifdef WOLFSSL_TLS13
+#if defined(WOLFSSL_TLS13) && !defined(NO_BIG_INT)
     /* TLS v1.3 API tests */
     TEST_DECL(test_tls13_apis),
     TEST_DECL(test_tls13_cipher_suites),

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -248,7 +248,8 @@ int unit_test(int argc, char** argv)
     }
 
 #ifndef NO_WOLFSSL_CIPHER_SUITE_TEST
-#if !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER)
+#if !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    !defined(NO_BIG_INT)
 #ifndef SINGLE_THREADED
     if ((ret = SuiteTest(argc, argv)) != 0) {
         fprintf(stderr, "suite test failed with %d\n", ret);

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -32,7 +32,7 @@
 #include <wolfcrypt/test/test.h>
 
 
-#ifndef SINGLE_THREADED
+#if !defined(SINGLE_THREADED) && !defined(NO_BIG_INT)
 
 #ifdef OPENSSL_EXTRA
 #include <wolfssl/openssl/ssl.h>

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -257,10 +257,6 @@ ECC Curve Sizes:
         ((unsigned)((key)->dp->size * 8 + 1)))
 #endif
 
-#ifdef NO_BIG_INT
-#define MP_OKAY 0
-#endif
-
 #if !defined(NO_BIG_INT)
 /* forward declarations */
 static int  wc_ecc_new_point_ex(ecc_point** point, void* heap);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -534,9 +534,11 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t pbkdf2_test(void);
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t scrypt_test(void);
 #ifdef HAVE_ECC
     WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  ecc_test(void);
+    #ifndef NO_BIG_INT
     #if defined(HAVE_ECC_ENCRYPT) && defined(HAVE_AES_CBC) && \
         (defined(WOLFSSL_AES_128) || defined(WOLFSSL_AES_256))
         WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  ecc_encrypt_test(void);
+    #endif
     #endif
     #if defined(USE_CERT_BUFFERS_256) && !defined(WOLFSSL_ATECC508A) && \
         !defined(WOLFSSL_ATECC608A) && !defined(NO_ECC256) && \
@@ -1505,6 +1507,7 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 #endif
 
 #if defined(HAVE_ECC)
+    #ifndef NO_BIG_INT
     PRIVATE_KEY_UNLOCK();
     if ( (ret = ecc_test()) != 0)
         TEST_FAIL("ECC      test failed!\n", ret);
@@ -1517,6 +1520,7 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
             TEST_FAIL("ECC Enc  test failed!\n", ret);
         else
             TEST_PASS("ECC Enc  test passed!\n");
+    #endif
     #endif
     #if defined(USE_CERT_BUFFERS_256) && !defined(WOLFSSL_ATECC508A) && \
         !defined(WOLFSSL_ATECC608A) && !defined(NO_ECC256) && \
@@ -14656,7 +14660,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t memory_test(void)
 #if !defined(USE_CERT_BUFFERS_256) && !defined(NO_ECC256)
     #ifdef HAVE_ECC
         /* cert files to be used in rsa cert gen test, check if RSA enabled */
-        #ifdef HAVE_ECC_KEY_IMPORT
+        #if defined(HAVE_ECC_KEY_IMPORT) && !defined(NO_BIG_INT)
             static const char* eccKeyDerFile = CERT_ROOT "ecc-key.der";
         #endif
 #endif
@@ -14722,7 +14726,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t memory_test(void)
         #endif
     #endif
     #if defined(HAVE_ECC_KEY_EXPORT) && !defined(WC_NO_RNG) && \
-        !defined(WOLF_CRYPTO_CB_ONLY_ECC) && !defined(NO_ASN_CRYPT)
+        !defined(WOLF_CRYPTO_CB_ONLY_ECC) && !defined(NO_ASN_CRYPT) && \
+        !defined(NO_BIG_INT)
         static const char* eccCaKeyPemFile  = CERT_WRITE_TEMP_DIR "ecc-key.pem";
         static const char* eccPubKeyDerFile = CERT_WRITE_TEMP_DIR "ecc-public-key.der";
         static const char* eccCaKeyTempFile = CERT_WRITE_TEMP_DIR "ecc-key.der";
@@ -24276,6 +24281,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hpke_test(void)
 #endif /* HAVE_HPKE && HAVE_ECC && HAVE_AESGCM */
 
 #ifdef HAVE_ECC
+#ifndef NO_BIG_INT
 
 /* size to use for ECC key gen tests */
 #ifndef ECC_KEYGEN_SIZE
@@ -24689,8 +24695,9 @@ static wc_test_ret_t ecc_test_vector(int keySize)
 }
 #endif /* WOLF_CRYPTO_CB_ONLY_ECC */
 
-#if defined(HAVE_ECC_SIGN) && (defined(WOLFSSL_ECDSA_DETERMINISTIC_K) || \
-                               defined(WOLFSSL_ECDSA_DETERMINISTIC_K_VARIANT)) \
+#if !defined(NO_BIG_INT) && defined(HAVE_ECC_SIGN) && \
+        (defined(WOLFSSL_ECDSA_DETERMINISTIC_K) || \
+         defined(WOLFSSL_ECDSA_DETERMINISTIC_K_VARIANT)) \
     && (!defined(FIPS_VERSION_GE) || FIPS_VERSION_GE(5,3))
 #if defined(HAVE_ECC256)
 static wc_test_ret_t ecc_test_deterministic_k(WC_RNG* rng)
@@ -26208,7 +26215,8 @@ static wc_test_ret_t ecc_test_curve(WC_RNG* rng, int keySize, int curve_id)
 #if (!defined(NO_ECC256) || defined(HAVE_ALL_CURVES)) && ECC_MIN_KEY_SZ <= 256
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
     defined(HAVE_ECC_KEY_IMPORT) && defined(HAVE_ECC_KEY_EXPORT) && \
-    !defined(WOLFSSL_NO_MALLOC) && !defined(WOLF_CRYPTO_CB_ONLY_ECC)
+    !defined(WOLFSSL_NO_MALLOC) && !defined(WOLF_CRYPTO_CB_ONLY_ECC) && \
+    !defined(NO_BIG_INT)
 static wc_test_ret_t ecc_point_test(void)
 {
     wc_test_ret_t ret;
@@ -26700,7 +26708,7 @@ done:
 }
 #endif
 
-#if defined(HAVE_ECC_DHE) && !defined(WC_NO_RNG) && \
+#if !defined(NO_BIG_INT) && defined(HAVE_ECC_DHE) && !defined(WC_NO_RNG) && \
     !defined(WOLF_CRYPTO_CB_ONLY_ECC)
 static wc_test_ret_t ecc_ssh_test(ecc_key* key, WC_RNG* rng)
 {
@@ -26798,7 +26806,7 @@ static wc_test_ret_t ecc_def_curve_test(WC_RNG *rng)
     TEST_SLEEP();
 
     #if defined(HAVE_ECC_DHE) && !defined(WOLFSSL_CRYPTOCELL) && \
-       !defined(WOLF_CRYPTO_CB_ONLY_ECC)
+       !defined(WOLF_CRYPTO_CB_ONLY_ECC) && !defined(NO_BIG_INT)
     ret = ecc_ssh_test(key, rng);
     if (ret < 0)
         goto done;
@@ -26862,6 +26870,7 @@ done:
     return ret;
 }
 #endif /* !NO_ECC256 || HAVE_ALL_CURVES */
+#endif /* NO_BIG_INT */
 
 #if defined(WOLFSSL_CERT_EXT) && \
     (!defined(NO_ECC256) || defined(HAVE_ALL_CURVES)) && ECC_MIN_KEY_SZ <= 256
@@ -27959,7 +27968,8 @@ exit:
 
 #if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST) && \
     !defined(WOLFSSL_NO_MALLOC) && !defined(WOLF_CRYPTO_CB_ONLY_ECC) && \
-    (!defined(NO_ECC_SECP) || defined(WOLFSSL_CUSTOM_CURVES))
+    (!defined(NO_ECC_SECP) || defined(WOLFSSL_CUSTOM_CURVES)) && \
+    !defined(NO_BIG_INT)
 /* Test for the wc_ecc_key_new() and wc_ecc_key_free() functions. */
 static wc_test_ret_t ecc_test_allocator(WC_RNG* rng)
 {
@@ -28478,8 +28488,10 @@ static wc_test_ret_t ecc_test_nonblock(WC_RNG* rng)
 
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ecc_test(void)
 {
-    wc_test_ret_t ret;
+    wc_test_ret_t ret = 0;
+#ifndef NO_BIG_INT
     WC_RNG rng;
+#endif
 
 #if defined(WOLFSSL_CERT_EXT) && \
     (!defined(NO_ECC256) || defined(HAVE_ALL_CURVES)) && ECC_MIN_KEY_SZ <= 256
@@ -28488,6 +28500,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ecc_test(void)
         return ret;
 #endif
 
+#ifndef NO_BIG_INT
 #ifndef HAVE_FIPS
     ret = wc_InitRng_ex(&rng, HEAP_HINT, devId);
 #else
@@ -28557,12 +28570,14 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ecc_test(void)
     }
 #endif
 #if !defined(NO_ECC_SECP) || defined(WOLFSSL_CUSTOM_CURVES)
+#ifndef NO_BIG_INT
     ret = ecc_def_curve_test(&rng);
     if (ret < 0) {
         printf("Default\n");
         goto done;
     }
 #endif
+#endif /* NO_BIG_INT */
 #endif /* !NO_ECC256 */
 #if (defined(HAVE_ECC320) || defined(HAVE_ALL_CURVES)) && ECC_MIN_KEY_SZ <= 320
     ret = ecc_test_curve(&rng, 40, ECC_CURVE_DEF);
@@ -28621,8 +28636,9 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ecc_test(void)
     }
 #endif
 
-#if defined(HAVE_ECC_SIGN) && (defined(WOLFSSL_ECDSA_DETERMINISTIC_K) || \
-                               defined(WOLFSSL_ECDSA_DETERMINISTIC_K_VARIANT)) \
+#if !defined(NO_BIG_INT) && defined(HAVE_ECC_SIGN) && \
+        (defined(WOLFSSL_ECDSA_DETERMINISTIC_K) || \
+         defined(WOLFSSL_ECDSA_DETERMINISTIC_K_VARIANT)) \
     && (!defined(FIPS_VERSION_GE) || FIPS_VERSION_GE(5,3))
     #ifdef HAVE_ECC256
     ret = ecc_test_deterministic_k(&rng);
@@ -28704,6 +28720,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ecc_test(void)
 
 done:
     wc_FreeRng(&rng);
+#endif
 
     return ret;
 }

--- a/wolfssl/openssl/bn.h
+++ b/wolfssl/openssl/bn.h
@@ -40,7 +40,9 @@
 typedef struct WOLFSSL_BIGNUM {
     int neg;        /* openssh deference */
     void *internal; /* our big num */
+#ifndef NO_BIG_INT
     mp_int mpi;
+#endif
 } WOLFSSL_BIGNUM;
 
 #define WOLFSSL_BN_ULONG unsigned long

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -244,8 +244,10 @@ typedef struct ASNSetData {
         word16  u16;
         /* 32-bit integer value. */
         word32  u32;
+    #ifndef NO_BIG_INT
         /* Big number as an mp_int. */
         mp_int* mp;
+    #endif
         /* Buffer as data pointer and length. */
         struct {
             /* Data to write out. */
@@ -276,8 +278,10 @@ typedef struct ASNGetData {
         word16*     u16;
         /* Pointer to 32-bit integer. */
         word32*     u32;
+    #ifndef NO_BIG_INT
         /* Pointer to mp_int for big number. */
         mp_int*     mp;
+    #endif
         /* List of possible tags. Useful for CHOICE ASN.1 items. */
         const byte* choice;
         /* Buffer to copy into. */
@@ -2193,8 +2197,10 @@ WOLFSSL_LOCAL int GetSet_ex(const byte* input, word32* inOutIdx, int* len,
                         word32 maxIdx, int check);
 WOLFSSL_LOCAL int GetMyVersion(const byte* input, word32* inOutIdx,
                               int* version, word32 maxIdx);
+#ifndef NO_BIG_INT
 WOLFSSL_LOCAL int GetInt(mp_int* mpi, const byte* input, word32* inOutIdx,
                          word32 maxIdx);
+#endif /* NO_BIG_INT */
 
 #ifdef HAVE_OID_ENCODING
     WOLFSSL_API int wc_EncodeObjectId(const word16* in, word32 inSz,
@@ -2251,11 +2257,13 @@ WOLFSSL_LOCAL int GetNameHash_ex(const byte* source, word32* idx, byte* hash,
 WOLFSSL_LOCAL int wc_CheckPrivateKeyCert(const byte* key, word32 keySz, DecodedCert* der);
 WOLFSSL_LOCAL int wc_CheckPrivateKey(const byte* privKey, word32 privKeySz,
                                      const byte* pubKey, word32 pubKeySz, enum Key_Sum ks);
+#ifndef NO_BIG_INT
 WOLFSSL_LOCAL int StoreDHparams(byte* out, word32* outLen, mp_int* p, mp_int* g);
 #ifdef WOLFSSL_DH_EXTRA
 WOLFSSL_API int wc_DhPublicKeyDecode(const byte* input, word32* inOutIdx,
                         DhKey* key, word32 inSz);
 #endif
+#endif /* NO_BIG_INT */
 WOLFSSL_LOCAL int FlattenAltNames(byte* output, word32 outputSz,
                                   const DNS_entry* names);
 
@@ -2266,6 +2274,7 @@ WOLFSSL_LOCAL int wc_EncodeNameCanonical(EncodedName* name, const char* nameStr,
 
 #if defined(HAVE_ECC) || !defined(NO_DSA)
     /* ASN sig helpers */
+    #ifndef NO_BIG_INT
     WOLFSSL_LOCAL int StoreECC_DSA_Sig(byte* out, word32* outLen, mp_int* r,
                                       mp_int* s);
     WOLFSSL_LOCAL int StoreECC_DSA_Sig_Bin(byte* out, word32* outLen,
@@ -2276,6 +2285,7 @@ WOLFSSL_LOCAL int wc_EncodeNameCanonical(EncodedName* name, const char* nameStr,
                                        mp_int* r, mp_int* s);
     WOLFSSL_LOCAL int DecodeECC_DSA_Sig_Ex(const byte* sig, word32 sigLen,
                                        mp_int* r, mp_int* s, int init);
+    #endif
 #endif
 #ifndef NO_DSA
 WOLFSSL_LOCAL int StoreDSAParams(byte*, word32*, const mp_int*, const mp_int*,

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2168,9 +2168,7 @@ extern void uITRON4_free(void *p) ;
         #undef HAVE_ECC_KEY_IMPORT
         #define HAVE_ECC_KEY_IMPORT
     #endif
-    /* The ECC key export requires mp_int or SP */
-    #if (!defined(NO_ECC_KEY_EXPORT) && defined(WOLFSSL_SP_MATH)) || \
-        (!defined(NO_ECC_KEY_EXPORT) && !defined(NO_BIG_INT))
+    #if !defined(NO_ECC_KEY_EXPORT)
         #undef HAVE_ECC_KEY_EXPORT
         #define HAVE_ECC_KEY_EXPORT
     #endif
@@ -2472,6 +2470,11 @@ extern void uITRON4_free(void *p) ;
         #error leantls build needs ECC
     #endif
 #endif /* WOLFSSL_LEANTLS*/
+
+#ifdef NO_BIG_INT
+    #undef NO_SIG_WRAPPER
+    #define NO_SIG_WRAPPER
+#endif
 
 /* restriction with static memory */
 #ifdef WOLFSSL_STATIC_MEMORY

--- a/wolfssl/wolfcrypt/wolfmath.h
+++ b/wolfssl/wolfcrypt/wolfmath.h
@@ -85,7 +85,8 @@ WOLFSSL_API int mp_rand(mp_int* a, int digits, WC_RNG* rng);
     #define WC_TYPE_BLACK_KEY 3
 #endif
 
-#if defined(HAVE_ECC) || defined(WOLFSSL_EXPORT_INT)
+#if !defined(NO_BIG_INT) && \
+    (defined(HAVE_ECC) || defined(WOLFSSL_EXPORT_INT))
 WOLFSSL_API int wc_export_int(mp_int* mp, byte* buf, word32* len,
     word32 keySz, int encType);
 #endif

--- a/wolfssl/wolfcrypt/wolfmath.h
+++ b/wolfssl/wolfcrypt/wolfmath.h
@@ -48,6 +48,10 @@ This library provides big integer math functions.
     #include <wolfssl/wolfcrypt/sp_int.h>
 #endif
 
+#ifdef NO_BIG_INT
+    #define MP_OKAY 0
+#endif
+
 #if !defined(NO_BIG_INT) || defined(WOLFSSL_SP_MATH)
     #include <wolfssl/wolfcrypt/random.h>
 #endif


### PR DESCRIPTION
Currently completes a TLS connection with ECC using the configure:

```
./configure --enable-static --enable-pkcallbacks --disable-fastmath --disable-heapmath --disable-sp-math-all --disable-oldtls --disable-dh --disable-rsa --disable-pwdbased --disable-pkcs12 --disable-benchmark --enable-ecc 
```

Example server : 
```
./examples/server/server -P -c ./certs/server-ecc.pem  -k ./certs/ecc-key.pem -d
```

Example client : 
```
./examples/client/client -P -c ./certs/client-ecc-cert.pem -k ./certs/ecc-client-key.pem -A ./certs/ca-ecc-cert.pem 
```

Comparing the static library with and without a math BN implementation:
With sp-math-all `746396 Apr 26 15:41 src/.libs/libwolfssl.a`
Without any `527256 Apr 26 15:41 src/.libs/libwolfssl.a`