### PR TITLE
wolfSSL_NewThread() type update for Espressif FreeRTOS

### DIFF
--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -127,6 +127,12 @@
     #include <wolfssl/wolfcrypt/port/psa/psa.h>
 #endif
 
+#if defined(FREERTOS) && defined(WOLFSSL_ESPIDF)
+    #include <freertos/FreeRTOS.h>
+    #include <freertos/task.h>
+    /* The Espressif-specific platform include: */
+    #include <pthread.h>
+#endif
 
 /* prevent multiple mutex initializations */
 static volatile int initRefCount = 0;
@@ -3426,6 +3432,7 @@ char* mystrnstr(const char* s1, const char* s2, unsigned int n)
 
 #ifndef SINGLE_THREADED
 
+/* Environment-specific multi-thread implementation check  */
 #if defined(USE_WINDOWS_API) && !defined(WOLFSSL_PTHREADS)
     int wolfSSL_NewThread(THREAD_TYPE* thread,
         THREAD_CB cb, void* arg)
@@ -3724,7 +3731,8 @@ char* mystrnstr(const char* s1, const char* s2, unsigned int n)
 
 #endif /* WOLFSSL_COND */
 
-#elif defined(WOLFSSL_PTHREADS)
+#elif defined(WOLFSSL_PTHREADS) || \
+     (defined(FREERTOS) && defined(WOLFSSL_ESPIDF))
 
     int wolfSSL_NewThread(THREAD_TYPE* thread,
         THREAD_CB cb, void* arg)
@@ -3738,18 +3746,18 @@ char* mystrnstr(const char* s1, const char* s2, unsigned int n)
         return 0;
     }
 
-#ifdef WOLFSSL_THREAD_NO_JOIN
-    int wolfSSL_NewThreadNoJoin(THREAD_CB_NOJOIN cb, void* arg)
-    {
-        THREAD_TYPE thread;
-        int ret;
-        XMEMSET(&thread, 0, sizeof(thread));
-        ret = wolfSSL_NewThread(&thread, cb, arg);
-        if (ret == 0)
-            ret = pthread_detach(thread);
-        return ret;
-    }
-#endif
+    #ifdef WOLFSSL_THREAD_NO_JOIN
+        int wolfSSL_NewThreadNoJoin(THREAD_CB_NOJOIN cb, void* arg)
+        {
+            THREAD_TYPE thread;
+            int ret;
+            XMEMSET(&thread, 0, sizeof(thread));
+            ret = wolfSSL_NewThread(&thread, cb, arg);
+            if (ret == 0)
+                ret = pthread_detach(thread);
+            return ret;
+        }
+    #endif
 
     int wolfSSL_JoinThread(THREAD_TYPE thread)
     {
@@ -3937,6 +3945,6 @@ char* mystrnstr(const char* s1, const char* s2, unsigned int n)
     #endif /* __MACH__ */
 #endif /* WOLFSSL_COND */
 
-#endif
+#endif /* Environment check */
 
-#endif /* SINGLE_THREADED */
+#endif /* not SINGLE_THREADED */

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1399,6 +1399,10 @@ typedef struct w64wrapper {
         #ifndef HAVE_SELFTEST
             #define WOLFSSL_THREAD_NO_JOIN
         #endif
+    #elif defined(FREERTOS) && defined(WOLFSSL_ESPIDF)
+        typedef void*          THREAD_RETURN;
+        typedef pthread_t      THREAD_TYPE;
+        #define WOLFSSL_THREAD
     #elif defined(FREERTOS)
         typedef unsigned int   THREAD_RETURN;
         typedef TaskHandle_t   THREAD_TYPE;


### PR DESCRIPTION
# Description

This PR updates the conditions for the wolfcrypt `wc_port.c` [wolfSSL_NewThread()](https://github.com/wolfSSL/wolfssl/blob/64e48deb0efc68df7b9546a379cd6252a3733cee/wolfcrypt/src/wc_port.c#L3729) definition when used in the multi-threaded Espressif ESP-IDF application. There's also an Espressif-specific FreeRTOS definition update for `THREAD_RETURN` and `THREAD_TYPE` in the wolfSSL `types.h`.


While working on a [wolfSSH example server app for the ESP32](https://github.com/gojimmypi/wolfssh/tree/component-manager/ide/Espressif/ESP-IDF/examples/wolfssh_server) I bumped into this curious typedef problem. The Espressif `pthread` types are slightly different. I could not find the source online, but in my case, defined in this file: 

```
C:\SysGCC\esp32\tools\xtensa-esp32-elf\esp-12.2.0_20230208\xtensa-esp32-elf\xtensa-esp32-elf\sys-include\sys\_pthreadtypes.h
```

These are the settings of interest in my respective [user_settings.h](https://github.com/gojimmypi/wolfssh/blob/fbdff5f6ff697c310a72eefac942bb06169b497f/ide/Espressif/ESP-IDF/examples/wolfssh_server/components/wolfssl/include/user_settings.h#L45):

```
    #define WOLFSSL_KEY_GEN
    #define WOLFSSL_PTHREADS

    #define WOLFSSH_TERM
    #define DEBUG_WOLFSSH

    #define WOLFSSH_TEST_SERVER
    #define WOLFSSH_TEST_THREADING
```

Note defining `WOLFSSL_PTHREADS` in `user_settings.h`, although not intuitive, also resolved the typedef warning. That's the reason I chose the conditional inclusion location of the "or `(defined(FREERTOS) && defined(WOLFSSL_ESPIDF))`" in this PR.

See also [Espressif POSIX Threads Support](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/pthread.html)


Fixes zd# n/a

# Testing

How did you test?

Tested with Espressif apps & the usual Linux `make clean && make test`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
