### PR TITLE
Update IAR-EWARM project user-settings.h.

### DIFF
--- a/IDE/IAR-EWARM/Projects/user_settings.h
+++ b/IDE/IAR-EWARM/Projects/user_settings.h
@@ -1,4 +1,3 @@
-
 #define NO_MAIN_DRIVER
 #define BENCH_EMBEDDED
 #define NO_WRITEV
@@ -17,10 +16,59 @@
 
 #define WOLFSSL_GENSEED_FORTEST /* Warning: define your own seed gen */
 
-#define TFM_TIMING_RESISTANT
+/* A few examples of different math options below.
+ *
+ * See examples/configs/user_settings_template.h for a more
+ * detailed template. */
+#if 1
+    /* Use only single precision (SP) math and algorithms.
+     * SP math is written to accelerate specific/common key
+     * sizes and curves. This adds code from sp_c32.c, or one of the specific
+     * assembly implementations like sp_cortexm.c. This code is faster than the
+     * multi-precision support because it's optimized for the key/curve.
+     * The SP math can be used together with any multi-precision math library
+     * if WOLFSSL_SP_MATH is removed. If only standard keys/curves are being
+     * used the multi-precision math is not required.
+     */
+    #define WOLFSSL_SP_MATH
+    /* Enable SP ECC support */
+    #define WOLFSSL_HAVE_SP_ECC
+    /* Enable SP RSA support */
+    #define WOLFSSL_HAVE_SP_RSA
+    /* Enable SP DH support */
+    #define WOLFSSL_HAVE_SP_DH
+    /* Reduce stack use specifically in SP implementation.  */
+    #define WOLFSSL_SP_SMALL_STACK
+    /* use smaller version of code */
+    #define WOLFSSL_SP_SMALL
+    /* Assembly optimized version - sp_cortexm.c */
+    //#define WOLFSSL_SP_ARM_CORTEX_M_ASM
+#elif 1
+    /* Use SP math for all key sizes and curves. This will use
+     * the multi-precision (MP) math implementation in sp_int.c */
+    #define WOLFSSL_SP_MATH_ALL
+    /* Disable use of dynamic stack items */
+    #define WOLFSSL_SP_NO_DYN_STACK
+    /* use smaller version of code */
+    #define WOLFSSL_SP_SMALL
+#elif 1
+    /* Fast Math (tfm.c) (stack based and timing resistant) */
+    #define USE_FAST_MATH
+    /* Enable Fast Math Timing Resistance */
+    #define TFM_TIMING_RESISTANT
+#else
+    /* Normal (integer.c) (heap based, not timing resistant) - not recommended*/
+    #define USE_INTEGER_HEAP_MATH
+#endif
+
+/* Enable ECC Timing Resistance */
 #define ECC_TIMING_RESISTANT
+/* Enables blinding mode, to prevent timing attacks */
 #define WC_RSA_BLINDING
 
+/* reduce stack use. For variables over 100 bytes allocate from heap */
+#define WOLFSSL_SMALL_STACK
+/* disable mutex locking */
 #define SINGLE_THREADED  /* or define RTOS  option */
 /* #define WOLFSSL_CMSIS_RTOS */
 #define NO_FILESYSTEM


### PR DESCRIPTION
# Description

The `IAR-EWARM/Projects/user_settings.h` was outdated and assumed fast-math by default. This resulted in many build errors when building IAR-EWARM wolfssl-lib.a.

Update the user_settings.h to use SP Math All.

Fixes zd#17406

# Testing

Built wolfssl lib with IAR ARM IDE on windows.
