### PR TITLE
Initialize some Kyber variables

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -8437,7 +8437,7 @@ static int TLSX_KeyShare_ProcessPqc(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
         XMEMCPY(ssl->arrays->preMasterSecret, keyShareEntry->ke,
                 keyShareEntry->keLen);
         ssl->arrays->preMasterSz = keyShareEntry->keLen;
-        XFREE(keyShareEntry->ke, ssl->heap, DYNAMIC_TYPE_SECRET)
+        XFREE(keyShareEntry->ke, ssl->heap, DYNAMIC_TYPE_SECRET);
         keyShareEntry->ke = NULL;
         keyShareEntry->keLen = 0;
         return 0;

--- a/wolfcrypt/src/wc_kyber.c
+++ b/wolfcrypt/src/wc_kyber.c
@@ -364,12 +364,12 @@ static int kyberkey_encapsulate(KyberKey* key, const byte* msg, byte* coins,
     unsigned char* ct)
 {
     int ret = 0;
-    sword16* sp;
-    sword16* ep;
-    sword16* k;
-    sword16* epp;
-    unsigned int kp;
-    unsigned int compVecSz;
+    sword16* sp = NULL;
+    sword16* ep = NULL;
+    sword16* k = NULL;
+    sword16* epp = NULL;
+    unsigned int kp = 0;
+    unsigned int compVecSz = 0;
 #ifndef USE_INTEL_SPEEDUP
     sword16* at = NULL;
 #else
@@ -636,7 +636,7 @@ static KYBER_NOINLINE int kyberkey_decapsulate(KyberKey* key,
     int ret = 0;
     sword16* v;
     sword16* mp;
-    unsigned int kp;
+    unsigned int kp = 0;
     unsigned int compVecSz;
 #ifndef USE_INTEL_SPEEDUP
     sword16* bp = NULL;
@@ -741,7 +741,7 @@ int wc_KyberKey_Decapsulate(KyberKey* key, unsigned char* ss,
     byte msg[2 * KYBER_SYM_SZ];
     byte kr[2 * KYBER_SYM_SZ + 1];
     int ret = 0;
-    unsigned int ctSz;
+    unsigned int ctSz = 0;
     unsigned int i;
     int fail;
 #ifndef USE_INTEL_SPEEDUP


### PR DESCRIPTION
# Description

While looking into possibly testing Kyber on the Espressif ESP-IDF environment, I ran into a few compile time warnings. This PR fixes them. 

Fixes zd# n/a

# Testing

How did you test?

I have not been able to test this. 

I'm only as far as partial compile success, pending final [liboqs](https://github.com/open-quantum-safe/liboqs) integration as an Espressif component.

Currently my [liboqs/Espressif-dev branch](https://github.com/gojimmypi/liboqs/tree/Espressif-dev) is installed to [wolfssl_test](https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/wolfssl_test) `wolfssl_test/components/liboqs`.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
