### PR TITLE
Add support for nginx-1.25.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
         uses: ./.github/workflows/openvpn.yml
     hostap:
         uses: ./.github/workflows/hostap.yml
+    nginx:
+        uses: ./.github/workflows/nginx.yml
 # TODO: Currently this test fails. Enable it once it becomes passing.        
 #    haproxy:
 #        uses: ./.github/workflows/haproxy.yml

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -1,0 +1,176 @@
+name: nginx Tests
+
+on:
+  push:
+  workflow_call:
+
+jobs:
+  build_wolfssl:
+    name: Build wolfSSL
+    # Just to keep it the same as the testing target
+    runs-on: ubuntu-latest
+    steps:
+      - if: ${{ runner.debug }}
+        name: Enable wolfSSL debug logging
+        run: |
+          # We don't use --enable-debug since it makes the logs too loud
+          echo "wolf_debug_flags= CFLAGS='-g3 -O0'" >> $GITHUB_ENV
+
+      - name: Build wolfSSL
+        uses: wolfSSL/actions-build-autotools-project@v1
+        with:
+          path: wolfssl
+          configure: --enable-nginx ${{ env.wolf_debug_flags }}
+          install: true
+
+      - name: Upload built lib
+        uses: actions/upload-artifact@v3
+        with:
+          name: wolf-install-nginx
+          path: build-dir
+          retention-days: 1
+
+  nginx_check:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # in general we want to pass all tests that match *ssl*
+          - ref: 1.25.0
+            test-ref: 5b2894ea1afd01a26c589ce11f310df118e42592
+            # Following tests pass with sanitizer on
+            sanitize-ok: >-
+              h2_ssl_proxy_cache.t h2_ssl.t h2_ssl_variables.t h2_ssl_verify_client.t
+              mail_imap_ssl.t mail_ssl_conf_command.t mail_ssl_session_reuse.t
+              mail_ssl.t proxy_ssl_certificate_empty.t proxy_ssl_certificate.t
+              proxy_ssl_certificate_vars.t proxy_ssl_conf_command.t proxy_ssl_name.t
+              ssl_certificate_chain.t ssl_certificate_perl.t ssl_certificates.t
+              ssl_certificate.t ssl_client_escaped_cert.t ssl_conf_command.t
+              ssl_crl.t ssl_curve.t ssl_engine_keys.t ssl_ocsp.t ssl_password_file.t
+              ssl_proxy_protocol.t ssl_proxy_upgrade.t ssl_reject_handshake.t
+              ssl_session_reuse.t ssl_session_ticket_key.t ssl_sni_reneg.t
+              ssl_sni_sessions.t ssl_sni.t ssl_stapling.t ssl.t ssl_verify_client.t
+              ssl_verify_depth.t stream_proxy_ssl_certificate.t stream_proxy_ssl_certificate_vars.t
+              stream_proxy_ssl_conf_command.t stream_proxy_ssl_name_complex.t
+              stream_proxy_ssl_name.t stream_ssl_certificate.t stream_ssl_conf_command.t
+              stream_ssl_preread_alpn.t stream_ssl_preread_protocol.t stream_ssl_preread.t
+              stream_ssl_realip.t stream_ssl_session_reuse.t stream_ssl.t stream_ssl_variables.t
+              stream_ssl_verify_client.t stream_upstream_zone_ssl.t upstream_zone_ssl.t
+              uwsgi_ssl_certificate.t uwsgi_ssl_certificate_vars.t uwsgi_ssl.t
+              uwsgi_ssl_verify.t
+            # Following tests do not pass with sanitizer on (with OpenSSL too)
+            sanitize-not-ok: >-
+              grpc_ssl.t h2_proxy_request_buffering_ssl.t h2_proxy_ssl.t
+              proxy_request_buffering_ssl.t proxy_ssl_keepalive.t proxy_ssl.t
+              proxy_ssl_verify.t stream_proxy_protocol_ssl.t stream_proxy_ssl.t
+              stream_proxy_ssl_verify.t stream_ssl_alpn.t
+    name: ${{ matrix.ref }}
+    runs-on: ubuntu-latest
+    needs: build_wolfssl
+    steps:
+      - name: Download lib
+        uses: actions/download-artifact@v3
+        with:
+          name: wolf-install-nginx
+          path: build-dir
+
+      - name: Install dependencies
+        run: |
+          sudo cpan -iT Proc::Find Net::SSLeay IO::Socket::SSL
+
+      - name: Checkout wolfssl-nginx
+        uses: actions/checkout@v3
+        with:
+          repository: wolfssl/wolfssl-nginx
+          path: wolfssl-nginx
+
+      - name: Checkout nginx
+        uses: actions/checkout@v3
+        with:
+          repository: nginx/nginx
+          path: nginx
+          ref: release-${{ matrix.ref }}
+
+      - name: Apply nginx patch
+        working-directory: nginx
+        run: patch -p1 < ../wolfssl-nginx/nginx-${{ matrix.ref }}-wolfssl.patch
+
+      - if: ${{ runner.debug }}
+        name: Apply nginx debug patch
+        working-directory: nginx
+        run: patch -p1 < ../wolfssl-nginx/nginx-${{ matrix.ref }}-wolfssl-debug.patch
+
+      - name: Checkout nginx-tests
+        uses: actions/checkout@v3
+        with:
+          repository: nginx/nginx-tests
+          path: nginx-tests
+          ref: ${{ matrix.test-ref }}
+
+      - name: Apply nginx-tests patch
+        working-directory: nginx-tests
+        run: patch -p1 < ../wolfssl-nginx/nginx-tests-patches/*${{ matrix.test-ref }}.patch
+
+      - name: Build nginx without sanitizer
+        working-directory: nginx
+        run: |
+          ./auto/configure --with-wolfssl=$GITHUB_WORKSPACE/build-dir --with-http_ssl_module \
+            --with-stream --with-stream_ssl_module --with-stream_ssl_preread_module \
+            --with-http_v2_module --with-mail --with-mail_ssl_module
+          make -j
+
+      - name: Confirm nginx built with wolfSSL
+        working-directory: nginx
+        run: ldd objs/nginx | grep wolfssl
+
+      - if: ${{ runner.debug }}
+        name: Run nginx-tests without sanitizer (debug)
+        working-directory: nginx-tests
+        run: |
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/build-dir/lib \
+            TMPDIR=$GITHUB_WORKSPACE TEST_NGINX_VERBOSE=y TEST_NGINX_CATLOG=y \
+            TEST_NGINX_BINARY=../nginx/objs/nginx prove -v ${{ matrix.sanitize-not-ok }}
+
+      - if: ${{ !runner.debug }}
+        name: Run nginx-tests without sanitizer
+        working-directory: nginx-tests
+        run: |
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/build-dir/lib \
+            TMPDIR=$GITHUB_WORKSPACE TEST_NGINX_BINARY=../nginx/objs/nginx \
+            prove ${{ matrix.sanitize-not-ok }}
+
+      - if: ${{ runner.debug }}
+        name: Enable wolfSSL debug logging
+        run: |
+          echo "nginx_c_flags=-O0" >> $GITHUB_ENV
+
+      - name: Build nginx with sanitizer
+        working-directory: nginx
+        run: |
+          ./auto/configure --with-wolfssl=$GITHUB_WORKSPACE/build-dir --with-http_ssl_module \
+            --with-stream --with-stream_ssl_module --with-stream_ssl_preread_module \
+            --with-http_v2_module --with-mail --with-mail_ssl_module \
+            --with-cc-opt='-fsanitize=address -DNGX_DEBUG_PALLOC=1 -g3 ${{ env.nginx_c_flags }}' \
+            --with-ld-opt='-fsanitize=address ${{ env.nginx_c_flags }}'
+          make -j
+
+      - name: Confirm nginx built with wolfSSL
+        working-directory: nginx
+        run: ldd objs/nginx | grep wolfssl
+
+      - if: ${{ runner.debug }}
+        name: Run nginx-tests with sanitizer (debug)
+        working-directory: nginx-tests
+        run: |
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/build-dir/lib \
+          TMPDIR=$GITHUB_WORKSPACE TEST_NGINX_VERBOSE=y TEST_NGINX_CATLOG=y \
+          TEST_NGINX_BINARY=../nginx/objs/nginx prove -v ${{ matrix.sanitize-ok }}
+
+      - if: ${{ !runner.debug }}
+        name: Run nginx-tests with sanitizer
+        working-directory: nginx-tests
+        run: |
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/build-dir/lib \
+            TMPDIR=$GITHUB_WORKSPACE TEST_NGINX_BINARY=../nginx/objs/nginx \
+            prove ${{ matrix.sanitize-ok }}
+ 

--- a/configure.ac
+++ b/configure.ac
@@ -5844,6 +5844,8 @@ fi
 if test "$ENABLED_NGINX" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_NGINX -DWOLFSSL_SIGNER_DER_CERT"
+    AM_CFLAGS="$AM_CFLAGS -DOPENSSL_COMPATIBLE_DEFAULTS"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ERROR_CODE_OPENSSL"
 fi
 
 if test "$ENABLED_HAPROXY" = "yes"
@@ -7836,6 +7838,8 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALT_CERT_CHAINS"
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_PRIORITIZE_PSK"
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_CHECK_ALERT_ON_ERR"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_TICKET_HAVE_ID"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_NO_OCSP_ISSUER_CHECK"
     ENABLED_TRUSTED_PEER_CERT=yes
 fi
 
@@ -8855,8 +8859,14 @@ fi
 
 if test "$ENABLED_REPRODUCIBLE_BUILD" != "yes"
 then
-    echo "#define LIBWOLFSSL_CONFIGURE_ARGS \"$ac_configure_args\"" | sed 's/\\/\\\\/g' > "${output_objdir}/.build_params" &&
-        echo "#define LIBWOLFSSL_GLOBAL_CFLAGS \"$CPPFLAGS $AM_CPPFLAGS $CFLAGS $AM_CFLAGS\" LIBWOLFSSL_GLOBAL_EXTRA_CFLAGS" | sed 's/\\/\\\\/g' >> "${output_objdir}/.build_params" ||
+    ESCAPED_ARGS="$ac_configure_args"
+    ESCAPED_ARGS=$(echo "$ESCAPED_ARGS" | sed 's/\\/\\\\/g')
+    ESCAPED_ARGS=$(echo "$ESCAPED_ARGS" | sed 's/\"/\\\"/g')
+    ESCAPED_GLOBAL_ARGS="$CPPFLAGS $AM_CPPFLAGS $CFLAGS $AM_CFLAGS"
+    ESCAPED_GLOBAL_ARGS=$(echo "$ESCAPED_GLOBAL_ARGS" | sed 's/\\/\\\\/g')
+    ESCAPED_GLOBAL_ARGS=$(echo "$ESCAPED_GLOBAL_ARGS" | sed 's/\"/\\\"/g')
+    echo "#define LIBWOLFSSL_CONFIGURE_ARGS \"$ESCAPED_ARGS\"" > "${output_objdir}/.build_params" &&
+        echo "#define LIBWOLFSSL_GLOBAL_CFLAGS \"$ESCAPED_GLOBAL_ARGS\" LIBWOLFSSL_GLOBAL_EXTRA_CFLAGS" >> "${output_objdir}/.build_params" ||
         AC_MSG_ERROR([Couldn't create ${output_objdir}/.build_params.])
 else
     rm -f "${output_objdir}/.build_params"

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4519,6 +4519,10 @@ int wolfSSL_get_error(WOLFSSL* ssl, int ret)
         return WOLFSSL_ERROR_WANT_WRITE;        /* convert to OpenSSL type */
     else if (ssl->error == ZERO_RETURN || ssl->options.shutdownDone)
         return WOLFSSL_ERROR_ZERO_RETURN;       /* convert to OpenSSL type */
