### PR TITLE
20230509-THIS_MODULE-mem-and-more-Wconversion

### DIFF
--- a/linuxkm/linuxkm_memory.c
+++ b/linuxkm/linuxkm_memory.c
@@ -21,7 +21,7 @@
 
 /* included by wolfcrypt/src/memory.c */
 
-#if defined(WOLFSSL_LINUXKM_SIMD_X86)
+#if defined(WOLFSSL_LINUXKM_USE_SAVE_VECTOR_REGISTERS) && defined(CONFIG_X86)
     #ifdef LINUXKM_SIMD_IRQ
         #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
             static union fpregs_state **wolfcrypt_linuxkm_fpu_states = NULL;
@@ -335,7 +335,7 @@
 
         return;
     }
-#endif /* WOLFSSL_LINUXKM_SIMD_X86 && WOLFSSL_LINUXKM_SIMD_X86_IRQ_ALLOWED */
+#endif /* WOLFSSL_LINUXKM_USE_SAVE_VECTOR_REGISTERS && CONFIG_X86 */
 
 #if defined(__PIE__) && (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
 /* needed in 6.1+ because show_free_areas() static definition in mm.h calls

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -2159,7 +2159,7 @@ int GetLength_ex(const byte* input, word32* inOutIdx, int* len, word32 maxIdx,
         /* Bottom 7 bits are the number of bytes to calculate length with.
          * Note: 0 indicates indefinite length encoding *not* 0 bytes of length.
          */
-        word32 bytes = b & 0x7F;
+        word32 bytes = (word32)b & 0x7FU;
         int minLen;
 
         /* Calculate minimum length to be encoded with bytes. */
@@ -2935,7 +2935,7 @@ static int SetASNIntMP(mp_int* n, int maxSz, byte* output)
     length = mp_unsigned_bin_size(n);
     if (maxSz >= 0 && (1 + length + (leadingBit ? 1 : 0)) > maxSz)
         return BUFFER_E;
-    idx = SetASNInt(length, leadingBit ? 0x80 : 0x00, output);
+    idx = SetASNInt(length, (byte)(leadingBit ? 0x80U : 0x00U), output);
     if (maxSz >= 0 && (idx + length) > maxSz)
         return BUFFER_E;
 
@@ -14468,7 +14468,7 @@ word32 SetLength(word32 length, byte* output)
 
         if (output) {
             /* Encode count byte. */
-            output[i] = j | ASN_LONG_LENGTH;
+            output[i] = (byte)(j | ASN_LONG_LENGTH);
         }
         /* Skip over count byte. */
         i++;
@@ -14550,8 +14550,8 @@ word32 SetSet(word32 len, byte* output)
  */
 word32 SetImplicit(byte tag, byte number, word32 len, byte* output)
 {
-    tag = ((tag == ASN_SEQUENCE || tag == ASN_SET) ? ASN_CONSTRUCTED : 0)
-                    | ASN_CONTEXT_SPECIFIC | number;
+    tag = (byte)(((tag == ASN_SEQUENCE || tag == ASN_SET) ? ASN_CONSTRUCTED : 0)
+                 | ASN_CONTEXT_SPECIFIC | number);
     return SetHeader(tag, len, output);
 }
 
@@ -14566,8 +14566,8 @@ word32 SetImplicit(byte tag, byte number, word32 len, byte* output)
  */
 word32 SetExplicit(byte number, word32 len, byte* output)
 {
-    return SetHeader(ASN_CONTEXT_SPECIFIC | ASN_CONSTRUCTED | number, len,
-                     output);
+    return SetHeader((byte)(ASN_CONTEXT_SPECIFIC | ASN_CONSTRUCTED | number),
+                     len, output);
 }
 
 #if defined(OPENSSL_EXTRA)
