### PR TITLE
20240430-xmss-analyzer-cleanups

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -10071,12 +10071,10 @@ exit_xmss_sign_verify:
 
     if (freeRng) {
         wc_FreeRng(&rng);
-        freeRng = 0;
     }
 
     if (freeKey) {
         wc_XmssKey_Free(&key);
-        freeKey = 0;
     }
 
     return;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -38381,7 +38381,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t xmss_test_verify_only(void)
     }
 
     if (pub_len != XMSS_SHA256_PUBLEN) {
-        printf("error: xmss pub len %d, expected %d\n", pub_len,
+        printf("error: xmss pub len %u, expected %d\n", pub_len,
                XMSS_SHA256_PUBLEN);
         return WC_TEST_RET_ENC_EC(pub_len);
     }


### PR DESCRIPTION
`wolfcrypt/benchmark/benchmark.c`: fixes for `clang-analyzer-deadcode.DeadStore`s in `bench_xmss_sign_verify()`;

`wolfcrypt/test/test.c`: fix for `invalidPrintfArgType_sint` in `xmss_test_verify_only()`.

tested with `wolfssl-multi-test.sh ... xmss-wolfssl-all-gcc-latest xmss-wolfssl-all-clang-tidy xmss-wolfssl-all-sanitizer xmss-wolfssl-all-clang-sanitizer xmss-wolfssl-all-cppcheck xmss-wolfssl-cross-aarch64-all-armasm-unittest-sanitizer` with https://github.com/wolfSSL/pqcrypto/pull/12 as `PQCRYPTO_NATIVE_HEAD`
