### PR TITLE
SRTP/SRTCP KDF: add APIs that derives one key from a label

### DIFF
--- a/doc/dox_comments/header_files/kdf.h
+++ b/doc/dox_comments/header_files/kdf.h
@@ -4,7 +4,7 @@
 
     \brief This function derives keys using SRTP KDF algorithm.
 
-    \return 0 Returned upon successful key derviation.
+    \return 0 Returned upon successful key derivation.
     \return BAD_FUNC_ARG Returned when key or salt is NULL
     \return BAD_FUNC_ARG Returned when key length is not 16, 24 or 32.
     \return BAD_FUNC_ARG Returned when saltSz is larger than 14.
@@ -57,7 +57,7 @@ int wc_SRTP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
 
     \brief This function derives keys using SRTCP KDF algorithm.
 
-    \return 0 Returned upon successful key derviation.
+    \return 0 Returned upon successful key derivation.
     \return BAD_FUNC_ARG Returned when key or salt is NULL
     \return BAD_FUNC_ARG Returned when key length is not 16, 24 or 32.
     \return BAD_FUNC_ARG Returned when saltSz is larger than 14.
@@ -109,7 +109,7 @@ int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
 
     \brief This function derives a key with label using SRTP KDF algorithm.
 
-    \return 0 Returned upon successful key derviation.
+    \return 0 Returned upon successful key derivation.
     \return BAD_FUNC_ARG Returned when key, salt or outKey is NULL
     \return BAD_FUNC_ARG Returned when key length is not 16, 24 or 32.
     \return BAD_FUNC_ARG Returned when saltSz is larger than 14.
@@ -156,7 +156,7 @@ int wc_SRTP_KDF_label(const byte* key, word32 keySz, const byte* salt,
 
     \brief This function derives key with label using SRTCP KDF algorithm.
 
-    \return 0 Returned upon successful key derviation.
+    \return 0 Returned upon successful key derivation.
     \return BAD_FUNC_ARG Returned when key, salt or outKey is NULL
     \return BAD_FUNC_ARG Returned when key length is not 16, 24 or 32.
     \return BAD_FUNC_ARG Returned when saltSz is larger than 14.

--- a/doc/dox_comments/header_files/kdf.h
+++ b/doc/dox_comments/header_files/kdf.h
@@ -44,6 +44,8 @@
     \endcode
 
     \sa wc_SRTCP_KDF
+    \sa wc_SRTP_KDF_label
+    \sa wc_SRTCP_KDF_label
     \sa wc_SRTP_KDF_kdr_to_idx
 */
 int wc_SRTP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
@@ -95,12 +97,107 @@ int wc_SRTP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
     \endcode
 
     \sa wc_SRTP_KDF
+    \sa wc_SRTP_KDF_label
+    \sa wc_SRTCP_KDF_label
     \sa wc_SRTP_KDF_kdr_to_idx
 */
 int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
         int kdrIdx, const byte* index, byte* key1, word32 key1Sz, byte* key2,
         word32 key2Sz, byte* key3, word32 key3Sz);
