### PR TITLE
20230831-ge_p3_dbl

### DIFF
--- a/wolfssl/wolfcrypt/ge_operations.h
+++ b/wolfssl/wolfcrypt/ge_operations.h
@@ -115,7 +115,7 @@ typedef struct {
 void ge_p1p1_to_p2(ge_p2 *r, const ge_p1p1 *p);
 void ge_p1p1_to_p3(ge_p3 *r, const ge_p1p1 *p);
 void ge_p2_dbl(ge_p1p1 *r, const ge_p2 *p);
-#define ge_p3_dbl(r, p)     ge_p2_dbl((ge_p1p1 *)r, (ge_p2 *)p)
+#define ge_p3_dbl(r, p)     ge_p2_dbl((ge_p1p1 *)(r), (ge_p2 *)(p))
 void ge_madd(ge_p1p1 *r, const ge_p3 *p, const ge_precomp *q);
 void ge_msub(ge_p1p1 *r, const ge_p3 *p, const ge_precomp *q);
 void ge_add(ge_p1p1 *r, const ge_p3 *p, const ge_cached *q);


### PR DESCRIPTION
`wolfssl/wolfcrypt/ge_operations.h`: fix for `bugprone-macro-parentheses` in `ge_p3_dbl()` found by multi-test `clang-tidy-all-intelasm`.

tested with `wolfssl-multi-test.sh ... clang-tidy-all-intelasm check-self check-file-modes check-source-text check-shell-scripts check-configure all-gcc-c99`

After this merges, I will merge https://github.com/wolfSSL/testing/pull/494.
