### PR TITLE
tfm fp_exptmod_nct: set result to zero when base is zero

### DIFF
--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -3171,8 +3171,10 @@ int fp_exptmod_nct(fp_int * G, fp_int * X, fp_int * P, fp_int * Y)
    int x = fp_count_bits (X);
 #endif
 
+   /* 0^X mod P = 0 mod P = 0.
+    * Set result to 0 and return early. */
    if (fp_iszero(G)) {
-      fp_set(G, 0);
+      fp_set(Y, 0);
       return FP_OKAY;
    }
 

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -3171,16 +3171,21 @@ int fp_exptmod_nct(fp_int * G, fp_int * X, fp_int * P, fp_int * Y)
    int x = fp_count_bits (X);
 #endif
 
-   /* 0^X mod P = 0 mod P = 0.
-    * Set result to 0 and return early. */
-   if (fp_iszero(G)) {
+   /* handle modulus of zero and prevent overflows */
+   if (fp_iszero(P) || (P->used > (FP_SIZE/2))) {
+      return FP_VAL;
+   }
+   if (fp_isone(P)) {
       fp_set(Y, 0);
       return FP_OKAY;
    }
-
-   /* prevent overflows */
-   if (P->used > (FP_SIZE/2)) {
-      return FP_VAL;
+   if (fp_iszero(X)) {
+      fp_set(Y, 1);
+      return FP_OKAY;
+   }
+   if (fp_iszero(G)) {
+      fp_set(Y, 0);
+      return FP_OKAY;
    }
 
 #if defined(WOLFSSL_ESP32_CRYPT_RSA_PRI) && \


### PR DESCRIPTION
# Description
Fix `fp_exptmod_nct`  to handle special cases:

- mod = 0: return `FP_VAL`
- mod = 1: set result 0
- exp = 0: set result 1
- base = 0: set result 0

This makes `fp_exptmod_nct` behave consistently with `sp_exptmod_nct`.

Fixes zd#16426

# Testing

Tested with  reproducers in ticket.
