### PR TITLE
20231102-examples-asn1-double-fclose

### DIFF
--- a/examples/asn1/asn1.c
+++ b/examples/asn1/asn1.c
@@ -92,8 +92,6 @@ static int asn1App_ReadFile(FILE* fp, unsigned char** pdata, word32* plen)
             /* Set data to new pointer. */
             data = p;
         }
-        /* Done with file. */
-        fclose(fp);
     }
 
     if (data != NULL) {


### PR DESCRIPTION
`examples/asn1/asn1.c`: remove now-redundant `fclose(fp)` in `asn1App_ReadFile()` (which also was incorrectly closing `stdin`).  see #6905.

tested with `wolfssl-multi-test.sh ... all-gcc-c89-sanitize check-self check-file-modes check-source-text check-shell-scripts check-configure all-gcc-c99 all-gcc-c99-asn-original cryptonly-opensslextra-gcc-c99 all-gcc-c89 allcryptonly-Wconversion-intelasm-build allcryptonly-c89-Wconversion-m32-build all-g++ all-gcc-latest-c99-smallstack cross-amd64-mingw-all-crypto-Wconversion cross-mingw-all-crypto`
