### PR TITLE
add include to wolfio.h and replace cmake NAMESPACE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2376,7 +2376,8 @@ install(FILES
 # Install the export set
 install(EXPORT wolfssl-targets
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/wolfssl
-        FILE wolfssl-config.cmake)
+        FILE wolfssl-targets.cmake
+        NAMESPACE wolfssl::)
 
 # TODO: Distro build + rules for what to include in the distro.
 #       See various include.am files.

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -26,6 +26,8 @@
 #ifndef WOLFSSL_IO_H
 #define WOLFSSL_IO_H
 
+#include <wolfssl/ssl.h>
+
 #ifdef __cplusplus
     extern "C" {
 #endif


### PR DESCRIPTION
- Adds in include of ssl.h in case an application includes wolfio.h first (finding WOLFSSL_CTX structs and others)
- Adds back in cmake NAMESPACE. Instead the cmake's of wolftpm (https://github.com/wolfSSL/wolfTPM/pull/280) and wolfmqtt (https://github.com/wolfSSL/wolfMQTT/pull/343) were adjusted to find wolfSSL. 