### PR TITLE
20240509-fix-linuxkm-x86_vector_register_glue

### DIFF
--- a/linuxkm/include.am
+++ b/linuxkm/include.am
@@ -13,4 +13,5 @@ EXTRA_DIST += m4/ax_linuxkm.m4 \
 	      linuxkm/pie_last.c \
 	      linuxkm/linuxkm_memory.c \
 	      linuxkm/linuxkm_wc_port.h \
-	      linuxkm/lkcapi_glue.c
+	      linuxkm/lkcapi_glue.c \
+	      linuxkm/x86_vector_register_glue.c


### PR DESCRIPTION
`linuxkm/include.am`: add `linuxkm/x86_vector_register_glue.c` to `EXTRA_DIST`.

discovered and tested with `wolfssl-multi-test.sh ... make-dist-clean-check`
