### PR TITLE
20230427-linuxkm-simd-fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8634,8 +8634,8 @@ fi
 
 if test "$ENABLED_REPRODUCIBLE_BUILD" != "yes"
 then
-    echo "#define LIBWOLFSSL_CONFIGURE_ARGS \"$ac_configure_args\"" > "${output_objdir}/.build_params" &&
-        echo "#define LIBWOLFSSL_GLOBAL_CFLAGS \"$CPPFLAGS $AM_CPPFLAGS $CFLAGS $AM_CFLAGS\" LIBWOLFSSL_GLOBAL_EXTRA_CFLAGS" >> "${output_objdir}/.build_params" ||
+    echo "#define LIBWOLFSSL_CONFIGURE_ARGS \"$ac_configure_args\"" | sed 's/\\/\\\\/g' > "${output_objdir}/.build_params" &&
+        echo "#define LIBWOLFSSL_GLOBAL_CFLAGS \"$CPPFLAGS $AM_CPPFLAGS $CFLAGS $AM_CFLAGS\" LIBWOLFSSL_GLOBAL_EXTRA_CFLAGS" | sed 's/\\/\\\\/g' >> "${output_objdir}/.build_params" ||
         AC_MSG_ERROR([Couldn't create ${output_objdir}/.build_params.])
 else
     rm -f "${output_objdir}/.build_params"
@@ -8680,8 +8680,9 @@ for option in $CPPFLAGS $AM_CPPFLAGS $CFLAGS $AM_CFLAGS; do
     opt_type=$(echo $option | $TRIM )
     case "$opt_type" in
     -D)
-        RHS_only=$(echo $option | sed 's/^-D//')
-        noequalsign=$(echo $RHS_only | sed 's/=/ /')
+        option=$(echo "$option" | tr -d '\\')
+        RHS_only=$(echo "$option" | sed 's/^-D//')
+        noequalsign=$(echo "$RHS_only" | tr '=' ' ')
         if test "$noequalsign" = "NDEBUG" || test "$noequalsign" = "DEBUG"
         then
             if test "$verbose" = "yes"; then
@@ -8697,7 +8698,9 @@ for option in $CPPFLAGS $AM_CPPFLAGS $CFLAGS $AM_CFLAGS; do
             echo "#ifndef WOLFSSL_OPTIONS_IGNORE_SYS" >> $OPTION_FILE
         fi
 
-        noarg=$(echo "$RHS_only" | sed 's/=.*//')
+        # note need to use both autotools-style [] quoting and shell-style ''
+        # quoting for sed script with [] character set expression here.
+        noarg=$(echo "$RHS_only" | sed ['s/\(([^=)]*)\)\{0,1\}=.*//'])
         echo "#undef  $noarg" >> $OPTION_FILE
         echo "#define $noequalsign" >> $OPTION_FILE
 

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -24,6 +24,10 @@
     #include <config.h>
 #endif
 
+#ifdef WOLFSSL_LINUXKM
+    #define WOLFSSL_NEED_LINUX_CURRENT
+#endif
+
 #include <wolfssl/wolfcrypt/settings.h>
 
 /* check old macros @wc_fips */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -789,6 +789,12 @@ static int wolfssl_pb_print(const char* msg, ...)
     }
 #endif
 
+#ifdef TEST_ALWAYS_RUN_TO_END
+    #define TEST_FAIL(msg, retval) do { last_failed_test_ret = (retval); render_error_message(msg, retval); } while (0)
+#elif !defined(TEST_FAIL)
+    #define TEST_FAIL(msg, retval) return err_sys(msg, retval)
+#endif
+
 #ifdef HAVE_STACK_SIZE
 THREAD_RETURN WOLFSSL_THREAD wolfcrypt_test(void* args)
 #else
@@ -798,6 +804,9 @@ int wolfcrypt_test(void* args)
     int ret;
 #ifdef WOLFSSL_TRACK_MEMORY_VERBOSE
     long heap_baselineAllocs, heap_baselineBytes;
+#endif
+#ifdef TEST_ALWAYS_RUN_TO_END
+    int last_failed_test_ret = 0;
 #endif
     STACK_SIZE_INIT();
 
@@ -918,29 +927,29 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 
 #ifdef HAVE_SELFTEST
     if ( (ret = wolfCrypt_SelfTest()) != 0)
-        return err_sys("CAVP selftest failed!\n", ret);
+        TEST_FAIL("CAVP selftest failed!\n", ret);
     else
         TEST_PASS("CAVP selftest passed!\n");
 #endif
 
     if ( (ret = error_test()) != 0)
-        return err_sys("error    test failed!\n", ret);
+        TEST_FAIL("error    test failed!\n", ret);
     else
         TEST_PASS("error    test passed!\n");
 
     if ( (ret = memory_test()) != 0)
-        return err_sys("MEMORY   test failed!\n", ret);
+        TEST_FAIL("MEMORY   test failed!\n", ret);
     else
         TEST_PASS("MEMORY   test passed!\n");
 
 #ifndef NO_CODING
     if ( (ret = base64_test()) != 0)
