### PR TITLE
multi-byte code

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1859,7 +1859,9 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         { "wolfsentry-config", 1, 256 },
 #endif
         { "help", 0, 257 },
+#ifndef NO_MULTIBYTE_PRINT
         { "ヘルプ", 0, 258 },
+#endif
 #if defined(HAVE_PQC)
         { "pqc", 1, 259 },
 #endif

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -1399,7 +1399,9 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
         { "wolfsentry-config", 1, 256 },
 #endif
         { "help", 0, 257 },
+#ifndef NO_MULTIBYTE_PRINT
         { "ヘルプ", 0, 258 },
+#endif
 #if defined(HAVE_PQC)
         { "pqc", 1, 259 },
 #endif


### PR DESCRIPTION
# Description

It derives a compile error with various versions of Visual Studio.
Guard Multi-byte code by #ifndef NO_MULTBYTE_PRINT

Fixes zd#16496

# Testing

By local Visual Studio

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
