### PR TITLE
ZD16445

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -3728,7 +3728,7 @@ static int test_wolfSSL_CTX_load_verify_buffer_ex(void)
     WOLFSSL_CTX* ctx;
     const char* ca_expired_cert_file = "./certs/test/expired/expired-ca.der";
     byte ca_expired_cert[TWOK_BUF];
-    word32 sizeof_ca_expired_cert;
+    word32 sizeof_ca_expired_cert = 0;
     XFILE fp = XBADFILE;
 
 #ifndef NO_WOLFSSL_CLIENT
@@ -11337,7 +11337,7 @@ static int test_wolfSSL_no_password_cb(void)
     const char eccPkcs8PrivKeyDerFile[] = "./certs/ecc-privkeyPkcs8.der";
     const char eccPkcs8PrivKeyPemFile[] = "./certs/ecc-privkeyPkcs8.pem";
     XFILE f = XBADFILE;
-    int bytes;
+    int bytes = 0;
 
 #ifndef NO_WOLFSSL_CLIENT
     ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLS_client_method()));
@@ -19788,7 +19788,7 @@ static int test_wc_DsaKeyToPublicDer(void)
     DsaKey key;
     WC_RNG rng;
     byte*  der = NULL;
-    word32 sz;
+    word32 sz = 0;
     word32 idx = 0;
 
     XMEMSET(&key, 0, sizeof(DsaKey));
@@ -26113,7 +26113,7 @@ static int test_wc_PKCS7_EncodeDecodeEnvelopedData(void)
 #if !defined(NO_AES) && defined(HAVE_AES_CBC) && !defined(NO_AES_256)
     /* test of decrypt callback with KEKRI enveloped data */
     {
-        int envelopedSz;
+        int envelopedSz = 0;
         const byte keyId[] = { 0x00 };
 
         ExpectNotNull(pkcs7 = wc_PKCS7_New(HEAP_HINT, testDevId));
@@ -26638,7 +26638,7 @@ static int test_wc_PKCS7_BER(void)
 #ifndef NO_DES3
     byte   decoded[2048];
 #endif
-    word32 derSz;
+    word32 derSz = 0;
 
     ExpectTrue((f = XFOPEN(fName, "rb")) != XBADFILE);
     ExpectTrue((derSz = (word32)XFREAD(der, 1, sizeof(der), f)) > 0);

--- a/tests/w64wrapper.c
+++ b/tests/w64wrapper.c
@@ -41,7 +41,7 @@ int w64wrapper_test(void)
 
     a = w64From32(0x01020304, 0x05060708);
 #if defined(WORD64_AVAILABLE) && !defined(WOLFSSL_W64_WRAPPER_TEST)
-    if (a.n != 0x0102030405060708)
+    if (a.n != 0x0102030405060708LL)
         return -1;
 #else
     if (a.n[0] != 0x01020304 || a.n[1] != 0x05060708)

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -639,13 +639,13 @@ static word32 SizeASN_Num(word32 n, int bits, byte tag)
  * @param [in]      idx    Index of item working on.
  */
 static void SizeASN_CalcDataLength(const ASNItem* asn, ASNSetData *data,
-                                   int idx, int max)
+                                   int idx, int maxIdx)
 {
     int j;
 
     data[idx].data.buffer.length = 0;
     /* Sum the item length of all items underneath. */
-    for (j = idx + 1; j < max; j++) {
+    for (j = idx + 1; j < maxIdx; j++) {
         /* Stop looking if the next ASN.1 is same level or higher. */
         if (asn[j].depth <= asn[idx].depth)
             break;


### PR DESCRIPTION
- Use unions for type punning in xor API
- Initialise potentially uninitialised variables
- Use `LL` suffix to specify a larger integer type
- Don't use `max` as it can shadow other definitions
