### PR TITLE
Correct cryptocb cmd debug message

### DIFF
--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -199,7 +199,7 @@ WOLFSSL_API void wc_CryptoCb_InfoString(wc_CryptoInfo* info)
     }
 #ifdef WOLF_CRYPTO_CB_CMD
     else if (info->algo_type == WC_ALGO_TYPE_NONE) {
-        printf("Crypto CB: CMD %s (%d)\n", GetAlgoTypeStr(info->algo_type),
+        printf("Crypto CB: %s %s (%d)\n", GetAlgoTypeStr(info->algo_type),
             GetCryptoCbCmdTypeStr(info->cmd.type), info->cmd.type);
     }
 #endif

--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -154,6 +154,7 @@ static const char* GetRsaType(int type)
 }
 #endif
 
+#ifdef WOLF_CRYPTO_CB_CMD
 static const char* GetCryptoCbCmdTypeStr(int type)
 {
     switch (type) {
@@ -162,6 +163,8 @@ static const char* GetCryptoCbCmdTypeStr(int type)
     }
     return NULL;
 }
+#endif
+
 WOLFSSL_API void wc_CryptoCb_InfoString(wc_CryptoInfo* info)
 {
     if (info == NULL)
@@ -194,9 +197,11 @@ WOLFSSL_API void wc_CryptoCb_InfoString(wc_CryptoInfo* info)
         printf("Crypto CB: %s %s (%d)\n", GetAlgoTypeStr(info->algo_type),
             GetHashTypeStr(info->hmac.macType), info->hmac.macType);
     }
+#ifdef WOLF_CRYPTO_CB_CMD
     else if (info->algo_type == WC_ALGO_TYPE_NONE) {
-        printf("Crypto CB: %s %s (%d)\n", GetAlgoTypeStr(info->algo_type),
+        printf("Crypto CB: CMD %s (%d)\n", GetAlgoTypeStr(info->algo_type),
             GetCryptoCbCmdTypeStr(info->cmd.type), info->cmd.type);
+#endif
     }
     else {
         printf("CryptoCb: %s \n", GetAlgoTypeStr(info->algo_type));

--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -201,8 +201,8 @@ WOLFSSL_API void wc_CryptoCb_InfoString(wc_CryptoInfo* info)
     else if (info->algo_type == WC_ALGO_TYPE_NONE) {
         printf("Crypto CB: CMD %s (%d)\n", GetAlgoTypeStr(info->algo_type),
             GetCryptoCbCmdTypeStr(info->cmd.type), info->cmd.type);
-#endif
     }
+#endif
     else {
         printf("CryptoCb: %s \n", GetAlgoTypeStr(info->algo_type));
     }


### PR DESCRIPTION
# Description

Compilation fails when --enable-cryptocb and DEBUG_CRYPTOCB is defined when WOLF_CRYPTOCB_CMD is NOT defined, which is the default.  Fix corrects conditional defines to handle this case.  Error introduced in PR#6636.

# Testing

Caught by Andras during ARIA testing.

# Checklist

 - [ N/A ] added tests
 - [ N/A ] updated/added doxygen
 - [ N/A ] updated appropriate READMEs
 - [ N/A ] Updated manual and documentation
