### PR TITLE
20240215-benchmark-smallstack-refactors

### DIFF
--- a/linuxkm/Kbuild
+++ b/linuxkm/Kbuild
@@ -99,10 +99,8 @@ ifeq "$(ENABLED_LINUXKM_PIE)" "yes"
     $(obj)/linuxkm/module_hooks.o: ccflags-y += $(PIE_SUPPORT_FLAGS)
 endif
 
-ifeq "$(ENABLED_LINUXKM_BENCHMARKS)" "yes"
-    $(obj)/linuxkm/module_hooks.o: ccflags-y = $(WOLFSSL_CFLAGS) $(CFLAGS_FPU_ENABLE) $(CFLAGS_SIMD_ENABLE) $(PIE_SUPPORT_FLAGS)
-    $(obj)/linuxkm/module_hooks.o: asflags-y = $(WOLFSSL_ASFLAGS) $(ASFLAGS_FPU_ENABLE_SIMD_DISABLE)
-endif
+$(obj)/wolfcrypt/benchmark/benchmark.o: ccflags-y = $(WOLFSSL_CFLAGS) $(CFLAGS_FPU_ENABLE) $(CFLAGS_SIMD_ENABLE) $(PIE_SUPPORT_FLAGS) -DNO_MAIN_FUNCTION
+$(obj)/wolfcrypt/benchmark/benchmark.o: asflags-y = $(WOLFSSL_ASFLAGS) $(ASFLAGS_FPU_ENABLE_SIMD_DISABLE)
 
 asflags-y := $(WOLFSSL_ASFLAGS) $(ASFLAGS_FPUSIMD_DISABLE)
 

--- a/linuxkm/Makefile
+++ b/linuxkm/Makefile
@@ -47,6 +47,10 @@ else
     WOLFSSL_CFLAGS+=-DNO_CRYPT_TEST
 endif
 
+ifeq "$(ENABLED_LINUXKM_BENCHMARKS)" "yes"
+    WOLFSSL_OBJ_FILES+=wolfcrypt/benchmark/benchmark.o
+endif
+
 ifeq "$(ENABLED_LINUXKM_PIE)" "yes"
     WOLFCRYPT_PIE_FILES := linuxkm/pie_first.o $(filter wolfcrypt/src/%,$(WOLFSSL_OBJ_FILES)) linuxkm/pie_redirect_table.o linuxkm/pie_last.o
     WOLFSSL_OBJ_FILES := $(WOLFCRYPT_PIE_FILES) $(filter-out $(WOLFCRYPT_PIE_FILES),$(WOLFSSL_OBJ_FILES))

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -121,11 +121,7 @@ static int updateFipsHash(void);
 #endif
 
 #ifdef WOLFSSL_LINUXKM_BENCHMARKS
-#define STRING_USER
-#define NO_MAIN_FUNCTION
-#define current_time benchmark_current_time
-#define WOLFSSL_NO_FLOAT_FMT
-#include "wolfcrypt/benchmark/benchmark.c"
+extern int wolfcrypt_benchmark_main(int argc, char** argv);
 #endif /* WOLFSSL_LINUXKM_BENCHMARKS */
 
 #ifdef LINUXKM_LKCAPI_REGISTER

--- a/src/tls.c
+++ b/src/tls.c
@@ -182,6 +182,7 @@ int BuildTlsFinished(WOLFSSL* ssl, Hashes* hashes, const byte* sender)
     byte handshake_hash[HSHASH_SZ];
 #else
     WC_DECLARE_VAR(handshake_hash, byte, HSHASH_SZ, ssl->heap);
+    WC_ALLOC_VAR(handshake_hash, byte, HSHASH_SZ, ssl->heap);
     if (handshake_hash == NULL)
         return MEMORY_E;
 #endif
