### PR TITLE
Fix PKCS#7 build with NO_PKCS7_STREAM

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -28961,7 +28961,7 @@ static int test_wc_PKCS7_EncodeSignedData_ex(void)
         outputHead, outputHeadSz, outputFoot, 0), WC_PKCS7_WANT_READ_E);
 #else
     AssertIntEQ(wc_PKCS7_VerifySignedData_ex(pkcs7, hashBuf, hashSz,
-        outputHead, outputHeadSz, outputFoot, 0), ASN_PARSE_E);
+        outputHead, outputHeadSz, outputFoot, 0), BUFFER_E);
 #endif
 
     wc_PKCS7_Free(pkcs7);


### PR DESCRIPTION
# Description

This PR fixes PKCS#7 support when `NO_PKCS7_STREAM` is defined.

Related to ZD 15927.

# Testing

Tested with built-in unit and wolfCrypt tests, using:

```
$ ./configure --enable-pkcs7
$ ./configure --enable-pkcs7 CFLAGS="-DNO_PKCS7_STREAM"
```

Also tested using `wolfssl-examples/pkcs7` example apps:

```
$ cd wolfssl-examples/pkcs7
$ make
$ ./scripts/runall.sh
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
