### PR TITLE
20231216-client_usage_msg-array-length

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1103,7 +1103,7 @@ static int ClientWriteRead(WOLFSSL* ssl, const char* msg, int msgSz,
 /*  4. add the same message into Japanese section         */
 /*     (will be translated later)                         */
 /*  5. add printf() into suitable position of Usage()     */
-static const char* client_usage_msg[][70] = {
+static const char* client_usage_msg[][75] = {
     /* English */
     {
         " NOTE: All files relative to wolfSSL home dir\n",          /* 0 */
@@ -1188,7 +1188,7 @@ static const char* client_usage_msg[][70] = {
         "            string 'scr-app-data' is passed in as the value and\n"
         "            Non-blocking sockets are enabled ('-N') then wolfSSL\n"
         "            sends a test message during the secure renegotiation.\n"
-        "            The string parameter is optional.\n", /* 29 */
+        "            The string parameter is optional.\n",              /* 29 */
 #endif
         "-f          Fewer packets/group messages\n",                   /* 30 */
 #ifndef NO_CERTS


### PR DESCRIPTION
`examples/client/client.c`: fix `client_usage_msg` undersized array dimension.

(discovered by `wolfssl-multi-test.sh` `sanitizer-all-secure-renegotiation` with `--enable-srtp` added to `ENABLE_ALL_TEST_FLAGS`.)
