### PR TITLE
Introduce cmake SET_WOLFSSL_DEFINITIONS; Add Kyber and OQS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-# CMakeList.txt
+# CMakeLists.txt
 #
-# Copyright (C) 2006-2023 wolfSSL Inc.
+# Copyright (C) 2006-2024 wolfSSL Inc.
 #
 # This file is part of wolfSSL. (formerly known as CyaSSL)
 #
@@ -539,16 +539,89 @@ add_option(WOLFSSL_OQS
     "Enable integration with the OQS (Open Quantum Safe) liboqs library (default: disabled)"
     "no" "yes;no")
 
-if (WOLFSSL_OQS)
-    find_package(OQS)
+# Kyber
+add_option(WOLFSSL_KYBER
+    "Enable the wolfSSL PQ Kyber library (default: disabled)"
+    "no" "yes;no")
 
-    if (OQS_FOUND)
-        list(APPEND WOLFSSL_LINK_LIBS ${OQS_LIBRARY})
-        list(APPEND WOLFSSL_INCLUDE_DIRS ${OQS_INCLUDE_DIR})
-        set(HAVE_LIBOQS 1)
-        list(APPEND WOLFSSL_DEFINITIONS
-          "-DHAVE_TLS_EXTENSIONS"
-          "-DHAVE_LIBOQS")
+# Experimental features
+add_option(WOLFSSL_EXPERIMENTAL
+    "Enable experimental features (default: disabled)"
+    "no" "yes;no")
+
+message(STATUS "Looking for WOLFSSL_EXPERIMENTAL")
+if (WOLFSSL_EXPERIMENTAL)
+    message(STATUS "Looking for WOLFSSL_EXPERIMENTAL - found")
+
+    # We've enabled the experimental environment, but let's
+    # check if any experimental features are also enabled:
+    set(WOLFSSL_FOUND_EXPERIMENTAL_FEATURE 0)
+
+    set_wolfssl_definitions("WOLFSSL_EXPERIMENTAL_SETTINGS" RESUlT)
+
+    # Checking for experimental feature: OQS
+    message(STATUS "Looking for WOLFSSL_OQS")
+    if (WOLFSSL_OQS)
+        set(WOLFSSL_FOUND_EXPERIMENTAL_FEATURE 1)
+        message(STATUS "Looking for WOLFSSL_OQS - found")
+
+        message(STATUS "Checking OQS")
+        find_package(OQS)
+        if (OQS_FOUND)
+            message(STATUS "Checking OQS - found")
+            list(APPEND WOLFSSL_LINK_LIBS ${OQS_LIBRARY})
+            list(APPEND WOLFSSL_INCLUDE_DIRS ${OQS_INCLUDE_DIR})
+
+            set_wolfssl_definitions("HAVE_LIBOQS"          RESUlT)
+            set_wolfssl_definitions("HAVE_TLS_EXTENSIONS"  RESUlT)
+            set_wolfssl_definitions("OPENSSL_EXTRA"        RESUlT)
+
+        else()
+            message(STATUS "Checking OQS - not found")
+            message(STATUS "WARNING: WOLFSSL_OQS enabled but not found: OQS_LIBRARY=${OQS_LIBRARY}, OQS_INCLUDE_DIR=${OQS_INCLUDE_DIR} ")
+        endif()
+    else()
+        message(STATUS "Looking for WOLFSSL_OQS - not found")
+    endif()
+
+    # Checking for experimental feature: Kyber
+    message(STATUS "Looking for WOLFSSL_KYBER")
+    if (WOLFSSL_KYBER)
+        set(WOLFSSL_FOUND_EXPERIMENTAL_FEATURE 1)
+
+        message(STATUS "Automatically set related requirements for Kyber:")
+        set_wolfssl_definitions("WOLFSSL_HAVE_KYBER" RESUlT)
+        set_wolfssl_definitions("WOLFSSL_WC_KYBER"   RESUlT)
+        set_wolfssl_definitions("WOLFSSL_SHA3"       RESUlT)
+        set_wolfssl_definitions("WOLFSSL_SHAKE128"   RESUlT)
+        set_wolfssl_definitions("WOLFSSL_SHAKE256"   RESUlT)
+        message(STATUS "Looking for WOLFSSL_KYBER - found")
+    else()
+        message(STATUS "Looking for WOLFSSL_KYBER - not found")
+    endif()
+
+    # Other experimental feature detection can be added here...
+
+    # Were any experimental features found? Display a message.
+    if(WOLFSSL_FOUND_EXPERIMENTAL_FEATURE)
+        message(STATUS "WOLFSSL_EXPERIMENTAL enabled, experimental features enabled.")
+    else()
+        message(STATUS "Warning: WOLFSSL_EXPERIMENTAL enabled, but no experimental features enabled.")
+    endif()
+
+    # Sanity checks
+    if(WOLFSSL_OQS AND WOLFSSL_KYBER)
+        message(FATAL_ERROR "Error: cannot enable both WOLFSSL_OQS and WOLFSSL_KYBER at the same time.")
+    endif()
+
+else()
+    # Experimental mode not enabled, but were any experimental features enabled? Error out if so:
+    message(STATUS "Looking for WOLFSSL_EXPERIMENTAL - not found")
+    if (WOLFSSL_OQS)
+        message(FATAL_ERROR "Error: WOLFSSL_OQS requires WOLFSSL_EXPERIMENTAL at this time.")
+    endif()
+    if(WOLFSSL_KYBER)
+        message(FATAL_ERROR "Error: WOLFSSL_KYBER requires WOLFSSL_EXPERIMENTAL at this time.")
     endif()
 endif()
 
