### PR TITLE
fix wc_MakeRsaKey and wc_RsaKeyToDer to work with WOLFSSL_NO_MALLOC

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,4 +52,5 @@ jobs:
 #        uses: ./.github/workflows/haproxy.yml
     ocsp:
         uses: ./.github/workflows/ocsp.yml
-
+    no-malloc:
+        uses: ./.github/workflows/no-malloc.yml

--- a/.github/workflows/no-malloc.yml
+++ b/.github/workflows/no-malloc.yml
@@ -22,6 +22,7 @@ jobs:
 
       - name: Test wolfSSL
         run: |
+          ./autogen.sh
           ./configure ${{ matrix.config }}
           make check
 

--- a/.github/workflows/no-malloc.yml
+++ b/.github/workflows/no-malloc.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           ./autogen.sh
           ./configure ${{ matrix.config }}
+          make
           ./wolfcrypt/test/testwolfcrypt
 
       - name: Print errors 

--- a/.github/workflows/no-malloc.yml
+++ b/.github/workflows/no-malloc.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           ./autogen.sh
           ./configure ${{ matrix.config }}
-          make check
+          ./wolfcrypt/test/testwolfcrypt
 
       - name: Print errors 
         if: ${{ failure() }}

--- a/.github/workflows/no-malloc.yml
+++ b/.github/workflows/no-malloc.yml
@@ -9,8 +9,7 @@ jobs:
       matrix:
         config: [
           # Add new configs here
-          '--enable-rsa --enable-keygen --disable-dh',
-          'CFLAGS="-DWOLFSSL_NO_MALLOC"',
+          '--enable-rsa --enable-keygen --disable-dh CFLAGS="-DWOLFSSL_NO_MALLOC"',
         ]
     name: make check
     runs-on: ubuntu-latest

--- a/.github/workflows/no-malloc.yml
+++ b/.github/workflows/no-malloc.yml
@@ -10,7 +10,7 @@ jobs:
         config: [
           # Add new configs here
           '--enable-rsa --enable-keygen --disable-dh',
-          'CFLAGS=-DWOLFSSL_NO_MALLOC',
+          'CFLAGS="-DWOLFSSL_NO_MALLOC"',
         ]
     name: make check
     runs-on: ubuntu-latest

--- a/.github/workflows/no-malloc.yml
+++ b/.github/workflows/no-malloc.yml
@@ -1,0 +1,33 @@
+name: No Malloc Tests
+
+on:
+  workflow_call:
+
+jobs:
+  make_check:
+    strategy:
+      matrix:
+        config: [
+          # Add new configs here
+          '--enable-rsa --enable-keygen --disable-dh',
+          'CFLAGS=-DWOLFSSL_NO_MALLOC',
+        ]
+    name: make check
+    runs-on: ubuntu-latest
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 6
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout wolfSSL
+
+      - name: Test wolfSSL
+        run: |
+          ./configure ${{ matrix.config }}
+          make check
+
+      - name: Print errors 
+        if: ${{ failure() }}
+        run: |
+          if [ -f test-suite.log ] ; then
+            cat test-suite.log
+          fi

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -25938,13 +25938,13 @@ int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen)
 #ifndef WOLFSSL_ASN_TEMPLATE
     int ret = 0, i;
     int mpSz;
-    word32 rawLen;
     word32 seqSz = 0, verSz = 0, intTotalLen = 0, outLen = 0;
     word32 sizes[RSA_INTS];
     byte  seq[MAX_SEQ_SZ];
     byte  ver[MAX_VERSION_SZ];
     mp_int* keyInt;
 #ifndef WOLFSSL_NO_MALLOC
+    word32 rawLen;
     byte* tmps[RSA_INTS];
 #endif
 
@@ -25965,9 +25965,9 @@ int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen)
         ret = mp_unsigned_bin_size(keyInt);
         if (ret < 0)
             break;
+#ifndef WOLFSSL_NO_MALLOC
         rawLen = (word32)ret + 1;
         ret = 0;
-#ifndef WOLFSSL_NO_MALLOC
         if (output != NULL) {
             tmps[i] = (byte*)XMALLOC(rawLen + MAX_SEQ_SZ, key->heap,
                                  DYNAMIC_TYPE_RSA);
@@ -25978,6 +25978,7 @@ int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen)
         }
         mpSz = SetASNIntMP(keyInt, MAX_RSA_INT_SZ, tmps[i]);
 #else
