### PR TITLE
Enforce WOLFSSL_SP_NO_UMAAL with _CORTEX_M_ASM

### DIFF
--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -178,6 +178,13 @@ extern "C" {
 #define WOLFSSL_SP_DIV_WORD_HALF
 #endif
 
+/* Detect Cortex M3 (no UMAAL) */
+#if defined(WOLFSSL_SP_ARM_CORTEX_M_ASM) && defined(__ARM_ARCH_7M__)
+    #undef  WOLFSSL_SP_NO_UMAAL
+    #define WOLFSSL_SP_NO_UMAAL
+#endif
+
+
 /* Make sure WOLFSSL_SP_ASM build option defined when requested */
 #if !defined(WOLFSSL_SP_ASM) && ( \
       defined(WOLFSSL_SP_X86_64_ASM) || defined(WOLFSSL_SP_ARM32_ASM) || \


### PR DESCRIPTION
# Description

Implicitly add WOLFSSL_SP_NO_UMAAL when WOLFSSL_SP_ARM_CORTEX_M_ASM is enabled


# Testing

Tested via wolfBoot build

