### PR TITLE
fix bad & statement that was setting ocspSendNonce

### DIFF
--- a/src/ssl_certman.c
+++ b/src/ssl_certman.c
@@ -1974,7 +1974,8 @@ int wolfSSL_CertManagerEnableOCSP(WOLFSSL_CERT_MANAGER* cm, int options)
             cm->ocspUseOverrideURL = 1;
         }
         /* Set nonce option for creating OCSP requests. */
-        cm->ocspSendNonce = (options & WOLFSSL_OCSP_NO_NONCE) != 0;
+        cm->ocspSendNonce = (options & WOLFSSL_OCSP_NO_NONCE) !=
+            WOLFSSL_OCSP_NO_NONCE;
         /* Set all OCSP checks on if requested. */
         if (options & WOLFSSL_OCSP_CHECKALL) {
             cm->ocspCheckAll = 1;


### PR DESCRIPTION
to 1 when WOLFSSL_OCSP_NO_NONCE was selected
related to but doesn't solve zd 16377

# Description

OCSP sends an optional nonce which is supposed to be disabled by `WOLFSSL_OCSP_NO_NONCE` but the logical statement was doing the opposite and sending the nonce when `WOLFSSL_OCSP_NO_NONCE` was set

# Testing

Tested in gdb to confirm the nonce was being skipped

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
