### PR TITLE
Fixes for STM32 PKA

### DIFF
--- a/IDE/STM32Cube/default_conf.ftl
+++ b/IDE/STM32Cube/default_conf.ftl
@@ -213,14 +213,17 @@ extern ${variable.value} ${variable.name};
 /* ------------------------------------------------------------------------- */
 /* Math Configuration */
 /* ------------------------------------------------------------------------- */
-/* 1=Fast (stack)
- * 2=Normal (heap)
- * 3=Single Precision C (only common curves/key sizes)
- * 4=Single Precision ASM Cortex-M3+
- * 5=Single Precision ASM Cortex-M0 (Generic Thumb)
- * 6=Single Precision C all small
- * 7=Single Precision C all big
+/* 1=Fast (stack)                      (tfm.c)
+ * 2=Normal (heap)                     (integer.c)
+ * 3-5=Single Precision: only common curves/key sizes:
+ *                   (ECC 256/384/521 and RSA/DH 2048/3072/4096)
+ *   3=Single Precision C              (sp_c32.c)
+ *   4=Single Precision ASM Cortex-M3+ (sp_cortexm.c)
+ *   5=Single Precision ASM Cortex-M0  (sp_armthumb.c)
+ * 6=Wolf multi-precision C small      (sp_int.c)
+ * 7=Wolf multi-precision C big        (sp_int.c)
  */
+
 #if defined(WOLF_CONF_MATH) && WOLF_CONF_MATH == 1
     /* fast (stack) math - tfm.c */
     #define USE_FAST_MATH
@@ -246,19 +249,26 @@ extern ${variable.value} ${variable.name};
     #endif
     #if defined(WOLF_CONF_RSA) && WOLF_CONF_RSA == 1
         #define WOLFSSL_HAVE_SP_RSA
+        //#define WOLFSSL_SP_NO_2048
+        //#define WOLFSSL_SP_NO_3072
+        //#define WOLFSSL_SP_4096
     #endif
     #if defined(WOLF_CONF_DH) && WOLF_CONF_DH == 1
         #define WOLFSSL_HAVE_SP_DH
     #endif
     #if defined(WOLF_CONF_ECC) && WOLF_CONF_ECC == 1
         #define WOLFSSL_HAVE_SP_ECC
+        //#define WOLFSSL_SP_NO_256
+        //#define WOLFSSL_SP_384
+        //#define WOLFSSL_SP_521
     #endif
     #if WOLF_CONF_MATH == 6 || WOLF_CONF_MATH == 7
         #define WOLFSSL_SP_MATH_ALL /* use sp_int.c multi precision math */
+        //#define WOLFSSL_SP_ARM_THUMB /* enable ARM Thumb ASM speedups */
     #else
         #define WOLFSSL_SP_MATH    /* disable non-standard curves / key sizes */
     #endif
-    #define SP_WORD_SIZE 32
+    #define SP_WORD_SIZE 32 /* force 32-bit mode */
 
     /* Enable to put all math on stack (no heap) */
     //#define WOLFSSL_SP_NO_MALLOC

--- a/IDE/STM32Cube/default_conf.ftl
+++ b/IDE/STM32Cube/default_conf.ftl
@@ -226,6 +226,12 @@ extern ${variable.value} ${variable.name};
     #define USE_FAST_MATH
     #define TFM_TIMING_RESISTANT
 
+    #if !defined(NO_RSA) || !defined(NO_DH)
+        /* Maximum math bits (Max DH/RSA key bits * 2) */
+        #undef  FP_MAX_BITS
+        #define FP_MAX_BITS     4096
+    #endif
+
     /* Optimizations (TFM_ARM, TFM_ASM or none) */
     //#define TFM_NO_ASM
     //#define TFM_ASM
@@ -331,12 +337,6 @@ extern ${variable.value} ${variable.name};
 /* RSA */
 #undef NO_RSA
 #if defined(WOLF_CONF_RSA) && WOLF_CONF_RSA == 1
-    #ifdef USE_FAST_MATH
-        /* Maximum math bits (Max RSA key bits * 2) */
-        #undef  FP_MAX_BITS
-        #define FP_MAX_BITS     4096
-    #endif
-
     /* half as much memory but twice as slow */
     #undef  RSA_LOW_MEM
     //#define RSA_LOW_MEM
