### PR TITLE
Ignore all the paths generated by IAR-EWARM in .ewp's directory

### DIFF
--- a/IDE/IAR-EWARM/.gitignore
+++ b/IDE/IAR-EWARM/.gitignore
@@ -1,0 +1,11 @@
+# Generated files
+settings/
+*.dep
+
+# Unused project settings for C-STAT and C-RUN
+*.ewt
+
+# Build artifacts
+ewarm/
+Debug/
+Release/

--- a/IDE/IAR-EWARM/embOS/.gitignore
+++ b/IDE/IAR-EWARM/embOS/.gitignore
@@ -1,6 +1,0 @@
-*.bat
-*.xcl
-*.crun
-*.dbgdt
-*.dni
-


### PR DESCRIPTION
# Description

`settings/` contains all the files previously ignored by extension and more. For the description of files, see chapter `Product files` of [IDE Project Management and Building Guide](https://wwwfiles.iar.com/arm/webic/doc/EWARM_IDEGuide.ENU.pdf).

My motivation is that merely opening a folder with wolfssl in Visual Studio Code with [the official IAR Build extension](https://marketplace.visualstudio.com/items?itemName=iarsystems.iar-build) enabled creates untracked files.

# Testing

Manual

# Checklist

N/A
