### PR TITLE
Define WOLFSSL_THREAD for FREERTOS case

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -808,6 +808,7 @@ extern void uITRON4_free(void *p) ;
 
 #ifdef FREERTOS
     #include "FreeRTOS.h"
+    #include <task.h>
 
     #if !defined(XMALLOC_USER) && !defined(NO_WOLFSSL_MEMORY) && \
         !defined(WOLFSSL_STATIC_MEMORY) && !defined(WOLFSSL_TRACK_MEMORY)

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1327,6 +1327,10 @@ typedef struct w64wrapper {
         #define WOLFSSL_THREAD
         #define INFINITE      (-1)
         #define WAIT_OBJECT_0 0L
+    #elif defined(FREERTOS)
+        typedef unsigned int   THREAD_RETURN;
+        typedef TaskHandle_t   THREAD_TYPE;
+        #define WOLFSSL_THREAD
     #else
         typedef unsigned int  THREAD_RETURN;
         typedef size_t        THREAD_TYPE;


### PR DESCRIPTION
# Description

Fix for using `WOLFSSL_THREAD` with FREERTOS


# Testing

Tested using the  wolfSSH Cube Pack

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
