### PR TITLE
20240418-pq-hybrid-fixes

### DIFF
--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -1757,6 +1757,7 @@ static int ProcessBufferCertAltPublicKey(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
     DecodedCert* cert, int checkKeySz)
 {
     int ret = 0;
+    void* heap = WOLFSSL_HEAP(ctx, ssl);
     byte keyType = 0;
     int keySz = 0;
 #ifndef NO_RSA
@@ -2575,9 +2576,14 @@ int ProcessFile(WOLFSSL_CTX* ctx, const char* fname, int format, int type,
 #endif
 #ifdef WOLFSSL_DUAL_ALG_CERTS
         else if (type == PRIVATEKEY_TYPE) {
-            /* Load all other certificate types. */
+            /* When support for dual algorithm certificates is enabled, the
+             * private key file may contain both the primary and the
+             * alternative private key. Hence, we have to parse both of them.
+             */
+            long consumed = 0;
+
             ret = ProcessBuffer(ctx, content.buffer, sz, format, type, ssl,
-                NULL, userChain, verify);
+                &consumed, userChain, verify);
             if ((ret == 1) && (consumed < sz)) {
                 ret = ProcessBuffer(ctx, content.buffer + consumed,
                     sz - consumed, format, ALT_PRIVATEKEY_TYPE, ssl, NULL, 0,
@@ -3951,7 +3957,7 @@ int wolfSSL_CTX_use_PrivateKey_Id(WOLFSSL_CTX* ctx, const unsigned char* id,
     #ifdef WOLFSSL_DUAL_ALG_CERTS
         /* Set the ID for the alternative key, too. User can still override that
          * afterwards. */
-        ret = wolfSSL_CTX_use_AltPrivateKey_id(ctx, id, sz, devId, keySz);
+        ret = wolfSSL_CTX_use_AltPrivateKey_Id(ctx, id, sz, devId);
     #endif
     }
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3585,7 +3585,7 @@ struct WOLFSSL_CTX {
 
 #ifdef WOLFSSL_DUAL_ALG_CERTS
     DerBuffer*  altPrivateKey;
-    byte        altPrivateKeyType:6;
+    byte        altPrivateKeyType;
     byte        altPrivateKeyId:1;
     byte        altPrivateKeyLabel:1;
     int         altPrivateKeySz;
@@ -4560,7 +4560,7 @@ typedef struct Buffers {
     int             keyDevId;              /* Device Id for key */
 #ifdef WOLFSSL_DUAL_ALG_CERTS
     DerBuffer*      altKey;                /* WOLFSSL_CTX owns, unless we own */
-    byte            altKeyType:6;          /* Type of alt key */
+    byte            altKeyType;            /* Type of alt key */
     byte            altKeyId:1;            /* Key data is an id not data */
     byte            altKeyLabel:1;         /* Key data is a label not data */
     int             altKeySz;              /* Size of alt key */


### PR DESCRIPTION
fixes for `WOLFSSL_DUAL_ALG_CERTS`: "cannot take address of bit-field ‘altKeyType’" and "‘altPrivateKeyType’" in `ProcessBufferTryDecode()`, "‘heap’ undeclared" in `ProcessBufferCertAltPublicKey()`, "‘consumed’ undeclared" in `ProcessFile()`, "‘keySz’ undeclared" in `wolfSSL_CTX_use_PrivateKey_Id()`.

discovered and tested with `wolfssl-multi-test.sh ... pq-hybrid-all-.\*`, matching `pq-hybrid-all-rpk pq-hybrid-all-rpk-clang-tidy pq-hybrid-all-rpk-sanitizer pq-hybrid-all-rpk-cppcheck pq-hybrid-all-rpk-valgrind-unittest`
