### PR TITLE
Minor fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7702,7 +7702,7 @@ case $host_cpu in
     ;;
 esac
 
-if test "$ENABLED_LOWRESOURCE" = "yes" && test "$ENABLED_ECC" = "yes" && (test "$ENABLED_RSA" = "yes" || test "$ENABLED_DH" == "yes") && (test "$ENABLED_SP_MATH" = "yes" || test "$ENABLED_SP_MATH_ALL" = "yes")
+if test "$ENABLED_LOWRESOURCE" = "yes" && test "$ENABLED_ECC" = "yes" && (test "$ENABLED_RSA" = "yes" || test "$ENABLED_DH" = "yes") && (test "$ENABLED_SP_MATH" = "yes" || test "$ENABLED_SP_MATH_ALL" = "yes")
 then
     AM_CFLAGS="$AM_CFLAGS -DALT_ECC_SIZE"
 fi

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1262,8 +1262,7 @@ static const char* client_usage_msg[][70] = {
         "--onlyPskDheKe Must use DHE key exchange with PSK\n",          /* 73 */
 #endif
 #ifndef NO_PSK
-        "--openssl-psk  Use TLS 1.3 PSK callback compatible with "
-        "OpenSSL\n",                                                    /* 74 */
+        "--openssl-psk  Use TLS 1.3 PSK callback compatible with OpenSSL\n", /* 74 */
 #endif
         "\n"
            "For simpler wolfSSL TLS client examples, visit\n"
@@ -1487,8 +1486,7 @@ static const char* client_usage_msg[][70] = {
         "--onlyPskDheKe Must use DHE key exchange with PSK\n",          /* 73 */
 #endif
 #ifndef NO_PSK
-        "--openssl-psk  Use TLS 1.3 PSK callback compatible with "
-        "OpenSSL\n",                                                    /* 74 */
+        "--openssl-psk  Use TLS 1.3 PSK callback compatible with OpenSSL\n", /* 74 */
 #endif
         "\n"
         "より簡単なwolfSSL TSL クライアントの例については"

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -949,19 +949,19 @@ typedef struct Asn1PrintOptions {
     /* Length of DER/BER encoding to parse. */
     word32 length;
     /* Number of spaces to indent for each change in depth. */
-    int indent:4;
+    word8 indent;
     /* Draw branches instead of indenting. */
-    int draw_branch:1;
+    word8 draw_branch:1;
     /* Show raw data of primitive types as octets. */
-    int show_data:1;
+    word8 show_data:1;
     /* Show header data as octets. */
-    int show_header_data:1;
+    word8 show_header_data:1;
     /* Show the wolfSSL OID value for OBJECT_ID. */
-    int show_oid:1;
+    word8 show_oid:1;
     /* Don't show text representations of primitive types. */
-    int show_no_text:1;
+    word8 show_no_text:1;
     /* Don't show dump text representations of primitive types. */
-    int show_no_dump_text:1;
+    word8 show_no_dump_text:1;
 } Asn1PrintOptions;
 
 /* ASN.1 item data. */


### PR DESCRIPTION
# Description

configure.ac: Don't use == in test.
client.c: Merge string to one line.
asn.c/asn_public.h:
  fix conversion warnings/errors.
  wc_Asn1_Print no longer public and doesn't need to check for NULL.
  wc_Asn1_PrintAll check all pointer parameters for NULL.

# Testing

Standard.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
