### PR TITLE
CMake: add option to enable asio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMakeList.txt
 #
-# Copyright (C) 2006-2020 wolfSSL Inc.
+# Copyright (C) 2006-2023 wolfSSL Inc.
 #
 # This file is part of wolfSSL. (formerly known as CyaSSL)
 #
@@ -391,6 +391,24 @@ add_option(WOLFSSL_OPENSSLEXTRA
     "Enable extra OpenSSL API, size+ (default: disabled)"
     "no" "yes;no")
 
+add_option(WOLFSSL_OPENSSLALL
+    "Enable all OpenSSL API, size++ (default: disabled)"
+    "no" "yes;no")
+
+add_option(WOLFSSL_ASIO
+    "Enable asio support (default: disabled)"
+    "no" "yes;no")
+
+if (WOLFSSL_ASIO)
+    list(APPEND WOLFSSL_DEFINITIONS
+    "-DWOLFSSL_ASIO" "-DASIO_USE_WOLFSSL"
+    "-DBOOST_ASIO_USE_WOLFSSL" "-DHAVE_EX_DATA"
+    "-DSSL_TXT_TLSV1_2" "-DOPENSSL_NO_SSL2" "-DOPENSSL_NO_SSL3"
+    "-DHAVE_OCSP" "-DWOLFSSL_KEY_GEN")
+    override_cache(WOLFSSL_OPENSSLALL "yes")
+    override_cache(WOLFSSL_OPENSSLEXTRA "yes")
+endif()
+
 if (WOLFSSL_OPENSSLEXTRA AND NOT WOLFSSL_OPENSSLCOEXIST)
     list(APPEND WOLFSSL_DEFINITIONS
       "-DOPENSSL_EXTRA"
@@ -400,6 +418,14 @@ if (WOLFSSL_OPENSSLEXTRA AND NOT WOLFSSL_OPENSSLCOEXIST)
       "-DHAVE_EXT_CACHE"
       "-DWOLFSSL_FORCE_CACHE_ON_TICKET")
 endif()
+
+if (WOLFSSL_OPENSSLALL)
+    list(APPEND WOLFSSL_DEFINITIONS
+      "-DOPENSSL_ALL" "-DWOLFSSL_EITHER_SIDE" "-DWC_RSA_NO_PADDING"
+      "-DWC_RSA_PSS" "-DWOLFSSL_PSS_LONG_SALT" "-DWOLFSSL_TICKET_HAVE_ID"
+      "-DWOLFSSL_ERROR_CODE_OPENSSL" "-DWOLFSSL_CERT_NAME_ALL")
+endif()
+
 
 # TODO: - IPv6 test apps
 
@@ -548,7 +574,7 @@ endif()
 
 # SHA224
 set(SHA224_DEFAULT "no")
-if(("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64|AMD64") OR
+if(("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64|AMD64|arm64") OR
     ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64"))
     if(NOT WOLFSSL_AFALG AND NOT WOLFSSL_DEVCRYPTO AND
        (NOT WOLFSSL_FIPS OR ("${FIPS_VERSION}" STREQUAL "v2")))
@@ -562,7 +588,7 @@ add_option("WOLFSSL_SHA224"
 
 # SHA3
 set(SHA3_DEFAULT "no")
-if(("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64|AMD64") OR
+if(("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64|AMD64|arm64") OR
     ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64"))
     if(NOT WOLFSSL_FIPS OR ("${FIPS_VERSION}" STREQUAL "v2"))
         set(SHA3_DEFAULT "yes")
@@ -1048,7 +1074,7 @@ endif()
 
 # Base64
 set(BASE64_ENCODE_DEFAULT "no")
-if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64|AMD64")
+if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64|AMD64|arm64")
     set(BASE64_ENCODE_DEFAULT "yes")
 endif()
 
@@ -1068,7 +1094,8 @@ add_option("WOLFSSL_DES3" ${WOLFSSL_DES3_HELP_STRING} "no" "yes;no")
 if(WOLFSSL_OPENSSH OR
    WOLFSSL_QT OR
    WOLFSSL_OPENVPN OR
-   WOLFSSL_WPAS)
+   WOLFSSL_WPAS OR
+   WOLFSSL_ASIO)
     override_cache(WOLFSSL_DES3 "yes")
 endif()
 
@@ -1867,6 +1894,16 @@ if(WOLFSSL_CONFIG_H)
                    "${CMAKE_CURRENT_BINARY_DIR}/wolfcrypt/test/test_paths.h" )
 endif()
 
+# If config.h or wolfssl/options.h exists, delete it to avoid
+# a mixup with build/wolfssl/options.h.
+if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/wolfssl/options.h")
+    file(REMOVE "${CMAKE_CURRENT_SOURCE_DIR}/wolfssl/options.h")
+endif()
+
+if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/config.h")
+    file(REMOVE "${CMAKE_CURRENT_SOURCE_DIR}/config.h")
+endif()
+
 # Suppress some warnings about separate compilation, inlining
 add_definitions("-DWOLFSSL_IGNORE_FILE_WARN")
 # Generate user options header
@@ -1892,7 +1929,7 @@ file(REMOVE ${OPTION_FILE})
 file(APPEND ${OPTION_FILE} "/* wolfssl options.h\n")
 file(APPEND ${OPTION_FILE} " * generated from configure options\n")
 file(APPEND ${OPTION_FILE} " *\n")
-file(APPEND ${OPTION_FILE} " * Copyright (C) 2006-2020 wolfSSL Inc.\n")
+file(APPEND ${OPTION_FILE} " * Copyright (C) 2006-2023 wolfSSL Inc.\n")
 file(APPEND ${OPTION_FILE} " *\n")
 file(APPEND ${OPTION_FILE} " * This file is part of wolfSSL. (formerly known as CyaSSL)\n")
 file(APPEND ${OPTION_FILE} " *\n")

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -824,6 +824,7 @@ function(generate_lib_src_list LIB_SOURCES)
                    src/wolfio.c
                    src/keys.c
                    src/ssl.c
+                   src/ocsp.c
                    src/tls.c)
 
               if(BUILD_TLS13)

--- a/src/pk.c
+++ b/src/pk.c
@@ -7435,7 +7435,8 @@ static WOLFSSL_DH *wolfssl_dhparams_read_pem(WOLFSSL_DH **dh,
         }
         /* If Success on X9.42 DH format, clear error from failed DH format */
         else {
-            wolfSSL_ERR_clear_error();
+            unsigned long error;
+            CLEAR_ASN_NO_PEM_HEADER_ERROR(error);
         }
     }
     if (memAlloced) {

--- a/src/pk.c
+++ b/src/pk.c
@@ -7433,6 +7433,10 @@ static WOLFSSL_DH *wolfssl_dhparams_read_pem(WOLFSSL_DH **dh,
                 != 0) {
             err = 1;
         }
+        /* If Success on X9.42 DH format, clear error from failed DH format */
+        else {
+            wolfSSL_ERR_clear_error();
+        }
     }
     if (memAlloced) {
         /* PEM data no longer needed.  */


### PR DESCRIPTION
# Description

Also a minor change to `src/pk.c` to get the asio examples working.

# Testing

Tested using https://github.com/wolfSSL/osp/tree/master/asio#readme. Skip the wolfSSL autoconf setup instructions in favor of the below.

```
mkdir build
cd build
cmake -DWOLFSSL_ASIO=yes  ..
make
sudo make install
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
