### PR TITLE
Espressif refactor WROOM32 ESP32

### DIFF
--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_test/main/main.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_test/main/main.c
@@ -170,18 +170,18 @@ void app_main(void)
     ESP_LOGI(TAG, "Stack HWM: %d\n", uxTaskGetStackHighWaterMark(NULL));
 
     /* check to see if we are using hardware encryption */
-#if defined(NO_ESP32WROOM32_CRYPT)
-    ESP_LOGI(TAG, "NO_ESP32WROOM32_CRYPT defined! HW acceleration DISABLED.");
+#if defined(NO_ESP32_CRYPT)
+    ESP_LOGI(TAG, "NO_ESP32_CRYPT defined! HW acceleration DISABLED.");
 #else
     #if defined(CONFIG_IDF_TARGET_ESP32C3)
-        #error "ESP32WROOM32_CRYPT not yet supported on ESP32-C3"
+        #error "ESP32_CRYPT not yet supported on ESP32-C3"
     #elif defined(CONFIG_IDF_TARGET_ESP32S2)
-        #error "ESP32WROOM32_CRYPT not yet supported on ESP32-S2"
+        #error "ESP32_CRYPT not yet supported on ESP32-S2"
     #elif defined(CONFIG_IDF_TARGET_ESP32S3)
-        /* #error "ESP32WROOM32_CRYPT not yet supported on ESP32-S3" */
-        ESP_LOGI(TAG, "ESP32WROOM32_CRYPT is enabled for  ESP32-S3.");
+        /* #error "ESP32_CRYPT not yet supported on ESP32-S3" */
+        ESP_LOGI(TAG, "ESP32_CRYPT is enabled for  ESP32-S3.");
     #else
-        ESP_LOGI(TAG, "ESP32WROOM32_CRYPT is enabled.");
+        ESP_LOGI(TAG, "ESP32_CRYPT is enabled.");
     #endif
 #endif
 

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_test_idf/main/main.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_test_idf/main/main.c
@@ -170,17 +170,17 @@ void app_main(void)
     ESP_LOGI(TAG, "Stack HWM: %d\n", uxTaskGetStackHighWaterMark(NULL));
 
     /* check to see if we are using hardware encryption */
-#if defined(NO_ESP32WROOM32_CRYPT)
-    ESP_LOGI(TAG, "NO_ESP32WROOM32_CRYPT defined! HW acceleration DISABLED.");
+#if defined(NO_ESP32_CRYPT)
+    ESP_LOGI(TAG, "NO_ESP32_CRYPT defined! HW acceleration DISABLED.");
 #else
     #if defined(CONFIG_IDF_TARGET_ESP32C3)
-        #error "ESP32WROOM32_CRYPT not yet supported on ESP32-C3"
+        #error "ESP32_CRYPT not yet supported on ESP32-C3"
     #elif defined(CONFIG_IDF_TARGET_ESP32S2)
-        #error "ESP32WROOM32_CRYPT not yet supported on ESP32-S2"
+        #error "ESP32_CRYPT not yet supported on ESP32-S2"
     #elif defined(CONFIG_IDF_TARGET_ESP32S3)
-        #error "ESP32WROOM32_CRYPT not yet supported on ESP32-S3"
+        #error "ESP32_CRYPT not yet supported on ESP32-S3"
     #else
-        ESP_LOGI(TAG, "ESP32WROOM32_CRYPT is enabled.");
+        ESP_LOGI(TAG, "ESP32_CRYPT is enabled.");
     #endif
 #endif
 

--- a/IDE/Espressif/ESP-IDF/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/user_settings.h
@@ -19,9 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 #undef WOLFSSL_ESPIDF
-#undef WOLFSSL_ESPWROOM32
+#undef WOLFSSL_ESP32
 #undef WOLFSSL_ESPWROOM32SE
-#undef WOLFSSL_ESPWROOM32
+#undef WOLFSSL_ESP32
 #undef WOLFSSL_ESP8266
 
 #define WOLFSSL_ESPIDF
@@ -29,12 +29,12 @@
 /*
  * choose ONE of these Espressif chips to define:
  *
- * WOLFSSL_ESPWROOM32
+ * WOLFSSL_ESP32
  * WOLFSSL_ESPWROOM32SE
  * WOLFSSL_ESP8266
  */
 
-#define WOLFSSL_ESPWROOM32
+#define WOLFSSL_ESP32
 
 /* #define DEBUG_WOLFSSL_VERBOSE */
 
@@ -86,7 +86,7 @@
 #endif
 
 /* rsa primitive specific definition */
-#if defined(WOLFSSL_ESPWROOM32) || defined(WOLFSSL_ESPWROOM32SE)
+#if defined(WOLFSSL_ESP32) || defined(WOLFSSL_ESPWROOM32SE)
     /* Define USE_FAST_MATH and SMALL_STACK                        */
     #define ESP32_USE_RSA_PRIMITIVE
     /* threshold for performance adjustment for hw primitive use   */
@@ -98,7 +98,7 @@
 
 /* debug options */
 /* #define DEBUG_WOLFSSL */
-/* #define WOLFSSL_ESP32WROOM32_CRYPT_DEBUG */
+/* #define WOLFSSL_ESP32_CRYPT_DEBUG */
 /* #define WOLFSSL_ATECC508A_DEBUG          */
 
 /* date/time                               */
@@ -108,10 +108,10 @@
 /* #define XTIME time */
 
 /* when you want not to use HW acceleration */
-/* #define NO_ESP32WROOM32_CRYPT */
-/* #define NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH*/
-/* #define NO_WOLFSSL_ESP32WROOM32_CRYPT_AES */
-/* #define NO_WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI */
+/* #define NO_ESP32_CRYPT */
+/* #define NO_WOLFSSL_ESP32_CRYPT_HASH*/
+/* #define NO_WOLFSSL_ESP32_CRYPT_AES */
+/* #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI */
 
 /* adjust wait-timeout count if you see timeout in rsa hw acceleration */
 #define ESP_RSA_TIMEOUT_CNT    0x249F00

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -676,8 +676,8 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
         #error nRF51 AES Hardware does not support decrypt
     #endif /* HAVE_AES_DECRYPT */
 
