### PR TITLE
tls13: wolfSSL_read_early_data() set outSz to 0 if no early data and update doc

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -14357,6 +14357,7 @@ int wolfSSL_read_early_data(WOLFSSL* ssl, void* data, int sz, int* outSz)
     if (!IsAtLeastTLSv1_3(ssl->version))
         return BAD_FUNC_ARG;
 
+    *outSz = 0;
 #ifndef NO_WOLFSSL_SERVER
     if (ssl->options.side == WOLFSSL_CLIENT_END)
         return SIDE_ERROR;

--- a/tests/api.c
+++ b/tests/api.c
@@ -69268,6 +69268,7 @@ static int test_tls13_early_data(void)
                 ExpectFalse(wolfSSL_is_init_finished(ssl_s));
                 ExpectIntEQ(wolfSSL_read_early_data(ssl_s, msgBuf, sizeof(msgBuf),
                         &read), 0);
+                ExpectIntEQ(read, 0);
                 ExpectTrue(wolfSSL_is_init_finished(ssl_s));
 
                 ExpectIntEQ(wolfSSL_connect(ssl_c), WOLFSSL_SUCCESS);
@@ -69278,7 +69279,7 @@ static int test_tls13_early_data(void)
                 ExpectFalse(wolfSSL_is_init_finished(ssl_s));
                 ExpectIntEQ(wolfSSL_read_early_data(ssl_s, msgBuf, sizeof(msgBuf),
                         &read), 0);
-
+                ExpectIntEQ(read, 0);
                 ExpectTrue(wolfSSL_is_init_finished(ssl_s));
 
                 /* Read server 0.5-RTT data */


### PR DESCRIPTION
# Description

The function has a different return behavior compared to the doc. It also fails to set outSz to zero if no early data are received. Fixed and updated the doc.

