### PR TITLE
20230705-analyzer-fixes

### DIFF
--- a/examples/pem/pem.c
+++ b/examples/pem/pem.c
@@ -323,7 +323,8 @@ static int FindPem(char* data, word32 offset, word32 len, word32* start,
             ret = 1;
         }
         if (ret == 0) {
-            memcpy(str, data + type_off, type_len);
+            if (type_len > 0)
+                memcpy(str, data + type_off, type_len);
             str[type_len] = '\0';
             ret = StringToType(str, type);
         }
@@ -537,6 +538,9 @@ static int EncryptDer(unsigned char* in, word32 in_len, char* password,
     WC_RNG rng;
     unsigned char salt[SALT_MAX_LEN];
 
+    if (password == NULL)
+        return 1;
+
     XMEMSET(&rng, 0, sizeof(rng));
 
     /* Create a random number generator. */
@@ -610,7 +614,7 @@ static int ConvDerToPem(unsigned char* in, word32 offset, word32 len,
     if (ret > 0) {
         ret = 0;
     }
-    if (ret == 0) {
+    if ((ret == 0) && (pem_len > 0)) {
         /* Allocate memory to hold PEM encoding. */
         pem = (unsigned char*)malloc(pem_len);
         if (pem == NULL) {
@@ -944,7 +948,7 @@ int main(int argc, char* argv[])
         ret = 1;
     }
 
-    if (pem) {
+    if ((ret == 0) && pem) {
         /* Convert PEM to DER. */
         ret = ConvPemToDer((char*)in, offset, in_len, &der, type, &info,
             padding);

--- a/scripts/pem.test
+++ b/scripts/pem.test
@@ -148,7 +148,7 @@ check_der() {
 convert_to_der() {
     if [ "$SKIP" = "" -a "$FAILED" = "" ]; then
         echo "    $PEM_EXE $* -out $tmp_pem_file"
-        $PEM_EXE $* -out $tmp_der_file
+        $PEM_EXE "$@" -out $tmp_der_file
         if [ "$?" != "0" ]; then
             echo "  Failed to convert to DER"
             test_fail
@@ -176,7 +176,7 @@ compare_der() {
 convert_to_pem() {
     if [ "$SKIP" = "" -a "$FAILED" = "" ]; then
         echo "    $PEM_EXE --der -t \"$PEM_TYPE\" $* -out $tmp_pem_file"
-        $PEM_EXE --der $* -t "$PEM_TYPE" -out $tmp_pem_file
+        $PEM_EXE --der "$@" -t "$PEM_TYPE" -out $tmp_pem_file
         if [ "$?" != "0" ]; then
             test_fail
         fi

--- a/src/internal.c
+++ b/src/internal.c
@@ -11476,7 +11476,6 @@ static int CipherRequires(byte first, byte second, int requirement)
                 if (requirement == REQUIRES_AEAD)
                     return 1;
                 return 0;
-                break;
 
             default:
                 WOLFSSL_MSG("Unsupported cipher suite, CipherRequires "

--- a/tests/api.c
+++ b/tests/api.c
@@ -56697,10 +56697,10 @@ static int test_wolfSSL_CTX_LoadCRL(void)
                                                 WOLFSSL_SUCCESS)
 #ifndef NO_WOLFSSL_CLIENT
     #define NEW_CTX(ctx) AssertNotNull( \
-            ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()))
+            (ctx) = wolfSSL_CTX_new(wolfSSLv23_client_method()))
 #elif !defined(NO_WOLFSSL_SERVER)
     #define NEW_CTX(ctx) AssertNotNull( \
-            ctx = wolfSSL_CTX_new(wolfSSLv23_server_method()))
+            (ctx) = wolfSSL_CTX_new(wolfSSLv23_server_method()))
 #else
     #define NEW_CTX(ctx) return
 #endif

--- a/tests/unit.h
+++ b/tests/unit.h
@@ -189,17 +189,17 @@
 
 #define ExpectPtr(x, y, op, er) do {                                           \
     if (_ret != TEST_FAIL) {                                                   \
-        PRAGMA_GCC_DIAG_PUSH;                                                  \
+        PRAGMA_DIAG_PUSH;                                                      \
           /* remarkably, without this inhibition, */                           \
           /* the _Pragma()s make the declarations warn. */                     \
-        PRAGMA_GCC("GCC diagnostic ignored \"-Wdeclaration-after-statement\"");\
+        PRAGMA("GCC diagnostic ignored \"-Wdeclaration-after-statement\"");    \
           /* inhibit "ISO C forbids conversion of function pointer */          \
           /* to object pointer type [-Werror=pedantic]" */                     \
-        PRAGMA_GCC("GCC diagnostic ignored \"-Wpedantic\"");                   \
+        PRAGMA("GCC diagnostic ignored \"-Wpedantic\"");                       \
         void* _x = (void*)(x);                                                 \
         void* _y = (void*)(y);                                                 \
         Expect(_x op _y, ("%s " #op " %s", #x, #y), ("%p " #er " %p", _x, _y));\
-        PRAGMA_GCC_DIAG_POP;                                                   \
+        PRAGMA_DIAG_POP;                                                       \
     }                                                                          \
 } while(0)
 

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -619,8 +619,6 @@ void wait_tcp_ready(func_args* args)
 #endif /* thread checks */
 }
 
-#ifndef SINGLE_THREADED
-
 /* Start a thread.
  *
  * @param [in]  fun     Function to executre in thread.
@@ -719,8 +717,6 @@ void join_thread(THREAD_TYPE thread)
     (void)res; /* Suppress un-used variable warning */
 #endif
 }
-
-#endif /* SINGLE_THREADED */
 
 #ifndef NO_FILESYSTEM
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -11972,7 +11972,7 @@ static int StoreRsaKey(DecodedCert* cert, const byte* source, word32* srcIdx,
     #ifdef HAVE_OCSP
         /* Calculate the hash of the public key for OCSP. */
         ret = CalcHashId_ex(cert->publicKey, cert->pubKeySize,
-                         cert->subjectKeyHash, HashIdAlg(cert->signatureOID));
+                         cert->subjectKeyHash, HashIdAlg((int)cert->signatureOID));
     #endif
     }
 
@@ -12125,7 +12125,7 @@ static int StoreEccKey(DecodedCert* cert, const byte* source, word32* srcIdx,
         /* Calculate the hash of the subject public key for OCSP. */
         ret = CalcHashId_ex(dataASN[ECCCERTKEYASN_IDX_SUBJPUBKEY].data.ref.data,
                          dataASN[ECCCERTKEYASN_IDX_SUBJPUBKEY].data.ref.length,
-                         cert->subjectKeyHash, HashIdAlg(cert->signatureOID));
+                         cert->subjectKeyHash, HashIdAlg((int)cert->signatureOID));
     }
     if (ret == 0) {
     #endif
@@ -13948,7 +13948,7 @@ static int GetCertName(DecodedCert* cert, char* full, byte* hash, int nameType,
      * calculated over the entire DER encoding of the Name field, including
      * the tag and length. */
     if (CalcHashId_ex(input + srcIdx, maxIdx - srcIdx, hash,
-            HashIdAlg(cert->signatureOID)) != 0) {
+            HashIdAlg((int)cert->signatureOID)) != 0) {
         ret = ASN_PARSE_E;
     }
 
@@ -18873,7 +18873,7 @@ static int DecodeAuthKeyId(const byte* input, word32 sz, DecodedCert* cert)
             /* Get the hash or hash of the hash if wrong size. */
             ret = GetHashId(dataASN[AUTHKEYIDASN_IDX_KEYID].data.ref.data,
                         (int)dataASN[AUTHKEYIDASN_IDX_KEYID].data.ref.length,
-                        cert->extAuthKeyId, HashIdAlg(cert->signatureOID));
+                        cert->extAuthKeyId, HashIdAlg((int)cert->signatureOID));
         }
     }
 
