### PR TITLE
Fixes for release

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -32504,7 +32504,7 @@ static int EccSpecifiedECDomainDecode(const byte* input, word32 inSz,
         }
     }
 
-    if (curveSz) {
+    if ((ret == 0) && (curveSz)) {
         *curveSz = curve->size;
     }
 

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -11825,6 +11825,10 @@ WOLFSSL_API int wc_PKCS7_DecodeAuthEnvelopedData(PKCS7* pkcs7, byte* in,
     }
 #endif
 
+#ifndef WOLFSSL_SMALL_STACK
+    XMEMSET(decryptedKey, 0, MAX_ENCRYPTED_KEY_SZ);
+#endif
+
     switch (pkcs7->state) {
         case WC_PKCS7_START:
         case WC_PKCS7_INFOSET_START:
@@ -11855,6 +11859,9 @@ WOLFSSL_API int wc_PKCS7_DecodeAuthEnvelopedData(PKCS7* pkcs7, byte* in,
             if (decryptedKey == NULL) {
                 ret = MEMORY_E;
                 break;
+            }
+            else {
+                XMEMSET(decryptedKey, 0, MAX_ENCRYPTED_KEY_SZ);
             }
         #ifndef NO_PKCS7_STREAM
             pkcs7->stream->key = decryptedKey;


### PR DESCRIPTION
# Description

asn.c - `EccSpecifiedECDomainDecode` - Null dereference
pkcs7.c - `wc_PKCS7_DecodeAuthEnvelopedData` - Access uninitialized data

# Testing

Confirmed fix in Coverity

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
