### PR TITLE
20240203-linuxkm-fixes

### DIFF
--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -292,7 +292,7 @@
          * AES_ENCRYPTION_AND_DECRYPTION on AES-XTS.
          */
         #ifndef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
-        #define WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
+            #define WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
         #endif
     #endif
 
@@ -822,6 +822,11 @@
         #define realloc(ptr, newsize) krealloc(ptr, WC_LINUXKM_ROUND_UP_P_OF_2(newsize), GFP_KERNEL)
     #endif
 
+    #ifndef static_assert
+        #define static_assert(expr, ...) __static_assert(expr, ##__VA_ARGS__, #expr)
+        #define __static_assert(expr, msg, ...) _Static_assert(expr, msg)
+    #endif
+
     #include <wolfssl/wolfcrypt/memory.h>
 
 #ifdef WOLFSSL_TRACK_MEMORY
@@ -848,7 +853,7 @@
      * them to be evaluable by the preprocessor, for use in sp_int.h.
      */
     #if BITS_PER_LONG == 64
-        _Static_assert(sizeof(ULONG_MAX) == 8,
+        static_assert(sizeof(ULONG_MAX) == 8,
                        "BITS_PER_LONG is 64, but ULONG_MAX is not.");
 
         #undef UCHAR_MAX
@@ -870,7 +875,7 @@
 
     #elif BITS_PER_LONG == 32
 
-        _Static_assert(sizeof(ULONG_MAX) == 4,
+        static_assert(sizeof(ULONG_MAX) == 4,
                        "BITS_PER_LONG is 32, but ULONG_MAX is not.");
 
         #undef UCHAR_MAX

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -12356,32 +12356,35 @@ int wc_AesXtsSetKeyNoInit(XtsAes* aes, const byte* key, word32 len, int dir)
          * conflicting _aesni status, but the AES-XTS asm implementations need
          * them to all be AESNI.  If any aren't, disable AESNI on all.
          */
-        if ((((dir == AES_ENCRYPTION)
-#ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
-              || (dir == AES_ENCRYPTION_AND_DECRYPTION)
-#endif
-             ) &&
-             (aes->aes.use_aesni != aes->tweak.use_aesni))
-#ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
+    #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
+        if ((((dir == AES_ENCRYPTION) ||
+              (dir == AES_ENCRYPTION_AND_DECRYPTION))
+             && (aes->aes.use_aesni != aes->tweak.use_aesni))
             ||
-            (((dir == AES_DECRYPTION)
-              || (dir == AES_ENCRYPTION_AND_DECRYPTION)) &&
-             (aes->aes_decrypt.use_aesni != aes->tweak.use_aesni))
-#endif
-            )
+            (((dir == AES_DECRYPTION) ||
+              (dir == AES_ENCRYPTION_AND_DECRYPTION))
+             && (aes->aes_decrypt.use_aesni != aes->tweak.use_aesni)))
         {
-#ifdef WC_AES_C_DYNAMIC_FALLBACK
+        #ifdef WC_AES_C_DYNAMIC_FALLBACK
             aes->aes.use_aesni = 0;
-#ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
             aes->aes_decrypt.use_aesni = 0;
-#endif
             aes->tweak.use_aesni = 0;
-#else
+        #else
             ret = SYSLIB_FAILED_E;
-#endif
+        #endif
         }
+    #else /* !WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS */
+        if (aes->aes.use_aesni != aes->tweak.use_aesni) {
+        #ifdef WC_AES_C_DYNAMIC_FALLBACK
+            aes->aes.use_aesni = 0;
+            aes->tweak.use_aesni = 0;
+        #else
+            ret = SYSLIB_FAILED_E;
+        #endif
+        }
+    #endif /* !WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS */
     }
-#endif
+#endif /* WOLFSSL_AESNI */
 
     return ret;
 }


### PR DESCRIPTION
linuxkm fixes:
`linuxkm/linuxkm_wc_port.h`: add fallback definition for `static_assert()` to support legacy kernels.
`wolfcrypt/src/aes.c`: fix AESNI runtime failure/fallback logic in `wc_AesXtsSetKeyNoInit()`.

tested with `wolfssl-multi-test.sh ... check-self check-source-text cppcheck-all clang-tidy-all-sp-all linuxkm-aesni-DEBUG_VECTOR_REGISTER_ACCESS_FUZZING-insmod sanitizer-all-intelasm-c-fallback-fuzzer linuxkm-aesni-LKCS-no-twc-insmod-ksanitize-6.1.73 linuxkm-aesni-ksanitize-insmod linuxkm-mainline-plus-wireguard linuxkm-legacy-3.16 linuxkm-legacy-4.4 linuxkm-legacy-4.9` (some of these are new tests not yet in nightly production)
