### PR TITLE
Ensure all memory initialized when buffer is grown

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -10095,6 +10095,9 @@ static WC_INLINE int GrowOutputBuffer(WOLFSSL* ssl, int size)
     if (tmp == NULL)
         return MEMORY_E;
 
+    /* Zeroize new buffer memory */
+    ForceZero(tmp, size + ssl->buffers.outputBuffer.length + align);
+
 #if WOLFSSL_GENERAL_ALIGNMENT > 0
     if (align)
         tmp += align - hdrSz;


### PR DESCRIPTION
# Description

**Fixes zd16021**

This change ensures that when a buffer is grown all memory is initialized, by the previous buffer contents and/or set to zero.  This prevents the possibility of uninitialized data being used for communications from re-sized buffers.

# Testing

Tested using a crypto-fuzz reproducer provided on zd16021 with valgrind.  Also tested with wolfSSL unit tests.

