### PR TITLE
Add EC_POINT_hex2point

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -59640,6 +59640,7 @@ static int test_wolfSSL_EC_POINT(void)
     EC_POINT* Gxy = NULL;
     EC_POINT* new_point = NULL;
     EC_POINT* set_point = NULL;
+    EC_POINT* get_point = NULL;
     EC_POINT* infinity = NULL;
     BIGNUM* k = NULL;
     BIGNUM* Gx = NULL;
@@ -59657,6 +59658,14 @@ static int test_wolfSSL_EC_POINT(void)
                         "77037D812DEB33A0F4A13945D898C296";
     const char* kGy   = "4FE342E2FE1A7F9B8EE7EB4A7C0F9E16"
                         "2BCE33576B315ECECBB6406837BF51F5";
+    const char* uncompG
+                      = "046B17D1F2E12C4247F8BCE6E563A440F2"
+                        "77037D812DEB33A0F4A13945D898C296"
+                        "4FE342E2FE1A7F9B8EE7EB4A7C0F9E16"
+                        "2BCE33576B315ECECBB6406837BF51F5";
+    const char* compG
+                      = "036B17D1F2E12C4247F8BCE6E563A440F2"
+                        "77037D812DEB33A0F4A13945D898C296";
 
 #ifndef HAVE_SELFTEST
     EC_POINT *tmp = NULL;
@@ -59665,10 +59674,6 @@ static int test_wolfSSL_EC_POINT(void)
     unsigned char* buf = NULL;
     unsigned char bufInf[1] = { 0x00 };
 
-    const char* uncompG   = "046B17D1F2E12C4247F8BCE6E563A440F2"
-                              "77037D812DEB33A0F4A13945D898C296"
-                              "4FE342E2FE1A7F9B8EE7EB4A7C0F9E16"
-                              "2BCE33576B315ECECBB6406837BF51F5";
     const unsigned char binUncompG[] = {
         0x04, 0x6b, 0x17, 0xd1, 0xf2, 0xe1, 0x2c, 0x42, 0x47, 0xf8, 0xbc,
         0xe6, 0xe5, 0x63, 0xa4, 0x40, 0xf2, 0x77, 0x03, 0x7d, 0x81, 0x2d,
@@ -59686,8 +59691,6 @@ static int test_wolfSSL_EC_POINT(void)
         0x5e, 0xce, 0xcb, 0xb6, 0x40, 0x68, 0x37, 0xbf, 0x51, 0xf5,
     };
 
-    const char* compG   = "036B17D1F2E12C4247F8BCE6E563A440F2"
-                            "77037D812DEB33A0F4A13945D898C296";
 #ifdef HAVE_COMP_KEY
     const unsigned char binCompG[] = {
         0x03, 0x6b, 0x17, 0xd1, 0xf2, 0xe1, 0x2c, 0x42, 0x47, 0xf8, 0xbc,
@@ -59912,7 +59915,6 @@ static int test_wolfSSL_EC_POINT(void)
 #endif
     XFREE(hexStr, NULL, DYNAMIC_TYPE_ECC);
 
-#ifndef HAVE_SELFTEST
     /* Test point to hex */
     ExpectNull(EC_POINT_point2hex(NULL, NULL, POINT_CONVERSION_UNCOMPRESSED,
         ctx));
@@ -59929,13 +59931,22 @@ static int test_wolfSSL_EC_POINT(void)
     hexStr = EC_POINT_point2hex(group, Gxy, POINT_CONVERSION_UNCOMPRESSED, ctx);
     ExpectNotNull(hexStr);
     ExpectStrEQ(hexStr, uncompG);
+    AssertNotNull(get_point = EC_POINT_hex2point(group, hexStr, NULL, ctx));
+    AssertIntEQ(EC_POINT_cmp(group, Gxy, get_point, ctx), 0);
     XFREE(hexStr, NULL, DYNAMIC_TYPE_ECC);
 
     hexStr = EC_POINT_point2hex(group, Gxy, POINT_CONVERSION_COMPRESSED, ctx);
     ExpectNotNull(hexStr);
     ExpectStrEQ(hexStr, compG);
+    #ifdef HAVE_COMP_KEY
+    AssertNotNull(get_point = EC_POINT_hex2point
+                                            (group, hexStr, get_point, ctx));
+    AssertIntEQ(EC_POINT_cmp(group, Gxy, get_point, ctx), 0);
+    #endif
     XFREE(hexStr, NULL, DYNAMIC_TYPE_ECC);
+    EC_POINT_free(get_point);
 
+#ifndef HAVE_SELFTEST
     /* Test point to oct */
     ExpectIntEQ(EC_POINT_point2oct(NULL, NULL, POINT_CONVERSION_UNCOMPRESSED,
         NULL, 0, ctx), 0);

--- a/wolfssl/openssl/ec.h
+++ b/wolfssl/openssl/ec.h
@@ -306,12 +306,14 @@ WOLFSSL_API
 int wolfSSL_EC_POINT_is_at_infinity(const WOLFSSL_EC_GROUP *group,
                                     const WOLFSSL_EC_POINT *a);
 
-#ifndef HAVE_SELFTEST
 WOLFSSL_API
 char* wolfSSL_EC_POINT_point2hex(const WOLFSSL_EC_GROUP* group,
                                  const WOLFSSL_EC_POINT* point, int form,
                                  WOLFSSL_BN_CTX* ctx);
-#endif
+WOLFSSL_API
+WOLFSSL_EC_POINT *wolfSSL_EC_POINT_hex2point
+                                (const WOLFSSL_EC_GROUP *group, const char *hex,
+                                    WOLFSSL_EC_POINT *p, WOLFSSL_BN_CTX *ctx);
 
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 
@@ -395,9 +397,8 @@ typedef WOLFSSL_EC_BUILTIN_CURVE      EC_builtin_curve;
 #define EC_KEY_set_conv_form            wolfSSL_EC_KEY_set_conv_form
 #define EC_KEY_get_conv_form            wolfSSL_EC_KEY_get_conv_form
 
-#ifndef HAVE_SELFTEST
-    #define EC_POINT_point2hex          wolfSSL_EC_POINT_point2hex
-#endif
+#define EC_POINT_point2hex              wolfSSL_EC_POINT_point2hex
+#define EC_POINT_hex2point              wolfSSL_EC_POINT_hex2point
 
 #define EC_POINT_dump                   wolfSSL_EC_POINT_dump
 #define EC_get_builtin_curves           wolfSSL_EC_get_builtin_curves


### PR DESCRIPTION
# Description

Add EC_POINT_hex2point
Enable HAVE_COMP_KEY for Compressed Key

Fixes zd #17090

# Testing
    compressed and uncompressed in test_wolfSSL_EC_POINT, api.c

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