@@ -18911,7 +18911,7 @@ static int DecodeSubjKeyId(const byte* input, word32 sz, DecodedCert* cert)
 
         /* Get the hash or hash of the hash if wrong size. */
         ret = GetHashId(input + idx, length, cert->extSubjKeyId,
-            HashIdAlg(cert->signatureOID));
+            HashIdAlg((int)cert->signatureOID));
     }
 
     return ret;
@@ -22557,11 +22557,11 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
                 /* TODO: GmSSL creates IDs this way but whole public key info
                  * block should be hashed. */
                 ret = CalcHashId_ex(cert->publicKey + cert->pubKeySize - 65, 65,
-                    cert->extSubjKeyId, HashIdAlg(cert->signatureOID));
+                    cert->extSubjKeyId, HashIdAlg((int)cert->signatureOID));
             }
             else {
                 ret = CalcHashId_ex(cert->publicKey, cert->pubKeySize,
-                    cert->extSubjKeyId, HashIdAlg(cert->signatureOID));
+                    cert->extSubjKeyId, HashIdAlg((int)cert->signatureOID));
             }
             if (ret != 0) {
                 WOLFSSL_ERROR_VERBOSE(ret);
@@ -30419,7 +30419,7 @@ static int SetAuthKeyIdFromDcert(Cert* cert, DecodedCert* decoded)
         cert->akidSz = KEYID_SIZE;
     #endif
         /* Put the SKID of CA to AKID of certificate */
-        XMEMCPY(cert->akid, decoded->extSubjKeyId, cert->akidSz);
+        XMEMCPY(cert->akid, decoded->extSubjKeyId, (size_t)cert->akidSz);
     }
 
     return ret;

