### PR TITLE
Update enum wc_LmsParm for wolfboot support.

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -9860,8 +9860,8 @@ void bench_lms(void)
 #endif
 
 #if defined(WOLFSSL_WC_LMS) && !defined(LMS_PARAMS_BENCHED)
-    bench_lms_keygen(0x100, pub);
-    bench_lms_sign_verify(0x100, pub);
+    bench_lms_keygen(WC_LMS_PARM_L1_H5_W1, pub);
+    bench_lms_sign_verify(WC_LMS_PARM_L1_H5_W1, pub);
 #endif
 
     return;

--- a/wolfcrypt/src/ext_lms.c
+++ b/wolfcrypt/src/ext_lms.c
@@ -160,38 +160,77 @@ const char * wc_LmsKey_ParmToStr(enum wc_LmsParm lmsParm)
 {
     switch (lmsParm) {
     case WC_LMS_PARM_NONE:
-        return "LMS_NONE";
-
+        return "LMS/HSS NONE";
+    case WC_LMS_PARM_L1_H5_W1:
+        return "LMS/HSS L1_H5_W1";
+    case WC_LMS_PARM_L1_H5_W2:
+        return "LMS/HSS L1_H5_W2";
+    case WC_LMS_PARM_L1_H5_W4:
+        return "LMS/HSS L1_H5_W4";
+    case WC_LMS_PARM_L1_H5_W8:
+        return "LMS/HSS L1_H5_W8";
+    case WC_LMS_PARM_L1_H10_W2:
+        return "LMS/HSS L1_H10_W2";
+    case WC_LMS_PARM_L1_H10_W4:
+        return "LMS/HSS L1_H10_W4";
+    case WC_LMS_PARM_L1_H10_W8:
+        return "LMS/HSS L1_H10_W8";
     case WC_LMS_PARM_L1_H15_W2:
         return "LMS/HSS L1_H15_W2";
-
     case WC_LMS_PARM_L1_H15_W4:
         return "LMS/HSS L1_H15_W4";
-
+    case WC_LMS_PARM_L1_H15_W8:
+        return "LMS/HSS L1_H15_W8";
+    case WC_LMS_PARM_L1_H20_W2:
+        return "LMS/HSS L1_H20_W2";
+    case WC_LMS_PARM_L1_H20_W4:
+        return "LMS/HSS L1_H20_W4";
+    case WC_LMS_PARM_L1_H20_W8:
+        return "LMS/HSS L1_H20_W8";
+    case WC_LMS_PARM_L2_H5_W2:
+        return "LMS/HSS L2_H5_W2";
+    case WC_LMS_PARM_L2_H5_W4:
+        return "LMS/HSS L2_H5_W4";
+    case WC_LMS_PARM_L2_H5_W8:
+        return "LMS/HSS L2_H5_W8";
     case WC_LMS_PARM_L2_H10_W2:
         return "LMS/HSS L2_H10_W2";
-
     case WC_LMS_PARM_L2_H10_W4:
         return "LMS/HSS L2_H10_W4";
-
     case WC_LMS_PARM_L2_H10_W8:
         return "LMS/HSS L2_H10_W8";
-
+    case WC_LMS_PARM_L2_H15_W2:
+        return "LMS/HSS L2_H15_W2";
+    case WC_LMS_PARM_L2_H15_W4:
+        return "LMS/HSS L2_H15_W4";
+    case WC_LMS_PARM_L2_H15_W8:
+        return "LMS/HSS L2_H15_W8";
+    case WC_LMS_PARM_L2_H20_W2:
+        return "LMS/HSS L2_H20_W2";
+    case WC_LMS_PARM_L2_H20_W4:
+        return "LMS/HSS L2_H20_W4";
+    case WC_LMS_PARM_L2_H20_W8:
+        return "LMS/HSS L2_H20_W8";
     case WC_LMS_PARM_L3_H5_W2:
         return "LMS/HSS L3_H5_W2";
-
     case WC_LMS_PARM_L3_H5_W4:
         return "LMS/HSS L3_H5_W4";
-
     case WC_LMS_PARM_L3_H5_W8:
         return "LMS/HSS L3_H5_W8";
-
     case WC_LMS_PARM_L3_H10_W4:
         return "LMS/HSS L3_H10_W4";
-
+    case WC_LMS_PARM_L3_H10_W8:
+        return "LMS/HSS L3_H10_W8";
+    case WC_LMS_PARM_L4_H5_W2:
+        return "LMS/HSS L4_H5_W2";
+    case WC_LMS_PARM_L4_H5_W4:
+        return "LMS/HSS L4_H5_W4";
     case WC_LMS_PARM_L4_H5_W8:
         return "LMS/HSS L4_H5_W8";
-
+    case WC_LMS_PARM_L4_H10_W4:
+        return "LMS/HSS L4_H10_W4";
+    case WC_LMS_PARM_L4_H10_W8:
+        return "LMS/HSS L4_H10_W8";
     default:
         WOLFSSL_MSG("error: invalid LMS parameter");
         break;
@@ -279,36 +318,76 @@ int wc_LmsKey_SetLmsParm(LmsKey * key, enum wc_LmsParm lmsParm)
     /* If NONE is passed, default to the lowest predefined set. */
     switch (lmsParm) {
     case WC_LMS_PARM_NONE:
+    case WC_LMS_PARM_L1_H5_W1:
+        return wc_LmsKey_SetParameters(key, 1, 5, 1);
+    case WC_LMS_PARM_L1_H5_W2:
+        return wc_LmsKey_SetParameters(key, 1, 5, 2);
+    case WC_LMS_PARM_L1_H5_W4:
+        return wc_LmsKey_SetParameters(key, 1, 5, 4);
+    case WC_LMS_PARM_L1_H5_W8:
+        return wc_LmsKey_SetParameters(key, 1, 5, 8);
+    case WC_LMS_PARM_L1_H10_W2:
+        return wc_LmsKey_SetParameters(key, 1, 10, 2);
+    case WC_LMS_PARM_L1_H10_W4:
+        return wc_LmsKey_SetParameters(key, 1, 10, 4);
+    case WC_LMS_PARM_L1_H10_W8:
+        return wc_LmsKey_SetParameters(key, 1, 10, 8);
     case WC_LMS_PARM_L1_H15_W2:
         return wc_LmsKey_SetParameters(key, 1, 15, 2);
-
     case WC_LMS_PARM_L1_H15_W4:
         return wc_LmsKey_SetParameters(key, 1, 15, 4);
-
+    case WC_LMS_PARM_L1_H15_W8:
+        return wc_LmsKey_SetParameters(key, 1, 15, 8);
+    case WC_LMS_PARM_L1_H20_W2:
+        return wc_LmsKey_SetParameters(key, 1, 20, 2);
+    case WC_LMS_PARM_L1_H20_W4:
+        return wc_LmsKey_SetParameters(key, 1, 20, 4);
+    case WC_LMS_PARM_L1_H20_W8:
+        return wc_LmsKey_SetParameters(key, 1, 20, 8);
+    case WC_LMS_PARM_L2_H5_W2:
+        return wc_LmsKey_SetParameters(key, 2, 5, 2);
+    case WC_LMS_PARM_L2_H5_W4:
+        return wc_LmsKey_SetParameters(key, 2, 5, 4);
+    case WC_LMS_PARM_L2_H5_W8:
+        return wc_LmsKey_SetParameters(key, 2, 5, 8);
     case WC_LMS_PARM_L2_H10_W2:
         return wc_LmsKey_SetParameters(key, 2, 10, 2);
-
     case WC_LMS_PARM_L2_H10_W4:
         return wc_LmsKey_SetParameters(key, 2, 10, 4);
-
     case WC_LMS_PARM_L2_H10_W8:
         return wc_LmsKey_SetParameters(key, 2, 10, 8);
-
+    case WC_LMS_PARM_L2_H15_W2:
+        return wc_LmsKey_SetParameters(key, 2, 15, 2);
+    case WC_LMS_PARM_L2_H15_W4:
+        return wc_LmsKey_SetParameters(key, 2, 15, 4);
+    case WC_LMS_PARM_L2_H15_W8:
+        return wc_LmsKey_SetParameters(key, 2, 15, 8);
+    case WC_LMS_PARM_L2_H20_W2:
+        return wc_LmsKey_SetParameters(key, 2, 20, 2);
+    case WC_LMS_PARM_L2_H20_W4:
+        return wc_LmsKey_SetParameters(key, 2, 20, 4);
+    case WC_LMS_PARM_L2_H20_W8:
+        return wc_LmsKey_SetParameters(key, 2, 20, 8);
     case WC_LMS_PARM_L3_H5_W2:
         return wc_LmsKey_SetParameters(key, 3, 5, 2);
-
     case WC_LMS_PARM_L3_H5_W4:
         return wc_LmsKey_SetParameters(key, 3, 5, 4);
-
     case WC_LMS_PARM_L3_H5_W8:
         return wc_LmsKey_SetParameters(key, 3, 5, 8);
-
     case WC_LMS_PARM_L3_H10_W4:
         return wc_LmsKey_SetParameters(key, 3, 10, 4);
-
+    case WC_LMS_PARM_L3_H10_W8:
+        return wc_LmsKey_SetParameters(key, 3, 10, 8);
+    case WC_LMS_PARM_L4_H5_W2:
+        return wc_LmsKey_SetParameters(key, 4, 5, 2);
+    case WC_LMS_PARM_L4_H5_W4:
+        return wc_LmsKey_SetParameters(key, 4, 5, 4);
     case WC_LMS_PARM_L4_H5_W8:
         return wc_LmsKey_SetParameters(key, 4, 5, 8);
-
+    case WC_LMS_PARM_L4_H10_W4:
+        return wc_LmsKey_SetParameters(key, 4, 10, 4);
+    case WC_LMS_PARM_L4_H10_W8:
+        return wc_LmsKey_SetParameters(key, 4, 10, 8);
     default:
         WOLFSSL_MSG("error: invalid LMS parameter set");
         break;

--- a/wolfssl/wolfcrypt/lms.h
+++ b/wolfssl/wolfcrypt/lms.h
@@ -75,20 +75,45 @@ enum wc_LmsRc {
 
 /* Predefined LMS/HSS parameter sets for convenience.
  *
- * Not predefining a set with Winternitz=1, because the signatures
+ * Not predefining many sets with Winternitz=1, because the signatures
  * will be large. */
 enum wc_LmsParm {
-    WC_LMS_PARM_NONE      =  0,
-    WC_LMS_PARM_L1_H15_W2 =  1, /* 1 level Merkle tree of 15 height. */
-    WC_LMS_PARM_L1_H15_W4 =  2,
-    WC_LMS_PARM_L2_H10_W2 =  3, /* 2 level Merkle tree of 10 height. */
-    WC_LMS_PARM_L2_H10_W4 =  4,
-    WC_LMS_PARM_L2_H10_W8 =  5,
-    WC_LMS_PARM_L3_H5_W2  =  6, /* 3 level Merkle tree of 5 height. */
-    WC_LMS_PARM_L3_H5_W4  =  7,
-    WC_LMS_PARM_L3_H5_W8  =  8,
-    WC_LMS_PARM_L3_H10_W4 =  9, /* 3 level Merkle tree of 10 height. */
-    WC_LMS_PARM_L4_H5_W8  = 10, /* 4 level Merkle tree of 5 height. */
+    WC_LMS_PARM_NONE = 0,
+    WC_LMS_PARM_L1_H5_W1 = 1,
+    WC_LMS_PARM_L1_H5_W2 = 2,
+    WC_LMS_PARM_L1_H5_W4 = 3,
+    WC_LMS_PARM_L1_H5_W8 = 4,
+    WC_LMS_PARM_L1_H10_W2 = 5,
+    WC_LMS_PARM_L1_H10_W4 = 6,
+    WC_LMS_PARM_L1_H10_W8 = 7,
+    WC_LMS_PARM_L1_H15_W2 = 8,
+    WC_LMS_PARM_L1_H15_W4 = 9,
+    WC_LMS_PARM_L1_H15_W8 = 10,
+    WC_LMS_PARM_L1_H20_W2 = 11,
+    WC_LMS_PARM_L1_H20_W4 = 12,
+    WC_LMS_PARM_L1_H20_W8 = 13,
+    WC_LMS_PARM_L2_H5_W2 = 14,
+    WC_LMS_PARM_L2_H5_W4 = 15,
+    WC_LMS_PARM_L2_H5_W8 = 16,
+    WC_LMS_PARM_L2_H10_W2 = 17,
+    WC_LMS_PARM_L2_H10_W4 = 18,
+    WC_LMS_PARM_L2_H10_W8 = 19,
+    WC_LMS_PARM_L2_H15_W2 = 20,
+    WC_LMS_PARM_L2_H15_W4 = 21,
+    WC_LMS_PARM_L2_H15_W8 = 22,
+    WC_LMS_PARM_L2_H20_W2 = 23,
+    WC_LMS_PARM_L2_H20_W4 = 24,
+    WC_LMS_PARM_L2_H20_W8 = 25,
+    WC_LMS_PARM_L3_H5_W2 = 26,
+    WC_LMS_PARM_L3_H5_W4 = 27,
+    WC_LMS_PARM_L3_H5_W8 = 28,
+    WC_LMS_PARM_L3_H10_W4 = 29,
+    WC_LMS_PARM_L3_H10_W8 = 30,
+    WC_LMS_PARM_L4_H5_W2 = 31,
+    WC_LMS_PARM_L4_H5_W4 = 32,
+    WC_LMS_PARM_L4_H5_W8 = 33,
+    WC_LMS_PARM_L4_H10_W4 = 34,
+    WC_LMS_PARM_L4_H10_W8 = 35,
 };
 
 /* enum wc_LmsState is to help track the state of an LMS/HSS Key. */


### PR DESCRIPTION
# Description

The enum wc_LmsParm was incomplete, which created some practical difficulties for wolfboot wc_lms support on embedded targets.

Also, added `wc_LmsKey_ExportPubRaw()` to `lms_test_verify_only()` because it was not covered in wolfcrypt test.

# Testing

- Tested wolfcrypt with wc_lms, ext_lms.
- Tested wolfboot  with wc_lms, ext_lms.
