### PR TITLE
20231128-misc-fixes

### DIFF
--- a/src/quic.c
+++ b/src/quic.c
@@ -1056,7 +1056,7 @@ size_t wolfSSL_quic_get_aead_tag_len(const WOLFSSL_EVP_CIPHER* aead_cipher)
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(ctx, NULL, DYNAMIC_TYPE_TMP_BUF);
+    XFREE(ctx, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return ret;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -30149,7 +30149,7 @@ static int set_curves_list(WOLFSSL* ssl, WOLFSSL_CTX *ctx, const char* names)
     char name[MAX_CURVE_NAME_SZ];
     byte groups_len = 0;
 #ifdef WOLFSSL_SMALL_STACK
-    void *heap = ssl? ssl->heap : ctx ? ctx->heap : NULL; (void)heap;
+    void *heap = ssl? ssl->heap : ctx ? ctx->heap : NULL;
     int *groups;
 #else
     int groups[WOLFSSL_MAX_GROUP_COUNT];

--- a/src/tls.c
+++ b/src/tls.c
@@ -8386,7 +8386,7 @@ static int TLSX_KeyShare_ProcessPqc(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
         XMEMCPY(ssl->arrays->preMasterSecret, keyShareEntry->ke,
                 keyShareEntry->keLen);
         ssl->arrays->preMasterSz = keyShareEntry->keLen;
-        XFREE(keyShareEntry->ke, sl->heap, DYNAMIC_TYPE_SECRET)
+        XFREE(keyShareEntry->ke, ssl->heap, DYNAMIC_TYPE_SECRET)
         keyShareEntry->ke = NULL;
         keyShareEntry->keLen = 0;
         return 0;

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -3885,6 +3885,8 @@ static WARN_UNUSED_RESULT int wc_AesDecrypt(
  * and we need both HW and SW. */
 #ifdef NEED_SOFTWARE_AES_SETKEY
 
+#ifdef NEED_AES_TABLES
+
 #ifndef WC_AES_BITSLICED
 /* Set the AES key and expand.
  *
@@ -4124,6 +4126,8 @@ static void AesSetKey_C(Aes* aes, const byte* key, word32 keySz, int dir)
     bs_set_key(aes->bs_key, key, keySz, aes->rounds);
 }
 #endif /* WC_AES_BITSLICED */
+
+#endif /* NEED_AES_TABLES */
 
     /* Software AES - SetKey */
     static WARN_UNUSED_RESULT int wc_AesSetKeyLocal(

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -13066,7 +13066,7 @@ int wc_ecc_mulmod_ex(const mp_int* k, ecc_point *G, ecc_point *R, mp_int* a,
 #ifndef WOLFSSL_SP_NO_256
     if (mp_count_bits(modulus) == 256) {
         int ret;
-        SAVE_VECTOR_REGISTERS(return _svr_ret);
+        SAVE_VECTOR_REGISTERS(return _svr_ret;);
         ret = sp_ecc_mulmod_256(k, G, R, map, heap);
         RESTORE_VECTOR_REGISTERS();
         return ret;
@@ -13075,7 +13075,7 @@ int wc_ecc_mulmod_ex(const mp_int* k, ecc_point *G, ecc_point *R, mp_int* a,
 #ifdef WOLFSSL_SP_384
     if (mp_count_bits(modulus) == 384) {
         int ret;
-        SAVE_VECTOR_REGISTERS(return _svr_ret);
+        SAVE_VECTOR_REGISTERS(return _svr_ret;);
         ret = sp_ecc_mulmod_384(k, G, R, map, heap);
         RESTORE_VECTOR_REGISTERS();
         return ret;
@@ -13084,7 +13084,7 @@ int wc_ecc_mulmod_ex(const mp_int* k, ecc_point *G, ecc_point *R, mp_int* a,
 #ifdef WOLFSSL_SP_521
     if (mp_count_bits(modulus) == 521) {
         int ret;
-        SAVE_VECTOR_REGISTERS(return _svr_ret);
+        SAVE_VECTOR_REGISTERS(return _svr_ret;);
         ret = sp_ecc_mulmod_521(k, G, R, map, heap);
         RESTORE_VECTOR_REGISTERS();
         return ret;
@@ -13235,7 +13235,7 @@ int wc_ecc_mulmod_ex2(const mp_int* k, ecc_point *G, ecc_point *R, mp_int* a,
 #if defined(WOLFSSL_SM2) && defined(WOLFSSL_SP_SM2)
     if ((mp_count_bits(modulus) == 256) && (!mp_is_bit_set(modulus, 224))) {
         int ret;
-        SAVE_VECTOR_REGISTERS(return _svr_ret);
+        SAVE_VECTOR_REGISTERS(return _svr_ret;);
         ret = sp_ecc_mulmod_sm2_256(k, G, R, map, heap);
         RESTORE_VECTOR_REGISTERS();
         return ret;
@@ -13244,7 +13244,7 @@ int wc_ecc_mulmod_ex2(const mp_int* k, ecc_point *G, ecc_point *R, mp_int* a,
 #ifndef WOLFSSL_SP_NO_256
     if (mp_count_bits(modulus) == 256) {
         int ret;
-        SAVE_VECTOR_REGISTERS(return _svr_ret);
+        SAVE_VECTOR_REGISTERS(return _svr_ret;);
         ret = sp_ecc_mulmod_256(k, G, R, map, heap);
         RESTORE_VECTOR_REGISTERS();
         return ret;
@@ -13253,7 +13253,7 @@ int wc_ecc_mulmod_ex2(const mp_int* k, ecc_point *G, ecc_point *R, mp_int* a,
 #ifdef WOLFSSL_SP_384
     if (mp_count_bits(modulus) == 384) {
         int ret;
-        SAVE_VECTOR_REGISTERS(return _svr_ret);
+        SAVE_VECTOR_REGISTERS(return _svr_ret;);
         ret = sp_ecc_mulmod_384(k, G, R, map, heap);
         RESTORE_VECTOR_REGISTERS();
         return ret;
@@ -13262,7 +13262,7 @@ int wc_ecc_mulmod_ex2(const mp_int* k, ecc_point *G, ecc_point *R, mp_int* a,
 #ifdef WOLFSSL_SP_521
     if (mp_count_bits(modulus) == 521) {
         int ret;
-        SAVE_VECTOR_REGISTERS(return _svr_ret);
+        SAVE_VECTOR_REGISTERS(return _svr_ret;);
         ret = sp_ecc_mulmod_521(k, G, R, map, heap);
         RESTORE_VECTOR_REGISTERS();
         return ret;

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -7687,7 +7687,7 @@ static void sp_clamp_ct(sp_int* a)
     unsigned int used = a->used;
     unsigned int mask = (unsigned int)-1;
 
-    for (i = a->used-1; i >= 0; i--) {
+    for (i = (int)a->used - 1; i >= 0; i--) {
         used -= ((unsigned int)(a->dp[i] == 0)) & mask;
         mask &= (unsigned int)0 - (a->dp[i] == 0);
     }
@@ -17072,7 +17072,9 @@ static int _sp_mont_red(sp_int* a, const sp_int* m, sp_int_digit mp, int ct)
     }
     else {
         for (i = 0; i < m->used * 2; i++) {
-            a->dp[i] &= (sp_int_digit)(sp_int_sdigit)ctMaskIntGTE(a->used-1, i);
+            a->dp[i] &=
+                (sp_int_digit)
+                (sp_int_sdigit)ctMaskIntGTE((int)(a->used-1), (int)i);
         }
     }
 
@@ -17195,7 +17197,9 @@ static int _sp_mont_red(sp_int* a, const sp_int* m, sp_int_digit mp, int ct)
     }
     else {
         for (i = 0; i < m->used * 2; i++) {
-            a->dp[i] &= (sp_int_digit)(sp_int_sdigit)ctMaskIntGTE(a->used-1, i);
+            a->dp[i] &=
+                (sp_int_digit)
+                (sp_int_sdigit)ctMaskIntGTE((int)(a->used-1), (int)i);
         }
     }
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -20683,6 +20683,14 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t dsa_test(void)
     if (answer != 1)
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
+    wc_FreeDsaKey(key);
+    key_inited = 0;
+
+    ret = wc_InitDsaKey_h(key, NULL);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    key_inited = 1;
+
 #ifdef WOLFSSL_KEY_GEN
     {
     int    derSz = 0;
@@ -20726,16 +20734,6 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t dsa_test(void)
 #endif /* WOLFSSL_KEY_GEN */
 
   out:
-
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-    if (key) {
-#endif
-        ret = wc_InitDsaKey_h(key, NULL);
-        if (ret != 0)
-            ret = WC_TEST_RET_ENC_EC(ret);
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-    }
-#endif
 
 #ifdef WOLFSSL_KEY_GEN
     if (der)

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -636,8 +636,8 @@
 #ifdef WOLFSSL_PICOTCP_DEMO
     #define WOLFSSL_STM32
     #define TFM_TIMING_RESISTANT
-    #define XMALLOC(s, h, type)  PICO_ZALLOC((s))
-    #define XFREE(p, h, type)    PICO_FREE((p))
+    #define XMALLOC(s, h, type)  ((void)(h), (void)(type), PICO_ZALLOC((s)))
+    #define XFREE(p, h, type)    ((void)(h), (void)(type), PICO_FREE((p)))
     #define SINGLE_THREADED
     #define NO_WRITEV
     #define WOLFSSL_USER_IO
@@ -824,9 +824,9 @@ extern void *uITRON4_malloc(size_t sz) ;
 extern void *uITRON4_realloc(void *p, size_t sz) ;
 extern void uITRON4_free(void *p) ;
 
-#define XMALLOC(sz, heap, type)     uITRON4_malloc(sz)
-#define XREALLOC(p, sz, heap, type) uITRON4_realloc(p, sz)
-#define XFREE(p, heap, type)        uITRON4_free(p)
+#define XMALLOC(sz, heap, type)     ((void)(heap), (void)(type), uITRON4_malloc(sz))
+#define XREALLOC(p, sz, heap, type) ((void)(heap), (void)(type), uITRON4_realloc(p, sz))
+#define XFREE(p, heap, type)        ((void)(heap), (void)(type), uITRON4_free(p))
 #endif
 
 #if defined(WOLFSSL_uTKERNEL2)
@@ -836,9 +836,9 @@ extern void uITRON4_free(void *p) ;
     void* uTKernel_malloc(unsigned int sz);
     void* uTKernel_realloc(void *p, unsigned int sz);
     void  uTKernel_free(void *p);
-    #define XMALLOC(s, h, type)  uTKernel_malloc((s))
-    #define XREALLOC(p, n, h, t) uTKernel_realloc((p), (n))
-    #define XFREE(p, h, type)    uTKernel_free((p))
+    #define XMALLOC(s, h, type)  ((void)(h), (void)(type), uTKernel_malloc((s)))
+    #define XREALLOC(p, n, h, t) ((void)(h), (void)(t), uTKernel_realloc((p), (n)))
+    #define XFREE(p, h, type)    ((void)(h), (void)(type), uTKernel_free((p)))
   #endif
 
   #ifndef NO_STDIO_FGETS_REMAP
@@ -868,9 +868,9 @@ extern void uITRON4_free(void *p) ;
 #if defined(WOLFSSL_LEANPSK) && !defined(XMALLOC_USER) && \
         !defined(NO_WOLFSSL_MEMORY)
     #include <stdlib.h>
-    #define XMALLOC(s, h, type)  malloc((s))
-    #define XFREE(p, h, type)    free((p))
-    #define XREALLOC(p, n, h, t) realloc((p), (n))
+    #define XMALLOC(s, h, type)  ((void)(h), (void)(type), malloc((s)))
+    #define XFREE(p, h, type)    ((void)(h), (void)(type), free((p)))
+    #define XREALLOC(p, n, h, t) ((void)(h), (void)(t), realloc((p), (n)))
 #endif
 
 #if defined(XMALLOC_USER) && defined(SSN_BUILDING_LIBYASSL)
@@ -889,16 +889,16 @@ extern void uITRON4_free(void *p) ;
 
     #if !defined(XMALLOC_USER) && !defined(NO_WOLFSSL_MEMORY) && \
         !defined(WOLFSSL_STATIC_MEMORY) && !defined(WOLFSSL_TRACK_MEMORY)
-        #define XMALLOC(s, h, type)  pvPortMalloc((s))
-        #define XFREE(p, h, type)    vPortFree((p))
+        #define XMALLOC(s, h, type)  ((void)(h), (void)(type), pvPortMalloc((s)))
+        #define XFREE(p, h, type)    ((void)(h), (void)(type), vPortFree((p)))
         #if defined(WOLFSSL_ESPIDF)
                 /* In IDF, realloc(p, n) is equivalent to
                  * heap_caps_realloc(p, s, MALLOC_CAP_8BIT) */
-                #define XREALLOC(p, n, h, t) realloc((p), (n))
+                #define XREALLOC(p, n, h, t) ((void)(h), (void)(t), realloc((p), (n)))
         /* FreeRTOS pvPortRealloc() implementation can be found here:
          * https://github.com/wolfSSL/wolfssl-freertos/pull/3/files */
         #elif defined(USE_INTEGER_HEAP_MATH) || defined(OPENSSL_EXTRA)
-                #define XREALLOC(p, n, h, t) pvPortRealloc((p), (n))
+                #define XREALLOC(p, n, h, t) ((void)(h), (void)(t), pvPortRealloc((p), (n)))
         #endif
     #endif
 
@@ -1018,9 +1018,9 @@ extern void uITRON4_free(void *p) ;
         #define strtok_r strtok_s
     #endif
 
-    #define XMALLOC(s, h, type) ((void *)rtp_malloc((s), SSL_PRO_MALLOC))
-    #define XFREE(p, h, type) (rtp_free(p))
-    #define XREALLOC(p, n, h, t) (rtp_realloc((p), (n), (t)))
+    #define XMALLOC(s, h, type) ((void)(h), (void)(type), ((void *)rtp_malloc((s), SSL_PRO_MALLOC)))
+    #define XFREE(p, h, type) ((void)(h), (void)(type), rtp_free(p))
+    #define XREALLOC(p, n, h, t) ((void)(h), rtp_realloc((p), (n), (t)))
 
     #if (WINMSP3)
         #define XSTRNCASECMP(s1,s2,n)  _strnicmp((s1),(s2),(n))
@@ -1080,14 +1080,14 @@ extern void uITRON4_free(void *p) ;
     #endif
     #if !defined(XMALLOC_USER) && !defined(NO_WOLFSSL_MEMORY) && \
         !defined(WOLFSSL_STATIC_MEMORY)
-        #define XMALLOC(s, h, type)  pvPortMalloc((s))
-        #define XFREE(p, h, type)    vPortFree((p))
+        #define XMALLOC(s, h, type)  ((void)(h), (void)(type), pvPortMalloc((s)))
+        #define XFREE(p, h, type)    ((void)(h), (void)(type), vPortFree((p)))
 
         /* FreeRTOS pvPortRealloc() implementation can be found here:
             https://github.com/wolfSSL/wolfssl-freertos/pull/3/files */
         #if !defined(USE_FAST_MATH) || defined(HAVE_ED25519) || \
             defined(HAVE_ED448)
-            #define XREALLOC(p, n, h, t) pvPortRealloc((p), (n))
+            #define XREALLOC(p, n, h, t) ((void)(h), (void)(t), pvPortRealloc((p), (n)))
         #endif
     #endif
 #endif
@@ -1143,8 +1143,8 @@ extern void uITRON4_free(void *p) ;
 
     #if !defined(XMALLOC_OVERRIDE) && !defined(XMALLOC_USER)
         #define XMALLOC_OVERRIDE
-        #define XMALLOC(s, h, t)    (void *)_mem_alloc_system((s))
-        #define XFREE(p, h, t)      {void* xp = (p); if ((xp)) _mem_free((xp));}
+        #define XMALLOC(s, h, t)    ((void)(h), (void)(t), (void *)_mem_alloc_system((s)))
+        #define XFREE(p, h, t)      {void* xp = (p); (void)(h); (void)(t); if ((xp)) _mem_free((xp));}
         /* Note: MQX has no realloc, using fastmath above */
     #endif
     #ifdef USE_FAST_MATH
@@ -1174,8 +1174,8 @@ extern void uITRON4_free(void *p) ;
         #include <mutex.h>
     #endif
 
-    #define XMALLOC(s, h, t)    (void *)_mem_alloc_system((s))
-    #define XFREE(p, h, t)      {void* xp = (p); if ((xp)) _mem_free((xp));}
+    #define XMALLOC(s, h, t)    ((void)(h), (void)(t), (void *)_mem_alloc_system((s)))
+    #define XFREE(p, h, t)      {void* xp = (p); (void)(h); (void)(t); if ((xp)) _mem_free((xp));}
     #define XREALLOC(p, n, h, t) _mem_realloc((p), (n)) /* since MQX 4.1.2 */
 
     #define MQX_FILE_PTR FILE *
@@ -1188,8 +1188,8 @@ extern void uITRON4_free(void *p) ;
     #define WOLFSSL_CRYPT_HW_MUTEX 1
 
     #if !defined(XMALLOC_USER) && !defined(NO_WOLFSSL_MEMORY)
-        #define XMALLOC(s, h, type)  pvPortMalloc((s))
-        #define XFREE(p, h, type)    vPortFree((p))
+        #define XMALLOC(s, h, type)  ((void)(h), (void)(type), pvPortMalloc((s)))
+        #define XFREE(p, h, type)    ((void)(h), (void)(type), vPortFree((p)))
     #endif
 
     /* #define USER_TICKS */
@@ -1851,9 +1851,9 @@ extern void uITRON4_free(void *p) ;
     #define NO_SESSION_CACHE
     #define NO_ERROR_STRINGS
     #define XMALLOC_USER
-    #define XMALLOC(sz, heap, type)     os_malloc(sz)
-    #define XREALLOC(p, sz, heap, type) os_realloc(p, sz)
-    #define XFREE(p, heap, type)        os_free(p)
+    #define XMALLOC(sz, heap, type)     ((void)(heap), (void)(type), os_malloc(sz))
+    #define XREALLOC(p, sz, heap, type) ((void)(heap), (void)(type), os_realloc(p, sz))
+    #define XFREE(p, heap, type)        ((void)(heap), (void)(type), os_free(p))
 
 #endif /*(WOLFSSL_APACHE_MYNEWT)*/
 
@@ -1991,9 +1991,9 @@ extern void uITRON4_free(void *p) ;
     #include "RTOS.h"
     #if !defined(XMALLOC_USER) && !defined(NO_WOLFSSL_MEMORY) && \
         !defined(WOLFSSL_STATIC_MEMORY)
-        #define XMALLOC(s, h, type)  OS_HEAP_malloc((s))
-        #define XFREE(p, h, type)    OS_HEAP_free((p))
-        #define XREALLOC(p, n, h, t) OS_HEAP_realloc(((p), (n))
+        #define XMALLOC(s, h, type)  ((void)(h), (void)(type), OS_HEAP_malloc((s)))
+        #define XFREE(p, h, type)    ((void)(h), (void)(type), OS_HEAP_free((p)))
+        #define XREALLOC(p, n, h, t) ((void)(h), (void)(t), OS_HEAP_realloc(((p), (n)))
     #endif
 #endif
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -488,7 +488,7 @@ typedef struct w64wrapper {
     #elif defined(WOLFSSL_TELIT_M2MB)
         /* Telit M2MB SDK requires use m2mb_os API's, not std malloc/free */
         /* Use of malloc/free will cause CPU reboot */
-        #define XMALLOC(s, h, t)     ((void)h, (void)t, m2mb_os_malloc((s)))
+        #define XMALLOC(s, h, t)     ((void)(h), (void)(t), m2mb_os_malloc((s)))
         #ifdef WOLFSSL_XFREE_NO_NULLNESS_CHECK
             #define XFREE(p, h, t)       m2mb_os_free(xp)
         #else
@@ -505,25 +505,25 @@ typedef struct w64wrapper {
                     fprintf(stderr, "wolfSSL_malloc failed");
                     return NULL;
                 };
-                #define XMALLOC(s, h, t)     malloc_check((s))
-                #define XFREE(p, h, t)       WC_DO_NOTHING
-                #define XREALLOC(p, n, h, t) (NULL)
+                #define XMALLOC(s, h, t)     ((void)(h), (void)(t), malloc_check((s)))
+                #define XFREE(p, h, t)       (void)(h); (void)(t)
+                #define XREALLOC(p, n, h, t) ((void)(h), (void)(t), NULL)
             #else
-                #define XMALLOC(s, h, t)     (NULL)
-                #define XFREE(p, h, t)       WC_DO_NOTHING
-                #define XREALLOC(p, n, h, t) (NULL)
+                #define XMALLOC(s, h, t)     ((void)(s), (void)(h), (void)(t), NULL)
+                #define XFREE(p, h, t)       (void)(p); (void)(h); (void)(t)
+                #define XREALLOC(p, n, h, t) ((void)(p), (void)(n), (void)(h), (void)(t), NULL)
             #endif
         #else
-        /* just use plain C stdlib stuff if desired */
-        #include <stdlib.h>
-        #define XMALLOC(s, h, t)     ((void)(h), (void)(t), malloc((size_t)(s)))
-        #ifdef WOLFSSL_XFREE_NO_NULLNESS_CHECK
-            #define XFREE(p, h, t)       ((void)(h), (void)(t), free(p))
-        #else
-            #define XFREE(p, h, t)       {void* xp = (p); if (xp) free(xp);}
-        #endif
-        #define XREALLOC(p, n, h, t) \
-            ((void)(h), (void)(t), realloc((p), (size_t)(n)))
+            /* just use plain C stdlib stuff if desired */
+            #include <stdlib.h>
+            #define XMALLOC(s, h, t)     ((void)(h), (void)(t), malloc((size_t)(s)))
+            #ifdef WOLFSSL_XFREE_NO_NULLNESS_CHECK
+                #define XFREE(p, h, t)       ((void)(h), (void)(t), free(p))
+            #else
+                #define XFREE(p, h, t)       {void* xp = (p); (void)(h); if (xp) free(xp);}
+            #endif
+            #define XREALLOC(p, n, h, t) \
+                ((void)(h), (void)(t), realloc((p), (size_t)(n)))
         #endif
 
     #elif defined(WOLFSSL_LINUXKM)
@@ -560,19 +560,19 @@ typedef struct w64wrapper {
             #ifdef WOLFSSL_DEBUG_MEMORY
                 #define XMALLOC(s, h, t)     ((void)(h), (void)(t), wolfSSL_Malloc((s), __func__, __LINE__))
                 #ifdef WOLFSSL_XFREE_NO_NULLNESS_CHECK
-                    #define XFREE(p, h, t)       wolfSSL_Free(xp, __func__, __LINE__)
+                    #define XFREE(p, h, t)       ((void)(h), (void)(t), wolfSSL_Free(xp, __func__, __LINE__))
                 #else
-                    #define XFREE(p, h, t)       {void* xp = (p); if (xp) wolfSSL_Free(xp, __func__, __LINE__);}
+                    #define XFREE(p, h, t)       {void* xp = (p); (void)(h); (void)(t); if (xp) wolfSSL_Free(xp, __func__, __LINE__);}
                 #endif
-                #define XREALLOC(p, n, h, t) wolfSSL_Realloc((p), (n), __func__, __LINE__)
+                #define XREALLOC(p, n, h, t) ((void)(h), (void)(t), wolfSSL_Realloc((p), (n), __func__, __LINE__))
             #else
                 #define XMALLOC(s, h, t)     ((void)(h), (void)(t), wolfSSL_Malloc((s)))
                 #ifdef WOLFSSL_XFREE_NO_NULLNESS_CHECK
-                    #define XFREE(p, h, t)       wolfSSL_Free(p)
+                    #define XFREE(p, h, t)       ((void)(h), (void)(t), wolfSSL_Free(p))
                 #else
-                    #define XFREE(p, h, t)       {void* xp = (p); if (xp) wolfSSL_Free(xp);}
+                    #define XFREE(p, h, t)       {void* xp = (p); (void)(h); (void)(t); if (xp) wolfSSL_Free(xp);}
                 #endif
-                #define XREALLOC(p, n, h, t) wolfSSL_Realloc((p), (n))
+                #define XREALLOC(p, n, h, t) ((void)(h), (void)(t), wolfSSL_Realloc((p), (n)))
             #endif /* WOLFSSL_DEBUG_MEMORY */
         #endif /* WOLFSSL_STATIC_MEMORY */
     #endif


### PR DESCRIPTION
`src/ssl.c`: remove frivolous `(void)heap` to clear `-Wdeclaration-after-statement`.

`wolfcrypt/src/aes.c`: add `NEED_AES_TABLES` gate around `AesSetKey_C()` implementations (fixes `WOLFSSL_KCAPI_AES` builds, probably among others).

`wolfcrypt/src/sp_int.c`: add missing casts to clear `-Wconversions`.

tested with `wolfssl-multi-test.sh ... super-quick-check all-gcc-latest-c99-smallstack benchmark-wolfcrypt-intelasm-sp-asm-all fips-140-3-dev-kcapi fips-140-3-dev-kcapi-opensslextra-build linuxkm-aesni-sp-asm-pie-insmod-no-ec521-no-dh-no-rsa-ksanitize`
