### PR TITLE
WOLFSSL_NO_HASH_RAW Hmac_UpdateFinal() properties for SM3

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -1052,7 +1052,7 @@ static int Hmac_UpdateFinal(Hmac* hmac, byte* digest, const byte* in,
                             word32 sz, byte* header)
 {
     byte       dummy[WC_MAX_BLOCK_SIZE] = {0};
-    int        ret;
+    int        ret = 0;
     word32     msgSz, blockSz, macSz, padSz, maxSz, realSz;
     word32     offset = 0;
     int        msgBlocks, blocks, blockBits;
@@ -1104,7 +1104,17 @@ static int Hmac_UpdateFinal(Hmac* hmac, byte* digest, const byte* in,
             break;
     #endif /* HAVE_BLAKE2 */
 
+    #ifdef WOLFSSL_SM3
+        case WC_SM3:
+            blockSz = WC_SM3_BLOCK_SIZE;
+            blockBits = 6;
+            macSz = WC_SM3_DIGEST_SIZE;
+            padSz = WC_SM3_BLOCK_SIZE - WC_SM3_PAD_SIZE + 1;
+            break;
+    #endif
+
         default:
+            WOLFSSL_MSG("ERROR: Hmac_UpdateFinal failed, no hmac->macType");
             return BAD_FUNC_ARG;
     }
 


### PR DESCRIPTION
# Description

Update the Hmac_UpdateFinal() properties needed when SM3 is enabled.

Fixes zd# n/a

Fixes https://github.com/wolfSSL/wolfssl/issues/6643

Thanks @JacobBarthelmeh for the SM3 help and suggestions.

# Testing

How did you test?

Tested with manual install of SM cipher suite with upcoming ESP32 example & Windows & Linux client.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
