### PR TITLE
Memory usage fixes: nonce type and TLSX extension free

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -8458,12 +8458,22 @@ void FreeHandshakeResources(WOLFSSL* ssl)
     }
 #endif /* HAVE_PK_CALLBACKS */
 
-#if defined(HAVE_TLS_EXTENSIONS) && !defined(HAVE_SNI) && \
-!defined(NO_TLS) && !defined(HAVE_ALPN) && !defined(WOLFSSL_POST_HANDSHAKE_AUTH) && \
+#if defined(HAVE_TLS_EXTENSIONS) && !defined(HAVE_SNI) && !defined(NO_TLS) && \
+    !defined(HAVE_ALPN) && !defined(WOLFSSL_POST_HANDSHAKE_AUTH) && \
     !defined(WOLFSSL_DTLS_CID)
     /* Some extensions need to be kept for post-handshake querying. */
     TLSX_FreeAll(ssl->extensions, ssl->heap);
     ssl->extensions = NULL;
+#else
+#if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
+    TLSX_Remove(&ssl->extensions, TLSX_SIGNATURE_ALGORITHMS, ssl->heap);
+#endif
+    TLSX_Remove(&ssl->extensions, TLSX_EC_POINT_FORMATS, ssl->heap);
+    TLSX_Remove(&ssl->extensions, TLSX_SUPPORTED_GROUPS, ssl->heap);
+#ifdef WOLFSSL_TLS13
+    TLSX_Remove(&ssl->extensions, TLSX_SUPPORTED_VERSIONS, ssl->heap);
+    TLSX_Remove(&ssl->extensions, TLSX_KEY_SHARE, ssl->heap);
+#endif
 #endif
 
 #ifdef WOLFSSL_STATIC_MEMORY

--- a/src/tls.c
+++ b/src/tls.c
@@ -12003,111 +12003,141 @@ void TLSX_FreeAll(TLSX* list, void* heap)
 
 #if defined(HAVE_RPK)
             case TLSX_CLIENT_CERTIFICATE_TYPE:
+                WOLFSSL_MSG("Client Certificate Type extension free");
+                /* nothing to do */
+                break;
             case TLSX_SERVER_CERTIFICATE_TYPE:
+                WOLFSSL_MSG("Server Certificate Type extension free");
                 /* nothing to do */
                 break;
 #endif
 
 #ifdef HAVE_SNI
             case TLSX_SERVER_NAME:
+                WOLFSSL_MSG("SNI extension free");
                 SNI_FREE_ALL((SNI*)extension->data, heap);
                 break;
 #endif
 
             case TLSX_TRUSTED_CA_KEYS:
+                WOLFSSL_MSG("Trusted CA Indication extension free");
                 TCA_FREE_ALL((TCA*)extension->data, heap);
                 break;
 
             case TLSX_MAX_FRAGMENT_LENGTH:
+                WOLFSSL_MSG("Max Fragment Length extension free");
                 MFL_FREE_ALL(extension->data, heap);
                 break;
 
             case TLSX_EXTENDED_MASTER_SECRET:
+                WOLFSSL_MSG("Extended Master Secret free");
+                /* Nothing to do. */
+                break;
             case TLSX_TRUNCATED_HMAC:
+                WOLFSSL_MSG("Truncated HMAC extension free");
                 /* Nothing to do. */
                 break;
 
             case TLSX_SUPPORTED_GROUPS:
+                WOLFSSL_MSG("Supported Groups extension free");
                 EC_FREE_ALL((SupportedCurve*)extension->data, heap);
                 break;
 
             case TLSX_EC_POINT_FORMATS:
+                WOLFSSL_MSG("Point Formats extension free");
                 PF_FREE_ALL((PointFormat*)extension->data, heap);
                 break;
 
             case TLSX_STATUS_REQUEST:
+                WOLFSSL_MSG("Certificate Status Request extension free");
                 CSR_FREE_ALL((CertificateStatusRequest*)extension->data, heap);
                 break;
 
             case TLSX_STATUS_REQUEST_V2:
