### PR TITLE
Update "--enable-jni" to include additional defines

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5959,7 +5959,7 @@ AC_ARG_ENABLE([jni],
     )
 if test "$ENABLED_JNI" = "yes"
 then
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_JNI -DHAVE_EX_DATA"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_JNI -DHAVE_EX_DATA -DKEEP_PEER_CERT"
 
     # Enable prereqs if not already enabled
     if test "x$ENABLED_DTLS" = "xno"
@@ -6041,6 +6041,13 @@ then
         ENABLED_CERTGEN="yes"
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_CERT_GEN"
     fi
+    # wolfCrypt JNI/JCE uses keygen, enable by default here so
+    # both JCE and JSSE builds can use --enable-jni
+    if test "x$ENABLED_KEYGEN" = "xno"
+    then
+        ENABLED_KEYGEN="yes"
+        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_KEY_GEN"
+    fi
     if test "x$ENABLED_CERTREQ" = "xno"
     then
         ENABLED_CERTREQ="yes"
@@ -6055,6 +6062,11 @@ then
     then
         ENABLED_ALPN="yes"
         AM_CFLAGS="$AM_CFLAGS -DHAVE_ALPN"
+    fi
+    if test "x$ENABLED_ALT_CERT_CHAINS" = "xno"
+    then
+        ENABLED_ALT_CERT_CHAINS="yes"
+        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALT_CERT_CHAINS"
     fi
 
     # cert gen requires alt names


### PR DESCRIPTION
# Description

This PR expands the features enabled with `--enable-jni` to include the following additional defines. These defines are commonly added by users of JNI/JCE/JSSE and should make builds easier while reducing issues encountered when tested out of the box.

- `KEEP_PEER_CERT` - required when JSSE gets peer certificates, commonly used by JSSE consumers
- `WOLFSSL_ALT_CERT_CHAINS` - needed by several JSSE users recently, enabling here by default for JNI builds
- `WOLFSSL_KEY_GEN` - Used by JCE. Previously JCE users needed to use `--enable-keygen`, but this will consolidate both JCE and JSSE builds to be compatible with just using `--enable-jni`.

# Testing

Tested against both wolfJSSE and wolfJCE product builds.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
