### PR TITLE
20230714-WC_DO_NOTHING

### DIFF
--- a/IDE/MDK-ARM/STM32F2xx_StdPeriph_Lib/time-STM32F2xx.c
+++ b/IDE/MDK-ARM/STM32F2xx_StdPeriph_Lib/time-STM32F2xx.c
@@ -32,7 +32,7 @@
  *----------------------------------------------------------------------------*/
 #include "stm32f2xx.h"
 
-#define assert_param(a)
+#define assert_param(a) /* null expansion */
 
 #define RTC_RSF_MASK         ((uint32_t)0xFFFFFF5F)
 #define SYNCHRO_TIMEOUT      ((uint32_t) 0x00008000)

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -508,11 +508,11 @@ static int set_up_wolfssl_linuxkm_pie_redirect_table(void) {
 
 #include <wolfssl/wolfcrypt/coding.h>
 
-PRAGMA_GCC_DIAG_PUSH;
-PRAGMA_GCC("GCC diagnostic ignored \"-Wnested-externs\"");
-PRAGMA_GCC("GCC diagnostic ignored \"-Wpointer-arith\"");
+PRAGMA_GCC_DIAG_PUSH
+PRAGMA_GCC("GCC diagnostic ignored \"-Wnested-externs\"")
+PRAGMA_GCC("GCC diagnostic ignored \"-Wpointer-arith\"")
 #include <crypto/hash.h>
-PRAGMA_GCC_DIAG_POP;
+PRAGMA_GCC_DIAG_POP
 
 extern char verifyCore[WC_SHA256_DIGEST_SIZE*2 + 1];
 extern const char coreKey[WC_SHA256_DIGEST_SIZE*2 + 1];

--- a/src/crl.c
+++ b/src/crl.c
@@ -1357,7 +1357,7 @@ static int StopMonitor(wolfSSL_CRL_mfd_t mfd)
     LocalFree(lpMsgBuf);                                        \
 } while(0)
 #else
-#define SHOW_WINDOWS_ERROR()
+#define SHOW_WINDOWS_ERROR() WC_DO_NOTHING
 #endif
 
 #define DM_ERROR() do {                                         \

--- a/src/internal.c
+++ b/src/internal.c
@@ -24483,18 +24483,18 @@ void SetErrorString(int error, char* str)
     #ifndef NO_ERROR_STRINGS
         #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
             #define SUITE_INFO(x,y,z,w,v,u) {(x),(y),(z),(w),(v),(u),WOLFSSL_CIPHER_SUITE_FLAG_NONE}
-            #define SUITE_ALIAS(x,z,w,v,u)
+            #define SUITE_ALIAS(x,z,w,v,u) /* null expansion */
         #else
             #define SUITE_INFO(x,y,z,w,v,u) {(x),(y),(z),(w),WOLFSSL_CIPHER_SUITE_FLAG_NONE}
-            #define SUITE_ALIAS(x,z,w,v,u)
+            #define SUITE_ALIAS(x,z,w,v,u) /* null expansion */
         #endif
     #else
         #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
             #define SUITE_INFO(x,y,z,w,v,u) {(x),(z),(w),(v),(u),WOLFSSL_CIPHER_SUITE_FLAG_NONE}
-            #define SUITE_ALIAS(x,z,w,v,u)
+            #define SUITE_ALIAS(x,z,w,v,u) /* null expansion */
         #else
             #define SUITE_INFO(x,y,z,w,v,u) {(x),(z),(w),WOLFSSL_CIPHER_SUITE_FLAG_NONE}
-            #define SUITE_ALIAS(x,z,w,v,u)
+            #define SUITE_ALIAS(x,z,w,v,u) /* null expansion */
         #endif
     #endif
 #else /* !NO_CIPHER_SUITE_ALIASES */

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -619,8 +619,8 @@ static void UpdateMissedDataSessions(void)
 
 #ifdef WOLFSSL_SNIFFER_STATS
     #ifdef HAVE_C___ATOMIC
-        #define LOCK_STAT()
-        #define UNLOCK_STAT()
+        #define LOCK_STAT() WC_DO_NOTHING
+        #define UNLOCK_STAT() WC_DO_NOTHING
         #define NOLOCK_ADD_TO_STAT(x,y) ({ TraceStat(#x, y); \
             __atomic_fetch_add(&x, y, __ATOMIC_RELAXED); })
     #else
@@ -636,10 +636,10 @@ static void UpdateMissedDataSessions(void)
 #endif /* WOLFSSL_SNIFFER_STATS */
 
 #ifdef HAVE_C___ATOMIC
-    #define LOCK_SESSION()
-    #define UNLOCK_SESSION()
-    #define LOCK_SERVER_LIST()
-    #define UNLOCK_SERVER_LIST()
+    #define LOCK_SESSION() WC_DO_NOTHING
+    #define UNLOCK_SESSION() WC_DO_NOTHING
+    #define LOCK_SERVER_LIST() WC_DO_NOTHING
+    #define UNLOCK_SERVER_LIST() WC_DO_NOTHING
 #else
     #define LOCK_SESSION() wc_LockMutex(&SessionMutex)
     #define UNLOCK_SESSION() wc_UnLockMutex(&SessionMutex)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -14955,10 +14955,10 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
            /* myBuffer may not be initialized fully, but the span up to the
             * sending length will be.
             */