-        return err_sys("base64   test failed!\n", ret);
+        TEST_FAIL("base64   test failed!\n", ret);
     else
         TEST_PASS("base64   test passed!\n");
 #ifdef WOLFSSL_BASE16
     if ( (ret = base16_test()) != 0)
-        return err_sys("base16   test failed!\n", ret);
+        TEST_FAIL("base16   test failed!\n", ret);
     else
         TEST_PASS("base16   test passed!\n");
 #endif
@@ -948,70 +957,70 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 
 #ifndef NO_ASN
     if ( (ret = asn_test()) != 0)
-        return err_sys("asn      test failed!\n", ret);
+        TEST_FAIL("asn      test failed!\n", ret);
     else
         TEST_PASS("asn      test passed!\n");
 #endif
 
 #ifndef WC_NO_RNG
     if ( (ret = random_test()) != 0)
-        return err_sys("RANDOM   test failed!\n", ret);
+        TEST_FAIL("RANDOM   test failed!\n", ret);
     else
         TEST_PASS("RANDOM   test passed!\n");
 #endif /* WC_NO_RNG */
 
 #ifndef NO_MD5
     if ( (ret = md5_test()) != 0)
-        return err_sys("MD5      test failed!\n", ret);
+        TEST_FAIL("MD5      test failed!\n", ret);
     else
         TEST_PASS("MD5      test passed!\n");
 #endif
 
 #ifdef WOLFSSL_MD2
     if ( (ret = md2_test()) != 0)
-        return err_sys("MD2      test failed!\n", ret);
+        TEST_FAIL("MD2      test failed!\n", ret);
     else
         TEST_PASS("MD2      test passed!\n");
 #endif
 
 #ifndef NO_MD4
     if ( (ret = md4_test()) != 0)
-        return err_sys("MD4      test failed!\n", ret);
+        TEST_FAIL("MD4      test failed!\n", ret);
     else
         TEST_PASS("MD4      test passed!\n");
 #endif
 
 #ifndef NO_SHA
     if ( (ret = sha_test()) != 0)
-        return err_sys("SHA      test failed!\n", ret);
+        TEST_FAIL("SHA      test failed!\n", ret);
     else
         TEST_PASS("SHA      test passed!\n");
 #endif
 
 #ifdef WOLFSSL_SHA224
     if ( (ret = sha224_test()) != 0)
-        return err_sys("SHA-224  test failed!\n", ret);
+        TEST_FAIL("SHA-224  test failed!\n", ret);
     else
         TEST_PASS("SHA-224  test passed!\n");
 #endif
 
 #ifndef NO_SHA256
     if ( (ret = sha256_test()) != 0)
-        return err_sys("SHA-256  test failed!\n", ret);
+        TEST_FAIL("SHA-256  test failed!\n", ret);
     else
         TEST_PASS("SHA-256  test passed!\n");
 #endif
 
 #ifdef WOLFSSL_SHA384
     if ( (ret = sha384_test()) != 0)
-        return err_sys("SHA-384  test failed!\n", ret);
+        TEST_FAIL("SHA-384  test failed!\n", ret);
     else
         TEST_PASS("SHA-384  test passed!\n");
 #endif
 
 #ifdef WOLFSSL_SHA512
     if ((ret = sha512_test()) != 0) {
-        return err_sys("SHA-512  test failed!\n", ret);
+        TEST_FAIL("SHA-512  test failed!\n", ret);
     }
     else {
         TEST_PASS("SHA-512  test passed!\n");
@@ -1020,7 +1029,7 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 #if !defined(WOLFSSL_NOSHA512_224) && \
    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)) && !defined(HAVE_SELFTEST)
     if ((ret = sha512_224_test()) != 0) {
-        return err_sys("SHA-512/224  test failed!\n", ret);
+        TEST_FAIL("SHA-512/224  test failed!\n", ret);
     }
     else
         TEST_PASS("SHA-512/224  test passed!\n");
@@ -1029,7 +1038,7 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 #if !defined(WOLFSSL_NOSHA512_256) && \
    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)) && !defined(HAVE_SELFTEST)
     if ((ret = sha512_256_test()) != 0) {
-        return err_sys("SHA-512/256  test failed!\n", ret);
+        TEST_FAIL("SHA-512/256  test failed!\n", ret);
     }
     else
         TEST_PASS("SHA-512/256  test passed!\n");
@@ -1039,48 +1048,48 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 
 #ifdef WOLFSSL_SHA3
     if ( (ret = sha3_test()) != 0)
-        return err_sys("SHA-3    test failed!\n", ret);
+        TEST_FAIL("SHA-3    test failed!\n", ret);
     else
         TEST_PASS("SHA-3    test passed!\n");
 #endif
 
 #ifdef WOLFSSL_SHAKE128
     if ( (ret = shake128_test()) != 0)
