### PR TITLE
Update benchmark to only parse rsa size if keygen is enabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3545,7 +3545,7 @@ fi
 
 # KEY GENERATION
 AC_ARG_ENABLE([keygen],
-    [AS_HELP_STRING([--enable-keygen],[Enable key generation (default: disabled)])],
+    [AS_HELP_STRING([--enable-keygen],[Enable key generation (only applies to RSA key generation) (default: disabled)])],
     [ ENABLED_KEYGEN=$enableval ],
     [ ENABLED_KEYGEN=no ]
     )

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -926,7 +926,9 @@ static const bench_alg bench_asym_opt[] = {
     { "-rsa-kg",             BENCH_RSA_KEYGEN        },
     #endif
     { "-rsa",                BENCH_RSA               },
+    #ifdef WOLFSSL_KEY_GEN
     { "-rsa-sz",             BENCH_RSA_SZ            },
+    #endif
 #endif
 #ifndef NO_DH
     { "-dh",                 BENCH_DH                },


### PR DESCRIPTION
Benchmark.c currently parses "-rsa-sz" argument at all times, despite the fact that it relies on non-default RSA keygen code to run the test. Only list and parse the option if WOLFSSL_KEY_GEN is defined. Also update the configure.ac help output to specify that the --enable-keygen option only applies to RSA key generation. 
