### PR TITLE
ssl_misc.c: wolfssl_file_len() protection

### DIFF
--- a/src/ssl_misc.c
+++ b/src/ssl_misc.c
@@ -208,9 +208,7 @@ static int wolfssl_read_bio(WOLFSSL_BIO* bio, char** data, int* dataSz,
 #endif /* OPENSSL_EXTRA && !WOLFCRYPT_ONLY */
 
 #if (defined(OPENSSL_EXTRA) || defined(PERSIST_CERT_CACHE) || \
-     (!defined(NO_CERTS) && (!defined(NO_WOLFSSL_CLIENT) || \
-      !defined(WOLFSSL_NO_CLIENT_AUTH)))) && !defined(WOLFCRYPT_ONLY) && \
-    !defined(NO_FILESYSTEM)
+     !defined(NO_CERTS)) && !defined(WOLFCRYPT_ONLY) && !defined(NO_FILESYSTEM)
 /* Read all the data from a file.
  *
  * @param [in]  fp          File pointer to read with.


### PR DESCRIPTION
# Description

wolfssl_file_len is now used by wolfssl_read_file_static() which is compiled in with less restrictions.
Fix #ifdef protection.

# Testing

./configure C_EXTRA_FLAGS=-DNO_WOLFSSL_CLIENT CFLAGS=-DWOLFSSL_NO_CLIENT_AUTH

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
