### PR TITLE
20231212-QUIC-WOLFSSL_CALLBACKS-error

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3147,6 +3147,10 @@ extern void uITRON4_free(void *p) ;
 #error "ConnectionID is supported for DTLSv1.3 only"
 #endif
 
+#if defined(WOLFSSL_QUIC) && defined(WOLFSSL_CALLBACKS)
+    #error WOLFSSL_QUIC is incompatible with WOLFSSL_CALLBACKS.
+#endif
+
 /* RSA Key Checking is disabled by default unless WOLFSSL_RSA_KEY_CHECK is
  *   defined or FIPS v2 3389, FIPS v5 or later.
  * Not allowed for:


### PR DESCRIPTION
`wolfssl/quic.h`: add `#ifdef WOLFSSL_CALLBACKS` `#error` ("ERROR - tests/quic.c line 1027 failed").
