### PR TITLE
20230930-aes-xts-test-gate

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -9501,7 +9501,9 @@ static wc_test_ret_t aes_xts_128_test(void)
 
 #endif /* !HAVE_FIPS || FIPS_VERSION_GE(5,3) */
 
-#if !defined(BENCH_EMBEDDED) && !defined(HAVE_CAVIUM)
+#if !defined(BENCH_EMBEDDED) && !defined(HAVE_CAVIUM) && \
+    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3)) &&     \
+    !defined(WOLFSSL_AFALG)
     {
     #define LARGE_XTS_SZ        1024
     #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
@@ -9554,7 +9556,10 @@ static wc_test_ret_t aes_xts_128_test(void)
         XFREE(large_input, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     #endif
     }
-#endif
+#endif /* !BENCH_EMBEDDED && !HAVE_CAVIUM &&
+        * (!HAVE_FIPS || FIPS_VERSION_GE(5,3)) &&
+        * !WOLFSSL_AFALG
+        */
 
   out:
 


### PR DESCRIPTION
`wolfcrypt/test/test.c`: in `aes_xts_128_test()`, fix gate on `LARGE_XTS_SZ` test added in 3ea0fb30dd (disable for `AF_ALG` and pre-5.3 FIPS).

tested with `wolfssl-multi-test.sh ... all-afalg fips-140-3-all fips-140-3-pilot-all linuxkm-defaults-all-fips-140-3 linuxkm-defaults-all-fips-140-3-pilot fips-140-3-RC12 clang-tidy-fips-140-3-all clang-tidy-fips-140-3-pilot-all check-self check-file-modes check-source-text check-shell-scripts check-configure all-gcc-c99 all-gcc-c99-asn-original cryptonly-opensslextra-gcc-c99 all-gcc-c89`.

fixes failures found in nightly on the above scenarios, all of the form:
```
AES      test failed!
 error L=9549
 [fiducial line numbers: 7863 24104 35490 47669]
FAIL testsuite/testsuite.test (exit status: 255)
```
except `AF_ALG`:
```
AES      test failed!
 error L=9534 code=-264 (AF_ALG socket error)
 [fiducial line numbers: 7863 24104 35490 47669]
FAIL testsuite/testsuite.test (exit status: 255)
```
