### PR TITLE
Update --enable-jni with WOLFSSL_ALWAYS_VERIFY_CB

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6105,7 +6105,10 @@ AC_ARG_ENABLE([jni],
     )
 if test "$ENABLED_JNI" = "yes"
 then
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_JNI -DHAVE_EX_DATA -DKEEP_PEER_CERT"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_JNI"
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_EX_DATA"
+    AM_CFLAGS="$AM_CFLAGS -DKEEP_PEER_CERT"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALWAYS_VERIFY_CB"
 
     # Enable prereqs if not already enabled
     if test "x$ENABLED_DTLS" = "xno"


### PR DESCRIPTION
# Description

This PR updated the `--enable-jni` build option to define `WOLFSSL_ALWAYS_VERIFY_CB`.  New addition of `X509ExtendedTrustManager` to wolfSSL JNI/JSSE uses this to do additional hostname verification after internal certificate verification has completed.

# Testing

Tested with wolfssljni PR https://github.com/wolfSSL/wolfssljni/pull/159. 

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
