### PR TITLE
SRTP KDF: Don't use i outside loop

### DIFF
--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -910,7 +910,7 @@ static void wc_srtp_kdf_first_block(const byte* salt, word32 saltSz, int kdrIdx,
         }
         else {
             /* XOR in as bit shifted index. */
-            block[WC_SRTP_MAX_SALT - indexSz] ^= index[i+0] >> bits;
+            block[WC_SRTP_MAX_SALT - indexSz] ^= index[0] >> bits;
             for (i = 1; i < indexSz; i++) {
                 block[i + WC_SRTP_MAX_SALT - indexSz] ^=
                     (index[i-1] << (8 - bits)) |


### PR DESCRIPTION
# Description

When shifting index down, first XOR outside loop isn't meant to use i.

Fixes zd#16967

# Testing
PoC

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
