### PR TITLE
IoT-Safe sha384+sha512 support

### DIFF
--- a/doc/dox_comments/header_files/iotsafe.h
+++ b/doc/dox_comments/header_files/iotsafe.h
@@ -346,7 +346,7 @@ int wc_iotsafe_ecc_export_private_ex(ecc_key *key, byte *key_id, word16 id_size)
 
 /*!
     \ingroup IoTSafe
-    \brief Sign a pre-computed 256-bit HASH, using a private key previously stored, or pre-provisioned,
+    \brief Sign a pre-computed HASH, using a private key previously stored, or pre-provisioned,
     in the IoT-Safe applet.
 
     \param in pointer to the buffer containing the message hash to sign
@@ -367,7 +367,7 @@ int wc_iotsafe_ecc_sign_hash(byte *in, word32 inlen, byte *out, word32 *outlen, 
 
 /*!
     \ingroup IoTSafe
-    \brief Sign a pre-computed 256-bit HASH, using a private key previously stored, or pre-provisioned,
+    \brief Sign a pre-computed HASH, using a private key previously stored, or pre-provisioned,
            in the IoT-Safe applet. Equivalent to \ref wc_iotsafe_ecc_sign_hash "wc_iotsafe_ecc_sign_hash",
            except that it can be invoked with a key ID of two or more bytes.
 
@@ -390,7 +390,7 @@ int wc_iotsafe_ecc_sign_hash_ex(byte *in, word32 inlen, byte *out, word32 *outle
 
 /*!
     \ingroup IoTSafe
-    \brief Verify an ECC signature against a pre-computed 256-bit HASH, using a public key previously stored, or pre-provisioned,
+    \brief Verify an ECC signature against a pre-computed HASH, using a public key previously stored, or pre-provisioned,
     in the IoT-Safe applet. Result is written to res. 1 is valid, 0 is invalid.
     Note: Do not use the return value to test for valid. Only use res.
 
@@ -412,7 +412,7 @@ int wc_iotsafe_ecc_verify_hash(byte *sig, word32 siglen, byte *hash, word32 hash
 
 /*!
     \ingroup IoTSafe
-    \brief Verify an ECC signature against a pre-computed 256-bit HASH, using a public key previously stored, or pre-provisioned,
+    \brief Verify an ECC signature against a pre-computed HASH, using a public key previously stored, or pre-provisioned,
     in the IoT-Safe applet. Result is written to res. 1 is valid, 0 is invalid.
     Note: Do not use the return value to test for valid. Only use res.
     Equivalent to \ref wc_iotsafe_ecc_verify_hash "wc_iotsafe_ecc_verify_hash",

--- a/wolfcrypt/src/port/iotsafe/iotsafe.c
+++ b/wolfcrypt/src/port/iotsafe/iotsafe.c
@@ -749,43 +749,37 @@ static int iotsafe_hkdf_extract(byte* prk, const byte* salt, word32 saltLen,
     int ret;
     char *resp;
     uint16_t hash_algo = 0;
-    int len;
+    int hash_len;
     uint16_t hash_algo_be = 0;
 
     WOLFSSL_MSG("Enter iotsafe_hkdf_extract");
-     switch (digest) {
-        #ifndef NO_SHA256
+    switch (digest) {
+#ifndef NO_SHA256
         case WC_SHA256:
-        hash_algo = (uint16_t)1;
-        if (ikmLen == 0) {
-            len = WC_SHA256_DIGEST_SIZE;
-        }
+            hash_algo = (uint16_t)1;
+            hash_len = WC_SHA256_DIGEST_SIZE;
             break;
-        #endif
-        #ifdef WOLFSSL_SHA384
+#endif
+#ifdef WOLFSSL_SHA384
         case WC_SHA384:
-        hash_algo = (uint16_t)2;
-        if (ikmLen == 0) {
-            len = WC_SHA384_DIGEST_SIZE;
-        }
+            hash_algo = (uint16_t)2;
+            hash_len = WC_SHA384_DIGEST_SIZE;
             break;
-        #endif
-        #ifdef WOLFSSL_TLS13_SHA512
+#endif
+#ifdef WOLFSSL_TLS13_SHA512
         case WC_SHA512:
-        hash_algo = (uint16_t)4;
-        if (ikmLen == 0) {
-            len = WC_SHA512_DIGEST_SIZE;
-        }
+            hash_algo = (uint16_t)4;
+            hash_len = WC_SHA512_DIGEST_SIZE;
             break;
-        #endif
+#endif
         default:
             return BAD_FUNC_ARG;
             break;
-     }
+    }
 
     if (ikmLen == 0) {
-        ikmLen = len;
-        XMEMSET(ikm, 0, len);
+        ikmLen = hash_len;
+        XMEMSET(ikm, 0, hash_len);
     }
 
 #ifdef DEBUG_IOTSAFE
@@ -812,14 +806,12 @@ static int iotsafe_hkdf_extract(byte* prk, const byte* salt, word32 saltLen,
         WOLFSSL_MSG("Unexpected reply from HKDF extract");
         ret = WC_HW_E;
     } else {
-
-         ret = hexbuffer_conv(resp, prk, 32);
+        ret = hexbuffer_conv(resp, prk, hash_len);
         if (ret < 0)
             ret = WC_HW_E;
         else
             ret = 0;
     }
-
     return ret;
 }
 #endif

--- a/wolfcrypt/src/port/iotsafe/iotsafe.c
+++ b/wolfcrypt/src/port/iotsafe/iotsafe.c
@@ -766,7 +766,7 @@ static int iotsafe_hkdf_extract(byte* prk, const byte* salt, word32 saltLen,
             hash_len = WC_SHA384_DIGEST_SIZE;
             break;
 #endif
-#ifdef WOLFSSL_TLS13_SHA512
+#ifdef WOLFSSL_SHA512
         case WC_SHA512:
             hash_algo = (uint16_t)4;
             hash_len = WC_SHA512_DIGEST_SIZE;


### PR DESCRIPTION
# Description

Add SHA384 and SHA512 support by removing hardcoded digest size.

Should fix github reported issue #7175 

# Testing

via #7175 

# Checklist


 - [x] updated/added doxygen
 - [x] updated appropriate READMEs (no update needed)
 - [x] Updated manual and documentation (no update needed)
