### PR TITLE
CRL Monitor Test Fix

### DIFF
--- a/tests/utils.h
+++ b/tests/utils.h
@@ -111,6 +111,13 @@ cleanup:
         XFCLOSE(outFile);
     return ret;
 }
+
+#if defined(__MACH__) || defined(__FreeBSD__)
+int link_file(const char* in, const char* out)
+{
+    return link(in, out);
+}
+#endif
 #endif /* !NO_FILESYSTEM */
 
 #if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && !defined(NO_RSA) && \

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -327,7 +327,7 @@ static int test_crl_monitor(void)
         if (i % 2 == 0) {
             /* succeed on even rounds */
             sprintf(buf, "%s/%s", tmpDir, "crl.pem");
-            if (copy_file("certs/crl/crl.pem", buf) != 0) {
+            if (STAGE_FILE("certs/crl/crl.pem", buf) != 0) {
                 fprintf(stderr, "[%d] Failed to copy file to %s\n", i, buf);
                 goto cleanup;
             }
@@ -350,7 +350,7 @@ static int test_crl_monitor(void)
         else {
             /* fail on odd rounds */
             sprintf(buf, "%s/%s", tmpDir, "crl.revoked");
-            if (copy_file("certs/crl/crl.revoked", buf) != 0) {
+            if (STAGE_FILE("certs/crl/crl.revoked", buf) != 0) {
                 fprintf(stderr, "[%d] Failed to copy file to %s\n", i, buf);
                 goto cleanup;
             }

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -656,6 +656,13 @@ int rem_dir(const char* dirName);
 int rem_file(const char* fileName);
 int copy_file(const char* in, const char* out);
 
+#if defined(__MACH__) || defined(__FreeBSD__)
+    int link_file(const char* in, const char* out);
+    #define STAGE_FILE(x,y) link_file((x),(y))
+#else
+    #define STAGE_FILE(x,y) copy_file((x),(y))
+#endif
+
 void signal_ready(tcp_ready* ready);
 
 /* wolfSSL */


### PR DESCRIPTION
# Description

Changed the CRL Monitor test so that it uses the macro STAGE_FILE to stage the CRL files for its test cases. That macro will be copy_file() in most builds. In macOS builds (Mach or FreeBSD), STAGE_FILE will be link_file() which makes a hard link of the CRL file instead of a copy. On the Mac, intermittently, the copy_file() will trigger a CRL monitor update when the file is first opened, not when the copy is complete. link() is atomic.

# Testing

Running on a macMini M1, I would get intermittent failures in the testsuite. Just ran it `./configure --enable-all`, or `./configure --enable-crl --enable-crl-monitor`. I'd just run the testsuite a few times.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
