### PR TITLE
Fix dataASN null pointer dereference in asn.c.

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -3097,6 +3097,7 @@ static word16 TLSX_CSR_Write(CertificateStatusRequest* csr, byte* output,
 
 #ifndef NO_WOLFSSL_CLIENT
     if (isRequest) {
+        int ret = 0;
         word16 offset = 0;
         word16 length = 0;
 
@@ -3110,11 +3111,15 @@ static word16 TLSX_CSR_Write(CertificateStatusRequest* csr, byte* output,
                 offset += OPAQUE16_LEN;
 
                 /* request extensions */
-                if (csr->request.ocsp.nonceSz)
-                    length = (word16)EncodeOcspRequestExtensions(
-                                                 &csr->request.ocsp,
+                if (csr->request.ocsp.nonceSz) {
+                    ret = (int)EncodeOcspRequestExtensions(&csr->request.ocsp,
                                                  output + offset + OPAQUE16_LEN,
                                                  OCSP_NONCE_EXT_SZ);
+
+                    if (ret > 0) {
+                        length = (word16)ret;
+                    }
+                }
 
                 c16toa(length, output + offset);
                 offset += OPAQUE16_LEN + length;
@@ -3558,6 +3563,7 @@ static word16 TLSX_CSR2_Write(CertificateStatusRequestItemV2* csr2,
 
 #ifndef NO_WOLFSSL_CLIENT
     if (isRequest) {
+        int ret = 0;
         word16 offset;
         word16 length;
 
@@ -3585,11 +3591,16 @@ static word16 TLSX_CSR2_Write(CertificateStatusRequestItemV2* csr2,
                     /* request extensions */
                     length = 0;
 
-                    if (csr2->request.ocsp[0].nonceSz)
-                        length = (word16)EncodeOcspRequestExtensions(
+                    if (csr2->request.ocsp[0].nonceSz) {
+                        ret = (int)EncodeOcspRequestExtensions(
                                                  &csr2->request.ocsp[0],
                                                  output + offset + OPAQUE16_LEN,
                                                  OCSP_NONCE_EXT_SZ);
+
+                        if (ret > 0) {
+                            length = (word16)ret;
+                        }
+                    }
 
                     c16toa(length, output + offset);
                     offset += OPAQUE16_LEN + length;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -36359,18 +36359,20 @@ word32 EncodeOcspRequestExtensions(OcspRequest* req, byte* output, word32 size)
     /* Check request has nonce to write in extension. */
     if (req != NULL && req->nonceSz != 0) {
         DECL_ASNSETDATA(dataASN, ocspNonceExtASN_Length);
-        int sz;
+        int sz = 0;
 
         CALLOC_ASNSETDATA(dataASN, ocspNonceExtASN_Length, ret, req->heap);
 
-        /* Set nonce extension OID and nonce. */
-        SetASN_Buffer(&dataASN[OCSPNONCEEXTASN_IDX_EXT_OID], NonceObjId,
-                sizeof(NonceObjId));
-        SetASN_Buffer(&dataASN[OCSPNONCEEXTASN_IDX_EXT_NONCE], req->nonce,
-                (word32)req->nonceSz);
-        /* Calculate size of nonce extension. */
-        ret = SizeASN_Items(ocspNonceExtASN, dataASN, ocspNonceExtASN_Length,
-                            &sz);
+        if ((ret == 0) && (output != NULL)) {
+            /* Set nonce extension OID and nonce. */
+            SetASN_Buffer(&dataASN[OCSPNONCEEXTASN_IDX_EXT_OID], NonceObjId,
+                    sizeof(NonceObjId));
+            SetASN_Buffer(&dataASN[OCSPNONCEEXTASN_IDX_EXT_NONCE], req->nonce,
+                    (word32)req->nonceSz);
+            /* Calculate size of nonce extension. */
+            ret = SizeASN_Items(ocspNonceExtASN, dataASN,
+                                ocspNonceExtASN_Length, &sz);
+        }
         /* Check buffer big enough for encoding if supplied. */
         if ((ret == 0) && (output != NULL) && (sz > (int)size)) {
             ret = BUFFER_E;


### PR DESCRIPTION
# Description

Several issues:

- In smallstack build CALLOC_ASNSETDATA can fail and set ret=MEMORY_E. Check ret before attempting to deref null dataASN.
- Check return value of EncodeOcspRequestExtensions before attempting to assign length.
- Initialize sz = 0 to fix CI build warning.

Fixes zd#17560.

# Testing

Reproducer in ticket.