### PR TITLE
Add support for Microchip Trust Anchor TA100

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2242,15 +2242,42 @@ AC_ARG_WITH([maxq10xx],
     ]
 )
 
+AC_ARG_ENABLE([microchip],
+    [AS_HELP_STRING([--enable-microchip],[Enable wolfSSL support for microchip/atmel 508/608/100 (default: disabled)])],
+    [ ENABLED_ATMEL=$enableval ],
+    [ ENABLED_ATMEL=no ]
+    )
+
+if test "$ENABLED_ATMEL" != "no"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_MICROCHIP"
+
+    for v in `echo $ENABLED_ATMEL | tr "," " "`
+    do
+      case $v in
+        508)
+            AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ATECC508A"
+            ;;
+
+        608)
+            AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ATECC608A"
+            ;;
+
+        100)
+            AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ATECC508A -DWOLFSSL_MICROCHIP_TA100 -DMICROCHIP_DEV_TYPE=TA100"
+            ;;
+      esac
+    done
+fi
 # Microchip/Atmel CryptoAuthLib
 ENABLED_CRYPTOAUTHLIB="no"
 trylibatcadir=""
 AC_ARG_WITH([cryptoauthlib],
-    [AS_HELP_STRING([--with-cryptoauthlib=PATH],[PATH to CryptoAuthLib install (default /usr/)])],
+    [AS_HELP_STRING([--with-cryptoauthlib=PATH],[PATH to CryptoAuthLib install (default /usr)])],
     [
         AC_MSG_CHECKING([for cryptoauthlib])
         CPPFLAGS="$CPPFLAGS -DWOLFSSL_ATECC508A"
-        LIBS="$LIBS -lcryptoauth"
+        LIBS="$LIBS -lcryptoauth -lwolfssl -lpthread -lrt"
 
         AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <cryptoauthlib.h>]], [[ atcab_init(0); ]])],[ libatca_linked=yes ],[ libatca_linked=no ])
 
@@ -2262,18 +2289,17 @@ AC_ARG_WITH([cryptoauthlib],
                 trylibatcadir="/usr"
             fi
 
-            LDFLAGS="$LDFLAGS -L$trylibatcadir/lib"
-            CPPFLAGS="$CPPFLAGS -I$trylibatcadir/lib"
-
-            AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <cryptoauthlib.h>]], [[ atcab_init(0); ]])],[ libatca_linked=yes ],[ libatca_linked=no ])
-
-            if test "x$libatca_linked" = "xno" ; then
-                AC_MSG_ERROR([cryptoauthlib isn't found.
-                If it's already installed, specify its path using --with-cryptoauthlib=/dir/])
+            if test "$host_cpu" = "aarch64" ; then
+                LIB_SUFFIX="/aarch64-linux-gnu"
+            else
+                LIB_SUFFIX=""
             fi
 
-            AM_LDFLAGS="$AM_LDFLAGS -L$trylibatcadir/lib"
-            AM_CFLAGS="$AM_CFLAGS -I$trylibatcadir/lib"
+            LDFLAGS="$LDFLAGS -L$trylibatcadir/lib$LIB_SUFFIX"
+            CPPFLAGS="$CPPFLAGS -I$trylibatcadir/include/cryptoauthlib"
+            AM_LDFLAGS="$AM_LDFLAGS -L$trylibatcadir/lib$LIB_SUFFIX"
+            AM_CFLAGS="$AM_CFLAGS -I$trylibatcadir/include/cryptoauthlib"
+
             AC_MSG_RESULT([yes])
         else
             AC_MSG_RESULT([yes])

--- a/configure.ac
+++ b/configure.ac
@@ -2264,7 +2264,7 @@ then
             ;;
 
         100)
-            AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ATECC508A -DWOLFSSL_MICROCHIP_TA100 -DMICROCHIP_DEV_TYPE=TA100"
+            AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_MICROCHIP_TA100 -DMICROCHIP_DEV_TYPE=TA100"
             ;;
       esac
     done
@@ -2276,7 +2276,6 @@ AC_ARG_WITH([cryptoauthlib],
     [AS_HELP_STRING([--with-cryptoauthlib=PATH],[PATH to CryptoAuthLib install (default /usr)])],
     [
         AC_MSG_CHECKING([for cryptoauthlib])
-        CPPFLAGS="$CPPFLAGS -DWOLFSSL_ATECC508A"
         LIBS="$LIBS -lcryptoauth -lwolfssl -lpthread -lrt"
 
         AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <cryptoauthlib.h>]], [[ atcab_init(0); ]])],[ libatca_linked=yes ],[ libatca_linked=no ])
@@ -2306,7 +2305,6 @@ AC_ARG_WITH([cryptoauthlib],
         fi
 
         ENABLED_CRYPTOAUTHLIB="yes"
-        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ATECC508A"
     ]
 )
 

--- a/src/pk.c
+++ b/src/pk.c
@@ -10459,6 +10459,7 @@ int wolfSSL_EC_POINT_set_affine_coordinates_GFp(const WOLFSSL_EC_GROUP* group,
 }
 
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+    !defined(WOLFSSL_MICROCHIP_TA100) && \
     !defined(HAVE_SELFTEST) && !defined(WOLFSSL_SP_MATH) && \
     !defined(WOLF_CRYPTO_CB_ONLY_ECC)
 /* Add two points on the same together.

--- a/tests/api.c
+++ b/tests/api.c
@@ -24338,7 +24338,7 @@ static int test_wc_ecc_pointFns(void)
     EXPECT_DECLS;
 #if defined(HAVE_ECC) && defined(HAVE_ECC_KEY_EXPORT) && \
     !defined(WC_NO_RNG) && !defined(WOLFSSL_ATECC508A) && \
-    !defined(WOLFSSL_ATECC608A)
+    !defined(WOLFSSL_ATECC608A) && !defined(WOLFSSL_MICROCHIP_TA100)
     ecc_key    key;
     WC_RNG     rng;
     int        ret;
@@ -24438,7 +24438,7 @@ static int test_wc_ecc_shared_secret_ssh(void)
     EXPECT_DECLS;
 #if defined(HAVE_ECC) && defined(HAVE_ECC_DHE) && \
     !defined(WC_NO_RNG) && !defined(WOLFSSL_ATECC508A) && \
-    !defined(WOLFSSL_ATECC608A)
+    !defined(WOLFSSL_ATECC608A) && !defined(WOLFSSL_MICROCHIP_TA100)
     ecc_key key;
     ecc_key key2;
     WC_RNG  rng;
@@ -24512,7 +24512,8 @@ static int test_wc_ecc_verify_hash_ex(void)
     EXPECT_DECLS;
 #if defined(HAVE_ECC) && defined(HAVE_ECC_SIGN) && defined(WOLFSSL_PUBLIC_MP) \
     && !defined(WC_NO_RNG) && !defined(WOLFSSL_ATECC508A) && \
-       !defined(WOLFSSL_ATECC608A) && !defined(WOLFSSL_KCAPI_ECC)
+       !defined(WOLFSSL_ATECC608A) && !defined(WOLFSSL_KCAPI_ECC) && \
+       !defined(WOLFSSL_MICROCHIP_TA100)
     ecc_key       key;
     WC_RNG        rng;
     int           ret;
@@ -24607,7 +24608,7 @@ static int test_wc_ecc_mulmod(void)
     EXPECT_DECLS;
 #if defined(HAVE_ECC) && !defined(WC_NO_RNG) && \
     !(defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
-      defined(WOLFSSL_VALIDATE_ECC_IMPORT))
+      defined(WOLFSSL_MICROCHIP_TA100) || defined(WOLFSSL_VALIDATE_ECC_IMPORT))
     ecc_key     key1;
     ecc_key     key2;
     ecc_key     key3;
@@ -57850,6 +57851,7 @@ static int test_wolfSSL_EC_POINT(void)
         X, Y, ctx), 0);
 
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+    !defined(WOLFSSL_MICROCHIP_TA100) && \
     !defined(HAVE_SELFTEST) && !defined(WOLFSSL_SP_MATH) && \
     !defined(WOLF_CRYPTO_CB_ONLY_ECC)
     ExpectIntEQ(EC_POINT_add(NULL, NULL, NULL, NULL, ctx), 0);

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -469,15 +469,9 @@
     #define TEST_SLEEP() WC_DO_NOTHING
 #endif
 
+#define TEST_STRING    "Everyone gets Friday off."
+#define TEST_STRING_SZ 25
 
-#if defined(WOLFSSL_MICROCHIP_TA100)
-    /* pad test message to 32 bytes */
-    #define TEST_STRING    "Everyone gets Friday off.padto32"
-    #define TEST_STRING_SZ 32
-#else
-    #define TEST_STRING    "Everyone gets Friday off."
-    #define TEST_STRING_SZ 25
-#endif
 /* Bit values for each algorithm that is able to be benchmarked.
  * Common grouping of algorithms also.
  * Each algorithm has a unique value for its type e.g. cipher.

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -3056,7 +3056,7 @@ static WARN_UNUSED_RESULT int wc_AesDecrypt(
         }
 #endif
 #if defined(WOLFSSL_MICROCHIP_TA100) && defined(WOLFSSL_MICROCHIP_AESGCM)
-        ret = microchip_aes_set_key(aes, userKey, keylen, iv, dir);
+        ret = wc_Microchip_aes_set_key(aes, userKey, keylen, iv, dir);
         if (ret == 0) {
             ret = wc_AesSetIV(aes, iv);
         }
@@ -6935,7 +6935,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
         authIn, authInSz);
 #endif
 #if defined(WOLFSSL_MICROCHIP_TA100) && defined(WOLFSSL_MICROCHIP_AESGCM)
-    return microchip_AesGcmEncrypt(
+    return wc_Microchip_AesGcmEncrypt(
         aes, out, in, sz,
         iv, ivSz,
         authTag, authTagSz,
@@ -7500,7 +7500,7 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
 
 #endif
 #if defined(WOLFSSL_MICROCHIP_TA100) && defined(WOLFSSL_MICROCHIP_AESGCM)
-    return microchip_AesGcmDecrypt(
+    return wc_Microchip_AesGcmDecrypt(
         aes, out, in, sz, iv, ivSz,
         authTag, authTagSz, authIn, authInSz);
 #endif
@@ -9960,7 +9960,7 @@ void wc_AesFree(Aes* aes)
     }
 #endif
 #if defined(WOLFSSL_MICROCHIP_TA100) && defined(WOLFSSL_MICROCHIP_AESGCM)
-    microchip_aes_free(aes);
+    wc_Microchip_aes_free(aes);
 #endif
 #if defined(WOLFSSL_HAVE_PSA) && !defined(WOLFSSL_PSA_NO_AES)
     wc_psa_aes_free(aes);

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -216,6 +216,7 @@ ECC Curve Sizes:
 #endif
 
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+    !defined(WOLFSSL_MICROCHIP_TA100) && \
     !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_SILABS_SE_ACCEL) && \
     !defined(WOLFSSL_KCAPI_ECC) && !defined(WOLFSSL_SE050) && \
     !defined(WOLFSSL_XILINX_CRYPT_VERSAL)
@@ -224,6 +225,7 @@ ECC Curve Sizes:
 #endif
 
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+        !defined(WOLFSSL_MICROCHIP_TA100) && \
     !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_SILABS_SE_ACCEL) && \
     !defined(WOLFSSL_KCAPI_ECC) && !defined(NO_ECC_MAKE_PUB) && \
     !defined(WOLF_CRYPTO_CB_ONLY_ECC)
@@ -233,6 +235,7 @@ ECC Curve Sizes:
 
 #if !defined(WOLFSSL_SP_MATH) && \
     !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+    !defined(WOLFSSL_MICROCHIP_TA100) && \
     !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_SILABS_SE_ACCEL) && \
     !defined(WOLFSSL_SE050) && !defined(WOLFSSL_STM32_PKA) && \
     !defined(WOLF_CRYPTO_CB_ONLY_ECC)
@@ -1817,6 +1820,7 @@ static void alt_fp_init(mp_int* a)
 
 
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+    !defined(WOLFSSL_MICROCHIP_TA100) && \
     !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLF_CRYPTO_CB_ONLY_ECC)
 
 #if !defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_PUBLIC_ECC_ADD_DBL)
@@ -4536,7 +4540,7 @@ int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key, byte* out,
    int err = 0;
 
 #if defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_ATECC508A) && \
-   !defined(WOLFSSL_ATECC608A)
+   !defined(WOLFSSL_ATECC608A) && !defined(WOLFSSL_MICROCHIP_TA100)
    CRYS_ECDH_TempData_t tempBuff;
 #endif
 
@@ -4584,7 +4588,8 @@ int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key, byte* out,
       return ECC_BAD_ARG_E;
    }
 
-#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A)
+#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
+    defined(WOLFSSL_MICROCHIP_TA100)
    /* For SECP256R1 use hardware */
    if (private_key->dp->id == ECC_SECP256R1) {
        err = atmel_ecc_create_pms(private_key->slot, public_key->pubkey_raw, out);
@@ -4622,6 +4627,7 @@ int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key, byte* out,
 
 
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+    !defined(WOLFSSL_MICROCHIP_TA100) && \
     !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_KCAPI_ECC) && \
     !defined(WOLF_CRYPTO_CB_ONLY_ECC)
 
