### PR TITLE
TLS_hmac: when no raw hash, make sure maxSz is not neg

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -1139,6 +1139,8 @@ static int Hmac_UpdateFinal(Hmac* hmac, byte* digest, const byte* in,
     msgSz &= ~(0 - (msgSz >> 31));
     realSz = WOLFSSL_TLS_HMAC_INNER_SZ + msgSz;
     maxSz = WOLFSSL_TLS_HMAC_INNER_SZ + (sz - 1) - macSz;
+    /* Make negative result 0 */
+    maxSz &= ~(0 - (maxSz >> 31));
 
     /* Calculate #blocks processed in HMAC for max and real data. */
     blocks      = maxSz >> blockBits;


### PR DESCRIPTION
# Description

When padding byte is invalid, the maxSz can be negative. Make maxSz 0 in this case so that blocks doesn't get very large and cause delays.

Fixes zd#17062

# Testing

PoC

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
