### PR TITLE
Add missing wc_AesInit calls.

### DIFF
--- a/src/ssl_crypto.c
+++ b/src/ssl_crypto.c
@@ -2904,7 +2904,6 @@ void wolfSSL_DES_ecb_encrypt(WOLFSSL_DES_cblock* in, WOLFSSL_DES_cblock* out,
 /* Sets the key into the AES key object for encryption or decryption.
  *
  * TODO: check bits value?
- * TODO: initialize AES key?
  *
  * @param [in]  key   Key data.
  * @param [in]  bits  Number of bits in key.
@@ -2927,6 +2926,12 @@ static int wolfssl_aes_set_key(const unsigned char *key, const int bits,
     }
 
     XMEMSET(aes, 0, sizeof(AES_KEY));
+
+    if (wc_AesInit((Aes*)aes, NULL, INVALID_DEVID) != 0) {
+        WOLFSSL_MSG("Error in initting AES key");
+        return -1;
+    }
+
     if (wc_AesSetKey((Aes*)aes, key, ((bits)/8), NULL, enc) != 0) {
         WOLFSSL_MSG("Error in setting AES key");
         return -1;

--- a/tests/api.c
+++ b/tests/api.c
@@ -18165,6 +18165,7 @@ static int test_wc_GmacUpdate(void)
 
 #ifdef WOLFSSL_AES_192
     ExpectNotNull(XMEMSET(&gmac, 0, sizeof(Gmac)));
+    ExpectIntEQ(wc_AesInit(&gmac.aes, NULL, INVALID_DEVID), 0);
     ExpectIntEQ(wc_GmacSetKey(&gmac, key24, sizeof(key24)/sizeof(byte)), 0);
     ExpectIntEQ(wc_GmacUpdate(&gmac, iv2, sizeof(iv2), authIn2, sizeof(authIn2),
         tagOut2, sizeof(tag2)), 0);
@@ -18173,6 +18174,7 @@ static int test_wc_GmacUpdate(void)
 
 #ifdef WOLFSSL_AES_256
     ExpectNotNull(XMEMSET(&gmac, 0, sizeof(Gmac)));
+    ExpectIntEQ(wc_AesInit(&gmac.aes, NULL, INVALID_DEVID), 0);
     ExpectIntEQ(wc_GmacSetKey(&gmac, key32, sizeof(key32)/sizeof(byte)), 0);
     ExpectIntEQ(wc_GmacUpdate(&gmac, iv3, sizeof(iv3), authIn3, sizeof(authIn3),
         tagOut3, sizeof(tag3)), 0);

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -4521,6 +4521,12 @@ static void bench_aescfb_internal(const byte* key,
     int    i, ret, count;
     DECLARE_MULTI_VALUE_STATS_VARS()
 
+    ret = wc_AesInit(&enc, HEAP_HINT, INVALID_DEVID);
+    if (ret != 0) {
+        printf("AesInit failed, ret = %d\n", ret);
+        return;
+    }
+
     ret = wc_AesSetKey(&enc, key, keySz, iv, AES_ENCRYPTION);
     if (ret != 0) {
         printf("AesSetKey failed, ret = %d\n", ret);

--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -137,6 +137,8 @@ int wc_InitCmac_ex(Cmac* cmac, const byte* key, word32 keySz,
         return BAD_FUNC_ARG;
     }
 
+    ret = wc_AesInit(&cmac->aes, NULL, devId);
+
 #if defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_CRYPT)
     cmac->useSWCrypt = useSW;
     if (cmac->useSWCrypt == 1) {
@@ -144,7 +146,10 @@ int wc_InitCmac_ex(Cmac* cmac, const byte* key, word32 keySz,
     }
 #endif
 
-    ret = wc_AesSetKey(&cmac->aes, key, keySz, NULL, AES_ENCRYPTION);
+    if (ret == 0) {
+        ret = wc_AesSetKey(&cmac->aes, key, keySz, NULL, AES_ENCRYPTION);
+    }
+
     if (ret == 0) {
         byte l[AES_BLOCK_SIZE];
 

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -6762,6 +6762,10 @@ void wolfSSL_EVP_init(void)
             if (enc == 0 || enc == 1)
                 ctx->enc = enc ? 1 : 0;
             if (key) {
+                ret = wc_AesInit(&ctx->cipher.aes, NULL, INVALID_DEVID);
+                if (ret != 0)
+                    return WOLFSSL_FAILURE;
+
                 ret = AesSetKey_ex(&ctx->cipher.aes, key, (word32)ctx->keyLen,
                             iv, ctx->enc ? AES_ENCRYPTION : AES_DECRYPTION, 0);
                 if (ret != 0)
@@ -7034,6 +7038,10 @@ void wolfSSL_EVP_init(void)
             if (enc == 0 || enc == 1)
                 ctx->enc = enc ? 1 : 0;
             if (key) {
+                ret = wc_AesInit(&ctx->cipher.aes, NULL, INVALID_DEVID);
+                if (ret != 0)
+                    return WOLFSSL_FAILURE;
+
                 ret = AesSetKey_ex(&ctx->cipher.aes, key, (word32)ctx->keyLen,
                     iv, AES_ENCRYPTION, 0);
                 if (ret != 0)
@@ -7058,6 +7066,10 @@ void wolfSSL_EVP_init(void)
             if (enc == 0 || enc == 1)
                 ctx->enc = enc ? 1 : 0;
             if (key) {
+                ret = wc_AesInit(&ctx->cipher.aes, NULL, INVALID_DEVID);
+                if (ret != 0)
+                    return WOLFSSL_FAILURE;
+
                 ret = AesSetKey_ex(&ctx->cipher.aes, key, (word32)ctx->keyLen,
                     iv, AES_ENCRYPTION, 0);
                 if (ret != 0)
@@ -7082,6 +7094,10 @@ void wolfSSL_EVP_init(void)
             if (enc == 0 || enc == 1)
                 ctx->enc = enc ? 1 : 0;
             if (key) {
+                ret = wc_AesInit(&ctx->cipher.aes, NULL, INVALID_DEVID);
+                if (ret != 0)
+                    return WOLFSSL_FAILURE;
+
                 ret = AesSetKey_ex(&ctx->cipher.aes, key, (word32)ctx->keyLen,
                     iv, AES_ENCRYPTION, 0);
                 if (ret != 0){
@@ -7110,6 +7126,10 @@ void wolfSSL_EVP_init(void)
             if (enc == 0 || enc == 1)
                 ctx->enc = enc ? 1 : 0;
             if (key) {
+                ret = wc_AesInit(&ctx->cipher.aes, NULL, INVALID_DEVID);
+                if (ret != 0)
+                    return WOLFSSL_FAILURE;
+
                 ret = AesSetKey_ex(&ctx->cipher.aes, key, (word32)ctx->keyLen,
                     iv, AES_ENCRYPTION, 0);
                 if (ret != 0)
@@ -7134,6 +7154,10 @@ void wolfSSL_EVP_init(void)
             if (enc == 0 || enc == 1)
                 ctx->enc = enc ? 1 : 0;
             if (key) {
+                ret = wc_AesInit(&ctx->cipher.aes, NULL, INVALID_DEVID);
+                if (ret != 0)
+                    return WOLFSSL_FAILURE;
+
                 ret = AesSetKey_ex(&ctx->cipher.aes, key, (word32)ctx->keyLen,
                     iv, AES_ENCRYPTION, 0);
                 if (ret != 0)
@@ -7158,6 +7182,10 @@ void wolfSSL_EVP_init(void)
             if (enc == 0 || enc == 1)
                 ctx->enc = enc ? 1 : 0;
             if (key) {
+                ret = wc_AesInit(&ctx->cipher.aes, NULL, INVALID_DEVID);
+                if (ret != 0)
+                    return WOLFSSL_FAILURE;
+
                 ret = AesSetKey_ex(&ctx->cipher.aes, key, (word32)ctx->keyLen,
                     iv, AES_ENCRYPTION, 0);
                 if (ret != 0){
@@ -7186,6 +7214,10 @@ void wolfSSL_EVP_init(void)
             if (enc == 0 || enc == 1)
                 ctx->enc = enc ? 1 : 0;
             if (key) {
+                ret = wc_AesInit(&ctx->cipher.aes, NULL, INVALID_DEVID);
+                if (ret != 0)
+                    return WOLFSSL_FAILURE;
+
                 ret = AesSetKey_ex(&ctx->cipher.aes, key, (word32)ctx->keyLen,
                     iv, AES_ENCRYPTION, 0);
                 if (ret != 0)
@@ -7210,6 +7242,10 @@ void wolfSSL_EVP_init(void)
             if (enc == 0 || enc == 1)
                 ctx->enc = enc ? 1 : 0;
             if (key) {
+                ret = wc_AesInit(&ctx->cipher.aes, NULL, INVALID_DEVID);
+                if (ret != 0)
+                    return WOLFSSL_FAILURE;
+
                 ret = AesSetKey_ex(&ctx->cipher.aes, key, (word32)ctx->keyLen,
                     iv, AES_ENCRYPTION, 0);
                 if (ret != 0)
@@ -7234,6 +7270,10 @@ void wolfSSL_EVP_init(void)
             if (enc == 0 || enc == 1)
                 ctx->enc = enc ? 1 : 0;
             if (key) {
+                ret = wc_AesInit(&ctx->cipher.aes, NULL, INVALID_DEVID);
+                if (ret != 0)
+                    return WOLFSSL_FAILURE;
+
                 ret = AesSetKey_ex(&ctx->cipher.aes, key, (word32)ctx->keyLen,
                     iv, AES_ENCRYPTION, 0);
                 if (ret != 0){
@@ -7264,6 +7304,10 @@ void wolfSSL_EVP_init(void)
             if (enc == 0 || enc == 1)
                 ctx->enc = enc ? 1 : 0;
             if (key) {
+                ret = wc_AesInit(&ctx->cipher.aes, NULL, INVALID_DEVID);
+                if (ret != 0)
+                    return WOLFSSL_FAILURE;
+
                 ret = AesSetKey_ex(&ctx->cipher.aes, key, (word32)ctx->keyLen,
                     iv, AES_ENCRYPTION, 0);
                 if (ret != 0)
@@ -7288,6 +7332,10 @@ void wolfSSL_EVP_init(void)
             if (enc == 0 || enc == 1)
                 ctx->enc = enc ? 1 : 0;
             if (key) {
+                ret = wc_AesInit(&ctx->cipher.aes, NULL, INVALID_DEVID);
+                if (ret != 0)
+                    return WOLFSSL_FAILURE;
+
                 ret = AesSetKey_ex(&ctx->cipher.aes, key, (word32)ctx->keyLen,
                     iv, AES_ENCRYPTION, 0);
                 if (ret != 0)
@@ -7312,6 +7360,10 @@ void wolfSSL_EVP_init(void)
             if (enc == 0 || enc == 1)
                 ctx->enc = enc ? 1 : 0;
             if (key) {
+                ret = wc_AesInit(&ctx->cipher.aes, NULL, INVALID_DEVID);
+                if (ret != 0)
+                    return WOLFSSL_FAILURE;
+
                 ret = AesSetKey_ex(&ctx->cipher.aes, key, (word32)ctx->keyLen,
                     iv, AES_ENCRYPTION, 0);
                 if (ret != 0){

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -8163,6 +8163,14 @@ EVP_TEST_END:
         }
     #endif
 
+        ret = wc_AesInit(enc, HEAP_HINT, INVALID_DEVID);
+        if (ret != 0)
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+        ret = wc_AesInit(dec, HEAP_HINT, INVALID_DEVID);
+        if (ret != 0)
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
         ret = wc_AesSetKey(enc, key2, sizeof(key2), iv2, AES_ENCRYPTION);
         if (ret != 0)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -13563,6 +13571,10 @@ static wc_test_ret_t aesccm_128_test(void)
     XMEMSET(c2, 0, sizeof(c2));
     XMEMSET(p2, 0, sizeof(p2));
     XMEMSET(iv2, 0, sizeof(iv2));
+
+    ret = wc_AesInit(enc, HEAP_HINT, devId);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
 #ifndef HAVE_SELFTEST
     /* selftest build does not have wc_AesCcmSetNonce() or


### PR DESCRIPTION
# Description

There were a number of places in `src/*`, and `wolfcrypt/*`,  where we called `wc_AesSetKey()` without a preceding `wc_AesInit()`.

Fixes zd#17075

# Testing

Temporarily added a magic number variable to struct `Aes` that was set in Init, and checked in SetKey. Then did the following to find all the cases of missing AesInits.

Built with `--enable-all --enable-all-crypto`.

Tested with:
```
./wolfcrypt/test/testwolfcrypt
```

```
./wolfcrypt/benchmark/benchmark \
  -aes-cbc \
  -aes-gcm \
  -aes-ecb \
  -aes-xts \
  -aes-cfb \
  -aes-ofb \
  -aes-ctr \
  -aes-ccm \
  -aes-siv
```

```
./scripts/unit.test
```


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
