### PR TITLE
Fix define guards for X509 api tests.

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -49717,11 +49717,11 @@ static int test_wolfSSL_SMIME_write_PKCS7(void)
 static int test_X509_STORE_No_SSL_CTX(void)
 {
     EXPECT_DECLS;
-#if defined(OPENSSL_ALL) && !defined(NO_FILESYSTEM) && \
-    !defined(NO_WOLFSSL_DIR) && defined(HAVE_CRL) && \
+#if defined(OPENSSL_ALL) && defined(WOLFSSL_CERT_GEN) && \
     (defined(WOLFSSL_CERT_REQ) || defined(WOLFSSL_CERT_EXT)) && \
+    !defined(NO_FILESYSTEM) && !defined(NO_WOLFSSL_DIR)  && \
     (defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)) && \
-    !defined(NO_RSA)
+    defined(HAVE_CRL) && !defined(NO_RSA)
 
     X509_STORE *     store = NULL;
     X509_STORE_CTX * storeCtx = NULL;
@@ -49786,11 +49786,11 @@ static int test_X509_STORE_No_SSL_CTX(void)
 static int test_X509_LOOKUP_add_dir(void)
 {
     EXPECT_DECLS;
-#if defined(OPENSSL_ALL) && !defined(NO_FILESYSTEM) && \
-    !defined(NO_WOLFSSL_DIR) && defined(HAVE_CRL) && \
+#if defined(OPENSSL_ALL) && defined(WOLFSSL_CERT_GEN) && \
     (defined(WOLFSSL_CERT_REQ) || defined(WOLFSSL_CERT_EXT)) && \
+    !defined(NO_FILESYSTEM) && !defined(NO_WOLFSSL_DIR)  && \
     (defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)) && \
-    !defined(NO_RSA)
+    defined(HAVE_CRL) && !defined(NO_RSA)
 
     X509_STORE *     store = NULL;
     X509_STORE_CTX * storeCtx = NULL;


### PR DESCRIPTION
# Description

Fix define guards for `test_X509_STORE_No_SSL_CTX()` and `test_X509_LOOKUP_add_dir()` in `tests/api.c` to be consistent with the relevant  code in `src/crl.c`.

The relevant code around `LoadCertByIssuer()` in `crl.c` is guarded by these CERT_X defines

```
defined(WOLFSSL_CERT_GEN) && \
    (defined(WOLFSSL_CERT_REQ) || defined(WOLFSSL_CERT_EXT))
```

but the two API tests were guarded only by

```
(defined(WOLFSSL_CERT_REQ) || defined(WOLFSSL_CERT_EXT))
```

This caused failures if certext was enabled without certgen.

# Testing

```
#!/bin/bash
cd src

make clean || exit 1

./configure \
  --enable-tls13 \
  --enable-ocsp \
  --enable-dtls \
  --enable-sni \
  --enable-blake2 \
  --enable-blake2s \
  --enable-curve25519 \
  --enable-session-ticket \
  --enable-nullcipher \
  --enable-crl \
  --enable-ed25519 \
  --enable-psk \
  --enable-earlydata \
  --enable-postauth \
  --enable-hrrcookie \
  --enable-opensslextra \
  --enable-certext \
  --enable-tlsx \
  --enable-asn=original \
  --enable-opensslall \
  || exit 1

make || exit 1

./scripts/unit.test -564 -565
```