### PR TITLE
Remove STM AES always true check

### DIFF
--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -318,7 +318,7 @@ int wc_Stm32_Hash_Update(STM32_HASH_Context* stmCtx, word32 algo,
         }
     #endif
 
-        if (len >= 0 && stmCtx->buffLen == chunkSz) {
+        if (stmCtx->buffLen == chunkSz) {
             wc_Stm32_Hash_Data(stmCtx, stmCtx->buffLen);
             wroteToFifo = 1;
         #ifdef STM32_HASH_FIFO_WORKAROUND


### PR DESCRIPTION
# Description

Remove always true check (unsigned, so `len` is always >= 0).

Fixes ZD 16033

# Testing


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