+#ifdef OPENSSL_EXTRA
+    else if (ssl->error == SOCKET_PEER_CLOSED_E)
+        return WOLFSSL_ERROR_SYSCALL;           /* convert to OpenSSL type */
+#endif
 #if defined(WOLFSSL_HAPROXY)
     return GetX509Error(ssl->error);
 #else
@@ -5803,6 +5807,46 @@ Signer* GetCA(void* vp, byte* hash)
     return ret;
 }
 
+#ifdef WOLFSSL_AKID_NAME
+Signer* GetCAByAKID(void* vp, const byte* issuer, word32 issuerSz,
+        const byte* serial, word32 serialSz)
+{
+    WOLFSSL_CERT_MANAGER* cm = (WOLFSSL_CERT_MANAGER*)vp;
+    Signer* ret = NULL;
+    Signer* signers;
+    byte nameHash[SIGNER_DIGEST_SIZE];
+    byte serialHash[SIGNER_DIGEST_SIZE];
+    word32 row;
+
+    if (cm == NULL || issuer == NULL || issuerSz == 0 ||
+            serial == NULL || serialSz == 0)
+        return NULL;
+
+    if (CalcHashId(issuer, issuerSz, nameHash) != 0 ||
+            CalcHashId(serial, serialSz, serialHash) != 0)
+        return NULL;
+
+    if (wc_LockMutex(&cm->caLock) != 0)
+        return ret;
+
+    /* Unfortunately we need to look through the entire table */
+    for (row = 0; row < CA_TABLE_SIZE && ret == NULL; row++) {
+        for (signers = cm->caTable[row]; signers != NULL;
+                signers = signers->next) {
+            if (XMEMCMP(signers->subjectNameHash, nameHash, SIGNER_DIGEST_SIZE)
+                    == 0 && XMEMCMP(signers->serialHash, serialHash,
+                                    SIGNER_DIGEST_SIZE) == 0) {
+                ret = signers;
+                break;
+            }
+        }
+    }
+
+    wc_UnLockMutex(&cm->caLock);
+
+    return ret;
+}
+#endif
 
 #ifndef NO_SKID
 /* return CA if found, otherwise NULL. Walk through hash table. */
