### PR TITLE
Fix build errors with dtls1.3 and no tls1.2

### DIFF
--- a/examples/sctp/sctp-client-dtls.c
+++ b/examples/sctp/sctp-client-dtls.c
@@ -27,7 +27,7 @@
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/ssl.h>
 
-#if defined(WOLFSSL_SCTP) && defined(WOLFSSL_DTLS)
+#if defined(WOLFSSL_SCTP) && defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12)
 /* sctp */
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -47,13 +47,13 @@ static int err_sys(const char* msg)
     perror(msg);
     exit(EXIT_FAILURE);
 }
-#endif /* WOLFSSL_SCTP && WOLFSSL_DTLS */
+#endif /* WOLFSSL_SCTP && WOLFSSL_DTLS && !WOLFSSL_NO_TLS12 */
 
 int main(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
-#if defined(WOLFSSL_SCTP) && defined(WOLFSSL_DTLS)
+#if defined(WOLFSSL_SCTP) && defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12)
     int sd = socket(PF_INET, SOCK_STREAM, IPPROTO_SCTP);
 
     if (sd < 0)
@@ -126,7 +126,7 @@ int main(int argc, char **argv)
     wolfSSL_CTX_free(ctx);
 
     close(sd);
-#endif /* WOLFSSL_SCTP && WOLFSSL_DTLS */
+#endif /* WOLFSSL_SCTP && WOLFSSL_DTLS && !WOLFSSL_NO_TLS12 */
 
     return 0;
 }

--- a/examples/sctp/sctp-server-dtls.c
+++ b/examples/sctp/sctp-server-dtls.c
@@ -26,7 +26,7 @@
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/ssl.h>
 
-#if defined(WOLFSSL_SCTP) && defined(WOLFSSL_DTLS)
+#if defined(WOLFSSL_SCTP) && defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12)
 /* sctp */
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -47,13 +47,13 @@ static int err_sys(const char* msg)
     perror(msg);
     exit(EXIT_FAILURE);
 }
-#endif /* WOLFSSL_SCTP && WOLFSSL_DTLS */
+#endif /* WOLFSSL_SCTP && WOLFSSL_DTLS && !WOLFSSL_NO_TLS12 */
 
 int main(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
-#if defined(WOLFSSL_SCTP) && defined(WOLFSSL_DTLS)
+#if defined(WOLFSSL_SCTP) && defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12)
     int sd = socket(PF_INET, SOCK_STREAM, IPPROTO_SCTP);
 
     if (sd < 0)
@@ -125,6 +125,6 @@ int main(int argc, char **argv)
     wolfSSL_CTX_free(ctx);
 
     close(sd);
-#endif /* WOLFSSL_SCTP && WOLFSSL_DTLS */
+#endif /* WOLFSSL_SCTP && WOLFSSL_DTLS && !WOLFSSL_NO_TLS12 */
     return 0;
 }

--- a/src/dtls.c
+++ b/src/dtls.c
@@ -868,6 +868,7 @@ static int SendStatelessReply(const WOLFSSL* ssl, WolfSSL_CH* ch, byte isTls13)
     else
 #endif
     {
+#if !defined(WOLFSSL_NO_TLS12)
         if (!ch->dtls12cookieSet) {
             ret = CreateDtls12Cookie(ssl, ch, ch->dtls12cookie);
             if (ret != 0)
@@ -876,6 +877,11 @@ static int SendStatelessReply(const WOLFSSL* ssl, WolfSSL_CH* ch, byte isTls13)
         }
         ret = SendHelloVerifyRequest((WOLFSSL*)ssl, ch->dtls12cookie,
                 DTLS_COOKIE_SZ);
+#else
+        WOLFSSL_MSG("DTLS1.2 disabled with WOLFSSL_NO_TLS12");
+        WOLFSSL_ERROR_VERBOSE(NOT_COMPILED_IN);
+        ret = NOT_COMPILED_IN;
+#endif
     }
     return ret;
 }

