### PR TITLE
Fix typo in eccsi_mulmod_base_add

### DIFF
--- a/wolfcrypt/src/eccsi.c
+++ b/wolfcrypt/src/eccsi.c
@@ -1376,7 +1376,7 @@ static int eccsi_mulmod_base_add(EccsiKey* key, const mp_int* n,
         err = NOT_COMPILED_IN;
     }
     (void)key;
-    (void)h;
+    (void)n;
     (void)a;
     (void)res;
     (void)mp;


### PR DESCRIPTION
# Description

Fix typo. There is no variable `h`. `h` should be `n`.

# Testing

Compile using `./configure --enable-sp --enable-sp-math --enable-eccsi && make`, which fails prior to this PR:

```
wolfcrypt/src/eccsi.c: In function ‘eccsi_mulmod_base_add’:
wolfcrypt/src/eccsi.c:1379:11: error: ‘h’ undeclared (first use in this function)
 1379 |     (void)h;
      |           ^
wolfcrypt/src/eccsi.c:1379:11: note: each undeclared identifier is reported only once for each function it appears in
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