@@ -6111,6 +6155,9 @@ int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify)
         ret = AllocDer(&signer->derCert, der->length, der->type, NULL);
     }
     if (ret == 0 && signer != NULL) {
+        ret = CalcHashId(cert->serial, cert->serialSz, signer->serialHash);
+    }
+    if (ret == 0 && signer != NULL) {
         XMEMCPY(signer->derCert->buffer, der->buffer, der->length);
     #endif
         signer->keyOID         = cert->keyOID;
@@ -6137,7 +6184,10 @@ int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify)
         XMEMCPY(signer->subjectNameHash, cert->subjectHash,
                 SIGNER_DIGEST_SIZE);
     #ifdef HAVE_OCSP
-        XMEMCPY(signer->subjectKeyHash, cert->subjectKeyHash, KEYID_SIZE);
+        XMEMCPY(signer->issuerNameHash, cert->issuerHash,
+                SIGNER_DIGEST_SIZE);
+        XMEMCPY(signer->subjectKeyHash, cert->subjectKeyHash,
+                KEYID_SIZE);
     #endif
         signer->keyUsage = cert->extKeyUsageSet ? cert->extKeyUsage
                                                 : 0xFFFF;
@@ -8641,7 +8691,7 @@ int wolfSSL_CertManagerCheckOCSP(WOLFSSL_CERT_MANAGER* cm, byte* der, int sz)
     if ((ret = ParseCertRelative(cert, CERT_TYPE, VERIFY_OCSP, cm)) != 0) {
         WOLFSSL_MSG("ParseCert failed");
     }
-    else if ((ret = CheckCertOCSP(cm->ocsp, cert, NULL)) != 0) {
+    else if ((ret = CheckCertOCSP(cm->ocsp, cert)) != 0) {
         WOLFSSL_MSG("CheckCertOCSP failed");
     }
 
@@ -8666,7 +8716,7 @@ int wolfSSL_CertManagerCheckOCSPResponse(WOLFSSL_CERT_MANAGER *cm,
         return WOLFSSL_SUCCESS;
 
     ret = CheckOcspResponse(cm->ocsp, response, responseSz, responseBuffer, status,
-                        entry, ocspRequest);
+                        entry, ocspRequest, NULL);
 
     return ret == 0 ? WOLFSSL_SUCCESS : ret;
 }
@@ -12156,13 +12206,19 @@ long wolfSSL_CTX_set_session_cache_mode(WOLFSSL_CTX* ctx, long mode)
     if (ctx == NULL)
         return WOLFSSL_FAILURE;
 
-    if (mode == WOLFSSL_SESS_CACHE_OFF)
+    if (mode == WOLFSSL_SESS_CACHE_OFF) {
         ctx->sessionCacheOff = 1;
+#ifdef HAVE_EXT_CACHE
+        ctx->internalCacheOff = 1;
+        ctx->internalCacheLookupOff = 1;
+#endif
+    }
 
     if ((mode & WOLFSSL_SESS_CACHE_NO_AUTO_CLEAR) != 0)
         ctx->sessionCacheFlushOff = 1;
 
 #ifdef HAVE_EXT_CACHE
+    /* WOLFSSL_SESS_CACHE_NO_INTERNAL activates both if's */
     if ((mode & WOLFSSL_SESS_CACHE_NO_INTERNAL_STORE) != 0)
         ctx->internalCacheOff = 1;
     if ((mode & WOLFSSL_SESS_CACHE_NO_INTERNAL_LOOKUP) != 0)
@@ -14965,6 +15021,22 @@ static int TlsSessionCacheGetAndLock(const byte *id,
     return 0;
 }
 
