### PR TITLE
Fix for early exit out of ParseCertRelative

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -23198,7 +23198,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
 #endif
             {
                 WOLFSSL_ERROR_VERBOSE(ASN_NO_SIGNER_E);
-                return ASN_NO_SIGNER_E;
+                ret = ASN_NO_SIGNER_E;
             }
         }
     }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -23192,7 +23192,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
             /* ret needs to be self-signer error for Qt compat */
             if (cert->selfSigned) {
                 WOLFSSL_ERROR_VERBOSE(ASN_SELF_SIGNED_E);
-                return ASN_SELF_SIGNED_E;
+                ret = ASN_SELF_SIGNED_E;
             }
             else
 #endif


### PR DESCRIPTION
# Description

Reproducer is posted as an internal note in zd16775

Fixes zd#16775

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
