### PR TITLE
add wolfSSL_CTX_GetEchConfigsBase64 to make getting

### DIFF
--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -988,6 +988,9 @@ WOLFSSL_API WOLFSSL_METHOD *wolfSSLv23_method(void);
 WOLFSSL_API int wolfSSL_CTX_GenerateEchConfig(WOLFSSL_CTX* ctx,
     const char* publicName, word16 kemId, word16 kdfId, word16 aeadId);
 
+WOLFSSL_API int wolfSSL_CTX_GetEchConfigsBase64(WOLFSSL_CTX* ctx, byte* output,
+    word32* outputLen);
+
 WOLFSSL_API int wolfSSL_CTX_GetEchConfigs(WOLFSSL_CTX* ctx, byte* output,
     word32* outputLen);
 


### PR DESCRIPTION
the base64 encoded ech configs convenient

# Description

Adds `wolfSSL_CTX_GetEchConfigsBase64` which directly exports the ech configs as

Requested from https://github.com/wolfSSL/wolfssl/issues/6568

# Testing

Added examples to wolfssl-examples that uses this function to export from the server and then import to the client side.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
