### PR TITLE
SM2 named curve disabled: value outside of supported values

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -4705,8 +4705,7 @@ int TLSX_ValidateSupportedCurves(const WOLFSSL* ssl, byte first, byte second,
     #ifdef OPENSSL_EXTRA
         /* skip if name is not in supported ECC range
          * or disabled by user */
-        if (curve->name > WOLFSSL_ECC_MAX ||
-            wolfSSL_curve_is_disabled(ssl, curve->name))
+        if (wolfSSL_curve_is_disabled(ssl, curve->name))
             continue;
     #endif
 
@@ -8651,8 +8650,7 @@ static int TLSX_SupportedGroups_Find(const WOLFSSL* ssl, word16 name,
     TLSX*          extension;
     SupportedCurve* curve = NULL;
 
-    if ((extension = TLSX_Find(extensions,
-                                              TLSX_SUPPORTED_GROUPS)) == NULL) {
+    if ((extension = TLSX_Find(extensions, TLSX_SUPPORTED_GROUPS)) == NULL) {
         if ((extension = TLSX_Find(ssl->ctx->extensions,
                                               TLSX_SUPPORTED_GROUPS)) == NULL) {
             return 0;

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3926,7 +3926,10 @@ enum {
     WOLFSSL_ECC_X448      = 30,
     WOLFSSL_ECC_SM2P256V1 = 41,
     WOLFSSL_ECC_MAX       = 41,
+    WOLFSSL_ECC_MAX_AVAIL = 46,
+    /* Update use of disabled curves when adding value greater than 46. */
 
+    WOLFSSL_FFDHE_START   = 256,
     WOLFSSL_FFDHE_2048    = 256,
     WOLFSSL_FFDHE_3072    = 257,
     WOLFSSL_FFDHE_4096    = 258,


### PR DESCRIPTION
# Description

SM2 named curve value is specified in specification. Values 0-14 aren't used, so, those bits in disabledCurves are used for values over 31.
Add range checks.

# Testing

Standard

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
