### PR TITLE
20240327-tls-int-overflows

### DIFF
--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -430,6 +430,9 @@ typedef struct w64wrapper {
 
     #define XELEM_CNT(x) (sizeof((x))/sizeof(*(x)))
 
+    #define WC_SAFE_SUM_WORD32(in1, in2, out) ((in2) <= 0xffffffffU - (in1) ? \
+                ((out) = (in1) + (in2), 1) : ((out) = 0xffffffffU, 0))
+
     /* idea to add global alloc override by Moises Guimaraes  */
     /* default to libc stuff */
     /* XREALLOC is used once in normal math lib, not in fast math lib */


### PR DESCRIPTION
`src/internal.c`: mitigations for potential integer overflows in figuring allocation sizes.

tested with `wolfssl-multi-test.sh ... super-quick-check`

see ZD#17733
