### PR TITLE
Regression test fixes

### DIFF
--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -6183,6 +6183,9 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
                             contentDynamic = (byte*)XMALLOC(contentSz,
                                                pkcs7->heap, DYNAMIC_TYPE_PKCS7);
                             if (contentDynamic == NULL) {
+                            #ifndef NO_PKCS7_STREAM
+                                pkcs7->stream = stream;
+                            #endif
                                 ret = MEMORY_E;
                                 break;
                             }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -44891,7 +44891,7 @@ static wc_test_ret_t pkcs7signed_run_SingleShotVectors(
 
             /* encode Signed Encrypted Compressed FirmwarePkgData */
             encodedSz = wc_PKCS7_EncodeSignedEncryptedCompressedFPD(pkcs7,
-                    testVectors[i].encryptKey, testVectors[i].encryptKeySz,
+                    (byte*)testVectors[i].encryptKey, testVectors[i].encryptKeySz,
                     testVectors[i].privateKey, testVectors[i].privateKeySz,
                     testVectors[i].encryptOID, testVectors[i].signOID,
                     testVectors[i].hashOID, (byte*)testVectors[i].content,
@@ -45000,7 +45000,7 @@ static wc_test_ret_t pkcs7signed_run_SingleShotVectors(
             XMEMSET(encryptedTmp, 0, encryptedTmpSz);
 
             /* decrypt inner encryptedData */
-            pkcs7->encryptionKey = testVectors[i].encryptKey;
+            pkcs7->encryptionKey = (byte*)testVectors[i].encryptKey;
             pkcs7->encryptionKeySz = testVectors[i].encryptKeySz;
 
             encryptedTmpSz = wc_PKCS7_DecodeEncryptedData(pkcs7, pkcs7->content,


### PR DESCRIPTION
# Description

pkcs7.c: pkcs7->stream must be restored or there will be a leak.
test.c: when compiled for compression, compiler warning about const

# Testing

Regression testing
./configure '--disable-shared' '--enable-all' '--enable-blake2' 'CFLAGS=-DWOLFSSL_TEST_PLATFORMDEPEND -DTEST_RESEED_INTERVAL -DWOLFSSL_SMALL_CERT_VERIFY -DWOLFSSL_CUSTOM_OID -DWOLFSSL_PUBLIC_MP' '--enable-debug' '--enable-secure-renegotiation' '--enable-sessionexport' '--enable-rc2' '--enable-dtls13' '--with-libz=/usr/lib' '

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
