### PR TITLE
OCSP_WANT_READ mishandled re-run

### DIFF
--- a/.github/workflows/async.yml
+++ b/.github/workflows/async.yml
@@ -10,7 +10,8 @@ jobs:
         config: [
           # Add new configs here
           '--enable-asynccrypt --enable-all --enable-dtls13',
-          '--enable-asynccrypt-sw',
+          '--enable-asynccrypt-sw --enable-ocspstapling --enable-ocspstapling2',
+          '--enable-ocsp CFLAGS="-DTEST_NONBLOCK_CERTS"',
         ]
     name: make check
     runs-on: ubuntu-latest

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -223,6 +223,9 @@ static int NonBlockingSSL_Connect(WOLFSSL* ssl)
         #ifdef WOLFSSL_ASYNC_CRYPT
             || error == WC_PENDING_E
         #endif
+        #ifdef WOLFSSL_NONBLOCK_OCSP
+            || error == OCSP_WANT_READ
+        #endif
         ) {
         #ifndef WOLFSSL_CALLBACKS
             ret = wolfSSL_connect(ssl);

--- a/src/internal.c
+++ b/src/internal.c
@@ -16501,7 +16501,9 @@ int SendFatalAlertOnly(WOLFSSL *ssl, int error)
     case WANT_WRITE:
     case WANT_READ:
     case ZERO_RETURN:
+#ifdef HAVE_OCSP
     case OCSP_WANT_READ:
+#endif
 #ifdef WOLFSSL_ASYNC_CRYPT
     case WC_PENDING_E:
 #endif

--- a/src/internal.c
+++ b/src/internal.c
@@ -16332,11 +16332,6 @@ static int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     }
 
 #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
-    /* make sure async error is cleared */
-    if (ret == 0 && (ssl->error == WC_PENDING_E || ssl->error == OCSP_WANT_READ)) {
-        ssl->error = 0;
-    }
-
     /* if async, offset index so this msg will be processed again */
     if ((ret == WC_PENDING_E || ret == OCSP_WANT_READ) && *inOutIdx > 0) {
         *inOutIdx -= HANDSHAKE_HEADER_SZ;
@@ -16345,10 +16340,11 @@ static int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             *inOutIdx -= DTLS_HANDSHAKE_EXTRA;
         }
     #endif
+    }
 
-        /* set the async error so the re-run will work and won't send alert */
-        ssl->error = ret;
-        ret = 0;
+    /* make sure async error is cleared */
+    if (ret == 0 && (ssl->error == WC_PENDING_E || ssl->error == OCSP_WANT_READ)) {
+        ssl->error = 0;
     }
 #endif /* WOLFSSL_ASYNC_CRYPT || WOLFSSL_NONBLOCK_OCSP */
 
@@ -16505,6 +16501,7 @@ int SendFatalAlertOnly(WOLFSSL *ssl, int error)
     case WANT_WRITE:
     case WANT_READ:
     case ZERO_RETURN:
+    case OCSP_WANT_READ:
 #ifdef WOLFSSL_ASYNC_CRYPT
     case WC_PENDING_E:
 #endif

--- a/src/internal.c
+++ b/src/internal.c
@@ -16501,7 +16501,7 @@ int SendFatalAlertOnly(WOLFSSL *ssl, int error)
     case WANT_WRITE:
     case WANT_READ:
     case ZERO_RETURN:
-#ifdef HAVE_OCSP
+#ifdef WOLFSSL_NONBLOCK_OCSP
     case OCSP_WANT_READ:
 #endif
 #ifdef WOLFSSL_ASYNC_CRYPT

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -11479,12 +11479,12 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
          * == 0) */
         *inOutIdx -= HANDSHAKE_HEADER_SZ;
     }
-#endif
 
-    /* reset error */
-    if (ret == 0 && ssl->error == WC_PENDING_E)
+    /* make sure async error is cleared */
+    if (ret == 0 && (ssl->error == WC_PENDING_E || ssl->error == OCSP_WANT_READ)) {
         ssl->error = 0;
-
+    }
+#endif
     if (ret == 0 && type != client_hello && type != session_ticket &&
                                                            type != key_update) {
         ret = HashInput(ssl, input + inIdx, size);


### PR DESCRIPTION
# Description

in the event of a OCSP_WANT_READ, set the ssl->error so that the re-run of DoHandShakeMsgType knows not to hash the certificate twice and won't send an alert to the server as it was when OCSP_WANT_READ instead of setting ret to 0

Fixes zd# 16377

# Testing

TODO adding server and client side test

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
