### PR TITLE
Aarch64 and ARM32 AES XTS with crypto instructions

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -11041,6 +11041,7 @@ void AES_XTS_decrypt_avx1(const unsigned char *in, unsigned char *out,
 
 #endif /* WOLFSSL_AESNI */
 
+#if !defined(WOLFSSL_ARMASM) || defined(WOLFSSL_ARMASM_NO_HW_CRYPTO)
 #ifdef HAVE_AES_ECB
 /* helper function for encrypting / decrypting full buffer at once */
 static WARN_UNUSED_RESULT int _AesXtsHelper(
@@ -11438,6 +11439,8 @@ int wc_AesXtsDecrypt(XtsAes* xaes, byte* out, const byte* in, word32 sz,
         return AesXtsDecrypt_sw(xaes, out, in, sz, i);
     }
 }
+#endif /* !WOLFSSL_ARMASM || WOLFSSL_ARMASM_NO_HW_CRYPTO */
+
 #endif /* WOLFSSL_AES_XTS */
 
 #ifdef WOLFSSL_AES_SIV

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -9321,6 +9321,12 @@ static wc_test_ret_t aes_xts_128_test(void)
         0xff, 0x8d, 0xbc, 0x1d, 0x9f, 0x7f, 0xc8, 0x22
     };
 
+    WOLFSSL_SMALL_STACK_STATIC unsigned char cp2[] = {
+        0x2b, 0xf7, 0x2c, 0xf3, 0xeb, 0x85, 0xef, 0x7b,
+        0x0b, 0x76, 0xa0, 0xaa, 0xf3, 0x3f, 0x25, 0x8b,
+        0x77, 0x8a, 0xe8, 0xb4, 0x3c, 0xb9, 0x8d, 0x5a
+    };
+
 #if !defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3)
 
     WOLFSSL_SMALL_STACK_STATIC unsigned char k3[] = {
@@ -9405,6 +9411,8 @@ static wc_test_ret_t aes_xts_128_test(void)
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    if (XMEMCMP(cp2, cipher, sizeof(cp2)))
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     wc_AesXtsFree(aes);
 
     /* partial block decrypt test */


### PR DESCRIPTION
# Description

Optimised assembly of AES-XTS for Aarch64 and ARM32 using hardware crypto instructions.
Aarch64 has loop unrolling.
Update aes.c to not have AES-XTS implementation when assembly compilable.
Update test of AES-XTS to check expected cipher text of partial block encryption.

# Testing

Tested on Aarch64 Mac and ARM platforms with emulator.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
