### PR TITLE
Fixes for NO_FILESYSTEM and NO_BIO config

### DIFF
--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -1433,7 +1433,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
 #else
     int    doCliCertCheck = 0;
 #endif
-#ifdef HAVE_CRL
+#if defined(HAVE_CRL) && !defined(NO_FILESYSTEM)
     int    disableCRL = 0;
 #endif
     int    useAnyAddr = 0;
@@ -1545,7 +1545,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
     int useDtlsCID = 0;
     char dtlsCID[DTLS_CID_BUFFER_SIZE] = { 0 };
 #endif /* WOLFSSL_DTLS_CID */
-#ifdef HAVE_CRL
+#if defined(HAVE_CRL) && !defined(NO_FILESYSTEM)
     char* crlDir = NULL;
 #endif
 
@@ -1710,7 +1710,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                 break;
 
             case 'V' :
-                #ifdef HAVE_CRL
+                #if defined(HAVE_CRL) && !defined(NO_FILESYSTEM)
                     disableCRL = 1;
                 #endif
                 break;
@@ -2299,7 +2299,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
 #endif
             break;
         case 265:
-#ifdef HAVE_CRL
+#if defined(HAVE_CRL) && !defined(NO_FILESYSTEM)
             crlDir = myoptarg;
 #endif
             break;

--- a/tests/api.c
+++ b/tests/api.c
@@ -66211,11 +66211,13 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_dtls_stateless),
     TEST_DECL(test_generate_cookie),
 
+#ifndef NO_BIO
     /* Can't memory test as server hangs. */
     TEST_DECL(test_wolfSSL_BIO_connect),
     /* Can't memory test as server Asserts in thread. */
     TEST_DECL(test_wolfSSL_BIO_accept),
     TEST_DECL(test_wolfSSL_BIO_tls),
+#endif
 
 #if defined(HAVE_PK_CALLBACKS) && !defined(WOLFSSL_NO_TLS12)
     TEST_DECL(test_DhCallbacks),

--- a/tests/api.c
+++ b/tests/api.c
@@ -1010,7 +1010,7 @@ static int test_wolfSSL_CTX_set_cipher_list_bytes(void)
     EXPECT_DECLS;
 #if (defined(OPENSSL_EXTRA) || defined(WOLFSSL_SET_CIPHER_BYTES)) && \
     (!defined(NO_WOLFSSL_CLIENT) || !defined(NO_WOLFSSL_SERVER)) && \
-    (!defined(NO_RSA) || defined(HAVE_ECC))
+    (!defined(NO_RSA) || defined(HAVE_ECC)) && !defined(NO_FILESYSTEM)
     const char* testCertFile;
     const char* testKeyFile;
     WOLFSSL_CTX* ctx = NULL;
@@ -23866,7 +23866,7 @@ static int test_ToTraditional(void)
     EXPECT_DECLS;
 #if !defined(NO_ASN) && (defined(HAVE_PKCS8) || defined(HAVE_PKCS12)) && \
     (defined(WOLFSSL_TEST_CERT) || defined(OPENSSL_EXTRA) || \
-     defined(OPENSSL_EXTRA_X509_SMALL))
+     defined(OPENSSL_EXTRA_X509_SMALL)) && !defined(NO_FILESYSTEM)
     XFILE  f = XBADFILE;
     byte   input[TWOK_BUF];
     word32 sz;


### PR DESCRIPTION
# Description

Fixes a couple build errors

Fixes zd16187

# Testing

`./configure --enable-crl CFLAGS="-DNO_FILESYSTEM"`
Produces build errors:

```
examples/server/server.c: In function ‘server_test’:
examples/server/server.c:1549:11: error: variable ‘crlDir’ set but not used [-Werror=unused-but-set-variable]
 1549 |     char* crlDir = NULL;
      |           ^~~~~~
examples/server/server.c:1437:12: error: variable ‘disableCRL’ set but not used [-Werror=unused-but-set-variable]
 1437 |     int    disableCRL = 0;
      |            ^~~~~~~~~~

examples/server/server.c: In function ‘server_test’:
examples/server/server.c:1549:11: error: variable ‘crlDir’ set but not used [-Werror=unused-but-set-variable]
 1549 |     char* crlDir = NULL;
      |           ^~~~~~
examples/server/server.c:1437:12: error: variable ‘disableCRL’ set but not used [-Werror=unused-but-set-variable]
 1437 |     int    disableCRL = 0;
      |            ^~~~~~~~~~
```

Also fixes `./configure --enable-opensslextra CFLAGS="-DNO_BIO"`

```
tests/api.c:66215:15: error: ‘test_wolfSSL_BIO_connect’ undeclared here (not in a function); did you mean ‘test_wolfSSL_SCR_Reconnect’?
66215 |     TEST_DECL(test_wolfSSL_BIO_connect),
      |               ^~~~~~~~~~~~~~~~~~~~~~~~
tests/api.c:65038:34: note: in definition of macro ‘TEST_DECL’
65038 | #define TEST_DECL(func) { #func, func, 0, 0 }
      |                                  ^~~~
tests/api.c:66217:15: error: ‘test_wolfSSL_BIO_accept’ undeclared here (not in a function); did you mean ‘test_wolfSSL_DH_check’?
66217 |     TEST_DECL(test_wolfSSL_BIO_accept),
      |               ^~~~~~~~~~~~~~~~~~~~~~~
tests/api.c:65038:34: note: in definition of macro ‘TEST_DECL’
65038 | #define TEST_DECL(func) { #func, func, 0, 0 }
      |                                  ^~~~
tests/api.c:66218:15: error: ‘test_wolfSSL_BIO_tls’ undeclared here (not in a function); did you mean ‘test_wolfSSL_BN_bits’?
66218 |     TEST_DECL(test_wolfSSL_BIO_tls),
      |               ^~~~~~~~~~~~~~~~~~~~
tests/api.c:65038:34: note: in definition of macro ‘TEST_DECL’
65038 | #define TEST_DECL(func) { #func, func, 0, 0 }
      |                                  ^~~~
```

# Checklist

 - [ X] added tests (added configs in testing repo)
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
