### PR TITLE
RSA ct test: force RsaFunctionCheckIn to not be inlined

### DIFF
--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -3082,7 +3082,7 @@ int cc310_RsaSSL_Verify(const byte* in, word32 inLen, byte* sig,
 #ifndef WOLF_CRYPTO_CB_ONLY_RSA
 #if !defined(WOLFSSL_RSA_VERIFY_ONLY) && !defined(TEST_UNPAD_CONSTANT_TIME) &&     !defined(NO_RSA_BOUNDS_CHECK)
 /* Check that 1 < in < n-1. (Requirement of 800-56B.) */
-static int RsaFunctionCheckIn(const byte* in, word32 inLen, RsaKey* key,
+int RsaFunctionCheckIn(const byte* in, word32 inLen, RsaKey* key,
     int checkSmallCt)
 {
     int ret = 0;

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -444,6 +444,8 @@ WOLFSSL_LOCAL int wc_RsaUnPad_ex(byte* pkcsBlock, word32 pkcsBlockLen, byte** ou
                                    int bits, void* heap);
 
 WOLFSSL_LOCAL int wc_hash2mgf(enum wc_HashType hType);
+WOLFSSL_LOCAL int RsaFunctionCheckIn(const byte* in, word32 inLen, RsaKey* key,
+    int checkSmallCt);
 
 #ifdef __cplusplus
     } /* extern "C" */


### PR DESCRIPTION
# Description

In non-debug compilation, RsaFunctionCheckIn may be inlined. The function operates on the input - value to exponentiate. Constant time testing excludes all operations in this function.

# Testing

ct-valgrind testing with --enable-sp

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
