### PR TITLE
Add wolfcrypt SHA support for ESP32-C2/ESP8684, other minor updates

### DIFF
--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_test/main/main.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_test/main/main.c
@@ -36,6 +36,10 @@
 #include <wolfcrypt/test/test.h>
 #include <wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h>
 
+/* set to 0 for one benchmark,
+** set to 1 for continuous benchmark loop */
+#define TEST_LOOP 0
+
 /*
 ** the wolfssl component can be installed in either:
 **
@@ -190,7 +194,10 @@ void app_main(void)
 #if defined(NO_ESP32_CRYPT)
     ESP_LOGI(TAG, "NO_ESP32_CRYPT defined! HW acceleration DISABLED.");
 #else
-    #if defined(CONFIG_IDF_TARGET_ESP32C3)
+    #if defined(CONFIG_IDF_TARGET_ESP32C2)
+        ESP_LOGI(TAG, "ESP32_CRYPT is enabled for ESP32-C2.");
+
+    #elif defined(CONFIG_IDF_TARGET_ESP32C3)
         ESP_LOGI(TAG, "ESP32_CRYPT is enabled for ESP32-C3.");
 
     #elif defined(CONFIG_IDF_TARGET_ESP32S2)
@@ -239,8 +246,11 @@ void app_main(void)
 
         loops++;
     }
-    while (ret == 0);
-    ESP_LOGI(TAG, "loops = %d", loops);
+    while (TEST_LOOP && (ret == 0));
+
+#if defined TEST_LOOP && (TEST_LOOP == 1)
+    ESP_LOGI(TAG, "Test loops completed: %d", loops);
+#endif
 
     /* note wolfCrypt_Cleanup() should always be called when finished.
     ** This is called at the end of wolf_test_task();
@@ -266,8 +276,12 @@ void app_main(void)
                                         - (uxTaskGetStackHighWaterMark(NULL)));
 #endif
 
+#ifdef WOLFSSL_ESPIDF_EXIT_MESSAGE
+    ESP_LOGI(TAG, WOLFSSL_ESPIDF_EXIT_MESSAGE);
+#else
     ESP_LOGI(TAG, "\n\nDone!\n\n"
                   "If running from idf.py monitor, press twice: Ctrl+]");
+#endif
 
     /* done */
     while (1) {

--- a/wolfcrypt/src/port/Espressif/esp32_util.c
+++ b/wolfcrypt/src/port/Espressif/esp32_util.c
@@ -592,9 +592,10 @@ int ShowExtendedSystemInfo(void)
     ESP_LOGI(TAG, "CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ = %u MHz",
                    CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ
             );
-#elif defined(CONFIG_IDF_TARGET_ESP32C3)
-    ESP_LOGI(TAG, "CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ = %u MHz",
-                   CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ
+#elif defined(CONFIG_IDF_TARGET_ESP32C3) && \
+      defined(CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ)
+    ESP_LOGI(TAG, "CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ = %u MHz",
+                   CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ
             );
 
 #elif defined(CONFIG_IDF_TARGET_ESP32C6)

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -644,9 +644,15 @@ int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)
         #endif
 
         #if defined(LITTLE_ENDIAN_ORDER) && !defined(FREESCALE_MMCAU_SHA)
-            #if (defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6)) \
-              && defined(WOLFSSL_ESP32_CRYPT) && \
+            #if ( defined(CONFIG_IDF_TARGET_ESP32C2) || \
+                  defined(CONFIG_IDF_TARGET_ESP8684) || \
+                  defined(CONFIG_IDF_TARGET_ESP32C3) || \
+                  defined(CONFIG_IDF_TARGET_ESP32C6)    \
+                ) && \
+                 defined(WOLFSSL_ESP32_CRYPT) && \
                 !defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
+                /* For Espressif RISC-V Targets, we *may* need to reverse bytes
+                 * depending on if HW is active or not. */
                 if (esp_sha_need_byte_reversal(&sha->ctx))
             #endif
             {
@@ -722,9 +728,15 @@ int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)
     #endif
 
     #if defined(LITTLE_ENDIAN_ORDER) && !defined(FREESCALE_MMCAU_SHA)
-        #if (defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6)) && \
+        #if ( defined(CONFIG_IDF_TARGET_ESP32C2) || \
+              defined(CONFIG_IDF_TARGET_ESP8684) || \
+              defined(CONFIG_IDF_TARGET_ESP32C3) || \
+              defined(CONFIG_IDF_TARGET_ESP32C6)    \
+            ) && \
              defined(WOLFSSL_ESP32_CRYPT) && \
             !defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
