### PR TITLE
20240208-test-config-and-linuxkm-tweaks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -745,7 +745,6 @@ then
     test "$enable_psk" = "" && enable_psk=yes
     test "$enable_cmac" = "" && enable_cmac=yes
     test "$enable_siphash" = "" && enable_siphash=yes
-    test "$enable_aesxts" = "" && enable_aesxts=yes
     test "$enable_ocsp" = "" && enable_ocsp=yes
     test "$enable_ocspstapling" = "" && test "$enable_ocsp" != "no" && enable_ocspstapling=yes
     test "$enable_ocspstapling2" = "" && test "$enable_ocsp" != "no" && enable_ocspstapling2=yes
@@ -787,6 +786,7 @@ then
     test "$enable_session_ticket" = "" && enable_session_ticket=yes
     test "$enable_earlydata" = "" && enable_earlydata=yes
     test "$enable_ech" = "" && enable_ech=yes
+    test "$enable_srtp" = "" && enable_srtp=yes
 
     if test "$ENABLED_32BIT" != "yes"
     then
@@ -861,7 +861,8 @@ then
         fi
     fi
 
-    if test "$ENABLED_FIPS" = "no" || test "$ENABLED_FIPS" = "dev"; then
+    if test "$ENABLED_FIPS" = "no" || test "$FIPS_VERSION" = "dev"; then
+        test "$enable_aesxts" = "" && enable_aesxts=yes
         test "$enable_aessiv" = "" && enable_aessiv=yes
     fi
 
@@ -933,7 +934,6 @@ then
     test "$enable_psk" = "" && enable_psk=yes
     test "$enable_cmac" = "" && enable_cmac=yes
     test "$enable_siphash" = "" && enable_siphash=yes
-    test "$enable_aesxts" = "" && enable_aesxts=yes
     test "$enable_ocsp" = "" && enable_ocsp=yes
     test "$enable_ocspstapling" = "" && test "$enable_ocsp" != "no" && enable_ocspstapling=yes
     test "$enable_ocspstapling2" = "" && test "$enable_ocsp" != "no" && enable_ocspstapling2=yes
@@ -959,6 +959,7 @@ then
     test "$enable_cryptocb" = "" && enable_cryptocb=yes
     test "$enable_anon" = "" && enable_anon=yes
     test "$enable_ssh" = "" && test "$enable_hmac" != "no" && enable_ssh=yes
+    test "$enable_srtp_kdf" = "" && enable_srtp_kdf=yes
 
     if test "$ENABLED_32BIT" != "yes"
     then
@@ -1001,7 +1002,8 @@ then
         fi
     fi
 
-    if test "$ENABLED_FIPS" = "no" || test "$ENABLED_FIPS" = "dev"; then
+    if test "$ENABLED_FIPS" = "no" || test "$FIPS_VERSION" = "dev"; then
+        test "$enable_aesxts" = "" && enable_aesxts=yes
         test "$enable_aessiv" = "" && enable_aessiv=yes
     fi
 
@@ -4848,13 +4850,6 @@ AC_ARG_ENABLE([xts],
     [ ENABLED_AESXTS=$enableval ]
     )
 
