### PR TITLE
Fixes for PKCS w/out RSA and Cert/CSR signing with unknown OID

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -27644,6 +27644,7 @@ static int test_wc_PKCS7_EncodeDecodeEnvelopedData(void)
         tmpBytePtr = pkcs7->singleCert;
         pkcs7->singleCert = NULL;
     }
+  #ifndef NO_RSA
     #if defined(NO_PKCS7_STREAM)
     /* when none streaming mode is used and PKCS7 is in bad state buffer error
      * is returned from kari parse which gets set to bad func arg */
@@ -27655,6 +27656,7 @@ static int test_wc_PKCS7_EncodeDecodeEnvelopedData(void)
         (word32)sizeof(output), decoded, (word32)sizeof(decoded)),
         ASN_PARSE_E);
     #endif
+  #endif /* !NO_RSA */
     if (pkcs7 != NULL) {
         pkcs7->singleCert = tmpBytePtr;
     }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -29007,6 +29007,12 @@ int AddSignature(byte* buf, int bodySz, const byte* sig, int sigSz,
         /* Set signature OID and signature data. */
         SetASN_OID(&dataASN[SIGASN_IDX_SIGALGO_OID], (word32)sigAlgoType,
                    oidSigType);
+        if (dataASN[SIGASN_IDX_SIGALGO_OID].data.buffer.data == NULL) {
+            /* The OID was not found or compiled in! */
+            ret = ASN_UNKNOWN_OID_E;
+        }
+    }
+    if (ret == 0) {
         if (IsSigAlgoECC((word32)sigAlgoType)) {
             /* ECDSA and EdDSA doesn't have NULL tagged item. */
             dataASN[SIGASN_IDX_SIGALGO_NULL].noOut = 1;


### PR DESCRIPTION
# Description

* Fix for build PKCS7 with RSA disabled.
* Fix for adding signature where OID is not found. Currently our `AddSignature` function will add without OID, which is invalid. For example RSA is disabled and CSR tries to use `CTC_SHA256wRSA`. The `wc_SignCert_ex` will succeed and report success, but the CSR/Cert will be invalid (missing sigType OID).

Fixes ZD 16675

# Testing

```
./configure --enable-pkcs7 --disable-rsa && make check
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
