### PR TITLE
20240417-fix-LoadSystemCaCertsWindows

### DIFF
--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -2872,7 +2872,7 @@ static int LoadSystemCaCertsWindows(WOLFSSL_CTX* ctx, byte* loaded)
         ret = 0;
     }
 
-    for (i = 0; (ret == 0) && (i < sizeof(storeNames)/sizeof(*storeNames));
+    for (i = 0; (ret == 1) && (i < sizeof(storeNames)/sizeof(*storeNames));
          ++i) {
         handle = CertOpenSystemStoreA(hProv, storeNames[i]);
         if (handle != NULL) {


### PR DESCRIPTION
`src/ssl_load.c`: in `LoadSystemCaCertsWindows()`, fix flub introduced in 8e9810e87e.

discovered and tested with `wolfssl-multi-test.sh ... cross-mingw-all-crypto`.
