### PR TITLE
Fix issues from infer diff report.

### DIFF
--- a/src/quic.c
+++ b/src/quic.c
@@ -950,8 +950,18 @@ cleanup:
 
 const WOLFSSL_EVP_CIPHER* wolfSSL_quic_get_aead(WOLFSSL* ssl)
 {
-    WOLFSSL_CIPHER* cipher = wolfSSL_get_current_cipher(ssl);
-    const WOLFSSL_EVP_CIPHER* evp_cipher;
+    WOLFSSL_CIPHER* cipher = NULL;
+    const WOLFSSL_EVP_CIPHER* evp_cipher = NULL;
+
+    if (ssl == NULL) {
+        return NULL;
+    }
+
+    cipher = wolfSSL_get_current_cipher(ssl);
+
+    if (cipher == NULL) {
+        return NULL;
+    }
 
     switch (cipher->cipherSuite) {
 #if !defined(NO_AES) && defined(HAVE_AESGCM)
@@ -997,8 +1007,18 @@ static int evp_cipher_eq(const WOLFSSL_EVP_CIPHER* c1,
 
 const WOLFSSL_EVP_CIPHER* wolfSSL_quic_get_hp(WOLFSSL* ssl)
 {
-    WOLFSSL_CIPHER* cipher = wolfSSL_get_current_cipher(ssl);
-    const WOLFSSL_EVP_CIPHER* evp_cipher;
+    WOLFSSL_CIPHER* cipher = NULL;
+    const WOLFSSL_EVP_CIPHER* evp_cipher = NULL;
+
+    if (ssl == NULL) {
+        return NULL;
+    }
+
+    cipher = wolfSSL_get_current_cipher(ssl);
+
+    if (cipher == NULL) {
+        return NULL;
+    }
 
     switch (cipher->cipherSuite) {
 #if !defined(NO_AES) && defined(HAVE_AESGCM)

--- a/tests/api.c
+++ b/tests/api.c
@@ -45099,8 +45099,8 @@ static int test_wolfSSL_cert_cb_dyn_ciphers_certCB(WOLFSSL* ssl, void* arg)
         haveECC = 0;
     }
     for (idx = 0; idx < hashSigAlgoSz; idx += 2) {
-        int hashAlgo;
-        int sigAlgo;
+        int hashAlgo = 0;
+        int sigAlgo = 0;
 
         if (wolfSSL_get_sigalg_info(hashSigAlgo[idx+0], hashSigAlgo[idx+1],
                 &hashAlgo, &sigAlgo) != 0)
@@ -45313,8 +45313,8 @@ static int test_wolfSSL_sigalg_info(void)
 
     InitSuitesHashSigAlgo_ex2(hashSigAlgo, allSigAlgs, 1, 0xFFFFFFFF, &len);
     for (idx = 0; idx < len; idx += 2) {
-        int hashAlgo;
-        int sigAlgo;
+        int hashAlgo = 0;
+        int sigAlgo = 0;
 
         ExpectIntEQ(wolfSSL_get_sigalg_info(hashSigAlgo[idx+0],
                 hashSigAlgo[idx+1], &hashAlgo, &sigAlgo), 0);
@@ -45326,8 +45326,8 @@ static int test_wolfSSL_sigalg_info(void)
     InitSuitesHashSigAlgo_ex2(hashSigAlgo, allSigAlgs | SIG_ANON, 1,
             0xFFFFFFFF, &len);
     for (idx = 0; idx < len; idx += 2) {
-        int hashAlgo;
-        int sigAlgo;
+        int hashAlgo = 0;
+        int sigAlgo = 0;
 
         ExpectIntEQ(wolfSSL_get_sigalg_info(hashSigAlgo[idx+0],
                 hashSigAlgo[idx+1], &hashAlgo, &sigAlgo), 0);

--- a/tests/quic.c
+++ b/tests/quic.c
@@ -543,10 +543,11 @@ static int ctx_send_alert(WOLFSSL *ssl, WOLFSSL_ENCRYPTION_LEVEL level, uint8_t 
 {
     QuicTestContext *ctx = (QuicTestContext*)wolfSSL_get_app_data(ssl);
 
+    AssertNotNull(ctx);
+
     if (ctx->verbose) {
         printf("[%s] send_alert: level=%d, err=%d\n", ctx->name, level, err);
     }
-    AssertNotNull(ctx);
     ctx->alert_level = level;
     ctx->alert = alert;
     return 1;
@@ -558,6 +559,8 @@ static int ctx_session_ticket_cb(WOLFSSL* ssl,
                                  void* cb_ctx)
 {
     QuicTestContext *ctx = (QuicTestContext*)wolfSSL_get_app_data(ssl);
+
+    AssertNotNull(ctx);
 
     (void)cb_ctx;
     if (ticketSz < 0 || (size_t)ticketSz > sizeof(ctx->ticket)) {
@@ -1534,6 +1537,8 @@ static int new_session_cb(WOLFSSL *ssl, WOLFSSL_SESSION *session)
     byte *data;
     int ret = 0;
     int sz;
+
+    AssertNotNull(ctx);
 
     sz = wolfSSL_i2d_SSL_SESSION(session, NULL);
     if (sz <= 0) {

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -2495,7 +2495,7 @@ static int RsaFunctionPrivate(mp_int* tmp, RsaKey* key, WC_RNG* rng)
 {
     int    ret = 0;
 #if defined(WC_RSA_BLINDING) && !defined(WC_NO_RNG)
-    mp_digit mp;
+    mp_digit mp = 0;
     DECL_MP_INT_SIZE_DYN(rnd, mp_bitsused(&key->n), RSA_MAX_SIZE);
     DECL_MP_INT_SIZE_DYN(rndi, mp_bitsused(&key->n), RSA_MAX_SIZE);
 #endif /* WC_RSA_BLINDING && !WC_NO_RNG */


### PR DESCRIPTION
# Description

- `src/quic.c`:  2 null derefs of pointer `cipher`.
- `tests/api.c`: integers `hashAlgo` and `sigAlgo` needed init. 
- `tests/quic.c`: 3 places needed `AssertNotNull(ctx);`.
- `wolfcrypt/src/rsa.c`: mp_digit mp needed init.

# Testing

A rerun with infer confirmed these issues are fixed.
