### PR TITLE
20231025-sp_to_unsigned_bin_len_ct-Wconversion-cast

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -17813,7 +17813,7 @@ int sp_to_unsigned_bin_len_ct(const sp_int* a, byte* out, int outSz)
             d = a->dp[i];
             /* Place each byte of a digit into the buffer. */
             for (b = 0; (j >= 0) && (b < SP_WORD_SIZEOF); b++) {
-                out[j--] = (byte)(d & mask);
+                out[j--] = (byte)((sp_digit)d & mask);
                 d >>= 8;
             }
             mask &= (sp_digit)0 - (i < a->used - 1);


### PR DESCRIPTION
`wolfcrypt/src/sp_int.c`: add cast in `sp_to_unsigned_bin_len_ct()` to mollify `-Wconversion`.

```
wolfcrypt/src/sp_int.c: In function ‘sp_to_unsigned_bin_len_ct’:
fcf1406675 (<sean@wolfssl.com> 2023-10-20 10:13:50 +1000 17816)                 out[j--] = (byte)(d & mask);
wolfcrypt/src/sp_int.c:17816:37: error: conversion to ‘long unsigned int’ from ‘sp_digit’ {aka ‘long int’} may change the sign of the result [-Werror=sign-conversion]
17816 |                 out[j--] = (byte)(d & mask);
      |                                     ^
```

tested with `wolfssl-multi-test.sh ... super-quick-check`.
