### PR TITLE
20240315-pq-experimental

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -102,6 +102,18 @@ else
     REPRODUCIBLE_BUILD_DEFAULT=no
 fi
 
+# Allow experimental settings
+AC_ARG_ENABLE([experimental],
+    [AS_HELP_STRING([--enable-experimental],[Allow experimental settings in the configuration (default: disabled)])],
+    [ ENABLED_EXPERIMENTAL=$enableval ],
+    [ ENABLED_EXPERIMENTAL=no ]
+    )
+if test "$ENABLED_EXPERIMENTAL" = "yes"
+then
+    AS_IF([ test "$ENABLED_DISTRO" = "yes" && test "$ENABLED_EXPERIMENTAL" = "yes" ],[ AC_MSG_ERROR([--enable-distro and --enable-experimental are mutually exclusive.]) ])
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_EXPERIMENTAL_SETTINGS"
+    AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_EXPERIMENTAL_SETTINGS"
+fi
 
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netdb.h netinet/in.h stddef.h time.h sys/ioctl.h sys/socket.h sys/time.h errno.h sys/un.h])
 AC_CHECK_LIB([network],[socket])
@@ -1057,8 +1069,9 @@ fi
 ENABLED_LIBOQS="no"
 tryliboqsdir=""
 AC_ARG_WITH([liboqs],
-    [AS_HELP_STRING([--with-liboqs=PATH],[Path to liboqs install (default /usr/local) EXPERIMENTAL!])],
+    [AS_HELP_STRING([--with-liboqs=PATH],[Path to liboqs install (default /usr/local) (requires --enable-experimental)])],
     [
+        AS_IF([ test "$ENABLED_EXPERIMENTAL" != "yes" ],[ AC_MSG_ERROR([LIBOQS requires --enable-experimental.]) ])
         AC_MSG_CHECKING([for liboqs])
         LIBS="$LIBS -loqs"
 
@@ -1105,7 +1118,7 @@ AC_ARG_WITH([liboqs],
 #  - SHA3, Shake128 and Shake256, or
 #  - SHA256, SHA512, AES-CTR
 AC_ARG_ENABLE([kyber],
-    [AS_HELP_STRING([--enable-kyber],[Enable KYBER (default: disabled)])],
+    [AS_HELP_STRING([--enable-kyber],[Enable KYBER (requires --enable-experimental) (default: disabled)])],
     [ ENABLED_KYBER=$enableval ],
     [ ENABLED_KYBER=no ]
     )
@@ -1141,6 +1154,7 @@ done
 
 if test "$ENABLED_KYBER" != "no"
 then
+    AS_IF([ test "$ENABLED_EXPERIMENTAL" != "yes" ],[ AC_MSG_ERROR([KYBER requires --enable-experimental.]) ])
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_HAVE_KYBER"
     # Use liboqs if specified.
     if test "$ENABLED_LIBOQS" = "no"; then
@@ -1220,8 +1234,9 @@ fi
 ENABLED_LIBXMSS="no"
 trylibxmssdir=""
 AC_ARG_WITH([libxmss],
-    [AS_HELP_STRING([--with-libxmss=PATH],[PATH to xmss-reference root dir. EXPERIMENTAL!])],
+    [AS_HELP_STRING([--with-libxmss=PATH],[PATH to xmss-reference root dir. (requires --enable-experimental)!])],
     [
+        AS_IF([ test "$ENABLED_EXPERIMENTAL" != "yes" ],[ AC_MSG_ERROR([libxmss requires --enable-experimental.]) ])
         AC_MSG_CHECKING([for libxmss])
 
         trylibxmssdir=$withval
@@ -1318,8 +1333,9 @@ fi
 ENABLED_LIBLMS="no"
 tryliblmsdir=""
 AC_ARG_WITH([liblms],
-    [AS_HELP_STRING([--with-liblms=PATH],[PATH to hash-sigs LMS/HSS install (default /usr/local) EXPERIMENTAL!])],
+    [AS_HELP_STRING([--with-liblms=PATH],[PATH to hash-sigs LMS/HSS install (default /usr/local) (requires --enable-experimental)!])],
     [
+        AS_IF([ test "$ENABLED_EXPERIMENTAL" != "yes" ],[ AC_MSG_ERROR([liblms requires --enable-experimental.]) ])
         AC_MSG_CHECKING([for liblms])
 
         AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <hss.h>]], [[ param_set_t lm_type; param_set_t lm_ots_type; hss_get_public_key_len(4, &lm_type, &lm_ots_type); ]])], [ liblms_linked=yes ],[ liblms_linked=no ])
@@ -8185,10 +8201,12 @@ AC_ARG_ENABLE([sys-ca-certs],
     )
 
 AC_ARG_ENABLE([dual-alg-certs],
-    [AS_HELP_STRING([--enable-dual-alg-certs],[Enable support for dual key/signature certificates in TLS 1.3 as defined in X9.146 (default: disabled)])],
+    [AS_HELP_STRING([--enable-dual-alg-certs],[Enable support for dual key/signature certificates in TLS 1.3 as defined in X9.146 (requires --enable-experimental) (default: disabled)])],
     [ ENABLED_DUAL_ALG_CERTS=$enableval ],
     [ ENABLED_DUAL_ALG_CERTS=no ]
     )
+
+AS_IF([ test "$ENABLED_DUAL_ALG_CERTS" != "no" && test "$ENABLED_EXPERIMENTAL" != "yes" ],[ AC_MSG_ERROR([dual-alg-certs requires --enable-experimental.]) ])
 
 # check if should run the trusted peer certs test
 # (for now checking both C_FLAGS and C_EXTRA_FLAGS)
@@ -9430,6 +9448,12 @@ echo "   * SIMD+FPU enable as flags:   $ASFLAGS_FPUSIMD_ENABLE" && \
 echo "   * Linux kernel module PIE:    $ENABLED_LINUXKM_PIE"
 echo "   * Linux kernel module bench:  $ENABLED_LINUXKM_BENCHMARKS"
 
+if test "$ENABLED_EXPERIMENTAL" = "yes"
+then
+    echo "   * Experimental settings:      Allowed"
+else
+    echo "   * Experimental settings:      Forbidden"
+fi
 echo "   * Debug enabled:              $ax_enable_debug"
 echo "   * Coverage enabled:           $ax_enable_coverage"
 echo "   * Warnings as failure:        $ac_cv_warnings_as_errors"

--- a/tests/api.c
+++ b/tests/api.c
@@ -54328,7 +54328,7 @@ static int test_tls13_apis(void)
 #endif
 #if (!defined(NO_ECC256)  || defined(HAVE_ALL_CURVES)) && ECC_MIN_KEY_SZ <= 256
             "P-256"
-#ifdef HAVE_PQC
+#if defined(HAVE_PQC) && defined(HAVE_LIBOQS)
             ":P256_KYBER_LEVEL1"
 #endif
 #endif

--- a/wolfcrypt/src/wc_kyber_poly.c
+++ b/wolfcrypt/src/wc_kyber_poly.c
@@ -1015,10 +1015,9 @@ static int kyber_xof_squeezeblocks(wc_Shake* shake128, byte* out, int blocks)
  *
  * @param  [in, out]  shake256  SHAKE-256 object.
  */
-void kyber_prf_init(wc_Shake* shake256)
+void kyber_prf_init(wc_Shake* prf)
 {
-    XMEMSET(shake256->s, 0, sizeof(shake256->s));
-
+    XMEMSET(prf->s, 0, sizeof(prf->s));
 }
 
 /* New/Initialize SHAKE-256 object.
@@ -1028,18 +1027,18 @@ void kyber_prf_init(wc_Shake* shake256)
  * @param  [in]       devId     Device id.
  * @return  0 on success always.
  */
-int kyber_prf_new(wc_Shake* shake256, void* heap, int devId)
+int kyber_prf_new(wc_Shake* prf, void* heap, int devId)
 {
-    return wc_InitShake256(shake256, heap, devId);
+    return wc_InitShake256(prf, heap, devId);
 }
 
 /* Free SHAKE-256 object.
  *
  * @param  [in, out]  shake256  SHAKE-256 object.
  */
-void kyber_prf_free(wc_Shake* shake256)
+void kyber_prf_free(wc_Shake* prf)
 {
-    wc_Shake256_Free(shake256);
+    wc_Shake256_Free(prf);
 }
 
 /* Create pseudo-random data from the key using SHAKE-256.
@@ -1340,8 +1339,8 @@ int kyber_gen_matrix(KYBER_PRF_T* prf, sword16* a, int kp, byte* seed,
  * @return  Difference of the two values with range 0..2.
  */
 #define ETA2_SUB(d, i) \
-    (((sword16)((d >> ((i) * 4 + 0)) & 0x3)) - \
-     ((sword16)((d >> ((i) * 4 + 2)) & 0x3)))
+    (((sword16)(((d) >> ((i) * 4 + 0)) & 0x3)) - \
+     ((sword16)(((d) >> ((i) * 4 + 2)) & 0x3)))
 
 /* Compute polynomial with coefficients distributed according to a centered
  * binomial distribution with parameter eta2 from uniform random bytes.
@@ -1448,8 +1447,8 @@ static void kyber_cbd_eta2(sword16* p, const byte* r)
  * @return  Difference of the two values with range 0..3.
  */
 #define ETA3_SUB(d, i) \
-    (((sword16)((d >> ((i) * 6 + 0)) & 0x7)) - \
-     ((sword16)((d >> ((i) * 6 + 3)) & 0x7)))
+    (((sword16)(((d) >> ((i) * 6 + 0)) & 0x7)) - \
+     ((sword16)(((d) >> ((i) * 6 + 3)) & 0x7)))
 
 /* Compute polynomial with coefficients distributed according to a centered
  * binomial distribution with parameter eta3 from uniform random bytes.
@@ -2041,7 +2040,7 @@ static KYBER_NOINLINE void kyber_csubq_c(sword16* p)
  * @return  Compressed value.
  */
 #define TO_COMP_WORD_10(v, i, j, k) \
-    ((((KYBER_V54 << 10) * v[i * KYBER_N + j + k]) + KYBER_V54_HALF) >> 54)
+    ((((KYBER_V54 << 10) * (v)[(i) * KYBER_N + (j) + (k)]) + KYBER_V54_HALF) >> 54)
 
 /* Compress value to 11 bits.
  *
@@ -2055,7 +2054,7 @@ static KYBER_NOINLINE void kyber_csubq_c(sword16* p)
  * @return  Compressed value.
  */
 #define TO_COMP_WORD_11(v, i, j, k) \
-    ((((KYBER_V53 << 11) * v[i * KYBER_N + j + k]) + KYBER_V53_HALF) >> 53)
+    ((((KYBER_V53 << 11) * (v)[(i) * KYBER_N + (j) + (k)]) + KYBER_V53_HALF) >> 53)
 
 #endif /* CONV_WITH_DIV */
 
@@ -2241,8 +2240,8 @@ void kyber_vec_compress_11(byte* r, sword16* v)
  * @return  Decompressed value.
  */
 #define DECOMP_10(v, i, j, k, t) \
-    v[i * KYBER_N + 4 * j + k] = \
-        (word16)((((word32)(t & 0x3ff) * KYBER_Q) + 512) >> 10)
+    v[(i) * KYBER_N + 4 * (j) + (k)] = \
+        (word16)((((word32)((t) & 0x3ff) * KYBER_Q) + 512) >> 10)
 
 /* Decompress an 11 bit value.
  *
@@ -2254,8 +2253,8 @@ void kyber_vec_compress_11(byte* r, sword16* v)
  * @return  Decompressed value.
  */
 #define DECOMP_11(v, i, j, k, t) \
-    v[i * KYBER_N + 8 * j + k] = \
-        (word16)((((word32)(t & 0x7ff) * KYBER_Q) + 1024) >> 11)
+    v[(i) * KYBER_N + 8 * (j) + (k)] = \
+        (word16)((((word32)((t) & 0x7ff) * KYBER_Q) + 1024) >> 11)
 
 #if defined(WOLFSSL_KYBER512) || defined(WOLFSSL_KYBER768)
 /* Decompress the byte array of packed 10 bits into vector of polynomials.
@@ -2474,7 +2473,7 @@ void kyber_vec_decompress_11(sword16* v, const unsigned char* b)
  * @return  Compressed value.
  */
 #define TO_COMP_WORD_4(p, i, j) \
-    ((((KYBER_V28 << 4) * p[i + j]) + KYBER_V28_HALF) >> 28)
+    ((((KYBER_V28 << 4) * (p)[(i) + (j)]) + KYBER_V28_HALF) >> 28)
 
 /* Compress value to 5 bits.
  *
@@ -2486,7 +2485,7 @@ void kyber_vec_decompress_11(sword16* v, const unsigned char* b)
  * @return  Compressed value.
  */
 #define TO_COMP_WORD_5(p, i, j) \
-    ((((KYBER_V27 << 5) * p[i + j]) + KYBER_V27_HALF) >> 27)
+    ((((KYBER_V27 << 5) * (p)[(i) + (j)]) + KYBER_V27_HALF) >> 27)
 
 #endif /* CONV_WITH_DIV */
 
@@ -2644,7 +2643,7 @@ void kyber_compress_5(byte* b, sword16* p)
  * @return  Decompressed value.
  */
 #define DECOMP_4(p, i, j, t) \
-    p[i + j] = ((word16)((t) * KYBER_Q) + 8) >> 4
+    p[(i) + (j)] = ((word16)((t) * KYBER_Q) + 8) >> 4
 
 /* Decompress a 5 bit value.
  *
@@ -2655,7 +2654,7 @@ void kyber_compress_5(byte* b, sword16* p)
  * @return  Decompressed value.
  */
 #define DECOMP_5(p, i, j, t) \
-    p[i + j] = (((word32)((t) & 0x1f) * KYBER_Q) + 16) >> 5
+    p[(i) + (j)] = (((word32)((t) & 0x1f) * KYBER_Q) + 16) >> 5
 
 #if defined(WOLFSSL_KYBER512) || defined(WOLFSSL_KYBER768)
 /* Decompress the byte array of packed 4 bits into polynomial.
@@ -2781,7 +2780,7 @@ void kyber_decompress_5(sword16* p, const unsigned char* b)
  * @param  [in]   j    Index of bit in byte.
  */
 #define FROM_MSG_BIT(p, msg, i, j) \
-    p[8 * i + j] = ((sword16)0 - (sword16)((msg[i] >> j) & 1)) & KYBER_Q_1_HALF
+    p[8 * (i) + (j)] = ((sword16)0 - (sword16)(((msg)[i] >> (j)) & 1)) & KYBER_Q_1_HALF
 
 /* Convert message to polynomial.
  *
@@ -2864,7 +2863,7 @@ void kyber_from_msg(sword16* p, const byte* msg)
  * @param  [in]   j   Index of bit in byte.
  */
 #define TO_MSG_BIT(m, p, i, j) \
-    m[i] |= ((word32)((KYBER_V31_2 * p[8 * i + j]) + KYBER_V31_HALF) >> 31) << j
+    (m)[i] |= ((word32)((KYBER_V31_2 * (p)[8 * (i) + (j)]) + KYBER_V31_HALF) >> 31) << (j)
 
 #endif /* CONV_WITH_DIV */
 

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3262,6 +3262,15 @@ extern void uITRON4_free(void *p) ;
 #define WOLFSSL_NO_KYBER1024
 #endif
 
+#if (defined(HAVE_LIBOQS) ||                                            \
+     defined(WOLFSSL_WC_KYBER) ||                                       \
+     defined(HAVE_LIBXMSS) ||                                           \
+     defined(HAVE_LIBLMS) ||                                            \
+     defined(WOLFSSL_DUAL_ALG_CERTS)) &&                                \
+    !defined(WOLFSSL_EXPERIMENTAL_SETTINGS)
+    #error Experimental settings without WOLFSSL_EXPERIMENTAL_SETTINGS
+#endif
+
 #if defined(HAVE_PQC) && !defined(HAVE_LIBOQS) && !defined(HAVE_PQM4) && \
     !defined(WOLFSSL_HAVE_KYBER)
 #error Please do not define HAVE_PQC yourself.

--- a/wolfssl/wolfcrypt/wc_kyber.h
+++ b/wolfssl/wolfcrypt/wc_kyber.h
@@ -112,7 +112,7 @@ struct KyberKey {
     void* heap;
 #if defined(WOLF_CRYPTO_CB)
     /* Device Id. */
-    int* devId;
+    int devId;
 #endif
     /* Flags indicating what is stored in the key. */
     int flags;


### PR DESCRIPTION
`configure.ac` and `wolfssl/wolfcrypt/settings.h`:
* implement `--enable-experimental`
* add a `WOLFSSL_EXPERIMENTAL_SETTINGS` gate
* refactor "EXPERIMENTAL" features (all pq) to note and enforce requirement for `--enable-experimental` and `WOLFSSL_EXPERIMENTAL_SETTINGS`.

Kyber fixes:
* `wolfssl/wolfcrypt/wc_kyber.h`: in definition of `struct KyberKey`, use correct type for `devId`;

`wolfcrypt/src/wc_kyber_poly.c`: numerous fixes for `bugprone-macro-parentheses` and `readability-inconsistent-declaration-parameter-name`;

`tests/api.c`: in `test_tls13_apis()`, add missing `defined(HAVE_LIBOQS)` gate on inclusion of ":P256_KYBER_LEVEL1" in `groupList`.


tested with `wolfssl-multi-test.sh ... --patterns-match-optional-scenarios super-quick-check 'pq-all-.*' '.*kyber.*'`.

all selected tests are passing, including new `kyber-all-gcc-latest kyber-all-clang-tidy kyber-all-sanitizer kyber-all-crypto-only-sanitizer kyber-all-cppcheck kyber-cross-aarch64-all-armasm-unittest-sanitizer sanitize-all-wolfcrypt-kyber-benchmark`, except one `SEGV` on `kyber-all-clang-sanitizer` which is best to ignore for now.

Note that native `'.*lms-wolfssl.*'` tests are also all passing via the private overlay, not retested here but good to know.
