### PR TITLE
Add Espressif ESP-IDF template project

### DIFF
--- a/IDE/Espressif/ESP-IDF/examples/template/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/template/CMakeLists.txt
@@ -1,0 +1,43 @@
+# The following lines of boilerplate have to be in your project's
+# CMakeLists in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.5)
+
+# set(WOLFSSL_ROOT "~/workspace/wolfssl-other-source")
+
+# This tag is used to include this file in the ESP Component Registry:
+# __ESP_COMPONENT_SOURCE__
+
+# Optional WOLFSSL_CMAKE_SYSTEM_NAME detection to find
+# USE_MY_PRIVATE_CONFIG path for my_private_config.h
+#
+if(WIN32)
+    # Windows-specific configuration here
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
+    message("Detected Windows")
+endif()
+if(CMAKE_HOST_UNIX)
+    message("Detected UNIX")
+endif()
+if(APPLE)
+    message("Detected APPLE")
+endif()
+if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
+    # Windows-specific configuration here
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
+    message("Detected WSL")
+endif()
+if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
+    # Windows-specific configuration here
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
+    message("Detected Linux")
+endif()
+if(APPLE)
+    # Windows-specific configuration here
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
+    message("Detected Apple")
+endif()
+# End optional WOLFSSL_CMAKE_SYSTEM_NAME
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+project(wolfssl_template)

