### PR TITLE
20240107-fix-linuxkm-commercial-POC

### DIFF
--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -350,6 +350,8 @@ static int my_preempt_count(void) {
     return preempt_count();
 }
 
+#if defined(WOLFSSL_LINUXKM_SIMD_X86) && defined(WOLFSSL_COMMERCIAL_LICENSE)
+
 /* ditto for fpregs_lock/fpregs_unlock */
 #ifdef WOLFSSL_LINUXKM_USE_SAVE_VECTOR_REGISTERS
 static void my_fpregs_lock(void) {
@@ -359,7 +361,10 @@ static void my_fpregs_lock(void) {
 static void my_fpregs_unlock(void) {
     fpregs_unlock();
 }
-#endif
+
+#endif /* WOLFSSL_LINUXKM_SIMD_X86 && WOLFSSL_COMMERCIAL_LICENSE */
+
+#endif /* USE_WOLFSSL_LINUXKM_PIE_REDIRECT_TABLE */
 
 static int set_up_wolfssl_linuxkm_pie_redirect_table(void) {
     memset(


### PR DESCRIPTION
`linuxkm/module_hooks.c`: add proper gating for ``my_fpregs_[un]lock()`.

tested with `wolfssl-multi-test.sh ... super-quick-check '.*linuxkm-commercial.*' linuxkm-all-fips-140-3 linuxkm-all-fips-140-3-dyn-hash linuxkm-all-fips-140-3-dev-dyn-hash linuxkm-pie linuxkm-all-asm-cryptonly-opensslextra-pie linuxkm-legacy-4.4 linuxkm-legacy-4.9 linuxkm-legacy-5.4 linuxkm-legacy-5.10 linuxkm-legacy-5.15 linuxkm-legacy-6.1 linuxkm-mainline-pie linuxkm-mainline-aesni-pie-gcc-latest-insmod`
