### PR TITLE
Fix 'negative character value'

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -744,7 +744,7 @@ static char* expandValue(WOLFSSL_CONF *conf, const char* section,
                     strIdx += 2;
                     startIdx = strIdx;
                 }
-                while (*strIdx && (XISALNUM((int)(*strIdx)) || *strIdx == '_'))
+                while (*strIdx && (XISALNUM(*strIdx) || *strIdx == '_'))
                     strIdx++;
                 endIdx = strIdx;
                 if (startIdx == endIdx) {

--- a/src/conf.c
+++ b/src/conf.c
@@ -744,7 +744,7 @@ static char* expandValue(WOLFSSL_CONF *conf, const char* section,
                     strIdx += 2;
                     startIdx = strIdx;
                 }
-                while (*strIdx && (XISALNUM(*strIdx) || *strIdx == '_'))
+                while (*strIdx && (XISALNUM((unsigned char)*strIdx) || *strIdx == '_'))
                     strIdx++;
                 endIdx = strIdx;
                 if (startIdx == endIdx) {

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1225,7 +1225,7 @@ static WC_INLINE void build_addr(SOCKADDR_IN_T* addr, const char* peer,
 
 #ifndef TEST_IPV6
     /* peer could be in human readable form */
-    if ( ((size_t)peer != INADDR_ANY) && isalpha(peer[0])) {
+    if ( ((size_t)peer != INADDR_ANY) && isalpha((unsigned char)peer[0])) {
     #ifdef WOLFSSL_USE_POPEN_HOST
         char host_ipaddr[4] = { 127, 0, 0, 1 };
         int found = 1;

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1225,7 +1225,7 @@ static WC_INLINE void build_addr(SOCKADDR_IN_T* addr, const char* peer,
 
 #ifndef TEST_IPV6
     /* peer could be in human readable form */
-    if ( ((size_t)peer != INADDR_ANY) && isalpha((int)peer[0])) {
+    if ( ((size_t)peer != INADDR_ANY) && isalpha(peer[0])) {
     #ifdef WOLFSSL_USE_POPEN_HOST
         char host_ipaddr[4] = { 127, 0, 0, 1 };
         int found = 1;


### PR DESCRIPTION
In a number of libc implementations, isalpha()/isalnum() is implemented using lookup tables (arrays): passing in a negative value can result in a read underrun.
