### PR TITLE
configure.ac : fix detection of cut

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8726,7 +8726,7 @@ echo "" >> $OPTION_FILE
 # check for supported command to trim option with
 if colrm >/dev/null 2>&1 </dev/null; then
     TRIM="colrm 3"
-elif cut >/dev/null 2>&1 </dev/null; then
+elif cut -c1-2 >/dev/null 2>&1 </dev/null; then
     TRIM="cut -c1-2"
 else
     AC_MSG_ERROR([Could not find colrm or cut to make options file])


### PR DESCRIPTION
# Description

When colrm is not present, ./configure fails because of cut's behavior, which is to exit with code 1 if no arguments are given (either GNU coreutils or busybox).
This fixes this by giving an appropriate argument to cut in order to test for its existence.

# Testing

Build works after fix.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
