### PR TITLE
AES GCM ARM64: Fix clobber lists

### DIFF
--- a/wolfcrypt/src/port/arm/armv8-aes.c
+++ b/wolfcrypt/src/port/arm/armv8-aes.c
@@ -3508,7 +3508,7 @@ static int Aes128GcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
           [aSz] "+r" (authInSz), [sz] "+r" (sz), [aad] "+r" (authIn)
         : [ctr] "r" (ctr), [scratch] "r" (scratch),
           [h] "m" (aes->gcm.H), [tag] "r" (authTag), [tagSz] "r" (authTagSz)
-        : "cc", "w11", "w12", "w13", "w14", "w15", "w16",
+        : "cc", "memory", "x11", "x12", "w13", "x14", "x15", "w16",
           "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
           "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15",
           "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",
@@ -5271,7 +5271,7 @@ static int Aes192GcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
           [aSz] "+r" (authInSz), [sz] "+r" (sz), [aad] "+r" (authIn)
         : [ctr] "r" (ctr), [scratch] "r" (scratch),
           [h] "m" (aes->gcm.H), [tag] "r" (authTag), [tagSz] "r" (authTagSz)
-        : "cc", "w11", "w12", "w13", "w14", "w15", "w16",
+        : "cc", "memory", "x11", "x12", "w13", "x14", "x15", "w16",
           "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
           "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15",
           "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",
@@ -7165,7 +7165,7 @@ static int Aes256GcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
           [aSz] "+r" (authInSz), [sz] "+r" (sz), [aad] "+r" (authIn)
         : [ctr] "r" (ctr), [scratch] "r" (scratch),
           [h] "m" (aes->gcm.H), [tag] "r" (authTag), [tagSz] "r" (authTagSz)
-        : "cc", "w11", "w12", "w13", "w14", "w15", "w16",
+        : "cc", "memory", "x11", "x12", "w13", "x14", "x15", "w16",
           "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
           "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15",
           "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",
@@ -8878,7 +8878,7 @@ static int Aes128GcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
           [ret] "+r" (ret)
         : [ctr] "r" (ctr), [scratch] "r" (scratch),
           [h] "m" (aes->gcm.H), [tag] "r" (authTag), [tagSz] "r" (authTagSz)
-        : "cc", "memory", "w11", "w12", "w13", "w14", "w15", "w16",
+        : "cc", "memory", "x11", "x12", "w13", "x14", "x15", "w16",
           "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
           "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15",
           "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",
@@ -10646,7 +10646,7 @@ static int Aes192GcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
           [ret] "+r" (ret)
         : [ctr] "r" (ctr), [scratch] "r" (scratch),
           [h] "m" (aes->gcm.H), [tag] "r" (authTag), [tagSz] "r" (authTagSz)
-        : "cc", "memory", "w11", "w12", "w13", "w14", "w15", "w16",
+        : "cc", "memory", "x11", "x12", "w13", "x14", "x15", "w16",
           "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
           "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15",
           "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",
@@ -12535,7 +12535,7 @@ static int Aes256GcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
           [ret] "+r" (ret)
         : [ctr] "r" (ctr), [scratch] "r" (scratch),
           [h] "m" (aes->gcm.H), [tag] "r" (authTag), [tagSz] "r" (authTagSz)
-        : "cc", "memory", "w11", "w12", "w13", "w14", "w15", "w16",
+        : "cc", "memory", "x11", "x12", "w13", "x14", "x15", "w16",
           "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
           "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15",
           "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",


### PR DESCRIPTION
# Description

Fixes the clobber lists for the new AES GCM ARM64 code

# Testing

Tested manually on an arm64 device where benchmarks were failing with -180 on AES decrypt

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
