### PR TITLE
add cryptoCbSWFallback byte field

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -5488,6 +5488,8 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
             int crypto_cb_ret = wc_CryptoCb_AesCbcEncrypt(aes, out, in, sz);
             if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
                 return crypto_cb_ret;
+            /* mark that fallback was used so the user can act accordingly */
+            aes->cryptoCbSWFallback = 1;
             /* fall-through when unavailable */
         }
     #endif
@@ -5657,6 +5659,8 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
             int crypto_cb_ret = wc_CryptoCb_AesCbcDecrypt(aes, out, in, sz);
             if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
                 return crypto_cb_ret;
+            /* mark that fallback was used so the user can act accordingly */
+            aes->cryptoCbSWFallback = 1;
             /* fall-through when unavailable */
         }
     #endif
@@ -6045,6 +6049,8 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
                 int crypto_cb_ret = wc_CryptoCb_AesCtrEncrypt(aes, out, in, sz);
                 if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
                     return crypto_cb_ret;
+                /* mark that fallback was used so the user can act accordingly */
+                aes->cryptoCbSWFallback = 1;
                 /* fall-through when unavailable */
             }
         #endif
@@ -8294,6 +8300,8 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
                                       authTagSz, authIn, authInSz);
         if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
             return crypto_cb_ret;
+        /* mark that fallback was used so the user can act accordingly */
+        aes->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
     }
 #endif
@@ -8858,6 +8866,8 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
                                       authTag, authTagSz, authIn, authInSz);
         if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
             return crypto_cb_ret;
+        /* mark that fallback was used so the user can act accordingly */
+        aes->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
     }
 #endif
@@ -10751,6 +10761,8 @@ int wc_AesCcmEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
                                       authTag, authTagSz, authIn, authInSz);
         if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
             return crypto_cb_ret;
+        /* mark that fallback was used so the user can act accordingly */
+        aes->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
     }
 #endif
@@ -10893,6 +10905,8 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
             authTag, authTagSz, authIn, authInSz);
         if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
             return crypto_cb_ret;
+        /* mark that fallback was used so the user can act accordingly */
+        aes->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
     }
 #endif
@@ -11393,6 +11407,8 @@ static WARN_UNUSED_RESULT int _AesEcbEncrypt(
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
         ret = 0;
+        /* mark that fallback was used so the user can act accordingly */
+        aes->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
     }
 #endif
@@ -11444,6 +11460,8 @@ static WARN_UNUSED_RESULT int _AesEcbDecrypt(
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
         ret = 0;
+        /* mark that fallback was used so the user can act accordingly */
+        aes->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
     }
 #endif

--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -127,6 +127,8 @@ int wc_InitCmac_ex(Cmac* cmac, const byte* key, word32 keySz,
                 type, unused);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
+        /* mark that fallback was used so the user can act accordingly */
+        cmac->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
     }
 #else
@@ -195,6 +197,8 @@ int wc_CmacUpdate(Cmac* cmac, const byte* in, word32 inSz)
                 NULL, NULL, 0, NULL);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
+        /* mark that fallback was used so the user can act accordingly */
+        cmac->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
         ret = 0; /* reset error code */
     }
@@ -261,6 +265,8 @@ int wc_CmacFinalNoFree(Cmac* cmac, byte* out, word32* outSz)
         ret = wc_CryptoCb_Cmac(cmac, NULL, 0, NULL, 0, out, outSz, 0, NULL);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
+        /* mark that fallback was used so the user can act accordingly */
+        cmac->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
     }
 #endif

--- a/wolfcrypt/src/curve25519.c
+++ b/wolfcrypt/src/curve25519.c
@@ -232,6 +232,8 @@ int wc_curve25519_make_key(WC_RNG* rng, int keysize, curve25519_key* key)
         ret = wc_CryptoCb_Curve25519Gen(rng, keysize, key);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
+        /* mark that fallback was used so the user can act accordingly */
+        key->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
     }
 #endif
@@ -293,6 +295,9 @@ int wc_curve25519_shared_secret_ex(curve25519_key* private_key,
             endian);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
+        /* mark that fallback was used so the user can act accordingly */
+        private_key->cryptoCbSWFallback = 1;
+        public_key->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
     }
 #endif

--- a/wolfcrypt/src/des3.c
+++ b/wolfcrypt/src/des3.c
@@ -1604,6 +1604,8 @@
             int ret = wc_CryptoCb_Des3Encrypt(des, out, in, sz);
             if (ret != CRYPTOCB_UNAVAILABLE)
                 return ret;
+            /* mark that fallback was used so the user can act accordingly */
+            des->cryptoCbSWFallback = 1;
             /* fall-through when unavailable */
         }
     #endif
