### PR TITLE
Address fips 140-3 failures with wolfEngine support enabled

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -297,7 +297,7 @@
     #if FIPS_VERSION_LT(2,0)
         #define WC_RNG RNG
     #else
-        #ifndef NO_OLD_RNGNAME
+        #ifndef RNG
             #define RNG WC_RNG
         #endif
     #endif

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -297,6 +297,10 @@
     #if FIPS_VERSION_LT(2,0)
         #define WC_RNG RNG
     #else
+        /* RNG needs to be defined to WC_RNG anytime another library on the
+         * system or other set of headers included by wolfSSL already defines
+         * RNG. Examples are:
+         * wolfEngine, wolfProvider and potentially other use-cases */
         #ifndef RNG
             #define RNG WC_RNG
         #endif


### PR DESCRIPTION
# Description

Required for wolfEngine and wolfProvider support.

Broken in https://github.com/wolfSSL/wolfssl/pull/7052

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