-        return err_sys("SHAKE128 test failed!\n", ret);
+        TEST_FAIL("SHAKE128 test failed!\n", ret);
     else
         TEST_PASS("SHAKE128 test passed!\n");
 #endif
 
 #ifdef WOLFSSL_SHAKE256
     if ( (ret = shake256_test()) != 0)
-        return err_sys("SHAKE256 test failed!\n", ret);
+        TEST_FAIL("SHAKE256 test failed!\n", ret);
     else
         TEST_PASS("SHAKE256 test passed!\n");
 #endif
 
 #ifndef NO_HASH_WRAPPER
     if ( (ret = hash_test()) != 0)
-        return err_sys("Hash     test failed!\n", ret);
+        TEST_FAIL("Hash     test failed!\n", ret);
     else
         TEST_PASS("Hash     test passed!\n");
 #endif
 
 #ifdef WOLFSSL_RIPEMD
     if ( (ret = ripemd_test()) != 0)
-        return err_sys("RIPEMD   test failed!\n", ret);
+        TEST_FAIL("RIPEMD   test failed!\n", ret);
     else
         TEST_PASS("RIPEMD   test passed!\n");
 #endif
 
 #ifdef HAVE_BLAKE2
     if ( (ret = blake2b_test()) != 0)
-        return err_sys("BLAKE2b  test failed!\n", ret);
+        TEST_FAIL("BLAKE2b  test failed!\n", ret);
     else
         TEST_PASS("BLAKE2b  test passed!\n");
 #endif
 #ifdef HAVE_BLAKE2S
     if ( (ret = blake2s_test()) != 0)
-        return err_sys("BLAKE2s  test failed!\n", ret);
+        TEST_FAIL("BLAKE2s  test failed!\n", ret);
     else
         TEST_PASS("BLAKE2s  test passed!\n");
 #endif
@@ -1089,42 +1098,42 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
     #if !defined(NO_MD5) && !(defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) \
                               && (HAVE_FIPS_VERSION >= 5))
         if ( (ret = hmac_md5_test()) != 0)
-            return err_sys("HMAC-MD5 test failed!\n", ret);
+            TEST_FAIL("HMAC-MD5 test failed!\n", ret);
         else
             TEST_PASS("HMAC-MD5 test passed!\n");
     #endif
 
     #ifndef NO_SHA
     if ( (ret = hmac_sha_test()) != 0)
-        return err_sys("HMAC-SHA test failed!\n", ret);
+        TEST_FAIL("HMAC-SHA test failed!\n", ret);
     else
         TEST_PASS("HMAC-SHA test passed!\n");
     #endif
 
     #ifdef WOLFSSL_SHA224
         if ( (ret = hmac_sha224_test()) != 0)
-            return err_sys("HMAC-SHA224 test failed!\n", ret);
+            TEST_FAIL("HMAC-SHA224 test failed!\n", ret);
         else
             TEST_PASS("HMAC-SHA224 test passed!\n");
     #endif
 
     #ifndef NO_SHA256
         if ( (ret = hmac_sha256_test()) != 0)
-            return err_sys("HMAC-SHA256 test failed!\n", ret);
+            TEST_FAIL("HMAC-SHA256 test failed!\n", ret);
         else
             TEST_PASS("HMAC-SHA256 test passed!\n");
     #endif
 
     #ifdef WOLFSSL_SHA384
         if ( (ret = hmac_sha384_test()) != 0)
-            return err_sys("HMAC-SHA384 test failed!\n", ret);
+            TEST_FAIL("HMAC-SHA384 test failed!\n", ret);
         else
             TEST_PASS("HMAC-SHA384 test passed!\n");
     #endif
 
     #ifdef WOLFSSL_SHA512
         if ( (ret = hmac_sha512_test()) != 0)
-            return err_sys("HMAC-SHA512 test failed!\n", ret);
+            TEST_FAIL("HMAC-SHA512 test failed!\n", ret);
         else
             TEST_PASS("HMAC-SHA512 test passed!\n");
     #endif
@@ -1133,7 +1142,7 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
       !defined(WOLFSSL_NOSHA3_224) && !defined(WOLFSSL_NOSHA3_256) && \
       !defined(WOLFSSL_NOSHA3_384) && !defined(WOLFSSL_NOSHA3_512)
         if ( (ret = hmac_sha3_test()) != 0)
-            return err_sys("HMAC-SHA3   test failed!\n", ret);
+            TEST_FAIL("HMAC-SHA3   test failed!\n", ret);
         else
             TEST_PASS("HMAC-SHA3   test passed!\n");
     #endif
@@ -1141,7 +1150,7 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
     #if defined(HAVE_HKDF) && !defined(NO_HMAC)
         PRIVATE_KEY_UNLOCK();
         if ( (ret = hkdf_test()) != 0)
-            return err_sys("HMAC-KDF    test failed!\n", ret);
+            TEST_FAIL("HMAC-KDF    test failed!\n", ret);
         else
             TEST_PASS("HMAC-KDF    test passed!\n");
         PRIVATE_KEY_LOCK();
@@ -1151,7 +1160,7 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 #ifdef WOLFSSL_WOLFSSH
     PRIVATE_KEY_UNLOCK();
     if ( (ret = sshkdf_test()) != 0)
