### PR TITLE
fix NO_MALLOC guard in an error case

### DIFF
--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -1734,7 +1734,9 @@ static int RsaUnPad_PSS(byte *pkcsBlock, unsigned int pkcsBlockLen,
 
     if ((ret = RsaMGF(mgf, pkcsBlock + maskLen, (word32)hLen, tmp, (word32)maskLen,
                                                                   heap)) != 0) {
+        #if !defined(WOLFSSL_NO_MALLOC) || defined(WOLFSSL_STATIC_MEMORY)
         XFREE(tmp, heap, DYNAMIC_TYPE_RSA_BUFFER);
+        #endif
         return ret;
     }
 
@@ -1748,7 +1750,9 @@ static int RsaUnPad_PSS(byte *pkcsBlock, unsigned int pkcsBlockLen,
             }
         }
         if (tmp[i] != (pkcsBlock[i] ^ 0x01)) {
+            #if !defined(WOLFSSL_NO_MALLOC) || defined(WOLFSSL_STATIC_MEMORY)
             XFREE(tmp, heap, DYNAMIC_TYPE_RSA_BUFFER);
+            #endif
             WOLFSSL_MSG("RsaUnPad_PSS: Padding Error Match");
             return PSS_SALTLEN_RECOVER_E;
         }
@@ -1759,13 +1763,17 @@ static int RsaUnPad_PSS(byte *pkcsBlock, unsigned int pkcsBlockLen,
     {
         for (i = 0; i < maskLen - 1 - saltLen; i++) {
             if (tmp[i] != pkcsBlock[i]) {
+                #if !defined(WOLFSSL_NO_MALLOC) || defined(WOLFSSL_STATIC_MEMORY)
                 XFREE(tmp, heap, DYNAMIC_TYPE_RSA_BUFFER);
+                #endif
                 WOLFSSL_MSG("RsaUnPad_PSS: Padding Error Match");
                 return PSS_SALTLEN_E;
             }
         }
         if (tmp[i] != (pkcsBlock[i] ^ 0x01)) {
+            #if !defined(WOLFSSL_NO_MALLOC) || defined(WOLFSSL_STATIC_MEMORY)
             XFREE(tmp, heap, DYNAMIC_TYPE_RSA_BUFFER);
+            #endif
             WOLFSSL_MSG("RsaUnPad_PSS: Padding Error End");
             return PSS_SALTLEN_E;
         }


### PR DESCRIPTION
# Description

fix NO_MALLOC guard in RsaUnPad_PSS, an error case XFREE. 

Fixes zd#
    #16717

# Testing

pre-commit tests

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
