### PR TITLE
20231208-asn-big-short-ints

### DIFF
--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -146,14 +146,16 @@ static const struct s_ent {
     #endif
     #endif /* WOLFSSL_AES_OFB */
 
-    #ifdef WOLFSSL_AES_XTS
+    #if defined(WOLFSSL_AES_XTS) && \
+        (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3))
     #ifdef WOLFSSL_AES_128
         static const char EVP_AES_128_XTS[] = "AES-128-XTS";
     #endif
     #ifdef WOLFSSL_AES_256
         static const char EVP_AES_256_XTS[] = "AES-256-XTS";
     #endif
-    #endif /* WOLFSSL_AES_XTS */
+    #endif /* WOLFSSL_AES_XTS &&
+              (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3)) */
 
     #ifdef WOLFSSL_AES_CFB
     #ifdef WOLFSSL_AES_128
@@ -330,7 +332,7 @@ int wolfSSL_EVP_Cipher_key_length(const WOLFSSL_EVP_CIPHER* c)
       case AES_192_OFB_TYPE: return 24;
       case AES_256_OFB_TYPE: return 32;
   #endif
-  #if defined(WOLFSSL_AES_XTS)
+  #if defined(WOLFSSL_AES_XTS) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3))
       /* Two keys for XTS. */
       case AES_128_XTS_TYPE: return 16 * 2;
       case AES_256_XTS_TYPE: return 32 * 2;
@@ -632,7 +634,7 @@ static int evpCipherBlock(WOLFSSL_EVP_CIPHER_CTX *ctx,
                 ret = wc_AesCfbDecrypt(&ctx->cipher.aes, out, in, inl);
             break;
     #endif
-#if defined(WOLFSSL_AES_XTS)
+#if defined(WOLFSSL_AES_XTS) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3))
     case AES_128_XTS_TYPE:
     case AES_256_XTS_TYPE:
         if (ctx->enc)
@@ -1703,7 +1705,7 @@ int wolfSSL_EVP_CIPHER_CTX_block_size(const WOLFSSL_EVP_CIPHER_CTX *ctx)
     case AES_192_OFB_TYPE:
     case AES_256_OFB_TYPE:
 #endif
-#if defined(WOLFSSL_AES_XTS)
+#if defined(WOLFSSL_AES_XTS) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3))
     case AES_128_XTS_TYPE:
     case AES_256_XTS_TYPE:
 #endif
@@ -1831,7 +1833,7 @@ static unsigned int cipherType(const WOLFSSL_EVP_CIPHER *cipher)
         return AES_256_ECB_TYPE;
     #endif
 #endif /*HAVE_AES_CBC */
-#if defined(WOLFSSL_AES_XTS)
+#if defined(WOLFSSL_AES_XTS) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3))
     #ifdef WOLFSSL_AES_128
     else if (EVP_CIPHER_TYPE_MATCHES(cipher, EVP_AES_128_XTS))
         return AES_128_XTS_TYPE;
@@ -1997,7 +1999,8 @@ int wolfSSL_EVP_CIPHER_block_size(const WOLFSSL_EVP_CIPHER *cipher)
         case AES_256_OFB_TYPE:
             return 1;
     #endif
-    #if defined(WOLFSSL_AES_XTS)
+    #if defined(WOLFSSL_AES_XTS) && \
+        (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3))
         case AES_128_XTS_TYPE:
         case AES_256_XTS_TYPE:
             return 1;
@@ -2106,7 +2109,8 @@ unsigned long WOLFSSL_CIPHER_mode(const WOLFSSL_EVP_CIPHER *cipher)
         case AES_256_OFB_TYPE:
             return WOLFSSL_EVP_CIPH_OFB_MODE;
     #endif
-    #if defined(WOLFSSL_AES_XTS)
+    #if defined(WOLFSSL_AES_XTS) && \
+        (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3))
         case AES_128_XTS_TYPE:
         case AES_256_XTS_TYPE:
             return WOLFSSL_EVP_CIPH_XTS_MODE;
@@ -4852,7 +4856,8 @@ static const struct cipher{
     #endif
     #endif
 
-    #ifdef WOLFSSL_AES_XTS
+    #if defined(WOLFSSL_AES_XTS) && \
+        (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3))
     #ifdef WOLFSSL_AES_128
     {AES_128_XTS_TYPE, EVP_AES_128_XTS, NID_aes_128_xts},
     #endif
