### PR TITLE
An expired CRL should not override a successful match in other CRL

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -438,7 +438,8 @@ static int CheckCertCRLList(WOLFSSL_CRL* crl, byte* issuerHash, byte* serial,
                         serialHash, crle->totalCerts);
                 if (ret != 0)
                     break;
-            } else if (foundEntry == 0) {
+            }
+            else if (foundEntry == 0) {
                 ret = ASN_AFTER_DATE_E;
             }
         }

--- a/src/crl.c
+++ b/src/crl.c
@@ -392,6 +392,8 @@ static int CheckCertCRLList(WOLFSSL_CRL* crl, byte* issuerHash, byte* serial,
 
     for (crle = crl->crlList; crle != NULL; crle = crle->next) {
         if (XMEMCMP(crle->issuerHash, issuerHash, CRL_DIGEST_SIZE) == 0) {
+            int nextDateValid = 1;
+
             WOLFSSL_MSG("Found CRL Entry on list");
 
             if (crle->verified == 0) {
@@ -426,16 +428,18 @@ static int CheckCertCRLList(WOLFSSL_CRL* crl, byte* issuerHash, byte* serial,
             #if !defined(NO_ASN_TIME) && !defined(WOLFSSL_NO_CRL_DATE_CHECK)
                 if (!XVALIDATE_DATE(crle->nextDate,crle->nextDateFormat, AFTER)) {
                     WOLFSSL_MSG("CRL next date is no longer valid");
-                    ret = ASN_AFTER_DATE_E;
+                    nextDateValid = 0;
                 }
             #endif
             }
-            if (ret == 0) {
+            if (nextDateValid) {
                 foundEntry = 1;
                 ret = FindRevokedSerial(crle->certs, serial, serialSz,
                         serialHash, crle->totalCerts);
                 if (ret != 0)
                     break;
+            } else if (foundEntry == 0) {
+                ret = ASN_AFTER_DATE_E;
             }
         }
     }


### PR DESCRIPTION
# Description

If we have an expired CRL and loads another non-expired CRL, the current CRL check ends up returning the error from checking the CRL next date, while it found a good CRL match before that. This can be seen happening in wolfSSL debug logs here for example:

```
[2024-04-26T05:45:57.017Z] Info : [Gothenburg 1] Entering CheckCertCRL
[2024-04-26T05:45:57.017Z] Info : [Gothenburg 1] Found CRL Entry on list
[2024-04-26T05:45:57.017Z] Info : [Gothenburg 1] Checking next date validity
[2024-04-26T05:45:57.018Z] Info : [Gothenburg 1] Found CRL Entry on list
[2024-04-26T05:45:57.018Z] Info : [Gothenburg 1] Checking next date validity
[2024-04-26T05:45:57.018Z] Info : [Gothenburg 1] Date AFTER check failed
[2024-04-26T05:45:57.018Z] Info : [Gothenburg 1] CRL next date is no longer valid
[2024-04-26T05:45:57.018Z] Info : [Gothenburg 1]        CRL check not ok
 ...
[2024-04-26T05:45:57.018Z] Info : [Gothenburg 1] verify_callback err: -151
```

# Testing

Verified in internal tests.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
