### PR TITLE
remove software aes and only do cryptoCb aes when WOLF_CRYPTO_CB_ONLY_AES is defined

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -967,7 +967,7 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
 #elif defined(WOLFSSL_HAVE_PSA) && !defined(WOLFSSL_PSA_NO_AES)
 /* implemented in wolfcrypt/src/port/psa/psa_aes.c */
 
-#elif WOLF_CRYPTO_CB_ONLY_AES
+#elif defined(WOLF_CRYPTO_CB_ONLY_AES)
 /* no sw fallback */
 #else
 

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -6260,21 +6260,24 @@ static WC_INLINE void IncCtr(byte* ctr, word32 ctrSz)
     /* implemented in wolfcrypt/src/port/devcrypt/devcrypto_aes.c */
 
 #else /* software + AESNI implementation */
-
+#ifndef WOLF_CRYPTO_CB_ONLY_AES
 #ifndef WOLFSSL_AESNI
-static WARN_UNUSED_RESULT int AES_GCM_encrypt_C(
+static
+#endif
+WARN_UNUSED_RESULT int AES_GCM_encrypt_C(
                       Aes* aes, byte* out, const byte* in, word32 sz,
                       const byte* iv, word32 ivSz,
                       byte* authTag, word32 authTagSz,
                       const byte* authIn, word32 authInSz);
-static WARN_UNUSED_RESULT int AES_GCM_decrypt_C(
+#ifdef WOLFSSL_AESNI
+static
+#endif
+WARN_UNUSED_RESULT int AES_GCM_decrypt_C(
                       Aes* aes, byte* out, const byte* in, word32 sz,
                       const byte* iv, word32 ivSz,
                       const byte* authTag, word32 authTagSz,
                       const byte* authIn, word32 authInSz);
-#endif /* !WOLFSSL_AESNI */
 
-#ifndef WOLF_CRYPTO_CB_ONLY_AES
 #if !defined(FREESCALE_LTC_AES_GCM)
 static WC_INLINE void IncrementGcmCounter(byte* inOutCtr)
 {

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -6269,7 +6269,7 @@ WARN_UNUSED_RESULT int AES_GCM_encrypt_C(
                       const byte* iv, word32 ivSz,
                       byte* authTag, word32 authTagSz,
                       const byte* authIn, word32 authInSz);
-#ifdef WOLFSSL_AESNI
+#ifndef WOLFSSL_AESNI
 static
 #endif
 WARN_UNUSED_RESULT int AES_GCM_decrypt_C(

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -6260,6 +6260,20 @@ static WC_INLINE void IncCtr(byte* ctr, word32 ctrSz)
     /* implemented in wolfcrypt/src/port/devcrypt/devcrypto_aes.c */
 
 #else /* software + AESNI implementation */
+
+#ifndef WOLFSSL_AESNI
+static WARN_UNUSED_RESULT int AES_GCM_encrypt_C(
+                      Aes* aes, byte* out, const byte* in, word32 sz,
+                      const byte* iv, word32 ivSz,
+                      byte* authTag, word32 authTagSz,
+                      const byte* authIn, word32 authInSz);
+static WARN_UNUSED_RESULT int AES_GCM_decrypt_C(
+                      Aes* aes, byte* out, const byte* in, word32 sz,
+                      const byte* iv, word32 ivSz,
+                      const byte* authTag, word32 authTagSz,
+                      const byte* authIn, word32 authInSz);
+#endif /* !WOLFSSL_AESNI */
+
 #ifndef WOLF_CRYPTO_CB_ONLY_AES
 #if !defined(FREESCALE_LTC_AES_GCM)
 static WC_INLINE void IncrementGcmCounter(byte* inOutCtr)

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -522,30 +522,36 @@ WOLFSSL_API int wc_AesEcbDecrypt(Aes* aes, byte* out,
 
 /* AES-CTR */
 #ifdef WOLFSSL_AES_COUNTER
- WOLFSSL_API int wc_AesCtrEncrypt(Aes* aes, byte* out,
+WOLFSSL_API int wc_AesCtrEncrypt(Aes* aes, byte* out,
                                    const byte* in, word32 sz);
- WOLFSSL_API int wc_AesCtrSetKey(Aes* aes, const byte* key, word32 len,
+WOLFSSL_API int wc_AesCtrSetKey(Aes* aes, const byte* key, word32 len,
                                         const byte* iv, int dir);
 
 #endif
 /* AES-DIRECT */
 #if defined(WOLFSSL_AES_DIRECT)
 #if defined(BUILDING_WOLFSSL)
- WOLFSSL_API WARN_UNUSED_RESULT int wc_AesEncryptDirect(Aes* aes, byte* out,
+WOLFSSL_API WARN_UNUSED_RESULT int wc_AesEncryptDirect(Aes* aes, byte* out,
                                                         const byte* in);
- WOLFSSL_API WARN_UNUSED_RESULT int wc_AesDecryptDirect(Aes* aes, byte* out,
+WOLFSSL_API WARN_UNUSED_RESULT int wc_AesDecryptDirect(Aes* aes, byte* out,
                                                         const byte* in);
- WOLFSSL_API WARN_UNUSED_RESULT int wc_AesSetKeyDirect(Aes* aes,
+#else
+WOLFSSL_API int wc_AesEncryptDirect(Aes* aes, byte* out, const byte* in);
+WOLFSSL_API int wc_AesDecryptDirect(Aes* aes, byte* out, const byte* in);
+#endif
+#endif
+
+#if defined(WOLFSSL_AES_COUNTER) || defined(WOLFSSL_AES_DIRECT)
+#if defined(BUILDING_WOLFSSL)
+WOLFSSL_API int wc_AesSetKeyDirect(Aes* aes, const byte* key, word32 len,
+                                const byte* iv, int dir);
+#else
+WOLFSSL_API WARN_UNUSED_RESULT int wc_AesSetKeyDirect(Aes* aes,
                                                        const byte* key,
                                                        word32 len,
                                 const byte* iv, int dir);
-#else
- WOLFSSL_API int wc_AesEncryptDirect(Aes* aes, byte* out, const byte* in);
- WOLFSSL_API int wc_AesDecryptDirect(Aes* aes, byte* out, const byte* in);
- WOLFSSL_API int wc_AesSetKeyDirect(Aes* aes, const byte* key, word32 len,
-                                const byte* iv, int dir);
 #endif
-#endif
+#endif /* WOLFSSL_AES_COUNTER || WOLFSSL_AES_DIRECT */
 
 #ifdef HAVE_AESGCM
 #ifdef WOLFSSL_XILINX_CRYPT

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3614,6 +3614,17 @@ extern void uITRON4_free(void *p) ;
     #endif
 #endif /* HAVE_ENTROPY_MEMUSE */
 
+/* disable modes not currently supported by crypto cb */
+#ifdef WOLF_CRYPTO_CB_ONLY_AES
+    #undef WOLFSSL_AES_DIRECT
+    #undef WOLFSSL_AES_CFB
+    #undef WOLFSSL_AES_OFB
+    #undef HAVE_AES_KEYWRAP
+    #undef WOLFSSL_AES_XTS
+    #undef WOLFSSL_AES_SIV
+    #undef WOLFSSL_AES_EAX
+#endif
+
 #ifdef __cplusplus
     }   /* extern "C" */
 #endif


### PR DESCRIPTION
# Description

Adds the WOLF_CRYPTO_CB_ONLY_AES compile flag which removes all software AES and only allows for cryptoCb to handle the crypto

# Testing

Tested with internal cryptoCb project, hard to test in wolfSSL proper since removing GCM streaming and the non cryptoCb AES modes breaks the tests.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation