### PR TITLE
Parse explicit parameters in StoreEccKey()

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -7627,8 +7627,16 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
                 keyType = ecc_dsa_sa_algo;
             #endif
                 /* Determine ECC key size based on curve */
-                keySz = wc_ecc_get_curve_size_from_id(
-                    wc_ecc_get_oid(cert->pkCurveOID, NULL, NULL));
+            #ifdef WOLFSSL_CUSTOM_CURVES
+                if (cert->pkCurveOID == 0 && cert->pkCurveSize != 0) {
+                    keySz = cert->pkCurveSize * 8;
+                }
+                else
+            #endif
+                {
+                    keySz = wc_ecc_get_curve_size_from_id(
+                        wc_ecc_get_oid(cert->pkCurveOID, NULL, NULL));
+                }
 
                 if (ssl && !ssl->options.verifyNone) {
                     if (ssl->options.minEccKeySz < 0 ||

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1717,6 +1717,9 @@ struct DecodedCert {
 
 #if defined(HAVE_ECC) || defined(HAVE_ED25519) || defined(HAVE_ED448)
     word32  pkCurveOID;           /* Public Key's curve OID */
+    #ifdef WOLFSSL_CUSTOM_CURVES
+        int  pkCurveSize;         /* Public Key's curve size */
+    #endif
 #endif /* HAVE_ECC */
     const byte* beforeDate;
     int     beforeDateLen;


### PR DESCRIPTION
# Description

Parse explicit parameters in StoreEccKey() so that keySz is known when processing a cert with a non-named curve

Fixes zd#16470

# Testing

Zendesk reproducer.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
