### PR TITLE
SHA256 uses ForceZero now too

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2919,7 +2919,7 @@ extern void uITRON4_free(void *p) ;
 #if defined(WOLFCRYPT_ONLY) && defined(NO_AES) && !defined(WOLFSSL_SHA384) && \
     !defined(WOLFSSL_SHA512) && defined(WC_NO_RNG) && \
     !defined(WOLFSSL_SP_MATH) && !defined(WOLFSSL_SP_MATH_ALL) \
-    && !defined(USE_FAST_MATH)
+    && !defined(USE_FAST_MATH) && defined(NO_SHA256)
     #undef  WOLFSSL_NO_FORCE_ZERO
     #define WOLFSSL_NO_FORCE_ZERO
 #endif


### PR DESCRIPTION
Building using the following configure :

```
 ./configure --disable-filesystem --enable-singlethreaded --disable-examples --disable-crypttests --disable-benchmark --enable-static CPPFLAGS='-DNO_ERROR_STRINGS -DIGNORE_NAME_CONSTRAINTS -DNO_ASN_TIME -DUSE_SLOW_SHA -DUSE_SLOW_SHA256 -Os -ffunction-sections -fdata-sections' --disable-chacha --disable-poly1305 --disable-dh --disable-des3 --disable-sha512 --disable-rsa --disable-ecc --disable-sha3 --disable-sha224 --disable-md5 --disable-sha --disable-sha384 --disable-rng --disable-sp --disable-fastmath --disable-heapmath --disable-aesctr --disable-aesgcm --disable-pkcs12 --disable-aes --disable-asn --disable-kdf --disable-sp-math-all --disable-harden --disable-asm --enable-cryptonly
 ```
 
Before this change results in :

```
 nm src/.libs/libwolfssl.a | grep ForceZero
                 U ForceZero
                 U ForceZero
```
