### PR TITLE
Eliminate bad record mac alert

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -20621,7 +20621,7 @@ default:
                             return HandleDTLSDecryptFailed(ssl);
                         }
                     #endif /* WOLFSSL_DTLS */
-                    #ifdef WOLFSSL_EXTRA_ALERTS
+                    #if defined(WOLFSSL_EXTRA_ALERTS) && !defined(WOLFSSL_NO_ETM_ALERT)
                         if (!ssl->options.dtls)
                             SendAlert(ssl, alert_fatal, bad_record_mac);
                     #endif
@@ -20715,7 +20715,7 @@ default:
 #endif
                                 ) {
                     WOLFSSL_MSG("Plaintext too long - Encrypt-Then-MAC");
-            #if defined(WOLFSSL_EXTRA_ALERTS)
+            #if defined(WOLFSSL_EXTRA_ALERTS) && !defined(WOLFSSL_NO_ETM_ALERT)
                     SendAlert(ssl, alert_fatal, record_overflow);
             #endif
                     WOLFSSL_ERROR_VERBOSE(BUFFER_ERROR);


### PR DESCRIPTION
# Description

WOLFSSL_NO_ETM_ALERT option to eliminate a vulnerability scan warning

Fixes zd#16462

# Testing

Checked with the scan

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
