### PR TITLE
Fixes from configuration testing

### DIFF
--- a/examples/asn1/asn1.c
+++ b/examples/asn1/asn1.c
@@ -133,6 +133,7 @@ static int PrintDer(FILE* fp)
     return ret;
 }
 
+#ifndef NO_CODING
 /* Print ASN.1 of a file containing Base64 encoding of BER/DER data.
  *
  * @param [in] fp  File pointer to read from.
@@ -279,6 +280,7 @@ static int PrintPem(FILE* fp, int pem_skip)
 
     return ret;
 }
+#endif
 
 /* Usage lines to show. */
 const char* usage[] = {
@@ -288,7 +290,9 @@ const char* usage[] = {
     "Options:",
     "  -?, --help           display this help and exit",
     "  -b, --branch         draw branches before tag name",
+#ifndef NO_CODING
     "  -B, --base64         file contents are Base64 encoded",
+#endif
     "  -d, --dump           show all ASN.1 item data as a hex dump",
     "  -h, --headers        show all ASN.1 item headers as a hex dump",
     "  -i, --indent         indent tag name with depth",
@@ -297,7 +301,9 @@ const char* usage[] = {
     "  -N, --no-dump-text   do not show data as a hex dump text",
     "  -o, --offset OFFSET  start decoding from offset",
     "  -O, --oid            show wolfSSL OID value in text",
+#ifndef NO_CODING
     "  -p, --pem            file contents are PEM",
+#endif
     "  -s, --skip-pem NUM   number of PEM blocks to skip",
 };
 /* Number of usage lines. */
@@ -342,11 +348,13 @@ int main(int argc, char* argv[])
             (strcmp(argv[0], "--branch") == 0)) {
             wc_Asn1PrintOptions_Set(&opts, ASN1_PRINT_OPT_DRAW_BRANCH, 1);
         }
+#ifndef NO_CODING
         /* File is Base64 encoded data. */
         else if ((strcmp(argv[0], "-b64") == 0) ||
                  (strcmp(argv[0], "--base64") == 0)) {
             file_format = FORMAT_BASE64;
         }
+#endif
         /* Dump all ASN.1 item data. */
         else if ((strcmp(argv[0], "-d") == 0) ||
                  (strcmp(argv[0], "--dump") == 0)) {
@@ -403,11 +411,13 @@ int main(int argc, char* argv[])
                  (strcmp(argv[0], "--oid") == 0)) {
             wc_Asn1PrintOptions_Set(&opts, ASN1_PRINT_OPT_SHOW_OID, 1);
         }
+#ifndef NO_CODING
         /* File contains PEM blocks. */
         else if ((strcmp(argv[0], "-p") == 0) ||
                  (strcmp(argv[0], "--pem") == 0)) {
             file_format = FORMAT_PEM;
         }
+#endif
         /* Skip a number of PEM blocks. */
         else if ((strcmp(argv[0], "-s") == 0) ||
                  (strcmp(argv[0], "--skip-pem") == 0)) {
@@ -458,12 +468,16 @@ int main(int argc, char* argv[])
     if (file_format == FORMAT_DER) {
         ret = PrintDer(fp);
     }
+#ifndef NO_CODING
     else if (file_format == FORMAT_BASE64) {
         ret = PrintBase64(fp);
     }
+#endif
+#ifndef NO_CODING
     else if (file_format == FORMAT_PEM) {
         ret = PrintPem(fp, pem_skip);
     }
+#endif
 
     if (ret != 0) {
         fprintf(stderr, "%s\n", wc_GetErrorString(ret));

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -21329,7 +21329,7 @@ static int set_curves_list(WOLFSSL* ssl, WOLFSSL_CTX *ctx, const char* names)
         }
     #endif
         else {
-        #if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
+        #if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST) && defined(HAVE_ECC)
             int   nret;
             const ecc_set_type *eccSet;
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -4884,10 +4884,11 @@ WOLFSSL_API WOLFSSL_X509_CRL *wolfSSL_X509_OBJECT_get0_X509_CRL(WOLFSSL_X509_OBJ
 WOLFSSL_API void wolfSSL_sk_X509_pop_free(WOLF_STACK_OF(WOLFSSL_X509)* sk, void (*f) (WOLFSSL_X509*));
 #endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL */
 
-#if (defined(OPENSSL_EXTRA) || defined(HAVE_CURL)) && defined(HAVE_ECC)
+#if (defined(OPENSSL_EXTRA) || defined(HAVE_CURL)) && (defined(HAVE_ECC) || \
+    defined(HAVE_CURVE25519) || defined(HAVE_CURVE448))
 WOLFSSL_API int wolfSSL_CTX_set1_curves_list(WOLFSSL_CTX* ctx, const char* names);
 WOLFSSL_API int wolfSSL_set1_curves_list(WOLFSSL* ssl, const char* names);
-#endif /* (OPENSSL_EXTRA || HAVE_CURL) && HAVE_ECC */
+#endif
 
 #if defined(OPENSSL_ALL) || \
     defined(HAVE_STUNNEL) || defined(WOLFSSL_MYSQL_COMPATIBLE) || \


### PR DESCRIPTION
# Description

asn1.c: Allow sample to build without coding (base64 decoding).

set_curves_list(): function for ECC, Ed25519, Ed448 but this block of code is ECC only. Fixed #ifdef protection.

wolfSSL_CTX_set1_curves_list and wolfSSL_set1_curves_list also available when Curve25519/Curve448 compiled in but not ECC.

# Testing

./configure --disable-coding
make

./configure '--disable-dh' '--disable-ecc' '--enable-curve25519' '--enable-opensslall'
make

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
