### PR TITLE
HAVE_PTHREAD gate in test.h

### DIFF
--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -182,7 +182,9 @@
     #include <sys/ioctl.h>
     #include <sys/time.h>
     #include <sys/socket.h>
-    #include <pthread.h>
+    #ifdef HAVE_PTHREAD
+        #include <pthread.h>
+    #endif
     #include <fcntl.h>
     #ifdef TEST_IPV6
         #include <netdb.h>


### PR DESCRIPTION
# Description

This is a corner case of cross-compiling testwolfcrypt, in my case for the Xtensa ESP32-S3 Linux kernel.

I didn't have a `pthread.h` and noticed that several other places (but not all?) are gated with `HAVE_PTHREAD`. 

This PR adds the `HAVE_PTHREAD` only to  `test.h` that I encountered, but I can add to other places in this PR if desired

Fixes zd# n/a/

# Testing

How did you test?

Ran the test app in cross-compiled app as well as Linux & ESP-IDF for ESP32.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
