### PR TITLE
Support DTLS1.3 downgrade when using PSK

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -28818,6 +28818,9 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             if (!ssl->options.downgrade ||
                     ssl->options.minDowngrade <= DTLSv1_3_MINOR)
                 return VERSION_ERROR;
+
+            /* Cannot be DTLS1.3 as HELLO_VERIFY_REQUEST */
+            ssl->options.tls1_3 = 0;
         }
 #endif /* defined(WOLFSSL_DTLS13) && defined(WOLFSSL_TLS13) */
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -14914,7 +14914,8 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
     }
 
 #ifdef HAVE_EXTENDED_MASTER
-    if (IsAtLeastTLSv1_3(ssl->version) && msgType == hello_retry_request) {
+    if (IsAtLeastTLSv1_3(ssl->version) &&
+        (msgType == hello_retry_request || msgType == hello_verify_request)) {
         /* Don't change EMS status until server_hello received.
          * Second ClientHello must have same extensions.
          */

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5285,6 +5285,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             }
 
             ssl->version.minor = args->pv.minor;
+            ssl->options.tls1_3 = 0;
 
 #ifdef WOLFSSL_DTLS13
             if (ssl->options.dtls) {
@@ -5386,7 +5387,10 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         }
 
         /* Force client hello version 1.2 to work for static RSA. */
-        ssl->chVersion.minor = TLSv1_2_MINOR;
+        if (ssl->options.dtls)
+            ssl->chVersion.minor = DTLSv1_2_MINOR;
+        else
+            ssl->chVersion.minor = TLSv1_2_MINOR;
         /* Complete TLS v1.2 processing of ServerHello. */
         ret = CompleteServerHello(ssl);
 #else

--- a/tests/test-dtls13-downgrade.conf
+++ b/tests/test-dtls13-downgrade.conf
@@ -41,3 +41,16 @@
 -7 2
 -u
 -l TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+
+# server DTLSv1.2 - PSK
+-v 3
+-u
+-s
+-l ECDHE-PSK-AES128-GCM-SHA256
+
+# client DTLS PSK multiversion, allow downgrade
+-vd
+-7 2
+-u
+-s
+-l ECDHE-PSK-AES128-GCM-SHA256

--- a/tests/test-tls13-down.conf
+++ b/tests/test-tls13-down.conf
@@ -108,3 +108,14 @@
 # client TLSv 1.2
 -v 3
 -H exitWithRet
+
+# server TLSv1.2 - PSK
+-v 3
+-s
+-l ECDHE-PSK-AES128-GCM-SHA256
+
+# client TLS PSK multiversion, allow downgrade
+-v d
+-7 3
+-s
+-l ECDHE-PSK-AES128-GCM-SHA256


### PR DESCRIPTION

# Description

Support checking for DTLS1.2 Hello Verify Request when using PSK.

Unset options.tls1_3 when handling a DTLS1.2 Hello Verify Request.

Unset options.tls1_3 when handling a DTLS1.2 Server Hello to stop checking of Encrypted Client Hello

Requires ./configure --enable-all --enable-dtls13

# Testing

Server:
examples/server/server -v3 -u -s

Client
examples/client/client -vd -g -u -s

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
