### PR TITLE
ECC, ALT_ECC_SIZE, CryptoCB: ensure err is 0 in _ecc_make_key_ex

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -5612,6 +5612,7 @@ static int _ecc_make_key_ex(WC_RNG* rng, int keysize, ecc_key* key,
 #ifndef ALT_ECC_SIZE
         err = mp_init(key->k);
 #else
+        err = 0;
         key->k = (mp_int*)key->ka;
         alt_fp_init(key->k);
 #endif


### PR DESCRIPTION
# Description

When CryptoCB is used and the key gen operation is not implemented, err is CRYPTOCB_UNAVAILABLE and needs to be reset to 0.

# Testing

./configure '--disable-shared' '--enable-cryptocb' 'CFLAGS=-DALT_ECC_SIZE'
make
./tests/unit.test -test_wc_CryptoCb

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
