### PR TITLE
Improved Espressif SHA HW/SW selection

### DIFF
--- a/wolfcrypt/src/port/Espressif/esp32_sha.c
+++ b/wolfcrypt/src/port/Espressif/esp32_sha.c
@@ -679,7 +679,10 @@ int esp_sha256_ctx_copy(struct wc_Sha256* src, struct wc_Sha256* dst)
 } /* esp_sha256_ctx_copy */
 #endif
 
-#if defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512)
+#if !(defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA384) && \
+      defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA512)    \
+     ) && \
+    (defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512))
 /*
 ** internal sha384 ctx copy for ESP HW
 */
@@ -744,7 +747,10 @@ int esp_sha384_ctx_copy(struct wc_Sha512* src, struct wc_Sha512* dst)
 } /* esp_sha384_ctx_copy */
 #endif
 
-#if defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512)
+#if !(defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA384) && \
+      defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA512)    \
+     ) && \
+    (defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512))
 /*
 ** Internal sha512 ctx copy for ESP HW.
 ** If HW already active, fall back to SW for this ctx.
@@ -1190,7 +1196,7 @@ int esp_sha_try_hw_lock(WC_ESP32SHA* ctx)
         ESP_LOGE(TAG, "unexpected error in esp_sha_try_hw_lock.");
         return ESP_FAIL;
     }
-#else /* not ESP_FAILfined(SINGLE_THREADED) */
+#else /* not SINGLE_THREADED */
     /*
     ** there's only one SHA engine for all the hash types
     ** so when any hash is in use, no others can use it.
@@ -2013,7 +2019,7 @@ int wc_esp_digest_state(WC_ESP32SHA* ctx, byte* hash)
             pwrd1[i]     ^= pwrd1[i + 1];
         }
     }
-#endif
+#endif /* SHA512 or SHA384*/
 #endif /* not CONFIG_IDF_TARGET_ESP32S3, C3, else... */
 
     ESP_LOGV(TAG, "leave esp_digest_state");
@@ -2122,6 +2128,9 @@ int esp_sha256_digest_process(struct wc_Sha256* sha, byte blockprocess)
     }
 
     wc_esp_digest_state(&sha->ctx, (byte*)sha->digest);
+#else
+    ESP_LOGE(TAG, "Call esp_sha256_digest_process with "
+                  "NO_WOLFSSL_ESP32_CRYPT_HASH_SHA256 ");
 #endif
     ESP_LOGV(TAG, "leave esp_sha256_digest_process");
     return ret;
@@ -2130,7 +2139,10 @@ int esp_sha256_digest_process(struct wc_Sha256* sha, byte blockprocess)
 
 #endif /* NO_SHA256 */
 
-#if defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)
+#if !(defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA384) && \
+      defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA512)    \
+     ) && \
+    (defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384))
 /*
 ** sha512 process. this is used for sha384 too.
 */

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -109,7 +109,8 @@ on the specific device platform.
     **
     ** Beware of possible conflict in test.c (that one now named TEST_TAG)
     */
-    #if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
+    #if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW) && \
+       !defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA256)
         static const char* TAG = "wc_sha256";
     #endif
 #endif
@@ -731,7 +732,7 @@ static int InitSha256(wc_Sha256* sha256)
         sha256->hiLen   = 0;
 
 #ifndef NO_WOLFSSL_ESP32_CRYPT_HASH_SHA256
-        ret = esp_sha_init(&(sha256->ctx), WC_HASH_TYPE_SHA256);
+        ret = esp_sha_init((WC_ESP32SHA*)&(sha256->ctx), WC_HASH_TYPE_SHA256);
 #endif
         return ret;
     }
@@ -748,15 +749,14 @@ static int InitSha256(wc_Sha256* sha256)
             return BAD_FUNC_ARG;
         }
 
-    #ifdef WOLFSSL_USE_ESP32_CRYPT_HASH_HW
-#ifndef NO_WOLFSSL_ESP32_CRYPT_HASH_SHA256
+    #if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW) && \
+       !defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA256)
         /* We know this is a fresh, uninitialized item, so set to INIT */
         if (sha256->ctx.mode != ESP32_SHA_INIT) {
             ESP_LOGV(TAG, "Set ctx mode from prior value: "
                                "%d", sha256->ctx.mode);
         }
         sha256->ctx.mode = ESP32_SHA_INIT;
-#endif
     #endif
 
         return InitSha256(sha256);

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -40,7 +40,10 @@
      * but individual components can be turned off. See user_settings.h
      */
     #define WOLFSSL_USE_ESP32_CRYPT_HASH_HW
