### PR TITLE
Remove references to WOLFSSL_SP_CACHE_RESISTANT as it is always on

### DIFF
--- a/IDE/AURIX/user_settings.h
+++ b/IDE/AURIX/user_settings.h
@@ -98,7 +98,6 @@ extern unsigned int my_rng_seed_gen(void);
 
     #define WOLFSSL_SP_NO_MALLOC
     //#define WOLFSSL_SP_DIV_32 /* do not use 64-bit divides */
-    //#define WOLFSSL_SP_CACHE_RESISTANT
 
     /* use smaller version of code */
     #define WOLFSSL_SP_SMALL

--- a/IDE/CRYPTOCELL/user_settings.h
+++ b/IDE/CRYPTOCELL/user_settings.h
@@ -88,7 +88,6 @@ extern "C" {
     #define WOLFSSL_HAVE_SP_RSA
     #define WOLFSSL_HAVE_SP_DH
     #define WOLFSSL_HAVE_SP_ECC
-    #define WOLFSSL_SP_CACHE_RESISTANT
     //#define WOLFSSL_SP_MATH     /* only SP math - eliminates fast math code */
 
     /* Assembly */

--- a/IDE/ECLIPSE/DEOS/user_settings.h
+++ b/IDE/ECLIPSE/DEOS/user_settings.h
@@ -85,7 +85,6 @@ You can get the current time from https://www.unixtimestamp.com/ */
     #define WOLFSSL_SP_4096 /* Enable RSA/RH 4096-bit support */
     #define WOLFSSL_SP_384 /* Enable ECC 384-bit SECP384R1 support */
 
-    //#define WOLFSSL_SP_CACHE_RESISTANT
     #define WOLFSSL_SP_MATH     /* only SP math - disables integer.c/tfm.c */
     //#define WOLFSSL_SP_MATH_ALL /* use SP math for all key sizes and curves */
 

--- a/IDE/GCC-ARM/Header/user_settings.h
+++ b/IDE/GCC-ARM/Header/user_settings.h
@@ -70,7 +70,6 @@ extern "C" {
     #define WOLFSSL_HAVE_SP_RSA
     #define WOLFSSL_HAVE_SP_DH
     #define WOLFSSL_HAVE_SP_ECC
-    //#define WOLFSSL_SP_CACHE_RESISTANT
     #define WOLFSSL_SP_MATH     /* only SP math - eliminates fast math code */
 
     /* SP Assembly Speedups */

--- a/IDE/MDK-ARM/MDK-ARM/wolfSSL/config-BARE-METAL.h
+++ b/IDE/MDK-ARM/MDK-ARM/wolfSSL/config-BARE-METAL.h
@@ -233,7 +233,6 @@
 
     #define WOLFSSL_SP_SMALL /* use smaller version of code */
     //#define WOLFSSL_SP_NO_MALLOC /* do not use heap */
-    //#define WOLFSSL_SP_CACHE_RESISTANT
     //#define WOLFSSL_SP_DIV_32 /* do not use 64-bit divides */
 
     #if MDK_CONF_MATH == 4

--- a/IDE/MDK-ARM/MDK-ARM/wolfSSL/config-FS.h
+++ b/IDE/MDK-ARM/MDK-ARM/wolfSSL/config-FS.h
@@ -270,7 +270,6 @@
 
     #define WOLFSSL_SP_SMALL /* use smaller version of code */
     //#define WOLFSSL_SP_NO_MALLOC /* do not use heap */
-    //#define WOLFSSL_SP_CACHE_RESISTANT
     //#define WOLFSSL_SP_DIV_32 /* do not use 64-bit divides */
 
     #if MDK_CONF_MATH == 4

--- a/IDE/MDK-ARM/MDK-ARM/wolfSSL/config-RTX-TCP-FS.h
+++ b/IDE/MDK-ARM/MDK-ARM/wolfSSL/config-RTX-TCP-FS.h
@@ -292,7 +292,6 @@
 
     #define WOLFSSL_SP_SMALL /* use smaller version of code */
     //#define WOLFSSL_SP_NO_MALLOC /* do not use heap */
-    //#define WOLFSSL_SP_CACHE_RESISTANT
     //#define WOLFSSL_SP_DIV_32 /* do not use 64-bit divides */
 
     #if MDK_CONF_MATH == 4

--- a/IDE/MDK5-ARM/Conf/user_settings.h
+++ b/IDE/MDK5-ARM/Conf/user_settings.h
@@ -478,7 +478,6 @@
 
     #define WOLFSSL_SP_SMALL /* use smaller version of code */
     //#define WOLFSSL_SP_NO_MALLOC /* do not use heap */
-    //#define WOLFSSL_SP_CACHE_RESISTANT
     //#define WOLFSSL_SP_DIV_32 /* do not use 64-bit divides */
 
     #if MDK_CONF_MATH == 4

--- a/IDE/ROWLEY-CROSSWORKS-ARM/user_settings.h
+++ b/IDE/ROWLEY-CROSSWORKS-ARM/user_settings.h
@@ -53,7 +53,6 @@ extern "C" {
     #define WOLFSSL_HAVE_SP_RSA
     #define WOLFSSL_HAVE_SP_DH
     #define WOLFSSL_HAVE_SP_ECC
-    //#define WOLFSSL_SP_CACHE_RESISTANT
     #define WOLFSSL_SP_MATH     /* only SP math - eliminates fast math code */
 
     /* SP Assembly Speedups */

--- a/IDE/STM32Cube/default_conf.ftl
+++ b/IDE/STM32Cube/default_conf.ftl
@@ -249,7 +249,6 @@ extern ${variable.value} ${variable.name};
     /* Enable to put all math on stack (no heap) */
     //#define WOLFSSL_SP_NO_MALLOC
     /* Enable for SP cache resistance (not usually enabled for embedded micros) */
-    //#define WOLFSSL_SP_CACHE_RESISTANT
 
     #if WOLF_CONF_MATH == 4 || WOLF_CONF_MATH == 5
         #define WOLFSSL_SP_ASM /* required if using the ASM versions */

--- a/IDE/SimplicityStudio/user_settings.h
+++ b/IDE/SimplicityStudio/user_settings.h
@@ -67,7 +67,6 @@ extern "C" {
     //#define WOLFSSL_SP_4096 /* Enable RSA/RH 4096-bit support */
     //#define WOLFSSL_SP_384 /* Enable ECC 384-bit SECP384R1 support */
 
-    //#define WOLFSSL_SP_CACHE_RESISTANT
     //#define WOLFSSL_SP_MATH     /* only SP math - disables integer.c/tfm.c */
     #define WOLFSSL_SP_MATH_ALL /* use SP math for all key sizes and curves */
 

--- a/IDE/VisualDSP/user_settings.h
+++ b/IDE/VisualDSP/user_settings.h
@@ -77,7 +77,6 @@ extern "C" {
     #define WOLFSSL_HAVE_SP_RSA
     #define WOLFSSL_HAVE_SP_DH
     #define WOLFSSL_HAVE_SP_ECC
-    #define WOLFSSL_SP_CACHE_RESISTANT
     //#define WOLFSSL_SP_MATH     /* only SP math - eliminates fast math code */
 
     /* 64 or 32 bit version */

--- a/IDE/WICED-STUDIO/user_settings.h
+++ b/IDE/WICED-STUDIO/user_settings.h
@@ -75,7 +75,6 @@ extern "C" {
     #define WOLFSSL_HAVE_SP_RSA
     #define WOLFSSL_HAVE_SP_DH
     #define WOLFSSL_HAVE_SP_ECC
-    #define WOLFSSL_SP_CACHE_RESISTANT
     //#define WOLFSSL_SP_MATH
 
     /* 64 or 32 bit version */

--- a/IDE/WINCE/user_settings.h
+++ b/IDE/WINCE/user_settings.h
@@ -36,7 +36,6 @@
     #define WOLFSSL_HAVE_SP_RSA
     #define WOLFSSL_HAVE_SP_DH
     #define WOLFSSL_HAVE_SP_ECC
-    //#define WOLFSSL_SP_CACHE_RESISTANT
     //#define WOLFSSL_SP_MATH     /* only SP math - eliminates fast math code */
 
     /* SP Assembly Speedups */

--- a/examples/configs/user_settings_stm32.h
+++ b/examples/configs/user_settings_stm32.h
@@ -243,7 +243,6 @@
     #define SP_WORD_SIZE 32
 
     //#define WOLFSSL_SP_NO_MALLOC
-    //#define WOLFSSL_SP_CACHE_RESISTANT
 
     /* single precision Cortex-M only */
     #if WOLF_CONF_MATH == 4

--- a/examples/configs/user_settings_template.h
+++ b/examples/configs/user_settings_template.h
@@ -69,7 +69,6 @@ extern "C" {
     //#define WOLFSSL_SP_4096 /* Enable RSA/RH 4096-bit support */
     //#define WOLFSSL_SP_384 /* Enable ECC 384-bit SECP384R1 support */
 
-    //#define WOLFSSL_SP_CACHE_RESISTANT
     //#define WOLFSSL_SP_MATH     /* only SP math - disables integer.c/tfm.c */
     #define WOLFSSL_SP_MATH_ALL /* use SP math for all key sizes and curves */
 


### PR DESCRIPTION
# Description

Removed all references to WOLFSSL_SP_CACHE_RESISTANT in user_settings.h headers as the feature is always on unless explicitly disabled and the CFLAG is no longer used in any part of the library or headers. See also: ~https://github.com/kaleb-himes/documentation/pull/2~ https://github.com/wolfSSL/documentation/pull/107/files

Fixes zd#

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [X] Updated manual and documentation
