### PR TITLE
20240206-cmake-install-rule-by-default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,7 @@ if(WOLFSSL_REPRODUCIBLE_BUILD)
     set(CMAKE_C_ARCHIVE_FINISH "<CMAKE_RANLIB> -D <TARGET>")
 endif()
 
-add_option("WOLFSSL_INSTALL" "Create install target for WolfSSL project" "no" "yes;no")
+add_option("WOLFSSL_INSTALL" "Create install target for WolfSSL project" "yes" "yes;no")
 
 # Support for forcing 32-bit mode
 # TODO: detect platform from other options


### PR DESCRIPTION
`CMakeLists.txt`: include the `install` rule by default, disabled with `-DWOLFSSL_INSTALL=no`, to restore status quo ante.  see #7188

tested with `cmake ..` and `cmake -DWOLFSSL_INSTALL=no ..`, each followed by `make install`, confirming `install` rule functions by default but is absent with `cmake -DWOLFSSL_INSTALL=no ..`.
