### PR TITLE
20230711-linuxkm-fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -508,6 +508,9 @@ AC_SUBST([ENABLED_LINUXKM_BENCHMARKS])
 if test "$ENABLED_LINUXKM_DEFAULTS" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DH_CONST -DWOLFSSL_SP_MOD_WORD_RP -DWOLFSSL_SP_DIV_64 -DWOLFSSL_SP_DIV_WORD_HALF -DWOLFSSL_SMALL_STACK_STATIC -DWOLFSSL_TEST_SUBROUTINE=static"
+    if test "$ENABLED_LINUXKM_PIE" = "yes"; then
+        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_NO_OCSP_ISSUER_CHECK"
+    fi
     if test "$ENABLED_FIPS" = "no"; then
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_OLD_PRIME_CHECK"
     fi
@@ -4391,6 +4394,14 @@ then
 fi
 
 
+# MD4
+AC_ARG_ENABLE([md4],
+    [AS_HELP_STRING([--enable-md4],[Enable MD4 (default: disabled)])],
+    [ ENABLED_MD4=$enableval ],
+    [ ENABLED_MD4=no ]
+    )
+
+
 # DES3
 AC_ARG_ENABLE([des3],
     [AS_HELP_STRING([--enable-des3],[Enable DES3 (default: disabled)])],
@@ -4701,7 +4712,7 @@ AS_CASE([$FIPS_VERSION],
         AS_IF([test "x$ENABLED_DES3" = "xno"],[ENABLED_DES3="yes"])
     ])
 
