### PR TITLE
Fix missing return in DTLS1.3 / FIPS code

### DIFF
--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -262,6 +262,7 @@ static int Dtls13GetRnMask(WOLFSSL* ssl, const byte* ciphertext, byte* mask,
         return wc_AesEncryptDirect(c->aes, mask, ciphertext);
 #else
         wc_AesEncryptDirect(c->aes, mask, ciphertext);
+        return 0;
 #endif
     }
 #endif /* HAVE_AESGCM || HAVE_AESCCM */


### PR DESCRIPTION
# Description

My previous commit 0a88bb9779b1355cc833f2b8614a698ee41c30f8 to be able to compile DTLS1.3 with FIPS (older versions) was missing a return. 

# Testing

With this is can create working DTLS 1.3 connections in FIPS builds.
 
# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
