### PR TITLE
If bio.h is included first then it can't include options.h on its own

### DIFF
--- a/wolfssl/openssl/bio.h
+++ b/wolfssl/openssl/bio.h
@@ -25,6 +25,7 @@
 #ifndef WOLFSSL_BIO_H_
 #define WOLFSSL_BIO_H_
 
+#include <wolfssl/openssl/ssl.h>
 
 #ifdef __cplusplus
     extern "C" {


### PR DESCRIPTION
When EXTERNAL_OPTS_OPENVPN is defined, we should be including options.h internally. When bio.h is included first, we don't include options.h and we don't pass the `#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)` guard.
