### PR TITLE
openssh 9.6p1 fixes

### DIFF
--- a/.github/workflows/openssh.yml
+++ b/.github/workflows/openssh.yml
@@ -1,0 +1,72 @@
+name: openssh Tests
+
+on:
+  workflow_call:
+  # TODO: remove this from PR
+  push:
+
+jobs:
+  build_wolfssl:
+    name: Build wolfSSL
+    # Just to keep it the same as the testing target
+    runs-on: ubuntu-latest
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 4
+    steps:
+      - name: Build wolfSSL
+        uses: wolfSSL/actions-build-autotools-project@v1
+        with:
+          path: wolfssl
+          configure: >-
+            --enable-openssh --enable-dsa --with-max-rsa-bits=8192
+            --enable-intelasm --enable-sp-asm
+          install: true
+
+      - name: Upload built lib
+        uses: actions/upload-artifact@v4
+        with:
+          name: wolf-install-openssh
+          path: build-dir
+          retention-days: 1
+
+  openssh_check:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - git_ref: 'V_9_6_P1'
+            osp_ver: '9.6'
+    name: ${{ matrix.ref }}
+    runs-on: ubuntu-latest
+    needs: build_wolfssl
+    steps:
+      - name: Download lib
+        uses: actions/download-artifact@v4
+        with:
+          name: wolf-install-openssh
+          path: build-dir
+
+      - name: Checkout OSP
+        uses: actions/checkout@v4
+        with:
+          # TODO: update with wolfssl repo after merge
+          repository: julek-wolfssl/osp
+          ref: openssh-9.6
+          path: osp
+
+      - name: Build and test openssh
+        uses: wolfSSL/actions-build-autotools-project@v1
+        with:
+          repository: openssh/openssh-portable
+          ref: ${{ matrix.git_ref }}
+          path: openssh
+          patch-file: $GITHUB_WORKSPACE/osp/openssh-patches/openssh-${{ matrix.osp_ver }}.patch
+          configure: --with-wolfssl=$GITHUB_WORKSPACE/build-dir --with-rpath=-Wl,-rpath=
+          check: false
+
+      # make tests take >20 minutes. Consider limiting? 
+      - name: Run tests
+        working-directory: ./openssh
+        run: |
+          # Run all the tests except (t-exec) as it takes too long
+          make file-tests interop-tests extra-tests unit

--- a/src/pk.c
+++ b/src/pk.c
@@ -5033,15 +5033,19 @@ int wolfSSL_DSA_set0_key(WOLFSSL_DSA *d, WOLFSSL_BIGNUM *pub_key,
     WOLFSSL_ENTER("wolfSSL_DSA_set0_key");
 
     /* The private key may be NULL */
-    if (pub_key == NULL) {
+    if (d->pub_key == NULL && pub_key == NULL) {
         WOLFSSL_MSG("Bad parameter");
         return 0;
     }
 
-    wolfSSL_BN_free(d->pub_key);
-    wolfSSL_BN_free(d->priv_key);
-    d->pub_key = pub_key;
-    d->priv_key = priv_key;
+    if (pub_key != NULL) {
+        wolfSSL_BN_free(d->pub_key);
+        d->pub_key = pub_key;
+    }
+    if (priv_key != NULL) {
+        wolfSSL_BN_free(d->priv_key);
+        d->priv_key = priv_key;
+    }
 
     return 1;
 }

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -5358,6 +5358,9 @@ int mp_read_radix (mp_int * a, const char *str, int radix)
     ++str;
   }
 
+  /* Skip whitespace at end of str */
+  while (CharIsWhiteSpace(*str))
+    ++str;
   /* if digit in isn't null term, then invalid character was found */
   if (*str != '\0') {
      mp_zero (a);

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -545,6 +545,18 @@ WC_MISC_STATIC WC_INLINE int ByteToHexStr(byte in, char* out)
     return 0;
 }
 
+WC_MISC_STATIC WC_INLINE int CharIsWhiteSpace(char ch)
+{
+    switch (ch) {
+        case ' ':
+        case '\t':
+        case '\n':
+            return 1;
+        default:
+            return 0;
+    }
+}
+
 #ifndef WOLFSSL_NO_CT_OPS
 /* Constant time - mask set when a > b. */
 WC_MISC_STATIC WC_INLINE byte ctMaskGT(int a, int b)

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -18068,6 +18068,8 @@ static int _sp_read_radix_16(sp_int* a, const char* in)
     unsigned int s = 0;
     unsigned int j = 0;
     sp_int_digit d;
+    /* Skip whitespace at end of line */
+    int eol_done = 0;
 
     /* Make all nibbles in digit 0. */
     d = 0;
@@ -18078,9 +18080,12 @@ static int _sp_read_radix_16(sp_int* a, const char* in)
         int ch = (int)HexCharToByte(in[i]);
         /* Check for invalid character. */
         if (ch < 0) {
+            if (!eol_done && CharIsWhiteSpace(in[i]))
+                continue;
             err = MP_VAL;
             break;
         }
+        eol_done = 1;
 
         /* Check whether we have filled the digit. */
         if (s == SP_WORD_SIZE) {
@@ -18150,6 +18155,8 @@ static int _sp_read_radix_10(sp_int* a, const char* in)
             ch -= '0';
         }
         else {
+            if (CharIsWhiteSpace(ch))
+                continue;
             /* Return error on invalid character. */
             err = MP_VAL;
             break;

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -6029,7 +6029,13 @@ static int fp_read_radix(fp_int *a, const char *str, int radix)
       }
     }
     if (y >= radix) {
-      return FP_VAL;
+      /* Check if whitespace at end of line */
+      while (CharIsWhiteSpace(*str))
+        ++str;
+      if (*str)
+        return FP_VAL;
+      else
+        break;
     }
 
     /* if the char was found in the map

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -5945,6 +5945,8 @@ static int fp_read_radix_16(fp_int *a, const char *str)
 {
   int     i, j, k, neg;
   int     ch;
+  /* Skip whitespace at end of line */
+  int     eol_done = 0;
 
   /* if the leading digit is a
    * minus set the sign to negative.
@@ -5961,8 +5963,11 @@ static int fp_read_radix_16(fp_int *a, const char *str)
   for (i = (int)(XSTRLEN(str) - 1); i >= 0; i--) {
       ch = (int)HexCharToByte(str[i]);
       if (ch < 0) {
+        if (!eol_done && CharIsWhiteSpace(str[i]))
+          continue;
         return FP_VAL;
       }
+      eol_done = 1;
 
       k += j == DIGIT_BIT;
       j &= DIGIT_BIT - 1;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -44708,7 +44708,7 @@ static wc_test_ret_t mp_test_radix_10(mp_int* a, mp_int* r, WC_RNG* rng)
     char str[30];
     WOLFSSL_SMALL_STACK_STATIC const char* badStr1 = "A";
     WOLFSSL_SMALL_STACK_STATIC const char* badStr2 = "a";
-    WOLFSSL_SMALL_STACK_STATIC const char* badStr3 = " ";
+    WOLFSSL_SMALL_STACK_STATIC const char* empty2 = " ";
     WOLFSSL_SMALL_STACK_STATIC const char* zeros = "000";
     WOLFSSL_SMALL_STACK_STATIC const char* empty = "";
 
@@ -44740,8 +44740,8 @@ static wc_test_ret_t mp_test_radix_10(mp_int* a, mp_int* r, WC_RNG* rng)
     ret = mp_read_radix(r, badStr2, MP_RADIX_DEC);
     if (ret != MP_VAL)
         return WC_TEST_RET_ENC_EC(ret);
-    ret = mp_read_radix(r, badStr3, MP_RADIX_DEC);
-    if (ret != MP_VAL)
+    ret = mp_read_radix(r, empty2, MP_RADIX_DEC);
+    if (ret != MP_OKAY)
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = mp_read_radix(r, zeros, MP_RADIX_DEC);
@@ -44788,7 +44788,7 @@ static wc_test_ret_t mp_test_radix_16(mp_int* a, mp_int* r, WC_RNG* rng)
 #if defined(WOLFSSL_SP_MATH) || defined(USE_FAST_MATH)
     static char longStr[2 * sizeof(a->dp) + 2];
 #endif
-    WOLFSSL_SMALL_STACK_STATIC const char* badStr1 = " ";
+    WOLFSSL_SMALL_STACK_STATIC const char* empty2 = " ";
     WOLFSSL_SMALL_STACK_STATIC const char* badStr2 = "}";
     WOLFSSL_SMALL_STACK_STATIC const char* empty = "";
 
@@ -44808,8 +44808,8 @@ static wc_test_ret_t mp_test_radix_16(mp_int* a, mp_int* r, WC_RNG* rng)
         }
     }
 
-    ret = mp_read_radix(r, badStr1, MP_RADIX_HEX);
-    if (ret != MP_VAL)
+    ret = mp_read_radix(r, empty2, MP_RADIX_HEX);
+    if (ret != MP_OKAY)
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_read_radix(r, badStr2, MP_RADIX_HEX);
     if (ret != MP_VAL)

--- a/wolfssl/openssl/opensslv.h
+++ b/wolfssl/openssl/opensslv.h
@@ -36,7 +36,8 @@
      /* valid version */
 #elif defined(WOLFSSL_APACHE_HTTPD) || defined(HAVE_LIBEST) || \
       defined(WOLFSSL_BIND) || defined(WOLFSSL_NGINX) || \
-      defined(WOLFSSL_RSYSLOG) || defined(WOLFSSL_KRB) || defined(HAVE_STUNNEL)
+      defined(WOLFSSL_RSYSLOG) || defined(WOLFSSL_KRB) || defined(HAVE_STUNNEL) || \
+      defined(WOLFSSL_OPENSSH)
     /* For Apache httpd, Use 1.1.0 compatibility */
      #define OPENSSL_VERSION_NUMBER 0x10100003L
 #elif defined(WOLFSSL_QT) || defined(WOLFSSL_PYTHON) || defined(WOLFSSL_KRB)
@@ -45,7 +46,7 @@
 #elif defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_FFMPEG)
      #define OPENSSL_VERSION_NUMBER 0x1010000fL
 #elif defined(OPENSSL_ALL) || defined(HAVE_LIGHTY) || \
-    defined(WOLFSSL_NGINX) || defined(WOLFSSL_OPENSSH) || defined(WOLFSSL_OPENVPN)
+    defined(WOLFSSL_NGINX) || defined(WOLFSSL_OPENVPN)
      /* version number can be increased for Lighty after compatibility for ECDH
         is added */
      #define OPENSSL_VERSION_NUMBER 0x10001040L

--- a/wolfssl/wolfcrypt/misc.h
+++ b/wolfssl/wolfcrypt/misc.h
@@ -114,6 +114,7 @@ word32 btoi(byte b);
 WOLFSSL_LOCAL signed char HexCharToByte(char ch);
 WOLFSSL_LOCAL char ByteToHex(byte in);
 WOLFSSL_LOCAL int  ByteToHexStr(byte in, char* out);
+WOLFSSL_LOCAL int CharIsWhiteSpace(char ch);
 
 WOLFSSL_LOCAL byte ctMaskGT(int a, int b);
 WOLFSSL_LOCAL byte ctMaskGTE(int a, int b);


### PR DESCRIPTION
- wolfSSL_DSA_set0_key: allow setting just the public key
- radix: allow skipping the end of line whitespace
- Add openssh action