### PR TITLE
Restore `HAVE_NETDB_H` and `HAVE_SYS_IOCTL_H` checks in the wolfio.c.

### DIFF
--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -78,11 +78,15 @@
             #elif !defined(DEVKITPRO) && !defined(WOLFSSL_PICOTCP) \
                     && !defined(WOLFSSL_CONTIKI) && !defined(WOLFSSL_WICED) \
                     && !defined(WOLFSSL_GNRC) && !defined(WOLFSSL_RIOT_OS)
-                #include <netdb.h>
+                #ifdef HAVE_NETDB_H
+                    #include <netdb.h>
+                #endif
                 #ifdef __PPU
                     #include <netex/errno.h>
                 #else
-                    #include <sys/ioctl.h>
+                    #ifdef HAVE_SYS_IOCTL_H
+                        #include <sys/ioctl.h>
+                    #endif
                 #endif
             #endif
         #endif


### PR DESCRIPTION
# Description

Restore `HAVE_NETDB_H` and `HAVE_SYS_IOCTL_H` checks in the wolfio.c.

Added in https://github.com/wolfSSL/wolfssl/pull/7072/files/3c6651e1e2c88e4f5cc7c68e7ce124c70dd50f1f#diff-afe610cf6326ddbd817e8749cbd0b9eb29ed2a3a3d366856badf12df457c8062R172
Removed in https://github.com/wolfSSL/wolfssl/pull/7288/files/897a8419c10fbe7ea3d0ce32fbcb6a9b3b9c367f#diff-afe610cf6326ddbd817e8749cbd0b9eb29ed2a3a3d366856badf12df457c8062L166

Tagging: @farazrbx 

# Testing



# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
