### PR TITLE
TLS SM2, SM3, SM4-CBC: hash details missing for SM3

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -1095,6 +1095,15 @@ static int Hmac_UpdateFinal(Hmac* hmac, byte* digest, const byte* in,
             break;
     #endif /* WOLFSSL_SHA512 */
 
+    #ifdef WOLFSSL_SM3
+        case WC_SM3:
+            blockSz = WC_SM3_BLOCK_SIZE;
+            blockBits = 6;
+            macSz = WC_SM3_DIGEST_SIZE;
+            padSz = WC_SM3_BLOCK_SIZE - WC_SM3_PAD_SIZE + 1;
+            break;
+    #endif /* WOLFSSL_SM3 */
+
     #ifdef HAVE_BLAKE2
         case WC_HASH_TYPE_BLAKE2B:
             blockSz = BLAKE2B_BLOCKBYTES;


### PR DESCRIPTION
# Description

When WOLFSSL_NO_HASH_RAW and not Encrypt-then-MAC, Hmac_UpdateFinal is called.
Add in details of SM3 hash so handshake will work.

Fixes #6643

# Testing

./configure '--disable-shared' --enable-sm2 --enable-sm3 --enable-sm4-cbc --enable-sm4-gcm 'CFLAGS=-DWOLFSSL_NO_HASH_RAW' --disable-enc-then-mac

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
