### PR TITLE
Heapmath mp_add_d: fix for when a and c same pointer

### DIFF
--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -4425,9 +4425,6 @@ int mp_add_d (mp_int* a, mp_digit b, mp_int* c) /* //NOLINT(misc-no-recursion) *
   /* old number of used digits in c */
   oldused = c->used;
 
-  /* sign always positive */
-  c->sign = MP_ZPOS;
-
   /* source alias */
   tmpa    = a->dp;
 
@@ -4477,6 +4474,9 @@ int mp_add_d (mp_int* a, mp_digit b, mp_int* c) /* //NOLINT(misc-no-recursion) *
       */
      ix       = 1;
   }
+
+  /* sign always positive */
+  c->sign = MP_ZPOS;
 
   /* now zero to oldused */
   while (ix++ < oldused) {


### PR DESCRIPTION
# Description

When parameters a and c to mp_add_d are the same pointer, c->sign was being set to zero/positive and then a->sign was being checked. Set the c->sign at end as it will always be zero/positive through the code and the sign of the result isn't otherwise used.

Fixes zd#17142

# Testing

PoC

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
