### PR TITLE
20231008-Wconversion-and-Aes-Eax-FIPS-fixes

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -12150,7 +12150,7 @@ int wc_AesEaxDecryptFinal(AesEax* eax,
                     ^ eax->ciphertextCmacFinal[i];
     }
 
-    if (ConstantCompare((const byte*)authTag, authIn, authInSz) != 0) {
+    if (ConstantCompare((const byte*)authTag, authIn, (int)authInSz) != 0) {
         ret = AES_EAX_AUTH_E;
     }
     else {

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -674,7 +674,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t certpiv_test(void);
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes_siv_test(void);
 #endif
 
-#if defined(WOLFSSL_AES_EAX)
+#if defined(WOLFSSL_AES_EAX) && \
+    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)) && !defined(HAVE_SELFTEST)
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes_eax_test(void);
 #endif /* WOLFSSL_AES_EAX */
 
@@ -1439,7 +1440,8 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 #endif
 #endif
 
-#if defined(WOLFSSL_AES_EAX)
+#if defined(WOLFSSL_AES_EAX) && \
+    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)) && !defined(HAVE_SELFTEST)
     if ( (ret = aes_eax_test()) != 0)
         TEST_FAIL("AES-EAX  test failed!\n", ret);
     else
@@ -12996,7 +12998,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aesccm_test(void)
 #endif /* HAVE_AESCCM */
 
 
-#if defined(WOLFSSL_AES_EAX)
+#if defined(WOLFSSL_AES_EAX) && \
+    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)) && !defined(HAVE_SELFTEST)
 
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes_eax_test(void)
 {


### PR DESCRIPTION
minor fixes for AES-EAX implementation and test routines.

fixes 2 reports:

```
wolfcrypt/src/aes.c: In function ‘wc_AesEaxDecryptFinal’:
fafb9e81c0 (<brett.r.nicholas.15@dartmouth.edu> 2023-09-25 17:37:26 -0600 12153)     if (ConstantCompare((const byte*)authTag, authIn, authInSz) != 0) {
wolfcrypt/src/aes.c:12153:55: error: conversion to ‘int’ from ‘word32’ {aka ‘unsigned int’} may change the sign of the result [-Werror=sign-conversion]
12153 |     if (ConstantCompare((const byte*)authTag, authIn, authInSz) != 0) {
      |                                                       ^~~~~~~~
```
and
```
wolfcrypt/test/test.c: In function ‘aes_eax_test’:
fafb9e81c0 (<brett.r.nicholas.15@dartmouth.edu> 2023-09-25 17:37:26 -0600 13105)         ret = wc_AesEaxEncryptAuth(vectors[i].key, vectors[i].key_length,
wolfcrypt/test/test.c:13105:15: error: implicit declaration of function ‘wc_AesEaxEncryptAuth’; did you mean ‘wc_AesEcbEncrypt’? [-Werror=implicit-function-declaration]
13105 |         ret = wc_AesEaxEncryptAuth(vectors[i].key, vectors[i].key_length,
      |               ^~~~~~~~~~~~~~~~~~~~
```
(and more like it -- aes.c in FIPS < 5.3 doesn't have AES-EAX of course.)

tested with `wolfssl-multi-test.sh ... check-source-text allcryptonly-Wconversion-intelasm-build allcryptonly-c99-Wconversion-build allcryptonly-c99-Wconversion-m32-build allcryptonly-c89-Wconversion-build allcryptonly-c89-Wconversion-m32-build fips-140-3-all fips-140-3-pilot-all linuxkm-all-fips-140-3 linuxkm-all-fips-140-3-dyn-hash linuxkm-defaults-all-fips-140-3 linuxkm-defaults-all-fips-140-3-pilot fips-140-3-RC12 clang-tidy-fips-140-3-all clang-tidy-fips-140-3-pilot-all`
