### PR TITLE
20231224-clang-unreachable-code-aggressive

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -30338,9 +30338,9 @@ int wolfSSL_curve_is_disabled(const WOLFSSL* ssl, word16 curve_id)
     }
     if (curve_id >= 32) {
         /* 0 is for invalid and 1-14 aren't used otherwise. */
-        return (ssl->disabledCurves & (1 << (curve_id - 32))) != 0;
+        return (ssl->disabledCurves & (1U << (curve_id - 32))) != 0;
     }
-    return (ssl->disabledCurves & (1 << curve_id)) != 0;
+    return (ssl->disabledCurves & (1U << curve_id)) != 0;
 }
 
 #if (defined(HAVE_ECC) || \

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -1455,8 +1455,8 @@ exit:
 
     return args.return_code;
 #else
-    return NOT_COMPILED_IN;
     (void)argc;
     (void)argv;
+    return NOT_COMPILED_IN;
 #endif /* !NO_WOLFSSL_SERVER && !NO_WOLFSSL_CLIENT */
 }

--- a/wolfcrypt/src/chacha.c
+++ b/wolfcrypt/src/chacha.c
@@ -200,6 +200,7 @@ int wc_Chacha_SetKey(ChaCha* ctx, const byte* key, word32 keySz)
     return 0;
 }
 
+#ifndef USE_INTEL_CHACHA_SPEEDUP
 /**
   * Converts word into bytes with rotations having been done.
   */
@@ -228,6 +229,7 @@ static WC_INLINE void wc_Chacha_wordtobyte(word32 x[CHACHA_CHUNK_WORDS],
 #endif
     }
 }
+#endif /* !USE_INTEL_CHACHA_SPEEDUP */
 
 
 #ifdef HAVE_XCHACHA
@@ -325,6 +327,7 @@ extern void chacha_encrypt_avx2(ChaCha* ctx, const byte* m, byte* c,
 #endif
 
 
+#ifndef USE_INTEL_CHACHA_SPEEDUP
 /**
   * Encrypt a stream of bytes
   */
@@ -372,6 +375,8 @@ static void wc_Chacha_encrypt_bytes(ChaCha* ctx, const byte* m, byte* c,
         ctx->left = CHACHA_CHUNK_BYTES - bytes;
     }
 }
