### PR TITLE
20240126-LINUXKM_LKCAPI_REGISTER

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8042,6 +8042,11 @@ AC_ARG_ENABLE([linuxkm-lkcapi-register],
 if test "$ENABLED_LINUXKM_LKCAPI_REGISTER" != "none"
 then
     AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_REGISTER"
+
+    if test "$ENABLED_AESGCM" != "no" && test "$ENABLED_AESGCM_STREAM" = "no" && test "$ENABLED_AESNI" = "no" && test "$ENABLED_ARMASM" = "no" && test "$ENABLED_FIPS" = "no"; then
+        ENABLED_AESGCM_STREAM=yes
+    fi
+
     for lkcapi_alg in $(echo "$ENABLED_LINUXKM_LKCAPI_REGISTER" | tr ',' ' ')
     do
         case "$lkcapi_alg" in

--- a/configure.ac
+++ b/configure.ac
@@ -745,7 +745,7 @@ then
     test "$enable_psk" = "" && enable_psk=yes
     test "$enable_cmac" = "" && enable_cmac=yes
     test "$enable_siphash" = "" && enable_siphash=yes
-    test "$enable_xts" = "" && enable_xts=yes
+    test "$enable_aesxts" = "" && enable_aesxts=yes
     test "$enable_ocsp" = "" && enable_ocsp=yes
     test "$enable_ocspstapling" = "" && test "$enable_ocsp" != "no" && enable_ocspstapling=yes
     test "$enable_ocspstapling2" = "" && test "$enable_ocsp" != "no" && enable_ocspstapling2=yes
@@ -933,7 +933,7 @@ then
     test "$enable_psk" = "" && enable_psk=yes
     test "$enable_cmac" = "" && enable_cmac=yes
     test "$enable_siphash" = "" && enable_siphash=yes
-    test "$enable_xts" = "" && enable_xts=yes
+    test "$enable_aesxts" = "" && enable_aesxts=yes
     test "$enable_ocsp" = "" && enable_ocsp=yes
     test "$enable_ocspstapling" = "" && test "$enable_ocsp" != "no" && enable_ocspstapling=yes
     test "$enable_ocspstapling2" = "" && test "$enable_ocsp" != "no" && enable_ocspstapling2=yes
@@ -4836,17 +4836,23 @@ AS_IF([test "x$ENABLED_CMAC" = "xyes"],
 
 
 # AES-XTS
-AC_ARG_ENABLE([xts],
-    [AS_HELP_STRING([--enable-xts],[Enable XTS (default: disabled)])],
-    [ ENABLED_XTS=$enableval ],
-    [ ENABLED_XTS=no ]
+AC_ARG_ENABLE([aesxts],
+    [AS_HELP_STRING([--enable-aesxts],[Enable AES XTS (default: disabled)])],
+    [ ENABLED_AESXTS=$enableval ],
+    [ ENABLED_AESXTS=no ]
     )
 
-AS_IF([test "x$ENABLED_XTS" = "xyes"],
+# legacy old option name, for compatibility:
+AC_ARG_ENABLE([xts],
+    [AS_HELP_STRING([--enable-xts],[Please use --enable-aesxts])],
+    [ ENABLED_AESXTS=$enableval ]
+    )
+
+AS_IF([test "x$ENABLED_AESXTS" = "xyes"],
       [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_AES_XTS -DWOLFSSL_AES_DIRECT"])
-AS_IF([test "x$ENABLED_XTS" = "xyes" && test "x$ENABLED_INTELASM" = "xyes"],
+AS_IF([test "x$ENABLED_AESXTS" = "xyes" && test "x$ENABLED_INTELASM" = "xyes"],
       [AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_AES_XTS"])
-AS_IF([test "x$ENABLED_XTS" = "xyes" && test "x$ENABLED_AESNI" = "xyes"],
+AS_IF([test "x$ENABLED_AESXTS" = "xyes" && test "x$ENABLED_AESNI" = "xyes"],
       [AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_AES_XTS"])
 
 # Web Server Build
@@ -8028,6 +8034,32 @@ if test -n "$MPI_MAX_KEY_BITS" -o -n "$WITH_MAX_ECC_BITS"; then
    fi
 fi
 
+AC_ARG_ENABLE([linuxkm-lkcapi-register],
+    [AS_HELP_STRING([--enable-linuxkm-lkcapi-register],[Register wolfCrypt implementations with the Linux Kernel Crypto API backplane.  Possible values are "none", "all", "cbc(aes)", "cfb(aes)", "gcm(aes)", and "xts(aes)", or a comma-separate combination. (default: none)])],
+    [ENABLED_LINUXKM_LKCAPI_REGISTER=$enableval],
+    [ENABLED_LINUXKM_LKCAPI_REGISTER=none]
+    )
+if test "$ENABLED_LINUXKM_LKCAPI_REGISTER" != "none"
+then
+    AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_REGISTER"
+    for lkcapi_alg in $(echo "$ENABLED_LINUXKM_LKCAPI_REGISTER" | tr ',' ' ')
+    do
+        case "$lkcapi_alg" in
+        all) AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_REGISTER_ALL"           ;;
+        'cbc(aes)') test "$ENABLED_AESCBC" != "no" || AC_MSG_ERROR([linuxkm-lkcapi-register ${lkcapi_alg}: AES-CBC implementation not enabled.])
+                    AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_REGISTER_AESCBC" ;;
+        'cfb(aes)') test "$ENABLED_AESCFB" != "no" || AC_MSG_ERROR([linuxkm-lkcapi-register ${lkcapi_alg}: AES-CFB implementation not enabled.])
+                    AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_REGISTER_AESCFB" ;;
+        'gcm(aes)') test "$ENABLED_AESGCM" != "no" || AC_MSG_ERROR([linuxkm-lkcapi-register ${lkcapi_alg}: AES-GCM implementation not enabled.])
+                    test "$ENABLED_AESGCM_STREAM" != "no" || AC_MSG_ERROR([linuxkm-lkcapi-register ${lkcapi_alg}: --enable-aesgcm-stream is required for LKCAPI.])
+                    AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_REGISTER_AESGCM" ;;
+        'xts(aes)') test "$ENABLED_AESXTS" != "no" || AC_MSG_ERROR([linuxkm-lkcapi-register ${lkcapi_alg}: AES-XTS implementation not enabled.])
+                    AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_REGISTER_AESXTS" ;;
+        *) AC_MSG_ERROR([Unsupported LKCAPI algorithm "$lkcapi_alg".])      ;;
+        esac
+    done
+fi
+
 # Library Suffix
 LIBSUFFIX=""
 AC_ARG_WITH([libsuffix],
@@ -8958,7 +8990,7 @@ AM_CONDITIONAL([BUILD_SNIFFER],  [ test "x$ENABLED_SNIFFER"   = "xyes" || test "
 AM_CONDITIONAL([BUILD_SNIFFTEST],[ test "x$ENABLED_SNIFFTEST" = "xyes"])
 AM_CONDITIONAL([BUILD_AESGCM],[test "x$ENABLED_AESGCM" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_AESCCM],[test "x$ENABLED_AESCCM" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
-AM_CONDITIONAL([BUILD_XTS],[test "x$ENABLED_XTS" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
+AM_CONDITIONAL([BUILD_AESXTS],[test "x$ENABLED_AESXTS" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_ARMASM],[test "x$ENABLED_ARMASM" = "xyes"])
 AM_CONDITIONAL([BUILD_ARMASM_INLINE],[test "x$ENABLED_ARMASM_INLINE" = "xyes"])
 AM_CONDITIONAL([BUILD_ARMASM_CRYPTO],[test "x$ENABLED_ARMASM_CRYPTO" = "xyes"])
@@ -9397,6 +9429,7 @@ echo "   * AES-CCM:                    $ENABLED_AESCCM"
 echo "   * AES-CTR:                    $ENABLED_AESCTR"
 echo "   * AES-CFB:                    $ENABLED_AESCFB"
 echo "   * AES-OFB:                    $ENABLED_AESOFB"
+echo "   * AES-XTS:                    $ENABLED_AESXTS"
 echo "   * AES-SIV:                    $ENABLED_AESSIV"
 echo "   * AES-EAX:                    $ENABLED_AESEAX"
 echo "   * AES Bitspliced:             $ENABLED_AESBS"

--- a/linuxkm/Kbuild
+++ b/linuxkm/Kbuild
@@ -32,6 +32,10 @@ WOLFSSL_CFLAGS += -ffreestanding -Wframe-larger-than=$(MAX_STACK_FRAME_SIZE) -is
 
 ifeq "$(KERNEL_ARCH)" "x86"
     WOLFSSL_CFLAGS += -mpreferred-stack-boundary=4
+else ifeq "$(KERNEL_ARCH)" "aarch64"
+    WOLFSSL_CFLAGS += -mno-outline-atomics
+else ifeq "$(KERNEL_ARCH)" "arm64"
+    WOLFSSL_CFLAGS += -mno-outline-atomics
 endif
 
 obj-m := libwolfssl.o
@@ -47,14 +51,14 @@ $(obj)/linuxkm/module_exports.o: $(WOLFSSL_OBJ_TARGETS)
 # this mechanism only works in kernel 5.x+ (fallback to hardcoded value)
 hostprogs := linuxkm/get_thread_size
 always-y := $(hostprogs)
+
+HOST_EXTRACFLAGS += $(NOSTDINC_FLAGS) $(LINUXINCLUDE) $(KBUILD_CFLAGS) -static -fno-omit-frame-pointer
+
 # "-mindirect-branch=keep -mfunction-return=keep" to avoid "undefined reference
 #  to `__x86_return_thunk'" on CONFIG_RETHUNK kernels (5.19.0-rc7)
-ifeq "$(KERNEL_ARCH)" "aarch64"
-  HOST_EXTRACFLAGS += $(NOSTDINC_FLAGS) $(LINUXINCLUDE) $(KBUILD_CFLAGS) -static -fno-omit-frame-pointer
-else
-  HOST_EXTRACFLAGS += $(NOSTDINC_FLAGS) $(LINUXINCLUDE) $(KBUILD_CFLAGS) -static -fno-omit-frame-pointer -mindirect-branch=keep -mfunction-return=keep
+ifeq "$(KERNEL_ARCH)" "x86"
+  HOST_EXTRACFLAGS += -mindirect-branch=keep -mfunction-return=keep
 endif
-
 
 # this rule is needed to get build to succeed in 4.x (get_thread_size still doesn't get built)
 $(obj)/linuxkm/get_thread_size: $(src)/linuxkm/get_thread_size.c

--- a/linuxkm/Kbuild
+++ b/linuxkm/Kbuild
@@ -49,7 +49,12 @@ hostprogs := linuxkm/get_thread_size
 always-y := $(hostprogs)
 # "-mindirect-branch=keep -mfunction-return=keep" to avoid "undefined reference
 #  to `__x86_return_thunk'" on CONFIG_RETHUNK kernels (5.19.0-rc7)
-HOST_EXTRACFLAGS += $(NOSTDINC_FLAGS) $(LINUXINCLUDE) $(KBUILD_CFLAGS) -static -fno-omit-frame-pointer -mindirect-branch=keep -mfunction-return=keep
+ifeq "$(KERNEL_ARCH)" "aarch64"
+  HOST_EXTRACFLAGS += $(NOSTDINC_FLAGS) $(LINUXINCLUDE) $(KBUILD_CFLAGS) -static -fno-omit-frame-pointer
+else
+  HOST_EXTRACFLAGS += $(NOSTDINC_FLAGS) $(LINUXINCLUDE) $(KBUILD_CFLAGS) -static -fno-omit-frame-pointer -mindirect-branch=keep -mfunction-return=keep
+endif
+
 
 # this rule is needed to get build to succeed in 4.x (get_thread_size still doesn't get built)
 $(obj)/linuxkm/get_thread_size: $(src)/linuxkm/get_thread_size.c

--- a/linuxkm/Kbuild
+++ b/linuxkm/Kbuild
@@ -154,10 +154,10 @@ ifneq "$(quiet)" "silent_"
 endif
 	@cd "$(obj)" || exit $$?; \
 	for file in $(WOLFCRYPT_PIE_FILES); do \
-	    $(OBJCOPY) --rename-section .text=.text.wolfcrypt --rename-section .data=.data.wolfcrypt "$$file" || exit $$?; \
+	    $(OBJCOPY) --rename-section .text=.text.wolfcrypt --rename-section .data=.data.wolfcrypt --rename-section .rodata=.rodata.wolfcrypt "$$file" || exit $$?; \
 	done
 ifneq "$(quiet)" "silent_"
-	@echo '  wolfCrypt .{text,data} sections containerized to .{text,data}.wolfcrypt'
+	@echo '  wolfCrypt .{text,data,rodata} sections containerized to .{text,data,rodata}.wolfcrypt'
 endif
 
 $(src)/linuxkm/module_exports.c: rename-pie-text-and-data-sections

--- a/linuxkm/include.am
+++ b/linuxkm/include.am
@@ -12,4 +12,5 @@ EXTRA_DIST += m4/ax_linuxkm.m4 \
 	      linuxkm/pie_redirect_table.c \
 	      linuxkm/pie_last.c \
 	      linuxkm/linuxkm_memory.c \
-	      linuxkm/linuxkm_wc_port.h
+	      linuxkm/linuxkm_wc_port.h \
+	      linuxkm/lkcapi_glue.c

--- a/linuxkm/linuxkm_memory.c
+++ b/linuxkm/linuxkm_memory.c
@@ -275,7 +275,7 @@ WARN_UNUSED_RESULT int save_vector_registers_x86(void)
 {
     struct wc_thread_fpu_count_ent *pstate = wc_linuxkm_fpu_state_assoc(1);
     if (pstate == NULL)
-        return ENOMEM;
+        return MEMORY_E;
 
     /* allow for nested calls */
     if (pstate->fpu_state != 0U) {
@@ -314,7 +314,7 @@ WARN_UNUSED_RESULT int save_vector_registers_x86(void)
         if (! warned_fpu_forbidden)
             pr_err("save_vector_registers_x86 called from IRQ handler.\n");
         wc_linuxkm_fpu_state_release(pstate);
-        return EPERM;
+        return BAD_STATE_E;
     } else {
 #if defined(CONFIG_SMP) && !defined(CONFIG_PREEMPT_COUNT) && \
     (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 7, 0)) && \
@@ -378,5 +378,13 @@ void my__show_free_areas(
     (void)nodemask;
     (void)max_zone_idx;
     return;
+}
+#endif
+
+#if defined(__PIE__) && defined(CONFIG_FORTIFY_SOURCE)
+/* needed because FORTIFY_SOURCE inline implementations call fortify_panic(). */
+void __my_fortify_panic(const char *name) {
+    pr_emerg("__my_fortify_panic in %s\n", name);
+    BUG();
 }
 #endif

--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -269,6 +269,10 @@
         #include <crypto/scatterwalk.h>
         #include <crypto/internal/aead.h>
         #include <crypto/internal/skcipher.h>
+
+        #ifndef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
+        #define WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
+        #endif
     #endif
 
     #if defined(WOLFSSL_AESNI) || defined(USE_INTEL_SPEEDUP) || defined(WOLFSSL_SP_X86_64_ASM)

--- a/linuxkm/lkcapi_glue.c
+++ b/linuxkm/lkcapi_glue.c
@@ -1,0 +1,2448 @@
+/* lkcapi_glue.c -- glue logic to register wolfCrypt implementations with
+ * the Linux Kernel Cryptosystem
+ *
+ * Copyright (C) 2006-2024 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifndef LINUXKM_LKCAPI_REGISTER
+    #error lkcapi_glue.c included in non-LINUXKM_LKCAPI_REGISTER project.
+#endif
+
+#if defined(LINUXKM_LKCAPI_REGISTER_AESGCM) && defined(WOLFSSL_AESNI) && defined(WC_AES_C_DYNAMIC_FALLBACK)
+    /* xxx temporary */
+    #error LINUXKM_LKCAPI_REGISTER_AESGCM is incompatible with WOLFSSL_AESNI && WC_AES_C_DYNAMIC_FALLBACK
+#endif
+
+#if defined(LINUXKM_LKCAPI_REGISTER_AESGCM) && !defined(WOLFSSL_AESGCM_STREAM)
+    #error LINUXKM_REGISTER_ALG requires AESGCM_STREAM.
+#endif
+
+#ifndef WOLFSSL_LINUXKM_LKCAPI_PRIORITY
+/* Larger number means higher priority.  The highest in-tree priority is 4001,
+ * in the Cavium driver.
+ */
+#define WOLFSSL_LINUXKM_LKCAPI_PRIORITY 10000
+#endif
+
+#ifndef NO_AES
+
+#define WOLFKM_AESCBC_NAME   "cbc(aes)"
+#define WOLFKM_AESCFB_NAME   "cfb(aes)"
+#define WOLFKM_AESGCM_NAME   "gcm(aes)"
+#define WOLFKM_AESXTS_NAME   "xts(aes)"
+#define WOLFKM_AESCBC_DRIVER "cbc-aes-wolfcrypt"
+#define WOLFKM_AESCFB_DRIVER "cfb-aes-wolfcrypt"
+#define WOLFKM_AESGCM_DRIVER "gcm-aes-wolfcrypt"
+#define WOLFKM_AESXTS_DRIVER "xts-aes-wolfcrypt"
+
+#if defined(HAVE_AES_CBC) && \
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESCBC))
+static int  linuxkm_test_aescbc(void);
+#endif
+#if defined(WOLFSSL_AES_CFB) && \
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESCFB))
+static int  linuxkm_test_aescfb(void);
+#endif
+#if defined(HAVE_AESGCM) && \
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESGCM)) && \
+    (! (defined(WOLFSSL_AESNI) && defined(WC_AES_C_DYNAMIC_FALLBACK)))
+static int  linuxkm_test_aesgcm(void);
+#endif
+#if defined(WOLFSSL_AES_XTS) && \
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESXTS))
+static int  linuxkm_test_aesxts(void);
+#endif
+
+/* km_AesX(): wrappers to wolfcrypt wc_AesX functions and
+ * structures.  */
+
+#include <wolfssl/wolfcrypt/aes.h>
+
+struct km_AesCtx {
+    Aes          *aes; /* must be pointer to control alignment, needed for AESNI. */
+    u8           key[AES_MAX_KEY_SIZE / 8];
+    unsigned int keylen;
+};
+
+static inline void km_ForceZero(struct km_AesCtx * ctx)
+{
+    memzero_explicit(ctx->key, sizeof(ctx->key));
+    ctx->keylen = 0;
+}
+
+#if defined(LINUXKM_LKCAPI_REGISTER_ALL) || \
+    defined(LINUXKM_LKCAPI_REGISTER_AESCBC) || \
+    defined(LINUXKM_LKCAPI_REGISTER_AESCFB) || \
+    defined(LINUXKM_LKCAPI_REGISTER_AESGCM)
+
+static int km_AesInitCommon(struct km_AesCtx * ctx, const char * name)
+{
+    int err;
+
+    ctx->aes = (Aes *)malloc(sizeof(*ctx->aes));
+
+    if (! ctx->aes)
+        return MEMORY_E;
+
+    err = wc_AesInit(ctx->aes, NULL, INVALID_DEVID);
+
+    if (unlikely(err)) {
+        pr_err("error: km_AesInitCommon %s failed: %d\n", name, err);
+        return err;
+    }
+
+    return 0;
+}
+
+static void km_AesExitCommon(struct km_AesCtx * ctx)
+{
+    wc_AesFree(ctx->aes);
+    free(ctx->aes);
+    ctx->aes = NULL;
+    km_ForceZero(ctx);
+}
+
+static int km_AesSetKeyCommon(struct km_AesCtx * ctx, const u8 *in_key,
+                              unsigned int key_len, const char * name)
+{
+    int err;
+
+    err = wc_AesSetKey(ctx->aes, in_key, key_len, NULL, 0);
+
+    if (unlikely(err)) {
+        pr_err("error: km_AesSetKeyCommon %s failed: %d\n", name, err);
+        return err;
+    }
+
+    XMEMCPY(ctx->key, in_key, key_len);
+    ctx->keylen = key_len;
+
+    return 0;
+}
+
+#if defined(LINUXKM_LKCAPI_REGISTER_ALL) || \
+    defined(LINUXKM_LKCAPI_REGISTER_AESCBC) || \
+    defined(LINUXKM_LKCAPI_REGISTER_AESCFB)
+
+static int km_AesInit(struct crypto_skcipher *tfm)
+{
+    struct km_AesCtx * ctx = crypto_skcipher_ctx(tfm);
+    return km_AesInitCommon(ctx, WOLFKM_AESCBC_DRIVER);
+}
+
+static void km_AesExit(struct crypto_skcipher *tfm)
+{
+    struct km_AesCtx * ctx = crypto_skcipher_ctx(tfm);
+    km_AesExitCommon(ctx);
+}
+
+static int km_AesSetKey(struct crypto_skcipher *tfm, const u8 *in_key,
+                          unsigned int key_len)
+{
+    struct km_AesCtx * ctx = crypto_skcipher_ctx(tfm);
+    return km_AesSetKeyCommon(ctx, in_key, key_len, WOLFKM_AESCBC_DRIVER);
+}
+
+#endif /* LINUXKM_LKCAPI_REGISTER_ALL ||
+        * LINUXKM_LKCAPI_REGISTER_AESCBC ||
+        * LINUXKM_LKCAPI_REGISTER_AESCFB
+        */
+
+#endif /* LINUXKM_LKCAPI_REGISTER_ALL || LINUXKM_LKCAPI_REGISTER_AESCBC ||
+        * LINUXKM_LKCAPI_REGISTER_AESCFB || LINUXKM_LKCAPI_REGISTER_AESGCM
+        */
+
+#if defined(HAVE_AES_CBC) && \
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESCBC))
+
+static int km_AesCbcEncrypt(struct skcipher_request *req)
+{
+    struct crypto_skcipher * tfm = NULL;
+    struct km_AesCtx *       ctx = NULL;
+    struct skcipher_walk     walk;
+    unsigned int             nbytes = 0;
+    int                      err = 0;
+
+    tfm = crypto_skcipher_reqtfm(req);
+    ctx = crypto_skcipher_ctx(tfm);
+
+    err = skcipher_walk_virt(&walk, req, false);
+
+    while ((nbytes = walk.nbytes)) {
+        err = wc_AesSetKey(ctx->aes, ctx->key, ctx->keylen, walk.iv,
+                           AES_ENCRYPTION);
+
+        if (unlikely(err)) {
+            pr_err("wc_AesSetKey failed: %d\n", err);
+            return err;
+        }
+
+        err = wc_AesCbcEncrypt(ctx->aes, walk.dst.virt.addr,
+                               walk.src.virt.addr, nbytes);
+
+        if (unlikely(err)) {
+            pr_err("wc_AesCbcEncrypt failed %d\n", err);
+            return err;
+        }
+
+        err = skcipher_walk_done(&walk, walk.nbytes - nbytes);
+    }
+
+    return err;
+}
+
+static int km_AesCbcDecrypt(struct skcipher_request *req)
+{
+    struct crypto_skcipher * tfm = NULL;
+    struct km_AesCtx *       ctx = NULL;
+    struct skcipher_walk     walk;
+    unsigned int             nbytes = 0;
+    int                      err = 0;
+
+    tfm = crypto_skcipher_reqtfm(req);
+    ctx = crypto_skcipher_ctx(tfm);
+
+    err = skcipher_walk_virt(&walk, req, false);
+
+    while ((nbytes = walk.nbytes)) {
+        err = wc_AesSetKey(ctx->aes, ctx->key, ctx->keylen, walk.iv,
+                           AES_DECRYPTION);
+
+        if (unlikely(err)) {
+            pr_err("wc_AesSetKey failed");
+            return err;
+        }
+
+        err = wc_AesCbcDecrypt(ctx->aes, walk.dst.virt.addr,
+                               walk.src.virt.addr, nbytes);
+
+        if (unlikely(err)) {
+            pr_err("wc_AesCbcDecrypt failed");
+            return err;
+        }
+
+        err = skcipher_walk_done(&walk, walk.nbytes - nbytes);
+    }
+
+    return err;
+}
+
+static struct skcipher_alg cbcAesAlg = {
+    .base.cra_name        = WOLFKM_AESCBC_NAME,
+    .base.cra_driver_name = WOLFKM_AESCBC_DRIVER,
+    .base.cra_priority    = WOLFSSL_LINUXKM_LKCAPI_PRIORITY,
+    .base.cra_blocksize   = AES_BLOCK_SIZE,
+    .base.cra_ctxsize     = sizeof(struct km_AesCtx),
+    .base.cra_module      = THIS_MODULE,
+    .init                 = km_AesInit,
+    .exit                 = km_AesExit,
+    .min_keysize          = AES_128_KEY_SIZE,
+    .max_keysize          = AES_256_KEY_SIZE,
+    .ivsize               = AES_BLOCK_SIZE,
+    .setkey               = km_AesSetKey,
+    .encrypt              = km_AesCbcEncrypt,
+    .decrypt              = km_AesCbcDecrypt,
+};
+static int cbcAesAlg_loaded = 0;
+
+#endif /* HAVE_AES_CBC &&
+        * (LINUXKM_LKCAPI_REGISTER_ALL || LINUXKM_LKCAPI_REGISTER_AESCBC)
+        */
+
+#if defined(WOLFSSL_AES_CFB) && \
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESCFB))
+
+static int km_AesCfbEncrypt(struct skcipher_request *req)
+{
+    struct crypto_skcipher * tfm = NULL;
+    struct km_AesCtx *       ctx = NULL;
+    struct skcipher_walk     walk;
+    unsigned int             nbytes = 0;
+    int                      err = 0;
+
+    tfm = crypto_skcipher_reqtfm(req);
+    ctx = crypto_skcipher_ctx(tfm);
+
+    err = skcipher_walk_virt(&walk, req, false);
+
+    while ((nbytes = walk.nbytes)) {
+        err = wc_AesSetKey(ctx->aes, ctx->key, ctx->keylen, walk.iv,
+                           AES_ENCRYPTION);
+
+        if (unlikely(err)) {
+            pr_err("wc_AesSetKey failed: %d\n", err);
+            return err;
+        }
+
+        err = wc_AesCfbEncrypt(ctx->aes, walk.dst.virt.addr,
+                               walk.src.virt.addr, nbytes);
+
+        if (unlikely(err)) {
+            pr_err("wc_AesCfbEncrypt failed %d\n", err);
+            return err;
+        }
+
+        err = skcipher_walk_done(&walk, walk.nbytes - nbytes);
+    }
+
+    return err;
+}
+
+static int km_AesCfbDecrypt(struct skcipher_request *req)
+{
+    struct crypto_skcipher * tfm = NULL;
+    struct km_AesCtx *       ctx = NULL;
+    struct skcipher_walk     walk;
+    unsigned int             nbytes = 0;
+    int                      err = 0;
+
+    tfm = crypto_skcipher_reqtfm(req);
+    ctx = crypto_skcipher_ctx(tfm);
+
+    err = skcipher_walk_virt(&walk, req, false);
+
+    while ((nbytes = walk.nbytes)) {
+        err = wc_AesSetKey(ctx->aes, ctx->key, ctx->keylen, walk.iv,
+                           AES_ENCRYPTION);
+
+        if (unlikely(err)) {
+            pr_err("wc_AesSetKey failed");
+            return err;
+        }
+
+        err = wc_AesCfbDecrypt(ctx->aes, walk.dst.virt.addr,
+                               walk.src.virt.addr, nbytes);
+
+        if (unlikely(err)) {
+            pr_err("wc_AesCfbDecrypt failed");
+            return err;
+        }
+
+        err = skcipher_walk_done(&walk, walk.nbytes - nbytes);
+    }
+
+    return err;
+}
+
+static struct skcipher_alg cfbAesAlg = {
+    .base.cra_name        = WOLFKM_AESCFB_NAME,
+    .base.cra_driver_name = WOLFKM_AESCFB_DRIVER,
+    .base.cra_priority    = WOLFSSL_LINUXKM_LKCAPI_PRIORITY,
+    .base.cra_blocksize   = AES_BLOCK_SIZE,
+    .base.cra_ctxsize     = sizeof(struct km_AesCtx),
+    .base.cra_module      = THIS_MODULE,
+    .init                 = km_AesInit,
+    .exit                 = km_AesExit,
+    .min_keysize          = AES_128_KEY_SIZE,
+    .max_keysize          = AES_256_KEY_SIZE,
+    .ivsize               = AES_BLOCK_SIZE,
+    .setkey               = km_AesSetKey,
+    .encrypt              = km_AesCfbEncrypt,
+    .decrypt              = km_AesCfbDecrypt,
+};
+static int cfbAesAlg_loaded = 0;
+
+#endif /* WOLFSSL_AES_CFB &&
+        * (LINUXKM_LKCAPI_REGISTER_ALL || LINUXKM_LKCAPI_REGISTER_AESCBC)
+        */
+
+#if defined(HAVE_AESGCM) && \
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESGCM)) && \
+    (! (defined(WOLFSSL_AESNI) && defined(WC_AES_C_DYNAMIC_FALLBACK)))
+
+static int km_AesGcmInit(struct crypto_aead * tfm)
+{
+    struct km_AesCtx * ctx = crypto_aead_ctx(tfm);
+    km_ForceZero(ctx);
+    return km_AesInitCommon(ctx, WOLFKM_AESGCM_DRIVER);
+}
+
+static void km_AesGcmExit(struct crypto_aead * tfm)
+{
+    struct km_AesCtx * ctx = crypto_aead_ctx(tfm);
+    km_AesExitCommon(ctx);
+}
+
+static int km_AesGcmSetKey(struct crypto_aead *tfm, const u8 *in_key,
+                           unsigned int key_len)
+{
+    struct km_AesCtx * ctx = crypto_aead_ctx(tfm);
+    return km_AesSetKeyCommon(ctx, in_key, key_len, WOLFKM_AESGCM_DRIVER);
+}
+
+static int km_AesGcmSetAuthsize(struct crypto_aead *tfm, unsigned int authsize)
+{
+    (void)tfm;
+    if (authsize > AES_BLOCK_SIZE ||
+        authsize < WOLFSSL_MIN_AUTH_TAG_SZ) {
+        pr_err("error: invalid authsize: %d\n", authsize);
+        return -EINVAL;
+    }
+    return 0;
+}
+
+/*
+ * aead ciphers recieve data in scatterlists in following order:
+ *   encrypt
+ *     req->src: aad||plaintext
+ *     req->dst: aad||ciphertext||tag
+ *   decrypt
+ *     req->src: aad||ciphertext||tag
+ *     req->dst: aad||plaintext, return 0 or -EBADMSG
+ */
+
+static int km_AesGcmEncrypt(struct aead_request *req)
+{
+    struct crypto_aead * tfm = NULL;
+    struct km_AesCtx *   ctx = NULL;
+    struct skcipher_walk walk;
+    struct scatter_walk  assocSgWalk;
+    unsigned int         nbytes = 0;
+    u8                   authTag[AES_BLOCK_SIZE];
+    int                  err = 0;
+    unsigned int         assocLeft = 0;
+    unsigned int         cryptLeft = 0;
+    u8 *                 assoc = NULL;
+
+    tfm = crypto_aead_reqtfm(req);
+    ctx = crypto_aead_ctx(tfm);
+    assocLeft = req->assoclen;
+    cryptLeft = req->cryptlen;
+
+    scatterwalk_start(&assocSgWalk, req->src);
+
+    err = skcipher_walk_aead_encrypt(&walk, req, false);
+    if (unlikely(err)) {
+        pr_err("error: skcipher_walk_aead_encrypt: %d\n", err);
+        return -1;
+    }
+
+    err = wc_AesGcmInit(ctx->aes, ctx->key, ctx->keylen, walk.iv,
+                        AES_BLOCK_SIZE);
+    if (unlikely(err)) {
+        pr_err("error: wc_AesGcmInit failed with return code %d.\n", err);
+        return err;
+    }
+
+    assoc = scatterwalk_map(&assocSgWalk);
+    if (unlikely(IS_ERR(assoc))) {
+        pr_err("error: scatterwalk_map failed %ld\n", PTR_ERR(assoc));
+        return err;
+    }
+
+    err = wc_AesGcmEncryptUpdate(ctx->aes, NULL, NULL, 0, assoc, assocLeft);
+    assocLeft -= assocLeft;
+    scatterwalk_unmap(assoc);
+    assoc = NULL;
+
+    if (unlikely(err)) {
+        pr_err("error: wc_AesGcmEncryptUpdate failed %d\n", err);
+        return err;
+    }
+
+    while ((nbytes = walk.nbytes)) {
+        int n = nbytes;
+
+        if (likely(cryptLeft && nbytes)) {
+            n = cryptLeft < nbytes ? cryptLeft : nbytes;
+
+            err = wc_AesGcmEncryptUpdate(ctx->aes, walk.dst.virt.addr,
+                                         walk.src.virt.addr, cryptLeft, NULL, 0);
+            nbytes -= n;
+            cryptLeft -= n;
+        }
+
+        if (unlikely(err)) {
+            pr_err("wc_AesGcmEncryptUpdate failed %d\n", err);
+            return err;
+        }
+
+        err = skcipher_walk_done(&walk, nbytes);
+    }
+
+    err = wc_AesGcmEncryptFinal(ctx->aes, authTag, tfm->authsize);
+    if (unlikely(err)) {
+        pr_err("error: wc_AesGcmEncryptFinal failed with return code %d\n", err);
+        return err;
+    }
+
+    /* Now copy the auth tag into request scatterlist. */
+    scatterwalk_map_and_copy(authTag, req->dst,
+                             req->assoclen + req->cryptlen,
+                             tfm->authsize, 1);
+
+    return err;
+}
+
+static int km_AesGcmDecrypt(struct aead_request *req)
+{
+    struct crypto_aead * tfm = NULL;
+    struct km_AesCtx *   ctx = NULL;
+    struct skcipher_walk walk;
+    struct scatter_walk  assocSgWalk;
+    unsigned int         nbytes = 0;
+    u8                   origAuthTag[AES_BLOCK_SIZE];
+    int                  err = 0;
+    unsigned int         assocLeft = 0;
+    unsigned int         cryptLeft = 0;
+    u8 *                 assoc = NULL;
+
+    tfm = crypto_aead_reqtfm(req);
+    ctx = crypto_aead_ctx(tfm);
+    assocLeft = req->assoclen;
+    cryptLeft = req->cryptlen - tfm->authsize;
+
+    /* Copy out original auth tag from req->src. */
+    scatterwalk_map_and_copy(origAuthTag, req->src,
+                             req->assoclen + req->cryptlen - tfm->authsize,
+                             tfm->authsize, 0);
+
+    scatterwalk_start(&assocSgWalk, req->src);
+
+    err = skcipher_walk_aead_decrypt(&walk, req, false);
+    if (unlikely(err)) {
+        pr_err("error: skcipher_walk_aead_decrypt: %d\n", err);
+        return -1;
+    }
+
+    err = wc_AesGcmInit(ctx->aes, ctx->key, ctx->keylen, walk.iv,
+                        AES_BLOCK_SIZE);
+    if (unlikely(err)) {
+        pr_err("error: wc_AesGcmInit failed with return code %d.\n", err);
+        return err;
+    }
+
+    assoc = scatterwalk_map(&assocSgWalk);
+    if (unlikely(IS_ERR(assoc))) {
+        pr_err("error: scatterwalk_map failed %ld\n", PTR_ERR(assoc));
+        return err;
+    }
+
+    err = wc_AesGcmDecryptUpdate(ctx->aes, NULL, NULL, 0, assoc, assocLeft);
+    assocLeft -= assocLeft;
+    scatterwalk_unmap(assoc);
+    assoc = NULL;
+
+    if (unlikely(err)) {
+        pr_err("error: wc_AesGcmDecryptUpdate failed %d\n", err);
+        return err;
+    }
+
+    while ((nbytes = walk.nbytes)) {
+        int n = nbytes;
+
+        if (likely(cryptLeft && nbytes)) {
+            n = cryptLeft < nbytes ? cryptLeft : nbytes;
+
+            err = wc_AesGcmDecryptUpdate(ctx->aes, walk.dst.virt.addr,
+                                         walk.src.virt.addr, cryptLeft, NULL, 0);
+            nbytes -= n;
+            cryptLeft -= n;
+        }
+
+        if (unlikely(err)) {
+            pr_err("wc_AesGcmDecryptUpdate failed %d\n", err);
+            return err;
+        }
+
+        err = skcipher_walk_done(&walk, nbytes);
+    }
+
+    err = wc_AesGcmDecryptFinal(ctx->aes, origAuthTag, tfm->authsize);
+    if (unlikely(err)) {
+        pr_err("error: wc_AesGcmDecryptFinal failed with return code %d\n", err);
+
+        if (err == AES_GCM_AUTH_E) {
+            return -EBADMSG;
+        }
+        else {
+            return err;
+        }
+    }
+
+    return err;
+}
+
+static struct aead_alg gcmAesAead = {
+    .base.cra_name        = WOLFKM_AESGCM_NAME,
+    .base.cra_driver_name = WOLFKM_AESGCM_DRIVER,
+    .base.cra_priority    = WOLFSSL_LINUXKM_LKCAPI_PRIORITY,
+    .base.cra_blocksize   = 1,
+    .base.cra_ctxsize     = sizeof(struct km_AesCtx),
+    .base.cra_module      = THIS_MODULE,
+    .init                 = km_AesGcmInit,
+    .exit                 = km_AesGcmExit,
+    .setkey               = km_AesGcmSetKey,
+    .setauthsize          = km_AesGcmSetAuthsize,
+    .encrypt              = km_AesGcmEncrypt,
+    .decrypt              = km_AesGcmDecrypt,
+    .ivsize               = AES_BLOCK_SIZE,
+    .maxauthsize          = AES_BLOCK_SIZE,
+    .chunksize            = AES_BLOCK_SIZE,
+};
+static int gcmAesAead_loaded = 0;
+
+#endif /* HAVE_AESGCM &&
+        * (LINUXKM_LKCAPI_REGISTER_ALL || LINUXKM_LKCAPI_REGISTER_AESGCM) &&
+        * (! (WOLFSSL_AESNI && WC_AES_C_DYNAMIC_FALLBACK))
+        */
+
+#if defined(WOLFSSL_AES_XTS) && \
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESXTS))
+
+struct km_AesXtsCtx {
+    XtsAes       *aesXts; /* allocated here, with correct alignment, for AESNI. */
+};
+
+static int km_AesXtsInitCommon(struct km_AesXtsCtx * ctx, const char * name)
+{
+    int err;
+
+    ctx->aesXts = (XtsAes *)malloc(sizeof(*ctx->aesXts));
+
+    if (! ctx->aesXts)
+        return -MEMORY_E;
+
+    err = wc_AesXtsInit(ctx->aesXts, NULL, INVALID_DEVID);
+
+    if (unlikely(err)) {
+        pr_err("error: km_AesXtsInitCommon %s failed: %d\n", name, err);
+        return err;
+    }
+
+    return 0;
+}
+
+static int km_AesXtsInit(struct crypto_skcipher *tfm)
+{
+    struct km_AesXtsCtx * ctx = crypto_skcipher_ctx(tfm);
+    return km_AesXtsInitCommon(ctx, WOLFKM_AESXTS_DRIVER);
+}
+
+static void km_AesXtsExit(struct crypto_skcipher *tfm)
+{
+    struct km_AesXtsCtx * ctx = crypto_skcipher_ctx(tfm);
+    wc_AesXtsFree(ctx->aesXts);
+    free(ctx->aesXts);
+    ctx->aesXts = NULL;
+#if 0
+    km_ForceZeroXts(ctx);
+#endif
+}
+
+static int km_AesXtsSetKey(struct crypto_skcipher *tfm, const u8 *in_key,
+                          unsigned int key_len)
+{
+    int err;
+    struct km_AesXtsCtx * ctx = crypto_skcipher_ctx(tfm);
+
+    err = wc_AesXtsSetKeyNoInit(ctx->aesXts, in_key, key_len, AES_ENCRYPTION_AND_DECRYPTION);
+
+    if (unlikely(err)) {
+        pr_err("error: km_AesXtsSetKey %s failed: %d\n", WOLFKM_AESXTS_DRIVER, err);
+        return err;
+    }
+
+#if 0
+    XMEMCPY(ctx->key, in_key, key_len);
+    ctx->keylen = key_len;
+#endif
+
+    return 0;
+}
+
+/* see /usr/src/linux/drivers/md/dm-crypt.c */
+
+static int km_AesXtsEncrypt(struct skcipher_request *req)
+{
+    int                      err = 0;
+
+    struct crypto_skcipher * tfm = NULL;
+    struct km_AesXtsCtx *    ctx = NULL;
+    struct skcipher_walk     walk;
+    unsigned int             nbytes = 0;
+
+    tfm = crypto_skcipher_reqtfm(req);
+    ctx = crypto_skcipher_ctx(tfm);
+
+    err = skcipher_walk_virt(&walk, req, false);
+
+    if (unlikely(err)) {
+        pr_err("skcipher_walk_virt() failed: %d\n", err);
+        return err;
+    }
+
+    while ((nbytes = walk.nbytes)) {
+        err = wc_AesXtsEncrypt(ctx->aesXts, walk.dst.virt.addr,
+                               walk.src.virt.addr, nbytes,
+                               walk.iv, walk.ivsize);
+
+        if (unlikely(err)) {
+            pr_err("wc_AesXtsEncrypt failed: %d\n", err);
+            return err;
+        }
+
+        err = skcipher_walk_done(&walk, walk.nbytes - nbytes);
+
+        if (unlikely(err)) {
+            pr_err("skcipher_walk_done() failed: %d\n", err);
+            return err;
+        }
+    }
+
+    return err;
+}
+
+static int km_AesXtsDecrypt(struct skcipher_request *req)
+{
+    int                      err = 0;
+    struct crypto_skcipher * tfm = NULL;
+    struct km_AesXtsCtx *    ctx = NULL;
+    struct skcipher_walk     walk;
+    unsigned int             nbytes = 0;
+
+    tfm = crypto_skcipher_reqtfm(req);
+    ctx = crypto_skcipher_ctx(tfm);
+
+    err = skcipher_walk_virt(&walk, req, false);
+
+    if (unlikely(err)) {
+        pr_err("skcipher_walk_virt() failed: %d\n", err);
+        return err;
+    }
+
+    while ((nbytes = walk.nbytes)) {
+        err = wc_AesXtsDecrypt(ctx->aesXts, walk.dst.virt.addr,
+                               walk.src.virt.addr, nbytes,
+                               walk.iv, walk.ivsize);
+
+        if (unlikely(err)) {
+            pr_err("wc_AesCbcDecrypt failed");
+            return err;
+        }
+
+        err = skcipher_walk_done(&walk, walk.nbytes - nbytes);
+
+        if (unlikely(err)) {
+            pr_err("skcipher_walk_done() failed: %d\n", err);
+            return err;
+        }
+    }
+
+    return err;
+}
+
+static struct skcipher_alg xtsAesAlg = {
+    .base.cra_name          = WOLFKM_AESXTS_NAME,
+    .base.cra_driver_name   = WOLFKM_AESXTS_DRIVER,
+    .base.cra_priority      = WOLFSSL_LINUXKM_LKCAPI_PRIORITY,
+    .base.cra_blocksize     = AES_BLOCK_SIZE,
+    .base.cra_ctxsize       = sizeof(struct km_AesXtsCtx),
+    .base.cra_module        = THIS_MODULE,
+
+    .min_keysize            = 2 * AES_128_KEY_SIZE,
+    .max_keysize            = 2 * AES_256_KEY_SIZE,
+    .ivsize                 = AES_BLOCK_SIZE,
+    .walksize               = 2 * AES_BLOCK_SIZE,
+    .init                   = km_AesXtsInit,
+    .exit                   = km_AesXtsExit,
+    .setkey                 = km_AesXtsSetKey,
+    .encrypt                = km_AesXtsEncrypt,
+    .decrypt                = km_AesXtsDecrypt
+};
+static int xtsAesAlg_loaded = 0;
+
+#endif /* WOLFSSL_AES_XTS &&
+        * (LINUXKM_LKCAPI_REGISTER_ALL || LINUXKM_LKCAPI_REGISTER_AESXTS)
+        */
+
+/* cipher tests, cribbed from test.c, with supplementary LKCAPI tests: */
+
+#if defined(HAVE_AES_CBC) && \
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESCBC))
+
+static int linuxkm_test_aescbc(void)
+{
+    int     ret = 0;
+    struct crypto_skcipher *  tfm = NULL;
+    struct skcipher_request * req = NULL;
+    struct scatterlist        src, dst;
+    Aes     aes;
+    WOLFSSL_SMALL_STACK_STATIC const byte key32[] =
+    {
+        0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+        0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66,
+        0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+        0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66
+    };
+    WOLFSSL_SMALL_STACK_STATIC const byte vector[] = /* Now is the time for all good men w/o trailing 0 */
+    {
+        0x4e,0x6f,0x77,0x20,0x69,0x73,0x20,0x74,
+        0x68,0x65,0x20,0x74,0x69,0x6d,0x65,0x20,
+        0x66,0x6f,0x72,0x20,0x61,0x6c,0x6c,0x20,
+        0x67,0x6f,0x6f,0x64,0x20,0x6d,0x65,0x6e
+    };
+    WOLFSSL_SMALL_STACK_STATIC const byte iv[] = "1234567890abcdef";
+    byte    iv_copy[sizeof iv];
+    byte    enc[sizeof(vector)];
+    byte    dec[sizeof(vector)];
+    u8 *    enc2 = NULL;
+    u8 *    dec2 = NULL;
+
+    XMEMSET(enc, 0, sizeof(enc));
+    XMEMSET(dec, 0, sizeof(enc));
+
+    ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
+    if (ret) {
+        pr_err("wolfcrypt wc_AesInit failed with return code %d.\n", ret);
+        return -1;
+    }
+
+    ret = wc_AesSetKey(&aes, key32, AES_BLOCK_SIZE * 2, iv, AES_ENCRYPTION);
+    if (ret) {
+        pr_err("wolfcrypt wc_AesSetKey failed with return code %d\n", ret);
+        return -1;
+    }
+
+    ret = wc_AesCbcEncrypt(&aes, enc, vector, sizeof(vector));
+    if (ret) {
+        pr_err("wolfcrypt wc_AesCbcEncrypt failed with return code %d\n", ret);
+        return -1;
+    }
+
+    /* Re init for decrypt and set flag. */
+    wc_AesFree(&aes);
+
+    ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
+    if (ret) {
+        pr_err("wolfcrypt wc_AesInit failed with return code %d.\n", ret);
+        return -1;
+    }
+
+    ret = wc_AesSetKey(&aes, key32, AES_BLOCK_SIZE * 2, iv, AES_DECRYPTION);
+    if (ret) {
+        pr_err("wolfcrypt wc_AesSetKey failed with return code %d.\n", ret);
+        return -1;
+    }
+
+    ret = wc_AesCbcDecrypt(&aes, dec, enc, sizeof(vector));
+    if (ret) {
+        pr_err("wolfcrypt wc_AesCbcDecrypt failed with return code %d\n", ret);
+        return -1;
+    }
+
+    ret = XMEMCMP(vector, dec, sizeof(vector));
+    if (ret) {
+        pr_err("error: vector and dec do not match: %d\n", ret);
+        return -1;
+    }
+
+    /* now the kernel crypto part */
+    enc2 = kmalloc(sizeof(vector), GFP_KERNEL);
+    if (!enc2) {
+        pr_err("error: kmalloc failed\n");
+        goto test_cbc_end;
+    }
+
+    dec2 = kmalloc(sizeof(vector), GFP_KERNEL);
+    if (!dec2) {
+        pr_err("error: kmalloc failed\n");
+        goto test_cbc_end;
+    }
+
+    memcpy(dec2, vector, sizeof(vector));
+
+    tfm = crypto_alloc_skcipher(WOLFKM_AESCBC_DRIVER, 0, 0);
+    if (IS_ERR(tfm)) {
+        pr_err("error: allocating AES skcipher algorithm %s failed: %ld\n",
+               WOLFKM_AESCBC_DRIVER, PTR_ERR(tfm));
+        goto test_cbc_end;
+    }
+
+    ret = crypto_skcipher_setkey(tfm, key32, AES_BLOCK_SIZE * 2);
+    if (ret) {
+        pr_err("error: crypto_skcipher_setkey returned: %d\n", ret);
+        goto test_cbc_end;
+    }
+
+    req = skcipher_request_alloc(tfm, GFP_KERNEL);
+    if (IS_ERR(req)) {
+        pr_err("error: allocating AES skcipher request %s failed\n",
+               WOLFKM_AESCBC_DRIVER);
+        goto test_cbc_end;
+    }
+
+    sg_init_one(&src, dec2, sizeof(vector));
+    sg_init_one(&dst, enc2, sizeof(vector));
+
+    XMEMCPY(iv_copy, iv, sizeof iv);
+    skcipher_request_set_crypt(req, &src, &dst, sizeof(vector), iv_copy);
+
+    ret = crypto_skcipher_encrypt(req);
+
+    if (ret) {
+        pr_err("error: crypto_skcipher_encrypt returned: %d\n", ret);
+        goto test_cbc_end;
+    }
+
+    ret = XMEMCMP(enc, enc2, sizeof(vector));
+    if (ret) {
+        pr_err("error: enc and enc2 do not match: %d\n", ret);
+        goto test_cbc_end;
+    }
+
+    memset(dec2, 0, sizeof(vector));
+    sg_init_one(&src, enc2, sizeof(vector));
+    sg_init_one(&dst, dec2, sizeof(vector));
+
+    XMEMCPY(iv_copy, iv, sizeof iv);
+    skcipher_request_set_crypt(req, &src, &dst, sizeof(vector), iv_copy);
+
+    ret = crypto_skcipher_decrypt(req);
+
+    if (ret) {
+        pr_err("ERROR: crypto_skcipher_decrypt returned %d\n", ret);
+        goto test_cbc_end;
+    }
+
+    ret = XMEMCMP(dec, dec2, sizeof(vector));
+    if (ret) {
+        pr_err("error: dec and dec2 do not match: %d\n", ret);
+        goto test_cbc_end;
+    }
+
+test_cbc_end:
+
+    if (enc2) { kfree(enc2); enc2 = NULL; }
+    if (dec2) { kfree(dec2); dec2 = NULL; }
+    if (req) { skcipher_request_free(req); req = NULL; }
+    if (tfm) { crypto_free_skcipher(tfm); tfm = NULL; }
+
+    return ret;
+}
+
+#endif /* HAVE_AES_CBC &&
+        * (LINUXKM_LKCAPI_REGISTER_ALL || LINUXKM_LKCAPI_REGISTER_AESCBC)
+        */
+
+#if defined(WOLFSSL_AES_CFB) && \
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESCFB))
+
+static int linuxkm_test_aescfb(void)
+{
+    int ret = 0;
+    struct crypto_skcipher *  tfm = NULL;
+    struct skcipher_request * req = NULL;
+    struct scatterlist        src, dst;
+    Aes     aes;
+    WOLFSSL_SMALL_STACK_STATIC const byte key32[] =
+    {
+        0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+        0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66,
+        0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+        0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66
+    };
+    WOLFSSL_SMALL_STACK_STATIC const byte vector[] = /* Now is the time for all good men w/o trailing 0 */
+    {
+        0x4e,0x6f,0x77,0x20,0x69,0x73,0x20,0x74,
+        0x68,0x65,0x20,0x74,0x69,0x6d,0x65,0x20,
+        0x66,0x6f,0x72,0x20,0x61,0x6c,0x6c,0x20,
+        0x67,0x6f,0x6f,0x64,0x20,0x6d,0x65,0x6e
+    };
+    WOLFSSL_SMALL_STACK_STATIC const byte iv[] = "1234567890abcdef";
+    byte    iv_copy[sizeof iv];
+    byte    enc[sizeof(vector)];
+    byte    dec[sizeof(vector)];
+    u8 *    enc2 = NULL;
+    u8 *    dec2 = NULL;
+
+    XMEMSET(enc, 0, sizeof(enc));
+    XMEMSET(dec, 0, sizeof(enc));
+
+    ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
+    if (ret) {
+        pr_err("wolfcrypt wc_AesInit failed with return code %d.\n", ret);
+        return -1;
+    }
+
+    ret = wc_AesSetKey(&aes, key32, AES_BLOCK_SIZE * 2, iv, AES_ENCRYPTION);
+    if (ret) {
+        pr_err("wolfcrypt wc_AesSetKey failed with return code %d\n", ret);
+        return -1;
+    }
+
+    ret = wc_AesCfbEncrypt(&aes, enc, vector, sizeof(vector));
+    if (ret) {
+        pr_err("wolfcrypt wc_AesCfbEncrypt failed with return code %d\n", ret);
+        return -1;
+    }
+
+    /* Re init for decrypt and set flag. */
+    wc_AesFree(&aes);
+
+    ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
+    if (ret) {
+        pr_err("wolfcrypt wc_AesInit failed with return code %d.\n", ret);
+        return -1;
+    }
+
+    ret = wc_AesSetKey(&aes, key32, AES_BLOCK_SIZE * 2, iv, AES_ENCRYPTION);
+    if (ret) {
+        pr_err("wolfcrypt wc_AesSetKey failed with return code %d.\n", ret);
+        return -1;
+    }
+
+    ret = wc_AesCfbDecrypt(&aes, dec, enc, sizeof(vector));
+    if (ret) {
+        pr_err("wolfcrypt wc_AesCfbDecrypt failed with return code %d\n", ret);
+        return -1;
+    }
+
+    ret = XMEMCMP(vector, dec, sizeof(vector));
+    if (ret) {
+        pr_err("error: vector and dec do not match: %d\n", ret);
+        return -1;
+    }
+
+    /* now the kernel crypto part */
+    enc2 = kmalloc(sizeof(vector), GFP_KERNEL);
+    if (!enc2) {
+        pr_err("error: kmalloc failed\n");
+        goto test_cfb_end;
+    }
+
+    dec2 = kmalloc(sizeof(vector), GFP_KERNEL);
+    if (!dec2) {
+        pr_err("error: kmalloc failed\n");
+        goto test_cfb_end;
+    }
+
+    memcpy(dec2, vector, sizeof(vector));
+
+    tfm = crypto_alloc_skcipher(WOLFKM_AESCFB_DRIVER, 0, 0);
+    if (IS_ERR(tfm)) {
+        pr_err("error: allocating AES skcipher algorithm %s failed: %ld\n",
+               WOLFKM_AESCFB_DRIVER, PTR_ERR(tfm));
+        goto test_cfb_end;
+    }
+
+    ret = crypto_skcipher_setkey(tfm, key32, AES_BLOCK_SIZE * 2);
+    if (ret) {
+        pr_err("error: crypto_skcipher_setkey returned: %d\n", ret);
+        goto test_cfb_end;
+    }
+
+    req = skcipher_request_alloc(tfm, GFP_KERNEL);
+    if (IS_ERR(req)) {
+        pr_err("error: allocating AES skcipher request %s failed\n",
+               WOLFKM_AESCFB_DRIVER);
+        goto test_cfb_end;
+    }
+
+    sg_init_one(&src, dec2, sizeof(vector));
+    sg_init_one(&dst, enc2, sizeof(vector));
+
+    XMEMCPY(iv_copy, iv, sizeof iv);
+    skcipher_request_set_crypt(req, &src, &dst, sizeof(vector), iv_copy);
+
+    ret = crypto_skcipher_encrypt(req);
+
+    if (ret) {
+        pr_err("error: crypto_skcipher_encrypt returned: %d\n", ret);
+        goto test_cfb_end;
+    }
+
+    ret = XMEMCMP(enc, enc2, sizeof(vector));
+    if (ret) {
+        pr_err("error: enc and enc2 do not match: %d\n", ret);
+        goto test_cfb_end;
+    }
+
+    memset(dec2, 0, sizeof(vector));
+    sg_init_one(&src, enc2, sizeof(vector));
+    sg_init_one(&dst, dec2, sizeof(vector));
+
+    XMEMCPY(iv_copy, iv, sizeof iv);
+    skcipher_request_set_crypt(req, &src, &dst, sizeof(vector), iv_copy);
+
+    ret = crypto_skcipher_decrypt(req);
+
+    if (ret) {
+        pr_err("error: crypto_skcipher_decrypt returned: %d\n", ret);
+        goto test_cfb_end;
+    }
+
+    ret = XMEMCMP(dec, dec2, sizeof(vector));
+    if (ret) {
+        pr_err("error: dec and dec2 do not match: %d\n", ret);
+        goto test_cfb_end;
+    }
+
+test_cfb_end:
+
+    if (enc2) { kfree(enc2); enc2 = NULL; }
+    if (dec2) { kfree(dec2); dec2 = NULL; }
+    if (req) { skcipher_request_free(req); req = NULL; }
+    if (tfm) { crypto_free_skcipher(tfm); tfm = NULL; }
+
+    return ret;
+}
+
+#endif /* WOLFSSL_AES_CFB &&
+        * (LINUXKM_LKCAPI_REGISTER_ALL || LINUXKM_LKCAPI_REGISTER_AESCFB)
+        */
+
+#if defined(HAVE_AESGCM) && \
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESGCM)) && \
+    (! (defined(WOLFSSL_AESNI) && defined(WC_AES_C_DYNAMIC_FALLBACK)))
+
+static int linuxkm_test_aesgcm(void)
+{
+    int     ret = 0;
+    struct crypto_aead *  tfm = NULL;
+    struct aead_request * req = NULL;
+    struct scatterlist *  src = NULL;
+    struct scatterlist *  dst = NULL;
+    Aes     aes;
+    WOLFSSL_SMALL_STACK_STATIC const byte key32[] =
+    {
+        0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+        0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66,
+        0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+        0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66
+    };
+    WOLFSSL_SMALL_STACK_STATIC const byte vector[] = /* Now is the time for all w/o trailing 0 */
+    {
+        0x4e,0x6f,0x77,0x20,0x69,0x73,0x20,0x74,
+        0x68,0x65,0x20,0x74,0x69,0x6d,0x65,0x20,
+        0x66,0x6f,0x72,0x20,0x61,0x6c,0x6c,0x20
+    };
+    WOLFSSL_SMALL_STACK_STATIC const byte assoc[] =
+    {
+        0xfe, 0xed, 0xfa, 0xce, 0xde, 0xad, 0xbe, 0xef,
+        0xfe, 0xed, 0xfa, 0xce, 0xde, 0xad, 0xbe, 0xef,
+        0xab, 0xad, 0xda, 0xd2
+    };
+    WOLFSSL_SMALL_STACK_STATIC const byte ivstr[] = "1234567890abcdef";
+    byte    enc[sizeof(vector)];
+    byte    authTag[AES_BLOCK_SIZE];
+    byte    dec[sizeof(vector)];
+    u8 *    assoc2 = NULL;
+    u8 *    enc2 = NULL;
+    u8 *    dec2 = NULL;
+    u8 *    iv = NULL;
+    size_t  encryptLen = sizeof(vector);
+    size_t  decryptLen = sizeof(vector) + sizeof(authTag);
+
+    /* Init stack variables. */
+    XMEMSET(enc, 0, sizeof(vector));
+    XMEMSET(dec, 0, sizeof(vector));
+    XMEMSET(authTag, 0, AES_BLOCK_SIZE);
+
+    ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
+    if (ret) {
+        pr_err("error: wc_AesInit failed with return code %d.\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = wc_AesGcmInit(&aes, key32, sizeof(key32)/sizeof(byte), ivstr,
+                        AES_BLOCK_SIZE);
+    if (ret) {
+        pr_err("error: wc_AesGcmInit failed with return code %d.\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = wc_AesGcmEncryptUpdate(&aes, NULL, NULL, 0, assoc, sizeof(assoc));
+    if (ret) {
+        pr_err("error: wc_AesGcmEncryptUpdate failed with return code %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = wc_AesGcmEncryptUpdate(&aes, enc, vector, sizeof(vector), NULL, 0);
+    if (ret) {
+        pr_err("error: wc_AesGcmEncryptUpdate failed with return code %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = wc_AesGcmEncryptFinal(&aes, authTag, AES_BLOCK_SIZE);
+    if (ret) {
+        pr_err("error: wc_AesGcmEncryptFinal failed with return code %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = wc_AesGcmInit(&aes, key32, sizeof(key32)/sizeof(byte), ivstr,
+                        AES_BLOCK_SIZE);
+    if (ret) {
+        pr_err("error: wc_AesGcmInit failed with return code %d.\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = wc_AesGcmDecryptUpdate(&aes, dec, enc, sizeof(vector), assoc, sizeof(assoc));
+    if (ret) {
+        pr_err("error: wc_AesGcmDecryptUpdate failed with return code %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = wc_AesGcmDecryptFinal(&aes, authTag, AES_BLOCK_SIZE);
+    if (ret) {
+        pr_err("error: wc_AesGcmEncryptFinal failed with return code %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = XMEMCMP(vector, dec, sizeof(vector));
+    if (ret) {
+        pr_err("error: gcm: vector and dec do not match: %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    /* now the kernel crypto part */
+    assoc2 = kmalloc(sizeof(assoc), GFP_KERNEL);
+    if (IS_ERR(assoc2)) {
+        pr_err("error: kmalloc failed\n");
+        goto test_gcm_end;
+    }
+    memset(assoc2, 0, sizeof(assoc));
+    memcpy(assoc2, assoc, sizeof(assoc));
+
+    iv = kmalloc(AES_BLOCK_SIZE, GFP_KERNEL);
+    if (IS_ERR(iv)) {
+        pr_err("error: kmalloc failed\n");
+        goto test_gcm_end;
+    }
+    memset(iv, 0, AES_BLOCK_SIZE);
+    memcpy(iv, ivstr, AES_BLOCK_SIZE);
+
+    enc2 = kmalloc(decryptLen, GFP_KERNEL);
+    if (IS_ERR(enc2)) {
+        pr_err("error: kmalloc failed\n");
+        goto test_gcm_end;
+    }
+
+    dec2 = kmalloc(decryptLen, GFP_KERNEL);
+    if (IS_ERR(dec2)) {
+        pr_err("error: kmalloc failed\n");
+        goto test_gcm_end;
+    }
+
+    memset(enc2, 0, decryptLen);
+    memset(dec2, 0, decryptLen);
+    memcpy(dec2, vector, sizeof(vector));
+
+    tfm = crypto_alloc_aead(WOLFKM_AESGCM_DRIVER, 0, 0);
+    if (IS_ERR(tfm)) {
+        pr_err("error: allocating AES skcipher algorithm %s failed: %ld\n",
+               WOLFKM_AESGCM_DRIVER, PTR_ERR(tfm));
+        goto test_gcm_end;
+    }
+
+    ret = crypto_aead_setkey(tfm, key32, AES_BLOCK_SIZE * 2);
+    if (ret) {
+        pr_err("error: crypto_aead_setkey returned: %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = crypto_aead_setauthsize(tfm, sizeof(authTag));
+    if (ret) {
+        pr_err("error: crypto_aead_setauthsize returned: %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    req = aead_request_alloc(tfm, GFP_KERNEL);
+    if (IS_ERR(req)) {
+        pr_err("error: allocating AES aead request %s failed: %ld\n",
+               WOLFKM_AESCBC_DRIVER, PTR_ERR(req));
+        goto test_gcm_end;
+    }
+
+    src = kmalloc(sizeof(struct scatterlist) * 2, GFP_KERNEL);
+    dst = kmalloc(sizeof(struct scatterlist) * 2, GFP_KERNEL);
+
+    if (IS_ERR(src) || IS_ERR(dst)) {
+        pr_err("error: kmalloc src or dst failed: %ld, %ld\n",
+               PTR_ERR(src), PTR_ERR(dst));
+        goto test_gcm_end;
+    }
+
+    sg_init_table(src, 2);
+    sg_set_buf(src, assoc2, sizeof(assoc));
+    sg_set_buf(&src[1], dec2, sizeof(vector));
+
+    sg_init_table(dst, 2);
+    sg_set_buf(dst, assoc2, sizeof(assoc));
+    sg_set_buf(&dst[1], enc2, decryptLen);
+
+    aead_request_set_callback(req, 0, NULL, NULL);
+    aead_request_set_ad(req, sizeof(assoc));
+    aead_request_set_crypt(req, src, dst, sizeof(vector), iv);
+
+    ret = crypto_aead_encrypt(req);
+
+    if (ret) {
+        pr_err("error: crypto_aead_encrypt returned: %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = XMEMCMP(enc, enc2, sizeof(vector));
+    if (ret) {
+        pr_err("error: enc and enc2 do not match: %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = XMEMCMP(authTag, enc2 + encryptLen, sizeof(authTag));
+    if (ret) {
+        pr_err("error: authTags do not match: %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    /* Now decrypt crypto request. Reverse src and dst. */
+    memset(dec2, 0, decryptLen);
+    aead_request_set_ad(req, sizeof(assoc));
+    aead_request_set_crypt(req, dst, src, decryptLen, iv);
+
+    ret = crypto_aead_decrypt(req);
+
+    if (ret) {
+        pr_err("error: crypto_aead_decrypt returned: %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = XMEMCMP(dec, dec2, sizeof(vector));
+    if (ret) {
+        pr_err("error: dec and dec2 do not match: %d\n", ret);
+        goto test_gcm_end;
+    }
+
+test_gcm_end:
+    if (req) { aead_request_free(req); req = NULL; }
+    if (tfm) { crypto_free_aead(tfm); tfm = NULL; }
+
+    if (src) { kfree(src); src = NULL; }
+    if (dst) { kfree(dst); dst = NULL; }
+
+    if (dec2) { kfree(dec2); dec2 = NULL; }
+    if (enc2) { kfree(enc2); enc2 = NULL; }
+
+    if (assoc2) { kfree(assoc2); assoc2 = NULL; }
+    if (iv) { kfree(iv); iv = NULL; }
+
+    return ret;
+}
+
+#endif /* HAVE_AESGCM &&
+        * (LINUXKM_LKCAPI_REGISTER_ALL || LINUXKM_LKCAPI_REGISTER_AESGCM) &&
+        * (! (WOLFSSL_AESNI && WC_AES_C_DYNAMIC_FALLBACK))
+        */
+
+#if defined(WOLFSSL_AES_XTS) && \
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESXTS))
+
+#ifndef HEAP_HINT
+#define HEAP_HINT NULL
+#endif
+
+#ifndef ERROR_OUT
+#define ERROR_OUT(err, eLabel) do { ret = (err); goto eLabel; } while (0)
+#endif
+
+#ifndef WC_TEST_RET_ENC_EC
+#define WC_TEST_RET_ENC_EC(ret) (ret)
+#endif
+
+#ifndef WC_TEST_RET_ENC_NC
+#define WC_TEST_RET_ENC_NC (-1)
+#endif
+
+#ifndef WC_USE_DEVID
+#define WC_USE_DEVID INVALID_DEVID
+#endif
+static const int devId = WC_USE_DEVID;
+
+/* test vectors from http://csrc.nist.gov/groups/STM/cavp/block-cipher-modes.html */
+#ifdef WOLFSSL_AES_128
+static int aes_xts_128_test(void)
+{
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
+    XtsAes *aes = NULL;
+#else
+    XtsAes aes[1];
+#endif
+    int aes_inited = 0;
+    int ret = 0;
+    unsigned char buf[AES_BLOCK_SIZE * 2 + 8];
+    unsigned char cipher[AES_BLOCK_SIZE * 2 + 8];
+
+    /* 128 key tests */
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char k1[] = {
+        0xa1, 0xb9, 0x0c, 0xba, 0x3f, 0x06, 0xac, 0x35,
+        0x3b, 0x2c, 0x34, 0x38, 0x76, 0x08, 0x17, 0x62,
+        0x09, 0x09, 0x23, 0x02, 0x6e, 0x91, 0x77, 0x18,
+        0x15, 0xf2, 0x9d, 0xab, 0x01, 0x93, 0x2f, 0x2f
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char i1[] = {
+        0x4f, 0xae, 0xf7, 0x11, 0x7c, 0xda, 0x59, 0xc6,
+        0x6e, 0x4b, 0x92, 0x01, 0x3e, 0x76, 0x8a, 0xd5
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char p1[] = {
+        0xeb, 0xab, 0xce, 0x95, 0xb1, 0x4d, 0x3c, 0x8d,
+        0x6f, 0xb3, 0x50, 0x39, 0x07, 0x90, 0x31, 0x1c
+    };
+
+    /* plain text test of partial block is not from NIST test vector list */
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char pp[] = {
+        0xeb, 0xab, 0xce, 0x95, 0xb1, 0x4d, 0x3c, 0x8d,
+        0x6f, 0xb3, 0x50, 0x39, 0x07, 0x90, 0x31, 0x1c,
+        0x6e, 0x4b, 0x92, 0x01, 0x3e, 0x76, 0x8a, 0xd5
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char c1[] = {
+        0x77, 0x8a, 0xe8, 0xb4, 0x3c, 0xb9, 0x8d, 0x5a,
+        0x82, 0x50, 0x81, 0xd5, 0xbe, 0x47, 0x1c, 0x63
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char cp[] = {
+        0x2b, 0xf7, 0x2c, 0xf3, 0xeb, 0x85, 0xef, 0x7b,
+        0x0b, 0x76, 0xa0, 0xaa, 0xf3, 0x3f, 0x25, 0x8b,
+        0x77, 0x8a, 0xe8, 0xb4, 0x3c, 0xb9, 0x8d, 0x5a
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char k2[] = {
+        0x39, 0x25, 0x79, 0x05, 0xdf, 0xcc, 0x77, 0x76,
+        0x6c, 0x87, 0x0a, 0x80, 0x6a, 0x60, 0xe3, 0xc0,
+        0x93, 0xd1, 0x2a, 0xcf, 0xcb, 0x51, 0x42, 0xfa,
+        0x09, 0x69, 0x89, 0x62, 0x5b, 0x60, 0xdb, 0x16
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char i2[] = {
+        0x5c, 0xf7, 0x9d, 0xb6, 0xc5, 0xcd, 0x99, 0x1a,
+        0x1c, 0x78, 0x81, 0x42, 0x24, 0x95, 0x1e, 0x84
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char p2[] = {
+        0xbd, 0xc5, 0x46, 0x8f, 0xbc, 0x8d, 0x50, 0xa1,
+        0x0d, 0x1c, 0x85, 0x7f, 0x79, 0x1c, 0x5c, 0xba,
+        0xb3, 0x81, 0x0d, 0x0d, 0x73, 0xcf, 0x8f, 0x20,
+        0x46, 0xb1, 0xd1, 0x9e, 0x7d, 0x5d, 0x8a, 0x56
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char c2[] = {
+        0xd6, 0xbe, 0x04, 0x6d, 0x41, 0xf2, 0x3b, 0x5e,
+        0xd7, 0x0b, 0x6b, 0x3d, 0x5c, 0x8e, 0x66, 0x23,
+        0x2b, 0xe6, 0xb8, 0x07, 0xd4, 0xdc, 0xc6, 0x0e,
+        0xff, 0x8d, 0xbc, 0x1d, 0x9f, 0x7f, 0xc8, 0x22
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char cp2[] = {
+        0x2b, 0xf7, 0x2c, 0xf3, 0xeb, 0x85, 0xef, 0x7b,
+        0x0b, 0x76, 0xa0, 0xaa, 0xf3, 0x3f, 0x25, 0x8b,
+        0x77, 0x8a, 0xe8, 0xb4, 0x3c, 0xb9, 0x8d, 0x5a
+    };
+
+#ifndef HAVE_FIPS_VERSION /* FIPS requires different keys for main and tweak. */
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char k3[] = {
+        0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+        0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+        0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+        0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+    };
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char i3[] = {
+        0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+        0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+    };
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char p3[] = {
+        0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+        0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+        0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+        0x20, 0xff, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+        0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20
+    };
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char c3[] = {
+        0xA2, 0x07, 0x47, 0x76, 0x3F, 0xEC, 0x0C, 0x23,
+        0x1B, 0xD0, 0xBD, 0x46, 0x9A, 0x27, 0x38, 0x12,
+        0x95, 0x02, 0x3D, 0x5D, 0xC6, 0x94, 0x51, 0x36,
+        0xA0, 0x85, 0xD2, 0x69, 0x6E, 0x87, 0x0A, 0xBF,
+        0xB5, 0x5A, 0xDD, 0xCB, 0x80, 0xE0, 0xFC, 0xCD
+    };
+#endif /* HAVE_FIPS_VERSION */
+
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
+    if ((aes = (XtsAes *)XMALLOC(sizeof *aes, HEAP_HINT, DYNAMIC_TYPE_AES)) == NULL)
+        ERROR_OUT(MEMORY_E, out);
+#endif
+
+#if defined(OPENSSL_EXTRA) && !defined(WOLFCRYPT_ONLY) \
+    && !defined(HAVE_SELFTEST) && !defined(HAVE_FIPS)
+    ret = EVP_test(EVP_aes_128_xts(), k2, i2, p2, sizeof(p2), c2, sizeof(c2));
+    if (ret != 0) {
+        printf("EVP_aes_128_xts failed!\n");
+        goto out;
+    }
+#endif
+
+    XMEMSET(buf, 0, sizeof(buf));
+    ret = wc_AesXtsInit(aes, HEAP_HINT, devId);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    else
+        aes_inited = 1;
+
+    ret = wc_AesXtsSetKeyNoInit(aes, k2, sizeof(k2), AES_ENCRYPTION);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    ret = wc_AesXtsEncrypt(aes, buf, p2, sizeof(p2), i2, sizeof(i2));
+#if defined(WOLFSSL_ASYNC_CRYPT)
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    if (XMEMCMP(c2, buf, sizeof(c2)))
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+
+#if defined(DEBUG_VECTOR_REGISTER_ACCESS) && defined(WC_AES_C_DYNAMIC_FALLBACK)
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    ret = wc_AesXtsEncrypt(aes, buf, p2, sizeof(p2), i2, sizeof(i2));
+#if defined(WOLFSSL_ASYNC_CRYPT)
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    if (XMEMCMP(c2, buf, sizeof(c2)))
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+#endif
+
+    XMEMSET(buf, 0, sizeof(buf));
+
+    ret = wc_AesXtsSetKeyNoInit(aes, k1, sizeof(k1), AES_ENCRYPTION);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    ret = wc_AesXtsEncrypt(aes, buf, p1, sizeof(p1), i1, sizeof(i1));
+#if defined(WOLFSSL_ASYNC_CRYPT)
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    if (XMEMCMP(c1, buf, AES_BLOCK_SIZE))
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+
+#if defined(DEBUG_VECTOR_REGISTER_ACCESS) && defined(WC_AES_C_DYNAMIC_FALLBACK)
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    ret = wc_AesXtsEncrypt(aes, buf, p1, sizeof(p1), i1, sizeof(i1));
+#if defined(WOLFSSL_ASYNC_CRYPT)
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    if (XMEMCMP(c1, buf, AES_BLOCK_SIZE))
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+#endif
+
+    /* partial block encryption test */
+    XMEMSET(cipher, 0, sizeof(cipher));
+    ret = wc_AesXtsEncrypt(aes, cipher, pp, sizeof(pp), i1, sizeof(i1));
+#if defined(WOLFSSL_ASYNC_CRYPT)
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    if (XMEMCMP(cp2, cipher, sizeof(cp2)))
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+
+#if defined(DEBUG_VECTOR_REGISTER_ACCESS) && defined(WC_AES_C_DYNAMIC_FALLBACK)
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    XMEMSET(cipher, 0, sizeof(cipher));
+    ret = wc_AesXtsEncrypt(aes, cipher, pp, sizeof(pp), i1, sizeof(i1));
+#if defined(WOLFSSL_ASYNC_CRYPT)
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    if (XMEMCMP(cp2, cipher, sizeof(cp2)))
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+#endif
+
+    /* partial block decrypt test */
+    XMEMSET(buf, 0, sizeof(buf));
+    ret = wc_AesXtsSetKeyNoInit(aes, k1, sizeof(k1), AES_DECRYPTION);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    ret = wc_AesXtsDecrypt(aes, buf, cipher, sizeof(pp), i1, sizeof(i1));
+#if defined(WOLFSSL_ASYNC_CRYPT)
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    if (XMEMCMP(pp, buf, sizeof(pp)))
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+
+#if defined(DEBUG_VECTOR_REGISTER_ACCESS) && defined(WC_AES_C_DYNAMIC_FALLBACK)
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    XMEMSET(buf, 0, sizeof(buf));
+    ret = wc_AesXtsDecrypt(aes, buf, cipher, sizeof(pp), i1, sizeof(i1));
+#if defined(WOLFSSL_ASYNC_CRYPT)
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    if (XMEMCMP(pp, buf, sizeof(pp)))
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+#endif
+
+    /* NIST decrypt test vector */
+    XMEMSET(buf, 0, sizeof(buf));
+    ret = wc_AesXtsDecrypt(aes, buf, c1, sizeof(c1), i1, sizeof(i1));
+#if defined(WOLFSSL_ASYNC_CRYPT)
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    if (XMEMCMP(p1, buf, AES_BLOCK_SIZE))
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+
+#if defined(DEBUG_VECTOR_REGISTER_ACCESS) && defined(WC_AES_C_DYNAMIC_FALLBACK)
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    XMEMSET(buf, 0, sizeof(buf));
+    ret = wc_AesXtsDecrypt(aes, buf, c1, sizeof(c1), i1, sizeof(i1));
+#if defined(WOLFSSL_ASYNC_CRYPT)
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    if (XMEMCMP(p1, buf, AES_BLOCK_SIZE))
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+#endif
+
+    /* fail case with decrypting using wrong key */
+    XMEMSET(buf, 0, sizeof(buf));
+    ret = wc_AesXtsDecrypt(aes, buf, c2, sizeof(c2), i2, sizeof(i2));
+#if defined(WOLFSSL_ASYNC_CRYPT)
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    if (XMEMCMP(p2, buf, sizeof(p2)) == 0) /* fail case with wrong key */
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+
+    /* set correct key and retest */
+    XMEMSET(buf, 0, sizeof(buf));
+    ret = wc_AesXtsSetKeyNoInit(aes, k2, sizeof(k2), AES_DECRYPTION);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    ret = wc_AesXtsDecrypt(aes, buf, c2, sizeof(c2), i2, sizeof(i2));
+#if defined(WOLFSSL_ASYNC_CRYPT)
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    if (XMEMCMP(p2, buf, sizeof(p2)))
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+
+#ifndef HAVE_FIPS_VERSION
+
+    /* Test ciphertext stealing in-place. */
+    XMEMCPY(buf, p3, sizeof(p3));
+    ret = wc_AesXtsSetKeyNoInit(aes, k3, sizeof(k3), AES_ENCRYPTION);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    ret = wc_AesXtsEncrypt(aes, buf, buf, sizeof(p3), i3, sizeof(i3));
+#if defined(WOLFSSL_ASYNC_CRYPT)
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    if (XMEMCMP(c3, buf, sizeof(c3)))
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+
+    ret = wc_AesXtsSetKeyNoInit(aes, k3, sizeof(k3), AES_DECRYPTION);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    ret = wc_AesXtsDecrypt(aes, buf, buf, sizeof(c3), i3, sizeof(i3));
+#if defined(WOLFSSL_ASYNC_CRYPT)
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    if (XMEMCMP(p3, buf, sizeof(p3)))
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+
+#endif /* HAVE_FIPS_VERSION */
+
+#if !defined(BENCH_EMBEDDED) && !defined(HAVE_CAVIUM) && \
+    !defined(WOLFSSL_AFALG)
+    {
+    #define LARGE_XTS_SZ        1024
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
+        byte* large_input = (byte *)XMALLOC(LARGE_XTS_SZ, HEAP_HINT,
+            DYNAMIC_TYPE_TMP_BUFFER);
+    #else
+        byte large_input[LARGE_XTS_SZ];
+    #endif
+        int i;
+        int j;
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
+        if (large_input == NULL)
+            ERROR_OUT(WC_TEST_RET_ENC_EC(MEMORY_E), out);
+    #endif
+
+        for (i = 0; i < (int)LARGE_XTS_SZ; i++)
+            large_input[i] = (byte)i;
+
+        for (j = 16; j < (int)LARGE_XTS_SZ; j++) {
+            ret = wc_AesXtsSetKeyNoInit(aes, k1, sizeof(k1), AES_ENCRYPTION);
+            if (ret != 0)
+                ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+            ret = wc_AesXtsEncrypt(aes, large_input, large_input, j, i1,
+                sizeof(i1));
+        #if defined(WOLFSSL_ASYNC_CRYPT)
+            ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+        #endif
+            if (ret != 0)
+                ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+            ret = wc_AesXtsSetKeyNoInit(aes, k1, sizeof(k1), AES_DECRYPTION);
+            if (ret != 0)
+                ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+            ret = wc_AesXtsDecrypt(aes, large_input, large_input, j, i1,
+                sizeof(i1));
+        #if defined(WOLFSSL_ASYNC_CRYPT)
+            ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+        #endif
+            if (ret != 0)
+                ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+            for (i = 0; i < j; i++) {
+                if (large_input[i] != (byte)i) {
+                    ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+                }
+            }
+        }
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
+        XFREE(large_input, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    #endif
+    }
+#endif /* !BENCH_EMBEDDED && !HAVE_CAVIUM &&
+        * !WOLFSSL_AFALG
+        */
+
+    /* now the kernel crypto part */
+
+    {
+    u8 *    enc2 = NULL;
+    u8 *    dec2 = NULL;
+    struct scatterlist *  src = NULL;
+    struct scatterlist *  dst = NULL;
+    struct crypto_skcipher *tfm = NULL;
+    struct skcipher_request *req = NULL;
+    u8 iv[AES_BLOCK_SIZE];
+    const char *driver_name;
+
+    enc2 = XMALLOC(sizeof(p1), NULL, DYNAMIC_TYPE_AES);
+    if (!enc2) {
+        pr_err("error: malloc failed\n");
+        ret = -ENOMEM;
+        goto test_xts_end;
+    }
+
+    dec2 = XMALLOC(sizeof(p1), NULL, DYNAMIC_TYPE_AES);
+    if (!dec2) {
+        pr_err("error: malloc failed\n");
+        ret = -ENOMEM;
+        goto test_xts_end;
+    }
+
+    src = XMALLOC(sizeof(*src) * 2, NULL, DYNAMIC_TYPE_AES);
+    if (! src) {
+        pr_err("error: malloc failed\n");
+        ret = -ENOMEM;
+        goto test_xts_end;
+    }
+
+    dst = XMALLOC(sizeof(*dst) * 2, NULL, DYNAMIC_TYPE_AES);
+    if (! dst) {
+        pr_err("error: malloc failed\n");
+        ret = -ENOMEM;
+        goto test_xts_end;
+    }
+
+    tfm = crypto_alloc_skcipher(WOLFKM_AESXTS_NAME, 0, 0);
+    if (IS_ERR(tfm)) {
+        ret = PTR_ERR(tfm);
+        pr_err("error: allocating AES skcipher algorithm %s failed: %d\n",
+               WOLFKM_AESXTS_DRIVER, ret);
+        goto test_xts_end;
+    }
+
+    driver_name = crypto_tfm_alg_driver_name(crypto_skcipher_tfm(tfm));
+    if (strcmp(driver_name, WOLFKM_AESXTS_DRIVER)) {
+        pr_err("error: unexpected implementation for %s: %s (expected %s)\n",
+               WOLFKM_AESXTS_NAME, driver_name, WOLFKM_AESXTS_DRIVER);
+        ret = -ENOENT;
+        goto test_xts_end;
+    }
+
+    ret = crypto_skcipher_ivsize(tfm);
+    if (ret != sizeof iv) {
+        pr_err("error: AES skcipher algorithm %s crypto_skcipher_ivsize()"
+               " returned %d but expected %d\n",
+               WOLFKM_AESXTS_DRIVER, ret, (int)sizeof iv);
+        ret = -EINVAL;
+        goto test_xts_end;
+    }
+
+    ret = crypto_skcipher_setkey(tfm, k1, sizeof(k1));
+    if (ret) {
+        pr_err("error: crypto_skcipher_setkey for %s returned: %d\n", WOLFKM_AESXTS_NAME, ret);
+        goto test_xts_end;
+    }
+
+    req = skcipher_request_alloc(tfm, GFP_KERNEL);
+    if (IS_ERR(req)) {
+        ret = PTR_ERR(req);
+        pr_err("error: allocating AES skcipher request %s failed: %d\n",
+               WOLFKM_AESXTS_DRIVER, ret);
+        goto test_xts_end;
+    }
+
+    memcpy(dec2, p1, sizeof(p1));
+    memset(enc2, 0, sizeof(p1));
+
+    sg_init_one(src, dec2, sizeof(p1));
+    sg_init_one(dst, enc2, sizeof(p1));
+
+    memcpy(iv, i1, sizeof iv);
+    skcipher_request_set_crypt(req, src, dst, sizeof(p1), iv);
+
+    ret = crypto_skcipher_encrypt(req);
+
+    if (ret) {
+        pr_err("error: crypto_skcipher_encrypt returned: %d\n", ret);
+        goto test_xts_end;
+    }
+
+    ret = XMEMCMP(c1, enc2, sizeof(enc2));
+    if (ret) {
+        pr_err("error: c1 and enc2 do not match: %d\n", ret);
+        ret = -EINVAL;
+        goto test_xts_end;
+    }
+
+    memset(dec2, 0, sizeof(p1));
+    sg_init_one(src, enc2, sizeof(p1));
+    sg_init_one(dst, dec2, sizeof(p1));
+
+    memcpy(iv, i1, sizeof iv);
+    skcipher_request_set_crypt(req, src, dst, sizeof(p1), iv);
+
+    ret = crypto_skcipher_decrypt(req);
+
+    if (ret) {
+        pr_err("ERROR: crypto_skcipher_decrypt returned %d\n", ret);
+        goto test_xts_end;
+    }
+
+    ret = XMEMCMP(p1, dec2, sizeof(p1));
+    if (ret) {
+        pr_err("error: p1 and dec2 do not match: %d\n", ret);
+        ret = -EINVAL;
+        goto test_xts_end;
+    }
+
+    memcpy(dec2, pp, sizeof(pp));
+    memset(enc2, 0, sizeof(pp));
+
+    sg_init_one(src, dec2, sizeof(pp));
+    sg_init_one(dst, enc2, sizeof(pp));
+
+    memcpy(iv, i1, sizeof iv);
+    skcipher_request_set_crypt(req, src, dst, sizeof(pp), iv);
+
+    ret = crypto_skcipher_encrypt(req);
+
+    if (ret) {
+        pr_err("error: crypto_skcipher_encrypt returned: %d\n", ret);
+        goto test_xts_end;
+    }
+
+    ret = XMEMCMP(cp, enc2, sizeof(cp));
+    if (ret) {
+        pr_err("error: cp and enc2 do not match: %d\n", ret);
+        ret = -EINVAL;
+        goto test_xts_end;
+    }
+
+    memset(dec2, 0, sizeof(pp));
+    sg_init_one(src, enc2, sizeof(pp));
+    sg_init_one(dst, dec2, sizeof(pp));
+
+    memcpy(iv, i1, sizeof iv);
+    skcipher_request_set_crypt(req, src, dst, sizeof(pp), iv);
+
+    ret = crypto_skcipher_decrypt(req);
+
+    if (ret) {
+        pr_err("ERROR: crypto_skcipher_decrypt returned %d\n", ret);
+        goto test_xts_end;
+    }
+
+    ret = XMEMCMP(pp, dec2, sizeof(pp));
+    if (ret) {
+        pr_err("error: pp and dec2 do not match: %d\n", ret);
+        ret = -EINVAL;
+        goto test_xts_end;
+    }
+
+    test_xts_end:
+
+    if (enc2)
+        XFREE(enc2, NULL, DYNAMIC_TYPE_AES);
+    if (dec2)
+        XFREE(dec2, NULL, DYNAMIC_TYPE_AES);
+    if (src)
+        XFREE(src, NULL, DYNAMIC_TYPE_AES);
+    if (dst)
+        XFREE(dst, NULL, DYNAMIC_TYPE_AES);
+    if (req)
+        skcipher_request_free(req);
+    if (tfm)
+        crypto_free_skcipher(tfm);
+
+    }
+
+  out:
+
+    if (aes_inited)
+        wc_AesXtsFree(aes);
+
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
+    if (aes)
+        XFREE(aes, HEAP_HINT, DYNAMIC_TYPE_AES);
+#endif
+
+    return ret;
+}
+#endif /* WOLFSSL_AES_128 */
+
+#ifdef WOLFSSL_AES_256
+static int aes_xts_256_test(void)
+{
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
+    XtsAes *aes = NULL;
+#else
+    XtsAes aes[1];
+#endif
+    int aes_inited = 0;
+    int ret = 0;
+    unsigned char buf[AES_BLOCK_SIZE * 3];
+    unsigned char cipher[AES_BLOCK_SIZE * 3];
+
+    /* 256 key tests */
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char k1[] = {
+        0x1e, 0xa6, 0x61, 0xc5, 0x8d, 0x94, 0x3a, 0x0e,
+        0x48, 0x01, 0xe4, 0x2f, 0x4b, 0x09, 0x47, 0x14,
+        0x9e, 0x7f, 0x9f, 0x8e, 0x3e, 0x68, 0xd0, 0xc7,
+        0x50, 0x52, 0x10, 0xbd, 0x31, 0x1a, 0x0e, 0x7c,
+        0xd6, 0xe1, 0x3f, 0xfd, 0xf2, 0x41, 0x8d, 0x8d,
+        0x19, 0x11, 0xc0, 0x04, 0xcd, 0xa5, 0x8d, 0xa3,
+        0xd6, 0x19, 0xb7, 0xe2, 0xb9, 0x14, 0x1e, 0x58,
+        0x31, 0x8e, 0xea, 0x39, 0x2c, 0xf4, 0x1b, 0x08
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char i1[] = {
+        0xad, 0xf8, 0xd9, 0x26, 0x27, 0x46, 0x4a, 0xd2,
+        0xf0, 0x42, 0x8e, 0x84, 0xa9, 0xf8, 0x75, 0x64
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char p1[] = {
+        0x2e, 0xed, 0xea, 0x52, 0xcd, 0x82, 0x15, 0xe1,
+        0xac, 0xc6, 0x47, 0xe8, 0x10, 0xbb, 0xc3, 0x64,
+        0x2e, 0x87, 0x28, 0x7f, 0x8d, 0x2e, 0x57, 0xe3,
+        0x6c, 0x0a, 0x24, 0xfb, 0xc1, 0x2a, 0x20, 0x2e
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char c1[] = {
+        0xcb, 0xaa, 0xd0, 0xe2, 0xf6, 0xce, 0xa3, 0xf5,
+        0x0b, 0x37, 0xf9, 0x34, 0xd4, 0x6a, 0x9b, 0x13,
+        0x0b, 0x9d, 0x54, 0xf0, 0x7e, 0x34, 0xf3, 0x6a,
+        0xf7, 0x93, 0xe8, 0x6f, 0x73, 0xc6, 0xd7, 0xdb
+    };
+
+    /* plain text test of partial block is not from NIST test vector list */
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char pp[] = {
+        0xeb, 0xab, 0xce, 0x95, 0xb1, 0x4d, 0x3c, 0x8d,
+        0x6f, 0xb3, 0x50, 0x39, 0x07, 0x90, 0x31, 0x1c,
+        0x6e, 0x4b, 0x92, 0x01, 0x3e, 0x76, 0x8a, 0xd5
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char cp[] = {
+        0x65, 0x5e, 0x1d, 0x37, 0x4a, 0x91, 0xe7, 0x6c,
+        0x4f, 0x83, 0x92, 0xbc, 0x5a, 0x10, 0x55, 0x27,
+        0x61, 0x0e, 0x5a, 0xde, 0xca, 0xc5, 0x12, 0xd8
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char k2[] = {
+        0xad, 0x50, 0x4b, 0x85, 0xd7, 0x51, 0xbf, 0xba,
+        0x69, 0x13, 0xb4, 0xcc, 0x79, 0xb6, 0x5a, 0x62,
+        0xf7, 0xf3, 0x9d, 0x36, 0x0f, 0x35, 0xb5, 0xec,
+        0x4a, 0x7e, 0x95, 0xbd, 0x9b, 0xa5, 0xf2, 0xec,
+        0xc1, 0xd7, 0x7e, 0xa3, 0xc3, 0x74, 0xbd, 0x4b,
+        0x13, 0x1b, 0x07, 0x83, 0x87, 0xdd, 0x55, 0x5a,
+        0xb5, 0xb0, 0xc7, 0xe5, 0x2d, 0xb5, 0x06, 0x12,
+        0xd2, 0xb5, 0x3a, 0xcb, 0x47, 0x8a, 0x53, 0xb4
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char i2[] = {
+        0xe6, 0x42, 0x19, 0xed, 0xe0, 0xe1, 0xc2, 0xa0,
+        0x0e, 0xf5, 0x58, 0x6a, 0xc4, 0x9b, 0xeb, 0x6f
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char p2[] = {
+        0x24, 0xcb, 0x76, 0x22, 0x55, 0xb5, 0xa8, 0x00,
+        0xf4, 0x6e, 0x80, 0x60, 0x56, 0x9e, 0x05, 0x53,
+        0xbc, 0xfe, 0x86, 0x55, 0x3b, 0xca, 0xd5, 0x89,
+        0xc7, 0x54, 0x1a, 0x73, 0xac, 0xc3, 0x9a, 0xbd,
+        0x53, 0xc4, 0x07, 0x76, 0xd8, 0xe8, 0x22, 0x61,
+        0x9e, 0xa9, 0xad, 0x77, 0xa0, 0x13, 0x4c, 0xfc
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const unsigned char c2[] = {
+        0xa3, 0xc6, 0xf3, 0xf3, 0x82, 0x79, 0x5b, 0x10,
+        0x87, 0xd7, 0x02, 0x50, 0xdb, 0x2c, 0xd3, 0xb1,
+        0xa1, 0x62, 0xa8, 0xb6, 0xdc, 0x12, 0x60, 0x61,
+        0xc1, 0x0a, 0x84, 0xa5, 0x85, 0x3f, 0x3a, 0x89,
+        0xe6, 0x6c, 0xdb, 0xb7, 0x9a, 0xb4, 0x28, 0x9b,
+        0xc3, 0xea, 0xd8, 0x10, 0xe9, 0xc0, 0xaf, 0x92
+    };
+
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
+    if ((aes = (XtsAes *)XMALLOC(sizeof *aes, HEAP_HINT, DYNAMIC_TYPE_AES)) == NULL)
+        ERROR_OUT(MEMORY_E, out);
+#endif
+
+#if defined(OPENSSL_EXTRA) && !defined(WOLFCRYPT_ONLY) \
+    && !defined(HAVE_SELFTEST) && !defined(HAVE_FIPS)
+    ret = EVP_test(EVP_aes_256_xts(), k2, i2, p2, sizeof(p2), c2, sizeof(c2));
+    if (ret != 0) {
+        printf("EVP_aes_256_xts failed\n");
+        goto out;
+    }
+#endif
+
+    ret = wc_AesXtsInit(aes, HEAP_HINT, devId);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    else
+        aes_inited = 1;
+
+    XMEMSET(buf, 0, sizeof(buf));
+    ret = wc_AesXtsSetKeyNoInit(aes, k2, sizeof(k2), AES_ENCRYPTION);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    ret = wc_AesXtsEncrypt(aes, buf, p2, sizeof(p2), i2, sizeof(i2));
+#if defined(WOLFSSL_ASYNC_CRYPT)
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    if (XMEMCMP(c2, buf, sizeof(c2)))
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+
+    XMEMSET(buf, 0, sizeof(buf));
+    ret = wc_AesXtsSetKeyNoInit(aes, k1, sizeof(k1), AES_ENCRYPTION);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    ret = wc_AesXtsEncrypt(aes, buf, p1, sizeof(p1), i1, sizeof(i1));
+#if defined(WOLFSSL_ASYNC_CRYPT)
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    if (XMEMCMP(c1, buf, AES_BLOCK_SIZE))
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+
+    /* partial block encryption test */
+    XMEMSET(cipher, 0, sizeof(cipher));
+    ret = wc_AesXtsEncrypt(aes, cipher, pp, sizeof(pp), i1, sizeof(i1));
+#if defined(WOLFSSL_ASYNC_CRYPT)
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+    /* partial block decrypt test */
+    XMEMSET(buf, 0, sizeof(buf));
+    ret = wc_AesXtsSetKeyNoInit(aes, k1, sizeof(k1), AES_DECRYPTION);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    ret = wc_AesXtsDecrypt(aes, buf, cipher, sizeof(pp), i1, sizeof(i1));
+#if defined(WOLFSSL_ASYNC_CRYPT)
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    if (XMEMCMP(pp, buf, sizeof(pp)))
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+
+    /* NIST decrypt test vector */
+    XMEMSET(buf, 0, sizeof(buf));
+    ret = wc_AesXtsDecrypt(aes, buf, c1, sizeof(c1), i1, sizeof(i1));
+#if defined(WOLFSSL_ASYNC_CRYPT)
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    if (XMEMCMP(p1, buf, AES_BLOCK_SIZE))
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+
+    XMEMSET(buf, 0, sizeof(buf));
+    ret = wc_AesXtsSetKeyNoInit(aes, k2, sizeof(k2), AES_DECRYPTION);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    ret = wc_AesXtsDecrypt(aes, buf, c2, sizeof(c2), i2, sizeof(i2));
+#if defined(WOLFSSL_ASYNC_CRYPT)
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+    if (XMEMCMP(p2, buf, sizeof(p2)))
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+
+    /* now the kernel crypto part */
+
+    {
+    u8 *    enc2 = NULL;
+    u8 *    dec2 = NULL;
+    struct scatterlist *  src = NULL;
+    struct scatterlist *  dst = NULL;
+    struct crypto_skcipher *tfm = NULL;
+    struct skcipher_request *req = NULL;
+    u8 iv[AES_BLOCK_SIZE];
+    const char *driver_name;
+
+    enc2 = XMALLOC(sizeof(p1), NULL, DYNAMIC_TYPE_AES);
+    if (!enc2) {
+        pr_err("error: malloc failed\n");
+        ret = -ENOMEM;
+        goto test_xts_end;
+    }
+
+    dec2 = XMALLOC(sizeof(p1), NULL, DYNAMIC_TYPE_AES);
+    if (!dec2) {
+        pr_err("error: malloc failed\n");
+        ret = -ENOMEM;
+        goto test_xts_end;
+    }
+
+    src = XMALLOC(sizeof(*src) * 2, NULL, DYNAMIC_TYPE_AES);
+    if (! src) {
+        pr_err("error: malloc failed\n");
+        ret = -ENOMEM;
+        goto test_xts_end;
+    }
+
+    dst = XMALLOC(sizeof(*dst) * 2, NULL, DYNAMIC_TYPE_AES);
+    if (! dst) {
+        pr_err("error: malloc failed\n");
+        ret = -ENOMEM;
+        goto test_xts_end;
+    }
+
+    tfm = crypto_alloc_skcipher(WOLFKM_AESXTS_NAME, 0, 0);
+    if (IS_ERR(tfm)) {
+        ret = PTR_ERR(tfm);
+        pr_err("error: allocating AES skcipher algorithm %s failed: %d\n",
+               WOLFKM_AESXTS_DRIVER, ret);
+        goto test_xts_end;
+    }
+
+    driver_name = crypto_tfm_alg_driver_name(crypto_skcipher_tfm(tfm));
+    if (strcmp(driver_name, WOLFKM_AESXTS_DRIVER)) {
+        pr_err("error: unexpected implementation for %s: %s (expected %s)\n",
+               WOLFKM_AESXTS_NAME, driver_name, WOLFKM_AESXTS_DRIVER);
+        ret = -ENOENT;
+        goto test_xts_end;
+    }
+
+    ret = crypto_skcipher_ivsize(tfm);
+    if (ret != sizeof iv) {
+        pr_err("error: AES skcipher algorithm %s crypto_skcipher_ivsize()"
+               " returned %d but expected %d\n",
+               WOLFKM_AESXTS_DRIVER, ret, (int)sizeof iv);
+        ret = -EINVAL;
+        goto test_xts_end;
+    }
+
+    ret = crypto_skcipher_setkey(tfm, k1, sizeof(k1));
+    if (ret) {
+        pr_err("error: crypto_skcipher_setkey for %s returned: %d\n", WOLFKM_AESXTS_NAME, ret);
+        goto test_xts_end;
+    }
+
+    req = skcipher_request_alloc(tfm, GFP_KERNEL);
+    if (IS_ERR(req)) {
+        ret = PTR_ERR(req);
+        pr_err("error: allocating AES skcipher request %s failed: %d\n",
+               WOLFKM_AESXTS_DRIVER, ret);
+        goto test_xts_end;
+    }
+
+    memcpy(dec2, p1, sizeof(p1));
+    memset(enc2, 0, sizeof(p1));
+
+    sg_init_one(src, dec2, sizeof(p1));
+    sg_init_one(dst, enc2, sizeof(p1));
+
+    memcpy(iv, i1, sizeof iv);
+    skcipher_request_set_crypt(req, src, dst, sizeof(p1), iv);
+
+    ret = crypto_skcipher_encrypt(req);
+
+    if (ret) {
+        pr_err("error: crypto_skcipher_encrypt returned: %d\n", ret);
+        goto test_xts_end;
+    }
+
+    ret = XMEMCMP(c1, enc2, sizeof(enc2));
+    if (ret) {
+        pr_err("error: c1 and enc2 do not match: %d\n", ret);
+        ret = -EINVAL;
+        goto test_xts_end;
+    }
+
+    memset(dec2, 0, sizeof(p1));
+    sg_init_one(src, enc2, sizeof(p1));
+    sg_init_one(dst, dec2, sizeof(p1));
+
+    memcpy(iv, i1, sizeof iv);
+    skcipher_request_set_crypt(req, src, dst, sizeof(p1), iv);
+
+    ret = crypto_skcipher_decrypt(req);
+
+    if (ret) {
+        pr_err("ERROR: crypto_skcipher_decrypt returned %d\n", ret);
+        goto test_xts_end;
+    }
+
+    ret = XMEMCMP(p1, dec2, sizeof(p1));
+    if (ret) {
+        pr_err("error: p1 and dec2 do not match: %d\n", ret);
+        ret = -EINVAL;
+        goto test_xts_end;
+    }
+
+    memcpy(dec2, pp, sizeof(pp));
+    memset(enc2, 0, sizeof(pp));
+
+    sg_init_one(src, dec2, sizeof(pp));
+    sg_init_one(dst, enc2, sizeof(pp));
+
+    memcpy(iv, i1, sizeof iv);
+    skcipher_request_set_crypt(req, src, dst, sizeof(pp), iv);
+
+    ret = crypto_skcipher_encrypt(req);
+
+    if (ret) {
+        pr_err("error: crypto_skcipher_encrypt returned: %d\n", ret);
+        goto test_xts_end;
+    }
+
+    ret = XMEMCMP(cp, enc2, sizeof(cp));
+    if (ret) {
+        pr_err("error: cp and enc2 do not match: %d\n", ret);
+        ret = -EINVAL;
+        goto test_xts_end;
+    }
+
+    memset(dec2, 0, sizeof(pp));
+    sg_init_one(src, enc2, sizeof(pp));
+    sg_init_one(dst, dec2, sizeof(pp));
+
+    memcpy(iv, i1, sizeof iv);
+    skcipher_request_set_crypt(req, src, dst, sizeof(pp), iv);
+
+    ret = crypto_skcipher_decrypt(req);
+
+    if (ret) {
+        pr_err("ERROR: crypto_skcipher_decrypt returned %d\n", ret);
+        goto test_xts_end;
+    }
+
+    ret = XMEMCMP(pp, dec2, sizeof(pp));
+    if (ret) {
+        pr_err("error: pp and dec2 do not match: %d\n", ret);
+        ret = -EINVAL;
+        goto test_xts_end;
+    }
+
+    test_xts_end:
+
+    if (enc2)
+        XFREE(enc2, NULL, DYNAMIC_TYPE_AES);
+    if (dec2)
+        XFREE(dec2, NULL, DYNAMIC_TYPE_AES);
+    if (src)
+        XFREE(src, NULL, DYNAMIC_TYPE_AES);
+    if (dst)
+        XFREE(dst, NULL, DYNAMIC_TYPE_AES);
+    if (req)
+        skcipher_request_free(req);
+    if (tfm)
+        crypto_free_skcipher(tfm);
+
+    }
+
+  out:
+
+    if (aes_inited)
+        wc_AesXtsFree(aes);
+
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
+    if (aes)
+        XFREE(aes, HEAP_HINT, DYNAMIC_TYPE_AES);
+#endif
+
+    return ret;
+}
+#endif /* WOLFSSL_AES_256 */
+
+static int linuxkm_test_aesxts(void) {
+    int ret;
+
+    #ifdef WOLFSSL_AES_128
+    ret = aes_xts_128_test();
+    if (ret != 0) {
+        pr_err("aes_xts_128_test() failed with retval %d.\n", ret);
+        goto out;
+    }
+    #endif
+    #ifdef WOLFSSL_AES_256
+    ret = aes_xts_256_test();
+    if (ret != 0) {
+        pr_err("aes_xts_256_test() failed with retval %d.\n", ret);
+        goto out;
+    }
+    #endif
+
+out:
+
+    return ret;
+}
+
+#endif /* WOLFSSL_AES_XTS &&
+        * (LINUXKM_LKCAPI_REGISTER_ALL || LINUXKM_LKCAPI_REGISTER_AESXTS)
+        */
+
+#endif /* !NO_AES */
+
+static int linuxkm_lkcapi_register(void)
+{
+    int ret = 0;
+
+#define REGISTER_ALG(alg, installer, tester) do {                       \
+        if (alg ## _loaded) {\
+            pr_err("ERROR: %s is already registered.\n", (alg).base.cra_driver_name); \
+            return -EEXIST;                                             \
+        }                                                               \
+                                                                        \
+        ret =  (installer)(&(alg));                                     \
+                                                                        \
+        if (ret) {                                                      \
+            pr_err("ERROR: " #installer " for %s failed with return code %d.\n", (alg).base.cra_driver_name, ret); \
+            return ret;                                                 \
+        }                                                               \
+                                                                        \
+        alg ## _loaded = 1;                                             \
+                                                                        \
+        ret = (tester());                                               \
+                                                                        \
+        if (ret) {                                                      \
+            pr_err("ERROR: self-test for %s failed with return code %d.\n", (alg).base.cra_driver_name, ret); \
+            return ret;                                                 \
+        }                                                               \
+        pr_info("%s self-test OK -- registered for %s with priority %d.\n", (alg).base.cra_driver_name, (alg).base.cra_name, (alg).base.cra_priority); \
+    } while (0)
+
+#if defined(HAVE_AES_CBC) && \
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESCBC))
+
+    REGISTER_ALG(cbcAesAlg, crypto_register_skcipher, linuxkm_test_aescbc);
+#endif
+
+#if defined(WOLFSSL_AES_CFB) && \
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESCFB))
+
+    REGISTER_ALG(cfbAesAlg, crypto_register_skcipher, linuxkm_test_aescfb);
+#endif
+
+#if defined(HAVE_AESGCM) && \
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESGCM)) && \
+    (! (defined(WOLFSSL_AESNI) && defined(WC_AES_C_DYNAMIC_FALLBACK)))
+
+    REGISTER_ALG(gcmAesAead, crypto_register_aead, linuxkm_test_aesgcm);
+#endif
+
+#if defined(WOLFSSL_AES_XTS) && \
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESXTS))
+
+    REGISTER_ALG(xtsAesAlg, crypto_register_skcipher, linuxkm_test_aesxts);
+#endif
+
+#undef REGISTER_ALG
+
+    return 0;
+}
+
+static void linuxkm_lkcapi_unregister(void)
+{
+#if defined(HAVE_AES_CBC) && \
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESCBC))
+    if (cbcAesAlg_loaded) {
+        crypto_unregister_skcipher(&cbcAesAlg);
+        cbcAesAlg_loaded = 0;
+    }
+#endif
+#if defined(WOLFSSL_AES_CFB) && \
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESCFB))
+    if (cfbAesAlg_loaded) {
+        crypto_unregister_skcipher(&cfbAesAlg);
+        cfbAesAlg_loaded = 0;
+    }
+#endif
+#if defined(HAVE_AESGCM) && \
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESGCM)) && \
+    (! (defined(WOLFSSL_AESNI) && defined(WC_AES_C_DYNAMIC_FALLBACK)))
+    if (gcmAesAead_loaded) {
+        crypto_unregister_aead(&gcmAesAead);
+        gcmAesAead_loaded = 0;
+    }
+#endif
+#if defined(WOLFSSL_AES_XTS) && \
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESXTS))
+    if (xtsAesAlg_loaded) {
+        crypto_unregister_skcipher(&xtsAesAlg);
+        xtsAesAlg_loaded = 0;
+    }
+#endif
+}

--- a/linuxkm/lkcapi_glue.c
+++ b/linuxkm/lkcapi_glue.c
@@ -54,8 +54,10 @@
     #define WOLFKM_DRIVER_ISA_EXT ""
 #endif
 
-#ifdef HAVE_FIPS_VERSION
-    #if HAVE_FIPS_VERSION >= 5
+#ifdef HAVE_FIPS
+    #ifndef HAVE_FIPS_VERSION
+        #define WOLFKM_DRIVER_FIPS "-fips-140"
+    #elif HAVE_FIPS_VERSION >= 5
         #define WOLFKM_DRIVER_FIPS "-fips-140-3"
     #elif HAVE_FIPS_VERSION == 2
         #define WOLFKM_DRIVER_FIPS "-fips-140-2"
@@ -1648,7 +1650,7 @@ static int aes_xts_128_test(void)
         0xff, 0x8d, 0xbc, 0x1d, 0x9f, 0x7f, 0xc8, 0x22
     };
 
-#ifndef HAVE_FIPS_VERSION /* FIPS requires different keys for main and tweak. */
+#ifndef HAVE_FIPS /* FIPS requires different keys for main and tweak. */
     WOLFSSL_SMALL_STACK_STATIC const unsigned char k3[] = {
         0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
         0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
@@ -1673,7 +1675,7 @@ static int aes_xts_128_test(void)
         0xA0, 0x85, 0xD2, 0x69, 0x6E, 0x87, 0x0A, 0xBF,
         0xB5, 0x5A, 0xDD, 0xCB, 0x80, 0xE0, 0xFC, 0xCD
     };
-#endif /* HAVE_FIPS_VERSION */
+#endif /* HAVE_FIPS */
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     if ((aes = (XtsAes *)XMALLOC(sizeof(*aes), HEAP_HINT, DYNAMIC_TYPE_AES))
@@ -1866,7 +1868,7 @@ static int aes_xts_128_test(void)
     if (XMEMCMP(p2, buf, sizeof(p2)))
         ERROR_OUT(LINUXKM_LKCAPI_AES_KAT_MISMATCH_E, out);
 
-#ifndef HAVE_FIPS_VERSION
+#ifndef HAVE_FIPS
 
     /* Test ciphertext stealing in-place. */
     XMEMCPY(buf, p3, sizeof(p3));
@@ -1895,7 +1897,7 @@ static int aes_xts_128_test(void)
     if (XMEMCMP(p3, buf, sizeof(p3)))
         ERROR_OUT(LINUXKM_LKCAPI_AES_KAT_MISMATCH_E, out);
 
-#endif /* HAVE_FIPS_VERSION */
+#endif /* HAVE_FIPS */
 
 #if !defined(BENCH_EMBEDDED) && !defined(HAVE_CAVIUM) && \
     !defined(WOLFSSL_AFALG)

--- a/linuxkm/lkcapi_glue.c
+++ b/linuxkm/lkcapi_glue.c
@@ -579,7 +579,7 @@ static int km_AesGcmEncrypt(struct aead_request *req)
 
     err = skcipher_walk_aead_encrypt(&walk, req, false);
     if (unlikely(err)) {
-        pr_err("%s: skcipher_walk_aead_encrypt: %d\n",
+        pr_err("%s: skcipher_walk_aead_encrypt failed: %d\n",
                crypto_tfm_alg_driver_name(crypto_aead_tfm(tfm)), err);
         return -1;
     }
@@ -685,7 +685,7 @@ static int km_AesGcmDecrypt(struct aead_request *req)
 
     err = skcipher_walk_aead_decrypt(&walk, req, false);
     if (unlikely(err)) {
-        pr_err("%s: skcipher_walk_aead_decrypt: %d\n",
+        pr_err("%s: skcipher_walk_aead_decrypt failed: %d\n",
                crypto_tfm_alg_driver_name(crypto_aead_tfm(tfm)), err);
         return err;
     }

--- a/linuxkm/lkcapi_glue.c
+++ b/linuxkm/lkcapi_glue.c
@@ -134,7 +134,7 @@ static int km_AesInitCommon(struct km_AesCtx * ctx, const char * name, int need_
 
     ctx->aes_decrypt = (Aes *)malloc(sizeof(*ctx->aes_decrypt));
 
-    if (! ctx->aes_encrypt) {
+    if (! ctx->aes_decrypt) {
         pr_err("error: km_AesInitCommon %s failed: %d\n", name, MEMORY_E);
         km_AesExitCommon(ctx);
         return MEMORY_E;
@@ -239,7 +239,7 @@ static int km_AesCbcEncrypt(struct skcipher_request *req)
 
     err = skcipher_walk_virt(&walk, req, false);
 
-    while ((nbytes = walk.nbytes)) {
+    while ((nbytes = walk.nbytes) != 0) {
         err = wc_AesSetIV(ctx->aes_encrypt, walk.iv);
 
         if (unlikely(err)) {
@@ -274,7 +274,7 @@ static int km_AesCbcDecrypt(struct skcipher_request *req)
 
     err = skcipher_walk_virt(&walk, req, false);
 
-    while ((nbytes = walk.nbytes)) {
+    while ((nbytes = walk.nbytes) != 0) {
         err = wc_AesSetIV(ctx->aes_decrypt, walk.iv);
 
         if (unlikely(err)) {
@@ -347,7 +347,7 @@ static int km_AesCfbEncrypt(struct skcipher_request *req)
 
     err = skcipher_walk_virt(&walk, req, false);
 
-    while ((nbytes = walk.nbytes)) {
+    while ((nbytes = walk.nbytes) != 0) {
         err = wc_AesSetIV(ctx->aes_encrypt, walk.iv);
 
         if (unlikely(err)) {
@@ -382,7 +382,7 @@ static int km_AesCfbDecrypt(struct skcipher_request *req)
 
     err = skcipher_walk_virt(&walk, req, false);
 
-    while ((nbytes = walk.nbytes)) {
+    while ((nbytes = walk.nbytes) != 0) {
         err = wc_AesSetIV(ctx->aes_encrypt, walk.iv);
 
         if (unlikely(err)) {
@@ -527,7 +527,7 @@ static int km_AesGcmEncrypt(struct aead_request *req)
         return err;
     }
 
-    while ((nbytes = walk.nbytes)) {
+    while ((nbytes = walk.nbytes) != 0) {
         int n = nbytes;
 
         if (likely(cryptLeft && nbytes)) {
@@ -615,7 +615,7 @@ static int km_AesGcmDecrypt(struct aead_request *req)
         return err;
     }
 
-    while ((nbytes = walk.nbytes)) {
+    while ((nbytes = walk.nbytes) != 0) {
         int n = nbytes;
 
         if (likely(cryptLeft && nbytes)) {
@@ -712,9 +712,6 @@ static void km_AesXtsExit(struct crypto_skcipher *tfm)
     wc_AesXtsFree(ctx->aesXts);
     free(ctx->aesXts);
     ctx->aesXts = NULL;
-#if 0
-    km_ForceZeroXts(ctx);
-#endif
 }
 
 static int km_AesXtsSetKey(struct crypto_skcipher *tfm, const u8 *in_key,
@@ -729,11 +726,6 @@ static int km_AesXtsSetKey(struct crypto_skcipher *tfm, const u8 *in_key,
         pr_err("error: km_AesXtsSetKey %s failed: %d\n", WOLFKM_AESXTS_DRIVER, err);
         return err;
     }
-
-#if 0
-    XMEMCPY(ctx->key, in_key, key_len);
-    ctx->keylen = key_len;
-#endif
 
     return 0;
 }
@@ -759,7 +751,7 @@ static int km_AesXtsEncrypt(struct skcipher_request *req)
         return err;
     }
 
-    while ((nbytes = walk.nbytes)) {
+    while ((nbytes = walk.nbytes) != 0) {
         err = wc_AesXtsEncrypt(ctx->aesXts, walk.dst.virt.addr,
                                walk.src.virt.addr, nbytes,
                                walk.iv, walk.ivsize);
@@ -798,7 +790,7 @@ static int km_AesXtsDecrypt(struct skcipher_request *req)
         return err;
     }
 
-    while ((nbytes = walk.nbytes)) {
+    while ((nbytes = walk.nbytes) != 0) {
         err = wc_AesXtsDecrypt(ctx->aesXts, walk.dst.virt.addr,
                                walk.src.virt.addr, nbytes,
                                walk.iv, walk.ivsize);

--- a/linuxkm/lkcapi_glue.c
+++ b/linuxkm/lkcapi_glue.c
@@ -46,10 +46,31 @@
 #define WOLFKM_AESCFB_NAME   "cfb(aes)"
 #define WOLFKM_AESGCM_NAME   "gcm(aes)"
 #define WOLFKM_AESXTS_NAME   "xts(aes)"
-#define WOLFKM_AESCBC_DRIVER "cbc-aes-wolfcrypt"
-#define WOLFKM_AESCFB_DRIVER "cfb-aes-wolfcrypt"
-#define WOLFKM_AESGCM_DRIVER "gcm-aes-wolfcrypt"
-#define WOLFKM_AESXTS_DRIVER "xts-aes-wolfcrypt"
+
+#ifdef WOLFSSL_AESNI
+    #define WOLFKM_DRIVER_ISA_EXT "-aesni"
+#else
+    #define WOLFKM_DRIVER_ISA_EXT ""
+#endif
+
+#ifdef HAVE_FIPS_VERSION
+    #if HAVE_FIPS_VERSION >= 5
+        #define WOLFKM_DRIVER_FIPS "-fips-140-3"
+    #elif HAVE_FIPS_VERSION == 2
+        #define WOLFKM_DRIVER_FIPS "-fips-140-2"
+    #else
+        #define WOLFKM_DRIVER_FIPS "-fips-140"
+    #endif
+#else
+    #define WOLFKM_DRIVER_FIPS ""
+#endif
+
+#define WOLFKM_DRIVER_SUFFIX WOLFKM_DRIVER_ISA_EXT WOLFKM_DRIVER_FIPS "-wolfcrypt"
+
+#define WOLFKM_AESCBC_DRIVER ("cbc-aes" WOLFKM_DRIVER_SUFFIX)
+#define WOLFKM_AESCFB_DRIVER ("cfb-aes" WOLFKM_DRIVER_SUFFIX)
+#define WOLFKM_AESGCM_DRIVER ("gcm-aes" WOLFKM_DRIVER_SUFFIX)
+#define WOLFKM_AESXTS_DRIVER ("xts-aes" WOLFKM_DRIVER_SUFFIX)
 
 #if defined(HAVE_AES_CBC) && \
     (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESCBC))
@@ -1509,7 +1530,7 @@ static int aes_xts_128_test(void)
 
     ret = wc_AesXtsEncrypt(aes, buf, p2, sizeof(p2), i2, sizeof(i2));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -1520,7 +1541,7 @@ static int aes_xts_128_test(void)
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
     ret = wc_AesXtsEncrypt(aes, buf, p2, sizeof(p2), i2, sizeof(i2));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
     if (ret != 0)
@@ -1536,7 +1557,7 @@ static int aes_xts_128_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsEncrypt(aes, buf, p1, sizeof(p1), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -1547,7 +1568,7 @@ static int aes_xts_128_test(void)
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
     ret = wc_AesXtsEncrypt(aes, buf, p1, sizeof(p1), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
     if (ret != 0)
@@ -1560,7 +1581,7 @@ static int aes_xts_128_test(void)
     XMEMSET(cipher, 0, sizeof(cipher));
     ret = wc_AesXtsEncrypt(aes, cipher, pp, sizeof(pp), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -1572,7 +1593,7 @@ static int aes_xts_128_test(void)
     XMEMSET(cipher, 0, sizeof(cipher));
     ret = wc_AesXtsEncrypt(aes, cipher, pp, sizeof(pp), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
     if (ret != 0)
@@ -1588,7 +1609,7 @@ static int aes_xts_128_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsDecrypt(aes, buf, cipher, sizeof(pp), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -1600,7 +1621,7 @@ static int aes_xts_128_test(void)
     XMEMSET(buf, 0, sizeof(buf));
     ret = wc_AesXtsDecrypt(aes, buf, cipher, sizeof(pp), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
     if (ret != 0)
@@ -1613,7 +1634,7 @@ static int aes_xts_128_test(void)
     XMEMSET(buf, 0, sizeof(buf));
     ret = wc_AesXtsDecrypt(aes, buf, c1, sizeof(c1), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -1625,7 +1646,7 @@ static int aes_xts_128_test(void)
     XMEMSET(buf, 0, sizeof(buf));
     ret = wc_AesXtsDecrypt(aes, buf, c1, sizeof(c1), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
     if (ret != 0)
@@ -1638,7 +1659,7 @@ static int aes_xts_128_test(void)
     XMEMSET(buf, 0, sizeof(buf));
     ret = wc_AesXtsDecrypt(aes, buf, c2, sizeof(c2), i2, sizeof(i2));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -1652,7 +1673,7 @@ static int aes_xts_128_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsDecrypt(aes, buf, c2, sizeof(c2), i2, sizeof(i2));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -1669,7 +1690,7 @@ static int aes_xts_128_test(void)
 
     ret = wc_AesXtsEncrypt(aes, buf, buf, sizeof(p3), i3, sizeof(i3));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -1681,7 +1702,7 @@ static int aes_xts_128_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsDecrypt(aes, buf, buf, sizeof(c3), i3, sizeof(i3));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -1717,7 +1738,7 @@ static int aes_xts_128_test(void)
             ret = wc_AesXtsEncrypt(aes, large_input, large_input, j, i1,
                 sizeof(i1));
         #if defined(WOLFSSL_ASYNC_CRYPT)
-            ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+            ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
         #endif
             if (ret != 0)
                 ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -1728,7 +1749,7 @@ static int aes_xts_128_test(void)
             ret = wc_AesXtsDecrypt(aes, large_input, large_input, j, i1,
                 sizeof(i1));
         #if defined(WOLFSSL_ASYNC_CRYPT)
-            ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+            ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
         #endif
             if (ret != 0)
                 ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -2062,7 +2083,7 @@ static int aes_xts_256_test(void)
 
     ret = wc_AesXtsEncrypt(aes, buf, p2, sizeof(p2), i2, sizeof(i2));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -2075,7 +2096,7 @@ static int aes_xts_256_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsEncrypt(aes, buf, p1, sizeof(p1), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -2086,7 +2107,7 @@ static int aes_xts_256_test(void)
     XMEMSET(cipher, 0, sizeof(cipher));
     ret = wc_AesXtsEncrypt(aes, cipher, pp, sizeof(pp), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -2098,7 +2119,7 @@ static int aes_xts_256_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsDecrypt(aes, buf, cipher, sizeof(pp), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -2109,7 +2130,7 @@ static int aes_xts_256_test(void)
     XMEMSET(buf, 0, sizeof(buf));
     ret = wc_AesXtsDecrypt(aes, buf, c1, sizeof(c1), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -2122,7 +2143,7 @@ static int aes_xts_256_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsDecrypt(aes, buf, c2, sizeof(c2), i2, sizeof(i2));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -2361,15 +2382,18 @@ static int linuxkm_lkcapi_register(void)
     int ret = 0;
 
 #define REGISTER_ALG(alg, installer, tester) do {                       \
-        if (alg ## _loaded) {\
-            pr_err("ERROR: %s is already registered.\n", (alg).base.cra_driver_name); \
+        if (alg ## _loaded) {                                           \
+            pr_err("ERROR: %s is already registered.\n",                \
+                   (alg).base.cra_driver_name);                         \
             return -EEXIST;                                             \
         }                                                               \
                                                                         \
         ret =  (installer)(&(alg));                                     \
                                                                         \
         if (ret) {                                                      \
-            pr_err("ERROR: " #installer " for %s failed with return code %d.\n", (alg).base.cra_driver_name, ret); \
+            pr_err("ERROR: " #installer " for %s failed "               \
+                   "with return code %d.\n",                            \
+                   (alg).base.cra_driver_name, ret);                    \
             return ret;                                                 \
         }                                                               \
                                                                         \
@@ -2378,33 +2402,43 @@ static int linuxkm_lkcapi_register(void)
         ret = (tester());                                               \
                                                                         \
         if (ret) {                                                      \
-            pr_err("ERROR: self-test for %s failed with return code %d.\n", (alg).base.cra_driver_name, ret); \
+            pr_err("ERROR: self-test for %s failed "                    \
+                   "with return code %d.\n",                            \
+                   (alg).base.cra_driver_name, ret);                    \
             return ret;                                                 \
         }                                                               \
-        pr_info("%s self-test OK -- registered for %s with priority %d.\n", (alg).base.cra_driver_name, (alg).base.cra_name, (alg).base.cra_priority); \
+        pr_info("%s self-test OK -- "                                   \
+                "registered for %s with priority %d.\n",                \
+                (alg).base.cra_driver_name,                             \
+                (alg).base.cra_name,                                    \
+                (alg).base.cra_priority);                               \
     } while (0)
 
 #if defined(HAVE_AES_CBC) && \
-    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESCBC))
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || \
+     defined(LINUXKM_LKCAPI_REGISTER_AESCBC))
 
     REGISTER_ALG(cbcAesAlg, crypto_register_skcipher, linuxkm_test_aescbc);
 #endif
 
 #if defined(WOLFSSL_AES_CFB) && \
-    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESCFB))
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || \
+     defined(LINUXKM_LKCAPI_REGISTER_AESCFB))
 
     REGISTER_ALG(cfbAesAlg, crypto_register_skcipher, linuxkm_test_aescfb);
 #endif
 
 #if defined(HAVE_AESGCM) && \
-    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESGCM)) && \
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || \
+     defined(LINUXKM_LKCAPI_REGISTER_AESGCM)) &&                        \
     (! (defined(WOLFSSL_AESNI) && defined(WC_AES_C_DYNAMIC_FALLBACK)))
 
     REGISTER_ALG(gcmAesAead, crypto_register_aead, linuxkm_test_aesgcm);
 #endif
 
 #if defined(WOLFSSL_AES_XTS) && \
-    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESXTS))
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || \
+     defined(LINUXKM_LKCAPI_REGISTER_AESXTS))
 
     REGISTER_ALG(xtsAesAlg, crypto_register_skcipher, linuxkm_test_aesxts);
 #endif
@@ -2416,33 +2450,38 @@ static int linuxkm_lkcapi_register(void)
 
 static void linuxkm_lkcapi_unregister(void)
 {
+#define UNREGISTER_ALG(alg, uninstaller) do {                           \
+        if (alg ## _loaded) {                                           \
+            (uninstaller)(&(alg));                                      \
+            alg ## _loaded = 0;                                         \
+        }                                                               \
+    } while (0)
+
 #if defined(HAVE_AES_CBC) && \
-    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESCBC))
-    if (cbcAesAlg_loaded) {
-        crypto_unregister_skcipher(&cbcAesAlg);
-        cbcAesAlg_loaded = 0;
-    }
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || \
+     defined(LINUXKM_LKCAPI_REGISTER_AESCBC))
+
+    UNREGISTER_ALG(cbcAesAlg, crypto_unregister_skcipher);
 #endif
 #if defined(WOLFSSL_AES_CFB) && \
-    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESCFB))
-    if (cfbAesAlg_loaded) {
-        crypto_unregister_skcipher(&cfbAesAlg);
-        cfbAesAlg_loaded = 0;
-    }
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || \
+     defined(LINUXKM_LKCAPI_REGISTER_AESCFB))
+
+    UNREGISTER_ALG(cfbAesAlg, crypto_unregister_skcipher);
 #endif
 #if defined(HAVE_AESGCM) && \
-    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESGCM)) && \
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || \
+     defined(LINUXKM_LKCAPI_REGISTER_AESGCM)) && \
     (! (defined(WOLFSSL_AESNI) && defined(WC_AES_C_DYNAMIC_FALLBACK)))
-    if (gcmAesAead_loaded) {
-        crypto_unregister_aead(&gcmAesAead);
-        gcmAesAead_loaded = 0;
-    }
+
+    UNREGISTER_ALG(gcmAesAead, crypto_unregister_aead);
 #endif
 #if defined(WOLFSSL_AES_XTS) && \
-    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || defined(LINUXKM_LKCAPI_REGISTER_AESXTS))
-    if (xtsAesAlg_loaded) {
-        crypto_unregister_skcipher(&xtsAesAlg);
-        xtsAesAlg_loaded = 0;
-    }
+    (defined(LINUXKM_LKCAPI_REGISTER_ALL) || \
+     defined(LINUXKM_LKCAPI_REGISTER_AESXTS))
+
+    UNREGISTER_ALG(xtsAesAlg, crypto_unregister_skcipher);
 #endif
+
+#undef UNREGISTER_ALG
 }

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -760,11 +760,19 @@ static int updateFipsHash(void)
         }
     }
 
-    if (XMEMCMP(hash, binVerify, WC_SHA256_DIGEST_SIZE) == 0)
+    if (XMEMCMP(hash, binVerify, WC_SHA256_DIGEST_SIZE) == 0) {
+#if defined(DEBUG_LINUXKM_PIE_SUPPORT) || defined(WOLFSSL_LINUXKM_VERBOSE_DEBUG)
+        pr_info("updateFipsHash: verifyCore already matches [%s]\n", verifyCore);
+#else
         pr_info("updateFipsHash: verifyCore already matches.\n");
-    else {
+#endif
+    } else {
         XMEMCPY(verifyCore, base16_hash, WC_SHA256_DIGEST_SIZE*2 + 1);
+#if defined(DEBUG_LINUXKM_PIE_SUPPORT) || defined(WOLFSSL_LINUXKM_VERBOSE_DEBUG)
+        pr_info("updateFipsHash: verifyCore updated [%s].\n", base16_hash);
+#else
         pr_info("updateFipsHash: verifyCore updated.\n");
+#endif
     }
 
     ret = 0;

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -121,7 +121,6 @@ static int updateFipsHash(void);
 #endif
 
 #ifdef WOLFSSL_LINUXKM_BENCHMARKS
-#undef HAVE_PTHREAD
 #define STRING_USER
 #define NO_MAIN_FUNCTION
 #define current_time benchmark_current_time

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -245,7 +245,8 @@ static int wolfssl_init(void)
         return -ECANCELED;
     }
 
-    pr_info("FIPS 140-3 wolfCrypt-fips v%d.%d.%d%s%s startup self-test succeeded.\n",
+    pr_info("FIPS 140-3 wolfCrypt-fips v%d.%d.%d%s%s startup "
+            "self-test succeeded.\n",
 #ifdef HAVE_FIPS_VERSION_MAJOR
             HAVE_FIPS_VERSION_MAJOR,
 #else
@@ -306,7 +307,8 @@ static int wolfssl_init(void)
     }
     pr_info("wolfCrypt self-test passed.\n");
 #else
-    pr_info("skipping full wolfcrypt_test() (configure with --enable-crypttests to enable).\n");
+    pr_info("skipping full wolfcrypt_test() "
+            "(configure with --enable-crypttests to enable).\n");
 #endif
 
 #ifdef LINUXKM_LKCAPI_REGISTER
@@ -559,12 +561,15 @@ static int set_up_wolfssl_linuxkm_pie_redirect_table(void) {
     /* runtime assert that the table has no null slots after initialization. */
     {
         unsigned long *i;
+        static_assert(sizeof(unsigned long) == sizeof(void *),
+                      "unexpected pointer size");
         for (i = (unsigned long *)&wolfssl_linuxkm_pie_redirect_table;
              i < (unsigned long *)&wolfssl_linuxkm_pie_redirect_table._last_slot;
              ++i)
             if (*i == 0) {
-                pr_err("wolfCrypt container redirect table initialization was incomplete [%lu].\n",
-                       i - (unsigned long *)&wolfssl_linuxkm_pie_redirect_table);
+                pr_err("wolfCrypt container redirect table initialization was "
+                       "incomplete [%lu].\n",
+                       i-(unsigned long *)&wolfssl_linuxkm_pie_redirect_table);
                 return -EFAULT;
             }
     }

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -126,6 +126,34 @@ static int updateFipsHash(void);
 #include "wolfcrypt/benchmark/benchmark.c"
 #endif /* WOLFSSL_LINUXKM_BENCHMARKS */
 
+#ifdef LINUXKM_REGISTER_ALG
+#if defined(NO_AES)
+    #error LINUXKM_REGISTER_ALG requires AES.
+#endif
+
+#if !defined(HAVE_AESGCM) && !defined(HAVe_AES_CBC) && !defined(WOLFSSL_AES_CFB)
+    #error LINUXKM_REGISTER_ALG requires AES-CBC, CFB, or GCM.
+#endif
+
+#if defined(HAVE_AESGCM) && !defined(WOLFSSL_AESGCM_STREAM)
+    #error LINUXKM_REGISTER_ALG requires AESGCM_STREAM.
+#endif
+
+#define WOLFKM_CBC_NAME   "cbc(aes)"
+#define WOLFKM_CFB_NAME   "cfb(aes)"
+#define WOLFKM_GCM_NAME   "gcm(aes)"
+#define WOLFKM_CBC_DRIVER "cbc-aes-wolfcrypt"
+#define WOLFKM_CFB_DRIVER "cfb-aes-wolfcrypt"
+#define WOLFKM_GCM_DRIVER "gcm-aes-wolfcrypt"
+#define WOLFKM_ALG_PRIORITY (100)
+static int  linuxkm_register_alg(void);
+static void linuxkm_unregister_alg(void);
+static int  linuxkm_test_alg(void);
+static int  linuxkm_test_cbc(void);
+static int  linuxkm_test_cfb(void);
+static int  linuxkm_test_gcm(void);
+#endif /* endif LINUXKM_REGISTER_ALG */
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
 static int __init wolfssl_init(void)
 #else
@@ -315,6 +343,27 @@ static int wolfssl_init(void)
         );
 #endif
 
+#if defined(LINUXKM_REGISTER_ALG) && !defined(NO_AES)
+    ret = linuxkm_register_alg();
+
+    if (ret) {
+        pr_err("linuxkm_register_alg failed with return code %d.\n", ret);
+        (void)libwolfssl_cleanup();
+        linuxkm_unregister_alg();
+        msleep(10);
+        return -ECANCELED;
+    }
+
+    ret = linuxkm_test_alg();
+
+    if (ret) {
+        pr_err("linuxkm_test_alg failed with return code %d.\n", ret);
+        (void)libwolfssl_cleanup();
+        linuxkm_unregister_alg();
+        msleep(10);
+        return -ECANCELED;
+    }
+#endif
     return 0;
 }
 
@@ -328,6 +377,9 @@ static void wolfssl_exit(void)
 {
     (void)libwolfssl_cleanup();
 
+#if defined(LINUXKM_REGISTER_ALG) && !defined(NO_AES)
+    linuxkm_unregister_alg();
+#endif
     return;
 }
 
@@ -739,3 +791,1134 @@ static int updateFipsHash(void)
 }
 
 #endif /* WOLFCRYPT_FIPS_CORE_DYNAMIC_HASH_VALUE */
+
+
+#if defined(LINUXKM_REGISTER_ALG) && !defined(NO_AES)
+#include <linux/crypto.h>
+
+PRAGMA_GCC_DIAG_PUSH;
+PRAGMA_GCC("GCC diagnostic ignored \"-Wnested-externs\"");
+PRAGMA_GCC("GCC diagnostic ignored \"-Wpointer-arith\"");
+PRAGMA_GCC("GCC diagnostic ignored \"-Wpointer-sign\"");
+PRAGMA_GCC("GCC diagnostic ignored \"-Wbad-function-cast\"");
+PRAGMA_GCC("GCC diagnostic ignored \"-Wunused-parameter\"");
+#include <linux/scatterlist.h>
+#include <crypto/scatterwalk.h>
+#include <crypto/internal/aead.h>
+#include <crypto/internal/skcipher.h>
+PRAGMA_GCC_DIAG_POP;
+
+/* km_AesX(): wrappers to wolfcrypt wc_AesX functions and
+ * structures.  */
+
+struct km_AesCtx {
+    Aes          aes;
+    u8           key[AES_MAX_KEY_SIZE / 8];
+    unsigned int keylen;
+};
+
+static inline void km_ForceZero(struct km_AesCtx * ctx)
+{
+    memzero_explicit(ctx->key, sizeof(ctx->key));
+    ctx->keylen = 0;
+}
+
+static int km_AesInitCommon(struct km_AesCtx * ctx, const char * name)
+{
+    int err = wc_AesInit(&ctx->aes, NULL, INVALID_DEVID);
+
+    if (unlikely(err)) {
+        pr_err("error: km_AesInitCommon %s failed: %d\n", name, err);
+        return err;
+    }
+
+    return 0;
+}
+
+static void km_AesExitCommon(struct km_AesCtx * ctx)
+{
+    wc_AesFree(&ctx->aes);
+    km_ForceZero(ctx);
+}
+
+static int km_AesSetKeyCommon(struct km_AesCtx * ctx, const u8 *in_key,
+                              unsigned int key_len, const char * name)
+{
+    int err = wc_AesSetKey(&ctx->aes, in_key, key_len, NULL, 0);
+
+    if (unlikely(err)) {
+        pr_err("error: km_AesSetKeyCommon %s failed: %d\n", name, err);
+        return err;
+    }
+
+    XMEMCPY(ctx->key, in_key, key_len);
+    ctx->keylen = key_len;
+
+    return 0;
+}
+
+static int km_AesInit(struct crypto_skcipher *tfm)
+{
+    struct km_AesCtx * ctx = crypto_skcipher_ctx(tfm);
+    return km_AesInitCommon(ctx, WOLFKM_CBC_DRIVER);
+}
+
+static void km_AesExit(struct crypto_skcipher *tfm)
+{
+    struct km_AesCtx * ctx = crypto_skcipher_ctx(tfm);
+    km_AesExitCommon(ctx);
+}
+
+static int km_AesSetKey(struct crypto_skcipher *tfm, const u8 *in_key,
+                          unsigned int key_len)
+{
+    struct km_AesCtx * ctx = crypto_skcipher_ctx(tfm);
+    return km_AesSetKeyCommon(ctx, in_key, key_len, WOLFKM_CBC_DRIVER);
+}
+
+#if defined(HAVE_AES_CBC)
+static int km_AesCbcEncrypt(struct skcipher_request *req)
+{
+    struct crypto_skcipher * tfm = NULL;
+    struct km_AesCtx *       ctx = NULL;
+    struct skcipher_walk     walk;
+    unsigned int             nbytes = 0;
+    int                      err = 0;
+
+    tfm = crypto_skcipher_reqtfm(req);
+    ctx = crypto_skcipher_ctx(tfm);
+
+    err = skcipher_walk_virt(&walk, req, false);
+
+    while ((nbytes = walk.nbytes)) {
+        err = wc_AesSetKey(&ctx->aes, ctx->key, ctx->keylen, walk.iv,
+                           AES_ENCRYPTION);
+
+        if (unlikely(err)) {
+            pr_err("wc_AesSetKey failed: %d\n", err);
+            return err;
+        }
+
+        err = wc_AesCbcEncrypt(&ctx->aes, walk.dst.virt.addr,
+                               walk.src.virt.addr, nbytes);
+
+        if (unlikely(err)) {
+            pr_err("wc_AesCbcEncrypt failed %d\n", err);
+            return err;
+        }
+
+        err = skcipher_walk_done(&walk, walk.nbytes - nbytes);
+    }
+
+    return err;
+}
+
+static int km_AesCbcDecrypt(struct skcipher_request *req)
+{
+    struct crypto_skcipher * tfm = NULL;
+    struct km_AesCtx *       ctx = NULL;
+    struct skcipher_walk     walk;
+    unsigned int             nbytes = 0;
+    int                      err = 0;
+
+    tfm = crypto_skcipher_reqtfm(req);
+    ctx = crypto_skcipher_ctx(tfm);
+
+    err = skcipher_walk_virt(&walk, req, false);
+
+    while ((nbytes = walk.nbytes)) {
+        err = wc_AesSetKey(&ctx->aes, ctx->key, ctx->keylen, walk.iv,
+                           AES_DECRYPTION);
+
+        if (unlikely(err)) {
+            pr_err("wc_AesSetKey failed");
+            return err;
+        }
+
+        err = wc_AesCbcDecrypt(&ctx->aes, walk.dst.virt.addr,
+                               walk.src.virt.addr, nbytes);
+
+        if (unlikely(err)) {
+            pr_err("wc_AesCbcDecrypt failed");
+            return err;
+        }
+
+        err = skcipher_walk_done(&walk, walk.nbytes - nbytes);
+    }
+
+    return err;
+}
+#endif /* endif HAVE_AES_CBC */
+
+#if defined(WOLFSSL_AES_CFB)
+static int km_AesCfbEncrypt(struct skcipher_request *req)
+{
+    struct crypto_skcipher * tfm = NULL;
+    struct km_AesCtx *       ctx = NULL;
+    struct skcipher_walk     walk;
+    unsigned int             nbytes = 0;
+    int                      err = 0;
+
+    tfm = crypto_skcipher_reqtfm(req);
+    ctx = crypto_skcipher_ctx(tfm);
+
+    err = skcipher_walk_virt(&walk, req, false);
+
+    while ((nbytes = walk.nbytes)) {
+        err = wc_AesSetKey(&ctx->aes, ctx->key, ctx->keylen, walk.iv,
+                           AES_ENCRYPTION);
+
+        if (unlikely(err)) {
+            pr_err("wc_AesSetKey failed: %d\n", err);
+            return err;
+        }
+
+        err = wc_AesCfbEncrypt(&ctx->aes, walk.dst.virt.addr,
+                               walk.src.virt.addr, nbytes);
+
+        if (unlikely(err)) {
+            pr_err("wc_AesCfbEncrypt failed %d\n", err);
+            return err;
+        }
+
+        err = skcipher_walk_done(&walk, walk.nbytes - nbytes);
+    }
+
+    return err;
+}
+
+static int km_AesCfbDecrypt(struct skcipher_request *req)
+{
+    struct crypto_skcipher * tfm = NULL;
+    struct km_AesCtx *       ctx = NULL;
+    struct skcipher_walk     walk;
+    unsigned int             nbytes = 0;
+    int                      err = 0;
+
+    tfm = crypto_skcipher_reqtfm(req);
+    ctx = crypto_skcipher_ctx(tfm);
+
+    err = skcipher_walk_virt(&walk, req, false);
+
+    while ((nbytes = walk.nbytes)) {
+        err = wc_AesSetKey(&ctx->aes, ctx->key, ctx->keylen, walk.iv,
+                           AES_ENCRYPTION);
+
+        if (unlikely(err)) {
+            pr_err("wc_AesSetKey failed");
+            return err;
+        }
+
+        err = wc_AesCfbDecrypt(&ctx->aes, walk.dst.virt.addr,
+                               walk.src.virt.addr, nbytes);
+
+        if (unlikely(err)) {
+            pr_err("wc_AesCfbDecrypt failed");
+            return err;
+        }
+
+        err = skcipher_walk_done(&walk, walk.nbytes - nbytes);
+    }
+
+    return err;
+}
+#endif /* endif WOLFSSL_AES_CFB */
+
+
+#if defined(HAVE_AESGCM)
+static int km_AesGcmInit(struct crypto_aead * tfm)
+{
+    struct km_AesCtx * ctx = crypto_aead_ctx(tfm);
+    km_ForceZero(ctx);
+    return km_AesInitCommon(ctx, WOLFKM_GCM_DRIVER);
+}
+
+static void km_AesGcmExit(struct crypto_aead * tfm)
+{
+    struct km_AesCtx * ctx = crypto_aead_ctx(tfm);
+    km_AesExitCommon(ctx);
+}
+
+static int km_AesGcmSetKey(struct crypto_aead *tfm, const u8 *in_key,
+                           unsigned int key_len)
+{
+    struct km_AesCtx * ctx = crypto_aead_ctx(tfm);
+    return km_AesSetKeyCommon(ctx, in_key, key_len, WOLFKM_GCM_DRIVER);
+}
+
+static int km_AesGcmSetAuthsize(struct crypto_aead *tfm, unsigned int authsize)
+{
+    (void)tfm;
+    if (authsize > AES_BLOCK_SIZE ||
+        authsize < WOLFSSL_MIN_AUTH_TAG_SZ) {
+        pr_err("error: invalid authsize: %d\n", authsize);
+        return -EINVAL;
+    }
+    return 0;
+}
+
+/*
+ * aead ciphers recieve data in scatterlists in following order:
+ *   encrypt
+ *     req->src: aad||plaintext
+ *     req->dst: aad||ciphertext||tag
+ *   decrypt
+ *     req->src: aad||ciphertext||tag
+ *     req->dst: aad||plaintext, return 0 or -EBADMSG
+ */
+
+static int km_AesGcmEncrypt(struct aead_request *req)
+{
+    struct crypto_aead * tfm = NULL;
+    struct km_AesCtx *   ctx = NULL;
+    struct skcipher_walk walk;
+    struct scatter_walk  assocSgWalk;
+    unsigned int         nbytes = 0;
+    u8                   authTag[AES_BLOCK_SIZE];
+    int                  err = 0;
+    unsigned int         assocLeft = 0;
+    unsigned int         cryptLeft = 0;
+    u8 *                 assoc = NULL;
+
+    tfm = crypto_aead_reqtfm(req);
+    ctx = crypto_aead_ctx(tfm);
+    assocLeft = req->assoclen;
+    cryptLeft = req->cryptlen;
+
+    scatterwalk_start(&assocSgWalk, req->src);
+
+    err = skcipher_walk_aead_encrypt(&walk, req, false);
+    if (unlikely(err)) {
+        pr_err("error: skcipher_walk_aead_encrypt: %d\n", err);
+        return -1;
+    }
+
+    err = wc_AesGcmInit(&ctx->aes, ctx->key, ctx->keylen, walk.iv,
+                        AES_BLOCK_SIZE);
+    if (unlikely(err)) {
+        pr_err("error: wc_AesGcmInit failed with return code %d.\n", err);
+        return err;
+    }
+
+    assoc = scatterwalk_map(&assocSgWalk);
+    if (unlikely(IS_ERR(assoc))) {
+        pr_err("error: scatterwalk_map failed %ld\n", PTR_ERR(assoc));
+        return err;
+    }
+
+    err = wc_AesGcmEncryptUpdate(&ctx->aes, NULL, NULL, 0, assoc, assocLeft);
+    assocLeft -= assocLeft;
+    scatterwalk_unmap(assoc);
+    assoc = NULL;
+
+    if (unlikely(err)) {
+        pr_err("error: wc_AesGcmEncryptUpdate failed %d\n", err);
+        return err;
+    }
+
+    while ((nbytes = walk.nbytes)) {
+        int n = nbytes;
+
+        if (likely(cryptLeft && nbytes)) {
+            n = cryptLeft < nbytes ? cryptLeft : nbytes;
+
+            err = wc_AesGcmEncryptUpdate(&ctx->aes, walk.dst.virt.addr,
+                                         walk.src.virt.addr, cryptLeft, NULL, 0);
+            nbytes -= n;
+            cryptLeft -= n;
+        }
+
+        if (unlikely(err)) {
+            pr_err("wc_AesGcmEncryptUpdate failed %d\n", err);
+            return err;
+        }
+
+        err = skcipher_walk_done(&walk, nbytes);
+    }
+
+    err = wc_AesGcmEncryptFinal(&ctx->aes, authTag, tfm->authsize);
+    if (unlikely(err)) {
+        pr_err("error: wc_AesGcmEncryptFinal failed with return code %d\n", err);
+        return err;
+    }
+
+    /* Now copy the auth tag into request scatterlist. */
+    scatterwalk_map_and_copy(authTag, req->dst,
+                             req->assoclen + req->cryptlen,
+                             tfm->authsize, 1);
+
+    return err;
+}
+
+static int km_AesGcmDecrypt(struct aead_request *req)
+{
+    struct crypto_aead * tfm = NULL;
+    struct km_AesCtx *   ctx = NULL;
+    struct skcipher_walk walk;
+    struct scatter_walk  assocSgWalk;
+    unsigned int         nbytes = 0;
+    u8                   origAuthTag[AES_BLOCK_SIZE];
+    int                  err = 0;
+    unsigned int         assocLeft = 0;
+    unsigned int         cryptLeft = 0;
+    u8 *                 assoc = NULL;
+
+    tfm = crypto_aead_reqtfm(req);
+    ctx = crypto_aead_ctx(tfm);
+    assocLeft = req->assoclen;
+    cryptLeft = req->cryptlen - tfm->authsize;
+
+    /* Copy out original auth tag from req->src. */
+    scatterwalk_map_and_copy(origAuthTag, req->src,
+                             req->assoclen + req->cryptlen - tfm->authsize,
+                             tfm->authsize, 0);
+
+    scatterwalk_start(&assocSgWalk, req->src);
+
+    err = skcipher_walk_aead_decrypt(&walk, req, false);
+    if (unlikely(err)) {
+        pr_err("error: skcipher_walk_aead_decrypt: %d\n", err);
+        return -1;
+    }
+
+    err = wc_AesGcmInit(&ctx->aes, ctx->key, ctx->keylen, walk.iv,
+                        AES_BLOCK_SIZE);
+    if (unlikely(err)) {
+        pr_err("error: wc_AesGcmInit failed with return code %d.\n", err);
+        return err;
+    }
+
+    assoc = scatterwalk_map(&assocSgWalk);
+    if (unlikely(IS_ERR(assoc))) {
+        pr_err("error: scatterwalk_map failed %ld\n", PTR_ERR(assoc));
+        return err;
+    }
+
+    err = wc_AesGcmDecryptUpdate(&ctx->aes, NULL, NULL, 0, assoc, assocLeft);
+    assocLeft -= assocLeft;
+    scatterwalk_unmap(assoc);
+    assoc = NULL;
+
+    if (unlikely(err)) {
+        pr_err("error: wc_AesGcmDecryptUpdate failed %d\n", err);
+        return err;
+    }
+
+    while ((nbytes = walk.nbytes)) {
+        int n = nbytes;
+
+        if (likely(cryptLeft && nbytes)) {
+            n = cryptLeft < nbytes ? cryptLeft : nbytes;
+
+            err = wc_AesGcmDecryptUpdate(&ctx->aes, walk.dst.virt.addr,
+                                         walk.src.virt.addr, cryptLeft, NULL, 0);
+            nbytes -= n;
+            cryptLeft -= n;
+        }
+
+        if (unlikely(err)) {
+            pr_err("wc_AesGcmDecryptUpdate failed %d\n", err);
+            return err;
+        }
+
+        err = skcipher_walk_done(&walk, nbytes);
+    }
+
+    err = wc_AesGcmDecryptFinal(&ctx->aes, origAuthTag, tfm->authsize);
+    if (unlikely(err)) {
+        pr_err("error: wc_AesGcmDecryptFinal failed with return code %d\n", err);
+
+        if (err == AES_GCM_AUTH_E) {
+            return -EBADMSG;
+        }
+        else {
+            return err;
+        }
+    }
+
+    return err;
+}
+#endif /* endif HAVE_AESGCM */
+
+#if defined(HAVE_AES_CBC)
+static struct skcipher_alg cbcAesAlg = {
+    .base.cra_name        = WOLFKM_CBC_NAME,
+    .base.cra_driver_name = WOLFKM_CBC_DRIVER,
+    .base.cra_priority    = WOLFKM_ALG_PRIORITY,
+    .base.cra_blocksize   = AES_BLOCK_SIZE,
+    .base.cra_ctxsize     = sizeof(struct km_AesCtx),
+    .base.cra_module      = THIS_MODULE,
+    .init                 = km_AesInit,
+    .exit                 = km_AesExit,
+    .min_keysize          = (128 / 8),
+    .max_keysize          = (AES_MAX_KEY_SIZE / 8),
+    .ivsize               = AES_BLOCK_SIZE,
+    .setkey               = km_AesSetKey,
+    .encrypt              = km_AesCbcEncrypt,
+    .decrypt              = km_AesCbcDecrypt,
+};
+#endif
+
+#if defined(WOLFSSL_AES_CFB)
+static struct skcipher_alg cfbAesAlg = {
+    .base.cra_name        = WOLFKM_CFB_NAME,
+    .base.cra_driver_name = WOLFKM_CFB_DRIVER,
+    .base.cra_priority    = WOLFKM_ALG_PRIORITY,
+    .base.cra_blocksize   = AES_BLOCK_SIZE,
+    .base.cra_ctxsize     = sizeof(struct km_AesCtx),
+    .base.cra_module      = THIS_MODULE,
+    .init                 = km_AesInit,
+    .exit                 = km_AesExit,
+    .min_keysize          = (128 / 8),
+    .max_keysize          = (AES_MAX_KEY_SIZE / 8),
+    .ivsize               = AES_BLOCK_SIZE,
+    .setkey               = km_AesSetKey,
+    .encrypt              = km_AesCfbEncrypt,
+    .decrypt              = km_AesCfbDecrypt,
+};
+#endif
+
+#if defined(HAVE_AESGCM)
+static struct aead_alg gcmAesAead = {
+    .base.cra_name        = WOLFKM_GCM_NAME,
+    .base.cra_driver_name = WOLFKM_GCM_DRIVER,
+    .base.cra_priority    = WOLFKM_ALG_PRIORITY,
+    .base.cra_blocksize   = 1,
+    .base.cra_ctxsize     = sizeof(struct km_AesCtx),
+    .base.cra_module      = THIS_MODULE,
+    .init                 = km_AesGcmInit,
+    .exit                 = km_AesGcmExit,
+    .setkey               = km_AesGcmSetKey,
+    .setauthsize          = km_AesGcmSetAuthsize,
+    .encrypt              = km_AesGcmEncrypt,
+    .decrypt              = km_AesGcmDecrypt,
+    .ivsize               = AES_BLOCK_SIZE,
+    .maxauthsize          = AES_BLOCK_SIZE,
+    .chunksize            = AES_BLOCK_SIZE,
+};
+#endif
+
+static int linuxkm_register_alg(void)
+{
+    int ret = 0;
+#if defined(HAVE_AES_CBC)
+    ret =  crypto_register_skcipher(&cbcAesAlg);
+
+    if (ret) {
+        pr_err("crypto_register_skcipher failed with return code %d.\n", ret);
+        return ret;
+    }
+#endif
+
+#if defined(WOLFSSL_AES_CFB)
+    ret =  crypto_register_skcipher(&cfbAesAlg);
+
+    if (ret) {
+        pr_err("crypto_register_skcipher failed with return code %d.\n", ret);
+        return ret;
+    }
+#endif
+
+#if defined(HAVE_AESGCM)
+    ret =  crypto_register_aead(&gcmAesAead);
+
+    if (ret) {
+        pr_err("crypto_register_aead failed with return code %d.\n", ret);
+        return ret;
+    }
+#endif
+
+    return 0;
+}
+
+static void linuxkm_unregister_alg(void)
+{
+#if defined(HAVE_AES_CBC)
+    crypto_unregister_skcipher(&cbcAesAlg);
+#endif
+#if defined(WOLFSSL_AES_CFB)
+    crypto_unregister_skcipher(&cfbAesAlg);
+#endif
+#if defined(HAVE_AESGCM)
+    crypto_unregister_aead(&gcmAesAead);
+#endif
+}
+
+/* Given registered wolfcrypt kernel crypto, sanity test against
+ * direct wolfcrypt calls. */
+
+static int linuxkm_test_alg(void)
+{
+    int ret = 0;
+
+    ret = linuxkm_test_cbc();
+    if (ret) { return ret; }
+
+    ret = linuxkm_test_cfb();
+    if (ret) { return ret; }
+
+    ret = linuxkm_test_gcm();
+    if (ret) { return ret; }
+
+    return 0;
+}
+
+static int linuxkm_test_cbc(void)
+{
+    int     ret = 0;
+#if defined(HAVE_AES_CBC)
+    struct crypto_skcipher *  tfm = NULL;
+    struct skcipher_request * req = NULL;
+    struct scatterlist        src, dst;
+    Aes     aes;
+    byte    key32[] =
+    {
+        0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+        0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66,
+        0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+        0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66
+    };
+    byte    vector[] = /* Now is the time for all good men w/o trailing 0 */
+    {
+        0x4e,0x6f,0x77,0x20,0x69,0x73,0x20,0x74,
+        0x68,0x65,0x20,0x74,0x69,0x6d,0x65,0x20,
+        0x66,0x6f,0x72,0x20,0x61,0x6c,0x6c,0x20,
+        0x67,0x6f,0x6f,0x64,0x20,0x6d,0x65,0x6e
+    };
+    byte    iv[]    = "1234567890abcdef";
+    byte    enc[sizeof(vector)];
+    byte    dec[sizeof(vector)];
+    u8 *    enc2 = NULL;
+    u8 *    dec2 = NULL;
+
+    XMEMSET(enc, 0, sizeof(enc));
+    XMEMSET(dec, 0, sizeof(enc));
+
+    ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
+    if (ret) {
+        pr_err("wolfcrypt wc_AesInit failed with return code %d.\n", ret);
+        return -1;
+    }
+
+    ret = wc_AesSetKey(&aes, key32, AES_BLOCK_SIZE * 2, iv, AES_ENCRYPTION);
+    if (ret) {
+        pr_err("wolfcrypt wc_AesSetKey failed with return code %d\n", ret);
+        return -1;
+    }
+
+    ret = wc_AesCbcEncrypt(&aes, enc, vector, sizeof(vector));
+    if (ret) {
+        pr_err("wolfcrypt wc_AesCbcEncrypt failed with return code %d\n", ret);
+        return -1;
+    }
+
+    /* Re init for decrypt and set flag. */
+    wc_AesFree(&aes);
+
+    ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
+    if (ret) {
+        pr_err("wolfcrypt wc_AesInit failed with return code %d.\n", ret);
+        return -1;
+    }
+
+    ret = wc_AesSetKey(&aes, key32, AES_BLOCK_SIZE * 2, iv, AES_DECRYPTION);
+    if (ret) {
+        pr_err("wolfcrypt wc_AesSetKey failed with return code %d.\n", ret);
+        return -1;
+    }
+
+    ret = wc_AesCbcDecrypt(&aes, dec, enc, sizeof(vector));
+    if (ret) {
+        pr_err("wolfcrypt wc_AesCbcDecrypt failed with return code %d\n", ret);
+        return -1;
+    }
+
+    ret = XMEMCMP(vector, dec, sizeof(vector));
+    if (ret) {
+        pr_err("error: vector and dec do not match: %d\n", ret);
+        return -1;
+    }
+
+    /* now the kernel crypto part */
+    enc2 = kmalloc(sizeof(vector), GFP_KERNEL);
+    if (!enc2) {
+        pr_err("error: kmalloc failed\n");
+        goto test_cbc_end;
+    }
+
+    dec2 = kmalloc(sizeof(vector), GFP_KERNEL);
+    if (!dec2) {
+        pr_err("error: kmalloc failed\n");
+        goto test_cbc_end;
+    }
+
+    memcpy(dec2, vector, sizeof(vector));
+
+    tfm = crypto_alloc_skcipher(WOLFKM_CBC_DRIVER, 0, 0);
+    if (IS_ERR(tfm)) {
+        pr_err("error: allocating AES skcipher algorithm %s failed: %ld\n",
+               WOLFKM_CBC_DRIVER, PTR_ERR(tfm));
+        goto test_cbc_end;
+    }
+
+    ret = crypto_skcipher_setkey(tfm, key32, AES_BLOCK_SIZE * 2);
+    if (ret) {
+        pr_err("error: crypto_skcipher_setkey returned: %d\n", ret);
+        goto test_cbc_end;
+    }
+
+    req = skcipher_request_alloc(tfm, GFP_KERNEL);
+    if (IS_ERR(req)) {
+        pr_err("error: allocating AES skcipher request %s failed\n",
+               WOLFKM_CBC_DRIVER);
+        goto test_cbc_end;
+    }
+
+    sg_init_one(&src, dec2, sizeof(vector));
+    sg_init_one(&dst, enc2, sizeof(vector));
+
+    skcipher_request_set_crypt(req, &src, &dst, sizeof(vector), iv);
+
+    ret = crypto_skcipher_encrypt(req);
+
+    if (ret) {
+        pr_err("error: crypto_skcipher_encrypt returned: %d\n", ret);
+        goto test_cbc_end;
+    }
+
+    ret = XMEMCMP(enc, enc2, sizeof(vector));
+    if (ret) {
+        pr_err("error: enc and enc2 do not match: %d\n", ret);
+        goto test_cbc_end;
+    }
+
+    memset(dec2, 0, sizeof(vector));
+    sg_init_one(&src, enc2, sizeof(vector));
+    sg_init_one(&dst, dec2, sizeof(vector));
+
+    skcipher_request_set_crypt(req, &src, &dst, sizeof(vector), iv);
+
+    ret = crypto_skcipher_decrypt(req);
+
+    if (ret) {
+        pr_err("error: crypto_skcipher_decrypt returned: %d\n", ret);
+        goto test_cbc_end;
+    }
+
+    ret = XMEMCMP(dec, dec2, sizeof(vector));
+    if (ret) {
+        pr_err("error: dec and dec2 do not match: %d\n", ret);
+        goto test_cbc_end;
+    }
+
+    pr_info("info: test driver %s: good\n", WOLFKM_CBC_DRIVER);
+
+test_cbc_end:
+
+    if (enc2) { kfree(enc2); enc2 = NULL; }
+    if (dec2) { kfree(dec2); dec2 = NULL; }
+    if (req) { skcipher_request_free(req); req = NULL; }
+    if (tfm) { crypto_free_skcipher(tfm); tfm = NULL; }
+
+#endif /* if defined HAVE_AES_CBC */
+    return ret;
+}
+
+static int linuxkm_test_cfb(void)
+{
+    int ret = 0;
+#if defined(WOLFSSL_AES_CFB)
+    struct crypto_skcipher *  tfm = NULL;
+    struct skcipher_request * req = NULL;
+    struct scatterlist        src, dst;
+    Aes     aes;
+    byte    key32[] =
+    {
+        0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+        0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66,
+        0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+        0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66
+    };
+    byte    vector[] = /* Now is the time for all good men w/o trailing 0 */
+    {
+        0x4e,0x6f,0x77,0x20,0x69,0x73,0x20,0x74,
+        0x68,0x65,0x20,0x74,0x69,0x6d,0x65,0x20,
+        0x66,0x6f,0x72,0x20,0x61,0x6c,0x6c,0x20,
+        0x67,0x6f,0x6f,0x64,0x20,0x6d,0x65,0x6e
+    };
+    byte    iv[]    = "1234567890abcdef";
+    byte    enc[sizeof(vector)];
+    byte    dec[sizeof(vector)];
+    u8 *    enc2 = NULL;
+    u8 *    dec2 = NULL;
+
+    XMEMSET(enc, 0, sizeof(enc));
+    XMEMSET(dec, 0, sizeof(enc));
+
+    ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
+    if (ret) {
+        pr_err("wolfcrypt wc_AesInit failed with return code %d.\n", ret);
+        return -1;
+    }
+
+    ret = wc_AesSetKey(&aes, key32, AES_BLOCK_SIZE * 2, iv, AES_ENCRYPTION);
+    if (ret) {
+        pr_err("wolfcrypt wc_AesSetKey failed with return code %d\n", ret);
+        return -1;
+    }
+
+    ret = wc_AesCfbEncrypt(&aes, enc, vector, sizeof(vector));
+    if (ret) {
+        pr_err("wolfcrypt wc_AesCfbEncrypt failed with return code %d\n", ret);
+        return -1;
+    }
+
+    /* Re init for decrypt and set flag. */
+    wc_AesFree(&aes);
+
+    ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
+    if (ret) {
+        pr_err("wolfcrypt wc_AesInit failed with return code %d.\n", ret);
+        return -1;
+    }
+
+    ret = wc_AesSetKey(&aes, key32, AES_BLOCK_SIZE * 2, iv, AES_ENCRYPTION);
+    if (ret) {
+        pr_err("wolfcrypt wc_AesSetKey failed with return code %d.\n", ret);
+        return -1;
+    }
+
+    ret = wc_AesCfbDecrypt(&aes, dec, enc, sizeof(vector));
+    if (ret) {
+        pr_err("wolfcrypt wc_AesCfbDecrypt failed with return code %d\n", ret);
+        return -1;
+    }
+
+    ret = XMEMCMP(vector, dec, sizeof(vector));
+    if (ret) {
+        pr_err("error: vector and dec do not match: %d\n", ret);
+        return -1;
+    }
+
+    /* now the kernel crypto part */
+    enc2 = kmalloc(sizeof(vector), GFP_KERNEL);
+    if (!enc2) {
+        pr_err("error: kmalloc failed\n");
+        goto test_cfb_end;
+    }
+
+    dec2 = kmalloc(sizeof(vector), GFP_KERNEL);
+    if (!dec2) {
+        pr_err("error: kmalloc failed\n");
+        goto test_cfb_end;
+    }
+
+    memcpy(dec2, vector, sizeof(vector));
+
+    tfm = crypto_alloc_skcipher(WOLFKM_CFB_DRIVER, 0, 0);
+    if (IS_ERR(tfm)) {
+        pr_err("error: allocating AES skcipher algorithm %s failed: %ld\n",
+               WOLFKM_CFB_DRIVER, PTR_ERR(tfm));
+        goto test_cfb_end;
+    }
+
+    ret = crypto_skcipher_setkey(tfm, key32, AES_BLOCK_SIZE * 2);
+    if (ret) {
+        pr_err("error: crypto_skcipher_setkey returned: %d\n", ret);
+        goto test_cfb_end;
+    }
+
+    req = skcipher_request_alloc(tfm, GFP_KERNEL);
+    if (IS_ERR(req)) {
+        pr_err("error: allocating AES skcipher request %s failed\n",
+               WOLFKM_CFB_DRIVER);
+        goto test_cfb_end;
+    }
+
+    sg_init_one(&src, dec2, sizeof(vector));
+    sg_init_one(&dst, enc2, sizeof(vector));
+
+    skcipher_request_set_crypt(req, &src, &dst, sizeof(vector), iv);
+
+    ret = crypto_skcipher_encrypt(req);
+
+    if (ret) {
+        pr_err("error: crypto_skcipher_encrypt returned: %d\n", ret);
+        goto test_cfb_end;
+    }
+
+    ret = XMEMCMP(enc, enc2, sizeof(vector));
+    if (ret) {
+        pr_err("error: enc and enc2 do not match: %d\n", ret);
+        goto test_cfb_end;
+    }
+
+    memset(dec2, 0, sizeof(vector));
+    sg_init_one(&src, enc2, sizeof(vector));
+    sg_init_one(&dst, dec2, sizeof(vector));
+
+    skcipher_request_set_crypt(req, &src, &dst, sizeof(vector), iv);
+
+    ret = crypto_skcipher_decrypt(req);
+
+    if (ret) {
+        pr_err("error: crypto_skcipher_decrypt returned: %d\n", ret);
+        goto test_cfb_end;
+    }
+
+    ret = XMEMCMP(dec, dec2, sizeof(vector));
+    if (ret) {
+        pr_err("error: dec and dec2 do not match: %d\n", ret);
+        goto test_cfb_end;
+    }
+
+    pr_info("info: test driver %s: good\n", WOLFKM_CFB_DRIVER);
+
+test_cfb_end:
+
+    if (enc2) { kfree(enc2); enc2 = NULL; }
+    if (dec2) { kfree(dec2); dec2 = NULL; }
+    if (req) { skcipher_request_free(req); req = NULL; }
+    if (tfm) { crypto_free_skcipher(tfm); tfm = NULL; }
+#endif /* if defined WOLFSSL_AES_CFB */
+
+    return ret;
+}
+
+static int linuxkm_test_gcm(void)
+{
+    int     ret = 0;
+#if defined(HAVE_AESGCM)
+    struct crypto_aead *  tfm = NULL;
+    struct aead_request * req = NULL;
+    struct scatterlist *  src = NULL;
+    struct scatterlist *  dst = NULL;
+    Aes     aes;
+    byte    key32[] =
+    {
+        0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+        0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66,
+        0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+        0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66
+    };
+    byte    vector[] = /* Now is the time for all w/o trailing 0 */
+    {
+        0x4e,0x6f,0x77,0x20,0x69,0x73,0x20,0x74,
+        0x68,0x65,0x20,0x74,0x69,0x6d,0x65,0x20,
+        0x66,0x6f,0x72,0x20,0x61,0x6c,0x6c,0x20
+    };
+    const byte assoc[] =
+    {
+        0xfe, 0xed, 0xfa, 0xce, 0xde, 0xad, 0xbe, 0xef,
+        0xfe, 0xed, 0xfa, 0xce, 0xde, 0xad, 0xbe, 0xef,
+        0xab, 0xad, 0xda, 0xd2
+    };
+    byte    ivstr[] = "1234567890abcdef";
+    byte    enc[sizeof(vector)];
+    byte    authTag[AES_BLOCK_SIZE];
+    byte    dec[sizeof(vector)];
+    u8 *    assoc2 = NULL;
+    u8 *    enc2 = NULL;
+    u8 *    dec2 = NULL;
+    u8 *    iv = NULL;
+    size_t  encryptLen = sizeof(vector);
+    size_t  decryptLen = sizeof(vector) + sizeof(authTag);
+
+    /* Init stack variables. */
+    XMEMSET(enc, 0, sizeof(vector));
+    XMEMSET(dec, 0, sizeof(vector));
+    XMEMSET(authTag, 0, AES_BLOCK_SIZE);
+
+    ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
+    if (ret) {
+        pr_err("error: wc_AesInit failed with return code %d.\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = wc_AesGcmInit(&aes, key32, sizeof(key32)/sizeof(byte), ivstr,
+                        AES_BLOCK_SIZE);
+    if (ret) {
+        pr_err("error: wc_AesGcmInit failed with return code %d.\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = wc_AesGcmEncryptUpdate(&aes, NULL, NULL, 0, assoc, sizeof(assoc));
+    if (ret) {
+        pr_err("error: wc_AesGcmEncryptUpdate failed with return code %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = wc_AesGcmEncryptUpdate(&aes, enc, vector, sizeof(vector), NULL, 0);
+    if (ret) {
+        pr_err("error: wc_AesGcmEncryptUpdate failed with return code %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = wc_AesGcmEncryptFinal(&aes, authTag, AES_BLOCK_SIZE);
+    if (ret) {
+        pr_err("error: wc_AesGcmEncryptFinal failed with return code %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = wc_AesGcmInit(&aes, key32, sizeof(key32)/sizeof(byte), ivstr,
+                        AES_BLOCK_SIZE);
+    if (ret) {
+        pr_err("error: wc_AesGcmInit failed with return code %d.\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = wc_AesGcmDecryptUpdate(&aes, dec, enc, sizeof(vector), assoc, sizeof(assoc));
+    if (ret) {
+        pr_err("error: wc_AesGcmDecryptUpdate failed with return code %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = wc_AesGcmDecryptFinal(&aes, authTag, AES_BLOCK_SIZE);
+    if (ret) {
+        pr_err("error: wc_AesGcmEncryptFinal failed with return code %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = XMEMCMP(vector, dec, sizeof(vector));
+    if (ret) {
+        pr_err("error: gcm: vector and dec do not match: %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    /* now the kernel crypto part */
+    assoc2 = kmalloc(sizeof(assoc), GFP_KERNEL);
+    if (IS_ERR(assoc2)) {
+        pr_err("error: kmalloc failed\n");
+        goto test_gcm_end;
+    }
+    memset(assoc2, 0, sizeof(assoc));
+    memcpy(assoc2, assoc, sizeof(assoc));
+
+    iv = kmalloc(AES_BLOCK_SIZE, GFP_KERNEL);
+    if (IS_ERR(iv)) {
+        pr_err("error: kmalloc failed\n");
+        goto test_gcm_end;
+    }
+    memset(iv, 0, AES_BLOCK_SIZE);
+    memcpy(iv, ivstr, AES_BLOCK_SIZE);
+
+    enc2 = kmalloc(decryptLen, GFP_KERNEL);
+    if (IS_ERR(enc2)) {
+        pr_err("error: kmalloc failed\n");
+        goto test_gcm_end;
+    }
+
+    dec2 = kmalloc(decryptLen, GFP_KERNEL);
+    if (IS_ERR(dec2)) {
+        pr_err("error: kmalloc failed\n");
+        goto test_gcm_end;
+    }
+
+    memset(enc2, 0, decryptLen);
+    memset(dec2, 0, decryptLen);
+    memcpy(dec2, vector, sizeof(vector));
+
+    tfm = crypto_alloc_aead(WOLFKM_GCM_DRIVER, 0, 0);
+    if (IS_ERR(tfm)) {
+        pr_err("error: allocating AES skcipher algorithm %s failed: %ld\n",
+               WOLFKM_GCM_DRIVER, PTR_ERR(tfm));
+        goto test_gcm_end;
+    }
+
+    ret = crypto_aead_setkey(tfm, key32, AES_BLOCK_SIZE * 2);
+    if (ret) {
+        pr_err("error: crypto_aead_setkey returned: %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = crypto_aead_setauthsize(tfm, sizeof(authTag));
+    if (ret) {
+        pr_err("error: crypto_aead_setauthsize returned: %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    req = aead_request_alloc(tfm, GFP_KERNEL);
+    if (IS_ERR(req)) {
+        pr_err("error: allocating AES aead request %s failed: %ld\n",
+               WOLFKM_CBC_DRIVER, PTR_ERR(req));
+        goto test_gcm_end;
+    }
+
+    src = kmalloc(sizeof(struct scatterlist) * 2, GFP_KERNEL);
+    dst = kmalloc(sizeof(struct scatterlist) * 2, GFP_KERNEL);
+
+    if (IS_ERR(src) || IS_ERR(dst)) {
+        pr_err("error: kmalloc src or dst failed: %ld, %ld\n",
+               PTR_ERR(src), PTR_ERR(dst));
+        goto test_gcm_end;
+    }
+
+    sg_init_table(src, 2);
+    sg_set_buf(src, assoc2, sizeof(assoc));
+    sg_set_buf(&src[1], dec2, sizeof(vector));
+
+    sg_init_table(dst, 2);
+    sg_set_buf(dst, assoc2, sizeof(assoc));
+    sg_set_buf(&dst[1], enc2, decryptLen);
+
+    aead_request_set_callback(req, 0, NULL, NULL);
+    aead_request_set_ad(req, sizeof(assoc));
+    aead_request_set_crypt(req, src, dst, sizeof(vector), iv);
+
+    ret = crypto_aead_encrypt(req);
+
+    if (ret) {
+        pr_err("error: crypto_aead_encrypt returned: %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = XMEMCMP(enc, enc2, sizeof(vector));
+    if (ret) {
+        pr_err("error: enc and enc2 do not match: %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = XMEMCMP(authTag, enc2 + encryptLen, sizeof(authTag));
+    if (ret) {
+        pr_err("error: authTags do not match: %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    /* Now decrypt crypto request. Reverse src and dst. */
+    memset(dec2, 0, decryptLen);
+    aead_request_set_ad(req, sizeof(assoc));
+    aead_request_set_crypt(req, dst, src, decryptLen, iv);
+
+    ret = crypto_aead_decrypt(req);
+
+    if (ret) {
+        pr_err("error: crypto_aead_decrypt returned: %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    ret = XMEMCMP(dec, dec2, sizeof(vector));
+    if (ret) {
+        pr_err("error: dec and dec2 do not match: %d\n", ret);
+        goto test_gcm_end;
+    }
+
+    pr_info("info: test driver %s: good\n", WOLFKM_GCM_DRIVER);
+
+test_gcm_end:
+    if (req) { aead_request_free(req); req = NULL; }
+    if (tfm) { crypto_free_aead(tfm); tfm = NULL; }
+
+    if (src) { kfree(src); src = NULL; }
+    if (dst) { kfree(dst); dst = NULL; }
+
+    if (dec2) { kfree(dec2); dec2 = NULL; }
+    if (enc2) { kfree(enc2); enc2 = NULL; }
+
+    if (assoc2) { kfree(assoc2); assoc2 = NULL; }
+    if (iv) { kfree(iv); iv = NULL; }
+#endif /* if defined HAVE_AESGCM */
+
+    return 0;
+}
+
+#endif /* LINUXKM_REGISTER_ALG && !defined(NO_AES) */

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -12328,9 +12328,9 @@ int wc_AesXtsSetKeyNoInit(XtsAes* aes, const byte* key, word32 len, int dir)
     }
 #endif
 
-    if ((dir == AES_ENCRYPTION)
+    if (dir == AES_ENCRYPTION
 #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
-        || (dir == AES_ENCRYPTION_AND_DECRYPTION)
+        || dir == AES_ENCRYPTION_AND_DECRYPTION
 #endif
         )
     {

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -12252,6 +12252,14 @@ int wc_AesKeyUnWrap(const byte* key, word32 keySz, const byte* in, word32 inSz,
 /* Galois Field to use */
 #define GF_XTS 0x87
 
+/* Set up keys for encryption and/or decryption.
+ *
+ * aes   buffer holding aes subkeys
+ * heap  heap hint to use for memory. Can be NULL
+ * devId id to use with async crypto. Can be 0
+ *
+ * return 0 on success
+ */
 int wc_AesXtsInit(XtsAes* aes, void* heap, int devId)
 {
     int    ret = 0;
@@ -12278,15 +12286,12 @@ int wc_AesXtsInit(XtsAes* aes, void* heap, int devId)
 
 /* Set up keys for encryption and/or decryption.
  *
- * tweak AES key for tweak in XTS
- * aes   AES key for encrypt/decrypt process
- * key   buffer holding aes key | tweak key
+ * aes   buffer holding aes subkeys
+ * key   AES key for encrypt/decrypt and tweak process (concatenated)
  * len   length of key buffer in bytes. Should be twice that of key size. i.e.
  *       32 for a 16 byte key.
  * dir   direction: AES_ENCRYPTION, AES_DECRYPTION, or
  *       AES_ENCRYPTION_AND_DECRYPTION
- * heap  heap hint to use for memory. Can be NULL
- * devId id to use with async crypto. Can be 0
  *
  * return 0 on success
  */
@@ -12680,15 +12685,19 @@ int wc_AesXtsEncrypt(XtsAes* xaes, byte* out, const byte* in, word32 sz,
         if (xaes->aes_encrypt.use_aesni) {
 #if defined(HAVE_INTEL_AVX1)
             if (IS_INTEL_AVX1(intel_flags)) {
-                AES_XTS_encrypt_avx1(in, out, sz, i, (const byte*)xaes->aes_encrypt.key,
-                                     (const byte*)xaes->tweak.key, (int)xaes->aes_encrypt.rounds);
+                AES_XTS_encrypt_avx1(in, out, sz, i,
+                                     (const byte*)xaes->aes_encrypt.key,
+                                     (const byte*)xaes->tweak.key,
+                                     (int)xaes->aes_encrypt.rounds);
                 ret = 0;
             }
             else
 #endif
             {
-                AES_XTS_encrypt_aesni(in, out, sz, i, (const byte*)xaes->aes_encrypt.key,
-                                      (const byte*)xaes->tweak.key, (int)xaes->aes_encrypt.rounds);
+                AES_XTS_encrypt_aesni(in, out, sz, i,
+                                      (const byte*)xaes->aes_encrypt.key,
+                                      (const byte*)xaes->tweak.key,
+                                      (int)xaes->aes_encrypt.rounds);
                 ret = 0;
             }
         }
@@ -12893,15 +12902,19 @@ int wc_AesXtsDecrypt(XtsAes* xaes, byte* out, const byte* in, word32 sz,
         if (xaes->aes_decrypt.use_aesni) {
 #if defined(HAVE_INTEL_AVX1)
             if (IS_INTEL_AVX1(intel_flags)) {
-                AES_XTS_decrypt_avx1(in, out, sz, i, (const byte*)xaes->aes_decrypt.key,
-                                     (const byte*)xaes->tweak.key, (int)xaes->aes_decrypt.rounds);
+                AES_XTS_decrypt_avx1(in, out, sz, i,
+                                     (const byte*)xaes->aes_decrypt.key,
+                                     (const byte*)xaes->tweak.key,
+                                     (int)xaes->aes_decrypt.rounds);
                 ret = 0;
             }
             else
 #endif
             {
-                AES_XTS_decrypt_aesni(in, out, sz, i, (const byte*)xaes->aes_decrypt.key,
-                                      (const byte*)xaes->tweak.key, (int)xaes->aes_decrypt.rounds);
+                AES_XTS_decrypt_aesni(in, out, sz, i,
+                                      (const byte*)xaes->aes_decrypt.key,
+                                      (const byte*)xaes->tweak.key,
+                                      (int)xaes->aes_decrypt.rounds);
                 ret = 0;
             }
         }

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -1560,25 +1560,18 @@ WOLFSSL_LOCAL int SAVE_VECTOR_REGISTERS2_fuzzer(void) {
                                                          */
     /* barrel-roll using the bottom 6 bits. */
     if (new_prn & 0x3f)
-        new_prn = (new_prn << (new_prn & 0x3f)) | (new_prn >> (0x40 - (new_prn & 0x3f)));
+        new_prn = (new_prn << (new_prn & 0x3f)) |
+            (new_prn >> (0x40 - (new_prn & 0x3f)));
     prn = new_prn;
 
     balance_bit = !balance_bit;
 
-    if (balance_bit) {
-        if (prn & 1)
-            return IO_FAILED_E;
-        else
-            return 0;
-    } else {
-        if (prn & 1)
-            return 0;
-        else
-            return IO_FAILED_E;
-    }
+    return ((prn & 1) ^ balance_bit) ? IO_FAILED_E : 0;
 }
 
-#endif /* DEBUG_VECTOR_REGISTER_ACCESS || DEBUG_VECTOR_REGISTER_ACCESS_FUZZING */
+#endif /* DEBUG_VECTOR_REGISTER_ACCESS ||
+        * DEBUG_VECTOR_REGISTER_ACCESS_FUZZING
+        */
 
 #ifdef WOLFSSL_LINUXKM
     #include "../../linuxkm/linuxkm_memory.c"

--- a/wolfcrypt/src/port/arm/armv8-aes.c
+++ b/wolfcrypt/src/port/arm/armv8-aes.c
@@ -15624,7 +15624,7 @@ int wc_AesXtsEncrypt(XtsAes* xaes, byte* out, const byte* in, word32 sz,
 
         : [blocks] "+r" (blocks), [in] "+r" (in), [out] "+r" (out),
           [sz] "+r" (sz)
-        : [key] "r" (xaes->aes.key), [rounds] "r" (xaes->aes.rounds),
+        : [key] "r" (xaes->aes_encrypt.key), [rounds] "r" (xaes->aes_encrypt.rounds),
           [key2] "r" (xaes->tweak.key), [i] "r" (i),
           [tmp] "r" (tmp)
         : "cc", "memory",
@@ -15972,7 +15972,7 @@ int wc_AesXtsDecrypt(XtsAes* xaes, byte* out, const byte* in, word32 sz,
 
         : [blocks] "+r" (blocks), [in] "+r" (in), [out] "+r" (out),
           [sz] "+r" (sz)
-        : [key] "r" (xaes->aes.key), [rounds] "r" (xaes->aes.rounds),
+        : [key] "r" (xaes->aes_decrypt.key), [rounds] "r" (xaes->aes_decrypt.rounds),
           [key2] "r" (xaes->tweak.key), [i] "r" (i),
           [tmp] "r" (tmp)
         : "cc", "memory",
@@ -16298,7 +16298,7 @@ int wc_AesXtsEncrypt(XtsAes* xaes, byte* out, const byte* in, word32 sz,
 
         : [blocks] "+r" (blocks), [in] "+r" (in), [out] "+r" (out),
           [sz] "+r" (sz), [i] "+r" (i), [key2] "+r" (key2)
-        : [key] "r" (xaes->aes.key), [rounds] "r" (xaes->aes.rounds),
+        : [key] "r" (xaes->aes_encrypt.key), [rounds] "r" (xaes->aes_encrypt.rounds),
           [tmp] "r" (tmp)
         : "cc", "memory",
           "r9", "r10", "r11", "r12", "r14",
@@ -16455,7 +16455,7 @@ int wc_AesXtsDecrypt(XtsAes* xaes, byte* out, const byte* in, word32 sz,
 
         : [blocks] "+r" (blocks), [in] "+r" (in), [out] "+r" (out),
           [sz] "+r" (sz), [i] "+r" (i), [key2] "+r" (key2)
-        : [key] "r" (xaes->aes.key), [rounds] "r" (xaes->aes.rounds),
+        : [key] "r" (xaes->aes_decrypt.key), [rounds] "r" (xaes->aes_decrypt.rounds),
           [tmp] "r" (tmp)
         : "cc", "memory",
           "r9", "r10", "r11", "r12", "r14",

--- a/wolfcrypt/src/port/arm/armv8-aes.c
+++ b/wolfcrypt/src/port/arm/armv8-aes.c
@@ -15624,7 +15624,7 @@ int wc_AesXtsEncrypt(XtsAes* xaes, byte* out, const byte* in, word32 sz,
 
         : [blocks] "+r" (blocks), [in] "+r" (in), [out] "+r" (out),
           [sz] "+r" (sz)
-        : [key] "r" (xaes->aes_encrypt.key), [rounds] "r" (xaes->aes_encrypt.rounds),
+        : [key] "r" (xaes->aes.key), [rounds] "r" (xaes->aes.rounds),
           [key2] "r" (xaes->tweak.key), [i] "r" (i),
           [tmp] "r" (tmp)
         : "cc", "memory",
@@ -15972,7 +15972,7 @@ int wc_AesXtsDecrypt(XtsAes* xaes, byte* out, const byte* in, word32 sz,
 
         : [blocks] "+r" (blocks), [in] "+r" (in), [out] "+r" (out),
           [sz] "+r" (sz)
-        : [key] "r" (xaes->aes_decrypt.key), [rounds] "r" (xaes->aes_decrypt.rounds),
+        : [key] "r" (xaes->aes.key), [rounds] "r" (xaes->aes.rounds),
           [key2] "r" (xaes->tweak.key), [i] "r" (i),
           [tmp] "r" (tmp)
         : "cc", "memory",
@@ -16298,7 +16298,7 @@ int wc_AesXtsEncrypt(XtsAes* xaes, byte* out, const byte* in, word32 sz,
 
         : [blocks] "+r" (blocks), [in] "+r" (in), [out] "+r" (out),
           [sz] "+r" (sz), [i] "+r" (i), [key2] "+r" (key2)
-        : [key] "r" (xaes->aes_encrypt.key), [rounds] "r" (xaes->aes_encrypt.rounds),
+        : [key] "r" (xaes->aes.key), [rounds] "r" (xaes->aes.rounds),
           [tmp] "r" (tmp)
         : "cc", "memory",
           "r9", "r10", "r11", "r12", "r14",
@@ -16455,7 +16455,7 @@ int wc_AesXtsDecrypt(XtsAes* xaes, byte* out, const byte* in, word32 sz,
 
         : [blocks] "+r" (blocks), [in] "+r" (in), [out] "+r" (out),
           [sz] "+r" (sz), [i] "+r" (i), [key2] "+r" (key2)
-        : [key] "r" (xaes->aes_decrypt.key), [rounds] "r" (xaes->aes_decrypt.rounds),
+        : [key] "r" (xaes->aes.key), [rounds] "r" (xaes->aes.rounds),
           [tmp] "r" (tmp)
         : "cc", "memory",
           "r9", "r10", "r11", "r12", "r14",

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -9492,7 +9492,7 @@ static wc_test_ret_t aes_xts_128_test(void)
 
     ret = wc_AesXtsEncrypt(aes, buf, p2, sizeof(p2), i2, sizeof(i2));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9503,7 +9503,7 @@ static wc_test_ret_t aes_xts_128_test(void)
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
     ret = wc_AesXtsEncrypt(aes, buf, p2, sizeof(p2), i2, sizeof(i2));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
     if (ret != 0)
@@ -9519,7 +9519,7 @@ static wc_test_ret_t aes_xts_128_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsEncrypt(aes, buf, p1, sizeof(p1), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9530,7 +9530,7 @@ static wc_test_ret_t aes_xts_128_test(void)
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
     ret = wc_AesXtsEncrypt(aes, buf, p1, sizeof(p1), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
     if (ret != 0)
@@ -9543,7 +9543,7 @@ static wc_test_ret_t aes_xts_128_test(void)
     XMEMSET(cipher, 0, sizeof(cipher));
     ret = wc_AesXtsEncrypt(aes, cipher, pp, sizeof(pp), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9555,7 +9555,7 @@ static wc_test_ret_t aes_xts_128_test(void)
     XMEMSET(cipher, 0, sizeof(cipher));
     ret = wc_AesXtsEncrypt(aes, cipher, pp, sizeof(pp), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
     if (ret != 0)
@@ -9571,7 +9571,11 @@ static wc_test_ret_t aes_xts_128_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsDecrypt(aes, buf, cipher, sizeof(pp), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
+    #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
     ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    #else
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    #endif
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9583,7 +9587,11 @@ static wc_test_ret_t aes_xts_128_test(void)
     XMEMSET(buf, 0, sizeof(buf));
     ret = wc_AesXtsDecrypt(aes, buf, cipher, sizeof(pp), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
+    #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
     ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    #else
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    #endif
 #endif
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
     if (ret != 0)
@@ -9596,7 +9604,11 @@ static wc_test_ret_t aes_xts_128_test(void)
     XMEMSET(buf, 0, sizeof(buf));
     ret = wc_AesXtsDecrypt(aes, buf, c1, sizeof(c1), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
+    #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
     ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    #else
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    #endif
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9608,7 +9620,11 @@ static wc_test_ret_t aes_xts_128_test(void)
     XMEMSET(buf, 0, sizeof(buf));
     ret = wc_AesXtsDecrypt(aes, buf, c1, sizeof(c1), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
+    #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
     ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    #else
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    #endif
 #endif
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
     if (ret != 0)
@@ -9621,7 +9637,11 @@ static wc_test_ret_t aes_xts_128_test(void)
     XMEMSET(buf, 0, sizeof(buf));
     ret = wc_AesXtsDecrypt(aes, buf, c2, sizeof(c2), i2, sizeof(i2));
 #if defined(WOLFSSL_ASYNC_CRYPT)
+    #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
     ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    #else
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    #endif
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9635,7 +9655,11 @@ static wc_test_ret_t aes_xts_128_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsDecrypt(aes, buf, c2, sizeof(c2), i2, sizeof(i2));
 #if defined(WOLFSSL_ASYNC_CRYPT)
+    #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
     ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    #else
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    #endif
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9652,7 +9676,7 @@ static wc_test_ret_t aes_xts_128_test(void)
 
     ret = wc_AesXtsEncrypt(aes, buf, buf, sizeof(p3), i3, sizeof(i3));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9664,7 +9688,11 @@ static wc_test_ret_t aes_xts_128_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsDecrypt(aes, buf, buf, sizeof(c3), i3, sizeof(i3));
 #if defined(WOLFSSL_ASYNC_CRYPT)
+    #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
     ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    #else
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    #endif
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9700,7 +9728,7 @@ static wc_test_ret_t aes_xts_128_test(void)
             ret = wc_AesXtsEncrypt(aes, large_input, large_input, j, i1,
                 sizeof(i1));
         #if defined(WOLFSSL_ASYNC_CRYPT)
-            ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+            ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
         #endif
             if (ret != 0)
                 ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9711,7 +9739,11 @@ static wc_test_ret_t aes_xts_128_test(void)
             ret = wc_AesXtsDecrypt(aes, large_input, large_input, j, i1,
                 sizeof(i1));
         #if defined(WOLFSSL_ASYNC_CRYPT)
+            #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
             ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+            #else
+            ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+            #endif
         #endif
             if (ret != 0)
                 ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9856,7 +9888,7 @@ static wc_test_ret_t aes_xts_256_test(void)
 
     ret = wc_AesXtsEncrypt(aes, buf, p2, sizeof(p2), i2, sizeof(i2));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9869,7 +9901,7 @@ static wc_test_ret_t aes_xts_256_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsEncrypt(aes, buf, p1, sizeof(p1), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9880,7 +9912,7 @@ static wc_test_ret_t aes_xts_256_test(void)
     XMEMSET(cipher, 0, sizeof(cipher));
     ret = wc_AesXtsEncrypt(aes, cipher, pp, sizeof(pp), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9892,7 +9924,11 @@ static wc_test_ret_t aes_xts_256_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsDecrypt(aes, buf, cipher, sizeof(pp), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
+    #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
     ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    #else
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    #endif
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9903,7 +9939,11 @@ static wc_test_ret_t aes_xts_256_test(void)
     XMEMSET(buf, 0, sizeof(buf));
     ret = wc_AesXtsDecrypt(aes, buf, c1, sizeof(c1), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
+    #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
     ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    #else
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    #endif
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9916,7 +9956,11 @@ static wc_test_ret_t aes_xts_256_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsDecrypt(aes, buf, c2, sizeof(c2), i2, sizeof(i2));
 #if defined(WOLFSSL_ASYNC_CRYPT)
+    #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
     ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    #else
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    #endif
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -10133,7 +10177,7 @@ static wc_test_ret_t aes_xts_sector_test(void)
 
     ret = wc_AesXtsEncryptSector(aes, buf, p1, sizeof(p1), s1);
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -10147,7 +10191,11 @@ static wc_test_ret_t aes_xts_sector_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsDecryptSector(aes, buf, c1, sizeof(c1), s1);
 #if defined(WOLFSSL_ASYNC_CRYPT)
+    #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
     ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    #else
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    #endif
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -10161,7 +10209,7 @@ static wc_test_ret_t aes_xts_sector_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsEncryptSector(aes, buf, p2, sizeof(p2), s2);
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -10175,7 +10223,11 @@ static wc_test_ret_t aes_xts_sector_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsDecryptSector(aes, buf, c2, sizeof(c2), s2);
 #if defined(WOLFSSL_ASYNC_CRYPT)
+    #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
     ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    #else
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    #endif
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -10192,7 +10244,7 @@ static wc_test_ret_t aes_xts_sector_test(void)
     ret = wc_AesXtsEncryptConsecutiveSectors(aes, data, p3,
             sizeof(p3), s3, sectorSz);
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -10207,7 +10259,11 @@ static wc_test_ret_t aes_xts_sector_test(void)
     ret = wc_AesXtsDecryptConsecutiveSectors(aes, data, c3,
             sizeof(c3), s3, sectorSz);
 #if defined(WOLFSSL_ASYNC_CRYPT)
+    #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
     ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    #else
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    #endif
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -10286,14 +10342,14 @@ static wc_test_ret_t aes_xts_args_test(void)
 
     ret = wc_AesXtsEncryptSector(NULL, buf, p1, sizeof(p1), s1);
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret == 0)
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     ret = wc_AesXtsEncryptSector(aes, NULL, p1, sizeof(p1), s1);
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret == 0)
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
@@ -10304,14 +10360,22 @@ static wc_test_ret_t aes_xts_args_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsDecryptSector(NULL, buf, c1, sizeof(c1), s1);
 #if defined(WOLFSSL_ASYNC_CRYPT)
+    #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
     ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    #else
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    #endif
 #endif
     if (ret == 0)
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     ret = wc_AesXtsDecryptSector(aes, NULL, c1, sizeof(c1), s1);
 #if defined(WOLFSSL_ASYNC_CRYPT)
+    #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
     ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+    #else
+    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    #endif
 #endif
     if (ret == 0)
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -9438,7 +9438,7 @@ static wc_test_ret_t aes_xts_128_test(void)
         0x77, 0x8a, 0xe8, 0xb4, 0x3c, 0xb9, 0x8d, 0x5a
     };
 
-#ifndef HAVE_FIPS_VERSION /* FIPS requires different keys for main and tweak. */
+#ifndef HAVE_FIPS /* FIPS requires different keys for main and tweak. */
     WOLFSSL_SMALL_STACK_STATIC unsigned char k3[] = {
         0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
         0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
@@ -9463,7 +9463,7 @@ static wc_test_ret_t aes_xts_128_test(void)
         0xA0, 0x85, 0xD2, 0x69, 0x6E, 0x87, 0x0A, 0xBF,
         0xB5, 0x5A, 0xDD, 0xCB, 0x80, 0xE0, 0xFC, 0xCD
     };
-#endif /* HAVE_FIPS_VERSION */
+#endif /* HAVE_FIPS */
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     if ((aes = (XtsAes *)XMALLOC(sizeof *aes, HEAP_HINT, DYNAMIC_TYPE_AES)) == NULL)
@@ -9666,7 +9666,7 @@ static wc_test_ret_t aes_xts_128_test(void)
     if (XMEMCMP(p2, buf, sizeof(p2)))
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
-#ifndef HAVE_FIPS_VERSION
+#ifndef HAVE_FIPS
 
     /* Test ciphertext stealing in-place. */
     XMEMCPY(buf, p3, sizeof(p3));
@@ -9699,7 +9699,7 @@ static wc_test_ret_t aes_xts_128_test(void)
     if (XMEMCMP(p3, buf, sizeof(p3)))
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
-#endif /* !HAVE_FIPS_VERSION */
+#endif /* !HAVE_FIPS */
 
 #if !defined(BENCH_EMBEDDED) && !defined(HAVE_CAVIUM) && \
     !defined(WOLFSSL_AFALG)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -9740,7 +9740,8 @@ static wc_test_ret_t aes_xts_128_test(void)
                 sizeof(i1));
         #if defined(WOLFSSL_ASYNC_CRYPT)
             #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
-            ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
+            ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev,
+                               WC_ASYNC_FLAG_NONE);
             #else
             ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
             #endif

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -9438,6 +9438,7 @@ static wc_test_ret_t aes_xts_128_test(void)
         0x77, 0x8a, 0xe8, 0xb4, 0x3c, 0xb9, 0x8d, 0x5a
     };
 
+#ifndef HAVE_FIPS_VERSION /* FIPS requires different keys for main and tweak. */
     WOLFSSL_SMALL_STACK_STATIC unsigned char k3[] = {
         0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
         0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
@@ -9462,6 +9463,7 @@ static wc_test_ret_t aes_xts_128_test(void)
         0xA0, 0x85, 0xD2, 0x69, 0x6E, 0x87, 0x0A, 0xBF,
         0xB5, 0x5A, 0xDD, 0xCB, 0x80, 0xE0, 0xFC, 0xCD
     };
+#endif /* HAVE_FIPS_VERSION */
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     if ((aes = (XtsAes *)XMALLOC(sizeof *aes, HEAP_HINT, DYNAMIC_TYPE_AES)) == NULL)
@@ -9490,7 +9492,7 @@ static wc_test_ret_t aes_xts_128_test(void)
 
     ret = wc_AesXtsEncrypt(aes, buf, p2, sizeof(p2), i2, sizeof(i2));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9501,7 +9503,7 @@ static wc_test_ret_t aes_xts_128_test(void)
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
     ret = wc_AesXtsEncrypt(aes, buf, p2, sizeof(p2), i2, sizeof(i2));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
     if (ret != 0)
@@ -9517,7 +9519,7 @@ static wc_test_ret_t aes_xts_128_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsEncrypt(aes, buf, p1, sizeof(p1), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9528,7 +9530,7 @@ static wc_test_ret_t aes_xts_128_test(void)
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
     ret = wc_AesXtsEncrypt(aes, buf, p1, sizeof(p1), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
     if (ret != 0)
@@ -9541,7 +9543,7 @@ static wc_test_ret_t aes_xts_128_test(void)
     XMEMSET(cipher, 0, sizeof(cipher));
     ret = wc_AesXtsEncrypt(aes, cipher, pp, sizeof(pp), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9553,7 +9555,7 @@ static wc_test_ret_t aes_xts_128_test(void)
     XMEMSET(cipher, 0, sizeof(cipher));
     ret = wc_AesXtsEncrypt(aes, cipher, pp, sizeof(pp), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
     if (ret != 0)
@@ -9569,7 +9571,7 @@ static wc_test_ret_t aes_xts_128_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsDecrypt(aes, buf, cipher, sizeof(pp), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9581,7 +9583,7 @@ static wc_test_ret_t aes_xts_128_test(void)
     XMEMSET(buf, 0, sizeof(buf));
     ret = wc_AesXtsDecrypt(aes, buf, cipher, sizeof(pp), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
     if (ret != 0)
@@ -9594,7 +9596,7 @@ static wc_test_ret_t aes_xts_128_test(void)
     XMEMSET(buf, 0, sizeof(buf));
     ret = wc_AesXtsDecrypt(aes, buf, c1, sizeof(c1), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9606,7 +9608,7 @@ static wc_test_ret_t aes_xts_128_test(void)
     XMEMSET(buf, 0, sizeof(buf));
     ret = wc_AesXtsDecrypt(aes, buf, c1, sizeof(c1), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
     if (ret != 0)
@@ -9619,7 +9621,7 @@ static wc_test_ret_t aes_xts_128_test(void)
     XMEMSET(buf, 0, sizeof(buf));
     ret = wc_AesXtsDecrypt(aes, buf, c2, sizeof(c2), i2, sizeof(i2));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9633,12 +9635,14 @@ static wc_test_ret_t aes_xts_128_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsDecrypt(aes, buf, c2, sizeof(c2), i2, sizeof(i2));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     if (XMEMCMP(p2, buf, sizeof(p2)))
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+
+#ifndef HAVE_FIPS_VERSION
 
     /* Test ciphertext stealing in-place. */
     XMEMCPY(buf, p3, sizeof(p3));
@@ -9648,7 +9652,7 @@ static wc_test_ret_t aes_xts_128_test(void)
 
     ret = wc_AesXtsEncrypt(aes, buf, buf, sizeof(p3), i3, sizeof(i3));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9660,12 +9664,14 @@ static wc_test_ret_t aes_xts_128_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsDecrypt(aes, buf, buf, sizeof(c3), i3, sizeof(i3));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     if (XMEMCMP(p3, buf, sizeof(p3)))
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+
+#endif /* !HAVE_FIPS_VERSION */
 
 #if !defined(BENCH_EMBEDDED) && !defined(HAVE_CAVIUM) && \
     !defined(WOLFSSL_AFALG)
@@ -9694,7 +9700,7 @@ static wc_test_ret_t aes_xts_128_test(void)
             ret = wc_AesXtsEncrypt(aes, large_input, large_input, j, i1,
                 sizeof(i1));
         #if defined(WOLFSSL_ASYNC_CRYPT)
-            ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+            ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
         #endif
             if (ret != 0)
                 ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9705,7 +9711,7 @@ static wc_test_ret_t aes_xts_128_test(void)
             ret = wc_AesXtsDecrypt(aes, large_input, large_input, j, i1,
                 sizeof(i1));
         #if defined(WOLFSSL_ASYNC_CRYPT)
-            ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+            ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
         #endif
             if (ret != 0)
                 ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9850,7 +9856,7 @@ static wc_test_ret_t aes_xts_256_test(void)
 
     ret = wc_AesXtsEncrypt(aes, buf, p2, sizeof(p2), i2, sizeof(i2));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9863,7 +9869,7 @@ static wc_test_ret_t aes_xts_256_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsEncrypt(aes, buf, p1, sizeof(p1), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9874,7 +9880,7 @@ static wc_test_ret_t aes_xts_256_test(void)
     XMEMSET(cipher, 0, sizeof(cipher));
     ret = wc_AesXtsEncrypt(aes, cipher, pp, sizeof(pp), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9886,7 +9892,7 @@ static wc_test_ret_t aes_xts_256_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsDecrypt(aes, buf, cipher, sizeof(pp), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9897,7 +9903,7 @@ static wc_test_ret_t aes_xts_256_test(void)
     XMEMSET(buf, 0, sizeof(buf));
     ret = wc_AesXtsDecrypt(aes, buf, c1, sizeof(c1), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -9910,7 +9916,7 @@ static wc_test_ret_t aes_xts_256_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsDecrypt(aes, buf, c2, sizeof(c2), i2, sizeof(i2));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -10127,7 +10133,7 @@ static wc_test_ret_t aes_xts_sector_test(void)
 
     ret = wc_AesXtsEncryptSector(aes, buf, p1, sizeof(p1), s1);
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -10141,7 +10147,7 @@ static wc_test_ret_t aes_xts_sector_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsDecryptSector(aes, buf, c1, sizeof(c1), s1);
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -10155,7 +10161,7 @@ static wc_test_ret_t aes_xts_sector_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsEncryptSector(aes, buf, p2, sizeof(p2), s2);
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -10169,7 +10175,7 @@ static wc_test_ret_t aes_xts_sector_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsDecryptSector(aes, buf, c2, sizeof(c2), s2);
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -10186,7 +10192,7 @@ static wc_test_ret_t aes_xts_sector_test(void)
     ret = wc_AesXtsEncryptConsecutiveSectors(aes, data, p3,
             sizeof(p3), s3, sectorSz);
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -10201,7 +10207,7 @@ static wc_test_ret_t aes_xts_sector_test(void)
     ret = wc_AesXtsDecryptConsecutiveSectors(aes, data, c3,
             sizeof(c3), s3, sectorSz);
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -10280,14 +10286,14 @@ static wc_test_ret_t aes_xts_args_test(void)
 
     ret = wc_AesXtsEncryptSector(NULL, buf, p1, sizeof(p1), s1);
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret == 0)
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     ret = wc_AesXtsEncryptSector(aes, NULL, p1, sizeof(p1), s1);
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_encrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret == 0)
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
@@ -10298,14 +10304,14 @@ static wc_test_ret_t aes_xts_args_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesXtsDecryptSector(NULL, buf, c1, sizeof(c1), s1);
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret == 0)
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     ret = wc_AesXtsDecryptSector(aes, NULL, c1, sizeof(c1), s1);
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret == 0)
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
@@ -30070,8 +30076,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ecc_test(void)
 #endif /* HAVE_ECC160 */
 #if (defined(HAVE_ECC192) || defined(HAVE_ALL_CURVES)) && ECC_MIN_KEY_SZ <= 192
     ret = ecc_test_curve(&rng, 24, ECC_CURVE_DEF);
-        printf("keySize=24, Default\n");
     if (ret < 0) {
+        printf("keySize=24, Default\n");
         goto done;
     }
 #endif /* HAVE_ECC192 */

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -179,6 +179,7 @@ enum {
     AES_ENC_TYPE   = WC_CIPHER_AES,   /* cipher unique type */
     AES_ENCRYPTION = 0,
     AES_DECRYPTION = 1,
+    AES_ENCRYPTION_AND_DECRYPTION = 2,
 
     AES_BLOCK_SIZE      = 16,
 
@@ -398,7 +399,8 @@ struct Aes {
 
 #ifdef WOLFSSL_AES_XTS
 typedef struct XtsAes {
-    Aes aes;
+    Aes aes_encrypt;
+    Aes aes_decrypt;
     Aes tweak;
 } XtsAes;
 #endif

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -179,7 +179,9 @@ enum {
     AES_ENC_TYPE   = WC_CIPHER_AES,   /* cipher unique type */
     AES_ENCRYPTION = 0,
     AES_DECRYPTION = 1,
+#ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
     AES_ENCRYPTION_AND_DECRYPTION = 2,
+#endif
 
     AES_BLOCK_SIZE      = 16,
 

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -399,8 +399,10 @@ struct Aes {
 
 #ifdef WOLFSSL_AES_XTS
 typedef struct XtsAes {
-    Aes aes_encrypt;
+    Aes aes;
+#ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
     Aes aes_decrypt;
+#endif
     Aes tweak;
 } XtsAes;
 #endif

--- a/wolfssl/wolfcrypt/memory.h
+++ b/wolfssl/wolfcrypt/memory.h
@@ -267,6 +267,13 @@ WOLFSSL_LOCAL int wc_debug_CipherLifecycleFree(void **CipherLifecycleTag,
         ((void)(CipherLifecycleTag), (void)(heap), (void)(abort_p), 0)
 #endif
 
+#ifdef DEBUG_VECTOR_REGISTER_ACCESS_FUZZING
+    WOLFSSL_LOCAL int SAVE_VECTOR_REGISTERS2_fuzzer(void);
+    #ifndef WC_DEBUG_VECTOR_REGISTERS_FUZZING_SEED
+        #define WC_DEBUG_VECTOR_REGISTERS_FUZZING_SEED 0
+    #endif
+#endif
+
 #ifdef DEBUG_VECTOR_REGISTER_ACCESS
     WOLFSSL_API extern THREAD_LS_T int wc_svr_count;
     WOLFSSL_API extern THREAD_LS_T const char *wc_svr_last_file;
@@ -320,11 +327,6 @@ WOLFSSL_LOCAL int wc_debug_CipherLifecycleFree(void **CipherLifecycleTag,
     } while (0)
 
 #ifdef DEBUG_VECTOR_REGISTER_ACCESS_FUZZING
-    #ifndef WC_DEBUG_VECTOR_REGISTERS_FUZZING_SEED
-        #define WC_DEBUG_VECTOR_REGISTERS_FUZZING_SEED 0
-    #endif
-        WOLFSSL_LOCAL int SAVE_VECTOR_REGISTERS2_fuzzer(void);
-
     #define SAVE_VECTOR_REGISTERS2(...) ({                          \
         int _svr2_val = SAVE_VECTOR_REGISTERS2_fuzzer();            \
         if (_svr2_val == 0) {                                       \

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2771,6 +2771,7 @@ extern void uITRON4_free(void *p) ;
     #ifndef WOLFSSL_TEST_SUBROUTINE
         #define WOLFSSL_TEST_SUBROUTINE static
     #endif
+    #undef HAVE_PTHREAD
     #undef HAVE_STRINGS_H
     #undef HAVE_ERRNO_H
     #undef HAVE_THREAD_LS


### PR DESCRIPTION
linuxkm: completion and stabilization of LKCAPI integration for AES-CBC, AES-CFB, AES-GCM, and AES-XTS:

AES-XTS:
split `XtsAes.aes` in two, `XtsAes.aes_encrypt` and `XtsAes.aes_decrypt`, and add `AES_ENCRYPTION_AND_DECRYPTION` option constant, to accommodate Linux kernel crypto API model.
in `wc_AesXtsSetKeyNoInit()`, add FIPS check that main and tweak keys differ, and allow setting encrypt and decrypt keys simultaneously using `AES_ENCRYPTION_AND_DECRYPTION`.
in `wc_AesXtsEncrypt()` and `wc_AesXtsDecrypt()`, error if the required subkey has not been set.

add `DEBUG_VECTOR_REGISTER_ACCESS_FUZZING` && !`DEBUG_VECTOR_REGISTER_ACCESS`, with a kernel-compatible implementation of `SAVE_VECTOR_REGISTERS2_fuzzer()`.

squash of philljj's POC work integrating `libwolfssl.ko` with `crypto_register_skcipher`/`crypto_register_aead`, start 2022-12-26, end 2023-01-14.

`linuxkm/lkcapi_glue.c`:
implement `linuxkm_lkcapi_register()` and `linuxkm_lkcapi_unregister()` with idempotency.
add AES-XTS algorithm glue and self-test implementations.
add per-algorithm gating: `LINUXKM_LKCAPI_REGISTER_AESCBC`, `_AESCFB`, `_AESGCM`, and `_AESXTS`.
carry forward philljj's implementations for AES-CBC, AES-CFB, and AES-GCM, with various cleanups.

`linuxkm/module_hooks.c`:
print the "wolfCrypt container hashes" message only if `DEBUG_LINUXKM_PIE_SUPPORT` is set.
render the FIPS version for the self-test success message using the `HAVE_FIPS_VERSION*` macros.
add a "skipping full wolfcrypt_test() ..." message for `--disable-crypttests` builds.
add `CONFIG_FORTIFY_SOURCE` gates.

`configure.ac`:
add support for `--enable-linuxkm-lkcapi-register`;
add AES-XTS to output config summary;
rename `--enable-xts` to `--enable-aesxts` (retaining old option for backward compatibility).

`linuxkm/linuxkm_wc_port.h`: add support for `CONFIG_FORTIFY_SOURCE`.

`linuxkm/linuxkm_memory.c`:
fix retvals in `save_vector_registers_x86()` (wc-style `MEMORY_E`, not sys-style `ENOMEM`).
add `__my_fortify_panic()` implementation.

`linuxkm/Kbuild`: for `ENABLED_LINUXKM_PIE` in `rename-pie-text-and-data-sections` recipe, create an `.rodata.wolfcrypt` section.

`linuxkm/include.am`: add `linuxkm/lkcapi_glue.c` to `EXTRA_DIST`.

`wolfcrypt/test/test.c`:
when `defined(HAVE_FIPS_VERSION)`, inhibit a test clause in `aes_xts_128_test()` disallowed by FIPS ("FIPS AES-XTS main and tweak keys must differ").
fix out-of-order user message in `ecc_test()`.

tested with `wolfssl-multi-test.sh ... super-quick-check` plus a slew (2 dozen) of LKCAPI scenarios with live module loads, including various combinations of AESNI, FIPS, `CONFIG_FORTIFY_SOURCE`, kernel sanitizers, `--enable-crypttests` and `--disable-crypttests`.