### PR TITLE
Fixes for ARM ASM with Thumb

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -2889,7 +2889,7 @@ static WARN_UNUSED_RESULT WC_INLINE word32 PreFetchTd(void)
     }
     return x;
 }
-#endif
+#endif /* !WOLFSSL_AES_SMALL_TABLES */
 
 /* load Td Table4 into cache by cache line stride */
 static WARN_UNUSED_RESULT WC_INLINE word32 PreFetchTd4(void)
@@ -2906,7 +2906,7 @@ static WARN_UNUSED_RESULT WC_INLINE word32 PreFetchTd4(void)
     return 0;
 #endif
 }
-#endif
+#endif /* !WC_NO_CACHE_RESISTANT */
 
 /* Decrypt a block using AES.
  *
@@ -3161,7 +3161,7 @@ static void AesDecryptBlocks_C(Aes* aes, const byte* in, byte* out, word32 sz)
 }
 #endif
 
-#else
+#else /* WC_AES_BITSLICED */
 
 /* http://cs-www.cs.yale.edu/homes/peralta/CircuitStuff/Sinv.txt */
 static void bs_inv_sub_bytes(bs_word u[8])
@@ -3501,7 +3501,7 @@ static void AesDecryptBlocks_C(Aes* aes, const byte* in, byte* out, word32 sz)
 }
 #endif
 
-#endif
+#endif /* !WC_AES_BITSLICED */
 
 #if !defined(WC_AES_BITSLICED) || defined(WOLFSSL_AES_DIRECT)
 /* Software AES - ECB Decrypt */