-#elif defined(WOLFSSL_ESP32WROOM32_CRYPT) && \
-    !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_AES)
+#elif defined(WOLFSSL_ESP32_CRYPT) && \
+    !defined(NO_WOLFSSL_ESP32_CRYPT_AES)
 
     #include "wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h"
 
@@ -2865,8 +2865,8 @@ static WARN_UNUSED_RESULT int wc_AesDecrypt(
     {
         return wc_AesSetKey(aes, userKey, keylen, iv, dir);
     }
-#elif defined(WOLFSSL_ESP32WROOM32_CRYPT) && \
-    !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_AES)
+#elif defined(WOLFSSL_ESP32_CRYPT) && \
+    !defined(NO_WOLFSSL_ESP32_CRYPT_AES)
 
     int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen,
         const byte* iv, int dir)
@@ -3176,8 +3176,8 @@ static WARN_UNUSED_RESULT int wc_AesDecrypt(
         rk = aes->key;
         XMEMCPY(rk, userKey, keylen);
     #if defined(LITTLE_ENDIAN_ORDER) && !defined(WOLFSSL_PIC32MZ_CRYPT) && \
-        (!defined(WOLFSSL_ESP32WROOM32_CRYPT) || \
-          defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_AES))
+        (!defined(WOLFSSL_ESP32_CRYPT) || \
+          defined(NO_WOLFSSL_ESP32_CRYPT_AES))
         ByteReverseWords(rk, rk, keylen);
     #endif
 
@@ -4152,8 +4152,8 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
         return ret;
     }
     #endif /* HAVE_AES_DECRYPT */
-#elif defined(WOLFSSL_ESP32WROOM32_CRYPT) && \
-    !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_AES)
+#elif defined(WOLFSSL_ESP32_CRYPT) && \
+    !defined(NO_WOLFSSL_ESP32_CRYPT_AES)
 
     int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     {
@@ -4641,8 +4641,8 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
     #elif defined(WOLFSSL_DEVCRYPTO_AES)
         /* implemented in wolfcrypt/src/port/devcrypt/devcrypto_aes.c */
 
-    #elif defined(WOLFSSL_ESP32WROOM32_CRYPT) && \
-        !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_AES)
+    #elif defined(WOLFSSL_ESP32_CRYPT) && \
+        !defined(NO_WOLFSSL_ESP32_CRYPT_AES)
         /* esp32 doesn't support CRT mode by hw.     */
         /* use aes ecnryption plus sw implementation */
         #define NEED_AES_CTR_SOFT

--- a/wolfcrypt/src/port/Espressif/esp32_aes.c
+++ b/wolfcrypt/src/port/Espressif/esp32_aes.c
@@ -33,8 +33,8 @@
 
 #ifndef NO_AES
 
-#if defined(WOLFSSL_ESP32WROOM32_CRYPT) && \
-    !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_AES)
+#if defined(WOLFSSL_ESP32_CRYPT) && \
+    !defined(NO_WOLFSSL_ESP32_CRYPT_AES)
 #include "sdkconfig.h" /* programmatically generated from sdkconfig */
 #include <wolfssl/wolfcrypt/aes.h>
 #include "wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h"
@@ -428,5 +428,5 @@ int wc_esp32AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     return 0;
 } /* wc_esp32AesCbcDecrypt */
 
-#endif /* WOLFSSL_ESP32WROOM32_CRYPT */
+#endif /* WOLFSSL_ESP32_CRYPT */
 #endif /* NO_AES */

--- a/wolfcrypt/src/port/Espressif/esp32_mp.c
+++ b/wolfcrypt/src/port/Espressif/esp32_mp.c
@@ -30,8 +30,8 @@
 
 #if !defined(NO_RSA) || defined(HAVE_ECC)
 
-#if defined(WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI) && \
-   !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI)
+#if defined(WOLFSSL_ESP32_CRYPT_RSA_PRI) && \
+   !defined(NO_WOLFSSL_ESP32_CRYPT_RSA_PRI)
 
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>
@@ -908,7 +908,7 @@ int esp_mp_exptmod(MATH_INT_T* X, MATH_INT_T* Y, word32 Ys, MATH_INT_T* M, MATH_
 #endif
 }
 
-#endif /* WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI) &&
-        * !NO_WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI */
+#endif /* WOLFSSL_ESP32_CRYPT_RSA_PRI) &&
+        * !NO_WOLFSSL_ESP32_CRYPT_RSA_PRI */
 
 #endif /* !NO_RSA || HAVE_ECC */

--- a/wolfcrypt/src/port/Espressif/esp32_sha.c
+++ b/wolfcrypt/src/port/Espressif/esp32_sha.c
@@ -34,8 +34,8 @@
 
 
 /* this entire file content is excluded if not using HW hash acceleration */
-#if defined(WOLFSSL_ESP32WROOM32_CRYPT) && \
-   !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+#if defined(WOLFSSL_ESP32_CRYPT) && \
+   !defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
 
 /* TODO this may be chip type dependent: add support for others */
 #include <hal/clk_gate_ll.h> /* ESP32-WROOM */
@@ -1364,5 +1364,5 @@ int esp_sha512_digest_process(struct wc_Sha512* sha, byte blockproc)
     return ret;
 } /* esp_sha512_digest_process */
 #endif /* WOLFSSL_SHA512 || WOLFSSL_SHA384 */
-#endif /* WOLFSSL_ESP32WROOM32_CRYPT */
+#endif /* WOLFSSL_ESP32_CRYPT */
 #endif /* !defined(NO_SHA) ||... */

--- a/wolfcrypt/src/port/Espressif/esp32_util.c
+++ b/wolfcrypt/src/port/Espressif/esp32_util.c
@@ -21,7 +21,7 @@
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/version.h>
 
-#if defined(WOLFSSL_ESP32WROOM32_CRYPT) && \
+#if defined(WOLFSSL_ESP32_CRYPT) && \
   (!defined(NO_AES)        || !defined(NO_SHA) || !defined(NO_SHA256) ||\
    defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512))
 
