### PR TITLE
Adding stubs required for latest nginx

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -1599,4 +1599,33 @@ int wolfSSL_CONF_cmd_value_type(WOLFSSL_CONF_CTX *cctx, const char *cmd)
  * END OF CONF API
  ******************************************************************************/
 
+#if defined(WOLFSSL_NGINX)
+OPENSSL_INIT_SETTINGS* wolfSSL_OPENSSL_INIT_new(void)
+{
+    OPENSSL_INIT_SETTINGS* init = (OPENSSL_INIT_SETTINGS*)XMALLOC(
+            sizeof(OPENSSL_INIT_SETTINGS), NULL, DYNAMIC_TYPE_OPENSSL);
+
+    return init;
+}
+
+void wolfSSL_OPENSSL_INIT_free(OPENSSL_INIT_SETTINGS* init)
+{
+    XFREE(init, NULL, DYNAMIC_TYPE_OPENSSL);
+}
+
+#ifndef NO_WOLFSSL_STUB
+int wolfSSL_OPENSSL_INIT_set_config_appname(OPENSSL_INIT_SETTINGS* init,
+        char* appname)
+{
+    (void)init;
+    (void)appname;
+    WOLFSSL_STUB("OPENSSL_INIT_set_config_appname");
+    return WOLFSSL_SUCCESS;
+}
+#endif
+
+#endif /* WOLFSSL_NGINX */
+
+
+
 #endif /* WOLFSSL_CONF_INCLUDED */

--- a/src/conf.c
+++ b/src/conf.c
@@ -1599,7 +1599,7 @@ int wolfSSL_CONF_cmd_value_type(WOLFSSL_CONF_CTX *cctx, const char *cmd)
  * END OF CONF API
  ******************************************************************************/
 
-#if defined(WOLFSSL_NGINX)
+#if defined(OPENSSL_EXTRA)
 OPENSSL_INIT_SETTINGS* wolfSSL_OPENSSL_INIT_new(void)
 {
     OPENSSL_INIT_SETTINGS* init = (OPENSSL_INIT_SETTINGS*)XMALLOC(
@@ -1624,7 +1624,7 @@ int wolfSSL_OPENSSL_INIT_set_config_appname(OPENSSL_INIT_SETTINGS* init,
 }
 #endif
 
-#endif /* WOLFSSL_NGINX */
+#endif /* OPENSSL_EXTRA */
 
 
 

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -1337,6 +1337,10 @@ typedef WOLFSSL_SRTP_PROTECTION_PROFILE      SRTP_PROTECTION_PROFILE;
 #define SSL_CONF_TYPE_FILE               WOLFSSL_CONF_TYPE_FILE
 #define SSL_CONF_TYPE_DIR                WOLFSSL_CONF_TYPE_DIR
 
+#define OPENSSL_INIT_new                 wolfSSL_OPENSSL_INIT_new
+#define OPENSSL_INIT_free                wolfSSL_OPENSSL_INIT_free
+#define OPENSSL_INIT_set_config_appname  wolfSSL_OPENSSL_INIT_set_config_appname
+
 #if defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX) || \
     defined(WOLFSSL_HAPROXY) || defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -5011,6 +5011,12 @@ WOLFSSL_API int wolfSSL_SSL_do_handshake(WOLFSSL *s);
 #ifdef OPENSSL_EXTRA
 WOLFSSL_API int wolfSSL_OPENSSL_init_ssl(word64 opts,
     const OPENSSL_INIT_SETTINGS *settings);
+#ifdef WOLFSSL_NGINX
+WOLFSSL_API OPENSSL_INIT_SETTINGS* wolfSSL_OPENSSL_INIT_new(void);
+WOLFSSL_API void wolfSSL_OPENSSL_INIT_free(OPENSSL_INIT_SETTINGS* init);
+WOLFSSL_API int  wolfSSL_OPENSSL_INIT_set_config_appname(
+        OPENSSL_INIT_SETTINGS* init, char* appname);
+#endif
 #endif
 #if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
 WOLFSSL_API int wolfSSL_SSL_in_init(const WOLFSSL* ssl);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -5011,12 +5011,10 @@ WOLFSSL_API int wolfSSL_SSL_do_handshake(WOLFSSL *s);
 #ifdef OPENSSL_EXTRA
 WOLFSSL_API int wolfSSL_OPENSSL_init_ssl(word64 opts,
     const OPENSSL_INIT_SETTINGS *settings);
-#ifdef WOLFSSL_NGINX
 WOLFSSL_API OPENSSL_INIT_SETTINGS* wolfSSL_OPENSSL_INIT_new(void);
 WOLFSSL_API void wolfSSL_OPENSSL_INIT_free(OPENSSL_INIT_SETTINGS* init);
 WOLFSSL_API int  wolfSSL_OPENSSL_INIT_set_config_appname(
         OPENSSL_INIT_SETTINGS* init, char* appname);
-#endif
 #endif
 #if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
 WOLFSSL_API int wolfSSL_SSL_in_init(const WOLFSSL* ssl);


### PR DESCRIPTION
# Description

Adding stubs required for latest nginx (1.25.5)

# Testing

nginx unit tests

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
