### PR TITLE
wc_ecc_shared_secret_ssh fix

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -25052,14 +25052,15 @@ static int test_wc_ecc_pointFns(void)
 
 
 /*
- * Testing wc_ecc_sahred_secret_ssh()
+ * Testing wc_ecc_shared_secret_ssh()
  */
 static int test_wc_ecc_shared_secret_ssh(void)
 {
     EXPECT_DECLS;
 #if defined(HAVE_ECC) && defined(HAVE_ECC_DHE) && \
     !defined(WC_NO_RNG) && !defined(WOLFSSL_ATECC508A) && \
-    !defined(WOLFSSL_ATECC608A)
+    !defined(WOLFSSL_ATECC608A) && !defined(PLUTON_CRYPTO_ECC) && \
+    !defined(WOLFSSL_CRYPTOCELL)
     ecc_key key;
     ecc_key key2;
     WC_RNG  rng;

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -2497,9 +2497,9 @@ int wolfSSL_EVP_PKEY_derive(WOLFSSL_EVP_PKEY_CTX *ctx, unsigned char *key, size_
 #endif
                 return WOLFSSL_FAILURE;
             }
-            if (wc_ecc_shared_secret_ssh((ecc_key*)ctx->pkey->ecc->internal,
-                                         (ecc_point*)ctx->peerKey->ecc->pub_key->internal,
-                                         key, &len32) != MP_OKAY) {
+            if (wc_ecc_shared_secret((ecc_key*)ctx->pkey->ecc->internal,
+                    (ecc_key*)ctx->peerKey->ecc->internal, key, &len32)
+                    != MP_OKAY) {
                 WOLFSSL_MSG("wc_ecc_shared_secret failed");
 #if defined(ECC_TIMING_RESISTANT) && !defined(HAVE_SELFTEST) \
     && (!defined(HAVE_FIPS) || \

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -28310,7 +28310,9 @@ done:
 #endif
 
 #if defined(HAVE_ECC_DHE) && !defined(WC_NO_RNG) && \
-    !defined(WOLF_CRYPTO_CB_ONLY_ECC)
+    !defined(WOLF_CRYPTO_CB_ONLY_ECC) && !defined(WOLFSSL_ATECC508A) && \
+    !defined(WOLFSSL_ATECC608A) && !defined(PLUTON_CRYPTO_ECC) && \
+    !defined(WOLFSSL_CRYPTOCELL)
 static wc_test_ret_t ecc_ssh_test(ecc_key* key, WC_RNG* rng)
 {
     wc_test_ret_t ret;

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -659,10 +659,8 @@ WOLFSSL_LOCAL
 int wc_ecc_shared_secret_gen_sync(ecc_key* private_key,
     ecc_point* point, byte* out, word32* outlen);
 
-#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
-    defined(PLUTON_CRYPTO_ECC) || defined(WOLFSSL_CRYPTOCELL)
-#define wc_ecc_shared_secret_ssh wc_ecc_shared_secret
-#else
+#if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
+    !defined(PLUTON_CRYPTO_ECC) && !defined(WOLFSSL_CRYPTOCELL)
 #define wc_ecc_shared_secret_ssh wc_ecc_shared_secret_ex /* For backwards compat */
 #endif
 


### PR DESCRIPTION
- wc_ecc_shared_secret_ssh should either be declared or not. Having two different signatures for the same function is error prone.
- Don't use wc_ecc_shared_secret_ssh in our code. Use wc_ecc_shared_secret directly.

Fixes ZD17507