### PR TITLE
Add memcached support.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,8 @@ jobs:
         uses: ./.github/workflows/krb5.yml
     packaging:
         uses: ./.github/workflows/packaging.yml
+    memcached:
+        uses: ./.github/workflows/memcached.yml
 # TODO: Currently this test fails. Enable it once it becomes passing.        
 #    haproxy:
 #        uses: ./.github/workflows/haproxy.yml

--- a/.github/workflows/memcached.yml
+++ b/.github/workflows/memcached.yml
@@ -1,0 +1,83 @@
+name: memcached Tests
+
+on:
+  workflow_call:
+
+jobs:
+  build_wolfssl:
+    name: Build wolfSSL
+    # Just to keep it the same as the testing target
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build wolfSSL
+        uses: wolfSSL/actions-build-autotools-project@v1
+        with:
+          path: wolfssl
+          configure: --enable-memcached
+          install: true
+
+      - name: Upload built lib
+        uses: actions/upload-artifact@v3
+        with:
+          name: wolf-install-memcached
+          path: build-dir
+          retention-days: 1
+
+  memcached_check:
+    strategy:
+      fail-fast: false
+      matrix:
+        # List of releases to test
+        include:
+          - ref: 1.6.22
+    name: ${{ matrix.ref }}
+    runs-on: ubuntu-latest
+    needs: build_wolfssl
+    steps:
+      - name: Download lib
+        uses: actions/download-artifact@v3
+        with:
+          name: wolf-install-memcached
+          path: build-dir
+
+      - name: Checkout OSP
+        uses: actions/checkout@v3
+        with:
+          # TODO: Change to upstream wolfssl/osp once merged
+          repository: kareem-wolfssl/osp
+          ref: memcached
+          path: osp
+
+      - name: Install dependencies
+        run: |
+            export DEBIAN_FRONTEND=noninteractive
+            sudo apt-get update
+            sudo apt-get install -y libevent-dev libevent-2.1-7 automake pkg-config make libio-socket-ssl-perl
+
+      - name: Checkout memcached
+        uses: actions/checkout@v3
+        with:
+          repository: memcached/memcached
+          ref: 1.6.22
+          path: memcached
+
+      - name: Configure and build memcached
+        run: |
+            cd $GITHUB_WORKSPACE/memcached/
+            patch -p1 < $GITHUB_WORKSPACE/osp/memcached/memcached_1.6.22.patch
+            ./autogen.sh
+            export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/build-dir/lib:$LD_LIBRARY_PATH
+            PKG_CONFIG_PATH=$GITHUB_WORKSPACE/build-dir/lib/pkgconfig ./configure --enable-wolfssl
+            make -j$(nproc)
+
+      - name: Confirm memcached built with wolfSSL
+        working-directory: ./memcached
+        run: |
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/build-dir/lib:$LD_LIBRARY_PATH
+          ldd memcached | grep wolfssl
+
+      - name: Run memcached tests
+        working-directory: ./memcached
+        run: |
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/build-dir/lib:$LD_LIBRARY_PATH
+          make -j$(nproc) test_tls

--- a/.github/workflows/memcached.yml
+++ b/.github/workflows/memcached.yml
@@ -43,9 +43,7 @@ jobs:
       - name: Checkout OSP
         uses: actions/checkout@v3
         with:
-          # TODO: Change to upstream wolfssl/osp once merged
-          repository: kareem-wolfssl/osp
-          ref: memcached
+          repository: wolfssl/osp
           path: osp
 
       - name: Install dependencies