-AS_IF([test "x$ENABLED_AESXTS" = "xyes"],
-      [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_AES_XTS -DWOLFSSL_AES_DIRECT"])
-AS_IF([test "x$ENABLED_AESXTS" = "xyes" && test "x$ENABLED_INTELASM" = "xyes"],
-      [AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_AES_XTS"])
-AS_IF([test "x$ENABLED_AESXTS" = "xyes" && test "x$ENABLED_AESNI" = "xyes"],
-      [AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_AES_XTS"])
-
 # Web Server Build
 AC_ARG_ENABLE([webserver],
     [AS_HELP_STRING([--enable-webserver],[Enable Web Server (default: disabled)])],
@@ -4953,6 +4948,9 @@ AS_CASE([$FIPS_VERSION],
         AS_IF([test "$ENABLED_AESCCM" != "yes" && (test "$FIPS_VERSION" != "dev" || test "$enable_aesccm" != "no")],
             [ENABLED_AESCCM="yes"; AM_CFLAGS="$AM_CFLAGS -DHAVE_AESCCM"])
 
+        AS_IF([test "$ENABLED_AESXTS" = "yes" && (test "$FIPS_VERSION" != "dev" || test "$enable_aesxts" != "yes")],
+            [ENABLED_AESXTS="no"])
+
         AS_IF([test "$ENABLED_RSAPSS" != "yes" && (test "$FIPS_VERSION" != "dev" || test "$enable_rsapss" != "no")],
             [ENABLED_RSAPSS="yes"; AM_CFLAGS="$AM_CFLAGS -DWC_RSA_PSS"])
 
@@ -4994,7 +4992,8 @@ AS_CASE([$FIPS_VERSION],
         AS_IF([(test "$ENABLED_AESCCM" = "yes" && test "$HAVE_AESCCM_PORT" != "yes") ||
                (test "$ENABLED_AESCTR" = "yes" && test "$HAVE_AESCTR_PORT" != "yes") ||
                (test "$ENABLED_AESGCM" = "yes" && test "$HAVE_AESGCM_PORT" != "yes") ||
-               (test "$ENABLED_AESOFB" = "yes" && test "$HAVE_AESOFB_PORT" != "yes")],
+               (test "$ENABLED_AESOFB" = "yes" && test "$HAVE_AESOFB_PORT" != "yes") ||
+               (test "$ENABLED_AESXTS" = "yes" && test "$HAVE_AESXTS_PORT" != "yes")],
             [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_AES_DIRECT -DHAVE_AES_ECB"])
     ],
 
@@ -5098,6 +5097,14 @@ AS_CASE([$SELFTEST_VERSION],
     ["v1"],[
         AM_CFLAGS="$AM_CFLAGS -DHAVE_SELFTEST -DHAVE_PUBLIC_FFDHE"
     ])
+
+
+AS_IF([test "x$ENABLED_AESXTS" = "xyes"],
+      [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_AES_XTS -DWOLFSSL_AES_DIRECT"])
+AS_IF([test "x$ENABLED_AESXTS" = "xyes" && test "x$ENABLED_INTELASM" = "xyes"],
+      [AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_AES_XTS"])
+AS_IF([test "x$ENABLED_AESXTS" = "xyes" && test "x$ENABLED_AESNI" = "xyes"],
+      [AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_AES_XTS"])
 
 
 # Set SHA-3 flags

--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -120,7 +120,7 @@
     #include <linux/kernel.h>
     #include <linux/ctype.h>
 
-    #ifdef CONFIG_FORTIFY_SOURCE
+    #if defined(CONFIG_FORTIFY_SOURCE) || defined(DEBUG_LINUXKM_FORTIFY_OVERLAY)
         #ifdef __PIE__
             /* the inline definitions in fortify-string.h use non-inline
              * fortify_panic().
@@ -345,6 +345,8 @@
                     fail_clause                             \
                 }                                           \
             }
+        #endif
+        #ifndef SAVE_VECTOR_REGISTERS2
             #ifdef DEBUG_VECTOR_REGISTER_ACCESS_FUZZING
                 #define SAVE_VECTOR_REGISTERS2() ({                    \
                     int _fuzzer_ret = SAVE_VECTOR_REGISTERS2_fuzzer(); \
@@ -363,6 +365,8 @@
         #include <asm/fpsimd.h>
         #ifndef SAVE_VECTOR_REGISTERS
             #define SAVE_VECTOR_REGISTERS(fail_clause) { int _svr_ret = save_vector_registers_arm(); if (_svr_ret != 0) { fail_clause } }
+        #endif
+        #ifndef SAVE_VECTOR_REGISTERS2
             #define SAVE_VECTOR_REGISTERS2() save_vector_registers_arm()
         #endif
         #ifndef RESTORE_VECTOR_REGISTERS

--- a/wolfcrypt/src/curve25519.c
+++ b/wolfcrypt/src/curve25519.c
@@ -51,6 +51,14 @@
     #include <wolfssl/wolfcrypt/cryptocb.h>
 #endif
 
+#if defined(WOLFSSL_LINUXKM) && !defined(USE_INTEL_SPEEDUP)
+    /* force off unneeded vector register save/restore. */
+    #undef SAVE_VECTOR_REGISTERS
+    #define SAVE_VECTOR_REGISTERS(...) WC_DO_NOTHING
+    #undef RESTORE_VECTOR_REGISTERS
+    #define RESTORE_VECTOR_REGISTERS() WC_DO_NOTHING
+#endif
+
 const curve25519_set_type curve25519_sets[] = {
     {
         CURVE25519_KEYSIZE,

--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -55,6 +55,13 @@
     #include <wolfcrypt/src/misc.c>
 #endif
 
+#if defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_SP_ASM)
+    /* force off unneeded vector register save/restore. */
+    #undef SAVE_VECTOR_REGISTERS
+    #define SAVE_VECTOR_REGISTERS(...) WC_DO_NOTHING
+    #undef RESTORE_VECTOR_REGISTERS
+    #define RESTORE_VECTOR_REGISTERS() WC_DO_NOTHING
+#endif
 
 /*
 Possible DH enable options:
@@ -3003,7 +3010,7 @@ int wc_DhGenerateParams(WC_RNG *rng, int modSz, DhKey *dh)
 
     /* loop until p is prime */
     if (ret == 0) {
-        do {
+        for (;;) {
             if (mp_prime_is_prime_ex(&dh->p, 8, &primeCheck, rng) != MP_OKAY)
                 ret = PRIME_GEN_E;
 
@@ -3014,7 +3021,14 @@ int wc_DhGenerateParams(WC_RNG *rng, int modSz, DhKey *dh)
                 else
                     primeCheckCount++;
             }
-        } while (ret == 0 && primeCheck == MP_NO);
+
+            if (ret != 0 || primeCheck == MP_YES)
+                break;
+
+            /* linuxkm: release the kernel for a moment before iterating. */
+            RESTORE_VECTOR_REGISTERS();
+            SAVE_VECTOR_REGISTERS(ret = _svr_ret; break;);
+        };
     }
 
     /* tmp2 += (2*loop_check_prime)

--- a/wolfcrypt/src/dsa.c
+++ b/wolfcrypt/src/dsa.c
@@ -42,6 +42,14 @@
     #include <wolfcrypt/src/misc.c>
 #endif
 
+#if defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_SP_ASM)
+    /* force off unneeded vector register save/restore. */
+    #undef SAVE_VECTOR_REGISTERS
+    #define SAVE_VECTOR_REGISTERS(...) WC_DO_NOTHING
+    #undef RESTORE_VECTOR_REGISTERS
+    #define RESTORE_VECTOR_REGISTERS() WC_DO_NOTHING
+#endif
+
 #ifdef _MSC_VER
     /* disable for while(0) cases (MSVC bug) */
     #pragma warning(disable:4127)

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -213,6 +213,14 @@ ECC Curve Sizes:
     #include <wolfssl/wolfcrypt/hmac.h>
 #endif
 
+#if defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_SP_ASM)
+    /* force off unneeded vector register save/restore. */
+    #undef SAVE_VECTOR_REGISTERS
+    #define SAVE_VECTOR_REGISTERS(...) WC_DO_NOTHING
+    #undef RESTORE_VECTOR_REGISTERS
+    #define RESTORE_VECTOR_REGISTERS() WC_DO_NOTHING
+#endif
+
 #if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
     #define GEN_MEM_ERR MP_MEM
 #elif defined(USE_FAST_MATH)

--- a/wolfcrypt/src/eccsi.c
+++ b/wolfcrypt/src/eccsi.c
@@ -43,6 +43,14 @@
     #include <wolfssl/wolfcrypt/sp.h>
 #endif
 
+#if defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_SP_ASM)
+    /* force off unneeded vector register save/restore. */
+    #undef SAVE_VECTOR_REGISTERS
+    #define SAVE_VECTOR_REGISTERS(...) WC_DO_NOTHING
+    #undef RESTORE_VECTOR_REGISTERS
+    #define RESTORE_VECTOR_REGISTERS() WC_DO_NOTHING
+#endif
+
 #ifndef WOLFSSL_HAVE_ECC_KEY_GET_PRIV
     /* FIPS build has replaced ecc.h. */
     #define wc_ecc_key_get_priv(key) (&((key)->k))

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -888,12 +888,12 @@ int wc_SSH_KDF(byte hashId, byte keyId, byte* key, word32 keySz,
  * @param [out] block    First block to encrypt.
  */
 static void wc_srtp_kdf_first_block(const byte* salt, word32 saltSz, int kdrIdx,
-        const byte* index, byte indexSz, unsigned char* block)
+        const byte* index, int indexSz, unsigned char* block)
 {
-    word32 i;
+    int i;
 
     /* XOR salt into zeroized buffer. */
-    for (i = 0; i < WC_SRTP_MAX_SALT - saltSz; i++) {
+    for (i = 0; i < WC_SRTP_MAX_SALT - (int)saltSz; i++) {
         block[i] = 0;
     }
     XMEMCPY(block + WC_SRTP_MAX_SALT - saltSz, salt, saltSz);
@@ -942,13 +942,13 @@ static int wc_srtp_kdf_derive_key(byte* block, byte indexSz, byte label,
     int i;
     int ret = 0;
     /* Calculate the number of full blocks needed for derived key. */
-    int blocks = keySz / AES_BLOCK_SIZE;
+    int blocks = (int)(keySz / AES_BLOCK_SIZE);
 
     /* XOR in label. */
     block[WC_SRTP_MAX_SALT - indexSz - 1] ^= label;
     for (i = 0; (ret == 0) && (i < blocks); i++) {
         /* Set counter. */
-        block[15] = i;
+        block[15] = (byte)i;
         /* Encrypt block into key buffer. */
         ret = wc_AesEcbEncrypt(aes, key, block, AES_BLOCK_SIZE);
         /* Reposition for more derived key. */
@@ -960,7 +960,7 @@ static int wc_srtp_kdf_derive_key(byte* block, byte indexSz, byte label,
     if ((ret == 0) && (keySz > 0)) {
         byte enc[AES_BLOCK_SIZE];
         /* Set counter. */
-        block[15] = i;
+        block[15] = (byte)i;
         /* Encrypt block into temporary. */
         ret = wc_AesEcbEncrypt(aes, enc, block, AES_BLOCK_SIZE);
         if (ret == 0) {

--- a/wolfcrypt/src/sakke.c
+++ b/wolfcrypt/src/sakke.c
@@ -44,6 +44,14 @@
 #include <wolfssl/wolfcrypt/sakke.h>
 #include <wolfssl/wolfcrypt/asn_public.h>
 
+#if defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_SP_ASM)
+    /* force off unneeded vector register save/restore. */
+    #undef SAVE_VECTOR_REGISTERS
+    #define SAVE_VECTOR_REGISTERS(...) WC_DO_NOTHING
+    #undef RESTORE_VECTOR_REGISTERS
+    #define RESTORE_VECTOR_REGISTERS() WC_DO_NOTHING
+#endif
+
 #ifndef WOLFSSL_HAVE_ECC_KEY_GET_PRIV
     /* FIPS build has replaced ecc.h. */
     #define wc_ecc_key_get_priv(key) (&((key)->k))

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -115,6 +115,14 @@ This library provides single precision (SP) integer math functions.
 
 #include <wolfssl/wolfcrypt/sp_int.h>
 
+#if defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_SP_ASM)
+    /* force off unneeded vector register save/restore. */
+    #undef SAVE_VECTOR_REGISTERS
+    #define SAVE_VECTOR_REGISTERS(...) WC_DO_NOTHING
+    #undef RESTORE_VECTOR_REGISTERS
+    #define RESTORE_VECTOR_REGISTERS() WC_DO_NOTHING
+#endif
+
 /* DECL_SP_INT: Declare one variable of type 'sp_int'. */
 #if (defined(WOLFSSL_SMALL_STACK) || defined(SP_ALLOC)) && \
     !defined(WOLFSSL_SP_NO_MALLOC)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -536,6 +536,12 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  XChaCha20Poly1305_test(void);
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  des_test(void);
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  des3_test(void);
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  aes_test(void);
+#if defined(WOLFSSL_AES_CFB)
+WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  aes_cfb_test(void);
+#endif
+#ifdef WOLFSSL_AES_XTS
+WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  aes_xts_test(void);
+#endif
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  aes192_test(void);
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  aes256_test(void);
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  aesofb_test(void);
@@ -1463,7 +1469,7 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
     if ( (ret = aesofb_test()) != 0)
         TEST_FAIL("AES-OFB  test failed!\n", ret);
     else
-        TEST_PASS("AESOFB   test passed!\n");
+        TEST_PASS("AES-OFB   test passed!\n");
 #endif
 
 #ifdef HAVE_AESGCM
@@ -1490,6 +1496,21 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
     else
         TEST_PASS("AES-CCM  test passed!\n");
 #endif
+
+#ifdef WOLFSSL_AES_CFB
+    if ( (ret = aes_cfb_test()) != 0)
+        TEST_FAIL("AES-CFB  test failed!\n", ret);
+    else
+        TEST_PASS("AES-CFB  test passed!\n");
+#endif
+
+#ifdef WOLFSSL_AES_XTS
+    if ( (ret = aes_xts_test()) != 0)
+        TEST_FAIL("AES-XTS  test failed!\n", ret);
+    else
+        TEST_PASS("AES-XTS  test passed!\n");
+#endif
+
 #ifdef HAVE_AES_KEYWRAP
     if ( (ret = aeskeywrap_test()) != 0)
         TEST_FAIL("AES Key Wrap test failed!\n", ret);
@@ -8433,8 +8454,10 @@ EVP_TEST_END:
 #endif /* WOLFSSL_AES_OFB */
 
 #if defined(WOLFSSL_AES_CFB)
-    /* Test cases from NIST SP 800-38A, Recommendation for Block Cipher Modes of Operation Methods an*/
-    static wc_test_ret_t aescfb_test(void)
+    /* Test cases from NIST SP 800-38A, Recommendation for Block Cipher Modes of
+     * Operation Methods and Techniques
+     */
+    static wc_test_ret_t aescfb_test_0(void)
     {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
         Aes *enc = NULL;
@@ -9360,7 +9383,7 @@ static wc_test_ret_t aes_key_size_test(void)
     return ret;
 }
 
-#if defined(WOLFSSL_AES_XTS) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3))
+#if defined(WOLFSSL_AES_XTS)
 
 /* test vectors from http://csrc.nist.gov/groups/STM/cavp/block-cipher-modes.html */
 #ifdef WOLFSSL_AES_128
@@ -11770,44 +11793,6 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes_test(void)
         goto out;
 #endif
 
-#if defined(WOLFSSL_AES_XTS) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5,3))
-    #ifdef WOLFSSL_AES_128
-    ret = aes_xts_128_test();
-    if (ret != 0)
-        goto out;
-    #endif
-    #ifdef WOLFSSL_AES_256
-    ret = aes_xts_256_test();
-    if (ret != 0)
-        goto out;
-    #endif
-    #if defined(WOLFSSL_AES_128) && defined(WOLFSSL_AES_256)
-    ret = aes_xts_sector_test();
-    if (ret != 0)
-        goto out;
-    #endif
-    #ifdef WOLFSSL_AES_128
-    ret = aes_xts_args_test();
-    if (ret != 0)
-        goto out;
-    #endif
-#endif
-
-#if defined(WOLFSSL_AES_CFB)
-    ret = aescfb_test();
-    if (ret != 0)
-        goto out;
-#if !defined(HAVE_SELFTEST) && !defined(HAVE_FIPS)
-    ret = aescfb1_test();
-    if (ret != 0)
-        goto out;
-
-    ret = aescfb8_test();
-    if (ret != 0)
-        goto out;
-#endif
-#endif
-
 #if defined(HAVE_AES_ECB) && !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
     ret = aesecb_test();
     if (ret != 0)
@@ -11845,6 +11830,54 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes_test(void)
 
     return ret;
 }
+
+#if defined(WOLFSSL_AES_CFB)
+WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes_cfb_test(void)
+{
+    int ret;
+    ret = aescfb_test_0();
+    if (ret != 0)
+        return ret;
+#if !defined(HAVE_SELFTEST) && !defined(HAVE_FIPS)
+    ret = aescfb1_test();
+    if (ret != 0)
+        return ret;
+
+    ret = aescfb8_test();
+    if (ret != 0)
+        return ret;
+#endif
+    return 0;
+}
+#endif
+
+#if defined(WOLFSSL_AES_XTS)
+WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes_xts_test(void)
+{
+    int ret = 0;
+    #ifdef WOLFSSL_AES_128
+    ret = aes_xts_128_test();
+    if (ret != 0)
+        return ret;
+    #endif
+    #ifdef WOLFSSL_AES_256
+    ret = aes_xts_256_test();
+    if (ret != 0)
+        return ret;
+    #endif
+    #if defined(WOLFSSL_AES_128) && defined(WOLFSSL_AES_256)
+    ret = aes_xts_sector_test();
+    if (ret != 0)
+        return ret;
+    #endif
+    #ifdef WOLFSSL_AES_128
+    ret = aes_xts_args_test();
+    if (ret != 0)
+        return ret;
+    #endif
+    return 0;
+}
+#endif
 
 #ifdef WOLFSSL_AES_192
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes192_test(void)
@@ -49671,6 +49704,10 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t cryptocb_test(void)
     #ifdef HAVE_AES_CBC
     if (ret == 0)
         ret = aes_test();
+    #endif
+    #ifdef WOLFSSL_AES_XTS
+    if (ret == 0)
+        ret = aes_xts_test();
     #endif
     #if defined(HAVE_AESCCM) && defined(WOLFSSL_AES_128)
     if (ret == 0)

--- a/wolfssl/wolfcrypt/memory.h
+++ b/wolfssl/wolfcrypt/memory.h
@@ -283,27 +283,29 @@ WOLFSSL_LOCAL int wc_debug_CipherLifecycleFree(void **CipherLifecycleTag,
         #define DEBUG_VECTOR_REGISTERS_EXTRA_FAIL_CLAUSE abort();
     #elif defined(DEBUG_VECTOR_REGISTERS_EXIT_ON_FAIL)
         #define DEBUG_VECTOR_REGISTERS_EXTRA_FAIL_CLAUSE exit(1);
-    #else
+    #elif !defined(DEBUG_VECTOR_REGISTERS_EXTRA_FAIL_CLAUSE)
         #define DEBUG_VECTOR_REGISTERS_EXTRA_FAIL_CLAUSE
     #endif
 
     #define SAVE_VECTOR_REGISTERS(fail_clause) {                    \
         int _svr_ret = wc_debug_vector_registers_retval;            \
         if (_svr_ret != 0) { fail_clause }                          \
-        ++wc_svr_count;                                             \
-        if (wc_svr_count > 5) {                                     \
-            fprintf(stderr,                                         \
-                    ("%s @ L%d : incr : "                           \
-                     "wc_svr_count %d (last op %s L%d)\n"),         \
-                    __FILE__,                                       \
-                    __LINE__,                                       \
-                    wc_svr_count,                                   \
-                    wc_svr_last_file,                               \
-                    wc_svr_last_line);                              \
-            DEBUG_VECTOR_REGISTERS_EXTRA_FAIL_CLAUSE                \
+        else {                                                      \
+          ++wc_svr_count;                                           \
+          if (wc_svr_count > 5) {                                   \
+              fprintf(stderr,                                       \
+                      ("%s @ L%d : incr : "                         \
+                       "wc_svr_count %d (last op %s L%d)\n"),       \
+                      __FILE__,                                     \
+                      __LINE__,                                     \
+                      wc_svr_count,                                 \
+                      wc_svr_last_file,                             \
+                      wc_svr_last_line);                            \
+              DEBUG_VECTOR_REGISTERS_EXTRA_FAIL_CLAUSE              \
+          }                                                         \
+          wc_svr_last_file = __FILE__;                              \
+          wc_svr_last_line = __LINE__;                              \
         }                                                           \
-        wc_svr_last_file = __FILE__;                                \
-        wc_svr_last_line = __LINE__;                                \
     }
 
     WOLFSSL_API extern THREAD_LS_T int wc_debug_vector_registers_retval;


### PR DESCRIPTION
`configure.ac`:
* add srtp to enable-all
* add srtp-kdf to enable-all-crypto
* fix typo in enable-all[-crypto] where `ENABLED_FIPS` was used when `FIPS_VERSION` was needed.
* in enable-all[-crypto], conditionalize aesxts on !FIPS || FIPS_VERSION == dev.
* move AES-XTS CFLAG setup after FIPS settings, to allow non-dev FIPS to force it off, and add clause to FIPS v5 setup to do that.
* in FIPS v5 setup, add AES-XTS to the list of modes that forces `-DWOLFSSL_AES_DIRECT -DHAVE_AES_ECB`.

`wolfcrypt/src/kdf.c`: fix several benign `-Wconversion`s.

`wolfcrypt/test/test.c`: add `aes_cfb_test()` and `aes_xts_test()` as top-level tests with separate "pass" messages, for transparency that those modes have indeed been tested in builds that activate them.

`linuxkm/linuxkm_wc_port.h`:
* add support for `DEBUG_LINUXKM_FORTIFY_OVERLAY` to allow KASAN analysis of the overlay without actually enabling `CONFIG_FORTIFY_SOURCE` (which is buggy in combination with KASAN).
* make `SAVE_VECTOR_REGISTERS2` definition conditional on `!defined(SAVE_VECTOR_REGISTERS2)`.

`wolfssl/wolfcrypt/memory.h`: fix the `DEBUG_VECTOR_REGISTER_ACCESS` definition for `SAVE_VECTOR_REGISTERS` to properly omit the on-success bookkeeping code even if the supplied fail_clause doesn't return.

`wolfcrypt/src/rsa.c`: in `wc_MakeRsaKey()` primality loop, invoke `RESTORE_VECTOR_REGISTERS()` `SAVE_VECTOR_REGISTERS()` to prevent lengthy kernel lockups.

`wolfcrypt/src/dh.c`: in `wc_DhGenerateParams()` primality loop, invoke `RESTORE_VECTOR_REGISTERS()` `SAVE_VECTOR_REGISTERS()` to prevent lengthy kernel lockups.

`wolfcrypt/src/{curve25519.c,dh.c,dsa.c,ecc.c,eccsi.c,rsa.c,sakke.c,sp_int.c}`: when `WOLFSSL_LINUXKM`, force `{SAVE,RESTORE}_VECTOR_REGISTERS()` to `WC_DO_NOTHING` if settings gate out applicable asm.
