### PR TITLE
Dtls13GetRnMask: Correctly get chacha counter on BE systems

### DIFF
--- a/.github/workflows/async.yml
+++ b/.github/workflows/async.yml
@@ -14,6 +14,8 @@ jobs:
         ]
     name: make check
     runs-on: ubuntu-latest
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 6
     steps:
       - uses: actions/checkout@v3
         name: Checkout wolfSSL

--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -6,36 +6,26 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 14
     steps:
-    - uses: actions/checkout@master
-    - name: autogen
-      run: ./autogen.sh
-    - name: configure
-      run: ./configure --enable-all
-    - name: make
-      run: make
-    - name: install
-      run: sudo make install
-    - uses: actions/checkout@master
+    - name: Install test dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install nghttp2
+
+    - name: Build wolfSSL
+      uses: wolfSSL/actions-build-autotools-project@v1
+      with:
+        path: wolfssl
+        configure: --enable-curl
+        install: true
+
+    - name: Build and test stunnel
+      uses: wolfSSL/actions-build-autotools-project@v1
       with:
         repository: curl/curl
         path: curl
-    - name: Install test dependency
-      working-directory: ./curl
-      run: sudo apt-get install nghttp2
-    - name: curl buildconf
-      working-directory: ./curl
-      run: ./buildconf
-    - name: curl configure
-      working-directory: ./curl
-      run: ./configure --with-wolfssl
-    - name: curl make
-      working-directory: ./curl
-      run: make
-    - name: curl unit tests
-      working-directory: ./curl
-      run: make test
-
+        configure: --with-wolfssl=$GITHUB_WORKSPACE/build-dir
+        check: true

--- a/.github/workflows/docker-Espressif.yml
+++ b/.github/workflows/docker-Espressif.yml
@@ -6,6 +6,8 @@ jobs:
   espressif_latest:
     name: latest Docker container
     runs-on: ubuntu-latest
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 12
     container:
       image: espressif/idf:latest
     steps:

--- a/.github/workflows/docker-OpenWrt.yml
+++ b/.github/workflows/docker-OpenWrt.yml
@@ -9,6 +9,8 @@ jobs:
     build_library:
         name: Compile libwolfssl.so
         runs-on: ubuntu-latest
+        # This should be a safe limit for the tests to run.
+        timeout-minutes: 4
         container:
             image: alpine:latest
         steps:
@@ -26,6 +28,8 @@ jobs:
     compile_container:
         name: Compile container
         runs-on: ubuntu-latest
+        # This should be a safe limit for the tests to run.
+        timeout-minutes: 2
         needs: build_library
         strategy:
             fail-fast: false

--- a/.github/workflows/hitch.yml
+++ b/.github/workflows/hitch.yml
@@ -8,6 +8,8 @@ jobs:
     name: Build wolfSSL
     # Just to keep it the same as the testing target
     runs-on: ubuntu-latest
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 4
     steps:
       - name: Build wolfSSL
         uses: wolfSSL/actions-build-autotools-project@v1
@@ -34,6 +36,8 @@ jobs:
               test13-r82.sh test15-proxy-v2-npn.sh test39-client-cert-proxy.sh
     name: ${{ matrix.ref }}
     runs-on: ubuntu-latest
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 4
     needs: build_wolfssl
     steps:
       - name: Download lib

--- a/.github/workflows/hostap.yml
+++ b/.github/workflows/hostap.yml
@@ -15,6 +15,8 @@ jobs:
     name: Build wolfSSL
     # Just to keep it the same as the testing target
     runs-on: ubuntu-20.04
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 4
     steps:
         # No way to view the full strategy in the browser (really weird)
       - name: Print strategy
@@ -90,6 +92,8 @@ jobs:
     name: hwsim test
     # For openssl 1.1
     runs-on: ubuntu-20.04
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 12
     needs: build_wolfssl
     steps:
         # No way to view the full strategy in the browser (really weird)

--- a/.github/workflows/multi-compiler.yml
+++ b/.github/workflows/multi-compiler.yml
@@ -25,6 +25,8 @@ jobs:
           - CC: clang-14
             CXX: clang++-14
     runs-on: ubuntu-latest
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 2
     steps:
       - uses: actions/checkout@v3
       - name: Build

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -9,6 +9,8 @@ jobs:
     name: Build wolfSSL
     # Just to keep it the same as the testing target
     runs-on: ubuntu-latest
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 4
     steps:
       - if: ${{ runner.debug }}
         name: Enable wolfSSL debug logging
@@ -66,6 +68,8 @@ jobs:
               stream_proxy_ssl_verify.t stream_ssl_alpn.t
     name: ${{ matrix.ref }}
     runs-on: ubuntu-latest
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 6
     needs: build_wolfssl
     steps:
       - name: Download lib

--- a/.github/workflows/openvpn.yml
+++ b/.github/workflows/openvpn.yml
@@ -8,6 +8,8 @@ jobs:
     name: Build wolfSSL
     # Just to keep it the same as the testing target
     runs-on: ubuntu-latest
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 4
     steps:
       - name: Build wolfSSL
         uses: wolfSSL/actions-build-autotools-project@v1
@@ -31,6 +33,8 @@ jobs:
         ref: [ master, release/2.6, v2.6.0 ]
     name: ${{ matrix.ref }}
     runs-on: ubuntu-latest
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 6
     needs: build_wolfssl
     steps:
       - name: Download lib

