### PR TITLE
Add `wolfSSL_SessionIsSetup`

### DIFF
--- a/src/ssl_sess.c
+++ b/src/ssl_sess.c
@@ -283,6 +283,13 @@ WOLFSSL_SESSION* wolfSSL_get1_session(WOLFSSL* ssl)
     return sess;
 }
 
+/* session is a private struct, return if it is setup or not */
+WOLFSSL_API int wolfSSL_SessionIsSetup(WOLFSSL_SESSION* session)
+{
+    if (session != NULL)
+        return session->isSetup;
+    return 0;
+}
 
 /*
  * Sets the session object to use when establishing a TLS/SSL session using

--- a/tests/api.c
+++ b/tests/api.c
@@ -47152,6 +47152,7 @@ static int test_wolfSSL_SESSION(void)
 
     ExpectPtrNE((sess = wolfSSL_get1_session(ssl)), NULL); /* ref count 1 */
     ExpectPtrNE((sess_copy = wolfSSL_get1_session(ssl)), NULL); /* ref count 2 */
+    ExpectIntEQ(wolfSSLSessionIsSetup(sess), 1);
 #ifdef HAVE_EXT_CACHE
     ExpectPtrEq(sess, sess_copy); /* they should be the same pointer but without
                                    * HAVE_EXT_CACHE we get new objects each time */

--- a/tests/api.c
+++ b/tests/api.c
@@ -47152,7 +47152,7 @@ static int test_wolfSSL_SESSION(void)
 
     ExpectPtrNE((sess = wolfSSL_get1_session(ssl)), NULL); /* ref count 1 */
     ExpectPtrNE((sess_copy = wolfSSL_get1_session(ssl)), NULL); /* ref count 2 */
-    ExpectIntEQ(wolfSSLSessionIsSetup(sess), 1);
+    ExpectIntEQ(wolfSSL_SessionIsSetup(sess), 1);
 #ifdef HAVE_EXT_CACHE
     ExpectPtrEq(sess, sess_copy); /* they should be the same pointer but without
                                    * HAVE_EXT_CACHE we get new objects each time */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1691,6 +1691,7 @@ WOLFSSL_API const char*  wolfSSL_SESSION_CIPHER_get_name(const WOLFSSL_SESSION* 
 WOLFSSL_API const char*  wolfSSL_get_cipher(WOLFSSL* ssl);
 WOLFSSL_API void wolfSSL_sk_CIPHER_free(WOLF_STACK_OF(WOLFSSL_CIPHER)* sk);
 WOLFSSL_API WOLFSSL_SESSION* wolfSSL_get1_session(WOLFSSL* ssl);
+WOLFSSL_API int wolfSSLSessionIsSetup(WOLFSSL_SESSION* session);
 
 WOLFSSL_API WOLFSSL_X509* wolfSSL_X509_new(void);
 WOLFSSL_API WOLFSSL_X509* wolfSSL_X509_new_ex(void* heap);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1691,7 +1691,7 @@ WOLFSSL_API const char*  wolfSSL_SESSION_CIPHER_get_name(const WOLFSSL_SESSION* 
 WOLFSSL_API const char*  wolfSSL_get_cipher(WOLFSSL* ssl);
 WOLFSSL_API void wolfSSL_sk_CIPHER_free(WOLF_STACK_OF(WOLFSSL_CIPHER)* sk);
 WOLFSSL_API WOLFSSL_SESSION* wolfSSL_get1_session(WOLFSSL* ssl);
-WOLFSSL_API int wolfSSLSessionIsSetup(WOLFSSL_SESSION* session);
+WOLFSSL_API int wolfSSL_SessionIsSetup(WOLFSSL_SESSION* session);
 
 WOLFSSL_API WOLFSSL_X509* wolfSSL_X509_new(void);
 WOLFSSL_API WOLFSSL_X509* wolfSSL_X509_new_ex(void* heap);


### PR DESCRIPTION
# Description
Add `wolfSSL_SessionIsSetup`, so the user can check if a session ticket has been sent by the server

Fixes zd#17557

# Testing

Added a check to the normal session tests

# Checklist

 - [X] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
