### PR TITLE
Clear sig algos for SSL objects on calling wolfSSL_clear()

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -20230,6 +20230,11 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
         #endif
         ssl->options.rejectTicket = 0;
     #endif
+        ssl->options.haveRSA = 0;
+        ssl->options.haveECC = 0;
+        ssl->options.haveFalconSig = 0;
+        ssl->options.haveDilithiumSig = 0;
+        ssl->options.haveDH = 0;
     #ifdef WOLFSSL_EARLY_DATA
         ssl->earlyData = no_early_data;
         ssl->earlyDataSz = 0;


### PR DESCRIPTION
# Description

Initializing a CTX with a dummy RSA cert would set ctx->haveRSA to 1. Later when using the real ECC cert, ctx->haveRSA is still set to 1 even if it's no longer available. The  info is then copied into ssl->options.haveRSA. This PR clears pre-existing settings on processing new certs.

Fixes zd#16168

# Testing

Tested by customer.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
