### PR TITLE
20231012-aes-xts-fixes

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -11461,9 +11461,9 @@ int wc_AesXtsEncryptConsecutiveSectors(XtsAes* aes, byte* out, const byte* in,
         word32 sz, word64 sector, word32 sectorSz)
 {
     int ret  = 0;
-    int iter = 0;
-    int sectorCount  = sz / sectorSz;
-    int remainder = sz % sectorSz;
+    word32 iter = 0;
+    word32 sectorCount;
+    word32 remainder;
 
     if (aes == NULL || out == NULL || in == NULL || sectorSz == 0) {
         return BAD_FUNC_ARG;
@@ -11473,6 +11473,9 @@ int wc_AesXtsEncryptConsecutiveSectors(XtsAes* aes, byte* out, const byte* in,
         WOLFSSL_MSG("Cipher text input too small for encryption");
         return BAD_FUNC_ARG;
     }
+
+    sectorCount  = sz / sectorSz;
+    remainder = sz % sectorSz;
 
     while (sectorCount) {
         ret = wc_AesXtsEncryptSector(aes, out + (iter * sectorSz),
@@ -11507,9 +11510,9 @@ int wc_AesXtsDecryptConsecutiveSectors(XtsAes* aes, byte* out, const byte* in,
         word32 sz, word64 sector, word32 sectorSz)
 {
     int ret  = 0;
-    int iter = 0;
-    int sectorCount  = sz / sectorSz;
-    int remainder = sz % sectorSz;
+    word32 iter = 0;
+    word32 sectorCount;
+    word32 remainder;
 
     if (aes == NULL || out == NULL || in == NULL || sectorSz == 0) {
         return BAD_FUNC_ARG;
@@ -11519,6 +11522,9 @@ int wc_AesXtsDecryptConsecutiveSectors(XtsAes* aes, byte* out, const byte* in,
         WOLFSSL_MSG("Cipher text input too small for decryption");
         return BAD_FUNC_ARG;
     }
+
+    sectorCount  = sz / sectorSz;
+    remainder = sz % sectorSz;
 
     while (sectorCount) {
         ret = wc_AesXtsDecryptSector(aes, out + (iter * sectorSz),

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -9820,10 +9820,6 @@ static wc_test_ret_t aes_xts_sector_test(void)
     int aes_inited = 0;
     wc_test_ret_t ret = 0;
     unsigned char buf[AES_BLOCK_SIZE * 2];
-#ifndef BENCH_EMBEDDED
-    /* Sector size for encrypt/decrypt consecutive sectors testcase */
-    word32 sectorSz = 512;
-#endif
 
     /* 128 key tests */
     WOLFSSL_SMALL_STACK_STATIC unsigned char k1[] = {
@@ -9871,7 +9867,11 @@ static wc_test_ret_t aes_xts_sector_test(void)
     };
     word64 s2 = 187;
 
-#ifndef BENCH_EMBEDDED
+#if !defined(BENCH_EMBEDDED) && \
+    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)) && !defined(HAVE_SELFTEST)
+    /* Sector size for encrypt/decrypt consecutive sectors testcase */
+    word32 sectorSz = 512;
+
     unsigned char data[550];
 
     WOLFSSL_SMALL_STACK_STATIC unsigned char k3[] = {
@@ -10055,7 +10055,8 @@ static wc_test_ret_t aes_xts_sector_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     wc_AesXtsFree(aes);
 
-#ifndef BENCH_EMBEDDED
+#if !defined(BENCH_EMBEDDED) && \
+    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)) && !defined(HAVE_SELFTEST)
     /* encrypt consecutive sectors test */
     XMEMSET(data, 0, sizeof(buf));
     ret = wc_AesXtsSetKey(aes, k3, sizeof(k3), AES_ENCRYPTION,
@@ -10090,7 +10091,7 @@ static wc_test_ret_t aes_xts_sector_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     wc_AesXtsFree(aes);
 
-#endif
+#endif /* !BENCH_EMBEDDED && (!HAVE_FIPS || FIPS_VERSION_GE(5, 3)) */
 
 out:
 


### PR DESCRIPTION
`wolfcrypt/src/aes.c`: fix `zerodivcond` and `-Wconversion` in `wc_AesXtsEncryptConsecutiveSectors()` and `wc_AesXtsDecryptConsecutiveSectors()`.

`wolfcrypt/test/test.c`: add missing FIPS gating around AES-XTS testing.

tested with `wolfssl-multi-test.sh ... check-self check-file-modes check-source-text check-shell-scripts check-configure all-gcc-c99 all-c89-cppcheck allcryptonly-Wconversion-intelasm-build allcryptonly-c99-Wconversion-build allcryptonly-c99-Wconversion-m32-build allcryptonly-c89-Wconversion-build allcryptonly-c89-Wconversion-m32-build cppcheck-force-source fips-140-3-all fips-140-3-pilot-all linuxkm-all-fips-140-3 linuxkm-all-fips-140-3-dyn-hash linuxkm-defaults-all-fips-140-3 linuxkm-defaults-all-fips-140-3-pilot fips-140-3-RC12 linuxkm-aesni-insmod cppcheck-all cppcheck-all-smallstack cppcheck-all-intmath cppcheck-all-async-quic cppcheck-all-no-sha-1 all-WOLFSSL_CALLBACKS-cppcheck cppcheck-all-fips-dev clang-tidy-fips-140-3-all clang-tidy-fips-140-3-pilot-all`
