### PR TITLE
Allow wolfSSL_RAND_Init to pass if already initialized

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -35785,6 +35785,11 @@ int wolfSSL_RAND_Init(void)
                 ret = WOLFSSL_SUCCESS;
             }
         }
+        else {
+            /* GlobalRNG is already initialized */
+            ret = WOLFSSL_SUCCESS;
+        }
+
         wc_UnLockMutex(&globalRNGMutex);
     }
 #endif


### PR DESCRIPTION
# Description

If `wolfSSL_RAND_Init` was called before `wolfSSL_Init()`, then it fails because GlobalRNG is already set. Fix to allow `wolfSSL_RAND_Init` to pass when already initialized.

Fixes zd16184

# Testing

Test case

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
