### PR TITLE
Fixes for TI AES and SHA

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -99,6 +99,7 @@ ASN Options:
  * WOLFSSL_ALLOW_ENCODING_CA_FALSE: Allow encoding BasicConstraints CA:FALSE
  *  which is discouraged by X.690 specification - default values shall not
  *  be encoded.
+ * NO_TIME_SIGNEDNESS_CHECK: Disabled the time_t signedness check.
 */
 
 #include <wolfssl/wolfcrypt/error-crypt.h>
@@ -14726,7 +14727,7 @@ int wc_ValidateDate(const byte* date, byte format, int dateType)
     (void)tmpTime;
 
     ltime = wc_Time(0);
-#ifndef NO_TIME_SIGNED_CHECK
+#ifndef NO_TIME_SIGNEDNESS_CHECK
     if (sizeof(ltime) == sizeof(word32) && (int)ltime < 0){
         /* A negative response here could be due to a 32-bit time_t
          * where the year is 2038 or later. */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -14726,12 +14726,14 @@ int wc_ValidateDate(const byte* date, byte format, int dateType)
     (void)tmpTime;
 
     ltime = wc_Time(0);
+#ifndef NO_TIME_SIGNED_CHECK
     if (sizeof(ltime) == sizeof(word32) && (int)ltime < 0){
         /* A negative response here could be due to a 32-bit time_t
          * where the year is 2038 or later. */
         WOLFSSL_MSG("wc_Time failed to return a valid value");
         return 0;
     }
+#endif
 
 #ifdef WOLFSSL_BEFORE_DATE_CLOCK_SKEW
     if (dateType == BEFORE) {

--- a/wolfcrypt/src/port/ti/ti-aes.c
+++ b/wolfcrypt/src/port/ti/ti-aes.c
@@ -382,7 +382,7 @@ static int AesAuthEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
         XMEMSET(in_a, 0, ROUNDUP_16(inSz));
         XMEMCPY(in_a, in, inSz);
 
-        out_save = XMALLOC(ROUNDUP_16(inSz), NULL, DYNAMIC_TYPE_TMP_BUFFER)
+        out_save = XMALLOC(ROUNDUP_16(inSz), NULL, DYNAMIC_TYPE_TMP_BUFFER);
         if (out_save == NULL) { ret = MEMORY_E; goto exit; }
         out_a = out_save;
     }
@@ -453,7 +453,7 @@ static int AesAuthDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
 
 
     ret = AesAuthArgCheck(aes, out, in, inSz, nonce, nonceSz, authTag,
-        authTagSz, authIn, authInSz, &M, &L)
+        authTagSz, authIn, authInSz, &M, &L);
     if (ret != 0) {
         return ret;
     }

--- a/wolfcrypt/src/port/ti/ti-aes.c
+++ b/wolfcrypt/src/port/ti/ti-aes.c
@@ -471,7 +471,7 @@ static int AesAuthDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
         XMEMSET(in_a, 0, ROUNDUP_16(inSz));
         XMEMCPY(in_a, in, inSz);
 
-        out_save = XMALLOC(ROUNDUP_16(inSz), NULL, DYNAMIC_TYPE_TMP_BUFFER)
+        out_save = XMALLOC(ROUNDUP_16(inSz), NULL, DYNAMIC_TYPE_TMP_BUFFER);
         if (out_save == NULL) { ret = MEMORY_E; goto exit; }
         out_a = out_save;
     }
