### PR TITLE
20231016-sp-math-aes-eax-fips-fixes

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -19556,7 +19556,8 @@ static int test_wc_AesCcmEncryptDecrypt(void)
 } /* END test_wc_AesCcmEncryptDecrypt */
 
 
-#if defined(WOLFSSL_AES_EAX)
+#if defined(WOLFSSL_AES_EAX) && \
+    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)) && !defined(HAVE_SELFTEST)
 
 /*
  * Testing test_wc_AesEaxVectors()
@@ -21028,7 +21029,9 @@ static int test_wc_AesEaxDecryptAuth(void)
     return EXPECT_RESULT();
 } /* END test_wc_AesEaxDecryptAuth() */
 
-#endif /* defined(WOLFSSL_AES_EAX) */
+#endif /* WOLFSSL_AES_EAX &&
+        * (!HAVE_FIPS || FIPS_VERSION_GE(5, 3)) && !HAVE_SELFTEST
+        */
 
 /*
  * Testing wc_InitDsaKey()
@@ -67214,7 +67217,8 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wc_GmacUpdate),
     TEST_DECL(test_wc_AesCcmSetKey),
     TEST_DECL(test_wc_AesCcmEncryptDecrypt),
-#if defined(WOLFSSL_AES_EAX)
+#if defined(WOLFSSL_AES_EAX) && \
+    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)) && !defined(HAVE_SELFTEST)
     TEST_DECL(test_wc_AesEaxVectors),
     TEST_DECL(test_wc_AesEaxEncryptAuth),
     TEST_DECL(test_wc_AesEaxDecryptAuth),

--- a/wolfcrypt/src/eccsi.c
+++ b/wolfcrypt/src/eccsi.c
@@ -1376,7 +1376,6 @@ static int eccsi_mulmod_base_add(EccsiKey* key, const mp_int* n,
         err = NOT_COMPILED_IN;
     }
     (void)key;
-    (void)h;
     (void)a;
     (void)res;
     (void)mp;


### PR DESCRIPTION
`tests/api.c`: gate `test_wc_AesEaxVectors()`, `test_wc_AesEaxEncryptAuth()`, and `test_wc_AesEaxDecryptAuth()`, on !FIPS || FIPS>=5.3.

`wolfcrypt/src/eccsi.c`: remove incorrect `(void)h` from `eccsi_mulmod_base_add()` in newly exposed `WOLFSSL_SP_MATH` code path.

tested with `wolfssl-multi-test.sh ... super-quick-check fips-140-3-all linuxkm-defaults-all-fips-140-3-pilot all-crypt-sp-math-vector-register-access cross-riscv64-sp-math-asm clang-tidy-fips-140-3-all`
