### PR TITLE
WOLFSSL_SM2 sp_sm2_nnn files: no error for Espressif ESP-IDF

### DIFF
--- a/wolfcrypt/src/sp_sm2_arm32.c
+++ b/wolfcrypt/src/sp_sm2_arm32.c
@@ -27,7 +27,11 @@
 
 #ifdef WOLFSSL_SM2
 
-#error "See https://github.com/wolfSSL/wolfsm for implementation of this file"
+    #if defined(WOLFSSL_ESPIDF)
+        /* not used by Espressif ESP-IDF */
+    #else
+        #error "See https://github.com/wolfSSL/wolfsm for implementation of this file"
+    #endif
 
 #endif
 

--- a/wolfcrypt/src/sp_sm2_arm64.c
+++ b/wolfcrypt/src/sp_sm2_arm64.c
@@ -27,7 +27,11 @@
 
 #ifdef WOLFSSL_SM2
 
-#error "See https://github.com/wolfSSL/wolfsm for implementation of this file"
+    #if defined(WOLFSSL_ESPIDF)
+        /* not used by Espressif ESP-IDF */
+    #else
+        #error "See https://github.com/wolfSSL/wolfsm for implementation of this file"
+    #endif
 
 #endif
 

--- a/wolfcrypt/src/sp_sm2_armthumb.c
+++ b/wolfcrypt/src/sp_sm2_armthumb.c
@@ -27,7 +27,11 @@
 
 #ifdef WOLFSSL_SM2
 
-#error "See https://github.com/wolfSSL/wolfsm for implementation of this file"
+    #if defined(WOLFSSL_ESPIDF)
+        /* not used by Espressif ESP-IDF */
+    #else
+        #error "See https://github.com/wolfSSL/wolfsm for implementation of this file"
+    #endif
 
 #endif
 

--- a/wolfcrypt/src/sp_sm2_c32.c
+++ b/wolfcrypt/src/sp_sm2_c32.c
@@ -27,7 +27,11 @@
 
 #ifdef WOLFSSL_SM2
 
-#error "See https://github.com/wolfSSL/wolfsm for implementation of this file"
+    #if defined(WOLFSSL_ESPIDF)
+        /* not used by Espressif ESP-IDF */
+    #else
+        #error "See https://github.com/wolfSSL/wolfsm for implementation of this file"
+    #endif
 
 #endif
 

--- a/wolfcrypt/src/sp_sm2_c64.c
+++ b/wolfcrypt/src/sp_sm2_c64.c
@@ -27,7 +27,11 @@
 
 #ifdef WOLFSSL_SM2
 
-#error "See https://github.com/wolfSSL/wolfsm for implementation of this file"
+    #if defined(WOLFSSL_ESPIDF)
+        /* not used by Espressif ESP-IDF */
+    #else
+        #error "See https://github.com/wolfSSL/wolfsm for implementation of this file"
+    #endif
 
 #endif
 

--- a/wolfcrypt/src/sp_sm2_cortexm.c
+++ b/wolfcrypt/src/sp_sm2_cortexm.c
@@ -27,7 +27,11 @@
 
 #ifdef WOLFSSL_SM2
 
-#error "See https://github.com/wolfSSL/wolfsm for implementation of this file"
+    #if defined(WOLFSSL_ESPIDF)
+        /* not used by Espressif ESP-IDF */
+    #else
+        #error "See https://github.com/wolfSSL/wolfsm for implementation of this file"
+    #endif
 
 #endif
 

--- a/wolfcrypt/src/sp_sm2_x86_64.c
+++ b/wolfcrypt/src/sp_sm2_x86_64.c
@@ -27,7 +27,11 @@
 
 #ifdef WOLFSSL_SM2
 
-#error "See https://github.com/wolfSSL/wolfsm for implementation of this file"
+    #if defined(WOLFSSL_ESPIDF)
+        /* not used by Espressif ESP-IDF */
+    #else
+        #error "See https://github.com/wolfSSL/wolfsm for implementation of this file"
+    #endif
 
 #endif
 


### PR DESCRIPTION
# Description

Modifies ` wolfcrypt/src/sp_sm2_[arch].c` files to not give compiler error for missing SM cipher files in Espressif ESP-IDF environment that otherwise causes build-time error for files not used.

I'm also in the process of modifying https://github.com/wolfSSL/wolfssl/pull/6844 to update example `CMakeLists.txt` files to also exclude these file from build. Any existing projects will of course still be problematic without this PR.

Fixes zd# n/a

# Testing

How did you test? 

Tested in ESP-IDF only.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