@@ -1655,6 +1657,8 @@
             int ret = wc_CryptoCb_Des3Decrypt(des, out, in, sz);
             if (ret != CRYPTOCB_UNAVAILABLE)
                 return ret;
+            /* mark that fallback was used so the user can act accordingly */
+            des->cryptoCbSWFallback = 1;
             /* fall-through when unavailable */
         }
     #endif

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4562,9 +4562,13 @@ int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key, byte* out,
         #ifndef WOLF_CRYPTO_CB_ONLY_ECC
         if (err != CRYPTOCB_UNAVAILABLE)
             return err;
+        /* mark that fallback was used so the user can act accordingly */
+        else {
+            private_key->cryptoCbSWFallback = 1;
+            public_key->cryptoCbSWFallback = 1;
+        }
         /* fall-through when unavailable */
-        #endif
-        #ifdef WOLF_CRYPTO_CB_ONLY_ECC
+        #else
         if (err == CRYPTOCB_UNAVAILABLE) {
             err = NO_VALID_DEVID;
         }
@@ -5521,9 +5525,11 @@ static int _ecc_make_key_ex(WC_RNG* rng, int keysize, ecc_key* key,
         #ifndef WOLF_CRYPTO_CB_ONLY_ECC
         if (err != CRYPTOCB_UNAVAILABLE)
             return err;
+        /* mark that fallback was used so the user can act accordingly */
+        else
+            key->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
-        #endif
-        #ifdef WOLF_CRYPTO_CB_ONLY_ECC
+        #else
         if (err == CRYPTOCB_UNAVAILABLE) {
             return NO_VALID_DEVID;
         }
@@ -6554,9 +6560,11 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
         #ifndef WOLF_CRYPTO_CB_ONLY_ECC
         if (err != CRYPTOCB_UNAVAILABLE)
             return err;
+        /* mark that fallback was used so the user can act accordingly */
+        else
+            key->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
-        #endif
-        #ifdef WOLF_CRYPTO_CB_ONLY_ECC
+        #else
         if (err == CRYPTOCB_UNAVAILABLE) {
             err = NO_VALID_DEVID;
         }
@@ -8280,9 +8288,11 @@ int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
         #ifndef WOLF_CRYPTO_CB_ONLY_ECC
         if (err != CRYPTOCB_UNAVAILABLE)
             return err;
+        /* mark that fallback was used so the user can act accordingly */
+        else
+            key->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
-        #endif
-        #ifdef WOLF_CRYPTO_CB_ONLY_ECC
+        #else
         if (err == CRYPTOCB_UNAVAILABLE) {
             err = NO_VALID_DEVID;
         }

--- a/wolfcrypt/src/ed25519.c
+++ b/wolfcrypt/src/ed25519.c
@@ -247,6 +247,9 @@ int wc_ed25519_make_key(WC_RNG* rng, int keySz, ed25519_key* key)
         ret = wc_CryptoCb_Ed25519Gen(rng, keySz, key);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
+
+        /* mark that fallback was used so the user can act accordingly */
+        key->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
     }
 #endif
@@ -317,6 +320,8 @@ int wc_ed25519_sign_msg_ex(const byte* in, word32 inLen, byte* out,
             context, contextLen);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
+        /* mark that fallback was used so the user can act accordingly */
+        key->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
     }
 #endif
@@ -773,6 +778,8 @@ int wc_ed25519_verify_msg_ex(const byte* sig, word32 sigLen, const byte* msg,
             type, context, contextLen);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
+        /* mark that fallback was used so the user can act accordingly */
+        key->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
     }
 #endif

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -668,6 +668,8 @@ int wc_HmacUpdate(Hmac* hmac, const byte* msg, word32 length)
         ret = wc_CryptoCb_Hmac(hmac, hmac->macType, msg, length, NULL);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
+        /* mark that fallback was used so the user can act accordingly */
+        hmac->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
         ret = 0; /* reset error code */
     }
@@ -777,6 +779,8 @@ int wc_HmacFinal(Hmac* hmac, byte* hash)
         ret = wc_CryptoCb_Hmac(hmac, hmac->macType, NULL, 0, hash);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
+        /* mark that fallback was used so the user can act accordingly */
+        hmac->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
     }
 #endif

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1790,6 +1790,8 @@ int wc_RNG_GenerateBlock(WC_RNG* rng, byte* output, word32 sz)
         ret = wc_CryptoCb_RandomBlock(rng, output, sz);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
+        /* mark that fallback was used so the user can act accordingly */
+        rng->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
     }
 #endif
@@ -2552,6 +2554,8 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         ret = wc_CryptoCb_RandomSeed(os, output, sz);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
+        /* mark that fallback was used so the user can act accordingly */
+        os->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
     }
 #endif
