### PR TITLE
SRTP/SRTCP KDF: add implementation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3547,6 +3547,22 @@ then
   AM_CFLAGS="$AM_CFLAGS -DHAVE_X963_KDF"
 fi
 
+# SRTP-KDF
+AC_ARG_ENABLE([srtp-kdf],
+    [AS_HELP_STRING([--enable-srtp-kdf],[Enable SRTP-KDF support (default: disabled)])],
+    [ ENABLED_SRTP_KDF=$enableval ],
+    [ ENABLED_SRTP_KDF=no ]
+    )
+if test "$ENABLED_SRTP" = "yes"
+then
+  ENABLED_SRTP_KDF="yes"
+fi
+if test "$ENABLED_SRTP_KDF" = "yes"
+then
+  AM_CFLAGS="$AM_CFLAGS -DWC_SRTP_KDF -DHAVE_AES_ECB -DWOLFSSL_AES_DIRECT"
+fi
+
+
 # DSA
 AC_ARG_ENABLE([dsa],
     [AS_HELP_STRING([--enable-dsa],[Enable DSA (default: disabled)])],
@@ -9579,6 +9595,7 @@ echo "   * wolfCrypt Only:             $ENABLED_CRYPTONLY"
 echo "   * HKDF:                       $ENABLED_HKDF"
 echo "   * HPKE:                       $ENABLED_HPKE"
 echo "   * X9.63 KDF:                  $ENABLED_X963KDF"
+echo "   * SRTP-KDF:                   $ENABLED_SRTP_KDF"
 echo "   * PSK:                        $ENABLED_PSK"
 echo "   * Poly1305:                   $ENABLED_POLY1305"
 echo "   * LEANPSK:                    $ENABLED_LEANPSK"

--- a/doc/dox_comments/header_files/doxygen_groups.h
+++ b/doc/dox_comments/header_files/doxygen_groups.h
@@ -206,6 +206,7 @@
     \defgroup RSA Algorithms - RSA
     \defgroup SHA Algorithms - SHA 128/224/256/384/512
     \defgroup SipHash Algorithm - SipHash
+    \defgroup SrtpKdf Algorithm - SRTP KDF
     \defgroup SRP Algorithms - SRP
 
     \defgroup ASN ASN.1

--- a/doc/dox_comments/header_files/doxygen_pages.h
+++ b/doc/dox_comments/header_files/doxygen_pages.h
@@ -57,6 +57,7 @@
         <li>\ref RSA</li>
         <li>\ref SHA</li>
         <li>\ref SipHash</li>
+        <li>\ref SrtpKdf</li>
         <li>\ref SRP</li>
     </ul>
 */

--- a/doc/dox_comments/header_files/kdf.h
+++ b/doc/dox_comments/header_files/kdf.h
@@ -1,0 +1,126 @@
+
+/*!
+    \ingroup SrtpKdf
+
+    \brief This function derives keys using SRTP KDF algorithm.
+
+    \return 0 Returned upon successful key derviation.
+    \return BAD_FUNC_ARG Returned when key or salt is NULL
+    \return BAD_FUNC_ARG Returned when key length is not 16, 24 or 32.
+    \return BAD_FUNC_ARG Returned when saltSz is larger than 14.
+    \return BAD_FUNC_ARG Returned when kdrIdx is less than -1 or larger than 24.
+    \return MEMORY_E on dynamic memory allocation failure.
+
+    \param [in] key Key to use with encryption.
+    \param [in] keySz Size of key in bytes.
+    \param [in] salt Random non-secret value.
+    \param [in] saltSz Size of random in bytes.
+    \param [in] kdrIdx Key derivation rate. kdr = 0 when -1, otherwise kdr = 2^kdrIdx.
+    \param [in] index Index value to XOR in.
+    \param [out] key1 First key. Label value of 0x00.
+    \param [in] key1Sz Size of first key in bytes.
+    \param [out] key2 Second key. Label value of 0x01.
+    \param [in] key2Sz Size of second key in bytes.
+    \param [out] key3 Third key. Label value of 0x02.
+    \param [in] key3Sz Size of third key in bytes.
+
+
+    _Example_
+    \code
+    unsigned char key[16] = { ... };
+    unsigned char salt[14] = { ... };
+    unsigned char index[6] = { ... };
+    unsigned char keyE[16];
+    unsigned char keyA[20];
+    unsigned char keyS[14];
+    int kdrIdx = 0; // Use all of index
+    int ret;
+
+    ret = wc_SRTP_KDF(key, sizeof(key), salt, sizeof(salt), kdrIdx, index,
+        keyE, sizeof(keyE), keyA, sizeof(keyA), keyS, sizeof(keyS));
+    if (ret != 0) {
+        WOLFSSL_MSG("wc_SRTP_KDF failed");
+    }
+    \endcode
+
+    \sa wc_SRTCP_KDF
+    \sa wc_SRTP_KDF_kdr_to_idx
+*/
+int wc_SRTP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
+        int kdrIdx, const byte* index, byte* key1, word32 key1Sz, byte* key2,
+        word32 key2Sz, byte* key3, word32 key3Sz);
+
+/*!
+    \ingroup SrtpKdf
+
+    \brief This function derives keys using SRTCP KDF algorithm.
+
+    \return 0 Returned upon successful key derviation.
+    \return BAD_FUNC_ARG Returned when key or salt is NULL
+    \return BAD_FUNC_ARG Returned when key length is not 16, 24 or 32.
+    \return BAD_FUNC_ARG Returned when saltSz is larger than 14.
+    \return BAD_FUNC_ARG Returned when kdrIdx is less than -1 or larger than 24.
+    \return MEMORY_E on dynamic memory allocation failure.
+
+    \param [in] key Key to use with encryption.
+    \param [in] keySz Size of key in bytes.
+    \param [in] salt Random non-secret value.
+    \param [in] saltSz Size of random in bytes.
+    \param [in] kdrIdx Key derivation rate. kdr = 0 when -1, otherwise kdr = 2^kdrIdx.
+    \param [in] index Index value to XOR in.
+    \param [out] key1 First key. Label value of 0x00.
+    \param [in] key1Sz Size of first key in bytes.
+    \param [out] key2 Second key. Label value of 0x01.
+    \param [in] key2Sz Size of second key in bytes.
+    \param [out] key3 Third key. Label value of 0x02.
+    \param [in] key3Sz Size of third key in bytes.
+
+
+    _Example_
+    \code
+    unsigned char key[16] = { ... };
+    unsigned char salt[14] = { ... };
+    unsigned char index[4] = { ... };
+    unsigned char keyE[16];
+    unsigned char keyA[20];
+    unsigned char keyS[14];
+    int kdrIdx = 0; // Use all of index
+    int ret;
+
+    ret = wc_SRTCP_KDF(key, sizeof(key), salt, sizeof(salt), kdrIdx, index,
+        keyE, sizeof(keyE), keyA, sizeof(keyA), keyS, sizeof(keyS));
+    if (ret != 0) {
+        WOLFSSL_MSG("wc_SRTP_KDF failed");
+    }
+    \endcode
+
+    \sa wc_SRTP_KDF
+    \sa wc_SRTP_KDF_kdr_to_idx
+*/
+int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
+        int kdrIdx, const byte* index, byte* key1, word32 key1Sz, byte* key2,
+        word32 key2Sz, byte* key3, word32 key3Sz);
+
+/*!
+    \ingroup SrtpKdf
+
+    \brief This function converts a kdr value to an index to use in SRTP/SRTCP KDF API.
+
+    \return Key derivation rate as an index.
+
+    \param [in] kdr Key derivation rate to convert.
+
+    _Example_
+    \code
+    word32 kdr = 0x00000010;
+    int kdrIdx;
+    int ret;
+
+    kdrIdx = wc_SRTP_KDF_kdr_to_idx(kdr);
+    \endcode
+
+    \sa wc_SRTP_KDF
+    \sa wc_SRTCP_KDF
+*/
+int wc_SRTP_KDF_kdr_to_idx(word32 kdr);
+

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -127,6 +127,7 @@
 #ifdef WOLFSSL_SIPHASH
     #include <wolfssl/wolfcrypt/siphash.h>
 #endif
