### PR TITLE
Introduce cmake_policy CMP0128 NEW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMakeList.txt
 #
-# Copyright (C) 2006-2023 wolfSSL Inc.
+# Copyright (C) 2006-2024 wolfSSL Inc.
 #
 # This file is part of wolfSSL. (formerly known as CyaSSL)
 #
@@ -20,6 +20,12 @@
 ####################################################
 
 cmake_minimum_required(VERSION 3.16)
+
+if(${CMAKE_VERSION} VERSION_LESS "3.22")
+    message(STATUS "This project recommends using CMake version 3.22 or higher. You are using ${CMAKE_VERSION}.")
+else()
+    cmake_policy(SET CMP0128 NEW)
+endif()
 
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     message(FATAL_ERROR "In-source builds are not allowed.\


### PR DESCRIPTION
# Description



While working on the wolfSSL `CMakeLists.txt` updates in Visual Studio 2022, I've encountered many of these messages:

```
1> [CMake] CMake Warning (dev) in CMakeLists.txt:
1> [CMake]   Policy CMP0128 is not set: Selection of language standard and extension
1> [CMake]   flags improved.  Run "cmake --help-policy CMP0128" for policy details.  Use
1> [CMake]   the cmake_policy command to set the policy and suppress this warning.
1> [CMake] 
1> [CMake]   For compatibility with older versions of CMake, compiler extensions won't
1> [CMake]   be enabled.
1> [CMake] This warning is for project developers.  Use -Wno-dev to suppress it.
```

New in version 3.22 of CMake is [CMP0128 Policy](https://cmake.org/cmake/help/latest/policy/CMP0128.html).

Currently the required version for the wolfSSL CmakeLists.txt is v3.16.

This PR conditionally sets the recommended `NEW` policy when the cmake version is v3.22 or newer, and gives a suggestion to update CMake for older versions.

Fixes zd# n/a

# Testing

How did you test?

Tested only on Visual Studio 2022 and WSL.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
