### PR TITLE
Add null check to wolfSSL_Free

### DIFF
--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -1141,6 +1141,10 @@ void wolfSSL_Free(void *ptr, void* heap, int type)
             #endif
             }
             mem = hint->memory;
+            if (mem == NULL) {
+                WOLFSSL_MSG("Bad hint pointer to memory");
+                return;
+            }
 
             /* get memory struct and add it to available list */
             pt = (wc_Memory*)((byte*)ptr - sizeof(wc_Memory) - padSz);


### PR DESCRIPTION
# Description

If wolfSSL_Free() determines that the ‘heap’ argument is not NULL, it goes on to the ‘else’ statement of memory.c, where it executes the following: 'wc_LockMutex(&(mem->memory_mutex)’ without checking whether ‘mem’ (AKA hint->memory) is NULL.

Fixes zd17779

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
