### PR TITLE
ARIA no longer needs OpenSSL enabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2668,9 +2668,8 @@ if test "$ENABLED_ARIA" = "yes"
 then
     ARIA_DIR=MagicCrypto
     # Enable dependency
-    ENABLED_OPENSSLEXTRA="yes"
     CFLAGS="$CFLAGS -I$ARIA_DIR/include"
-    AM_CFLAGS="$AM_CFLAGS -DHAVE_ARIA -DOPENSSL_EXTRA"
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_ARIA"
     AM_LDFLAGS="$AM_LDFLAGS -L$ARIA_DIR/lib -lMagicCrypto"
     build_pwd="$(pwd)"
     headers="mcapi_error.h mcapi_type.h mcapi.h"

--- a/wolfcrypt/src/port/aria/aria-crypt.c
+++ b/wolfcrypt/src/port/aria/aria-crypt.c
@@ -36,8 +36,10 @@ size and a key size of 128, 192, or 256 bits.
 #ifdef HAVE_ARIA
 
 #include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/ssl.h>
+#include <wolfssl/wolfcrypt/aes.h>
 #include <wolfssl/wolfcrypt/port/aria/aria-crypt.h>
+#include <wolfssl/error-ssl.h>
+#include <wolfssl/ssl.h>
 
 /* return 0 on success or WC_INIT_E on failure */
 int wc_AriaInitCrypt(wc_Aria* aria, MC_ALGID algo)

--- a/wolfcrypt/src/port/aria/aria-cryptocb.c
+++ b/wolfcrypt/src/port/aria/aria-cryptocb.c
@@ -35,8 +35,9 @@ size and a key size of 128, 192, or 256 bits.
 
 #ifdef HAVE_ARIA
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/ssl.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+#include <wolfssl/wolfcrypt/ecc.h>
 #include <wolfssl/wolfcrypt/asn_public.h>
 #include <wolfssl/wolfcrypt/port/aria/aria-cryptocb.h>
 


### PR DESCRIPTION
# Description

Related to https://github.com/wolfSSL/wolfssl/pull/6400 and https://github.com/wolfSSL/wolfssl/pull/6600 this PR removes the dependency of OpenSSL for the ARIA Ciphers.

Fixes zd# n/a

# Testing

How did you test?

```
git clone https://github.com/gojimmypi/wolfssl.git wolfssl-no-openssl
cd  wolfssl-no-openssl
git remote add upstream https://github.com/wolfssl/wolfssl.git
git fetch upstream master
git pull upstream master

# maually Copy MagicCrypto into ./MagicCrypto

cp yourMagicCrypto ./MagicCrypto
 
./autogen.sh
./configure --disable-opensslall --disable-opensslextra --disable-opensslcoexist --enable-aria

export LD_LIBRARY_PATH=./MagicCrypto/lib
make

# Run the ARIA ECDHE-ECDSA-ARIA128-GCM-SHA256 Server
./examples/server/server -i -x -v 3 -A ./certs/ca-ecc-cert.pem -k ./certs/ecc-key.pem -c ./certs/intermediate/server-chain-ecc.pem -V -l ECDHE-ECDSA-ARIA128-GCM-SHA256
```


In a separate bash prompt, connect  client:

```
cd /mnt/c/test/wolfssl-no-openssl
export LD_LIBRARY_PATH=./MagicCrypto/lib
./examples/client/client -v 3 -l ECDHE-ECDSA-ARIA128-GCM-SHA256 -A ./certs/ca-ecc-cert.pem -k ./certs/ecc-client-key.pem -c ./certs/intermediate/client-chain-ecc.pem -C
```

To optionally confirm this in the `client.c` or `server.c` example apps, add this to int main(int argc, char** argv):

```
        #ifdef OPENSSL_EXTRA
            printf("OPENSSL_EXTRA defined\n");
        #else
            printf("OPENSSL_EXTRA NOT defined\n");
        #endif

        #ifdef OPENSSL_ALL
            printf("OPENSSL_ALL defined\n");
        #else
            printf("OPENSSL_ALL NOT defined\n");
        #endif

        #ifdef OPENSSL_COEXIST
            printf("OPENSSL_COEXIST defined\n");
        #else
            printf("OPENSSL_COEXIST NOT defined\n");
        #endif
```


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
