### PR TITLE
20240328-multi-test-fixes

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -14429,7 +14429,7 @@ int wolfSSL_GetSessionFromCache(WOLFSSL* ssl, WOLFSSL_SESSION* output)
             XFREE(preallocNonce, output->heap, DYNAMIC_TYPE_SESSION_TICK);
             preallocNonce = NULL;
 #else
-            output->ticketNonce.data = XREALLOC(preallocNonce,
+            output->ticketNonce.data = (byte*)XREALLOC(preallocNonce,
                 preallocNonceLen, output->heap, DYNAMIC_TYPE_SESSION_TICK);
             if (output->ticketNonce.data != NULL) {
                 /* don't free the reallocated pointer */


### PR DESCRIPTION
`src/ssl.c`: add missing cast in `wolfSSL_GetSessionFromCache()`.

tested with `../testing/git-hooks/wolfssl-multi-test.sh --enable-bwrap --enable-git-blame -j 24 --keep-going --max-check-try-count=3 --no-result-cache --verbose-analyzers --enable-text-styles --patterns-match-optional-scenarios --test-uncommitted all-g\\+\\+ clang-tidy-all-sp-all all-c89-clang-tidy all-g\\+\\+-gnu17 pq-all-clang-tidy all-c\\+\\+17 all-g\\+\\+-6.5.0-no-asm clang-tidy-asn-template-sp-all-small-stack all-WOLFSSL_CALLBACKS-clang-tidy clang-tidy-all-intelasm clang-tidy-all-async-quic clang-tidy-fips-140-3-all clang-tidy-fips-140-3-pilot-all clang-tidy-fips-140-3-dev-all linuxkm-legacy-5.4-insmod`
