### PR TITLE
Add wolfSSL debug messages

### DIFF
--- a/src/ssl_certman.c
+++ b/src/ssl_certman.c
@@ -25,7 +25,7 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
- #include <wolfssl/internal.h>
+#include <wolfssl/internal.h>
 
 #if !defined(WOLFSSL_SSL_CERTMAN_INCLUDED)
     #ifndef WOLFSSL_IGNORE_FILE_WARN
@@ -89,11 +89,22 @@ WOLFSSL_CERT_MANAGER* wolfSSL_CertManagerNew_ex(void* heap)
     WOLFSSL_CERT_MANAGER* cm;
 
     WOLFSSL_ENTER("wolfSSL_CertManagerNew");
+    if (heap == NULL) {
+         WOLFSSL_MSG("heap param is null");
+    }
+    else {
+        /* Some systems may have heap in unexpected segments. (IRAM vs DRAM) */
+        WOLFSSL_MSG_EX("heap param = %p", heap);
+    }
+    WOLFSSL_MSG_EX("DYNAMIC_TYPE_CERT_MANAGER Allocating = %d bytes",
+                    (word32)sizeof(WOLFSSL_CERT_MANAGER));
 
     /* Allocate memory for certificate manager. */
     cm = (WOLFSSL_CERT_MANAGER*)XMALLOC(sizeof(WOLFSSL_CERT_MANAGER), heap,
         DYNAMIC_TYPE_CERT_MANAGER);
     if (cm == NULL) {
+        WOLFSSL_MSG_EX("XMALLOC failed to allocate WOLFSSL_CERT_MANAGER %d "
+                    "bytes.", (int)sizeof(WOLFSSL_CERT_MANAGER));
         err = 1;
     }
     if (!err) {

--- a/src/tls.c
+++ b/src/tls.c
@@ -7459,7 +7459,9 @@ static int TLSX_KeyShare_GenEccKey(WOLFSSL *ssl, KeyShareEntry* kse)
         /* Allocate an ECC key to hold private key. */
         kse->key = (byte*)XMALLOC(sizeof(ecc_key), ssl->heap, DYNAMIC_TYPE_ECC);
         if (kse->key == NULL) {
-            WOLFSSL_MSG("EccTempKey Memory error");
+            WOLFSSL_MSG_EX("Failed to allocate %d bytes, ssl->heap: %p",
+                           (int)sizeof(ecc_key), (uintptr_t)ssl->heap);
+            WOLFSSL_MSG("EccTempKey Memory error!");
             return MEMORY_E;
         }
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -12633,7 +12633,7 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
             }
 
             ssl->options.connectState = CLIENT_HELLO_SENT;
