### PR TITLE
20230603-unittest-maybe-uninited

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -36409,7 +36409,7 @@ static int test_wolfSSL_PEM_PrivateKey(void)
         !defined(HAVE_USER_RSA) && !defined(NO_RSA)
     {
         XFILE f = XBADFILE;
-        wc_pem_password_cb* passwd_cb;
+        wc_pem_password_cb* passwd_cb = NULL;
         void* passwd_cb_userdata;
         SSL_CTX* ctx = NULL;
         char passwd[] = "bad password";


### PR DESCRIPTION
`tests/api.c`: fix a likely-spurious maybe-uninitialized from `gcc-11` `-m32` (`all-sp-m32`) in `test_wolfSSL_PEM_PrivateKey()`.

tested with `wolfssl-multi-test.sh ... all-sp-m32`.