@@ -3661,6 +3665,8 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
             ret = wc_CryptoCb_RandomSeed(os, output, sz);
             if (ret != CRYPTOCB_UNAVAILABLE)
                 return ret;
+            /* mark that fallback was used so the user can act accordingly */
+            os->cryptoCbSWFallback = 1;
             /* fall-through when unavailable */
             ret = 0; /* reset error code */
         }

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -3127,9 +3127,11 @@ static int wc_RsaFunction_ex(const byte* in, word32 inLen, byte* out,
         #ifndef WOLF_CRYPTO_CB_ONLY_RSA
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
+        /* mark that fallback was used so the user can act accordingly */
+        else
+            key->cryptoCbSWFallback = 1;
         /* fall-through when unavailable and try using software */
-        #endif
-        #ifdef WOLF_CRYPTO_CB_ONLY_RSA
+        #else
         if (ret == CRYPTOCB_UNAVAILABLE) {
             return NO_VALID_DEVID;
         }
@@ -4759,9 +4761,11 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
         #ifndef WOLF_CRYPTO_CB_ONLY_RSA
         if (err != CRYPTOCB_UNAVAILABLE)
             goto out;
+        /* mark that fallback was used so the user can act accordingly */
+        else
+            key->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
-        #endif
-        #ifdef WOLF_CRYPTO_CB_ONLY_RSA
+        #else
         if (err == CRYPTOCB_UNAVAILABLE)
             err = NO_VALID_DEVID;
             goto out;

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -601,6 +601,8 @@ int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
         ret = 0; /* reset ret */
+        /* mark that fallback was used so the user can act accordingly */
+        sha->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
     }
 #endif
@@ -819,6 +821,8 @@ int wc_ShaFinal(wc_Sha* sha, byte* hash)
         ret = wc_CryptoCb_ShaHash(sha, NULL, 0, hash);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
+        /* mark that fallback was used so the user can act accordingly */
+        sha->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
     }
 #endif

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -1260,6 +1260,8 @@ static int InitSha256(wc_Sha256* sha256)
             int ret = wc_CryptoCb_Sha256Hash(sha256, data, len, NULL);
             if (ret != CRYPTOCB_UNAVAILABLE)
                 return ret;
+            /* mark that fallback was used so the user can act accordingly */
+            sha256->cryptoCbSWFallback = 1;
             /* fall-through when unavailable */
         }
     #endif
@@ -1510,6 +1512,8 @@ static int InitSha256(wc_Sha256* sha256)
             ret = wc_CryptoCb_Sha256Hash(sha256, NULL, 0, hash);
             if (ret != CRYPTOCB_UNAVAILABLE)
                 return ret;
+            /* mark that fallback was used so the user can act accordingly */
+            sha256->cryptoCbSWFallback = 1;
             /* fall-through when unavailable */
         }
     #endif

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -893,6 +893,8 @@ int wc_Sha512Update(wc_Sha512* sha512, const byte* data, word32 len)
         int ret = wc_CryptoCb_Sha512Hash(sha512, data, len, NULL);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
+        /* mark that fallback was used so the user can act accordingly */
+        sha512->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
     }
 #endif
@@ -1111,6 +1113,8 @@ static int Sha512_Family_Final(wc_Sha512* sha512, byte* hash, size_t digestSz,
             XMEMCPY(hash, localHash, digestSz);
             return ret;
         }
+        /* mark that fallback was used so the user can act accordingly */
+        sha512->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
     }
 #endif
@@ -1354,6 +1358,8 @@ int wc_Sha384Update(wc_Sha384* sha384, const byte* data, word32 len)
         int ret = wc_CryptoCb_Sha384Hash(sha384, data, len, NULL);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
+        /* mark that fallback was used so the user can act accordingly */
+        sha384->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
     }
 #endif
@@ -1406,6 +1412,8 @@ int wc_Sha384Final(wc_Sha384* sha384, byte* hash)
         ret = wc_CryptoCb_Sha384Hash(sha384, NULL, 0, hash);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
