### PR TITLE
Fix typos found by codespell

### DIFF
--- a/IDE/AURIX/user_settings.h
+++ b/IDE/AURIX/user_settings.h
@@ -205,7 +205,7 @@ extern unsigned int my_rng_seed_gen(void);
             /* use heap allocation for ECC points */
             #define ALT_ECC_SIZE
 
-            /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overriden */
+            /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overridden */
             //#define FP_MAX_BITS_ECC (256 * 2)
         #endif
 

--- a/IDE/Espressif/ESP-IDF/setup_win.bat
+++ b/IDE/Espressif/ESP-IDF/setup_win.bat
@@ -73,7 +73,7 @@ dir %WOLFSSL_ESPIDFDIR%\*.xyzzy 2> nul | findstr  \
 
 echo;
 echo Equivalalent source directory paths:
-:: show the path of the equivalent  %VALUE% (search for files that don't exist, supress error, and look for string with "\")
+:: show the path of the equivalent  %VALUE% (search for files that don't exist, suppress error, and look for string with "\")
 dir %BASEDIR%\*.xyzzy 2> nul | findstr  \
 dir %WOLFSSLLIB_TRG_DIR%\*.xyzzy 2> nul | findstr  \
 dir %WOLFSSLEXP_TRG_DIR%\*.xyzzy 2> nul | findstr  \

--- a/IDE/GCC-ARM/Header/user_settings.h
+++ b/IDE/GCC-ARM/Header/user_settings.h
@@ -214,7 +214,7 @@ extern "C" {
         #else
             #undef  ALT_ECC_SIZE
             #define ALT_ECC_SIZE
-            /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overriden */
+            /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overridden */
             //#undef  FP_MAX_BITS_ECC
             //#define FP_MAX_BITS_ECC (256 * 2)
         #endif

--- a/IDE/IAR-EWARM/embOS/SAMV71_XULT/embOS_SAMV71_XULT_user_settings/user_settings_verbose_example.h
+++ b/IDE/IAR-EWARM/embOS/SAMV71_XULT/embOS_SAMV71_XULT_user_settings/user_settings_verbose_example.h
@@ -87,7 +87,7 @@
         #undef  ALT_ECC_SIZE
         #define ALT_ECC_SIZE
 
-        /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overriden */
+        /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overridden */
         /* MAX ECC BITS = ROUND8(MAX ECC) * 2 */
         //#undef  FP_MAX_BITS_ECC
         //#define FP_MAX_BITS_ECC (528 * 2)

--- a/IDE/IAR-MSP430/README.md
+++ b/IDE/IAR-MSP430/README.md
@@ -78,10 +78,10 @@ Bob init
 Successfully generated a common secret
 Alices' Secret: 85f3c7f599620c768e6dbb77dc2f8f764254cc1821aeb0a30503632dbc9bdb54
 Bobs' Secret: 85f3c7f599620c768e6dbb77dc2f8f764254cc1821aeb0a30503632dbc9bdb54
-ChaCha20/Poly1305 Encryption Start, 1000 itterations, 1024 bytes
+ChaCha20/Poly1305 Encryption Start, 1000 iterations, 1024 bytes
 ............................................
 End 44 seconds
-ChaCha20/Poly1305 Decryption Start, 1000 itterations
+ChaCha20/Poly1305 Decryption Start, 1000 iterations
 ............................................
 End 44 seconds
 end

--- a/IDE/IAR-MSP430/main.c
+++ b/IDE/IAR-MSP430/main.c
@@ -36,7 +36,7 @@
 #include <msp430f5659.h>
 
 /* Without __root on some of the functions, IAR's "Discard Unused Publics"
-   will optimze out some of the functions
+   will optimize out some of the functions
  */
 #if defined(__IAR_SYSTEMS_ICC__)
 #define IAR_KEEP __root
@@ -304,7 +304,7 @@ only_rng:
     wc_FreeRng(&rng);
 
     printf(
-        "ChaCha20/Poly1305 Encryption Start, 1000 itterations, %d bytes\r\n",
+        "ChaCha20/Poly1305 Encryption Start, 1000 iterations, %d bytes\r\n",
         (int)strlen((const char*)plaintext));
     start = seconds;
     for (int i=0; i <= 1000; i++) {
@@ -319,7 +319,7 @@ only_rng:
     printf("\r\nEnd %d seconds\r\n", seconds - start);
 
     start = seconds;
-    printf("ChaCha20/Poly1305 Decryption Start, 1000 itterations\r\n");
+    printf("ChaCha20/Poly1305 Decryption Start, 1000 iterations\r\n");
     start = seconds;
     for (int i=0; i <= 1000; i++) {
         ret = wc_ChaCha20Poly1305_Decrypt(key, iv, aad, sizeof(aad),

--- a/IDE/M68K/Makefile
+++ b/IDE/M68K/Makefile
@@ -84,7 +84,7 @@ clean: rmo
 	rm -f $(OUTPUT)/$(NAME).a
 
 help:
-	@echo "all     : exectue compile, link, rmo"
+	@echo "all     : execute compile, link, rmo"
 	@echo "compile : create .o files"
 	@echo "link    : create .a library from .o files"
 	@echo "rmo     : remove all .o files"

--- a/IDE/MCUEXPRESSO/RT1170/fsl_caam_c.patch
+++ b/IDE/MCUEXPRESSO/RT1170/fsl_caam_c.patch
@@ -117,7 +117,7 @@
 +    /* initialize descriptor from template */
 +    (void)caam_memcpy(descriptor, templateKeyPairECC, sizeof(templateKeyPairECC));
 +
-+    /* add descriptor lenght in bytes to HEADER descriptor command */
++    /* add descriptor length in bytes to HEADER descriptor command */
 +    DESC_HEADER_ADD_DESCLEN(descriptor[0], descriptorSize);
 +
 +    DESC_SET_ADDR(descriptor[1], (CAAM_ECDSA_KEYGEN_PD | keyType));
@@ -200,7 +200,7 @@
 +    /* initialize descriptor from template */
 +    (void)caam_memcpy(descriptor, templateSignECC, sizeof(templateSignECC));
 +
-+    /* add descriptor lenght in bytes to HEADER descriptor command */
++    /* add descriptor length in bytes to HEADER descriptor command */
 +    DESC_HEADER_ADD_DESCLEN(descriptor[0], descriptorSize);
 +
 +    DESC_SET_ADDR(descriptor[1], (CAAM_ECDSA_PD | keyType));
@@ -275,7 +275,7 @@
 +    /* initialize descriptor from template */
 +    (void)caam_memcpy(descriptor, templateVerifyECC, sizeof(templateVerifyECC));
 +
-+    /* add descriptor lenght in bytes to HEADER descriptor command */
++    /* add descriptor length in bytes to HEADER descriptor command */
 +    DESC_HEADER_ADD_DESCLEN(descriptor[0], descriptorSize);
 +
 +    DESC_SET_ADDR(descriptor[1], (CAAM_ECDSA_PD | keyType));
@@ -344,7 +344,7 @@
 +    /* initialize descriptor from template */
 +    (void)caam_memcpy(descriptor, templateAgreeECC, sizeof(templateAgreeECC));
 +
-+    /* add descriptor lenght in bytes to HEADER descriptor command */
++    /* add descriptor length in bytes to HEADER descriptor command */
 +    DESC_HEADER_ADD_DESCLEN(descriptor[0], descriptorSize);
 +
 +    DESC_SET_ADDR(descriptor[1], (CAAM_ECDSA_KEYGEN_PD | keyType));
@@ -445,7 +445,7 @@
 +    /* initialize descriptor from template */
 +    (void)caam_memcpy(descriptor, templateBlob, sizeof(templateBlob));
 +
-+    /* add descriptor lenght in bytes to HEADER descriptor command */
++    /* add descriptor length in bytes to HEADER descriptor command */
 +    DESC_HEADER_ADD_DESCLEN(descriptor[0], descriptorSize);
 +    descriptor[1] |= keyModSz;
 +    DESC_SET_ADDR(descriptor[2], keyMod);

--- a/IDE/MCUEXPRESSO/benchmark/source/run_benchmark.c
+++ b/IDE/MCUEXPRESSO/benchmark/source/run_benchmark.c
@@ -78,7 +78,7 @@ static void doBenchmark(void* params)
         wolfCrypt_Cleanup();
     }
     else {
-    	PRINTF("Failied to initialize wolfCrypt\r\n");
+    	PRINTF("Failed to initialize wolfCrypt\r\n");
     }
 }
 

--- a/IDE/MCUEXPRESSO/wolfcrypt_test.c
+++ b/IDE/MCUEXPRESSO/wolfcrypt_test.c
@@ -136,7 +136,7 @@ int main(void)
         wolfCrypt_Cleanup();
     }
     else {
-    	PRINTF("Failied to initialize wolfCrypt\r\n");
+    	PRINTF("Failed to initialize wolfCrypt\r\n");
     }
 
 #if defined(FREESCALE_KSDK_2_0_TRNG) && defined(FREESCALE_RTC)

--- a/IDE/MDK-ARM/MDK-ARM/wolfSSL/shell.c
+++ b/IDE/MDK-ARM/MDK-ARM/wolfSSL/shell.c
@@ -301,7 +301,7 @@ static struct {
     "",  NULL
 } ;
 
-enum jobtype { FORGROUND, BACKGROUND }  ;
+enum jobtype { FOREGROUND, BACKGROUND }  ;
 
 #define IF_DELIMITER(ch) ((ch) == ' ' || (ch) == '\n')
 
@@ -326,7 +326,7 @@ static int getline(char * line, int sz, func_args *args, int*bf_flg)
         (*bf_flg) = BACKGROUND ;
         line[strlen(line)-2] = '\n' ;
     } else {
-        (*bf_flg) = FORGROUND ;
+        (*bf_flg) = FOREGROUND ;
     }
     args->argc = 0 ;
     for(i=0; i<sz; i++) {
@@ -542,7 +542,7 @@ void shell_main(void) {
         for(i=0; commandTable[i].func != NULL; i++) {
             if(strcmp(commandTable[i].command, args.argv[0]) == 0) {
             args.argv[0] = (char *) commandTable[i].func ;
-                if(bf_flg == FORGROUND) {
+                if(bf_flg == FOREGROUND) {
                     #ifdef  HAVE_KEIL_RTX
                     wc_UnLockMutex((wolfSSL_Mutex *)&command_mutex) ;
                     os_tsk_create_user_ex( (void(*)(void *))&command_invoke, 7,

--- a/IDE/MDK5-ARM/Projects/wolfSSL-Full/shell.c
+++ b/IDE/MDK5-ARM/Projects/wolfSSL-Full/shell.c
@@ -308,7 +308,7 @@ static struct {
     "",  NULL
 } ;
 
-enum jobtype { FORGROUND, BACKGROUND }  ;
+enum jobtype { FOREGROUND, BACKGROUND }  ;
 
 #define IF_DELIMITER(ch) ((ch) == ' ' || (ch) == '\n')
 
@@ -368,7 +368,7 @@ static int getline(char * line, int sz, func_args *args, int*bf_flg)
         (*bf_flg) = BACKGROUND ;
         line[strlen(line)-2] = '\n' ;
     } else {
-        (*bf_flg) = FORGROUND ;
+        (*bf_flg) = FOREGROUND ;
     }
     args->argc = 0 ;
     for(i=0; i<sz; i++) {
@@ -633,7 +633,7 @@ void shell_main(void *arg) {
         for(i=0; commandTable[i].func != NULL; i++) {
             if(strcmp(commandTable[i].command, args.argv[0]) == 0) {
             args.argv[0] = (char *) commandTable[i].func ;
-                if(bf_flg == FORGROUND) {
+                if(bf_flg == FOREGROUND) {
                     #if defined(HAVE_KEIL_RTX) && !defined(WOLFSSL_CMSIS_RTOS)
                         wc_UnLockMutex((wolfSSL_Mutex *)&command_mutex) ;
                         os_tsk_create_user_ex( (void(*)(void *))&command_invoke, 7,

--- a/IDE/NETOS/user_settings.h
+++ b/IDE/NETOS/user_settings.h
@@ -198,7 +198,7 @@ extern "C" {
         #else
             #undef ALT_ECC_SIZE
             #define ALT_ECC_SIZE
-            /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overriden */
+            /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overridden */
             //#undef FP_MAX_BITS_ECC
             //#define FP_MAX_BITS_ECC (256 * 2)
         #endif

--- a/IDE/QNX/README.md
+++ b/IDE/QNX/README.md
@@ -17,7 +17,7 @@ source ~/qnx700/qnxsdp-env.sh
 make
 ```
 
-Once the wolfSSL library has been built cd to IDE/QNX/CAAM-DRIVER and run "make". This will produce the wolfCrypt resource manager. It should be started on the device with root permisions. Once wolfCrypt is running on the device with root permisions then any user with access to open a connection to /dev/wolfCrypt can make use of the driver.  
+Once the wolfSSL library has been built cd to IDE/QNX/CAAM-DRIVER and run "make". This will produce the wolfCrypt resource manager. It should be started on the device with root permissions. Once wolfCrypt is running on the device with root permissions then any user with access to open a connection to /dev/wolfCrypt can make use of the driver.  
 
 ### Momentics
 To build in momentics IDE:

--- a/IDE/Renesas/e2studio/DK-S7G2/README.md
+++ b/IDE/Renesas/e2studio/DK-S7G2/README.md
@@ -18,7 +18,7 @@
 - Generate the changes by clicking on "Generate Project Content"
 - Exclude src/wolfcrypt/port and all src/wolfcrypt/*.S and src/wolfcrypt/*.asm files from the build
 - Exclude src/wolfcrypt/evp.c, src/wolfcrypt/misc.c and src/wolfssl/bio.c
-- Set the Preprocessor define in wolfssl proejct to have WOLFSSL_USER_SETTINGS. Right click on wolfssl project "Properties -> C/C++ Build -> GNU ARM Cross C Compiler -> Preprocessor" add WOLFSSL_USER_SETTINGS under "Defined symbols"
+- Set the Preprocessor define in wolfssl project to have WOLFSSL_USER_SETTINGS. Right click on wolfssl project "Properties -> C/C++ Build -> GNU ARM Cross C Compiler -> Preprocessor" add WOLFSSL_USER_SETTINGS under "Defined symbols"
 - Set include to wolfssl directory. Right click on project "Properties -> C/C++Build -> GNU ARM Cross Compiler -> Includes". Add "${ProjDirPath}/../../../../.." and "${ProjDirPath}/../"
 - Build wolfssl by right clicking on wolfssl project and selecting "Build Project"
 
@@ -29,7 +29,7 @@
 - Copy in the .cproject, .project and source file from the template desired i.e. wolfssl-X.X.X/IDE/Renesas/e2studio/DK-S7G2/wolfcrypttest-template/
 - Right click on the created project and select "Build Project"
 
-The example_server loops looking to accept connections and closes immediatly after a successful connection was made.
+The example_server loops looking to accept connections and closes immediately after a successful connection was made.
 
 The benchmark example tries to do a TCP connection to SERVER_IP on port 11112 and a TLS connection to SERVER_IP on port 11111 then does wolfCrypt benchmark collection.
 

--- a/IDE/Renesas/e2studio/DK-S7G2/benchmark-template/src/app_entry.c
+++ b/IDE/Renesas/e2studio/DK-S7G2/benchmark-template/src/app_entry.c
@@ -41,10 +41,10 @@ extern void initialise_monitor_handles(void);
 #define TLS_PORT 11111
 #define TCP_PORT 11112
 
-static double miliseconds = 0;
+static double milliseconds = 0;
 void  timer_callback(timer_callback_args_t * args)
 {
-    miliseconds++;
+    milliseconds++;
     (void)args;
 }
 
@@ -127,7 +127,7 @@ static void benchmark_TLS(int version, char* suites, int group)
 
     printf("Trying to connect to 0x%lX on port %d\n", TEST_IP, TEST_PORT);
 
-    miliseconds = 0;
+    milliseconds = 0;
     g_timer0.p_api->open(g_timer0.p_ctrl, g_timer0.p_cfg);
     g_timer0.p_api->start(g_timer0.p_ctrl);
 
@@ -195,7 +195,7 @@ static void benchmark_TLS(int version, char* suites, int group)
     g_timer0.p_api->close(g_timer0.p_ctrl);
 
     printf("%d TLS connections took %f seconds and %f tx_time ticks\n",
-            CONNECTION_TIMES, (miliseconds / 10), start);
+            CONNECTION_TIMES, (milliseconds / 10), start);
     wolfSSL_CTX_free(ctx);
 }
 

--- a/IDE/Renesas/e2studio/Projects/tools/rsa_pss_sign.sh
+++ b/IDE/Renesas/e2studio/Projects/tools/rsa_pss_sign.sh
@@ -29,6 +29,6 @@ openssl dgst -sha256 -sign $1 -sigopt $SIGOPT -sigopt $SIGOPT2 -out $3.sign $3
 echo verify by private key
 openssl dgst -sha256 -prverify $1 -sigopt $SIGOPT -sigopt $SIGOPT2 -signature $3.sign $3
 
-echo verifiy by public key
+echo verify by public key
 openssl dgst -sha256 -verify $2 -sigopt $SIGOPT -sigopt $SIGOPT2 -signature $3.sign $3
 

--- a/IDE/Renesas/e2studio/RA6M3/README.md
+++ b/IDE/Renesas/e2studio/RA6M3/README.md
@@ -122,7 +122,7 @@ The following steps explain how to generate the missing files and where to place
 + Build wolfSSL_RA6M3.
 
 5.) Copy files from `dummy_app` into each executable projects\
-+ Select and Copy the followng folder inside dummy_app\
++ Select and Copy the following folder inside dummy_app\
 
   `script/`
 

--- a/IDE/Renesas/e2studio/RA6M3/README_APRA6M_en.md
+++ b/IDE/Renesas/e2studio/RA6M3/README_APRA6M_en.md
@@ -106,7 +106,7 @@ The following steps explain how to generate the missing files and where to place
 6.) Copy files from `dummy_app` into `./IDE/Renesas/e2studio/RA6M3/common/ra6m3g/`
     **NOTE:** This may need to be done outside of the e2studio environment (e.g. File Explorer).
 
-+ Select and Copy the followng folder inside dummy_app
++ Select and Copy the following folder inside dummy_app
 
     `src/`  
     `script/`

--- a/IDE/Renesas/e2studio/RA6M4/README.md
+++ b/IDE/Renesas/e2studio/RA6M4/README.md
@@ -102,7 +102,7 @@ The wolfssl Project Summary is listed below and is relevant for every project.
 + Enter `dummy_application` as the project name. Click Next.
 + Under `RA library project`, select `wolfSSL_RA6M4`.
 + Click Finish.
-+ Copy the followng folder and file at `dummy_application` to `test_RA6M4`\
++ Copy the following folder and file at `dummy_application` to `test_RA6M4`\
   script/\
   src/sce_tst_thread_entry.c
   
@@ -136,7 +136,7 @@ The wolfssl Project Summary is listed below and is relevant for every project.
     you can specify "RTT control block" to 0x20020000 0x10000 by Search Range
   
 ## Run Client
-1.) Enable TLS_CLIENT definition in wolfssl_demo.h of test_RA6M4 projet
+1.) Enable TLS_CLIENT definition in wolfssl_demo.h of test_RA6M4 project
 
 2.) Client IP address and Server IP address
 
@@ -233,7 +233,7 @@ You will see the following message on J-LinK RTT Viewer when using ECDSA sign an
 
 
 ### Run Multi Client Session example
-1.) Enable TLS_CLIENT and TLS_MULTITHREAD_TEST definition in wolfssl_demo.h of test_RA6M4 projet
+1.) Enable TLS_CLIENT and TLS_MULTITHREAD_TEST definition in wolfssl_demo.h of test_RA6M4 project
 
 2.) Follow [Run Client](#run-client) instruction 
 

--- a/IDE/Renesas/e2studio/RA6M4/test/key_data/key_data.h
+++ b/IDE/Renesas/e2studio/RA6M4/test/key_data/key_data.h
@@ -3,7 +3,7 @@
 
 #include "r_sce.h"
 
-/** Firmware update data and user key datas */
+/** Firmware update data and user key data */
 typedef struct user_key_block_data
 {
     /* Provisioning key wapped by Renesas DLM */

--- a/IDE/Renesas/e2studio/RX65N/GR-ROSE/common/user_settings.h
+++ b/IDE/Renesas/e2studio/RX65N/GR-ROSE/common/user_settings.h
@@ -150,7 +150,7 @@
   * -- "NO_ASN_TIME" macro is to avoid certificate expiration validation --
   *  
   * Note. In your actual products, do not forget to comment-out 
-  * "NO_ASN_TIME" macro. And prepare time function to get calender time,
+  * "NO_ASN_TIME" macro. And prepare time function to get calendar time,
   * otherwise, certificate expiration validation will not work.  
   */
   /*#define NO_ASN_TIME*/

--- a/IDE/Renesas/e2studio/RX65N/GR-ROSE/test/src/wolf_client.c
+++ b/IDE/Renesas/e2studio/RX65N/GR-ROSE/test/src/wolf_client.c
@@ -136,13 +136,13 @@ void wolfSSL_TLS_client_init(const char* cipherlist)
 
     if ((client_ctx = wolfSSL_CTX_new_ex(wolfSSLv23_client_method_ex(heapHint),
                                                       heapHint)) == NULL) {
-        printf("ERROR: faild to create WOLFSSL_CTX\n");
+        printf("ERROR: failed to create WOLFSSL_CTX\n");
         return;                                                
     }
 
     if ((wolfSSL_CTX_load_static_memory(&client_ctx, NULL, heapBufIO,
                 sizeof(heapBufIO), WOLFMEM_IO_POOL, 10)) != WOLFSSL_SUCCESS) {
-        printf("ERROR: faild to set static memory for IO\n");
+        printf("ERROR: failed to set static memory for IO\n");
         return;
     }
 

--- a/IDE/Renesas/e2studio/RX65N/RSK/wolfssl_demo/user_settings.h
+++ b/IDE/Renesas/e2studio/RX65N/RSK/wolfssl_demo/user_settings.h
@@ -149,7 +149,7 @@
   * -- "NO_ASN_TIME" macro is to avoid certificate expiration validation --
   *  
   * Note. In your actual products, do not forget to comment-out 
-  * "NO_ASN_TIME" macro. And prepare time function to get calender time,
+  * "NO_ASN_TIME" macro. And prepare time function to get calendar time,
   * otherwise, certificate expiration validation will not work.  
   */
   /*#define NO_ASN_TIME*/

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/Simple/README_EN.md
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/Simple/README_EN.md
@@ -114,14 +114,14 @@ Now that the test application is ready to build.
 ## 7. Running test application as Client
 -----
 ### 7.1 Run Client as TCP
-When it enables SIMPLE_TCP_CLIENT, we can run TCP clint on the board. We are able to use [this TCP server allication](https://github.com/wolfSSL/wolfssl-examples/blob/master/tls/server-tcp.c) as the opposite TCP server. To complie and run the server,
+When it enables SIMPLE_TCP_CLIENT, we can run TCP clint on the board. We are able to use [this TCP server allication](https://github.com/wolfSSL/wolfssl-examples/blob/master/tls/server-tcp.c) as the opposite TCP server. To compile and run the server,
 ```
 $ gcc server-tcp.c -o server-tcp
 $ ./server-tcp
 ```
 
 If needed, it updates server IP address and port. Those are defined by `SIMPLE_TCPSERVER_IP` and `SIMPLE_TCPSERVER_PORT` in `test/src/simple_tcp.c`
-You will see messages on Reneas Virtual Console when its communication succedes.
+You will see messages on Reneas Virtual Console when its communication succeeds.
 
 ```
 Received : I hear ya fa shizzle!
@@ -140,7 +140,7 @@ Waiting for a connection...
 When it enables SIMPLE_TLS_CLIENT, we can run TLS client on the board.If needed, it updates server IP address and port. Those are defined by `SIMPLE_TLSSERVER_IP` and `SIMPLE_TLSSERVER_PORT` in `test/src/simple_tls_tsip.c`. After changing it, you need to re-compile test project.
 
 
-As the opposite TLS server, we can use an example server in wolfSSL soure tree. To configure and build it,
+As the opposite TLS server, we can use an example server in wolfSSL source tree. To configure and build it,
 
 ```
 $ cd <wolfssl-folder>
@@ -159,7 +159,7 @@ Therefore, for an example server, it needs to specify ECC certificate correspond
 ./examples/server/server -v 4 -b -i -c ./certs/server-ecc.pem -k ./certs/ecc-key.pem -A ./certs/client-ecc-cert.pem
 ```
 
-You will see messages on Renesas Debug Virtual Consol
+You will see messages on Renesas Debug Virtual Console
 ```
 cipher : TLS13-AES128-GCM-SHA256
 Received: I hear you fa shizzle!
@@ -243,7 +243,7 @@ When you want to run test project by TLS 1.3, it enables `#define WOLFSSL_TLS13`
 ## 8. Running test application as Server
 
 ### 8.1 Run Server as TCP Server
-When it enables `SIMPLE_TCP_SERVER`, we can run TCP server on the board. We are able to use [this TCP client](https://github.com/wolfSSL/wolfssl-examples/blob/master/tls/client-tcp.c) as the opposite TCP client. To complie and run the server,
+When it enables `SIMPLE_TCP_SERVER`, we can run TCP server on the board. We are able to use [this TCP client](https://github.com/wolfSSL/wolfssl-examples/blob/master/tls/client-tcp.c) as the opposite TCP client. To compile and run the server,
 
 ```
 $ gcc client-tcp.c -o client-tcp

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/Simple/README_JP.md
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/Simple/README_JP.md
@@ -237,7 +237,7 @@ $ ./configure CFLAGS="-DWOLFSSL_STATIC_RSA"
 $ ./examples/server/server -b -i
 ```
 
-実行すると、下記のようなメッセージがRenesas Debug Virtual Consol に表示されます。
+実行すると、下記のようなメッセージがRenesas Debug Virtual Console に表示されます。
 
 ```
 cipher : ECDHE-RSA-AES128-GCM-SHA256
@@ -298,7 +298,7 @@ SSL curve name is SECP256R1
 hello wolfssl!
 ```
 
-Renesas Debug Virtual Consol に下記のように表示されていれば、ボード上の TLS サーバーとクライアント間でTLS通信が行われています。
+Renesas Debug Virtual Console に下記のように表示されていれば、ボード上の TLS サーバーとクライアント間でTLS通信が行われています。
 ```
 Received: hello wolfssl!
 ```

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/user_settings.h
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/user_settings.h
@@ -162,7 +162,7 @@
   * -- "NO_ASN_TIME" macro is to avoid certificate expiration validation --
   *  
   * Note. In your actual products, do not forget to comment-out 
-  * "NO_ASN_TIME" macro. And prepare time function to get calender time,
+  * "NO_ASN_TIME" macro. And prepare time function to get calendar time,
   * otherwise, certificate expiration validation will not work.  
   */
   /*#define NO_ASN_TIME*/

--- a/IDE/STARCORE/starcore_test.c
+++ b/IDE/STARCORE/starcore_test.c
@@ -293,7 +293,7 @@ int testharness_main()
         process_a_file(strcat(path, "AES_CBC_47242.json")); // Failed to allocate buffer large enough for file, fixed by chopping into smaller sections
         process_a_file(strcat(path, "AES_CCM_47247.json")); // Failed, increase stack/heap
         process_a_file(strcat(path, "AES_CCM_47247-part1.json")); // Failed to write out the entire response (got 104 of 370 tgId's in the response)
-        process_a_file(strcat(path, "AES_CCM_47247-part2.json")); // Failed ot write out the entire response (started at 371 and got to 429 of 741 tgId's in the response) looks like alloc failures, increase HEAP
+        process_a_file(strcat(path, "AES_CCM_47247-part2.json")); // Failed to write out the entire response (started at 371 and got to 429 of 741 tgId's in the response) looks like alloc failures, increase HEAP
         process_a_file(strcat(path, "DSA_keyGen_47253.json")); // Success
         process_a_file(strcat(path, "RSA_DecPrim_47306.json")); // Success
         process_a_file(strcat(path, "ECDSA_sigVer_47258.json")); // Success

--- a/IDE/STARCORE/user_settings.h
+++ b/IDE/STARCORE/user_settings.h
@@ -39,7 +39,7 @@ extern "C" {
 #undef WOLFSSL_STARCORE
 #define WOLFSSL_STARCORE
 
-/* Endianess */
+/* Endianness */
 #undef BIG_ENDIAN_ORDER
 #define BIG_ENDIAN_ORDER
 
@@ -204,7 +204,7 @@ extern "C" {
         #else
             #undef ALT_ECC_SIZE
             #define ALT_ECC_SIZE
-            /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overriden */
+            /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overridden */
             /* #undef FP_MAX_BITS_ECC */
             /* #define FP_MAX_BITS_ECC (256 * 2) */
         #endif

--- a/IDE/STM32Cube/main.c
+++ b/IDE/STM32Cube/main.c
@@ -142,7 +142,7 @@ static void SystemClock_Config(void)
     */
     __HAL_RCC_PWR_CLK_ENABLE();
     __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
-    /** Initializes the CPU, AHB and APB busses clocks 
+    /** Initializes the CPU, AHB and APB buses clocks 
     */
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI|RCC_OSCILLATORTYPE_LSI;
     RCC_OscInitStruct.HSIState = RCC_HSI_ON;
@@ -157,7 +157,7 @@ static void SystemClock_Config(void)
     if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
         Error_Handler();
     }
-    /** Initializes the CPU, AHB and APB busses clocks 
+    /** Initializes the CPU, AHB and APB buses clocks 
     */
     RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK|RCC_CLOCKTYPE_SYSCLK|RCC_CLOCKTYPE_PCLK1|RCC_CLOCKTYPE_PCLK2;
     RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;

--- a/IDE/WINCE/user_settings.h
+++ b/IDE/WINCE/user_settings.h
@@ -187,7 +187,7 @@
             #else
                 #undef  ALT_ECC_SIZE
                 #define ALT_ECC_SIZE
-                /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overriden */
+                /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overridden */
                 //#undef  FP_MAX_BITS_ECC
                 //#define FP_MAX_BITS_ECC (256 * 2)
             #endif

--- a/IDE/XCODE-FIPSv2/macOS-C++/Intel/user_settings.h
+++ b/IDE/XCODE-FIPSv2/macOS-C++/Intel/user_settings.h
@@ -194,7 +194,7 @@ extern "C" {
         #else
             #undef  ALT_ECC_SIZE
             #define ALT_ECC_SIZE
-            /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overriden */
+            /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overridden */
             //#undef  FP_MAX_BITS_ECC
             //#define FP_MAX_BITS_ECC (256 * 2)
         #endif

--- a/IDE/XCODE-FIPSv2/macOS-C++/M1/user_settings.h
+++ b/IDE/XCODE-FIPSv2/macOS-C++/M1/user_settings.h
@@ -205,7 +205,7 @@ extern "C" {
         #else
             #undef  ALT_ECC_SIZE
             #define ALT_ECC_SIZE
-            /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overriden */
+            /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overridden */
             //#undef  FP_MAX_BITS_ECC
             //#define FP_MAX_BITS_ECC (256 * 2)
         #endif

--- a/IDE/XCODE-FIPSv2/user_settings.h
+++ b/IDE/XCODE-FIPSv2/user_settings.h
@@ -205,7 +205,7 @@ extern "C" {
         #else
             #undef  ALT_ECC_SIZE
             #define ALT_ECC_SIZE
-            /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overriden */
+            /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overridden */
             //#undef  FP_MAX_BITS_ECC
             //#define FP_MAX_BITS_ECC (256 * 2)
         #endif

--- a/IDE/XCODE-FIPSv5/user_settings.h
+++ b/IDE/XCODE-FIPSv5/user_settings.h
@@ -223,7 +223,7 @@ extern "C" {
         #else
             #undef  ALT_ECC_SIZE
             #define ALT_ECC_SIZE
-            /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overriden */
+            /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overridden */
             //#undef  FP_MAX_BITS_ECC
             //#define FP_MAX_BITS_ECC (256 * 2)
         #endif

--- a/IDE/XilinxSDK/README.md
+++ b/IDE/XilinxSDK/README.md
@@ -70,7 +70,7 @@ This shows the necessary steps on the basis of using the VMK180 development boar
 2. Repeat the same steps of the previous step 3 for the newly created domain.
    - In the tree-view select "freertos10_xilinx" and then open the "kernel_behavior" sub-entry.
    - Change `minimal_stack_size` to `8000`, `tick_rate` to `1000` and `total_heap_size` to `8388608`. "Big chunk sizes" have not been tested under FreeRTOS.
-3. Repeat the same steps of the preivous steps 4 to 6, but with the `wolfCrypt_FreeRTOS_example` resp. `wolfCrypt_FreeRTOS_example_system`.
+3. Repeat the same steps of the previous steps 4 to 6, but with the `wolfCrypt_FreeRTOS_example` resp. `wolfCrypt_FreeRTOS_example_system`.
 
 
 ## Troubleshooting

--- a/IDE/XilinxSDK/graph.sh
+++ b/IDE/XilinxSDK/graph.sh
@@ -66,7 +66,7 @@ aad_sizes["default"]="16 Bytes"
 
 # not pretty but works for me :)
 # CBC&GCM encryption is in software a lot faster than decryption,
-# therefor use the same Range on the Y-Axis to also have a visual indication.
+# therefore use the same Range on the Y-Axis to also have a visual indication.
 # This will break if something changes, so let the user override the value
 cbc_yrange="${cbc_yrange:=1400}"
 gcm_yrange="${gcm_yrange:=500}"

--- a/SCRIPTS-LIST
+++ b/SCRIPTS-LIST
@@ -1,7 +1,7 @@
 autogen.sh - creates ./configure from source checkout, sets up git hooks
 
 pre-commit.sh - our pre commit hook, saves current state before running commit
-                tests to allow a resotre back to current state
+                tests to allow a restore back to current state
 
 commit-tests.sh - our commit tests, must pass before a commit is accepted, use
                   -n (--no-verify) to disable

--- a/doc/check_api.sh
+++ b/doc/check_api.sh
@@ -21,7 +21,7 @@ while read h_file; do
         api_count="$(wc -l < dox_api.txt)"
         match_count="$(grep -Ff dox_api.txt wolf_api.txt | wc -l)"
         if [ "$api_count" != "$match_count" ]; then
-            echo "Mistmatch"
+            echo "Mismatch"
             echo "Dox_api: $api_count"
             echo "Matched_api: $match_count"
             echo "Header file: $h_file"

--- a/doc/dox_comments/header_files-ja/doxygen_groups.h
+++ b/doc/dox_comments/header_files-ja/doxygen_groups.h
@@ -220,7 +220,7 @@
     key operations and reducing the attack surface by restricting access to certificate and keys
     to the SIM.
 
-    IoT-Safe support can be enabled on an existing WOLFSSL_CTX contex, using wolfSSL_CTX_iotsafe_enable().\n
+    IoT-Safe support can be enabled on an existing WOLFSSL_CTX context, using wolfSSL_CTX_iotsafe_enable().\n
     Session created within the context can set the parameters for IoT-Safe key and files usage, and enable
     the public keys callback, with wolfSSL_iotsafe_on().
 

--- a/doc/dox_comments/header_files/asn_public.h
+++ b/doc/dox_comments/header_files/asn_public.h
@@ -2110,7 +2110,7 @@ int wc_SetCustomExtension(Cert *cert, int critical, const char *oid,
     _Example_
     \code
     int ret = 0;
-    // Unkown extension callback prototype
+    // Unknown extension callback prototype
     int myUnknownExtCallback(const word16* oid, word32 oidSz, int crit,
                              const unsigned char* der, word32 derSz);
 

--- a/doc/dox_comments/header_files/cmac.h
+++ b/doc/dox_comments/header_files/cmac.h
@@ -6,7 +6,7 @@
     \param key key pointer
     \param keySz size of the key pointer (16, 24 or 32)
     \param type Always WC_CMAC_AES = 1
-    \param unused not used, exists for potential future use around compatiblity
+    \param unused not used, exists for potential future use around compatibility
 
     _Example_
     \code
@@ -36,7 +36,7 @@ int wc_InitCmac(Cmac* cmac,
     \param key key pointer
     \param keySz size of the key pointer (16, 24 or 32)
     \param type Always WC_CMAC_AES = 1
-    \param unused not used, exists for potential future use around compatiblity
+    \param unused not used, exists for potential future use around compatibility
     \param heap pointer to the heap hint used for dynamic allocation. Typically used with our static memory option. Can be NULL.
     \param devId ID to use with async hardware. Set to INVALID_DEVID if not using async hardware.
 
@@ -100,7 +100,7 @@ int wc_CmacFinal(Cmac* cmac,
 
 /*!
     \ingroup CMAC
-    \brief Single shot fuction for generating a CMAC
+    \brief Single shot function for generating a CMAC
     \return 0 on success
     \param out pointer to return the result
     \param outSz pointer size of output (in/out)
@@ -122,7 +122,7 @@ int wc_AesCmacGenerate(byte* out, word32* outSz,
 
 /*!
     \ingroup CMAC
-    \brief Single shot fuction for validating a CMAC
+    \brief Single shot function for validating a CMAC
     \return 0 on success
     \param check pointer to return the result
     \param checkSz size of checkout buffer

--- a/doc/dox_comments/header_files/doxygen_groups.h
+++ b/doc/dox_comments/header_files/doxygen_groups.h
@@ -221,7 +221,7 @@
     key operations and reducing the attack surface by restricting access to certificate and keys
     to the SIM.
 
-    IoT-Safe support can be enabled on an existing WOLFSSL_CTX contex, using wolfSSL_CTX_iotsafe_enable().\n
+    IoT-Safe support can be enabled on an existing WOLFSSL_CTX context, using wolfSSL_CTX_iotsafe_enable().\n
     Session created within the context can set the parameters for IoT-Safe key and files usage, and enable
     the public keys callback, with wolfSSL_iotsafe_on().
 

--- a/doc/dox_comments/header_files/ed25519.h
+++ b/doc/dox_comments/header_files/ed25519.h
@@ -950,7 +950,7 @@ int wc_ed25519_export_key(ed25519_key* key,
 
     \return 0 Returned if the private and public key matched.
     \return BAD_FUNC_ARG Returned if the given key is NULL.
-    \return PUBLIC_KEY_E Returned if the no public key availble or is invalid.
+    \return PUBLIC_KEY_E Returned if the no public key available or is invalid.
 
     \param [in] key Pointer to an ed25519_key structure holding a private and
     public key.

--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -1645,7 +1645,7 @@ int wolfSSL_use_certificate_chain_file(WOLFSSL* ssl, const char *file);
     \param file a pointer to the name of the file containing the RSA private
     key to be loaded into the wolfSSL SSL session, with format as specified
     by format.
-    \parm format the encoding type of the RSA private key specified by file.
+    \param format the encoding type of the RSA private key specified by file.
     Possible values include SSL_FILETYPE_PEM and SSL_FILETYPE_ASN1.
 
     _Example_
@@ -7084,7 +7084,7 @@ int  wolfSSL_SetTmpDH_file(WOLFSSL* ssl, const char* f, int format);
     to MAX_DH_SIZE.
     \param g a constant unsigned char pointer loaded into the buffer
     member of the serverDH_G struct.
-    \param gSz an int type representing the size of g, initialized ot
+    \param gSz an int type representing the size of g, initialized to
     MAX_DH_SIZE.
 
     _Exmaple_
@@ -13157,7 +13157,7 @@ int  wolfSSL_connect(WOLFSSL* ssl);
     exchange. Please note that when using protocol DTLS v1.3, the cookie
     exchange is enabled by default. The Cookie holds a hash of the current
     transcript so that another server process can handle the ClientHello in
-    reply.  The secret is used when generting the integrity check on the Cookie
+    reply.  The secret is used when generating the integrity check on the Cookie
     data.
 
     \param [in,out] ssl a pointer to a WOLFSSL structure, created using wolfSSL_new().
@@ -13168,7 +13168,7 @@ int  wolfSSL_connect(WOLFSSL* ssl);
 
     \return BAD_FUNC_ARG if ssl is NULL or not using TLS v1.3.
     \return SIDE_ERROR if called with a client.
-    \return WOLFSSL_SUCCESS if succesful.
+    \return WOLFSSL_SUCCESS if successful.
     \return MEMORY_ERROR if allocating dynamic memory for storing secret failed.
     \return Another -ve value on internal error.
 
@@ -13326,7 +13326,7 @@ int  wolfSSL_no_dhe_psk(WOLFSSL* ssl);
     \brief This function is called on a TLS v1.3 client or server wolfSSL to
     force the rollover of keys. A KeyUpdate message is sent to the peer and
     new keys are calculated for encryption. The peer will send back a KeyUpdate
-    message and the new decryption keys wil then be calculated.
+    message and the new decryption keys will then be calculated.
     This function can only be called after a handshake has been completed.
 
     \param [in,out] ssl a pointer to a WOLFSSL structure, created using wolfSSL_new().
@@ -13391,7 +13391,7 @@ int  wolfSSL_key_update_response(WOLFSSL* ssl, int* required);
     \ingroup Setup
 
     \brief This function is called on a TLS v1.3 client wolfSSL context to allow
-    a client certifcate to be sent post handshake upon request from server.
+    a client certificate to be sent post handshake upon request from server.
     This is useful when connecting to a web server that has some pages that
     require client authentication and others that don't.
 
@@ -13422,7 +13422,7 @@ int  wolfSSL_CTX_allow_post_handshake_auth(WOLFSSL_CTX* ctx);
     \ingroup Setup
 
     \brief This function is called on a TLS v1.3 client wolfSSL to allow
-    a client certifcate to be sent post handshake upon request from server.
+    a client certificate to be sent post handshake upon request from server.
     A Post-Handshake Client Authentication extension is sent in the ClientHello.
     This is useful when connecting to a web server that has some pages that
     require client authentication and others that don't.
@@ -13612,7 +13612,7 @@ int  wolfSSL_preferred_group(WOLFSSL* ssl);
 
     \param [in,out] ctx a pointer to a WOLFSSL_CTX structure, created
     with wolfSSL_CTX_new().
-    \param [in] groups a list of key exhange groups by identifier.
+    \param [in] groups a list of key exchange groups by identifier.
     \param [in] count the number of key exchange groups in groups.
 
     \return BAD_FUNC_ARG if a pointer parameter is null, the number of groups
@@ -13654,7 +13654,7 @@ int  wolfSSL_CTX_set_groups(WOLFSSL_CTX* ctx, int* groups,
     use with the TLS v1.3 connections.
 
     \param [in,out] ssl a pointer to a WOLFSSL structure, created using wolfSSL_new().
-    \param [in] groups a list of key exhange groups by identifier.
+    \param [in] groups a list of key exchange groups by identifier.
     \param [in] count the number of key exchange groups in groups.
 
     \return BAD_FUNC_ARG if a pointer parameter is null, the number of groups

--- a/examples/asn1/asn1.c
+++ b/examples/asn1/asn1.c
@@ -227,7 +227,7 @@ static int FindPem(unsigned char* data, word32 offset, word32 len,
     }
 
     if (ret == 0) {
-        /* Return start and end indeces. */
+        /* Return start and end indices. */
         *start = i;
         *end = j;
     }

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -285,7 +285,7 @@ static void ShowVersions(void)
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_EITHER_SIDE)
     XSTRNCAT(verStr, "e(either):", 11);
 #endif
-    /* print all stings at same time on stdout to avoid any flush issues */
+    /* print all strings at same time on stdout to avoid any flush issues */
     printf("%s\n", verStr);
 }
 

--- a/examples/configs/user_settings_template.h
+++ b/examples/configs/user_settings_template.h
@@ -184,7 +184,7 @@ extern "C" {
             /* use heap allocation for ECC points */
             #define ALT_ECC_SIZE
 
-            /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overriden */
+            /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overridden */
             //#define FP_MAX_BITS_ECC (256 * 2)
         #endif
 

--- a/examples/pem/pem.c
+++ b/examples/pem/pem.c
@@ -647,7 +647,7 @@ const char* usage[] = {
     "  -out             name of file to write to (uses stdout otherwise)",
     "  -o --offset      offset into file where data to convert starts",
 #if defined(WOLFSSL_ENCRYPTED_KEYS) && !defined(NO_PWDBASED)
-    "  -p --pass        password to use wih enncrypted keys",
+    "  -p --pass        password to use with encrypted keys",
 #endif
 #ifdef WOLFSSL_DER_TO_PEM
     "  -d --der         input is DER and output is PEM",

--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -372,7 +372,7 @@ mkdir -p $RPM_BUILD_ROOT/
 * Thu May 31 2018 John Safranek <john@wolfssl.com>
 - Update the version number on the library SO file.
 * Fri Mar 02 2018 Jacob Barthelmeh <jacob@wolfssl.com>
-- Added headder files fips.h, buffer.h, objects.h, rc4.h and example tls_bench.c
+- Added header files fips.h, buffer.h, objects.h, rc4.h and example tls_bench.c
 * Fri Sep 08 2017 Jacob Barthelmeh <jacob@wolfssl.com>
 - Change name for header wolfssl/io.h to wolfssl/wolfio.h
 * Fri Aug 04 2017 Jacob Barthelmeh <jacob@wolfssl.com>

--- a/scripts/makedistsmall.sh
+++ b/scripts/makedistsmall.sh
@@ -74,7 +74,7 @@ find . -name "*.vcxproj" -delete
 find . -name "*.vcproj" -delete
 find . -name "*.sln" -delete
 
-# TLS/Compatiblity layer
+# TLS/Compatibility layer
 #rm -rf ./src
 #rm -rf ./wolfssl/openssl
 

--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -2,7 +2,7 @@
 
 # openssl.test
 
-# Enviornment variables used:
+# Environment variables used:
 # OPENSSL            (openssl app to use)
 # OPENSSL_ENGINE_ID  (engine id if any i.e. "wolfengine")
 
@@ -490,7 +490,7 @@ IFS="$OIFS" #restore separator
 # Start OpenSSL servers
 #
 
-# Check for cerificate support in wolfSSL
+# Check for certificate support in wolfSSL
 wolf_certs=`$WOLFSSL_CLIENT -? 2>&1`
 case $wolf_certs in
 *"cert"*)

--- a/src/dtls.c
+++ b/src/dtls.c
@@ -1105,7 +1105,7 @@ int TLSX_ConnectionID_Use(WOLFSSL* ssl)
     /* CIDInfo needs to be accessed every time we send or receive a record. To
      * avoid the cost of the extension lookup save a pointer to the structure
      * inside the SSL object itself, and save a pointer to the SSL object in the
-     * extension. The extension freeing routine uses te pointer to the SSL
+     * extension. The extension freeing routine uses the pointer to the SSL
      * object to find the structure and to set ssl->dtlsCidInfo pointer to NULL
      * after freeing the structure. */
     ssl->dtlsCidInfo = info;

--- a/src/pk.c
+++ b/src/pk.c
@@ -10201,7 +10201,7 @@ int wolfSSL_EC_POINT_is_on_curve(const WOLFSSL_EC_GROUP *group,
 /* Convert Jacobian ordinates to affine.
  *
  * @param [in]      group  EC group.
- * @param [in]      point  EC point to get co-ordinates from.
+ * @param [in]      point  EC point to get coordinates from.
  * @return  1 on success.
  * @return  0 on error.
  */
@@ -10266,9 +10266,9 @@ static int ec_point_convert_to_affine(const WOLFSSL_EC_GROUP *group,
     return err;
 }
 
-/* Get the affine co-ordinates of the EC point on a Prime curve.
+/* Get the affine coordinates of the EC point on a Prime curve.
  *
- * When z-ordinate is not one then co-ordinates are Jacobian and need to be
+ * When z-ordinate is not one then coordinates are Jacobian and need to be
  * converted to affine before storing in BNs.
  *
  * Return code compliant with OpenSSL.
@@ -10276,7 +10276,7 @@ static int ec_point_convert_to_affine(const WOLFSSL_EC_GROUP *group,
  * TODO: OpenSSL doesn't change point when Jacobian. Do the same?
  *
  * @param [in]      group  EC group.
- * @param [in]      point  EC point to get co-ordinates from.
+ * @param [in]      point  EC point to get coordinates from.
  * @param [in, out] x      BN to hold x-ordinate.
  * @param [in, out] y      BN to hold y-ordinate.
  * @param [in]      ctx    Context to use for BN operations. Unused.
@@ -10330,10 +10330,10 @@ int wolfSSL_EC_POINT_get_affine_coordinates_GFp(const WOLFSSL_EC_GROUP* group,
 }
 #endif /* !WOLFSSL_SP_MATH && !WOLF_CRYPTO_CB_ONLY_ECC */
 
-/* Sets the affine co-ordinates that belong on a prime curve.
+/* Sets the affine coordinates that belong on a prime curve.
  *
  * @param [in]      group  EC group.
- * @param [in, out] point  EC point to set co-ordinates into.
+ * @param [in, out] point  EC point to set coordinates into.
  * @param [in]      x      BN holding x-ordinate.
  * @param [in]      y      BN holding y-ordinate.
  * @param [in]      ctx    Context to use for BN operations. Unused.
@@ -10387,7 +10387,7 @@ int wolfSSL_EC_POINT_set_affine_coordinates_GFp(const WOLFSSL_EC_GROUP* group,
         WOLFSSL_MSG("wolfSSL_BN_copy failed");
         ret = 0;
     }
-    /* z-ordinate is one for affine co-ordinates. */
+    /* z-ordinate is one for affine coordinates. */
     if ((ret == 1) && ((wolfSSL_BN_one(point->Z)) == 0)) {
         WOLFSSL_MSG("wolfSSL_BN_one failed");
         ret = 0;
@@ -10551,7 +10551,7 @@ static int wolfssl_ec_point_add(int curveIdx, ecc_point* r, ecc_point* p1,
         ret = 0;
     }
 
-    /* Map point back to affine co-ordinates. Converts from Montogomery form. */
+    /* Map point back to affine coordinates. Converts from Montogomery form. */
     if ((ret == 1) && (ecc_map(r, prime, mp) != MP_OKAY)) {
         WOLFSSL_MSG("ecc_map error");
         ret = 0;
@@ -10671,7 +10671,7 @@ static int ec_mul2add(ecc_point* r, ecc_point* b, mp_int* n, ecc_point* q,
         WOLFSSL_MSG("wc_ecc_mulmod nqm error");
         ret = 0;
     }
-    /* Map point back to affine co-ordinates. Converts from Montogomery
+    /* Map point back to affine coordinates. Converts from Montogomery
      * form. */
     if ((ret == 1) && (ecc_map(r, prime, mp) != MP_OKAY)) {
         WOLFSSL_MSG("ecc_map nqm error");

--- a/src/ssl_asn1.c
+++ b/src/ssl_asn1.c
@@ -1139,7 +1139,7 @@ int wolfSSL_i2a_ASN1_INTEGER(BIO *bp, const WOLFSSL_ASN1_INTEGER *a)
  * @param [in]       len     Length of number in bytes.
  * @param [in, out]  neg     Indicates number is negative.
  * @param [out]      pad     Number of padding bytes required.
- * @param [out]      padVal  Padding byte to preprend.
+ * @param [out]      padVal  Padding byte to prepend.
  */
 static void wolfssl_asn1_integer_pad(unsigned char* data, int len,
     unsigned char* neg, char* pad, unsigned char* padVal)
@@ -2316,7 +2316,7 @@ int wolfSSL_ASN1_STRING_to_UTF8(unsigned char **out, WOLFSSL_ASN1_STRING *asn1)
  * Assumes length is greater than 0.
  *
  * @param [in] s  ASN.1 STRING object.
- * @return  Buffer cotaining string representation on success.
+ * @return  Buffer containing string representation on success.
  * @return  NULL when dynamic memory allocation fails.
  * @return  NULL when encoding a character as hex fails.
  */

--- a/src/tls.c
+++ b/src/tls.c
@@ -9502,7 +9502,7 @@ static int TLSX_PreSharedKey_Write(PreSharedKey* list, byte* output,
         word16 len;
         int ret;
 
-        /* Write identites only. Binders after HMACing over this. */
+        /* Write identities only. Binders after HMACing over this. */
         lenIdx = idx;
         idx += OPAQUE16_LEN;
         while (current != NULL) {
@@ -9519,7 +9519,7 @@ static int TLSX_PreSharedKey_Write(PreSharedKey* list, byte* output,
 
             current = current->next;
         }
-        /* Length of the identites. */
+        /* Length of the identities. */
         len = idx - lenIdx - OPAQUE16_LEN;
         c16toa(len, output + lenIdx);
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -77,7 +77,7 @@
  *    Requires client to set a client certificate
  * WOLFSSL_PSK_MULTI_ID_PER_CS
  *    When multiple PSK identities are available for the same cipher suite.
- *    Sets the first byte of the client identity to the count of identites
+ *    Sets the first byte of the client identity to the count of identities
  *    that have been seen so far for the cipher suite.
  * WOLFSSL_CHECK_SIG_FAULTS
  *    Verifies the ECC signature after signing in case of faults in the

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -656,7 +656,7 @@ int EmbedSendTo(WOLFSSL* ssl, char *buf, int sz, void *ctx)
         peerSz = dtlsCtx->peer.sz;
 #ifndef WOLFSSL_IPV6
         if (PeerIsIpv6(peer, peerSz)) {
-            WOLFSSL_MSG("ipv6 dtls peer setted but no ipv6 support compiled");
+            WOLFSSL_MSG("ipv6 dtls peer set but no ipv6 support compiled");
             return NOT_COMPILED_IN;
         }
 #endif

--- a/tests/api.c
+++ b/tests/api.c
@@ -4770,7 +4770,7 @@ static int test_wolfSSL_EVP_DecodeUpdate(void)
                 &outl),
             1                    /* expected result code 1: success */
             );
-        ExpectIntEQ(outl, 0);   /* expected DecodeFinal outout no data */
+        ExpectIntEQ(outl, 0);   /* expected DecodeFinal output no data */
 
         ExpectIntEQ(XSTRNCMP( (const char*)plain2,(const char*)decOutBuff,
                               sizeof(plain2) -1 ),0);
@@ -6577,7 +6577,7 @@ static void test_client_reuse_WOLFSSLobj(void* args, cbType cb,
     if (ssl == NULL) {
         goto done;
     }
-    /* keep handshakre resources for re-using WOLFSSL obj */
+    /* keep handshake resources for re-using WOLFSSL obj */
     wolfSSL_KeepArrays(ssl);
     if (wolfSSL_KeepHandshakeResources(ssl)) {
         /* err_sys("SSL_KeepHandshakeResources failed"); */
@@ -7284,7 +7284,7 @@ static int test_wolfSSL_reuse_WOLFSSLobj(void)
 #if defined(OPENSSL_EXTRA) && !defined(NO_SESSION_CACHE) && \
     !defined(WOLFSSL_NO_TLS12)
     /* The unit test for session resumption by re-using WOLFSSL object.
-     * WOLFSSL object is not cleared after first session. It re-use the obeject
+     * WOLFSSL object is not cleared after first session. It re-use the object
      * for second connection.
     */
     tcp_ready ready;
@@ -7517,7 +7517,7 @@ static int test_wolfSSL_CTX_set_cipher_list(void)
     ExpectTrue(wolfSSL_CTX_set_cipher_list(ctxClient, "ECDHE+AESGCM"));
     ExpectNotNull((sslClient = wolfSSL_new(ctxClient)));
 
-    /* check for the existance of an ECDHE ECDSA cipher suite */
+    /* check for the existence of an ECDHE ECDSA cipher suite */
     if (EXPECT_SUCCESS()) {
         int i = 0;
         int found = 0;
@@ -7968,7 +7968,7 @@ static int twcase_cache_intOff_extOff(WOLFSSL_CTX* ctx)
             WOLFSSL_SESS_CACHE_NO_INTERNAL_STORE,
             WOLFSSL_SESS_CACHE_NO_INTERNAL_STORE);
 #endif
-    /* off - Donot setup external cache */
+    /* off - Do not setup external cache */
 
     /* Require both peers to provide certs */
     wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_PEER, NULL);
@@ -7977,8 +7977,8 @@ static int twcase_cache_intOff_extOff(WOLFSSL_CTX* ctx)
 
 static int twcase_cache_intOn_extOff(WOLFSSL_CTX* ctx)
 {
-    /* on - internal cache is on by default*/
-    /* off - Donot setup external cache */
+    /* on - internal cache is on by default */
+    /* off - Do not setup external cache */
     /* Require both peers to provide certs */
     wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_PEER, NULL);
     return TEST_SUCCESS;
@@ -9551,7 +9551,7 @@ static int test_wolfSSL_SNI_GetFromBuffer(void)
 
     byte buff5[] = { /* SSL v2.0 client hello */
         0x00, 0x2b, 0x01, 0x03, 0x01, 0x00, 0x09, 0x00, 0x00,
-        /* dummy bytes bellow, just to pass size check */
+        /* dummy bytes below, just to pass size check */
         0xb6, 0x03, 0x03, 0x83, 0xa3, 0xe6, 0xdc, 0x16, 0xa1, 0x43, 0xe9, 0x45,
         0x15, 0xbd, 0x64, 0xa9, 0xb6, 0x07, 0xb4, 0x50, 0xc6, 0xdd, 0xff, 0xc2,
         0xd3, 0x0d, 0x4f, 0x36, 0xb4, 0x41, 0x51, 0x61, 0xc1, 0xa5, 0x9e, 0x00,
@@ -10811,7 +10811,7 @@ static int test_wolfSSL_PKCS12(void)
     ExpectNull(pkey);
     ExpectNull(cert);
 
-    /* check parse iwth not extra certs kept */
+    /* check parse with not extra certs kept */
     ExpectIntEQ(ret = PKCS12_parse(pkcs12, "wolfSSL test", &pkey, &cert, NULL),
         WOLFSSL_SUCCESS);
     ExpectNotNull(pkey);
@@ -12320,7 +12320,7 @@ static int test_wc_Sha512Update(void)
 #ifdef WOLFSSL_SHA512
 #if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST) && \
         (!defined(WOLFSSL_NOSHA512_224) || !defined(WOLFSSL_NOSHA512_256))
-/* Perfoms test for
+/* Performs test for
  * - wc_Sha512Final/wc_Sha512FinalRaw
  * - wc_Sha512_224Final/wc_Sha512_224Final
  * - wc_Sha512_256Final/wc_Sha512_256Final
@@ -15520,7 +15520,7 @@ static int test_wc_Chacha_Process(void)
     word32      keySz = sizeof(key)/sizeof(byte);
     unsigned long int inlen = XSTRLEN(input);
 
-    /* Initialize stack varialbes.*/
+    /* Initialize stack variables. */
     XMEMSET(cipher, 0, 128);
     XMEMSET(plain, 0, 128);
 
@@ -19259,7 +19259,7 @@ static int test_wc_curve25519_export_key_raw_ex(void)
     ExpectIntEQ(wc_curve25519_export_key_raw_ex(&key, privateKey,
         &prvkSz, publicKey, NULL, EC25519_BIG_ENDIAN), BAD_FUNC_ARG);
 
-    /* illegal value for endien */
+    /* illegal value for endian */
     prvkSz = CURVE25519_KEYSIZE;
     /* pubkSz = CURVE25519_KEYSIZE; */
     ExpectIntEQ(wc_curve25519_export_key_raw_ex(&key, privateKey, &prvkSz,
@@ -25937,7 +25937,7 @@ static int test_wolfSSL_a2i_ASN1_INTEGER(void)
 
     ExpectNotNull(fixed = BIO_new(wolfSSL_BIO_s_fixed_mem()));
     ExpectIntEQ(BIO_set_write_buf_size(fixed, 1), 1);
-    /* Ensure there is 0 bytes avaialble to write into. */
+    /* Ensure there is 0 bytes available to write into. */
     ExpectIntEQ(BIO_write(fixed, tmp, 1), 1);
     ExpectIntEQ(i2a_ASN1_INTEGER(fixed, ai), 0);
     ExpectIntEQ(BIO_set_write_buf_size(fixed, 1), 1);
@@ -26707,7 +26707,7 @@ static int test_wolfSSL_ASN1_STRING_print(void)
 
     ExpectNotNull(bio = BIO_new(wolfSSL_BIO_s_fixed_mem()));
     ExpectIntEQ(BIO_set_write_buf_size(bio, 1), 1);
-    /* Ensure there is 0 bytes avaialble to write into. */
+    /* Ensure there is 0 bytes available to write into. */
     ExpectIntEQ(BIO_write(bio, rbuf, 1), 1);
     ExpectIntEQ(wolfSSL_ASN1_STRING_print(bio, asnStr), 0);
     ExpectIntEQ(BIO_set_write_buf_size(bio, 1), 1);
@@ -26769,7 +26769,7 @@ static int test_wolfSSL_ASN1_STRING_print_ex(void)
     ExpectIntEQ(BIO_read(bio, (void*)rbuf, 15), 15);
     ExpectStrEQ((char*)rbuf, "Hello wolfSSL!");
     ExpectIntEQ(BIO_set_write_buf_size(fixed, 1), 1);
-    /* Ensure there is 0 bytes avaialble to write into. */
+    /* Ensure there is 0 bytes available to write into. */
     ExpectIntEQ(BIO_write(fixed, rbuf, 1), 1);
     ExpectIntEQ(wolfSSL_ASN1_STRING_print_ex(fixed, asn_str, flags), 0);
     ExpectIntEQ(BIO_set_write_buf_size(fixed, 1), 1);
@@ -26784,7 +26784,7 @@ static int test_wolfSSL_ASN1_STRING_print_ex(void)
     ExpectIntEQ(BIO_read(bio, (void*)rbuf, 9), 9);
     ExpectStrEQ((char*)rbuf, "a\\+\\;\\<\\>");
     ExpectIntEQ(BIO_set_write_buf_size(fixed, 1), 1);
-    /* Ensure there is 0 bytes avaialble to write into. */
+    /* Ensure there is 0 bytes available to write into. */
     ExpectIntEQ(BIO_write(fixed, rbuf, 1), 1);
     ExpectIntEQ(wolfSSL_ASN1_STRING_print_ex(fixed, esc_str, flags), 0);
     ExpectIntEQ(BIO_set_write_buf_size(fixed, 1), 1);
@@ -26799,7 +26799,7 @@ static int test_wolfSSL_ASN1_STRING_print_ex(void)
     ExpectIntEQ(BIO_read(bio, (void*)rbuf, 28), 28);
     ExpectStrEQ((char*)rbuf, "OCTET STRING:Hello wolfSSL!");
     ExpectIntEQ(BIO_set_write_buf_size(fixed, 1), 1);
-    /* Ensure there is 0 bytes avaialble to write into. */
+    /* Ensure there is 0 bytes available to write into. */
     ExpectIntEQ(BIO_write(fixed, rbuf, 1), 1);
     ExpectIntEQ(wolfSSL_ASN1_STRING_print_ex(fixed, asn_str, flags), 0);
     ExpectIntEQ(BIO_set_write_buf_size(fixed, 1), 1);
@@ -26816,7 +26816,7 @@ static int test_wolfSSL_ASN1_STRING_print_ex(void)
     ExpectIntEQ(BIO_read(bio, (void*)rbuf, 31), 31);
     ExpectStrEQ((char*)rbuf, "#48656C6C6F20776F6C6653534C2100");
     ExpectIntEQ(BIO_set_write_buf_size(fixed, 1), 1);
-    /* Ensure there is 0 bytes avaialble to write into. */
+    /* Ensure there is 0 bytes available to write into. */
     ExpectIntEQ(BIO_write(fixed, rbuf, 1), 1);
     ExpectIntEQ(wolfSSL_ASN1_STRING_print_ex(fixed, asn_str, flags), 0);
     ExpectIntEQ(BIO_set_write_buf_size(fixed, 1), 1);
@@ -26831,7 +26831,7 @@ static int test_wolfSSL_ASN1_STRING_print_ex(void)
     ExpectIntEQ(BIO_read(bio, (void*)rbuf, 35), 35);
     ExpectStrEQ((char*)rbuf, "#040F48656C6C6F20776F6C6653534C2100");
     ExpectIntEQ(BIO_set_write_buf_size(fixed, 1), 1);
-    /* Ensure there is 0 bytes avaialble to write into. */
+    /* Ensure there is 0 bytes available to write into. */
     ExpectIntEQ(BIO_write(fixed, rbuf, 1), 1);
     ExpectIntEQ(wolfSSL_ASN1_STRING_print_ex(fixed, asn_str, flags), 0);
     ExpectIntEQ(BIO_set_write_buf_size(fixed, 1), 1);
@@ -26986,7 +26986,7 @@ static int test_wolfSSL_ASN1_GENERALIZEDTIME_print(void)
 
     ExpectNotNull(bio = BIO_new(wolfSSL_BIO_s_fixed_mem()));
     ExpectIntEQ(BIO_set_write_buf_size(bio, 1), 1);
-    /* Ensure there is 0 bytes avaialble to write into. */
+    /* Ensure there is 0 bytes available to write into. */
     ExpectIntEQ(BIO_write(bio, buf, 1), 1);
     ExpectIntEQ(wolfSSL_ASN1_GENERALIZEDTIME_print(bio, &gtime), 0);
     for (i = 1; i < 20; i++) {
@@ -27454,7 +27454,7 @@ static int test_wolfSSL_ASN1_TIME_print(void)
 
     /* Test BIO_write fails. */
     ExpectIntEQ(BIO_set_write_buf_size(fixed, 1), 1);
-    /* Ensure there is 0 bytes avaialble to write into. */
+    /* Ensure there is 0 bytes available to write into. */
     ExpectIntEQ(BIO_write(fixed, buf, 1), 1);
     ExpectIntEQ(ASN1_TIME_print(fixed, notBefore), 0);
     ExpectIntEQ(BIO_set_write_buf_size(fixed, 1), 1);
@@ -32063,7 +32063,7 @@ static int test_wolfSSL_CTX_get0_set1_param(void)
     ExpectIntEQ(0x01, pParam->hostFlags);
     ExpectIntEQ(0, XSTRNCMP(pParam->ipasc, testIPv4, WOLFSSL_MAX_IPSTR));
 
-    /* test for incorrect patameter */
+    /* test for incorrect parameter */
     ExpectIntEQ(1,SSL_CTX_set1_param(ctx, NULL));
     ExpectIntEQ(1,SSL_CTX_set1_param(NULL, pvpm));
     ExpectIntEQ(1,SSL_CTX_set1_param(NULL, NULL));
@@ -34112,7 +34112,7 @@ static int test_wolfSSL_BN_math_other(void)
     ExpectIntEQ(BN_gcd(r, a, &emptyBN, NULL), 0);
     /* END Invalid parameters. */
 
-    /* No comman factors between 2 and 3. */
+    /* No common factors between 2 and 3. */
     ExpectIntEQ(BN_set_word(a, 2), 1);
     ExpectIntEQ(BN_set_word(b, 3), 1);
     ExpectIntEQ(BN_gcd(r, a, b, NULL), 1);
@@ -37720,7 +37720,7 @@ static int test_wolfSSL_X509_NAME_ENTRY(void)
     return EXPECT_RESULT();
 }
 
-/* Note the lack of wolfSSL_ prefix...this is a compatability layer test. */
+/* Note the lack of wolfSSL_ prefix...this is a compatibility layer test. */
 static int test_GENERAL_NAME_set0_othername(void) {
     EXPECT_DECLS;
 #if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && \
@@ -37804,7 +37804,7 @@ static int test_GENERAL_NAME_set0_othername(void) {
     return EXPECT_RESULT();
 }
 
-/* Note the lack of wolfSSL_ prefix...this is a compatability layer test. */
+/* Note the lack of wolfSSL_ prefix...this is a compatibility layer test. */
 static int test_othername_and_SID_ext(void) {
     EXPECT_DECLS;
 #if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && \
@@ -52410,7 +52410,7 @@ static int test_wolfSSL_DH_check(void)
     ExpectIntEQ(wolfSSL_DH_check(dh, &codes), 1);
     ExpectIntEQ(wolfSSL_DH_check(dh, NULL), 0);
     ExpectIntEQ(codes, DH_CHECK_P_NOT_PRIME);
-    /* set dh->p back to normal so it wont fail on next tests */
+    /* set dh->p back to normal so it won't fail on next tests */
     if (dh != NULL) {
         dh->p = pTmp;
         pTmp = NULL;
@@ -55929,7 +55929,7 @@ static int test_export_keying_material_cb(WOLFSSL_CTX *ctx, WOLFSSL *ssl)
 
     (void)ctx;
 
-    /* Succes Cases */
+    /* Success Cases */
     ExpectIntEQ(wolfSSL_export_keying_material(ssl, ekm, sizeof(ekm),
             "Test label", XSTR_SIZEOF("Test label"), NULL, 0, 0), 1);
     ExpectIntEQ(wolfSSL_export_keying_material(ssl, ekm, sizeof(ekm),
@@ -60556,12 +60556,12 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_X509_STORE_No_SSL_CTX),
     TEST_DECL(test_X509_LOOKUP_add_dir),
 
-    /* RAND compatability API */
+    /* RAND compatibility API */
     TEST_DECL(test_wolfSSL_RAND_set_rand_method),
     TEST_DECL(test_wolfSSL_RAND_bytes),
     TEST_DECL(test_wolfSSL_RAND),
 
-    /* BN compatability API */
+    /* BN compatibility API */
     TEST_DECL(test_wolfSSL_BN_CTX),
     TEST_DECL(test_wolfSSL_BN),
     TEST_DECL(test_wolfSSL_BN_init),

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -465,7 +465,7 @@ void wait_tcp_ready(func_args* args)
 
 /* Start a thread.
  *
- * @param [in]  fun     Function to executre in thread.
+ * @param [in]  fun     Function to execute in thread.
  * @param [in]  args    Object to send to function in thread.
  * @param [out] thread  Handle to thread.
  */

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -2769,7 +2769,7 @@ static void* benchmarks_do(void* args)
 
             do {
             #ifdef WOLFCRYPT_HAVE_SAKKE
-                /* SAKKE is not useable with ECDH/ECDSA. Run separate test. */
+                /* SAKKE is not usable with ECDH/ECDSA. Run separate test. */
                 if (curveId == ECC_SAKKE_1) {
                     curveId++;
                     continue;

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -5471,7 +5471,7 @@ static const word16 R[32] = {
  * H: hash key = encrypt(key, 0)
  * x = x * H in field
  *
- * x: cumlative result
+ * x: cumulative result
  * m: 4-bit table
  *    [0..15] * H
  */
@@ -6322,7 +6322,7 @@ static void GHASH_INIT(Aes* aes) {
     /* Reset counts of AAD and cipher text. */
     aes->aOver = 0;
     aes->cOver = 0;
-    /* Extra initialization baed on implementation. */
+    /* Extra initialization based on implementation. */
     GHASH_INIT_EXTRA(aes);
 }
 
@@ -6401,7 +6401,7 @@ static void GHASH_UPDATE(Aes* aes, const byte* a, word32 aSz, const byte* c,
                 sz = (byte)cSz;
             }
             XMEMCPY(AES_LASTGBLOCK(aes) + aes->cOver, c, sz);
-            /* Update count of unsed encrypted counter. */
+            /* Update count of unused encrypted counter. */
             aes->cOver += sz;
             if (aes->cOver == AES_BLOCK_SIZE) {
                 /* We have filled up the block and can process. */
@@ -6578,7 +6578,7 @@ static WARN_UNUSED_RESULT int wc_AesGcmEncrypt_STM32(
     /* if IV is not 12 calculate GHASH using software */
     if (ivSz != GCM_NONCE_MID_SZ
     #ifndef CRYP_HEADERWIDTHUNIT_BYTE
-        /* or harware that does not support partial block */
+        /* or hardware that does not support partial block */
         || sz == 0 || partial != 0
     #endif
     #if !defined(CRYP_HEADERWIDTHUNIT_BYTE) && !defined(STM32_AESGCM_PARTIAL)
@@ -7081,7 +7081,7 @@ static WARN_UNUSED_RESULT int wc_AesGcmDecrypt_STM32(
     /* if IV is not 12 calculate GHASH using software */
     if (ivSz != GCM_NONCE_MID_SZ
     #ifndef CRYP_HEADERWIDTHUNIT_BYTE
-        /* or harware that does not support partial block */
+        /* or hardware that does not support partial block */
         || sz == 0 || partial != 0
     #endif
     #if !defined(CRYP_HEADERWIDTHUNIT_BYTE) && !defined(STM32_AESGCM_PARTIAL)
@@ -7968,7 +7968,7 @@ static WARN_UNUSED_RESULT int AesGcmEncryptUpdate_aesni(
             /* Encrypt some of the plaintext. */
             xorbuf(AES_LASTGBLOCK(aes) + aes->cOver, p, sz);
             XMEMCPY(c, AES_LASTGBLOCK(aes) + aes->cOver, sz);
-            /* Update count of unsed encrypted counter. */
+            /* Update count of unused encrypted counter. */
             aes->cOver += sz;
             if (aes->cOver == AES_BLOCK_SIZE) {
                 /* We have filled up the block and can process. */
@@ -8165,7 +8165,7 @@ extern void AES_GCM_decrypt_final_aesni(unsigned char* tag,
  *
  * @param [in, out] aes  AES object.
  * @param [out]     p    Buffer to hold plaintext.
- * @param [in]      c    Buffer holding ciper text.
+ * @param [in]      c    Buffer holding cipher text.
  * @param [in]      cSz  Length of cipher text/plaintext in bytes.
  * @param [in]      a    Buffer holding authentication data.
  * @param [in]      aSz  Length of authentication data in bytes.
@@ -8198,7 +8198,7 @@ static WARN_UNUSED_RESULT int AesGcmDecryptUpdate_aesni(
             /* Decrypt some of the cipher text. */
             xorbuf(AES_LASTGBLOCK(aes) + aes->cOver, c, sz);
             XMEMCPY(p, AES_LASTGBLOCK(aes) + aes->cOver, sz);
-            /* Update count of unsed encrypted counter. */
+            /* Update count of unused encrypted counter. */
             aes->cOver += sz;
             if (aes->cOver == AES_BLOCK_SIZE) {
                 /* We have filled up the block and can process. */
@@ -8574,7 +8574,7 @@ int wc_AesGcmEncryptUpdate(Aes* aes, byte* out, const byte* in, word32 sz,
             ret = AesGcmCryptUpdate_C(aes, out, in, sz);
             if (ret != 0)
                 return ret;
-            /* Update the authenication tag with any authentication data and the
+            /* Update the authentication tag with any authentication data and the
              * new cipher text. */
             GHASH_UPDATE(aes, authIn, authInSz, out, sz);
         }
@@ -8716,7 +8716,7 @@ int wc_AesGcmDecryptUpdate(Aes* aes, byte* out, const byte* in, word32 sz,
         else
     #endif
         {
-            /* Update the authenication tag with any authentication data and
+            /* Update the authentication tag with any authentication data and
              * cipher text. */
             GHASH_UPDATE(aes, authIn, authInSz, in, sz);
             /* Decrypt the cipher text. */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -588,7 +588,7 @@ static word32 SizeASNLength(word32 length)
  * @param [in] data_a  Data to place in each item. Lengths set were not known.
  * @param [in] i       Index of item to check.
  * @return  1 when ASN.1 item is an integer and MSB is 1.
- * @erturn  0 otherwise.
+ * @return  0 otherwise.
  */
 #define ASNIntMSBSet(asn, data_a, i)                  \
     (((asn)[i].tag == ASN_INTEGER) &&                 \
@@ -1771,7 +1771,7 @@ static int GetASN_ItemsDebug(const char* name, const ASNItem* asn,
  * @param [in, out]  inOutIdx  On in, index to start decoding from.
  *                             On out, index of next encoded byte.
  * @param [out]      len       Length of data under SEQUENCE.
- * @param [in]       maxIdx    Maximim index of data. Index of byte after SEQ.
+ * @param [in]       maxIdx    Maximum index of data. Index of byte after SEQ.
  * @param [in]       complete  All data used with SEQUENCE and data under.
  * @return  0 on success.
  * @return  BUFFER_E when not enough data to complete decode.
@@ -2893,7 +2893,7 @@ int SetASNInt(int len, byte firstByte, byte* output)
     }
     /* Encode length - passing NULL for output will not encode. */
     idx += (int)SetLength((word32)len, output ? output + idx : NULL);
-    /* Put out pre-pended 0 as well. */
+    /* Put out prepended 0 as well. */
     if (firstByte & 0x80) {
         if (output) {
             /* Write out 0 byte. */
@@ -9891,7 +9891,7 @@ int wc_DhKeyToDer(DhKey* key, byte* output, word32* outSz, int exportPriv)
 
     /* determine size */
     if (exportPriv) {
-        /* octect string: priv */
+        /* octet string: priv */
         privSz = SetASNIntMP(&key->priv, -1, NULL);
         if (privSz < 0)
             return privSz;
@@ -9959,7 +9959,7 @@ int wc_DhKeyToDer(DhKey* key, byte* output, word32* outSz, int exportPriv)
         return ret;
     idx += total;
 
-    /* octect string: priv */
+    /* octet string: priv */
     if (exportPriv) {
         idx += (word32)SetOctetString((word32)privSz, output + idx);
         idx += (word32)SetASNIntMP(&key->priv, -1, output + idx);
@@ -11304,7 +11304,7 @@ static int GetCertHeader(DecodedCert* cert)
 
 #if defined(HAVE_ED25519) || defined(HAVE_ED448) || (defined(HAVE_PQC) && \
     defined(HAVE_LIBOQS))
-/* Store the key data under the BIT_STRING in dynamicly allocated data.
+/* Store the key data under the BIT_STRING in dynamically allocated data.
  *
  * @param [in, out] cert    Certificate object.
  * @param [in]      source  Buffer containing encoded key.
@@ -11694,7 +11694,7 @@ enum {
  * Pass NULL for output to get the size of the encoding.
  *
  * @param [in]  pubKey       public key buffer
- * @param [in]  pubKeyLen    public ket buffer length
+ * @param [in]  pubKeyLen    public key buffer length
  * @param [out] output       Buffer to put encoded data in (optional)
  * @param [in]  outLen       Size of buffer in bytes
  * @param [in]  keyType      is "enum Key_Sum" like ED25519k
@@ -12231,7 +12231,7 @@ static int ParseDsaKey(const byte* source, word32* srcIdx, word32 maxIdx,
  * Stores the public key in fields of the certificate object.
  * Validates the BER/DER items and does not store in a key object.
  *
- * @param [in, out] cert      Decoded certificate oject.
+ * @param [in, out] cert      Decoded certificate object.
  * @param [in]      source    BER/DER encoded SubjectPublicKeyInfo block.
  * @param [in, out] inOutIdx  On in, start of public key.
  *                            On out, start of ASN.1 item after public key.
@@ -12254,7 +12254,7 @@ static int GetCertKey(DecodedCert* cert, const byte* source, word32* inOutIdx,
     int ret = 0;
     int length;
 
-    /* Validate paramaters. */
+    /* Validate parameters. */
     if (source == NULL) {
         return ASN_PARSE_E;
     }
@@ -13866,7 +13866,7 @@ static int GetCertName(DecodedCert* cert, char* full, byte* hash, int nameType,
 
 #ifdef WOLFSSL_X509_NAME_AVAILABLE
     if (ret == 0) {
-        /* Create an X509_NAME to hold data for OpenSSL compatability APIs. */
+        /* Create an X509_NAME to hold data for OpenSSL compatibility APIs. */
         dName = wolfSSL_X509_NAME_new_ex(cert->heap);
         if (dName == NULL) {
             ret = MEMORY_E;
@@ -17030,7 +17030,7 @@ static int ConfirmNameConstraints(Signer* signer, DecodedCert* cert)
                 name = cert->altNames;
                 break;
             case ASN_RFC822_TYPE:
-                /* Shouldn't it validade E= in subject as well? */
+                /* Shouldn't it validate E= in subject as well? */
                 name = cert->altEmailNames;
 
                 /* Add subject email for checking. */
@@ -18063,7 +18063,7 @@ static int DecodeAltNames(const byte* input, word32 sz, DecodedCert* cert)
 }
 
 #ifdef WOLFSSL_ASN_TEMPLATE
-/* ASN.1 template for BasicContraints.
+/* ASN.1 template for BasicConstraints.
  * X.509: RFC 5280, 4.2.1.9 - BasicConstraints.
  */
 static const ASNItem basicConsASN[] = {
@@ -18415,7 +18415,7 @@ static int DecodeCrlDist(const byte* input, word32 sz, DecodedCert* cert)
     if  (ret == 0) {
         /* Get the GeneralName choice */
         GetASN_Choice(&dataASN[CRLDISTASN_IDX_DP_DISTPOINT_FN_GN], generalNameChoice);
-        /* Parse CRL distribtion point. */
+        /* Parse CRL distribution point. */
         ret = GetASN_Items(crlDistASN, dataASN, crlDistASN_Length, 0, input,
                            &idx, sz);
     }
@@ -19107,7 +19107,7 @@ static int DecodeSubtreeGeneralName(const byte* input, word32 sz, byte tag,
 
 /* Decode a subtree of a name constraints in a certificate.
  *
- * X.509: RFC 5280, 4.2.1.10 - Name Contraints.
+ * X.509: RFC 5280, 4.2.1.10 - Name Constraints.
  *
  * @param [in]      input  Buffer holding data.
  * @param [in]      sz     Size of data in buffer.
@@ -19239,7 +19239,7 @@ static int DecodeSubtree(const byte* input, word32 sz, Base_entry** head,
 
 #ifdef WOLFSSL_ASN_TEMPLATE
 /* ASN.1 template for NameConstraints.
- * X.509: RFC 5280, 4.2.1.10 - Name Contraints.
+ * X.509: RFC 5280, 4.2.1.10 - Name Constraints.
  */
 static const ASNItem nameConstraintsASN[] = {
 /* SEQ     */ { 0, ASN_SEQUENCE, 1, 1, 0 },
@@ -19621,7 +19621,7 @@ exit:
              * NOT appear more than once in a certificate policies
              * extension". This is a sanity check for duplicates.
              * extCertPolicies should only have OID values, additional
-             * qualifiers need to be stored in a seperate array. */
+             * qualifiers need to be stored in a separate array. */
             for (i = 0; (ret == 0) && (i < cert->extCertPoliciesNb); i++) {
                 if (XMEMCMP(cert->extCertPolicies[i],
                             cert->extCertPolicies[cert->extCertPoliciesNb],
@@ -19666,7 +19666,7 @@ enum {
     SUBJDIRATTRASN_IDX_SET,
 };
 
-/* Number of items in ASN.1 template for BasicContraints. */
+/* Number of items in ASN.1 template for BasicConstraints. */
 #define subjDirAttrASN_Length (sizeof(subjDirAttrASN) / sizeof(ASNItem))
 #endif
 /* Decode subject directory attributes extension in a certificate.
@@ -19789,7 +19789,7 @@ static int DecodeSubjDirAttr(const byte* input, int sz, DecodedCert* cert)
 #endif /* WOLFSSL_SUBJ_DIR_ATTR */
 
 #ifdef WOLFSSL_SUBJ_INFO_ACC
-/* Decode subject infomation access extension in a certificate.
+/* Decode subject information access extension in a certificate.
  *
  * X.509: RFC 5280, 4.2.2.2 - Subject Information Access.
  *
@@ -20140,7 +20140,7 @@ enum {
     CERTEXTHDRASN_IDX_EXTSEQ
 };
 
-/* Number of itesm in ASN.1 template for extensions. */
+/* Number of items in ASN.1 template for extensions. */
 #define certExtHdrASN_Length (sizeof(certExtHdrASN) / sizeof(ASNItem))
 
 /* ASN.1 template for Extension.
@@ -20317,7 +20317,7 @@ end:
 
         /* Clear dynamic data. */
         XMEMSET(dataASN, 0, sizeof(*dataASN) * certExtASN_Length);
-        /* Ensure OID is an extention type. */
+        /* Ensure OID is an extension type. */
         GetASN_OID(&dataASN[CERTEXTASN_IDX_OID], oidCertExtType);
         /* Set criticality variable. */
         GetASN_Int8Bit(&dataASN[CERTEXTASN_IDX_CRIT], &critical);
@@ -20384,7 +20384,7 @@ static const ASNItem x509CertASN[] = {
                                                    /* tbsCertificate       TBSCertificate */
                                                    /* TBSCertificate ::= SEQUENCE */
 /* TBS_SEQ                       */        { 1, ASN_SEQUENCE, 1, 1, 0 },
-                                                   /* version         [0]  EXPLICT Version DEFAULT v1 */
+                                                   /* version         [0]  EXPLICIT Version DEFAULT v1 */
 /* TBS_VER                       */            { 2, ASN_CONTEXT_SPECIFIC | ASN_X509_CERT_VERSION, 1, 1, 1 },
                                                    /* Version ::= INTEGER { v1(0), v2(1), v3(2) */
 /* TBS_VER_INT                   */                { 3, ASN_INTEGER, 0, 0, 0 },
@@ -20898,7 +20898,7 @@ static const byte strAttrChoice[] = {
  *
  * @param [in]  cert         Certificate request object.
  * @param [out] criticalExt  Critical extension return code.
- * @param [in]  oid          OID decribing which attribute was found.
+ * @param [in]  oid          OID describing which attribute was found.
  * @param [in]  aIdx         Index into certificate source to start parsing.
  * @param [in]  input        Attribute value data.
  * @param [in]  maxIdx       Maximum index to parse to.
@@ -21218,7 +21218,7 @@ int ParseCert(DecodedCert* cert, int type, int verify, void* cm)
 
 #if (!defined(WOLFSSL_NO_MALLOC) && !defined(NO_WOLFSSL_CM_VERIFY)) || \
     defined(WOLFSSL_DYN_CERT)
-    /* cert->subjectCN not stored as copy of WOLFSSL_NO_MALLOC defind */
+    /* cert->subjectCN not stored as copy of WOLFSSL_NO_MALLOC defined */
     if (cert->subjectCNLen > 0) {
         ptr = (char*)XMALLOC((size_t)cert->subjectCNLen + 1, cert->heap,
                               DYNAMIC_TYPE_SUBJECT_CN);
@@ -21333,7 +21333,7 @@ static Signer* GetCABySubjectAndPubKey(DecodedCert* cert, void* cm)
 static int GetAKIHash(const byte* input, word32 maxIdx, byte* hash, int* set,
                       void* heap)
 {
-    /* AKI and Certificate Extenion ASN.1 templates are the same length. */
+    /* AKI and Certificate Extension ASN.1 templates are the same length. */
     DECL_ASNGETDATA(dataASN, certExtASN_Length);
     int ret = 0;
     word32 idx = 0;
@@ -24534,7 +24534,7 @@ int wc_GetUUIDFromCert(struct DecodedCert* cert, byte* uuid, word32* uuidSz)
 }
 
 
-/* reutrns 0 on success */
+/* returns 0 on success */
 int wc_GetFASCNFromCert(struct DecodedCert* cert, byte* fascn, word32* fascnSz)
 {
     int ret = ALT_NAME_E;
@@ -25090,7 +25090,7 @@ typedef struct DerCert {
     int  keyUsageSz;                   /* encoded KeyUsage extension length */
     int  extKeyUsageSz;                /* encoded ExtendedKeyUsage extension length */
 #ifndef IGNORE_NETSCAPE_CERT_TYPE
-    int  nsCertTypeSz;                 /* encoded Netscape Certifcate Type
+    int  nsCertTypeSz;                 /* encoded Netscape Certificate Type
                                         * extension length */
 #endif
     int  certPoliciesSz;               /* encoded CertPolicies extension length*/
@@ -28316,7 +28316,7 @@ int AddSignature(byte* buf, int bodySz, const byte* sig, int sigSz,
 
     /* In place, put body between SEQUENCE and signature. */
     if (ret == 0) {
-        /* Set sigature OID and signature data. */
+        /* Set signature OID and signature data. */
         SetASN_OID(&dataASN[SIGASN_IDX_SIGALGO_OID], (word32)sigAlgoType,
                    oidSigType);
         if (IsSigAlgoECC((word32)sigAlgoType)) {
@@ -28749,7 +28749,7 @@ static int MakeAnyCert(Cert* cert, byte* derBuffer, word32 derSz,
                 dataASN[X509CERTASN_IDX_TBS_EXT_SEQ].data.buffer.length, 0);
     }
     if (ret >= 0) {
-        /* Store encoded certifcate body size. */
+        /* Store encoded certificate body size. */
         cert->bodySz = sz;
         /* Return the encoding size. */
         ret = sz;
@@ -29694,7 +29694,7 @@ static int MakeCertReq(Cert* cert, byte* derBuffer, word32 derSz,
                 dataASN[CERTREQBODYASN_IDX_EXT_BODY].data.buffer.length, 1);
     }
     if (ret >= 0) {
-        /* Store encoded certifcate request body size. */
+        /* Store encoded certificate request body size. */
         cert->bodySz = sz;
         /* Return the encoding size. */
         ret = sz;
@@ -31524,7 +31524,7 @@ static void DataToHexString(const byte* input, word32 inSz, char* out)
  * @param [out] out       Allocated buffer holding hex string.
  * @param [in]  heap      Dynamic memory allocation hint.
  * @param [in]  heapType  Type of heap to use.
- * @return  0 on succcess.
+ * @return  0 on success.
  * @return  MEMORY_E when dynamic memory allocation fails.
  */
 static int DataToHexStringAlloc(const byte* input, word32 inSz, char** out,
@@ -31598,7 +31598,7 @@ enum {
 /* Number of items in ASN.1 template for SpecifiedECDomain. */
 #define eccSpecifiedASN_Length (sizeof(eccSpecifiedASN) / sizeof(ASNItem))
 
-/* OID indicating the prime field is explicity defined. */
+/* OID indicating the prime field is explicitly defined. */
 static const byte primeFieldOID[] = {
     0x2a, 0x86, 0x48, 0xce, 0x3d, 0x01, 0x01
 };
@@ -31759,7 +31759,7 @@ static int EccSpecifiedECDomainDecode(const byte* input, word32 inSz,
     }
 
     if ((ret != 0) && (curve != NULL)) {
-        /* Failed to set parameters so free paramter set. */
+        /* Failed to set parameters so free parameter set. */
         wc_ecc_free_curve(curve, key->heap);
     }
 
@@ -33235,9 +33235,9 @@ int wc_Curve25519PublicKeyDecode(const byte* input, word32* inOutIdx,
  * Pass NULL for output to get the size of the encoding.
  *
  * @param [in]  privKey      private key buffer
- * @param [in]  privKeyLen   private ket buffer length
+ * @param [in]  privKeyLen   private key buffer length
  * @param [in]  pubKey       public key buffer (optional)
- * @param [in]  pubKeyLen    public ket buffer length
+ * @param [in]  pubKeyLen    public key buffer length
  * @param [out] output       Buffer to put encoded data in (optional)
  * @param [in]  outLen       Size of buffer in bytes
  * @param [in]  keyType      is "enum Key_Sum" like ED25519k
@@ -34730,7 +34730,7 @@ static int DecodeBasicOcspResponse(byte* source, word32* ioIndex,
         Signer* ca;
         int sigValid = -1;
 
-        /* Resonse didn't have a certificate - lookup CA. */
+        /* Response didn't have a certificate - lookup CA. */
     #ifndef NO_SKID
         ca = GetCA(cm, resp->single->issuerKeyHash);
     #else
@@ -34980,7 +34980,7 @@ static const ASNItem ocspNonceExtASN[] = {
 /* EXT       */     { 1, ASN_SEQUENCE, 1, 1, 0 },
                                         /* extnId */
 /* EXT_OID   */        {2, ASN_OBJECT_ID, 0, 0, 0 },
-                                        /* critcal not encoded. */
+                                        /* critical not encoded. */
                                         /* extnValue */
 /* EXT_VAL   */        {2, ASN_OCTET_STRING, 0, 1, 0 },
                                                /* nonce */
@@ -35742,7 +35742,7 @@ static int ParseCRL_RevokedCerts(RevokedCert* rcert, DecodedCRL* dcrl,
 {
     int ret = 0;
 
-    /* Parse each revoked cerificate. */
+    /* Parse each revoked certificate. */
     while ((ret == 0) && (idx < maxIdx)) {
         /* Parse a revoked certificate. */
         if (GetRevoked(rcert, buff, &idx, dcrl, maxIdx) < 0) {
@@ -36194,7 +36194,7 @@ static int ParseCRL_Extensions(DecodedCRL* dcrl, const byte* buf, word32 idx,
 
         /* Clear dynamic data. */
         XMEMSET(dataASN, 0, sizeof(*dataASN) * certExtASN_Length);
-        /* Ensure OID is an extention type. */
+        /* Ensure OID is an extension type. */
         GetASN_OID(&dataASN[CERTEXTASN_IDX_OID], oidCertExtType);
         /* Set criticality variable. */
         GetASN_Int8Bit(&dataASN[CERTEXTASN_IDX_CRIT], &critical);
@@ -36209,7 +36209,7 @@ static int ParseCRL_Extensions(DecodedCRL* dcrl, const byte* buf, word32 idx,
 
             if (oid == AUTH_KEY_OID) {
             #ifndef NO_SKID
-                /* Parse Authority Key Id extesion.
+                /* Parse Authority Key Id extension.
                  * idx is at start of OCTET_STRING data. */
                 ret = ParseCRL_AuthKeyIdExt(buf + idx, length, dcrl);
                 if (ret != 0) {
@@ -36483,7 +36483,7 @@ end:
     }
 
     if ((ret == 0) && (dataASN[CRLASN_IDX_TBS_REVOKEDCERTS].tag != 0)) {
-        /* Parse revoked cerificates - starting after SEQUENCE OF. */
+        /* Parse revoked certificates - starting after SEQUENCE OF. */
         ret = ParseCRL_RevokedCerts(rcert, dcrl, buff,
             GetASNItem_DataIdx(dataASN[CRLASN_IDX_TBS_REVOKEDCERTS], buff),
             GetASNItem_EndIdx(dataASN[CRLASN_IDX_TBS_REVOKEDCERTS], buff));
@@ -37037,7 +37037,7 @@ int wc_MIME_free_hdrs(MimeHdr* head)
 #ifdef WOLFSSL_ASN_PRINT
 
 /*******************************************************************************
- * ASN.1 Parsing and Printing Implemenation
+ * ASN.1 Parsing and Printing Implementation
  ******************************************************************************/
 
 /* Initialize ASN.1 print options.
@@ -37198,7 +37198,7 @@ static void PrintObjectIdNum(XFILE file, unsigned char* oid, word32 len)
         /* Print out each number of dotted form. */
         for (i = 0; i < num; i++) {
             XFPRINTF(file, "%d", dotted_nums[i]);
-            /* Add separetor. */
+            /* Add separator. */
             if (i < num - 1) {
                 XFPRINTF(file, ".");
             }
@@ -37208,7 +37208,7 @@ static void PrintObjectIdNum(XFILE file, unsigned char* oid, word32 len)
         /* Print out bytes as we couldn't decode. */
         for (i = 0; i < len; i++) {
             XFPRINTF(file, "%02x", oid[i]);
-            /* Add separetor. */
+            /* Add separator. */
             if (i < len - 1) {
                 XFPRINTF(file, ":");
             }
@@ -37608,7 +37608,7 @@ static void DumpHeader(Asn1* asn1, Asn1PrintOptions* opts)
     }
 }
 
-/* Print ASN.1 item info based on header and indeces.
+/* Print ASN.1 item info based on header and indices.
  *
  * @param [in] asn1  ASN.1 parse object.
  * @param [in] opts  ASN.1 options for printing.
@@ -37709,7 +37709,7 @@ static int wc_Asn1_Print(Asn1* asn1, Asn1PrintOptions* opts)
                 /* Done with this ASN.1 item. */
                 asn1->part = ASN_PART_TAG;
             }
-            /* Check end indeces are valid. */
+            /* Check end indices are valid. */
             ret = CheckDepth(asn1);
         }
     }
@@ -37731,7 +37731,7 @@ static int wc_Asn1_Print(Asn1* asn1, Asn1PrintOptions* opts)
         }
         /* Step past data to next ASN.1 item. */
         asn1->curr += asn1->item.len;
-        /* Update the depth based on end indeces. */
+        /* Update the depth based on end indices. */
         UpdateDepth(asn1);
         /* Done with this ASN.1 item. */
         asn1->part = ASN_PART_TAG;

--- a/wolfcrypt/src/curve25519.c
+++ b/wolfcrypt/src/curve25519.c
@@ -372,7 +372,7 @@ int wc_curve25519_export_public_ex(curve25519_key* key, byte* out,
                                      (int)sizeof(key->k), key->k);
         key->pubSet = (ret == 0);
     }
-    /* export public point with endianess */
+    /* export public point with endianness */
     curve25519_copy_point(out, key->p.point, endian);
     *outLen = CURVE25519_KEYSIZE;
 
@@ -410,7 +410,7 @@ int wc_curve25519_import_public_ex(const byte* in, word32 inLen,
        return ECC_BAD_ARG_E;
     }
 
-    /* import public point with endianess */
+    /* import public point with endianness */
     curve25519_copy_point(key->p.point, in, endian);
     key->pubSet = 1;
 
@@ -535,7 +535,7 @@ int wc_curve25519_export_private_raw_ex(curve25519_key* key, byte* out,
         return ECC_BAD_ARG_E;
     }
 
-    /* export private scalar with endianess */
+    /* export private scalar with endianness */
     curve25519_copy_point(out, key->k, endian);
     *outLen = CURVE25519_KEYSIZE;
 
@@ -632,7 +632,7 @@ int wc_curve25519_import_private_ex(const byte* priv, word32 privSz,
     se050_curve25519_free_key(key);
 #endif
 
-    /* import private scalar with endianess */
+    /* import private scalar with endianness */
     curve25519_copy_point(key->k, priv, endian);
     key->privSet = 1;
 

--- a/wolfcrypt/src/dsa.c
+++ b/wolfcrypt/src/dsa.c
@@ -260,7 +260,7 @@ int wc_MakeDsaParameters(WC_RNG *rng, int modulus_size, DsaKey *dsa)
      */
     switch (modulus_size) {
 #ifdef WOLFSSL_DSA_768_MODULUS
-    /* This key length is unsecure and only included for bind 9 testing */
+    /* This key length is insecure and only included for bind 9 testing */
         case 768:
 #endif
         case 1024:
@@ -641,7 +641,7 @@ int wc_DsaExportKeyRaw(DsaKey* dsa, byte* x, word32* xSz, byte* y, word32* ySz)
 
 int wc_DsaSign(const byte* digest, byte* out, DsaKey* key, WC_RNG* rng)
 {
-    /* use sha1 by default for backwards compatability */
+    /* use sha1 by default for backwards compatibility */
     return wc_DsaSign_ex(digest, WC_SHA_DIGEST_SIZE, out, key, rng);
 }
 
@@ -756,7 +756,7 @@ int wc_DsaSign_ex(const byte* digest, word32 digestSz, byte* out, DsaKey* key,
                 break;
             }
 
-            /* k is a random numnber and it should be less than q-1
+            /* k is a random number and it should be less than q-1
              * if k greater than repeat
              */
             /* Step 6 */
@@ -976,7 +976,7 @@ int wc_DsaSign_ex(const byte* digest, word32 digestSz, byte* out, DsaKey* key,
 
 int wc_DsaVerify(const byte* digest, const byte* sig, DsaKey* key, int* answer)
 {
-    /* use sha1 by default for backwards compatability */
+    /* use sha1 by default for backwards compatibility */
     return wc_DsaVerify_ex(digest, WC_SHA_DIGEST_SIZE, sig, key, answer);
 }
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -9090,7 +9090,7 @@ int wc_ecc_import_point_der_ex(const byte* in, word32 inLen,
     return err;
 }
 
-/* function for backwards compatiblity with previous implementations */
+/* function for backwards compatibility with previous implementations */
 int wc_ecc_import_point_der(const byte* in, word32 inLen, const int curve_idx,
                             ecc_point* point)
 {

--- a/wolfcrypt/src/ed448.c
+++ b/wolfcrypt/src/ed448.c
@@ -168,7 +168,7 @@ static int ed448_hash(ed448_key* key, const byte* in, word32 inLen,
 /* Derive the public key for the private key.
  *
  * key       [in]  Ed448 key object.
- * pubKey    [in]  Byte array to hold te public key.
+ * pubKey    [in]  Byte array to hold the public key.
  * pubKeySz  [in]  Size of the array in bytes.
  * returns BAD_FUNC_ARG when key is NULL or pubKeySz is not equal to
  *         ED448_PUB_KEY_SIZE,

--- a/wolfcrypt/src/ext_kyber.c
+++ b/wolfcrypt/src/ext_kyber.c
@@ -548,7 +548,7 @@ int wc_KyberKey_Decapsulate(KyberKey* key, unsigned char* ss,
  * @param  [in]       in   Buffer holding encoded key.
  * @param  [in]       len  Length of data in buffer.
  * @return  0 on success.
- * @return  BAD_FUNC_ARG when key ot in is NULL.
+ * @return  BAD_FUNC_ARG when key or in is NULL.
  * @return  NOT_COMPILED_IN when key type is not supported.
  * @return  BUFFER_E when len is not the correct size.
  */

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -3314,7 +3314,7 @@ int mp_init_size (mp_int * a, int size)
 }
 
 
-/* the jist of squaring...
+/* the list of squaring...
  * you do like mult except the offset of the tmpx [one that
  * starts closer to zero] can't equal the offset of tmpy.
  * So basically you set up iy like before then you min it with

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -129,7 +129,7 @@ int wc_PRF(byte* result, word32 resLen, const byte* secret,
     if (lastLen)
         times += 1;
 
-    /* times == 0 iif resLen == 0, but times == 0 abides clang static analyzer
+    /* times == 0 if resLen == 0, but times == 0 abides clang static analyzer
        while resLen == 0 doesn't */
     if (times == 0)
         return BAD_FUNC_ARG;

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -725,7 +725,7 @@ unsigned long wc_PeekErrorNodeLineData(const char **file, int *line,
 
 /**
  * Get the error value at the HEAD of the ERR queue or 0 if the queue
- * is emtpy. The HEAD entry is removed by this call.
+ * is empty. The HEAD entry is removed by this call.
  */
 unsigned long wc_GetErrorNodeErr(void)
 {

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -1230,7 +1230,7 @@ static int PKCS12_CheckConstructedZero(byte* data, word32 dataSz, word32* idx)
 static int PKCS12_CoalesceOctetStrings(WC_PKCS12* pkcs12, byte* data,
         word32 dataSz, word32* idx, int* curIdx)
 {
-    byte*  mergedData = NULL; /* buffer for concatonated strings */
+    byte*  mergedData = NULL; /* buffer for concatenated strings */
     word32 mergedSz = 0;      /* total size of merged strings */
     int    encryptedContentSz = 0;
     int    originalEncSz = 0;
@@ -1244,7 +1244,7 @@ static int PKCS12_CoalesceOctetStrings(WC_PKCS12* pkcs12, byte* data,
         ret = ASN_PARSE_E;
     }
 
-    /* Loop through octet strings and concatonate them without
+    /* Loop through octet strings and concatenate them without
      * the tags and length */
     while ((int)*idx < originalEncSz + *curIdx) {
         if (GetASNTag(data, idx, &tag, dataSz) < 0) {
@@ -1282,7 +1282,7 @@ static int PKCS12_CoalesceOctetStrings(WC_PKCS12* pkcs12, byte* data,
     *idx += SetLength(mergedSz, &data[*idx]);
 
     if (mergedSz > 0) {
-        /* Copy over concatonated octet strings into data buffer */
+        /* Copy over concatenated octet strings into data buffer */
         XMEMCPY(&data[*idx], mergedData, mergedSz);
 
         XFREE(mergedData, pkcs12->heap, DYNAMIC_TYPE_PKCS);

--- a/wolfcrypt/src/port/Espressif/esp32_aes.c
+++ b/wolfcrypt/src/port/Espressif/esp32_aes.c
@@ -214,7 +214,7 @@ static void esp_aes_bk(const byte* in, byte* out)
 
     /* wait until finishing the process */
     while (DPORT_REG_READ(AES_STATE_REG) != 0) {
-        /* wating for the hardware accelerator to complete operation. */
+        /* waiting for the hardware accelerator to complete operation. */
     }
 
     /* read-out blocks */

--- a/wolfcrypt/src/port/Renesas/renesas_sce_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_sce_util.c
@@ -372,7 +372,7 @@ WOLFSSL_LOCAL int SCE_EccSharedSecret(WOLFSSL* ssl, ecc_key* otherKey,
                 return ret;
             }
 
-            /* copy generated ecdh public key inot buffer */
+            /* copy generated ecdh public key into buffer */
             pubKeyDer[0] = ECC_POINT_UNCOMP;
             *pubKeySz = 1 + sizeof(cbInfo->ecc_ecdh_public_key);
             XMEMCPY(&pubKeyDer[1], &cbInfo->ecc_ecdh_public_key,

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_util.c
@@ -332,7 +332,7 @@ WOLFSSL_LOCAL int tsip_Tls13GenEccKeyPair(WOLFSSL* ssl, KeyShareEntry* kse)
                             &(tuc->handle13),
                             TSIP_TLS13_MODE_FULL_HANDSHAKE,
                             &(tuc->EcdhPrivKey13Idx),    /* private key index */
-                            &(kse->pubKey[1]));       /* genereted public key */
+                            &(kse->pubKey[1]));       /* generated public key */
 
             if (err != TSIP_SUCCESS){ret = WC_HW_E;}
 
@@ -422,7 +422,7 @@ WOLFSSL_LOCAL int tsip_Tls13GenSharedSecret(struct WOLFSSL* ssl,
         if ((ret = tsip_hw_lock()) == 0) {
 
             tuc->SharedSecret_set = 0;
-            pubkeyraw = kse->ke + 1;        /* peer's raw publick key data */
+            pubkeyraw = kse->ke + 1;        /* peer's raw public key data */
 
             /* derive shared secret */
             err = R_TSIP_Tls13GenerateEcdheSharedSecret(
@@ -2113,7 +2113,7 @@ static uint32_t GetTsipCipherSuite(
     return tsipCipher;
 }
 
-/*  Attempt to get a public key exchaged with the peer in ECDHE.
+/*  Attempt to get a public key exchanged with the peer in ECDHE.
  *  the public key is verified by given signature then stored into ctx.
  *
  *  return WOLFSSL_SUCCESS on success, WOLFSSL_FAILURE on failure.

--- a/wolfcrypt/src/port/arm/armv8-aes.c
+++ b/wolfcrypt/src/port/arm/armv8-aes.c
@@ -4638,7 +4638,7 @@ static void GHASH_UPDATE(Aes* aes, const byte* a, word32 aSz, const byte* c,
                 sz = cSz;
             }
             XMEMCPY(AES_LASTGBLOCK(aes) + aes->cOver, c, sz);
-            /* Update count of unsed encrypted counter. */
+            /* Update count of unused encrypted counter. */
             aes->cOver += sz;
             if (aes->cOver == AES_BLOCK_SIZE) {
                 /* We have filled up the block and can process. */
@@ -4972,7 +4972,7 @@ int wc_AesGcmEncryptUpdate(Aes* aes, byte* out, const byte* in, word32 sz,
     if (ret == 0) {
         /* Encrypt the plaintext. */
         AesGcmCryptUpdate_C(aes, out, in, sz);
-        /* Update the authenication tag with any authentication data and the
+        /* Update the authentication tag with any authentication data and the
          * new cipher text. */
         GHASH_UPDATE(aes, authIn, authInSz, out, sz);
     }
@@ -5081,7 +5081,7 @@ int wc_AesGcmDecryptUpdate(Aes* aes, byte* out, const byte* in, word32 sz,
 
     if (ret == 0) {
         /* Decrypt with AAD and/or cipher text. */
-        /* Update the authenication tag with any authentication data and
+        /* Update the authentication tag with any authentication data and
          * cipher text. */
         GHASH_UPDATE(aes, authIn, authInSz, in, sz);
         /* Decrypt the cipher text. */

--- a/wolfcrypt/src/port/caam/caam_driver.c
+++ b/wolfcrypt/src/port/caam/caam_driver.c
@@ -1840,7 +1840,7 @@ void caamDescInit(DESCSTRUCT* desc, int type, unsigned int args[4],
 
 static int SetupJobRing(struct JobRing* r)
 {
-    /* get enviornment specific addresses to use for job rings */
+    /* get environment specific addresses to use for job rings */
     CAAM_SET_JOBRING_ADDR(&r->BaseAddr, &r->JobIn, &r->VirtualIn);
 
     /* register the in/out and sizes of job ring */

--- a/wolfcrypt/src/port/caam/caam_qnx.c
+++ b/wolfcrypt/src/port/caam/caam_qnx.c
@@ -27,7 +27,7 @@
  * wolfssl/wolfcrypt/- path includes other than
  * wolfssl/wolfcrypt/port/caam/caam_* should be avoided!! */
 #undef WC_NO_HARDEN
-#define WC_NO_HARDEN /* silence warning, it is irrelavent here */
+#define WC_NO_HARDEN /* silence warning, it is irrelevant here */
 #include <wolfssl/wolfcrypt/settings.h>
 
 #if defined(__QNX__) || defined(__QNXNTO__)
@@ -55,7 +55,7 @@ static void* localMemory = NULL;
 static unsigned int localPhy = 0;
 sem_t localMemSem;
 
-/* Can be overriden, variable for how large of a local buffer to have.
+/* Can be overridden, variable for how large of a local buffer to have.
  * This allows for large performance gains when avoiding mapping new memory
  * for each operation. */
 #ifndef WOLFSSL_CAAM_QNX_MEMORY

--- a/wolfcrypt/src/port/caam/wolfcaam_ecdsa.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_ecdsa.c
@@ -352,7 +352,7 @@ int wc_CAAM_EccSign(const byte* in, int inlen, byte* out, word32* outlen,
             buf[idx].Length = keySz;
         }
         buf[idx].TheAddress = (CAAM_ADDRESS)pk;
-        args[0] = key->blackKey; /* potentail black key, not in sm */
+        args[0] = key->blackKey; /* potential black key, not in sm */
     }
     idx++;
 

--- a/wolfcrypt/src/port/caam/wolfcaam_seco.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_seco.c
@@ -1323,7 +1323,7 @@ int wc_TranslateHSMError(int current, hsm_err_t err)
             break;
 
         default:
-            WOLFSSL_MSG("SECO HSM: unkown error value found");
+            WOLFSSL_MSG("SECO HSM: unknown error value found");
     }
 
     if (current != 0) {

--- a/wolfcrypt/src/port/kcapi/kcapi_aes.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_aes.c
@@ -97,7 +97,7 @@
             iov.iov_len = sz;
             ret = (int)kcapi_cipher_stream_update(aes->handle, &iov, 1);
             if (ret < 0) {
-                WOLFSSL_MSG("CbcEncrypt error updateing through KCAPI");
+                WOLFSSL_MSG("CbcEncrypt error updating through KCAPI");
             }
         }
         if (ret >= 0) {
@@ -155,7 +155,7 @@
             iov.iov_len = sz;
             ret = (int)kcapi_cipher_stream_update(aes->handle, &iov, 1);
             if (ret < 0) {
-                WOLFSSL_MSG("CbcDecrypt error updateing through KCAPI");
+                WOLFSSL_MSG("CbcDecrypt error updating through KCAPI");
             }
         }
         if (ret >= 0) {

--- a/wolfcrypt/src/port/nxp/README_SE050.md
+++ b/wolfcrypt/src/port/nxp/README_SE050.md
@@ -163,7 +163,7 @@ To enable SCP03 authentication, wolfSSL was using the following defines:
 ```
 
 Default ENC, MAC, and DEK keys for SCP03 should be set by defining the
-following values. Thes are the default keys wolfSSL used for the SE50C2
+following values. These are the default keys wolfSSL used for the SE50C2
 variant (OEF OID: A201). The variant can be seen by running the
 `se05x_GetInfo` sample application.
 

--- a/wolfcrypt/src/port/psa/psa_pkcbs.c
+++ b/wolfcrypt/src/port/psa/psa_pkcbs.c
@@ -58,7 +58,7 @@ static int psa_ecc_get_curve_info_from_curve_id(int ecc_curve,
  * psa_ecc_export_to_wc_key() - export psa @key_id into ecc_key @key
  * @key: already initialized ecc_key to export the key into [out]
  * @key_id: key to export [in]
- * @key_size: size fo the key [in]
+ * @key_size: size of the key [in]
  * @curve_id: wc id of the curve [in]
  *
  * returns 0 on success

--- a/wolfcrypt/src/port/silabs/README.md
+++ b/wolfcrypt/src/port/silabs/README.md
@@ -19,7 +19,7 @@ To enable support define the following:
 
 :warning: **Be sure to update the SE firmware** Testing and results were done using SE firmware `1.2.6`
 
-Update was preformed under Simplicity Studio directory:
+Update was performed under Simplicity Studio directory:
     `./developer/adapter_packs/commander/commander  flash ./offline/efr32/firmware/series2config1/se_firmware_package/s2c1_se_fw_upgrade_app_1v2p6.hex`
 
  * AES GCM tags length >= 16 bytes

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -3277,7 +3277,7 @@ static int wc_RsaFunction_ex(const byte* in, word32 inLen, byte* out,
 int wc_RsaFunction(const byte* in, word32 inLen, byte* out,
                           word32* outLen, int type, RsaKey* key, WC_RNG* rng)
 {
-    /* Always check for ciphertext of 0 or 1. (Should't for OAEP decrypt.) */
+    /* Always check for ciphertext of 0 or 1. (Shouldn't for OAEP decrypt.) */
     return wc_RsaFunction_ex(in, inLen, out, outLen, type, key, rng, 1);
 }
 
@@ -3389,7 +3389,7 @@ static int RsaPublicEncryptEx(const byte* in, word32 inLen, byte* out,
                                   labelSz, sz);
         }
     #elif defined(WOLFSSL_RENESAS_SCEPROTECT_CRYPTONLY)
-           /* SCE needs warpped key which is passed via
+           /* SCE needs wrapped key which is passed via
             * user ctx object of crypt-call back.
             */
        #ifdef WOLF_CRYPTO_CB

--- a/wolfcrypt/src/sakke.c
+++ b/wolfcrypt/src/sakke.c
@@ -293,7 +293,7 @@ static int sakke_load_base_point(SakkeKey* key)
             err = mp_read_radix(params->base->y, key->ecc.dp->Gy, MP_RADIX_HEX);
         }
         if (err == 0) {
-            /* Affine co-ordinates have a Z of 1 in Jacobian. */
+            /* Affine coordinates have a Z of 1 in Jacobian. */
             err = mp_set(params->base->z, 1);
         }
         if (err == 0) {
@@ -312,7 +312,7 @@ static int sakke_load_base_point(SakkeKey* key)
  * @param  [in]   key   SAKKE key.
  * @param  [in]   n     MP integer that is the scalar.
  * @param  [out]  res   ECC point to hold the result.
- * @param  [in]   map   Map the result to affine co-ordinates.
+ * @param  [in]   map   Map the result to affine coordinates.
  * @return  0 on success.
  * @return  MEMORY_E when dynamic memory allocation fails.
  */
@@ -338,7 +338,7 @@ static int sakke_mulmod_base(SakkeKey* key, const mp_int* n, ecc_point* res,
  * @param  [in]   n     MP integer that is the scalar.
  * @param  [in]   a     ECC point to add.
  * @param  [out]  res   ECC point to hold the result.
- * @param  [in]   map   Map the result to affine co-ordinates.
+ * @param  [in]   map   Map the result to affine coordinates.
  * @return  0 on success.
  * @return  MEMORY_E when dynamic memory allocation fails.
  */
@@ -363,7 +363,7 @@ static int sakke_mulmod_base_add(SakkeKey* key, const mp_int* n,
  * @param  [in]   key   SAKKE key.
  * @param  [in]   n     MP integer that is the scalar.
  * @param  [out]  res   ECC point to hold the result.
- * @param  [in]   map   Map the result to affine co-ordinates.
+ * @param  [in]   map   Map the result to affine coordinates.
  * @return  0 on success.
  * @return  MEMORY_E when dynamic memory allocation fails.
  */
@@ -386,7 +386,7 @@ static int sakke_mulmod_base(SakkeKey* key, const mp_int* n, ecc_point* res,
  * @param  [in]   a     ECC point to add. Point ordinates must be in Montgomery
  *                      form.
  * @param  [out]  res   ECC point to hold the result.
- * @param  [in]   map   Map the result to affine co-ordinates.
+ * @param  [in]   map   Map the result to affine coordinates.
  * @return  0 on success.
  * @return  MEMORY_E when dynamic memory allocation fails.
  */
@@ -408,7 +408,7 @@ static int sakke_mulmod_base_add(SakkeKey* key, const mp_int* n, ecc_point* a,
                 &params->prime, mp);
     }
     if ((err == 0) && map) {
-        /* Map result back to affine co-ordinates. */
+        /* Map result back to affine coordinates. */
         err = ecc_map(res, &params->prime, mp);
     }
 
@@ -425,7 +425,7 @@ static int sakke_mulmod_base_add(SakkeKey* key, const mp_int* n, ecc_point* a,
  * @param  [in]   p      ECC point to multiply.
  * @param  [in]   table  Precomputation table for p. May be NULL.
  * @param  [out]  res    ECC point to hold the result.
- * @param  [in]   map    Map the result to affine co-ordinates.
+ * @param  [in]   map    Map the result to affine coordinates.
  * @return  0 on success.
  * @return  MEMORY_E when dynamic memory allocation fails.
  */
@@ -457,7 +457,7 @@ static int sakke_mulmod_point(SakkeKey* key, const mp_int* n,
  * @param  [in]   p      ECC point to multiply.
  * @param  [in]   table  Precomputation table for p. May be NULL.
  * @param  [out]  res    ECC point to hold the result.
- * @param  [in]   map    Map the result to affine co-ordinates.
+ * @param  [in]   map    Map the result to affine coordinates.
  * @return  0 on success.
  * @return  MEMORY_E when dynamic memory allocation fails.
  */
@@ -1004,7 +1004,7 @@ int wc_MakeSakkeRsk(SakkeKey* key, const byte* id, word16 idSz, ecc_point* rsk)
 /**
  * Encode the SAKKE Receiver Secret Key (RSK) as DER encoded public ECC key.
  *
- * Encode the RSK to send to ther receiving client.
+ * Encode the RSK to send to the receiving client.
  *
  * X and y ordinate of RSK point concatenated. Each number is zero padded to
  * key size.
@@ -6794,7 +6794,7 @@ int wc_GenerateSakkeSSV(SakkeKey* key, WC_RNG* rng, byte* ssv, word16* ssvSz)
         }
     }
     if (err == 0) {
-        /* Return length only if an ouput buffer is NULL. */
+        /* Return length only if an output buffer is NULL. */
         if (ssv == NULL) {
             *ssvSz = (word16) (n / 8);
             err = LENGTH_ONLY_E;

--- a/wolfcrypt/src/siphash.c
+++ b/wolfcrypt/src/siphash.c
@@ -315,7 +315,7 @@ static WC_INLINE void SipHashOut(SipHash* sipHash, byte* out)
  *
  * @param [in, out] sipHash  SipHash object.
  * @param [out]     out      Buffer to place MAC into.
- * @param [in]      outSz    Size of ouput MAC. 8 or 16 only.
+ * @param [in]      outSz    Size of output MAC. 8 or 16 only.
  * @return  BAD_FUNC_ARG when sipHash or out is NULL.
  * @return  BAD_FUNC_ARG when outSz is not the same as initialized value.
  * @return  0 on success.
@@ -393,7 +393,7 @@ int wc_SipHashFinal(SipHash* sipHash, unsigned char* out, unsigned char outSz)
  * @param [in]      in       Input message.
  * @param [in]      inSz     Size of input message.
  * @param [out]     out      Buffer to place MAC into.
- * @param [in]      outSz    Size of ouput MAC. 8 or 16 only.
+ * @param [in]      outSz    Size of output MAC. 8 or 16 only.
  * @return  BAD_FUNC_ARG when key or out is NULL.
  * @return  BAD_FUNC_ARG when in is NULL and inSz is not zero.
  * @return  BAD_FUNC_ARG when outSz is neither 8 nor 16.
@@ -622,7 +622,7 @@ int wc_SipHash(const unsigned char* key, const unsigned char* in, word32 inSz,
  * @param [in]      in       Input message.
  * @param [in]      inSz     Size of input message.
  * @param [out]     out      Buffer to place MAC into.
- * @param [in]      outSz    Size of ouput MAC. 8 or 16 only.
+ * @param [in]      outSz    Size of output MAC. 8 or 16 only.
  * @return  BAD_FUNC_ARG when key or out is NULL.
  * @return  BAD_FUNC_ARG when in is NULL and inSz is not zero.
  * @return  BAD_FUNC_ARG when outSz is not 8 nor 16.
@@ -851,7 +851,7 @@ int wc_SipHash(const unsigned char* key, const unsigned char* in, word32 inSz,
  * @param [in]      in       Input message.
  * @param [in]      inSz     Size of input message.
  * @param [out]     out      Buffer to place MAC into.
- * @param [in]      outSz    Size of ouput MAC. 8 or 16 only.
+ * @param [in]      outSz    Size of output MAC. 8 or 16 only.
  * @return  BAD_FUNC_ARG when key or out is NULL.
  * @return  BAD_FUNC_ARG when in is NULL and inSz is not zero.
  * @return  BAD_FUNC_ARG when outSz is not 8 nor 16.

--- a/wolfcrypt/src/wc_pkcs11.c
+++ b/wolfcrypt/src/wc_pkcs11.c
@@ -74,7 +74,7 @@
 #endif
 
 
-/* Maximim length of the EC parameter string. */
+/* Maximum length of the EC parameter string. */
 #define MAX_EC_PARAM_LEN   16
 
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -809,7 +809,7 @@ static int rng_crypto_cb(int thisDevId, wc_CryptoInfo* info, void* ctx)
     }
 #endif
 
-/* set test pass output to printf if not overriden */
+/* set test pass output to printf if not overridden */
 #ifndef TEST_PASS
     /* redirect to printf */
     #define TEST_PASS(...) {                                    \
@@ -6119,7 +6119,7 @@ static wc_test_ret_t rc2_cbc_test(void)
             return WC_TEST_RET_ENC_NC;
         }
 
-        /* reset IV for decrypt, since overriden by encrypt operation */
+        /* reset IV for decrypt, since overridden by encrypt operation */
         ret = wc_Rc2SetIV(&rc2, (byte*)test_rc2[j].iv);
         if (ret != 0) {
             return WC_TEST_RET_ENC_EC(ret);

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -2580,7 +2580,7 @@ static WC_INLINE unsigned int my_psk_client_cs_cb(WOLFSSL* ssl,
 
 #ifdef WOLFSSL_PSK_MULTI_ID_PER_CS
     /* Multiple calls for each cipher suite. First identity byte indicates the
-     * number of identites seen so far for cipher suite. */
+     * number of identities seen so far for cipher suite. */
     if (identity[0] != 0) {
         return 0;
     }

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -862,7 +862,7 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #include "os.h"           /* dc_rtc_api needs    */
     #include "dc_rtc_api.h"   /* to get current time */
 
-    /* uses parital <time.h> structures */
+    /* uses partial <time.h> structures */
     #define XTIME(tl)       (0)
     #define XGMTIME(c, t)   rtpsys_gmtime((c))
 

--- a/wrapper/CSharp/wolfSSL_CSharp/wolfSSL.cs
+++ b/wrapper/CSharp/wolfSSL_CSharp/wolfSSL.cs
@@ -725,7 +725,7 @@ namespace wolfSSL.CSharp {
                 int ret;
                 byte[] msg;
 
-                buf.Clear(); /* Clear incomming buffer */
+                buf.Clear(); /* Clear incoming buffer */
 
                 if (sslCtx == IntPtr.Zero)
                 {
@@ -1760,7 +1760,7 @@ namespace wolfSSL.CSharp {
         /// Used to load in the private key from a file
         /// </summary>
         /// <param name="ctx">CTX structure for TLS/SSL connections </param>
-        /// <param name="fileKey">Name of the file, includeing absolute directory</param>
+        /// <param name="fileKey">Name of the file, including absolute directory</param>
         /// <param name="type">Type of file ie PEM or DER</param>
         /// <returns>1 on success</returns>
         public static int CTX_use_PrivateKey_file(IntPtr ctx, string fileKey, int type)

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -24,7 +24,7 @@ config WOLFSSL_PROMPTLESS
           Symbol to disable the prompt for WOLFSSL selection.
           This symbol may be used internally in a Kconfig tree to hide the
           wolfSSL menu prompt and instead handle the selection of WOLFSSL from
-          dependent sub-configurations and thus preven stuck symbol behavior.
+          dependent sub-configurations and thus prevent stuck symbol behavior.
 
 
 menuconfig WOLFSSL


### PR DESCRIPTION
# Description

Fix typos found by [codespell](https://github.com/codespell-project/codespell).

# Testing

\-

# Checklist

 - [ ] added tests
 - [x] updated/added doxygen
 - [x] updated appropriate READMEs
 - [x] Updated manual and documentation
