### PR TITLE
Add WOLFSSL_CERT_EXT to --enable-jni, minor CSR items

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5984,6 +5984,11 @@ then
         ENABLED_CERTGEN="yes"
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_CERT_GEN"
     fi
+    if test "x$ENABLED_CERTREQ" = "xno"
+    then
+        ENABLED_CERTREQ="yes"
+        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_CERT_REQ"
+    fi
     if test "x$ENABLED_SNI" = "xno"
     then
         ENABLED_SNI="yes"

--- a/src/x509.c
+++ b/src/x509.c
@@ -9691,7 +9691,8 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_X509_chain_up_ref(
             }
             if (req->keyUsageSet)
                 cert->keyUsage = req->keyUsage;
-            /* Extended Key Usage not supported. */
+
+            cert->extKeyUsage = req->extKeyUsage;
     #endif
 
             XMEMCPY(cert->challengePw, req->challengePw, CTC_NAME_SIZE);
@@ -12611,6 +12612,10 @@ static int get_dn_attr_by_nid(int n, const char** buf)
             str = "ST";
             len = 2;
             break;
+        case NID_streetAddress:
+            str = "street";
+            len = 6;
+            break;
         case NID_organizationName:
             str = "O";
             len = 1;
@@ -12618,6 +12623,10 @@ static int get_dn_attr_by_nid(int n, const char** buf)
         case NID_organizationalUnitName:
             str = "OU";
             len = 2;
+            break;
+        case NID_postalCode:
+            str = "postalCode";
+            len = 10;
             break;
         case NID_emailAddress:
             str = "emailAddress";
@@ -12650,6 +12659,10 @@ static int get_dn_attr_by_nid(int n, const char** buf)
         case NID_pkcs9_contentType:
             str = "contentType";
             len = 11;
+            break;
+        case NID_userId:
+            str = "UID";
+            len = 3;
             break;
         default:
             WOLFSSL_MSG("Attribute type not found");


### PR DESCRIPTION
# Description

This PR enables Certificate Signing Request (CSR) generation (`WOLFSSL_CERT_REQ`) to the JNI/JSSE/JCE build (`--enable-jni`). CSR has been added to wolfSSL JNI as of this PR: https://github.com/wolfSSL/wolfssljni/pull/146

In addition, this PR copies over the Extended Key Usage byte when doing an `509_REQ_sign()`, and adds a few missing SubjectName fields to `X509_NAME_print_ex()`, called by `X509_REQ_print()`.

# Testing

Tested via wolfSSL JNI ant tests and example CSR generation.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
