### PR TITLE
Fixes for the Zephyr port

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -7,10 +7,13 @@ jobs:
   run_test:
     name: Build and run
     strategy:
+      fail-fast: false
       matrix:
         config:
           - zephyr-ref: v3.4.0
             zephyr-sdk: 0.16.1
+          - zephyr-ref: v3.5.0
+            zephyr-sdk: 0.16.3
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 15

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -3506,20 +3506,6 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
      * extern int myRngFunc(byte* output, word32 sz);
      */
 
-#elif defined(WOLFSSL_SAFERTOS) || defined(WOLFSSL_LEANPSK) || \
-      defined(WOLFSSL_IAR_ARM)  || defined(WOLFSSL_MDK_ARM) || \
-      defined(WOLFSSL_uITRON4)  || defined(WOLFSSL_uTKERNEL2) || \
-      defined(WOLFSSL_LPC43xx)  || defined(NO_STM32_RNG) || \
-      defined(MBED)             || defined(WOLFSSL_EMBOS) || \
-      defined(WOLFSSL_GENSEED_FORTEST) || defined(WOLFSSL_CHIBIOS) || \
-      defined(WOLFSSL_CONTIKI)  || defined(WOLFSSL_AZSPHERE)
-
-    /* these platforms do not have a default random seed and
-       you'll need to implement your own wc_GenerateSeed or define via
-       CUSTOM_RAND_GENERATE_BLOCK */
-
-    #define USE_TEST_GENSEED
-
 #elif defined(WOLFSSL_ZEPHYR)
 
         #include <version.h>
@@ -3629,6 +3615,20 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         }
         return ret;
     }
+
+#elif defined(WOLFSSL_SAFERTOS) || defined(WOLFSSL_LEANPSK) || \
+      defined(WOLFSSL_IAR_ARM)  || defined(WOLFSSL_MDK_ARM) || \
+      defined(WOLFSSL_uITRON4)  || defined(WOLFSSL_uTKERNEL2) || \
+      defined(WOLFSSL_LPC43xx)  || defined(NO_STM32_RNG) || \
+      defined(MBED)             || defined(WOLFSSL_EMBOS) || \
+      defined(WOLFSSL_GENSEED_FORTEST) || defined(WOLFSSL_CHIBIOS) || \
+      defined(WOLFSSL_CONTIKI)  || defined(WOLFSSL_AZSPHERE)
+
+    /* these platforms do not have a default random seed and
+       you'll need to implement your own wc_GenerateSeed or define via
+       CUSTOM_RAND_GENERATE_BLOCK */
+
+    #define USE_TEST_GENSEED
 
 #elif defined(NO_DEV_RANDOM)
 

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -3522,7 +3522,14 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 
 #elif defined(WOLFSSL_ZEPHYR)
 
+        #include <version.h>
+
+    #if KERNEL_VERSION_NUMBER >= 0x30500
+        #include <zephyr/random/random.h>
+    #else
         #include <zephyr/random/rand32.h>
+    #endif
+
     #ifndef _POSIX_C_SOURCE
         #include <zephyr/posix/time.h>
     #else

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -985,6 +985,14 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
         #include <time.h>
     #endif
 
+    #if defined(CONFIG_RTC)
+        #if defined(CONFIG_PICOLIBC) || defined(CONFIG_NEWLIB_LIBC)
+            #include <zephyr/drivers/rtc.h>
+        #else
+            #warning "RTC support needs picolibc or newlib (nano)"
+        #endif
+    #endif
+
     time_t z_time(time_t *timer);
 
     #define XTIME(tl)       z_time((tl))

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -982,7 +982,7 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #ifndef _POSIX_C_SOURCE
         #include <zephyr/posix/time.h>
     #else
-        #include <sys/time.h>
+        #include <time.h>
     #endif
 
     time_t z_time(time_t *timer);


### PR DESCRIPTION
Hi there, 

This PR contains fixes for the Zephyr OS port. I implemented them while getting WolfSSL running on an STM32H573I discovery board. 
* The first commit fixes a deprecation warning in the current version of Zephyr (V 3.5).
* The second commit fixes a (probably) wrong include in wc_port.h that resulted in compile errors due to redefinition of some types and methods (this also resulted in the Zephyr WolfSSL samples all not properly compiling with the latest version).
* The third commit adds support for reading the wall clock via the Zephyr RTC interface. In case no RTC time is available (either because RTC support is disabled or no valid time is set), we fall back to the old implementation, which gives us the relative time since boot. With the RTC time, we are now able to properly validate certificates.
* The forth commit deals with the assembly optimizations for the Cortex-M architecture. When compiling with `SP_MATH` and `SP_ARM_CORTEX_M_ASM`, we get compilation errors, as the Zephyr SDK gcc compiler doesn't recognize the `asm` keyword (it needs `__asm__`). Hence, when the Zephyr port is enabled, we add a makro to map the keyword name.
* The final commit is a fix that I found in preparation for enabling the STM32 hardware acceleration inside WolfSSL along Zephyr. Even with STM32 hardware acceleration enabled, we still want to use the random number generator via the Zephyr interface (so that the Zephyr OS itself also has access to random data). For that, we have to define `NO_STM32_RNG`. This, however, resulted in not properly configuring the Zephyr port for the RNG, as the order of the configuration checks was incorrect.

All fixes have been tested using Zephyr on both a STM32H573I discovery board and a STM32H743 Nucleo board. 

Once this PR is (hopefully) merged, I will open a follow-up issue (and potentially a PR) for the STM32 hardware acceleration enablement on the STM32H5, as this doesn't work currently (both AES and HASH fails to work for me).

I'm looking forward to your feedback regarding the fixes.