### PR TITLE
Fixed crash in wc_ecc_free.

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -7654,7 +7654,9 @@ int wc_ecc_free(ecc_key* key)
     mp_clear(key->pubkey.y);
     mp_clear(key->pubkey.z);
 
+#ifdef ALT_ECC_SIZE
     if (key->k)
+#endif
         mp_forcezero(key->k);
 
 #ifdef WOLFSSL_CUSTOM_CURVES

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -7654,7 +7654,8 @@ int wc_ecc_free(ecc_key* key)
     mp_clear(key->pubkey.y);
     mp_clear(key->pubkey.z);
 
-    mp_forcezero(key->k);
+    if (key->k)
+        mp_forcezero(key->k);
 
 #ifdef WOLFSSL_CUSTOM_CURVES
     if (key->deallocSet && key->dp != NULL)

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -4398,6 +4398,9 @@ void fp_clear(fp_int *a)
 
 void fp_forcezero (mp_int * a)
 {
+    if (a == NULL)
+      return;
+
     int size;
     a->used = 0;
     a->sign = FP_ZPOS;


### PR DESCRIPTION
# Description

Fixes zd# 16383

# Testing

Reproduced crash in wolfCrypt test using provided user_settings.h.  Confirmed that crash is no longer present with this fix.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation