### PR TITLE
20231227-cppcheck-2v13v0

### DIFF
--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -636,11 +636,19 @@
 #ifdef WOLFSSL_TRACK_MEMORY
     #include <wolfssl/wolfcrypt/memory.h>
     #define XMALLOC(s, h, t)     ({(void)(h); (void)(t); wolfSSL_Malloc(s);})
-    #define XFREE(p, h, t)       ({void* _xp; (void)(h); _xp = (p); if(_xp) wolfSSL_Free(_xp);})
+    #ifdef WOLFSSL_XFREE_NO_NULLNESS_CHECK
+        #define XFREE(p, h, t)       ({(void)(h); (void)(t); wolfSSL_Free(p);})
+    #else
+        #define XFREE(p, h, t)       ({void* _xp; (void)(h); _xp = (p); if(_xp) wolfSSL_Free(_xp);})
+    #endif
     #define XREALLOC(p, n, h, t) ({(void)(h); (void)(t); wolfSSL_Realloc(p, n);})
 #else
     #define XMALLOC(s, h, t)     ({(void)(h); (void)(t); malloc(s);})
-    #define XFREE(p, h, t)       ({void* _xp; (void)(h); _xp = (p); if(_xp) free(_xp);})
+    #ifdef WOLFSSL_XFREE_NO_NULLNESS_CHECK
+        #define XFREE(p, h, t)       ({(void)(h); (void)(t); free(p);})
+    #else
+        #define XFREE(p, h, t)       ({void* _xp; (void)(h); (void)(t); _xp = (p); if(_xp) free(_xp);})
+    #endif
     #define XREALLOC(p, n, h, t) ({(void)(h); (void)(t); realloc(p, n);})
 #endif
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -23944,8 +23944,11 @@ static int CheckTLS13AEADSendLimit(WOLFSSL* ssl)
                 ssl->keys.sequence_number_lo);
     }
 
-    if (w64GTE(seq, limit))
+    if (w64GTE(seq, limit)) { /* cppcheck-suppress uninitvar
+                               * (false positive from cppcheck-2.13.0)
+                               */
         return Tls13UpdateKeys(ssl); /* Need to generate new keys */
+    }
 
     return 0;
 }
@@ -35828,7 +35831,8 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 #endif
 
 #ifdef OPENSSL_EXTRA
-        ssl->clSuites = clSuites;
+        ssl->clSuites = clSuites; /* cppcheck-suppress autoVariables
+                                   */
         /* Give user last chance to provide a cert for cipher selection */
         if (ret == 0 && ssl->ctx->certSetupCb != NULL)
             ret = CertSetupCbWrapper(ssl);

