### PR TITLE
20240129-fix-wc_RsaFunction_ex

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4570,20 +4570,15 @@ int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key, byte* out,
     #endif
     {
         err = wc_CryptoCb_Ecdh(private_key, public_key, out, outlen);
-        #ifndef WOLF_CRYPTO_CB_ONLY_ECC
         if (err != CRYPTOCB_UNAVAILABLE)
             return err;
         /* fall-through when unavailable */
-        #endif
-        #ifdef WOLF_CRYPTO_CB_ONLY_ECC
-        if (err == CRYPTOCB_UNAVAILABLE) {
-            err = NO_VALID_DEVID;
-        }
-        #endif
     }
 #endif
 
-#ifndef WOLF_CRYPTO_CB_ONLY_ECC
+#ifdef WOLF_CRYPTO_CB_ONLY_ECC
+    return NO_VALID_DEVID;
+#else /* !WOLF_CRYPTO_CB_ONLY_ECC */
    /* type valid? */
    if (private_key->type != ECC_PRIVATEKEY &&
            private_key->type != ECC_PRIVATEKEY_ONLY) {
@@ -4632,7 +4627,7 @@ int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key, byte* out,
 #else
    err = wc_ecc_shared_secret_ex(private_key, &public_key->pubkey, out, outlen);
 #endif /* WOLFSSL_ATECC508A */
-#endif /* WOLF_CRYPTO_CB_ONLY_ECC */
+#endif /* !WOLF_CRYPTO_CB_ONLY_ECC */
 
    return err;
 }
@@ -5529,21 +5524,15 @@ static int _ecc_make_key_ex(WC_RNG* rng, int keysize, ecc_key* key,
     #endif
     {
         err = wc_CryptoCb_MakeEccKey(rng, keysize, key, curve_id);
-        #ifndef WOLF_CRYPTO_CB_ONLY_ECC
         if (err != CRYPTOCB_UNAVAILABLE)
             return err;
         /* fall-through when unavailable */
-        #endif
-        #ifdef WOLF_CRYPTO_CB_ONLY_ECC
-        if (err == CRYPTOCB_UNAVAILABLE) {
-            return NO_VALID_DEVID;
-        }
-        return err;
-        #endif
     }
 #endif
 
-#ifndef WOLF_CRYPTO_CB_ONLY_ECC
+#ifdef WOLF_CRYPTO_CB_ONLY_ECC
+    return NO_VALID_DEVID;
+#else /* !WOLF_CRYPTO_CB_ONLY_ECC */
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_ECC)
     if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_ECC) {
     #ifdef HAVE_CAVIUM
@@ -5859,7 +5848,7 @@ static int _ecc_make_key_ex(WC_RNG* rng, int keysize, ecc_key* key,
 #endif /* HAVE_ECC_MAKE_PUB */
 
     return err;
-#endif /* WOLF_CRYPTO_CB_ONLY_ECC */
+#endif /* !WOLF_CRYPTO_CB_ONLY_ECC */
 }
 
 
@@ -6563,20 +6552,20 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
     #endif
     {
         err = wc_CryptoCb_EccSign(in, inlen, out, outlen, rng, key);
-        #ifndef WOLF_CRYPTO_CB_ONLY_ECC
         if (err != CRYPTOCB_UNAVAILABLE)
             return err;
         /* fall-through when unavailable */
-        #endif
-        #ifdef WOLF_CRYPTO_CB_ONLY_ECC
-        if (err == CRYPTOCB_UNAVAILABLE) {
-            err = NO_VALID_DEVID;
-        }
-        #endif
     }
 #endif
 
-#ifndef WOLF_CRYPTO_CB_ONLY_ECC
+#ifdef WOLF_CRYPTO_CB_ONLY_ECC
+    (void)rng;
+    (void)inlen;
+    (void)s;
+    (void)r;
+    (void)err;
+    return NO_VALID_DEVID;
+#else /* !WOLF_CRYPTO_CB_ONLY_ECC */
     if (rng == NULL) {
         WOLFSSL_MSG("ECC sign RNG missing");
         return ECC_BAD_ARG_E;
@@ -6640,15 +6629,8 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
     FREE_MP_INT_SIZE(s, key->heap, DYNAMIC_TYPE_ECC);
     FREE_MP_INT_SIZE(r, key->heap, DYNAMIC_TYPE_ECC);
 #endif /* WOLFSSL_ASYNC_CRYPT */
-#else
-    (void)rng;
-    (void)inlen;
-    (void)s;
-    (void)r;
-    (void)err;
-#endif /* WOLF_CRYPTO_CB_ONLY_ECC */
-
     return err;
+#endif /* !WOLF_CRYPTO_CB_ONLY_ECC */
 }
 #endif /* !NO_ASN */
 
@@ -8289,21 +8271,20 @@ int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
     #endif
     {
         err = wc_CryptoCb_EccVerify(sig, siglen, hash, hashlen, res, key);
-        #ifndef WOLF_CRYPTO_CB_ONLY_ECC
         if (err != CRYPTOCB_UNAVAILABLE)
             return err;
         /* fall-through when unavailable */
-        #endif
-        #ifdef WOLF_CRYPTO_CB_ONLY_ECC
-        if (err == CRYPTOCB_UNAVAILABLE) {
-            err = NO_VALID_DEVID;
-        }
-        #endif
     }
 #endif
 
-#ifndef WOLF_CRYPTO_CB_ONLY_ECC
-
+#ifdef WOLF_CRYPTO_CB_ONLY_ECC
+    (void)siglen;
+    (void)hashlen;
+    (void)s;
+    (void)r;
+    (void)err;
+    return NO_VALID_DEVID;
+#else /* !WOLF_CRYPTO_CB_ONLY_ECC */
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_ECC)
     err = wc_ecc_alloc_async(key);
     if (err != 0)