--- a/configure.ac
+++ b/configure.ac
@@ -1601,6 +1601,7 @@ AC_ARG_ENABLE([mcast],
 # strongSwan (--enable-strongswan)
 # OpenLDAP (--enable-openldap)
 # hitch (--enable-hitch)
+# memcached (--enable-memcached)
 
 # Bind DNS compatibility Build
 AC_ARG_ENABLE([bind],
@@ -1809,6 +1810,13 @@ AC_ARG_ENABLE([hitch],
     [AS_HELP_STRING([--enable-hitch],[Enable hitch support (default: disabled)])],
     [ ENABLED_HITCH=$enableval ],
     [ ENABLED_HITCH=no ]
+    )
+
+# memcached support
+AC_ARG_ENABLE([memcached],
+    [AS_HELP_STRING([--enable-memcached],[Enable memcached support (default: disabled)])],
+    [ ENABLED_MEMCACHED=$enableval ],
+    [ ENABLED_MEMCACHED=no ]
     )
 
 # OpenSSL Coexist
@@ -6391,6 +6399,12 @@ then
     AM_CFLAGS="$AM_CFLAGS -DOPENSSL_COMPATIBLE_DEFAULTS -DWOLFSSL_CIPHER_INTERNALNAME"
 fi
 
+if test "$ENABLED_MEMCACHED" = "yes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SESSION_ID_CTX"
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_EXT_CACHE -DHAVE_MEMCACHED"
+fi
+
 
 if test "$ENABLED_NGINX" = "yes"|| test "x$ENABLED_HAPROXY" = "xyes" || test "x$ENABLED_LIGHTY" = "xyes"
 then
@@ -9682,6 +9696,7 @@ echo "   * chrony:                     $ENABLED_CHRONY"
 echo "   * strongSwan:                 $ENABLED_STRONGSWAN"
 echo "   * OpenLDAP:                   $ENABLED_OPENLDAP"
 echo "   * hitch:                      $ENABLED_HITCH"
+echo "   * memcached:                  $ENABLED_MEMCACHED"
 echo "   * ERROR_STRINGS:              $ENABLED_ERROR_STRINGS"
 echo "   * DTLS:                       $ENABLED_DTLS"
 echo "   * DTLS v1.3:                  $ENABLED_DTLS13"

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -29505,7 +29505,13 @@ int wolfSSL_SSL_in_connect_init(WOLFSSL* ssl)
     if (ssl == NULL)
         return WOLFSSL_FAILURE;
 
-    return ssl->options.handShakeState == NULL_STATE;
+    if (ssl->options.side == WOLFSSL_CLIENT_END) {
+        return ssl->options.connectState > CONNECT_BEGIN &&
+            ssl->options.connectState < SECOND_REPLY_DONE;
+    }
+
+    return ssl->options.acceptState > ACCEPT_BEGIN &&
+        ssl->options.acceptState < ACCEPT_THIRD_REPLY_DONE;
 }
 
 #ifndef NO_SESSION_CACHE

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -29505,13 +29505,7 @@ int wolfSSL_SSL_in_connect_init(WOLFSSL* ssl)
     if (ssl == NULL)
         return WOLFSSL_FAILURE;
 
-    if (ssl->options.side == WOLFSSL_CLIENT_END) {
-        return ssl->options.connectState > CONNECT_BEGIN &&
-            ssl->options.connectState < SECOND_REPLY_DONE;
-    }
-
-    return ssl->options.acceptState > ACCEPT_BEGIN &&
-        ssl->options.acceptState < ACCEPT_THIRD_REPLY_DONE;
+    return ssl->options.handShakeState == NULL_STATE;
 }
 
 #ifndef NO_SESSION_CACHE

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -13509,7 +13509,7 @@ void SetupSession(WOLFSSL* ssl)
     if (!IsAtLeastTLSv1_3(ssl->version) && ssl->arrays != NULL)
         XMEMCPY(session->masterSecret, ssl->arrays->masterSecret, SECRET_LEN);
     session->haveEMS = ssl->options.haveEMS;
