### PR TITLE
ESP32 debug only: Mode REVERT to ESP32_SHA_SW

### DIFF
--- a/wolfcrypt/src/port/Espressif/esp32_sha.c
+++ b/wolfcrypt/src/port/Espressif/esp32_sha.c
@@ -757,7 +757,9 @@ int esp_sha_try_hw_lock(WC_ESP32SHA* ctx)
         else {
             /* We should have otherwise anticipated this; how did we get here?
             ** This code should rarely, ideally never be reached. */
+        #if defined(DEBUG_WOLFSSL)
             ESP_LOGI(TAG, "\nHardware in use; Mode REVERT to ESP32_SHA_SW\n");
+        #endif
             ctx->mode = ESP32_SHA_SW;
             return 0; /* success, but revert to SW */
         }


### PR DESCRIPTION
# Description

This PR addresses https://github.com/wolfSSL/wolfMQTT/issues/353 by wrapping a single line of code in conditional debug macro. The HW lock is unexpectedly unable to be obtained when using wolfMQTT. The result is a flood of undesired debug messages.

This is related to https://github.com/wolfSSL/wolfMQTT/issues/352, specifically my [AWS_IoT_MQTT](https://github.com/gojimmypi/wolfMQTT/tree/component-manager/IDE/Espressif/ESP-IDF/examples/AWS_IoT_MQTT) example.

Fixes zd# n/a

# Testing

How did you test?

manual testing

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