-        return err_sys("SSH-KDF     test failed!\n", ret);
+        TEST_FAIL("SSH-KDF     test failed!\n", ret);
     else
         TEST_PASS("SSH-KDF     test passed!\n");
     PRIVATE_KEY_LOCK();
@@ -1160,7 +1169,7 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 #ifdef WOLFSSL_TLS13
     PRIVATE_KEY_UNLOCK();
     if ( (ret = tls13_kdf_test()) != 0)
-        return err_sys("TLSv1.3 KDF test failed!\n", ret);
+        TEST_FAIL("TLSv1.3 KDF test failed!\n", ret);
     else
         TEST_PASS("TLSv1.3 KDF test passed!\n");
     PRIVATE_KEY_LOCK();
@@ -1168,14 +1177,14 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 
 #if defined(HAVE_X963_KDF) && defined(HAVE_ECC)
     if ( (ret = x963kdf_test()) != 0)
-        return err_sys("X963-KDF    test failed!\n", ret);
+        TEST_FAIL("X963-KDF    test failed!\n", ret);
     else
         TEST_PASS("X963-KDF    test passed!\n");
 #endif
 
 #if defined(HAVE_HPKE) && defined(HAVE_ECC) && defined(HAVE_AESGCM)
     if ( (ret = hpke_test()) != 0)
-        return err_sys("HPKE     test failed!\n", ret);
+        TEST_FAIL("HPKE     test failed!\n", ret);
     else
         TEST_PASS("HPKE     test passed!\n");
 #endif
@@ -1183,97 +1192,97 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 #if defined(HAVE_AESGCM) && defined(WOLFSSL_AES_128) && \
    !defined(WOLFSSL_AFALG_XILINX_AES) && !defined(WOLFSSL_XILINX_CRYPT)
     if ( (ret = gmac_test()) != 0)
-        return err_sys("GMAC     test failed!\n", ret);
+        TEST_FAIL("GMAC     test failed!\n", ret);
     else
         TEST_PASS("GMAC     test passed!\n");
 #endif
 
 #ifdef WC_RC2
     if ( (ret = rc2_test()) != 0)
-        return err_sys("RC2      test failed!\n", ret);
+        TEST_FAIL("RC2      test failed!\n", ret);
     else
         TEST_PASS("RC2      test passed!\n");
 #endif
 
 #ifndef NO_RC4
     if ( (ret = arc4_test()) != 0)
-        return err_sys("ARC4     test failed!\n", ret);
+        TEST_FAIL("ARC4     test failed!\n", ret);
     else
         TEST_PASS("ARC4     test passed!\n");
 #endif
 
 #ifdef HAVE_CHACHA
     if ( (ret = chacha_test()) != 0)
-        return err_sys("Chacha   test failed!\n", ret);
+        TEST_FAIL("Chacha   test failed!\n", ret);
     else
         TEST_PASS("Chacha   test passed!\n");
 #endif
 
 #ifdef HAVE_XCHACHA
     if ( (ret = XChaCha_test()) != 0)
-        return err_sys("XChacha  test failed!\n", ret);
+        TEST_FAIL("XChacha  test failed!\n", ret);
     else
         TEST_PASS("XChacha  test passed!\n");
 #endif
 
 #ifdef HAVE_POLY1305
     if ( (ret = poly1305_test()) != 0)
-        return err_sys("POLY1305 test failed!\n", ret);
+        TEST_FAIL("POLY1305 test failed!\n", ret);
     else
         TEST_PASS("POLY1305 test passed!\n");
 #endif
 
 #if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
     if ( (ret = chacha20_poly1305_aead_test()) != 0)
-        return err_sys("ChaCha20-Poly1305 AEAD test failed!\n", ret);
+        TEST_FAIL("ChaCha20-Poly1305 AEAD test failed!\n", ret);
     else
         TEST_PASS("ChaCha20-Poly1305 AEAD test passed!\n");
 #endif
 
 #if defined(HAVE_XCHACHA) && defined(HAVE_POLY1305)
     if ( (ret = XChaCha20Poly1305_test()) != 0)
-        return err_sys("XChaCha20-Poly1305 AEAD test failed!\n", ret);
+        TEST_FAIL("XChaCha20-Poly1305 AEAD test failed!\n", ret);
     else
         TEST_PASS("XChaCha20-Poly1305 AEAD test passed!\n");
 #endif
 
 #ifndef NO_DES3
     if ( (ret = des_test()) != 0)
-        return err_sys("DES      test failed!\n", ret);
+        TEST_FAIL("DES      test failed!\n", ret);
     else
         TEST_PASS("DES      test passed!\n");
 #endif
 
 #ifndef NO_DES3
     if ( (ret = des3_test()) != 0)
-        return err_sys("DES3     test failed!\n", ret);
+        TEST_FAIL("DES3     test failed!\n", ret);
     else
         TEST_PASS("DES3     test passed!\n");
 #endif
 
 #ifndef NO_AES
     if ( (ret = aes_test()) != 0)
