### PR TITLE
Update random generation on RX TSIP

### DIFF
--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/user_settings.h
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/user_settings.h
@@ -31,7 +31,7 @@
 /*-- Renesas TSIP usage and its version ---------------------------------------
  *
  *  "WOLFSSL_RENESAS_TSIP" definition makes wolfSSL to use H/W acceleration
- *   for cipher operations. 
+ *   for cipher operations.
  *  TSIP definition asks to have its version number.
  *  "WOLFSSL_RENESAS_TSIP_VER" takes following value:
  *      106: TSIPv1.06
@@ -54,16 +54,16 @@
  *
  * wolfSSL supports TLSv1.2 by default. In case you want your system to support
  * TLSv1.3, uncomment line below.
- * 
+ *
  *----------------------------------------------------------------------------*/
 #define WOLFSSL_TLS13
 
 
 /*-- Operating System related definitions --------------------------------------
- * 
+ *
  *  In case any real-time OS is used, define its name(e.g. FREERTOS).
  *  Otherwise, define "SINGLE_THREADED". They are exclusive each other.
- *   
+ *
  *----------------------------------------------------------------------------*/
 #if !defined(RENESAS_T4_USE)
  #define FREERTOS
@@ -114,23 +114,23 @@
 
   /* USE_ECC_CERT
    * This macro is for selecting root CA certificate to load, it is valid only
-   * in example applications. wolfSSL does not refer this macro. 
-   * If you want to use cipher suites including ECDSA authentication in 
+   * in example applications. wolfSSL does not refer this macro.
+   * If you want to use cipher suites including ECDSA authentication in
    * the example applications with TSIP, enable this macro.
-   * In TSIP 1.13 or later version, following cipher suites are 
+   * In TSIP 1.13 or later version, following cipher suites are
    * available:
    * - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
    * - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SAH256
-   * 
+   *
    * Note that, this macro disables cipher suites including RSA
    * authentication such as:
    * - TLS_RSA_WITH_AES_128_CBC_SHA
-   * - TLS_RSA_WITH_AES_256_CBC_SHA 
+   * - TLS_RSA_WITH_AES_256_CBC_SHA
    * - TLS_RSA_WITH_AES_128_CBC_SHA256
    * - TLS_RSA_WITH_AES_256_CBC_SHA256
    * - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
    * - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA256
-   * 
+   *
    */
   #define USE_ECC_CERT
 
@@ -139,14 +139,14 @@
    */
   /*#define WOLFSSL_CHECK_SIG_FAULTS*/
 
-  /* In this example application, Root CA cert buffer named 
-   * "ca_ecc_cert_der_256" is used under the following macro definition 
+  /* In this example application, Root CA cert buffer named
+   * "ca_ecc_cert_der_256" is used under the following macro definition
    * for ECDSA.
    */
   #define USE_CERT_BUFFERS_256
 
-  /* In this example application, Root CA cert buffer named 
-   * "ca_cert_der_2048" is used under the following macro definition 
+  /* In this example application, Root CA cert buffer named
+   * "ca_cert_der_2048" is used under the following macro definition
    * for RSA authentication.
    */
   #define USE_CERT_BUFFERS_2048
@@ -159,25 +159,25 @@
 
   #define WOLFSSL_SMALL_STACK
 
- /* 
+ /*
   * -- "NO_ASN_TIME" macro is to avoid certificate expiration validation --
-  *  
-  * Note. In your actual products, do not forget to comment-out 
+  *
+  * Note. In your actual products, do not forget to comment-out
   * "NO_ASN_TIME" macro. And prepare time function to get calendar time,
-  * otherwise, certificate expiration validation will not work.  
+  * otherwise, certificate expiration validation will not work.
   */
   /*#define NO_ASN_TIME*/
-  
+
   #define NO_MAIN_DRIVER
   #define BENCH_EMBEDDED
-  #define NO_WOLFSSL_DIR 
+  #define NO_WOLFSSL_DIR
   #define WOLFSSL_NO_CURRDIR
   #define NO_FILESYSTEM
   #define WOLFSSL_LOG_PRINTF
   #define WOLFSSL_HAVE_MIN
   #define WOLFSSL_HAVE_MAX
   #define NO_WRITEV
-  
+
 
   #define WOLFSSL_USER_CURRTIME /* for benchmark */
   #define TIME_OVERRIDES
@@ -210,7 +210,7 @@
 
 /*-- Definitions for functionality negation  -----------------------------------
  *
- * 
+ *
  *----------------------------------------------------------------------------*/
 
 /*#define NO_RENESAS_TSIP_CRYPT*/
@@ -276,3 +276,5 @@
 
 /*-- strcasecmp */
 #define XSTRCASECMP(s1,s2) strcmp((s1),(s2))
