### PR TITLE
Reworking MinGW mutex/threading

### DIFF
--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -1203,7 +1203,7 @@ static THREAD_RETURN WOLFSSL_THREAD_NO_JOIN client_thread(void* args)
     THREAD_CHECK_RET(wolfSSL_CondSignal(&info->to_server.cond));
     THREAD_CHECK_RET(wolfSSL_CondEnd(&info->to_server.cond));
 
-    WOLFSSL_RETURN_FROM_THREAD(NULL);
+    WOLFSSL_RETURN_FROM_THREAD(0);
 }
 #endif /* !SINGLE_THREADED */
 #endif /* !NO_WOLFSSL_CLIENT */
@@ -1663,7 +1663,7 @@ static THREAD_RETURN WOLFSSL_THREAD_NO_JOIN server_thread(void* args)
     THREAD_CHECK_RET(wolfSSL_CondSignal(&info->to_client.cond));
     THREAD_CHECK_RET(wolfSSL_CondEnd(&info->to_client.cond));
 
-    WOLFSSL_RETURN_FROM_THREAD(NULL);
+    WOLFSSL_RETURN_FROM_THREAD(0);
 }
 #endif /* !SINGLE_THREADED */
 #endif /* !NO_WOLFSSL_SERVER */

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -1489,7 +1489,7 @@ int wolfSSL_CryptHwMutexUnLock(void)
         return 0;
     }
 
-#elif defined(USE_WINDOWS_API)
+#elif defined(USE_WINDOWS_API) && !defined(WOLFSSL_PTHREADS)
 
     int wc_InitMutex(wolfSSL_Mutex* m)
     {
@@ -3426,7 +3426,7 @@ char* mystrnstr(const char* s1, const char* s2, unsigned int n)
 
 #ifndef SINGLE_THREADED
 
-#ifdef _MSC_VER
+#if defined(USE_WINDOWS_API) && !defined(WOLFSSL_PTHREADS)
     int wolfSSL_NewThread(THREAD_TYPE* thread,
         THREAD_CB cb, void* arg)
     {
@@ -3450,6 +3450,7 @@ char* mystrnstr(const char* s1, const char* s2, unsigned int n)
         return 0;
     }
 
+#ifdef WOLFSSL_THREAD_NO_JOIN
     int wolfSSL_NewThreadNoJoin(THREAD_CB_NOJOIN cb, void* arg)
     {
         THREAD_TYPE thread;
@@ -3464,6 +3465,7 @@ char* mystrnstr(const char* s1, const char* s2, unsigned int n)
 
         return 0;
     }
+#endif
 
     int wolfSSL_JoinThread(THREAD_TYPE thread)
     {

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1377,7 +1377,7 @@ typedef struct w64wrapper {
         typedef unsigned int  THREAD_RETURN;
         typedef size_t        THREAD_TYPE;
         #define WOLFSSL_THREAD
-    #elif (defined(_POSIX_THREADS) || defined(HAVE_PTHREAD))
+    #elif defined(WOLFSSL_PTHREADS)
         #ifndef __MACH__
             #include <pthread.h>
             typedef struct COND_TYPE {
@@ -1402,7 +1402,7 @@ typedef struct w64wrapper {
         typedef unsigned int   THREAD_RETURN;
         typedef TaskHandle_t   THREAD_TYPE;
         #define WOLFSSL_THREAD
-    #elif defined(_MSC_VER)
+    #elif defined(USE_WINDOWS_API)
         typedef unsigned      THREAD_RETURN;
         typedef uintptr_t     THREAD_TYPE;
         typedef struct COND_TYPE {
@@ -1412,7 +1412,9 @@ typedef struct w64wrapper {
         #define WOLFSSL_COND
         #define INVALID_THREAD_VAL ((THREAD_TYPE)(INVALID_HANDLE_VALUE))
         #define WOLFSSL_THREAD __stdcall
-        #define WOLFSSL_THREAD_NO_JOIN __cdecl
+        #if !defined(__MINGW32__)
+            #define WOLFSSL_THREAD_NO_JOIN __cdecl
+        #endif
     #else
         typedef unsigned int  THREAD_RETURN;
         typedef size_t        THREAD_TYPE;

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -60,8 +60,7 @@
 
 /* THREADING/MUTEX SECTION */
 #ifdef USE_WINDOWS_API
-    #if defined(__MINGW32__) && !defined(SINGLE_THREADED)
-        #define WOLFSSL_PTHREADS
+    #if defined(WOLFSSL_PTHREADS)
         #include <pthread.h>
     #endif
     #ifdef WOLFSSL_GAME_BUILD
@@ -231,7 +230,7 @@
             signed char mutexBuffer[portQUEUE_OVERHEAD_BYTES];
             xSemaphoreHandle mutex;
         } wolfSSL_Mutex;
-    #elif defined(USE_WINDOWS_API)
+    #elif defined(USE_WINDOWS_API) && !defined(WOLFSSL_PTHREADS)
         typedef CRITICAL_SECTION wolfSSL_Mutex;
     #elif defined(MAXQ10XX_MUTEX)
         #include <sys/mman.h>


### PR DESCRIPTION
# Description

Default to native windows threading API on MinGW. Posix threading can be specified by defining `WOLFSSL_PTHREADS`

Fixes zd#17088

# Testing

Tested on local MINGW32

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
