### PR TITLE
Ignore build file warnings for Arduino; Update examples

### DIFF
--- a/IDE/ARDUINO/README.md
+++ b/IDE/ARDUINO/README.md
@@ -129,6 +129,7 @@ rm -rf /mnt/c/workspace/wolfssl-$USER/IDE/ARDUINO/wolfSSL
 Publish wolfSSL from WSL to default Windows local library.
 
 ```bash
+cd /mnt/c/workspace/wolfssl-$USER/IDE/ARDUINO
 rm -rf /mnt/c/Users/$USER/Documents/Arduino/libraries/wolfSSL
 rm -rf /mnt/c/workspace/wolfssl-arduino/IDE/ARDUINO/wolfSSL
 ./wolfssl-arduino.sh INSTALL

--- a/IDE/ARDUINO/include.am
+++ b/IDE/ARDUINO/include.am
@@ -11,5 +11,7 @@ EXTRA_DIST+= IDE/ARDUINO/sketches/wolfssl_client/README.md
 EXTRA_DIST+= IDE/ARDUINO/sketches/wolfssl_client/wolfssl_client.ino
 EXTRA_DIST+= IDE/ARDUINO/sketches/wolfssl_server/README.md
 EXTRA_DIST+= IDE/ARDUINO/sketches/wolfssl_server/wolfssl_server.ino
+EXTRA_DIST+= IDE/ARDUINO/sketches/wolfssl_version/README.md
+EXTRA_DIST+= IDE/ARDUINO/sketches/wolfssl_version/wolfssl_version.ino
 EXTRA_DIST+= IDE/ARDUINO/wolfssl.h
 EXTRA_DIST+= IDE/ARDUINO/wolfssl-arduino.sh

--- a/IDE/ARDUINO/sketches/wolfssl_server/wolfssl_server.ino
+++ b/IDE/ARDUINO/sketches/wolfssl_server/wolfssl_server.ino
@@ -68,12 +68,12 @@ Tested with:
     /* the /workspace directory may contain a private config
      * excluded from GitHub with items such as WiFi passwords */
     #include MY_PRIVATE_CONFIG
-    const char* ssid PROGMEM = CONFIG_ESP_WIFI_SSID;
-    const char* password PROGMEM  = CONFIG_ESP_WIFI_PASSWORD;
+    static const char* ssid PROGMEM = MY_ARDUINO_WIFI_SSID;
+    static const char* password PROGMEM = MY_ARDUINO_WIFI_PASSWORD;
 #else
     /* when using WiFi capable boards: */
-    const char* ssid PROGMEM  = "your_SSID";
-    const char* password PROGMEM = "your_PASSWORD";
+    static const char* ssid PROGMEM  = "your_SSID";
+    static const char* password PROGMEM = "your_PASSWORD";
 #endif
 
 #define BROADCAST_ADDRESS "255.255.255.255"
@@ -135,7 +135,7 @@ Tested with:
 #elif defined(ARDUINO_SAMD_NANO_33_IOT)
     #define USING_WIFI
     #include <SPI.h>
-    #include <WiFiNINA.h>
+    #include <WiFiNINA.h> /* Needs Arduino WiFiNINA library installed manually */
     WiFiClient client;
     WiFiServer server(WOLFSSL_PORT);
 #elif defined(ARDUINO_ARCH_RP2040)
@@ -178,19 +178,18 @@ Tested with:
 
 
 /* we expect our IP address from DHCP */
-const int serial_baud = SERIAL_BAUD; /* local serial port to monitor */
 
-WOLFSSL_CTX* ctx = NULL;
-WOLFSSL* ssl = NULL;
-char* wc_error_message = (char*)malloc(80 + 1);
-char errBuf[80];
+static WOLFSSL_CTX* ctx = NULL;
+static WOLFSSL* ssl = NULL;
+static char* wc_error_message = (char*)malloc(80 + 1);
+static char errBuf[80];
 
 #if defined(MEMORY_STRESS_TEST)
     #define MEMORY_STRESS_ITERATIONS 100
     #define MEMORY_STRESS_BLOCK_SIZE 1024
     #define MEMORY_STRESS_INITIAL (4*1024)
-    char* memory_stress[MEMORY_STRESS_ITERATIONS]; /* typically 1K per item */
-    int mem_ctr        = 0;
+    static char* memory_stress[MEMORY_STRESS_ITERATIONS]; /* typically 1K per item */
+    static int mem_ctr        = 0;
 #endif
 
 static int EthernetSend(WOLFSSL* ssl, char* msg, int sz, void* ctx);
@@ -202,8 +201,8 @@ static int lng_index PROGMEM = 0; /* 0 = English */
     #include <malloc.h>
     extern char _end;
     extern "C" char *sbrk(int i);
-    char *ramstart=(char *)0x20070000;
-    char *ramend=(char *)0x20088000;
+    static char *ramstart=(char *)0x20070000;
+    static char *ramend=(char *)0x20088000;
 #endif
 
 /*****************************************************************************/
@@ -372,28 +371,31 @@ int setup_network(void) {
 #if defined(USING_WIFI)
     int status = WL_IDLE_STATUS;
 
-    if (WiFi.status() == WL_NO_MODULE) {
-        Serial.println("Communication with WiFi module failed!");
-        /* don't continue if no network */
-        while (true) ;
-    }
-
-    String fv = WiFi.firmwareVersion();
-    if (fv < WIFI_FIRMWARE_LATEST_VERSION) {
-        Serial.println("Please upgrade the firmware");
-    }
-
     /* The ESP8266 & ESP32 support both AP and STA. We'll use STA: */
     #if defined(ESP8266) || defined(ESP32)
         WiFi.mode(WIFI_STA);
+    #else
+        String fv;
+        if (WiFi.status() == WL_NO_MODULE) {
+            Serial.println("Communication with WiFi module failed!");
+            /* don't continue if no network */
+            while (true) ;
+        }
+
+        fv = WiFi.firmwareVersion();
+        if (fv < WIFI_FIRMWARE_LATEST_VERSION) {
+            Serial.println("Please upgrade the firmware");
+        }
     #endif
 
     Serial.print(F("Connecting to WiFi "));
     Serial.print(ssid);
+    status = WiFi.begin(ssid, password);
     while (status != WL_CONNECTED) {
-        status = WiFi.begin(ssid, password);
-        delay(5000);
+        delay(1000);
         Serial.print(F("."));
+        Serial.print(status);
+        status = WiFi.status();
     }
 
     Serial.println(F(" Connected!"));
@@ -582,9 +584,12 @@ int setup_certificates(void) {
 /*****************************************************************************/
 /*****************************************************************************/
 void setup(void) {
+    int i = 0;
     Serial.begin(SERIAL_BAUD);
-    while (!Serial) {
+    while (!Serial && (i < 10)) {
         /* wait for serial port to connect. Needed for native USB port only */
+        delay(1000);
+        i++;
     }
 
     Serial.println(F(""));
@@ -608,9 +613,9 @@ void setup(void) {
 
     setup_hardware();
 
-    setup_datetime();
-
     setup_network();
+
+    setup_datetime();
 
     setup_wolfssl();
 

--- a/IDE/ARDUINO/sketches/wolfssl_version/README.md
+++ b/IDE/ARDUINO/sketches/wolfssl_version/README.md
@@ -1,0 +1,3 @@
+# Arduino Basic Hello World
+
+This example simply compiles in wolfSSL and shows the current version number.

--- a/IDE/ARDUINO/sketches/wolfssl_version/wolfssl_version.ino
+++ b/IDE/ARDUINO/sketches/wolfssl_version/wolfssl_version.ino
@@ -1,0 +1,24 @@
+#include <Arduino.h>
+#include <wolfssl.h>
+#include <wolfssl/version.h>
+
+/* Choose a monitor serial baud rate: 9600, 14400, 19200, 57600, 74880, etc. */
+#define SERIAL_BAUD 115200
+
+/* Arduino setup */
+void setup() {
+    Serial.begin(SERIAL_BAUD);
+    while (!Serial) {
+        /* wait for serial port to connect. Needed for native USB port only */
+    }
+    Serial.println(F(""));
+    Serial.println(F(""));
+    Serial.println(F("wolfSSL setup complete!"));
+}
+
+/* Arduino main application loop. */
+void loop() {
+    Serial.print("wolfSSL Version: ");
+    Serial.println(LIBWOLFSSL_VERSION_STRING);
+    delay(60000);
+}

--- a/IDE/ARDUINO/wolfssl-arduino.sh
+++ b/IDE/ARDUINO/wolfssl-arduino.sh
@@ -29,7 +29,7 @@
 ROOT_DIR="/wolfssl"
 
 # The Arduino Version will initially have a suffix appended during fine tuning stage.
-WOLFSSL_VERSION_ARUINO_SUFFIX="-Arduino.2"
+WOLFSSL_VERSION_ARUINO_SUFFIX="-Arduino.3"
 
 # For verbose copy, set CP_CMD="-v", otherwise clear it: CP_CMD="cp"
 # Do not set to empty string, as copy will fail with this: CP_CMD=""
@@ -241,6 +241,10 @@ if [ "$THIS_DIR" = "ARDUINO" ]; then
     $CP_CMD ./sketches/wolfssl_server/wolfssl_server.ino ".${EXAMPLES_DIR}"/wolfssl_server/wolfssl_server.ino || exit 1
     $CP_CMD ./sketches/wolfssl_server/README.md          ".${EXAMPLES_DIR}"/wolfssl_server/README.md          || exit 1
 
+    echo "Copy wolfssl_server example...."
+    mkdir -p .${EXAMPLES_DIR}/wolfssl_version
+    $CP_CMD ./sketches/wolfssl_version/wolfssl_version.ino ".${EXAMPLES_DIR}"/wolfssl_version/wolfssl_version.ino || exit 1
+    $CP_CMD ./sketches/wolfssl_version/README.md           ".${EXAMPLES_DIR}"/wolfssl_version/README.md           || exit 1
 else
     echo "ERROR: You must be in the IDE/ARDUINO directory to run this script"
     exit 1
@@ -265,7 +269,7 @@ sed s/"$VERSION_PLACEHOLDER"/"$WOLFSSL_VERSION"/ "$PREPEND_FILE" > "$PREPEND_FIL
 cat "$PREPEND_FILE.tmp" ${TOP_DIR}/README.md > PREPENDED_README.md
 
 # Here we'll insert the wolfSSL version into the `library.properties.tmp` file, along with an Arduino version suffix.
-# The result should be something like version=5.6.601 (for the 1st incremental version on top of 5.6.6)
+# The result should be something like version=5.6.6.Arduino.1 (for the 1st incremental version on top of 5.6.6)
 sed            s/"$VERSION_PLACEHOLDER"/"$WOLFSSL_VERSION"/                              "$PROPERTIES_FILE_TEMPLATE" > "library.properties.tmp"
 sed -i.backup  s/"$ARDUINO_VERSION_SUFFIX_PLACEHOLDER"/"$WOLFSSL_VERSION_ARUINO_SUFFIX"/ "library.properties.tmp"
 

--- a/examples/configs/user_settings_arduino.h
+++ b/examples/configs/user_settings_arduino.h
@@ -25,7 +25,12 @@
 */
 
 /* Define a macro to display user settings version in example code: */
-#define WOLFSSL_USER_SETTINGS_ID "Arduino user_settings.h v5.6.6 Rev 5"
+#define WOLFSSL_USER_SETTINGS_ID "Arduino user_settings.h v5.6.7"
+
+/* Due to limited build control, we'll ignore file warnings. */
+/* See https://github.com/arduino/arduino-cli/issues/631     */
+#undef  WOLFSSL_IGNORE_FILE_WARN
+#define WOLFSSL_IGNORE_FILE_WARN
 
 #define NO_FILESYSTEM
 #define USE_CERT_BUFFERS_2048

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -266,6 +266,11 @@
 /* #define WOLFSSL_MAXQ108X */
 
 #if defined(ARDUINO)
+    /* Due to limited build control, we'll ignore file warnings. */
+    /* See https://github.com/arduino/arduino-cli/issues/631     */
+    #undef  WOLFSSL_IGNORE_FILE_WARN
+    #define WOLFSSL_IGNORE_FILE_WARN
+
     /* we don't have the luxury of compiler options, so manually define */
     #if defined(__arm__)
         #undef  WOLFSSL_ARDUINO


### PR DESCRIPTION
# Description

Defines `WOLFSSL_IGNORE_FILE_WARN` for the Arduino platform to ignore compile-time warnings in Arduino due to build system limitations noted in https://github.com/wolfSSL/Arduino-wolfSSL/pull/1 with a root cause described in https://github.com/arduino/arduino-cli/issues/631.

Both the wolfcrypt default `settings.h` and example Arduino `user_settings.h` file have been updated.

This is a nice-to-have, but not essential update to hopefully make it into the upcoming release.

Without this update, there are warnings such as this one observed in the PlatformIO Arduino build:

```
.pio/libdeps/esp32dev/wolfssl/src/wolfcrypt/src/bio.c:35:10: warning: #warning bio.c does not need to be compiled separately from ssl.c [-Wcpp]
         #warning bio.c does not need to be compiled separately from ssl.c
          ^~~~~~~
```

The Arduino warnings (and in fact the entire log) is hidden unless otherwise turned enabled for the Arduino IDE. PlatformIO is the opposite: showing the entire compiler log by default.

* edit: I needed to refresh/rebase from upstream, so I took the opportunity to also polish existing Arduino examples as well as add a new, bare-bones `wolfssl_version.ino` example.

Fixes zd# n/a

# Testing

How did you test?

Tested in Arduino only.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
