### PR TITLE
20240502-test_server_loop-double-close

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -7437,8 +7437,8 @@ done:
     !defined(WOLFSSL_NO_TLS12)
 static THREAD_RETURN WOLFSSL_THREAD test_server_loop(void* args)
 {
-    SOCKET_T sockfd = 0;
-    SOCKET_T clientfd = 0;
+    SOCKET_T sockfd;
+    SOCKET_T clientfd = -1;
     word16 port;
 
     callback_functions* cbf;
@@ -7601,6 +7601,7 @@ static THREAD_RETURN WOLFSSL_THREAD test_server_loop(void* args)
         wolfSSL_shutdown(ssl);
         wolfSSL_free(ssl); ssl = NULL;
         CloseSocket(clientfd);
+        clientfd = -1;
 
         count++;
     }
@@ -7618,7 +7619,8 @@ done:
     if (!sharedCtx)
         wolfSSL_CTX_free(ctx);
 
-    CloseSocket(clientfd);
+    if (clientfd >= 0)
+        CloseSocket(clientfd);
 
 #ifdef WOLFSSL_TIRTOS
     fdCloseSession(Task_self());


### PR DESCRIPTION
`tests/api.c`: fix double close in `test_server_loop()`.

tested with `wolfssl-multi-test.sh ... super-quick-check pq-hybrid-all-rpk-valgrind-unittest sp-all-asm-smallstack-valgrind-testsuite all-noasm-valgrind-unittest`

note, the double-close was detected after upgrade to `valgrind-3.23.0`.
