### PR TITLE
TLS 1.3, HRR Cookie: send cookie back in new ClientHello

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -6479,7 +6479,7 @@ static int TLSX_Cookie_Parse(WOLFSSL* ssl, const byte* input, word16 length,
         return BUFFER_E;
 
     if (msgType == hello_retry_request)
-        return TLSX_Cookie_Use(ssl, input + idx, len, NULL, 0, 0,
+        return TLSX_Cookie_Use(ssl, input + idx, len, NULL, 0, 1,
                                &ssl->extensions);
 
     /* client_hello */


### PR DESCRIPTION
# Description

Make it mandatory that the cookie is sent back in new ClientHello when seen in a HelloRetryRequest.

Fixes zd#17292

# Testing

./examples/server/server -v 4 -J
./examples/client/client -v 4 -J
(This is also in tests/test-tls13.conf)

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
