### PR TITLE
cmake aarch64 fix 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1577,8 +1577,11 @@ endif()
 
 # TODO: - Fast huge math
 
+# Set processor-specific build macros
 if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64|AMD64")
     list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_X86_64_BUILD")
+elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "aarch64|arm64")
+    list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_AARCH64_BUILD")
 endif()
 
 # SP math all


### PR DESCRIPTION
 This PR adds a CMake host processor check to appropriately set `WOLFSSL_AARCH64_BUILD` for 64-bit ARM targets (incl. M1 macs). It fixes a bug where using the example client to connect to google.com in conjunction with `WOLFSSL_SYS_CA_CERTS` on an M1 mac crashes, but ONLY when building with CMake. The equivalent `configure` build works fine. 

## Steps to Reproduce
Building on an M1 Mac using `master` with 
```
mkdir cmake-build && cd cmake-build
cmake ../ -DWOLFSSL_SYS_CA_CERTS=1 && cmake --build .
```

and running the example client against will abort 
```
$./examples/client/client -h www.google.com -p 443 -g --sys-ca-certs
zsh: abort      ./examples/client/client -h www.google.com -p 443 --sys-ca-certs
```

Using the same client arguments on this PR branch should succeed.  

