### PR TITLE
Add grpc support

### DIFF
--- a/.github/workflows/grpc.yml
+++ b/.github/workflows/grpc.yml
@@ -1,0 +1,103 @@
+name: grpc Tests
+
+# START OF COMMON SECTION
+on:
+  push:
+    branches: [ 'master', 'main', 'release/**' ]
+  pull_request:
+    branches: [ '*' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+# END OF COMMON SECTION
+
+jobs:
+  build_wolfssl:
+    name: Build wolfSSL
+    # Just to keep it the same as the testing target
+    runs-on: ubuntu-latest
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 10
+    steps:
+      - name: Build wolfSSL
+        uses: wolfSSL/actions-build-autotools-project@v1
+        with:
+          path: wolfssl
+          configure: --enable-all 'CPPFLAGS=-DWOLFSSL_RSA_KEY_CHECK -DHAVE_EX_DATA_CLEANUP_HOOKS'
+          install: true
+
+      - name: Upload built lib
+        uses: actions/upload-artifact@v4
+        with:
+          name: wolf-install-grpc
+          path: build-dir
+          retention-days: 5
+
+  grpc_check:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ref: v1.60.0
+            tests: >-
+              bad_ssl_alpn_test bad_ssl_cert_test client_ssl_test
+              crl_ssl_transport_security_test server_ssl_test
+              ssl_transport_security_test ssl_transport_security_utils_test
+              test_core_security_ssl_credentials_test test_cpp_end2end_ssl_credentials_test
+              h2_ssl_cert_test h2_ssl_session_reuse_test
+    name: ${{ matrix.ref }}
+    runs-on: ubuntu-latest
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 60
+    needs: build_wolfssl
+    steps:
+      - name: Confirm IPv4 and IPv6 support
+        run: |
+          ip addr list lo | grep 'inet '
+          ip addr list lo | grep 'inet6 '
+
+      - name: Install prereqs
+        run:
+          sudo apt-get install build-essential autoconf libtool pkg-config cmake clang libc++-dev
+
+      - name: Download lib
+        uses: actions/download-artifact@v4
+        with:
+          name: wolf-install-grpc
+          path: build-dir
+
+      - name: Checkout OSP
+        uses: actions/checkout@v4
+        with:
+          # TODO point to wolf repo once merged
+          repository: julek-wolfssl/osp
+          path: osp
+          ref: grpc-update
+
+      - name: Checkout grpc
+        uses: actions/checkout@v4
+        with:
+          repository: grpc/grpc
+          path: grpc
+          ref: ${{ matrix.ref }}
+
+      - name: Build grpc
+        working-directory: ./grpc
+        run: |
+          patch -p1 < ../osp/grpc/grpc-${{ matrix.ref }}.patch
+          git submodule update --init
+          mkdir cmake/build
+          cd cmake/build
+          cmake -DgRPC_BUILD_TESTS=ON -DgRPC_SSL_PROVIDER=wolfssl \
+            -DWOLFSSL_INSTALL_DIR=$GITHUB_WORKSPACE/build-dir ../..
+          make -j $(nproc) ${{ matrix.tests }}
+
+      - name: Run grpc tests
+        working-directory: ./grpc
+        run: |
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/build-dir/lib:$LD_LIBRARY_PATH
+          ./tools/run_tests/start_port_server.py
+          for t in ${{ matrix.tests }} ; do
+            ./cmake/build/$t
+          done

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -11811,7 +11811,7 @@ cleanup:
     }
 #endif /* SESSION_CERTS && OPENSSL_EXTRA */
 
-    WOLFSSL_X509_STORE* wolfSSL_CTX_get_cert_store(WOLFSSL_CTX* ctx)
+    WOLFSSL_X509_STORE* wolfSSL_CTX_get_cert_store(const WOLFSSL_CTX* ctx)
     {
         if (ctx == NULL) {
             return NULL;
@@ -11819,7 +11819,7 @@ cleanup:
 
         if (ctx->x509_store_pt != NULL)
             return ctx->x509_store_pt;
-        return &ctx->x509_store;
+        return &((WOLFSSL_CTX*)ctx)->x509_store;
     }
 
     void wolfSSL_CTX_set_cert_store(WOLFSSL_CTX* ctx, WOLFSSL_X509_STORE* str)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3062,7 +3062,7 @@ word16 wolfSSL_SNI_GetRequest(WOLFSSL* ssl, byte type, void** data)
         *data = NULL;
 
     if (ssl && ssl->extensions)
-        return TLSX_SNI_GetRequest(ssl->extensions, type, data);
+        return TLSX_SNI_GetRequest(ssl->extensions, type, data, 0);
 
     return 0;
 }
@@ -17745,7 +17745,7 @@ WOLFSSL_X509* wolfSSL_get_chain_X509(WOLFSSL_X509_CHAIN* chain, int idx)
 #endif
 
     WOLFSSL_ENTER("wolfSSL_get_chain_X509");
