### PR TITLE
fix: tls13: don't use stale suites pointers in CheckPreSharedKeys

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -6064,7 +6064,7 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
     int    first = 0;
 #ifndef WOLFSSL_PSK_ONE_ID
     int    i;
-    const Suites* suites = WOLFSSL_SUITES(ssl);
+    const Suites* suites;
 #else
     byte   suite[2];
 #endif
@@ -6102,7 +6102,8 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
 
     /* Refine list for PSK processing. */
     RefineSuites(ssl, clSuites);
-
+    /* set after refineSuites, to avoid taking a stale ptr to ctx->Suites */
+    suites = WOLFSSL_SUITES(ssl);
 #ifndef WOLFSSL_PSK_ONE_ID
     if (usingPSK == NULL)
         return BAD_FUNC_ARG;


### PR DESCRIPTION
# Description

Fix to avoid using a stale pointer for suites. 
