### PR TITLE
For NO_RSA, don't advertise support for RSA.

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -3187,6 +3187,10 @@ void InitSuites(Suites* suites, ProtocolVersion pv, int keySz, word16 haveRSA,
     }
 #endif /* !NO_WOLFSSL_SERVER */
 
+#ifdef NO_RSA
+    haveRSAsig = 0;    /* can't have RSA sig if don't have RSA */
+#endif
+
 #ifdef WOLFSSL_DTLS
     if (pv.major == DTLS_MAJOR) {
         dtls   = 1;

--- a/src/tls.c
+++ b/src/tls.c
@@ -6500,8 +6500,10 @@ static word16 TLSX_SignatureAlgorithms_Write(void* data, byte* output)
         hashSigAlgoSz = sa->hashSigAlgoSz;
     }
 
+#ifndef NO_RSA
     TLSX_SignatureAlgorithms_MapPss(sa->ssl, output + OPAQUE16_LEN,
             hashSigAlgoSz);
+#endif
 
     return OPAQUE16_LEN + hashSigAlgoSz;
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -64320,8 +64320,9 @@ static int test_wolfSSL_DTLS_fragment_buckets(void)
 
 
 #if !defined(NO_FILESYSTEM) && \
-     defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12) &&                    \
-    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER)
+     defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    !defined(NO_RSA)
 
 static int test_wolfSSL_dtls_stateless2(void)
 {
@@ -64580,7 +64581,7 @@ static int test_wolfSSL_dtls_stateless_downgrade(void)
 
 #if defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12) &&                     \
     !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) &&              \
-    !defined(NO_OLD_TLS)
+    !defined(NO_OLD_TLS) && !defined(NO_RSA)
 static int test_WOLFSSL_dtls_version_alert(void)
 {
     struct test_memio_ctx test_ctx;
@@ -64635,7 +64636,7 @@ static int test_WOLFSSL_dtls_version_alert(void)
 }
 #endif /* defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12) &&
         * !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) &&
-        * !defined(NO_OLD_TLS)
+        * !defined(NO_OLD_TLS) && !defined(NO_RSA)
         */
 
 
@@ -65927,7 +65928,7 @@ static int test_wolfSSL_dtls13_null_cipher(void)
 #endif
 #if defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12) &&          \
     !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) &&   \
-    !defined(SINGLE_THREADED)
+    !defined(SINGLE_THREADED) && !defined(NO_RSA)
 
 static int test_dtls_msg_get_connected_port(int fd, word16 *port)
 {
@@ -66021,7 +66022,7 @@ static int test_dtls_msg_from_other_peer(void)
 }
 #endif /* defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12) &&          \
         *  !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) &&  \
-        *  !defined(SINGLE_THREADED) */
+        *  !defined(SINGLE_THREADED) && !defined(NO_RSA) */
 #if defined(WOLFSSL_DTLS) && !defined(WOLFSSL_IPV6) &&               \
     !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) &&   \
     defined(HAVE_IO_TESTS_DEPENDENCIES)
@@ -67108,10 +67109,12 @@ TEST_CASE testCases[] = {
 #ifdef HAVE_MAX_FRAGMENT
     TEST_DECL(test_wolfSSL_dtls_stateless_maxfrag),
 #endif /* HAVE_MAX_FRAGMENT */
+#ifndef NO_RSA
     TEST_DECL(test_wolfSSL_dtls_stateless2),
 #if !defined(NO_OLD_TLS)
     TEST_DECL(test_wolfSSL_dtls_stateless_downgrade),
 #endif /* !defined(NO_OLD_TLS) */
+#endif /* ! NO_RSA */
 #endif /* defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12) &&     \
         *  !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) */
     TEST_DECL(test_wolfSSL_CTX_set_ciphersuites),


### PR DESCRIPTION
Fixes https://github.com/wolfSSL/wolfssl/issues/6451

Tested with: 
`--disable-rsa --enable-dtls`