### PR TITLE
Add support for Mosquitto OSP

### DIFF
--- a/.github/workflows/mosquitto.yml
+++ b/.github/workflows/mosquitto.yml
@@ -1,7 +1,16 @@
 name: mosquitto Tests
 
+# START OF COMMON SECTION
 on:
-  workflow_call:
+  push:
+    branches: [ 'master', 'main', 'release/**' ]
+  pull_request:
+    branches: [ '*' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+# END OF COMMON SECTION
 
 jobs:
   build_wolfssl:
@@ -19,43 +28,17 @@ jobs:
           install: true
 
       - name: Upload built lib
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wolf-install-mosquitto
           path: build-dir
-          retention-days: 1
+          retention-days: 5
 
   mosquitto_check:
     strategy:
       fail-fast: false
       matrix:
-        # List of releases to test
-        include:
-          - ref: v2.0.15
-            ignore-tests: >-
-              ./01-connect-zero-length-id.py 06-bridge-reconnect-local-out.py
-              ./08-ssl-connect-cert-auth-crl.py
-              ./08-ssl-connect-cert-auth-revoked.py
-              ./08-ssl-connect-cert-auth.py
-              ./08-ssl-connect-identity.py
-              ./08-ssl-connect-no-auth.py
-              ./08-ssl-connect-no-identity.py
-              ./08-ssl-hup-disconnect.py
-              ./14-dynsec-acl.py
-              ./14-dynsec-anon-group.py
-              ./14-dynsec-auth.py
-              ./14-dynsec-client-invalid.py
-              ./14-dynsec-client.py
-              ./14-dynsec-default-access.py
-              ./14-dynsec-disable-client.py
-              ./14-dynsec-group-invalid.py
-              ./14-dynsec-group.py
-              ./14-dynsec-modify-client.py
-              ./14-dynsec-modify-group.py
-              ./14-dynsec-modify-role.py
-              ./14-dynsec-plugin-invalid.py
-              ./14-dynsec-role-invalid.py
-              ./14-dynsec-role.py
+        ref: [ 2.0.18 ]
     name: ${{ matrix.ref }}
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
@@ -63,13 +46,13 @@ jobs:
     needs: build_wolfssl
     steps:
       - name: Download lib
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: wolf-install-mosquitto
           path: build-dir
 
       - name: Checkout OSP
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: wolfssl/osp
           path: osp
@@ -79,29 +62,22 @@ jobs:
             export DEBIAN_FRONTEND=noninteractive
             sudo apt-get update
             sudo apt-get install -y build-essential libev-dev libssl-dev automake python3-docutils libcunit1 libcunit1-doc libcunit1-dev pkg-config make
+            sudo pip install --upgrade psutil
 
       - name: Checkout mosquitto
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: eclipse/mosquitto
-          ref: v2.0.15
+          ref: v${{ matrix.ref }}
           path: mosquitto
-
-      # Do this before configuring so that it only detects the updated list of
-      # tests
-      - if: ${{ matrix.ignore-tests }}
-        name: Remove tests that we want to ignore
-        working-directory: ./mosquitto/test/broker
-        run: |
-          rm ${{ matrix.ignore-tests }}
 
       - name: Configure and build mosquitto
         run: |
             cd $GITHUB_WORKSPACE/mosquitto/
-            patch -p1 < $GITHUB_WORKSPACE/osp/mosquitto/2.0.15.patch
-            make WITH_TLS=wolfssl WITH_CJSON=no WITH_DOCS=no
+            patch -p1 < $GITHUB_WORKSPACE/osp/mosquitto/${{ matrix.ref }}.patch
+            make WITH_TLS=wolfssl WITH_CJSON=no WITH_DOCS=no WOLFSSLDIR=$GITHUB_WORKSPACE/build-dir -j
 
       - name: Run mosquitto tests, skipping ignored tests
         working-directory: ./mosquitto
         run: |
-          make WITH_TLS=wolfssl WITH_CJSON=no WITH_DOCS=no ptest
+          make WITH_TLS=wolfssl WITH_CJSON=no WITH_DOCS=no WOLFSSLDIR=$GITHUB_WORKSPACE/build-dir ptest -j

--- a/.github/workflows/mosquitto.yml
+++ b/.github/workflows/mosquitto.yml
@@ -24,7 +24,7 @@ jobs:
         uses: wolfSSL/actions-build-autotools-project@v1
         with:
           path: wolfssl
-          configure: --enable-mosquitto
+          configure: --enable-mosquitto CFLAGS="-DALLOW_INVALID_CERTSIGN"
           install: true
 
       - name: Upload built lib
@@ -75,9 +75,9 @@ jobs:
         run: |
             cd $GITHUB_WORKSPACE/mosquitto/
             patch -p1 < $GITHUB_WORKSPACE/osp/mosquitto/${{ matrix.ref }}.patch
-            make WITH_TLS=wolfssl WITH_CJSON=no WITH_DOCS=no WOLFSSLDIR=$GITHUB_WORKSPACE/build-dir -j
+            make WITH_TLS=wolfssl WITH_CJSON=no WITH_DOCS=no WOLFSSLDIR=$GITHUB_WORKSPACE/build-dir
 
-      - name: Run mosquitto tests, skipping ignored tests
+      - name: Run mosquitto tests
         working-directory: ./mosquitto
         run: |
-          make WITH_TLS=wolfssl WITH_CJSON=no WITH_DOCS=no WOLFSSLDIR=$GITHUB_WORKSPACE/build-dir ptest -j
+          make WITH_TLS=wolfssl WITH_CJSON=no WITH_DOCS=no WOLFSSLDIR=$GITHUB_WORKSPACE/build-dir ptest

--- a/.github/workflows/mosquitto.yml
+++ b/.github/workflows/mosquitto.yml
@@ -1,0 +1,107 @@
+name: mosquitto Tests
+
+on:
+  workflow_call:
+
+jobs:
+  build_wolfssl:
+    name: Build wolfSSL
+    # Just to keep it the same as the testing target
+    runs-on: ubuntu-latest
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 4
+    steps:
+      - name: Build wolfSSL
+        uses: wolfSSL/actions-build-autotools-project@v1
+        with:
+          path: wolfssl
+          configure: --enable-mosquitto
+          install: true
+
+      - name: Upload built lib
+        uses: actions/upload-artifact@v3
+        with:
+          name: wolf-install-mosquitto
+          path: build-dir
+          retention-days: 1
+
+  mosquitto_check:
+    strategy:
+      fail-fast: false
+      matrix:
+        # List of releases to test
+        include:
+          - ref: v2.0.15
+            ignore-tests: >-
+              ./01-connect-zero-length-id.py 06-bridge-reconnect-local-out.py
+              ./08-ssl-connect-cert-auth-crl.py
+              ./08-ssl-connect-cert-auth-revoked.py
+              ./08-ssl-connect-cert-auth.py
+              ./08-ssl-connect-identity.py
+              ./08-ssl-connect-no-auth.py
+              ./08-ssl-connect-no-identity.py
+              ./08-ssl-hup-disconnect.py
+              ./14-dynsec-acl.py
+              ./14-dynsec-anon-group.py
+              ./14-dynsec-auth.py
+              ./14-dynsec-client-invalid.py
+              ./14-dynsec-client.py
+              ./14-dynsec-default-access.py
+              ./14-dynsec-disable-client.py
+              ./14-dynsec-group-invalid.py
+              ./14-dynsec-group.py
+              ./14-dynsec-modify-client.py
+              ./14-dynsec-modify-group.py
+              ./14-dynsec-modify-role.py
+              ./14-dynsec-plugin-invalid.py
+              ./14-dynsec-role-invalid.py
+              ./14-dynsec-role.py
+    name: ${{ matrix.ref }}
+    runs-on: ubuntu-latest
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 4
+    needs: build_wolfssl
+    steps:
+      - name: Download lib
+        uses: actions/download-artifact@v3
+        with:
+          name: wolf-install-mosquitto
+          path: build-dir
+
+      - name: Checkout OSP
+        uses: actions/checkout@v3
+        with:
+          repository: wolfssl/osp
+          path: osp
+
+      - name: Install dependencies
+        run: |
+            export DEBIAN_FRONTEND=noninteractive
+            sudo apt-get update
+            sudo apt-get install -y build-essential libev-dev libssl-dev automake python3-docutils libcunit1 libcunit1-doc libcunit1-dev pkg-config make
+
+      - name: Checkout mosquitto
+        uses: actions/checkout@v3
+        with:
+          repository: eclipse/mosquitto
+          ref: v2.0.15
+          path: mosquitto
+
+      # Do this before configuring so that it only detects the updated list of
+      # tests
+      - if: ${{ matrix.ignore-tests }}
+        name: Remove tests that we want to ignore
+        working-directory: ./mosquitto/test/broker
+        run: |
+          rm ${{ matrix.ignore-tests }}
+
+      - name: Configure and build mosquitto
+        run: |
+            cd $GITHUB_WORKSPACE/mosquitto/
+            patch -p1 < $GITHUB_WORKSPACE/osp/mosquitto/2.0.15.patch
+            make WITH_TLS=wolfssl WITH_CJSON=no WITH_DOCS=no
+
+      - name: Run mosquitto tests, skipping ignored tests
+        working-directory: ./mosquitto
+        run: |
+          make WITH_TLS=wolfssl WITH_CJSON=no WITH_DOCS=no ptest

--- a/configure.ac
+++ b/configure.ac
@@ -1817,6 +1817,7 @@ AC_ARG_ENABLE([mcast],
 # OpenLDAP (--enable-openldap)
 # hitch (--enable-hitch)
 # memcached (--enable-memcached)
+# Mosquitto (--enable-mosquitto) HAVE_MOSQUITTO
 
 # Bind DNS compatibility Build
 AC_ARG_ENABLE([bind],
@@ -1880,12 +1881,25 @@ AC_ARG_ENABLE([openldap],
     [ ENABLED_OPENLDAP=no ]
     )
 
+# Mosquitto support
+AC_ARG_ENABLE([mosquitto],
+    [AS_HELP_STRING([--enable-mosquitto],[Enable Mosquitto support (default: disabled)])],
+    [ ENABLED_MOSQUITTO=$enableval ],
+    [ ENABLED_MOSQUITTO=no ]
+    )
+
+if test "x$ENABLED_MOSQUITTO" = "xyes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_MOSQUITTO"
+fi
+
 # lighty Support
 AC_ARG_ENABLE([lighty],
     [AS_HELP_STRING([--enable-lighty],[Enable lighttpd/lighty (default: disabled)])],
     [ ENABLED_LIGHTY=$enableval ],
     [ ENABLED_LIGHTY=no ]
     )
+
 # rsyslog Support
 AC_ARG_ENABLE([rsyslog],
     [AS_HELP_STRING([--enable-rsyslog],[Enable rsyslog (default: disabled)])],
@@ -2145,7 +2159,7 @@ if test "$ENABLED_LIBWEBSOCKETS" = "yes" || test "$ENABLED_OPENVPN" = "yes" || \
    test "$ENABLED_OPENRESTY" = "yes" || test "$ENABLED_RSYSLOG" = "yes" || \
    test "$ENABLED_KRB" = "yes" || test "$ENABLED_CHRONY" = "yes" || \
    test "$ENABLED_FFMPEG" = "yes" || test "$ENABLED_STRONGSWAN" = "yes" || \
-   test "$ENABLED_OPENLDAP" = "yes" || test "$ENABLED_HITCH" = "yes"
+   test "$ENABLED_OPENLDAP" = "yes" || test "x$ENABLED_MOSQUITTO" = "xyes" || test "$ENABLED_HITCH" = "yes"
 then
     ENABLED_OPENSSLALL="yes"
 fi
@@ -3742,7 +3756,7 @@ AC_ARG_ENABLE([sessioncerts],
 
 if test "x$ENABLED_NGINX" = "xyes" || test "x$ENABLED_OPENVPN" = "xyes" || \
    test "x$ENABLED_LIGHTY" = "xyes" || test "x$ENABLED_NETSNMP" = "xyes" || \
-   test "x$ENABLED_STRONGSWAN" = "xyes" || test "x$ENABLED_HITCH" = "xyes"
+   test "x$ENABLED_STRONGSWAN" = "xyes" || test "x$ENABLED_HITCH" = "xyes" || test "x$ENABLED_MOSQUITTO" = "xyes"
 then
     ENABLED_SESSIONCERTS=yes
 fi
@@ -4225,6 +4239,11 @@ AC_ARG_ENABLE([psk],
     [ ENABLED_PSK=$enableval ],
     [ ENABLED_PSK=no ]
     )
+
+if test "x$ENABLED_MOSQUITTO" = "xyes"
+then
+    ENABLED_PSK=yes
+fi
 
 # Single PSK identity
 AC_ARG_ENABLE([psk-one-id],
@@ -5851,7 +5870,8 @@ fi
 
 
 # OCSP
-if test "x$ENABLED_OPENSSLALL" = "xyes" || test "x$ENABLED_NGINX" = "xyes" || test "x$ENABLED_LIGHTY" = "xyes"
+if test "x$ENABLED_OPENSSLALL" = "xyes" || test "x$ENABLED_NGINX" = "xyes" || \
+   test "x$ENABLED_LIGHTY" = "xyes" || test "x$ENABLED_MOSQUITTO" = "xyes"
 then
     test "$enable_ocsp" = "" && enable_ocsp=yes
 fi
@@ -5883,7 +5903,9 @@ AC_ARG_ENABLE([ocspstapling],
     [ ENABLED_CERTIFICATE_STATUS_REQUEST=no ]
     )
 
-if test "x$ENABLED_NGINX" = "xyes" || test "x$ENABLED_WPAS" = "xyes" || test "x$ENABLED_HAPROXY" = "xyes" || test "x$ENABLED_LIGHTY" = "xyes"
+if test "x$ENABLED_NGINX" = "xyes" || test "x$ENABLED_WPAS" = "xyes" || \
+   test "x$ENABLED_HAPROXY" = "xyes" || test "x$ENABLED_LIGHTY" = "xyes" || \
+   test "x$ENABLED_MOSQUITTO" = "xyes"
 then
     ENABLED_CERTIFICATE_STATUS_REQUEST="yes"
 fi
@@ -5931,9 +5953,11 @@ AC_ARG_ENABLE([crl],
     [ ENABLED_CRL=no ]
     )
 
-if test "x$ENABLED_NGINX" = "xyes" || test "x$ENABLED_HAPROXY" = "xyes" || test "x$ENABLED_OPENVPN" = "xyes" || \
-   test "x$ENABLED_WPAS" != "xno" || test "x$ENABLED_LIGHTY" = "xyes" || test "x$ENABLED_NETSNMP" = "xyes" || \
-   test "x$ENABLED_KRB" = "xyes" || test "x$ENABLED_STRONGSWAN" = "xyes"
+if test "x$ENABLED_NGINX" = "xyes" || test "x$ENABLED_HAPROXY" = "xyes" || \
+   test "x$ENABLED_OPENVPN" = "xyes" || test "x$ENABLED_WPAS" != "xno" ||  \
+   test "x$ENABLED_LIGHTY" = "xyes" || test "x$ENABLED_NETSNMP" = "xyes" || \
+   test "x$ENABLED_KRB" = "xyes" || test "x$ENABLED_STRONGSWAN" = "xyes" || \
+   test "x$ENABLED_MOSQUITTO" = "xyes"
 then
     ENABLED_CRL=yes
 fi
@@ -8947,7 +8971,7 @@ if test "$ENABLED_OPENSSH" = "yes" || test "$ENABLED_NGINX" = "yes" || \
    test "$ENABLED_LIBWEBSOCKETS" = "yes" || \
    test "x$ENABLED_LIGHTY" = "xyes" || test "$ENABLED_LIBSSH2" = "yes" || \
    test "x$ENABLED_NTP" = "xyes" || test "$ENABLED_RSYSLOG" = "yes" || \
-   test "$ENABLED_OPENLDAP" = "yes" || test "$ENABLED_HITCH" = "yes"
+   test "$ENABLED_OPENLDAP" = "yes" || test "$ENABLED_HITCH" = "yes" || test "x$ENABLED_MOSQUITTO" = "xyes"
 then
     ENABLED_OPENSSLEXTRA="yes"
 fi
@@ -9138,6 +9162,8 @@ AS_IF([test "x$ENABLED_STRONGSWAN" = "xyes"],
       [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DES_ECB -DWOLFSSL_LOG_PRINTF -DWOLFSSL_PUBLIC_MP -DHAVE_EX_DATA"])
 
 AS_IF([test "x$ENABLED_OPENLDAP" = "xyes"], [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SIGNER_DER_CERT"])
+
+AS_IF([test "x$ENABLED_MOSQUITTO" = "xyes"], [AM_CFLAGS="$AM_CFLAGS -DHAVE_EX_DATA"])
 
 if test "$ENABLED_ED25519_STREAM" != "no" && test "$ENABLED_SE050" != "yes"
 then
@@ -10181,6 +10207,7 @@ echo "   * strongSwan:                 $ENABLED_STRONGSWAN"
 echo "   * OpenLDAP:                   $ENABLED_OPENLDAP"
 echo "   * hitch:                      $ENABLED_HITCH"
 echo "   * memcached:                  $ENABLED_MEMCACHED"
+echo "   * Mosquitto                   $ENABLED_MOSQUITTO"
 echo "   * ERROR_STRINGS:              $ENABLED_ERROR_STRINGS"
 echo "   * DTLS:                       $ENABLED_DTLS"
 echo "   * DTLS v1.3:                  $ENABLED_DTLS13"

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -23240,6 +23240,18 @@ int wolfSSL_CTX_set_ecdh_auto(WOLFSSL_CTX* ctx, int onoff)
     return WOLFSSL_SUCCESS;
 }
 
+/* wolfSSL_CTX_set_dh_auto is provided as compatible API with
+ * SSL_CTX_set_dh_auto to enable auto dh selection functionality.
+ * Since this functionality is enabled by default in wolfSSL,
+ * this API exists as a stub.
+ */
+int wolfSSL_CTX_set_dh_auto(WOLFSSL_CTX* ctx, int onoff)
+{
+    (void)ctx;
+    (void)onoff;
+    return WOLFSSL_SUCCESS;
+}
+
 /**
  * set security level (wolfSSL doesn't support security level)
  * @param ctx  a pointer to WOLFSSL_EVP_PKEY_CTX structure

--- a/tests/api.c
+++ b/tests/api.c
@@ -3709,6 +3709,7 @@ static int test_wolfSSL_CertManagerCRL(void)
         wolfSSL_CertManagerLoadCRL(cm, crl2, WOLFSSL_FILETYPE_PEM, 0));
     wolfSSL_CertManagerFreeCRL(cm);
 
+#ifndef WOLFSSL_CRL_ALLOW_MISSING_CDP
     ExpectIntEQ(WOLFSSL_SUCCESS,
         wolfSSL_CertManagerLoadCRL(cm, crl1, WOLFSSL_FILETYPE_PEM, 0));
     ExpectIntEQ(WOLFSSL_SUCCESS,
@@ -3717,6 +3718,7 @@ static int test_wolfSSL_CertManagerCRL(void)
         sizeof_server_cert_der_2048), CRL_MISSING);
     ExpectIntEQ(wolfSSL_CertManagerVerifyBuffer(cm, server_cert_der_2048,
         sizeof_server_cert_der_2048, WOLFSSL_FILETYPE_ASN1), CRL_MISSING);
+#endif /* !WOLFSSL_CRL_ALLOW_MISSING_CDP */
 
     ExpectIntEQ(wolfSSL_CertManagerLoadCRLBuffer(cm, crl_buff, sizeof(crl_buff),
         WOLFSSL_FILETYPE_ASN1), 1);
@@ -48722,13 +48724,15 @@ static int test_wolfSSL_X509_STORE(void)
 
 #ifdef HAVE_CRL
     X509_STORE_CTX *storeCtx = NULL;
-    X509_CRL *crl = NULL;
     X509 *ca = NULL;
     X509 *cert = NULL;
-    const char crlPem[] = "./certs/crl/crl.revoked";
     const char srvCert[] = "./certs/server-revoked-cert.pem";
     const char caCert[] = "./certs/ca-cert.pem";
+#ifndef WOLFSSL_CRL_ALLOW_MISSING_CDP
+    X509_CRL *crl = NULL;
+    const char crlPem[] = "./certs/crl/crl.revoked";
     XFILE fp = XBADFILE;
+#endif /* !WOLFSSL_CRL_ALLOW_MISSING_CDP */
 
     ExpectNotNull(store = (X509_STORE *)X509_STORE_new());
     ExpectNotNull((ca = wolfSSL_X509_load_certificate_file(caCert,
@@ -48748,6 +48752,7 @@ static int test_wolfSSL_X509_STORE(void)
     X509_free(ca);
     ca = NULL;
 
+#ifndef WOLFSSL_CRL_ALLOW_MISSING_CDP
     /* should fail to verify now after adding in CRL */
     ExpectNotNull(store = (X509_STORE *)X509_STORE_new());
     ExpectNotNull((ca = wolfSSL_X509_load_certificate_file(caCert,
@@ -48777,6 +48782,7 @@ static int test_wolfSSL_X509_STORE(void)
     cert = NULL;
     X509_free(ca);
     ca = NULL;
+#endif /* !WOLFSSL_CRL_ALLOW_MISSING_CDP */
 #endif /* HAVE_CRL */
 
 
@@ -66996,7 +67002,8 @@ static int test_wolfSSL_X509_load_crl_file(void)
 {
     EXPECT_DECLS;
 #if defined(OPENSSL_EXTRA) && defined(HAVE_CRL) && !defined(NO_FILESYSTEM) && \
-    !defined(NO_STDIO_FILESYSTEM) && !defined(NO_RSA) && !defined(NO_BIO)
+    !defined(NO_STDIO_FILESYSTEM) && !defined(NO_RSA) && !defined(NO_BIO) && \
+    !defined(WOLFSSL_CRL_ALLOW_MISSING_CDP)
     int i;
     char pem[][100] = {
         "./certs/crl/crl.pem",
@@ -73682,7 +73689,8 @@ static int test_wolfSSL_CTX_LoadCRL(void)
     return EXPECT_RESULT();
 }
 
-#if defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && defined(HAVE_CRL)
+#if defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && defined(HAVE_CRL) && \
+    !defined(WOLFSSL_CRL_ALLOW_MISSING_CDP)
 static int test_multiple_crls_same_issuer_ctx_ready(WOLFSSL_CTX* ctx)
 {
     EXPECT_DECLS;
@@ -73696,7 +73704,8 @@ static int test_multiple_crls_same_issuer_ctx_ready(WOLFSSL_CTX* ctx)
 static int test_multiple_crls_same_issuer(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && defined(HAVE_CRL)
+#if defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && defined(HAVE_CRL) && \
+    !defined(WOLFSSL_CRL_ALLOW_MISSING_CDP)
     test_ssl_cbf client_cbs, server_cbs;
     struct {
         const char* server_cert;
@@ -81299,7 +81308,8 @@ static int test_certreq_sighash_algos(void)
     return EXPECT_RESULT();
 }
 
-#if defined(HAVE_CRL) && defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES)
+#if defined(HAVE_CRL) && defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && \
+    !defined(WOLFSSL_CRL_ALLOW_MISSING_CDP)
 static int test_revoked_loaded_int_cert_ctx_ready1(WOLFSSL_CTX* ctx)
 {
     EXPECT_DECLS;
@@ -81349,7 +81359,8 @@ static int test_revoked_loaded_int_cert_ctx_ready2(WOLFSSL_CTX* ctx)
 static int test_revoked_loaded_int_cert(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_CRL) && defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES)
+#if defined(HAVE_CRL) && defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && \
+    !defined(WOLFSSL_CRL_ALLOW_MISSING_CDP)
     test_ssl_cbf client_cbf;
     test_ssl_cbf server_cbf;
     struct {
@@ -81389,7 +81400,6 @@ static int test_revoked_loaded_int_cert(void)
             break;
         printf("\t%s passed\n", test_params[i].certPemFile);
     }
-
 #endif
     return EXPECT_RESULT();
 }

--- a/wolfssl/openssl/opensslv.h
+++ b/wolfssl/openssl/opensslv.h
@@ -35,24 +35,26 @@
     defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER == 0x10100000L) ||\
     defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER == 0x10001040L)
      /* valid version */
+#elif defined(HAVE_MOSQUITTO)
+    #define OPENSSL_VERSION_NUMBER 0x10100000L
 #elif defined(WOLFSSL_APACHE_HTTPD) || defined(HAVE_LIBEST) || \
       defined(WOLFSSL_BIND) || defined(WOLFSSL_NGINX) || \
       defined(WOLFSSL_RSYSLOG) || defined(WOLFSSL_KRB) || defined(HAVE_STUNNEL) || \
       defined(WOLFSSL_OPENSSH)
     /* For Apache httpd, Use 1.1.0 compatibility */
-     #define OPENSSL_VERSION_NUMBER 0x10100003L
-#elif defined(WOLFSSL_QT) || defined(WOLFSSL_PYTHON) || defined(WOLFSSL_KRB)
+    #define OPENSSL_VERSION_NUMBER 0x10100003L
+#elif defined(WOLFSSL_QT) || defined(WOLFSSL_PYTHON)
     /* For Qt and Python 3.8.5 compatibility */
-     #define OPENSSL_VERSION_NUMBER 0x10101000L
+    #define OPENSSL_VERSION_NUMBER 0x10101000L
 #elif defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_FFMPEG)
-     #define OPENSSL_VERSION_NUMBER 0x1010000fL
+    #define OPENSSL_VERSION_NUMBER 0x1010000fL
 #elif defined(OPENSSL_ALL) || defined(HAVE_LIGHTY) || \
-    defined(WOLFSSL_NGINX) || defined(WOLFSSL_OPENVPN)
-     /* version number can be increased for Lighty after compatibility for ECDH
-        is added */
-     #define OPENSSL_VERSION_NUMBER 0x10001040L
+    defined(WOLFSSL_NGINX) || defined(WOLFSSL_OPENSSH) || defined(WOLFSSL_OPENVPN)
+    /* version number can be increased for Lighty after compatibility for ECDH
+       is added */
+    #define OPENSSL_VERSION_NUMBER 0x10001040L
 #else
-     #define OPENSSL_VERSION_NUMBER 0x0090810fL
+    #define OPENSSL_VERSION_NUMBER 0x0090810fL
 #endif
 
 #define OPENSSL_VERSION_TEXT             "wolfSSL " LIBWOLFSSL_VERSION_STRING

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -1228,7 +1228,7 @@ typedef WOLFSSL_SRTP_PROTECTION_PROFILE      SRTP_PROTECTION_PROFILE;
                                                                   (char *)(arg))
 #endif /* OPENSSL_ALL || WOLFSSL_ASIO || WOLFSSL_HAPROXY */
 
-#define SSL_CTX_set_dh_auto(ctx, arg)   wolfSSL_CTX_set_dh_auto;
+#define SSL_CTX_set_dh_auto             wolfSSL_CTX_set_dh_auto
 #define SSL_CTX_set_tmp_dh              wolfSSL_CTX_set_tmp_dh
 
 #define TLSEXT_STATUSTYPE_ocsp  1

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -1209,7 +1209,6 @@ typedef WOLFSSL_SRTP_PROTECTION_PROFILE      SRTP_PROTECTION_PROFILE;
 #define SSL_R_SHORT_READ     10
 #define ERR_R_PEM_LIB        9
 #define SSL_CTRL_MODE        33
-
 #define SSL_CTRL_CLEAR_EXTRA_CHAIN_CERTS        83
 
 #define SSL_CTX_clear_chain_certs(ctx) SSL_CTX_set0_chain(ctx,NULL)
@@ -1229,6 +1228,7 @@ typedef WOLFSSL_SRTP_PROTECTION_PROFILE      SRTP_PROTECTION_PROFILE;
                                                                   (char *)(arg))
 #endif /* OPENSSL_ALL || WOLFSSL_ASIO || WOLFSSL_HAPROXY */
 
+#define SSL_CTX_set_dh_auto(ctx, arg)   wolfSSL_CTX_set_dh_auto;
 #define SSL_CTX_set_tmp_dh              wolfSSL_CTX_set_tmp_dh
 
 #define TLSEXT_STATUSTYPE_ocsp  1

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1143,6 +1143,7 @@ WOLFSSL_API int wolfSSL_CTX_up_ref(WOLFSSL_CTX* ctx);
 #ifdef OPENSSL_EXTRA
 WOLFSSL_API int wolfSSL_set_ecdh_auto(WOLFSSL* ssl, int onoff);
 WOLFSSL_API int wolfSSL_CTX_set_ecdh_auto(WOLFSSL_CTX* ctx, int onoff);
+WOLFSSL_API int wolfSSL_CTX_set_dh_auto(WOLFSSL_CTX* ctx, int onoff);
 WOLFSSL_API int wolfSSL_get_signature_nid(WOLFSSL* ssl, int* nid);
 WOLFSSL_API int wolfSSL_get_signature_type_nid(const WOLFSSL* ssl, int* nid);
 WOLFSSL_API int wolfSSL_get_peer_signature_nid(WOLFSSL* ssl, int* nid);


### PR DESCRIPTION
# Description

To support mosquitto OSP
Add `SSL_CTX_set_dh_auto` stub
Add `--enable-mosquitto` config option

# Testing

wolfSSL

```
git clone https://github.com/wolfSSL/wolfssl.git
cd wolfssl
./autogen.sh
./configure --enable-mosquitto CFLAGS="-DALLOW_INVALID_CERTSIGN"
make
make install
```

Mosquito OSP patch
https://github.com/wolfSSL/osp/blob/master/mosquitto/2.0.18.patch

Eclipse Mosquitto

```
git clone https://github.com/eclipse/mosquitto.git
cd mosquitto
git checkout v2.0.18
patch -p1 < <path/to/patch/file>
make WITH_TLS=wolfssl
make WITH_TLS=wolfssl ptest
```

# Checklist

 - [X] added tests
 - [ ] updated/added doxygen
 - [X] updated appropriate READMEs
 - [ ] Updated manual and documentation
