### PR TITLE
Introduce WOLFSSL_ESPIDF_EXIT_MESSAGE macro

### DIFF
--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/main/main.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/main/main.c
@@ -24,21 +24,25 @@
 #include "sdkconfig.h"
 
 /* wolfSSL */
+/* The wolfSSL user_settings.h file is automatically included by the settings.h
+ * file and should never be explicitly included in any other source files.
+ * The settings.h should also be listed above wolfssl library include files. */
 #include <wolfssl/wolfcrypt/settings.h>
-#include <user_settings.h>
 #include <wolfssl/version.h>
-#include "wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h"
+#include <wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h>
 #ifndef WOLFSSL_ESPIDF
-    #warning "Problem with wolfSSL user_settings."
-    #warning "Check components/wolfssl/include"
+    #error "Problem with wolfSSL user_settings. "           \
+           "Check components/wolfssl/include "              \
+           "and confirm WOLFSSL_USER_SETTINGS is defined, " \
+           "typically in the component CMakeLists.txt"
 #endif
 
 #include <wolfssl/wolfcrypt/types.h>
 #include <wolfcrypt/benchmark/benchmark.h>
 
 /* set to 0 for one benchmark,
-** set to 1 for continous benchmark loop */
-#define BENCHMARK_LOOP 1
+** set to 1 for continuous benchmark loop */
+#define BENCHMARK_LOOP 0
 
 /* check BENCH_ARGV in sdkconfig to determine need to set WOLFSSL_BENCH_ARGV */
 #ifdef CONFIG_BENCH_ARGV
@@ -129,6 +133,7 @@ void my_atmel_free(int slotId)
 /* the following are needed by benchmark.c with args */
 #ifdef WOLFSSL_BENCH_ARGV
 char* __argv[WOLFSSL_BENCH_ARGV_MAX_ARGUMENTS];
+#define ARG_BUFF_SIZE 16
 
 int construct_argv()
 {
@@ -137,7 +142,7 @@ int construct_argv()
     int len = 0;
     char *_argv; /* buffer for copying the string    */
     char *ch; /* char pointer to trace the string */
-    char buff[16] = { 0 }; /* buffer for a argument copy       */
+    char buff[ARG_BUFF_SIZE] = { 0 }; /* buffer for a argument copy       */
 
     ESP_LOGI(TAG, "construct_argv arg:%s\n", CONFIG_BENCH_ARGV);
     len = strlen(CONFIG_BENCH_ARGV);
@@ -170,7 +175,7 @@ int construct_argv()
         memset(buff, 0, sizeof(buff));
         /* copy each args into buffer */
         i = 0;
-        while ((*ch != ' ') && (*ch != '\0') && (i < 16)) {
+        while ((*ch != ' ') && (*ch != '\0') && (i <= ARG_BUFF_SIZE)) {
             buff[i] = *ch;
             ++i;
             ++ch;
@@ -193,14 +198,15 @@ int construct_argv()
 void app_main(void)
 {
     int stack_start = 0;
-    ESP_LOGI(TAG, "---------------- wolfSSL Benchmark Example ------------");
+
+    ESP_LOGI(TAG, "---------------- wolfSSL Benchmark Example -------------");
     ESP_LOGI(TAG, "--------------------------------------------------------");
     ESP_LOGI(TAG, "--------------------------------------------------------");
     ESP_LOGI(TAG, "---------------------- BEGIN MAIN ----------------------");
     ESP_LOGI(TAG, "--------------------------------------------------------");
     ESP_LOGI(TAG, "--------------------------------------------------------");
 
-#ifdef HAVE_VERSION_EXTENDED_INFO
+#if defined(HAVE_VERSION_EXTENDED_INFO) && defined(WOLFSSL_HAS_METRICS)
     esp_ShowExtendedSystemInfo();
 #endif
 
@@ -236,7 +242,7 @@ void app_main(void)
         ESP_LOGI(TAG, "Stack used: %d\n",
                       stack_start - uxTaskGetStackHighWaterMark(NULL));
 
-        #ifdef WOLFSSL_HW_METRICS_DISABLED/* Remove _DISABLED upon #6990 Merge */
+        #if defined(WOLFSSL_HW_METRICS) && defined(WOLFSSL_HAS_METRICS)
             esp_hw_show_metrics();
         #endif
     } while (BENCHMARK_LOOP);
@@ -249,8 +255,9 @@ void app_main(void)
     ESP_LOGI(TAG, "Stack HWM: %d\n", uxTaskGetStackHighWaterMark(NULL));
 #endif
 
-    ESP_LOGI(TAG, "\n\nDone!\n\n"
-                  "If running from idf.py monitor, press twice: Ctrl+]");
+#ifdef WOLFSSL_ESPIDF_EXIT_MESSAGE
+    ESP_LOGI(TAG, WOLFSSL_ESPIDF_EXIT_MESSAGE);
+#endif
 
     /* after the test, we'll just wait */
     while (1) {

--- a/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
+++ b/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
@@ -51,6 +51,13 @@
     #define WOLFSSL_ESPIDF_BLANKLINE_MESSAGE "."
 #endif
 
+/* Optional exit message.
+ * The WOLFSSL_COMPLETE keyword exits wolfSSL test harness script. */
+#define WOLFSSL_ESPIDF_EXIT_MESSAGE \
+    "\n\nDone!"                 \
+    "\n\nWOLFSSL_COMPLETE"      \
+    "\n\nIf running from idf.py monitor, press twice: Ctrl+]"
+
 /* exit codes to be used in tfm.c, sp_int.c, integer.c, etc.
  *
  * see wolfssl/wolfcrypt/error-crypt.h


### PR DESCRIPTION
# Description

This PR adds the `WOLFSSL_ESPIDF_EXIT_MESSAGE ` macro to the Espressif port, along with some minor example code cleanup.

When a keyword is encountered by the new `testMonitor.sh` script (PR for that coming soon)... the serial port capture process exits. This is in contrast to using the `ESP-IDF.py monitor` command that continues to monitor until `Ctrl-]` is pressed. 

For reference, see also the [suggestion from Ivan](https://x.com/i_grr/status/1703831313696850425?s=20) regarding using the [espressif/pytest-embedded](https://github.com/espressif/pytest-embedded). I chose to write a small Python script, instead.

```
./testMonitor.sh wolfssl_benchmark esp32c6 HW
```

The exit when detecting the `WOLFSSL_COMPLETE` keyword looks something like this for the [benchmark example](https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark):

```text
I (55745) wolfssl_benchmark:

Done!

WOLFSSL_COMPLETE
Example completed. Exiting monitor.
```

Fixes zd# n/a/

# Testing

How did you test?

Tested in the ESP-IDF environment only.

See https://github.com/wolfSSL/wolfssl/issues/6234 for a roadmap of Espressif updates.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