--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -22,6 +22,8 @@ jobs:
         ]
     name: make check
     runs-on: ${{ matrix.os }}
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 8
     steps:
       - name: Build and test wolfSSL
         uses: wolfSSL/actions-build-autotools-project@v1
@@ -40,6 +42,8 @@ jobs:
         ]
     name: make user_setting.h
     runs-on: ${{ matrix.os }}
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 6
     steps:
       - name: Build and test wolfSSL
         uses: wolfSSL/actions-build-autotools-project@v1
@@ -61,6 +65,8 @@ jobs:
         ]
     name: make user_setting.h (testwolfcrypt only)
     runs-on: ${{ matrix.os }}
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 4
     steps:
       - name: Build and test wolfSSL
         uses: wolfSSL/actions-build-autotools-project@v1
@@ -80,6 +86,8 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
     name: make user_setting.h (with sed)
     runs-on: ${{ matrix.os }}
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 8
     steps:
     - uses: actions/checkout@v3
     - if: ${{ matrix.os == 'macos-latest' }}
@@ -96,6 +104,8 @@ jobs:
   windows_build:
     name: Windows Build Test
     runs-on: windows-latest
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 6
     env:
       # Path to the solution file relative to the root of the project.
       SOLUTION_FILE_PATH: wolfssl64.sln

--- a/.github/workflows/stunnel.yml
+++ b/.github/workflows/stunnel.yml
@@ -8,6 +8,8 @@ jobs:
     name: Build wolfSSL
     # Just to keep it the same as the testing target
     runs-on: ubuntu-latest
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 4
     steps:
       - name: Build wolfSSL
         uses: wolfSSL/actions-build-autotools-project@v1
@@ -31,6 +33,8 @@ jobs:
         ref: [ 5.67 ]
     name: ${{ matrix.ref }}
     runs-on: ubuntu-latest
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 4
     needs: build_wolfssl
     steps:
       - name: Download lib

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -7,7 +7,8 @@ jobs:
   run_test:
     name: Build and run
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 15
     steps:
       - name: Install dependencies
         run: |

--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -274,13 +274,7 @@ static int Dtls13GetRnMask(WOLFSSL* ssl, const byte* ciphertext, byte* mask,
         if (c->chacha == NULL)
             return BAD_STATE_E;
 
-        /* assuming CIPHER[0..3] should be interpreted as little endian 32-bits
-           integer. The draft rfc isn't really clear on that. See sec 4.2.3 of
-           the draft. See also Section 2.3 of the Chacha RFC. */
-        XMEMCPY(&counter, ciphertext, sizeof(counter));
-#ifdef BIG_ENDIAN
-        counter = ByteReverseWord32(counter);
-#endif /* BIG_ENDIAN */
+        ato32le(ciphertext, &counter);
 
         ret = wc_Chacha_SetIV(c->chacha, &ciphertext[4], counter);
         if (ret != 0)

--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -274,6 +274,9 @@ static int Dtls13GetRnMask(WOLFSSL* ssl, const byte* ciphertext, byte* mask,
         if (c->chacha == NULL)
             return BAD_STATE_E;
 
+        /* assuming CIPHER[0..3] should be interpreted as little endian 32-bits
+           integer. The draft rfc isn't really clear on that. See sec 4.2.3 of
+           the draft. See also Section 2.3 of the Chacha RFC. */
         ato32le(ciphertext, &counter);
 
         ret = wc_Chacha_SetIV(c->chacha, &ciphertext[4], counter);

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -472,6 +472,15 @@ WC_MISC_STATIC WC_INLINE void ato32(const byte* c, word32* wc_u32)
                (word32)c[3];
 }
 
+/* convert opaque to 32 bit integer. Interpret as little endian. */
+WC_MISC_STATIC WC_INLINE void ato32le(const byte* c, word32* wc_u32)
+{
+    *wc_u32 =  (word32)c[0] |
+              ((word32)c[1] << 8) |
+              ((word32)c[2] << 16) |
+              ((word32)c[3] << 24);
+}
+
 
 WC_MISC_STATIC WC_INLINE word32 btoi(byte b)
 {

--- a/wolfssl/wolfcrypt/misc.h
+++ b/wolfssl/wolfcrypt/misc.h
@@ -102,12 +102,13 @@ void   ByteReverseWords64(word64* out, const word64* in, word32 byteCount);
 
 
 void c32to24(word32 in, word24 out);
-void c16toa(word16 u16, byte* c);
-void c32toa(word32 u32, byte* c);
-void c24to32(const word24 u24, word32* u32);
-void ato16(const byte* c, word16* u16);
-void ato24(const byte* c, word32* u24);
-void ato32(const byte* c, word32* u32);
+void c16toa(word16 wc_u16, byte* c);
+void c32toa(word32 wc_u32, byte* c);
+void c24to32(const word24 wc_u24, word32* wc_u32);
+void ato16(const byte* c, word16* wc_u16);
+void ato24(const byte* c, word32* wc_u24);
+void ato32(const byte* c, word32* wc_u32);
+void ato32le(const byte* c, word32* wc_u32);
 word32 btoi(byte b);
 
 WOLFSSL_LOCAL signed char HexCharToByte(char ch);


### PR DESCRIPTION
The issue was that BIG_ENDIAN is defined in endian.h (on linux). Our define is BIG_ENDIAN_ORDER.

Tested on a big endian Debian running on qemu-system-mips.

Fixes issue reported in https://github.com/wolfSSL/wolfssl/issues/6555.