@@ -390,8 +390,8 @@ extern ${variable.value} ${variable.name};
     //#define HAVE_COMP_KEY
 
     #ifdef USE_FAST_MATH
-        #ifdef NO_RSA
-            /* Custom fastmath size if not using RSA */
+        #if defined(NO_RSA) && defined(NO_DH)
+            /* Custom fastmath size if not using RSA/DH */
             /* MAX = ROUND32(ECC BITS) * 2 */
             #define FP_MAX_BITS     (256 * 2)
         #else

--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -638,9 +638,42 @@ static int stm32_get_from_hexstr(const char* hex, uint8_t* dst, int sz)
     return stm32_getabs_from_hexstr(hex, dst, sz, NULL);
 }
 
-
 /* STM32 PKA supports up to 640-bit numbers */
 #define STM32_MAX_ECC_SIZE (80)
+
+#ifdef WOLFSSL_STM32_PKA_V2
+/* find curve based on prime/modulus and return order/coefB */
+static int stm32_get_curve_params(mp_int* modulus,
+    uint8_t* order, uint8_t* coefB)
+{
+    int res, i, found = 0;
+    mp_int modulusChk;
+    res = mp_init(&modulusChk);
+    if (res != MP_OKAY)
+        return res;
+    for (i = 0; ecc_sets[i].size != 0 && ecc_sets[i].name != NULL; i++) {
+        const ecc_set_type* curve = &ecc_sets[i];
+        /* match based on curve prime */
+        if ((res = mp_read_radix(&modulusChk, curve->prime, MP_RADIX_HEX)) ==
+                MP_OKAY && (mp_cmp(modulus, &modulusChk) == MP_EQ))
+        {
+            found = 1;
+            if (order) {
+                res = stm32_get_from_hexstr(curve->order, order, curve->size);
+            }
+            if (coefB) {
+                res = stm32_get_from_hexstr(curve->Bf, coefB, curve->size);
+            }
+            break;
+        }
+    }
+    mp_clear(&modulusChk);
+    if (!found && res == MP_OKAY) {
+        res = MP_RANGE;
+    }
+    return res;
+}
+#endif /* WOLFSSL_STM32_PKA_V2 */
 
 
 /**
@@ -706,8 +739,19 @@ int wc_ecc_mulmod_ex2(const mp_int* k, ecc_point *G, ecc_point *R, mp_int* a,
 #ifdef WOLFSSL_STM32_PKA_V2
     XMEMSET(order, 0, sizeof(order));
     XMEMSET(coefB, 0, sizeof(coefB));
-    if (res == MP_OKAY && o != NULL)
-        res = stm32_get_from_mp_int(order, o, szModulus);
+    if (res == MP_OKAY) {
+        if (o != NULL) {
+            /* use provided order and get coefB */
+            res = stm32_get_from_mp_int(order, o, szModulus);
+            if (res == MP_OKAY) {
+                res = stm32_get_curve_params(modulus, NULL, coefB);
+            }
+        }
+        else {
+            /* get order and coefB for matching prime */
+            res = stm32_get_curve_params(modulus, order, coefB);
+        }
+    }
 #endif
     if (res != MP_OKAY)
         return res;

--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -595,7 +595,7 @@ static int stm32_getabs_from_mp_int(uint8_t *dst, const mp_int *a, int sz,
     #else
         *abs_sign = 1; /* default to negative */
     #endif
-        res = mp_abs(a, &x);
+        res = mp_abs((mp_int*)a, &x);
         if (res == MP_OKAY)
             res = stm32_get_from_mp_int(dst, &x, sz);
         mp_clear(&x);


### PR DESCRIPTION
# Description

* Fix STM32 PKA V2 (STM32U5) point multiply missing order/coefB.
* Fix STM32 PKA ECC cast warning.
* Improve detection of FP_MAX_BITS for RSA or DH.
* Add useful information about single precision math and document options for enabling additional curves/key sizes.

# Testing

Tested on STM32U585 with STM32CubeIDE and wolfSSL v5.6.6 Cube Pack patched.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
