### PR TITLE
fix a bug in client-tls.c

### DIFF
--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/client-tls.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/client-tls.c
@@ -409,7 +409,7 @@ WOLFSSL_ESP_TASK tls_smp_client_task(void* args)
     WOLFSSL_MSG("Connect to wolfSSL on the server side");
     /* Connect to wolfSSL on the server side */
     ret_i = wolfSSL_connect(ssl);
-    if (wolfSSL_connect(ssl) == SSL_SUCCESS) {
+    if (ret_i == SSL_SUCCESS) {
 #ifdef DEBUG_WOLFSSL
         ShowCiphers(ssl);
 #endif


### PR DESCRIPTION
`wolfSSL_connect` is called twice. Use `ret_i` in if check instead.

# Description

fix a bug in client-tls.c

Fixes zd#

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
