### PR TITLE
exercise --sys-ca-certs optionin external.test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1723,10 +1723,16 @@ if(WOLFSSL_SYS_CA_CERTS)
         message("Can't enable system CA certs without a filesystem.")
         override_cache(WOLFSSL_SYS_CA_CERTS "no")
     elseif(APPLE)
+        # Headers used for MacOS default system CA certs behavior. Only MacOS SDK will have this header
         check_include_file("Security/SecTrustSettings.h" HAVE_SECURITY_SECTRUSTSETTINGS_H)
+        # Headers used for Apple native cert validation. All device SDKs should have these headers
         check_include_file("Security/SecCertificate.h" HAVE_SECURITY_SECCERTIFICATE_H)
         check_include_file("Security/SecTrust.h" HAVE_SECURITY_SECTRUST_H)
         check_include_file("Security/SecPolicy.h" HAVE_SECURITY_SECPOLICY_H)
+        # Either Security/SecTrustSettings (for MacOS cert loading), or the
+        # trio of Security/SecCertificate.h, Security/SecTrust.h, and
+        # Security/SecPolicy.h (for native trust APIs on other apple devices)
+        # must be present. Default to SecTrustSettings method on MacOS.
         if(HAVE_SECURITY_SECTRUSTSETTINGS_H OR (HAVE_SECURITY_SECCERTIFICATE_H
                                                 AND HAVE_SECURITY_SECTRUST_H
                                                 AND HAVE_SECURITY_SECPOLICY_H))
@@ -1739,6 +1745,14 @@ if(WOLFSSL_SYS_CA_CERTS)
                     message(FATAL_ERROR "Can't enable system CA certs without Security framework.")
                 endif()
             endif()
+
+            # MacOS should not use native cert validation by default, but other apple devices should.
+            if(NOT HAVE_SECURITY_SECTRUSTSETTINGS_H AND HAVE_SECURITY_SECCERTIFICATE_H
+                                                    AND HAVE_SECURITY_SECTRUST_H
+                                                    AND HAVE_SECURITY_SECPOLICY_H)
+                list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_APPLE_NATIVE_CERT_VALIDATION")
+            endif()
+
         else()
             message(FATAL_ERROR "Can't enable system CA certs without Apple Security.framework headers.")
         endif()

--- a/configure.ac
+++ b/configure.ac
@@ -8351,26 +8351,30 @@ then
 
     case $host_os in
         *darwin*)
-            # Creates the HAVE_SECURITY_SECXXX_H macros in config.h
+            # Headers used for MacOS default system CA certs behavior. Only MacOS SDK will have this header
             AC_CHECK_HEADERS([Security/SecTrustSettings.h])
+            # Headers used for Apple native cert validation. All device SDKs should have these headers
             AC_CHECK_HEADERS([Security/SecCertificate.h])
             AC_CHECK_HEADERS([Security/SecTrust.h])
             AC_CHECK_HEADERS([Security/SecPolicy.h])
             # Either Security/SecTrustSettings (for MacOS cert loading), or the
             # trio of Security/SecCertificate.h, Security/SecTrust.h, and
-            # Security/SecPolicy.h (for native trust APIs other apple devices)
-            # must be present
-            AS_IF([test -n "$ac_cv_header_Security_SecTrustSettings_h" \
-                   || (test -n "$ac_cv_header_Security_SecCertificate_h" \
-                       && test -n "$ac_cv_header_Security_SecTrust_h" \
-                       && test -n "$ac_cv_header_Security_SecPolicy_h")],
+            # Security/SecPolicy.h (for native trust APIs on other apple devices)
+            # must be present. Default to SecTrustSettings method on MacOS.
+            AS_IF([test "$ac_cv_header_Security_SecTrustSettings_h" = "yes" \
+                   || (test "$ac_cv_header_Security_SecCertificate_h" = "yes" \
+                       && test "$ac_cv_header_Security_SecTrust_h" = "yes" \
+                       && test "$ac_cv_header_Security_SecPolicy_h" = "yes")],
+            [
+                LDFLAGS="$LDFLAGS -framework CoreFoundation -framework Security"
+                AS_IF([test "$ac_cv_header_Security_SecTrustSettings_h" != "yes"],
                 [
-                    LDFLAGS="$LDFLAGS -framework CoreFoundation -framework Security"
-                ],
-                [
-                    AC_MSG_ERROR([Unable to find Apple Security.framework headers])
-                ]
-            )
+                  AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_APPLE_NATIVE_CERT_VALIDATION"
+                ])
+            ],
+            [
+              AC_MSG_ERROR([Unable to find Apple Security.framework headers])
+            ])
             ;;
     esac
 fi

--- a/scripts/external.test
+++ b/scripts/external.test
@@ -45,4 +45,15 @@ RESULT=$?
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nClient connection failed" && exit 1
 
+# test again, but using system CA certs to verify the server if support is enabled.
+# We don't want to use --sys-ca-certs with static memory, as we don't know how
+# much memory will be required to store an unbounded number of certs
+BUILD_FLAGS="$(./examples/client/client '-#')"
+if echo "$BUILD_FLAGS" | grep -q "WOLFSSL_SYS_CA_CERTS" && ! echo "$BUILD_FLAGS" | grep -q "WOLFSSL_STATIC_MEMORY"; then
+    echo -e "\nConnecting using WOLFSSL_SYS_CA_CERTS..."
+    ./examples/client/client -X -C -h $server -p 443 -g --sys-ca-certs
+    RESULT=$?
+    [ $RESULT -ne 0 ] && echo -e "\n\nClient connection failed when using WOLFSSL_SYS_CA_CERTS" && exit 1
+fi
+
 exit 0

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -8567,10 +8567,7 @@ int wolfSSL_CTX_load_system_CA_certs(WOLFSSL_CTX* ctx)
      * load them manually into wolfSSL "the old way". Accessiblity of this API
      * is indicated by the presence of the Security/SecTrustSettings.h header */
     ret = LoadSystemCaCertsMac(ctx, &loaded);
-#elif defined(WOLFSSL_APPLE_NATIVE_CERT_VALIDATION) \
-   || (defined(HAVE_SECURITY_SECCERTIFICATE_H) \
-       && defined(HAVE_SECURITY_SECTRUST_H)    \
-       && defined(HAVE_SECURITY_SECPOLICY_H))
+#elif defined(WOLFSSL_APPLE_NATIVE_CERT_VALIDATION)
     /* For other Apple devices, Apple has removed the ability to obtain
      * certificates from the trust store, so we can't use wolfSSL's built-in
      * certificate validation mechanisms anymore. We instead must call into the


### PR DESCRIPTION
# Description
- Adds `--sys-ca-certs` to client in `external.test`, so make check and CI tests can now exercise it ([PRB-external-tests now runs on a MacOS node](https://github.com/wolfSSL/testing/pull/519), so the new apple native cert validation can be tested)
- Simplifies macro inclusion logic in source code so user settings builds only need to define `WOLFSSL_APPLE_NATIVE_CERT_VALIDATION` instead of defining the `HAVE_XXX` header detection macros
- Adds comments in CMake/configure.ac