### PR TITLE
20240117-nightly-fixes

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -778,7 +778,9 @@ static CRL_Entry* DupCRL_Entry(const CRL_Entry* ent, void* heap)
         XMEMCPY(dupl->toBeSigned, ent->toBeSigned, dupl->tbsSz);
         XMEMCPY(dupl->signature, ent->signature, dupl->signatureSz);
     #ifdef WC_RSA_PSS
-        XMEMCPY(dupl->sigParams, ent->sigParams, dupl->sigParamsSz);
+        if (dupl->sigParamsSz > 0) {
+            XMEMCPY(dupl->sigParams, ent->sigParams, dupl->sigParamsSz);
+        }
     #endif
     }
     else {


### PR DESCRIPTION
`src/crl.c`: fix "null pointer passed as argument 2" in new `XMEMCPY()` call in `WC_RSA_PSS` path of `DupCRL_Entry()`, added in b140f93b17, detected by gcc 14.0.0_pre20240107 p15 with sanitizers.

tested with `../testing/git-hooks/wolfssl-multi-test.sh --enable-bwrap --enable-git-blame -j 24 --keep-going --max-check-try-count=3 --no-result-cache --verbose-analyzers --test-uncommitted sanitizer-all-intelasm-c-fallback-fuzzer all-gcc-c89-sanitize pq-all-sanitizer linuxkm-commercial-aesni-pie-insmod cross-aarch64-all-armasm-unittest-sanitizer check-self check-file-modes check-source-text check-shell-scripts check-configure all-gcc-c99 all-g++ cppcheck-all clang-tidy-all-sp-all sanitizer-all-intelasm-c-fallback-fuzzer`
