### PR TITLE
Support for ECC_CACHE_CURVE with no malloc

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2755,7 +2755,9 @@ extern void uITRON4_free(void *p) ;
     #endif
 
     /* Enable ECC_CACHE_CURVE for ASYNC */
-    #if !defined(ECC_CACHE_CURVE)
+    #if !defined(ECC_CACHE_CURVE) && !defined(NO_ECC_CACHE_CURVE)
+        /* Enabled by default for increased async performance,
+         * but not required */
         #define ECC_CACHE_CURVE
     #endif
 #endif /* WOLFSSL_ASYNC_CRYPT */


### PR DESCRIPTION
# Description

Support for ECC_CACHE_CURVE with no malloc.

Fixes ZD 17774

# Testing

```
./configure CFLAGS="-DECC_CACHE_CURVE -DWOLFSSL_NO_MALLOC" --enable-staticmemory && make
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
