### PR TITLE
Adjust wc_xmss and wc_lms settings to support wolfboot.

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3312,7 +3312,8 @@ extern void uITRON4_free(void *p) ;
 
 /* (D)TLS v1.3 requires 64-bit number wrappers as does XMSS and LMS. */
 #if defined(WOLFSSL_TLS13) || defined(WOLFSSL_DTLS_DROP_STATS) || \
-    defined(WOLFSSL_WC_XMSS) || defined(WOLFSSL_WC_LMS)
+    (defined(WOLFSSL_WC_XMSS) && (!defined(WOLFSSL_XMSS_MAX_HEIGHT) || \
+    WOLFSSL_XMSS_MAX_HEIGHT > 32)) || defined(WOLFSSL_WC_LMS)
     #undef WOLFSSL_W64_WRAPPER
     #define WOLFSSL_W64_WRAPPER
 #endif

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3313,13 +3313,14 @@ extern void uITRON4_free(void *p) ;
 /* (D)TLS v1.3 requires 64-bit number wrappers as does XMSS and LMS. */
 #if defined(WOLFSSL_TLS13) || defined(WOLFSSL_DTLS_DROP_STATS) || \
     (defined(WOLFSSL_WC_XMSS) && (!defined(WOLFSSL_XMSS_MAX_HEIGHT) || \
-    WOLFSSL_XMSS_MAX_HEIGHT > 32)) || defined(WOLFSSL_WC_LMS)
+    WOLFSSL_XMSS_MAX_HEIGHT > 32)) || (defined(WOLFSSL_WC_LMS) && \
+    !defined(WOLFSSL_LMS_VERIFY_ONLY))
     #undef WOLFSSL_W64_WRAPPER
     #define WOLFSSL_W64_WRAPPER
 #endif
 
-/* wc_xmss_impl requires these misc.c functions. */
-#ifdef WOLFSSL_WC_XMSS
+/* wc_xmss and wc_lms require these misc.c functions. */
+#if defined(WOLFSSL_WC_XMSS) || defined(WOLFSSL_WC_LMS)
     #undef  WOLFSSL_NO_INT_ENCODE
     #undef  WOLFSSL_NO_INT_DECODE
 #endif

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3318,6 +3318,12 @@ extern void uITRON4_free(void *p) ;
     #define WOLFSSL_W64_WRAPPER
 #endif
 
+/* wc_xmss_impl requires these misc.c functions. */
+#ifdef WOLFSSL_WC_XMSS
+    #undef  WOLFSSL_NO_INT_ENCODE
+    #undef  WOLFSSL_NO_INT_DECODE
+#endif
+
 /* DTLS v1.3 requires AES ECB if using AES */
 #if defined(WOLFSSL_DTLS13) && !defined(NO_AES) && \
     !defined(WOLFSSL_AES_DIRECT)


### PR DESCRIPTION
# Description
- Don't define WOLFSSL_W64_WRAPPER if WOLFSSL_XMSS_MAX_HEIGHT<=32, or if WOLFSSL_LMS_VERIFY_ONLY.
- Include int decode/encode functions for WOLFSSL_WC_XMSS or WOLFSSL_WC_LMS build. NO_ASN was gating out c32toa(), ato24(), etc.

# Testing
Tested with wolfBoot with wc_xmss, ext_xmss, wc_lms, and ext_lms.


