### PR TITLE
Improved the prioritization of crypto callback vs async crypt in ECC …

### DIFF
--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -153,19 +153,10 @@ static void wc_RsaCleanup(RsaKey* key)
 int wc_InitRsaKey_ex(RsaKey* key, void* heap, int devId)
 {
     int ret      = 0;
-#if defined(HAVE_PKCS11)
-    int isPkcs11 = 0;
-#endif
 
     if (key == NULL) {
         return BAD_FUNC_ARG;
     }
-
-#if defined(HAVE_PKCS11)
-    if (key->isPkcs11) {
-        isPkcs11 = 1;
-    }
-#endif
 
     XMEMSET(key, 0, sizeof(RsaKey));
 
@@ -193,19 +184,18 @@ int wc_InitRsaKey_ex(RsaKey* key, void* heap, int devId)
     #endif
 
     #ifdef WC_ASYNC_ENABLE_RSA
-        #if defined(HAVE_PKCS11)
-            if (!isPkcs11)
+        #ifdef WOLF_CRYPTO_CB
+        /* prefer crypto callback */
+        if (key->devId != INVALID_DEVID)
         #endif
-            {
-                /* handle as async */
-                ret = wolfAsync_DevCtxInit(&key->asyncDev,
-                        WOLFSSL_ASYNC_MARKER_RSA, key->heap, devId);
-                if (ret != 0)
-                    return ret;
-            }
+        {
+            /* handle as async */
+            ret = wolfAsync_DevCtxInit(&key->asyncDev,
+                    WOLFSSL_ASYNC_MARKER_RSA, key->heap, devId);
+            if (ret != 0)
+                return ret;
+        }
     #endif /* WC_ASYNC_ENABLE_RSA */
-#elif defined(HAVE_PKCS11)
-    (void)isPkcs11;
 #endif /* WOLFSSL_ASYNC_CRYPT */
 
 #ifndef WOLFSSL_RSA_PUBLIC_ONLY
@@ -278,14 +268,6 @@ int wc_InitRsaKey_Id(RsaKey* key, unsigned char* id, int len, void* heap,
         ret = BAD_FUNC_ARG;
     if (ret == 0 && (len < 0 || len > RSA_MAX_ID_LEN))
         ret = BUFFER_E;
-
-#if defined(HAVE_PKCS11)
-    if (ret == 0) {
-        XMEMSET(key, 0, sizeof(RsaKey));
-        key->isPkcs11 = 1;
-    }
-#endif
-
     if (ret == 0)
         ret = wc_InitRsaKey_ex(key, heap, devId);
     if (ret == 0 && id != NULL && len != 0) {
@@ -315,14 +297,6 @@ int wc_InitRsaKey_Label(RsaKey* key, const char* label, void* heap, int devId)
         if (labelLen == 0 || labelLen > RSA_MAX_LABEL_LEN)
             ret = BUFFER_E;
     }
-
-#if defined(HAVE_PKCS11)
-    if (ret == 0) {
-        XMEMSET(key, 0, sizeof(RsaKey));
-        key->isPkcs11 = 1;
-    }
-#endif
-
     if (ret == 0)
         ret = wc_InitRsaKey_ex(key, heap, devId);
     if (ret == 0) {

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -519,9 +519,6 @@ struct ecc_key {
     void* devCtx;
     int devId;
 #endif
-#if defined(HAVE_PKCS11)
-    byte isPkcs11 : 1; /* indicate if PKCS11 is preferred */
-#endif
 #ifdef WOLFSSL_SILABS_SE_ACCEL
     sl_se_command_context_t  cmd_ctx;
     sl_se_key_descriptor_t   key;

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -217,9 +217,6 @@ struct RsaKey {
     void* devCtx;
     int   devId;
 #endif
-#if defined(HAVE_PKCS11)
-    byte isPkcs11 : 1; /* indicate if PKCS11 is preferred */
-#endif
 #ifdef WOLFSSL_ASYNC_CRYPT
     WC_ASYNC_DEV asyncDev;
     #ifdef WOLFSSL_CERT_GEN


### PR DESCRIPTION
# Description

Improved the prioritization of crypto callback vs async crypt in ECC and RSA (prefer crypto callback over async).
Resolves possible use of uninitialized value on ECC/RSA key when PKCS11 is enabled.

Fixes #7482

# Testing

```
./configure --enable-all --enable-dtls13 --enable-pkcs11
valgrind -v --tool=memcheck --leak-check=full --show-leak-kinds=all --track-origins=yes --error-exitcode=5 ./tests/unit.test
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
