### PR TITLE
SM2 and SP_MATH: don't enable SM2 with SP_MATH

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3460,6 +3460,10 @@ AC_ARG_ENABLE([sm2],
     [ ENABLED_SM2=no ]
     )
 
+if test "$ENABLED_SP_MATH" = "yes"
+then
+    ENABLED_SM2="no"
+fi
 if test "$ENABLED_SM2" = "yes"
 then
     if test "$ENABLED_ECC" = "no"
@@ -9341,6 +9345,7 @@ echo "   * ECC Minimum Bits:           $ENABLED_ECCMINSZ"
 echo "   * FPECC:                      $ENABLED_FPECC"
 echo "   * ECC_ENCRYPT:                $ENABLED_ECC_ENCRYPT"
 echo "   * Brainpool:                  $ENABLED_BRAINPOOL"
+echo "   * SM2:                        $ENABLED_SM2"
 echo "   * CURVE25519:                 $ENABLED_CURVE25519"
 echo "   * ED25519:                    $ENABLED_ED25519"
 echo "   * ED25519 streaming:          $ENABLED_ED25519_STREAM"

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -666,7 +666,7 @@ enum {
         #endif
         #define ecc_oid_brainpoolp256r1_sz CODED_BRAINPOOLP256R1_SZ
     #endif /* HAVE_ECC_BRAINPOOL */
-    #ifdef WOLFSSL_SM2
+    #if defined(WOLFSSL_SM2) && !defined(WOLFSSL_SP_MATH)
         #ifdef HAVE_OID_ENCODING
             #define CODED_SM2P256V1    {1,2,156,10197,1,301}
             #define CODED_SM2P256V1_SZ 6
@@ -680,7 +680,7 @@ enum {
             #define ecc_oid_sm2p256v1 CODED_SM2P256V1
         #endif
         #define ecc_oid_sm2p256v1_sz CODED_SM2P256V1_SZ
-    #endif /* WOLFSSL_SM2 */
+    #endif /* WOLFSSL_SM2 && !WOLFSSL_SP_MATH */
 #endif /* ECC256 */
 #ifdef ECC320
     #ifdef HAVE_ECC_BRAINPOOL
@@ -1161,7 +1161,7 @@ const ecc_set_type ecc_sets[] = {
         1,                                                                  /* cofactor   */
     },
     #endif /* HAVE_ECC_BRAINPOOL */
-    #ifdef WOLFSSL_SM2
+    #if defined(WOLFSSL_SM2) && !defined(WOLFSSL_SP_MATH)
     {
         32,                                                     /* size/bytes */
         ECC_SM2P256V1,                                          /* ID         */
@@ -1179,7 +1179,7 @@ const ecc_set_type ecc_sets[] = {
         ECC_SM2P256V1_OID,                                      /* oid sum    */
         1,                                                      /* cofactor   */
     },
-    #endif /* WOLFSSL_SM2 */
+    #endif /* WOLFSSL_SM2 && !WOLFSSL_SP_MATH */
 #endif /* ECC256 */
 #ifdef ECC320
     #ifdef HAVE_ECC_BRAINPOOL


### PR DESCRIPTION
# Description

No implementation of SM2 with SP so can't use SM2 with SP MATH.

Fixes zd#16443

# Testing

POC

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
