### PR TITLE
20240425-fixes

### DIFF
--- a/src/quic.c
+++ b/src/quic.c
@@ -1013,7 +1013,8 @@ const WOLFSSL_EVP_CIPHER* wolfSSL_quic_get_aead(WOLFSSL* ssl)
     return evp_cipher;
 }
 
-static int evp_cipher_eq(const WOLFSSL_EVP_CIPHER* c1,
+/* currently only used if HAVE_CHACHA && HAVE_POLY1305. */
+WC_MAYBE_UNUSED static int evp_cipher_eq(const WOLFSSL_EVP_CIPHER* c1,
                          const WOLFSSL_EVP_CIPHER* c2)
 {
     /* We could check on nid equality, but we seem to have singulars */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5757,7 +5757,8 @@ int wolfSSL_Init(void)
 
     if (ret == WOLFSSL_SUCCESS) {
         initRefCount++;
-    } else {
+    }
+    else {
         initRefCount = 1; /* Force cleanup */
     }
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -38878,7 +38878,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t lms_test_verify_only(void)
     }
 
     if (pub_len != HSS_MAX_PUBLIC_KEY_LEN) {
-        printf("error: LMS pub len %d, expected %d\n", pub_len,
+        printf("error: LMS pub len %u, expected %d\n", pub_len,
                HSS_MAX_PUBLIC_KEY_LEN);
         return WC_TEST_RET_ENC_EC(pub_len);
     }


### PR DESCRIPTION
`wolfcrypt/test/test.c`: fix `invalidPrintfArgType_sint` in `lms_test_verify_only()`.

`src/ssl.c`: fix races in `wolfSSL_Init()` and `wolfSSL_RAND_bytes()`.
