### PR TITLE
Fix for `wc_SignatureGenerate_ex` calling verify twice

### DIFF
--- a/wolfcrypt/src/signature.c
+++ b/wolfcrypt/src/signature.c
@@ -525,15 +525,10 @@ int wc_SignatureGenerate_ex(
         #endif
         }
         if (ret == 0) {
-            /* Generate signature using hash */
-            ret = wc_SignatureGenerateHash(hash_type, sig_type,
-                hash_data, hash_enc_len, sig, sig_len, key, key_len, rng);
+            /* Generate signature using hash (also handles verify) */
+            ret = wc_SignatureGenerateHash_ex(hash_type, sig_type, hash_data,
+                hash_enc_len, sig, sig_len, key, key_len, rng, verify);
         }
-    }
-
-    if (ret == 0 && verify) {
-        ret = wc_SignatureVerifyHash(hash_type, sig_type, hash_data,
-            hash_enc_len, sig, *sig_len, key, key_len);
     }
 
 #if defined(WOLFSSL_SMALL_STACK) || defined(NO_ASN)


### PR DESCRIPTION
# Description

Fix for `wc_SignatureGenerate_ex` calling verify twice

The `wc_SignatureGenerate_ex` function called `wc_SignatureGenerate`, which did verify and then it was done again a second time below.

Fixes ZD 15874

# Testing

`./configure && make check`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
