### PR TITLE
SP C: support e up to 64-bits

### DIFF
--- a/wolfcrypt/src/sp_c32.c
+++ b/wolfcrypt/src/sp_c32.c
@@ -3543,7 +3543,7 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     sp_digit* norm = NULL;
-    sp_digit e[1] = {0};
+    sp_uint64 e[1] = {0};
     sp_digit mp = 0;
     int i;
     int err = MP_OKAY;
@@ -3553,7 +3553,7 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
     }
 
     if (err == MP_OKAY) {
-        if (mp_count_bits(em) > 29) {
+        if (mp_count_bits(em) > 64) {
             err = MP_READ_E;
         }
         else if (inLen > 256U) {
@@ -3582,12 +3582,12 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         norm = r;
 
         sp_2048_from_bin(a, 72, in, inLen);
-#if DIGIT_BIT >= 29
-        e[0] = (sp_digit)em->dp[0];
+#if DIGIT_BIT >= 64
+        e[0] = (sp_uint64)em->dp[0];
 #else
-        e[0] = (sp_digit)em->dp[0];
+        e[0] = (sp_uint64)em->dp[0];
         if (em->used > 1) {
-            e[0] |= ((sp_digit)em->dp[1]) << DIGIT_BIT;
+            e[0] |= ((sp_uint64)em->dp[1]) << DIGIT_BIT;
         }
 #endif
         if (e[0] == 0) {
@@ -3606,7 +3606,7 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         err = sp_2048_mod_72(a, a, m);
     }
     if (err == MP_OKAY) {
-        for (i=28; i>=0; i--) {
+        for (i=63; i>=0; i--) {
             if ((e[0] >> i) != 0) {
                 break;
             }
@@ -3643,14 +3643,14 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
     sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-    sp_digit e[1] = {0};
+    sp_uint64 e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 256U) {
         err = MP_TO_E;
     }
     if (err == MP_OKAY) {
-        if (mp_count_bits(em) > 29) {
+        if (mp_count_bits(em) > 64) {
             err = MP_READ_E;
         }
         else if (inLen > 256U) {
@@ -3679,12 +3679,12 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         m = r + 72 * 2;
 
         sp_2048_from_bin(a, 72, in, inLen);
-#if DIGIT_BIT >= 29
-        e[0] = (sp_digit)em->dp[0];
+#if DIGIT_BIT >= 64
+        e[0] = (sp_uint64)em->dp[0];
 #else
-        e[0] = (sp_digit)em->dp[0];
+        e[0] = (sp_uint64)em->dp[0];
         if (em->used > 1) {
-            e[0] |= ((sp_digit)em->dp[1]) << DIGIT_BIT;
+            e[0] |= ((sp_uint64)em->dp[1]) << DIGIT_BIT;
         }
 #endif
         if (e[0] == 0) {
@@ -3714,7 +3714,7 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
             err = sp_2048_mod_72(a, a, m);
 
             if (err == MP_OKAY) {
-                for (i=28; i>=0; i--) {
+                for (i=63; i>=0; i--) {
                     if ((e[0] >> i) != 0) {
                         break;
                     }
@@ -7001,7 +7001,7 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     sp_digit* norm = NULL;
-    sp_digit e[1] = {0};
+    sp_uint64 e[1] = {0};
     sp_digit mp = 0;
     int i;
     int err = MP_OKAY;
@@ -7011,7 +7011,7 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
     }
 
     if (err == MP_OKAY) {
-        if (mp_count_bits(em) > 29) {
+        if (mp_count_bits(em) > 64) {
             err = MP_READ_E;
         }
         else if (inLen > 384U) {
@@ -7040,12 +7040,12 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         norm = r;
 
         sp_3072_from_bin(a, 106, in, inLen);
-#if DIGIT_BIT >= 29
-        e[0] = (sp_digit)em->dp[0];
+#if DIGIT_BIT >= 64
+        e[0] = (sp_uint64)em->dp[0];
 #else
-        e[0] = (sp_digit)em->dp[0];
+        e[0] = (sp_uint64)em->dp[0];
         if (em->used > 1) {
-            e[0] |= ((sp_digit)em->dp[1]) << DIGIT_BIT;
+            e[0] |= ((sp_uint64)em->dp[1]) << DIGIT_BIT;
         }
 #endif
         if (e[0] == 0) {
@@ -7064,7 +7064,7 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         err = sp_3072_mod_106(a, a, m);
     }
     if (err == MP_OKAY) {
-        for (i=28; i>=0; i--) {
+        for (i=63; i>=0; i--) {
             if ((e[0] >> i) != 0) {
                 break;
             }
@@ -7101,14 +7101,14 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
     sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-    sp_digit e[1] = {0};
+    sp_uint64 e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 384U) {
         err = MP_TO_E;
     }
     if (err == MP_OKAY) {
-        if (mp_count_bits(em) > 29) {
+        if (mp_count_bits(em) > 64) {
             err = MP_READ_E;
         }
         else if (inLen > 384U) {
@@ -7137,12 +7137,12 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         m = r + 106 * 2;
 
         sp_3072_from_bin(a, 106, in, inLen);
-#if DIGIT_BIT >= 29
-        e[0] = (sp_digit)em->dp[0];
+#if DIGIT_BIT >= 64
+        e[0] = (sp_uint64)em->dp[0];
 #else
-        e[0] = (sp_digit)em->dp[0];
+        e[0] = (sp_uint64)em->dp[0];
         if (em->used > 1) {
-            e[0] |= ((sp_digit)em->dp[1]) << DIGIT_BIT;
+            e[0] |= ((sp_uint64)em->dp[1]) << DIGIT_BIT;
         }
 #endif
         if (e[0] == 0) {
@@ -7172,7 +7172,7 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
             err = sp_3072_mod_106(a, a, m);
 
             if (err == MP_OKAY) {
-                for (i=28; i>=0; i--) {
+                for (i=63; i>=0; i--) {
                     if ((e[0] >> i) != 0) {
                         break;
                     }
@@ -11119,7 +11119,7 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     sp_digit* norm = NULL;
-    sp_digit e[1] = {0};
+    sp_uint64 e[1] = {0};
     sp_digit mp = 0;
     int i;
     int err = MP_OKAY;
@@ -11129,7 +11129,7 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
     }
 
     if (err == MP_OKAY) {
-        if (mp_count_bits(em) > 28) {
+        if (mp_count_bits(em) > 64) {
             err = MP_READ_E;
         }
         else if (inLen > 384U) {
@@ -11158,12 +11158,12 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         norm = r;
 
         sp_3072_from_bin(a, 112, in, inLen);
-#if DIGIT_BIT >= 28
-        e[0] = (sp_digit)em->dp[0];
+#if DIGIT_BIT >= 64
+        e[0] = (sp_uint64)em->dp[0];
 #else
-        e[0] = (sp_digit)em->dp[0];
+        e[0] = (sp_uint64)em->dp[0];
         if (em->used > 1) {
-            e[0] |= ((sp_digit)em->dp[1]) << DIGIT_BIT;
+            e[0] |= ((sp_uint64)em->dp[1]) << DIGIT_BIT;
         }
 #endif
         if (e[0] == 0) {
@@ -11182,7 +11182,7 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         err = sp_3072_mod_112(a, a, m);
     }
     if (err == MP_OKAY) {
-        for (i=27; i>=0; i--) {
+        for (i=63; i>=0; i--) {
             if ((e[0] >> i) != 0) {
                 break;
             }
@@ -11219,14 +11219,14 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
     sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-    sp_digit e[1] = {0};
+    sp_uint64 e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 384U) {
         err = MP_TO_E;
     }
     if (err == MP_OKAY) {
-        if (mp_count_bits(em) > 28) {
+        if (mp_count_bits(em) > 64) {
             err = MP_READ_E;
         }
         else if (inLen > 384U) {
@@ -11255,12 +11255,12 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         m = r + 112 * 2;
 
         sp_3072_from_bin(a, 112, in, inLen);
-#if DIGIT_BIT >= 28
-        e[0] = (sp_digit)em->dp[0];
+#if DIGIT_BIT >= 64
+        e[0] = (sp_uint64)em->dp[0];
 #else
-        e[0] = (sp_digit)em->dp[0];
+        e[0] = (sp_uint64)em->dp[0];
         if (em->used > 1) {
-            e[0] |= ((sp_digit)em->dp[1]) << DIGIT_BIT;
+            e[0] |= ((sp_uint64)em->dp[1]) << DIGIT_BIT;
         }
 #endif
         if (e[0] == 0) {
@@ -11290,7 +11290,7 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
             err = sp_3072_mod_112(a, a, m);
 
             if (err == MP_OKAY) {
-                for (i=27; i>=0; i--) {
+                for (i=63; i>=0; i--) {
                     if ((e[0] >> i) != 0) {
                         break;
                     }
@@ -14659,7 +14659,7 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     sp_digit* norm = NULL;
-    sp_digit e[1] = {0};
+    sp_uint64 e[1] = {0};
     sp_digit mp = 0;
     int i;
     int err = MP_OKAY;
@@ -14669,7 +14669,7 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
     }
 
     if (err == MP_OKAY) {
-        if (mp_count_bits(em) > 29) {
+        if (mp_count_bits(em) > 64) {
             err = MP_READ_E;
         }
         else if (inLen > 512U) {
@@ -14698,12 +14698,12 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         norm = r;
 
         sp_4096_from_bin(a, 142, in, inLen);
-#if DIGIT_BIT >= 29
-        e[0] = (sp_digit)em->dp[0];
+#if DIGIT_BIT >= 64
+        e[0] = (sp_uint64)em->dp[0];
 #else
-        e[0] = (sp_digit)em->dp[0];
+        e[0] = (sp_uint64)em->dp[0];
         if (em->used > 1) {
-            e[0] |= ((sp_digit)em->dp[1]) << DIGIT_BIT;
+            e[0] |= ((sp_uint64)em->dp[1]) << DIGIT_BIT;
         }
 #endif
         if (e[0] == 0) {
@@ -14722,7 +14722,7 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         err = sp_4096_mod_142(a, a, m);
     }
     if (err == MP_OKAY) {
-        for (i=28; i>=0; i--) {
+        for (i=63; i>=0; i--) {
             if ((e[0] >> i) != 0) {
                 break;
             }
@@ -14759,14 +14759,14 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
     sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-    sp_digit e[1] = {0};
+    sp_uint64 e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 512U) {
         err = MP_TO_E;
     }
     if (err == MP_OKAY) {
-        if (mp_count_bits(em) > 29) {
+        if (mp_count_bits(em) > 64) {
             err = MP_READ_E;
         }
         else if (inLen > 512U) {
@@ -14795,12 +14795,12 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         m = r + 142 * 2;
 
         sp_4096_from_bin(a, 142, in, inLen);
-#if DIGIT_BIT >= 29
-        e[0] = (sp_digit)em->dp[0];
+#if DIGIT_BIT >= 64
+        e[0] = (sp_uint64)em->dp[0];
 #else
-        e[0] = (sp_digit)em->dp[0];
+        e[0] = (sp_uint64)em->dp[0];
         if (em->used > 1) {
-            e[0] |= ((sp_digit)em->dp[1]) << DIGIT_BIT;
+            e[0] |= ((sp_uint64)em->dp[1]) << DIGIT_BIT;
         }
 #endif
         if (e[0] == 0) {
@@ -14830,7 +14830,7 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
             err = sp_4096_mod_142(a, a, m);
 
             if (err == MP_OKAY) {
-                for (i=28; i>=0; i--) {
+                for (i=63; i>=0; i--) {
                     if ((e[0] >> i) != 0) {
                         break;
                     }
@@ -18644,7 +18644,7 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     sp_digit* norm = NULL;
-    sp_digit e[1] = {0};
+    sp_uint64 e[1] = {0};
     sp_digit mp = 0;
     int i;
     int err = MP_OKAY;
@@ -18654,7 +18654,7 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
     }
 
     if (err == MP_OKAY) {
-        if (mp_count_bits(em) > 26) {
+        if (mp_count_bits(em) > 64) {
             err = MP_READ_E;
         }
         else if (inLen > 512U) {
@@ -18683,12 +18683,12 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         norm = r;
 
         sp_4096_from_bin(a, 162, in, inLen);
-#if DIGIT_BIT >= 26
-        e[0] = (sp_digit)em->dp[0];
+#if DIGIT_BIT >= 64
+        e[0] = (sp_uint64)em->dp[0];
 #else
-        e[0] = (sp_digit)em->dp[0];
+        e[0] = (sp_uint64)em->dp[0];
         if (em->used > 1) {
-            e[0] |= ((sp_digit)em->dp[1]) << DIGIT_BIT;
+            e[0] |= ((sp_uint64)em->dp[1]) << DIGIT_BIT;
         }
 #endif
         if (e[0] == 0) {
@@ -18707,7 +18707,7 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         err = sp_4096_mod_162(a, a, m);
     }
     if (err == MP_OKAY) {
-        for (i=25; i>=0; i--) {
+        for (i=63; i>=0; i--) {
             if ((e[0] >> i) != 0) {
                 break;
             }
@@ -18744,14 +18744,14 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
     sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-    sp_digit e[1] = {0};
+    sp_uint64 e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 512U) {
         err = MP_TO_E;
     }
     if (err == MP_OKAY) {
-        if (mp_count_bits(em) > 26) {
+        if (mp_count_bits(em) > 64) {
             err = MP_READ_E;
         }
         else if (inLen > 512U) {
@@ -18780,12 +18780,12 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         m = r + 162 * 2;
 
         sp_4096_from_bin(a, 162, in, inLen);
-#if DIGIT_BIT >= 26
-        e[0] = (sp_digit)em->dp[0];
+#if DIGIT_BIT >= 64
+        e[0] = (sp_uint64)em->dp[0];
 #else
-        e[0] = (sp_digit)em->dp[0];
+        e[0] = (sp_uint64)em->dp[0];
         if (em->used > 1) {
-            e[0] |= ((sp_digit)em->dp[1]) << DIGIT_BIT;
+            e[0] |= ((sp_uint64)em->dp[1]) << DIGIT_BIT;
         }
 #endif
         if (e[0] == 0) {
@@ -18815,7 +18815,7 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
             err = sp_4096_mod_162(a, a, m);
 
             if (err == MP_OKAY) {
-                for (i=25; i>=0; i--) {
+                for (i=63; i>=0; i--) {
                     if ((e[0] >> i) != 0) {
                         break;
                     }

--- a/wolfcrypt/src/sp_c64.c
+++ b/wolfcrypt/src/sp_c64.c
@@ -2214,7 +2214,7 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     sp_digit* norm = NULL;
-    sp_digit e[1] = {0};
+    sp_uint64 e[1] = {0};
     sp_digit mp = 0;
     int i;
     int err = MP_OKAY;
@@ -2224,7 +2224,7 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
     }
 
     if (err == MP_OKAY) {
-        if (mp_count_bits(em) > 61) {
+        if (mp_count_bits(em) > 64) {
             err = MP_READ_E;
         }
         else if (inLen > 256U) {
@@ -2253,12 +2253,12 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         norm = r;
 
         sp_2048_from_bin(a, 34, in, inLen);
-#if DIGIT_BIT >= 61
-        e[0] = (sp_digit)em->dp[0];
+#if DIGIT_BIT >= 64
+        e[0] = (sp_uint64)em->dp[0];
 #else
-        e[0] = (sp_digit)em->dp[0];
+        e[0] = (sp_uint64)em->dp[0];
         if (em->used > 1) {
-            e[0] |= ((sp_digit)em->dp[1]) << DIGIT_BIT;
+            e[0] |= ((sp_uint64)em->dp[1]) << DIGIT_BIT;
         }
 #endif
         if (e[0] == 0) {
@@ -2277,7 +2277,7 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         err = sp_2048_mod_34(a, a, m);
     }
     if (err == MP_OKAY) {
-        for (i=60; i>=0; i--) {
+        for (i=63; i>=0; i--) {
             if ((e[0] >> i) != 0) {
                 break;
             }
@@ -2314,14 +2314,14 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
     sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-    sp_digit e[1] = {0};
+    sp_uint64 e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 256U) {
         err = MP_TO_E;
     }
     if (err == MP_OKAY) {
-        if (mp_count_bits(em) > 61) {
+        if (mp_count_bits(em) > 64) {
             err = MP_READ_E;
         }
         else if (inLen > 256U) {
@@ -2350,12 +2350,12 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         m = r + 34 * 2;
 
         sp_2048_from_bin(a, 34, in, inLen);
-#if DIGIT_BIT >= 61
-        e[0] = (sp_digit)em->dp[0];
+#if DIGIT_BIT >= 64
+        e[0] = (sp_uint64)em->dp[0];
 #else
-        e[0] = (sp_digit)em->dp[0];
+        e[0] = (sp_uint64)em->dp[0];
         if (em->used > 1) {
-            e[0] |= ((sp_digit)em->dp[1]) << DIGIT_BIT;
+            e[0] |= ((sp_uint64)em->dp[1]) << DIGIT_BIT;
         }
 #endif
         if (e[0] == 0) {
@@ -2385,7 +2385,7 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
             err = sp_2048_mod_34(a, a, m);
 
             if (err == MP_OKAY) {
-                for (i=60; i>=0; i--) {
+                for (i=63; i>=0; i--) {
                     if ((e[0] >> i) != 0) {
                         break;
                     }
@@ -5814,7 +5814,7 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     sp_digit* norm = NULL;
-    sp_digit e[1] = {0};
+    sp_uint64 e[1] = {0};
     sp_digit mp = 0;
     int i;
     int err = MP_OKAY;
@@ -5824,7 +5824,7 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
     }
 
     if (err == MP_OKAY) {
-        if (mp_count_bits(em) > 57) {
+        if (mp_count_bits(em) > 64) {
             err = MP_READ_E;
         }
         else if (inLen > 256U) {
@@ -5853,12 +5853,12 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         norm = r;
 
         sp_2048_from_bin(a, 36, in, inLen);
-#if DIGIT_BIT >= 57
-        e[0] = (sp_digit)em->dp[0];
+#if DIGIT_BIT >= 64
+        e[0] = (sp_uint64)em->dp[0];
 #else
-        e[0] = (sp_digit)em->dp[0];
+        e[0] = (sp_uint64)em->dp[0];
         if (em->used > 1) {
-            e[0] |= ((sp_digit)em->dp[1]) << DIGIT_BIT;
+            e[0] |= ((sp_uint64)em->dp[1]) << DIGIT_BIT;
         }
 #endif
         if (e[0] == 0) {
@@ -5877,7 +5877,7 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         err = sp_2048_mod_36(a, a, m);
     }
     if (err == MP_OKAY) {
-        for (i=56; i>=0; i--) {
+        for (i=63; i>=0; i--) {
             if ((e[0] >> i) != 0) {
                 break;
             }
@@ -5914,14 +5914,14 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
     sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-    sp_digit e[1] = {0};
+    sp_uint64 e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 256U) {
         err = MP_TO_E;
     }
     if (err == MP_OKAY) {
-        if (mp_count_bits(em) > 57) {
+        if (mp_count_bits(em) > 64) {
             err = MP_READ_E;
         }
         else if (inLen > 256U) {
@@ -5950,12 +5950,12 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         m = r + 36 * 2;
 
         sp_2048_from_bin(a, 36, in, inLen);
-#if DIGIT_BIT >= 57
-        e[0] = (sp_digit)em->dp[0];
+#if DIGIT_BIT >= 64
+        e[0] = (sp_uint64)em->dp[0];
 #else
-        e[0] = (sp_digit)em->dp[0];
+        e[0] = (sp_uint64)em->dp[0];
         if (em->used > 1) {
-            e[0] |= ((sp_digit)em->dp[1]) << DIGIT_BIT;
+            e[0] |= ((sp_uint64)em->dp[1]) << DIGIT_BIT;
         }
 #endif
         if (e[0] == 0) {
@@ -5985,7 +5985,7 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
             err = sp_2048_mod_36(a, a, m);
 
             if (err == MP_OKAY) {
-                for (i=56; i>=0; i--) {
+                for (i=63; i>=0; i--) {
                     if ((e[0] >> i) != 0) {
                         break;
                     }
@@ -9097,7 +9097,7 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     sp_digit* norm = NULL;
-    sp_digit e[1] = {0};
+    sp_uint64 e[1] = {0};
     sp_digit mp = 0;
     int i;
     int err = MP_OKAY;
@@ -9107,7 +9107,7 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
     }
 
     if (err == MP_OKAY) {
-        if (mp_count_bits(em) > 60) {
+        if (mp_count_bits(em) > 64) {
             err = MP_READ_E;
         }
         else if (inLen > 384U) {
@@ -9136,12 +9136,12 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         norm = r;
 
         sp_3072_from_bin(a, 52, in, inLen);
-#if DIGIT_BIT >= 60
-        e[0] = (sp_digit)em->dp[0];
+#if DIGIT_BIT >= 64
+        e[0] = (sp_uint64)em->dp[0];
 #else
-        e[0] = (sp_digit)em->dp[0];
+        e[0] = (sp_uint64)em->dp[0];
         if (em->used > 1) {
-            e[0] |= ((sp_digit)em->dp[1]) << DIGIT_BIT;
+            e[0] |= ((sp_uint64)em->dp[1]) << DIGIT_BIT;
         }
 #endif
         if (e[0] == 0) {
@@ -9160,7 +9160,7 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         err = sp_3072_mod_52(a, a, m);
     }
     if (err == MP_OKAY) {
-        for (i=59; i>=0; i--) {
+        for (i=63; i>=0; i--) {
             if ((e[0] >> i) != 0) {
                 break;
             }
@@ -9197,14 +9197,14 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
     sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-    sp_digit e[1] = {0};
+    sp_uint64 e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 384U) {
         err = MP_TO_E;
     }
     if (err == MP_OKAY) {
-        if (mp_count_bits(em) > 60) {
+        if (mp_count_bits(em) > 64) {
             err = MP_READ_E;
         }
         else if (inLen > 384U) {
@@ -9233,12 +9233,12 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         m = r + 52 * 2;
 
         sp_3072_from_bin(a, 52, in, inLen);
-#if DIGIT_BIT >= 60
-        e[0] = (sp_digit)em->dp[0];
+#if DIGIT_BIT >= 64
+        e[0] = (sp_uint64)em->dp[0];
 #else
-        e[0] = (sp_digit)em->dp[0];
+        e[0] = (sp_uint64)em->dp[0];
         if (em->used > 1) {
-            e[0] |= ((sp_digit)em->dp[1]) << DIGIT_BIT;
+            e[0] |= ((sp_uint64)em->dp[1]) << DIGIT_BIT;
         }
 #endif
         if (e[0] == 0) {
@@ -9268,7 +9268,7 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
             err = sp_3072_mod_52(a, a, m);
 
             if (err == MP_OKAY) {
-                for (i=59; i>=0; i--) {
+                for (i=63; i>=0; i--) {
                     if ((e[0] >> i) != 0) {
                         break;
                     }
@@ -12846,7 +12846,7 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     sp_digit* norm = NULL;
-    sp_digit e[1] = {0};
+    sp_uint64 e[1] = {0};
     sp_digit mp = 0;
     int i;
     int err = MP_OKAY;
@@ -12856,7 +12856,7 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
     }
 
     if (err == MP_OKAY) {
-        if (mp_count_bits(em) > 57) {
+        if (mp_count_bits(em) > 64) {
             err = MP_READ_E;
         }
         else if (inLen > 384U) {
@@ -12885,12 +12885,12 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         norm = r;
 
         sp_3072_from_bin(a, 54, in, inLen);
-#if DIGIT_BIT >= 57
-        e[0] = (sp_digit)em->dp[0];
+#if DIGIT_BIT >= 64
+        e[0] = (sp_uint64)em->dp[0];
 #else
-        e[0] = (sp_digit)em->dp[0];
+        e[0] = (sp_uint64)em->dp[0];
         if (em->used > 1) {
-            e[0] |= ((sp_digit)em->dp[1]) << DIGIT_BIT;
+            e[0] |= ((sp_uint64)em->dp[1]) << DIGIT_BIT;
         }
 #endif
         if (e[0] == 0) {
@@ -12909,7 +12909,7 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         err = sp_3072_mod_54(a, a, m);
     }
     if (err == MP_OKAY) {
-        for (i=56; i>=0; i--) {
+        for (i=63; i>=0; i--) {
             if ((e[0] >> i) != 0) {
                 break;
             }
@@ -12946,14 +12946,14 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
     sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-    sp_digit e[1] = {0};
+    sp_uint64 e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 384U) {
         err = MP_TO_E;
     }
     if (err == MP_OKAY) {
-        if (mp_count_bits(em) > 57) {
+        if (mp_count_bits(em) > 64) {
             err = MP_READ_E;
         }
         else if (inLen > 384U) {
@@ -12982,12 +12982,12 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         m = r + 54 * 2;
 
         sp_3072_from_bin(a, 54, in, inLen);
-#if DIGIT_BIT >= 57
-        e[0] = (sp_digit)em->dp[0];
+#if DIGIT_BIT >= 64
+        e[0] = (sp_uint64)em->dp[0];
 #else
-        e[0] = (sp_digit)em->dp[0];
+        e[0] = (sp_uint64)em->dp[0];
         if (em->used > 1) {
-            e[0] |= ((sp_digit)em->dp[1]) << DIGIT_BIT;
+            e[0] |= ((sp_uint64)em->dp[1]) << DIGIT_BIT;
         }
 #endif
         if (e[0] == 0) {
@@ -13017,7 +13017,7 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
             err = sp_3072_mod_54(a, a, m);
 
             if (err == MP_OKAY) {
-                for (i=56; i>=0; i--) {
+                for (i=63; i>=0; i--) {
                     if ((e[0] >> i) != 0) {
                         break;
                     }
@@ -16166,7 +16166,7 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     sp_digit* norm = NULL;
-    sp_digit e[1] = {0};
+    sp_uint64 e[1] = {0};
     sp_digit mp = 0;
     int i;
     int err = MP_OKAY;
@@ -16176,7 +16176,7 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
     }
 
     if (err == MP_OKAY) {
-        if (mp_count_bits(em) > 59) {
+        if (mp_count_bits(em) > 64) {
             err = MP_READ_E;
         }
         else if (inLen > 512U) {
@@ -16205,12 +16205,12 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         norm = r;
 
         sp_4096_from_bin(a, 70, in, inLen);
-#if DIGIT_BIT >= 59
-        e[0] = (sp_digit)em->dp[0];
+#if DIGIT_BIT >= 64
+        e[0] = (sp_uint64)em->dp[0];
 #else
-        e[0] = (sp_digit)em->dp[0];
+        e[0] = (sp_uint64)em->dp[0];
         if (em->used > 1) {
-            e[0] |= ((sp_digit)em->dp[1]) << DIGIT_BIT;
+            e[0] |= ((sp_uint64)em->dp[1]) << DIGIT_BIT;
         }
 #endif
         if (e[0] == 0) {
@@ -16229,7 +16229,7 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         err = sp_4096_mod_70(a, a, m);
     }
     if (err == MP_OKAY) {
-        for (i=58; i>=0; i--) {
+        for (i=63; i>=0; i--) {
             if ((e[0] >> i) != 0) {
                 break;
             }
@@ -16266,14 +16266,14 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
     sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-    sp_digit e[1] = {0};
+    sp_uint64 e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 512U) {
         err = MP_TO_E;
     }
     if (err == MP_OKAY) {
-        if (mp_count_bits(em) > 59) {
+        if (mp_count_bits(em) > 64) {
             err = MP_READ_E;
         }
         else if (inLen > 512U) {
@@ -16302,12 +16302,12 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         m = r + 70 * 2;
 
         sp_4096_from_bin(a, 70, in, inLen);
-#if DIGIT_BIT >= 59
-        e[0] = (sp_digit)em->dp[0];
+#if DIGIT_BIT >= 64
+        e[0] = (sp_uint64)em->dp[0];
 #else
-        e[0] = (sp_digit)em->dp[0];
+        e[0] = (sp_uint64)em->dp[0];
         if (em->used > 1) {
-            e[0] |= ((sp_digit)em->dp[1]) << DIGIT_BIT;
+            e[0] |= ((sp_uint64)em->dp[1]) << DIGIT_BIT;
         }
 #endif
         if (e[0] == 0) {
@@ -16337,7 +16337,7 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
             err = sp_4096_mod_70(a, a, m);
 
             if (err == MP_OKAY) {
-                for (i=58; i>=0; i--) {
+                for (i=63; i>=0; i--) {
                     if ((e[0] >> i) != 0) {
                         break;
                     }
@@ -19971,7 +19971,7 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     sp_digit* norm = NULL;
-    sp_digit e[1] = {0};
+    sp_uint64 e[1] = {0};
     sp_digit mp = 0;
     int i;
     int err = MP_OKAY;
@@ -19981,7 +19981,7 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
     }
 
     if (err == MP_OKAY) {
-        if (mp_count_bits(em) > 53) {
+        if (mp_count_bits(em) > 64) {
             err = MP_READ_E;
         }
         else if (inLen > 512U) {
@@ -20010,12 +20010,12 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         norm = r;
 
         sp_4096_from_bin(a, 78, in, inLen);
-#if DIGIT_BIT >= 53
-        e[0] = (sp_digit)em->dp[0];
+#if DIGIT_BIT >= 64
+        e[0] = (sp_uint64)em->dp[0];
 #else
-        e[0] = (sp_digit)em->dp[0];
+        e[0] = (sp_uint64)em->dp[0];
         if (em->used > 1) {
-            e[0] |= ((sp_digit)em->dp[1]) << DIGIT_BIT;
+            e[0] |= ((sp_uint64)em->dp[1]) << DIGIT_BIT;
         }
 #endif
         if (e[0] == 0) {
@@ -20034,7 +20034,7 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         err = sp_4096_mod_78(a, a, m);
     }
     if (err == MP_OKAY) {
-        for (i=52; i>=0; i--) {
+        for (i=63; i>=0; i--) {
             if ((e[0] >> i) != 0) {
                 break;
             }
@@ -20071,14 +20071,14 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
     sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-    sp_digit e[1] = {0};
+    sp_uint64 e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 512U) {
         err = MP_TO_E;
     }
     if (err == MP_OKAY) {
-        if (mp_count_bits(em) > 53) {
+        if (mp_count_bits(em) > 64) {
             err = MP_READ_E;
         }
         else if (inLen > 512U) {
@@ -20107,12 +20107,12 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         m = r + 78 * 2;
 
         sp_4096_from_bin(a, 78, in, inLen);
-#if DIGIT_BIT >= 53
-        e[0] = (sp_digit)em->dp[0];
+#if DIGIT_BIT >= 64
+        e[0] = (sp_uint64)em->dp[0];
 #else
-        e[0] = (sp_digit)em->dp[0];
+        e[0] = (sp_uint64)em->dp[0];
         if (em->used > 1) {
-            e[0] |= ((sp_digit)em->dp[1]) << DIGIT_BIT;
+            e[0] |= ((sp_uint64)em->dp[1]) << DIGIT_BIT;
         }
 #endif
         if (e[0] == 0) {
@@ -20142,7 +20142,7 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
             err = sp_4096_mod_78(a, a, m);
 
             if (err == MP_OKAY) {
-                for (i=52; i>=0; i--) {
+                for (i=63; i>=0; i--) {
                     if ((e[0] >> i) != 0) {
                         break;
                     }


### PR DESCRIPTION
# Description

SP C code only supported one digit worth of e which is less than 64 or 32.
Change is to support up to 64 bit of e using sp_uint64 to hold value.

# Testing

PoC - large e with SP C

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
