### PR TITLE
20240119-DoTls13CertificateVerify-CreateSigData-error-handling

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -9882,8 +9882,9 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
                     ERROR_OUT(MEMORY_E, exit_dcv);
                 }
 
-                CreateSigData(ssl, args->sigData, &args->sigDataSz, 1);
-                ret = 0;
+                ret = CreateSigData(ssl, args->sigData, &args->sigDataSz, 1);
+                if (ret < 0)
+                    goto exit_dcv;
             }
         #endif
         #ifdef HAVE_ED448
@@ -9896,8 +9897,9 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
                     ERROR_OUT(MEMORY_E, exit_dcv);
                 }
 
-                CreateSigData(ssl, args->sigData, &args->sigDataSz, 1);
-                ret = 0;
+                ret = CreateSigData(ssl, args->sigData, &args->sigDataSz, 1);
+                if (ret < 0)
+                    goto exit_dcv;
             }
        #endif
        #ifdef HAVE_PQC
@@ -9909,7 +9911,11 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
                     ERROR_OUT(MEMORY_E, exit_dcv);
                 }
 
-                CreateSigData(ssl, sigData, &sigDataSz, 1);
+                ret = CreateSigData(ssl, sigData, &sigDataSz, 1);
+                if (ret < 0) {
+                    goto exit_dcv;
+                }
+
 #ifdef WOLFSSL_DUAL_ALG_CERTS
                 if (!wolfSSL_is_server(ssl) &&
                     ssl->sigSpec != NULL &&


### PR DESCRIPTION
`src/tls13.c`: in `DoTls13CertificateVerify()`, add missing error handling in several calls to `CreateSigData()`.

tested with `../testing/git-hooks/wolfssl-multi-test.sh --enable-bwrap --enable-git-blame -j 24 --keep-going --max-check-try-count=3 --no-result-cache --verbose-analyzers --test-uncommitted --verbose-qemu-system pq-all-clang-tidy`

problem report from nightly:
```
[pq-all-clang-tidy] [54 of 216] [ac81d9d29c]
    configure...   real 0m19.953s  user 0m10.616s  sys 0m10.792s
    build...9be390250d (<anhu@users.noreply.github.com> 2024-01-18 16:20:57 -0500 9925)                     args->sigDataSz = sigDataSz;
/home/wolfbot/tmp/wolfssl_test_workdir.56048/wolfssl/src/tls13.c:9925:37: warning: Assigned value is garbage or undefined [clang-analyzer-core.uninitialized.Assign]
9925 |                     args->sigDataSz = sigDataSz;
|                                     ^ ~~~~~~~~~
[...]
```
