### PR TITLE
ESP32 examples: update interim set_time() fixed value

### DIFF
--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/wifi_connect.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/wifi_connect.c
@@ -58,10 +58,10 @@ static void set_time()
     time_t now;
     struct tm timeinfo;
     char strftime_buf[64];
-    /* please update the time if seeing unknown failure when loading cert.  */
-    /* this could cause TLS communication failure due to time expiration    */
-    /* incleasing 31536000 seconds is close to spend 356 days.              */
-    utctime.tv_sec = 1645797600; /* dummy time: Fri 25 Feb 2022 02:00:00 2022 */
+    /* please update the time if seeing unknown failure when loading cert.   */
+    /* this could cause TLS communication failure due to time expiration     */
+    /* increasing 31536000 seconds is close to spanning 356 days.            */
+    utctime.tv_sec = 1695513105; /* dummy time: Sat Sep 23 17:05:31 PDT 2023 */
     utctime.tv_usec = 0;
     tz.tz_minuteswest = 0;
     tz.tz_dsttime = 0;

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/wifi_connect.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/wifi_connect.c
@@ -58,10 +58,10 @@ static void set_time()
     time_t now;
     struct tm timeinfo;
     char strftime_buf[64];
-    /* please update the time if seeing unknown failure when loading cert.  */
-    /* this could cause TLS communication failure due to time expiration    */
-    /* incleasing 31536000 seconds is close to spend 356 days.              */
-    utctime.tv_sec = 1645797600; /* dummy time: Fri 25 Feb 2022 02:00:00 2022 */
+    /* please update the time if seeing unknown failure when loading cert.   */
+    /* this could cause TLS communication failure due to time expiration     */
+    /* increasing 31536000 seconds is close to spanning 356 days.            */
+    utctime.tv_sec = 1695513105; /* dummy time: Sat Sep 23 17:05:31 PDT 2023 */
     utctime.tv_usec = 0;
     tz.tz_minuteswest = 0;
     tz.tz_dsttime = 0;


### PR DESCRIPTION
# Description

Updates the fixed pseudo-time settings for the ESP32 client and server examples to accommodate the updated example certificates.  

This is an interim update while I prepare a more robust NTP time server implementation for the examples.

Without this adjustment, the ESP32 examples fail:

```
I (5836) tls_client: Set dummy time...
I (5841) tls_client: The current date/time is: Fri Feb 25 14:00:00 2022
I (5848) tls_client: get target IP address
I (5852) tls_client: 192.168.1.125
E (5859) tls_client: ERROR: failed to load -150, please check the file.

I (5864) main_task: Returned from app_main()
Connecting to server....192.168.1.125(port:11111)
E (24136) tls_client: ERROR: failed to connect ret=-1
```

Fixes zd# n/a

# Testing

How did you test?

I manually loaded the apps and confirmed the certs load. This is related to my work at the Espressif Component Staging site:

https://components-staging.espressif.com/components/gojimmypi/mywolfssl?language=en

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
