### PR TITLE
No match cipher suite alert type change

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -17206,9 +17206,6 @@ int SendFatalAlertOnly(WOLFSSL *ssl, int error)
     case COMPRESSION_ERROR:
         why = decode_error;
         break;
-    case MATCH_SUITE_ERROR:
-        why = illegal_parameter;
-        break;
     case VERIFY_FINISHED_ERROR:
     case SIG_VERIFY_E:
         why = decrypt_error;
@@ -17221,6 +17218,7 @@ int SendFatalAlertOnly(WOLFSSL *ssl, int error)
     case ECC_OUT_OF_RANGE_E:
         why = bad_record_mac;
         break;
+    case MATCH_SUITE_ERROR:
     case VERSION_ERROR:
     default:
         why = handshake_failure;

--- a/tests/api.c
+++ b/tests/api.c
@@ -66610,7 +66610,7 @@ static int test_extra_alerts_wrong_cs(void)
     ExpectIntNE(wolfSSL_get_error(ssl_c, WOLFSSL_FATAL_ERROR),
         WOLFSSL_ERROR_WANT_READ);
     ExpectIntEQ(wolfSSL_get_alert_history(ssl_c, &h), WOLFSSL_SUCCESS);
-    ExpectIntEQ(h.last_tx.code, illegal_parameter);
+    ExpectIntEQ(h.last_tx.code, handshake_failure);
     ExpectIntEQ(h.last_tx.level, alert_fatal);
 
     wolfSSL_free(ssl_c);


### PR DESCRIPTION
# Description
TLS 1.0/1.1/1.2 specifications require the of a return a handshake failure alert when no cipher suites match.
TLS 1.3 specification requires the return of a "handshake_failure" or "insufficient_security" fatal alert.

Change alert sent from "illegal_parameter" to "handshake_failure".

Fixes zd#17802

# Testing

./configure --enable-all

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
