### PR TITLE
Fix WOLFSSL_NO_MALLOC build.

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -12556,7 +12556,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aesgcm_test(void)
 
 #else
     byte large_input[BENCH_AESGCM_LARGE];
-    byte large_output[BENCH_AESGCM_LARGE];
+    byte large_output[BENCH_AESGCM_LARGE + AES_BLOCK_SIZE];
     byte large_outdec[BENCH_AESGCM_LARGE];
 #endif
 


### PR DESCRIPTION
# Description
This issue is in the wolfCrypt test application only, not the library proper.

Fix memset overrun build error:
```
error: 'memset' will always overflow; destination buffer has size 1024, but size argument is 1040 [-Werror,-Wfortify-source]
```

The static array NO_MALLOC version of `large_output` is shorter than the dynamic malloc version.

# Testing

```
cd src || exit 1            
                                                             
./configure \                                                
  --enable-staticmemory \
  CPPFLAGS=-DWOLFSSL_NO_MALLOC \                             
 || exit 1                                                   
                                                             
make || exit 1                                               
                                                             
./wolfcrypt/test/testwolfcrypt || exit 1                     
                                                             
echo "built wolfssl"
```