### PR TITLE
FIPS Script

### DIFF
--- a/fips-check.sh
+++ b/fips-check.sh
@@ -140,7 +140,7 @@ marvell-linux-selftest)
 linuxv5)
   FIPS_OPTION='v5'
   FIPS_FILES=(
-    'wolfcrypt/src/fips.c:WCv5.0-RC12'
+    'wolfcrypt/src/fips.c:WCv5.2.0.1-RC01'
     'wolfcrypt/src/fips_test.c:WCv5.0-RC12'
     'wolfcrypt/src/wolfcrypt_first.c:WCv5.0-RC12'
     'wolfcrypt/src/wolfcrypt_last.c:WCv5.0-RC12'


### PR DESCRIPTION
# Description

Update fips-check.sh for checking out v5.2.0.1 of the fips.c file.

# Testing

Run fips-check linuxv5, should have the file src/fips.c that says "v5.2.0.1" in the version function.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
