### PR TITLE
Support for the STM32WL55 and PKA improvements for ECC parameters

### DIFF
--- a/IDE/STM32Cube/README.md
+++ b/IDE/STM32Cube/README.md
@@ -31,7 +31,7 @@ You need both the STM32 IDE and the STM32 initialization code generator (STM32Cu
 2. Under “Software Packs” choose “Select Components”.
 3. Find and check all components for the wolfSSL.wolfSSL packs (wolfSSL / Core, wolfCrypt / Core and wolfCrypt / Test). Close
 4. Under the “Software Packs” section click on “wolfSSL.wolfSSL” and configure the parameters.
-5. For Cortex-M recommend “Math Configuration” -> “Single Precision Cortex-M Math” for the fastest option.
+5. For Cortex-M recommend “Math Configuration” -> “Single Precision Cortex-M Math” for the fastest option. If seeing `error: r7 cannot be used in 'asm` add `-fomit-frame-pointer` to the CFLAGS. This only happens in debug builds, because r7 is used for debug.
 6. Hit the "Generate Code" button
 7. Open the project in STM32CubeIDE
 8. The Benchmark example uses float. To enable go to "Project Properties" -> "C/C++ Build" -> "Settings" -> "Tool Settings" -> "MCU Settings" -> Check "Use float with printf".
@@ -87,6 +87,7 @@ The section for "Hardware platform" may need to be adjusted depending on your pr
 * To enable STM32L5 support define `WOLFSSL_STM32L5`.
 * To enable STM32H7 support define `WOLFSSL_STM32H7`.
 * To enable STM32WB support define `WOLFSSL_STM32WB`.
+* To enable STM32WL support define `WOLFSSL_STM32WL`.
 * To enable STM32U5 support define `WOLFSSL_STM32U5`.
 * To enable STM32H5 support define `WOLFSSL_STM32H5`.
 

--- a/IDE/STM32Cube/STM32_Benchmarks.md
+++ b/IDE/STM32Cube/STM32_Benchmarks.md
@@ -2,6 +2,7 @@
 
 * [STM32H753ZI](#stm32h753zi)
 * [STM32WB55](#stm32wb55)
+* [STM32WL55](#stm32wl55)
 * [STM32F437](#stm32f437)
 * [STM32L4A6Z](#stm32l4a6z)
 * [STM32L562E](#stm32l562e)
@@ -9,6 +10,7 @@
 * [STM32U585](#stm32u585)
 * [STM32H563ZI](#stm32h563zi)
 * [STM32G071RB](#stm32g071rb)
+
 
 ## STM32H753ZI
 
@@ -93,6 +95,7 @@ ECDSA    256 verify          6 ops took 1.016 sec, avg 169.333 ms, 5.906 ops/sec
 Benchmark complete
 Benchmark Test: Return code 0
 ```
+
 
 ## STM32WB55
 
@@ -211,6 +214,86 @@ Benchmark complete
 Benchmark Test: Return code 0
 ```
 
+
+## STM32WL55
+
+Supports RNG, ECC P-256 and AES-CBC acceleration.
+Note: SP math beats PKA HW. HW RNG on for all tests
+
+Board: NUCLEO-WL55JC1 (MB1389-HIGHBAND-E02)
+CPU: Cortex-M4 at 64 MHz
+IDE: STM32CubeIDE
+RTOS: Bare-Metal
+
+### STM32WL55 (STM AES-CBC Acceleration, -Os, SP-ASM Cortex-M WOLF_CONF_MATH=4)
+
+```
+------------------------------------------------------------------------------
+ wolfSSL version 5.6.4
+------------------------------------------------------------------------------
+wolfCrypt Benchmark (block bytes 1024, min 1.0 sec each)
+RNG                        200 KiB took 1.012 seconds,  197.628 KiB/s
+AES-128-CBC-enc              2 MiB took 1.000 seconds,    2.246 MiB/s
+AES-128-CBC-dec              2 MiB took 1.004 seconds,    2.213 MiB/s
+AES-256-CBC-enc              2 MiB took 1.008 seconds,    2.228 MiB/s
+AES-256-CBC-dec              2 MiB took 1.000 seconds,    2.197 MiB/s
+SHA-256                    600 KiB took 1.000 seconds,  600.000 KiB/s
+HMAC-SHA256                600 KiB took 1.012 seconds,  592.885 KiB/s
+ECC   [      SECP256R1]   256  key gen        56 ops took 1.023 sec, avg 18.268 ms, 54.741 ops/sec
+ECDHE [      SECP256R1]   256    agree        26 ops took 1.024 sec, avg 39.385 ms, 25.391 ops/sec
+ECDSA [      SECP256R1]   256     sign        30 ops took 1.019 sec, avg 33.967 ms, 29.441 ops/sec
+ECDSA [      SECP256R1]   256   verify        18 ops took 1.098 sec, avg 61.000 ms, 16.393 ops/sec
+Benchmark complete
+Benchmark Test: Return code 0
+```
+
+### STM32WL55 (STM AES-CBC Acceleration and PKA ECC, -Os)
+
+```
+------------------------------------------------------------------------------
+ wolfSSL version 5.6.4
+------------------------------------------------------------------------------
+wolfCrypt Benchmark (block bytes 1024, min 1.0 sec each)
+RNG                        200 KiB took 1.000 seconds,  200.000 KiB/s
+AES-128-CBC-enc              2 MiB took 1.000 seconds,    2.295 MiB/s
+AES-128-CBC-dec              2 MiB took 1.007 seconds,    2.279 MiB/s
+AES-256-CBC-enc              2 MiB took 1.000 seconds,    2.295 MiB/s
+AES-256-CBC-dec              2 MiB took 1.008 seconds,    2.252 MiB/s
+SHA-256                    575 KiB took 1.043 seconds,  551.294 KiB/s
+HMAC-SHA256                550 KiB took 1.000 seconds,  550.000 KiB/s
+ECC   [      SECP256R1]   256  key gen         4 ops took 1.172 sec, avg 293.000 ms, 3.413 ops/sec
+ECDHE [      SECP256R1]   256    agree         4 ops took 1.165 sec, avg 291.250 ms, 3.433 ops/sec
+ECDSA [      SECP256R1]   256     sign        10 ops took 1.070 sec, avg 107.000 ms, 9.346 ops/sec
+ECDSA [      SECP256R1]   256   verify         6 ops took 1.275 sec, avg 212.500 ms, 4.706 ops/sec
+Benchmark complete
+Benchmark Test: Return code 0
+```
+
+### STM32WL55 (No HW Crypto, -Os, SP Math All (WOLF_CONF_MATH=6))
+
+```
+------------------------------------------------------------------------------
+ wolfSSL version 5.6.4
+------------------------------------------------------------------------------
+wolfCrypt Benchmark (block bytes 1024, min 1.0 sec each)
+RNG                        200 KiB took 1.015 seconds,  197.044 KiB/s
+AES-128-CBC-enc            400 KiB took 1.004 seconds,  398.406 KiB/s
+AES-128-CBC-dec            400 KiB took 1.000 seconds,  400.000 KiB/s
+AES-192-CBC-enc            350 KiB took 1.031 seconds,  339.476 KiB/s
+AES-192-CBC-dec            350 KiB took 1.028 seconds,  340.467 KiB/s
+AES-256-CBC-enc            300 KiB took 1.007 seconds,  297.915 KiB/s
+AES-256-CBC-dec            300 KiB took 1.004 seconds,  298.805 KiB/s
+SHA-256                    550 KiB took 1.016 seconds,  541.339 KiB/s
+HMAC-SHA256                550 KiB took 1.024 seconds,  537.109 KiB/s
+ECC   [      SECP256R1]   256  key gen         4 ops took 1.180 sec, avg 295.000 ms, 3.390 ops/sec
+ECDHE [      SECP256R1]   256    agree         4 ops took 1.181 sec, avg 295.250 ms, 3.387 ops/sec
+ECDSA [      SECP256R1]   256     sign         4 ops took 1.306 sec, avg 326.500 ms, 3.063 ops/sec
+ECDSA [      SECP256R1]   256   verify         2 ops took 1.188 sec, avg 594.000 ms, 1.684 ops/sec
+Benchmark complete
+Benchmark Test: Return code 0
+```
+
+
 ## STM32F437
 
 Supports RNG, AES-CBC/GCM and SHA-256 acceleration.
@@ -295,6 +378,7 @@ Benchmark complete
 Benchmark Test: Return code 0
 ```
 
+
 ## STM32L4A6Z
 
 Supports RNG, AES-CBC/GCM and SHA-256 acceleration.
@@ -306,7 +390,6 @@ IDE: STM32CubeIDE
 RTOS: FreeRTOS
 
 ### STM32L4A6Z (STM Crypto/Hash Acceleration, -Os, SP-ASM Cortex-M)
-
 
 ```
 ------------------------------------------------------------------------------
@@ -375,6 +458,7 @@ ECDSA    256 verify          2 ops took 1.294 sec, avg 647.000 ms, 1.546 ops/sec
 Benchmark complete
 Benchmark Test: Return code 0
 ```
+
 
 ## STM32L562E
 
@@ -489,6 +573,7 @@ Benchmark complete
 Benchmark Test: Return code 0
 ```
 
+
 ## STM32F777
 
 Supports RNG, AES-CBC/GCM and SHA-256 acceleration.
@@ -572,6 +657,7 @@ ECDSA    256 verify          2 ops took 1.463 sec, avg 731.500 ms, 1.367 ops/sec
 Benchmark complete
 Benchmark Test: Return code 0
 ```
+
 
 ## STM32U585
 
@@ -710,6 +796,7 @@ ECDSA [      SECP256R1]   256 verify          4 ops took 1.196 sec, avg 299.000 
 Benchmark complete
 Benchmark Test: Return code 0
 ```
+
 
 ## STM32H563ZI
 

--- a/IDE/STM32Cube/default_conf.ftl
+++ b/IDE/STM32Cube/default_conf.ftl
@@ -182,7 +182,8 @@ extern ${variable.value} ${variable.name};
     //#define NO_STM32_RNG
     //#undef  NO_STM32_HASH
     //#undef  NO_STM32_CRYPTO
-    //#define WOLFSSL_GENSEED_FORTEST /* if no HW RNG is available use test seed */
+    /* if no HW RNG is available use test seed */
+    //#define WOLFSSL_GENSEED_FORTEST
     //#define STM32_HAL_V2
 #endif
 
@@ -255,7 +256,6 @@ extern ${variable.value} ${variable.name};
 
     /* Enable to put all math on stack (no heap) */
     //#define WOLFSSL_SP_NO_MALLOC
-    /* Enable for SP cache resistance (not usually enabled for embedded micros) */
 
     #if WOLF_CONF_MATH == 4 || WOLF_CONF_MATH == 5
         #define WOLFSSL_SP_ASM /* required if using the ASM versions */

--- a/IDE/STM32Cube/default_conf.ftl
+++ b/IDE/STM32Cube/default_conf.ftl
@@ -33,9 +33,9 @@
 [#list SWIPdatas as SWIP]
 [#-- Global variables --]
 [#if SWIP.variables??]
-	[#list SWIP.variables as variable]
+    [#list SWIP.variables as variable]
 extern ${variable.value} ${variable.name};
-	[/#list]
+    [/#list]
 [/#if]
 
 [#-- Global variables --]
@@ -45,16 +45,16 @@ extern ${variable.value} ${variable.name};
 [#assign version = SWIP.version]
 
 /**
-	MiddleWare name : ${instName}
-	MiddleWare fileName : ${fileName}
-	MiddleWare version : ${version}
+    MiddleWare name : ${instName}
+    MiddleWare fileName : ${fileName}
+    MiddleWare version : ${version}
 */
 [#if SWIP.defines??]
-	[#list SWIP.defines as definition]
+    [#list SWIP.defines as definition]
 /*---------- [#if definition.comments??]${definition.comments}[/#if] -----------*/
 #define ${definition.name} #t#t ${definition.value}
 [#if definition.description??]${definition.description} [/#if]
-	[/#list]
+    [/#list]
 [/#if]
 
 
@@ -76,6 +76,11 @@ extern ${variable.value} ${variable.name};
     #define WOLFSSL_STM32_PKA
     #undef  NO_STM32_CRYPTO
     #define HAL_CONSOLE_UART huart1
+#elif defined(STM32WL55xx)
+    #define WOLFSSL_STM32WL
+    #define WOLFSSL_STM32_PKA
+    #undef  NO_STM32_CRYPTO
+    #define HAL_CONSOLE_UART huart2
 #elif defined(STM32F407xx)
     #define WOLFSSL_STM32F4
     #define HAL_CONSOLE_UART huart2
@@ -242,6 +247,8 @@ extern ${variable.value} ${variable.name};
         #define WOLFSSL_HAVE_SP_ECC
     #endif
     #if WOLF_CONF_MATH == 6 || WOLF_CONF_MATH == 7
+        #define WOLFSSL_SP_MATH_ALL /* use sp_int.c multi precision math */
+    #else
         #define WOLFSSL_SP_MATH    /* disable non-standard curves / key sizes */
     #endif
     #define SP_WORD_SIZE 32
@@ -504,12 +511,12 @@ extern ${variable.value} ${variable.name};
 /* Sha3 */
 #undef WOLFSSL_SHA3
 #if defined(WOLF_CONF_SHA3) && WOLF_CONF_SHA3 == 1
-	#define WOLFSSL_SHA3
+    #define WOLFSSL_SHA3
 #endif
 
 /* MD5 */
 #if defined(WOLF_CONF_MD5) && WOLF_CONF_MD5 == 1
-	/* enabled */
+    /* enabled */
 #else
     #define NO_MD5
 #endif
@@ -534,8 +541,8 @@ extern ${variable.value} ${variable.name};
     #if 0
         #define USE_WOLFSSL_MEMORY
         #define WOLFSSL_TRACK_MEMORY
-  		  #define WOLFSSL_DEBUG_MEMORY
-	  	  #define WOLFSSL_DEBUG_MEMORY_PRINT
+        #define WOLFSSL_DEBUG_MEMORY
+        #define WOLFSSL_DEBUG_MEMORY_PRINT
     #endif
 #else
     //#define NO_WOLFSSL_MEMORY

--- a/examples/configs/user_settings_stm32.h
+++ b/examples/configs/user_settings_stm32.h
@@ -243,7 +243,8 @@ extern "C" {
     //#define NO_STM32_RNG
     //#undef  NO_STM32_HASH
     //#undef  NO_STM32_CRYPTO
-    //#define WOLFSSL_GENSEED_FORTEST /* if no HW RNG is available use test seed */
+    /* if no HW RNG is available use test seed */
+    //#define WOLFSSL_GENSEED_FORTEST
     //#define STM32_HAL_V2
 #endif
 
@@ -313,7 +314,6 @@ extern "C" {
 
     /* Enable to put all math on stack (no heap) */
     //#define WOLFSSL_SP_NO_MALLOC
-    /* Enable for SP cache resistance (not usually enabled for embedded micros) */
 
     #if WOLF_CONF_MATH == 4 || WOLF_CONF_MATH == 5
         #define WOLFSSL_SP_ASM /* required if using the ASM versions */
@@ -566,12 +566,12 @@ extern "C" {
 /* Sha3 */
 #undef WOLFSSL_SHA3
 #if defined(WOLF_CONF_SHA3) && WOLF_CONF_SHA3 == 1
-	#define WOLFSSL_SHA3
+    #define WOLFSSL_SHA3
 #endif
 
 /* MD5 */
 #if defined(WOLF_CONF_MD5) && WOLF_CONF_MD5 == 1
-	/* enabled */
+    /* enabled */
 #else
     #define NO_MD5
 #endif
@@ -594,8 +594,8 @@ extern "C" {
     #if 0
         #define USE_WOLFSSL_MEMORY
         #define WOLFSSL_TRACK_MEMORY
-  		  #define WOLFSSL_DEBUG_MEMORY
-	  	  #define WOLFSSL_DEBUG_MEMORY_PRINT
+        #define WOLFSSL_DEBUG_MEMORY
+        #define WOLFSSL_DEBUG_MEMORY_PRINT
     #endif
 #else
     //#define NO_WOLFSSL_MEMORY

--- a/examples/configs/user_settings_stm32.h
+++ b/examples/configs/user_settings_stm32.h
@@ -1,4 +1,5 @@
-/* wolfSSL_conf.h (example of generated wolfSSL.I-CUBE-wolfSSL_conf.h)
+/* wolfSSL_conf.h (example of generated wolfSSL.I-CUBE-wolfSSL_conf.h using
+ * default_conf.ftl and STM32CubeIDE or STM32CubeMX tool)
  *
  * Copyright (C) 2006-2023 wolfSSL Inc.
  *
@@ -23,11 +24,15 @@
  * Generated automatically using `default_conf.ftl` template
  *
  * Included automatically when USE_HAL_DRIVER is defined
- * (and not WOLFSSL_USER_SETTINGS or HAVE_CONF_H).
+ * (and not WOLFSSL_USER_SETTINGS or HAVE_CONFIG_H).
  */
 
 #ifndef __WOLFSSL_I_CUBE_WOLFSSL_CONF_H__
 #define __WOLFSSL_I_CUBE_WOLFSSL_CONF_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 
 /*---------- WOLF_CONF_DEBUG -----------*/
@@ -50,6 +55,9 @@
 
 /*---------- WOLF_CONF_RTOS -----------*/
 #define WOLF_CONF_RTOS      2
+
+/*---------- WOLF_CONF_RNG -----------*/
+#define WOLF_CONF_RNG      1
 
 /*---------- WOLF_CONF_RSA -----------*/
 #define WOLF_CONF_RSA      1
@@ -111,17 +119,29 @@
 /*---------- WOLF_CONF_TEST -----------*/
 #define WOLF_CONF_TEST      1
 
+/*---------- WOLF_CONF_PQM4 -----------*/
+#define WOLF_CONF_PQM4      0
+
 /* ------------------------------------------------------------------------- */
 /* Hardware platform */
 /* ------------------------------------------------------------------------- */
+/* Setup default (No crypto hardware acceleration or TLS UART test).
+ * Use undef in platform section to enable it.
+ */
 #define NO_STM32_HASH
 #define NO_STM32_CRYPTO
+#define NO_TLS_UART_TEST
 
 #if defined(STM32WB55xx)
     #define WOLFSSL_STM32WB
     #define WOLFSSL_STM32_PKA
     #undef  NO_STM32_CRYPTO
     #define HAL_CONSOLE_UART huart1
+#elif defined(STM32WL55xx)
+    #define WOLFSSL_STM32WL
+    #define WOLFSSL_STM32_PKA
+    #undef  NO_STM32_CRYPTO
+    #define HAL_CONSOLE_UART huart2
 #elif defined(STM32F407xx)
     #define WOLFSSL_STM32F4
     #define HAL_CONSOLE_UART huart2
@@ -137,10 +157,19 @@
     #undef  NO_STM32_CRYPTO
     #define STM32_HAL_V2
     #define HAL_CONSOLE_UART huart2
+#elif defined(STM32F756xx)
+    #define WOLFSSL_STM32F7
+    #undef  NO_STM32_HASH
+    #undef  NO_STM32_CRYPTO
+    #define STM32_HAL_V2
+    #define HAL_CONSOLE_UART huart3
 #elif defined(STM32H753xx)
     #define WOLFSSL_STM32H7
     #undef  NO_STM32_HASH
     #undef  NO_STM32_CRYPTO
+    #define HAL_CONSOLE_UART huart3
+#elif defined(STM32H723xx)
+    #define WOLFSSL_STM32H7
     #define HAL_CONSOLE_UART huart3
 #elif defined(STM32L4A6xx)
     #define WOLFSSL_STM32L4
@@ -163,6 +192,9 @@
 #elif defined(STM32F207xx)
     #define WOLFSSL_STM32F2
     #define HAL_CONSOLE_UART huart3
+#elif defined(STM32F217xx)
+    #define WOLFSSL_STM32F2
+    #define HAL_CONSOLE_UART huart2
 #elif defined(STM32F107xC)
     #define WOLFSSL_STM32F1
     #define HAL_CONSOLE_UART huart4
@@ -171,18 +203,34 @@
     #define WOLFSSL_STM32F4
     #define HAL_CONSOLE_UART huart2
     #define NO_STM32_RNG
-    #define WOLFSSL_GENSEED_FORTEST
+    #define WOLFSSL_GENSEED_FORTEST /* no HW RNG is available use test seed */
 #elif defined(STM32G071xx)
     #define WOLFSSL_STM32G0
     #define HAL_CONSOLE_UART huart2
     #define NO_STM32_RNG
-    #define WOLFSSL_GENSEED_FORTEST
+    #define WOLFSSL_GENSEED_FORTEST /* no HW RNG is available use test seed */
+#elif defined(STM32U575xx) || defined(STM32U585xx)
+    #define HAL_CONSOLE_UART huart1
+    #define WOLFSSL_STM32U5
+    #define STM32_HAL_V2
+    #ifdef STM32U585xx
+        #undef  NO_STM32_HASH
+        #undef  NO_STM32_CRYPTO
+        #define WOLFSSL_STM32_PKA
+    #endif
+#elif defined(STM32H563xx)
+    #define WOLFSSL_STM32H5
+    #define HAL_CONSOLE_UART huart3
+    #define STM32_HAL_V2
+    #undef  NO_STM32_HASH
+
 #else
     #warning Please define a hardware platform!
     /* This means there is not a pre-defined platform for your board/CPU */
     /* You need to define a CPU type, HW crypto and debug UART */
     /* CPU Type: WOLFSSL_STM32F1, WOLFSSL_STM32F2, WOLFSSL_STM32F4,
-        WOLFSSL_STM32F7, WOLFSSL_STM32H7, WOLFSSL_STM32L4 and WOLFSSL_STM32L5 */
+        WOLFSSL_STM32F7, WOLFSSL_STM32H7, WOLFSSL_STM32L4, WOLFSSL_STM32L5,
+        WOLFSSL_STM32G0, WOLFSSL_STM32WB and WOLFSSL_STM32U5 */
     #define WOLFSSL_STM32F4
 
     /* Debug UART used for printf */
@@ -195,7 +243,7 @@
     //#define NO_STM32_RNG
     //#undef  NO_STM32_HASH
     //#undef  NO_STM32_CRYPTO
-    //#define WOLFSSL_GENSEED_FORTEST
+    //#define WOLFSSL_GENSEED_FORTEST /* if no HW RNG is available use test seed */
     //#define STM32_HAL_V2
 #endif
 
@@ -222,32 +270,61 @@
 /* ------------------------------------------------------------------------- */
 /* Math Configuration */
 /* ------------------------------------------------------------------------- */
-/* 1=Fast, 2=Normal, 3=SP C, 4=SP Cortex-M */
-#if defined(WOLF_CONF_MATH) && WOLF_CONF_MATH != 2
-    /* fast (stack) math */
+/* 1=Fast (stack)
+ * 2=Normal (heap)
+ * 3=Single Precision C (only common curves/key sizes)
+ * 4=Single Precision ASM Cortex-M3+
+ * 5=Single Precision ASM Cortex-M0 (Generic Thumb)
+ * 6=Single Precision C all small
+ * 7=Single Precision C all big
+ */
+#if defined(WOLF_CONF_MATH) && WOLF_CONF_MATH == 1
+    /* fast (stack) math - tfm.c */
     #define USE_FAST_MATH
     #define TFM_TIMING_RESISTANT
 
     /* Optimizations (TFM_ARM, TFM_ASM or none) */
     //#define TFM_NO_ASM
     //#define TFM_ASM
-#endif
-#if defined(WOLF_CONF_MATH) && (WOLF_CONF_MATH == 3 || WOLF_CONF_MATH == 4)
+#elif defined(WOLF_CONF_MATH) && WOLF_CONF_MATH == 2
+    /* heap math - integer.c */
+    #define USE_INTEGER_HEAP_MATH
+#elif defined(WOLF_CONF_MATH) && (WOLF_CONF_MATH >= 3)
     /* single precision only */
     #define WOLFSSL_SP
-    #define WOLFSSL_SP_SMALL      /* use smaller version of code */
-    #define WOLFSSL_HAVE_SP_RSA
-    #define WOLFSSL_HAVE_SP_DH
-    #define WOLFSSL_HAVE_SP_ECC
-    #define WOLFSSL_SP_MATH
+    #if WOLF_CONF_MATH != 7
+        #define WOLFSSL_SP_SMALL      /* use smaller version of code */
+    #endif
+    #if defined(WOLF_CONF_RSA) && WOLF_CONF_RSA == 1
+        #define WOLFSSL_HAVE_SP_RSA
+    #endif
+    #if defined(WOLF_CONF_DH) && WOLF_CONF_DH == 1
+        #define WOLFSSL_HAVE_SP_DH
+    #endif
+    #if defined(WOLF_CONF_ECC) && WOLF_CONF_ECC == 1
+        #define WOLFSSL_HAVE_SP_ECC
+    #endif
+    #if WOLF_CONF_MATH == 6 || WOLF_CONF_MATH == 7
+        #define WOLFSSL_SP_MATH_ALL /* use sp_int.c multi precision math */
+    #else
+        #define WOLFSSL_SP_MATH    /* disable non-standard curves / key sizes */
+    #endif
     #define SP_WORD_SIZE 32
 
+    /* Enable to put all math on stack (no heap) */
     //#define WOLFSSL_SP_NO_MALLOC
+    /* Enable for SP cache resistance (not usually enabled for embedded micros) */
 
-    /* single precision Cortex-M only */
-    #if WOLF_CONF_MATH == 4
+    #if WOLF_CONF_MATH == 4 || WOLF_CONF_MATH == 5
         #define WOLFSSL_SP_ASM /* required if using the ASM versions */
-        #define WOLFSSL_SP_ARM_CORTEX_M_ASM
+        #if WOLF_CONF_MATH == 4
+            /* ARM Cortex-M3+ */
+            #define WOLFSSL_SP_ARM_CORTEX_M_ASM
+        #endif
+        #if WOLF_CONF_MATH == 5
+            /* Generic ARM Thumb (Cortex-M0) Assembly */
+            #define WOLFSSL_SP_ARM_THUMB_ASM
+        #endif
     #endif
 #endif
 
@@ -279,8 +356,14 @@
 #if defined(WOLF_CONF_BASE64_ENCODE) && WOLF_CONF_BASE64_ENCODE == 1
     #define WOLFSSL_BASE64_ENCODE
 #endif
-#if defined(WOLF_CONF_OPENSSL_EXTRA) && WOLF_CONF_OPENSSL_EXTRA == 1
+#if defined(WOLF_CONF_OPENSSL_EXTRA) && WOLF_CONF_OPENSSL_EXTRA >= 1
     #define OPENSSL_EXTRA
+    #if !defined(INT_MAX)
+        #include <limits.h>
+    #endif
+#endif
+#if defined(WOLF_CONF_OPENSSL_EXTRA) && WOLF_CONF_OPENSSL_EXTRA >= 2
+    #define OPENSSL_ALL
 #endif
 
 /* TLS Session Cache */
@@ -288,6 +371,14 @@
     #define SMALL_SESSION_CACHE
 #else
     #define NO_SESSION_CACHE
+#endif
+
+/* Post Quantum
+ * Note: PQM4 is compatible with STM32. The project can be found at:
+ * https://github.com/mupq/pqm4
+ */
+#if defined(WOLF_CONF_PQM4) && WOLF_CONF_PQM4 == 1
+    #define HAVE_PQM4
 #endif
 
 /* ------------------------------------------------------------------------- */
@@ -475,12 +566,12 @@
 /* Sha3 */
 #undef WOLFSSL_SHA3
 #if defined(WOLF_CONF_SHA3) && WOLF_CONF_SHA3 == 1
-    #define WOLFSSL_SHA3
+	#define WOLFSSL_SHA3
 #endif
 
 /* MD5 */
 #if defined(WOLF_CONF_MD5) && WOLF_CONF_MD5 == 1
-    /* enabled */
+	/* enabled */
 #else
     #define NO_MD5
 #endif
@@ -503,8 +594,8 @@
     #if 0
         #define USE_WOLFSSL_MEMORY
         #define WOLFSSL_TRACK_MEMORY
-        #define WOLFSSL_DEBUG_MEMORY
-        #define WOLFSSL_DEBUG_MEMORY_PRINT
+  		  #define WOLFSSL_DEBUG_MEMORY
+	  	  #define WOLFSSL_DEBUG_MEMORY_PRINT
     #endif
 #else
     //#define NO_WOLFSSL_MEMORY
@@ -519,7 +610,6 @@
 /* Allows custom "custom_time()" function to be used for benchmark */
 #define WOLFSSL_USER_CURRTIME
 
-
 /* ------------------------------------------------------------------------- */
 /* RNG */
 /* ------------------------------------------------------------------------- */
@@ -531,7 +621,6 @@
     #define WC_NO_HASHDRBG
     #define WC_NO_RNG
 #endif
-
 
 /* ------------------------------------------------------------------------- */
 /* Disable Features */
@@ -574,7 +663,6 @@
 #ifndef HAL_RTC_MODULE_ENABLED
     #define NO_ASN_TIME
 #endif
-
 
 #ifdef __cplusplus
 }

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -218,7 +218,7 @@ ECC Curve Sizes:
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
     !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_SILABS_SE_ACCEL) && \
     !defined(WOLFSSL_KCAPI_ECC) && !defined(WOLFSSL_SE050) && \
-    !defined(WOLFSSL_XILINX_CRYPT_VERSAL)
+    !defined(WOLFSSL_XILINX_CRYPT_VERSAL) && !defined(WOLFSSL_STM32_PKA)
     #undef  HAVE_ECC_VERIFY_HELPER
     #define HAVE_ECC_VERIFY_HELPER
 #endif

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -27286,8 +27286,9 @@ static wc_test_ret_t ecc_def_curve_test(WC_RNG *rng)
 #else
     ecc_key key[1];
 #endif
-#if (defined(HAVE_ECC_KEY_IMPORT) && defined(HAVE_ECC_KEY_EXPORT)) || \
-    (defined(HAVE_ECC_KEY_IMPORT) && !defined(WOLFSSL_VALIDATE_ECC_IMPORT))
+#if !defined(NO_ECC_SECP) && \
+    ((defined(HAVE_ECC_KEY_IMPORT) && defined(HAVE_ECC_KEY_EXPORT)) || \
+     (defined(HAVE_ECC_KEY_IMPORT) && !defined(WOLFSSL_VALIDATE_ECC_IMPORT)))
     word32 idx = 0;
 #endif
 
@@ -27338,8 +27339,9 @@ static wc_test_ret_t ecc_def_curve_test(WC_RNG *rng)
     (void)rng;
 #endif /* !WC_NO_RNG */
 
-#if (defined(HAVE_ECC_KEY_IMPORT) && defined(HAVE_ECC_KEY_EXPORT)) || \
-    (defined(HAVE_ECC_KEY_IMPORT) && !defined(WOLFSSL_VALIDATE_ECC_IMPORT))
+#if !defined(NO_ECC_SECP) && \
+    ((defined(HAVE_ECC_KEY_IMPORT) && defined(HAVE_ECC_KEY_EXPORT)) || \
+     (defined(HAVE_ECC_KEY_IMPORT) && !defined(WOLFSSL_VALIDATE_ECC_IMPORT)))
     /* Use test ECC key - ensure real private "d" exists */
     #ifdef USE_CERT_BUFFERS_256
     ret = wc_EccPrivateKeyDecode(ecc_key_der_256, &idx, key,

--- a/wolfssl/wolfcrypt/port/st/stm32.h
+++ b/wolfssl/wolfcrypt/port/st/stm32.h
@@ -131,9 +131,13 @@ int  wc_Stm32_Hash_Final(STM32_HASH_Context* stmCtx, word32 algo,
         #define STM32_CRYPTO_AES_GCM
     #endif
 
-    #if defined(WOLFSSL_STM32WB)
+    #if defined(WOLFSSL_STM32WB) || defined(WOLFSSL_STM32WL)
         #define STM32_CRYPTO_AES_ONLY /* crypto engine only supports AES */
-        #define CRYP AES1
+        #ifdef WOLFSSL_STM32WB
+            #define CRYP AES1
+        #else
+            #define CRYP AES
+        #endif
         #define STM32_HAL_V2
     #endif
     #if defined(WOLFSSL_STM32L4) || defined(WOLFSSL_STM32L5) || \

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1402,7 +1402,7 @@ extern void uITRON4_free(void *p) ;
     defined(WOLFSSL_STM32L4) || defined(WOLFSSL_STM32L5) || \
     defined(WOLFSSL_STM32WB) || defined(WOLFSSL_STM32H7) || \
     defined(WOLFSSL_STM32G0) || defined(WOLFSSL_STM32U5) || \
-    defined(WOLFSSL_STM32H5)
+    defined(WOLFSSL_STM32H5) || defined(WOLFSSL_STM32WL)
 
     #define SIZEOF_LONG_LONG 8
     #ifndef CHAR_BIT
@@ -1422,7 +1422,8 @@ extern void uITRON4_free(void *p) ;
         #define STM32_CRYPTO
 
         #if defined(WOLFSSL_STM32L4) || defined(WOLFSSL_STM32L5) || \
-            defined(WOLFSSL_STM32WB) || defined(WOLFSSL_STM32U5)
+            defined(WOLFSSL_STM32WB) || defined(WOLFSSL_STM32U5) || \
+            defined(WOLFSSL_STM32WL)
             #define NO_AES_192 /* hardware does not support 192-bit */
         #endif
     #endif
@@ -1453,6 +1454,8 @@ extern void uITRON4_free(void *p) ;
             #include "stm32h7xx_hal.h"
         #elif defined(WOLFSSL_STM32WB)
             #include "stm32wbxx_hal.h"
+        #elif defined(WOLFSSL_STM32WL)
+            #include "stm32wlxx_hal.h"
         #elif defined(WOLFSSL_STM32G0)
             #include "stm32g0xx_hal.h"
         #elif defined(WOLFSSL_STM32U5)
@@ -1466,6 +1469,11 @@ extern void uITRON4_free(void *p) ;
 
         #ifndef STM32_HAL_TIMEOUT
             #define STM32_HAL_TIMEOUT   0xFF
+        #endif
+
+        #if defined(WOLFSSL_STM32_PKA) && !defined(WOLFSSL_SP_INT_NEGATIVE)
+            /* enable the negative support for abs(a) |a| */
+            #define WOLFSSL_SP_INT_NEGATIVE
         #endif
     #else
         #if defined(WOLFSSL_STM32F2)


### PR DESCRIPTION
# Description

* Support for the STM32WL55
* PKA improvements for ECC parameters to support custom curves
* Fix for `WOLF_CONF_MATH` options `6=Single Precision C all small` and `7=Single Precision C all big`.

Fixes #6386 and Fixes #6396

# Testing

Tested on STM32WL55 and STM32U585.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
