### PR TITLE
Zd16449 more fixes

### DIFF
--- a/async-check.sh
+++ b/async-check.sh
@@ -75,7 +75,7 @@ function Test() {
 function Remove() {
     UnlinkFiles
 
-    rm -rf ./async
+    rm -rf ${ASYNC_DIR}
 }
 
 if [ "$#" -gt 1 ]; then

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -8672,7 +8672,6 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                         sigLen = args->length;
                     args->sigData = (byte*)XMALLOC(sigLen, ssl->heap,
                                                             DYNAMIC_TYPE_SIGNATURE);
-                    args->sigDataSz = sigLen;
                 }
                 else {
                     args->sigData = (byte*)XMALLOC(MAX_SIG_DATA_SZ, ssl->heap,

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -8665,19 +8665,22 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
             }
             EncodeSigAlg(ssl->options.hashAlgo, args->sigAlgo, args->verify);
 
-            if (ssl->hsType == DYNAMIC_TYPE_RSA) {
-                int sigLen = MAX_SIG_DATA_SZ;
-                if (args->length > MAX_SIG_DATA_SZ)
-                    sigLen = args->length;
-                args->sigData = (byte*)XMALLOC(sigLen, ssl->heap,
-                                                        DYNAMIC_TYPE_SIGNATURE);
-            }
-            else {
-                args->sigData = (byte*)XMALLOC(MAX_SIG_DATA_SZ, ssl->heap,
-                                                        DYNAMIC_TYPE_SIGNATURE);
-            }
             if (args->sigData == NULL) {
-                ERROR_OUT(MEMORY_E, exit_scv);
+                if (ssl->hsType == DYNAMIC_TYPE_RSA) {
+                    int sigLen = MAX_SIG_DATA_SZ;
+                    if (args->length > MAX_SIG_DATA_SZ)
+                        sigLen = args->length;
+                    args->sigData = (byte*)XMALLOC(sigLen, ssl->heap,
+                                                            DYNAMIC_TYPE_SIGNATURE);
+                    args->sigDataSz = sigLen;
+                }
+                else {
+                    args->sigData = (byte*)XMALLOC(MAX_SIG_DATA_SZ, ssl->heap,
+                                                            DYNAMIC_TYPE_SIGNATURE);
+                }
+                if (args->sigData == NULL) {
+                    ERROR_OUT(MEMORY_E, exit_scv);
+                }
             }
 
             /* Create the data to be signed. */


### PR DESCRIPTION
Fixes zd#16449: memory leak issue with args->sigData.

Better to not reallocate the memory which will presumably be the same length and will only lead to possible memory fragmentation. It's also not great to free the memory in case the offloaded asynchronous device is using it.