### PR TITLE
Fix evp SM cipherType check

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -14682,7 +14682,7 @@ int AddSessionToCache(WOLFSSL_CTX* ctx, WOLFSSL_SESSION* addSession,
         cacheSession->ticketNonce.data = cacheSession->ticketNonce.dataStatic;
         cacheSession->ticketNonce.len = 0;
     }
-#endif /* WOFLSSL_TLS13 && WOLFSSL_TICKET_NONCE_MALLOC && FIPS_VERSION_GE(5,3)*/
+#endif /* WOLFSSL_TLS13 && WOLFSSL_TICKET_NONCE_MALLOC && FIPS_VERSION_GE(5,3)*/
 #endif
 #ifdef SESSION_CERTS
     if (overwrite &&

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -6040,7 +6040,7 @@ void wolfSSL_EVP_init(void)
                 else
 #endif /* HAVE_CHACHA && HAVE_POLY1305 */
 #if defined(WOLFSSL_SM4_GCM)
-                if (ctx->cipherType == WOLFSSL_SM4_GCM) {
+                if (ctx->cipherType == SM4_GCM_TYPE) {
                     if (arg <= 0 || arg > SM4_BLOCK_SIZE) {
                         break;
                     }
@@ -6048,7 +6048,7 @@ void wolfSSL_EVP_init(void)
                 else
 #endif
 #if defined(WOLFSSL_SM4_CCM)
-                if (ctx->cipherType == WOLFSSL_SM4_CCM) {
+                if (ctx->cipherType == SM4_CCM_TYPE) {
                     if (arg <= 0 || arg > SM4_BLOCK_SIZE) {
                         break;
                     }

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -5992,8 +5992,8 @@ void wolfSSL_EVP_init(void)
                 }
                 else
 #endif /* HAVE_CHACHA && HAVE_POLY1305 */
-#if defined(WOFLSSL_SM4_GCM)
-                if (ctx->cipherType == WOLFSSL_SM4_GCM) {
+#if defined(WOLFSSL_SM4_GCM)
+                if (ctx->cipherType == SM4_GCM_TYPE) {
                     if ((arg <= 0) || (arg > SM4_BLOCK_SIZE) || (ptr == NULL)) {
                         break;
                     }
@@ -6005,8 +6005,8 @@ void wolfSSL_EVP_init(void)
                 }
                 else
 #endif
-#if defined(WOFLSSL_SM4_CCM)
-                if (ctx->cipherType == WOLFSSL_SM4_CCM) {
+#if defined(WOLFSSL_SM4_CCM)
+                if (ctx->cipherType == SM4_CCM_TYPE) {
                     if ((arg <= 0) || (arg > SM4_BLOCK_SIZE) || (ptr == NULL)) {
                         break;
                     }


### PR DESCRIPTION
# Description

wolfcrypt [evp.c](https://github.com/wolfSSL/wolfssl/blob/69450932211fbf0b5ff02f01d2858ff0e53e53c0/wolfcrypt/src/evp.c#L6042) appears to have an incorrect value for SM Ciphers during `ctx->cipherType` check. The gating `WOLFSSL_SM4_GCM` is used, whereas I believe they need to be the macros in this PR.

Edit: updates `wolfSSL_EVP_CIPHER_CTX_ctrl()` for `EVP_CTRL_AEAD_SET_TAG` and `EVP_CTRL_AEAD_GET_TAG` conditions when using SM Ciphers with `WOLFSSL_SM4_GCM` and/or `WOLFSSL_SM4_CCM` enabled.

Fixes zd# n/a

# Testing

How did you test?

Tested only on embedded Espressif device.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
