### PR TITLE
Fix for pthreads on MSYS2 & MINGW

### DIFF
--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1377,8 +1377,7 @@ typedef struct w64wrapper {
         typedef unsigned int  THREAD_RETURN;
         typedef size_t        THREAD_TYPE;
         #define WOLFSSL_THREAD
-    #elif (defined(_POSIX_THREADS) || defined(HAVE_PTHREAD)) && \
-        !defined(__MINGW32__)
+    #elif (defined(_POSIX_THREADS) || defined(HAVE_PTHREAD))
         #ifndef __MACH__
             #include <pthread.h>
             typedef struct COND_TYPE {

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -761,8 +761,8 @@ typedef struct w64wrapper {
 
         /* snprintf is used in asn.c for GetTimeString, PKCS7 test, and when
            debugging is turned on */
+        #ifndef XSNPRINTF
         #ifndef USE_WINDOWS_API
-            #ifndef XSNPRINTF
             #if defined(WOLFSSL_ESPIDF) && \
                 (!defined(NO_ASN_TIME) && defined(HAVE_PKCS7))
                     #include<stdarg.h>
@@ -797,7 +797,6 @@ typedef struct w64wrapper {
             #else
                 #include <stdio.h>
                 #define XSNPRINTF snprintf
-            #endif
             #endif
         #else
             #if defined(_MSC_VER) || defined(__CYGWIN__) || defined(__MINGW32__)
@@ -834,6 +833,7 @@ typedef struct w64wrapper {
                 #define XSNPRINTF snprintf
             #endif /* _MSC_VER */
         #endif /* USE_WINDOWS_API */
+        #endif /* !XSNPRINTF */
 
         #if defined(WOLFSSL_CERT_EXT) || defined(OPENSSL_EXTRA) || \
             defined(HAVE_ALPN) || defined(WOLFSSL_SNIFFER)

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -743,10 +743,10 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
 #endif
 
     #ifndef MAX_FILENAME_SZ
-        #define MAX_FILENAME_SZ  260 + 1 /* max file name length */
+        #define MAX_FILENAME_SZ (260 + 1) /* max file name length */
     #endif
     #ifndef MAX_PATH
-        #define MAX_PATH 260 + 1
+        #define MAX_PATH (260 + 1)
     #endif
 
     WOLFSSL_LOCAL int wc_FileLoad(const char* fname, unsigned char** buf,

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -60,7 +60,7 @@
 
 /* THREADING/MUTEX SECTION */
 #ifdef USE_WINDOWS_API
-    #if defined(MINGW32) && !defined(SINGLE_THREADED)
+    #if defined(__MINGW32__) && !defined(SINGLE_THREADED)
         #define WOLFSSL_PTHREADS
         #include <pthread.h>
     #endif

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -60,6 +60,10 @@
 
 /* THREADING/MUTEX SECTION */
 #ifdef USE_WINDOWS_API
+    #if defined(MINGW32) && !defined(SINGLE_THREADED)
+        #define WOLFSSL_PTHREADS
+        #include <pthread.h>
+    #endif
     #ifdef WOLFSSL_GAME_BUILD
         #include "system/xtl.h"
     #else
@@ -739,10 +743,10 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
 #endif
 
     #ifndef MAX_FILENAME_SZ
-        #define MAX_FILENAME_SZ  256 /* max file name length */
+        #define MAX_FILENAME_SZ  260 + 1 /* max file name length */
     #endif
     #ifndef MAX_PATH
-        #define MAX_PATH 256
+        #define MAX_PATH 260 + 1
     #endif
 
     WOLFSSL_LOCAL int wc_FileLoad(const char* fname, unsigned char** buf,


### PR DESCRIPTION
# Description

Fix for pthread issues in https://github.com/wolfSSL/wolfssl/issues/6874 and https://github.com/wolfSSL/wolfssl/issues/6838. 

Includes a fix for a truncated output warning. This was resolved by incrementing `MAX_PATH` and `MAX_FILENAME_SZ` to `260+1` as the max value on windows is 260 (https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry)

```
In file included from wolfcrypt/src/wc_port.c:28:
wolfcrypt/src/wc_port.c: In function 'wc_ReadDirFirst':
./wolfssl/wolfcrypt/types.h:674:35: error: 'strncpy' output may be truncated copying between 0 and 255 bytes from a string of length 259 [-Werror=stringop-truncation]
  674 |         #define XSTRNCPY(s1,s2,n) strncpy((s1),(s2),(n))
      |                                   ^~~~~~~~~~~~~~~~~~~~~~
wolfcrypt/src/wc_port.c:635:13: note: in expansion of macro 'XSTRNCPY'
  635 |             XSTRNCPY(ctx->name + pathLen + 1,
      |             ^~~~~~~~
wolfcrypt/src/wc_port.c: In function 'wc_ReadDirNext':
./wolfssl/wolfcrypt/types.h:674:35: error: 'strncpy' output may be truncated copying between 0 and 255 bytes from a string of length 259 [-Werror=stringop-truncation]
  674 |         #define XSTRNCPY(s1,s2,n) strncpy((s1),(s2),(n))
      |                                   ^~~~~~~~~~~~~~~~~~~~~~
wolfcrypt/src/wc_port.c:788:13: note: in expansion of macro 'XSTRNCPY'
  788 |             XSTRNCPY(ctx->name + pathLen + 1,
      |             ^~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [Makefile:6351: wolfcrypt/src/src_libwolfssl_la-wc_port.lo] Error 1
```

# Testing

Reproduced reports on mingw. These changes resolved the problems locally.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