-    if (chain != NULL) {
+    if (chain != NULL && idx < MAX_CHAIN_DEPTH) {
     #ifdef WOLFSSL_SMALL_STACK
         cert = (DecodedCert*)XMALLOC(sizeof(DecodedCert), NULL,
                                                        DYNAMIC_TYPE_DCERT);
@@ -20025,17 +20025,17 @@ int wolfSSL_set_tlsext_host_name(WOLFSSL* ssl, const char* host_name)
     return ret;
 }
 
-
-#ifndef NO_WOLFSSL_SERVER
+/* May be called by server to get the requested accepted name and by the client
+ * to get the requested name. */
 const char * wolfSSL_get_servername(WOLFSSL* ssl, byte type)
 {
     void * serverName = NULL;
     if (ssl == NULL)
         return NULL;
-    TLSX_SNI_GetRequest(ssl->extensions, type, &serverName);
+    TLSX_SNI_GetRequest(ssl->extensions, type, &serverName,
+            !wolfSSL_is_server(ssl));
     return (const char *)serverName;
 }
-#endif /* NO_WOLFSSL_SERVER */
 #endif /* HAVE_SNI */
 
 WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
@@ -20062,6 +20062,13 @@ WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
         return NULL;
     if (ssl->ctx == ctx)
         return ssl->ctx;
+
+    if (ctx->suites == NULL) {
+        /* suites */
+        if (AllocateCtxSuites(ctx) != 0)
+            return NULL;
+        InitSSL_CTX_Suites(ctx);
+    }
 
     wolfSSL_RefInc(&ctx->ref, &ret);
 #ifdef WOLFSSL_REFCNT_ERROR_RETURN
@@ -20988,8 +20995,9 @@ long wolfSSL_CTX_get_tlsext_ticket_keys(WOLFSSL_CTX *ctx,
  *          correct length.
  */
 long wolfSSL_CTX_set_tlsext_ticket_keys(WOLFSSL_CTX *ctx,
-     unsigned char *keys, int keylen)
+     const void *keys_vp, int keylen)
 {
+    const byte* keys = (const byte*)keys_vp;
     if (ctx == NULL || keys == NULL) {
         return WOLFSSL_FAILURE;
     }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4081,11 +4081,7 @@ int wolfSSL_get_error(WOLFSSL* ssl, int ret)
     else if (ssl->error == SOCKET_PEER_CLOSED_E)
         return WOLFSSL_ERROR_SYSCALL;           /* convert to OpenSSL type */
 #endif
-#if defined(WOLFSSL_HAPROXY)
-    return GetX509Error(ssl->error);
-#else
-    return (ssl->error);
-#endif
+    return ssl->error;
 }
 
 

--- a/src/ssl_asn1.c
+++ b/src/ssl_asn1.c
@@ -2997,7 +2997,7 @@ void wolfSSL_ASN1_GENERALIZEDTIME_free(WOLFSSL_ASN1_TIME* asn1Time)
 {
     WOLFSSL_ENTER("wolfSSL_ASN1_GENERALIZEDTIME_free");
     if (asn1Time != NULL) {
-        XMEMSET(asn1Time->data, 0, sizeof(asn1Time->data));
+        XFREE(asn1Time, NULL, DYNAMIC_TYPE_OPENSSL);
     }
 }
 
@@ -3533,6 +3533,32 @@ WOLFSSL_ASN1_TIME* wolfSSL_ASN1_TIME_to_generalizedtime(WOLFSSL_ASN1_TIME *t,
         if (out != NULL) {
             *out = ret;
         }
+    }
+
+    return ret;
+}
+
+WOLFSSL_ASN1_TIME* wolfSSL_ASN1_UTCTIME_set(WOLFSSL_ASN1_TIME *s, time_t t)
+{
+    WOLFSSL_ASN1_TIME* ret = s;
+
+    WOLFSSL_ENTER("wolfSSL_ASN1_UTCTIME_set");
+
+    if (ret == NULL) {
+        ret = wolfSSL_ASN1_TIME_new();
+        if (ret == NULL)
+            return NULL;
+    }
+
+    ret->length = GetFormattedTime(&t, ret->data, sizeof(ret->data));
+    if (ret->length + 1 != ASN_UTC_TIME_SIZE) {
+        /* Either snprintf error or t can't be represented in UTC format */
+        if (ret != s)
+            wolfSSL_ASN1_TIME_free(ret);
+        ret = NULL;
+    }
+    else {
+        ret->type = V_ASN1_UTCTIME;
     }
 
     return ret;

--- a/src/ssl_sess.c
+++ b/src/ssl_sess.c
@@ -1726,7 +1726,7 @@ WOLFSSL_SESSION* ClientSessionToSession(const WOLFSSL_SESSION* session)
             /* Check the session ID hash matches */
             error = clientSession->sessionIDHash != sessionIDHash;
             if (error != 0)
-                WOLFSSL_MSG("session ID hash don't match");
+                WOLFSSL_MSG("session ID hashes don't match");
         }
         if (error == 0) {
             /* Hashes match */

--- a/src/tls.c
+++ b/src/tls.c
@@ -2407,12 +2407,13 @@ int TLSX_UseSNI(TLSX** extensions, byte type, const void* data, word16 size,
 #ifndef NO_WOLFSSL_SERVER
 
 /** Tells the SNI requested by the client. */
-word16 TLSX_SNI_GetRequest(TLSX* extensions, byte type, void** data)
+word16 TLSX_SNI_GetRequest(TLSX* extensions, byte type, void** data,
+        byte ignoreStatus)
 {
     TLSX* extension = TLSX_Find(extensions, TLSX_SERVER_NAME);
     SNI* sni = TLSX_SNI_Find(extension ? (SNI*)extension->data : NULL, type);
 
-    if (sni && sni->status != WOLFSSL_SNI_NO_MATCH) {
+    if (sni && (ignoreStatus || sni->status != WOLFSSL_SNI_NO_MATCH)) {
         switch (sni->type) {
             case WOLFSSL_SNI_HOST_NAME:
                 if (data) {

--- a/src/x509_str.c
+++ b/src/x509_str.c
@@ -40,27 +40,59 @@
  * START OF X509_STORE_CTX APIs
  ******************************************************************************/
 
-#ifdef OPENSSL_EXTRA
-
-WOLFSSL_X509_STORE_CTX* wolfSSL_X509_STORE_CTX_new(void)
+/* This API is necessary outside of OPENSSL_EXTRA because it is used in
+ * SetupStoreCtxCallback */
+WOLFSSL_X509_STORE_CTX* wolfSSL_X509_STORE_CTX_new_ex(void* heap)
 {
     WOLFSSL_X509_STORE_CTX* ctx;
-    WOLFSSL_ENTER("wolfSSL_X509_STORE_CTX_new");
+    WOLFSSL_ENTER("wolfSSL_X509_STORE_CTX_new_ex");
 
-    ctx = (WOLFSSL_X509_STORE_CTX*)XMALLOC(sizeof(WOLFSSL_X509_STORE_CTX), NULL,
+    ctx = (WOLFSSL_X509_STORE_CTX*)XMALLOC(sizeof(WOLFSSL_X509_STORE_CTX), heap,
                                     DYNAMIC_TYPE_X509_CTX);
     if (ctx != NULL) {
-        ctx->param = NULL;
+        XMEMSET(ctx, 0, sizeof(WOLFSSL_X509_STORE_CTX));
+        ctx->heap = heap;
+#ifdef OPENSSL_EXTRA
         if (wolfSSL_X509_STORE_CTX_init(ctx, NULL, NULL, NULL) !=
                 WOLFSSL_SUCCESS) {
-            XFREE(ctx, NULL, DYNAMIC_TYPE_X509_CTX);
+            XFREE(ctx, heap, DYNAMIC_TYPE_X509_CTX);
             ctx = NULL;
         }
+#endif
     }
 
     return ctx;
 }
 
+/* This API is necessary outside of OPENSSL_EXTRA because it is used in
+ * SetupStoreCtxCallback */
+/* free's extra data */
+void wolfSSL_X509_STORE_CTX_free(WOLFSSL_X509_STORE_CTX* ctx)
+{
+    WOLFSSL_ENTER("wolfSSL_X509_STORE_CTX_free");
+    if (ctx != NULL) {
+#ifdef HAVE_EX_DATA_CLEANUP_HOOKS
+        wolfSSL_CRYPTO_cleanup_ex_data(&ctx->ex_data);
+#endif
+
+#ifdef OPENSSL_EXTRA
+        if (ctx->param != NULL) {
+            XFREE(ctx->param, ctx->heap, DYNAMIC_TYPE_OPENSSL);
+            ctx->param = NULL;
+        }
+#endif
+
+        XFREE(ctx, ctx->heap, DYNAMIC_TYPE_X509_CTX);
+    }
+}
+
+#ifdef OPENSSL_EXTRA
+
+WOLFSSL_X509_STORE_CTX* wolfSSL_X509_STORE_CTX_new(void)
+{
+    WOLFSSL_ENTER("wolfSSL_X509_STORE_CTX_new");
+    return wolfSSL_X509_STORE_CTX_new_ex(NULL);
+}
 
 int wolfSSL_X509_STORE_CTX_init(WOLFSSL_X509_STORE_CTX* ctx,
      WOLFSSL_X509_STORE* store, WOLFSSL_X509* x509,
@@ -134,35 +166,17 @@ int wolfSSL_X509_STORE_CTX_init(WOLFSSL_X509_STORE_CTX* ctx,
         if (ctx->param == NULL) {
             ctx->param = (WOLFSSL_X509_VERIFY_PARAM*)XMALLOC(
                            sizeof(WOLFSSL_X509_VERIFY_PARAM),
-                           NULL, DYNAMIC_TYPE_OPENSSL);
+                           ctx->heap, DYNAMIC_TYPE_OPENSSL);
             if (ctx->param == NULL){
                 WOLFSSL_MSG("wolfSSL_X509_STORE_CTX_init failed");
                 return WOLFSSL_FAILURE;
             }
+            XMEMSET(ctx->param, 0, sizeof(*ctx->param));
         }
 
         return WOLFSSL_SUCCESS;
     }
     return WOLFSSL_FAILURE;
-}
-
-
-/* free's extra data */
-void wolfSSL_X509_STORE_CTX_free(WOLFSSL_X509_STORE_CTX* ctx)
-{
-    WOLFSSL_ENTER("wolfSSL_X509_STORE_CTX_free");
-    if (ctx != NULL) {
-#ifdef HAVE_EX_DATA_CLEANUP_HOOKS
-        wolfSSL_CRYPTO_cleanup_ex_data(&ctx->ex_data);
-#endif
-
-        if (ctx->param != NULL) {
-            XFREE(ctx->param, NULL, DYNAMIC_TYPE_OPENSSL);
-            ctx->param = NULL;
-        }
-
-        XFREE(ctx, NULL, DYNAMIC_TYPE_X509_CTX);
-    }
 }
 
 /* Its recommended to use a full free -> init cycle of all the objects
@@ -173,7 +187,7 @@ void wolfSSL_X509_STORE_CTX_cleanup(WOLFSSL_X509_STORE_CTX* ctx)
     if (ctx != NULL) {
 
         if (ctx->param != NULL) {
-            XFREE(ctx->param, NULL, DYNAMIC_TYPE_OPENSSL);
+            XFREE(ctx->param, ctx->heap, DYNAMIC_TYPE_OPENSSL);
             ctx->param = NULL;
         }
 
@@ -212,6 +226,8 @@ int GetX509Error(int e)
             return WOLFSSL_X509_V_ERR_CERT_SIGNATURE_FAILURE;
         case CRL_CERT_REVOKED:
             return WOLFSSL_X509_V_ERR_CERT_REVOKED;
+        case CRL_MISSING:
+            return X509_V_ERR_UNABLE_TO_GET_CRL;
         case 0:
         case 1:
             return 0;
@@ -504,39 +520,19 @@ WOLFSSL_STACK* wolfSSL_X509_STORE_CTX_get_chain(WOLFSSL_X509_STORE_CTX* ctx)
     /* if chain is null but sesChain is available then populate stack */
     if (ctx->chain == NULL && ctx->sesChain != NULL) {
         int i;
+        int error = 0;
         WOLFSSL_X509_CHAIN* c = ctx->sesChain;
-        WOLFSSL_STACK*     sk = (WOLFSSL_STACK*)XMALLOC(sizeof(WOLFSSL_STACK),
-                                    NULL, DYNAMIC_TYPE_X509);
+        WOLFSSL_STACK*     sk = wolfSSL_sk_new_node(ctx->heap);
 
-        if (sk == NULL) {
+        if (sk == NULL)
             return NULL;
-        }
-
-        XMEMSET(sk, 0, sizeof(WOLFSSL_STACK));
-
-        for (i = 0; i < c->count && i < MAX_CHAIN_DEPTH; i++) {
-            WOLFSSL_X509* x509 = wolfSSL_get_chain_X509(c, i);
-
-            if (x509 == NULL) {
-                WOLFSSL_MSG("Unable to get x509 from chain");
-                wolfSSL_sk_X509_pop_free(sk, NULL);
-                return NULL;
-            }
-
-            if (wolfSSL_sk_X509_push(sk, x509) != WOLFSSL_SUCCESS) {
-                WOLFSSL_MSG("Unable to load x509 into stack");
-                wolfSSL_sk_X509_pop_free(sk, NULL);
-                wolfSSL_X509_free(x509);
-                return NULL;
-            }
-        }
 
 #if defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) || defined(OPENSSL_EXTRA)
         /* add CA used to verify top of chain to the list */
         if (c->count > 0) {
             WOLFSSL_X509* x509 = wolfSSL_get_chain_X509(c, c->count - 1);
+            WOLFSSL_X509* issuer = NULL;
             if (x509 != NULL) {
-                WOLFSSL_X509* issuer = NULL;
                 if (wolfSSL_X509_STORE_CTX_get1_issuer(&issuer, ctx, x509)
                         == WOLFSSL_SUCCESS) {
                     /* check that the certificate being looked up is not self
@@ -545,24 +541,47 @@ WOLFSSL_STACK* wolfSSL_X509_STORE_CTX_get_chain(WOLFSSL_X509_STORE_CTX* ctx)
                                 &x509->subject) != 0) {
                         if (wolfSSL_sk_X509_push(sk, issuer) != WOLFSSL_SUCCESS) {
                             WOLFSSL_MSG("Unable to load CA x509 into stack");
-                            wolfSSL_sk_X509_pop_free(sk, NULL);
-                            wolfSSL_X509_free(issuer);
-                            return NULL;
+                            error = 1;
                         }
                     }
                     else {
                         WOLFSSL_MSG("Certificate is self signed");
-                        if (issuer != NULL)
-                            wolfSSL_X509_free(issuer);
+                        wolfSSL_X509_free(issuer);
                     }
                 }
                 else {
-                    wolfSSL_X509_free(x509);
                     WOLFSSL_MSG("Could not find CA for certificate");
                 }
             }
+            wolfSSL_X509_free(x509);
+            if (error) {
+                wolfSSL_sk_X509_pop_free(sk, NULL);
+                wolfSSL_X509_free(issuer);
+                return NULL;
+            }
         }
 #endif
+
+        for (i = c->count - 1; i >= 0; i--) {
+            WOLFSSL_X509* x509 = wolfSSL_get_chain_X509(c, i);
+
+            if (x509 == NULL) {
+                WOLFSSL_MSG("Unable to get x509 from chain");
+                error = 1;
+                break;
+            }
+
+            if (wolfSSL_sk_X509_push(sk, x509) != WOLFSSL_SUCCESS) {
+                WOLFSSL_MSG("Unable to load x509 into stack");
+                wolfSSL_X509_free(x509);
+                error = 1;
+                break;
+            }
+        }
+        if (error) {
+            wolfSSL_sk_X509_pop_free(sk, NULL);
+            return NULL;
+        }
         ctx->chain = sk;
     }
 #endif /* SESSION_CERTS */
@@ -611,6 +630,14 @@ int wolfSSL_X509_STORE_get_by_subject(WOLFSSL_X509_STORE_CTX* ctx, int idx,
 }
 #endif
 
+WOLFSSL_X509_VERIFY_PARAM *wolfSSL_X509_STORE_CTX_get0_param(
+        WOLFSSL_X509_STORE_CTX *ctx)
+{
+    if (ctx == NULL)
+        return NULL;
+
+    return ctx->param;
+}
 
 #endif /* OPENSSL_EXTRA */
 
@@ -935,14 +962,33 @@ int wolfSSL_X509_STORE_set_ex_data_with_cleanup(
 #ifdef OPENSSL_EXTRA
 
 #if defined(WOLFSSL_QT) || defined(OPENSSL_ALL)
-    void wolfSSL_X509_STORE_set_verify_cb(WOLFSSL_X509_STORE *st,
-                                 WOLFSSL_X509_STORE_CTX_verify_cb verify_cb)
-    {
-        WOLFSSL_ENTER("wolfSSL_X509_STORE_set_verify_cb");
-        if (st != NULL) {
-            st->verify_cb = verify_cb;
-        }
+void wolfSSL_X509_STORE_set_verify_cb(WOLFSSL_X509_STORE *st,
+        WOLFSSL_X509_STORE_CTX_verify_cb verify_cb)
+{
+    WOLFSSL_ENTER("wolfSSL_X509_STORE_set_verify_cb");
+    if (st != NULL) {
+        st->verify_cb = verify_cb;
     }
+}
+
+void wolfSSL_X509_STORE_set_get_crl(WOLFSSL_X509_STORE *st,
+        WOLFSSL_X509_STORE_CTX_get_crl_cb get_cb)
+{
+    WOLFSSL_ENTER("wolfSSL_X509_STORE_set_get_crl");
+    if (st != NULL) {
+        st->get_crl_cb = get_cb;
+    }
+}
+
+#ifndef NO_WOLFSSL_STUB
+void wolfSSL_X509_STORE_set_check_crl(WOLFSSL_X509_STORE *st,
+        WOLFSSL_X509_STORE_CTX_check_crl_cb check_crl)
+{
+    (void)st;
+    (void)check_crl;
+    WOLFSSL_STUB("wolfSSL_X509_STORE_set_check_crl (not implemented)");
+}
+#endif
 #endif /* WOLFSSL_QT || OPENSSL_ALL */
 
 WOLFSSL_X509_LOOKUP* wolfSSL_X509_STORE_add_lookup(WOLFSSL_X509_STORE* store,
@@ -1327,6 +1373,17 @@ err_cleanup:
     return NULL;
 }
 #endif /* OPENSSL_ALL */
+
+#if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER) || \
+    defined(WOLFSSL_WPAS_SMALL)
+WOLFSSL_X509_VERIFY_PARAM *wolfSSL_X509_STORE_get0_param(
+        const WOLFSSL_X509_STORE *ctx)
+{
+    if (ctx == NULL)
+        return NULL;
+    return ctx->param;
+}
+#endif
 
 /*******************************************************************************
  * END OF X509_STORE APIs

--- a/tests/api.c
+++ b/tests/api.c
@@ -41936,7 +41936,8 @@ static int test_wolfSSL_X509_VERIFY_PARAM(void)
     return EXPECT_RESULT();
 }
 
-#if defined(OPENSSL_EXTRA) && defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES)
+#if defined(OPENSSL_EXTRA) && defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && \
+    !defined(WOLFSSL_HOSTNAME_VERIFY_ALT_NAME_ONLY)
 
 static int test_wolfSSL_check_domain_verify_count = 0;
 
@@ -41998,6 +41999,14 @@ static int test_wolfSSL_check_domain(void)
     ExpectIntEQ(test_wolfSSL_check_domain_verify_count, 1);
 #endif
 
+    return EXPECT_RESULT();
+}
+
+#else
+
+static int test_wolfSSL_check_domain(void)
+{
+    EXPECT_DECLS;
     return EXPECT_RESULT();
 }
 
@@ -72953,9 +72962,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_BIO_get_len),
 #endif
 
-#if defined(OPENSSL_EXTRA) && defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES)
     TEST_DECL(test_wolfSSL_check_domain),
-#endif
     TEST_DECL(test_wolfSSL_cert_cb),
     TEST_DECL(test_wolfSSL_cert_cb_dyn_ciphers),
     TEST_DECL(test_wolfSSL_ciphersuite_auth),

--- a/tests/api.c
+++ b/tests/api.c
@@ -32408,20 +32408,11 @@ static int test_wolfSSL_ASN1_GENERALIZEDTIME_free(void)
     EXPECT_DECLS;
 #if defined(OPENSSL_EXTRA)
     WOLFSSL_ASN1_GENERALIZEDTIME* asn1_gtime = NULL;
-    unsigned char nullstr[32];
 
-    XMEMSET(nullstr, 0, 32);
-    ExpectNotNull(asn1_gtime = (WOLFSSL_ASN1_GENERALIZEDTIME*)XMALLOC(
-        sizeof(WOLFSSL_ASN1_GENERALIZEDTIME), NULL, DYNAMIC_TYPE_TMP_BUFFER));
-    if (asn1_gtime != NULL) {
-        XMEMCPY(asn1_gtime->data,"20180504123500Z",ASN_GENERALIZED_TIME_SIZE);
-
-        wolfSSL_ASN1_GENERALIZEDTIME_free(asn1_gtime);
-        ExpectIntEQ(0, XMEMCMP(asn1_gtime->data, nullstr, 32));
-
-        XFREE(asn1_gtime, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
-    wolfSSL_ASN1_GENERALIZEDTIME_free(NULL);
+    ExpectNotNull(asn1_gtime = ASN1_GENERALIZEDTIME_new());
+    if (asn1_gtime != NULL)
+        XMEMCPY(asn1_gtime->data, "20180504123500Z", ASN_GENERALIZED_TIME_SIZE);
+    ASN1_GENERALIZEDTIME_free(asn1_gtime);
 #endif /* OPENSSL_EXTRA */
     return EXPECT_RESULT();
 }
@@ -32430,7 +32421,7 @@ static int test_wolfSSL_ASN1_GENERALIZEDTIME_print(void)
 {
     EXPECT_DECLS;
 #if defined(OPENSSL_EXTRA) && !defined(NO_BIO)
-    WOLFSSL_ASN1_GENERALIZEDTIME gtime;
+    WOLFSSL_ASN1_GENERALIZEDTIME* gtime = NULL;
     BIO* bio = NULL;
     unsigned char buf[24];
     int i;
@@ -32438,19 +32429,17 @@ static int test_wolfSSL_ASN1_GENERALIZEDTIME_print(void)
     ExpectNotNull(bio = BIO_new(BIO_s_mem()));
     BIO_set_write_buf_size(bio, 24);
 
-    XMEMSET(&gtime, 0, sizeof(WOLFSSL_ASN1_GENERALIZEDTIME));
-    XMEMCPY(gtime.data, "20180504123500Z", ASN_GENERALIZED_TIME_SIZE);
-    gtime.length = ASN_GENERALIZED_TIME_SIZE;
+    ExpectNotNull(gtime = ASN1_GENERALIZEDTIME_new());
     /* Type not set. */
-    ExpectIntEQ(wolfSSL_ASN1_GENERALIZEDTIME_print(bio, &gtime), 0);
-    gtime.type = V_ASN1_GENERALIZEDTIME;
+    ExpectIntEQ(wolfSSL_ASN1_GENERALIZEDTIME_print(bio, gtime), 0);
+    ExpectIntEQ(wolfSSL_ASN1_TIME_set_string(gtime, "20180504123500Z"), 1);
 
     /* Invalid parameters testing. */
     ExpectIntEQ(wolfSSL_ASN1_GENERALIZEDTIME_print(NULL, NULL), BAD_FUNC_ARG);
     ExpectIntEQ(wolfSSL_ASN1_GENERALIZEDTIME_print(bio, NULL), BAD_FUNC_ARG);
-    ExpectIntEQ(wolfSSL_ASN1_GENERALIZEDTIME_print(NULL, &gtime), BAD_FUNC_ARG);
+    ExpectIntEQ(wolfSSL_ASN1_GENERALIZEDTIME_print(NULL, gtime), BAD_FUNC_ARG);
 
-    ExpectIntEQ(wolfSSL_ASN1_GENERALIZEDTIME_print(bio, &gtime), 1);
+    ExpectIntEQ(wolfSSL_ASN1_GENERALIZEDTIME_print(bio, gtime), 1);
     ExpectIntEQ(BIO_read(bio, buf, sizeof(buf)), 20);
     ExpectIntEQ(XMEMCMP(buf, "May 04 12:35:00 2018", 20), 0);
 
@@ -32461,14 +32450,14 @@ static int test_wolfSSL_ASN1_GENERALIZEDTIME_print(void)
     ExpectIntEQ(BIO_set_write_buf_size(bio, 1), 1);
     /* Ensure there is 0 bytes available to write into. */
     ExpectIntEQ(BIO_write(bio, buf, 1), 1);
-    ExpectIntEQ(wolfSSL_ASN1_GENERALIZEDTIME_print(bio, &gtime), 0);
+    ExpectIntEQ(wolfSSL_ASN1_GENERALIZEDTIME_print(bio, gtime), 0);
     for (i = 1; i < 20; i++) {
         ExpectIntEQ(BIO_set_write_buf_size(bio, i), 1);
-        ExpectIntEQ(wolfSSL_ASN1_GENERALIZEDTIME_print(bio, &gtime), 0);
+        ExpectIntEQ(wolfSSL_ASN1_GENERALIZEDTIME_print(bio, gtime), 0);
     }
     BIO_free(bio);
 
-    wolfSSL_ASN1_GENERALIZEDTIME_free(&gtime);
+    wolfSSL_ASN1_GENERALIZEDTIME_free(gtime);
 #endif /* OPENSSL_EXTRA */
     return EXPECT_RESULT();
 }
@@ -41650,6 +41639,13 @@ static int test_wolfSSL_X509_sign(void)
     }
 #endif
 #endif /* WOLFSSL_ALT_NAMES */
+
+    {
+        ASN1_UTCTIME* infinite_past = NULL;
+        ExpectNotNull(infinite_past = ASN1_UTCTIME_set(NULL, 0));
+        ExpectIntEQ(X509_set1_notBefore(x509, infinite_past), 1);
+        ASN1_UTCTIME_free(infinite_past);
+    }
 
     /* test valid sign case */
     ExpectIntGT(ret = X509_sign(x509, priv, EVP_sha256()), 0);
@@ -55183,7 +55179,8 @@ static int test_X509_LOOKUP_add_dir(void)
     /* Now we SHOULD get CRL_MISSING, because we looked for PEM
      * in dir containing only ASN1/DER. */
     ExpectIntEQ(X509_verify_cert(storeCtx), WOLFSSL_FAILURE);
-    ExpectIntEQ(X509_STORE_CTX_get_error(storeCtx), CRL_MISSING);
+    ExpectIntEQ(X509_STORE_CTX_get_error(storeCtx),
+            X509_V_ERR_UNABLE_TO_GET_CRL);
 
     X509_CRL_free(crl);
     X509_STORE_free(store);
@@ -58647,6 +58644,155 @@ static int test_wolfSSL_X509_STORE_get1_certs(void)
 #endif /* OPENSSL_EXTRA && WOLFSSL_SIGNER_DER_CERT && !NO_FILESYSTEM */
     return EXPECT_RESULT();
 }
+
+#if defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && \
+    defined(WOLFSSL_LOCAL_X509_STORE) && \
+    (defined(OPENSSL_ALL) || defined(WOLFSSL_QT)) && defined(HAVE_CRL)
+static int test_wolfSSL_X509_STORE_set_get_crl_provider(X509_STORE_CTX* ctx,
+        X509_CRL** crl_out, X509* cert) {
+    X509_CRL *crl = NULL;
+    XFILE fp = XBADFILE;
+    char* cert_issuer = X509_NAME_oneline(X509_get_issuer_name(cert), NULL, 0);
+    int ret = 0;
+
+    (void)ctx;
+
+    if (cert_issuer == NULL)
+        return 0;
+
+    if ((fp = XFOPEN("certs/crl/crl.pem", "rb")) != XBADFILE) {
+        PEM_read_X509_CRL(fp, &crl, NULL, NULL);
+        XFCLOSE(fp);
+        if (crl != NULL) {
+            char* crl_issuer = X509_NAME_oneline(
+                    X509_CRL_get_issuer(crl), NULL, 0);
+            if (XSTRCMP(cert_issuer, crl_issuer) == 0) {
+                *crl_out = X509_CRL_dup(crl);
+                if (*crl_out != NULL)
+                    ret = 1;
+            }
+            OPENSSL_free(crl_issuer);
+        }
+    }
+
+    X509_CRL_free(crl);
+    OPENSSL_free(cert_issuer);
+    return ret;
+}
+
+static int test_wolfSSL_X509_STORE_set_get_crl_provider2(X509_STORE_CTX* ctx,
+        X509_CRL** crl_out, X509* cert) {
+    (void)ctx;
+    (void)cert;
+    *crl_out = NULL;
+    return 1;
+}
+
+#ifndef NO_WOLFSSL_STUB
+static int test_wolfSSL_X509_STORE_set_get_crl_check(X509_STORE_CTX* ctx,
+        X509_CRL* crl) {
+    (void)ctx;
+    (void)crl;
+    return 1;
+}
+#endif
+
+static int test_wolfSSL_X509_STORE_set_get_crl_verify(int ok,
+        X509_STORE_CTX* ctx) {
+    int cert_error = X509_STORE_CTX_get_error(ctx);
+    X509_VERIFY_PARAM* param = X509_STORE_CTX_get0_param(ctx);
+    int flags = X509_VERIFY_PARAM_get_flags(param);
+    if ((flags & (X509_V_FLAG_CRL_CHECK | X509_V_FLAG_CRL_CHECK_ALL)) !=
+            (X509_V_FLAG_CRL_CHECK | X509_V_FLAG_CRL_CHECK_ALL)) {
+        /* Make sure the flags are set */
+        return 0;
+    }
+    /* Ignore CRL missing error */
+#ifndef OPENSSL_COMPATIBLE_DEFAULTS
+    if (cert_error == CRL_MISSING)
+#else
+    if (cert_error == X509_V_ERR_UNABLE_TO_GET_CRL)
+#endif
+        return 1;
+    return ok;
+}
+
+static int test_wolfSSL_X509_STORE_set_get_crl_ctx_ready(WOLFSSL_CTX* ctx)
+{
+    EXPECT_DECLS;
+    X509_STORE* cert_store = NULL;
+
+    ExpectIntEQ(wolfSSL_CTX_EnableCRL(ctx, WOLFSSL_CRL_CHECKALL),
+            WOLFSSL_SUCCESS);
+    ExpectNotNull(cert_store = SSL_CTX_get_cert_store(ctx));
+    X509_STORE_set_get_crl(cert_store,
+            test_wolfSSL_X509_STORE_set_get_crl_provider);
+#ifndef NO_WOLFSSL_STUB
+    X509_STORE_set_check_crl(cert_store,
+            test_wolfSSL_X509_STORE_set_get_crl_check);
+#endif
+
+    return EXPECT_RESULT();
+}
+
+static int test_wolfSSL_X509_STORE_set_get_crl_ctx_ready2(WOLFSSL_CTX* ctx)
+{
+    EXPECT_DECLS;
+    X509_STORE* cert_store = NULL;
+    X509_VERIFY_PARAM* param = NULL;
+
+    SSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_PEER, NULL);
+    ExpectIntEQ(wolfSSL_CTX_EnableCRL(ctx, WOLFSSL_CRL_CHECKALL),
+            WOLFSSL_SUCCESS);
+    ExpectNotNull(cert_store = SSL_CTX_get_cert_store(ctx));
+    X509_STORE_set_get_crl(cert_store,
+            test_wolfSSL_X509_STORE_set_get_crl_provider2);
+#ifndef NO_WOLFSSL_STUB
+    X509_STORE_set_check_crl(cert_store,
+            test_wolfSSL_X509_STORE_set_get_crl_check);
+#endif
+    X509_STORE_set_verify_cb(cert_store,
+            test_wolfSSL_X509_STORE_set_get_crl_verify);
+    ExpectNotNull(param = X509_STORE_get0_param(cert_store));
+    ExpectIntEQ(X509_VERIFY_PARAM_set_flags(
+        param, X509_V_FLAG_CRL_CHECK | X509_V_FLAG_CRL_CHECK_ALL), 1);
+    ExpectIntEQ(X509_STORE_set_flags(cert_store,
+            X509_V_FLAG_CRL_CHECK | X509_V_FLAG_CRL_CHECK_ALL), 1);
+
+    return EXPECT_RESULT();
+}
+#endif
+
+/* This test mimics the usage of the CRL provider in gRPC */
+static int test_wolfSSL_X509_STORE_set_get_crl(void)
+{
+    EXPECT_DECLS;
+#if defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && \
+    defined(WOLFSSL_LOCAL_X509_STORE) && \
+    (defined(OPENSSL_ALL) || defined(WOLFSSL_QT)) && defined(HAVE_CRL)
+    test_ssl_cbf func_cb_client;
+    test_ssl_cbf func_cb_server;
+
+    XMEMSET(&func_cb_client, 0, sizeof(func_cb_client));
+    XMEMSET(&func_cb_server, 0, sizeof(func_cb_server));
+
+    func_cb_client.ctx_ready = test_wolfSSL_X509_STORE_set_get_crl_ctx_ready;
+
+    ExpectIntEQ(test_wolfSSL_client_server_nofail_memio(&func_cb_client,
+        &func_cb_server, NULL), TEST_SUCCESS);
+
+    XMEMSET(&func_cb_client, 0, sizeof(func_cb_client));
+    XMEMSET(&func_cb_server, 0, sizeof(func_cb_server));
+
+    func_cb_client.ctx_ready = test_wolfSSL_X509_STORE_set_get_crl_ctx_ready2;
+
+    ExpectIntEQ(test_wolfSSL_client_server_nofail_memio(&func_cb_client,
+        &func_cb_server, NULL), TEST_SUCCESS);
+#endif
+    return EXPECT_RESULT();
+}
+
+
 static int test_wolfSSL_dup_CA_list(void)
 {
     int res = TEST_SKIPPED;
@@ -70724,11 +70870,7 @@ static int test_revoked_loaded_int_cert(void)
 
         ExpectIntEQ(test_wolfSSL_client_server_nofail_memio(&client_cbf,
             &server_cbf, NULL), TEST_FAIL);
-#ifndef WOLFSSL_HAPROXY
         ExpectIntEQ(client_cbf.last_err, CRL_CERT_REVOKED);
-#else
-        ExpectIntEQ(client_cbf.last_err, WOLFSSL_X509_V_ERR_CERT_REVOKED);
-#endif
         ExpectIntEQ(server_cbf.last_err, FATAL_ERROR);
 
         if (!EXPECT_SUCCESS())
@@ -72647,6 +72789,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_X509_STORE_get0_objects),
     TEST_DECL(test_wolfSSL_X509_load_crl_file),
     TEST_DECL(test_wolfSSL_X509_STORE_get1_certs),
+    TEST_DECL(test_wolfSSL_X509_STORE_set_get_crl),
     TEST_DECL(test_wolfSSL_X509_NAME_ENTRY_get_object),
     TEST_DECL(test_wolfSSL_X509_cmp_time),
     TEST_DECL(test_wolfSSL_X509_time_adj),

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -11408,6 +11408,47 @@ DNS_entry* AltNameNew(void* heap)
     return ret;
 }
 
+DNS_entry* AltNameDup(DNS_entry* from, void* heap)
+{
+    DNS_entry* ret;
+
+    ret = AltNameNew(heap);
+    if (ret == NULL) {
+        WOLFSSL_MSG("\tOut of Memory");
+        return NULL;
+    }
+
+    ret->type = from->type;
+    ret->len = from->len;
+
+
+    ret->name = CopyString(from->name, from->len, heap, DYNAMIC_TYPE_ALTNAME);
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME)
+    ret->ipString = CopyString(from->ipString, 0, heap, DYNAMIC_TYPE_ALTNAME);
+#endif
+#ifdef OPENSSL_ALL
+    ret->ridString = CopyString(from->ridString, 0, heap, DYNAMIC_TYPE_ALTNAME);
+#endif
+    if (ret->name == NULL
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME)
+            || (from->ipString != NULL && ret->ipString == NULL)
+#endif
+#ifdef OPENSSL_ALL
+            || (from->ridString != NULL && ret->ridString == NULL)
+#endif
+            ) {
+        WOLFSSL_MSG("\tOut of Memory");
+        FreeAltNames(ret, heap);
+        return NULL;
+    }
+
+#ifdef WOLFSSL_FPKI
+    ret->oidSum = from->oidSum;
+#endif
+
+    return ret;
+}
+
 
 #ifndef IGNORE_NAME_CONSTRAINTS
 

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -1001,6 +1001,25 @@ WC_MISC_STATIC WC_INLINE word32 HashObject(const byte* o, word32 len,
 #endif /* WOLFCRYPT_ONLY && !NO_HASH_WRAPPER &&
         * (!NO_SESSION_CACHE || HAVE_SESSION_TICKET) */
 
+WC_MISC_STATIC WC_INLINE char* CopyString(const char* src, int srcLen,
+        void* heap, int type) {
+    char* dst = NULL;
+
+    if (src == NULL)
+        return NULL;
+
+    if (srcLen <= 0)
+        srcLen = (int)XSTRLEN(src);
+
+    dst = (char*)XMALLOC(srcLen + 1, heap, type);
+    if (dst != NULL) {
+        XMEMCPY(dst, src, srcLen);
+        dst[srcLen] = '\0';
+    }
+
+    return dst;
+}
+
 #endif /* !WOLFSSL_MISC_INCLUDED && !NO_INLINE */
 
 #endif /* WOLF_CRYPT_MISC_C */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2689,6 +2689,14 @@ typedef struct ProcPeerCertArgs {
 } ProcPeerCertArgs;
 WOLFSSL_LOCAL int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl,
         int ret, ProcPeerCertArgs* args);
+WOLFSSL_LOCAL void DoCrlCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl,
+        ProcPeerCertArgs* args, int* outRet);
+
+WOLFSSL_LOCAL int SetupStoreCtxCallback(WOLFSSL_X509_STORE_CTX** store_pt,
+        WOLFSSL* ssl, WOLFSSL_CERT_MANAGER* cm, ProcPeerCertArgs* args,
+        int cert_err, void* heap, int* x509Free);
+WOLFSSL_LOCAL void CleanupStoreCtxCallback(WOLFSSL_X509_STORE_CTX* store,
+        WOLFSSL* ssl, void* heap, int x509Free);
 #endif /* !defined(NO_WOLFSSL_CLIENT) || !defined(WOLFSSL_NO_CLIENT_AUTH) */
 #endif /* !defined NO_CERTS */
 
@@ -3050,7 +3058,7 @@ WOLFSSL_LOCAL int TLSX_UseSNI(TLSX** extensions, byte type, const void* data,
                                                        word16 size, void* heap);
 WOLFSSL_LOCAL byte TLSX_SNI_Status(TLSX* extensions, byte type);
 WOLFSSL_LOCAL word16 TLSX_SNI_GetRequest(TLSX* extensions, byte type,
-                                                                   void** data);
+                                                void** data, byte ignoreStatus);
 
 #ifndef NO_WOLFSSL_SERVER
 WOLFSSL_LOCAL void   TLSX_SNI_SetOptions(TLSX* extensions, byte type,

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -401,6 +401,7 @@ typedef union {
 
 #define NID_X9_62_id_ecPublicKey EVP_PKEY_EC
 #define NID_rsaEncryption        EVP_PKEY_RSA
+#define NID_rsa                  EVP_PKEY_RSA
 #define NID_dsa                  EVP_PKEY_DSA
 
 #define EVP_PKEY_OP_SIGN    (1 << 3)

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -501,6 +501,8 @@ typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS;
 #define X509_set_pubkey                 wolfSSL_X509_set_pubkey
 #define X509_set_notAfter               wolfSSL_X509_set_notAfter
 #define X509_set_notBefore              wolfSSL_X509_set_notBefore
+#define X509_set1_notAfter              wolfSSL_X509_set1_notAfter
+#define X509_set1_notBefore             wolfSSL_X509_set1_notBefore
 #define X509_set_serialNumber           wolfSSL_X509_set_serialNumber
 #define X509_set_version                wolfSSL_X509_set_version
 #define X509_REQ_set_version            wolfSSL_X509_set_version
@@ -635,6 +637,9 @@ typedef WOLFSSL_X509_NAME_ENTRY X509_NAME_ENTRY;
 #define X509_V_FLAG_CRL_CHECK     WOLFSSL_CRL_CHECK
 #define X509_V_FLAG_CRL_CHECK_ALL WOLFSSL_CRL_CHECKALL
 
+#define X509_V_FLAG_PARTIAL_CHAIN 0
+#define X509_V_FLAG_TRUSTED_FIRST 0
+
 #define X509_V_FLAG_USE_CHECK_TIME WOLFSSL_USE_CHECK_TIME
 #define X509_V_FLAG_NO_CHECK_TIME  WOLFSSL_NO_CHECK_TIME
 #define X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT WOLFSSL_ALWAYS_CHECK_SUBJECT
@@ -675,10 +680,13 @@ typedef WOLFSSL_X509_NAME_ENTRY X509_NAME_ENTRY;
 wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_CTX_verify_cb)(c))
 #define X509_STORE_set_verify_cb_func(s, c) \
 wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_CTX_verify_cb)(c))
+#define X509_STORE_set_get_crl          wolfSSL_X509_STORE_set_get_crl
+#define X509_STORE_set_check_crl        wolfSSL_X509_STORE_set_check_crl
 
 
 #define X509_STORE_new                  wolfSSL_X509_STORE_new
 #define X509_STORE_free                 wolfSSL_X509_STORE_free
+#define X509_STORE_up_ref               wolfSSL_X509_STORE_up_ref
 #define X509_STORE_add_lookup           wolfSSL_X509_STORE_add_lookup
 #define X509_STORE_add_cert             wolfSSL_X509_STORE_add_cert
 #define X509_STORE_add_crl              wolfSSL_X509_STORE_add_crl
@@ -687,8 +695,10 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #define X509_STORE_get_by_subject       wolfSSL_X509_STORE_get_by_subject
 #define X509_STORE_set_ex_data          wolfSSL_X509_STORE_set_ex_data
 #define X509_STORE_get_ex_data          wolfSSL_X509_STORE_get_ex_data
+#define X509_STORE_get0_param           wolfSSL_X509_STORE_get0_param
 #define X509_STORE_CTX_get1_issuer      wolfSSL_X509_STORE_CTX_get1_issuer
 #define X509_STORE_CTX_set_time         wolfSSL_X509_STORE_CTX_set_time
+#define X509_STORE_CTX_get0_param       wolfSSL_X509_STORE_CTX_get0_param
 #define X509_VERIFY_PARAM_new           wolfSSL_X509_VERIFY_PARAM_new
 #define X509_VERIFY_PARAM_free          wolfSSL_X509_VERIFY_PARAM_free
 #define X509_VERIFY_PARAM_set_flags     wolfSSL_X509_VERIFY_PARAM_set_flags
@@ -712,6 +722,7 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #define d2i_X509_CRL_fp                 wolfSSL_d2i_X509_CRL_fp
 #define PEM_read_X509_CRL               wolfSSL_PEM_read_X509_CRL
 
+#define X509_CRL_dup                    wolfSSL_X509_CRL_dup
 #define X509_CRL_free                   wolfSSL_X509_CRL_free
 #define X509_CRL_get_lastUpdate         wolfSSL_X509_CRL_get_lastUpdate
 #define X509_CRL_get0_lastUpdate        wolfSSL_X509_CRL_get_lastUpdate
@@ -836,18 +847,21 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #ifndef NO_ASN_TIME
 #define ASN1_TIME_new                   wolfSSL_ASN1_TIME_new
 #define ASN1_UTCTIME_new                wolfSSL_ASN1_TIME_new
+#define ASN1_GENERALIZEDTIME_new        wolfSSL_ASN1_TIME_new
 #define ASN1_TIME_free                  wolfSSL_ASN1_TIME_free
 #define ASN1_UTCTIME_free               wolfSSL_ASN1_TIME_free
+#define ASN1_GENERALIZEDTIME_free       wolfSSL_ASN1_TIME_free
 #define ASN1_TIME_adj                   wolfSSL_ASN1_TIME_adj
 #define ASN1_TIME_print                 wolfSSL_ASN1_TIME_print
 #define ASN1_TIME_to_string             wolfSSL_ASN1_TIME_to_string
 #define ASN1_TIME_to_tm                 wolfSSL_ASN1_TIME_to_tm
 #define ASN1_TIME_to_generalizedtime    wolfSSL_ASN1_TIME_to_generalizedtime
+#define ASN1_UTCTIME_set                wolfSSL_ASN1_UTCTIME_set
 #endif
 #define ASN1_TIME_set                   wolfSSL_ASN1_TIME_set
 #define ASN1_TIME_set_string            wolfSSL_ASN1_TIME_set_string
+#define ASN1_GENERALIZEDTIME_set_string wolfSSL_ASN1_TIME_set_string
 #define ASN1_GENERALIZEDTIME_print      wolfSSL_ASN1_GENERALIZEDTIME_print
-#define ASN1_GENERALIZEDTIME_free       wolfSSL_ASN1_GENERALIZEDTIME_free
 
 #define ASN1_tag2str                    wolfSSL_ASN1_tag2str
 
@@ -938,7 +952,7 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 
 #define SSL_alert_type_string           wolfSSL_alert_type_string
 #define SSL_alert_desc_string           wolfSSL_alert_desc_string
-#define SSL_state_string                wolfSSL_state_string
+#define SSL_state_string                wolfSSL_state_string_long
 
 #define RSA_free                        wolfSSL_RSA_free
 #define RSA_generate_key                wolfSSL_RSA_generate_key

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -931,7 +931,7 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #endif
 #define SSL_set0_verify_cert_store      wolfSSL_set0_verify_cert_store
 #define SSL_set1_verify_cert_store      wolfSSL_set1_verify_cert_store
-#define SSL_CTX_get_cert_store(x)       wolfSSL_CTX_get_cert_store ((WOLFSSL_CTX*) (x))
+#define SSL_CTX_get_cert_store(x)       wolfSSL_CTX_get_cert_store ((x))
 #define SSL_get_client_CA_list          wolfSSL_get_client_CA_list
 #define SSL_set_client_CA_list          wolfSSL_set_client_CA_list
 #define SSL_get_ex_data_X509_STORE_CTX_idx wolfSSL_get_ex_data_X509_STORE_CTX_idx

--- a/wolfssl/openssl/x509v3.h
+++ b/wolfssl/openssl/x509v3.h
@@ -145,7 +145,7 @@ WOLFSSL_API WOLFSSL_ASN1_STRING* wolfSSL_a2i_IPADDRESS(const char* ipa);
 
 #define BASIC_CONSTRAINTS_free    wolfSSL_BASIC_CONSTRAINTS_free
 #define AUTHORITY_KEYID_free      wolfSSL_AUTHORITY_KEYID_free
-#define SSL_CTX_get_cert_store(x) wolfSSL_CTX_get_cert_store ((WOLFSSL_CTX*) (x))
+#define SSL_CTX_get_cert_store(x) wolfSSL_CTX_get_cert_store ((x))
 #define ASN1_INTEGER              WOLFSSL_ASN1_INTEGER
 #define ASN1_OCTET_STRING         WOLFSSL_ASN1_STRING
 #define X509V3_EXT_get            wolfSSL_X509V3_EXT_get

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -153,8 +153,6 @@ typedef struct WOLFSSL_SOCKADDR     WOLFSSL_SOCKADDR;
 typedef struct WOLFSSL_CRL          WOLFSSL_CRL;
 typedef struct WOLFSSL_X509_STORE_CTX WOLFSSL_X509_STORE_CTX;
 
-typedef int (*WOLFSSL_X509_STORE_CTX_verify_cb)(int, WOLFSSL_X509_STORE_CTX *);
-
 typedef struct WOLFSSL_BY_DIR_HASH  WOLFSSL_BY_DIR_HASH;
 typedef struct WOLFSSL_BY_DIR_entry WOLFSSL_BY_DIR_entry;
 typedef struct WOLFSSL_BY_DIR       WOLFSSL_BY_DIR;
@@ -228,6 +226,12 @@ typedef struct WOLFSSL_DIST_POINT_NAME WOLFSSL_DIST_POINT_NAME;
 typedef struct WOLFSSL_DIST_POINT WOLFSSL_DIST_POINT;
 
 typedef struct WOLFSSL_CONF_CTX     WOLFSSL_CONF_CTX;
+
+typedef int (*WOLFSSL_X509_STORE_CTX_verify_cb)(int, WOLFSSL_X509_STORE_CTX *);
+typedef int (*WOLFSSL_X509_STORE_CTX_get_crl_cb)(WOLFSSL_X509_STORE_CTX *,
+        WOLFSSL_X509_CRL **, WOLFSSL_X509 *);
+typedef int (*WOLFSSL_X509_STORE_CTX_check_crl_cb)(WOLFSSL_X509_STORE_CTX *,
+        WOLFSSL_X509_CRL *);
 
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL) || defined(HAVE_CURL)
 
