### PR TITLE
Add error reporting to loadX509orX509REQFromBuffer

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -5203,7 +5203,7 @@ static WOLFSSL_X509* loadX509orX509REQFromBuffer(
     const unsigned char* buf, int sz, int format, int type)
 {
 
-    int ret;
+    int ret = 0;
     WOLFSSL_X509* x509 = NULL;
     DerBuffer* der = NULL;
 
@@ -5211,7 +5211,8 @@ static WOLFSSL_X509* loadX509orX509REQFromBuffer(
 
     if (format == WOLFSSL_FILETYPE_PEM) {
     #ifdef WOLFSSL_PEM_TO_DER
-        if (PemToDer(buf, sz, type, &der, NULL, NULL, NULL) != 0) {
+        ret = PemToDer(buf, sz, type, &der, NULL, NULL, NULL);
+        if (ret != 0) {
             FreeDer(&der);
         }
     #else
@@ -5237,19 +5238,27 @@ static WOLFSSL_X509* loadX509orX509REQFromBuffer(
     #ifdef WOLFSSL_SMALL_STACK
         cert = (DecodedCert*)XMALLOC(sizeof(DecodedCert), NULL,
                                      DYNAMIC_TYPE_DCERT);
-        if (cert != NULL)
+        if (cert == NULL) {
+            ret = MEMORY_ERROR;
+        }
+        else
     #endif
         {
             InitDecodedCert(cert, der->buffer, der->length, NULL);
-            if (ParseCertRelative(cert, type, 0, NULL) == 0) {
+            ret = ParseCertRelative(cert, type, 0, NULL);
+            if (ret == 0) {
                 x509 = (WOLFSSL_X509*)XMALLOC(sizeof(WOLFSSL_X509), NULL,
                                                              DYNAMIC_TYPE_X509);
                 if (x509 != NULL) {
                     InitX509(x509, 1, NULL);
-                    if (CopyDecodedToX509(x509, cert) != 0) {
+                    ret = CopyDecodedToX509(x509, cert);
+                    if (ret != 0) {
                         wolfSSL_X509_free(x509);
                         x509 = NULL;
                     }
+                }
+                else {
+                    ret = MEMORY_ERROR;
                 }
             }
 
@@ -5260,6 +5269,10 @@ static WOLFSSL_X509* loadX509orX509REQFromBuffer(
         }
 
         FreeDer(&der);
+    }
+
+    if (ret != 0) {
+        WOLFSSL_ERROR(ret);
     }
 
     return x509;


### PR DESCRIPTION
# Description

If there is a failure parsing a certificate from the bio, we should be able to get a reason for the error (either as a return code, or another mechanism such as ERR_get_error).

Fixes #6890 

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