@@ -170,35 +170,35 @@ static int ShowExtendedSystemInfo_platform_espressif()
 #endif
 
     /* check to see if we are using hardware encryption */
-#if defined(NO_ESP32WROOM32_CRYPT)
-    WOLFSSL_VERSION_PRINTF("NO_ESP32WROOM32_CRYPT defined! "
+#if defined(NO_ESP32_CRYPT)
+    WOLFSSL_VERSION_PRINTF("NO_ESP32_CRYPT defined! "
                            "HW acceleration DISABLED.");
 #else
     /* first show what platform hardware acceleration is enabled
     ** (some new platforms may not be supported yet) */
 #if defined(CONFIG_IDF_TARGET_ESP32)
-    WOLFSSL_VERSION_PRINTF("ESP32WROOM32_CRYPT is enabled for ESP32.");
+    WOLFSSL_VERSION_PRINTF("ESP32_CRYPT is enabled for ESP32.");
 #elif defined(CONFIG_IDF_TARGET_ESP32S2)
-    WOLFSSL_VERSION_PRINTF("ESP32WROOM32_CRYPT is enabled for ESP32-S2.");
+    WOLFSSL_VERSION_PRINTF("ESP32_CRYPT is enabled for ESP32-S2.");
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)
-    WOLFSSL_VERSION_PRINTF("ESP32WROOM32_CRYPT is enabled for ESP32-S3.");
+    WOLFSSL_VERSION_PRINTF("ESP32_CRYPT is enabled for ESP32-S3.");
 #else
-#error "ESP32WROOM32_CRYPT not yet supported on this IDF TARGET"
+#error "ESP32_CRYPT not yet supported on this IDF TARGET"
 #endif
 
     /* Even though enabled, some specifics may be disabled */
-#if defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
-    WOLFSSL_VERSION_PRINTF("NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH is defined!"
+#if defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
+    WOLFSSL_VERSION_PRINTF("NO_WOLFSSL_ESP32_CRYPT_HASH is defined!"
                            "(disabled HW SHA).");
 #endif
 
-#if defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_AES)
-    WOLFSSL_VERSION_PRINTF("NO_WOLFSSL_ESP32WROOM32_CRYPT_AES is defined!"
+#if defined(NO_WOLFSSL_ESP32_CRYPT_AES)
+    WOLFSSL_VERSION_PRINTF("NO_WOLFSSL_ESP32_CRYPT_AES is defined!"
                            "(disabled HW AES).");
 #endif
 
-#if defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI)
-    WOLFSSL_VERSION_PRINTF("NO_WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI defined!"
+#if defined(NO_WOLFSSL_ESP32_CRYPT_RSA_PRI)
+    WOLFSSL_VERSION_PRINTF("NO_WOLFSSL_ESP32_CRYPT_RSA_PRI defined!"
                            "(disabled HW RSA)");
 #endif
 #endif

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -3431,7 +3431,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 #elif defined(WOLFSSL_ESPIDF)
 
     /* Espressif */
-    #if defined(WOLFSSL_ESPWROOM32) || defined(WOLFSSL_ESPWROOM32SE)
+    #if defined(WOLFSSL_ESP32) || defined(WOLFSSL_ESPWROOM32SE)
 
         /* Espressif ESP32 */
         #include <esp_system.h>
@@ -3477,7 +3477,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 
             return 0;
         }
-    #endif /* end WOLFSSL_ESPWROOM32 */
+    #endif /* end WOLFSSL_ESP32 */
 
 #elif defined(WOLFSSL_LINUXKM)
     #include <linux/random.h>

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -58,15 +58,15 @@
 #include <wolfssl/wolfcrypt/port/caam/wolfcaam_fsl_nxp.h>
 #endif
 
-#undef WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW
-#if defined(WOLFSSL_ESP32WROOM32_CRYPT) && \
-    !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+#undef WOLFSSL_USE_ESP32_CRYPT_HASH_HW
+#if defined(WOLFSSL_ESP32_CRYPT) && \
+    !defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
     /* define a single keyword for simplicity & readability
      *
      * by default the HW acceleration is on for ESP32-WROOM32
      * but individual components can be turned off.
      */
-    #define WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW
+    #define WOLFSSL_USE_ESP32_CRYPT_HASH_HW
     #include "wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h"
 
     /* Although we have hardware acceleration,
@@ -78,7 +78,7 @@
     ** We'll be using software for RISC-V at this time */
     static const char* TAG = "wc_sha-c3";
 #else
-    #undef WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW
+    #undef WOLFSSL_USE_ESP32_CRYPT_HASH_HW
 #endif
 
 /* fips wrapper calls, user can call direct */
@@ -321,7 +321,7 @@
     !defined(WOLFSSL_QNX_CAAM)
     /* wolfcrypt/src/port/caam/caam_sha.c */
 
-#elif defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW) || \
+#elif defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW) || \
       defined(WOLFSSL_USE_ESP32C3_CRYPT_HASH_HW)
 
     /* This function initializes SHA.
@@ -567,7 +567,7 @@ int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
     sha->devCtx = NULL;
 #endif
 
-#ifdef WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW
+#ifdef WOLFSSL_USE_ESP32_CRYPT_HASH_HW
     if (sha->ctx.mode != ESP32_SHA_INIT) {
         /* it may be interesting to see old values during debugging */
         ESP_LOGV(TAG, "Set ctx mode from prior value: %d", sha->ctx.mode);
@@ -651,7 +651,7 @@ int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)
             ByteReverseWords(sha->buffer, sha->buffer, WC_SHA_BLOCK_SIZE);
         #endif
 
-        #if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+        #if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
             if (sha->ctx.mode == ESP32_SHA_INIT) {
                 ESP_LOGV(TAG, "wc_ShaUpdate try hardware");
                 esp_sha_try_hw_lock(&sha->ctx);
@@ -712,7 +712,7 @@ int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)
         ByteReverseWords(local32, local32, WC_SHA_BLOCK_SIZE);
     #endif
 
-    #if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+    #if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
         if (sha->ctx.mode == ESP32_SHA_INIT){
             esp_sha_try_hw_lock(&sha->ctx);
         }
@@ -806,7 +806,7 @@ int wc_ShaFinal(wc_Sha* sha, byte* hash)
         ByteReverseWords(sha->buffer, sha->buffer, WC_SHA_BLOCK_SIZE);
     #endif
 
-    #if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+    #if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
         /* For a fresh sha.ctx, try to use hardware acceleration */
         if (sha->ctx.mode == ESP32_SHA_INIT) {
             esp_sha_try_hw_lock(&sha->ctx);
@@ -855,7 +855,7 @@ int wc_ShaFinal(wc_Sha* sha, byte* hash)
                      2 * sizeof(word32));
 #endif
 
-#if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+#if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
     if (sha->ctx.mode == ESP32_SHA_INIT) {
         esp_sha_try_hw_lock(&sha->ctx);
     }
@@ -1012,7 +1012,7 @@ int wc_ShaCopy(wc_Sha* src, wc_Sha* dst)
     ret = se050_hash_copy(&src->se050Ctx, &dst->se050Ctx);
 #endif
 
-#if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+#if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
     esp_sha_ctx_copy(src, dst);
 #endif
 

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -90,17 +90,17 @@ on the specific device platform.
 
 
 /* determine if we are using Espressif SHA hardware acceleration */
-#undef WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW
-#if defined(WOLFSSL_ESP32WROOM32_CRYPT) && \
-    !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+#undef WOLFSSL_USE_ESP32_CRYPT_HASH_HW
+#if defined(WOLFSSL_ESP32_CRYPT) && \
+    !defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
     /* define a single keyword for simplicity & readability
      *
      * by default the HW acceleration is on for ESP32-WROOM32
      * but individual components can be turned off.
      */
-    #define WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW
+    #define WOLFSSL_USE_ESP32_CRYPT_HASH_HW
 #else
-    #undef WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW
+    #undef WOLFSSL_USE_ESP32_CRYPT_HASH_HW
 #endif
 
 #ifdef WOLFSSL_ESPIDF
@@ -218,7 +218,7 @@ on the specific device platform.
     (!defined(WOLFSSL_IMX6_CAAM) || defined(NO_IMX6_CAAM_HASH) || \
      defined(WOLFSSL_QNX_CAAM)) && \
     !defined(WOLFSSL_AFALG_HASH) && !defined(WOLFSSL_DEVCRYPTO_HASH) && \
-    (!defined(WOLFSSL_ESP32WROOM32_CRYPT) || defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)) && \
+    (!defined(WOLFSSL_ESP32_CRYPT) || defined(NO_WOLFSSL_ESP32_CRYPT_HASH)) && \
     (!defined(WOLFSSL_RENESAS_TSIP_CRYPT) || defined(NO_WOLFSSL_RENESAS_TSIP_CRYPT_HASH)) && \
     !defined(WOLFSSL_PSOC6_CRYPTO) && !defined(WOLFSSL_IMXRT_DCP) && !defined(WOLFSSL_SILABS_SE_ACCEL) && \
     !defined(WOLFSSL_KCAPI_HASH) && !defined(WOLFSSL_SE050_HASH) && \