@@ -493,7 +493,7 @@ static int AesAuthDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
     }
     else {
         nonce_save = XMALLOC(ROUNDUP_16(nonceSz), NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        if (authIn_save == NULL) { ret = MEMORY_E; goto exit; }
+        if (nonce_save == NULL) { ret = MEMORY_E; goto exit; }
 
         nonce_a = nonce_save;
         XMEMSET(nonce_a, 0, ROUNDUP_16(nonceSz));

--- a/wolfcrypt/src/port/ti/ti-aes.c
+++ b/wolfcrypt/src/port/ti/ti-aes.c
@@ -26,10 +26,8 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
-#ifndef NO_AES
+#if !defined(NO_AES) && defined(WOLFSSL_TI_CRYPT)
 
-
-#if defined(WOLFSSL_TI_CRYPT)
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -45,7 +43,14 @@
 #include "driverlib/rom_map.h"
 #include "driverlib/rom.h"
 
-static int  AesSetIV(Aes* aes, const byte* iv)
+#define AES_CFG_MODE_CTR_NOCTR (AES_CFG_MODE_CTR + 100)
+#define IS_ALIGN16(p) (((unsigned int)(p) & 0xf) == 0)
+#define ROUNDUP_16(n) ((n+15) & 0xfffffff0)
+#ifndef TI_BUFFSIZE
+#define TI_BUFFSIZE 1024
+#endif
+
+static int AesSetIV(Aes* aes, const byte* iv)
 {
     if (aes == NULL)
         return BAD_FUNC_ARG;
@@ -58,196 +63,198 @@ static int  AesSetIV(Aes* aes, const byte* iv)
     return 0;
 }
 
-WOLFSSL_API int  wc_AesSetKey(Aes* aes, const byte* key, word32 len, const byte* iv,
-                          int dir)
+int wc_AesSetKey(Aes* aes, const byte* key, word32 len, const byte* iv, int dir)
 {
-    if(!wolfSSL_TI_CCMInit())return 1 ;
+    if (!wolfSSL_TI_CCMInit())
+        return 1;
     if ((aes == NULL) || (key == NULL) || (iv == NULL))
         return BAD_FUNC_ARG;
-    if(!((dir == AES_ENCRYPTION) || (dir == AES_DECRYPTION)))
+    if (!((dir == AES_ENCRYPTION) || (dir == AES_DECRYPTION)))
         return BAD_FUNC_ARG;
 
-    switch(len) {
-    case 16: aes->keylen = AES_CFG_KEY_SIZE_128BIT ; break ;
-    case 24: aes->keylen = AES_CFG_KEY_SIZE_192BIT ; break ;
-    case 32: aes->keylen = AES_CFG_KEY_SIZE_256BIT ; break ;
+    switch (len) {
+        case 16: aes->keylen = AES_CFG_KEY_SIZE_128BIT; break;
+        case 24: aes->keylen = AES_CFG_KEY_SIZE_192BIT; break;
+        case 32: aes->keylen = AES_CFG_KEY_SIZE_256BIT; break;
     default: return BAD_FUNC_ARG;
     }
 
-    XMEMCPY(aes->key, key, len) ;
-    #ifdef WOLFSSL_AES_COUNTER
+    XMEMCPY(aes->key, key, len);
+#ifdef WOLFSSL_AES_COUNTER
     aes->left = 0;
-    #endif /* WOLFSSL_AES_COUNTER */
+#endif
     return AesSetIV(aes, iv);
 }
 
-#define AES_CFG_MODE_CTR_NOCTR AES_CFG_MODE_CTR+100
-#define IS_ALIGN16(p) (((unsigned int)(p)&0xf) == 0)
-
-static int  AesAlign16(Aes* aes, byte* out, const byte* in, word32 sz, word32 dir, word32 mode)
+static int AesAlign16(Aes* aes, byte* out, const byte* in, word32 sz,
+    word32 dir, word32 mode)
 {
-    wolfSSL_TI_lockCCM() ;
+    /* Processed aligned chunk to HW AES */
+    wolfSSL_TI_lockCCM();
     ROM_AESReset(AES_BASE);
     ROM_AESConfigSet(AES_BASE, (aes->keylen | dir |
-                     (mode==AES_CFG_MODE_CTR_NOCTR ? AES_CFG_MODE_CTR : mode)));
+        (mode == AES_CFG_MODE_CTR_NOCTR ? AES_CFG_MODE_CTR : mode)));
     ROM_AESIVSet(AES_BASE, (uint32_t *)aes->reg);
     ROM_AESKey1Set(AES_BASE, (uint32_t *)aes->key, aes->keylen);
-    if((dir == AES_CFG_DIR_DECRYPT)&& (mode == AES_CFG_MODE_CBC))
+    if ((dir == AES_CFG_DIR_DECRYPT)&& (mode == AES_CFG_MODE_CBC)) {
         /* if input and output same will overwrite input iv */
         XMEMCPY(aes->tmp, in + sz - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
+    }
     ROM_AESDataProcess(AES_BASE, (uint32_t *)in, (uint32_t *)out, sz);
-    wolfSSL_TI_unlockCCM() ;
+    wolfSSL_TI_unlockCCM();
 
     /* store iv for next call */
-    if(mode == AES_CFG_MODE_CBC){
-        if(dir == AES_CFG_DIR_ENCRYPT)
+    if (mode == AES_CFG_MODE_CBC){
+        if (dir == AES_CFG_DIR_ENCRYPT)
             XMEMCPY(aes->reg, out + sz - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
         else
             XMEMCPY(aes->reg, aes->tmp, AES_BLOCK_SIZE);
     }
 
-    if(mode == AES_CFG_MODE_CTR) {
+    if (mode == AES_CFG_MODE_CTR) {
         do {
-            int i ;
+            int i;
             for (i = AES_BLOCK_SIZE - 1; i >= 0; i--) {
                  if (++((byte *)aes->reg)[i])
-                     break ;
+                     break;
             }
-            sz -= AES_BLOCK_SIZE ;
-        } while((int)sz > 0) ;
+            sz -= AES_BLOCK_SIZE;
+        } while ((int)sz > 0);
     }
 
-    return 0 ;
+    return 0;
 }
 
-static int  AesProcess(Aes* aes, byte* out, const byte* in, word32 sz, word32 dir, word32 mode)
+static int AesProcess(Aes* aes, byte* out, const byte* in, word32 sz,
+    word32 dir, word32 mode)
 {
-    const byte * in_p ; byte * out_p ;
-    word32 size ;
-    #define TI_BUFFSIZE 1024
-    byte buff[TI_BUFFSIZE] ;
+    const byte * in_p; byte * out_p;
+    word32 size;
+    byte buff[TI_BUFFSIZE];
 
     if ((aes == NULL) || (in == NULL) || (out == NULL))
         return BAD_FUNC_ARG;
-    if(sz % AES_BLOCK_SIZE)
+    if (sz % AES_BLOCK_SIZE)
         return BAD_FUNC_ARG;
 
-    while(sz > 0) {
-        size = sz ; in_p = in ; out_p = out ;
-        if(!IS_ALIGN16(in)){
-            size = sz>TI_BUFFSIZE ? TI_BUFFSIZE : sz ;
-            XMEMCPY(buff, in, size) ;
-            in_p = (const byte *)buff ;
+    while (sz > 0) {
+        size = sz; in_p = in; out_p = out;
+        if (!IS_ALIGN16(in)){
+            size = sz > TI_BUFFSIZE ? TI_BUFFSIZE : sz;
+            XMEMCPY(buff, in, size);
+            in_p = (const byte *)buff;
         }
-        if(!IS_ALIGN16(out)){
-            size = sz>TI_BUFFSIZE ? TI_BUFFSIZE : sz ;
-            out_p = buff ;
+        if (!IS_ALIGN16(out)){
+            size = sz > TI_BUFFSIZE ? TI_BUFFSIZE : sz;
+            out_p = buff;
         }
 
-        AesAlign16(aes, out_p, in_p, size, dir, mode) ;
+        AesAlign16(aes, out_p, in_p, size, dir, mode);
 
-        if(!IS_ALIGN16(out)){
-            XMEMCPY(out, buff, size) ;
+        if (!IS_ALIGN16(out)){
+            XMEMCPY(out, buff, size);
         }
-        sz -= size ; in += size ; out += size ;
+        sz -= size; in += size; out += size;
     }
 
-    return 0 ;
+    return 0;
 }
 
-WOLFSSL_API int  wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
+int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
-    return AesProcess(aes, out, in, sz, AES_CFG_DIR_ENCRYPT, AES_CFG_MODE_CBC) ;
+    return AesProcess(aes, out, in, sz, AES_CFG_DIR_ENCRYPT, AES_CFG_MODE_CBC);
 }
 
-WOLFSSL_API int  wc_AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
+int wc_AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
-    return AesProcess(aes, out, in, sz, AES_CFG_DIR_DECRYPT, AES_CFG_MODE_CBC) ;
+    return AesProcess(aes, out, in, sz, AES_CFG_DIR_DECRYPT, AES_CFG_MODE_CBC);
 }
 
 #ifdef WOLFSSL_AES_COUNTER
-WOLFSSL_API int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
+int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
-            char out_block[AES_BLOCK_SIZE] ;
-            int odd ;
-            int even ;
-            char *tmp ; /* (char *)aes->tmp, for short */
-            int ret;
+    char out_block[AES_BLOCK_SIZE];
+    int odd;
+    int even;
+    char *tmp; /* (char *)aes->tmp, for short */
+    int ret;
 
-            tmp = (char *)aes->tmp ;
-            if(aes->left) {
-                if((aes->left + sz) >= AES_BLOCK_SIZE){
-                    odd = AES_BLOCK_SIZE - aes->left ;
-                } else {
-                    odd = sz ;
-                }
-                XMEMCPY(tmp+aes->left, in, odd) ;
-                if((odd+aes->left) == AES_BLOCK_SIZE){
-                    ret = AesProcess(aes, (byte *)out_block, (byte const *)tmp, AES_BLOCK_SIZE,
-                             AES_CFG_DIR_ENCRYPT, AES_CFG_MODE_CTR) ;
-                    if (ret != 0)
-                        return ret;
-                    XMEMCPY(out, out_block+aes->left, odd) ;
-                    aes->left = 0 ;
-                    XMEMSET(tmp, 0x0, AES_BLOCK_SIZE) ;
-                }
-                in += odd ;
-                out+= odd ;
-                sz -= odd ;
-            }
-            odd = sz % AES_BLOCK_SIZE ;  /* if there is tail flagment */
-            if(sz / AES_BLOCK_SIZE) {
-                even = (sz/AES_BLOCK_SIZE)*AES_BLOCK_SIZE ;
-                ret = AesProcess(aes, out, in, even, AES_CFG_DIR_ENCRYPT, AES_CFG_MODE_CTR);
-                if (ret != 0)
-                    return ret;
-                out += even ;
-                in  += even ;
-            }
-            if(odd) {
-                XMEMSET(tmp+aes->left, 0x0, AES_BLOCK_SIZE - aes->left) ;
-                XMEMCPY(tmp+aes->left, in, odd) ;
-                ret = AesProcess(aes, (byte *)out_block, (byte const *)tmp, AES_BLOCK_SIZE,
-                           AES_CFG_DIR_ENCRYPT,
-                           AES_CFG_MODE_CTR_NOCTR /* Counter mode without counting IV */
-                           );
-                if (ret != 0)
-                    return ret;
-                XMEMCPY(out, out_block+aes->left,odd) ;
-                aes->left += odd ;
-            }
-            return 0;
+    tmp = (char *)aes->tmp;
+    if (aes->left) {
+        if ((aes->left + sz) >= AES_BLOCK_SIZE){
+            odd = AES_BLOCK_SIZE - aes->left;
+        } else {
+            odd = sz;
+        }
+        XMEMCPY(tmp+aes->left, in, odd);
+        if ((odd+aes->left) == AES_BLOCK_SIZE){
+            ret = AesProcess(aes, (byte *)out_block, (byte const *)tmp, AES_BLOCK_SIZE,
+                        AES_CFG_DIR_ENCRYPT, AES_CFG_MODE_CTR);
+            if (ret != 0)
+                return ret;
+            XMEMCPY(out, out_block+aes->left, odd);
+            aes->left = 0;
+            XMEMSET(tmp, 0x0, AES_BLOCK_SIZE);
+        }
+        in += odd;
+        out+= odd;
+        sz -= odd;
+    }
+    odd = sz % AES_BLOCK_SIZE;  /* if there is tail fragment */
+    if (sz / AES_BLOCK_SIZE) {
+        even = (sz/AES_BLOCK_SIZE)*AES_BLOCK_SIZE;
+        ret = AesProcess(aes, out, in, even, AES_CFG_DIR_ENCRYPT, AES_CFG_MODE_CTR);
+        if (ret != 0)
+            return ret;
+        out += even;
+        in  += even;
+    }
+    if (odd) {
+        XMEMSET(tmp+aes->left, 0x0, AES_BLOCK_SIZE - aes->left);
+        XMEMCPY(tmp+aes->left, in, odd);
+        ret = AesProcess(aes, (byte *)out_block, (byte const *)tmp, AES_BLOCK_SIZE,
+                    AES_CFG_DIR_ENCRYPT,
+                    AES_CFG_MODE_CTR_NOCTR /* Counter mode without counting IV */
+                    );
+        if (ret != 0)
+            return ret;
+        XMEMCPY(out, out_block+aes->left,odd);
+        aes->left += odd;
+    }
+    return 0;
 }
-#endif
+#endif /* WOLFSSL_AES_COUNTER */
 
 /* AES-DIRECT */
 #if defined(WOLFSSL_AES_DIRECT)
-WOLFSSL_API int wc_AesEncryptDirect(Aes* aes, byte* out, const byte* in)
+int wc_AesEncryptDirect(Aes* aes, byte* out, const byte* in)
 {
-    return AesProcess(aes, out, in, AES_BLOCK_SIZE, AES_CFG_DIR_ENCRYPT, AES_CFG_MODE_CBC) ;
+    return AesProcess(aes, out, in, AES_BLOCK_SIZE, AES_CFG_DIR_ENCRYPT,
+        AES_CFG_MODE_CBC);
 }
-WOLFSSL_API int wc_AesDecryptDirect(Aes* aes, byte* out, const byte* in)
+int wc_AesDecryptDirect(Aes* aes, byte* out, const byte* in)
 {
-    return AesProcess(aes, out, in, AES_BLOCK_SIZE, AES_CFG_DIR_DECRYPT, AES_CFG_MODE_CBC) ;
+    return AesProcess(aes, out, in, AES_BLOCK_SIZE, AES_CFG_DIR_DECRYPT,
+        AES_CFG_MODE_CBC);
 }
-WOLFSSL_API int wc_AesSetKeyDirect(Aes* aes, const byte* key, word32 len,
-                                     const byte* iv, int dir)
+int wc_AesSetKeyDirect(Aes* aes, const byte* key, word32 len, const byte* iv,
+    int dir)
 {
-    return(wc_AesSetKey(aes, key, len, iv, dir)) ;
+    return wc_AesSetKey(aes, key, len, iv, dir);
 }
-#endif
+#endif /* WOLFSSL_AES_DIRECT */
 
 
 #if defined(HAVE_AESGCM) || defined(HAVE_AESCCM)
 
-static int  AesAuthSetKey(Aes* aes, const byte* key, word32 keySz)
+static int AesAuthSetKey(Aes* aes, const byte* key, word32 keySz)
 {
     byte nonce[AES_BLOCK_SIZE];
 
     if ((aes == NULL) || (key == NULL))
-        return BAD_FUNC_ARG ;
+        return BAD_FUNC_ARG;
     if (!((keySz == 16) || (keySz == 24) || (keySz == 32)))
-        return BAD_FUNC_ARG ;
+        return BAD_FUNC_ARG;
 
     XMEMSET(nonce, 0, sizeof(nonce));
     return wc_AesSetKey(aes, key, keySz, nonce, AES_ENCRYPTION);
@@ -255,166 +262,180 @@ static int  AesAuthSetKey(Aes* aes, const byte* key, word32 keySz)
 
 
 static int AesAuthArgCheck(Aes* aes, byte* out, const byte* in, word32 inSz,
-                              const byte* nonce, word32 nonceSz,
-                              const byte* authTag, word32 authTagSz,
-                              const byte* authIn, word32 authInSz, word32 *M,  word32 *L)
+    const byte* nonce, word32 nonceSz,
+    const byte* authTag, word32 authTagSz,
+    const byte* authIn, word32 authInSz, word32 *M, word32 *L)
 {
-    (void) authInSz ;
-    if((aes == NULL)||(nonce == NULL)||(authTag== NULL)||(authIn == NULL))
+    (void) authInSz;
+    if ((aes == NULL)||(nonce == NULL)||(authTag== NULL)||(authIn == NULL))
         return BAD_FUNC_ARG;
-    if((inSz != 0) && ((out == NULL)||(in == NULL)))
+    if ((inSz != 0) && ((out == NULL)||(in == NULL)))
         return BAD_FUNC_ARG;
 
     switch(authTagSz){
-    case  4:
-        *M = AES_CFG_CCM_M_4; break ;
+    case 4:
+        *M = AES_CFG_CCM_M_4; break;
     case 6:
-        *M = AES_CFG_CCM_M_6; break ;
+        *M = AES_CFG_CCM_M_6; break;
     case 8:
-        *M = AES_CFG_CCM_M_8; break ;
+        *M = AES_CFG_CCM_M_8; break;
     case 10:
-        *M = AES_CFG_CCM_M_10; break ;
+        *M = AES_CFG_CCM_M_10; break;
     case 12:
-        *M = AES_CFG_CCM_M_12; break ;
+        *M = AES_CFG_CCM_M_12; break;
     case 14:
-        *M = AES_CFG_CCM_M_14; break ;
+        *M = AES_CFG_CCM_M_14; break;
     case 16:
-        *M = AES_CFG_CCM_M_16; break ;
+        *M = AES_CFG_CCM_M_16; break;
     default:
-        return 1 ;
+        return 1;
     }
 
     switch(nonceSz){
     case 7:
-        *L = AES_CFG_CCM_L_8; break ;
+        *L = AES_CFG_CCM_L_8; break;
     case 8:
-        *L = AES_CFG_CCM_L_7; break ;
+        *L = AES_CFG_CCM_L_7; break;
     case 9:
-        *L = AES_CFG_CCM_L_6; break ;
+        *L = AES_CFG_CCM_L_6; break;
     case  10:
-        *L = AES_CFG_CCM_L_5; break ;
+        *L = AES_CFG_CCM_L_5; break;
     case 11:
-        *L = AES_CFG_CCM_L_4; break ;
+        *L = AES_CFG_CCM_L_4; break;
     case 12:
-        *L = AES_CFG_CCM_L_3; break ;
+        *L = AES_CFG_CCM_L_3; break;
     case 13:
-        *L = AES_CFG_CCM_L_2; break ;
+        *L = AES_CFG_CCM_L_2; break;
     case 14:
-        *L = AES_CFG_CCM_L_1; break ;
+        *L = AES_CFG_CCM_L_1; break;
     default:
         return 1;
     }
-    return 0 ;
+    return 0;
 }
 
-static void AesAuthSetIv(Aes *aes, const byte *nonce, word32 len, word32 L, int mode) {
-
-  if(mode == AES_CFG_MODE_CCM){
-    XMEMSET(aes->reg, 0, 16) ;
-    switch(L){
-    case AES_CFG_CCM_L_8:
-      aes->reg[0] = 0x7; break ;
-    case AES_CFG_CCM_L_7:
-      aes->reg[0] = 0x6; break ;
-    case AES_CFG_CCM_L_6:
-      aes->reg[0] = 0x5; break ;
-    case AES_CFG_CCM_L_5:
-      aes->reg[0] = 0x4; break ;
-    case AES_CFG_CCM_L_4:
-      aes->reg[0] = 0x3; break ;
-    case AES_CFG_CCM_L_3:
-      aes->reg[0] = 0x2; break ;
-    case AES_CFG_CCM_L_2:
-      aes->reg[0] = 0x1; break ;
-    case AES_CFG_CCM_L_1:
-      aes->reg[0] = 0x0; break ;
+static void AesAuthSetIv(Aes *aes, const byte *nonce, word32 len, word32 L,
+    int mode)
+{
+    if (mode == AES_CFG_MODE_CCM){
+        XMEMSET(aes->reg, 0, 16);
+        switch (L) {
+        case AES_CFG_CCM_L_8:
+            aes->reg[0] = 0x7; break;
+        case AES_CFG_CCM_L_7:
+            aes->reg[0] = 0x6; break;
+        case AES_CFG_CCM_L_6:
+            aes->reg[0] = 0x5; break;
+        case AES_CFG_CCM_L_5:
+            aes->reg[0] = 0x4; break;
+        case AES_CFG_CCM_L_4:
+            aes->reg[0] = 0x3; break;
+        case AES_CFG_CCM_L_3:
+            aes->reg[0] = 0x2; break;
+        case AES_CFG_CCM_L_2:
+            aes->reg[0] = 0x1; break;
+        case AES_CFG_CCM_L_1:
+            aes->reg[0] = 0x0; break;
+        }
+        XMEMCPY(((byte *)aes->reg)+1, nonce, len);
     }
-    XMEMCPY(((byte *)aes->reg)+1, nonce, len) ;
-  } else {
-    byte *b = (byte *)aes->reg ;
-    XMEMSET(aes->reg, 0, AES_BLOCK_SIZE);
-    XMEMCPY(aes->reg, nonce, len);
-    b[AES_BLOCK_SIZE-4] = 0 ;
-    b[AES_BLOCK_SIZE-3] = 0 ;
-    b[AES_BLOCK_SIZE-2] = 0 ;
-    b[AES_BLOCK_SIZE-1] = 1 ;
-  }
+    else {
+        byte *b = (byte *)aes->reg;
+        XMEMSET(aes->reg, 0, AES_BLOCK_SIZE);
+        XMEMCPY(aes->reg, nonce, len);
+        b[AES_BLOCK_SIZE-4] = 0;
+        b[AES_BLOCK_SIZE-3] = 0;
+        b[AES_BLOCK_SIZE-2] = 0;
+        b[AES_BLOCK_SIZE-1] = 1;
+    }
 }
-
-#define RoundUp16(n) ((n+15)&0xfffffff0)
-#define FREE_ALL \
-    if(in_save)    XFREE(in_save, NULL, DYNAMIC_TYPE_TMP_BUFFER);\
-    if(out_save)   XFREE(out_save, NULL, DYNAMIC_TYPE_TMP_BUFFER);\
-    if(authIn_save)XFREE(authIn_save, NULL, DYNAMIC_TYPE_TMP_BUFFER);\
-    if(nonce_save) XFREE(nonce_save, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
 static int AesAuthEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
                               const byte* nonce, word32 nonceSz,
                               byte* authTag, word32 authTagSz,
                               const byte* authIn, word32 authInSz, int mode)
 {
-    word32 M, L ;
-    byte *in_a,     *in_save ;
-    byte *out_a,    *out_save ;
-    byte *authIn_a, *authIn_save ;
-    byte *nonce_a,    *nonce_save ;
-    word32 tmpTag[4] ;
-    int ret ;
+    int ret;
+    word32 M, L;
+    byte *in_a,     *in_save = NULL;
+    byte *out_a,    *out_save = NULL;
+    byte *authIn_a, *authIn_save = NULL;
+    byte *nonce_a,  *nonce_save = NULL;
+    word32 tmpTag[4];
 
-    if(AesAuthArgCheck(aes, out, in, inSz, nonce, nonceSz, authTag, authTagSz, authIn, authInSz, &M, &L)
-       == BAD_FUNC_ARG)return BAD_FUNC_ARG ;
+    ret = AesAuthArgCheck(aes, out, in, inSz, nonce, nonceSz, authTag,
+        authTagSz, authIn, authInSz, &M, &L);
+    if (ret != 0) {
+        return ret;
+    }
 
     /* 16 byte padding */
-    in_save = NULL ; out_save = NULL ; authIn_save = NULL ; nonce_save = NULL ;
-    if((inSz%16)==0){
-        in_save = NULL ; in_a = (byte *)in ;
-        out_save = NULL ; out_a = out ;
-    } else {
-      if((in_save = XMALLOC(RoundUp16(inSz), NULL, DYNAMIC_TYPE_TMP_BUFFER)) == NULL){
-          FREE_ALL; return MEMORY_E ; }
-      in_a = in_save ; XMEMSET(in_a, 0, RoundUp16(inSz)) ; XMEMCPY(in_a, in, inSz) ;
+    in_save = NULL; out_save = NULL; authIn_save = NULL; nonce_save = NULL;
+    if (IS_ALIGN16(inSz)) {
+        in_save = NULL; in_a = (byte *)in;
+        out_save = NULL; out_a = out;
+    }
+    else {
+        in_save = XMALLOC(ROUNDUP_16(inSz), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        if (in_save == NULL) { ret = MEMORY_E; goto exit; }
+        in_a = in_save;
+        XMEMSET(in_a, 0, ROUNDUP_16(inSz));
+        XMEMCPY(in_a, in, inSz);
 
-      if((out_save = XMALLOC(RoundUp16(inSz), NULL, DYNAMIC_TYPE_TMP_BUFFER)) == NULL){
-          FREE_ALL; return MEMORY_E ; }
-      out_a = out_save ;
+        out_save = XMALLOC(ROUNDUP_16(inSz), NULL, DYNAMIC_TYPE_TMP_BUFFER)
+        if (out_save == NULL) { ret = MEMORY_E; goto exit; }
+        out_a = out_save;
     }
 
-    if((authInSz%16)==0){
-        authIn_save = NULL ; authIn_a = (byte *)authIn ;
-    } else {
-      if((authIn_save = XMALLOC(RoundUp16(authInSz), NULL, DYNAMIC_TYPE_TMP_BUFFER)) == NULL){
-          FREE_ALL; return MEMORY_E ; }
-      authIn_a = authIn_save ; XMEMSET(authIn_a, 0, RoundUp16(authInSz)) ; XMEMCPY(authIn_a, authIn, authInSz) ;
+    if (IS_ALIGN16(authInSz)) {
+        authIn_save = NULL; authIn_a = (byte *)authIn;
+    }
+    else {
+        authIn_save = XMALLOC(ROUNDUP_16(authInSz), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        if (authIn_save == NULL) { ret = MEMORY_E; goto exit; }
+
+        authIn_a = authIn_save;
+        XMEMSET(authIn_a, 0, ROUNDUP_16(authInSz));
+        XMEMCPY(authIn_a, authIn, authInSz);
     }
 
-    if((nonceSz%16)==0){
-        nonce_save = NULL ; nonce_a = (byte *)nonce ;
-    } else {
-      if((nonce_save = XMALLOC(RoundUp16(nonceSz), NULL, DYNAMIC_TYPE_TMP_BUFFER)) == NULL){
-          FREE_ALL; return MEMORY_E; }
-      nonce_a = nonce_save ; XMEMSET(nonce_a, 0, RoundUp16(nonceSz)) ; XMEMCPY(nonce_a, nonce, nonceSz) ;
+    if (IS_ALIGN16(nonceSz)) {
+        nonce_save = NULL;
+        nonce_a = (byte *)nonce;
+    }
+    else {
+        nonce_save = XMALLOC(ROUNDUP_16(nonceSz), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        if (nonce_save == NULL) { ret = MEMORY_E; goto exit; }
+
+        nonce_a = nonce_save;
+        XMEMSET(nonce_a, 0, ROUNDUP_16(nonceSz));
+        XMEMCPY(nonce_a, nonce, nonceSz);
     }
 
     /* do aes-ccm */
-    AesAuthSetIv(aes, nonce, nonceSz, L, mode) ;
+    AesAuthSetIv(aes, nonce, nonceSz, L, mode);
     ROM_AESReset(AES_BASE);
     ROM_AESConfigSet(AES_BASE, (aes->keylen | AES_CFG_DIR_ENCRYPT |
                                 AES_CFG_CTR_WIDTH_128 |
-                                mode | ((mode== AES_CFG_MODE_CCM) ? (L | M) : 0 ))) ;
+                                mode | ((mode== AES_CFG_MODE_CCM) ? (L | M) : 0 )));
     ROM_AESIVSet(AES_BASE, aes->reg);
     ROM_AESKey1Set(AES_BASE, aes->key, aes->keylen);
     ret = ROM_AESDataProcessAuth(AES_BASE, (unsigned int*)in_a, (unsigned int *)out_a, inSz,
                            (unsigned int*)authIn_a, authInSz, (unsigned int *)tmpTag);
-    if(ret == false){
-        XMEMSET(out, 0, inSz) ;
-        XMEMSET(authTag, 0, authTagSz) ;
+    if (ret == false) {
+        XMEMSET(out, 0, inSz);
+        XMEMSET(authTag, 0, authTagSz);
     } else {
-        XMEMCPY(out, out_a, inSz) ;
-        XMEMCPY(authTag, tmpTag, authTagSz) ;
+        XMEMCPY(out, out_a, inSz);
+        XMEMCPY(authTag, tmpTag, authTagSz);
     }
 
-    FREE_ALL;
-    return 0 ;
+exit:
+    if (in_save)    XFREE(in_save, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (out_save)   XFREE(out_save, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (authIn_save)XFREE(authIn_save, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (nonce_save) XFREE(nonce_save, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    return 0;
 }
 
 static int AesAuthDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
@@ -422,78 +443,97 @@ static int AesAuthDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
                               const byte* authTag, word32 authTagSz,
                               const byte* authIn, word32 authInSz, int mode)
 {
-    word32 M, L ;
-    byte *in_a,     *in_save ;
-    byte *out_a,    *out_save ;
-    byte *authIn_a, *authIn_save ;
-    byte *nonce_a,    *nonce_save ;
-    word32 tmpTag[4] ;
-    bool ret ;
+    int ret;
+    word32 M, L;
+    byte *in_a,     *in_save = NULL;
+    byte *out_a,    *out_save = NULL;
+    byte *authIn_a, *authIn_save = NULL;
+    byte *nonce_a,  *nonce_save = NULL;
+    word32 tmpTag[4];
 
-    if(AesAuthArgCheck(aes, out, in, inSz, nonce, nonceSz, authTag, authTagSz, authIn, authInSz, &M, &L)
-       == BAD_FUNC_ARG)return  BAD_FUNC_ARG ;
+
+    ret = AesAuthArgCheck(aes, out, in, inSz, nonce, nonceSz, authTag,
+        authTagSz, authIn, authInSz, &M, &L)
+    if (ret != 0) {
+        return ret;
+    }
 
     /* 16 byte padding */
-    in_save = NULL ; out_save = NULL ; authIn_save = NULL ; nonce_save = NULL ;
-    if((inSz%16)==0){
-        in_save = NULL ; in_a = (byte *)in ;
-        out_save = NULL ; out_a = out ;
-    } else {
-      if((in_save = XMALLOC(RoundUp16(inSz), NULL, DYNAMIC_TYPE_TMP_BUFFER)) == NULL){
-          FREE_ALL; return MEMORY_E;}
-      in_a = in_save ; XMEMSET(in_a, 0, RoundUp16(inSz)) ; XMEMCPY(in_a, in, inSz) ;
+    in_save = NULL; out_save = NULL; authIn_save = NULL; nonce_save = NULL;
+    if (IS_ALIGN16(inSz)) {
+        in_save = NULL; in_a = (byte *)in;
+        out_save = NULL; out_a = out;
+    }
+    else {
+        in_save = XMALLOC(ROUNDUP_16(inSz), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        if (in_save == NULL) { ret = MEMORY_E; goto exit; }
+        in_a = in_save;
+        XMEMSET(in_a, 0, ROUNDUP_16(inSz));
+        XMEMCPY(in_a, in, inSz);
 
-      if((out_save = XMALLOC(RoundUp16(inSz), NULL, DYNAMIC_TYPE_TMP_BUFFER)) == NULL){
-          FREE_ALL; return MEMORY_E;}
-      out_a = out_save ;
+        out_save = XMALLOC(ROUNDUP_16(inSz), NULL, DYNAMIC_TYPE_TMP_BUFFER)
+        if (out_save == NULL) { ret = MEMORY_E; goto exit; }
+        out_a = out_save;
     }
 
-    if((authInSz%16)==0){
-        authIn_save = NULL ; authIn_a = (byte *)authIn ;
-    } else {
-      if((authIn_save = XMALLOC(RoundUp16(authInSz), NULL, DYNAMIC_TYPE_TMP_BUFFER)) == NULL){
-          FREE_ALL; return MEMORY_E; }
-      authIn_a = authIn_save ; XMEMSET(authIn_a, 0, RoundUp16(authInSz)) ; XMEMCPY(authIn_a, authIn, authInSz) ;
+    if (IS_ALIGN16(authInSz)) {
+        authIn_save = NULL; authIn_a = (byte *)authIn;
+    }
+    else {
+        authIn_save = XMALLOC(ROUNDUP_16(authInSz), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        if (authIn_save == NULL) { ret = MEMORY_E; goto exit; }
+
+        authIn_a = authIn_save;
+        XMEMSET(authIn_a, 0, ROUNDUP_16(authInSz));
+        XMEMCPY(authIn_a, authIn, authInSz);
     }
 
-    if((nonceSz%16)==0){
-        nonce_save = NULL ; nonce_a = (byte *)nonce ;
-    } else {
-      if((nonce_save = XMALLOC(RoundUp16(nonceSz), NULL, DYNAMIC_TYPE_TMP_BUFFER)) == NULL){
-          FREE_ALL; return MEMORY_E; }
-      nonce_a = nonce_save ; XMEMSET(nonce_a, 0, RoundUp16(nonceSz)) ; XMEMCPY(nonce_a, nonce, nonceSz) ;
+    if (IS_ALIGN16(nonceSz)) {
+        nonce_save = NULL; nonce_a = (byte *)nonce;
+    }
+    else {
+        nonce_save = XMALLOC(ROUNDUP_16(nonceSz), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        if (authIn_save == NULL) { ret = MEMORY_E; goto exit; }
+
+        nonce_a = nonce_save;
+        XMEMSET(nonce_a, 0, ROUNDUP_16(nonceSz));
+        XMEMCPY(nonce_a, nonce, nonceSz);
     }
 
     /* do aes-ccm */
-    AesAuthSetIv(aes, nonce, nonceSz, L, mode) ;
+    AesAuthSetIv(aes, nonce, nonceSz, L, mode);
     ROM_AESReset(AES_BASE);
     ROM_AESConfigSet(AES_BASE, (aes->keylen | AES_CFG_DIR_DECRYPT |
                                 AES_CFG_CTR_WIDTH_128 |
-                                  mode | ((mode== AES_CFG_MODE_CCM) ? (L | M) : 0 ))) ;
+                                  mode | ((mode== AES_CFG_MODE_CCM) ? (L | M) : 0 )));
     ROM_AESIVSet(AES_BASE, aes->reg);
     ROM_AESKey1Set(AES_BASE, aes->key, aes->keylen);
     ret = ROM_AESDataProcessAuth(AES_BASE, (unsigned int*)in_a, (unsigned int *)out_a, inSz,
                            (unsigned int*)authIn_a, authInSz, (unsigned int *)tmpTag);
-    if((ret == false) || (XMEMCMP(authTag, tmpTag, authTagSz) != 0)){
-        XMEMSET(out, 0, inSz) ;
-        ret = false ;
+    if ((ret == false) || (XMEMCMP(authTag, tmpTag, authTagSz) != 0)){
+        XMEMSET(out, 0, inSz);
+        ret = false;
     } else {
-        XMEMCPY(out, out_a, inSz) ;
+        XMEMCPY(out, out_a, inSz);
     }
 
-    FREE_ALL ;
-    return ret==true ? 0 : 1 ;
-}
-#endif
+exit:
+    if (in_save)    XFREE(in_save, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (out_save)   XFREE(out_save, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (authIn_save)XFREE(authIn_save, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (nonce_save) XFREE(nonce_save, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
+    return ret==true ? 0 : 1;
+}
+#endif /* HAVE_AESGCM || HAVE_AESCCM */
 
 #ifdef HAVE_AESGCM
-WOLFSSL_API int  wc_AesGcmSetKey(Aes* aes, const byte* key, word32 len)
+int wc_AesGcmSetKey(Aes* aes, const byte* key, word32 len)
 {
-    return AesAuthSetKey(aes, key, len) ;
+    return AesAuthSetKey(aes, key, len);
 }
 
-WOLFSSL_API int  wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
+int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
                               const byte* iv, word32 ivSz,
                               byte* authTag, word32 authTagSz,
                               const byte* authIn, word32 authInSz)
@@ -502,58 +542,57 @@ WOLFSSL_API int  wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz
         return BAD_FUNC_ARG;
     }
     return AesAuthEncrypt(aes, out, in, sz, iv, ivSz, authTag, authTagSz,
-                              authIn, authInSz, AES_CFG_MODE_GCM_HY0CALC) ;
+                              authIn, authInSz, AES_CFG_MODE_GCM_HY0CALC);
 }
-WOLFSSL_API int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
+int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
                               const byte* iv, word32 ivSz,
                               const byte* authTag, word32 authTagSz,
                               const byte* authIn, word32 authInSz)
 {
     return AesAuthDecrypt(aes, out, in, sz, iv, ivSz, authTag, authTagSz,
-                              authIn, authInSz, AES_CFG_MODE_GCM_HY0CALC) ;
+                              authIn, authInSz, AES_CFG_MODE_GCM_HY0CALC);
 }
 
-WOLFSSL_API int wc_GmacSetKey(Gmac* gmac, const byte* key, word32 len)
+int wc_GmacSetKey(Gmac* gmac, const byte* key, word32 len)
 {
-      return AesAuthSetKey(&gmac->aes, key, len) ;
+    return AesAuthSetKey(&gmac->aes, key, len);
 }
 
-WOLFSSL_API int wc_GmacUpdate(Gmac* gmac, const byte* iv, word32 ivSz,
+int wc_GmacUpdate(Gmac* gmac, const byte* iv, word32 ivSz,
                               const byte* authIn, word32 authInSz,
                               byte* authTag, word32 authTagSz)
 {
     return AesAuthEncrypt(&gmac->aes, NULL, NULL, 0, iv, ivSz, authTag, authTagSz,
-                              authIn, authInSz, AES_CFG_MODE_GCM_HY0CALC) ;
+                              authIn, authInSz, AES_CFG_MODE_GCM_HY0CALC);
 }
-
 #endif /* HAVE_AESGCM */
 
 #ifdef HAVE_AESCCM
-WOLFSSL_API int wc_AesCcmSetKey(Aes* aes, const byte* key, word32 keySz)
+int wc_AesCcmSetKey(Aes* aes, const byte* key, word32 keySz)
 {
-    return AesAuthSetKey(aes, key, keySz) ;
+    return AesAuthSetKey(aes, key, keySz);
 }
 
-WOLFSSL_API int wc_AesCcmEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
+int wc_AesCcmEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
                               const byte* nonce, word32 nonceSz,
                               byte* authTag, word32 authTagSz,
                               const byte* authIn, word32 authInSz)
 {
     return AesAuthEncrypt(aes, out, in, inSz, nonce, nonceSz, authTag, authTagSz,
-                              authIn, authInSz, AES_CFG_MODE_CCM) ;
+                              authIn, authInSz, AES_CFG_MODE_CCM);
 }
 
-WOLFSSL_API int wc_AesCcmDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
+int wc_AesCcmDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
                               const byte* nonce, word32 nonceSz,
                               const byte* authTag, word32 authTagSz,
                               const byte* authIn, word32 authInSz)
 {
     return AesAuthDecrypt(aes, out, in, inSz, nonce, nonceSz, authTag, authTagSz,
-                              authIn, authInSz, AES_CFG_MODE_CCM) ;
+                              authIn, authInSz, AES_CFG_MODE_CCM);
 }
 #endif /* HAVE_AESCCM */
 
-WOLFSSL_API int wc_AesInit(Aes* aes, void* heap, int devId)
+int wc_AesInit(Aes* aes, void* heap, int devId)
 {
     if (aes == NULL)
         return BAD_FUNC_ARG;
@@ -564,14 +603,9 @@ WOLFSSL_API int wc_AesInit(Aes* aes, void* heap, int devId)
     return 0;
 }
 
-WOLFSSL_API void wc_AesFree(Aes* aes)
+void wc_AesFree(Aes* aes)
 {
     (void)aes;
 }
 
-#endif /* WOLFSSL_TI_CRYPT */
-
-#endif /* NO_AES */
-
-
-
+#endif /* !NO_AES && WOLFSSL_TI_CRYPT */

--- a/wolfcrypt/src/port/ti/ti-hash.c
+++ b/wolfcrypt/src/port/ti/ti-hash.c
@@ -62,8 +62,10 @@
 #define SHAMD5_ALGO_SHA224 4
 #endif
 
-static int hashInit(wolfssl_TI_Hash *hash) {
-    if (!wolfSSL_TI_CCMInit())return 1;
+static int hashInit(wolfssl_TI_Hash *hash)
+{
+    if (!wolfSSL_TI_CCMInit())
+        return 1;
     hash->used = 0;
     hash->msg  = 0;
     hash->len  = 0;
@@ -115,8 +117,13 @@ static int hashGetHash(wolfssl_TI_Hash *hash, byte* result, word32 algo, word32 
     return 0;
 }
 
-static int hashCopy(wolfssl_TI_Hash *src, wolfssl_TI_Hash *dst) {
-    XMEMCPY(dst, src, sizeof(wolfssl_TI_Hash));
+static int hashCopy(wolfssl_TI_Hash *src, wolfssl_TI_Hash *dst)
+{
+    /* only copy hash, zero the rest of the struct to avoid double-free */
+    dst->msg = NULL;
+    dst->used = 0;
+    dst->len = 0;
+    XMEMCPY(dst->hash, src->hash, sizeof(dst->hash));
     return 0;
 }
 
@@ -194,11 +201,12 @@ WOLFSSL_API int wc_Md5GetHash(Md5* md5, byte* hash)
     return hashGetHash((wolfssl_TI_Hash *)md5, hash, SHAMD5_ALGO_MD5, MD5_DIGEST_SIZE);
 }
 
-WOLFSSL_API int wc_Md5Copy(Md5* src, Md5* dst) {
+WOLFSSL_API int wc_Md5Copy(Md5* src, Md5* dst)
+{
 	return hashCopy((wolfssl_TI_Hash *)src, (wolfssl_TI_Hash *)dst);
 }
 
-WOLFSSL_API int wc_Md5Hash(const byte*data, word32 len, byte*hash)
+WOLFSSL_API int wc_Md5Hash(const byte*data, word32 len, byte* hash)
 {
     return hashHash(data, len, hash, SHAMD5_ALGO_MD5, MD5_DIGEST_SIZE);
 }
@@ -239,11 +247,12 @@ WOLFSSL_API int wc_ShaGetHash(Sha* sha, byte* hash)
     return hashGetHash(sha, hash, SHAMD5_ALGO_SHA1, SHA_DIGEST_SIZE);
 }
 
-WOLFSSL_API int wc_ShaCopy(Sha* src, Sha* dst) {
+WOLFSSL_API int wc_ShaCopy(Sha* src, Sha* dst)
+{
 	return hashCopy((wolfssl_TI_Hash *)src, (wolfssl_TI_Hash *)dst);
 }
 
-WOLFSSL_API int wc_ShaHash(const byte*data, word32 len, byte*hash)
+WOLFSSL_API int wc_ShaHash(const byte*data, word32 len, byte* hash)
 {
     return hashHash(data, len, hash, SHAMD5_ALGO_SHA1, SHA_DIGEST_SIZE);
 }
@@ -284,7 +293,12 @@ WOLFSSL_API int wc_Sha224GetHash(Sha224* sha224, byte* hash)
     return hashGetHash(sha224, hash, SHAMD5_ALGO_SHA224, SHA224_DIGEST_SIZE);
 }
 
-WOLFSSL_API int wc_Sha224Hash(const byte* data, word32 len, byte*hash)
+WOLFSSL_API int wc_Sha224Copy(Sha224* src, Sha224* dst)
+{
+    return hashCopy((wolfssl_TI_Hash *)src, (wolfssl_TI_Hash *)dst);
+}
+
+WOLFSSL_API int wc_Sha224Hash(const byte* data, word32 len, byte* hash)
 {
     return hashHash(data, len, hash, SHAMD5_ALGO_SHA224, SHA224_DIGEST_SIZE);
 }
@@ -326,7 +340,12 @@ WOLFSSL_API int wc_Sha256GetHash(Sha256* sha256, byte* hash)
     return hashGetHash(sha256, hash, SHAMD5_ALGO_SHA256, SHA256_DIGEST_SIZE);
 }
 
-WOLFSSL_API int wc_Sha256Hash(const byte* data, word32 len, byte*hash)
+WOLFSSL_API int wc_Sha256Copy(Sha256* src, Sha256* dst)
+{
+    return hashCopy((wolfssl_TI_Hash *)src, (wolfssl_TI_Hash *)dst);
+}
+
+WOLFSSL_API int wc_Sha256Hash(const byte* data, word32 len, byte* hash)
 {
     return hashHash(data, len, hash, SHAMD5_ALGO_SHA256, SHA256_DIGEST_SIZE);
 }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -15427,7 +15427,7 @@ static int simple_mem_test(int sz)
 static wc_test_ret_t const_byte_ptr_test(const byte* in, word32 *outJ)
 {
     wc_test_ret_t ret = 0;
-    volatile word32 j = -1UL; /* must be volatile to properly detect error */
+    volatile word32 j = (word32)-1; /* must be volatile to properly detect error */
 
     ret = (wc_test_ret_t)*in; /* accessed *in value. */
     (void)ret;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -15427,7 +15427,7 @@ static int simple_mem_test(int sz)
 static wc_test_ret_t const_byte_ptr_test(const byte* in, word32 *outJ)
 {
     wc_test_ret_t ret = 0;
-    volatile word32 j = -1; /* must be volatile to properly detect error */
+    volatile word32 j = -1UL; /* must be volatile to properly detect error */
 
     ret = (wc_test_ret_t)*in; /* accessed *in value. */
     (void)ret;

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -110,7 +110,9 @@
 #elif defined(WOLFSSL_TIRTOS)
     #include <string.h>
     #include <netdb.h>
-    #include <sys/types.h>
+    #if !defined(__ti__) /* conflicts with sys/socket.h */
+        #include <sys/types.h>
+    #endif
     #include <arpa/inet.h>
     #include <sys/socket.h>
     #include <ti/sysbios/knl/Task.h>
@@ -1284,7 +1286,7 @@ static WC_INLINE void build_addr(SOCKADDR_IN_T* addr, const char* peer,
             int err;
             struct hostent* entry = gethostbyname(peer, &err);
         #elif defined(WOLFSSL_TIRTOS)
-            struct hostent* entry = DNSGetHostByName(peer);
+            struct hostent* entry = (struct hostent*)DNSGetHostByName(peer);
         #elif defined(WOLFSSL_VXWORKS)
             struct hostent* entry = (struct hostent*)hostGetByName((char*)peer);
         #else

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1026,7 +1026,7 @@ extern void uITRON4_free(void *p) ;
     #if defined(__ti__) && !defined(USER_TIME)
         /* TI internal time() offsets by 2208988800 (1990 -> 1970),
          * which overflows signed 32-bit */
-        #define NO_TIME_SIGNED_CHECK
+        #define NO_TIME_SIGNEDNESS_CHECK
     #endif
 #endif
 

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -968,12 +968,6 @@ extern void uITRON4_free(void *p) ;
     #define NO_MAIN_DRIVER
 #endif
 
-#ifdef WOLFSSL_TI_CRYPT
-    #define NO_GCM_ENCRYPT_EXTRA
-    #define NO_PUBLIC_GCM_SET_IV
-    #define NO_PUBLIC_CCM_SET_NONCE
-#endif
-
 #ifdef WOLFSSL_TIRTOS
     #define SIZEOF_LONG_LONG 8
     #define NO_WRITEV
@@ -983,13 +977,20 @@ extern void uITRON4_free(void *p) ;
      * specified in user_settings.
      */
     #ifndef USE_FAST_MATH
-        #define WOLFSSL_HAVE_SP_ECC
         #define SP_WORD_SIZE 32
-        #define WOLFSSL_HAVE_SP_RSA
+        #define WOLFSSL_HAVE_SP_ECC
+        #ifndef NO_RSA
+            #define WOLFSSL_HAVE_SP_RSA
+        #endif
         #ifndef NO_DH
             #define WOLFSSL_HAVE_SP_DH
         #endif
-        #define WOLFSSL_SP_4096
+        #if !defined(NO_RSA) || !defined(NO_DH)
+            /* DH/RSA 2048, 3072 and 4096 */
+            #if defined(SP_INT_MAX_BITS) && SP_INT_MAX_BITS >= 4096
+                #define WOLFSSL_SP_4096
+            #endif
+        #endif
     #endif
     #define TFM_TIMING_RESISTANT
     #define ECC_TIMING_RESISTANT

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -986,6 +986,9 @@ extern void uITRON4_free(void *p) ;
         #define WOLFSSL_HAVE_SP_ECC
         #define SP_WORD_SIZE 32
         #define WOLFSSL_HAVE_SP_RSA
+        #ifndef NO_DH
+            #define WOLFSSL_HAVE_SP_DH
+        #endif
         #define WOLFSSL_SP_4096
     #endif
     #define TFM_TIMING_RESISTANT
@@ -993,25 +996,37 @@ extern void uITRON4_free(void *p) ;
     #define WC_RSA_BLINDING
     #define NO_DEV_RANDOM
     #define NO_FILESYSTEM
-    #define NO_SIG_WRAPPER
     #define NO_MAIN_DRIVER
-    #define USE_CERT_BUFFERS_2048
-    #define NO_ERROR_STRINGS
-    /* Uncomment this setting if your toolchain does not offer time.h header */
-    /* #define USER_TIME */
+    #ifndef NO_CRYPT_TEST
+        #define USE_CERT_BUFFERS_2048
+    #endif
+    #ifndef DEBUG_WOLFSSL
+        #define NO_ERROR_STRINGS
+    #endif
+
     #define HAVE_ECC
     #define HAVE_ALPN
     #define USE_WOLF_STRTOK /* use with HAVE_ALPN */
     #define HAVE_TLS_EXTENSIONS
-    #define HAVE_AESGCM
     #define HAVE_SUPPORTED_CURVES
+
+    #define HAVE_AESGCM
+
     #ifdef __IAR_SYSTEMS_ICC__
         #pragma diag_suppress=Pa089
     #elif !defined(__GNUC__)
         /* Suppress the sslpro warning */
         #pragma diag_suppress=11
     #endif
+
+    /* Uncomment this setting if your toolchain does not offer time.h header */
+    /* #define USER_TIME */
     #include <ti/sysbios/hal/Seconds.h>
+    #if defined(__ti__) && !defined(USER_TIME)
+        /* TI internal time() offsets by 2208988800 (1990 -> 1970),
+         * which overflows signed 32-bit */
+        #define NO_TIME_SIGNED_CHECK
+    #endif
 #endif
 
 #ifdef EBSNET

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -130,6 +130,7 @@
     #include "cmsis_os.h"
 #elif defined(WOLFSSL_TIRTOS)
     #include <ti/sysbios/BIOS.h>
+    #include <ti/sysbios/knl/Task.h>
     #include <ti/sysbios/knl/Semaphore.h>
 #elif defined(WOLFSSL_FROSTED)
     #include <semaphore.h>


### PR DESCRIPTION
# Description

Fixes for TI AES and SHA on TM4C with HW acceleration.
Adds full AES GCM and CCM support with TLS.

Fixes ZD 17079

# Testing

CCS and TM4C

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
