### PR TITLE
Espressif Update wolfSSL component CMakeLists.txt

### DIFF
--- a/IDE/Espressif/ESP-IDF/compileAllExamples.sh
+++ b/IDE/Espressif/ESP-IDF/compileAllExamples.sh
@@ -62,6 +62,9 @@ if  [[ "$RUN_SETUP" == "--run-setup" ]]; then
     echo "Testing a build of wolfSSL in ESP-IDF components directory"
     echo ""
     for file in "test_idf"; do
+        if [ -e "../../../include/user_settings.h" ]; then
+          mv "../../../include/user_settings.h" "../../../include/user_settings.h.${file}.bak"
+        fi
         pushd ${SCRIPT_DIR}/examples/wolfssl_${file}/ && idf.py fullclean build;
         THIS_ERR=$?
         popd

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/components/wolfssl/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/components/wolfssl/CMakeLists.txt
@@ -17,210 +17,395 @@
 #  along with this program; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 #
-# cmake for wolfssl
+# cmake for wolfssl Espressif projects
 #
-cmake_minimum_required(VERSION 3.5)
+# Version 5.6.0.009 for FIND_WOLFSSL_DIRECTORY
+#
+# See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html
+#
+
+cmake_minimum_required(VERSION 3.16)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
 set(CMAKE_CURRENT_SOURCE_DIR ".")
+set(COMPONENT_REQUIRES lwip) # we typically don't need lwip directly in wolfssl component
+set(WOLFSSL_ROOT "$ENV{WOLFSSL_ROOT}" )
 
