### PR TITLE
AES bitsliced, ARMASM: config needs WOLFSSL_AES_DIRECT defined

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8707,6 +8707,9 @@ then
     AM_CFLAGS="$AM_CFLAGS -DNO_MD5 -DNO_OLD_TLS"
 fi
 
+AS_IF([test "x$ENABLED_AESBS" = "xyes" && test "x$ENABLED_ARMASM" = "xyes"],
+      [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_AES_DIRECT"])
+
 if test "$ENABLED_HMAC" = "no"
 then
     AM_CFLAGS="$AM_CFLAGS -DNO_HMAC"


### PR DESCRIPTION
# Description

AES bitsliced needs WOLFSSL_AES_DIRECT defined when compiling for ARMASM as there are different APIs used.

# Testing

./configure '--disable-shared' '--enable-aes-bitsliced' 'LDFLAGS=--static' '--host=aarch64' 'CC=aarch64-linux-gnu-gcc' '--enable-armasm' '--enable-cryptonly'

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
