### PR TITLE
20230601-fix-fips-XASM_LINK

### DIFF
--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1180,8 +1180,16 @@ typedef struct w64wrapper {
     /* invalid device id */
     #define INVALID_DEVID    (-2)
 
-    #ifdef XASM_LINK
+    #if defined(HAVE_FIPS) && FIPS_VERSION_LT(5,3)
+        #ifdef XASM_LINK
+            #error User-supplied XASM_LINK is not compatible with this FIPS version.
+        #else
+            /* use version in FIPS <=5.2 aes.c */
+        #endif
+    #elif defined(XASM_LINK)
         /* keep user-supplied definition */
+    #elif defined(WOLFSSL_NO_ASM)
+        #define XASM_LINK(f)
     #elif defined(_MSC_VER)
         #define XASM_LINK(f)
     #elif defined(__APPLE__)


### PR DESCRIPTION
`wolfssl/wolfcrypt/types.h`: conditionalize `XASM_LINK()` definition on `!FIPS_VERSION_LT(5,3)` and !`WOLFSSL_NO_ASM`.

tested with `wolfssl-multi-test.sh ... super-quick-check fips-140-3-optest-acvp-sp-asm fips-140-3-all linuxkm-all-fips-140-3 linuxkm-all-fips-140-3-dyn-hash linuxkm-defaults-all-fips-140-3 sp-all-asm-smallstack-sanitizer-fips-140-3-dev sp-all-asm-smallstack-sanitizer-fips-140-3 fips-140-3-optest-acvp-sp-asm sp-all-asm-smallstack-sanitizer-fips-140-3-dev sp-all-asm-smallstack-sanitizer-fips-140-3`.
