### PR TITLE
rpm: move *.so file to -devel to be consistent with ecosystem

### DIFF
--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -81,7 +81,7 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_docdir}/wolfssl/README.txt
 %{_docdir}/wolfssl/QUIC.md
 
-%{_libdir}/libwolfssl@LIBSUFFIX@.so*
+%{_libdir}/libwolfssl@LIBSUFFIX@.so.*
 
 %files devel
 %defattr(-,root,root,-)
@@ -91,6 +91,8 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_includedir}/wolfssl/wolfcrypt/*.h
 %{_includedir}/wolfssl/openssl/*.h
 %{_libdir}/pkgconfig/wolfssl.pc
+
+%{_libdir}/libwolfssl@LIBSUFFIX@.so
 
 %changelog
 * Mon Oct 17 2022 Juliusz Sosinowicz <juliusz@wolfssl.com>


### PR DESCRIPTION
The bare *.so files are usually placed in the -devel subpackage

# Description

RPM packaging : move `libwolfssl.so` to the `-devel` subpackage to be consistent with most of the ecosystem

Fixes: N/A, enhancement

# Testing

How did you test? Rebuild from `rpm/spec`

# Checklist

 - [ ] added tests - N/A
 - [ ] updated/added doxygen - N/A
 - [ ] updated appropriate READMEs - N/A
 - [ ] Updated manual and documentation - N/A
