### PR TITLE
uint128 and CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ check_type_size("time_t" SIZEOF_TIME_T)
 # but we want it as 1.
 if(HAVE___UINT128_T)
     set(HAVE___UINT128_T "1" CACHE INTERNAL "Result of TRY_COMPILE" FORCE)
+    list(APPEND WOLFSSL_DEFINITIONS "-DHAVE___UINT128_T")
 endif()
 
 include(TestBigEndian)


### PR DESCRIPTION
# Description

Add to the check for HAVE___UINT128_T adding it to the list of items that get dumped into the options.h file.

Fixes #6960.

# Testing

I built the library following the process in #6960 and compiled the sample code. Also built wolfSSH against this wolfSSL change and it didn't have issues.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