@@ -14754,8 +14754,7 @@ word32 SetAlgoID(int algoOID, byte* output, int type, int curveSz)
 
     tagSz = (type == oidHashType ||
              (type == oidSigType && !IsSigAlgoECC((word32)algoOID)) ||
-             (type == oidKeyType && algoOID == RSAk)) ? 2 : 0;
-
+             (type == oidKeyType && algoOID == RSAk)) ? 2U : 0U;
     algoName = OidFromId((word32)algoOID, (word32)type, &algoSz);
     if (algoName == NULL) {
         WOLFSSL_MSG("Unknown Algorithm");
@@ -18634,7 +18633,7 @@ static int DecodeSubtree(const byte* input, word32 sz, Base_entry** head,
         }
 
         /* Get type, LSB 4-bits */
-        bType = (b & ASN_TYPE_MASK);
+        bType = (byte)(b & ASN_TYPE_MASK);
 
         if (bType == ASN_DNS_TYPE || bType == ASN_RFC822_TYPE ||
                                                         bType == ASN_DIR_TYPE) {
@@ -21988,7 +21987,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
 
                 if (decrementMaxPathLen && cert->ca->maxPathLen > 0) {
                     WOLFSSL_MSG("\tmaxPathLen status: reduce by 1");
-                    cert->maxPathLen = cert->ca->maxPathLen - 1;
+                    cert->maxPathLen = (byte)(cert->ca->maxPathLen - 1);
                     if (verify != NO_VERIFY && type != CA_TYPE &&
                                                     type != TRUSTED_PEER_TYPE) {
                         WOLFSSL_MSG("\tmaxPathLen status: OK");
@@ -22006,7 +22005,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
             } else if (cert->ca && cert->isCA) {
                 /* case where cert->pathLength extension is not set */
                 if (cert->ca->maxPathLen > 0) {
-                    cert->maxPathLen = cert->ca->maxPathLen - 1;
+                    cert->maxPathLen = (byte)(cert->ca->maxPathLen - 1);
                 } else {
                     cert->maxPathLen = 0;
                     if (verify != NO_VERIFY && type != CA_TYPE &&
@@ -31240,7 +31239,7 @@ int StoreECC_DSA_Sig_Bin(byte* out, word32* outLen, const byte* r, word32 rLen,
     idx = SetSequence(rLen+rAddLeadZero + sLen+sAddLeadZero + headerSz, out);
 
     /* store r */
-    ret = SetASNInt((int)rLen, rAddLeadZero ? 0x80 : 0x00, &out[idx]);
+    ret = SetASNInt((int)rLen, (byte)(rAddLeadZero ? 0x80U : 0x00U), &out[idx]);
     if (ret < 0)
         return ret;
     idx += (word32)ret;
@@ -31248,7 +31247,7 @@ int StoreECC_DSA_Sig_Bin(byte* out, word32* outLen, const byte* r, word32 rLen,
     idx += rLen;
 
     /* store s */
-    ret = SetASNInt((int)sLen, sAddLeadZero ? 0x80 : 0x00, &out[idx]);
+    ret = SetASNInt((int)sLen, (byte)(sAddLeadZero ? 0x80U : 0x00U), &out[idx]);
     if (ret < 0)
         return ret;
     idx += (word32)ret;

--- a/wolfcrypt/src/coding.c
+++ b/wolfcrypt/src/coding.c
@@ -100,11 +100,11 @@ static WC_INLINE byte Base64_Char2Val(byte c)
     byte mask;
 
     c -= BASE64_MIN;
-    mask = (((byte)(0x3f - c)) >> 7) - 1;
+    mask = (byte)((((byte)(0x3f - c)) >> 7) - 1);
     /* Load a value from the first cache line and use when mask set. */
-    v  = base64Decode[ c & 0x3f        ] &   mask ;
+    v  = (byte)(base64Decode[ c & 0x3f        ] &   mask);
     /* Load a value from the second cache line and use when mask not set. */
-    v |= base64Decode[(c & 0x0f) | 0x40] & (~mask);
+    v |= (byte)(base64Decode[(c & 0x0f) | 0x40] & (~mask));
 
     return v;
 #else
@@ -236,8 +236,8 @@ int Base64_Decode(const byte* in, word32 inLen, byte* out, word32* outLen)
 
         e1 = Base64_Char2Val(e1);
         e2 = Base64_Char2Val(e2);
-        e3 = (e3 == PAD) ? 0 : Base64_Char2Val(e3);
-        e4 = (e4 == PAD) ? 0 : Base64_Char2Val(e4);
+        e3 = (byte)((e3 == PAD) ? 0 : Base64_Char2Val(e3));
+        e4 = (byte)((e4 == PAD) ? 0 : Base64_Char2Val(e4));
 
         if (e1 == BAD || e2 == BAD || e3 == BAD || e4 == BAD) {
             WOLFSSL_MSG("Bad Base64 Decode bad character");

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -1633,7 +1633,7 @@ static int wc_ecc_curve_load(const ecc_set_type* dp, ecc_curve_spec** pCurve,
     curve->dp = dp; /* set dp info */
 
     /* determine items to load */
-    load_items = (((byte)~(word32)curve->load_mask) & load_mask);
+    load_items = (byte)(((byte)~(word32)curve->load_mask) & load_mask);
     curve->load_mask |= load_items;
 
     /* load items */
@@ -6928,7 +6928,7 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
 
        /* may still need bit truncation too */
        if (err == MP_OKAY && (WOLFSSL_BIT_SIZE * inlen) > orderBits)
-           mp_rshb(e, WOLFSSL_BIT_SIZE - (orderBits & 0x7));
+           mp_rshb(e, (int)(WOLFSSL_BIT_SIZE - (orderBits & 0x7)));
    }
 
    /* make up a key and export the public copy */
@@ -8389,7 +8389,7 @@ static int ecc_verify_hash(mp_int *r, mp_int *s, const byte* hash,
 
        /* may still need bit truncation too */
        if (err == MP_OKAY && (WOLFSSL_BIT_SIZE * hashlen) > orderBits)
-           mp_rshb(e, WOLFSSL_BIT_SIZE - (orderBits & 0x7));
+           mp_rshb(e, (int)(WOLFSSL_BIT_SIZE - (orderBits & 0x7)));
    }
 
    /* check for async hardware acceleration */

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -586,7 +586,7 @@ int wc_HmacSetKey(Hmac* hmac, int type, const byte* key, word32 length)
             XMEMSET(ip + length, 0, hmac_block_size - length);
 
         for(i = 0; i < hmac_block_size; i++) {
-            op[i] = ip[i] ^ OPAD;
+            op[i] = (byte)(ip[i] ^ OPAD);
             ip[i] ^= IPAD;
         }
     }

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -289,7 +289,7 @@ WC_MISC_STATIC WC_INLINE void xorbufout(void* out, const void* buf,
         /* Move alignment so that it lines up with a
          * WOLFSSL_WORD_SIZE boundary */
         while (((wc_ptr_t)b) % WOLFSSL_WORD_SIZE != 0 && count > 0) {
-            *(o++) = *(b++) ^ *(m++);
+            *(o++) = (byte)(*(b++) ^ *(m++));
             count--;
         }
         XorWordsOut( (wolfssl_word**)&o, (const wolfssl_word**)&b,
@@ -298,7 +298,7 @@ WC_MISC_STATIC WC_INLINE void xorbufout(void* out, const void* buf,
     }
 
     for (i = 0; i < count; i++)
-        o[i] = b[i] ^ m[i];
+        o[i] = (byte)(b[i] ^ m[i]);
 }
 
 /* This routine performs a bitwise XOR operation of <*r> and <*a> for <n> number
@@ -505,8 +505,8 @@ WC_MISC_STATIC WC_INLINE int ByteToHexStr(byte in, char* out)
     if (out == NULL)
         return -1;
 
-    out[0] = ByteToHex(in >> 4);
-    out[1] = ByteToHex(in & 0xf);
+    out[0] = ByteToHex((byte)(in >> 4));
+    out[1] = ByteToHex((byte)(in & 0xf));
     return 0;
 }
 
@@ -544,7 +544,7 @@ WC_MISC_STATIC WC_INLINE byte ctMaskLTE(int a, int b)
 /* Constant time - mask set when a == b. */
 WC_MISC_STATIC WC_INLINE byte ctMaskEq(int a, int b)
 {
-    return (byte)(~ctMaskGT(a, b)) & (byte)(~ctMaskLT(a, b));
+    return (byte)((byte)(~ctMaskGT(a, b)) & (byte)(~ctMaskLT(a, b)));
 }
 
 /* Constant time - sets 16 bit integer mask when a > b */
@@ -574,13 +574,13 @@ WC_MISC_STATIC WC_INLINE word16 ctMask16LTE(int a, int b)
 /* Constant time - sets 16 bit integer mask when a == b. */
 WC_MISC_STATIC WC_INLINE word16 ctMask16Eq(int a, int b)
 {
-    return (word16)(~ctMask16GT(a, b)) & (word16)(~ctMask16LT(a, b));
+    return (word16)((word16)(~ctMask16GT(a, b)) & (word16)(~ctMask16LT(a, b)));
 }
 
 /* Constant time - mask set when a != b. */
 WC_MISC_STATIC WC_INLINE byte ctMaskNotEq(int a, int b)
 {
-    return (byte)ctMaskGT(a, b) | (byte)ctMaskLT(a, b);
+    return (byte)((byte)ctMaskGT(a, b) | (byte)ctMaskLT(a, b));
 }
 
 /* Constant time - select a when mask is set and b otherwise. */

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -12576,7 +12576,7 @@ static int _sp_exptmod_ex(const sp_int* b, const sp_int* e, int bits,
 
             if (err == MP_OKAY) {
                 /* 4.2. y = e[i] */
-                int y = (e->dp[i >> SP_WORD_SHIFT] >> (i & SP_WORD_MASK)) & 1;
+                int y = (int)((e->dp[i >> SP_WORD_SHIFT] >> (i & SP_WORD_MASK)) & 1);
                 /* 4.3. j = y & s */
                 int j = y & s;
                 /* 4.4  s = s | y */
@@ -12709,7 +12709,7 @@ static int _sp_exptmod_mont_ex(const sp_int* b, const sp_int* e, int bits,
 
             if (err == MP_OKAY) {
                 /* 6.2. y = e[i] */
-                int y = (e->dp[i >> SP_WORD_SHIFT] >> (i & SP_WORD_MASK)) & 1;
+                int y = (int)((e->dp[i >> SP_WORD_SHIFT] >> (i & SP_WORD_MASK)) & 1);
                 /* 6.3  j = y & s */
                 int j = y & s;
                 /* 6.4  s = s | y */


### PR DESCRIPTION
linuxkm: add coverage for Linux 6.4+ module memory layout refactor; also, refactor `WOLFSSL_LINUXKM_USE_SAVE_VECTOR_REGISTERS` to make it settable independent of `WOLFSSL_AESNI` etc.

fixes for various wolfcrypt `-Wconversion`s visible only on compilers that promote `byte` and `word16` to `signed int`, then warn of a sign conflict when an intrinsically safe result is assigned back to the original type.

tested with `wolfssl-mult-test.sh ... super-quick-check '.*-Wconversion.*'`
