### PR TITLE
Move AesEax definition to aes.h

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -76,9 +76,9 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
     #include <wolfssl/wolfcrypt/port/nxp/se050_port.h>
 #endif
 
-#if defined(WOLFSSL_AES_SIV) || defined(WOLFSSL_AES_EAX)
+#if defined(WOLFSSL_AES_SIV)
     #include <wolfssl/wolfcrypt/cmac.h>
-#endif /* WOLFSSL_AES_SIV || WOLFSSL_AES_EAX */
+#endif /* WOLFSSL_AES_SIV */
 
 #if defined(WOLFSSL_HAVE_PSA) && !defined(WOLFSSL_PSA_NO_AES)
     #include <wolfssl/wolfcrypt/port/psa/psa.h>
@@ -11788,17 +11788,6 @@ int wc_AesSivDecrypt(const byte* key, word32 keySz, const byte* assoc,
 #endif /* WOLFSSL_AES_SIV */
 
 #if defined(WOLFSSL_AES_EAX)
-
-struct AesEax {
-    Aes  aes;
-    Cmac nonceCmac;
-    Cmac aadCmac;
-    Cmac ciphertextCmac;
-    byte nonceCmacFinal[AES_BLOCK_SIZE];
-    byte aadCmacFinal[AES_BLOCK_SIZE];
-    byte ciphertextCmacFinal[AES_BLOCK_SIZE];
-    byte prefixBuf[AES_BLOCK_SIZE];
-};
 
 /*
  * AES EAX one-shot API

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -602,6 +602,22 @@ int wc_AesSivDecrypt(const byte* key, word32 keySz, const byte* assoc,
 
 #ifdef WOLFSSL_AES_EAX
 
+/* Because of the circular dependency between AES and CMAC, we need to prevent
+ * inclusion of AES EAX from CMAC to avoid a recursive inclusion */
+#ifndef WOLF_CRYPT_CMAC_H
+#include <wolfssl/wolfcrypt/cmac.h>
+struct AesEax {
+    Aes  aes;
+    Cmac nonceCmac;
+    Cmac aadCmac;
+    Cmac ciphertextCmac;
+    byte nonceCmacFinal[AES_BLOCK_SIZE];
+    byte aadCmacFinal[AES_BLOCK_SIZE];
+    byte ciphertextCmacFinal[AES_BLOCK_SIZE];
+    byte prefixBuf[AES_BLOCK_SIZE];
+};
+#endif /* !defined(WOLF_CRYPT_CMAC_H) */
+
 typedef struct AesEax AesEax;
 
 /* One-shot API */


### PR DESCRIPTION
# Description
Makes AesEax struct available for public use.

New PR taking over for #6864 
Fixes #6862 

# Testing

Tested using provided reproducer.  Confirmed fixed.