### PR TITLE
Add compile-time option WOLFSSL_PKCS11_RW_TOKENS

### DIFF
--- a/wolfcrypt/src/wc_pkcs11.c
+++ b/wolfcrypt/src/wc_pkcs11.c
@@ -3755,7 +3755,12 @@ int wc_Pkcs11_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
     int ret = 0;
     Pkcs11Token* token = (Pkcs11Token*)ctx;
     Pkcs11Session session;
+
+#ifdef WOLFSSL_PKCS11_RW_TOKENS
+    int readWrite = 1;
+#else
     int readWrite = 0;
+#endif
 
     if (devId <= INVALID_DEVID || info == NULL || ctx == NULL)
         ret = BAD_FUNC_ARG;


### PR DESCRIPTION
# Description

By default, wolfcrypt PKCS11 interface accesses tokens in read-only mode. In some cases, we might want to build the client with write permissions, i.e. when initializing tokens via C_InitToken().

The WOLFSSL_PKCS11_RW_TOKENS option, if present, allows write access to PKCS11 tokens.

# Testing

Tested via TrustZone-M + wolfBoot + wolfPKCS11 in [wolfBoot PR 275](https://github.com/wolfssl/wolfboot/pull/275)

