### PR TITLE
TLS 1.3: compiling with WOLFSSL_PSK_ONE_ID fix

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -6129,12 +6129,12 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
 
     /* Refine list for PSK processing. */
     RefineSuites(ssl, clSuites);
-    /* set after refineSuites, to avoid taking a stale ptr to ctx->Suites */
-    suites = WOLFSSL_SUITES(ssl);
 #ifndef WOLFSSL_PSK_ONE_ID
     if (usingPSK == NULL)
         return BAD_FUNC_ARG;
 
+    /* set after refineSuites, to avoid taking a stale ptr to ctx->Suites */
+    suites = WOLFSSL_SUITES(ssl);
     /* Server list has only common suites from refining in server or client
      * order. */
     for (i = 0; !(*usingPSK) && i < suites->suiteSz; i += 2) {


### PR DESCRIPTION
# Description

Move use of 'suites' into non-WOLFSSL_PSK_ONE_ID path as variable declared and used only in that case.

# Testing

./configure '--enable-tls13' '--enable-psk' 'C_EXTRA_FLAGS=-DWOLFSSL_PSK_ONE_ID'

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
