### PR TITLE
ASN PQC: fix typo

### DIFF
--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -935,7 +935,7 @@ enum Misc_ASN {
 #ifdef HAVE_SPHINCS
     MAX_ENCODED_SIG_SZ  = 51200,
 #elif defined(HAVE_PQC)
-    MAX_ENCODED_SIG_SZ  = 5120;
+    MAX_ENCODED_SIG_SZ  = 5120,
 #elif !defined(NO_RSA)
 #ifdef WOLFSSL_HAPROXY
     MAX_ENCODED_SIG_SZ  = 1024,    /* Supports 8192 bit keys */


### PR DESCRIPTION
# Description

Replace semicolon with comma.

# Testing

./configure --disable-shared --enable-kyber=wolfssl,all
Though anything that defines HAVE_PQC will fail.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
