### PR TITLE
correctly set invalid devId for when cryptoCb is on

### DIFF
--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -115,7 +115,7 @@ int wc_InitCmac_ex(Cmac* cmac, const byte* key, word32 keySz,
     XMEMSET(cmac, 0, sizeof(Cmac));
 
 #ifdef WOLF_CRYPTO_CB
-    /* set invalid devId regardless of value */
+    /* Set devId regardless of value (invalid or not) */
     cmac->devId = devId;
     #ifndef WOLF_CRYPTO_CB_FIND
     if (devId != INVALID_DEVID)
@@ -129,7 +129,6 @@ int wc_InitCmac_ex(Cmac* cmac, const byte* key, word32 keySz,
             return ret;
         /* fall-through when unavailable */
     }
-
 #else
     (void)devId;
 #endif

--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -114,12 +114,13 @@ int wc_InitCmac_ex(Cmac* cmac, const byte* key, word32 keySz,
 #endif
     XMEMSET(cmac, 0, sizeof(Cmac));
 
+    /* set invalid devId regardless of cryptoCb */
+    cmac->devId = devId;
 #ifdef WOLF_CRYPTO_CB
     #ifndef WOLF_CRYPTO_CB_FIND
     if (devId != INVALID_DEVID)
     #endif
     {
-        cmac->devId = devId;
         cmac->devCtx = NULL;
 
         ret = wc_CryptoCb_Cmac(cmac, key, keySz, NULL, 0, NULL, NULL,
@@ -128,6 +129,7 @@ int wc_InitCmac_ex(Cmac* cmac, const byte* key, word32 keySz,
             return ret;
         /* fall-through when unavailable */
     }
+
 #else
     (void)devId;
 #endif

--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -114,9 +114,9 @@ int wc_InitCmac_ex(Cmac* cmac, const byte* key, word32 keySz,
 #endif
     XMEMSET(cmac, 0, sizeof(Cmac));
 
-    /* set invalid devId regardless of cryptoCb */
-    cmac->devId = devId;
 #ifdef WOLF_CRYPTO_CB
+    /* set invalid devId regardless of value */
+    cmac->devId = devId;
     #ifndef WOLF_CRYPTO_CB_FIND
     if (devId != INVALID_DEVID)
     #endif


### PR DESCRIPTION
but the user has opted to use software, or cmac is not available on for their device. currently a devId of 0 is set which causes CRYPTOCB_UNAVAILABLE

# Description

Fixes erroneous 0 devId being set

# Testing

Tested alongside internal cryptoCb project

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
