### PR TITLE
Fix WinCE XSEEK_SET

### DIFF
--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -621,7 +621,7 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XFREAD     fread
     #define XFWRITE    fwrite
     #define XFCLOSE    fclose
-    #define XSEEK_END  SEEK_SET
+    #define XSEEK_SET  SEEK_SET
     #define XSEEK_END  SEEK_END
     #define XBADFILE   NULL
     #define XFGETS     fgets


### PR DESCRIPTION
# Description

Fix redefinition error - should be `XSEEK_SET`

Fixes forum report https://www.wolfssl.com/forums/topic2018-compilation-error-for-win32wce.html

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
