### PR TITLE
Allow to enable DES3 support without the DES3 ciphers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1213,6 +1213,14 @@ if(WOLFSSL_OPENSSH OR
     override_cache(WOLFSSL_DES3 "yes")
 endif()
 
+# DES3 TLS Suites
+set(WOLFSSL_DES3_TLS_SUITES_STRING "Enable DES3 TLS cipher suites (default: disabled)")
+add_option("WOLFSSL_DES3_TLS_SUITES" ${WOLFSSL_DES3_TLS_SUITES_STRING} "no" "yes;no")
+
+if(NOT WOLFSSL_DES3_TLS_SUITES)
+    list(APPEND WOLFSSL_DEFINITIONS "-DNO_DES3_TLS_SUITES")
+endif()
+
 # ARC4
 set(WOLFSSL_ARC4_HELP_STRING "Enable ARC4 (default: disabled)")
 add_option("WOLFSSL_ARC4" ${WOLFSSL_ARC4_HELP_STRING} "no" "yes;no")

--- a/configure.ac
+++ b/configure.ac
@@ -4791,11 +4791,11 @@ then
     ENABLED_DES3="yes"
 fi
 
-# DES3 ciphers
-AC_ARG_ENABLE([des3-ciphers],
-    [AS_HELP_STRING([--enable-des3-ciphers],[Enable DES3 ciphers (default: disabled unless des3 is enabled)])],
-    [ ENABLED_DES3_CIPHERS=$enableval ],
-    [ ENABLED_DES3_CIPHERS=no ]
+# DES3 TLS suites
+AC_ARG_ENABLE([des3-tls-suites],
+    [AS_HELP_STRING([--enable-des3-tls-suites],[Enable DES3 TLS cipher suites (default: disabled)])],
+    [ ENABLED_DES3_TLS_SUITES=$enableval ],
+    [ ENABLED_DES3_TLS_SUITES=no ]
     )
 
 # ARC4
@@ -8697,12 +8697,12 @@ else
     fi
 fi
 
-if test "x$ENABLED_DES3_CIPHERS" = "xno"
+if test "x$ENABLED_DES3_TLS_SUITES" = "xno"
 then
-    AM_CFLAGS="$AM_CFLAGS -DNO_DES3_CIPHERS"
+    AM_CFLAGS="$AM_CFLAGS -DNO_DES3_TLS_SUITES"
 else
     AS_IF([test "x$ENABLED_DES3" = "xno"],
-        [AC_MSG_ERROR([DES3 ciphers require DES3])])
+        [AC_MSG_ERROR([DES3 TLS suites require DES3])])
 fi
 
 if test "$ENABLED_AESGCM" != "no"
@@ -9503,7 +9503,7 @@ echo "   * AES-EAX:                    $ENABLED_AESEAX"
 echo "   * AES Bitspliced:             $ENABLED_AESBS"
 echo "   * ARIA:                       $ENABLED_ARIA"
 echo "   * DES3:                       $ENABLED_DES3"
-echo "   * DES3_CIPHERS:               $ENABLED_DES3_CIPHERS"
+echo "   * DES3 TLS Suites:            $ENABLED_DES3_TLS_SUITES"
 echo "   * Camellia:                   $ENABLED_CAMELLIA"
 echo "   * SM4-ECB:                    $ENABLED_SM4_ECB"
 echo "   * SM4-CBC:                    $ENABLED_SM4_CBC"

--- a/configure.ac
+++ b/configure.ac
@@ -4791,6 +4791,13 @@ then
     ENABLED_DES3="yes"
 fi
 
+# DES3 ciphers
+AC_ARG_ENABLE([des3-ciphers],
+    [AS_HELP_STRING([--enable-des3-ciphers],[Enable DES3 ciphers (default: disabled unless des3 is enabled)])],
+    [ ENABLED_DES3_CIPHERS=$enableval ],
+    [ ENABLED_DES3_CIPHERS=no ]
+    )
+
 # ARC4
 if (test "$ENABLED_OPENSSH" = "yes" && test "x$ENABLED_FIPS" = "xno") || \
    test "$ENABLED_WPAS" = "yes" || test "$ENABLED_KRB" = "yes"
@@ -8690,6 +8697,14 @@ else
     fi
 fi
 
+if test "x$ENABLED_DES3_CIPHERS" = "xno"
+then
+    AM_CFLAGS="$AM_CFLAGS -DNO_DES3_CIPHERS"
+else
+    AS_IF([test "x$ENABLED_DES3" = "xno"],
+        [AC_MSG_ERROR([DES3 ciphers require DES3])])
+fi
+
 if test "$ENABLED_AESGCM" != "no"
 then
     if test "$ENABLED_AESGCM" = "word"
@@ -9488,6 +9503,7 @@ echo "   * AES-EAX:                    $ENABLED_AESEAX"
 echo "   * AES Bitspliced:             $ENABLED_AESBS"
 echo "   * ARIA:                       $ENABLED_ARIA"
 echo "   * DES3:                       $ENABLED_DES3"
+echo "   * DES3_CIPHERS:               $ENABLED_DES3_CIPHERS"
 echo "   * Camellia:                   $ENABLED_CAMELLIA"
 echo "   * SM4-ECB:                    $ENABLED_SM4_ECB"
 echo "   * SM4-CBC:                    $ENABLED_SM4_CBC"

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -343,7 +343,7 @@
         #endif
     #endif
 
-    #if !defined(NO_RSA) && !defined(NO_DES3) && !defined(NO_DES3_CIPHERS)
+    #if !defined(NO_RSA) && !defined(NO_DES3) && !defined(NO_DES3_TLS_SUITES)
         #if !defined(NO_SHA)
             #if defined(WOLFSSL_STATIC_RSA)
                 #define BUILD_SSL_RSA_WITH_3DES_EDE_CBC_SHA
@@ -500,7 +500,7 @@
             #if defined(WOLFSSL_AES_256) && defined(HAVE_AES_CBC)
                 #define BUILD_TLS_DHE_RSA_WITH_AES_256_CBC_SHA
             #endif
-            #if !defined(NO_DES3) && !defined(NO_DES3_CIPHERS)
+            #if !defined(NO_DES3) && !defined(NO_DES3_TLS_SUITES)
                 #define BUILD_TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA
             #endif
         #endif
@@ -687,7 +687,7 @@
         #endif
         #if !defined(NO_DES3) && !(defined(WSSL_HARDEN_TLS) && \
                                            WSSL_HARDEN_TLS > 112) && \
