### PR TITLE
fix to cast diff type, int and uint

### DIFF
--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -388,7 +388,7 @@ static int sockAddrEqual(
 #ifndef WOLFSSL_IPV6
 static int PeerIsIpv6(const SOCKADDR_S *peer, XSOCKLENT len)
 {
-    if (len < sizeof(peer->ss_family))
+    if (len < (int)sizeof(peer->ss_family))
         return 0;
     return peer->ss_family == WOLFSSL_IP6;
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -65944,7 +65944,7 @@ static int test_dtls_msg_get_connected_port(int fd, word16 *port)
     XMEMSET((byte*)&peer, 0, sizeof(peer));
     len = sizeof(peer);
     ret = getpeername(fd,  (SOCKADDR*)&peer, &len);
-    if (ret != 0 || len > sizeof(peer))
+    if (ret != 0 || len > (int)sizeof(peer))
         return -1;
     switch (peer.ss_family) {
 #ifdef WOLFSSL_IPV6


### PR DESCRIPTION
# Description

This fixes android jenkins failure.
Cast to fix difference type comparison

# Testing
Build wolfssl using arm-linux-androideabi-gcc (GCC) 4.9

# Checklist

 - [n/a] added tests
 - [n/a] updated/added doxygen
 - [n/a] updated appropriate READMEs
 - [n/a] Updated manual and documentation
