### PR TITLE
fix for nightly toolchain armv7 build warning

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -9078,7 +9078,7 @@ int EncryptContent(byte* input, word32 inputSz, byte* out, word32* outSz,
     DECL_ASNSETDATA(dataASN, p8EncPbes1ASN_Length);
     int ret = 0;
     int sz = 0;
-    int version;
+    int version = 0;
     int id = -1;
     int blockSz = 0;
     word32 pkcs8Sz = 0;


### PR DESCRIPTION
nightly-toolchain-armv7-eabihf-glibc-v2

```
  CC       wolfcrypt/src/src_libwolfssl_la-asn.lo
wolfcrypt/src/asn.c: In function ‘EncryptContent’:

wolfcrypt/src/asn.c:9164:13: error: ‘version’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
         ret = wc_CryptKey(password, passwordSz, salt, (int)saltSz, itt, id,
         ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                           pkcs8, (int)pkcs8Sz, version, cbcIv, 1, 0);
                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```