### PR TITLE
SM3 ASM file: protect with check for WOLFSSL_SM3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2733,6 +2733,7 @@ then
             esac
         fi
         AS_IF([test "x$ENABLED_AESGCM" != "xno"],[AM_CCASFLAGS="$AM_CCASFLAGS -DHAVE_AESGCM"])
+        AS_IF([test "x$ENABLED_SM3" != "xno"],[AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_SM3"])
     fi
 
     if test "$ENABLED_INTELASM" = "yes"

--- a/wolfcrypt/src/sm3_asm.S
+++ b/wolfcrypt/src/sm3_asm.S
@@ -1,3 +1,13 @@
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/wolfcrypt/settings.h>
+
+#ifdef WOLFSSL_SM3
+
 #error "Contact wolfSSL to get the implementation of this file"
+
+#endif
 


### PR DESCRIPTION
# Description

Protect sm3_asm.S with check for WOLFSSL_SM3.
Change configure.ac to define WOLFSSL_SM3 in ASM flags when SM3 enabled and enabling intelasm.

# Testing

Standard

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