@@ -5565,7 +5570,8 @@ void wolfSSL_EVP_init(void)
     #endif /* WOLFSSL_AES_256 */
     #endif /* WOLFSSL_AES_OFB */
 
-    #ifdef WOLFSSL_AES_XTS
+    #if defined(WOLFSSL_AES_XTS) && \
+        (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3))
     #ifdef WOLFSSL_AES_128
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_128_xts(void)
     {
@@ -5581,7 +5587,8 @@ void wolfSSL_EVP_init(void)
         return EVP_AES_256_XTS;
     }
     #endif /* WOLFSSL_AES_256 */
-    #endif /* WOLFSSL_AES_XTS */
+    #endif /* WOLFSSL_AES_XTS &&
+              (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3)) */
 
     #ifdef HAVE_AESGCM
     #ifdef WOLFSSL_AES_128
@@ -6135,7 +6142,8 @@ void wolfSSL_EVP_init(void)
                     wc_AesFree(&ctx->cipher.aes);
                     ctx->flags &= ~WOLFSSL_EVP_CIPH_LOW_LEVEL_INITED;
                     break;
-    #ifdef WOLFSSL_AES_XTS
+    #if defined(WOLFSSL_AES_XTS) && \
+        (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3))
                 case AES_128_XTS_TYPE:
                 case AES_256_XTS_TYPE:
                     wc_AesXtsFree(&ctx->cipher.xts);
@@ -7465,7 +7473,8 @@ void wolfSSL_EVP_init(void)
         }
         #endif /* WOLFSSL_AES_256 */
     #endif /* WOLFSSL_AES_OFB */
-    #ifdef WOLFSSL_AES_XTS
+        #if defined(WOLFSSL_AES_XTS) && \
+            (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3))
         #ifdef WOLFSSL_AES_128
         if (ctx->cipherType == AES_128_XTS_TYPE ||
             (type && EVP_CIPHER_TYPE_MATCHES(type, EVP_AES_128_XTS))) {
@@ -7548,7 +7557,8 @@ void wolfSSL_EVP_init(void)
             }
         }
         #endif /* WOLFSSL_AES_256 */
-    #endif /* WOLFSSL_AES_XTS */
+    #endif /* WOLFSSL_AES_XTS &&
+              (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3)) */
 #endif /* NO_AES */
     #if defined(HAVE_ARIA)
         if (ctx->cipherType == ARIA_128_GCM_TYPE ||
@@ -8210,7 +8220,7 @@ void wolfSSL_EVP_init(void)
                     ret = (int)len;
                 break;
 #endif /* WOLFSSL_AES_OFB */
-#if defined(WOLFSSL_AES_XTS)
+#if defined(WOLFSSL_AES_XTS) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3))
             case AES_128_XTS_TYPE:
             case AES_256_XTS_TYPE:
                 WOLFSSL_MSG("AES XTS");
@@ -8223,7 +8233,7 @@ void wolfSSL_EVP_init(void)
                 if (ret == 0)
                     ret = (int)len;
                 break;
-#endif /* WOLFSSL_AES_XTS */
+#endif /* WOLFSSL_AES_XTS && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3)) */
 
 #if defined(HAVE_AESGCM) && ((!defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)) \
     || FIPS_VERSION_GE(2,0))
@@ -9309,12 +9319,12 @@ int wolfSSL_EVP_CIPHER_CTX_iv_length(const WOLFSSL_EVP_CIPHER_CTX* ctx)
             WOLFSSL_MSG("AES OFB");
             return AES_BLOCK_SIZE;
 #endif /* WOLFSSL_AES_OFB */
-#ifdef WOLFSSL_AES_XTS
+#if defined(WOLFSSL_AES_XTS) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3))
         case AES_128_XTS_TYPE:
         case AES_256_XTS_TYPE:
             WOLFSSL_MSG("AES XTS");
             return AES_BLOCK_SIZE;
-#endif /* WOLFSSL_AES_XTS */
+#endif /* WOLFSSL_AES_XTS && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3)) */
 #ifdef HAVE_ARIA
         case ARIA_128_GCM_TYPE :
         case ARIA_192_GCM_TYPE :
@@ -9438,7 +9448,7 @@ int wolfSSL_EVP_CIPHER_iv_length(const WOLFSSL_EVP_CIPHER* cipher)
         return AES_BLOCK_SIZE;
     #endif
 #endif
-#ifdef WOLFSSL_AES_XTS
+#if defined(WOLFSSL_AES_XTS) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3))
     #ifdef WOLFSSL_AES_128
     if (XSTRCMP(name, EVP_AES_128_XTS) == 0)
         return AES_BLOCK_SIZE;
