### PR TITLE
20240501-openssl-sha3-sizeof-fix

### DIFF
--- a/wolfssl/openssl/sha3.h
+++ b/wolfssl/openssl/sha3.h
@@ -43,7 +43,7 @@
 struct WOLFSSL_SHA3_CTX {
     /* big enough to hold wolfcrypt Sha3, but check on init */
 #ifdef WOLFSSL_SHA3
-    ALIGN16 void* holder[sizeof(struct wc_Sha3)];
+    ALIGN16 void* holder[sizeof(wc_Sha3)];
 #else
     ALIGN16 void* holder[(424 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
 #endif


### PR DESCRIPTION
`wolfssl/openssl/sha3.h`: use `sizeof(wc_Sha3)`, not `sizeof(struct wc_Sha3)`, for compatibility with `afalg_hash.h` and other ports that don't define a `struct wc_Sha3`.

discovered with `nightly-XILINX-builds`.

tested with `wolfssl-multi-test.sh ... check-source-text all-gcc-c99`
