### PR TITLE
Fix arm64 kernel module build

### DIFF
--- a/linuxkm/Kbuild
+++ b/linuxkm/Kbuild
@@ -30,6 +30,10 @@ endif
 
 WOLFSSL_CFLAGS += -ffreestanding -Wframe-larger-than=$(MAX_STACK_FRAME_SIZE) -isystem $(shell $(CC) -print-file-name=include)
 
+ifeq "$(KERNEL_ARCH)" "arm64"
+	WOLFSSL_CFLAGS += -mno-outline-atomics
+endif
+
 ifeq "$(KERNEL_ARCH)" "x86"
     WOLFSSL_CFLAGS += -mpreferred-stack-boundary=4
 endif
@@ -49,7 +53,11 @@ hostprogs := linuxkm/get_thread_size
 always-y := $(hostprogs)
 # "-mindirect-branch=keep -mfunction-return=keep" to avoid "undefined reference
 #  to `__x86_return_thunk'" on CONFIG_RETHUNK kernels (5.19.0-rc7)
-HOST_EXTRACFLAGS += $(NOSTDINC_FLAGS) $(LINUXINCLUDE) $(KBUILD_CFLAGS) -static -fno-omit-frame-pointer -mindirect-branch=keep -mfunction-return=keep
+HOST_EXTRACFLAGS += $(NOSTDINC_FLAGS) $(LINUXINCLUDE) $(KBUILD_CFLAGS) -static -fno-omit-frame-pointer
+
+ifeq "$(KERNEL_ARCH)" "x86"
+	HOST_EXTRACFLAGS += -mindirect-branch=keep -mfunction-return=keep
+endif
 
 # this rule is needed to get build to succeed in 4.x (get_thread_size still doesn't get built)
 $(obj)/linuxkm/get_thread_size: $(src)/linuxkm/get_thread_size.c


### PR DESCRIPTION
# Description

This PR fixes the kernel module build on arm64. I wanted to build the wolfssl kernel module, and it turned out that some of the x86 gcc flags `-mindirect-branch=keep -mfunction-return=keep` are not behind conditions. Also on arm64, another gcc flag must be used otherwise the build fails.

# Testing

How did you test?
For testing, I used a Apple M1 powered Macbook Pro with Lima running its Ubuntu LTS template.
Lima version: 0.19.1
Kernel version: lima-ubuntu 5.15.0-91-generic

The following commands were used:

```
sudo apt install autoconf
sudo apt install libtool
sudo apt install make
./autogen.sh
./configure --enable-linuxkm --with-linux-source=/lib/modules/`uname -r`/build
make module
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
