### PR TITLE
Revert #6536 types.h one line HAVE_PTHREAD

### DIFF
--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1354,7 +1354,8 @@ typedef struct w64wrapper {
         typedef unsigned int  THREAD_RETURN;
         typedef size_t        THREAD_TYPE;
         #define WOLFSSL_THREAD
-    #elif defined(HAVE_PTHREAD)
+    #elif (defined(_POSIX_THREADS) || defined(HAVE_PTHREAD)) && \
+        !defined(__MINGW32__)
         typedef void*         THREAD_RETURN;
         typedef pthread_t     THREAD_TYPE;
         #define WOLFSSL_THREAD


### PR DESCRIPTION
# Description

This update reverts one line of https://github.com/wolfSSL/wolfssl/pull/6536 that was seen to be problematic in wolfCLU

Fixes zd# n/a

# Testing

checked wolfCLU

```
#!/bin/bash
rm -rf /mnt/c/test/wolfssl-install/bin
rm -rf /mnt/c/test/wolfssl-install/include
rm -rf /mnt/c/test/wolfssl-install/lib
rm -rf /mnt/c/test/wolfssl-install/share

./configure --enable-wolfclu  --prefix=/mnt/c/test/wolfssl-install && make clean && make && make install

# make && make install && cd /mnt/c/test/wolfCLU-fix && make clean && make && cd /mnt/c/test/wolfssl-master
```

Default config, threading enabled:

```
./configure &&  make && ./wolfcrypt/test/testwolfcrypt
```
Forced single-thread. This was observed to have failed during PRB with prior changes:
```
 ./configure --enable-singlethreaded --disable-fastmath --enable-smallstack --enable-smallstackcache  --disable-shared  && make && ./wolfcrypt/test/testwolfcrypt 
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
