### PR TITLE
Fix writedup rng leak

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -7934,6 +7934,8 @@ void SSL_ResourceFree(WOLFSSL* ssl)
     if (ssl->options.weOwnRng) {
         wc_FreeRng(ssl->rng);
         XFREE(ssl->rng, ssl->heap, DYNAMIC_TYPE_RNG);
+        ssl->rng = NULL;
+        ssl->options.weOwnRng = 0;
     }
     FreeSuites(ssl);
     FreeHandshakeHashes(ssl);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1563,6 +1563,13 @@ static int DupSSL(WOLFSSL* dup, WOLFSSL* ssl)
     ssl->dupWrite->dupCount = 2;    /* both sides have a count to start */
     dup->dupWrite = ssl->dupWrite; /* each side uses */
 
+    if (dup->options.weOwnRng) {
+        wc_FreeRng(dup->rng);
+        XFREE(dup->rng, dup->heap, DYNAMIC_TYPE_RNG);
+        dup->rng = NULL;
+        dup->options.weOwnRng = 0;
+    }
+
     /* copy write parts over to dup writer */
     XMEMCPY(&dup->specs,   &ssl->specs,   sizeof(CipherSpecs));
     XMEMCPY(&dup->options, &ssl->options, sizeof(Options));


### PR DESCRIPTION
# Description

In `DupSSL`, the already allocated `dup->rng` is only freed when `dup->options.weOwnRng` is true. But `dup->options.weOwnRng` is cleared when the options are copied from the original ssl:

```
    /* copy write parts over to dup writer */
    XMEMCPY(&dup->specs,   &ssl->specs,   sizeof(CipherSpecs));
    XMEMCPY(&dup->options, &ssl->options, sizeof(Options));
```

Fixes #6760 

# Testing

## wolfssl

```
./configure --enable-debug --enable-all --disable-fpecc -disable-aligndata --disable-examples --enable-writedup --enable-tlsv10 --disable-jni --disable-crl-monitor   C_EXTRA_FLAGS="-fPIC"   CFLAGS="-DWOLFSSL_STATIC_RSA -DWOLFSSL_DEBUG_MEMORY" && make && sudo make install
```

## wolfssl-examples

Change writedup example to use TLS1.0
[writedup_tls1_0.patch](https://github.com/wolfSSL/wolfssl/files/12653632/writedup_tls1_0.patch)

Build with fsanitize=leak

Run `wolfssl-examples/tls$ ./server-tls-writedup`
and `wolfssl-examples/tls$ ./client-tls-writedup 127.0.0.1`

Observe memory leaks:
[fsan_client_error.log](https://github.com/wolfSSL/wolfssl/files/12653635/fsan_client_error.log)

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
