### PR TITLE
20231214-WOLF_CRYPTO_CB-not-WC_AESFREE_IS_MANDATORY

### DIFF
--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -407,7 +407,6 @@ typedef struct XtsAes {
      (defined(WOLFSSL_DEVCRYPTO) &&                                     \
       (defined(WOLFSSL_DEVCRYPTO_AES) ||                                \
        defined(WOLFSSL_DEVCRYPTO_CBC))) ||                              \
-     defined(WOLF_CRYPTO_CB) ||                                         \
      defined(WOLFSSL_IMXRT_DCP) ||                                      \
      (defined(WOLFSSL_AESGCM_STREAM) && defined(WOLFSSL_SMALL_STACK) && \
       !defined(WOLFSSL_AESNI)) ||                                       \


### PR DESCRIPTION
`wolfssl/wolfcrypt/aes.h`: don't set `WC_AESFREE_IS_MANDATORY` for `WOLF_CRYPTO_CB` -- free is only needed when callbacks are both installed and used.

tested with `wolfssl-multi-test.sh ... sp-all-asm-sanitizer`
