### PR TITLE
Allow using wolfSSL_CTX_set_default_verify_paths without WOLFSSL_SYS_CA_CERTS defined.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -19648,7 +19648,7 @@ long wolfSSL_CTX_ctrl(WOLFSSL_CTX* ctx, int cmd, long opt, void* pt)
     return ret;
 }
 
-#ifndef WOLFSSL_NO_STUB
+#ifndef NO_WOLFSSL_STUB
 long wolfSSL_CTX_callback_ctrl(WOLFSSL_CTX* ctx, int cmd, void (*fp)(void))
 {
     (void) ctx;
@@ -19658,7 +19658,7 @@ long wolfSSL_CTX_callback_ctrl(WOLFSSL_CTX* ctx, int cmd, void (*fp)(void))
     return WOLFSSL_FAILURE;
 
 }
-#endif /* WOLFSSL_NO_STUB */
+#endif /* NO_WOLFSSL_STUB */
 
 #ifndef NO_WOLFSSL_STUB
 long wolfSSL_CTX_clear_extra_chain_certs(WOLFSSL_CTX* ctx)

--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -5026,8 +5026,6 @@ int wolfSSL_CTX_use_RSAPrivateKey(WOLFSSL_CTX* ctx, WOLFSSL_RSA* rsa)
 
 #ifdef OPENSSL_EXTRA
 
-#ifdef WOLFSSL_SYS_CA_CERTS
-
 /* Use the default paths to look for CA certificate.
  *
  * This is an OpenSSL compatibility layer function, but it doesn't mirror
@@ -5086,7 +5084,7 @@ int wolfSSL_CTX_set_default_verify_paths(WOLFSSL_CTX* ctx)
         WOLFSSL_MSG("wolfSSL_CTX_set_default_verify_paths not supported"
                     " with NO_FILESYSTEM enabled");
         ret = WOLFSSL_FATAL_ERROR;
-    #else
+    #elif defined(WOLFSSL_SYS_CA_CERTS)
         /* Load the system CA certificates. */
         ret = wolfSSL_CTX_load_system_CA_certs(ctx);
         if (ret == WOLFSSL_BAD_PATH) {
@@ -5095,6 +5093,10 @@ int wolfSSL_CTX_set_default_verify_paths(WOLFSSL_CTX* ctx)
              */
             ret = 1;
         }
+    #else
+        /* OpenSSL's implementation of this API does not require loading the
+           system CA cert directory.  Allow skipping this without erroring out. */
+        ret = 1;
     #endif
     }
 
@@ -5102,8 +5104,6 @@ int wolfSSL_CTX_set_default_verify_paths(WOLFSSL_CTX* ctx)
 
     return ret;
 }
-
-#endif /* WOLFSSL_SYS_CA_CERTS */
 
 #endif /* OPENSSL_EXTRA */
 


### PR DESCRIPTION
# Description

Allow using wolfSSL_CTX_set_default_verify_paths without WOLFSSL_SYS_CA_CERTS defined.
Fix NO_WOLFSSL_STUB typo.

Fixes zd#17857

# Testing

Built in tests

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
