### PR TITLE
Updates for Kerberos 5 1.21.1

### DIFF
--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -1,7 +1,6 @@
 name: curl Test
 
 on:
-  push:
   workflow_call:
 
 jobs:

--- a/.github/workflows/krb5.yml
+++ b/.github/workflows/krb5.yml
@@ -1,0 +1,84 @@
+name: Kerberos 5 Tests
+
+on:
+  workflow_call:
+  # TODO remove push when opening the PR
+  push:
+
+jobs:
+  build_wolfssl:
+    name: Build wolfSSL
+    # Just to keep it the same as the testing target
+    runs-on: ubuntu-latest
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 5
+    steps:
+      - name: Build wolfSSL
+        uses: wolfSSL/actions-build-autotools-project@v1
+        with:
+          path: wolfssl
+          configure: --enable-krb CFLAGS='-fsanitize=address'
+          install: true
+
+      - name: Upload built lib
+        uses: actions/upload-artifact@v3
+        with:
+          name: wolf-install-krb5
+          path: build-dir
+          retention-days: 1
+
+  krb5_check:
+    strategy:
+      fail-fast: false
+      matrix:
+        # List of releases to test
+        ref: [ 1.21.1 ]
+    name: ${{ matrix.ref }}
+    runs-on: ubuntu-latest
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 8
+    needs: build_wolfssl
+    steps:
+      - name: Download lib
+        uses: actions/download-artifact@v3
+        with:
+          name: wolf-install-krb5
+          path: build-dir
+
+      - name: Checkout OSP
+        uses: actions/checkout@v3
+        with:
+          # TODO revert repo to wolfssl on merge
+          repository: julek-wolfssl/osp
+          # TODO remove ref on merge
+          ref: krb5-1.21.1
+          path: osp
+
+      - name: Checkout krb5
+        uses: actions/checkout@v3
+        with:
+          repository: krb5/krb5
+          ref: krb5-${{ matrix.ref }}-final
+          path: krb5
+
+      - name: Apply patch
+        working-directory: ./krb5
+        run: |
+          patch -p1 < $GITHUB_WORKSPACE/osp/krb5/Patch-for-Kerberos-5-${{ matrix.ref }}.patch
+
+      - name: Build krb5
+        working-directory: ./krb5/src
+        run: |
+          autoreconf -ivf
+          # Using rpath because LD_LIBRARY_PATH is overwritten during testing
+          export WOLFSSL_CFLAGS="-I$GITHUB_WORKSPACE/build-dir/include -I$GITHUB_WORKSPACE/build-dir/include/wolfssl  -Wl,-rpath=$GITHUB_WORKSPACE/build-dir/lib"
+          export WOLFSSL_LIBS="-lwolfssl -L$GITHUB_WORKSPACE/build-dir/lib -Wl,-rpath=$GITHUB_WORKSPACE/build-dir/lib"
+          ./configure --with-crypto-impl=wolfssl --with-tls-impl=wolfssl --disable-pkinit \
+            CFLAGS='-fsanitize=address' LDFLAGS='-fsanitize=address'
+          CFLAGS='-fsanitize=address' LDFLAGS='-fsanitize=address' make -j
+
+      - name: Run tests
+        working-directory: ./krb5/src
+        run: |
+          CFLAGS='-fsanitize=address' LDFLAGS='-fsanitize=address' make -j check
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,8 @@ jobs:
         uses: ./.github/workflows/hitch.yml
     curl:
         uses: ./.github/workflows/curl.yml
+    krb5:
+        uses: ./.github/workflows/krb5.yml
 # TODO: Currently this test fails. Enable it once it becomes passing.        
 #    haproxy:
 #        uses: ./.github/workflows/haproxy.yml

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -1,7 +1,6 @@
 name: nginx Tests
 
 on:
-  push:
   workflow_call:
 
 jobs:

--- a/configure.ac
+++ b/configure.ac
@@ -3526,7 +3526,7 @@ AC_ARG_ENABLE([compkey],
     [ ENABLED_COMPKEY=no ]
     )
 