@@ -604,6 +608,7 @@ struct WOLFSSL_X509_STORE {
 #endif
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
     WOLFSSL_X509_STORE_CTX_verify_cb verify_cb;
+    WOLFSSL_X509_STORE_CTX_get_crl_cb get_crl_cb;
 #endif
 #ifdef HAVE_EX_DATA
     WOLFSSL_CRYPTO_EX_DATA ex_data;
@@ -705,6 +710,7 @@ struct WOLFSSL_X509_STORE_CTX {
     int   totalCerts;            /* number of peer cert buffers */
     WOLFSSL_BUFFER_INFO* certs;  /* peer certs */
     WOLFSSL_X509_STORE_CTX_verify_cb verify_cb; /* verify callback */
+    void* heap;
 };
 
 typedef char* WOLFSSL_STRING;
@@ -1883,6 +1889,10 @@ WOLFSSL_API void  wolfSSL_X509_STORE_CTX_set_verify_cb(WOLFSSL_X509_STORE_CTX *c
                                   WOLFSSL_X509_STORE_CTX_verify_cb verify_cb);
 WOLFSSL_API void wolfSSL_X509_STORE_set_verify_cb(WOLFSSL_X509_STORE *st,
                                  WOLFSSL_X509_STORE_CTX_verify_cb verify_cb);
+WOLFSSL_API void wolfSSL_X509_STORE_set_get_crl(WOLFSSL_X509_STORE *st,
+                            WOLFSSL_X509_STORE_CTX_get_crl_cb get_cb);
+WOLFSSL_API void wolfSSL_X509_STORE_set_check_crl(WOLFSSL_X509_STORE *st,
+        WOLFSSL_X509_STORE_CTX_check_crl_cb check_crl);
 WOLFSSL_API int wolfSSL_i2d_X509_NAME(WOLFSSL_X509_NAME* n,
                                                            unsigned char** out);
 WOLFSSL_API int wolfSSL_i2d_X509_NAME_canon(WOLFSSL_X509_NAME* name,
@@ -1944,8 +1954,12 @@ WOLFSSL_API int wolfSSL_X509_set_issuer_name(WOLFSSL_X509* cert,
 WOLFSSL_API int wolfSSL_X509_set_pubkey(WOLFSSL_X509* cert, WOLFSSL_EVP_PKEY* pkey);
 WOLFSSL_API int wolfSSL_X509_set_notAfter(WOLFSSL_X509* x509,
         const WOLFSSL_ASN1_TIME* t);
+WOLFSSL_API int wolfSSL_X509_set1_notAfter(WOLFSSL_X509* x509,
+        const WOLFSSL_ASN1_TIME *t);
 WOLFSSL_API int wolfSSL_X509_set_notBefore(WOLFSSL_X509* x509,
         const WOLFSSL_ASN1_TIME* t);
+WOLFSSL_API int wolfSSL_X509_set1_notBefore(WOLFSSL_X509* x509,
+        const WOLFSSL_ASN1_TIME *t);
 WOLFSSL_API WOLFSSL_ASN1_TIME* wolfSSL_X509_get_notBefore(const WOLFSSL_X509* x509);
 WOLFSSL_API WOLFSSL_ASN1_TIME* wolfSSL_X509_get_notAfter(const WOLFSSL_X509* x509);
 WOLFSSL_API int wolfSSL_X509_set_serialNumber(WOLFSSL_X509* x509,
@@ -2002,6 +2016,8 @@ WOLFSSL_API void         wolfSSL_X509_STORE_free(WOLFSSL_X509_STORE* store);
 WOLFSSL_API int          wolfSSL_X509_STORE_up_ref(WOLFSSL_X509_STORE* store);
 WOLFSSL_API int          wolfSSL_X509_STORE_add_cert(
                                               WOLFSSL_X509_STORE* store, WOLFSSL_X509* x509);
+WOLFSSL_API WOLFSSL_X509_VERIFY_PARAM *wolfSSL_X509_STORE_get0_param(
+        const WOLFSSL_X509_STORE *ctx);
 WOLFSSL_API WOLFSSL_STACK* wolfSSL_X509_STORE_CTX_get_chain(
                                                    WOLFSSL_X509_STORE_CTX* ctx);
 WOLFSSL_API WOLFSSL_STACK* wolfSSL_X509_STORE_CTX_get1_chain(
@@ -2013,7 +2029,10 @@ WOLFSSL_API int wolfSSL_X509_STORE_set_flags(WOLFSSL_X509_STORE* store,
 WOLFSSL_API int          wolfSSL_X509_STORE_set_default_paths(WOLFSSL_X509_STORE* store);
 WOLFSSL_API int          wolfSSL_X509_STORE_get_by_subject(WOLFSSL_X509_STORE_CTX* ctx,
                                    int idx, WOLFSSL_X509_NAME* name, WOLFSSL_X509_OBJECT* obj);
+WOLFSSL_API WOLFSSL_X509_VERIFY_PARAM *wolfSSL_X509_STORE_CTX_get0_param(
+        WOLFSSL_X509_STORE_CTX *ctx);
 WOLFSSL_API WOLFSSL_X509_STORE_CTX* wolfSSL_X509_STORE_CTX_new(void);
+WOLFSSL_API WOLFSSL_X509_STORE_CTX* wolfSSL_X509_STORE_CTX_new_ex(void* heap);
 WOLFSSL_API int  wolfSSL_X509_STORE_CTX_init(WOLFSSL_X509_STORE_CTX* ctx,
                       WOLFSSL_X509_STORE* store, WOLFSSL_X509* x509, WOLF_STACK_OF(WOLFSSL_X509)*);
 WOLFSSL_API void wolfSSL_X509_STORE_CTX_free(WOLFSSL_X509_STORE_CTX* ctx);
@@ -2941,6 +2960,7 @@ WOLFSSL_API int wolfSSL_X509_REVOKED_get_serial_number(RevokedCert* rev,
                                                        byte* in, int* inOutSz);
 #endif
 #if defined(HAVE_CRL) && (defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL))
+WOLFSSL_API WOLFSSL_X509_CRL* wolfSSL_X509_CRL_dup(const WOLFSSL_X509_CRL* crl);
 WOLFSSL_API void wolfSSL_X509_CRL_free(WOLFSSL_X509_CRL *crl);
 #endif
 
@@ -5094,7 +5114,7 @@ WOLFSSL_API int PEM_write_bio_WOLFSSL_X509(WOLFSSL_BIO *bio,
 WOLFSSL_API long wolfSSL_CTX_get_tlsext_ticket_keys(WOLFSSL_CTX *ctx,
      unsigned char *keys, int keylen);
 WOLFSSL_API long wolfSSL_CTX_set_tlsext_ticket_keys(WOLFSSL_CTX *ctx,
-     unsigned char *keys, int keylen);
+     const void *keys_vp, int keylen);
 #endif
 
 WOLFSSL_API void wolfSSL_get0_alpn_selected(const WOLFSSL *ssl,
@@ -5196,6 +5216,7 @@ WOLFSSL_API int wolfSSL_ASN1_TIME_get_length(const WOLFSSL_ASN1_TIME *t);
 WOLFSSL_API unsigned char* wolfSSL_ASN1_TIME_get_data(const WOLFSSL_ASN1_TIME *t);
 WOLFSSL_API WOLFSSL_ASN1_TIME *wolfSSL_ASN1_TIME_to_generalizedtime(WOLFSSL_ASN1_TIME *t,
                                                                 WOLFSSL_ASN1_TIME **out);
+WOLFSSL_API WOLFSSL_ASN1_TIME* wolfSSL_ASN1_UTCTIME_set(WOLFSSL_ASN1_TIME *s, time_t t);
 WOLFSSL_API int wolfSSL_i2c_ASN1_INTEGER(WOLFSSL_ASN1_INTEGER *a, unsigned char **pp);
 WOLFSSL_API int wolfSSL_a2i_ASN1_INTEGER(WOLFSSL_BIO *bio, WOLFSSL_ASN1_INTEGER *asn1,
         char *buf, int size);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -4493,7 +4493,7 @@ WOLFSSL_API int wolfSSL_set0_verify_cert_store(WOLFSSL *ssl,
                                                        WOLFSSL_X509_STORE* str);
 WOLFSSL_API int wolfSSL_set1_verify_cert_store(WOLFSSL *ssl,
                                                        WOLFSSL_X509_STORE* str);
-WOLFSSL_API WOLFSSL_X509_STORE* wolfSSL_CTX_get_cert_store(WOLFSSL_CTX* ctx);
+WOLFSSL_API WOLFSSL_X509_STORE* wolfSSL_CTX_get_cert_store(const WOLFSSL_CTX* ctx);
 #endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL */
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL) || \
     defined(HAVE_SECRET_CALLBACK)

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -2113,6 +2113,7 @@ WOLFSSL_LOCAL int StreamOctetString(const byte* inBuf, word32 inBufSz,
 
 WOLFSSL_ASN_API void FreeAltNames(DNS_entry* altNames, void* heap);
 WOLFSSL_ASN_API DNS_entry* AltNameNew(void* heap);
+WOLFSSL_ASN_API DNS_entry* AltNameDup(DNS_entry* from, void* heap);
 #ifndef IGNORE_NAME_CONSTRAINTS
     WOLFSSL_ASN_API void FreeNameSubtrees(Base_entry* names, void* heap);
 #endif /* IGNORE_NAME_CONSTRAINTS */

--- a/wolfssl/wolfcrypt/misc.h
+++ b/wolfssl/wolfcrypt/misc.h
@@ -135,6 +135,8 @@ WOLFSSL_LOCAL byte ctSetLTE(int a, int b);
 WOLFSSL_LOCAL void ctMaskCopy(byte mask, byte* dst, byte* src, word16 size);
 WOLFSSL_LOCAL word32 MakeWordFromHash(const byte* hashID);
 WOLFSSL_LOCAL word32 HashObject(const byte* o, word32 len, int* error);
+WOLFSSL_LOCAL char* CopyString(const char* src, int srcLen, void* heap,
+        int type);
 
 WOLFSSL_LOCAL void w64Increment(w64wrapper *n);
 WOLFSSL_LOCAL void w64Decrement(w64wrapper *n);


### PR DESCRIPTION
- Fix BIO_BIO type
  - Set retry flags correctly
- Add CRL callback
- Copy the alt names instead of trying to share a pointer
- Allow calling wolfSSL_get_servername on client side (to get the requested name)
- Return the chain in wolfSSL_X509_STORE_CTX_get_chain in the correct order
  - Peer first, top CA last
- Fix leak in RebuildFullName
- Add CopyString helper function
- Implement
  - X509_CRL_dup
  - ASN1_UTCTIME_set
  - X509_STORE_CTX_get0_param
  - X509_STORE_get0_param
  - X509_STORE_set_verify_cb
  - X509_STORE_set_get_crl
  - X509_set1_notAfter
  - X509_set1_notBefore