### PR TITLE
Move netdb.h and ioctl.h into wolfio.c

### DIFF
--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -41,6 +41,54 @@
 #include <wolfssl/error-ssl.h>
 #include <wolfssl/wolfio.h>
 
+#ifndef USE_WINDOWS_API
+    #if defined(WOLFSSL_LWIP) && !defined(WOLFSSL_APACHE_MYNEWT)
+    #elif defined(ARDUINO)
+    #elif defined(FREESCALE_MQX)
+    #elif defined(FREESCALE_KSDK_MQX)
+    #elif (defined(WOLFSSL_MDK_ARM) || defined(WOLFSSL_KEIL_TCP_NET))
+    #elif defined(WOLFSSL_CMSIS_RTOS)
+    #elif defined(WOLFSSL_CMSIS_RTOSv2)
+    #elif defined(WOLFSSL_TIRTOS)
+    #elif defined(FREERTOS_TCP)
+    #elif defined(WOLFSSL_IAR_ARM)
+    #elif defined(HAVE_NETX_BSD)
+    #elif defined(WOLFSSL_VXWORKS)
+    #elif defined(WOLFSSL_NUCLEUS_1_2)
+    #elif defined(WOLFSSL_LINUXKM)
+        /* the requisite linux/net.h is included in wc_port.h, with incompatible warnings masked out. */
+    #elif defined(WOLFSSL_ATMEL)
+    #elif defined(INTIME_RTOS)
+        #include <netdb.h>
+    #elif defined(WOLFSSL_PRCONNECT_PRO)
+        #include <netdb.h>
+        #include <sys/ioctl.h>
+    #elif defined(WOLFSSL_SGX)
+    #elif defined(WOLFSSL_APACHE_MYNEWT) && !defined(WOLFSSL_LWIP)
+    #elif defined(WOLFSSL_DEOS)
+    #elif defined(WOLFSSL_ZEPHYR)
+    #elif defined(MICROCHIP_PIC32)
+    #elif defined(HAVE_NETX)
+    #elif defined(FUSION_RTOS)
+    #elif !defined(WOLFSSL_NO_SOCK)
+        #if defined(HAVE_RTP_SYS)
+        #elif defined(EBSNET)
+        #elif defined(NETOS)
+        #elif !defined(DEVKITPRO) && !defined(WOLFSSL_PICOTCP) \
+                && !defined(WOLFSSL_CONTIKI) && !defined(WOLFSSL_WICED) \
+                && !defined(WOLFSSL_GNRC) && !defined(WOLFSSL_RIOT_OS)
+            #include <netdb.h>
+            #ifdef __PPU
+                #include <netex/errno.h>
+            #else
+                #include <sys/ioctl.h>
+            #endif
+        #endif
+    #endif
+
+#endif /* USE_WINDOWS_API */
+
+
 #if defined(HAVE_HTTP_CLIENT)
     #include <stdlib.h>   /* strtol() */
 #endif

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -120,8 +120,6 @@
         #include <errno.h>
         #include <unistd.h>
         #include <fcntl.h>
-        #include <netdb.h>
-        #include <sys/ioctl.h>
     #elif defined(WOLFSSL_SGX)
         #include <errno.h>
     #elif defined(WOLFSSL_APACHE_MYNEWT) && !defined(WOLFSSL_LWIP)
@@ -163,15 +161,9 @@
             #include <sys/socket.h>
             #include <arpa/inet.h>
             #include <netinet/in.h>
-            #ifdef HAVE_NETDB_H
-                #include <netdb.h>
-            #endif
             #ifdef __PPU
                 #include <netex/errno.h>
             #else
-                #ifdef HAVE_SYS_IOCTL_H
-                    #include <sys/ioctl.h>
-                #endif
             #endif
         #endif
     #endif


### PR DESCRIPTION
Better way to fix exclusion of netdb.h in the header files.