### PR TITLE
Initialize variables to appease Espressif compiler

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -30123,7 +30123,7 @@ static int set_curves_list(WOLFSSL* ssl, WOLFSSL_CTX *ctx, const char* names)
     char name[MAX_CURVE_NAME_SZ];
     byte groups_len = 0;
 #ifdef WOLFSSL_SMALL_STACK
-    void *heap = ssl? ssl->heap : ctx ? ctx->heap : NULL;
+    void *heap = ssl? ssl->heap : ctx ? ctx->heap : NULL; (void)heap;
     int *groups;
 #else
     int groups[WOLFSSL_MAX_GROUP_COUNT];

--- a/src/ssl_crypto.c
+++ b/src/ssl_crypto.c
@@ -1972,7 +1972,7 @@ unsigned char* wolfSSL_HMAC(const WOLFSSL_EVP_MD* evp_md, const void* key,
     unsigned char* ret = NULL;
     int rc = 0;
     int type = 0;
-    int hmacLen;
+    int hmacLen = 0;
 #ifdef WOLFSSL_SMALL_STACK
     Hmac* hmac = NULL;
 #else


### PR DESCRIPTION
# Description

Minor edits to appease compiler error / warnings, currently causing Jenkins failure in https://github.com/wolfSSL/wolfssl/pull/6844

```
[635/647] Building C object esp-idf/wolfssl/CMakeFiles/__idf_wolfssl.dir/C_/workspace/wolfssl-master/wolfcrypt/benchmark/benchmark.c.obj
[636/647] Building C object esp-idf/wolfssl/CMakeFiles/__idf_wolfssl.dir/C_/workspace/wolfssl-master/src/ssl.c.obj
FAILED: esp-idf/wolfssl/CMakeFiles/__idf_wolfssl.dir/C_/workspace/wolfssl-master/src/ssl.c.obj 
C:\SysGCC\esp32-11.2\tools\xtensa-esp32-elf\esp-2022r1-11.2.0\xtensa-esp32-elf\bin\xtensa-esp32-elf-gcc.exe -DLIBWOLFSSL_VERSION_GIT_BRANCH=\"master\" -DLIBWOLFSSL_VERSION_GIT_HASH=\"0306d07c47fcd2aee049dde734dd97ad3aa6b22c\" -DLIBWOLFSSL_VERSION_GIT_HASH_DATE="\"'Wed Nov 22 13:29:51 2023 -0700'\"" -DLIBWOLFSSL_VERSION_GIT_ORIGIN=\"https://github.com/gojimmypi/wolfssl.git\" -DLIBWOLFSSL_VERSION_GIT_SHORT_HASH=\"0306d07c4\" -Iconfig -I../../../components/wolfssl/include -IC:/workspace/wolfssl-master -IC:/workspace/wolfssl-master/wolfssl -IC:/workspace/wolfssl-master/wolfssl/wolfcrypt -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/freertos/FreeRTOS-Kernel/include/freertos -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/newlib/platform_include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/freertos/FreeRTOS-Kernel/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/freertos/esp_additions/include/freertos -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/freertos/FreeRTOS-Kernel/portable/xtensa/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/freertos/esp_additions/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/esp_hw_support/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/esp_hw_support/include/soc -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/esp_hw_support/include/soc/esp32 -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/esp_hw_support/port/esp32/. -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/esp_hw_support/port/esp32/private_include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/heap/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/log/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/soc/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/soc/esp32/. -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/soc/esp32/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/hal/esp32/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/hal/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/hal/platform_port/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/esp_rom/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/esp_rom/include/esp32 -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/esp_rom/esp32 -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/esp_common/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/esp_system/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/esp_system/port/soc -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/esp_system/port/include/private -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/xtensa/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/xtensa/esp32/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/lwip/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/lwip/include/apps -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/lwip/include/apps/sntp -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/lwip/lwip/src/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/lwip/port/esp32/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/lwip/port/esp32/include/arch -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/esp_timer/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/driver/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/driver/deprecated -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/driver/esp32/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/esp_pm/include -IC:/SysGCC/esp32-11.2/esp-idf/v5.0/components/esp_ringbuf/include -mlongcalls -Wno-frame-address  -DWOLFSSL_USER_SETTINGS -g -ffunction-sections -fdata-sections -Wall -Werror=all -Wno-error=unused-function -Wno-error=unused-variable -Wno-error=deprecated-declarations -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-enum-conversion -gdwarf-4 -ggdb -Og -fstack-protector -fmacro-prefix-map=C:/workspace/wolfssl-master/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark=. -fmacro-prefix-map=C:/SysGCC/esp32-11.2/esp-idf/v5.0=/IDF -fstrict-volatile-bitfields -Wno-error=unused-but-set-variable -fno-jump-tables -fno-tree-switch-conversion -DconfigENABLE_FREERTOS_DEBUG_OCDAWARE=1 -std=gnu17 -Wno-old-style-declaration -D_GNU_SOURCE -DIDF_VER=\"v5.0-dirty\" -DESP_PLATFORM -D_POSIX_READER_WRITER_LOCKS -MD -MT esp-idf/wolfssl/CMakeFiles/__idf_wolfssl.dir/C_/workspace/wolfssl-master/src/ssl.c.obj -MF esp-idf\wolfssl\CMakeFiles\__idf_wolfssl.dir\C_\workspace\wolfssl-master\src\ssl.c.obj.d -o esp-idf/wolfssl/CMakeFiles/__idf_wolfssl.dir/C_/workspace/wolfssl-master/src/ssl.c.obj -c C:/workspace/wolfssl-master/src/ssl.c
C:/workspace/wolfssl-master/src/ssl.c: In function 'set_curves_list':
C:/workspace/wolfssl-master/src/ssl.c:30126:11: warning: unused variable 'heap' [-Wunused-variable]
30126 |     void *heap = ssl? ssl->heap : ctx ? ctx->heap : NULL;
      |           ^~~~
In file included from C:/workspace/wolfssl-master/src/ssl.c:213:
C:/workspace/wolfssl-master/src/ssl_crypto.c: In function 'wolfSSL_HMAC':
C:/workspace/wolfssl-master/src/ssl_crypto.c:2021:25: error: 'hmacLen' may be used uninitialized in this function [-Werror=maybe-uninitialized]
 2021 |                 *md_len = hmacLen;
      |                 ~~~~~~~~^~~~~~~~~
cc1.exe: some warnings being treated as errors
[637/647] Performing build step for 'bootloader'

```

Fixes zd#  n/a

# Testing

How did you test?

Tested in Espressif only.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
