### PR TITLE
Modify PlatformIO FreeRTOS include path, settings.h

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -9696,7 +9696,12 @@ ProtocolVersion MakeDTLSv1_3(void)
 
 #elif defined(FREERTOS)
 
-    #include "task.h"
+    #ifdef PLATFORMIO
+        #include <freertos/FreeRTOS.h>
+        #include <freertos/task.h>
+    #else
+        #include "task.h"
+    #endif
 
     unsigned int LowResTimer(void)
     {

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -12801,7 +12801,13 @@ void bench_sphincsKeySign(byte level, byte optim)
 
 #elif defined(FREERTOS)
 
-    #include "task.h"
+    #ifdef PLATFORMIO
+        #include <freertos/FreeRTOS.h>
+        #include <freertos/task.h>
+    #else
+        #include "task.h"
+    #endif
+
 #if defined(WOLFSSL_ESPIDF)
     /* prototype definition */
     int construct_argv();

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -265,6 +265,23 @@
 /* Uncomment next line if using MAXQ108x */
 /* #define WOLFSSL_MAXQ108X */
 
+/* Check PLATFORMIO first, as it may define other known environments. */
+#ifdef PLATFORMIO
+    #ifdef ESP_PLATFORM
+        /* Turn on the wolfSSL ESPIDF flag for the PlatformIO ESP-IDF detect */
+        #define WOLFSSL_ESPIDF
+    #endif /* ESP_PLATFORM */
+
+    /* Ensure all PlatformIO boards have the wolfSSL user_setting.h enabled. */
+    #ifndef WOLFSSL_USER_SETTINGS
+        #define WOLFSSL_USER_SETTINGS
+    #endif /* WOLFSSL_USER_SETTINGS */
+
+    /* Similar to Arduino we have limited build control, so suppress warning */
+    #undef  WOLFSSL_IGNORE_FILE_WARN
+    #define WOLFSSL_IGNORE_FILE_WARN
+#endif
+
 #if defined(ARDUINO)
     /* Due to limited build control, we'll ignore file warnings. */
     /* See https://github.com/arduino/arduino-cli/issues/631     */
@@ -1034,8 +1051,14 @@ extern void uITRON4_free(void *p) ;
 
 
 #ifdef FREERTOS
-    #include "FreeRTOS.h"
-    #include <task.h>
+
+    #ifdef PLATFORMIO
+        #include <freertos/FreeRTOS.h>
+        #include <freertos/task.h>
+    #else
+        #include "FreeRTOS.h"
+        #include <task.h>
+    #endif
 
     #if !defined(XMALLOC_USER) && !defined(NO_WOLFSSL_MEMORY) && \
         !defined(WOLFSSL_STATIC_MEMORY) && !defined(WOLFSSL_TRACK_MEMORY)


### PR DESCRIPTION
# Description

This PR modified some paths for including FreeRTOS headers in the PlatformIO environment.

I'm working on adding wolfSSL support to [PlatformIO](https://platformio.org/) as noted in https://github.com/wolfSSL/Arduino-wolfSSL/issues/7 and https://github.com/platformio/platformio-registry/issues/85. See the [wolfssl-staging/wolfSSL](https://registry.platformio.org/libraries/wolfssl-staging/wolfSSL) preview.

I'm making progress. It appears the Arduino-wolfSSL is trivial to publish to PlatformIO, but adding ESP-IDF support there is considerably more challenging. 

Similar to the restructuring of directories in [Arduino-wolfSSL](https://github.com/wolfSSL/Arduino-wolfSSL) as noted in https://github.com/wolfSSL/Arduino-wolfSSL/pull/1 and https://github.com/arduino/arduino-cli/issues/631, the PlatformIO also  needs to have directories restructured for the wolfSSL include files to work properly. Fortunately in the case of PlatformIO - a new repository is not needed. Files can be assembled into a temporary directory and published from there, similar to the [Espressif Managed Components](https://components.espressif.com/components?q=namespace:wolfssl).

One of the oddities encountered during the file restructuring process is a problem finding the FreeRTOS files, with compile-time errors similar to this:

```
Compiling .pio\build\esp32dev\bootloader_support\src\bootloader_random_esp32.o
In file included from src/main.c:2:
.pio/libdeps/esp32dev/wolfSSL/src/wolfssl/wolfcrypt/settings.h:998:14: fatal error: FreeRTOS.h: No such file or directory

******************************************************************
* Looking for FreeRTOS.h dependency? Check our library registry!
*
* CLI  > platformio lib search "header:FreeRTOS.h"
* Web  > https://registry.platformio.org/search?q=header:FreeRTOS.h
*
******************************************************************

Compiling .pio\build\esp32dev\bootloader_support\bootloader_flash\src\bootloader_flash.o
  998 |     #include "FreeRTOS.h"
      |              ^~~~~~~~~~~~
compilation terminated.
Compiling .pio\build\esp32dev\bootloader_support\bootloader_flash\src\flash_qio_mode.o
*** [.pio\build\esp32dev\src\main.o] Error 1
===================================================== [FAILED] Took 4.77 seconds =====================================================

 *  The terminal process "C:\Users\gojimmypi\.platformio\penv\Scripts\platformio.exe 'run'" terminated with exit code: 1. 
 *  Terminal will be reused by tasks, press any key to close it. 
```

This PR slightly modifies the path for FreeRTOS for inclusion when using PlatformIO to fix the compile errors.

Fixes zd# n/a

# Testing

How did you test?

Minimal testing. Only simple compile checks from Linux prompt, Espressif projects, and of course PlatformIO library.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