+  #include <wolfssl/wolfcrypt/kdf.h>
 #ifndef NO_PWDBASED
     #include <wolfssl/wolfcrypt/pwdbased.h>
 #endif
@@ -534,6 +535,9 @@
 #define BENCH_PBKDF2             0x00000100
 #define BENCH_SIPHASH            0x00000200
 
+/* KDF algorithms */
+#define BENCH_SRTP_KDF           0x00000001
+
 /* Asymmetric algorithms. */
 #define BENCH_RSA_KEYGEN         0x00000001
 #define BENCH_RSA                0x00000002
@@ -619,6 +623,8 @@ static word32 bench_cipher_algs = 0;
 static word32 bench_digest_algs = 0;
 /* MAC algorithms to benchmark. */
 static word32 bench_mac_algs = 0;
+/* KDF algorithms to benchmark. */
+static word32 bench_kdf_algs = 0;
 /* Asymmetric algorithms to benchmark. */
 static word32 bench_asym_algs = 0;
 /* Post-Quantum Asymmetric algorithms to benchmark. */
@@ -797,9 +803,18 @@ static const bench_alg bench_mac_opt[] = {
     #ifndef NO_PWDBASED
     { "-pbkdf2",             BENCH_PBKDF2            },
     #endif
+#endif
     #ifdef WOLFSSL_SIPHASH
     { "-siphash",            BENCH_SIPHASH           },
     #endif
+    { NULL, 0 }
+};
+
+/* All recognized KDF algorithm choosing command line options. */
+static const bench_alg bench_kdf_opt[] = {
+    { "-kdf",                0xffffffff              },
+#ifdef WC_SRTP_KDF
+    { "-srtp-kdf",           BENCH_SRTP_KDF          },
 #endif
     { NULL, 0 }
 };
