### PR TITLE
20230531-analyzer-guided-fixes

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -9276,7 +9276,7 @@ static int test_wolfSSL_SNI_GetFromBuffer(void)
 
     ExpectIntEQ(WOLFSSL_SUCCESS, wolfSSL_SNI_GetFromBuffer(buff, sizeof(buff),
                                                            0, result, &length));
-    if (EXPECT_RESULT() == TEST_SUCCESS)
+    if (EXPECT_SUCCESS())
         result[length] = 0;
     ExpectStrEQ("www.paypal.com", (const char*) result);
 
@@ -9284,7 +9284,7 @@ static int test_wolfSSL_SNI_GetFromBuffer(void)
 
     ExpectIntEQ(WOLFSSL_SUCCESS, wolfSSL_SNI_GetFromBuffer(buff2, sizeof(buff2),
                                                            0, result, &length));
-    if (EXPECT_RESULT() == TEST_SUCCESS)
+    if (EXPECT_SUCCESS())
         result[length] = 0;
     ExpectStrEQ("api.textmate.org", (const char*) result);
 
@@ -34871,7 +34871,7 @@ static int test_wc_KeyPemToDer(void)
     /* Test NULL for DER buffer to return needed DER buffer size */
     ExpectIntGT(ret = wc_KeyPemToDer(cert_buf, cert_sz, NULL, 0, ""), 0);
     ExpectIntLE(ret, cert_sz);
