### PR TITLE
Fix build error with RECORD_SIZE defined

### DIFF
--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1560,7 +1560,6 @@ enum Misc {
 #endif
     SIZEOF_SENDER   =  4,       /* clnt or srvr           */
     FINISHED_SZ     = 36,       /* WC_MD5_DIGEST_SIZE + WC_SHA_DIGEST_SIZE */
-    MAX_RECORD_SIZE = 16384,    /* 2^14, max size by standard */
     MAX_PLAINTEXT_SZ   = (1 << 14),        /* Max plaintext sz   */
     MAX_TLS_CIPHER_SZ  = (1 << 14) + 2048, /* Max TLS encrypted data sz */
 #ifdef WOLFSSL_TLS13
@@ -2273,6 +2272,8 @@ enum {
 
 
 /* determine maximum record size */
+#define MAX_RECORD_SIZE 16384  /* 2^14, max size by standard */
+
 #ifdef RECORD_SIZE
     /* user supplied value */
     #if RECORD_SIZE < 128 || RECORD_SIZE > MAX_RECORD_SIZE


### PR DESCRIPTION
# Description

`MAX_RECORD_SIZE` is defined in an enum, which would have a value of 0 during preprocessing. So if `RECORD_SIZE` is user defined, then the check `RECORD_SIZE > MAX_RECORD_SIZE` produces errors:

```
In file included from wolfcrypt/src/asn.c:200:
./wolfssl/internal.h:2278:44: error: "MAX_RECORD_SIZE" is not defined, evaluates to 0 [-Werror=undef]
 2278 |     #if RECORD_SIZE < 128 || RECORD_SIZE > MAX_RECORD_SIZE
      |                                            ^~~~~~~~~~~~~~~
./wolfssl/internal.h:2279:10: error: #error Invalid record size
 2279 |         #error Invalid record size
      |          ^~~~~
  CC       wolfcrypt/src/src_libwolfssl_la-chacha.lo
  CC       wolfcrypt/src/src_libwolfssl_la-chacha20_poly1305.lo
cc1: all warnings being treated as errors
```

Fixes zd17763

# Testing

`./configure CFLAGS="-DRECORD_SIZE=1024" && make`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
