### PR TITLE
Enabled ctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2211,6 +2211,12 @@ if(WOLFSSL_EXAMPLES)
     set_property(TARGET unit_test
                  PROPERTY RUNTIME_OUTPUT_NAME
                  unit.test)
+    enable_testing()
+    add_test(
+        NAME unit.test
+        COMMAND $<TARGET_FILE:unit_test>
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        )
 endif()
 
 if(WOLFSSL_CRYPT_TESTS)


### PR DESCRIPTION
# Description

Enable unit tests in cmake

Fixes zd#

# Testing

build an test with cmake following these steps:

    mkdir build
    cd build
    cmake -G Ninja ..
    ninja
    ninja test

Note that tests are executed and results logged. this is the standard way to run unit tests for a library project.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