@@ -735,7 +735,7 @@ static int InitSha256(wc_Sha256* sha256)
         return ret;
     }
 
-#elif defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+#elif defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
 
     /* HW may fail since there's only one, so we still need SW */
     #define NEED_SOFT_SHA256
@@ -781,7 +781,7 @@ static int InitSha256(wc_Sha256* sha256)
             return BAD_FUNC_ARG;
         }
 
-    #ifdef WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW
+    #ifdef WOLFSSL_USE_ESP32_CRYPT_HASH_HW
         /* We know this is a fresh, uninitialized item, so set to INIT */
         if (sha256->ctx.mode != ESP32_SHA_INIT) {
             ESP_LOGV(TAG, "Set ctx mode from prior value: "
@@ -1102,7 +1102,7 @@ static int InitSha256(wc_Sha256* sha256)
                 }
             #endif
 
-            #if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+            #if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
                 if (sha256->ctx.mode == ESP32_SHA_INIT) {
                     ESP_LOGV(TAG, "Sha256Update try hardware");
                     esp_sha_try_hw_lock(&sha256->ctx);
@@ -1186,7 +1186,7 @@ static int InitSha256(wc_Sha256* sha256)
                 }
             #endif
 
-            #if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+            #if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
                 if (sha256->ctx.mode == ESP32_SHA_INIT){
                     ESP_LOGV(TAG, "Sha256Update try hardware loop");
                     esp_sha_try_hw_lock(&sha256->ctx);
@@ -1293,7 +1293,7 @@ static int InitSha256(wc_Sha256* sha256)
             }
         #endif
 
-        #if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+        #if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
             if (sha256->ctx.mode == ESP32_SHA_INIT) {
                 esp_sha_try_hw_lock(&sha256->ctx);
             }
@@ -1351,7 +1351,7 @@ static int InitSha256(wc_Sha256* sha256)
         }
     #endif
 
-    #if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+    #if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
         if (sha256->ctx.mode == ESP32_SHA_INIT) {
             esp_sha_try_hw_lock(&sha256->ctx);
         }
@@ -1594,7 +1594,7 @@ static int InitSha256(wc_Sha256* sha256)
         sha224->used = 0;
     #endif
 
-    #if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+    #if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
         /* not to be confused with HAS512_224 */
         sha224->ctx.mode = ESP32_SHA_SW; /* no SHA224 HW, so always SW */
     #endif
@@ -1617,7 +1617,7 @@ static int InitSha256(wc_Sha256* sha256)
         sha224->W = NULL;
     #endif
 
