### PR TITLE
OCSP Error Return

### DIFF
--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -409,10 +409,14 @@ int CheckOcspResponse(WOLFSSL_OCSP *ocsp, byte *response, int responseSz,
 end:
     if (ret == 0 && validated == 1) {
         WOLFSSL_MSG("New OcspResponse validated");
-    } else if ((ret == ocsp->error) && (ocspResponse->single->status->status == CERT_UNKNOWN)) {
+    }
+    else if (ret == OCSP_CERT_REVOKED) {
+        WOLFSSL_MSG("OCSP revoked");
+    }
+    else if (ret == OCSP_CERT_UNKNOWN) {
         WOLFSSL_MSG("OCSP unknown");
-        ret = OCSP_CERT_UNKNOWN;
-    } else if (ret != OCSP_CERT_REVOKED) {
+    }
+    else {
         WOLFSSL_MSG("OCSP lookup failure");
         ret = OCSP_LOOKUP_FAIL;
     }


### PR DESCRIPTION
# Description
Modify the check of the OCSP response and return better error codes.

1. In CheckOcspResponse(), remove the existing check for UNKNOWN certificate status. Given the values of ret and ocsp->error, unknown won't get checked.
2. Separated checks for UKNOWN and REJECTED for logging purposes. Return that as an error.
3. Anything else should be a failure.

Fixes ZD 17027.

# Testing

I set up an OCSP responder with a set of certificates and demo CA I have set up. I created a new certificate to use with the example server.

```
openssl ocsp -port 12345 -ndays 1000 -index demoCA/index.txt -rsigner demoCA/cacert.pem -rkey demoCA/private/cakey.pem -CA demoCA/cacert.pem
./examples/server/server -d -A ./ca/demoCA/cacert.pem -c ./ca/slack.pem -k ./ca/key-ecc.pem
./examples/client/client -A ./ca/demoCA/cacert.pem -o
```

I first ran the OCSP responder. I generated a new server certificate, slack.pem, and connected to the server with the client. The responder didn't know about the certificate yet and returned unknown. I restarted the responder and connected again getting a good status. I revoked the certificate and restarted the responder, client returned the revoked error.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
