### PR TITLE
Add fencing to ClientSessionToSession()

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -14469,6 +14469,9 @@ WOLFSSL_SESSION* ClientSessionToSession(const WOLFSSL_SESSION* session)
             WOLFSSL_MSG("Client cache serverRow or serverIdx invalid");
             error = -1;
         }
+        /* Prevent memory access before clientSession->serverRow and
+         * clientSession->serverIdx are sanitized. */
+        XFENCE();
         if (error == 0) {
             /* Lock row */
             sessRow = &SessionCache[clientSession->serverRow];

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -1180,15 +1180,22 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #endif
 #endif
 
+#ifdef WOLF_C99
+    /* use alternate keyword for compatibility with -std=c99 */
+    #define XASM_VOLATILE(a) __asm__ volatile(a)
+#else
+    #define XASM_VOLATILE(a) asm volatile(a)
+#endif
+
 #ifndef WOLFSSL_NO_FENCE
     #if defined (__i386__) || defined(__x86_64__)
-        #define XFENCE() asm volatile("lfence")
+        #define XFENCE() XASM_VOLATILE("lfence")
     #elif defined (__arm__) || defined(__aarch64__)
-        #define XFENCE() asm volatile("isb")
+        #define XFENCE() XASM_VOLATILE("isb")
     #elif defined(__riscv)
-        #define XFENCE() asm volatile("fence")
+        #define XFENCE() XASM_VOLATILE("fence")
     #elif defined(__PPC__)
-        #define XFENCE() asm volatile("isync; sync")
+        #define XFENCE() XASM_VOLATILE("isync; sync")
     #else
         #define XFENCE() do{}while(0)
     #endif

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -1183,8 +1183,12 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
 #ifdef WOLF_C99
     /* use alternate keyword for compatibility with -std=c99 */
     #define XASM_VOLATILE(a) __asm__ volatile(a)
-#else
+#elif defined(__IAR_SYSTEMS_ICC__)
     #define XASM_VOLATILE(a) asm volatile(a)
+#elif defined(__KEIL__)
+    #define XASM_VOLATILE(a) __asm volatile(a)
+#else
+    #define XASM_VOLATILE(a) __asm__ __volatile__(a)
 #endif
 
 #ifndef WOLFSSL_NO_FENCE

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -1180,6 +1180,22 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #endif
 #endif
 
+#ifndef WOLFSSL_NO_FENCE
+    #if defined (__i386__) || defined(__x86_64__)
+        #define XFENCE() asm volatile("lfence")
+    #elif defined (__arm__) || defined(__aarch64__)
+        #define XFENCE() asm volatile("isb")
+    #elif defined(__riscv)
+        #define XFENCE() asm volatile("fence")
+    #elif defined(__PPC__)
+        #define XFENCE() asm volatile("isync; sync")
+    #else
+        #define XFENCE() do{}while(0)
+    #endif
+#else
+    #define XFENCE() do{}while(0)
+#endif
+
 
     /* AFTER user_settings.h is loaded,
     ** determine if POSIX multi-threaded: HAVE_PTHREAD  */


### PR DESCRIPTION
Prevent memory access before clientSession->serverRow and clientSession->serverIdx are sanitized.

Fixes ZD17219

Co-authored-by: Daniele Lacamera <dan@danielinux.net>
