### PR TITLE
pqc: fix memory type for shared secret storage server side

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -8925,7 +8925,7 @@ static int server_generate_pqc_ciphertext(WOLFSSL* ssl,
 
     if (ret == 0) {
         sharedSecret = (byte*)XMALLOC(ecc_kse->keyLen + ssSz, ssl->heap,
-            DYNAMIC_TYPE_TLSX);
+            DYNAMIC_TYPE_SECRET);
         ciphertext = (byte*)XMALLOC(ecc_kse->pubKeyLen + ctSz, ssl->heap,
             DYNAMIC_TYPE_TLSX);
 
@@ -8999,7 +8999,7 @@ static int server_generate_pqc_ciphertext(WOLFSSL* ssl,
 
     TLSX_KeyShare_FreeAll(ecc_kse, ssl->heap);
     if (sharedSecret != NULL)
-        XFREE(sharedSecret, ssl->heap, DYNAMIC_TYPE_TLSX);
+        XFREE(sharedSecret, ssl->heap, DYNAMIC_TYPE_SECRET);
     if (ciphertext != NULL)
         XFREE(ciphertext, ssl->heap, DYNAMIC_TYPE_TLSX);
     wc_ecc_free(&eccpubkey);


### PR DESCRIPTION
# Description

Fixes a mismatch between allocation types.

The memory is freed in
https://github.com/wolfSSL/wolfssl/blob/5bc5b8a99b6689f47efdaae595329c76d69eb006/src/tls.c#L8351-L8367

But has a completely different type.

It also wasn't clear to me who frees the public key but the pubKey might also need to be swapped to a different type.

# Testing

CI tested

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
