### PR TITLE
Fix WOLFSSL_SYS_CA_CERTS bug on Apple devices

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -14223,7 +14223,9 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     /* If we are using native Apple CA validation, it is okay
                      * for a CA cert to fail validation here, as we will verify
                      * the entire chain when we hit the peer (leaf) cert */
-                    if (ssl->ctx->doAppleNativeCertValidationFlag) {
+                    if ((ssl->ctx->doAppleNativeCertValidationFlag)
+                        && (ret == ASN_NO_SIGNER_E)) {
+
                         WOLFSSL_MSG("Bypassing errors to allow for Apple native"
                                     " CA validation");
                         ret = 0; /* clear errors and continue */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -8576,6 +8576,12 @@ int wolfSSL_CTX_load_system_CA_certs(WOLFSSL_CTX* ctx)
     ctx->doAppleNativeCertValidationFlag = 1;
     ret = WOLFSSL_SUCCESS;
     loaded = 1;
+
+#if FIPS_VERSION_GE(2,0) /* Gate back to cert 3389 FIPS modules */
+#warning "Cryptographic operations may occur outside the FIPS module boundary" \
+         "Please review FIPS claims for cryptography on this Apple device"
+#endif /* FIPS_VERSION_GE(2,0) */
+
 #else
 /* HAVE_SECURITY_SECXXX_H macros are set by autotools or CMake when searching
  * system for the required SDK headers. If building with user_settings.h, you


### PR DESCRIPTION
## Description
Fixes bug where `WOLFSSL_SYS_CA_CERTS` with `WOLFSSL_APPLE_NATIVE_CERT_VALIDATION` can cause invalid certificates (e.g. bad signature) to be accepted as valid, as well as cause potentially valid intermediate CAs to be skipped over during parsing. 

The erroneous behavior was called by blindly overriding ALL errors if `ssl->ctx->doAppleNativeCertValidationFlag` was set (attempting to defer to the native trust eval routine), which actually prevented the cert chain from being evaluated against the native trust when the leaf cert was encountered (it was only called if there was an error).

The correct behavior is that the cert chain should only be checked using Apple trust APIs at the end of the certificate chain check if the chain fails to authenticate against loaded/trusted certs (e.g. `ASN_NO_SIGNER_E`). Things like expired or invalid signatures, or other ASN issues should still trigger a failure. 

## Reproduce
To reproduce the worst case scenario, run the following client/server test. You should see the connection succeed, which should NOT happen.

```
# server
./examples/server/server -v 3 -l DHE-RSA-AES128-GCM-SHA256 -c ./certs/test/server-cert-rsa-badsig.pem

# client
examples/client/client -v 3 -l DHE-RSA-AES128-GCM-SHA256 --sys-ca-certs
```

Follow up to: #6869  