--- a/wolfcrypt/src/hash.c
+++ b/wolfcrypt/src/hash.c
@@ -303,8 +303,8 @@ enum wc_HashType wc_OidGetHash(int oid)
     #ifdef WOLFSSL_SM3
         case SM3h:
             hash_type = WC_HASH_TYPE_SM3;
-    #endif
             break;
+    #endif
         default:
             break;
     }
@@ -1172,8 +1172,8 @@ int wc_HashSetFlags(wc_HashAlg* hash, enum wc_HashType type, word32 flags)
     #ifdef WOLFSSL_SM3
         case WC_HASH_TYPE_SM3:
             ret = wc_Sm3SetFlags(&hash->sm3, flags);
-    #endif
             break;
+    #endif
 
         /* not supported */
         case WC_HASH_TYPE_MD5_SHA:

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -5291,9 +5291,11 @@ int sp_cond_swap_ct(sp_int* a, sp_int* b, int cnt, int swap)
     /* Allocate temporary to hold masked xor of a and b. */
     ALLOC_SP_INT(t, cnt, err, NULL);
 
-    err = sp_cond_swap_ct_ex(a, b, cnt, swap, t);
+    if (err == MP_OKAY) {
+        err = sp_cond_swap_ct_ex(a, b, cnt, swap, t);
+        FREE_SP_INT(t, NULL);
+    }
 
-    FREE_SP_INT(t, NULL);
     return err;
 }
 #endif /* HAVE_ECC && ECC_TIMING_RESISTANT && !WC_NO_CACHE_RESISTANT */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -14282,6 +14282,7 @@ static wc_test_ret_t const_byte_ptr_test(const byte* in, word32 *outJ)
     volatile word32 j = -1; /* must be volatile to properly detect error */
 
     ret = (wc_test_ret_t)*in; /* accessed *in value. */
+    (void)ret;
     j = *outJ; /* Found index to use in const array. */
 
     if (j == 0) {
@@ -28440,7 +28441,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ecc_test(void)
 #if !defined(NO_ECC_SECP) || defined(WOLFSSL_CUSTOM_CURVES)
     ret = ecc_def_curve_test(&rng);
     if (ret < 0) {
-        fprintf(stderr, "Default\n");
+        printf("Default\n");
         goto done;
     }
 #endif
@@ -28476,7 +28477,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ecc_test(void)
 #ifdef WOLFSSL_SM2
     ret = ecc_test_curve(&rng, 32, ECC_SM2P256V1);
     if (ret < 0) {
-        fprintf(stderr, "SM2\n");
+        printf("SM2\n");
         goto done;
     }
 #endif
@@ -28484,7 +28485,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ecc_test(void)
 #if defined(WOLFSSL_CUSTOM_CURVES)
     ret = ecc_test_custom_curves(&rng);
     if (ret != 0) {
-        fprintf(stderr, "Custom\n");
+        printf("Custom\n");
         goto done;
     }
 #endif
@@ -28492,12 +28493,12 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ecc_test(void)
 #if defined(WOLFSSL_SM2)
     ret = test_sm2_verify();
     if (ret != 0) {
-        fprintf(stderr, "SM2 Verify\n");
+        printf("SM2 Verify\n");
         goto done;
     }
     ret = ecc_sm2_test_curve(&rng, ECC_TEST_VERIFY_COUNT);
     if (ret != 0) {
-        fprintf(stderr, "SM2 test\n");
+        printf("SM2 test\n");
         goto done;
     }
 #endif


### PR DESCRIPTION
fixes for `clang-analyzer-core.NullDereference`, `clang-analyzer-core.NonNullParamChecker`, `clang-analyzer-deadcode.DeadStores`, `readability-redundant-preprocessor`, `clang-diagnostic-unreachable-code-break`, `-Werror=sign-conversion`, `bugprone-macro-parentheses`, "Call to 'malloc' has an allocation size of 0 bytes", `clang-diagnostic-declaration-after-statement` re `tests/unit.h`:`ExpectPtr()` pragmas.

tested with `wolfssl-multi-test.sh ... '.*linuxkm.*' '.*Wconversion.*' super-quick-check`

note `cmake` build is still broken re `"HAVE_PTHREAD" redefined`.
