### PR TITLE
Remove the PSA restriction to allow use with crypto callbacks

### DIFF
--- a/wolfssl/wolfcrypt/port/psa/psa.h
+++ b/wolfssl/wolfcrypt/port/psa/psa.h
@@ -44,13 +44,6 @@
 
 #include <wolfssl/wolfcrypt/types.h>
 
-/* PSA implementation takes over the Sha struct and Sha functions implementation
-   completely. Devoiding the struct of the DevId field and hooks to make
-   crypto_cb work. */
-#if !defined(WOLFSSL_PSA_NO_HASH) && defined(WOLF_CRYPTO_CB)
-#error "WOLFSSL PSA is not supported with WOLF_CRYPTO_CB"
-#endif
-
 #if defined(WOLFSSL_HAVE_PSA)
 
 #include <psa/crypto.h>


### PR DESCRIPTION
# Description

Remove the PSA restriction to allow use with crypto callbacks

# Testing

`./configure --enable-pkcs7 --enable-psa --with-psa-lib-name=mbedcrypto --enable-cryptocb --enable-pkcallbacks CFLAGS="-DWOLFSSL_PSA_GLOBAL_LOCK" --enable-debug && make && sudo make install`

Tested with https://github.com/wolfSSL/wolfssl-examples/pull/417

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
