### PR TITLE
Reset expired session on ssl object

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -14480,6 +14480,8 @@ int wolfSSL_SetSession(WOLFSSL* ssl, WOLFSSL_SESSION* session)
 
     if (LowResTimer() >= (ssl->session->bornOn + ssl->session->timeout)) {
 #if !defined(OPENSSL_EXTRA) || !defined(WOLFSSL_ERROR_CODE_OPENSSL)
+        wolfSSL_FreeSession(ssl->ctx, ssl->session);
+        ssl->session = NULL;
         return WOLFSSL_FAILURE;  /* session timed out */
 #else /* defined(OPENSSL_EXTRA) && defined(WOLFSSL_ERROR_CODE_OPENSSL) */
         WOLFSSL_MSG("Session is expired but return success for "

--- a/tests/api.c
+++ b/tests/api.c
@@ -45817,7 +45817,7 @@ static int test_wolfSSL_SESSION(void)
     ExpectNotNull(ssl = wolfSSL_new(ctx));
     ExpectIntEQ(wolfSSL_set_session(ssl, sess), SSL_FAILURE);
 #endif
-#else
+#elif !defined(NO_SESSION_CACHE) && defined(HAVE_EXT_CACHE)
     /* session timeout case */
     /* make the session to be expired */
     ExpectIntEQ(wolfSSL_SSL_SESSION_set_timeout(sess,1), SSL_SUCCESS);

--- a/tests/api.c
+++ b/tests/api.c
@@ -45788,12 +45788,11 @@ static int test_wolfSSL_SESSION(void)
     }
 #endif
 
+#ifdef OPENSSL_EXTRA
     /* session timeout case */
     /* make the session to be expired */
-    ExpectIntEQ(wolfSSL_SSL_SESSION_set_timeout(sess,1), SSL_SUCCESS);
+    ExpectIntEQ(SSL_SESSION_set_timeout(sess,1), SSL_SUCCESS);
     XSLEEP_MS(1200);
-
-#ifdef OPENSSL_EXTRA
     /* SSL_set_session should reject specified session but return success
      * if WOLFSSL_ERROR_CODE_OPENSSL macro is defined for OpenSSL compatibility.
      */
@@ -45819,6 +45818,10 @@ static int test_wolfSSL_SESSION(void)
     ExpectIntEQ(wolfSSL_set_session(ssl, sess), SSL_FAILURE);
 #endif
 #else
+    /* session timeout case */
+    /* make the session to be expired */
+    ExpectIntEQ(wolfSSL_SSL_SESSION_set_timeout(sess,1), SSL_SUCCESS);
+    XSLEEP_MS(1200);
     ExpectIntEQ(wolfSSL_set_session(ssl,sess), SSL_FAILURE);
     /* verify session was reset for a clean ssl object */
     ExpectNull(ssl->session);

--- a/tests/api.c
+++ b/tests/api.c
@@ -45788,12 +45788,12 @@ static int test_wolfSSL_SESSION(void)
     }
 #endif
 
-#ifdef OPENSSL_EXTRA
     /* session timeout case */
     /* make the session to be expired */
-    ExpectIntEQ(SSL_SESSION_set_timeout(sess,1), SSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_SSL_SESSION_set_timeout(sess,1), SSL_SUCCESS);
     XSLEEP_MS(1200);
 
+#ifdef OPENSSL_EXTRA
     /* SSL_set_session should reject specified session but return success
      * if WOLFSSL_ERROR_CODE_OPENSSL macro is defined for OpenSSL compatibility.
      */
@@ -45818,6 +45818,10 @@ static int test_wolfSSL_SESSION(void)
     ExpectNotNull(ssl = wolfSSL_new(ctx));
     ExpectIntEQ(wolfSSL_set_session(ssl, sess), SSL_FAILURE);
 #endif
+#else
+    ExpectIntEQ(wolfSSL_set_session(ssl,sess), SSL_FAILURE);
+    /* verify session was reset for a clean ssl object */
+    ExpectNull(ssl->session);
 #endif /* OPENSSL_EXTRA */
 
     wolfSSL_free(ssl);


### PR DESCRIPTION
# Description

when a session is set but is expired, free the expired

session on ssl object in case the user still wants to use the ssl object, but with a fresh session

Fixes zd#17345

# Testing

Added test case that times out the session and makes sure it's NULL after wolfSSL_set_session is called

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
