### PR TITLE
configure.ac: Add in --enable-rpk option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -868,6 +868,7 @@ then
     test "$enable_earlydata" = "" && enable_earlydata=yes
     test "$enable_ech" = "" && enable_ech=yes
     test "$enable_srtp" = "" && enable_srtp=yes
+    test "$enable_rpk" = "" && enable_rpk=yes
 
     if test "$ENABLED_LINUXKM_DEFAULTS" != "yes"
     then
@@ -8451,6 +8452,13 @@ AC_ARG_ENABLE([dual-alg-certs],
 
 AS_IF([ test "$ENABLED_DUAL_ALG_CERTS" != "no" && test "$ENABLED_EXPERIMENTAL" != "yes" ],[ AC_MSG_ERROR([dual-alg-certs requires --enable-experimental.]) ])
 
+# Adds functionality to support Raw Public Key (RPK) RFC7250
+AC_ARG_ENABLE([rpk],
+    [AS_HELP_STRING([--enable-rpk],[Enable support for Raw Public Key (RPK) RFC7250 (default: disabled)])],
+    [ ENABLED_RPK=$enableval ],
+    [ ENABLED_RPK=no ]
+    )
+
 # check if should run the trusted peer certs test
 # (for now checking both C_FLAGS and C_EXTRA_FLAGS)
 AS_CASE(["$CFLAGS $CPPFLAGS"],[*'WOLFSSL_TRUST_PEER_CERT'*],[ENABLED_TRUSTED_PEER_CERT=yes])
@@ -8818,6 +8826,9 @@ AS_IF([test "x$ENABLED_SYS_CA_CERTS" = "xyes"],
 
 AS_IF([test "x$ENABLED_DUAL_ALG_CERTS" = "xyes"],
       [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DUAL_ALG_CERTS"])
+
+AS_IF([test "x$ENABLED_RPK" = "xyes"],
+      [AM_CFLAGS="$AM_CFLAGS -DHAVE_RPK"])
 
 AS_IF([test "x$ENABLED_ALTNAMES" = "xyes"],
       [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALT_NAMES"])
@@ -9883,6 +9894,7 @@ echo "   * TLS v1.0 (Old):             $ENABLED_TLSV10"
 echo "   * TLS v1.1 (Old):             $ENABLED_OLD_TLS"
 echo "   * TLS v1.2:                   $ENABLED_TLSV12"
 echo "   * TLS v1.3:                   $ENABLED_TLS13"
+echo "   * RPK:                        $ENABLED_RPK"
 echo "   * Post-handshake Auth:        $ENABLED_TLS13_POST_AUTH"
 echo "   * Early Data:                 $ENABLED_TLS13_EARLY_DATA"
 echo "   * QUIC:                       $ENABLED_QUIC"

--- a/tests/api.c
+++ b/tests/api.c
@@ -68186,6 +68186,9 @@ static int test_tls13_rpk_handshake(void)
     int typeCnt_c;
     int typeCnt_s;
     int tp;
+#if defined(WOLFSSL_ALWAYS_VERIFY_CB)
+    int isServer;
+#endif
 
     (void)err;
     (void)typeCnt_c;
@@ -68805,7 +68808,7 @@ static int test_tls13_rpk_handshake(void)
                                                         WOLFSSL_SUCCESS);
 
     /* set certificate verify callback to both client and server */
-    int isServer = 0;
+    isServer = 0;
     wolfSSL_SetCertCbCtx(ssl_c, &isServer);
     wolfSSL_set_verify(ssl_c, SSL_VERIFY_PEER, MyRpkVerifyCb);
 


### PR DESCRIPTION

# Description

By default RPK (RFC7250) support is not enabled, but is enabled when
--enable-rpk, --enable-all or --enable-dist is used.

Makes use of the HAVE_RPK compile time option.

Note: should not be merged until  after #7375 is merged.

# Testing

Checking that the CFLAGS -DHAVE_RPK option is created when --enable-rpk, --enable-all or --enable-dist options are used, but not set otherwise.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