+#endif /* !USE_INTEL_CHACHA_SPEEDUP */
+
 
 /**
   * API to encrypt/decrypt a message of any size.
@@ -423,10 +428,10 @@ int wc_Chacha_Process(ChaCha* ctx, byte* output, const byte* input,
         chacha_encrypt_x64(ctx, input, output, msglen);
         return 0;
     }
-#endif
+#else
     wc_Chacha_encrypt_bytes(ctx, input, output, msglen);
-
     return 0;
+#endif
 }
 
 void wc_Chacha_purge_current_block(ChaCha* ctx) {

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -356,7 +356,7 @@ static int InitSha256(wc_Sha256* sha256)
         intel_flags = cpuid_get_flags();
 
     #ifdef HAVE_INTEL_AVX2
-        if (1 && IS_INTEL_AVX2(intel_flags)) {
+        if (IS_INTEL_AVX2(intel_flags)) {
         #ifdef HAVE_INTEL_RORX
             if (IS_INTEL_BMI2(intel_flags)) {
                 Transform_Sha256_p = Transform_Sha256_AVX2_RORX;
@@ -365,27 +365,29 @@ static int InitSha256(wc_Sha256* sha256)
             }
             else
         #endif
-            if (1)
             {
                 Transform_Sha256_p = Transform_Sha256_AVX2;
                 Transform_Sha256_Len_p = Transform_Sha256_AVX2_Len;
                 Transform_Sha256_is_vectorized = 1;
             }
-        #ifdef HAVE_INTEL_RORX
-            else {
-                Transform_Sha256_p = Transform_Sha256_AVX1_RORX;
-                Transform_Sha256_Len_p = Transform_Sha256_AVX1_RORX_Len;
-                Transform_Sha256_is_vectorized = 1;
-            }
-        #endif
         }
         else
     #endif
     #ifdef HAVE_INTEL_AVX1
         if (IS_INTEL_AVX1(intel_flags)) {
-            Transform_Sha256_p = Transform_Sha256_AVX1;
-            Transform_Sha256_Len_p = Transform_Sha256_AVX1_Len;
-            Transform_Sha256_is_vectorized = 1;
+        #ifdef HAVE_INTEL_RORX
+            if (IS_INTEL_BMI2(intel_flags)) {
+                Transform_Sha256_p = Transform_Sha256_AVX1_RORX;
+                Transform_Sha256_Len_p = Transform_Sha256_AVX1_RORX_Len;
+                Transform_Sha256_is_vectorized = 1;
+            }
+            else
+        #endif
+            {
+                Transform_Sha256_p = Transform_Sha256_AVX1;
+                Transform_Sha256_Len_p = Transform_Sha256_AVX1_Len;
+                Transform_Sha256_is_vectorized = 1;
+            }
         }
         else
     #endif

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -452,32 +452,36 @@ static int InitSha512_256(wc_Sha512* sha512)
             }
             else
         #endif
-            if (1) {
+            {
                 Transform_Sha512_p = Transform_Sha512_AVX2;
                 Transform_Sha512_Len_p = Transform_Sha512_AVX2_Len;
                 Transform_Sha512_is_vectorized = 1;
             }
-        #ifdef HAVE_INTEL_RORX
-            else {
-                Transform_Sha512_p = Transform_Sha512_AVX1_RORX;
-                Transform_Sha512_Len_p = Transform_Sha512_AVX1_RORX_Len;
-                Transform_Sha512_is_vectorized = 1;
-            }
-        #endif
         }
         else
     #endif
     #if defined(HAVE_INTEL_AVX1)
         if (IS_INTEL_AVX1(intel_flags)) {
-            Transform_Sha512_p = Transform_Sha512_AVX1;
-            Transform_Sha512_Len_p = Transform_Sha512_AVX1_Len;
-            Transform_Sha512_is_vectorized = 1;
+        #ifdef HAVE_INTEL_RORX
+            if (IS_INTEL_BMI2(intel_flags)) {
+                Transform_Sha512_p = Transform_Sha512_AVX1_RORX;
+                Transform_Sha512_Len_p = Transform_Sha512_AVX1_RORX_Len;
+                Transform_Sha512_is_vectorized = 1;
+            }
+            else
+        #endif
+            {
+                Transform_Sha512_p = Transform_Sha512_AVX1;
+                Transform_Sha512_Len_p = Transform_Sha512_AVX1_Len;
+                Transform_Sha512_is_vectorized = 1;
+            }
         }
         else
     #endif
         {
             Transform_Sha512_p = _Transform_Sha512;
-            Transform_Sha512_is_vectorized = 1;
+            Transform_Sha512_Len_p = NULL;
+            Transform_Sha512_is_vectorized = 0;
         }
 
         transform_check = 1;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -6139,9 +6139,15 @@ WOLFSSL_LOCAL int SetECKeyExternal(WOLFSSL_EC_KEY* eckey);
 
 #if defined(OPENSSL_EXTRA) || defined(HAVE_CURL)
 WOLFSSL_LOCAL int wolfSSL_curve_is_disabled(const WOLFSSL* ssl,
-                                            word16 named_curve);
+                                            word16 curve_id);
 #else
-#define wolfSSL_curve_is_disabled(ssl, c)   ((void)(ssl), (void)(c), 0)
+static WC_INLINE int wolfSSL_curve_is_disabled(const WOLFSSL* ssl,
+                                               word16 curve_id)
+{
+    (void)ssl;
+    (void)curve_id;
+    return 0;
+}
 #endif
 
 WOLFSSL_LOCAL WC_RNG* WOLFSSL_RSA_GetRNG(WOLFSSL_RSA *rsa, WC_RNG **tmpRNG,


### PR DESCRIPTION
more fixes for `clang -Wunreachable-code-aggressive`:

`tests/suites.c`: in `SuiteTest()`, swap order of `(void)`s and `return`.

`wolfcrypt/src/chacha.c`: gate out unreachable C `wc_Chacha_encrypt_bytes()` call in `wc_Chacha_Process`, and gate out unused implementations of `wc_Chacha_wordtobyte()` and `wc_Chacha_encrypt_bytes()`, when `defined(USE_INTEL_CHACHA_SPEEDUP)`.

`wolfcrypt/src/sha256.c` and `wolfcrypt/src/sha512.c`: fix logic in `Sha256_SetTransform()` and `Sha512_SetTransform()` to make the `AVX1_RORX` implementations accessible.  also add a missing `Transform_Sha512_Len_p = NULL` in the C path of `Sha512_SetTransform()`.

`wolfssl/internal.h`: for the fallback definition of `wolfSSL_curve_is_disabled`, use an inline function instead of a compound-clause macro, because clang isn't smart enough to treat the compound expression as a bare constant zero, producing a lame-positive `-Wunreachable-code`.

`src/ssl.c`: in `wolfSSL_curve_is_disabled()`, fix `shiftTooManyBitsSigned`.

tested with `wolfssl-multi-test.sh ... super-quick-check clang-aesni all-clang-sp-all-intelasm all-clang-sp-all-intelasm-Os clang-tidy-Customer-CFG-7 clang-tidy-defaults clang-tidy-intmath clang-tidy-all-intelasm clang-tidy-fips-140-3-defaults clang-tidy-fips-140-3-pilot-defaults clang-tidy-fips-140-3-dev-defaults clang-tidy-fips-140-3-dev-defaults-no-sha-1 clang-tidy-fips-140-3-dev-all-crypto-no-sha-1 clang-tidy-all-crypto-no-sha-1 sanitizer-clang-all-intelasm benchmark-wolfcrypt-intelasm-all-clang`
