### PR TITLE
Async v5.6.4

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -36008,7 +36008,8 @@ static int test_wolfSSL_CTX_add_client_CA(void)
 #endif /* OPENSSL_EXTRA  && !NO_RSA && !NO_CERTS && !NO_WOLFSSL_CLIENT */
     return EXPECT_RESULT();
 }
-#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH) && \
+    defined(HAVE_IO_TESTS_DEPENDENCIES)
 static THREAD_RETURN WOLFSSL_THREAD server_task_ech(void* args)
 {
     callback_functions* callbacks = ((func_args*)args)->callbacks;
@@ -68190,7 +68191,8 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_wolfSSL_UseSecureRenegotiation),
     TEST_DECL(test_wolfSSL_SCR_Reconnect),
     TEST_DECL(test_tls_ext_duplicate),
-#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH) && \
+    defined(HAVE_IO_TESTS_DEPENDENCIES)
     TEST_DECL(test_wolfSSL_Tls13_ECH_params),
     /* Uses Assert in handshake callback. */
     TEST_DECL(test_wolfSSL_Tls13_ECH),


### PR DESCRIPTION
# Description

* Fix for async edge case with Intel QuickAssist/Cavium Nitrox that was broken in PR #6783. Was causing re-entry and multiple calls for some operations like DH KeyGen that don't advance state on completion. https://github.com/wolfSSL/wolfAsyncCrypt/pull/71
* Fix for ECH build errors in API unit test without IO dependencies.

# Testing

```
./configure --with-intelqa=../QAT1.8 --enable-asynccrypt --enable-all --enable-trackmemory CFLAGS="-DQAT_DEBUG -DWOLFSSL_DEBUG_MEMORY -DWOLFSSL_DEBUG_MEMORY_PRINT -DWC_ASYNC_NO_HASH" --enable-debug --disable-shared && make
sudo ./tests/unit.test
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
