### PR TITLE
EarlySanityCheckMsgReceived: version_negotiated should always be checked

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -10971,18 +10971,11 @@ int EarlySanityCheckMsgReceived(WOLFSSL* ssl, byte type, word32 msgSz)
 {
     int ret = 0;
 #ifndef WOLFSSL_DISABLE_EARLY_SANITY_CHECKS
-    byte version_negotiated = 0;
-
-    WOLFSSL_ENTER("EarlySanityCheckMsgReceived");
-
-#ifdef WOLFSSL_DTLS
     /* Version has only been negotiated after we either send or process a
      * ServerHello message */
-    if (ssl->options.dtls)
-        version_negotiated = ssl->options.serverState >= SERVER_HELLO_COMPLETE;
-    else
-#endif
-        version_negotiated = 1;
+    byte version_negotiated = ssl->options.serverState >= SERVER_HELLO_COMPLETE;
+
+    WOLFSSL_ENTER("EarlySanityCheckMsgReceived");
 
     if (version_negotiated)
         ret = MsgCheckEncryption(ssl, type, ssl->keys.decryptedCur == 1);


### PR DESCRIPTION
Multiple handshake messages in one record will fail the MsgCheckBoundary() check on the client side when the client is set to TLS 1.3 but allows downgrading.
  --> ClientHello
  <-- ServerHello + rest of TLS 1.2 flight
  Client returns OUT_OF_ORDER_E because in TLS 1.3 the ServerHello has to be the last message in a record. In TLS 1.2 the ServerHello can be in the same record as the rest of the server's first flight.
