### PR TITLE
fix set_cipherlist edge case

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -12713,8 +12713,8 @@ static int wolfSSL_parse_cipher_list(WOLFSSL_CTX* ctx, Suites* suites,
             return WOLFSSL_FAILURE;
         else {
             /* suiteSz is zero. Depending on malloc implementation-dependent
-             * it will return a NULL or Address. Try again to memory allocation 
-             * by smallest size. 
+             * it will return a NULL or Address. Try again to memory allocation
+             * by smallest size.
              */
             suitesCpy = (byte*)XMALLOC(1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             if (suitesCpy == NULL)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -12708,8 +12708,19 @@ static int wolfSSL_parse_cipher_list(WOLFSSL_CTX* ctx, Suites* suites,
 
 #ifdef WOLFSSL_SMALL_STACK
     suitesCpy = (byte*)XMALLOC(suites->suiteSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    if (suitesCpy == NULL)
-        return WOLFSSL_FAILURE;
+    if (suitesCpy == NULL) {
+        if (suites->suiteSz != 0)
+            return WOLFSSL_FAILURE;
+        else {
+            /* suiteSz is zero. Depending on malloc implementation-dependent
+             * it will return a NULL or Address. Try again to memory allocation 
+             * by smallest size. 
+             */
+            suitesCpy = (byte*)XMALLOC(1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            if (suitesCpy == NULL)
+                return WOLFSSL_FAILURE;
+        }
+    }
 #endif
 
     XMEMCPY(suitesCpy, suites->suites, suites->suiteSz);

--- a/tests/api.c
+++ b/tests/api.c
@@ -933,9 +933,9 @@ static int test_for_double_Free(void)
             WOLFSSL_FILETYPE_PEM));
 #if defined(OPENSSL_EXTRA) && defined(WOLFSSL_TLS13) && defined(HAVE_AESGCM) && \
         defined(WOLFSSL_SHA384) && defined(WOLFSSL_AES_256)
-        /* only update TLSv13 suites 
-         * ctx->suite is not yet allocated. This is tls13Only case.
-         * Therefore, suite->suiteSz is zero at allocating suitesCpy.
+        /* only update TLSv13 suites
+         * ctx->suite is not yet allocated. This is tls13Only case
+         * Therefore, suite->suiteSz is zero at allocating suitesCpy
          */
         ExpectTrue(wolfSSL_CTX_set_cipher_list(ctx, "TLS13-AES256-GCM-SHA384"));
 #endif


### PR DESCRIPTION
# Description

CC-RX malloc returns NULL when its size is zero. This causes wolfSSL_CTX_set_cipher_list failure in edge case.

./configure --enable-opensslextra --enable-smallstack

# Testing
Run unit test case
Confirm the fix by CC-RX

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
