### PR TITLE
Fix for AES-CFB1 encrypt/decrypt on size (8*x-1) bits

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -11863,7 +11863,7 @@ static WARN_UNUSED_RESULT int wc_AesFeedbackCFB1(
     }
 
     if (ret == 0) {
-        if (bit > 0 && bit < 7) {
+        if (bit >= 0 && bit < 7) {
             out[0] = cur;
         }
     }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -9152,6 +9152,11 @@ EVP_TEST_END:
         {
             0xC0
         };
+
+        WOLFSSL_SMALL_STACK_STATIC const byte cipher1_7bit[] =
+        {
+            0x1C
+        };
 #endif /* WOLFSSL_AES_128 */
 #ifdef WOLFSSL_AES_192
         WOLFSSL_SMALL_STACK_STATIC const byte iv2[] = {
@@ -9251,6 +9256,15 @@ EVP_TEST_END:
         if (plain[0] != msg1[0])
             ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     #endif /* HAVE_AES_DECRYPT */
+
+        XMEMSET(cipher, 0, sizeof(cipher));
+        ret = wc_AesCfb1Encrypt(enc, cipher, msg1, 7);
+
+        if (ret != 0)
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
+
+        if (cipher[0] != cipher1_7bit[0])
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     #ifdef OPENSSL_EXTRA
         ret = wc_AesSetKey(enc, key1, AES_BLOCK_SIZE, iv, AES_ENCRYPTION);


### PR DESCRIPTION
# Description

Prior to this commit, AES-CFB1 encrypt/decrypts of size (8*x-1) bits would leave the last 7 bits of the input the same as the output

# Testing

SRTP-KDF harness

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