-        return err_sys("AES      test failed!\n", ret);
+        TEST_FAIL("AES      test failed!\n", ret);
     else
         TEST_PASS("AES      test passed!\n");
 
 #ifdef WOLFSSL_AES_192
     if ( (ret = aes192_test()) != 0)
-        return err_sys("AES192   test failed!\n", ret);
+        TEST_FAIL("AES192   test failed!\n", ret);
     else
         TEST_PASS("AES192   test passed!\n");
 #endif
 
 #ifdef WOLFSSL_AES_256
     if ( (ret = aes256_test()) != 0)
-        return err_sys("AES256   test failed!\n", ret);
+        TEST_FAIL("AES256   test failed!\n", ret);
     else
         TEST_PASS("AES256   test passed!\n");
 #endif
 
 #ifdef WOLFSSL_AES_OFB
     if ( (ret = aesofb_test()) != 0)
-        return err_sys("AES-OFB  test failed!\n", ret);
+        TEST_FAIL("AES-OFB  test failed!\n", ret);
     else
         TEST_PASS("AESOFB   test passed!\n");
 #endif
@@ -1281,13 +1290,13 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 #ifdef HAVE_AESGCM
     #if !defined(WOLFSSL_AFALG) && !defined(WOLFSSL_DEVCRYPTO)
     if ( (ret = aesgcm_test()) != 0)
