### PR TITLE
Used codespell and fixed obvious typos.

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -13475,7 +13475,7 @@ PRAGMA_GCC_DIAG_POP
                 if ((cType == WOLFSSL_CERT_TYPE_RPK && !args->dCert->isRPK) ||
                     (cType == WOLFSSL_CERT_TYPE_X509 && args->dCert->isRPK)) {
                     /* cert type mismatch */
-                    WOLFSSL_MSG("unsuported certificate type received");
+                    WOLFSSL_MSG("unsupported certificate type received");
                     ret = UNSUPPORTED_CERTIFICATE;
                 }
             }
@@ -13486,7 +13486,7 @@ PRAGMA_GCC_DIAG_POP
                 if ((cType == WOLFSSL_CERT_TYPE_RPK && !args->dCert->isRPK) ||
                     (cType == WOLFSSL_CERT_TYPE_X509 && args->dCert->isRPK)) {
                     /* cert type mismatch */
-                    WOLFSSL_MSG("unsuported certificate type received");
+                    WOLFSSL_MSG("unsupported certificate type received");
                     ret = UNSUPPORTED_CERTIFICATE;
                 }
             }

--- a/src/ssl_certman.c
+++ b/src/ssl_certman.c
@@ -726,7 +726,7 @@ int CM_VerifyBuffer_ex(WOLFSSL_CERT_MANAGER* cm, const unsigned char* buff,
  *                         WOLFSSL_FILETYPE_ASN1, WOLFSSL_FILETYPE_PEM.
  * @param [in] prev_err  Previous error. Passed to callback.
  * @return  WOLFSSL_SUCCESS on success.
- * @return  BAD_FUNC_ARG when cm or buff is NULL ot sz is negative or zero.
+ * @return  BAD_FUNC_ARG when cm or buff is NULL or sz is negative or zero.
  * @return  WOLFSSL_BAD_FILETYPE when format is invalid.
  * @return  MEMORY_E when dynamic memory allocation fails.
  * @return  NOT_COMPILED_IN when converting from PEM to DER is not a feature of
@@ -768,7 +768,7 @@ int wolfSSL_CertManagerVerifyBuffer(WOLFSSL_CERT_MANAGER* cm,
  *                         WOLFSSL_FILETYPE_ASN1, WOLFSSL_FILETYPE_PEM.
  * @param [in] prev_err  Previous error. Passed to callback.
  * @return  WOLFSSL_SUCCESS on success.
- * @return  BAD_FUNC_ARG when cm or buff is NULL ot sz is negative.
+ * @return  BAD_FUNC_ARG when cm or buff is NULL or sz is negative.
  * @return  WOLFSSL_BAD_FILETYPE when format is invalid.
  * @return  WOLFSSL_BAD_FILE when reading the certificate file fails.
  * @return  MEMORY_E when dynamic memory allocation fails.
@@ -2332,7 +2332,7 @@ int wolfSSL_CertManagerSetOCSPOverrideURL(WOLFSSL_CERT_MANAGER* cm,
  * @param [in] cm          Certificate manager.
  * @param [in] ioCb        OCSP callback.
  * @param [in] respFreeCb  Callback to free OCSP response buffer.
- * @param [in] ioCbCtx     Context daa to pass to OCSP callbacks.
+ * @param [in] ioCbCtx     Context data to pass to OCSP callbacks.
  * @return  WOLFSSL_SUCCESS on success.
  * @return  BAD_FUNC_ARG when cm is NULL.
  */

--- a/src/tls.c
+++ b/src/tls.c
@@ -10774,7 +10774,7 @@ static int GetCommonItem(const byte* a, byte aLen, const byte* b, byte bLen,
 }
 
 /* Creates a "client certificate type" extension if necessary.
- * Returns 0 if no error occured, negative value otherwise.
+ * Returns 0 if no error occurred, negative value otherwise.
  * A return of 0, it does not indicae that the extension was created.
  */
 static int TLSX_ClientCertificateType_Use(WOLFSSL* ssl, byte isServer)
@@ -11029,7 +11029,7 @@ static int TLSX_ClientCertificateType_GetSize(WOLFSSL* ssl, byte msgType)
 /* Server_Certificate_Type extension                                          */
 /******************************************************************************/
 /* Creates a "server certificate type" extension if necessary.
- * Returns 0 if no error occured, negative value otherwise.
+ * Returns 0 if no error occurred, negative value otherwise.
  * A return of 0, it does not indicae that the extension was created.
  */
 static int TLSX_ServerCertificateType_Use(WOLFSSL* ssl, byte isServer)

--- a/tests/api.c
+++ b/tests/api.c
@@ -63449,7 +63449,7 @@ static int test_tls13_rpk_handshake(void)
     ExpectIntEQ(wolfSSL_set_client_cert_type(ssl_s, certType_c, typeCnt_c),
                                                         WOLFSSL_SUCCESS);
 
-    /* have server tell to use x509 cert intensionally. This will bring
+    /* have server tell to use x509 cert intentionally. This will bring
      * certificate type mismatch in client side.
      */
     certType_s[0] = WOLFSSL_CERT_TYPE_X509;
@@ -63531,7 +63531,7 @@ static int test_tls13_rpk_handshake(void)
     ExpectIntEQ(wolfSSL_set_client_cert_type(ssl_s, certType_c, typeCnt_c),
                                                         WOLFSSL_SUCCESS);
 
-    /* have server tell to use x509 cert intensionally. This will bring
+    /* have server tell to use x509 cert intentionally. This will bring
      * certificate type mismatch in client side.
      */
     certType_s[0] = WOLFSSL_CERT_TYPE_X509;
@@ -63575,7 +63575,7 @@ static int test_tls13_rpk_handshake(void)
 
 
 #if defined(WOLFSSL_ALWAYS_VERIFY_CB)
-    /*  Both client and server load RPK cert and set certificate vefiry
+    /*  Both client and server load RPK cert and set certificate verify
      *  callbacks then start handshaking.
      *  Confirm both side can refer the peer's cert.
      */
@@ -63615,7 +63615,7 @@ static int test_tls13_rpk_handshake(void)
     ExpectIntEQ(wolfSSL_set_server_cert_type(ssl_s, certType_s, typeCnt_s),
                                                         WOLFSSL_SUCCESS);
 
-    /* set certificate verify callcack to both client and server */
+    /* set certificate verify callback to both client and server */
     int isServer = 0;
     wolfSSL_SetCertCbCtx(ssl_c, &isServer);
     wolfSSL_set_verify(ssl_c, SSL_VERIFY_PEER, MyRpkVerifyCb);

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -3266,7 +3266,7 @@ static int RsaPublicEncryptEx(const byte* in, word32 inLen, byte* out,
     #elif defined(WOLFSSL_RENESAS_FSPSM_CRYPTONLY) || \
           (!defined(WOLFSSL_RENESAS_TSIP_TLS) && \
             defined(WOLFSSL_RENESAS_TSIP_CRYPTONLY))
-           /* SCE needs warpped key which is passed via
+           /* SCE needs wrapped key which is passed via
             * user ctx object of crypt-call back.
             */
        #ifdef WOLF_CRYPTO_CB

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -6466,7 +6466,7 @@ static void _sp_div_3(const sp_int* a, sp_int* r, sp_int_digit* rem)
         }
         /* Sum digits of sum. */
         t = (t >> SP_WORD_SIZE) + (t & SP_MASK);
-        /* Get top digit after multipling by (2^SP_WORD_SIZE) / 3. */
+        /* Get top digit after multiplying by (2^SP_WORD_SIZE) / 3. */
         tt = (sp_int_digit)((t * SP_DIV_3_CONST) >> SP_WORD_SIZE);
         /* Subtract trial division. */
         tr = (sp_int_digit)(t - (sp_int_word)tt * 3);
@@ -6498,7 +6498,7 @@ static void _sp_div_3(const sp_int* a, sp_int* r, sp_int_digit* rem)
     #ifndef SQR_MUL_ASM
             /* Combine remainder from last operation with this word. */
             t = ((sp_int_word)tr << SP_WORD_SIZE) | a->dp[i];
-            /* Get top digit after multipling by (2^SP_WORD_SIZE) / 3. */
+            /* Get top digit after multiplying by (2^SP_WORD_SIZE) / 3. */
             tt = (sp_int_digit)((t * SP_DIV_3_CONST) >> SP_WORD_SIZE);
             /* Subtract trial division. */
             tr = (sp_int_digit)(t - (sp_int_word)tt * 3);
@@ -6559,7 +6559,7 @@ static void _sp_div_10(const sp_int* a, sp_int* r, sp_int_digit* rem)
     #ifndef SQR_MUL_ASM
             /* Combine remainder from last operation with this word. */
             t = ((sp_int_word)tr << SP_WORD_SIZE) | a->dp[i];
-            /* Get top digit after multipling by (2^SP_WORD_SIZE) / 10. */
+            /* Get top digit after multiplying by (2^SP_WORD_SIZE) / 10. */
             tt = (sp_int_digit)((t * SP_DIV_10_CONST) >> SP_WORD_SIZE);
             /* Subtract trial division. */
             tr = (sp_int_digit)(t - (sp_int_word)tt * 10);
@@ -6585,7 +6585,7 @@ static void _sp_div_10(const sp_int* a, sp_int* r, sp_int_digit* rem)
     #ifndef SQR_MUL_ASM
             /* Combine remainder from last operation with this word. */
             t = ((sp_int_word)tr << SP_WORD_SIZE) | a->dp[i];
-            /* Get top digit after multipling by (2^SP_WORD_SIZE) / 10. */
+            /* Get top digit after multiplying by (2^SP_WORD_SIZE) / 10. */
             tt = (sp_int_digit)((t * SP_DIV_10_CONST) >> SP_WORD_SIZE);
             /* Subtract trial division. */
             tr = (sp_int_digit)(t - (sp_int_word)tt * 10);
@@ -6649,7 +6649,7 @@ static void _sp_div_small(const sp_int* a, sp_int_digit d, sp_int* r,
         #ifndef SQR_MUL_ASM
             /* Combine remainder from last operation with this word. */
             t = ((sp_int_word)tr << SP_WORD_SIZE) | a->dp[i];
-            /* Get top digit after multipling. */
+            /* Get top digit after multiplying. */
             tt = (sp_int_digit)((t * m) >> SP_WORD_SIZE);
             /* Subtract trial division. */
             tr = (sp_int_digit)t - (sp_int_digit)(tt * d);
@@ -6676,7 +6676,7 @@ static void _sp_div_small(const sp_int* a, sp_int_digit d, sp_int* r,
         #ifndef SQR_MUL_ASM
             /* Combine remainder from last operation with this word. */
             t = ((sp_int_word)tr << SP_WORD_SIZE) | a->dp[i];
-            /* Get top digit after multipling. */
+            /* Get top digit after multiplying. */
             tt = (sp_int_digit)((t * m) >> SP_WORD_SIZE);
             /* Subtract trial division. */
             tr = (sp_int_digit)t - (sp_int_digit)(tt * d);
@@ -8744,9 +8744,9 @@ int sp_mod(const sp_int* a, const sp_int* m, sp_int* r)
  *
  * Optimised code for when number of digits in a and b are the same.
  *
- * @param  [in]   a    SP integer to mulitply.
- * @param  [in]   b    SP integer to mulitply by.
- * @param  [out]  r    SP integer to hod reult.
+ * @param  [in]   a    SP integer to multiply.
+ * @param  [in]   b    SP integer to multiply by.
+ * @param  [out]  r    SP integer to hold result.
  *
  * @return  MP_OKAY otherwise.
  * @return  MP_MEM when dynamic memory allocation fails.
@@ -8823,9 +8823,9 @@ static int _sp_mul_nxn(const sp_int* a, const sp_int* b, sp_int* r)
 
 /* Multiply a by b into r. r = a * b
  *
- * @param  [in]   a    SP integer to mulitply.
- * @param  [in]   b    SP integer to mulitply by.
- * @param  [out]  r    SP integer to hod reult.
+ * @param  [in]   a    SP integer to multiply.
+ * @param  [in]   b    SP integer to multiply by.
+ * @param  [out]  r    SP integer to hold result.
  *
  * @return  MP_OKAY otherwise.
  * @return  MP_MEM when dynamic memory allocation fails.
@@ -8901,9 +8901,9 @@ static int _sp_mul(const sp_int* a, const sp_int* b, sp_int* r)
 #else
 /* Multiply a by b into r. r = a * b
  *
- * @param  [in]   a    SP integer to mulitply.
- * @param  [in]   b    SP integer to mulitply by.
- * @param  [out]  r    SP integer to hod reult.
+ * @param  [in]   a    SP integer to multiply.
+ * @param  [in]   b    SP integer to multiply by.
+ * @param  [out]  r    SP integer to hold result.
  *
  * @return  MP_OKAY otherwise.
  * @return  MP_MEM when dynamic memory allocation fails.
@@ -17617,7 +17617,7 @@ int sp_read_unsigned_bin(sp_int* a, const byte* in, word32 inSz)
         a->used = (inSz + SP_WORD_SIZEOF - 1) / SP_WORD_SIZEOF;
 
     #if defined(BIG_ENDIAN_ORDER) && !defined(WOLFSSL_SP_INT_DIGIT_ALIGN)
-        /* Data endian matches respresentation of number.
+        /* Data endian matches representation of number.
          * Directly copy if we don't have alignment issues.
          */
         for (i = (int)(inSz-1); i > SP_WORD_SIZEOF-1; i -= SP_WORD_SIZEOF) {
@@ -17901,7 +17901,7 @@ static int _sp_read_radix_10(sp_int* a, const char* in)
         ch = in[i];
         /* Check character is valid. */
         if ((ch >= '0') && (ch <= '9')) {
-            /* Assume '0'..'9' are continuous valus as characters. */
+            /* Assume '0'..'9' are continuous values as characters. */
             ch -= '0';
         }
         else {
@@ -18495,7 +18495,7 @@ int sp_rand_prime(sp_int* r, int len, WC_RNG* rng, void* heap)
  *
  * @param  [in]   a       SP integer to check.
  * @param  [in]   b       SP integer that is a small prime.
- * @param  [out]  result  MP_YES when number is likey prime.
+ * @param  [out]  result  MP_YES when number is likely prime.
  *                        MP_NO otherwise.
  * @param  [in]   n1      SP integer temporary.
  * @param  [in]   r       SP integer temporary.

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1445,7 +1445,7 @@ typedef struct w64wrapper {
          *                  callbacks
          * WOLFSSL_THREAD_NO_JOIN - attribute that should be used to declare
          *                          thread callbacks that don't require cleanup
-         * WOLFSSL_COND - defined if this system suports signaling
+         * WOLFSSL_COND - defined if this system supports signaling
          * COND_TYPE - type that should be passed into the signaling API
          * WOLFSSL_THREAD_VOID_RETURN - defined if the thread callback has a
          *                              void return


### PR DESCRIPTION
# Description

Used codespell and fixed obvious typos in `src`, `tests`, `wolfcrypt`, and `wolfssl`.