### PR TITLE
Remove DES3 flag guard from pkcs12 tests

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -30335,7 +30335,7 @@ static int test_wc_i2d_PKCS12(void)
     EXPECT_DECLS;
 #if !defined(NO_ASN) && !defined(NO_PWDBASED) && defined(HAVE_PKCS12) \
     && !defined(NO_FILESYSTEM) && !defined(NO_RSA) \
-    && !defined(NO_AES) && !defined(NO_DES3) && !defined(NO_SHA)
+    && !defined(NO_AES) && !defined(NO_SHA)
     WC_PKCS12* pkcs12 = NULL;
     unsigned char der[FOURK_BUF * 2];
     unsigned char* pt;


### PR DESCRIPTION
PKCS12 code in included in the default build, however the code in api.c that tests it is guarded by !defined(NO_DES3), and DES3 is not included in the default build. The PKCS12 test code itself as is does not actually perform any DES3 operations, so can run fine as is in the default build. If the core code is included in the default build, I believe the tests for that code should also be included.
