### PR TITLE
ServerKeyExchange edche-psk: Add missing setting of ecdhCurveOID

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -29900,6 +29900,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                     if ((args->idx - args->begin) + length > size) {
                         ERROR_OUT(BUFFER_ERROR, exit_dske);
                     }
+                    ssl->ecdhCurveOID = curveOid;
 
                 #ifdef HAVE_CURVE25519
                     if (ssl->ecdhCurveOID == ECC_X25519_OID) {


### PR DESCRIPTION
Found when DTLS wolfSSL client and Mbed TLS server agree on using TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256 in ServerHello.

ServerKeyExchange

case ecdhe_psk_kea:

curveOid correctly determing to be ECC_X25519_OID, but ecdhCurveOID was not getting set for subsequent tests.  Error result occurred when (wrongly) trying to do wc_ecc_import_x963_ex().

(Eee correct solution under case ecc_diffie_hellman_kea:).

# Description

Please describe the scope of the fix or feature addition.

Fixes handling TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256  when talking to Mbed TLS server

# Testing

Connecting to a MBedTLS server using DTLS.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
