### PR TITLE
Improve GCC-ARM user-settings.h FIPS configurability

### DIFF
--- a/IDE/GCC-ARM/Header/user_settings.h
+++ b/IDE/GCC-ARM/Header/user_settings.h
@@ -195,6 +195,9 @@ extern "C" {
 
         #undef  WOLFSSL_VALIDATE_ECC_IMPORT
         #define WOLFSSL_VALIDATE_ECC_IMPORT /* Validate import */
+
+        #undef  WOLFSSL_ECDSA_SET_K
+        #define WOLFSSL_ECDSA_SET_K
     #endif
 
     /* Compressed Key Support */

--- a/IDE/GCC-ARM/Header/user_settings.h
+++ b/IDE/GCC-ARM/Header/user_settings.h
@@ -85,11 +85,24 @@ extern "C" {
 /* FIPS - Requires eval or license from wolfSSL */
 /* ------------------------------------------------------------------------- */
 #undef  HAVE_FIPS
+#undef  HAVE_FIPS_VERSION
+#undef  HAVE_FIPS_VERSION_MINOR
 #if 0
     #define HAVE_FIPS
 
-    #undef  HAVE_FIPS_VERSION
-    #define HAVE_FIPS_VERSION 2
+    /* Choose a FIPS version */
+    #if 0
+        /* FIPS 140-2 */
+        #define HAVE_FIPS_VERSION 2
+    #elif 0
+        /* FIPS 140-3 */
+        #define HAVE_FIPS_VERSION 5
+        #define HAVE_FIPS_VERSION_MINOR 2
+    #elif 0
+        /* FIPS Ready */
+        #define HAVE_FIPS_VERSION 5
+        #define HAVE_FIPS_VERSION_MINOR 3
+    #endif
 
     #ifdef SINGLE_THREADED
         #undef  NO_THREAD_LS

--- a/IDE/GCC-ARM/Makefile.common
+++ b/IDE/GCC-ARM/Makefile.common
@@ -1,11 +1,11 @@
 # Set to @ if you want to suppress command echo
-CMD_ECHO = 
+CMD_ECHO =
 
 # Important directories
 BUILD_DIR = ./Build
 
 # Toolchain location and prefix
-#TOOLCHAIN = 
+#TOOLCHAIN =
 TOOLCHAIN ?= /opt/gcc-arm-none-eabi/bin/arm-none-eabi-
 
 # Tools selection
@@ -101,6 +101,7 @@ SRC_C += ../../wolfcrypt/src/des3.c
 SRC_C += ../../wolfcrypt/src/dh.c
 SRC_C += ../../wolfcrypt/src/ecc.c
 SRC_C += ../../wolfcrypt/src/hmac.c
+SRC_C += ../../wolfcrypt/src/kdf.c
 SRC_C += ../../wolfcrypt/src/random.c
 SRC_C += ../../wolfcrypt/src/rsa.c
 SRC_C += ../../wolfcrypt/src/sha.c
@@ -138,7 +139,6 @@ SRC_C += ../../wolfcrypt/src/ge_448.c
 SRC_C += ../../wolfcrypt/src/ge_low_mem.c
 SRC_C += ../../wolfcrypt/src/ge_operations.c
 SRC_C += ../../wolfcrypt/src/hash.c
-SRC_C += ../../wolfcrypt/src/kdf.c
 SRC_C += ../../wolfcrypt/src/integer.c
 SRC_C += ../../wolfcrypt/src/logging.c
 SRC_C += ../../wolfcrypt/src/md5.c


### PR DESCRIPTION
# Description

Improve FIPS-build for gcc-arm example makefile & user settings.

Fixes zd#16195

# Testing

Test with:
```
./fips-check.sh linuxv5 keep
cd XXX-fips-test
cd IDE/GCC-ARM
```
Edit `Header/user_settings.h `to enable and specify a FIPS version.

```
make clean
make
```
# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
