### PR TITLE
TLS13 padding bounds check

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -21162,19 +21162,14 @@ default:
                 ssl->keys.decryptedCur = 1;
 #ifdef WOLFSSL_TLS13
                 if (ssl->options.tls1_3) {
-                    word16 i;
-                    word32 boundsCheck = (ssl->buffers.inputBuffer.idx +
+                    word32 i = (ssl->buffers.inputBuffer.idx +
                         ssl->curSize - ssl->specs.aead_mac_size);
                     /* check that the end of the logical length doesn't extend
                      * past the real buffer */
-                    if (boundsCheck > ssl->buffers.inputBuffer.length ||
-                        boundsCheck == 0) {
+                    if (i > ssl->buffers.inputBuffer.length || i == 0) {
                         WOLFSSL_ERROR(BUFFER_ERROR);
                         return BUFFER_ERROR;
                     }
-
-                    /* end of plaintext */
-                    i = (word16)(boundsCheck);
 
                     /* Remove padding from end of plain text. */
                     for (--i; i > ssl->buffers.inputBuffer.idx; i--) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -21162,15 +21162,18 @@ default:
                 ssl->keys.decryptedCur = 1;
 #ifdef WOLFSSL_TLS13
                 if (ssl->options.tls1_3) {
-                    /* end of plaintext */
-                    word16 i = (word16)(ssl->buffers.inputBuffer.idx +
-                                 ssl->curSize - ssl->specs.aead_mac_size);
-
-                    /* check i isn't too big and won't wrap around on --i */
-                    if (i > ssl->buffers.inputBuffer.length || i == 0) {
+                    /* check that the end of the logical length doesn't extend
+                     * past the real buffer */
+                    word32 boundsCheck = (ssl->buffers.inputBuffer.idx +
+                        ssl->curSize - ssl->specs.aead_mac_size);
+                    if (boundsCheck > ssl->buffers.inputBuffer.length ||
+                        boundsCheck == 0) {
                         WOLFSSL_ERROR(BUFFER_ERROR);
                         return BUFFER_ERROR;
                     }
+
+                    /* end of plaintext */
+                    word16 i = (word16)(boundsCheck);
 
                     /* Remove padding from end of plain text. */
                     for (--i; i > ssl->buffers.inputBuffer.idx; i--) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -21162,10 +21162,11 @@ default:
                 ssl->keys.decryptedCur = 1;
 #ifdef WOLFSSL_TLS13
                 if (ssl->options.tls1_3) {
-                    /* check that the end of the logical length doesn't extend
-                     * past the real buffer */
+                    word16 i;
                     word32 boundsCheck = (ssl->buffers.inputBuffer.idx +
                         ssl->curSize - ssl->specs.aead_mac_size);
+                    /* check that the end of the logical length doesn't extend
+                     * past the real buffer */
                     if (boundsCheck > ssl->buffers.inputBuffer.length ||
                         boundsCheck == 0) {
                         WOLFSSL_ERROR(BUFFER_ERROR);
@@ -21173,7 +21174,7 @@ default:
                     }
 
                     /* end of plaintext */
-                    word16 i = (word16)(boundsCheck);
+                    i = (word16)(boundsCheck);
 
                     /* Remove padding from end of plain text. */
                     for (--i; i > ssl->buffers.inputBuffer.idx; i--) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -21166,7 +21166,8 @@ default:
                     word16 i = (word16)(ssl->buffers.inputBuffer.idx +
                                  ssl->curSize - ssl->specs.aead_mac_size);
 
-                    if (i > ssl->buffers.inputBuffer.length) {
+                    /* check i isn't too big and won't wrap around on --i */
+                    if (i > ssl->buffers.inputBuffer.length || i == 0) {
                         WOLFSSL_ERROR(BUFFER_ERROR);
                         return BUFFER_ERROR;
                     }


### PR DESCRIPTION
# Description

When removing the padding for the TLS13 verify message step, check that the index doesn't wrap around due to a malformed packet

Fixes https://github.com/wolfSSL/wolfssl/issues/7089

# Testing

Tested with malicious client example provided by the bug reporter.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
