### PR TITLE
20231215-srtp-cleanup

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2240,15 +2240,19 @@ static int DtlsSrtpSelProfiles(word16* id, const char* profile_str)
     do {
         current = next;
         next = XSTRSTR(current, ":");
-        current_length = (!next) ? (word32)XSTRLEN(current)
-                                 : (word32)(next - current);
+        if (next) {
+            current_length = (word32)(next - current);
+            ++next; /* ++ needed to skip ':' */
+        } else {
+            current_length = (word32)XSTRLEN(current);
+        }
         if (current_length < length)
             length = current_length;
         profile = DtlsSrtpFindProfile(current, current_length, 0);
         if (profile != NULL) {
             *id |= (1 << profile->id); /* selected bit based on ID */
         }
-    } while (next != NULL && next++); /* ++ needed to skip ':' */
+    } while (next != NULL);
     return WOLFSSL_SUCCESS;
 }
 

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -304,12 +304,8 @@ static int execute_test_case(int svr_argc, char** svr_argv,
                              int forceCliDefCipherList)
 {
 #if defined(WOLFSSL_TIRTOS) || defined(WOLFSSL_SRTP)
-    func_args cliArgs = {0};
-    func_args svrArgs = {0};
-    cliArgs.argc = cli_argc;
-    cliArgs.argv = cli_argv;
-    svrArgs.argc = svr_argc;
-    svrArgs.argv = svr_argv;
+    func_args cliArgs = {0, NULL, 0, NULL, NULL, NULL};
+    func_args svrArgs = {0, NULL, 0, NULL, NULL, NULL};
 #else
     func_args cliArgs = {cli_argc, cli_argv, 0, NULL, NULL};
     func_args svrArgs = {svr_argc, svr_argv, 0, NULL, NULL};
@@ -333,6 +329,14 @@ static int execute_test_case(int svr_argc, char** svr_argv,
 #if defined(WOLFSSL_SRTP) && defined(WOLFSSL_COND)
     srtp_test_helper srtp_helper;
 #endif
+
+#if defined(WOLFSSL_TIRTOS) || defined(WOLFSSL_SRTP)
+    cliArgs.argc = cli_argc;
+    cliArgs.argv = cli_argv;
+    svrArgs.argc = svr_argc;
+    svrArgs.argv = svr_argv;
+#endif
+
     /* Is Valid Cipher and Version Checks */
     /* build command list for the Is checks below */
     commandLine[0] = '\0';

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -1006,6 +1006,7 @@ int wc_SRTP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
 #else
     Aes aes[1];
 #endif
+    int aes_inited = 0;
 
     /* Validate parameters. */
     if ((key == NULL) || (keySz > AES_256_KEY_SIZE) || (salt == NULL) ||
@@ -1031,6 +1032,7 @@ int wc_SRTP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
         ret = wc_AesInit(aes, NULL, INVALID_DEVID);
     }
     if (ret == 0) {
+        aes_inited = 1;
         ret = wc_AesSetKey(aes, key, keySz, NULL, AES_ENCRYPTION);
     }
 
@@ -1056,8 +1058,8 @@ int wc_SRTP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
             WC_SRTP_LABEL_SALT, key3, key3Sz, aes);
     }
 
-    /* AES object memset so can always free. */
-    wc_AesFree(aes);
+    if (aes_inited)
+        wc_AesFree(aes);
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(aes, NULL, DYNAMIC_TYPE_CIPHER);
 #endif
@@ -1099,6 +1101,7 @@ int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
 #else
     Aes aes[1];
 #endif
+    int aes_inited = 0;
 
     /* Validate parameters. */
     if ((key == NULL) || (keySz > AES_256_KEY_SIZE) || (salt == NULL) ||
@@ -1124,6 +1127,7 @@ int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
         ret = wc_AesInit(aes, NULL, INVALID_DEVID);
     }
     if (ret == 0) {
+        aes_inited = 1;
         ret = wc_AesSetKey(aes, key, keySz, NULL, AES_ENCRYPTION);
     }
 
@@ -1149,8 +1153,8 @@ int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
             WC_SRTCP_LABEL_SALT, key3, key3Sz, aes);
     }
 
-    /* AES object memset so can always free. */
-    wc_AesFree(aes);
+    if (aes_inited)
+        wc_AesFree(aes);
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(aes, NULL, DYNAMIC_TYPE_CIPHER);
 #endif
