### PR TITLE
Add bounds check to GetIntPositive

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -3283,6 +3283,10 @@ static int GetIntPositive(mp_int* mpi, const byte* input, word32* inOutIdx,
     if (ret != 0)
         return ret;
 
+    if (idx < 1 || idx >= maxIdx) {
+        return BUFFER_E;
+    }
+
     if (((input[idx] & 0x80) == 0x80) && (input[idx - 1] != 0x00))
         return MP_INIT_E;
 


### PR DESCRIPTION
# Description

Add bounds check to asn.c GetIntPositive() to ensure subsequent buffer access is within array bounds.

ZD 16549

# Testing

Fuzzing

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
