### PR TITLE
Fix memory leak in TLSX_KeyShare_Setup

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -9249,6 +9249,7 @@ int TLSX_KeyShare_Setup(WOLFSSL *ssl, KeyShareEntry* clientKSE)
             && ret != WC_PENDING_E
         #endif
         ) {
+            TLSX_KeyShare_FreeAll(list, ssl->heap);
             return ret;
         }
     }


### PR DESCRIPTION
# Description

A KeyShareEntry list was being leaked in in TLSX_KeyShare_Setup() if TLSX_KeyShare_GenKey() failed. This fix frees the allocated list before returning error to caller.

Fixes zd#16114

# Testing

Tested with reproducer in ticket.
