### PR TITLE
EVP SM3: fix cast

### DIFF
--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -10308,8 +10308,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
                 break;
         #ifdef WOLFSSL_SM3
             case WC_HASH_TYPE_SM3:
-                ret = wc_Sm3Update(&ctx->hash.digest.sm3, data,
-                                     (unsigned long)sz);
+                ret = wc_Sm3Update(&ctx->hash.digest.sm3, data, (word32)sz);
                 if (ret == 0) {
                     ret = WOLFSSL_SUCCESS;
                 }


### PR DESCRIPTION
# Description

wc_Sm3Update takes a word32 for the size.
Others cases are using the OpenSSL compatibility API but SM3 APIs don't exist in OpenSSL.

Fixes zd#16414

# Testing

Standard

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
