### PR TITLE
Fix for no malloc with SP and fix defaultdhparams typo

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7743,13 +7743,13 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_HASH_FLAGS"
 fi
 
-# Support for enabling setting default DH parameters in
+# Support for enabling setting default DH parameters in TLS
 AC_ARG_ENABLE([defaultdhparams],
-    [AS_HELP_STRING([--enable-dhdefaultparams],[Enables option for default dh parameters (default: disabled)])],
+    [AS_HELP_STRING([--enable-defaultdhparams],[Enables option for default dh parameters (default: disabled)])],
     [ ENABLED_DHDEFAULTPARAMS=$enableval ],
-    [ ENABLED_DHDEFAULTPARAMS=no ]
+    [ ENABLED_DHDEFAULTPARAMS=yes ]
     )
-if test "$ENABLED_DHDEFAULTPARAMS" = "yes" || test "$ENABLED_QT" = "no"
+if test "x$ENABLED_DH" = "xyes" && test "x$ENABLED_DHDEFAULTPARAMS" = "xyes" && test "x$ENABLED_QT" != "xyes"
 then
     ENABLED_DHDEFAULTPARAMS=yes
     AM_CFLAGS="$AM_CFLAGS -DHAVE_DH_DEFAULT_PARAMS"

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2871,6 +2871,12 @@ extern void uITRON4_free(void *p) ;
     #error Small stack cannot be used with no malloc (WOLFSSL_NO_MALLOC)
 #endif
 
+/* If malloc is disabled make sure it is also disabled in SP math */
+#if defined(WOLFSSL_NO_MALLOC) && !defined(WOLFSSL_SP_NO_MALLOC) && \
+    (defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL))
+    #define WOLFSSL_SP_NO_MALLOC
+#endif
+
 /* Enable DH Extra for QT, openssl all, openssh and static ephemeral */
 /* Allows export/import of DH key and params as DER */
 #if !defined(NO_DH) && !defined(WOLFSSL_DH_EXTRA) && \


### PR DESCRIPTION
# Description

* Fix `defaultdhparams` typo fix logic.
* If malloc is disabled make sure it is also disabled in SP math.

# Testing

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
