### PR TITLE
implement aes-mp kdf function for use in internal project

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2479,6 +2479,17 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_AES_OFB -DWOLFSSL_AES_DIRECT"
 fi
 
+# AES-MP KDF
+AC_ARG_ENABLE([aesmp],
+    [AS_HELP_STRING([--enable-aesmp],[Enable wolfSSL AES-MP KDF support (default: disabled)])],
+    [ ENABLED_AESMP=$enableval ],
+    [ ENABLED_AESMP=no ]
+    )
+
+if test "$ENABLED_AESMP" = "yes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_AES_MP -DWOLFSSL_AES_DIRECT -DHAVE_AES_ECB"
+fi
 
 # AES-CFB
 AC_ARG_ENABLE([aescfb],

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -48752,7 +48752,6 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes_siv_test(void)
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes_mp_test(void)
 {
     int ret;
-    int blockSz = AES_BLOCK_SIZE;
     byte messageZero[AES_BLOCK_SIZE] = {0};
     /*
     byte testVectorKey[AES_BLOCK_SIZE] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
@@ -48763,26 +48762,25 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes_mp_test(void)
         0x01, 0x53, 0x48, 0x45, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0xb0};
     byte output[AES_BLOCK_SIZE];
-    byte testVectorOutput[AES_BLOCK_SIZE] = {0x11, 0x8a, 0x46, 0x44, 0x7a, 0x77, 0x0d, 0x87, 0x82, 0x8a,
-        0x69, 0xc2, 0x22, 0xe2, 0xd1, 0x7e};
+    byte testVectorOutput[AES_BLOCK_SIZE] = {0x11, 0x8a, 0x46, 0x44, 0x7a, 0x77,
+        0x0d, 0x87, 0x82, 0x8a, 0x69, 0xc2, 0x22, 0xe2, 0xd1, 0x7e};
     /* check bad func args */
-    ret = wc_AesMp(NULL, blockSz * 2, messageZero, blockSz, output);
+    ret = wc_AesMp16(NULL, sizeof(testVectorInput), messageZero, output);
     if (ret != BAD_FUNC_ARG)
         return WC_TEST_RET_ENC_NC;
-    ret = wc_AesMp(testVectorInput, 0, messageZero, blockSz, output);
+    ret = wc_AesMp16(testVectorInput, 0, messageZero, output);
     if (ret != BAD_FUNC_ARG)
         return WC_TEST_RET_ENC_NC;
-    ret = wc_AesMp(testVectorInput, blockSz * 2, NULL, blockSz, output);
+    ret = wc_AesMp16(testVectorInput, sizeof(testVectorInput), NULL, output);
     if (ret != BAD_FUNC_ARG)
         return WC_TEST_RET_ENC_NC;
-    ret = wc_AesMp(testVectorInput, blockSz * 2, messageZero, 0, output);
-    if (ret != BAD_FUNC_ARG)
-        return WC_TEST_RET_ENC_NC;
-    ret = wc_AesMp(testVectorInput, blockSz * 2, messageZero, blockSz, NULL);
+    ret = wc_AesMp16(testVectorInput, sizeof(testVectorInput), messageZero,
+        NULL);
     if (ret != BAD_FUNC_ARG)
         return WC_TEST_RET_ENC_NC;
     /* try the actual test vector */
-    ret = wc_AesMp(testVectorInput, blockSz * 2, messageZero, blockSz, output);
+    ret = wc_AesMp16(testVectorInput, sizeof(testVectorInput), messageZero,
+        output);
     if (ret != 0)
         return WC_TEST_RET_ENC_NC;
     /* compare to test vector */

--- a/wolfssl/wolfcrypt/kdf.h
+++ b/wolfssl/wolfcrypt/kdf.h
@@ -106,8 +106,7 @@ WOLFSSL_API int wc_SSH_KDF(byte hashId, byte keyId,
 #endif /* WOLFSSL_WOLFSSH */
 
 #if defined(HAVE_AES_ECB) && defined(WOLFSSL_AES_MP)
-WOLFSSL_API int wc_AesMp(byte* in, word32 inSz, byte* messageZero,
-    word32 blockSz, byte* out);
+WOLFSSL_API int wc_AesMp16(byte* in, word32 inSz, byte* messageZero, byte* out);
 #endif
 
 #ifdef __cplusplus

--- a/wolfssl/wolfcrypt/kdf.h
+++ b/wolfssl/wolfcrypt/kdf.h
@@ -105,6 +105,11 @@ WOLFSSL_API int wc_SSH_KDF(byte hashId, byte keyId,
 
 #endif /* WOLFSSL_WOLFSSH */
 
+#if defined(HAVE_AES_ECB) && defined(WOLFSSL_AES_MP)
+WOLFSSL_API int wc_AesMp(byte* in, word32 inSz, byte* messageZero,
+    word32 blockSz, byte* out);
+#endif
+
 #ifdef __cplusplus
     } /* extern "C" */
 #endif
@@ -112,4 +117,3 @@ WOLFSSL_API int wc_SSH_KDF(byte hashId, byte keyId,
 #endif /* WOLF_CRYPT_KDF_H */
 
 #endif /* NO_KDF */
-


### PR DESCRIPTION
# Description

Adds AES-MP algorithm, Miyaguchi–Preneel is the compression function and AES-ECB is the block cipher used. Enabled with --enable-aesmp.

# Testing

Added a test that uses a known test vector and checks for bad function arguments

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation