### PR TITLE
20230612-windows-fixes

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -5623,10 +5623,10 @@ static WC_INLINE void GMULT(byte *x, byte m[32][AES_BLOCK_SIZE])
     a = (z8[1] >> 56) & 0xf;
 
     /* Rotate z by 4-bits */
-    n3 = z8[1] & W64LIT(0xf0f0f0f0f0f0f0f0U);
-    n2 = z8[1] & W64LIT(0x0f0f0f0f0f0f0f0fU);
-    n1 = z8[0] & W64LIT(0xf0f0f0f0f0f0f0f0U);
-    n0 = z8[0] & W64LIT(0x0f0f0f0f0f0f0f0fU);
+    n3 = z8[1] & W64LIT(0xf0f0f0f0f0f0f0f0);
+    n2 = z8[1] & W64LIT(0x0f0f0f0f0f0f0f0f);
+    n1 = z8[0] & W64LIT(0xf0f0f0f0f0f0f0f0);
+    n0 = z8[0] & W64LIT(0x0f0f0f0f0f0f0f0f);
     z8[1] = (n3 >> 4) | (n2 << 12) | (n0 >> 52);
     z8[0] = (n1 >> 4) | (n0 << 12);
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -31485,6 +31485,7 @@ static void DataToHexString(const byte* input, word32 inSz, char* out)
     out[i * 2] = '\0';
 }
 
