### PR TITLE
revert null check in wc_Sha256Update

### DIFF
--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -617,7 +617,7 @@ static int InitSha256(wc_Sha256* sha256)
     {
         int ret = 0;
 
-        if (sha224 == NULL || (data == NULL && len > 0)) {
+        if (sha256 == NULL || (data == NULL && len > 0)) {
             return BAD_FUNC_ARG;
         }
 


### PR DESCRIPTION
Suspect this was a typo or merge rebase issue? Saw it when looking over recent changes.