### PR TITLE
Fix for SP math only case to ensure fast math and heap math are disabled

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2033,17 +2033,22 @@ extern void uITRON4_free(void *p) ;
          *      Constant time: Always
          *      Enable:        WOLFSSL_SP_MATH_ALL
          */
+        #undef USE_FAST_MATH
+        #undef USE_INTEGER_HEAP_MATH
     #elif defined(WOLFSSL_SP_MATH)
         /*  2) SP Math with restricted key sizes: wolfSSL proprietary math
          *         implementation (sp_*.c).
          *      Constant time: Always
          *      Enable:        WOLFSSL_SP_MATH
          */
+        #undef USE_FAST_MATH
+        #undef USE_INTEGER_HEAP_MATH
     #elif defined(USE_FAST_MATH)
         /*  3) Tom's Fast Math: Stack based (tfm.c)
          *      Constant time: Only with TFM_TIMING_RESISTANT
          *      Enable:        USE_FAST_MATH
          */
+        #undef USE_INTEGER_HEAP_MATH
     #elif defined(USE_INTEGER_HEAP_MATH)
         /*  4) Integer Heap Math:  Heap based (integer.c)
          *      Constant time: Not supported

--- a/wolfssl/wolfcrypt/sp.h
+++ b/wolfssl/wolfcrypt/sp.h
@@ -41,7 +41,11 @@
 #include <wolfssl/wolfcrypt/wolfmath.h>
 #include <wolfssl/wolfcrypt/sp_int.h>
 
-#include <wolfssl/wolfcrypt/ecc.h>
+#if defined(HAVE_ECC) && defined(WOLFSSL_HAVE_SP_ECC)
+    #include <wolfssl/wolfcrypt/ecc.h>
+#else
+    #undef WOLFSSL_HAVE_SP_ECC
+#endif
 
 #ifdef noinline
     #define SP_NOINLINE noinline


### PR DESCRIPTION
# Description

* Fix for SP math only case to ensure fast math and heap math are disabled. This worked prior to PR https://github.com/wolfSSL/wolfssl/pull/6123
* Fix build error for case where `WOLFSSL_HAVE_SP_ECC` is defined, but `HAVE_ECC` is not.

Fixes ZD 16419 and 16415

# Testing

```
./configure --enable-sp-math CFLAGS="-DUSE_FAST_MATH" && make
./configure --enable-sp-math-all CFLAGS="-DUSE_FAST_MATH" && make
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