@@ -1189,6 +1193,7 @@ int wc_SRTP_KDF_label(const byte* key, word32 keySz, const byte* salt,
 #else
     Aes aes[1];
 #endif
+    int aes_inited = 0;
 
     /* Validate parameters. */
     if ((key == NULL) || (keySz > AES_256_KEY_SIZE) || (salt == NULL) ||
@@ -1215,6 +1220,7 @@ int wc_SRTP_KDF_label(const byte* key, word32 keySz, const byte* salt,
         ret = wc_AesInit(aes, NULL, INVALID_DEVID);
     }
     if (ret == 0) {
+        aes_inited = 1;
         ret = wc_AesSetKey(aes, key, keySz, NULL, AES_ENCRYPTION);
     }
 
@@ -1229,8 +1235,8 @@ int wc_SRTP_KDF_label(const byte* key, word32 keySz, const byte* salt,
             outKeySz, aes);
     }
 
-    /* AES object memset so can always free. */
-    wc_AesFree(aes);
+    if (aes_inited)
+        wc_AesFree(aes);
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(aes, NULL, DYNAMIC_TYPE_CIPHER);
 #endif
@@ -1270,6 +1276,7 @@ int wc_SRTCP_KDF_label(const byte* key, word32 keySz, const byte* salt,
 #else
     Aes aes[1];
 #endif
+    int aes_inited = 0;
 
     /* Validate parameters. */
     if ((key == NULL) || (keySz > AES_256_KEY_SIZE) || (salt == NULL) ||
@@ -1296,6 +1303,7 @@ int wc_SRTCP_KDF_label(const byte* key, word32 keySz, const byte* salt,
         ret = wc_AesInit(aes, NULL, INVALID_DEVID);
     }
     if (ret == 0) {
+        aes_inited = 1;
         ret = wc_AesSetKey(aes, key, keySz, NULL, AES_ENCRYPTION);
     }
 
@@ -1310,8 +1318,8 @@ int wc_SRTCP_KDF_label(const byte* key, word32 keySz, const byte* salt,
             outKeySz, aes);
     }
 
-    /* AES object memset so can always free. */
-    wc_AesFree(aes);
+    if (aes_inited)
+        wc_AesFree(aes);
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(aes, NULL, DYNAMIC_TYPE_CIPHER);
 #endif

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -25678,7 +25678,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t srtpkdf_test(void)
 
         ret = wc_SRTCP_KDF_label(tv[i].key, tv[i].keySz, tv[i].salt,
             tv[i].saltSz, tv[i].kdfIdx, tv[i].index_c, WC_SRTCP_LABEL_SALT,
-            keyS, tv[i].kaSz);
+            keyS, tv[i].ksSz);
         if (ret != 0)
             return WC_TEST_RET_ENC_EC(ret);
         if (XMEMCMP(keyS, tv[i].ks_c, tv[i].ksSz) != 0)
@@ -25806,7 +25806,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t srtpkdf_test(void)
     if (idx != -1)
         return WC_TEST_RET_ENC_NC;
     for (i = 0; i < 32; i++) {
-        word32 kdr = 1 << i;
+        word32 kdr = 1U << i;
         idx = wc_SRTP_KDF_kdr_to_idx(kdr);
         if (idx != i)
             return WC_TEST_RET_ENC_NC;

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1478,8 +1478,10 @@ typedef struct WOLFSSL_SRTP_PROTECTION_PROFILE {
 } WOLFSSL_SRTP_PROTECTION_PROFILE;
 
 /* Compatibility API's for SRTP */
-WOLFSSL_API int wolfSSL_CTX_set_tlsext_use_srtp(WOLFSSL_CTX* ctx, const char*);
-WOLFSSL_API int wolfSSL_set_tlsext_use_srtp(WOLFSSL* ssl, const char*);
+WOLFSSL_API int wolfSSL_CTX_set_tlsext_use_srtp(WOLFSSL_CTX* ctx,
+                                                const char* profile_str);
+WOLFSSL_API int wolfSSL_set_tlsext_use_srtp(WOLFSSL* ssl,
+                                const char* wolfSSL_set_tlsext_use_srtp);
 WOLFSSL_API const WOLFSSL_SRTP_PROTECTION_PROFILE*
                 wolfSSL_get_selected_srtp_profile(WOLFSSL* ssl);
 WOLFSSL_API WOLF_STACK_OF(WOLFSSL_SRTP_PROTECTION_PROFILE)*
@@ -1487,7 +1489,7 @@ WOLFSSL_API WOLF_STACK_OF(WOLFSSL_SRTP_PROTECTION_PROFILE)*
 
 /* Non standard API for getting the SRTP session keys using KDF */
 WOLFSSL_API int wolfSSL_export_dtls_srtp_keying_material(WOLFSSL* ssl,
-    unsigned char*, size_t*);
+    unsigned char* out, size_t* olen);
 #endif /* WOLFSSL_SRTP */
 
 WOLFSSL_API int  wolfSSL_dtls_get_drop_stats(WOLFSSL* ssl,


### PR DESCRIPTION
SRTP fixes:
* in `wolfssl/ssl.h`, add missing arg names to `wolfSSL_CTX_set_tlsext_use_srtp()`, `wolfSSL_set_tlsext_use_srtp()`, and `wolfSSL_export_dtls_srtp_keying_material()`;
* in `wolfcrypt/src/kdf.c`, call `wc_AesFree` if and only if `wc_AesInit()` succeeded;
* in `src/ssl.c:DtlsSrtpSelProfiles()`, fix `bugprone-inc-dec-in-conditions`;
* in `tests/suites.c`:`execute_test_case()`, fix several `-Wdeclaration-after-statement` and `-Wmissing-field-initializers`;
* in `wolfcrypt/test/test.c`, fix a `shiftTooManyBitsSigned` warning in `srtpkdf_test()`, and fix a typo (`kaSz`/`ksSz`).

tested with `wolfssl-multi-test.sh ... super-quick-check` with `--enable-srtp` added to `ENABLE_ALL_TEST_FLAGS`.
