### PR TITLE
Fixes for RPM Spec: Move the .so to devel files

### DIFF
--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -80,8 +80,7 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_docdir}/wolfssl/example/tls_bench.c
 %{_docdir}/wolfssl/README.txt
 %{_docdir}/wolfssl/QUIC.md
-
-%{_libdir}/libwolfssl@LIBSUFFIX@.so*
+%{_libdir}/libwolfssl@LIBSUFFIX@.so.*
 
 %files devel
 %defattr(-,root,root,-)
@@ -91,6 +90,7 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_includedir}/wolfssl/wolfcrypt/*.h
 %{_includedir}/wolfssl/openssl/*.h
 %{_libdir}/pkgconfig/wolfssl.pc
+%{_libdir}/libwolfssl@LIBSUFFIX@.so
 
 %changelog
 * Mon Oct 17 2022 Juliusz Sosinowicz <juliusz@wolfssl.com>


### PR DESCRIPTION
# Description

Move the .so to devel files. The pure *.so file is considered a dev file.

# Testing

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
