### PR TITLE
introduce WARNING_OUT, when goto is not a hard error during tests

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -133,6 +133,7 @@ const byte const_byte_array[] = "A+Gd\0\0\0";
     #include <time.h>
     #include <sys/time.h>
     #include <esp_log.h>
+    #include <wolfcrypt/port/Espressif/esp32-crypt.h> /* */
 #elif defined(WOLFSSL_ZEPHYR)
     #include <stdio.h>
 
@@ -713,8 +714,25 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes_eax_test(void);
 /* General big buffer size for many tests. */
 #define FOURK_BUF 4096
 
+#if defined(WOLFSSL_ESPIDF_ERROR_PAUSE)
+    /* When defined, pause at error condition rather than exit with error. */
+        #define ERROR_OUT(err, eLabel) \
+            do { \
+                ret = (err); \
+                esp_ShowExtendedSystemInfo(); \
+                ESP_LOGE("wolfcrypt_test", "ESP Error! ret = %d ", err); \
+                while (1) { \
+                    vTaskDelay(60000); \
+                } \
+                /* Just to appease compiler, don't actually go to eLabel */ \
+                goto eLabel; \
+            } while (0)
+#else
+    #define ERROR_OUT(err, eLabel) do { ret = (err); goto eLabel; } while (0)
+#endif
 
-#define ERROR_OUT(err, eLabel) do { ret = (err); goto eLabel; } while (0)
+/* Not all unexpected conditions are actually errors .*/
+#define WARNING_OUT(err, eLabel) do { ret = (err); goto eLabel; } while (0)
 
 static void render_error_message(const char* msg, wc_test_ret_t es)
 {
@@ -1893,7 +1911,7 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 #endif
     {
         wc_test_ret_t ret;
-        func_args args;
+        func_args args = { 0 };
 #if defined(WOLFSSL_ESPIDF) || defined(WOLFSSL_SE050)
         /* set dummy wallclock time. */
         struct timeval utctime;
@@ -1995,16 +2013,7 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
         while (1);
 #endif
 
-#ifdef WOLFSSL_ESPIDF
-        /* ESP_LOGI to print takes up a lot less memory than printf */
-        ESP_LOGI("wolfcrypt_test", "Exiting main with return code: % d\n", args.return_code);
-#endif
-
-/* everything else will use printf */
-#if !defined(WOLFSSL_ESPIDF)
-/* gate this for target platforms wishing to avoid printf reference */
         printf("Exiting main with return code: %ld\n", (long int)args.return_code);
-#endif
 
         return args.return_code;
     } /* wolfcrypt_test_main or wolf_test_task */
@@ -26370,7 +26379,8 @@ static wc_test_ret_t ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerif
 
     /* only perform the below tests if the key size matches */
     if (dp == NULL && keySize > 0 && wc_ecc_size(userA) != keySize)
-        ERROR_OUT(ECC_CURVE_OID_E, done);
+        /* Not an error, just not a key size match */
+        WARNING_OUT(ECC_CURVE_OID_E, done);
 
 #ifdef HAVE_ECC_DHE
 #if defined(ECC_TIMING_RESISTANT) && (!defined(HAVE_FIPS) || \
@@ -40150,7 +40160,7 @@ static int myDecryptionFunc(PKCS7* pkcs7, int encryptOID, byte* iv, int ivSz,
     #ifdef WOLFSSL_AES_256
         case AES256CBCb:
             if ((keySz != 32 ) || (ivSz  != AES_BLOCK_SIZE))
-                ERROR_OUT(BAD_FUNC_ARG, out);
+                WARNING_OUT(BAD_FUNC_ARG, out);
             break;
     #endif
     #ifdef WOLFSSL_AES_128


### PR DESCRIPTION
# Description

This is a revision of https://github.com/wolfSSL/wolfssl/pull/6923 using a different source branch name [as suggested](https://github.com/wolfSSL/wolfssl/pull/6923#issuecomment-1786073661).

Sometimes it may be desired to capture the call stack during test error conditions rather than just error out.

This PR introduces `WARNING_OUT` that will normally do the same thing as `ERROR_OUT`, except when an alterative is defined, such as the `WOLFSSL_ESPIDF_ERROR_PAUSE` for a custom `ERROR_OUT` handler in the Espressif environment. 

Not all uses of the current `ERROR_OUT` are actually hard errors. Some simply capture expected but undesired results and still handle with the same `ret = (err); goto eLabel;` logic. The  `WARNING_OUT` is used for situations where we don't actually want to capture a custom call stack with alternate `ERROR_OUT` code.

Note the `ecc_test_curve_size` test is one example now using  `WARNING_OUT` instead of `ERROR_OUT`.

Other custom error-pausing code can easily be added as desired for other environments. 

Also included is a variable-initialization for `args` in `wolfcrypt_test_main()`.

Fixes zd# n/a

# Testing

How did you test?

manual testing in Espressif environment.

 Confirmation with:

```
./configure --enable-all && make clean && make && make check
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
