### PR TITLE
fix WOLFSSL_CALLBACK memory error

### DIFF
--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -3392,7 +3392,14 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
             } while (err == WC_PENDING_E);
         }
 #else
-        (void)nonBlocking;
+        if (nonBlocking) {
+            #ifdef WOLFSSL_DTLS
+            if (doDTLS) {
+                wolfSSL_dtls_set_using_nonblock(ssl, 1);
+            }
+            #endif
+            tcp_set_nonblocking(&clientfd);
+        }
         ret = NonBlockingSSL_Accept(ssl);
 #endif
 #ifdef WOLFSSL_EARLY_DATA

--- a/src/internal.c
+++ b/src/internal.c
@@ -26884,7 +26884,7 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
             /* add data, put in buffer if bigger than static buffer */
             info->packets[info->numberPackets].valueSz = totalSz;
             if (totalSz < MAX_VALUE_SZ) {
-                XMEMCPY(info->packets[info->numberPackets].value, data + lateRL,
+                XMEMCPY(info->packets[info->numberPackets].value + lateRL, data,
                                sz);
             }
             else {


### PR DESCRIPTION
- Fixes [ZD16925](https://wolfssl.zendesk.com/agent/tickets/16925). Reproduction steps in ticket.
- Fixes bug that prevented `make check` from passing when used with `WOLFSSL_CALLBACKS`. When invoking the example server with `WOLFSSL_CALLBACKS` defined and using either the `-6` option (simulated WANT_WRITE errors) or `-u` (DTLS), the server will hang in `recv()` because the socket isn't set as non-blocking. To reproduce, run `./configure --enable-all CFLAGS="-DWOLFSSL_CALLBACKS" && make check` on `master`.