### PR TITLE
Fix wolfSSL_get_curve_name() returning NULL when using PQC groups

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -8991,6 +8991,10 @@ static int server_generate_pqc_ciphertext(WOLFSSL* ssl,
         keyShareEntry->pubKey = ciphertext;
         keyShareEntry->pubKeyLen = (word32)(ecc_kse->pubKeyLen + ctSz);
         ciphertext = NULL;
+
+        /* Set namedGroup so wolfSSL_get_curve_name() can function properly on
+         * the server side. */
+        ssl->namedGroup = keyShareEntry->group;
     }
 
     TLSX_KeyShare_FreeAll(ecc_kse, ssl->heap);


### PR DESCRIPTION
# Description

Fixes an issue where wolfSSL_get_curve_name() will return NULL when using PQC groups. This is because `namedGroup` is not set and wolfSSL_get_curve_name relies on the `namedGroup` variable.

This issue was first fixed in https://github.com/wolfSSL/wolfssl/pull/5444 but was unintentionally dropped in https://github.com/wolfSSL/wolfssl/pull/5836

Fixes zd#16670

# Testing

Tested manually

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
