### PR TITLE
20240304-wolfcrypttest-fixes

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6805,7 +6805,7 @@ static int ProcessBufferTryDecodeEd25519(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
                     ssl->buffers.keyType = ed25519_sa_algo;
                     ssl->buffers.keySz = *keySz;
                 }
-                else if (ctx) {
+                else {
                     ctx->privateKeyType = ed25519_sa_algo;
                     ctx->privateKeySz = *keySz;
                 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -28015,7 +28015,7 @@ static int test_wc_PKCS7_VerifySignedData_RSA(void)
         XFILE signedBundle = XBADFILE;
         int   signedBundleSz = 0;
         int   chunkSz = 1;
-        int   i, rc;
+        int   i, rc = 0;
         byte* buf = NULL;
 
         ExpectTrue((signedBundle = XFOPEN("./certs/test-stream-sign.p7b",


### PR DESCRIPTION
`wolfcrypt/test/test.c`: fix gating for `verify4` in `scrypt_test()`, and fix `-Wframe-larger-than=2048` warnings in `sha256_test()` and `sha512_test()`.

tested with `wolfssl-multi-test.sh ... super-quick-check`
