### PR TITLE
Fix wolfSSL_set_verify_result to use correct value

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -10752,8 +10752,9 @@ void wolfSSL_set_verify_result(WOLFSSL *ssl, long v)
     if (ssl == NULL)
         return;
 
-#ifdef OPENSSL_ALL
-    ssl->verifyCallbackResult = v;
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || \
+    defined(OPENSSL_ALL)
+    ssl->peerVerifyRet = v;
 #else
     (void)v;
     WOLFSSL_STUB("wolfSSL_set_verify_result");
@@ -23074,7 +23075,8 @@ size_t wolfSSL_get_peer_finished(const WOLFSSL *ssl, void *buf, size_t count)
 }
 #endif /* WOLFSSL_HAVE_TLS_UNIQUE */
 
-#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || \
+    defined(OPENSSL_ALL)
 long wolfSSL_get_verify_result(const WOLFSSL *ssl)
 {
     if (ssl == NULL) {

--- a/tests/api.c
+++ b/tests/api.c
@@ -42475,6 +42475,29 @@ static int test_wolfSSL_verify_depth(void)
     return EXPECT_RESULT();
 }
 
+static int test_wolfSSL_verify_result(void)
+{
+    EXPECT_DECLS;
+#if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || \
+    defined(OPENSSL_ALL)) && !defined(NO_WOLFSSL_CLIENT)
+    WOLFSSL*     ssl = NULL;
+    WOLFSSL_CTX* ctx = NULL;
+    long         result = 0xDEADBEEF;
+
+    ExpectIntEQ(WOLFSSL_FAILURE, wolfSSL_get_verify_result(ssl));
+
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()));
+    ExpectNotNull(ssl = SSL_new(ctx));
+
+    wolfSSL_set_verify_result(ssl, result);
+    ExpectIntEQ(result, wolfSSL_get_verify_result(ssl));
+
+    SSL_free(ssl);
+    SSL_CTX_free(ctx);
+#endif
+    return EXPECT_RESULT();
+}
+
 #if defined(OPENSSL_EXTRA) && !defined(NO_HMAC)
 /* helper function for test_wolfSSL_HMAC_CTX, digest size is expected to be a
  * buffer of 64 bytes.
@@ -65936,6 +65959,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_sk_DIST_POINT),
     TEST_DECL(test_wolfSSL_verify_mode),
     TEST_DECL(test_wolfSSL_verify_depth),
+    TEST_DECL(test_wolfSSL_verify_result),
     TEST_DECL(test_wolfSSL_msg_callback),
 
     TEST_DECL(test_wolfSSL_MD4),

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -5476,7 +5476,8 @@ struct WOLFSSL {
 #if defined(OPENSSL_EXTRA) || defined(HAVE_CURL)
     word32            disabledCurves;   /* curves disabled by user */
 #endif
-#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || \
+    defined(OPENSSL_ALL)
     unsigned long    peerVerifyRet;
 #endif
 #ifdef OPENSSL_EXTRA
@@ -5792,9 +5793,6 @@ struct WOLFSSL {
     EarlyDataState earlyData;
     word32 earlyDataSz;
     byte earlyDataStatus;
-#endif
-#ifdef OPENSSL_ALL
-    long verifyCallbackResult;
 #endif
 #if defined(OPENSSL_EXTRA)
     WOLFSSL_STACK* supportedCiphers; /* Used in wolfSSL_get_ciphers_compat */


### PR DESCRIPTION
# Description

Currently, these two functions are not complimentary:
* `wolfSSL_get_verify_result()` returns the value of `ssl->peerVerifyRet`
* `wolfSSL_set_verify_result()` sets the value of `ssl->verifyCallbackResult` 
        (`verifyCallbackResult` isn't referenced anywhere else in wolfSSL)

FIX: these two functions should read/write the same location

Fixes zd16767

# Testing

Customer confirmed.

# Checklist

 - [X ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