--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -372,8 +372,14 @@ int Dtls13ProcessBufferedMessages(WOLFSSL* ssl)
                 downgraded = 1;
         }
         else {
+#if !defined(WOLFSSL_NO_TLS12)
             ret = DoHandShakeMsgType(ssl, msg->fullMsg, &idx, msg->type,
                     msg->sz, msg->sz);
+#else
+            WOLFSSL_MSG("DTLS1.2 disabled with WOLFSSL_NO_TLS12");
+            WOLFSSL_ERROR_VERBOSE(NOT_COMPILED_IN);
+            ret = NOT_COMPILED_IN;
+#endif
         }
 
         /* processing certificate_request triggers a connect. The error came

--- a/src/tls.c
+++ b/src/tls.c
@@ -678,55 +678,6 @@ int wolfSSL_make_eap_keys(WOLFSSL* ssl, void* msk, unsigned int len,
     return ret;
 }
 
-int wolfSSL_GetHmacType_ex(CipherSpecs* specs)
-{
-    if (specs == NULL)
-        return BAD_FUNC_ARG;
-
-    switch (specs->mac_algorithm) {
-        #ifndef NO_MD5
-        case md5_mac:
-        {
-            return WC_MD5;
-        }
-        #endif
-        #ifndef NO_SHA256
-        case sha256_mac:
-        {
-            return WC_SHA256;
-        }
-        #endif
-        #ifdef WOLFSSL_SHA384
-        case sha384_mac:
-        {
-            return WC_SHA384;
-        }
-        #endif
-        #ifdef WOLFSSL_SM3
-        case sm3_mac:
-        {
-            return WC_SM3;
-        }
-        #endif
-        #ifndef NO_SHA
-        case sha_mac:
-        {
-            return WC_SHA;
-        }
-        #endif
-        #ifdef HAVE_BLAKE2
-        case blake2b_mac:
-        {
-            return BLAKE2B_ID;
-        }
-        #endif
-        default:
-        {
-            return WOLFSSL_FATAL_ERROR;
-        }
-    }
-}
-
 /* return HMAC digest type in wolfSSL format */
 int wolfSSL_GetHmacType(WOLFSSL* ssl)
 {
@@ -1276,6 +1227,55 @@ int TLS_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz, int padSz,
 #endif /* WOLFSSL_AEAD_ONLY */
 
 #endif /* !WOLFSSL_NO_TLS12 */
+
+int wolfSSL_GetHmacType_ex(CipherSpecs* specs)
+{
+    if (specs == NULL)
+        return BAD_FUNC_ARG;
+
+    switch (specs->mac_algorithm) {
+        #ifndef NO_MD5
+        case md5_mac:
+        {
+            return WC_MD5;
+        }
+        #endif
+        #ifndef NO_SHA256
+        case sha256_mac:
+        {
+            return WC_SHA256;
+        }
+        #endif
+        #ifdef WOLFSSL_SHA384
+        case sha384_mac:
+        {
+            return WC_SHA384;
+        }
+        #endif
+        #ifdef WOLFSSL_SM3
+        case sm3_mac:
+        {
+            return WC_SM3;
+        }
+        #endif
+        #ifndef NO_SHA
+        case sha_mac:
+        {
+            return WC_SHA;
+        }
+        #endif
+        #ifdef HAVE_BLAKE2
+        case blake2b_mac:
+        {
+            return BLAKE2B_ID;
+        }
+        #endif
+        default:
+        {
+            return WOLFSSL_FATAL_ERROR;
+        }
+    }
+}
 
 #ifdef HAVE_TLS_EXTENSIONS
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -59684,7 +59684,8 @@ static int test_wolfSSL_dtls_set_mtu(void)
 {
     EXPECT_DECLS;
 #if (defined(WOLFSSL_DTLS_MTU) || defined(WOLFSSL_SCTP)) && \
-    !defined(NO_WOLFSSL_SERVER) && defined(WOLFSSL_DTLS)
+    !defined(NO_WOLFSSL_SERVER) && defined(WOLFSSL_DTLS) && \
+    !defined(WOLFSSL_NO_TLS12)
     WOLFSSL_CTX* ctx = NULL;
     WOLFSSL*     ssl = NULL;
     const char* testCertFile;
@@ -59722,7 +59723,7 @@ static int test_wolfSSL_dtls_set_mtu(void)
 }
 
 #if defined(HAVE_IO_TESTS_DEPENDENCIES) && !defined(SINGLE_THREADED) && \
-    defined(WOLFSSL_DTLS)
+    defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12)
 
 static WC_INLINE void generateDTLSMsg(byte* out, int outSz, word32 seq,
         enum HandShakeType hsType, word16 length)
