### PR TITLE
Fix unit test failure for FIPS 140-2 + WOLFSSL_ARMASM

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -18496,11 +18496,13 @@ static int test_wc_AesGcmEncryptDecrypt(void)
     ExpectIntEQ(wc_AesGcmDecrypt(&aes, dec, enc, sizeof(enc)/sizeof(byte), iv,
         sizeof(iv)/sizeof(byte), NULL, sizeof(resultT), a, sizeof(a)),
         BAD_FUNC_ARG);
+    #if (defined(HAVE_FIPS) && FIPS_VERSION_LE(2,0) && defined(WOLFSSL_ARMASM))
     ExpectIntEQ(wc_AesGcmDecrypt(&aes, dec, enc, sizeof(enc)/sizeof(byte), iv,
         sizeof(iv)/sizeof(byte), resultT, sizeof(resultT) + 1, a, sizeof(a)),
-    #if (defined(HAVE_FIPS) && FIPS_VERSION_LE(2,0) && defined(WOLFSSL_ARMASM))
         AES_GCM_AUTH_E);
     #else
+    ExpectIntEQ(wc_AesGcmDecrypt(&aes, dec, enc, sizeof(enc)/sizeof(byte), iv,
+        sizeof(iv)/sizeof(byte), resultT, sizeof(resultT) + 1, a, sizeof(a)),
         BAD_FUNC_ARG);
     #endif
     #if ((defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && \

--- a/tests/api.c
+++ b/tests/api.c
@@ -18498,7 +18498,11 @@ static int test_wc_AesGcmEncryptDecrypt(void)
         BAD_FUNC_ARG);
     ExpectIntEQ(wc_AesGcmDecrypt(&aes, dec, enc, sizeof(enc)/sizeof(byte), iv,
         sizeof(iv)/sizeof(byte), resultT, sizeof(resultT) + 1, a, sizeof(a)),
+    #if (defined(HAVE_FIPS) && FIPS_VERSION_LE(2,0) && defined(WOLFSSL_ARMASM))
+        AES_GCM_AUTH_E);
+    #else
         BAD_FUNC_ARG);
+    #endif
     #if ((defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && \
             (HAVE_FIPS_VERSION == 2)) || defined(HAVE_SELFTEST)) && \
             !defined(WOLFSSL_AES_GCM_FIXED_IV_AAD)


### PR DESCRIPTION
# Description

Fix unit test failure for FIPS 140-2 + WOLFSSL_ARMASM by comparing return val to expected error code

Fixes zd#17472

# Testing

Tested with `./configure --enable-fips=v2 --enable-armasm` on the wolfssl-5.6.6-commercial-fips-ARMv8-G-v2 bundle. Make check will pass with this commit.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
