### PR TITLE
add check to sp_invmod_mont_ct to make sure the

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -12445,6 +12445,10 @@ int sp_invmod_mont_ct(const sp_int* a, const sp_int* m, sp_int* r,
     else if (m->used * 2 >= SP_INT_DIGITS) {
         err = MP_VAL;
     }
+    /* check that r can hold the range of the modulus result */
+    else if (m->used > r->size) {
+        err = MP_VAL;
+    }
 
     /* 0 != n*m + 1 (+ve m), r*a mod 0 is always 0 (never 1) */
     if ((err == MP_OKAY) && (sp_iszero(a) || sp_iszero(m) ||


### PR DESCRIPTION
result integer can hold the range of the modulus

# Description

`sp_invmod_mont_ct` puts its result into into an `sp_int` r but doesn't check that r can hold the full range of the result. I've added this check

Fixes zd# 16129

# Testing

Tested with Guido's (the big G, the fuzz god) reproducer code

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
