### PR TITLE
fix for AES-GCM use with petalinux

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -9802,7 +9802,7 @@ int wc_AesInit(Aes* aes, void* heap, int devId)
                                                         aes->heap, devId);
 #endif /* WOLFSSL_ASYNC_CRYPT */
 
-#ifdef WOLFSSL_AFALG
+#if defined(WOLFSSL_AFALG) || defined(WOLFSSL_AFALG_XILINX_AES)
     aes->alFd = WC_SOCK_NOTSET;
     aes->rdFd = WC_SOCK_NOTSET;
 #endif

--- a/wolfcrypt/src/port/af_alg/afalg_aes.c
+++ b/wolfcrypt/src/port/af_alg/afalg_aes.c
@@ -71,7 +71,11 @@ static int wc_AesSetup(Aes* aes, const char* type, const char* name, int ivSz, i
         aes->rdFd = WC_SOCK_NOTSET;
         return WC_AFALG_SOCK_E;
     }
+#ifdef WOLFSSL_AFALG_XILINX_AES
+    ForceZero(key, sizeof(aes->msgBuf));
+#else
     ForceZero(key, sizeof(aes->key));
+#endif
 
     /* set up CMSG headers */
     XMEMSET((byte*)&(aes->msg), 0, sizeof(struct msghdr));


### PR DESCRIPTION
ZD16292

Tested on the petalinux test node with ./configure --enable-afalg and tested with cross compiling for the node.