@@ -1646,6 +1661,7 @@ static void benchmark_static_init(int force)
         bench_cipher_algs = 0;
         bench_digest_algs = 0;
         bench_mac_algs = 0;
+        bench_kdf_algs = 0;
         bench_asym_algs = 0;
         bench_pq_asym_algs = 0;
         bench_other_algs = 0;
@@ -2785,12 +2801,18 @@ static void* benchmarks_do(void* args)
             bench_pbkdf2();
         }
     #endif
-    #ifdef WOLFSSL_SIPHASH
-        if (bench_all || (bench_mac_algs & BENCH_SIPHASH)) {
-            bench_siphash();
-        }
-    #endif
 #endif /* NO_HMAC */
+#ifdef WOLFSSL_SIPHASH
+    if (bench_all || (bench_mac_algs & BENCH_SIPHASH)) {
+        bench_siphash();
+    }
+#endif
+
+#ifdef WC_SRTP_KDF
+    if (bench_all || (bench_kdf_algs & BENCH_SRTP_KDF)) {
+        bench_srtpkdf();
+    }
+#endif
 
 #ifdef HAVE_SCRYPT
     if (bench_all || (bench_other_algs & BENCH_SCRYPT))
@@ -6717,6 +6739,68 @@ void bench_siphash(void)
         count += i;
     } while (bench_stats_check(start));
     bench_stats_sym_finish("SipHash-16", 1, count, bench_size, start, ret);
