### PR TITLE
Fixes for building wolfSSL in Visual Studio

### DIFF
--- a/IDE/WIN10/wolfssl-fips.vcxproj
+++ b/IDE/WIN10/wolfssl-fips.vcxproj
@@ -272,6 +272,7 @@
     <ClCompile Include="..\..\wolfcrypt\src\hash.c" />
     <ClCompile Include="..\..\wolfcrypt\src\hmac.c" />
     <ClCompile Include="..\..\wolfcrypt\src\integer.c" />
+    <ClCompile Include="..\..\wolfcrypt\src\pkcs7.c" />
     <ClCompile Include="..\..\wolfcrypt\src\tfm.c" />
     <ClCompile Include="..\..\src\internal.c" />
     <ClCompile Include="..\..\src\wolfio.c" />

--- a/src/internal.c
+++ b/src/internal.c
@@ -27050,7 +27050,7 @@ int DecodePrivateKey(WOLFSSL *ssl, word16* length)
             || wolfSSL_CTX_IsPrivatePkSet(ssl->ctx)
         #endif
         ) {
-            *length = GetPrivateKeySigSize(ssl);
+            *length = (word16)GetPrivateKeySigSize(ssl);
             return 0;
         }
         else
@@ -31582,7 +31582,7 @@ int SendCertificateVerify(WOLFSSL* ssl)
             if (ssl->buffers.key == NULL) {
             #ifdef HAVE_PK_CALLBACKS
                 if (wolfSSL_CTX_IsPrivatePkSet(ssl->ctx))
-                    args->length = GetPrivateKeySigSize(ssl);
+                    args->length = (word16)GetPrivateKeySigSize(ssl);
                 else
             #endif
                     ERROR_OUT(NO_PRIVATE_KEY, exit_scv);
@@ -33555,7 +33555,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                             if (ssl->buffers.key == NULL) {
                             #ifdef HAVE_PK_CALLBACKS
                                 if (wolfSSL_CTX_IsPrivatePkSet(ssl->ctx))
-                                    keySz = (word32)GetPrivateKeySigSize(ssl);
+                                    keySz = (word16)GetPrivateKeySigSize(ssl);
                                 else
                             #endif
                                     ERROR_OUT(NO_PRIVATE_KEY, exit_sske);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -7779,11 +7779,11 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
 
     #ifdef WOLF_PRIVATE_KEY_ID
         if (ssl != NULL) {
-            ssl->buffers.keyType = keyType;
+            ssl->buffers.keyType = (byte)keyType;
             ssl->buffers.keySz = keySz;
         }
         else if (ctx != NULL) {
-            ctx->privateKeyType = keyType;
+            ctx->privateKeyType = (byte)keyType;
             ctx->privateKeySz = keySz;
         }
     #endif

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -8633,7 +8633,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
             if (ssl->buffers.key == NULL) {
             #ifdef HAVE_PK_CALLBACKS
                 if (wolfSSL_CTX_IsPrivatePkSet(ssl->ctx))
-                    args->length = GetPrivateKeySigSize(ssl);
+                    args->length = (word16)GetPrivateKeySigSize(ssl);
                 else
             #endif
                     ERROR_OUT(NO_PRIVATE_KEY, exit_scv);

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -4627,7 +4627,7 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
                 WOLFSSL_MSG("PKCS#7 signedData needs to be version 1 or 3");
                 ret = ASN_VERSION_E;
             }
-            pkcs7->version = version;
+            pkcs7->version = (byte)version;
 
             /* Get the set of DigestAlgorithmIdentifiers */
             if (ret == 0 && GetSet(pkiMsg, &idx, &length, pkiMsgSz) < 0)
@@ -4913,7 +4913,7 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
             if (multiPart) {
                 pkcs7->stream->expected = contentLen + ASN_TAG_SZ;
             }
-            pkcs7->stream->multi = multiPart;
+            pkcs7->stream->multi = (byte)multiPart;
 
         #endif
             wc_PKCS7_ChangeState(pkcs7, WC_PKCS7_VERIFY_STAGE3);
@@ -5221,7 +5221,7 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
                         pkcs7->stream = stream;
                     #endif
                     }
-                    pkcs7->version = version;
+                    pkcs7->version = (byte)version;
         #ifdef ASN_BER_TO_DER
                     pkcs7->der = der;
         #endif
@@ -7692,7 +7692,7 @@ static int wc_PKCS7_PwriKek_KeyWrap(PKCS7* pkcs7, const byte* kek, word32 kekSz,
     if (*outSz < (word32)outLen)
         return BUFFER_E;
 
-    out[0] = cekSz;
+    out[0] = (byte)cekSz;
     out[1] = ~cek[0];
     out[2] = ~cek[1];
     out[3] = ~cek[2];
@@ -10845,7 +10845,7 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* in,
     byte* encryptedContent = NULL;
     int explicitOctet = 0;
     word32 localIdx;
-    byte   tag;
+    byte   tag = 0;
 
     if (pkcs7 == NULL)
         return BAD_FUNC_ARG;

--- a/wolfssl.vcxproj
+++ b/wolfssl.vcxproj
@@ -299,6 +299,7 @@
     <ClCompile Include="wolfcrypt\src\curve25519.c" />
     <ClCompile Include="wolfcrypt\src\curve448.c" />
     <ClCompile Include="wolfcrypt\src\cpuid.c" />
+    <ClCompile Include="wolfcrypt\src\cryptocb.c" />
     <ClCompile Include="wolfcrypt\src\des3.c" />
     <ClCompile Include="wolfcrypt\src\dh.c" />
     <ClCompile Include="wolfcrypt\src\dsa.c" />


### PR DESCRIPTION
# Description

Fixes for building wolfSSL in Visual Studio. Adds missing files. Fix for type cast warnings.

Note: There are still several ASN and PKCS7 warnings about potentially uninitialized local variables. 

```
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\pkcs7.c(11953): warning C4701: potentially uninitialized local variable 'tag' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\pkcs7.c(12784): warning C4701: potentially uninitialized local variable 'tag' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\pkcs7.c(12852): warning C4701: potentially uninitialized local variable 'version' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\pkcs7.c(4598): warning C4701: potentially uninitialized local variable 'outerContentType' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\pkcs7.c(10756): warning C4701: potentially uninitialized local variable 'length' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\pkcs7.c(10646): warning C4701: potentially uninitialized local variable 'contentType' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\pkcs7.c(10659): warning C4701: potentially uninitialized local variable 'tag' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\pkcs7.c(4374): warning C4701: potentially uninitialized local variable 'length' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\pkcs7.c(4314): warning C4701: potentially uninitialized local variable 'version' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\asn.c(3450): warning C4701: potentially uninitialized local variable 'bits' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\asn.c(6845): warning C4701: potentially uninitialized local variable 'version' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\asn.c(7146): warning C4701: potentially uninitialized local variable 'sz' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\asn.c(8781): warning C4701: potentially uninitialized local variable 'version' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\asn.c(8821): warning C4701: potentially uninitialized local variable 'iterations' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\asn.c(15784): warning C4701: potentially uninitialized local variable 'sz' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\asn.c(29093): warning C4701: potentially uninitialized local variable 'sz' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\asn.c(32739): warning C4701: potentially uninitialized local variable 'version' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\asn.c(33427): warning C4701: potentially uninitialized local variable 'privSz' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\asn.c(33447): warning C4701: potentially uninitialized local variable 'pubSz' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\asn.c(14139): warning C4701: potentially uninitialized local variable 'len' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\asn.c(21760): warning C4701: potentially uninitialized local variable 'version' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\asn.c(21192): warning C4701: potentially uninitialized local variable 'version' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\asn.c(21203): warning C4701: potentially uninitialized local variable 'serialSz' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\asn.c(28068): warning C4701: potentially uninitialized local variable 'sz' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\asn.c(26662): warning C4701: potentially uninitialized local variable 'piSz' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\asn.c(19586): warning C4701: potentially uninitialized local variable 'entry' used
1>C:\Users\David Garske\Documents\wolfssl\wolfcrypt\src\asn.c(19586): warning C4703: potentially uninitialized local pointer variable 'entry' used
```

# Testing

See: https://github.com/wolfSSL/wolfTPM/pull/316

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
