### PR TITLE
Make RsaPad/UnPad available when -DWOLFSSL_PUBLIC_MP set

### DIFF
--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -434,11 +434,11 @@ WOLFSSL_API int wc_RsaExportKey(RsaKey* key,
                                           int nlen, int* isPrime);
 #endif
 
-WOLFSSL_LOCAL int wc_RsaPad_ex(const byte* input, word32 inputLen, byte* pkcsBlock,
+MP_API int wc_RsaPad_ex(const byte* input, word32 inputLen, byte* pkcsBlock,
         word32 pkcsBlockLen, byte padValue, WC_RNG* rng, int padType,
         enum wc_HashType hType, int mgf, byte* optLabel, word32 labelLen,
         int saltLen, int bits, void* heap);
-WOLFSSL_LOCAL int wc_RsaUnPad_ex(byte* pkcsBlock, word32 pkcsBlockLen, byte** out,
+MP_API int wc_RsaUnPad_ex(byte* pkcsBlock, word32 pkcsBlockLen, byte** out,
                                    byte padValue, int padType, enum wc_HashType hType,
                                    int mgf, byte* optLabel, word32 labelLen, int saltLen,
                                    int bits, void* heap);


### PR DESCRIPTION
# Description

Customer requested this change, being tracked under OE addition effort and was scheduled to go into master as part of OE check-in. However, FIPS cert is taking longer than anticipated, OE work is feature complete but only gets checked-in when approved by CSTL review.  The customer is eager to see this in the next release.

# Testing

N/A

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