+/*!
+    \ingroup SrtpKdf
 
+    \brief This function derives a key with label using SRTP KDF algorithm.
+
+    \return 0 Returned upon successful key derviation.
+    \return BAD_FUNC_ARG Returned when key, salt or outKey is NULL
+    \return BAD_FUNC_ARG Returned when key length is not 16, 24 or 32.
+    \return BAD_FUNC_ARG Returned when saltSz is larger than 14.
+    \return BAD_FUNC_ARG Returned when kdrIdx is less than -1 or larger than 24.
+    \return MEMORY_E on dynamic memory allocation failure.
+
+    \param [in] key Key to use with encryption.
+    \param [in] keySz Size of key in bytes.
+    \param [in] salt Random non-secret value.
+    \param [in] saltSz Size of random in bytes.
+    \param [in] kdrIdx Key derivation rate. kdr = 0 when -1, otherwise kdr = 2^kdrIdx.
+    \param [in] index Index value to XOR in.
+    \param [in] label Label to use when deriving key.
+    \param [out] outKey Derived key.
+    \param [in] outKeySz Size of derived key in bytes.
+
+
+    _Example_
+    \code
+    unsigned char key[16] = { ... };
+    unsigned char salt[14] = { ... };
+    unsigned char index[6] = { ... };
+    unsigned char keyE[16];
+    int kdrIdx = 0; // Use all of index
+    int ret;
+
+    ret = wc_SRTP_KDF_label(key, sizeof(key), salt, sizeof(salt), kdrIdx, index,
+        WC_SRTP_LABEL_ENCRYPTION, keyE, sizeof(keyE));
+    if (ret != 0) {
+        WOLFSSL_MSG("wc_SRTP_KDF failed");
+    }
+    \endcode
+
+    \sa wc_SRTP_KDF
+    \sa wc_SRTCP_KDF
+    \sa wc_SRTCP_KDF_label
+    \sa wc_SRTP_KDF_kdr_to_idx
+*/
+int wc_SRTP_KDF_label(const byte* key, word32 keySz, const byte* salt,
+        word32 saltSz, int kdrIdx, const byte* index, byte label, byte* outKey,
+        word32 outKeySz);
+/*!
+    \ingroup SrtpKdf
+
+    \brief This function derives key with label using SRTCP KDF algorithm.
+
+    \return 0 Returned upon successful key derviation.
+    \return BAD_FUNC_ARG Returned when key, salt or outKey is NULL
+    \return BAD_FUNC_ARG Returned when key length is not 16, 24 or 32.
+    \return BAD_FUNC_ARG Returned when saltSz is larger than 14.
+    \return BAD_FUNC_ARG Returned when kdrIdx is less than -1 or larger than 24.
+    \return MEMORY_E on dynamic memory allocation failure.
+
+    \param [in] key Key to use with encryption.
+    \param [in] keySz Size of key in bytes.
+    \param [in] salt Random non-secret value.
+    \param [in] saltSz Size of random in bytes.
+    \param [in] kdrIdx Key derivation rate. kdr = 0 when -1, otherwise kdr = 2^kdrIdx.
+    \param [in] index Index value to XOR in.
+    \param [in] label Label to use when deriving key.
+    \param [out] outKey Derived key.
+    \param [in] outKeySz Size of derived key in bytes.
+
+
+    _Example_
+    \code
+    unsigned char key[16] = { ... };
+    unsigned char salt[14] = { ... };
+    unsigned char index[4] = { ... };
+    unsigned char keyE[16];
+    int kdrIdx = 0; // Use all of index
+    int ret;
+
+    ret = wc_SRTCP_KDF_label(key, sizeof(key), salt, sizeof(salt), kdrIdx,
+        index, WC_SRTCP_LABEL_ENCRYPTION, keyE, sizeof(keyE));
+    if (ret != 0) {
+        WOLFSSL_MSG("wc_SRTP_KDF failed");
+    }
+    \endcode
+
+    \sa wc_SRTP_KDF
+    \sa wc_SRTCP_KDF
+    \sa wc_SRTP_KDF_label
+    \sa wc_SRTP_KDF_kdr_to_idx
+*/
+int wc_SRTP_KDF_label(const byte* key, word32 keySz, const byte* salt,
+        word32 saltSz, int kdrIdx, const byte* index, byte label, byte* outKey,
+        word32 outKeySz);
 /*!
     \ingroup SrtpKdf
 
@@ -121,6 +218,8 @@ int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
 
     \sa wc_SRTP_KDF
     \sa wc_SRTCP_KDF
+    \sa wc_SRTP_KDF_label
+    \sa wc_SRTCP_KDF_label
 */
 int wc_SRTP_KDF_kdr_to_idx(word32 kdr);
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -25617,11 +25617,35 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t srtpkdf_test(void)
             keyS, tv[i].ksSz);
         if (ret != 0)
             return WC_TEST_RET_ENC_EC(ret);
-        if (XMEMCMP(keyE, tv[i].ke, 16) != 0)
+        if (XMEMCMP(keyE, tv[i].ke, tv[i].keSz) != 0)
             return WC_TEST_RET_ENC_NC;
-        if (XMEMCMP(keyA, tv[i].ka, 20) != 0)
+        if (XMEMCMP(keyA, tv[i].ka, tv[i].kaSz) != 0)
             return WC_TEST_RET_ENC_NC;
-        if (XMEMCMP(keyS, tv[i].ks, 14) != 0)
+        if (XMEMCMP(keyS, tv[i].ks, tv[i].ksSz) != 0)
+            return WC_TEST_RET_ENC_NC;
+
+        ret = wc_SRTP_KDF_label(tv[i].key, tv[i].keySz, tv[i].salt,
+            tv[i].saltSz, tv[i].kdfIdx, tv[i].index, WC_SRTP_LABEL_ENCRYPTION,
+            keyE, tv[i].keSz);
+        if (ret != 0)
+            return WC_TEST_RET_ENC_EC(ret);
+        if (XMEMCMP(keyE, tv[i].ke, tv[i].keSz) != 0)
+            return WC_TEST_RET_ENC_NC;
+
+        ret = wc_SRTP_KDF_label(tv[i].key, tv[i].keySz, tv[i].salt,
+            tv[i].saltSz, tv[i].kdfIdx, tv[i].index, WC_SRTP_LABEL_MSG_AUTH,
+            keyA, tv[i].kaSz);
+        if (ret != 0)
+            return WC_TEST_RET_ENC_EC(ret);
+        if (XMEMCMP(keyA, tv[i].ka, tv[i].kaSz) != 0)
+            return WC_TEST_RET_ENC_NC;
+
+        ret = wc_SRTP_KDF_label(tv[i].key, tv[i].keySz, tv[i].salt,
+            tv[i].saltSz, tv[i].kdfIdx, tv[i].index, WC_SRTP_LABEL_SALT, keyS,
+            tv[i].ksSz);
+        if (ret != 0)
+            return WC_TEST_RET_ENC_EC(ret);
+        if (XMEMCMP(keyS, tv[i].ks, tv[i].ksSz) != 0)
             return WC_TEST_RET_ENC_NC;
 
         ret = wc_SRTCP_KDF(tv[i].key, tv[i].keySz, tv[i].salt, tv[i].saltSz,
@@ -25629,11 +25653,35 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t srtpkdf_test(void)
             keyS, tv[i].ksSz);
         if (ret != 0)
             return WC_TEST_RET_ENC_EC(ret);