@@ -5118,6 +5124,7 @@ int wc_ecc_point_is_on_curve(ecc_point *p, int curve_idx)
 #endif /* USE_ECC_B_PARAM */
 
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+    !defined(WOLFSSL_MICROCHIP_TA100) && \
     !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLF_CRYPTO_CB_ONLY_ECC)
 /* return 1 if point is at infinity, 0 if not, < 0 on error */
 int wc_ecc_point_is_at_infinity(ecc_point* p)
@@ -5430,6 +5437,7 @@ static int _ecc_make_key_ex(WC_RNG* rng, int keysize, ecc_key* key,
 {
     int err = 0;
 #if defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_ATECC508A) && \
+    !defined(WOLFSSL_MICROCHIP_TA100) && \
     !defined(WOLFSSL_ATECC608A)
     const CRYS_ECPKI_Domain_t*  pDomain;
     CRYS_ECPKI_KG_TempData_t    tempBuff;
@@ -5982,7 +5990,8 @@ int wc_ecc_init_ex(ecc_key* key, void* heap, int devId)
     (void)devId;
 #endif
 
-#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A)
+#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
+    defined(WOLFSSL_MICROCHIP_TA100)
     key->slot = ATECC_INVALID_SLOT;
 #elif defined(WOLFSSL_KCAPI_ECC)
     key->handle = NULL;
@@ -6171,6 +6180,7 @@ static int wc_ecc_get_curve_order_bit_count(const ecc_set_type* dp)
 
 
 #if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) ||  \
+    defined(WOLFSSL_MICROCHIP_TA100) || \
     defined(PLUTON_CRYPTO_ECC) || defined(WOLFSSL_CRYPTOCELL) || \
     defined(WOLFSSL_SILABS_SE_ACCEL) || defined(WOLFSSL_KCAPI_ECC) || \
     defined(WOLFSSL_SE050) || defined(WOLFSSL_XILINX_CRYPT_VERSAL)
@@ -6184,7 +6194,7 @@ static int wc_ecc_sign_hash_hw(const byte* in, word32 inlen,
 #endif
     {
     #if defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_ATECC508A) && \
-        !defined(WOLFSSL_ATECC608A)
+        !defined(WOLFSSL_ATECC608A) && !defined(WOLFSSL_MICROCHIP_TA100)
         CRYS_ECDSA_SignUserContext_t sigCtxTemp;
         word32 raw_sig_size = *outlen;
         word32 msgLenInBytes = inlen;
@@ -6215,10 +6225,12 @@ static int wc_ecc_sign_hash_hw(const byte* in, word32 inlen,
         }
     #endif
 
-    #if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A)
+    #if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
+         defined(WOLFSSL_MICROCHIP_TA100)
         (void)inlen;
         /* Sign: Result is 32-bytes of R then 32-bytes of S */
         err = atmel_ecc_sign(key->slot, in, out);
+
         if (err != 0) {
            return err;
         }
@@ -6558,6 +6570,7 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
 
 /* hardware crypto */
 #if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
+    defined(WOLFSSL_MICROCHIP_TA100) || \
     defined(PLUTON_CRYPTO_ECC) || defined(WOLFSSL_CRYPTOCELL) || \
     defined(WOLFSSL_SILABS_SE_ACCEL) || defined(WOLFSSL_KCAPI_ECC) || \
     defined(WOLFSSL_SE050) || defined(WOLFSSL_XILINX_CRYPT_VERSAL)
@@ -6666,6 +6679,7 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
     return stm32_ecc_sign_hash_ex(in, inlen, rng, key, r, s);
 }
 #elif !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+      !defined(WOLFSSL_MICROCHIP_TA100) && \
       !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_KCAPI_ECC)
 #ifndef WOLFSSL_SP_MATH
 static int ecc_sign_hash_sw(ecc_key* key, ecc_key* pubkey, WC_RNG* rng,
@@ -7666,7 +7680,8 @@ int wc_ecc_free(ecc_key* key)
     se050_ecc_free_key(key);
 #endif
 
-#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A)
+#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
+    defined(WOLFSSL_MICROCHIP_TA100)
     atmel_ecc_free(key->slot);
     key->slot = ATECC_INVALID_SLOT;
 #endif /* WOLFSSL_ATECC508A */
@@ -7707,6 +7722,7 @@ int wc_ecc_free(ecc_key* key)
 }
 
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+    !defined(WOLFSSL_MICROCHIP_TA100) && \
     !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_SP_MATH) && \
     !defined(WOLF_CRYPTO_CB_ONLY_ECC)
 /* Handles add failure cases:
@@ -7819,7 +7835,8 @@ int ecc_projective_dbl_point_safe(ecc_point *P, ecc_point *R, mp_int* a,
           && !WOLFSSL_CRYPTOCELL && !WOLFSSL_SP_MATH */
 
 #if !defined(WOLFSSL_SP_MATH) && !defined(WOLFSSL_ATECC508A) && \
-    !defined(WOLFSSL_ATECC608A) && !defined(WOLFSSL_CRYPTOCELL) && \
+    !defined(WOLFSSL_ATECC608A) && !defined(WOLFSSL_MICROCHIP_TA100) && \
+    !defined(WOLFSSL_CRYPTOCELL) && \
     !defined(WOLFSSL_KCAPI_ECC) && !defined(WOLF_CRYPTO_CB_ONLY_ECC)
 #ifdef ECC_SHAMIR
 
@@ -8554,7 +8571,7 @@ static int ecc_verify_hash_sp(mp_int *r, mp_int *s, const byte* hash,
 
     return NOT_COMPILED_IN;
 }
-#endif /* !WOLFSSL_MICROCHIP_TA100 */
+
 #if !defined(WOLFSSL_MICROCHIP) && (!defined(WOLFSSL_SP_MATH) || defined(FREESCALE_LTC_ECC))
 static int ecc_verify_hash(mp_int *r, mp_int *s, const byte* hash,
     word32 hashlen, int* res, ecc_key* key, ecc_curve_spec* curve)
@@ -8812,7 +8829,8 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
 #else
    int           err;
    word32        keySz = 0;
-#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A)
+#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
+    defined(WOLFSSL_MICROCHIP_TA100)
    byte sigRS[ATECC_KEY_SIZE*2];
 #elif defined(WOLFSSL_CRYPTOCELL)
    byte sigRS[ECC_MAX_CRYPTO_HW_SIZE*2];
@@ -8883,7 +8901,8 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
     }
 #endif /* WOLFSSL_SE050 */
 
