### PR TITLE
Add CryptoCb features

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -40,6 +40,9 @@
  * Enable tracking of the stats into an allocated linked list:
  * (use -print to display results):
  * WC_BENCH_TRACK_STATS
+ *
+ * set the default devId for cryptocb to the value instead of INVALID_DEVID
+ * WC_USE_DEVID=0x1234
  */
 
 
@@ -1300,8 +1303,8 @@ static const char* bench_result_words2[][5] = {
 
     static THREAD_LS_T int devId = WOLFSSL_CAAM_DEVID;
 #else
-  #ifdef FORCE_DEVID
-    static THREAD_LS_T int devId = FORCE_DEVID;
+  #ifdef WC_USE_DEVID
+    static THREAD_LS_T int devId = WC_USE_DEVID;
   #else
     static THREAD_LS_T int devId = INVALID_DEVID;
   #endif
@@ -1316,7 +1319,7 @@ static const char* bench_result_words2[][5] = {
     static volatile int g_threadCount;
 #endif
 
-#if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_CAAM) || defined(FORCE_DEVID)
+#if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_CAAM) || defined(WC_USE_DEVID)
     #ifndef NO_HW_BENCH
         #define BENCH_DEVID
     #endif

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1300,7 +1300,11 @@ static const char* bench_result_words2[][5] = {
 
     static THREAD_LS_T int devId = WOLFSSL_CAAM_DEVID;
 #else
+  #ifdef FORCE_DEVID
+    static THREAD_LS_T int devId = FORCE_DEVID;
+  #else
     static THREAD_LS_T int devId = INVALID_DEVID;
+  #endif
 #endif
 
 /* Asynchronous helper macros */
@@ -1312,7 +1316,7 @@ static const char* bench_result_words2[][5] = {
     static volatile int g_threadCount;
 #endif
 
-#if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_CAAM)
+#if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_CAAM) || defined(FORCE_DEVID)
     #ifndef NO_HW_BENCH
         #define BENCH_DEVID
     #endif

--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -157,8 +157,8 @@ static const char* GetRsaType(int type)
 static const char* GetCryptoCbCmdTypeStr(int type)
 {
     switch (type) {
-        case WC_CRYPTOCB_CMD_TYPE_REGISTER:  return "Register";
-        case WC_CRYPTOCB_CMD_TYPE_UNREGISTER:  return "UnRegister";
+        case WC_CRYPTOCB_CMD_TYPE_REGISTER:   return "Register";
+        case WC_CRYPTOCB_CMD_TYPE_UNREGISTER: return "UnRegister";
     }
     return NULL;
 }
@@ -196,7 +196,7 @@ WOLFSSL_API void wc_CryptoCb_InfoString(wc_CryptoInfo* info)
     }
     else if (info->algo_type == WC_ALGO_TYPE_NONE) {
         printf("Crypto CB: %s %s (%d)\n", GetAlgoTypeStr(info->algo_type),
-                GetCryptoCbCmdTypeStr(info->cmd.type), info->cmd.type);
+            GetCryptoCbCmdTypeStr(info->cmd.type), info->cmd.type);
     }
     else {
         printf("CryptoCb: %s \n", GetAlgoTypeStr(info->algo_type));
@@ -253,7 +253,7 @@ static WC_INLINE int wc_CryptoCb_TranslateErrorCode(int ret)
 }
 
 /* Helper function to reset a device entry to invalid */
-static inline void wc_CryptoCb_ClearDev(CryptoCb *dev)
+static WC_INLINE void wc_CryptoCb_ClearDev(CryptoCb *dev)
 {
     XMEMSET(dev, 0, sizeof(*dev));
     dev->devId = INVALID_DEVID;
@@ -262,7 +262,7 @@ static inline void wc_CryptoCb_ClearDev(CryptoCb *dev)
 void wc_CryptoCb_Init(void)
 {
     int i;
-    for (i=0; i<MAX_CRYPTO_DEVID_CALLBACKS; i++) {
+    for (i = 0; i < MAX_CRYPTO_DEVID_CALLBACKS; i++) {
         wc_CryptoCb_ClearDev(&gCryptoDev[i]);
     }
 }
@@ -270,7 +270,7 @@ void wc_CryptoCb_Init(void)
 void wc_CryptoCb_Cleanup(void)
 {
     int i;
-    for (i=0; i<MAX_CRYPTO_DEVID_CALLBACKS; i++) {
+    for (i = 0; i < MAX_CRYPTO_DEVID_CALLBACKS; i++) {
         if(gCryptoDev[i].devId != INVALID_DEVID) {
             wc_CryptoCb_UnRegisterDevice(gCryptoDev[i].devId);
         }
@@ -301,7 +301,7 @@ void wc_CryptoCb_SetDeviceFindCb(CryptoDevCallbackFind cb)
 
 int wc_CryptoCb_RegisterDevice(int devId, CryptoDevCallbackFunc cb, void* ctx)
 {
-    int rc=0;
+    int rc = 0;
 
     /* find existing or new */
     CryptoCb* dev = wc_CryptoCb_GetDevice(devId);
@@ -312,13 +312,14 @@ int wc_CryptoCb_RegisterDevice(int devId, CryptoDevCallbackFunc cb, void* ctx)
         return BUFFER_E; /* out of devices */
 
     dev->devId = devId;
-    dev->cb = cb;
-    dev->ctx = ctx;
+    dev->cb    = cb;
+    dev->ctx   = ctx;
 
 #ifdef WOLF_CRYPTO_CB_CMD
     if (cb != NULL) {
         /* Invoke callback with register command */
-        wc_CryptoInfo info= {0};
+        wc_CryptoInfo info;
+        XMEMSET(&info, 0, sizeof(info));
         info.algo_type = WC_ALGO_TYPE_NONE;
         info.cmd.type  = WC_CRYPTOCB_CMD_TYPE_REGISTER;
         info.cmd.ctx   = ctx;  /* cb may update on success */
@@ -358,7 +359,8 @@ void wc_CryptoCb_UnRegisterDevice(int devId)
 #ifdef WOLF_CRYPTO_CB_CMD
     if (dev->cb != NULL) {
         /* Invoke callback with unregister command.*/
-        wc_CryptoInfo info= {0};
+        wc_CryptoInfo info;
+        XMEMSET(&info, 0, sizeof(info));
         info.algo_type = WC_ALGO_TYPE_NONE;
         info.cmd.type  = WC_CRYPTOCB_CMD_TYPE_UNREGISTER;
         info.cmd.ctx   = NULL;  /* Not used */

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -486,6 +486,10 @@ int wolfCrypt_Cleanup(void)
         Entropy_Final();
     #endif
 
+    #ifdef WOLF_CRYPTO_CB
+        wc_CryptoCb_Cleanup();
+    #endif
+
     #if defined(WOLFSSL_MEM_FAIL_COUNT) && defined(WOLFCRYPT_ONLY)
         wc_MemFailCount_Free();
     #endif

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -19,6 +19,15 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+/*
+ * Some common, optional build settings:
+ * these can also be set in wolfssl/options.h or user_settings.h
+ * -------------------------------------------------------------
+ *
+ * set the default devId for cryptocb to the value instead of INVALID_DEVID
+ * WC_USE_DEVID=0x1234
+ */
+
 #ifdef HAVE_CONFIG_H
     #include <config.h>
 #endif
@@ -407,8 +416,8 @@ static void initDefaultName(void);
 #ifdef WOLFSSL_CAAM_DEVID
 static int devId = WOLFSSL_CAAM_DEVID;
 #else
-  #ifdef FORCE_DEVID
-static int devId = FORCE_DEVID;
+  #ifdef WC_USE_DEVID
+static int devId = WC_USE_DEVID;
   #else
 static int devId = INVALID_DEVID;
   #endif
@@ -882,7 +891,11 @@ wc_test_ret_t wolfcrypt_test(void* args)
 #endif
 
     printf("------------------------------------------------------------------------------\n");
-    printf(" wolfSSL version %s with DevID:%X\n", LIBWOLFSSL_VERSION_STRING,devId);
+    printf(" wolfSSL version %s\n", LIBWOLFSSL_VERSION_STRING);
+#ifdef WOLF_CRYPTO_CB
+    if (devId != INVALID_DEVID)
+        printf("  CryptoCB with DevID:%X\n", devId);
+#endif
     printf("------------------------------------------------------------------------------\n");
 
     if (args) {

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -407,7 +407,11 @@ static void initDefaultName(void);
 #ifdef WOLFSSL_CAAM_DEVID
 static int devId = WOLFSSL_CAAM_DEVID;
 #else
+  #ifdef FORCE_DEVID
+static int devId = FORCE_DEVID;
+  #else
 static int devId = INVALID_DEVID;
+  #endif
 #endif
 
 #ifdef HAVE_WNR
@@ -878,7 +882,7 @@ wc_test_ret_t wolfcrypt_test(void* args)
 #endif
 
     printf("------------------------------------------------------------------------------\n");
-    printf(" wolfSSL version %s\n", LIBWOLFSSL_VERSION_STRING);
+    printf(" wolfSSL version %s with DevID:%X\n", LIBWOLFSSL_VERSION_STRING,devId);
     printf("------------------------------------------------------------------------------\n");
 
     if (args) {

--- a/wolfssl/wolfcrypt/cryptocb.h
+++ b/wolfssl/wolfcrypt/cryptocb.h
@@ -72,6 +72,7 @@
     #include <wolfssl/wolfcrypt/sha512.h>
 #endif
 
+#ifdef WOLF_CRYPTO_CB_CMD
 /* CryptoCb Commands */
 enum wc_CryptoCbCmdType {
     WC_CRYPTOCB_CMD_TYPE_NONE = 0,
@@ -80,6 +81,7 @@ enum wc_CryptoCbCmdType {
 
     WC_CRYPTOCB_CMD_TYPE_MAX = WC_CRYPTOCB_CMD_TYPE_UNREGISTER
 };
+#endif
 
 /* Crypto Information Structure for callbacks */
 typedef struct wc_CryptoInfo {
@@ -365,10 +367,12 @@ typedef struct wc_CryptoInfo {
         int type;
     } cmac;
 #endif
+#ifdef WOLF_CRYPTO_CB_CMD
     struct {      /* uses wc_AlgoType=ALGO_NONE */
         int type; /* enum wc_CryptoCbCmdType */
         void *ctx;
     } cmd;
+#endif
 #if HAVE_ANONYMOUS_INLINE_AGGREGATES
     };
 #endif

--- a/wolfssl/wolfcrypt/cryptocb.h
+++ b/wolfssl/wolfcrypt/cryptocb.h
@@ -72,6 +72,15 @@
     #include <wolfssl/wolfcrypt/sha512.h>
 #endif
 
+/* CryptoCb Commands */
+enum wc_CryptoCbCmdType {
+    WC_CRYPTOCB_CMD_TYPE_NONE = 0,
+    WC_CRYPTOCB_CMD_TYPE_REGISTER,
+    WC_CRYPTOCB_CMD_TYPE_UNREGISTER,
+
+    WC_CRYPTOCB_CMD_TYPE_MAX = WC_CRYPTOCB_CMD_TYPE_UNREGISTER
+};
+
 /* Crypto Information Structure for callbacks */
 typedef struct wc_CryptoInfo {
     int algo_type; /* enum wc_AlgoType */
@@ -356,6 +365,10 @@ typedef struct wc_CryptoInfo {
         int type;
     } cmac;
 #endif
+    struct {      /* uses wc_AlgoType=ALGO_NONE */
+        int type; /* enum wc_CryptoCbCmdType */
+        void *ctx;
+    } cmd;
 #if HAVE_ANONYMOUS_INLINE_AGGREGATES
     };
 #endif
@@ -365,6 +378,7 @@ typedef struct wc_CryptoInfo {
 typedef int (*CryptoDevCallbackFunc)(int devId, wc_CryptoInfo* info, void* ctx);
 
 WOLFSSL_LOCAL void wc_CryptoCb_Init(void);
+WOLFSSL_LOCAL void wc_CryptoCb_Cleanup(void);
 WOLFSSL_LOCAL int wc_CryptoCb_GetDevIdAtIndex(int startIdx);
 WOLFSSL_API int  wc_CryptoCb_RegisterDevice(int devId, CryptoDevCallbackFunc cb, void* ctx);
 WOLFSSL_API void wc_CryptoCb_UnRegisterDevice(int devId);


### PR DESCRIPTION
# Description

Added additional cryptocb features:
1. Test and Benchmark will now use WC_USE_DEVID if defined to set the default devId to allow out of tree build of test and benchmark objects
2. Added support for cryptocb commands which are invoked during Register and UnRegister using ALGO_TYPE_NONE
3. Register command callback allows hardware initialization/context to be set during register.  Returning 0 indicates success and the dev->ctx will be updated to the value set in the provided info pointer.  Returning CRYPTOCB_UNAVAILABLE or NOT_COMPILED_IN is silently handled as a success.
4. Unregister command callback allows state and hardware cleanup to be triggered internally during the unregister.
5. wolfCrypt_Cleanup now invokes UnRegister device on all devices, which will invoke the callback as well.
6. Register/UnRegister command callback allow late hardware initialization and supports the Java JNI wrapper that is not able to easily pass in a hardware context pointer.


# Testing

This was tested using the out-of-tree VaultIC 420 porting library.  The current cryptocb test passed within test and the cleanup is being called automatically.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
