### PR TITLE
20231012-keylog-export-warning-fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1338,13 +1338,14 @@ fi
 
 # KeyLog file export
 AC_ARG_ENABLE([keylog-export],
-              [AS_HELP_STRING([--enable-keylog-export],[Enable (DANGEROUS INSECURE) exporting TLS secrets to an NSS keylog file (default: disabled)])],
+              [AS_HELP_STRING([--enable-keylog-export],[Enable insecure export of TLS secrets to an NSS keylog file (default: disabled)])],
     [ ENABLED_KEYLOG_EXPORT=$enableval ],
     [ ENABLED_KEYLOG_EXPORT=no ]
     )
 if test "$ENABLED_KEYLOG_EXPORT" = "yes"
 then
-  AM_CFLAGS="$AM_CFLAGS -DSHOW_SECRETS -DHAVE_SECRET_CALLBACK -DWOLFSSL_SSLKEYLOGFILE"
+  AC_MSG_WARN([Keylog export enabled -- Sensitive key data will be stored insecurely.])
+  AM_CFLAGS="$AM_CFLAGS -DSHOW_SECRETS -DHAVE_SECRET_CALLBACK -DWOLFSSL_SSLKEYLOGFILE -DWOLFSSL_KEYLOG_EXPORT_WARNED"
 fi
 
 # TLS v1.3 Draft 18 (Note: only final TLS v1.3 supported, here for backwards build compatibility)

--- a/src/tls.c
+++ b/src/tls.c
@@ -106,7 +106,8 @@ static int TLSX_PopulateSupportedGroups(WOLFSSL* ssl, TLSX** extensions);
 #endif
 
 /* Warn if secrets logging is enabled */
-#if defined(SHOW_SECRETS) || defined(WOLFSSL_SSLKEYLOGFILE)
+#if (defined(SHOW_SECRETS) || defined(WOLFSSL_SSLKEYLOGFILE)) && \
+    !defined(WOLFSSL_KEYLOG_EXPORT_WARNED)
     #ifndef _MSC_VER
         #warning The SHOW_SECRETS and WOLFSSL_SSLKEYLOGFILE options should only be used for debugging and never in a production environment
     #else


### PR DESCRIPTION
`configure.ac` and `src/tls.c`: fix `--enable-keylog-export` to warn at configure time, then build cleanly.

tested with `wolfssl-multi-test.sh ... check-self check-file-modes check-source-text check-shell-scripts check-configure all-gcc-c99`.