@@ -565,6 +638,9 @@ endif()
 #       - Atomic user record layer
 #       - Public key callbacks
 #       - Microchip/Atmel CryptoAuthLib
+#       - XMSS
+#       - LMS
+#       - dual-certs
 
 # AES-CBC
 add_option("WOLFSSL_AESCBC"

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -941,3 +941,73 @@ function(add_to_options_file DEFINITIONS OPTION_FILE)
         endif()
     endforeach()
 endfunction()
+
+# Function: set_wolfssl_definitions
+#   Parameter: SEARCH_VALUE  The string to search for. (e.g. "WOLFSSL_SHA3")
+#   Returns:   RESULT
+#
+# Searches WOLFSSL_DEFINITIONS for SEARCH_VALUE
+#   Returns RESULT = 1 (true) if the search value is found
+#
+# Ensures setting is only added once and prints status messages.
+#
+# Also sets a parent (global in cmake file) variable by the same name to 1.
+#
+# See also get_wolfssl_definitions() for query-only.
+#
+function(set_wolfssl_definitions SEARCH_VALUE RESULT)
+    if (${SEARCH_VALUE} STREQUAL "")
+        message(FATAL_ERROR "Function set_wolfssl_definitions cannot have blank SEARCH_VALUE")
+    endif()
+
+    list(FIND WOLFSSL_DEFINITIONS "${SEARCH_VALUE}" pos)
+    string(SUBSTRING "${SEARCH_VALUE}" 0 2 PREFIX_VALUE)
+
+    if ("${PREFIX_VALUE}" STREQUAL "-D")
+        message(FATAL_ERROR "Do not specify the -D prefix in set_wolfssl_definitions")
+    endif()
+
+    if(${pos} EQUAL -1)
+        message(STATUS "${SEARCH_VALUE} not found in WOLFSSL_DEFINITIONS.")
+
+        message(STATUS "Enabling ${SEARCH_VALUE}")
+        list(APPEND WOLFSSL_DEFINITIONS "-D${SEARCH_VALUE}")
+        set(${SEARCH_VALUE} 1 PARENT_SCOPE)
+        # override_cache("${SEARCH_VALUE}" "yes") # Need to check that value is settable
+        set(${RESULT} 1 PARENT_SCOPE)
+        message(STATUS "Enabling ${SEARCH_VALUE} - success")
+
+    else()
+        message(STATUS "${SEARCH_VALUE} found in WOLFSSL_DEFINITIONS.")
+        set(${RESULT} 0 PARENT_SCOPE)
+    endif()
+endfunction()
+
+# Function: get_wolfssl_definitions
+#   Parameter: SEARCH_VALUE  The string to search for. (e.g. "WOLFSSL_SHA3")
+#   Returns:   RESULT
+#
+# Searches WOLFSSL_DEFINITIONS for SEARCH_VALUE
+#   Returns RESULT = 1 (true) if the search value is found
+#
+# Unlike set_wolfssl_definitions(), this function only queries the WOLFSSL_DEFINITIONS.
+#
+function(get_wolfssl_definitions SEARCH_VALUE RESULT)
+    if (${SEARCH_VALUE} STREQUAL "")
+        message(FATAL_ERROR "Function get_wolfssl_definitions cannot have blank SEARCH_VALUE")
+    endif()
+
+    list(FIND WOLFSSL_DEFINITIONS "${SEARCH_VALUE}" pos)
+    string(SUBSTRING "${SEARCH_VALUE}" 0 2 PREFIX_VALUE)
+
+    if ("${PREFIX_VALUE}" STREQUAL "-D")
+        message(FATAL_ERROR "Do not specify the -D prefix in get_wolfssl_definitions")
+    endif()
+
+
+    if(${pos} EQUAL -1)
+        message(STATUS "${SEARCH_VALUE} not found in WOLFSSL_DEFINITIONS.")
+    else()
+        message(STATUS "${SEARCH_VALUE} found in WOLFSSL_DEFINITIONS.")
+    endif()
+endfunction()


### PR DESCRIPTION
# Description

This PR adds a new cmake helper function `SET_WOLFSSL_DEFINITIONS` and adds support for Kyber and LIBOQS as noted in https://github.com/wolfSSL/wolfssl/issues/7425

The additional items mentioned in the comments https://github.com/wolfSSL/wolfssl/issues/7425#issuecomment-2056780549 were move to the TODO section, not addressed in this PR:

```text
#       - XMSS
#       - LMS
#       - dual-certs
```

See also the request in https://github.com/wolfSSL/wolfssl/issues/7427 and my `cmake_policy CMP0128 NEW` in https://github.com/wolfSSL/wolfssl/pull/7479.

Sample new cmake output:

```
-- Enabling WOLFSSL_EXPERIMENTAL_SETTINGS
-- Enabling WOLFSSL_EXPERIMENTAL_SETTINGS - success
-- Looking for WOLFSSL_OQS
-- Looking for WOLFSSL_OQS - not found
-- Looking for WOLFSSL_KYBER
-- Looking for WOLFSSL_KYBER - not found
-- Warning: WOLFSSL_EXPERIMENTAL enabled, but no experimental features enabled.
```

or

```
-- Looking for WOLFSSL_EXPERIMENTAL
-- Looking for WOLFSSL_EXPERIMENTAL - not found
CMake Error at CMakeLists.txt:678 (message):
  Error: WOLFSSL_OQS requires WOLFSSL_EXPERIMENTAL at this time.

-- Configuring incomplete, errors occurred!
```

See [o-test.txt](https://github.com/gojimmypi/wolfssl/blob/ED25519_SHA2_fix/o-test.txt) sample output from the `o-test.sh` script mentioned below.

Fixes zd# n/a

* Edit: [confirmed](https://github.com/wolfSSL/wolfssl/issues/7425#issuecomment-2101599039) to fix https://github.com/wolfSSL/wolfssl/issues/7425

# Testing

How did you test?

Tested on WSL using the example scripts noted in https://github.com/wolfSSL/wolfssl/issues/7425#issuecomment-2071177128 (see also this [o-test.sh](https://github.com/gojimmypi/wolfssl/blob/ED25519_SHA2_fix/o-test.sh) and [sample output](https://github.com/gojimmypi/wolfssl/blob/ED25519_SHA2_fix/o-test.txt)) such as:

```bash
rm -rf ./build

echo "--------------------------------"
echo "No OQS, No Experimental"
echo "--------------------------------"
cmake -Wno-dev -B build \
    -DCMAKE_INSTALL_PREFIX=/usr     \
    -DCMAKE_BUILD_TYPE=None         \
    -DWOLFSSL_CURVE25519=ON         \
    -DWOLFSSL_CURVE448=ON           \
    -DWOLFSSL_ED25519=ON            \
    -DWOLFSSL_ED448=ON              \
    -DWOLFSSL_REPRODUCIBLE_BUILD=ON \
    -DWOLFSSL_EXAMPLES=ON           \
    -DWOLFSSL_CRYPT_TESTS=ON        \
                                      || exit 1
cmake --build build --verbose
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
