### PR TITLE
Improved Arduino Support: ESP32, Due

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -322,6 +322,10 @@ wolfcrypt/src/port/intel/qat_test
 # Arduino Generated Files
 /IDE/ARDUINO/wolfSSL
 scripts/memtest.txt
+/IDE/ARDUINO/Arduino_README_prepend.md.tmp
+/IDE/ARDUINO/library.properties.tmp
+/IDE/ARDUINO/library.properties.tmp.backup
+/IDE/ARDUINO/PREPENDED_README.md
 
 # Doxygen generated files
 doc/doxygen_warnings

--- a/IDE/ARDUINO/Arduino_README_prepend.md
+++ b/IDE/ARDUINO/Arduino_README_prepend.md
@@ -1,0 +1,4 @@
+# Arduino wolfSSL Library
+
+The library is modified from wolfSSL Release ${WOLFSSL_VERSION} for the Arduino platform.
+

--- a/IDE/ARDUINO/README.md
+++ b/IDE/ARDUINO/README.md
@@ -1,5 +1,16 @@
 ### wolfSSL with Arduino
 
+Many of the supported devices are natively built-in to the [Arduino IDE Board Manager](https://docs.arduino.cc/software/ide-v2/tutorials/ide-v2-board-manager/)
+and by adding [additional cores](https://docs.arduino.cc/learn/starting-guide/cores/) as needed.
+
+STM32 Support can be added by including this link in the "Additional Boards Managers URLs" field:
+
+https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json
+
+from [stm32duino/Arduino_Core_STM32](https://github.com/stm32duino/Arduino_Core_STM32?tab=readme-ov-file#getting-started)   .
+
+
+
 ##### Reformatting wolfSSL as a compatible Arduino Library
 This is a shell script that will re-organize the wolfSSL library to be 
 compatible with Arduino projects that use Arduino IDE 1.5.0 or newer. 
@@ -8,23 +19,42 @@ directory with a header file in the name of the library. This script moves all
 src/ files to the `IDE/ARDUINO/wolfSSL/src` directory and creates a stub header
 file called `wolfssl.h` inside that directory.
 
-Step 1: To configure wolfSSL with Arduino, enter the following from within the
-wolfssl/IDE/ARDUINO directory:
+Step 1: To configure wolfSSL with Arduino, enter one of the following commands
+from within the `wolfssl/IDE/ARDUINO` directory:
 
-        `./wolfssl-arduino.sh`
+1. `./wolfssl-arduino.sh`
+    - Creates an Arduino Library in `wolfSSL` directory
+2 `./wolfssl-arduino.sh INSTALL`
+     - Creates an Arduino Library in `wolfSSL` directory
+     - Moves that directory to the Arduino library directory:
+       - `$HOME/Arduino/libraries` for most bash environments
+       - `/mnt/c/Users/$USER/Documents/Arduino/libraries` (for WSL)
+3. `./wolfssl-arduino.sh INSTALL /path/to/repository`
+     - Creates an Arduino Library in `wolfSSL` directory
+     - Copies that directory contents to the specified `/path/to/repository`
+4. `./wolfssl-arduino.sh INSTALL /path/to/any/other/directory`
+     - Creates an Arduino Library in `wolfSSL` directory
+     - Copies that directory contents to the specified `/path/to/repository`
 
-Step 2: Copy the directory wolfSSL that was just created to:
-`~/Documents/Arduino/libraries/` directory so the Arduino IDE can find it.
-
-Step 3: Edit `<arduino-libraries>/wolfSSL/src/user_settings.h`
+Step 2: Edit `<arduino-libraries>/wolfSSL/src/user_settings.h`
 If building for Intel Galileo platform add: `#define INTEL_GALILEO`.
 Add any other custom settings, for a good start see the examples in wolfssl root
 "/examples/configs/user_settings_*.h"
 
-Step 4: If you experience any issues with custom user_settings.h see the wolfssl
+Step 3: If you experience any issues with custom user_settings.h see the wolfssl
 porting guide here for more assistance: https://www.wolfssl.com/docs/porting-guide/
 
-Step 5: If you still have any issues contact support@wolfssl.com for more help.
+If you have any issues contact support@wolfssl.com for help.
+
+##### Including wolfSSL in Arduino Libraries (for Arduino version 2.0 or greater)
+
+1. In the Arduino IDE:
+
+The wolfSSL library should automatically be detected when found in the `libraries`
+directory.
+
+    - In `Sketch -> Include Library` choose wolfSSL for new sketches.
+
 
 ##### Including wolfSSL in Arduino Libraries (for Arduino version 1.6.6)
 
@@ -33,6 +63,72 @@ Step 5: If you still have any issues contact support@wolfssl.com for more help.
         `IDE/ARDUNIO/wolfSSL` folder.
     - In `Sketch -> Include Library` choose wolfSSL.
 
-2. Open an example Arduino sketch for wolfSSL:
+##### wolfSSL Examples
+
+Open an example Arduino sketch for wolfSSL:
+
 	- wolfSSL Client INO sketch: `sketches/wolfssl_client/wolfssl_client.ino`
+
 	- wolfSSL Server INO sketch: `sketches/wolfssl_server/wolfssl_server.ino`
+
+#### Script Examples
+
+Publish wolfSSL from WSL to a repository.
+
+```bash
+rm -rf /mnt/c/Users/$USER/Documents/Arduino/libraries/wolfSSL
+rm -rf /mnt/c/workspace/wolfssl-$USER/IDE/ARDUINO/wolfSSL
+./wolfssl-arduino.sh INSTALL /mnt/c/workspace/Arduino-wolfSSL-$USER/
+```
+
+Publish wolfSSL from WSL to default Windows local library.
+
+```bash
+rm -rf /mnt/c/Users/$USER/Documents/Arduino/libraries/wolfSSL
+rm -rf /mnt/c/workspace/wolfssl-arduino/IDE/ARDUINO/wolfSSL
+./wolfssl-arduino.sh INSTALL
+```
+
+Test the TLS server by running a local command-line client.
+
+```bash
+cd /mnt/c/workspace/wolfssl-$USER
+./examples/client/client -h 192.168.1.43 -p 11111 -v 3
+```
+
+Build wolfSSL to include wolfSSH support, but to an alternate development directory.
+
+```bash
+ cd /mnt/c/workspace/wolfssl-$USER
+ ./configure --prefix=/mnt/c/workspace/wolfssh-$USER/wolfssl_install --enable-ssh
+ make
+ make install
+```
+
+Build wolfSSH with wolfSSL not installed to default directory.
+
+```bash
+cd /mnt/c/workspace/wolfssh-$USER
+./configure --with-wolfssl=/mnt/c/workspace/wolfssh-$USER/wolfssl_install
+make
+./examples/client/client -u jill -h 192.168.1.34 -p 22222 -P upthehill
+```
+
+Test the current wolfSSL.
+
+```bash
+cd /mnt/c/workspace/wolfssl-arduino
+git status
+./autogen.sh
+./configure --enable-all
+make clean
+make && make test
+```
+
+Build and run `testwolfcrypt`
+
+```bash
+./autogen.sh
+./configure --enable-all
+make clean && make && ./wolfcrypt/test/testwolfcrypt
+```

--- a/IDE/ARDUINO/README.md
+++ b/IDE/ARDUINO/README.md
@@ -1,59 +1,79 @@
-### wolfSSL with Arduino
+# wolfSSL with Arduino
 
-Many of the supported devices are natively built-in to the [Arduino IDE Board Manager](https://docs.arduino.cc/software/ide-v2/tutorials/ide-v2-board-manager/)
+Many of the supported boards are natively built-in to the [Arduino IDE Board Manager](https://docs.arduino.cc/software/ide-v2/tutorials/ide-v2-board-manager/)
 and by adding [additional cores](https://docs.arduino.cc/learn/starting-guide/cores/) as needed.
 
-STM32 Support can be added by including this link in the "Additional Boards Managers URLs" field:
-
-https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json
-
+STM32 Support can be added by including this link in the "Additional Boards Managers URLs" field
 from [stm32duino/Arduino_Core_STM32](https://github.com/stm32duino/Arduino_Core_STM32?tab=readme-ov-file#getting-started)   .
 
+```
+https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json
+```
 
+## Using wolfSSL from the Arduino IDE
 
-##### Reformatting wolfSSL as a compatible Arduino Library
-This is a shell script that will re-organize the wolfSSL library to be 
-compatible with Arduino projects that use Arduino IDE 1.5.0 or newer. 
-The Arduino IDE requires a library's source files to be in the library's root 
-directory with a header file in the name of the library. This script moves all 
-src/ files to the `IDE/ARDUINO/wolfSSL/src` directory and creates a stub header
-file called `wolfssl.h` inside that directory.
+Coming soon! https://github.com/wolfSSL/arduino-wolfSSL See [PR #1](https://github.com/wolfSSL/Arduino-wolfSSL/pull/1).
 
-Step 1: To configure wolfSSL with Arduino, enter one of the following commands
+This option will allow wolfSSL to be installed directly using the native Arduino tools.
+
+## Manually Reformatting wolfSSL as a Compatible Arduino Library
+
+Use [this](./wolfssl-arduino.sh) shell script that will re-organize the wolfSSL library to be 
+compatible with [Arduino Library Specification](https://arduino.github.io/arduino-cli/0.35/library-specification/)
+for projects that use Arduino IDE 1.5.0 or newer.
+
+The Arduino IDE requires a library's source files to be in the library's root directory with a
+header file in the name of the library. This script moves all `src/` files to the `IDE/ARDUINO/wolfSSL/src`
+directory and creates a stub header file called `wolfssl.h` inside that directory.
+
+### Step 1:
+
+To configure wolfSSL with Arduino, enter one of the following commands
 from within the `wolfssl/IDE/ARDUINO` directory:
 
 1. `./wolfssl-arduino.sh`
+    - Creates an Arduino Library directory structure in the local `wolfSSL` directory of `IDE/ARDUINO`.
+    - You can add your own `user_settings.h`, or copy/rename the [default](../../examples/configs/user_settings_arduino.h).
+
+2. `./wolfssl-arduino.sh INSTALL` (The most common option)
+    - Creates an Arduino Library in the local `wolfSSL` directory
+    - Moves that directory to the Arduino library directory:
+        - `$HOME/Arduino/libraries` for most bash environments
+        - `/mnt/c/Users/$USER/Documents/Arduino/libraries` (for WSL)
+    - Adds the [default](../../examples/configs/user_settings_arduino.h) as `user_settings.h`.
+    - The wolfSSL library is now available from the Arduino IDE.
+
+3. `./wolfssl-arduino.sh INSTALL /path/to/repository` (Used to update [arduino-wolfSSL](https://github.com/wolfSSL/arduino-wolfSSL))
     - Creates an Arduino Library in `wolfSSL` directory
-2 `./wolfssl-arduino.sh INSTALL`
-     - Creates an Arduino Library in `wolfSSL` directory
-     - Moves that directory to the Arduino library directory:
-       - `$HOME/Arduino/libraries` for most bash environments
-       - `/mnt/c/Users/$USER/Documents/Arduino/libraries` (for WSL)
-3. `./wolfssl-arduino.sh INSTALL /path/to/repository`
-     - Creates an Arduino Library in `wolfSSL` directory
-     - Copies that directory contents to the specified `/path/to/repository`
+    - Copies that directory contents to the specified `/path/to/repository`
+    - Adds the [default](../../examples/configs/user_settings_arduino.h) as `user_settings.h`. 
+     
 4. `./wolfssl-arduino.sh INSTALL /path/to/any/other/directory`
-     - Creates an Arduino Library in `wolfSSL` directory
-     - Copies that directory contents to the specified `/path/to/repository`
+    - Creates an Arduino Library in `wolfSSL` directory
+    - Copies that directory contents to the specified `/path/to/any/other/directory`
 
-Step 2: Edit `<arduino-libraries>/wolfSSL/src/user_settings.h`
+### Step 2:
+
+Edit `<arduino-libraries>/wolfSSL/src/user_settings.h`
 If building for Intel Galileo platform add: `#define INTEL_GALILEO`.
-Add any other custom settings, for a good start see the examples in wolfssl root
-"/examples/configs/user_settings_*.h"
+Add any other custom settings. For a good start see the examples in wolfssl root
+"[/examples/configs/user_settings_*.h](https://github.com/wolfssl/wolfssl/tree/master/examples/configs)"
 
-Step 3: If you experience any issues with custom user_settings.h see the wolfssl
+### Step 3:
+
+If you experience any issues with custom `user_settings.h` see the wolfssl
 porting guide here for more assistance: https://www.wolfssl.com/docs/porting-guide/
 
 If you have any issues contact support@wolfssl.com for help.
 
-##### Including wolfSSL in Arduino Libraries (for Arduino version 2.0 or greater)
+# Including wolfSSL in Arduino Libraries (for Arduino version 2.0 or greater)
 
 1. In the Arduino IDE:
 
 The wolfSSL library should automatically be detected when found in the `libraries`
 directory.
 
-    - In `Sketch -> Include Library` choose wolfSSL for new sketches.
+  - In `Sketch -> Include Library` choose wolfSSL for new sketches.
 
 
 ##### Including wolfSSL in Arduino Libraries (for Arduino version 1.6.6)
@@ -67,9 +87,9 @@ directory.
 
 Open an example Arduino sketch for wolfSSL:
 
-	- wolfSSL Client INO sketch: `sketches/wolfssl_client/wolfssl_client.ino`
+  - wolfSSL [Client INO sketch](./sketches/wolfssl_client/README.md): `sketches/wolfssl_client/wolfssl_client.ino`
 
-	- wolfSSL Server INO sketch: `sketches/wolfssl_server/wolfssl_server.ino`
+  - wolfSSL [Server INO sketch](./sketches/wolfssl_server/README.md): `sketches/wolfssl_server/wolfssl_server.ino`
 
 #### Script Examples
 
@@ -96,13 +116,14 @@ cd /mnt/c/workspace/wolfssl-$USER
 ./examples/client/client -h 192.168.1.43 -p 11111 -v 3
 ```
 
-Build wolfSSL to include wolfSSH support, but to an alternate development directory.
+Build wolfSSL to include wolfSSH support to an alternate development directory.
 
 ```bash
- cd /mnt/c/workspace/wolfssl-$USER
- ./configure --prefix=/mnt/c/workspace/wolfssh-$USER/wolfssl_install --enable-ssh
- make
- make install
+cd /mnt/c/workspace/wolfssl-$USER
+./configure --prefix=/mnt/c/workspace/wolfssh-$USER/wolfssl_install --enable-ssh
+make
+make install
+
 ```
 
 Build wolfSSH with wolfSSL not installed to default directory.
@@ -125,7 +146,7 @@ make clean
 make && make test
 ```
 
-Build and run `testwolfcrypt`
+Build and run `testwolfcrypt`.
 
 ```bash
 ./autogen.sh

--- a/IDE/ARDUINO/include.am
+++ b/IDE/ARDUINO/include.am
@@ -3,6 +3,12 @@
 # All paths should be given relative to the root
 
 EXTRA_DIST+= IDE/ARDUINO/README.md
+EXTRA_DIST+= IDE/ARDUINO/Arduino_README_prepend.md
+EXTRA_DIST+= IDE/ARDUINO/keywords.txt
+EXTRA_DIST+= IDE/ARDUINO/library.properties.template
+EXTRA_DIST+= IDE/ARDUINO/sketches/README.md
+EXTRA_DIST+= IDE/ARDUINO/sketches/wolfssl_client/README.md
 EXTRA_DIST+= IDE/ARDUINO/sketches/wolfssl_client/wolfssl_client.ino
+EXTRA_DIST+= IDE/ARDUINO/sketches/wolfssl_server/README.md
 EXTRA_DIST+= IDE/ARDUINO/sketches/wolfssl_server/wolfssl_server.ino
 EXTRA_DIST+= IDE/ARDUINO/wolfssl-arduino.sh

--- a/IDE/ARDUINO/keywords.txt
+++ b/IDE/ARDUINO/keywords.txt
@@ -1,0 +1,21 @@
+# Syntax Coloring Map For wolfSSL
+# See https://arduino.github.io/arduino-cli/0.35/library-specification/#keywords
+#
+# Be sure to use tabs, not spaces. This might help:
+#  tr ' ' '\t' < keywords1.txt > keywords.txt
+
+#=============================================
+#	Datatypes	(KEYWORD1)
+#=============================================
+
+
+#=============================================
+#	Methods	and	Functions	(KEYWORD2)
+#=============================================
+wolfSSL_SetIORecv	KEYWORD1
+
+#=============================================
+#	Instances	(KEYWORD2)
+#=============================================
+ctx	KEYWORD2
+

--- a/IDE/ARDUINO/library.properties.template
+++ b/IDE/ARDUINO/library.properties.template
@@ -1,0 +1,9 @@
+name=wolfSSL
+version=${WOLFSSL_VERSION}${WOLFSSL_VERSION_ARUINO_SUFFIX}
+author=wolfSSL inc
+maintainer=wolfSSL inc <support@wolfssl.com>
+sentence=A lightweight SSL/TLS library written in ANSI C and targeted for embedded, RTOS, and resource-constrained environments.
+paragraph=Manual: https://www.wolfssl.com/documentation/manuals/wolfssl/index.html.
+category=Communication
+url=https://www.wolfssl.com/
+architectures=*

--- a/IDE/ARDUINO/sketches/README.md
+++ b/IDE/ARDUINO/sketches/README.md
@@ -1,0 +1,12 @@
+# wolfSSL Arduino Examples
+
+There are currently two example Arduino sketches:
+
+* [wolfssl_client](./wolfssl_client/README.md): Basic TLS listening client.
+* [wolfssl_server](./wolfssl_server/README.md): Basic TLS server.
+
+Examples have been most recently confirmed operational on the
+[Arduino IDE](https://www.arduino.cc/en/software) 2.2.1.
+
+For examples on other platforms, see the [IDE directory](https://github.com/wolfssl/wolfssl/tree/master/IDE).
+Additional examples can be found on [wolfSSL/wolfssl-examples](https://github.com/wolfSSL/wolfssl-examples/).

--- a/IDE/ARDUINO/sketches/wolfssl_client/README.md
+++ b/IDE/ARDUINO/sketches/wolfssl_client/README.md
@@ -1,0 +1,22 @@
+# Arduino Basic TLS Listening Client
+
+Open the [wolfssl_client.ino](./wolfssl_client.ino) file in the Arduino IDE.
+
+Other IDE products are also supported, such as:
+
+- [PlatformIO in VS Code](https://docs.platformio.org/en/latest/frameworks/arduino.html)
+- [VisualGDB](https://visualgdb.com/tutorials/arduino/)
+- [VisualMicro](https://www.visualmicro.com/)
+
+For examples on other platforms, see the [IDE directory](https://github.com/wolfssl/wolfssl/tree/master/IDE).
+Additional examples can be found on [wolfSSL/wolfssl-examples](https://github.com/wolfSSL/wolfssl-examples/).
+
+
+### Troubleshooting
+
+When encountering odd errors such as `undefined reference to ``_impure_ptr'`, try cleaning the Arduino
+cache directories. For Windows, that's typically in:
+
+```text
+C:\Users\%USERNAME%\AppData\Local\Temp\arduino\sketches
+```

--- a/IDE/ARDUINO/sketches/wolfssl_server/README.md
+++ b/IDE/ARDUINO/sketches/wolfssl_server/README.md
@@ -1,0 +1,134 @@
+# Arduino Basic TLS Server
+
+Open the [wolfssl_server.ino](./wolfssl_server.ino) file in the Arduino IDE.
+
+Other IDE products are also supported, such as:
+
+- [PlatformIO in VS Code](https://docs.platformio.org/en/latest/frameworks/arduino.html)
+- [VisualGDB](https://visualgdb.com/tutorials/arduino/)
+- [VisualMicro](https://www.visualmicro.com/)
+
+For examples on other platforms, see the [IDE directory](https://github.com/wolfssl/wolfssl/tree/master/IDE).
+Additional examples can be found on [wolfSSL/wolfssl-examples](https://github.com/wolfSSL/wolfssl-examples/).
+
+## Connect with an Arduino Sketch
+
+See the companion [Arduino Sketch Client](../wolfssl_client/wolfssl_client.ino). 
+
+## Connect with Linux Client
+
+See also the [wolfSSL Example TLS Client](https://github.com/wolfSSL/wolfssl/tree/master/examples/client)
+and [wolfSSL Example TLS Server](https://github.com/wolfSSL/wolfssl/tree/master/examples/server).
+
+Assuming a listening [Arduino Sketch Server](./wolfssl_server.ino) at `192.168.1.38` on port `11111`,
+connect with the `client` executable:
+
+```
+./examples/client/client -h 192.168.1.38 -p 11111 -v 3
+```
+
+## wolfSSL Error -308 wolfSSL_connect error state on socket
+
+When using a wired Ethernet connection, and this error is encountered, simply
+press the reset button or power cycle the Arduino before making a connection.
+
+Here's one possible script to test the server from a command-line client:
+
+```bash
+#!/bin/bash
+echo "client log " > client_log.txt
+counter=1
+THIS_ERR=0
+while [ $THIS_ERR -eq 0 ]; do
+    ./examples/client/client -h 192.168.1.38 -p 11111 -v 3 >> client_log.txt
+
+    THIS_ERR=$?
+    if [ $? -ne 0 ]; then
+        echo "Failed!"
+        exit 1
+    fi
+    echo "Iteration $counter"
+    echo "Iteration $counter" >> client_log.txt
+    ((counter++))
+done
+```
+
+Output expected from the `client` command:
+
+```
+$ ./examples/client/client -h 192.168.1.38 -p 11111 -v 3
+Alternate cert chain used
+ issuer : /C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+ subject: /C=US/ST=Montana/L=Bozeman/O=wolfSSL/OU=Support/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+ altname = example.com
+ altname = 127.0.0.1
+ serial number:01
+SSL version is TLSv1.2
+SSL cipher suite is ECDHE-RSA-AES128-GCM-SHA256
+SSL curve name is SECP256R1
+---
+Server certificate
+-----BEGIN CERTIFICATE-----
+MIIE6DCCA9CgAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlDELMAkGA1UEBhMCVVMx
+EDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNh
+d3Rvb3RoMRMwEQYDVQQLDApDb25zdWx0aW5nMRgwFgYDVQQDDA93d3cud29sZnNz
+bC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcNMjMxMjEz
+MjIxOTI4WhcNMjYwOTA4MjIxOTI4WjCBkDELMAkGA1UEBhMCVVMxEDAOBgNVBAgM
+B01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xEDAOBgNVBAoMB3dvbGZTU0wxEDAO
+BgNVBAsMB1N1cHBvcnQxGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEfMB0GCSqG
+SIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEP
+ADCCAQoCggEBAMCVCOFXQfJxbbfSRUEnAWXGRa7yvCQwuJXOL07W9hyIvHyf+6hn
+f/5cnFF194rKB+c1L4/hvXvAL3yrZKgX/Mpde7rgIeVyLm8uhtiVc9qsG1O5Xz/X
+GQ0lT+FjY1GLC2Q/rUO4pRxcNLOuAKBjxfZ/C1loeHOmjBipAm2vwxkBLrgQ48bM
+QLRpo0YzaYduxLsXpvPo3a1zvHsvIbX9ZlEMvVSz4W1fHLwjc9EJA4kU0hC5ZMMq
+0KGWSrzh1Bpbx6DAwWN4D0Q3MDKWgDIjlaF3uhPSl3PiXSXJag3DOWCktLBpQkIJ
+6dgIvDMgs1gip6rrxOHmYYPF0pbf2dBPrdcCAwEAAaOCAUUwggFBMB0GA1UdDgQW
+BBSzETLJkpiE4sn40DtuA0LKHw6OPDCB1AYDVR0jBIHMMIHJgBQnjmcRdMMmHT/t
+M2OzpNgdMOXo1aGBmqSBlzCBlDELMAkGA1UEBhMCVVMxEDAOBgNVBAgMB01vbnRh
+bmExEDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNhd3Rvb3RoMRMwEQYDVQQL
+DApDb25zdWx0aW5nMRgwFgYDVQQDDA93d3cud29sZnNzbC5jb20xHzAdBgkqhkiG
+9w0BCQEWEGluZm9Ad29sZnNzbC5jb22CFDNEGqhsAez2YPJwUQpM0RT6vOlEMAwG
+A1UdEwQFMAMBAf8wHAYDVR0RBBUwE4ILZXhhbXBsZS5jb22HBH8AAAEwHQYDVR0l
+BBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA0GCSqGSIb3DQEBCwUAA4IBAQBK/7nl
+hZvaU2Z/ByK/thnqQuukEQdi/zlfMzc6hyZxPROyyrhkOHuKmUgOpaRrsZlu4EZR
+vRlSrbymfip6fCOnzNteQ31rBMi33ZWt8JGAWcUZkSYnkbhIHOtVtqp9pDjxA7xs
+i6qU1jwFepbFBvEmFC51+93lNbMBLLOtYlohmgi+Vvz5okKHhuWpxZnPrhS+4LkI
+JA0dXNYU4UyfQLOp6S1Si0y/rEQxZ8GNBoXsD+SZ10t7IQZm1OT1nf+O8IY5WB2k
+W+Jj73zJGIeoAiUQPoco+fXvR56lgAgRkGj+0aOoUbk3/9XKfId/a7wsEsjFhYv8
+DMa5hrjJBMNRN9JP
+-----END CERTIFICATE-----
+Session timeout set to 500 seconds
+Client Random : 56A0BB9647B064D3F20947032B74B31FDB4C93DBAC9460BA8AEA213A2B2DD4A8
+SSL-Session:
+    Protocol  : TLSv1.2
+    Cipher    : TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    Session-ID: 3255404E997FA9C27ECB4F1A20A70E722E4AA504B63A945FC175434D1907EC31
+    Session-ID-ctx:
+    Master-Key: 67F22168BBADD678643BBA76B398277270C29788AC18FD05B57F6B715F49A7BCEEF75BEAF7FE266B0CC058534AF76C1F
+    TLS session ticket: NONE
+    Start Time: 1705533296
+    Timeout   : 500 (sec)
+    Extended master secret: no
+I hear you fa shizzle!
+```
+
+### Troubleshooting
+
+When encountering odd errors such as `undefined reference to ``_impure_ptr'`, such as this:
+
+```text
+c:/users/gojimmypi/appdata/local/arduino15/packages/esp32/tools/xtensa-esp32-elf-gcc/esp-2021r2-patch5-8.4.0/bin/../lib/gcc/xtensa-esp32-elf/8.4.0/../../../../xtensa-esp32-elf/bin/ld.exe: C:\Users\gojimmypi\AppData\Local\Temp\arduino\sketches\EAB8D79A02D1ECF107884802D893914E\libraries\wolfSSL\wolfcrypt\src\logging.c.o:(.literal.wolfssl_log+0x8): undefined reference to `_impure_ptr'
+collect2.exe: error: ld returned 1 exit status
+
+exit status 1
+
+Compilation error: exit status 1
+```
+
+Try cleaning the Arduino cache directories. For Windows, that's typically in:
+
+```text
+C:\Users\%USERNAME%\AppData\Local\Temp\arduino\sketches
+```
+
+Remove all other boards from other serial ports, leaving one the one being programmed.

--- a/IDE/ARDUINO/wolfssl-arduino.sh
+++ b/IDE/ARDUINO/wolfssl-arduino.sh
@@ -2,9 +2,100 @@
 
 # this script will reformat the wolfSSL source code to be compatible with
 # an Arduino project
-# run as bash ./wolfssl-arduino.sh
-
+# run as bash ./wolfssl-arduino.sh [INSTALL] [path]
+#
+# The default is to install to a local wolfSSL directory (`ROOT_DIR`).
+# If successfully built, and the INSTALL option is used, tis directory
+# is then moved to the target.
+#
+# To ensure a pristine build, the directory must not exist.
+#
+# Reminder there's typically no $USER for GitHub actions, but:
+# ROOT_DIR="/mnt/c/Users/$USER/Documents/Arduino/libraries"
+#
 ROOT_DIR="/wolfSSL"
+
+# The Arduino Version will initially have a suffix appended during fine tuning stage.
+WOLFSSL_VERSION_ARUINO_SUFFIX="01"
+
+# For verbose copy, set CP_CMD="-v", otherwise clear it: CP_CMD="cp"
+# Do not set to empty string, as copy will fail with this: CP_CMD=""
+# CP_CMD="cp -v "
+CP_CMD="cp "
+
+# Specify the executable shell checker you want to use:
+MY_SHELLCHECK="shellcheck"
+
+# There are special circumstances to publish to GitHub repository.
+# Typically: https://github.com/wolfSSL/Arduino-wolfSSL
+#
+# Unlike a local Arduino library that requires a clean directory,
+# we'll allow extra files, overwrites, etc.
+#
+# Note in all cases, the local IDE/ARDUINO/wolfSSL must be empty.
+THIS_INSTALL_IS_GITHUB="false"
+
+# Check if the executable is available in the PATH
+if command -v "$MY_SHELLCHECK" >/dev/null 2>&1; then
+    # Run your command here
+    shellcheck "$0" || exit 1
+else
+    echo "$MY_SHELLCHECK is not installed. Please install it if changes to this script have been made."
+fi
+
+if ! [ "$CP_CMD" = "cp " ]; then
+    if [ "$CP_CMD" = "cp -v" ]; then
+        echo "Copy verbose mode"
+    else
+        echo "ERROR: Copy mode not supported: $CP_CMD"
+        exit 1
+    fi
+fi
+
+# Check environment
+if [ -n "$WSL_DISTRO_NAME" ]; then
+    # we found a non-blank WSL environment distro name
+    current_path="$(pwd)"
+    pattern="/mnt/?"
+    if echo "$current_path" | grep -Eq "^$pattern"; then
+        # if we are in WSL and shared Windows file system, 'ln' does not work.
+        ARDUINO_ROOT="/mnt/c/Users/$USER/Documents/Arduino/libraries"
+    else
+        ARDUINO_ROOT="$HOME/Arduino/libraries"
+    fi
+fi
+echo "The Arduino library root is: $ARDUINO_ROOT"
+
+if [ $# -gt 0 ]; then
+    THIS_OPERATION="$1"
+    if [ "$THIS_OPERATION" = "INSTALL" ]; then
+        THIS_INSTALL_DIR=$2
+
+        echo "Install is active."
+
+        if [ "$THIS_INSTALL_DIR" = "" ]; then
+            if [ -d "$ARDUINO_ROOT$ROOT_DIR" ]; then
+                echo "Error: the installation directory already exists: $ARDUINO_ROOT$ROOT_DIR"
+                echo "A new directory needs to be created to ensure there are no stray files"
+                echo "Please delete or move the directory and try again."
+                exit 1
+            fi
+        else
+            echo "Installing to $THIS_INSTALL_DIR"
+            if [ -d "$THIS_INSTALL_DIR/.git" ];then
+                echo "Target is a GitHub repository."
+                THIS_INSTALL_IS_GITHUB="true"
+            else
+                echo "Target is NOT a GitHub repository."
+            fi
+        fi
+    else
+        echo "Error: not a valid operation: $THIS_OPERATION"
+        exit 1
+    fi
+fi
+
+
 ROOT_SRC_DIR="${ROOT_DIR}/src"
 WOLFSSL_SRC="${ROOT_SRC_DIR}/src"
 WOLFSSL_HEADERS="${ROOT_SRC_DIR}/wolfssl"
@@ -12,9 +103,9 @@ WOLFCRYPT_ROOT="${ROOT_SRC_DIR}/wolfcrypt"
 WOLFCRYPT_SRC="${WOLFCRYPT_ROOT}/src"
 WOLFCRYPT_HEADERS="${WOLFSSL_HEADERS}/wolfcrypt"
 OPENSSL_DIR="${WOLFSSL_HEADERS}/openssl"
-WOLFSSL_VERSION="5.6.4"
 
-# TOP indicates the file directory comes from the top level of the wolfssl repo
+
+# TOP indicates the file directory for top level of the wolfssl repository.
 TOP_DIR="../.."
 WOLFSSL_SRC_TOP="${TOP_DIR}/src"
 WOLFSSL_HEADERS_TOP="${TOP_DIR}/wolfssl"
@@ -24,57 +115,98 @@ WOLFCRYPT_HEADERS_TOP="${WOLFSSL_HEADERS_TOP}/wolfcrypt"
 OPENSSL_DIR_TOP="${WOLFSSL_HEADERS_TOP}/openssl"
 
 
-# TODO: Parse version number
 WOLFSSL_VERSION=$(grep -i "LIBWOLFSSL_VERSION_STRING" ${TOP_DIR}/wolfssl/version.h | cut -d '"' -f 2)
+if [ "$WOLFSSL_VERSION" = "" ]; then
+    echo "ERROR: Could not find wolfSSL Version in ${TOP_DIR}/wolfssl/version.h"
+    exit 1
+else
+    echo "Found wolfSSL version $WOLFSSL_VERSION"
+fi
 
+THIS_DIR=${PWD##*/}
 
-DIR=${PWD##*/}
-
-if [ "$DIR" = "ARDUINO" ]; then
-	if [ ! -d ".${ROOT_DIR}" ]; then
-	    mkdir .${ROOT_DIR}
+if [ "$THIS_DIR" = "ARDUINO" ]; then
+    # mkdir ./wolfSSL
+    if [ -d ".${ROOT_DIR}" ]; then
+        echo "ERROR: $(realpath ".${ROOT_DIR}") is not empty"
+        exit 1
+    else
+        echo "Step 01: mkdir .${ROOT_DIR}"
+        mkdir .${ROOT_DIR}
     fi
+
+    # mkdir ./wolfSSL/src
     if [ ! -d ".${ROOT_SRC_DIR}" ]; then
-	    mkdir .${ROOT_SRC_DIR}
+        echo "Step 02: mkdir .${ROOT_SRC_DIR}"
+        mkdir .${ROOT_SRC_DIR}
     fi
 
+    # mkdir ./wolfSSL/src/wolfssl
     if [ ! -d ".${WOLFSSL_HEADERS}" ]; then
-	    mkdir .${WOLFSSL_HEADERS}
+        echo "Step 03: mkdir .${WOLFSSL_HEADERS}"
+        mkdir .${WOLFSSL_HEADERS}
     fi
 
-    cp ${WOLFSSL_HEADERS_TOP}/*.h .${WOLFSSL_HEADERS}
+    #  cp ../../wolfssl/*.h  ./wolfSSL/src/wolfssl
+    echo "Step 04: cp    ${WOLFSSL_HEADERS_TOP}/*.h               .${WOLFSSL_HEADERS}"
+    $CP_CMD ${WOLFSSL_HEADERS_TOP}/*.h .${WOLFSSL_HEADERS}
     if [ ! -d ".${WOLFCRYPT_HEADERS}" ]; then
+        #  mkdir ./wolfSSL/src/wolfssl/wolfcrypt
+        echo "Step 05: mkdir .${WOLFCRYPT_HEADERS}"
         mkdir .${WOLFCRYPT_HEADERS}
+        mkdir .${WOLFCRYPT_HEADERS}/port
+        mkdir .${WOLFCRYPT_HEADERS}/port/atmel
+        mkdir .${WOLFCRYPT_HEADERS}/port/Espressif
     fi
-    cp ${WOLFCRYPT_HEADERS_TOP}/*.h .${WOLFCRYPT_HEADERS}
+
+    # cp  ../../wolfssl/wolfcrypt/*.h  ./wolfSSL/src/wolfssl/wolfcrypt
+    echo "Step 06: cp    ${WOLFCRYPT_HEADERS_TOP}/*.h     .${WOLFCRYPT_HEADERS}"
+    $CP_CMD ${WOLFCRYPT_HEADERS_TOP}/*.h                .${WOLFCRYPT_HEADERS}                 || exit 1
+    $CP_CMD ${WOLFCRYPT_HEADERS_TOP}/port/atmel/*.h     .${WOLFCRYPT_HEADERS}/port/atmel      || exit 1
+    $CP_CMD ${WOLFCRYPT_HEADERS_TOP}/port/Espressif/*.h .${WOLFCRYPT_HEADERS}/port/Espressif  || exit 1
 
     # Add in source files to wolfcrypt/src
     if [ ! -d ".${WOLFCRYPT_ROOT}" ]; then
+        # mkdir ./wolfSSL/src/wolfcrypt
+        echo "Step 07: mkdir .${WOLFCRYPT_ROOT}"
         mkdir .${WOLFCRYPT_ROOT}
     fi
+
+    # mkdir ./wolfSSL/src/wolfcrypt/src
     if [ ! -d ".${WOLFCRYPT_SRC}" ]; then
+        echo "Step 08: mkdir .${WOLFCRYPT_SRC}"
         mkdir .${WOLFCRYPT_SRC}
+        mkdir .${WOLFCRYPT_SRC}/port
+        mkdir .${WOLFCRYPT_SRC}/port/atmel
+        mkdir .${WOLFCRYPT_SRC}/port/Espressif
     fi
-    cp ${WOLFCRYPT_SRC_TOP}/*.c .${WOLFCRYPT_SRC}
-    
+
+    # cp  ../../wolfcrypt/src/*.c  ./wolfSSL/src/wolfcrypt/src
+    echo "Step 09: cp    ${WOLFCRYPT_SRC_TOP}/*.c         .${WOLFCRYPT_SRC}"
+    $CP_CMD -r ${WOLFCRYPT_SRC_TOP}/*.c                  .${WOLFCRYPT_SRC}                || exit 1
+    $CP_CMD -r ${WOLFCRYPT_SRC_TOP}/port/atmel/*.c       .${WOLFCRYPT_SRC}/port/atmel     || exit 1
+    $CP_CMD -r ${WOLFCRYPT_SRC_TOP}/port/Espressif/*.c   .${WOLFCRYPT_SRC}/port/Espressif || exit 1
+
     # Add in source files to top level src folders
     if [ ! -d ".${WOLFSSL_SRC}" ]; then
+        # mkdir ./wolfSSL/src/src
+        echo "Step 10: mkdir .${WOLFSSL_SRC}"
         mkdir .${WOLFSSL_SRC}
     fi
-    cp ${WOLFSSL_SRC_TOP}/*.c .${WOLFSSL_SRC}
+    $CP_CMD ${WOLFSSL_SRC_TOP}/*.c .${WOLFSSL_SRC}                                        || exit 1
     # put bio and evp as includes
-    cp .${WOLFSSL_SRC}/bio.c .${WOLFSSL_HEADERS}
-    cp .${WOLFCRYPT_SRC}/evp.c .${WOLFSSL_HEADERS}
+    $CP_CMD .${WOLFSSL_SRC}/bio.c .${WOLFSSL_HEADERS}                                     || exit 1
+    $CP_CMD .${WOLFCRYPT_SRC}/evp.c .${WOLFSSL_HEADERS}                                   || exit 1
 
     # make a copy of evp.c and bio.c for ssl.c to include inline
-    cp .${WOLFSSL_HEADERS}/evp.c .${WOLFCRYPT_SRC}/evp.c
-    cp .${WOLFSSL_HEADERS}/bio.c .${WOLFCRYPT_SRC}/bio.c
-    
+    $CP_CMD .${WOLFSSL_HEADERS}/evp.c .${WOLFCRYPT_SRC}/evp.c                             || exit 1
+    $CP_CMD .${WOLFSSL_HEADERS}/bio.c .${WOLFCRYPT_SRC}/bio.c                             || exit 1
+
     # copy openssl compatibility headers to their appropriate location
     if [ ! -d ".${OPENSSL_DIR}" ]; then
         mkdir .${OPENSSL_DIR}
     fi
-    cp ${OPENSSL_DIR_TOP}/* .${OPENSSL_DIR}
+    $CP_CMD ${OPENSSL_DIR_TOP}/* .${OPENSSL_DIR}                                          || exit 1
 
 
     cat > .${ROOT_SRC_DIR}/wolfssl.h <<EOF
@@ -84,62 +216,72 @@ if [ "$DIR" = "ARDUINO" ]; then
 #include <wolfssl/ssl.h>
 EOF
 
-
-# Creates user_settings file if one does not exist
-    if [ ! -f ".${ROOT_SRC_DIR}/user_settings.h" ]; then
-    	cat > .${ROOT_SRC_DIR}/user_settings.h <<EOF
-/* Generated wolfSSL user_settings.h file for Arduino */
-#ifndef ARDUINO_USER_SETTINGS_H
-#define ARDUINO_USER_SETTINGS_H
-
-/* Platform */
-#define WOLFSSL_ARDUINO
-
-/* Math library (remove this to use normal math)*/
-#define USE_FAST_MATH
-#define TFM_NO_ASM
-#define NO_ASN_TIME
-
-/* When using Intel Galileo Uncomment the line below */
-/* #define INTEL_GALILEO */
-
-/* RNG DEFAULT !!FOR TESTING ONLY!! */
-/* comment out the error below to get started w/ bad entropy source
- * This will need fixed before distribution but is OK to test with */
-#error "needs solved, see: https://www.wolfssl.com/docs/porting-guide/"
-#define WOLFSSL_GENSEED_FORTEST
-
-#endif /* ARDUINO_USER_SETTINGS_H */
-EOF
-    fi
-
-    cp .${WOLFCRYPT_HEADERS}/settings.h .${WOLFCRYPT_HEADERS}/settings.h.bak
-    cat > .${WOLFCRYPT_HEADERS}/settings.h <<EOF
-/*wolfSSL Generated ARDUINO settings */
-#ifndef WOLFSSL_USER_SETTINGS
-    #define WOLFSSL_USER_SETTINGS
-#endif /* WOLFSSL_USER_SETTINGS */ 
-/*wolfSSL Generated ARDUINO settings: END */	
-
-EOF
-    cat .${WOLFCRYPT_HEADERS}/settings.h.bak >> .${WOLFCRYPT_HEADERS}/settings.h
-
-    #Creating library.properties file based off of: 
-    #https://arduino.github.io/arduino-cli/0.35/library-specification/#libraryproperties-file-format
-
-    cat > .${ROOT_DIR}/library.properties <<EOF
-name=wolfSSL
-version=${WOLFSSL_VERSION}
-author=wolfSSL inc
-maintainer=wolfSSL inc <support@wolfssl.com>
-sentence=A lightweight SSL/TLS library written in ANSI C and targeted for embedded, RTOS, and resource-constrained environments.
-paragraph=Manual: https://www.wolfssl.com/documentation/manuals/wolfssl/index.html.
-category=Communication
-url=https://www.wolfssl.com/
-architectures=*
-
-EOF
-
 else
     echo "ERROR: You must be in the IDE/ARDUINO directory to run this script"
+    exit 1
 fi
+
+# At this point, the library is complete, but we need some additional files.
+#
+# optional diagnostics:
+# echo ".${ROOT_DIR}"
+# echo "${TOP_DIR}"
+# echo "cp ${TOP_DIR}/README.md     .${ROOT_DIR}/"
+
+# Replace the `${WOLFSSL_VERSION}` text in Arduino_README_prepend.md,
+# saving it to a .tmp file. Prepend that file to the wolfSSL README.md
+# file as PREPENDED_README.md, then copy that to the publish directory
+# as an Arduino-specific README.md file.
+VERSION_PLACEHOLDER="\${WOLFSSL_VERSION}"
+ARDUINO_VERSION_SUFFIX_PLACEHOLDER="\${WOLFSSL_VERSION_ARUINO_SUFFIX}"
+PREPEND_FILE="Arduino_README_prepend.md"
+PROPERTIES_FILE_TEMPLATE="library.properties.template"
+sed s/"$VERSION_PLACEHOLDER"/"$WOLFSSL_VERSION"/ "$PREPEND_FILE" > "$PREPEND_FILE.tmp"
+cat "$PREPEND_FILE.tmp" ${TOP_DIR}/README.md > PREPENDED_README.md
+
+# Here we'll insert the wolfSSL version into the `library.properties.tmp` file, along with an Arduino version suffix.
+# The result should be something like version=5.6.601 (for the 1st incremental version on top of 5.6.6)
+sed            s/"$VERSION_PLACEHOLDER"/"$WOLFSSL_VERSION"/                              "$PROPERTIES_FILE_TEMPLATE" > "library.properties.tmp"
+sed -i.backup  s/"$ARDUINO_VERSION_SUFFIX_PLACEHOLDER"/"$WOLFSSL_VERSION_ARUINO_SUFFIX"/ "library.properties.tmp"
+
+# cat library.properties.tmp
+# echo "${WOLFSSL_VERSION_ARUINO_SUFFIX}"
+
+echo "Step 11: Final root file copy"
+$CP_CMD  PREPENDED_README.md        .${ROOT_DIR}/README.md           || exit 1
+$CP_CMD  library.properties.tmp     .${ROOT_DIR}/library.properties  || exit 1
+$CP_CMD  ${TOP_DIR}/"LICENSING"     .${ROOT_DIR}/                    || exit 1
+$CP_CMD  ${TOP_DIR}/"README"        .${ROOT_DIR}/                    || exit 1
+$CP_CMD  ${TOP_DIR}/"COPYING"       .${ROOT_DIR}/                    || exit 1
+$CP_CMD  ${TOP_DIR}/"ChangeLog.md"  .${ROOT_DIR}/                    || exit 1
+$CP_CMD  ${TOP_DIR}/".editorconfig" .${ROOT_DIR}/                    || exit 1
+$CP_CMD  ${TOP_DIR}/".gitignore"    .${ROOT_DIR}/                    || exit 1
+
+$CP_CMD  "keywords.txt"             .${ROOT_DIR}/                    || exit 1
+
+
+echo "Step 12: workspace to publish:"
+echo ""
+head -n 3  PREPENDED_README.md
+echo ""
+ls ./wolfSSL -al
+echo ""
+
+# Optionally install to a separate directory.
+# Note we should have exited above if a problem was encountered,
+# as we'll never want to install a bad library.
+if [ "$THIS_OPERATION" = "INSTALL" ]; then
+    if [ "$THIS_INSTALL_IS_GITHUB" = "true" ]; then
+        echo "Installing to GitHub directory: $THIS_INSTALL_DIR"
+        cp -r ".$ROOT_DIR"/* "$THIS_INSTALL_DIR" || exit 1
+    else
+        echo "Install:"
+        echo "cp ../../examples/configs/user_settings_arduino.h  .${ROOT_SRC_DIR}/user_settings.h"
+        cp ../../examples/configs/user_settings_arduino.h  ".${ROOT_SRC_DIR}/user_settings.h" || exit 1
+
+        echo "mv $ROOT_DIR $ARDUINO_ROOT"
+        mv ".$ROOT_DIR" "$ARDUINO_ROOT" || exit 1
+    fi
+fi
+
+echo "Done!"

--- a/examples/configs/include.am
+++ b/examples/configs/include.am
@@ -3,6 +3,7 @@
 
 EXTRA_DIST += examples/configs/README.md
 EXTRA_DIST += examples/configs/user_settings_all.h
+EXTRA_DIST += examples/configs/user_settings_arduino.h
 EXTRA_DIST += examples/configs/user_settings_min_ecc.h
 EXTRA_DIST += examples/configs/user_settings_wolfboot_keytools.h
 EXTRA_DIST += examples/configs/user_settings_template.h

--- a/examples/configs/user_settings_arduino.h
+++ b/examples/configs/user_settings_arduino.h
@@ -1,0 +1,429 @@
+/* examples/configs/user_settings_arduino.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* This is a sample Arduino user_settings.h for wolfSSL */
+
+#define NO_FILESYSTEM
+#define USE_CERT_BUFFERS_2048
+
+/* Make sure this is not an ESP-IDF file */
+#undef  WOLFSSL_ESPIDF
+
+#define HAVE_ECC
+#define WOLFSSL_SMALL_STACK
+/* #define WOLFSSL_SMALL_STACK_EXTRA */
+/* #define WOLFSSL_SMALL_STACK_CIPHERS */
+/* #define NO_DH */
+
+/* RSA must be enabled for examples, but can be disabled like this: */
+/* #define NO_RSA */
+#define RSA_LOW_MEM
+
+/* #define NO_OLD_TLS */
+
+/* Cannot use WOLFSSL_NO_MALLOC with small stack */
+/* #define WOLFSSL_NO_MALLOC */
+
+#define HAVE_TLS_EXTENSIONS
+#define HAVE_SUPPORTED_CURVES
+
+#define HAVE_AESGCM
+
+/* optionally turn off SHA512/224 SHA512/256 */
+/* #define WOLFSSL_NOSHA512_224 */
+/* #define WOLFSSL_NOSHA512_256 */
+
+/* when you want to use SINGLE THREAD. Note Default ESP-IDF is FreeRTOS */
+#define SINGLE_THREADED
+
+
+/* Optional OPENSSL compatibility */
+/* #define OPENSSL_EXTRA */
+/* #define OPENSSL_ALL */
+
+/* when you want to use pkcs7 */
+/* #define HAVE_PKCS7 */
+
+/* when you want to use AES counter mode */
+/* #define WOLFSSL_AES_DIRECT */
+/* #define WOLFSSL_AES_COUNTER */
+
+/* esp32-wroom-32se specific definition */
+#if defined(WOLFSSL_ESPWROOM32SE)
+    #define WOLFSSL_ATECC508A
+    #define HAVE_PK_CALLBACKS
+    /* when you want to use a custom slot allocation for ATECC608A */
+    /* unless your configuration is unusual, you can use default   */
+    /* implementation.                                             */
+    /* #define CUSTOM_SLOT_ALLOCATION                              */
+#endif
+
+/* RSA primitive specific definition */
+#if defined(WOLFSSL_ESP32) || defined(WOLFSSL_ESPWROOM32SE)
+    /* Define USE_FAST_MATH and SMALL_STACK                        */
+    #define ESP32_USE_RSA_PRIMITIVE
+
+    #if defined(CONFIG_IDF_TARGET_ESP32)
+
+        /* NOTE HW unreliable for small values! */
+        /* threshold for performance adjustment for HW primitive use   */
+        /* X bits of G^X mod P greater than                            */
+        #undef  ESP_RSA_EXPT_XBITS
+        #define ESP_RSA_EXPT_XBITS 32
+
+        /* X and Y of X * Y mod P greater than                         */
+        #undef  ESP_RSA_MULM_BITS
+        #define ESP_RSA_MULM_BITS  16
+
+    #endif
+#endif
+
+/* #define WOLFSSL_ATECC508A_DEBUG         */
+
+/* date/time                               */
+/* if it cannot adjust time in the device, */
+/* enable macro below                      */
+/* #define NO_ASN_TIME */
+/* #define XTIME time */
+
+
+/* adjust wait-timeout count if you see timeout in RSA HW acceleration */
+#define ESP_RSA_TIMEOUT_CNT    0x249F00
+
+#define HASH_SIZE_LIMIT /* for test.c */
+
+/* USE_FAST_MATH is default */
+#define USE_FAST_MATH
+
+/*****      Use SP_MATH      *****/
+/* #undef USE_FAST_MATH          */
+/* #define SP_MATH               */
+/* #define WOLFSSL_SP_MATH_ALL   */
+
+/***** Use Integer Heap Math *****/
+/* #undef USE_FAST_MATH          */
+/* #define USE_INTEGER_HEAP_MATH */
+
+/* Default is HW enabled unless turned off.
+** Uncomment these lines to force SW instead of HW acceleration */
+
+#if defined(CONFIG_IDF_TARGET_ESP32)
+    /* wolfSSL HW Acceleration supported on ESP32. Uncomment to disable: */
+    /*  #define NO_ESP32_CRYPT                 */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_HASH    */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_AES     */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_MP_MUL  */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_MULMOD  */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_EXPTMOD */
+
+    /*  These are defined automatically in esp32-crypt.h, here for clarity:  */
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH_SHA224 /* no SHA224 HW on ESP32  */
+
+    #undef  ESP_RSA_MULM_BITS
+    #define ESP_RSA_MULM_BITS 16 /* TODO add compile-time warning */
+    /***** END CONFIG_IDF_TARGET_ESP32 *****/
+
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)
+    /* wolfSSL HW Acceleration supported on ESP32-S2. Uncomment to disable: */
+    /*  #define NO_ESP32_CRYPT                 */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_HASH    */
+    /* Note: There's no AES192 HW on the ESP32-S2; falls back to SW */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_AES     */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_MP_MUL  */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_MULMOD  */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_EXPTMOD */
+    /***** END CONFIG_IDF_TARGET_ESP32S2 *****/
+
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+    /* wolfSSL HW Acceleration supported on ESP32-S3. Uncomment to disable: */
+    /*  #define NO_ESP32_CRYPT                         */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_HASH            */
+    /* Note: There's no AES192 HW on the ESP32-S3; falls back to SW */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_AES             */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI         */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_MP_MUL  */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_MULMOD  */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_EXPTMOD */
+    /***** END CONFIG_IDF_TARGET_ESP32S3 *****/
+
+#elif defined(CONFIG_IDF_TARGET_ESP32C2) || \
+      defined(CONFIG_IDF_TARGET_ESP8684)
+    /* ESP8684 is essentially ESP32-C2 chip + flash embedded together in a
+     * single QFN 4x4 mm package. Out of released documentation, Technical
+     * Reference Manual as well as ESP-IDF Programming Guide is applicable
+     * to both ESP32-C2 and ESP8684.
+     *
+     * See: https://www.esp32.com/viewtopic.php?f=5&t=27926#:~:text=ESP8684%20is%20essentially%20ESP32%2DC2,both%20ESP32%2DC2%20and%20ESP8684. */
+
+    /* wolfSSL HW Acceleration supported on ESP32-C2. Uncomment to disable: */
+    /*  #define NO_ESP32_CRYPT                 */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_HASH    */ /* to disable all SHA HW   */
+
+    /* These are defined automatically in esp32-crypt.h, here for clarity    */
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH_SHA384    /* no SHA384 HW on C2  */
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH_SHA512    /* no SHA512 HW on C2  */
+
+    /* There's no AES or RSA/Math accelerator on the ESP32-C2
+     * Auto defined with NO_WOLFSSL_ESP32_CRYPT_RSA_PRI, for clarity: */
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_MP_MUL
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_MULMOD
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_EXPTMOD
+    /***** END CONFIG_IDF_TARGET_ESP32C2 *****/
+
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+    /* wolfSSL HW Acceleration supported on ESP32-C3. Uncomment to disable: */
+
+    /*  #define NO_ESP32_CRYPT                 */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_HASH    */ /* to disable all SHA HW   */
+
+    /* These are defined automatically in esp32-crypt.h, here for clarity:  */
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH_SHA384    /* no SHA384 HW on C6  */
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH_SHA512    /* no SHA512 HW on C6  */
+
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_AES             */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI         */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_MP_MUL  */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_MULMOD  */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_EXPTMOD */
+    /***** END CONFIG_IDF_TARGET_ESP32C3 *****/
+
+#elif defined(CONFIG_IDF_TARGET_ESP32C6)
+    /* wolfSSL HW Acceleration supported on ESP32-C6. Uncomment to disable: */
+
+    /*  #define NO_ESP32_CRYPT                 */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_HASH    */
+    /*  These are defined automatically in esp32-crypt.h, here for clarity:  */
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH_SHA384    /* no SHA384 HW on C6  */
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH_SHA512    /* no SHA512 HW on C6  */
+
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_AES             */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI         */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_MP_MUL  */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_MULMOD  */
+    /*  #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_EXPTMOD */
+    /***** END CONFIG_IDF_TARGET_ESP32C6 *****/
+
+#elif defined(CONFIG_IDF_TARGET_ESP32H2)
+    /*  wolfSSL Hardware Acceleration not yet implemented */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+    /***** END CONFIG_IDF_TARGET_ESP32H2 *****/
+
+#elif defined(CONFIG_IDF_TARGET_ESP8266)
+    /*  TODO: Revisit ESP8266 */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+    /***** END CONFIG_IDF_TARGET_ESP266 *****/
+#else
+    /* Anything else encountered, disable HW accleration */
+    #define NO_ESP32_CRYPT
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH
+    #define NO_WOLFSSL_ESP32_CRYPT_AES
+    #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+#endif /* CONFIG_IDF_TARGET Check */
+
+/* Debug options:
+
+#define ESP_VERIFY_MEMBLOCK
+#define DEBUG_WOLFSSL
+#define DEBUG_WOLFSSL_VERBOSE
+#define DEBUG_WOLFSSL_SHA_MUTEX
+#define WOLFSSL_ESP32_CRYPT_DEBUG
+#define WOLFSSL_ESP32_CRYPT_HASH_SHA224_DEBUG
+#define NO_RECOVER_SOFTWARE_CALC
+#define WOLFSSL_TEST_STRAY 1
+#define USE_ESP_DPORT_ACCESS_READ_BUFFER
+#define WOLFSSL_ESP32_HW_LOCK_DEBUG
+#define WOLFSSL_DEBUG_ESP_RSA_MULM_BITS
+#define ESP_DISABLE_HW_TASK_LOCK
+*/
+
+#define WOLFSSL_ESPIDF_ERROR_PAUSE /* Pause in a loop rather than exit. */
+#define WOLFSSL_HW_METRICS
+
+/* #define HASH_SIZE_LIMIT */ /* for test.c */
+
+/* #define NO_HW_MATH_TEST */ /* Optionall turn off HW math checks */
+
+/* Optionally include alternate HW test library: alt_hw_test.h */
+/* When enabling, the ./components/wolfssl/CMakeLists.txt file
+ * will need the name of the library in the idf_component_register
+ * for the PRIV_REQUIRES list. */
+/* #define INCLUDE_ALT_HW_TEST */
+
+/* optionally turn off individual math HW acceleration features */
+
+/* Turn off Large Number ESP32 HW Multiplication:
+** [Z = X * Y] in esp_mp_mul()                                  */
+/* #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_MP_MUL                */
+
+/* Turn off Large Number ESP32 HW Modular Exponentiation:
+** [Z = X^Y mod M] in esp_mp_exptmod()                          */
+/* #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_EXPTMOD               */
+
+/* Turn off Large Number ESP32 HW Modular Multiplication
+** [Z = X * Y mod M] in esp_mp_mulmod()                         */
+/* #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_MULMOD                */
+
+
+#define WOLFSSL_PUBLIC_MP /* used by benchmark */
+
+/* when turning on ECC508 / ECC608 support
+#define WOLFSSL_ESPWROOM32SE
+#define HAVE_PK_CALLBACKS
+#define WOLFSSL_ATECC508A
+#define ATCA_WOLFSSL
+*/
+
+/* The section below defines macros used in typically all of the wolfSSL
+ * examples such as the client and server for certs stored in header files.
+ *
+ * There are various certificate examples in this header file:
+ * https://github.com/wolfSSL/wolfssl/blob/master/wolfssl/certs_test.h
+ *
+ * To use the sets of macros below, define *one* of these:
+ *
+ *    USE_CERT_BUFFERS_1024  - ECC 1024 bit encoded ASN1
+ *    USE_CERT_BUFFERS_2048  - RSA 2048 bit encoded ASN1
+ *    WOLFSSL_SM[2,3,4]      - SM Ciphers
+ *
+ * For example: define USE_CERT_BUFFERS_2048 to use CA Certs used in this
+ *  wolfSSL function for the `ca_cert_der_2048` buffer, size and types:
+ *
+ *     ret = wolfSSL_CTX_load_verify_buffer(ctx,
+ *                                          CTX_CA_CERT,
+ *                                          CTX_CA_CERT_SIZE,
+ *                                          CTX_CA_CERT_TYPE);
+ *
+ * See https://www.wolfssl.com/documentation/manuals/wolfssl/group__CertsKeys.html#function-wolfssl_ctx_load_verify_buffer
+ *
+ * In this case the CTX_CA_CERT will be defined as `ca_cert_der_2048` as
+ * defined here: https://github.com/wolfSSL/wolfssl/blob/master/wolfssl/certs_test.h
+ *
+ * The CTX_CA_CERT_SIZE and CTX_CA_CERT_TYPE are similarly used to reference
+ * array size and cert type respectively.
+ *
+ * Similarly for loading the private client key:
+ *
+ *  ret = wolfSSL_CTX_use_PrivateKey_buffer(ctx,
+ *                                          CTX_CLIENT_KEY,
+ *                                          CTX_CLIENT_KEY_SIZE,
+ *                                          CTX_CLIENT_KEY_TYPE);
+ *
+ * see https://www.wolfssl.com/documentation/manuals/wolfssl/group__CertsKeys.html#function-wolfssl_ctx_use_privatekey_buffer
+ *
+ * Similarly, the other macros are for server certificates and keys:
+ *   `CTX_SERVER_CERT` and `CTX_SERVER_KEY` are available.
+ *
+ * The certificate and key names are typically `static const unsigned char`
+ * arrays. The [NAME]_size are typically `sizeof([array name])`, and the types
+ * are the known wolfSSL encoding type integers (e.g. WOLFSSL_FILETYPE_PEM).
+ *
+ * See `SSL_FILETYPE_[name]` in
+ *   https://github.com/wolfSSL/wolfssl/blob/master/wolfssl/ssl.h
+ *
+ * See Abstract Syntax Notation One (ASN.1) in:
+ *   https://github.com/wolfSSL/wolfssl/blob/master/wolfssl/wolfcrypt/asn.h
+ *
+ * Optional SM4 Ciphers:
+ *
+ * Although the SM ciphers are shown here, the `certs_test_sm.h` may not yet
+ * be available. See:
+ *   https://github.com/wolfSSL/wolfssl/pull/6825
+ *   https://github.com/wolfSSL/wolfsm
+ *
+ * Uncomment these 3 macros to enable the SM Ciphers and use the macros below.
+ */
+
+/*
+#define WOLFSSL_SM2
+#define WOLFSSL_SM3
+#define WOLFSSL_SM4
+*/
+
+/* Conditional macros used in wolfSSL TLS client and server examples */
+#if defined(WOLFSSL_SM2) || defined(WOLFSSL_SM3) || defined(WOLFSSL_SM4)
+    #include <wolfssl/certs_test_sm.h>
+    #define CTX_CA_CERT          root_sm2
+    #define CTX_CA_CERT_SIZE     sizeof_root_sm2
+    #define CTX_CA_CERT_TYPE     WOLFSSL_FILETYPE_PEM
+    #define CTX_SERVER_CERT      server_sm2
+    #define CTX_SERVER_CERT_SIZE sizeof_server_sm2
+    #define CTX_SERVER_CERT_TYPE WOLFSSL_FILETYPE_PEM
+    #define CTX_SERVER_KEY       server_sm2_priv
+    #define CTX_SERVER_KEY_SIZE  sizeof_server_sm2_priv
+    #define CTX_SERVER_KEY_TYPE  WOLFSSL_FILETYPE_PEM
+
+    #undef  WOLFSSL_BASE16
+    #define WOLFSSL_BASE16
+#else
+    #if defined(USE_CERT_BUFFERS_2048)
+        #include <wolfssl/certs_test.h>
+        #define CTX_CA_CERT          ca_cert_der_2048
+        #define CTX_CA_CERT_SIZE     sizeof_ca_cert_der_2048
+        #define CTX_CA_CERT_TYPE     WOLFSSL_FILETYPE_ASN1
+
+        #define CTX_SERVER_CERT      server_cert_der_2048
+        #define CTX_SERVER_CERT_SIZE sizeof_server_cert_der_2048
+        #define CTX_SERVER_CERT_TYPE WOLFSSL_FILETYPE_ASN1
+        #define CTX_SERVER_KEY       server_key_der_2048
+        #define CTX_SERVER_KEY_SIZE  sizeof_server_key_der_2048
+        #define CTX_SERVER_KEY_TYPE  WOLFSSL_FILETYPE_ASN1
+
+        #define CTX_CLIENT_CERT      client_cert_der_2048
+        #define CTX_CLIENT_CERT_SIZE sizeof_client_cert_der_2048
+        #define CTX_CLIENT_CERT_TYPE WOLFSSL_FILETYPE_ASN1
+        #define CTX_CLIENT_KEY       client_key_der_2048
+        #define CTX_CLIENT_KEY_SIZE  sizeof_client_key_der_2048
+        #define CTX_CLIENT_KEY_TYPE  WOLFSSL_FILETYPE_ASN1
+
+    #elif defined(USE_CERT_BUFFERS_1024)
+        #include <wolfssl/certs_test.h>
+        #define CTX_CA_CERT          ca_cert_der_1024
+        #define CTX_CA_CERT_SIZE     sizeof_ca_cert_der_1024
+        #define CTX_CA_CERT_TYPE     WOLFSSL_FILETYPE_ASN1
+
+        #define CTX_CLIENT_CERT      client_cert_der_1024
+        #define CTX_CLIENT_CERT_SIZE sizeof_client_cert_der_1024
+        #define CTX_CLIENT_CERT_TYPE WOLFSSL_FILETYPE_ASN1
+        #define CTX_CLIENT_KEY       client_key_der_1024
+        #define CTX_CLIENT_KEY_SIZE  sizeof_client_key_der_1024
+        #define CTX_CLIENT_KEY_TYPE  WOLFSSL_FILETYPE_ASN1
+
+        #define CTX_SERVER_CERT      server_cert_der_1024
+        #define CTX_SERVER_CERT_SIZE sizeof_server_cert_der_1024
+        #define CTX_SERVER_CERT_TYPE WOLFSSL_FILETYPE_ASN1
+        #define CTX_SERVER_KEY       server_key_der_1024
+        #define CTX_SERVER_KEY_SIZE  sizeof_server_key_der_1024
+        #define CTX_SERVER_KEY_TYPE  WOLFSSL_FILETYPE_ASN1
+    #else
+        /* Optionally define custom cert arrays, sizes, and types here */
+        #error "Must define USE_CERT_BUFFERS_2048 or USE_CERT_BUFFERS_1024"
+    #endif
+#endif /* Conditional key and cert constant names */

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -3415,6 +3415,73 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         return 0;
     }
 
+#elif defined(ARDUINO)
+
+    int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
+    {
+        int ret = 0;
+        word32 rand;
+        while (sz > 0) {
+            word32 len = sizeof(rand);
+            if (sz < len)
+                len = sz;
+        /* Get an Arduino framework random number */
+        #if defined(__arm__)
+            /* See: https://github.com/avrxml/asf/tree/master/sam/utils/cmsis/sam3x/include */
+            #if defined(__SAM3A4C__)
+                #ifndef TRNG
+                    #define TRNG (0x400BC000U)
+                #endif
+            #elif defined(__SAM3A8C__)
+                #ifndef TRNG
+                    #define TRNG (0x400BC000U)
+                #endif
+            #elif defined(__SAM3X4C__)
+                #ifndef TRNG
+                    #define TRNG (0x400BC000U)
+                #endif
+            #elif defined(__SAM3X4E__)
+                #ifndef TRNG
+                    #define TRNG (0x400BC000U)
+                #endif
+            #elif defined(__SAM3X8C__)
+                #ifndef TRNG
+                    #define TRNG (0x400BC000U)
+                #endif
+            #elif defined(__SAM3X8E__)
+                /* This is the Arduino Due */
+                #ifndef TRNG
+                    #define TRNG (0x400BC000U)
+                #endif
+            #elif  defined(__SAM3A8H__)
+                #ifndef TRNG
+                    #define TRNG (0x400BC000U)
+                #endif
+            #else
+                #ifndef TRNG
+                    #error "Unknown TRNG for this device"
+                #endif
+            #endif
+
+            srand(analogRead(0));
+            rand = trng_read_output_data(TRNG);
+        #elif defined(__STM32__)
+            /* TODO: confirm this is proper random number on Arduino STM32 */
+            #warning "Not yet tested on STM32 targets"
+            rand = random();
+        #else
+            /* TODO: Pull requests appreciated for new targets */
+            #warning "Not yet tested on this target"
+            rand = random();
+        #endif
+            XMEMCPY(output, &rand, len);
+            output += len;
+            sz -= len;
+        }
+
+        return ret;
+    }
+
 #elif defined(WOLFSSL_ESPIDF)
 
     /* Espressif */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3039,18 +3039,20 @@ WOLFSSL_API int wolfSSL_make_eap_keys(WOLFSSL* ssl, void* key, unsigned int len,
         #ifdef __PPU
             #include <sys/types.h>
             #include <sys/socket.h>
-        #elif !defined(WOLFSSL_MDK_ARM) && !defined(WOLFSSL_IAR_ARM) && \
+        #elif defined(ARDUINO)
+            /* TODO board specific */
+        #elif !defined(WOLFSSL_MDK_ARM) && !defined(WOLFSSL_IAR_ARM)    && \
               !defined(WOLFSSL_PICOTCP) && !defined(WOLFSSL_ROWLEY_ARM) && \
-              !defined(WOLFSSL_EMBOS) && !defined(WOLFSSL_FROSTED) && \
-              !defined(WOLFSSL_CHIBIOS) && !defined(WOLFSSL_CONTIKI) && \
-              !defined(WOLFSSL_ZEPHYR) && !defined(NETOS)
+              !defined(WOLFSSL_EMBOS)   && !defined(WOLFSSL_FROSTED)    && \
+              !defined(WOLFSSL_CHIBIOS) && !defined(WOLFSSL_CONTIKI)    && \
+              !defined(WOLFSSL_ZEPHYR)  && !defined(NETOS)
             #include <sys/uio.h>
         #endif
         /* allow writev style writing */
         WOLFSSL_API int wolfSSL_writev(WOLFSSL* ssl, const struct iovec* iov,
                                      int iovcnt);
-    #endif
-#endif
+    #endif /* !NO_WRITEV */
+#endif /* !_WIN32 */
 
 
 #ifndef NO_CERTS

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -175,6 +175,8 @@
         int h_length;        /* length of address */
         char** h_addr_list;  /* list of addresses from the name server */
     };
+#elif defined(ARDUINO)
+    /* TODO, define board-specific */
 #else
     #include <string.h>
     #include <sys/types.h>

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -265,6 +265,32 @@
 /* Uncomment next line if using MAXQ108x */
 /* #define WOLFSSL_MAXQ108X */
 
+#if defined(ARDUINO)
+    /* we don't have the luxury of compiler options, so manually define */
+    #if defined(__arm__)
+        #undef  WOLFSSL_ARDUINO
+        #define WOLFSSL_ARDUINO
+    /* ESP32? */
+    #endif // defined(__arm__)
+
+    #undef FREERTOS
+    #ifndef WOLFSSL_USER_SETTINGS
+        #define WOLFSSL_USER_SETTINGS
+    #endif /* WOLFSSL_USER_SETTINGS */
+
+    /* board-specific */
+    #if defined(__AVR__)
+        #define WOLFSSL_NO_SOCK
+        #define NO_WRITEV
+    #elif defined(__arm__)
+        #define WOLFSSL_NO_SOCK
+        #define NO_WRITEV
+    #elif defined(ESP32) || defined(ESP8266)
+        /* assume sockets available */
+    #else
+        #define WOLFSSL_NO_SOCK
+    #endif
+#endif
 
 #ifdef WOLFSSL_USER_SETTINGS
     #include "user_settings.h"
@@ -419,6 +445,33 @@
         #include <types.h>
     #endif
     #include <nx_api.h>
+#endif
+
+#if defined(ARDUINO)
+    #if defined(ESP32)
+        #ifndef NO_ARDUINO_DEFAULT
+            #define SIZEOF_LONG_LONG 8
+            #ifdef FREERTOS
+                #undef FREERTOS
+            #endif
+
+            #define WOLFSSL_LWIP
+            #define NO_WRITEV
+            #define NO_WOLFSSL_DIR
+            #define WOLFSSL_NO_CURRDIR
+
+            #define TFM_TIMING_RESISTANT
+            #define ECC_TIMING_RESISTANT
+            #define WC_RSA_BLINDING
+            #define WC_NO_CACHE_RESISTANT
+        #endif /* !NO_ARDUINO_DEFAULT */
+    #elif defined(__arm__)
+            #define NO_WRITEV
+            #define NO_WOLFSSL_DIR
+            #define WOLFSSL_NO_CURRDIR
+    #elif defined(OTHERBOARD)
+        /* TODO: define other Arduino boards here */
+    #endif
 #endif
 
 #if defined(WOLFSSL_ESPIDF)
@@ -751,11 +804,20 @@
 
 
 #ifdef WOLFSSL_ARDUINO
+    /* Define WOLFSSL_USER_IO here to avoid check in internal.c */
+    #define WOLFSSL_USER_IO
+
     #define NO_WRITEV
     #define NO_WOLFSSL_DIR
     #define SINGLE_THREADED
     #define NO_DEV_RANDOM
-    #ifndef INTEL_GALILEO /* Galileo has time.h compatibility */
+    #if defined(INTEL_GALILEO) || defined(ESP32)
+        /* boards with has time.h compatibility */
+    #elif defined(__arm__)
+        /* TODO is time really missing from Arduino Due? */
+        /* This is a brute-force solution to make it work: */
+        #define NO_ASN_TIME
+    #else
         #define TIME_OVERRIDES
         #ifndef XTIME
             #error "Must define XTIME externally see porting guide"
@@ -3328,6 +3390,11 @@ extern void uITRON4_free(void *p) ;
         #error "RFC9325 requires some additional alerts to be sent"
     #endif
     /* Ciphersuite check done in internal.h */
+#endif
+
+/* Some final sanity checks */
+#if defined(WOLFSSL_ESPIDF) && defined(ARDUINO)
+    #error "Found both ESPIDF and ARDUINO. Pick one."
 #endif
 
 

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -271,7 +271,7 @@
         #undef  WOLFSSL_ARDUINO
         #define WOLFSSL_ARDUINO
     /* ESP32? */
-    #endif // defined(__arm__)
+    #endif
 
     #undef FREERTOS
     #ifndef WOLFSSL_USER_SETTINGS

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -364,7 +364,7 @@ while (0)
 /* Initialize an mp_int. */
 #define INIT_MP_INT_SIZE(name, bits) \
     mp_init(name)
-/* Type to cast to when using size marcos. */
+/* Type to cast to when using size macros. */
 #define MP_INT_SIZE     mp_int
 
 

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -698,49 +698,57 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
 
     #if !defined(NO_WOLFSSL_DIR)\
         && !defined(WOLFSSL_NUCLEUS) && !defined(WOLFSSL_NUCLEUS_1_2)
-    #if defined(USE_WINDOWS_API)
-        #include <sys/stat.h>
-        #ifndef XSTAT
-        #define XSTAT       _stat
-        #endif
-        #define XS_ISREG(s) (s & _S_IFREG)
-        #define SEPARATOR_CHAR ';'
+        #if defined(USE_WINDOWS_API)
+            #include <sys/stat.h>
+            #ifndef XSTAT
+                #define XSTAT       _stat
+            #endif
+            #define XS_ISREG(s) (s & _S_IFREG)
+            #define SEPARATOR_CHAR ';'
 
-    #elif defined(INTIME_RTOS)
-        #include <sys/stat.h>
-        #ifndef XSTAT
-        #define XSTAT _stat64
-        #endif
-        #define XS_ISREG(s) S_ISREG(s)
-        #define SEPARATOR_CHAR ';'
-        #define XWRITE      write
-        #define XREAD       read
-        #define XCLOSE      close
+        #elif defined(ARDUINO)
+            #ifndef XSTAT
+                #define XSTAT       _stat
+            #endif
+            #define XS_ISREG(s) (s & _S_IFREG)
+            #define SEPARATOR_CHAR ';'
 
-    #elif defined(WOLFSSL_TELIT_M2MB)
-        #ifndef XSTAT
-        #define XSTAT       m2mb_fs_stat
-        #endif
-        #define XS_ISREG(s) (s & M2MB_S_IFREG)
-        #define SEPARATOR_CHAR ':'
-    #else
-        #include <dirent.h>
-        #include <unistd.h>
-        #include <sys/stat.h>
-        #define XWRITE      write
-        #define XREAD       read
-        #define XCLOSE      close
-        #ifndef XSTAT
-        #define XSTAT       stat
-        #endif
-        #define XS_ISREG(s) S_ISREG(s)
-        #define SEPARATOR_CHAR ':'
-    #endif
+        #elif defined(INTIME_RTOS)
+            #include <sys/stat.h>
+            #ifndef XSTAT
+            #define XSTAT _stat64
+            #endif
+            #define XS_ISREG(s) S_ISREG(s)
+            #define SEPARATOR_CHAR ';'
+            #define XWRITE      write
+            #define XREAD       read
+            #define XCLOSE      close
 
-    #ifndef XSTAT_TYPE
-        #define XSTAT_TYPE struct XSTAT
-    #endif
-    #endif
+        #elif defined(WOLFSSL_TELIT_M2MB)
+            #ifndef XSTAT
+            #define XSTAT       m2mb_fs_stat
+            #endif
+            #define XS_ISREG(s) (s & M2MB_S_IFREG)
+            #define SEPARATOR_CHAR ':'
+
+        #else
+            #include <dirent.h>
+            #include <unistd.h>
+            #include <sys/stat.h>
+            #define XWRITE      write
+            #define XREAD       read
+            #define XCLOSE      close
+            #ifndef XSTAT
+            #define XSTAT       stat
+            #endif
+            #define XS_ISREG(s) S_ISREG(s)
+            #define SEPARATOR_CHAR ':'
+        #endif
+
+        #ifndef XSTAT_TYPE
+            #define XSTAT_TYPE struct XSTAT
+        #endif
+    #endif /* !NO_WOLFSSL_DIR !WOLFSSL_NUCLEUS !WOLFSSL_NUCLEUS_1_2 */
 #endif
 
     #ifndef MAX_FILENAME_SZ
@@ -777,6 +785,8 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
         #define IntimeFindNext(data)  (0 == _findnext64(data))
         #define IntimeFindClose(data) (0 == _findclose64(data))
         #define IntimeFilename(ctx)   ctx->FindFileData.f_filename
+    #elif defined(ARDUINO)
+        /* TODO: board specific features */
     #else
         struct dirent* entry;
         DIR*   dir;

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -66,6 +66,8 @@
             #include <errno.h>
             #define LWIP_PROVIDE_ERRNO 1
         #endif
+    #elif defined(ARDUINO)
+        /* TODO Add specific boards */
     #elif defined(FREESCALE_MQX)
         #include <posix.h>
         #include <rtcs.h>
@@ -318,6 +320,12 @@
     #include <network.h>
     #define SEND_FUNCTION net_send
     #define RECV_FUNCTION net_recv
+#elif defined(WOLFSSL_ESPIDF)
+    #define SEND_FUNCTION send
+    #define RECV_FUNCTION recv
+    #if !defined(HAVE_SOCKADDR) && !defined(WOLFSSL_NO_SOCK)
+        #define HAVE_SOCKADDR
+    #endif
 #elif defined(WOLFSSL_LWIP) && !defined(WOLFSSL_APACHE_MYNEWT)
     #define SEND_FUNCTION lwip_send
     #define RECV_FUNCTION lwip_recv


### PR DESCRIPTION
# Description

This PR improves support for the Arduino platform.

I'll be testing other Arduino boards, but I've added the `help wanted` label to invite others to test these changes with various other devices.

Of particular interest, gated sections added to:

- `src/internal.c` (only a placeholder reminder / not part of "else" gating)
- `wolfcrypt/src/random.c` (more board-specific implementation will be needed here)
- `wolfssl/wolfcrypt/settings.h` (only AVR, ARM, and Espressif at this time)
- `wolfssl/wolfcrypt/tfm.h` (just a spelling correction)
- `wolfssl/wolfcrypt/wc_port.h` (only basic Arduino support, likely needs work for other boards)
- `wolfssl/ssl.h` (only a placeholder reminder & adjacent cleanup)
- `wolfssl/test.h` (only a placeholder reminder; test.h not yet working in Arduino)
- `wolfssl/wolfio.h` (only Espressif at this time)

Fixes zd# may help with 17001, although more ESP8266 work is known to be needed. 

See also https://github.com/wolfSSL/wolfssl/issues/6360 and https://github.com/wolfSSL/Arduino-wolfSSL/pull/1


# Testing

How did you test?

Primarily tested in the Arduino environment, as well as the usual:

```
./configure --enable-all
make clean
make && make test
```


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