-        if (XMEMCMP(keyE, tv[i].ke_c, 16) != 0)
+        if (XMEMCMP(keyE, tv[i].ke_c, tv[i].keSz) != 0)
             return WC_TEST_RET_ENC_NC;
-        if (XMEMCMP(keyA, tv[i].ka_c, 20) != 0)
+        if (XMEMCMP(keyA, tv[i].ka_c, tv[i].kaSz) != 0)
             return WC_TEST_RET_ENC_NC;
-        if (XMEMCMP(keyS, tv[i].ks_c, 14) != 0)
+        if (XMEMCMP(keyS, tv[i].ks_c, tv[i].ksSz) != 0)
+            return WC_TEST_RET_ENC_NC;
+
+        ret = wc_SRTCP_KDF_label(tv[i].key, tv[i].keySz, tv[i].salt,
+            tv[i].saltSz, tv[i].kdfIdx, tv[i].index_c,
+            WC_SRTCP_LABEL_ENCRYPTION, keyE, tv[i].keSz);
+        if (ret != 0)
+            return WC_TEST_RET_ENC_EC(ret);
+        if (XMEMCMP(keyE, tv[i].ke_c, tv[i].keSz) != 0)
+            return WC_TEST_RET_ENC_NC;
+
+        ret = wc_SRTCP_KDF_label(tv[i].key, tv[i].keySz, tv[i].salt,
+            tv[i].saltSz, tv[i].kdfIdx, tv[i].index_c, WC_SRTCP_LABEL_MSG_AUTH,
+            keyA, tv[i].kaSz);
+        if (ret != 0)
+            return WC_TEST_RET_ENC_EC(ret);
+        if (XMEMCMP(keyA, tv[i].ka_c, tv[i].kaSz) != 0)
+            return WC_TEST_RET_ENC_NC;
+
+        ret = wc_SRTCP_KDF_label(tv[i].key, tv[i].keySz, tv[i].salt,
+            tv[i].saltSz, tv[i].kdfIdx, tv[i].index_c, WC_SRTCP_LABEL_SALT,
+            keyS, tv[i].kaSz);
+        if (ret != 0)
+            return WC_TEST_RET_ENC_EC(ret);
+        if (XMEMCMP(keyS, tv[i].ks_c, tv[i].ksSz) != 0)
             return WC_TEST_RET_ENC_NC;
     }
 

--- a/wolfssl/wolfcrypt/kdf.h
+++ b/wolfssl/wolfcrypt/kdf.h
@@ -106,6 +106,21 @@ WOLFSSL_API int wc_SSH_KDF(byte hashId, byte keyId,
 #endif /* WOLFSSL_WOLFSSH */
 
 #ifdef WC_SRTP_KDF
+/* Label values for purpose. */
+#define WC_SRTP_LABEL_ENCRYPTION        0x00
+#define WC_SRTP_LABEL_MSG_AUTH          0x01
+#define WC_SRTP_LABEL_SALT              0x02
+#define WC_SRTCP_LABEL_ENCRYPTION       0x03
+#define WC_SRTCP_LABEL_MSG_AUTH         0x04
+#define WC_SRTCP_LABEL_SALT             0x05
+#define WC_SRTP_LABEL_HDR_ENCRYPTION    0x06
+#define WC_SRTP_LABEL_HDR_SALT          0x07
+
+/* Length of index for SRTP KDF. */
+#define WC_SRTP_INDEX_LEN               6
+/* Length of index for SRTCP KDF. */
+#define WC_SRTCP_INDEX_LEN              4
+
 /* Maximum length of salt that can be used with SRTP/SRTCP. */
 #define WC_SRTP_MAX_SALT    14
 
@@ -115,6 +130,12 @@ WOLFSSL_API int wc_SRTP_KDF(const byte* key, word32 keySz, const byte* salt,
 WOLFSSL_API int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt,
     word32 saltSz, int kdrIdx, const byte* index, byte* key1, word32 key1Sz,
     byte* key2, word32 key2Sz, byte* key3, word32 key3Sz);
+WOLFSSL_API int wc_SRTP_KDF_label(const byte* key, word32 keySz,
+    const byte* salt, word32 saltSz, int kdrIdx, const byte* index, byte label,
+    byte* outKey, word32 outKeySz);
+WOLFSSL_API int wc_SRTCP_KDF_label(const byte* key, word32 keySz,
+    const byte* salt, word32 saltSz, int kdrIdx, const byte* index, byte label,
+    byte* outKey, word32 outKeySz);
 
 WOLFSSL_API int wc_SRTP_KDF_kdr_to_idx(word32 kdr);
 


### PR DESCRIPTION
# Description

Added more generic APIs that derive a single key with a label.
Added defines for label values and index lengths.

# Testing

./configure --enable-drtp-kdf

# Checklist

 - [x] added tests
 - [x] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
