### PR TITLE
Fix for benchmark always using 4KB of memory for `gStats`

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -22,48 +22,178 @@
 
 /* wolfCrypt benchmark */
 
+/* Some common, optional build settings:
+ * these can also be set in wolfssl/options.h or user_settings.h
+ * -------------------------------------------------------------
+ * make the binary always use CSV format:
+ * WOLFSSL_BENCHMARK_FIXED_CSV
+ *
+ * choose to use the same units, regardless of scale. pick 1:
+ * WOLFSSL_BENCHMARK_FIXED_UNITS_GB
+ * WOLFSSL_BENCHMARK_FIXED_UNITS_MB
+ * WOLFSSL_BENCHMARK_FIXED_UNITS_KB
+ * WOLFSSL_BENCHMARK_FIXED_UNITS_B
+ *
+ * when the output should be in machine-parseable format:
+ * GENERATE_MACHINE_PARSEABLE_REPORT
+ *
+ * Enable tracking of the stats into a static buffer (MAX_BENCH_STATS):
+ * WC_BENCH_TRACK_STATS
+ */
+
 
 #ifdef HAVE_CONFIG_H
     #include <config.h>
 #endif
 
-/* Some common, optional user settings                           */
-/* these can also be set in wolfssl/options.h or user_settings.h */
-/* ------------------------------------------------------------- */
-/* make the binary always use CSV format:                        */
-/* #define WOLFSSL_BENCHMARK_FIXED_CSV                           */
-/*                                                               */
-/* choose to use the same units, regardless of scale. pick 1:    */
-/* #define WOLFSSL_BENCHMARK_FIXED_UNITS_GB                      */
-/* #define WOLFSSL_BENCHMARK_FIXED_UNITS_MB                      */
-/* #define WOLFSSL_BENCHMARK_FIXED_UNITS_KB                      */
-/* #define WOLFSSL_BENCHMARK_FIXED_UNITS_B                       */
-/*                                                               */
-/* when the output should be in machine-parseable format:        */
-/* #define GENERATE_MACHINE_PARSEABLE_REPORT                     */
-/*                                                               */
-
-/* define the max length for each string of metric reported */
-#define __BENCHMARK_MAXIMUM_LINE_LENGTH 150
-
-/* some internal helpers to get values of settings   */
-/* this first one gets the text name of the #define parameter */
-#define __BENCHMARK_VALUE_TO_STRING(x) #x
-
-/* this next one gets the text value of the assigned value of #define param */
-#define __BENCHMARK_VALUE(x) __BENCHMARK_VALUE_TO_STRING(x)
-
-#define WOLFSSL_FIXED_UNITS_PER_SEC "MB/s" /* may be re-set by fixed units */
-
 #ifndef WOLFSSL_USER_SETTINGS
     #include <wolfssl/options.h>
 #endif
 #include <wolfssl/wolfcrypt/settings.h> /* also picks up user_settings.h */
+
+/* Macro to disable benchmark */
+#ifndef NO_CRYPT_BENCHMARK
+
 #include <wolfssl/wolfcrypt/types.h>
-#include <wolfssl/version.h>
 #include <wolfssl/wolfcrypt/wc_port.h>
-#include <wolfssl/wolfcrypt/ecc.h>
 #include <wolfssl/wolfcrypt/wolfmath.h>