+static int CheckSessionMatch(const WOLFSSL* ssl, const WOLFSSL_SESSION* sess)
+{
+    if (ssl == NULL || sess == NULL)
+        return 0;
+#ifdef OPENSSL_EXTRA
+    if (ssl->sessionCtxSz > 0 && (ssl->sessionCtxSz != sess->sessionCtxSz ||
+           XMEMCMP(ssl->sessionCtx, sess->sessionCtx, sess->sessionCtxSz) != 0))
+        return 0;
+#endif
+#if defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET)
+    if (IsAtLeastTLSv1_3(ssl->version) != IsAtLeastTLSv1_3(sess->version))
+        return 0;
+#endif
+    return 1;
+}
+
 int TlsSessionCacheGetAndRdLock(const byte *id, const WOLFSSL_SESSION **sess,
         word32 *lockedRow, byte side)
 {
@@ -15040,37 +15112,38 @@ int wolfSSL_GetSessionFromCache(WOLFSSL* ssl, WOLFSSL_SESSION* output)
 #ifdef HAVE_EXT_CACHE
     if (ssl->ctx->get_sess_cb != NULL) {
         int copy = 0;
+        int found = 0;
         WOLFSSL_SESSION* extSess;
         /* Attempt to retrieve the session from the external cache. */
         WOLFSSL_MSG("Calling external session cache");
         extSess = ssl->ctx->get_sess_cb(ssl, (byte*)id, ID_LEN, &copy);
         if ((extSess != NULL)
-        #if defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET)
-            && (IsAtLeastTLSv1_3(ssl->version) ==
-                IsAtLeastTLSv1_3(extSess->version))
-        #endif
+                && CheckSessionMatch(ssl, extSess)
             ) {
             WOLFSSL_MSG("Session found in external cache");
+            found = 1;
+
             error = wolfSSL_DupSession(extSess, output, 0);
 #ifdef HAVE_EX_DATA
             extSess->ownExData = 1;
             output->ownExData = 0;
 #endif
-            /* If copy not set then free immediately */
-            if (!copy)
-                wolfSSL_FreeSession(ssl->ctx, extSess);
             /* We want to restore the bogus ID for TLS compatibility */
             if (ssl->session->haveAltSessionID &&
                     output == ssl->session) {
                 XMEMCPY(ssl->session->sessionID, bogusID, ID_LEN);
                 ssl->session->sessionIDSz = bogusIDSz;
             }
-            return error;
         }
+        /* If copy not set then free immediately */
+        if (extSess != NULL && !copy)
+            wolfSSL_FreeSession(ssl->ctx, extSess);
+        if (found)
+            return error;
         WOLFSSL_MSG("Session not found in external cache");
     }
 
-    if (ssl->ctx->internalCacheLookupOff) {
+    if (ssl->options.internalCacheLookupOff) {
         WOLFSSL_MSG("Internal cache lookup turned off");
         return WOLFSSL_FAILURE;
     }
@@ -15154,12 +15227,12 @@ int wolfSSL_GetSessionFromCache(WOLFSSL* ssl, WOLFSSL_SESSION* output)
 #endif
     }
     else {
-#if defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET)
-        if (IsAtLeastTLSv1_3(ssl->version) != IsAtLeastTLSv1_3(sess->version)) {
-            WOLFSSL_MSG("Invalid session: different protocol version");
+        if (!CheckSessionMatch(ssl, sess)) {
+            WOLFSSL_MSG("Invalid session: can't be used in this context");
             TlsSessionCacheUnlockRow(row);
             error = WOLFSSL_FAILURE;
         }
+#if defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET)
         else if (LowResTimer() >= (sess->bornOn + sess->timeout)) {
             WOLFSSL_SESSION* wrSess = NULL;
             WOLFSSL_MSG("Invalid session: timed out");
@@ -15932,27 +16005,32 @@ void AddSession(WOLFSSL* ssl)
         idSz = ID_LEN;
     }
 
-    /* Try to add the session to internal cache or external cache
-    if a new_sess_cb is set. Its ok if we don't succeed. */
-    (void)AddSessionToCache(ssl->ctx, session, id, idSz,
-#ifdef SESSION_INDEX
-            &ssl->sessionIndex,
-#else
-            NULL,
+#ifdef HAVE_EXT_CACHE
+    if (!ssl->options.internalCacheOff)
 #endif
-            ssl->options.side,
-#ifdef HAVE_SESSION_TICKET
-            ssl->options.useTicket,
+    {
+        /* Try to add the session to internal cache or external cache
+        if a new_sess_cb is set. Its ok if we don't succeed. */
+        (void)AddSessionToCache(ssl->ctx, session, id, idSz,
+#ifdef SESSION_INDEX
+                &ssl->sessionIndex,
 #else
-            0,
+                NULL,
+#endif
+                ssl->options.side,
+#ifdef HAVE_SESSION_TICKET
+                ssl->options.useTicket,
+#else
+                0,
 #endif
 #ifdef NO_SESSION_CACHE_REF
-            NULL
+                NULL
 #else
-            (ssl->options.side == WOLFSSL_CLIENT_END) ?
-                    &ssl->clientSession : NULL
+                (ssl->options.side == WOLFSSL_CLIENT_END) ?
+                        &ssl->clientSession : NULL
 #endif
-                    );
+                        );
+    }
 
 #ifdef HAVE_EXT_CACHE
     if (error == 0 && ssl->ctx->new_sess_cb != NULL) {
@@ -17337,8 +17415,8 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
     {
         WOLFSSL_ENTER("wolfSSL_CTX_set_client_CA_list");
         if (ctx != NULL) {
-            wolfSSL_sk_X509_NAME_pop_free(ctx->ca_names, NULL);
-            ctx->ca_names = names;
+            wolfSSL_sk_X509_NAME_pop_free(ctx->client_ca_names, NULL);
+            ctx->client_ca_names = names;
         }
     }
 
@@ -17347,9 +17425,9 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
     {
         WOLFSSL_ENTER("wolfSSL_set_client_CA_list");
         if (ssl != NULL) {
-            if (ssl->ca_names != ssl->ctx->ca_names)
-                wolfSSL_sk_X509_NAME_pop_free(ssl->ca_names, NULL);
-            ssl->ca_names = names;
+            if (ssl->client_ca_names != ssl->ctx->client_ca_names)
+                wolfSSL_sk_X509_NAME_pop_free(ssl->client_ca_names, NULL);
+            ssl->client_ca_names = names;
         }
     }
 
@@ -17409,7 +17487,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
 
 #endif /* OPENSSL_EXTRA || WOLFSSL_EXTRA || HAVE_WEBSERVER */
 
-#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_EXTRA)
+#ifndef WOLFSSL_NO_CA_NAMES
     WOLF_STACK_OF(WOLFSSL_X509_NAME)* wolfSSL_CTX_get_client_CA_list(
             const WOLFSSL_CTX *ctx)
     {
@@ -17420,7 +17498,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             return NULL;
         }
 
-        return ctx->ca_names;
+        return ctx->client_ca_names;
     }
 
     /* returns the CA's set on server side or the CA's sent from server when
@@ -17450,9 +17528,9 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             return WOLFSSL_FAILURE;
         }
 
-        if (ctx->ca_names == NULL) {
-            ctx->ca_names = wolfSSL_sk_X509_NAME_new(NULL);
-            if (ctx->ca_names == NULL) {
+        if (ctx->client_ca_names == NULL) {
+            ctx->client_ca_names = wolfSSL_sk_X509_NAME_new(NULL);
+            if (ctx->client_ca_names == NULL) {
                 WOLFSSL_MSG("wolfSSL_sk_X509_NAME_new error");
                 return WOLFSSL_FAILURE;
             }
@@ -17464,7 +17542,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             return WOLFSSL_FAILURE;
         }
 
-        if (wolfSSL_sk_X509_NAME_push(ctx->ca_names, nameCopy) != WOLFSSL_SUCCESS) {
+        if (wolfSSL_sk_X509_NAME_push(ctx->client_ca_names, nameCopy) != WOLFSSL_SUCCESS) {
             WOLFSSL_MSG("wolfSSL_sk_X509_NAME_push error");
             wolfSSL_X509_NAME_free(nameCopy);
             return WOLFSSL_FAILURE;
@@ -22165,6 +22243,8 @@ const char* wolfSSL_get_curve_name(WOLFSSL* ssl)
 {
     const char* cName = NULL;
 
+    WOLFSSL_ENTER("wolfSSL_get_curve_name");
+
     if (ssl == NULL)
         return NULL;
 
@@ -23864,7 +23944,7 @@ long wolfSSL_set_tlsext_debug_arg(WOLFSSL* ssl, void *arg)
 }
 #endif /* HAVE_PK_CALLBACKS */
 
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY)
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_NGINX)
 const unsigned char *wolfSSL_SESSION_get0_id_context(
                       const WOLFSSL_SESSION *sess, unsigned int *sid_ctx_length)
 {
@@ -26069,17 +26149,6 @@ long wolfSSL_SESSION_get_timeout(const WOLFSSL_SESSION* sess)
     return timeout;
 }
 
-
-long wolfSSL_SESSION_get_time(const WOLFSSL_SESSION* sess)
-{
-    long bornOn = 0;
-    WOLFSSL_ENTER("wolfSSL_SESSION_get_time");
-    sess = ClientSessionToSession(sess);
-    if (sess)
-        bornOn = sess->bornOn;
-    return bornOn;
-}
-
 long wolfSSL_SSL_SESSION_set_timeout(WOLFSSL_SESSION* ses, long t)
 {
     word32 tmptime;
@@ -26093,6 +26162,27 @@ long wolfSSL_SSL_SESSION_set_timeout(WOLFSSL_SESSION* ses, long t)
     ses->timeout = tmptime;
 
     return WOLFSSL_SUCCESS;
+}
+
+long wolfSSL_SESSION_get_time(const WOLFSSL_SESSION* sess)
+{
+    long bornOn = 0;
+    WOLFSSL_ENTER("wolfSSL_SESSION_get_time");
+    sess = ClientSessionToSession(sess);
+    if (sess)
+        bornOn = sess->bornOn;
+    return bornOn;
+}
+
+long wolfSSL_SESSION_set_time(WOLFSSL_SESSION *ses, long t)
+{
+
+    ses = ClientSessionToSession(ses);
+    if (ses == NULL || t < 0) {
+        return 0;
+    }
+    ses->bornOn = (word32)t;
+    return t;
 }
 
 #endif /* !NO_SESSION_CACHE && OPENSSL_EXTRA || HAVE_EXT_CACHE */
@@ -33006,10 +33096,9 @@ int wolfSSL_SSL_in_init(WOLFSSL *ssl)
     if (ssl == NULL)
         return WOLFSSL_FAILURE;
 
-    if (ssl->options.side == WOLFSSL_CLIENT_END) {
-        return ssl->options.connectState < SECOND_REPLY_DONE;
-    }
-    return ssl->options.acceptState < ACCEPT_THIRD_REPLY_DONE;
+    /* Can't use ssl->options.connectState and ssl->options.acceptState because
+     * they differ in meaning for TLS <=1.2 and 1.3 */
+    return ssl->options.handShakeState != HANDSHAKE_DONE;
 }
 
 int wolfSSL_SSL_in_connect_init(WOLFSSL* ssl)

