### PR TITLE
check for conflicting secure renegotiation macros (settings.h)

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3257,6 +3257,13 @@ extern void uITRON4_free(void *p) ;
     #define HAVE_ONE_TIME_AUTH
 #endif
 
+/* This is checked for in configure.ac, so might want to do it in here as well.
+ */
+#if defined(HAVE_SECURE_RENEGOTIATION) && defined(HAVE_RENEGOTIATION_INDICATION)
+    #error HAVE_RENEGOTIATION_INDICATION cannot be defined together with \
+           HAVE_SECURE_RENEGOTIATION
+#endif
+
 /* Check for insecure build combination:
  * secure renegotiation   [enabled]
  * extended master secret [disabled]


### PR DESCRIPTION
HAVE_RENEGOTIATION_INDICATION and HAVE_SECURE_RENEGOTIATION 
