### PR TITLE
Fix wolfSSL_SMIME_write_PKCS7 not removing NULL characters between sections.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -36134,7 +36134,7 @@ static int wolfSSL_BIO_to_MIME_crlf(WOLFSSL_BIO* in, WOLFSSL_BIO* out)
             }
 
             /* remove trailing null */
-            if (canonLine[canonLineLen] == '\0') {
+            if (canonLineLen >= 1 && canonLine[canonLineLen-1] == '\0') {
                 canonLineLen--;
             }
 


### PR DESCRIPTION
# Description

Fixes zd# 16073

# Testing

User provided test cases

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
