### PR TITLE
Fix ext_xmss sigsleft null deref.

### DIFF
--- a/wolfcrypt/src/ext_xmss.c
+++ b/wolfcrypt/src/ext_xmss.c
@@ -804,10 +804,10 @@ int  wc_XmssKey_SigsLeft(XmssKey* key)
         }
 
         ret = idx < ((1ULL << params->full_height) - 1);
-    }
 
-    /* Force zero the secret key from memory always. */
-    ForceZero(key->sk, key->sk_len);
+        /* Force zero the secret key from memory always. */
+        ForceZero(key->sk, key->sk_len);
+    }
 
     return ret;
 }


### PR DESCRIPTION
# Description

Fix null pointer deref found with cppcheck. Only ForceZero the secret key in the last if else branch where key != null and reading key->sk succeeded.