### PR TITLE
20240422-wc_SRTCP_KDF_ex-Wconversion

### DIFF
--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -942,7 +942,7 @@ static void wc_srtp_kdf_first_block(const byte* salt, word32 saltSz, int kdrIdx,
  * @param [in]      aes      AES object to encrypt with.
  * @return  0 on success.
  */
-static int wc_srtp_kdf_derive_key(byte* block, byte indexSz, byte label,
+static int wc_srtp_kdf_derive_key(byte* block, int indexSz, byte label,
         byte* key, word32 keySz, Aes* aes)
 {
     int i;


### PR DESCRIPTION
`wolfcrypt/src/kdf.c`: fix `-Wconversion`s in `wc_SRTCP_KDF_ex()`.

tested with `wolfssl-multi-test.sh ... allcryptonly-c89-Wconversion-build allcryptonly-c89-Wconversion-m32-build`