+}
+#endif
+
+#ifdef WC_SRTP_KDF
+void bench_srtpkdf(void)
+{
+    double start;
+    int count;
+    int ret = 0;
+    byte keyE[32];
+    byte keyA[20];
+    byte keyS[14];
+    const byte *key = bench_key_buf;
+    const byte salt[14] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                           0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e };
+    const byte index[6] = { 0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA };
+    int kdrIdx = 0;
+    int i;
+
+    bench_stats_start(&count, &start);
+    do {
+        for (i = 0; i < numBlocks; i++) {
+            ret = wc_SRTP_KDF(key, AES_128_KEY_SIZE, salt, sizeof(salt),
+                kdrIdx, index, keyE, AES_128_KEY_SIZE, keyA, sizeof(keyA),
+                keyS, sizeof(keyS));
+        }
+        count += i;
+    } while (bench_stats_check(start));
+    bench_stats_asym_finish("KDF", 128, "SRTP", 0, count, start, ret);
+
+    bench_stats_start(&count, &start);
+    do {
+        for (i = 0; i < numBlocks; i++) {
+            ret = wc_SRTP_KDF(key, AES_256_KEY_SIZE, salt, sizeof(salt),
+                kdrIdx, index, keyE, AES_256_KEY_SIZE, keyA, sizeof(keyA),
+                keyS, sizeof(keyS));
+        }
+        count += i;
+    } while (bench_stats_check(start));
+    bench_stats_asym_finish("KDF", 256, "SRTP", 0, count, start, ret);
+
+    bench_stats_start(&count, &start);
+    do {
+        for (i = 0; i < numBlocks; i++) {
+            ret = wc_SRTCP_KDF(key, AES_128_KEY_SIZE, salt, sizeof(salt),
+                kdrIdx, index, keyE, AES_128_KEY_SIZE, keyA, sizeof(keyA),
+                keyS, sizeof(keyS));
+        }
+        count += i;
+    } while (bench_stats_check(start));
+    bench_stats_asym_finish("KDF", 128, "SRTCP", 0, count, start, ret);
+
+    bench_stats_start(&count, &start);
+    do {
+        for (i = 0; i < numBlocks; i++) {
+            ret = wc_SRTCP_KDF(key, AES_256_KEY_SIZE, salt, sizeof(salt),
+                kdrIdx, index, keyE, AES_256_KEY_SIZE, keyA, sizeof(keyA),
+                keyS, sizeof(keyS));
+        }
+        count += i;
+    } while (bench_stats_check(start));
+    bench_stats_asym_finish("KDF", 256, "SRTCP", 0, count, start, ret);
 }
 #endif
 
@@ -10660,6 +10744,8 @@ static void Usage(void)
         print_alg(bench_digest_opt[i].str, &line);
     for (i=0; bench_mac_opt[i].str != NULL; i++)
         print_alg(bench_mac_opt[i].str, &line);
+    for (i=0; bench_kdf_opt[i].str != NULL; i++)
+        print_alg(bench_kdf_opt[i].str, &line);
     for (i=0; bench_asym_opt[i].str != NULL; i++)
         print_alg(bench_asym_opt[i].str, &line);
     for (i=0; bench_other_opt[i].str != NULL; i++)
