### PR TITLE
Always enable tls13MiddleBoxCompat with WOLFSSL_TLS13_MIDDLEBOX_COMPAT

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -7189,6 +7189,10 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         XMEMCPY(ssl->group, ctx->group, sizeof(*ctx->group) * ctx->numGroups);
         ssl->numGroups = ctx->numGroups;
     }
+
+    #ifdef WOLFSSL_TLS13_MIDDLEBOX_COMPAT
+        ssl->options.tls13MiddleBoxCompat = 1;
+    #endif
 #endif
 
 #ifdef HAVE_TLS_EXTENSIONS

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -4249,9 +4249,6 @@ int SendTls13ClientHello(WOLFSSL* ssl)
     /* Version | Random | Cipher Suites | Compression */
     args->length = VERSION_SZ + RAN_LEN + suites->suiteSz +
             SUITE_LEN + COMP_LEN + ENUM_LEN;
-#if defined(WOLFSSL_TLS13_MIDDLEBOX_COMPAT)
-    ssl->options.tls13MiddleBoxCompat = 1;
-#endif
 #ifdef WOLFSSL_QUIC
     if (WOLFSSL_IS_QUIC(ssl)) {
         /* RFC 9001 ch. 8.4 sessionID in ClientHello MUST be 0 length */

--- a/tests/api.c
+++ b/tests/api.c
@@ -34218,6 +34218,8 @@ static int test_wolfSSL_Tls12_Key_Logging_test(void)
     }
     /* a log starting with "CLIENT_RANDOM " should exit in the file */
     ExpectIntEQ(found, 1);
+    /* clean up */
+    ExpectIntEQ(rem_file("./MyKeyLog.txt"), 0);
 #endif /* OPENSSL_EXTRA && HAVE_SECRET_CALLBACK */
     return EXPECT_RESULT();
 }


### PR DESCRIPTION
Tested with `./examples/server/server -v 4` and `./examples/client/client -v 4` and compatibility features checked with Wireshark