### PR TITLE
Remove obsolete mkdir call

### DIFF
--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -49,7 +49,6 @@ fi
 %install
 %{__rm} -rf %{buildroot}
 %{__make} install  DESTDIR="%{buildroot}" AM_INSTALL_PROGRAM_FLAGS=""
-mkdir -p $RPM_BUILD_ROOT/
 %{__rm} -f %{buildroot}/%{_libdir}/libwolfssl@LIBSUFFIX@.la
 %{__rm} -f %{buildroot}/%{_libdir}/libwolfssl.a
 


### PR DESCRIPTION
# Description

Remove obsolete mkdir call

Fixes https://github.com/wolfSSL/wolfssl/pull/7055#discussion_r1425844138

# Testing

`make rpm` and `make deb`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