-#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A)
+#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
+    defined(WOLFSSL_MICROCHIP_TA100)
     err = atmel_ecc_verify(hash, sigRS, key->pubkey_raw, res);
     if (err != 0) {
        return err;
@@ -9547,6 +9566,7 @@ int wc_ecc_export_x963_ex(ecc_key* key, byte* out, word32* outLen,
 
 
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+    !defined(WOLFSSL_MICROCHIP_TA100) && \
     !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_SE050) && \
     !defined(WOLF_CRYPTO_CB_ONLY_ECC) && !defined(WOLFSSL_STM32_PKA)
 
@@ -9873,14 +9893,16 @@ static int ecc_check_privkey_gen(ecc_key* key, mp_int* a, mp_int* prime)
 static int ecc_check_privkey_gen_helper(ecc_key* key)
 {
     int    err;
-#if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A)
+#if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+    !defined(WOLFSSL_MICROCHIP_TA100)
     DECLARE_CURVE_SPECS(2);
 #endif
 
     if (key == NULL)
         return BAD_FUNC_ARG;
 
-#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A)
+#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
+    defined(WOLFSSL_MICROCHIP_TA100)
     /* Hardware based private key, so this operation is not supported */
     err = MP_OKAY; /* just report success */
 #elif defined(WOLFSSL_SILABS_SE_ACCEL)
@@ -10089,6 +10111,7 @@ static int _ecc_validate_public_key(ecc_key* key, int partial, int priv)
     int err = MP_OKAY;
 #ifndef WOLFSSL_SP_MATH
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+    !defined(WOLFSSL_MICROCHIP_TA100) && \
     !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_SILABS_SE_ACCEL) && \
     !defined(WOLFSSL_SE050) && !defined(WOLF_CRYPTO_CB_ONLY_ECC) && \
     !defined(WOLF_CRYPTO_CB_ONLY_ECC) && !defined(WOLFSSL_STM32_PKA)
@@ -10363,7 +10386,8 @@ int wc_ecc_import_x963_ex(const byte* in, word32 inLen, ecc_key* key,
     inLen -= 1;
     in += 1;
 
-#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A)
+#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
+    defined(WOLFSSL_MICROCHIP_TA100)
     /* For SECP256R1 only save raw public key for hardware */
     if (curve_id == ECC_SECP256R1 && inLen <= (word32)sizeof(key->pubkey_raw)) {
     #ifdef HAVE_COMP_KEY
@@ -10629,7 +10653,8 @@ int wc_ecc_export_ex(ecc_key* key, byte* qx, word32* qxLen,
             (key->type != ECC_PRIVATEKEY && key->type != ECC_PRIVATEKEY_ONLY))
             return BAD_FUNC_ARG;
 
-    #if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A)
+    #if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
+        defined(WOLFSSL_MICROCHIP_TA100)
         /* Hardware cannot export private portion */
         return NOT_COMPILED_IN;
     #else
@@ -11064,14 +11089,14 @@ static int wc_ecc_import_raw_private(ecc_key* key, const char* qx,
 {
     int err = MP_OKAY;
 #if defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_ATECC508A) && \
-    !defined(WOLFSSL_ATECC608A)
+    !defined(WOLFSSL_ATECC608A) && !defined(WOLFSSL_MICROCHIP_TA100)
     const CRYS_ECPKI_Domain_t* pDomain;
     CRYS_ECPKI_BUILD_TempData_t tempBuff;
     byte keyRaw[ECC_MAX_CRYPTO_HW_SIZE*2 + 1];
 #endif
 
 #if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
-    defined(WOLFSSL_CRYPTOCELL)
+    defined(WOLFSSL_MICROCHIP_TA100) || defined(WOLFSSL_CRYPTOCELL)
     word32 keySz = 0;
 #endif
 
@@ -11150,7 +11175,8 @@ static int wc_ecc_import_raw_private(ecc_key* key, const char* qx,
     if (err == MP_OKAY)
         err = mp_set(key->pubkey.z, 1);
 
-#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A)
+#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
+    defined(WOLFSSL_MICROCHIP_TA100)
     /* For SECP256R1 only save raw public key for hardware */
     if (err == MP_OKAY && curve_id == ECC_SECP256R1) {
         keySz = key->dp->size;
@@ -11235,7 +11261,8 @@ static int wc_ecc_import_raw_private(ecc_key* key, const char* qx,
     /* import private key */
     if (err == MP_OKAY) {
         if (d != NULL) {
-        #if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A)
+        #if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
+            defined(WOLFSSL_MICROCHIP_TA100)
             /* Hardware doesn't support loading private key */
             err = NOT_COMPILED_IN;
 
@@ -14480,6 +14507,7 @@ int wc_ecc_decrypt(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
 
 #ifdef HAVE_COMP_KEY
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+    !defined(WOLFSSL_MICROCHIP_TA100) && \
     !defined(WOLFSSL_CRYPTOCELL)
 
 #ifndef WOLFSSL_SP_MATH

--- a/wolfcrypt/src/port/atmel/README.md
+++ b/wolfcrypt/src/port/atmel/README.md
@@ -96,5 +96,43 @@ ATECC508A HW accelerated implementation:
 `EC-DSA   sign   time     293.400 milliseconds, avg over 5 iterations, 17.065 ops/sec`
 `EC-DSA   verify time     208.400 milliseconds, avg over 5 iterations, 24.038 ops/sec`
 
+### Microchip Trust Anchor TA100 ECC
+
+`./configure CFLAGS="-DWOLFSSL_CMAC -DHAVE_PK_CALLBACKS -DWOLFSSL_ATECC508A_NOIDLE -DECC_USER_CURVES -DWOLFSSL_ATECC_NO_ECDH_ENC -DWOLFSSL_ATECC_DEBUG" --enable-cmac --enable-microchip=100 --with-cryptoauthlib`
+
+
+```
+ $ lscpu -e
+CPU SOCKET CORE L1d:L1i:L2 ONLINE    MAXMHZ   MINMHZ
+  0      0    0 0:0:0         yes 1800.0000 600.0000
+  1      0    1 1:1:0         yes 1800.0000 600.0000
+  2      0    2 2:2:0         yes 1800.0000 600.0000
+  3      0    3 3:3:0         yes 1800.0000 600.0000
+
+$ uname -a
+Linux raspberrypi 6.1.21-v8+ #1642 SMP PREEMPT Mon Apr  3 17:24:16 BST 2023 aarch64 GNU/Linux
+
+Software:
+------------------------------------------------------------------------------
+ wolfSSL version 5.6.0
+------------------------------------------------------------------------------
+Math:     Multi-Precision: Wolf(SP) word-size=64 bits=4096 sp_int.c
+wolfCrypt Benchmark (block bytes 1048576, min 1.0 sec each)
+
+ECC   [      SECP256R1]   256  key gen       700 ops took 1.065 sec, avg 1.522 ms, 657.067 ops/sec
+ECDHE [      SECP256R1]   256    agree       700 ops took 1.016 sec, avg 1.451 ms, 689.240 ops/sec
+ECDSA [      SECP256R1]   256     sign       700 ops took 1.049 sec, avg 1.499 ms, 667.097 ops/sec
+ECDSA [      SECP256R1]   256   verify      1000 ops took 1.001 sec, avg 1.001 ms, 998.930 ops/sec
+
+
+Hardware Microchip TA100 with SPI:
+
+ECC Benchmarks:
+ECC   [      SECP256R1]   256  key gen       100 ops took 6.790 sec, avg 67.898 ms, 14.728 ops/sec
+ECDHE [      SECP256R1]   256    agree       100 ops took 2.413 sec, avg 24.126 ms, 41.449 ops/sec
+ECDSA [      SECP256R1]   256     sign       100 ops took 1.832 sec, avg 18.317 ms, 54.594 ops/sec
+ECDSA [      SECP256R1]   256   verify       100 ops took 2.120 sec, avg 21.198 ms, 47.175 ops/sec
+
+```
 
 For details see our [wolfSSL Atmel ATECC508/608A](https://wolfssl.com/wolfSSL/wolfssl-atmel.html) page.

--- a/wolfcrypt/src/port/atmel/README.md
+++ b/wolfcrypt/src/port/atmel/README.md
@@ -96,10 +96,17 @@ ATECC508A HW accelerated implementation:
 `EC-DSA   sign   time     293.400 milliseconds, avg over 5 iterations, 17.065 ops/sec`
 `EC-DSA   verify time     208.400 milliseconds, avg over 5 iterations, 24.038 ops/sec`
 
-### Microchip Trust Anchor TA100 ECC
+### Microchip Trust Anchor TA100 ECC/RSA
 
-`./configure CFLAGS="-DWOLFSSL_CMAC -DHAVE_PK_CALLBACKS -DWOLFSSL_ATECC508A_NOIDLE -DECC_USER_CURVES -DWOLFSSL_ATECC_NO_ECDH_ENC -DWOLFSSL_ATECC_DEBUG" --enable-cmac --enable-microchip=100 --with-cryptoauthlib`
+` ./configure CFLAGS="-DECC_USER_CURVES -DWOLFSSL_ATECC_NO_ECDH_ENC" --enable-microchip=100 --with-cryptoauthlib --enable-debug --disable-shared --enable-pkcallbacks --enable-keygen --enable-cmac && make
+`
 
+Supported Features:
+RSA 2048 keygen/sign/verify
+ECC-P256 keygen/sign/verify/shared secret
+
+WOLFSSL_MICROCHIP_AESGCM can be used to enable AES-GCM but
+It's unclear how to enable data zone locking in TA100.
 
 ```
  $ lscpu -e
@@ -118,6 +125,11 @@ Software:
 ------------------------------------------------------------------------------
 Math:     Multi-Precision: Wolf(SP) word-size=64 bits=4096 sp_int.c
 wolfCrypt Benchmark (block bytes 1048576, min 1.0 sec each)
+Benchmarks:
+
+RSA     2048  key gen         2 ops took 1.113 sec, avg 556.332 ms, 1.797 ops/sec
+RSA     2048     sign       200 ops took 1.891 sec, avg 9.455 ms, 105.766 ops/sec
+RSA     2048   verify      6900 ops took 1.011 sec, avg 0.147 ms, 6824.614 ops/sec
 
 ECC   [      SECP256R1]   256  key gen       700 ops took 1.065 sec, avg 1.522 ms, 657.067 ops/sec
 ECDHE [      SECP256R1]   256    agree       700 ops took 1.016 sec, avg 1.451 ms, 689.240 ops/sec
@@ -127,7 +139,13 @@ ECDSA [      SECP256R1]   256   verify      1000 ops took 1.001 sec, avg 1.001 m
 
 Hardware Microchip TA100 with SPI:
 
-ECC Benchmarks:
+Benchmarks:
+./wolfcrypt/benchmark/benchmark -rsa_sign
+
+RSA     2048  key gen   HW      1 ops took 12.190 sec, avg 12190.346 ms, 0.082 ops/sec
+RSA     2048     sign   HW    100 ops took 14.006 sec, avg 140.062 ms, 7.140 ops/sec
+RSA     2048   verify   HW    100 ops took 13.168 sec, avg 131.679 ms, 7.594 ops/sec
+
 ECC   [      SECP256R1]   256  key gen       100 ops took 6.790 sec, avg 67.898 ms, 14.728 ops/sec
 ECDHE [      SECP256R1]   256    agree       100 ops took 2.413 sec, avg 24.126 ms, 41.449 ops/sec
 ECDSA [      SECP256R1]   256     sign       100 ops took 1.832 sec, avg 18.317 ms, 54.594 ops/sec

--- a/wolfcrypt/src/port/atmel/atmel.c
+++ b/wolfcrypt/src/port/atmel/atmel.c
@@ -26,7 +26,8 @@
 #include <wolfssl/wolfcrypt/settings.h>
 
 #if defined(WOLFSSL_ATMEL) || defined(WOLFSSL_ATECC508A) || \
-    defined(WOLFSSL_ATECC608A) || defined(WOLFSSL_ATECC_PKCB)
+    defined(WOLFSSL_ATECC608A) || defined(WOLFSSL_ATECC_PKCB) || \
+    defined(WOLFSSL_MICROCHIP_TA100)
 
 #include <wolfssl/wolfcrypt/memory.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
@@ -88,15 +89,108 @@ static wolfSSL_Mutex mSlotMutex;
 #ifndef ATECC_I2C_BUS
 #define ATECC_I2C_BUS  1
 #endif
-#ifndef ATECC_DEV_TYPE
+#ifdef ATECC_DEV_TYPE /* for backward compatibility */
+    #define MICROCHIP_DEV_TYPE ATECC_DEV_TYPE
+#endif
+#ifndef MICROCHIP_DEV_TYPE
     #ifdef WOLFSSL_ATECC508A
-        #define ATECC_DEV_TYPE ATECC508A
-    #else
-        #define ATECC_DEV_TYPE ATECC608A
+        #define MICROCHIP_DEV_TYPE ATECC508A
+    #elif defined(WOLFSSL_ATECC608A)
+        #define MICROCHIP_DEV_TYPE ATECC608A
+    #elif defined(WOLFSSL_MICROCHIP_TA100)
+        #define MICROCHIP_DEV_TYPE TA100
     #endif
 #endif
 static int ateccx08a_cfg_initialized = 0;
-static ATCAIfaceCfg cfg_ateccx08a_i2c_pi;
+
+#if defined(WOLFSSL_ATECC608A) && defined(MICROCHIP_MPLAB_HARMONY_3)
+    /* Harmony3 will generate configuration based on user inputs */
+    extern ATCAIfaceCfg atecc608_0_init_data;
+#endif
+
+#ifndef WOLFSSL_ATCA_DEVICE_NO
+    /* Default to first device in the list*/
+    #define WOLFSSL_ATCA_DEVICE_NO 0
+#endif
+    static ATCAIfaceCfg config_atmel_device[]  = {
+    /* Try detecting all available device configs */
+#if defined(WOLFSSL_ATECC608A) && defined(MICROCHIP_MPLAB_HARMONY_3)
+    atecc608_0_init_data,
+#endif
+#ifdef ATCA_HAL_SPI
+    {
+        .iface_type = ATCA_SPI_IFACE,
+        .devtype    = MICROCHIP_DEV_TYPE,
+        .atcaspi = {
+            .bus = 0,
+            .select_pin = 0,
+            .baud = 16000000,
+        },
+        .wake_delay = 1500,
+        .rx_retries = 20,
+    },
+#endif
+#ifdef ATCA_HAL_I2C
+    {
+        .iface_type = ATCA_I2C_IFACE,
+        .devtype    = MICROCHIP_DEV_TYPE,
+        .atcai2c = {
+            #ifdef ATCA_ENABLE_DEPRECATED
+                .slave_addressus = 1,
+            #else
+                .address = ATECC_I2C_ADDR,
+            #endif
+            .baud = 400000,
+        },
+        .wake_delay = 1500,
+        .rx_retries = 20,
+    },
+#endif
+};
+static ATCAIfaceCfg* gCfg = &config_atmel_device[WOLFSSL_ATCA_DEVICE_NO];
+
+#if defined(WOLFSSL_MICROCHIP_TA100)
+    #ifndef SHARED_DATA_ADDR
+        #define SHARED_DATA_ADDR 0x8006
+    #endif
+        #define MAP_TO_HANDLE(value) (SHARED_DATA_ADDR + (value))
+#else
+    #define MAP_TO_HANDLE(value) value
+#endif
+
+#if defined(WOLFSSL_MICROCHIP_TA100)
+/*
+TA_ElementAttributes contains data element attributes of the handle
+which is of 8 byte
+
+typedef struct
+{
+    uint8_t  element_CKA;     //!< contains class, key_type & Algorithm mode
+    uint16_t property;        //!< properties of the element
+    uint8_t  usage_key;       //!< usage key
+    uint8_t  write_key;       //!< write key
+    uint8_t  read_key;        //!< read key
+    uint8_t  permission;      //!< permission of the element usage|write|read|
+                              //delete perm
+    uint8_t  byte7_settings;  //!< Byte 7 attributes use_count|exportable|
+                              // lockable|access_limit
+} ATCA_PACKED ta_element_attributes_t;
+
+See Shared Data Element Attributes in the programming specifications
+*/
+static ta_element_attributes_t sharedData_attr[ATECC_MAX_SLOT] = {
+    {0x81, 0x1600, 0x00, 0x00, 0x00, 0x41, 0x10},
+    {0x81, 0x1600, 0x00, 0x00, 0x00, 0x41, 0x10},
+    {0x81, 0x1600, 0x00, 0x00, 0x00, 0x41, 0x10},
+    {0x81, 0x1600, 0x00, 0x00, 0x00, 0x41, 0x10},
+    {0x81, 0x1600, 0x00, 0x00, 0x00, 0x41, 0x10},
+    {0x81, 0x1600, 0x00, 0x00, 0x00, 0x41, 0x10},
+    {0x81, 0x1600, 0x00, 0x00, 0x00, 0x41, 0x10},
+    {0x81, 0x1600, 0x00, 0x00, 0x00, 0x41, 0x10},
+};
+static ta_element_attributes_t* gSharedDataAttr = sharedData_attr;
+
+#endif /* WOLFSSL_MICROCHIP_TA100 */
 #endif /* WOLFSSL_ATECC508A */
 
 /**
@@ -180,7 +274,26 @@ long atmel_get_curr_time_and_date(long* tm)
 }
 #endif
 
+#if defined(WOLFSSL_MICROCHIP_TA100)
+/* Set the Shared Data configuration for wolfSSL to use.
+ *
+ * Return 0 on success, negative upon error */
+int atmel_SetSharedDataConfig(ta_element_attributes_t* cfg)
+{
+    WOLFSSL_MSG("Setting Shared Data configuration");
+    if (cfg == NULL) {
+        return -1;
+    }
+    /* copy configuration into our local struct */
+    (void)XMEMMOVE(gSharedDataAttr, cfg,
+                   sizeof(ta_element_attributes_t)*ATECC_MAX_SLOT);
 
+    ateccx08a_cfg_initialized = 0;
+
+    return 0;
+}
+
+#endif
 #if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A)
 
 /* Set the ATECC configuration for wolfSSL to use.
@@ -192,23 +305,10 @@ int wolfCrypt_ATECC_SetConfig(ATCAIfaceCfg* cfg)
     if (cfg == NULL) {
         return -1;
     }
-
     /* copy configuration into our local struct */
-    XMEMSET(&cfg_ateccx08a_i2c_pi, 0, sizeof(cfg_ateccx08a_i2c_pi));
-    cfg_ateccx08a_i2c_pi.iface_type            = cfg->iface_type;
-    cfg_ateccx08a_i2c_pi.devtype               = cfg->devtype;
-#ifdef ATCA_ENABLE_DEPRECATED
-    cfg_ateccx08a_i2c_pi.atcai2c.slave_address = cfg->atcai2c.slave_address;
-#else
-    cfg_ateccx08a_i2c_pi.atcai2c.address       = cfg->atcai2c.address;
-#endif
-    cfg_ateccx08a_i2c_pi.atcai2c.bus           = cfg->atcai2c.bus;
-    cfg_ateccx08a_i2c_pi.atcai2c.baud          = cfg->atcai2c.baud;
-    cfg_ateccx08a_i2c_pi.wake_delay            = cfg->wake_delay;
-    cfg_ateccx08a_i2c_pi.rx_retries            = cfg->rx_retries;
-    cfg_ateccx08a_i2c_pi.cfg_data              = cfg->cfg_data;
+    (void)XMEMMOVE(gCfg, cfg, sizeof(ATCAIfaceCfg));
 
-    ateccx08a_cfg_initialized = 1;
+    ateccx08a_cfg_initialized = 0;
 
     return 0;
 }
@@ -284,6 +384,14 @@ int atmel_ecc_alloc(int slotType)
             #else
                 break;
             #endif
+            case ATMEL_SLOT_ECDHE_ALICE:
+                /* not reserved in mSlotList, so return */
+                slotId = ATECC_SLOT_ECDHE_PRIV_ALICE;
+                goto exit;
+            case ATMEL_SLOT_ECDHE_BOB:
+                /* not reserved in mSlotList, so return */
+                slotId = ATECC_SLOT_ECDHE_PRIV_BOB;
+                goto exit;
             case ATMEL_SLOT_ANY:
                 for (i=0; i < ATECC_MAX_SLOT; i++) {
                     /* Find free slotId */
@@ -296,7 +404,8 @@ int atmel_ecc_alloc(int slotType)
         }
 
         /* is slot available */
-        if (mSlotList[slotId] != ATECC_INVALID_SLOT) {
+        if (mSlotList[slotId] != ATECC_INVALID_SLOT &&
+            mSlotList[slotId] != slotId ) {
             slotId = ATECC_INVALID_SLOT;
         }
         else {
@@ -413,6 +522,7 @@ int atmel_ecc_create_pms(int slotId, const uint8_t* peerKey, uint8_t* pms)
 {
     int ret;
     uint8_t read_key[ATECC_KEY_SIZE];
+
 #ifdef WOLFSSL_ATECC_ECDH_ENC
     int slotIdEnc;
 
@@ -425,13 +535,21 @@ int atmel_ecc_create_pms(int slotId, const uint8_t* peerKey, uint8_t* pms)
     ATECC_GET_ENC_KEY(read_key, sizeof(read_key));
 
 #ifdef WOLFSSL_ATECC_ECDH_ENC
+    #ifdef WOLFSSL_MICROCHIP_TA100
+        /* #define atcab_ecdh_enc(...) (ATCA_UNIMPLEMENTED) */
+        (void)slotId;
+        (void)peerKey;
+        (void)pms;
+        return NOT_COMPILED_IN;
+    #endif
     /* send the encrypted version of the ECDH command */
-    ret = atcab_ecdh_enc(slotId, peerKey, pms, read_key, slotIdEnc);
+    ret = atcab_ecdh_enc(MAP_TO_HANDLE(slotId), peerKey, pms, read_key,
+                         MAP_TO_HANDLE(slotIdEnc));
 #elif defined(WOLFSSL_ATECC_ECDH_IOENC)
     /* encrypted ECDH command, using I/O protection key */
-    ret = atcab_ecdh_ioenc(slotId, peerKey, pms, read_key);
+    ret = atcab_ecdh_ioenc(MAP_TO_HANDLE(slotId), peerKey, pms, read_key);
 #else
-    ret = atcab_ecdh(slotId, peerKey, pms);
+    ret = atcab_ecdh(MAP_TO_HANDLE(slotId), peerKey, pms);
 #endif
 
     ret = atmel_ecc_translate_err(ret);
@@ -440,21 +558,42 @@ int atmel_ecc_create_pms(int slotId, const uint8_t* peerKey, uint8_t* pms)
     /* free the ECDHE slot */
     atmel_ecc_free(slotIdEnc);
 #endif
-
     return ret;
 }
-
-int atmel_ecc_create_key(int slotId, byte* peerKey)
+#ifdef WOLFSSL_MICROCHIP_TA100
+static uint8_t getCurveType(int curve_id)
+{
+    switch(curve_id)
+    {
+        case ECC_SECP256R1: return TA_KEY_TYPE_ECCP256;
+        case ECC_SECP224R1: return TA_KEY_TYPE_ECCP224;
+        case ECC_SECP384R1: return TA_KEY_TYPE_ECCP384;
+        case ECC_SECP256K1: return TA_KEY_TYPE_SECP256K1;
+        case ECC_BRAINPOOLP256R1: return TA_KEY_TYPE_ECCBP256R1;
+        case ECC_CURVE_DEF: return TA_KEY_TYPE_ECCP256; /* default */
+        default: WOLFSSL_MSG("Curve not identified");
+            return MICROCHIP_INVALID_ECC;
+    }
+}
+#endif
+int atmel_ecc_create_key(int slotId, int curve_id, byte* peerKey)
 {
     int ret;
-
+#ifndef WOLFSSL_MICROCHIP_TA100
+    (void)curve_id;
+#endif
     /* verify provided slotId */
     if (slotId == ATECC_INVALID_SLOT) {
         return WC_HW_WAIT_E;
     }
+#ifdef WOLFSSL_MICROCHIP_TA100
 
+    if (getCurveType(curve_id) == MICROCHIP_INVALID_ECC)
+        return NOT_COMPILED_IN;
+
+#endif
     /* generate new ephemeral key on device */
-    ret = atcab_genkey(slotId, peerKey);
+    ret = atcab_genkey(MAP_TO_HANDLE(slotId), peerKey);
     ret = atmel_ecc_translate_err(ret);
     return ret;
 }
@@ -463,7 +602,7 @@ int atmel_ecc_sign(int slotId, const byte* message, byte* signature)
 {
     int ret;
 
-    ret = atcab_sign(slotId, message, signature);
+    ret = atcab_sign(MAP_TO_HANDLE(slotId), message, signature);
     ret = atmel_ecc_translate_err(ret);
     return ret;
 }
@@ -483,7 +622,242 @@ int atmel_ecc_verify(const byte* message, const byte* signature,
 
 #endif /* WOLFSSL_ATECC508A */
 
+#ifdef WOLFSSL_MICROCHIP_TA100
 
+int microchip_rsa_create_key(struct RsaKey* key, int size, long e)
+{
+    ATCA_STATUS ret;
+    ta_element_attributes_t rKeyA, uKeyA;
+    size_t uKey_len = TA_KEY_TYPE_RSA2048_SIZE;
+
+    (void)size;
+    (void)e;
+
+    ret = talib_handle_init_private_key(&rKeyA, TA_KEY_TYPE_RSA2048,
+            TA_ALG_MODE_RSA_SSA_PSS,TA_PROP_SIGN_INT_EXT_DIGEST,
+            TA_PROP_KEY_AGREEMENT_OUT_BUFF);
+    if (ret != ATCA_SUCCESS) return WC_HW_E;
+
+    ret = talib_create_element(atcab_get_device(), &rKeyA, &key->rKeyH);
+    if (ret != ATCA_SUCCESS) return WC_HW_E;
+
+    ret = talib_handle_init_public_key(&uKeyA, TA_KEY_TYPE_RSA2048,
+            TA_ALG_MODE_RSA_SSA_PSS, TA_PROP_VAL_NO_SECURE_BOOT_SIGN,
+            TA_PROP_ROOT_PUB_KEY_VERIFY);
+    if (ret != ATCA_SUCCESS) return WC_HW_E;
+
+    ret = talib_create_element(atcab_get_device(), &uKeyA, &key->uKeyH);
+    if (ret != ATCA_SUCCESS) return WC_HW_E;
+
+    ret = talib_genkey_base(atcab_get_device(), TA_KEYGEN_MODE_NEWKEY,
+            (uint32_t)key->rKeyH, key->uKey, &uKey_len);
+    if (ret != ATCA_SUCCESS) return WC_HW_E;
+
+    /* Write the RSA public key to the handle. */
+    ret = talib_write_pub_key(atcab_get_device(), key->uKeyH, (uint16_t)uKey_len,
+            key->uKey);
+
+    ret = atmel_ecc_translate_err(ret);
+
+    return ret;
+
+}
+int microchip_rsa_sign(const byte* in, word32 inLen, byte* out, word32 outLen,
+                       RsaKey* key)
+{
+    int ret;
+
+    uint16_t sign_size = outLen; /* TA_KEY_TYPE_RSA2048_SIZE */
+
+    ret = talib_sign_external(atcab_get_device(), TA_KEY_TYPE_RSA2048,
+                              key->rKeyH, TA_HANDLE_INPUT_BUFFER, in,
+                              (uint16_t)inLen, out, &sign_size);
+    ret = atmel_ecc_translate_err(ret);
+    return ret;
+}
+
+int microchip_rsa_verify(const byte* in, word32 inLen, byte* sig, word32 sigLen,
+                     RsaKey* key, int* pVerified)
+{
+    int ret;
+    bool verified = false;
+
+    ret = talib_verify(atcab_get_device(), TA_KEY_TYPE_RSA2048,
+                        TA_HANDLE_INPUT_BUFFER, key->uKeyH, sig,
+                        sigLen, in, (uint16_t)inLen, NULL,
+                        sigLen, &verified);
+
+    ret = atmel_ecc_translate_err(ret);
+    if (pVerified)
+        *pVerified = (int)verified;
+
+    return ret;
+}
+
+int microchip_rsa_encrypt(const byte* in, word32 inLen, byte* out, word32 outLen,
+                       RsaKey* key)
+{
+    int ret;
+
+    /* Encrypt the plaintext with the rsa public key in handle */
+    ret = talib_rsaenc_encrypt(atcab_get_device(), key->uKeyH,
+                               inLen, in, outLen, out);
+    ret = atmel_ecc_translate_err(ret);
+    return ret;
+}
+
+int microchip_rsa_decrypt(const byte* in, word32 inLen, byte* out,
+                          word32 outLen, RsaKey* key)
+{
+    int ret;
+    /* Decrypt the ciphertext with the rsa private key in handle */
+    ret = talib_rsaenc_decrypt(atcab_get_device(), key->rKeyH,
+                             inLen, in, outLen, out);
+    ret = atmel_ecc_translate_err(ret);
+    return ret;
+}
+
+void microchip_rsa_free(struct RsaKey* key)
+{
+    if (key->rKeyH)
+        (void)talib_delete_handle(atcab_get_device(), (uint32_t)key->rKeyH);
+    if (key->uKeyH)
+        (void)talib_delete_handle(atcab_get_device(), (uint32_t)key->uKeyH);
+
+}
+#ifdef WOLFSSL_ATECC_DEBUG
+static void atmel_print_info(ta_element_attributes_t attr)
+{
+    printf("{0x%02x, 0x%04x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x},\n",
+            attr.element_CKA, attr.property, attr.usage_key, attr.write_key,
+            attr.read_key, attr.permission , attr.byte7_settings);
+}
+
+static void atmel_Handle_Attributes(void)
+{
+    ATCA_STATUS status;
+    ta_element_attributes_t attributes;
+    (void) status;
+
+    printf("Symmetric key AES \n"
+           "Symmetric key HMAC \n"
+           "Public key ECC \n"
+           "Public key RSA \n"
+           "Private key ECC - sign \n"
+           "Private key ECC - keygen \n");
+    status = talib_handle_init_symmetric_key(&attributes, TA_KEY_TYPE_AES128,
+                                             TA_PROP_SYMM_KEY_USAGE_ANY);
+
+    /* Symmetric key AES */
+    atmel_print_info(attributes);
+
+    status = talib_handle_init_symmetric_key(&attributes, TA_KEY_TYPE_HMAC,
+                                             TA_PROP_SYMM_KEY_USAGE_MAC);
+    /* Symmetric key HMAC */
+    atmel_print_info(attributes);
+
+    status = talib_handle_init_public_key(&attributes, TA_KEY_TYPE_ECCP256,
+                       TA_ALG_MODE_ECC_ECDSA, TA_PROP_VAL_NO_SECURE_BOOT_SIGN,
+                       TA_PROP_ROOT_PUB_KEY_VERIFY);
+
+    /* Public key ECC */
+    atmel_print_info(attributes);
+
+    status = talib_handle_init_public_key(&attributes, TA_KEY_TYPE_RSA2048,
+                    TA_ALG_MODE_RSA_SSA_PSS, TA_PROP_VAL_NO_SECURE_BOOT_SIGN,
+                    TA_PROP_ROOT_PUB_KEY_VERIFY);
+    /* Public key RSA */
+    atmel_print_info(attributes);
+
+    status = talib_handle_init_private_key(&attributes, TA_KEY_TYPE_ECCP256,
+                              TA_ALG_MODE_ECC_ECDH, TA_PROP_SIGN_INT_EXT_DIGEST,
+                              TA_PROP_KEY_AGREEMENT_OUT_BUFF);
+
+    /* Private key ECC - sign */
+    atmel_print_info(attributes);
+
+    /* Byte 0 Element Attribute */
+    attributes.element_CKA = TA_CLASS_PRIVATE_KEY |
+            (uint8_t)(TA_KEY_TYPE_ECCP256 << TA_HANDLE_INFO_KEY_TYPE_SHIFT) |
+            (uint8_t)(TA_ALG_MODE_ECC_ECDSA << TA_HANDLE_INFO_ALG_MODE_SHIFT);
+
+    attributes.property = (uint16_t)0x00 /*Public Key Handle*/ |
+            (uint16_t)(0x00 << TA_PROP_SESSION_KEY_SHIFT) |
+    (uint16_t)(0x00 << TA_PROP_KEY_GEN_SHIFT) |
+    (uint16_t)(TA_PROP_SIGN_INT_EXT_DIGEST << TA_PROP_SIGN_USE_SHIFT) |
+    (uint16_t)(TA_PROP_NO_KEY_AGREEMENT << TA_PROP_KEY_AGREEMENT_SHIFT);
+
+    /* Byte 3 Element Attribute */
+    attributes.usage_key = 0x00;
+
+    /* Byte 4 Element Attribute */
+    attributes.write_key = 0x00;
+
+    /* Byte 5 Element Attribute */
+    attributes.read_key = 0x00;
+
+    /* Byte 6 Element Attribute */
+    attributes.permission = TA_PERM_USAGE(TA_PERM_ALWAYS) |
+            TA_PERM_WRITE(TA_PERM_ALWAYS)| TA_PERM_READ(TA_PERM_ALWAYS) |
+            TA_PERM_DELETE(TA_PERM_ALWAYS);
+
+    /* Byte 7  Element Attribute */
+    attributes.byte7_settings = ((0x00 & 0x03) << 0) /*Use Count*/ |
+        TA_NOT_EXPORTABLE_FROM_CHIP_MASK | TA_PERMANENTLY_NOT_LOCKABLE_MASK |
+    TA_ACCESS_LIMIT_ALWAYS_MASK | (0 << 7) /*Intrusion Detection (N/A here)*/;
+
+     /* Private key ECC - keygen */
+    atmel_print_info(attributes);
+
+}
+#endif
+
+#define CHECK_STATUS(s)                                                        \
+    if (s != ATCA_SUCCESS)                                                     \
+    {                                                                          \
+        printf("Error: Line %d in File %s\r\n", __LINE__, __FILE__);           \
+        printf("STATUS = %X\r\n", s);                                          \
+        printf("See atca_status.h for error code \r\n");                       \
+        return atmel_ecc_translate_err(s);                                     \
+    }
+static int atmel_createHandles(void)
+{
+    ATCA_STATUS status;
+    uint8_t is_handle_valid = 0;
+    uint16_t shared_handle = SHARED_DATA_ADDR;
+    int i;
+#ifdef WOLFSSL_ATECC_DEBUG
+    atmel_Handle_Attributes();
+    printf("atmel_Handle_Attributes() finished \n\n");
+#endif
+    for (i = 0; i < ATECC_MAX_SLOT; i++ ) {
+
+        status = talib_is_handle_valid(atcab_get_device(),
+                                 (uint32_t)shared_handle, &is_handle_valid);
+        CHECK_STATUS(status);
+#ifdef WOLFSSL_ATECC_DEBUG
+        atmel_print_info(gSharedDataAttr[i]);
+#endif
+        if(is_handle_valid == 0x01) {
+            /* Handle already Exists */;
+#ifndef WOLFSSL_NO_DEL_HANDLE
+            status = talib_delete_handle(atcab_get_device(),
+                                    (uint32_t)shared_handle);
+            CHECK_STATUS(status);
+#else
+            shared_handle += 1;
+            continue;
+#endif
+        }
+
+        status = talib_create_element_with_handle(atcab_get_device(),
+                shared_handle, &gSharedDataAttr[i]);
+        CHECK_STATUS(status);
+        shared_handle += 1;
+    }
+    return 0;
+}
+#endif /* WOLFSSL_MICROCHIP_TA100 */
 
 int atmel_init(void)
 {
@@ -491,13 +865,6 @@ int atmel_init(void)
 
 #if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A)
 
-#if defined(WOLFSSL_ATECC608A)
-    /*Harmony3 will generate configuration based on user inputs*/
-    #ifdef MICROCHIP_MPLAB_HARMONY_3
-    extern ATCAIfaceCfg atecc608_0_init_data;
-    #endif
-#endif
-    
     if (!mAtcaInitDone) {
         ATCA_STATUS status;
         int i;
@@ -523,31 +890,19 @@ int atmel_init(void)
 #ifdef MICROCHIP_MPLAB_HARMONY_3
         atcab_release();
         atcab_wakeup();
-        #ifdef WOLFSSL_ATECC608A
-        wolfCrypt_ATECC_SetConfig(&atecc608_0_init_data);
-        #endif
 #endif
         if (ateccx08a_cfg_initialized == 0) {
             /* Setup the hardware interface using defaults */
-            XMEMSET(&cfg_ateccx08a_i2c_pi, 0, sizeof(cfg_ateccx08a_i2c_pi));
-            cfg_ateccx08a_i2c_pi.iface_type             = ATCA_I2C_IFACE;
-            cfg_ateccx08a_i2c_pi.devtype                = ATECC_DEV_TYPE;
-        #ifdef ATCA_ENABLE_DEPRECATED
-            cfg_ateccx08a_i2c_pi.atcai2c.slave_address  = ATECC_I2C_ADDR;
-        #else
-            cfg_ateccx08a_i2c_pi.atcai2c.address        = ATECC_I2C_ADDR;
-        #endif
-            cfg_ateccx08a_i2c_pi.atcai2c.bus            = ATECC_I2C_BUS;
-            cfg_ateccx08a_i2c_pi.atcai2c.baud           = 400000;
-            cfg_ateccx08a_i2c_pi.wake_delay             = 1500;
-            cfg_ateccx08a_i2c_pi.rx_retries             = 20;
-        }
-
-        /* Initialize the CryptoAuthLib to communicate with ATECC508A */
-        status = atcab_init(&cfg_ateccx08a_i2c_pi);
-        if (status != ATCA_SUCCESS) {
-            WOLFSSL_MSG("Failed to initialize atcab");
-            return WC_HW_E;
+            status = atcab_init(gCfg);
+            /* Initialize the CryptoAuthLib to communicate with */
+            if (status != ATCA_SUCCESS) {
+                WOLFSSL_MSG("Failed to initialize atcab");
+                return WC_HW_E;
+            }
+            #ifdef WOLFSSL_MICROCHIP_TA100
+                /* create handles for TA100 */
+                atmel_createHandles();
+            #endif
         }
 
         /* show revision information */
@@ -616,7 +971,7 @@ int atcatls_create_key_cb(WOLFSSL* ssl, ecc_key* key, unsigned int keySz,
             return WC_HW_WAIT_E;
 
         /* generate new ephemeral key on device */
-        ret = atmel_ecc_create_key(slotId, peerKey);
+        ret = atmel_ecc_create_key(MAP_TO_HANDLE(slotId), ecc_curve, peerKey);
 
         /* load generated ECC508A public key into key, used by wolfSSL */
         if (ret == 0) {
@@ -691,7 +1046,8 @@ int atcatls_create_pms_cb(WOLFSSL* ssl, ecc_key* otherKey,
             tmpKey.slot = slotId;
 
             /* generate new ephemeral key on device */
-            ret = atmel_ecc_create_key(slotId, peerKey);
+            ret = atmel_ecc_create_key(MAP_TO_HANDLE(slotId), otherKey->dp->id,
+                                                     peerKey);
             if (ret != ATCA_SUCCESS) {
                 goto exit;
             }
@@ -820,7 +1176,7 @@ int atcatls_sign_certificate_cb(WOLFSSL* ssl, const byte* in, unsigned int inSz,
         return WC_HW_WAIT_E;
 
     /* We can only sign with P-256 */
-    ret = atmel_ecc_sign(slotId, in, sigRs);
+    ret = atmel_ecc_sign(MAP_TO_HANDLE(slotId), in, sigRs);
     if (ret != ATCA_SUCCESS) {
         ret = WC_HW_E; goto exit;
     }
@@ -940,6 +1296,7 @@ exit:
     return ret;
 }
 
+#ifdef ATCA_TFLEX_SUPPORT
 static int atcatls_set_certificates(WOLFSSL_CTX *ctx) 
 {
     #ifndef ATCATLS_SIGNER_CERT_MAX_SIZE
@@ -957,7 +1314,6 @@ static int atcatls_set_certificates(WOLFSSL_CTX *ctx)
     #endif
 
     int ret = 0;
-    ATCA_STATUS status;
     size_t signerCertSize = ATCATLS_SIGNER_CERT_MAX_SIZE;
     size_t deviceCertSize = ATCATLS_DEVICE_CERT_MAX_SIZE;
     uint8_t certBuffer[ATCATLS_CERT_BUFF_MAX_SIZE];
@@ -966,7 +1322,8 @@ static int atcatls_set_certificates(WOLFSSL_CTX *ctx)
     uint8_t signerPubKeyBuffer[ATCATLS_PUBKEY_BUFF_MAX_SIZE];
 #endif
 
-#ifdef WOLFSSL_ATECC_TNGTLS	
+#ifdef WOLFSSL_ATECC_TNGTLS
+    ATCA_STATUS status;
     ret = tng_atcacert_max_signer_cert_size(&signerCertSize);
     if (ret != ATCACERT_E_SUCCESS) {
     #ifdef WOLFSSL_ATECC_DEBUG
@@ -1003,7 +1360,7 @@ static int atcatls_set_certificates(WOLFSSL_CTX *ctx)
     #endif
        return -1;
     }
-#endif
+#endif /* WOLFSSL_ATECC_TNGTLS */
 
 #ifdef WOLFSSL_ATECC_TFLXTLS
     /* MAKE SURE TO COPY YOUR CUSTOM CERTIFICATE FILES UNDER CAL/tng
@@ -1069,6 +1426,7 @@ static int atcatls_set_certificates(WOLFSSL_CTX *ctx)
 
     return ret;
 }
+#endif /* ATCA_TFLEX_SUPPORT */
 
 int atcatls_set_callbacks(WOLFSSL_CTX* ctx)
 {
@@ -1077,6 +1435,8 @@ int atcatls_set_callbacks(WOLFSSL_CTX* ctx)
     wolfSSL_CTX_SetEccVerifyCb(ctx, atcatls_verify_signature_cb);
     wolfSSL_CTX_SetEccSignCb(ctx, atcatls_sign_certificate_cb);
     wolfSSL_CTX_SetEccSharedSecretCb(ctx, atcatls_create_pms_cb);
+
+#ifdef ATCA_TFLEX_SUPPORT
 #if defined(WOLFSSL_ATECC_TNGTLS) || defined(WOLFSSL_ATECC_TFLXTLS)
     ret = atcatls_set_certificates(ctx);
     if (ret != 0) {
@@ -1085,6 +1445,7 @@ int atcatls_set_callbacks(WOLFSSL_CTX* ctx)
     #endif
     }
 #endif
+#endif /* ATCA_TFLEX_SUPPORT */
     return ret;
 }
 
@@ -1100,4 +1461,124 @@ int atcatls_set_callback_ctx(WOLFSSL* ssl, void* user_ctx)
 
 #endif /* HAVE_PK_CALLBACKS */
 
-#endif /* WOLFSSL_ATMEL || WOLFSSL_ATECC508A || WOLFSSL_ATECC_PKCB */
+#if defined(WOLFSSL_MICROCHIP_TA100) && !defined(NO_AES) && \
+    defined(HAVE_AESGCM) && defined(WOLFSSL_MICROCHIP_AESGCM)
+int microchip_aes_set_key(Aes* aes, const byte* key, word32 keylen,
+                                        const byte* iv, int dir)
+{
+    ATCA_STATUS status;
+
+    (void)dir;
+    (void)iv;
+
+    if (aes == NULL) {
+        return BAD_FUNC_ARG;
+    }
+    status = atcab_nonce_load(NONCE_MODE_TARGET_TEMPKEY, key, keylen);
+    CHECK_STATUS(status);
+
+    aes->keylen = keylen;
+    aes->rounds = keylen/4 + 6;
+    XMEMCPY(aes->key, key, keylen);
+    aes->key_id = ATCA_TEMPKEY_KEYID;
+
+    return atmel_ecc_translate_err(status);
+}
+
+void microchip_aes_free(Aes* aes)
+{
+    (void)aes;
+}
+
+static int wc_Microchip_AesGcmCommon(Aes* aes, byte* out, const byte* in,
+        word32 sz, const byte* iv, word32 ivSz, byte* authTag, word32 authTagSz,
+        const byte* authIn, word32 authInSz, int dir)
+{
+    ATCA_STATUS status;
+    atca_aes_gcm_ctx_t ctx;
+
+    (void)out;
+    (void)in;
+    (void)sz;
+    (void)iv;
+    (void)ivSz;
+    (void)authTag;
+    (void)authTagSz;
+    (void)authIn;
+    (void)authInSz;
+    (void)dir;
+
+    (void)ctx;
+
+    if (aes == NULL) {
+        return BAD_FUNC_ARG;
+    }
+    if (dir != AES_ENCRYPTION &&
+        dir != AES_DECRYPTION) {
+        return BAD_FUNC_ARG;
+    }
+    /* Load AES keys into TempKey */
+    status = atcab_nonce_load(NONCE_MODE_TARGET_TEMPKEY, aes->key, 32);
+    CHECK_STATUS(status);
+
+    /* Initialize gcm ctx with IV */
+    if (iv && ivSz > 0) {
+        status = atcab_aes_gcm_init(&ctx, aes->key_id, AES_BLOCK_SIZE,
+                                iv, ivSz);
+    }
+    else {
+        status = atcab_aes_gcm_init(&ctx, aes->key_id, AES_BLOCK_SIZE,
+                                    (byte*)(aes->reg), AES_IV_SIZE);
+    }
+
+    CHECK_STATUS(status);
+
+    /* Add aad to gcm */
+    status = atcab_aes_gcm_aad_update(&ctx, authIn, authInSz);
+    CHECK_STATUS(status);
+
+    if (dir == AES_ENCRYPTION) {
+        /* Add plaintext to gcm */
+        status = atcab_aes_gcm_encrypt_update(&ctx, in, sz, out);
+        CHECK_STATUS(status);
+
+        /* Finish encrypt and get tag */
+        status = atcab_aes_gcm_encrypt_finish(&ctx, authTag, authTagSz);
+        CHECK_STATUS(status);
+    }
+    else {
+        /* Add cipher to gcm */
+        status = atcab_aes_gcm_decrypt_update(&ctx, in, sz, out);
+        CHECK_STATUS(status);
+
+        /* Complete GCM decrypt and validate tag */
+        bool is_verified = false;
+        status = atcab_aes_gcm_decrypt_finish(&ctx, authTag, authTagSz,
+                                              &is_verified);
+        CHECK_STATUS(status);
+        if (!is_verified) {
+            printf("FAIL\n");
+        }
+    }
+    return atmel_ecc_translate_err(status);
+}
+int microchip_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
+                             const byte* iv, word32 ivSz,
+                             byte* authTag, word32 authTagSz,
+                             const byte* authIn, word32 authInSz)
+{
+    return wc_Microchip_AesGcmCommon(aes, out, in, sz, iv, ivSz, authTag,
+                            authTagSz, authIn, authInSz, AES_ENCRYPTION);
+}
+
+int microchip_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
+                             const byte* iv, word32 ivSz,
+                             const byte* authTag, word32 authTagSz,
+                             const byte* authIn, word32 authInSz)
+{
+    return wc_Microchip_AesGcmCommon(aes, out, in, sz, iv, ivSz, (byte*)authTag,
+                                   authTagSz, authIn, authInSz, AES_DECRYPTION);
+}
+#endif /* WOLFSSL_MICROCHIP_TA100 && !NO_AES && HAVE_AESGCM */
+#endif /* WOLFSSL_ATMEL || WOLFSSL_ATECC508A || WOLFSSL_ATECC_PKCB || \
+          WOLFSSL_MICROCHIP_TA100 */

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -601,7 +601,7 @@ int wc_FreeRsaKey(RsaKey* key)
     wc_fspsm_RsaKeyFree(key);
 #endif
 #ifdef WOLFSSL_MICROCHIP_TA100
-    microchip_rsa_free(key);
+    wc_Microchip_rsa_free(key);
 #endif
     return ret;
 }
@@ -3277,11 +3277,11 @@ static int RsaPublicEncryptEx(const byte* in, word32 inLen, byte* out,
         if (rsa_type == RSA_PUBLIC_ENCRYPT &&
                                             pad_value == RSA_BLOCK_TYPE_2) {
 
-            return microchip_rsa_encrypt(in, inLen, out, outLen, key);
+            return wc_Microchip_rsa_encrypt(in, inLen, out, outLen, key);
         }
         else if (rsa_type == RSA_PRIVATE_ENCRYPT &&
                                          pad_value == RSA_BLOCK_TYPE_1) {
-            return microchip_rsa_sign(in, inLen, out, outLen, key);
+            return wc_Microchip_rsa_sign(in, inLen, out, outLen, key);
         }
     #elif defined(WOLFSSL_SE050)
         if (rsa_type == RSA_PUBLIC_ENCRYPT && pad_value == RSA_BLOCK_TYPE_2) {
@@ -3440,12 +3440,12 @@ static int RsaPrivateDecryptEx(const byte* in, word32 inLen, byte* out,
         if (rsa_type == RSA_PRIVATE_DECRYPT &&
                                             pad_value == RSA_BLOCK_TYPE_2) {
 
-            return microchip_rsa_decrypt(in, inLen, out, outLen, key);
+            return wc_Microchip_rsa_decrypt(in, inLen, out, outLen, key);
         }
         else if (rsa_type == RSA_PUBLIC_DECRYPT &&
                                          pad_value == RSA_BLOCK_TYPE_1) {
             int tmp;
-            return microchip_rsa_verify(in, inLen, out, outLen, key, &tmp);
+            return wc_Microchip_rsa_verify(in, inLen, out, outLen, key, &tmp);
         }
     #elif defined(WOLFSSL_SE050)
         if (rsa_type == RSA_PRIVATE_DECRYPT && pad_value == RSA_BLOCK_TYPE_2) {
@@ -4720,7 +4720,7 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
     err = cc310_RSA_GenerateKeyPair(key, size, e);
     goto out;
 #elif defined(WOLFSSL_MICROCHIP_TA100)
-    err = microchip_rsa_create_key(key, size, e);
+    err = wc_Microchip_rsa_create_key(key, size, e);
     goto out;
 #elif defined(WOLFSSL_SE050)
     err = se050_rsa_create_key(key, size, e);

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -55,7 +55,8 @@
 #endif
 
 #if defined(WOLFSSL_ATMEL) || defined(WOLFSSL_ATECC508A) || \
-    defined(WOLFSSL_ATECC608A)
+    defined(WOLFSSL_ATECC608A) || \
+    defined(WOLFSSL_MICROCHIP_TA100)
     #include <wolfssl/wolfcrypt/port/atmel/atmel.h>
 #endif
 #if defined(WOLFSSL_RENESAS_TSIP)
@@ -251,7 +252,7 @@ int wolfCrypt_Init(void)
     #endif
 
     #if defined(WOLFSSL_ATMEL) || defined(WOLFSSL_ATECC508A) || \
-        defined(WOLFSSL_ATECC608A)
+        defined(WOLFSSL_ATECC608A) || defined(WOLFSSL_MICROCHIP_TA100)
         ret = atmel_init();
         if (ret != 0) {
             WOLFSSL_MSG("CryptoAuthLib init failed");

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -578,7 +578,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t scrypt_test(void);
         WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  ecc_encrypt_test(void);
     #endif
     #if defined(USE_CERT_BUFFERS_256) && !defined(WOLFSSL_ATECC508A) && \
-        !defined(WOLFSSL_ATECC608A) && !defined(NO_ECC256) && \
+        !defined(WOLFSSL_ATECC608A) && !defined(WOLFSSL_MICROCHIP_TA100) && \
+        !defined(NO_ECC256) && \
         defined(HAVE_ECC_VERIFY) && defined(HAVE_ECC_SIGN) && \
         !defined(WOLF_CRYPTO_CB_ONLY_ECC) && !defined(NO_ECC_SECP)
         /* skip for ATECC508/608A, cannot import private key buffers */
@@ -1597,7 +1598,8 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
             TEST_PASS("ECC Enc  test passed!\n");
     #endif
     #if defined(USE_CERT_BUFFERS_256) && !defined(WOLFSSL_ATECC508A) && \
-        !defined(WOLFSSL_ATECC608A) && !defined(NO_ECC256) && \
+        !defined(WOLFSSL_ATECC608A) && !defined(WOLFSSL_MICROCHIP_TA100) && \
+        !defined(NO_ECC256) && \
         defined(HAVE_ECC_VERIFY) && defined(HAVE_ECC_SIGN) && \
         !defined(WOLF_CRYPTO_CB_ONLY_ECC) && !defined(NO_ECC_SECP)
         /* skip for ATECC508/608A, cannot import private key buffers */
@@ -26241,7 +26243,8 @@ static wc_test_ret_t ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerif
     int curve_id, const ecc_set_type* dp)
 {
 #if defined(HAVE_ECC_DHE) && !defined(WC_NO_RNG) && \
-    !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A)
+    !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+    !defined(WOLFSSL_MICROCHIP_TA100)
     WC_DECLARE_VAR(sharedA, byte, ECC_SHARED_SIZE, HEAP_HINT);
     WC_DECLARE_VAR(sharedB, byte, ECC_SHARED_SIZE, HEAP_HINT);
     word32  y;
@@ -26277,7 +26280,8 @@ static wc_test_ret_t ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerif
 
 #ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
 #if (defined(HAVE_ECC_DHE) || defined(HAVE_ECC_CDH)) && !defined(WC_NO_RNG) && \
-    !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A)
+    !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+    !defined(WOLFSSL_MICROCHIP_TA100)
     if (sharedA == NULL || sharedB == NULL)
         ERROR_OUT(WC_TEST_RET_ENC_ERRNO, done);
 #endif
@@ -26363,7 +26367,8 @@ static wc_test_ret_t ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerif
     TEST_SLEEP();
 
 /* ATECC508/608 configuration may not support more than one ECDH key */
-#if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A)
+#if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+    !defined(WOLFSSL_MICROCHIP_TA100)
 #if defined(WOLFSSL_MICROCHIP_TA100)
     key->slot = atmel_ecc_alloc(ATMEL_SLOT_ECDHE_BOB);
 #endif
@@ -26481,7 +26486,8 @@ static wc_test_ret_t ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
-#if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A)
+#if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+    !defined(WOLFSSL_MICROCHIP_TA100)
 #ifdef HAVE_ECC_DHE
     y = ECC_SHARED_SIZE;
     do {
@@ -26746,6 +26752,7 @@ static wc_test_ret_t ecc_test_curve(WC_RNG* rng, int keySize, int curve_id)
 
 #if (!defined(NO_ECC256) || defined(HAVE_ALL_CURVES)) && ECC_MIN_KEY_SZ <= 256
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+    !defined(WOLFSSL_MICROCHIP_TA100) && \
     defined(HAVE_ECC_KEY_IMPORT) && defined(HAVE_ECC_KEY_EXPORT) && \
     !defined(WOLFSSL_NO_MALLOC) && !defined(WOLF_CRYPTO_CB_ONLY_ECC)
 static wc_test_ret_t ecc_point_test(void)
@@ -29094,6 +29101,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ecc_test(void)
         goto done;
     }
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+    !defined(WOLFSSL_MICROCHIP_TA100) && \
     defined(HAVE_ECC_KEY_IMPORT) && defined(HAVE_ECC_KEY_EXPORT) && \
     !defined(WOLFSSL_NO_MALLOC) && !defined(WOLF_CRYPTO_CB_ONLY_ECC)
     ret = ecc_point_test();
@@ -29211,8 +29219,9 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ecc_test(void)
     }
 #endif
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
-  !defined(WOLFSSL_STM32_PKA) && !defined(WOLFSSL_SILABS_SE_ACCEL) && \
-  !defined(WOLF_CRYPTO_CB_ONLY_ECC) && !defined(NO_ECC_SECP)
+    !defined(WOLFSSL_MICROCHIP_TA100) && \
+    !defined(WOLFSSL_STM32_PKA) && !defined(WOLFSSL_SILABS_SE_ACCEL) && \
+    !defined(WOLF_CRYPTO_CB_ONLY_ECC) && !defined(NO_ECC_SECP)
     ret = ecc_test_make_pub(&rng);
     if (ret != 0) {
         printf("ecc_test_make_pub failed!\n");
@@ -30046,7 +30055,8 @@ done:
 #endif /* HAVE_ECC_ENCRYPT && HAVE_AES_CBC && WOLFSSL_AES_128 */
 
 #if defined(USE_CERT_BUFFERS_256) && !defined(WOLFSSL_ATECC508A) && \
-    !defined(WOLFSSL_ATECC608A) && !defined(NO_ECC256) && \
+    !defined(WOLFSSL_ATECC608A) && !defined(WOLFSSL_MICROCHIP_TA100) && \
+    !defined(NO_ECC256) && \
     defined(HAVE_ECC_VERIFY) && defined(HAVE_ECC_SIGN) && \
     !defined(WOLF_CRYPTO_CB_ONLY_ECC) && !defined(NO_ECC_SECP)
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ecc_test_buffers(void)

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -228,6 +228,9 @@ struct Aes {
     byte   keyIdSet;
     byte   useSWCrypt; /* Use SW crypt instead of SE050, before SCP03 auth */
 #endif
+#ifdef WOLFSSL_MICROCHIP_TA100
+    uint16_t key_id;
+#endif
 #ifdef HAVE_CAVIUM_OCTEON_SYNC
     word32 y0;
 #endif

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -229,7 +229,7 @@ struct Aes {
     byte   useSWCrypt; /* Use SW crypt instead of SE050, before SCP03 auth */
 #endif
 #ifdef WOLFSSL_MICROCHIP_TA100
-    uint16_t key_id;
+    word16 key_id; /* use word16 instead of uint16_t for mplabx */
 #endif
 #ifdef HAVE_CAVIUM_OCTEON_SYNC
     word32 y0;

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -165,7 +165,8 @@ enum {
     ECC_MAX_SIG_SIZE= ((MAX_ECC_BYTES * 2) + ECC_MAX_PAD_SZ + SIG_HEADER_SZ),
 
     /* max crypto hardware size */
-#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A)
+#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
+    defined(WOLFSSL_MICROCHIP_TA100)
     ECC_MAX_CRYPTO_HW_SIZE = ATECC_KEY_SIZE, /* from port/atmel/atmel.h */
     ECC_MAX_CRYPTO_HW_PUBKEY_SIZE = (ATECC_KEY_SIZE*2),
 #elif defined(PLUTON_CRYPTO_ECC)
@@ -501,7 +502,8 @@ struct ecc_key {
     word32 keyId;
     byte   keyIdSet;
 #endif
-#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A)
+#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
+    defined(WOLFSSL_MICROCHIP_TA100)
     int  slot;        /* Key Slot Number (-1 unknown) */
     byte pubkey_raw[ECC_MAX_CRYPTO_HW_PUBKEY_SIZE];
 #endif
@@ -661,6 +663,7 @@ int wc_ecc_shared_secret_gen_sync(ecc_key* private_key,
     ecc_point* point, byte* out, word32* outlen);
 
 #if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
+    defined(WOLFSSL_MICROCHIP_TA100) || \
     defined(PLUTON_CRYPTO_ECC) || defined(WOLFSSL_CRYPTOCELL)
 #define wc_ecc_shared_secret_ssh wc_ecc_shared_secret
 #else
@@ -777,7 +780,8 @@ int wc_ecc_point_is_at_infinity(ecc_point *p);
 WOLFSSL_API
 int wc_ecc_point_is_on_curve(ecc_point *p, int curve_idx);
 
-#if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A)
+#if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+    !defined(WOLFSSL_MICROCHIP_TA100)
 WOLFSSL_API
 int wc_ecc_mulmod(const mp_int* k, ecc_point *G, ecc_point *R,
                   mp_int* a, mp_int* modulus, int map);

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -50,7 +50,8 @@
     #endif
 #endif
 
-#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A)
+#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
+    defined(WOLFSSL_MICROCHIP_TA100)
     #include <wolfssl/wolfcrypt/port/atmel/atmel.h>
 #endif /* WOLFSSL_ATECC508A */
 

--- a/wolfssl/wolfcrypt/port/atmel/atmel.h
+++ b/wolfssl/wolfcrypt/port/atmel/atmel.h
@@ -27,20 +27,25 @@
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
-#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
-    defined(WOLFSSL_ATECC_PKCB)
-    #undef SHA_BLOCK_SIZE
-    #include <cryptoauthlib.h>
-#endif
-
 /* ATECC508A/608A only supports ECC P-256 */
 #define ATECC_KEY_SIZE      (32)
 #define ATECC_PUBKEY_SIZE   (ATECC_KEY_SIZE*2) /* X and Y */
 #define ATECC_SIG_SIZE      (ATECC_KEY_SIZE*2) /* R and S */
+
+#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
+    defined(WOLFSSL_ATECC_PKCB) || defined(WOLFSSL_MICROCHIP_TA100)
+    #undef SHA_BLOCK_SIZE
+    #include <cryptoauthlib.h>
+    #include <calib/calib_command.h>
+#endif
+#if defined(WOLFSSL_MICROCHIP_TA100) && defined(HAVE_AESGCM)
+    #include <cryptoauthlib/calib/calib_aes_gcm.h>
+#endif
 #ifndef ATECC_MAX_SLOT
 #define ATECC_MAX_SLOT      (0x8) /* Only use 0-7 */
 #endif
 #define ATECC_INVALID_SLOT  (0xFF)
+#define MICROCHIP_INVALID_ECC (0xFF)
 
 /* Device Key for signing */
 #ifndef ATECC_SLOT_AUTH_PRIV
@@ -65,6 +70,12 @@
     #else
         #define ATECC_SLOT_ENC_PARENT     (0x7)
     #endif
+#endif
+#ifndef ATECC_SLOT_ECDHE_PRIV_ALICE
+    #define ATECC_SLOT_ECDHE_PRIV_ALICE   (0x1)
+#endif
+#ifndef ATECC_SLOT_ECDHE_PRIV_BOB
+    #define ATECC_SLOT_ECDHE_PRIV_BOB     (0x3)
 #endif
 
 /* ATECC_KEY_SIZE required for ecc.h */
@@ -93,10 +104,12 @@ enum atmelSlotType {
     ATMEL_SLOT_DEVICE,
     ATMEL_SLOT_ECDHE,
     ATMEL_SLOT_ECDHE_ENC,
+    ATMEL_SLOT_ECDHE_ALICE,
+    ATMEL_SLOT_ECDHE_BOB,
 };
 
-int  atmel_ecc_alloc(int slotType);
-void atmel_ecc_free(int slotId);
+WOLFSSL_API int  atmel_ecc_alloc(int slotType);
+WOLFSSL_API void atmel_ecc_free(int slotId);
 
 typedef int  (*atmel_slot_alloc_cb)(int);
 typedef void (*atmel_slot_dealloc_cb)(int);
@@ -108,7 +121,9 @@ int  atmel_get_rev_info(word32* revision);
 void atmel_show_rev_info(void);
 
 WOLFSSL_API int wolfCrypt_ATECC_SetConfig(ATCAIfaceCfg* cfg);
-
+#if defined(WOLFSSL_MICROCHIP_TA100)
+WOLFSSL_API int atmel_SetSharedDataConfig(ta_element_attributes_t* cfg);
+#endif
 /* The macro ATECC_GET_ENC_KEY can be set to override the default
    encryption key with your own at build-time */
 #ifndef ATECC_GET_ENC_KEY
@@ -116,12 +131,44 @@ WOLFSSL_API int wolfCrypt_ATECC_SetConfig(ATCAIfaceCfg* cfg);
 #endif
 int  atmel_get_enc_key_default(byte* enckey, word16 keysize);
 int  atmel_ecc_create_pms(int slotId, const uint8_t* peerKey, uint8_t* pms);
-int  atmel_ecc_create_key(int slotId, byte* peerKey);
+int  atmel_ecc_create_key(int slotId, int curve_id, byte* peerKey);
 int  atmel_ecc_sign(int slotId, const byte* message, byte* signature);
 int  atmel_ecc_verify(const byte* message, const byte* signature,
     const byte* pubkey, int* pVerified);
 
 #endif /* WOLFSSL_ATECC508A */
+
+#if defined(WOLFSSL_MICROCHIP_TA100)
+
+#if !defined(NO_AES) && defined(HAVE_AESGCM) && \
+    defined(WOLFSSL_MICROCHIP_AESGCM)
+#include <wolfssl/wolfcrypt/aes.h>
+
+int microchip_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
+                            const byte* iv, word32 ivSz,
+                            byte* authTag, word32 authTagSz,
+                            const byte* authIn, word32 authInSz);
+int microchip_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
+                            const byte* iv, word32 ivSz,
+                            const byte* authTag, word32 authTagSz,
+                            const byte* authIn, word32 authInSz);
+int microchip_aes_set_key(Aes* aes, const byte* key, word32 len,
+                          const byte* iv, int dir);
+void microchip_aes_free(Aes* aes);
+#endif /* !NO_AES && HAVE_AESGCM */
+#ifndef NO_RSA
+int microchip_rsa_create_key(RsaKey* key, int size, long e);
+void microchip_rsa_free(RsaKey* key);
+int microchip_rsa_sign(const byte* in, word32 inLen, byte* out, word32 outLen,
+                       RsaKey* key);
+int microchip_rsa_verify(const byte* in, word32 inLen, byte* sig, word32 sigLen,
+                         RsaKey* key, int* pVerified);
+int microchip_rsa_encrypt(const byte* in, word32 inLen, byte* out,
+                          word32 outLen, RsaKey* key);
+int microchip_rsa_decrypt(const byte* in, word32 inLen, byte* out,
+                          word32 outLen, RsaKey* key);
+#endif /* NO_RSA */
+#endif /* WOLFSSL_MICROCHIP_TA100 */
 
 #ifdef HAVE_PK_CALLBACKS
     int atcatls_create_key_cb(struct WOLFSSL* ssl, struct ecc_key* key, unsigned int keySz,

--- a/wolfssl/wolfcrypt/port/atmel/atmel.h
+++ b/wolfssl/wolfcrypt/port/atmel/atmel.h
@@ -96,7 +96,8 @@ int  atmel_get_random_number(uint32_t count, uint8_t* rand_out);
 #endif
 long atmel_get_curr_time_and_date(long* tm);
 
-#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A)
+#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
+    defined(WOLFSSL_MICROCHIP_TA100)
 
 enum atmelSlotType {
     ATMEL_SLOT_ANY,
@@ -108,8 +109,8 @@ enum atmelSlotType {
     ATMEL_SLOT_ECDHE_BOB,
 };
 
-WOLFSSL_API int  atmel_ecc_alloc(int slotType);
-WOLFSSL_API void atmel_ecc_free(int slotId);
+int  atmel_ecc_alloc(int slotType);
+void atmel_ecc_free(int slotId);
 
 typedef int  (*atmel_slot_alloc_cb)(int);
 typedef void (*atmel_slot_dealloc_cb)(int);
@@ -122,7 +123,7 @@ void atmel_show_rev_info(void);
 
 WOLFSSL_API int wolfCrypt_ATECC_SetConfig(ATCAIfaceCfg* cfg);
 #if defined(WOLFSSL_MICROCHIP_TA100)
-WOLFSSL_API int atmel_SetSharedDataConfig(ta_element_attributes_t* cfg);
+WOLFSSL_API int wc_Microchip_SetSharedDataConfig(ta_element_attributes_t* cfg);
 #endif
 /* The macro ATECC_GET_ENC_KEY can be set to override the default
    encryption key with your own at build-time */
@@ -130,12 +131,13 @@ WOLFSSL_API int atmel_SetSharedDataConfig(ta_element_attributes_t* cfg);
     #define ATECC_GET_ENC_KEY(enckey, keysize) atmel_get_enc_key_default((enckey), (keysize))
 #endif
 int  atmel_get_enc_key_default(byte* enckey, word16 keysize);
+#ifdef HAVE_ECC
 int  atmel_ecc_create_pms(int slotId, const uint8_t* peerKey, uint8_t* pms);
 int  atmel_ecc_create_key(int slotId, int curve_id, byte* peerKey);
 int  atmel_ecc_sign(int slotId, const byte* message, byte* signature);
 int  atmel_ecc_verify(const byte* message, const byte* signature,
     const byte* pubkey, int* pVerified);
-
+#endif /* HAVE_ECC */
 #endif /* WOLFSSL_ATECC508A */
 
 #if defined(WOLFSSL_MICROCHIP_TA100)
@@ -144,29 +146,43 @@ int  atmel_ecc_verify(const byte* message, const byte* signature,
     defined(WOLFSSL_MICROCHIP_AESGCM)
 #include <wolfssl/wolfcrypt/aes.h>
 
-int microchip_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
+WOLFSSL_LOCAL int wc_Microchip_AesGcmEncrypt(Aes* aes, byte* out,
+                            const byte* in, word32 sz,
                             const byte* iv, word32 ivSz,
                             byte* authTag, word32 authTagSz,
                             const byte* authIn, word32 authInSz);
-int microchip_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
+WOLFSSL_LOCAL int wc_Microchip_AesGcmDecrypt(Aes* aes, byte* out,
+                            const byte* in, word32 sz,
                             const byte* iv, word32 ivSz,
                             const byte* authTag, word32 authTagSz,
                             const byte* authIn, word32 authInSz);
-int microchip_aes_set_key(Aes* aes, const byte* key, word32 len,
-                          const byte* iv, int dir);
-void microchip_aes_free(Aes* aes);
+WOLFSSL_LOCAL int wc_Microchip_aes_set_key(Aes* aes, const byte* key,
+                                           word32 len, const byte* iv, int dir);
+WOLFSSL_LOCAL void wc_Microchip_aes_free(Aes* aes);
 #endif /* !NO_AES && HAVE_AESGCM */
 #ifndef NO_RSA
-int microchip_rsa_create_key(RsaKey* key, int size, long e);
-void microchip_rsa_free(RsaKey* key);
-int microchip_rsa_sign(const byte* in, word32 inLen, byte* out, word32 outLen,
-                       RsaKey* key);
-int microchip_rsa_verify(const byte* in, word32 inLen, byte* sig, word32 sigLen,
-                         RsaKey* key, int* pVerified);
-int microchip_rsa_encrypt(const byte* in, word32 inLen, byte* out,
-                          word32 outLen, RsaKey* key);
-int microchip_rsa_decrypt(const byte* in, word32 inLen, byte* out,
-                          word32 outLen, RsaKey* key);
+WOLFSSL_LOCAL int wc_Microchip_rsa_create_key(RsaKey* key, int size, long e);
+WOLFSSL_LOCAL void wc_Microchip_rsa_free(RsaKey* key);
+WOLFSSL_LOCAL int wc_Microchip_rsa_sign(const byte* in, word32 inLen, byte* out,
+                                    word32 outLen, RsaKey* key);
+WOLFSSL_LOCAL int wc_Microchip_rsa_verify(const byte* in, word32 inLen,
+                                          byte* sig, word32 sigLen, RsaKey* key,
+                                          int* pVerified);
+WOLFSSL_LOCAL int wc_Microchip_rsa_encrypt(const byte* in, word32 inLen,
+                                         byte* out, word32 outLen, RsaKey* key);
+WOLFSSL_LOCAL int wc_Microchip_rsa_decrypt(const byte* in, word32 inLen,
+                                         byte* out, word32 outLen, RsaKey* key);
+
+#ifndef WOLFSSL_SP_NO_2048
+    #define WOLFSSL_TA_KEY_TYPE_RSA TA_KEY_TYPE_RSA2048
+    #define WOLFSSL_TA_KEY_TYPE_RSA_SIZE TA_KEY_TYPE_RSA2048_SIZE
+#elif WOLFSSL_SP_NO_3072
+    #define WOLFSSL_TA_KEY_TYPE_RSA TA_KEY_TYPE_RSA3072
+    #define WOLFSSL_TA_KEY_TYPE_RSA_SIZE TA_KEY_TYPE_RSA3072_SIZE
+#else
+    #error Microchip requires enabling 2048 or 3072 RSA.*/
+#endif
+
 #endif /* NO_RSA */
 #endif /* WOLFSSL_MICROCHIP_TA100 */
 

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -140,6 +140,9 @@ RSA keys can be used to encrypt, decrypt, sign and verify data.
         #include <wolfssl/wolfcrypt/asn.h>
     #endif
 #endif
+#if defined(WOLFSSL_MICROCHIP_TA100)
+    #include <wolfssl/wolfcrypt/port/atmel/atmel.h>
+#endif /* WOLFSSL_MICROCHIP_TA100 */
 
 enum {
     RSA_PUBLIC   = 0,
@@ -207,6 +210,11 @@ struct RsaKey {
 #ifdef WOLFSSL_SE050
     word32 keyId;
     byte   keyIdSet;
+#endif
+#if defined(WOLFSSL_MICROCHIP_TA100)
+    uint16_t  rKeyH;        /* private key handle */
+    uint16_t  uKeyH;        /* public key handle */
+    byte uKey[TA_KEY_TYPE_RSA2048_SIZE]; /* public key */
 #endif
 #ifdef WOLF_CRYPTO_CB
     void* devCtx;

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -523,7 +523,9 @@
     #endif
 #endif
 
-#ifdef WOLFSSL_ATECC508A
+/*#ifdef WOLFSSL_ATECC508A*/
+#if defined(WOLFSSL_ATECC508A) || \
+    defined(WOLFSSL_MICROCHIP_TA100)
     /* backwards compatibility */
 #ifndef WOLFSSL_ATECC_NO_ECDH_ENC
     #define WOLFSSL_ATECC_ECDH_ENC
@@ -2207,6 +2209,7 @@ extern void uITRON4_free(void *p) ;
 
 #if defined(OPENSSL_EXTRA) && defined(HAVE_ECC) && \
     !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+    !defined(WOLFSSL_MICROCHIP_TA100) && \
     !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_SE050) && \
     !defined(WOLF_CRYPTO_CB_ONLY_ECC) && !defined(WOLFSSL_STM32_PKA)
     #undef  USE_ECC_B_PARAM


### PR DESCRIPTION
# Description

This PR adds support for Microchip/Atmel Trust Anchor TA100 secure element from their portfolio of CryptoAutomotive™ security ICs for automotive security applications.

Fixes zd#

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
