### PR TITLE
Skip Async_DevCtxInit when using init rsa/ecc label/id api's

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -5796,13 +5796,15 @@ WOLFSSL_ABI
 int wc_ecc_init_ex(ecc_key* key, void* heap, int devId)
 {
     int ret      = 0;
+#if defined(HAVE_PKCS11)
     int isPkcs11 = 0;
+#endif
 
     if (key == NULL) {
         return BAD_FUNC_ARG;
     }
 
-#if defined(WOLF_PRIVATE_KEY_ID) || defined(WOLFSSL_ASYNC_CRYPT)
+#if defined(HAVE_PKCS11)
     if (key->isPkcs11) {
         isPkcs11 = 1;
     }
@@ -5860,14 +5862,18 @@ int wc_ecc_init_ex(ecc_key* key, void* heap, int devId)
 #endif
 
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_ECC)
-    if (!isPkcs11) {
-        /* handle as async */
-        ret = wolfAsync_DevCtxInit(&key->asyncDev, WOLFSSL_ASYNC_MARKER_ECC,
+    #if defined(HAVE_PKCS11)
+        if (!isPkcs11) {
+    #endif
+            /* handle as async */
+            ret = wolfAsync_DevCtxInit(&key->asyncDev, WOLFSSL_ASYNC_MARKER_ECC,
                                                             key->heap, devId);
-    }
-#endif
-
+    #if defined(HAVE_PKCS11)
+        }
+    #endif
+#elif defined(HAVE_PKCS11) 
     (void)isPkcs11;
+#endif
 
 #if defined(WOLFSSL_DSP)
     key->handle = -1;
@@ -5919,7 +5925,7 @@ int wc_ecc_init_id(ecc_key* key, unsigned char* id, int len, void* heap,
     if (ret == 0 && (len < 0 || len > ECC_MAX_ID_LEN))
         ret = BUFFER_E;
 
-#if defined(WOLF_PRIVATE_KEY_ID) || defined(WOLFSSL_ASYNC_CRYPT)
+#if defined(HAVE_PKCS11)
     XMEMSET(key, 0, sizeof(ecc_key));
     key->isPkcs11 = 1;
 #endif
@@ -5954,7 +5960,7 @@ int wc_ecc_init_label(ecc_key* key, const char* label, void* heap, int devId)
             ret = BUFFER_E;
     }
 
-#if defined(WOLF_PRIVATE_KEY_ID) || defined(WOLFSSL_ASYNC_CRYPT)
+#if defined(HAVE_PKCS11)
     XMEMSET(key, 0, sizeof(ecc_key));
     key->isPkcs11 = 1;
 #endif

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -5863,15 +5863,14 @@ int wc_ecc_init_ex(ecc_key* key, void* heap, int devId)
 
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_ECC)
     #if defined(HAVE_PKCS11)
-        if (!isPkcs11) {
+        if (!isPkcs11)
     #endif
+        {
             /* handle as async */
             ret = wolfAsync_DevCtxInit(&key->asyncDev, WOLFSSL_ASYNC_MARKER_ECC,
                                                             key->heap, devId);
-    #if defined(HAVE_PKCS11)
         }
-    #endif
-#elif defined(HAVE_PKCS11) 
+#elif defined(HAVE_PKCS11)
     (void)isPkcs11;
 #endif
 

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -309,18 +309,17 @@ int wc_InitRsaKey_ex(RsaKey* key, void* heap, int devId)
 
     #ifdef WC_ASYNC_ENABLE_RSA
         #if defined(HAVE_PKCS11)
-            if (!isPkcs11) {
+            if (!isPkcs11)
         #endif
+            {
                 /* handle as async */
                 ret = wolfAsync_DevCtxInit(&key->asyncDev,
                         WOLFSSL_ASYNC_MARKER_RSA, key->heap, devId);
                 if (ret != 0)
                     return ret;
-        #if defined(HAVE_PKCS11)
             }
-        #endif
     #endif /* WC_ASYNC_ENABLE_RSA */
-#elif defined(HAVE_PKCS11) 
+#elif defined(HAVE_PKCS11)
     (void)isPkcs11;
 #endif /* WOLFSSL_ASYNC_CRYPT */
 

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -504,6 +504,9 @@ struct ecc_key {
 #if defined(PLUTON_CRYPTO_ECC) || defined(WOLF_CRYPTO_CB)
     int devId;
 #endif
+#if defined(WOLF_PRIVATE_KEY_ID) || defined(WOLFSSL_ASYNC_CRYPT)
+    byte isPkcs11 : 1; /* indicate if PKCS11 is preferred */
+#endif
 #ifdef WOLFSSL_SILABS_SE_ACCEL
     sl_se_command_context_t  cmd_ctx;
     sl_se_key_descriptor_t   key;

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -504,7 +504,7 @@ struct ecc_key {
 #if defined(PLUTON_CRYPTO_ECC) || defined(WOLF_CRYPTO_CB)
     int devId;
 #endif
-#if defined(WOLF_PRIVATE_KEY_ID) || defined(WOLFSSL_ASYNC_CRYPT)
+#if defined(HAVE_PKCS11)
     byte isPkcs11 : 1; /* indicate if PKCS11 is preferred */
 #endif
 #ifdef WOLFSSL_SILABS_SE_ACCEL

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -215,7 +215,7 @@ struct RsaKey {
 #ifdef WOLF_CRYPTO_CB
     int   devId;
 #endif
-#if defined(WOLF_PRIVATE_KEY_ID) || defined(WOLFSSL_ASYNC_CRYPT)
+#if defined(HAVE_PKCS11)
     byte isPkcs11 : 1; /* indicate if PKCS11 is preferred */
 #endif
 #ifdef WOLFSSL_ASYNC_CRYPT

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -215,6 +215,9 @@ struct RsaKey {
 #ifdef WOLF_CRYPTO_CB
     int   devId;
 #endif
+#if defined(WOLF_PRIVATE_KEY_ID) || defined(WOLFSSL_ASYNC_CRYPT)
+    byte isPkcs11 : 1; /* indicate if PKCS11 is preferred */
+#endif
 #ifdef WOLFSSL_ASYNC_CRYPT
     WC_ASYNC_DEV asyncDev;
     #ifdef WOLFSSL_CERT_GEN


### PR DESCRIPTION
# Description

When `wc_ InitRsaKey_ex()` is called from `wc_InitRsaKey_Label()` or `wc_InitRsaKey_Id()`, set the `key->isPkcs11` bit to 1 so that calls to `IntelQaOpen()` aren't made with the pkcs11 devId

Fixes zd#16094

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
