### PR TITLE
Zephyr misc fixes for TLS

### DIFF
--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -516,7 +516,6 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #include <zephyr/fs/fs.h>
 
     #define XFILE      struct fs_file_t*
-    #define STAT       struct fs_dirent
 
     /* These are our wrappers for opening and closing files to
      * make the API more POSIX like. */
@@ -537,6 +536,7 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XFGETS(b,s,f)       -2 /* Not ported yet */
 
     #define XSTAT               fs_stat
+    #define XSTAT_TYPE          struct fs_dirent
     #define XS_ISREG(s)         (s == FS_DIR_ENTRY_FILE)
     #define SEPARATOR_CHAR      ':'
 

--- a/zephyr/samples/wolfssl_tls_sock/CMakeLists.txt
+++ b/zephyr/samples/wolfssl_tls_sock/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-project(wolfssl_tls_threaded)
+project(wolfssl_tls_sock)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/zephyr/samples/wolfssl_tls_sock/src/tls_sock.c
+++ b/zephyr/samples/wolfssl_tls_sock/src/tls_sock.c
@@ -19,7 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#include <wolfssl/options.h>
+#ifndef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/options.h>
+#endif
 #include <wolfssl/ssl.h>
 #define USE_CERT_BUFFERS_2048
 #include <wolfssl/certs_test.h>


### PR DESCRIPTION
- define XSTAT_TYPE for use with XSTAT
- tls_sock.c: don't include options.h when using user settings
- wolfssl_tls_sock: fix project name