### PR TITLE
fix include path for FSP 3.5 on Renesas RA6M4

### DIFF
--- a/IDE/Renesas/e2studio/RA6M4/test/.cproject
+++ b/IDE/Renesas/e2studio/RA6M4/test/.cproject
@@ -94,7 +94,7 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfSSL_RA6M4/ra/fsp/inc/api}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfSSL_RA6M4/ra/fsp/inc/instances}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfSSL_RA6M4/ra/fsp/src/rm_freertos_port}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfSSL_RA6M4/ra/aws/FreeRTOS/FreeRTOS/Source/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfSSL_RA6M4/ra/aws/amazon-freertos/freertos_kernel/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfSSL_RA6M4/ra/arm/CMSIS_5/CMSIS/Core/Include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfSSL_RA6M4/ra_gen}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfSSL_RA6M4/ra_cfg/fsp_cfg/bsp}&quot;"/>
@@ -103,7 +103,7 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfSSL_RA6M4/ra/fsp/src/r_sce_protected/crypto_procedures_protected/src/sce9/inc/api}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfSSL_RA6M4/ra/fsp/src/r_sce_protected/crypto_procedures_protected/src/sce9/inc/instances}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfSSL_RA6M4/ra/fsp/src/r_sce_protected/crypto_procedures_protected/src/sce9/private/inc}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfSSL_RA6M4/ra/aws/FreeRTOS/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfSSL_RA6M4/ra/aws/amazon-freertos/libraries/freertos_plus/standard/freertos_plus_tcp/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfSSL_RA6M4/ra/fsp/src/rm_freertos_plus_tcp}&quot;"/>
 								</option>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.defs.1484044149" name="Defined symbols (-D)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.defs" useByScannerDiscovery="true" valueType="definedSymbols">


### PR DESCRIPTION
# Description
Fix include path on Renesas RA6M4 with FSP 3.5

# Testing

Compile the changes on e2studio using FSP 3.5

# Checklist

 - [n/a] added tests
 - [n/a] updated/added doxygen
 - [n/a] updated appropriate READMEs
 - [n/a] Updated manual and documentation