-#ifdef OPENSSL_EXTRA
+#ifdef WOLFSSL_SESSION_ID_CTX
     /* If using compatibility layer then check for and copy over session context
      * id. */
     if (ssl->sessionCtxSz > 0 && ssl->sessionCtxSz < ID_LEN) {
@@ -14279,7 +14279,7 @@ int wolfSSL_SetSession(WOLFSSL* ssl, WOLFSSL_SESSION* session)
     if (ret != WOLFSSL_SUCCESS)
         return ret;
 
-#ifdef OPENSSL_EXTRA
+#ifdef WOLFSSL_SESSION_ID_CTX
     /* check for application context id */
     if (ssl->sessionCtxSz > 0) {
         if (XMEMCMP(ssl->sessionCtx, ssl->session->sessionCtx, ssl->sessionCtxSz)) {
@@ -14288,7 +14288,7 @@ int wolfSSL_SetSession(WOLFSSL* ssl, WOLFSSL_SESSION* session)
             return WOLFSSL_FAILURE;
         }
     }
-#endif /* OPENSSL_EXTRA */
+#endif /* WOLFSSL_SESSION_ID_CTX */
 
     if (LowResTimer() >= (ssl->session->bornOn + ssl->session->timeout)) {
 #if !defined(OPENSSL_EXTRA) || !defined(WOLFSSL_ERROR_CODE_OPENSSL)
@@ -17137,7 +17137,20 @@ cleanup:
 #endif /* WOLFSSL_ENCRYPTED_KEYS */
 
 
+#if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER) || defined(HAVE_MEMCACHED)
+    unsigned long wolfSSL_ERR_get_error(void)
+    {
+        WOLFSSL_ENTER("wolfSSL_ERR_get_error");
+#ifdef WOLFSSL_HAVE_ERROR_QUEUE
+        return wc_GetErrorNodeErr();
+#else
+        return (unsigned long)(0 - NOT_COMPILED_IN);
+#endif
+    }
+#endif
+
 #if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER)
+
     int wolfSSL_num_locks(void)
     {
         return 0;
@@ -17177,16 +17190,6 @@ cleanup:
     void wolfSSL_set_id_callback(unsigned long (*f)(void))
     {
         inner_idCb = f;
-    }
-
-    unsigned long wolfSSL_ERR_get_error(void)
-    {
-        WOLFSSL_ENTER("wolfSSL_ERR_get_error");
-#ifdef WOLFSSL_HAVE_ERROR_QUEUE
-        return wc_GetErrorNodeErr();
-#else
-        return (unsigned long)(0 - NOT_COMPILED_IN);
-#endif
     }
 
 #ifdef WOLFSSL_HAVE_ERROR_QUEUE
@@ -18218,7 +18221,7 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
 
 #endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL */
 
-#if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER)
+#if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER) || defined(HAVE_MEMCACHED)
     long wolfSSL_CTX_set_mode(WOLFSSL_CTX* ctx, long mode)
     {
         /* WOLFSSL_MODE_ACCEPT_MOVING_WRITE_BUFFER is wolfSSL default mode */
@@ -18274,39 +18277,7 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
     }
 #endif
 
-#ifdef OPENSSL_EXTRA
-
-    #ifndef NO_WOLFSSL_STUB
-    long wolfSSL_SSL_get_mode(WOLFSSL* ssl)
-    {
-        /* TODO: */
-        (void)ssl;
-        WOLFSSL_STUB("SSL_get_mode");
-        return 0;
-    }
-    #endif
-
-    #ifndef NO_WOLFSSL_STUB
-    long wolfSSL_CTX_get_mode(WOLFSSL_CTX* ctx)
-    {
-        /* TODO: */
-        (void)ctx;
-        WOLFSSL_STUB("SSL_CTX_get_mode");
-        return 0;
-    }
-    #endif
-
-    #ifndef NO_WOLFSSL_STUB
-    void wolfSSL_CTX_set_default_read_ahead(WOLFSSL_CTX* ctx, int m)
-    {
-        /* TODO: maybe? */
-        (void)ctx;
-        (void)m;
-        WOLFSSL_STUB("SSL_CTX_set_default_read_ahead");
-    }
-    #endif
-
-
+#ifdef WOLFSSL_SESSION_ID_CTX
     /* Storing app session context id, this value is inherited by WOLFSSL
      * objects created from WOLFSSL_CTX. Any session that is imported with a
      * different session context id will be rejected.
@@ -18357,6 +18328,39 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
 
         return WOLFSSL_SUCCESS;
     }
+#endif
+
+#ifdef OPENSSL_EXTRA
+
+    #ifndef NO_WOLFSSL_STUB
+    long wolfSSL_SSL_get_mode(WOLFSSL* ssl)
+    {
+        /* TODO: */
+        (void)ssl;
+        WOLFSSL_STUB("SSL_get_mode");
+        return 0;
+    }
+    #endif
+
+    #ifndef NO_WOLFSSL_STUB
+    long wolfSSL_CTX_get_mode(WOLFSSL_CTX* ctx)
+    {
+        /* TODO: */
+        (void)ctx;
+        WOLFSSL_STUB("SSL_CTX_get_mode");
+        return 0;
+    }
+    #endif
+
+    #ifndef NO_WOLFSSL_STUB
+    void wolfSSL_CTX_set_default_read_ahead(WOLFSSL_CTX* ctx, int m)
+    {
+        /* TODO: maybe? */
+        (void)ctx;
+        (void)m;
+        WOLFSSL_STUB("SSL_CTX_set_default_read_ahead");
+    }
+    #endif
 
 
     long wolfSSL_CTX_sess_get_cache_size(WOLFSSL_CTX* ctx)
@@ -20992,6 +20996,18 @@ void wolfSSL_CTX_set_info_callback(WOLFSSL_CTX* ctx,
     }
 }
 
+void wolfSSL_set_info_callback(WOLFSSL* ssl,
+       void (*f)(const WOLFSSL* ssl, int type, int val))
+{
+    WOLFSSL_ENTER("wolfSSL_set_info_callback");
+    if (ssl == NULL) {
+        WOLFSSL_MSG("Bad function argument");
+    }
+    else {
+        ssl->CBIS = f;
+    }
+}
+
 
 unsigned long wolfSSL_ERR_peek_error(void)
 {
@@ -22802,7 +22818,7 @@ int wolfSSL_i2d_SSL_SESSION(WOLFSSL_SESSION* sess, unsigned char** p)
     /* ServerID len | ServerID */
     size += OPAQUE16_LEN + sess->idLen;
 #endif
-#ifdef OPENSSL_EXTRA
+#ifdef WOLFSSL_SESSION_ID_CTX
     /* session context ID len | session context ID */
     size += OPAQUE8_LEN + sess->sessionCtxSz;
 #endif
@@ -22882,7 +22898,7 @@ int wolfSSL_i2d_SSL_SESSION(WOLFSSL_SESSION* sess, unsigned char** p)
         XMEMCPY(data + idx, sess->serverID, sess->idLen);
         idx += sess->idLen;
 #endif
-#ifdef OPENSSL_EXTRA
+#ifdef WOLFSSL_SESSION_ID_CTX
         data[idx++] = sess->sessionCtxSz;
         XMEMCPY(data + idx, sess->sessionCtx, sess->sessionCtxSz);
         idx += sess->sessionCtxSz;
@@ -23062,7 +23078,7 @@ WOLFSSL_SESSION* wolfSSL_d2i_SSL_SESSION(WOLFSSL_SESSION** sess,
     }
     XMEMCPY(s->serverID, data + idx, s->idLen); idx += s->idLen;
 #endif
-#ifdef OPENSSL_EXTRA
+#ifdef WOLFSSL_SESSION_ID_CTX
     /* byte for length of session context ID */
     if (i - idx < OPAQUE8_LEN) {
         ret = BUFFER_ERROR;
@@ -27871,7 +27887,7 @@ WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
     ssl->options.haveDilithiumSig = ctx->haveDilithiumSig;
 #endif
 
-#ifdef OPENSSL_EXTRA
+#ifdef WOLFSSL_SESSION_ID_CTX
     /* copy over application session context ID */
     ssl->sessionCtxSz = ctx->sessionCtxSz;
     XMEMCPY(ssl->sessionCtx, ctx->sessionCtx, ctx->sessionCtxSz);
@@ -29470,6 +29486,16 @@ int wolfSSL_SSL_in_init(WOLFSSL *ssl)
     WOLFSSL_ENTER("wolfSSL_SSL_in_init");
 
     return !wolfSSL_is_init_finished(ssl);
+}
+
+int wolfSSL_SSL_in_before(const WOLFSSL *ssl)
+{
+    WOLFSSL_ENTER("wolfSSL_SSL_in_before");
+
+    if (ssl == NULL)
+        return WOLFSSL_FAILURE;
+
+    return ssl->options.handShakeState == NULL_STATE;
 }
 
 int wolfSSL_SSL_in_connect_init(WOLFSSL* ssl)

--- a/tests/api.c
+++ b/tests/api.c
@@ -40602,7 +40602,7 @@ static int test_wolfSSL_ERR_put_error(void)
 static int test_wolfSSL_ERR_get_error_order(void)
 {
     EXPECT_DECLS;
-#ifdef WOLFSSL_HAVE_ERROR_QUEUE
+#if defined(WOLFSSL_HAVE_ERROR_QUEUE) && defined(OPENSSL_EXTRA)
     /* Empty the queue. */
     wolfSSL_ERR_clear_error();
 
@@ -40613,7 +40613,7 @@ static int test_wolfSSL_ERR_get_error_order(void)
     ExpectIntEQ(wolfSSL_ERR_get_error(), -ASN_NO_SIGNER_E);
     ExpectIntEQ(wolfSSL_ERR_peek_error(), -ASN_SELF_SIGNED_E);
     ExpectIntEQ(wolfSSL_ERR_get_error(), -ASN_SELF_SIGNED_E);
-#endif /* WOLFSSL_HAVE_ERROR_QUEUE */
+#endif /* WOLFSSL_HAVE_ERROR_QUEUE && OPENSSL_EXTRA */
     return EXPECT_RESULT();
 }
 
@@ -45068,6 +45068,7 @@ static int test_wolfSSL_SESSION(void)
 #endif
     ExpectIntEQ(wolfSSL_SSL_SESSION_set_timeout(sess, 500), SSL_SUCCESS);
 
+#ifdef WOLFSSL_SESSION_ID_CTX
     /* fail case with miss match session context IDs (use compatibility API) */
     ExpectIntEQ(SSL_set_session_id_context(ssl, context, contextSz),
             SSL_SUCCESS);
@@ -45080,6 +45081,7 @@ static int test_wolfSSL_SESSION(void)
             SSL_SUCCESS);
     ExpectNotNull(ssl = wolfSSL_new(ctx));
     ExpectIntEQ(wolfSSL_set_session(ssl, sess), SSL_FAILURE);
+#endif
 #endif /* OPENSSL_EXTRA */
 
     wolfSSL_free(ssl);
@@ -62120,7 +62122,9 @@ static int test_wolfSSL_set_SSL_CTX(void)
     ExpectNotNull(ssl = wolfSSL_new(ctx2));
     ExpectIntNE((wolfSSL_get_options(ssl) & WOLFSSL_OP_NO_TLSv1_3), 0);
 #ifdef WOLFSSL_INT_H
+#ifdef WOLFSSL_SESSION_ID_CTX
     ExpectIntEQ(XMEMCMP(ssl->sessionCtx, session_id2, 4), 0);
+#endif
     ExpectTrue(ssl->buffers.certificate == ctx2->certificate);
     ExpectTrue(ssl->buffers.certChain == ctx2->certChain);
 #endif
@@ -62142,7 +62146,9 @@ static int test_wolfSSL_set_SSL_CTX(void)
 #ifdef WOLFSSL_INT_H
     ExpectTrue(ssl->buffers.certificate == ctx1->certificate);
     ExpectTrue(ssl->buffers.certChain == ctx1->certChain);
+#ifdef WOLFSSL_SESSION_ID_CTX
     ExpectIntEQ(XMEMCMP(ssl->sessionCtx, session_id1, 4), 0);
+#endif
 #endif
 
     wolfSSL_free(ssl);

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -443,7 +443,7 @@ WOLFSSL_API int WOLFSSL_IS_DEBUG_ON(void)
 #endif /* !WOLFSSL_DEBUG_ERRORS_ONLY */
 #endif /* DEBUG_WOLFSSL */
 
-#if defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE)
+#if defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE) || defined(HAVE_MEMCACHED)
 
 #ifdef WOLFSSL_HAVE_ERROR_QUEUE
 
@@ -1463,7 +1463,8 @@ void wc_ERR_print_errors_fp(XFILE fp)
 
 #endif /* !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM) */
 
-#endif /* defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE) */
+#endif /* defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE)
+          || defined(HAVE_MEMCACHED) */
 
 /*
  * When using OPENSSL_EXTRA or DEBUG_WOLFSSL_VERBOSE macro then WOLFSSL_ERROR is

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3666,11 +3666,13 @@ struct WOLFSSL_CTX {
 #if defined(OPENSSL_EXTRA) || defined(HAVE_CURL)
     word32            disabledCurves;   /* curves disabled by user */
 #endif
-#ifdef OPENSSL_EXTRA
+#ifdef WOLFSSL_SESSION_ID_CTX
     byte              sessionCtx[ID_LEN]; /* app session context ID */
+    byte              sessionCtxSz;
+#endif
+#ifdef OPENSSL_EXTRA
     const unsigned char *alpn_cli_protos;/* ALPN client protocol list */
     unsigned int         alpn_cli_protos_len;
-    byte              sessionCtxSz;
     byte              cbioFlag;  /* WOLFSSL_CBIO_RECV/SEND: CBIORecv/Send is set */
     CallbackInfoState* CBIS;      /* used to get info about SSL state */
     WOLFSSL_X509_VERIFY_PARAM* param;    /* verification parameters*/
@@ -4325,10 +4327,10 @@ struct WOLFSSL_SESSION {
     word16             idLen;             /* serverID length          */
     byte               serverID[SERVER_ID_LEN]; /* for easier client lookup */
 #endif
-#ifdef OPENSSL_EXTRA
+#ifdef WOLFSSL_SESSION_ID_CTX
     byte               sessionCtxSz;      /* sessionCtx length        */
     byte               sessionCtx[ID_LEN]; /* app specific context id */
-#endif /* OPENSSL_EXTRA */
+#endif /* WOLFSSL_SESSION_ID_CTX */
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     byte               peerVerifyRet;     /* cert verify error */
 #endif
@@ -5475,13 +5477,16 @@ struct WOLFSSL {
     CipherSpecs     specs;
     Keys            keys;
     Options         options;
+#ifdef WOLFSSL_SESSION_ID_CTX
+    byte             sessionCtx[ID_LEN]; /* app session context ID */
+    byte             sessionCtxSz;       /* size of sessionCtx stored */
+#endif
 #ifdef OPENSSL_EXTRA
     CallbackInfoState* CBIS;             /* used to get info about SSL state */
     int              cbmode;             /* read or write on info callback */
     int              cbtype;             /* event type in info callback */
     WOLFSSL_BIO*     biord;              /* socket bio read  to free/close */
     WOLFSSL_BIO*     biowr;              /* socket bio write to free/close */
-    byte             sessionCtx[ID_LEN]; /* app session context ID */
     WOLFSSL_X509_VERIFY_PARAM* param;    /* verification parameters*/
 #endif
 #if defined(OPENSSL_EXTRA) || defined(HAVE_CURL)
@@ -5493,7 +5498,6 @@ struct WOLFSSL {
 #endif
 #ifdef OPENSSL_EXTRA
     byte             readAhead;
-    byte             sessionCtxSz;       /* size of sessionCtx stored */
 #ifdef HAVE_PK_CALLBACKS
     void*            loggingCtx;         /* logging callback argument */
 #endif

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -925,6 +925,7 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #define SSL_CTX_set_timeout(ctx, to)    \
                                  wolfSSL_CTX_set_timeout(ctx, (unsigned int)(to))
 #define SSL_CTX_set_info_callback       wolfSSL_CTX_set_info_callback
+#define SSL_set_info_callback           wolfSSL_set_info_callback
 #define SSL_CTX_set_alpn_protos         wolfSSL_CTX_set_alpn_protos
 
 #define SSL_CTX_keylog_cb_func          wolfSSL_CTX_keylog_cb_func
@@ -1552,6 +1553,7 @@ typedef WOLFSSL_SRTP_PROTECTION_PROFILE      SRTP_PROTECTION_PROFILE;
 #define SSL_OP_SINGLE_DH_USE            WOLFSSL_OP_SINGLE_DH_USE
 #define SSL_OP_SINGLE_ECDH_USE          WOLFSSL_OP_SINGLE_ECDH_USE
 #define SSL_OP_CIPHER_SERVER_PREFERENCE WOLFSSL_OP_CIPHER_SERVER_PREFERENCE
+#define SSL_OP_NO_RENEGOTIATION         WOLFSSL_OP_NO_RENEGOTIATION
 
 #define OPENSSL_config                  wolfSSL_OPENSSL_config
 #define OPENSSL_memdup                  wolfSSL_OPENSSL_memdup
@@ -1563,6 +1565,7 @@ typedef WOLFSSL_SRTP_PROTECTION_PROFILE      SRTP_PROTECTION_PROFILE;
 #define SSL_get_wbio                    wolfSSL_SSL_get_wbio
 #define SSL_do_handshake                wolfSSL_SSL_do_handshake
 #define SSL_in_init                     wolfSSL_SSL_in_init
+#define SSL_in_before                   wolfSSL_SSL_in_before
 #define SSL_in_connect_init             wolfSSL_SSL_in_connect_init
 #define SSL_get0_session                wolfSSL_SSL_get0_session
 #define SSL_CTX_set_tlsext_ticket_key_cb wolfSSL_CTX_set_tlsext_ticket_key_cb

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2169,6 +2169,8 @@ WOLFSSL_API void *wolfSSL_CTX_get_default_passwd_cb_userdata(WOLFSSL_CTX *ctx);
 
 WOLFSSL_API void wolfSSL_CTX_set_info_callback(WOLFSSL_CTX* ctx,
                           void (*f)(const WOLFSSL* ssl, int type, int val));
+WOLFSSL_API void wolfSSL_set_info_callback(WOLFSSL* ssl,
+                          void (*f)(const WOLFSSL* ssl, int type, int val));
 
 WOLFSSL_API unsigned long wolfSSL_ERR_peek_error(void);
 WOLFSSL_API int           wolfSSL_GET_REASON(int);
@@ -2271,6 +2273,7 @@ enum {
     WOLFSSL_OP_TLS_D5_BUG                             = 0x00000080,
     WOLFSSL_OP_TLS_BLOCK_PADDING_BUG                  = 0x00000100,
     WOLFSSL_OP_TLS_ROLLBACK_BUG                       = 0x00000200,
+    WOLFSSL_OP_NO_RENEGOTIATION                       = 0x00000400,
     WOLFSSL_OP_EPHEMERAL_RSA                          = 0x00000800,
     WOLFSSL_OP_NO_SSLv3                               = 0x00001000,
     WOLFSSL_OP_NO_TLSv1                               = 0x00002000,
@@ -2306,7 +2309,7 @@ enum {
 };
 
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || \
-    defined(HAVE_WEBSERVER)
+    defined(HAVE_WEBSERVER) || defined(HAVE_MEMCACHED)
 /* for compatibility these must be macros */
 
 #define SSL_OP_MICROSOFT_SESS_ID_BUG            WOLFSSL_OP_MICROSOFT_SESS_ID_BUG
@@ -4939,6 +4942,7 @@ WOLFSSL_API int wolfSSL_SSL_in_init(const WOLFSSL* ssl);
 #else
 WOLFSSL_API int wolfSSL_SSL_in_init(WOLFSSL* ssl);
 #endif
+WOLFSSL_API int wolfSSL_SSL_in_before(const WOLFSSL* ssl);
 WOLFSSL_API int wolfSSL_SSL_in_connect_init(WOLFSSL* ssl);
 
 #ifndef NO_SESSION_CACHE

--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -109,11 +109,12 @@ WOLFSSL_API void wolfSSL_SetLoggingPrefix(const char* prefix);
 
 
 #if (defined(OPENSSL_EXTRA) && !defined(_WIN32) && \
-        !defined(NO_ERROR_QUEUE)) || defined(DEBUG_WOLFSSL_VERBOSE)
+        !defined(NO_ERROR_QUEUE)) || defined(DEBUG_WOLFSSL_VERBOSE) \
+        || defined(HAVE_MEMCACHED)
 #define WOLFSSL_HAVE_ERROR_QUEUE
 #endif
 
-#if defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE)
+#if defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE) || defined(HAVE_MEMCACHED)
     WOLFSSL_LOCAL int wc_LoggingInit(void);
     WOLFSSL_LOCAL int wc_LoggingCleanup(void);
     WOLFSSL_LOCAL int wc_AddErrorNode(int error, int line, char* buf,
@@ -135,7 +136,7 @@ WOLFSSL_API void wolfSSL_SetLoggingPrefix(const char* prefix);
         WOLFSSL_API void wc_ERR_print_errors_cb(int (*cb)(const char *str,
                                                 size_t len, void *u), void *u);
     #endif
-#endif /* OPENSSL_EXTRA || DEBUG_WOLFSSL_VERBOSE */
+#endif /* OPENSSL_EXTRA || DEBUG_WOLFSSL_VERBOSE || HAVE_MEMCACHED */
 
 #ifdef WOLFSSL_FUNC_TIME
     /* WARNING: This code is only to be used for debugging performance.

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -334,6 +334,9 @@
 
 #undef HAVE_CTS
 #define HAVE_CTS
+
+#undef WOLFSSL_SESSION_ID_CTX
+#define WOLFSSL_SESSION_ID_CTX
 #endif /* OPENSSL_EXTRA && !OPENSSL_COEXIST */
 
 /* Special small OpenSSL compat layer for certs */


### PR DESCRIPTION
memcached support: add required functions/defines.

Break out session_id_context APIs into separate option WOLFSSL_SESSION_ID_CTX, so they can be used without OPENSSL_EXTRA.

Make wolfSSL_ERR_get_error available for memcached.

Add --enable-memcached.

# Testing

Tested by building with memcached and using its test suite.