-    #ifdef WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW
+    #ifdef WOLFSSL_USE_ESP32_CRYPT_HASH_HW
         /* We know this is a fresh, uninitialized item, so set to INIT */
         if (sha224->ctx.mode != ESP32_SHA_SW) {
             ESP_LOGV(TAG, "Set sha224 ctx mode init to ESP32_SHA_SW. "
@@ -1642,7 +1642,7 @@ static int InitSha256(wc_Sha256* sha256)
      ret = wc_CAAM_HashInit(&sha224->hndl, &sha224->ctx, WC_HASH_TYPE_SHA224);
 #endif
 
-    #ifdef WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW
+    #ifdef WOLFSSL_USE_ESP32_CRYPT_HASH_HW
         if (sha224->ctx.mode != ESP32_SHA_INIT) {
             ESP_LOGV("SHA224", "Set ctx mode from prior value: "
                                "%d", sha224->ctx.mode);
@@ -1670,7 +1670,7 @@ static int InitSha256(wc_Sha256* sha256)
         }
     #endif /* WOLFSSL_ASYNC_CRYPT */
 
-    #if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+    #if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
         sha224->ctx.mode = ESP32_SHA_SW; /* no SHA224 HW, so always SW */
     #endif
 
@@ -1696,7 +1696,7 @@ static int InitSha256(wc_Sha256* sha256)
         }
     #endif /* WOLFSSL_ASYNC_CRYPT */
 
-    #if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+    #if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
         sha224->ctx.mode = ESP32_SHA_SW; /* no SHA224 HW, so always SW */
     #endif
 
@@ -1832,7 +1832,7 @@ void wc_Sha256Free(wc_Sha256* sha256)
 #endif
 
 /* Espressif embedded hardware acceleration specific: */
-#if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+#if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
     if (sha256->ctx.lockDepth > 0) {
         /* probably due to unclean shutdown, error, or other problem.
          *
@@ -1942,7 +1942,7 @@ int wc_Sha224_Grow(wc_Sha224* sha224, const byte* in, int inSz)
         ret = wolfAsync_DevCopy(&src->asyncDev, &dst->asyncDev);
     #endif
 
-    #if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+    #if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
         ret = esp_sha224_ctx_copy(src, dst);
     #endif
 
@@ -2081,7 +2081,7 @@ int wc_Sha256Copy(wc_Sha256* src, wc_Sha256* dst)
     ret = wc_Pic32HashCopy(&src->cache, &dst->cache);
 #endif
 
-#if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+#if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
     esp_sha256_ctx_copy(src, dst);
 #endif
 

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -29,18 +29,18 @@
 #if (defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)) && !defined(WOLFSSL_ARMASM) && !defined(WOLFSSL_PSOC6_CRYPTO)
 
 /* determine if we are using Espressif SHA hardware acceleration */
-#undef WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW
-#if defined(WOLFSSL_ESP32WROOM32_CRYPT) && \
-    !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+#undef WOLFSSL_USE_ESP32_CRYPT_HASH_HW
+#if defined(WOLFSSL_ESP32_CRYPT) && \
+    !defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
     /* define a single keyword for simplicity & readability
      *
      * by default the HW acceleration is on for ESP32-WROOM32
      * but individual components can be turned off.
      */
-    #define WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW
+    #define WOLFSSL_USE_ESP32_CRYPT_HASH_HW
     static const char* TAG = "wc_sha_512";
 #else
-    #undef WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW
+    #undef WOLFSSL_USE_ESP32_CRYPT_HASH_HW
 #endif
 
 #if defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)
@@ -294,7 +294,7 @@ static int InitSha512(wc_Sha512* sha512)
     sha512->loLen   = 0;
     sha512->hiLen   = 0;
 
-#if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+#if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
 
     /* HW needs to be carefully initialized, taking into account soft copy.
     ** If already in use; copy may revert to SW as needed. */
@@ -334,7 +334,7 @@ static int InitSha512_224(wc_Sha512* sha512)
     sha512->loLen   = 0;
     sha512->hiLen   = 0;
 
-#if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+#if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
     /* HW needs to be carefully initialized, taking into account soft copy.
     ** If already in use; copy may revert to SW as needed.
     **
@@ -376,7 +376,7 @@ static int InitSha512_256(wc_Sha512* sha512)
     sha512->loLen   = 0;
     sha512->hiLen   = 0;
 
-#if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+#if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
     /* HW needs to be carefully initialized, taking into account soft copy.
     ** If already in use; copy may revert to SW as needed.
     **
@@ -616,7 +616,7 @@ static int InitSha512_Family(wc_Sha512* sha512, void* heap, int devId,
 
 int wc_InitSha512_ex(wc_Sha512* sha512, void* heap, int devId)
 {
-#if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+#if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
     if (sha512->ctx.mode != ESP32_SHA_INIT) {
         ESP_LOGV(TAG, "Set ctx mode from prior value: "
                       "%d", sha512->ctx.mode);
@@ -632,7 +632,7 @@ int wc_InitSha512_ex(wc_Sha512* sha512, void* heap, int devId)
    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)) && !defined(HAVE_SELFTEST)
 int wc_InitSha512_224_ex(wc_Sha512* sha512, void* heap, int devId)
 {
-#ifdef WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW
+#ifdef WOLFSSL_USE_ESP32_CRYPT_HASH_HW
     /* No SHA512/224 HW support is available, set to SW. */
     sha512->ctx.mode = ESP32_SHA_SW; /* no SHA224 HW, so always SW */
 #endif
@@ -644,7 +644,7 @@ int wc_InitSha512_224_ex(wc_Sha512* sha512, void* heap, int devId)
    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)) && !defined(HAVE_SELFTEST)
 int wc_InitSha512_256_ex(wc_Sha512* sha512, void* heap, int devId)
 {
-#ifdef WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW
+#ifdef WOLFSSL_USE_ESP32_CRYPT_HASH_HW
     /* No SHA512/256 HW support is available on ESP32, set to SW. */
     sha512->ctx.mode = ESP32_SHA_SW;
 #endif
@@ -835,15 +835,15 @@ static WC_INLINE int Sha512Update(wc_Sha512* sha512, const byte* data, word32 le
             if (!IS_INTEL_AVX1(intel_flags) && !IS_INTEL_AVX2(intel_flags))
         #endif
             {
-        #if !defined(WOLFSSL_ESP32WROOM32_CRYPT) || \
-             defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+        #if !defined(WOLFSSL_ESP32_CRYPT) || \
+             defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
                 ByteReverseWords64(sha512->buffer, sha512->buffer,
                                                          WC_SHA512_BLOCK_SIZE);
         #endif
             }
     #endif
-    #if !defined(WOLFSSL_ESP32WROOM32_CRYPT) || \
-         defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+    #if !defined(WOLFSSL_ESP32_CRYPT) || \
+         defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
             ret = Transform_Sha512(sha512);
     #else
             if(sha512->ctx.mode == ESP32_SHA_INIT) {
@@ -908,13 +908,13 @@ static WC_INLINE int Sha512Update(wc_Sha512* sha512, const byte* data, word32 le
 
             data += WC_SHA512_BLOCK_SIZE;
             len  -= WC_SHA512_BLOCK_SIZE;
-    #if !defined(WOLFSSL_ESP32WROOM32_CRYPT) || \
-         defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+    #if !defined(WOLFSSL_ESP32_CRYPT) || \
+         defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
             ByteReverseWords64(sha512->buffer, sha512->buffer,
                                                        WC_SHA512_BLOCK_SIZE);
     #endif
-    #if !defined(WOLFSSL_ESP32WROOM32_CRYPT) || \
-         defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+    #if !defined(WOLFSSL_ESP32_CRYPT) || \
+         defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
             ret = Transform_Sha512(sha512);
     #else
             if(sha512->ctx.mode == ESP32_SHA_INIT) {
@@ -1014,15 +1014,15 @@ static WC_INLINE int Sha512Final(wc_Sha512* sha512)
     #endif
         {
 
-       #if !defined(WOLFSSL_ESP32WROOM32_CRYPT) || \
-            defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+       #if !defined(WOLFSSL_ESP32_CRYPT) || \
+            defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
             ByteReverseWords64(sha512->buffer,sha512->buffer,
                                                          WC_SHA512_BLOCK_SIZE);
        #endif
         }
 
 #endif /* LITTLE_ENDIAN_ORDER */
-    #if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+    #if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
         if (sha512->ctx.mode == ESP32_SHA_INIT) {
             esp_sha_try_hw_lock(&sha512->ctx);
         }
@@ -1056,15 +1056,15 @@ static WC_INLINE int Sha512Final(wc_Sha512* sha512)
         (defined(HAVE_INTEL_AVX1) || defined(HAVE_INTEL_AVX2))
         if (!IS_INTEL_AVX1(intel_flags) && !IS_INTEL_AVX2(intel_flags))
     #endif
-    #if !defined(WOLFSSL_ESP32WROOM32_CRYPT) || \
-         defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+    #if !defined(WOLFSSL_ESP32_CRYPT) || \
+         defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
             ByteReverseWords64(sha512->buffer, sha512->buffer, WC_SHA512_PAD_SIZE);
     #endif
 #endif
     /* ! length ordering dependent on digest endian type ! */
 
-#if !defined(WOLFSSL_ESP32WROOM32_CRYPT) || \
-     defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+#if !defined(WOLFSSL_ESP32_CRYPT) || \
+     defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
     sha512->buffer[WC_SHA512_BLOCK_SIZE / sizeof(word64) - 2] = sha512->hiLen;
     sha512->buffer[WC_SHA512_BLOCK_SIZE / sizeof(word64) - 1] = sha512->loLen;
 #endif
@@ -1077,8 +1077,8 @@ static WC_INLINE int Sha512Final(wc_Sha512* sha512)
                            WC_SHA512_BLOCK_SIZE - WC_SHA512_PAD_SIZE);
 #endif
 
-#if !defined(WOLFSSL_ESP32WROOM32_CRYPT) || \
-    defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+#if !defined(WOLFSSL_ESP32_CRYPT) || \
+    defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
     ret = Transform_Sha512(sha512);
 #else
     if(sha512->ctx.mode == ESP32_SHA_INIT) {
@@ -1354,7 +1354,7 @@ static int InitSha384(wc_Sha384* sha384)
     sha384->loLen   = 0;
     sha384->hiLen   = 0;
 
-#if  defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+#if  defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
     /* HW needs to be carefully initialized, taking into account soft copy.
     ** If already in use; copy may revert to SW as needed. */
     esp_sha_init(&(sha384->ctx), WC_HASH_TYPE_SHA384);
@@ -1476,7 +1476,7 @@ int wc_InitSha384_ex(wc_Sha384* sha384, void* heap, int devId)
     sha384->devId = devId;
     sha384->devCtx = NULL;
 #endif
-#if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+#if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
     if (sha384->ctx.mode != ESP32_SHA_INIT) {
         ESP_LOGV(TAG, "Set ctx mode from prior value: "
                            "%d", sha384->ctx.mode);
@@ -1626,7 +1626,7 @@ int wc_Sha512Copy(wc_Sha512* src, wc_Sha512* dst)
     ret = wolfAsync_DevCopy(&src->asyncDev, &dst->asyncDev);
 #endif
 
-#if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+#if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
     if (ret == 0) {
         ret = esp_sha512_ctx_copy(src, dst);
     }
@@ -1878,7 +1878,7 @@ int wc_Sha384Copy(wc_Sha384* src, wc_Sha384* dst)
     ret = wolfAsync_DevCopy(&src->asyncDev, &dst->asyncDev);
 #endif
 
-#if defined(WOLFSSL_USE_ESP32WROOM32_CRYPT_HASH_HW)
+#if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
     esp_sha384_ctx_copy(src, dst);
 #endif
 

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -232,8 +232,8 @@ int fp_mul(fp_int *A, fp_int *B, fp_int *C)
     int   ret = 0;
     int   y, yy, oldused;
 
-#if defined(WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI) && \
-   !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI)
+#if defined(WOLFSSL_ESP32_CRYPT_RSA_PRI) && \
+   !defined(NO_WOLFSSL_ESP32_CRYPT_RSA_PRI)
   ret = esp_mp_mul(A, B, C);
   if(ret != -2) return ret;
 #endif
@@ -2997,8 +2997,8 @@ static int _fp_exptmod_base_2(fp_int * X, int digits, fp_int * P,
 int fp_exptmod(fp_int * G, fp_int * X, fp_int * P, fp_int * Y)
 {
 
-#if defined(WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI) && \
-   !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI)
+#if defined(WOLFSSL_ESP32_CRYPT_RSA_PRI) && \
+   !defined(NO_WOLFSSL_ESP32_CRYPT_RSA_PRI)
    int x = fp_count_bits (X);
 #endif
 
@@ -3019,8 +3019,8 @@ int fp_exptmod(fp_int * G, fp_int * X, fp_int * P, fp_int * Y)
       return FP_OKAY;
    }
 
-#if defined(WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI) && \
-   !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI)
+#if defined(WOLFSSL_ESP32_CRYPT_RSA_PRI) && \
+   !defined(NO_WOLFSSL_ESP32_CRYPT_RSA_PRI)
    if(x > EPS_RSA_EXPT_XBTIS) {
       return esp_mp_exptmod(G, X, x, P, Y);
    }
@@ -3082,8 +3082,8 @@ int fp_exptmod(fp_int * G, fp_int * X, fp_int * P, fp_int * Y)
 int fp_exptmod_ex(fp_int * G, fp_int * X, int digits, fp_int * P, fp_int * Y)
 {
 
-#if defined(WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI) && \
-   !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI)
+#if defined(WOLFSSL_ESP32_CRYPT_RSA_PRI) && \
+   !defined(NO_WOLFSSL_ESP32_CRYPT_RSA_PRI)
    int x = fp_count_bits (X);
 #endif
 
@@ -3104,8 +3104,8 @@ int fp_exptmod_ex(fp_int * G, fp_int * X, int digits, fp_int * P, fp_int * Y)
       return FP_OKAY;
    }
 
-#if defined(WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI) && \
-   !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI)
+#if defined(WOLFSSL_ESP32_CRYPT_RSA_PRI) && \
+   !defined(NO_WOLFSSL_ESP32_CRYPT_RSA_PRI)
    if(x > EPS_RSA_EXPT_XBTIS) {
       return esp_mp_exptmod(G, X, x, P, Y);
    }
@@ -3166,8 +3166,8 @@ int fp_exptmod_ex(fp_int * G, fp_int * X, int digits, fp_int * P, fp_int * Y)
 
 int fp_exptmod_nct(fp_int * G, fp_int * X, fp_int * P, fp_int * Y)
 {
-#if defined(WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI) && \
-   !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI)
+#if defined(WOLFSSL_ESP32_CRYPT_RSA_PRI) && \
+   !defined(NO_WOLFSSL_ESP32_CRYPT_RSA_PRI)
    int x = fp_count_bits (X);
 #endif
 
@@ -3181,8 +3181,8 @@ int fp_exptmod_nct(fp_int * G, fp_int * X, fp_int * P, fp_int * Y)
       return FP_VAL;
    }
 
-#if defined(WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI) && \
-   !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI)
+#if defined(WOLFSSL_ESP32_CRYPT_RSA_PRI) && \
+   !defined(NO_WOLFSSL_ESP32_CRYPT_RSA_PRI)
    if(x > EPS_RSA_EXPT_XBTIS) {
       return esp_mp_exptmod(G, X, x, P, Y);
    }