-            WOLFSSL_MSG("connect state: CLIENT_HELLO_SENT");
+            WOLFSSL_MSG("TLSv13 connect state: CLIENT_HELLO_SENT");
     #ifdef WOLFSSL_EARLY_DATA
             if (ssl->earlyData != no_early_data) {
         #if defined(WOLFSSL_TLS13_MIDDLEBOX_COMPAT)

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -527,10 +527,10 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
     #endif /* HAVE_AES_DECRYPT */
 
 #elif defined(WOLFSSL_ESP32_CRYPT) && \
-    !defined(NO_WOLFSSL_ESP32_CRYPT_AES)
+     !defined(NO_WOLFSSL_ESP32_CRYPT_AES)
     #include <esp_log.h>
     #include <wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h>
-    const char* TAG = "aes";
+    #define TAG "aes"
 
     /* We'll use SW for fallback:
      *   unsupported key lengths. (e.g. ESP32-S3)
@@ -967,6 +967,10 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
 #endif
 
 
+
+#if defined(WC_AES_BITSLICED) && !defined(HAVE_AES_ECB)
+    #error "When WC_AES_BITSLICED is defined, HAVE_AES_ECB is needed."
+#endif
 
 #ifdef NEED_AES_TABLES
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3828,6 +3828,7 @@ int wc_ecc_mulmod_ex2(const mp_int* k, ecc_point* G, ecc_point* R, mp_int* a,
 #endif
    /* k can't have more bits than order */
    if (mp_count_bits(k) > mp_count_bits(order)) {
+      WOLFSSL_MSG("Private key length is greater than order in bits.");
       return ECC_OUT_OF_RANGE_E;
    }
 
@@ -5801,19 +5802,32 @@ static int _ecc_make_key_ex(WC_RNG* rng, int keysize, ecc_key* key,
         /* load curve info */
         if (err == MP_OKAY) {
             ALLOC_CURVE_SPECS(ECC_CURVE_FIELD_COUNT, err);
+            if (err != MP_OKAY) {
+                WOLFSSL_MSG("ALLOC_CURVE_SPECS failed");
+            }
         }
+
         if (err == MP_OKAY) {
             err = wc_ecc_curve_load(key->dp, &curve, ECC_CURVE_FIELD_ALL);
+            if (err != MP_OKAY) {
+                WOLFSSL_MSG("wc_ecc_curve_load failed");
+            }
         }
 
         /* generate k */
         if (err == MP_OKAY) {
             err = wc_ecc_gen_k(rng, key->dp->size, key->k, curve->order);
+            if (err != MP_OKAY) {
+                WOLFSSL_MSG("wc_ecc_gen_k failed");
+            }
         }
 
         /* generate public key from k */
         if (err == MP_OKAY) {
             err = ecc_make_pub_ex(key, curve, NULL, rng);
+            if (err != MP_OKAY) {
+                WOLFSSL_MSG("ecc_make_pub_ex failed");
+            }
         }
 
         if (err == MP_OKAY

--- a/wolfcrypt/src/md5.c
+++ b/wolfcrypt/src/md5.c
@@ -454,6 +454,7 @@ int wc_Md5Final(wc_Md5* md5, byte* hash)
 
     /* ensure we have a valid buffer length; (-1 to append a byte to length) */
     if (md5->buffLen > WC_MD5_BLOCK_SIZE - 1) {
+        /* some places consider this BAD_STATE_E */
         return BUFFER_E;
     }
 

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -2681,12 +2681,16 @@ static int RsaFunctionSync(const byte* in, word32 inLen, byte* out,
 
     NEW_MP_INT_SIZE(tmp, mp_bitsused(&key->n), key->heap, DYNAMIC_TYPE_RSA);
 #ifdef MP_INT_SIZE_CHECK_NULL
-    if (tmp == NULL)
+    if (tmp == NULL) {
+        WOLFSSL_MSG("NEW_MP_INT_SIZE tmp is NULL, return MEMORY_E");
         return MEMORY_E;
+    }
 #endif
 
-    if (INIT_MP_INT_SIZE(tmp, mp_bitsused(&key->n)) != MP_OKAY)
+    if (INIT_MP_INT_SIZE(tmp, mp_bitsused(&key->n)) != MP_OKAY) {
+        WOLFSSL_MSG("INIT_MP_INT_SIZE failed.");
         ret = MP_INIT_E;
+    }
 
 #ifndef TEST_UNPAD_CONSTANT_TIME
     if (ret == 0 && mp_read_unsigned_bin(tmp, in, inLen) != MP_OKAY)
@@ -2710,8 +2714,10 @@ static int RsaFunctionSync(const byte* in, word32 inLen, byte* out,
     #endif
         case RSA_PUBLIC_ENCRYPT:
         case RSA_PUBLIC_DECRYPT:
-            if (mp_exptmod_nct(tmp, &key->e, &key->n, tmp) != MP_OKAY)
+            if (mp_exptmod_nct(tmp, &key->e, &key->n, tmp) != MP_OKAY) {
+                WOLFSSL_MSG("mp_exptmod_nct failed");
                 ret = MP_EXPTMOD_E;
+            }
             break;
         default:
             ret = RSA_WRONG_TYPE_E;
@@ -2720,8 +2726,11 @@ static int RsaFunctionSync(const byte* in, word32 inLen, byte* out,
     }
 
     if (ret == 0) {
-        if (mp_to_unsigned_bin_len_ct(tmp, out, (int)*outLen) != MP_OKAY)
-             ret = MP_TO_E;
+        WOLFSSL_MSG("mp_to_unsigned_bin_len_ct...");
+        if (mp_to_unsigned_bin_len_ct(tmp, out, (int)*outLen) != MP_OKAY) {
+            WOLFSSL_MSG("mp_to_unsigned_bin_len_ct failed");
+            ret = MP_TO_E;
+        }
     }
 #ifdef WOLFSSL_RSA_CHECK_D_ON_DECRYPT
     if ((ret == 0) && (type == RSA_PRIVATE_DECRYPT)) {
@@ -2757,6 +2766,7 @@ static int wc_RsaFunctionSync(const byte* in, word32 inLen, byte* out,
 
     ret = wc_RsaEncryptSize(key);
     if (ret < 0) {
+        WOLFSSL_MSG_EX("wc_RsaEncryptSize failed err = %d", ret);
         return ret;
     }
     keyLen = (word32)ret;
@@ -2771,6 +2781,7 @@ static int wc_RsaFunctionSync(const byte* in, word32 inLen, byte* out,
     }
 
     if (mp_iseven(&key->n)) {
+        WOLFSSL_MSG("MP_VAL is even");
         return MP_VAL;
     }
 


### PR DESCRIPTION
# Description

The PR adds debug messages in various functions, mostly surrounding more informative failures. 

I found these useful while troubleshooting memory-constrained devices. It's particularly helpful to see the sizes of heap allocation attempts.

Of particular interest is [wolfSSL_new](https://github.com/gojimmypi/wolfssl/blob/2d7d68dc46ad43ca607e3c67cca9286bff9a3188/src/ssl.c#L1470C10-L1470C21) `XMALLOC` and the subsequent check of `InitSSL()` for positive return values. I didn't actually _see_ any. They _probably_ don't even occur. Still...

There's otherwise some tidying up and other minor changes.

Fixes zd# n/a

# Testing

How did you test?

Tested in Espressif environment and 

```
./configure --enable-all
make clean
make && make test
```

I did see a failure for this:

```
FAIL: testsuite/testsuite.test
```

But the exact same failure also occurs with a fresh clone of wolfssl.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
