### PR TITLE
Fix wc_RsaKeyToDer docs return value

### DIFF
--- a/doc/dox_comments/header_files-ja/rsa.h
+++ b/doc/dox_comments/header_files-ja/rsa.h
@@ -859,7 +859,7 @@ int  wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz,
 /*!
     \ingroup RSA
     \brief  この機能はRSAKEYキーをDERフォーマットに変換します。結果は出力に書き込まれ、書き込まれたバイト数を返します。
-    \return 0  成功
+    \return >0  成功、書かれたバイト数。
     \return BAD_FUNC_ARG  キーまたは出力がNULLの場合、またはキー - >タイプがRSA_PRIVATEでない場合、またはINLENが出力バッファに十分な大きさでない場合は返されます。
     \return MEMORY_E  メモリの割り当て中にエラーが発生した場合に返されます。
     \param key  初期化されたRsaKey構造体

--- a/doc/dox_comments/header_files/rsa.h
+++ b/doc/dox_comments/header_files/rsa.h
@@ -1104,7 +1104,7 @@ int  wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz,
     \brief This function converts an RsaKey key to DER format.  The result is
     written to output and it returns the number of bytes written.
 
-    \return 0 Success
+    \return >0 Success, number of bytes written.
     \return BAD_FUNC_ARG Returned if key or output is null, or if key->type
     is not RSA_PRIVATE, or if inLen isn't large enough for output buffer.
     \return MEMORY_E Returned if there is an error allocating memory.


### PR DESCRIPTION
# Description

Documentation for wc_RsaKeyToDer() return value is incorrect.

Fixes zd#

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
