### PR TITLE
Enable TFM mp_sqr even when HAVE_ECC disabled

### DIFF
--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -6092,13 +6092,13 @@ int mp_montgomery_setup(fp_int *a, fp_digit *rho)
 
 #endif /* HAVE_ECC || (!NO_RSA && WC_RSA_BLINDING) */
 
-#ifdef HAVE_ECC
-
 /* fast math conversion */
 int mp_sqr(fp_int *A, fp_int *B)
 {
     return fp_sqr(A, B);
 }
+
+#ifdef HAVE_ECC
 
 /* fast math conversion */
 int mp_div_2(fp_int * a, fp_int * b)

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -877,8 +877,9 @@ MP_API int mp_radix_size (mp_int * a, int radix, int *size);
 MP_API int mp_montgomery_reduce(fp_int *a, fp_int *m, fp_digit mp);
 MP_API int mp_montgomery_reduce_ex(fp_int *a, fp_int *m, fp_digit mp, int ct);
 MP_API int mp_montgomery_setup(fp_int *a, fp_digit *rho);
+MP_API int mp_sqr(fp_int *a, fp_int *b);
+
 #ifdef HAVE_ECC
-    MP_API int mp_sqr(fp_int *a, fp_int *b);
     MP_API int mp_div_2(fp_int * a, fp_int * b);
     MP_API int mp_div_2_mod_ct(mp_int *a, mp_int *b, mp_int *c);
 #endif


### PR DESCRIPTION
# Description

This may not be essential to release... however during ESP8266 testing, I realized the wolfssl_test expects to see the TFM `mp_sqr()` even when `HAVE_ECC` is not defined.

Fixes zd# n/a

# Testing

How did you test?

Not fully tested. Proposed last-minute inclusion in next release.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
