### PR TITLE
cppcheck: fixes from scan

### DIFF
--- a/IDE/MCUEXPRESSO/wolfcrypt_test.c
+++ b/IDE/MCUEXPRESSO/wolfcrypt_test.c
@@ -78,8 +78,6 @@ static void setup()
 #include "fsl_snvs_hp.h"
 static void setup()
 {
-    uint32_t sec;
-    uint8_t index;
     snvs_hp_rtc_datetime_t rtcDate;
     snvs_hp_rtc_config_t snvsRtcConfig;
 

--- a/IDE/Renesas/e2studio/RA6M4/test/src/test_main.c
+++ b/IDE/Renesas/e2studio/RA6M4/test/src/test_main.c
@@ -165,7 +165,6 @@ void sce_test(void)
         (defined(WOLFSSL_RENESAS_SCEPROTECT) || \
         defined(WOLFSSL_RENESAS_SCEPROTECT_CRYPTONLY))
     int ret = 0;
-    BaseType_t xRet;
 
     if ((ret = wolfCrypt_Init()) != 0) {
         printf("wolfCrypt_Init failed %d\n", ret);

--- a/IDE/Renesas/e2studio/RA6M4/test/src/wolfssl_sce_unit_test.c
+++ b/IDE/Renesas/e2studio/RA6M4/test/src/wolfssl_sce_unit_test.c
@@ -1270,7 +1270,6 @@ int sce_crypt_Sha_AesCbcGcm_multitest()
     
     if ((xRet == pdPASS) && 
         (Aes128_Gcm_multTst_rslt == 0 && Aes256_Gcm_multTst_rslt == 0) &&
-        (Aes128_Gcm_multTst_rslt == 0 && Aes256_Gcm_multTst_rslt == 0) &&
         (sha256_multTst_rslt1 == 0 && sha256_multTst_rslt2 == 0)) {
         
         ret = 0;

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_demo.c
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_demo.c
@@ -494,7 +494,9 @@ static void Tls_client(void *pvParam)
         }
     }
     
+#if defined(TLS_MULTITHREAD_TEST)
 out:
+#endif
     if (ssl) {
         wolfSSL_shutdown(ssl);
         wolfSSL_free(ssl);

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_tsip_unit_test.c
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_tsip_unit_test.c
@@ -361,15 +361,11 @@ static int tsip_aesgcm256_test(int prnt, tsip_aes_key_index_t* aes256_key)
         0xcd, 0xdf, 0x88, 0x53, 0xbb, 0x2d, 0x55, 0x1b
     };
 
-    int ivlen;
-
     byte resultT[sizeof(t1)];
     byte resultP[sizeof(p) + AES_BLOCK_SIZE];
     byte resultC[sizeof(p) + AES_BLOCK_SIZE];
     int  result = 0;
     int  ret;
-    int  alen;
-    int  plen;
 
     (void) result;
 
@@ -950,8 +946,6 @@ int tsip_crypt_Sha_AesCbcGcm_multitest()
     int ret = 0;
     int num = 0;
     int i;
-    Info info_aes128cbc;
-    Info info_aes128gcm;
     Info info_aes256cbc;
     Info info_aes256gcm;
     BaseType_t xRet;

--- a/IDE/iotsafe/devices.c
+++ b/IDE/iotsafe/devices.c
@@ -150,7 +150,6 @@ int usart_rx(uint32_t dev, uint8_t *c)
 
 int usart_init(uint32_t dev, uint32_t bitrate, uint8_t data, char parity, uint8_t stop)
 {
-    uint32_t reg;
     int rtscts = 0;
 
     if (dev == USART1_BASE) {
@@ -219,7 +218,6 @@ int usart_init(uint32_t dev, uint32_t bitrate, uint8_t data, char parity, uint8_
 int _write(void *r, uint8_t *text, int len)
 {
     char *p = (char *)text;
-    int i;
     (void)r;
     while(*p && (p < (char *)(text + len))) {
         usart_tx(USART2_BASE, *p);

--- a/src/bio.c
+++ b/src/bio.c
@@ -1790,9 +1790,7 @@ WOLFSSL_BIO_METHOD *wolfSSL_BIO_meth_new(int type, const char *name)
 void wolfSSL_BIO_meth_free(WOLFSSL_BIO_METHOD *biom)
 {
     WOLFSSL_ENTER("wolfSSL_BIO_meth_free");
-    if (biom) {
-        XFREE(biom, NULL, DYNAMIC_TYPE_OPENSSL);
-    }
+    XFREE(biom, NULL, DYNAMIC_TYPE_OPENSSL);
 }
 
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -1110,9 +1110,8 @@ void wolfSSL_CONF_CTX_free(WOLFSSL_CONF_CTX* cctx)
 {
     WOLFSSL_ENTER("wolfSSL_CONF_CTX_free");
 
-    if (cctx) {
-        XFREE(cctx, NULL, DYNAMIC_TYPE_OPENSSL);
-    }
+    XFREE(cctx, NULL, DYNAMIC_TYPE_OPENSSL);
+
     WOLFSSL_LEAVE("wolfSSL_CONF_CTX_free", 1);
 }
 /**

--- a/src/internal.c
+++ b/src/internal.c
@@ -18784,10 +18784,10 @@ static void LogAlert(int type)
 {
 #ifdef DEBUG_WOLFSSL
     const char* typeStr;
-    char buff[60];
 
     typeStr = AlertTypeToString(type);
     if (typeStr != NULL) {
+        char buff[60];
         XSNPRINTF(buff, sizeof(buff), "Alert type: %s", typeStr);
         WOLFSSL_MSG(buff);
     }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -12637,17 +12637,19 @@ static int CheckcipherList(const char* list)
             /* list has mixed suites */
             return 0;
         }
-    }  while (next++); /* ++ needed to skip ':' */
+    }
+    while (next++); /* ++ needed to skip ':' */
 
     if (findTLSv13Suites == 0 && findbeforeSuites == 1) {
-        return 1;/* only before TLSv13 suites */
+        ret = 1;/* only before TLSv13 suites */
     }
     else if (findTLSv13Suites == 1 && findbeforeSuites == 0) {
-        return 2;/* only TLSv13 suties */
+        ret = 2;/* only TLSv13 suties */
     }
     else {
-        return 0;/* handle as mixed */
+        ret = 0;/* handle as mixed */
     }
+    return ret;
 }
 
 /* parse some bulk lists like !eNULL / !aNULL
@@ -35818,7 +35820,6 @@ const char* wolfSSL_RAND_file_name(char* fname, unsigned long len)
 {
 #ifndef NO_FILESYSTEM
     char* rt;
-    char ap[] = "/.rnd";
 
     WOLFSSL_ENTER("wolfSSL_RAND_file_name");
 
@@ -35840,6 +35841,8 @@ const char* wolfSSL_RAND_file_name(char* fname, unsigned long len)
 
     /* $RANDFILE was not set or is too large, check $HOME */
     if (rt == NULL) {
+        char ap[] = "/.rnd";
+
         WOLFSSL_MSG("Environment variable RANDFILE not set");
         if ((rt = XGETENV("HOME")) == NULL) {
             WOLFSSL_MSG("Environment variable HOME not set");

--- a/src/x509.c
+++ b/src/x509.c
@@ -309,9 +309,6 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_EXTENSION_create_by_OBJ(
 
     if (err == 0) {
         ret->crit = crit;
-    }
-
-    if (err == 0) {
         ret->obj = wolfSSL_ASN1_OBJECT_dup(obj);
         if (ret->obj == NULL) {
             err = 1;
@@ -3278,14 +3275,9 @@ unsigned long wolfSSL_X509_issuer_name_hash(const WOLFSSL_X509* x509)
  */
 char* wolfSSL_X509_get_name_oneline(WOLFSSL_X509_NAME* name, char* in, int sz)
 {
-    WOLFSSL_X509_NAME_ENTRY* entry;
-    int nameSz, strSz, strLen, count, i;
+    int count, i;
     int totalLen = 0;
-    char *str;
     char tmpBuf[256];
-    const int tmpBufSz = sizeof(tmpBuf);
-    char buf[80];
-    const char* sn;
     WOLFSSL_ENTER("wolfSSL_X509_get_name_oneline");
 
     if (name == NULL) {
@@ -3302,6 +3294,14 @@ char* wolfSSL_X509_get_name_oneline(WOLFSSL_X509_NAME* name, char* in, int sz)
     /* Loop through X509 name entries and copy new format to buffer */
     count = wolfSSL_X509_NAME_entry_count(name);
     for (i = 0; i < count; i++) {
+        WOLFSSL_X509_NAME_ENTRY* entry;
+        int nameSz;
+        int strSz;
+        int strLen;
+        char *str;
+        const int tmpBufSz = sizeof(tmpBuf);
+        char buf[80];
+        const char* sn;
 
         /* Get name entry and size */
         entry = wolfSSL_X509_NAME_get_entry(name, i);
@@ -3582,7 +3582,6 @@ int wolfSSL_X509_get_pubkey_buffer(WOLFSSL_X509* x509,
 #else
     DecodedCert cert[1];
 #endif
-    word32 idx;
     const byte*  der;
     int length = 0;
     int    ret = 0, derSz = 0;
@@ -3611,7 +3610,7 @@ int wolfSSL_X509_get_pubkey_buffer(WOLFSSL_X509* x509,
         InitDecodedCert(cert, der, derSz, NULL);
         ret = wc_GetPubX509(cert, 0, &badDate);
         if (ret >= 0) {
-            idx = cert->srcIdx;
+            word32 idx = cert->srcIdx;
             pubKeyX509 = cert->source + cert->srcIdx;
             ret = GetSequence(cert->source, &cert->srcIdx, &length,
                     cert->maxIdx);
@@ -5599,7 +5598,6 @@ static int X509PrintSubjAltName(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
         int indent)
 {
     int ret = WOLFSSL_SUCCESS;
-    int nameCount = 0;
     DNS_entry* entry;
 
     if (bio == NULL || x509 == NULL) {
@@ -5620,6 +5618,8 @@ static int X509PrintSubjAltName(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
             }
         }
         if (ret == WOLFSSL_SUCCESS) {
+            int nameCount = 0;
+
             entry = x509->altNames;
             while (entry != NULL) {
                 ++nameCount;
@@ -5708,8 +5708,6 @@ static int X509PrintSubjAltName(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
 static int X509PrintKeyUsage(WOLFSSL_BIO* bio, WOLFSSL_X509* x509, int indent)
 {
     int ret = WOLFSSL_SUCCESS;
-    word32 i = 0;
-    int usageCount = 0;
     const int usages[] = {
         KEYUSE_DIGITAL_SIG,
         KEYUSE_CONTENT_COMMIT,
@@ -5740,6 +5738,8 @@ static int X509PrintKeyUsage(WOLFSSL_BIO* bio, WOLFSSL_X509* x509, int indent)
     if (ret == WOLFSSL_SUCCESS && x509->keyUsageSet && x509->keyUsage != 0) {
         char scratch[MAX_WIDTH];
         int len;
+        word32 i = 0;
+        int usageCount = 0;
 
         len = XSNPRINTF(scratch, MAX_WIDTH, "%*s", indent, "");
         if (len >= MAX_WIDTH)
@@ -5776,8 +5776,6 @@ static int X509PrintExtendedKeyUsage(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
         int indent)
 {
     int ret = WOLFSSL_SUCCESS;
-    word32 i = 0;
-    int usageCount = 0;
     const int usages[] = {
         EXTKEYUSE_OCSP_SIGN,
         EXTKEYUSE_TIMESTAMP,
@@ -5803,6 +5801,8 @@ static int X509PrintExtendedKeyUsage(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
             && x509->extKeyUsage != 0) {
         char scratch[MAX_WIDTH];
         int len;
+        word32 i = 0;
+        int usageCount = 0;
 
         len = XSNPRINTF(scratch, MAX_WIDTH, "%*s", indent, "");
         if (len >= MAX_WIDTH)
@@ -5857,7 +5857,6 @@ static int X509PrintSerial_ex(WOLFSSL_BIO* bio, byte* serial, int sz,
 
     if (sz > (int)sizeof(byte)) {
         int i;
-        int valLen;
 
         /* serial is larger than int size so print off hex values */
         if ((scratchLen = XSNPRINTF(
@@ -5867,6 +5866,8 @@ static int X509PrintSerial_ex(WOLFSSL_BIO* bio, byte* serial, int sz,
             return WOLFSSL_FAILURE;
         }
         for (i = 0; i < sz; i++) {
+            int valLen;
+
             if ((valLen = XSNPRINTF(
                      scratch + scratchLen, scratchSz - scratchLen,
                      "%02x%s", serial[i], (i < sz - 1) ?
@@ -6158,7 +6159,6 @@ static int X509PrintSignature_ex(WOLFSSL_BIO* bio, byte* sig,
     int scratchLen;
     WOLFSSL_ASN1_OBJECT* obj = NULL;
     int ret = WOLFSSL_SUCCESS;
-    int i;
     char tmp[100];
     int tmpLen = 0;
 
@@ -6219,6 +6219,8 @@ static int X509PrintSignature_ex(WOLFSSL_BIO* bio, byte* sig,
     }
 
     if (ret == WOLFSSL_SUCCESS) {
+        int i;
+
         for (i = 0; i < sigSz; i++) {
             char val[6];
             int valLen;
@@ -6394,9 +6396,10 @@ static int X509PrintPubKey(WOLFSSL_BIO* bio, WOLFSSL_X509* x509, int indent)
 static int X509PrintName(WOLFSSL_BIO* bio, WOLFSSL_X509_NAME* name,
         char* type, int indent)
 {
-    char scratch[MAX_WIDTH];
-    int scratchLen;
     if (name != NULL) {
+        char scratch[MAX_WIDTH];
+        int scratchLen;
+
         if ((scratchLen = XSNPRINTF(scratch, MAX_WIDTH,
                                      "%*s%s", indent, "", type))
             >= MAX_WIDTH)

--- a/tests/api.c
+++ b/tests/api.c
@@ -5501,13 +5501,6 @@ static WC_INLINE int test_ssl_memio_setup(test_ssl_memio_ctx *ctx)
     {
         ExpectIntEQ(wolfSSL_use_certificate_file(ctx->s_ssl, certFile,
             WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
-    }
-    if (0
-#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_EITHER_SIDE)
-     || s_sharedCtx
-#endif
-        )
-    {
         ExpectIntEQ(wolfSSL_use_PrivateKey_file(ctx->s_ssl, keyFile,
             WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
     }
@@ -26224,7 +26217,7 @@ static int test_wc_ecc_signVerify_hash(void)
         if (signH == ECC_BAD_ARG_E) {
             signH = 0;
         }
-        else if (ret == 0) {
+        else {
             signH = WOLFSSL_FATAL_ERROR;
         }
     }
@@ -26267,7 +26260,7 @@ static int test_wc_ecc_signVerify_hash(void)
         if (verifyH == ECC_BAD_ARG_E) {
             verifyH = 0;
         }
-        else if (ret == 0) {
+        else {
             verifyH = WOLFSSL_FATAL_ERROR;
         }
     }

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -4014,7 +4014,6 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
 #elif defined(FREESCALE_MMCAU)
     int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     {
-        int i;
         int offset = 0;
         byte *iv;
         byte temp_block[AES_BLOCK_SIZE];
@@ -4052,7 +4051,6 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
     #ifdef HAVE_AES_DECRYPT
     int wc_AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     {
-        int i;
         int offset = 0;
         byte* iv;
         byte temp_block[AES_BLOCK_SIZE];

--- a/wolfcrypt/src/des3.c
+++ b/wolfcrypt/src/des3.c
@@ -920,7 +920,6 @@
 
     int wc_Des_CbcEncrypt(Des* des, byte* out, const byte* in, word32 sz)
     {
-        int i;
         int offset = 0;
         int len = sz;
         int ret = 0;
@@ -966,7 +965,6 @@
 
     int wc_Des_CbcDecrypt(Des* des, byte* out, const byte* in, word32 sz)
     {
-        int i;
         int offset = 0;
         int len = sz;
         int ret = 0;
@@ -1013,7 +1011,6 @@
 
     int wc_Des3_CbcEncrypt(Des3* des, byte* out, const byte* in, word32 sz)
     {
-        int i;
         int offset = 0;
         int len = sz;
         int ret = 0;
@@ -1064,7 +1061,6 @@
 
     int wc_Des3_CbcDecrypt(Des3* des, byte* out, const byte* in, word32 sz)
     {
-        int i;
         int offset = 0;
         int len = sz;
         int ret = 0;

--- a/wolfcrypt/src/fe_448.c
+++ b/wolfcrypt/src/fe_448.c
@@ -358,14 +358,13 @@ int curve448(byte* r, const byte* n, const byte* a)
     word8 t1[56];
     int i;
     unsigned int swap;
-    unsigned int b;
 
     fe448_copy(x1, a);
     fe448_copy(x3, a);
 
     swap = 0;
     for (i = 447; i >= 0; --i) {
-        b = (n[i >> 3] >> (i & 7)) & 1;
+        unsigned int b = (n[i >> 3] >> (i & 7)) & 1;
         swap ^= b;
         fe448_cswap(x2, x3, swap);
         fe448_cswap(z2, z3, swap);
@@ -1077,7 +1076,6 @@ int curve448(byte* r, const byte* n, const byte* a)
     sword64 t1[8];
     int i;
     unsigned int swap;
-    unsigned int b;
 
     fe448_from_bytes(x1, a);
     fe448_1(x2);
@@ -1087,7 +1085,7 @@ int curve448(byte* r, const byte* n, const byte* a)
 
     swap = 0;
     for (i = 447; i >= 0; --i) {
-        b = (n[i >> 3] >> (i & 7)) & 1;
+        unsigned int b = (n[i >> 3] >> (i & 7)) & 1;
         swap ^= b;
         fe448_cswap(x2, x3, swap);
         fe448_cswap(z2, z3, swap);
@@ -2169,7 +2167,6 @@ int curve448(byte* r, const byte* n, const byte* a)
     sword32 t1[16];
     int i;
     unsigned int swap;
-    unsigned int b;
 
     fe448_from_bytes(x1, a);
     fe448_1(x2);
@@ -2179,7 +2176,7 @@ int curve448(byte* r, const byte* n, const byte* a)
 
     swap = 0;
     for (i = 447; i >= 0; --i) {
-        b = (n[i >> 3] >> (i & 7)) & 1;
+        unsigned int b = (n[i >> 3] >> (i & 7)) & 1;
         swap ^= b;
         fe448_cswap(x2, x3, swap);
         fe448_cswap(z2, z3, swap);

--- a/wolfcrypt/src/fe_operations.c
+++ b/wolfcrypt/src/fe_operations.c
@@ -142,7 +142,6 @@ int curve25519(byte* q, const byte* n, const byte* p)
   fe tmp1 = {0};
   int pos = 0;
   unsigned int swap = 0;
-  unsigned int b = 0;
 
   /* Clamp already done during key generation and import */
 #if 0
@@ -163,6 +162,7 @@ int curve25519(byte* q, const byte* n, const byte* p)
 
   swap = 0;
   for (pos = 254;pos >= 0;--pos) {
+    unsigned int b;
 #if 0
     b = e[pos / 8] >> (pos & 7);
 #else

--- a/wolfcrypt/src/ge_low_mem.c
+++ b/wolfcrypt/src/ge_low_mem.c
@@ -133,7 +133,6 @@ static void barrett_reduce(word32* r, word32 x[64])
   word32 r2[33];
   word32 carry;
   word32 pb = 0;
-  word32 b;
 
   for (i = 0;i < 66;++i) q2[i] = 0;
   for (i = 0;i < 33;++i) r2[i] = 0;
@@ -160,6 +159,7 @@ static void barrett_reduce(word32* r, word32 x[64])
 
   for(i=0;i<32;i++)
   {
+    word32 b;
     pb += r2[i];
     b = lt(r1[i],pb);
     r[i] = r1[i]-pb+(b<<8);

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -299,7 +299,7 @@ int wc_HmacSetKey(Hmac* hmac, int type, const byte* key, word32 length)
 #ifndef WOLFSSL_MAXQ108X
     byte*  ip;
     byte*  op;
-    word32 i, hmac_block_size = 0;
+    word32 hmac_block_size = 0;
 #endif
     int    ret = 0;
     void*  heap = NULL;
@@ -582,6 +582,8 @@ int wc_HmacSetKey(Hmac* hmac, int type, const byte* key, word32 length)
 #endif
 
     if (ret == 0) {
+        word32 i;
+
         if (length < hmac_block_size)
             XMEMSET(ip + length, 0, hmac_block_size - length);
 

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -73,8 +73,6 @@ int wc_PRF(byte* result, word32 resLen, const byte* secret,
     word32 times;
     word32 lastLen;
     word32 lastTime;
-    word32 i;
-    word32 idx = 0;
     int    ret = 0;
 #ifdef WOLFSSL_SMALL_STACK
     byte*  previous;
@@ -164,6 +162,9 @@ int wc_PRF(byte* result, word32 resLen, const byte* secret,
         if (ret == 0)
             ret = wc_HmacFinal(hmac, previous);       /* A1 */
         if (ret == 0) {
+            word32 i;
+            word32 idx = 0;
+
             for (i = 0; i < times; i++) {
                 ret = wc_HmacUpdate(hmac, previous, len);
                 if (ret != 0)

--- a/wolfcrypt/src/port/kcapi/kcapi_hash.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_hash.c
@@ -167,9 +167,9 @@ static int KcapiHashFinal(wolfssl_KCAPI_Hash* hash, byte* out, word32 outSz,
         ret = (int)kcapi_md_update(hash->handle, hash->msg, hash->used);
         XFREE(hash->msg, heap, DYNAMIC_TYPE_TMP_BUFFER);
         hash->msg = NULL;
+        if (ret == 0)
     #endif
-
-        if (ret == 0) {
+        {
             ret = (int)kcapi_md_final(hash->handle, out, outSz);
         }
 

--- a/wolfcrypt/src/port/kcapi/kcapi_rsa.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_rsa.c
@@ -136,7 +136,7 @@ static int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen)
 {
     word32 seqSz, verSz, rawLen, intTotalLen = 0;
     word32 sizes[RSA_INTS];
-    int    i, j, outLen, ret = 0, mpSz;
+    int    i, j, outLen, ret = 0;
 
     byte  seq[MAX_SEQ_SZ];
     byte  ver[MAX_VERSION_SZ];
@@ -153,6 +153,7 @@ static int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen)
 
     /* write all big ints from key to DER tmps */
     for (i = 0; i < RSA_INTS; i++) {
+        int mpSz;
         mp_int* keyInt = GetRsaInt(key, i);
 
         rawLen = mp_unsigned_bin_size(keyInt) + 1;
@@ -249,7 +250,7 @@ int KcapiRsa_Decrypt(RsaKey* key, const byte* in, word32 inLen, byte* out,
         if (ret != 0) {
             WOLFSSL_MSG("KcapiRsa_Decrypt: Failed initialization");
         }
-        if (ret != 0) {
+        else {
             ret = KcapiRsa_SetPrivKey(key);
         }
     }
@@ -340,7 +341,7 @@ int KcapiRsa_Encrypt(RsaKey* key, const byte* in, word32 inLen, byte* out,
         if (ret != 0) {
             WOLFSSL_MSG("KcapiRsa_Encrypt: Failed initialization");
         }
-        if (ret == 0) {
+        else {
             ret = KcapiRsa_SetPubKey(key);
         }
     }

--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -196,10 +196,10 @@ static void wc_Stm32_Hash_GetDigest(byte* hash, int digestSize)
 
 #ifdef DEBUG_STM32_HASH
     {
-        word32 i;
+        word32 ii;
         printf("STM Digest %d\n", digestSize);
-        for (i=0; i<digestSize/sizeof(word32); i++) {
-            printf("\tDIG 0x%04x\n", digest[i]);
+        for (ii=0; ii<digestSize/sizeof(word32); ii++) {
+            printf("\tDIG 0x%04x\n", digest[ii]);
         }
     }
 #endif

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -3664,10 +3664,11 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     {
         int ret = 0;
-        int len = 0;
         (void)os;
 
         while (sz) {
+            int len;
+
             errno = 0;
             len = (int)getrandom(output, sz, 0);
             if (len == -1) {

--- a/wolfcrypt/src/sakke.c
+++ b/wolfcrypt/src/sakke.c
@@ -6222,7 +6222,7 @@ static int sakke_hash_to_range(SakkeKey* key, enum wc_HashType hashType,
     int hash_inited = 0;
 
     err = wc_HashInit_ex(&key->hash, hashType, key->heap, INVALID_DEVID);
-    if (err == 0)
+    if (err == 0) {
         hash_inited = 1;
 
     /* Step 1: A = hashfn( s ), where s = data | extra
@@ -6230,8 +6230,8 @@ static int sakke_hash_to_range(SakkeKey* key, enum wc_HashType hashType,
      */
 
     /* Step 2: h_0 = 00...00, a string of null bits of length hashlen bits */
-    if (err == 0)
         err = wc_HashGetDigestSize(hashType);
+    }
     if (err > 0) {
         hashSz = (word32)err;
         XMEMSET(h, 0, hashSz);

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -599,7 +599,6 @@ int wc_ReadDirFirst(ReadDirCtx* ctx, const char* path, char** name)
 {
     int ret = WC_READDIR_NOFILE; /* default to no files found */
     int pathLen = 0;
-    int dnameLen = 0;
 
     if (name)
         *name = NULL;
@@ -626,7 +625,7 @@ int wc_ReadDirFirst(ReadDirCtx* ctx, const char* path, char** name)
 
     do {
         if (!(ctx->FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
-            dnameLen = (int)XSTRLEN(ctx->FindFileData.cFileName);
+            int dnameLen = (int)XSTRLEN(ctx->FindFileData.cFileName);
 
             if (pathLen + dnameLen + 2 > MAX_FILENAME_SZ) {
                 return BAD_PATH_ERROR;
@@ -655,7 +654,7 @@ int wc_ReadDirFirst(ReadDirCtx* ctx, const char* path, char** name)
     }
 
     do {
-        dnameLen = (int)XSTRLEN(IntimeFilename(ctx));
+        int dnameLen = (int)XSTRLEN(IntimeFilename(ctx));
 
         if (pathLen + dnameLen + 2 > MAX_FILENAME_SZ) {
             return BAD_PATH_ERROR;
@@ -680,7 +679,7 @@ int wc_ReadDirFirst(ReadDirCtx* ctx, const char* path, char** name)
     ctx->dirp = &ctx->dir;
 
     while ((fs_readdir(&ctx->dir, &ctx->entry)) != 0) {
-        dnameLen = (int)XSTRLEN(ctx->entry.name);
+        int dnameLen = (int)XSTRLEN(ctx->entry.name);
 
         if (pathLen + dnameLen + 2 >= MAX_FILENAME_SZ) {
             ret = BAD_PATH_ERROR;
@@ -707,7 +706,7 @@ int wc_ReadDirFirst(ReadDirCtx* ctx, const char* path, char** name)
     }
 
     while ((ctx->entry = m2mb_fs_readdir(ctx->dir)) != NULL) {
-        dnameLen = (int)XSTRLEN(ctx->entry->d_name);
+        int dnameLen = (int)XSTRLEN(ctx->entry->d_name);
 
         if (pathLen + dnameLen + 2 >= MAX_FILENAME_SZ) {
             ret = BAD_PATH_ERROR;
@@ -735,7 +734,7 @@ int wc_ReadDirFirst(ReadDirCtx* ctx, const char* path, char** name)
     }
 
     while ((ctx->entry = readdir(ctx->dir)) != NULL) {
-        dnameLen = (int)XSTRLEN(ctx->entry->d_name);
+        int dnameLen = (int)XSTRLEN(ctx->entry->d_name);
 
         if (pathLen + dnameLen + 2 >= MAX_FILENAME_SZ) {
             ret = BAD_PATH_ERROR;
@@ -765,7 +764,6 @@ int wc_ReadDirNext(ReadDirCtx* ctx, const char* path, char** name)
 {
     int ret = WC_READDIR_NOFILE; /* default to no file found */
     int pathLen = 0;
-    int dnameLen = 0;
 
     if (name)
         *name = NULL;
@@ -780,7 +778,7 @@ int wc_ReadDirNext(ReadDirCtx* ctx, const char* path, char** name)
 #ifdef USE_WINDOWS_API
     while (FindNextFileA(ctx->hFind, &ctx->FindFileData)) {
         if (!(ctx->FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
-            dnameLen = (int)XSTRLEN(ctx->FindFileData.cFileName);
+            int dnameLen = (int)XSTRLEN(ctx->FindFileData.cFileName);
 
             if (pathLen + dnameLen + 2 > MAX_FILENAME_SZ) {
                 return BAD_PATH_ERROR;
@@ -798,7 +796,7 @@ int wc_ReadDirNext(ReadDirCtx* ctx, const char* path, char** name)
 
 #elif defined(INTIME_RTOS)
     while (IntimeFindNext(&ctx->FindFileData)) {
-        dnameLen = (int)XSTRLEN(IntimeFilename(ctx));
+        int dnameLen = (int)XSTRLEN(IntimeFilename(ctx));
 
         if (pathLen + dnameLen + 2 > MAX_FILENAME_SZ) {
             return BAD_PATH_ERROR;
@@ -817,7 +815,7 @@ int wc_ReadDirNext(ReadDirCtx* ctx, const char* path, char** name)
 
 #elif defined(WOLFSSL_ZEPHYR)
     while ((fs_readdir(&ctx->dir, &ctx->entry)) != 0) {
-        dnameLen = (int)XSTRLEN(ctx->entry.name);
+        int dnameLen = (int)XSTRLEN(ctx->entry.name);
 
         if (pathLen + dnameLen + 2 >= MAX_FILENAME_SZ) {
             ret = BAD_PATH_ERROR;
@@ -838,7 +836,7 @@ int wc_ReadDirNext(ReadDirCtx* ctx, const char* path, char** name)
     }
 #elif defined(WOLFSSL_TELIT_M2MB)
     while ((ctx->entry = m2mb_fs_readdir(ctx->dir)) != NULL) {
-        dnameLen = (int)XSTRLEN(ctx->entry->d_name);
+        int dnameLen = (int)XSTRLEN(ctx->entry->d_name);
 
         if (pathLen + dnameLen + 2 >= MAX_FILENAME_SZ) {
             ret = BAD_PATH_ERROR;
@@ -860,7 +858,7 @@ int wc_ReadDirNext(ReadDirCtx* ctx, const char* path, char** name)
     }
 #else
     while ((ctx->entry = readdir(ctx->dir)) != NULL) {
-        dnameLen = (int)XSTRLEN(ctx->entry->d_name);
+        int dnameLen = (int)XSTRLEN(ctx->entry->d_name);
 
         if (pathLen + dnameLen + 2 >= MAX_FILENAME_SZ) {
             ret = BAD_PATH_ERROR;


### PR DESCRIPTION
# Description

wolfssl_sce_unit_test.c:
  sce_crypt_Sha_AesCbcGcm_multitest(): duplicate condition
ssl_asn1.c:
  wolfSSL_i2t_ASN1_OBJECT(): done is not needed
  MonthStr(): fix bounds check on i
woolfcrypt_test.c, test_main.c, wolfssl_tsip_unit_test.c, devices.c, aes.c, des3.c:
  Variable not used.
asn.c:
DecodeSubjKeyId(): sz is unsigned - check for less than zero does nothing
kcapi_rsa.c:
  KcapiRsa_Decrypt(): fix ret check by using else
  KcapiRsa_Encrypt(): make same change for consistency
kcapi_hash.c:
  KcapiHashFinal(): move ret into #ifdef where it is needed
stm32.c:
wc_Stm32_Hash_GetDigest(): i redeclared with different type - use ii instead
bio.c, conf.c:
  XFREE checks for NULL

Reduce scope of varialbes.
Condition same.

# Testing

cppcheck

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
