### PR TITLE
ssize_t proper detection/gating fix (MSVC)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,8 @@ AC_CHECK_SIZEOF([long long])
 AC_CHECK_SIZEOF([long])
 AC_CHECK_SIZEOF([time_t])
 AC_CHECK_TYPES([__uint128_t])
+AC_CHECK_TYPES([ssize_t], [], [], [[#include <BaseTsd.h>]])
+
 
 
 # Distro build feature subset (Debian, Ubuntu, etc.)

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1879,7 +1879,9 @@ extern void uITRON4_free(void *p) ;
 #ifdef _MSC_VER
     #ifndef HAVE_SSIZE_T
         #include <BaseTsd.h>
-        typedef SSIZE_T ssize_t;
+        #if ! defined(ssize_t)
+            typedef SSIZE_T ssize_t;
+        #endif
     #endif
 #endif
 


### PR DESCRIPTION
fixes #6497

# Description

See bug report but the code checks for the define of HAVE_SSIZE_T however the autoconf file does not actually check (or result in it being declared) causing a conflict if it is defined.   This patch not only adds the proper check and output, but also double gates the define based on if it is actually defined or not (as why not, and it may be declared by a consumer elsewhere in their code).

There is the AC_TYPE_SSIZE_T but it defines it as an INT rather than using SSIZE_T as desired.

Fixes #6497

