### PR TITLE
Add explicit break to switch statement in GetHmacLength

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -10138,6 +10138,8 @@ static WC_INLINE byte GetHmacLength(int hmac)
         case sm3_mac:
             return WC_SM3_DIGEST_SIZE;
     #endif
+        default:
+            break;
     }
     return 0;
 }


### PR DESCRIPTION
# Description

Add explicit break to switch statement in GetHmacLength.

Fixes zd# 16824

# Testing

Customer confirmed fixed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
