### PR TITLE
Regression testing fixes

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -26623,6 +26623,8 @@ static int ParseCipherList(Suites* suites,
         suites->setSuites = 1;
     }
 
+    (void)privateKeySz;
+
     return ret;
 }
 

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -5408,7 +5408,8 @@ int sp_cmp_mag(const sp_int* a, const sp_int* b)
 
 #if defined(WOLFSSL_SP_MATH_ALL) || defined(HAVE_ECC) || !defined(NO_DSA) || \
     defined(OPENSSL_EXTRA) || !defined(NO_DH) || \
-    (!defined(NO_RSA) && !defined(WOLFSSL_RSA_VERIFY_ONLY))
+    (!defined(NO_RSA) && (!defined(WOLFSSL_RSA_VERIFY_ONLY) || \
+     defined(WOLFSSL_KEY_GEN)))
 /* Compare two multi-precision numbers.
  *
  * Assumes a and b are not NULL.
@@ -19260,7 +19261,7 @@ int sp_prime_is_prime_ex(const sp_int* a, int trials, int* result, WC_RNG* rng)
 }
 #endif /* WOLFSSL_SP_PRIME_GEN */
 
-#if !defined(NO_RSA) || defined(WOLFSSL_KEY_GEN)
+#if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN)
 
 /* Calculates the Greatest Common Denominator (GCD) of a and b into r.
  *
@@ -19428,7 +19429,7 @@ int sp_gcd(const sp_int* a, const sp_int* b, sp_int* r)
     return err;
 }
 
-#endif /* WOLFSSL_SP_MATH_ALL && !NO_RSA && WOLFSSL_KEY_GEN */
+#endif /* !NO_RSA && WOLFSSL_KEY_GEN */
 
 #if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN) && \
     (!defined(WC_RSA_BLINDING) || defined(HAVE_FIPS) || defined(HAVE_SELFTEST))
@@ -19554,7 +19555,8 @@ int sp_lcm(const sp_int* a, const sp_int* b, sp_int* r)
     return err;
 }
 
-#endif /* WOLFSSL_SP_MATH_ALL && !NO_RSA && WOLFSSL_KEY_GEN */
+#endif /* !NO_RSA && WOLFSSL_KEY_GEN && (!WC_RSA_BLINDING || HAVE_FIPS ||
+        * HAVE_SELFTEST) */
 
 /* Returns the run time settings.
  *


### PR DESCRIPTION
# Description

internal.c: NO_CERT, privateKeySz not used.
./configure --disable-shared --disable-asn --disable-rsa --disable-ecc --enable-psk

sp_int.c: fix when sp_gcm is available
./configure --disable-shared  --disable-shared --disable-ecc --disable-dh --disable-aes --disable-aesgcm --disable-sha512 --disable-sha384 --disable-sha --disable-poly1305 --disable-chacha --disable-md5 --disable-sha3 --enable-cryptonly --disable-inline --enable-rsavfy --disable-asn --disable-oaep --disable-rng --disable-filesystem --enable-sp=rsa2048 --disable-sp-asm --enable-sp-math

# Testing

See configurations above.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
