### PR TITLE
Initialize DhKey's to NULL in pk.c

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -37155,7 +37155,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     {
         int decryptRet = WOLFSSL_TICKET_RET_REJECT;
         int ret;
-        InternalTicket* it;
+        InternalTicket* it = NULL;
 #ifdef WOLFSSL_TLS13
         InternalTicket staticIt;
         const WOLFSSL_SESSION* sess = NULL;

--- a/src/pk.c
+++ b/src/pk.c
@@ -7626,7 +7626,7 @@ static int wolfssl_dhparams_to_der(WOLFSSL_DH* dh, unsigned char** out,
     int err = 0;
     byte* der = NULL;
     word32 derSz;
-    DhKey* key;
+    DhKey* key = NULL;
 
     (void)heap;
 
@@ -8306,7 +8306,7 @@ int wolfSSL_DH_generate_parameters_ex(WOLFSSL_DH* dh, int prime_len,
     int generator, void (*callback) (int, int, void *))
 {
     int ret = 1;
-    DhKey* key;
+    DhKey* key = NULL;
 #ifdef WOLFSSL_SMALL_STACK
     WC_RNG* tmpRng = NULL;
 #else


### PR DESCRIPTION
# Description

Fixes for uninitialized variable compilation issues.

Fixes zd#16674

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
