### PR TITLE
XCODE project: install all headers

### DIFF
--- a/IDE/XCODE/user_settings.h
+++ b/IDE/XCODE/user_settings.h
@@ -17,8 +17,8 @@
     /* 128-bit type */
     #define HAVE___UINT128_T
 
-    /* fast math */
-    #define USE_FAST_MATH
+    /* SP Math */
+    #define WOLFSSL_SP_MATH
     #define HAVE_ECC
 
     /* ECC speedups */

--- a/IDE/XCODE/wolfssl-FIPS.xcodeproj/project.pbxproj
+++ b/IDE/XCODE/wolfssl-FIPS.xcodeproj/project.pbxproj
@@ -96,15 +96,15 @@
 		521646F51A8A7FF30062516A /* types.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 521646871A8993770062516A /* types.h */; };
 		521646F61A8A7FF30062516A /* visibility.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 521646881A8993770062516A /* visibility.h */; };
 		521646F71A8A7FF30062516A /* wc_port.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 521646891A8993770062516A /* wc_port.h */; };
-		521646F81A8A80030062516A /* callbacks.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5216468A1A8993BB0062516A /* callbacks.h */; };
-		521646F91A8A80030062516A /* certs_test.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5216468B1A8993BB0062516A /* certs_test.h */; };
-		521646FA1A8A80030062516A /* crl.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5216468C1A8993BB0062516A /* crl.h */; };
-		521646FB1A8A80030062516A /* error-ssl.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5216468D1A8993BB0062516A /* error-ssl.h */; };
-		521646FC1A8A80030062516A /* internal.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5216468E1A8993BB0062516A /* internal.h */; };
-		521646FD1A8A80030062516A /* ocsp.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5216468F1A8993BB0062516A /* ocsp.h */; };
-		521646FE1A8A80030062516A /* ssl.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 521646921A8993BB0062516A /* ssl.h */; };
-		521646FF1A8A80030062516A /* test.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 521646931A8993BB0062516A /* test.h */; };
-		521647001A8A80030062516A /* version.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 521646941A8993BB0062516A /* version.h */; };
+		521646F81A8A80030062516A /* callbacks.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 5216468A1A8993BB0062516A /* callbacks.h */; };
+		521646F91A8A80030062516A /* certs_test.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 5216468B1A8993BB0062516A /* certs_test.h */; };
+		521646FA1A8A80030062516A /* crl.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 5216468C1A8993BB0062516A /* crl.h */; };
+		521646FB1A8A80030062516A /* error-ssl.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 5216468D1A8993BB0062516A /* error-ssl.h */; };
+		521646FC1A8A80030062516A /* internal.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 5216468E1A8993BB0062516A /* internal.h */; };
+		521646FD1A8A80030062516A /* ocsp.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 5216468F1A8993BB0062516A /* ocsp.h */; };
+		521646FE1A8A80030062516A /* ssl.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 521646921A8993BB0062516A /* ssl.h */; };
+		521646FF1A8A80030062516A /* test.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 521646931A8993BB0062516A /* test.h */; };
+		521647001A8A80030062516A /* version.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 521646941A8993BB0062516A /* version.h */; };
 		521647011A8A80100062516A /* aes.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 521646951A8993F50062516A /* aes.h */; };
 		521647021A8A80100062516A /* arc4.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 521646961A8993F50062516A /* arc4.h */; };
 		521647031A8A80100062516A /* asn_public.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 521646971A8993F50062516A /* asn_public.h */; };
@@ -165,6 +165,44 @@
 		525BE5BC1B3885750054BBCD /* hash.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 525BE5BB1B3885580054BBCD /* hash.h */; };
 		6AC85136272CAFEC00F2B32A /* kdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 6AC85135272CAFEC00F2B32A /* kdf.c */; };
 		6AC85137272CAFEC00F2B32A /* kdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 6AC85135272CAFEC00F2B32A /* kdf.c */; };
+		700F0CED2A2FC11300755BA7 /* async.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CCB2A2FC0D500755BA7 /* async.h */; };
+		700F0CEE2A2FC11300755BA7 /* chacha20_poly1305.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CC62A2FC0D400755BA7 /* chacha20_poly1305.h */; };
+		700F0CEF2A2FC11300755BA7 /* cmac.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CD72A2FC0D500755BA7 /* cmac.h */; };
+		700F0CF02A2FC11300755BA7 /* cpuid.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CCE2A2FC0D500755BA7 /* cpuid.h */; };
+		700F0CF12A2FC11300755BA7 /* cryptocb.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CE02A2FC0D500755BA7 /* cryptocb.h */; };
+		700F0CF22A2FC11300755BA7 /* curve448.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CD32A2FC0D500755BA7 /* curve448.h */; };
+		700F0CF32A2FC11300755BA7 /* curve25519.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CC82A2FC0D500755BA7 /* curve25519.h */; };
+		700F0CF42A2FC11300755BA7 /* dilithium.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CE52A2FC0D500755BA7 /* dilithium.h */; };
+		700F0CF52A2FC11300755BA7 /* eccsi.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CDB2A2FC0D500755BA7 /* eccsi.h */; };
+		700F0CF62A2FC11300755BA7 /* ed448.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CD22A2FC0D500755BA7 /* ed448.h */; };
+		700F0CF72A2FC11300755BA7 /* ed25519.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CE12A2FC0D500755BA7 /* ed25519.h */; };
+		700F0CF82A2FC11300755BA7 /* ext_kyber.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CD52A2FC0D500755BA7 /* ext_kyber.h */; };
+		700F0CF92A2FC11300755BA7 /* falcon.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CDD2A2FC0D500755BA7 /* falcon.h */; };
+		700F0CFA2A2FC11300755BA7 /* fe_448.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CDE2A2FC0D500755BA7 /* fe_448.h */; };
+		700F0CFB2A2FC11300755BA7 /* fe_operations.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CC72A2FC0D400755BA7 /* fe_operations.h */; };
+		700F0CFC2A2FC11300755BA7 /* fips.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CCF2A2FC0D500755BA7 /* fips.h */; };
+		700F0CFD2A2FC11300755BA7 /* ge_448.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CE22A2FC0D500755BA7 /* ge_448.h */; };
+		700F0CFE2A2FC11300755BA7 /* ge_operations.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CCA2A2FC0D500755BA7 /* ge_operations.h */; };
+		700F0CFF2A2FC11300755BA7 /* hpke.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CCD2A2FC0D500755BA7 /* hpke.h */; };
+		700F0D002A2FC11300755BA7 /* kyber.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CCC2A2FC0D500755BA7 /* kyber.h */; };
+		700F0D012A2FC11300755BA7 /* mem_track.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CDA2A2FC0D500755BA7 /* mem_track.h */; };
+		700F0D022A2FC11300755BA7 /* pkcs11.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CD92A2FC0D500755BA7 /* pkcs11.h */; };
+		700F0D032A2FC11300755BA7 /* pkcs12.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CE42A2FC0D500755BA7 /* pkcs12.h */; };
+		700F0D042A2FC11300755BA7 /* rc2.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CEA2A2FC0D500755BA7 /* rc2.h */; };
+		700F0D052A2FC11300755BA7 /* sakke.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CE62A2FC0D500755BA7 /* sakke.h */; };
+		700F0D062A2FC11300755BA7 /* selftest.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CC92A2FC0D500755BA7 /* selftest.h */; };
+		700F0D072A2FC11300755BA7 /* sha3.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CD02A2FC0D500755BA7 /* sha3.h */; };
+		700F0D082A2FC11300755BA7 /* signature.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CE72A2FC0D500755BA7 /* signature.h */; };
+		700F0D092A2FC11300755BA7 /* siphash.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CD42A2FC0D500755BA7 /* siphash.h */; };
+		700F0D0A2A2FC11300755BA7 /* sp_int.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CDF2A2FC0D500755BA7 /* sp_int.h */; };
+		700F0D0B2A2FC11300755BA7 /* sp.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CD12A2FC0D500755BA7 /* sp.h */; };
+		700F0D0C2A2FC11300755BA7 /* sphincs.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CEC2A2FC0D500755BA7 /* sphincs.h */; };
+		700F0D0D2A2FC11300755BA7 /* srp.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CDC2A2FC0D500755BA7 /* srp.h */; };
+		700F0D0E2A2FC11300755BA7 /* wc_kyber.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CD82A2FC0D500755BA7 /* wc_kyber.h */; };
+		700F0D0F2A2FC11300755BA7 /* wc_pkcs11.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CE82A2FC0D500755BA7 /* wc_pkcs11.h */; };
+		700F0D102A2FC11300755BA7 /* wolfevent.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CD62A2FC0D500755BA7 /* wolfevent.h */; };
+		700F0D112A2FC11300755BA7 /* wolfmath.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0CEB2A2FC0D500755BA7 /* wolfmath.h */; };
+		700F0D122A2FC11300755BA7 /* kdf.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 6AC8513A272CB01200F2B32A /* kdf.h */; };
 		9D2E31D7291CE2190082B941 /* dtls13.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D2E31D6291CE2190082B941 /* dtls13.c */; };
 		9D2E31D8291CE2190082B941 /* dtls13.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D2E31D6291CE2190082B941 /* dtls13.c */; };
 		9D2E31DA291CE2370082B941 /* dtls.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D2E31D9291CE2370082B941 /* dtls.c */; };