+            /* For Espressif RISC-V Targets, we *may* need to reverse bytes
+             * depending on if HW is active or not. */
             if (esp_sha_need_byte_reversal(&sha->ctx))
         #endif
         {
@@ -765,9 +777,15 @@ int wc_ShaFinalRaw(wc_Sha* sha, byte* hash)
     }
 
 #ifdef LITTLE_ENDIAN_ORDER
-    #if (defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6)) && \
+    #if ( defined(CONFIG_IDF_TARGET_ESP32C2) || \
+          defined(CONFIG_IDF_TARGET_ESP8684) || \
+          defined(CONFIG_IDF_TARGET_ESP32C3) || \
+          defined(CONFIG_IDF_TARGET_ESP32C6)    \
+        ) && \
          defined(WOLFSSL_ESP32_CRYPT) && \
         !defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
+        /* For Espressif RISC-V Targets, we *may* need to reverse bytes
+         * depending on if HW is active or not. */
         if (esp_sha_need_byte_reversal(&sha->ctx))
     #endif
     {
@@ -834,9 +852,15 @@ int wc_ShaFinal(wc_Sha* sha, byte* hash)
     #endif
 
     #if defined(LITTLE_ENDIAN_ORDER) && !defined(FREESCALE_MMCAU_SHA)
-        #if (defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6)) && \
+        #if ( defined(CONFIG_IDF_TARGET_ESP32C2) || \
+              defined(CONFIG_IDF_TARGET_ESP8684) || \
+              defined(CONFIG_IDF_TARGET_ESP32C3) || \
+              defined(CONFIG_IDF_TARGET_ESP32C6)    \
+            ) && \
              defined(WOLFSSL_ESP32_CRYPT) && \
             !defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
+            /* For Espressif RISC-V Targets, we *may* need to reverse bytes
+             * depending on if HW is active or not. */
             if (esp_sha_need_byte_reversal(&sha->ctx))
         #endif
         {
@@ -875,9 +899,15 @@ int wc_ShaFinal(wc_Sha* sha, byte* hash)
 #endif
 
 #if defined(LITTLE_ENDIAN_ORDER) && !defined(FREESCALE_MMCAU_SHA)
-    #if (defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6)) && \
+    #if ( defined(CONFIG_IDF_TARGET_ESP32C2) || \
+          defined(CONFIG_IDF_TARGET_ESP8684) || \
+          defined(CONFIG_IDF_TARGET_ESP32C3) || \
+          defined(CONFIG_IDF_TARGET_ESP32C6)    \
+        ) && \
          defined(WOLFSSL_ESP32_CRYPT) && \
         !defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
+        /* For Espressif RISC-V Targets, we *may* need to reverse bytes
+         * depending on if HW is active or not. */
         if (esp_sha_need_byte_reversal(&sha->ctx))
     #endif
     { /* reminder local also points to sha->buffer  */
@@ -902,8 +932,12 @@ int wc_ShaFinal(wc_Sha* sha, byte* hash)
 #endif
 
 
-#if (defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6)) && \
-     defined(WOLFSSL_ESP32_CRYPT) && !defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
+#if ( defined(CONFIG_IDF_TARGET_ESP32C2) || \
+      defined(CONFIG_IDF_TARGET_ESP8684) || \
+      defined(CONFIG_IDF_TARGET_ESP32C3) || \
+      defined(CONFIG_IDF_TARGET_ESP32C6)    \
+    ) && \
+    defined(WOLFSSL_ESP32_CRYPT) && !defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
 if (sha->ctx.mode == ESP32_SHA_HW) {
     #if defined(WOLFSSL_SUPER_VERBOSE_DEBUG)
     {
@@ -938,9 +972,14 @@ if (sha->ctx.mode == ESP32_SHA_HW) {
 #endif
 
 #ifdef LITTLE_ENDIAN_ORDER
-    #if (defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6)) && \
-         defined(WOLFSSL_ESP32_CRYPT) && \
-        !defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
+    #if ( defined(CONFIG_IDF_TARGET_ESP32C2) || \
+          defined(CONFIG_IDF_TARGET_ESP8684) || \
+          defined(CONFIG_IDF_TARGET_ESP32C3) || \
+          defined(CONFIG_IDF_TARGET_ESP32C6)    \
+        ) && \
+        defined(WOLFSSL_ESP32_CRYPT) && !defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
+        /* For Espressif RISC-V Targets, we *may* need to reverse bytes
+         * depending on if HW is active or not. */
         if (esp_sha_need_byte_reversal(&sha->ctx))
     #endif
     {

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -1073,11 +1073,16 @@ static int InitSha256(wc_Sha256* sha256)
                           (defined(HAVE_INTEL_AVX1) || defined(HAVE_INTEL_AVX2))
                 if (!IS_INTEL_AVX1(intel_flags) && !IS_INTEL_AVX2(intel_flags))
                 #endif
-                #if (defined(CONFIG_IDF_TARGET_ESP32C3) || \
-                     defined(CONFIG_IDF_TARGET_ESP32C6)) && \
-                    defined(WOLFSSL_ESP32_CRYPT) && \
+                #if ( defined(CONFIG_IDF_TARGET_ESP32C2) || \
+                      defined(CONFIG_IDF_TARGET_ESP8684) || \
+                      defined(CONFIG_IDF_TARGET_ESP32C3) || \
+                      defined(CONFIG_IDF_TARGET_ESP32C6)    \
+                    ) && \
+                    defined(WOLFSSL_ESP32_CRYPT) &&         \
                    !defined(NO_WOLFSSL_ESP32_CRYPT_HASH) && \
                    !defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA256)