+#ifndef WOLFSSL_ECC_CURVE_STATIC
 /* Convert data to hex string and place in allocated buffer.
  *
  * Big-endian byte array is converted to big-endian hexadecimal string.
@@ -31519,6 +31520,7 @@ static int DataToHexStringAlloc(const byte* input, word32 inSz, char** out,
 
     return ret;
 }
+#endif /* WOLFSSL_ECC_CURVE_STATIC */
 
 /* ASN.1 template for SpecifiedECDomain.
  * SEC 1 Ver. 2.0, C.2 - Syntax for Elliptic Curve Domain Parameters

--- a/wolfcrypt/src/blake2b.c
+++ b/wolfcrypt/src/blake2b.c
@@ -48,10 +48,10 @@
 
 static const word64 blake2b_IV[8] =
 {
-  W64LIT(0x6a09e667f3bcc908U), W64LIT(0xbb67ae8584caa73bU),
-  W64LIT(0x3c6ef372fe94f82bU), W64LIT(0xa54ff53a5f1d36f1U),
-  W64LIT(0x510e527fade682d1U), W64LIT(0x9b05688c2b3e6c1fU),
-  W64LIT(0x1f83d9abfb41bd6bU), W64LIT(0x5be0cd19137e2179U)
+  W64LIT(0x6a09e667f3bcc908), W64LIT(0xbb67ae8584caa73b),
+  W64LIT(0x3c6ef372fe94f82b), W64LIT(0xa54ff53a5f1d36f1),
+  W64LIT(0x510e527fade682d1), W64LIT(0x9b05688c2b3e6c1f),
+  W64LIT(0x1f83d9abfb41bd6b), W64LIT(0x5be0cd19137e2179)
 };
 
 static const byte blake2b_sigma[12][16] =
@@ -73,7 +73,7 @@ static const byte blake2b_sigma[12][16] =
 
 static WC_INLINE int blake2b_set_lastnode( blake2b_state *S )
 {
-  S->f[1] = ~W64LIT(0U);
+  S->f[1] = ~W64LIT(0);
   return 0;
 }
 
@@ -82,7 +82,7 @@ static WC_INLINE int blake2b_set_lastblock( blake2b_state *S )
 {
   if( S->last_node ) blake2b_set_lastnode( S );
 
-  S->f[0] = ~W64LIT(0U);
+  S->f[0] = ~W64LIT(0);
   return 0;
 }
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4311,6 +4311,14 @@ int wc_ecc_get_curve_id_from_oid(const byte* oid, word32 len)
     }
 #endif
 
+#if !defined(HAVE_OID_ENCODING) && !defined(HAVE_OID_DECODING)
+    if (len == 0) {
+        /* SAKKE has zero oidSz and will otherwise match with len==0. */
+        WOLFSSL_MSG("zero oidSz");
+        return ECC_CURVE_INVALID;
+    }
+#endif
+
     for (curve_idx = 0; ecc_sets[curve_idx].size != 0; curve_idx++) {
     #if defined(HAVE_OID_ENCODING) && !defined(HAVE_OID_DECODING)
         decOidSz = (word32)sizeof(decOid);

--- a/wolfcrypt/src/siphash.c
+++ b/wolfcrypt/src/siphash.c
@@ -165,15 +165,15 @@ int wc_InitSipHash(SipHash* sipHash, const unsigned char* key,
         word64 k1 = GET_U64(key + 8);
 
         /* Initialize state with key. */
-        sipHash->v[0] = W64LIT(0x736f6d6570736575U);
+        sipHash->v[0] = W64LIT(0x736f6d6570736575);
         if (outSz == SIPHASH_MAC_SIZE_8) {
-            sipHash->v[1] = W64LIT(0x646f72616e646f6dU);
+            sipHash->v[1] = W64LIT(0x646f72616e646f6d);
         }
         else {
-            sipHash->v[1] = W64LIT(0x646f72616e646f83U);
+            sipHash->v[1] = W64LIT(0x646f72616e646f83);
         }
-        sipHash->v[2] = W64LIT(0x6c7967656e657261U);
-        sipHash->v[3] = W64LIT(0x7465646279746573U);
+        sipHash->v[2] = W64LIT(0x6c7967656e657261);
+        sipHash->v[3] = W64LIT(0x7465646279746573);
 
         sipHash->v[0] ^= k0;
         sipHash->v[1] ^= k1;

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -615,7 +615,7 @@ int wc_ReadDirFirst(ReadDirCtx* ctx, const char* path, char** name)
         return BAD_PATH_ERROR;
 
     XSTRNCPY(ctx->name, path, MAX_FILENAME_SZ - 3);
-    XSTRNCPY(ctx->name + pathLen, "\\*", MAX_FILENAME_SZ - pathLen);
+    XSTRNCPY(ctx->name + pathLen, "\\*", (size_t)(MAX_FILENAME_SZ - pathLen));
 
     ctx->hFind = FindFirstFileA(ctx->name, &ctx->FindFileData);
     if (ctx->hFind == INVALID_HANDLE_VALUE) {
@@ -630,11 +630,11 @@ int wc_ReadDirFirst(ReadDirCtx* ctx, const char* path, char** name)
             if (pathLen + dnameLen + 2 > MAX_FILENAME_SZ) {
                 return BAD_PATH_ERROR;
             }
-            XSTRNCPY(ctx->name, path, pathLen + 1);
+            XSTRNCPY(ctx->name, path, (size_t)pathLen + 1);
             ctx->name[pathLen] = '\\';
             XSTRNCPY(ctx->name + pathLen + 1,
                      ctx->FindFileData.cFileName,
-                     MAX_FILENAME_SZ - pathLen - 1);
+                     (size_t)(MAX_FILENAME_SZ - pathLen - 1));
             if (name)
                 *name = ctx->name;
             return 0;
@@ -783,11 +783,11 @@ int wc_ReadDirNext(ReadDirCtx* ctx, const char* path, char** name)
             if (pathLen + dnameLen + 2 > MAX_FILENAME_SZ) {
                 return BAD_PATH_ERROR;
             }
-            XSTRNCPY(ctx->name, path, pathLen + 1);
+            XSTRNCPY(ctx->name, path, (size_t)pathLen + 1);
             ctx->name[pathLen] = '\\';
             XSTRNCPY(ctx->name + pathLen + 1,
                      ctx->FindFileData.cFileName,
-                     MAX_FILENAME_SZ - pathLen - 1);
+                     (size_t)(MAX_FILENAME_SZ - pathLen - 1));
             if (name)
                 *name = ctx->name;
             return 0;

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -306,14 +306,14 @@ typedef struct ecc_set_type {
 typedef struct ecc_set_type {
     int size;             /* The size of the curve in octets */
     int id;               /* id of this curve */
-    const char name[MAX_ECC_NAME];     /* name of this curve */
-    const char prime[MAX_ECC_STRING];    /* prime that defines the field, curve is in (hex) */
-    const char Af[MAX_ECC_STRING];       /* fields A param (hex) */
-    const char Bf[MAX_ECC_STRING];       /* fields B param (hex) */
-    const char order[MAX_ECC_STRING];    /* order of the curve (hex) */
-    const char Gx[MAX_ECC_STRING];       /* x coordinate of the base point on curve (hex) */
-    const char Gy[MAX_ECC_STRING];       /* y coordinate of the base point on curve (hex) */
-    const ecc_oid_t oid[10];
+    char name[MAX_ECC_NAME];     /* name of this curve */
+    char prime[MAX_ECC_STRING];    /* prime that defines the field, curve is in (hex) */
+    char Af[MAX_ECC_STRING];       /* fields A param (hex) */
+    char Bf[MAX_ECC_STRING];       /* fields B param (hex) */
+    char order[MAX_ECC_STRING];    /* order of the curve (hex) */
+    char Gx[MAX_ECC_STRING];       /* x coordinate of the base point on curve (hex) */
+    char Gy[MAX_ECC_STRING];       /* y coordinate of the base point on curve (hex) */
+    ecc_oid_t oid[10];
     word32      oidSz;
     word32      oidSum;    /* sum of encoded OID bytes */
     int         cofactor;

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -177,37 +177,45 @@ decouple library dependencies with standard string, memory and so on.
     #if defined(_MSC_VER) || defined(__BCPLUSPLUS__)
         #define WORD64_AVAILABLE
         #define W64LIT(x) x##ui64
+        #define SW64LIT(x) x##i64
         typedef          __int64 sword64;
         typedef unsigned __int64 word64;
     #elif defined(__EMSCRIPTEN__)
         #define WORD64_AVAILABLE
         #define W64LIT(x) x##ull
+        #define SW64LIT(x) x##ll
         typedef          long long sword64;
         typedef unsigned long long word64;
     #elif defined(SIZEOF_LONG) && SIZEOF_LONG == 8
         #define WORD64_AVAILABLE
         #ifdef WOLF_C89
-            #define W64LIT(x) x##L
+            #define W64LIT(x) x##UL
+            #define SW64LIT(x) x##L
         #else
-            #define W64LIT(x) x##LL
+            #define W64LIT(x) x##ULL
+            #define SW64LIT(x) x##LL
         #endif
         typedef          long sword64;
         typedef unsigned long word64;
     #elif defined(SIZEOF_LONG_LONG) && SIZEOF_LONG_LONG == 8
         #define WORD64_AVAILABLE
         #ifdef WOLF_C89
-            #define W64LIT(x) x##L
+            #define W64LIT(x) x##UL
+            #define SW64LIT(x) x##L
         #else
-            #define W64LIT(x) x##LL
+            #define W64LIT(x) x##ULL
+            #define SW64LIT(x) x##LL
         #endif
         typedef          long long sword64;
         typedef unsigned long long word64;
     #elif defined(__SIZEOF_LONG_LONG__) && __SIZEOF_LONG_LONG__ == 8
         #define WORD64_AVAILABLE
         #ifdef WOLF_C89
-            #define W64LIT(x) x##L
+            #define W64LIT(x) x##UL
+            #define SW64LIT(x) x##L
         #else
-            #define W64LIT(x) x##LL
+            #define W64LIT(x) x##ULL
+            #define SW64LIT(x) x##LL
         #endif
         typedef          long long sword64;
         typedef unsigned long long word64;


### PR DESCRIPTION
`wolfcrypt/src/{aes.c,blake2b.c,siphash.c}`: fix `W64LIT()` arguments to not have improper 'U' suffix;

`wolfssl/wolfcrypt/types.h`: add 'U' suffix to `W64LIT()` macro defs, and add `SW64LIT()` macro defs (not yet used anywhere);

`wolfcrypt/src/asn.c`: add !`WOLFSSL_ECC_CURVE_STATIC` gate around `DataToHexStringAlloc()` to resolve `-Wunused`;

`wolfcrypt/src/ecc.c`: guard against zero-valued `len` arg to `wc_ecc_get_curve_id_from_oid()`;

`wolfcrypt/src/wc_port.c`: fix several argument implicit sign changes in `USE_WINDOWS_API` paths;

`wolfssl/wolfcrypt/ecc.h`: remove `const` attribute from inline buffers in `WOLFSSL_ECC_CURVE_STATIC` `struct ecc_set_type`.

tested with `wolfssl-multi-test.sh ... super-quick-check` with newly added `cross-amd64-mingw-all-crypto-Wconversion` and `cross-mingw-all-crypto` for pseudo-Windows build and tests.

Intended to fix #6493 and related issues, and supersedes #6494 .