-if test "$ENABLED_WPAS" = "yes"
+if test "$ENABLED_WPAS" = "yes" || test "$ENABLED_OPENSSLALL" = "yes"
 then
     ENABLED_COMPKEY=yes
 fi

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -23747,12 +23747,14 @@ size_t wolfSSL_CRYPTO_cts128_encrypt(const unsigned char *in,
     if (lastBlkLen == 0)
         lastBlkLen = WOLFSSL_CTS128_BLOCK_SZ;
 
-    /* Encrypt data up to last block */
-    (*cbc)(in, out, len - lastBlkLen, key, iv, AES_ENCRYPT);
+    if (len - lastBlkLen != 0) {
+        /* Encrypt data up to last block */
+        (*cbc)(in, out, len - lastBlkLen, key, iv, AES_ENCRYPT);
 
-    /* Move to last block */
-    in += len - lastBlkLen;
-    out += len - lastBlkLen;
+        /* Move to last block */
+        in += len - lastBlkLen;
+        out += len - lastBlkLen;
+    }
 
     /* RFC2040: Pad Pn with zeros at the end to create P of length BB. */
     XMEMCPY(lastBlk, in, lastBlkLen);
@@ -23783,13 +23785,15 @@ size_t wolfSSL_CRYPTO_cts128_decrypt(const unsigned char *in,
     if (lastBlkLen == 0)
         lastBlkLen = WOLFSSL_CTS128_BLOCK_SZ;
 
-    /* Decrypt up to last two blocks */
-    (*cbc)(in, out, len - lastBlkLen - WOLFSSL_CTS128_BLOCK_SZ, key, iv,
-            AES_DECRYPTION);
+    if (len - lastBlkLen - WOLFSSL_CTS128_BLOCK_SZ != 0) {
+        /* Decrypt up to last two blocks */
+        (*cbc)(in, out, len - lastBlkLen - WOLFSSL_CTS128_BLOCK_SZ, key, iv,
+                AES_DECRYPTION);
 
-    /* Move to last two blocks */
-    in += len - lastBlkLen - WOLFSSL_CTS128_BLOCK_SZ;
-    out += len - lastBlkLen - WOLFSSL_CTS128_BLOCK_SZ;
+        /* Move to last two blocks */
+        in += len - lastBlkLen - WOLFSSL_CTS128_BLOCK_SZ;
+        out += len - lastBlkLen - WOLFSSL_CTS128_BLOCK_SZ;
+    }
 
     /* RFC2040: Decrypt Cn-1 to create Dn.
      * Use 0 buffer as IV to do straight decryption.

--- a/src/ssl_bn.c
+++ b/src/ssl_bn.c
@@ -1689,22 +1689,30 @@ int wolfSSL_BN_div(WOLFSSL_BIGNUM* dv, WOLFSSL_BIGNUM* rem,
     const WOLFSSL_BIGNUM* a, const WOLFSSL_BIGNUM* d, WOLFSSL_BN_CTX* ctx)
 {
     int ret = 1;
+    WOLFSSL_BIGNUM* res = dv;
 
     /* BN context not needed. */
     (void)ctx;
 
     WOLFSSL_ENTER("wolfSSL_BN_div");
 
+    if (BN_IS_NULL(res)) {
+        res = wolfSSL_BN_new();
+    }
+
     /* Validate parameters. */
-    if (BN_IS_NULL(dv) || BN_IS_NULL(rem) || BN_IS_NULL(a) || BN_IS_NULL(d)) {
+    if (BN_IS_NULL(res) || BN_IS_NULL(rem) || BN_IS_NULL(a) || BN_IS_NULL(d)) {
         ret = 0;
     }
 
     /* Have wolfCrypt perform operation with internal representations. */
     if ((ret == 1) && (mp_div((mp_int*)a->internal, (mp_int*)d->internal,
-            (mp_int*)dv->internal, (mp_int*)rem->internal) != MP_OKAY)) {
+            (mp_int*)res->internal, (mp_int*)rem->internal) != MP_OKAY)) {
         ret = 0;
     }
+
+    if (res != dv)
+        wolfSSL_BN_free(res);
 
     WOLFSSL_LEAVE("wolfSSL_BN_div", ret);
     return ret;

--- a/wolfssl/openssl/ec.h
+++ b/wolfssl/openssl/ec.h
@@ -265,6 +265,9 @@ WOLFSSL_API
 int wolfSSL_EC_METHOD_get_field_type(const WOLFSSL_EC_METHOD *meth);
 WOLFSSL_API
 WOLFSSL_EC_POINT *wolfSSL_EC_POINT_new(const WOLFSSL_EC_GROUP *group);
+WOLFSSL_LOCAL
+int ec_point_convert_to_affine(const WOLFSSL_EC_GROUP *group,
+    WOLFSSL_EC_POINT *point);
 WOLFSSL_API
 int wolfSSL_EC_POINT_get_affine_coordinates_GFp(const WOLFSSL_EC_GROUP *group,
                                                 const WOLFSSL_EC_POINT *p,

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -49,6 +49,7 @@
 #include <wolfssl/openssl/dsa.h>
 #include <wolfssl/openssl/ec.h>
 #include <wolfssl/openssl/dh.h>
+#include <wolfssl/openssl/opensslv.h>
 #include <wolfssl/openssl/compat_types.h>
 
 #include <wolfssl/wolfcrypt/aes.h>

--- a/wolfssl/openssl/opensslv.h
+++ b/wolfssl/openssl/opensslv.h
@@ -24,6 +24,8 @@
 #ifndef WOLFSSL_OPENSSLV_H_
 #define WOLFSSL_OPENSSLV_H_
 
+#include <wolfssl/wolfcrypt/settings.h>
+
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 
 /* api version compatibility */
@@ -37,7 +39,7 @@
       defined(WOLFSSL_RSYSLOG) || defined(WOLFSSL_KRB) || defined(HAVE_STUNNEL)
     /* For Apache httpd, Use 1.1.0 compatibility */
      #define OPENSSL_VERSION_NUMBER 0x10100003L
-#elif defined(WOLFSSL_QT) || defined(WOLFSSL_PYTHON)
+#elif defined(WOLFSSL_QT) || defined(WOLFSSL_PYTHON) || defined(WOLFSSL_KRB)
     /* For Qt and Python 3.8.5 compatibility */
      #define OPENSSL_VERSION_NUMBER 0x10101000L
 #elif defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_FFMPEG)


### PR DESCRIPTION
- wolfssl_ec_point_mul: fix parameters being passed into ec_mul2add
- Compile in compressed ecc key parsing for OPENSSLALL
- Improve debugging around compat layer ecc operations
- wolfSSL_BN_div: dv can be NULL
- Add spake like computation test
- Add CI krb5 testing
- Add timeouts to CI
