### PR TITLE
Fix compilation errors about uninitialized variables

### DIFF
--- a/examples/asn1/asn1.c
+++ b/examples/asn1/asn1.c
@@ -180,8 +180,8 @@ static int FindPem(unsigned char* data, word32 offset, word32 len,
     word32* start, word32* end)
 {
     int ret = 0;
-    word32 i;
-    word32 j;
+    word32 i = 0;
+    word32 j = 0;
 
     /* Find header. */
     for (i = offset; i < len; i++) {

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -4724,8 +4724,8 @@ static int EchCheckAcceptance(WOLFSSL* ssl, const byte* input,
     int serverRandomOffset, int helloSz)
 {
     int ret = 0;
-    int digestType;
-    int digestSize;
+    int digestType = 0;
+    int digestSize = 0;
     HS_Hashes* tmpHashes;
     HS_Hashes* acceptHashes;
     byte zeros[WC_MAX_DIGEST_SIZE];
@@ -4857,10 +4857,10 @@ static int EchWriteAcceptance(WOLFSSL* ssl, byte* output,
   int serverRandomOffset, int helloSz)
 {
     int ret = 0;
-    int digestType;
-    int digestSize;
-    HS_Hashes* tmpHashes;
-    HS_Hashes* acceptHashes;
+    int digestType = 0;
+    int digestSize = 0;
+    HS_Hashes* tmpHashes = NULL;
+    HS_Hashes* acceptHashes = NULL;
     byte zeros[WC_MAX_DIGEST_SIZE];
     byte transcriptEchConf[WC_MAX_DIGEST_SIZE];
     byte expandLabelPrk[WC_MAX_DIGEST_SIZE];

--- a/tests/api.c
+++ b/tests/api.c
@@ -2390,7 +2390,7 @@ static int test_wolfSSL_CertManagerGetCerts(void)
 #endif
     int i = 0;
     int ret = 0;
-    const byte* der;
+    const byte* der = NULL;
     int derSz = 0;
 
     ExpectNotNull(file1 = fopen("./certs/ca-cert.pem", "rb"));
@@ -11525,14 +11525,14 @@ static int test_wolfSSL_X509_NAME_get_entry(void)
         (defined(OPENSSL_EXTRA) && \
             (defined(KEEP_PEER_CERT) || defined(SESSION_CERTS)))
     /* use openssl like name to test mapping */
-    X509_NAME_ENTRY* ne;
-    X509_NAME* name;
+    X509_NAME_ENTRY* ne = NULL;
+    X509_NAME* name = NULL;
     X509* x509 = NULL;
 #ifndef NO_FILESYSTEM
-    ASN1_STRING* asn;
+    ASN1_STRING* asn = NULL;
     char* subCN = NULL;
 #endif
-    int idx;
+    int idx = 0;
     ASN1_OBJECT *object = NULL;
 #if defined(WOLFSSL_APACHE_HTTPD) || defined(OPENSSL_ALL) || \
     defined(WOLFSSL_NGINX)
@@ -11606,7 +11606,7 @@ static int test_wolfSSL_PKCS12(void)
     WOLFSSL_X509      *x509 = NULL;
 #endif
     XFILE f = XBADFILE;
-    int  bytes, ret, goodPswLen, badPswLen;
+    int  bytes = 0, ret = 0, goodPswLen = 0, badPswLen = 0;
     WOLFSSL_BIO      *bio = NULL;
     WOLFSSL_EVP_PKEY *pkey = NULL;
     WC_PKCS12        *pkcs12 = NULL;
@@ -21728,9 +21728,9 @@ static int test_wc_DsaPublicPrivateKeyDecode(void)
     EXPECT_DECLS;
 #if !defined(NO_DSA)
     DsaKey key;
-    word32 bytes;
+    word32 bytes = 0;
     word32 idx  = 0;
-    int    ret;
+    int    ret = 0;
 #ifdef USE_CERT_BUFFERS_1024
     byte   tmp[ONEK_BUF];
 
@@ -30123,8 +30123,8 @@ static int test_wolfSSL_i2c_ASN1_INTEGER(void)
     EXPECT_DECLS;
 #if defined(OPENSSL_EXTRA) && !defined(NO_ASN)
     ASN1_INTEGER *a = NULL;
-    unsigned char *pp,*tpp;
-    int ret;
+    unsigned char *pp = NULL,*tpp = NULL;
+    int ret = 0;
 
     ExpectNotNull(a = wolfSSL_ASN1_INTEGER_new());
 
@@ -31605,8 +31605,8 @@ static int test_wolfSSL_ASN1_TIME_print(void)
     BIO*  fixed = NULL;
     X509*  x509 = NULL;
     const unsigned char* der = client_cert_der_2048;
-    ASN1_TIME* notAfter;
-    ASN1_TIME* notBefore;
+    ASN1_TIME* notAfter = NULL;
+    ASN1_TIME* notBefore = NULL;
     unsigned char buf[25];
 
     ExpectNotNull(bio = BIO_new(BIO_s_mem()));
@@ -32014,15 +32014,15 @@ static int test_wolfSSL_X509_NAME(void)
     (defined(WOLFSSL_CERT_REQ) || defined(WOLFSSL_CERT_EXT) || \
      defined(OPENSSL_EXTRA))
     X509* x509 = NULL;
-    const unsigned char* c;
+    const unsigned char* c = NULL;
     unsigned char buf[4096];
-    int bytes;
+    int bytes = 0;
     XFILE f = XBADFILE;
     const X509_NAME* a = NULL;
     const X509_NAME* b = NULL;
     X509_NAME* d2i_name = NULL;
     int sz = 0;
-    unsigned char* tmp;
+    unsigned char* tmp = NULL;
     char file[] = "./certs/ca-cert.der";
 #ifndef OPENSSL_EXTRA_X509_SMALL
     byte empty[] = { /* CN=empty emailAddress= */
@@ -32973,7 +32973,7 @@ static int test_wc_CheckCertSigPubKey(void)
     EXPECT_DECLS;
 #if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && !defined(NO_FILESYSTEM) && \
     !defined(NO_RSA) && defined(WOLFSSL_PEM_TO_DER) && defined(HAVE_ECC)
-    int ret;
+    int ret = 0;
     const char* ca_cert = "./certs/ca-cert.pem";
     byte* cert_buf = NULL;
     size_t cert_sz = 0;
@@ -39802,9 +39802,9 @@ static int test_wolfSSL_X509_sign(void)
     EXPECT_DECLS;
 #if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && !defined(NO_ASN_TIME) && \
     defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_REQ) && !defined(NO_RSA)
-    int ret;
+    int ret = 0;
     char *cn = NULL;
-    word32 cnSz;
+    word32 cnSz = 0;
     X509_NAME *name = NULL;
     X509 *x509 = NULL;
     X509 *ca = NULL;
@@ -40671,8 +40671,8 @@ static int test_wolfSSL_PKCS8_d2i(void)
 
 #ifndef NO_FILESYSTEM
     unsigned char pkcs8_buffer[2048];
-    const unsigned char* p;
-    int bytes;
+    const unsigned char* p = NULL;
+    int bytes = 0;
     XFILE file = XBADFILE;
     WOLFSSL_EVP_PKEY* pkey = NULL;
 #ifndef NO_BIO
@@ -41386,7 +41386,7 @@ static int test_wolfSSL_SHA(void)
         unsigned char expected[] = "\xA9\x99\x3E\x36\x47\x06\x81\x6A\xBA\x3E"
                                    "\x25\x71\x78\x50\xC2\x6C\x9C\xD0\xD8\x9D";
         unsigned char out[WC_SHA_DIGEST_SIZE];
-        unsigned char* p;
+        unsigned char* p = NULL;
         WOLFSSL_SHA_CTX sha;
 
         XMEMSET(out, 0, WC_SHA_DIGEST_SIZE);
@@ -41427,7 +41427,7 @@ static int test_wolfSSL_SHA(void)
             "\x23\xB0\x03\x61\xA3\x96\x17\x7A\x9C\xB4\x10\xFF\x61\xF2\x00"
             "\x15\xAD";
         unsigned char out[WC_SHA256_DIGEST_SIZE];
-        unsigned char* p;
+        unsigned char* p = NULL;
 
         XMEMSET(out, 0, WC_SHA256_DIGEST_SIZE);
 #if !defined(NO_OLD_NAMES) && !defined(HAVE_FIPS)
@@ -41454,7 +41454,7 @@ static int test_wolfSSL_SHA(void)
             "\x5b\xed\x80\x86\x07\x2b\xa1\xe7\xcc\x23\x58\xba\xec\xa1\x34"
             "\xc8\x25\xa7";
         unsigned char out[WC_SHA384_DIGEST_SIZE];
-        unsigned char* p;
+        unsigned char* p = NULL;
 
         XMEMSET(out, 0, WC_SHA384_DIGEST_SIZE);
 #if !defined(NO_OLD_NAMES) && !defined(HAVE_FIPS)
@@ -41482,7 +41482,7 @@ static int test_wolfSSL_SHA(void)
             "\xfe\xeb\xbd\x45\x4d\x44\x23\x64\x3c\xe8\x0e\x2a\x9a\xc9\x4f"
             "\xa5\x4c\xa4\x9f";
         unsigned char out[WC_SHA512_DIGEST_SIZE];
-        unsigned char* p;
+        unsigned char* p = NULL;
 
         XMEMSET(out, 0, WC_SHA512_DIGEST_SIZE);
 #if !defined(NO_OLD_NAMES) && !defined(HAVE_FIPS)
@@ -42420,8 +42420,8 @@ static int test_wolfSSL_DES(void)
     const_DES_cblock myDes;
     DES_cblock iv;
     DES_key_schedule key;
-    word32 i;
-    DES_LONG dl;
+    word32 i = 0;
+    DES_LONG dl = 0;
     unsigned char msg[] = "hello wolfssl";
     unsigned char weakKey[][8] = {
         { 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01 },
@@ -45577,12 +45577,12 @@ static int test_wolfSSL_SESSION(void)
 #ifdef HAVE_EXT_CACHE
     unsigned char* sessDer = NULL;
     unsigned char* ptr     = NULL;
-    int sz;
+    int sz = 0;
 #endif
     const unsigned char context[] = "user app context";
     unsigned int contextSz = (unsigned int)sizeof(context);
 #endif
-    int ret, err;
+    int ret = 0, err = 0;
     SOCKET_T sockfd;
     tcp_ready ready;
     func_args server_args;
@@ -46230,7 +46230,7 @@ static int test_wolfSSL_d2i_PrivateKeys_bio(void)
     {
         XFILE file = XBADFILE;
         const char* fname = "./certs/server-key.der";
-        size_t sz;
+        size_t sz = 0;
         byte* buf = NULL;
 
         ExpectTrue((file = XFOPEN(fname, "rb")) != XBADFILE);
@@ -46259,7 +46259,7 @@ static int test_wolfSSL_d2i_PrivateKeys_bio(void)
     {
         XFILE file = XBADFILE;
         const char* fname = "./certs/ecc-key.der";
-        size_t sz;
+        size_t sz = 0;
         byte* buf = NULL;
 
         ExpectTrue((file = XFOPEN(fname, "rb")) != XBADFILE);
@@ -46650,14 +46650,14 @@ static int test_wolfSSL_sk_DIST_POINT(void)
     X509* x509 = NULL;
     unsigned char buf[4096];
     const unsigned char* bufPt;
-    int bytes;
-    int i;
-    int j;
+    int bytes = 0;
+    int i = 0;
+    int j = 0;
     XFILE f = XBADFILE;
-    DIST_POINT* dp;
-    DIST_POINT_NAME* dpn;
-    GENERAL_NAME* gn;
-    ASN1_IA5STRING* uri;
+    DIST_POINT* dp = NULL;
+    DIST_POINT_NAME* dpn = NULL;
+    GENERAL_NAME* gn = NULL;
+    ASN1_IA5STRING* uri = NULL;
     STACK_OF(DIST_POINT)* dps = NULL;
     STACK_OF(GENERAL_NAME)* gns = NULL;
     const char cliCertDerCrlDistPoint[] = "./certs/client-crl-dist.der";
@@ -47364,22 +47364,22 @@ static int test_wolfSSL_make_cert(void)
     EXPECT_DECLS;
 #if !defined(NO_RSA) && !defined(NO_ASN_TIME) && defined(WOLFSSL_CERT_GEN) && \
     defined(WOLFSSL_CERT_EXT)
-    int      ret;
+    int      ret = 0;
     Cert     cert;
     CertName name;
     RsaKey   key;
     WC_RNG   rng;
     byte     der[FOURK_BUF];
-    word32   idx;
+    word32   idx = 0;
     const byte mySerial[8] = {1,2,3,4,5,6,7,8};
 
 #ifdef OPENSSL_EXTRA
-    const unsigned char* pt;
-    int                  certSz;
+    const unsigned char* pt = NULL;
+    int                  certSz = 0;
     X509*                x509 = NULL;
-    X509_NAME*           x509name;
-    X509_NAME_ENTRY*     entry;
-    ASN1_STRING*         entryValue;
+    X509_NAME*           x509name = NULL;
+    X509_NAME_ENTRY*     entry = NULL;
+    ASN1_STRING*         entryValue = NULL;
 #endif
 
     XMEMSET(&name, 0, sizeof(CertName));
@@ -47930,7 +47930,7 @@ static int test_wolfSSL_CTX_ctrl(void)
     byte buf[6000];
     char file[] = "./certs/dsaparams.pem";
     XFILE f = XBADFILE;
-    int  bytes;
+    int  bytes = 0;
     BIO* bio = NULL;
     DSA* dsa = NULL;
     DH*  dh = NULL;
@@ -50042,7 +50042,7 @@ static int test_wolfSSL_X509_get_ext_by_NID(void)
 {
     EXPECT_DECLS;
 #if defined(OPENSSL_ALL) && !defined(NO_RSA)
-    int rc;
+    int rc = 0;
     XFILE f = XBADFILE;
     WOLFSSL_X509* x509 = NULL;
     ASN1_OBJECT* obj = NULL;
@@ -50084,12 +50084,12 @@ static int test_wolfSSL_X509_get_ext_subj_alt_name(void)
 {
     EXPECT_DECLS;
 #if defined(OPENSSL_ALL) && !defined(NO_RSA)
-    int rc;
+    int rc = 0;
     XFILE f = XBADFILE;
     WOLFSSL_X509* x509 = NULL;
-    WOLFSSL_X509_EXTENSION* ext;
-    WOLFSSL_ASN1_STRING* sanString;
-    byte* sanDer;
+    WOLFSSL_X509_EXTENSION* ext = NULL;
+    WOLFSSL_ASN1_STRING* sanString = NULL;
+    byte* sanDer = NULL;
 
     const byte expectedDer[] = {
         0x30, 0x13, 0x82, 0x0b, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e,
@@ -50159,8 +50159,8 @@ static int test_wolfSSL_X509_EXTENSION_get_data(void)
     EXPECT_DECLS;
 #if !defined(NO_FILESYSTEM) && defined(OPENSSL_ALL) && !defined(NO_RSA)
     WOLFSSL_X509* x509 = NULL;
-    WOLFSSL_X509_EXTENSION* ext;
-    WOLFSSL_ASN1_STRING* str;
+    WOLFSSL_X509_EXTENSION* ext = NULL;
+    WOLFSSL_ASN1_STRING* str = NULL;
     XFILE file = XBADFILE;
 
     ExpectTrue((file = XFOPEN("./certs/server-cert.pem", "rb")) != XBADFILE);
@@ -50182,9 +50182,9 @@ static int test_wolfSSL_X509_EXTENSION_get_critical(void)
     EXPECT_DECLS;
 #if !defined(NO_FILESYSTEM) && defined(OPENSSL_ALL) && !defined(NO_RSA)
     WOLFSSL_X509* x509 = NULL;
-    WOLFSSL_X509_EXTENSION* ext;
+    WOLFSSL_X509_EXTENSION* ext = NULL;
     XFILE file = XBADFILE;
-    int crit;
+    int crit = 0;
 
     ExpectTrue((file = XFOPEN("./certs/server-cert.pem", "rb")) != XBADFILE);
     ExpectNotNull(x509 = wolfSSL_PEM_read_X509(file, NULL, NULL, NULL));
@@ -50210,7 +50210,7 @@ static int test_wolfSSL_X509V3_EXT_print(void)
         XFILE f = XBADFILE;
         WOLFSSL_X509* x509 = NULL;
         X509_EXTENSION * ext = NULL;
-        int loc;
+        int loc = 0;
         BIO *bio = NULL;
 
         ExpectTrue((f = XFOPEN(svrCertFile, "rb")) != XBADFILE);
@@ -50242,9 +50242,9 @@ static int test_wolfSSL_X509V3_EXT_print(void)
     {
         X509 *x509 = NULL;
         BIO *bio = NULL;
-        X509_EXTENSION *ext;
-        unsigned int i;
-        unsigned int idx;
+        X509_EXTENSION *ext = NULL;
+        unsigned int i = 0;
+        unsigned int idx = 0;
         /* Some NIDs to test with */
         int nids[] = {
                 /* NID_key_usage, currently X509_get_ext returns this as a bit
@@ -50252,7 +50252,7 @@ static int test_wolfSSL_X509V3_EXT_print(void)
                 /* NID_ext_key_usage, */
                 NID_subject_alt_name,
         };
-        int* n;
+        int* n = NULL;
 
         ExpectNotNull(bio = BIO_new_fp(stderr, BIO_NOCLOSE));
 
@@ -50502,7 +50502,7 @@ static int test_wolfSSL_i2d_PrivateKey(void)
             (const unsigned char*)server_key_der_2048;
         unsigned char buf[FOURK_BUF];
         unsigned char* pt = NULL;
-        int bufSz;
+        int bufSz = 0;
 
         ExpectNotNull(pkey = d2i_PrivateKey(EVP_PKEY_RSA, NULL, &server_key,
             (long)sizeof_server_key_der_2048));
@@ -50521,7 +50521,7 @@ static int test_wolfSSL_i2d_PrivateKey(void)
             (const unsigned char*)ecc_clikey_der_256;
         unsigned char buf[FOURK_BUF];
         unsigned char* pt = NULL;
-        int bufSz;
+        int bufSz = 0;
 
         ExpectNotNull((pkey = d2i_PrivateKey(EVP_PKEY_EC, NULL, &client_key,
             (long)sizeof_ecc_clikey_der_256)));
@@ -50551,7 +50551,7 @@ static int test_wolfSSL_OCSP_id_get0_info(void)
     ASN1_OBJECT* pmd  = NULL;
     ASN1_STRING* keyHash = NULL;
     ASN1_INTEGER* serial = NULL;
-    ASN1_INTEGER* x509Int;
+    ASN1_INTEGER* x509Int = NULL;
 
     ExpectNotNull(cert = wolfSSL_X509_load_certificate_file(svrCertFile,
         SSL_FILETYPE_PEM));
@@ -54905,8 +54905,8 @@ static int test_wolfSSL_d2i_X509_REQ(void)
     }
     {
 #ifdef OPENSSL_ALL
-        X509_ATTRIBUTE* attr;
-        ASN1_TYPE *at;
+        X509_ATTRIBUTE* attr = NULL;
+        ASN1_TYPE *at = NULL;
 #endif
         ExpectNotNull(bio = BIO_new_file(csrPopFile, "rb"));
         ExpectNotNull(d2i_X509_REQ_bio(bio, &req));
@@ -54944,8 +54944,8 @@ static int test_wolfSSL_d2i_X509_REQ(void)
     }
     {
 #ifdef OPENSSL_ALL
-        X509_ATTRIBUTE* attr;
-        ASN1_TYPE *at;
+        X509_ATTRIBUTE* attr = NULL;
+        ASN1_TYPE *at = NULL;
         STACK_OF(X509_EXTENSION) *exts = NULL;
 #endif
         ExpectNotNull(bio = BIO_new_file(csrExtFile, "rb"));
@@ -56778,7 +56778,7 @@ static int test_wolfSSL_X509_print(void)
     X509 *x509 = NULL;
     BIO *bio = NULL;
 #if defined(OPENSSL_ALL) && !defined(NO_WOLFSSL_DIR)
-    const X509_ALGOR *cert_sig_alg;
+    const X509_ALGOR *cert_sig_alg = NULL;
 #endif
 
     ExpectNotNull(x509 = X509_load_certificate_file(svrCertFile,
@@ -56883,14 +56883,14 @@ static int test_wolfSSL_RSA(void)
     EXPECT_DECLS;
 #if defined(OPENSSL_EXTRA) && !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN)
     RSA* rsa = NULL;
-    const BIGNUM *n;
-    const BIGNUM *e;
-    const BIGNUM *d;
-    const BIGNUM *p;
-    const BIGNUM *q;
-    const BIGNUM *dmp1;
-    const BIGNUM *dmq1;
-    const BIGNUM *iqmp;
+    const BIGNUM *n = NULL;
+    const BIGNUM *e = NULL;
+    const BIGNUM *d = NULL;
+    const BIGNUM *p = NULL;
+    const BIGNUM *q = NULL;
+    const BIGNUM *dmp1 = NULL;
+    const BIGNUM *dmq1 = NULL;
+    const BIGNUM *iqmp = NULL;
 
     ExpectNotNull(rsa = RSA_new());
     ExpectIntEQ(RSA_size(NULL), 0);
@@ -57026,7 +57026,7 @@ static int test_wolfSSL_RSA(void)
         const char PrivKeyPemFile[] = "certs/client-keyEnc.pem";
 
         XFILE f = XBADFILE;
-        int bytes;
+        int bytes = 0;
 
         /* test loading encrypted RSA private pem w/o password */
         ExpectTrue((f = XFOPEN(PrivKeyPemFile, "rb")) != XBADFILE);
@@ -59006,9 +59006,9 @@ static int test_wolfSSL_DH_get_2048_256(void)
         0x40, 0x12, 0x9D, 0xA2, 0x99, 0xB1, 0xA4, 0x7D, 0x1E, 0xB3, 0x75, 0x0B,
         0xA3, 0x08, 0xB0, 0xFE, 0x64, 0xF5, 0xFB, 0xD3
     };
-    int pSz;
-    int qSz;
-    int gSz;
+    int pSz = 0;
+    int qSz = 0;
+    int gSz = 0;
     byte* pReturned = NULL;
     byte* qReturned = NULL;
     byte* gReturned = NULL;
@@ -59280,7 +59280,7 @@ static int test_wolfSSL_i2d_DHparams(void)
 #ifdef HAVE_FFDHE_3072
     const char* params2 = "./certs/dh3072.der";
 #endif
-    long len;
+    long len = 0;
     WOLFSSL_DH* dh = NULL;
 
     /* Test 2048 bit parameters */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -32734,12 +32734,12 @@ static int EccSpecifiedECDomainDecode(const byte* input, word32 inSz,
 {
     DECL_ASNGETDATA(dataASN, eccSpecifiedASN_Length);
     int ret = 0;
-    ecc_set_type* curve;
+    ecc_set_type* curve = NULL;
     word32 idx = 0;
-    byte version;
-    byte cofactor;
-    const byte *base;
-    word32 baseLen;
+    byte version = 0;
+    byte cofactor = 0;
+    const byte *base = NULL;
+    word32 baseLen = 0;
 
     /* Allocate a new parameter set. */
     curve = (ecc_set_type*)XMALLOC(sizeof(*curve), heap,


### PR DESCRIPTION
When compiling with '--enable-all CFLAGS=-Og' there were a ton of errors that needed fixing.
