### PR TITLE
added test case for wolfSSL_configure_args

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -66101,6 +66101,16 @@ static int test_dtls_ipv6_check(void)
     return TEST_SKIPPED;
 }
 #endif
+
+static int test_wolfSSL_configure_args(void)
+{
+#if defined(LIBWOLFSSL_CONFIGURE_ARGS) && defined(HAVE_WC_INTROSPECTION)
+    AssertNotNull(wolfSSL_configure_args());
+    return TEST_SUCCESS;
+#else
+    return TEST_SKIPPED;
+#endif
+}
 /*----------------------------------------------------------------------------*
  | Main
  *----------------------------------------------------------------------------*/
@@ -66348,6 +66358,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wc_ERR_remove_state),
     TEST_DECL(test_wc_ERR_print_errors_fp),
 #endif
+    TEST_DECL(test_wolfSSL_configure_args),
     TEST_DECL(test_wolfSSL_set_options),
     TEST_DECL(test_wolfSSL_sk_SSL_CIPHER),
     TEST_DECL(test_wolfSSL_set1_curves_list),


### PR DESCRIPTION
Made a simple unit test case for wolfSSL_configure_args that is found in the wolfcrypt/src/logging.c

Using this as an on-boarding process for wolfSSL's GitHub approval process