### PR TITLE
Guard SRTP-KDF on FIPS=v5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5064,6 +5064,12 @@ AS_CASE([$FIPS_VERSION],
         AS_IF([test "x$ENABLED_DES3" = "xno"],[ENABLED_DES3="yes"])
     ])
 
+AS_IF([test "x$ENABLED_FIPS" = "xyes" && test "x$ENABLED_ALL" = "xyes"],
+    [AC_MSG_ERROR([FIPS is incompatible with --enable-all])])
+
+AS_IF([test "x$ENABLED_FIPS" = "xyes" && test "x$ENABLED_ALL_CRYPT" = "xyes"],
+    [AC_MSG_ERROR([FIPS is incompatible with --enable-all-crypto])])
+
 AS_IF([test "x$ENABLED_FIPS" = "xyes" && test "x$thread_ls_on" = "xno" && test "$ENABLE_LINUXKM" = "no"],
     [AC_MSG_ERROR([FIPS requires Thread Local Storage])])
 

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -910,7 +910,8 @@ static const bench_alg bench_mac_opt[] = {
 /* All recognized KDF algorithm choosing command line options. */
 static const bench_alg bench_kdf_opt[] = {
     { "-kdf",                0xffffffff              },
-#ifdef WC_SRTP_KDF
+#if defined(WC_SRTP_KDF)  && \
+    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)) && !defined(HAVE_SELFTEST)
     { "-srtp-kdf",           BENCH_SRTP_KDF          },
 #endif
     { NULL, 0 }
@@ -3458,7 +3459,8 @@ static void* benchmarks_do(void* args)
     }
 #endif
 
-#ifdef WC_SRTP_KDF
+#if defined(WC_SRTP_KDF)  && \
+    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)) && !defined(HAVE_SELFTEST)
     if (bench_all || (bench_kdf_algs & BENCH_SRTP_KDF)) {
         bench_srtpkdf();
     }
@@ -8141,7 +8143,8 @@ void bench_siphash(void)
 }
 #endif
 
-#ifdef WC_SRTP_KDF
+#if defined(WC_SRTP_KDF)  && \
+    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)) && !defined(HAVE_SELFTEST)
 void bench_srtpkdf(void)
 {
     double start;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -522,7 +522,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  tls13_kdf_test(void);
 #endif
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  x963kdf_test(void);
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  hpke_test(void);
-#ifdef WC_SRTP_KDF
+#if defined(WC_SRTP_KDF)  && \
+    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)) && !defined(HAVE_SELFTEST)
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  srtpkdf_test(void);
 #endif
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  arc4_test(void);
@@ -966,6 +967,10 @@ wc_test_ret_t wolfcrypt_test(void* args)
     heap_baselineBytes = wolfCrypt_heap_peakBytes_checkpoint();
 #endif
 
+#ifdef WC_RNG_SEED_CB
+    wc_SetSeed_Cb(wc_GenerateSeed);
+#endif
+
     printf("------------------------------------------------------------------------------\n");
     printf(" wolfSSL version %s\n", LIBWOLFSSL_VERSION_STRING);
 #ifdef WOLF_CRYPTO_CB
@@ -1365,7 +1370,8 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
         TEST_PASS("HPKE     test passed!\n");
 #endif
 
-#if defined(WC_SRTP_KDF)
+#if defined(WC_SRTP_KDF)  && \
+    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)) && !defined(HAVE_SELFTEST)
     if ( (ret = srtpkdf_test()) != 0)
         TEST_FAIL("SRTP KDF test failed!\n", ret);
     else
@@ -2020,10 +2026,6 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
     #ifdef HAVE_WC_INTROSPECTION
         printf("Math: %s\n", wc_GetMathInfo());
     #endif
-
-#ifdef WC_RNG_SEED_CB
-    wc_SetSeed_Cb(wc_GenerateSeed);
-#endif
 
     #ifdef HAVE_STACK_SIZE
         StackSizeCheck(&args, wolfcrypt_test);
@@ -25471,7 +25473,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hpke_test(void)
 }
 #endif /* HAVE_HPKE && HAVE_ECC && HAVE_AESGCM */
 
-#if defined(WC_SRTP_KDF)
+#if defined(WC_SRTP_KDF)  && \
+    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)) && !defined(HAVE_SELFTEST)
 typedef struct Srtp_Kdf_Tv {
     const unsigned char* key;
     word32 keySz;


### PR DESCRIPTION
# Description

- Disallow --enable-all with FIPS
- Don't compile SRTP-KDF test & benchmark code when FIPS=v5
- In test.c, call wc_SetSeed_Cb from wolfcrypt_test instead of from main (fix for NO_MAIN_DRIVER case)


# Testing

Generic testing & FIPS Op-testing 

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
