### PR TITLE
wolfBot fixes

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -20965,7 +20965,8 @@ static int test_wc_ecc_import_raw(void)
         wc_ecc_free(&key);
     #endif
 #ifdef WOLFSSL_VALIDATE_ECC_IMPORT
-    ExpectIntEQ(wc_ecc_import_raw(&key, "0", qy, d, curveName), BAD_FUNC_ARG);
+    ExpectIntLT(ret = wc_ecc_import_raw(&key, "0", qy, d, curveName), 0);
+    ExpectTrue((ret == BAD_FUNC_ARG) || (ret == MP_VAL));
 #else
     ExpectIntEQ(wc_ecc_import_raw(&key, "0", qy, d, curveName), 0);
 #endif
@@ -20973,7 +20974,8 @@ static int test_wc_ecc_import_raw(void)
         wc_ecc_free(&key);
     #endif
 #ifdef WOLFSSL_VALIDATE_ECC_IMPORT
-    ExpectIntEQ(wc_ecc_import_raw(&key, qx, "0", d, curveName), BAD_FUNC_ARG);
+    ExpectIntLT(ret = wc_ecc_import_raw(&key, qx, "0", d, curveName), 0);
+    ExpectTrue((ret == BAD_FUNC_ARG) || (ret == MP_VAL));
 #else
     ExpectIntEQ(wc_ecc_import_raw(&key, qx, "0", d, curveName), 0);
 #endif

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -892,9 +892,9 @@ static int lng_index = 0;
 
 #ifndef NO_MAIN_DRIVER
 #ifndef MAIN_NO_ARGS
-static const char* bench_Usage_msg1[][21] = {
+static const char* bench_Usage_msg1[][22] = {
     /* 0 English  */
-    {   "-? <num>    Help, print this usage\n"
+    {   "-? <num>    Help, print this usage\n",
         "            0: English, 1: Japanese\n",
         "-csv        Print terminal output in csv format\n",
         "-base10     Display bytes as power of 10 (eg 1 kB = 1000 Bytes)\n",
@@ -927,7 +927,7 @@ static const char* bench_Usage_msg1[][21] = {
     },
 #ifndef NO_MULTIBYTE_PRINT
     /* 1 Japanese */
-    {   "-? <num>    ヘルプ, 使い方を表示します。\n"
+    {   "-? <num>    ヘルプ, 使い方を表示します。\n",
         "            0: 英語、 1: 日本語\n",
         "-csv        csv 形式で端末に出力します。\n",
         "-base10     バイトを10のべき乗で表示します。(例 1 kB = 1000 Bytes)\n",


### PR DESCRIPTION
# Description

Importing an EC point ordinate with one being zero will result in different errors based on different implementations. Check both known error codes.

Benchmark usage fixed.

# Testing

./configure --disable-shared --enable-all 'CFLAGS=-DWOLFSSL_VALIDATE_ECC_IMPORT -DWOLFSSL_VALIDATE_ECC_KEYGEN' --enable-testcert --enable-intelasm --enable-sp-math-all --enable-sp-asm

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
