### PR TITLE
Fix argument typo at `wolfSSL_write_early_data`

### DIFF
--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -13919,7 +13919,7 @@ int  wolfSSL_set_max_early_data(WOLFSSL* ssl, unsigned int sz);
     \sa wolfSSL_connect
     \sa wolfSSL_connect_TLSv13
 */
-int  wolfSSL_write_early_data(OLFSSL* ssl, const void* data,
+int  wolfSSL_write_early_data(WOLFSSL* ssl, const void* data,
     int sz, int* outSz);
 
 /*!


### PR DESCRIPTION
# Description

Fixes a documentation typo.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [x] Updated manual and documentation
