### PR TITLE
make "yes;no" cmake options boolean instead of string

### DIFF
--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -1,7 +1,7 @@
 function(override_cache VAR VAL)
     get_property(VAR_STRINGS CACHE ${VAR} PROPERTY STRINGS)
     LIST(FIND VAR_STRINGS ${VAL} CK)
-    if(-1 EQUAL ${CK})
+    if(-1 EQUAL ${CK} AND DEFINED VAR_STRINGS)
         message(SEND_ERROR
             "\"${VAL}\" is not valid override value for \"${VAR}\"."
             " Please select value from \"${VAR_STRINGS}\"\n")
@@ -10,10 +10,15 @@ function(override_cache VAR VAL)
 endfunction()
 
 function(add_option NAME HELP_STRING DEFAULT VALUES)
-    # Set the default value for the option.
-    set(${NAME} ${DEFAULT} CACHE STRING ${HELP_STRING})
-    # Set the list of allowed values for the option.
-    set_property(CACHE ${NAME} PROPERTY STRINGS ${VALUES})
+    if(VALUES STREQUAL "yes;no")
+        # Set the default value for the option.
+        set(${NAME} ${DEFAULT} CACHE BOOL ${HELP_STRING})
+    else()
+        # Set the default value for the option.
+        set(${NAME} ${DEFAULT} CACHE STRING ${HELP_STRING})
+        # Set the list of allowed values for the option.
+        set_property(CACHE ${NAME} PROPERTY STRINGS ${VALUES})
+    endif()
 
     if(DEFINED ${NAME})
         list(FIND VALUES ${${NAME}} IDX)


### PR DESCRIPTION
# Description

Please describe the scope of the fix or feature addition.

Fixes https://github.com/wolfSSL/wolfssl/issues/5438

`add_option` in `functions.cmake` always produces variables of type string even for boolean options. I fixed it to produce boolean variables for options that only allow "yes;no".