### PR TITLE
ocsp: don't error out if we can't verify our certificate

### DIFF
--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -243,16 +243,18 @@ else
     OPENSSL_RESULT=$?
     echo "$OPENSSL_OUTPUT"
     fgrep -q 'self signed certificate in certificate chain' <<< "$OPENSSL_OUTPUT"
-    FGREP_RESULT=$?
-    if [ $OPENSSL_RESULT -eq 0 -a $FGREP_RESULT -ne 0 ]; then
+    FGREP1_RESULT=$?
+    fgrep -q 'self-signed certificate in certificate chain' <<< "$OPENSSL_OUTPUT"
+    FGREP2_RESULT=$?
+    if [ $OPENSSL_RESULT -eq 0 -a $FGREP1_RESULT -ne 0 -a $FGREP2_RESULT -ne 0 ]; then
         printf '%s\n' "Expected verification error from s_client is missing."
         remove_single_rF "$ready_file"
         exit 1
     fi
     remove_single_rF "$ready_file"
     wait $wolf_pid
-    if [ $? -ne 1 ]; then
-        printf '%s\n' "wolfSSL server unexpected fail value"
+    if [ $? -ne 0 ]; then
+        printf '%s\n' "wolfSSL server unexpected fail"
         exit 1
     fi
 fi

--- a/src/tls.c
+++ b/src/tls.c
@@ -3307,9 +3307,13 @@ static int TLSX_CSR_Parse(WOLFSSL* ssl, const byte* input, word16 length,
             InitDecodedCert(cert, ssl->buffers.certificate->buffer,
                             ssl->buffers.certificate->length, ssl->heap);
             ret = ParseCert(cert, CERT_TYPE, 1, SSL_CM(ssl));
-            if (ret != 0 ) {
+            if (ret != 0) {
                 FreeDecodedCert(cert);
                 XFREE(cert, ssl->heap, DYNAMIC_TYPE_DCERT);
+                /* Let's not error out the connection if we can't verify our
+                 * cert */
+                if (ret == ASN_SELF_SIGNED_E || ret == ASN_NO_SIGNER_E)
+                    ret = 0;
                 return ret;
             }
             ret = TLSX_CSR_InitRequest(ssl->extensions, cert, ssl->heap);


### PR DESCRIPTION
We can omit either the CeritificateStatus message or the appropriate extension when we can not provide the OCSP staple that the peer is asking for. Let peer decide if it requires stapling and error out if we don't send it.

Fixes ZD17137