--- a/src/internal.c
+++ b/src/internal.c
@@ -35832,6 +35832,11 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
 #ifdef OPENSSL_EXTRA
         ssl->clSuites = clSuites; /* cppcheck-suppress autoVariables
+                                   *
+                                   * (suppress warning that ssl, a persistent
+                                   * non-local allocation, has its ->clSuites
+                                   * set to clSuites, a local stack allocation.
+                                   * we clear this assignment before returning.)
                                    */
         /* Give user last chance to provide a cert for cipher selection */
         if (ret == 0 && ssl->ctx->certSetupCb != NULL)

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -9641,7 +9641,7 @@ static void bench_xmss_sign_verify(const char * params)
 
     ret = wc_XmssKey_GetPubLen(&key, &pkSz);
     if (pkSz != XMSS_SHA256_PUBLEN) {
-        fprintf(stderr, "error: xmss pub len: got %d, expected %d\n", pkSz,
+        fprintf(stderr, "error: xmss pub len: got %u, expected %d\n", pkSz,
                 XMSS_SHA256_PUBLEN);
         goto exit_xmss_sign_verify;
     }

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -252,19 +252,27 @@ ECC Curve Sizes:
 #define MAX_ECC_BITS_USE    MAX_ECC_BITS_NEEDED
 #endif
 
-static WC_MAYBE_UNUSED WC_INLINE word32 ECC_KEY_MAX_BITS(const ecc_key *key) {
-    if (((key) == NULL) || ((key)->dp == NULL))
-        return MAX_ECC_BITS_USE;
-    else {
-    #if !defined(WOLFSSL_CUSTOM_CURVES) && (ECC_MIN_KEY_SZ > 160) && \
-            (!defined(HAVE_ECC_KOBLITZ) || (ECC_MIN_KEY_SZ > 224))
-        return (word32)((key)->dp->size * 8);
-    #else
-        /* Add one bit for cases when order is a bit greater than prime. */
-        return (word32)((key)->dp->size * 8 + 1);
-    #endif
-    }
-}
+#if !defined(WOLFSSL_CUSTOM_CURVES) && (ECC_MIN_KEY_SZ > 160) && \
+    (!defined(HAVE_ECC_KOBLITZ) || (ECC_MIN_KEY_SZ > 224))
+
+#define ECC_KEY_MAX_BITS(key)                                       \
+    ((((key) == NULL) || ((key)->dp == NULL)) ? MAX_ECC_BITS_USE :  \
+        ((unsigned)((key)->dp->size * 8)))
+#define ECC_KEY_MAX_BITS_NONULLCHECK(key)                           \
+    (((key)->dp == NULL) ? MAX_ECC_BITS_USE :                       \
+        ((unsigned)((key)->dp->size * 8)))
+
+#else
+
+/* Add one bit for cases when order is a bit greater than prime. */
+#define ECC_KEY_MAX_BITS(key)                                       \
+    ((((key) == NULL) || ((key)->dp == NULL)) ? MAX_ECC_BITS_USE :  \
+        ((unsigned)((key)->dp->size * 8 + 1)))
+#define ECC_KEY_MAX_BITS_NONULLCHECK(key)                           \
+    (((key)->dp == NULL) ? MAX_ECC_BITS_USE :                       \
+        ((unsigned)((key)->dp->size * 8 + 1)))
+
+#endif
 
 /* forward declarations */
 static int  wc_ecc_new_point_ex(ecc_point** point, void* heap);
@@ -3482,12 +3490,12 @@ static int ecc_key_tmp_init(ecc_key* key, void* heap)
    XMEMSET(key, 0, sizeof(*key));
 
 #if defined(WOLFSSL_SP_MATH_ALL) && defined(WOLFSSL_SMALL_STACK)
-   NEW_MP_INT_SIZE(key->t1, ECC_KEY_MAX_BITS(key), heap, DYNAMIC_TYPE_ECC);
-   NEW_MP_INT_SIZE(key->t2, ECC_KEY_MAX_BITS(key), heap, DYNAMIC_TYPE_ECC);
+   NEW_MP_INT_SIZE(key->t1, ECC_KEY_MAX_BITS_NONULLCHECK(key), heap, DYNAMIC_TYPE_ECC);
+   NEW_MP_INT_SIZE(key->t2, ECC_KEY_MAX_BITS_NONULLCHECK(key), heap, DYNAMIC_TYPE_ECC);
 #ifdef ALT_ECC_SIZE
-   NEW_MP_INT_SIZE(key->x, ECC_KEY_MAX_BITS(key), heap, DYNAMIC_TYPE_ECC);
-   NEW_MP_INT_SIZE(key->y, ECC_KEY_MAX_BITS(key), heap, DYNAMIC_TYPE_ECC);
-   NEW_MP_INT_SIZE(key->z, ECC_KEY_MAX_BITS(key), heap, DYNAMIC_TYPE_ECC);
+   NEW_MP_INT_SIZE(key->x, ECC_KEY_MAX_BITS_NONULLCHECK(key), heap, DYNAMIC_TYPE_ECC);
+   NEW_MP_INT_SIZE(key->y, ECC_KEY_MAX_BITS_NONULLCHECK(key), heap, DYNAMIC_TYPE_ECC);
+   NEW_MP_INT_SIZE(key->z, ECC_KEY_MAX_BITS_NONULLCHECK(key), heap, DYNAMIC_TYPE_ECC);
 #endif
    if (key->t1 == NULL || key->t2 == NULL
 #ifdef ALT_ECC_SIZE
@@ -3497,20 +3505,20 @@ static int ecc_key_tmp_init(ecc_key* key, void* heap)
        err = MEMORY_E;
    }
    if (err == 0) {
-       err = INIT_MP_INT_SIZE(key->t1, ECC_KEY_MAX_BITS(key));
+       err = INIT_MP_INT_SIZE(key->t1, ECC_KEY_MAX_BITS_NONULLCHECK(key));
    }
    if (err == 0) {
-       err = INIT_MP_INT_SIZE(key->t2, ECC_KEY_MAX_BITS(key));
+       err = INIT_MP_INT_SIZE(key->t2, ECC_KEY_MAX_BITS_NONULLCHECK(key));
    }
 #ifdef ALT_ECC_SIZE
    if (err == 0) {
-       err = INIT_MP_INT_SIZE(key->x, ECC_KEY_MAX_BITS(key));
+       err = INIT_MP_INT_SIZE(key->x, ECC_KEY_MAX_BITS_NONULLCHECK(key));
    }
    if (err == 0) {
-       err = INIT_MP_INT_SIZE(key->y, ECC_KEY_MAX_BITS(key));
+       err = INIT_MP_INT_SIZE(key->y, ECC_KEY_MAX_BITS_NONULLCHECK(key));
    }
    if (err == 0) {
-       err = INIT_MP_INT_SIZE(key->z, ECC_KEY_MAX_BITS(key));
+       err = INIT_MP_INT_SIZE(key->z, ECC_KEY_MAX_BITS_NONULLCHECK(key));
    }
 #endif
 #else
@@ -6578,12 +6586,12 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
     err = wc_ecc_sign_hash_async(in, inlen, out, outlen, rng, key);
 #else
 
-    NEW_MP_INT_SIZE(r, ECC_KEY_MAX_BITS(key), key->heap, DYNAMIC_TYPE_ECC);
+    NEW_MP_INT_SIZE(r, ECC_KEY_MAX_BITS_NONULLCHECK(key), key->heap, DYNAMIC_TYPE_ECC);
 #ifdef MP_INT_SIZE_CHECK_NULL
     if (r == NULL)
         return MEMORY_E;
 #endif
-    NEW_MP_INT_SIZE(s, ECC_KEY_MAX_BITS(key), key->heap, DYNAMIC_TYPE_ECC);
+    NEW_MP_INT_SIZE(s, ECC_KEY_MAX_BITS_NONULLCHECK(key), key->heap, DYNAMIC_TYPE_ECC);
 #ifdef MP_INT_SIZE_CHECK_NULL
     if (s == NULL) {
         FREE_MP_INT_SIZE(r, key->heap, DYNAMIC_TYPE_ECC);
@@ -6591,13 +6599,13 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
     }
 #endif
 
-    err = INIT_MP_INT_SIZE(r, ECC_KEY_MAX_BITS(key));
+    err = INIT_MP_INT_SIZE(r, ECC_KEY_MAX_BITS_NONULLCHECK(key));
     if (err != 0) {
         FREE_MP_INT_SIZE(s, key->heap, DYNAMIC_TYPE_ECC);
         FREE_MP_INT_SIZE(r, key->heap, DYNAMIC_TYPE_ECC);
         return err;
     }
-    err = INIT_MP_INT_SIZE(s, ECC_KEY_MAX_BITS(key));
+    err = INIT_MP_INT_SIZE(s, ECC_KEY_MAX_BITS_NONULLCHECK(key));
     if (err != 0) {
         FREE_MP_INT_SIZE(s, key->heap, DYNAMIC_TYPE_ECC);
         FREE_MP_INT_SIZE(r, key->heap, DYNAMIC_TYPE_ECC);
@@ -6722,16 +6730,16 @@ static int ecc_sign_hash_sw(ecc_key* key, ecc_key* pubkey, WC_RNG* rng,
 {
     int err = MP_OKAY;
     int loop_check = 0;
-    DECL_MP_INT_SIZE_DYN(b, ECC_KEY_MAX_BITS(key), MAX_ECC_BITS_USE);
+    DECL_MP_INT_SIZE_DYN(b, ECC_KEY_MAX_BITS_NONULLCHECK(key), MAX_ECC_BITS_USE);
 
-    NEW_MP_INT_SIZE(b, ECC_KEY_MAX_BITS(key), key->heap, DYNAMIC_TYPE_ECC);
+    NEW_MP_INT_SIZE(b, ECC_KEY_MAX_BITS_NONULLCHECK(key), key->heap, DYNAMIC_TYPE_ECC);
 #ifdef MP_INT_SIZE_CHECK_NULL
     if (b == NULL)
         err = MEMORY_E;
 #endif
 
     if (err == MP_OKAY) {
-        err = INIT_MP_INT_SIZE(b, ECC_KEY_MAX_BITS(key));
+        err = INIT_MP_INT_SIZE(b, ECC_KEY_MAX_BITS_NONULLCHECK(key));
     }
 
 #ifdef WOLFSSL_CUSTOM_CURVES
@@ -7125,7 +7133,7 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
    }
    e = key->e;
 #else
-   NEW_MP_INT_SIZE(e_lcl, ECC_KEY_MAX_BITS(key), key->heap, DYNAMIC_TYPE_ECC);
+   NEW_MP_INT_SIZE(e_lcl, ECC_KEY_MAX_BITS_NONULLCHECK(key), key->heap, DYNAMIC_TYPE_ECC);
 #ifdef MP_INT_SIZE_CHECK_NULL
    if (e_lcl == NULL) {
       return MEMORY_E;
@@ -7136,7 +7144,7 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
 
    /* get the hash and load it as a bignum into 'e' */
    /* init the bignums */
-   if ((err = INIT_MP_INT_SIZE(e, ECC_KEY_MAX_BITS(key))) != MP_OKAY) {
+   if ((err = INIT_MP_INT_SIZE(e, ECC_KEY_MAX_BITS_NONULLCHECK(key))) != MP_OKAY) {
       FREE_MP_INT_SIZE(e_lcl, key->heap, DYNAMIC_TYPE_ECC);
       return err;
    }
@@ -8302,25 +8310,25 @@ int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
     r = key->r;
     s = key->s;
 #else
-    NEW_MP_INT_SIZE(r, ECC_KEY_MAX_BITS(key), key->heap, DYNAMIC_TYPE_ECC);
+    NEW_MP_INT_SIZE(r, ECC_KEY_MAX_BITS_NONULLCHECK(key), key->heap, DYNAMIC_TYPE_ECC);
 #ifdef MP_INT_SIZE_CHECK_NULL
     if (r == NULL)
         return MEMORY_E;
 #endif
-    NEW_MP_INT_SIZE(s, ECC_KEY_MAX_BITS(key), key->heap, DYNAMIC_TYPE_ECC);
+    NEW_MP_INT_SIZE(s, ECC_KEY_MAX_BITS_NONULLCHECK(key), key->heap, DYNAMIC_TYPE_ECC);
 #ifdef MP_INT_SIZE_CHECK_NULL
     if (s == NULL) {
         FREE_MP_INT_SIZE(r, key->heap, DYNAMIC_TYPE_ECC);
         return MEMORY_E;
     }
 #endif
-    err = INIT_MP_INT_SIZE(r, ECC_KEY_MAX_BITS(key));
+    err = INIT_MP_INT_SIZE(r, ECC_KEY_MAX_BITS_NONULLCHECK(key));
     if (err != 0) {
         FREE_MP_INT_SIZE(s, key->heap, DYNAMIC_TYPE_ECC);
         FREE_MP_INT_SIZE(r, key->heap, DYNAMIC_TYPE_ECC);
         return err;
     }
-    err = INIT_MP_INT_SIZE(s, ECC_KEY_MAX_BITS(key));
+    err = INIT_MP_INT_SIZE(s, ECC_KEY_MAX_BITS_NONULLCHECK(key));
     if (err != 0) {
         FREE_MP_INT_SIZE(s, key->heap, DYNAMIC_TYPE_ECC);
         FREE_MP_INT_SIZE(r, key->heap, DYNAMIC_TYPE_ECC);
@@ -8621,9 +8629,9 @@ static int ecc_verify_hash(mp_int *r, mp_int *s, const byte* hash,
    ecc_point  lcl_mG;
    ecc_point  lcl_mQ;
 #endif
-   DECL_MP_INT_SIZE_DYN(w, ECC_KEY_MAX_BITS(key), MAX_ECC_BITS_USE);
+   DECL_MP_INT_SIZE_DYN(w, ECC_KEY_MAX_BITS_NONULLCHECK(key), MAX_ECC_BITS_USE);
 #if !defined(WOLFSSL_ASYNC_CRYPT) || !defined(HAVE_CAVIUM_V)
-   DECL_MP_INT_SIZE_DYN(e_lcl, ECC_KEY_MAX_BITS(key), MAX_ECC_BITS_USE);
+   DECL_MP_INT_SIZE_DYN(e_lcl, ECC_KEY_MAX_BITS_NONULLCHECK(key), MAX_ECC_BITS_USE);
 #endif
    mp_int*    e;
    mp_int*    v = NULL;      /* Will be w. */
@@ -8639,7 +8647,7 @@ static int ecc_verify_hash(mp_int *r, mp_int *s, const byte* hash,
 
    err = mp_init(e);
 #else
-   NEW_MP_INT_SIZE(e_lcl, ECC_KEY_MAX_BITS(key), key->heap, DYNAMIC_TYPE_ECC);
+   NEW_MP_INT_SIZE(e_lcl, ECC_KEY_MAX_BITS_NONULLCHECK(key), key->heap, DYNAMIC_TYPE_ECC);
 #ifdef MP_INT_SIZE_CHECK_NULL
    if (e_lcl == NULL) {
        return MEMORY_E;
@@ -8647,7 +8655,7 @@ static int ecc_verify_hash(mp_int *r, mp_int *s, const byte* hash,
 #endif
    e = e_lcl;
 
-   err = INIT_MP_INT_SIZE(e, ECC_KEY_MAX_BITS(key));
+   err = INIT_MP_INT_SIZE(e, ECC_KEY_MAX_BITS_NONULLCHECK(key));
 #endif /* WOLFSSL_ASYNC_CRYPT && HAVE_CAVIUM_V */
    if (err != MP_OKAY) {
 #ifdef WOLFSSL_SMALL_STACK
@@ -8709,7 +8717,7 @@ static int ecc_verify_hash(mp_int *r, mp_int *s, const byte* hash,
    }
 #endif /* WOLFSSL_ASYNC_CRYPT && WC_ASYNC_ENABLE_ECC */
 
-   NEW_MP_INT_SIZE(w, ECC_KEY_MAX_BITS(key), key->heap, DYNAMIC_TYPE_ECC);
+   NEW_MP_INT_SIZE(w, ECC_KEY_MAX_BITS_NONULLCHECK(key), key->heap, DYNAMIC_TYPE_ECC);
 #ifdef MP_INT_SIZE_CHECK_NULL
    if (w == NULL) {
        err = MEMORY_E;
@@ -8722,7 +8730,7 @@ static int ecc_verify_hash(mp_int *r, mp_int *s, const byte* hash,
        v = w;
    }
    if (err == MP_OKAY) {
-       err = INIT_MP_INT_SIZE(w, ECC_KEY_MAX_BITS(key));
+       err = INIT_MP_INT_SIZE(w, ECC_KEY_MAX_BITS_NONULLCHECK(key));
    }
 
    /* allocate points */

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -267,8 +267,10 @@ int wc_InitRsaKey_Id(RsaKey* key, unsigned char* id, int len, void* heap,
         ret = BUFFER_E;
 
 #if defined(HAVE_PKCS11)
-    XMEMSET(key, 0, sizeof(RsaKey));
-    key->isPkcs11 = 1;
+    if (ret == 0) {
+        XMEMSET(key, 0, sizeof(RsaKey));
+        key->isPkcs11 = 1;
+    }
 #endif
 
     if (ret == 0)
@@ -302,8 +304,10 @@ int wc_InitRsaKey_Label(RsaKey* key, const char* label, void* heap, int devId)
     }
 
 #if defined(HAVE_PKCS11)
-    XMEMSET(key, 0, sizeof(RsaKey));
-    key->isPkcs11 = 1;
+    if (ret == 0) {
+        XMEMSET(key, 0, sizeof(RsaKey));
+        key->isPkcs11 = 1;
+    }
 #endif
 
     if (ret == 0)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -212,7 +212,7 @@ const byte const_byte_array[] = "A+Gd\0\0\0";
         int ret;
         char tmpBuf[80];
 
-        ret = vsnprintf(tmpBuf, sizeof(tmpBuf), format, args);
+        ret = XVSNPRINTF(tmpBuf, sizeof(tmpBuf), format, args);
         printf(tmpBuf);
 
     return ret;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -212,7 +212,7 @@ const byte const_byte_array[] = "A+Gd\0\0\0";
         int ret;
         char tmpBuf[80];
 
-        ret = XSNPRINTF(tmpBuf, sizeof(tmpBuf), format, args);
+        ret = vsnprintf(tmpBuf, sizeof(tmpBuf), format, args);
         printf(tmpBuf);
 
     return ret;

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1193,7 +1193,12 @@ extern void uITRON4_free(void *p) ;
     #if !defined(XMALLOC_OVERRIDE) && !defined(XMALLOC_USER)
         #define XMALLOC_OVERRIDE
         #define XMALLOC(s, h, t)    ((void)(h), (void)(t), (void *)_mem_alloc_system((s)))
-        #define XFREE(p, h, t)      {void* xp = (p); (void)(h); (void)(t); if ((xp)) _mem_free((xp));}
+        #ifdef WOLFSSL_XFREE_NO_NULLNESS_CHECK
+            #define XFREE(p, h, t)      {(void)(h); (void)(t); _mem_free(p);}
+        #else
+            #define XFREE(p, h, t)      {void* xp = (p); (void)(h); (void)(t); if ((xp)) _mem_free((xp));}
+        #endif
+
         /* Note: MQX has no realloc, using fastmath above */
     #endif
     #ifdef USE_FAST_MATH
@@ -1224,7 +1229,11 @@ extern void uITRON4_free(void *p) ;
     #endif
 
     #define XMALLOC(s, h, t)    ((void)(h), (void)(t), (void *)_mem_alloc_system((s)))
-    #define XFREE(p, h, t)      {void* xp = (p); (void)(h); (void)(t); if ((xp)) _mem_free((xp));}
+    #ifdef WOLFSSL_XFREE_NO_NULLNESS_CHECK
+        #define XFREE(p, h, t)      {(void)(h); (void)(t); _mem_free(p);}
+    #else
+        #define XFREE(p, h, t)      {void* xp = (p); (void)(h); (void)(t); if ((xp)) _mem_free((xp));}
+    #endif
     #define XREALLOC(p, n, h, t) _mem_realloc((p), (n)) /* since MQX 4.1.2 */
 
     #define MQX_FILE_PTR FILE *

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -356,7 +356,7 @@ typedef struct w64wrapper {
                 #define WC_INLINE inline
             #endif
         #else
-            #define WC_INLINE
+            #define WC_INLINE WC_MAYBE_UNUSED
         #endif
     #else
         #define WC_INLINE WC_MAYBE_UNUSED


### PR DESCRIPTION
fixes for cppcheck-2.13.0 `--force`:
* fix null pointer derefs in `wc_InitRsaKey_Id()` and `wc_InitRsaKey_Label()` (`nullPointerRedundantCheck`).
* fix use of wrong `printf` variant in `rsip_vprintf()` (`wrongPrintfScanfArgNum`).
* fix wrong `printf` format in `bench_xmss_sign_verify()` (`invalidPrintfArgType_sint`).
* add missing `WOLFSSL_XFREE_NO_NULLNESS_CHECK` variants of `XFREE()` (`WOLFSSL_LINUXKM`, `FREESCALE_MQX`, `FREESCALE_KSDK_MQX`).
* suppress false-positive `uninitvar` on `limit` in `CheckTLS13AEADSendLimit()`.
* suppress true-but-benign-positive `autoVariables` in `DoClientHello()`.
* in `wolfcrypt/src/ecc.c`, refactor `ECC_KEY_MAX_BITS()` as a local function to resolve true-but-benign-positive `identicalInnerCondition`.
* refactor flow in `wc_ecc_sign_hash_ex()` to resolve true-but-benign-positive `identicalInnerCondition`.

tested with `wolfssl-multi-test.sh ... super-quick-check '.*cppcheck.*'` with the following updates (relative to testing repo master) to `CPPCHECK_COMMON_ARGS`:
```
@@ -786,24 +797,32 @@ fi
 
 if [[ ! -v CPPCHECK_COMMON_ARGS ]]; then
     # blanket suppressions are to work around noise (warnings for non-defects) and bugs (false positives) in cppcheck 2.9
+    # -U clauses for FP_* added to work around likely-bug in cppcheck-2.13.0 around the __USE_ISOC99 definitions in math.h.
+    # -UWOLFSSL_XILINX avoids broken macro scheme in wc_port.h for XFILE and friends.
     CPPCHECK_COMMON_ARGS=(
        --error-exitcode=2
        --inline-suppr
        -I.
        -DWOLFSSL_XFREE_NO_NULLNESS_CHECK
+       -UWOLFSSL_SP_NO_DYN_STACK
        --std=c99
-       --suppress=arrayIndexOutOfBounds
-       --suppress=arrayIndexOutOfBoundsCond
-       --suppress=objectIndex
+       -D__STDC_VERSION__=199901L
        --suppress=preprocessorErrorDirective
        --suppress=knownConditionTrueFalse
+       --suppress=objectIndex:wolfcrypt/src/misc.c
        --suppress=legacyUninitvar
        '--suppress=uninitvar:*.i'
        --suppress=uninitvar:wolfcrypt/src/integer.c
        --suppress=nullPointerRedundantCheck:wolfcrypt/src/wolfmath.c
+       -UFP_NAN -UFP_INFINITE -UFP_ZERO -UFP_SUBNORMAL -UFP_NORMAL
+       -UWOLFSSL_XILINX
+       -UWC_16BIT_CPU
     )
     # formerly masked for false positives in cppcheck 2.6.3, but clean in 2.9:
     #  --suppress=pointerOutOfBoundsCond
+    # formerly masked for false positives, but clean in 2.13.0:
+    #  --suppress=arrayIndexOutOfBounds
+    #  --suppress=arrayIndexOutOfBoundsCond
 else
     string_to_array CPPCHECK_COMMON_ARGS
 fi
```
and also adding `--suppress=shiftTooManyBits:wolfcrypt/src/sp_int.c -UWOLFSSL_DEBUG_MATH` to `cppcheck_args` in the `cppcheck-force-source` recipe.

(will post update to `wolfssl-multi-test` once it's had a fully clean run through the nightly.)
