### PR TITLE
20230703-clang-tidy-fixes

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -45867,7 +45867,11 @@ static int test_wc_ecc_get_curve_id_from_dp_params(void)
         ExpectIntEQ(wc_ecc_get_curve_id_from_name("SECP256R1"), ECC_SECP256R1);
         ExpectNotNull(ecKey = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1));
 
-        ret = EC_KEY_generate_key(ecKey);
+        if (EXPECT_SUCCESS()) {
+            ret = EC_KEY_generate_key(ecKey);
+        } else
+            ret = 0;
+
         if (ret == 1) {
             /* normal test */
             key = (ecc_key*)ecKey->internal;

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -915,8 +915,9 @@ static const char* bench_Usage_msg1[][22] = {
         "-p521       Measure ECC using P-521 curve.\n",
         "-ecc-all    Bench all enabled ECC curves.\n",
         "-<alg>      Algorithm to benchmark. Available algorithms include:\n",
-        "-lng <num>  Display benchmark result by specified language.\n"
-        "            0: English, 1: Japanese\n",
+        ("-lng <num>  Display benchmark result by specified language.\n"
+         "            0: English, 1: Japanese\n"
+        ),
         "<num>       Size of block in bytes\n",
        ("-blocks <num>  Number of blocks. Can be used together with the "
         "'Size of block'\n"
@@ -943,10 +944,12 @@ static const char* bench_Usage_msg1[][22] = {
         "-p384       Measure ECC using P-384 curve.\n",
         "-p521       Measure ECC using P-521 curve.\n",
         "-ecc-all    Bench all enabled ECC curves.\n",
-        "-<alg>      アルゴリズムのベンチマークを実施します。\n"
-        "            利用可能なアルゴリズムは下記を含みます:\n",
-        "-lng <num>  指定された言語でベンチマーク結果を表示します。\n"
-        "            0: 英語、 1: 日本語\n",
+       ("-<alg>      アルゴリズムのベンチマークを実施します。\n"
+        "            利用可能なアルゴリズムは下記を含みます:\n"
+       ),
+       ("-lng <num>  指定された言語でベンチマーク結果を表示します。\n"
+        "            0: 英語、 1: 日本語\n"
+       ),
         "<num>       ブロックサイズをバイト単位で指定します。\n",
         "-blocks <num>  TBD.\n",
         "-threads <num> 実行するスレッド数\n",

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -11133,9 +11133,7 @@ void InitDecodedCert_ex(DecodedCert* cert,
     #endif /* WOLFSSL_HAVE_ISSUER_NAMES */
     #endif /* WOLFSSL_CERT_GEN || WOLFSSL_CERT_EXT */
 
-    #ifndef NO_CERTS
         InitSignatureCtx(&cert->sigCtx, heap, devId);
-    #endif
     }
 }
 
@@ -11246,9 +11244,7 @@ void FreeDecodedCert(DecodedCert* cert)
     if (cert->sce_tsip_encRsaKeyIdx != NULL)
         XFREE(cert->sce_tsip_encRsaKeyIdx, cert->heap, DYNAMIC_TYPE_RSA);
 #endif
-#ifndef NO_CERTS
     FreeSignatureCtx(&cert->sigCtx);
-#endif
 }
 
 void wc_FreeDecodedCert(DecodedCert* cert)


### PR DESCRIPTION
fixes for `bugprone-suspicious-missing-comma`, `clang-analyzer-core.NullDereference`, and `readability-redundant-preprocessor`.

tested with `wolfssl-multi-test.sh ... all-gcc-c89-clang-tidy clang-tidy-all-sp-all`