-AS_IF([test "x$ENABLED_FIPS" = "xyes" && test "x$thread_ls_on" = "xno"],
+AS_IF([test "x$ENABLED_FIPS" = "xyes" && test "x$thread_ls_on" = "xno" && test "$ENABLE_LINUXKM" = "no"],
     [AC_MSG_ERROR([FIPS requires Thread Local Storage])])
 
 
@@ -6299,6 +6310,11 @@ AC_ARG_ENABLE([curl],
 # curl support requires all the features enabled within this conditional.
 if test "$ENABLED_CURL" = "yes"
 then
+    if test "$ENABLED_MD4" = "no"
+    then
+        ENABLED_MD4="yes"
+    fi
+
     if test "x$ENABLED_DES3" = "xno"
     then
         ENABLED_DES3="yes"
@@ -6512,14 +6528,6 @@ then
         AC_MSG_WARN([Enabling DSA with --enable-dsa is recommended for libest])
     fi
 fi
-
-# MD4
-AC_ARG_ENABLE([md4],
-    [AS_HELP_STRING([--enable-md4],[Enable MD4 (default: disabled)])],
-    [ ENABLED_MD4=$enableval ],
-    [ ENABLED_MD4=no ]
-    )
-
 
 if test "$ENABLED_MD4" = "no"
 then
@@ -8933,14 +8941,10 @@ fi
 
 if test "$ENABLED_REPRODUCIBLE_BUILD" != "yes"
 then
-    ESCAPED_ARGS="$ac_configure_args"
-    ESCAPED_ARGS=$(echo "$ESCAPED_ARGS" | sed 's/\\/\\\\/g')
-    ESCAPED_ARGS=$(echo "$ESCAPED_ARGS" | sed 's/\"/\\\"/g')
-    ESCAPED_GLOBAL_ARGS="$CPPFLAGS $AM_CPPFLAGS $CFLAGS $AM_CFLAGS"
-    ESCAPED_GLOBAL_ARGS=$(echo "$ESCAPED_GLOBAL_ARGS" | sed 's/\\/\\\\/g')
-    ESCAPED_GLOBAL_ARGS=$(echo "$ESCAPED_GLOBAL_ARGS" | sed 's/\"/\\\"/g')
+    ESCAPED_ARGS=$(echo "$ac_configure_args" | sed 's/\\/\\\\/g;s/\"/\\\"/g')
+    ESCAPED_GLOBAL_CFLAGS=$(echo "$CPPFLAGS $AM_CPPFLAGS $CFLAGS $AM_CFLAGS" | sed 's/\\/\\\\/g;s/\"/\\\"/g')
     echo "#define LIBWOLFSSL_CONFIGURE_ARGS \"$ESCAPED_ARGS\"" > "${output_objdir}/.build_params" &&
-        echo "#define LIBWOLFSSL_GLOBAL_CFLAGS \"$ESCAPED_GLOBAL_ARGS\" LIBWOLFSSL_GLOBAL_EXTRA_CFLAGS" >> "${output_objdir}/.build_params" ||
+        echo "#define LIBWOLFSSL_GLOBAL_CFLAGS \"$ESCAPED_GLOBAL_CFLAGS\" LIBWOLFSSL_GLOBAL_EXTRA_CFLAGS" >> "${output_objdir}/.build_params" ||
         AC_MSG_ERROR([Couldn't create ${output_objdir}/.build_params.])
 else
     rm -f "${output_objdir}/.build_params"

--- a/scripts/sniffer-gen.sh
+++ b/scripts/sniffer-gen.sh
@@ -65,7 +65,7 @@ run_sequence() {
         run_test "" "-v 4 -g" "-v 4 -J"
     else
         echo "Invalid test"
-        exit -1
+        exit 1
     fi
 }
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -35791,6 +35791,11 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     #endif
 
         if (!ssl->options.tls1_3) {
+            if (ssl->arrays == NULL) {
+                WOLFSSL_MSG("CreateTicket called with null arrays");
+                ret = BAD_FUNC_ARG;
+                goto error;
+            }
             XMEMCPY(it->msecret, ssl->arrays->masterSecret, SECRET_LEN);
 #ifndef NO_ASN_TIME
             c32toa(LowResTimer(), it->timestamp);

--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -549,8 +549,6 @@ int CheckOcspRequest(WOLFSSL_OCSP* ocsp, OcspRequest* ocspRequest,
     return ret;
 }
 
-#ifdef HAVE_OCSP
-
 #ifndef WOLFSSL_NO_OCSP_ISSUER_CHAIN_CHECK
 static int CheckOcspResponderChain(OcspEntry* single, DecodedCert *cert,
         void* vp) {
@@ -646,7 +644,6 @@ int CheckOcspResponder(OcspResponse *bs, DecodedCert *cert, void* vp)
     }
     return ret;
 }
-#endif /* HAVE_OCSP */
 
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) || \
     defined(WOLFSSL_APACHE_HTTPD) || defined(HAVE_LIGHTY)

--- a/src/tls.c
+++ b/src/tls.c
@@ -1693,7 +1693,6 @@ int ALPN_Select(WOLFSSL *ssl)
                 SendAlert(ssl, alert_fatal, no_application_protocol);
                 WOLFSSL_ERROR_VERBOSE(UNKNOWN_ALPN_PROTOCOL_NAME_E);
                 return UNKNOWN_ALPN_PROTOCOL_NAME_E;
-                break;
         }
     }
     else
@@ -10290,8 +10289,10 @@ static int TLSX_PskKeModes_Parse(WOLFSSL* ssl, const byte* input, word16 length,
     if (ret == 0)
         ret = TLSX_PskKeyModes_Use(ssl, modes);
 
-    if (ret != 0)
+    if (ret != 0) {
         WOLFSSL_ERROR_VERBOSE(ret);
+    }
+
     return ret;
 }
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -40233,12 +40233,15 @@ static int test_wolfSSL_BIO_gets(void)
     ExpectNotNull(emp_bm = BUF_MEM_new());
     ExpectNotNull(msg_bm = BUF_MEM_new());
     ExpectIntEQ(BUF_MEM_grow(msg_bm, sizeof(msg)), sizeof(msg));
-    XFREE(msg_bm->data, NULL, DYNAMIC_TYPE_OPENSSL);
+    if (EXPECT_SUCCESS())
+        XFREE(msg_bm->data, NULL, DYNAMIC_TYPE_OPENSSL);
     /* emp size is 1 for terminator */
     ExpectIntEQ(BUF_MEM_grow(emp_bm, sizeof(emp)), sizeof(emp));
-    XFREE(emp_bm->data, NULL, DYNAMIC_TYPE_OPENSSL);
-    emp_bm->data = emp;
-    msg_bm->data = msg;
+    if (EXPECT_SUCCESS()) {
+        XFREE(emp_bm->data, NULL, DYNAMIC_TYPE_OPENSSL);
+        emp_bm->data = emp;
+        msg_bm->data = msg;
+    }
     ExpectIntEQ(BIO_set_mem_buf(bio, emp_bm, BIO_CLOSE), WOLFSSL_SUCCESS);
 
     /* check reading an empty string */
@@ -40256,9 +40259,11 @@ static int test_wolfSSL_BIO_gets(void)
     ExpectIntEQ(BIO_gets(bio, bio_buffer, bufferSz), 8);
     ExpectIntEQ(BIO_gets(bio, bio_buffer, -1), 0);
 
-    emp_bm->data = NULL;
+    if (EXPECT_SUCCESS())
+        emp_bm->data = NULL;
     BUF_MEM_free(emp_bm);
-    msg_bm->data = NULL;
+    if (EXPECT_SUCCESS())
+        msg_bm->data = NULL;
     BUF_MEM_free(msg_bm);
 #endif
 

--- a/tests/utils.c
+++ b/tests/utils.c
@@ -53,6 +53,9 @@ char* create_tmp_dir(char *tmpDir, int len)
 #ifdef _MSC_VER
     if (_mkdir(tmpDir) != 0)
         return NULL;
+#elif defined(__CYGWIN__) || defined(__MINGW32__)
+    if (mkdir(tmpDir) != 0)
+        return NULL;
 #else
     if (mkdir(tmpDir, 0700) != 0)
         return NULL;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -6128,12 +6128,14 @@ WOLFSSL_LOCAL WC_RNG* WOLFSSL_RSA_GetRNG(WOLFSSL_RSA *rsa, WC_RNG **tmpRNG,
                                                              DecodedCert* cert);
     #endif
 
-    WOLFSSL_LOCAL Signer* GetCA(void* vp, byte* hash);
+    #ifndef GetCA
+        WOLFSSL_LOCAL Signer* GetCA(void* vp, byte* hash);
+    #endif
     #ifdef WOLFSSL_AKID_NAME
         WOLFSSL_LOCAL Signer* GetCAByAKID(void* vp, const byte* issuer,
                 word32 issuerSz, const byte* serial, word32 serialSz);
     #endif
-    #ifndef NO_SKID
+    #if !defined(NO_SKID) && !defined(GetCAByName)
         WOLFSSL_LOCAL Signer* GetCAByName(void* cm, byte* hash);
     #endif
 #endif /* !NO_CERTS */


### PR DESCRIPTION
`configure.ac`:

  if `ENABLED_LINUXKM_PIE`, add `-DWOLFSSL_NO_OCSP_ISSUER_CHECK` to gate out backward dependency in `asn.c`;

  if `ENABLE_LINUXKM`, don't error on FIPS without `thread_ls_on`;

  for `--enable-curl`, set `ENABLED_MD4="yes"`, and move `--enable-md4` `AC_ARG_ENABLE()` clause up to a position adjacent to des3 handling;

`scripts/sniffer-gen.sh`: fix illegal exit code (`SC2242`);

`src/internal.c`: fix `clang-analyzer-core.NonNullParamChecker` in `CreateTicket()`;

`src/ocsp.c`: fix `readability-redundant-preprocessor`;

`src/tls.c`: fix empty-body in `TLSX_PskKeModes_Parse()` and `clang-diagnostic-unreachable-code-break` in `ALPN_Select()`;

`tests/api.c`: fix several `clang-analyzer-core.NullDereference` related to `Expect*()` refactor;

`wolfcrypt/src/asn.c`:

  fix `-Wconversion`s in `DecodeAuthKeyId()` and `ParseCertRelative()`;

  fix `readability-redundant-declaration` re `GetCA()` and `GetCAByName()`;

  gate inclusion of `wolfssl/internal.h` on `!defined(WOLFCRYPT_ONLY)`;

`wolfssl/internal.h`: add macro-detection gating around `GetCA()` and `GetCAByName()` prototypes matching gates in `wolfcrypt/src/asn.c`;

`tests/utils.c`: in `create_tmp_dir()`, use one-arg variant of `mkdir()` if `defined(__CYGWIN__) || defined(__MINGW32__)`.

tested with `wolfssl-multi-test.sh ... super-quick-check check-shell-scripts all-c89-clang-tidy defaults-cryptonly-Wconversion-intelasm-build defaults-cryptonly-Wconversion-intelasm-fips-140-3-dev-build defaults-cryptonly-Wconversion-noasm-fips-140-3-dev-build defaults-cryptonly-Wconversion-noasm-fips-140-3-dev-m32-build allcryptonly-Wconversion-intelasm-build defaults-cryptonly-c99-Wconversion-build allcryptonly-c99-Wconversion-build defaults-cryptonly-c99-Wconversion-m32-build allcryptonly-c99-Wconversion-m32-build defaults-cryptonly-c89-Wconversion-build defaults-cryptonly-c89-Wconversion-m32-build allcryptonly-c89-Wconversion-build allcryptonly-c89-Wconversion-m32-build cross-amd64-mingw-all-crypto-Wconversion cross-mingw-all-crypto pq-benchmark-build linuxkm-all-fips-140-3 linuxkm-all-fips-140-3-dyn-hash linuxkm-all-fips-140-3-dev-dyn-hash linuxkm-defaults-all-fips-140-3 linuxkm-defaults-all-no-asm all-crypto-linuxkm-defaults-max-func-stack-2k-build all-crypto-linuxkm-defaults-max-func-stack-2k-build-fips all-linuxkm-defaults-max-total-stack-8k all-linuxkm-defaults-max-total-stack-8k-fips all-linuxkm-defaults-error-code-openssl linuxkm linuxkm-pie linuxkm-legacy-3.16 linuxkm-legacy-4.4 linuxkm-legacy-4.9 linuxkm-legacy-5.4 linuxkm-legacy-5.10 linuxkm-legacy-5.15 linuxkm-legacy-6.1 linuxkm-mainline-pie linuxkm-mainline-pie-gcc-latest clang-tidy-asn-template-sp-all-small-stack all-WOLFSSL_CALLBACKS-clang-tidy clang-tidy-Customer-CFG-7 clang-tidy-defaults clang-tidy-intmath clang-tidy-all-sp-all clang-tidy-all-intelasm clang-tidy-all-async-quic clang-tidy-fips-140-3-defaults clang-tidy-fips-140-3-all clang-tidy-fips-140-3-dev-defaults clang-tidy-fips-140-3-dev-defaults-no-sha-1 clang-tidy-fips-140-3-dev-all clang-tidy-fips-140-3-dev-all-crypto-no-sha-1 clang-tidy-all-crypto-no-sha-1 curl-with-wolfssl`
