### PR TITLE
fix incorrect buffer size check

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -41672,7 +41672,7 @@ static int myOriEncryptCb(PKCS7* pkcs7, byte* cek, word32 cekSz, byte* oriType,
     int i;
 
     /* make sure buffers are large enough */
-    if ((*oriValueSz < (2 + cekSz)) || (*oriTypeSz < sizeof(oriType)))
+    if ((*oriValueSz < (2 + cekSz)) || (*oriTypeSz < sizeof(asnDataOid)))
         return WC_TEST_RET_ENC_NC;
 
     /* our simple encryption algorithm will be take the bitwise complement */


### PR DESCRIPTION

# Description

Fix incorrect buffer size check in wolfcrypt/test/test.c
The length of oriType should be at least sizeof(asnDataOid) because of the XMEMCPY on line 41687.

# Testing

N/A
# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
