### PR TITLE
add HW error codes to tfm.h, sp_int.h, integer.h

### DIFF
--- a/wolfssl/wolfcrypt/integer.h
+++ b/wolfssl/wolfcrypt/integer.h
@@ -161,11 +161,17 @@ extern "C" {
 #define MP_ZPOS       0   /* positive integer */
 #define MP_NEG        1   /* negative */
 
-#define MP_OKAY       0   /* ok result */
-#define MP_MEM       (-2) /* out of mem */
-#define MP_VAL       (-3) /* invalid input */
-#define MP_NOT_INF   (-4) /* point not at infinity */
-#define MP_RANGE      MP_NOT_INF
+#define MP_OKAY          0  /* ok result */
+#define MP_ERROR       (-1) /* generic math error */
+#define MP_MEM         (-2) /* out of mem */
+#define MP_VAL         (-3) /* invalid input */
+#define MP_NOT_INF     (-4) /* point not at infinity */
+#define MP_NOT_USED    (-5) /* not used, here for consistency only   */
+#define MP_HW_ERROR    (-6) /* hardware error, consider SW fallback  */
+#define MP_HW_BUSY     (-7) /* assigned -7 to match SP_HW_BUSY       */
+#define MP_HW_FALLBACK (-8) /* signal to caller to fall back to SW   */
+#define MP_HW_VALIDATION_ACTIVE (-9) /* optional HW validation ative */
+#define MP_RANGE       MP_HW_VALIDATION_ACTIVE /* range is last item */
 
 #define MP_YES        1   /* yes response */
 #define MP_NO         0   /* no response */

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -731,6 +731,8 @@ typedef struct sp_ecc_ctx {
 /* ERROR VALUES */
 /** Error value on success. */
 #define MP_OKAY          0
+/* unexpected, generic error. xP_VAL elsewhere */
+#define MP_ERROR        (-1)
 /** Error value when dynamic memory allocation fails. */
 #define MP_MEM          (-2)
 /** Error value when value passed is not able to be used. */
@@ -739,10 +741,21 @@ typedef struct sp_ecc_ctx {
  * completion.
  */
 #define FP_WOULDBLOCK   (-4)
+#define MP_WOULDBLOCK   (-4)
 /* Unused error. Defined for backward compatibility. */
 #define MP_NOT_INF      (-5)
-/* Unused error. Defined for backward compatibility. */
-#define MP_RANGE        MP_NOT_INF
+/* hardware error, consider falling back to SW */
+#define MP_HW_ERROR     (-6)
+/* hardware busy; wait or fall back to SW */
+#define MP_HW_BUSY      (-7)
+/* signal to caller to fall back to SW (e.g unsupported, etc) */
+#define MP_HW_FALLBACK  (-8)
+/* typically used only during debugging, validation active
+ * will prevent recursive calls to HW for SW validation check.*/
+#define MP_HW_VALIDATION_ACTIVE (-9)
+#define MP_RANGE MP_HW_VALIDATION_ACTIVE /* last item is range */
+
+#define MP_SIZE SP_INT_DIGITS
 
 #ifdef USE_FAST_MATH
 /* For old FIPS, need FP_MEM defined for old implementation. */

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -290,6 +290,8 @@
 #define FP_MASK    (fp_digit)(-1)
 #define FP_DIGIT_MAX FP_MASK
 #define FP_SIZE    (FP_MAX_SIZE/DIGIT_BIT)
+#define MP_SIZE    (FP_MAX_SIZE/DIGIT_BIT) /* for compatibility with SP_INT */
+
 
 #define FP_MAX_PRIME_SIZE (FP_MAX_BITS/(2*CHAR_BIT))
 /* In terms of FP_MAX_BITS, it is double the size possible for a number
@@ -302,11 +304,18 @@
 #define FP_NEG      1
 
 /* return codes */
-#define FP_OKAY      0
-#define FP_VAL      (-1)
-#define FP_MEM      (-2)
-#define FP_NOT_INF  (-3)
-#define FP_WOULDBLOCK (-4)
+#define FP_OKAY        ( 0)
+#define FP_VAL         (-1)
+#define FP_MEM         (-2)
+#define FP_NOT_INF     (-3)
+#define FP_WOULDBLOCK  (-4)
+#define FP_NOT_USED    (-5) /* not used, here for consistency only   */
+#define FP_HW_ERROR    (-6) /* hardware error, consider SW fallback  */
+#define FP_HW_BUSY     (-7) /* assigned -7 to match SP_HW_BUSY       */
+#define FP_HW_FALLBACK (-8) /* signal to caller to fall back to SW   */
+#define FP_HW_VALIDATION_ACTIVE (-9) /* optional HW validation ative */
+
+#define FP_RANGE       MP_HW_VALIDATION_ACTIVE /* range is last item */
 
 /* equalities */
 #define FP_LT        (-1)   /* less than */
@@ -778,6 +787,12 @@ int  fp_sqr_comba64(fp_int *a, fp_int *b);
 #define MP_MEM  FP_MEM  /* memory error */
 #define MP_NOT_INF FP_NOT_INF /* point not at infinity */
 #define MP_OKAY FP_OKAY /* ok result    */
+#define MP_HW_ERROR FP_HW_ERROR /* HW accleration error */
+#define MP_HW_BUSY FP_HW_BUSY /* hardware is busy, need to fall back to SW */
+#define MP_HW_FALLBACK FP_HW_FALLBACK /* detected data that needs SW */
+#define MP_HW_VALIDATION_ACTIVE FP_HW_VALIDATION_ACTIVE /* typically debug */
+#define MP_RANGE FP_RANGE /* range is last item */
+
 #define MP_NO   FP_NO   /* yes/no result */
 #define MP_YES  FP_YES  /* yes/no result */
 #define MP_ZPOS FP_ZPOS


### PR DESCRIPTION
# Description

Adds new hardware-acceleration-specific return error code definitions to math library header files.

Also makes return codes consistent between `tfm.h`, `sp_int.h`, and `integer.h`.

The intention is to allow better visibility to math errors with hardware acceleration. This change will also allow the ability to fall back to SW if hardware fails, is busy, etc.

These changes are needed for my current WIP for Espressif HW acceleration.

Fixes zd#  n/a

# Testing

How did you test?

ran wolfcrypt benchmark and test apps.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
