### PR TITLE
SSL: make temp X25519/X448 key failure

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -32894,6 +32894,10 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                                     ssl->eccTempKeyPresent =
                                         DYNAMIC_TYPE_CURVE25519;
                                 }
+                                else {
+                                    FreeKey(ssl, DYNAMIC_TYPE_CURVE25519,
+                                    (void**)&ssl->eccTempKey);
+                                }
                             }
                             break;
                         }
@@ -32916,6 +32920,10 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                                 if (ret == 0 || ret == WC_PENDING_E) {
                                     ssl->eccTempKeyPresent =
                                         DYNAMIC_TYPE_CURVE448;
+                                }
+                                else {
+                                    FreeKey(ssl, DYNAMIC_TYPE_CURVE448,
+                                    (void**)&ssl->eccTempKey);
                                 }
                             }
                             break;


### PR DESCRIPTION
# Description

On failure to make the temporary X25519/X448 key, free it as the type is stored in eccTempKeyPresent which also indicates a valid key is present. Otherwise on SSL free, it will default to freeing the key with ECC APIs.

Fixes zd#17072

# Testing
PoC

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
