### PR TITLE
windows: fix x64 benchmark release builds

### DIFF
--- a/wolfcrypt/benchmark/benchmark.vcxproj
+++ b/wolfcrypt/benchmark/benchmark.vcxproj
@@ -146,7 +146,7 @@
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <TargetMachine>MachineX86</TargetMachine>
+      <TargetMachine>MachineX64</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
# Description

Fixes an issue where a linker error would occur on 64bit release builds

```
Release\benchmark.obj : fatal error LNK1112: module machine type 'x64' conflicts with target machine type 'x86' [D:\a\wolfssl\wolfssl\wolfcrypt\benchmark\benchmark.vcxproj]
```


# Testing

Tested using github actions

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
