### PR TITLE
20240403-RPK-cleanups

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -12454,7 +12454,8 @@ void CopyDecodedName(WOLFSSL_X509_NAME* name, DecodedCert* dCert, int nameType)
         name->sz = (int)XSTRLEN(name->name) + 1;
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(HAVE_LIGHTY)
         name->rawLen = min(dCert->subjectRawLen, ASN_NAME_MAX);
-        XMEMCPY(name->raw, dCert->subjectRaw, name->rawLen);
+        if (name->rawLen > 0)
+            XMEMCPY(name->raw, dCert->subjectRaw, name->rawLen);
 #endif
     }
     else {
@@ -12464,7 +12465,7 @@ void CopyDecodedName(WOLFSSL_X509_NAME* name, DecodedCert* dCert, int nameType)
 #if (defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(HAVE_LIGHTY)) \
     && (defined(HAVE_PKCS7) || defined(WOLFSSL_CERT_EXT))
         name->rawLen = min(dCert->issuerRawLen, ASN_NAME_MAX);
-        if (name->rawLen) {
+        if (name->rawLen > 0) {
             XMEMCPY(name->raw, dCert->issuerRaw, name->rawLen);
         }
 #endif

--- a/src/tls.c
+++ b/src/tls.c
@@ -11212,8 +11212,10 @@ static int TLSX_ClientCertificateType_GetSize(WOLFSSL* ssl, byte msgType)
         ret = (int)(OPAQUE8_LEN + cnt * OPAQUE8_LEN);
     }
     else if (msgType == server_hello || msgType == encrypted_extensions) {
-        /* sever side */
+        /* server side */
         cnt = ssl->options.rpkState.sending_ClientCertTypeCnt;/* must be one */
+        if (cnt != 1)
+            return SANITY_MSG_E;
         ret = OPAQUE8_LEN;
     }
     else {

--- a/tests/api.c
+++ b/tests/api.c
@@ -67498,7 +67498,7 @@ static int test_tls13_rpk_handshake(void)
     certType_s[1] = WOLFSSL_CERT_TYPE_X509;
     typeCnt_s = 2;
 
-    /*  both clien and server do not call client/server_cert_type APIs,
+    /*  both client and server do not call client/server_cert_type APIs,
      *  expecting default settings works and no negotiation performed.
      */
 
@@ -67519,6 +67519,9 @@ static int test_tls13_rpk_handshake(void)
     ExpectIntEQ(wolfSSL_get_negotiated_server_cert_type(ssl_s, &tp),
                                                             WOLFSSL_SUCCESS);
     ExpectIntEQ(tp, WOLFSSL_CERT_TYPE_UNKNOWN);
+
+    (void)typeCnt_c;
+    (void)typeCnt_s;
 
     wolfSSL_free(ssl_c);
     wolfSSL_CTX_free(ctx_c);
@@ -67551,7 +67554,7 @@ static int test_tls13_rpk_handshake(void)
     certType_s[1] = WOLFSSL_CERT_TYPE_X509;
     typeCnt_s = 2;
 
-    /*  both clien and server do not call client/server_cert_type APIs,
+    /*  both client and server do not call client/server_cert_type APIs,
      *  expecting default settings works and no negotiation performed.
      */
 
@@ -67574,6 +67577,9 @@ static int test_tls13_rpk_handshake(void)
     ExpectIntEQ(wolfSSL_get_negotiated_server_cert_type(ssl_s, &tp),
                                                         WOLFSSL_SUCCESS);
     ExpectIntEQ(tp, WOLFSSL_CERT_TYPE_UNKNOWN);
+
+    (void)typeCnt_c;
+    (void)typeCnt_s;
 
     wolfSSL_free(ssl_c);
     wolfSSL_CTX_free(ctx_c);
@@ -67733,12 +67739,9 @@ static int test_tls13_rpk_handshake(void)
             svrKeyFile,      WOLFSSL_FILETYPE_PEM )
         , 0);
 
-    /* set client certificate type in client end */
-    certType_c[0] = WOLFSSL_CERT_TYPE_RPK;
-    certType_c[1] = WOLFSSL_CERT_TYPE_X509;
-    typeCnt_c = 2;
-
-    /* client indicates both RPK and x509 certs are available but loaded RPK
+    /* set client certificate type in client end
+     *
+     * client indicates both RPK and x509 certs are available but loaded RPK
      * cert only. It does not have client add client-cert-type extension in CH.
      */
     certType_c[0] = WOLFSSL_CERT_TYPE_RPK;


### PR DESCRIPTION
fixes for analyzer carps around `HAVE_RPK`:

fix `clang-analyzer-deadcode.DeadStores` in `src/tls.c` `TLSX_ClientCertificateType_GetSize()`;

fix `clang-analyzer-deadcode.DeadStores` in `tests/api.c` `test_tls13_rpk_handshake()`;

fix null pointer to `XMEMCPY()` in `src/internal.c` `CopyDecodedName()`.

tested wtih `wolfssl-multi-test.sh ... RPK-all RPK-all-clang-tidy RPK-all-sanitizer RPK-all-cppcheck` (new tests to go into production once this merges)

see #6544
