### PR TITLE
update soname to 40

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,10 +46,10 @@ AC_SUBST([WOLFSSL_CONFIG_ARGS])
 # shared library versioning
 # The three numbers in the libwolfssl.so.*.*.* file name. Unfortunately
 # these numbers don't always line up nicely with the library version.
-WOLFSSL_LIBRARY_VERSION_FIRST=35
-WOLFSSL_LIBRARY_VERSION_SECOND=5
-WOLFSSL_LIBRARY_VERSION_THIRD=1
-WOLFSSL_LIBRARY_VERSION=40:1:5
+WOLFSSL_LIBRARY_VERSION_FIRST=40
+WOLFSSL_LIBRARY_VERSION_SECOND=0
+WOLFSSL_LIBRARY_VERSION_THIRD=0
+WOLFSSL_LIBRARY_VERSION=40:0:0
 #                        | | |
 #                 +------+ | +---+
 #                 |        |     |


### PR DESCRIPTION
# Description

Updates the library soname to 40. In wolfSSL release 5.6.0 there was three parameter type changes in public facing API that require that the age be reset. This is with an expanded configure used when tracking across version (--enable-distro --disable-examples).

```
[−] wolfSSL_EC_KEY_set_conv_form ( WOLFSSL_EC_KEY* eckey, char form )  1 
⇣
wolfSSL_EC_KEY_set_conv_form ( WOLFSSL_EC_KEY* key, int form )
```

```
[−] wolfSSL_EC_POINT_point2bn ( WOLFSSL_EC_GROUP const* group, WOLFSSL_EC_POINT const* p, char form, WOLFSSL_BIGNUM* in, WOLFSSL_BN_CTX* ctx )  1 
⇣
wolfSSL_EC_POINT_point2bn ( WOLFSSL_EC_GROUP const* group, WOLFSSL_EC_POINT const* point, int form, WOLFSSL_BIGNUM* bn, WOLFSSL_BN_CTX* ctx )
```

```
[−] wolfSSL_EC_POINT_point2oct ( WOLFSSL_EC_GROUP const* group, WOLFSSL_EC_POINT const* p, char form, byte* buf, size_t len, WOLFSSL_BN_CTX* ctx )  1 
⇣
wolfSSL_EC_POINT_point2oct ( WOLFSSL_EC_GROUP const* group, WOLFSSL_EC_POINT const* point, int form, byte* buf, size_t len, WOLFSSL_BN_CTX* ctx )
```

## How did you test?

Using abi-tracker and abi-monitor