@@ -9448,7 +9458,7 @@ int wolfSSL_EVP_CIPHER_iv_length(const WOLFSSL_EVP_CIPHER* cipher)
     if (XSTRCMP(name, EVP_AES_256_XTS) == 0)
         return AES_BLOCK_SIZE;
     #endif /* WOLFSSL_AES_256 */
-#endif /* WOLFSSL_AES_XTS */
+#endif /* WOLFSSL_AES_XTS && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3)) */
 
 #endif
 #ifdef HAVE_ARIA

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -9358,7 +9358,8 @@ static wc_test_ret_t aes_key_size_test(void)
     return ret;
 }
 
-#if defined(WOLFSSL_AES_XTS)
+#if defined(WOLFSSL_AES_XTS) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3))
+
 /* test vectors from http://csrc.nist.gov/groups/STM/cavp/block-cipher-modes.html */
 #ifdef WOLFSSL_AES_128
 static wc_test_ret_t aes_xts_128_test(void)
@@ -9435,8 +9436,6 @@ static wc_test_ret_t aes_xts_128_test(void)
         0x77, 0x8a, 0xe8, 0xb4, 0x3c, 0xb9, 0x8d, 0x5a
     };
 
-#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3)
-
     WOLFSSL_SMALL_STACK_STATIC unsigned char k3[] = {
         0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
         0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
@@ -9461,8 +9460,6 @@ static wc_test_ret_t aes_xts_128_test(void)
         0xA0, 0x85, 0xD2, 0x69, 0x6E, 0x87, 0x0A, 0xBF,
         0xB5, 0x5A, 0xDD, 0xCB, 0x80, 0xE0, 0xFC, 0xCD
     };
-
-#endif /* !HAVE_FIPS || FIPS_VERSION_GE(5,3) */
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     if ((aes = (XtsAes *)XMALLOC(sizeof *aes, HEAP_HINT, DYNAMIC_TYPE_AES)) == NULL)
@@ -9641,8 +9638,6 @@ static wc_test_ret_t aes_xts_128_test(void)
     if (XMEMCMP(p2, buf, sizeof(p2)))
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
-#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3)
-
     /* Test ciphertext stealing in-place. */
     XMEMCPY(buf, p3, sizeof(p3));
     ret = wc_AesXtsSetKeyNoInit(aes, k3, sizeof(k3), AES_ENCRYPTION);
@@ -9670,10 +9665,7 @@ static wc_test_ret_t aes_xts_128_test(void)
     if (XMEMCMP(p3, buf, sizeof(p3)))
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
-#endif /* !HAVE_FIPS || FIPS_VERSION_GE(5,3) */
-
 #if !defined(BENCH_EMBEDDED) && !defined(HAVE_CAVIUM) && \
-    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3)) &&     \
     !defined(WOLFSSL_AFALG)
     {
     #define LARGE_XTS_SZ        1024
@@ -9726,7 +9718,6 @@ static wc_test_ret_t aes_xts_128_test(void)
     #endif
     }
 #endif /* !BENCH_EMBEDDED && !HAVE_CAVIUM &&
-        * (!HAVE_FIPS || FIPS_VERSION_GE(5,3)) &&
         * !WOLFSSL_AFALG
         */
 
@@ -10332,7 +10323,7 @@ static wc_test_ret_t aes_xts_args_test(void)
     return ret;
 }
 #endif /* WOLFSSL_AES_128 */
-#endif /* WOLFSSL_AES_XTS */
+#endif /* WOLFSSL_AES_XTS && (!HAVE_FIPS || FIPS_VERSION_GE(5,3)) */
 
 #if defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_128)
 static wc_test_ret_t aes_cbc_test(void)
@@ -11706,7 +11697,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes_test(void)
         goto out;
 #endif
 
-#if defined(WOLFSSL_AES_XTS)
+#if defined(WOLFSSL_AES_XTS) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3))
     #ifdef WOLFSSL_AES_128
     ret = aes_xts_128_test();
     if (ret != 0)

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -901,6 +901,10 @@ enum ECC_TYPES
 /* Maximum OID dotted form size. */
 #define ASN1_OID_DOTTED_MAX_SZ         16
 