@@ -8415,15 +8396,8 @@ int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
 
     /* make sure required variables are reset */
     wc_ecc_reset(key);
-#else
-    (void)siglen;
-    (void)hashlen;
-    (void)s;
-    (void)r;
-    (void)err;
-#endif /* WOLF_CRYPTO_CB_ONLY_ECC */
-
     return err;
+#endif /* !WOLF_CRYPTO_CB_ONLY_ECC */
 }
 #endif /* !NO_ASN */
 

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -3141,7 +3141,9 @@ static int wc_RsaFunction_ex(const byte* in, word32 inLen, byte* out,
     }
 #endif
 
-#ifndef WOLF_CRYPTO_CB_ONLY_RSA
+#ifdef WOLF_CRYPTO_CB_ONLY_RSA
+    return NO_VALID_DEVID;
+#else /* !WOLF_CRYPTO_CB_ONLY_RSA */
     SAVE_VECTOR_REGISTERS(return _svr_ret;);
 
 #if !defined(WOLFSSL_RSA_VERIFY_ONLY) && !defined(TEST_UNPAD_CONSTANT_TIME) && \
@@ -3192,7 +3194,7 @@ static int wc_RsaFunction_ex(const byte* in, word32 inLen, byte* out,
         wc_RsaCleanup(key);
     }
     return ret;
-#endif /* WOLF_CRYPTO_CB_ONLY_RSA */
+#endif /* !WOLF_CRYPTO_CB_ONLY_RSA */
 }
 
 int wc_RsaFunction(const byte* in, word32 inLen, byte* out,


### PR DESCRIPTION
`wolfcrypt/src/rsa.c`: in `wc_RsaFunction_ex()`, if `defined(WOLF_CRYPTO_CB_ONLY_RSA)`, add clause to return `NO_VALID_DEVID` if `key->devId == INVALID_DEVID`.  fixes "control reaches end of non-void function" in `PRB-single-flag.txt`.

`wolfcrypt/src/ecc.c`: fix logic around `WOLF_CRYPTO_CB_ONLY_ECC` in `wc_ecc_shared_secret()`, `_ecc_make_key_ex()`, `wc_ecc_sign_hash()`, and `wc_ecc_verify_hash()` (defects reported by `-Wreturn-type`, `-Wmaybe-uninitialized` around `err`, and a failure of `ecc_onlycb_test()`).

tested with `wolfssl-multi-test.sh ... check-source-text all-gcc-c99`, and with `CFLAGS="-DWOLF_CRYPTO_CB_ONLY_RSA -DWOLF_CRYPTO_CB_ONLY_ECC -DUSE_CERT_BUFFERS_256" --enable-cryptocb --disable-examples`.

fixes defects in `master`:
```
Testing configuration:
CFLAGS="-DWOLF_CRYPTO_CB_ONLY_RSA -DWOLF_CRYPTO_CB_ONLY_ECC -DUSE_CERT_BUFFERS_256" --enable-cryptocb --disable-examples 
The case with CFLAGS + double-quotes
EXTRACTED_CFLAGS = -DWOLF_CRYPTO_CB_ONLY_RSA -DWOLF_CRYPTO_CB_ONLY_ECC -DUSE_CERT_BUFFERS_256
Testing CONFIG_REMAINDER =  --enable-cryptocb --disable-examples 
Configure RESULT = 0

make[2]: warning: -j17 forced in submake: resetting jobserver mode.
wolfcrypt/src/rsa.c: In function ‘wc_RsaFunction_ex’:
wolfcrypt/src/rsa.c:3196:1: error: control reaches end of non-void function [-Werror=return-type]
 3196 | }
      | ^
```
and
```
wolfcrypt/src/ecc.c: In function '_ecc_make_key_ex':
wolfcrypt/src/ecc.c:5863:1: error: control reaches end of non-void function [-Werror=return-type]
 5863 | }
      | ^
wolfcrypt/src/ecc.c: In function 'wc_ecc_sign_hash':
wolfcrypt/src/ecc.c:6550:9: error: 'err' may be used uninitialized [-Werror=maybe-uninitialized]
 6550 |     int err;
      |         ^~~
wolfcrypt/src/ecc.c: In function 'wc_ecc_verify_hash':
wolfcrypt/src/ecc.c:8270:9: error: 'err' may be used uninitialized [-Werror=maybe-uninitialized]
 8270 |     int err;
      |         ^~~
```
