### PR TITLE
Mem fail fix: ProcessingBuffer()

### DIFF
--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -2352,6 +2352,9 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff, long sz,
             ret = ProcessBufferCertTypes(ctx, ssl, buff, sz, der, format, type,
                 verify);
         }
+        else {
+            FreeDer(&der);
+        }
     }
 
     /* Reset suites if this is a private key or user certificate. */


### PR DESCRIPTION
# Description

When ProcessBufferCertTypes() is not called, 'der' is not freed.

# Testing

Mem fail testing.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
