### PR TITLE
always call crypto cb when compiled in

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -4011,6 +4011,9 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
     #endif
 
     #ifdef WOLF_CRYPTO_CB
+        #ifndef WOLF_CRYPTO_CB_FIND
+        if (aes->devId != INVALID_DEVID)
+        #endif
         {
             int crypto_cb_ret = wc_CryptoCb_AesCbcEncrypt(aes, out, in, sz);
             if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
@@ -4144,6 +4147,9 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
     #endif
 
     #ifdef WOLF_CRYPTO_CB
+        #ifndef WOLF_CRYPTO_CB_FIND
+        if (aes->devId != INVALID_DEVID)
+        #endif
         {
             int crypto_cb_ret = wc_CryptoCb_AesCbcDecrypt(aes, out, in, sz);
             if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
@@ -4462,6 +4468,9 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
             }
 
         #ifdef WOLF_CRYPTO_CB
+            #ifndef WOLF_CRYPTO_CB_FIND
+            if (aes->devId != INVALID_DEVID)
+            #endif
             {
                 int crypto_cb_ret = wc_CryptoCb_AesCtrEncrypt(aes, out, in, sz);
                 if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
@@ -6655,6 +6664,9 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     }
 
 #ifdef WOLF_CRYPTO_CB
+    #ifndef WOLF_CRYPTO_CB_FIND
+    if (aes->devId != INVALID_DEVID)
+    #endif
     {
         int crypto_cb_ret =
             wc_CryptoCb_AesGcmEncrypt(aes, out, in, sz, iv, ivSz, authTag,
@@ -7211,6 +7223,9 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     }
 
 #ifdef WOLF_CRYPTO_CB
+    #ifndef WOLF_CRYPTO_CB_FIND
+    if (aes->devId != INVALID_DEVID)
+    #endif
     {
         int crypto_cb_ret =
             wc_CryptoCb_AesGcmDecrypt(aes, out, in, sz, iv, ivSz,
@@ -9103,6 +9118,9 @@ int wc_AesCcmEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
     }
 
 #ifdef WOLF_CRYPTO_CB
+    #ifndef WOLF_CRYPTO_CB_FIND
+    if (aes->devId != INVALID_DEVID)
+    #endif
     {
         int crypto_cb_ret =
             wc_CryptoCb_AesCcmEncrypt(aes, out, in, inSz, nonce, nonceSz,
@@ -9282,6 +9300,9 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
     }
 
 #ifdef WOLF_CRYPTO_CB
+    #ifndef WOLF_CRYPTO_CB_FIND
+    if (aes->devId != INVALID_DEVID)
+    #endif
     {
         int crypto_cb_ret =
             wc_CryptoCb_AesCcmDecrypt(aes, out, in, inSz, nonce, nonceSz,
@@ -9801,6 +9822,9 @@ static WARN_UNUSED_RESULT int _AesEcbEncrypt(
     word32 blocks = sz / AES_BLOCK_SIZE;
 
 #ifdef WOLF_CRYPTO_CB
+    #ifndef WOLF_CRYPTO_CB_FIND
+    if (aes->devId != INVALID_DEVID)
+    #endif
     {
         int ret = wc_CryptoCb_AesEcbEncrypt(aes, out, in, sz);
         if (ret != CRYPTOCB_UNAVAILABLE)
@@ -9837,6 +9861,9 @@ static WARN_UNUSED_RESULT int _AesEcbDecrypt(
     word32 blocks = sz / AES_BLOCK_SIZE;
 
 #ifdef WOLF_CRYPTO_CB
+    #ifndef WOLF_CRYPTO_CB_FIND
+    if (aes->devId != INVALID_DEVID)
+    #endif
     {
         int ret = wc_CryptoCb_AesEcbDecrypt(aes, out, in, sz);
         if (ret != CRYPTOCB_UNAVAILABLE)

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -4011,7 +4011,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
     #endif
 
     #ifdef WOLF_CRYPTO_CB
-        if (aes->devId != INVALID_DEVID) {
+        {
             int crypto_cb_ret = wc_CryptoCb_AesCbcEncrypt(aes, out, in, sz);
             if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
                 return crypto_cb_ret;
@@ -4144,7 +4144,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
     #endif
 
     #ifdef WOLF_CRYPTO_CB
-        if (aes->devId != INVALID_DEVID) {
+        {
             int crypto_cb_ret = wc_CryptoCb_AesCbcDecrypt(aes, out, in, sz);
             if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
                 return crypto_cb_ret;
@@ -4462,7 +4462,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
             }
 
         #ifdef WOLF_CRYPTO_CB
-            if (aes->devId != INVALID_DEVID) {
+            {
                 int crypto_cb_ret = wc_CryptoCb_AesCtrEncrypt(aes, out, in, sz);
                 if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
                     return crypto_cb_ret;
@@ -6655,7 +6655,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     }
 
 #ifdef WOLF_CRYPTO_CB
-    if (aes->devId != INVALID_DEVID) {
+    {
         int crypto_cb_ret =
             wc_CryptoCb_AesGcmEncrypt(aes, out, in, sz, iv, ivSz, authTag,
                                       authTagSz, authIn, authInSz);
@@ -7211,7 +7211,7 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     }
 
 #ifdef WOLF_CRYPTO_CB
-    if (aes->devId != INVALID_DEVID) {
+    {
         int crypto_cb_ret =
             wc_CryptoCb_AesGcmDecrypt(aes, out, in, sz, iv, ivSz,
                                       authTag, authTagSz, authIn, authInSz);
@@ -9103,7 +9103,7 @@ int wc_AesCcmEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
     }
 
 #ifdef WOLF_CRYPTO_CB
-    if (aes->devId != INVALID_DEVID) {
+    {
         int crypto_cb_ret =
             wc_CryptoCb_AesCcmEncrypt(aes, out, in, inSz, nonce, nonceSz,
                                       authTag, authTagSz, authIn, authInSz);
@@ -9282,7 +9282,7 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
     }
 
 #ifdef WOLF_CRYPTO_CB
-    if (aes->devId != INVALID_DEVID) {
+    {
         int crypto_cb_ret =
             wc_CryptoCb_AesCcmDecrypt(aes, out, in, inSz, nonce, nonceSz,
             authTag, authTagSz, authIn, authInSz);
@@ -9801,7 +9801,7 @@ static WARN_UNUSED_RESULT int _AesEcbEncrypt(
     word32 blocks = sz / AES_BLOCK_SIZE;
 
 #ifdef WOLF_CRYPTO_CB
-    if (aes->devId != INVALID_DEVID) {
+    {
         int ret = wc_CryptoCb_AesEcbEncrypt(aes, out, in, sz);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
@@ -9837,7 +9837,7 @@ static WARN_UNUSED_RESULT int _AesEcbDecrypt(
     word32 blocks = sz / AES_BLOCK_SIZE;
 
 #ifdef WOLF_CRYPTO_CB
-    if (aes->devId != INVALID_DEVID) {
+    {
         int ret = wc_CryptoCb_AesEcbDecrypt(aes, out, in, sz);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;

--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -115,6 +115,9 @@ int wc_InitCmac_ex(Cmac* cmac, const byte* key, word32 keySz,
     XMEMSET(cmac, 0, sizeof(Cmac));
 
 #ifdef WOLF_CRYPTO_CB
+    #ifndef WOLF_CRYPTO_CB_FIND
+    if (devId != INVALID_DEVID)
+    #endif
     {
         cmac->devId = devId;
         cmac->devCtx = NULL;
@@ -178,6 +181,9 @@ int wc_CmacUpdate(Cmac* cmac, const byte* in, word32 inSz)
     }
 
 #ifdef WOLF_CRYPTO_CB
+    #ifndef WOLF_CRYPTO_CB_FIND
+    if (cmac->devId != INVALID_DEVID)
+    #endif
     {
         ret = wc_CryptoCb_Cmac(cmac, NULL, 0, in, inSz,
                 NULL, NULL, 0, NULL);
@@ -226,10 +232,15 @@ int wc_CmacFinal(Cmac* cmac, byte* out, word32* outSz)
     }
 
 #ifdef WOLF_CRYPTO_CB
-    ret = wc_CryptoCb_Cmac(cmac, NULL, 0, NULL, 0, out, outSz, 0, NULL);
-    if (ret != CRYPTOCB_UNAVAILABLE)
-        return ret;
-    /* fall-through when unavailable */
+    #ifndef WOLF_CRYPTO_CB_FIND
+    if (cmac->devId != INVALID_DEVID)
+    #endif
+    {
+        ret = wc_CryptoCb_Cmac(cmac, NULL, 0, NULL, 0, out, outSz, 0, NULL);
+        if (ret != CRYPTOCB_UNAVAILABLE)
+            return ret;
+        /* fall-through when unavailable */
+    }
 #endif
 
     if (cmac->bufferSz == AES_BLOCK_SIZE) {

--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -115,7 +115,7 @@ int wc_InitCmac_ex(Cmac* cmac, const byte* key, word32 keySz,
     XMEMSET(cmac, 0, sizeof(Cmac));
 
 #ifdef WOLF_CRYPTO_CB
-    if (devId != INVALID_DEVID) {
+    {
         cmac->devId = devId;
         cmac->devCtx = NULL;
 
@@ -178,7 +178,7 @@ int wc_CmacUpdate(Cmac* cmac, const byte* in, word32 inSz)
     }
 
 #ifdef WOLF_CRYPTO_CB
-    if (cmac->devId != INVALID_DEVID) {
+    {
         ret = wc_CryptoCb_Cmac(cmac, NULL, 0, in, inSz,
                 NULL, NULL, 0, NULL);
         if (ret != CRYPTOCB_UNAVAILABLE)
@@ -226,12 +226,10 @@ int wc_CmacFinal(Cmac* cmac, byte* out, word32* outSz)
     }
 
 #ifdef WOLF_CRYPTO_CB
-    if (cmac->devId != INVALID_DEVID) {
-        ret = wc_CryptoCb_Cmac(cmac, NULL, 0, NULL, 0, out, outSz, 0, NULL);
-        if (ret != CRYPTOCB_UNAVAILABLE)
-            return ret;
-        /* fall-through when unavailable */
-    }
+    ret = wc_CryptoCb_Cmac(cmac, NULL, 0, NULL, 0, out, outSz, 0, NULL);
+    if (ret != CRYPTOCB_UNAVAILABLE)
+        return ret;
+    /* fall-through when unavailable */
 #endif
 
     if (cmac->bufferSz == AES_BLOCK_SIZE) {

--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -49,8 +49,10 @@ typedef struct CryptoCb {
     void* ctx;
 } CryptoCb;
 static WOLFSSL_GLOBAL CryptoCb gCryptoDev[MAX_CRYPTO_DEVID_CALLBACKS];
-static CryptoDevCallbackFind CryptoCb_FindCb = NULL;
 
+#ifdef WOLF_CRYPTO_CB_FIND
+static CryptoDevCallbackFind CryptoCb_FindCb = NULL;
+#endif
 
 #ifdef DEBUG_CRYPTOCB
 static const char* GetAlgoTypeStr(int algo)
@@ -188,9 +190,11 @@ static CryptoCb* wc_CryptoCb_FindDevice(int devId, int algoType)
 {
     int localDevId = devId;
 
+#ifdef WOLF_CRYPTO_CB_FIND
     if (CryptoCb_FindCb != NULL) {
         localDevId = CryptoCb_FindCb(devId, algoType);
     }
+#endif /* WOLF_CRYPTO_CB_FIND */
     return wc_CryptoCb_GetDevice(localDevId);
 }
 
@@ -233,6 +237,7 @@ int wc_CryptoCb_GetDevIdAtIndex(int startIdx)
 }
 
 
+#ifdef WOLF_CRYPTO_CB_FIND
 /* Used to register a find device function. Useful for cases where the
  * device ID in the struct may not have been set but still wanting to use
  * a specific crypto callback device ID. The find callback is global and
@@ -241,6 +246,7 @@ void wc_CryptoCb_SetDeviceFindCb(CryptoDevCallbackFind cb)
 {
     CryptoCb_FindCb = cb;
 }
+#endif
 
 int wc_CryptoCb_RegisterDevice(int devId, CryptoDevCallbackFunc cb, void* ctx)
 {

--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -195,6 +195,7 @@ static CryptoCb* wc_CryptoCb_FindDevice(int devId, int algoType)
         localDevId = CryptoCb_FindCb(devId, algoType);
     }
 #endif /* WOLF_CRYPTO_CB_FIND */
+    (void)algoType;
     return wc_CryptoCb_GetDevice(localDevId);
 }
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -5334,6 +5334,7 @@ static int _ecc_make_key_ex(WC_RNG* rng, int keysize, ecc_key* key,
     if (err == CRYPTOCB_UNAVAILABLE) {
         return NO_VALID_DEVID;
     }
+    return err;
     #endif
 #endif
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4428,17 +4428,22 @@ int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key, byte* out,
    }
 
 #ifdef WOLF_CRYPTO_CB
-    err = wc_CryptoCb_Ecdh(private_key, public_key, out, outlen);
-    #ifndef WOLF_CRYPTO_CB_ONLY_ECC
-    if (err != CRYPTOCB_UNAVAILABLE)
-        return err;
-    /* fall-through when unavailable */
+    #ifndef WOLF_CRYPTO_CB_FIND
+    if (private_key->devId != INVALID_DEVID)
     #endif
-    #ifdef WOLF_CRYPTO_CB_ONLY_ECC
-    if (err == CRYPTOCB_UNAVAILABLE) {
-        err = NO_VALID_DEVID;
+    {
+        err = wc_CryptoCb_Ecdh(private_key, public_key, out, outlen);
+        #ifndef WOLF_CRYPTO_CB_ONLY_ECC
+        if (err != CRYPTOCB_UNAVAILABLE)
+            return err;
+        /* fall-through when unavailable */
+        #endif
+        #ifdef WOLF_CRYPTO_CB_ONLY_ECC
+        if (err == CRYPTOCB_UNAVAILABLE) {
+            err = NO_VALID_DEVID;
+        }
+        #endif
     }
-    #endif
 #endif
 
 #ifndef WOLF_CRYPTO_CB_ONLY_ECC
@@ -5324,18 +5329,23 @@ static int _ecc_make_key_ex(WC_RNG* rng, int keysize, ecc_key* key,
     key->flags = (byte)flags;
 
 #ifdef WOLF_CRYPTO_CB
-    err = wc_CryptoCb_MakeEccKey(rng, keysize, key, curve_id);
-    #ifndef WOLF_CRYPTO_CB_ONLY_ECC
-    if (err != CRYPTOCB_UNAVAILABLE)
+    #ifndef WOLF_CRYPTO_CB_FIND
+    if (key->devId != INVALID_DEVID)
+    #endif
+    {
+        err = wc_CryptoCb_MakeEccKey(rng, keysize, key, curve_id);
+        #ifndef WOLF_CRYPTO_CB_ONLY_ECC
+        if (err != CRYPTOCB_UNAVAILABLE)
+            return err;
+        /* fall-through when unavailable */
+        #endif
+        #ifdef WOLF_CRYPTO_CB_ONLY_ECC
+        if (err == CRYPTOCB_UNAVAILABLE) {
+            return NO_VALID_DEVID;
+        }
         return err;
-    /* fall-through when unavailable */
-    #endif
-    #ifdef WOLF_CRYPTO_CB_ONLY_ECC
-    if (err == CRYPTOCB_UNAVAILABLE) {
-        return NO_VALID_DEVID;
+        #endif
     }
-    return err;
-    #endif
 #endif
 
 #ifndef WOLF_CRYPTO_CB_ONLY_ECC
@@ -6311,17 +6321,22 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
     }
 
 #ifdef WOLF_CRYPTO_CB
-    err = wc_CryptoCb_EccSign(in, inlen, out, outlen, rng, key);
-    #ifndef WOLF_CRYPTO_CB_ONLY_ECC
-    if (err != CRYPTOCB_UNAVAILABLE)
-        return err;
-    /* fall-through when unavailable */
+    #ifndef WOLF_CRYPTO_CB_FIND
+    if (key->devId != INVALID_DEVID)
     #endif
-    #ifdef WOLF_CRYPTO_CB_ONLY_ECC
-    if (err == CRYPTOCB_UNAVAILABLE) {
-        err = NO_VALID_DEVID;
+    {
+        err = wc_CryptoCb_EccSign(in, inlen, out, outlen, rng, key);
+        #ifndef WOLF_CRYPTO_CB_ONLY_ECC
+        if (err != CRYPTOCB_UNAVAILABLE)
+            return err;
+        /* fall-through when unavailable */
+        #endif
+        #ifdef WOLF_CRYPTO_CB_ONLY_ECC
+        if (err == CRYPTOCB_UNAVAILABLE) {
+            err = NO_VALID_DEVID;
+        }
+        #endif
     }
-    #endif
 #endif
 
 #ifndef WOLF_CRYPTO_CB_ONLY_ECC
@@ -8009,17 +8024,22 @@ int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
     }
 
 #ifdef WOLF_CRYPTO_CB
-    err = wc_CryptoCb_EccVerify(sig, siglen, hash, hashlen, res, key);
-    #ifndef WOLF_CRYPTO_CB_ONLY_ECC
-    if (err != CRYPTOCB_UNAVAILABLE)
-        return err;
-    /* fall-through when unavailable */
+    #ifndef WOLF_CRYPTO_CB_FIND
+    if (key->devId != INVALID_DEVID)
     #endif
-    #ifdef WOLF_CRYPTO_CB_ONLY_ECC
-    if (err == CRYPTOCB_UNAVAILABLE) {
-        err = NO_VALID_DEVID;
+    {
+        err = wc_CryptoCb_EccVerify(sig, siglen, hash, hashlen, res, key);
+        #ifndef WOLF_CRYPTO_CB_ONLY_ECC
+        if (err != CRYPTOCB_UNAVAILABLE)
+            return err;
+        /* fall-through when unavailable */
+        #endif
+        #ifdef WOLF_CRYPTO_CB_ONLY_ECC
+        if (err == CRYPTOCB_UNAVAILABLE) {
+            err = NO_VALID_DEVID;
+        }
+        #endif
     }
-    #endif
 #endif
 
 #ifndef WOLF_CRYPTO_CB_ONLY_ECC

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4428,16 +4428,14 @@ int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key, byte* out,
    }
 
 #ifdef WOLF_CRYPTO_CB
-    if (private_key->devId != INVALID_DEVID) {
-        err = wc_CryptoCb_Ecdh(private_key, public_key, out, outlen);
+    err = wc_CryptoCb_Ecdh(private_key, public_key, out, outlen);
     #ifndef WOLF_CRYPTO_CB_ONLY_ECC
-        if (err != CRYPTOCB_UNAVAILABLE)
-            return err;
-        /* fall-through when unavailable */
+    if (err != CRYPTOCB_UNAVAILABLE)
+        return err;
+    /* fall-through when unavailable */
     #endif
-    }
     #ifdef WOLF_CRYPTO_CB_ONLY_ECC
-    else {
+    if (err == CRYPTOCB_UNAVAILABLE) {
         err = NO_VALID_DEVID;
     }
     #endif
@@ -5326,18 +5324,14 @@ static int _ecc_make_key_ex(WC_RNG* rng, int keysize, ecc_key* key,
     key->flags = (byte)flags;
 
 #ifdef WOLF_CRYPTO_CB
-    if (key->devId != INVALID_DEVID) {
-        err = wc_CryptoCb_MakeEccKey(rng, keysize, key, curve_id);
+    err = wc_CryptoCb_MakeEccKey(rng, keysize, key, curve_id);
     #ifndef WOLF_CRYPTO_CB_ONLY_ECC
-        if (err != CRYPTOCB_UNAVAILABLE)
-            return err;
-        /* fall-through when unavailable */
-    #else
+    if (err != CRYPTOCB_UNAVAILABLE)
         return err;
+    /* fall-through when unavailable */
     #endif
-    }
     #ifdef WOLF_CRYPTO_CB_ONLY_ECC
-    else {
+    if (err == CRYPTOCB_UNAVAILABLE) {
         return NO_VALID_DEVID;
     }
     #endif
@@ -6316,16 +6310,14 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
     }
 
 #ifdef WOLF_CRYPTO_CB
-    if (key->devId != INVALID_DEVID) {
-        err = wc_CryptoCb_EccSign(in, inlen, out, outlen, rng, key);
+    err = wc_CryptoCb_EccSign(in, inlen, out, outlen, rng, key);
     #ifndef WOLF_CRYPTO_CB_ONLY_ECC
-        if (err != CRYPTOCB_UNAVAILABLE)
-            return err;
-        /* fall-through when unavailable */
+    if (err != CRYPTOCB_UNAVAILABLE)
+        return err;
+    /* fall-through when unavailable */
     #endif
-    }
     #ifdef WOLF_CRYPTO_CB_ONLY_ECC
-    else {
+    if (err == CRYPTOCB_UNAVAILABLE) {
         err = NO_VALID_DEVID;
     }
     #endif
@@ -8016,16 +8008,14 @@ int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
     }
 
 #ifdef WOLF_CRYPTO_CB
-    if (key->devId != INVALID_DEVID) {
-        err = wc_CryptoCb_EccVerify(sig, siglen, hash, hashlen, res, key);
+    err = wc_CryptoCb_EccVerify(sig, siglen, hash, hashlen, res, key);
     #ifndef WOLF_CRYPTO_CB_ONLY_ECC
-        if (err != CRYPTOCB_UNAVAILABLE)
-            return err;
-        /* fall-through when unavailable */
+    if (err != CRYPTOCB_UNAVAILABLE)
+        return err;
+    /* fall-through when unavailable */
     #endif
-    }
     #ifdef WOLF_CRYPTO_CB_ONLY_ECC
-    else {
+    if (err == CRYPTOCB_UNAVAILABLE) {
         err = NO_VALID_DEVID;
     }
     #endif

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1829,12 +1829,10 @@ int wc_RNG_GenerateBlock(WC_RNG* rng, byte* output, word32 sz)
         return 0;
 
 #ifdef WOLF_CRYPTO_CB
-    if (rng->devId != INVALID_DEVID) {
-        ret = wc_CryptoCb_RandomBlock(rng, output, sz);
-        if (ret != CRYPTOCB_UNAVAILABLE)
-            return ret;
-        /* fall-through when unavailable */
-    }
+    ret = wc_CryptoCb_RandomBlock(rng, output, sz);
+    if (ret != CRYPTOCB_UNAVAILABLE)
+        return ret;
+    /* fall-through when unavailable */
 #endif
 
 #ifdef HAVE_INTEL_RDRAND
@@ -2583,7 +2581,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 #ifdef WOLF_CRYPTO_CB
     int ret;
 
-    if (os != NULL && os->devId != INVALID_DEVID) {
+    if (os != NULL) {
         ret = wc_CryptoCb_RandomSeed(os, output, sz);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
@@ -3702,7 +3700,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         }
 
     #ifdef WOLF_CRYPTO_CB
-        if (os->devId != INVALID_DEVID) {
+        {
             ret = wc_CryptoCb_RandomSeed(os, output, sz);
             if (ret != CRYPTOCB_UNAVAILABLE)
                 return ret;

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1829,10 +1829,15 @@ int wc_RNG_GenerateBlock(WC_RNG* rng, byte* output, word32 sz)
         return 0;
 
 #ifdef WOLF_CRYPTO_CB
-    ret = wc_CryptoCb_RandomBlock(rng, output, sz);
-    if (ret != CRYPTOCB_UNAVAILABLE)
-        return ret;
-    /* fall-through when unavailable */
+    #ifndef WOLF_CRYPTO_CB_FIND
+    if (rng->devId != INVALID_DEVID)
+    #endif
+    {
+        ret = wc_CryptoCb_RandomBlock(rng, output, sz);
+        if (ret != CRYPTOCB_UNAVAILABLE)
+            return ret;
+        /* fall-through when unavailable */
+    }
 #endif
 
 #ifdef HAVE_INTEL_RDRAND
@@ -2581,7 +2586,11 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 #ifdef WOLF_CRYPTO_CB
     int ret;
 
-    if (os != NULL) {
+    if (os != NULL
+    #ifndef WOLF_CRYPTO_CB_FIND
+        && os->devId != INVALID_DEVID)
+    #endif
+    {
         ret = wc_CryptoCb_RandomSeed(os, output, sz);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
@@ -3700,6 +3709,9 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         }
 
     #ifdef WOLF_CRYPTO_CB
+        #ifndef WOLF_CRYPTO_CB_FIND
+        if (os->devId != INVALID_DEVID)
+        #endif
         {
             ret = wc_CryptoCb_RandomSeed(os, output, sz);
             if (ret != CRYPTOCB_UNAVAILABLE)

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -3172,18 +3172,14 @@ static int wc_RsaFunction_ex(const byte* in, word32 inLen, byte* out,
     }
 
 #ifdef WOLF_CRYPTO_CB
-    if (key->devId != INVALID_DEVID) {
-        ret = wc_CryptoCb_Rsa(in, inLen, out, outLen, type, key, rng);
+    ret = wc_CryptoCb_Rsa(in, inLen, out, outLen, type, key, rng);
     #ifndef WOLF_CRYPTO_CB_ONLY_RSA
-        if (ret != CRYPTOCB_UNAVAILABLE)
-            return ret;
-        /* fall-through when unavailable and try using software */
-    #else
+    if (ret != CRYPTOCB_UNAVAILABLE)
         return ret;
+    /* fall-through when unavailable and try using software */
     #endif
-    }
     #ifdef WOLF_CRYPTO_CB_ONLY_RSA
-    else {
+    if (ret == CRYPTOCB_UNAVAILABLE)
         return NO_VALID_DEVID;
     }
     #endif
@@ -4768,18 +4764,14 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
 #endif
 
 #ifdef WOLF_CRYPTO_CB
-    if (key->devId != INVALID_DEVID) {
-        err = wc_CryptoCb_MakeRsaKey(key, size, e, rng);
+    err = wc_CryptoCb_MakeRsaKey(key, size, e, rng);
     #ifndef WOLF_CRYPTO_CB_ONLY_RSA
-        if (err != CRYPTOCB_UNAVAILABLE)
-            goto out;
-        /* fall-through when unavailable */
-    #else
+    if (err != CRYPTOCB_UNAVAILABLE)
         goto out;
+    /* fall-through when unavailable */
     #endif
-    }
     #ifdef WOLF_CRYPTO_CB_ONLY_RSA
-    else {
+    if (err == CRYPTOCB_UNAVAILABLE)
         err = NO_VALID_DEVID;
         goto out;
     }

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -3179,9 +3179,10 @@ static int wc_RsaFunction_ex(const byte* in, word32 inLen, byte* out,
     /* fall-through when unavailable and try using software */
     #endif
     #ifdef WOLF_CRYPTO_CB_ONLY_RSA
-    if (ret == CRYPTOCB_UNAVAILABLE)
+    if (ret == CRYPTOCB_UNAVAILABLE) {
         return NO_VALID_DEVID;
     }
+    return ret;
     #endif
 #endif
 

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -1231,6 +1231,9 @@ static int InitSha256(wc_Sha256* sha256)
         }
 
     #ifdef WOLF_CRYPTO_CB
+        #ifndef WOLF_CRYPTO_CB_FIND
+        if (sha256->devId != INVALID_DEVID)
+        #endif
         {
             int ret = wc_CryptoCb_Sha256Hash(sha256, data, len, NULL);
             if (ret != CRYPTOCB_UNAVAILABLE)
@@ -1394,10 +1397,15 @@ static int InitSha256(wc_Sha256* sha256)
         }
 
     #ifdef WOLF_CRYPTO_CB
-        ret = wc_CryptoCb_Sha256Hash(sha256, NULL, 0, hash);
-        if (ret != CRYPTOCB_UNAVAILABLE)
-            return ret;
-        /* fall-through when unavailable */
+        #ifndef WOLF_CRYPTO_CB_FIND
+        if (sha256->devId != INVALID_DEVID)
+        #endif
+        {
+            ret = wc_CryptoCb_Sha256Hash(sha256, NULL, 0, hash);
+            if (ret != CRYPTOCB_UNAVAILABLE)
+                return ret;
+            /* fall-through when unavailable */
+        }
     #endif
 
     #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_SHA256)

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -1231,7 +1231,7 @@ static int InitSha256(wc_Sha256* sha256)
         }
 
     #ifdef WOLF_CRYPTO_CB
-        if (sha256->devId != INVALID_DEVID) {
+        {
             int ret = wc_CryptoCb_Sha256Hash(sha256, data, len, NULL);
             if (ret != CRYPTOCB_UNAVAILABLE)
                 return ret;
@@ -1394,12 +1394,10 @@ static int InitSha256(wc_Sha256* sha256)
         }
 
     #ifdef WOLF_CRYPTO_CB
-        if (sha256->devId != INVALID_DEVID) {
-            ret = wc_CryptoCb_Sha256Hash(sha256, NULL, 0, hash);
-            if (ret != CRYPTOCB_UNAVAILABLE)
-                return ret;
-            /* fall-through when unavailable */
-        }
+        ret = wc_CryptoCb_Sha256Hash(sha256, NULL, 0, hash);
+        if (ret != CRYPTOCB_UNAVAILABLE)
+            return ret;
+        /* fall-through when unavailable */
     #endif
 
     #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_SHA256)

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -952,6 +952,9 @@ int wc_Sha512Update(wc_Sha512* sha512, const byte* data, word32 len)
     }
 
 #ifdef WOLF_CRYPTO_CB
+    #ifndef WOLF_CRYPTO_CB_FIND
+    if (sha512->devId != INVALID_DEVID)
+    #endif
     {
         int ret = wc_CryptoCb_Sha512Hash(sha512, data, len, NULL);
         if (ret != CRYPTOCB_UNAVAILABLE)
@@ -1151,6 +1154,9 @@ static int Sha512_Family_Final(wc_Sha512* sha512, byte* hash, size_t digestSz,
     }
 
 #ifdef WOLF_CRYPTO_CB
+    #ifndef WOLF_CRYPTO_CB_FIND
+    if (sha512->devId != INVALID_DEVID)
+    #endif
     {
         byte localHash[WC_SHA512_DIGEST_SIZE];
         ret = wc_CryptoCb_Sha512Hash(sha512, NULL, 0, localHash);
@@ -1374,6 +1380,9 @@ int wc_Sha384Update(wc_Sha384* sha384, const byte* data, word32 len)
     }
 
 #ifdef WOLF_CRYPTO_CB
+    #ifndef WOLF_CRYPTO_CB_FIND
+    if (sha384->devId != INVALID_DEVID)
+    #endif
     {
         int ret = wc_CryptoCb_Sha384Hash(sha384, data, len, NULL);
         if (ret != CRYPTOCB_UNAVAILABLE)
@@ -1423,10 +1432,15 @@ int wc_Sha384Final(wc_Sha384* sha384, byte* hash)
     }
 
 #ifdef WOLF_CRYPTO_CB
-    ret = wc_CryptoCb_Sha384Hash(sha384, NULL, 0, hash);
-    if (ret != CRYPTOCB_UNAVAILABLE)
-        return ret;
-    /* fall-through when unavailable */
+    #ifndef WOLF_CRYPTO_CB_FIND
+    if (sha384->devId != INVALID_DEVID)
+    #endif
+    {
+        ret = wc_CryptoCb_Sha384Hash(sha384, NULL, 0, hash);
+        if (ret != CRYPTOCB_UNAVAILABLE)
+            return ret;
+        /* fall-through when unavailable */
+    }
 #endif
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_SHA384)
     if (sha384->asyncDev.marker == WOLFSSL_ASYNC_MARKER_SHA384) {

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -952,7 +952,7 @@ int wc_Sha512Update(wc_Sha512* sha512, const byte* data, word32 len)
     }
 
 #ifdef WOLF_CRYPTO_CB
-    if (sha512->devId != INVALID_DEVID) {
+    {
         int ret = wc_CryptoCb_Sha512Hash(sha512, data, len, NULL);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
@@ -1151,7 +1151,7 @@ static int Sha512_Family_Final(wc_Sha512* sha512, byte* hash, size_t digestSz,
     }
 
 #ifdef WOLF_CRYPTO_CB
-    if (sha512->devId != INVALID_DEVID) {
+    {
         byte localHash[WC_SHA512_DIGEST_SIZE];
         ret = wc_CryptoCb_Sha512Hash(sha512, NULL, 0, localHash);
         if (ret != CRYPTOCB_UNAVAILABLE) {
@@ -1374,7 +1374,7 @@ int wc_Sha384Update(wc_Sha384* sha384, const byte* data, word32 len)
     }
 
 #ifdef WOLF_CRYPTO_CB
-    if (sha384->devId != INVALID_DEVID) {
+    {
         int ret = wc_CryptoCb_Sha384Hash(sha384, data, len, NULL);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
@@ -1423,12 +1423,10 @@ int wc_Sha384Final(wc_Sha384* sha384, byte* hash)
     }
 
 #ifdef WOLF_CRYPTO_CB
-    if (sha384->devId != INVALID_DEVID) {
-        ret = wc_CryptoCb_Sha384Hash(sha384, NULL, 0, hash);
-        if (ret != CRYPTOCB_UNAVAILABLE)
-            return ret;
-        /* fall-through when unavailable */
-    }
+    ret = wc_CryptoCb_Sha384Hash(sha384, NULL, 0, hash);
+    if (ret != CRYPTOCB_UNAVAILABLE)
+        return ret;
+    /* fall-through when unavailable */
 #endif
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_SHA384)
     if (sha384->asyncDev.marker == WOLFSSL_ASYNC_MARKER_SHA384) {

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -45197,12 +45197,20 @@ static int myCryptoCbFind(int currentId, int algoType)
     /* can have algo specific overrides here
        switch (algoType) {
 
+            i.e.
+            WC_ALGO_TYPE_CMAC
+            WC_ALGO_TYPE_SEED
+            WC_ALGO_TYPE_HMAC
+            WC_ALGO_TYPE_HASH
+            WC_ALGO_TYPE_CIPHER
+            WC_ALGO_TYPE_PK
+
         }
     */
     (void)algoType;
 
     if (currentId == INVALID_DEVID) {
-        return 1; /* override invalid devid found with 1 */
+        /* can override invalid devid found with 1 */
     }
     return currentId;
 }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -45192,6 +45192,7 @@ static int myCryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
 }
 
 
+#ifdef WOLF_CRYPTO_CB_FIND
 static int myCryptoCbFind(int currentId, int algoType)
 {
     /* can have algo specific overrides here
@@ -45214,6 +45215,7 @@ static int myCryptoCbFind(int currentId, int algoType)
     }
     return currentId;
 }
+#endif /* WOLF_CRYPTO_CB_FIND */
 
 
 WOLFSSL_TEST_SUBROUTINE int cryptocb_test(void)
@@ -45228,7 +45230,9 @@ WOLFSSL_TEST_SUBROUTINE int cryptocb_test(void)
     /* set devId to something other than INVALID_DEVID */
     devId = 1;
     ret = wc_CryptoCb_RegisterDevice(devId, myCryptoDevCb, &myCtx);
+#ifdef WOLF_CRYPTO_CB_FIND
     wc_CryptoCb_SetDeviceFindCb(myCryptoCbFind);
+#endif /* WOLF_CRYPTO_CB_FIND */
 #ifndef WC_NO_RNG
     if (ret == 0)
         ret = random_test();

--- a/wolfssl/wolfcrypt/cryptocb.h
+++ b/wolfssl/wolfcrypt/cryptocb.h
@@ -366,8 +366,10 @@ WOLFSSL_API int  wc_CryptoCb_RegisterDevice(int devId, CryptoDevCallbackFunc cb,
 WOLFSSL_API void wc_CryptoCb_UnRegisterDevice(int devId);
 WOLFSSL_API int wc_CryptoCb_DefaultDevID(void);
 
+#ifdef WOLF_CRYPTO_CB_FIND
 typedef int (*CryptoDevCallbackFind)(int devId, int algoType);
 WOLFSSL_API void wc_CryptoCb_SetDeviceFindCb(CryptoDevCallbackFind cb);
+#endif
 
 #ifdef DEBUG_CRYPTOCB
 WOLFSSL_API void wc_CryptoCb_InfoString(wc_CryptoInfo* info);

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1816,8 +1816,6 @@ extern void uITRON4_free(void *p) ;
 
 #ifdef WOLFSSL_IMXRT1170_CAAM
     #define WOLFSSL_CAAM
-
-    #define WOLFSSL_NO_CAAM_BLOB
 #endif
 
 /* OS specific support so far */


### PR DESCRIPTION
To fix cases where a "find device ID" callback is set the code needs to always call down into the crypto callback function. In cases where it is INVALID_DEVID the callback may choose to override it.

ZD 15973