@@ -338,6 +376,44 @@
 			dstPath = include/wolfssl/wolfcrypt;
 			dstSubfolderSpec = 7;
 			files = (
+				700F0CED2A2FC11300755BA7 /* async.h in CopyFiles */,
+				700F0CEE2A2FC11300755BA7 /* chacha20_poly1305.h in CopyFiles */,
+				700F0CEF2A2FC11300755BA7 /* cmac.h in CopyFiles */,
+				700F0CF02A2FC11300755BA7 /* cpuid.h in CopyFiles */,
+				700F0CF12A2FC11300755BA7 /* cryptocb.h in CopyFiles */,
+				700F0CF22A2FC11300755BA7 /* curve448.h in CopyFiles */,
+				700F0CF32A2FC11300755BA7 /* curve25519.h in CopyFiles */,
+				700F0CF42A2FC11300755BA7 /* dilithium.h in CopyFiles */,
+				700F0CF52A2FC11300755BA7 /* eccsi.h in CopyFiles */,
+				700F0CF62A2FC11300755BA7 /* ed448.h in CopyFiles */,
+				700F0CF72A2FC11300755BA7 /* ed25519.h in CopyFiles */,
+				700F0CF82A2FC11300755BA7 /* ext_kyber.h in CopyFiles */,
+				700F0CF92A2FC11300755BA7 /* falcon.h in CopyFiles */,
+				700F0CFA2A2FC11300755BA7 /* fe_448.h in CopyFiles */,
+				700F0CFB2A2FC11300755BA7 /* fe_operations.h in CopyFiles */,
+				700F0CFC2A2FC11300755BA7 /* fips.h in CopyFiles */,
+				700F0CFD2A2FC11300755BA7 /* ge_448.h in CopyFiles */,
+				700F0CFE2A2FC11300755BA7 /* ge_operations.h in CopyFiles */,
+				700F0CFF2A2FC11300755BA7 /* hpke.h in CopyFiles */,
+				700F0D002A2FC11300755BA7 /* kyber.h in CopyFiles */,
+				700F0D012A2FC11300755BA7 /* mem_track.h in CopyFiles */,
+				700F0D022A2FC11300755BA7 /* pkcs11.h in CopyFiles */,
+				700F0D032A2FC11300755BA7 /* pkcs12.h in CopyFiles */,
+				700F0D042A2FC11300755BA7 /* rc2.h in CopyFiles */,
+				700F0D052A2FC11300755BA7 /* sakke.h in CopyFiles */,
+				700F0D062A2FC11300755BA7 /* selftest.h in CopyFiles */,
+				700F0D072A2FC11300755BA7 /* sha3.h in CopyFiles */,
+				700F0D082A2FC11300755BA7 /* signature.h in CopyFiles */,
+				700F0D092A2FC11300755BA7 /* siphash.h in CopyFiles */,
+				700F0D0A2A2FC11300755BA7 /* sp_int.h in CopyFiles */,
+				700F0D0B2A2FC11300755BA7 /* sp.h in CopyFiles */,
+				700F0D0C2A2FC11300755BA7 /* sphincs.h in CopyFiles */,
+				700F0D0D2A2FC11300755BA7 /* srp.h in CopyFiles */,
+				700F0D0E2A2FC11300755BA7 /* wc_kyber.h in CopyFiles */,
+				700F0D0F2A2FC11300755BA7 /* wc_pkcs11.h in CopyFiles */,
+				700F0D102A2FC11300755BA7 /* wolfevent.h in CopyFiles */,
+				700F0D112A2FC11300755BA7 /* wolfmath.h in CopyFiles */,
+				700F0D122A2FC11300755BA7 /* kdf.h in CopyFiles */,
 				522DBE131B792A190031F454 /* wc_encrypt.h in CopyFiles */,
 				525BE5BC1B3885750054BBCD /* hash.h in CopyFiles */,
 				521646CD1A8A7FF30062516A /* aes.h in CopyFiles */,
@@ -384,22 +460,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		521646C21A8A7B3B0062516A /* CopyFiles */ = {
+		521646C21A8A7B3B0062516A /* Copy Files */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = include/cyassl;
 			dstSubfolderSpec = 7;
 			files = (
-				521646F81A8A80030062516A /* callbacks.h in CopyFiles */,
-				521646F91A8A80030062516A /* certs_test.h in CopyFiles */,
-				521646FA1A8A80030062516A /* crl.h in CopyFiles */,
-				521646FB1A8A80030062516A /* error-ssl.h in CopyFiles */,
-				521646FC1A8A80030062516A /* internal.h in CopyFiles */,
-				521646FD1A8A80030062516A /* ocsp.h in CopyFiles */,
-				521646FE1A8A80030062516A /* ssl.h in CopyFiles */,
-				521646FF1A8A80030062516A /* test.h in CopyFiles */,
-				521647001A8A80030062516A /* version.h in CopyFiles */,
+				521646F81A8A80030062516A /* callbacks.h in Copy Files */,
+				521646F91A8A80030062516A /* certs_test.h in Copy Files */,
+				521646FA1A8A80030062516A /* crl.h in Copy Files */,
+				521646FB1A8A80030062516A /* error-ssl.h in Copy Files */,
+				521646FC1A8A80030062516A /* internal.h in Copy Files */,
+				521646FD1A8A80030062516A /* ocsp.h in Copy Files */,
+				521646FE1A8A80030062516A /* ssl.h in Copy Files */,
+				521646FF1A8A80030062516A /* test.h in Copy Files */,
+				521647001A8A80030062516A /* version.h in Copy Files */,
 			);
+			name = "Copy Files";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		521646C31A8A7B3D0062516A /* CopyFiles */ = {
@@ -772,6 +849,43 @@
 		52B1344D16F3C9E800C07B32 /* libwolfssl_fips_ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libwolfssl_fips_ios.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		6AC85135272CAFEC00F2B32A /* kdf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = kdf.c; path = ../../wolfcrypt/src/kdf.c; sourceTree = "<group>"; };
 		6AC8513A272CB01200F2B32A /* kdf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = kdf.h; path = ../../wolfssl/wolfcrypt/kdf.h; sourceTree = "<group>"; };
+		700F0CC62A2FC0D400755BA7 /* chacha20_poly1305.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = chacha20_poly1305.h; path = ../../wolfssl/wolfcrypt/chacha20_poly1305.h; sourceTree = "<group>"; };
+		700F0CC72A2FC0D400755BA7 /* fe_operations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fe_operations.h; path = ../../wolfssl/wolfcrypt/fe_operations.h; sourceTree = "<group>"; };
+		700F0CC82A2FC0D500755BA7 /* curve25519.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = curve25519.h; path = ../../wolfssl/wolfcrypt/curve25519.h; sourceTree = "<group>"; };
+		700F0CC92A2FC0D500755BA7 /* selftest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = selftest.h; path = ../../wolfssl/wolfcrypt/selftest.h; sourceTree = "<group>"; };
+		700F0CCA2A2FC0D500755BA7 /* ge_operations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ge_operations.h; path = ../../wolfssl/wolfcrypt/ge_operations.h; sourceTree = "<group>"; };
+		700F0CCB2A2FC0D500755BA7 /* async.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = async.h; path = ../../wolfssl/wolfcrypt/async.h; sourceTree = "<group>"; };
+		700F0CCC2A2FC0D500755BA7 /* kyber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = kyber.h; path = ../../wolfssl/wolfcrypt/kyber.h; sourceTree = "<group>"; };
+		700F0CCD2A2FC0D500755BA7 /* hpke.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = hpke.h; path = ../../wolfssl/wolfcrypt/hpke.h; sourceTree = "<group>"; };
+		700F0CCE2A2FC0D500755BA7 /* cpuid.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = cpuid.h; path = ../../wolfssl/wolfcrypt/cpuid.h; sourceTree = "<group>"; };
+		700F0CCF2A2FC0D500755BA7 /* fips.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fips.h; path = ../../wolfssl/wolfcrypt/fips.h; sourceTree = "<group>"; };
+		700F0CD02A2FC0D500755BA7 /* sha3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sha3.h; path = ../../wolfssl/wolfcrypt/sha3.h; sourceTree = "<group>"; };
+		700F0CD12A2FC0D500755BA7 /* sp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sp.h; path = ../../wolfssl/wolfcrypt/sp.h; sourceTree = "<group>"; };
+		700F0CD22A2FC0D500755BA7 /* ed448.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ed448.h; path = ../../wolfssl/wolfcrypt/ed448.h; sourceTree = "<group>"; };
+		700F0CD32A2FC0D500755BA7 /* curve448.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = curve448.h; path = ../../wolfssl/wolfcrypt/curve448.h; sourceTree = "<group>"; };
+		700F0CD42A2FC0D500755BA7 /* siphash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = siphash.h; path = ../../wolfssl/wolfcrypt/siphash.h; sourceTree = "<group>"; };
+		700F0CD52A2FC0D500755BA7 /* ext_kyber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ext_kyber.h; path = ../../wolfssl/wolfcrypt/ext_kyber.h; sourceTree = "<group>"; };
+		700F0CD62A2FC0D500755BA7 /* wolfevent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = wolfevent.h; path = ../../wolfssl/wolfcrypt/wolfevent.h; sourceTree = "<group>"; };
+		700F0CD72A2FC0D500755BA7 /* cmac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = cmac.h; path = ../../wolfssl/wolfcrypt/cmac.h; sourceTree = "<group>"; };
+		700F0CD82A2FC0D500755BA7 /* wc_kyber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = wc_kyber.h; path = ../../wolfssl/wolfcrypt/wc_kyber.h; sourceTree = "<group>"; };
+		700F0CD92A2FC0D500755BA7 /* pkcs11.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pkcs11.h; path = ../../wolfssl/wolfcrypt/pkcs11.h; sourceTree = "<group>"; };
+		700F0CDA2A2FC0D500755BA7 /* mem_track.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mem_track.h; path = ../../wolfssl/wolfcrypt/mem_track.h; sourceTree = "<group>"; };
+		700F0CDB2A2FC0D500755BA7 /* eccsi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = eccsi.h; path = ../../wolfssl/wolfcrypt/eccsi.h; sourceTree = "<group>"; };
+		700F0CDC2A2FC0D500755BA7 /* srp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = srp.h; path = ../../wolfssl/wolfcrypt/srp.h; sourceTree = "<group>"; };
+		700F0CDD2A2FC0D500755BA7 /* falcon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = falcon.h; path = ../../wolfssl/wolfcrypt/falcon.h; sourceTree = "<group>"; };
+		700F0CDE2A2FC0D500755BA7 /* fe_448.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fe_448.h; path = ../../wolfssl/wolfcrypt/fe_448.h; sourceTree = "<group>"; };
+		700F0CDF2A2FC0D500755BA7 /* sp_int.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sp_int.h; path = ../../wolfssl/wolfcrypt/sp_int.h; sourceTree = "<group>"; };
+		700F0CE02A2FC0D500755BA7 /* cryptocb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = cryptocb.h; path = ../../wolfssl/wolfcrypt/cryptocb.h; sourceTree = "<group>"; };
+		700F0CE12A2FC0D500755BA7 /* ed25519.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ed25519.h; path = ../../wolfssl/wolfcrypt/ed25519.h; sourceTree = "<group>"; };
+		700F0CE22A2FC0D500755BA7 /* ge_448.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ge_448.h; path = ../../wolfssl/wolfcrypt/ge_448.h; sourceTree = "<group>"; };
+		700F0CE42A2FC0D500755BA7 /* pkcs12.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pkcs12.h; path = ../../wolfssl/wolfcrypt/pkcs12.h; sourceTree = "<group>"; };
+		700F0CE52A2FC0D500755BA7 /* dilithium.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = dilithium.h; path = ../../wolfssl/wolfcrypt/dilithium.h; sourceTree = "<group>"; };
+		700F0CE62A2FC0D500755BA7 /* sakke.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sakke.h; path = ../../wolfssl/wolfcrypt/sakke.h; sourceTree = "<group>"; };
+		700F0CE72A2FC0D500755BA7 /* signature.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = signature.h; path = ../../wolfssl/wolfcrypt/signature.h; sourceTree = "<group>"; };
+		700F0CE82A2FC0D500755BA7 /* wc_pkcs11.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = wc_pkcs11.h; path = ../../wolfssl/wolfcrypt/wc_pkcs11.h; sourceTree = "<group>"; };
+		700F0CEA2A2FC0D500755BA7 /* rc2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rc2.h; path = ../../wolfssl/wolfcrypt/rc2.h; sourceTree = "<group>"; };
+		700F0CEB2A2FC0D500755BA7 /* wolfmath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = wolfmath.h; path = ../../wolfssl/wolfcrypt/wolfmath.h; sourceTree = "<group>"; };
+		700F0CEC2A2FC0D500755BA7 /* sphincs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sphincs.h; path = ../../wolfssl/wolfcrypt/sphincs.h; sourceTree = "<group>"; };
 		9D2E31D6291CE2190082B941 /* dtls13.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = dtls13.c; path = ../../src/dtls13.c; sourceTree = "<group>"; };
 		9D2E31D9291CE2370082B941 /* dtls.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = dtls.c; path = ../../src/dtls.c; sourceTree = "<group>"; };
 		9D2E31DC291CE2740082B941 /* quic.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = quic.c; path = ../../src/quic.c; sourceTree = "<group>"; };
@@ -877,6 +991,43 @@
 		521645F81A89916A0062516A /* wolfCrypt */ = {
 			isa = PBXGroup;
 			children = (
+				700F0CCB2A2FC0D500755BA7 /* async.h */,
+				700F0CC62A2FC0D400755BA7 /* chacha20_poly1305.h */,
+				700F0CD72A2FC0D500755BA7 /* cmac.h */,
+				700F0CCE2A2FC0D500755BA7 /* cpuid.h */,
+				700F0CE02A2FC0D500755BA7 /* cryptocb.h */,
+				700F0CD32A2FC0D500755BA7 /* curve448.h */,
+				700F0CC82A2FC0D500755BA7 /* curve25519.h */,
+				700F0CE52A2FC0D500755BA7 /* dilithium.h */,
+				700F0CDB2A2FC0D500755BA7 /* eccsi.h */,
+				700F0CD22A2FC0D500755BA7 /* ed448.h */,
+				700F0CE12A2FC0D500755BA7 /* ed25519.h */,
+				700F0CD52A2FC0D500755BA7 /* ext_kyber.h */,
+				700F0CDD2A2FC0D500755BA7 /* falcon.h */,
+				700F0CDE2A2FC0D500755BA7 /* fe_448.h */,
+				700F0CC72A2FC0D400755BA7 /* fe_operations.h */,
+				700F0CCF2A2FC0D500755BA7 /* fips.h */,
+				700F0CE22A2FC0D500755BA7 /* ge_448.h */,
+				700F0CCA2A2FC0D500755BA7 /* ge_operations.h */,
+				700F0CCD2A2FC0D500755BA7 /* hpke.h */,
+				700F0CCC2A2FC0D500755BA7 /* kyber.h */,
+				700F0CDA2A2FC0D500755BA7 /* mem_track.h */,
+				700F0CD92A2FC0D500755BA7 /* pkcs11.h */,
+				700F0CE42A2FC0D500755BA7 /* pkcs12.h */,
+				700F0CEA2A2FC0D500755BA7 /* rc2.h */,
+				700F0CE62A2FC0D500755BA7 /* sakke.h */,
+				700F0CC92A2FC0D500755BA7 /* selftest.h */,
+				700F0CD02A2FC0D500755BA7 /* sha3.h */,
+				700F0CE72A2FC0D500755BA7 /* signature.h */,
+				700F0CD42A2FC0D500755BA7 /* siphash.h */,
+				700F0CDF2A2FC0D500755BA7 /* sp_int.h */,
+				700F0CD12A2FC0D500755BA7 /* sp.h */,
+				700F0CEC2A2FC0D500755BA7 /* sphincs.h */,
+				700F0CDC2A2FC0D500755BA7 /* srp.h */,
+				700F0CD82A2FC0D500755BA7 /* wc_kyber.h */,
+				700F0CE82A2FC0D500755BA7 /* wc_pkcs11.h */,
+				700F0CD62A2FC0D500755BA7 /* wolfevent.h */,
+				700F0CEB2A2FC0D500755BA7 /* wolfmath.h */,
 				5216465E1A8993770062516A /* aes.h */,
 				5216465F1A8993770062516A /* arc4.h */,
 				521646601A8993770062516A /* asn_public.h */,
@@ -1059,7 +1210,7 @@
 				52B1344A16F3C9E800C07B32 /* Frameworks */,
 				52B1344B16F3C9E800C07B32 /* CopyFiles */,
 				521646C11A8A7B380062516A /* CopyFiles */,
-				521646C21A8A7B3B0062516A /* CopyFiles */,
+				521646C21A8A7B3B0062516A /* Copy Files */,
 				521646C31A8A7B3D0062516A /* CopyFiles */,
 				52B1344916F3C9E800C07B32 /* Sources */,
 			);

--- a/IDE/XCODE/wolfssl.xcodeproj/project.pbxproj
+++ b/IDE/XCODE/wolfssl.xcodeproj/project.pbxproj
@@ -347,6 +347,102 @@
 		6AC85129272CAF2E00F2B32A /* kdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 6AC85128272CAF2E00F2B32A /* kdf.c */; };
 		6AC8512A272CAF2E00F2B32A /* kdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 6AC85128272CAF2E00F2B32A /* kdf.c */; };
 		6AC8512B272CAF2E00F2B32A /* kdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 6AC85128272CAF2E00F2B32A /* kdf.c */; };
+		700F0C052A2FBC5100755BA7 /* async.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C032A2FBC1600755BA7 /* async.h */; };
+		700F0C062A2FBC5100755BA7 /* chacha20_poly1305.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BED2A2FBC1500755BA7 /* chacha20_poly1305.h */; };
+		700F0C072A2FBC5100755BA7 /* cmac.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BFC2A2FBC1600755BA7 /* cmac.h */; };
+		700F0C082A2FBC5100755BA7 /* cpuid.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BF12A2FBC1600755BA7 /* cpuid.h */; };
+		700F0C092A2FBC5100755BA7 /* cryptocb.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BEE2A2FBC1500755BA7 /* cryptocb.h */; };
+		700F0C0A2A2FBC5100755BA7 /* curve448.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BE32A2FBC1500755BA7 /* curve448.h */; };
+		700F0C0B2A2FBC5100755BA7 /* curve25519.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BE52A2FBC1500755BA7 /* curve25519.h */; };
+		700F0C0C2A2FBC5100755BA7 /* dilithium.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BEF2A2FBC1500755BA7 /* dilithium.h */; };
+		700F0C0D2A2FBC5100755BA7 /* eccsi.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BF72A2FBC1600755BA7 /* eccsi.h */; };
+		700F0C0E2A2FBC5100755BA7 /* ed448.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BF82A2FBC1600755BA7 /* ed448.h */; };
+		700F0C0F2A2FBC5100755BA7 /* ed25519.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BF42A2FBC1600755BA7 /* ed25519.h */; };
+		700F0C102A2FBC5100755BA7 /* ext_kyber.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BF92A2FBC1600755BA7 /* ext_kyber.h */; };
+		700F0C112A2FBC5100755BA7 /* falcon.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C022A2FBC1600755BA7 /* falcon.h */; };
+		700F0C122A2FBC5100755BA7 /* fe_448.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BEB2A2FBC1500755BA7 /* fe_448.h */; };
+		700F0C132A2FBC5100755BA7 /* fe_operations.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BF62A2FBC1600755BA7 /* fe_operations.h */; };
+		700F0C142A2FBC5100755BA7 /* fips.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C002A2FBC1600755BA7 /* fips.h */; };
+		700F0C152A2FBC5100755BA7 /* ge_448.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BE72A2FBC1500755BA7 /* ge_448.h */; };
+		700F0C162A2FBC5100755BA7 /* ge_operations.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C012A2FBC1600755BA7 /* ge_operations.h */; };
+		700F0C172A2FBC5100755BA7 /* hpke.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BE12A2FBC1500755BA7 /* hpke.h */; };
+		700F0C182A2FBC5100755BA7 /* kyber.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BEA2A2FBC1500755BA7 /* kyber.h */; };
+		700F0C192A2FBC5100755BA7 /* pkcs11.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BFD2A2FBC1600755BA7 /* pkcs11.h */; };
+		700F0C1A2A2FBC5100755BA7 /* pkcs12.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BEC2A2FBC1500755BA7 /* pkcs12.h */; };
+		700F0C1B2A2FBC5100755BA7 /* rc2.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BE02A2FBC1500755BA7 /* rc2.h */; };
+		700F0C1C2A2FBC5100755BA7 /* sakke.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BF02A2FBC1500755BA7 /* sakke.h */; };
+		700F0C1D2A2FBC5100755BA7 /* selftest.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BF22A2FBC1600755BA7 /* selftest.h */; };
+		700F0C1E2A2FBC5100755BA7 /* sha3.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BFA2A2FBC1600755BA7 /* sha3.h */; };
+		700F0C1F2A2FBC5100755BA7 /* signature.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BFB2A2FBC1600755BA7 /* signature.h */; };
+		700F0C202A2FBC5100755BA7 /* siphash.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BFE2A2FBC1600755BA7 /* siphash.h */; };
+		700F0C212A2FBC5100755BA7 /* sp_int.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BE82A2FBC1500755BA7 /* sp_int.h */; };
+		700F0C222A2FBC5100755BA7 /* sp.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BE92A2FBC1500755BA7 /* sp.h */; };
+		700F0C232A2FBC5100755BA7 /* sphincs.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BE22A2FBC1500755BA7 /* sphincs.h */; };
+		700F0C242A2FBC5100755BA7 /* srp.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BF32A2FBC1600755BA7 /* srp.h */; };
+		700F0C252A2FBC5100755BA7 /* wc_kyber.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BFF2A2FBC1600755BA7 /* wc_kyber.h */; };
+		700F0C262A2FBC5100755BA7 /* wc_pkcs11.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BF52A2FBC1600755BA7 /* wc_pkcs11.h */; };
+		700F0C272A2FBC5100755BA7 /* wolfevent.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0BE62A2FBC1500755BA7 /* wolfevent.h */; };
+		700F0C282A2FBC5100755BA7 /* kdf.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 6AC8513B272CB04F00F2B32A /* kdf.h */; };
+		700F0C2C2A2FBD1700755BA7 /* quic.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C292A2FBCAD00755BA7 /* quic.h */; };
+		700F0C2D2A2FBD1700755BA7 /* sniffer.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C2B2A2FBCF800755BA7 /* sniffer.h */; };
+		700F0C2E2A2FBD1700755BA7 /* sniffer_error.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C2A2A2FBCAD00755BA7 /* sniffer_error.h */; };
+		700F0C8C2A2FBEF100755BA7 /* aes.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C7C2A2FBE8200755BA7 /* aes.h */; };
+		700F0C8D2A2FBEF100755BA7 /* asn1.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C512A2FBE8000755BA7 /* asn1.h */; };
+		700F0C8E2A2FBEF100755BA7 /* asn1t.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C722A2FBE8100755BA7 /* asn1t.h */; };
+		700F0C8F2A2FBEF100755BA7 /* bio.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C582A2FBE8100755BA7 /* bio.h */; };
+		700F0C902A2FBEF100755BA7 /* bn.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C692A2FBE8100755BA7 /* bn.h */; };
+		700F0C912A2FBEF100755BA7 /* buffer.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C852A2FBE8200755BA7 /* buffer.h */; };
+		700F0C922A2FBEF100755BA7 /* camellia.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C5B2A2FBE8100755BA7 /* camellia.h */; };
+		700F0C932A2FBEF100755BA7 /* cmac.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C632A2FBE8100755BA7 /* cmac.h */; };
+		700F0C942A2FBEF100755BA7 /* cms.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C5E2A2FBE8100755BA7 /* cms.h */; };
+		700F0C952A2FBEF100755BA7 /* compat_types.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C532A2FBE8100755BA7 /* compat_types.h */; };
+		700F0C962A2FBEF100755BA7 /* conf.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C662A2FBE8100755BA7 /* conf.h */; };
+		700F0C972A2FBEF100755BA7 /* crypto.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C862A2FBE8200755BA7 /* crypto.h */; };
+		700F0C982A2FBEF100755BA7 /* des.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C612A2FBE8100755BA7 /* des.h */; };
+		700F0C992A2FBEF100755BA7 /* dh.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C522A2FBE8100755BA7 /* dh.h */; };
+		700F0C9A2A2FBEF100755BA7 /* dsa.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C882A2FBE8200755BA7 /* dsa.h */; };
+		700F0C9B2A2FBEF100755BA7 /* ec.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C6F2A2FBE8100755BA7 /* ec.h */; };
+		700F0C9C2A2FBEF100755BA7 /* ec448.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C672A2FBE8100755BA7 /* ec448.h */; };
+		700F0C9D2A2FBEF100755BA7 /* ec25519.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C602A2FBE8100755BA7 /* ec25519.h */; };
+		700F0C9E2A2FBEF100755BA7 /* ecdh.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C542A2FBE8100755BA7 /* ecdh.h */; };
+		700F0C9F2A2FBEF100755BA7 /* ecdsa.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C812A2FBE8200755BA7 /* ecdsa.h */; };
+		700F0CA02A2FBEF100755BA7 /* ed448.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C642A2FBE8100755BA7 /* ed448.h */; };
+		700F0CA12A2FBEF100755BA7 /* ed25519.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C7E2A2FBE8200755BA7 /* ed25519.h */; };
+		700F0CA22A2FBEF100755BA7 /* engine.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C5D2A2FBE8100755BA7 /* engine.h */; };
+		700F0CA32A2FBEF100755BA7 /* err.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C6A2A2FBE8100755BA7 /* err.h */; };
+		700F0CA42A2FBEF100755BA7 /* evp.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C5F2A2FBE8100755BA7 /* evp.h */; };
+		700F0CA52A2FBEF100755BA7 /* fips_rand.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C7F2A2FBE8200755BA7 /* fips_rand.h */; };
+		700F0CA62A2FBEF100755BA7 /* hmac.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C832A2FBE8200755BA7 /* hmac.h */; };
+		700F0CA82A2FBEF100755BA7 /* kdf.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C6E2A2FBE8100755BA7 /* kdf.h */; };
+		700F0CA92A2FBEF100755BA7 /* lhash.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C652A2FBE8100755BA7 /* lhash.h */; };
+		700F0CAA2A2FBEF100755BA7 /* md4.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C6D2A2FBE8100755BA7 /* md4.h */; };
+		700F0CAB2A2FBEF100755BA7 /* md5.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C702A2FBE8100755BA7 /* md5.h */; };
+		700F0CAC2A2FBEF100755BA7 /* modes.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C772A2FBE8200755BA7 /* modes.h */; };
+		700F0CAD2A2FBEF100755BA7 /* obj_mac.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C802A2FBE8200755BA7 /* obj_mac.h */; };
+		700F0CAE2A2FBEF100755BA7 /* objects.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C572A2FBE8100755BA7 /* objects.h */; };
+		700F0CAF2A2FBEF100755BA7 /* ocsp.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C842A2FBE8200755BA7 /* ocsp.h */; };
+		700F0CB02A2FBEF100755BA7 /* opensslconf.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C732A2FBE8100755BA7 /* opensslconf.h */; };
+		700F0CB12A2FBEF100755BA7 /* opensslv.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C7D2A2FBE8200755BA7 /* opensslv.h */; };
+		700F0CB22A2FBEF100755BA7 /* ossl_typ.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C792A2FBE8200755BA7 /* ossl_typ.h */; };
+		700F0CB32A2FBEF100755BA7 /* pem.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C6C2A2FBE8100755BA7 /* pem.h */; };
+		700F0CB42A2FBEF100755BA7 /* pkcs7.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C742A2FBE8100755BA7 /* pkcs7.h */; };
+		700F0CB52A2FBEF100755BA7 /* pkcs12.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C782A2FBE8200755BA7 /* pkcs12.h */; };
+		700F0CB62A2FBEF100755BA7 /* rand.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C7B2A2FBE8200755BA7 /* rand.h */; };
+		700F0CB72A2FBEF100755BA7 /* rc4.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C562A2FBE8100755BA7 /* rc4.h */; };
+		700F0CB82A2FBEF100755BA7 /* ripemd.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C6B2A2FBE8100755BA7 /* ripemd.h */; };
+		700F0CB92A2FBEF100755BA7 /* rsa.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C8A2A2FBE8200755BA7 /* rsa.h */; };
+		700F0CBA2A2FBEF100755BA7 /* sha.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C5C2A2FBE8100755BA7 /* sha.h */; };
+		700F0CBB2A2FBEF100755BA7 /* sha3.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C712A2FBE8100755BA7 /* sha3.h */; };
+		700F0CBC2A2FBEF100755BA7 /* srp.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C752A2FBE8100755BA7 /* srp.h */; };
+		700F0CBD2A2FBEF100755BA7 /* ssl.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C892A2FBE8200755BA7 /* ssl.h */; };
+		700F0CBE2A2FBEF100755BA7 /* ssl23.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C762A2FBE8100755BA7 /* ssl23.h */; };
+		700F0CBF2A2FBEF100755BA7 /* stack.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C5A2A2FBE8100755BA7 /* stack.h */; };
+		700F0CC02A2FBEF100755BA7 /* tls1.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C822A2FBE8200755BA7 /* tls1.h */; };
+		700F0CC12A2FBEF100755BA7 /* txt_db.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C872A2FBE8200755BA7 /* txt_db.h */; };
+		700F0CC22A2FBEF100755BA7 /* ui.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C552A2FBE8100755BA7 /* ui.h */; };
+		700F0CC32A2FBEF100755BA7 /* x509_vfy.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C7A2A2FBE8200755BA7 /* x509_vfy.h */; };
+		700F0CC42A2FBEF100755BA7 /* x509.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C682A2FBE8100755BA7 /* x509.h */; };
+		700F0CC52A2FBEF100755BA7 /* x509v3.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 700F0C622A2FBE8100755BA7 /* x509v3.h */; };
 		9D01059E291CEA5000A854D3 /* armv8-sha512.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D01058C291CEA4F00A854D3 /* armv8-sha512.c */; };
 		9D01059F291CEA5000A854D3 /* armv8-sha512.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D01058C291CEA4F00A854D3 /* armv8-sha512.c */; };
 		9D0105A0291CEA5000A854D3 /* armv8-sha512.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D01058C291CEA4F00A854D3 /* armv8-sha512.c */; };
