### PR TITLE
OCSP Date Checks

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -35934,13 +35934,11 @@ static int DecodeBasicOcspResponse(byte* source, word32* ioIndex,
     if (ret == 0) {
         word32 dataIdx = 0;
         /* Decode the response data. */
-        if (DecodeResponseData(
+        ret = DecodeResponseData(
                 GetASNItem_Addr(dataASN[OCSPBASICRESPASN_IDX_TBS_SEQ], source),
                 &dataIdx, resp,
                 GetASNItem_Length(dataASN[OCSPBASICRESPASN_IDX_TBS_SEQ], source)
-                ) < 0) {
-            ret = ASN_PARSE_E;
-        }
+                );
     }
 #ifdef WC_RSA_PSS
     if (ret == 0 && (dataASN[OCSPBASICRESPASN_IDX_SIGNATURE_PARAMS].tag != 0)) {


### PR DESCRIPTION
# Description

When calling DecodeResponseData(), no matter the return value, if it is not success, it is assigned to ASN_PARSE_E. This isn't the pattern for other branch parsing. Return the value returned. This is seen when decoding an OCSP response that is past the next-available time.
(ZD 17027)

# Testing

I set up an OCSP responder with a response lifetime of one minute. I run a client and server using a good certificate and capture the OCSP response off the wire. I export that response to a binary file. It is fed into a hand-tooled utility that decodes the response. At this point the response should be expired.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
