### PR TITLE
Fix storage of SendBuffered's return code in wolfSSL_connect_TLSv13.

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -11824,7 +11824,8 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
         && ssl->error != WC_PENDING_E
     #endif
     ) {
-        if ((ssl->error = SendBuffered(ssl)) == 0) {
+        ret = SendBuffered(ssl);
+        if (ret == 0) {
             if (ssl->fragOffset == 0 && !ssl->options.buildingMsg) {
                 if (advanceState) {
 #ifdef WOLFSSL_DTLS13


### PR DESCRIPTION
# Description

Fixes exactly the same issue as https://github.com/wolfSSL/wolfssl/issues/5325 but for tls 1.3 connect.

Fixes zd#

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
