### PR TITLE
Fix MSVC compiler error, WIN64LIT macro appends type already

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -5623,10 +5623,10 @@ static WC_INLINE void GMULT(byte *x, byte m[32][AES_BLOCK_SIZE])
     a = (z8[1] >> 56) & 0xf;
 
     /* Rotate z by 4-bits */
-    n3 = z8[1] & W64LIT(0xf0f0f0f0f0f0f0f0U);
-    n2 = z8[1] & W64LIT(0x0f0f0f0f0f0f0f0fU);
-    n1 = z8[0] & W64LIT(0xf0f0f0f0f0f0f0f0U);
-    n0 = z8[0] & W64LIT(0x0f0f0f0f0f0f0f0fU);
+    n3 = z8[1] & W64LIT(0xf0f0f0f0f0f0f0f0);
+    n2 = z8[1] & W64LIT(0x0f0f0f0f0f0f0f0f);
+    n1 = z8[0] & W64LIT(0xf0f0f0f0f0f0f0f0);
+    n0 = z8[0] & W64LIT(0x0f0f0f0f0f0f0f0f);
     z8[1] = (n3 >> 4) | (n2 << 12) | (n0 >> 52);
     z8[0] = (n1 >> 4) | (n0 << 12);
 


### PR DESCRIPTION
closes #6493

# Description

Please describe the scope of the fix or feature addition.

Fixes #6493

See description in bug report

Note the code does this in several other places, the defines I am using don't hit them but not sure if the best option is just change all macro calls.