### PR TITLE
Fix to resolve collision between FIPS `RNG` in settings.h and STM32 HAL header

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -297,7 +297,7 @@
     #if FIPS_VERSION_LT(2,0)
         #define WC_RNG RNG
     #else
-        #ifndef WOLFSSL_STM32L4
+        #ifndef NO_OLD_RNGNAME
             #define RNG WC_RNG
         #endif
     #endif


### PR DESCRIPTION
# Description

In FIPS builds only, fix to resolve collision between `#define RNG WC_RNG` in settings.h and the STM32 Cube HAL (ex: stm32h7xx.h).  

In STM32 platforms we use NO_OLD_RNGNAME (see https://github.com/wolfSSL/wolfssl/blob/master/examples/configs/user_settings_stm32.h#L616)

Fixes ZD 16675

# Testing

FIPS ready in STM32CubeIDE

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
