### PR TITLE
20231016-sp-math-fix-redux

### DIFF
--- a/wolfcrypt/src/eccsi.c
+++ b/wolfcrypt/src/eccsi.c
@@ -1376,6 +1376,7 @@ static int eccsi_mulmod_base_add(EccsiKey* key, const mp_int* n,
         err = NOT_COMPILED_IN;
     }
     (void)key;
+    (void)n;
     (void)a;
     (void)res;
     (void)mp;


### PR DESCRIPTION
fix to 3e9f8bc649: `(void)h` was a typo for correct `(void)n`.

tested with `wolfssl-multi-test.sh ... all-crypt-sp-math-vector-register-access`
