### PR TITLE
Fix for g++ builds

### DIFF
--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -911,9 +911,6 @@ WOLFSSL_API int wc_GetUUIDFromCert(struct DecodedCert* cert,
 WOLFSSL_API int wc_GetFASCNFromCert(struct DecodedCert* cert,
                                     byte* fascn, word32* fascnSz);
 #endif /* WOLFSSL_FPKI */
-#ifdef __cplusplus
-    } /* extern "C" */
-#endif
 
 #if !defined(XFPRINTF) || defined(NO_FILESYSTEM) || \
     defined(NO_STDIO_FILESYSTEM) && defined(WOLFSSL_ASN_PRINT)
@@ -1014,5 +1011,9 @@ WOLFSSL_API int wc_Asn1_PrintAll(Asn1* asn1, Asn1PrintOptions* opts,
     unsigned char* data, word32 len);
 
 #endif /* WOLFSSL_ASN_PRINT */
+
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
 
 #endif /* WOLF_CRYPT_ASN_PUBLIC_H */


### PR DESCRIPTION
# Description

Fix for `./configure cc="g++" --enable-all && make`

Fixes zd# none. Discovered doing async release testing.

# Testing

make check

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