+                /* For Espressif RISC-V Targets, we *may* need to reverse bytes
+                 * depending on if HW is active or not. */
                     if (esp_sha_need_byte_reversal(&sha256->ctx))
                 #endif
                 {
@@ -1179,11 +1184,16 @@ static int InitSha256(wc_Sha256* sha256)
             #endif
 
             #if defined(LITTLE_ENDIAN_ORDER) && !defined(FREESCALE_MMCAU_SHA)
-                #if (defined(CONFIG_IDF_TARGET_ESP32C3) || \
-                     defined(CONFIG_IDF_TARGET_ESP32C6)) && \
-                    defined(WOLFSSL_ESP32_CRYPT) && \
+                #if ( defined(CONFIG_IDF_TARGET_ESP32C2) || \
+                      defined(CONFIG_IDF_TARGET_ESP8684) || \
+                      defined(CONFIG_IDF_TARGET_ESP32C3) || \
+                      defined(CONFIG_IDF_TARGET_ESP32C6)    \
+                    ) && \
+                    defined(WOLFSSL_ESP32_CRYPT)         && \
                    !defined(NO_WOLFSSL_ESP32_CRYPT_HASH) && \
                    !defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA256)
+                /* For Espressif RISC-V Targets, we *may* need to reverse bytes
+                 * depending on if HW is active or not. */
                     if (esp_sha_need_byte_reversal(&sha256->ctx))
                 #endif
                 #if defined(WOLFSSL_X86_64_BUILD) && \
@@ -1297,11 +1307,16 @@ static int InitSha256(wc_Sha256* sha256)
         #endif
 
         #if defined(LITTLE_ENDIAN_ORDER) && !defined(FREESCALE_MMCAU_SHA)
-            #if (defined(CONFIG_IDF_TARGET_ESP32C3) || \
-                 defined(CONFIG_IDF_TARGET_ESP32C6))  && \
-                defined(WOLFSSL_ESP32_CRYPT) && \
+            #if ( defined(CONFIG_IDF_TARGET_ESP32C2) || \
+                  defined(CONFIG_IDF_TARGET_ESP8684) || \
+                  defined(CONFIG_IDF_TARGET_ESP32C3) || \
+                  defined(CONFIG_IDF_TARGET_ESP32C6)    \
+                )  && \
+                defined(WOLFSSL_ESP32_CRYPT) &&         \
                !defined(NO_WOLFSSL_ESP32_CRYPT_HASH) && \
                !defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA256)
+            /* For Espressif RISC-V Targets, we *may* need to reverse bytes
+             * depending on if HW is active or not. */
                 if (esp_sha_need_byte_reversal(&sha256->ctx))
             #endif
             #if defined(WOLFSSL_X86_64_BUILD) && defined(USE_INTEL_SPEEDUP) && \
@@ -1350,11 +1365,16 @@ static int InitSha256(wc_Sha256* sha256)
 
         /* store lengths */
     #if defined(LITTLE_ENDIAN_ORDER) && !defined(FREESCALE_MMCAU_SHA)
