### PR TITLE
20240301-linuxkm-leak-and-small-stack-fixes

### DIFF
--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -809,11 +809,13 @@
     /* fun fact: since linux commit 59bb47985c, kmalloc with power-of-2 size is
      * aligned to the size.
      */
-    #define WC_LINUXKM_ROUND_UP_P_OF_2(x) (                                         \
-    {                                                                               \
-        size_t _alloc_sz = (x);                                                     \
-        _alloc_sz = 1UL << ((sizeof(_alloc_sz) * 8UL) - __builtin_clzl(_alloc_sz)); \
-        _alloc_sz;                                                                  \
+    #define WC_LINUXKM_ROUND_UP_P_OF_2(x) (                                \
+    {                                                                      \
+        size_t _alloc_sz = (x);                                            \
+        if (_alloc_sz < 8192)                                              \
+          _alloc_sz = 1UL <<                                               \
+              ((sizeof(_alloc_sz) * 8UL) - __builtin_clzl(_alloc_sz - 1)); \
+        _alloc_sz;                                                         \
     })
     #ifdef HAVE_KVMALLOC
         #define malloc(size) kvmalloc_node(WC_LINUXKM_ROUND_UP_P_OF_2(size), GFP_KERNEL, NUMA_NO_NODE)


### PR DESCRIPTION
`linuxkm/linuxkm_wc_port.h`:
* fix `WC_LINUXKM_ROUND_UP_P_OF_2()` to not round up values that are already powers of 2, nor values larger than 8192.

`linuxkm/lkcapi_glue.c`:
* fix gating on `km_AesSetKeyCommon()`.
* small stack refactors of `Aes` objects in self-test routines.
* change `kmalloc`/`kfree` to `malloc`/`free` in self-test routines.
* fix error-path `return`s to `goto exit`s in self-test routines.
* fix memory leak around `large_input` in `aes_xts_128_test()`.

`wolfcrypt/benchmark/benchmark.c`:
* smallstack refactors in `bench_chacha()` and `bench_chacha20_poly1305_aead()`.
* add error handling in `bench_chacha()`.

`wolfcrypt/src/chacha20_poly1305.c`: smallstack refactor for `wc_ChaCha20Poly1305_Encrypt()` and `wc_ChaCha20Poly1305_Decrypt()`.

tested with `wolfssl-multi-test.sh ... super-quick-check '.*kmemleak.*'` bringing in new tests `linuxkm-noasm-insmod-kmemleak`, `linuxkm-aesni-insmod-kmemleak`, and `linuxkm-benchmarks-insmod-kmemleak`.
