### PR TITLE
Fix Micrium config and new examples with NO_FILESYSTEM

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -84,3 +84,9 @@ and
 This directory contains example wolfSSL configuration file templates for use when autoconf is not available, such as building with a custom IDE.
 
 See [configs/README.md](configs/README.md) for more details.
+
+## asn1
+This directory contains an example that prints the ASN.1 data of a BER/DER or PEM encoded file. Configure wolfSSL with `--enable-asn-print`.
+
+## pem
+This directory contains an example of converting to/from PEM and DER. Configure wolfSSL with `--enable-coding`

--- a/examples/asn1/asn1.c
+++ b/examples/asn1/asn1.c
@@ -30,8 +30,9 @@
 #include <wolfssl/wolfcrypt/asn_public.h>
 #include <wolfssl/wolfcrypt/coding.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
+#include <stdio.h>
 
-#ifdef WOLFSSL_ASN_PRINT
+#if defined(WOLFSSL_ASN_PRINT) && !defined(NO_FILESYSTEM)
 
 /* Increment allocated data by this much. */
 #define DATA_INC_LEN    256
@@ -485,9 +486,9 @@ int main(int argc, char* argv[])
 {
     (void)argc;
     (void)argv;
-    fprintf(stderr, "ASN.1 Parsing and Printing not compiled in.\n");
+    fprintf(stderr, "ASN.1 Parsing and Printing or file system not compiled"
+                    " in.\n");
     return 0;
 }
 
-#endif /* WOLFSSL_ASN_PRINT */
-
+#endif /* WOLFSSL_ASN_PRINT && !defined(NO_FILESYSTEM)*/

--- a/examples/pem/pem.c
+++ b/examples/pem/pem.c
@@ -35,8 +35,9 @@
 #ifdef DEBUG_WOLFSSL
     #include <wolfssl/wolfcrypt/logging.h>
 #endif
+#include <stdio.h>
 
-#ifdef WOLFSSL_PEM_TO_DER
+#if defined(WOLFSSL_PEM_TO_DER) && !defined(NO_FILESYSTEM)
 
 /* Increment allocated data by this much. */
 #define DATA_INC_LEN        256
@@ -1034,9 +1035,9 @@ int main(int argc, char* argv[])
 {
     (void)argc;
     (void)argv;
-    fprintf(stderr, "PEM to DER conversion not compiled in.\n");
+    fprintf(stderr, "PEM to DER conversion of file system support not compiled"
+                    " in.\n");
     return 0;
 }
 
-#endif /* WOLFSSL_PEM_TO_DER */
-
+#endif /* WOLFSSL_PEM_TO_DER && !NO_FILESYSTEM */

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1528,6 +1528,7 @@ extern void uITRON4_free(void *p) ;
 #ifdef MICRIUM
     #include <stdlib.h>
     #include <os.h>
+    #include <app_cfg.h>
     #if defined(RTOS_MODULE_NET_AVAIL) || (APP_CFG_TCPIP_EN == DEF_ENABLED)
         #include <net_cfg.h>
         #include <net_sock.h>


### PR DESCRIPTION
# Description

Fix Micrium config and new examples with NO_FILESYSTEM

Fixes zd16415

# Testing

Micrium fix is customer confirmed.

Examples:
Build with `./configure CFLAGS="-DNO_FILESYSTEM" && make`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [x] updated appropriate READMEs
 - [x] Updated manual and documentation