@@ -4498,8 +4498,8 @@ int wolfcrypt_mp_mulmod (mp_int * a, mp_int * b, mp_int * c, mp_int * d)
 int mp_mulmod (mp_int * a, mp_int * b, mp_int * c, mp_int * d)
 #endif
 {
- #if defined(WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI) && \
-    !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI)
+ #if defined(WOLFSSL_ESP32_CRYPT_RSA_PRI) && \
+    !defined(NO_WOLFSSL_ESP32_CRYPT_RSA_PRI)
     int A = fp_count_bits (a);
     int B = fp_count_bits (b);
 

--- a/wolfssl/openssl/sha.h
+++ b/wolfssl/openssl/sha.h
@@ -41,8 +41,8 @@
     #define CTX_SHA_HW_ADDER sizeof(STM32_HASH_Context)
 #elif defined(WOLFSSL_IMXRT1170_CAAM)
     #define CTX_SHA_HW_ADDER (sizeof(caam_hash_ctx_t) + sizeof(caam_handle_t))
-#elif defined(WOLFSSL_ESPWROOM32) && \
-     !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+#elif defined(WOLFSSL_ESP32) && \
+     !defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
     #define CTX_SHA_HW_ADDER sizeof(WC_ESP32SHA)
 #else
     #define CTX_SHA_HW_ADDER 0

