### PR TITLE
Fix ThreadSanitizer unlock of an unlocked mutex warning

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -14404,7 +14404,7 @@ int wolfSSL_Cleanup(void)
         SessionCache[i].lock_valid = 0;
     }
     #else
-    if ((session_lock_valid == 1) && (wc_UnLockRwLock(&session_lock) != 0)) {
+    if ((session_lock_valid == 1) && (wc_FreeRwLock(&session_lock) != 0)) {
         if (ret == WOLFSSL_SUCCESS)
             ret = BAD_MUTEX_E;
     }


### PR DESCRIPTION
# Description

`wc_UnLockRwLock(&session_lock)` was being called instead of `wc_FreeRwLock(&session_lock)`  in `wolfSSL_Cleanup()`.

This triggered thread sanitizer warnings when built with gcc or g++ `-fsanitize=thread`.

Fixes zd#16310

# Testing

Tested with reproducer in ticket.
