### PR TITLE
Implicit Type Conversion Fix

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -66573,7 +66573,7 @@ static byte* test_find_string(const char *string,
 {
     int string_size, i;
 
-    string_size = XSTRLEN(string);
+    string_size = (int)XSTRLEN(string);
     for (i = 0; i < buf_size - string_size - 1; i++) {
         if (XSTRCMP((char*)&buf[i], string) == 0)
             return &buf[i];


### PR DESCRIPTION
# Description

1. Typecast the return of strlen() to int for the variable used.

Only affects the API test in a narrow set of configuration parameters with clang-14. GCC ignored it.

# Testing

    % ./configure --enable-dtls --enable-tls13 --enable-dtls13 --enable-nullcipher && make

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
