### PR TITLE
add full support to wolfcrypt tests for random.c cryptocbs

### DIFF
--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1770,21 +1770,23 @@ WC_RNG* wc_rng_new(byte* nonce, word32 nonceSz, void* heap)
 }
 
 
-WOLFSSL_ABI
-WC_RNG* wc_rng_new_ex(byte* nonce, word32 nonceSz, void* heap, int devId)
+int wc_rng_new_ex(WC_RNG **rng, byte* nonce, word32 nonceSz,
+                  void* heap, int devId)
 {
-    WC_RNG* rng;
+    int ret;
 
-    rng = (WC_RNG*)XMALLOC(sizeof(WC_RNG), heap, DYNAMIC_TYPE_RNG);
-    if (rng) {
-        int error = _InitRng(rng, nonce, nonceSz, heap, devId) != 0;
-        if (error) {
-            XFREE(rng, heap, DYNAMIC_TYPE_RNG);
-            rng = NULL;
-        }
+    *rng = (WC_RNG*)XMALLOC(sizeof(WC_RNG), heap, DYNAMIC_TYPE_RNG);
+    if (*rng == NULL) {
+        return MEMORY_E;
     }
 
-    return rng;
+    ret = _InitRng(*rng, nonce, nonceSz, heap, devId);
+    if (ret != 0) {
+        XFREE(*rng, heap, DYNAMIC_TYPE_RNG);
+        *rng = NULL;
+    }
+
+    return ret;
 }
 
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -15282,7 +15282,7 @@ static wc_test_ret_t random_rng_test(void)
     {
         byte nonce[8] = { 0 };
         /* Test dynamic RNG. */
-        rng = wc_rng_new(nonce, (word32)sizeof(nonce), HEAP_HINT);
+        rng = wc_rng_new_ex(nonce, (word32)sizeof(nonce), HEAP_HINT, devId);
         if (rng == NULL)
             return WC_TEST_RET_ENC_ERRNO;
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -15281,14 +15281,30 @@ static wc_test_ret_t random_rng_test(void)
 #if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST) && !defined(WOLFSSL_NO_MALLOC)
     {
         byte nonce[8] = { 0 };
-        /* Test dynamic RNG. */
-        rng = wc_rng_new_ex(nonce, (word32)sizeof(nonce), HEAP_HINT, devId);
+
+        /* Test dynamic RNG */
+        rng = wc_rng_new(nonce, (word32)sizeof(nonce), HEAP_HINT);
         if (rng == NULL)
             return WC_TEST_RET_ENC_ERRNO;
 
         ret = _rng_test(rng, WC_TEST_RET_ENC_NC);
-
         wc_rng_free(rng);
+        rng = NULL;
+
+        if (ret != 0)
+            return ret;
+
+        /* Test dynamic RNG using extended API */
+        ret = wc_rng_new_ex(&rng, nonce, (word32)sizeof(nonce),
+                            HEAP_HINT, devId);
+        if (ret != 0)
+            return WC_TEST_RET_ENC_EC(ret);
+
+        ret = _rng_test(rng, WC_TEST_RET_ENC_NC);
+        wc_rng_free(rng);
+
+        if (ret != 0)
+            return ret;
     }
 #endif
 

--- a/wolfssl/wolfcrypt/random.h
+++ b/wolfssl/wolfcrypt/random.h
@@ -206,6 +206,7 @@ WOLFSSL_API int wc_GenerateSeed(OS_Seed* os, byte* seed, word32 sz);
 
 
 WOLFSSL_ABI WOLFSSL_API WC_RNG* wc_rng_new(byte* nonce, word32 nonceSz, void* heap);
+WOLFSSL_ABI WOLFSSL_API WC_RNG* wc_rng_new_ex(byte* nonce, word32 nonceSz, void* heap, int devId);
 WOLFSSL_ABI WOLFSSL_API void wc_rng_free(WC_RNG* rng);
 
 

--- a/wolfssl/wolfcrypt/random.h
+++ b/wolfssl/wolfcrypt/random.h
@@ -205,8 +205,10 @@ WOLFSSL_API int wc_GenerateSeed(OS_Seed* os, byte* seed, word32 sz);
 #endif /* HAVE_WNR */
 
 
-WOLFSSL_ABI WOLFSSL_API WC_RNG* wc_rng_new(byte* nonce, word32 nonceSz, void* heap);
-WOLFSSL_ABI WOLFSSL_API WC_RNG* wc_rng_new_ex(byte* nonce, word32 nonceSz, void* heap, int devId);
+WOLFSSL_ABI WOLFSSL_API WC_RNG* wc_rng_new(byte* nonce, word32 nonceSz,
+                                           void* heap);
+WOLFSSL_API int wc_rng_new_ex(WC_RNG **rng, byte* nonce, word32 nonceSz,
+                              void* heap, int devId);
 WOLFSSL_ABI WOLFSSL_API void wc_rng_free(WC_RNG* rng);
 
 


### PR DESCRIPTION
# Description

- Adds a new `_ex` function for RNG initialization that takes a devid argument and adds return code for better error propagation
- Enables `NO_DEV_RANDOM` (e.g. bare metal) targets to use a cryptoCb for DRBG seed generation



# Testing

Unit tests pass with new additions
