### PR TITLE
Fix trusted_ca_keys, refactor MAX_X509_SIZE

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -13203,15 +13203,16 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
             #endif
 
 #ifdef WOLFSSL_TLS13
+                /* RFC 8446 4.2.4 states trusted_ca_keys is not used
+                   in TLS 1.3. */
                 if (IsAtLeastTLSv1_3(ssl->version)) {
-                    if (msgType != client_hello &&
-                        msgType != encrypted_extensions)
-                        return EXT_NOT_ALLOWED;
+                    return EXT_NOT_ALLOWED;
                 }
                 else
 #endif
                 {
-                    if (msgType != client_hello)
+                    if (msgType != client_hello &&
+                        msgType != server_hello)
                         return EXT_NOT_ALLOWED;
                 }
                 ret = TCA_PARSE(ssl, input + offset, size, isRequest);

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1737,13 +1737,6 @@ enum Misc {
     MAX_WOLFSSL_FILE_SIZE = 1024UL * 1024UL * 4,  /* 4 mb file size alloc limit */
 #endif
 
-#if defined(HAVE_PQC)
-    MAX_X509_SIZE      = 8*1024, /* max static x509 buffer size; dilithium is big */
-#elif defined(WOLFSSL_HAPROXY)
-    MAX_X509_SIZE      = 3072, /* max static x509 buffer size */
-#else
-    MAX_X509_SIZE      = 2048, /* max static x509 buffer size */
-#endif
     CERT_MIN_SIZE      =  256, /* min PEM cert size with header/footer */
 
     NO_SNIFF           =   0,  /* not sniffing */
@@ -1876,6 +1869,15 @@ enum Misc {
 #define SESSIDX_IDX_MASK  0x0F
 #endif
 
+#ifndef MAX_X509_SIZE
+    #if defined(HAVE_PQC)
+        #define MAX_X509_SIZE   (8*1024) /* max static x509 buffer size; dilithium is big */
+    #elif defined(WOLFSSL_HAPROXY)
+        #define MAX_X509_SIZE   3072 /* max static x509 buffer size */
+    #else
+        #define MAX_X509_SIZE   2048 /* max static x509 buffer size */
+    #endif
+#endif
 
 /* max cert chain peer depth */
 #ifndef MAX_CHAIN_DEPTH


### PR DESCRIPTION
# Description

Fix trusted_ca_keys extension allowed logic.
Refactor MAX_X509_SIZE into a define so it can be overriden in build settings.

Fixes zd# 16270, 16273

# Testing

Test suite