### PR TITLE
20230714-asn-DecodeAuthKeyId-Wconversion-fix

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -18873,7 +18873,7 @@ static int DecodeAuthKeyId(const byte* input, word32 sz, DecodedCert* cert)
         /* Get the hash or hash of the hash if wrong size. */
         ret = GetHashId(dataASN[AUTHKEYIDASN_IDX_KEYID].data.ref.data,
                     (int)dataASN[AUTHKEYIDASN_IDX_KEYID].data.ref.length,
-                    cert->extAuthKeyId, HashIdAlg((int)cert->signatureOID));
+                    cert->extAuthKeyId, HashIdAlg(cert->signatureOID));
     }
 #ifdef WOLFSSL_AKID_NAME
     if (ret == 0 && dataASN[AUTHKEYIDASN_IDX_ISSUER].data.ref.data != NULL) {


### PR DESCRIPTION
`wolfcrypt/src/asn.c`: fix merge conflict between 648f474d83 and 2c9609039d, re `-Wconversion` in `DecodeAuthKeyId()`.

tested with `wolfssl-multi-test.sh ... allcryptonly-Wconversion-intelasm-build allcryptonly-c89-Wconversion-m32-build cross-amd64-mingw-all-crypto-Wconversion`
