### PR TITLE
20231219-clang-analyzer-optin.core.EnumCastOutOfRange

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -16393,7 +16393,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         /* cast so that compiler reminds us of unimplemented values */
         switch ((enum SignatureAlgorithm)sigType) {
         case anonymous_sa_algo:
-            *sigAlgo = (enum Key_Sum)0;
+            *sigAlgo = ANONk;
             break;
         case rsa_sa_algo:
             *sigAlgo = RSAk;

--- a/tests/api.c
+++ b/tests/api.c
@@ -29064,7 +29064,9 @@ static int test_wc_SignatureGetSize_ecc(void)
     ExpectIntGT(wc_SignatureGetSize(sig_type, &ecc, key_len), 0);
 
     /* Test bad args */
+    /* // NOLINTBEGIN(clang-analyzer-optin.core.EnumCastOutOfRange) */
     sig_type = (enum wc_SignatureType) 100;
+    /* // NOLINTEND(clang-analyzer-optin.core.EnumCastOutOfRange) */
     ExpectIntEQ(wc_SignatureGetSize(sig_type, &ecc, key_len), BAD_FUNC_ARG);
     sig_type = WC_SIGNATURE_TYPE_ECC;
     ExpectIntEQ(wc_SignatureGetSize(sig_type, NULL, key_len), 0);
@@ -29129,7 +29131,9 @@ static int test_wc_SignatureGetSize_rsa(void)
     ExpectIntGT(wc_SignatureGetSize(sig_type, &rsa_key, key_len), 0);
 
     /* Test bad args */
+    /* // NOLINTBEGIN(clang-analyzer-optin.core.EnumCastOutOfRange) */
     sig_type = (enum wc_SignatureType)100;
+    /* // NOLINTEND(clang-analyzer-optin.core.EnumCastOutOfRange) */
     ExpectIntEQ(wc_SignatureGetSize(sig_type, &rsa_key, key_len), BAD_FUNC_ARG);
     sig_type = WC_SIGNATURE_TYPE_RSA;
     #ifndef HAVE_USER_RSA

--- a/tests/srp.c
+++ b/tests/srp.c
@@ -128,9 +128,11 @@ static void test_SrpInit(void)
     /* invalid params */
     AssertIntEQ(BAD_FUNC_ARG, wc_SrpInit(NULL, SRP_TYPE_TEST_DEFAULT,
                                          SRP_CLIENT_SIDE));
+    /* // NOLINTBEGIN(clang-analyzer-optin.core.EnumCastOutOfRange) */
     AssertIntEQ(BAD_FUNC_ARG, wc_SrpInit(&srp, (SrpType)255, SRP_CLIENT_SIDE));
     AssertIntEQ(BAD_FUNC_ARG, wc_SrpInit(&srp, SRP_TYPE_TEST_DEFAULT,
                                          (SrpSide)255));
+    /* // NOLINTEND(clang-analyzer-optin.core.EnumCastOutOfRange) */
 
     /* success */
     AssertIntEQ(0, wc_SrpInit(&srp, SRP_TYPE_TEST_DEFAULT, SRP_CLIENT_SIDE));

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1124,6 +1124,7 @@ enum Block_Sum {
 
 
 enum Key_Sum {
+    ANONk             = 0,
     DSAk              = 515,
     RSAk              = 645,
     RSAPSSk           = 654,


### PR DESCRIPTION
`wolfssl/wolfcrypt/asn.h`, `src/ssl.c`: add `ANONk` to `enum Key_Sum`, and use the new value in `wolfSSL_get_sigalg_info()`, fixing `clang-analyzer-optin.core.EnumCastOutOfRange`.

add suppressions in tests for expected `clang-analyzer-optin.core.EnumCastOutOfRange`'s.

tested with `wolfssl-multi-test.sh ... '.*clang-tidy.*'`.
