### PR TITLE
Various cleanups - CRL and comments - 20231207

### DIFF
--- a/IDE/GCC-ARM/linker_fips.ld
+++ b/IDE/GCC-ARM/linker_fips.ld
@@ -54,23 +54,23 @@ SECTIONS
         . = ALIGN(4);
     } > FLASH
 
-    /* Custom section for wolfCrypt and LibC to prevent FIPS hash from changing 
+    /* Custom section for wolfCrypt and LibC to prevent FIPS hash from changing
         when application code changes are made */
     .wolfCryptNonFIPS_text :
     {
         . = ALIGN(4);
-        KEEP(*wolf*src*.o(.text .text*))
         lib_a* ( .text .text*)
+        *wolf*src*.o(.text .text*)
         . = ALIGN(4);
     } > FLASH
     .wolfCryptNonFIPS_rodata :
     {
         . = ALIGN(4);
-        KEEP(*wolf*src*.o(.rodata .rodata*))
         lib_a* (.rodata .rodata*)
+        *wolf*src*.o(.rodata .rodata*)
         . = ALIGN(4);
     } > FLASH
-    
+
 	.sys    : { *(.sys*) }    > FLASH
     .text   : { *(.text*) }   > FLASH
     .rodata : { *(.text*) }   > FLASH

--- a/src/crl.c
+++ b/src/crl.c
@@ -393,7 +393,7 @@ static int CheckCertCRLList(WOLFSSL_CRL* crl, byte* issuerHash, byte* serial,
             if (crle->nextDateFormat != ASN_OTHER_TYPE)
         #endif
             {
-            #ifndef NO_ASN_TIME
+            #if !defined(NO_ASN_TIME) && !defined(WOLFSSL_NO_CRL_DATE_CHECK)
                 if (!XVALIDATE_DATE(crle->nextDate,crle->nextDateFormat, AFTER)) {
                     WOLFSSL_MSG("CRL next date is no longer valid");
                     ret = ASN_AFTER_DATE_E;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -14707,6 +14707,9 @@ static WC_INLINE int DateLessThan(const struct tm* a, const struct tm* b)
 
 /* like atoi but only use first byte */
 /* Make sure before and after dates are valid */
+/* date = ASN.1 raw */
+/* format = ASN_UTC_TIME or ASN_GENERALIZED_TIME */
+/* dateType = AFTER or BEFORE */
 int wc_ValidateDate(const byte* date, byte format, int dateType)
 {
     time_t ltime;

--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -33,7 +33,7 @@
  * WOLF_CRYPTO_CB_CMD
  *
  * enable debug InfoString functions
- * DEBUG_CRYPTO_CB
+ * DEBUG_CRYPTOCB
  */
 
 #ifdef HAVE_CONFIG_H


### PR DESCRIPTION
# Description

* Expand `WOLFSSL_NO_CRL_DATE_CHECK` to the process cert CRL next date check. Originally added in https://github.com/wolfSSL/wolfssl/pull/6927 . For ZD 16675
* Fix comment typo for `DEBUG_CRYPTOCB`. 
* Add comments for `wc_ValidateDate` arguments.
* Improve linker script example for FIPS to put stdlib before FIPS and not force KEEP.

# Testing



# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
