### PR TITLE
remove packaging status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-<a href="https://repology.org/project/wolfssl/versions">
-    <img src="https://repology.org/badge/vertical-allrepos/wolfssl.svg?exclude_unsupported=1" alt="Packaging status" align="right">
-</a>
-
 # wolfSSL Embedded SSL/TLS Library
 
 The [wolfSSL embedded SSL library](https://www.wolfssl.com/products/wolfssl/) 


### PR DESCRIPTION
Removing until badge status is cleaned up and possible alternatives found.