### PR TITLE
Update to copy unaligned data into buffer during sha256

### DIFF
--- a/wolfcrypt/src/port/arm/armv8-sha256.c
+++ b/wolfcrypt/src/port/arm/armv8-sha256.c
@@ -301,6 +301,7 @@ static WC_INLINE int Sha256Update(wc_Sha256* sha256, const byte* data, word32 le
         numBlocks = (len + sha256->buffLen)/WC_SHA256_BLOCK_SIZE;
 
         if (numBlocks > 0) {
+#if defined(WC_HASH_DATA_ALIGNMENT) && (WC_HASH_DATA_ALIGNMENT >= 8)
             /* handle unaligned data */
             if ((wc_ptr_t)data & 0x7) {
                 while (numBlocks--) {
@@ -315,7 +316,10 @@ static WC_INLINE int Sha256Update(wc_Sha256* sha256, const byte* data, word32 le
                 }
                 add = len;
             }
-            else {
+            else 
+#endif /* WC_HASH_DATA_ALIGNMENT>=8 */
+            {
+
               /* get leftover amount after blocks */
               add = (len + sha256->buffLen) - numBlocks * WC_SHA256_BLOCK_SIZE;
 


### PR DESCRIPTION
# Description

When aarch64 optimized assembly is used, the ld1 instruction is used to directly read data from a user-supplied data buffer during the sha256 update, which may be unaligned on a 64-bit boundary especially during wolfBoot.  This correction detects non-aligned data pointers and XMEMCPY's the data into the aligned sha256->buffer structure, which roughly approximates the same operations the hardware would perform, but this avoids any unaligned 64-bit reads from memory.  This specifically corrects accesses to on-chip RAM (OCRAM) on ARMv8 processors that must be mapped as Device instead of Normal memory, as all unaligned accesses to Device memory generate a synchronous unaligned data exception.

# Testing

This change was installed on an NXP LS1028A board with wolfBoot executing out of OCRAM.  Without this correction, all boot attempts with ARMASM enabled failed as the size of the image header is 44 bytes, causing the initial image data pointer to be unaligned. 

# Checklist

 - [ None ] added tests - triggering this error would require a specific hardware setup.  No additional tests necessary.
 - [ N/A ] updated/added doxygen
 - [ N/A ] updated appropriate READMEs
 - [ N/A] Updated manual and documentation