+        ret = 0;
         mpSz = SetASNIntMP(keyInt, MAX_RSA_INT_SZ, NULL);
 #endif
         if (mpSz < 0) {

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -26018,9 +26018,8 @@ int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen)
 #else
             keyInt = GetRsaInt(key, i);
             ret = mp_unsigned_bin_size(keyInt);
-            if (ret < 0) {
-                return ret;
-            }
+            if (ret < 0)
+                break;
             ret = 0;
             /* This won't overrun output due to the outLen check above */
             mpSz = SetASNIntMP(keyInt, MAX_RSA_INT_SZ, output + j);

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -25938,7 +25938,7 @@ int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen)
 #ifndef WOLFSSL_ASN_TEMPLATE
     int ret = 0, i;
     int mpSz;
-        word32 rawLen;
+    word32 rawLen;
     word32 seqSz = 0, verSz = 0, intTotalLen = 0, outLen = 0;
     word32 sizes[RSA_INTS];
     byte  seq[MAX_SEQ_SZ];
@@ -25966,7 +25966,7 @@ int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen)
             /* free outstanding tmps */
             for (i = 0; i < RSA_INTS; i++) {
                 if (tmps[i] != NULL)
-                    XFREE(tmps[i]);
+                    XFREE(tmps[i], key->heap, DYNAMIC_TYPE_RSA);
             }
 #endif
             return ret;
@@ -26020,19 +26020,19 @@ int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen)
             XMEMCPY(output + j, tmps[i], sizes[i]);
             j += sizes[i];
 #else
-        keyInt = GetRsaInt(key, i);
-        ret = mp_unsigned_bin_size(keyInt);
-        if (ret < 0) {
-            return ret;
-        }
-        rawLen = (word32)ret + 1;
-        ret = 0;
-        mpSz = SetASNIntMP(keyInt, MAX_RSA_INT_SZ, output + j);
-        if (mpSz < 0) {
-            ret = mpSz;
-            break;
-        }
-        j += mpSz;
+            keyInt = GetRsaInt(key, i);
+            ret = mp_unsigned_bin_size(keyInt);
+            if (ret < 0) {
+                return ret;
+            }
+            rawLen = (word32)ret + 1;
+            ret = 0;
+            mpSz = SetASNIntMP(keyInt, MAX_RSA_INT_SZ, output + j);
+            if (mpSz < 0) {
+                ret = mpSz;
+                break;
+            }
+            j += mpSz;
 #endif
         }
     }

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -4724,6 +4724,7 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
 #ifndef WOLFSSL_NO_MALLOC
     byte* buf = NULL;
 #else
+    /* RSA_MAX_SIZE is the size of n in bits. */
     byte buf[RSA_MAX_SIZE/16];
 #endif
 #endif /* !WOLFSSL_CRYPTOCELL && !WOLFSSL_SE050 */
@@ -4946,6 +4947,8 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
         ForceZero(buf, primeSz);
         XFREE(buf, key->heap, DYNAMIC_TYPE_RSA);
     }
