### PR TITLE
XC32 compiler version 4.x compatibility

### DIFF
--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -700,8 +700,8 @@ typedef struct w64wrapper {
         #endif
 
         #ifndef XSTRCASECMP
-        #if defined(MICROCHIP_PIC32) && (__XC32_VERSION >= 1000)
-            /* XC32 supports str[n]casecmp in version >= 1.0. */
+        #if defined(MICROCHIP_PIC32) && (__XC32_VERSION >= 1000) && (__XC32_VERSION < 4000)
+            /* XC32 supports str[n]casecmp in version >= 1.0 through 4.0. */
             #define XSTRCASECMP(s1,s2) strcasecmp((s1),(s2))
         #elif defined(MICROCHIP_PIC32) || defined(WOLFSSL_TIRTOS) || \
                 defined(WOLFSSL_ZEPHYR)


### PR DESCRIPTION
# Description

With the new Microchip Unified Standard C Library in the XC32 v4.00 release, most functions that are not part of the C99 spec were removed.

“strcasecmp” is one of those functions. It seems all versions from v4.00 onward should use wc_strcasecmp.

# Fixes

zd17251

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