+#ifndef WOLFSSL_ASN_MAX_LENGTH_SZ
+    #define WOLFSSL_ASN_MAX_LENGTH_SZ 5 /* 1 byte length + 4 bytes of number */
+#endif
+
 enum Misc_ASN {
     MAX_SALT_SIZE       =  64,     /* MAX PKCS Salt length */
     MAX_IV_SIZE         =  64,     /* MAX PKCS Iv length */
@@ -943,18 +947,18 @@ enum Misc_ASN {
 #endif
     MAX_SIG_SZ          = 256,
     MAX_ALGO_SZ         =  20,
-    MAX_SHORT_SZ        =   6,     /* asn int + byte len + 4 byte length */
-    MAX_LENGTH_SZ       =   4,     /* Max length size for DER encoding */
-    MAX_SEQ_SZ          =   5,     /* enum(seq | con) + length(4) */
-    MAX_SET_SZ          =   5,     /* enum(set | con) + length(4) */
-    MAX_OCTET_STR_SZ    =   5,     /* enum(set | con) + length(4) */
-    MAX_EXP_SZ          =   5,     /* enum(contextspec|con|exp) + length(4) */
-    MAX_PRSTR_SZ        =   5,     /* enum(prstr) + length(4) */
+    MAX_LENGTH_SZ       = WOLFSSL_ASN_MAX_LENGTH_SZ, /* Max length size for DER encoding */
+    MAX_SHORT_SZ        = (1 + MAX_LENGTH_SZ),     /* asn int + byte len + 4 byte length */
+    MAX_SEQ_SZ          = (1 + MAX_LENGTH_SZ), /* enum(seq | con) + length(5) */
+    MAX_SET_SZ          = (1 + MAX_LENGTH_SZ), /* enum(set | con) + length(5) */
+    MAX_OCTET_STR_SZ    = (1 + MAX_LENGTH_SZ), /* enum(set | con) + length(5) */
+    MAX_EXP_SZ          = (1 + MAX_LENGTH_SZ), /* enum(contextspec|con|exp) + length(5) */
+    MAX_PRSTR_SZ        = (1 + MAX_LENGTH_SZ), /* enum(prstr) + length(5) */
     MAX_VERSION_SZ      =   5,     /* enum + id + version(byte) + (header(2))*/
-    MAX_ENCODED_DIG_ASN_SZ= 9,     /* enum(bit or octet) + length(4) */
+    MAX_ENCODED_DIG_ASN_SZ = (5 + MAX_LENGTH_SZ),   /* enum(bit or octet) + length(5) */
     MAX_ENCODED_DIG_SZ  =  64 + MAX_ENCODED_DIG_ASN_SZ, /* asn header + sha512 */
-    MAX_RSA_INT_SZ      = 517,     /* RSA raw sz 4096 for bits + tag + len(4) */
-    MAX_DSA_INT_SZ      = 389,     /* DSA raw sz 3072 for bits + tag + len(4) */
+    MAX_RSA_INT_SZ      = (512 + 1 + MAX_LENGTH_SZ), /* RSA raw sz 4096 for bits + tag + len(5) */
+    MAX_DSA_INT_SZ      = (384 + 1 + MAX_LENGTH_SZ), /* DSA raw sz 3072 for bits + tag + len(5) */
     MAX_DSA_PUBKEY_SZ   = (DSA_PUB_INTS * MAX_DSA_INT_SZ) + (2 * MAX_SEQ_SZ) +
                           2 + MAX_LENGTH_SZ, /* Maximum size of a DSA public
                                       key taken from wc_SetDsaPublicKey. */


### PR DESCRIPTION
support ASN ShortInts up to 4 bytes (2^32-1):
* parameterize `MAX_LENGTH_SZ` using overrideable `WOLFSSL_ASN_MAX_LENGTH_SZ`, default value 5 (raised from 4).
* refactor other Misc_ASN constants to refer to `MAX_LENGTH_SZ` as appropriate.
* tweak `BytePrecision()` appropriately.
* refactor `SetShortInt()` to use `BytePrecision()` and include a length assert against `MAX_SHORT_SZ` to assure no buffer overruns with reduced `WOLFSSL_ASN_MAX_LENGTH_SZ`.

`wolfcrypt/src/evp.c` and `wolfcrypt/test/test.c`: in FIPS builds <5.3, gate out AES-XTS functionality that depends on new APIs added in #7031 (b14aba48af and 931ac4e568) (AES-XTS is non-FIPS in FIPS <5.3).

tested with `wolfssl-multi-test.sh ... super-quick-check` and https://github.com/wolfssl/wolfssl-examples/pkcs7/ hacked to generate and validate a PKCS#7 object larger than 2^24 bytes.