+#else
+        ForceZero(buf, primeSz);
 #endif
 
     if (err == MP_OKAY && mp_cmp(p, q) < 0) {

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -4721,7 +4721,11 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
 #endif /* WOLFSSL_SMALL_STACK */
     int i, failCount, isPrime = 0;
     word32 primeSz;
+#ifndef WOLFSSL_NO_MALLOC
     byte* buf = NULL;
+#else
+    byte buf[RSA_MAX_SIZE/16];
+#endif
 #endif /* !WOLFSSL_CRYPTOCELL && !WOLFSSL_SE050 */
     int err;
 
@@ -4827,12 +4831,14 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
     primeSz = (word32)size / 16; /* size is the size of n in bits.
                             primeSz is in bytes. */
 
+#ifndef WOLFSSL_NO_MALLOC
     /* allocate buffer to work with */
     if (err == MP_OKAY) {
         buf = (byte*)XMALLOC(primeSz, key->heap, DYNAMIC_TYPE_RSA);
         if (buf == NULL)
             err = MEMORY_E;
     }
+#endif
 
     SAVE_VECTOR_REGISTERS(err = _svr_ret;);
 
@@ -4935,10 +4941,12 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
     if (err == MP_OKAY && !isPrime)
         err = PRIME_GEN_E;
 
+#ifndef WOLFSSL_NO_MALLOC
     if (buf) {
         ForceZero(buf, primeSz);
         XFREE(buf, key->heap, DYNAMIC_TYPE_RSA);
     }
+#endif
 
     if (err == MP_OKAY && mp_cmp(p, q) < 0) {
         err = mp_copy(p, tmp1);

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -4948,7 +4948,7 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
         XFREE(buf, key->heap, DYNAMIC_TYPE_RSA);
     }
 #else
-        ForceZero(buf, primeSz);
+    ForceZero(buf, primeSz);
 #endif
 
     if (err == MP_OKAY && mp_cmp(p, q) < 0) {

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -2128,7 +2128,7 @@ static wc_test_ret_t _SaveDerAndPem(const byte* der, int derSz,
     #ifndef WOLFSSL_NO_MALLOC
         byte* pem;
     #else
-        byte pem[FOURK_BUF];
+        byte pem[1024];
     #endif
         int pemSz;
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -18999,7 +18999,7 @@ static wc_test_ret_t rsa_keygen_test(WC_RNG* rng)
 #ifndef WOLFSSL_NO_MALLOC
     byte*  der = NULL;
 #else
-    byte der[FOURK_BUF];
+    byte der[1024];
 #endif
 #ifndef WOLFSSL_CRYPTOCELL
     word32 idx = 0;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -2125,7 +2125,11 @@ static wc_test_ret_t _SaveDerAndPem(const byte* der, int derSz,
     #if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
         XFILE pemFile;
     #endif
+    #ifndef WOLFSSL_NO_MALLOC
         byte* pem;
+    #else
+        byte pem[FOURK_BUF];
+    #endif
         int pemSz;
 
         /* calculate PEM size */
@@ -2133,10 +2137,15 @@ static wc_test_ret_t _SaveDerAndPem(const byte* der, int derSz,
         if (pemSz < 0) {
             return WC_TEST_RET_ENC(calling_line, 2, WC_TEST_RET_TAG_I);
         }
+    #ifndef WOLFSSL_NO_MALLOC
         pem = (byte*)XMALLOC(pemSz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         if (pem == NULL) {
             return WC_TEST_RET_ENC(calling_line, 3, WC_TEST_RET_TAG_I);
         }
+    #else
+        if (pemSz > (int)sizeof(pem))
+            return BAD_FUNC_ARG;
+    #endif
         /* Convert to PEM */
         pemSz = wc_DerToPem(der, derSz, pem, pemSz, pemType);
         if (pemSz < 0) {
@@ -18987,7 +18996,11 @@ static wc_test_ret_t rsa_keygen_test(WC_RNG* rng)
     RsaKey genKey[1];
 #endif
     wc_test_ret_t ret;
+#ifndef WOLFSSL_NO_MALLOC
     byte*  der = NULL;
+#else
+    byte der[FOURK_BUF];
+#endif
 #ifndef WOLFSSL_CRYPTOCELL
     word32 idx = 0;
 #endif
@@ -19032,11 +19045,12 @@ static wc_test_ret_t rsa_keygen_test(WC_RNG* rng)
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
 #endif
+#ifndef WOLFSSL_NO_MALLOC
     der = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     if (der == NULL) {
         ERROR_OUT(WC_TEST_RET_ENC_ERRNO, exit_rsa);
     }
-
+#endif
     derSz = wc_RsaKeyToDer(genKey, der, FOURK_BUF);
     if (derSz < 0) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(derSz), exit_rsa);
@@ -19072,10 +19086,12 @@ exit_rsa:
     wc_FreeRsaKey(genKey);
 #endif
 
+#ifndef WOLFSSL_NO_MALLOC
     if (der != NULL) {
         XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         der = NULL;
     }
+#endif
 
     return ret;
 }


### PR DESCRIPTION
# Description

wc_MakeRsaKey and wc_RsaKeyToDer bother required XMALLOC to work however wolfHSM requires these functions to work with WOLFSSL_NO_MALLOC so this PR adds support.

# Testing

Tested with wolfHSM

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