@@ -10890,6 +10976,14 @@ int wolfcrypt_benchmark_main(int argc, char** argv)
             for (i=0; !optMatched && bench_mac_opt[i].str != NULL; i++) {
                 if (string_matches(argv[1], bench_mac_opt[i].str)) {
                     bench_mac_algs |= bench_mac_opt[i].val;
+                    bench_all = 0;
+                    optMatched = 1;
+                }
+            }
+            /* Known KDF algorithms */
+            for (i=0; !optMatched && bench_kdf_opt[i].str != NULL; i++) {
+                if (string_matches(argv[1], bench_kdf_opt[i].str)) {
+                    bench_kdf_algs |= bench_kdf_opt[i].val;
                     bench_all = 0;
                     optMatched = 1;
                 }

--- a/wolfcrypt/benchmark/benchmark.h
+++ b/wolfcrypt/benchmark/benchmark.h
@@ -95,6 +95,7 @@ void bench_hmac_sha256(int useDeviceID);
 void bench_hmac_sha384(int useDeviceID);
 void bench_hmac_sha512(int useDeviceID);
 void bench_siphash(void);
+void bench_srtpkdf(void);
 void bench_rsaKeyGen(int useDeviceID);
 void bench_rsaKeyGen_size(int useDeviceID, word32 keySz);
 void bench_rsa(int useDeviceID);

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -52,6 +52,9 @@
 
 #include <wolfssl/wolfcrypt/hmac.h>
 #include <wolfssl/wolfcrypt/kdf.h>
+#ifdef WC_SRTP_KDF
+#include <wolfssl/wolfcrypt/aes.h>
+#endif
 
 
 #if defined(WOLFSSL_HAVE_PRF) && !defined(NO_HMAC)
@@ -869,5 +872,293 @@ int wc_SSH_KDF(byte hashId, byte keyId, byte* key, word32 keySz,
 }
 
 #endif /* WOLFSSL_WOLFSSH */
+
+#ifdef WC_SRTP_KDF
+/* Calculate first block to encrypt.
+ *
+ * @param [in]  salt     Random value to XOR in.
+ * @param [in]  saltSz   Size of random value in bytes.
+ * @param [in]  kdrIdx   Key derivation rate. kdr = 0 when -1, otherwise
+ *                       kdr = 2^kdrIdx.
+ * @param [in]  index    Index value to XOR in.
+ * @param [in]  indexSz  Size of index value in bytes.
+ * @param [out] block    First block to encrypt.
+ */
+static void wc_srtp_kdf_first_block(const byte* salt, word32 saltSz, int kdrIdx,
+        const byte* index, byte indexSz, unsigned char* block)
+{
+    word32 i;
+
+    /* XOR salt into zeroized buffer. */
+    for (i = 0; i < WC_SRTP_MAX_SALT - saltSz; i++)
+        block[i] = 0;
+    XMEMCPY(block + WC_SRTP_MAX_SALT - saltSz, salt, saltSz);
+    block[WC_SRTP_MAX_SALT] = 0;
+    /* block[15] is counter. */
+
+    /* When kdrIdx is -1, don't XOR in index. */
+    if (kdrIdx >= 0) {
+        /* Get the number of bits to shift index by. */
+        word32 bits = kdrIdx & 0x7;
+        /* Reduce index size by number of bytes to remove. */
+        indexSz -= kdrIdx >> 3;
+
+        if ((kdrIdx & 0x7) == 0) {
+            /* Just XOR in as no bit shifting. */
+            for (i = 0; i < indexSz; i++)
+                block[i + WC_SRTP_MAX_SALT - indexSz] ^= index[i];
+        }
+        else {
+            /* XOR in as bit shifted index. */
+            block[WC_SRTP_MAX_SALT - indexSz] ^= index[i+0] >> bits;
+            for (i = 1; i < indexSz; i++) {
+                block[i + WC_SRTP_MAX_SALT - indexSz] ^=
+                    (index[i-1] << (8 - bits)) |
+                    (index[i+0] >>      bits );
+            }
+        }
+    }
+}
+
+/* Derive a key given the first block.
+ *
+ * @param [in, out] block    First block to encrypt. Need label XORed in.
+ * @param [in]      indexSz  Size of index in bytes to calculate where label is
+ *                           XORed into.
+ * @param [in]      label    Label byte that differs for each key.
+ * @param [out]     key      Derived key.
+ * @param [in]      keySz    Size of key to derive in bytes.
+ * @param [in]      aes      AES object to encrypt with.
+ * @return  0 on success.
+ */
+static int wc_srtp_kdf_derive_key(byte* block, byte indexSz, byte label,
+        byte* key, word32 keySz, Aes* aes)
+{
+    int i;
+    int ret = 0;
+    /* Calculate the number of full blocks needed for derived key. */
+    int blocks = keySz / AES_BLOCK_SIZE;
+
+    /* XOR in label. */
+    block[WC_SRTP_MAX_SALT - indexSz - 1] ^= label;
+    for (i = 0; (ret == 0) && (i < blocks); i++) {
+        /* Set counter. */
+        block[15] = i;
+        /* Encrypt block into key buffer. */
+        ret = wc_AesEcbEncrypt(aes, key, block, AES_BLOCK_SIZE);
+        /* Reposition for more derived key. */
+        key += AES_BLOCK_SIZE;
+        /* Reduce the count of key bytes required. */
+        keySz -= AES_BLOCK_SIZE;
+    }
+    /* Do any partial blocks. */
+    if ((ret == 0) && (keySz > 0)) {
+        byte enc[AES_BLOCK_SIZE];
+        /* Set counter. */
+        block[15] = i;
+        /* Encrypt block into temporary. */
+        ret = wc_AesEcbEncrypt(aes, enc, block, AES_BLOCK_SIZE);
+        if (ret == 0) {
+            /* Copy into key required amount. */
+            XMEMCPY(key, enc, keySz);
+        }
+    }
+    /* XOR out label. */
+    block[WC_SRTP_MAX_SALT - indexSz - 1] ^= label;
+
+    return ret;
+}
+
+/* Derive keys using SRTP KDF algorithm.
+ *
+ * SP 800-135 (RFC 3711).
+ *
+ * @param [in]  key      Key to use with encryption.
+ * @param [in]  keySz    Size of key in bytes.
+ * @param [in]  salt     Random non-secret value.
+ * @param [in]  saltSz   Size of random in bytes.
+ * @param [in]  kdrIdx   Key derivation rate. kdr = 0 when -1, otherwise
+ *                       kdr = 2^kdrIdx.
+ * @param [in]  index    Index value to XOR in.
+ * @param [out] key1     First key. Label value of 0x00.
+ * @param [in]  key1Sz   Size of first key in bytes.
+ * @param [out] key2     Second key. Label value of 0x01.
+ * @param [in]  key2Sz   Size of second key in bytes.
+ * @param [out] key3     Third key. Label value of 0x02.
+ * @param [in]  key3Sz   Size of third key in bytes.
+ * @return  BAD_FUNC_ARG when key or salt is NULL.
+ * @return  BAD_FUNC_ARG when key length is not 16, 24 or 32.
+ * @return  BAD_FUNC_ARG when saltSz is larger than 14.
+ * @return  BAD_FUNC_ARG when kdrIdx is less than -1 or larger than 24.
+ * @return  MEMORY_E on dynamic memory allocation failure.
+ * @return  0 on success.
+ */
+int wc_SRTP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
+        int kdrIdx, const byte* index, byte* key1, word32 key1Sz, byte* key2,
+        word32 key2Sz, byte* key3, word32 key3Sz)
+{
+    int ret = 0;
+    byte block[AES_BLOCK_SIZE];
+#ifdef WOLFSSL_SMALL_STACK
+    Aes* aes = NULL;
+#else
+    Aes aes[1];
+#endif
+
+    /* Validate parameters. */
+    if ((key == NULL) || (keySz > AES_256_KEY_SIZE) || (salt == NULL) ||
+            (saltSz > WC_SRTP_MAX_SALT) || (kdrIdx < -1) || (kdrIdx > 24)) {
+        ret = BAD_FUNC_ARG;
+    }
+
+#ifdef WOLFSSL_SMALL_STACK
+    if (ret == 0) {
+        aes = (Aes*)XMALLOC(sizeof(Aes), NULL, DYNAMIC_TYPE_CIPHER);
+        if (aes == NULL) {
+            ret = MEMORY_E;
+        }
+    }
+    if (aes != NULL)
+#endif
+    {
+        XMEMSET(aes, 0, sizeof(Aes));
+    }
+
+    /* Setup AES object. */
+    if (ret == 0)
+        ret = wc_AesInit(aes, NULL, INVALID_DEVID);
+    if (ret == 0)
+        ret = wc_AesSetKey(aes, key, keySz, NULL, AES_ENCRYPTION);
+
+    /* Calculate first block that can be used in each derivation. */
+    if (ret == 0)
+        wc_srtp_kdf_first_block(salt, saltSz, kdrIdx, index, 6, block);
+
+    /* Calculate first key if required. */
+    if ((ret == 0) && (key1 != NULL)) {
+        ret = wc_srtp_kdf_derive_key(block, 6, 0x00, key1, key1Sz, aes);
+    }
+    /* Calculate second key if required. */
+    if ((ret == 0) && (key2 != NULL)) {
+        ret = wc_srtp_kdf_derive_key(block, 6, 0x01, key2, key2Sz, aes);
+    }
+    /* Calculate third key if required. */
+    if ((ret == 0) && (key3 != NULL)) {
+        ret = wc_srtp_kdf_derive_key(block, 6, 0x02, key3, key3Sz, aes);
+    }
+
+    /* AES object memset so can always free. */
+    wc_AesFree(aes);
+#ifdef WOLFSSL_SMALL_STACK
+    XFREE(aes, NULL, DYNAMIC_TYPE_CIPHER);
+#endif
+    return ret;
+}
+
+/* Derive keys using SRTCP KDF algorithm.
+ *
+ * SP 800-135 (RFC 3711).
+ *
+ * @param [in]  key      Key to use with encryption.
+ * @param [in]  keySz    Size of key in bytes.
+ * @param [in]  salt     Random non-secret value.
+ * @param [in]  saltSz   Size of random in bytes.
+ * @param [in]  kdrIdx   Key derivation rate index. kdr = 0 when -1, otherwise
+ *                       kdr = 2^kdrIdx. See wc_SRTP_KDF_kdr_to_idx()
+ * @param [in]  index    Index value to XOR in.
+ * @param [out] key1     First key. Label value of 0x03.
+ * @param [in]  key1Sz   Size of first key in bytes.
+ * @param [out] key2     Second key. Label value of 0x04.
+ * @param [in]  key2Sz   Size of second key in bytes.
+ * @param [out] key3     Third key. Label value of 0x05.
+ * @param [in]  key3Sz   Size of third key in bytes.
+ * @return  BAD_FUNC_ARG when key or salt is NULL.
+ * @return  BAD_FUNC_ARG when key length is not 16, 24 or 32.
+ * @return  BAD_FUNC_ARG when saltSz is larger than 14.
+ * @return  BAD_FUNC_ARG when kdrIdx is less than -1 or larger than 24.
+ * @return  MEMORY_E on dynamic memory allocation failure.
+ * @return  0 on success.
+ */
+int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
+        int kdrIdx, const byte* index, byte* key1, word32 key1Sz, byte* key2,
+        word32 key2Sz, byte* key3, word32 key3Sz)
+{
+    int ret = 0;
+    byte block[AES_BLOCK_SIZE];
+#ifdef WOLFSSL_SMALL_STACK
+    Aes* aes = NULL;
+#else
+    Aes aes[1];
+#endif
+
+    /* Validate parameters. */
+    if ((key == NULL) || (keySz > AES_256_KEY_SIZE) || (salt == NULL) ||
+            (saltSz > WC_SRTP_MAX_SALT) || (kdrIdx < -1) || (kdrIdx > 24)) {
+        ret = BAD_FUNC_ARG;
+    }
+
+#ifdef WOLFSSL_SMALL_STACK
+    if (ret == 0) {
+        aes = (Aes*)XMALLOC(sizeof(Aes), NULL, DYNAMIC_TYPE_CIPHER);
+        if (aes == NULL) {
+            ret = MEMORY_E;
+        }
+    }
+    if (aes != NULL)
+#endif
+    {
+        XMEMSET(aes, 0, sizeof(Aes));
+    }
+
+    /* Setup AES object. */
+    if (ret == 0)
+        ret = wc_AesInit(aes, NULL, INVALID_DEVID);
+    if (ret == 0)
+        ret = wc_AesSetKey(aes, key, keySz, NULL, AES_ENCRYPTION);
+
+    /* Calculate first block that can be used in each derivation. */
+    if (ret == 0)
+        wc_srtp_kdf_first_block(salt, saltSz, kdrIdx, index, 4, block);
+
+    /* Calculate first key if required. */
+    if ((ret == 0) && (key1 != NULL)) {
+        ret = wc_srtp_kdf_derive_key(block, 4, 0x03, key1, key1Sz, aes);
+    }
+    /* Calculate second key if required. */
+    if ((ret == 0) && (key2 != NULL)) {
+        ret = wc_srtp_kdf_derive_key(block, 4, 0x04, key2, key2Sz, aes);
+    }
+    /* Calculate third key if required. */
+    if ((ret == 0) && (key3 != NULL)) {
+        ret = wc_srtp_kdf_derive_key(block, 4, 0x05, key3, key3Sz, aes);
+    }
+
+    /* AES object memset so can always free. */
+    wc_AesFree(aes);
+#ifdef WOLFSSL_SMALL_STACK
+    XFREE(aes, NULL, DYNAMIC_TYPE_CIPHER);
+#endif
+    return ret;
+}
+
+/* Converts a kdr value to an index to use in SRTP/SRTCP KDF API.
+ *
+ * @param [in] kdr  Key derivation rate to convert.
+ * @return  Key derivation rate as an index.
+ */
+int wc_SRTP_KDF_kdr_to_idx(word32 kdr)
+{
+    int idx = -1;
+
+    /* Keep shifting value down and incrementing index until top bit is gone. */
+    while (kdr != 0) {
+        kdr >>= 1;
+        idx++;
+    }
+
+    /* Index of top bit set. */
+    return idx;
+}
+#endif /* WC_SRTP_KDF */
 
 #endif /* NO_KDF */

