### PR TITLE
add guard around public key validation on import

### DIFF
--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -1021,9 +1021,11 @@ static int wc_PKCS7_CheckPublicKeyDer(PKCS7* pkcs7, int keyOID,
 
             /* Try to decode public key and check with wc_ecc_check_key() */
             ret = wc_EccPublicKeyDecode(key, &scratch, ecc, keySz);
+        #if defined(WOLFSSL_VALIDATE_ECC_IMPORT)
             if (ret == 0) {
                 ret = wc_ecc_check_key(ecc);
             }
+        #endif
             wc_ecc_free(ecc);
 
             break;


### PR DESCRIPTION
ZD 17312

Optimization to avoid public key check on import with PKCS7 init. Reduces time to init PKCS7 struct on resource constrained devices.