### PR TITLE
OCSP Extension Encoding Fix

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -36642,7 +36642,7 @@ word32 EncodeOcspRequestExtensions(OcspRequest* req, byte* output, word32 size)
 
         CALLOC_ASNSETDATA(dataASN, ocspNonceExtASN_Length, ret, req->heap);
 
-        if ((ret == 0) && (output != NULL)) {
+        if (ret == 0) {
             /* Set nonce extension OID and nonce. */
             SetASN_Buffer(&dataASN[OCSPNONCEEXTASN_IDX_EXT_OID], NonceObjId,
                     sizeof(NonceObjId));


### PR DESCRIPTION
# Description

Removed redundant check for the output being NULL in `EncodeOcspRequestExtensions()`. The chuck of code being protected only cared about the value of ret, not the pointer. The code was supposed to calculate the size of the data without writing it.

Found doing some wolfSSH testing.

# Testing

I was using the certificates in my test CA repository. I have some certificates set up for wolfSSH X.509 testing. The server certificate used with wolfSSL by itself also shows the issue.

wolfSSL configuration:

    ./configure --enable-ocsp && make clean && make

Running the servers from the certificate directory:

    openssl ocsp -port 12345 -ndays 1000 -index demoCA/index.txt -rsigner demoCA/cacert.pem -rkey demoCA/private/cakey.pem -CA demoCA/cacert.pem
    openssl s_server -port 11111 -cert ultraviolet-cert.pem -key shared-key.pem

Run the client:

    ./examples/client/client -A ../test-ca/demoCA/cacert.pem -o

The client will fail with "Invalid OCSP Status" error.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
