### PR TITLE
AES bitsliced implementation added

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2492,6 +2492,16 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_AES_CFB"
 fi
 
+AC_ARG_ENABLE([aes-bitsliced],
+    [AS_HELP_STRING([--enable-aes-bitsliced],[Enable bitsliced implementation of AES (default: disabled)])],
+    [ ENABLED_AESBS=$enableval ],
+    [ ENABLED_AESBS=no ]
+    )
+
+if test "$ENABLED_AESBS" = "yes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWC_AES_BITSLICED -DHAVE_AES_ECB"
+fi
 
 # SM4
 ENABLED_SM4="no"
@@ -9542,6 +9552,7 @@ echo "   * AES-CFB:                    $ENABLED_AESCFB"
 echo "   * AES-OFB:                    $ENABLED_AESOFB"
 echo "   * AES-SIV:                    $ENABLED_AESSIV"
 echo "   * AES-EAX:                    $ENABLED_AESEAX"
+echo "   * AES Bitspliced:             $ENABLED_AESBS"
 echo "   * ARIA:                       $ENABLED_ARIA"
 echo "   * DES3:                       $ENABLED_DES3"
 echo "   * Camellia:                   $ENABLED_CAMELLIA"

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -11070,6 +11070,35 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 #endif
 
+#ifdef HAVE_AES_ECB
+    {
+        WOLFSSL_SMALL_STACK_STATIC const byte verify_ecb[AES_BLOCK_SIZE] = {
+            0xd0, 0xc9, 0xd9, 0xc9, 0x40, 0xe8, 0x97, 0xb6,
+            0xc8, 0x8c, 0x33, 0x3b, 0xb5, 0x8f, 0x85, 0xd1
+        };
+        XMEMSET(cipher, 0, AES_BLOCK_SIZE * 4);
+        ret = wc_AesEcbEncrypt(enc, cipher, msg, AES_BLOCK_SIZE);
+    #if defined(WOLFSSL_ASYNC_CRYPT)
+        ret = wc_AsyncWait(ret, &enc->asyncDev, WC_ASYNC_FLAG_NONE);
+    #endif
+        if (ret != 0)
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+        if (XMEMCMP(cipher, verify_ecb, AES_BLOCK_SIZE))
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+    #ifdef HAVE_AES_DECRYPT
+        XMEMSET(plain, 0, AES_BLOCK_SIZE * 4);
+        ret = wc_AesEcbDecrypt(dec, plain, cipher, AES_BLOCK_SIZE);
+    #if defined(WOLFSSL_ASYNC_CRYPT)
+        ret = wc_AsyncWait(ret, &dec->asyncDev, WC_ASYNC_FLAG_NONE);
+    #endif
+        if (ret != 0)
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+        if (XMEMCMP(plain, msg, AES_BLOCK_SIZE))
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+    #endif /* HAVE_AES_DECRYPT */
+    }
+#endif
+
     XMEMSET(cipher, 0, AES_BLOCK_SIZE * 4);
     ret = wc_AesCbcEncrypt(enc, cipher, msg, AES_BLOCK_SIZE);
 #if defined(WOLFSSL_ASYNC_CRYPT)


### PR DESCRIPTION
# Description

AES bitsliced implementation that is cache attack safe. Configure with:
  --enable-aes-bitslice
or define:
  WC_AES_BITSLICE
  HAVE_AES_ECB
  HAVE_AES_DIRECT
Very slow for CBC, CFB, OFB and any mode that uses a previous encrypt block to calculate current.
CTR, GCM, XTS can parallelize the data and be much faster.

Added AES-ECB test to test.c.

Fixes zd#

# Testing

--enable-aes-bitsliced

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