@@ -11410,7 +11410,7 @@ static WARN_UNUSED_RESULT int _AesEcbEncrypt(
     else
 #endif
     {
-#ifndef WOLFSSL_ARMASM
+#ifdef NEED_AES_TABLES
         AesEncryptBlocks_C(aes, in, out, sz);
 #else
         word32 i;
@@ -11461,7 +11461,7 @@ static WARN_UNUSED_RESULT int _AesEcbDecrypt(
     else
 #endif
     {
-#ifndef WOLFSSL_ARMASM
+#ifdef NEED_AES_TABLES
         AesDecryptBlocks_C(aes, in, out, sz);
 #else
         word32 i;

--- a/wolfcrypt/src/port/arm/thumb2-aes-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-aes-asm_c.c
@@ -54,7 +54,7 @@
 #include <wolfssl/wolfcrypt/aes.h>
 
 #ifdef HAVE_AES_DECRYPT
-static const uint32_t L_AES_Thumb2_td_data[] = {
+XALIGNED(16) static const uint32_t L_AES_Thumb2_td_data[] = {
     0x5051f4a7, 0x537e4165, 0xc31a17a4, 0x963a275e,
     0xcb3bab6b, 0xf11f9d45, 0xabacfa58, 0x934be303,
     0x552030fa, 0xf6ad766d, 0x9188cc76, 0x25f5024c,
@@ -123,7 +123,7 @@ static const uint32_t L_AES_Thumb2_td_data[] = {
 
 #endif /* HAVE_AES_DECRYPT */
 #if defined(HAVE_AES_DECRYPT) || defined(HAVE_AES_CBC) || defined(HAVE_AESCCM) || defined(HAVE_AESGCM) || defined(WOLFSSL_AES_DIRECT) || defined(WOLFSSL_AES_COUNTER)
-static const uint32_t L_AES_Thumb2_te_data[] = {
+XALIGNED(16) static const uint32_t L_AES_Thumb2_te_data[] = {
     0xa5c66363, 0x84f87c7c, 0x99ee7777, 0x8df67b7b,
     0x0dfff2f2, 0xbdd66b6b, 0xb1de6f6f, 0x5491c5c5,
     0x50603030, 0x03020101, 0xa9ce6767, 0x7d562b2b,
@@ -319,7 +319,7 @@ void AES_invert_key(unsigned char* ks, word32 rounds)
 }
 
 #endif /* HAVE_AES_DECRYPT */
-static const uint32_t L_AES_Thumb2_rcon[] = {
+XALIGNED(16) static const uint32_t L_AES_Thumb2_rcon[] = {
     0x01000000, 0x02000000, 0x04000000, 0x08000000,
     0x10000000, 0x20000000, 0x40000000, 0x80000000,
     0x1b000000, 0x36000000
@@ -2205,7 +2205,7 @@ void AES_CBC_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
 #endif /* WOLFSSL_AES_DIRECT || WOLFSSL_AES_COUNTER || HAVE_AES_CBC */
 #endif /* HAVE_AES_DECRYPT */
 #ifdef HAVE_AESGCM
-static const uint32_t L_GCM_gmult_len_r[] = {
+XALIGNED(16) static const uint32_t L_GCM_gmult_len_r[] = {
     0x00000000, 0x1c200000, 0x38400000, 0x24600000,
     0x70800000, 0x6ca00000, 0x48c00000, 0x54e00000,
     0xe1000000, 0xfd200000, 0xd9400000, 0xc5600000,

--- a/wolfcrypt/src/port/arm/thumb2-sha256-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-sha256-asm_c.c
@@ -54,7 +54,7 @@
 #include <wolfssl/wolfcrypt/sha256.h>
 
 #ifdef WOLFSSL_ARMASM_NO_NEON
-static const uint32_t L_SHA256_transform_len_k[] = {
+XALIGNED(16) static const uint32_t L_SHA256_transform_len_k[] = {
     0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
     0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
     0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1237,87 +1237,57 @@ typedef struct w64wrapper {
           #ifndef WOLFSSL_USE_ALIGN
               #define WOLFSSL_USE_ALIGN
           #endif
-    #endif /* WOLFSSL_AESNI || WOLFSSL_ARMASM || USE_INTEL_SPEEDUP || WOLFSSL_AFALG_XILINX */
+    #endif /* WOLFSSL_AESNI || WOLFSSL_ARMASM || USE_INTEL_SPEEDUP || \
+            * WOLFSSL_AFALG_XILINX */
 
+    /* Helpers for memory alignment */
+    #ifndef XALIGNED
+        #if defined(__GNUC__) || defined(__llvm__) || \
+              defined(__IAR_SYSTEMS_ICC__)
+            #define XALIGNED(x) __attribute__ ( (aligned (x)))
+        #elif defined(__KEIL__)
+            #define XALIGNED(x) __align(x)
+        #elif defined(_MSC_VER)
+            /* disable align warning, we want alignment ! */
+            #pragma warning(disable: 4324)
+            #define XALIGNED(x) __declspec (align (x))
+        #else
+            #define XALIGNED(x) /* null expansion */
+        #endif
+    #endif
+
+    /* Only use alignment in wolfSSL/wolfCrypt if WOLFSSL_USE_ALIGN is set */
     #ifdef WOLFSSL_USE_ALIGN
-        #if !defined(ALIGN16)
-            #if defined(__IAR_SYSTEMS_ICC__) || defined(__GNUC__) || \
-                defined(__llvm__)
-                #define ALIGN16 __attribute__ ( (aligned (16)))
-            #elif defined(_MSC_VER)
-                /* disable align warning, we want alignment ! */
-                #pragma warning(disable: 4324)
-                #define ALIGN16 __declspec (align (16))
-            #else
-                #define ALIGN16
-            #endif
-        #endif /* !ALIGN16 */
-
-        #if !defined (ALIGN32)
-            #if defined(__IAR_SYSTEMS_ICC__) || defined(__GNUC__) || \
-                defined(__llvm__)
-                #define ALIGN32 __attribute__ ( (aligned (32)))
-            #elif defined(_MSC_VER)
-                /* disable align warning, we want alignment ! */
-                #pragma warning(disable: 4324)
-                #define ALIGN32 __declspec (align (32))
-            #else
-                #define ALIGN32
-            #endif
-        #endif /* !ALIGN32 */
-
-        #if !defined(ALIGN64)
-            #if defined(__IAR_SYSTEMS_ICC__) || defined(__GNUC__) || \
-                defined(__llvm__)
-                #define ALIGN64 __attribute__ ( (aligned (64)))
-            #elif defined(_MSC_VER)
-                /* disable align warning, we want alignment ! */
-                #pragma warning(disable: 4324)
-                #define ALIGN64 __declspec (align (64))
-            #else
-                #define ALIGN64
-            #endif
-        #endif /* !ALIGN64 */
-
-        #if defined(__IAR_SYSTEMS_ICC__) || defined(__GNUC__) || \
-            defined(__llvm__)
-            #define ALIGN128 __attribute__ ( (aligned (128)))
-        #elif defined(_MSC_VER)
-            /* disable align warning, we want alignment ! */
-            #pragma warning(disable: 4324)
-            #define ALIGN128 __declspec (align (128))
+        /* For IAR ARM the maximum variable alignment on stack is 8-bytes.
+         * Variables declared outside stack (like static globals) can have
+         * higher alignment. */
+        #if defined(__ICCARM__)
+            #define WOLFSSL_ALIGN(x) XALIGNED(8)
         #else
-            #define ALIGN128
+            #define WOLFSSL_ALIGN(x) XALIGNED(x)
         #endif
-
-        #if defined(__IAR_SYSTEMS_ICC__) || defined(__GNUC__)  || \
-            defined(__llvm__)
-            #define ALIGN256 __attribute__ ( (aligned (256)))
-        #elif defined(_MSC_VER)
-            /* disable align warning, we want alignment ! */
-            #pragma warning(disable: 4324)
-            #define ALIGN256 __declspec (align (256))
-        #else
-            #define ALIGN256
-        #endif
-
     #else
-        #ifndef ALIGN16
-            #define ALIGN16
-        #endif
-        #ifndef ALIGN32
-            #define ALIGN32
-        #endif
-        #ifndef ALIGN64
-            #define ALIGN64
-        #endif
-        #ifndef ALIGN128
-            #define ALIGN128
-        #endif
-        #ifndef ALIGN256
-            #define ALIGN256
-        #endif
-    #endif /* WOLFSSL_USE_ALIGN */
+        #define WOLFSSL_ALIGN(x) /* null expansion */
+    #endif
+
+    #ifndef ALIGN8
+        #define ALIGN8   WOLFSSL_ALIGN(8)
+    #endif
+    #ifndef ALIGN16
+        #define ALIGN16  WOLFSSL_ALIGN(16)
+    #endif
+    #ifndef ALIGN32
+        #define ALIGN32  WOLFSSL_ALIGN(32)
+    #endif
+    #ifndef ALIGN64
+        #define ALIGN64  WOLFSSL_ALIGN(64)
+    #endif
+    #ifndef ALIGN128
+        #define ALIGN128 WOLFSSL_ALIGN(128)
+    #endif
+    #ifndef ALIGN256
+        #define ALIGN256 WOLFSSL_ALIGN(256)
+    #endif
 
     #if !defined(PEDANTIC_EXTENSION)
         #if defined(__GNUC__)


### PR DESCRIPTION
# Description

Fixes for ARM ASM with Thumb. 
* Fix for AES ECB build with Thumb. 
* Added alignment to thumb2 AES tables. 
* Refactored alignment macros and expose generic alignment macro `XALIGNED`. The `WOLFSSL_USE_ALIGN` still controls alignment enablement in wolfSSL/wolfCrypt.

Fixes ZD 17225 and ZD 17226

# Testing

IAR EWARM example and customer

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