-    static const char* TAG = "wc_sha_512";
+    #if !defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA384) && \
+        !defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA512)
+        static const char* TAG = "wc_sha_512";
+    #endif
 #else
     #undef WOLFSSL_USE_ESP32_CRYPT_HASH_HW
 #endif

--- a/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
+++ b/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
@@ -238,6 +238,11 @@ enum {
 **   See NO_HW_MATH_TEST.
 **
 *******************************************************************************
+** WOLFSSL_FULL_WOLFSSH_SUPPORT
+**   TODO - there's a known, unresolved problem with SHA256 in wolfSSH
+**   Until fixed by a release version or this macro being define once resolved,
+**   this macro should remain undefined.
+**
 */
 #ifdef WOLFSSL_ESP32_CRYPT_DEBUG
     #undef LOG_LOCAL_LEVEL
@@ -452,7 +457,10 @@ enum {
 #endif
 
 #ifdef SINGLE_THREADED
-    #undef ESP_MONITOR_HW_TASK_LOCK
+    #ifdef WOLFSSL_DEBUG_MUTEX
+        #undef  ESP_MONITOR_HW_TASK_LOCK
+        #define ESP_MONITOR_HW_TASK_LOCK
+    #endif
 #else
     /* Unless explicitly disabled, monitor task lock when not single thread. */
     #ifndef ESP_DISABLE_HW_TASK_LOCK
@@ -616,7 +624,7 @@ extern "C"
     {
         /* pointer to object the initialized HW; to track copies */
         void* initializer;
-#ifndef SINGLE_THREADED
+#if !defined(SINGLE_THREADED) || defined(ESP_MONITOR_HW_TASK_LOCK)
         void* task_owner;
 #endif
 
@@ -856,6 +864,16 @@ extern "C"
 #ifdef __cplusplus
 }
 #endif
+
+/* Compatibility checks */
+#if defined(DEBUG_WOLFSSH) || defined(ESP_ENABLE_WOLFSSH) || \
+    defined(WOLFSSH_TERM)  || defined(WOLFSSH_TEST_SERVER)
+    #ifndef NO_WOLFSSL_ESP32_CRYPT_HASH_SHA256
+        /* need to add this line to wolfssl component user_settings.h
+         * #define NO_WOLFSSL_ESP32_CRYPT_HASH_SHA256 */
+        #error "ESP32_CRYPT_HASH_SHA256 not supported on wolfSSL at this time"
+    #endif
+#endif /* SSH SHA256 HW check */
 
 #endif /* WOLFSSL_ESPIDF (entire contents excluded when not Espressif ESP-IDF) */
 

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -436,6 +436,16 @@
         #define WC_NO_CACHE_RESISTANT
     #endif /* !WOLFSSL_ESPIDF_NO_DEFAULT */
 
+    #if defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA384) && \
+       !defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA512)
+        #error "NO_WOLFSSL_ESP32_CRYPT_HASH_SHA384 cannot be defined without" \
+               "NO_WOLFSSL_ESP32_CRYPT_HASH_SHA512 (enable or disable both)"
+    #endif
+    #if defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA512) && \
+       !defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA384)
+        #error "NO_WOLFSSL_ESP32_CRYPT_HASH_SHA512 cannot be defined without" \
+               "NO_WOLFSSL_ESP32_CRYPT_HASH_SHA384 (enable or disable both)"
+    #endif
 #if defined(WOLFSSL_ESPWROOM32)
     /* WOLFSSL_ESPWROOM32 is a legacy macro gate.
     ** Not be be confused with WOLFSSL_ESPWROOM32SE, naming a specific board */


### PR DESCRIPTION
# Description

Adds some fine-tuning of SHA hardware / software selection allowing for more granular control of individual SHA implementations. For example, instead of having all hash algorithms hardware acceleration enabled or not, each can now be individually controlled:

```c++
    #define NO_WOLFSSL_ESP32_CRYPT_HASH_SHA
    #define NO_WOLFSSL_ESP32_CRYPT_HASH_SHA224
    #define NO_WOLFSSL_ESP32_CRYPT_HASH_SHA256
    #define NO_WOLFSSL_ESP32_CRYPT_HASH_SHA384
    #define NO_WOLFSSL_ESP32_CRYPT_HASH_SHA512
```

See https://github.com/wolfSSL/wolfssl/issues/6234 for a roadmap of Espressif updates.

Fixes zd# n/a

# Testing

How did you test?

Tested only in Espressif environment.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
