### PR TITLE
Disable broken library

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,8 +42,9 @@ jobs:
         uses: ./.github/workflows/packaging.yml
     memcached:
         uses: ./.github/workflows/memcached.yml
-    libssh2:
-        uses: ./.github/workflows/libssh2.yml
+# TODO: Currently this test fails. Enable it once it becomes passing.        
+#    libssh2:
+#        uses: ./.github/workflows/libssh2.yml
     openssh:
         uses: ./.github/workflows/openssh.yml
 # TODO: Currently this test fails. Enable it once it becomes passing.        


### PR DESCRIPTION
The tests on the libssh2 repo are also failing for the same reason
