### PR TITLE
Fix residual typos found by codespell

### DIFF
--- a/IDE/MDK5-ARM/Projects/wolfSSL-Full/wolfsslFull.uvoptx
+++ b/IDE/MDK5-ARM/Projects/wolfSSL-Full/wolfsslFull.uvoptx
@@ -308,7 +308,7 @@
   </Group>
 
   <Group>
-    <GroupName>Dcumentation</GroupName>
+    <GroupName>Documentation</GroupName>
     <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>

--- a/IDE/MDK5-ARM/Projects/wolfSSL-Full/wolfsslFull.uvprojx
+++ b/IDE/MDK5-ARM/Projects/wolfSSL-Full/wolfsslFull.uvprojx
@@ -446,7 +446,7 @@
           </Files>
         </Group>
         <Group>
-          <GroupName>Dcumentation</GroupName>
+          <GroupName>Documentation</GroupName>
           <Files>
             <File>
               <FileName>Abstract.txt</FileName>

--- a/debian/copyright
+++ b/debian/copyright
@@ -212,6 +212,6 @@ License: BSD-3-clause
 
 
 License: Apache-2.0
- On modern Debian systens, the text of this license can be found
+ On modern Debian systems, the text of this license can be found
  at:  /usr/share/common-licenses/Apache-2.0
 

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -7559,7 +7559,7 @@ static int addKeyLogSnifferServerHelper(const char* address,
     }
 
     /* Tag the new or existing server as requiring keylog support to
-     * decrypt, otherwise it won't be useable */
+     * decrypt, otherwise it won't be usable */
     sniffer->useKeyLogFile = 1;
 
     return 0;

--- a/tests/api.c
+++ b/tests/api.c
@@ -64558,7 +64558,7 @@ static int test_session_ticket_hs_update(void)
     ExpectIntEQ(wolfSSL_set_session(ssl_c3, sess), WOLFSSL_SUCCESS);
 
     wolfSSL_SetLoggingPrefix("client");
-    /* Exchange intial flights for the second connection */
+    /* Exchange initial flights for the second connection */
     ExpectIntEQ(wolfSSL_connect(ssl_c2), WOLFSSL_FATAL_ERROR);
     ExpectIntEQ(wolfSSL_get_error(ssl_c2, WOLFSSL_FATAL_ERROR),
         WOLFSSL_ERROR_WANT_READ);

--- a/tests/quic.c
+++ b/tests/quic.c
@@ -1154,7 +1154,7 @@ static int test_quic_server_hello(int verbose) {
     /* we have the app secrets */
     check_secrets(&tclient, wolfssl_encryption_application, 32, 32);
     check_secrets(&tserver, wolfssl_encryption_application, 32, 32);
-    /* verify client and server have the same secrets establishd */
+    /* verify client and server have the same secrets established */
     assert_secrets_EQ(&tclient, &tserver, wolfssl_encryption_handshake);
     assert_secrets_EQ(&tclient, &tserver, wolfssl_encryption_application);
     /* AEAD cipher should be known */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -15071,7 +15071,7 @@ static int DecodeCertInternal(DecodedCert* cert, int verify, int* criticalExt,
 /* Assumes the target is a Raw-Public-Key certificate and parsed up to the
  * public key. Returns CRYPTOCB_UNAVAILABLE if it determines that the cert is
  * different from the Paw-Public-Key cert. In that case, cert->srcIdx is not
- * consumed so as successing parse function can take over.
+ * consumed so as succeeding parse function can take over.
  * In case that the target is Raw-Public-Key cert and contains a public key,
  * returns 0  and consumes cert->srcIdx so as a public key retrieval function
  * can follow.
@@ -20885,7 +20885,7 @@ static const ASNItem x509CertASN[] = {
                                                    /* Version ::= INTEGER { v1(0), v2(1), v3(2) */
 /* TBS_VER_INT                   */                { 3, ASN_INTEGER, 0, 0, 0 },
                                                    /* serialNumber         CertificateSerialNumber */
-                                                   /* CetificateSerialNumber ::= INTEGER */
+                                                   /* CertificateSerialNumber ::= INTEGER */
 /* TBS_SERIAL                    */            { 2, ASN_INTEGER, 0, 0, 0 },
                                                    /* signature            AlgorithmIdentifier */
                                                    /* AlgorithmIdentifier ::= SEQUENCE */
@@ -37387,7 +37387,7 @@ int wc_ParseCertPIV(wc_CertPIV* piv, const byte* buf, word32 totalSz)
         GetASN_Int8Bit(&dataASN[PIVCERTASN_IDX_INFO], &info);
         /* Start parsing from start of buffer. */
         idx = 0;
-        /* Parse PIV cetificate data. */
+        /* Parse PIV certificate data. */
         ret = GetASN_Items(pivCertASN, dataASN, pivCertASN_Length, 1, buf, &idx,
                 totalSz);
         if (ret == 0) {

--- a/wolfcrypt/src/port/arm/armv8-aes.c
+++ b/wolfcrypt/src/port/arm/armv8-aes.c
@@ -21,7 +21,7 @@
 
 
 /*
- * There are two versions one for 64 (Aarch64)  and one for 32 bit (Aarch32).
+ * There are two versions one for 64 (Aarch64) and one for 32 bit (Aarch32).
  * If changing one check the other.
  */
 

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -4328,7 +4328,7 @@ static int wc_CompareDiffPQ(mp_int* p, mp_int* q, int size, int* valid)
 
 #ifdef WOLFSSL_CHECK_MEM_ZERO
     if (ret == 0)
-        mp_memzero_add("Comare PQ d", d);
+        mp_memzero_add("Compare PQ d", d);
 #endif
 
 #if !defined(WOLFSSL_SP_MATH) && (!defined(WOLFSSL_SP_MATH_ALL) || \


### PR DESCRIPTION
# Description

Fix typos found by [codespell](https://github.com/codespell-project/codespell).

# Testing

\-

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