-# We are currently in [root]/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl
-# The root of wolfSSL is 7 directories up from here:
-get_filename_component(WOLFSSL_ROOT  "../../../../../../../" ABSOLUTE)
-
-# Espressif may take several passes through this makefile. Check to see if we found IDF
-string(COMPARE EQUAL "${PROJECT_SOURCE_DIR}" "" WOLFSSL_FOUND_IDF)
-
-if($WOLFSSL_FOUND_IDF)
-    message(STATUS "IDF_PATH = $ENV{IDF_PATH}")
-    message(STATUS "WOLFSSL_ROOT = ${WOLFSSL_ROOT}")
-    message(STATUS "PROJECT_SOURCE_DIR = ${PROJECT_SOURCE_DIR}")
-endif()
-
-# get a list of all wolfcrypt assembly files; we'll exclude them as they don't target Xtensa
-FILE(GLOB EXCLUDE_ASM *.S)
-file(GLOB_RECURSE EXCLUDE_ASM ${CMAKE_SOURCE_DIR} "${WOLFSSL_ROOT}/wolfcrypt/src/*.S")
-
-if(NOT CMAKE_BUILD_EARLY_EXPANSION)
-    message(STATUS "EXCLUDE_ASM = ${EXCLUDE_ASM}")
-endif()
-
-set(INCLUDE_PATH ${WOLFSSL_ROOT})
-
-set(COMPONENT_SRCDIRS "${WOLFSSL_ROOT}/src/"
-                        "${WOLFSSL_ROOT}/wolfcrypt/src/"
-                        "${WOLFSSL_ROOT}/wolfcrypt/src/port/Espressif/"
-                        "${WOLFSSL_ROOT}/wolfcrypt/src/port/atmel/"
-                        "${WOLFSSL_ROOT}/wolfcrypt/benchmark/"
-                        "${WOLFSSL_ROOT}/wolfcrypt/test/"
-                        )
-
-set(COMPONENT_REQUIRES lwip)
-
-
-# check to see if there's both a local copy and EDP-IDF copy of the wolfssl and/or wolfssh components
-if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/" AND EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
-    #
-    # wolfSSL found in both ESP-IDF and local project - needs to be resolved by user
-    #
-    message(STATUS "")
-    message(STATUS "**************************************************************************************")
-    message(STATUS "")
-    message(STATUS "Error: Found components/wolfssl in both local project and IDF_PATH")
-    message(STATUS "")
-    message(STATUS "To proceed: ")
-    message(STATUS "")
-    message(STATUS "Remove either the local project component: ${CMAKE_HOME_DIRECTORY}/components/wolfssl/ ")
-    message(STATUS "or the Espressif shared component installed at: $ENV{IDF_PATH}/components/wolfssl/ ")
-    message(STATUS "")
-    message(FATAL_ERROR "Please use wolfSSL in either local project or Espressif components, but not both.")
-    message(STATUS "")
-    message(STATUS "**************************************************************************************")
-    message(STATUS "")
-
-    # Optional: if you change the above FATAL_ERROR to STATUS you can warn at runtime with this macro definition:
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_MULTI_INSTALL_WARNING")
-
-else()
-    if( EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
-        #
-        # wolfSSL found in ESP-IDF components and is assumed to be already configured in user_settings.h via setup.
-        #
-        message(STATUS "")
-        message(STATUS "Using components/wolfssl in IDF_PATH = $ENV{IDF_PATH}")
-        message(STATUS "")
+# find the user name to search for possible "wolfssl-username"
+message(STATUS "USERNAME = $ENV{USERNAME}")
+if(  "$ENV{USER}" STREQUAL "" ) # the bash user
+    if(  "$ENV{USERNAME}" STREQUAL "" ) # the Windows user
+        message(STATUS "could not find USER or USERNAME")
     else()
-        #
-        # wolfSSL is not an ESP-IDF component. We need to now determine if it is local and if so if it is part of the wolfSSL repo
-        # or if  wolfSSL is simply installed as a local component.
-        #
-        if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/" )
-            #
-            # wolfSSL found in local project.
-            #
-            if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/include/" )
-                message(STATUS "")
-                message(STATUS "Using installed project ./components/wolfssl in CMAKE_HOME_DIRECTORY = $ENV{CMAKE_HOME_DIRECTORY}")
-                message(STATUS "")
-                #
-                # Note we already checked above and confirmed there's not another wolfSSL installed in the ESP-IDF components.
-                #
-                # We won't do anything else here, as it will be assumed the original install completed successfully.
-                #
-            else()
-                #
-                # This is the developer repo mode. wolfSSL will be assume to be not installed to ESP-IDF nor local project
-                # In this configuration, we are likely running a wolfSSL example found directly in the repo.
-                #
-                message(STATUS "")
-                message(STATUS "Using developer repo ./components/wolfssl in CMAKE_HOME_DIRECTORY = $ENV{CMAKE_HOME_DIRECTORY}")
-                message(STATUS "")
-
-                message(STATUS "************************************************************************************************")
-                # When in developer mode, we are typically running wolfSSL examples such as benchmark or test directories.
-                # However, the as-cloned or distributed wolfSSL does not have the ./include/ directory, so we'll add it as needed.
-                #
-                # first check if there's a [root]/include/user_settings.h
-                if( EXISTS "${WOLFSSL_ROOT}/include/user_settings.h" )
-                    # we won't overwrite an existing user settings file, just note that we already have one:
-                    message(STATUS "Found wolfSSL user_settings.h in ${WOLFSSL_ROOT}/include/user_settings.h")
-                else()
-                    message(STATUS "Installing wolfSSL user_settings.h to ${WOLFSSL_ROOT}/include/user_settings.h")
-                    file(COPY "${WOLFSSL_ROOT}/IDE/Espressif/ESP-IDF/user_settings.h" DESTINATION "${WOLFSSL_ROOT}/include/")
-                endif() # user_settings.h
-
-                # next check if there's a [root]/include/config.h
-                if( EXISTS "${WOLFSSL_ROOT}/include/config.h" )
-                    message(STATUS "Found wolfSSL config.h in ${WOLFSSL_ROOT}/include/config.h")
-                else()
-                    message(STATUS "Installing wolfSSL config.h to ${WOLFSSL_ROOT}/include/config.h")
-                    file(COPY "${WOLFSSL_ROOT}/IDE/Espressif/ESP-IDF/dummy_config_h" DESTINATION "${WOLFSSL_ROOT}/include/")
-                    file(RENAME "${WOLFSSL_ROOT}/include/dummy_config_h" "${WOLFSSL_ROOT}/include/config.h")
-                endif() # config.h
-                message(STATUS "************************************************************************************************")
-                message(STATUS "")
-            endif()
-
-        else()
-            # we did not find a ./components/wolfssl/include/ directory from this pass of cmake.
-            if($WOLFSSL_FOUND_IDF)
-                message(STATUS "")
-                message(STATUS "WARNING: wolfSSL not found.")
-                message(STATUS "")
-            else()
-                # probably needs to be re-parsed by Espressif
-                message(STATUS "wolfSSL found IDF. Project Source:${PROJECT_SOURCE_DIR}")
-            endif() # else we have not found ESP-IDF yet
-        endif() # else not a local wolfSSL component
-
-    endif() #else not an ESP-IDF component
-endif() # else not local copy and EDP-IDF wolfSSL
-
-
-# RTOS_IDF_PATH is typically:
-# "/Users/{username}/Desktop/esp-idf/components/freertos/include/freertos"
-# depending on the environment, we may need to swap backslashes with forward slashes
-string(REPLACE "\\" "/" RTOS_IDF_PATH "$ENV{IDF_PATH}/components/freertos/include/freertos")
-
-# ESP-IDF after version 4.4x has a different RTOS directory structure
-string(REPLACE "\\" "/" RTOS_IDF_PATH5 "$ENV{IDF_PATH}/components/freertos/FreeRTOS-Kernel/include/freertos")
-
-if(IS_DIRECTORY ${IDF_PATH}/components/freertos/FreeRTOS-Kernel/)
-    set(COMPONENT_ADD_INCLUDEDIRS
-        "."
-       "${WOLFSSL_ROOT}/include"
-       "${RTOS_IDF_PATH5}"
-       "${WOLFSSL_ROOT}"
-       )
+        # the bash user is not blank, so we'll use it.
+        set(THIS_USER "$ENV{USERNAME}")
+    endif()
 else()
-
-   set(COMPONENT_ADD_INCLUDEDIRS
-       "."
-       "${WOLFSSL_ROOT}/include"
-       "${RTOS_IDF_PATH}"
-       "${WOLFSSL_ROOT}"
-      )
+    # the bash user is not blank, so we'll use it.
+    set(THIS_USER "$ENV{USER}")
 endif()
+message(STATUS "THIS_USER = ${THIS_USER}")
 
-if(IS_DIRECTORY ${IDF_PATH}/components/cryptoauthlib)
-    list(APPEND COMPONENT_ADD_INCLUDEDIRS "../cryptoauthlib/lib")
-endif()
 
-set(COMPONENT_SRCEXCLUDE
-    "${WOLFSSL_ROOT}/src/bio.c"
-    "${WOLFSSL_ROOT}/src/conf.c"
-    "${WOLFSSL_ROOT}/src/misc.c"
-    "${WOLFSSL_ROOT}/src/pk.c"
-    "${WOLFSSL_ROOT}/src/ssl_asn1.c" # included by ssl.c
-    "${WOLFSSL_ROOT}/src/ssl_bn.c" # included by ssl.c
-    "${WOLFSSL_ROOT}/src/ssl_certman.c" # included by ssl.c
-    "${WOLFSSL_ROOT}/src/ssl_misc.c" # included by ssl.c
-    "${WOLFSSL_ROOT}/src/x509.c"
-    "${WOLFSSL_ROOT}/src/x509_str.c"
-    "${WOLFSSL_ROOT}/wolfcrypt/src/evp.c"
-    "${WOLFSSL_ROOT}/wolfcrypt/src/misc.c"
-    "${EXCLUDE_ASM}"
-    )
-set(COMPONENT_PRIV_INCLUDEDIRS ${IDF_PATH}/components/driver/include)
+# COMPONENT_NAME = wolfssl
+# The component name is the directory name. "No feature to change this".
+# See https://github.com/espressif/esp-idf/issues/8978#issuecomment-1129892685
 
-register_component()
+# set the root of wolfSSL:
+#   set(WOLFSSL_ROOT  "C:/some path/with/spaces")
+#   set(WOLFSSL_ROOT  "c:/workspace/wolfssl-gojimmypi")
+#   set(WOLFSSL_ROOT  "/mnt/c/some path/with/spaces")
+#   or use this logic to assign value from Environment Variable WOLFSSL_ROOT,
+#   or assume this is an example 7 subdirectories below:
 
-# some optional diagnostics
-if (0)
-    get_cmake_property(_variableNames VARIABLES)
-    list (SORT _variableNames)
-    message(STATUS "")
-    message(STATUS "ALL VARIABLES BEGIN")
-    message(STATUS "")
-    foreach (_variableName ${_variableNames})
-        message(STATUS "${_variableName}=${${_variableName}}")
-    endforeach()
-    message(STATUS "")
-    message(STATUS "ALL VARIABLES END")
-    message(STATUS "")
-endif()
+# We are typically in [root]/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl
+# The root of wolfSSL is 7 directories up from here:
+
+# function: IS_WOLFSSL_SOURCE
+#  parameter: DIRECTORY_PARAMETER - the directory to test
+#  output:    RESULT = contains contents of DIRECTORY_PARAMETER for wolfssl directory, otherwise blank.
+function(IS_WOLFSSL_SOURCE DIRECTORY_PARAMETER RESULT)
+    if (EXISTS "${DIRECTORY_PARAMETER}/wolfcrypt/src")
+        set(${RESULT} "${DIRECTORY_PARAMETER}" PARENT_SCOPE)
+    else()
+        set(${RESULT} "" PARENT_SCOPE)
+    endif()
+endfunction()
+
+# function: FIND_WOLFSSL_DIRECTORY
+#  parameter: OUTPUT_FOUND_WOLFSSL_DIRECTORY contains root of source code, otherwise blank
+#
+function(FIND_WOLFSSL_DIRECTORY OUTPUT_FOUND_WOLFSSL_DIRECTORY)
+    message(STATUS "Starting FIND_WOLFSSL_DIRECTORY")
+    set(CURRENT_SEARCH_DIR "$ENV{WOLFSSL_ROOT}")
+    if( "${CURRENT_SEARCH_DIR}" STREQUAL "" )
+        message(STATUS "The WOLFSSL_ROOT environment variable is not set. Searching...")
+    else()
+        get_filename_component(CURRENT_SEARCH_DIR "$ENV{WOLFSSL_ROOT}" ABSOLUTE)
+        IS_WOLFSSL_SOURCE("${CURRENT_SEARCH_DIR}" FOUND_WOLFSSL)
+        if("${FOUND_WOLFSSL}")
+            message(STATUS "Found WOLFSSL_ROOT via Environment Variable:")
+        else()
+            message(FATAL_ERROR "WOLFSSL_ROOT Environment Variable defined, but path not found:")
+            message(STATUS "$ENV{WOLFSSL_ROOT}")
+        endif()
+    endif()
+
+    # we'll start in the CMAKE_CURRENT_SOURCE_DIR, typically [something]/projectname/components/wolfssl
+    message(STATUS "CMAKE_CURRENT_SOURCE_DIR = ${CMAKE_CURRENT_SOURCE_DIR}")
+    get_filename_component(CURRENT_SEARCH_DIR "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
+    message(STATUS "CURRENT_SEARCH_DIR = ${CURRENT_SEARCH_DIR}")
+    string(LENGTH ${CURRENT_SEARCH_DIR} CURRENT_SEARCH_DIR_LENGTH)
+
+    # loop through all the parents, looking for wolfssl
+    while(NOT CURRENT_SEARCH_DIR STREQUAL "/" AND NOT CURRENT_SEARCH_DIR STREQUAL "" )
+        string(LENGTH ${CURRENT_SEARCH_DIR} CURRENT_SEARCH_DIR_LENGTH)
+        # wolfSSL may simply be in a parent directory, such as for local examples in wolfssl repo
+        IS_WOLFSSL_SOURCE("${CURRENT_SEARCH_DIR}" FOUND_WOLFSSL)
+        if( FOUND_WOLFSSL )
+            message(STATUS "Found wolfssl in CURRENT_SEARCH_DIR = ${CURRENT_SEARCH_DIR}")
+            set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} ${CURRENT_SEARCH_DIR} PARENT_SCOPE)
+            return()
+        endif()
+
+        if( THIS_USER )
+            # Check for "wolfssl-[username]" subdirectory as we recurse up the directory tree
+            set(CURRENT_SEARCH_DIR_ALT ${CURRENT_SEARCH_DIR}/wolfssl-${THIS_USER})
+            message(STATUS "Looking in ${CURRENT_SEARCH_DIR}")
+
+            #if(EXISTS ${CURRENT_SEARCH_DIR_ALT} AND IS_DIRECTORY ${CURRENT_SEARCH_DIR_ALT} AND EXISTS "${CURRENT_SEARCH_DIR_ALT}/wolfcrypt/src")
+            IS_WOLFSSL_SOURCE("${CURRENT_SEARCH_DIR_ALT}" FOUND_WOLFSSL )
+            if ( FOUND_WOLFSSL )
+               message(STATUS "Found wolfssl in user-suffix CURRENT_SEARCH_DIR_ALT = ${CURRENT_SEARCH_DIR_ALT}")
+                set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} ${CURRENT_SEARCH_DIR_ALT} PARENT_SCOPE)
+                return()
+            endif()
+        endif()
+
+        # Next check for no user suffix "wolfssl" subdirectory as we recurse up the directory tree
+        set(CURRENT_SEARCH_DIR_ALT ${CURRENT_SEARCH_DIR}/wolfssl)
+        # if(EXISTS ${CURRENT_SEARCH_DIR} AND IS_DIRECTORY ${CURRENT_SEARCH_DIR} AND EXISTS "${CURRENT_SEARCH_DIR}/wolfcrypt/src")
+        IS_WOLFSSL_SOURCE("${CURRENT_SEARCH_DIR_ALT}" FOUND_WOLFSSL )
+        if ( FOUND_WOLFSSL )
+            message(STATUS "Found wolfssl in CURRENT_SEARCH_DIR = ${CURRENT_SEARCH_DIR}")
+            set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} ${CURRENT_SEARCH_DIR} PARENT_SCOPE)
+            return()
+        endif()
+
+        # Move up one directory level
+        set(PRIOR_SEARCH_DIR "${CURRENT_SEARCH_DIR}")
+        get_filename_component(CURRENT_SEARCH_DIR "${CURRENT_SEARCH_DIR}" DIRECTORY)
+        message(STATUS "Next CURRENT_SEARCH_DIR = ${CURRENT_SEARCH_DIR}")
+        if( "${PRIOR_SEARCH_DIR}" STREQUAL "${CURRENT_SEARCH_DIR}" )
+            # when the search directory is empty, we'll give up
+            set(CURRENT_SEARCH_DIR "")
+        endif()
+    endwhile()
+
+    # If not found, set the output variable to empty before exiting
+    set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} "" PARENT_SCOPE)
+endfunction()
+
+if(CMAKE_BUILD_EARLY_EXPANSION)
+    message(STATUS "wolfssl component CMAKE_BUILD_EARLY_EXPANSION:")
+    idf_component_register(
+                            REQUIRES "${COMPONENT_REQUIRES}"
+                            PRIV_REQUIRES # esp_hw_support
+                                          esp_timer
+                                          driver # this will typically only be needed for wolfSSL benchmark
+                           )
+
+else()
+    # not CMAKE_BUILD_EARLY_EXPANSION
+    message(STATUS "************************************************************************************************")
+    message(STATUS "wolfssl component config:")
+    message(STATUS "************************************************************************************************")
+
+    # search for wolfSSL
+    FIND_WOLFSSL_DIRECTORY(WOLFSSL_ROOT)
+    if(WOLFSSL_ROOT)
+        message(STATUS "NEW Found wolfssl directory at: ${WOLFSSL_ROOT}")
+    else()
+        message(STATUS "NEW wolfssl directory not found.")
+        # Abort. We need wolfssl _somewhere_.
+        message(FATAL_ERROR "Could not find wolfssl in ${WOLFSSL_ROOT}.\n"
+                            "Try setting WOLFSSL_ROOT environment variable or git clone.")
+    endif()
+
+    set(INCLUDE_PATH ${WOLFSSL_ROOT})
+
+    set(COMPONENT_SRCDIRS "\"${WOLFSSL_ROOT}/src/\""
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/src\""
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/src/port/Espressif\""
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/src/port/atmel\""
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/benchmark\"" # the benchmark application
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/test\"" # the test application
+       ) # COMPONENT_SRCDIRS
+    message(STATUS "This COMPONENT_SRCDIRS = ${COMPONENT_SRCDIRS}")
+
+    set(WOLFSSL_PROJECT_DIR "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
+
+    # Espressif may take several passes through this makefile. Check to see if we found IDF
+    string(COMPARE EQUAL "${PROJECT_SOURCE_DIR}" "" WOLFSSL_FOUND_IDF)
+
+    # get a list of all wolfcrypt assembly files; we'll exclude them as they don't target Xtensa
+    file(GLOB EXCLUDE_ASM *.S)
+    file(GLOB_RECURSE EXCLUDE_ASM ${CMAKE_SOURCE_DIR} "${WOLFSSL_ROOT}/wolfcrypt/src/*.S")
+
+    message(STATUS "IDF_PATH = $ENV{IDF_PATH}")
+    message(STATUS "PROJECT_SOURCE_DIR = ${PROJECT_SOURCE_DIR}")
+    message(STATUS "EXCLUDE_ASM = ${EXCLUDE_ASM}")
+
+    #
+    # Check to see if there's both a local copy and EDP-IDF copy of the wolfssl and/or wolfssh components.
+    #
+    if( EXISTS "${WOLFSSL_PROJECT_DIR}" AND EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
+        #
+        # wolfSSL found in both ESP-IDF and local project - needs to be resolved by user
+        #
+        message(STATUS "")
+        message(STATUS "**************************************************************************************")
+        message(STATUS "")
+        message(STATUS "Error: Found components/wolfssl in both local project and IDF_PATH")
+        message(STATUS "")
+        message(STATUS "To proceed: ")
+        message(STATUS "")
+        message(STATUS "Remove either the local project component: ${WOLFSSL_PROJECT_DIR} ")
+        message(STATUS "or the Espressif shared component installed at: $ENV{IDF_PATH}/components/wolfssl/ ")
+        message(STATUS "")
+        message(FATAL_ERROR "Please use wolfSSL in either local project or Espressif components, but not both.")
+        message(STATUS "")
+        message(STATUS "**************************************************************************************")
+        message(STATUS "")
+
+        # Optional: if you change the above FATAL_ERROR to STATUS you can warn at runtime with this macro definition:
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_MULTI_INSTALL_WARNING")
+
+    else()
+        if( EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
+            #
+            # wolfSSL found in ESP-IDF components and is assumed to be already configured in user_settings.h via setup.
+            #
+            message(STATUS "")
+            message(STATUS "Using components/wolfssl in IDF_PATH = $ENV{IDF_PATH}")
+            message(STATUS "")
+        else()
+            #
+            # wolfSSL is not an ESP-IDF component.
+            # We need to now determine if it is local and if so if it is part of the wolfSSL repo,
+            # or if  wolfSSL is simply installed as a local component.
+            #
+
+            if( EXISTS "${WOLFSSL_PROJECT_DIR}" )
+                #
+                # wolfSSL found in local project.
+                #
+                if( EXISTS "${WOLFSSL_PROJECT_DIR}/wolfcrypt/" )
+                    message(STATUS "")
+                    message(STATUS "Using installed project ./components/wolfssl in CMAKE_HOME_DIRECTORY = ${CMAKE_HOME_DIRECTORY}")
+                    message(STATUS "")
+                    #
+                    # Note we already checked above and confirmed there's not another wolfSSL installed in the ESP-IDF components.
+                    #
+                    # We won't do anything else here, as it will be assumed the original install completed successfully.
+                    #
+                else() # full wolfSSL not installed in local project
+                    #
+                    # This is the developer repo mode. wolfSSL will be assumed to be not installed to ESP-IDF nor local project
+                    # In this configuration, we are likely running a wolfSSL example found directly in the repo.
+                    #
+                    message(STATUS "")
+                    message(STATUS "Using developer repo ./components/wolfssl in CMAKE_HOME_DIRECTORY = ${CMAKE_HOME_DIRECTORY}")
+                    message(STATUS "")
+
+                    message(STATUS "************************************************************************************************")
+                    # When in developer mode, we are typically running wolfSSL examples such as benchmark or test directories.
+                    # However, the as-cloned or distributed wolfSSL does not have the ./include/ directory, so we'll add it as needed.
+                    #
+                    # first check if there's a [root]/include/user_settings.h
+                    if( EXISTS "${WOLFSSL_ROOT}/include/user_settings.h" )
+                        message(FATAL_ERROR "Found stray wolfSSL user_settings.h in "
+                                            "${WOLFSSL_ROOT}/include/user_settings.h "
+                                            " (please move it to ${WOLFSSL_PROJECT_DIR}/include/user_settings.h )")
+                    else()
+                        # we won't overwrite an existing user settings file, just note that we already have one:
+                        if( EXISTS "${WOLFSSL_PROJECT_DIR}/include/user_settings.h" )
+                            message(STATUS "Using existing wolfSSL user_settings.h in "
+                                           "${WOLFSSL_PROJECT_DIR}/include/user_settings.h")
+                        else()
+                            message(STATUS "Installing wolfSSL user_settings.h to "
+                                           "${WOLFSSL_PROJECT_DIR}/include/user_settings.h")
+                            file(COPY "${WOLFSSL_ROOT}/IDE/Espressif/ESP-IDF/user_settings.h"
+                            DESTINATION "${CMAKE_HOME_DIRECTORY}/wolfssl/include/")
+                        endif()
+                    endif() # user_settings.h
+
+                    # next check if there's a [root]/include/config.h
+                    if( EXISTS "${WOLFSSL_ROOT}/include/config.h" )
+                        message(FATAL_ERROR "Found stray wolfSSL config.h in        ${WOLFSSL_ROOT}/include/config.h (please move it to ${WOLFSSL_PROJECT_DIR}/include/config.h")
+                    else()
+                        # we won't overwrite an existing user settings file, just note that we already have one:
+                        if( EXISTS "${WOLFSSL_PROJECT_DIR}/include/config.h" )
+                            message(STATUS "Using existing wolfSSL config.h           ${WOLFSSL_PROJECT_DIR}/include/config.h")
+                        else()
+                            message(STATUS "Installing wolfSSL config.h to            ${WOLFSSL_PROJECT_DIR}/include/config.h")
+                            file(COPY   "${WOLFSSL_ROOT}/IDE/Espressif/ESP-IDF/dummy_config_h" DESTINATION "${WOLFSSL_PROJECT_DIR}/include/")
+                            file(RENAME "${WOLFSSL_PROJECT_DIR}/include/dummy_config_h" "${WOLFSSL_PROJECT_DIR}/include/config.h")
+                        endif() # Project config.h
+                    endif() # WOLFSSL_ROOT config.h
+                    message(STATUS "************************************************************************************************")
+                    message(STATUS "")
+                endif()
+
+            else()
+                # we did not find a ./components/wolfssl/include/ directory from this pass of cmake.
+                if($WOLFSSL_FOUND_IDF)
+                    message(STATUS "")
+                    message(STATUS "WARNING: wolfSSL not found.")
+                    message(STATUS "")
+                else()
+                    # probably needs to be re-parsed by Espressif
+                    message(STATUS "wolfSSL found IDF. Project Source:${PROJECT_SOURCE_DIR}")
+                endif() # else we have not found ESP-IDF yet
+            endif() # else not a local wolfSSL component
+
+        endif() #else not an ESP-IDF component
+    endif() # else not local copy and EDP-IDF wolfSSL
+
+    # RTOS_IDF_PATH is typically:
+    # "/Users/{username}/Desktop/esp-idf/components/freertos/include/freertos"
+    # depending on the environment, we may need to swap backslashes with forward slashes
+    string(REPLACE "\\" "/" RTOS_IDF_PATH "$ENV{IDF_PATH}/components/freertos/FreeRTOS-Kernel/include/freertos")
+
+    string(REPLACE "\\" "/" WOLFSSL_ROOT ${WOLFSSL_ROOT})
+
+    if(IS_DIRECTORY "${RTOS_IDF_PATH}")
+        message(STATUS "Found current RTOS path: ${RTOS_IDF_PATH}")
+    else()
+        # ESP-IDF prior version 4.4x has a different RTOS directory structure
+        string(REPLACE "\\" "/" RTOS_IDF_PATH "$ENV{IDF_PATH}/components/freertos/include/freertos")
+        if(IS_DIRECTORY "${RTOS_IDF_PATH}")
+            message(STATUS "Found legacy RTOS path: ${RTOS_IDF_PATH}")
+        else()
+            message(STATUS "Could not find RTOS path")
+        endif()
+    endif()
+
+    set(COMPONENT_ADD_INCLUDEDIRS
+        "./include" # this is the location of wolfssl user_settings.h
+        "\"${WOLFSSL_ROOT}/\""
+        "\"${WOLFSSL_ROOT}/wolfssl/\""
+        "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/\""
+        "\"${RTOS_IDF_PATH}/\""
+        )
+
+    if(IS_DIRECTORY ${IDF_PATH}/components/cryptoauthlib)
+        list(APPEND COMPONENT_ADD_INCLUDEDIRS "../cryptoauthlib/lib")
+    endif()
+
+    list(APPEND COMPONENT_ADD_INCLUDEDIRS "\"${WOLFSSL_ROOT}/wolfssl/\"")
+    list(APPEND COMPONENT_ADD_INCLUDEDIRS "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/\"")
+
+    set(COMPONENT_SRCEXCLUDE
+        "\"${WOLFSSL_ROOT}/src/bio.c\""
+        "\"${WOLFSSL_ROOT}/src/conf.c\""
+        "\"${WOLFSSL_ROOT}/src/misc.c\""
+        "\"${WOLFSSL_ROOT}/src/pk.c\""
+        "\"${WOLFSSL_ROOT}/src/ssl_asn1.c\""    # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/ssl_bn.c\""      # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/ssl_certman.c\"" # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/ssl_misc.c\""    # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/x509.c\""
+        "\"${WOLFSSL_ROOT}/src/x509_str.c\""
+        "\"${WOLFSSL_ROOT}/wolfcrypt/src/evp.c\""
+        "\"${WOLFSSL_ROOT}/wolfcrypt/src/misc.c\""
+        "\"${EXCLUDE_ASM}\""
+        )
+
+    spaces2list(COMPONENT_REQUIRES)
+
+    separate_arguments(COMPONENT_SRCDIRS NATIVE_COMMAND "${COMPONENT_SRCDIRS}")
+    separate_arguments(COMPONENT_SRCEXCLUDE NATIVE_COMMAND "${COMPONENT_SRCEXCLUDE}")
+    separate_arguments(COMPONENT_ADD_INCLUDEDIRS NATIVE_COMMAND "${COMPONENT_ADD_INCLUDEDIRS}")
+
+    #
+    # See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#example-component-requirements
+    #
+    message(STATUS "COMPONENT_SRCDIRS = ${COMPONENT_SRCDIRS}")
+    message(STATUS "COMPONENT_ADD_INCLUDEDIRS = ${COMPONENT_ADD_INCLUDEDIRS}")
+    message(STATUS "COMPONENT_REQUIRES = ${COMPONENT_REQUIRES}")
+    message(STATUS "COMPONENT_SRCEXCLUDE = ${COMPONENT_SRCEXCLUDE}")
+
+    #
+    # see https://docs.espressif.com/projects/esp-idf/en/stable/esp32/migration-guides/release-5.x/build-system.html?highlight=space%20path
+    #
+    set(EXTRA_COMPONENT_DIRS "${COMPONENT_SRCDIRS}")
+    idf_component_register(
+                            SRC_DIRS "${COMPONENT_SRCDIRS}"
+                            INCLUDE_DIRS "${COMPONENT_ADD_INCLUDEDIRS}"
+                            REQUIRES "${COMPONENT_REQUIRES}"
+                            EXCLUDE_SRCS "${COMPONENT_SRCEXCLUDE}"
+                            PRIV_REQUIRES esp_timer driver # this will typically only be needed for wolfSSL benchmark
+                           )
+    # some optional diagnostics
+    if (0)
+        get_cmake_property(_variableNames VARIABLES)
+        list (SORT _variableNames)
+        message(STATUS "")
+        message(STATUS "ALL VARIABLES BEGIN")
+        message(STATUS "")
+        foreach (_variableName ${_variableNames})
+            message(STATUS "${_variableName}=${${_variableName}}")
+        endforeach()
+        message(STATUS "")
+        message(STATUS "ALL VARIABLES END")
+        message(STATUS "")
+    endif()
+
+    # target_sources(wolfssl PRIVATE  "\"${WOLFSSL_ROOT}/wolfssl/\""  "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt\"")
+endif() # CMAKE_BUILD_EARLY_EXPANSION
 
 # check to see if there's both a local copy and EDP-IDF copy of the wolfssl components
-if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/" AND EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
+if( EXISTS "${WOLFSSL_PROJECT_DIR}" AND EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
     message(STATUS "")
     message(STATUS "")
     message(STATUS "********************************************************************")
@@ -231,3 +416,69 @@ endif()
 # end multiple component check
 
 
+#
+# LIBWOLFSSL_SAVE_INFO(VAR_OUPUT THIS_VAR VAR_RESULT)
+#
+# Save the THIS_VAR as a string in a macro called VAR_OUPUT
+#
+# VAR_OUPUT:  the name of the macro to define
+# THIS_VAR:   the OUTPUT_VARIABLE result from a execute_process()
+# VAR_RESULT: the RESULT_VARIABLE from a execute_process(); "0" if successful.
+#
+function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
+    # is the RESULT_VARIABLE output value 0? If so, IS_VALID_VALUE is true.
+    string(COMPARE EQUAL "${VAR_RESULT}" "0" IS_VALID_VALUE)
+
+    # if we had a successful operation, save the THIS_VAR in VAR_OUPUT
+    if(${IS_VALID_VALUE})
+        # strip newline chars in THIS_VAR parameter and save in VAR_VALUE
+        string(REPLACE "\n" ""  VAR_VALUE  ${THIS_VAR})
+
+        # we'll could percolate the value to the parent for possible later use
+        # set(${VAR_OUPUT} ${VAR_VALUE} PARENT_SCOPE)
+
+        # but we're only using it here in this function
+        set(${VAR_OUPUT} ${VAR_VALUE})
+
+        # we'll print what we found to the console
+        message(STATUS "Found ${VAR_OUPUT}=${VAR_VALUE}")
+
+        # the interesting part is defining the VAR_OUPUT name a value to use in the app
+        add_definitions(-D${VAR_OUPUT}=\"${VAR_VALUE}\")
+    else()
+        # if we get here, check the execute_process command and parameters.
+        message(STATUS "LIBWOLFSSL_SAVE_INFO encountered a non-zero VAR_RESULT")
+        set(${VAR_OUPUT} "Unknown")
+    endif()
+endfunction() # LIBWOLFSSL_SAVE_INFO
+
+# create some programmatic #define values that will be used by ShowExtendedSystemInfo().
+# see wolfcrypt\src\port\Espressif\esp32_utl.c
+if(NOT CMAKE_BUILD_EARLY_EXPANSION)
+    set (git_cmd "git")
+    message(STATUS "Adding macro definitions:")
+
+    # LIBWOLFSSL_VERSION_GIT_ORIGIN: git config --get remote.origin.url
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "config" "--get" "remote.origin.url" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_ORIGIN "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_BRANCH: git rev-parse --abbrev-ref HEAD
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "--abbrev-ref" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_BRANCH "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_HASH: git rev-parse HEAD
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_SHORT_HASH: git rev-parse --short HEAD
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "--short" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_SHORT_HASH "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_HASH_DATE git show --no-patch --no-notes --pretty=\'\%cd\'
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "show" "--no-patch" "--no-notes" "--pretty=\'\%cd\'" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES  )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH_DATE "${TMP_OUT}" "${TMP_RES}")
+
+    message(STATUS "************************************************************************************************")
+    message(STATUS "wolfssl component config complete!")
+    message(STATUS "************************************************************************************************")
+endif()

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/components/wolfssl/include/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/components/wolfssl/include/user_settings.h
@@ -1,0 +1,168 @@
+/* user_settings.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#undef WOLFSSL_ESPIDF
+#undef WOLFSSL_ESP32
+#undef WOLFSSL_ESPWROOM32SE
+#undef WOLFSSL_ESP32
+#undef WOLFSSL_ESP8266
+
+/* The Espressif sdkconfig will have chipset info.
+**
+** Possible values:
+**
+**   CONFIG_IDF_TARGET_ESP32
+**   CONFIG_IDF_TARGET_ESP32S3
+**   CONFIG_IDF_TARGET_ESP32C3
+**   CONFIG_IDF_TARGET_ESP32C6
+*/
+#include <sdkconfig.h>
+
+#define WOLFSSL_ESPIDF
+
+/*
+ * choose ONE of these Espressif chips to define:
+ *
+ * WOLFSSL_ESP32
+ * WOLFSSL_ESPWROOM32SE
+ * WOLFSSL_ESP8266
+ */
+
+#define WOLFSSL_ESP32
+
+/* #define DEBUG_WOLFSSL_VERBOSE */
+
+#define BENCH_EMBEDDED
+#define USE_CERT_BUFFERS_2048
+
+/* TLS 1.3                                 */
+#define WOLFSSL_TLS13
+#define HAVE_TLS_EXTENSIONS
+#define WC_RSA_PSS
+#define HAVE_HKDF
+#define HAVE_AEAD
+#define HAVE_SUPPORTED_CURVES
+
+/* when you want to use SINGLE THREAD */
+/* #define SINGLE_THREADED */
+#define NO_FILESYSTEM
+
+#define HAVE_AESGCM
+/* when you want to use SHA384 */
+/* #define WOLFSSL_SHA384 */
+#define WOLFSSL_SHA512
+#define HAVE_ECC
+#define HAVE_CURVE25519
+#define CURVE25519_SMALL
+#define HAVE_ED25519
+
+/* when you want to use pkcs7 */
+/* #define HAVE_PKCS7 */
+
+#if defined(HAVE_PKCS7)
+    #define HAVE_AES_KEYWRAP
+    #define HAVE_X963_KDF
+    #define WOLFSSL_AES_DIRECT
+#endif
+
+/* when you want to use aes counter mode */
+/* #define WOLFSSL_AES_DIRECT */
+/* #define WOLFSSL_AES_COUNTER */
+
+/* esp32-wroom-32se specific definition */
+#if defined(WOLFSSL_ESPWROOM32SE)
+    #define WOLFSSL_ATECC508A
+    #define HAVE_PK_CALLBACKS
+    /* when you want to use a custom slot allocation for ATECC608A */
+    /* unless your configuration is unusual, you can use default   */
+    /* implementation.                                             */
+    /* #define CUSTOM_SLOT_ALLOCATION                              */
+#endif
+
+/* RSA primitive specific definition */
+#if defined(WOLFSSL_ESP32) || defined(WOLFSSL_ESPWROOM32SE)
+    /* Define USE_FAST_MATH and SMALL_STACK                        */
+    #define ESP32_USE_RSA_PRIMITIVE
+    /* threshold for performance adjustment for HW primitive use   */
+    /* X bits of G^X mod P greater than                            */
+    #define EPS_RSA_EXPT_XBTIS           36
+    /* X and Y of X * Y mod P greater than                         */
+    #define ESP_RSA_MULM_BITS            2000
+#endif
+
+/* debug options */
+/* #define DEBUG_WOLFSSL */
+/* #define WOLFSSL_ESP32_CRYPT_DEBUG */
+/* #define WOLFSSL_ATECC508A_DEBUG          */
+
+/* date/time                               */
+/* if it cannot adjust time in the device, */
+/* enable macro below                      */
+/* #define NO_ASN_TIME */
+/* #define XTIME time */
+
+
+/* adjust wait-timeout count if you see timeout in RSA HW acceleration */
+#define ESP_RSA_TIMEOUT_CNT    0x249F00
+
+#if defined(CONFIG_IDF_TARGET_ESP32)
+    /* when you want not to use HW acceleration on ESP32 (below for S3, etc */
+    /* #define NO_ESP32_CRYPT                 */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_HASH    */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_AES     */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI */
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)
+    /* ESP32-S2 disabled by default; not implemented */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+    /* when you want not to use HW acceleration on ESP32-S3 */
+    /* #define NO_ESP32_CRYPT                 */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_HASH    */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_AES     */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI */
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+    /* ESP32-C3 disabled by default, not implemented */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#elif defined(CONFIG_IDF_TARGET_ESP32C6)
+    /* ESP32-C6 disabled by default, not implemented */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#elif defined(CONFIG_IDF_TARGET_ESP32H2)
+    /* ESP32-H2 disabled by default, not implemented */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#else
+    /* anything else unknown will have HW disabled by default */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#endif

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/partitions_singleapp_large.csv
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/partitions_singleapp_large.csv
@@ -1,0 +1,34 @@
+# This tag is used to include this file in the ESP Component Registry:
+# __ESP_COMPONENT_SOURCE__
+
+# to view: idf.py partition-table
+#
+# ESP-IDF Partition Table
+# Name, Type,  SubType, Offset,  Size, Flags
+nvs,     data, nvs,     0x9000,  24K,
+phy_init,data, phy,     0xf000,  4K,
+factory, app,  factory, 0x10000, 1500K,
+
+
+# For other settings, see:
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html#creating-custom-tables
+#
+# Here is the summary printed for the “Single factory app, no OTA” configuration:
+#
+# # ESP-IDF Partition Table
+# # Name,   Type, SubType, Offset,  Size, Flags
+# nvs,      data, nvs,     0x9000,  0x6000,
+# phy_init, data, phy,     0xf000,  0x1000,
+# factory,  app,  factory, 0x10000, 1M,
+#
+#
+# Here is the summary printed for the “Factory app, two OTA definitions” configuration:
+#
+# # ESP-IDF Partition Table
+# # Name,   Type, SubType, Offset,  Size, Flags
+# nvs,      data, nvs,     0x9000,  0x4000,
+# otadata,  data, ota,     0xd000,  0x2000,
+# phy_init, data, phy,     0xf000,  0x1000,
+# factory,  app,  factory, 0x10000,  1M,
+# ota_0,    app,  ota_0,   0x110000, 1M,
+# ota_1,    app,  ota_1,   0x210000, 1M,

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/components/wolfssl/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/components/wolfssl/CMakeLists.txt
@@ -17,206 +17,437 @@
 #  along with this program; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 #
-# cmake for wolfssl
+# cmake for wolfssl Espressif projects
 #
-cmake_minimum_required(VERSION 3.5)
+# Version 5.6.3.001
+#
+# See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html
+#
+
+cmake_minimum_required(VERSION 3.16)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
 set(CMAKE_CURRENT_SOURCE_DIR ".")
+set(COMPONENT_REQUIRES lwip) # we typically don't need lwip directly in wolfssl component
 
-# We are currently in [root]/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl
+# COMPONENT_NAME = wolfssl
+# The component name is the directory name. "No feature to change this".
+# See https://github.com/espressif/esp-idf/issues/8978#issuecomment-1129892685
+
+# set the root of wolfSSL:
+#   set(WOLFSSL_ROOT  "C:/some path/with/spaces")
+#   set(WOLFSSL_ROOT  "c:/workspace/wolfssl-gojimmypi")
+#   set(WOLFSSL_ROOT  "/mnt/c/some path/with/spaces")
+#   or use this logic to assign value from Environment Variable WOLFSSL_ROOT,
+#   or assume this is an example 7 subdirectories below:
+
+# We are typically in [root]/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl
 # The root of wolfSSL is 7 directories up from here:
-get_filename_component(WOLFSSL_ROOT  "../../../../../../../" ABSOLUTE)
 
-# Espressif may take several passes through this makefile. Check to see if we found IDF
-string(COMPARE EQUAL "${PROJECT_SOURCE_DIR}" "" WOLFSSL_FOUND_IDF)
-
-if($WOLFSSL_FOUND_IDF)
-    message(STATUS "IDF_PATH = $ENV{IDF_PATH}")
-    message(STATUS "WOLFSSL_ROOT = ${WOLFSSL_ROOT}")
-    message(STATUS "PROJECT_SOURCE_DIR = ${PROJECT_SOURCE_DIR}")
-endif()
-
-# get a list of all wolfcrypt assembly files; we'll exclude them as they don't target Xtensa
-FILE(GLOB EXCLUDE_ASM *.S)
-file(GLOB_RECURSE EXCLUDE_ASM ${CMAKE_SOURCE_DIR} "${WOLFSSL_ROOT}/wolfcrypt/src/*.S")
-
-if(NOT CMAKE_BUILD_EARLY_EXPANSION)
-    message(STATUS "EXCLUDE_ASM = ${EXCLUDE_ASM}")
-endif()
-
-set(INCLUDE_PATH ${WOLFSSL_ROOT})
-
-set(COMPONENT_SRCDIRS "${WOLFSSL_ROOT}/src/"
-                        "${WOLFSSL_ROOT}/wolfcrypt/src/"
-                        "${WOLFSSL_ROOT}/wolfcrypt/src/port/Espressif/"
-                        "${WOLFSSL_ROOT}/wolfcrypt/src/port/atmel/"
-                        "${WOLFSSL_ROOT}/wolfcrypt/benchmark/"
-                        "${WOLFSSL_ROOT}/wolfcrypt/test/"
-                        )
-
-set(COMPONENT_REQUIRES lwip)
-
-
-# check to see if there's both a local copy and EDP-IDF copy of the wolfssl and/or wolfssh components
-if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/" AND EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
-    #
-    # wolfSSL found in both ESP-IDF and local project - needs to be resolved by user
-    #
-    message(STATUS "")
-    message(STATUS "**************************************************************************************")
-    message(STATUS "")
-    message(STATUS "Error: Found components/wolfssl in both local project and IDF_PATH")
-    message(STATUS "")
-    message(STATUS "To proceed: ")
-    message(STATUS "")
-    message(STATUS "Remove either the local project component: ${CMAKE_HOME_DIRECTORY}/components/wolfssl/ ")
-    message(STATUS "or the Espressif shared component installed at: $ENV{IDF_PATH}/components/wolfssl/ ")
-    message(STATUS "")
-    message(FATAL_ERROR "Please use wolfSSL in either local project or Espressif components, but not both.")
-    message(STATUS "")
-    message(STATUS "**************************************************************************************")
-    message(STATUS "")
-
-    # Optional: if you change the above FATAL_ERROR to STATUS you can warn at runtime with this macro definition:
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_MULTI_INSTALL_WARNING")
+if(CMAKE_BUILD_EARLY_EXPANSION)
+    message(STATUS "wolfssl component CMAKE_BUILD_EARLY_EXPANSION:")
+    idf_component_register(
+                            REQUIRES "${COMPONENT_REQUIRES}"
+                            PRIV_REQUIRES # esp_hw_support
+                                          esp_timer
+                                          driver # this will typically only be needed for wolfSSL benchmark
+                           )
 
 else()
-    if( EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
-        #
-        # wolfSSL found in ESP-IDF components and is assumed to be already configured in user_settings.h via setup.
-        #
-        message(STATUS "")
-        message(STATUS "Using components/wolfssl in IDF_PATH = $ENV{IDF_PATH}")
-        message(STATUS "")
-    else()
-        #
-        # wolfSSL is not an ESP-IDF component. We need to now determine if it is local and if so if it is part of the wolfSSL repo
-        # or if  wolfSSL is simply installed as a local component.
-        #
-        if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/" )
+    # not CMAKE_BUILD_EARLY_EXPANSION
+    message(STATUS "************************************************************************************************")
+    message(STATUS "wolfssl component config:")
+    message(STATUS "************************************************************************************************")
+
+    # TODO
+    if(WIN32)
+        # Windows-specific configuration here
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
+        message("Detected Windows")
+    endif()
+    if(CMAKE_HOST_UNIX)
+        message("Detected UNIX")
+    endif()
+    if(APPLE)
+        message("Detected APPLE")
+    endif()
+    if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
+        # Windows-specific configuration here
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
+        message("Detected WSL")
+    endif()
+    if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
+        # Windows-specific configuration here
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
+        message("Detected Linux")
+    endif()
+    if(APPLE)
+        # Windows-specific configuration here
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
+        message("Detected Apple")
+    endif()
+
+    # Check to see if we're already in wolfssl, and only if WOLFSSL_ROOT not specified
+    if ("${WOLFSSL_ROOT}" STREQUAL "")
+        # wolfssl examples are 7 directories deep from wolfssl repo root
+        #                        1  2  3  4  5  6  7
+        set(THIS_RELATIVE_PATH "../../../../../../..")
+        get_filename_component(THIS_SEARCH_PATH  "${THIS_RELATIVE_PATH}" ABSOLUTE)
+        message(STATUS "Searching in path = ${THIS_SEARCH_PATH}")
+
+        if (EXISTS "${THIS_SEARCH_PATH}/wolfcrypt/src")
+            # we're already in wolfssl examples!
+            get_filename_component(WOLFSSL_ROOT  "${THIS_SEARCH_PATH}" ABSOLUTE)
+            message(STATUS "Using wolfSSL example with root ${WOLFSSL_ROOT}")
+        else()
+            # We're in some other repo such as wolfssh, so we'll search for an
+            # adjacent-level directory for wolfssl. (8 directories up, then down one)
             #
-            # wolfSSL found in local project.
+            # For example wolfSSL examples:
+            #   C:\workspace\wolfssl-gojimmypi\IDE\Espressif\ESP-IDF\examples\wolfssl_benchmark\components\wolfssl
             #
-            if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/include/" )
-                message(STATUS "")
-                message(STATUS "Using installed project ./components/wolfssl in CMAKE_HOME_DIRECTORY = $ENV{CMAKE_HOME_DIRECTORY}")
-                message(STATUS "")
-                #
-                # Note we already checked above and confirmed there's not another wolfSSL installed in the ESP-IDF components.
-                #
-                # We won't do anything else here, as it will be assumed the original install completed successfully.
-                #
+            # For example wolfSSH examples:
+            #   C:\workspace\wolfssh-gojimmypi\ide\Espressif\ESP-IDF\examples\wolfssh_benchmark\components\wolfssl
+            #
+            #                        1  2  3  4  5  6  7  8
+            set(THIS_RELATIVE_PATH "../../../../../../../..")
+            get_filename_component(THIS_SEARCH_PATH  "${THIS_RELATIVE_PATH}" ABSOLUTE)
+            message(STATUS "Searching next in path = ${THIS_SEARCH_PATH}")
+        endif()
+    endif()
+
+    # search other possible locations
+    if ("${WOLFSSL_ROOT}" STREQUAL "")
+        # there's not a hard-coded WOLFSSL_ROOT value above, so let's see if we can find it.
+        if( "$ENV{WOLFSSL_ROOT}" STREQUAL "" )
+            message(STATUS "Environment Variable WOLFSSL_ROOT not set. Will search common locations.")
+
+            message(STATUS "CMAKE_CURRENT_SOURCE_DIR = ${CMAKE_CURRENT_SOURCE_DIR}")
+            get_filename_component(THIS_DIR "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
+            message(STATUS "THIS_DIR = ${THIS_DIR}")
+
+            # find the user name to search for possible "wolfssl-username"
+            message(STATUS "USERNAME = $ENV{USERNAME}")
+            if(  "$ENV{USER}" STREQUAL "" ) # the bash user
+                if(  "$ENV{USERNAME}" STREQUAL "" ) # the Windows user
+                    message(STATUS "could not find USER or USERNAME")
+                else()
+                    # the bash user is not blank, so we'll use it.
+                    set(THIS_USER "$ENV{USERNAME}")
+                endif()
             else()
-                #
-                # This is the developer repo mode. wolfSSL will be assume to be not installed to ESP-IDF nor local project
-                # In this configuration, we are likely running a wolfSSL example found directly in the repo.
-                #
-                message(STATUS "")
-                message(STATUS "Using developer repo ./components/wolfssl in CMAKE_HOME_DIRECTORY = $ENV{CMAKE_HOME_DIRECTORY}")
-                message(STATUS "")
+                # the bash user is not blank, so we'll use it.
+               set(THIS_USER "$ENV{USER}")
+            endif()
+            message(STATUS "THIS_USER = ${THIS_USER}")
 
-                message(STATUS "************************************************************************************************")
-                # When in developer mode, we are typically running wolfSSL examples such as benchmark or test directories.
-                # However, the as-cloned or distributed wolfSSL does not have the ./include/ directory, so we'll add it as needed.
-                #
-                # first check if there's a [root]/include/user_settings.h
-                if( EXISTS "${WOLFSSL_ROOT}/include/user_settings.h" )
-                    # we won't overwrite an existing user settings file, just note that we already have one:
-                    message(STATUS "Found wolfSSL user_settings.h in ${WOLFSSL_ROOT}/include/user_settings.h")
-                else()
-                    message(STATUS "Installing wolfSSL user_settings.h to ${WOLFSSL_ROOT}/include/user_settings.h")
-                    file(COPY "${WOLFSSL_ROOT}/IDE/Espressif/ESP-IDF/user_settings.h" DESTINATION "${WOLFSSL_ROOT}/include/")
-                endif() # user_settings.h
+            # This same makefile is used for both the wolfssl component, and other
+            # components that may depend on wolfssl, such as wolfssh. Therefore
+            # we need to determine if this makefile is in the wolfssl repo, or
+            # some other repo.
 
-                # next check if there's a [root]/include/config.h
-                if( EXISTS "${WOLFSSL_ROOT}/include/config.h" )
-                    message(STATUS "Found wolfSSL config.h in ${WOLFSSL_ROOT}/include/config.h")
+            if(  "{THIS_USER}" STREQUAL "" )
+                # This is highly unusual to not find a user name.
+                # In this case, we'll just search for a "wolfssl" directory:
+                message(STATUS "No username found!")
+                get_filename_component(WOLFSSL_ROOT  "${THIS_RELATIVE_PATH}/wolfssl" ABSOLUTE)
+            else()
+                # We found an environment USER name!
+                # The first place to look for wolfssl will be in a user-clone called "wolfssl-[username]"
+                message(STATUS "Using [THIS_USER = ${THIS_USER}] to see if there's a [relative path]/wolfssl-${THIS_USER} directory.")
+                get_filename_component(WOLFSSL_ROOT  "${THIS_RELATIVE_PATH}/wolfssl-${THIS_USER}" ABSOLUTE)
+
+                if( EXISTS "${WOLFSSL_ROOT}" )
+                    message(STATUS "Found wolfssl in user-suffix ${WOLFSSL_ROOT}")
                 else()
-                    message(STATUS "Installing wolfSSL config.h to ${WOLFSSL_ROOT}/include/config.h")
-                    file(COPY "${WOLFSSL_ROOT}/IDE/Espressif/ESP-IDF/dummy_config_h" DESTINATION "${WOLFSSL_ROOT}/include/")
-                    file(RENAME "${WOLFSSL_ROOT}/include/dummy_config_h" "${WOLFSSL_ROOT}/include/config.h")
-                endif() # config.h
-                message(STATUS "************************************************************************************************")
-                message(STATUS "")
+                    # If there's not a user-clone called "wolfssl-[username]",
+                    # perhaps there's simply a git clone called "wolfssl"?
+                    message(STATUS "Did not find wolfssl-${THIS_USER}; continuing search...")
+                    get_filename_component(WOLFSSL_ROOT  "${THIS_RELATIVE_PATH}/wolfssl" ABSOLUTE)
+
+                    if( EXISTS "${WOLFSSL_ROOT}" )
+                        message(STATUS "Found wolfssl in standard ${WOLFSSL_ROOT}")
+                    else()
+                        # Things are looking pretty bleak. We'll likely not be able to compile.
+                        message(STATUS "Did not find wolfssl in ${WOLFSSL_ROOT}")
+                    endif()
+                endif()
             endif()
 
         else()
-            # we did not find a ./components/wolfssl/include/ directory from this pass of cmake.
-            if($WOLFSSL_FOUND_IDF)
-                message(STATUS "")
-                message(STATUS "WARNING: wolfSSL not found.")
-                message(STATUS "")
+            # there's an environment variable, so use it.
+            set(WOLFSSL_ROOT "$ENV{WOLFSSL_ROOT}")
+
+            if( EXISTS "${WOLFSSL_ROOT}" )
+                get_filename_component(WOLFSSL_ROOT  "$ENV{WOLFSSL_ROOT}" ABSOLUTE)
+                message(STATUS "Found WOLFSSL_ROOT via Environment Variable:")
             else()
-                # probably needs to be re-parsed by Espressif
-                message(STATUS "wolfSSL found IDF. Project Source:${PROJECT_SOURCE_DIR}")
-            endif() # else we have not found ESP-IDF yet
-        endif() # else not a local wolfSSL component
+                message(FATAL_ERROR "WOLFSSL_ROOT Environment Variable defined, but path not found:")
+                message(STATUS "$ENV{WOLFSSL_ROOT}")
+            endif()
+        endif()
+        # end of search for wolfssl component root
+    else()
+        # There's already a value assigned; we won't search for anything else.
+        message(STATUS "Found user-specified WOLFSSL_ROOT value.")
+    endif() # WOLFSSL_ROOT user defined
 
-    endif() #else not an ESP-IDF component
-endif() # else not local copy and EDP-IDF wolfSSL
+    # After all the logic above, does our WOLFSSL_ROOT actually exist?
+    if( EXISTS "${WOLFSSL_ROOT}" )
+        message(STATUS "WOLFSSL_ROOT = ${WOLFSSL_ROOT}")
+    else()
+        # Abort. We need wolfssl _somewhere_.
+        message(FATAL_ERROR "Could not find wolfssl in ${WOLFSSL_ROOT}. Try setting environment variable or git clone.")
+    endif()
 
 
-# RTOS_IDF_PATH is typically:
-# "/Users/{username}/Desktop/esp-idf/components/freertos/include/freertos"
-# depending on the environment, we may need to swap backslashes with forward slashes
-string(REPLACE "\\" "/" RTOS_IDF_PATH "$ENV{IDF_PATH}/components/freertos/include/freertos")
+    set(INCLUDE_PATH ${WOLFSSL_ROOT})
 
-# ESP-IDF after version 4.4x has a different RTOS directory structure
-string(REPLACE "\\" "/" RTOS_IDF_PATH5 "$ENV{IDF_PATH}/components/freertos/FreeRTOS-Kernel/include/freertos")
+    set(COMPONENT_SRCDIRS "\"${WOLFSSL_ROOT}/src/\""
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/src\""
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/src/port/Espressif\""
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/src/port/atmel\""
+                          # TODO: Make this a univeral makefile that detects if bechmark / test needed
+                          # Sometimes problematic with SM; consider gating detection.
+                          #"\"${WOLFSSL_ROOT}/wolfcrypt/benchmark\"" # the benchmark application
+                          #"\"${WOLFSSL_ROOT}/wolfcrypt/test\"" # the test application
+       ) # COMPONENT_SRCDIRS
+    message(STATUS "This COMPONENT_SRCDIRS = ${COMPONENT_SRCDIRS}")
 
-if(IS_DIRECTORY ${IDF_PATH}/components/freertos/FreeRTOS-Kernel/)
+    set(WOLFSSL_PROJECT_DIR "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
+    add_definitions(-DWOLFSSL_USER_SETTINGS_DIR="${WOLFSSL_PROJECT_DIR}/include/user_settings.h")
+
+
+    # Espressif may take several passes through this makefile. Check to see if we found IDF
+    string(COMPARE EQUAL "${PROJECT_SOURCE_DIR}" "" WOLFSSL_FOUND_IDF)
+
+    # get a list of all wolfcrypt assembly files; we'll exclude them as they don't target Xtensa
+    file(GLOB EXCLUDE_ASM *.S)
+    file(GLOB_RECURSE EXCLUDE_ASM ${CMAKE_SOURCE_DIR} "${WOLFSSL_ROOT}/wolfcrypt/src/*.S")
+
+    message(STATUS "IDF_PATH = $ENV{IDF_PATH}")
+    message(STATUS "PROJECT_SOURCE_DIR = ${PROJECT_SOURCE_DIR}")
+    message(STATUS "EXCLUDE_ASM = ${EXCLUDE_ASM}")
+
+    #
+    # Check to see if there's both a local copy and EDP-IDF copy of the wolfssl and/or wolfssh components.
+    #
+    if( EXISTS "${WOLFSSL_PROJECT_DIR}" AND EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
+        #
+        # wolfSSL found in both ESP-IDF and local project - needs to be resolved by user
+        #
+        message(STATUS "")
+        message(STATUS "**************************************************************************************")
+        message(STATUS "")
+        message(STATUS "Error: Found components/wolfssl in both local project and IDF_PATH")
+        message(STATUS "")
+        message(STATUS "To proceed: ")
+        message(STATUS "")
+        message(STATUS "Remove either the local project component: ${WOLFSSL_PROJECT_DIR} ")
+        message(STATUS "or the Espressif shared component installed at: $ENV{IDF_PATH}/components/wolfssl/ ")
+        message(STATUS "")
+        message(FATAL_ERROR "Please use wolfSSL in either local project or Espressif components, but not both.")
+        message(STATUS "")
+        message(STATUS "**************************************************************************************")
+        message(STATUS "")
+
+        # Optional: if you change the above FATAL_ERROR to STATUS you can warn at runtime with this macro definition:
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_MULTI_INSTALL_WARNING")
+
+    else()
+        if( EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
+            #
+            # wolfSSL found in ESP-IDF components and is assumed to be already configured in user_settings.h via setup.
+            #
+            message(STATUS "")
+            message(STATUS "Using components/wolfssl in IDF_PATH = $ENV{IDF_PATH}")
+            message(STATUS "")
+        else()
+            #
+            # wolfSSL is not an ESP-IDF component.
+            # We need to now determine if it is local and if so if it is part of the wolfSSL repo,
+            # or if  wolfSSL is simply installed as a local component.
+            #
+
+            if( EXISTS "${WOLFSSL_PROJECT_DIR}" )
+                #
+                # wolfSSL found in local project.
+                #
+                if( EXISTS "${WOLFSSL_PROJECT_DIR}/wolfcrypt/" )
+                    message(STATUS "")
+                    message(STATUS "Using installed project ./components/wolfssl in CMAKE_HOME_DIRECTORY = ${CMAKE_HOME_DIRECTORY}")
+                    message(STATUS "")
+                    #
+                    # Note we already checked above and confirmed there's not another wolfSSL installed in the ESP-IDF components.
+                    #
+                    # We won't do anything else here, as it will be assumed the original install completed successfully.
+                    #
+                else() # full wolfSSL not installed in local project
+                    #
+                    # This is the developer repo mode. wolfSSL will be assumed to be not installed to ESP-IDF nor local project
+                    # In this configuration, we are likely running a wolfSSL example found directly in the repo.
+                    #
+                    message(STATUS "")
+                    message(STATUS "Using developer repo ./components/wolfssl in CMAKE_HOME_DIRECTORY = ${CMAKE_HOME_DIRECTORY}")
+                    message(STATUS "")
+
+                    message(STATUS "************************************************************************************************")
+                    # When in developer mode, we are typically running wolfSSL examples such as benchmark or test directories.
+                    # However, the as-cloned or distributed wolfSSL does not have the ./include/ directory, so we'll add it as needed.
+                    #
+                    # first check if there's a [root]/include/user_settings.h
+                    if( EXISTS "${WOLFSSL_ROOT}/include/user_settings.h" )
+                        message(FATAL_ERROR "Found stray wolfSSL user_settings.h in "
+                                            "${WOLFSSL_ROOT}/include/user_settings.h "
+                                            " (please move it to ${WOLFSSL_PROJECT_DIR}/include/user_settings.h )")
+                    else()
+                        # we won't overwrite an existing user settings file, just note that we already have one:
+                        if( EXISTS "${WOLFSSL_PROJECT_DIR}/include/user_settings.h" )
+                            message(STATUS "Using existing wolfSSL user_settings.h in "
+                                           "${WOLFSSL_PROJECT_DIR}/include/user_settings.h")
+                        else()
+                            message(STATUS "Installing wolfSSL user_settings.h to "
+                                           "${WOLFSSL_PROJECT_DIR}/include/user_settings.h")
+                            file(COPY "${WOLFSSL_ROOT}/IDE/Espressif/ESP-IDF/user_settings.h"
+                            DESTINATION "${CMAKE_HOME_DIRECTORY}/wolfssl/include/")
+                        endif()
+                    endif() # user_settings.h
+
+                    # next check if there's a [root]/include/config.h
+                    if( EXISTS "${WOLFSSL_ROOT}/include/config.h" )
+                        message(FATAL_ERROR "Found stray wolfSSL config.h in "
+                                            "${WOLFSSL_ROOT}/include/config.h "
+                                            " (please move it to ${WOLFSSL_PROJECT_DIR}/include/config.h )")
+                    else()
+                        # we won't overwrite an existing user settings file, just note that we already have one:
+                        if( EXISTS "${WOLFSSL_PROJECT_DIR}/include/config.h" )
+                            message(STATUS "Using existing wolfSSL config.h           ${WOLFSSL_PROJECT_DIR}/include/config.h")
+                        else()
+                            message(STATUS "Installing wolfSSL config.h to            ${WOLFSSL_PROJECT_DIR}/include/config.h")
+                            file(COPY   "${WOLFSSL_ROOT}/IDE/Espressif/ESP-IDF/dummy_config_h" DESTINATION "${WOLFSSL_PROJECT_DIR}/include/")
+                            file(RENAME "${WOLFSSL_PROJECT_DIR}/include/dummy_config_h" "${WOLFSSL_PROJECT_DIR}/include/config.h")
+                        endif() # Project config.h
+                    endif() # WOLFSSL_ROOT config.h
+                    message(STATUS "************************************************************************************************")
+                    message(STATUS "")
+                endif()
+
+            else()
+                # we did not find a ./components/wolfssl/include/ directory from this pass of cmake.
+                if($WOLFSSL_FOUND_IDF)
+                    message(STATUS "")
+                    message(STATUS "WARNING: wolfSSL not found.")
+                    message(STATUS "")
+                else()
+                    # probably needs to be re-parsed by Espressif
+                    message(STATUS "wolfSSL found IDF. Project Source:${PROJECT_SOURCE_DIR}")
+                endif() # else we have not found ESP-IDF yet
+            endif() # else not a local wolfSSL component
+
+        endif() #else not an ESP-IDF component
+    endif() # else not local copy and EDP-IDF wolfSSL
+
+
+    # RTOS_IDF_PATH is typically:
+    # "/Users/{username}/Desktop/esp-idf/components/freertos/include/freertos"
+    # depending on the environment, we may need to swap backslashes with forward slashes
+    string(REPLACE "\\" "/" RTOS_IDF_PATH "$ENV{IDF_PATH}/components/freertos/FreeRTOS-Kernel/include/freertos")
+
+    string(REPLACE "\\" "/" WOLFSSL_ROOT ${WOLFSSL_ROOT})
+
+    if(IS_DIRECTORY "${RTOS_IDF_PATH}")
+        message(STATUS "Found current RTOS path: ${RTOS_IDF_PATH}")
+    else()
+        # ESP-IDF prior version 4.4x has a different RTOS directory structure
+        string(REPLACE "\\" "/" RTOS_IDF_PATH "$ENV{IDF_PATH}/components/freertos/include/freertos")
+        if(IS_DIRECTORY "${RTOS_IDF_PATH}")
+            message(STATUS "Found legacy RTOS path: ${RTOS_IDF_PATH}")
+        else()
+            message(STATUS "Could not find RTOS path")
+        endif()
+    endif()
+
+
     set(COMPONENT_ADD_INCLUDEDIRS
-        "."
-       "${WOLFSSL_ROOT}/include"
-       "${RTOS_IDF_PATH5}"
-       "${WOLFSSL_ROOT}"
-       )
-else()
+        "./include" # this is the location of wolfssl user_settings.h
+        "\"${WOLFSSL_ROOT}/\""
+        "\"${WOLFSSL_ROOT}/wolfssl/\""
+        "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/\""
+        "\"${RTOS_IDF_PATH}/\""
+        )
 
-   set(COMPONENT_ADD_INCLUDEDIRS
-       "."
-       "${WOLFSSL_ROOT}/include"
-       "${RTOS_IDF_PATH}"
-       "${WOLFSSL_ROOT}"
-      )
-endif()
 
-if(IS_DIRECTORY ${IDF_PATH}/components/cryptoauthlib)
-    list(APPEND COMPONENT_ADD_INCLUDEDIRS "../cryptoauthlib/lib")
-endif()
+    if(IS_DIRECTORY ${IDF_PATH}/components/cryptoauthlib)
+        list(APPEND COMPONENT_ADD_INCLUDEDIRS "../cryptoauthlib/lib")
+    endif()
 
-set(COMPONENT_SRCEXCLUDE
-    "${WOLFSSL_ROOT}/src/bio.c"
-    "${WOLFSSL_ROOT}/src/conf.c"
-    "${WOLFSSL_ROOT}/src/misc.c"
-    "${WOLFSSL_ROOT}/src/pk.c"
-    "${WOLFSSL_ROOT}/src/ssl_misc.c" # included by ssl.c
-    "${WOLFSSL_ROOT}/src/x509.c"
-    "${WOLFSSL_ROOT}/src/x509_str.c"
-    "${WOLFSSL_ROOT}/wolfcrypt/src/evp.c"
-    "${WOLFSSL_ROOT}/wolfcrypt/src/misc.c"
-    "${EXCLUDE_ASM}"
-    )
+    list(APPEND COMPONENT_ADD_INCLUDEDIRS "\"${WOLFSSL_ROOT}/wolfssl/\"")
+    list(APPEND COMPONENT_ADD_INCLUDEDIRS "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/\"")
 
-register_component()
 
-# some optional diagnostics
-if (0)
-    get_cmake_property(_variableNames VARIABLES)
-    list (SORT _variableNames)
-    message(STATUS "")
-    message(STATUS "ALL VARIABLES BEGIN")
-    message(STATUS "")
-    foreach (_variableName ${_variableNames})
-        message(STATUS "${_variableName}=${${_variableName}}")
-    endforeach()
-    message(STATUS "")
-    message(STATUS "ALL VARIABLES END")
-    message(STATUS "")
-endif()
+
+    set(COMPONENT_SRCEXCLUDE
+        "\"${WOLFSSL_ROOT}/src/bio.c\""
+        "\"${WOLFSSL_ROOT}/src/conf.c\""
+        "\"${WOLFSSL_ROOT}/src/misc.c\""
+        "\"${WOLFSSL_ROOT}/src/pk.c\""
+        "\"${WOLFSSL_ROOT}/src/ssl_asn1.c\""    # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/ssl_bn.c\""      # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/ssl_certman.c\"" # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/ssl_misc.c\""    # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/x509.c\""
+        "\"${WOLFSSL_ROOT}/src/x509_str.c\""
+        "\"${WOLFSSL_ROOT}/wolfcrypt/src/evp.c\""
+        "\"${WOLFSSL_ROOT}/wolfcrypt/src/misc.c\""
+        "\"${EXCLUDE_ASM}\""
+        )
+
+    spaces2list(COMPONENT_REQUIRES)
+
+    separate_arguments(COMPONENT_SRCDIRS NATIVE_COMMAND "${COMPONENT_SRCDIRS}")
+    separate_arguments(COMPONENT_SRCEXCLUDE NATIVE_COMMAND "${COMPONENT_SRCEXCLUDE}")
+    separate_arguments(COMPONENT_ADD_INCLUDEDIRS NATIVE_COMMAND "${COMPONENT_ADD_INCLUDEDIRS}")
+
+    #
+    # See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#example-component-requirements
+    #
+    message(STATUS "COMPONENT_SRCDIRS = ${COMPONENT_SRCDIRS}")
+    message(STATUS "COMPONENT_ADD_INCLUDEDIRS = ${COMPONENT_ADD_INCLUDEDIRS}")
+    message(STATUS "COMPONENT_REQUIRES = ${COMPONENT_REQUIRES}")
+    message(STATUS "COMPONENT_SRCEXCLUDE = ${COMPONENT_SRCEXCLUDE}")
+
+    #
+    # see https://docs.espressif.com/projects/esp-idf/en/stable/esp32/migration-guides/release-5.x/build-system.html?highlight=space%20path
+    #
+    set(EXTRA_COMPONENT_DIRS "${COMPONENT_SRCDIRS}")
+    idf_component_register(
+                            SRC_DIRS "${COMPONENT_SRCDIRS}"
+                            INCLUDE_DIRS "${COMPONENT_ADD_INCLUDEDIRS}"
+                            REQUIRES "${COMPONENT_REQUIRES}"
+                            EXCLUDE_SRCS "${COMPONENT_SRCEXCLUDE}"
+                            PRIV_REQUIRES esp_timer driver # this will typically only be needed for wolfSSL benchmark
+                           )
+    # some optional diagnostics
+    if (1)
+        get_cmake_property(_variableNames VARIABLES)
+        list (SORT _variableNames)
+        message(STATUS "")
+        message(STATUS "ALL VARIABLES BEGIN")
+        message(STATUS "")
+        foreach (_variableName ${_variableNames})
+            message(STATUS "${_variableName}=${${_variableName}}")
+        endforeach()
+        message(STATUS "")
+        message(STATUS "ALL VARIABLES END")
+        message(STATUS "")
+    endif()
+
+    # target_sources(wolfssl PRIVATE  "\"${WOLFSSL_ROOT}/wolfssl/\""  "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt\"")
+endif() # CMAKE_BUILD_EARLY_EXPANSION
+
+
 
 # check to see if there's both a local copy and EDP-IDF copy of the wolfssl components
-if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/" AND EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
+if( EXISTS "${WOLFSSL_PROJECT_DIR}" AND EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
     message(STATUS "")
     message(STATUS "")
     message(STATUS "********************************************************************")
@@ -227,3 +458,69 @@ endif()
 # end multiple component check
 
 
+#
+# LIBWOLFSSL_SAVE_INFO(VAR_OUPUT THIS_VAR VAR_RESULT)
+#
+# Save the THIS_VAR as a string in a macro called VAR_OUPUT
+#
+# VAR_OUPUT:  the name of the macro to define
+# THIS_VAR:   the OUTPUT_VARIABLE result from a execute_process()
+# VAR_RESULT: the RESULT_VARIABLE from a execute_process(); "0" if successful.
+#
+function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
+    # is the RESULT_VARIABLE output value 0? If so, IS_VALID_VALUE is true.
+    string(COMPARE EQUAL "${VAR_RESULT}" "0" IS_VALID_VALUE)
+
+    # if we had a successful operation, save the THIS_VAR in VAR_OUPUT
+    if(${IS_VALID_VALUE})
+        # strip newline chars in THIS_VAR parameter and save in VAR_VALUE
+        string(REPLACE "\n" ""  VAR_VALUE  ${THIS_VAR})
+
+        # we'll could percolate the value to the parent for possible later use
+        # set(${VAR_OUPUT} ${VAR_VALUE} PARENT_SCOPE)
+
+        # but we're only using it here in this function
+        set(${VAR_OUPUT} ${VAR_VALUE})
+
+        # we'll print what we found to the console
+        message(STATUS "Found ${VAR_OUPUT}=${VAR_VALUE}")
+
+        # the interesting part is defining the VAR_OUPUT name a value to use in the app
+        add_definitions(-D${VAR_OUPUT}=\"${VAR_VALUE}\")
+    else()
+        # if we get here, check the execute_process command and parameters.
+        message(STATUS "LIBWOLFSSL_SAVE_INFO encountered a non-zero VAR_RESULT")
+        set(${VAR_OUPUT} "Unknown")
+    endif()
+endfunction() # LIBWOLFSSL_SAVE_INFO
+
+# create some programmatic #define values that will be used by ShowExtendedSystemInfo().
+# see wolfcrypt\src\port\Espressif\esp32_utl.c
+if(NOT CMAKE_BUILD_EARLY_EXPANSION)
+    set (git_cmd "git")
+    message(STATUS "Adding macro definitions:")
+
+    # LIBWOLFSSL_VERSION_GIT_ORIGIN: git config --get remote.origin.url
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "config" "--get" "remote.origin.url" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_ORIGIN "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_BRANCH: git rev-parse --abbrev-ref HEAD
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "--abbrev-ref" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_BRANCH "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_HASH: git rev-parse HEAD
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_SHORT_HASH: git rev-parse --short HEAD
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "--short" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_SHORT_HASH "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_HASH_DATE git show --no-patch --no-notes --pretty=\'\%cd\'
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "show" "--no-patch" "--no-notes" "--pretty=\'\%cd\'" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES  )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH_DATE "${TMP_OUT}" "${TMP_RES}")
+
+    message(STATUS "************************************************************************************************")
+    message(STATUS "wolfssl component config complete!")
+    message(STATUS "************************************************************************************************")
+endif()

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/components/wolfssl/include/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/components/wolfssl/include/user_settings.h
@@ -1,0 +1,380 @@
+/* user_settings.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* This is the user_settings.h file for the wolfssl_client TLS example.
+ * For application-specific settings, please see client-tls.h file */
+
+#include <sdkconfig.h> /* essential to chip set detection */
+
+/* optional timezone used when setting time */
+#define TIME_ZONE "PST+8PDT,M3.2.0,M11.1.0"
+
+/* #define SHOW_SSID_AND_PASSWORD */ /* remove this to not show in startup log */
+
+#undef WOLFSSL_ESPIDF
+#undef WOLFSSL_ESP32
+#undef WOLFSSL_ESPWROOM32SE
+#undef WOLFSSL_ESP32
+#undef WOLFSSL_ESP8266
+
+/* The Espressif sdkconfig will have chipset info.
+**
+** Possible values:
+**
+**   CONFIG_IDF_TARGET_ESP32
+**   CONFIG_IDF_TARGET_ESP32S2
+**   CONFIG_IDF_TARGET_ESP32S3
+**   CONFIG_IDF_TARGET_ESP32C3
+**   CONFIG_IDF_TARGET_ESP32C6
+*/
+
+#define WOLFSSL_ESPIDF
+
+/*
+ * choose ONE of these Espressif chips to define:
+ *
+ * WOLFSSL_ESP32
+ * WOLFSSL_ESPWROOM32SE
+ * WOLFSSL_ESP8266
+ */
+
+#define WOLFSSL_ESP32
+
+#if defined(CONFIG_IDF_TARGET_ESP32)
+    /* HW Enabled by default for ESP32. To disable: */
+    /* #define NO_ESP32_CRYPT                 */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_HASH    */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_AES     */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI */
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)
+    /* HW Disabled by default for ESP32-S2.   */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+    /* HW Enabled by default for ESP32. To disable: */
+    /* #define NO_ESP32_CRYPT                 */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_HASH    */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_AES     */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI */
+#elif defined(CONFIG_IDF_TARGET_ESP32C2)
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+    /* HW Disabled by default for ESP32-C3.   */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#elif defined(CONFIG_IDF_TARGET_ESP32C6)
+    /* HW Disabled by default for ESP32-C6.   */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#elif defined(CONFIG_IDF_TARGET_ESP32H2)
+    /* HW Disabled by default for ESP32-H2.   */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#else
+    /* HW Disabled by default for all other ESP32-[?].  */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#endif
+
+
+/* optionally turn off SHA512/224 SHA512/256 */
+/* #define WOLFSSL_NOSHA512_224 */
+/* #define WOLFSSL_NOSHA512_256 */
+
+#define BENCH_EMBEDDED
+
+/* TLS 1.3                                 */
+#define WOLFSSL_TLS13
+#define HAVE_TLS_EXTENSIONS
+#define WC_RSA_PSS
+#define HAVE_HKDF
+#define HAVE_AEAD
+#define HAVE_SUPPORTED_CURVES
+
+#define WOLFSSL_BENCHMARK_FIXED_UNITS_KB
+
+/* when you want to use SINGLE THREAD */
+/* #define SINGLE_THREADED */
+#define NO_FILESYSTEM
+
+#define HAVE_AESGCM
+
+#define WOLFSSL_RIPEMD
+/* when you want to use SHA224 */
+/* #define WOLFSSL_SHA224      */
+
+#define NO_OLD_TLS
+
+/* when you want to use SHA384 */
+/* #define WOLFSSL_SHA384 */
+
+/* #define WOLFSSL_SHA3 */
+
+#define WOLFSSL_SHA512
+#define HAVE_ECC
+#define HAVE_CURVE25519
+#define CURVE25519_SMALL
+#define HAVE_ED25519
+
+/* when you want to use pkcs7 */
+/* #define HAVE_PKCS7 */
+
+#if defined(HAVE_PKCS7)
+    #define HAVE_AES_KEYWRAP
+    #define HAVE_X963_KDF
+    #define WOLFSSL_AES_DIRECT
+#endif
+
+/* optional DH */
+/* #define PROJECT_DH */
+#ifdef PROJECT_DH
+    #define HAVE_DH
+    #define HAVE_FFDHE_2048
+#endif
+
+/* when you want to use aes counter mode */
+/* #define WOLFSSL_AES_DIRECT */
+/* #define WOLFSSL_AES_COUNTER */
+
+/* esp32-wroom-32se specific definition */
+#if defined(WOLFSSL_ESPWROOM32SE)
+    #define WOLFSSL_ATECC508A
+    #define HAVE_PK_CALLBACKS
+    /* when you want to use a custom slot allocation for ATECC608A */
+    /* unless your configuration is unusual, you can use default   */
+    /* implementation.                                             */
+    /* #define CUSTOM_SLOT_ALLOCATION                              */
+#endif
+
+/* RSA primitive specific definition */
+#if defined(WOLFSSL_ESP32) || defined(WOLFSSL_ESPWROOM32SE)
+    /* Define USE_FAST_MATH and SMALL_STACK                        */
+    #define ESP32_USE_RSA_PRIMITIVE
+    /* threshold for performance adjustment for HW primitive use   */
+    /* X bits of G^X mod P greater than                            */
+    #define EPS_RSA_EXPT_XBTIS           36
+    /* X and Y of X * Y mod P greater than                         */
+    #define ESP_RSA_MULM_BITS            36
+#endif
+#define RSA_LOW_MEM
+
+/* debug options */
+/* #define DEBUG_WOLFSSL */
+/* #define WOLFSSL_ESP32_CRYPT_DEBUG */
+/* #define WOLFSSL_ESP32_HW_LOCK_DEBUG */
+/* #define WOLFSSL_ATECC508A_DEBUG          */
+
+/* date/time                               */
+/* if it cannot adjust time in the device, */
+/* enable macro below                      */
+/* #define NO_ASN_TIME */
+/* #define XTIME time */
+
+/* adjust wait-timeout count if you see timeout in RSA HW acceleration */
+#define ESP_RSA_TIMEOUT_CNT    0x249F00
+
+/* see esp_ShowExtendedSystemInfo in esp32-crypt.h for startup log info */
+#define HAVE_VERSION_EXTENDED_INFO
+
+
+/* debug options */
+/* #define ESP_VERIFY_MEMBLOCK              */
+#define WOLFSSL_HW_METRICS
+/* #define DEBUG_WOLFSSL_VERBOSE            */
+/* #define DEBUG_WOLFSSL                    */
+/* #define WOLFSSL_ESP32_CRYPT_DEBUG        */
+#define NO_RECOVER_SOFTWARE_CALC
+
+/* optionally turn off individual math HW acceleration features */
+
+/* Turn off Large Number Multiplication:
+** [Z = X * Y] in esp_mp_mul()                                  */
+/* #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_MP_MUL         */
+
+/* Turn off Large Number Modular Exponentiation:
+** [Z = X^Y mod M] in esp_mp_exptmod()                          */
+/* #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_EXPTMOD        */
+
+/* Turn off Large Number Modular Multiplication
+** [Z = X × Y mod M] in esp_mp_mulmod()                         */
+/* #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_MULMOD         */
+
+
+/* this is known to fail in TFM: */
+/* #define HONOR_MATH_USED_LENGTH */
+
+/* this is known to fail in TFM */
+/* #define CHECK_MP_READ_UNSIGNED_BIN */
+
+#define WOLFSSL_PUBLIC_MP /* used by benchmark */
+
+/* optional SM4 Ciphers. See https://github.com/wolfSSL/wolfsm */
+/* Uncomment this section to enable SM
+#define WOLFSSL_SM2
+#define WOLFSSL_SM3
+#define WOLFSSL_SM4
+*/
+
+#if defined(WOLFSSL_SM2) || defined(WOLFSSL_SM3) || defined(WOLFSSL_SM4)
+    /* see https://github.com/wolfSSL/wolfssl/pull/6537
+     *
+     * see settings.h for other features turned on with SM4 ciphers.
+     */
+    #undef  USE_CERT_BUFFERS_1024
+    #define USE_CERT_BUFFERS_1024
+
+    #undef  WOLFSSL_SM4_ECB
+    #define WOLFSSL_SM4_ECB
+
+    #undef  WOLFSSL_SM4_CBC
+    #define WOLFSSL_SM4_CBC
+
+    #undef  WOLFSSL_SM4_CTR
+    #define WOLFSSL_SM4_CTR
+
+    #undef  WOLFSSL_SM4_GCM
+    #define WOLFSSL_SM4_GCM
+
+    #undef  WOLFSSL_SM4_CCM
+    #define WOLFSSL_SM4_CCM
+
+    #define HAVE_POLY1305
+    #define HAVE_CHACHA
+
+    #undef  HAVE_AESGCM
+    #define HAVE_AESGCM
+
+    #undef  HAVE_ECC
+    #define HAVE_ECC
+
+    /* see https://github.com/wolfSSL/wolfssl/pull/6825 */
+    #include <wolfssl/certs_test_sm.h>
+
+    #define CTX_CA_CERT          root_sm2
+    #define CTX_CA_CERT_SIZE     sizeof_root_sm2
+    #define CTX_CA_CERT_TYPE     WOLFSSL_FILETYPE_PEM
+    #define CTX_SERVER_CERT      server_sm2
+    #define CTX_SERVER_CERT_SIZE sizeof_server_sm2
+    #define CTX_SERVER_CERT_TYPE WOLFSSL_FILETYPE_PEM
+    #define CTX_SERVER_KEY       server_sm2_priv
+    #define CTX_SERVER_KEY_SIZE  sizeof_server_sm2_priv
+    #define CTX_SERVER_KEY_TYPE  WOLFSSL_FILETYPE_PEM
+/*
+ * SM optional cipher suite settings:
+ *
+    #define WOLFSSL_ESP32_CIPHER_SUITE "TLS13-SM4-GCM-SM3"
+    #define WOLFSSL_ESP32_CIPHER_SUITE "TLS13-SM4-CCM-SM3"
+    #define WOLFSSL_ESP32_CIPHER_SUITE "ECDHE-ECDSA-SM4-CBC-SM3"
+    #define WOLFSSL_ESP32_CIPHER_SUITE "ECDHE-ECDSA-SM4-GCM-SM3"
+    #define WOLFSSL_ESP32_CIPHER_SUITE "ECDHE-ECDSA-SM4-CCM-SM3"
+*/
+    #define WOLFSSL_ESP32_CIPHER_SUITE "TLS13-SM4-GCM-SM3:" \
+                                       "TLS13-SM4-CCM-SM3:" \
+                                       "TLS-SM4-GCM-SM3:" /* not a valid command-line cipher */ \
+                                       "TLS-SM4-CCM-SM3:" /* not a valid command-line cipher */ \
+                                       "ECDHE-ECDSA-SM4-CBC-SM3:" \
+                                       "ECDHE-ECDSA-SM4-GCM-SM3:" \
+                                       "ECDHE-ECDSA-SM4-CCM-SM3"
+
+#else
+    /* default settings */
+    #define USE_CERT_BUFFERS_2048
+    #define USE_CERT_BUFFERS_256
+    #define CTX_CA_CERT          ca_cert_der_2048
+    #define CTX_CA_CERT_SIZE     sizeof_ca_cert_der_2048
+    #define CTX_CA_CERT_TYPE     WOLFSSL_FILETYPE_ASN1
+    #define CTX_SERVER_CERT      server_cert_der_2048
+    #define CTX_SERVER_CERT_SIZE sizeof_server_cert_der_2048
+    #define CTX_SERVER_CERT_TYPE WOLFSSL_FILETYPE_ASN1
+    #define CTX_SERVER_KEY       server_key_der_2048
+    #define CTX_SERVER_KEY_SIZE  sizeof_server_key_der_2048
+    #define CTX_SERVER_KEY_TYPE  WOLFSSL_FILETYPE_ASN1
+/*
+ * Optional Cipher Suite Specification
+ *
+ * nothing defined, default used = "TLS13-AES128-GCM-SHA256"
+ #define WOLFSSL_ESP32_CIPHER_SUITE "ECDHE-ECDSA-SM4-CBC-SM3"
+ #define WOLFSSL_ESP32_CIPHER_SUITE "ECDHE-ECDSA-SM4-CBC-SM3:"
+ #define WOLFSSL_ESP32_CIPHER_SUITE "TLS13-AES128-GCM-SHA256"
+ #define WOLFSSL_ESP32_CIPHER_SUITE "TLS13-AES128-GCM-SHA256:"
+ #define WOLFSSL_ESP32_CIPHER_SUITE "TLS13-AES128-GCM-SHA256:DHE-PSK-AES128-GCM-SHA256"
+ #define WOLFSSL_ESP32_CIPHER_SUITE "TLS13-AES128-GCM-SHA256:PSK-AES128-GCM-SHA256:"
+ #define WOLFSSL_ESP32_CIPHER_SUITE "TLS13-CHACHA20-POLY1305-SHA256:TLS13-AES128-GCM-SHA256:TLS13-AES256-GCM-SHA384:"
+ #define WOLFSSL_ESP32_CIPHER_SUITE "TLS13-CHACHA20-POLY1305-SHA256"
+ #define WOLFSSL_ESP32_CIPHER_SUITE "TLS_CHACHA20_POLY1305_SHA256"
+ #define WOLFSSL_ESP32_CIPHER_SUITE "TLS_SM4_CCM_SM3"
+*/
+#endif
+
+    #undef  HAVE_ECC
+    #define HAVE_ECC
+
+    #undef  HAVE_SUPPORTED_CURVES
+    #define HAVE_SUPPORTED_CURVES
+
+/* Optionally include alternate HW test library: alt_hw_test.h */
+/* When enabling, the ./components/wolfssl/CMakeLists.txt file
+ * will need the name of the library in the idf_component_register
+ * for the PRIV_REQUIRES list. */
+/* #define INCLUDE_ALT_HW_TEST */
+
+/* #define NO_HW_MATH_TEST */
+
+
+/* when turning on ECC508 / ECC608 support
+#define WOLFSSL_ESPWROOM32SE
+#define HAVE_PK_CALLBACKS
+#define WOLFSSL_ATECC508A
+#define ATCA_WOLFSSL
+*/
+
+/* USE_FAST_MATH is default */
+#define USE_FAST_MATH
+
+/* use SP_MATH */
+/*
+#undef USE_FAST_MATH
+#define WOLFSSL_SP_MATH_ALL
+*/
+
+/* use integer heap math */
+/*
+#undef USE_FAST_MATH
+#define USE_INTEGER_HEAP_MATH
+*/
+
+/* optionally use DPORT_ACCESS_READ_BUFFER */
+/*
+#define USE_ESP_DPORT_ACCESS_READ_BUFFER
+*/

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/components/wolfssl/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/components/wolfssl/CMakeLists.txt
@@ -17,206 +17,437 @@
 #  along with this program; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 #
-# cmake for wolfssl
+# cmake for wolfssl Espressif projects
 #
-cmake_minimum_required(VERSION 3.5)
+# Version 5.6.3.001
+#
+# See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html
+#
+
+cmake_minimum_required(VERSION 3.16)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
 set(CMAKE_CURRENT_SOURCE_DIR ".")
+set(COMPONENT_REQUIRES lwip) # we typically don't need lwip directly in wolfssl component
 
-# We are currently in [root]/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl
+# COMPONENT_NAME = wolfssl
+# The component name is the directory name. "No feature to change this".
+# See https://github.com/espressif/esp-idf/issues/8978#issuecomment-1129892685
+
+# set the root of wolfSSL:
+#   set(WOLFSSL_ROOT  "C:/some path/with/spaces")
+#   set(WOLFSSL_ROOT  "c:/workspace/wolfssl-gojimmypi")
+#   set(WOLFSSL_ROOT  "/mnt/c/some path/with/spaces")
+#   or use this logic to assign value from Environment Variable WOLFSSL_ROOT,
+#   or assume this is an example 7 subdirectories below:
+
+# We are typically in [root]/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl
 # The root of wolfSSL is 7 directories up from here:
-get_filename_component(WOLFSSL_ROOT  "../../../../../../../" ABSOLUTE)
 
-# Espressif may take several passes through this makefile. Check to see if we found IDF
-string(COMPARE EQUAL "${PROJECT_SOURCE_DIR}" "" WOLFSSL_FOUND_IDF)
-
-if($WOLFSSL_FOUND_IDF)
-    message(STATUS "IDF_PATH = $ENV{IDF_PATH}")
-    message(STATUS "WOLFSSL_ROOT = ${WOLFSSL_ROOT}")
-    message(STATUS "PROJECT_SOURCE_DIR = ${PROJECT_SOURCE_DIR}")
-endif()
-
-# get a list of all wolfcrypt assembly files; we'll exclude them as they don't target Xtensa
-FILE(GLOB EXCLUDE_ASM *.S)
-file(GLOB_RECURSE EXCLUDE_ASM ${CMAKE_SOURCE_DIR} "${WOLFSSL_ROOT}/wolfcrypt/src/*.S")
-
-if(NOT CMAKE_BUILD_EARLY_EXPANSION)
-    message(STATUS "EXCLUDE_ASM = ${EXCLUDE_ASM}")
-endif()
-
-set(INCLUDE_PATH ${WOLFSSL_ROOT})
-
-set(COMPONENT_SRCDIRS "${WOLFSSL_ROOT}/src/"
-                        "${WOLFSSL_ROOT}/wolfcrypt/src/"
-                        "${WOLFSSL_ROOT}/wolfcrypt/src/port/Espressif/"
-                        "${WOLFSSL_ROOT}/wolfcrypt/src/port/atmel/"
-                        "${WOLFSSL_ROOT}/wolfcrypt/benchmark/"
-                        "${WOLFSSL_ROOT}/wolfcrypt/test/"
-                        )
-
-set(COMPONENT_REQUIRES lwip)
-
-
-# check to see if there's both a local copy and EDP-IDF copy of the wolfssl and/or wolfssh components
-if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/" AND EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
-    #
-    # wolfSSL found in both ESP-IDF and local project - needs to be resolved by user
-    #
-    message(STATUS "")
-    message(STATUS "**************************************************************************************")
-    message(STATUS "")
-    message(STATUS "Error: Found components/wolfssl in both local project and IDF_PATH")
-    message(STATUS "")
-    message(STATUS "To proceed: ")
-    message(STATUS "")
-    message(STATUS "Remove either the local project component: ${CMAKE_HOME_DIRECTORY}/components/wolfssl/ ")
-    message(STATUS "or the Espressif shared component installed at: $ENV{IDF_PATH}/components/wolfssl/ ")
-    message(STATUS "")
-    message(FATAL_ERROR "Please use wolfSSL in either local project or Espressif components, but not both.")
-    message(STATUS "")
-    message(STATUS "**************************************************************************************")
-    message(STATUS "")
-
-    # Optional: if you change the above FATAL_ERROR to STATUS you can warn at runtime with this macro definition:
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_MULTI_INSTALL_WARNING")
+if(CMAKE_BUILD_EARLY_EXPANSION)
+    message(STATUS "wolfssl component CMAKE_BUILD_EARLY_EXPANSION:")
+    idf_component_register(
+                            REQUIRES "${COMPONENT_REQUIRES}"
+                            PRIV_REQUIRES # esp_hw_support
+                                          esp_timer
+                                          driver # this will typically only be needed for wolfSSL benchmark
+                           )
 
 else()
-    if( EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
-        #
-        # wolfSSL found in ESP-IDF components and is assumed to be already configured in user_settings.h via setup.
-        #
-        message(STATUS "")
-        message(STATUS "Using components/wolfssl in IDF_PATH = $ENV{IDF_PATH}")
-        message(STATUS "")
-    else()
-        #
-        # wolfSSL is not an ESP-IDF component. We need to now determine if it is local and if so if it is part of the wolfSSL repo
-        # or if  wolfSSL is simply installed as a local component.
-        #
-        if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/" )
+    # not CMAKE_BUILD_EARLY_EXPANSION
+    message(STATUS "************************************************************************************************")
+    message(STATUS "wolfssl component config:")
+    message(STATUS "************************************************************************************************")
+
+    # TODO
+    if(WIN32)
+        # Windows-specific configuration here
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
+        message("Detected Windows")
+    endif()
+    if(CMAKE_HOST_UNIX)
+        message("Detected UNIX")
+    endif()
+    if(APPLE)
+        message("Detected APPLE")
+    endif()
+    if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
+        # Windows-specific configuration here
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
+        message("Detected WSL")
+    endif()
+    if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
+        # Windows-specific configuration here
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
+        message("Detected Linux")
+    endif()
+    if(APPLE)
+        # Windows-specific configuration here
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
+        message("Detected Apple")
+    endif()
+
+    # Check to see if we're already in wolfssl, and only if WOLFSSL_ROOT not specified
+    if ("${WOLFSSL_ROOT}" STREQUAL "")
+        # wolfssl examples are 7 directories deep from wolfssl repo root
+        #                        1  2  3  4  5  6  7
+        set(THIS_RELATIVE_PATH "../../../../../../..")
+        get_filename_component(THIS_SEARCH_PATH  "${THIS_RELATIVE_PATH}" ABSOLUTE)
+        message(STATUS "Searching in path = ${THIS_SEARCH_PATH}")
+
+        if (EXISTS "${THIS_SEARCH_PATH}/wolfcrypt/src")
+            # we're already in wolfssl examples!
+            get_filename_component(WOLFSSL_ROOT  "${THIS_SEARCH_PATH}" ABSOLUTE)
+            message(STATUS "Using wolfSSL example with root ${WOLFSSL_ROOT}")
+        else()
+            # We're in some other repo such as wolfssh, so we'll search for an
+            # adjacent-level directory for wolfssl. (8 directories up, then down one)
             #
-            # wolfSSL found in local project.
+            # For example wolfSSL examples:
+            #   C:\workspace\wolfssl-gojimmypi\IDE\Espressif\ESP-IDF\examples\wolfssl_benchmark\components\wolfssl
             #
-            if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/include/" )
-                message(STATUS "")
-                message(STATUS "Using installed project ./components/wolfssl in CMAKE_HOME_DIRECTORY = $ENV{CMAKE_HOME_DIRECTORY}")
-                message(STATUS "")
-                #
-                # Note we already checked above and confirmed there's not another wolfSSL installed in the ESP-IDF components.
-                #
-                # We won't do anything else here, as it will be assumed the original install completed successfully.
-                #
+            # For example wolfSSH examples:
+            #   C:\workspace\wolfssh-gojimmypi\ide\Espressif\ESP-IDF\examples\wolfssh_benchmark\components\wolfssl
+            #
+            #                        1  2  3  4  5  6  7  8
+            set(THIS_RELATIVE_PATH "../../../../../../../..")
+            get_filename_component(THIS_SEARCH_PATH  "${THIS_RELATIVE_PATH}" ABSOLUTE)
+            message(STATUS "Searching next in path = ${THIS_SEARCH_PATH}")
+        endif()
+    endif()
+
+    # search other possible locations
+    if ("${WOLFSSL_ROOT}" STREQUAL "")
+        # there's not a hard-coded WOLFSSL_ROOT value above, so let's see if we can find it.
+        if( "$ENV{WOLFSSL_ROOT}" STREQUAL "" )
+            message(STATUS "Environment Variable WOLFSSL_ROOT not set. Will search common locations.")
+
+            message(STATUS "CMAKE_CURRENT_SOURCE_DIR = ${CMAKE_CURRENT_SOURCE_DIR}")
+            get_filename_component(THIS_DIR "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
+            message(STATUS "THIS_DIR = ${THIS_DIR}")
+
+            # find the user name to search for possible "wolfssl-username"
+            message(STATUS "USERNAME = $ENV{USERNAME}")
+            if(  "$ENV{USER}" STREQUAL "" ) # the bash user
+                if(  "$ENV{USERNAME}" STREQUAL "" ) # the Windows user
+                    message(STATUS "could not find USER or USERNAME")
+                else()
+                    # the bash user is not blank, so we'll use it.
+                    set(THIS_USER "$ENV{USERNAME}")
+                endif()
             else()
-                #
-                # This is the developer repo mode. wolfSSL will be assume to be not installed to ESP-IDF nor local project
-                # In this configuration, we are likely running a wolfSSL example found directly in the repo.
-                #
-                message(STATUS "")
-                message(STATUS "Using developer repo ./components/wolfssl in CMAKE_HOME_DIRECTORY = $ENV{CMAKE_HOME_DIRECTORY}")
-                message(STATUS "")
+                # the bash user is not blank, so we'll use it.
+               set(THIS_USER "$ENV{USER}")
+            endif()
+            message(STATUS "THIS_USER = ${THIS_USER}")
 
-                message(STATUS "************************************************************************************************")
-                # When in developer mode, we are typically running wolfSSL examples such as benchmark or test directories.
-                # However, the as-cloned or distributed wolfSSL does not have the ./include/ directory, so we'll add it as needed.
-                #
-                # first check if there's a [root]/include/user_settings.h
-                if( EXISTS "${WOLFSSL_ROOT}/include/user_settings.h" )
-                    # we won't overwrite an existing user settings file, just note that we already have one:
-                    message(STATUS "Found wolfSSL user_settings.h in ${WOLFSSL_ROOT}/include/user_settings.h")
-                else()
-                    message(STATUS "Installing wolfSSL user_settings.h to ${WOLFSSL_ROOT}/include/user_settings.h")
-                    file(COPY "${WOLFSSL_ROOT}/IDE/Espressif/ESP-IDF/user_settings.h" DESTINATION "${WOLFSSL_ROOT}/include/")
-                endif() # user_settings.h
+            # This same makefile is used for both the wolfssl component, and other
+            # components that may depend on wolfssl, such as wolfssh. Therefore
+            # we need to determine if this makefile is in the wolfssl repo, or
+            # some other repo.
 
-                # next check if there's a [root]/include/config.h
-                if( EXISTS "${WOLFSSL_ROOT}/include/config.h" )
-                    message(STATUS "Found wolfSSL config.h in ${WOLFSSL_ROOT}/include/config.h")
+            if(  "{THIS_USER}" STREQUAL "" )
+                # This is highly unusual to not find a user name.
+                # In this case, we'll just search for a "wolfssl" directory:
+                message(STATUS "No username found!")
+                get_filename_component(WOLFSSL_ROOT  "${THIS_RELATIVE_PATH}/wolfssl" ABSOLUTE)
+            else()
+                # We found an environment USER name!
+                # The first place to look for wolfssl will be in a user-clone called "wolfssl-[username]"
+                message(STATUS "Using [THIS_USER = ${THIS_USER}] to see if there's a [relative path]/wolfssl-${THIS_USER} directory.")
+                get_filename_component(WOLFSSL_ROOT  "${THIS_RELATIVE_PATH}/wolfssl-${THIS_USER}" ABSOLUTE)
+
+                if( EXISTS "${WOLFSSL_ROOT}" )
+                    message(STATUS "Found wolfssl in user-suffix ${WOLFSSL_ROOT}")
                 else()
-                    message(STATUS "Installing wolfSSL config.h to ${WOLFSSL_ROOT}/include/config.h")
-                    file(COPY "${WOLFSSL_ROOT}/IDE/Espressif/ESP-IDF/dummy_config_h" DESTINATION "${WOLFSSL_ROOT}/include/")
-                    file(RENAME "${WOLFSSL_ROOT}/include/dummy_config_h" "${WOLFSSL_ROOT}/include/config.h")
-                endif() # config.h
-                message(STATUS "************************************************************************************************")
-                message(STATUS "")
+                    # If there's not a user-clone called "wolfssl-[username]",
+                    # perhaps there's simply a git clone called "wolfssl"?
+                    message(STATUS "Did not find wolfssl-${THIS_USER}; continuing search...")
+                    get_filename_component(WOLFSSL_ROOT  "${THIS_RELATIVE_PATH}/wolfssl" ABSOLUTE)
+
+                    if( EXISTS "${WOLFSSL_ROOT}" )
+                        message(STATUS "Found wolfssl in standard ${WOLFSSL_ROOT}")
+                    else()
+                        # Things are looking pretty bleak. We'll likely not be able to compile.
+                        message(STATUS "Did not find wolfssl in ${WOLFSSL_ROOT}")
+                    endif()
+                endif()
             endif()
 
         else()
-            # we did not find a ./components/wolfssl/include/ directory from this pass of cmake.
-            if($WOLFSSL_FOUND_IDF)
-                message(STATUS "")
-                message(STATUS "WARNING: wolfSSL not found.")
-                message(STATUS "")
+            # there's an environment variable, so use it.
+            set(WOLFSSL_ROOT "$ENV{WOLFSSL_ROOT}")
+
+            if( EXISTS "${WOLFSSL_ROOT}" )
+                get_filename_component(WOLFSSL_ROOT  "$ENV{WOLFSSL_ROOT}" ABSOLUTE)
+                message(STATUS "Found WOLFSSL_ROOT via Environment Variable:")
             else()
-                # probably needs to be re-parsed by Espressif
-                message(STATUS "wolfSSL found IDF. Project Source:${PROJECT_SOURCE_DIR}")
-            endif() # else we have not found ESP-IDF yet
-        endif() # else not a local wolfSSL component
+                message(FATAL_ERROR "WOLFSSL_ROOT Environment Variable defined, but path not found:")
+                message(STATUS "$ENV{WOLFSSL_ROOT}")
+            endif()
+        endif()
+        # end of search for wolfssl component root
+    else()
+        # There's already a value assigned; we won't search for anything else.
+        message(STATUS "Found user-specified WOLFSSL_ROOT value.")
+    endif() # WOLFSSL_ROOT user defined
 
-    endif() #else not an ESP-IDF component
-endif() # else not local copy and EDP-IDF wolfSSL
+    # After all the logic above, does our WOLFSSL_ROOT actually exist?
+    if( EXISTS "${WOLFSSL_ROOT}" )
+        message(STATUS "WOLFSSL_ROOT = ${WOLFSSL_ROOT}")
+    else()
+        # Abort. We need wolfssl _somewhere_.
+        message(FATAL_ERROR "Could not find wolfssl in ${WOLFSSL_ROOT}. Try setting environment variable or git clone.")
+    endif()
 
 
-# RTOS_IDF_PATH is typically:
-# "/Users/{username}/Desktop/esp-idf/components/freertos/include/freertos"
-# depending on the environment, we may need to swap backslashes with forward slashes
-string(REPLACE "\\" "/" RTOS_IDF_PATH "$ENV{IDF_PATH}/components/freertos/include/freertos")
+    set(INCLUDE_PATH ${WOLFSSL_ROOT})
 
-# ESP-IDF after version 4.4x has a different RTOS directory structure
-string(REPLACE "\\" "/" RTOS_IDF_PATH5 "$ENV{IDF_PATH}/components/freertos/FreeRTOS-Kernel/include/freertos")
+    set(COMPONENT_SRCDIRS "\"${WOLFSSL_ROOT}/src/\""
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/src\""
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/src/port/Espressif\""
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/src/port/atmel\""
+                          # TODO: Make this a univeral makefile that detects if bechmark / test needed
+                          # Sometimes problematic with SM; consider gating detection.
+                          #"\"${WOLFSSL_ROOT}/wolfcrypt/benchmark\"" # the benchmark application
+                          #"\"${WOLFSSL_ROOT}/wolfcrypt/test\"" # the test application
+       ) # COMPONENT_SRCDIRS
+    message(STATUS "This COMPONENT_SRCDIRS = ${COMPONENT_SRCDIRS}")
 
-if(IS_DIRECTORY ${IDF_PATH}/components/freertos/FreeRTOS-Kernel/)
+    set(WOLFSSL_PROJECT_DIR "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
+    add_definitions(-DWOLFSSL_USER_SETTINGS_DIR="${WOLFSSL_PROJECT_DIR}/include/user_settings.h")
+
+
+    # Espressif may take several passes through this makefile. Check to see if we found IDF
+    string(COMPARE EQUAL "${PROJECT_SOURCE_DIR}" "" WOLFSSL_FOUND_IDF)
+
+    # get a list of all wolfcrypt assembly files; we'll exclude them as they don't target Xtensa
+    file(GLOB EXCLUDE_ASM *.S)
+    file(GLOB_RECURSE EXCLUDE_ASM ${CMAKE_SOURCE_DIR} "${WOLFSSL_ROOT}/wolfcrypt/src/*.S")
+
+    message(STATUS "IDF_PATH = $ENV{IDF_PATH}")
+    message(STATUS "PROJECT_SOURCE_DIR = ${PROJECT_SOURCE_DIR}")
+    message(STATUS "EXCLUDE_ASM = ${EXCLUDE_ASM}")
+
+    #
+    # Check to see if there's both a local copy and EDP-IDF copy of the wolfssl and/or wolfssh components.
+    #
+    if( EXISTS "${WOLFSSL_PROJECT_DIR}" AND EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
+        #
+        # wolfSSL found in both ESP-IDF and local project - needs to be resolved by user
+        #
+        message(STATUS "")
+        message(STATUS "**************************************************************************************")
+        message(STATUS "")
+        message(STATUS "Error: Found components/wolfssl in both local project and IDF_PATH")
+        message(STATUS "")
+        message(STATUS "To proceed: ")
+        message(STATUS "")
+        message(STATUS "Remove either the local project component: ${WOLFSSL_PROJECT_DIR} ")
+        message(STATUS "or the Espressif shared component installed at: $ENV{IDF_PATH}/components/wolfssl/ ")
+        message(STATUS "")
+        message(FATAL_ERROR "Please use wolfSSL in either local project or Espressif components, but not both.")
+        message(STATUS "")
+        message(STATUS "**************************************************************************************")
+        message(STATUS "")
+
+        # Optional: if you change the above FATAL_ERROR to STATUS you can warn at runtime with this macro definition:
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_MULTI_INSTALL_WARNING")
+
+    else()
+        if( EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
+            #
+            # wolfSSL found in ESP-IDF components and is assumed to be already configured in user_settings.h via setup.
+            #
+            message(STATUS "")
+            message(STATUS "Using components/wolfssl in IDF_PATH = $ENV{IDF_PATH}")
+            message(STATUS "")
+        else()
+            #
+            # wolfSSL is not an ESP-IDF component.
+            # We need to now determine if it is local and if so if it is part of the wolfSSL repo,
+            # or if  wolfSSL is simply installed as a local component.
+            #
+
+            if( EXISTS "${WOLFSSL_PROJECT_DIR}" )
+                #
+                # wolfSSL found in local project.
+                #
+                if( EXISTS "${WOLFSSL_PROJECT_DIR}/wolfcrypt/" )
+                    message(STATUS "")
+                    message(STATUS "Using installed project ./components/wolfssl in CMAKE_HOME_DIRECTORY = ${CMAKE_HOME_DIRECTORY}")
+                    message(STATUS "")
+                    #
+                    # Note we already checked above and confirmed there's not another wolfSSL installed in the ESP-IDF components.
+                    #
+                    # We won't do anything else here, as it will be assumed the original install completed successfully.
+                    #
+                else() # full wolfSSL not installed in local project
+                    #
+                    # This is the developer repo mode. wolfSSL will be assumed to be not installed to ESP-IDF nor local project
+                    # In this configuration, we are likely running a wolfSSL example found directly in the repo.
+                    #
+                    message(STATUS "")
+                    message(STATUS "Using developer repo ./components/wolfssl in CMAKE_HOME_DIRECTORY = ${CMAKE_HOME_DIRECTORY}")
+                    message(STATUS "")
+
+                    message(STATUS "************************************************************************************************")
+                    # When in developer mode, we are typically running wolfSSL examples such as benchmark or test directories.
+                    # However, the as-cloned or distributed wolfSSL does not have the ./include/ directory, so we'll add it as needed.
+                    #
+                    # first check if there's a [root]/include/user_settings.h
+                    if( EXISTS "${WOLFSSL_ROOT}/include/user_settings.h" )
+                        message(FATAL_ERROR "Found stray wolfSSL user_settings.h in "
+                                            "${WOLFSSL_ROOT}/include/user_settings.h "
+                                            " (please move it to ${WOLFSSL_PROJECT_DIR}/include/user_settings.h )")
+                    else()
+                        # we won't overwrite an existing user settings file, just note that we already have one:
+                        if( EXISTS "${WOLFSSL_PROJECT_DIR}/include/user_settings.h" )
+                            message(STATUS "Using existing wolfSSL user_settings.h in "
+                                           "${WOLFSSL_PROJECT_DIR}/include/user_settings.h")
+                        else()
+                            message(STATUS "Installing wolfSSL user_settings.h to "
+                                           "${WOLFSSL_PROJECT_DIR}/include/user_settings.h")
+                            file(COPY "${WOLFSSL_ROOT}/IDE/Espressif/ESP-IDF/user_settings.h"
+                            DESTINATION "${CMAKE_HOME_DIRECTORY}/wolfssl/include/")
+                        endif()
+                    endif() # user_settings.h
+
+                    # next check if there's a [root]/include/config.h
+                    if( EXISTS "${WOLFSSL_ROOT}/include/config.h" )
+                        message(FATAL_ERROR "Found stray wolfSSL config.h in "
+                                            "${WOLFSSL_ROOT}/include/config.h "
+                                            " (please move it to ${WOLFSSL_PROJECT_DIR}/include/config.h )")
+                    else()
+                        # we won't overwrite an existing user settings file, just note that we already have one:
+                        if( EXISTS "${WOLFSSL_PROJECT_DIR}/include/config.h" )
+                            message(STATUS "Using existing wolfSSL config.h           ${WOLFSSL_PROJECT_DIR}/include/config.h")
+                        else()
+                            message(STATUS "Installing wolfSSL config.h to            ${WOLFSSL_PROJECT_DIR}/include/config.h")
+                            file(COPY   "${WOLFSSL_ROOT}/IDE/Espressif/ESP-IDF/dummy_config_h" DESTINATION "${WOLFSSL_PROJECT_DIR}/include/")
+                            file(RENAME "${WOLFSSL_PROJECT_DIR}/include/dummy_config_h" "${WOLFSSL_PROJECT_DIR}/include/config.h")
+                        endif() # Project config.h
+                    endif() # WOLFSSL_ROOT config.h
+                    message(STATUS "************************************************************************************************")
+                    message(STATUS "")
+                endif()
+
+            else()
+                # we did not find a ./components/wolfssl/include/ directory from this pass of cmake.
+                if($WOLFSSL_FOUND_IDF)
+                    message(STATUS "")
+                    message(STATUS "WARNING: wolfSSL not found.")
+                    message(STATUS "")
+                else()
+                    # probably needs to be re-parsed by Espressif
+                    message(STATUS "wolfSSL found IDF. Project Source:${PROJECT_SOURCE_DIR}")
+                endif() # else we have not found ESP-IDF yet
+            endif() # else not a local wolfSSL component
+
+        endif() #else not an ESP-IDF component
+    endif() # else not local copy and EDP-IDF wolfSSL
+
+
+    # RTOS_IDF_PATH is typically:
+    # "/Users/{username}/Desktop/esp-idf/components/freertos/include/freertos"
+    # depending on the environment, we may need to swap backslashes with forward slashes
+    string(REPLACE "\\" "/" RTOS_IDF_PATH "$ENV{IDF_PATH}/components/freertos/FreeRTOS-Kernel/include/freertos")
+
+    string(REPLACE "\\" "/" WOLFSSL_ROOT ${WOLFSSL_ROOT})
+
+    if(IS_DIRECTORY "${RTOS_IDF_PATH}")
+        message(STATUS "Found current RTOS path: ${RTOS_IDF_PATH}")
+    else()
+        # ESP-IDF prior version 4.4x has a different RTOS directory structure
+        string(REPLACE "\\" "/" RTOS_IDF_PATH "$ENV{IDF_PATH}/components/freertos/include/freertos")
+        if(IS_DIRECTORY "${RTOS_IDF_PATH}")
+            message(STATUS "Found legacy RTOS path: ${RTOS_IDF_PATH}")
+        else()
+            message(STATUS "Could not find RTOS path")
+        endif()
+    endif()
+
+
     set(COMPONENT_ADD_INCLUDEDIRS
-        "."
-       "${WOLFSSL_ROOT}/include"
-       "${RTOS_IDF_PATH5}"
-       "${WOLFSSL_ROOT}"
-       )
-else()
+        "./include" # this is the location of wolfssl user_settings.h
+        "\"${WOLFSSL_ROOT}/\""
+        "\"${WOLFSSL_ROOT}/wolfssl/\""
+        "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/\""
+        "\"${RTOS_IDF_PATH}/\""
+        )
 
-   set(COMPONENT_ADD_INCLUDEDIRS
-       "."
-       "${WOLFSSL_ROOT}/include"
-       "${RTOS_IDF_PATH}"
-       "${WOLFSSL_ROOT}"
-      )
-endif()
 
-if(IS_DIRECTORY ${IDF_PATH}/components/cryptoauthlib)
-    list(APPEND COMPONENT_ADD_INCLUDEDIRS "../cryptoauthlib/lib")
-endif()
+    if(IS_DIRECTORY ${IDF_PATH}/components/cryptoauthlib)
+        list(APPEND COMPONENT_ADD_INCLUDEDIRS "../cryptoauthlib/lib")
+    endif()
 
-set(COMPONENT_SRCEXCLUDE
-    "${WOLFSSL_ROOT}/src/bio.c"
-    "${WOLFSSL_ROOT}/src/conf.c"
-    "${WOLFSSL_ROOT}/src/misc.c"
-    "${WOLFSSL_ROOT}/src/pk.c"
-    "${WOLFSSL_ROOT}/src/ssl_misc.c" # included by ssl.c
-    "${WOLFSSL_ROOT}/src/x509.c"
-    "${WOLFSSL_ROOT}/src/x509_str.c"
-    "${WOLFSSL_ROOT}/wolfcrypt/src/evp.c"
-    "${WOLFSSL_ROOT}/wolfcrypt/src/misc.c"
-    "${EXCLUDE_ASM}"
-    )
+    list(APPEND COMPONENT_ADD_INCLUDEDIRS "\"${WOLFSSL_ROOT}/wolfssl/\"")
+    list(APPEND COMPONENT_ADD_INCLUDEDIRS "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/\"")
 
-register_component()
 
-# some optional diagnostics
-if (0)
-    get_cmake_property(_variableNames VARIABLES)
-    list (SORT _variableNames)
-    message(STATUS "")
-    message(STATUS "ALL VARIABLES BEGIN")
-    message(STATUS "")
-    foreach (_variableName ${_variableNames})
-        message(STATUS "${_variableName}=${${_variableName}}")
-    endforeach()
-    message(STATUS "")
-    message(STATUS "ALL VARIABLES END")
-    message(STATUS "")
-endif()
+
+    set(COMPONENT_SRCEXCLUDE
+        "\"${WOLFSSL_ROOT}/src/bio.c\""
+        "\"${WOLFSSL_ROOT}/src/conf.c\""
+        "\"${WOLFSSL_ROOT}/src/misc.c\""
+        "\"${WOLFSSL_ROOT}/src/pk.c\""
+        "\"${WOLFSSL_ROOT}/src/ssl_asn1.c\""    # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/ssl_bn.c\""      # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/ssl_certman.c\"" # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/ssl_misc.c\""    # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/x509.c\""
+        "\"${WOLFSSL_ROOT}/src/x509_str.c\""
+        "\"${WOLFSSL_ROOT}/wolfcrypt/src/evp.c\""
+        "\"${WOLFSSL_ROOT}/wolfcrypt/src/misc.c\""
+        "\"${EXCLUDE_ASM}\""
+        )
+
+    spaces2list(COMPONENT_REQUIRES)
+
+    separate_arguments(COMPONENT_SRCDIRS NATIVE_COMMAND "${COMPONENT_SRCDIRS}")
+    separate_arguments(COMPONENT_SRCEXCLUDE NATIVE_COMMAND "${COMPONENT_SRCEXCLUDE}")
+    separate_arguments(COMPONENT_ADD_INCLUDEDIRS NATIVE_COMMAND "${COMPONENT_ADD_INCLUDEDIRS}")
+
+    #
+    # See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#example-component-requirements
+    #
+    message(STATUS "COMPONENT_SRCDIRS = ${COMPONENT_SRCDIRS}")
+    message(STATUS "COMPONENT_ADD_INCLUDEDIRS = ${COMPONENT_ADD_INCLUDEDIRS}")
+    message(STATUS "COMPONENT_REQUIRES = ${COMPONENT_REQUIRES}")
+    message(STATUS "COMPONENT_SRCEXCLUDE = ${COMPONENT_SRCEXCLUDE}")
+
+    #
+    # see https://docs.espressif.com/projects/esp-idf/en/stable/esp32/migration-guides/release-5.x/build-system.html?highlight=space%20path
+    #
+    set(EXTRA_COMPONENT_DIRS "${COMPONENT_SRCDIRS}")
+    idf_component_register(
+                            SRC_DIRS "${COMPONENT_SRCDIRS}"
+                            INCLUDE_DIRS "${COMPONENT_ADD_INCLUDEDIRS}"
+                            REQUIRES "${COMPONENT_REQUIRES}"
+                            EXCLUDE_SRCS "${COMPONENT_SRCEXCLUDE}"
+                            PRIV_REQUIRES esp_timer driver # this will typically only be needed for wolfSSL benchmark
+                           )
+    # some optional diagnostics
+    if (1)
+        get_cmake_property(_variableNames VARIABLES)
+        list (SORT _variableNames)
+        message(STATUS "")
+        message(STATUS "ALL VARIABLES BEGIN")
+        message(STATUS "")
+        foreach (_variableName ${_variableNames})
+            message(STATUS "${_variableName}=${${_variableName}}")
+        endforeach()
+        message(STATUS "")
+        message(STATUS "ALL VARIABLES END")
+        message(STATUS "")
+    endif()
+
+    # target_sources(wolfssl PRIVATE  "\"${WOLFSSL_ROOT}/wolfssl/\""  "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt\"")
+endif() # CMAKE_BUILD_EARLY_EXPANSION
+
+
 
 # check to see if there's both a local copy and EDP-IDF copy of the wolfssl components
-if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/" AND EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
+if( EXISTS "${WOLFSSL_PROJECT_DIR}" AND EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
     message(STATUS "")
     message(STATUS "")
     message(STATUS "********************************************************************")
@@ -227,3 +458,69 @@ endif()
 # end multiple component check
 
 
+#
+# LIBWOLFSSL_SAVE_INFO(VAR_OUPUT THIS_VAR VAR_RESULT)
+#
+# Save the THIS_VAR as a string in a macro called VAR_OUPUT
+#
+# VAR_OUPUT:  the name of the macro to define
+# THIS_VAR:   the OUTPUT_VARIABLE result from a execute_process()
+# VAR_RESULT: the RESULT_VARIABLE from a execute_process(); "0" if successful.
+#
+function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
+    # is the RESULT_VARIABLE output value 0? If so, IS_VALID_VALUE is true.
+    string(COMPARE EQUAL "${VAR_RESULT}" "0" IS_VALID_VALUE)
+
+    # if we had a successful operation, save the THIS_VAR in VAR_OUPUT
+    if(${IS_VALID_VALUE})
+        # strip newline chars in THIS_VAR parameter and save in VAR_VALUE
+        string(REPLACE "\n" ""  VAR_VALUE  ${THIS_VAR})
+
+        # we'll could percolate the value to the parent for possible later use
+        # set(${VAR_OUPUT} ${VAR_VALUE} PARENT_SCOPE)
+
+        # but we're only using it here in this function
+        set(${VAR_OUPUT} ${VAR_VALUE})
+
+        # we'll print what we found to the console
+        message(STATUS "Found ${VAR_OUPUT}=${VAR_VALUE}")
+
+        # the interesting part is defining the VAR_OUPUT name a value to use in the app
+        add_definitions(-D${VAR_OUPUT}=\"${VAR_VALUE}\")
+    else()
+        # if we get here, check the execute_process command and parameters.
+        message(STATUS "LIBWOLFSSL_SAVE_INFO encountered a non-zero VAR_RESULT")
+        set(${VAR_OUPUT} "Unknown")
+    endif()
+endfunction() # LIBWOLFSSL_SAVE_INFO
+
+# create some programmatic #define values that will be used by ShowExtendedSystemInfo().
+# see wolfcrypt\src\port\Espressif\esp32_utl.c
+if(NOT CMAKE_BUILD_EARLY_EXPANSION)
+    set (git_cmd "git")
+    message(STATUS "Adding macro definitions:")
+
+    # LIBWOLFSSL_VERSION_GIT_ORIGIN: git config --get remote.origin.url
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "config" "--get" "remote.origin.url" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_ORIGIN "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_BRANCH: git rev-parse --abbrev-ref HEAD
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "--abbrev-ref" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_BRANCH "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_HASH: git rev-parse HEAD
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_SHORT_HASH: git rev-parse --short HEAD
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "--short" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_SHORT_HASH "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_HASH_DATE git show --no-patch --no-notes --pretty=\'\%cd\'
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "show" "--no-patch" "--no-notes" "--pretty=\'\%cd\'" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES  )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH_DATE "${TMP_OUT}" "${TMP_RES}")
+
+    message(STATUS "************************************************************************************************")
+    message(STATUS "wolfssl component config complete!")
+    message(STATUS "************************************************************************************************")
+endif()

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/components/wolfssl/include/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/components/wolfssl/include/user_settings.h
@@ -1,0 +1,380 @@
+/* user_settings.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* This is the user_settings.h file for the wolfssl_server TLS example.
+ * For application-specific settings, please see server-tls.h file */
+
+#include <sdkconfig.h> /* essential to chip set detection */
+
+/* optional timezone used when setting time */
+#define TIME_ZONE "PST+8PDT,M3.2.0,M11.1.0"
+
+/* #define SHOW_SSID_AND_PASSWORD */ /* remove this to not show in startup log */
+
+#undef WOLFSSL_ESPIDF
+#undef WOLFSSL_ESP32
+#undef WOLFSSL_ESPWROOM32SE
+#undef WOLFSSL_ESP32
+#undef WOLFSSL_ESP8266
+
+/* The Espressif sdkconfig will have chipset info.
+**
+** Possible values:
+**
+**   CONFIG_IDF_TARGET_ESP32
+**   CONFIG_IDF_TARGET_ESP32S2
+**   CONFIG_IDF_TARGET_ESP32S3
+**   CONFIG_IDF_TARGET_ESP32C3
+**   CONFIG_IDF_TARGET_ESP32C6
+*/
+
+#define WOLFSSL_ESPIDF
+
+/*
+ * choose ONE of these Espressif chips to define:
+ *
+ * WOLFSSL_ESP32
+ * WOLFSSL_ESPWROOM32SE
+ * WOLFSSL_ESP8266
+ */
+
+#define WOLFSSL_ESP32
+
+#if defined(CONFIG_IDF_TARGET_ESP32)
+    /* HW Enabled by default for ESP32. To disable: */
+    /* #define NO_ESP32_CRYPT                 */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_HASH    */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_AES     */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI */
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)
+    /* HW Disabled by default for ESP32-S2.   */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+    /* HW Enabled by default for ESP32. To disable: */
+    /* #define NO_ESP32_CRYPT                 */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_HASH    */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_AES     */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI */
+#elif defined(CONFIG_IDF_TARGET_ESP32C2)
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+    /* HW Disabled by default for ESP32-C3.   */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#elif defined(CONFIG_IDF_TARGET_ESP32C6)
+    /* HW Disabled by default for ESP32-C6.   */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#elif defined(CONFIG_IDF_TARGET_ESP32H2)
+    /* HW Disabled by default for ESP32-H2.   */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#else
+    /* HW Disabled by default for all other ESP32-[?].  */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#endif
+
+
+/* optionally turn off SHA512/224 SHA512/256 */
+/* #define WOLFSSL_NOSHA512_224 */
+/* #define WOLFSSL_NOSHA512_256 */
+
+#define BENCH_EMBEDDED
+
+/* TLS 1.3                                 */
+#define WOLFSSL_TLS13
+#define HAVE_TLS_EXTENSIONS
+#define WC_RSA_PSS
+#define HAVE_HKDF
+#define HAVE_AEAD
+#define HAVE_SUPPORTED_CURVES
+
+#define WOLFSSL_BENCHMARK_FIXED_UNITS_KB
+
+/* when you want to use SINGLE THREAD */
+/* #define SINGLE_THREADED */
+#define NO_FILESYSTEM
+
+#define HAVE_AESGCM
+
+#define WOLFSSL_RIPEMD
+/* when you want to use SHA224 */
+/* #define WOLFSSL_SHA224      */
+
+#define NO_OLD_TLS
+
+/* when you want to use SHA384 */
+/* #define WOLFSSL_SHA384 */
+
+/* #define WOLFSSL_SHA3 */
+
+#define WOLFSSL_SHA512
+#define HAVE_ECC
+#define HAVE_CURVE25519
+#define CURVE25519_SMALL
+#define HAVE_ED25519
+
+/* when you want to use pkcs7 */
+/* #define HAVE_PKCS7 */
+
+#if defined(HAVE_PKCS7)
+    #define HAVE_AES_KEYWRAP
+    #define HAVE_X963_KDF
+    #define WOLFSSL_AES_DIRECT
+#endif
+
+/* optional DH */
+/* #define PROJECT_DH */
+#ifdef PROJECT_DH
+    #define HAVE_DH
+    #define HAVE_FFDHE_2048
+#endif
+
+/* when you want to use aes counter mode */
+/* #define WOLFSSL_AES_DIRECT */
+/* #define WOLFSSL_AES_COUNTER */
+
+/* esp32-wroom-32se specific definition */
+#if defined(WOLFSSL_ESPWROOM32SE)
+    #define WOLFSSL_ATECC508A
+    #define HAVE_PK_CALLBACKS
+    /* when you want to use a custom slot allocation for ATECC608A */
+    /* unless your configuration is unusual, you can use default   */
+    /* implementation.                                             */
+    /* #define CUSTOM_SLOT_ALLOCATION                              */
+#endif
+
+/* RSA primitive specific definition */
+#if defined(WOLFSSL_ESP32) || defined(WOLFSSL_ESPWROOM32SE)
+    /* Define USE_FAST_MATH and SMALL_STACK                        */
+    #define ESP32_USE_RSA_PRIMITIVE
+    /* threshold for performance adjustment for HW primitive use   */
+    /* X bits of G^X mod P greater than                            */
+    #define EPS_RSA_EXPT_XBTIS           36
+    /* X and Y of X * Y mod P greater than                         */
+    #define ESP_RSA_MULM_BITS            36
+#endif
+#define RSA_LOW_MEM
+
+/* debug options */
+/* #define DEBUG_WOLFSSL */
+/* #define WOLFSSL_ESP32_CRYPT_DEBUG */
+/* #define WOLFSSL_ESP32_HW_LOCK_DEBUG */
+/* #define WOLFSSL_ATECC508A_DEBUG          */
+
+/* date/time                               */
+/* if it cannot adjust time in the device, */
+/* enable macro below                      */
+/* #define NO_ASN_TIME */
+/* #define XTIME time */
+
+/* adjust wait-timeout count if you see timeout in RSA HW acceleration */
+#define ESP_RSA_TIMEOUT_CNT    0x249F00
+
+/* see esp_ShowExtendedSystemInfo in esp32-crypt.h for startup log info */
+#define HAVE_VERSION_EXTENDED_INFO
+
+
+/* debug options */
+/* #define ESP_VERIFY_MEMBLOCK              */
+#define WOLFSSL_HW_METRICS
+/* #define DEBUG_WOLFSSL_VERBOSE            */
+/* #define DEBUG_WOLFSSL                    */
+/* #define WOLFSSL_ESP32_CRYPT_DEBUG        */
+#define NO_RECOVER_SOFTWARE_CALC
+
+/* optionally turn off individual math HW acceleration features */
+
+/* Turn off Large Number Multiplication:
+** [Z = X * Y] in esp_mp_mul()                                  */
+/* #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_MP_MUL         */
+
+/* Turn off Large Number Modular Exponentiation:
+** [Z = X^Y mod M] in esp_mp_exptmod()                          */
+/* #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_EXPTMOD        */
+
+/* Turn off Large Number Modular Multiplication
+** [Z = X × Y mod M] in esp_mp_mulmod()                         */
+/* #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_MULMOD         */
+
+
+/* this is known to fail in TFM: */
+/* #define HONOR_MATH_USED_LENGTH */
+
+/* this is known to fail in TFM */
+/* #define CHECK_MP_READ_UNSIGNED_BIN */
+
+#define WOLFSSL_PUBLIC_MP /* used by benchmark */
+
+/* optional SM4 Ciphers. See https://github.com/wolfSSL/wolfsm */
+/* Uncomment this section to enable SM
+#define WOLFSSL_SM2
+#define WOLFSSL_SM3
+#define WOLFSSL_SM4
+*/
+
+#if defined(WOLFSSL_SM2) || defined(WOLFSSL_SM3) || defined(WOLFSSL_SM4)
+    /* see https://github.com/wolfSSL/wolfssl/pull/6537
+     *
+     * see settings.h for other features turned on with SM4 ciphers.
+     */
+    #undef  USE_CERT_BUFFERS_1024
+    #define USE_CERT_BUFFERS_1024
+
+    #undef  WOLFSSL_SM4_ECB
+    #define WOLFSSL_SM4_ECB
+
+    #undef  WOLFSSL_SM4_CBC
+    #define WOLFSSL_SM4_CBC
+
+    #undef  WOLFSSL_SM4_CTR
+    #define WOLFSSL_SM4_CTR
+
+    #undef  WOLFSSL_SM4_GCM
+    #define WOLFSSL_SM4_GCM
+
+    #undef  WOLFSSL_SM4_CCM
+    #define WOLFSSL_SM4_CCM
+
+    #define HAVE_POLY1305
+    #define HAVE_CHACHA
+
+    #undef  HAVE_AESGCM
+    #define HAVE_AESGCM
+
+    #undef  HAVE_ECC
+    #define HAVE_ECC
+
+    /* see https://github.com/wolfSSL/wolfssl/pull/6825 */
+    #include <wolfssl/certs_test_sm.h>
+
+    #define CTX_CA_CERT          root_sm2
+    #define CTX_CA_CERT_SIZE     sizeof_root_sm2
+    #define CTX_CA_CERT_TYPE     WOLFSSL_FILETYPE_PEM
+    #define CTX_SERVER_CERT      server_sm2
+    #define CTX_SERVER_CERT_SIZE sizeof_server_sm2
+    #define CTX_SERVER_CERT_TYPE WOLFSSL_FILETYPE_PEM
+    #define CTX_SERVER_KEY       server_sm2_priv
+    #define CTX_SERVER_KEY_SIZE  sizeof_server_sm2_priv
+    #define CTX_SERVER_KEY_TYPE  WOLFSSL_FILETYPE_PEM
+/*
+ * SM optional cipher suite settings:
+ *
+    #define WOLFSSL_ESP32_CIPHER_SUITE "TLS13-SM4-GCM-SM3"
+    #define WOLFSSL_ESP32_CIPHER_SUITE "TLS13-SM4-CCM-SM3"
+    #define WOLFSSL_ESP32_CIPHER_SUITE "ECDHE-ECDSA-SM4-CBC-SM3"
+    #define WOLFSSL_ESP32_CIPHER_SUITE "ECDHE-ECDSA-SM4-GCM-SM3"
+    #define WOLFSSL_ESP32_CIPHER_SUITE "ECDHE-ECDSA-SM4-CCM-SM3"
+*/
+    #define WOLFSSL_ESP32_CIPHER_SUITE "TLS13-SM4-GCM-SM3:" \
+                                       "TLS13-SM4-CCM-SM3:" \
+                                       "TLS-SM4-GCM-SM3:" /* not a valid command-line cipher */ \
+                                       "TLS-SM4-CCM-SM3:" /* not a valid command-line cipher */ \
+                                       "ECDHE-ECDSA-SM4-CBC-SM3:" \
+                                       "ECDHE-ECDSA-SM4-GCM-SM3:" \
+                                       "ECDHE-ECDSA-SM4-CCM-SM3"
+
+#else
+    /* default settings */
+    #define USE_CERT_BUFFERS_2048
+    #define USE_CERT_BUFFERS_256
+    #define CTX_CA_CERT          ca_cert_der_2048
+    #define CTX_CA_CERT_SIZE     sizeof_ca_cert_der_2048
+    #define CTX_CA_CERT_TYPE     WOLFSSL_FILETYPE_ASN1
+    #define CTX_SERVER_CERT      server_cert_der_2048
+    #define CTX_SERVER_CERT_SIZE sizeof_server_cert_der_2048
+    #define CTX_SERVER_CERT_TYPE WOLFSSL_FILETYPE_ASN1
+    #define CTX_SERVER_KEY       server_key_der_2048
+    #define CTX_SERVER_KEY_SIZE  sizeof_server_key_der_2048
+    #define CTX_SERVER_KEY_TYPE  WOLFSSL_FILETYPE_ASN1
+/*
+ * Optional Cipher Suite Specification
+ *
+ * nothing defined, default used = "TLS13-AES128-GCM-SHA256"
+ #define WOLFSSL_ESP32_CIPHER_SUITE "ECDHE-ECDSA-SM4-CBC-SM3"
+ #define WOLFSSL_ESP32_CIPHER_SUITE "ECDHE-ECDSA-SM4-CBC-SM3:"
+ #define WOLFSSL_ESP32_CIPHER_SUITE "TLS13-AES128-GCM-SHA256"
+ #define WOLFSSL_ESP32_CIPHER_SUITE "TLS13-AES128-GCM-SHA256:"
+ #define WOLFSSL_ESP32_CIPHER_SUITE "TLS13-AES128-GCM-SHA256:DHE-PSK-AES128-GCM-SHA256"
+ #define WOLFSSL_ESP32_CIPHER_SUITE "TLS13-AES128-GCM-SHA256:PSK-AES128-GCM-SHA256:"
+ #define WOLFSSL_ESP32_CIPHER_SUITE "TLS13-CHACHA20-POLY1305-SHA256:TLS13-AES128-GCM-SHA256:TLS13-AES256-GCM-SHA384:"
+ #define WOLFSSL_ESP32_CIPHER_SUITE "TLS13-CHACHA20-POLY1305-SHA256"
+ #define WOLFSSL_ESP32_CIPHER_SUITE "TLS_CHACHA20_POLY1305_SHA256"
+ #define WOLFSSL_ESP32_CIPHER_SUITE "TLS_SM4_CCM_SM3"
+*/
+#endif
+
+    #undef  HAVE_ECC
+    #define HAVE_ECC
+
+    #undef  HAVE_SUPPORTED_CURVES
+    #define HAVE_SUPPORTED_CURVES
+
+/* Optionally include alternate HW test library: alt_hw_test.h */
+/* When enabling, the ./components/wolfssl/CMakeLists.txt file
+ * will need the name of the library in the idf_component_register
+ * for the PRIV_REQUIRES list. */
+/* #define INCLUDE_ALT_HW_TEST */
+
+/* #define NO_HW_MATH_TEST */
+
+
+/* when turning on ECC508 / ECC608 support
+#define WOLFSSL_ESPWROOM32SE
+#define HAVE_PK_CALLBACKS
+#define WOLFSSL_ATECC508A
+#define ATCA_WOLFSSL
+*/
+
+/* USE_FAST_MATH is default */
+#define USE_FAST_MATH
+
+/* use SP_MATH */
+/*
+#undef USE_FAST_MATH
+#define WOLFSSL_SP_MATH_ALL
+*/
+
+/* use integer heap math */
+/*
+#undef USE_FAST_MATH
+#define USE_INTEGER_HEAP_MATH
+*/
+
+/* optionally use DPORT_ACCESS_READ_BUFFER */
+/*
+#define USE_ESP_DPORT_ACCESS_READ_BUFFER
+*/

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl/CMakeLists.txt
@@ -17,208 +17,526 @@
 #  along with this program; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 #
-# cmake for wolfssl
+# cmake for wolfssl Espressif projects
 #
-cmake_minimum_required(VERSION 3.5)
+# Version 5.6.0.009 for FIND_WOLFSSL_DIRECTORY
+#
+# See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html
+#
+
+cmake_minimum_required(VERSION 3.16)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
 set(CMAKE_CURRENT_SOURCE_DIR ".")
+set(COMPONENT_REQUIRES lwip) # we typically don't need lwip directly in wolfssl component
+set(WOLFSSL_ROOT "$ENV{WOLFSSL_ROOT}" )
 
-# We are currently in [root]/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl
+# find the user name to search for possible "wolfssl-username"
+message(STATUS "USERNAME = $ENV{USERNAME}")
+if(  "$ENV{USER}" STREQUAL "" ) # the bash user
+    if(  "$ENV{USERNAME}" STREQUAL "" ) # the Windows user
+        message(STATUS "could not find USER or USERNAME")
+    else()
+        # the bash user is not blank, so we'll use it.
+        set(THIS_USER "$ENV{USERNAME}")
+    endif()
+else()
+    # the bash user is not blank, so we'll use it.
+    set(THIS_USER "$ENV{USER}")
+endif()
+message(STATUS "THIS_USER = ${THIS_USER}")
+
+
+# COMPONENT_NAME = wolfssl
+# The component name is the directory name. "No feature to change this".
+# See https://github.com/espressif/esp-idf/issues/8978#issuecomment-1129892685
+
+# set the root of wolfSSL:
+#   set(WOLFSSL_ROOT  "C:/some path/with/spaces")
+#   set(WOLFSSL_ROOT  "c:/workspace/wolfssl-gojimmypi")
+#   set(WOLFSSL_ROOT  "/mnt/c/some path/with/spaces")
+#   or use this logic to assign value from Environment Variable WOLFSSL_ROOT,
+#   or assume this is an example 7 subdirectories below:
+
+# We are typically in [root]/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl
 # The root of wolfSSL is 7 directories up from here:
-get_filename_component(WOLFSSL_ROOT  "../../../../../../../" ABSOLUTE)
 
-# Espressif may take several passes through this makefile. Check to see if we found IDF
-string(COMPARE EQUAL "${PROJECT_SOURCE_DIR}" "" WOLFSSL_FOUND_IDF)
+# function: IS_WOLFSSL_SOURCE
+#  parameter: DIRECTORY_PARAMETER - the directory to test
+#  output:    RESULT = contains contents of DIRECTORY_PARAMETER for wolfssl directory, otherwise blank.
+function(IS_WOLFSSL_SOURCE DIRECTORY_PARAMETER RESULT)
+    if (EXISTS "${DIRECTORY_PARAMETER}/wolfcrypt/src")
+        set(${RESULT} "${DIRECTORY_PARAMETER}" PARENT_SCOPE)
+    else()
+        set(${RESULT} "" PARENT_SCOPE)
+    endif()
+endfunction()
 
-if($WOLFSSL_FOUND_IDF)
-    message(STATUS "IDF_PATH = $ENV{IDF_PATH}")
-    message(STATUS "WOLFSSL_ROOT = ${WOLFSSL_ROOT}")
-    message(STATUS "PROJECT_SOURCE_DIR = ${PROJECT_SOURCE_DIR}")
-endif()
+# function: FIND_WOLFSSL_DIRECTORY
+#  parameter: OUTPUT_FOUND_WOLFSSL_DIRECTORY contains root of source code, otherwise blank
+#
+function(FIND_WOLFSSL_DIRECTORY OUTPUT_FOUND_WOLFSSL_DIRECTORY)
+    message(STATUS "Starting FIND_WOLFSSL_DIRECTORY")
+    set(CURRENT_SEARCH_DIR "$ENV{WOLFSSL_ROOT}")
+    if( "${CURRENT_SEARCH_DIR}" STREQUAL "" )
+        message(STATUS "The WOLFSSL_ROOT environment variable is not set. Searching...")
+    else()
+        get_filename_component(CURRENT_SEARCH_DIR "$ENV{WOLFSSL_ROOT}" ABSOLUTE)
+        IS_WOLFSSL_SOURCE("${CURRENT_SEARCH_DIR}" FOUND_WOLFSSL)
+        if("${FOUND_WOLFSSL}")
+            message(STATUS "Found WOLFSSL_ROOT via Environment Variable:")
+        else()
+            message(FATAL_ERROR "WOLFSSL_ROOT Environment Variable defined, but path not found:")
+            message(STATUS "$ENV{WOLFSSL_ROOT}")
+        endif()
+    endif()
 
-# get a list of all wolfcrypt assembly files; we'll exclude them as they don't target Xtensa
-FILE(GLOB EXCLUDE_ASM *.S)
-file(GLOB_RECURSE EXCLUDE_ASM ${CMAKE_SOURCE_DIR} "${WOLFSSL_ROOT}/wolfcrypt/src/*.S")
+    # we'll start in the CMAKE_CURRENT_SOURCE_DIR, typically [something]/projectname/components/wolfssl
+    message(STATUS "CMAKE_CURRENT_SOURCE_DIR = ${CMAKE_CURRENT_SOURCE_DIR}")
+    get_filename_component(CURRENT_SEARCH_DIR "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
+    message(STATUS "CURRENT_SEARCH_DIR = ${CURRENT_SEARCH_DIR}")
+    string(LENGTH ${CURRENT_SEARCH_DIR} CURRENT_SEARCH_DIR_LENGTH)
 
-if(NOT CMAKE_BUILD_EARLY_EXPANSION)
-    message(STATUS "EXCLUDE_ASM = ${EXCLUDE_ASM}")
-endif()
+    # loop through all the parents, looking for wolfssl
+    while(NOT CURRENT_SEARCH_DIR STREQUAL "/" AND NOT CURRENT_SEARCH_DIR STREQUAL "" )
+        string(LENGTH ${CURRENT_SEARCH_DIR} CURRENT_SEARCH_DIR_LENGTH)
+        # wolfSSL may simply be in a parent directory, such as for local examples in wolfssl repo
+        IS_WOLFSSL_SOURCE("${CURRENT_SEARCH_DIR}" FOUND_WOLFSSL)
+        if( FOUND_WOLFSSL )
+            message(STATUS "Found wolfssl in CURRENT_SEARCH_DIR = ${CURRENT_SEARCH_DIR}")
+            set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} ${CURRENT_SEARCH_DIR} PARENT_SCOPE)
+            return()
+        endif()
 
-set(INCLUDE_PATH ${WOLFSSL_ROOT})
+        if( THIS_USER )
+            # Check for "wolfssl-[username]" subdirectory as we recurse up the directory tree
+            set(CURRENT_SEARCH_DIR_ALT ${CURRENT_SEARCH_DIR}/wolfssl-${THIS_USER})
+            message(STATUS "Looking in ${CURRENT_SEARCH_DIR}")
 
-set(COMPONENT_SRCDIRS "${WOLFSSL_ROOT}/src/"
-                        "${WOLFSSL_ROOT}/wolfcrypt/src/"
-                        "${WOLFSSL_ROOT}/wolfcrypt/src/port/Espressif/"
-                        "${WOLFSSL_ROOT}/wolfcrypt/src/port/atmel/"
-                        "${WOLFSSL_ROOT}/wolfcrypt/test/"
-                        )
+            #if(EXISTS ${CURRENT_SEARCH_DIR_ALT} AND IS_DIRECTORY ${CURRENT_SEARCH_DIR_ALT} AND EXISTS "${CURRENT_SEARCH_DIR_ALT}/wolfcrypt/src")
+            IS_WOLFSSL_SOURCE("${CURRENT_SEARCH_DIR_ALT}" FOUND_WOLFSSL )
+            if ( FOUND_WOLFSSL )
+               message(STATUS "Found wolfssl in user-suffix CURRENT_SEARCH_DIR_ALT = ${CURRENT_SEARCH_DIR_ALT}")
+                set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} ${CURRENT_SEARCH_DIR_ALT} PARENT_SCOPE)
+                return()
+            endif()
+        endif()
 
-set(COMPONENT_REQUIRES lwip)
+        # Next check for no user suffix "wolfssl" subdirectory as we recurse up the directory tree
+        set(CURRENT_SEARCH_DIR_ALT ${CURRENT_SEARCH_DIR}/wolfssl)
+        # if(EXISTS ${CURRENT_SEARCH_DIR} AND IS_DIRECTORY ${CURRENT_SEARCH_DIR} AND EXISTS "${CURRENT_SEARCH_DIR}/wolfcrypt/src")
+        IS_WOLFSSL_SOURCE("${CURRENT_SEARCH_DIR_ALT}" FOUND_WOLFSSL )
+        if ( FOUND_WOLFSSL )
+            message(STATUS "Found wolfssl in CURRENT_SEARCH_DIR = ${CURRENT_SEARCH_DIR}")
+            set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} ${CURRENT_SEARCH_DIR} PARENT_SCOPE)
+            return()
+        endif()
+
+        # Move up one directory level
+        set(PRIOR_SEARCH_DIR "${CURRENT_SEARCH_DIR}")
+        get_filename_component(CURRENT_SEARCH_DIR "${CURRENT_SEARCH_DIR}" DIRECTORY)
+        message(STATUS "Next CURRENT_SEARCH_DIR = ${CURRENT_SEARCH_DIR}")
+        if( "${PRIOR_SEARCH_DIR}" STREQUAL "${CURRENT_SEARCH_DIR}" )
+            # when the search directory is empty, we'll give up
+            set(CURRENT_SEARCH_DIR "")
+        endif()
+    endwhile()
+
+    # If not found, set the output variable to empty before exiting
+    set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} "" PARENT_SCOPE)
+endfunction()
 
 
-# check to see if there's both a local copy and EDP-IDF copy of the wolfssl and/or wolfssh components
-if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/" AND EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
-    #
-    # wolfSSL found in both ESP-IDF and local project - needs to be resolved by user
-    #
-    message(STATUS "")
-    message(STATUS "**************************************************************************************")
-    message(STATUS "")
-    message(STATUS "Error: Found components/wolfssl in both local project and IDF_PATH")
-    message(STATUS "")
-    message(STATUS "To proceed: ")
-    message(STATUS "")
-    message(STATUS "Remove either the local project component: ${CMAKE_HOME_DIRECTORY}/components/wolfssl/ ")
-    message(STATUS "or the Espressif shared component installed at: $ENV{IDF_PATH}/components/wolfssl/ ")
-    message(STATUS "")
-    message(FATAL_ERROR "Please use wolfSSL in either local project or Espressif components, but not both.")
-    message(STATUS "")
-    message(STATUS "**************************************************************************************")
-    message(STATUS "")
+# Example usage:
 
-    # Optional: if you change the above FATAL_ERROR to STATUS you can warn at runtime with this macro definition:
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_MULTI_INSTALL_WARNING")
+
+
+
+if(CMAKE_BUILD_EARLY_EXPANSION)
+    message(STATUS "wolfssl component CMAKE_BUILD_EARLY_EXPANSION:")
+    idf_component_register(
+                            REQUIRES "${COMPONENT_REQUIRES}"
+                            PRIV_REQUIRES # esp_hw_support
+                                          esp_timer
+                                          driver # this will typically only be needed for wolfSSL benchmark
+                           )
 
 else()
-    if( EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
-        #
-        # wolfSSL found in ESP-IDF components and is assumed to be already configured in user_settings.h via setup.
-        #
-        message(STATUS "")
-        message(STATUS "Using components/wolfssl in IDF_PATH = $ENV{IDF_PATH}")
-        message(STATUS "")
+    # not CMAKE_BUILD_EARLY_EXPANSION
+    message(STATUS "************************************************************************************************")
+    message(STATUS "wolfssl component config:")
+    message(STATUS "************************************************************************************************")
+
+    # search for wolfSSL
+    FIND_WOLFSSL_DIRECTORY(WOLFSSL_ROOT)
+    if(WOLFSSL_ROOT)
+        message(STATUS "NEW Found wolfssl directory at: ${WOLFSSL_ROOT}")
     else()
-        #
-        # wolfSSL is not an ESP-IDF component. We need to now determine if it is local and if so if it is part of the wolfSSL repo
-        # or if  wolfSSL is simply installed as a local component.
-        #
-        if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/" )
+        message(STATUS "NEW wolfssl directory not found.")
+        # Abort. We need wolfssl _somewhere_.
+        message(FATAL_ERROR "Could not find wolfssl in ${WOLFSSL_ROOT}.\n"
+                            "Try setting WOLFSSL_ROOT environment variable or git clone.")
+    endif()
+
+if( 0 )
+    # Check to see if we're already in wolfssl, and only if WOLFSSL_ROOT not specified
+    if ("${WOLFSSL_ROOT}" STREQUAL "")
+        # wolfssl examples are 7 directories deep from wolfssl repo root
+        #                        1  2  3  4  5  6  7
+        set(THIS_RELATIVE_PATH "../../../../../../..")
+        get_filename_component(THIS_SEARCH_PATH  "${THIS_RELATIVE_PATH}" ABSOLUTE)
+        message(STATUS "Searching in path = ${THIS_SEARCH_PATH}")
+
+        if (EXISTS "${THIS_SEARCH_PATH}/wolfcrypt/src")
+            # we're already in wolfssl examples!
+            get_filename_component(WOLFSSL_ROOT  "${THIS_SEARCH_PATH}" ABSOLUTE)
+            message(STATUS "Using wolfSSL example with root ${WOLFSSL_ROOT}")
+        else()
+            # We're in some other repo such as wolfssh, so we'll search for an
+            # adjacent-level directory for wolfssl. (8 directories up, then down one)
             #
-            # wolfSSL found in local project.
+            # For example wolfSSL examples:
+            #   C:\workspace\wolfssl-gojimmypi\IDE\Espressif\ESP-IDF\examples\wolfssl_benchmark\components\wolfssl
             #
-            if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/include/" )
-                message(STATUS "")
-                message(STATUS "Using installed project ./components/wolfssl in CMAKE_HOME_DIRECTORY = $ENV{CMAKE_HOME_DIRECTORY}")
-                message(STATUS "")
-                #
-                # Note we already checked above and confirmed there's not another wolfSSL installed in the ESP-IDF components.
-                #
-                # We won't do anything else here, as it will be assumed the original install completed successfully.
-                #
+            # For example wolfSSH examples:
+            #   C:\workspace\wolfssh-gojimmypi\ide\Espressif\ESP-IDF\examples\wolfssh_benchmark\components\wolfssl
+            #
+            #                        1  2  3  4  5  6  7  8
+            set(THIS_RELATIVE_PATH "../../../../../../../..")
+            get_filename_component(THIS_SEARCH_PATH  "${THIS_RELATIVE_PATH}" ABSOLUTE)
+            message(STATUS "Searching next in path = ${THIS_SEARCH_PATH}")
+        endif()
+    endif()
+
+    # search other possible locations
+    if ("${WOLFSSL_ROOT}" STREQUAL "")
+        # there's not a hard-coded WOLFSSL_ROOT value above, so let's see if we can find it.
+        if( "$ENV{WOLFSSL_ROOT}" STREQUAL "" )
+            message(STATUS "Environment Variable WOLFSSL_ROOT not set. Will search common locations.")
+
+            message(STATUS "CMAKE_CURRENT_SOURCE_DIR = ${CMAKE_CURRENT_SOURCE_DIR}")
+            get_filename_component(THIS_DIR "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
+            message(STATUS "THIS_DIR = ${THIS_DIR}")
+
+            # find the user name to search for possible "wolfssl-username"
+            message(STATUS "USERNAME = $ENV{USERNAME}")
+            if(  "$ENV{USER}" STREQUAL "" ) # the bash user
+                if(  "$ENV{USERNAME}" STREQUAL "" ) # the Windows user
+                    message(STATUS "could not find USER or USERNAME")
+                else()
+                    # the bash user is not blank, so we'll use it.
+                    set(THIS_USER "$ENV{USERNAME}")
+                endif()
             else()
-                #
-                # This is the developer repo mode. wolfSSL will be assume to be not installed to ESP-IDF nor local project
-                # In this configuration, we are likely running a wolfSSL example found directly in the repo.
-                #
-                message(STATUS "")
-                message(STATUS "Using developer repo ./components/wolfssl in CMAKE_HOME_DIRECTORY = $ENV{CMAKE_HOME_DIRECTORY}")
-                message(STATUS "")
+                # the bash user is not blank, so we'll use it.
+               set(THIS_USER "$ENV{USER}")
+            endif()
+            message(STATUS "THIS_USER = ${THIS_USER}")
 
-                message(STATUS "************************************************************************************************")
-                # When in developer mode, we are typically running wolfSSL examples such as benchmark or test directories.
-                # However, the as-cloned or distributed wolfSSL does not have the ./include/ directory, so we'll add it as needed.
-                #
-                # first check if there's a [root]/include/user_settings.h
-                if( EXISTS "${WOLFSSL_ROOT}/include/user_settings.h" )
-                    # we won't overwrite an existing user settings file, just note that we already have one:
-                    message(STATUS "Found wolfSSL user_settings.h in ${WOLFSSL_ROOT}/include/user_settings.h")
-                else()
-                    message(STATUS "Installing wolfSSL user_settings.h to ${WOLFSSL_ROOT}/include/user_settings.h")
-                    file(COPY "${WOLFSSL_ROOT}/IDE/Espressif/ESP-IDF/user_settings.h" DESTINATION "${WOLFSSL_ROOT}/include/")
-                endif() # user_settings.h
+            # This same makefile is used for both the wolfssl component, and other
+            # components that may depend on wolfssl, such as wolfssh. Therefore
+            # we need to determine if this makefile is in the wolfssl repo, or
+            # some other repo.
 
-                # next check if there's a [root]/include/config.h
-                if( EXISTS "${WOLFSSL_ROOT}/include/config.h" )
-                    message(STATUS "Found wolfSSL config.h in ${WOLFSSL_ROOT}/include/config.h")
+            if(  "{THIS_USER}" STREQUAL "" )
+                # This is highly unusual to not find a user name.
+                # In this case, we'll just search for a "wolfssl" directory:
+                message(STATUS "No username found!")
+                get_filename_component(WOLFSSL_ROOT  "${THIS_RELATIVE_PATH}/wolfssl" ABSOLUTE)
+            else()
+                # We found an environment USER name!
+                # The first place to look for wolfssl will be in a user-clone called "wolfssl-[username]"
+                message(STATUS "Using [THIS_USER = ${THIS_USER}] to see if there's a [relative path]/wolfssl-${THIS_USER} directory.")
+                get_filename_component(WOLFSSL_ROOT  "${THIS_RELATIVE_PATH}/wolfssl-${THIS_USER}" ABSOLUTE)
+
+                if( EXISTS "${WOLFSSL_ROOT}" )
+                    message(STATUS "Found wolfssl in user-suffix ${WOLFSSL_ROOT}")
                 else()
-                    message(STATUS "Installing wolfSSL config.h to ${WOLFSSL_ROOT}/include/config.h")
-                    file(COPY "${WOLFSSL_ROOT}/IDE/Espressif/ESP-IDF/dummy_config_h" DESTINATION "${WOLFSSL_ROOT}/include/")
-                    file(RENAME "${WOLFSSL_ROOT}/include/dummy_config_h" "${WOLFSSL_ROOT}/include/config.h")
-                endif() # config.h
-                message(STATUS "************************************************************************************************")
-                message(STATUS "")
+                    # If there's not a user-clone called "wolfssl-[username]",
+                    # perhaps there's simply a git clone called "wolfssl"?
+                    message(STATUS "Did not find wolfssl-${THIS_USER}; continuing search...")
+                    get_filename_component(WOLFSSL_ROOT  "${THIS_RELATIVE_PATH}/wolfssl" ABSOLUTE)
+
+                    if( EXISTS "${WOLFSSL_ROOT}" )
+                        message(STATUS "Found wolfssl in standard ${WOLFSSL_ROOT}")
+                    else()
+                        # Things are looking pretty bleak. We'll likely not be able to compile.
+                        message(STATUS "Did not find wolfssl in ${WOLFSSL_ROOT}")
+                    endif()
+                endif()
             endif()
 
         else()
-            # we did not find a ./components/wolfssl/include/ directory from this pass of cmake.
-            if($WOLFSSL_FOUND_IDF)
-                message(STATUS "")
-                message(STATUS "WARNING: wolfSSL not found.")
-                message(STATUS "")
+            # there's an environment variable, so use it.
+            set(WOLFSSL_ROOT "$ENV{WOLFSSL_ROOT}")
+
+            if( EXISTS "${WOLFSSL_ROOT}" )
+                get_filename_component(WOLFSSL_ROOT  "$ENV{WOLFSSL_ROOT}" ABSOLUTE)
+                message(STATUS "Found WOLFSSL_ROOT via Environment Variable:")
             else()
-                # probably needs to be re-parsed by Espressif
-                message(STATUS "wolfSSL found IDF. Project Source:${PROJECT_SOURCE_DIR}")
-            endif() # else we have not found ESP-IDF yet
-        endif() # else not a local wolfSSL component
+                message(FATAL_ERROR "WOLFSSL_ROOT Environment Variable defined, but path not found:")
+                message(STATUS "$ENV{WOLFSSL_ROOT}")
+            endif()
+        endif()
+        # end of search for wolfssl component root
+    else()
+        # There's already a value assigned; we won't search for anything else.
+        message(STATUS "Found user-specified WOLFSSL_ROOT value.")
+    endif() # WOLFSSL_ROOT user defined
 
-    endif() #else not an ESP-IDF component
-endif() # else not local copy and EDP-IDF wolfSSL
+    # After all the logic above, does our WOLFSSL_ROOT actually exist?
+    if( EXISTS "${WOLFSSL_ROOT}" )
+        message(STATUS "WOLFSSL_ROOT = ${WOLFSSL_ROOT}")
+    else()
+        # Abort. We need wolfssl _somewhere_.
+        message(FATAL_ERROR "Could not find wolfssl in ${WOLFSSL_ROOT}. Try setting environment variable or git clone.")
+    endif()
+endif()
 
 
-# RTOS_IDF_PATH is typically:
-# "/Users/{username}/Desktop/esp-idf/components/freertos/include/freertos"
-# depending on the environment, we may need to swap backslashes with forward slashes
-string(REPLACE "\\" "/" RTOS_IDF_PATH "$ENV{IDF_PATH}/components/freertos/include/freertos")
 
-# ESP-IDF after version 4.4x has a different RTOS directory structure
-string(REPLACE "\\" "/" RTOS_IDF_PATH5 "$ENV{IDF_PATH}/components/freertos/FreeRTOS-Kernel/include/freertos")
 
-if(IS_DIRECTORY ${IDF_PATH}/components/freertos/FreeRTOS-Kernel/)
+    set(INCLUDE_PATH ${WOLFSSL_ROOT})
+
+    set(COMPONENT_SRCDIRS "\"${WOLFSSL_ROOT}/src/\""
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/src\""
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/src/port/Espressif\""
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/src/port/atmel\""
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/benchmark\"" # the benchmark application
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/test\"" # the test application
+       ) # COMPONENT_SRCDIRS
+    message(STATUS "This COMPONENT_SRCDIRS = ${COMPONENT_SRCDIRS}")
+
+    set(WOLFSSL_PROJECT_DIR "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
+
+    # Espressif may take several passes through this makefile. Check to see if we found IDF
+    string(COMPARE EQUAL "${PROJECT_SOURCE_DIR}" "" WOLFSSL_FOUND_IDF)
+
+    # get a list of all wolfcrypt assembly files; we'll exclude them as they don't target Xtensa
+    file(GLOB EXCLUDE_ASM *.S)
+    file(GLOB_RECURSE EXCLUDE_ASM ${CMAKE_SOURCE_DIR} "${WOLFSSL_ROOT}/wolfcrypt/src/*.S")
+
+    message(STATUS "IDF_PATH = $ENV{IDF_PATH}")
+    message(STATUS "PROJECT_SOURCE_DIR = ${PROJECT_SOURCE_DIR}")
+    message(STATUS "EXCLUDE_ASM = ${EXCLUDE_ASM}")
+
+    #
+    # Check to see if there's both a local copy and EDP-IDF copy of the wolfssl and/or wolfssh components.
+    #
+    if( EXISTS "${WOLFSSL_PROJECT_DIR}" AND EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
+        #
+        # wolfSSL found in both ESP-IDF and local project - needs to be resolved by user
+        #
+        message(STATUS "")
+        message(STATUS "**************************************************************************************")
+        message(STATUS "")
+        message(STATUS "Error: Found components/wolfssl in both local project and IDF_PATH")
+        message(STATUS "")
+        message(STATUS "To proceed: ")
+        message(STATUS "")
+        message(STATUS "Remove either the local project component: ${WOLFSSL_PROJECT_DIR} ")
+        message(STATUS "or the Espressif shared component installed at: $ENV{IDF_PATH}/components/wolfssl/ ")
+        message(STATUS "")
+        message(FATAL_ERROR "Please use wolfSSL in either local project or Espressif components, but not both.")
+        message(STATUS "")
+        message(STATUS "**************************************************************************************")
+        message(STATUS "")
+
+        # Optional: if you change the above FATAL_ERROR to STATUS you can warn at runtime with this macro definition:
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_MULTI_INSTALL_WARNING")
+
+    else()
+        if( EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
+            #
+            # wolfSSL found in ESP-IDF components and is assumed to be already configured in user_settings.h via setup.
+            #
+            message(STATUS "")
+            message(STATUS "Using components/wolfssl in IDF_PATH = $ENV{IDF_PATH}")
+            message(STATUS "")
+        else()
+            #
+            # wolfSSL is not an ESP-IDF component.
+            # We need to now determine if it is local and if so if it is part of the wolfSSL repo,
+            # or if  wolfSSL is simply installed as a local component.
+            #
+
+            if( EXISTS "${WOLFSSL_PROJECT_DIR}" )
+                #
+                # wolfSSL found in local project.
+                #
+                if( EXISTS "${WOLFSSL_PROJECT_DIR}/wolfcrypt/" )
+                    message(STATUS "")
+                    message(STATUS "Using installed project ./components/wolfssl in CMAKE_HOME_DIRECTORY = ${CMAKE_HOME_DIRECTORY}")
+                    message(STATUS "")
+                    #
+                    # Note we already checked above and confirmed there's not another wolfSSL installed in the ESP-IDF components.
+                    #
+                    # We won't do anything else here, as it will be assumed the original install completed successfully.
+                    #
+                else() # full wolfSSL not installed in local project
+                    #
+                    # This is the developer repo mode. wolfSSL will be assumed to be not installed to ESP-IDF nor local project
+                    # In this configuration, we are likely running a wolfSSL example found directly in the repo.
+                    #
+                    message(STATUS "")
+                    message(STATUS "Using developer repo ./components/wolfssl in CMAKE_HOME_DIRECTORY = ${CMAKE_HOME_DIRECTORY}")
+                    message(STATUS "")
+
+                    message(STATUS "************************************************************************************************")
+                    # When in developer mode, we are typically running wolfSSL examples such as benchmark or test directories.
+                    # However, the as-cloned or distributed wolfSSL does not have the ./include/ directory, so we'll add it as needed.
+                    #
+                    # first check if there's a [root]/include/user_settings.h
+                    if( EXISTS "${WOLFSSL_ROOT}/include/user_settings.h" )
+                        message(FATAL_ERROR "Found stray wolfSSL user_settings.h in "
+                                            "${WOLFSSL_ROOT}/include/user_settings.h "
+                                            " (please move it to ${WOLFSSL_PROJECT_DIR}/include/user_settings.h )")
+                    else()
+                        # we won't overwrite an existing user settings file, just note that we already have one:
+                        if( EXISTS "${WOLFSSL_PROJECT_DIR}/include/user_settings.h" )
+                            message(STATUS "Using existing wolfSSL user_settings.h in "
+                                           "${WOLFSSL_PROJECT_DIR}/include/user_settings.h")
+                        else()
+                            message(STATUS "Installing wolfSSL user_settings.h to "
+                                           "${WOLFSSL_PROJECT_DIR}/include/user_settings.h")
+                            file(COPY "${WOLFSSL_ROOT}/IDE/Espressif/ESP-IDF/user_settings.h"
+                            DESTINATION "${CMAKE_HOME_DIRECTORY}/wolfssl/include/")
+                        endif()
+                    endif() # user_settings.h
+
+                    # next check if there's a [root]/include/config.h
+                    if( EXISTS "${WOLFSSL_ROOT}/include/config.h" )
+                        message(FATAL_ERROR "Found stray wolfSSL config.h in        ${WOLFSSL_ROOT}/include/config.h (please move it to ${WOLFSSL_PROJECT_DIR}/include/config.h")
+                    else()
+                        # we won't overwrite an existing user settings file, just note that we already have one:
+                        if( EXISTS "${WOLFSSL_PROJECT_DIR}/include/config.h" )
+                            message(STATUS "Using existing wolfSSL config.h           ${WOLFSSL_PROJECT_DIR}/include/config.h")
+                        else()
+                            message(STATUS "Installing wolfSSL config.h to            ${WOLFSSL_PROJECT_DIR}/include/config.h")
+                            file(COPY   "${WOLFSSL_ROOT}/IDE/Espressif/ESP-IDF/dummy_config_h" DESTINATION "${WOLFSSL_PROJECT_DIR}/include/")
+                            file(RENAME "${WOLFSSL_PROJECT_DIR}/include/dummy_config_h" "${WOLFSSL_PROJECT_DIR}/include/config.h")
+                        endif() # Project config.h
+                    endif() # WOLFSSL_ROOT config.h
+                    message(STATUS "************************************************************************************************")
+                    message(STATUS "")
+                endif()
+
+            else()
+                # we did not find a ./components/wolfssl/include/ directory from this pass of cmake.
+                if($WOLFSSL_FOUND_IDF)
+                    message(STATUS "")
+                    message(STATUS "WARNING: wolfSSL not found.")
+                    message(STATUS "")
+                else()
+                    # probably needs to be re-parsed by Espressif
+                    message(STATUS "wolfSSL found IDF. Project Source:${PROJECT_SOURCE_DIR}")
+                endif() # else we have not found ESP-IDF yet
+            endif() # else not a local wolfSSL component
+
+        endif() #else not an ESP-IDF component
+    endif() # else not local copy and EDP-IDF wolfSSL
+
+
+    # RTOS_IDF_PATH is typically:
+    # "/Users/{username}/Desktop/esp-idf/components/freertos/include/freertos"
+    # depending on the environment, we may need to swap backslashes with forward slashes
+    string(REPLACE "\\" "/" RTOS_IDF_PATH "$ENV{IDF_PATH}/components/freertos/FreeRTOS-Kernel/include/freertos")
+
+    string(REPLACE "\\" "/" WOLFSSL_ROOT ${WOLFSSL_ROOT})
+
+    if(IS_DIRECTORY "${RTOS_IDF_PATH}")
+        message(STATUS "Found current RTOS path: ${RTOS_IDF_PATH}")
+    else()
+        # ESP-IDF prior version 4.4x has a different RTOS directory structure
+        string(REPLACE "\\" "/" RTOS_IDF_PATH "$ENV{IDF_PATH}/components/freertos/include/freertos")
+        if(IS_DIRECTORY "${RTOS_IDF_PATH}")
+            message(STATUS "Found legacy RTOS path: ${RTOS_IDF_PATH}")
+        else()
+            message(STATUS "Could not find RTOS path")
+        endif()
+    endif()
+
+
     set(COMPONENT_ADD_INCLUDEDIRS
-        "."
-       "${WOLFSSL_ROOT}/include"
-       "${RTOS_IDF_PATH5}"
-       "${WOLFSSL_ROOT}"
-       )
-else()
+        "./include" # this is the location of wolfssl user_settings.h
+        "\"${WOLFSSL_ROOT}/\""
+        "\"${WOLFSSL_ROOT}/wolfssl/\""
+        "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/\""
+        "\"${RTOS_IDF_PATH}/\""
+        )
 
-   set(COMPONENT_ADD_INCLUDEDIRS
-       "."
-       "${WOLFSSL_ROOT}/include"
-       "${RTOS_IDF_PATH}"
-       "${WOLFSSL_ROOT}"
-      )
-endif()
 
-if(IS_DIRECTORY ${IDF_PATH}/components/cryptoauthlib)
-    list(APPEND COMPONENT_ADD_INCLUDEDIRS "../cryptoauthlib/lib")
-endif()
+    if(IS_DIRECTORY ${IDF_PATH}/components/cryptoauthlib)
+        list(APPEND COMPONENT_ADD_INCLUDEDIRS "../cryptoauthlib/lib")
+    endif()
 
-set(COMPONENT_SRCEXCLUDE
-    "${WOLFSSL_ROOT}/src/bio.c"
-    "${WOLFSSL_ROOT}/src/conf.c"
-    "${WOLFSSL_ROOT}/src/misc.c"
-    "${WOLFSSL_ROOT}/src/pk.c"
-    "${WOLFSSL_ROOT}/src/ssl_asn1.c"    # included by ssl.c
-    "${WOLFSSL_ROOT}/src/ssl_bn.c"      # included by ssl.c
-    "${WOLFSSL_ROOT}/src/ssl_certman.c" # included by ssl.c
-    "${WOLFSSL_ROOT}/src/ssl_misc.c"    # included by ssl.c
-    "${WOLFSSL_ROOT}/src/x509.c"
-    "${WOLFSSL_ROOT}/src/x509_str.c"
-    "${WOLFSSL_ROOT}/wolfcrypt/src/evp.c"
-    "${WOLFSSL_ROOT}/wolfcrypt/src/misc.c"
-    "${EXCLUDE_ASM}"
-    )
+    list(APPEND COMPONENT_ADD_INCLUDEDIRS "\"${WOLFSSL_ROOT}/wolfssl/\"")
+    list(APPEND COMPONENT_ADD_INCLUDEDIRS "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/\"")
 
-register_component()
 
-# some optional diagnostics
-if (0)
-    get_cmake_property(_variableNames VARIABLES)
-    list (SORT _variableNames)
-    message(STATUS "")
-    message(STATUS "ALL VARIABLES BEGIN")
-    message(STATUS "")
-    foreach (_variableName ${_variableNames})
-        message(STATUS "${_variableName}=${${_variableName}}")
-    endforeach()
-    message(STATUS "")
-    message(STATUS "ALL VARIABLES END")
-    message(STATUS "")
-endif()
+
+    set(COMPONENT_SRCEXCLUDE
+        "\"${WOLFSSL_ROOT}/src/bio.c\""
+        "\"${WOLFSSL_ROOT}/src/conf.c\""
+        "\"${WOLFSSL_ROOT}/src/misc.c\""
+        "\"${WOLFSSL_ROOT}/src/pk.c\""
+        "\"${WOLFSSL_ROOT}/src/ssl_asn1.c\""    # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/ssl_bn.c\""      # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/ssl_certman.c\"" # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/ssl_misc.c\""    # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/x509.c\""
+        "\"${WOLFSSL_ROOT}/src/x509_str.c\""
+        "\"${WOLFSSL_ROOT}/wolfcrypt/src/evp.c\""
+        "\"${WOLFSSL_ROOT}/wolfcrypt/src/misc.c\""
+        "\"${EXCLUDE_ASM}\""
+        )
+
+    spaces2list(COMPONENT_REQUIRES)
+
+    separate_arguments(COMPONENT_SRCDIRS NATIVE_COMMAND "${COMPONENT_SRCDIRS}")
+    separate_arguments(COMPONENT_SRCEXCLUDE NATIVE_COMMAND "${COMPONENT_SRCEXCLUDE}")
+    separate_arguments(COMPONENT_ADD_INCLUDEDIRS NATIVE_COMMAND "${COMPONENT_ADD_INCLUDEDIRS}")
+
+    #
+    # See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#example-component-requirements
+    #
+    message(STATUS "COMPONENT_SRCDIRS = ${COMPONENT_SRCDIRS}")
+    message(STATUS "COMPONENT_ADD_INCLUDEDIRS = ${COMPONENT_ADD_INCLUDEDIRS}")
+    message(STATUS "COMPONENT_REQUIRES = ${COMPONENT_REQUIRES}")
+    message(STATUS "COMPONENT_SRCEXCLUDE = ${COMPONENT_SRCEXCLUDE}")
+
+    #
+    # see https://docs.espressif.com/projects/esp-idf/en/stable/esp32/migration-guides/release-5.x/build-system.html?highlight=space%20path
+    #
+    set(EXTRA_COMPONENT_DIRS "${COMPONENT_SRCDIRS}")
+    idf_component_register(
+                            SRC_DIRS "${COMPONENT_SRCDIRS}"
+                            INCLUDE_DIRS "${COMPONENT_ADD_INCLUDEDIRS}"
+                            REQUIRES "${COMPONENT_REQUIRES}"
+                            EXCLUDE_SRCS "${COMPONENT_SRCEXCLUDE}"
+                            PRIV_REQUIRES esp_timer driver # this will typically only be needed for wolfSSL benchmark
+                           )
+    # some optional diagnostics
+    if (1)
+        get_cmake_property(_variableNames VARIABLES)
+        list (SORT _variableNames)
+        message(STATUS "")
+        message(STATUS "ALL VARIABLES BEGIN")
+        message(STATUS "")
+        foreach (_variableName ${_variableNames})
+            message(STATUS "${_variableName}=${${_variableName}}")
+        endforeach()
+        message(STATUS "")
+        message(STATUS "ALL VARIABLES END")
+        message(STATUS "")
+    endif()
+
+    # target_sources(wolfssl PRIVATE  "\"${WOLFSSL_ROOT}/wolfssl/\""  "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt\"")
+endif() # CMAKE_BUILD_EARLY_EXPANSION
+
+
 
 # check to see if there's both a local copy and EDP-IDF copy of the wolfssl components
-if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/" AND EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
+if( EXISTS "${WOLFSSL_PROJECT_DIR}" AND EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
     message(STATUS "")
     message(STATUS "")
     message(STATUS "********************************************************************")
@@ -229,3 +547,69 @@ endif()
 # end multiple component check
 
 
+#
+# LIBWOLFSSL_SAVE_INFO(VAR_OUPUT THIS_VAR VAR_RESULT)
+#
+# Save the THIS_VAR as a string in a macro called VAR_OUPUT
+#
+# VAR_OUPUT:  the name of the macro to define
+# THIS_VAR:   the OUTPUT_VARIABLE result from a execute_process()
+# VAR_RESULT: the RESULT_VARIABLE from a execute_process(); "0" if successful.
+#
+function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
+    # is the RESULT_VARIABLE output value 0? If so, IS_VALID_VALUE is true.
+    string(COMPARE EQUAL "${VAR_RESULT}" "0" IS_VALID_VALUE)
+
+    # if we had a successful operation, save the THIS_VAR in VAR_OUPUT
+    if(${IS_VALID_VALUE})
+        # strip newline chars in THIS_VAR parameter and save in VAR_VALUE
+        string(REPLACE "\n" ""  VAR_VALUE  ${THIS_VAR})
+
+        # we'll could percolate the value to the parent for possible later use
+        # set(${VAR_OUPUT} ${VAR_VALUE} PARENT_SCOPE)
+
+        # but we're only using it here in this function
+        set(${VAR_OUPUT} ${VAR_VALUE})
+
+        # we'll print what we found to the console
+        message(STATUS "Found ${VAR_OUPUT}=${VAR_VALUE}")
+
+        # the interesting part is defining the VAR_OUPUT name a value to use in the app
+        add_definitions(-D${VAR_OUPUT}=\"${VAR_VALUE}\")
+    else()
+        # if we get here, check the execute_process command and parameters.
+        message(STATUS "LIBWOLFSSL_SAVE_INFO encountered a non-zero VAR_RESULT")
+        set(${VAR_OUPUT} "Unknown")
+    endif()
+endfunction() # LIBWOLFSSL_SAVE_INFO
+
+# create some programmatic #define values that will be used by ShowExtendedSystemInfo().
+# see wolfcrypt\src\port\Espressif\esp32_utl.c
+if(NOT CMAKE_BUILD_EARLY_EXPANSION)
+    set (git_cmd "git")
+    message(STATUS "Adding macro definitions:")
+
+    # LIBWOLFSSL_VERSION_GIT_ORIGIN: git config --get remote.origin.url
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "config" "--get" "remote.origin.url" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_ORIGIN "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_BRANCH: git rev-parse --abbrev-ref HEAD
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "--abbrev-ref" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_BRANCH "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_HASH: git rev-parse HEAD
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_SHORT_HASH: git rev-parse --short HEAD
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "--short" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_SHORT_HASH "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_HASH_DATE git show --no-patch --no-notes --pretty=\'\%cd\'
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "show" "--no-patch" "--no-notes" "--pretty=\'\%cd\'" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES  )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH_DATE "${TMP_OUT}" "${TMP_RES}")
+
+    message(STATUS "************************************************************************************************")
+    message(STATUS "wolfssl component config complete!")
+    message(STATUS "************************************************************************************************")
+endif()

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl/include/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl/include/user_settings.h
@@ -1,0 +1,168 @@
+/* user_settings.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#undef WOLFSSL_ESPIDF
+#undef WOLFSSL_ESP32
+#undef WOLFSSL_ESPWROOM32SE
+#undef WOLFSSL_ESP32
+#undef WOLFSSL_ESP8266
+
+/* The Espressif sdkconfig will have chipset info.
+**
+** Possible values:
+**
+**   CONFIG_IDF_TARGET_ESP32
+**   CONFIG_IDF_TARGET_ESP32S3
+**   CONFIG_IDF_TARGET_ESP32C3
+**   CONFIG_IDF_TARGET_ESP32C6
+*/
+#include <sdkconfig.h>
+
+#define WOLFSSL_ESPIDF
+
+/*
+ * choose ONE of these Espressif chips to define:
+ *
+ * WOLFSSL_ESP32
+ * WOLFSSL_ESPWROOM32SE
+ * WOLFSSL_ESP8266
+ */
+
+#define WOLFSSL_ESP32
+
+/* #define DEBUG_WOLFSSL_VERBOSE */
+
+#define BENCH_EMBEDDED
+#define USE_CERT_BUFFERS_2048
+
+/* TLS 1.3                                 */
+#define WOLFSSL_TLS13
+#define HAVE_TLS_EXTENSIONS
+#define WC_RSA_PSS
+#define HAVE_HKDF
+#define HAVE_AEAD
+#define HAVE_SUPPORTED_CURVES
+
+/* when you want to use SINGLE THREAD */
+/* #define SINGLE_THREADED */
+#define NO_FILESYSTEM
+
+#define HAVE_AESGCM
+/* when you want to use SHA384 */
+/* #define WOLFSSL_SHA384 */
+#define WOLFSSL_SHA512
+#define HAVE_ECC
+#define HAVE_CURVE25519
+#define CURVE25519_SMALL
+#define HAVE_ED25519
+
+/* when you want to use pkcs7 */
+/* #define HAVE_PKCS7 */
+
+#if defined(HAVE_PKCS7)
+    #define HAVE_AES_KEYWRAP
+    #define HAVE_X963_KDF
+    #define WOLFSSL_AES_DIRECT
+#endif
+
+/* when you want to use aes counter mode */
+/* #define WOLFSSL_AES_DIRECT */
+/* #define WOLFSSL_AES_COUNTER */
+
+/* esp32-wroom-32se specific definition */
+#if defined(WOLFSSL_ESPWROOM32SE)
+    #define WOLFSSL_ATECC508A
+    #define HAVE_PK_CALLBACKS
+    /* when you want to use a custom slot allocation for ATECC608A */
+    /* unless your configuration is unusual, you can use default   */
+    /* implementation.                                             */
+    /* #define CUSTOM_SLOT_ALLOCATION                              */
+#endif
+
+/* RSA primitive specific definition */
+#if defined(WOLFSSL_ESP32) || defined(WOLFSSL_ESPWROOM32SE)
+    /* Define USE_FAST_MATH and SMALL_STACK                        */
+    #define ESP32_USE_RSA_PRIMITIVE
+    /* threshold for performance adjustment for HW primitive use   */
+    /* X bits of G^X mod P greater than                            */
+    #define EPS_RSA_EXPT_XBTIS           36
+    /* X and Y of X * Y mod P greater than                         */
+    #define ESP_RSA_MULM_BITS            2000
+#endif
+
+/* debug options */
+/* #define DEBUG_WOLFSSL */
+/* #define WOLFSSL_ESP32_CRYPT_DEBUG */
+/* #define WOLFSSL_ATECC508A_DEBUG          */
+
+/* date/time                               */
+/* if it cannot adjust time in the device, */
+/* enable macro below                      */
+/* #define NO_ASN_TIME */
+/* #define XTIME time */
+
+
+/* adjust wait-timeout count if you see timeout in RSA HW acceleration */
+#define ESP_RSA_TIMEOUT_CNT    0x249F00
+
+#if defined(CONFIG_IDF_TARGET_ESP32)
+    /* when you want not to use HW acceleration on ESP32 (below for S3, etc */
+    /* #define NO_ESP32_CRYPT                 */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_HASH    */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_AES     */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI */
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)
+    /* ESP32-S2 disabled by default; not implemented */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+    /* when you want not to use HW acceleration on ESP32-S3 */
+    /* #define NO_ESP32_CRYPT                 */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_HASH    */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_AES     */
+    /* #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI */
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+    /* ESP32-C3 disabled by default, not implemented */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#elif defined(CONFIG_IDF_TARGET_ESP32C6)
+    /* ESP32-C6 disabled by default, not implemented */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#elif defined(CONFIG_IDF_TARGET_ESP32H2)
+    /* ESP32-H2 disabled by default, not implemented */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#else
+    /* anything else unknown will have HW disabled by default */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#endif

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_test/partitions_singleapp_large.csv
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_test/partitions_singleapp_large.csv
@@ -1,0 +1,34 @@
+# This tag is used to include this file in the ESP Component Registry:
+# __ESP_COMPONENT_SOURCE__
+
+# to view: idf.py partition-table
+#
+# ESP-IDF Partition Table
+# Name, Type,  SubType, Offset,  Size, Flags
+nvs,     data, nvs,     0x9000,  24K,
+phy_init,data, phy,     0xf000,  4K,
+factory, app,  factory, 0x10000, 1500K,
+
+
+# For other settings, see:
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html#creating-custom-tables
+#
+# Here is the summary printed for the “Single factory app, no OTA” configuration:
+#
+# # ESP-IDF Partition Table
+# # Name,   Type, SubType, Offset,  Size, Flags
+# nvs,      data, nvs,     0x9000,  0x6000,
+# phy_init, data, phy,     0xf000,  0x1000,
+# factory,  app,  factory, 0x10000, 1M,
+#
+#
+# Here is the summary printed for the “Factory app, two OTA definitions” configuration:
+#
+# # ESP-IDF Partition Table
+# # Name,   Type, SubType, Offset,  Size, Flags
+# nvs,      data, nvs,     0x9000,  0x4000,
+# otadata,  data, ota,     0xd000,  0x2000,
+# phy_init, data, phy,     0xf000,  0x1000,
+# factory,  app,  factory, 0x10000,  1M,
+# ota_0,    app,  ota_0,   0x110000, 1M,
+# ota_1,    app,  ota_1,   0x210000, 1M,


### PR DESCRIPTION
# Description

* Updates cmake files for `wolfssl_benchmark`, `wolfssl_test`, (as well as TLS Client/Server) examples using wolfssl as an Espressif component. Only a `CMakeLists.txt` file is local to the component; it searches for wolfSSL source.
* Adds support for per-project `user_settings.h`.
* No longer [copies user_settings.h](https://github.com/gojimmypi/wolfssl/blob/c23559a91c55902deefe6f1a5b72c623250b96c9/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/components/wolfssl/CMakeLists.txt#L136) into `${WOLFSSL_ROOT}/include/user_settings.h`.
* Includes `partitions_singleapp_large.csv` for consistency across project examples.


https://github.com/wolfSSL/wolfssl/pull/6844 is currently failing Jenkins tests as the respective `CMakeLists.txt` checks for both a wolfSSL `/include/user_settings.h` _and_ a `[project]/components/wolfssl/include/user_settings.h`. Since those TLS examples support (and in fact, prefer) per-project `user_settings.h`, the build process fails due to the prior copy of the `user_settings.h` into `/include/user_settings.h` by the wolfssl_benchmark build.

* edit: to resolve the check & egg problem of half the examples expecting (benchmark & test) a local `user_settings.h` (error if also in root `/include`), and half expecting shared (TLS Client/Server, not yet updated, see [#6844](https://github.com/wolfSSL/wolfssl/pull/6844), (Error if also found locally): *This update now changes the `CmakeLists.txt` for all 4 primary examples.*
 
See https://github.com/wolfSSL/wolfssl/issues/6234 for a roadmap of Espressif updates.

Fixes zd# n/a

# Testing

How did you test?

manually tested locally

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