@@ -317,6 +318,7 @@ static int _DeriveTlsKeys(byte* key_dig, word32 key_dig_len,
     int ret;
 #if defined(WOLFSSL_ASYNC_CRYPT) && !defined(WC_ASYNC_NO_HASH)
     WC_DECLARE_VAR(seed, byte, SEED_LEN, heap);
+    WC_ALLOC_VAR(seed, byte, SEED_LEN, heap);
     if (seed == NULL)
         return MEMORY_E;
 #else
@@ -422,6 +424,7 @@ static int _MakeTlsMasterSecret(byte* ms, word32 msLen,
     byte seed[SEED_LEN];
 #else
     WC_DECLARE_VAR(seed, byte, SEED_LEN, heap);
+    WC_ALLOC_VAR(seed, byte, SEED_LEN, heap);
     if (seed == NULL)
         return MEMORY_E;
 #endif

--- a/tests/api.c
+++ b/tests/api.c
@@ -19754,6 +19754,10 @@ static int test_wc_RsaPublicEncryptDecrypt(void)
     WC_DECLARE_VAR(plain, byte, TEST_STRING_SZ, NULL);
     WC_DECLARE_VAR(cipher, byte, TEST_RSA_BYTES, NULL);
 
+    WC_ALLOC_VAR(in, byte, TEST_STRING_SZ, NULL);
+    WC_ALLOC_VAR(plain, byte, TEST_STRING_SZ, NULL);
+    WC_ALLOC_VAR(cipher, byte, TEST_RSA_BYTES, NULL);
+
 #ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
     ExpectNotNull(in);
     ExpectNotNull(plain);
@@ -19815,6 +19819,10 @@ static int test_wc_RsaPublicEncryptDecrypt_ex(void)
     WC_DECLARE_VAR(in, byte, TEST_STRING_SZ, NULL);
     WC_DECLARE_VAR(plain, byte, TEST_STRING_SZ, NULL);
     WC_DECLARE_VAR(cipher, byte, TEST_RSA_BYTES, NULL);
+
+    WC_ALLOC_VAR(in, byte, TEST_STRING_SZ, NULL);
+    WC_ALLOC_VAR(plain, byte, TEST_STRING_SZ, NULL);
+    WC_ALLOC_VAR(cipher, byte, TEST_RSA_BYTES, NULL);
 
 #ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
     ExpectNotNull(in);
@@ -19880,6 +19888,10 @@ static int test_wc_RsaSSL_SignVerify(void)
     WC_DECLARE_VAR(in, byte, TEST_STRING_SZ, NULL);
     WC_DECLARE_VAR(out, byte, TEST_RSA_BYTES, NULL);
     WC_DECLARE_VAR(plain, byte, TEST_STRING_SZ, NULL);
+
+    WC_ALLOC_VAR(in, byte, TEST_STRING_SZ, NULL);
+    WC_ALLOC_VAR(out, byte, TEST_RSA_BYTES, NULL);
+    WC_ALLOC_VAR(plain, byte, TEST_STRING_SZ, NULL);
 
 #ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
     ExpectNotNull(in);

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -8940,6 +8940,11 @@ void bench_dh(int useDeviceID)
     WC_DECLARE_VAR(priv2, byte,
                      BENCH_DH_PRIV_SIZE, HEAP_HINT);
 
+    /* old scan-build misfires -Wmaybe-uninitialized on these. */
+    XMEMSET(pub, 0, sizeof(pub));
+    XMEMSET(agree, 0, sizeof(agree));
+    XMEMSET(priv, 0, sizeof(priv));
+
     WC_CALLOC_ARRAY(dhKey, DhKey, BENCH_MAX_PENDING,
                      sizeof(DhKey), HEAP_HINT);
     WC_ALLOC_ARRAY(pub, byte,
@@ -10347,6 +10352,11 @@ void bench_ecc(int useDeviceID, int curveId)
     WC_DECLARE_ARRAY(digest, byte,
                      BENCH_MAX_PENDING, MAX_ECC_BYTES, HEAP_HINT);
 #endif
+
+    /* old scan-build misfires -Wmaybe-uninitialized on these. */
+    XMEMSET(sig, 0, sizeof(sig));
+    XMEMSET(digest, 0, sizeof(digest));
+    XMEMSET(shared, 0, sizeof(shared));
 
     WC_CALLOC_ARRAY(genKey, ecc_key, BENCH_MAX_PENDING,
                      sizeof(ecc_key), HEAP_HINT);

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -55,7 +55,6 @@
  *
  */
 
-
 #ifdef HAVE_CONFIG_H
     #include <config.h>
 #endif
@@ -68,6 +67,8 @@
 /* Macro to disable benchmark */
 #ifndef NO_CRYPT_BENCHMARK
 
+#define WC_ALLOC_DO_ON_FAILURE() do { printf("out of memory at benchmark.c L %d\n", __LINE__); ret = MEMORY_E; goto exit; } while (0)
+
 #include <wolfssl/wolfcrypt/types.h>
 #include <wolfssl/wolfcrypt/wc_port.h>
 #include <wolfssl/wolfcrypt/wolfmath.h>
@@ -76,6 +77,11 @@
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/asn.h>
 #include <wolfssl/version.h>
+
+#ifdef WOLFSSL_LINUXKM
+    /* remap current_time() -- collides with a function in kernel linux/fs.h */
+    #define current_time benchmark_current_time
+#endif /* WOLFSSL_LINUXKM */
 
 #ifdef HAVE_CHACHA
     #include <wolfssl/wolfcrypt/chacha.h>
@@ -223,7 +229,6 @@
 #else
     #include "wolfcrypt/benchmark/benchmark.h"
 #endif
-
 
 /* define the max length for each string of metric reported */
 #ifndef WC_BENCH_MAX_LINE_LEN
@@ -467,7 +472,7 @@
         #include <stdlib.h>  /* we're using malloc / free direct here */
     #endif
 
-    #ifndef STRING_USER
+    #if !defined(STRING_USER) && !defined(NO_STDIO_FILESYSTEM)
         #include <string.h>
         #include <stdio.h>
     #endif
@@ -1873,21 +1878,33 @@ static const char* bench_result_words2[][5] = {
 
 /* use kB instead of mB for embedded benchmarking */
 #ifdef BENCH_EMBEDDED
+    #ifndef BENCH_NTIMES
+    #define BENCH_NTIMES 2
+    #endif
+    #ifndef BENCH_AGREETIMES
+    #define BENCH_AGREETIMES 2
+    #endif
     enum BenchmarkBounds {
         scryptCnt  = 1,
-        ntimes     = 2,
+        ntimes     = BENCH_NTIMES,
         genTimes   = BENCH_MAX_PENDING,
-        agreeTimes = 2
+        agreeTimes = BENCH_AGREETIMES
     };
     /* how many kB to test (en/de)cryption */
     #define NUM_BLOCKS 25
     #define BENCH_SIZE (1024uL)
 #else
+    #ifndef BENCH_NTIMES
+    #define BENCH_NTIMES 100
+    #endif
+    #ifndef BENCH_AGREETIMES
+    #define BENCH_AGREETIMES 100
+    #endif
     enum BenchmarkBounds {
         scryptCnt  = 10,
-        ntimes     = 100,
+        ntimes     = BENCH_NTIMES,
         genTimes   = BENCH_MAX_PENDING, /* must be at least BENCH_MAX_PENDING */
-        agreeTimes = 100
+        agreeTimes = BENCH_AGREETIMES
     };
     /* how many megs to test (en/de)cryption */
     #define NUM_BLOCKS 5
@@ -4066,22 +4083,23 @@ static void bench_aescbc_internal(int useDeviceID,
                                   const char* decLabel)
 {
     int    ret = 0, i, count = 0, times, pending = 0;
-    Aes    enc[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(enc, Aes, BENCH_MAX_PENDING,
+                     sizeof(Aes), HEAP_HINT);
     double start;
     DECLARE_MULTI_VALUE_STATS_VARS()
 
-    /* clear for done cleanup */
-    XMEMSET(enc, 0, sizeof(enc));
+    WC_CALLOC_ARRAY(enc, Aes, BENCH_MAX_PENDING,
+                     sizeof(Aes), HEAP_HINT);
 
     /* init keys */
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        if ((ret = wc_AesInit(&enc[i], HEAP_HINT,
+        if ((ret = wc_AesInit(enc[i], HEAP_HINT,
                                 useDeviceID ? devId: INVALID_DEVID)) != 0) {
-            printf("AesInit failed, ret = %d\n", ret);
+            printf("AesInit failed at L%d, ret = %d\n", __LINE__, ret);
             goto exit;
         }
 
-        ret = wc_AesSetKey(&enc[i], key, keySz, iv, AES_ENCRYPTION);
+        ret = wc_AesSetKey(enc[i], key, keySz, iv, AES_ENCRYPTION);
         if (ret != 0) {
             printf("AesSetKey failed, ret = %d\n", ret);
             goto exit;
@@ -4095,12 +4113,12 @@ static void bench_aescbc_internal(int useDeviceID,
 
             /* while free pending slots in queue, submit ops */
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&enc[i]), 0,
+                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(enc[i]), 0,
                                       &times, numBlocks, &pending)) {
-                    ret = wc_AesCbcEncrypt(&enc[i], bench_plain, bench_cipher,
+                    ret = wc_AesCbcEncrypt(enc[i], bench_plain, bench_cipher,
                         bench_size);
 
-                    if (!bench_async_handle(&ret, BENCH_ASYNC_GET_DEV(&enc[i]),
+                    if (!bench_async_handle(&ret, BENCH_ASYNC_GET_DEV(enc[i]),
                                             0, &times, &pending)) {
                         goto exit_aes_enc;
                     }
@@ -4129,7 +4147,7 @@ exit_aes_enc:
 #ifdef HAVE_AES_DECRYPT
     /* init keys */
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        ret = wc_AesSetKey(&enc[i], key, keySz, iv, AES_DECRYPTION);
+        ret = wc_AesSetKey(enc[i], key, keySz, iv, AES_DECRYPTION);
         if (ret != 0) {
             printf("AesSetKey failed, ret = %d\n", ret);
             goto exit;
@@ -4145,12 +4163,12 @@ exit_aes_enc:
 
             /* while free pending slots in queue, submit ops */
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&enc[i]), 0,
+                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(enc[i]), 0,
                                       &times, numBlocks, &pending)) {
-                    ret = wc_AesCbcDecrypt(&enc[i], bench_cipher, bench_plain,
+                    ret = wc_AesCbcDecrypt(enc[i], bench_cipher, bench_plain,
                         bench_size);
 
-                    if (!bench_async_handle(&ret, BENCH_ASYNC_GET_DEV(&enc[i]),
+                    if (!bench_async_handle(&ret, BENCH_ASYNC_GET_DEV(enc[i]),
                                             0, &times, &pending)) {
                         goto exit_aes_dec;
                     }
@@ -4177,8 +4195,11 @@ exit_aes_dec:
     (void)decLabel;
 exit:
 
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_AesFree(&enc[i]);
+    if (WC_ARRAY_OK(enc)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_AesFree(enc[i]);
+        }
+        WC_FREE_ARRAY(enc, BENCH_MAX_PENDING, HEAP_HINT);
     }
 }
 
@@ -4217,24 +4238,26 @@ static void bench_aesgcm_internal(int useDeviceID,
                                   const char* encLabel, const char* decLabel)
 {
     int    ret = 0, i, count = 0, times, pending = 0;
-    Aes    enc[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(enc, Aes, BENCH_MAX_PENDING,
+                     sizeof(Aes), HEAP_HINT);
 #ifdef HAVE_AES_DECRYPT
-    Aes    dec[BENCH_MAX_PENDING+1];
+    WC_DECLARE_ARRAY(dec, Aes, BENCH_MAX_PENDING,
+                     sizeof(Aes), HEAP_HINT);
 #endif
     double start;
     DECLARE_MULTI_VALUE_STATS_VARS()
-
     WC_DECLARE_VAR(bench_additional, byte, AES_AUTH_ADD_SZ, HEAP_HINT);
     WC_DECLARE_VAR(bench_tag, byte, AES_AUTH_TAG_SZ, HEAP_HINT);
-#ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
-    if (bench_additional == NULL || bench_tag == NULL) {
-        printf("bench_aesgcm_internal malloc failed\n");
-        goto exit;
-    }
+
+    WC_ALLOC_VAR(bench_additional, byte, AES_AUTH_ADD_SZ, HEAP_HINT);
+    WC_ALLOC_VAR(bench_tag, byte, AES_AUTH_TAG_SZ, HEAP_HINT);
+    WC_CALLOC_ARRAY(enc, Aes, BENCH_MAX_PENDING,
+                  sizeof(Aes), HEAP_HINT);
+#ifdef HAVE_AES_DECRYPT
+    WC_CALLOC_ARRAY(dec, Aes, BENCH_MAX_PENDING,
+                  sizeof(Aes), HEAP_HINT);
 #endif
 
-    /* clear for done cleanup */
-    XMEMSET(enc, 0, sizeof(enc));
 #ifdef WOLFSSL_ASYNC_CRYPT
     if (bench_additional)
 #endif
@@ -4246,13 +4269,13 @@ static void bench_aesgcm_internal(int useDeviceID,
 
     /* init keys */
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        if ((ret = wc_AesInit(&enc[i], HEAP_HINT,
+        if ((ret = wc_AesInit(enc[i], HEAP_HINT,
                         useDeviceID ? devId: INVALID_DEVID)) != 0) {
-            printf("AesInit failed, ret = %d\n", ret);
+            printf("AesInit failed at L%d, ret = %d\n", __LINE__, ret);
             goto exit;
         }
 
-        ret = wc_AesGcmSetKey(&enc[i], key, keySz);
+        ret = wc_AesGcmSetKey(enc[i], key, keySz);
         if (ret != 0) {
             printf("AesGcmSetKey failed, ret = %d\n", ret);
             goto exit;
@@ -4267,13 +4290,13 @@ static void bench_aesgcm_internal(int useDeviceID,
 
             /* while free pending slots in queue, submit ops */
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&enc[i]), 0,
+                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(enc[i]), 0,
                                       &times, numBlocks, &pending)) {
-                    ret = wc_AesGcmEncrypt(&enc[i], bench_cipher,
+                    ret = wc_AesGcmEncrypt(enc[i], bench_cipher,
                         bench_plain, bench_size,
                         iv, ivSz, bench_tag, AES_AUTH_TAG_SZ,
                         bench_additional, aesAuthAddSz);
-                    if (!bench_async_handle(&ret, BENCH_ASYNC_GET_DEV(&enc[i]),
+                    if (!bench_async_handle(&ret, BENCH_ASYNC_GET_DEV(enc[i]),
                                             0, &times, &pending)) {
                         goto exit_aes_gcm;
                     }
@@ -4296,19 +4319,18 @@ exit_aes_gcm:
 #endif
 
 #ifdef HAVE_AES_DECRYPT
-    XMEMSET(dec, 0, sizeof(dec));
 
     RESET_MULTI_VALUE_STATS_VARS();
 
     /* init keys */
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        if ((ret = wc_AesInit(&dec[i], HEAP_HINT,
+        if ((ret = wc_AesInit(dec[i], HEAP_HINT,
                         useDeviceID ? devId: INVALID_DEVID)) != 0) {
-            printf("AesInit failed, ret = %d\n", ret);
+            printf("AesInit failed at L%d, ret = %d\n", __LINE__, ret);
             goto exit;
         }
 
-        ret = wc_AesGcmSetKey(&dec[i], key, keySz);
+        ret = wc_AesGcmSetKey(dec[i], key, keySz);
         if (ret != 0) {
             printf("AesGcmSetKey failed, ret = %d\n", ret);
             goto exit;
@@ -4322,13 +4344,13 @@ exit_aes_gcm:
 
             /* while free pending slots in queue, submit ops */
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&dec[i]), 0,
+                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(dec[i]), 0,
                                       &times, numBlocks, &pending)) {
-                    ret = wc_AesGcmDecrypt(&dec[i], bench_plain,
+                    ret = wc_AesGcmDecrypt(dec[i], bench_plain,
                         bench_cipher, bench_size,
                         iv, ivSz, bench_tag, AES_AUTH_TAG_SZ,
                         bench_additional, aesAuthAddSz);
-                    if (!bench_async_handle(&ret, BENCH_ASYNC_GET_DEV(&dec[i]),
+                    if (!bench_async_handle(&ret, BENCH_ASYNC_GET_DEV(dec[i]),
                                             0, &times, &pending)) {
                         goto exit_aes_gcm_dec;
                     }
@@ -4359,12 +4381,18 @@ exit:
         printf("bench_aesgcm failed: %d\n", ret);
     }
 #ifdef HAVE_AES_DECRYPT
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_AesFree(&dec[i]);
+    if (WC_ARRAY_OK(dec)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_AesFree(dec[i]);
+        }
+        WC_FREE_ARRAY(dec, BENCH_MAX_PENDING, HEAP_HINT);
     }
 #endif
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_AesFree(&enc[i]);
+    if (WC_ARRAY_OK(enc)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_AesFree(enc[i]);
+        }
+        WC_FREE_ARRAY(enc, BENCH_MAX_PENDING, HEAP_HINT);
     }
 
     WC_FREE_VAR(bench_additional, HEAP_HINT);
@@ -4377,27 +4405,28 @@ static void bench_aesgcm_stream_internal(int useDeviceID,
     const char* encLabel, const char* decLabel)
 {
     int    ret = 0, i, count = 0, times, pending = 0;
-    Aes    enc[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(enc, Aes, BENCH_MAX_PENDING,
+                     sizeof(Aes), HEAP_HINT);
 #ifdef HAVE_AES_DECRYPT
-    Aes    dec[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(dec, Aes, BENCH_MAX_PENDING,
+                     sizeof(Aes), HEAP_HINT);
 #endif
     double start;
     DECLARE_MULTI_VALUE_STATS_VARS()
 
     WC_DECLARE_VAR(bench_additional, byte, AES_AUTH_ADD_SZ, HEAP_HINT);
     WC_DECLARE_VAR(bench_tag, byte, AES_AUTH_TAG_SZ, HEAP_HINT);
-#ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
-    if (bench_additional == NULL || bench_tag == NULL) {
-        printf("bench_aesgcm_internal malloc failed\n");
-        goto exit;
-    }
+
+    WC_ALLOC_VAR(bench_additional, byte, AES_AUTH_ADD_SZ, HEAP_HINT);
+    WC_ALLOC_VAR(bench_tag, byte, AES_AUTH_TAG_SZ, HEAP_HINT);
+
+    WC_CALLOC_ARRAY(enc, Aes, BENCH_MAX_PENDING,
+                  sizeof(Aes), HEAP_HINT);
+#ifdef HAVE_AES_DECRYPT
+    WC_CALLOC_ARRAY(dec, Aes, BENCH_MAX_PENDING,
+                  sizeof(Aes), HEAP_HINT);
 #endif
 
-    /* clear for done cleanup */
-    XMEMSET(enc, 0, sizeof(enc));
-#ifdef HAVE_AES_DECRYPT
-    XMEMSET(dec, 0, sizeof(dec));
-#endif
 #ifdef WOLFSSL_ASYNC_CRYPT
     if (bench_additional)
 #endif
@@ -4409,13 +4438,13 @@ static void bench_aesgcm_stream_internal(int useDeviceID,
 
     /* init keys */
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        if ((ret = wc_AesInit(&enc[i], HEAP_HINT,
+        if ((ret = wc_AesInit(enc[i], HEAP_HINT,
                         useDeviceID ? devId: INVALID_DEVID)) != 0) {
-            printf("AesInit failed, ret = %d\n", ret);
+            printf("AesInit failed at L%d, ret = %d\n", __LINE__, ret);
             goto exit;
         }
 
-        ret = wc_AesGcmSetKey(&enc[i], key, keySz);
+        ret = wc_AesGcmSetKey(enc[i], key, keySz);
         if (ret != 0) {
             printf("AesGcmSetKey failed, ret = %d\n", ret);
             goto exit;
@@ -4430,19 +4459,19 @@ static void bench_aesgcm_stream_internal(int useDeviceID,
 
             /* while free pending slots in queue, submit ops */
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&enc[i]), 0,
+                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(enc[i]), 0,
                                       &times, numBlocks, &pending)) {
-                    ret = wc_AesGcmEncryptInit(&enc[i], NULL, 0, iv, ivSz);
+                    ret = wc_AesGcmEncryptInit(enc[i], NULL, 0, iv, ivSz);
                     if (ret == 0) {
-                        ret = wc_AesGcmEncryptUpdate(&enc[i], bench_cipher,
+                        ret = wc_AesGcmEncryptUpdate(enc[i], bench_cipher,
                             bench_plain, bench_size, bench_additional,
                             aesAuthAddSz);
                     }
                     if (ret == 0) {
-                        ret = wc_AesGcmEncryptFinal(&enc[i], bench_tag,
+                        ret = wc_AesGcmEncryptFinal(enc[i], bench_tag,
                             AES_AUTH_TAG_SZ);
                     }
-                    if (!bench_async_handle(&ret, BENCH_ASYNC_GET_DEV(&enc[i]),
+                    if (!bench_async_handle(&ret, BENCH_ASYNC_GET_DEV(enc[i]),
                                             0, &times, &pending)) {
                         goto exit_aes_gcm;
                     }
@@ -4467,13 +4496,13 @@ exit_aes_gcm:
 #ifdef HAVE_AES_DECRYPT
     /* init keys */
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        if ((ret = wc_AesInit(&dec[i], HEAP_HINT,
+        if ((ret = wc_AesInit(dec[i], HEAP_HINT,
                         useDeviceID ? devId: INVALID_DEVID)) != 0) {
-            printf("AesInit failed, ret = %d\n", ret);
+            printf("AesInit failed at L%d, ret = %d\n", __LINE__, ret);
             goto exit;
         }
 
-        ret = wc_AesGcmSetKey(&dec[i], key, keySz);
+        ret = wc_AesGcmSetKey(dec[i], key, keySz);
         if (ret != 0) {
             printf("AesGcmSetKey failed, ret = %d\n", ret);
             goto exit;
@@ -4489,19 +4518,19 @@ exit_aes_gcm:
 
             /* while free pending slots in queue, submit ops */
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&dec[i]), 0,
+                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(dec[i]), 0,
                                       &times, numBlocks, &pending)) {
-                    ret = wc_AesGcmDecryptInit(&enc[i], NULL, 0, iv, ivSz);
+                    ret = wc_AesGcmDecryptInit(enc[i], NULL, 0, iv, ivSz);
                     if (ret == 0) {
-                        ret = wc_AesGcmDecryptUpdate(&enc[i], bench_plain,
+                        ret = wc_AesGcmDecryptUpdate(enc[i], bench_plain,
                             bench_cipher, bench_size, bench_additional,
                             aesAuthAddSz);
                     }
                     if (ret == 0) {
-                        ret = wc_AesGcmDecryptFinal(&enc[i], bench_tag,
+                        ret = wc_AesGcmDecryptFinal(enc[i], bench_tag,
                             AES_AUTH_TAG_SZ);
                     }
-                    if (!bench_async_handle(&ret, BENCH_ASYNC_GET_DEV(&dec[i]),
+                    if (!bench_async_handle(&ret, BENCH_ASYNC_GET_DEV(dec[i]),
                                             0, &times, &pending)) {
                         goto exit_aes_gcm_dec;
                     }
@@ -4532,12 +4561,18 @@ exit:
         printf("bench_aesgcm failed: %d\n", ret);
     }
 #ifdef HAVE_AES_DECRYPT
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_AesFree(&dec[i]);
+    if (WC_ARRAY_OK(dec)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_AesFree(dec[i]);
+        }
+        WC_FREE_ARRAY(dec, BENCH_MAX_PENDING, HEAP_HINT);
     }
 #endif
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_AesFree(&enc[i]);
+    if (WC_ARRAY_OK(enc)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_AesFree(enc[i]);
+        }
+        WC_FREE_ARRAY(enc, BENCH_MAX_PENDING, HEAP_HINT);
     }
 
     WC_FREE_VAR(bench_additional, HEAP_HINT);
@@ -4659,7 +4694,8 @@ static void bench_aesecb_internal(int useDeviceID,
                                   const char* encLabel, const char* decLabel)
 {
     int    ret = 0, i, count = 0, times, pending = 0;
-    Aes    enc[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(enc, Aes, BENCH_MAX_PENDING,
+                     sizeof(Aes), HEAP_HINT);
     double start;
     DECLARE_MULTI_VALUE_STATS_VARS()
 #ifdef HAVE_FIPS
@@ -4668,18 +4704,18 @@ static void bench_aesecb_internal(int useDeviceID,
     const int benchSz = (int)bench_size;
 #endif
 
-    /* clear for done cleanup */
-    XMEMSET(enc, 0, sizeof(enc));
+    WC_CALLOC_ARRAY(enc, Aes, BENCH_MAX_PENDING,
+                     sizeof(Aes), HEAP_HINT);
 
     /* init keys */
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        if ((ret = wc_AesInit(&enc[i], HEAP_HINT,
+        if ((ret = wc_AesInit(enc[i], HEAP_HINT,
                                 useDeviceID ? devId: INVALID_DEVID)) != 0) {
-            printf("AesInit failed, ret = %d\n", ret);
+            printf("AesInit failed at L%d, ret = %d\n", __LINE__, ret);
             goto exit;
         }
 
-        ret = wc_AesSetKey(&enc[i], key, keySz, bench_iv, AES_ENCRYPTION);
+        ret = wc_AesSetKey(enc[i], key, keySz, bench_iv, AES_ENCRYPTION);
         if (ret != 0) {
             printf("AesSetKey failed, ret = %d\n", ret);
             goto exit;
@@ -4696,16 +4732,16 @@ static void bench_aesecb_internal(int useDeviceID,
 
             /* while free pending slots in queue, submit ops */
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&enc[i]), 0,
+                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(enc[i]), 0,
                                       &times, outer_loop_limit, &pending)) {
                 #ifdef HAVE_FIPS
-                    wc_AesEncryptDirect(&enc[i], bench_cipher, bench_plain);
+                    wc_AesEncryptDirect(enc[i], bench_cipher, bench_plain);
                 #else
-                    wc_AesEcbEncrypt(&enc[i], bench_cipher, bench_plain,
+                    wc_AesEcbEncrypt(enc[i], bench_cipher, bench_plain,
                         benchSz);
                 #endif
                     ret = 0;
-                    if (!bench_async_handle(&ret, BENCH_ASYNC_GET_DEV(&enc[i]),
+                    if (!bench_async_handle(&ret, BENCH_ASYNC_GET_DEV(enc[i]),
                                             0, &times, &pending)) {
                         goto exit_aes_enc;
                     }
@@ -4730,7 +4766,7 @@ exit_aes_enc:
 #ifdef HAVE_AES_DECRYPT
     /* init keys */
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        ret = wc_AesSetKey(&enc[i], key, keySz, bench_iv, AES_DECRYPTION);
+        ret = wc_AesSetKey(enc[i], key, keySz, bench_iv, AES_DECRYPTION);
         if (ret != 0) {
             printf("AesSetKey failed, ret = %d\n", ret);
             goto exit;
@@ -4747,16 +4783,16 @@ exit_aes_enc:
 
             /* while free pending slots in queue, submit ops */
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&enc[i]), 0,
+                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(enc[i]), 0,
                                       &times, outer_loop_limit, &pending)) {
                 #ifdef HAVE_FIPS
-                    wc_AesDecryptDirect(&enc[i], bench_plain, bench_cipher);
+                    wc_AesDecryptDirect(enc[i], bench_plain, bench_cipher);
                 #else
-                    wc_AesEcbDecrypt(&enc[i], bench_plain, bench_cipher,
+                    wc_AesEcbDecrypt(enc[i], bench_plain, bench_cipher,
                         benchSz);
                 #endif
                     ret = 0;
-                    if (!bench_async_handle(&ret, BENCH_ASYNC_GET_DEV(&enc[i]),
+                    if (!bench_async_handle(&ret, BENCH_ASYNC_GET_DEV(enc[i]),
                                             0, &times, &pending)) {
                         goto exit_aes_dec;
                     }
@@ -4782,8 +4818,11 @@ exit_aes_dec:
 
 exit:
 
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_AesFree(&enc[i]);
+    if (WC_ARRAY_OK(enc)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_AesFree(enc[i]);
+        }
+        WC_FREE_ARRAY(enc, BENCH_MAX_PENDING, HEAP_HINT);
     }
 }
 
@@ -4816,14 +4855,14 @@ static void bench_aescfb_internal(const byte* key,
 
     ret = wc_AesInit(&enc, HEAP_HINT, INVALID_DEVID);
     if (ret != 0) {
-        printf("AesInit failed, ret = %d\n", ret);
+        printf("AesInit failed at L%d, ret = %d\n", __LINE__, ret);
         return;
     }
 
     ret = wc_AesSetKey(&enc, key, keySz, iv, AES_ENCRYPTION);
     if (ret != 0) {
         printf("AesSetKey failed, ret = %d\n", ret);
-        return;
+        goto out;
     }
 
     bench_stats_start(&count, &start);
@@ -4832,7 +4871,7 @@ static void bench_aescfb_internal(const byte* key,
             if((ret = wc_AesCfbEncrypt(&enc, bench_plain, bench_cipher,
                             bench_size)) != 0) {
                 printf("wc_AesCfbEncrypt failed, ret = %d\n", ret);
-                return;
+                goto out;
             }
             RECORD_MULTI_VALUE_STATS();
         }
@@ -4847,6 +4886,11 @@ static void bench_aescfb_internal(const byte* key,
 #ifdef MULTI_VALUE_STATISTICS
     bench_multi_value_stats(max, min, sum, squareSum, runs);
 #endif
+
+out:
+
+    wc_AesFree(&enc);
+    return;
 }
 
 void bench_aescfb(void)
@@ -4876,7 +4920,7 @@ static void bench_aesofb_internal(const byte* key,
 
     ret = wc_AesInit(&enc, NULL, INVALID_DEVID);
     if (ret != 0) {
-        printf("AesInit failed, ret = %d\n", ret);
+        printf("AesInit failed at L%d, ret = %d\n", __LINE__, ret);
         return;
     }
 
@@ -4929,37 +4973,39 @@ void bench_aesofb(void)
 #ifdef WOLFSSL_AES_XTS
 void bench_aesxts(void)
 {
-    XtsAes aes;
+    WC_DECLARE_VAR(aes, XtsAes, 1, HEAP_HINT);
     double start;
     int    i, count, ret;
     DECLARE_MULTI_VALUE_STATS_VARS()
 
-    static unsigned char k1[] = {
+    static const unsigned char k1[] = {
         0xa1, 0xb9, 0x0c, 0xba, 0x3f, 0x06, 0xac, 0x35,
         0x3b, 0x2c, 0x34, 0x38, 0x76, 0x08, 0x17, 0x62,
         0x09, 0x09, 0x23, 0x02, 0x6e, 0x91, 0x77, 0x18,
         0x15, 0xf2, 0x9d, 0xab, 0x01, 0x93, 0x2f, 0x2f
     };
 
-    static unsigned char i1[] = {
+    static const unsigned char i1[] = {
         0x4f, 0xae, 0xf7, 0x11, 0x7c, 0xda, 0x59, 0xc6,
         0x6e, 0x4b, 0x92, 0x01, 0x3e, 0x76, 0x8a, 0xd5
     };
 
-    ret = wc_AesXtsSetKey(&aes, k1, sizeof(k1), AES_ENCRYPTION,
+    WC_ALLOC_VAR(aes, XtsAes, 1, HEAP_HINT);
+
+    ret = wc_AesXtsSetKey(aes, k1, sizeof(k1), AES_ENCRYPTION,
             HEAP_HINT, devId);
     if (ret != 0) {
         printf("wc_AesXtsSetKey failed, ret = %d\n", ret);
-        return;
+        goto exit;
     }
 
     bench_stats_start(&count, &start);
     do {
         for (i = 0; i < numBlocks; i++) {
-            if ((ret = wc_AesXtsEncrypt(&aes, bench_cipher, bench_plain,
+            if ((ret = wc_AesXtsEncrypt(aes, bench_cipher, bench_plain,
                             bench_size, i1, sizeof(i1))) != 0) {
                 printf("wc_AesXtsEncrypt failed, ret = %d\n", ret);
-                return;
+                goto exit;
             }
             RECORD_MULTI_VALUE_STATS();
         }
@@ -4974,14 +5020,14 @@ void bench_aesxts(void)
 #ifdef MULTI_VALUE_STATISTICS
     bench_multi_value_stats(max, min, sum, squareSum, runs);
 #endif
-    wc_AesXtsFree(&aes);
+    wc_AesXtsFree(aes);
 
     /* decryption benchmark */
-    ret = wc_AesXtsSetKey(&aes, k1, sizeof(k1), AES_DECRYPTION,
+    ret = wc_AesXtsSetKey(aes, k1, sizeof(k1), AES_DECRYPTION,
             HEAP_HINT, devId);
     if (ret != 0) {
         printf("wc_AesXtsSetKey failed, ret = %d\n", ret);
-        return;
+        goto exit;
     }
 
     RESET_MULTI_VALUE_STATS_VARS();
@@ -4989,10 +5035,10 @@ void bench_aesxts(void)
     bench_stats_start(&count, &start);
     do {
         for (i = 0; i < numBlocks; i++) {
-            if ((ret = wc_AesXtsDecrypt(&aes, bench_plain, bench_cipher,
+            if ((ret = wc_AesXtsDecrypt(aes, bench_plain, bench_cipher,
                             bench_size, i1, sizeof(i1))) != 0) {
                 printf("wc_AesXtsDecrypt failed, ret = %d\n", ret);
-                return;
+                goto exit;
             }
             RECORD_MULTI_VALUE_STATS();
         }
@@ -5007,7 +5053,11 @@ void bench_aesxts(void)
 #ifdef MULTI_VALUE_STATISTICS
     bench_multi_value_stats(max, min, sum, squareSum, runs);
 #endif
-    wc_AesXtsFree(&aes);
+
+exit:
+
+    wc_AesXtsFree(aes);
+    WC_FREE_VAR(aes, HEAP_HINT);
 }
 #endif /* WOLFSSL_AES_XTS */
 
@@ -5076,6 +5126,7 @@ void bench_aesctr(int useDeviceID)
 void bench_aesccm(int useDeviceID)
 {
     Aes    enc;
+    int    enc_inited = 0;
     double start;
     int    ret, i, count;
     DECLARE_MULTI_VALUE_STATS_VARS()
@@ -5083,18 +5134,15 @@ void bench_aesccm(int useDeviceID)
     WC_DECLARE_VAR(bench_additional, byte, AES_AUTH_ADD_SZ, HEAP_HINT);
     WC_DECLARE_VAR(bench_tag, byte, AES_AUTH_TAG_SZ, HEAP_HINT);
 
-#ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
-    if (bench_additional == NULL || bench_tag == NULL) {
-        printf("bench_aesccm malloc failed\n");
-        goto exit;
-    }
-#endif
+    WC_ALLOC_VAR(bench_additional, byte, AES_AUTH_ADD_SZ, HEAP_HINT);
+    WC_ALLOC_VAR(bench_tag, byte, AES_AUTH_TAG_SZ, HEAP_HINT);
 
     XMEMSET(bench_tag, 0, AES_AUTH_TAG_SZ);
     XMEMSET(bench_additional, 0, AES_AUTH_ADD_SZ);
 
     if ((ret = wc_AesInit(&enc, HEAP_HINT,
-        useDeviceID ? devId : INVALID_DEVID)) != 0) {
+        useDeviceID ? devId : INVALID_DEVID)) != 0)
+    {
         printf("wc_AesInit failed, ret = %d\n", ret);
         goto exit;
     }
@@ -5103,6 +5151,7 @@ void bench_aesccm(int useDeviceID)
         printf("wc_AesCcmSetKey failed, ret = %d\n", ret);
         goto exit;
     }
+    enc_inited = 1;
 
     bench_stats_start(&count, &start);
     do {
@@ -5157,6 +5206,9 @@ void bench_aesccm(int useDeviceID)
     }
 
   exit:
+
+    if (enc_inited)
+        wc_AesFree(&enc);
 
     WC_FREE_VAR(bench_additional, HEAP_HINT);
     WC_FREE_VAR(bench_tag, HEAP_HINT);
@@ -5575,22 +5627,23 @@ void bench_sm4_ccm()
 void bench_des(int useDeviceID)
 {
     int    ret = 0, i, count = 0, times, pending = 0;
-    Des3   enc[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(enc, Des3, BENCH_MAX_PENDING,
+                     sizeof(Des3), HEAP_HINT);
     double start;
     DECLARE_MULTI_VALUE_STATS_VARS()
 
-    /* clear for done cleanup */
-    XMEMSET(enc, 0, sizeof(enc));
+    WC_CALLOC_ARRAY(enc, Des3, BENCH_MAX_PENDING,
+                     sizeof(Des3), HEAP_HINT);
 
     /* init keys */
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        if ((ret = wc_Des3Init(&enc[i], HEAP_HINT,
+        if ((ret = wc_Des3Init(enc[i], HEAP_HINT,
                                 useDeviceID ? devId : INVALID_DEVID)) != 0) {
             printf("Des3Init failed, ret = %d\n", ret);
             goto exit;
         }
 
-        ret = wc_Des3_SetKey(&enc[i], bench_key, bench_iv, DES_ENCRYPTION);
+        ret = wc_Des3_SetKey(enc[i], bench_key, bench_iv, DES_ENCRYPTION);
         if (ret != 0) {
             printf("Des3_SetKey failed, ret = %d\n", ret);
             goto exit;
@@ -5604,12 +5657,12 @@ void bench_des(int useDeviceID)
 
             /* while free pending slots in queue, submit ops */
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&enc[i]), 0,
+                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(enc[i]), 0,
                                       &times, numBlocks, &pending)) {
-                    ret = wc_Des3_CbcEncrypt(&enc[i],
+                    ret = wc_Des3_CbcEncrypt(enc[i],
                                              bench_cipher,
                                              bench_plain, bench_size);
-                    if (!bench_async_handle(&ret, BENCH_ASYNC_GET_DEV(&enc[i]),
+                    if (!bench_async_handle(&ret, BENCH_ASYNC_GET_DEV(enc[i]),
                                             0, &times, &pending)) {
                         goto exit_3des;
                     }
@@ -5632,8 +5685,11 @@ exit_3des:
 
 exit:
 
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_Des3Free(&enc[i]);
+    if (WC_ARRAY_OK(enc)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_Des3Free(enc[i]);
+        }
+        WC_FREE_ARRAY(enc, BENCH_MAX_PENDING, HEAP_HINT);
     }
 }
 #endif /* !NO_DES3 */
@@ -5643,22 +5699,23 @@ exit:
 void bench_arc4(int useDeviceID)
 {
     int    ret = 0, i, count = 0, times, pending = 0;
-    Arc4   enc[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(enc, Arc4, BENCH_MAX_PENDING,
+                     sizeof(Arc4), HEAP_HINT);
     double start;
     DECLARE_MULTI_VALUE_STATS_VARS()
 
-    /* clear for done cleanup */
-    XMEMSET(enc, 0, sizeof(enc));
+    WC_CALLOC_ARRAY(enc, Arc4, BENCH_MAX_PENDING,
+                     sizeof(Arc4), HEAP_HINT);
 
     /* init keys */
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        if ((ret = wc_Arc4Init(&enc[i], HEAP_HINT,
+        if ((ret = wc_Arc4Init(enc[i], HEAP_HINT,
                             useDeviceID ? devId : INVALID_DEVID)) != 0) {
             printf("Arc4Init failed, ret = %d\n", ret);
             goto exit;
         }
 
-        ret = wc_Arc4SetKey(&enc[i], bench_key, 16);
+        ret = wc_Arc4SetKey(enc[i], bench_key, 16);
         if (ret != 0) {
             printf("Arc4SetKey failed, ret = %d\n", ret);
             goto exit;
@@ -5672,11 +5729,11 @@ void bench_arc4(int useDeviceID)
 
             /* while free pending slots in queue, submit ops */
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&enc[i]), 0,
+                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(enc[i]), 0,
                                       &times, numBlocks, &pending)) {
-                    ret = wc_Arc4Process(&enc[i], bench_cipher, bench_plain,
+                    ret = wc_Arc4Process(enc[i], bench_cipher, bench_plain,
                                          bench_size);
-                    if (!bench_async_handle(&ret, BENCH_ASYNC_GET_DEV(&enc[i]),
+                    if (!bench_async_handle(&ret, BENCH_ASYNC_GET_DEV(enc[i]),
                                             0, &times, &pending)) {
                         goto exit_arc4;
                     }
@@ -5699,8 +5756,11 @@ exit_arc4:
 
 exit:
 
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_Arc4Free(&enc[i]);
+    if (WC_ARRAY_OK(enc)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_Arc4Free(enc[i]);
+        }
+        WC_FREE_ARRAY(enc, BENCH_MAX_PENDING, HEAP_HINT);
     }
 }
 #endif /* !NO_RC4 */
@@ -5777,30 +5837,30 @@ void bench_chacha20_poly1305_aead(void)
 #ifndef NO_MD5
 void bench_md5(int useDeviceID)
 {
-    wc_Md5 hash[BENCH_MAX_PENDING];
-    double start;
+    WC_DECLARE_ARRAY(hash, wc_Md5, BENCH_MAX_PENDING,
+                     sizeof(wc_Md5), HEAP_HINT);
+    double start = 0;
     int    ret = 0, i, count = 0, times, pending = 0;
     DECLARE_MULTI_VALUE_STATS_VARS()
-
     WC_DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING,
                      WC_MD5_DIGEST_SIZE, HEAP_HINT);
-    WC_INIT_ARRAY(digest, byte, BENCH_MAX_PENDING,
-                  WC_MD5_DIGEST_SIZE, HEAP_HINT);
 
-    /* clear for done cleanup */
-    XMEMSET(hash, 0, sizeof(hash));
+    WC_CALLOC_ARRAY(hash, wc_Md5, BENCH_MAX_PENDING,
+                     sizeof(wc_Md5), HEAP_HINT);
+    WC_ALLOC_ARRAY(digest, byte, BENCH_MAX_PENDING,
+                  WC_MD5_DIGEST_SIZE, HEAP_HINT);
 
     if (digest_stream) {
         /* init keys */
         for (i = 0; i < BENCH_MAX_PENDING; i++) {
-            ret = wc_InitMd5_ex(&hash[i], HEAP_HINT,
+            ret = wc_InitMd5_ex(hash[i], HEAP_HINT,
                         useDeviceID ? devId : INVALID_DEVID);
             if (ret != 0) {
                 printf("InitMd5_ex failed, ret = %d\n", ret);
                 goto exit;
             }
         #ifdef WOLFSSL_PIC32MZ_HASH
-            wc_Md5SizeSet(&hash[i], numBlocks * bench_size);
+            wc_Md5SizeSet(hash[i], numBlocks * bench_size);
         #endif
         }
 
@@ -5811,12 +5871,12 @@ void bench_md5(int useDeviceID)
 
                 /* while free pending slots in queue, submit ops */
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Md5Update(&hash[i], bench_plain,
+                        ret = wc_Md5Update(hash[i], bench_plain,
                                            bench_size);
                         if (!bench_async_handle(&ret,
-                                                BENCH_ASYNC_GET_DEV(&hash[i]),
+                                                BENCH_ASYNC_GET_DEV(hash[i]),
                                                 0, &times, &pending)) {
                             goto exit_md5;
                         }
@@ -5831,11 +5891,11 @@ void bench_md5(int useDeviceID)
                 bench_async_poll(&pending);
 
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Md5Final(&hash[i], digest[i]);
+                        ret = wc_Md5Final(hash[i], digest[i]);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_md5;
                         }
@@ -5852,11 +5912,11 @@ void bench_md5(int useDeviceID)
         bench_stats_start(&count, &start);
         do {
             for (times = 0; times < numBlocks; times++) {
-                ret = wc_InitMd5_ex(hash, HEAP_HINT, INVALID_DEVID);
+                ret = wc_InitMd5_ex(hash[0], HEAP_HINT, INVALID_DEVID);
                 if (ret == 0)
-                    ret = wc_Md5Update(hash, bench_plain, bench_size);
+                    ret = wc_Md5Update(hash[0], bench_plain, bench_size);
                 if (ret == 0)
-                    ret = wc_Md5Final(hash, digest[0]);
+                    ret = wc_Md5Final(hash[0], digest[0]);
                 if (ret != 0)
                     goto exit_md5;
                 RECORD_MULTI_VALUE_STATS();
@@ -5877,11 +5937,14 @@ exit_md5:
 exit:
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_Md5Free(&hash[i]);
+    if (WC_ARRAY_OK(hash)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_Md5Free(hash[i]);
+        }
     }
 #endif
 
+    WC_FREE_ARRAY(hash, BENCH_MAX_PENDING, HEAP_HINT);
     WC_FREE_ARRAY(digest, BENCH_MAX_PENDING, HEAP_HINT);
 }
 #endif /* !NO_MD5 */
@@ -5890,29 +5953,30 @@ exit:
 #ifndef NO_SHA
 void bench_sha(int useDeviceID)
 {
-    wc_Sha hash[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(hash, wc_Sha, BENCH_MAX_PENDING,
+                     sizeof(wc_Sha), HEAP_HINT);
     double start;
     int    ret = 0, i, count = 0, times, pending = 0;
     DECLARE_MULTI_VALUE_STATS_VARS()
     WC_DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING,
                      WC_SHA_DIGEST_SIZE, HEAP_HINT);
-    WC_INIT_ARRAY(digest, byte, BENCH_MAX_PENDING,
-                  WC_SHA_DIGEST_SIZE, HEAP_HINT);
 
-    /* clear for done cleanup */
-    XMEMSET(hash, 0, sizeof(hash));
+    WC_CALLOC_ARRAY(hash, wc_Sha, BENCH_MAX_PENDING,
+                     sizeof(wc_Sha), HEAP_HINT);
+    WC_ALLOC_ARRAY(digest, byte, BENCH_MAX_PENDING,
+                  WC_SHA_DIGEST_SIZE, HEAP_HINT);
 
     if (digest_stream) {
         /* init keys */
         for (i = 0; i < BENCH_MAX_PENDING; i++) {
-            ret = wc_InitSha_ex(&hash[i], HEAP_HINT,
+            ret = wc_InitSha_ex(hash[i], HEAP_HINT,
                 useDeviceID ? devId : INVALID_DEVID);
             if (ret != 0) {
                 printf("InitSha failed, ret = %d\n", ret);
                 goto exit;
             }
         #ifdef WOLFSSL_PIC32MZ_HASH
-            wc_ShaSizeSet(&hash[i], numBlocks * bench_size);
+            wc_ShaSizeSet(hash[i], numBlocks * bench_size);
         #endif
         }
 
@@ -5923,12 +5987,12 @@ void bench_sha(int useDeviceID)
 
                 /* while free pending slots in queue, submit ops */
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_ShaUpdate(&hash[i], bench_plain,
+                        ret = wc_ShaUpdate(hash[i], bench_plain,
                             bench_size);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_sha;
                         }
@@ -5943,11 +6007,11 @@ void bench_sha(int useDeviceID)
                 bench_async_poll(&pending);
 
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_ShaFinal(&hash[i], digest[i]);
+                        ret = wc_ShaFinal(hash[i], digest[i]);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_sha;
                         }
@@ -5964,12 +6028,12 @@ void bench_sha(int useDeviceID)
         bench_stats_start(&count, &start);
         do {
             for (times = 0; times < numBlocks; times++) {
-                ret = wc_InitSha_ex(hash, HEAP_HINT,
+                ret = wc_InitSha_ex(hash[0], HEAP_HINT,
                     useDeviceID ? devId : INVALID_DEVID);
                 if (ret == 0)
-                    ret = wc_ShaUpdate(hash, bench_plain, bench_size);
+                    ret = wc_ShaUpdate(hash[0], bench_plain, bench_size);
                 if (ret == 0)
-                    ret = wc_ShaFinal(hash, digest[0]);
+                    ret = wc_ShaFinal(hash[0], digest[0]);
                 if (ret != 0)
                     goto exit_sha;
                 RECORD_MULTI_VALUE_STATS();
@@ -5989,10 +6053,12 @@ exit_sha:
 
 exit:
 
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_ShaFree(&hash[i]);
+    if (WC_ARRAY_OK(hash)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_ShaFree(hash[i]);
+        }
+        WC_FREE_ARRAY(hash, BENCH_MAX_PENDING, HEAP_HINT);
     }
-
     WC_FREE_ARRAY(digest, BENCH_MAX_PENDING, HEAP_HINT);
 }
 #endif /* NO_SHA */
@@ -6001,22 +6067,23 @@ exit:
 #ifdef WOLFSSL_SHA224
 void bench_sha224(int useDeviceID)
 {
-    wc_Sha224 hash[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(hash, wc_Sha224, BENCH_MAX_PENDING,
+                     sizeof(wc_Sha224), HEAP_HINT);
     double start;
     int    ret = 0, i, count = 0, times, pending = 0;
     DECLARE_MULTI_VALUE_STATS_VARS()
     WC_DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING,
                      WC_SHA224_DIGEST_SIZE, HEAP_HINT);
-    WC_INIT_ARRAY(digest, byte, BENCH_MAX_PENDING,
-                  WC_SHA224_DIGEST_SIZE, HEAP_HINT);
 
-    /* clear for done cleanup */
-    XMEMSET(hash, 0, sizeof(hash));
+    WC_CALLOC_ARRAY(hash, wc_Sha224, BENCH_MAX_PENDING,
+                     sizeof(wc_Sha224), HEAP_HINT);
+    WC_ALLOC_ARRAY(digest, byte, BENCH_MAX_PENDING,
+                  WC_SHA224_DIGEST_SIZE, HEAP_HINT);
 
     if (digest_stream) {
         /* init keys */
         for (i = 0; i < BENCH_MAX_PENDING; i++) {
-            ret = wc_InitSha224_ex(&hash[i], HEAP_HINT,
+            ret = wc_InitSha224_ex(hash[i], HEAP_HINT,
                 useDeviceID ? devId : INVALID_DEVID);
             if (ret != 0) {
                 printf("InitSha224_ex failed, ret = %d\n", ret);
@@ -6031,12 +6098,12 @@ void bench_sha224(int useDeviceID)
 
                 /* while free pending slots in queue, submit ops */
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Sha224Update(&hash[i], bench_plain,
+                        ret = wc_Sha224Update(hash[i], bench_plain,
                             bench_size);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_sha224;
                         }
@@ -6050,11 +6117,11 @@ void bench_sha224(int useDeviceID)
             do {
                 bench_async_poll(&pending);
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Sha224Final(&hash[i], digest[i]);
+                        ret = wc_Sha224Final(hash[i], digest[i]);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_sha224;
                         }
@@ -6071,12 +6138,12 @@ void bench_sha224(int useDeviceID)
         bench_stats_start(&count, &start);
         do {
             for (times = 0; times < numBlocks; times++) {
-                ret = wc_InitSha224_ex(hash, HEAP_HINT,
+                ret = wc_InitSha224_ex(hash[0], HEAP_HINT,
                     useDeviceID ? devId : INVALID_DEVID);
                 if (ret == 0)
-                    ret = wc_Sha224Update(hash, bench_plain, bench_size);
+                    ret = wc_Sha224Update(hash[0], bench_plain, bench_size);
                 if (ret == 0)
-                    ret = wc_Sha224Final(hash, digest[0]);
+                    ret = wc_Sha224Final(hash[0], digest[0]);
                 if (ret != 0)
                     goto exit_sha224;
             } /* for times */
@@ -6096,10 +6163,12 @@ exit_sha224:
 
 exit:
 
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_Sha224Free(&hash[i]);
+    if (WC_ARRAY_OK(hash)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_Sha224Free(hash[i]);
+        }
+        WC_FREE_ARRAY(hash, BENCH_MAX_PENDING, HEAP_HINT);
     }
-
     WC_FREE_ARRAY(digest, BENCH_MAX_PENDING, HEAP_HINT);
 }
 #endif
@@ -6108,29 +6177,30 @@ exit:
 #ifndef NO_SHA256
 void bench_sha256(int useDeviceID)
 {
-    wc_Sha256 hash[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(hash, wc_Sha256, BENCH_MAX_PENDING,
+                     sizeof(wc_Sha256), HEAP_HINT);
     double start;
     int    ret = 0, i, count = 0, times, pending = 0;
     DECLARE_MULTI_VALUE_STATS_VARS()
     WC_DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING,
                      WC_SHA256_DIGEST_SIZE, HEAP_HINT);
-    WC_INIT_ARRAY(digest, byte, BENCH_MAX_PENDING,
-                  WC_SHA256_DIGEST_SIZE, HEAP_HINT);
 
-    /* clear for done cleanup */
-    XMEMSET(hash, 0, sizeof(hash));
+    WC_CALLOC_ARRAY(hash, wc_Sha256, BENCH_MAX_PENDING,
+                     sizeof(wc_Sha256), HEAP_HINT);
+    WC_ALLOC_ARRAY(digest, byte, BENCH_MAX_PENDING,
+                  WC_SHA256_DIGEST_SIZE, HEAP_HINT);
 
     if (digest_stream) {
         /* init keys */
         for (i = 0; i < BENCH_MAX_PENDING; i++) {
-            ret = wc_InitSha256_ex(&hash[i], HEAP_HINT,
+            ret = wc_InitSha256_ex(hash[i], HEAP_HINT,
                 useDeviceID ? devId: INVALID_DEVID);
             if (ret != 0) {
                 printf("InitSha256_ex failed, ret = %d\n", ret);
                 goto exit;
             }
         #ifdef WOLFSSL_PIC32MZ_HASH
-            wc_Sha256SizeSet(&hash[i], numBlocks * bench_size);
+            wc_Sha256SizeSet(hash[i], numBlocks * bench_size);
         #endif
         }
 
@@ -6141,12 +6211,12 @@ void bench_sha256(int useDeviceID)
 
                 /* while free pending slots in queue, submit ops */
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Sha256Update(&hash[i], bench_plain,
+                        ret = wc_Sha256Update(hash[i], bench_plain,
                             bench_size);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_sha256;
                         }
@@ -6160,11 +6230,11 @@ void bench_sha256(int useDeviceID)
             do {
                 bench_async_poll(&pending);
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Sha256Final(&hash[i], digest[i]);
+                        ret = wc_Sha256Final(hash[i], digest[i]);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_sha256;
                         }
@@ -6181,12 +6251,12 @@ void bench_sha256(int useDeviceID)
         bench_stats_start(&count, &start);
         do {
             for (times = 0; times < numBlocks; times++) {
-                ret = wc_InitSha256_ex(hash, HEAP_HINT,
+                ret = wc_InitSha256_ex(hash[0], HEAP_HINT,
                     useDeviceID ? devId: INVALID_DEVID);
                 if (ret == 0)
-                    ret = wc_Sha256Update(hash, bench_plain, bench_size);
+                    ret = wc_Sha256Update(hash[0], bench_plain, bench_size);
                 if (ret == 0)
-                    ret = wc_Sha256Final(hash, digest[0]);
+                    ret = wc_Sha256Final(hash[0], digest[0]);
                 if (ret != 0)
                     goto exit_sha256;
                 RECORD_MULTI_VALUE_STATS();
@@ -6205,10 +6275,12 @@ exit_sha256:
     bench_multi_value_stats(max, min, sum, squareSum, runs);
 #endif
 exit:
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_Sha256Free(&hash[i]);
+    if (WC_ARRAY_OK(hash)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_Sha256Free(hash[i]);
+        }
+        WC_FREE_ARRAY(hash, BENCH_MAX_PENDING, HEAP_HINT);
     }
-
     WC_FREE_ARRAY(digest, BENCH_MAX_PENDING, HEAP_HINT);
 }
 #endif
@@ -6216,22 +6288,23 @@ exit:
 #ifdef WOLFSSL_SHA384
 void bench_sha384(int useDeviceID)
 {
-    wc_Sha384 hash[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(hash, wc_Sha384, BENCH_MAX_PENDING,
+                     sizeof(wc_Sha384), HEAP_HINT);
     double start;
     int    ret = 0, i, count = 0, times, pending = 0;
     DECLARE_MULTI_VALUE_STATS_VARS()
     WC_DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING,
                      WC_SHA384_DIGEST_SIZE, HEAP_HINT);
-    WC_INIT_ARRAY(digest, byte, BENCH_MAX_PENDING,
-                  WC_SHA384_DIGEST_SIZE, HEAP_HINT);
 
-    /* clear for done cleanup */
-    XMEMSET(hash, 0, sizeof(hash));
+    WC_CALLOC_ARRAY(hash, wc_Sha384, BENCH_MAX_PENDING,
+                     sizeof(wc_Sha384), HEAP_HINT);
+    WC_ALLOC_ARRAY(digest, byte, BENCH_MAX_PENDING,
+                  WC_SHA384_DIGEST_SIZE, HEAP_HINT);
 
     if (digest_stream) {
         /* init keys */
         for (i = 0; i < BENCH_MAX_PENDING; i++) {
-            ret = wc_InitSha384_ex(&hash[i], HEAP_HINT,
+            ret = wc_InitSha384_ex(hash[i], HEAP_HINT,
                 useDeviceID ? devId : INVALID_DEVID);
             if (ret != 0) {
                 printf("InitSha384_ex failed, ret = %d\n", ret);
@@ -6246,12 +6319,12 @@ void bench_sha384(int useDeviceID)
 
                 /* while free pending slots in queue, submit ops */
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Sha384Update(&hash[i], bench_plain,
+                        ret = wc_Sha384Update(hash[i], bench_plain,
                             bench_size);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_sha384;
                         }
@@ -6265,11 +6338,11 @@ void bench_sha384(int useDeviceID)
             do {
                 bench_async_poll(&pending);
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Sha384Final(&hash[i], digest[i]);
+                        ret = wc_Sha384Final(hash[i], digest[i]);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_sha384;
                         }
@@ -6286,12 +6359,12 @@ void bench_sha384(int useDeviceID)
         bench_stats_start(&count, &start);
         do {
             for (times = 0; times < numBlocks; times++) {
-                ret = wc_InitSha384_ex(hash, HEAP_HINT,
+                ret = wc_InitSha384_ex(hash[0], HEAP_HINT,
                     useDeviceID ? devId : INVALID_DEVID);
                 if (ret == 0)
-                    ret = wc_Sha384Update(hash, bench_plain, bench_size);
+                    ret = wc_Sha384Update(hash[0], bench_plain, bench_size);
                 if (ret == 0)
-                    ret = wc_Sha384Final(hash, digest[0]);
+                    ret = wc_Sha384Final(hash[0], digest[0]);
                 if (ret != 0)
                     goto exit_sha384;
                 RECORD_MULTI_VALUE_STATS();
@@ -6312,10 +6385,12 @@ exit_sha384:
 
 exit:
 
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_Sha384Free(&hash[i]);
+    if (WC_ARRAY_OK(hash)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_Sha384Free(hash[i]);
+        }
+        WC_FREE_ARRAY(hash, BENCH_MAX_PENDING, HEAP_HINT);
     }
-
     WC_FREE_ARRAY(digest, BENCH_MAX_PENDING, HEAP_HINT);
 }
 #endif
@@ -6323,22 +6398,23 @@ exit:
 #ifdef WOLFSSL_SHA512
 void bench_sha512(int useDeviceID)
 {
-    wc_Sha512 hash[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(hash, wc_Sha512, BENCH_MAX_PENDING,
+                     sizeof(wc_Sha512), HEAP_HINT);
     double start;
     int    ret = 0, i, count = 0, times, pending = 0;
     DECLARE_MULTI_VALUE_STATS_VARS()
     WC_DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING,
                      WC_SHA512_DIGEST_SIZE, HEAP_HINT);
-    WC_INIT_ARRAY(digest, byte, BENCH_MAX_PENDING,
-                  WC_SHA512_DIGEST_SIZE, HEAP_HINT);
 
-    /* clear for done cleanup */
-    XMEMSET(hash, 0, sizeof(hash));
+    WC_CALLOC_ARRAY(hash, wc_Sha512, BENCH_MAX_PENDING,
+                     sizeof(wc_Sha512), HEAP_HINT);
+    WC_ALLOC_ARRAY(digest, byte, BENCH_MAX_PENDING,
+                  WC_SHA512_DIGEST_SIZE, HEAP_HINT);
 
     if (digest_stream) {
         /* init keys */
         for (i = 0; i < BENCH_MAX_PENDING; i++) {
-            ret = wc_InitSha512_ex(&hash[i], HEAP_HINT,
+            ret = wc_InitSha512_ex(hash[i], HEAP_HINT,
                 useDeviceID ? devId : INVALID_DEVID);
             if (ret != 0) {
                 printf("InitSha512_ex failed, ret = %d\n", ret);
@@ -6353,12 +6429,12 @@ void bench_sha512(int useDeviceID)
 
                 /* while free pending slots in queue, submit ops */
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Sha512Update(&hash[i], bench_plain,
+                        ret = wc_Sha512Update(hash[i], bench_plain,
                             bench_size);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_sha512;
                         }
@@ -6372,11 +6448,11 @@ void bench_sha512(int useDeviceID)
             do {
                 bench_async_poll(&pending);
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Sha512Final(&hash[i], digest[i]);
+                        ret = wc_Sha512Final(hash[i], digest[i]);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_sha512;
                         }
@@ -6393,12 +6469,12 @@ void bench_sha512(int useDeviceID)
         bench_stats_start(&count, &start);
         do {
             for (times = 0; times < numBlocks; times++) {
-                ret = wc_InitSha512_ex(hash, HEAP_HINT,
+                ret = wc_InitSha512_ex(hash[0], HEAP_HINT,
                     useDeviceID ? devId : INVALID_DEVID);
                 if (ret == 0)
-                    ret = wc_Sha512Update(hash, bench_plain, bench_size);
+                    ret = wc_Sha512Update(hash[0], bench_plain, bench_size);
                 if (ret == 0)
-                    ret = wc_Sha512Final(hash, digest[0]);
+                    ret = wc_Sha512Final(hash[0], digest[0]);
                 if (ret != 0)
                     goto exit_sha512;
                 RECORD_MULTI_VALUE_STATS();
@@ -6419,10 +6495,12 @@ exit_sha512:
 
 exit:
 
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_Sha512Free(&hash[i]);
+    if (WC_ARRAY_OK(hash)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_Sha512Free(hash[i]);
+        }
+        WC_FREE_ARRAY(hash, BENCH_MAX_PENDING, HEAP_HINT);
     }
-
     WC_FREE_ARRAY(digest, BENCH_MAX_PENDING, HEAP_HINT);
 }
 
@@ -6430,22 +6508,23 @@ exit:
    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)) && !defined(HAVE_SELFTEST)
 void bench_sha512_224(int useDeviceID)
 {
-    wc_Sha512_224 hash[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(hash, wc_Sha512_224, BENCH_MAX_PENDING,
+                     sizeof(wc_Sha512_224), HEAP_HINT);
     double start;
     int    ret = 0, i, count = 0, times, pending = 0;
     DECLARE_MULTI_VALUE_STATS_VARS()
-   WC_DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING,
+    WC_DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING,
                      WC_SHA512_224_DIGEST_SIZE, HEAP_HINT);
-    WC_INIT_ARRAY(digest, byte, BENCH_MAX_PENDING,
-                  WC_SHA512_224_DIGEST_SIZE, HEAP_HINT);
 
-    /* clear for done cleanup */
-    XMEMSET(hash, 0, sizeof(hash));
+    WC_CALLOC_ARRAY(hash, wc_Sha512_224, BENCH_MAX_PENDING,
+                     sizeof(wc_Sha512_224), HEAP_HINT);
+    WC_ALLOC_ARRAY(digest, byte, BENCH_MAX_PENDING,
+                  WC_SHA512_224_DIGEST_SIZE, HEAP_HINT);
 
     if (digest_stream) {
         /* init keys */
         for (i = 0; i < BENCH_MAX_PENDING; i++) {
-            ret = wc_InitSha512_224_ex(&hash[i], HEAP_HINT,
+            ret = wc_InitSha512_224_ex(hash[i], HEAP_HINT,
                 useDeviceID ? devId : INVALID_DEVID);
             if (ret != 0) {
                 printf("InitSha512_224_ex failed, ret = %d\n", ret);
@@ -6460,12 +6539,12 @@ void bench_sha512_224(int useDeviceID)
 
                 /* while free pending slots in queue, submit ops */
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Sha512_224Update(&hash[i], bench_plain,
+                        ret = wc_Sha512_224Update(hash[i], bench_plain,
                             bench_size);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_sha512_224;
                         }
@@ -6479,11 +6558,11 @@ void bench_sha512_224(int useDeviceID)
             do {
                 bench_async_poll(&pending);
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Sha512_224Final(&hash[i], digest[i]);
+                        ret = wc_Sha512_224Final(hash[i], digest[i]);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_sha512_224;
                         }
@@ -6500,12 +6579,12 @@ void bench_sha512_224(int useDeviceID)
         bench_stats_start(&count, &start);
         do {
             for (times = 0; times < numBlocks; times++) {
-                ret = wc_InitSha512_224_ex(hash, HEAP_HINT,
+                ret = wc_InitSha512_224_ex(hash[0], HEAP_HINT,
                     useDeviceID ? devId : INVALID_DEVID);
                 if (ret == 0)
-                    ret = wc_Sha512_224Update(hash, bench_plain, bench_size);
+                    ret = wc_Sha512_224Update(hash[0], bench_plain, bench_size);
                 if (ret == 0)
-                    ret = wc_Sha512_224Final(hash, digest[0]);
+                    ret = wc_Sha512_224Final(hash[0], digest[0]);
                 if (ret != 0)
                     goto exit_sha512_224;
                 RECORD_MULTI_VALUE_STATS();
@@ -6526,10 +6605,12 @@ exit_sha512_224:
 
 exit:
 
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_Sha512_224Free(&hash[i]);
+    if (WC_ARRAY_OK(hash)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_Sha512_224Free(hash[i]);
+        }
+        WC_FREE_ARRAY(hash, BENCH_MAX_PENDING, HEAP_HINT);
     }
-
     WC_FREE_ARRAY(digest, BENCH_MAX_PENDING, HEAP_HINT);
 }
 #endif /* WOLFSSL_NOSHA512_224 && !FIPS ... */
@@ -6538,22 +6619,23 @@ exit:
    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)) && !defined(HAVE_SELFTEST)
 void bench_sha512_256(int useDeviceID)
 {
-    wc_Sha512_256 hash[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(hash, wc_Sha512_256, BENCH_MAX_PENDING,
+                     sizeof(wc_Sha512_256), HEAP_HINT);
     double start;
     int    ret = 0, i, count = 0, times, pending = 0;
     DECLARE_MULTI_VALUE_STATS_VARS()
     WC_DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING,
                      WC_SHA512_256_DIGEST_SIZE, HEAP_HINT);
-    WC_INIT_ARRAY(digest, byte, BENCH_MAX_PENDING,
-                  WC_SHA512_256_DIGEST_SIZE, HEAP_HINT);
 
-    /* clear for done cleanup */
-    XMEMSET(hash, 0, sizeof(hash));
+    WC_CALLOC_ARRAY(hash, wc_Sha512_256, BENCH_MAX_PENDING,
+                     sizeof(wc_Sha512_256), HEAP_HINT);
+    WC_ALLOC_ARRAY(digest, byte, BENCH_MAX_PENDING,
+                  WC_SHA512_256_DIGEST_SIZE, HEAP_HINT);
 
     if (digest_stream) {
         /* init keys */
         for (i = 0; i < BENCH_MAX_PENDING; i++) {
-            ret = wc_InitSha512_256_ex(&hash[i], HEAP_HINT,
+            ret = wc_InitSha512_256_ex(hash[i], HEAP_HINT,
                 useDeviceID ? devId : INVALID_DEVID);
             if (ret != 0) {
                 printf("InitSha512_256_ex failed, ret = %d\n", ret);
@@ -6568,12 +6650,12 @@ void bench_sha512_256(int useDeviceID)
 
                 /* while free pending slots in queue, submit ops */
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Sha512_256Update(&hash[i], bench_plain,
+                        ret = wc_Sha512_256Update(hash[i], bench_plain,
                             bench_size);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_sha512_256;
                         }
@@ -6587,11 +6669,11 @@ void bench_sha512_256(int useDeviceID)
             do {
                 bench_async_poll(&pending);
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Sha512_256Final(&hash[i], digest[i]);
+                        ret = wc_Sha512_256Final(hash[i], digest[i]);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_sha512_256;
                         }
@@ -6608,12 +6690,12 @@ void bench_sha512_256(int useDeviceID)
         bench_stats_start(&count, &start);
         do {
             for (times = 0; times < numBlocks; times++) {
-                ret = wc_InitSha512_256_ex(hash, HEAP_HINT,
+                ret = wc_InitSha512_256_ex(hash[0], HEAP_HINT,
                     useDeviceID ? devId : INVALID_DEVID);
                 if (ret == 0)
-                    ret = wc_Sha512_256Update(hash, bench_plain, bench_size);
+                    ret = wc_Sha512_256Update(hash[0], bench_plain, bench_size);
                 if (ret == 0)
-                    ret = wc_Sha512_256Final(hash, digest[0]);
+                    ret = wc_Sha512_256Final(hash[0], digest[0]);
                 if (ret != 0)
                     goto exit_sha512_256;
                 RECORD_MULTI_VALUE_STATS();
@@ -6634,10 +6716,12 @@ exit_sha512_256:
 
 exit:
 
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_Sha512_256Free(&hash[i]);
+    if (WC_ARRAY_OK(hash)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_Sha512_256Free(hash[i]);
+        }
+        WC_FREE_ARRAY(hash, BENCH_MAX_PENDING, HEAP_HINT);
     }
-
     WC_FREE_ARRAY(digest, BENCH_MAX_PENDING, HEAP_HINT);
 }
 #endif /* WOLFSSL_NOSHA512_256 && !FIPS ... */
@@ -6649,22 +6733,23 @@ exit:
 #ifndef WOLFSSL_NOSHA3_224
 void bench_sha3_224(int useDeviceID)
 {
-    wc_Sha3   hash[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(hash, wc_Sha3, BENCH_MAX_PENDING,
+                     sizeof(wc_Sha3), HEAP_HINT);
     double start;
     int    ret = 0, i, count = 0, times, pending = 0;
     DECLARE_MULTI_VALUE_STATS_VARS()
     WC_DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING,
                      WC_SHA3_224_DIGEST_SIZE, HEAP_HINT);
-    WC_INIT_ARRAY(digest, byte, BENCH_MAX_PENDING,
-                  WC_SHA3_224_DIGEST_SIZE, HEAP_HINT);
 
-    /* clear for done cleanup */
-    XMEMSET(hash, 0, sizeof(hash));
+    WC_CALLOC_ARRAY(hash, wc_Sha3, BENCH_MAX_PENDING,
+                     sizeof(wc_Sha3), HEAP_HINT);
+    WC_ALLOC_ARRAY(digest, byte, BENCH_MAX_PENDING,
+                  WC_SHA3_224_DIGEST_SIZE, HEAP_HINT);
 
     if (digest_stream) {
         /* init keys */
         for (i = 0; i < BENCH_MAX_PENDING; i++) {
-            ret = wc_InitSha3_224(&hash[i], HEAP_HINT,
+            ret = wc_InitSha3_224(hash[i], HEAP_HINT,
                 useDeviceID ? devId : INVALID_DEVID);
             if (ret != 0) {
                 printf("InitSha3_224 failed, ret = %d\n", ret);
@@ -6679,12 +6764,12 @@ void bench_sha3_224(int useDeviceID)
 
                 /* while free pending slots in queue, submit ops */
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Sha3_224_Update(&hash[i], bench_plain,
+                        ret = wc_Sha3_224_Update(hash[i], bench_plain,
                             bench_size);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_sha3_224;
                         }
@@ -6698,11 +6783,11 @@ void bench_sha3_224(int useDeviceID)
             do {
                 bench_async_poll(&pending);
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Sha3_224_Final(&hash[i], digest[i]);
+                        ret = wc_Sha3_224_Final(hash[i], digest[i]);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_sha3_224;
                         }
@@ -6719,12 +6804,12 @@ void bench_sha3_224(int useDeviceID)
         bench_stats_start(&count, &start);
         do {
             for (times = 0; times < numBlocks; times++) {
-                ret = wc_InitSha3_224(hash, HEAP_HINT,
+                ret = wc_InitSha3_224(hash[0], HEAP_HINT,
                     useDeviceID ? devId : INVALID_DEVID);
                 if (ret == 0)
-                    ret = wc_Sha3_224_Update(hash, bench_plain, bench_size);
+                    ret = wc_Sha3_224_Update(hash[0], bench_plain, bench_size);
                 if (ret == 0)
-                    ret = wc_Sha3_224_Final(hash, digest[0]);
+                    ret = wc_Sha3_224_Final(hash[0], digest[0]);
                 if (ret != 0)
                     goto exit_sha3_224;
                 RECORD_MULTI_VALUE_STATS();
@@ -6745,10 +6830,12 @@ exit_sha3_224:
 
 exit:
 
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_Sha3_224_Free(&hash[i]);
+    if (WC_ARRAY_OK(hash)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_Sha3_224_Free(hash[i]);
+        }
+        WC_FREE_ARRAY(hash, BENCH_MAX_PENDING, HEAP_HINT);
     }
-
     WC_FREE_ARRAY(digest, BENCH_MAX_PENDING, HEAP_HINT);
 }
 #endif /* WOLFSSL_NOSHA3_224 */
@@ -6756,22 +6843,23 @@ exit:
 #ifndef WOLFSSL_NOSHA3_256
 void bench_sha3_256(int useDeviceID)
 {
-    wc_Sha3   hash[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(hash, wc_Sha3, BENCH_MAX_PENDING,
+                     sizeof(wc_Sha3), HEAP_HINT);
     double start;
     DECLARE_MULTI_VALUE_STATS_VARS()
     int    ret = 0, i, count = 0, times, pending = 0;
     WC_DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING,
                      WC_SHA3_256_DIGEST_SIZE, HEAP_HINT);
-    WC_INIT_ARRAY(digest, byte, BENCH_MAX_PENDING,
-                  WC_SHA3_256_DIGEST_SIZE, HEAP_HINT);
 
-    /* clear for done cleanup */
-    XMEMSET(hash, 0, sizeof(hash));
+    WC_CALLOC_ARRAY(hash, wc_Sha3, BENCH_MAX_PENDING,
+                     sizeof(wc_Sha3), HEAP_HINT);
+    WC_ALLOC_ARRAY(digest, byte, BENCH_MAX_PENDING,
+                  WC_SHA3_256_DIGEST_SIZE, HEAP_HINT);
 
     if (digest_stream) {
         /* init keys */
         for (i = 0; i < BENCH_MAX_PENDING; i++) {
-            ret = wc_InitSha3_256(&hash[i], HEAP_HINT,
+            ret = wc_InitSha3_256(hash[i], HEAP_HINT,
                 useDeviceID ? devId : INVALID_DEVID);
             if (ret != 0) {
                 printf("InitSha3_256 failed, ret = %d\n", ret);
@@ -6786,12 +6874,12 @@ void bench_sha3_256(int useDeviceID)
 
                 /* while free pending slots in queue, submit ops */
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Sha3_256_Update(&hash[i], bench_plain,
+                        ret = wc_Sha3_256_Update(hash[i], bench_plain,
                             bench_size);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_sha3_256;
                         }
@@ -6805,11 +6893,11 @@ void bench_sha3_256(int useDeviceID)
             do {
                 bench_async_poll(&pending);
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Sha3_256_Final(&hash[i], digest[i]);
+                        ret = wc_Sha3_256_Final(hash[i], digest[i]);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_sha3_256;
                         }
@@ -6826,12 +6914,12 @@ void bench_sha3_256(int useDeviceID)
         bench_stats_start(&count, &start);
         do {
             for (times = 0; times < numBlocks; times++) {
-                ret = wc_InitSha3_256(hash, HEAP_HINT,
+                ret = wc_InitSha3_256(hash[0], HEAP_HINT,
                     useDeviceID ? devId : INVALID_DEVID);
                 if (ret == 0)
-                    ret = wc_Sha3_256_Update(hash, bench_plain, bench_size);
+                    ret = wc_Sha3_256_Update(hash[0], bench_plain, bench_size);
                 if (ret == 0)
-                    ret = wc_Sha3_256_Final(hash, digest[0]);
+                    ret = wc_Sha3_256_Final(hash[0], digest[0]);
                 if (ret != 0)
                     goto exit_sha3_256;
                 RECORD_MULTI_VALUE_STATS();
@@ -6852,10 +6940,12 @@ exit_sha3_256:
 
 exit:
 
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_Sha3_256_Free(&hash[i]);
+    if (WC_ARRAY_OK(hash)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_Sha3_256_Free(hash[i]);
+        }
+        WC_FREE_ARRAY(hash, BENCH_MAX_PENDING, HEAP_HINT);
     }
-
     WC_FREE_ARRAY(digest, BENCH_MAX_PENDING, HEAP_HINT);
 }
 #endif /* WOLFSSL_NOSHA3_256 */
@@ -6863,22 +6953,23 @@ exit:
 #ifndef WOLFSSL_NOSHA3_384
 void bench_sha3_384(int useDeviceID)
 {
-    wc_Sha3   hash[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(hash, wc_Sha3, BENCH_MAX_PENDING,
+                     sizeof(wc_Sha3), HEAP_HINT);
     double start;
     int    ret = 0, i, count = 0, times, pending = 0;
     DECLARE_MULTI_VALUE_STATS_VARS()
     WC_DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING,
                      WC_SHA3_384_DIGEST_SIZE, HEAP_HINT);
-    WC_INIT_ARRAY(digest, byte, BENCH_MAX_PENDING,
-                  WC_SHA3_384_DIGEST_SIZE, HEAP_HINT);
 
-    /* clear for done cleanup */
-    XMEMSET(hash, 0, sizeof(hash));
+    WC_CALLOC_ARRAY(hash, wc_Sha3, BENCH_MAX_PENDING,
+                     sizeof(wc_Sha3), HEAP_HINT);
+    WC_ALLOC_ARRAY(digest, byte, BENCH_MAX_PENDING,
+                  WC_SHA3_384_DIGEST_SIZE, HEAP_HINT);
 
     if (digest_stream) {
         /* init keys */
         for (i = 0; i < BENCH_MAX_PENDING; i++) {
-            ret = wc_InitSha3_384(&hash[i], HEAP_HINT,
+            ret = wc_InitSha3_384(hash[i], HEAP_HINT,
                 useDeviceID ? devId : INVALID_DEVID);
             if (ret != 0) {
                 printf("InitSha3_384 failed, ret = %d\n", ret);
@@ -6893,12 +6984,12 @@ void bench_sha3_384(int useDeviceID)
 
                 /* while free pending slots in queue, submit ops */
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Sha3_384_Update(&hash[i], bench_plain,
+                        ret = wc_Sha3_384_Update(hash[i], bench_plain,
                             bench_size);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_sha3_384;
                         }
@@ -6912,11 +7003,11 @@ void bench_sha3_384(int useDeviceID)
             do {
                 bench_async_poll(&pending);
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Sha3_384_Final(&hash[i], digest[i]);
+                        ret = wc_Sha3_384_Final(hash[i], digest[i]);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_sha3_384;
                         }
@@ -6933,12 +7024,12 @@ void bench_sha3_384(int useDeviceID)
         bench_stats_start(&count, &start);
         do {
             for (times = 0; times < numBlocks; times++) {
-                ret = wc_InitSha3_384(hash, HEAP_HINT,
+                ret = wc_InitSha3_384(hash[0], HEAP_HINT,
                     useDeviceID ? devId : INVALID_DEVID);
                 if (ret == 0)
-                    ret = wc_Sha3_384_Update(hash, bench_plain, bench_size);
+                    ret = wc_Sha3_384_Update(hash[0], bench_plain, bench_size);
                 if (ret == 0)
-                    ret = wc_Sha3_384_Final(hash, digest[0]);
+                    ret = wc_Sha3_384_Final(hash[0], digest[0]);
                 if (ret != 0)
                     goto exit_sha3_384;
                 RECORD_MULTI_VALUE_STATS();
@@ -6959,10 +7050,12 @@ exit_sha3_384:
 
 exit:
 
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_Sha3_384_Free(&hash[i]);
+    if (WC_ARRAY_OK(hash)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_Sha3_384_Free(hash[i]);
+        }
+        WC_FREE_ARRAY(hash, BENCH_MAX_PENDING, HEAP_HINT);
     }
-
     WC_FREE_ARRAY(digest, BENCH_MAX_PENDING, HEAP_HINT);
 }
 #endif /* WOLFSSL_NOSHA3_384 */
@@ -6970,22 +7063,23 @@ exit:
 #ifndef WOLFSSL_NOSHA3_512
 void bench_sha3_512(int useDeviceID)
 {
-    wc_Sha3   hash[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(hash, wc_Sha3, BENCH_MAX_PENDING,
+                     sizeof(wc_Sha3), HEAP_HINT);
     double start;
     int    ret = 0, i, count = 0, times, pending = 0;
     DECLARE_MULTI_VALUE_STATS_VARS()
     WC_DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING,
                      WC_SHA3_512_DIGEST_SIZE, HEAP_HINT);
-    WC_INIT_ARRAY(digest, byte, BENCH_MAX_PENDING,
-                  WC_SHA3_512_DIGEST_SIZE, HEAP_HINT);
 
-    /* clear for done cleanup */
-    XMEMSET(hash, 0, sizeof(hash));
+    WC_CALLOC_ARRAY(hash, wc_Sha3, BENCH_MAX_PENDING,
+                     sizeof(wc_Sha3), HEAP_HINT);
+    WC_ALLOC_ARRAY(digest, byte, BENCH_MAX_PENDING,
+                  WC_SHA3_512_DIGEST_SIZE, HEAP_HINT);
 
     if (digest_stream) {
         /* init keys */
         for (i = 0; i < BENCH_MAX_PENDING; i++) {
-            ret = wc_InitSha3_512(&hash[i], HEAP_HINT,
+            ret = wc_InitSha3_512(hash[i], HEAP_HINT,
                 useDeviceID ? devId : INVALID_DEVID);
             if (ret != 0) {
                 printf("InitSha3_512 failed, ret = %d\n", ret);
@@ -7000,12 +7094,12 @@ void bench_sha3_512(int useDeviceID)
 
                 /* while free pending slots in queue, submit ops */
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Sha3_512_Update(&hash[i], bench_plain,
+                        ret = wc_Sha3_512_Update(hash[i], bench_plain,
                             bench_size);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_sha3_512;
                         }
@@ -7019,11 +7113,11 @@ void bench_sha3_512(int useDeviceID)
             do {
                 bench_async_poll(&pending);
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Sha3_512_Final(&hash[i], digest[i]);
+                        ret = wc_Sha3_512_Final(hash[i], digest[i]);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_sha3_512;
                         }
@@ -7040,12 +7134,12 @@ void bench_sha3_512(int useDeviceID)
         bench_stats_start(&count, &start);
         do {
             for (times = 0; times < numBlocks; times++) {
-                ret = wc_InitSha3_512(hash, HEAP_HINT,
+                ret = wc_InitSha3_512(hash[0], HEAP_HINT,
                     useDeviceID ? devId : INVALID_DEVID);
                 if (ret == 0)
-                    ret = wc_Sha3_512_Update(hash, bench_plain, bench_size);
+                    ret = wc_Sha3_512_Update(hash[0], bench_plain, bench_size);
                 if (ret == 0)
-                    ret = wc_Sha3_512_Final(hash, digest[0]);
+                    ret = wc_Sha3_512_Final(hash[0], digest[0]);
                 if (ret != 0)
                     goto exit_sha3_512;
                 RECORD_MULTI_VALUE_STATS();
@@ -7066,10 +7160,12 @@ exit_sha3_512:
 
 exit:
 
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_Sha3_512_Free(&hash[i]);
+    if (WC_ARRAY_OK(hash)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_Sha3_512_Free(hash[i]);
+        }
+        WC_FREE_ARRAY(hash, BENCH_MAX_PENDING, HEAP_HINT);
     }
-
     WC_FREE_ARRAY(digest, BENCH_MAX_PENDING, HEAP_HINT);
 }
 #endif /* WOLFSSL_NOSHA3_512 */
@@ -7077,22 +7173,23 @@ exit:
 #ifdef WOLFSSL_SHAKE128
 void bench_shake128(int useDeviceID)
 {
-    wc_Shake hash[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(hash, wc_Shake, BENCH_MAX_PENDING,
+                     sizeof(wc_Shake), HEAP_HINT);
     double start;
     int    ret = 0, i, count = 0, times, pending = 0;
     DECLARE_MULTI_VALUE_STATS_VARS()
     WC_DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING,
                      WC_SHA3_128_BLOCK_SIZE, HEAP_HINT);
-    WC_INIT_ARRAY(digest, byte, BENCH_MAX_PENDING,
-                  WC_SHA3_128_BLOCK_SIZE, HEAP_HINT);
 
-    /* clear for done cleanup */
-    XMEMSET(hash, 0, sizeof(hash));
+    WC_CALLOC_ARRAY(hash, wc_Shake, BENCH_MAX_PENDING,
+                     sizeof(wc_Shake), HEAP_HINT);
+    WC_ALLOC_ARRAY(digest, byte, BENCH_MAX_PENDING,
+                  WC_SHA3_128_BLOCK_SIZE, HEAP_HINT);
 
     if (digest_stream) {
         /* init keys */
         for (i = 0; i < BENCH_MAX_PENDING; i++) {
-            ret = wc_InitShake128(&hash[i], HEAP_HINT,
+            ret = wc_InitShake128(hash[i], HEAP_HINT,
                 useDeviceID ? devId : INVALID_DEVID);
             if (ret != 0) {
                 printf("InitShake128 failed, ret = %d\n", ret);
@@ -7107,12 +7204,12 @@ void bench_shake128(int useDeviceID)
 
                 /* while free pending slots in queue, submit ops */
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Shake128_Update(&hash[i], bench_plain,
+                        ret = wc_Shake128_Update(hash[i], bench_plain,
                             bench_size);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_shake128;
                         }
@@ -7126,12 +7223,12 @@ void bench_shake128(int useDeviceID)
             do {
                 bench_async_poll(&pending);
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Shake128_Final(&hash[i], digest[i],
+                        ret = wc_Shake128_Final(hash[i], digest[i],
                             WC_SHA3_128_BLOCK_SIZE);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_shake128;
                         }
@@ -7148,12 +7245,12 @@ void bench_shake128(int useDeviceID)
         bench_stats_start(&count, &start);
         do {
             for (times = 0; times < numBlocks; times++) {
-                ret = wc_InitShake128(hash, HEAP_HINT,
+                ret = wc_InitShake128(hash[0], HEAP_HINT,
                     useDeviceID ? devId : INVALID_DEVID);
                 if (ret == 0)
-                    ret = wc_Shake128_Update(hash, bench_plain, bench_size);
+                    ret = wc_Shake128_Update(hash[0], bench_plain, bench_size);
                 if (ret == 0)
-                    ret = wc_Shake128_Final(hash, digest[0],
+                    ret = wc_Shake128_Final(hash[0], digest[0],
                         WC_SHA3_128_BLOCK_SIZE);
                 if (ret != 0)
                     goto exit_shake128;
@@ -7175,10 +7272,12 @@ exit_shake128:
 
 exit:
 
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_Shake128_Free(&hash[i]);
+    if (WC_ARRAY_OK(hash)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_Shake128_Free(hash[i]);
+        }
+        WC_FREE_ARRAY(hash, BENCH_MAX_PENDING, HEAP_HINT);
     }
-
     WC_FREE_ARRAY(digest, BENCH_MAX_PENDING, HEAP_HINT);
 }
 #endif /* WOLFSSL_SHAKE128 */
@@ -7186,22 +7285,23 @@ exit:
 #ifdef WOLFSSL_SHAKE256
 void bench_shake256(int useDeviceID)
 {
-    wc_Shake hash[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(hash, wc_Shake, BENCH_MAX_PENDING,
+                     sizeof(wc_Shake), HEAP_HINT);
     double start;
     int    ret = 0, i, count = 0, times, pending = 0;
     DECLARE_MULTI_VALUE_STATS_VARS()
     WC_DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING,
                      WC_SHA3_256_BLOCK_SIZE, HEAP_HINT);
-    WC_INIT_ARRAY(digest, byte, BENCH_MAX_PENDING,
-                  WC_SHA3_256_BLOCK_SIZE, HEAP_HINT);
 
-    /* clear for done cleanup */
-    XMEMSET(hash, 0, sizeof(hash));
+    WC_CALLOC_ARRAY(hash, wc_Shake, BENCH_MAX_PENDING,
+                     sizeof(wc_Shake), HEAP_HINT);
+    WC_ALLOC_ARRAY(digest, byte, BENCH_MAX_PENDING,
+                  WC_SHA3_256_BLOCK_SIZE, HEAP_HINT);
 
     if (digest_stream) {
         /* init keys */
         for (i = 0; i < BENCH_MAX_PENDING; i++) {
-            ret = wc_InitShake256(&hash[i], HEAP_HINT,
+            ret = wc_InitShake256(hash[i], HEAP_HINT,
                 useDeviceID ? devId : INVALID_DEVID);
             if (ret != 0) {
                 printf("InitShake256 failed, ret = %d\n", ret);
@@ -7216,12 +7316,12 @@ void bench_shake256(int useDeviceID)
 
                 /* while free pending slots in queue, submit ops */
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Shake256_Update(&hash[i], bench_plain,
+                        ret = wc_Shake256_Update(hash[i], bench_plain,
                             bench_size);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_shake256;
                         }
@@ -7235,12 +7335,12 @@ void bench_shake256(int useDeviceID)
             do {
                 bench_async_poll(&pending);
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                           0, &times, numBlocks, &pending)) {
-                        ret = wc_Shake256_Final(&hash[i], digest[i],
+                        ret = wc_Shake256_Final(hash[i], digest[i],
                             WC_SHA3_256_BLOCK_SIZE);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0,
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0,
                                                 &times, &pending)) {
                             goto exit_shake256;
                         }
@@ -7257,12 +7357,12 @@ void bench_shake256(int useDeviceID)
         bench_stats_start(&count, &start);
         do {
             for (times = 0; times < numBlocks; times++) {
-                ret = wc_InitShake256(hash, HEAP_HINT,
+                ret = wc_InitShake256(hash[0], HEAP_HINT,
                     useDeviceID ? devId : INVALID_DEVID);
                 if (ret == 0)
-                    ret = wc_Shake256_Update(hash, bench_plain, bench_size);
+                    ret = wc_Shake256_Update(hash[0], bench_plain, bench_size);
                 if (ret == 0)
-                    ret = wc_Shake256_Final(hash, digest[0],
+                    ret = wc_Shake256_Final(hash[0], digest[0],
                         WC_SHA3_256_BLOCK_SIZE);
                 if (ret != 0)
                     goto exit_shake256;
@@ -7284,10 +7384,12 @@ exit_shake256:
 
 exit:
 
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_Shake256_Free(&hash[i]);
+    if (WC_ARRAY_OK(hash)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_Shake256_Free(hash[i]);
+        }
+        WC_FREE_ARRAY(hash, BENCH_MAX_PENDING, HEAP_HINT);
     }
-
     WC_FREE_ARRAY(digest, BENCH_MAX_PENDING, HEAP_HINT);
 }
 #endif /* WOLFSSL_SHAKE256 */
@@ -7296,22 +7398,23 @@ exit:
 #ifdef WOLFSSL_SM3
 void bench_sm3(int useDeviceID)
 {
-    wc_Sm3 hash[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(hash, wc_Sm3, BENCH_MAX_PENDING,
+                     sizeof(wc_Sm3), HEAP_HINT);
     double start;
     int    ret = 0, i, count = 0, times, pending = 0;
     DECLARE_MULTI_VALUE_STATS_VARS()
     WC_DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING, WC_SM3_DIGEST_SIZE,
         HEAP_HINT);
-    WC_INIT_ARRAY(digest, byte, BENCH_MAX_PENDING, WC_SM3_DIGEST_SIZE,
-        HEAP_HINT);
 
-    /* clear for done cleanup */
-    XMEMSET(hash, 0, sizeof(hash));
+    WC_CALLOC_ARRAY(hash, wc_Sm3, BENCH_MAX_PENDING,
+                     sizeof(wc_Sm3), HEAP_HINT);
+    WC_ALLOC_ARRAY(digest, byte, BENCH_MAX_PENDING, WC_SM3_DIGEST_SIZE,
+        HEAP_HINT);
 
     if (digest_stream) {
         /* init keys */
         for (i = 0; i < BENCH_MAX_PENDING; i++) {
-            ret = wc_InitSm3(&hash[i], HEAP_HINT,
+            ret = wc_InitSm3(hash[i], HEAP_HINT,
                 useDeviceID ? devId: INVALID_DEVID);
             if (ret != 0) {
                 printf("InitSm3 failed, ret = %d\n", ret);
@@ -7326,12 +7429,12 @@ void bench_sm3(int useDeviceID)
 
                 /* while free pending slots in queue, submit ops */
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                               0, &times, numBlocks, &pending)) {
-                        ret = wc_Sm3Update(&hash[i], bench_plain,
+                        ret = wc_Sm3Update(hash[i], bench_plain,
                             bench_size);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0, &times, &pending)) {
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0, &times, &pending)) {
                             goto exit_sm3;
                         }
                     }
@@ -7344,11 +7447,11 @@ void bench_sm3(int useDeviceID)
             do {
                 bench_async_poll(&pending);
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&hash[i]),
+                    if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(hash[i]),
                                               0, &times, numBlocks, &pending)) {
-                        ret = wc_Sm3Final(&hash[i], digest[i]);
+                        ret = wc_Sm3Final(hash[i], digest[i]);
                         if (!bench_async_handle(&ret,
-                            BENCH_ASYNC_GET_DEV(&hash[i]), 0, &times, &pending)) {
+                            BENCH_ASYNC_GET_DEV(hash[i]), 0, &times, &pending)) {
                             goto exit_sm3;
                         }
                     }
@@ -7389,10 +7492,12 @@ exit_sm3:
 
 exit:
 
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_Sm3Free(&hash[i]);
+    if (WC_ARRAY_OK(hash)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_Sm3Free(hash[i]);
+        }
+        WC_FREE_ARRAY(hash, BENCH_MAX_PENDING, HEAP_HINT);
     }
-
     WC_FREE_ARRAY(digest, BENCH_MAX_PENDING, HEAP_HINT);
 }
 #endif
@@ -7751,14 +7856,15 @@ exit:
 static void bench_hmac(int useDeviceID, int type, int digestSz,
                        const byte* key, word32 keySz, const char* label)
 {
-    Hmac   hmac[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(hmac, Hmac, BENCH_MAX_PENDING,
+                     sizeof(Hmac), HEAP_HINT);
     double start;
     int    ret = 0, i, count = 0, times, pending = 0;
     DECLARE_MULTI_VALUE_STATS_VARS()
 #ifdef WOLFSSL_ASYNC_CRYPT
     WC_DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING,
                      WC_MAX_DIGEST_SIZE, HEAP_HINT);
-    WC_INIT_ARRAY(digest, byte, BENCH_MAX_PENDING,
+    WC_ALLOC_ARRAY(digest, byte, BENCH_MAX_PENDING,
                   WC_MAX_DIGEST_SIZE, HEAP_HINT);
 #else
     byte digest[BENCH_MAX_PENDING][WC_MAX_DIGEST_SIZE];
@@ -7766,19 +7872,19 @@ static void bench_hmac(int useDeviceID, int type, int digestSz,
 
     (void)digestSz;
 
-    /* clear for done cleanup */
-    XMEMSET(hmac, 0, sizeof(hmac));
+    WC_CALLOC_ARRAY(hmac, Hmac, BENCH_MAX_PENDING,
+                     sizeof(Hmac), HEAP_HINT);
 
     /* init keys */
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        ret = wc_HmacInit(&hmac[i], HEAP_HINT,
+        ret = wc_HmacInit(hmac[i], HEAP_HINT,
                 useDeviceID ? devId : INVALID_DEVID);
         if (ret != 0) {
             printf("wc_HmacInit failed for %s, ret = %d\n", label, ret);
             goto exit;
         }
 
-        ret = wc_HmacSetKey(&hmac[i], type, key, keySz);
+        ret = wc_HmacSetKey(hmac[i], type, key, keySz);
         if (ret != 0) {
             printf("wc_HmacSetKey failed for %s, ret = %d\n", label, ret);
             goto exit;
@@ -7793,11 +7899,11 @@ static void bench_hmac(int useDeviceID, int type, int digestSz,
             /* while free pending slots in queue, submit ops */
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
                 if (bench_async_check(&ret,
-                                      BENCH_ASYNC_GET_DEV(&hmac[i]), 0,
+                                      BENCH_ASYNC_GET_DEV(hmac[i]), 0,
                                       &times, numBlocks, &pending)) {
-                    ret = wc_HmacUpdate(&hmac[i], bench_plain, bench_size);
+                    ret = wc_HmacUpdate(hmac[i], bench_plain, bench_size);
                     if (!bench_async_handle(&ret,
-                                            BENCH_ASYNC_GET_DEV(&hmac[i]),
+                                            BENCH_ASYNC_GET_DEV(hmac[i]),
                                             0, &times, &pending)) {
                         goto exit_hmac;
                     }
@@ -7812,11 +7918,11 @@ static void bench_hmac(int useDeviceID, int type, int digestSz,
 
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
                 if (bench_async_check(&ret,
-                                      BENCH_ASYNC_GET_DEV(&hmac[i]), 0,
+                                      BENCH_ASYNC_GET_DEV(hmac[i]), 0,
                                       &times, numBlocks, &pending)) {
-                    ret = wc_HmacFinal(&hmac[i], digest[i]);
+                    ret = wc_HmacFinal(hmac[i], digest[i]);
                     if (!bench_async_handle(&ret,
-                                            BENCH_ASYNC_GET_DEV(&hmac[i]),
+                                            BENCH_ASYNC_GET_DEV(hmac[i]),
                                             0, &times, &pending)) {
                         goto exit_hmac;
                     }
@@ -7839,9 +7945,10 @@ exit_hmac:
 exit:
 
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_HmacFree(&hmac[i]);
+        wc_HmacFree(hmac[i]);
     }
 
+    WC_FREE_ARRAY(hmac, BENCH_MAX_PENDING, HEAP_HINT);
 #ifdef WOLFSSL_ASYNC_CRYPT
     WC_FREE_ARRAY(digest, BENCH_MAX_PENDING, HEAP_HINT);
 #endif
@@ -8141,28 +8248,16 @@ void bench_srtpkdf(void)
 #if defined(WOLFSSL_KEY_GEN)
 static void bench_rsaKeyGen_helper(int useDeviceID, word32 keySz)
 {
-#ifdef WOLFSSL_SMALL_STACK
-    RsaKey *genKey;
-#else
-    RsaKey genKey[BENCH_MAX_PENDING];
-#endif
-    double start;
+    WC_DECLARE_ARRAY(genKey, RsaKey, BENCH_MAX_PENDING,
+                     sizeof(RsaKey), HEAP_HINT);
+    double start = 0;
     int    ret = 0, i, count = 0, times, pending = 0;
     const long rsa_e_val = WC_RSA_EXPONENT;
     const char**desc = bench_desc_words[lng_index];
     DECLARE_MULTI_VALUE_STATS_VARS()
 
-#ifdef WOLFSSL_SMALL_STACK
-    genKey = (RsaKey *)XMALLOC(sizeof(*genKey) * BENCH_MAX_PENDING,
-                               HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-    if (genKey == NULL) {
-        printf("bench_rsaKeyGen_helper malloc failed\n");
-        return;
-    }
-#endif
-
-    /* clear for done cleanup */
-    XMEMSET(genKey, 0, sizeof(*genKey) * BENCH_MAX_PENDING);
+    WC_CALLOC_ARRAY(genKey, RsaKey, BENCH_MAX_PENDING,
+                     sizeof(RsaKey), HEAP_HINT);
 
     bench_stats_start(&count, &start);
     do {
@@ -8171,19 +8266,18 @@ static void bench_rsaKeyGen_helper(int useDeviceID, word32 keySz)
             bench_async_poll(&pending);
 
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&genKey[i]),
+                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(genKey[i]),
                                       0, &times, genTimes, &pending)) {
-
-                    wc_FreeRsaKey(&genKey[i]);
-                    ret = wc_InitRsaKey_ex(&genKey[i], HEAP_HINT, devId);
+                    wc_FreeRsaKey(genKey[i]);
+                    ret = wc_InitRsaKey_ex(genKey[i], HEAP_HINT, devId);
                     if (ret < 0) {
                         goto exit;
                     }
 
-                    ret = wc_MakeRsaKey(&genKey[i], (int)keySz, rsa_e_val,
+                    ret = wc_MakeRsaKey(genKey[i], (int)keySz, rsa_e_val,
                                         &gRng);
                     if (!bench_async_handle(&ret,
-                        BENCH_ASYNC_GET_DEV(&genKey[i]), 0,
+                        BENCH_ASYNC_GET_DEV(genKey[i]), 0,
                                             &times, &pending)) {
                         goto exit;
                     }
@@ -8207,12 +8301,10 @@ exit:
 
     /* cleanup */
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_FreeRsaKey(&genKey[i]);
+        wc_FreeRsaKey(genKey[i]);
     }
 
-#ifdef WOLFSSL_SMALL_STACK
-    XFREE(genKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-#endif
+    WC_FREE_ARRAY(genKey, BENCH_MAX_PENDING, HEAP_HINT);
 }
 
 void bench_rsaKeyGen(int useDeviceID)
@@ -8343,8 +8435,13 @@ static const unsigned char rsa_3072_sig[] = {
 #endif
 #endif /* WOLFSSL_RSA_VERIFY_INLINE || WOLFSSL_RSA_PUBLIC_ONLY */
 
-static void bench_rsa_helper(int useDeviceID, RsaKey rsaKey[BENCH_MAX_PENDING],
+#ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
+static void bench_rsa_helper(int useDeviceID, RsaKey *rsaKey[BENCH_MAX_PENDING],
                              word32 rsaKeySz)
+#else
+static void bench_rsa_helper(int useDeviceID, RsaKey rsaKey[1][BENCH_MAX_PENDING],
+                             word32 rsaKeySz)
+#endif
 {
     int         ret = 0, i, times, count = 0, pending = 0;
     word32      idx = 0;
@@ -8358,23 +8455,25 @@ static void bench_rsa_helper(int useDeviceID, RsaKey rsaKey[BENCH_MAX_PENDING],
 #ifndef WOLFSSL_RSA_VERIFY_ONLY
     WC_DECLARE_VAR(message, byte, TEST_STRING_SZ, HEAP_HINT);
 #endif
-    WC_DECLARE_ARRAY_DYNAMIC_DEC(enc, byte, BENCH_MAX_PENDING,
+    WC_DECLARE_HEAP_ARRAY(enc, byte, BENCH_MAX_PENDING,
                                  rsaKeySz, HEAP_HINT);
 
     #if (  !defined(WOLFSSL_RSA_VERIFY_INLINE) \
         && !defined(WOLFSSL_RSA_PUBLIC_ONLY)   )
-        WC_DECLARE_ARRAY_DYNAMIC_DEC(out, byte, BENCH_MAX_PENDING,
+        WC_DECLARE_HEAP_ARRAY(out, byte, BENCH_MAX_PENDING,
                                      rsaKeySz, HEAP_HINT);
     #else
         byte* out[BENCH_MAX_PENDING];
     #endif
 
-    WC_DECLARE_ARRAY_DYNAMIC_EXE(enc, byte, BENCH_MAX_PENDING,
+    XMEMSET(out, 0, sizeof(out));
+
+    WC_ALLOC_HEAP_ARRAY(enc, byte, BENCH_MAX_PENDING,
                                  rsaKeySz, HEAP_HINT);
 
     #if (  !defined(WOLFSSL_RSA_VERIFY_INLINE) \
         && !defined(WOLFSSL_RSA_PUBLIC_ONLY)   )
-        WC_DECLARE_ARRAY_DYNAMIC_EXE(out, byte, BENCH_MAX_PENDING,
+        WC_ALLOC_HEAP_ARRAY(out, byte, BENCH_MAX_PENDING,
                                      rsaKeySz, HEAP_HINT);
         if (out[0] == NULL) {
             ret = MEMORY_E;
@@ -8407,14 +8506,14 @@ static void bench_rsa_helper(int useDeviceID, RsaKey rsaKey[BENCH_MAX_PENDING],
                 /* while free pending slots in queue, submit ops */
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
                     if (bench_async_check(&ret,
-                                          BENCH_ASYNC_GET_DEV(&rsaKey[i]),
+                                          BENCH_ASYNC_GET_DEV(rsaKey[i]),
                                           1, &times, ntimes, &pending)) {
                         ret = wc_RsaPublicEncrypt(message, (word32)len, enc[i],
-                                                  rsaKeySz/8, &rsaKey[i],
+                                                  rsaKeySz/8, rsaKey[i],
                                                   GLOBAL_RNG);
                         if (!bench_async_handle(&ret,
                                                 BENCH_ASYNC_GET_DEV(
-                                                &rsaKey[i]), 1, &times,
+                                                rsaKey[i]), 1, &times,
                                                 &pending)) {
                             goto exit_rsa_verify;
                         }
@@ -8456,12 +8555,12 @@ exit_rsa_verify:
                 /* while free pending slots in queue, submit ops */
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
                     if (bench_async_check(&ret,
-                                          BENCH_ASYNC_GET_DEV(&rsaKey[i]),
+                                          BENCH_ASYNC_GET_DEV(rsaKey[i]),
                                           1, &times, ntimes, &pending)) {
                         ret = wc_RsaPrivateDecrypt(enc[i], idx, out[i],
-                                                   rsaKeySz/8, &rsaKey[i]);
+                                                   rsaKeySz/8, rsaKey[i]);
                         if (!bench_async_handle(&ret,
-                                           BENCH_ASYNC_GET_DEV(&rsaKey[i]),
+                                           BENCH_ASYNC_GET_DEV(rsaKey[i]),
                                                 1, &times, &pending)) {
                             goto exit_rsa_pub;
                         }
@@ -8495,12 +8594,12 @@ exit_rsa_pub:
                 /* while free pending slots in queue, submit ops */
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
                     if (bench_async_check(&ret,
-                                          BENCH_ASYNC_GET_DEV(&rsaKey[i]),
+                                          BENCH_ASYNC_GET_DEV(rsaKey[i]),
                                           1, &times, ntimes, &pending)) {
                         ret = wc_RsaSSL_Sign(message, len, enc[i],
-                                            rsaKeySz/8, &rsaKey[i], GLOBAL_RNG);
+                                            rsaKeySz/8, rsaKey[i], GLOBAL_RNG);
                         if (!bench_async_handle(&ret,
-                                           BENCH_ASYNC_GET_DEV(&rsaKey[i]),
+                                           BENCH_ASYNC_GET_DEV(rsaKey[i]),
                                            1, &times, &pending)) {
                             goto exit_rsa_sign;
                         }
@@ -8541,18 +8640,18 @@ exit_rsa_sign:
                 /* while free pending slots in queue, submit ops */
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
                     if (bench_async_check(&ret,
-                                          BENCH_ASYNC_GET_DEV(&rsaKey[i]),
+                                          BENCH_ASYNC_GET_DEV(rsaKey[i]),
                                           1, &times, ntimes, &pending)) {
                     #if !defined(WOLFSSL_RSA_VERIFY_INLINE) && \
                         !defined(WOLFSSL_RSA_PUBLIC_ONLY)
                         ret = wc_RsaSSL_Verify(enc[i], idx, out[i],
-                                                      rsaKeySz/8, &rsaKey[i]);
+                                                      rsaKeySz/8, rsaKey[i]);
                     #elif defined(USE_CERT_BUFFERS_2048)
                         XMEMCPY(enc[i], rsa_2048_sig, sizeof(rsa_2048_sig));
                         idx = sizeof(rsa_2048_sig);
                         out[i] = NULL;
                         ret = wc_RsaSSL_VerifyInline(enc[i], idx,
-                                                     &out[i], &rsaKey[i]);
+                                                     &out[i], rsaKey[i]);
                         if (ret > 0) {
                             ret = 0;
                         }
@@ -8562,12 +8661,12 @@ exit_rsa_sign:
                         idx = sizeof(rsa_3072_sig);
                         out[i] = NULL;
                         ret = wc_RsaSSL_VerifyInline(enc[i], idx,
-                                                     &out[i], &rsaKey[i]);
+                                                     &out[i], rsaKey[i]);
                         if (ret > 0)
                             ret = 0;
                     #endif
                         if (!bench_async_handle(&ret,
-                                              BENCH_ASYNC_GET_DEV(&rsaKey[i]),
+                                              BENCH_ASYNC_GET_DEV(rsaKey[i]),
                                               1, &times, &pending)) {
                             goto exit_rsa_verifyinline;
                         }
@@ -8592,9 +8691,9 @@ exit_rsa_verifyinline:
 
 exit:
 
-    WC_FREE_ARRAY_DYNAMIC(enc, BENCH_MAX_PENDING, HEAP_HINT);
+    WC_FREE_HEAP_ARRAY(enc, BENCH_MAX_PENDING, HEAP_HINT);
 #if !defined(WOLFSSL_RSA_VERIFY_INLINE) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)
-    WC_FREE_ARRAY_DYNAMIC(out, BENCH_MAX_PENDING, HEAP_HINT);
+    WC_FREE_HEAP_ARRAY(out, BENCH_MAX_PENDING, HEAP_HINT);
 #endif
 #ifndef WOLFSSL_RSA_VERIFY_ONLY
     WC_FREE_VAR(message, HEAP_HINT);
@@ -8604,11 +8703,8 @@ exit:
 void bench_rsa(int useDeviceID)
 {
     int         i;
-#ifdef WOLFSSL_SMALL_STACK
-    RsaKey      *rsaKey;
-#else
-    RsaKey      rsaKey[BENCH_MAX_PENDING];
-#endif
+    WC_DECLARE_ARRAY(rsaKey, RsaKey, BENCH_MAX_PENDING,
+                     sizeof(RsaKey), HEAP_HINT);
     int         ret = 0;
     word32      rsaKeySz = 0;
     const byte* tmp;
@@ -8617,10 +8713,10 @@ void bench_rsa(int useDeviceID)
     word32      idx;
 #endif
 
-#ifdef WOLFSSL_SMALL_STACK
-    rsaKey = (RsaKey *)XMALLOC(sizeof(*rsaKey) * BENCH_MAX_PENDING,
-                               HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-    if (rsaKey == NULL) {
+    WC_CALLOC_ARRAY(rsaKey, RsaKey, BENCH_MAX_PENDING,
+                     sizeof(RsaKey), HEAP_HINT);
+#ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
+    if (rsaKey[0] == NULL) {
         printf("bench_rsa malloc failed\n");
         return;
     }
@@ -8646,23 +8742,20 @@ void bench_rsa(int useDeviceID)
     #error "need a cert buffer size"
 #endif /* USE_CERT_BUFFERS */
 
-    /* clear for done cleanup */
-    XMEMSET(rsaKey, 0, sizeof(*rsaKey) * BENCH_MAX_PENDING);
-
     /* init keys */
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
         /* setup an async context for each key */
-        ret = wc_InitRsaKey_ex(&rsaKey[i], HEAP_HINT,
+        ret = wc_InitRsaKey_ex(rsaKey[i], HEAP_HINT,
             useDeviceID ? devId : INVALID_DEVID);
         if (ret < 0) {
-            goto exit_bench_rsa;
+            goto exit;
         }
 
 #if !defined(WOLFSSL_RSA_PUBLIC_ONLY) && !defined(WOLFSSL_RSA_VERIFY_ONLY)
     #ifdef WC_RSA_BLINDING
-        ret = wc_RsaSetRNG(&rsaKey[i], &gRng);
+        ret = wc_RsaSetRNG(rsaKey[i], &gRng);
         if (ret != 0)
-            goto exit_bench_rsa;
+            goto exit;
     #endif
 #endif
 
@@ -8670,9 +8763,9 @@ void bench_rsa(int useDeviceID)
         /* decode the private key */
         idx = 0;
         if ((ret = wc_RsaPrivateKeyDecode(tmp, &idx,
-                                          &rsaKey[i], (word32)bytes)) != 0) {
+                                          rsaKey[i], (word32)bytes)) != 0) {
             printf("wc_RsaPrivateKeyDecode failed! %d\n", ret);
-            goto exit_bench_rsa;
+            goto exit;
         }
 #elif defined(WOLFSSL_PUBLIC_MP)
         /* get offset to public portion of the RSA key */
@@ -8681,15 +8774,15 @@ void bench_rsa(int useDeviceID)
     #elif defined(USE_CERT_BUFFERS_2048) || defined(USE_CERT_BUFFERS_3072)
         bytes = 12;
     #endif
-        ret = mp_read_unsigned_bin(&rsaKey[i].n, &tmp[bytes], rsaKeySz/8);
+        ret = mp_read_unsigned_bin(rsaKey[i].n, &tmp[bytes], rsaKeySz/8);
         if (ret != 0) {
             printf("wc_RsaPrivateKeyDecode failed! %d\n", ret);
-            goto exit_bench_rsa;
+            goto exit;
         }
-        ret = mp_set_int(&rsaKey[i].e, WC_RSA_EXPONENT);
+        ret = mp_set_int(rsaKey[i].e, WC_RSA_EXPONENT);
         if (ret != 0) {
             printf("wc_RsaPrivateKeyDecode failed! %d\n", ret);
-            goto exit_bench_rsa;
+            goto exit;
         }
 #else
         /* Note: To benchmark public only define WOLFSSL_PUBLIC_MP */
@@ -8698,21 +8791,20 @@ void bench_rsa(int useDeviceID)
     }
 
     if (rsaKeySz > 0) {
-        bench_rsa_helper(useDeviceID, rsaKey, rsaKeySz);
+        bench_rsa_helper(useDeviceID, &rsaKey[0], rsaKeySz);
     }
 
     (void)bytes;
     (void)tmp;
 
-exit_bench_rsa:
+exit:
     /* cleanup */
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_FreeRsaKey(&rsaKey[i]);
+    if (WC_ARRAY_OK(rsaKey)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_FreeRsaKey(rsaKey[i]);
+        }
+        WC_FREE_ARRAY(rsaKey, BENCH_MAX_PENDING, HEAP_HINT);
     }
-
-#ifdef WOLFSSL_SMALL_STACK
-    XFREE(rsaKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-#endif
 }
 
 
@@ -8721,26 +8813,22 @@ exit_bench_rsa:
 void bench_rsa_key(int useDeviceID, word32 rsaKeySz)
 {
     int     ret = 0, i, pending = 0;
-#ifdef WOLFSSL_SMALL_STACK
-    RsaKey *rsaKey;
-#else
-    RsaKey  rsaKey[BENCH_MAX_PENDING];
-#endif
-    int     isPending[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(rsaKey, RsaKey, BENCH_MAX_PENDING,
+                     sizeof(RsaKey), HEAP_HINT);
+    int isPending[BENCH_MAX_PENDING];
     long    exp = 65537L;
 
-#ifdef WOLFSSL_SMALL_STACK
-    rsaKey = (RsaKey *)XMALLOC(sizeof(*rsaKey) * BENCH_MAX_PENDING,
-                               HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-    if (rsaKey == NULL) {
+    /* clear for done cleanup */
+    XMEMSET(isPending, 0, sizeof(isPending));
+
+    WC_CALLOC_ARRAY(rsaKey, RsaKey, BENCH_MAX_PENDING,
+                     sizeof(RsaKey), HEAP_HINT);
+#ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
+    if (rsaKey[0] == NULL) {
         printf("bench_rsa_key malloc failed\n");
         return;
     }
 #endif
-
-    /* clear for done cleanup */
-    XMEMSET(rsaKey, 0, sizeof(*rsaKey) * BENCH_MAX_PENDING);
-    XMEMSET(isPending, 0, sizeof(isPending));
 
     /* init keys */
     do {
@@ -8749,42 +8837,41 @@ void bench_rsa_key(int useDeviceID, word32 rsaKeySz)
             if (!isPending[i]) { /* if making the key is pending then just call
                                   * wc_MakeRsaKey again */
                 /* setup an async context for each key */
-                if (wc_InitRsaKey_ex(&rsaKey[i], HEAP_HINT,
+                if (wc_InitRsaKey_ex(rsaKey[i], HEAP_HINT,
                         useDeviceID ? devId : INVALID_DEVID) < 0) {
-                    goto exit_bench_rsa_key;
+                    goto exit;
                 }
 
             #ifdef WC_RSA_BLINDING
-                ret = wc_RsaSetRNG(&rsaKey[i], &gRng);
+                ret = wc_RsaSetRNG(rsaKey[i], &gRng);
                 if (ret != 0)
-                    goto exit_bench_rsa_key;
+                    goto exit;
             #endif
             }
 
             /* create the RSA key */
-            ret = wc_MakeRsaKey(&rsaKey[i], (int)rsaKeySz, exp, &gRng);
+            ret = wc_MakeRsaKey(rsaKey[i], (int)rsaKeySz, exp, &gRng);
             if (ret == WC_PENDING_E) {
                 isPending[i] = 1;
                 pending      = 1;
             }
             else if (ret != 0) {
                 printf("wc_MakeRsaKey failed! %d\n", ret);
-                goto exit_bench_rsa_key;
+                goto exit;
             }
         } /* for i */
     } while (pending > 0);
 
     bench_rsa_helper(useDeviceID, rsaKey, rsaKeySz);
-exit_bench_rsa_key:
+exit:
 
     /* cleanup */
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_FreeRsaKey(&rsaKey[i]);
+    if (WC_ARRAY_OK(rsaKey)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_FreeRsaKey(rsaKey[i]);
+        }
+        WC_FREE_ARRAY(rsaKey, BENCH_MAX_PENDING, HEAP_HINT);
     }
-
-#ifdef WOLFSSL_SMALL_STACK
-    XFREE(rsaKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-#endif
 }
 #endif /* WOLFSSL_KEY_GEN */
 #endif /* !NO_RSA */
@@ -8820,11 +8907,8 @@ void bench_dh(int useDeviceID)
     int    count = 0, times, pending = 0;
     const byte* tmp = NULL;
     double start = 0.0F;
-#ifdef WOLFSSL_SMALL_STACK
-    DhKey *dhKey = NULL;
-#else
-    DhKey  dhKey[BENCH_MAX_PENDING];
-#endif
+    WC_DECLARE_ARRAY(dhKey, DhKey, BENCH_MAX_PENDING,
+                     sizeof(DhKey), HEAP_HINT);
     int    dhKeySz = BENCH_DH_KEY_SIZE * 8; /* used in printf */
     const char**desc = bench_desc_words[lng_index];
 #ifndef NO_ASN
@@ -8856,28 +8940,18 @@ void bench_dh(int useDeviceID)
     WC_DECLARE_VAR(priv2, byte,
                      BENCH_DH_PRIV_SIZE, HEAP_HINT);
 
-    WC_INIT_ARRAY(pub, byte,
+    WC_CALLOC_ARRAY(dhKey, DhKey, BENCH_MAX_PENDING,
+                     sizeof(DhKey), HEAP_HINT);
+    WC_ALLOC_ARRAY(pub, byte,
                   BENCH_MAX_PENDING, BENCH_DH_KEY_SIZE, HEAP_HINT);
-    WC_INIT_ARRAY(agree, byte,
+    WC_ALLOC_ARRAY(agree, byte,
                   BENCH_MAX_PENDING, BENCH_DH_KEY_SIZE, HEAP_HINT);
-    WC_INIT_ARRAY(priv, byte,
+    WC_ALLOC_ARRAY(priv, byte,
                   BENCH_MAX_PENDING, BENCH_DH_PRIV_SIZE, HEAP_HINT);
 
-#ifdef WOLFSSL_SMALL_STACK
-    dhKey = (DhKey *)XMALLOC(sizeof(DhKey) * BENCH_MAX_PENDING, HEAP_HINT,
-                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (! dhKey) {
-        ret = MEMORY_E;
-        goto exit;
-    }
-#endif
+    WC_ALLOC_VAR(pub2, byte, BENCH_DH_KEY_SIZE, HEAP_HINT);
+    WC_ALLOC_VAR(priv2, byte, BENCH_DH_PRIV_SIZE, HEAP_HINT);
 
-#ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
-    if (pub[0] == NULL || pub2 == NULL || agree[0] == NULL || priv[0] == NULL || priv2 == NULL) {
-        ret = MEMORY_E;
-        goto exit;
-    }
-#endif
 
     (void)tmp;
 
@@ -8936,18 +9010,10 @@ void bench_dh(int useDeviceID)
     }
 #endif
 
-    /* clear for done cleanup */
-    XMEMSET(dhKey, 0, sizeof(DhKey) * BENCH_MAX_PENDING);
-#if 0
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        XMEMSET(dhKey[i], 0, sizeof(DhKey));
-    }
-#endif
-
     /* init keys */
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
         /* setup an async context for each key */
-        ret = wc_InitDhKey_ex(&dhKey[i], HEAP_HINT,
+        ret = wc_InitDhKey_ex(dhKey[i], HEAP_HINT,
                         useDeviceID ? devId : INVALID_DEVID);
         if (ret != 0)
             goto exit;
@@ -8955,22 +9021,22 @@ void bench_dh(int useDeviceID)
         /* setup key */
         if (!use_ffdhe) {
     #ifdef NO_ASN
-            ret = wc_DhSetKey(&dhKey[i], dh_p,
+            ret = wc_DhSetKey(dhKey[i], dh_p,
                               sizeof(dh_p), dh_g, sizeof(dh_g));
     #else
             idx = 0;
-            ret = wc_DhKeyDecode(tmp, &idx, &dhKey[i], (word32)bytes);
+            ret = wc_DhKeyDecode(tmp, &idx, dhKey[i], (word32)bytes);
     #endif
         }
     #if defined(HAVE_FFDHE_2048) || defined(HAVE_FFDHE_3072)
     #ifdef HAVE_PUBLIC_FFDHE
         else if (params != NULL) {
-            ret = wc_DhSetKey(&dhKey[i], params->p, params->p_len,
+            ret = wc_DhSetKey(dhKey[i], params->p, params->p_len,
                               params->g, params->g_len);
         }
     #else
         else if (paramName != 0) {
-            ret = wc_DhSetNamedKey(&dhKey[i], paramName);
+            ret = wc_DhSetNamedKey(dhKey[i], paramName);
         }
     #endif
     #endif
@@ -8990,15 +9056,15 @@ void bench_dh(int useDeviceID)
             bench_async_poll(&pending);
 
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&dhKey[i]),
+                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(dhKey[i]),
                                       0, &times, genTimes, &pending)) {
                     privSz[i] = BENCH_DH_PRIV_SIZE;
                     pubSz[i] = BENCH_DH_KEY_SIZE;
-                    ret = wc_DhGenerateKeyPair(&dhKey[i], &gRng,
+                    ret = wc_DhGenerateKeyPair(dhKey[i], &gRng,
                                                priv[i], &privSz[i],
                                                pub[i], &pubSz[i]);
                     if (!bench_async_handle(&ret,
-                                            BENCH_ASYNC_GET_DEV(&dhKey[i]),
+                                            BENCH_ASYNC_GET_DEV(dhKey[i]),
                                             0, &times, &pending)) {
                         goto exit_dh_gen;
                     }
@@ -9029,11 +9095,11 @@ exit_dh_gen:
 
     /* Generate key to use as other public */
     PRIVATE_KEY_UNLOCK();
-    ret = wc_DhGenerateKeyPair(&dhKey[0], &gRng,
+    ret = wc_DhGenerateKeyPair(dhKey[0], &gRng,
                                priv2, &privSz2, pub2, &pubSz2);
     PRIVATE_KEY_LOCK();
 #ifdef WOLFSSL_ASYNC_CRYPT
-    ret = wc_AsyncWait(ret, &dhKey[0].asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &dhKey[0]->asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
 
     /* Key Agree */
@@ -9045,12 +9111,12 @@ exit_dh_gen:
 
             /* while free pending slots in queue, submit ops */
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&dhKey[i]),
+                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(dhKey[i]),
                                       0, &times, agreeTimes, &pending)) {
-                    ret = wc_DhAgree(&dhKey[i], agree[i], &agreeSz[i], priv[i],
+                    ret = wc_DhAgree(dhKey[i], agree[i], &agreeSz[i], priv[i],
                                      privSz[i], pub2, pubSz2);
                     if (!bench_async_handle(&ret,
-                        BENCH_ASYNC_GET_DEV(&dhKey[i]), 0, &times, &pending)) {
+                        BENCH_ASYNC_GET_DEV(dhKey[i]), 0, &times, &pending)) {
                         goto exit;
                     }
                 }
@@ -9074,19 +9140,12 @@ exit:
 #endif
 
     /* cleanup */
-#ifdef WOLFSSL_SMALL_STACK
-    if (dhKey) {
+    if (WC_ARRAY_OK(dhKey)) {
         for (i = 0; i < BENCH_MAX_PENDING; i++) {
-            wc_FreeDhKey(&dhKey[i]);
+            wc_FreeDhKey(dhKey[i]);
         }
-        XFREE(dhKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+        WC_FREE_ARRAY(dhKey, BENCH_MAX_PENDING, HEAP_HINT);
     }
-#else
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_FreeDhKey(&dhKey[i]);
-    }
-#endif
-
     WC_FREE_ARRAY(pub, BENCH_MAX_PENDING, HEAP_HINT);
     WC_FREE_VAR(pub2, HEAP_HINT);
     WC_FREE_ARRAY(priv, BENCH_MAX_PENDING, HEAP_HINT);
@@ -10174,33 +10233,29 @@ void bench_ecc_curve(int curveId)
 
 void bench_eccMakeKey(int useDeviceID, int curveId)
 {
-    int ret = 0, i, times, count, pending = 0;
+    int ret = 0, i, times, count = 0, pending = 0;
     int deviceID;
-    int keySize;
-#ifdef WOLFSSL_SMALL_STACK
-    ecc_key *genKey;
-#else
-    ecc_key genKey[BENCH_MAX_PENDING];
-#endif
+    int keySize = 0;
+    WC_DECLARE_ARRAY(genKey, ecc_key, BENCH_MAX_PENDING,
+                     sizeof(ecc_key), HEAP_HINT);
     char name[BENCH_ECC_NAME_SZ];
-    double start;
+    double start = 0;
     const char**desc = bench_desc_words[lng_index];
     DECLARE_MULTI_VALUE_STATS_VARS()
 
-#ifdef WOLFSSL_SMALL_STACK
-    genKey = (ecc_key *)XMALLOC(sizeof(*genKey) * BENCH_MAX_PENDING,
-                                HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-    if (genKey == NULL) {
+    WC_CALLOC_ARRAY(genKey, ecc_key, BENCH_MAX_PENDING,
+                     sizeof(ecc_key), HEAP_HINT);
+#ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
+    if (genKey[0] == NULL) {
         printf("bench_eccMakeKey malloc failed\n");
         return;
     }
+    for (i = 0; i < BENCH_MAX_PENDING; ++i)
+        XMEMSET(genKey[i], 0, sizeof(ecc_key));
 #endif
 
     deviceID = useDeviceID ? devId : INVALID_DEVID;
     keySize = wc_ecc_get_curve_size_from_id(curveId);
-
-    /* clear for done cleanup */
-    XMEMSET(genKey, 0, sizeof(*genKey) * BENCH_MAX_PENDING);
 
     /* ECC Make Key */
     bench_stats_start(&count, &start);
@@ -10211,19 +10266,19 @@ void bench_eccMakeKey(int useDeviceID, int curveId)
 
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
                 if (bench_async_check(&ret,
-                                      BENCH_ASYNC_GET_DEV(&genKey[i]), 0,
+                                      BENCH_ASYNC_GET_DEV(genKey[i]), 0,
                                       &times, agreeTimes, &pending)) {
 
-                    wc_ecc_free(&genKey[i]);
-                    ret = wc_ecc_init_ex(&genKey[i], HEAP_HINT, deviceID);
+                    wc_ecc_free(genKey[i]);
+                    ret = wc_ecc_init_ex(genKey[i], HEAP_HINT, deviceID);
                     if (ret < 0) {
                         goto exit;
                     }
 
-                    ret = wc_ecc_make_key_ex(&gRng, keySize, &genKey[i],
+                    ret = wc_ecc_make_key_ex(&gRng, keySize, genKey[i],
                             curveId);
                     if (!bench_async_handle(&ret,
-                                BENCH_ASYNC_GET_DEV(&genKey[i]), 0, &times,
+                                BENCH_ASYNC_GET_DEV(genKey[i]), 0, &times,
                                 &pending)) {
                         goto exit;
                     }
@@ -10248,13 +10303,12 @@ exit:
 #endif
 
     /* cleanup */
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_ecc_free(&genKey[i]);
+    if (WC_ARRAY_OK(genKey)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_ecc_free(genKey[i]);
+        }
+        WC_FREE_ARRAY(genKey, BENCH_MAX_PENDING, HEAP_HINT);
     }
-
-#ifdef WOLFSSL_SMALL_STACK
-    XFREE(genKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-#endif
 }
 
 
@@ -10264,22 +10318,16 @@ void bench_ecc(int useDeviceID, int curveId)
     int deviceID;
     int  keySize;
     char name[BENCH_ECC_NAME_SZ];
-#ifdef WOLFSSL_SMALL_STACK
-    ecc_key *genKey;
-#else
-    ecc_key genKey[BENCH_MAX_PENDING];
-#endif
+    WC_DECLARE_ARRAY(genKey, ecc_key, BENCH_MAX_PENDING,
+                     sizeof(ecc_key), HEAP_HINT);
 #ifdef HAVE_ECC_DHE
-#ifdef WOLFSSL_SMALL_STACK
-    ecc_key *genKey2;
-#else
-    ecc_key genKey2[BENCH_MAX_PENDING];
-#endif
+    WC_DECLARE_ARRAY(genKey2, ecc_key, BENCH_MAX_PENDING,
+                     sizeof(ecc_key), HEAP_HINT);
 #endif
 
 #if !defined(NO_ASN) && defined(HAVE_ECC_SIGN)
     #ifdef HAVE_ECC_VERIFY
-        int    verify[BENCH_MAX_PENDING];
+        int verify[BENCH_MAX_PENDING];
     #endif
 #endif
 
@@ -10300,61 +10348,56 @@ void bench_ecc(int useDeviceID, int curveId)
                      BENCH_MAX_PENDING, MAX_ECC_BYTES, HEAP_HINT);
 #endif
 
-#ifdef WOLFSSL_SMALL_STACK
-    genKey = (ecc_key *)XMALLOC(sizeof(*genKey) * BENCH_MAX_PENDING,
-                                HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-    if (genKey == NULL) {
+    WC_CALLOC_ARRAY(genKey, ecc_key, BENCH_MAX_PENDING,
+                     sizeof(ecc_key), HEAP_HINT);
+#ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
+    if (genKey[0] == NULL) {
         printf("bench_eccMakeKey malloc failed\n");
         return;
     }
+#endif
+
 #ifdef HAVE_ECC_DHE
-    genKey2 = (ecc_key *)XMALLOC(sizeof(*genKey2) * BENCH_MAX_PENDING,
-                                 HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-    if (genKey2 == NULL) {
+    WC_CALLOC_ARRAY(genKey2, ecc_key, BENCH_MAX_PENDING,
+                     sizeof(ecc_key), HEAP_HINT);
+#ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
+    if (genKey2[0] == NULL) {
         XFREE(genKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         printf("bench_eccMakeKey malloc failed\n");
         return;
     }
 #endif
-#endif
-
-#ifdef HAVE_ECC_DHE
-    WC_INIT_ARRAY(shared, byte,
+    WC_ALLOC_ARRAY(shared, byte,
                   BENCH_MAX_PENDING, MAX_ECC_BYTES, HEAP_HINT);
 #endif
 
 #if !defined(NO_ASN) && defined(HAVE_ECC_SIGN)
-    WC_INIT_ARRAY(sig, byte, BENCH_MAX_PENDING, ECC_MAX_SIG_SIZE, HEAP_HINT);
-    WC_INIT_ARRAY(digest, byte, BENCH_MAX_PENDING, MAX_ECC_BYTES, HEAP_HINT);
+    WC_ALLOC_ARRAY(sig, byte, BENCH_MAX_PENDING, ECC_MAX_SIG_SIZE, HEAP_HINT);
+    WC_ALLOC_ARRAY(digest, byte, BENCH_MAX_PENDING, MAX_ECC_BYTES, HEAP_HINT);
 #endif
     deviceID = useDeviceID ? devId : INVALID_DEVID;
 
-    /* clear for done cleanup */
-    XMEMSET(genKey, 0, sizeof(*genKey) * BENCH_MAX_PENDING);
-#ifdef HAVE_ECC_DHE
-    XMEMSET(genKey2, 0, sizeof(*genKey2) * BENCH_MAX_PENDING);
-#endif
     keySize = wc_ecc_get_curve_size_from_id(curveId);
 
     /* init keys */
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
         /* setup an context for each key */
-        if ((ret = wc_ecc_init_ex(&genKey[i], HEAP_HINT, deviceID)) < 0) {
+        if ((ret = wc_ecc_init_ex(genKey[i], HEAP_HINT, deviceID)) < 0) {
             goto exit;
         }
-        ret = wc_ecc_make_key_ex(&gRng, keySize, &genKey[i], curveId);
+        ret = wc_ecc_make_key_ex(&gRng, keySize, genKey[i], curveId);
     #ifdef WOLFSSL_ASYNC_CRYPT
-        ret = wc_AsyncWait(ret, &genKey[i].asyncDev, WC_ASYNC_FLAG_NONE);
+        ret = wc_AsyncWait(ret, &genKey[i]->asyncDev, WC_ASYNC_FLAG_NONE);
     #endif
         if (ret < 0) {
             goto exit;
         }
 
     #ifdef HAVE_ECC_DHE
-        if ((ret = wc_ecc_init_ex(&genKey2[i], HEAP_HINT, deviceID)) < 0) {
+        if ((ret = wc_ecc_init_ex(genKey2[i], HEAP_HINT, deviceID)) < 0) {
             goto exit;
         }
-        if ((ret = wc_ecc_make_key_ex(&gRng, keySize, &genKey2[i],
+        if ((ret = wc_ecc_make_key_ex(&gRng, keySize, genKey2[i],
                     curveId)) > 0) {
             goto exit;
         }
@@ -10366,7 +10409,7 @@ void bench_ecc(int useDeviceID, int curveId)
     (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION != 2))) && \
     !defined(HAVE_SELFTEST)
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        (void)wc_ecc_set_rng(&genKey[i], &gRng);
+        (void)wc_ecc_set_rng(genKey[i], &gRng);
     }
 #endif
 
@@ -10379,13 +10422,13 @@ void bench_ecc(int useDeviceID, int curveId)
 
             /* while free pending slots in queue, submit ops */
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&genKey[i]), 1,
+                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(genKey[i]), 1,
                                       &times, agreeTimes, &pending)) {
                     x[i] = (word32)keySize;
-                    ret = wc_ecc_shared_secret(&genKey[i], &genKey2[i],
+                    ret = wc_ecc_shared_secret(genKey[i], genKey2[i],
                             shared[i], &x[i]);
                     if (!bench_async_handle(&ret,
-                                BENCH_ASYNC_GET_DEV(&genKey[i]), 1, &times,
+                                BENCH_ASYNC_GET_DEV(genKey[i]), 1, &times,
                                 &pending)) {
                         goto exit_ecdhe;
                     }
@@ -10436,18 +10479,18 @@ exit_ecdhe:
 
             /* while free pending slots in queue, submit ops */
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&genKey[i]), 1,
+                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(genKey[i]), 1,
                                       &times, agreeTimes, &pending)) {
 
-                    if (genKey[i].state == 0) {
+                    if (genKey[i]->state == 0) {
                         x[i] = ECC_MAX_SIG_SIZE;
                     }
 
                     ret = wc_ecc_sign_hash(digest[i], (word32)keySize, sig[i],
-                                           &x[i], GLOBAL_RNG, &genKey[i]);
+                                           &x[i], GLOBAL_RNG, genKey[i]);
 
                     if (!bench_async_handle(&ret,
-                                BENCH_ASYNC_GET_DEV(&genKey[i]), 1, &times,
+                                BENCH_ASYNC_GET_DEV(genKey[i]), 1, &times,
                                 &pending)) {
                         goto exit_ecdsa_sign;
                     }
@@ -10488,18 +10531,18 @@ exit_ecdsa_sign:
 
             /* while free pending slots in queue, submit ops */
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&genKey[i]), 1,
+                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(genKey[i]), 1,
                                       &times, agreeTimes, &pending)) {
-                    if (genKey[i].state == 0) {
+                    if (genKey[i]->state == 0) {
                         verify[i] = 0;
                     }
 
                     ret = wc_ecc_verify_hash(sig[i], x[i], digest[i],
                                              (word32)keySize, &verify[i],
-                                             &genKey[i]);
+                                             genKey[i]);
 
                     if (!bench_async_handle(&ret,
-                                            BENCH_ASYNC_GET_DEV(&genKey[i]),
+                                            BENCH_ASYNC_GET_DEV(genKey[i]),
                                                                 1, &times,
                                                                 &pending)) {
                         goto exit_ecdsa_verify;
@@ -10530,19 +10573,18 @@ exit_ecdsa_verify:
 exit:
 
     /* cleanup */
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_ecc_free(&genKey[i]);
-    #ifdef HAVE_ECC_DHE
-        wc_ecc_free(&genKey2[i]);
-    #endif
+    if (WC_ARRAY_OK(genKey)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++)
+            wc_ecc_free(genKey[i]);
+        WC_FREE_ARRAY(genKey, BENCH_MAX_PENDING, HEAP_HINT);
     }
-
-#ifdef WOLFSSL_SMALL_STACK
-    XFREE(genKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     #ifdef HAVE_ECC_DHE
-    XFREE(genKey2, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    if (WC_ARRAY_OK(genKey2)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++)
+            wc_ecc_free(genKey2[i]);
+        WC_FREE_ARRAY(genKey2, BENCH_MAX_PENDING, HEAP_HINT);
+    }
     #endif
-#endif
 
 #ifdef HAVE_ECC_DHE
     WC_FREE_ARRAY(shared, BENCH_MAX_PENDING, HEAP_HINT);
@@ -10732,7 +10774,8 @@ static void bench_sm2_MakeKey(int useDeviceID)
     int ret = 0, i, times, count, pending = 0;
     int deviceID;
     int keySize;
-    ecc_key genKey[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(genKey, ecc_key, BENCH_MAX_PENDING,
+                     sizeof(ecc_key), HEAP_HINT);
     char name[BENCH_ECC_NAME_SZ];
     double start;
     const char**desc = bench_desc_words[lng_index];
@@ -10741,8 +10784,17 @@ static void bench_sm2_MakeKey(int useDeviceID)
     deviceID = useDeviceID ? devId : INVALID_DEVID;
     keySize = wc_ecc_get_curve_size_from_id(ECC_SM2P256V1);
 
-    /* clear for done cleanup */
-    XMEMSET(&genKey, 0, sizeof(genKey));
+    WC_CALLOC_ARRAY(genKey, ecc_key, BENCH_MAX_PENDING,
+                     sizeof(ecc_key), HEAP_HINT);
+
+#ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
+    if (genKey[0] == NULL) {
+        printf("bench_sm2_MakeKey malloc failed\n");
+        return;
+    }
+    for (i = 0; i < BENCH_MAX_PENDING; ++i)
+        XMEMSET(genKey[i], 0, sizeof(ecc_key));
+#endif
 
     /* ECC Make Key */
     bench_stats_start(&count, &start);
@@ -10752,19 +10804,19 @@ static void bench_sm2_MakeKey(int useDeviceID)
             bench_async_poll(&pending);
 
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&genKey[i]), 0,
+                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(genKey[i]), 0,
                             &times, agreeTimes, &pending)) {
 
-                    wc_ecc_free(&genKey[i]);
-                    ret = wc_ecc_init_ex(&genKey[i], HEAP_HINT, deviceID);
+                    wc_ecc_free(genKey[i]);
+                    ret = wc_ecc_init_ex(genKey[i], HEAP_HINT, deviceID);
                     if (ret < 0) {
                         goto exit;
                     }
 
-                    ret = wc_ecc_sm2_make_key(&gRng, &genKey[i],
+                    ret = wc_ecc_sm2_make_key(&gRng, genKey[i],
                         WC_ECC_FLAG_NONE);
                     if (!bench_async_handle(&ret,
-                                BENCH_ASYNC_GET_DEV(&genKey[i]), 0, &times,
+                                BENCH_ASYNC_GET_DEV(genKey[i]), 0, &times,
                                 &pending)) {
                         goto exit;
                     }
@@ -10789,8 +10841,11 @@ exit:
 #endif
 
     /* cleanup */
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_ecc_free(&genKey[i]);
+    if (WC_ARRAY_OK(genKey)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++) {
+            wc_ecc_free(genKey[i]);
+        }
+        WC_FREE_ARRAY(genKey, BENCH_MAX_PENDING, HEAP_HINT);
     }
 }
 
@@ -10801,13 +10856,16 @@ void bench_sm2(int useDeviceID)
     int deviceID;
     int  keySize;
     char name[BENCH_ECC_NAME_SZ];
-    ecc_key genKey[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(genKey, ecc_key, BENCH_MAX_PENDING,
+                     sizeof(ecc_key), HEAP_HINT);
 #ifdef HAVE_ECC_DHE
-    ecc_key genKey2[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(genKey2, ecc_key, BENCH_MAX_PENDING,
+                     sizeof(ecc_key), HEAP_HINT);
 #endif
 #if !defined(NO_ASN) && defined(HAVE_ECC_SIGN)
 #ifdef HAVE_ECC_VERIFY
-    int    verify[BENCH_MAX_PENDING];
+    WC_DECLARE_ARRAY(verify, int, BENCH_MAX_PENDING,
+                     sizeof(int), HEAP_HINT);
 #endif
 #endif
     word32 x[BENCH_MAX_PENDING];
@@ -10824,20 +10882,21 @@ void bench_sm2(int useDeviceID)
 #endif
 
 #ifdef HAVE_ECC_DHE
-    WC_INIT_ARRAY(shared, byte, BENCH_MAX_PENDING, MAX_ECC_BYTES, HEAP_HINT);
+    WC_ALLOC_ARRAY(shared, byte, BENCH_MAX_PENDING, MAX_ECC_BYTES, HEAP_HINT);
 #endif
 #if !defined(NO_ASN) && defined(HAVE_ECC_SIGN)
-    WC_INIT_ARRAY(sig, byte, BENCH_MAX_PENDING, ECC_MAX_SIG_SIZE, HEAP_HINT);
-    WC_INIT_ARRAY(digest, byte, BENCH_MAX_PENDING, MAX_ECC_BYTES, HEAP_HINT);
+    WC_ALLOC_ARRAY(sig, byte, BENCH_MAX_PENDING, ECC_MAX_SIG_SIZE, HEAP_HINT);
+    WC_ALLOC_ARRAY(digest, byte, BENCH_MAX_PENDING, MAX_ECC_BYTES, HEAP_HINT);
 #endif
     deviceID = useDeviceID ? devId : INVALID_DEVID;
 
     bench_sm2_MakeKey(useDeviceID);
 
-    /* clear for done cleanup */
-    XMEMSET(&genKey, 0, sizeof(genKey));
+    WC_CALLOC_ARRAY(genKey, ecc_key, BENCH_MAX_PENDING,
+                     sizeof(ecc_key), HEAP_HINT);
 #ifdef HAVE_ECC_DHE
-    XMEMSET(&genKey2, 0, sizeof(genKey2));
+    WC_CALLOC_ARRAY(genKey2, ecc_key, BENCH_MAX_PENDING,
+                     sizeof(ecc_key), HEAP_HINT);
 #endif
 
     keySize = wc_ecc_get_curve_size_from_id(ECC_SM2P256V1);
@@ -10845,22 +10904,22 @@ void bench_sm2(int useDeviceID)
     /* init keys */
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
         /* setup an context for each key */
-        if ((ret = wc_ecc_init_ex(&genKey[i], HEAP_HINT, deviceID)) < 0) {
+        if ((ret = wc_ecc_init_ex(genKey[i], HEAP_HINT, deviceID)) < 0) {
             goto exit;
         }
-        ret = wc_ecc_sm2_make_key(&gRng, &genKey[i], WC_ECC_FLAG_NONE);
+        ret = wc_ecc_sm2_make_key(&gRng, genKey[i], WC_ECC_FLAG_NONE);
     #ifdef WOLFSSL_ASYNC_CRYPT
-        ret = wc_AsyncWait(ret, &genKey[i].asyncDev, WC_ASYNC_FLAG_NONE);
+        ret = wc_AsyncWait(ret, genKey[i].asyncDev, WC_ASYNC_FLAG_NONE);
     #endif
         if (ret < 0) {
             goto exit;
         }
 
     #ifdef HAVE_ECC_DHE
-        if ((ret = wc_ecc_init_ex(&genKey2[i], HEAP_HINT, deviceID)) < 0) {
+        if ((ret = wc_ecc_init_ex(genKey2[i], HEAP_HINT, deviceID)) < 0) {
             goto exit;
         }
-        if ((ret = wc_ecc_sm2_make_key(&gRng, &genKey2[i],
+        if ((ret = wc_ecc_sm2_make_key(&gRng, genKey2[i],
                 WC_ECC_FLAG_NONE)) > 0) {
             goto exit;
         }
@@ -10872,7 +10931,7 @@ void bench_sm2(int useDeviceID)
     (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION != 2))) && \
     !defined(HAVE_SELFTEST)
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        (void)wc_ecc_set_rng(&genKey[i], &gRng);
+        (void)wc_ecc_set_rng(genKey[i], &gRng);
     }
 #endif
 
@@ -10885,13 +10944,13 @@ void bench_sm2(int useDeviceID)
 
             /* while free pending slots in queue, submit ops */
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&genKey[i]), 1,
+                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(genKey[i]), 1,
                             &times, agreeTimes, &pending)) {
                     x[i] = (word32)keySize;
-                    ret = wc_ecc_sm2_shared_secret(&genKey[i], &genKey2[i],
+                    ret = wc_ecc_sm2_shared_secret(genKey[i], genKey2[i],
                             shared[i], &x[i]);
                     if (!bench_async_handle(&ret,
-                                BENCH_ASYNC_GET_DEV(&genKey[i]), 1, &times,
+                                BENCH_ASYNC_GET_DEV(genKey[i]), 1, &times,
                                 &pending)) {
                         goto exit_ecdhe;
                     }
@@ -10941,14 +11000,14 @@ exit_ecdhe:
 
             /* while free pending slots in queue, submit ops */
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&genKey[i]), 1,
+                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(genKey[i]), 1,
                             &times, agreeTimes, &pending)) {
                     if (genKey[i].state == 0)
                         x[i] = ECC_MAX_SIG_SIZE;
                     ret = wc_ecc_sm2_sign_hash(digest[i], (word32)keySize,
-                            sig[i], &x[i], &gRng, &genKey[i]);
+                            sig[i], x[i], &gRng, genKey[i]);
                     if (!bench_async_handle(&ret,
-                                BENCH_ASYNC_GET_DEV(&genKey[i]), 1, &times,
+                                BENCH_ASYNC_GET_DEV(genKey[i]), 1, &times,
                                 &pending)) {
                         goto exit_ecdsa_sign;
                     }
@@ -10987,14 +11046,14 @@ exit_ecdsa_sign:
 
             /* while free pending slots in queue, submit ops */
             for (i = 0; i < BENCH_MAX_PENDING; i++) {
-                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&genKey[i]), 1,
+                if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(genKey[i]), 1,
                             &times, agreeTimes, &pending)) {
                     if (genKey[i].state == 0)
                         verify[i] = 0;
                     ret = wc_ecc_sm2_verify_hash(sig[i], x[i], digest[i],
-                                       (word32)keySize, &verify[i], &genKey[i]);
+                                       (word32)keySize, verify[i], genKey[i]);
                     if (!bench_async_handle(&ret,
-                                BENCH_ASYNC_GET_DEV(&genKey[i]), 1, &times,
+                                BENCH_ASYNC_GET_DEV(genKey[i]), 1, &times,
                                 &pending)) {
                         goto exit_ecdsa_verify;
                     }
@@ -11025,12 +11084,18 @@ exit_ecdsa_verify:
 exit:
 
     /* cleanup */
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_ecc_free(&genKey[i]);
-    #ifdef HAVE_ECC_DHE
-        wc_ecc_free(&genKey2[i]);
-    #endif
+    if (WC_ARRAY_OK(genKey)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++)
+            wc_ecc_free(genKey[i]);
+        WC_FREE_ARRAY(genKey, BENCH_MAX_PENDING, HEAP_HINT);
     }
+    #ifdef HAVE_ECC_DHE
+    if (WC_ARRAY_OK(genKey2)) {
+        for (i = 0; i < BENCH_MAX_PENDING; i++)
+            wc_ecc_free(genKey2[i]);
+        WC_FREE_ARRAY(genKey2, BENCH_MAX_PENDING, HEAP_HINT);
+    }
+    #endif
 
 #ifdef HAVE_ECC_DHE
     WC_FREE_ARRAY(shared, BENCH_MAX_PENDING, HEAP_HINT);
@@ -11039,6 +11104,7 @@ exit:
     WC_FREE_ARRAY(sig, BENCH_MAX_PENDING, HEAP_HINT);
     WC_FREE_ARRAY(digest, BENCH_MAX_PENDING, HEAP_HINT);
 #endif
+
 
     (void)useDeviceID;
     (void)pending;
@@ -11403,7 +11469,7 @@ void bench_ed448KeyGen(void)
 void bench_ed448KeySign(void)
 {
     int    ret;
-    ed448_key genKey;
+    WC_DECLARE_VAR(genKey, ed448_key, 1, HEAP_HINT);
 #ifdef HAVE_ED448_SIGN
     double start;
     int    i, count;
@@ -11414,9 +11480,11 @@ void bench_ed448KeySign(void)
     DECLARE_MULTI_VALUE_STATS_VARS()
 #endif
 
-    wc_ed448_init(&genKey);
+    WC_ALLOC_VAR(genKey, ed448_key, 1, HEAP_HINT);
 
-    ret = wc_ed448_make_key(&gRng, ED448_KEY_SIZE, &genKey);
+    wc_ed448_init(genKey);
+
+    ret = wc_ed448_make_key(&gRng, ED448_KEY_SIZE, genKey);
     if (ret != 0) {
         printf("ed448_make_key failed\n");
         return;
@@ -11431,11 +11499,11 @@ void bench_ed448KeySign(void)
     do {
         for (i = 0; i < agreeTimes; i++) {
             x = sizeof(sig);
-            ret = wc_ed448_sign_msg(msg, sizeof(msg), sig, &x, &genKey,
+            ret = wc_ed448_sign_msg(msg, sizeof(msg), sig, &x, genKey,
                                     NULL, 0);
             if (ret != 0) {
                 printf("ed448_sign_msg failed\n");
-                goto exit_ed_sign;
+                goto exit;
             }
             RECORD_MULTI_VALUE_STATS();
         }
@@ -11446,7 +11514,6 @@ void bench_ed448KeySign(void)
 #endif
        );
 
-exit_ed_sign:
     bench_stats_asym_finish("ED", 448, desc[4], 0, count, start, ret);
 #ifdef MULTI_VALUE_STATISTICS
     bench_multi_value_stats(max, min, sum, squareSum, runs);
@@ -11460,10 +11527,10 @@ exit_ed_sign:
         for (i = 0; i < agreeTimes; i++) {
             int verify = 0;
             ret = wc_ed448_verify_msg(sig, x, msg, sizeof(msg), &verify,
-                                      &genKey, NULL, 0);
+                                      genKey, NULL, 0);
             if (ret != 0 || verify != 1) {
                 printf("ed448_verify_msg failed\n");
-                goto exit_ed_verify;
+                goto exit;
             }
             RECORD_MULTI_VALUE_STATS();
         }
@@ -11474,7 +11541,6 @@ exit_ed_sign:
 #endif
        );
 
-exit_ed_verify:
     bench_stats_asym_finish("ED", 448, desc[5], 0, count, start, ret);
 #ifdef MULTI_VALUE_STATISTICS
     bench_multi_value_stats(max, min, sum, squareSum, runs);
@@ -11482,7 +11548,10 @@ exit_ed_verify:
 #endif /* HAVE_ED448_VERIFY */
 #endif /* HAVE_ED448_SIGN */
 
-    wc_ed448_free(&genKey);
+exit:
+
+    wc_ed448_free(genKey);
+    WC_FREE_VAR(genKey, HEAP_HINT);
 }
 #endif /* HAVE_ED448 */
 
@@ -11490,24 +11559,26 @@ exit_ed_verify:
 #ifdef WOLFCRYPT_ECCSI_KMS
 void bench_eccsiKeyGen(void)
 {
-    EccsiKey genKey;
+    WC_DECLARE_VAR(genKey, EccsiKey, 1, HEAP_HINT);
     double start;
     int    i, count;
     const char**desc = bench_desc_words[lng_index];
     int    ret;
     DECLARE_MULTI_VALUE_STATS_VARS()
 
+    WC_ALLOC_VAR(genKey, EccsiKey, 1, HEAP_HINT);
+
     /* Key Gen */
     bench_stats_start(&count, &start);
     do {
         for (i = 0; i < genTimes; i++) {
-            wc_InitEccsiKey(&genKey, NULL, INVALID_DEVID);
-            ret = wc_MakeEccsiKey(&genKey, &gRng);
+            wc_InitEccsiKey(genKey, NULL, INVALID_DEVID);
+            ret = wc_MakeEccsiKey(genKey, &gRng);
+            wc_FreeEccsiKey(genKey);
             if (ret != 0) {
                 printf("wc_MakeEccsiKey failed: %d\n", ret);
-                break;
+                goto exit;
             }
-            wc_FreeEccsiKey(&genKey);
             RECORD_MULTI_VALUE_STATS();
         }
         count += i;
@@ -11521,34 +11592,41 @@ void bench_eccsiKeyGen(void)
 #ifdef MULTI_VALUE_STATISTICS
     bench_multi_value_stats(max, min, sum, squareSum, runs);
 #endif
+
+exit:
+
+    WC_FREE_VAR(genKey, HEAP_HINT);
 }
 
 void bench_eccsiPairGen(void)
 {
-    EccsiKey genKey;
+    WC_DECLARE_VAR(genKey, EccsiKey, 1, HEAP_HINT);
     double start;
     int    i, count;
     const char**desc = bench_desc_words[lng_index];
-    mp_int ssk;
+    WC_DECLARE_VAR(ssk, mp_int, 1, HEAP_HINT);
     ecc_point* pvt;
     static const byte id[] = { 0x01, 0x23, 0x34, 0x45 };
     int ret;
     DECLARE_MULTI_VALUE_STATS_VARS()
 
-    (void)mp_init(&ssk);
+    WC_ALLOC_VAR(genKey, EccsiKey, 1, HEAP_HINT);
+    WC_ALLOC_VAR(ssk, mp_int, 1, HEAP_HINT);
+
+    (void)mp_init(ssk);
     pvt = wc_ecc_new_point();
-    wc_InitEccsiKey(&genKey, NULL, INVALID_DEVID);
-    (void)wc_MakeEccsiKey(&genKey, &gRng);
+    wc_InitEccsiKey(genKey, NULL, INVALID_DEVID);
+    (void)wc_MakeEccsiKey(genKey, &gRng);
 
     /* RSK Gen */
     bench_stats_start(&count, &start);
     do {
         for (i = 0; i < genTimes; i++) {
-            ret = wc_MakeEccsiPair(&genKey, &gRng, WC_HASH_TYPE_SHA256, id,
-                                   sizeof(id), &ssk, pvt);
+            ret = wc_MakeEccsiPair(genKey, &gRng, WC_HASH_TYPE_SHA256, id,
+                                   sizeof(id), ssk, pvt);
             if (ret != 0) {
                 printf("wc_MakeEccsiPair failed: %d\n", ret);
-                break;
+                goto exit;
             }
             RECORD_MULTI_VALUE_STATS();
         }
@@ -11564,43 +11642,51 @@ void bench_eccsiPairGen(void)
     bench_multi_value_stats(max, min, sum, squareSum, runs);
 #endif
 
-    wc_FreeEccsiKey(&genKey);
+    wc_FreeEccsiKey(genKey);
     wc_ecc_del_point(pvt);
-    mp_free(&ssk);
+    mp_free(ssk);
+
+exit:
+
+    WC_FREE_VAR(genKey, HEAP_HINT);
+    WC_FREE_VAR(ssk, HEAP_HINT);
 }
 #endif
 
 #ifdef WOLFCRYPT_ECCSI_CLIENT
 void bench_eccsiValidate(void)
 {
-    EccsiKey genKey;
+    WC_DECLARE_VAR(genKey, EccsiKey, 1, HEAP_HINT);
     double start;
     int    i, count;
     const char**desc = bench_desc_words[lng_index];
-    mp_int ssk;
+    WC_DECLARE_VAR(ssk, mp_int, 1, HEAP_HINT);
     ecc_point* pvt;
     static const byte id[] = { 0x01, 0x23, 0x34, 0x45 };
     int valid;
     int ret;
     DECLARE_MULTI_VALUE_STATS_VARS()
 
-    (void)mp_init(&ssk);
+    WC_ALLOC_VAR(genKey, EccsiKey, 1, HEAP_HINT);
+    WC_ALLOC_VAR(ssk, mp_int, 1, HEAP_HINT);
+
+    (void)mp_init(ssk);
     pvt = wc_ecc_new_point();
-    wc_InitEccsiKey(&genKey, NULL, INVALID_DEVID);
-    (void)wc_MakeEccsiKey(&genKey, &gRng);
-    (void)wc_MakeEccsiPair(&genKey, &gRng, WC_HASH_TYPE_SHA256, id, sizeof(id),
-                           &ssk, pvt);
+    wc_InitEccsiKey(genKey, NULL, INVALID_DEVID);
+    (void)wc_MakeEccsiKey(genKey, &gRng);
+    (void)wc_MakeEccsiPair(genKey, &gRng, WC_HASH_TYPE_SHA256, id, sizeof(id),
+                           ssk, pvt);
 
     /* Validation of RSK */
     bench_stats_start(&count, &start);
     do {
         for (i = 0; i < genTimes; i++) {
-            ret = wc_ValidateEccsiPair(&genKey, WC_HASH_TYPE_SHA256, id,
-                                       sizeof(id), &ssk, pvt, &valid);
+            ret = wc_ValidateEccsiPair(genKey, WC_HASH_TYPE_SHA256, id,
+                                       sizeof(id), ssk, pvt, &valid);
             if (ret != 0 || !valid) {
                 printf("wc_ValidateEccsiPair failed: %d (valid=%d))\n", ret,
                        valid);
-                break;
+                goto exit;
             }
             RECORD_MULTI_VALUE_STATS();
         }
@@ -11616,18 +11702,23 @@ void bench_eccsiValidate(void)
     bench_multi_value_stats(max, min, sum, squareSum, runs);
 #endif
 
-    wc_FreeEccsiKey(&genKey);
+    wc_FreeEccsiKey(genKey);
     wc_ecc_del_point(pvt);
-    mp_free(&ssk);
+    mp_free(ssk);
+
+exit:
+
+    WC_FREE_VAR(genKey, HEAP_HINT);
+    WC_FREE_VAR(ssk, HEAP_HINT);
 }
 
 void bench_eccsi(void)
 {
-    EccsiKey genKey;
+    WC_DECLARE_VAR(genKey, EccsiKey, 1, HEAP_HINT);
     double start;
     int    i, count;
     const char**desc = bench_desc_words[lng_index];
-    mp_int ssk;
+    WC_DECLARE_VAR(ssk, mp_int, 1, HEAP_HINT);
     ecc_point* pvt;
     static const byte id[] = { 0x01, 0x23, 0x34, 0x45 };
     static const byte msg[] = { 0x01, 0x23, 0x34, 0x45 };
@@ -11639,22 +11730,25 @@ void bench_eccsi(void)
     int verified;
     DECLARE_MULTI_VALUE_STATS_VARS()
 
-    (void)mp_init(&ssk);
+    WC_ALLOC_VAR(genKey, EccsiKey, 1, HEAP_HINT);
+    WC_ALLOC_VAR(ssk, mp_int, 1, HEAP_HINT);
+
+    (void)mp_init(ssk);
     pvt = wc_ecc_new_point();
-    (void)wc_InitEccsiKey(&genKey, NULL, INVALID_DEVID);
-    (void)wc_MakeEccsiKey(&genKey, &gRng);
-    (void)wc_MakeEccsiPair(&genKey, &gRng, WC_HASH_TYPE_SHA256, id, sizeof(id),
-                           &ssk, pvt);
-    (void)wc_HashEccsiId(&genKey, WC_HASH_TYPE_SHA256, id, sizeof(id), pvt,
+    (void)wc_InitEccsiKey(genKey, NULL, INVALID_DEVID);
+    (void)wc_MakeEccsiKey(genKey, &gRng);
+    (void)wc_MakeEccsiPair(genKey, &gRng, WC_HASH_TYPE_SHA256, id, sizeof(id),
+                           ssk, pvt);
+    (void)wc_HashEccsiId(genKey, WC_HASH_TYPE_SHA256, id, sizeof(id), pvt,
                          hash, &hashSz);
-    (void)wc_SetEccsiHash(&genKey, hash, hashSz);
-    (void)wc_SetEccsiPair(&genKey, &ssk, pvt);
+    (void)wc_SetEccsiHash(genKey, hash, hashSz);
+    (void)wc_SetEccsiPair(genKey, ssk, pvt);
 
     /* Encapsulate */
     bench_stats_start(&count, &start);
     do {
         for (i = 0; i < genTimes; i++) {
-            ret = wc_SignEccsiHash(&genKey, &gRng, WC_HASH_TYPE_SHA256, msg,
+            ret = wc_SignEccsiHash(genKey, &gRng, WC_HASH_TYPE_SHA256, msg,
                                    sizeof(msg), sig, &sigSz);
             if (ret != 0) {
                 printf("wc_SignEccsiHash failed: %d\n", ret);
@@ -11680,13 +11774,13 @@ void bench_eccsi(void)
     bench_stats_start(&count, &start);
     do {
         for (i = 0; i < genTimes; i++) {
-            ret = wc_VerifyEccsiHash(&genKey, WC_HASH_TYPE_SHA256, msg,
+            ret = wc_VerifyEccsiHash(genKey, WC_HASH_TYPE_SHA256, msg,
                                      sizeof(msg), sig, sigSz, &verified);
 
             if (ret != 0 || !verified) {
                 printf("wc_VerifyEccsiHash failed: %d (verified: %d)\n", ret,
                        verified);
-                break;
+                goto exit;
             }
             RECORD_MULTI_VALUE_STATS();
         }
@@ -11702,8 +11796,13 @@ void bench_eccsi(void)
     bench_multi_value_stats(max, min, sum, squareSum, runs);
 #endif
 
-    wc_FreeEccsiKey(&genKey);
+    wc_FreeEccsiKey(genKey);
     wc_ecc_del_point(pvt);
+
+exit:
+
+    WC_FREE_VAR(genKey, HEAP_HINT);
+    WC_FREE_VAR(ssk, HEAP_HINT);
 }
 #endif /* WOLFCRYPT_ECCSI_CLIENT */
 #endif /* WOLFCRYPT_HAVE_ECCSI */
@@ -11712,24 +11811,26 @@ void bench_eccsi(void)
 #ifdef WOLFCRYPT_SAKKE_KMS
 void bench_sakkeKeyGen(void)
 {
-    SakkeKey genKey;
+    WC_DECLARE_VAR(genKey, SakkeKey, 1, HEAP_HINT);
     double start;
     int    i, count;
     const char**desc = bench_desc_words[lng_index];
     int    ret;
     DECLARE_MULTI_VALUE_STATS_VARS()
 
+    WC_ALLOC_VAR(genKey, SakkeKey, 1, HEAP_HINT);
+
     /* Key Gen */
     bench_stats_start(&count, &start);
     do {
         for (i = 0; i < genTimes; i++) {
-            wc_InitSakkeKey_ex(&genKey, 128, ECC_SAKKE_1, NULL, INVALID_DEVID);
-            ret = wc_MakeSakkeKey(&genKey, &gRng);
+            wc_InitSakkeKey_ex(genKey, 128, ECC_SAKKE_1, NULL, INVALID_DEVID);
+            ret = wc_MakeSakkeKey(genKey, &gRng);
             if (ret != 0) {
                 printf("wc_MakeSakkeKey failed: %d\n", ret);
-                break;
+                goto exit;
             }
-            wc_FreeSakkeKey(&genKey);
+            wc_FreeSakkeKey(genKey);
             RECORD_MULTI_VALUE_STATS();
         }
         count += i;
@@ -11743,11 +11844,15 @@ void bench_sakkeKeyGen(void)
 #ifdef MULTI_VALUE_STATISTICS
     bench_multi_value_stats(max, min, sum, squareSum, runs);
 #endif
+
+exit:
+
+    WC_FREE_VAR(genKey, HEAP_HINT);
 }
 
 void bench_sakkeRskGen(void)
 {
-    SakkeKey genKey;
+    WC_DECLARE_VAR(genKey, SakkeKey, 1, HEAP_HINT);
     double start;
     int    i, count;
     const char**desc = bench_desc_words[lng_index];
@@ -11756,18 +11861,20 @@ void bench_sakkeRskGen(void)
     int ret;
     DECLARE_MULTI_VALUE_STATS_VARS()
 
+    WC_ALLOC_VAR(genKey, SakkeKey, 1, HEAP_HINT);
+
     rsk = wc_ecc_new_point();
-    wc_InitSakkeKey_ex(&genKey, 128, ECC_SAKKE_1, NULL, INVALID_DEVID);
-    (void)wc_MakeSakkeKey(&genKey, &gRng);
+    wc_InitSakkeKey_ex(genKey, 128, ECC_SAKKE_1, NULL, INVALID_DEVID);
+    (void)wc_MakeSakkeKey(genKey, &gRng);
 
     /* RSK Gen */
     bench_stats_start(&count, &start);
     do {
         for (i = 0; i < genTimes; i++) {
-            ret = wc_MakeSakkeRsk(&genKey, id, sizeof(id), rsk);
+            ret = wc_MakeSakkeRsk(genKey, id, sizeof(id), rsk);
             if (ret != 0) {
                 printf("wc_MakeSakkeRsk failed: %d\n", ret);
-                break;
+                goto exit;
             }
             RECORD_MULTI_VALUE_STATS();
         }
@@ -11783,15 +11890,19 @@ void bench_sakkeRskGen(void)
     bench_multi_value_stats(max, min, sum, squareSum, runs);
 #endif
 
-    wc_FreeSakkeKey(&genKey);
+    wc_FreeSakkeKey(genKey);
     wc_ecc_del_point(rsk);
+
+exit:
+
+    WC_FREE_VAR(genKey, HEAP_HINT);
 }
 #endif
 
 #ifdef WOLFCRYPT_SAKKE_CLIENT
 void bench_sakkeValidate(void)
 {
-    SakkeKey genKey;
+    WC_DECLARE_VAR(genKey, SakkeKey, 1, HEAP_HINT);
     double start;
     int    i, count;
     const char**desc = bench_desc_words[lng_index];
@@ -11801,21 +11912,23 @@ void bench_sakkeValidate(void)
     int ret;
     DECLARE_MULTI_VALUE_STATS_VARS()
 
+    WC_ALLOC_VAR(genKey, SakkeKey, 1, HEAP_HINT);
+
     rsk = wc_ecc_new_point();
-    (void)wc_InitSakkeKey_ex(&genKey, 128, ECC_SAKKE_1, NULL, INVALID_DEVID);
-    (void)wc_MakeSakkeKey(&genKey, &gRng);
-    (void)wc_MakeSakkeRsk(&genKey, id, sizeof(id), rsk);
-    (void)wc_ValidateSakkeRsk(&genKey, id, sizeof(id), rsk, &valid);
+    (void)wc_InitSakkeKey_ex(genKey, 128, ECC_SAKKE_1, NULL, INVALID_DEVID);
+    (void)wc_MakeSakkeKey(genKey, &gRng);
+    (void)wc_MakeSakkeRsk(genKey, id, sizeof(id), rsk);
+    (void)wc_ValidateSakkeRsk(genKey, id, sizeof(id), rsk, &valid);
 
     /* Validation of RSK */
     bench_stats_start(&count, &start);
     do {
         for (i = 0; i < genTimes; i++) {
-            ret = wc_ValidateSakkeRsk(&genKey, id, sizeof(id), rsk, &valid);
+            ret = wc_ValidateSakkeRsk(genKey, id, sizeof(id), rsk, &valid);
             if (ret != 0 || !valid) {
                 printf("wc_ValidateSakkeRsk failed: %d (valid=%d))\n", ret,
                        valid);
-                break;
+                goto exit;
             }
             RECORD_MULTI_VALUE_STATS();
         }
@@ -11831,13 +11944,17 @@ void bench_sakkeValidate(void)
     bench_multi_value_stats(max, min, sum, squareSum, runs);
 #endif
 
-    wc_FreeSakkeKey(&genKey);
+    wc_FreeSakkeKey(genKey);
     wc_ecc_del_point(rsk);
+
+exit:
+
+    WC_FREE_VAR(genKey, HEAP_HINT);
 }
 
 void bench_sakke(void)
 {
-    SakkeKey genKey;
+    WC_DECLARE_VAR(genKey, SakkeKey, 1, HEAP_HINT);
     double start;
     int    i, count;
     const char**desc = bench_desc_words[lng_index];
@@ -11855,20 +11972,22 @@ void bench_sakke(void)
     word32 iTableLen = 0;
     DECLARE_MULTI_VALUE_STATS_VARS()
 
+    WC_ALLOC_VAR(genKey, SakkeKey, 1, HEAP_HINT);
+
     XMEMCPY(ssv, ssv_init, sizeof ssv);
 
     rsk = wc_ecc_new_point();
-    (void)wc_InitSakkeKey_ex(&genKey, 128, ECC_SAKKE_1, NULL, INVALID_DEVID);
-    (void)wc_MakeSakkeKey(&genKey, &gRng);
-    (void)wc_MakeSakkeRsk(&genKey, id, sizeof(id), rsk);
-    (void)wc_SetSakkeRsk(&genKey, rsk, NULL, 0);
-    (void)wc_SetSakkeIdentity(&genKey, id, sizeof(id));
+    (void)wc_InitSakkeKey_ex(genKey, 128, ECC_SAKKE_1, NULL, INVALID_DEVID);
+    (void)wc_MakeSakkeKey(genKey, &gRng);
+    (void)wc_MakeSakkeRsk(genKey, id, sizeof(id), rsk);
+    (void)wc_SetSakkeRsk(genKey, rsk, NULL, 0);
+    (void)wc_SetSakkeIdentity(genKey, id, sizeof(id));
 
     /* Encapsulate */
     bench_stats_start(&count, &start);
     do {
         for (i = 0; i < genTimes; i++) {
-            ret = wc_MakeSakkeEncapsulatedSSV(&genKey,
+            ret = wc_MakeSakkeEncapsulatedSSV(genKey,
                                               WC_HASH_TYPE_SHA256,
                                               ssv, sizeof(ssv), auth, &authSz);
             if (ret != 0) {
@@ -11897,7 +12016,7 @@ void bench_sakke(void)
     do {
         for (i = 0; i < genTimes; i++) {
             XMEMCPY(derSSV, ssv, sizeof(ssv));
-            ret = wc_DeriveSakkeSSV(&genKey, WC_HASH_TYPE_SHA256, derSSV,
+            ret = wc_DeriveSakkeSSV(genKey, WC_HASH_TYPE_SHA256, derSSV,
                                     sizeof(derSSV), auth, authSz);
             if (ret != 0) {
                 printf("wc_DeriveSakkeSSV failed: %d\n", ret);
@@ -11920,19 +12039,21 @@ void bench_sakke(void)
 #endif
 
     /* Calculate Point I and generate table. */
-    (void)wc_MakeSakkePointI(&genKey, id, sizeof(id));
+    (void)wc_MakeSakkePointI(genKey, id, sizeof(id));
     iTableLen = 0;
-    (void)wc_GenerateSakkePointITable(&genKey, NULL, &iTableLen);
+    (void)wc_GenerateSakkePointITable(genKey, NULL, &iTableLen);
     if (iTableLen != 0) {
         iTable = (byte*)XMALLOC(iTableLen, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-        (void)wc_GenerateSakkePointITable(&genKey, iTable, &iTableLen);
+        if (iTable == NULL)
+            WC_ALLOC_DO_ON_FAILURE();
+        (void)wc_GenerateSakkePointITable(genKey, iTable, &iTableLen);
     }
 
     /* Encapsulate with Point I table */
     bench_stats_start(&count, &start);
     do {
         for (i = 0; i < genTimes; i++) {
-            ret = wc_MakeSakkeEncapsulatedSSV(&genKey,
+            ret = wc_MakeSakkeEncapsulatedSSV(genKey,
                                               WC_HASH_TYPE_SHA256, ssv,
                                               sizeof(ssv), auth, &authSz);
             if (ret != 0) {
@@ -11956,14 +12077,14 @@ void bench_sakke(void)
 
     RESET_MULTI_VALUE_STATS_VARS();
 
-    (void)wc_SetSakkeRsk(&genKey, rsk, table, len);
+    (void)wc_SetSakkeRsk(genKey, rsk, table, len);
 
     /* Derive with Point I table */
     bench_stats_start(&count, &start);
     do {
         for (i = 0; i < genTimes; i++) {
             XMEMCPY(derSSV, ssv, sizeof(ssv));
-            ret = wc_DeriveSakkeSSV(&genKey, WC_HASH_TYPE_SHA256, derSSV,
+            ret = wc_DeriveSakkeSSV(genKey, WC_HASH_TYPE_SHA256, derSSV,
                                     sizeof(derSSV), auth, authSz);
             if (ret != 0) {
                 printf("wc_DeriveSakkeSSV failed: %d\n", ret);
@@ -11988,19 +12109,21 @@ void bench_sakke(void)
     RESET_MULTI_VALUE_STATS_VARS();
 
     len = 0;
-    (void)wc_GenerateSakkeRskTable(&genKey, rsk, NULL, &len);
+    (void)wc_GenerateSakkeRskTable(genKey, rsk, NULL, &len);
     if (len > 0) {
         table = (byte*)XMALLOC(len, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-        (void)wc_GenerateSakkeRskTable(&genKey, rsk, table, &len);
+        if (table == NULL)
+            WC_ALLOC_DO_ON_FAILURE();
+        (void)wc_GenerateSakkeRskTable(genKey, rsk, table, &len);
     }
-    (void)wc_SetSakkeRsk(&genKey, rsk, table, len);
+    (void)wc_SetSakkeRsk(genKey, rsk, table, len);
 
     /* Derive with Point I table and RSK table */
     bench_stats_start(&count, &start);
     do {
         for (i = 0; i < genTimes; i++) {
             XMEMCPY(derSSV, ssv, sizeof(ssv));
-            ret = wc_DeriveSakkeSSV(&genKey, WC_HASH_TYPE_SHA256, derSSV,
+            ret = wc_DeriveSakkeSSV(genKey, WC_HASH_TYPE_SHA256, derSSV,
                                     sizeof(derSSV), auth, authSz);
             if (ret != 0) {
                 printf("wc_DeriveSakkeSSV failed: %d\n", ret);
@@ -12024,13 +12147,13 @@ void bench_sakke(void)
 
     RESET_MULTI_VALUE_STATS_VARS();
 
-    wc_ClearSakkePointITable(&genKey);
+    wc_ClearSakkePointITable(genKey);
     /* Derive with RSK table */
     bench_stats_start(&count, &start);
     do {
         for (i = 0; i < genTimes; i++) {
             XMEMCPY(derSSV, ssv, sizeof(ssv));
-            ret = wc_DeriveSakkeSSV(&genKey, WC_HASH_TYPE_SHA256, derSSV,
+            ret = wc_DeriveSakkeSSV(genKey, WC_HASH_TYPE_SHA256, derSSV,
                                     sizeof(derSSV), auth, authSz);
             if (ret != 0) {
                 printf("wc_DeriveSakkeSSV failed: %d\n", ret);
@@ -12052,8 +12175,18 @@ void bench_sakke(void)
     bench_multi_value_stats(max, min, sum, squareSum, runs);
 #endif
 
-    wc_FreeSakkeKey(&genKey);
+    wc_FreeSakkeKey(genKey);
     wc_ecc_del_point(rsk);
+
+exit:
+
+    if (iTable)
+        XFREE(iTable, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+
+    if (table)
+        XFREE(table, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+
+    WC_FREE_VAR(genKey, HEAP_HINT);
 }
 #endif /* WOLFCRYPT_SAKKE_CLIENT */
 #endif /* WOLFCRYPT_HAVE_SAKKE */

--- a/wolfcrypt/src/ed448.c
+++ b/wolfcrypt/src/ed448.c
@@ -203,7 +203,10 @@ int wc_ed448_make_public(ed448_key* key, unsigned char* pubKey, word32 pubKeySz)
         az[55] |= 0x80;
         az[56]  = 0x00;
 
-        ge448_scalarmult_base(&A, az);
+        ret = ge448_scalarmult_base(&A, az);
+    }
+
+    if (ret == 0) {
         ge448_to_bytes(pubKey, &A);
 
         key->pubKeySet = 1;

--- a/wolfcrypt/src/sakke.c
+++ b/wolfcrypt/src/sakke.c
@@ -6522,7 +6522,6 @@ int wc_GenerateSakkePointITable(SakkeKey* key, byte* table, word32* len)
         key->i.table = table;
         key->i.tableLen = *len;
     }
-    (void)table;
 #endif
 
     return err;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -11917,12 +11917,12 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes192_test(void)
         0x71,0x78,0x18,0x3a,0x9f,0xa0,0x71,0xe8
     };
 
-    WOLFSSL_SMALL_STACK_STATIC byte key[] = {
+    WOLFSSL_SMALL_STACK_STATIC const byte key[] = {
         0x8e,0x73,0xb0,0xf7,0xda,0x0e,0x64,0x52,
         0xc8,0x10,0xf3,0x2b,0x80,0x90,0x79,0xe5,
         0x62,0xf8,0xea,0xd2,0x52,0x2c,0x6b,0x7b
     };
-    WOLFSSL_SMALL_STACK_STATIC byte iv[]  = {
+    WOLFSSL_SMALL_STACK_STATIC const byte iv[]  = {
         0x00,0x01,0x02,0x03,0x04,0x05,0x06,0x07,
         0x08,0x09,0x0A,0x0B,0x0C,0x0D,0x0E,0x0F
     };
@@ -12046,7 +12046,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes256_test(void)
                 (byte*)guser_PKCbInfo.wrapped_key_aes256;
     int keySz = (256/8);
 #else
-    WOLFSSL_SMALL_STACK_STATIC byte key[] = {
+    WOLFSSL_SMALL_STACK_STATIC const byte key[] = {
         0x60,0x3d,0xeb,0x10,0x15,0xca,0x71,0xbe,
         0x2b,0x73,0xae,0xf0,0x85,0x7d,0x77,0x81,
         0x1f,0x35,0x2c,0x07,0x3b,0x61,0x08,0xd7,
@@ -12054,7 +12054,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes256_test(void)
     };
     int keySz = (int)sizeof(key);
 #endif
-    WOLFSSL_SMALL_STACK_STATIC byte iv[]  = {
+    WOLFSSL_SMALL_STACK_STATIC const byte iv[]  = {
         0x00,0x01,0x02,0x03,0x04,0x05,0x06,0x07,
         0x08,0x09,0x0A,0x0B,0x0C,0x0D,0x0E,0x0F
     };
@@ -15977,16 +15977,16 @@ static void initDefaultName(void)
 
 #if !defined(NO_ASN_TIME) && !defined(NO_RSA) && defined(WOLFSSL_TEST_CERT) && \
     !defined(NO_FILESYSTEM)
-static byte minSerial[] = { 0x02, 0x01, 0x01 };
-static byte minName[] = { 0x30, 0x00 };
-static byte nameBad[] = {
+static const byte minSerial[] = { 0x02, 0x01, 0x01 };
+static const byte minName[] = { 0x30, 0x00 };
+static const byte nameBad[] = {
     0x30, 0x08,
           0x31, 0x06,
                 0x30, 0x04,
                       0x06, 0x02,
                             0x55, 0x04,
 };
-static byte minDates[] = {
+static const byte minDates[] = {
     0x30, 0x1e,
           0x17, 0x0d,
                 0x31, 0x38, 0x30, 0x34, 0x31, 0x33, 0x31, 0x35,
@@ -15995,7 +15995,7 @@ static byte minDates[] = {
                 0x32, 0x31, 0x30, 0x31, 0x30, 0x37, 0x31, 0x35,
                 0x32, 0x33, 0x31, 0x30, 0x5a
 };
-static byte minPubKey[] = {
+static const byte minPubKey[] = {
     0x30, 0x1c,
           0x30, 0x0d,
                 0x06, 0x09,
@@ -16009,14 +16009,14 @@ static byte minPubKey[] = {
                             0x02, 0x03,
                                   0x01, 0x00, 0x01
 };
-static byte minSigAlg[] = {
+static const byte minSigAlg[] = {
     0x30, 0x0d,
           0x06, 0x09,
                 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01,
                 0x0b,
           0x05, 0x00
 };
-static byte minSig[] = {
+static const byte minSig[] = {
     0x03, 0x01,
           0x00
 };
@@ -16028,7 +16028,7 @@ static int add_seq(byte* certData, int offset, byte* data, byte length)
     certData[offset++] = length;
     return offset + length;
 }
-static int add_data(byte* certData, int offset, byte* data, byte length)
+static int add_data(byte* certData, int offset, const byte* data, byte length)
 {
     XMEMCPY(certData + offset, data, length);
     return offset + length;
@@ -17259,6 +17259,10 @@ static wc_test_ret_t rsa_pss_test(WC_RNG* rng, RsaKey* key)
     WC_DECLARE_VAR(out, byte, RSA_TEST_BYTES, HEAP_HINT);
     WC_DECLARE_VAR(sig, byte, RSA_TEST_BYTES, HEAP_HINT);
 
+    WC_ALLOC_VAR(in, byte, RSA_TEST_BYTES, HEAP_HINT);
+    WC_ALLOC_VAR(out, byte, RSA_TEST_BYTES, HEAP_HINT);
+    WC_ALLOC_VAR(sig, byte, RSA_TEST_BYTES, HEAP_HINT);
+
 #ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
     if (in == NULL || out == NULL || sig == NULL)
         ERROR_OUT(MEMORY_E, exit_rsa_pss);
@@ -17579,6 +17583,10 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_no_pad_test(void)
     WC_DECLARE_VAR(out, byte, RSA_TEST_BYTES, HEAP_HINT);
     WC_DECLARE_VAR(plain, byte, RSA_TEST_BYTES, HEAP_HINT);
 
+    WC_ALLOC_VAR(key, RsaKey, 1, HEAP_HINT);
+    WC_ALLOC_VAR(out, byte, RSA_TEST_BYTES, HEAP_HINT);
+    WC_ALLOC_VAR(plain, byte, RSA_TEST_BYTES, HEAP_HINT);
+
 #ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
     if (key == NULL || out == NULL || plain == NULL)
         ERROR_OUT(MEMORY_E, exit_rsa_nopadding);
@@ -17809,6 +17817,12 @@ static wc_test_ret_t rsa_even_mod_test(WC_RNG* rng, RsaKey* key)
 #ifndef WOLFSSL_RSA_PUBLIC_ONLY
     WC_DECLARE_VAR(plain, byte, RSA_TEST_BYTES, HEAP_HINT);
 #endif
+
+    WC_ALLOC_VAR(out, byte, RSA_TEST_BYTES, HEAP_HINT);
+#ifndef WOLFSSL_RSA_PUBLIC_ONLY
+    WC_ALLOC_VAR(plain, byte, RSA_TEST_BYTES, HEAP_HINT);
+#endif
+
 #ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
     if (out == NULL
     #ifndef WOLFSSL_RSA_PUBLIC_ONLY
@@ -18625,6 +18639,10 @@ static wc_test_ret_t rsa_oaep_padding_test(RsaKey* key, WC_RNG* rng)
     WC_DECLARE_VAR(out, byte, RSA_TEST_BYTES, HEAP_HINT);
     WC_DECLARE_VAR(plain, byte, RSA_TEST_BYTES, HEAP_HINT);
 
+    WC_ALLOC_VAR(in, byte, TEST_STRING_SZ, HEAP_HINT);
+    WC_ALLOC_VAR(out, byte, RSA_TEST_BYTES, HEAP_HINT);
+    WC_ALLOC_VAR(plain, byte, RSA_TEST_BYTES, HEAP_HINT);
+
 #ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
     if (in == NULL || out == NULL || plain == NULL)
         ERROR_OUT(MEMORY_E, exit_rsa);
@@ -18985,6 +19003,10 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_test(void)
     WC_DECLARE_VAR(out, byte, RSA_TEST_BYTES, HEAP_HINT);
     WC_DECLARE_VAR(plain, byte, RSA_TEST_BYTES, HEAP_HINT);
 
+    WC_ALLOC_VAR(in, byte, TEST_STRING_SZ, HEAP_HINT);
+    WC_ALLOC_VAR(out, byte, RSA_TEST_BYTES, HEAP_HINT);
+    WC_ALLOC_VAR(plain, byte, RSA_TEST_BYTES, HEAP_HINT);
+
 #ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
     if (in == NULL || out == NULL || plain == NULL)
         ERROR_OUT(MEMORY_E, exit_rsa);
@@ -19190,7 +19212,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_test(void)
 
 #elif defined(WOLFSSL_PUBLIC_MP)
     {
-        static byte signature_2048[] = {
+        static const byte signature_2048[] = {
             0x07, 0x6f, 0xc9, 0x85, 0x73, 0x9e, 0x21, 0x79,
             0x47, 0xf1, 0xa3, 0xd7, 0xf4, 0x27, 0x29, 0xbe,
             0x99, 0x5d, 0xac, 0xb2, 0x10, 0x3f, 0x95, 0xda,
@@ -25964,6 +25986,13 @@ static wc_test_ret_t ecc_test_vector_item(const eccVector* vector)
     WC_DECLARE_VAR(s, byte, MAX_ECC_BYTES, HEAP_HINT);
 #endif
 
+    WC_ALLOC_VAR(sig, byte, ECC_SIG_SIZE, HEAP_HINT);
+#if !defined(NO_ASN) && !defined(HAVE_SELFTEST)
+    WC_ALLOC_VAR(sigRaw, byte, ECC_SIG_SIZE, HEAP_HINT);
+    WC_ALLOC_VAR(r, byte, MAX_ECC_BYTES, HEAP_HINT);
+    WC_ALLOC_VAR(s, byte, MAX_ECC_BYTES, HEAP_HINT);
+#endif
+
 #ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
     if (sig == NULL)
         ERROR_OUT(MEMORY_E, done);
@@ -27350,6 +27379,21 @@ static wc_test_ret_t ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerif
 #endif
 #ifndef WC_NO_RNG
     int     curveSize;
+#endif
+
+#if defined(HAVE_ECC_DHE) && !defined(WC_NO_RNG) && \
+    !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A)
+    WC_ALLOC_VAR(sharedA, byte, ECC_SHARED_SIZE, HEAP_HINT);
+    WC_ALLOC_VAR(sharedB, byte, ECC_SHARED_SIZE, HEAP_HINT);
+#endif
+#ifdef HAVE_ECC_KEY_EXPORT
+    WC_ALLOC_VAR(exportBuf, byte, ECC_KEY_EXPORT_BUF_SIZE, HEAP_HINT);
+#endif
+#if !defined(ECC_TIMING_RESISTANT) || (defined(ECC_TIMING_RESISTANT) && \
+    !defined(WC_NO_RNG) && !defined(WOLFSSL_KCAPI_ECC)) && \
+    defined(HAVE_ECC_SIGN)
+    WC_ALLOC_VAR(sig, byte, ECC_SIG_SIZE, HEAP_HINT);
+    WC_ALLOC_VAR(digest, byte, ECC_DIGEST_SIZE, HEAP_HINT);
 #endif
 
 #ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
@@ -29000,6 +29044,18 @@ static int ecc_sm2_test_curve(WC_RNG* rng, int testVerifyCount)
 #endif
 #ifndef WC_NO_RNG
     int     curveSize;
+#endif
+
+#if (defined(HAVE_ECC_DHE) || defined(HAVE_ECC_CDH)) && !defined(WC_NO_RNG)
+    WC_ALLOC_VAR(sharedA, byte, ECC_SHARED_SIZE, HEAP_HINT);
+    WC_ALLOC_VAR(sharedB, byte, ECC_SHARED_SIZE, HEAP_HINT);
+#endif
+#ifdef HAVE_ECC_KEY_EXPORT
+    WC_ALLOC_VAR(exportBuf, byte, ECC_KEY_EXPORT_BUF_SIZE, HEAP_HINT);
+#endif
+#ifdef HAVE_ECC_SIGN
+    WC_ALLOC_VAR(sig, byte, ECC_SIG_SIZE, HEAP_HINT);
+    WC_ALLOC_VAR(digest, byte, ECC_DIGEST_SIZE, HEAP_HINT);
 #endif
 
 #ifdef WC_DECLARE_VAR_IS_HEAP_ALLOC
@@ -32680,7 +32736,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ed25519_test(void)
                                    sizeof(msg4)
     };
 #ifndef NO_ASN
-    static byte privateEd25519[] = {
+    static const byte privateEd25519[] = {
         0x30,0x2e,0x02,0x01,0x00,0x30,0x05,0x06,
         0x03,0x2b,0x65,0x70,0x04,0x22,0x04,0x20,
         0x9d,0x61,0xb1,0x9d,0xef,0xfd,0x5a,0x60,
@@ -32688,7 +32744,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ed25519_test(void)
         0x44,0x49,0xc5,0x69,0x7b,0x32,0x69,0x19,
         0x70,0x3b,0xac,0x03,0x1c,0xae,0x7f,0x60
     };
-    static byte badPrivateEd25519[] = {
+    static const byte badPrivateEd25519[] = {
         0x30,0x52,0x02,0x01,0x00,0x30,0x05,0x06,
         0x03,0x2b,0x65,0x70,0x04,0x22,0x04,0x20,
         0x9d,0x61,0xb1,0x9d,0xef,0xfd,0x5a,0x60,
@@ -32702,7 +32758,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ed25519_test(void)
         0xf7,0x07,0x51,0x1a,
         0x00  /* add additional bytes to make the pubkey bigger  */
     };
-    static byte publicEd25519[] = {
+    static const byte publicEd25519[] = {
         0x30,0x2a,0x30,0x05,0x06,0x03,0x2b,0x65,
         0x70,0x03,0x21,0x00,0xd7,0x5a,0x98,0x01,
         0x82,0xb1,0x0a,0xb7,0xd5,0x4b,0xfe,0xd3,
@@ -32712,7 +32768,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ed25519_test(void)
     };
 
     /* size has been altered to catch if sanity check is done */
-    static byte badPublicEd25519[] = {
+    static const byte badPublicEd25519[] = {
         0x30,0x2a,0x30,0x05,0x06,0x03,0x2b,0x65,
         0x70,0x03,0x21,0x00,0xd7,0x5a,0x98,0x01,
         0x82,0xb1,0x0a,0xb7,0xd5,0x4b,0xfe,0xd3,
@@ -32721,7 +32777,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ed25519_test(void)
         0xf7,0x07,0x51,0x1a,
         0x00 /* add an additional byte to make the pubkey appear bigger */
     };
-    static byte privPubEd25519[] = {
+    static const byte privPubEd25519[] = {
         0x30,0x50,0x02,0x01,0x00,0x30,0x05,0x06,
         0x03,0x2b,0x65,0x70,0x04,0x22,0x04,0x20,
         0x9d,0x61,0xb1,0x9d,0xef,0xfd,0x5a,0x60,
@@ -36807,7 +36863,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t xmss_test(void)
  *   https://github.com/XMSS/xmss-reference
  * */
 
-static byte xmss_pub[XMSS_SHA256_PUBLEN] =
+static const byte xmss_pub[XMSS_SHA256_PUBLEN] =
 {
     0x00,0x00,0x00,0x01,0xA5,0x41,0x31,0x96,
     0x0A,0xF9,0xF3,0xB2,0x4B,0x2E,0x5B,0x3E,
@@ -36820,7 +36876,7 @@ static byte xmss_pub[XMSS_SHA256_PUBLEN] =
     0xC9,0xB7,0x39,0x4E
 };
 
-static byte xmss_msg[32] =
+static const byte xmss_msg[32] =
 {
     0x07,0x9F,0x80,0x86,0xDB,0x76,0x27,0xDF,
     0xED,0x5B,0x2A,0x81,0x60,0x60,0x7D,0xB4,
@@ -36830,7 +36886,7 @@ static byte xmss_msg[32] =
 
 /* This was actually the 5th signature produced from
  * xmss_fast test in xmss-reference. */
-static byte xmss_sig[2500] =
+static const byte xmss_sig[2500] =
 {
     0x00,0x00,0x00,0x05,0xF0,0x15,0x34,0xBA,
     0x92,0x03,0x6A,0xB9,0xA5,0x23,0x86,0x11,
@@ -37408,7 +37464,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t lms_test(void)
  * */
 
 /* "wolfSSL LMS example message!" without null terminator. */
-static byte lms_msg[28] =
+static const byte lms_msg[28] =
 {
     0x77,0x6F,0x6C,0x66,0x53,0x53,0x4C,0x20,
     0x4C,0x4D,0x53,0x20,0x65,0x78,0x61,0x6D,
@@ -37416,7 +37472,7 @@ static byte lms_msg[28] =
     0x61,0x67,0x65,0x21
 };
 
-static byte lms_L1H10W8_pub[HSS_MAX_PUBLIC_KEY_LEN] =
+static const byte lms_L1H10W8_pub[HSS_MAX_PUBLIC_KEY_LEN] =
 {
     0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x06,
     0x00,0x00,0x00,0x04,0xA1,0x26,0x76,0xF8,
@@ -37430,7 +37486,7 @@ static byte lms_L1H10W8_pub[HSS_MAX_PUBLIC_KEY_LEN] =
 
 #define LMS_L1H10W8_SIGLEN (1456)
 
-static byte lms_L1H10W8_sig[LMS_L1H10W8_SIGLEN] =
+static const byte lms_L1H10W8_sig[LMS_L1H10W8_SIGLEN] =
 {
     0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x01,
     0x00,0x00,0x00,0x04,0x18,0x70,0x09,0x2E,
@@ -39440,12 +39496,12 @@ static wc_test_ret_t sakke_kat_encapsulate_test(SakkeKey* key)
         0x37, 0x30, 0x30, 0x39, 0x30, 0x30, 0x31, 0x32,
         0x33, 0x00
     };
-    static word32 idSz = sizeof(id);
+    static const word32 idSz = sizeof(id);
     byte ssv[] = {
         0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0,
         0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0
     };
-    static word16 ssvSz = sizeof(ssv);
+    static const word16 ssvSz = sizeof(ssv);
     static const byte expAuth[] = {
         0x04,
         0x44, 0xE8, 0xAD, 0x44, 0xAB, 0x85, 0x92, 0xA6,
@@ -43145,8 +43201,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t pkcs7encrypted_test(void)
     /* Attribute example from RFC 4134, Section 7.2
      * OID = 1.2.5555
      * OCTET STRING = 'This is a test General ASN Attribute, number 1.' */
-    static byte genAttrOid[] = { 0x06, 0x03, 0x2a, 0xab, 0x33 };
-    static byte genAttr[] = { 0x04, 47,
+    static const byte genAttrOid[] = { 0x06, 0x03, 0x2a, 0xab, 0x33 };
+    static const byte genAttr[] = { 0x04, 47,
                               0x54, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20,
                               0x61, 0x20, 0x74, 0x65, 0x73, 0x74, 0x20, 0x47,
                               0x65, 0x6e, 0x65, 0x72, 0x61, 0x6c, 0x20, 0x41,
@@ -43154,8 +43210,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t pkcs7encrypted_test(void)
                               0x62, 0x75, 0x74, 0x65, 0x2c, 0x20, 0x6e, 0x75,
                               0x6d, 0x62, 0x65, 0x72, 0x20, 0x31, 0x2e };
 
-    static byte genAttrOid2[] = { 0x06, 0x03, 0x2a, 0xab, 0x34 };
-    static byte genAttr2[] = { 0x04, 47,
+    static const byte genAttrOid2[] = { 0x06, 0x03, 0x2a, 0xab, 0x34 };
+    static const byte genAttr2[] = { 0x04, 47,
                               0x54, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20,
                               0x61, 0x20, 0x74, 0x65, 0x73, 0x74, 0x20, 0x47,
                               0x65, 0x6e, 0x65, 0x72, 0x61, 0x6c, 0x20, 0x41,
@@ -43488,12 +43544,12 @@ typedef struct {
     word32       signedAttribsSz;
     const char*  outFileName;
     int          contentOID;
-    byte*        contentType;
+    const byte*  contentType;
     word32       contentTypeSz;
     int          sidType;
     int          encryptOID;   /* for single-shot encrypt alg OID */
     int          encCompFlag;  /* for single-shot. 1 = enc, 2 = comp, 3 = both*/
-    byte*        encryptKey;   /* for single-shot, encryptedData */
+    const byte*  encryptKey;   /* for single-shot, encryptedData */
     word32       encryptKeySz; /* for single-shot, encryptedData */
     PKCS7Attrib* unprotectedAttribs;   /* for single-shot, encryptedData */
     word32       unprotectedAttribsSz; /* for single-shot, encryptedData */
@@ -43527,24 +43583,24 @@ static wc_test_ret_t pkcs7signed_run_vectors(
         0x72,0x6c,0x64
     };
 
-    static byte transIdOid[] =
+    static const byte transIdOid[] =
                { 0x06, 0x0a, 0x60, 0x86, 0x48, 0x01, 0x86, 0xF8, 0x45, 0x01,
                  0x09, 0x07 };
-    static byte messageTypeOid[] =
+    static const byte messageTypeOid[] =
                { 0x06, 0x0a, 0x60, 0x86, 0x48, 0x01, 0x86, 0xF8, 0x45, 0x01,
                  0x09, 0x02 };
-    static byte senderNonceOid[] =
+    static const byte senderNonceOid[] =
                { 0x06, 0x0a, 0x60, 0x86, 0x48, 0x01, 0x86, 0xF8, 0x45, 0x01,
                  0x09, 0x05 };
 #ifndef NO_SHA
-    static byte transId[(WC_SHA_DIGEST_SIZE + 1) * 2 + 1];
+    byte transId[(WC_SHA_DIGEST_SIZE + 1) * 2 + 1];
 #else
-    static byte transId[(WC_SHA256_DIGEST_SIZE + 1) * 2 + 1];
+    byte transId[(WC_SHA256_DIGEST_SIZE + 1) * 2 + 1];
 #endif
-    static byte messageType[] = { 0x13, 2, '1', '9' };
-    static byte senderNonce[PKCS7_NONCE_SZ + 2];
+    static const byte messageType[] = { 0x13, 2, '1', '9' };
+    byte senderNonce[PKCS7_NONCE_SZ + 2];
 
-    static PKCS7Attrib attribs[] =
+    PKCS7Attrib attribs[] =
     {
         { transIdOid, sizeof(transIdOid), transId,
                                sizeof(transId) - 1 }, /* take off the null */
@@ -43555,13 +43611,13 @@ static wc_test_ret_t pkcs7signed_run_vectors(
     };
 
     /* for testing custom contentType, FirmwarePkgData */
-    static byte customContentType[] = { 0x06, 0x0B, 0x2A, 0x86,
+    static const byte customContentType[] = { 0x06, 0x0B, 0x2A, 0x86,
                                         0x48, 0x86, 0xF7, 0x0D,
                                         0x01, 0x09, 0x10, 0x01, 0x10 };
 
     #define MAX_TESTVECTORS_LEN 20
     #define ADD_PKCS7SIGNEDVECTOR(...) {                                       \
-            pkcs7SignedVector _this_vector = { __VA_ARGS__ };                  \
+            const pkcs7SignedVector _this_vector = { __VA_ARGS__ };            \
             if (testSz == MAX_TESTVECTORS_LEN) {                               \
                 ret = WC_TEST_RET_ENC_NC;                                      \
                 goto out;                                                      \
@@ -43818,7 +43874,8 @@ static wc_test_ret_t pkcs7signed_run_vectors(
         /* optional custom contentType, default is DATA,
            overrides contentOID if set */
         if (testVectors[i].contentType != NULL) {
-            ret = wc_PKCS7_SetContentType(pkcs7, testVectors[i].contentType,
+            ret = wc_PKCS7_SetContentType(pkcs7,
+                                          (byte *)testVectors[i].contentType,
                                           testVectors[i].contentTypeSz);
             if (ret != 0)
                 ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -43940,7 +43997,7 @@ static wc_test_ret_t pkcs7signed_run_vectors(
         #else
             byte buf[(WC_SHA256_DIGEST_SIZE + 1) * 2 + 1];
         #endif
-            byte* oidPt = transIdOid + 2;  /* skip object id tag and size */
+            const byte* oidPt = transIdOid + 2;  /* skip object id tag and size */
             int oidSz = (int)sizeof(transIdOid) - 2;
             int bufSz = 0;
 
@@ -44046,7 +44103,7 @@ static wc_test_ret_t pkcs7signed_run_SingleShotVectors(
 
 #if !defined(NO_PKCS7_ENCRYPTED_DATA) && \
      defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_256)
-    static byte aes256Key[] = {
+    static const byte aes256Key[] = {
         0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,
         0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,
         0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,
@@ -44054,10 +44111,10 @@ static wc_test_ret_t pkcs7signed_run_SingleShotVectors(
     };
 #endif
 
-    static byte messageTypeOid[] =
+    static const byte messageTypeOid[] =
                { 0x06, 0x0a, 0x60, 0x86, 0x48, 0x01, 0x86, 0xF8, 0x45, 0x01,
                  0x09, 0x02 };
-    static byte messageType[] = { 0x13, 2, '1', '9' };
+    static const byte messageType[] = { 0x13, 2, '1', '9' };
 
     PKCS7Attrib attribs[] =
     {
@@ -44347,7 +44404,7 @@ static wc_test_ret_t pkcs7signed_run_SingleShotVectors(
 
             /* encode Signed Encrypted FirmwarePkgData */
             encodedSz = wc_PKCS7_EncodeSignedEncryptedFPD(pkcs7,
-                    testVectors[i].encryptKey, testVectors[i].encryptKeySz,
+                    (byte *)testVectors[i].encryptKey, testVectors[i].encryptKeySz,
                     testVectors[i].privateKey, testVectors[i].privateKeySz,
                     testVectors[i].encryptOID, testVectors[i].signOID,
                     testVectors[i].hashOID, (byte*)testVectors[i].content,
@@ -44450,7 +44507,7 @@ static wc_test_ret_t pkcs7signed_run_SingleShotVectors(
         else if (testVectors[i].encCompFlag == 1) {
 
             /* decrypt inner encryptedData */
-            pkcs7->encryptionKey = testVectors[i].encryptKey;
+            pkcs7->encryptionKey = (byte *)testVectors[i].encryptKey;
             pkcs7->encryptionKeySz = testVectors[i].encryptKeySz;
 
             ret = wc_PKCS7_DecodeEncryptedData(pkcs7, pkcs7->content,

--- a/wolfssl/wolfcrypt/ge_448.h
+++ b/wolfssl/wolfcrypt/ge_448.h
@@ -64,7 +64,7 @@ WOLFSSL_LOCAL int  ge448_from_bytes_negate_vartime(ge448_p2 *r, const byte *b);
 
 WOLFSSL_LOCAL int  ge448_double_scalarmult_vartime(ge448_p2 *r, const byte *a,
                                     const ge448_p2 *A, const byte *b);
-WOLFSSL_LOCAL void ge448_scalarmult_base(ge448_p2* h, const byte* a);
+WOLFSSL_LOCAL int  ge448_scalarmult_base(ge448_p2* h, const byte* a);
 WOLFSSL_LOCAL void sc448_reduce(byte* b);
 WOLFSSL_LOCAL void sc448_muladd(byte* r, const byte* a, const byte* b, const byte* d);
 WOLFSSL_LOCAL void ge448_to_bytes(byte *s, const ge448_p2 *h);

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -627,8 +627,8 @@ typedef struct w64wrapper {
             VAR_TYPE* VAR_NAME = NULL
         #define WC_ALLOC_VAR(VAR_NAME, VAR_TYPE, VAR_SIZE, HEAP)        \
             do {                                                        \
-                VAR_NAME = (VAR_TYPE*)XMALLOC(sizeof(VAR_TYPE) * (VAR_SIZE), (HEAP), DYNAMIC_TYPE_WOLF_BIGINT);\
-                if (VAR_NAME == NULL) {                                 \
+                (VAR_NAME) = (VAR_TYPE*)XMALLOC(sizeof(VAR_TYPE) * (VAR_SIZE), (HEAP), DYNAMIC_TYPE_WOLF_BIGINT); \
+                if ((VAR_NAME) == NULL) {                               \
                     WC_ALLOC_DO_ON_FAILURE();                           \
                 }                                                       \
             } while (0)

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -580,71 +580,88 @@ typedef struct w64wrapper {
     #endif
 
     /* declare/free variable handling for async and smallstack */
+    #ifndef WC_ALLOC_DO_ON_FAILURE
+        #define WC_ALLOC_DO_ON_FAILURE() WC_DO_NOTHING
+    #endif
+
+    #define WC_DECLARE_HEAP_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) \
+        VAR_TYPE* VAR_NAME[VAR_ITEMS]; \
+        int idx##VAR_NAME = 0, inner_idx_##VAR_NAME
+    #define WC_ALLOC_HEAP_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) \
+        for (idx##VAR_NAME=0; idx##VAR_NAME<(VAR_ITEMS); idx##VAR_NAME++) { \
+            (VAR_NAME)[idx##VAR_NAME] = (VAR_TYPE*)XMALLOC(VAR_SIZE, (HEAP), DYNAMIC_TYPE_TMP_BUFFER); \
+            if ((VAR_NAME)[idx##VAR_NAME] == NULL) { \
+                for (inner_idx_##VAR_NAME = 0; inner_idx_##VAR_NAME < idx##VAR_NAME; inner_idx_##VAR_NAME++) { \
+                    XFREE((VAR_NAME)[inner_idx_##VAR_NAME], (HEAP), DYNAMIC_TYPE_TMP_BUFFER); \
+                    (VAR_NAME)[inner_idx_##VAR_NAME] = NULL; \
+                } \
+                for (inner_idx_##VAR_NAME = idx##VAR_NAME + 1; inner_idx_##VAR_NAME < (VAR_ITEMS); inner_idx_##VAR_NAME++) { \
+                    (VAR_NAME)[inner_idx_##VAR_NAME] = NULL; \
+                } \
+                idx##VAR_NAME = 0; \
+                WC_ALLOC_DO_ON_FAILURE(); \
+                break; \
+            } \
+        }
+    #define WC_CALLOC_HEAP_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) \
+            do { \
+                WC_ALLOC_HEAP_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP); \
+                if (idx##VAR_NAME != 0) { \
+                    for (idx##VAR_NAME=0; idx##VAR_NAME<(VAR_ITEMS); idx##VAR_NAME++) { \
+                        XMEMSET((VAR_NAME)[idx##VAR_NAME], 0, VAR_SIZE); \
+                    } \
+                } \
+            } while (0)
+    #define WC_HEAP_ARRAY_OK(VAR_NAME) (idx##VAR_NAME != 0)
+    #define WC_FREE_HEAP_ARRAY(VAR_NAME, VAR_ITEMS, HEAP)               \
+        if (WC_HEAP_ARRAY_OK(VAR_NAME)) {                               \
+            for (idx##VAR_NAME=0; idx##VAR_NAME<(VAR_ITEMS); idx##VAR_NAME++) { \
+                XFREE((VAR_NAME)[idx##VAR_NAME], (HEAP), DYNAMIC_TYPE_TMP_BUFFER); \
+            }                                                           \
+            idx##VAR_NAME = 0;                                          \
+        }
+
     #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_SMALL_STACK)
         #define WC_DECLARE_VAR_IS_HEAP_ALLOC
         #define WC_DECLARE_VAR(VAR_NAME, VAR_TYPE, VAR_SIZE, HEAP) \
-            VAR_TYPE* VAR_NAME = (VAR_TYPE*)XMALLOC(sizeof(VAR_TYPE) * (VAR_SIZE), (HEAP), DYNAMIC_TYPE_WOLF_BIGINT)
-        #define WC_DECLARE_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) \
-            VAR_TYPE* VAR_NAME[VAR_ITEMS]; \
-            int idx##VAR_NAME, inner_idx_##VAR_NAME
-        #define WC_INIT_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) \
-            for (idx##VAR_NAME=0; idx##VAR_NAME<(VAR_ITEMS); idx##VAR_NAME++) { \
-                (VAR_NAME)[idx##VAR_NAME] = (VAR_TYPE*)XMALLOC(VAR_SIZE, (HEAP), DYNAMIC_TYPE_WOLF_BIGINT); \
-                if ((VAR_NAME)[idx##VAR_NAME] == NULL) { \
-                    for (inner_idx_##VAR_NAME = 0; inner_idx_##VAR_NAME < idx##VAR_NAME; inner_idx_##VAR_NAME++) { \
-                        XFREE((VAR_NAME)[inner_idx_##VAR_NAME], (HEAP), DYNAMIC_TYPE_WOLF_BIGINT); \
-                        (VAR_NAME)[inner_idx_##VAR_NAME] = NULL; \
-                    } \
-                    for (inner_idx_##VAR_NAME = idx##VAR_NAME + 1; inner_idx_##VAR_NAME < (VAR_ITEMS); inner_idx_##VAR_NAME++) { \
-                        (VAR_NAME)[inner_idx_##VAR_NAME] = NULL; \
-                    } \
-                    break; \
-                } \
-            }
+            VAR_TYPE* VAR_NAME = NULL
+        #define WC_ALLOC_VAR(VAR_NAME, VAR_TYPE, VAR_SIZE, HEAP)        \
+            do {                                                        \
+                VAR_NAME = (VAR_TYPE*)XMALLOC(sizeof(VAR_TYPE) * (VAR_SIZE), (HEAP), DYNAMIC_TYPE_WOLF_BIGINT);\
+                if (VAR_NAME == NULL) {                                 \
+                    WC_ALLOC_DO_ON_FAILURE();                           \
+                }                                                       \
+            } while (0)
+        #define WC_CALLOC_VAR(VAR_NAME, VAR_TYPE, VAR_SIZE, HEAP)        \
+            do { \
+                WC_ALLOC_VAR(VAR_NAME, VAR_TYPE, VAR_SIZE, HEAP); \
+                XMEMSET(VAR_NAME, 0, sizeof(VAR_TYPE) * (VAR_SIZE)); \
+            } while (0)
         #define WC_FREE_VAR(VAR_NAME, HEAP) \
             XFREE(VAR_NAME, (HEAP), DYNAMIC_TYPE_WOLF_BIGINT)
+        #define WC_DECLARE_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) \
+            WC_DECLARE_HEAP_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP)
+        #define WC_ALLOC_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) \
+            WC_ALLOC_HEAP_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP)
+        #define WC_CALLOC_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) \
+            WC_CALLOC_HEAP_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP)
+        #define WC_ARRAY_OK(VAR_NAME) WC_HEAP_ARRAY_OK(VAR_NAME)
         #define WC_FREE_ARRAY(VAR_NAME, VAR_ITEMS, HEAP) \
-            for (idx##VAR_NAME=0; idx##VAR_NAME<(VAR_ITEMS); idx##VAR_NAME++) { \
-                XFREE((VAR_NAME)[idx##VAR_NAME], (HEAP), DYNAMIC_TYPE_WOLF_BIGINT); \
-            }
-
-        #define WC_DECLARE_ARRAY_DYNAMIC_DEC(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) \
-            WC_DECLARE_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP)
-        #define WC_DECLARE_ARRAY_DYNAMIC_EXE(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) \
-            WC_INIT_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP)
-        #define WC_FREE_ARRAY_DYNAMIC(VAR_NAME, VAR_ITEMS, HEAP) \
-            WC_FREE_ARRAY(VAR_NAME, VAR_ITEMS, HEAP)
+            WC_FREE_HEAP_ARRAY(VAR_NAME, VAR_ITEMS, HEAP)
     #else
         #undef WC_DECLARE_VAR_IS_HEAP_ALLOC
         #define WC_DECLARE_VAR(VAR_NAME, VAR_TYPE, VAR_SIZE, HEAP) \
             VAR_TYPE VAR_NAME[VAR_SIZE]
-        #define WC_DECLARE_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) \
-            VAR_TYPE VAR_NAME[VAR_ITEMS][VAR_SIZE]
-        #define WC_INIT_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) WC_DO_NOTHING
+        #define WC_ALLOC_VAR(VAR_NAME, VAR_TYPE, VAR_SIZE, HEAP) WC_DO_NOTHING
+        #define WC_CALLOC_VAR(VAR_NAME, VAR_TYPE, VAR_SIZE, HEAP)        \
+            XMEMSET(VAR_NAME, 0, sizeof(var))
         #define WC_FREE_VAR(VAR_NAME, HEAP) WC_DO_NOTHING /* nothing to free, its stack */
+        #define WC_DECLARE_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) \
+            VAR_TYPE VAR_NAME[VAR_ITEMS][(VAR_SIZE) / sizeof(VAR_TYPE)] /* // NOLINT(bugprone-sizeof-expression) */
+        #define WC_ALLOC_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) WC_DO_NOTHING
+        #define WC_CALLOC_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) XMEMSET(VAR_NAME, 0, sizeof(VAR_NAME))
+        #define WC_ARRAY_OK(VAR_NAME) 1
         #define WC_FREE_ARRAY(VAR_NAME, VAR_ITEMS, HEAP) WC_DO_NOTHING /* nothing to free, its stack */
-
-        #define WC_DECLARE_ARRAY_DYNAMIC_DEC(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) \
-            VAR_TYPE* VAR_NAME[VAR_ITEMS]; \
-            int idx##VAR_NAME, inner_idx_##VAR_NAME
-        #define WC_DECLARE_ARRAY_DYNAMIC_EXE(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) \
-            for (idx##VAR_NAME=0; idx##VAR_NAME<(VAR_ITEMS); idx##VAR_NAME++) { \
-                (VAR_NAME)[idx##VAR_NAME] = (VAR_TYPE*)XMALLOC(VAR_SIZE, (HEAP), DYNAMIC_TYPE_TMP_BUFFER); \
-                if ((VAR_NAME)[idx##VAR_NAME] == NULL) { \
-                    for (inner_idx_##VAR_NAME = 0; inner_idx_##VAR_NAME < idx##VAR_NAME; inner_idx_##VAR_NAME++) { \
-                        XFREE((VAR_NAME)[inner_idx_##VAR_NAME], HEAP, DYNAMIC_TYPE_TMP_BUFFER); \
-                        (VAR_NAME)[inner_idx_##VAR_NAME] = NULL; \
-                    } \
-                    for (inner_idx_##VAR_NAME = idx##VAR_NAME + 1; inner_idx_##VAR_NAME < (VAR_ITEMS); inner_idx_##VAR_NAME++) { \
-                        (VAR_NAME)[inner_idx_##VAR_NAME] = NULL; \
-                    } \
-                    break; \
-                } \
-            }
-        #define WC_FREE_ARRAY_DYNAMIC(VAR_NAME, VAR_ITEMS, HEAP) \
-            for (idx##VAR_NAME=0; idx##VAR_NAME<(VAR_ITEMS); idx##VAR_NAME++) { \
-                XFREE((VAR_NAME)[idx##VAR_NAME], (HEAP), DYNAMIC_TYPE_TMP_BUFFER); \
-            }
     #endif
 
     #if defined(HAVE_FIPS) || defined(HAVE_SELFTEST)
@@ -653,9 +670,9 @@ typedef struct w64wrapper {
         #define DECLARE_ARRAY               WC_DECLARE_ARRAY
         #define FREE_VAR                    WC_FREE_VAR
         #define FREE_ARRAY                  WC_FREE_ARRAY
-        #define DECLARE_ARRAY_DYNAMIC_DEC   WC_DECLARE_ARRAY_DYNAMIC_DEC
-        #define DECLARE_ARRAY_DYNAMIC_EXE   WC_DECLARE_ARRAY_DYNAMIC_EXE
-        #define FREE_ARRAY_DYNAMIC          WC_FREE_ARRAY_DYNAMIC
+        #define DECLARE_ARRAY_DYNAMIC_DEC   WC_DECLARE_HEAP_ARRAY
+        #define DECLARE_ARRAY_DYNAMIC_EXE   WC_ALLOC_HEAP_ARRAY
+        #define FREE_ARRAY_DYNAMIC          WC_FREE_HEAP_ARRAY
     #endif /* HAVE_FIPS */
 
     #if !defined(USE_WOLF_STRTOK) && \


### PR DESCRIPTION
`wolfssl/wolfcrypt/types.h`:
* fix overallocation in `WC_DECLARE_ARRAY()` macro in the !`WOLFSSL_SMALL_STACK` path.
* rename `WC_INIT_ARRAY()` to `WC_ALLOC_ARRAY()` for clarity (it doesn't initialize any memory).
* rename `WC_DECLARE_ARRAY_DYNAMIC_DEC()`, `WC_DECLARE_ARRAY_DYNAMIC_EXE()`, and `WC_FREE_ARRAY_DYNAMIC()` to `WC_DECLARE_HEAP_ARRAY()`, `WC_ALLOC_HEAP_ARRAY()`, and `WC_FREE_HEAP_ARRAY()`, respectively, also for clarity, and refactor out the duplicate definitions.
* add `WC_ALLOC_VAR()`, and move the `XMALLOC()` in smallstack `WC_DECLARE_VAR()` into it.  smallstack `WC_DECLARE_VAR()` now initializes the pointer to `NULL`, like smallstack `WC_DECLARE_ARRAY()`, assuring all pointers are valid upon shortcircuit to cleanup for a failed allocation (see `WC_ALLOC_DO_ON_FAILURE` below).
* add a new hook `WC_ALLOC_DO_ON_FAILURE` in `WC_ALLOC_VAR()`, `WC_ALLOC_ARRAY()`, and `WC_ALLOC_HEAP_ARRAY()`, which is invoked when an allocation fails.  by default the hook is defined to `WC_DO_NOTHING` preserving the incumbent behavior.
* add basic safety to `WC_*_HEAP_ARRAY()` by recording/detecting allocation state via `idx##VAR_NAME`.
* add macros `WC_ARRAY_OK()` and `WC_HEAP_ARRAY_OK()` to test if allocation succeeded.
* add macros `WC_CALLOC_ARRAY()` and `WC_CALLOC_HEAP_ARRAY()` which zero the objects.
* add macro `WC_CALLOC_VAR()` which zeros the object.

ED448: smallstack refactor of `ge448_scalarmult_base()`.

`src/tls.c` `tests/api.c` `wolfcrypt/test/test.c`: update `WC_DECLARE_VAR()`s with now-required matching `WC_ALLOC_VAR()`s.

`wolfcrypt/benchmark/benchmark.c`:
* no functional changes in default error-free behavior.
* add definition of `WC_ALLOC_DO_ON_FAILURE()` that prints error message, sets `ret`, and does `goto exit`.
* add `BENCH_NTIMES` and `BENCH_AGREETIMES` overrideeable macros, to allow fast sanitizer runs and slow high-precision runs.
* smallstack refactor of all declarations of stack arrays of the form `foo[BENCH_MAX_PENDING], using `WC_DECLARE_ARRAY()` (35 in all).
* additional smallstack refactors, using `WC_DECLARE_VAR()`, for `bench_aesxts()`, `bench_ed448KeyGen()`, `bench_eccsi*()`, and `bench_sakke*()`.
* fixes for various unhandled error conditions around `malloc` failures.

`wolfcrypt/test/test.c`: opportunistically `const`ify several (42) `static` constants, moving them to the readonly data segment.

`linuxkm/Makefile`: if `ENABLED_LINUXKM_BENCHMARKS`, add `wolfcrypt/benchmark/benchmark.o` to `WOLFSSL_OBJ_FILES`.

`linuxkm/Kbuild`: enable FPU for `benchmark.o`, and remove enablement for `module_hooks.o`.

`linuxkm/module_hooks.c`: remove inline include of `benchmark.c`.


tested with `wolfssl-multi-test.sh ... super-quick-check all-max-func-stack-2k linuxkm-benchmarks sanitize-all-wolfcrypt-benchmark sanitize-all-wolfcrypt-benchmark-smallstack`.

`sanitize-all-wolfcrypt-benchmark` and `sanitize-all-wolfcrypt-benchmark-smallstack` are new scenarios that run `benchmark` under the sanitizer.  `all-max-func-stack-2k` is modified from `--disable-benchmark` to `--enable-benchmark`.

before fix to WC_DECLARE_ARRAY(), bench_aescbc_internal() (for example) allocated 1218816 bytes on stack, versus needed 1104 bytes.