-        #if (defined(CONFIG_IDF_TARGET_ESP32C3) || \
-             defined(CONFIG_IDF_TARGET_ESP32C6)) && \
-            defined(WOLFSSL_ESP32_CRYPT) && \
+        #if ( defined(CONFIG_IDF_TARGET_ESP32C2) || \
+              defined(CONFIG_IDF_TARGET_ESP8684) || \
+              defined(CONFIG_IDF_TARGET_ESP32C3) || \
+              defined(CONFIG_IDF_TARGET_ESP32C6)    \
+            ) && \
+            defined(WOLFSSL_ESP32_CRYPT) &&         \
            !defined(NO_WOLFSSL_ESP32_CRYPT_HASH) && \
            !defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA256)
+            /* For Espressif RISC-V Targets, we *may* need to reverse bytes
+             * depending on if HW is active or not. */
             if (esp_sha_need_byte_reversal(&sha256->ctx))
         #endif
         #if defined(WOLFSSL_X86_64_BUILD) && defined(USE_INTEL_SPEEDUP) && \
@@ -1373,11 +1393,16 @@ static int InitSha256(wc_Sha256* sha256)
 
     /* Only the ESP32-C3 with HW enabled may need pad size byte order reversal
      * depending on HW or SW mode */
-    #if (defined(CONFIG_IDF_TARGET_ESP32C3) || \
-         defined(CONFIG_IDF_TARGET_ESP32C6)) && \
-         defined(WOLFSSL_ESP32_CRYPT) && \
+    #if ( defined(CONFIG_IDF_TARGET_ESP32C2) || \
+          defined(CONFIG_IDF_TARGET_ESP8684) || \
+          defined(CONFIG_IDF_TARGET_ESP32C3) || \
+          defined(CONFIG_IDF_TARGET_ESP32C6)    \
+        ) && \
+        defined(WOLFSSL_ESP32_CRYPT) &&         \
        !defined(NO_WOLFSSL_ESP32_CRYPT_HASH) && \
        !defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA256)
+        /* For Espressif RISC-V Targets, we *may* need to reverse bytes
+         * depending on if HW is active or not. */
         if (sha256->ctx.mode == ESP32_SHA_HW) {
         #if defined(WOLFSSL_SUPER_VERBOSE_DEBUG)
             ESP_LOGV(TAG, "Start: Reverse PAD SIZE Endianness.");
@@ -1442,11 +1467,16 @@ static int InitSha256(wc_Sha256* sha256)
         }
 
     #ifdef LITTLE_ENDIAN_ORDER
-        #if (defined(CONFIG_IDF_TARGET_ESP32C3) || \
-             defined(CONFIG_IDF_TARGET_ESP32C6)) && \
-            defined(WOLFSSL_ESP32_CRYPT) && \
+        #if ( defined(CONFIG_IDF_TARGET_ESP32C2) || \
+              defined(CONFIG_IDF_TARGET_ESP8684) || \
+              defined(CONFIG_IDF_TARGET_ESP32C3) || \
+              defined(CONFIG_IDF_TARGET_ESP32C6)    \
+            ) && \
+            defined(WOLFSSL_ESP32_CRYPT) &&         \
            !defined(NO_WOLFSSL_ESP32_CRYPT_HASH) && \
            !defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA256)
+            /* For Espressif RISC-V Targets, we *may* need to reverse bytes
+             * depending on if HW is active or not. */
             if (esp_sha_need_byte_reversal(&sha256->ctx))
         #endif
             {
@@ -1497,10 +1527,16 @@ static int InitSha256(wc_Sha256* sha256)
         }
 
     #if defined(LITTLE_ENDIAN_ORDER)
-        #if (defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6))  && \
-            defined(WOLFSSL_ESP32_CRYPT) && \
+        #if ( defined(CONFIG_IDF_TARGET_ESP32C2) || \
+              defined(CONFIG_IDF_TARGET_ESP8684) || \
+              defined(CONFIG_IDF_TARGET_ESP32C3) || \
+              defined(CONFIG_IDF_TARGET_ESP32C6)    \
+            )  && \
+            defined(WOLFSSL_ESP32_CRYPT) &&         \
            !defined(NO_WOLFSSL_ESP32_CRYPT_HASH) && \
            !defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA256)
+            /* For Espressif RISC-V Targets, we *may* need to reverse bytes
+             * depending on if HW is active or not. */
             if (esp_sha_need_byte_reversal(&sha256->ctx))
         #endif
             {
@@ -1792,11 +1828,11 @@ static int InitSha256(wc_Sha256* sha256)
         }
     #endif /* WOLFSSL_ASYNC_CRYPT */
 
