### PR TITLE
20231021-fix-null-derefs

### DIFF
--- a/examples/pem/pem.c
+++ b/examples/pem/pem.c
@@ -151,7 +151,7 @@ static int pemApp_ReadFile(FILE* fp, unsigned char** pdata, word32* plen)
  * @return  0 on success.
  * @return  1 on failure.
  */
-static int WriteFile(FILE* fp, unsigned char* data, word32 len)
+static int WriteFile(FILE* fp, const char* data, word32 len)
 {
     int ret = 0;
 
@@ -995,7 +995,7 @@ int main(int argc, char* argv[])
     }
     if (ret == 0) {
         /* Write out PEM. */
-        ret = WriteFile(out_file, out, out_len);
+        ret = WriteFile(out_file, out ? (const char *)out : "", out_len);
         if (ret != 0) {
             fprintf(stderr, "Could not write file\n");
         }

--- a/tests/api.c
+++ b/tests/api.c
@@ -26690,32 +26690,32 @@ static int LoadPKCS7SignedDataCerts(
                 ExpectIntGT(*intCARootSz, 0);
 
                 ExpectTrue((fp = XFOPEN(intCA1RSA, "rb")) != XBADFILE);
-                *intCA1Sz = (word32)XFREAD(intCA1, 1, *intCA1Sz, fp);
                 if (fp != XBADFILE) {
+                    *intCA1Sz = (word32)XFREAD(intCA1, 1, *intCA1Sz, fp);
                     XFCLOSE(fp);
                     fp = XBADFILE;
                 }
                 ExpectIntGT(*intCA1Sz, 0);
 
                 ExpectTrue((fp = XFOPEN(intCA2RSA, "rb")) != XBADFILE);
-                *intCA2Sz = (word32)XFREAD(intCA2, 1, *intCA2Sz, fp);
                 if (fp != XBADFILE) {
+                    *intCA2Sz = (word32)XFREAD(intCA2, 1, *intCA2Sz, fp);
                     XFCLOSE(fp);
                     fp = XBADFILE;
                 }
                 ExpectIntGT(*intCA2Sz, 0);
 
                 ExpectTrue((fp = XFOPEN(intServCertRSA, "rb")) != XBADFILE);
-                *certSz = (word32)XFREAD(cert, 1, *certSz, fp);
                 if (fp != XBADFILE) {
+                    *certSz = (word32)XFREAD(cert, 1, *certSz, fp);
                     XFCLOSE(fp);
                     fp = XBADFILE;
                 }
                 ExpectIntGT(*certSz, 0);
 
                 ExpectTrue((fp = XFOPEN(intServKeyRSA, "rb")) != XBADFILE);
-                *keySz = (word32)XFREAD(key, 1, *keySz, fp);
                 if (fp != XBADFILE) {
+                    *keySz = (word32)XFREAD(key, 1, *keySz, fp);
                     XFCLOSE(fp);
                     fp = XBADFILE;
                 }
@@ -26734,16 +26734,16 @@ static int LoadPKCS7SignedDataCerts(
                 XMEMCPY(cert, client_cert_der_1024, *certSz);
             #else
                 ExpectTrue((fp = XFOPEN(cli1024Key, "rb")) != XBADFILE);
-                *keySz = (word32)XFREAD(key, 1, *keySz, fp);
                 if (fp != XBADFILE) {
+                    *keySz = (word32)XFREAD(key, 1, *keySz, fp);
                     XFCLOSE(fp);
                     fp = XBADFILE;
                 }
                 ExpectIntGT(*keySz, 0);
 
                 ExpectTrue((fp = XFOPEN(cli1024Cert, "rb")) != XBADFILE);
-                *certSz = (word32)XFREAD(cert, 1, *certSz, fp);
                 if (fp != XBADFILE) {
+                    *certSz = (word32)XFREAD(cert, 1, *certSz, fp);
                     XFCLOSE(fp);
                     fp = XBADFILE;
                 }
@@ -26756,40 +26756,41 @@ static int LoadPKCS7SignedDataCerts(
         case ECC_TYPE:
             if (useIntermediateCertChain == 1) {
                 ExpectTrue((fp = XFOPEN(intCARootECC, "rb")) != XBADFILE);
-                *intCARootSz = (word32)XFREAD(intCARoot, 1, *intCARootSz, fp);
                 if (fp != XBADFILE) {
+                    *intCARootSz = (word32)XFREAD(intCARoot, 1, *intCARootSz,
+                                                  fp);
                     XFCLOSE(fp);
                     fp = XBADFILE;
                 }
                 ExpectIntGT(*intCARootSz, 0);
 
                 ExpectTrue((fp = XFOPEN(intCA1ECC, "rb")) != XBADFILE);
-                *intCA1Sz = (word32)XFREAD(intCA1, 1, *intCA1Sz, fp);
                 if (fp != XBADFILE) {
+                    *intCA1Sz = (word32)XFREAD(intCA1, 1, *intCA1Sz, fp);
                     XFCLOSE(fp);
                     fp = XBADFILE;
                 }
                 ExpectIntGT(*intCA1Sz, 0);
 
                 ExpectTrue((fp = XFOPEN(intCA2ECC, "rb")) != XBADFILE);
-                *intCA2Sz = (word32)XFREAD(intCA2, 1, *intCA2Sz, fp);
                 if (fp != XBADFILE) {
+                    *intCA2Sz = (word32)XFREAD(intCA2, 1, *intCA2Sz, fp);
                     XFCLOSE(fp);
                     fp = XBADFILE;
                 }
                 ExpectIntGT(*intCA2Sz, 0);
 
                 ExpectTrue((fp = XFOPEN(intServCertECC, "rb")) != XBADFILE);
-                *certSz = (word32)XFREAD(cert, 1, *certSz, fp);
                 if (fp != XBADFILE) {
+                    *certSz = (word32)XFREAD(cert, 1, *certSz, fp);
                     XFCLOSE(fp);
                     fp = XBADFILE;
                 }
                 ExpectIntGT(*certSz, 0);
 
                 ExpectTrue((fp = XFOPEN(intServKeyECC, "rb")) != XBADFILE);
-                *keySz = (word32)XFREAD(key, 1, *keySz, fp);
                 if (fp != XBADFILE) {
+                    *keySz = (word32)XFREAD(key, 1, *keySz, fp);
                     XFCLOSE(fp);
                     fp = XBADFILE;
                 }
@@ -26803,16 +26804,16 @@ static int LoadPKCS7SignedDataCerts(
                 XMEMCPY(cert, cliecc_cert_der_256, *certSz);
             #else
                 ExpectTrue((fp = XFOPEN(cliEccKey, "rb")) != XBADFILE);
-                *keySz = (word32)XFREAD(key, 1, *keySz, fp);
                 if (fp != XBADFILE) {
+                    *keySz = (word32)XFREAD(key, 1, *keySz, fp);
                     XFCLOSE(fp);
                     fp = XBADFILE;
                 }
                 ExpectIntGT(*keySz, 0);
 
                 ExpectTrue((fp = XFOPEN(cliEccCert, "rb")) != XBADFILE);
-                *certSz = (word32)XFREAD(cert, 1, *certSz, fp);
                 if (fp != XBADFILE) {
+                    *certSz = (word32)XFREAD(cert, 1, *certSz, fp);
                     XFCLOSE(fp);
                     fp = XBADFILE;
                 }


### PR DESCRIPTION
fix null pointer derefs in `examples/pem/pem.c`:`pemApp_ReadFile()` and `tests/api.c`:`LoadPKCS7SignedDataCerts()` detected by `clang-tidy` `18.0.0gite6e90840`.

tested with `wolfssl-multi-test.sh ... all-c89-clang-tidy clang-tidy-asn-template-sp-all-small-stack all-WOLFSSL_CALLBACKS-clang-tidy clang-tidy-Customer-CFG-7 clang-tidy-all-sp-all clang-tidy-all-intelasm clang-tidy-all-async-quic clang-tidy-fips-140-3-defaults clang-tidy-fips-140-3-all clang-tidy-fips-140-3-pilot-defaults clang-tidy-fips-140-3-pilot-all clang-tidy-fips-140-3-dev-defaults clang-tidy-fips-140-3-dev-defaults-no-sha-1 clang-tidy-fips-140-3-dev-all clang-tidy-fips-140-3-dev-all-crypto-no-sha-1 clang-tidy-all-crypto-no-sha-1 check-self check-file-modes check-source-text check-shell-scripts check-configure all-gcc-c99 all-gcc-c99-asn-original cryptonly-opensslextra-gcc-c99 all-gcc-c89 allcryptonly-Wconversion-intelasm-build allcryptonly-c89-Wconversion-m32-build all-g++`
