### PR TITLE
Update wolfssl_thread_entry.c

### DIFF
--- a/IDE/Renesas/e2studio/RA6M3/client-wolfssl/src/wolfssl_thread_entry.c
+++ b/IDE/Renesas/e2studio/RA6M3/client-wolfssl/src/wolfssl_thread_entry.c
@@ -93,7 +93,7 @@ void wolfssl_thread_entry(void *pvParameters) {
                                     FREERTOS_SOCK_STREAM,
                                     FREERTOS_IPPROTO_TCP);
     configASSERT(xClientSocket != FREERTOS_INVALID_SOCKET);
-    FreeRTOS_bind(xClientSocket, &xRemoteAddress, sizeof(xSize));
+    FreeRTOS_bind(xClientSocket, &xRemoteAddress, xSize);
 
     /* Client Socket Connect */
     ret = FreeRTOS_connect(xClientSocket,


### PR DESCRIPTION
Applying `sizeof` to an already calculated size makes no sense.

# Description

Please describe the scope of the fix or feature addition.

Fixes zd#

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
