### PR TITLE
updated comment links for Espressif examples

### DIFF
--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/wifi_connect.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/wifi_connect.c
@@ -92,7 +92,7 @@ static void tls_smp_client_init(void)
 #else
         xTaskHandle _handle;
 #endif
-    /* http://esp32.info/docs/esp_idf/html/dd/d3c/group__xTaskCreate.html */
+    /* see https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/freertos_idf.html */
     ret = xTaskCreate(tls_smp_client_task,
                       TLS_SMP_CLIENT_TASK_NAME,
                       TLS_SMP_CLIENT_TASK_WORDS,
@@ -121,7 +121,7 @@ static esp_err_t wifi_event_handler(void *ctx, system_event_t *event)
         ESP_LOGI(TAG, "got ip:%s",
                  ip4addr_ntoa(&event->event_info.got_ip.ip_info.ip));
     #endif
-        /* http://esp32.info/docs/esp_idf/html/dd/d08/group__xEventGroupSetBits.html */
+        /* see https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/freertos_idf.html */
         xEventGroupSetBits(wifi_event_group, CONNECTED_BIT);
         break;
     case SYSTEM_EVENT_STA_DISCONNECTED:
@@ -217,7 +217,7 @@ void app_main(void)
     };
     /* WiFi station mode */
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA) );
-    /* Wifi Set the configuration of the ESP32 STA or AP */ 
+    /* Wifi Set the configuration of the ESP32 STA or AP */
     ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config) );
     /* Start Wifi */
     ESP_ERROR_CHECK(esp_wifi_start() );

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/wifi_connect.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/wifi_connect.c
@@ -92,7 +92,7 @@ static void tls_smp_server_init(void)
 #else
         xTaskHandle _handle;
 #endif
-    /* http://esp32.info/docs/esp_idf/html/dd/d3c/group__xTaskCreate.html */
+    /* see https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/freertos_idf.html */
     ret = xTaskCreate(tls_smp_server_task,
                       TLS_SMP_SERVER_TASK_NAME,
                       TLS_SMP_SERVER_TASK_WORDS,
@@ -121,7 +121,7 @@ static esp_err_t wifi_event_handler(void *ctx, system_event_t *event)
         ESP_LOGI(TAG, "got ip:%s",
                  ip4addr_ntoa(&event->event_info.got_ip.ip_info.ip));
 #endif
-        /* http://esp32.info/docs/esp_idf/html/dd/d08/group__xEventGroupSetBits.html */
+        /* see https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/freertos_idf.html */
         xEventGroupSetBits(wifi_event_group, CONNECTED_BIT);
         break;
     case SYSTEM_EVENT_STA_DISCONNECTED:


### PR DESCRIPTION
# Description

As noted in https://github.com/espressif/esp-idf/issues/11970 the `esp32.info` domain appears to no longer be valid.

This update changes only the comments of two ESP32 Examples.

Fixes zd# n/a

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
