### PR TITLE
Fix for PSK callback with OPENSSL_EXTRA to correctly handle the 0 length

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -13364,7 +13364,7 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
                         MAX_PSK_ID_LEN, ssl->arrays->psk_key, MAX_PSK_KEY_LEN);
                 }
                 if (
-                #ifndef OPENSSL_EXTRA
+                #ifdef OPENSSL_EXTRA
                     /* OpenSSL treats a PSK key length of 0
                      * to indicate no PSK available.
                      */
@@ -13372,7 +13372,9 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
                 #endif
                          (ssl->arrays->psk_keySz > MAX_PSK_KEY_LEN &&
                      (int)ssl->arrays->psk_keySz != USE_HW_PSK)) {
+                #ifndef OPENSSL_EXTRA
                     ret = PSK_KEY_ERROR;
+                #endif
                 }
                 else {
                     ssl->arrays->client_identity[MAX_PSK_ID_LEN] = '\0';


### PR DESCRIPTION
# Description

Fix for PSK callback with OPENSSL_EXTRA to correctly handle the 0 length case. Thank you @miyazakh. 
Broken in #7302

Hide: "I am seeing Qt Jenkins failure from couple days ago. I have dig into it. It starts after the PR7302 got merged. Qt uses PSK call back and it returns 0 if there is suitable data unavailable. In the case, it's TLS extensions didn’t have PSK extension, and it went TLS handshake. Now, it tries to set PSK extension when returning 0 from call back, and then becomes failure due to no available PSK when building PSK extension.

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