@@ -740,6 +836,42 @@
 			dstPath = include/wolfssl/wolfcrypt;
 			dstSubfolderSpec = 7;
 			files = (
+				700F0C052A2FBC5100755BA7 /* async.h in CopyFiles */,
+				700F0C062A2FBC5100755BA7 /* chacha20_poly1305.h in CopyFiles */,
+				700F0C072A2FBC5100755BA7 /* cmac.h in CopyFiles */,
+				700F0C082A2FBC5100755BA7 /* cpuid.h in CopyFiles */,
+				700F0C092A2FBC5100755BA7 /* cryptocb.h in CopyFiles */,
+				700F0C0A2A2FBC5100755BA7 /* curve448.h in CopyFiles */,
+				700F0C0B2A2FBC5100755BA7 /* curve25519.h in CopyFiles */,
+				700F0C0C2A2FBC5100755BA7 /* dilithium.h in CopyFiles */,
+				700F0C0D2A2FBC5100755BA7 /* eccsi.h in CopyFiles */,
+				700F0C0E2A2FBC5100755BA7 /* ed448.h in CopyFiles */,
+				700F0C0F2A2FBC5100755BA7 /* ed25519.h in CopyFiles */,
+				700F0C102A2FBC5100755BA7 /* ext_kyber.h in CopyFiles */,
+				700F0C112A2FBC5100755BA7 /* falcon.h in CopyFiles */,
+				700F0C122A2FBC5100755BA7 /* fe_448.h in CopyFiles */,
+				700F0C132A2FBC5100755BA7 /* fe_operations.h in CopyFiles */,
+				700F0C142A2FBC5100755BA7 /* fips.h in CopyFiles */,
+				700F0C152A2FBC5100755BA7 /* ge_448.h in CopyFiles */,
+				700F0C162A2FBC5100755BA7 /* ge_operations.h in CopyFiles */,
+				700F0C172A2FBC5100755BA7 /* hpke.h in CopyFiles */,
+				700F0C182A2FBC5100755BA7 /* kyber.h in CopyFiles */,
+				700F0C192A2FBC5100755BA7 /* pkcs11.h in CopyFiles */,
+				700F0C1A2A2FBC5100755BA7 /* pkcs12.h in CopyFiles */,
+				700F0C1B2A2FBC5100755BA7 /* rc2.h in CopyFiles */,
+				700F0C1C2A2FBC5100755BA7 /* sakke.h in CopyFiles */,
+				700F0C1D2A2FBC5100755BA7 /* selftest.h in CopyFiles */,
+				700F0C1E2A2FBC5100755BA7 /* sha3.h in CopyFiles */,
+				700F0C1F2A2FBC5100755BA7 /* signature.h in CopyFiles */,
+				700F0C202A2FBC5100755BA7 /* siphash.h in CopyFiles */,
+				700F0C212A2FBC5100755BA7 /* sp_int.h in CopyFiles */,
+				700F0C222A2FBC5100755BA7 /* sp.h in CopyFiles */,
+				700F0C232A2FBC5100755BA7 /* sphincs.h in CopyFiles */,
+				700F0C242A2FBC5100755BA7 /* srp.h in CopyFiles */,
+				700F0C252A2FBC5100755BA7 /* wc_kyber.h in CopyFiles */,
+				700F0C262A2FBC5100755BA7 /* wc_pkcs11.h in CopyFiles */,
+				700F0C272A2FBC5100755BA7 /* wolfevent.h in CopyFiles */,
+				700F0C282A2FBC5100755BA7 /* kdf.h in CopyFiles */,
 				520775BE2239ACFF00087711 /* mem_track.h in CopyFiles */,
 				520775BF2239ACFF00087711 /* wolfmath.h in CopyFiles */,
 				522DBE0F1B7927A50031F454 /* wc_encrypt.h in CopyFiles */,
@@ -863,6 +995,9 @@
 			dstPath = include/wolfssl;
 			dstSubfolderSpec = 7;
 			files = (
+				700F0C2C2A2FBD1700755BA7 /* quic.h in CopyFiles */,
+				700F0C2D2A2FBD1700755BA7 /* sniffer.h in CopyFiles */,
+				700F0C2E2A2FBD1700755BA7 /* sniffer_error.h in CopyFiles */,
 				520775C02239B16C00087711 /* wolfio.h in CopyFiles */,
 				521646C41A8A7FE10062516A /* callbacks.h in CopyFiles */,
 				521646C51A8A7FE10062516A /* certs_test.h in CopyFiles */,
@@ -873,6 +1008,72 @@
 				521646CA1A8A7FE10062516A /* ssl.h in CopyFiles */,
 				521646CB1A8A7FE10062516A /* test.h in CopyFiles */,
 				521646CC1A8A7FE10062516A /* version.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		700F0C8B2A2FBEB400755BA7 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = include/wolfssl/openssl;
+			dstSubfolderSpec = 7;
+			files = (
+				700F0C8C2A2FBEF100755BA7 /* aes.h in CopyFiles */,
+				700F0C8D2A2FBEF100755BA7 /* asn1.h in CopyFiles */,
+				700F0C8E2A2FBEF100755BA7 /* asn1t.h in CopyFiles */,
+				700F0C8F2A2FBEF100755BA7 /* bio.h in CopyFiles */,
+				700F0C902A2FBEF100755BA7 /* bn.h in CopyFiles */,
+				700F0C912A2FBEF100755BA7 /* buffer.h in CopyFiles */,
+				700F0C922A2FBEF100755BA7 /* camellia.h in CopyFiles */,
+				700F0C932A2FBEF100755BA7 /* cmac.h in CopyFiles */,
+				700F0C942A2FBEF100755BA7 /* cms.h in CopyFiles */,
+				700F0C952A2FBEF100755BA7 /* compat_types.h in CopyFiles */,
+				700F0C962A2FBEF100755BA7 /* conf.h in CopyFiles */,
+				700F0C972A2FBEF100755BA7 /* crypto.h in CopyFiles */,
+				700F0C982A2FBEF100755BA7 /* des.h in CopyFiles */,
+				700F0C992A2FBEF100755BA7 /* dh.h in CopyFiles */,
+				700F0C9A2A2FBEF100755BA7 /* dsa.h in CopyFiles */,
+				700F0C9B2A2FBEF100755BA7 /* ec.h in CopyFiles */,
+				700F0C9C2A2FBEF100755BA7 /* ec448.h in CopyFiles */,
+				700F0C9D2A2FBEF100755BA7 /* ec25519.h in CopyFiles */,
+				700F0C9E2A2FBEF100755BA7 /* ecdh.h in CopyFiles */,
+				700F0C9F2A2FBEF100755BA7 /* ecdsa.h in CopyFiles */,
+				700F0CA02A2FBEF100755BA7 /* ed448.h in CopyFiles */,
+				700F0CA12A2FBEF100755BA7 /* ed25519.h in CopyFiles */,
+				700F0CA22A2FBEF100755BA7 /* engine.h in CopyFiles */,
+				700F0CA32A2FBEF100755BA7 /* err.h in CopyFiles */,
+				700F0CA42A2FBEF100755BA7 /* evp.h in CopyFiles */,
+				700F0CA52A2FBEF100755BA7 /* fips_rand.h in CopyFiles */,
+				700F0CA62A2FBEF100755BA7 /* hmac.h in CopyFiles */,
+				700F0CA82A2FBEF100755BA7 /* kdf.h in CopyFiles */,
+				700F0CA92A2FBEF100755BA7 /* lhash.h in CopyFiles */,
+				700F0CAA2A2FBEF100755BA7 /* md4.h in CopyFiles */,
+				700F0CAB2A2FBEF100755BA7 /* md5.h in CopyFiles */,
+				700F0CAC2A2FBEF100755BA7 /* modes.h in CopyFiles */,
+				700F0CAD2A2FBEF100755BA7 /* obj_mac.h in CopyFiles */,
+				700F0CAE2A2FBEF100755BA7 /* objects.h in CopyFiles */,
+				700F0CAF2A2FBEF100755BA7 /* ocsp.h in CopyFiles */,
+				700F0CB02A2FBEF100755BA7 /* opensslconf.h in CopyFiles */,
+				700F0CB12A2FBEF100755BA7 /* opensslv.h in CopyFiles */,
+				700F0CB22A2FBEF100755BA7 /* ossl_typ.h in CopyFiles */,
+				700F0CB32A2FBEF100755BA7 /* pem.h in CopyFiles */,
+				700F0CB42A2FBEF100755BA7 /* pkcs7.h in CopyFiles */,
+				700F0CB52A2FBEF100755BA7 /* pkcs12.h in CopyFiles */,
+				700F0CB62A2FBEF100755BA7 /* rand.h in CopyFiles */,
+				700F0CB72A2FBEF100755BA7 /* rc4.h in CopyFiles */,
+				700F0CB82A2FBEF100755BA7 /* ripemd.h in CopyFiles */,
+				700F0CB92A2FBEF100755BA7 /* rsa.h in CopyFiles */,
+				700F0CBA2A2FBEF100755BA7 /* sha.h in CopyFiles */,
+				700F0CBB2A2FBEF100755BA7 /* sha3.h in CopyFiles */,
+				700F0CBC2A2FBEF100755BA7 /* srp.h in CopyFiles */,
+				700F0CBD2A2FBEF100755BA7 /* ssl.h in CopyFiles */,
+				700F0CBE2A2FBEF100755BA7 /* ssl23.h in CopyFiles */,
+				700F0CBF2A2FBEF100755BA7 /* stack.h in CopyFiles */,
+				700F0CC02A2FBEF100755BA7 /* tls1.h in CopyFiles */,
+				700F0CC12A2FBEF100755BA7 /* txt_db.h in CopyFiles */,
+				700F0CC22A2FBEF100755BA7 /* ui.h in CopyFiles */,
+				700F0CC32A2FBEF100755BA7 /* x509_vfy.h in CopyFiles */,
+				700F0CC42A2FBEF100755BA7 /* x509.h in CopyFiles */,
+				700F0CC52A2FBEF100755BA7 /* x509v3.h in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1186,6 +1387,101 @@
 		52B1344D16F3C9E800C07B32 /* libwolfssl_ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libwolfssl_ios.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		6AC85128272CAF2E00F2B32A /* kdf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = kdf.c; path = ../../wolfcrypt/src/kdf.c; sourceTree = "<group>"; };
 		6AC8513B272CB04F00F2B32A /* kdf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = kdf.h; path = ../../wolfssl/wolfcrypt/kdf.h; sourceTree = "<group>"; };
+		700F0BE02A2FBC1500755BA7 /* rc2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rc2.h; path = ../../wolfssl/wolfcrypt/rc2.h; sourceTree = "<group>"; };
+		700F0BE12A2FBC1500755BA7 /* hpke.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = hpke.h; path = ../../wolfssl/wolfcrypt/hpke.h; sourceTree = "<group>"; };
+		700F0BE22A2FBC1500755BA7 /* sphincs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sphincs.h; path = ../../wolfssl/wolfcrypt/sphincs.h; sourceTree = "<group>"; };
+		700F0BE32A2FBC1500755BA7 /* curve448.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = curve448.h; path = ../../wolfssl/wolfcrypt/curve448.h; sourceTree = "<group>"; };
+		700F0BE52A2FBC1500755BA7 /* curve25519.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = curve25519.h; path = ../../wolfssl/wolfcrypt/curve25519.h; sourceTree = "<group>"; };
+		700F0BE62A2FBC1500755BA7 /* wolfevent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = wolfevent.h; path = ../../wolfssl/wolfcrypt/wolfevent.h; sourceTree = "<group>"; };
+		700F0BE72A2FBC1500755BA7 /* ge_448.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ge_448.h; path = ../../wolfssl/wolfcrypt/ge_448.h; sourceTree = "<group>"; };
+		700F0BE82A2FBC1500755BA7 /* sp_int.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sp_int.h; path = ../../wolfssl/wolfcrypt/sp_int.h; sourceTree = "<group>"; };
+		700F0BE92A2FBC1500755BA7 /* sp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sp.h; path = ../../wolfssl/wolfcrypt/sp.h; sourceTree = "<group>"; };
+		700F0BEA2A2FBC1500755BA7 /* kyber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = kyber.h; path = ../../wolfssl/wolfcrypt/kyber.h; sourceTree = "<group>"; };
+		700F0BEB2A2FBC1500755BA7 /* fe_448.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fe_448.h; path = ../../wolfssl/wolfcrypt/fe_448.h; sourceTree = "<group>"; };
+		700F0BEC2A2FBC1500755BA7 /* pkcs12.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pkcs12.h; path = ../../wolfssl/wolfcrypt/pkcs12.h; sourceTree = "<group>"; };
+		700F0BED2A2FBC1500755BA7 /* chacha20_poly1305.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = chacha20_poly1305.h; path = ../../wolfssl/wolfcrypt/chacha20_poly1305.h; sourceTree = "<group>"; };
+		700F0BEE2A2FBC1500755BA7 /* cryptocb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = cryptocb.h; path = ../../wolfssl/wolfcrypt/cryptocb.h; sourceTree = "<group>"; };
+		700F0BEF2A2FBC1500755BA7 /* dilithium.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = dilithium.h; path = ../../wolfssl/wolfcrypt/dilithium.h; sourceTree = "<group>"; };
+		700F0BF02A2FBC1500755BA7 /* sakke.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sakke.h; path = ../../wolfssl/wolfcrypt/sakke.h; sourceTree = "<group>"; };
+		700F0BF12A2FBC1600755BA7 /* cpuid.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = cpuid.h; path = ../../wolfssl/wolfcrypt/cpuid.h; sourceTree = "<group>"; };
+		700F0BF22A2FBC1600755BA7 /* selftest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = selftest.h; path = ../../wolfssl/wolfcrypt/selftest.h; sourceTree = "<group>"; };
+		700F0BF32A2FBC1600755BA7 /* srp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = srp.h; path = ../../wolfssl/wolfcrypt/srp.h; sourceTree = "<group>"; };
+		700F0BF42A2FBC1600755BA7 /* ed25519.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ed25519.h; path = ../../wolfssl/wolfcrypt/ed25519.h; sourceTree = "<group>"; };
+		700F0BF52A2FBC1600755BA7 /* wc_pkcs11.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = wc_pkcs11.h; path = ../../wolfssl/wolfcrypt/wc_pkcs11.h; sourceTree = "<group>"; };
+		700F0BF62A2FBC1600755BA7 /* fe_operations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fe_operations.h; path = ../../wolfssl/wolfcrypt/fe_operations.h; sourceTree = "<group>"; };
+		700F0BF72A2FBC1600755BA7 /* eccsi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = eccsi.h; path = ../../wolfssl/wolfcrypt/eccsi.h; sourceTree = "<group>"; };
+		700F0BF82A2FBC1600755BA7 /* ed448.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ed448.h; path = ../../wolfssl/wolfcrypt/ed448.h; sourceTree = "<group>"; };
+		700F0BF92A2FBC1600755BA7 /* ext_kyber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ext_kyber.h; path = ../../wolfssl/wolfcrypt/ext_kyber.h; sourceTree = "<group>"; };
+		700F0BFA2A2FBC1600755BA7 /* sha3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sha3.h; path = ../../wolfssl/wolfcrypt/sha3.h; sourceTree = "<group>"; };
+		700F0BFB2A2FBC1600755BA7 /* signature.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = signature.h; path = ../../wolfssl/wolfcrypt/signature.h; sourceTree = "<group>"; };
+		700F0BFC2A2FBC1600755BA7 /* cmac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = cmac.h; path = ../../wolfssl/wolfcrypt/cmac.h; sourceTree = "<group>"; };
+		700F0BFD2A2FBC1600755BA7 /* pkcs11.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pkcs11.h; path = ../../wolfssl/wolfcrypt/pkcs11.h; sourceTree = "<group>"; };
+		700F0BFE2A2FBC1600755BA7 /* siphash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = siphash.h; path = ../../wolfssl/wolfcrypt/siphash.h; sourceTree = "<group>"; };
+		700F0BFF2A2FBC1600755BA7 /* wc_kyber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = wc_kyber.h; path = ../../wolfssl/wolfcrypt/wc_kyber.h; sourceTree = "<group>"; };
+		700F0C002A2FBC1600755BA7 /* fips.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fips.h; path = ../../wolfssl/wolfcrypt/fips.h; sourceTree = "<group>"; };
+		700F0C012A2FBC1600755BA7 /* ge_operations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ge_operations.h; path = ../../wolfssl/wolfcrypt/ge_operations.h; sourceTree = "<group>"; };
+		700F0C022A2FBC1600755BA7 /* falcon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = falcon.h; path = ../../wolfssl/wolfcrypt/falcon.h; sourceTree = "<group>"; };
+		700F0C032A2FBC1600755BA7 /* async.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = async.h; path = ../../wolfssl/wolfcrypt/async.h; sourceTree = "<group>"; };
+		700F0C292A2FBCAD00755BA7 /* quic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = quic.h; path = ../../wolfssl/quic.h; sourceTree = "<group>"; };
+		700F0C2A2A2FBCAD00755BA7 /* sniffer_error.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sniffer_error.h; path = ../../wolfssl/sniffer_error.h; sourceTree = "<group>"; };
+		700F0C2B2A2FBCF800755BA7 /* sniffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sniffer.h; path = ../../wolfssl/sniffer.h; sourceTree = "<group>"; };
+		700F0C512A2FBE8000755BA7 /* asn1.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = asn1.h; path = ../../wolfssl/openssl/asn1.h; sourceTree = "<group>"; };
+		700F0C522A2FBE8100755BA7 /* dh.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = dh.h; path = ../../wolfssl/openssl/dh.h; sourceTree = "<group>"; };
+		700F0C532A2FBE8100755BA7 /* compat_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = compat_types.h; path = ../../wolfssl/openssl/compat_types.h; sourceTree = "<group>"; };
+		700F0C542A2FBE8100755BA7 /* ecdh.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ecdh.h; path = ../../wolfssl/openssl/ecdh.h; sourceTree = "<group>"; };
+		700F0C552A2FBE8100755BA7 /* ui.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ui.h; path = ../../wolfssl/openssl/ui.h; sourceTree = "<group>"; };
+		700F0C562A2FBE8100755BA7 /* rc4.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rc4.h; path = ../../wolfssl/openssl/rc4.h; sourceTree = "<group>"; };
+		700F0C572A2FBE8100755BA7 /* objects.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = objects.h; path = ../../wolfssl/openssl/objects.h; sourceTree = "<group>"; };
+		700F0C582A2FBE8100755BA7 /* bio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bio.h; path = ../../wolfssl/openssl/bio.h; sourceTree = "<group>"; };
+		700F0C5A2A2FBE8100755BA7 /* stack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = stack.h; path = ../../wolfssl/openssl/stack.h; sourceTree = "<group>"; };
+		700F0C5B2A2FBE8100755BA7 /* camellia.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = camellia.h; path = ../../wolfssl/openssl/camellia.h; sourceTree = "<group>"; };
+		700F0C5C2A2FBE8100755BA7 /* sha.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sha.h; path = ../../wolfssl/openssl/sha.h; sourceTree = "<group>"; };
+		700F0C5D2A2FBE8100755BA7 /* engine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = engine.h; path = ../../wolfssl/openssl/engine.h; sourceTree = "<group>"; };
+		700F0C5E2A2FBE8100755BA7 /* cms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = cms.h; path = ../../wolfssl/openssl/cms.h; sourceTree = "<group>"; };
+		700F0C5F2A2FBE8100755BA7 /* evp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = evp.h; path = ../../wolfssl/openssl/evp.h; sourceTree = "<group>"; };
+		700F0C602A2FBE8100755BA7 /* ec25519.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ec25519.h; path = ../../wolfssl/openssl/ec25519.h; sourceTree = "<group>"; };
+		700F0C612A2FBE8100755BA7 /* des.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = des.h; path = ../../wolfssl/openssl/des.h; sourceTree = "<group>"; };
+		700F0C622A2FBE8100755BA7 /* x509v3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = x509v3.h; path = ../../wolfssl/openssl/x509v3.h; sourceTree = "<group>"; };
+		700F0C632A2FBE8100755BA7 /* cmac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = cmac.h; path = ../../wolfssl/openssl/cmac.h; sourceTree = "<group>"; };
+		700F0C642A2FBE8100755BA7 /* ed448.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ed448.h; path = ../../wolfssl/openssl/ed448.h; sourceTree = "<group>"; };
+		700F0C652A2FBE8100755BA7 /* lhash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = lhash.h; path = ../../wolfssl/openssl/lhash.h; sourceTree = "<group>"; };
+		700F0C662A2FBE8100755BA7 /* conf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = conf.h; path = ../../wolfssl/openssl/conf.h; sourceTree = "<group>"; };
+		700F0C672A2FBE8100755BA7 /* ec448.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ec448.h; path = ../../wolfssl/openssl/ec448.h; sourceTree = "<group>"; };
+		700F0C682A2FBE8100755BA7 /* x509.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = x509.h; path = ../../wolfssl/openssl/x509.h; sourceTree = "<group>"; };
+		700F0C692A2FBE8100755BA7 /* bn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bn.h; path = ../../wolfssl/openssl/bn.h; sourceTree = "<group>"; };
+		700F0C6A2A2FBE8100755BA7 /* err.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = err.h; path = ../../wolfssl/openssl/err.h; sourceTree = "<group>"; };
+		700F0C6B2A2FBE8100755BA7 /* ripemd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ripemd.h; path = ../../wolfssl/openssl/ripemd.h; sourceTree = "<group>"; };
+		700F0C6C2A2FBE8100755BA7 /* pem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pem.h; path = ../../wolfssl/openssl/pem.h; sourceTree = "<group>"; };
+		700F0C6D2A2FBE8100755BA7 /* md4.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = md4.h; path = ../../wolfssl/openssl/md4.h; sourceTree = "<group>"; };
+		700F0C6E2A2FBE8100755BA7 /* kdf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = kdf.h; path = ../../wolfssl/openssl/kdf.h; sourceTree = "<group>"; };
+		700F0C6F2A2FBE8100755BA7 /* ec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ec.h; path = ../../wolfssl/openssl/ec.h; sourceTree = "<group>"; };
+		700F0C702A2FBE8100755BA7 /* md5.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = md5.h; path = ../../wolfssl/openssl/md5.h; sourceTree = "<group>"; };
+		700F0C712A2FBE8100755BA7 /* sha3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sha3.h; path = ../../wolfssl/openssl/sha3.h; sourceTree = "<group>"; };
+		700F0C722A2FBE8100755BA7 /* asn1t.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = asn1t.h; path = ../../wolfssl/openssl/asn1t.h; sourceTree = "<group>"; };
+		700F0C732A2FBE8100755BA7 /* opensslconf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = opensslconf.h; path = ../../wolfssl/openssl/opensslconf.h; sourceTree = "<group>"; };
+		700F0C742A2FBE8100755BA7 /* pkcs7.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pkcs7.h; path = ../../wolfssl/openssl/pkcs7.h; sourceTree = "<group>"; };
+		700F0C752A2FBE8100755BA7 /* srp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = srp.h; path = ../../wolfssl/openssl/srp.h; sourceTree = "<group>"; };
+		700F0C762A2FBE8100755BA7 /* ssl23.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ssl23.h; path = ../../wolfssl/openssl/ssl23.h; sourceTree = "<group>"; };
+		700F0C772A2FBE8200755BA7 /* modes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = modes.h; path = ../../wolfssl/openssl/modes.h; sourceTree = "<group>"; };
+		700F0C782A2FBE8200755BA7 /* pkcs12.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pkcs12.h; path = ../../wolfssl/openssl/pkcs12.h; sourceTree = "<group>"; };
+		700F0C792A2FBE8200755BA7 /* ossl_typ.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ossl_typ.h; path = ../../wolfssl/openssl/ossl_typ.h; sourceTree = "<group>"; };
+		700F0C7A2A2FBE8200755BA7 /* x509_vfy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = x509_vfy.h; path = ../../wolfssl/openssl/x509_vfy.h; sourceTree = "<group>"; };
+		700F0C7B2A2FBE8200755BA7 /* rand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rand.h; path = ../../wolfssl/openssl/rand.h; sourceTree = "<group>"; };
+		700F0C7C2A2FBE8200755BA7 /* aes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = aes.h; path = ../../wolfssl/openssl/aes.h; sourceTree = "<group>"; };
+		700F0C7D2A2FBE8200755BA7 /* opensslv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = opensslv.h; path = ../../wolfssl/openssl/opensslv.h; sourceTree = "<group>"; };
+		700F0C7E2A2FBE8200755BA7 /* ed25519.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ed25519.h; path = ../../wolfssl/openssl/ed25519.h; sourceTree = "<group>"; };
+		700F0C7F2A2FBE8200755BA7 /* fips_rand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fips_rand.h; path = ../../wolfssl/openssl/fips_rand.h; sourceTree = "<group>"; };
+		700F0C802A2FBE8200755BA7 /* obj_mac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = obj_mac.h; path = ../../wolfssl/openssl/obj_mac.h; sourceTree = "<group>"; };
+		700F0C812A2FBE8200755BA7 /* ecdsa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ecdsa.h; path = ../../wolfssl/openssl/ecdsa.h; sourceTree = "<group>"; };
+		700F0C822A2FBE8200755BA7 /* tls1.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = tls1.h; path = ../../wolfssl/openssl/tls1.h; sourceTree = "<group>"; };
+		700F0C832A2FBE8200755BA7 /* hmac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = hmac.h; path = ../../wolfssl/openssl/hmac.h; sourceTree = "<group>"; };
+		700F0C842A2FBE8200755BA7 /* ocsp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ocsp.h; path = ../../wolfssl/openssl/ocsp.h; sourceTree = "<group>"; };
+		700F0C852A2FBE8200755BA7 /* buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = buffer.h; path = ../../wolfssl/openssl/buffer.h; sourceTree = "<group>"; };
+		700F0C862A2FBE8200755BA7 /* crypto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = crypto.h; path = ../../wolfssl/openssl/crypto.h; sourceTree = "<group>"; };
+		700F0C872A2FBE8200755BA7 /* txt_db.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = txt_db.h; path = ../../wolfssl/openssl/txt_db.h; sourceTree = "<group>"; };
+		700F0C882A2FBE8200755BA7 /* dsa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = dsa.h; path = ../../wolfssl/openssl/dsa.h; sourceTree = "<group>"; };
+		700F0C892A2FBE8200755BA7 /* ssl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ssl.h; path = ../../wolfssl/openssl/ssl.h; sourceTree = "<group>"; };
+		700F0C8A2A2FBE8200755BA7 /* rsa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rsa.h; path = ../../wolfssl/openssl/rsa.h; sourceTree = "<group>"; };
 		9D01058C291CEA4F00A854D3 /* armv8-sha512.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = "armv8-sha512.c"; path = "../../wolfcrypt/src/port/arm/armv8-sha512.c"; sourceTree = "<group>"; };
 		9D01058F291CEA4F00A854D3 /* armv8-sha512-asm.S */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.asm; name = "armv8-sha512-asm.S"; path = "../../wolfcrypt/src/port/arm/armv8-sha512-asm.S"; sourceTree = "<group>"; };
 		9D010591291CEA4F00A854D3 /* armv8-sha256.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = "armv8-sha256.c"; path = "../../wolfcrypt/src/port/arm/armv8-sha256.c"; sourceTree = "<group>"; };
@@ -1255,6 +1551,7 @@
 				521645F81A89916A0062516A /* wolfCrypt */,
 				521645F71A8991680062516A /* CyaSSL */,
 				521645F61A8991640062516A /* CtaoCrypt */,
+				700F0C502A2FBE3600755BA7 /* OpenSSL */,
 			);
 			name = Headers;
 			sourceTree = SOURCE_ROOT;
