### PR TITLE
Handle PSK-Only negotiation with key_share not being sent in Server Hello

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -14925,6 +14925,12 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
     else if (!isRequest && ssl->options.haveEMS && !pendingEMS)
         ssl->options.haveEMS = 0;
 #endif
+#if defined(WOLFSSL_TLS13) && !defined(NO_PSK)
+    if (IsAtLeastTLSv1_3(ssl->version) && msgType == server_hello &&
+        IS_OFF(seenType, TLSX_ToSemaphore(TLSX_KEY_SHARE))) {
+        ssl->options.noPskDheKe = 1;
+    }
+#endif
 
     if (ret == 0)
         ret = SNI_VERIFY_PARSE(ssl, isRequest);


### PR DESCRIPTION
# Description

The wrong cipher suite is potentially chosen if key_share is not seen by the client in the server_hello

# Testing

$ cat /tmp/test
Client_identitySHA256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef

Server:
$ gnutls-serv --http --priority NORMAL:+ECDHE-PSK:+PSK:+ECDHE-ECDSA:+AES-128-CCM-8:+CTYPE-CLI-ALL:+CTYPE-SRV-ALL:+SHA256 --pskpasswd=/tmp/test

Client:
$ examples/client/client -vd -g -s -p 5556 2>&1| grep HTTP

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
