### PR TITLE
SP: WOLFSSL_SP_ARM_ARCH to WOLFSSL_ARM_ARCH

### DIFF
--- a/wolfcrypt/src/sp_cortexm.c
+++ b/wolfcrypt/src/sp_cortexm.c
@@ -67460,10 +67460,10 @@ static void sp_1024_mont_reduce_32(sp_digit* a_p, const sp_digit* m_p, sp_digit 
         "STR	r9, [%[a], #12]\n\t"
         "STR	r10, [%[a], #16]\n\t"
         "LDR	r12, [%[m], #124]\n\t"
-        "SUBS	r11, r12, r11\n\t"
+        "SUBS	r3, r12, r3\n\t"
         "neg	r5, r5\n\t"
-        "SBC	r11, r11, r11\n\t"
-        "ORR	r5, r5, r11\n\t"
+        "SBC	r3, r3, r3\n\t"
+        "ORR	r5, r5, r3\n\t"
         "MOV	%[mp], r5\n\t"
         : [a] "+r" (a), [m] "+r" (m), [mp] "+r" (mp)
         :

--- a/wolfssl/wolfcrypt/sp.h
+++ b/wolfssl/wolfcrypt/sp.h
@@ -24,6 +24,7 @@
 #define WOLF_CRYPT_SP_H
 
 #include <wolfssl/wolfcrypt/types.h>
+#include <wolfssl/wolfcrypt/settings.h>
 
 #if defined(WOLFSSL_HAVE_SP_RSA) || defined(WOLFSSL_HAVE_SP_DH) || \
                                     defined(WOLFSSL_HAVE_SP_ECC)

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -37,6 +37,10 @@ This library provides single precision (SP) integer math functions.
 extern "C" {
 #endif
 
+#if defined(WOLFSSL_SP_ARM_ARCH) && !defined(WOLFSSL_ARM_ARCH)
+    #define WOLFSSL_ARM_ARCH    WOLFSSL_SP_ARM_ARCH
+#endif
+
 #if defined(OPENSSL_EXTRA) && !defined(NO_ASN) && \
     !defined(WOLFSSL_SP_INT_NEGATIVE)
     #define WOLFSSL_SP_INT_NEGATIVE


### PR DESCRIPTION
# Description

WOLFSSL_SP_ARM_ARCH no longer used.
Using WOLFSSL_ARM_ARCH instead.

# Testing

Standard

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
