### PR TITLE
Tiny cleanup to benchmark print usage.

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -10297,6 +10297,7 @@ static void Usage(void)
 
     printf("benchmark\n");
     printf("%s", bench_Usage_msg1[lng_index][e++]);    /* option -? */
+    printf("%s", bench_Usage_msg1[lng_index][e++]);    /* English / Japanese */
     printf("%s", bench_Usage_msg1[lng_index][e++]);    /* option -csv */
     printf("%s", bench_Usage_msg1[lng_index][e++]);    /* option -base10 */
 #if defined(HAVE_AESGCM) || defined(HAVE_AESCCM)


### PR DESCRIPTION
# Description

Tiny cleanup to wolfcrypt benchmark print usage. The `-<alg>`  was being printed a line too late. This was happening for both English and Japanese.

# Testing

Before:
```
$./wolfcrypt/benchmark/benchmark -? 0
------------------------------------------------------------------------------
 wolfSSL version 5.6.3
------------------------------------------------------------------------------
benchmark
-? <num>    Help, print this usage
            0: English, 1: Japanese
-csv        Print terminal output in csv format
-base10     Display bytes as power of 10 (eg 1 kB = 1000 Bytes)
-no_aad     No additional authentication data passed.
...
-ecc-all    Bench all enabled ECC curves.
              -cipher -aes-cbc -aes-gcm -aes-ecb -aes-xts -aes-cfb -aes-ofb -aes-ctr
              -aes-ccm -aes-siv -camellia -arc4 -chacha20 -chacha20-poly1305 -des
              -digest -md5 -poly1305 -sha -sha2 -sha224 -sha256 -sha384 -sha512 -sha3
              -sha3-224 -sha3-256 -sha3-384 -sha3-512 -shake -shake128 -shake256 -ripemd
              -blake2b -blake2s -mac -cmac -hmac -hmac-md5 -hmac-sha -hmac-sha224
              -hmac-sha256 -hmac-sha384 -hmac-sha512 -pbkdf2 -siphash -asym -rsa-kg
              -rsa -rsa-sz -dh -ecc-kg -ecc -ecc-enc -ecc-all -curve25519-kg -x25519
              -ed25519-kg -ed25519 -curve448-kg -x448 -ed448-kg -ed448 -eccsi-kg -eccsi-pair
              -eccsi-val -eccsi -sakke-kg -sakke-rsk -sakke-val -sakke -other -rng
              -scrypt
-<alg>      Algorithm to benchmark. Available algorithms include:
-lng <num>  Display benchmark result by specified language.
...
```

After:
```
/wolfcrypt/benchmark/benchmark -? 0
------------------------------------------------------------------------------
 wolfSSL version 5.6.3
------------------------------------------------------------------------------
benchmark
-? <num>    Help, print this usage
            0: English, 1: Japanese
-csv        Print terminal output in csv format
-base10     Display bytes as power of 10 (eg 1 kB = 1000 Bytes)
-no_aad     No additional authentication data passed.
...
-ecc-all    Bench all enabled ECC curves.
-<alg>      Algorithm to benchmark. Available algorithms include:
              -cipher -aes-cbc -aes-gcm -aes-ecb -aes-xts -aes-cfb -aes-ofb -aes-ctr
              -aes-ccm -aes-siv -camellia -arc4 -chacha20 -chacha20-poly1305 -des
              -digest -md5 -poly1305 -sha -sha2 -sha224 -sha256 -sha384 -sha512 -sha3
              -sha3-224 -sha3-256 -sha3-384 -sha3-512 -shake -shake128 -shake256 -ripemd
              -blake2b -blake2s -mac -cmac -hmac -hmac-md5 -hmac-sha -hmac-sha224
              -hmac-sha256 -hmac-sha384 -hmac-sha512 -pbkdf2 -siphash -asym -rsa-kg
              -rsa -rsa-sz -dh -ecc-kg -ecc -ecc-enc -ecc-all -curve25519-kg -x25519
              -ed25519-kg -ed25519 -curve448-kg -x448 -ed448-kg -ed448 -eccsi-kg -eccsi-pair
              -eccsi-val -eccsi -sakke-kg -sakke-rsk -sakke-val -sakke -other -rng
              -scrypt
-lng <num>  Display benchmark result by specified language.
...
```