### PR TITLE
20231218-AddSessionToClientCache-round-2

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -14409,19 +14409,19 @@ ClientSession* AddSessionToClientCache(int side, int row, int idx, byte* serverI
             }
             if (error == 0) {
                 WOLFSSL_MSG("Adding client cache entry");
+
+                ret = &ClientCache[clientRow].Clients[clientIdx];
+
                 if (ClientCache[clientRow].totalCount < CLIENT_SESSIONS_PER_ROW)
                     ClientCache[clientRow].totalCount++;
                 ClientCache[clientRow].nextIdx++;
                 ClientCache[clientRow].nextIdx %= CLIENT_SESSIONS_PER_ROW;
             }
 
-            ret = &ClientCache[clientRow].Clients[clientIdx];
-
             wc_UnLockMutex(&clisession_mutex);
         }
         else {
             WOLFSSL_MSG("Hash session or lock failed");
-            error = -1;
         }
     }
     else {


### PR DESCRIPTION
`src/ssl.c`: in `AddSessionToClientCache()`, remove benign frivolous assignment, and fix so that `ret` is assigned only if no `error`.