+                WOLFSSL_MSG("Certificate Status Request v2 extension free");
                 CSR2_FREE_ALL((CertificateStatusRequestItemV2*)extension->data,
                         heap);
                 break;
 
             case TLSX_RENEGOTIATION_INFO:
+                WOLFSSL_MSG("Secure Renegotiation extension free");
                 SCR_FREE_ALL(extension->data, heap);
                 break;
 
             case TLSX_SESSION_TICKET:
+                WOLFSSL_MSG("Session Ticket extension free");
                 WOLF_STK_FREE(extension->data, heap);
                 break;
 
             case TLSX_APPLICATION_LAYER_PROTOCOL:
+                WOLFSSL_MSG("ALPN extension free");
                 ALPN_FREE_ALL((ALPN*)extension->data, heap);
                 break;
 #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
             case TLSX_SIGNATURE_ALGORITHMS:
+                WOLFSSL_MSG("Signature Algorithms extension to free");
                 SA_FREE_ALL((SignatureAlgorithms*)extension->data, heap);
                 break;
 #endif
 #if defined(HAVE_ENCRYPT_THEN_MAC) && !defined(WOLFSSL_AEAD_ONLY)
             case TLSX_ENCRYPT_THEN_MAC:
+                WOLFSSL_MSG("Encrypt-Then-Mac extension free");
                 break;
 #endif
 #ifdef WOLFSSL_TLS13
             case TLSX_SUPPORTED_VERSIONS:
+                WOLFSSL_MSG("Supported Versions extension free");
                 break;
 
     #ifdef WOLFSSL_SEND_HRR_COOKIE
             case TLSX_COOKIE:
+                WOLFSSL_MSG("Cookie extension freee");
                 CKE_FREE_ALL((Cookie*)extension->data, heap);
                 break;
     #endif
 
     #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
             case TLSX_PRE_SHARED_KEY:
+                WOLFSSL_MSG("Pre-Shared Key extension free");
                 PSK_FREE_ALL((PreSharedKey*)extension->data, heap);
                 break;
 
             case TLSX_PSK_KEY_EXCHANGE_MODES:
+                WOLFSSL_MSG("PSK Key Exchange Modes extension free");
                 break;
     #endif
 
     #ifdef WOLFSSL_EARLY_DATA
             case TLSX_EARLY_DATA:
+                WOLFSSL_MSG("Early Data extension free");
                 break;
     #endif
 
     #ifdef WOLFSSL_POST_HANDSHAKE_AUTH
             case TLSX_POST_HANDSHAKE_AUTH:
+                WOLFSSL_MSG("Post-Handshake Authentication extension free");
                 break;
     #endif
 
     #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
             case TLSX_SIGNATURE_ALGORITHMS_CERT:
+                WOLFSSL_MSG("Signature Algorithms extension free");
                 break;
     #endif
 
             case TLSX_KEY_SHARE:
+                WOLFSSL_MSG("Key Share extension free");
                 KS_FREE_ALL((KeyShareEntry*)extension->data, heap);
                 break;
     #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_CA_NAMES)
             case TLSX_CERTIFICATE_AUTHORITIES:
+                WOLFSSL_MSG("Certificate Authorities extension free");
                 break;
     #endif
 #endif
 #ifdef WOLFSSL_SRTP
             case TLSX_USE_SRTP:
+                WOLFSSL_MSG("SRTP extension free");
                 SRTP_FREE((TlsxSrtp*)extension->data, heap);
                 break;
 #endif
@@ -12116,22 +12146,25 @@ void TLSX_FreeAll(TLSX* list, void* heap)
             case TLSX_KEY_QUIC_TP_PARAMS:
                 FALL_THROUGH;
             case TLSX_KEY_QUIC_TP_PARAMS_DRAFT:
+                WOLFSSL_MSG("QUIC transport parameter free");
                 QTP_FREE((QuicTransportParam*)extension->data, heap);
                 break;
     #endif
 
 #ifdef WOLFSSL_DTLS_CID
