### PR TITLE
fix unsupported arm instruction compile error

### DIFF
--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -1194,7 +1194,7 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
 #ifndef WOLFSSL_NO_FENCE
     #if defined (__i386__) || defined(__x86_64__)
         #define XFENCE() XASM_VOLATILE("lfence")
-    #elif defined (__arm__) || defined(__aarch64__)
+    #elif (defined (__arm__) && (__ARM_ARCH > 6)) || defined(__aarch64__)
         #define XFENCE() XASM_VOLATILE("isb")
     #elif defined(__riscv)
         #define XFENCE() XASM_VOLATILE("fence")


### PR DESCRIPTION
# Description

Fix Jenkins jobs
[Android build](https://cloud.wolfssl-test.com/jenkins/job/nightly-Android6-wolfJSEE-build/)
[toolchain armv5](https://cloud.wolfssl-test.com/jenkins/job/nightly-toolchain-armv5-eabi-glibc-v2/)
[toolchain armv6](https://cloud.wolfssl-test.com/jenkins/job/nightly-toolchain-armv6-eabihf-glibc-v2/)

isb is supported from arm v7 architecture.

# Testing
Build wolfssl with cross compiler

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
