### PR TITLE
Configure Typo

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3234,7 +3234,7 @@ else
 fi
 
 AC_ARG_ENABLE([brainpool],
-    [AS_HELP_STRING([--enable-brainpool],[Enable Brainpool ECC curves (default: ${BRAINPOOL_DEFAULT})])],
+    [AS_HELP_STRING([--enable-brainpool],[Enable Brainpool ECC curves (default: enabled with ECC custom curves)])],
     [ ENABLED_BRAINPOOL=$enableval ],
     [ ENABLED_BRAINPOOL="$BRAINPOOL_DEFAULT" ]
     )


### PR DESCRIPTION
# Description

The description text for the brainpool enable option in configure was using a shell variable that ended up in the output. Switched to the description pattern used in other options.

# Testing

`./configure --help | grep -i brainpool`

The failure case shows `(default: ${BRAINPOOL_DEFAULT})`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