-    #if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW) && \
-       (!defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA256) || \
-        !defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA224))
+    #if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW) &&      \
+       ( !defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA256) || \
+         !defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA224) )
 
-        /* nothing enabled here for C3 success */
+        /* nothing enabled here for RISC-V C2/C3/C6 success */
     #endif
 
         ret = Sha256Final((wc_Sha256*)sha224);
@@ -1804,11 +1840,15 @@ static int InitSha256(wc_Sha256* sha256)
             return ret;
 
     #if defined(LITTLE_ENDIAN_ORDER)
-        #if (defined(CONFIG_IDF_TARGET_ESP32C3) || \
-             defined(CONFIG_IDF_TARGET_ESP32C6))  && \
+        #if ( defined(CONFIG_IDF_TARGET_ESP32C2) || \
+              defined(CONFIG_IDF_TARGET_ESP8684) || \
+              defined(CONFIG_IDF_TARGET_ESP32C3) || \
+              defined(CONFIG_IDF_TARGET_ESP32C6)    \
+            )  && \
             defined(WOLFSSL_ESP32_CRYPT) && \
-       (!defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA256) || \
-        !defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA224))
+           (!defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA256) || \
+            !defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA224)    \
+           )
             if (esp_sha_need_byte_reversal(&sha224->ctx))
         #endif
         {

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -1613,20 +1613,23 @@ int wc_Sha512Copy(wc_Sha512* src, wc_Sha512* dst)
     if (ret == 0) {
         ret = esp_sha512_ctx_copy(src, dst);
     }
-    #elif defined(CONFIG_IDF_TARGET_ESP32C3) || \
+    #elif defined(CONFIG_IDF_TARGET_ESP32C2) || \
+          defined(CONFIG_IDF_TARGET_ESP8684) || \
+          defined(CONFIG_IDF_TARGET_ESP32C3) || \
           defined(CONFIG_IDF_TARGET_ESP32C6)
         ESP_LOGV(TAG, "No SHA-512 HW on the ESP32-C3");
+
     #elif defined(CONFIG_IDF_TARGET_ESP32S2) || \
           defined(CONFIG_IDF_TARGET_ESP32S3)
-    if (ret == 0) {
-        ret = esp_sha512_ctx_copy(src, dst);
-    }
+        if (ret == 0) {
+            ret = esp_sha512_ctx_copy(src, dst);
+        }
     #else
         ESP_LOGW(TAG, "No SHA384 HW or not yet implemented for %s",
                        CONFIG_IDF_TARGET);
     #endif
 
-#endif
+#endif /* WOLFSSL_USE_ESP32_CRYPT_HASH_HW */
 
 #ifdef WOLFSSL_HASH_FLAGS
      dst->flags |= WC_HASH_FLAG_ISCOPY;
@@ -1893,7 +1896,9 @@ int wc_Sha384Copy(wc_Sha384* src, wc_Sha384* dst)
 #if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
     #if defined(CONFIG_IDF_TARGET_ESP32)
         esp_sha384_ctx_copy(src, dst);
-    #elif defined(CONFIG_IDF_TARGET_ESP32C3) || \
+    #elif defined(CONFIG_IDF_TARGET_ESP32C2) || \
+          defined(CONFIG_IDF_TARGET_ESP8684) || \
+          defined(CONFIG_IDF_TARGET_ESP32C3) || \
           defined(CONFIG_IDF_TARGET_ESP32C6)
         ESP_LOGV(TAG, "No SHA-384 HW on the ESP32-C3");
     #elif defined(CONFIG_IDF_TARGET_ESP32S2) || \


### PR DESCRIPTION
# Description

Modifies wolfcrypt SHA to add support for ESP32-C2 (aka ESP8684). 

Note that although `CONFIG_IDF_TARGET_ESP8684` is listed, and `ESP8684` is printed on the SoC, and the [manual](https://www.espressif.com/sites/default/files/documentation/esp8684_technical_reference_manual_en.pdf) names it as `ESP8684` the actual expected target in ESP-IDF is `esp32c2`. The `ESP8684` is explicitly stated here for clarity and just in case the ESP-IDF changes the notation at some point in the future.

Fixes zd# n/a

# Testing

How did you test? 

Tested with my new hardware jig for all ESP-IDF v5.1 targets.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
