### PR TITLE
20231003-options-h-flag-order-etc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9197,7 +9197,7 @@ else
     AC_MSG_ERROR([Could not find colrm or cut to make options file])
 fi
 
-for option in $CPPFLAGS $AM_CPPFLAGS $CFLAGS $AM_CFLAGS; do
+for option in $AM_CPPFLAGS $CPPFLAGS $AM_CFLAGS $CFLAGS; do
     opt_type=$(echo $option | $TRIM )
     case "$opt_type" in
     -D)


### PR DESCRIPTION
`configure.ac`: in `options.h` generation, fix order of flags to match `Makefile` order.

`wolfcrypt/test/test.c`: fix error codes in `hpke_test_single()`, `hpke_test()`, and `ecc521_test_deterministic_k()`.

tested with `wolfssl-multi-test.sh ... super-quick-check`.


Note, the fixes in `configure.ac` were needed for `CFLAGS='-UHAVE_ECC521 -UWOLFSSL_SP_521'` to work as expected.  Without the fix, the library is built with ECC521 disabled, but `testwolfcrypt` is built with it enabled (and naturally the ECC test fails).  Anyway it's more useful for user `CFLAGS` to appear at the end of `options.h`, so that undefs are possible, as in my disable-ECC521 use case.
