### PR TITLE
Add cryptoCb hook to one-shot CMAC functions

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -39968,16 +39968,42 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t cmac_test(void)
 
         XMEMSET(tag, 0, sizeof(tag));
         tagSz = sizeof(tag);
+#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)
+        ret = wc_AesCmacGenerate_ex(cmac, tag, &tagSz, tc->m, tc->mSz,
+                               tc->k, tc->kSz, NULL, devId);
+#else
         ret = wc_AesCmacGenerate(tag, &tagSz, tc->m, tc->mSz,
                                tc->k, tc->kSz);
+#endif
         if (ret != 0)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
         if (XMEMCMP(tag, tc->t, AES_BLOCK_SIZE) != 0)
             ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)
+        ret = wc_AesCmacVerify_ex(cmac, tc->t, tc->tSz, tc->m, tc->mSz,
+                             tc->k, tc->kSz, HEAP_HINT, devId);
+#else
         ret = wc_AesCmacVerify(tc->t, tc->tSz, tc->m, tc->mSz,
                              tc->k, tc->kSz);
+#endif
         if (ret != 0)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)
+        /* Test that keyless generate with init is the same */
+        XMEMSET(tag, 0, sizeof(tag));
+        tagSz = sizeof(tag);
+        ret = wc_InitCmac_ex(cmac, tc->k, tc->kSz, tc->type, NULL, HEAP_HINT, devId);
+        if (ret != 0) {
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+        }
+        ret = wc_AesCmacGenerate_ex(cmac, tag, &tagSz, tc->m, tc->mSz,
+                NULL, 0, HEAP_HINT, devId);
+        if (ret != 0) {
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+        }
+#endif
+
     }
 
     ret = 0;
@@ -49368,6 +49394,49 @@ static int myCryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
         info->hmac.hmac->devId = devIdArg;
     }
 #endif
+#if defined(WOLFSSL_CMAC) && !defined(NO_AES)
+    else if (info->algo_type == WC_ALGO_TYPE_CMAC) {
+        if (info->cmac.cmac == NULL) {
+            return NOT_COMPILED_IN;
+        }
+
+        /* set devId to invalid so software is used */
+        info->cmac.cmac->devId = INVALID_DEVID;
+
+        /* Handle one-shot cases */
+        if (info->cmac.key != NULL && info->cmac.in != NULL
+                && info->cmac.out != NULL) {
+            ret = wc_AesCmacGenerate(info->cmac.out,
+                    info->cmac.outSz,
+                    info->cmac.in,
+                    info->cmac.inSz,
+                    info->cmac.key,
+                    info->cmac.keySz);
+        /* Sequentially handle incremental cases */
+        } else {
+            if (info->cmac.key != NULL) {
+                ret = wc_InitCmac(info->cmac.cmac,
+                        info->cmac.key,
+                        info->cmac.keySz,
+                        info->cmac.type,
+                        NULL);
+            }
+            if ((ret == 0) && (info->cmac.in != NULL)) {
+                ret = wc_CmacUpdate(info->cmac.cmac,
+                        info->cmac.in,
+                        info->cmac.inSz);
+            }
+            if ((ret ==0) && (info->cmac.out != NULL)) {
+                ret = wc_CmacFinal(info->cmac.cmac,
+                        info->cmac.out,
+                        info->cmac.outSz);
+            }
+        }
+
+        /* reset devId */
+        info->cmac.cmac->devId = devIdArg;
+    }
+#endif /* WOLFSSL_CMAC && !(NO_AES) && WOLFSSL_AES_DIRECT */
 
     (void)devIdArg;
     (void)myCtx;

--- a/wolfssl/wolfcrypt/cmac.h
+++ b/wolfssl/wolfcrypt/cmac.h
@@ -111,11 +111,25 @@ WOLFSSL_API
 int wc_AesCmacGenerate(byte* out, word32* outSz,
                        const byte* in, word32 inSz,
                        const byte* key, word32 keySz);
+WOLFSSL_API
+int wc_AesCmacGenerate_ex(Cmac *cmac,
+                          byte* out, word32* outSz,
+                          const byte* in, word32 inSz,
+                          const byte* key, word32 keySz,
+                          void* heap,
+                          int devId);
 
 WOLFSSL_API
 int wc_AesCmacVerify(const byte* check, word32 checkSz,
                      const byte* in, word32 inSz,
                      const byte* key, word32 keySz);
+WOLFSSL_API
+int wc_AesCmacVerify_ex(Cmac* cmac,
+                        const byte* check, word32 checkSz,
+                        const byte* in, word32 inSz,
+                        const byte* key, word32 keySz,
+                        void* heap,
+                        int devId);
 
 WOLFSSL_LOCAL
 void ShiftAndXorRb(byte* out, byte* in);


### PR DESCRIPTION
- Adds cryptoCb hook to one-shot CMAC functions 
- add CMAC coverage to cryptoCb tests

# Testing

Added CMAC cryptoCb to `myCryptoDevCb` to exercise new and existing code paths



