### PR TITLE
Benchmark, SM3: fix full hash testing

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -28008,6 +28008,12 @@ int DecodePrivateKey(WOLFSSL *ssl, word32* length)
                                      ssl->buffers.key->length);
         }
     #endif
+    #ifdef WOLFSSL_SM2
+        if ((ret == 0) && (ssl->buffers.keyType == sm2_sa_algo)) {
+            ret = wc_ecc_set_curve((ecc_key*)ssl->hsKey,
+                WOLFSSL_SM2_KEY_BITS / 8, ECC_SM2P256V1);
+        }
+    #endif
         if (ret == 0) {
             WOLFSSL_MSG("Using ECC private key");
 
@@ -34542,7 +34548,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                             {
                                 word32 keySz;
 
-                                ssl->buffers.keyType = ecc_dsa_sa_algo;
+                                ssl->buffers.keyType = ssl->options.sigAlgo;
                                 ret = DecodePrivateKey(ssl, &keySz);
                                 if (ret != 0) {
                                     goto exit_sske;

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -7475,12 +7475,12 @@ void bench_sm3(int useDeviceID)
         bench_stats_start(&count, &start);
         do {
             for (times = 0; times < numBlocks; times++) {
-                ret = wc_InitSm3(hash, HEAP_HINT,
+                ret = wc_InitSm3(hash[0], HEAP_HINT,
                     useDeviceID ? devId: INVALID_DEVID);
                 if (ret == 0)
-                    ret = wc_Sm3Update(hash, bench_plain, bench_size);
+                    ret = wc_Sm3Update(hash[0], bench_plain, bench_size);
                 if (ret == 0)
-                    ret = wc_Sm3Final(hash, digest[0]);
+                    ret = wc_Sm3Final(hash[0], digest[0]);
                 if (ret != 0)
                     goto exit_sm3;
                 RECORD_MULTI_VALUE_STATS();

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -5536,7 +5536,7 @@ exit:
 #endif
 
 #ifdef WOLFSSL_SM4_CCM
-void bench_sm4_ccm()
+void bench_sm4_ccm(void)
 {
     wc_Sm4 enc;
     double start;

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -10939,13 +10939,13 @@ exit:
 #ifdef WOLFSSL_SM2
 static void bench_sm2_MakeKey(int useDeviceID)
 {
-    int ret = 0, i, times, count, pending = 0;
+    int ret = 0, i, times, count = 0, pending = 0;
     int deviceID;
     int keySize;
     WC_DECLARE_ARRAY(genKey, ecc_key, BENCH_MAX_PENDING,
                      sizeof(ecc_key), HEAP_HINT);
     char name[BENCH_ECC_NAME_SZ];
-    double start;
+    double start = 0;
     const char**desc = bench_desc_words[lng_index];
     DECLARE_MULTI_VALUE_STATS_VARS()
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -23790,13 +23790,19 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
         if (cert->ca) {
             if (verify == VERIFY || verify == VERIFY_OCSP ||
                                                  verify == VERIFY_SKIP_DATE) {
+                word32 keyOID = cert->ca->keyOID;
+            #if defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3)
+                if (cert->selfSigned && (cert->signatureOID == CTC_SM3wSM2)) {
+                    keyOID = SM2k;
+                }
+            #endif
                 /* try to confirm/verify signature */
                 if ((ret = ConfirmSignature(&cert->sigCtx,
                         cert->source + cert->certBegin,
                         cert->sigIndex - cert->certBegin,
                         cert->ca->publicKey, cert->ca->pubKeySize,
-                        cert->ca->keyOID, cert->signature,
-                        cert->sigLength, cert->signatureOID,
+                        keyOID, cert->signature, cert->sigLength,
+                        cert->signatureOID,
                     #ifdef WC_RSA_PSS
                         cert->source + cert->sigParamsIndex,
                         cert->sigParamsLength,

--- a/wolfcrypt/src/port/arm/armv8-aes.c
+++ b/wolfcrypt/src/port/arm/armv8-aes.c
@@ -1532,6 +1532,7 @@ void GHASH(Gcm* gcm, const byte* a, word32 aSz, const byte* c,
         "USHR v7.2d, v7.2d, #56 \n"
 
         "# AAD \n"
+        "CBZ %[a], 20f \n"
         "CBZ %w[aSz], 20f \n"
         "MOV w12, %w[aSz] \n"
 
@@ -1702,6 +1703,7 @@ void GHASH(Gcm* gcm, const byte* a, word32 aSz, const byte* c,
 
         "20: \n"
         "# Cipher Text \n"
+        "CBZ %[c], 120f \n"
         "CBZ %w[cSz], 120f \n"
         "MOV w12, %w[cSz] \n"
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -29740,21 +29740,19 @@ static wc_test_ret_t ecc_test_custom_curves(WC_RNG* rng)
 #ifdef WOLFSSL_SM2
 #ifdef HAVE_ECC_VERIFY
 #if defined(WOLFSSL_PUBLIC_MP) && defined(WOLFSSL_CUSTOM_CURVES)
-    #ifdef WOLFSSL_SM2
-        #ifdef HAVE_OID_ENCODING
-            #define CODED_SM2P256V1    {1,2,156,10197,1,301}
-            #define CODED_SM2P256V1_SZ 6
-        #else
-            #define CODED_SM2P256V1 {0x06,0x08,0x2A,0x81,0x1C,0xCF,0x55,0x01,0x82,0x2D}
-            #define CODED_SM2P256V1_SZ 10
-        #endif
-        #ifndef WOLFSSL_ECC_CURVE_STATIC
-            static const ecc_oid_t ecc_oid_sm2p256v1[] = CODED_SM2P256V1;
-        #else
-            #define ecc_oid_sm2p256v1 CODED_SM2P256V1
-        #endif
-        #define ecc_oid_sm2p256v1_sz CODED_SM2P256V1_SZ
-    #endif /* WOLFSSL_SM2 */
+    #ifdef HAVE_OID_ENCODING
+        #define CODED_SM2P256V1    {1,2,156,10197,1,301}
+        #define CODED_SM2P256V1_SZ 6
+    #else
+        #define CODED_SM2P256V1 {0x06,0x08,0x2A,0x81,0x1C,0xCF,0x55,0x01,0x82,0x2D}
+        #define CODED_SM2P256V1_SZ 10
+    #endif
+    #ifndef WOLFSSL_ECC_CURVE_STATIC
+        static const ecc_oid_t ecc_oid_sm2p256v1[] = CODED_SM2P256V1;
+    #else
+        #define ecc_oid_sm2p256v1 CODED_SM2P256V1
+    #endif
+    #define ecc_oid_sm2p256v1_sz CODED_SM2P256V1_SZ
     #define ECC_SM2P256V1_TEST 102
 static int test_sm2_verify_caseA2(void)
 {
@@ -29931,9 +29929,7 @@ static int ecc_sm2_test_curve(WC_RNG* rng, int testVerifyCount)
     WC_DECLARE_VAR(sig, byte, ECC_SIG_SIZE, HEAP_HINT);
     WC_DECLARE_VAR(digest, byte, ECC_DIGEST_SIZE, HEAP_HINT);
     int     i;
-#ifdef HAVE_ECC_VERIFY
     int     verify;
-#endif /* HAVE_ECC_VERIFY */
 #endif /* HAVE_ECC_SIGN */
     int     ret;
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
@@ -30129,7 +30125,6 @@ static int ecc_sm2_test_curve(WC_RNG* rng, int testVerifyCount)
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
-#ifdef HAVE_ECC_VERIFY
     for (i = 0; i < testVerifyCount; i++) {
         verify = 0;
         ret = wc_ecc_sm2_verify_hash(sig, x, digest, ECC_DIGEST_SIZE, &verify,
@@ -30139,7 +30134,6 @@ static int ecc_sm2_test_curve(WC_RNG* rng, int testVerifyCount)
         if (verify != 1)
             ERROR_OUT(WC_TEST_RET_ENC_NC, done);
     }
-#endif /* HAVE_ECC_VERIFY */
 #endif /* ECC_SHAMIR */
 
     /* test DSA sign hash with sequence (0,1,2,3,4,...) */
@@ -30152,7 +30146,6 @@ static int ecc_sm2_test_curve(WC_RNG* rng, int testVerifyCount)
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
-#ifdef HAVE_ECC_VERIFY
     for (i = 0; i < testVerifyCount; i++) {
         verify = 0;
         ret = wc_ecc_sm2_verify_hash(sig, x, digest, ECC_DIGEST_SIZE, &verify,
@@ -30162,7 +30155,6 @@ static int ecc_sm2_test_curve(WC_RNG* rng, int testVerifyCount)
         if (verify != 1)
             ERROR_OUT(WC_TEST_RET_ENC_NC, done);
     }
-#endif /* HAVE_ECC_VERIFY */
 #endif /* HAVE_ECC_SIGN */
 #endif /* !ECC_TIMING_RESISTANT || (ECC_TIMING_RESISTANT && !WC_NO_RNG) */
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -592,7 +592,7 @@ typedef struct w64wrapper {
     #endif
 
     #define WC_DECLARE_HEAP_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) \
-        VAR_TYPE* VAR_NAME[VAR_ITEMS]; \
+        VAR_TYPE* VAR_NAME[VAR_ITEMS] = { NULL, }; \
         int idx##VAR_NAME = 0, inner_idx_##VAR_NAME
     #define WC_HEAP_ARRAY_ARG(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE) \
         VAR_TYPE* VAR_NAME[VAR_ITEMS]


### PR DESCRIPTION
# Description

Test now has an array of hashes.
Use only first hash when testing full digest operation.

# Testing

Install SM code.
./configure --enable-sm3
make

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
