### PR TITLE
stop DoCertificate from reseting the cert chain

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -14510,6 +14510,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                                     args->dCert, ssl);
                     #ifdef WOLFSSL_NONBLOCK_OCSP
                         if (ret == OCSP_WANT_READ) {
+                            args->lastErr = ret;
                             goto exit_ppc;
                         }
                     #endif

--- a/src/internal.c
+++ b/src/internal.c
@@ -14045,10 +14045,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     }
 #endif
                 #ifdef WOLFSSL_ASYNC_CRYPT
-                    if (ret == WC_PENDING_E) {
-                        args->lastErr = ret;
+                    if (ret == WC_PENDING_E)
                         goto exit_ppc;
-                    }
                 #endif
                     if (ret == 0) {
                         ret = ProcessPeerCertCheckKey(ssl, args);
@@ -14304,10 +14302,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     }
 #endif
             #ifdef WOLFSSL_ASYNC_CRYPT
-                if (ret == WC_PENDING_E) {
-                    args->lastErr = ret;
+                if (ret == WC_PENDING_E)
                     goto exit_ppc;
-                }
             #endif
                 if (ret == 0) {
                     WOLFSSL_MSG("Verified Peer's cert");
@@ -14510,7 +14506,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                                     args->dCert, ssl);
                     #ifdef WOLFSSL_NONBLOCK_OCSP
                         if (ret == OCSP_WANT_READ) {
-                            args->lastErr = ret;
                             goto exit_ppc;
                         }
                     #endif
@@ -15129,12 +15124,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         case TLS_ASYNC_FINALIZE:
         {
             /* load last error */
-            if (args->lastErr != 0 && ret == 0
-#if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
-                && args->lastErr != WC_PENDING_E &&
-                args->lastErr != OCSP_WANT_READ
-#endif
-            ) {
+            if (args->lastErr != 0 && ret == 0) {
                 ret = args->lastErr;
             }
 
@@ -15248,9 +15238,9 @@ static int DoCertificate(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 
 #ifdef SESSION_CERTS
     /* Reset the session cert chain count in case the session resume failed,
-    do not reset if we are resuming after an async wait */
+     * do not reset if we are resuming after an async wait */
 #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
-    if ((ssl->error != OCSP_WANT_READ && ssl->error != WC_PENDING_E))
+    if (ssl->error != OCSP_WANT_READ && ssl->error != WC_PENDING_E)
 #endif
     {
         ssl->session->chain.count = 0;

--- a/src/internal.c
+++ b/src/internal.c
@@ -15250,7 +15250,7 @@ static int DoCertificate(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     /* Reset the session cert chain count in case the session resume failed,
     do not reset if we are resuming after an async wait */
 #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
-    if (ssl->async == NULL || ssl->async->args == NULL ||
+    if (ssl->async == NULL ||
         (((ProcPeerCertArgs*)(ssl->async->args))->lastErr != OCSP_WANT_READ &&
         ((ProcPeerCertArgs*)(ssl->async->args))->lastErr != WC_PENDING_E))
 #endif

--- a/src/internal.c
+++ b/src/internal.c
@@ -15237,11 +15237,18 @@ static int DoCertificate(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     WOLFSSL_ENTER("DoCertificate");
 
 #ifdef SESSION_CERTS
-    /* Reset the session cert chain count in case the session resume failed. */
-    ssl->session->chain.count = 0;
-    #ifdef WOLFSSL_ALT_CERT_CHAINS
+    /* Reset the session cert chain count in case the session resume failed,
+    do not reset if we are resuming after an async wait */
+#if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
+    if (((ProcPeerCertArgs*)(ssl->async->args))->lastErr != OCSP_WANT_READ &&
+        ((ProcPeerCertArgs*)(ssl->async->args))->lastErr != WC_PENDING_E)
+#endif
+    {
+        ssl->session->chain.count = 0;
+#ifdef WOLFSSL_ALT_CERT_CHAINS
         ssl->session->altChain.count = 0;
-    #endif
+#endif
+    }
 #endif /* SESSION_CERTS */
 
     ret = ProcessPeerCerts(ssl, input, inOutIdx, size);

--- a/src/internal.c
+++ b/src/internal.c
@@ -15250,9 +15250,7 @@ static int DoCertificate(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     /* Reset the session cert chain count in case the session resume failed,
     do not reset if we are resuming after an async wait */
 #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
-    if (ssl->async == NULL ||
-        (((ProcPeerCertArgs*)(ssl->async->args))->lastErr != OCSP_WANT_READ &&
-        ((ProcPeerCertArgs*)(ssl->async->args))->lastErr != WC_PENDING_E))
+    if ((ssl->error != OCSP_WANT_READ && ssl->error != WC_PENDING_E))
 #endif
     {
         ssl->session->chain.count = 0;


### PR DESCRIPTION
# Description

stop DoCertificate from reseting the cert chain count when an async error was returned

Please describe the scope of the fix or feature addition.

fixes https://github.com/wolfSSL/wolfssl/issues/6758

# Testing

Tested using the ocsp_nonblock_async test from wolfssl-examples, set to use tls1.2 since this is a 1.2 and under bug

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
