### PR TITLE
Generic Memory Pools

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -672,6 +672,91 @@ static int test_wolfCrypt_Cleanup(void)
     return EXPECT_RESULT();
 }
 
+static int test_wc_LoadStaticMemory_ex(void)
+{
+    EXPECT_DECLS;
+#ifdef WOLFSSL_STATIC_MEMORY
+    byte staticMemory[440000];
+    word32 sizeList[WOLFMEM_DEF_BUCKETS] = { WOLFMEM_BUCKETS };
+    word32 distList[WOLFMEM_DEF_BUCKETS] = { WOLFMEM_DIST };
+    WOLFSSL_HEAP_HINT* heap;
+
+    /* Pass in zero everything. */
+    ExpectIntEQ(wc_LoadStaticMemory_ex(NULL, 0, NULL, NULL, NULL, 0, 0, 0),
+            BAD_FUNC_ARG);
+
+    /* Set the heap pointer to NULL. */
+    ExpectIntEQ(wc_LoadStaticMemory_ex(NULL,
+                WOLFMEM_DEF_BUCKETS, sizeList, distList,
+                staticMemory, (word32)sizeof(staticMemory),
+                0, 1),
+            BAD_FUNC_ARG);
+
+    /* Set other pointer values to NULL one at a time. */
+    heap = NULL;
+    ExpectIntEQ(wc_LoadStaticMemory_ex(&heap,
+                WOLFMEM_DEF_BUCKETS, NULL, distList,
+                staticMemory, (word32)sizeof(staticMemory),
+                0, 1),
+            BAD_FUNC_ARG);
+    heap = NULL;
+    ExpectIntEQ(wc_LoadStaticMemory_ex(&heap,
+                WOLFMEM_DEF_BUCKETS, sizeList, NULL,
+                staticMemory, (word32)sizeof(staticMemory),
+                0, 1),
+            BAD_FUNC_ARG);
+    heap = NULL;
+    ExpectIntEQ(wc_LoadStaticMemory_ex(&heap,
+                WOLFMEM_DEF_BUCKETS, sizeList, distList,
+                NULL, (word32)sizeof(staticMemory),
+                0, 1),
+            BAD_FUNC_ARG);
+    /* Set the size of the static buffer to 0. */
+    heap = NULL;
+    ExpectIntEQ(wc_LoadStaticMemory_ex(&heap,
+                WOLFMEM_DEF_BUCKETS, sizeList, distList,
+                staticMemory, 0,
+                0, 1),
+            BUFFER_E);
+
+    /* Set the size of the static buffer to one less than minimum allowed. */
+    heap = NULL;
+    ExpectIntEQ(wc_LoadStaticMemory_ex(&heap,
+                WOLFMEM_DEF_BUCKETS, sizeList, distList,
+                staticMemory,
+                (word32)(sizeof(WOLFSSL_HEAP) + sizeof(WOLFSSL_HEAP_HINT)) - 1,
+                0, 1),
+            BUFFER_E);
+
+    /* Set the number of buckets to 1 too many allowed. */
+    heap = NULL;
+    ExpectIntEQ(wc_LoadStaticMemory_ex(&heap,
+                WOLFMEM_MAX_BUCKETS+1, sizeList, distList,
+                staticMemory, (word32)sizeof(staticMemory),
+                0, 1),
+            BAD_FUNC_ARG);
+
+    /* Set the size of the static buffer to exactly the minimum size. */
+    heap = NULL;
+    ExpectIntEQ(wc_LoadStaticMemory_ex(&heap,
+                WOLFMEM_DEF_BUCKETS, sizeList, distList,
+                staticMemory,
+                (word32)(sizeof(WOLFSSL_HEAP) + sizeof(WOLFSSL_HEAP_HINT)),
+                0, 1),
+            0);
+
+    /* Success case. */
+    heap = NULL;
+    ExpectIntEQ(wc_LoadStaticMemory_ex(&heap,
+                WOLFMEM_DEF_BUCKETS, sizeList, distList,
+                staticMemory, (word32)sizeof(staticMemory),
+                0, 1),
+            0);
+#endif /* WOLFSSL_STATIC_MEMORY */
+    return EXPECT_RESULT();
+}
+
+
 /*----------------------------------------------------------------------------*
  | Platform dependent function test
  *----------------------------------------------------------------------------*/
@@ -71564,6 +71649,8 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_ForceZero),
 
     TEST_DECL(test_wolfCrypt_Init),
+
+    TEST_DECL(test_wc_LoadStaticMemory_ex),
 
     /* Locking with Compat Mutex */
     TEST_DECL(test_wc_SetMutexCb),

--- a/tests/api.c
+++ b/tests/api.c
@@ -744,6 +744,7 @@ static int test_wc_LoadStaticMemory_ex(void)
                 (word32)(sizeof(WOLFSSL_HEAP) + sizeof(WOLFSSL_HEAP_HINT)),
                 0, 1),
             0);