@@ -59842,7 +59843,7 @@ static int test_wolfSSL_dtls_plaintext(void) {
 #endif
 
 #if defined(HAVE_IO_TESTS_DEPENDENCIES) && !defined(SINGLE_THREADED) && \
-    defined(WOLFSSL_DTLS)
+    defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_TLS12)
 
 static void test_wolfSSL_dtls12_fragments_spammer(WOLFSSL* ssl)
 {
@@ -59963,8 +59964,10 @@ static int test_wolfSSL_dtls_fragments(void)
         method_provider server_meth;
         ssl_callback spammer;
     } params[] = {
+#if !defined(WOLFSSL_NO_TLS12)
         {wolfDTLSv1_2_client_method, wolfDTLSv1_2_server_method,
                 test_wolfSSL_dtls12_fragments_spammer},
+#endif
 #ifdef WOLFSSL_DTLS13
         {wolfDTLSv1_3_client_method, wolfDTLSv1_3_server_method,
                 test_wolfSSL_dtls13_fragments_spammer},
@@ -60029,10 +60032,15 @@ static int _test_wolfSSL_ignore_alert_before_cookie(byte version12)
     XMEMSET(&server_cbs, 0, sizeof(server_cbs));
     client_cbs.doUdp = server_cbs.doUdp = 1;
     if (version12) {
+#if !defined(WOLFSSL_NO_TLS12)
         client_cbs.method = wolfDTLSv1_2_client_method;
         server_cbs.method = wolfDTLSv1_2_server_method;
+#else
+        return TEST_SKIPPED;
+#endif
     }
-    else {
+    else
+    {
 #ifdef WOLFSSL_DTLS13
         client_cbs.method = wolfDTLSv1_3_client_method;
         server_cbs.method = wolfDTLSv1_3_server_method;
@@ -60125,17 +60133,18 @@ static int _test_wolfSSL_dtls_bad_record(
 
 static int test_wolfSSL_dtls_bad_record(void)
 {
-    int ret;
+    int ret = TEST_SUCCESS;
+#if !defined(WOLFSSL_NO_TLS12)
     ret = _test_wolfSSL_dtls_bad_record(wolfDTLSv1_2_client_method,
         wolfDTLSv1_2_server_method);
+#endif
 #ifdef WOLFSSL_DTLS13
-    if (ret != TEST_SUCCESS)
-        return ret;
-    return _test_wolfSSL_dtls_bad_record(wolfDTLSv1_3_client_method,
+    if (ret == TEST_SUCCESS) {
+        ret = _test_wolfSSL_dtls_bad_record(wolfDTLSv1_3_client_method,
         wolfDTLSv1_3_server_method);
-#else
-    return ret;
+    }
 #endif /* WOLFSSL_DTLS13 */
+    return ret;
 
 }
 
@@ -60620,8 +60629,10 @@ static int test_wolfSSL_dtls_stateless(void)
         ssl_callback client_ssl_ready;
         ssl_callback server_ssl_ready;
     } test_params[] = {
+#if !defined(WOLFSSL_NO_TLS12)
         {wolfDTLSv1_2_client_method, wolfDTLSv1_2_server_method,
                 test_wolfSSL_dtls_send_ch, test_wolfSSL_dtls_compare_stateless},
+#endif
 #if defined(WOLFSSL_DTLS13) && defined(WOLFSSL_SEND_HRR_COOKIE)
         {wolfDTLSv1_3_client_method, wolfDTLSv1_3_server_method,
                 test_wolfSSL_dtls_send_ch, test_wolfSSL_dtls_enable_hrrcookie},
@@ -60629,6 +60640,10 @@ static int test_wolfSSL_dtls_stateless(void)
                 test_wolfSSL_dtls_send_ch_with_invalid_cookie, test_wolfSSL_dtls_enable_hrrcookie},
 #endif
     };
+
+    if (0 == sizeof(test_params)){
+        return TEST_SKIPPED;
+    }
 
     for (i = 0; i < sizeof(test_params)/sizeof(*test_params); i++) {
         XMEMSET(&client_cbs, 0, sizeof(client_cbs));
@@ -65867,7 +65882,7 @@ static int test_dtls_msg_from_other_peer(void)
         *  !defined(SINGLE_THREADED) && !defined(NO_RSA) */
 #if defined(WOLFSSL_DTLS) && !defined(WOLFSSL_IPV6) &&               \
     !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) &&   \
-    defined(HAVE_IO_TESTS_DEPENDENCIES)
+    defined(HAVE_IO_TESTS_DEPENDENCIES) && !defined(WOLFSSL_NO_TLS12)
 static int test_dtls_ipv6_check(void)
 {
     EXPECT_DECLS;
@@ -66017,7 +66032,8 @@ static int test_wolfSSL_configure_args(void)
 static int test_dtls_no_extensions(void)
 {
     EXPECT_DECLS;
-#if defined(WOLFSSL_DTLS) && defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES)
+#if defined(WOLFSSL_DTLS) && defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && \
+    !defined(WOLFSSL_NO_TLS12)
     WOLFSSL *ssl_s = NULL;
     WOLFSSL_CTX *ctx_s = NULL;
     struct test_memio_ctx test_ctx;
@@ -66498,7 +66514,9 @@ static int test_dtls_downgrade_scr(void)
 }
 #endif
 
-#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_DTLS13)
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_DTLS13) \
+    && !defined(WOLFSSL_NO_TLS12)
+
 static int test_dtls_client_hello_timeout_downgrade_read_cb(WOLFSSL *ssl,
         char *data, int sz, void *ctx)
 {
@@ -66525,7 +66543,9 @@ static int test_dtls_client_hello_timeout_downgrade_read_cb(WOLFSSL *ssl,
 static int test_dtls_client_hello_timeout_downgrade(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_DTLS13)
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_DTLS13) \
+    && !defined(WOLFSSL_NO_TLS12)
+
     WOLFSSL_CTX *ctx_c = NULL;
     WOLFSSL_CTX *ctx_s = NULL;
     WOLFSSL *ssl_c = NULL;
@@ -66733,7 +66753,9 @@ static int test_dtls_client_hello_timeout(void)
 static int test_dtls_dropped_ccs(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_DTLS)
+#if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_DTLS) \
+    && !defined(WOLFSSL_NO_TLS12)
+
     WOLFSSL_CTX *ctx_c = NULL;
     WOLFSSL_CTX *ctx_s = NULL;
     WOLFSSL *ssl_c = NULL;


### PR DESCRIPTION
# Description

Fixes build errors with `./configure --enable-dtls --enable-tls13 --enable-dtls13 --enable-sctp --disable-tlsv12`

Fixes #6974

# Testing

Clean build

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