-        return err_sys("AES-GCM  test failed!\n", ret);
+        TEST_FAIL("AES-GCM  test failed!\n", ret);
     #endif
     #if !defined(WOLFSSL_AFALG_XILINX_AES) && !defined(WOLFSSL_XILINX_CRYPT) && \
         !defined(WOLFSSL_KCAPI_AES) && !(defined(WOLF_CRYPTO_CB) && \
             (defined(HAVE_INTEL_QA_SYNC) || defined(HAVE_CAVIUM_OCTEON_SYNC)))
     if ((ret = aesgcm_default_test()) != 0) {
-        return err_sys("AES-GCM  test failed!\n", ret);
+        TEST_FAIL("AES-GCM  test failed!\n", ret);
     }
     #endif
     if (ret == 0) {
@@ -1297,19 +1306,19 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 
 #if defined(HAVE_AESCCM) && defined(WOLFSSL_AES_128)
     if ( (ret = aesccm_test()) != 0)
-        return err_sys("AES-CCM  test failed!\n", ret);
+        TEST_FAIL("AES-CCM  test failed!\n", ret);
     else
         TEST_PASS("AES-CCM  test passed!\n");
 #endif
 #ifdef HAVE_AES_KEYWRAP
     if ( (ret = aeskeywrap_test()) != 0)
-        return err_sys("AES Key Wrap test failed!\n", ret);
+        TEST_FAIL("AES Key Wrap test failed!\n", ret);
     else
         TEST_PASS("AES Key Wrap test passed!\n");
 #endif
 #ifdef WOLFSSL_AES_SIV
     if ( (ret = aes_siv_test()) != 0)
-        return err_sys("AES-SIV  test failed!\n", ret);
+        TEST_FAIL("AES-SIV  test failed!\n", ret);
     else
         TEST_PASS("AES-SIV  test passed!\n");
 #endif
@@ -1317,7 +1326,7 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 
 #ifdef HAVE_CAMELLIA
     if ( (ret = camellia_test()) != 0)
-        return err_sys("CAMELLIA test failed!\n", ret);
+        TEST_FAIL("CAMELLIA test failed!\n", ret);
     else
         TEST_PASS("CAMELLIA test passed!\n");
 #endif
@@ -1325,12 +1334,12 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 #if !defined(NO_RSA)
     #ifdef WC_RSA_NO_PADDING
     if ( (ret = rsa_no_pad_test()) != 0)
-        return err_sys("RSA NOPAD test failed!\n", ret);
+        TEST_FAIL("RSA NOPAD test failed!\n", ret);
     else
         TEST_PASS("RSA NOPAD test passed!\n");
     #endif
     if ( (ret = rsa_test()) != 0)
-        return err_sys("RSA      test failed!\n", ret);
+        TEST_FAIL("RSA      test failed!\n", ret);
     else
         TEST_PASS("RSA      test passed!\n");
 #endif
@@ -1338,7 +1347,7 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 #ifndef NO_DH
     PRIVATE_KEY_UNLOCK();
     if ( (ret = dh_test()) != 0)
-        return err_sys("DH       test failed!\n", ret);
+        TEST_FAIL("DH       test failed!\n", ret);
     else
         TEST_PASS("DH       test passed!\n");
     PRIVATE_KEY_LOCK();
@@ -1346,49 +1355,49 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 
 #ifndef NO_DSA
     if ( (ret = dsa_test()) != 0)
-        return err_sys("DSA      test failed!\n", ret);
+        TEST_FAIL("DSA      test failed!\n", ret);
     else
         TEST_PASS("DSA      test passed!\n");
 #endif
 
 #ifdef WOLFCRYPT_HAVE_SRP
     if ( (ret = srp_test()) != 0)
-        return err_sys("SRP      test failed!\n", ret);
+        TEST_FAIL("SRP      test failed!\n", ret);
     else
         TEST_PASS("SRP      test passed!\n");
 #endif
 
 #ifndef NO_PWDBASED
     if ( (ret = pwdbased_test()) != 0)
-        return err_sys("PWDBASED test failed!\n", ret);
+        TEST_FAIL("PWDBASED test failed!\n", ret);
     else
         TEST_PASS("PWDBASED test passed!\n");
 #endif
 
 #if defined(OPENSSL_EXTRA) && !defined(WOLFCRYPT_ONLY)
     if ( (ret = openssl_test()) != 0)
-        return err_sys("OPENSSL  test failed!\n", ret);
+        TEST_FAIL("OPENSSL  test failed!\n", ret);
     else
         TEST_PASS("OPENSSL  test passed!\n");
 
     if ( (ret = openSSL_evpMD_test()) != 0)
-        return err_sys("OPENSSL (EVP MD) test failed!\n", ret);
+        TEST_FAIL("OPENSSL (EVP MD) test failed!\n", ret);
     else
         TEST_PASS("OPENSSL (EVP MD) passed!\n");
 
     if ( (ret = openssl_pkey0_test()) != 0)
-        return err_sys("OPENSSL (PKEY0) test failed!\n", ret);
+        TEST_FAIL("OPENSSL (PKEY0) test failed!\n", ret);
     else
         TEST_PASS("OPENSSL (PKEY0) passed!\n");
 
     if ( (ret = openssl_pkey1_test()) != 0)
-        return err_sys("OPENSSL (PKEY1) test failed!\n", ret);
+        TEST_FAIL("OPENSSL (PKEY1) test failed!\n", ret);
     else
         TEST_PASS("OPENSSL (PKEY1) passed!\n");
 
     #if !defined(WOLF_CRYPTO_CB_ONLY_RSA) && !defined(WOLF_CRYPTO_CB_ONLY_ECC)
     if ( (ret = openssl_evpSig_test()) != 0)
-        return err_sys("OPENSSL (EVP Sign/Verify) test failed!\n", ret);
+        TEST_FAIL("OPENSSL (EVP Sign/Verify) test failed!\n", ret);
     else
         TEST_PASS("OPENSSL (EVP Sign/Verify) passed!\n");
     #endif
@@ -1397,14 +1406,14 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 #if defined(HAVE_ECC)
     PRIVATE_KEY_UNLOCK();
     if ( (ret = ecc_test()) != 0)
-        return err_sys("ECC      test failed!\n", ret);
+        TEST_FAIL("ECC      test failed!\n", ret);
     else
         TEST_PASS("ECC      test passed!\n");
     PRIVATE_KEY_LOCK();
     #if defined(HAVE_ECC_ENCRYPT) && defined(HAVE_AES_CBC) && \
         (defined(WOLFSSL_AES_128) || defined(WOLFSSL_AES_256))
         if ( (ret = ecc_encrypt_test()) != 0)
-            return err_sys("ECC Enc  test failed!\n", ret);
+            TEST_FAIL("ECC Enc  test failed!\n", ret);
         else
             TEST_PASS("ECC Enc  test passed!\n");
     #endif
@@ -1414,7 +1423,7 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
         !defined(WOLF_CRYPTO_CB_ONLY_ECC)
         /* skip for ATECC508/608A, cannot import private key buffers */
         if ( (ret = ecc_test_buffers()) != 0)
-            return err_sys("ECC buffer test failed!\n", ret);
+            TEST_FAIL("ECC buffer test failed!\n", ret);
         else
             TEST_PASS("ECC buffer test passed!\n");
     #endif
@@ -1423,7 +1432,7 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 #if !defined(NO_ASN_TIME) && !defined(NO_RSA) && defined(WOLFSSL_TEST_CERT) && \
     !defined(NO_FILESYSTEM)
     if ( (ret = cert_test()) != 0)
-        return err_sys("CERT     test failed!\n", ret);
+        TEST_FAIL("CERT     test failed!\n", ret);
     else
         TEST_PASS("CERT     test passed!\n");
 #endif
@@ -1431,7 +1440,7 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 #if defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_TEST_CERT) && \
    !defined(NO_FILESYSTEM) && !defined(NO_RSA) && defined(WOLFSSL_GEN_CERT)
     if ( (ret = certext_test()) != 0)
-        return err_sys("CERT EXT test failed!\n", ret);
+        TEST_FAIL("CERT EXT test failed!\n", ret);
     else
         TEST_PASS("CERT EXT test passed!\n");
 #endif
@@ -1439,76 +1448,76 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 #if defined(WOLFSSL_CERT_GEN_CACHE) && defined(WOLFSSL_TEST_CERT) && \
     defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_CERT_GEN)
     if ( (ret = decodedCertCache_test()) != 0)