--- a/tests/api.c
+++ b/tests/api.c
@@ -8275,7 +8275,8 @@ static int test_wolfSSL_CTX_add_session_ext(
                     /* (D)TLSv1.3 creates a new ticket,
                      * updates both internal and external cache */
                     ExpectIntEQ(twcase_new_session_called, 1);
-                    ExpectIntEQ(twcase_remove_session_called, 1);
+                    /* A new session ID is created for a new ticket */
+                    ExpectIntEQ(twcase_remove_session_called, 2);
 
                 }
                 else {

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -63,7 +63,7 @@ ASN Options:
     does not perform a PKI validation, so it is not a secure solution.
     Only enabled for OCSP.
  * WOLFSSL_NO_OCSP_ISSUER_CHECK: Can be defined for backwards compatibility to
-    disable checking of OCSP subject hash with issuer hash.
+    disable checking of https://www.rfc-editor.org/rfc/rfc6960#section-4.2.2.2.
  * WOLFSSL_SMALL_CERT_VERIFY: Verify the certificate signature without using
     DecodedCert. Doubles up on some code but allows smaller dynamic memory
     usage.
@@ -190,8 +190,8 @@ ASN Options:
     #include <wolfssl/wolfcrypt/cryptocb.h>
 #endif
 
+#include <wolfssl/internal.h>
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
-    #include <wolfssl/internal.h>
     #include <wolfssl/openssl/objects.h>
 #endif
 
@@ -18843,7 +18843,6 @@ static int DecodeAuthKeyId(const byte* input, word32 sz, DecodedCert* cert)
 #else
     DECL_ASNGETDATA(dataASN, authKeyIdASN_Length);
     int ret = 0;
-    word32 idx = 0;
 
     WOLFSSL_ENTER("DecodeAuthKeyId");
 
@@ -18851,30 +18850,58 @@ static int DecodeAuthKeyId(const byte* input, word32 sz, DecodedCert* cert)
 
     if (ret == 0) {
         /* Parse an authority key identifier. */
+        word32 idx = 0;
         ret = GetASN_Items(authKeyIdASN, dataASN, authKeyIdASN_Length, 1, input,
                            &idx, sz);
     }
-    if (ret == 0) {
-        /* Key id is optional. */
-        if (dataASN[AUTHKEYIDASN_IDX_KEYID].data.ref.data == NULL) {
-            WOLFSSL_MSG("\tinfo: OPTIONAL item 0, not available");
-        }
-        else {
+    /* Each field is optional */
+    if (ret == 0 && dataASN[AUTHKEYIDASN_IDX_KEYID].data.ref.data != NULL) {
 #ifdef OPENSSL_EXTRA
-            /* Store the authority key id. */
-#ifdef WOLFSSL_AKID_NAME
-            cert->extRawAuthKeyIdSrc = input;
-            cert->extRawAuthKeyIdSz = sz;
-#endif
-            GetASN_GetConstRef(&dataASN[AUTHKEYIDASN_IDX_KEYID], &cert->extAuthKeyIdSrc,
-                               &cert->extAuthKeyIdSz);
+        GetASN_GetConstRef(&dataASN[AUTHKEYIDASN_IDX_KEYID],
+                &cert->extAuthKeyIdSrc, &cert->extAuthKeyIdSz);
 #endif /* OPENSSL_EXTRA */
+        /* Get the hash or hash of the hash if wrong size. */
+        ret = GetHashId(dataASN[AUTHKEYIDASN_IDX_KEYID].data.ref.data,
+                    (int)dataASN[AUTHKEYIDASN_IDX_KEYID].data.ref.length,
+                    cert->extAuthKeyId, HashIdAlg(cert->signatureOID));
+    }
+#ifdef WOLFSSL_AKID_NAME
+    if (ret == 0 && dataASN[AUTHKEYIDASN_IDX_ISSUER].data.ref.data != NULL) {
+        /* We only support using one (first) name. Parse the name to perform
+         * a sanity check. */
+        word32 idx = 0;
+        ASNGetData nameASN[altNameASN_Length];
+        XMEMSET(nameASN, 0, sizeof(nameASN));
+        /* Parse GeneralName with the choices supported. */
+        GetASN_Choice(&nameASN[ALTNAMEASN_IDX_GN], generalNameChoice);
+        /* Decode a GeneralName choice. */
+        ret = GetASN_Items(altNameASN, nameASN, altNameASN_Length, 0,
+                dataASN[AUTHKEYIDASN_IDX_ISSUER].data.ref.data, &idx,
+                dataASN[AUTHKEYIDASN_IDX_ISSUER].data.ref.length);
 
-            /* Get the hash or hash of the hash if wrong size. */
-            ret = GetHashId(dataASN[AUTHKEYIDASN_IDX_KEYID].data.ref.data,
-                        (int)dataASN[AUTHKEYIDASN_IDX_KEYID].data.ref.length,
-                        cert->extAuthKeyId, HashIdAlg((int)cert->signatureOID));
+        if (ret == 0) {
+            GetASN_GetConstRef(&nameASN[ALTNAMEASN_IDX_GN],
+                    &cert->extAuthKeyIdIssuer, &cert->extAuthKeyIdIssuerSz);
         }
+    }
+    if (ret == 0 && dataASN[AUTHKEYIDASN_IDX_SERIAL].data.ref.data != NULL) {
+        GetASN_GetConstRef(&dataASN[AUTHKEYIDASN_IDX_SERIAL],
+                &cert->extAuthKeyIdIssuerSN, &cert->extAuthKeyIdIssuerSNSz);
+    }
+    if (ret == 0) {
+        if ((cert->extAuthKeyIdIssuerSz > 0) ^
+                (cert->extAuthKeyIdIssuerSNSz > 0)) {
+            WOLFSSL_MSG("authorityCertIssuer and authorityCertSerialNumber MUST"
+                       " both be present or both be absent");
+        }
+    }
+#endif /* WOLFSSL_AKID_NAME */
+    if (ret == 0) {
+#if defined(OPENSSL_EXTRA) && defined(WOLFSSL_AKID_NAME)
+        /* Store the raw authority key id. */
+        cert->extRawAuthKeyIdSrc = input;
+        cert->extRawAuthKeyIdSz = sz;
+#endif /* OPENSSL_EXTRA */
     }
 
     FREE_ASNGETDATA(dataASN, cert->heap);
@@ -21454,6 +21481,19 @@ Signer* GetCAByName(void* signers, byte* hash)
 }
 #endif /* NO_SKID */
 
+#ifdef WOLFSSL_AKID_NAME
+Signer* GetCAByAKID(void* vp, const byte* issuer, word32 issuerSz,
+        const byte* serial, word32 serialSz)
+{
+    (void)issuer;
+    (void)issuerSz;
+    (void)serial;
+    (void)serialSz;
+
+    return (Signer*)vp;
+}
+#endif
+
 #endif /* WOLFCRYPT_ONLY */
 
 #if defined(WOLFSSL_NO_TRUSTED_CERTS_VERIFY) && !defined(NO_SKID)
@@ -22576,6 +22616,13 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
     #ifndef NO_SKID
             if (cert->extAuthKeyIdSet) {
                 cert->ca = GetCA(cm, cert->extAuthKeyId);
+        #ifdef WOLFSSL_AKID_NAME
+                if (cert->ca == NULL) {
+                    cert->ca = GetCAByAKID(cm, cert->extAuthKeyIdIssuer,
+                        cert->extAuthKeyIdIssuerSz, cert->extAuthKeyIdIssuerSN,
+                        cert->extAuthKeyIdIssuerSNSz);
+                }
+        #endif
             }
             if (cert->ca == NULL && cert->extSubjKeyIdSet
                                  && verify != VERIFY_OCSP) {
@@ -34140,6 +34187,9 @@ static int DecodeSingleResponse(byte* source, word32* ioIndex, word32 size,
     if (ret == 0) {
         /* Store serial size. */
         cs->serialSz = serialSz;
+        /* Set the hash algorithm OID */
+        single->hashAlgoOID =
+                dataASN[SINGLERESPONSEASN_IDX_CID_HASHALGO_OID].data.oid.sum;
 
         /* Determine status by which item was found. */
         if (dataASN[SINGLERESPONSEASN_IDX_CS_GOOD].tag != 0) {
@@ -34909,7 +34959,7 @@ static int DecodeBasicOcspResponse(byte* source, word32* ioIndex,
     if ((ret == 0) &&
             (dataASN[OCSPBASICRESPASN_IDX_CERTS_SEQ].data.ref.data != NULL)) {
     #endif
-        /* Initialize the crtificate object. */
+        /* Initialize the certificate object. */
         InitDecodedCert(cert, resp->cert, resp->certSz, heap);
         certInit = 1;
         /* Parse the certificate and don't verify if we don't have access to
@@ -34920,6 +34970,13 @@ static int DecodeBasicOcspResponse(byte* source, word32* ioIndex,
             WOLFSSL_MSG("\tOCSP Responder certificate parsing failed");
         }
     }
+#ifndef WOLFSSL_NO_OCSP_ISSUER_CHECK
+    if ((ret == 0) &&
+            (dataASN[OCSPBASICRESPASN_IDX_CERTS_SEQ].data.ref.data != NULL) &&
+            !noVerify) {
+        ret = CheckOcspResponder(resp, cert, cm);
+    }
+#endif /* WOLFSSL_NO_OCSP_ISSUER_CHECK */
     if ((ret == 0) &&
             (dataASN[OCSPBASICRESPASN_IDX_CERTS_SEQ].data.ref.data != NULL)) {
         /* TODO: ConfirmSignature is blocking here */
@@ -35587,6 +35644,14 @@ void FreeOcspRequest(OcspRequest* req)
         if (req->url)
             XFREE(req->url, req->heap, DYNAMIC_TYPE_OCSP_REQUEST);
         req->url = NULL;
+
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || \
+    defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_APACHE_HTTPD) || \
+    defined(HAVE_LIGHTY)
+        if (req->cid != NULL)
+            wolfSSL_OCSP_CERTID_free((WOLFSSL_OCSP_CERTID*)req->cid);
+        req->cid = NULL;
+#endif
     }
 }
 

--- a/wolfssl/ocsp.h
+++ b/wolfssl/ocsp.h
@@ -53,15 +53,19 @@ typedef struct OcspRequest WOLFSSL_OCSP_REQUEST;
 WOLFSSL_LOCAL int  InitOCSP(WOLFSSL_OCSP* ocsp, WOLFSSL_CERT_MANAGER* cm);
 WOLFSSL_LOCAL void FreeOCSP(WOLFSSL_OCSP* ocsp, int dynamic);
 
-WOLFSSL_LOCAL int  CheckCertOCSP(WOLFSSL_OCSP* ocsp, DecodedCert* cert,
-                                 WOLFSSL_BUFFER_INFO* responseBuffer);
+WOLFSSL_LOCAL int  CheckCertOCSP(WOLFSSL_OCSP* ocsp, DecodedCert* cert);
 WOLFSSL_LOCAL int  CheckCertOCSP_ex(WOLFSSL_OCSP* ocsp, DecodedCert* cert,
-                                    WOLFSSL_BUFFER_INFO* responseBuffer, WOLFSSL* ssl);
+                                    WOLFSSL* ssl);
 WOLFSSL_LOCAL int  CheckOcspRequest(WOLFSSL_OCSP* ocsp,
-                 OcspRequest* ocspRequest, WOLFSSL_BUFFER_INFO* responseBuffer);
+                 OcspRequest* ocspRequest, WOLFSSL_BUFFER_INFO* responseBuffer,
+                 void* heap);
 WOLFSSL_LOCAL int CheckOcspResponse(WOLFSSL_OCSP *ocsp, byte *response, int responseSz,
                                     WOLFSSL_BUFFER_INFO *responseBuffer, CertStatus *status,
-                                    OcspEntry *entry, OcspRequest *ocspRequest);
+                                    OcspEntry *entry, OcspRequest *ocspRequest,
+                                    void* heap);
+
+WOLFSSL_LOCAL int CheckOcspResponder(OcspResponse *bs, DecodedCert *cert,
+                                     void* vp);
 
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) || \
     defined(WOLFSSL_APACHE_HTTPD) || defined(HAVE_LIGHTY)

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -1083,6 +1083,7 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
                                         wolfSSL_SESSION_get_ticket_lifetime_hint
 #define SSL_SESSION_set_timeout         wolfSSL_SSL_SESSION_set_timeout
 #define SSL_SESSION_get_timeout         wolfSSL_SESSION_get_timeout
+#define SSL_SESSION_set_time            wolfSSL_SESSION_set_time
 #define SSL_SESSION_get_time            wolfSSL_SESSION_get_time
 
 #define SSL_CTX_get_ex_new_index        wolfSSL_CTX_get_ex_new_index
@@ -1510,6 +1511,11 @@ typedef WOLFSSL_SRTP_PROTECTION_PROFILE      SRTP_PROTECTION_PROFILE;
 #define SSL_R_UNEXPECTED_MESSAGE                   OUT_OF_ORDER_E
 #define SSL_R_UNEXPECTED_RECORD                    SANITY_MSG_E
 #define SSL_R_UNKNOWN_ALERT_TYPE                   BUFFER_ERROR
+#define SSL_R_BAD_DIGEST_LENGTH                    BUFFER_ERROR
+#define SSL_R_BAD_PACKET_LENGTH                    BUFFER_ERROR
+#define SSL_R_DATA_LENGTH_TOO_LONG                 BUFFER_ERROR
+#define SSL_R_ENCRYPTED_LENGTH_TOO_LONG            BUFFER_ERROR
+#define SSL_R_BAD_LENGTH                           BUFFER_ERROR
 #define SSL_R_UNKNOWN_PROTOCOL                     VERSION_ERROR
 #define SSL_R_WRONG_VERSION_NUMBER                 VERSION_ERROR
 #define SSL_R_DECRYPTION_FAILED_OR_BAD_RECORD_MAC  ENCRYPT_ERROR
@@ -1519,6 +1525,7 @@ typedef WOLFSSL_SRTP_PROTECTION_PROFILE      SRTP_PROTECTION_PROFILE;
 #define SSL_R_CERTIFICATE_VERIFY_FAILED            VERIFY_CERT_ERROR
 #define SSL_R_CERT_CB_ERROR                        CLIENT_CERT_CB_ERROR
 #define SSL_R_NULL_SSL_METHOD_PASSED               BAD_FUNC_ARG
+#define SSL_R_CCS_RECEIVED_EARLY                   OUT_OF_ORDER_E
 
 #ifdef HAVE_SESSION_TICKET
 #define SSL_CTRL_SET_TLSEXT_TICKET_KEY_CB 72

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1233,6 +1233,7 @@ WOLFSSL_API int  wolfSSL_get_alert_history(WOLFSSL* ssl, WOLFSSL_ALERT_HISTORY *
 
 WOLFSSL_ABI WOLFSSL_API int  wolfSSL_set_session(WOLFSSL* ssl, WOLFSSL_SESSION* session);
 WOLFSSL_API long wolfSSL_SSL_SESSION_set_timeout(WOLFSSL_SESSION* ses, long t);
+WOLFSSL_API long wolfSSL_SESSION_set_time(WOLFSSL_SESSION *ses, long t);
 WOLFSSL_ABI WOLFSSL_API WOLFSSL_SESSION* wolfSSL_get_session(WOLFSSL* ssl);
 WOLFSSL_ABI WOLFSSL_API void wolfSSL_flush_sessions(WOLFSSL_CTX* ctx, long tm);
 WOLFSSL_API void wolfSSL_CTX_flush_sessions(WOLFSSL_CTX* ctx, long tm);
@@ -2251,25 +2252,25 @@ enum {
     WOLFSSL_OP_TLS_BLOCK_PADDING_BUG                  = 0x00000100,
     WOLFSSL_OP_TLS_ROLLBACK_BUG                       = 0x00000200,
     WOLFSSL_OP_EPHEMERAL_RSA                          = 0x00000800,
-    WOLFSSL_OP_NO_SSLv3                           = 0x00001000,
-    WOLFSSL_OP_NO_TLSv1                           = 0x00002000,
+    WOLFSSL_OP_NO_SSLv3                               = 0x00001000,
+    WOLFSSL_OP_NO_TLSv1                               = 0x00002000,
     WOLFSSL_OP_PKCS1_CHECK_1                          = 0x00004000,
     WOLFSSL_OP_PKCS1_CHECK_2                          = 0x00008000,
     WOLFSSL_OP_NETSCAPE_CA_DN_BUG                     = 0x00010000,
     WOLFSSL_OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG        = 0x00020000,
-    WOLFSSL_OP_SINGLE_DH_USE                      = 0x00040000,
+    WOLFSSL_OP_SINGLE_DH_USE                          = 0x00040000,
     WOLFSSL_OP_NO_TICKET                              = 0x00080000,
     WOLFSSL_OP_DONT_INSERT_EMPTY_FRAGMENTS            = 0x00100000,
     WOLFSSL_OP_NO_QUERY_MTU                           = 0x00200000,
     WOLFSSL_OP_COOKIE_EXCHANGE                        = 0x00400000,
     WOLFSSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION = 0x00800000,
-    WOLFSSL_OP_SINGLE_ECDH_USE                    = 0x01000000,
-    WOLFSSL_OP_CIPHER_SERVER_PREFERENCE           = 0x02000000,
-    WOLFSSL_OP_NO_TLSv1_1                         = 0x04000000,
-    WOLFSSL_OP_NO_TLSv1_2                         = 0x08000000,
-    WOLFSSL_OP_NO_COMPRESSION                     = 0x10000000,
-    WOLFSSL_OP_NO_TLSv1_3                         = 0x20000000,
-    WOLFSSL_OP_NO_SSLv2                           = 0x40000000,
+    WOLFSSL_OP_SINGLE_ECDH_USE                        = 0x01000000,
+    WOLFSSL_OP_CIPHER_SERVER_PREFERENCE               = 0x02000000,
+    WOLFSSL_OP_NO_TLSv1_1                             = 0x04000000,
+    WOLFSSL_OP_NO_TLSv1_2                             = 0x08000000,
+    WOLFSSL_OP_NO_COMPRESSION                         = 0x10000000,
+    WOLFSSL_OP_NO_TLSv1_3                             = 0x20000000,
+    WOLFSSL_OP_NO_SSLv2                               = 0x40000000,
     WOLFSSL_OP_ALL   =
                    (WOLFSSL_OP_MICROSOFT_SESS_ID_BUG
                   | WOLFSSL_OP_NETSCAPE_CHALLENGE_BUG
@@ -2535,7 +2536,9 @@ enum { /* ssl Constants */
     WOLFSSL_SESS_CACHE_NO_AUTO_CLEAR      = 0x0008,
     WOLFSSL_SESS_CACHE_NO_INTERNAL_LOOKUP = 0x0100,
     WOLFSSL_SESS_CACHE_NO_INTERNAL_STORE  = 0x0200,
-    WOLFSSL_SESS_CACHE_NO_INTERNAL        = 0x0300,
+    WOLFSSL_SESS_CACHE_NO_INTERNAL        =
+            (WOLFSSL_SESS_CACHE_NO_INTERNAL_STORE |
+                    WOLFSSL_SESS_CACHE_NO_INTERNAL_LOOKUP),
 
     WOLFSSL_ERROR_WANT_READ        =  2,
     WOLFSSL_ERROR_WANT_WRITE       =  3,

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1660,6 +1660,12 @@ struct DecodedCert {
     int     extCrlInfoSz;            /* length of the URI                */
     byte    extSubjKeyId[KEYID_SIZE]; /* Subject Key ID                  */
     byte    extAuthKeyId[KEYID_SIZE]; /* Authority Key ID                */
+#ifdef WOLFSSL_AKID_NAME
+    const byte* extAuthKeyIdIssuer;  /* Authority Key ID authorityCertIssuer */
+    word32  extAuthKeyIdIssuerSz;    /* Authority Key ID authorityCertIssuer length */
+    const byte* extAuthKeyIdIssuerSN; /* Authority Key ID authorityCertSerialNumber */
+    word32  extAuthKeyIdIssuerSNSz;   /* Authority Key ID authorityCertSerialNumber length */
+#endif
     byte    pathLength;              /* CA basic constraint path length  */
     byte    maxPathLen;              /* max_path_len see RFC 5280 section
                                       * 6.1.2 "Initialization" - (k) for
@@ -1947,13 +1953,22 @@ struct Signer {
 #endif /* IGNORE_NAME_CONSTRAINTS */
     byte    subjectNameHash[SIGNER_DIGEST_SIZE];
                                      /* sha hash of names in certificate */
+    #ifdef HAVE_OCSP
+        byte    issuerNameHash[SIGNER_DIGEST_SIZE];
+                                     /* sha hash of issuer names in certificate.
+                                      * Used in OCSP to check for authorized
+                                      * responders. */
+    #endif
     #ifndef NO_SKID
         byte    subjectKeyIdHash[SIGNER_DIGEST_SIZE];
-                                     /* sha hash of names in certificate */
+                                     /* sha hash of key in certificate */
     #endif
     #ifdef HAVE_OCSP
         byte subjectKeyHash[KEYID_SIZE];
     #endif
+#ifdef WOLFSSL_AKID_NAME
+    byte serialHash[SIGNER_DIGEST_SIZE]; /* serial number hash */
+#endif
 #ifdef WOLFSSL_SIGNER_DER_CERT
     DerBuffer* derCert;
 #endif
@@ -2450,6 +2465,11 @@ struct OcspRequest {
     int    serialSz;
 #ifdef OPENSSL_EXTRA
     WOLFSSL_ASN1_INTEGER* serialInt;
+#endif
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || \
+    defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_APACHE_HTTPD) || \
+    defined(HAVE_LIGHTY)
+    void* cid; /* WOLFSSL_OCSP_CERTID kept to free */
 #endif
     byte*  url;      /* copy of the extAuthInfo in source cert */
     int    urlSz;


### PR DESCRIPTION
- Add nginx github action test
- Implement Certificate Authorities for TLS 1.3
- Implement secret logging for TLS 1.3
  - Can be used for example with `./configure CPPFLAGS="-DWOLFSSL_SSLKEYLOGFILE -DSHOW_SECRETS -DHAVE_SECRET_CALLBACK -DWOLFSSL_SSLKEYLOGFILE_OUTPUT='\"/tmp/secrets\"'"`
- Implement session context checking for tickets
- Check for authorized responder in OCSP basic response
- Fix handling call to ocsp->statusCb
- compat: Translate SOCKET_PEER_CLOSED_E to WOLFSSL_ERROR_SYSCALL
- Fix wolfSSL_CTX_set_session_cache_mode
  - WOLFSSL_SESS_CACHE_OFF means nothing should be on
  - WOLFSSL_SESS_CACHE_NO_INTERNAL turns off only the internal cache
- Respect ssl->options.internalCacheOff
- Implement SSL_SESSION_set_time
- wolfSSL_SESSION_get_id: Return sess->altSessionID when available
- nginx: add necessary defines and function plus some misc additions
- Fix memory leaks
- wolfSSL_OCSP_basic_verify: implement OCSP_TRUSTOTHER flag
- AKID: implement matching on issuer name and serial number