### PR TITLE
OPENSSL_EXTRA NO_FILESYSTEM Error for wolfSSL_CTX_set_default_verify_…

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -16523,6 +16523,11 @@ cleanup:
         }
 #endif
 
+#ifdef NO_FILESYSTEM
+        WOLFSSL_MSG("wolfSSL_CTX_set_default_verify_paths not supported"
+                    " with NO_FILESYSTEM enabled");
+        ret = WOLFSSL_FATAL_ERROR;
+#else
         ret = wolfSSL_CTX_load_system_CA_certs(ctx);
         if (ret == WOLFSSL_BAD_PATH) {
             /*
@@ -16531,6 +16536,7 @@ cleanup:
              */
             ret = WOLFSSL_SUCCESS;
         }
+#endif
 
         WOLFSSL_LEAVE("wolfSSL_CTX_set_default_verify_paths", ret);
 


### PR DESCRIPTION
# Description

The `wolfSSL_CTX_set_default_verify_paths()` used when `OPENSSL_EXTRA` is enabled currently causes a build failure for `NO_FILESYSTEM` environments, as `wolfSSL_CTX_set_default_verify_paths()` is not available.

When `NO_FILESYSTEM` is encountered, the OpenSSL `wolfSSL_CTX_set_default_verify_paths` now returns a `WOLFSSL_FATAL_ERROR`

Fixes zd# n/a

# Testing

How did you test?

Tested only in NO_FILESYSTEM Espressif environment.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