-        return err_sys("DECODED CERT CACHE test failed!\n", ret);
+        TEST_FAIL("DECODED CERT CACHE test failed!\n", ret);
     else
         TEST_PASS("DECODED CERT CACHE test passed!\n");
 #endif
 
 #ifdef HAVE_CURVE25519
     if ( (ret = curve25519_test()) != 0)
-        return err_sys("CURVE25519 test failed!\n", ret);
+        TEST_FAIL("CURVE25519 test failed!\n", ret);
     else
         TEST_PASS("CURVE25519 test passed!\n");
 #endif
 
 #ifdef HAVE_ED25519
     if ( (ret = ed25519_test()) != 0)
-        return err_sys("ED25519  test failed!\n", ret);
+        TEST_FAIL("ED25519  test failed!\n", ret);
     else
         TEST_PASS("ED25519  test passed!\n");
 #endif
 
 #ifdef HAVE_CURVE448
     if ( (ret = curve448_test()) != 0)
-        return err_sys("CURVE448 test failed!\n", ret);
+        TEST_FAIL("CURVE448 test failed!\n", ret);
     else
         TEST_PASS("CURVE448 test passed!\n");
 #endif
 
 #ifdef HAVE_ED448
     if ( (ret = ed448_test()) != 0)
-        return err_sys("ED448    test failed!\n", ret);
+        TEST_FAIL("ED448    test failed!\n", ret);
     else
         TEST_PASS("ED448    test passed!\n");
 #endif
 
 #ifdef WOLFSSL_HAVE_KYBER
     if ( (ret = kyber_test()) != 0)
-        return err_sys("KYBER    test failed!\n", ret);
+        TEST_FAIL("KYBER    test failed!\n", ret);
     else
         TEST_PASS("KYBER    test passed!\n");
 #endif
 
 #ifdef WOLFCRYPT_HAVE_ECCSI
     if ( (ret = eccsi_test()) != 0)
-        return err_sys("ECCSI    test failed!\n", ret);
+        TEST_FAIL("ECCSI    test failed!\n", ret);
     else
         TEST_PASS("ECCSI    test passed!\n");
 #endif
 #ifdef WOLFCRYPT_HAVE_SAKKE
     if ( (ret = sakke_test()) != 0)
-        return err_sys("SAKKE    test failed!\n", ret);
+        TEST_FAIL("SAKKE    test failed!\n", ret);
     else
         TEST_PASS("SAKKE    test passed!\n");
 #endif
 
 #if defined(WOLFSSL_CMAC) && !defined(NO_AES)
     if ( (ret = cmac_test()) != 0)
-        return err_sys("CMAC     test failed!\n", ret);
+        TEST_FAIL("CMAC     test failed!\n", ret);
     else
         TEST_PASS("CMAC     test passed!\n");
 #endif
 
 #if defined(WOLFSSL_SIPHASH)
     if ( (ret = siphash_test()) != 0)
-        return err_sys("SipHash  test failed!\n", ret);
+        TEST_FAIL("SipHash  test failed!\n", ret);
     else
         TEST_PASS("SipHash  test passed!\n");
 #endif
 
 #ifdef HAVE_LIBZ
     if ( (ret = compress_test()) != 0)
-        return err_sys("COMPRESS test failed!\n", ret);
+        TEST_FAIL("COMPRESS test failed!\n", ret);
     else
         TEST_PASS("COMPRESS test passed!\n");
 #endif
@@ -1516,29 +1525,29 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 #ifdef HAVE_PKCS7
     #ifndef NO_PKCS7_ENCRYPTED_DATA
         if ( (ret = pkcs7encrypted_test()) != 0)
-            return err_sys("PKCS7encrypted  test failed!\n", ret);
+            TEST_FAIL("PKCS7encrypted  test failed!\n", ret);
         else
             TEST_PASS("PKCS7encrypted  test passed!\n");
     #endif
     #if defined(HAVE_LIBZ) && !defined(NO_PKCS7_COMPRESSED_DATA)
         if ( (ret = pkcs7compressed_test()) != 0)
-            return err_sys("PKCS7compressed test failed!\n", ret);
+            TEST_FAIL("PKCS7compressed test failed!\n", ret);
         else
             TEST_PASS("PKCS7compressed test passed!\n");
     #endif
     if ( (ret = pkcs7signed_test()) != 0)
-        return err_sys("PKCS7signed     test failed!\n", ret);
+        TEST_FAIL("PKCS7signed     test failed!\n", ret);
     else
         TEST_PASS("PKCS7signed     test passed!\n");
 
     if ( (ret = pkcs7enveloped_test()) != 0)
-        return err_sys("PKCS7enveloped  test failed!\n", ret);
+        TEST_FAIL("PKCS7enveloped  test failed!\n", ret);
     else
         TEST_PASS("PKCS7enveloped  test passed!\n");
 
     #if defined(HAVE_AESGCM) || defined(HAVE_AESCCM)
         if ( (ret = pkcs7authenveloped_test()) != 0)
