### PR TITLE
getsockopt needs to take in an int

### DIFF
--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -418,12 +418,12 @@ static int PeerIsIpv6(const SOCKADDR_S *peer, XSOCKLENT len)
 
 static int isDGramSock(int sfd)
 {
-    char type = 0;
+    int type = 0;
     /* optvalue 'type' is of size int */
-    XSOCKLENT length = (XSOCKLENT)sizeof(char);
+    XSOCKLENT length = (XSOCKLENT)sizeof(type);
 
-    if (getsockopt(sfd, SOL_SOCKET, SO_TYPE, &type, &length) == 0 &&
-            type != SOCK_DGRAM) {
+    if (getsockopt(sfd, SOL_SOCKET, SO_TYPE, (XSOCKOPT_TYPE_OPTVAL_TYPE)&type,
+            &length) == 0 && type != SOCK_DGRAM) {
         return 0;
     }
     else {

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -381,6 +381,13 @@
             #define XSOCKLENT socklen_t
         #endif
     #endif
+    #ifndef XSOCKOPT_TYPE_OPTVAL_TYPE
+        #ifdef USE_WINDOWS_API
+            #define XSOCKOPT_TYPE_OPTVAL_TYPE void*
+        #else
+            #define XSOCKOPT_TYPE_OPTVAL_TYPE char*
+        #endif
+    #endif
 
     /* Socket Addr Support */
     #ifdef HAVE_SOCKADDR


### PR DESCRIPTION
This caused an issue on big endian platforms. Using a char would cause an incorrect value to be returned.

From the getsockopt man page:
> Most socket-level options utilize an int argument for optval.
