### PR TITLE
fix ssl: typo in wolfssl/ssl.h breaks build

### DIFF
--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -4503,7 +4503,7 @@ WOLFSSL_API WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509_AUX
 #ifndef NO_FILESYSTEM
 WOLFSSL_API WOLF_STACK_OF(WOLFSSL_X509_INFO)* wolfSSL_PEM_X509_INFO_read(
         XFILE fp, WOLF_STACK_OF(WOLFSSL_X509_INFO)* sk,
-        pem_password_cb* cb, void* u);
+        wc_pem_password_cb* cb, void* u);
 #endif
 WOLFSSL_API WOLF_STACK_OF(WOLFSSL_X509_INFO)* wolfSSL_PEM_X509_INFO_read_bio(
         WOLFSSL_BIO* bio, WOLF_STACK_OF(WOLFSSL_X509_INFO)* sk,


### PR DESCRIPTION
# Description

Building with flags `-DOPENSSL_ALL -DOPENSSL_EXTRA -DOPENSSL_COEXIST` generates the error:

```
.../wolfssl/ssl.h:4484:9: error: unknown type 'pem_password_cb'; ...
 4484 |         pem_password_cb* cb, void* u);
      |         ^~~~~~~~~~~~~~~
      |         wc_pem_password_cb
```

This issue is reproducible on current master and v5.7.0-stable.

# Testing

Rebuild manually.