### PR TITLE
no WSL/Windows git hooks from autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -3,16 +3,44 @@
 # Create configure and makefile stuff...
 #
 
+# Check environment
+if [ -n "$WSL_DISTRO_NAME" ]; then
+    # we found a non-blank WSL environment distro name
+    current_path="$(pwd)"
+    pattern="/mnt/?"
+    if [ "$(echo "$current_path" | grep -E "^$pattern")" ]; then
+        # if we are in WSL and shared Windows file system, 'ln' does not work.
+        no_links=true
+    else
+        no_links=
+    fi
+fi
+
 # Git hooks should come before autoreconf.
 if [ -d .git ]; then
     if [ ! -d .git/hooks ]; then
         mkdir .git/hooks || exit $?
     fi
-    if [ ! -e .git/hooks/pre-commit ]; then
-        ln -s ../../pre-commit.sh .git/hooks/pre-commit || exit $?
-    fi
-    if [ ! -e .git/hooks/pre-push ]; then
-        ln -s ../../pre-push.sh .git/hooks/pre-push || exit $?
+
+    if [ -n "$no_links" ]; then
+        echo "Linux ln does not work on shared Windows file system in WSL."
+        if [ ! -e .git/hooks/pre-commit ]; then
+            echo "The pre-commit.sh file will not be copied to .git/hooks/pre-commit"
+            # shell scripts do not work on Windows; TODO create equivalent batch file
+            # cp ./pre-commit.sh .git/hooks/pre-commit || exit $?
+        fi
+        if [ ! -e .git/hooks/pre-push ]; then
+            echo "The pre-push.sh file will not be copied to .git/hooks/pre-commit"
+            # shell scripts do not work on Windows; TODO create equivalent batch file
+            # cp ./pre-push.sh .git/hooks/pre-push || exit $?
+        fi
+    else
+        if [ ! -e .git/hooks/pre-commit ]; then
+            ln -s ../../pre-commit.sh .git/hooks/pre-commit || exit $?
+        fi
+        if [ ! -e .git/hooks/pre-push ]; then
+            ln -s ../../pre-push.sh .git/hooks/pre-push || exit $?
+        fi
     fi
 fi
 


### PR DESCRIPTION
# Description

This PR addresses https://github.com/wolfSSL/wolfssl/issues/6779 and prevents [autogen.sh](https://github.com/wolfSSL/wolfssl/blob/master/autogen.sh) from copying git hook shell scripts in WSL when the underlying file system is shared with Windows. 

Fixes zd# n/a

# Testing

How did you test?

Tested on Windows / WSL / Ubuntu VM

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
