### PR TITLE
20240501-fix-pqcrypto-private_key-callback-names

### DIFF
--- a/wolfcrypt/src/ext_lms.c
+++ b/wolfcrypt/src/ext_lms.c
@@ -586,7 +586,7 @@ void wc_LmsKey_Free(LmsKey* key)
  *
  * Returns 0 on success.
  * */
-int wc_LmsKey_SetWriteCb(LmsKey * key, write_private_key_cb write_cb)
+int wc_LmsKey_SetWriteCb(LmsKey * key, wc_lms_write_private_key_cb write_cb)
 {
     if (key == NULL || write_cb == NULL) {
         return BAD_FUNC_ARG;
@@ -610,7 +610,7 @@ int wc_LmsKey_SetWriteCb(LmsKey * key, write_private_key_cb write_cb)
  *
  * Returns 0 on success.
  * */
-int wc_LmsKey_SetReadCb(LmsKey * key, read_private_key_cb read_cb)
+int wc_LmsKey_SetReadCb(LmsKey * key, wc_lms_read_private_key_cb read_cb)
 {
     if (key == NULL || read_cb == NULL) {
         return BAD_FUNC_ARG;

--- a/wolfcrypt/src/ext_xmss.c
+++ b/wolfcrypt/src/ext_xmss.c
@@ -307,7 +307,7 @@ void wc_XmssKey_Free(XmssKey* key)
  *  returns     BAD_FUNC_ARG when a parameter is NULL.
  *  returns     -1 on failure.
  * */
-int wc_XmssKey_SetWriteCb(XmssKey * key, write_private_key_cb write_cb)
+int wc_XmssKey_SetWriteCb(XmssKey * key, wc_xmss_write_private_key_cb write_cb)
 {
     if (key == NULL || write_cb == NULL) {
         return BAD_FUNC_ARG;
@@ -336,7 +336,7 @@ int wc_XmssKey_SetWriteCb(XmssKey * key, write_private_key_cb write_cb)
  *  returns     BAD_FUNC_ARG when a parameter is NULL.
  *  returns     -1 on failure.
  * */
-int wc_XmssKey_SetReadCb(XmssKey * key, read_private_key_cb read_cb)
+int wc_XmssKey_SetReadCb(XmssKey * key, wc_xmss_read_private_key_cb read_cb)
 {
     if (key == NULL || read_cb == NULL) {
         return BAD_FUNC_ARG;

--- a/wolfssl/wolfcrypt/ext_lms.h
+++ b/wolfssl/wolfcrypt/ext_lms.h
@@ -53,8 +53,8 @@ struct LmsKey {
     unsigned char        pub[HSS_MAX_PUBLIC_KEY_LEN];
 #ifndef WOLFSSL_LMS_VERIFY_ONLY
     hss_working_key *    working_key;
-    write_private_key_cb write_private_key; /* Callback to write/update key. */
-    read_private_key_cb  read_private_key;  /* Callback to read key. */
+    wc_lms_write_private_key_cb write_private_key; /* Callback to write/update key. */
+    wc_lms_read_private_key_cb  read_private_key;  /* Callback to read key. */
     void *               context;           /* Context arg passed to callbacks. */
     hss_extra_info       info;
 #endif /* ifndef WOLFSSL_LMS_VERIFY_ONLY */

--- a/wolfssl/wolfcrypt/ext_xmss.h
+++ b/wolfssl/wolfcrypt/ext_xmss.h
@@ -45,8 +45,8 @@ struct XmssKey {
     /* The secret key length is a function of xmss_params. */
     unsigned char *      sk;
     word32               sk_len;
-    write_private_key_cb write_private_key; /* Callback to write/update key. */
-    read_private_key_cb  read_private_key;  /* Callback to read key. */
+    wc_xmss_write_private_key_cb write_private_key; /* Callback to write/update key. */
+    wc_xmss_read_private_key_cb  read_private_key;  /* Callback to read key. */
     void *               context;           /* Context arg passed to callbacks. */
 #endif /* ifndef WOLFSSL_XMSS_VERIFY_ONLY */
     enum wc_XmssState    state;

--- a/wolfssl/wolfcrypt/lms.h
+++ b/wolfssl/wolfcrypt/lms.h
@@ -34,8 +34,8 @@
 typedef struct LmsKey LmsKey;
 
 /* Private key write and read callbacks. */
-typedef int (*write_private_key_cb)(const byte * priv, word32 privSz, void *context);
-typedef int (*read_private_key_cb)(byte * priv, word32 privSz, void *context);
+typedef int (*wc_lms_write_private_key_cb)(const byte * priv, word32 privSz, void *context);
+typedef int (*wc_lms_read_private_key_cb)(byte * priv, word32 privSz, void *context);
 
 /* Return codes returned by private key callbacks. */
 enum wc_LmsRc {
@@ -138,9 +138,9 @@ WOLFSSL_API int  wc_LmsKey_GetParameters(const LmsKey * key, int * levels,
     int * height, int * winternitz);
 #ifndef WOLFSSL_LMS_VERIFY_ONLY
 WOLFSSL_API int  wc_LmsKey_SetWriteCb(LmsKey * key,
-    write_private_key_cb write_cb);
+    wc_lms_write_private_key_cb write_cb);
 WOLFSSL_API int  wc_LmsKey_SetReadCb(LmsKey * key,
-    read_private_key_cb read_cb);
+    wc_lms_read_private_key_cb read_cb);
 WOLFSSL_API int  wc_LmsKey_SetContext(LmsKey * key, void * context);
 WOLFSSL_API int  wc_LmsKey_MakeKey(LmsKey * key, WC_RNG * rng);
 WOLFSSL_API int  wc_LmsKey_Reload(LmsKey * key);

--- a/wolfssl/wolfcrypt/xmss.h
+++ b/wolfssl/wolfcrypt/xmss.h
@@ -160,9 +160,9 @@ enum wc_XmssState {
 };
 
 /* Private key write and read callbacks. */
-typedef enum wc_XmssRc (*write_private_key_cb)(const byte* priv, word32 privSz,
+typedef enum wc_XmssRc (*wc_xmss_write_private_key_cb)(const byte* priv, word32 privSz,
     void* context);
-typedef enum wc_XmssRc (*read_private_key_cb)(byte* priv, word32 privSz,
+typedef enum wc_XmssRc (*wc_xmss_read_private_key_cb)(byte* priv, word32 privSz,
     void* context);
 
 #ifdef __cplusplus
@@ -173,9 +173,9 @@ WOLFSSL_API int  wc_XmssKey_Init(XmssKey* key, void* heap, int devId);
 WOLFSSL_API int  wc_XmssKey_SetParamStr(XmssKey* key, const char* str);
 #ifndef WOLFSSL_XMSS_VERIFY_ONLY
 WOLFSSL_API int  wc_XmssKey_SetWriteCb(XmssKey* key,
-    write_private_key_cb write_cb);
+    wc_xmss_write_private_key_cb write_cb);
 WOLFSSL_API int  wc_XmssKey_SetReadCb(XmssKey* key,
-    read_private_key_cb read_cb);
+    wc_xmss_read_private_key_cb read_cb);
 WOLFSSL_API int  wc_XmssKey_SetContext(XmssKey* key, void* context);
 WOLFSSL_API int  wc_XmssKey_MakeKey(XmssKey* key, WC_RNG* rng);
 WOLFSSL_API int  wc_XmssKey_Reload(XmssKey* key);


### PR DESCRIPTION
fix namespace collision: rename types `read_private_key_cb` and `write_private_key_cb` to `wc_{lms,xmss}_read_private_key_cb` and `wc_{lms,xmss}_write_private_key_cb`.

discovered and tested with `wolfssl-multi-test.sh ... lms-xmss-wolfssl-all-gcc-latest lms-xmss-wolfssl-all-clang-tidy lms-xmss-wolfssl-all-sanitizer lms-xmss-wolfssl-all-clang-sanitizer lms-xmss-wolfssl-all-cppcheck lms-xmss-wolfssl-cross-aarch64-all-armasm-unittest-sanitizer xmss-reference`

merge with https://github.com/wolfSSL/pqcrypto/pull/13