-    if (EXPECT_RESULT() == TEST_SUCCESS)
+    if (EXPECT_SUCCESS())
         cert_dersz = ret;
     ExpectNotNull(cert_der = (byte*)malloc(cert_dersz));
     ExpectIntGE(ret = wc_KeyPemToDer(cert_buf, cert_sz, cert_der, cert_dersz,

--- a/tests/unit.h
+++ b/tests/unit.h
@@ -187,17 +187,17 @@
 
 #define ExpectPtr(x, y, op, er) do {                                           \
     if (_ret == 0) {                                                           \
-        PRAGMA_GCC_DIAG_PUSH;                                                  \
+        PRAGMA_DIAG_PUSH;                                                      \
           /* remarkably, without this inhibition, */                           \
           /* the _Pragma()s make the declarations warn. */                     \
-        PRAGMA_GCC("GCC diagnostic ignored \"-Wdeclaration-after-statement\"");\
+        PRAGMA("GCC diagnostic ignored \"-Wdeclaration-after-statement\"");    \
           /* inhibit "ISO C forbids conversion of function pointer */          \
           /* to object pointer type [-Werror=pedantic]" */                     \
-        PRAGMA_GCC("GCC diagnostic ignored \"-Wpedantic\"");                   \
+        PRAGMA("GCC diagnostic ignored \"-Wpedantic\"");                       \
         void* _x = (void*)(x);                                                 \
         void* _y = (void*)(y);                                                 \
         Expect(_x op _y, ("%s " #op " %s", #x, #y), ("%p " #er " %p", _x, _y));\
-        PRAGMA_GCC_DIAG_POP;                                                   \
+        PRAGMA_DIAG_POP;                                                       \
     }                                                                          \
 } while(0)
 

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -709,14 +709,6 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
         #define AESNI_ALIGN 16
     #endif
 
-    #ifdef _MSC_VER
-        #define XASM_LINK(f)
-    #elif defined(__APPLE__)
-        #define XASM_LINK(f) asm("_" f)
-    #else
-        #define XASM_LINK(f) asm(f)
-    #endif /* _MSC_VER */
-
     static int checkAESNI = 0;
     static int haveAESNI  = 0;
     static word32 intel_flags = 0;

--- a/wolfcrypt/src/asm.c
+++ b/wolfcrypt/src/asm.c
@@ -46,15 +46,9 @@
             __asm__ __volatile__ ("cpuid":\
              "=a" (reg[0]), "=b" (reg[1]), "=c" (reg[2]), "=d" (reg[3]) :\
              "a" (leaf), "c"(sub));
-
-    #define XASM_LINK(f) asm(f)
 #else
-
     #include <intrin.h>
     #define cpuid(a,b,c) __cpuidex((int*)a,b,c)
-
-    #define XASM_LINK(f)
-
 #endif /* _MSC_VER */
 
 #define EAX 0

--- a/wolfcrypt/src/cpuid.c
+++ b/wolfcrypt/src/cpuid.c
@@ -43,14 +43,10 @@
             __asm__ __volatile__ ("cpuid":\
                 "=a" ((reg)[0]), "=b" ((reg)[1]), "=c" ((reg)[2]), "=d" ((reg)[3]) :\
                 "a" (leaf), "c"(sub));
-
-        #define XASM_LINK(f) asm(f)
     #else
         #include <intrin.h>
 
         #define cpuid(a,b,c) __cpuidex((int*)a,b,c)
-
-        #define XASM_LINK(f)
     #endif /* _MSC_VER */
 
     #define EAX 0

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -24,6 +24,13 @@
     #include <config.h>
 #endif
 
+#ifdef WOLFSSL_LINUXKM
+    /* inhibit "#undef current" in linuxkm_wc_port.h, included from wc_port.h,
+     * because needed in linuxkm_memory.c, included below.
+     */
+    #define WOLFSSL_NEED_LINUX_CURRENT
+#endif
+
 #include <wolfssl/wolfcrypt/settings.h>
 
 /* check old macros @wc_fips */

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -2928,8 +2928,9 @@ static WC_INLINE int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
                                        wolfSSL_X509_get_issuer_name(peer), 0, 0);
         char* subject = wolfSSL_X509_NAME_oneline(
                                       wolfSSL_X509_get_subject_name(peer), 0, 0);
-        printf("\tPeer's cert info:\n issuer : %s\n subject: %s\n", issuer,
-                                                                  subject);
+        printf("\tPeer's cert info:\n issuer : %s\n subject: %s\n",
+               issuer ? issuer : "[none]",
+               subject ? subject : "[none]");
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
         if (issuer != NULL && subject != NULL) {
             /* preverify needs to be self-signer error for Qt compat.

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1379,6 +1379,9 @@ typedef struct w64wrapper {
         #define PRAGMA_GCC_DIAG_PUSH _Pragma("GCC diagnostic push")
         #define PRAGMA_GCC(str) _Pragma(str)
         #define PRAGMA_GCC_DIAG_POP _Pragma("GCC diagnostic pop")
+        #define PRAGMA_DIAG_PUSH PRAGMA_GCC_DIAG_PUSH
+        #define PRAGMA(str) PRAGMA_GCC(str)
+        #define PRAGMA_DIAG_POP PRAGMA_GCC_DIAG_POP
     #else
         #define PRAGMA_GCC_DIAG_PUSH
         #define PRAGMA_GCC(str)
@@ -1389,10 +1392,23 @@ typedef struct w64wrapper {
         #define PRAGMA_CLANG_DIAG_PUSH _Pragma("clang diagnostic push")
         #define PRAGMA_CLANG(str) _Pragma(str)
         #define PRAGMA_CLANG_DIAG_POP _Pragma("clang diagnostic pop")
+        #define PRAGMA_DIAG_PUSH PRAGMA_CLANG_DIAG_PUSH
+        #define PRAGMA(str) PRAGMA_CLANG(str)
+        #define PRAGMA_DIAG_POP PRAGMA_CLANG_DIAG_POP
     #else
         #define PRAGMA_CLANG_DIAG_PUSH
         #define PRAGMA_CLANG(str)
         #define PRAGMA_CLANG_DIAG_POP
+    #endif
+
+    #ifndef PRAGMA_DIAG_PUSH
+        #define PRAGMA_DIAG_PUSH
+    #endif
+    #ifndef PRAGMA
+        #define PRAGMA(str)
+    #endif
+    #ifndef PRAGMA_DIAG_POP
+        #define PRAGMA_DIAG_POP
     #endif
 
     #ifdef DEBUG_VECTOR_REGISTER_ACCESS

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1180,8 +1180,22 @@ typedef struct w64wrapper {
     /* invalid device id */
     #define INVALID_DEVID    (-2)
 
-    /* AESNI requires alignment and ARMASM gains some performance from it
-     * Xilinx RSA operations require alignment */
+    #ifdef XASM_LINK
+        /* keep user-supplied definition */
+    #elif defined(_MSC_VER)
+        #define XASM_LINK(f)
+    #elif defined(__APPLE__)
+        #define XASM_LINK(f) asm("_" f)
+    #elif defined(__GNUC__)
+        /* use alternate keyword for compatibility with -std=c99 */
+        #define XASM_LINK(f) __asm__(f)
+    #else
+        #define XASM_LINK(f) asm(f)
+    #endif
+
+    /* AESNI requires alignment and ARMASM gains some performance from it.
+     * Xilinx RSA operations require alignment.
+     */
     #if defined(WOLFSSL_AESNI) || defined(WOLFSSL_ARMASM) || \
         defined(USE_INTEL_SPEEDUP) || defined(WOLFSSL_AFALG_XILINX) || \
         defined(WOLFSSL_XILINX)


### PR DESCRIPTION
`wolfcrypt/src/memory.c`: restore required linuxkm `#define WOLFSSL_NEED_LINUX_CURRENT`.

move definitions of `XASM_LINK()` from `wolfcrypt/src/aes.c`, `wolfcrypt/src/asm.c`, and `wolfcrypt/src/cpuid.c`, to `wolfssl/wolfcrypt/types.h`, and use `__asm__()` instead of `asm()` if `__GNUC__`, for compatibility with `-std=c99`.

`wolfssl/wolfcrypt/types.h`: add `PRAGMA_DIAG_PUSH`, `PRAGMA()`, and `PRAGMA_DIAG_POP()`, using the `gcc` or `clang` variants as applicable, to facilitate pragmas to be used on both `gcc` and `clang`;

`tests/unit.h`: fix `ExpectPtr()` to inhibit pedantic warnings on both `gcc` and `clang`;

`wolfssl/test.h`: in `myVerify()`, explicitly check for nullness when printing `issuer`/`subject`, to avoid `cppcheck` null-deref warning;

`tests/api.c`: fixes for:

* myriad "embedding a directive within macro arguments is not portable"
* an "ISO C forbids conversion of object pointer to function pointer type"
* some `stringop-overflow`s
* a `clang-analyzer-core.uninitialized.Assign`
* a `clang-analyzer-core.CallAndMessage` "2nd function call argument is an uninitialized value"
* a `nullPointerRedundantCheck`
* several `clang-diagnostic-declaration-after-statement`
* a spurious `gcc` sanitizer `maybe-uninitialized` in `test_wolfSSL_CheckOCSPResponse()`


tested with `wolfssl-multi-test.sh ...  super-quick-check all-gcc-c89-sanitize cross-aarch64-all-armasm-unittest-sanitizer clang-tidy-all-async-quic clang-tidy-fips-140-3-all sanitizer-all-asm-smallstack-async-quic'.*linuxkm.*' all-gcc-c89-sanitize sp-asn-template-asm-sanitizer intmath-sanitizeri ntmath-sanitizer-clang all-clang-sp-all-intelasm cross-armv7a-all-armasm-testsuite sp-asn-template-asm-sanitizer clang-tidy-all-intelasm`
