### PR TITLE
Add const in the list of wolfSSL_CTX_set1_groups_list() and wolfSSL_set1_groups_list()

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -24770,9 +24770,9 @@ int wolfSSL_get_peer_signature_type_nid(const WOLFSSL* ssl, int* nid)
 #ifdef HAVE_ECC
 
 #if defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES)
-static int populate_groups(int* groups, int max_count, char *list)
+static int populate_groups(int* groups, int max_count, const char *list)
 {
-    char *end;
+    const char *end;
     int count = 0;
     const WOLF_EC_NIST_NAME* nist_name;
 
@@ -24812,7 +24812,7 @@ static int populate_groups(int* groups, int max_count, char *list)
     return count;
 }
 
-int wolfSSL_CTX_set1_groups_list(WOLFSSL_CTX *ctx, char *list)
+int wolfSSL_CTX_set1_groups_list(WOLFSSL_CTX *ctx, const char *list)
 {
     int groups[WOLFSSL_MAX_GROUP_COUNT];
     int count = 0;
@@ -24829,7 +24829,7 @@ int wolfSSL_CTX_set1_groups_list(WOLFSSL_CTX *ctx, char *list)
     return wolfSSL_CTX_set1_groups(ctx, groups, count);
 }
 
-int wolfSSL_set1_groups_list(WOLFSSL *ssl, char *list)
+int wolfSSL_set1_groups_list(WOLFSSL *ssl, const char *list)
 {
     int groups[WOLFSSL_MAX_GROUP_COUNT];
     int count = 0;

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1204,8 +1204,8 @@ WOLFSSL_API int  wolfSSL_CTX_set1_groups(WOLFSSL_CTX* ctx, int* groups,
 WOLFSSL_API int  wolfSSL_set1_groups(WOLFSSL* ssl, int* groups, int count);
 
 #ifdef HAVE_ECC
-WOLFSSL_API int  wolfSSL_CTX_set1_groups_list(WOLFSSL_CTX *ctx, char *list);
-WOLFSSL_API int  wolfSSL_set1_groups_list(WOLFSSL *ssl, char *list);
+WOLFSSL_API int  wolfSSL_CTX_set1_groups_list(WOLFSSL_CTX *ctx, const char *list);
+WOLFSSL_API int  wolfSSL_set1_groups_list(WOLFSSL *ssl, const char *list);
 #endif
 #endif
 


### PR DESCRIPTION
# Description

`wolfSSL_CTX_set1_groups_list()` and `wolfSSL_set1_groups_list()` were not using `const` for the `list` parameter like `wolfSSL_CTX_set1_sigalgs_list()` and `wolfSSL_set1_sigalgs_list()` do.

# Testing

Passing a `const char*` shall work now like it works for `SSL_CTX_set1_sigalgs_list()`

```
const char *tls_sig_algs = "RSA-PSS+SHA512:RSA-PSS+SHA384:RSA+SHA512:RSA+SHA384:ECDSA+SHA512:ECDSA+SHA384";
if ((wolfssl_ret = SSL_CTX_set1_sigalgs_list(vpn_ctx->ssl_ctx, tls_sig_algs)) != SSL_SUCCESS)
{
...
}

const char *tls_groups = "P-521:P-384:P-256";
if ((wolfssl_ret = wolfSSL_CTX_set1_groups_list(vpn_ctx->ssl_ctx, tls_groups)) != SSL_SUCCESS)
{
...
}