-            PRAGMA_GCC_DIAG_PUSH;
-            PRAGMA_GCC("GCC diagnostic ignored \"-Wmaybe-uninitialized\"");
+            PRAGMA_GCC_DIAG_PUSH
+            PRAGMA_GCC("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
             ret = wolfSSL_write(ssl, myBuffer, sending);
-            PRAGMA_GCC_DIAG_POP;
+            PRAGMA_GCC_DIAG_POP
 
             if (dynamic)
                 XFREE(myBuffer, ssl->heap, DYNAMIC_TYPE_WRITEV);
@@ -26685,8 +26685,8 @@ WOLFSSL_EVP_PKEY *wolfSSL_PEM_read_PUBKEY(XFILE fp, WOLFSSL_EVP_PKEY **key,
 
     WOLFSSL_ENTER("wolfSSL_PEM_read_PUBKEY");
 
-    if (pem_read_file_key(fp, cb, pass, PUBLICKEY_TYPE, &keyFormat, &der)
-            >= 0) {
+    if ((pem_read_file_key(fp, cb, pass, PUBLICKEY_TYPE, &keyFormat, &der)
+            >= 0) && (der != NULL)) {
         const unsigned char* ptr = der->buffer;
 
         /* handle case where reuse is attempted */

--- a/src/tls.c
+++ b/src/tls.c
@@ -1887,7 +1887,7 @@ int TLSX_ALPN_GetRequest(TLSX* extensions, void** data, word16 *dataSz)
 
 #else /* HAVE_ALPN */
 
-#define ALPN_FREE_ALL(list, heap)
+#define ALPN_FREE_ALL(list, heap) WC_DO_NOTHING
 #define ALPN_GET_SIZE(list)     0
 #define ALPN_WRITE(a, b)        0
 #define ALPN_PARSE(a, b, c, d)  0
@@ -2504,7 +2504,7 @@ int TLSX_SNI_GetFromBuffer(const byte* clientHello, word32 helloSz,
 
 #else
 
-#define SNI_FREE_ALL(list, heap)
+#define SNI_FREE_ALL(list, heap) WC_DO_NOTHING
 #define SNI_GET_SIZE(list)     0
 #define SNI_WRITE(a, b)        0
 #define SNI_PARSE(a, b, c, d)  0
@@ -2844,7 +2844,7 @@ int TLSX_UseTrustedCA(TLSX** extensions, byte type,
 
 #else /* HAVE_TRUSTED_CA */
 
-#define TCA_FREE_ALL(list, heap)
+#define TCA_FREE_ALL(list, heap) WC_DO_NOTHING
 #define TCA_GET_SIZE(list)     0
 #define TCA_WRITE(a, b)        0
 #define TCA_PARSE(a, b, c, d)  0
@@ -2938,7 +2938,7 @@ int TLSX_UseMaxFragment(TLSX** extensions, byte mfl, void* heap)
 
 #else
 
-#define MFL_FREE_ALL(a, b)
+#define MFL_FREE_ALL(a, b) WC_DO_NOTHING
 #define MFL_GET_SIZE(a)       0
 #define MFL_WRITE(a, b)       0
 #define MFL_PARSE(a, b, c, d) 0
@@ -3445,7 +3445,7 @@ int TLSX_UseCertificateStatusRequest(TLSX** extensions, byte status_type,
 
 #else
 
-#define CSR_FREE_ALL(data, heap)
+#define CSR_FREE_ALL(data, heap) WC_DO_NOTHING
 #define CSR_GET_SIZE(a, b)    0
 #define CSR_WRITE(a, b, c)    0
 #define CSR_PARSE(a, b, c, d) 0
@@ -3891,7 +3891,7 @@ int TLSX_UseCertificateStatusRequestV2(TLSX** extensions, byte status_type,
 
 #else
 
-#define CSR2_FREE_ALL(data, heap)
+#define CSR2_FREE_ALL(data, heap) WC_DO_NOTHING
 #define CSR2_GET_SIZE(a, b)    0
 #define CSR2_WRITE(a, b, c)    0
 #define CSR2_PARSE(a, b, c, d) 0
@@ -5113,18 +5113,18 @@ int TLSX_UsePointFormat(TLSX** extensions, byte format, void* heap)
 
 #else
 
-#define EC_FREE_ALL(list, heap)
+#define EC_FREE_ALL(list, heap) WC_DO_NOTHING
 #define EC_GET_SIZE(list)         0
 #define EC_WRITE(a, b)            0
 #define EC_PARSE(a, b, c, d, e)   0
-#define EC_VALIDATE_REQUEST(a, b)
+#define EC_VALIDATE_REQUEST(a, b) WC_DO_NOTHING
 
-#define PF_FREE_ALL(list, heap)
+#define PF_FREE_ALL(list, heap)   WC_DO_NOTHING
 #define PF_GET_SIZE(list)         0
 #define PF_WRITE(a, b)            0
 #define PF_PARSE(a, b, c, d)      0
-#define PF_VALIDATE_REQUEST(a, b)
-#define PF_VALIDATE_RESPONSE(a, b)
+#define PF_VALIDATE_REQUEST(a, b) WC_DO_NOTHING
+#define PF_VALIDATE_RESPONSE(a, b) WC_DO_NOTHING
 
 #endif /* HAVE_SUPPORTED_CURVES */
 
@@ -5319,7 +5319,7 @@ int TLSX_AddEmptyRenegotiationInfo(TLSX** extensions, void* heap)
 
 #else
 
-#define SCR_FREE_ALL(a, heap)
+#define SCR_FREE_ALL(a, heap) WC_DO_NOTHING
 #define SCR_GET_SIZE(a, b)    0
 #define SCR_WRITE(a, b, c)    0
 #define SCR_PARSE(a, b, c, d) 0
@@ -5525,8 +5525,8 @@ int TLSX_UseSessionTicket(TLSX** extensions, SessionTicket* ticket, void* heap)
 
 #else
 
-#define WOLF_STK_FREE(a, b)
-#define WOLF_STK_VALIDATE_REQUEST(a)
+#define WOLF_STK_FREE(a, b) WC_DO_NOTHING
+#define WOLF_STK_VALIDATE_REQUEST(a) WC_DO_NOTHING
 #define WOLF_STK_GET_SIZE(a, b)      0
 #define WOLF_STK_WRITE(a, b, c)      0
 #define WOLF_STK_PARSE(a, b, c, d)   0
@@ -5882,7 +5882,7 @@ static int TLSX_UseSRTP(TLSX** extensions, word16 profiles, void* heap)
     #define SRTP_WRITE    TLSX_UseSRTP_Write
     #define SRTP_GET_SIZE TLSX_UseSRTP_GetSize
 #else
-    #define SRTP_FREE(a, b)
+    #define SRTP_FREE(a, b) WC_DO_NOTHING
     #define SRTP_PARSE(a, b, c, d)      0
     #define SRTP_WRITE(a, b)            0
     #define SRTP_GET_SIZE(a)            0
@@ -9657,7 +9657,7 @@ int TLSX_KeyShare_DeriveSecret(WOLFSSL *ssl)
 
 #else
 
-#define KS_FREE_ALL(a, b)
+#define KS_FREE_ALL(a, b) WC_DO_NOTHING
 #define KS_GET_SIZE(a, b)    0
 #define KS_WRITE(a, b, c)    0
 #define KS_PARSE(a, b, c, d) 0
@@ -10167,7 +10167,7 @@ int TLSX_PreSharedKey_Use(TLSX** extensions, const byte* identity, word16 len,
 
 #else
 
-#define PSK_FREE_ALL(a, b)
+#define PSK_FREE_ALL(a, b) WC_DO_NOTHING
 #define PSK_GET_SIZE(a, b, c) 0
 #define PSK_WRITE(a, b, c, d) 0
 #define PSK_PARSE(a, b, c, d) 0

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -262,15 +262,15 @@ static int Tls13HKDFExpandKeyLabel(WOLFSSL* ssl, byte* okm, word32 okmLen,
 /* hash buffer may not be fully initialized, but the sending length won't
  * extend beyond the initialized span.
  */
-PRAGMA_GCC_DIAG_PUSH;
-PRAGMA_GCC("GCC diagnostic ignored \"-Wmaybe-uninitialized\"");
+PRAGMA_GCC_DIAG_PUSH
+PRAGMA_GCC("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
     (void)ssl;
     (void)side;
     return wc_Tls13_HKDF_Expand_Label(okm, okmLen, prk, prkLen,
                                       protocol, protocolLen,
                                       label, labelLen,
                                       info, infoLen, digest);
-PRAGMA_GCC_DIAG_POP;
+PRAGMA_GCC_DIAG_POP
 }
 #endif /* !HAVE_FIPS || !wc_Tls13_HKDF_Expand_Label */
 
@@ -476,8 +476,8 @@ int Tls13DeriveKey(WOLFSSL* ssl, byte* output, int outputLen,
     /* hash buffer may not be fully initialized, but the sending length won't
      * extend beyond the initialized span.
      */
-    PRAGMA_GCC_DIAG_PUSH;
-    PRAGMA_GCC("GCC diagnostic ignored \"-Wmaybe-uninitialized\"");
+    PRAGMA_GCC_DIAG_PUSH
+    PRAGMA_GCC("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
     PRIVATE_KEY_UNLOCK();
     #if defined(HAVE_FIPS) && defined(wc_Tls13_HKDF_Expand_Label)
     (void)side;
@@ -495,7 +495,7 @@ int Tls13DeriveKey(WOLFSSL* ssl, byte* output, int outputLen,
     wc_MemZero_Add("TLS 1.3 derived key", output, outputLen);
 #endif
     return ret;
-    PRAGMA_GCC_DIAG_POP;
+    PRAGMA_GCC_DIAG_POP
 }
 
 /* Convert TLS mac ID to a hash algorithm ID

--- a/tests/api.c
+++ b/tests/api.c
@@ -2189,8 +2189,8 @@ void DEBUG_WRITE_DER(const byte* der, int derSz, const char* fileName)
     }
 }
 #else
-#define DEBUG_WRITE_CERT_X509(x509, fileName)
-#define DEBUG_WRITE_DER(der, derSz, fileName)
+#define DEBUG_WRITE_CERT_X509(x509, fileName) WC_DO_NOTHING
+#define DEBUG_WRITE_DER(der, derSz, fileName) WC_DO_NOTHING
 #endif
 
 

--- a/tests/unit.h
+++ b/tests/unit.h
@@ -27,7 +27,7 @@
 #include <wolfssl/test.h>    /* thread and tcp stuff */
 
 #ifdef WOLFSSL_FORCE_MALLOC_FAIL_TEST
-#define XABORT()
+#define XABORT() WC_DO_NOTHING
 #else
 #define XABORT() abort()
 #endif
@@ -99,17 +99,17 @@
 #else
 
 #define AssertPtr(x, y, op, er) do {                                           \
-    PRAGMA_GCC_DIAG_PUSH;                                                      \
+    PRAGMA_GCC_DIAG_PUSH                                                       \
       /* remarkably, without this inhibition, */                               \
       /* the _Pragma()s make the declarations warn. */                         \
-    PRAGMA_GCC("GCC diagnostic ignored \"-Wdeclaration-after-statement\"");    \
+    PRAGMA_GCC("GCC diagnostic ignored \"-Wdeclaration-after-statement\"")     \
       /* inhibit "ISO C forbids conversion of function pointer */              \
       /* to object pointer type [-Werror=pedantic]" */                         \
-    PRAGMA_GCC("GCC diagnostic ignored \"-Wpedantic\"");                       \
+    PRAGMA_GCC("GCC diagnostic ignored \"-Wpedantic\"")                        \
     void* _x = (void*)(x);                                                     \
     void* _y = (void*)(y);                                                     \
     Assert(_x op _y, ("%s " #op " %s", #x, #y), ("%p " #er " %p", _x, _y));    \
-    PRAGMA_GCC_DIAG_POP;                                                       \
+    PRAGMA_GCC_DIAG_POP                                                        \
 } while(0)
 
 #endif
@@ -189,17 +189,17 @@
 
 #define ExpectPtr(x, y, op, er) do {                                           \
     if (_ret != TEST_FAIL) {                                                   \
-        PRAGMA_DIAG_PUSH;                                                      \
+        PRAGMA_DIAG_PUSH                                                       \
           /* remarkably, without this inhibition, */                           \
           /* the _Pragma()s make the declarations warn. */                     \
-        PRAGMA("GCC diagnostic ignored \"-Wdeclaration-after-statement\"");    \
+        PRAGMA("GCC diagnostic ignored \"-Wdeclaration-after-statement\"")     \
           /* inhibit "ISO C forbids conversion of function pointer */          \
           /* to object pointer type [-Werror=pedantic]" */                     \
-        PRAGMA("GCC diagnostic ignored \"-Wpedantic\"");                       \
+        PRAGMA("GCC diagnostic ignored \"-Wpedantic\"")                        \
         void* _x = (void*)(x);                                                 \
         void* _y = (void*)(y);                                                 \
         Expect(_x op _y, ("%s " #op " %s", #x, #y), ("%p " #er " %p", _x, _y));\
-        PRAGMA_DIAG_POP;                                                       \
+        PRAGMA_DIAG_POP                                                        \
     }                                                                          \
 } while(0)
 
@@ -261,17 +261,17 @@
 #define DoExpectStrLE(x, y) DoExpectStr(x, y, <=,  >)
 
 #define DoExpectPtr(x, y, op, er) do {                                         \
-    PRAGMA_DIAG_PUSH;                                                          \
+    PRAGMA_DIAG_PUSH                                                           \
       /* remarkably, without this inhibition, */                               \
       /* the _Pragma()s make the declarations warn. */                         \
-    PRAGMA("GCC diagnostic ignored \"-Wdeclaration-after-statement\"");        \
+    PRAGMA("GCC diagnostic ignored \"-Wdeclaration-after-statement\"")         \
       /* inhibit "ISO C forbids conversion of function pointer */              \
       /* to object pointer type [-Werror=pedantic]" */                         \
-    PRAGMA("GCC diagnostic ignored \"-Wpedantic\"");                           \
+    PRAGMA("GCC diagnostic ignored \"-Wpedantic\"")                            \
     void* _x = (void*)(x);                                                     \
     void* _y = (void*)(y);                                                     \
     Expect(_x op _y, ("%s " #op " %s", #x, #y), ("%p " #er " %p", _x, _y));    \
-    PRAGMA_DIAG_POP;                                                           \
+    PRAGMA_DIAG_POP                                                            \
 } while(0)
 
 #define DoExpectPtrEq(x, y) DoExpectPtr(x, y, ==, !=)

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -267,7 +267,7 @@
     /* fflush in Zephyr doesn't work on stdout and stderr. Use
     * CONFIG_LOG_MODE_IMMEDIATE compilation option instead. */
     #undef  XFFLUSH
-    #define XFFLUSH(...) do {} while (0)
+    #define XFFLUSH(...) WC_DO_NOTHING
 #endif
 
 /* only for stack size check */
@@ -451,7 +451,7 @@
 /* optional macro to add sleep between tests */
 #ifndef TEST_SLEEP
     /* stub the sleep macro */
-    #define TEST_SLEEP()
+    #define TEST_SLEEP() WC_DO_NOTHING
 #endif
 
 #define TEST_STRING    "Everyone gets Friday off."
@@ -1420,7 +1420,7 @@ static const char* bench_result_words2[][5] = {
         }
         return 0;
     }
-    #define bench_async_poll(p)
+    #define bench_async_poll(p) WC_DO_NOTHING
 #endif /* WOLFSSL_ASYNC_CRYPT */
 
 

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -5211,7 +5211,7 @@ void GHASH(Gcm* gcm, const byte* a, word32 aSz, const byte* c,
  *
  * @param [in] aes  AES GCM object.
  */
-#define GHASH_INIT_EXTRA(aes)
+#define GHASH_INIT_EXTRA(aes) WC_DO_NOTHING
 
 /* GHASH one block of data..
  *
@@ -5412,7 +5412,7 @@ void GHASH(Gcm* gcm, const byte* a, word32 aSz, const byte* c,
  *
  * @param [in] aes  AES GCM object.
  */
-#define GHASH_INIT_EXTRA(aes)
+#define GHASH_INIT_EXTRA(aes) WC_DO_NOTHING
 
 /* GHASH one block of data..
  *
@@ -5712,7 +5712,7 @@ void GHASH(Gcm* gcm, const byte* a, word32 aSz, const byte* c,
  *
  * @param [in] aes  AES GCM object.
  */
-#define GHASH_INIT_EXTRA(aes)
+#define GHASH_INIT_EXTRA(aes) WC_DO_NOTHING
 
 /* GHASH one block of data..
  *
@@ -5962,7 +5962,7 @@ void GHASH(Gcm* gcm, const byte* a, word32 aSz, const byte* c,
  *
  * @param [in] aes  AES GCM object.
  */
-#define GHASH_INIT_EXTRA(aes)
+#define GHASH_INIT_EXTRA(aes) WC_DO_NOTHING
 
 /* GHASH one block of data..
  *
@@ -6246,7 +6246,7 @@ void GHASH(Gcm* gcm, const byte* a, word32 aSz, const byte* c,
  *
  * @param [in] aes  AES GCM object.
  */
-#define GHASH_INIT_EXTRA(aes)
+#define GHASH_INIT_EXTRA(aes) WC_DO_NOTHING
 
 /* GHASH one block of data..
  *

--- a/wolfcrypt/src/asm.c
+++ b/wolfcrypt/src/asm.c
@@ -118,7 +118,7 @@ WC_INLINE static int set_cpuid_flags(void) {
    if(IS_INTEL_BMI2 && IS_INTEL_ADX){  func;  ret ;  }
 
 #else
-    #define IF_HAVE_INTEL_MULX(func, ret)
+    #define IF_HAVE_INTEL_MULX(func, ret) WC_DO_NOTHING
 #endif
 
 #if defined(TFM_X86) && !defined(TFM_SSE2)

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -509,7 +509,7 @@ static word32 SizeASNLength(word32 length)
      * @param [in, out] err   Error variable.
      * @param [in]      heap  Dynamic memory allocation hint.
      */
-    #define ALLOC_ASNGETDATA(name, cnt, err, heap)
+    #define ALLOC_ASNGETDATA(name, cnt, err, heap) WC_DO_NOTHING
 
     /* Clears the memory of the dynamic BER encoding data.
      *
@@ -526,7 +526,7 @@ static word32 SizeASNLength(word32 length)
      * @param [in]      name  Variable name to declare.
      * @param [in]      heap  Dynamic memory allocation hint.
      */
-    #define FREE_ASNGETDATA(name, heap)
+    #define FREE_ASNGETDATA(name, heap) WC_DO_NOTHING
 
     /* Declare the variable that is the dynamic data for encoding DER data.
      *
@@ -543,7 +543,7 @@ static word32 SizeASNLength(word32 length)
      * @param [in, out] err   Error variable.
      * @param [in]      heap  Dynamic memory allocation hint.
      */
-    #define ALLOC_ASNSETDATA(name, cnt, err, heap)
+    #define ALLOC_ASNSETDATA(name, cnt, err, heap) WC_DO_NOTHING
 
     /* Clears the memory of the dynamic BER encoding data.
      *
@@ -560,7 +560,7 @@ static word32 SizeASNLength(word32 length)
      * @param [in]      name  Variable name to declare.
      * @param [in]      heap  Dynamic memory allocation hint.
      */
-    #define FREE_ASNSETDATA(name, heap)
+    #define FREE_ASNSETDATA(name, heap) WC_DO_NOTHING
 #endif
 
 

--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -1021,7 +1021,7 @@ static int _ffc_pairwise_consistency_test(DhKey* key,
 /* if not using fixed points use DiscreteLogWorkFactor function for unusual size
    otherwise round up on size needed */
 #ifndef WOLFSSL_DH_CONST
-    #define WOLFSSL_DH_ROUND(x)
+    #define WOLFSSL_DH_ROUND(x) WC_DO_NOTHING
 #else
     #define WOLFSSL_DH_ROUND(x) \
         do {                    \

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -1454,8 +1454,8 @@ static int xil_mpi_import(mp_int *mpi,
     #endif
 
     #define DECLARE_CURVE_SPECS(intcount) ecc_curve_spec* curve = NULL
-    #define ALLOC_CURVE_SPECS(intcount, err)
-    #define FREE_CURVE_SPECS()
+    #define ALLOC_CURVE_SPECS(intcount, err) WC_DO_NOTHING
+    #define FREE_CURVE_SPECS() WC_DO_NOTHING
 #elif defined(WOLFSSL_SMALL_STACK)
 #ifdef WOLFSSL_SP_MATH_ALL
     #define DECLARE_CURVE_SPECS(intcount)                               \
@@ -1510,8 +1510,8 @@ static int xil_mpi_import(mp_int *mpi,
         curve->spec_ints = spec_ints;                                   \
         curve->spec_count = (intcount)
 #endif
-    #define ALLOC_CURVE_SPECS(intcount, err)
-    #define FREE_CURVE_SPECS()
+    #define ALLOC_CURVE_SPECS(intcount, err) WC_DO_NOTHING
+    #define FREE_CURVE_SPECS() WC_DO_NOTHING
 #endif /* ECC_CACHE_CURVE */
 
 static void wc_ecc_curve_cache_free_spec_item(ecc_curve_spec* curve, mp_int* item,

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -535,7 +535,7 @@ int  wolfSSL_EVP_DecryptFinal_ex(WOLFSSL_EVP_CIPHER_CTX *ctx,
 #define PRINT_BUF(b, sz) { int _i; for(_i=0; _i<(sz); _i++) { \
   printf("%02x(%c),", (b)[_i], (b)[_i]); if ((_i+1)%8==0)printf("\n");}}
 #else
-#define PRINT_BUF(b, sz)
+#define PRINT_BUF(b, sz) WC_DO_NOTHING
 #endif
 
 static int fillBuff(WOLFSSL_EVP_CIPHER_CTX *ctx, const unsigned char *in, int sz)

--- a/wolfcrypt/src/port/Renesas/renesas_sce_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_sce_util.c
@@ -18,7 +18,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/types.h>
 
 #if defined(WOLFSSL_RENESAS_SCEPROTECT) || \
     defined(WOLFSSL_RENESAS_SCEPROTECT_CRYPTONLY)
@@ -39,7 +39,7 @@
 #if defined(DEBUG_PK_CB)
     #define WOLFSSL_PKMSG(_f_, ...) printf(_f_, ##__VA_ARGS__)
 #else
-    #define WOLFSSL_PKMSG(_f_, ...)
+    #define WOLFSSL_PKMSG(_f_, ...) WC_DO_NOTHING
 #endif
 
 #if defined(WOLFSSL_RENESAS_SCEPROTECT_ECC)

--- a/wolfcrypt/src/port/intel/quickassist_sync.c
+++ b/wolfcrypt/src/port/intel/quickassist_sync.c
@@ -23,7 +23,7 @@
     #include <config.h>
 #endif
 
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/types.h>
 
 #ifdef HAVE_INTEL_QA_SYNC
 
@@ -227,7 +227,7 @@ static int IntelQaGetCyInstanceCount(void);
 #ifdef QAT_DEBUG
     #define QLOG(...) do { printf(__VA_ARGS__); } while (0)
 #else
-    #define QLOG(...)
+    #define QLOG(...) WC_DO_NOTHING
 #endif
 
 

--- a/wolfcrypt/src/port/maxim/maxq10xx.c
+++ b/wolfcrypt/src/port/maxim/maxq10xx.c
@@ -23,7 +23,7 @@
     #include <config.h>
 #endif
 
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/types.h>
 
 #if defined(WOLFSSL_MAXQ1065) ||  defined(WOLFSSL_MAXQ108X)
 
@@ -52,7 +52,7 @@
 #ifdef MAXQ_DEBUG
 void dbg_dumphex(const char *identifier, const uint8_t* pdata, uint32_t plen);
 #else
-#define dbg_dumphex(identifier, pdata, plen)
+#define dbg_dumphex(identifier, pdata, plen) WC_DO_NOTHING
 #endif /* MAXQ_DEBUG */
 
 #if defined(USE_WINDOWS_API)

--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -47,9 +47,9 @@
 #define dcp_lock() wolfSSL_CryptHwMutexLock()
 #define dcp_unlock() wolfSSL_CryptHwMutexUnLock()
 #else
-#define dcp_lock_init() do{}while(0)
-#define dcp_lock() do{}while(0)
-#define dcp_unlock() do{}while(0)
+#define dcp_lock_init() WC_DO_NOTHING
+#define dcp_lock()      WC_DO_NOTHING
+#define dcp_unlock()    WC_DO_NOTHING
 #endif
 
 #if DCP_USE_OTP_KEY

--- a/wolfcrypt/src/port/st/stsafe.c
+++ b/wolfcrypt/src/port/st/stsafe.c
@@ -19,11 +19,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#include <wolfssl/wolfcrypt/types.h>
 #include <wolfssl/wolfcrypt/port/st/stsafe.h>
 #include <wolfssl/wolfcrypt/logging.h>
 
 #ifndef STSAFE_INTERFACE_PRINTF
-#define STSAFE_INTERFACE_PRINTF(...)
+#define STSAFE_INTERFACE_PRINTF(...) WC_DO_NOTHING
 #endif
 
 #ifdef WOLFSSL_STSAFEA100

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -197,7 +197,7 @@ This library provides single precision (SP) integer math functions.
     while (0)
 #else
     /* Nothing to do as declared on stack. */
-    #define FREE_SP_INT(n, h)
+    #define FREE_SP_INT(n, h) WC_DO_NOTHING
 #endif
 
 
@@ -318,7 +318,7 @@ while (0)
         FREE_DYN_SP_INT_ARRAY(n, h)
 #else
     /* Nothing to do as data declared on stack. */
-    #define FREE_SP_INT_ARRAY(n, h)
+    #define FREE_SP_INT_ARRAY(n, h) WC_DO_NOTHING
 #endif
 
 

--- a/wolfcrypt/src/wc_pkcs11.c
+++ b/wolfcrypt/src/wc_pkcs11.c
@@ -403,11 +403,11 @@ static void pkcs11_val(const char* op, CK_ULONG val)
 }
 #else
 /* Disable logging of PKCS#11 calls and return value. */
-#define PKCS11_RV(op, ev)
+#define PKCS11_RV(op, ev) WC_DO_NOTHING
 /* Disable logging of PKCS#11 calls and value. */
-#define PKCS11_VAL(op, val)
+#define PKCS11_VAL(op, val) WC_DO_NOTHING
 /* Disable logging of PKCS#11 template. */
-#define PKCS11_DUMP_TEMPLATE(name, templ, cnt)
+#define PKCS11_DUMP_TEMPLATE(name, templ, cnt) WC_DO_NOTHING
 #endif
 
 /**

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -86,7 +86,7 @@ const byte const_byte_array[] = "A+Gd\0\0\0";
     heap_baselineBytes = wolfCrypt_heap_peakBytes_checkpoint();              \
     }
 #else
-#define PRINT_HEAP_CHECKPOINT()
+#define PRINT_HEAP_CHECKPOINT() WC_DO_NOTHING
 #endif /* WOLFSSL_TRACK_MEMORY_VERBOSE && !WOLFSSL_STATIC_MEMORY */
 
 #ifdef USE_FLAT_TEST_H
@@ -811,7 +811,7 @@ static int rng_crypto_cb(int thisDevId, wc_CryptoInfo* info, void* ctx)
 
 /* optional macro to add sleep between tests */
 #ifndef TEST_SLEEP
-#define TEST_SLEEP()
+#define TEST_SLEEP() WC_DO_NOTHING
 #else
     #define TEST_PASS test_pass
     #include <stdarg.h> /* for var args */
@@ -22113,7 +22113,7 @@ static void show(const char *title, const char *p, unsigned int s) {
     printf("\n");
 }
 #else
-#define show(a,b,c)
+#define show(a,b,c) WC_DO_NOTHING
 #endif
 
 #define FOURK_BUFF 4096

--- a/wolfcrypt/user-crypto/src/rsa.c
+++ b/wolfcrypt/user-crypto/src/rsa.c
@@ -25,7 +25,7 @@
 #endif
 
 #include <wolfssl/options.h>
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/types.h>
 
 #ifndef NO_RSA
 
@@ -37,11 +37,11 @@
 #endif
 #include "user_rsa.h"
 
-#ifdef DEBUG_WOLFSSL /* debug done without variadric to allow older compilers */
+#ifdef DEBUG_WOLFSSL /* debug done without variadic to allow older compilers */
     #include <stdio.h>
     #define USER_DEBUG(x) printf x
 #else
-    #define USER_DEBUG(x)
+    #define USER_DEBUG(x) WC_DO_NOTHING
 #endif
 
 #define ASN_INTEGER    0x02

--- a/wolfssl/openssl/bn.h
+++ b/wolfssl/openssl/bn.h
@@ -30,7 +30,7 @@
 #ifndef WOLFSSL_BN_H_
 #define WOLFSSL_BN_H_
 
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/types.h>
 #include <wolfssl/wolfcrypt/wolfmath.h>
 
 #ifdef __cplusplus
@@ -271,7 +271,7 @@ typedef WOLFSSL_BN_GENCB BN_GENCB;
 
 #define BN_mod_inverse wolfSSL_BN_mod_inverse
 
-#define BN_set_flags(x1, x2)
+#define BN_set_flags(x1, x2) WC_DO_NOTHING
 
 #if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
 #define BN_get_rfc2409_prime_768   wolfSSL_DH_768_prime

--- a/wolfssl/openssl/ec.h
+++ b/wolfssl/openssl/ec.h
@@ -24,6 +24,7 @@
 #ifndef WOLFSSL_EC_H_
 #define WOLFSSL_EC_H_
 
+#include <wolfssl/wolfcrypt/types.h>
 #include <wolfssl/openssl/bn.h>
 #include <wolfssl/wolfcrypt/asn.h>
 #include <wolfssl/wolfcrypt/ecc.h>
@@ -352,7 +353,7 @@ typedef WOLFSSL_EC_BUILTIN_CURVE      EC_builtin_curve;
 #define EC_GROUP_order_bits             wolfSSL_EC_GROUP_order_bits
 #define EC_GROUP_method_of              wolfSSL_EC_GROUP_method_of
 #ifndef NO_WOLFSSL_STUB
-#define EC_GROUP_set_point_conversion_form(...)
+#define EC_GROUP_set_point_conversion_form(...) WC_DO_NOTHING
 #endif
 
 #define EC_METHOD_get_field_type        wolfSSL_EC_METHOD_get_field_type

--- a/wolfssl/openssl/engine.h
+++ b/wolfssl/openssl/engine.h
@@ -6,5 +6,4 @@
 
 /* ENGINE_load_builtin_engines not needed, as all builtin engines are already
    loaded into memory and used on startup. */
-#define ENGINE_load_builtin_engines()
-
+#define ENGINE_load_builtin_engines() WC_DO_NOTHING

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -30,7 +30,7 @@
 #ifndef WOLFSSL_EVP_H_
 #define WOLFSSL_EVP_H_
 
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/types.h>
 
 #ifdef WOLFSSL_PREFIX
 #include "prefix_evp.h"
@@ -1017,7 +1017,7 @@ WOLFSSL_API int wolfSSL_EVP_SignInit_ex(WOLFSSL_EVP_MD_CTX* ctx,
 #define EVP_MD_block_size       wolfSSL_EVP_MD_block_size
 #define EVP_MD_type             wolfSSL_EVP_MD_type
 #ifndef NO_WOLFSSL_STUB
-#define EVP_MD_CTX_set_flags(...)
+#define EVP_MD_CTX_set_flags(...) WC_DO_NOTHING
 #endif
 
 #define EVP_Digest             wolfSSL_EVP_Digest
@@ -1200,7 +1200,7 @@ WOLFSSL_API int wolfSSL_EVP_SignInit_ex(WOLFSSL_EVP_MD_CTX* ctx,
 #define EVP_CTRL_CCM_SET_MSGLEN        0x15
 
 #define EVP_PKEY_print_public           wolfSSL_EVP_PKEY_print_public
-#define EVP_PKEY_print_private(arg1, arg2, arg3, arg4)
+#define EVP_PKEY_print_private(arg1, arg2, arg3, arg4) WC_DO_NOTHING
 
 #ifndef EVP_MAX_MD_SIZE
     #define EVP_MAX_MD_SIZE   64     /* sha512 */

--- a/wolfssl/openssl/objects.h
+++ b/wolfssl/openssl/objects.h
@@ -23,7 +23,7 @@
 #ifndef WOLFSSL_OBJECTS_H_
 #define WOLFSSL_OBJECTS_H_
 
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/types.h>
 #ifndef OPENSSL_EXTRA_SSL_GUARD
 #define OPENSSL_EXTRA_SSL_GUARD
 #include <wolfssl/ssl.h>
@@ -62,7 +62,7 @@
 #define i2t_ASN1_OBJECT  wolfSSL_i2t_ASN1_OBJECT
 
 /* not required for wolfSSL */
-#define OPENSSL_load_builtin_modules()
+#define OPENSSL_load_builtin_modules() WC_DO_NOTHING
 
 
 #define NID_ad_OCSP                     178

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -29,6 +29,8 @@
 #ifndef WOLFSSL_OPENSSL_H_
 #define WOLFSSL_OPENSSL_H_
 
+#include <wolfssl/wolfcrypt/types.h>
+
 /* wolfssl_openssl compatibility layer */
 #ifndef OPENSSL_EXTRA_SSL_GUARD
 #define OPENSSL_EXTRA_SSL_GUARD
@@ -1098,16 +1100,16 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #define PEM_do_header                   wolfSSL_PEM_do_header
 
 /*#if OPENSSL_API_COMPAT < 0x10100000L*/
-#define CONF_modules_free()
-#define ENGINE_cleanup()
+#define CONF_modules_free()             WC_DO_NOTHING
+#define ENGINE_cleanup()                WC_DO_NOTHING
 #define SSL_CTX_need_tmp_RSA(ctx)       0
 #define SSL_CTX_set_tmp_rsa(ctx,rsa)    1
 #define SSL_need_tmp_RSA(ssl)           0
 #define SSL_set_tmp_rsa(ssl,rsa)        1
 /*#endif*/
 
-#define CONF_modules_unload(a)
-#define CONF_get1_default_config_file wolfSSL_CONF_get1_default_config_file
+#define CONF_modules_unload(a)          WC_DO_NOTHING
+#define CONF_get1_default_config_file   wolfSSL_CONF_get1_default_config_file
 
 #define SSL_get_hit                     wolfSSL_session_reused
 
@@ -1650,8 +1652,8 @@ typedef WOLFSSL_SRTP_PROTECTION_PROFILE      SRTP_PROTECTION_PROFILE;
 #endif
 
 #ifndef NO_WOLFSSL_STUB
-#define OBJ_create_objects(...)
-#define sk_SSL_COMP_free(...)
+#define OBJ_create_objects(...)         WC_DO_NOTHING
+#define sk_SSL_COMP_free(...)           WC_DO_NOTHING
 #endif
 
 #define OBJ_dup                         wolfSSL_ASN1_OBJECT_dup

--- a/wolfssl/openssl/x509v3.h
+++ b/wolfssl/openssl/x509v3.h
@@ -24,6 +24,7 @@
 #ifndef WOLFSSL_x509v3_H
 #define WOLFSSL_x509v3_H
 
+#include <wolfssl/wolfcrypt/types.h>
 #include <wolfssl/openssl/compat_types.h>
 #include <wolfssl/openssl/conf.h>
 #include <wolfssl/openssl/bio.h>
@@ -159,8 +160,8 @@ WOLFSSL_API WOLFSSL_ASN1_STRING* wolfSSL_a2i_IPADDRESS(const char* ipa);
 #define X509V3_EXT_conf_nid       wolfSSL_X509V3_EXT_conf_nid
 #define X509V3_set_ctx            wolfSSL_X509V3_set_ctx
 #ifndef NO_WOLFSSL_STUB
-#define X509V3_set_nconf(...)
-#define X509V3_EXT_cleanup(...)
+#define X509V3_set_nconf(...)     WC_DO_NOTHING
+#define X509V3_EXT_cleanup(...)   WC_DO_NOTHING
 #endif
 #define X509V3_set_ctx_test(ctx)  wolfSSL_X509V3_set_ctx(ctx, NULL, NULL, NULL, NULL, CTX_TEST)
 #define X509V3_set_ctx_nodb       wolfSSL_X509V3_set_ctx_nodb

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -3626,7 +3626,7 @@ typedef struct PkCbInfo {
 #if defined(DEBUG_PK_CB) || defined(TEST_PK_PRIVKEY)
     #define WOLFSSL_PKMSG(...) printf(__VA_ARGS__)
 #else
-    #define WOLFSSL_PKMSG(...)
+    #define WOLFSSL_PKMSG(...) WC_DO_NOTHING
 #endif
 
 #ifdef HAVE_ECC

--- a/wolfssl/wolfcrypt/fe_448.h
+++ b/wolfssl/wolfcrypt/fe_448.h
@@ -66,7 +66,7 @@ WOLFSSL_LOCAL int  curve448(byte* r, const byte* n, const byte* a);
 #if !defined(CURVED448_128BIT)
 WOLFSSL_LOCAL void fe448_reduce(fe448*);
 #else
-#define fe448_reduce(a)
+#define fe448_reduce(a) WC_DO_NOTHING
 #endif
 WOLFSSL_LOCAL void fe448_neg(fe448* r, const fe448* a);
 WOLFSSL_LOCAL void fe448_add(fe448* r, const fe448* a, const fe448* b);
@@ -93,7 +93,7 @@ WOLFSSL_LOCAL void fe448_pow_2_446_222_1(fe448* r, const fe448* a);
 WOLFSSL_LOCAL void fe448_init(void);
 WOLFSSL_LOCAL int  curve448(byte* r, const byte* n, const byte* a);
 
-#define fe448_reduce(a)
+#define fe448_reduce(a) WC_DO_NOTHING
 
 WOLFSSL_LOCAL void fe448_neg(word8* r, const word8* a);
 WOLFSSL_LOCAL void fe448_add(word8* r, const word8* a, const word8* b);

--- a/wolfssl/wolfcrypt/integer.h
+++ b/wolfssl/wolfcrypt/integer.h
@@ -69,7 +69,7 @@ extern "C" {
 #else
 
 /* C on the other hand doesn't care */
-#define  OPT_CAST(x)
+#define  OPT_CAST(x) /* null expansion */
 
 #endif /* __cplusplus */
 
@@ -206,7 +206,7 @@ typedef int           mp_err;
 #define NEW_MP_INT_SIZE(name, bits, heap, type) \
     XMEMSET(name, 0, sizeof(mp_int))
 /* Dispose of static mp_int. */
-#define FREE_MP_INT_SIZE(name, heap, type)
+#define FREE_MP_INT_SIZE(name, heap, type) WC_DO_NOTHING
 /* Initialize an mp_int. */
 #define INIT_MP_INT_SIZE(name, bits) \
     mp_init(name)
@@ -408,7 +408,7 @@ MP_API int mp_radix_size (mp_int * a, int radix, int *size);
 #ifdef WOLFSSL_DEBUG_MATH
     MP_API void mp_dump(const char* desc, mp_int* a, byte verbose);
 #else
-    #define mp_dump(desc, a, verbose)
+    #define mp_dump(desc, a, verbose) WC_DO_NOTHING
 #endif
 
 #if defined(HAVE_ECC) || defined(WOLFSSL_KEY_GEN) || !defined(NO_RSA) || \

--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -144,9 +144,9 @@ WOLFSSL_API void wolfSSL_Debugging_OFF(void);
     WOLFSSL_API void WOLFSSL_END(int funcNum);
     WOLFSSL_API void WOLFSSL_TIME(int count);
 #else
-    #define WOLFSSL_START(n)
-    #define WOLFSSL_END(n)
-    #define WOLFSSL_TIME(n)
+    #define WOLFSSL_START(n) WC_DO_NOTHING
+    #define WOLFSSL_END(n)   WC_DO_NOTHING
+    #define WOLFSSL_TIME(n)  WC_DO_NOTHING
 #endif
 
 #if defined(DEBUG_WOLFSSL) && !defined(WOLFSSL_DEBUG_ERRORS_ONLY)
@@ -170,21 +170,21 @@ WOLFSSL_API void wolfSSL_Debugging_OFF(void);
     WOLFSSL_API void WOLFSSL_MSG_EX(const char* fmt, ...);
     #define HAVE_WOLFSSL_MSG_EX
 #else
-    #define WOLFSSL_MSG_EX(...) do{} while(0)
+    #define WOLFSSL_MSG_EX(...) WC_DO_NOTHING
 #endif
     WOLFSSL_API void WOLFSSL_MSG(const char* msg);
     WOLFSSL_API void WOLFSSL_BUFFER(const byte* buffer, word32 length);
 
 #else
 
-    #define WOLFSSL_ENTER(m)
-    #define WOLFSSL_LEAVE(m, r)
-    #define WOLFSSL_STUB(m)
+    #define WOLFSSL_ENTER(m)      WC_DO_NOTHING
+    #define WOLFSSL_LEAVE(m, r)   WC_DO_NOTHING
+    #define WOLFSSL_STUB(m)       WC_DO_NOTHING
     #define WOLFSSL_IS_DEBUG_ON() 0
 
-    #define WOLFSSL_MSG_EX(...)    do{} while(0)
-    #define WOLFSSL_MSG(m)            do{} while(0)
-    #define WOLFSSL_BUFFER(b, l)      do{} while(0)
+    #define WOLFSSL_MSG_EX(...)   WC_DO_NOTHING
+    #define WOLFSSL_MSG(m)        WC_DO_NOTHING
+    #define WOLFSSL_BUFFER(b, l)  WC_DO_NOTHING
 
 #endif /* DEBUG_WOLFSSL && !WOLFSSL_DEBUG_ERRORS_ONLY */
 
@@ -202,8 +202,8 @@ WOLFSSL_API void wolfSSL_Debugging_OFF(void);
 
     WOLFSSL_API void WOLFSSL_ERROR_MSG(const char* msg);
 #else
-    #define WOLFSSL_ERROR(e)
-    #define WOLFSSL_ERROR_MSG(m)
+    #define WOLFSSL_ERROR(e) (void)(e)
+    #define WOLFSSL_ERROR_MSG(m) (void)(m)
 #endif /* DEBUG_WOLFSSL | OPENSSL_ALL || WOLFSSL_NGINX || WOLFSSL_HAPROXY ||
           OPENSSL_EXTRA */
 

--- a/wolfssl/wolfcrypt/mem_track.h
+++ b/wolfssl/wolfcrypt/mem_track.h
@@ -802,13 +802,13 @@ static WC_INLINE void StackTrap(void)
 #define STACK_SIZE_CHECKPOINT(...) (__VA_ARGS__)
 #endif
 #ifndef STACK_SIZE_CHECKPOINT_MSG
-#define STACK_SIZE_CHECKPOINT_MSG(msg)
+#define STACK_SIZE_CHECKPOINT_MSG(msg) WC_DO_NOTHING
 #endif
 #ifndef STACK_SIZE_CHECKPOINT_WITH_MAX_CHECK
 #define STACK_SIZE_CHECKPOINT_WITH_MAX_CHECK(max, ...) (__VA_ARGS__, 0)
 #endif
 #ifndef STACK_SIZE_INIT
-#define STACK_SIZE_INIT()
+#define STACK_SIZE_INIT() WC_DO_NOTHING
 #endif
 
 #endif /* WOLFSSL_MEM_TRACK_H */

--- a/wolfssl/wolfcrypt/port/caam/caam_driver.h
+++ b/wolfssl/wolfcrypt/port/caam/caam_driver.h
@@ -54,8 +54,8 @@
     #define WOLFSSL_MSG(in) printf("%s\n", (in))
     void DEBUG_PRINT_ARRAY(void* a, int aSz, char* str);
 #else
-    #define WOLFSSL_MSG(in)
-    #define DEBUG_PRINT_ARRAY(a,aSz,str)
+    #define WOLFSSL_MSG(in) do {} while (0)
+    #define DEBUG_PRINT_ARRAY(a,aSz,str) do {} while (0)
 #endif
 
 #define CAAM_PAGE_MAX 6

--- a/wolfssl/wolfcrypt/port/caam/caam_qnx.h
+++ b/wolfssl/wolfcrypt/port/caam/caam_qnx.h
@@ -47,7 +47,7 @@
 #define CAAM_ADDRESS uintptr_t
 #define Success 1
 #define Failure 0
-#define INTERRUPT_Panic()
+#define INTERRUPT_Panic() do {} while (0)
 #define MemoryMapMayNotBeEmpty -1
 #define CAAM_WAITING -2
 #define NoActivityReady -1

--- a/wolfssl/wolfcrypt/port/caam/wolfcaam_fsl_nxp.h
+++ b/wolfssl/wolfcrypt/port/caam/wolfcaam_fsl_nxp.h
@@ -24,7 +24,7 @@
 #ifndef WOLFCAAM_FSL_NXP_H
 #define WOLFCAAM_FSL_NXP_H
 
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/types.h>
 
 #ifdef WOLFSSL_IMXRT1170_CAAM
 
@@ -44,7 +44,7 @@
 #define Boolean int
 #define Success 1
 #define Failure 0
-#define INTERRUPT_Panic()
+#define INTERRUPT_Panic() WC_DO_NOTHING
 #define MemoryMapMayNotBeEmpty -1
 #define CAAM_WAITING -2
 #define NoActivityReady -1

--- a/wolfssl/wolfcrypt/port/caam/wolfcaam_qnx.h
+++ b/wolfssl/wolfcrypt/port/caam/wolfcaam_qnx.h
@@ -24,7 +24,7 @@
 #ifndef WOLFCAAM_QNX_H
 #define WOLFCAAM_QNX_H
 
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/types.h>
 
 #ifdef WOLFSSL_QNX_CAAM
 #include <sys/iofunc.h>
@@ -35,7 +35,7 @@
 #define Boolean int
 #define Success 1
 #define Failure 0
-#define INTERRUPT_Panic()
+#define INTERRUPT_Panic() WC_DO_NOTHING
 #define MemoryMapMayNotBeEmpty -1
 #define CAAM_WAITING -2
 #define NoActivityReady -1

--- a/wolfssl/wolfcrypt/port/caam/wolfcaam_seco.h
+++ b/wolfssl/wolfcrypt/port/caam/wolfcaam_seco.h
@@ -24,7 +24,7 @@
 #ifndef WOLFCAAM_SECO_H
 #define WOLFCAAM_SECO_H
 
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/types.h>
 
 #ifdef WOLFSSL_SECO_CAAM
 
@@ -38,7 +38,7 @@
 #define Boolean int
 #define Success 1
 #define Failure 0
-#define INTERRUPT_Panic()
+#define INTERRUPT_Panic() WC_DO_NOTHING
 #define MemoryMapMayNotBeEmpty -1
 #define CAAM_WAITING -2
 #define NoActivityReady -1

--- a/wolfssl/wolfcrypt/port/psa/psa.h
+++ b/wolfssl/wolfcrypt/port/psa/psa.h
@@ -42,7 +42,7 @@
     #include <config.h>
 #endif
 
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/types.h>
 
 /* PSA implementation takes over the Sha struct and Sha functions implementation
    completely. Devoiding the struct of the DevId field and hooks to make
@@ -78,8 +78,8 @@
 void PSA_LOCK(void);
 void PSA_UNLOCK(void);
 #else
-#define PSA_LOCK()
-#define PSA_UNLOCK()
+#define PSA_LOCK() WC_DO_NOTHING
+#define PSA_UNLOCK() WC_DO_NOTHING
 #endif
 
 int wc_psa_init(void);

--- a/wolfssl/wolfcrypt/port/ti/ti-ccm.h
+++ b/wolfssl/wolfcrypt/port/ti/ti-ccm.h
@@ -27,7 +27,7 @@
     #include <config.h>
 #endif
 
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/types.h>
 
 #if defined(WOLFSSL_TI_CRYPT) ||  defined(WOLFSSL_TI_HASH)
 
@@ -37,8 +37,8 @@ int wolfSSL_TI_CCMInit(void) ;
 void wolfSSL_TI_lockCCM(void) ;
 void wolfSSL_TI_unlockCCM(void) ;
 #else
-#define wolfSSL_TI_lockCCM()
-#define wolfSSL_TI_unlockCCM()
+#define wolfSSL_TI_lockCCM() WC_DO_NOTHING
+#define wolfSSL_TI_unlockCCM() WC_DO_NOTHING
 #endif
 
 #endif

--- a/wolfssl/wolfcrypt/port/xilinx/xil-versal-glue.h
+++ b/wolfssl/wolfcrypt/port/xilinx/xil-versal-glue.h
@@ -37,8 +37,8 @@ extern "C" {
 #define XIL_CAST_U64(v) ((u64)(UINTPTR)(v))
 
 #ifdef XSECURE_CACHE_DISABLE
-#define WOLFSSL_XIL_DCACHE_INVALIDATE_RANGE(p, l) do{}while(0)
-#define WOLFSSL_XIL_DCACHE_FLUSH_RANGE(p, l)      do{}while(0)
+#define WOLFSSL_XIL_DCACHE_INVALIDATE_RANGE(p, l) WC_DO_NOTHING
+#define WOLFSSL_XIL_DCACHE_FLUSH_RANGE(p, l)      WC_DO_NOTHING
 #else
 #define WOLFSSL_XIL_DCACHE_INVALIDATE_RANGE(p, l) \
     do{ Xil_DCacheInvalidateRange((p), (l)); }while(0)
@@ -51,7 +51,7 @@ extern "C" {
 #include <unistd.h>
 #define WOLFSSL_XIL_SLEEP(n) do{ sleep(n); }while(0)
 #else
-#define WOLFSSL_XIL_SLEEP(n) do{}while(0)
+#define WOLFSSL_XIL_SLEEP(n) WC_DO_NOTHING
 #endif
 
 /* Provide our own message macro since the Versal PLM maybe

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -548,9 +548,9 @@ typedef struct sp_ecc_ctx {
     /* No filesystem, no output
      * TODO: Use logging API?
      */
-    #define sp_print(a, s)
-    #define sp_print_digit(a, s)
-    #define sp_print_int(a, s)
+    #define sp_print(a, s) WC_DO_NOTHING
+    #define sp_print_digit(a, s) WC_DO_NOTHING
+    #define sp_print_int(a, s) WC_DO_NOTHING
 
 #endif /* !NO_FILESYSTEM */
 
@@ -656,7 +656,7 @@ typedef struct sp_ecc_ctx {
 /* Sets the multi-precision number negative.
  *
  * Negative support not compiled in, so does nothing. */
-#define sp_setneg(a) do{}while(0)
+#define sp_setneg(a) WC_DO_NOTHING
 #else
 /* Returns whether multi-precision number is negative.
  *
@@ -830,7 +830,7 @@ while (0)
 #define NEW_MP_INT_SIZE(name, bits, heap, type) \
     XMEMSET(name, 0, MP_INT_SIZEOF(MP_BITS_CNT(bits)))
 /* Dispose of static mp_int. */
-#define FREE_MP_INT_SIZE(name, heap, type)
+#define FREE_MP_INT_SIZE(name, heap, type) WC_DO_NOTHING
 /* Type to force compiler to not complain about size. */
 #define MP_INT_SIZE     sp_int_minimal
 #endif

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -356,7 +356,7 @@ while (0)
 #define NEW_MP_INT_SIZE(name, bits, heap, type) \
     XMEMSET(name, 0, sizeof(mp_int))
 /* Dispose of static mp_int. */
-#define FREE_MP_INT_SIZE(name, heap, type)
+#define FREE_MP_INT_SIZE(name, heap, type) WC_DO_NOTHING
 #endif
 
 /* Initialize an mp_int. */
@@ -861,7 +861,7 @@ MP_API int mp_radix_size (mp_int * a, int radix, int *size);
 #ifdef WOLFSSL_DEBUG_MATH
     MP_API void mp_dump(const char* desc, mp_int* a, byte verbose);
 #else
-    #define mp_dump(desc, a, verbose)
+    #define mp_dump(desc, a, verbose) WC_DO_NOTHING
 #endif
 
 #if defined(OPENSSL_EXTRA) || !defined(NO_DSA) || defined(HAVE_ECC)

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -131,7 +131,7 @@ decouple library dependencies with standard string, memory and so on.
     #if defined(WOLF_C89) || defined(WOLF_NO_TRAILING_ENUM_COMMAS)
         #define WOLF_ENUM_DUMMY_LAST_ELEMENT(prefix) _wolf_ ## prefix ## _enum_dummy_last_element
     #else
-        #define WOLF_ENUM_DUMMY_LAST_ELEMENT(prefix)
+        #define WOLF_ENUM_DUMMY_LAST_ELEMENT(prefix) /* null expansion */
     #endif
 
     /* helpers for stringifying the expanded value of a macro argument rather
@@ -316,6 +316,16 @@ typedef struct w64wrapper {
         #endif
     #endif /* WC_MAYBE_UNUSED */
 
+    #ifndef WC_DO_NOTHING
+        #define WC_DO_NOTHING do {} while (0)
+        #ifdef _MSC_VER
+            /* disable buggy MSC warning around while(0),
+             *"warning C4127: conditional expression is constant"
+             */
+            #pragma warning(disable: 4127)
+        #endif
+    #endif
+
     /* use inlining if compiler allows */
     #ifndef WC_INLINE
     #ifndef NO_INLINE
@@ -494,11 +504,11 @@ typedef struct w64wrapper {
                     return NULL;
                 };
                 #define XMALLOC(s, h, t)     malloc_check((s))
-                #define XFREE(p, h, t)
+                #define XFREE(p, h, t)       WC_DO_NOTHING
                 #define XREALLOC(p, n, h, t) (NULL)
             #else
                 #define XMALLOC(s, h, t)     (NULL)
-                #define XFREE(p, h, t)
+                #define XFREE(p, h, t)       WC_DO_NOTHING
                 #define XREALLOC(p, n, h, t) (NULL)
             #endif
         #else
@@ -606,9 +616,9 @@ typedef struct w64wrapper {
             VAR_TYPE VAR_NAME[VAR_SIZE]
         #define WC_DECLARE_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) \
             VAR_TYPE VAR_NAME[VAR_ITEMS][VAR_SIZE]
-        #define WC_INIT_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) do {} while(0)
-        #define WC_FREE_VAR(VAR_NAME, HEAP) do {} while(0) /* nothing to free, its stack */
-        #define WC_FREE_ARRAY(VAR_NAME, VAR_ITEMS, HEAP) do {} while(0) /* nothing to free, its stack */
+        #define WC_INIT_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) WC_DO_NOTHING
+        #define WC_FREE_VAR(VAR_NAME, HEAP) WC_DO_NOTHING /* nothing to free, its stack */
+        #define WC_FREE_ARRAY(VAR_NAME, VAR_ITEMS, HEAP) WC_DO_NOTHING /* nothing to free, its stack */
 
         #define WC_DECLARE_ARRAY_DYNAMIC_DEC(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) \
             VAR_TYPE* VAR_NAME[VAR_ITEMS]; \
@@ -1206,9 +1216,9 @@ typedef struct w64wrapper {
     #elif defined(XASM_LINK)
         /* keep user-supplied definition */
     #elif defined(WOLFSSL_NO_ASM)
-        #define XASM_LINK(f)
+        #define XASM_LINK(f) /* null expansion */
     #elif defined(_MSC_VER)
-        #define XASM_LINK(f)
+        #define XASM_LINK(f) /* null expansion */
     #elif defined(__APPLE__)
         #define XASM_LINK(f) asm("_" f)
     #elif defined(__GNUC__)
@@ -1460,9 +1470,9 @@ typedef struct w64wrapper {
         #define PRAGMA(str) PRAGMA_GCC(str)
         #define PRAGMA_DIAG_POP PRAGMA_GCC_DIAG_POP
     #else
-        #define PRAGMA_GCC_DIAG_PUSH
-        #define PRAGMA_GCC(str)
-        #define PRAGMA_GCC_DIAG_POP
+        #define PRAGMA_GCC_DIAG_PUSH /* null expansion */
+        #define PRAGMA_GCC(str) /* null expansion */
+        #define PRAGMA_GCC_DIAG_POP /* null expansion */
     #endif
 
     #ifdef __clang__
@@ -1473,19 +1483,19 @@ typedef struct w64wrapper {
         #define PRAGMA(str) PRAGMA_CLANG(str)
         #define PRAGMA_DIAG_POP PRAGMA_CLANG_DIAG_POP
     #else
-        #define PRAGMA_CLANG_DIAG_PUSH
-        #define PRAGMA_CLANG(str)
-        #define PRAGMA_CLANG_DIAG_POP
+        #define PRAGMA_CLANG_DIAG_PUSH /* null expansion */
+        #define PRAGMA_CLANG(str) /* null expansion */
+        #define PRAGMA_CLANG_DIAG_POP /* null expansion */
     #endif
 
     #ifndef PRAGMA_DIAG_PUSH
-        #define PRAGMA_DIAG_PUSH
+        #define PRAGMA_DIAG_PUSH /* null expansion */
     #endif
     #ifndef PRAGMA
-        #define PRAGMA(str)
+        #define PRAGMA(str) /* null expansion */
     #endif
     #ifndef PRAGMA_DIAG_POP
-        #define PRAGMA_DIAG_POP
+        #define PRAGMA_DIAG_POP /* null expansion */
     #endif
 
     #ifdef DEBUG_VECTOR_REGISTER_ACCESS
@@ -1558,23 +1568,17 @@ typedef struct w64wrapper {
             wc_svr_last_line = __LINE__;                                \
         }
     #else
-        #ifdef _MSC_VER
-            /* disable buggy MSC warning around while(0),
-             *"warning C4127: conditional expression is constant"
-             */
-            #pragma warning(disable: 4127)
-        #endif
         #ifndef SAVE_VECTOR_REGISTERS
-            #define SAVE_VECTOR_REGISTERS(...) do{}while(0)
+            #define SAVE_VECTOR_REGISTERS(...) WC_DO_NOTHING
         #endif
         #ifndef ASSERT_SAVED_VECTOR_REGISTERS
-            #define ASSERT_SAVED_VECTOR_REGISTERS(...) do{}while(0)
+            #define ASSERT_SAVED_VECTOR_REGISTERS(...) WC_DO_NOTHING
         #endif
         #ifndef ASSERT_RESTORED_VECTOR_REGISTERS
-            #define ASSERT_RESTORED_VECTOR_REGISTERS(...) do{}while(0)
+            #define ASSERT_RESTORED_VECTOR_REGISTERS(...) WC_DO_NOTHING
         #endif
         #ifndef RESTORE_VECTOR_REGISTERS
-            #define RESTORE_VECTOR_REGISTERS() do{}while(0)
+            #define RESTORE_VECTOR_REGISTERS() WC_DO_NOTHING
         #endif
     #endif
 
@@ -1584,8 +1588,8 @@ typedef struct w64wrapper {
         #define PRIVATE_KEY_LOCK() WC_SPKRE_F(0,WC_KEYTYPE_ALL)
         #define PRIVATE_KEY_UNLOCK() WC_SPKRE_F(1,WC_KEYTYPE_ALL)
     #else
-        #define PRIVATE_KEY_LOCK() do{}while(0)
-        #define PRIVATE_KEY_UNLOCK() do{}while(0)
+        #define PRIVATE_KEY_LOCK() WC_DO_NOTHING
+        #define PRIVATE_KEY_UNLOCK() WC_DO_NOTHING
     #endif
 
 

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -356,7 +356,7 @@ typedef struct wolfSSL_Ref {
         (ref)->count = 1;                    \
         *(err) = 0;                          \
     } while(0)
-#define wolfSSL_RefFree(ref)
+#define wolfSSL_RefFree(ref) WC_DO_NOTHING
     #define wolfSSL_RefInc(ref, err)         \
     do {                                     \
         (ref)->count++;                      \
@@ -376,7 +376,7 @@ typedef struct wolfSSL_Ref {
         wolfSSL_Atomic_Int_Init(&(ref)->count, 1); \
         *(err) = 0;                          \
     } while(0)
-#define wolfSSL_RefFree(ref)
+#define wolfSSL_RefFree(ref) WC_DO_NOTHING
 #define wolfSSL_RefInc(ref, err)             \
     do {                                     \
         (void)wolfSSL_Atomic_Int_FetchAdd(&(ref)->count, 1); \

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -436,7 +436,7 @@ WOLFSSL_API  int wolfIO_Recv(SOCKET_T sd, char *buf, int sz, int rdFlags);
         extern int closesocket(int);
         #define CloseSocket(s) closesocket(s)
     #endif
-    #define StartTCP()
+    #define StartTCP() WC_DO_NOTHING
 #elif defined(FUSION_RTOS)
     #ifndef CloseSocket
         #define CloseSocket(s) do {                     \
@@ -448,7 +448,7 @@ WOLFSSL_API  int wolfIO_Recv(SOCKET_T sd, char *buf, int sz, int rdFlags);
     #ifndef CloseSocket
         #define CloseSocket(s) close(s)
     #endif
-    #define StartTCP()
+    #define StartTCP() WC_DO_NOTHING
     #ifdef FREERTOS_TCP_WINSIM
         extern int close(int);
     #endif


### PR DESCRIPTION
add `WC_DO_NOTHING` macro to `wolfssl/wolfcrypt/types.h`, with default expansion `do {} while (0)`, and globally refactor to use the macro where appropriate, annotating intended-null macros-with-args with `/* null expansion */`;

tweak several `#include`s of `settings.h` to include `types.h` instead (all of these are for clarity, as `types.h` is indirectly included by later `#include`s), and add `#include <wolfssl/wolfcrypt/types.h>` where missing;

remove trailing semicolons from `PRAGMA*()` macro invocations as they are unneeded and can be harmful (inducing frivolous `-Wdeclaration-after-statement` etc.).

note, added one additional runtime nullness check, in `ssl.c`:`wolfSSL_PEM_read_PUBKEY()`, because `clang-tidy` isn't smart enough to know `der` can't be null after `pem_read_file_key(..., &der) >= 0`.

tested with `wolfssl-multi-test.sh ... super-quick-check`.
