### PR TITLE
Decode OCSP Revocation Reason

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -34937,7 +34937,7 @@ static const ASNItem singleResponseASN[] = {
                                                           /* revocationTime */
 /* CS_REVOKED_TIME       */         { 2, ASN_GENERALIZED_TIME, 0, 0, 0 },
                                                           /* revocationReason  [0] EXPLICIT CRLReason OPTIONAL */
-/* CS_REVOKED_REASON     */         { 2, ASN_CONTEXT_SPECIFIC | 0, 0, 1, 1 },
+/* CS_REVOKED_REASON     */         { 2, ASN_CONTEXT_SPECIFIC | 0, 1, 1, 1 },
                                                               /* crlReason */
 /* CS_REVOKED_REASON_VAL */             { 3, ASN_ENUMERATED, 0, 0, 0 },
                                                       /* unknown           [2] IMPLICIT UnknownInfo ::= NULL */


### PR DESCRIPTION
# Description

The ASN.1 parser wasn't handling the OCSP response correctly when there was a revocation reason included in the response. The encoded reason value is constructed, and was getting marked as not constructed in the parser. Changed the flag to mark it as constructed.
(Fixes ZD 17027)

# Testing

I have a set of certificates I've been using for some testing. I added one for a server and use it with an OCSP lookup. I have two alternate certificate lists where this certificate is revoked: one without a revocation reason and one with the optional reason. Both should report the certificate as revoked. (The original report was that the lookup failed.)

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
