### PR TITLE
Generic Memory Pools Fix

### DIFF
--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -656,9 +656,14 @@ int wc_LoadStaticMemory_ex(WOLFSSL_HEAP_HINT** pHint,
 
     WOLFSSL_ENTER("wc_LoadStaticMemory_ex");
 
-    if (pHint == NULL || buf == NULL || listSz > WOLFMEM_MAX_BUCKETS
-            || sizeList == NULL || distList == NULL) {
+    if (pHint == NULL || buf == NULL || sizeList == NULL || distList == NULL) {
         return BAD_FUNC_ARG;
+    }
+
+    /* Cap the listSz to the actual number of items allocated in the list. */
+    if (listSz > WOLFMEM_MAX_BUCKETS) {
+        WOLFSSL_MSG("Truncating the list of memory buckets");
+        listSz = WOLFMEM_MAX_BUCKETS;
     }
 
     if ((sizeof(WOLFSSL_HEAP) + sizeof(WOLFSSL_HEAP_HINT)) > sz - idx) {
@@ -761,9 +766,14 @@ int wolfSSL_StaticBufferSz_ex(unsigned int listSz,
 
     WOLFSSL_ENTER("wolfSSL_StaticBufferSz_ex");
 
-    if (buffer == NULL || listSz > WOLFMEM_MAX_BUCKETS
-            || sizeList == NULL || distList == NULL) {
+    if (buffer == NULL || sizeList == NULL || distList == NULL) {
         return BAD_FUNC_ARG;
+    }
+
+    /* Cap the listSz to the actual number of items allocated in the list. */
+    if (listSz > WOLFMEM_MAX_BUCKETS) {
+        WOLFSSL_MSG("Truncating the list of memory buckets");
+        listSz = WOLFMEM_MAX_BUCKETS;
     }
 
     /* align pt */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -16089,22 +16089,26 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t memory_test(void)
 
 #ifdef WOLFSSL_STATIC_MEMORY
     /* check macro settings */
-    if (sizeof(size)/sizeof(word32) != WOLFMEM_MAX_BUCKETS) {
+    if (sizeof(size)/sizeof(word32) != WOLFMEM_DEF_BUCKETS) {
         return WC_TEST_RET_ENC_NC;
     }
 
-    if (sizeof(dist)/sizeof(word32) != WOLFMEM_MAX_BUCKETS) {
+    if (sizeof(dist)/sizeof(word32) != WOLFMEM_DEF_BUCKETS) {
         return WC_TEST_RET_ENC_NC;
     }
 
-    for (i = 0; i < WOLFMEM_MAX_BUCKETS; i++) {
+    if (WOLFMEM_DEF_BUCKETS > WOLFMEM_MAX_BUCKETS) {
+        return WC_TEST_RET_ENC_NC;
+    }
+
+    for (i = 0; i < WOLFMEM_DEF_BUCKETS; i++) {
         if ((size[i] % WOLFSSL_STATIC_ALIGN) != 0) {
             /* each element in array should be divisible by alignment size */
             return WC_TEST_RET_ENC_NC;
         }
     }
 
-    for (i = 1; i < WOLFMEM_MAX_BUCKETS; i++) {
+    for (i = 1; i < WOLFMEM_DEF_BUCKETS; i++) {
         if (size[i - 1] >= size[i]) {
             return WC_TEST_RET_ENC_NC; /* sizes should be in increasing order */
         }


### PR DESCRIPTION
# Description

1. Add some expository comments describing the purpose of:
   * WOLFMEM_MAX_BUCKETS
   * WOLFMEM_DEF_BUCKETS
   * WOLFMEM_BUCKETS
   * WOLFMEM_DIST
2. Switch the API test for LoadStaticMemory() to named constants.
3. Delete redundant test case. Add a new test case.
4. In the wolfCrypt test for the memory constants, check the sizes of the WOLFMEM_BUCKETS and WOLFMEM_DIST lists against WOLFMEM_DEF_BUCKETS which should be their length. Check that WOLFMEM_DEF_BUCKETS is not greater than WOLFMEM_MAX_BUCKETS.
5. Default for WOLFMEM_MAX_BUCKETS should be WOLFMEM_DEF_BUCKETS, set it to what is specified. Add a warning if MAX is less than DEF.
6. Separate the definition of the constant LARGEST_MEM_BUCKET so it is dependent on config and not if WOLFMEM_BUCKETS isn't set.

Fixes ZD17924

# Testing

Added a test case to cover the size differences.

# Checklist

 - [X] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
