### PR TITLE
Fix for benchmark without filesystem unused globals

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1897,8 +1897,10 @@ static int csv_format = 0;
 /* globals for cipher tests */
 static THREAD_LS_T byte* bench_plain = NULL;
 static THREAD_LS_T byte* bench_cipher = NULL;
+#ifndef NO_FILESYSTEM
 static THREAD_LS_T char* hash_input = NULL;
 static THREAD_LS_T char* cipher_input = NULL;
+#endif
 
 static const XGEN_ALIGN byte bench_key_buf[] =
 {
@@ -12830,6 +12832,7 @@ int wolfcrypt_benchmark_main(int argc, char** argv)
             if (argc > 1)
                 numBlocks = XATOI(argv[1]);
         }
+#ifndef NO_FILESYSTEM
         else if (string_matches(argv[1], "-hash_input")) {
             argc--;
             argv++;
@@ -12842,6 +12845,7 @@ int wolfcrypt_benchmark_main(int argc, char** argv)
             if (argc > 1)
                 cipher_input = argv[1];
         }
+#endif
 #ifdef MULTI_VALUE_STATISTICS
         else if (string_matches(argv[1], "-min_runs")) {
             argc--;


### PR DESCRIPTION
# Description

Fix for benchmark without filesystem and unused hash_input and cipher_input.

# Testing

Building with NO_FILESYSTEM and NO_MAIN_DRIVER

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
