### PR TITLE
20240419-linuxkm-intelasm-expansion

### DIFF
--- a/linuxkm/Kbuild
+++ b/linuxkm/Kbuild
@@ -114,6 +114,16 @@ $(obj)/wolfcrypt/src/aes_xts_asm.o: asflags-y = $(WOLFSSL_ASFLAGS) $(ASFLAGS_FPU
 $(obj)/wolfcrypt/src/aes_xts_asm.o: OBJECT_FILES_NON_STANDARD := y
 $(obj)/wolfcrypt/src/sp_x86_64_asm.o: asflags-y = $(WOLFSSL_ASFLAGS) $(ASFLAGS_FPU_DISABLE_SIMD_ENABLE)
 $(obj)/wolfcrypt/src/sp_x86_64_asm.o: OBJECT_FILES_NON_STANDARD := y
+$(obj)/wolfcrypt/src/sha256_asm.o: asflags-y = $(WOLFSSL_ASFLAGS) $(ASFLAGS_FPU_DISABLE_SIMD_ENABLE)
+$(obj)/wolfcrypt/src/sha256_asm.o: OBJECT_FILES_NON_STANDARD := y
+$(obj)/wolfcrypt/src/sha512_asm.o: asflags-y = $(WOLFSSL_ASFLAGS) $(ASFLAGS_FPU_DISABLE_SIMD_ENABLE)
+$(obj)/wolfcrypt/src/sha512_asm.o: OBJECT_FILES_NON_STANDARD := y
+$(obj)/wolfcrypt/src/sha3_asm.o: asflags-y = $(WOLFSSL_ASFLAGS) $(ASFLAGS_FPU_DISABLE_SIMD_ENABLE)
+$(obj)/wolfcrypt/src/sha3_asm.o: OBJECT_FILES_NON_STANDARD := y
+$(obj)/wolfcrypt/src/chacha_asm.o: asflags-y = $(WOLFSSL_ASFLAGS) $(ASFLAGS_FPU_DISABLE_SIMD_ENABLE)
+$(obj)/wolfcrypt/src/chacha_asm.o: OBJECT_FILES_NON_STANDARD := y
+$(obj)/wolfcrypt/src/poly1305_asm.o: asflags-y = $(WOLFSSL_ASFLAGS) $(ASFLAGS_FPU_DISABLE_SIMD_ENABLE)
+$(obj)/wolfcrypt/src/poly1305_asm.o: OBJECT_FILES_NON_STANDARD := y
 
 ifeq "$(ENABLED_LINUXKM_PIE)" "yes"
 

--- a/wolfcrypt/src/ed25519.c
+++ b/wolfcrypt/src/ed25519.c
@@ -231,7 +231,7 @@ static int ed25519_pairwise_consistency_test(ed25519_key* key, WC_RNG* rng)
     if (err == 0) {
         /* Sign digest without context. */
         err = wc_ed25519_sign_msg_ex(digest, digestLen, sig, &sigLen, key,
-            Ed25519, NULL, 0);
+            (byte)Ed25519, NULL, 0);
         if (err != 0) {
             /* Any sign failure means test failed. */
             err = ECC_PCT_E;
@@ -240,7 +240,7 @@ static int ed25519_pairwise_consistency_test(ed25519_key* key, WC_RNG* rng)
     if (err == 0) {
         /* Verify digest without context. */
         err = wc_ed25519_verify_msg_ex(sig, sigLen, digest, digestLen, &res,
-            key, Ed25519, NULL, 0);
+            key, (byte)Ed25519, NULL, 0);
         if (err != 0) {
             /* Any verification operation failure means test failed. */
             err = ECC_PCT_E;


### PR DESCRIPTION
`linuxkm/Kbuild`: add SHA-2, SHA-3, ChaCha20, and poly1305, to kernel-safe vectorized-asm list.

`wolfcrypt/src/ed25519.c`: in `ed25519_pairwise_consistency_test()`, add casts to mollify `-Wconversion`.

tested with `wolfssl-multi-test.sh ... linuxkm-intelasm-pie-insmod defaults-cryptonly-Wconversion-intelasm-fips-140-3-dev-build`
