### PR TITLE
20231119-all-cryptonly-opensslextra

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -798,7 +798,7 @@ then
     if test "$ENABLED_LINUXKM_DEFAULTS" != "yes"
     then
         test "$enable_compkey" = "" && enable_compkey=yes
-        test "$enable_quic" = "" && enable_quic=yes
+        test "$enable_quic" = "" && test "$enable_cryptonly" != "yes" && enable_quic=yes
         AM_CFLAGS="$AM_CFLAGS -DHAVE_CRL_IO -DHAVE_IO_TIMEOUT"
     fi
 

--- a/linuxkm/module_exports.c.template
+++ b/linuxkm/module_exports.c.template
@@ -151,12 +151,14 @@
 
 #ifdef OPENSSL_EXTRA
   #ifndef WOLFCRYPT_ONLY
-    #include <wolfssl/openssl/evp.h>
+      #include <wolfssl/openssl/evp.h>
   #endif
     #include <wolfssl/openssl/rand.h>
     #include <wolfssl/openssl/hmac.h>
     #include <wolfssl/openssl/aes.h>
     #include <wolfssl/openssl/des.h>
+    #include <wolfssl/openssl/modes.h>
+    #include <wolfssl/openssl/rc4.h>
 #endif
 
 #if defined(NO_FILESYSTEM)

--- a/src/ssl_crypto.c
+++ b/src/ssl_crypto.c
@@ -2061,7 +2061,7 @@ size_t wolfSSL_HMAC_size(const WOLFSSL_HMAC_CTX* ctx)
  * START OF CMAC API
  ******************************************************************************/
 
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) && !defined(WOLFCRYPT_ONLY)
 #if defined(WOLFSSL_CMAC) && defined(OPENSSL_EXTRA) && \
     defined(WOLFSSL_AES_DIRECT)
 /* Allocate a new CMAC context object.
@@ -2275,7 +2275,7 @@ int wolfSSL_CMAC_Final(WOLFSSL_CMAC_CTX* ctx, unsigned char* out, size_t* len)
     return ret;
 }
 #endif /* WOLFSSL_CMAC && OPENSSL_EXTRA && WOLFSSL_AES_DIRECT */
-#endif /* OPENSSL_EXTRA */
+#endif /* OPENSSL_EXTRA && !WOLFCRYPT_ONLY */
 
 /*******************************************************************************
  * END OF CMAC API


### PR DESCRIPTION
cryptonly and linuxkm fixes: fix `--enable-all[-crypto]` with `--enable-opensslextra` and `--enable-cryptonly` (build failures detected by multi-test `linuxkm-all-asm-cryptonly-opensslextra-pie` after merge of 54f2d56300 and e2bbacd548).

tested with `wolfssl-multi-test.sh ... super-quick-check linuxkm-all-asm-cryptonly-opensslextra-pie`