--- a/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
+++ b/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
@@ -29,7 +29,7 @@
 #include "esp_types.h"
 #include "esp_log.h"
 
-#ifdef WOLFSSL_ESP32WROOM32_CRYPT_DEBUG
+#ifdef WOLFSSL_ESP32_CRYPT_DEBUG
     #undef LOG_LOCAL_LEVEL
     #define LOG_LOCAL_LEVEL ESP_LOG_DEBUG
 #else
@@ -104,14 +104,14 @@ int esp_CryptHwMutexUnLock(wolfSSL_Mutex* mutex);
 
 #endif
 
-#ifdef WOLFSSL_ESP32WROOM32_CRYPT_DEBUG
+#ifdef WOLFSSL_ESP32_CRYPT_DEBUG
 
     void wc_esp32TimerStart(void);
     uint64_t  wc_esp32elapsedTime(void);
 
-#endif /* WOLFSSL_ESP32WROOM32_CRYPT_DEBUG */
+#endif /* WOLFSSL_ESP32_CRYPT_DEBUG */
 
-#if !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH) &&     \
+#if !defined(NO_WOLFSSL_ESP32_CRYPT_HASH) &&     \
    (!defined(NO_SHA) || !defined(NO_SHA256) ||          \
      defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512) \
    )

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -224,7 +224,7 @@
 /* #define WOLFSSL_ESPIDF */
 
 /* Uncomment next line if using Espressif ESP32-WROOM-32 */
-/* #define WOLFSSL_ESPWROOM32 */
+/* #define WOLFSSL_ESP32 */
 
 /* Uncomment next line if using Espressif ESP32-WROOM-32SE */
 /* #define WOLFSSL_ESPWROOM32SE */