-            return err_sys("PKCS7authenveloped  test failed!\n", ret);
+            TEST_FAIL("PKCS7authenveloped  test failed!\n", ret);
         else
             TEST_PASS("PKCS7authenveloped  test passed!\n");
     #endif
@@ -1547,14 +1556,14 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 #if defined(WOLFSSL_PUBLIC_MP) && \
     (defined(WOLFSSL_SP_MATH_ALL) || defined(USE_FAST_MATH))
     if ( (ret = mp_test()) != 0)
-        return err_sys("mp       test failed!\n", ret);
+        TEST_FAIL("mp       test failed!\n", ret);
     else
         TEST_PASS("mp       test passed!\n");
 #endif
 
 #if defined(WOLFSSL_PUBLIC_MP) && defined(WOLFSSL_KEY_GEN)
     if ( (ret = prime_test()) != 0)
-        return err_sys("prime    test failed!\n", ret);
+        TEST_FAIL("prime    test failed!\n", ret);
     else
         TEST_PASS("prime    test passed!\n");
 #endif
@@ -1563,19 +1572,19 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
     (defined(WOLFSSL_TEST_CERT) || defined(OPENSSL_EXTRA) || \
      defined(OPENSSL_EXTRA_X509_SMALL))
     if ( (ret = berder_test()) != 0)
-        return err_sys("ber-der  test failed!\n", ret);
+        TEST_FAIL("ber-der  test failed!\n", ret);
     else
         TEST_PASS("ber-der  test passed!\n");
 #endif
 
     if ( (ret = logging_test()) != 0)
-        return err_sys("logging  test failed!\n", ret);
+        TEST_FAIL("logging  test failed!\n", ret);
     else
         TEST_PASS("logging  test passed!\n");
 
 #if !defined(NO_ASN) && !defined(NO_ASN_TIME)
     if ( (ret = time_test()) != 0)
-        return err_sys("time test failed!\n", ret);
+        TEST_FAIL("time test failed!\n", ret);
     else
         TEST_PASS("time test passed!\n");
 #endif
@@ -1585,20 +1594,20 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 #else
     if ((ret = mutex_test()) != 0)
 #endif
-        return err_sys("mutex    test failed!\n", ret);
+        TEST_FAIL("mutex    test failed!\n", ret);
     else
         TEST_PASS("mutex    test passed!\n");
 
 #if defined(USE_WOLFSSL_MEMORY) && !defined(FREERTOS)
     if ( (ret = memcb_test()) != 0)
-        return err_sys("memcb    test failed!\n", ret);
+        TEST_FAIL("memcb    test failed!\n", ret);
     else
         TEST_PASS("memcb    test passed!\n");
 #endif
 
 #ifdef WOLFSSL_CAAM_BLOB
     if ( (ret = blob_test()) != 0)
-        return err_sys("blob     test failed!\n", ret);
+        TEST_FAIL("blob     test failed!\n", ret);
     else
         TEST_PASS("blob     test passed!\n");
 #endif
@@ -1607,14 +1616,14 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
     !(defined(HAVE_INTEL_QAT_SYNC) || defined(HAVE_CAVIUM_OCTEON_SYNC) || \
       defined(WOLFSSL_QNX_CAAM))
     if ( (ret = cryptocb_test()) != 0)
-        return err_sys("crypto callback test failed!\n", ret);
+        TEST_FAIL("crypto callback test failed!\n", ret);
     else
         TEST_PASS("crypto callback test passed!\n");
 #endif
 
 #ifdef WOLFSSL_CERT_PIV
     if ( (ret = certpiv_test()) != 0)
-        return err_sys("cert piv test failed!\n", ret);
+        TEST_FAIL("cert piv test failed!\n", ret);
     else
         TEST_PASS("cert piv test passed!\n");
 #endif
@@ -1635,6 +1644,11 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
     /* cleanup the thread if fixed point cache is enabled and have thread local */
 #if defined(HAVE_THREAD_LS) && defined(HAVE_ECC) && defined(FP_ECC)
     wc_ecc_fp_free();
+#endif
+
+#ifdef TEST_ALWAYS_RUN_TO_END
+    if (last_failed_test_ret != 0)
+        ret = last_failed_test_ret;
 #endif
 
     if (args)


### PR DESCRIPTION
linuxkm: in `{save,restore}_vector_registers_x86()`, check if vector register file has already been saved and invalidated, and if so, inhibit the `kernel_fpu_{begin,end}()` wrap and instead just use `preempt_{disable,enable}()` wraps.

`wolfcrypt/test/test.c`: add `TEST_FAIL()` macro (counterpart to incumbent `TEST_PASS()`), by default same as incumbent functionality, but `#ifdef TEST_ALWAYS_RUN_TO_END`, print errors as they occur but continue to end.

`configure.ac`: escape backslashes when generating preprocessor directives for `.build_params`; delete backslashes and process parenthesized arguments correctly when generating `options.h`.

tested with `wolfssl-multi-test.sh ... super-quick-check linuxkm-legacy-.\*` and module load with in-kernel `wolfcrypt_test()` under `qemu-system` on kernels 5.10, 5.17, and 6.3.
