### PR TITLE
CMake SINGLE_THREADED not WOLFSSL_SINGLE_THREADED

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,7 +247,7 @@ add_option("WOLFSSL_SINGLE_THREADED"
     "no" "yes;no")
 
 # TODO: Logic here isn't complete, yet (see AX_PTHREAD)
-if(NOT WOLFSSL_SINGLE_THREADED)
+if(NOT SINGLE_THREADED)
     if(CMAKE_USE_PTHREADS_INIT)
         list(APPEND WOLFSSL_LINK_LIBS Threads::Threads)
         set(HAVE_PTHREAD 1)


### PR DESCRIPTION
# Description

As @douzzer pointed out: there's no `WOLFSSL_SINGLE_THREADED`.

This update changes the root level `CMakeFiles.txt` to instead check `SINGLE_THREADED`.

There are probably more places here and in other repos that may need `PTHREAD` attention.

See also https://github.com/wolfSSL/wolfssl/pull/6536 and https://github.com/wolfSSL/wolfssl/pull/6549.

This change has already been applied in https://github.com/wolfSSL/wolfssl/pull/6600.

Fixes zd# n/s

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
