### PR TITLE
Fix missing closing comment on example Espressif user_settings.h

### DIFF
--- a/IDE/Espressif/ESP-IDF/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/user_settings.h
@@ -99,7 +99,7 @@
 #define CURVE25519_SMALL
 #define HAVE_ED25519
 
-/* Optional OPENSSL compatibility *
+/* Optional OPENSSL compatibility */
 #define OPENSSL_EXTRA
 /* when you want to use pkcs7 */
 /* #define HAVE_PKCS7 */


### PR DESCRIPTION
# Description

This PR fixes a missing closing comment character as described in https://github.com/wolfSSL/wolfssl/commit/fb77319758da284f990605d2613289241ee52404#commitcomment-134912677 

Fixes zd# n/a

# Testing

How did you test?

Not tested. 

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
