### PR TITLE
fix double free in InitOCSPRequest

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -35260,6 +35260,7 @@ int InitOcspRequest(OcspRequest* req, DecodedCert* cert, byte useNonce,
                                                      DYNAMIC_TYPE_OCSP_REQUEST);
             if (req->url == NULL) {
                 XFREE(req->serial, req->heap, DYNAMIC_TYPE_OCSP);
+                req->serial = NULL;
                 return MEMORY_E;
             }
 


### PR DESCRIPTION
# Description

Fixes double free found by OSS-fuzz in [ZD16083](https://wolfssl.zendesk.com/agent/tickets/16083)

Double free occurs [here](https://github.com/wolfSSL/wolfssl/blob/master/wolfcrypt/src/asn.c#L35301) when pointer is not set to null after freeing

# Testing

- verified ASAN no longer reports double free
- unit tests pass 

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
