### PR TITLE
20240501-xilinx-wc_Sha3

### DIFF
--- a/wolfssl/wolfcrypt/port/xilinx/xil-sha3.h
+++ b/wolfssl/wolfcrypt/port/xilinx/xil-sha3.h
@@ -35,7 +35,7 @@
 #endif
 
 /* Sha3 digest */
-typedef struct Sha3 {
+typedef struct wc_Sha3 {
 #ifdef WOLFSSL_XILINX_CRYPT_VERSAL
     wc_Xsecure xSec;
 #else


### PR DESCRIPTION
`wolfssl/wolfcrypt/port/xilinx/xil-sha3.h`: fix struct name -- `struct wc_Sha3`, not `struct Sha3`.

(note, the FIPS code actually depends on the struct being named `struct wc_Sha3`.)
