### PR TITLE
tls13: update error code to NO_CERT_ERROR when no cert is set

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -8504,7 +8504,7 @@ static int SendTls13Certificate(WOLFSSL* ssl)
     else {
         if (!ssl->buffers.certificate) {
             WOLFSSL_MSG("Send Cert missing certificate buffer");
-            return BUFFER_ERROR;
+            return NO_CERT_ERROR;
         }
         /* Certificate Data */
         certSz = ssl->buffers.certificate->length;


### PR DESCRIPTION
# Description

Update BUFFER_ERROR to the more descriptive NO_CERT_ERROR in case the Server tries to handshake without a certificate set.

Fixes zd#17927

