### PR TITLE
Regression testing fixes

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4097,7 +4097,7 @@ int wolfSSL_Rehandshake(WOLFSSL* ssl)
     else {
         /* Reset resuming flag to do full secure handshake. */
         ssl->options.resuming = 0;
-        #ifdef HAVE_SESSION_TICKET
+        #if defined(HAVE_SESSION_TICKET) && !defined(NO_WOLFSSL_CLIENT)
             /* Clearing the ticket. */
             ret = wolfSSL_UseSessionTicket(ssl);
         #endif

--- a/tests/api.c
+++ b/tests/api.c
@@ -46323,7 +46323,7 @@ static int test_wolfSSL_ticket_keys(void)
     WOLFSSL_CTX* ctx;
     byte keys[WOLFSSL_TICKET_KEYS_SZ];
 
-    AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()));
+    AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_server_method()));
 
     AssertIntEQ(wolfSSL_CTX_get_tlsext_ticket_keys(NULL, NULL, 0),
                 WOLFSSL_FAILURE);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -579,7 +579,8 @@ WOLFSSL_TEST_SUBROUTINE int decodedCertCache_test(void);
 #endif
 WOLFSSL_TEST_SUBROUTINE int memory_test(void);
 #if defined(WOLFSSL_PUBLIC_MP) && \
-    (defined(WOLFSSL_SP_MATH_ALL) || defined(USE_FAST_MATH))
+    ((defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
+     defined(USE_FAST_MATH))
 WOLFSSL_TEST_SUBROUTINE int mp_test(void);
 #endif
 #if defined(WOLFSSL_PUBLIC_MP) && defined(WOLFSSL_KEY_GEN)
@@ -1587,7 +1588,8 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 #endif
 
 #if defined(WOLFSSL_PUBLIC_MP) && \
-    (defined(WOLFSSL_SP_MATH_ALL) || defined(USE_FAST_MATH))
+    ((defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
+     defined(USE_FAST_MATH))
     if ( (ret = mp_test()) != 0)
         TEST_FAIL("mp       test failed!\n", ret);
     else
@@ -13949,12 +13951,15 @@ static void initDefaultName(void)
     WOLFSSL_SMALL_STACK_STATIC const char certKeyUsage[] =
         "digitalSignature,nonRepudiation";
     #endif
-    #if defined(WOLFSSL_CERT_REQ) && !defined(NO_RSA)
+    #if !defined(NO_RSA) && defined(WOLFSSL_CERT_GEN) && \
+        !defined(NO_ASN_TIME) && defined(WOLFSSL_CERT_REQ) && \
+        !defined(WOLFSSL_NO_MALLOC)
         WOLFSSL_SMALL_STACK_STATIC const char certKeyUsage2[] =
         "digitalSignature,nonRepudiation,keyEncipherment,keyAgreement";
     #endif
 #endif /* WOLFSSL_CERT_EXT */
-#endif /* WOLFSSL_CERT_GEN */
+#endif /* WOLFSSL_CERT_GEN && (!NO_RSA || HAVE_ECC) || (WOLFSSL_TEST_CERT &&
+        * (HAVE_ED25519 || HAVE_ED448)) */
 
 #ifndef NO_RSA
 
@@ -40383,7 +40388,8 @@ WOLFSSL_TEST_SUBROUTINE int pkcs7signed_test(void)
 #endif /* HAVE_PKCS7 */
 
 #if defined(WOLFSSL_PUBLIC_MP) && \
-    (defined(WOLFSSL_SP_MATH_ALL) || defined(USE_FAST_MATH))
+    ((defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
+     defined(USE_FAST_MATH))
 
 /* Maximum number of bytes in a number to test. */
 #define MP_MAX_TEST_BYTE_LEN      32
@@ -43315,7 +43321,8 @@ done:
     return ret;
 }
 
-#endif /* WOLFSSL_PUBLIC_MP && (WOLFSSL_SP_MATH_ALL || USE_FAST_MATH) */
+#endif /* WOLFSSL_PUBLIC_MP && ((WOLFSSL_SP_MATH_ALL &&
+        * !WOLFSSL_RSA_VERIFY_ONLY) || USE_FAST_MATH) */
 
 
 #if defined(WOLFSSL_PUBLIC_MP) && defined(WOLFSSL_KEY_GEN)


### PR DESCRIPTION
# Description

Fix: ./configure --disable-shared  --enable-smallstack --enable-all CFLAGS=-DNO_ASN_TIME

Don't compile mp_test when compiling for SP Math All and RSA verification only - very few functions available.

ssl.c:
wolfSSL_Rehandshake(): wolfSSL_UseSessionTicket only available when not NO_WOLFSSL_CLIENT
api.c:
  test_wolfSSL_ticket_keys(): meant to be tested on server

# Testing

./configure --disable-shared  --enable-smallstack --enable-all CFLAGS=-DNO_ASN_TIME
./configure --disable-shared --disable-asn --disable-filesystem --enable-cryptonly --disable-dh --disable-sha224 --disable-ecc CFLAGS=-DWOLFSSL_PUBLIC_MP --enable-rsavfy --enable-sp=small2048 --disable-sp-asm  --enable-sp-math-all
/configure --disable-shared  --enable-opensslextra CFLAGS=-DNO_WOLFSSL_CLIENT --enable-session-ticket


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
