### PR TITLE
Initialize some Kyber client variables

### DIFF
--- a/wolfcrypt/src/wc_kyber.c
+++ b/wolfcrypt/src/wc_kyber.c
@@ -203,7 +203,7 @@ int wc_KyberKey_MakeKeyWithRandom(KyberKey* key, const unsigned char* rand,
     byte* pubSeed = buf;
     byte* noiseSeed = buf + KYBER_SYM_SZ;
     sword16* a = NULL;
-    sword16* e;
+    sword16* e = NULL;
     int ret = 0;
     int kp = 0;
 
@@ -528,7 +528,7 @@ int wc_KyberKey_EncapsulateWithRandom(KyberKey* key, unsigned char* ct,
     byte msg[2 * KYBER_SYM_SZ];
     byte kr[2 * KYBER_SYM_SZ + 1];
     int ret = 0;
-    unsigned int ctSz;
+    unsigned int ctSz = 0;
 
     /* Validate parameters. */
     if ((key == NULL) || (ct == NULL) || (ss == NULL) || (rand == NULL)) {
@@ -742,8 +742,8 @@ int wc_KyberKey_Decapsulate(KyberKey* key, unsigned char* ss,
     byte kr[2 * KYBER_SYM_SZ + 1];
     int ret = 0;
     unsigned int ctSz = 0;
-    unsigned int i;
-    int fail;
+    unsigned int i = 0;
+    int fail = 0;
 #ifndef USE_INTEL_SPEEDUP
     byte* cmp = NULL;
 #else


### PR DESCRIPTION
# Description


Similar to https://github.com/wolfSSL/wolfssl/pull/7364 this PR initializes some Kyber variables, this time encountered as TLS client.

These warnings surfaced when implementing a Kyber client test on the ESP8266:

```
C:/workspace/wolfssl-gojimmypi-pr/wolfcrypt/src/wc_kyber.c: In function 'wc_KyberKey_MakeKeyWithRandom':
C:/workspace/wolfssl-gojimmypi-pr/wolfcrypt/src/wc_kyber.c:273:15: error: 'e' may be used uninitialized in this function [-Werror=maybe-uninitialized]
         ret = kyber_get_noise(&key->prf, kp, key->priv, e, NULL, noiseSeed);
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:/workspace/wolfssl-gojimmypi-pr/wolfcrypt/src/wc_kyber.c: In function 'wc_KyberKey_Decapsulate':
C:/workspace/wolfssl-gojimmypi-pr/wolfcrypt/src/wc_kyber.c:822:42: error: 'fail' may be used uninitialized in this function [-Werror=maybe-uninitialized]
             kr[i] ^= (kr[i] ^ key->z[i]) & fail;
                      ~~~~~~~~~~~~~~~~~~~~^~~~~~
C:/workspace/wolfssl-gojimmypi-pr/wolfcrypt/src/wc_kyber.c: In function 'wc_KyberKey_EncapsulateWithRandom':
C:/workspace/wolfssl-gojimmypi-pr/wolfcrypt/src/wc_kyber.c:50:33: error: 'ctSz' may be used uninitialized in this function [-Werror=maybe-uninitialized]
 #define KYBER_HASH_H            wc_Sha3_256Hash
                                 ^~~~~~~~~~~~~~~
C:/workspace/wolfssl-gojimmypi-pr/wolfcrypt/src/wc_kyber.c:531:18: note: 'ctSz' was declared here
     unsigned int ctSz;
                  ^~~~
cc1.exe: some warnings being treated as errors
```

Fixes zd# n/a

# Testing

How did you test?

Tested with command-line Linux apps talking to ESP32 Server. ESP8266 client _appears_ to be working, but I have not yet been able to inspect with WireShark.


Enable Kyber in `user_settings.h`:

```
#define WOLFSSL_EXPERIMENTAL_SETTINGS
#define WOLFSSL_HAVE_KYBER
#define WOLFSSL_WC_KYBER
#define WOLFSSL_SHA3
```

or from command-line:

```
./configure --enable-kyber=all --enable-experimental
```

Talk to ESP32 Server from Linux client:

```
./examples/client/client -h 192.168.1.38 -v 4 \
                         -l TLS_AES_128_GCM_SHA256 \
                         --pqc KYBER_LEVEL5
```

Listen from Linux Server:

```
./examples/server/server -v 4 \
                         -l TLS_AES_128_GCM_SHA256 
                         --pqc KYBER_LEVEL5
```

Blog coming soon.


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
