### PR TITLE
warning fix for small PSK build

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -26678,7 +26678,9 @@ static int ParseCipherList(Suites* suites,
         suites->setSuites = 1;
     }
 
+#ifdef NO_CERTS
     (void)privateKeySz;
+#endif
 
     return ret;
 }

--- a/wolfssl/openssl/bn.h
+++ b/wolfssl/openssl/bn.h
@@ -40,7 +40,7 @@
 typedef struct WOLFSSL_BIGNUM {
     int neg;        /* openssh deference */
     void *internal; /* our big num */
-#ifndef NO_BIG_INT
+#if !defined(NO_BIG_INT) || defined(WOLFSSL_SP_MATH)
     mp_int mpi;
 #endif
 } WOLFSSL_BIGNUM;

--- a/wolfssl/openssl/bn.h
+++ b/wolfssl/openssl/bn.h
@@ -40,7 +40,9 @@
 typedef struct WOLFSSL_BIGNUM {
     int neg;        /* openssh deference */
     void *internal; /* our big num */
+#ifndef NO_BIG_INT
     mp_int mpi;
+#endif
 } WOLFSSL_BIGNUM;
 
 #define WOLFSSL_BN_ULONG unsigned long


### PR DESCRIPTION
Found when measuring heap use with a small PSK build:

```
./configure --enable-psk --enable-trackmemory CPPFLAGS="-DNO_BIG_INT -DWOLFSSL_STATIC_PSK" --disable-sp-math-all --disable-fastmath --disable-heapmath --disable-ecc --disable-rsa --disable-dh --disable-tls13 --disable-oldtls --enable-static --disable-shared --enable-smallstack --disable-pwdbased --disable-pkcs12
```