### PR TITLE
Allow option to create SSL without key/cert in ctx

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -89,6 +89,9 @@
  *     - WOLFSSL_HARDEN_TLS_NO_SCR_CHECK
  *     - WOLFSSL_HARDEN_TLS_NO_PKEY_CHECK
  *     - WOLFSSL_HARDEN_TLS_ALLOW_ALL_CIPHERSUITES
+ * WOLFSSL_NO_INIT_CTX_KEY
+ *      Allows SSL objects to be created from a CTX without a loaded key/cert
+ *      pair
  */
 
 
@@ -7060,9 +7063,13 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
 
     /* Initialize SSL with the appropriate fields from it's ctx */
     /* requires valid arrays and suites unless writeDup ing */
-    if ((ret = SetSSL_CTX(ssl, ctx, writeDup)) != WOLFSSL_SUCCESS)
+    if ((ret = SetSSL_CTX(ssl, ctx, writeDup)) != WOLFSSL_SUCCESS
+#ifdef WOLFSSL_NO_INIT_CTX_KEY
+        && ret != NO_PRIVATE_KEY
+#endif
+        ) {
         return ret;
-
+    }
     ssl->options.dtls = ssl->version.major == DTLS_MAJOR;
 
 #ifdef HAVE_WRITE_DUP

--- a/tests/api.c
+++ b/tests/api.c
@@ -3785,7 +3785,7 @@ static int test_server_wolfSSL_new(void)
     /* invalid context */
     ExpectNull(ssl = wolfSSL_new(NULL));
 #if !defined(WOLFSSL_SESSION_EXPORT) && !defined(WOLFSSL_QT) && \
-        !defined(OPENSSL_EXTRA)
+        !defined(OPENSSL_EXTRA) && !defined(WOLFSSL_NO_INIT_CTX_KEY)
     ExpectNull(ssl = wolfSSL_new(ctx_nocert));
 #endif
 


### PR DESCRIPTION
# Description

Allow build option to create SSL object without key/cert in ctx

Fixes zd#zd168

# Testing

Removed calls to load key/cert into the ctx object in https://github.com/wolfSSL/wolfssl-examples/blob/master/tls/server-tls.c and added calls to by load the key/cert into the ssl object.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
