### PR TITLE
20230511-analyzer-carps

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -1978,12 +1978,12 @@ static word32 GetTable8_4(const byte* t, byte o0, byte o1, byte o2, byte o3)
 #define GetTable(t, o)  t[o]
 #define GetTable8(t, o) t[o]
 #define GetTable_Multi(t, t0, o0, t1, o1, t2, o2, t3, o3)  \
-    *t0 = t[o0]; *t1 = t[o1]; *t2 = t[o2]; *t3 = t[o3]
+    *(t0) = (t)[o0]; *(t1) = (t)[o1]; *(t2) = (t)[o2]; *(t3) = (t)[o3]
 #define XorTable_Multi(t, t0, o0, t1, o1, t2, o2, t3, o3)  \
-    *t0 ^= t[o0]; *t1 ^= t[o1]; *t2 ^= t[o2]; *t3 ^= t[o3]
+    *(t0) ^= (t)[o0]; *(t1) ^= (t)[o1]; *(t2) ^= (t)[o2]; *(t3) ^= (t)[o3]
 #define GetTable8_4(t, o0, o1, o2, o3) \
-    (((word32)t[o0] << 24) | ((word32)t[o1] << 16) | \
-     ((word32)t[o2] <<  8) | ((word32)t[o3] <<  0))
+    (((word32)(t)[o0] << 24) | ((word32)(t)[o1] << 16) |   \
+     ((word32)(t)[o2] <<  8) | ((word32)(t)[o3] <<  0))
 #endif
 
 /* Software AES - ECB Encrypt */

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3368,6 +3368,10 @@ static int ecc_key_tmp_init(ecc_key* key, void* heap)
 
    (void)heap;
 
+   if (key == NULL) {
+       return ECC_BAD_ARG_E;
+   }
+
    XMEMSET(key, 0, sizeof(*key));
 
 #if defined(WOLFSSL_SP_MATH_ALL) && defined(WOLFSSL_SMALL_STACK)


### PR DESCRIPTION
`wolfcrypt/src/aes.c`: fixes for `bugprone-macro-parentheses`;

`wolfcrypt/src/ecc.c`: fix for `nullPointerRedundantCheck` ("possible null pointer dereference").

tested with `wolfssl-multi-test.sh ... all-gcc-c89-clang-tidy cppcheck-all-smallstack`
