### PR TITLE
Turn on SNI by default on hosts with resources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1299,7 +1299,6 @@ endif()
 #       - CRL monitor
 #       - User crypto
 #       - Whitewood netRandom client library
-#       - SNI
 #       - Max fragment length
 #       - ALPN
 #       - Trusted CA indication
@@ -1315,8 +1314,14 @@ add_option(WOLFSSL_CRL
     "Enable CRL (Use =io for inline CRL HTTP GET) (default: disabled)"
     "no" "yes;no;io")
 
+
+set(SNI_DEFAULT "no")
+if(("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64|x86|AMD64|arm64") OR
+    ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64"))
+    set(SNI_DEFAULT "yes")
+endif()
 set(WOLFSSL_SNI_HELP_STRING "Enable SNI (default: disabled)")
-add_option(WOLFSSL_SNI ${WOLFSSL_SNI_HELP_STRING} "no" "yes;no")
+add_option(WOLFSSL_SNI ${WOLFSSL_SNI_HELP_STRING} ${SNI_DEFAULT} "yes;no")
 
 set(WOLFSSL_TLSX_HELP_STRING "Enable all TLS Extensions (default: disabled)")
 add_option(WOLFSSL_TLSX ${WOLFSSL_TLSX_HELP_STRING} "no" "yes;no")

--- a/configure.ac
+++ b/configure.ac
@@ -4971,19 +4971,20 @@ AC_ARG_WITH([wnr],
 
 
 # SNI
+# enable SNI automatically for x86_64/x86/aarch64/amd64
+SNI_DEFAULT=no
+if test "$host_cpu" = "x86_64" || test "$host_cpu" = "x86" || test "$host_cpu" = "aarch64" || test "$host_cpu" = "amd64"
+then
+    SNI_DEFAULT=yes
+fi
 AC_ARG_ENABLE([sni],
-    [AS_HELP_STRING([--enable-sni],[Enable SNI (default: disabled)])],
+    [AS_HELP_STRING([--enable-sni],[Enable SNI (default: enabled on x86_64/x86/aarch64/amd64)])],
     [ ENABLED_SNI=$enableval ],
-    [ ENABLED_SNI=no ]
+    [ ENABLED_SNI=$SNI_DEFAULT ]
     )
-if test "x$ENABLED_QT" = "xyes"
+if test "x$ENABLED_QT" = "xyes" || test "$ENABLED_QUIC" = "yes"
 then
     ENABLED_SNI="yes"
-fi
-
-if test "$ENABLED_QUIC" = "yes"
-then
-    ENABLED_SNI=yes
 fi
 
 if test "x$ENABLED_SNI" = "xyes"

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -385,7 +385,7 @@ int wolfCrypt_Init(void)
     return ret;
 }
 
-#ifdef WOLFSSL_TRACK_MEMORY_VERBOSE
+#if defined(WOLFSSL_TRACK_MEMORY_VERBOSE) && !defined(WOLFSSL_STATIC_MEMORY)
 long wolfCrypt_heap_peakAllocs_checkpoint(void) {
     long ret = ourMemStats.peakAllocsTripOdometer;
     ourMemStats.peakAllocsTripOdometer = ourMemStats.totalAllocs -

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -55,7 +55,7 @@
 #endif
 #endif
 
-#ifdef WOLFSSL_TRACK_MEMORY_VERBOSE
+#if defined(WOLFSSL_TRACK_MEMORY_VERBOSE) && !defined(WOLFSSL_STATIC_MEMORY)
 #ifdef WOLFSSL_TEST_MAX_RELATIVE_HEAP_ALLOCS
     static ssize_t max_relative_heap_allocs = WOLFSSL_TEST_MAX_RELATIVE_HEAP_ALLOCS;
 #else
@@ -84,7 +84,7 @@
     }
 #else
 #define PRINT_HEAP_CHECKPOINT()
-#endif
+#endif /* WOLFSSL_TRACK_MEMORY_VERBOSE && !WOLFSSL_STATIC_MEMORY */
 
 #ifdef USE_FLAT_TEST_H
     #ifdef HAVE_CONFIG_H
@@ -832,7 +832,7 @@ wc_test_ret_t wolfcrypt_test(void* args)
 #endif
 {
     wc_test_ret_t ret;
-#ifdef WOLFSSL_TRACK_MEMORY_VERBOSE
+#if defined(WOLFSSL_TRACK_MEMORY_VERBOSE) && !defined(WOLFSSL_STATIC_MEMORY)
     long heap_baselineAllocs, heap_baselineBytes;
 #endif
 #ifdef TEST_ALWAYS_RUN_TO_END
@@ -840,7 +840,7 @@ wc_test_ret_t wolfcrypt_test(void* args)
 #endif
     STACK_SIZE_INIT();
 
-#ifdef WOLFSSL_TRACK_MEMORY_VERBOSE
+#if defined(WOLFSSL_TRACK_MEMORY_VERBOSE) && !defined(WOLFSSL_STATIC_MEMORY)
     (void)wolfCrypt_heap_peakAllocs_checkpoint();
     heap_baselineAllocs = wolfCrypt_heap_peakAllocs_checkpoint();
     (void)wolfCrypt_heap_peakBytes_checkpoint();

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -2903,7 +2903,8 @@ static WC_INLINE int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
     char buffer[WOLFSSL_MAX_ERROR_SZ];
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     WOLFSSL_X509* peer;
-#if defined(SHOW_CERTS) && !defined(NO_FILESYSTEM)
+#if defined(SHOW_CERTS) && !defined(NO_FILESYSTEM) && \
+    !defined(OPENSSL_EXTRA_X509_SMALL)
     WOLFSSL_BIO* bio = NULL;
     WOLFSSL_STACK* sk = NULL;
     X509* x509 = NULL;
@@ -2948,7 +2949,8 @@ static WC_INLINE int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
 
         XFREE(subject, 0, DYNAMIC_TYPE_OPENSSL);
         XFREE(issuer,  0, DYNAMIC_TYPE_OPENSSL);
-#if defined(SHOW_CERTS) && !defined(NO_FILESYSTEM)
+#if defined(SHOW_CERTS) && !defined(NO_FILESYSTEM) && \
+    !defined(OPENSSL_EXTRA_X509_SMALL)
         /* avoid printing duplicate certs */
         if (store->depth == 1) {
             int i;


### PR DESCRIPTION
# Description

Turn on SNI by default on hosts with resources

# Testing

```
./configure && make check
mkdir build && cd build && cmake .. && make
```

Confirmed SNI was on by default

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
