### PR TITLE
Fixes for bugs exposed with SCR

### DIFF
--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -19,6 +19,8 @@ jobs:
            --enable-opensslextra --enable-sessioncerts 
            CPPFLAGS=''-DWOLFSSL_DTLS_NO_HVR_ON_RESUME -DHAVE_EXT_CACHE 
            -DWOLFSSL_TICKET_HAVE_ID -DHAVE_EX_DATA -DSESSION_CACHE_DYNAMIC_MEM'' ',
+          '--enable-all --enable-secure-renegotiation',
+          '--enable-all --enable-haproxy --enable-quic',
         ]
     name: make check
     runs-on: ${{ matrix.os }}

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3338,22 +3338,6 @@ static int wolfSSL_read_internal(WOLFSSL* ssl, void* data, int sz, int peek)
         errno = 0;
 #endif
 
-#ifdef WOLFSSL_DTLS
-    if (ssl->options.dtls) {
-        ssl->dtls_expected_rx = max(sz + DTLS_MTU_ADDITIONAL_READ_BUFFER,
-                MAX_MTU);
-#ifdef WOLFSSL_SCTP
-        if (ssl->options.dtlsSctp)
-#endif
-#if defined(WOLFSSL_SCTP) || defined(WOLFSSL_DTLS_MTU)
-            /* Add some bytes so that we can operate with slight difference
-             * in set MTU size on each peer */
-            ssl->dtls_expected_rx = max(ssl->dtls_expected_rx,
-                    ssl->dtlsMtuSz + (word32)DTLS_MTU_ADDITIONAL_READ_BUFFER);
-#endif
-    }
-#endif
-
     ret = ReceiveData(ssl, (byte*)data, sz, peek);
 
 #ifdef HAVE_WRITE_DUP

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -30246,12 +30246,8 @@ WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
 #else
     (void)ret;
 #endif
-    if (ssl->ctx) {
+    if (ssl->ctx != NULL)
         wolfSSL_CTX_free(ssl->ctx);
-#if defined(WOLFSSL_HAPROXY)
-        wolfSSL_CTX_free(ssl->initial_ctx);
-#endif
-    }
     ssl->ctx = ctx;
 
 #ifndef NO_CERTS

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -5567,7 +5567,6 @@ struct WOLFSSL {
     DtlsMsg*        dtls_tx_msg;
     DtlsMsg*        dtls_rx_msg_list;
     void*           IOCB_CookieCtx;     /* gen cookie ctx */
-    word32          dtls_expected_rx;
 #ifdef WOLFSSL_SESSION_EXPORT
     wc_dtls_export  dtls_export;        /* export function for session */
 #endif


### PR DESCRIPTION
- Remove dtls_expected_rx and use expected values directly
  - We should always read MTU + EXTRA so that we capture the entire message and are able to correctly decrypt the entire datagram. A smaller MTU also breaks larger handshake messages sent during a connection like secure renegotiation in DTLS 1.2 (confirmed) and post-handshake messages in DTLS 1.3 (suspected).
- Proper initial_ctx clean up
  - Call wolfSSL_CTX_free on ssl->initial_ctx so that it decrements the counter and free's the object
  - Clean up where ssl->initial_ctx is free'd. It only needs to be free'd when the ssl object is being free'd
- Add configs that exposed this bug