### PR TITLE
20230805-clang-18-tidy-fixes

### DIFF
--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -3759,8 +3759,12 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
         resumeCount = 0;
 
         cnt++;
-        if (loops > 0 && --loops == 0) {
-            break;  /* out of while loop, done with normal and resume option */
+        if (loops > 0) {
+            if (--loops == 0) {
+                break;  /* out of while loop, done with normal and resume
+                         * option
+                         */
+            }
         }
     } /* while(1) */
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -11853,8 +11853,11 @@ int MatchDomainName(const char* pattern, int len, const char* str)
         if (p == '*') {
             char s;
 
-            while (--len > 0 &&
-                (p = (char)XTOLOWER((unsigned char)*pattern++)) == '*') {
+            while (--len > 0) {
+                p = (char)XTOLOWER((unsigned char)*pattern);
+                pattern++;
+                if (p != '*')
+                    break;
             }
 
             if (len == 0)

--- a/src/x509.c
+++ b/src/x509.c
@@ -1192,7 +1192,9 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
 
                 /* Get extension data and copy as ASN1_STRING */
                 tmpIdx = idx + length;
-                if ((tmpIdx >= (word32)sz) || (input[tmpIdx++] != ASN_OCTET_STRING)) {
+                if ((tmpIdx >= (word32)sz) ||
+                    (input[tmpIdx] != ASN_OCTET_STRING))
+                {
                     WOLFSSL_MSG("Error decoding unknown extension data");
                     wolfSSL_ASN1_OBJECT_free(ext->obj);
                     wolfSSL_X509_EXTENSION_free(ext);
@@ -1202,6 +1204,8 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
                 #endif
                     return NULL;
                 }
+
+                tmpIdx++;
 
                 if (GetLength(input, &tmpIdx, &length, sz) <= 0) {
                     WOLFSSL_MSG("Error: Invalid Input Length.");

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -17218,9 +17218,11 @@ static int MatchBaseName(int type, const char* name, int nameSz,
     }
 
     while (nameSz > 0) {
-        if (XTOLOWER((unsigned char)*name++) !=
-                                               XTOLOWER((unsigned char)*base++))
+        if (XTOLOWER((unsigned char)*name) !=
+                                               XTOLOWER((unsigned char)*base))
             return 0;
+        name++;
+        base++;
         nameSz--;
     }
 

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -3593,6 +3593,7 @@ char* mystrnstr(const char* s1, const char* s2, unsigned int n)
         /* TODO: maybe have to use tx_thread_delete? */
         free(thread.threadStack);
         thread.threadStack = NULL;
+        return 0;
     }
 
 #elif defined(WOLFSSL_ZEPHYR)
@@ -3680,7 +3681,7 @@ char* mystrnstr(const char* s1, const char* s2, unsigned int n)
         XMEMSET(&thread, 0, sizeof(thread));
         ret = wolfSSL_NewThread(&thread, cb, arg);
         if (ret == 0)
-            pthread_detach(thread);
+            ret = pthread_detach(thread);
         return ret;
     }
 #endif

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -2215,7 +2215,8 @@ static WC_INLINE void udp_accept(SOCKET_T* sockfd, SOCKET_T* clientfd,
     if (bind(*sockfd, (const struct sockaddr*)&addr, sizeof(addr)) != 0)
         err_sys_with_errno("tcp bind failed");
 
-    #if !defined(USE_WINDOWS_API) && !defined(WOLFSSL_TIRTOS)
+    #if !defined(USE_WINDOWS_API) && !defined(WOLFSSL_TIRTOS) && \
+           !defined(SINGLE_THREADED)
         if (port == 0) {
             socklen_t len = sizeof(addr);
             if (getsockname(*sockfd, (struct sockaddr*)&addr, &len) == 0) {
@@ -2226,6 +2227,8 @@ static WC_INLINE void udp_accept(SOCKET_T* sockfd, SOCKET_T* clientfd,
                 #endif
             }
         }
+    #else
+        (void)port;
     #endif
 
     if (args != NULL && args->signal != NULL) {


### PR DESCRIPTION
fixes for code warned by `clang-tidy`:18 and `cppcheck`-2.11:

`bugprone-inc-dec-in-conditions`: `examples/server/server.c`:`server_test()`, `src/internal.c`:`MatchDomainName()`, `src/x509.c`:`wolfSSL_X509_set_ext()`, `wolfcrypt/src/asn.c:MatchBaseName()`

`missingReturn`: `wolfcrypt/src/wc_port.c`:`mystrnstr()`

`bugprone-unused-return-value`: `wolfcrypt/src/wc_port.c`:`wolfSSL_NewThreadNoJoin()`

`clang-analyzer-deadcode.DeadStores`: `wolfssl/test.h`:`udp_accept()`

tested with `wolfssl-multi-test.sh ... super-quick-check all-c89-clang-tidy cppcheck-force-source clang-tidy-asn-template-sp-all-small-stack all-WOLFSSL_CALLBACKS-clang-tidy clang-tidy-Customer-CFG-7 clang-tidy-defaults clang-tidy-intmath clang-tidy-all-sp-all clang-tidy-all-intelasm clang-tidy-all-async-quic clang-tidy-fips-140-3-defaults clang-tidy-fips-140-3-all clang-tidy-fips-140-3-dev-defaults clang-tidy-fips-140-3-dev-defaults-no-sha-1 clang-tidy-fips-140-3-dev-all clang-tidy-fips-140-3-dev-all-crypto-no-sha-1 clang-tidy-all-crypto-no-sha-1`

Note, ignoring many new warnings for `bugprone-multi-level-implicit-pointer-conversion` -- this is noise that we'll suppress henceforth.
