### PR TITLE
Fix valgrind issue with memcpy

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -8410,7 +8410,7 @@ int wc_AesGcmInit(Aes* aes, const byte* key, word32 len, const byte* iv,
     if (ret == 0) {
         /* Set the IV passed in if it is smaller than a block. */
         if ((iv != NULL) && (ivSz <= AES_BLOCK_SIZE)) {
-            XMEMCPY((byte*)aes->reg, iv, ivSz);
+            XMEMMOVE((byte*)aes->reg, iv, ivSz);
             aes->nonceSz = ivSz;
         }
         /* No IV passed in, check for cached IV. */


### PR DESCRIPTION
# Description

Replaces `XMEMCPY` with `XMEMMOVE` to fix valgrind-3.15.0 reports "Source and destination overlap in memcpy" when using --enable-aesgcm-stream

Fixes #6413 

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