+        /* mark that fallback was used so the user can act accordingly */
+        sha384->cryptoCbSWFallback = 1;
         /* fall-through when unavailable */
     }
 #endif

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -284,6 +284,7 @@ struct Aes {
 #ifdef WOLF_CRYPTO_CB
     int    devId;
     void*  devCtx;
+    byte cryptoCbSWFallback;
 #endif
 #ifdef WOLF_PRIVATE_KEY_ID
     byte id[AES_MAX_ID_LEN];

--- a/wolfssl/wolfcrypt/cmac.h
+++ b/wolfssl/wolfcrypt/cmac.h
@@ -56,6 +56,7 @@ struct Cmac {
 #ifdef WOLF_CRYPTO_CB
     int devId;
     void* devCtx;
+    byte cryptoCbSWFallback;
     #ifdef WOLFSSL_CAAM
     byte ctx[32]; /* hold state for save and return */
     word32 blackKey;

--- a/wolfssl/wolfcrypt/curve25519.h
+++ b/wolfssl/wolfcrypt/curve25519.h
@@ -89,6 +89,7 @@ struct curve25519_key {
 #if defined(WOLF_CRYPTO_CB)
     void* devCtx;
     int devId;
+    byte cryptoCbSWFallback;
 #endif
 
 #ifdef WOLFSSL_SE050

--- a/wolfssl/wolfcrypt/des3.h
+++ b/wolfssl/wolfcrypt/des3.h
@@ -111,6 +111,7 @@ struct Des3 {
 #ifdef WOLF_CRYPTO_CB
     int    devId;
     void*  devCtx;
+    byte cryptoCbSWFallback;
 #endif
     void* heap;
 };

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -507,6 +507,7 @@ struct ecc_key {
 #if defined(PLUTON_CRYPTO_ECC) || defined(WOLF_CRYPTO_CB)
     void* devCtx;
     int devId;
+    byte cryptoCbSWFallback;
 #endif
 #if defined(HAVE_PKCS11)
     byte isPkcs11 : 1; /* indicate if PKCS11 is preferred */

--- a/wolfssl/wolfcrypt/ed25519.h
+++ b/wolfssl/wolfcrypt/ed25519.h
@@ -105,6 +105,7 @@ struct ed25519_key {
 #if defined(WOLF_CRYPTO_CB)
     void* devCtx;
     int devId;
+    byte cryptoCbSWFallback;
 #endif
     void *heap;
 #ifdef WOLFSSL_ED25519_PERSISTENT_SHA

--- a/wolfssl/wolfcrypt/hmac.h
+++ b/wolfssl/wolfcrypt/hmac.h
@@ -163,6 +163,7 @@ struct Hmac {
     int     devId;
     void*   devCtx;
     const byte* keyRaw;
+    byte cryptoCbSWFallback;
 #endif
 #ifdef WOLF_PRIVATE_KEY_ID
     byte    id[HMAC_MAX_ID_LEN];

--- a/wolfssl/wolfcrypt/random.h
+++ b/wolfssl/wolfcrypt/random.h
@@ -149,6 +149,7 @@ struct OS_Seed {
     #endif
     #if defined(WOLF_CRYPTO_CB)
         int devId;
+        byte cryptoCbSWFallback;
     #endif
 };
 
@@ -184,6 +185,7 @@ struct WC_RNG {
 #endif
 #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLF_CRYPTO_CB)
     int devId;
+    byte cryptoCbSWFallback;
 #endif
 };
 

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -211,6 +211,7 @@ struct RsaKey {
 #ifdef WOLF_CRYPTO_CB
     void* devCtx;
     int   devId;
+    byte cryptoCbSWFallback;
 #endif
 #if defined(HAVE_PKCS11)
     byte isPkcs11 : 1; /* indicate if PKCS11 is preferred */

--- a/wolfssl/wolfcrypt/sha.h
+++ b/wolfssl/wolfcrypt/sha.h
@@ -155,6 +155,7 @@ struct wc_Sha {
 #ifdef WOLF_CRYPTO_CB
     int    devId;
     void*  devCtx; /* generic crypto callback context */
+    byte cryptoCbSWFallback;
 #endif
 #ifdef WOLFSSL_IMXRT1170_CAAM
     caam_hash_ctx_t ctx;

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -218,6 +218,7 @@ struct wc_Sha256 {
 #ifdef WOLF_CRYPTO_CB
     int    devId;
     void*  devCtx; /* generic crypto callback context */
+    byte cryptoCbSWFallback;
 #endif
 #ifdef WOLFSSL_IMXRT1170_CAAM
     caam_hash_ctx_t ctx;

--- a/wolfssl/wolfcrypt/sha512.h
+++ b/wolfssl/wolfcrypt/sha512.h
@@ -175,6 +175,7 @@ struct wc_Sha512 {
 #ifdef WOLF_CRYPTO_CB
     int    devId;
     void*  devCtx; /* generic crypto callback context */
+    byte cryptoCbSWFallback;
 #endif
 #ifdef WOLFSSL_HASH_FLAGS
     word32 flags; /* enum wc_HashFlags in hash.h */


### PR DESCRIPTION
# Description

add cryptoCbSWFallback byte field to mark when sotware fallback was used, fix ssl using software fallback even when WOLF_CRYPTO_CB_ONLY_RSA or WOLF_CRYPTO_CB_ONLY_ECC are defined

# Testing

Tested with internal cryptocb project

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
