### PR TITLE
fix detection of cut tool in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8723,10 +8723,11 @@ echo "extern \"C\" {" >> $OPTION_FILE
 echo "#endif" >> $OPTION_FILE
 echo "" >> $OPTION_FILE
 
-# check for supported command to trim option with
+# Check for supported command to trim option with.
+# note: cut requires an argument to exit with success.
 if colrm >/dev/null 2>&1 </dev/null; then
     TRIM="colrm 3"
-elif cut >/dev/null 2>&1 </dev/null; then
+elif cut --version >/dev/null 2>&1 </dev/null; then
     TRIM="cut -c1-2"
 else
     AC_MSG_ERROR([Could not find colrm or cut to make options file])


### PR DESCRIPTION
# Description

Fixes a tool detection bug in `configure.ac`.

If `colrm` wasn't found, the detection of `cut` was failing because `cut` called without arguments returns failure.

Closes #6541.

# Testing
```
$if cut --version >/dev/null 2>&1 </dev/null; then echo "found cut"; fi
found cut
$if cut >/dev/null 2>&1 </dev/null; then echo "found cut"; fi
```


