### PR TITLE
workaround for Ubuntu runner, high entropy + ASLR

### DIFF
--- a/.github/workflows/krb5.yml
+++ b/.github/workflows/krb5.yml
@@ -11,11 +11,15 @@ jobs:
     # This should be a safe limit for the tests to run.
     timeout-minutes: 5
     steps:
+      - name: workaround high-entropy ASLR
+        # not needed after either an update to llvm or runner is done
+        run: sudo sysctl vm.mmap_rnd_bits=28
+
       - name: Build wolfSSL
         uses: wolfSSL/actions-build-autotools-project@v1
         with:
           path: wolfssl
-          configure: --enable-krb CFLAGS='-fsanitize=address'
+          configure: --enable-krb CC='gcc -fsanitize=address'
           install: true
 
       - name: Upload built lib
@@ -60,6 +64,10 @@ jobs:
         working-directory: ./krb5
         run: |
           patch -p1 < $GITHUB_WORKSPACE/osp/krb5/Patch-for-Kerberos-5-${{ matrix.ref }}.patch
+
+      - name: workaround high-entropy ASLR
+        # not needed after either an update to llvm or runner is done
+        run: sudo sysctl vm.mmap_rnd_bits=28
 
       - name: Build krb5
         working-directory: ./krb5/src

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -174,6 +174,10 @@ jobs:
         run: |
           echo "nginx_c_flags=-O0" >> $GITHUB_ENV
 
+      - name: workaround high-entropy ASLR
+        # not needed after either an update to llvm or runner is done
+        run: sudo sysctl vm.mmap_rnd_bits=28
+
       - name: Build nginx with sanitizer
         working-directory: nginx
         run: |

--- a/.github/workflows/openvpn.yml
+++ b/.github/workflows/openvpn.yml
@@ -50,10 +50,14 @@ jobs:
                      linux-libc-dev man2html libcmocka-dev python3-docutils \
                      libtool automake autoconf libnl-genl-3-dev libnl-genl-3-200
 
+      - name: workaround high-entropy ASLR
+        # not needed after either an update to llvm or runner is done
+        run: sudo sysctl vm.mmap_rnd_bits=28
+
       - if: ${{ matrix.ref != 'master' }}
         name: Build and test openvpn with fsanitize
         run: |
-          echo 'extra_c_flags=CFLAGS="-fsanitize=address -fno-omit-frame-pointer -O2"' >> $GITHUB_ENV
+          echo 'extra_c_flags=CC="gcc -fsanitize=address" CFLAGS="-fno-omit-frame-pointer -O2"' >> $GITHUB_ENV
 
       - name: Build and test openvpn
         uses: wolfSSL/actions-build-autotools-project@v1


### PR DESCRIPTION
Checked --enable-openvpn benchmark from v5.6.6-stable to master and did not see any obvious performance degradation in crypto operations.