### PR TITLE
20230911-linuxkm-my__show_free_areas-prototype

### DIFF
--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -133,6 +133,10 @@
              * reference to unexported __show_free_areas().
              */
             #define __show_free_areas my__show_free_areas
+            void my__show_free_areas(
+                unsigned int flags,
+                nodemask_t *nodemask,
+                int max_zone_idx);
         #endif
     #endif
     #include <linux/mm.h>


### PR DESCRIPTION
`linuxkm/linuxkm_wc_port.h`: add missing prototype for `my__show_free_areas()`.

fixes `-Wmissing-prototypes` exposed by Linux 6.6-rc1.

tested with `wolfssl-multi-test.sh ... linuxkm-mainline-pie linuxkm-mainline-aesni-pie-gcc-latest-insmod` on kernel 6.6-rc1.