-        case TLSX_CONNECTION_ID:
-            CID_FREE((byte*)extension->data, heap);
-            break;
+            case TLSX_CONNECTION_ID:
+                WOLFSSL_MSG("Connection ID extension free");
+                CID_FREE((byte*)extension->data, heap);
+                break;
 #endif /* WOLFSSL_DTLS_CID */
 #if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
-        case TLSX_ECH:
-            ECH_FREE((WOLFSSL_ECH*)extension->data, heap);
-            break;
+            case TLSX_ECH:
+                WOLFSSL_MSG("ECH extension free");
+                ECH_FREE((WOLFSSL_ECH*)extension->data, heap);
+                break;
 #endif
-        default:
-            break;
+            default:
+                break;
         }
 
         XFREE(extension, heap, DYNAMIC_TYPE_TLSX);
@@ -12509,6 +12542,7 @@ static int TLSX_Write(TLSX* list, byte* output, byte* semaphore,
 #endif
 #ifdef WOLFSSL_SRTP
             case TLSX_USE_SRTP:
+                WOLFSSL_MSG("SRTP extension to write");
                 offset += SRTP_WRITE((TlsxSrtp*)extension->data, output+offset);
                 break;
 #endif
@@ -12536,12 +12570,14 @@ static int TLSX_Write(TLSX* list, byte* output, byte* semaphore,
 #endif
 #ifdef WOLFSSL_DTLS_CID
             case TLSX_CONNECTION_ID:
+                WOLFSSL_MSG("Connection ID extension to write");
                 offset += CID_WRITE((byte*)extension->data, output+offset);
                 break;
 
 #endif /* WOLFSSL_DTLS_CID */
 #if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
             case TLSX_ECH:
+                WOLFSSL_MSG("ECH extension to write");
                 ret = ECH_WRITE((WOLFSSL_ECH*)extension->data,
                     output + offset, &offset);
                 break;
@@ -14655,6 +14691,7 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
 #endif /* HAVE_RPK */
 #if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
             case TLSX_ECH:
+                WOLFSSL_MSG("ECH extension received");
                 ret = ECH_PARSE(ssl, input + offset, size, msgType);
                 break;
 #endif

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -2582,7 +2582,7 @@ static int EncryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
         #ifdef CIPHER_NONCE
             if (ssl->encrypt.nonce == NULL) {
                 ssl->encrypt.nonce = (byte*)XMALLOC(AEAD_NONCE_SZ,
-                                            ssl->heap, DYNAMIC_TYPE_AES_BUFFER);
+                                                ssl->heap, DYNAMIC_TYPE_CIPHER);
             #ifdef WOLFSSL_CHECK_MEM_ZERO
                 if (ssl->encrypt.nonce != NULL) {
                     wc_MemZero_Add("EncryptTls13 nonce", ssl->encrypt.nonce,
@@ -2984,7 +2984,7 @@ int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
         #ifdef CIPHER_NONCE
             if (ssl->decrypt.nonce == NULL) {
                 ssl->decrypt.nonce = (byte*)XMALLOC(AEAD_NONCE_SZ,
-                                            ssl->heap, DYNAMIC_TYPE_AES_BUFFER);
+                                                ssl->heap, DYNAMIC_TYPE_CIPHER);
             #ifdef WOLFSSL_CHECK_MEM_ZERO
                 if (ssl->decrypt.nonce != NULL) {
                     wc_MemZero_Add("DecryptTls13 nonce", ssl->decrypt.nonce,


### PR DESCRIPTION
# Description

Nonce ciphers other than AES. Free uses DYNAMIC_TYPE_CIPHER.
AES allocation must use DYNAMIC_TYPE_CIPHER too.

If not all TLSX extensions can be freed, then free the ones that can.
Update TLSX_free() to have a message for each case.

# Testing

Memusage testing.
Errors reported and now none.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
