### PR TITLE
Add option to support disabling thread local storage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -159,9 +159,20 @@ then
     output_objdir=.
 fi
 
+
 # Thread local storage
-AX_TLS([thread_ls_on=yes],[thread_ls_on=no])
-AS_IF([test "x$thread_ls_on" = "xyes"],[AM_CFLAGS="$AM_CFLAGS -DHAVE_THREAD_LS"])
+thread_ls_on="no"
+AC_ARG_ENABLE([threadlocal],
+    [AS_HELP_STRING([--enable-threadlocal],[Enable thread local support (default: enabled)])],
+    [ ENABLED_THREADLOCAL=$enableval ],
+    [ ENABLED_THREADLOCAL=yes ]
+    )
+if test "$ENABLED_THREADLOCAL" = "yes"
+then
+    AX_TLS([thread_ls_on=yes],[thread_ls_on=no])
+    AS_IF([test "x$thread_ls_on" = "xyes"],[AM_CFLAGS="$AM_CFLAGS -DHAVE_THREAD_LS"])
+fi
+
 
 # DEBUG
 AX_DEBUG


### PR DESCRIPTION
# Description

Add option to support disabling thread local `--disable-threadlocal`.

Useful for cross-compile situation where thread local storage is not desired.

Fixes ZD 16062

# Testing

```
./configure --disable-threadlocal && make
./configure --disable-threadlocal --enable-singlethreaded && make
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
