### PR TITLE
Fix for building ED25519 with no client auth

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6739,9 +6739,11 @@ static int ProcessBufferTryDecodeEd25519(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
 
                 *keyFormat = ED25519k;
                 if (ssl != NULL) {
+#if !defined(WOLFSSL_NO_CLIENT_AUTH) && !defined(NO_ED25519_CLIENT_AUTH)
                     /* ED25519 requires caching enabled for tracking message
                      * hash used in EdDSA_Update for signing */
                     ssl->options.cacheMessages = 1;
+#endif
                     if (ssl->options.side == WOLFSSL_SERVER_END) {
                         *resetSuites = 1;
                     }


### PR DESCRIPTION
# Description

Fix for building ED25519 with `WOLFSSL_NO_CLIENT_AUTH` or `NO_ED25519_CLIENT_AUTH` set

```
/wolfssl/src/ssl.c:6744:33: error: 'Options' has no member named 'cacheMessages'
 6744 |                     ssl->options.cacheMessages = 1;
      |
```

# Testing

```
./configure CFLAGS="-DWOLFSSL_NO_CLIENT_AUTH" && make
./configure CFLAGS="-DNO_ED25519_CLIENT_AUTH" && make
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