@@ -1327,6 +1624,41 @@
 		521645F81A89916A0062516A /* wolfCrypt */ = {
 			isa = PBXGroup;
 			children = (
+				700F0C032A2FBC1600755BA7 /* async.h */,
+				700F0BED2A2FBC1500755BA7 /* chacha20_poly1305.h */,
+				700F0BFC2A2FBC1600755BA7 /* cmac.h */,
+				700F0BF12A2FBC1600755BA7 /* cpuid.h */,
+				700F0BEE2A2FBC1500755BA7 /* cryptocb.h */,
+				700F0BE32A2FBC1500755BA7 /* curve448.h */,
+				700F0BE52A2FBC1500755BA7 /* curve25519.h */,
+				700F0BEF2A2FBC1500755BA7 /* dilithium.h */,
+				700F0BF72A2FBC1600755BA7 /* eccsi.h */,
+				700F0BF82A2FBC1600755BA7 /* ed448.h */,
+				700F0BF42A2FBC1600755BA7 /* ed25519.h */,
+				700F0BF92A2FBC1600755BA7 /* ext_kyber.h */,
+				700F0C022A2FBC1600755BA7 /* falcon.h */,
+				700F0BEB2A2FBC1500755BA7 /* fe_448.h */,
+				700F0BF62A2FBC1600755BA7 /* fe_operations.h */,
+				700F0C002A2FBC1600755BA7 /* fips.h */,
+				700F0BE72A2FBC1500755BA7 /* ge_448.h */,
+				700F0C012A2FBC1600755BA7 /* ge_operations.h */,
+				700F0BE12A2FBC1500755BA7 /* hpke.h */,
+				700F0BEA2A2FBC1500755BA7 /* kyber.h */,
+				700F0BFD2A2FBC1600755BA7 /* pkcs11.h */,
+				700F0BEC2A2FBC1500755BA7 /* pkcs12.h */,
+				700F0BE02A2FBC1500755BA7 /* rc2.h */,
+				700F0BF02A2FBC1500755BA7 /* sakke.h */,
+				700F0BF22A2FBC1600755BA7 /* selftest.h */,
+				700F0BFA2A2FBC1600755BA7 /* sha3.h */,
+				700F0BFB2A2FBC1600755BA7 /* signature.h */,
+				700F0BFE2A2FBC1600755BA7 /* siphash.h */,
+				700F0BE82A2FBC1500755BA7 /* sp_int.h */,
+				700F0BE92A2FBC1500755BA7 /* sp.h */,
+				700F0BE22A2FBC1500755BA7 /* sphincs.h */,
+				700F0BF32A2FBC1600755BA7 /* srp.h */,
+				700F0BFF2A2FBC1600755BA7 /* wc_kyber.h */,
+				700F0BF52A2FBC1600755BA7 /* wc_pkcs11.h */,
+				700F0BE62A2FBC1500755BA7 /* wolfevent.h */,
 				5216465E1A8993770062516A /* aes.h */,
 				5216465F1A8993770062516A /* arc4.h */,
 				521646601A8993770062516A /* asn_public.h */,
@@ -1386,6 +1718,9 @@
 				521646561A8993290062516A /* error-ssl.h */,
 				521646571A8993290062516A /* internal.h */,
 				521646581A8993290062516A /* ocsp.h */,
+				700F0C292A2FBCAD00755BA7 /* quic.h */,
+				700F0C2B2A2FBCF800755BA7 /* sniffer.h */,
+				700F0C2A2A2FBCAD00755BA7 /* sniffer_error.h */,
 				5216465B1A8993290062516A /* ssl.h */,
 				5216465C1A8993290062516A /* test.h */,
 				5216465D1A8993290062516A /* version.h */,
@@ -1526,6 +1861,70 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		700F0C502A2FBE3600755BA7 /* OpenSSL */ = {
+			isa = PBXGroup;
+			children = (
+				700F0C7C2A2FBE8200755BA7 /* aes.h */,
+				700F0C512A2FBE8000755BA7 /* asn1.h */,
+				700F0C722A2FBE8100755BA7 /* asn1t.h */,
+				700F0C582A2FBE8100755BA7 /* bio.h */,
+				700F0C692A2FBE8100755BA7 /* bn.h */,
+				700F0C852A2FBE8200755BA7 /* buffer.h */,
+				700F0C5B2A2FBE8100755BA7 /* camellia.h */,
+				700F0C632A2FBE8100755BA7 /* cmac.h */,
+				700F0C5E2A2FBE8100755BA7 /* cms.h */,
+				700F0C532A2FBE8100755BA7 /* compat_types.h */,
+				700F0C662A2FBE8100755BA7 /* conf.h */,
+				700F0C862A2FBE8200755BA7 /* crypto.h */,
+				700F0C612A2FBE8100755BA7 /* des.h */,
+				700F0C522A2FBE8100755BA7 /* dh.h */,
+				700F0C882A2FBE8200755BA7 /* dsa.h */,
+				700F0C6F2A2FBE8100755BA7 /* ec.h */,
+				700F0C672A2FBE8100755BA7 /* ec448.h */,
+				700F0C602A2FBE8100755BA7 /* ec25519.h */,
+				700F0C542A2FBE8100755BA7 /* ecdh.h */,
+				700F0C812A2FBE8200755BA7 /* ecdsa.h */,
+				700F0C642A2FBE8100755BA7 /* ed448.h */,
+				700F0C7E2A2FBE8200755BA7 /* ed25519.h */,
+				700F0C5D2A2FBE8100755BA7 /* engine.h */,
+				700F0C6A2A2FBE8100755BA7 /* err.h */,
+				700F0C5F2A2FBE8100755BA7 /* evp.h */,
+				700F0C7F2A2FBE8200755BA7 /* fips_rand.h */,
+				700F0C832A2FBE8200755BA7 /* hmac.h */,
+				700F0C6E2A2FBE8100755BA7 /* kdf.h */,
+				700F0C652A2FBE8100755BA7 /* lhash.h */,
+				700F0C6D2A2FBE8100755BA7 /* md4.h */,
+				700F0C702A2FBE8100755BA7 /* md5.h */,
+				700F0C772A2FBE8200755BA7 /* modes.h */,
+				700F0C802A2FBE8200755BA7 /* obj_mac.h */,
+				700F0C572A2FBE8100755BA7 /* objects.h */,
+				700F0C842A2FBE8200755BA7 /* ocsp.h */,
+				700F0C732A2FBE8100755BA7 /* opensslconf.h */,
+				700F0C7D2A2FBE8200755BA7 /* opensslv.h */,
+				700F0C792A2FBE8200755BA7 /* ossl_typ.h */,
+				700F0C6C2A2FBE8100755BA7 /* pem.h */,
+				700F0C742A2FBE8100755BA7 /* pkcs7.h */,
+				700F0C782A2FBE8200755BA7 /* pkcs12.h */,
+				700F0C7B2A2FBE8200755BA7 /* rand.h */,
+				700F0C562A2FBE8100755BA7 /* rc4.h */,
+				700F0C6B2A2FBE8100755BA7 /* ripemd.h */,
+				700F0C8A2A2FBE8200755BA7 /* rsa.h */,
+				700F0C5C2A2FBE8100755BA7 /* sha.h */,
+				700F0C712A2FBE8100755BA7 /* sha3.h */,
+				700F0C752A2FBE8100755BA7 /* srp.h */,
+				700F0C892A2FBE8200755BA7 /* ssl.h */,
+				700F0C762A2FBE8100755BA7 /* ssl23.h */,
+				700F0C5A2A2FBE8100755BA7 /* stack.h */,
+				700F0C822A2FBE8200755BA7 /* tls1.h */,
+				700F0C872A2FBE8200755BA7 /* txt_db.h */,
+				700F0C552A2FBE8100755BA7 /* ui.h */,
+				700F0C7A2A2FBE8200755BA7 /* x509_vfy.h */,
+				700F0C682A2FBE8100755BA7 /* x509.h */,
+				700F0C622A2FBE8100755BA7 /* x509v3.h */,
+			);
+			name = OpenSSL;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -1558,6 +1957,7 @@
 				521646C11A8A7B380062516A /* CopyFiles */,
 				521646C21A8A7B3B0062516A /* CopyFiles */,
 				521646C31A8A7B3D0062516A /* CopyFiles */,
+				700F0C8B2A2FBEB400755BA7 /* CopyFiles */,
 				52B1344916F3C9E800C07B32 /* Sources */,
 			);
 			buildRules = (


### PR DESCRIPTION
# Description

Fix for https://github.com/wolfSSL/wolfssl/issues/6479. Add in some missing headers from wolfssl/wolfcrypt/ to library include directory. Also add in headers from wolfssl/openssl/

# Testing
Build the XCODE project and check the `build/include/` directory. Previously missing headers should now be present

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