@@ -350,12 +350,19 @@
     #define ECC_TIMING_RESISTANT
     #define WC_RSA_BLINDING
 
-#if defined(WOLFSSL_ESPWROOM32) || defined(WOLFSSL_ESPWROOM32SE)
-   #ifndef NO_ESP32WROOM32_CRYPT
-        #define WOLFSSL_ESP32WROOM32_CRYPT
+#if defined(WOLFSSL_ESPWROOM32)
+    /* WOLFSSL_ESPWROOM32 is a legacy macro gate.
+    ** Not be be confused with WOLFSSL_ESPWROOM32SE, naming a specific board */
+    #undef WOLFSSL_ESP32
+    #define WOLFSSL_ESP32
+#endif
+
+#if defined(WOLFSSL_ESP32) || defined(WOLFSSL_ESPWROOM32SE)
+   #ifndef NO_ESP32_CRYPT
+        #define WOLFSSL_ESP32_CRYPT
         #if defined(ESP32_USE_RSA_PRIMITIVE) && \
-            !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI)
-            #define WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI
+            !defined(NO_WOLFSSL_ESP32_CRYPT_RSA_PRI)
+            #define WOLFSSL_ESP32_CRYPT_RSA_PRI
             #define WOLFSSL_SMALL_STACK
         #endif
    #endif

--- a/wolfssl/wolfcrypt/sha.h
+++ b/wolfssl/wolfcrypt/sha.h
@@ -78,7 +78,7 @@
 #ifdef WOLFSSL_ASYNC_CRYPT
     #include <wolfssl/wolfcrypt/async.h>
 #endif
-#ifdef WOLFSSL_ESP32WROOM32_CRYPT
+#ifdef WOLFSSL_ESP32_CRYPT
     #include <wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h>
 #endif
 #if defined(WOLFSSL_SILABS_SE_ACCEL)
@@ -173,8 +173,8 @@ struct wc_Sha {
         word32 len;
     #endif
 #endif
-#if defined(WOLFSSL_ESP32WROOM32_CRYPT) && \
-   !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+#if defined(WOLFSSL_ESP32_CRYPT) && \
+   !defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
     WC_ESP32SHA ctx;
 #endif
 #ifdef WOLFSSL_HASH_FLAGS

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -97,7 +97,7 @@
 #if defined(WOLFSSL_DEVCRYPTO) && defined(WOLFSSL_DEVCRYPTO_HASH)
     #include <wolfssl/wolfcrypt/port/devcrypto/wc_devcrypto.h>
 #endif
-#if defined(WOLFSSL_ESP32WROOM32_CRYPT)
+#if defined(WOLFSSL_ESP32_CRYPT)
     #include "wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h"
 #endif
 #if defined(WOLFSSL_CRYPTOCELL)
@@ -214,8 +214,8 @@ struct wc_Sha256 {
     word32 used;
     word32 len;
 #endif
-#if defined(WOLFSSL_ESP32WROOM32_CRYPT) && \
-   !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+#if defined(WOLFSSL_ESP32_CRYPT) && \
+   !defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
     WC_ESP32SHA ctx;
 #endif
 #ifdef WOLFSSL_MAXQ10XX_CRYPTO

--- a/wolfssl/wolfcrypt/sha512.h
+++ b/wolfssl/wolfcrypt/sha512.h
@@ -75,7 +75,7 @@
 #ifdef WOLFSSL_ASYNC_CRYPT
     #include <wolfssl/wolfcrypt/async.h>
 #endif
-#ifdef WOLFSSL_ESP32WROOM32_CRYPT
+#ifdef WOLFSSL_ESP32_CRYPT
     #include <wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h>
 #endif
 #if defined(WOLFSSL_SILABS_SE_ACCEL)
@@ -172,8 +172,8 @@ struct wc_Sha512 {
 #ifdef WOLFSSL_SMALL_STACK_CACHE
     word64* W;
 #endif
-#if defined(WOLFSSL_ESP32WROOM32_CRYPT) && \
-   !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+#if defined(WOLFSSL_ESP32_CRYPT) && \
+   !defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
     WC_ESP32SHA ctx;
 #endif
 #if defined(WOLFSSL_SILABS_SE_ACCEL)


### PR DESCRIPTION
# Description

This update is preparation to an upcoming large update to the Espressif codebase. Addressed here is only the refactor of macro names as related to the `WROOM` keyword.

When first implemented, we never imagined there would be such a variety of ESP32 devices and arhcitectures. Many of the new ones have no reference at all to the `WROOM` product line.

Included is only a global file update of all wolfSSL repo files selected with this selection:

```
*.md;*.c;*.h;!*/dist/*;!*/managed_components/*;!*/component-manager/*;!*/.git/*;!*/XXX-fips-test/*;
```

These replacements were made in this order:

|Step | Replace | With |
| --- | -------- | ----|
| 1 | `WOLFSSL_ESPWROOM32SE` | `$$KEEP__ESP32SE$$` |
| 2 | `WOLFSSL_ESPWROOM32`   | `WOLFSSL_ESP32` |
| 3 | `ESP32WROOM32`         | `ESP32` |
| 4 | `$$KEEP__ESP32SE$$`    | `WOLFSSL_ESPWROOM32SE` |

Note that `WOLFSSL_ESPWROOM32SE` names a specific board and is retained.

Any legacy use of the `WOLFSSL_ESPWROOM32` is handled in the `settings.h` file.

See also the changes in https://github.com/wolfSSL/wolfssl/pull/6565 that will be needed for the upcoming PR.

Fixes zd# n/a

# Testing

How did you test?

Confirmed [wolfssl_test](https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark) and [benchmark](https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/wolfssl_test) examples working properly for ESP32 targets.

Confirmed Linux builds & examples apps:

```
make clean && make
./wolfcrypt/test/testwolfcrypt 
 wolfcrypt/benchmark/benchmark
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation

See https://github.com/wolfSSL/wolfssl/issues/6234 for a roadmap of all Espressif improvements  current in progress.