+#include <wolfssl/wolfcrypt/memory.h>
+#include <wolfssl/wolfcrypt/random.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+#include <wolfssl/wolfcrypt/asn.h>
+#include <wolfssl/version.h>
+
+#ifdef HAVE_CHACHA
+    #include <wolfssl/wolfcrypt/chacha.h>
+#endif
+#ifdef HAVE_POLY1305
+    #include <wolfssl/wolfcrypt/poly1305.h>
+#endif
+#if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
+    #include <wolfssl/wolfcrypt/chacha20_poly1305.h>
+#endif
+#ifndef NO_AES
+    #include <wolfssl/wolfcrypt/aes.h>
+#endif
+#ifdef HAVE_CAMELLIA
+    #include <wolfssl/wolfcrypt/camellia.h>
+#endif
+#ifndef NO_MD5
+    #include <wolfssl/wolfcrypt/md5.h>
+#endif
+#ifndef NO_SHA
+    #include <wolfssl/wolfcrypt/sha.h>
+#endif
+#ifndef NO_SHA256
+    #include <wolfssl/wolfcrypt/sha256.h>
+#endif
+#if defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)
+    #include <wolfssl/wolfcrypt/sha512.h>
+#endif
+#ifdef WOLFSSL_SHA3
+    #include <wolfssl/wolfcrypt/sha3.h>
+#endif
+#ifndef NO_RSA
+    #include <wolfssl/wolfcrypt/rsa.h>
+#endif
+#ifdef WOLFSSL_RIPEMD
+    #include <wolfssl/wolfcrypt/ripemd.h>
+#endif
+#ifdef WOLFSSL_CMAC
+    #include <wolfssl/wolfcrypt/cmac.h>
+#endif
+#ifndef NO_DH
+    #include <wolfssl/wolfcrypt/dh.h>
+#endif
+#ifndef NO_DES3
+    #include <wolfssl/wolfcrypt/des3.h>
+#endif
+#ifndef NO_RC4
+    #include <wolfssl/wolfcrypt/arc4.h>
+#endif
+#ifndef NO_HMAC
+    #include <wolfssl/wolfcrypt/hmac.h>
+#endif
+#ifdef WOLFSSL_SIPHASH
+    #include <wolfssl/wolfcrypt/siphash.h>
+#endif
+#ifndef NO_PWDBASED
+    #include <wolfssl/wolfcrypt/pwdbased.h>
+#endif
+#ifdef HAVE_ECC
+    #include <wolfssl/wolfcrypt/ecc.h>
+#endif
+#ifdef HAVE_CURVE25519
+    #include <wolfssl/wolfcrypt/curve25519.h>
+#endif
+#ifdef HAVE_ED25519
+    #include <wolfssl/wolfcrypt/ed25519.h>
+#endif
+#ifdef HAVE_CURVE448
+    #include <wolfssl/wolfcrypt/curve448.h>
+#endif
+#ifdef HAVE_ED448
+    #include <wolfssl/wolfcrypt/ed448.h>
+#endif
+#ifdef WOLFSSL_HAVE_KYBER
+    #include <wolfssl/wolfcrypt/kyber.h>
+#ifdef WOLFSSL_WC_KYBER
+    #include <wolfssl/wolfcrypt/wc_kyber.h>
+#endif
+#if defined(HAVE_LIBOQS) || defined(HAVE_PQM4)
+    #include <wolfssl/wolfcrypt/ext_kyber.h>
+#endif
+#endif
+#ifdef WOLFCRYPT_HAVE_ECCSI
+    #include <wolfssl/wolfcrypt/eccsi.h>
+#endif
+#ifdef WOLFCRYPT_HAVE_SAKKE
+    #include <wolfssl/wolfcrypt/sakke.h>
+#endif
+
+#if defined(HAVE_PQC)
+    #if defined(HAVE_FALCON)
+        #include <wolfssl/wolfcrypt/falcon.h>
+    #endif
+    #if defined(HAVE_DILITHIUM)
+        #include <wolfssl/wolfcrypt/dilithium.h>
+    #endif
+    #if defined(HAVE_SPHINCS)
+        #include <wolfssl/wolfcrypt/sphincs.h>
+    #endif
+#endif
+
+#ifdef WOLF_CRYPTO_CB
+    #include <wolfssl/wolfcrypt/cryptocb.h>
+    #ifdef HAVE_INTEL_QA_SYNC
+        #include <wolfssl/wolfcrypt/port/intel/quickassist_sync.h>
+    #endif
+    #ifdef HAVE_CAVIUM_OCTEON_SYNC
+        #include <wolfssl/wolfcrypt/port/cavium/cavium_octeon_sync.h>
+    #endif
+    #ifdef HAVE_RENESAS_SYNC
+        #include <wolfssl/wolfcrypt/port/renesas/renesas_sync.h>
+    #endif
+#endif
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #include <wolfssl/wolfcrypt/async.h>
+#endif
+
+#ifdef USE_FLAT_BENCHMARK_H
+    #include "benchmark.h"
+#else
+    #include "wolfcrypt/benchmark/benchmark.h"
+#endif
+
+
+/* define the max length for each string of metric reported */
+#ifndef WC_BENCH_MAX_LINE_LEN
+#define WC_BENCH_MAX_LINE_LEN 150
+#endif
+
+/* default units per second. See WOLFSSL_BENCHMARK_FIXED_UNITS_* to change */
+#define WOLFSSL_FIXED_UNITS_PER_SEC "MB/s" /* may be re-set by fixed units */
 
 #ifdef WOLFSSL_NO_FLOAT_FMT
     #define FLT_FMT "%0ld,%09lu"
