### PR TITLE
Fix leak in wolfSSL_X509_STORE_CTX_get_chain

### DIFF
--- a/src/x509_str.c
+++ b/src/x509_str.c
@@ -557,6 +557,7 @@ WOLFSSL_STACK* wolfSSL_X509_STORE_CTX_get_chain(WOLFSSL_X509_STORE_CTX* ctx)
                     }
                 }
                 else {
+                    wolfSSL_X509_free(x509);
                     WOLFSSL_MSG("Could not find CA for certificate");
                 }
             }


### PR DESCRIPTION
# Description

wolfSSL_X509_STORE_CTX_get_chain() can leak an X509 structure

Fixes zd17629

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
