### PR TITLE
20231222-clang-unreachable-code-aggressive

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -15762,10 +15762,11 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             return BAD_FUNC_ARG;
         }
 
-        verify = GET_VERIFY_SETTING_CTX(ctx);
-        if (WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS &
-                 WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY)
+        #if (WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS & WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY)
             verify = VERIFY_SKIP_DATE;
+        #else
+            verify = GET_VERIFY_SETTING_CTX(ctx);
+        #endif
 
         if (format == WOLFSSL_FILETYPE_PEM)
             return ProcessChainBuffer(ctx, in, sz, format, TRUSTED_PEER_TYPE,

--- a/tests/api.c
+++ b/tests/api.c
@@ -27684,6 +27684,14 @@ static int myCEKwrapFunc(PKCS7* pkcs7, byte* cek, word32 cekSz, byte* keyId,
 {
     int ret = -1;
 
+    (void)cekSz;
+    (void)cek;
+    (void)outSz;
+    (void)keyIdSz;
+    (void)direction;
+    (void)orginKey; /* used with KAKRI */
+    (void)orginKeySz;
+
     if (out == NULL)
         return BAD_FUNC_ARG;
 
@@ -27715,15 +27723,6 @@ static int myCEKwrapFunc(PKCS7* pkcs7, byte* cek, word32 cekSz, byte* keyId,
             WOLFSSL_MSG("Unsupported key wrap algorithm in example");
             return BAD_KEYWRAP_ALG_E;
     };
-
-    (void)cekSz;
-    (void)cek;
-    (void)outSz;
-    (void)keyIdSz;
-    (void)direction;
-    (void)orginKey; /* used with KAKRI */
-    (void)orginKeySz;
-    return ret;
 }
 #endif /* HAVE_PKCS7 && !NO_AES && HAVE_AES_CBC && !NO_AES_256 */
 


### PR DESCRIPTION
fixes for `clang` `-Wunreachable-code-aggressive` (`-Wunreachable-code`/`clang-diagnostic-unreachable-code` in `src/ssl.c`:`wolfSSL_CTX_load_verify_buffer_ex()` and `-Wunreachable-code`/`clang-diagnostic-unreachable-code-return` in `api.c`:`myCEKwrapFunc()`).

tested with `wolfssl-multi-test.sh ... super-quick-check` with new code adding supplementary `clang`-only warnings on `clang`/`clang-tidy` scenarios:
```
    CLANG_EXTRA_ARGS=('-Wunreachable-code-aggressive' '-Wthread-safety' '-Wloop-analysis' '-Wenum-compare-conditional' '-fcolor-diagnostics' '-fcomplete-member-pointers' '-Wheader-hygiene' '-Wstring-conversion' '-Wtautological-overlap-compare')
```
The new warning coverage is derived from extra warnings active in Chromium builds as of chromium-120.0.6099.129 (Chromium is now `clang`-native).
