### PR TITLE
20240423-linuxkm-sha-2-3-asm-save-vector-regs

### DIFF
--- a/wolfcrypt/src/sha3.c
+++ b/wolfcrypt/src/sha3.c
@@ -651,6 +651,10 @@ static int Sha3Update(wc_Sha3* sha3, const byte* data, word32 len, byte p)
     word32 i;
     word32 blocks;
 
+#if defined(WOLFSSL_LINUXKM) && defined(USE_INTEL_SPEEDUP)
+    if (sha3_block == sha3_block_avx2)
+        SAVE_VECTOR_REGISTERS(return _svr_ret;);
+#endif
     if (sha3->i > 0) {
         byte *t;
         byte l = (byte)(p * 8 - sha3->i);
@@ -699,6 +703,10 @@ static int Sha3Update(wc_Sha3* sha3, const byte* data, word32 len, byte p)
         len -= p * 8;
         data += p * 8;
     }
+#if defined(WOLFSSL_LINUXKM) && defined(USE_INTEL_SPEEDUP)
+    if (sha3_block == sha3_block_avx2)
+        RESTORE_VECTOR_REGISTERS();
+#endif
     XMEMCPY(sha3->t, data, len);
     sha3->i += (byte)len;
 
@@ -732,6 +740,12 @@ static int Sha3Final(wc_Sha3* sha3, byte padChar, byte* hash, byte p, word32 l)
     for (i = 0; i < p; i++) {
         sha3->s[i] ^= Load64BitBigEndian(sha3->t + 8 * i);
     }
+
+#if defined(WOLFSSL_LINUXKM) && defined(USE_INTEL_SPEEDUP)
+    if (sha3_block == sha3_block_avx2)
+        SAVE_VECTOR_REGISTERS(return _svr_ret;);
+#endif
+
     for (j = 0; l - j >= rate; j += rate) {
     #ifdef USE_INTEL_SPEEDUP
         (*sha3_block)(sha3->s);
@@ -755,6 +769,11 @@ static int Sha3Final(wc_Sha3* sha3, byte padChar, byte* hash, byte p, word32 l)
     #endif
         XMEMCPY(hash + j, sha3->s, l - j);
     }
+#if defined(WOLFSSL_LINUXKM) && defined(USE_INTEL_SPEEDUP)
+    if (sha3_block == sha3_block_avx2)
+        RESTORE_VECTOR_REGISTERS();
+#endif
+
     return 0;
 }
 
@@ -1328,6 +1347,10 @@ int wc_Shake128_Absorb(wc_Shake* shake, const byte* data, word32 len)
  */
 int wc_Shake128_SqueezeBlocks(wc_Shake* shake, byte* out, word32 blockCnt)
 {
+#if defined(WOLFSSL_LINUXKM) && defined(USE_INTEL_SPEEDUP)
+    if (sha3_block == sha3_block_avx2)
+        SAVE_VECTOR_REGISTERS(return _svr_ret;);
+#endif
     for (; (blockCnt > 0); blockCnt--) {
     #ifdef USE_INTEL_SPEEDUP
         (*sha3_block)(shake->s);
@@ -1341,6 +1364,10 @@ int wc_Shake128_SqueezeBlocks(wc_Shake* shake, byte* out, word32 blockCnt)
     #endif
         out += WC_SHA3_128_COUNT * 8;
     }
+#if defined(WOLFSSL_LINUXKM) && defined(USE_INTEL_SPEEDUP)
+    if (sha3_block == sha3_block_avx2)
+        RESTORE_VECTOR_REGISTERS();
+#endif
 
     return 0;
 }
@@ -1458,6 +1485,10 @@ int wc_Shake256_Absorb(wc_Shake* shake, const byte* data, word32 len)
  */
 int wc_Shake256_SqueezeBlocks(wc_Shake* shake, byte* out, word32 blockCnt)
 {
+#if defined(WOLFSSL_LINUXKM) && defined(USE_INTEL_SPEEDUP)
+    if (sha3_block == sha3_block_avx2)
+        SAVE_VECTOR_REGISTERS(return _svr_ret;);
+#endif
     for (; (blockCnt > 0); blockCnt--) {
     #ifdef USE_INTEL_SPEEDUP
         (*sha3_block)(shake->s);
@@ -1471,6 +1502,10 @@ int wc_Shake256_SqueezeBlocks(wc_Shake* shake, byte* out, word32 blockCnt)
     #endif
         out += WC_SHA3_256_COUNT * 8;
     }
+#if defined(WOLFSSL_LINUXKM) && defined(USE_INTEL_SPEEDUP)
+    if (sha3_block == sha3_block_avx2)
+        RESTORE_VECTOR_REGISTERS();
+#endif
 
     return 0;
 }

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2896,6 +2896,9 @@ extern void uITRON4_free(void *p) ;
     #ifndef WOLFSSL_SP_DIV_WORD_HALF
         #define WOLFSSL_SP_DIV_WORD_HALF
     #endif
+    #ifdef __PIE__
+        #define WC_NO_INTERNAL_FUNCTION_POINTERS
+    #endif
 #endif
 
 


### PR DESCRIPTION
`wolfcrypt/src/sha{256,512,3}.c` add `SAVE_VECTOR_REGISTERS()` for SHA-2 and SHA-3 vectorized implementations, and add `WC_NO_INTERNAL_FUNCTION_POINTERS` code paths to fix GOT relocations around implementation function pointers.

tested with `wolfssl-multi-test.sh ... linuxkm-mainline-intelasm-sp-asm-pie-gcc-latest-insmod check-source-text`