@@ -92,7 +222,7 @@
     #define FLT_FMT_ARGS(x) x
     #define FLT_FMT_PREC_ARGS(p, x) p, x
     #define FLT_FMT_PREC2_ARGS(w, p, x) w, p, x
-#endif
+#endif /* WOLFSSL_NO_FLOAT_FMT */
 
 #ifdef WOLFSSL_ESPIDF
     #if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6)
@@ -111,11 +241,12 @@
         #error "CONFIG_IDF_TARGET not implemented"
     #endif
     #include <esp_log.h>
-#endif
+#endif /* WOLFSSL_ESPIDF */
 
 #ifdef HAVE_PTHREAD
     #include <pthread.h>
 #endif
+
 #if defined(HAVE_PTHREAD) ||                                          \
     (!defined(NO_CRYPT_BENCHMARK) && !defined(NO_STDIO_FILESYSTEM) && \
      !defined(NO_ERROR_STRINGS) && !defined(NO_MAIN_DRIVER) &&        \
@@ -127,28 +258,17 @@
 #endif
 
 #if defined(WOLFSSL_ZEPHYR) || defined(NO_STDIO_FILESYSTEM) || !defined(XFFLUSH)
-/* fflush in Zephyr doesn't work on stdout and stderr. Use
- * CONFIG_LOG_MODE_IMMEDIATE compilation option instead. */
-#undef XFFLUSH
-#define XFFLUSH(...) do {} while (0)
+    /* fflush in Zephyr doesn't work on stdout and stderr. Use
+    * CONFIG_LOG_MODE_IMMEDIATE compilation option instead. */
+    #undef  XFFLUSH
+    #define XFFLUSH(...) do {} while (0)
 #endif
-
-/* Macro to disable benchmark */
-#ifndef NO_CRYPT_BENCHMARK
-
-#include <wolfssl/wolfcrypt/mem_track.h>
 
 /* only for stack size check */
-#if defined(WOLFSSL_ASYNC_CRYPT)
-    #ifndef WC_NO_ASYNC_THREADING
-        #define WC_ENABLE_BENCH_THREADING
-    #endif
-#endif
+#include <wolfssl/wolfcrypt/mem_track.h>
 
-#ifdef USE_FLAT_BENCHMARK_H
-    #include "benchmark.h"
-#else
-    #include "wolfcrypt/benchmark/benchmark.h"
+#if defined(WOLFSSL_ASYNC_CRYPT) && !defined(WC_NO_ASYNC_THREADING)
+    #define WC_ENABLE_BENCH_THREADING
 #endif
 
 #ifdef GENERATE_MACHINE_PARSEABLE_REPORT
@@ -189,7 +309,7 @@
     static int printfk(const char *fmt, ...)
     {
         int ret;
-        char line[__BENCHMARK_MAXIMUM_LINE_LENGTH];
+        char line[WC_BENCH_MAX_LINE_LEN];
         va_list ap;
 
         va_start(ap, fmt);
@@ -256,98 +376,6 @@
         #undef printf
         #define printf dc_log_printf
     #endif
-#endif
-
-#include <wolfssl/wolfcrypt/memory.h>
-#include <wolfssl/wolfcrypt/random.h>
-#include <wolfssl/wolfcrypt/des3.h>
-#include <wolfssl/wolfcrypt/arc4.h>
-#include <wolfssl/wolfcrypt/chacha.h>
-#include <wolfssl/wolfcrypt/chacha20_poly1305.h>
-#include <wolfssl/wolfcrypt/aes.h>
-#include <wolfssl/wolfcrypt/poly1305.h>
-#include <wolfssl/wolfcrypt/camellia.h>
-#include <wolfssl/wolfcrypt/md5.h>
-#include <wolfssl/wolfcrypt/sha.h>
-#include <wolfssl/wolfcrypt/sha256.h>
-#include <wolfssl/wolfcrypt/sha512.h>
-#include <wolfssl/wolfcrypt/sha3.h>
-#include <wolfssl/wolfcrypt/rsa.h>
-#include <wolfssl/wolfcrypt/asn.h>
-#include <wolfssl/wolfcrypt/ripemd.h>
-#include <wolfssl/wolfcrypt/cmac.h>
-#ifndef NO_HMAC
-    #include <wolfssl/wolfcrypt/hmac.h>
-#endif
-#ifdef WOLFSSL_SIPHASH
-    #include <wolfssl/wolfcrypt/siphash.h>
-#endif
-#ifndef NO_PWDBASED
-    #include <wolfssl/wolfcrypt/pwdbased.h>
-#endif
-#ifdef HAVE_ECC
-    #include <wolfssl/wolfcrypt/ecc.h>
-#endif
-#ifdef HAVE_CURVE25519
-    #include <wolfssl/wolfcrypt/curve25519.h>
-#endif
-#ifdef HAVE_ED25519
-    #include <wolfssl/wolfcrypt/ed25519.h>
-#endif
-#ifdef HAVE_CURVE448
-    #include <wolfssl/wolfcrypt/curve448.h>
-#endif
-#ifdef HAVE_ED448
-    #include <wolfssl/wolfcrypt/ed448.h>
-#endif
-#ifdef WOLFSSL_HAVE_KYBER
-    #include <wolfssl/wolfcrypt/kyber.h>
-#ifdef WOLFSSL_WC_KYBER
-    #include <wolfssl/wolfcrypt/wc_kyber.h>
-#endif
-#if defined(HAVE_LIBOQS) || defined(HAVE_PQM4)
-    #include <wolfssl/wolfcrypt/ext_kyber.h>
-#endif
-#endif
-#ifdef WOLFCRYPT_HAVE_ECCSI
-    #include <wolfssl/wolfcrypt/eccsi.h>
-#endif
-#ifdef WOLFCRYPT_HAVE_SAKKE
-    #include <wolfssl/wolfcrypt/sakke.h>
-#endif
-
-#if defined(HAVE_PQC)
-    #if defined(HAVE_FALCON)
-        #include <wolfssl/wolfcrypt/falcon.h>
-    #endif
-    #if defined(HAVE_DILITHIUM)
-        #include <wolfssl/wolfcrypt/dilithium.h>
-    #endif
-    #if defined(HAVE_SPHINCS)
-        #include <wolfssl/wolfcrypt/sphincs.h>
-    #endif
-#endif
-
-#include <wolfssl/wolfcrypt/dh.h>
-#include <wolfssl/wolfcrypt/random.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/types.h>
-
-#ifdef WOLF_CRYPTO_CB
-    #include <wolfssl/wolfcrypt/cryptocb.h>
-    #ifdef HAVE_INTEL_QA_SYNC
-        #include <wolfssl/wolfcrypt/port/intel/quickassist_sync.h>
-    #endif
-    #ifdef HAVE_CAVIUM_OCTEON_SYNC
-        #include <wolfssl/wolfcrypt/port/cavium/cavium_octeon_sync.h>
-    #endif
-    #ifdef HAVE_RENESAS_SYNC
-        #include <wolfssl/wolfcrypt/port/renesas/renesas_sync.h>
-    #endif
-#endif
-
-#ifdef WOLFSSL_ASYNC_CRYPT
-    #include <wolfssl/wolfcrypt/async.h>
 #endif
 
 #ifdef HAVE_FIPS
@@ -861,7 +889,8 @@ static int lng_index = 0;
 #ifndef MAIN_NO_ARGS
 static const char* bench_Usage_msg1[][21] = {
     /* 0 English  */
-    {   "-? <num>    Help, print this usage\n            0: English, 1: Japanese\n",
+    {   "-? <num>    Help, print this usage\n"
+        "            0: English, 1: Japanese\n",
         "-csv        Print terminal output in csv format\n",
         "-base10     Display bytes as power of 10 (eg 1 kB = 1000 Bytes)\n",
         "-no_aad     No additional authentication data passed.\n",
@@ -881,9 +910,11 @@ static const char* bench_Usage_msg1[][21] = {
         "-p521       Measure ECC using P-521 curve.\n",
         "-ecc-all    Bench all enabled ECC curves.\n",
         "-<alg>      Algorithm to benchmark. Available algorithms include:\n",
-        "-lng <num>  Display benchmark result by specified language.\n            0: English, 1: Japanese\n",
+        "-lng <num>  Display benchmark result by specified language.\n"
+        "            0: English, 1: Japanese\n",
         "<num>       Size of block in bytes\n",
-       ("-blocks <num>  Number of blocks. Can be used together with the 'Size of block'\n"
+       ("-blocks <num>  Number of blocks. Can be used together with the "
+        "'Size of block'\n"
         "            option, but must be used after that one.\n"
        ),
         "-threads <num> Number of threads to run\n",
@@ -891,7 +922,8 @@ static const char* bench_Usage_msg1[][21] = {
     },
 #ifndef NO_MULTIBYTE_PRINT
     /* 1 Japanese */
-    {   "-? <num>    ヘルプ, 使い方を表示します。\n            0: 英語、 1: 日本語\n",
+    {   "-? <num>    ヘルプ, 使い方を表示します。\n"
+        "            0: 英語、 1: 日本語\n",
         "-csv        csv 形式で端末に出力します。\n",
         "-base10     バイトを10のべき乗で表示します。(例 1 kB = 1000 Bytes)\n",
         "-no_aad     追加の認証データを使用しません.\n",
@@ -906,8 +938,10 @@ static const char* bench_Usage_msg1[][21] = {
         "-p384       Measure ECC using P-384 curve.\n",
         "-p521       Measure ECC using P-521 curve.\n",
         "-ecc-all    Bench all enabled ECC curves.\n",
-        "-<alg>      アルゴリズムのベンチマークを実施します。\n            利用可能なアルゴリズムは下記を含みます:\n",
-        "-lng <num>  指定された言語でベンチマーク結果を表示します。\n            0: 英語、 1: 日本語\n",
+        "-<alg>      アルゴリズムのベンチマークを実施します。\n"
+        "            利用可能なアルゴリズムは下記を含みます:\n",
+        "-lng <num>  指定された言語でベンチマーク結果を表示します。\n"
+        "            0: 英語、 1: 日本語\n",
         "<num>       ブロックサイズをバイト単位で指定します。\n",
         "-blocks <num>  TBD.\n",
         "-threads <num> 実行するスレッド数\n",
@@ -1242,7 +1276,8 @@ static const char* bench_result_words2[][5] = {
         /* if algo doesn't require calling again then use this flow */
         if (state == WOLF_EVENT_STATE_DONE) {
             if (callAgain) {
-                /* needs called again, so allow it and handle completion in bench_async_handle */
+                /* needs called again, so allow it and handle completion in
+                * bench_async_handle */
                 allowNext = 1;
             }
             else {
@@ -1369,7 +1404,9 @@ static const char* bench_result_words2[][5] = {
             #define AES_AAD_OPTIONS_DEFAULT 0x3U
         #endif
     #endif
-    #define AES_AAD_STRING(s)           (aesAuthAddSz == 0 ? (s "-no_AAD") : (aesAuthAddSz == AES_AUTH_ADD_SZ ? (s) : (s "-custom")))
+    #define AES_AAD_STRING(s) \
+        (aesAuthAddSz == 0 ? (s "-no_AAD") : \
+            (aesAuthAddSz == AES_AUTH_ADD_SZ ? (s) : (s "-custom")))
     enum en_aad_options {
         AAD_SIZE_DEFAULT = 0x1U,
         AAD_SIZE_ZERO = 0x2U,
@@ -1643,8 +1680,7 @@ typedef enum bench_stat_type {
         PTHREAD_CHECK_RET(pthread_mutex_unlock(&bench_lock));
     }
 
-#else /* !WC_ENABLE_BENCH_THREADING */
-
+#elif defined(WC_BENCH_TRACK_STATS)
     typedef struct bench_stats {
         const char* algo;
         const char* desc;
@@ -1654,8 +1690,10 @@ typedef enum bench_stat_type {
         bench_stat_type_t type;
         int ret;
     } bench_stats_t;
-    /* 16 threads and 8 different operations. */
-    #define MAX_BENCH_STATS (16 * 8)
+    /* Maximum number of stats to record */
+    #ifndef MAX_BENCH_STATS
+    #define MAX_BENCH_STATS (128)
+    #endif
     static bench_stats_t gStats[MAX_BENCH_STATS];
     static int gStatsCount;
 
@@ -1726,10 +1764,11 @@ static WC_INLINE void bench_stats_start(int* count, double* start)
 }
 
 #ifdef WOLFSSL_LINUXKM_USE_SAVE_VECTOR_REGISTERS
-    #define bench_stats_start(count, start) do {                                         \
-        SAVE_VECTOR_REGISTERS(pr_err("SAVE_VECTOR_REGISTERS failed for benchmark run."); \
-                              return; );                                                 \
-        bench_stats_start(count, start);                                                 \
+    #define bench_stats_start(count, start) do {                               \
+        SAVE_VECTOR_REGISTERS(pr_err(                                          \
+            "SAVE_VECTOR_REGISTERS failed for benchmark run.");                \
+                              return; );                                       \
+        bench_stats_start(count, start);                                       \
     } while (0)
 #endif
 
@@ -1832,7 +1871,7 @@ static void bench_stats_sym_finish(const char* desc, int useDeviceID,
 {
     double total, persec = 0, blocks = (double)count;
     const char* blockType;
-    char msg[__BENCHMARK_MAXIMUM_LINE_LENGTH];
+    char msg[WC_BENCH_MAX_LINE_LEN];
     const char** word = bench_result_words1[lng_index];
     static int sym_header_printed = 0;
 
@@ -1922,9 +1961,11 @@ static void bench_stats_sym_finish(const char* desc, int useDeviceID,
     /* note this codepath brings in all the fields from the non-CSV case. */
     #ifdef WOLFSSL_ESPIDF
         #ifdef HAVE_GET_CYCLES
-            (void)XSNPRINTF(msg, sizeof(msg), "sym,%s,%s,%lu," FLT_FMT "," FLT_FMT ",%lu,", desc,
+            (void)XSNPRINTF(msg, sizeof(msg),
+                            "sym,%s,%s,%lu," FLT_FMT "," FLT_FMT ",%lu,", desc,
                             BENCH_DEVID_GET_NAME(useDeviceID),
-                            bytes_processed, FLT_FMT_ARGS(total), FLT_FMT_ARGS(persec),
+                            bytes_processed, FLT_FMT_ARGS(total),
+                            FLT_FMT_ARGS(persec),
                             (long unsigned int) total_cycles);
         #else
             #warning "HAVE_GET_CYCLES should be defined for WOLFSSL_ESPIDF"
@@ -1949,9 +1990,10 @@ static void bench_stats_sym_finish(const char* desc, int useDeviceID,
     #endif
 #elif defined(BENCH_DEVID)
         (void)XSNPRINTF(msg, sizeof(msg), "%s,%s," FLT_FMT ",", desc,
-                            BENCH_DEVID_GET_NAME(useDeviceID), FLT_FMT_ARGS(persec));
+                       BENCH_DEVID_GET_NAME(useDeviceID), FLT_FMT_ARGS(persec));
 #else
-        (void)XSNPRINTF(msg, sizeof(msg), "%s," FLT_FMT ",", desc, FLT_FMT_ARGS(persec));
+        (void)XSNPRINTF(msg, sizeof(msg), "%s," FLT_FMT ",", desc,
+            FLT_FMT_ARGS(persec));
 #endif
 
     #ifdef WOLFSSL_ESPIDF
@@ -2014,9 +2056,11 @@ static void bench_stats_sym_finish(const char* desc, int useDeviceID,
     XFFLUSH(stdout);
 #endif
 
+#if defined(WC_ENABLE_BENCH_THREADING) || defined(WC_BENCH_TRACK_STATS)
     /* Add to thread stats */
     bench_stats_add(BENCH_STAT_SYM, desc, 0, desc, useDeviceID, persec,
         blockType, ret);
+#endif
 
     (void)useDeviceID;
     (void)ret;
@@ -2037,7 +2081,9 @@ static void bench_stats_asym_finish_ex(const char* algo, int strength,
 {
     double total, each = 0, opsSec, milliEach;
     const char **word = bench_result_words2[lng_index];
+#if defined(WC_ENABLE_BENCH_THREADING) || defined(WC_BENCH_TRACK_STATS)
     const char* kOpsSec = "Ops/Sec";
+#endif
     char msg[256];
     static int asym_header_printed = 0;
 
@@ -2098,22 +2144,27 @@ static void bench_stats_asym_finish_ex(const char* algo, int strength,
 #ifdef GENERATE_MACHINE_PARSEABLE_REPORT
     #ifdef HAVE_GET_CYCLES
         (void)XSNPRINTF(msg, sizeof(msg),
-                        "asym,%s,%d,%s%s," FLT_FMT_PREC "," FLT_FMT_PREC ",%d," FLT_FMT
-                        ",%lu," FLT_FMT_PREC "\n",
-                        algo, strength, desc, desc_extra, FLT_FMT_PREC_ARGS(3, milliEach),
+                        "asym,%s,%d,%s%s," FLT_FMT_PREC "," FLT_FMT_PREC ",%d,"
+                        FLT_FMT ",%lu," FLT_FMT_PREC "\n",
+                        algo, strength, desc, desc_extra,
+                        FLT_FMT_PREC_ARGS(3, milliEach),
                         FLT_FMT_PREC_ARGS(3, opsSec),
-                        count, FLT_FMT_ARGS(total), (unsigned long) total_cycles,
-                        FLT_FMT_PREC_ARGS(6, (double)total_cycles / (double)count));
+                        count, FLT_FMT_ARGS(total), (unsigned long)total_cycles,
+                        FLT_FMT_PREC_ARGS(6,
+                            (double)total_cycles / (double)count));
     #else
         (void)XSNPRINTF(msg, sizeof(msg),
-                        "asym,%s,%d,%s%s," FLT_FMT_PREC "," FLT_FMT_PREC ",%d," FLT_FMT "\n",
-                        algo, strength, desc, desc_extra, FLT_FMT_PREC_ARGS(3, milliEach),
+                        "asym,%s,%d,%s%s," FLT_FMT_PREC "," FLT_FMT_PREC ",%d,"
+                        FLT_FMT "\n",
+                        algo, strength, desc, desc_extra,
+                        FLT_FMT_PREC_ARGS(3, milliEach),
                         FLT_FMT_PREC_ARGS(3, opsSec),
                         count, FLT_FMT_ARGS(total));
     #endif
 #else
-        (void)XSNPRINTF(msg, sizeof(msg), "%s,%d,%s%s," FLT_FMT_PREC "," FLT_FMT_PREC ",\n", algo,
-                        strength, desc, desc_extra, FLT_FMT_PREC_ARGS(3, milliEach),
+        (void)XSNPRINTF(msg, sizeof(msg), "%s,%d,%s%s," FLT_FMT_PREC ","
+                        FLT_FMT_PREC ",\n", algo, strength, desc, desc_extra,
+                        FLT_FMT_PREC_ARGS(3, milliEach),
                         FLT_FMT_PREC_ARGS(3, opsSec));
 #endif
     } /* if (csv_format == 1) */
@@ -2122,28 +2173,33 @@ static void bench_stats_asym_finish_ex(const char* algo, int strength,
 #ifdef GENERATE_MACHINE_PARSEABLE_REPORT
     #ifdef HAVE_GET_CYCLES
         (void)XSNPRINTF(msg, sizeof(msg),
-                        "%-6s %5d %8s%-2s %s %6d %s " FLT_FMT_PREC2 " %s, %s " FLT_FMT_PREC2 " ms,"
-                        " " FLT_FMT_PREC " %s, %lu cycles\n", algo, strength, desc,
-                        desc_extra, BENCH_DEVID_GET_NAME(useDeviceID),
-                        count, word[0], FLT_FMT_PREC2_ARGS(5, 3, total), word[1], word[2],
+                        "%-6s %5d %8s%-2s %s %6d %s " FLT_FMT_PREC2 " %s, %s "
+                        FLT_FMT_PREC2 " ms, " FLT_FMT_PREC " %s, %lu cycles\n",
+                        algo, strength, desc, desc_extra,
+                        BENCH_DEVID_GET_NAME(useDeviceID), count, word[0],
+                        FLT_FMT_PREC2_ARGS(5, 3, total), word[1], word[2],
                         FLT_FMT_PREC2_ARGS(5, 3, milliEach),
-                        FLT_FMT_PREC_ARGS(3, opsSec), word[3], (unsigned long) total_cycles);
+                        FLT_FMT_PREC_ARGS(3, opsSec), word[3],
+                        (unsigned long)total_cycles);
     #else
         (void)XSNPRINTF(msg, sizeof(msg),
-                        "%-6s %5d %8s%-2s %s %6d %s " FLT_FMT_PREC2 " %s, %s " FLT_FMT_PREC2 " ms,"
-                        " " FLT_FMT_PREC " %s\n", algo, strength, desc,
-                        desc_extra, BENCH_DEVID_GET_NAME(useDeviceID),
-                        count, word[0], FLT_FMT_PREC2_ARGS(5, 3, total), word[1], word[2],
+                        "%-6s %5d %8s%-2s %s %6d %s " FLT_FMT_PREC2 " %s, %s "
+                        FLT_FMT_PREC2 " ms, " FLT_FMT_PREC " %s\n",
+                        algo, strength, desc, desc_extra,
+                        BENCH_DEVID_GET_NAME(useDeviceID), count, word[0],
+                        FLT_FMT_PREC2_ARGS(5, 3, total), word[1], word[2],
                         FLT_FMT_PREC2_ARGS(5, 3, milliEach),
                         FLT_FMT_PREC_ARGS(3, opsSec), word[3]);
     #endif /* HAVE_GET_CYCLES */
 #else
         (void)XSNPRINTF(msg, sizeof(msg),
-                        "%-6s %5d %8s%-2s %s %6d %s " FLT_FMT_PREC2 " %s, %s " FLT_FMT_PREC2 " ms,"
-                        " " FLT_FMT_PREC " %s\n", algo, strength, desc, desc_extra,
+                        "%-6s %5d %8s%-2s %s %6d %s " FLT_FMT_PREC2 " %s, %s "
+                        FLT_FMT_PREC2 " ms, " FLT_FMT_PREC " %s\n",
+                        algo, strength, desc, desc_extra,
                         BENCH_DEVID_GET_NAME(useDeviceID), count, word[0],
                         FLT_FMT_PREC2_ARGS(5, 3, total), word[1], word[2],
-                        FLT_FMT_PREC2_ARGS(5, 3, milliEach), FLT_FMT_PREC_ARGS(3, opsSec), word[3]);
+                        FLT_FMT_PREC2_ARGS(5, 3, milliEach),
+                        FLT_FMT_PREC_ARGS(3, opsSec), word[3]);
 #endif
     }
     printf("%s", msg);
@@ -2158,9 +2214,11 @@ static void bench_stats_asym_finish_ex(const char* algo, int strength,
     XFFLUSH(stdout);
 #endif
 
+#if defined(WC_ENABLE_BENCH_THREADING) || defined(WC_BENCH_TRACK_STATS)
     /* Add to thread stats */
     bench_stats_add(BENCH_STAT_ASYM, algo, strength, desc, useDeviceID, opsSec,
                     kOpsSec, ret);
+#endif
 
     (void)useDeviceID;
     (void)ret;
@@ -3004,7 +3062,7 @@ int benchmark_free(void)
 {
     int ret;
 
-#ifdef WC_ENABLE_BENCH_THREADING
+#if defined(WC_ENABLE_BENCH_THREADING) || defined(WC_BENCH_TRACK_STATS)
     if (gPrintStats || devId != INVALID_DEVID) {
         bench_stats_print();
     }

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1570,9 +1570,10 @@ typedef enum bench_stat_type {
     BENCH_STAT_IGNORE,
 } bench_stat_type_t;
 
-#ifdef WC_ENABLE_BENCH_THREADING
+#if defined(WC_ENABLE_BENCH_THREADING) || defined(WC_BENCH_TRACK_STATS)
     static int gPrintStats = 0;
-
+#endif
+#ifdef WC_ENABLE_BENCH_THREADING
     static pthread_mutex_t bench_lock = PTHREAD_MUTEX_INITIALIZER;
 
     #ifndef BENCH_MAX_NAME_SZ
@@ -9577,6 +9578,8 @@ int wolfcrypt_benchmark_main(int argc, char** argv)
                 }
             }
         }
+#endif
+#if defined(WC_ENABLE_BENCH_THREADING) || defined(WC_BENCH_TRACK_STATS)
         else if (string_matches(argv[1], "-print")) {
             gPrintStats = 1;
         }


### PR DESCRIPTION
# Description

* Fix for benchmark always using 4KB of memory for `gStats`, even when not required. Started in https://github.com/wolfSSL/wolfssl/pull/5871
* Added new `WC_BENCH_TRACK_STATS` to enable feature.
* Code cleanups for line length and headers.

# Testing

```
./configure CFLAGS="-DWC_BENCH_TRACK_STATS"
make
./wolfcrypt/benchmark/benchmark -print
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
