### PR TITLE
fix for warning of no stdint.h include with uintptr_t

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1517,7 +1517,7 @@ void wolfSSL_free(WOLFSSL* ssl)
     WOLFSSL_ENTER("wolfSSL_free");
 
     if (ssl) {
-        WOLFSSL_MSG_EX("Free SSL: %p", (uintptr_t)ssl);
+        WOLFSSL_MSG_EX("Free SSL: %p", (wc_ptr_t)ssl);
         FreeSSL(ssl, ssl->ctx->heap);
     }
     else {

--- a/src/tls.c
+++ b/src/tls.c
@@ -7480,7 +7480,7 @@ static int TLSX_KeyShare_GenEccKey(WOLFSSL *ssl, KeyShareEntry* kse)
         kse->key = (byte*)XMALLOC(sizeof(ecc_key), ssl->heap, DYNAMIC_TYPE_ECC);
         if (kse->key == NULL) {
             WOLFSSL_MSG_EX("Failed to allocate %d bytes, ssl->heap: %p",
-                           (int)sizeof(ecc_key), (uintptr_t)ssl->heap);
+                           (int)sizeof(ecc_key), (wc_ptr_t)ssl->heap);
             WOLFSSL_MSG("EccTempKey Memory error!");
             return MEMORY_E;
         }


### PR DESCRIPTION
Can be reproduced with:

```
git clone --depth=1 git@github.com:microsoft/vcpkg
cd vcpkg
./bootstrap-vcpkg.sh --disableMetrics

# point to master branch
./vcpkg install --head wolfssl
```