### PR TITLE
Fix Coverity issues.

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -31643,7 +31643,7 @@ int wc_SetExtKeyUsageOID(Cert *cert, const char *in, word32 sz, byte idx,
         void* heap)
 {
     byte oid[MAX_OID_SZ];
-    word32 oidSz = MAX_OID_SZ;
+    word32 oidSz = CTC_MAX_EKU_OID_SZ;
 
     if (idx >= CTC_MAX_EKU_NB || sz >= CTC_MAX_EKU_OID_SZ) {
         WOLFSSL_MSG("Either idx or sz was too large");

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -31642,7 +31642,7 @@ int wc_SetExtKeyUsage(Cert *cert, const char *value)
 int wc_SetExtKeyUsageOID(Cert *cert, const char *in, word32 sz, byte idx,
         void* heap)
 {
-    byte oid[MAX_OID_SZ];
+    byte oid[CTC_MAX_EKU_OID_SZ];
     word32 oidSz = CTC_MAX_EKU_OID_SZ;
 
     if (idx >= CTC_MAX_EKU_NB || sz >= CTC_MAX_EKU_OID_SZ) {


### PR DESCRIPTION
# Description

Fix Coverity Scan issues:

- Fix wc_SetExtKeyUsageOID buffer warning: extKeyUsageOID has dimensions `extKeyUsageOID[CTC_MAX_EKU_NB][CTC_MAX_EKU_OID_SZ]`, where CTC_MAX_EKU_OID_SZ < MAX_OID_SZ.

Fixes zd#17416.
