### PR TITLE
Fix windows 'gethostbyname' declaration

### DIFF
--- a/IDE/MSVS-2019-AZSPHERE/user_settings.h
+++ b/IDE/MSVS-2019-AZSPHERE/user_settings.h
@@ -85,6 +85,7 @@
 
 /* Filesystem */
 #define NO_FILESYSTEM
+#define HAVE_NETDB_H
 
 /* Debug */
 #include <applibs/log.h>


### PR DESCRIPTION
Example of passing test: nightly-Azure-Sphere-MT3620-mini-v2/1527