### PR TITLE
Read and assign err return val from _sp_mulmod_tmp

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -11736,7 +11736,7 @@ static int _sp_mulmod(const sp_int* a, const sp_int* b, const sp_int* m,
     }
     else {
         /* Do operation using temporary. */
-        _sp_mulmod_tmp(a, b, m, r);
+        err = _sp_mulmod_tmp(a, b, m, r);
     }
 
     return err;


### PR DESCRIPTION
# Description

The return code or error from _sp_mulmod_tmp is currently never checked. Assign err to return code.

Fixes zd#16252

# Testing

Zendesk reproducer.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
