### PR TITLE
TFM: fix big endian reading a zero length buffer

### DIFF
--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -3697,6 +3697,10 @@ int fp_read_unsigned_bin(fp_int *a, const unsigned char *b, int c)
   /* zero the int */
   fp_zero (a);
 
+  if (c == 0) {
+      return FP_OKAY;
+  }
+
   /* if input b excess max, then truncate */
   if (c > 0 && (word32)c > maxC) {
      int excess = (c - maxC);


### PR DESCRIPTION
# Description

Bail early as big endian implementation doesn't handle it.

# Testing

/configure '--disable-shared' '--host=mips' 'CC=mips-linux-gnu-gcc' 'LDFLAGS=--static' '--enable-fastmath' 'CFLAGS=-DWOLFSSL_PUBLIC_MP'

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
