### PR TITLE
Allow for critical extensions early.

### DIFF
--- a/src/ssl_certman.c
+++ b/src/ssl_certman.c
@@ -649,7 +649,11 @@ int CM_VerifyBuffer_ex(WOLFSSL_CERT_MANAGER* cm, const unsigned char* buff,
      }
 
 #ifdef HAVE_CRL
-    if ((ret == 0) && cm->crlEnabled) {
+    if ((ret == 0
+#ifdef WOLFSSL_NO_ASN_STRICT
+        || ret == ASN_CRIT_EXT_E
+#endif
+        ) && cm->crlEnabled) {
         /* Check for a CRL for the CA and check validity of certificate. */
         ret = CheckCertCRL(cm->crl, cert);
     }

--- a/src/ssl_certman.c
+++ b/src/ssl_certman.c
@@ -651,11 +651,7 @@ int CM_VerifyBuffer_ex(WOLFSSL_CERT_MANAGER* cm, const unsigned char* buff,
      }
 
 #ifdef HAVE_CRL
-     if ((ret == 0
-#ifdef WOLFSSL_CRL_CHECK_ON_CRIT_EXT
-        || ret == ASN_CRIT_EXT_E
-#endif
-        ) && cm->crlEnabled) {
+     if ((ret == 0 || ret == ASN_CRIT_EXT_E) && cm->crlEnabled) {
         /* Check for a CRL for the CA and check validity of certificate. */
         ret = CheckCertCRL(cm->crl, cert);
     }

--- a/src/ssl_certman.c
+++ b/src/ssl_certman.c
@@ -652,7 +652,7 @@ int CM_VerifyBuffer_ex(WOLFSSL_CERT_MANAGER* cm, const unsigned char* buff,
 
 #ifdef HAVE_CRL
      if ((ret == 0
-#ifdef WOLFSSL_NO_ASN_STRICT
+#ifdef WOLFSSL_CRL_CHECK_ON_CRIT_EXT
         || ret == ASN_CRIT_EXT_E
 #endif
         ) && cm->crlEnabled) {


### PR DESCRIPTION
Later another check will be done, but that one can be overridden with custom extension handler. 
Fixes ZD17329

