### PR TITLE
Enable math API's for wolfTPM

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5672,6 +5672,9 @@ then
         ENABLED_AESCFB="yes"
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_AES_CFB"
     fi
+
+    # Requires public mp_
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_PUBLIC_MP"
 fi
 
 if test "x$ENABLED_SMIME" = "xyes"


### PR DESCRIPTION
# Description

New TPM ECC encrypt needs access to the mp_ math functions.
https://github.com/wolfSSL/wolfTPM/pull/276

# Testing

`./configure --enable-wolftpm`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