+    wc_UnloadStaticMemory(heap);
 
     /* Success case. */
     heap = NULL;
@@ -752,6 +753,7 @@ static int test_wc_LoadStaticMemory_ex(void)
                 staticMemory, (word32)sizeof(staticMemory),
                 0, 1),
             0);
+    wc_UnloadStaticMemory(heap);
 #endif /* WOLFSSL_STATIC_MEMORY */
     return EXPECT_RESULT();
 }

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -729,6 +729,15 @@ int wc_LoadStaticMemory(WOLFSSL_HEAP_HINT** pHint,
 }
 
 
+void wc_UnloadStaticMemory(WOLFSSL_HEAP_HINT* heap)
+{
+    WOLFSSL_ENTER("wc_UnloadStaticMemory");
+    if (heap != NULL && heap->memory != NULL) {
+        wc_FreeMutex(&heap->memory->memory_mutex);
+    }
+}
+
+
 /* returns the size of management memory needed for each bucket.
  * This is memory that is used to keep track of and align memory buckets. */
 int wolfSSL_MemoryPaddingSz(void)

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -587,10 +587,10 @@ int wolfSSL_init_memory_heap(WOLFSSL_HEAP* heap)
 int wc_LoadStaticMemory(WOLFSSL_HEAP_HINT** pHint,
     unsigned char* buf, unsigned int sz, int flag, int maxSz)
 {
-    int ret;
-    WOLFSSL_HEAP*      heap;
-    WOLFSSL_HEAP_HINT* hint;
+    WOLFSSL_HEAP*      heap = NULL;
+    WOLFSSL_HEAP_HINT* hint = NULL;
     word32 idx = 0;
+    int ret;
 
     if (pHint == NULL || buf == NULL) {
         return BAD_FUNC_ARG;

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -662,7 +662,7 @@ int wc_LoadStaticMemory_ex(WOLFSSL_HEAP_HINT** pHint,
     word32 idx = 0;
     int ret;
 
-    if (pHint == NULL || buf == NULL) {
+    if (pHint == NULL || buf == NULL || listSz > WOLFMEM_MAX_BUCKETS) {
         return BAD_FUNC_ARG;
     }
 
@@ -754,7 +754,7 @@ int wolfSSL_StaticBufferSz_ex(unsigned int listSz,
 
     WOLFSSL_ENTER("wolfSSL_StaticBufferSz_ex");
 
-    if (buffer == NULL) {
+    if (buffer == NULL || listSz > WOLFMEM_MAX_BUCKETS) {
         return BAD_FUNC_ARG;
     }
 
@@ -781,7 +781,7 @@ int wolfSSL_StaticBufferSz_ex(unsigned int listSz,
 
         while ((ava >= (sizeList[0] + padSz + memSz)) && (ava > 0)) {
             /* start at largest and move to smaller buckets */
-            for (i = (listSz- 1); i >= 0; i--) {
+            for (i = (listSz - 1); i >= 0; i--) {
                 for (k = distList[i]; k > 0; k--) {
                     if ((sizeList[i] + padSz + memSz) <= ava) {
                         ava -= sizeList[i] + padSz + memSz;
@@ -800,10 +800,10 @@ int wolfSSL_StaticBufferSz_ex(unsigned int listSz,
  * used by wolfSSL by default. */
 int wolfSSL_StaticBufferSz(byte* buffer, word32 sz, int flag)
 {
-    word32 bucketSz[WOLFMEM_MAX_BUCKETS] = {WOLFMEM_BUCKETS};
-    word32 distList[WOLFMEM_MAX_BUCKETS] = {WOLFMEM_DIST};
+    word32 bucketSz[WOLFMEM_DEF_BUCKETS] = {WOLFMEM_BUCKETS};
+    word32 distList[WOLFMEM_DEF_BUCKETS] = {WOLFMEM_DIST};
 
-    return wolfSSL_StaticBufferSz_ex(WOLFMEM_MAX_BUCKETS, bucketSz, distList,
+    return wolfSSL_StaticBufferSz_ex(WOLFMEM_DEF_BUCKETS, bucketSz, distList,
         buffer, sz, flag);
 }
 

--- a/wolfssl/wolfcrypt/memory.h
+++ b/wolfssl/wolfcrypt/memory.h
@@ -222,6 +222,7 @@ WOLFSSL_API int wolfSSL_GetAllocators(wolfSSL_Malloc_cb* mf,
             int flag, int max);
     WOLFSSL_API int wc_LoadStaticMemory(WOLFSSL_HEAP_HINT** pHint,
             unsigned char* buf, unsigned int sz, int flag, int max);
+    WOLFSSL_API void wc_UnloadStaticMemory(WOLFSSL_HEAP_HINT* heap);
 
     WOLFSSL_API int wolfSSL_GetMemStats(WOLFSSL_HEAP* heap,
                                                       WOLFSSL_MEM_STATS* stats);

--- a/wolfssl/wolfcrypt/memory.h
+++ b/wolfssl/wolfcrypt/memory.h
@@ -216,12 +216,12 @@ WOLFSSL_API int wolfSSL_GetAllocators(wolfSSL_Malloc_cb* mf,
         byte        haFlag; /* flag used for checking handshake count */
     } WOLFSSL_HEAP_HINT;
 
+    WOLFSSL_API int wc_LoadStaticMemory_ex(WOLFSSL_HEAP_HINT** pHint,
+            unsigned int listSz, unsigned int *sizeList, unsigned int *distList,
+            unsigned char* buf, unsigned int sz, int flag, int max);
     WOLFSSL_API int wc_LoadStaticMemory(WOLFSSL_HEAP_HINT** pHint,
             unsigned char* buf, unsigned int sz, int flag, int max);
 
-    WOLFSSL_LOCAL int wolfSSL_init_memory_heap(WOLFSSL_HEAP* heap);
-    WOLFSSL_LOCAL int wolfSSL_load_static_memory(byte* buffer, word32 sz,
-                                                  int flag, WOLFSSL_HEAP* heap);
     WOLFSSL_LOCAL int wolfSSL_GetMemStats(WOLFSSL_HEAP* heap,
                                                       WOLFSSL_MEM_STATS* stats);
     WOLFSSL_LOCAL int SetFixedIO(WOLFSSL_HEAP* heap, wc_Memory** io);

--- a/wolfssl/wolfcrypt/memory.h
+++ b/wolfssl/wolfcrypt/memory.h
@@ -217,8 +217,9 @@ WOLFSSL_API int wolfSSL_GetAllocators(wolfSSL_Malloc_cb* mf,
     } WOLFSSL_HEAP_HINT;
 
     WOLFSSL_API int wc_LoadStaticMemory_ex(WOLFSSL_HEAP_HINT** pHint,
-            unsigned int listSz, unsigned int *sizeList, unsigned int *distList,
-            unsigned char* buf, unsigned int sz, int flag, int max);
+            unsigned int listSz, const unsigned int *sizeList,
+            const unsigned int *distList, unsigned char* buf, unsigned int sz,
+            int flag, int max);
     WOLFSSL_API int wc_LoadStaticMemory(WOLFSSL_HEAP_HINT** pHint,
             unsigned char* buf, unsigned int sz, int flag, int max);
 
@@ -227,6 +228,9 @@ WOLFSSL_API int wolfSSL_GetAllocators(wolfSSL_Malloc_cb* mf,
     WOLFSSL_LOCAL int SetFixedIO(WOLFSSL_HEAP* heap, wc_Memory** io);
     WOLFSSL_LOCAL int FreeFixedIO(WOLFSSL_HEAP* heap, wc_Memory** io);
 
+    WOLFSSL_API int wolfSSL_StaticBufferSz_ex(unsigned int listSz,
+            const unsigned int *sizeList, const unsigned int *distList,
+            byte* buffer, word32 sz, int flag);
     WOLFSSL_API int wolfSSL_StaticBufferSz(byte* buffer, word32 sz, int flag);
     WOLFSSL_API int wolfSSL_MemoryPaddingSz(void);
 #endif /* WOLFSSL_STATIC_MEMORY */

--- a/wolfssl/wolfcrypt/memory.h
+++ b/wolfssl/wolfcrypt/memory.h
@@ -223,7 +223,7 @@ WOLFSSL_API int wolfSSL_GetAllocators(wolfSSL_Malloc_cb* mf,
     WOLFSSL_API int wc_LoadStaticMemory(WOLFSSL_HEAP_HINT** pHint,
             unsigned char* buf, unsigned int sz, int flag, int max);
 
-    WOLFSSL_LOCAL int wolfSSL_GetMemStats(WOLFSSL_HEAP* heap,
+    WOLFSSL_API int wolfSSL_GetMemStats(WOLFSSL_HEAP* heap,
                                                       WOLFSSL_MEM_STATS* stats);
     WOLFSSL_LOCAL int SetFixedIO(WOLFSSL_HEAP* heap, wc_Memory** io);
     WOLFSSL_LOCAL int FreeFixedIO(WOLFSSL_HEAP* heap, wc_Memory** io);


### PR DESCRIPTION
1. Add a new API for creating a memory pool, `wc_LoadStaticMemory_ex()`, updated support functions to work with it. Reimplemented `wc_LoadStaticMemory()` in terms of the new API.
2. Changed `wolfSSL_CTX_load_static_memory()` to use `wc_LoadStaticMemory()` rather than reimplementing it.

Fixes 17726

# Testing

```
$ autoreconf -ivf
$ ./configure --enable-wolfssh --enable-staticmemory
$ make clean && make
$ ./wolfcrypt/test/test
$ ./examples/server/server &
$ ./examples/client/client
```

The code should work the same with and without the changes.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
