### PR TITLE
Support PKCS#7 definition for ContentType content ANY

### DIFF
--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -341,6 +341,7 @@ struct PKCS7 {
     byte*  cachedEncryptedContent;
     word32 cachedEncryptedContentSz;
     word16 contentCRLF:1; /* have content line endings been converted to CRLF */
+    word16 contentIsPkcs7Type:1; /* eContent follows PKCS#7 RFC not CMS */
     /* !! NEW DATA MEMBERS MUST BE ADDED AT END !! */
 };
 


### PR DESCRIPTION
# Description

This PR adds support to wolfCrypt's PKCS#7 to support the older PKCS#7 RFC (RFC 2315) encoding of the SignedData ContentInfo content as `ANY`. The newer CMS RFC (RFC 5652) defines that the content will be wrapped in an `OCTET STRING`, which our code was assuming would be the case.

PKCS#7 RFC 2315 definition of SignedData ContentInfo:

```
ContentInfo ::= SEQUENCE {
  contentType ContentType,
  content
    [0] EXPLICIT ANY DEFINED BY contentType OPTIONAL }
```

CMS RFC 5652 definition of the same thing:

```
EncapsulatedContentInfo ::= SEQUENCE {
  eContentType ContentType,
  eContent [0] EXPLICIT OCTET STRING OPTIONAL }
```

Related to ZD #16645.

# Testing

Tested using customer PKCS#7 SignedData bundle, fed into wolfCrypt's PKCS#7 routines using the sample app being added to our `wolfssl-examples` repository: https://github.com/wolfSSL/wolfssl-examples/pull/400

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
