### PR TITLE
IoT-SAFE: allow for 4B ID fields

### DIFF
--- a/IDE/iotsafe/memory-tls.c
+++ b/IDE/iotsafe/memory-tls.c
@@ -146,9 +146,12 @@ static int client_loop(void)
     #if (IOTSAFE_ID_SIZE == 1)
     byte cert_file_id, privkey_id, keypair_id, peer_pubkey_id, peer_cert_id, serv_cert_id;
     byte ca_cert_id;
-    #else
+    #elif (IOTSAFE_ID_SIZE == 2)
     word16 cert_file_id, privkey_id, keypair_id, peer_pubkey_id, peer_cert_id, serv_cert_id;
     word16 ca_cert_id;
+    #else
+    word32 cert_file_id, privkey_id, keypair_id, peer_pubkey_id, peer_cert_id, serv_cert_id;
+    word32 ca_cert_id;
     #endif
     cert_file_id = CRT_CLIENT_FILE_ID;
     privkey_id = PRIVKEY_ID;

--- a/IDE/iotsafe/user_settings.h
+++ b/IDE/iotsafe/user_settings.h
@@ -34,7 +34,21 @@
  *   - Default: one-byte ID sim, with hardcoded server certificate
  */
 
-#ifdef TWO_BYTES_ID_DEMO
+#if defined(FOUR_BYTES_ID_DEMO)
+    #define IOTSAFE_ID_SIZE 2
+    #define CRT_CLIENT_FILE_ID  0xABCD3430     /* pre-provisioned */
+    #define CRT_SERVER_FILE_ID  0xABCD3330
+    #define PRIVKEY_ID          0xABCD3230     /* pre-provisioned */
+    #define ECDH_KEYPAIR_ID     0xABCD3330
+    #define PEER_PUBKEY_ID      0xABCD3730
+    #define PEER_CERT_ID        0xABCD3430
+
+    /* In this version of the demo, the server certificate is
+     * stored in a buffer, while the CA is read from a file slot in IoT-SAFE
+     */
+    #define SOFT_SERVER_CERT
+
+#elif defined(TWO_BYTES_ID_DEMO)
     #define IOTSAFE_ID_SIZE 2
     #define CRT_CLIENT_FILE_ID  0x3430     /* pre-provisioned */
     #define CRT_SERVER_FILE_ID  0x3330

--- a/wolfssl/wolfcrypt/port/iotsafe/iotsafe.h
+++ b/wolfssl/wolfcrypt/port/iotsafe/iotsafe.h
@@ -93,6 +93,11 @@ struct wc_IOTSAFE {
     word16 ecdh_keypair_slot;
     word16 peer_pubkey_slot;
     word16 peer_cert_slot;
+#elif (IOTSAFE_ID_SIZE == 4)
+    word32 privkey_id;
+    word32 ecdh_keypair_slot;
+    word32 peer_pubkey_slot;
+    word32 peer_cert_slot;
 #else
 #error "IOTSAFE: ID_SIZE not supported"
 #endif


### PR DESCRIPTION
# Description

IoT-SAFE ID could be 4B long (reported by zd16911)

# Checklist

 - [x] added tests