--- a/wolfssl/wolfcrypt/kdf.h
+++ b/wolfssl/wolfcrypt/kdf.h
@@ -105,6 +105,21 @@ WOLFSSL_API int wc_SSH_KDF(byte hashId, byte keyId,
 
 #endif /* WOLFSSL_WOLFSSH */
 
+#ifdef WC_SRTP_KDF
+/* Maximum length of salt that can be used with SRTP/SRTCP. */
+#define WC_SRTP_MAX_SALT    14
+
+WOLFSSL_API int wc_SRTP_KDF(const byte* key, word32 keySz, const byte* salt,
+    word32 saltSz, int kdrIdx, const byte* index, byte* key1, word32 key1Sz,
+    byte* key2, word32 key2Sz, byte* key3, word32 key3Sz);
+WOLFSSL_API int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt,
+    word32 saltSz, int kdrIdx, const byte* index, byte* key1, word32 key1Sz,
+    byte* key2, word32 key2Sz, byte* key3, word32 key3Sz);
+
+WOLFSSL_API int wc_SRTP_KDF_kdr_to_idx(word32 kdr);
+
+#endif /* WC_SRTP_KDF */
+
 #ifdef __cplusplus
     } /* extern "C" */
 #endif


### PR DESCRIPTION
# Description

Add implementation of SRTP KDF and SRTCP KDF.
One shot APIs compatible with SP 800-135 and ACVP testing. Tests added to test.c.
Benchmarking added.
Doxygen added.

# Testing

./configure --enable-srtp-kdf
Tests added to test.c

# Checklist

 - [x] added tests
 - [x updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
