### PR TITLE
wolfio: request only IPv4 addresses unless IPv6 support is enabled

### DIFF
--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -1106,7 +1106,11 @@ int wolfIO_TcpConnect(SOCKET_T* sockfd, const char* ip, word16 port, int to_sec)
     /* use gethostbyname for c99 */
 #if defined(HAVE_GETADDRINFO)
     XMEMSET(&hints, 0, sizeof(hints));
+#ifdef WOLFSSL_IPV6
     hints.ai_family = AF_UNSPEC; /* detect IPv4 or IPv6 */
+#else
+    hints.ai_family = AF_INET;   /* detect only IPv4 */
+#endif
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_protocol = IPPROTO_TCP;
 


### PR DESCRIPTION
# Description

There is no need to request IPv6 addresses if IPv6 is not enabled - the returned addresses are assumed to be IPv4 ones later in the code. In fact the reverse is true as well - which is NOT a correct assumption as getaddrinfo() can return IPv4 addresses since hints.ai_family = AF_UNSPEC. This is outside of the scope here though as we do not enable IPv6 support for wolfIO.

# Testing

Manual tests .

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
