### PR TITLE
20230608-linuxkm-__is_constexpr

### DIFF
--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -199,6 +199,10 @@
 
     _Pragma("GCC diagnostic pop");
 
+    /* avoid -Wpointer-arith, encountered when -DCONFIG_FORTIFY_SOURCE */
+    #undef __is_constexpr
+    #define __is_constexpr(x) __builtin_constant_p(x)
+
     /* the kernel uses -std=c89, but not -pedantic, and makes full use of anon
      * structs/unions, so we should too.
      */


### PR DESCRIPTION
`linuxkm/linuxkm_wc_port.h`: override definition of `__is_constexpr()` from `/usr/src/linux/include/linux/const.h` with warning-free `__builtin_constant_p()`.

this fixes this build failure:
```
In file included from ./include/linux/align.h:5,
                 from ./include/linux/kernel.h:15,
                 from /home/jordan/work/wolfssl/src/wolfssl/wolfcrypt/../../linuxkm/linuxkm_wc_port.h:120,
                 from /home/jordan/work/wolfssl/src/wolfssl/wolfcrypt/wc_port.h:58,
                 from /home/jordan/work/wolfssl/src/wolfcrypt/src/hmac.c:27:
/home/jordan/work/wolfssl/src/wolfcrypt/src/hmac.c: In function 'wc_HmacInit_Label':
./include/linux/const.h:12:31: error: invalid application of 'sizeof' to a void type [-Werror=pointer-arith]
   12 |         (sizeof(int) == sizeof(*(8 ? ((void *)((long)(x) * 0l)) : (int *)8)))
      |                               ^
./include/linux/fortify-string.h:224:31: note: in expansion of macro '__is_constexpr'
  224 |         __builtin_choose_expr(__is_constexpr(__builtin_strlen(p)),      \
      |                               ^~~~~~~~~~~~~~
/home/jordan/work/wolfssl/src/wolfssl/wolfcrypt/types.h:665:35: note: in expansion of macro 'strlen'
  665 |         #define XSTRLEN(s1)       strlen((s1))
      |                                   ^~~~~~
/home/jordan/work/wolfssl/src/wolfcrypt/src/hmac.c:1073:25: note: in expansion of macro 'XSTRLEN'
 1073 |         labelLen = (int)XSTRLEN(label);
      |                         ^~~~~~~
```

tested with kernel module build targeting a `CONFIG_FORTIFY_SOURCE` kernel.
