### PR TITLE
Print out how ./configure was called

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9584,6 +9584,8 @@ echo "   * keylog export:              $ENABLED_KEYLOG_EXPORT"
 echo ""
 echo "---"
 
+echo "./configure flags: $(./config.status --config)"
+
 fi # $silent != yes
 
 ################################################################################


### PR DESCRIPTION
This will make debugging and tracing back from logs much easier