### PR TITLE
 dtls1.3: Fix issues when --enable-dtls13 enabled

### DIFF
--- a/scripts/dtlscid.test
+++ b/scripts/dtlscid.test
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-set -e
+# dtlscid.test
+# Copyright wolfSSL 2022-2024
 
 # if we can, isolate the network namespace to eliminate port collisions.
 if [[ -n "$NETWORK_UNSHARE_HELPER" ]]; then

--- a/src/tls.c
+++ b/src/tls.c
@@ -6120,8 +6120,12 @@ static int TLSX_SupportedVersions_Write(void* data, byte* output,
 #ifdef WOLFSSL_DTLS13
     if (ssl->options.dtls) {
         tls13minor = (byte)DTLSv1_3_MINOR;
+    #ifndef WOLFSSL_NO_TLS12
         tls12minor = (byte)DTLSv1_2_MINOR;
+    #endif
+    #ifndef NO_OLD_TLS
         tls11minor = (byte)DTLS_MINOR;
+    #endif
         isDtls = 1;
     }
 #endif /* WOLFSSL_DTLS13 */

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -4443,7 +4443,7 @@ int SendTls13ClientHello(WOLFSSL* ssl)
 
     {
 #ifdef WOLFSSL_DTLS_CH_FRAG
-        int maxFrag = wolfSSL_GetMaxFragSize(ssl, MAX_RECORD_SIZE);
+        word16 maxFrag = wolfSSL_GetMaxFragSize(ssl, MAX_RECORD_SIZE);
         word16 lenWithoutExts = args->length;
 #endif
 


### PR DESCRIPTION
# Description

Fixed issue reported by scan-build when DTLS13 is enabled.

Fix compile issue when WOLFSSL_DTLS_CH_FRAG is enabled.

Fix running of scripts/dtlscid.test by removing 'set -e' as bwrap
command may not be there.

# Testing

Temporarily make this change
````
diff --git a/configure.ac b/configure.ac
index 51fa5caa3..9cdc3b099 100644
--- a/configure.ac
+++ b/configure.ac
@@ -794,6 +794,9 @@ then
     then
         test "$enable_tls13" = "" && enable_tls13=yes
         test "$enable_rsapss" = "" && enable_rsapss=yes
+        test "$enable_dtls13" = "" && enable_dtls13=yes
+        test "$enable_dtlscid" = "" && enable_dtlscid=yes
+        test "$enable_dtls_frag_ch" = "" && enable_dtls_frag_ch=yes
     fi

     # this set is also enabled by enable-all-crypto:

````
Running `./configure --enable-all` and reviewed `AM_FLAGS `in `Makefile `as well as running `scan-build make`.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