+
+#define CUSTOM_RAND_GENERATE_BLOCK wc_tsip_GenerateRandBlock

--- a/src/tls.c
+++ b/src/tls.c
@@ -7434,12 +7434,6 @@ static int TLSX_KeyShare_GenEccKey(WOLFSSL *ssl, KeyShareEntry* kse)
     }
 
     if (kse->key == NULL) {
-    #if defined(WOLFSSL_RENESAS_TSIP_TLS)
-        ret = tsip_Tls13GenEccKeyPair(ssl, kse);
-        if (ret != CRYPTOCB_UNAVAILABLE) {
-            return ret;
-        }
-    #endif
         /* Allocate an ECC key to hold private key. */
         kse->key = (byte*)XMALLOC(sizeof(ecc_key), ssl->heap, DYNAMIC_TYPE_ECC);
         if (kse->key == NULL) {
@@ -7454,6 +7448,12 @@ static int TLSX_KeyShare_GenEccKey(WOLFSSL *ssl, KeyShareEntry* kse)
             kse->keyLen = keySize;
             kse->pubKeyLen = keySize * 2 + 1;
 
+        #if defined(WOLFSSL_RENESAS_TSIP_TLS)
+            ret = tsip_Tls13GenEccKeyPair(ssl, kse);
+            if (ret != CRYPTOCB_UNAVAILABLE) {
+                return ret;
+            }
+        #endif
             /* setting eccKey means okay to call wc_ecc_free */
             eccKey = (ecc_key*)kse->key;
 

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_util.c
@@ -2800,6 +2800,30 @@ WOLFSSL_LOCAL void tsip_Close(void)
     WOLFSSL_LEAVE("tsip_Close", 0);
 }
 
+int wc_tsip_GenerateRandBlock(byte* output, word32 sz)
+{
+    /* Generate PRNG based on NIST SP800-90A AES CTR-DRBG */
+    int ret = 0;
+    word32 buffer[4];
+
+    while (sz > 0) {
+        word32 len = sizeof(buffer);
+
+        if (sz < len) {
+            len = sz;
+        }
+        /* return 4 words random number*/
+        ret = R_TSIP_GenerateRandomNumber((uint32_t*)buffer);
+        if(ret == TSIP_SUCCESS) {
+            XMEMCPY(output, &buffer, len);
+            output += len;
+            sz -= len;
+         } else
+            return ret;
+    }
+    return ret;
+}
+
 #if (WOLFSSL_RENESAS_TSIP_VER>=109)
 void tsip_inform_user_keys_ex(
     byte*     encrypted_provisioning_key,

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -3445,35 +3445,6 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         return 0;
     }
 
-#elif defined(WOLFSSL_RENESAS_TSIP)
-#if defined(WOLFSSL_RENESA_TSIP_IAREWRX)
-   #include "r_bsp/mcu/all/r_rx_compiler.h"
-#endif
-   #include "r_bsp/platform.h"
-    #include "r_tsip_rx_if.h"
-
-    int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
-    {
-        int ret = 0;
-        word32 buffer[4];
-
-        while (sz > 0) {
-            word32 len = sizeof(buffer);
-
-            if (sz < len) {
-                len = sz;
-            }
-            /* return 4 words random number*/
-            ret = R_TSIP_GenerateRandomNumber((uint32_t*)buffer);
-            if(ret == TSIP_SUCCESS) {
-                XMEMCPY(output, &buffer, len);
-                output += len;
-                sz -= len;
-            } else
-                return ret;
-        }
-        return ret;
-    }
 
 #elif defined(WOLFSSL_SCE) && !defined(WOLFSSL_SCE_NO_TRNG)
     #include "hal_data.h"

--- a/wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h
+++ b/wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h
@@ -639,6 +639,7 @@ WOLFSSL_LOCAL int wc_tsip_MakeRsaKey(int size, void* ctx);
 WOLFSSL_LOCAL int wc_tsip_RsaVerifyPkcs(wc_CryptoInfo* info, 
                                                 TsipUserCtx* tuc);
 
+WOLFSSL_LOCAL int  wc_tsip_GenerateRandBlock(byte* output, word32 size);
 
 #if defined(WOLFSSL_RENESAS_TSIP_CRYPT_DEBUG)
 byte *ret2err(word32 ret);


### PR DESCRIPTION
# Description

Change to use custom random generation for that. TSIP Random generation is based on NIST SP800-90A AES CTR-DRBG(PRNG), but not TRNG. 

Fix TLS 1.3 failure

# Testing

Run Crypt, benchmark and TLS Client on RX72N

# Checklist

 - [n/a] added tests
 - [n/a] updated/added doxygen
 - [n/a] updated appropriate READMEs
 - [n/a] Updated manual and documentation
