### PR TITLE
fix pthread macro protection in tls_bench

### DIFF
--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -79,8 +79,11 @@ Or
     #endif
 #endif
 /* Conversely, if both server and client are enabled, we must require pthreads */
-#if !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && !defined(HAVE_PTHREAD)
-    #error "pthreads must be enabled if building benchmark suite to run both client and server. Please define HAVE_PTHREAD if your platform supports it."
+#if !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) \
+    && !defined(HAVE_PTHREAD)
+    #error "pthreads must be enabled if building benchmark suite \
+to run both client and server. Please define HAVE_PTHREAD if your \
+platform supports it"
 #endif
 
 #ifdef HAVE_PTHREAD

--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -2103,7 +2103,7 @@ int bench_tls(void* args)
         #endif
         #endif
                 if (argClientOnly) {
-            #if !defined(NO_WOLFSSL_SERVER) && !defined(NO_WOLFSSL_CLIENT)
+            #if !defined(NO_WOLFSSL_SERVER) && !defined(NO_WOLFSSL_CLIENT) && defined(HAVE_PTHREAD)
                     /* to avoid to wait server forever */
                     info->serverListening = 1;
             #endif

--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -78,6 +78,10 @@ Or
         #undef HAVE_PTHREAD
     #endif
 #endif
+/* Conversely, if both server and client are enabled, we must require pthreads */
+#if !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && !defined(HAVE_PTHREAD)
+    #error "pthreads must be enabled if building benchmark suite to run both client and server. Please define HAVE_PTHREAD if your platform supports it."
+#endif
 
 #ifdef HAVE_PTHREAD
     #include <pthread.h>


### PR DESCRIPTION
Fixes unprotected access to a variable who's definition is guarded by `HAVE_PTHREAD` 

If you build the benchmark program (`tls_bench.c`) on a platform that **doesn't define** `HAVE_PTHREAD` in addition to **not defining** both `NO_WOLFSSL_SERVER` and `NO_WOLFSSL_CLIENT`, then you will get a compiler error when accessing `info->serverListening`, as the definition is protected by `HAVE_PTHREAD`.

I don't think this is a valid use case (we clearly don't test for it in CI if it hasn't been caught yet) but the guarding is still wrong and should be fixed as the compiler error can be hit when building with user_settings.h if you don't know which macros you need to define, and you wouldn't actually know what the problem was until you dug through the source. 

I also added add a compile time validity check banning the configuration - please let me know if we actually do want to allow this configuration through.