--- a/IDE/Espressif/ESP-IDF/examples/template/README.md
+++ b/IDE/Espressif/ESP-IDF/examples/template/README.md
@@ -1,0 +1,64 @@
+# wolfSSL Template Project
+
+This is an example minimally viable wolfSSL template to get started with your own project.
+
+### Prerequisites
+
+It is assumed the [ESP-IDF environment](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/) has been installed.
+
+### Files Included
+
+- [main.c](./main/main.c) with a simple call to an Espressif library (`ESP_LOGI`) and a call to a wolfSSL library (`esp_ShowExtendedSystemInfo`) . 
+
+- See [components/wolfssl/include](./components/wolfssl/include/user_settings.h) directory to edit the wolfSSL `user_settings.h`.
+
+- Edit [main/CMakeLists.txt](./main/CMakeLists.txt) to add/remove source files.
+
+- The [components/wolfssl/CMakeLists.txt](./components/wolfssl/CMakeLists.txt) typically does not need to be changed.
+
+- Optional [VisualGDB Project](./VisualGDB/wolfssl_template_IDF_v5.1_ESP32.vgdbproj) for Visual Studio using ESP32 and ESP-IDF v5.1.
+
+- Edit the project [CMakeLists.txt](./CMakeLists.txt) to optionally point this project's wolfSSL component source code at a different directory:
+
+```
+set(WOLFSSL_ROOT "~/workspace/wolfssl-other-source")
+```
+
+
+## Getting Started:
+
+Here's an example using the command-line [idf.py](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-py.html).
+
+Edit your `WRK_IDF_PATH`to point to your ESP-IDF install directory.
+
+```
+WRK_IDF_PATH=/mnt/c/SysGCC/esp32/esp-idf/v5.1
+
+echo "Run export.sh from ${WRK_IDF_PATH}"
+. ${WRK_IDF_PATH}/export.sh
+
+# build the example:
+idf.py build
+
+# flash the code onto the serial device at /dev/ttyS19
+idf.py flash -p /dev/ttyS19 -b 115200
+
+# build, flash, and view UART output with one command:
+idf.py flash -p /dev/ttyS19 -b 115200 monitor
+```
+
+Press `Ctrl+]` to exit `idf.py monitor`. See [additional monitor keyboard commands](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-monitor.html).
+
+## Other Examples:
+
+For examples, see:
+
+- [TLS Client](../wolfssl_client/README.md)
+- [TLS Server](../wolfssl_server/README.md)
+- [Benchmark](../wolfssl_benchmark/README.md)
+- [Test](../wolfssl_test/README.md)
+- [wolfssl-examples](https://github.com/wolfSSL/wolfssl-examples/tree/master/ESP32)
+- [wolfssh-examples](https://github.com/wolfSSL/wolfssh-examples/tree/main/Espressif)
+
+
+

--- a/IDE/Espressif/ESP-IDF/examples/template/VisualGDB/wolfssl_template_IDF_v5.1_ESP32.vgdbproj
+++ b/IDE/Espressif/ESP-IDF/examples/template/VisualGDB/wolfssl_template_IDF_v5.1_ESP32.vgdbproj
@@ -1,0 +1,269 @@
+<?xml version="1.0"?>
+<VisualGDBProjectSettings2 xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Project xsi:type="com.visualgdb.project.external.esp-idf">
+    <CustomSourceDirectories>
+      <Directories />
+      <PathStyle>Unknown</PathStyle>
+    </CustomSourceDirectories>
+    <AutoProgramSPIFFSPartition>true</AutoProgramSPIFFSPartition>
+    <ProjectModeSettings>
+      <ProjectGUID>7bbd1486-d457-4e49-92ba-0cfc9d80849e</ProjectGUID>
+      <GroupSourcesByTypes>true</GroupSourcesByTypes>
+      <GroupSourcesByPaths>true</GroupSourcesByPaths>
+      <HeaderScanMode>SourceDirs</HeaderScanMode>
+    </ProjectModeSettings>
+  </Project>
+  <Build xsi:type="com.visualgdb.build.cmake">
+    <BuildLogMode xsi:nil="true" />
+    <ToolchainID>
+      <ID>com.visualgdb.xtensa-esp32-elf</ID>
+      <Version>
+        <GCC>12.2.0</GCC>
+        <GDB>12.1</GDB>
+        <Revision>1</Revision>
+      </Version>
+    </ToolchainID>
+    <RelativeSourceDirectory>..</RelativeSourceDirectory>
+    <ConfigurationType>DEBUG</ConfigurationType>
+    <BinaryDirectory>build/$(PlatformName)/$(ConfigurationName)</BinaryDirectory>
+    <MakeCommandTemplate>
+      <SkipWhenRunningCommandList>false</SkipWhenRunningCommandList>
+      <Command>$(ToolchainNinja)</Command>
+      <WorkingDirectory>$(BuildDir)</WorkingDirectory>
+      <BackgroundMode xsi:nil="true" />
+    </MakeCommandTemplate>
+    <CMakeCommand>
+      <SkipWhenRunningCommandList>false</SkipWhenRunningCommandList>
+      <Command>$(SYSPROGS_CMAKE_PATH)</Command>
+      <BackgroundMode xsi:nil="true" />
+    </CMakeCommand>
+    <UpdateSourcesInCMakeFile>true</UpdateSourcesInCMakeFile>
+    <ExportCompileCommands>false</ExportCompileCommands>
+    <DisableToolchainFile>false</DisableToolchainFile>
+    <CMakeMakefileType>Ninja</CMakeMakefileType>
+    <DeployAsRoot>false</DeployAsRoot>
+    <CMakeCleanMode>RemoveBuildDirectory</CMakeCleanMode>
+    <UseCCache>false</UseCCache>
+    <ProjectModeSettings>
+      <ProjectItemSettings>
+        <GroupSourcesByTypes>true</GroupSourcesByTypes>
+        <GroupSourcesByPaths>true</GroupSourcesByPaths>
+        <GroupTargetsByPaths>true</GroupTargetsByPaths>
+        <FollowCMakeSourceGroups>false</FollowCMakeSourceGroups>
+        <AutoRefreshProject>true</AutoRefreshProject>
+        <AlwaysConsiderOutdated>false</AlwaysConsiderOutdated>
+        <SortTargetsByName>true</SortTargetsByName>
+        <RedundantTargetMode>HideOuterProjectTargets</RedundantTargetMode>
+        <SortSourcesByName>true</SortSourcesByName>
+        <BuildAllTargetsInSubdir>false</BuildAllTargetsInSubdir>
+        <FoldSingleItemPathLevels>true</FoldSingleItemPathLevels>
+      </ProjectItemSettings>
+      <TargetSpecificSettings />
+      <SetLDLibraryPathFromDependentArtifacts>true</SetLDLibraryPathFromDependentArtifacts>
+      <ProjectGUID>eadcc9ab-72b3-4b51-a838-593e5d80ddf7</ProjectGUID>
+      <VirtualFolders />
+      <ConfigurationNameCase>Upper</ConfigurationNameCase>
+      <DefaultHeaderDiscoveryMode>HeaderDirectoryAndSubdirectories</DefaultHeaderDiscoveryMode>
+      <EnableFastUpToDateCheck>true</EnableFastUpToDateCheck>
+      <ESPIDFExtension>
+        <IDFCheckout>
+          <Version>release/v5.1</Version>
+          <Subdirectory>esp-idf/v5.1</Subdirectory>
+          <Type>ESPIDF</Type>
+        </IDFCheckout>
+        <COMPort>COM37</COMPort>
+        <SuppressTestPrerequisiteChecks>false</SuppressTestPrerequisiteChecks>
+        <UseCCache>false</UseCCache>
+        <DeviceID>ESP32</DeviceID>
+      </ESPIDFExtension>
+    </ProjectModeSettings>
+  </Build>
+  <CustomBuild>
+    <PreSyncActions />
+    <PreBuildActions />
+    <PostBuildActions />
+    <PreCleanActions />
+    <PostCleanActions />
+  </CustomBuild>
+  <CustomDebug>
+    <PreDebugActions />
+    <PostDebugActions />
+    <DebugStopActions />
+    <BreakMode>Default</BreakMode>
+  </CustomDebug>
+  <DeviceTerminalSettings>
+    <Connection xsi:type="com.sysprogs.terminal.connection.serial">
+      <ComPortName>COM37</ComPortName>
+      <AdvancedSettings>
+        <BaudRate>115200</BaudRate>
+        <DataBits>8</DataBits>
+        <Parity>None</Parity>
+        <StopBits>One</StopBits>
+        <FlowControl>None</FlowControl>
+      </AdvancedSettings>
+    </Connection>
+    <LastConnectionTime>0</LastConnectionTime>
+    <EchoTypedCharacters>false</EchoTypedCharacters>
+    <ClearContentsWhenReconnecting>false</ClearContentsWhenReconnecting>
+    <ReconnectAutomatically>false</ReconnectAutomatically>
+    <DisplayMode>ASCII</DisplayMode>
+    <Colors>
+      <Background>
+        <Alpha>255</Alpha>
+        <Red>0</Red>
+        <Green>0</Green>
+        <Blue>0</Blue>
+      </Background>
+      <Disconnected>
+        <Alpha>255</Alpha>
+        <Red>169</Red>
+        <Green>169</Green>
+        <Blue>169</Blue>
+      </Disconnected>
+      <Text>
+        <Alpha>255</Alpha>
+        <Red>211</Red>
+        <Green>211</Green>
+        <Blue>211</Blue>
+      </Text>
+      <Echo>
+        <Alpha>255</Alpha>
+        <Red>144</Red>
+        <Green>238</Green>
+        <Blue>144</Blue>
+      </Echo>
+      <Inactive>
+        <Alpha>255</Alpha>
+        <Red>169</Red>
+        <Green>169</Green>
+        <Blue>169</Blue>
+      </Inactive>
+    </Colors>
+    <HexSettings>
+      <MaximumBytesPerLine>16</MaximumBytesPerLine>
+      <ShowTextView>true</ShowTextView>
+      <BreaksAroundEcho>true</BreaksAroundEcho>
+      <AutoSend>true</AutoSend>
+      <SendAsHex>true</SendAsHex>
+      <TimeoutForAutoBreak>0</TimeoutForAutoBreak>
+    </HexSettings>
+    <LineEnding>LF</LineEnding>
+    <TreatLFAsCRLF>false</TreatLFAsCRLF>
+    <KeepOpenAfterExit>false</KeepOpenAfterExit>
+    <ShowAfterProgramming>false</ShowAfterProgramming>
+  </DeviceTerminalSettings>
+  <CustomShortcuts>
+    <Shortcuts />
+    <ShowMessageAfterExecuting>true</ShowMessageAfterExecuting>
+  </CustomShortcuts>
+  <UserDefinedVariables />
+  <ImportedPropertySheets />
+  <CodeSense>
+    <Enabled>Unknown</Enabled>
+    <ExtraSettings>
+      <HideErrorsInSystemHeaders>true</HideErrorsInSystemHeaders>
+      <SupportLightweightReferenceAnalysis>true</SupportLightweightReferenceAnalysis>
+      <CheckForClangFormatFiles>true</CheckForClangFormatFiles>
+      <FormattingEngine xsi:nil="true" />
+    </ExtraSettings>
+    <CodeAnalyzerSettings>
+      <Enabled>false</Enabled>
+    </CodeAnalyzerSettings>
+  </CodeSense>
+  <Configurations>
+    <VisualGDBConfiguration>
+      <Name>Debug</Name>
+      <BuildSettingsExtension xsi:type="com.visualgdb.build.external.esp-idf.cmake.extension" />
+    </VisualGDBConfiguration>
+    <VisualGDBConfiguration>
+      <Name>Release</Name>
+      <BuildSettingsExtension xsi:type="com.visualgdb.build.external.esp-idf.cmake.extension" />
+    </VisualGDBConfiguration>
+  </Configurations>
+  <ProgramArgumentsSuggestions />
+  <Debug xsi:type="com.visualgdb.debug.embedded">
+    <AdditionalStartupCommands />
+    <AdditionalGDBSettings>
+      <Features>
+        <DisableAutoDetection>false</DisableAutoDetection>
+        <UseFrameParameter>false</UseFrameParameter>
+        <SimpleValuesFlagSupported>false</SimpleValuesFlagSupported>
+        <ListLocalsSupported>false</ListLocalsSupported>
+        <ByteLevelMemoryCommandsAvailable>false</ByteLevelMemoryCommandsAvailable>
+        <ThreadInfoSupported>false</ThreadInfoSupported>
+        <PendingBreakpointsSupported>false</PendingBreakpointsSupported>
+        <SupportTargetCommand>false</SupportTargetCommand>
+        <ReliableBreakpointNotifications>false</ReliableBreakpointNotifications>
+      </Features>
+      <EnableSmartStepping>false</EnableSmartStepping>
+      <FilterSpuriousStoppedNotifications>false</FilterSpuriousStoppedNotifications>
+      <ForceSingleThreadedMode>false</ForceSingleThreadedMode>
+      <UseAppleExtensions>false</UseAppleExtensions>
+      <CanAcceptCommandsWhileRunning>false</CanAcceptCommandsWhileRunning>
+      <MakeLogFile>false</MakeLogFile>
+      <IgnoreModuleEventsWhileStepping>true</IgnoreModuleEventsWhileStepping>
+      <UseRelativePathsOnly>false</UseRelativePathsOnly>
+      <ExitAction>None</ExitAction>
+      <DisableDisassembly>false</DisableDisassembly>
+      <ExamineMemoryWithXCommand>false</ExamineMemoryWithXCommand>
+      <StepIntoNewInstanceEntry>app_main</StepIntoNewInstanceEntry>
+      <ExamineRegistersInRawFormat>true</ExamineRegistersInRawFormat>
+      <DisableSignals>false</DisableSignals>
+      <EnableAsyncExecutionMode>false</EnableAsyncExecutionMode>
+      <AsyncModeSupportsBreakpoints>true</AsyncModeSupportsBreakpoints>
+      <TemporaryBreakConsolidationTimeout>0</TemporaryBreakConsolidationTimeout>
+      <EnableNonStopMode>false</EnableNonStopMode>
+      <MaxBreakpointLimit>0</MaxBreakpointLimit>
+      <EnableVerboseMode>true</EnableVerboseMode>
+      <EnablePrettyPrinters>false</EnablePrettyPrinters>
+    </AdditionalGDBSettings>
+    <DebugMethod>
+      <ID>openocd</ID>
+      <Configuration xsi:type="com.visualgdb.edp.openocd.settings.esp32">
+        <CommandLine>-f interface/ftdi/tigard.cfg -c "adapter_khz 15000" -f target/esp32.cfg</CommandLine>
+        <ExtraParameters>
+          <Frequency xsi:nil="true" />
+          <BoostedFrequency xsi:nil="true" />
+          <ConnectUnderReset>false</ConnectUnderReset>
+        </ExtraParameters>
+        <LoadProgressGUIThreshold>131072</LoadProgressGUIThreshold>
+        <ProgramMode>Enabled</ProgramMode>
+        <StartupCommands>
+          <string>set remotetimeout 60</string>
+          <string>target remote :$$SYS:GDB_PORT$$</string>
+          <string>mon gdb_breakpoint_override hard</string>
+          <string>mon reset halt</string>
+          <string>load</string>
+        </StartupCommands>
+        <ProgramFLASHUsingExternalTool>false</ProgramFLASHUsingExternalTool>
+        <PreferredGDBPort>0</PreferredGDBPort>
+        <PreferredTelnetPort>0</PreferredTelnetPort>
+        <AlwaysPassSerialNumber>false</AlwaysPassSerialNumber>
+        <SelectedCoreIndex xsi:nil="true" />
+        <LiveMemoryTimeout>5000</LiveMemoryTimeout>
+        <SuggestionLogicRevision>1</SuggestionLogicRevision>
+        <CheckFLASHSize>true</CheckFLASHSize>
+        <FLASHSettings>
+          <Size>size2MB</Size>
+          <Frequency>freq40M</Frequency>
+          <Mode>DIO</Mode>
+        </FLASHSettings>
+        <PatchBootloader>true</PatchBootloader>
+      </Configuration>
+    </DebugMethod>
+    <AutoDetectRTOS>true</AutoDetectRTOS>
+    <SemihostingSupport>Disabled</SemihostingSupport>
+    <SemihostingPollingDelay>0</SemihostingPollingDelay>
+    <StepIntoEntryPoint>false</StepIntoEntryPoint>
+    <ReloadFirmwareOnReset>false</ReloadFirmwareOnReset>
+    <ValidateEndOfStackAddress>true</ValidateEndOfStackAddress>
+    <StopAtEntryPoint>false</StopAtEntryPoint>
+    <EnableVirtualHalts>false</EnableVirtualHalts>
+    <DynamicAnalysisSettings />
+    <EndOfStackSymbol>_estack</EndOfStackSymbol>
+    <TimestampProviderTicksPerSecond>0</TimestampProviderTicksPerSecond>
+    <KeepConsoleAfterExit>false</KeepConsoleAfterExit>
+    <UnusedStackFillPattern xsi:nil="true" />
+    <CheckInterfaceDrivers>true</CheckInterfaceDrivers>
+  </Debug>
+</VisualGDBProjectSettings2>

--- a/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/CMakeLists.txt
@@ -1,0 +1,488 @@
+#
+#  Copyright (C) 2006-2023 wolfSSL Inc.
+#
+#  This file is part of wolfSSL.
+#
+#  wolfSSL is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  wolfSSL is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+#
+# cmake for wolfssl Espressif projects
+#
+# See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html
+#
+
+cmake_minimum_required(VERSION 3.16)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
+set(CMAKE_CURRENT_SOURCE_DIR ".")
+set(COMPONENT_REQUIRES lwip) # we typically don't need lwip directly in wolfssl component
+
+# COMPONENT_NAME = wolfssl
+# The component name is the directory name. "No feature to change this".
+# See https://github.com/espressif/esp-idf/issues/8978#issuecomment-1129892685
+
+# set the root of wolfSSL in top-level project CMakelists.txt:
+#   set(WOLFSSL_ROOT  "C:/some path/with/spaces")
+#   set(WOLFSSL_ROOT  "c:/workspace/wolfssl-[username]")
+#   set(WOLFSSL_ROOT  "/mnt/c/some path/with/spaces")
+#   or use this logic to assign value from Environment Variable WOLFSSL_ROOT,
+#   or assume this is an example 7 subdirectories below:
+
+# We are typically in [root]/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl
+# The root of wolfSSL is 7 directories up from here:
+
+if(CMAKE_BUILD_EARLY_EXPANSION)
+    message(STATUS "wolfssl component CMAKE_BUILD_EARLY_EXPANSION:")
+    idf_component_register(
+                            REQUIRES "${COMPONENT_REQUIRES}"
+                            PRIV_REQUIRES esp_timer driver # this will typically only be needed for wolfSSL benchmark
+                           )
+
+else()
+    # not CMAKE_BUILD_EARLY_EXPANSION
+    message(STATUS "************************************************************************************************")
+    message(STATUS "wolfssl component config:")
+    message(STATUS "************************************************************************************************")
+
+    # Check to see if we're already in wolfssl, and only if WOLFSSL_ROOT not specified
+    if ("${WOLFSSL_ROOT}" STREQUAL "")
+        # wolfssl examples are 7 directories deep from wolfssl repo root
+        #                        1  2  3  4  5  6  7
+        set(THIS_RELATIVE_PATH "../../../../../../..")
+        get_filename_component(THIS_SEARCH_PATH  "${THIS_RELATIVE_PATH}" ABSOLUTE)
+        message(STATUS "Searching in path = ${THIS_SEARCH_PATH}")
+
+        if (EXISTS "${THIS_SEARCH_PATH}/wolfcrypt/src")
+            # we're already in wolfssl examples!
+            get_filename_component(WOLFSSL_ROOT  "${THIS_SEARCH_PATH}" ABSOLUTE)
+            message(STATUS "Using wolfSSL example with root ${WOLFSSL_ROOT}")
+        else()
+            # We're in some other repo such as wolfssh, so we'll search for an
+            # adjacent-level directory for wolfssl. (8 directories up, then down one)
+            #
+            # For example wolfSSL examples:
+            #   C:\workspace\wolfssl-gojimmypi\IDE\Espressif\ESP-IDF\examples\wolfssl_benchmark\components\wolfssl
+            #
+            # For example wolfSSH examples:
+            #   C:\workspace\wolfssh-gojimmypi\ide\Espressif\ESP-IDF\examples\wolfssh_benchmark\components\wolfssl
+            #
+            #                        1  2  3  4  5  6  7  8
+            set(THIS_RELATIVE_PATH "../../../../../../../..")
+            get_filename_component(THIS_SEARCH_PATH  "${THIS_RELATIVE_PATH}" ABSOLUTE)
+            message(STATUS "Searching next in path = ${THIS_SEARCH_PATH}")
+        endif()
+    endif()
+
+    # search other possible locations
+    if ("${WOLFSSL_ROOT}" STREQUAL "")
+        # there's not a hard-coded WOLFSSL_ROOT value above, so let's see if we can find it.
+        if( "$ENV{WOLFSSL_ROOT}" STREQUAL "" )
+            message(STATUS "Environment Variable WOLFSSL_ROOT not set. Will search common locations.")
+
+            message(STATUS "CMAKE_CURRENT_SOURCE_DIR = ${CMAKE_CURRENT_SOURCE_DIR}")
+            get_filename_component(THIS_DIR "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
+            message(STATUS "THIS_DIR = ${THIS_DIR}")
+
+            # find the user name to search for possible "wolfssl-username"
+            message(STATUS "USERNAME = $ENV{USERNAME}")
+            if(  "$ENV{USER}" STREQUAL "" ) # the bash user
+                if(  "$ENV{USERNAME}" STREQUAL "" ) # the Windows user
+                    message(STATUS "could not find USER or USERNAME")
+                else()
+                    # the bash user is not blank, so we'll use it.
+                    set(THIS_USER "$ENV{USERNAME}")
+                endif()
+            else()
+                # the bash user is not blank, so we'll use it.
+               set(THIS_USER "$ENV{USER}")
+            endif()
+            message(STATUS "THIS_USER = ${THIS_USER}")
+
+            # This same makefile is used for both the wolfssl component, and other
+            # components that may depend on wolfssl, such as wolfssh. Therefore
+            # we need to determine if this makefile is in the wolfssl repo, or
+            # some other repo.
+
+            if(  "{THIS_USER}" STREQUAL "" )
+                # This is highly unusual to not find a user name.
+                # In this case, we'll just search for a "wolfssl" directory:
+                message(STATUS "No username found!")
+                get_filename_component(WOLFSSL_ROOT  "${THIS_RELATIVE_PATH}/wolfssl" ABSOLUTE)
+            else()
+                # We found an environment USER name!
+                # The first place to look for wolfssl will be in a user-clone called "wolfssl-[username]"
+                message(STATUS "Using [THIS_USER = ${THIS_USER}] to see if there's a [relative path]/wolfssl-${THIS_USER} directory.")
+                get_filename_component(WOLFSSL_ROOT  "${THIS_RELATIVE_PATH}/wolfssl-${THIS_USER}" ABSOLUTE)
+
+                if( EXISTS "${WOLFSSL_ROOT}" )
+                    message(STATUS "Found wolfssl in user-suffix ${WOLFSSL_ROOT}")
+                else()
+                    # If there's not a user-clone called "wolfssl-[username]",
+                    # perhaps there's simply a git clone called "wolfssl"?
+                    message(STATUS "Did not find wolfssl-${THIS_USER}; continuing search...")
+                    get_filename_component(WOLFSSL_ROOT  "${THIS_RELATIVE_PATH}/wolfssl" ABSOLUTE)
+
+                    if( EXISTS "${WOLFSSL_ROOT}" )
+                        message(STATUS "Found wolfssl in standard ${WOLFSSL_ROOT}")
+                    else()
+                        # Things are looking pretty bleak. We'll likely not be able to compile.
+                        message(STATUS "Did not find wolfssl in ${WOLFSSL_ROOT}")
+                    endif()
+                endif()
+            endif()
+
+        else()
+            # there's an environment variable, so use it.
+            set(WOLFSSL_ROOT "$ENV{WOLFSSL_ROOT}")
+
+            if( EXISTS "${WOLFSSL_ROOT}" )
+                get_filename_component(WOLFSSL_ROOT  "$ENV{WOLFSSL_ROOT}" ABSOLUTE)
+                message(STATUS "Found WOLFSSL_ROOT via Environment Variable:")
+            else()
+                message(FATAL_ERROR "WOLFSSL_ROOT Environment Variable defined, but path not found:")
+                message(STATUS "$ENV{WOLFSSL_ROOT}")
+            endif()
+        endif()
+        # end of search for wolfssl component root
+    else()
+        # There's already a value assigned; we won't search for anything else.
+        message(STATUS "Found user-specified WOLFSSL_ROOT value.")
+    endif() # WOLFSSL_ROOT user defined
+
+    # After all the logic above, does our WOLFSSL_ROOT actually exist?
+    if( EXISTS "${WOLFSSL_ROOT}" )
+        message(STATUS "WOLFSSL_ROOT = ${WOLFSSL_ROOT}")
+    else()
+        # Abort. We need wolfssl _somewhere_.
+        message(FATAL_ERROR "Could not find wolfssl in ${WOLFSSL_ROOT}. Try setting environment variable or git clone.")
+    endif()
+
+
+    set(INCLUDE_PATH ${WOLFSSL_ROOT})
+
+    set(COMPONENT_SRCDIRS "\"${WOLFSSL_ROOT}/src/\""
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/src\""
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/src/port/Espressif\""
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/src/port/atmel\""
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/benchmark\"" # the benchmark application
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/test\"" # the test application
+       ) # COMPONENT_SRCDIRS
+    message(STATUS "This COMPONENT_SRCDIRS = ${COMPONENT_SRCDIRS}")
+
+    set(WOLFSSL_PROJECT_DIR "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
+
+    # Espressif may take several passes through this makefile. Check to see if we found IDF
+    string(COMPARE EQUAL "${PROJECT_SOURCE_DIR}" "" WOLFSSL_FOUND_IDF)
+
+    # get a list of all wolfcrypt assembly files; we'll exclude them as they don't target Xtensa
+    file(GLOB EXCLUDE_ASM *.S)
+    file(GLOB_RECURSE EXCLUDE_ASM ${CMAKE_SOURCE_DIR} "${WOLFSSL_ROOT}/wolfcrypt/src/*.S")
+
+    message(STATUS "IDF_PATH = $ENV{IDF_PATH}")
+    message(STATUS "PROJECT_SOURCE_DIR = ${PROJECT_SOURCE_DIR}")
+    message(STATUS "EXCLUDE_ASM = ${EXCLUDE_ASM}")
+
+    #
+    # Check to see if there's both a local copy and EDP-IDF copy of the wolfssl and/or wolfssh components.
+    #
+    if( EXISTS "${WOLFSSL_PROJECT_DIR}" AND EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
+        #
+        # wolfSSL found in both ESP-IDF and local project - needs to be resolved by user
+        #
+        message(STATUS "")
+        message(STATUS "**************************************************************************************")
+        message(STATUS "")
+        message(STATUS "Error: Found components/wolfssl in both local project and IDF_PATH")
+        message(STATUS "")
+        message(STATUS "To proceed: ")
+        message(STATUS "")
+        message(STATUS "Remove either the local project component: ${WOLFSSL_PROJECT_DIR} ")
+        message(STATUS "or the Espressif shared component installed at: $ENV{IDF_PATH}/components/wolfssl/ ")
+        message(STATUS "")
+        message(FATAL_ERROR "Please use wolfSSL in either local project or Espressif components, but not both.")
+        message(STATUS "")
+        message(STATUS "**************************************************************************************")
+        message(STATUS "")
+
+        # Optional: if you change the above FATAL_ERROR to STATUS you can warn at runtime with this macro definition:
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_MULTI_INSTALL_WARNING")
+
+    else()
+        if( EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
+            #
+            # wolfSSL found in ESP-IDF components and is assumed to be already configured in user_settings.h via setup.
+            #
+            message(STATUS "")
+            message(STATUS "Using components/wolfssl in IDF_PATH = $ENV{IDF_PATH}")
+            message(STATUS "")
+        else()
+            #
+            # wolfSSL is not an ESP-IDF component.
+            # We need to now determine if it is local and if so if it is part of the wolfSSL repo,
+            # or if  wolfSSL is simply installed as a local component.
+            #
+
+            if( EXISTS "${WOLFSSL_PROJECT_DIR}" )
+                #
+                # wolfSSL found in local project.
+                #
+                if( EXISTS "${WOLFSSL_PROJECT_DIR}/wolfcrypt/" )
+                    message(STATUS "")
+                    message(STATUS "Using installed project ./components/wolfssl in CMAKE_HOME_DIRECTORY = ${CMAKE_HOME_DIRECTORY}")
+                    message(STATUS "")
+                    #
+                    # Note we already checked above and confirmed there's not another wolfSSL installed in the ESP-IDF components.
+                    #
+                    # We won't do anything else here, as it will be assumed the original install completed successfully.
+                    #
+                else() # full wolfSSL not installed in local project
+                    #
+                    # This is the developer repo mode. wolfSSL will be assumed to be not installed to ESP-IDF nor local project
+                    # In this configuration, we are likely running a wolfSSL example found directly in the repo.
+                    #
+                    message(STATUS "")
+                    message(STATUS "Using developer repo ./components/wolfssl in CMAKE_HOME_DIRECTORY = ${CMAKE_HOME_DIRECTORY}")
+                    message(STATUS "")
+
+                    message(STATUS "************************************************************************************************")
+                    # When in developer mode, we are typically running wolfSSL examples such as benchmark or test directories.
+                    # However, the as-cloned or distributed wolfSSL does not have the ./include/ directory, so we'll add it as needed.
+                    #
+                    # first check if there's a [root]/include/user_settings.h
+                    if( EXISTS "${WOLFSSL_ROOT}/include/user_settings.h" )
+                        message(FATAL_ERROR "Found stray wolfSSL user_settings.h in "
+                                            "${WOLFSSL_ROOT}/include/user_settings.h "
+                                            " (please move it to ${WOLFSSL_PROJECT_DIR}/include/user_settings.h )")
+                    else()
+                        # we won't overwrite an existing user settings file, just note that we already have one:
+                        if( EXISTS "${WOLFSSL_PROJECT_DIR}/include/user_settings.h" )
+                            message(STATUS "Using existing wolfSSL user_settings.h in "
+                                           "${WOLFSSL_PROJECT_DIR}/include/user_settings.h")
+                        else()
+                            message(STATUS "Installing wolfSSL user_settings.h to "
+                                           "${WOLFSSL_PROJECT_DIR}/include/user_settings.h")
+                            file(COPY "${WOLFSSL_ROOT}/IDE/Espressif/ESP-IDF/user_settings.h"
+                            DESTINATION "${CMAKE_HOME_DIRECTORY}/wolfssl/include/")
+                        endif()
+                    endif() # user_settings.h
+
+                    # next check if there's a [root]/include/config.h
+                    if( EXISTS "${WOLFSSL_ROOT}/include/config.h" )
+                        message(FATAL_ERROR "Found stray wolfSSL config.h in        ${WOLFSSL_ROOT}/include/config.h (please move it to ${WOLFSSL_PROJECT_DIR}/include/config.h")
+                    else()
+                        # we won't overwrite an existing user settings file, just note that we already have one:
+                        if( EXISTS "${WOLFSSL_PROJECT_DIR}/include/config.h" )
+                            message(STATUS "Using existing wolfSSL config.h           ${WOLFSSL_PROJECT_DIR}/include/config.h")
+                        else()
+                            message(STATUS "Installing wolfSSL config.h to            ${WOLFSSL_PROJECT_DIR}/include/config.h")
+                            file(COPY   "${WOLFSSL_ROOT}/IDE/Espressif/ESP-IDF/dummy_config_h" DESTINATION "${WOLFSSL_PROJECT_DIR}/include/")
+                            file(RENAME "${WOLFSSL_PROJECT_DIR}/include/dummy_config_h" "${WOLFSSL_PROJECT_DIR}/include/config.h")
+                        endif() # Project config.h
+                    endif() # WOLFSSL_ROOT config.h
+                    message(STATUS "************************************************************************************************")
+                    message(STATUS "")
+                endif()
+
+            else()
+                # we did not find a ./components/wolfssl/include/ directory from this pass of cmake.
+                if($WOLFSSL_FOUND_IDF)
+                    message(STATUS "")
+                    message(STATUS "WARNING: wolfSSL not found.")
+                    message(STATUS "")
+                else()
+                    # probably needs to be re-parsed by Espressif
+                    message(STATUS "wolfSSL found IDF. Project Source:${PROJECT_SOURCE_DIR}")
+                endif() # else we have not found ESP-IDF yet
+            endif() # else not a local wolfSSL component
+
+        endif() #else not an ESP-IDF component
+    endif() # else not local copy and EDP-IDF wolfSSL
+
+
+    # RTOS_IDF_PATH is typically:
+    # "/Users/{username}/Desktop/esp-idf/components/freertos/include/freertos"
+    # depending on the environment, we may need to swap backslashes with forward slashes
+    string(REPLACE "\\" "/" RTOS_IDF_PATH "$ENV{IDF_PATH}/components/freertos/FreeRTOS-Kernel/include/freertos")
+
+    string(REPLACE "\\" "/" WOLFSSL_ROOT ${WOLFSSL_ROOT})
+
+    if(IS_DIRECTORY "${RTOS_IDF_PATH}")
+        message(STATUS "Found current RTOS path: ${RTOS_IDF_PATH}")
+    else()
+        # ESP-IDF prior version 4.4x has a different RTOS directory structure
+        string(REPLACE "\\" "/" RTOS_IDF_PATH "$ENV{IDF_PATH}/components/freertos/include/freertos")
+        if(IS_DIRECTORY "${RTOS_IDF_PATH}")
+            message(STATUS "Found legacy RTOS path: ${RTOS_IDF_PATH}")
+        else()
+            message(STATUS "Could not find RTOS path")
+        endif()
+    endif()
+
+
+    set(COMPONENT_ADD_INCLUDEDIRS
+        "./include" # this is the location of wolfssl user_settings.h
+        "\"${WOLFSSL_ROOT}/\""
+        "\"${WOLFSSL_ROOT}/wolfssl/\""
+        "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/\""
+        "\"${RTOS_IDF_PATH}/\""
+        )
+
+
+    if(IS_DIRECTORY ${IDF_PATH}/components/cryptoauthlib)
+        list(APPEND COMPONENT_ADD_INCLUDEDIRS "../cryptoauthlib/lib")
+    endif()
+
+    list(APPEND COMPONENT_ADD_INCLUDEDIRS "\"${WOLFSSL_ROOT}/wolfssl/\"")
+    list(APPEND COMPONENT_ADD_INCLUDEDIRS "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/\"")
+
+
+
+    set(COMPONENT_SRCEXCLUDE
+        "\"${WOLFSSL_ROOT}/src/bio.c\""
+        "\"${WOLFSSL_ROOT}/src/conf.c\""
+        "\"${WOLFSSL_ROOT}/src/misc.c\""
+        "\"${WOLFSSL_ROOT}/src/pk.c\""
+        "\"${WOLFSSL_ROOT}/src/ssl_asn1.c\""    # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/ssl_certman.c\"" # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/ssl_bn.c\""      # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/ssl_misc.c\""    # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/x509.c\""
+        "\"${WOLFSSL_ROOT}/src/x509_str.c\""
+        "\"${WOLFSSL_ROOT}/wolfcrypt/src/evp.c\""
+        "\"${WOLFSSL_ROOT}/wolfcrypt/src/misc.c\""
+        "\"${EXCLUDE_ASM}\""
+        )
+
+    spaces2list(COMPONENT_REQUIRES)
+
+    separate_arguments(COMPONENT_SRCDIRS NATIVE_COMMAND "${COMPONENT_SRCDIRS}")
+    separate_arguments(COMPONENT_SRCEXCLUDE NATIVE_COMMAND "${COMPONENT_SRCEXCLUDE}")
+    separate_arguments(COMPONENT_ADD_INCLUDEDIRS NATIVE_COMMAND "${COMPONENT_ADD_INCLUDEDIRS}")
+
+    #
+    # See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#example-component-requirements
+    #
+    message(STATUS "COMPONENT_SRCDIRS = ${COMPONENT_SRCDIRS}")
+    message(STATUS "COMPONENT_ADD_INCLUDEDIRS = ${COMPONENT_ADD_INCLUDEDIRS}")
+    message(STATUS "COMPONENT_REQUIRES = ${COMPONENT_REQUIRES}")
+    message(STATUS "COMPONENT_SRCEXCLUDE = ${COMPONENT_SRCEXCLUDE}")
+
+    #
+    # see https://docs.espressif.com/projects/esp-idf/en/stable/esp32/migration-guides/release-5.x/build-system.html?highlight=space%20path
+    #
+    set(EXTRA_COMPONENT_DIRS "${COMPONENT_SRCDIRS}")
+    idf_component_register(
+                            SRC_DIRS "${COMPONENT_SRCDIRS}"
+                            INCLUDE_DIRS "${COMPONENT_ADD_INCLUDEDIRS}"
+                            REQUIRES "${COMPONENT_REQUIRES}"
+                            EXCLUDE_SRCS "${COMPONENT_SRCEXCLUDE}"
+                            PRIV_REQUIRES esp_timer driver # this will typically only be needed for wolfSSL benchmark
+                           )
+    # some optional diagnostics
+    if (1)
+        get_cmake_property(_variableNames VARIABLES)
+        list (SORT _variableNames)
+        message(STATUS "")
+        message(STATUS "ALL VARIABLES BEGIN")
+        message(STATUS "")
+        foreach (_variableName ${_variableNames})
+            message(STATUS "${_variableName}=${${_variableName}}")
+        endforeach()
+        message(STATUS "")
+        message(STATUS "ALL VARIABLES END")
+        message(STATUS "")
+    endif()
+
+    # target_sources(wolfssl PRIVATE  "\"${WOLFSSL_ROOT}/wolfssl/\""  "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt\"")
+endif() # CMAKE_BUILD_EARLY_EXPANSION
+
+
+
+# check to see if there's both a local copy and EDP-IDF copy of the wolfssl components
+if( EXISTS "${WOLFSSL_PROJECT_DIR}" AND EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
+    message(STATUS "")
+    message(STATUS "")
+    message(STATUS "********************************************************************")
+    message(STATUS "WARNING: Found components/wolfssl in both local project and IDF_PATH")
+    message(STATUS "********************************************************************")
+    message(STATUS "")
+endif()
+# end multiple component check
+
+
+#
+# LIBWOLFSSL_SAVE_INFO(VAR_OUPUT THIS_VAR VAR_RESULT)
+#
+# Save the THIS_VAR as a string in a macro called VAR_OUPUT
+#
+# VAR_OUPUT:  the name of the macro to define
+# THIS_VAR:   the OUTPUT_VARIABLE result from a execute_process()
+# VAR_RESULT: the RESULT_VARIABLE from a execute_process(); "0" if successful.
+#
+function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
+    # is the RESULT_VARIABLE output value 0? If so, IS_VALID_VALUE is true.
+    string(COMPARE EQUAL "${VAR_RESULT}" "0" IS_VALID_VALUE)
+
+    # if we had a successful operation, save the THIS_VAR in VAR_OUPUT
+    if(${IS_VALID_VALUE})
+        # strip newline chars in THIS_VAR parameter and save in VAR_VALUE
+        string(REPLACE "\n" ""  VAR_VALUE  ${THIS_VAR})
+
+        # we'll could percolate the value to the parent for possible later use
+        # set(${VAR_OUPUT} ${VAR_VALUE} PARENT_SCOPE)
+
+        # but we're only using it here in this function
+        set(${VAR_OUPUT} ${VAR_VALUE})
+
+        # we'll print what we found to the console
+        message(STATUS "Found ${VAR_OUPUT}=${VAR_VALUE}")
+
+        # the interesting part is defining the VAR_OUPUT name a value to use in the app
+        add_definitions(-D${VAR_OUPUT}=\"${VAR_VALUE}\")
+    else()
+        # if we get here, check the execute_process command and parameters.
+        message(STATUS "LIBWOLFSSL_SAVE_INFO encountered a non-zero VAR_RESULT")
+        set(${VAR_OUPUT} "Unknown")
+    endif()
+endfunction() # LIBWOLFSSL_SAVE_INFO
+
+# create some programmatic #define values that will be used by ShowExtendedSystemInfo().
+# see wolfcrypt\src\port\Espressif\esp32_utl.c
+if(NOT CMAKE_BUILD_EARLY_EXPANSION)
+    set (git_cmd "git")
+    message(STATUS "Adding macro definitions:")
+
+    # LIBWOLFSSL_VERSION_GIT_ORIGIN: git config --get remote.origin.url
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "config" "--get" "remote.origin.url" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_ORIGIN "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_BRANCH: git rev-parse --abbrev-ref HEAD
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "--abbrev-ref" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_BRANCH "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_HASH: git rev-parse HEAD
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_SHORT_HASH: git rev-parse --short HEAD
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "--short" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_SHORT_HASH "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_HASH_DATE git show --no-patch --no-notes --pretty=\'\%cd\'
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "show" "--no-patch" "--no-notes" "--pretty=\'\%cd\'" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES  )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH_DATE "${TMP_OUT}" "${TMP_RES}")
+
+    message(STATUS "************************************************************************************************")
+    message(STATUS "wolfssl component config complete!")
+    message(STATUS "************************************************************************************************")
+endif()

--- a/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/include/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/include/user_settings.h
@@ -1,0 +1,197 @@
+/* user_settings.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#include <sdkconfig.h> /* essential to chip set detection */
+
+#undef WOLFSSL_ESPIDF
+#undef WOLFSSL_ESP32
+#undef WOLFSSL_ESPWROOM32SE
+#undef WOLFSSL_ESP32
+#undef WOLFSSL_ESP8266
+
+/* The Espressif sdkconfig will have chipset info.
+**
+** Possible values:
+**
+**   CONFIG_IDF_TARGET_ESP32
+**   CONFIG_IDF_TARGET_ESP32S2
+**   CONFIG_IDF_TARGET_ESP32S3
+**   CONFIG_IDF_TARGET_ESP32C3
+**   CONFIG_IDF_TARGET_ESP32C6
+*/
+
+#define WOLFSSL_ESPIDF
+
+/*
+ * choose ONE of these Espressif chips to define:
+ *
+ * WOLFSSL_ESP32
+ * WOLFSSL_ESPWROOM32SE
+ * WOLFSSL_ESP8266
+ */
+
+#define WOLFSSL_ESP32
+
+/* optionally turn off SHA512/224 SHA512/256 */
+/* #define WOLFSSL_NOSHA512_224 */
+/* #define WOLFSSL_NOSHA512_256 */
+
+#define BENCH_EMBEDDED
+#define USE_CERT_BUFFERS_2048
+
+/* TLS 1.3                                 */
+#define WOLFSSL_TLS13
+#define HAVE_TLS_EXTENSIONS
+#define WC_RSA_PSS
+#define HAVE_HKDF
+#define HAVE_AEAD
+#define HAVE_SUPPORTED_CURVES
+
+#define WOLFSSL_BENCHMARK_FIXED_UNITS_KB
+
+/* when you want to use SINGLE THREAD */
+#define SINGLE_THREADED
+
+#define NO_FILESYSTEM
+
+#define HAVE_AESGCM
+
+#define WOLFSSL_RIPEMD
+/* when you want to use SHA224 */
+#define WOLFSSL_SHA224
+
+/* when you want to use SHA384 */
+#define WOLFSSL_SHA3
+
+#define WOLFSSL_SHA384
+#define WOLFSSL_SHA512
+#define HAVE_ECC
+#define HAVE_CURVE25519
+#define CURVE25519_SMALL
+#define HAVE_ED25519
+
+/* when you want to use pkcs7 */
+/* #define HAVE_PKCS7 */
+
+#if defined(HAVE_PKCS7)
+    #define HAVE_AES_KEYWRAP
+    #define HAVE_X963_KDF
+    #define WOLFSSL_AES_DIRECT
+#endif
+
+/* when you want to use aes counter mode */
+/* #define WOLFSSL_AES_DIRECT */
+/* #define WOLFSSL_AES_COUNTER */
+
+/* esp32-wroom-32se specific definition */
+#if defined(WOLFSSL_ESPWROOM32SE)
+    #define WOLFSSL_ATECC508A
+    #define HAVE_PK_CALLBACKS
+    /* when you want to use a custom slot allocation for ATECC608A */
+    /* unless your configuration is unusual, you can use default   */
+    /* implementation.                                             */
+    /* #define CUSTOM_SLOT_ALLOCATION                              */
+#endif
+
+/* rsa primitive specific definition */
+#if defined(WOLFSSL_ESP32) || defined(WOLFSSL_ESPWROOM32SE)
+    /* Define USE_FAST_MATH and SMALL_STACK                        */
+    #define ESP32_USE_RSA_PRIMITIVE
+    /* threshold for performance adjustment for HW primitive use   */
+    /* X bits of G^X mod P greater than                            */
+    #define EPS_RSA_EXPT_XBTIS           32
+    /* X and Y of X * Y mod P greater than                         */
+    #define ESP_RSA_MULM_BITS            9
+#endif
+#define RSA_LOW_MEM
+
+/* debug options */
+/* #define DEBUG_WOLFSSL */
+/* #define WOLFSSL_ESP32_CRYPT_DEBUG */
+/* #define WOLFSSL_ATECC508A_DEBUG          */
+
+/* date/time                               */
+/* if it cannot adjust time in the device, */
+/* enable macro below                      */
+/* #define NO_ASN_TIME */
+/* #define XTIME time */
+
+/* adjust wait-timeout count if you see timeout in RSA HW acceleration */
+#define ESP_RSA_TIMEOUT_CNT    0x249F00
+
+#define HASH_SIZE_LIMIT /* for test.c */
+
+#define USE_FAST_MATH
+
+/* optionally use SP_MATH */
+/* #define SP_MATH */
+
+#define WOLFSSL_SMALL_STACK
+
+#define HAVE_VERSION_EXTENDED_INFO
+#define HAVE_WC_INTROSPECTION
+
+/* allows for all version info, even that suppressed with introspection */
+#define ALLOW_BINARY_MISMATCH_INTROSPECTION
+
+/* Default is HW enabled unless turned off.
+** Uncomment these lines for SW: */
+#if defined(CONFIG_IDF_TARGET_ESP32)
+    /* #define NO_ESP32_CRYPT                 */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_HASH    */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_AES     */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI */
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+    /* #define NO_ESP32_CRYPT                 */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_HASH    */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_AES     */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI */
+#elif defined(CONFIG_IDF_TARGET_ESP32C2)
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#elif defined(CONFIG_IDF_TARGET_ESP32C6)
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#elif defined(CONFIG_IDF_TARGET_ESP32H2)
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#else
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#endif

--- a/IDE/Espressif/ESP-IDF/examples/template/main/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/template/main/CMakeLists.txt
@@ -1,0 +1,77 @@
+# This tag is used to include this file in the ESP Component Registry:
+# __ESP_COMPONENT_SOURCE__
+
+#
+# wolfssl client test
+#
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
+
+set (git_cmd "git")
+
+if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/" AND EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
+    #
+    # wolfSSL found in both ESP-IDF and local project - needs to be resolved by user
+    #
+    message(STATUS "")
+    message(STATUS "WARNING: Found components/wolfssl in both local project and IDF_PATH")
+    message(STATUS "")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_MULTI_INSTALL_WARNING")
+endif()
+
+## register_component()
+idf_component_register(SRCS main.c
+                       INCLUDE_DIRS "." "./include")
+#
+
+#
+# LIBWOLFSSL_SAVE_INFO(VAR_OUPUT THIS_VAR VAR_RESULT)
+#
+# Save the THIS_VAR as a string in a macro called VAR_OUPUT
+#
+# VAR_OUPUT:  the name of the macro to define
+# THIS_VAR:   the OUTPUT_VARIABLE result from a execute_process()
+# VAR_RESULT: the RESULT_VARIABLE from a execute_process(); "0" if successful.
+#
+function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
+    # is the RESULT_VARIABLE output value 0? If so, IS_VALID_VALUE is true.
+    string(COMPARE EQUAL "${VAR_RESULT}" "0" IS_VALID_VALUE)
+
+    # if we had a successful operation, save the THIS_VAR in VAR_OUPUT
+    if(${IS_VALID_VALUE})
+        # strip newline chars in THIS_VAR parameter and save in VAR_VALUE
+        string(REPLACE "\n" ""  VAR_VALUE  ${THIS_VAR})
+
+        # we'll could percolate the value to the parent for possible later use
+        # set(${VAR_OUPUT} ${VAR_VALUE} PARENT_SCOPE)
+
+        # but we're only using it here in this function
+        set(${VAR_OUPUT} ${VAR_VALUE})
+
+        # we'll print what we found to the console
+        message(STATUS "Found ${VAR_OUPUT}=${VAR_VALUE}")
+
+        # the interesting part is defining the VAR_OUPUT name a value to use in the app
+        add_definitions(-D${VAR_OUPUT}=\"${VAR_VALUE}\")
+    else()
+        # if we get here, check the execute_process command and parameters.
+        message(STATUS "LIBWOLFSSL_SAVE_INFO encountered a non-zero VAR_RESULT")
+        set(${VAR_OUPUT} "Unknown")
+    endif()
+endfunction() # LIBWOLFSSL_SAVE_INFO
+
+if(NOT CMAKE_BUILD_EARLY_EXPANSION)
+    # LIBWOLFSSL_VERSION_GIT_HASH
+    execute_process(COMMAND ${git_cmd} "rev-parse" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_SHORT_HASH
+    execute_process(COMMAND ${git_cmd} "rev-parse" "--short" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_SHORT_HASH "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_HASH_DATE
+    execute_process(COMMAND ${git_cmd} "show" "--no-patch" "--no-notes" "--pretty=\'\%cd\'" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES  )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH_DATE "${TMP_OUT}" "${TMP_RES}")
+endif()
+
+message(STATUS "")
+

--- a/IDE/Espressif/ESP-IDF/examples/template/main/include/main.h
+++ b/IDE/Espressif/ESP-IDF/examples/template/main/include/main.h
@@ -1,0 +1,24 @@
+/* template main.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+#ifndef _MAIN_H_
+#define _MAIN_H_
+
+#endif

--- a/IDE/Espressif/ESP-IDF/examples/template/main/main.c
+++ b/IDE/Espressif/ESP-IDF/examples/template/main/main.c
@@ -1,0 +1,43 @@
+/* main.c
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* Espressif */
+#include <esp_log.h>
+
+/* wolfSSL  */
+#include <wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h>
+
+/* project */
+#include "main.h"
+
+static const char* const TAG = "My Project";
+
+void app_main(void)
+{
+    ESP_LOGI(TAG, "Hello wolfSSL!");
+
+#ifdef HAVE_VERSION_EXTENDED_INFO
+    esp_ShowExtendedSystemInfo();
+#endif
+
+    ESP_LOGI(TAG, "\n\nDone!"
+                  "If running from idf.py monitor, press twice: Ctrl+]");
+}

--- a/IDE/Espressif/include.am
+++ b/IDE/Espressif/include.am
@@ -22,7 +22,6 @@ EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/CMakeLists.txt
 EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/README.md
 EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/VisualGDB
 EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/CMakeLists.txt
-EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/include/config.h
 EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/include/user_settings.h
 EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/main/CMakeLists.txt
 EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/main/include

--- a/IDE/Espressif/include.am
+++ b/IDE/Espressif/include.am
@@ -17,6 +17,19 @@ EXTRA_DIST+= IDE/Espressif/ESP-IDF/setup_win.bat
 EXTRA_DIST+= IDE/Espressif/ESP-IDF/UPDATE.md
 EXTRA_DIST+= IDE/Espressif/ESP-IDF/user_settings.h
 
+# Template
+EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/CMakeLists.txt
+EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/README.md
+EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/VisualGDB
+EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/CMakeLists.txt
+EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/include/config.h
+EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/include/user_settings.h
+EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/main/CMakeLists.txt
+EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/main/include
+EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/main/main.c
+EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/main/include/main.h
+EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/VisualGDB/wolfssl_template_IDF_v5.1_ESP32.vgdbproj
+
 # Benchmark
 EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/CMakeLists.txt
 EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/main


### PR DESCRIPTION
# Description

Adds a new, minimally viable wolfSSL example project template for the Espressif ESP-IDF using an ESP32.

I'd like to include this in my upcoming [Getting Started with wolfSSL on the Espressif ESP32](https://us02web.zoom.us/webinar/register/2616747721343/WN_8KamUT5OTXunGmxxQ_ZmsQ#/registration) webinar.

Fixes zd# n/a

# Testing

How did you test? 

See included `README.md`  

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation


See https://github.com/wolfSSL/wolfssl/issues/6234 for a roadmap of Espressif updates.