-            !defined(NO_DES3_CIPHERS)
+            !defined(NO_DES3_TLS_SUITES)
             /* 3DES offers only 112 bits of security.
              * Using guidance from section 5.6.1
              * https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57pt1r5.pdf */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -343,7 +343,7 @@
         #endif
     #endif
 
-    #if !defined(NO_RSA) && !defined(NO_DES3)
+    #if !defined(NO_RSA) && !defined(NO_DES3) && !defined(NO_DES3_CIPHERS)
         #if !defined(NO_SHA)
             #if defined(WOLFSSL_STATIC_RSA)
                 #define BUILD_SSL_RSA_WITH_3DES_EDE_CBC_SHA
@@ -500,7 +500,7 @@
             #if defined(WOLFSSL_AES_256) && defined(HAVE_AES_CBC)
                 #define BUILD_TLS_DHE_RSA_WITH_AES_256_CBC_SHA
             #endif
-            #if !defined(NO_DES3)
+            #if !defined(NO_DES3) && !defined(NO_DES3_CIPHERS)
                 #define BUILD_TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA
             #endif
         #endif
@@ -686,7 +686,8 @@
             #endif
         #endif
         #if !defined(NO_DES3) && !(defined(WSSL_HARDEN_TLS) && \
-                                           WSSL_HARDEN_TLS > 112)
+                                           WSSL_HARDEN_TLS > 112) && \
+            !defined(NO_DES3_CIPHERS)
             /* 3DES offers only 112 bits of security.
              * Using guidance from section 5.6.1
              * https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57pt1r5.pdf */


### PR DESCRIPTION
DES3 support is required to use PBES2-3DES-CBC-encoded keys but also enabling the DES3 ciphers may be undesirable. When using Privoxy it results in a "Bad" rating at sites like https://www.howsmyssl.com/ due to the Sweet32 attack.