### PR TITLE
Always define XREALLOC for FreeRTOS.

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1045,7 +1045,7 @@ extern void uITRON4_free(void *p) ;
                 #define XREALLOC(p, n, h, t) ((void)(h), (void)(t), realloc((p), (n)))
         /* FreeRTOS pvPortRealloc() implementation can be found here:
          * https://github.com/wolfSSL/wolfssl-freertos/pull/3/files */
-        #elif defined(USE_INTEGER_HEAP_MATH) || defined(OPENSSL_EXTRA)
+        #else
                 #define XREALLOC(p, n, h, t) ((void)(h), (void)(t), pvPortRealloc((p), (n)))
         #endif
     #endif


### PR DESCRIPTION
# Description

Fixes zd# 17269

XREALLOC is used throughout our code, so it should always be defined rather than only when USE_INTEGER_HEAP_MATH or OPENSSL_EXTRA are defined.