### PR TITLE
Fix issue created by 62c14e4d5b5b5ff421742226c92dacc8621f26b7

### DIFF
--- a/tests/utils.h
+++ b/tests/utils.h
@@ -47,7 +47,7 @@ char* create_tmp_dir(char *tmpDir, int len)
 #ifdef _MSC_VER
     if (_mkdir(tmpDir) != 0)
         return NULL;
-#elif defined(__CYGWIN__) || defined(__MINGW32__)
+#elif defined(__MINGW32__)
     if (mkdir(tmpDir) != 0)
         return NULL;
 #else


### PR DESCRIPTION
Fix compilation error on Windows:
```
In file included from testsuite/testsuite.c:48:0:
./tests/utils.h: In function 'create_tmp_dir':
./tests/utils.h:51:9: error: too few arguments to function 'mkdir'
     if (mkdir(tmpDir) != 0)
         ^
In file included from /usr/include/sys/types.h:20:0,
                 from /usr/include/pthread.h:14,
                 from ./wolfssl/wolfcrypt/wc_port.h:186,
                 from ./wolfssl/wolfcrypt/types.h:35,
                 from testsuite/testsuite.c:28:
/usr/include/sys/stat.h:150:5: note: declared here
 int _EXFUN(mkdir,( const char *_path, mode_t __mode ));
```