### PR TITLE
Fix conversion

### DIFF
--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -412,7 +412,7 @@ static int ServerMemSend(info_t* info, char* buf, int sz)
     }
 #endif
 
-    XMEMCPY(&info->to_client.buf[info->to_client.write_idx], buf, sz);
+    XMEMCPY(&info->to_client.buf[info->to_client.write_idx], buf, (size_t)sz);
     info->to_client.write_idx += sz;
     info->to_client.write_bytes += sz;
 
@@ -443,7 +443,7 @@ static int ServerMemRecv(info_t* info, char* buf, int sz)
     }
 #endif
 
-    XMEMCPY(buf, &info->to_server.buf[info->to_server.read_idx], sz);
+    XMEMCPY(buf, &info->to_server.buf[info->to_server.read_idx], (size_t)sz);
     info->to_server.read_idx += sz;
     info->to_server.read_bytes += sz;
 
@@ -486,7 +486,7 @@ static int ClientMemSend(info_t* info, char* buf, int sz)
     }
 #endif
 
-    XMEMCPY(&info->to_server.buf[info->to_server.write_idx], buf, sz);
+    XMEMCPY(&info->to_server.buf[info->to_server.write_idx], buf, (size_t)sz);
     info->to_server.write_idx += sz;
     info->to_server.write_bytes += sz;
 
@@ -517,7 +517,7 @@ static int ClientMemRecv(info_t* info, char* buf, int sz)
     }
 #endif
 
-    XMEMCPY(buf, &info->to_client.buf[info->to_client.read_idx], sz);
+    XMEMCPY(buf, &info->to_client.buf[info->to_client.read_idx], (size_t)sz);
     info->to_client.read_idx += sz;
     info->to_client.read_bytes += sz;
 
@@ -544,7 +544,7 @@ static int ClientMemRecv(info_t* info, char* buf, int sz)
 
 static int SocketRecv(int sockFd, char* buf, int sz)
 {
-    int recvd = (int)recv(sockFd, buf, sz, 0);
+    int recvd = (int)recv(sockFd, buf, (size_t)sz, 0);
     if (recvd == -1) {
         switch (errno) {
     #if EAGAIN != SOCKET_EWOULDBLOCK
@@ -572,7 +572,7 @@ static int SocketRecv(int sockFd, char* buf, int sz)
 
 static int SocketSend(int sockFd, char* buf, int sz)
 {
-    int sent = (int)send(sockFd, buf, sz, 0);
+    int sent = (int)send(sockFd, buf, (size_t)sz, 0);
     if (sent == -1) {
         switch (errno) {
     #if EAGAIN != SOCKET_EWOULDBLOCK
@@ -618,7 +618,7 @@ static int ReceiveFrom(WOLFSSL *ssl, int sd, char *buf, int sz)
         }
     }
 
-    recvd = (int)recvfrom(sd, buf, sz, 0, (SOCKADDR*)&peer, &peerSz);
+    recvd = (int)recvfrom(sd, buf, (size_t)sz, 0, (SOCKADDR*)&peer, &peerSz);
 
     if (recvd < 0) {
         if (errno == SOCKET_EWOULDBLOCK || errno == SOCKET_EAGAIN) {
@@ -658,7 +658,7 @@ static int SendTo(int sd, char *buf, int sz, const struct sockaddr *peer,
 {
     int sent;
 
-    sent = (int)sendto(sd, buf, sz, 0, peer, peerSz);
+    sent = (int)sendto(sd, buf, (size_t)sz, 0, peer, peerSz);
 
     if (sent < 0) {
         if (errno == SOCKET_EWOULDBLOCK || errno == SOCKET_EAGAIN) {
@@ -813,13 +813,13 @@ static int SetupSocketAndConnect(info_t* info, const char* host,
     /* Setup server address */
     XMEMSET(&servAddr, 0, sizeof(servAddr));
     servAddr.sin_family = AF_INET;
-    servAddr.sin_port = htons(port);
+    servAddr.sin_port = htons((__uint16_t)port);
 
     /* Resolve host */
     entry = gethostbyname(host);
     if (entry) {
         XMEMCPY(&servAddr.sin_addr.s_addr, entry->h_addr_list[0],
-            entry->h_length);
+            (size_t)entry->h_length);
     }
     else {
         servAddr.sin_addr.s_addr = inet_addr(host);
@@ -981,7 +981,7 @@ static int bench_tls_client(info_t* info)
 
 
     /* Allocate and initialize a packet sized buffer */
-    writeBuf = (unsigned char*)XMALLOC(info->packetSize, NULL,
+    writeBuf = (unsigned char*)XMALLOC((size_t)info->packetSize, NULL,
         DYNAMIC_TYPE_TMP_BUFFER);
     if (writeBuf == NULL) {
         fprintf(stderr, "failed to allocate write memory\n");
@@ -990,7 +990,7 @@ static int bench_tls_client(info_t* info)
 
     /* Allocate read buffer */
     readBufSz = info->packetSize;
-    readBuf = (unsigned char*)XMALLOC(readBufSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    readBuf = (unsigned char*)XMALLOC((size_t)readBufSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (readBuf == NULL) {
         fprintf(stderr, "failed to allocate read memory\n");
         ret = MEMORY_E; goto exit;
@@ -1089,7 +1089,7 @@ static int bench_tls_client(info_t* info)
             info->client.shutdown = 1;
 
             writeSz = (int)XSTRLEN(kShutdown) + 1;
-            XMEMCPY(writeBuf, kShutdown, writeSz); /* include null term */
+            XMEMCPY(writeBuf, kShutdown, (size_t)writeSz); /* include null term */
             if (info->showVerbose) {
                 fprintf(stderr, "Sending shutdown\n");
             }
@@ -1102,8 +1102,8 @@ static int bench_tls_client(info_t* info)
             }
         }
         else {
-            XMEMSET(writeBuf, 0, info->packetSize);
-            XSTRNCPY((char*)writeBuf, kTestStr, info->packetSize);
+            XMEMSET(writeBuf, 0, (size_t)info->packetSize);
+            XSTRNCPY((char*)writeBuf, kTestStr, (size_t)info->packetSize);
         }
 
         /* write / read echo loop */
@@ -1131,7 +1131,7 @@ static int bench_tls_client(info_t* info)
             total_sz += ret;
 
             /* read echo of message from server */
-            XMEMSET(readBuf, 0, readBufSz);
+            XMEMSET(readBuf, 0, (size_t)readBufSz);
             start = gettime_secs(1);
         #ifndef BENCH_USE_NONBLOCK
             ret = wolfSSL_read(cli_ssl, readBuf, readBufSz);
@@ -1152,7 +1152,7 @@ static int bench_tls_client(info_t* info)
             ret = 0; /* reset return code */
 
             /* validate echo */
-            if (XMEMCMP((char*)writeBuf, (char*)readBuf, writeSz) != 0) {
+            if (XMEMCMP((char*)writeBuf, (char*)readBuf, (size_t)writeSz) != 0) {
                 fprintf(stderr, "echo check failed!\n");
                 ret = wolfSSL_get_error(cli_ssl, ret);
                 goto exit;
@@ -1169,7 +1169,7 @@ exit:
 
     if (ret != 0 && ret != WOLFSSL_SUCCESS) {
         fprintf(stderr, "Client Error: %d (%s)\n", ret,
-            wolfSSL_ERR_reason_error_string(ret));
+            wolfSSL_ERR_reason_error_string((unsigned long)ret));
     }
 
     /* clean up */
@@ -1224,7 +1224,7 @@ static int SetupSocketAndListen(int* listenFd, word32 port, int doDTLS)
     /* Setup server address */
     XMEMSET(&servAddr, 0, sizeof(servAddr));
     servAddr.sin_family = AF_INET;
-    servAddr.sin_port = htons(port);
+    servAddr.sin_port = htons((__uint16_t)port);
     servAddr.sin_addr.s_addr = INADDR_ANY;
 
 #ifdef WOLFSSL_DTLS
@@ -1440,7 +1440,7 @@ static int bench_tls_server(info_t* info)
 
     /* Allocate read buffer */
     readBufSz = info->packetSize;
-    readBuf = (unsigned char*)XMALLOC(readBufSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    readBuf = (unsigned char*)XMALLOC((size_t)readBufSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (readBuf == NULL) {
         fprintf(stderr, "failed to allocate read memory\n");
         ret = MEMORY_E; goto exit;
@@ -1538,7 +1538,7 @@ static int bench_tls_server(info_t* info)
             double rxTime;
 
             /* read message from client */
-            XMEMSET(readBuf, 0, readBufSz);
+            XMEMSET(readBuf, 0, (size_t)readBufSz);
             start = gettime_secs(1);
         #ifndef BENCH_USE_NONBLOCK
             ret = wolfSSL_read(srv_ssl, readBuf, readBufSz);
@@ -1615,7 +1615,7 @@ exit:
 
     if (ret != 0 && ret != WOLFSSL_SUCCESS) {
         fprintf(stderr, "Server Error: %d (%s)\n", ret,
-                wolfSSL_ERR_reason_error_string(ret));
+                wolfSSL_ERR_reason_error_string((unsigned long)ret));
     }
 
     /* clean up */
@@ -1834,7 +1834,7 @@ int bench_tls(void* args)
     int argClientOnly = 0;
     int argServerOnly = 0;
     const char* argHost = BENCH_DEFAULT_HOST;
-    int argPort = BENCH_DEFAULT_PORT;
+    word32 argPort = BENCH_DEFAULT_PORT;
     int argShowPeerInfo = 0;
 #ifndef SINGLE_THREADED
     int doShutdown;
@@ -1883,7 +1883,7 @@ int bench_tls(void* args)
                 break;
 
             case 'P':
-                argPort = atoi(myoptarg);
+                argPort = (word32)atoi(myoptarg);
                 break;
 
             case 'd' :
@@ -2003,12 +2003,12 @@ int bench_tls(void* args)
 #endif
 
     /* Allocate test info array */
-    theadInfo = (info_t*)XMALLOC(sizeof(info_t) * argThreadPairs, NULL,
+    theadInfo = (info_t*)XMALLOC(sizeof(info_t) * (size_t)argThreadPairs, NULL,
         DYNAMIC_TYPE_TMP_BUFFER);
     if (theadInfo == NULL) {
         ret = MEMORY_E; goto exit;
     }
-    XMEMSET(theadInfo, 0, sizeof(info_t) * argThreadPairs);
+    XMEMSET(theadInfo, 0, sizeof(info_t) * (size_t)argThreadPairs);
 
 #ifndef NO_WOLFSSL_SERVER
     /* Use same listen socket to avoid timing issues between client and server */
@@ -2073,7 +2073,7 @@ int bench_tls(void* args)
                 XMEMSET(info, 0, sizeof(info_t));
 
                 info->host = argHost;
-                info->port = argPort + i; /* threads must have separate ports */
+                info->port = argPort + (word32)i; /* threads must have separate ports */
                 info->cipher = cipher;
 
             #if defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES)

--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -813,7 +813,7 @@ static int SetupSocketAndConnect(info_t* info, const char* host,
     /* Setup server address */
     XMEMSET(&servAddr, 0, sizeof(servAddr));
     servAddr.sin_family = AF_INET;
-    servAddr.sin_port = htons((__uint16_t)port);
+    servAddr.sin_port = htons((u_int16_t)port);
 
     /* Resolve host */
     entry = gethostbyname(host);
@@ -1224,7 +1224,7 @@ static int SetupSocketAndListen(int* listenFd, word32 port, int doDTLS)
     /* Setup server address */
     XMEMSET(&servAddr, 0, sizeof(servAddr));
     servAddr.sin_family = AF_INET;
-    servAddr.sin_port = htons((__uint16_t)port);
+    servAddr.sin_port = htons((u_int16_t)port);
     servAddr.sin_addr.s_addr = INADDR_ANY;
 
 #ifdef WOLFSSL_DTLS

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -461,7 +461,7 @@ static void EarlyData(WOLFSSL_CTX* ctx, WOLFSSL* ssl, const char* msg,
     } while (err == WC_PENDING_E);
     if (ret != msgSz) {
         LOG_ERROR("SSL_write_early_data msg error %d, %s\n", err,
-                                         wolfSSL_ERR_error_string(err, buffer));
+                                         wolfSSL_ERR_error_string((unsigned long)err, buffer));
         wolfSSL_free(ssl); ssl = NULL;
         wolfSSL_CTX_free(ctx); ctx = NULL;
         err_sys("SSL_write_early_data failed");
@@ -683,8 +683,8 @@ static int ClientBenchmarkThroughput(WOLFSSL_CTX* ctx, char* host, word16 port,
         conn_time = current_time(0) - start;
 
         /* Allocate TX/RX buffers */
-        tx_buffer = (char*)XMALLOC(block, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        rx_buffer = (char*)XMALLOC(block, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        tx_buffer = (char*)XMALLOC((size_t)block, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        rx_buffer = (char*)XMALLOC((size_t)block, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         if (tx_buffer && rx_buffer) {
             WC_RNG rng;
 
@@ -698,7 +698,7 @@ static int ClientBenchmarkThroughput(WOLFSSL_CTX* ctx, char* host, word16 port,
                 size_t xfer_bytes;
 
                 /* Generate random data to send */
-                ret = wc_RNG_GenerateBlock(&rng, (byte*)tx_buffer, block);
+                ret = wc_RNG_GenerateBlock(&rng, (byte*)tx_buffer, (word32)block);
                 wc_FreeRng(&rng);
                 if(ret != 0) {
                     err_sys("wc_RNG_GenerateBlock failed");
@@ -710,7 +710,7 @@ static int ClientBenchmarkThroughput(WOLFSSL_CTX* ctx, char* host, word16 port,
                     int len, rx_pos, select_ret;
 
                     /* Determine packet size */
-                    len = min(block, (int)(throughput - xfer_bytes));
+                    len = (int)min((word32)block, (word32)(throughput - xfer_bytes));
 
                     /* Perform TX */
                     start = current_time(1);
@@ -766,7 +766,7 @@ static int ClientBenchmarkThroughput(WOLFSSL_CTX* ctx, char* host, word16 port,
                     }
 
                     /* Compare TX and RX buffers */
-                    if (XMEMCMP(tx_buffer, rx_buffer, len) != 0) {
+                    if (XMEMCMP(tx_buffer, rx_buffer, (size_t)len) != 0) {
                         free(tx_buffer);
                         tx_buffer = NULL;
                         free(rx_buffer);
@@ -775,7 +775,7 @@ static int ClientBenchmarkThroughput(WOLFSSL_CTX* ctx, char* host, word16 port,
                     }
 
                     /* Update overall position */
-                    xfer_bytes += len;
+                    xfer_bytes += (size_t)len;
                 }
             }
             else {
@@ -815,8 +815,8 @@ doExit:
         "\tRX      %8.3f ms (%8.3f MBps)\n",
         (SIZE_TYPE)throughput,
         conn_time * 1000,
-        tx_time * 1000, throughput / tx_time / 1024 / 1024,
-        rx_time * 1000, throughput / rx_time / 1024 / 1024
+        (double)tx_time * 1000, (double)throughput / tx_time / 1024 / 1024,
+        (double)rx_time * 1000, (double)throughput / rx_time / 1024 / 1024
     );
 
     return EXIT_SUCCESS;
@@ -852,7 +852,7 @@ static int StartTLS_Init(SOCKET_T* sockfd)
     }
 
     /* C: EHLO mail.example.com */
-    if (send(*sockfd, starttlsCmd[1], (int)XSTRLEN(starttlsCmd[1]), 0) !=
+    if (send(*sockfd, starttlsCmd[1], XSTRLEN(starttlsCmd[1]), 0) !=
               (int)XSTRLEN(starttlsCmd[1]))
         err_sys("failed to send STARTTLS EHLO command\n");
 
@@ -869,7 +869,7 @@ static int StartTLS_Init(SOCKET_T* sockfd)
     }
 
     /* C: STARTTLS */
-    if (send(*sockfd, starttlsCmd[3], (int)XSTRLEN(starttlsCmd[3]), 0) !=
+    if (send(*sockfd, starttlsCmd[3], XSTRLEN(starttlsCmd[3]), 0) !=
               (int)XSTRLEN(starttlsCmd[3])) {
         err_sys("failed to send STARTTLS command\n");
     }
@@ -980,7 +980,7 @@ static int ClientWrite(WOLFSSL* ssl, const char* msg, int msgSz, const char* str
     if (ret != msgSz) {
         char buffer[WOLFSSL_MAX_ERROR_SZ];
         LOG_ERROR("SSL_write%s msg error %d, %s\n", str, err,
-                                        wolfSSL_ERR_error_string(err, buffer));
+                                        wolfSSL_ERR_error_string((unsigned long)err, buffer));
         if (!exitWithRet) {
             err_sys("SSL_write failed");
         }
@@ -1011,7 +1011,7 @@ static int ClientRead(WOLFSSL* ssl, char* reply, int replyLen, int mustRead,
             if (err != WOLFSSL_ERROR_WANT_READ &&
                     err != WOLFSSL_ERROR_WANT_WRITE && err != APP_DATA_READY) {
                 LOG_ERROR("SSL_read reply error %d, %s\n", err,
-                                         wolfSSL_ERR_error_string(err, buffer));
+                                         wolfSSL_ERR_error_string((unsigned long)err, buffer));
                 if (!exitWithRet) {
                     err_sys("SSL_read failed");
                 }
@@ -1090,7 +1090,7 @@ static int ClientWriteRead(WOLFSSL* ssl, const char* msg, int msgSz,
     if (ret != 0) {
         char buffer[WOLFSSL_MAX_ERROR_SZ];
         LOG_ERROR("SSL_write%s msg error %d, %s\n", str, ret,
-                                        wolfSSL_ERR_error_string(ret, buffer));
+                                        wolfSSL_ERR_error_string((unsigned long)ret, buffer));
     }
 
     return ret;
@@ -2426,7 +2426,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 break;
 
             case 'B' :
-                throughput = atol(myoptarg);
+                throughput = (size_t)atol(myoptarg);
                 for (; *myoptarg != '\0'; myoptarg++) {
                     if (*myoptarg == ',') {
                         block = atoi(myoptarg + 1);
@@ -2489,7 +2489,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
             case 'F' :
                 #ifdef HAVE_MAX_FRAGMENT
-                    maxFragment = atoi(myoptarg);
+                    maxFragment = (byte)atoi(myoptarg);
                     if (maxFragment < WOLFSSL_MFL_MIN ||
                                                maxFragment > WOLFSSL_MFL_MAX) {
                         Usage();
@@ -2516,7 +2516,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 {
                     word32 myoptargSz;
 
-                    statusRequest = atoi(myoptarg);
+                    statusRequest = (byte)atoi(myoptarg);
                     if (statusRequest > OCSP_STAPLING_OPT_MAX) {
                         Usage();
                         XEXIT_T(MY_EX_USAGE);
@@ -3929,7 +3929,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     if (ret != WOLFSSL_SUCCESS) {
         err = wolfSSL_get_error(ssl, 0);
         LOG_ERROR("wolfSSL_connect error %d, %s\n", err,
-            wolfSSL_ERR_error_string(err, buffer));
+            wolfSSL_ERR_error_string((unsigned long)err, buffer));
 
         /* cleanup */
         wolfSSL_free(ssl); ssl = NULL;
@@ -4270,11 +4270,11 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         printf("SSL connect ok, sending GET...\n");
 
         msgSz = (int)XSTRLEN(kHttpGetMsg);
-        XMEMCPY(msg, kHttpGetMsg, msgSz);
+        XMEMCPY(msg, kHttpGetMsg, (size_t)msgSz);
     }
     else {
         msgSz = (int)XSTRLEN(kHelloMsg);
-        XMEMCPY(msg, kHelloMsg, msgSz);
+        XMEMCPY(msg, kHelloMsg, (size_t)msgSz);
     }
 
 /* allow some time for exporting the session */
@@ -4521,7 +4521,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #endif
         if (ret != WOLFSSL_SUCCESS) {
             LOG_ERROR("wolfSSL_connect resume error %d, %s\n", err,
-                wolfSSL_ERR_error_string(err, buffer));
+                wolfSSL_ERR_error_string((unsigned long)err, buffer));
             wolfSSL_free(sslResume); sslResume = NULL;
             CloseSocket(sockfd);
             wolfSSL_CTX_free(ctx); ctx = NULL;
@@ -4602,11 +4602,11 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         XMEMSET(msg, 0, sizeof(msg));
         if (sendGET) {
             msgSz = (int)XSTRLEN(kHttpGetMsg);
-            XMEMCPY(msg, kHttpGetMsg, msgSz);
+            XMEMCPY(msg, kHttpGetMsg, (size_t)msgSz);
         }
         else {
             msgSz = (int)XSTRLEN(kResumeMsg);
-            XMEMCPY(msg, kResumeMsg, msgSz);
+            XMEMCPY(msg, kResumeMsg, (size_t)msgSz);
         }
 
         (void)ClientWriteRead(sslResume, msg, msgSz, reply, sizeof(reply)-1,

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -801,7 +801,7 @@ doExit:
     if (exitWithRet)
         return err;
 
-#ifdef __MINGW32__
+#if defined(__MINGW32__) || defined(_WIN32)
 #define SIZE_FMT "%d"
 #define SIZE_TYPE int
 #else
@@ -852,7 +852,7 @@ static int StartTLS_Init(SOCKET_T* sockfd)
     }
 
     /* C: EHLO mail.example.com */
-    if (send(*sockfd, starttlsCmd[1], XSTRLEN(starttlsCmd[1]), 0) !=
+    if (send(*sockfd, starttlsCmd[1], (SIZE_TYPE)XSTRLEN(starttlsCmd[1]), 0) !=
               (int)XSTRLEN(starttlsCmd[1]))
         err_sys("failed to send STARTTLS EHLO command\n");
 
@@ -869,7 +869,7 @@ static int StartTLS_Init(SOCKET_T* sockfd)
     }
 
     /* C: STARTTLS */
-    if (send(*sockfd, starttlsCmd[3], XSTRLEN(starttlsCmd[3]), 0) !=
+    if (send(*sockfd, starttlsCmd[3], (SIZE_TYPE)XSTRLEN(starttlsCmd[3]), 0) !=
               (int)XSTRLEN(starttlsCmd[3])) {
         err_sys("failed to send STARTTLS command\n");
     }

--- a/examples/echoclient/echoclient.c
+++ b/examples/echoclient/echoclient.c
@@ -257,7 +257,7 @@ void echoclient_test(void* args)
     } while (err == WC_PENDING_E);
     if (ret != WOLFSSL_SUCCESS) {
         fprintf(stderr, "SSL_connect error %d, %s\n", err,
-            ERR_error_string(err, buffer));
+            ERR_error_string((unsigned long)err, buffer));
         err_sys("SSL_connect failed");
     }
 
@@ -280,7 +280,7 @@ void echoclient_test(void* args)
         } while (err == WC_PENDING_E);
         if (ret != sendSz) {
             fprintf(stderr, "SSL_write msg error %d, %s\n", err,
-                ERR_error_string(err, buffer));
+                ERR_error_string((unsigned long)err, buffer));
             err_sys("SSL_write failed");
         }
 
@@ -329,7 +329,7 @@ void echoclient_test(void* args)
 #endif
             else {
                 fprintf(stderr, "SSL_read msg error %d, %s\n", err,
-                    ERR_error_string(err, buffer));
+                    ERR_error_string((unsigned long)err, buffer));
                 err_sys("SSL_read failed");
             }
         }

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -350,7 +350,7 @@ THREAD_RETURN WOLFSSL_THREAD echoserver_test(void* args)
         } while (err == WC_PENDING_E);
         if (ret != WOLFSSL_SUCCESS) {
             fprintf(stderr, "SSL_accept error = %d, %s\n", err,
-                wolfSSL_ERR_error_string(err, buffer));
+                wolfSSL_ERR_error_string((unsigned long)err, buffer));
             fprintf(stderr, "SSL_accept failed\n");
             wolfSSL_free(ssl);
             CloseSocket(clientfd);
@@ -391,7 +391,7 @@ THREAD_RETURN WOLFSSL_THREAD echoserver_test(void* args)
             if (ret <= 0) {
                 if (err != WOLFSSL_ERROR_WANT_READ && err != WOLFSSL_ERROR_ZERO_RETURN){
                     fprintf(stderr, "SSL_read echo error %d, %s!\n", err,
-                        wolfSSL_ERR_error_string(err, buffer));
+                        wolfSSL_ERR_error_string((unsigned long)err, buffer));
                 }
                 break;
             }
@@ -453,7 +453,7 @@ THREAD_RETURN WOLFSSL_THREAD echoserver_test(void* args)
                 } while (err == WC_PENDING_E);
                 if (ret != echoSz) {
                     fprintf(stderr, "SSL_write get error = %d, %s\n", err,
-                        wolfSSL_ERR_error_string(err, buffer));
+                        wolfSSL_ERR_error_string((unsigned long)err, buffer));
                     err_sys("SSL_write get failed");
                 }
                 break;
@@ -480,7 +480,7 @@ THREAD_RETURN WOLFSSL_THREAD echoserver_test(void* args)
 
             if (ret != echoSz) {
                 fprintf(stderr, "SSL_write echo error = %d, %s\n", err,
-                        wolfSSL_ERR_error_string(err, buffer));
+                        wolfSSL_ERR_error_string((unsigned long)err, buffer));
                 err_sys("SSL_write echo failed");
             }
         }

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -262,7 +262,8 @@ static WC_INLINE int PeekSeq(const char* buf, word32* seq)
     const char* c = buf + 3;
 
     if ((c[0] | c[1] | c[2] | c[3]) == 0) {
-        *seq = (c[4] << 24) | (c[5] << 16) | (c[6] << 8) | c[7];
+        *seq = ((word32)c[4] << 24) | ((word32)c[5] << 16) |
+                ((word32)c[6] << 8) | (word32)c[7];
         return 1;
     }
 
@@ -292,8 +293,8 @@ static int TestEmbedSendTo(WOLFSSL* ssl, char *buf, int sz, void *ctx)
         }
     }
 
-    sent = (int)sendto(sd, buf, sz, 0, (const SOCKADDR*)&dtlsCtx->peer.sa,
-                                                             dtlsCtx->peer.sz);
+    sent = (int)sendto(sd, buf, (size_t)sz, 0,
+                        (const SOCKADDR*)&dtlsCtx->peer.sa, dtlsCtx->peer.sz);
 
     sent = TranslateReturnCode(sent, sd);
 
@@ -431,7 +432,7 @@ int ServerEchoData(SSL* ssl, int clientfd, int echoData, int block,
         if (select_ret == TEST_RECV_READY) {
 
             if (throughput)
-                len = min(block, (int)(throughput - xfer_bytes));
+                len = (int)min((word32)block, (word32)(throughput - xfer_bytes));
             else
                 len = block;
             rx_pos = 0;
@@ -479,7 +480,7 @@ int ServerEchoData(SSL* ssl, int clientfd, int echoData, int block,
             /* Write data */
             do {
                 err = 0; /* reset error */
-                ret = SSL_write(ssl, buffer, min(len, rx_pos));
+                ret = SSL_write(ssl, buffer, (int)min((word32)len, (word32)rx_pos));
                 if (ret <= 0) {
                     err = SSL_get_error(ssl, 0);
                 #ifdef WOLFSSL_ASYNC_CRYPT
@@ -490,7 +491,7 @@ int ServerEchoData(SSL* ssl, int clientfd, int echoData, int block,
                 #endif
                 }
             } while (err == WC_PENDING_E);
-            if (ret != (int)min(len, rx_pos)) {
+            if (ret != (int)min((word32)len, (word32)rx_pos)) {
                 LOG_ERROR("SSL_write echo error %d\n", err);
                 err_sys_ex(runWithErrors, "SSL_write failed");
             }
@@ -499,7 +500,7 @@ int ServerEchoData(SSL* ssl, int clientfd, int echoData, int block,
                 tx_time += current_time(0) - start;
             }
 
-            xfer_bytes += len;
+            xfer_bytes += (size_t)len;
         }
     }
 
@@ -519,8 +520,8 @@ int ServerEchoData(SSL* ssl, int clientfd, int echoData, int block,
                 "\tRX      %8.3f ms (%8.3f MBps)\n"
                 "\tTX      %8.3f ms (%8.3f MBps)\n",
                 (SIZE_TYPE)throughput,
-                rx_time * 1000, throughput / rx_time / 1024 / 1024,
-                tx_time * 1000, throughput / tx_time / 1024 / 1024
+                (double)rx_time * 1000, throughput / rx_time / 1024 / 1024,
+                (double)tx_time * 1000, throughput / tx_time / 1024 / 1024
             );
         }
         else {
@@ -582,7 +583,7 @@ static void ServerRead(WOLFSSL* ssl, char* input, int inputLen)
         #endif
             ) {
                 LOG_ERROR("SSL_read input error %d, %s\n", err,
-                                                 ERR_error_string(err, buffer));
+                                                 ERR_error_string((unsigned long)err, buffer));
                 err_sys_ex(runWithErrors, "SSL_read failed");
             }
         }
@@ -655,7 +656,7 @@ static void ServerWrite(WOLFSSL* ssl, const char* output, int outputLen)
     if (ret != outputLen) {
         char buffer[WOLFSSL_MAX_ERROR_SZ];
         LOG_ERROR("SSL_write msg error %d, %s\n", err,
-                                                 ERR_error_string(err, buffer));
+                                                 ERR_error_string((unsigned long)err, buffer));
         err_sys_ex(runWithErrors, "SSL_write failed");
     }
 }
@@ -1984,7 +1985,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                 break;
 
             case 'B':
-                throughput = atol(myoptarg);
+                throughput = (size_t)atol(myoptarg);
                 for (; *myoptarg != '\0'; myoptarg++) {
                     if (*myoptarg == ',') {
                         block = atoi(myoptarg + 1);
@@ -2143,7 +2144,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                 #if defined(WOLFSSL_DTLS) && defined(USE_WOLFSSL_IO)
                     XMEMSET(&dtlsCtx, 0, sizeof(dtlsCtx));
                     doBlockSeq = 1;
-                    dtlsCtx.blockSeq = atoi(myoptarg);
+                    dtlsCtx.blockSeq = (word32)atoi(myoptarg);
                 #endif
                     break;
 
@@ -3182,7 +3183,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
             #ifdef CAN_FORCE_CURVE
             if (force_curve_group_id > 0) {
                 do {
-                    ret = wolfSSL_UseKeyShare(ssl, force_curve_group_id);
+                    ret = wolfSSL_UseKeyShare(ssl, (word16)force_curve_group_id);
                     if (ret == WOLFSSL_SUCCESS) {
 
                     }
@@ -3444,7 +3445,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
         if (ret != WOLFSSL_SUCCESS) {
             err = SSL_get_error(ssl, 0);
             LOG_ERROR("SSL_accept error %d, %s\n", err,
-                                            ERR_error_string(err, buffer));
+                                            ERR_error_string((unsigned long)err, buffer));
             if (!exitWithRet) {
                 err_sys_ex(runWithErrors, "SSL_accept failed");
             } else {

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -420,7 +420,7 @@ int ServerEchoData(SSL* ssl, int clientfd, int echoData, int block,
     size_t xfer_bytes = 0;
     char* buffer;
 
-    buffer = (char*)malloc(block);
+    buffer = (char*)malloc((size_t)block);
     if (!buffer) {
         err_sys_ex(runWithErrors, "Server buffer malloc failed");
     }
@@ -520,8 +520,8 @@ int ServerEchoData(SSL* ssl, int clientfd, int echoData, int block,
                 "\tRX      %8.3f ms (%8.3f MBps)\n"
                 "\tTX      %8.3f ms (%8.3f MBps)\n",
                 (SIZE_TYPE)throughput,
-                (double)rx_time * 1000, throughput / rx_time / 1024 / 1024,
-                (double)tx_time * 1000, throughput / tx_time / 1024 / 1024
+                (double)rx_time * 1000, (double)throughput / rx_time / 1024 / 1024,
+                (double)tx_time * 1000, (double)throughput / tx_time / 1024 / 1024
             );
         }
         else {

--- a/src/crl.c
+++ b/src/crl.c
@@ -110,11 +110,11 @@ static int InitCRL_Entry(CRL_Entry* crle, DecodedCRL* dcrl, const byte* buff,
 #if defined(OPENSSL_EXTRA)
     crle->lastDateAsn1.length = MAX_DATE_SIZE;
     XMEMCPY (crle->lastDateAsn1.data, crle->lastDate,
-             crle->lastDateAsn1.length);
+             (size_t)crle->lastDateAsn1.length);
     crle->lastDateAsn1.type = crle->lastDateFormat;
     crle->nextDateAsn1.length = MAX_DATE_SIZE;
     XMEMCPY (crle->nextDateAsn1.data, crle->nextDate,
-             crle->nextDateAsn1.length);
+             (size_t)crle->nextDateAsn1.length);
     crle->nextDateAsn1.type = crle->nextDateFormat;
 
     crle->issuer = NULL;
@@ -318,14 +318,14 @@ static int FindRevokedSerial(RevokedCert* rc, byte* serial, int serialSz,
     while (rc) {
         if (serialHash == NULL) {
             if (rc->serialSz == serialSz &&
-                   XMEMCMP(rc->serialNumber, serial, rc->serialSz) == 0) {
+                   XMEMCMP(rc->serialNumber, serial, (size_t)rc->serialSz) == 0) {
                 WOLFSSL_MSG("Cert revoked");
                 ret = CRL_CERT_REVOKED;
                 break;
             }
         }
         else {
-            ret = CalcHashId(rc->serialNumber, rc->serialSz, hash);
+            ret = CalcHashId(rc->serialNumber, (word32)rc->serialSz, hash);
             if (ret != 0)
                 break;
             if (XMEMCMP(hash, serialHash, SIGNER_DIGEST_SIZE) == 0) {
@@ -362,7 +362,7 @@ static int VerifyCRLE(const WOLFSSL_CRL* crl, CRL_Entry* crle)
     ret = VerifyCRL_Signature(&sigCtx, crle->toBeSigned, crle->tbsSz,
             crle->signature, crle->signatureSz, crle->signatureOID,
         #ifdef WC_RSA_PSS
-            crle->sigParams, crle->sigParamsSz,
+            crle->sigParams, (int)crle->sigParamsSz,
         #else
             NULL, 0,
         #endif
@@ -528,7 +528,7 @@ int CheckCertCRL_ex(WOLFSSL_CRL* crl, byte* issuerHash, byte* serial,
             url[0] = '\0';
             if (extCrlInfo) {
                 if (extCrlInfoSz < (int)sizeof(url) -1 ) {
-                    XMEMCPY(url, extCrlInfo, extCrlInfoSz);
+                    XMEMCPY(url, extCrlInfo, (size_t)extCrlInfoSz);
                     url[extCrlInfoSz] = '\0';
                 }
                 else  {
@@ -849,7 +849,7 @@ static int DupX509_CRL(WOLFSSL_X509_CRL *dupl, const WOLFSSL_X509_CRL* crl)
 
 #ifdef HAVE_CRL_MONITOR
     if (crl->monitors[0].path) {
-        int pathSz = (int)XSTRLEN(crl->monitors[0].path) + 1;
+        size_t pathSz = XSTRLEN(crl->monitors[0].path) + 1;
         dupl->monitors[0].path = (char*)XMALLOC(pathSz, dupl->heap,
                 DYNAMIC_TYPE_CRL_MONITOR);
         if (dupl->monitors[0].path != NULL) {
@@ -861,7 +861,7 @@ static int DupX509_CRL(WOLFSSL_X509_CRL *dupl, const WOLFSSL_X509_CRL* crl)
     }
 
     if (crl->monitors[1].path) {
-        int pathSz = (int)XSTRLEN(crl->monitors[1].path) + 1;
+        size_t pathSz = XSTRLEN(crl->monitors[1].path) + 1;
         dupl->monitors[1].path = (char*)XMALLOC(pathSz, dupl->heap,
                 DYNAMIC_TYPE_CRL_MONITOR);
         if (dupl->monitors[1].path != NULL) {

--- a/src/dtls.c
+++ b/src/dtls.c
@@ -187,14 +187,14 @@ typedef struct WolfSSL_CH {
     byte dtls12cookieSet:1;
 } WolfSSL_CH;
 
-static int ReadVector8(const byte* input, WolfSSL_ConstVector* v)
+static word32 ReadVector8(const byte* input, WolfSSL_ConstVector* v)
 {
     v->size = *input;
     v->elements = input + OPAQUE8_LEN;
     return v->size + OPAQUE8_LEN;
 }
 
-static int ReadVector16(const byte* input, WolfSSL_ConstVector* v)
+static word32 ReadVector16(const byte* input, WolfSSL_ConstVector* v)
 {
     word16 size16;
     ato16(input, &size16);

--- a/src/internal.c
+++ b/src/internal.c
@@ -149,7 +149,7 @@
 #endif
 
 
-#define ERROR_OUT(err, eLabel) { ret = (err); goto eLabel; }
+#define ERROR_OUT(err, eLabel) { ret = (int)(err); goto eLabel; }
 
 #ifdef _MSC_VER
     /* disable for while(0) cases at the .c level for now */
@@ -4917,7 +4917,7 @@ int RsaSign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
 
     /* For positive response return in outSz */
     if (ret > 0) {
-        *outSz = ret;
+        *outSz = (word32)ret;
         ret = 0;
     }
 
@@ -5068,7 +5068,7 @@ int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig, word32 sigSz,
                                            TypeHash(hashAlgo), mgf,
                                            keyBuf, keySz, ctx);
             if (ret > 0) {
-                ret = wc_RsaPSS_CheckPadding(plain, plainSz, out, ret,
+                ret = wc_RsaPSS_CheckPadding(plain, plainSz, out, (word32)ret,
                                              hashType);
                 if (ret != 0) {
                     ret = VERIFY_CERT_ERROR;
@@ -5086,7 +5086,7 @@ int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig, word32 sigSz,
                 ret = wc_RsaPSS_CheckPadding(plain, plainSz, out, ret,
                                              hashType);
     #else
-                ret = wc_RsaPSS_CheckPadding_ex(plain, plainSz, out, ret,
+                ret = wc_RsaPSS_CheckPadding_ex(plain, plainSz, out, (word32)ret,
                                                 hashType, -1,
                                                 mp_count_bits(&key->n));
     #endif
@@ -5261,7 +5261,7 @@ int RsaEnc(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out, word32* outSz,
 
     /* For positive response return in outSz */
     if (ret > 0) {
-        *outSz = ret;
+        *outSz = (word32)ret;
         ret = 0;
     }
 
@@ -5515,7 +5515,7 @@ int EccMakeKey(WOLFSSL* ssl, ecc_key* key, ecc_key* peer)
 #ifdef HAVE_PK_CALLBACKS
     if (ssl->ctx->EccKeyGenCb) {
         void* ctx = wolfSSL_GetEccKeyGenCtx(ssl);
-        ret = ssl->ctx->EccKeyGenCb(ssl, key, keySz, ecc_curve, ctx);
+        ret = ssl->ctx->EccKeyGenCb(ssl, key, (unsigned int)keySz, ecc_curve, ctx);
     }
     else
 #endif
@@ -9523,7 +9523,7 @@ int DtlsMsgPoolSend(WOLFSSL* ssl, int sendOnlyFirstPacket)
                 int    inputSz, sendSz;
 
                 input = pool->raw;
-                inputSz = pool->sz;
+                inputSz = (int)pool->sz;
                 sendSz = inputSz + cipherExtraData(ssl);
 
 #ifdef HAVE_SECURE_RENEGOTIATION
@@ -9987,7 +9987,7 @@ int HashRaw(WOLFSSL* ssl, const byte* data, int sz)
 
     if (IsAtLeastTLSv1_2(ssl)) {
     #ifndef NO_SHA256
-        ret = wc_Sha256Update(&ssl->hsHashes->hashSha256, data, sz);
+        ret = wc_Sha256Update(&ssl->hsHashes->hashSha256, data, (word32)sz);
         if (ret != 0)
             return ret;
     #ifdef WOLFSSL_DEBUG_TLS
@@ -9997,7 +9997,7 @@ int HashRaw(WOLFSSL* ssl, const byte* data, int sz)
     #endif
     #endif
     #ifdef WOLFSSL_SHA384
-        ret = wc_Sha384Update(&ssl->hsHashes->hashSha384, data, sz);
+        ret = wc_Sha384Update(&ssl->hsHashes->hashSha384, data, (word32)sz);
         if (ret != 0)
             return ret;
     #ifdef WOLFSSL_DEBUG_TLS
@@ -10007,7 +10007,7 @@ int HashRaw(WOLFSSL* ssl, const byte* data, int sz)
     #endif
     #endif
     #ifdef WOLFSSL_SHA512
-        ret = wc_Sha512Update(&ssl->hsHashes->hashSha512, data, sz);
+        ret = wc_Sha512Update(&ssl->hsHashes->hashSha512, data, (word32)sz);
         if (ret != 0)
             return ret;
     #ifdef WOLFSSL_DEBUG_TLS
@@ -10555,7 +10555,7 @@ void ShrinkInputBuffer(WOLFSSL* ssl, int forcedFree)
     ssl->buffers.inputBuffer.dynamicFlag = 0;
     ssl->buffers.inputBuffer.offset      = 0;
     ssl->buffers.inputBuffer.idx = 0;
-    ssl->buffers.inputBuffer.length = usedLength;
+    ssl->buffers.inputBuffer.length = (word32)usedLength;
 }
 
 int SendBuffered(WOLFSSL* ssl)
@@ -10810,7 +10810,7 @@ int GrowInputBuffer(WOLFSSL* ssl, int size, int usedLength)
     ssl->buffers.inputBuffer.buffer = tmp;
     ssl->buffers.inputBuffer.bufferSize = size + usedLength;
     ssl->buffers.inputBuffer.idx    = 0;
-    ssl->buffers.inputBuffer.length = usedLength;
+    ssl->buffers.inputBuffer.length = (word32)usedLength;
 
     return 0;
 }
@@ -12460,10 +12460,10 @@ int CheckForAltNames(DecodedCert* dCert, const char* domain, int* checkCN)
 #endif /* OPENSSL_ALL || WOLFSSL_IP_ALT_NAME */
         {
             buf = altName->name;
-            len = altName->len;
+            len = (word32)altName->len;
         }
 
-        if (MatchDomainName(buf, len, domain)) {
+        if (MatchDomainName(buf, (int)len, domain)) {
             match = 1;
             if (checkCN != NULL) {
                 *checkCN = 0;
@@ -12536,7 +12536,7 @@ static void AddSessionCertToChain(WOLFSSL_X509_CHAIN* chain,
 {
    if (chain->count < MAX_CHAIN_DEPTH &&
                                certSz < MAX_X509_SIZE) {
-        chain->certs[chain->count].length = certSz;
+        chain->certs[chain->count].length = (int)certSz;
         XMEMCPY(chain->certs[chain->count].buffer, certBuf, certSz);
         chain->count++;
     }
@@ -12815,7 +12815,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
     {
         int minSz;
         if (dCert->beforeDateLen > 0) {
-            minSz = min(dCert->beforeDate[1], MAX_DATE_SZ);
+            minSz = (int)min(dCert->beforeDate[1], MAX_DATE_SZ);
             x509->notBefore.type = dCert->beforeDate[0];
             x509->notBefore.length = minSz;
             XMEMCPY(x509->notBefore.data, &dCert->beforeDate[2], minSz);
@@ -12823,7 +12823,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
         else
             x509->notBefore.length = 0;
         if (dCert->afterDateLen > 0) {
-            minSz = min(dCert->afterDate[1], MAX_DATE_SZ);
+            minSz = (int)min(dCert->afterDate[1], MAX_DATE_SZ);
             x509->notAfter.type = dCert->afterDate[0];
             x509->notAfter.length = minSz;
             XMEMCPY(x509->notAfter.data, &dCert->afterDate[2], minSz);
@@ -12836,7 +12836,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
         x509->pubKey.buffer = (byte*)XMALLOC(
                         dCert->pubKeySize, x509->heap, DYNAMIC_TYPE_PUBLIC_KEY);
         if (x509->pubKey.buffer != NULL) {
-            x509->pubKeyOID = dCert->keyOID;
+            x509->pubKeyOID = (int)dCert->keyOID;
             x509->pubKey.length = dCert->pubKeySize;
             XMEMCPY(x509->pubKey.buffer, dCert->publicKey, dCert->pubKeySize);
         }
@@ -12844,7 +12844,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
             ret = MEMORY_E;
 #if defined(OPENSSL_ALL)
         if (ret == 0) {
-            x509->key.pubKeyOID = dCert->keyOID;
+            x509->key.pubKeyOID = (int)dCert->keyOID;
 
             if (!x509->key.algor) {
                 x509->key.algor = wolfSSL_X509_ALGOR_new();
@@ -12882,7 +12882,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
         else {
             XMEMCPY(x509->sig.buffer, dCert->signature, dCert->sigLength);
             x509->sig.length = dCert->sigLength;
-            x509->sigOID = dCert->signatureOID;
+            x509->sigOID = (int)dCert->signatureOID;
         }
 #if defined(OPENSSL_ALL)
         wolfSSL_ASN1_OBJECT_free(x509->algor.algorithm);
@@ -13760,7 +13760,7 @@ int LoadCertByIssuer(WOLFSSL_X509_STORE* store, X509_NAME* issuer, int type)
     #if defined(NO_SHA) && !defined(NO_SHA256)
         retHash = wc_Sha256Hash((const byte*)pbuf, len, dgt);
     #elif !defined(NO_SHA)
-        retHash = wc_ShaHash((const byte*)pbuf, len, dgt);
+        retHash = wc_ShaHash((const byte*)pbuf, (word32)len, dgt);
     #endif
         if (retHash == 0) {
             /* 4 bytes in little endian as unsigned long */
@@ -13830,7 +13830,7 @@ int LoadCertByIssuer(WOLFSSL_X509_STORE* store, X509_NAME* issuer, int type)
 
         for (; suffix < MAX_SUFFIX; suffix++) {
             /* /folder-path/<hash>.(r)N[0..9] */
-            if (XSNPRINTF(filename, len, "%s/%08lx.%s%d", entry->dir_name,
+            if (XSNPRINTF(filename, (size_t)len, "%s/%08lx.%s%d", entry->dir_name,
                                                        hash, post, suffix)
                 >= len)
             {
@@ -16861,7 +16861,7 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             && ssl->error != OCSP_WANT_READ
     #endif
     ) {
-        ret = HashInput(ssl, input + *inOutIdx, size);
+        ret = HashInput(ssl, input + *inOutIdx, (int)size);
         if (ret != 0) {
             WOLFSSL_MSG("Incomplete handshake hashes");
             return ret;
@@ -18159,7 +18159,7 @@ static int Poly1305TagOld(WOLFSSL* ssl, byte* additional, const byte* out,
 
     /* add cipher info and then its length */
     XMEMSET(padding, 0, sizeof(padding));
-    if ((ret = wc_Poly1305Update(ssl->auth.poly1305, out, msglen)) != 0)
+    if ((ret = wc_Poly1305Update(ssl->auth.poly1305, out, (word32)msglen)) != 0)
         return ret;
 
     /* 32 bit size of cipher to 64 bit endian */
@@ -18544,7 +18544,7 @@ int ChachaAEADDecrypt(WOLFSSL* ssl, byte* plain, const byte* input,
             return ret;
         }
         if ((ret = wc_Poly1305_MAC(ssl->auth.poly1305, add,
-                          sizeof(add), input, msgLen, tag, sizeof(tag))) != 0) {
+                          sizeof(add), input, (word32)msgLen, tag, sizeof(tag))) != 0) {
             ForceZero(poly, sizeof(poly));
         #ifdef WOLFSSL_CHECK_MEM_ZERO
             wc_MemZero_Check(poly, CHACHA20_256_KEY_SIZE);
@@ -18568,7 +18568,7 @@ int ChachaAEADDecrypt(WOLFSSL* ssl, byte* plain, const byte* input,
 
     /* if the tag was good decrypt message */
     if ((ret = wc_Chacha_Process(ssl->decrypt.chacha, plain,
-                                                           input, msgLen)) != 0)
+                                                           input, (word32)msgLen)) != 0)
         return ret;
 
     #ifdef CHACHA_AEAD_TEST
@@ -20201,7 +20201,7 @@ int DoApplicationData(WOLFSSL* ssl, byte* input, word32* inOutIdx, int sniff)
         idx += rawSz;
 
         ssl->buffers.clearOutputBuffer.buffer = rawData;
-        ssl->buffers.clearOutputBuffer.length = dataSz;
+        ssl->buffers.clearOutputBuffer.length = (unsigned int)dataSz;
     }
 
     idx += ssl->keys.padSz;
@@ -20570,14 +20570,14 @@ static int GetInputData(WOLFSSL *ssl, word32 size)
 
     /* remove processed data */
     ssl->buffers.inputBuffer.idx    = 0;
-    ssl->buffers.inputBuffer.length = usedLength;
+    ssl->buffers.inputBuffer.length = (word32)usedLength;
 
     /* read data from network */
     do {
         int in = wolfSSLReceive(ssl,
                      ssl->buffers.inputBuffer.buffer +
                      ssl->buffers.inputBuffer.length,
-                     inSz);
+                     (word32)inSz);
         if (in == WANT_READ)
             return WANT_READ;
 
@@ -20628,7 +20628,7 @@ static WC_INLINE int VerifyMacEnc(WOLFSSL* ssl, const byte* input, word32 msgSz,
     }
 
     ret  = ssl->hmac(ssl, verify, input, msgSz - digestSz, -1, content, 1, PEER_ORDER);
-    ret |= ConstantCompare(verify, input + msgSz - digestSz, digestSz);
+    ret |= ConstantCompare(verify, input + msgSz - digestSz, (int)digestSz);
     if (ret != 0) {
         WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         return VERIFY_MAC_ERROR;
@@ -20668,7 +20668,7 @@ static WC_INLINE int VerifyMac(WOLFSSL* ssl, const byte* input, word32 msgSz,
                 void* ctx = wolfSSL_GetVerifyMacCtx(ssl);
                 ret = ssl->ctx->VerifyMacCb(ssl, input,
                            (msgSz - ivExtra) - digestSz - pad - 1,
-                           digestSz, content, ctx);
+                           digestSz, (word32)content, ctx);
                 if (ret != 0 && ret != PROTOCOLCB_UNAVAILABLE) {
                     return ret;
                 }
@@ -20694,9 +20694,9 @@ static WC_INLINE int VerifyMac(WOLFSSL* ssl, const byte* input, word32 msgSz,
             }
             (void)PadCheck(dummy, (byte)pad, MAX_PAD_SIZE);  /* timing only */
             ret = ssl->hmac(ssl, verify, input, msgSz - digestSz - pad - 1,
-                            pad, content, 1, PEER_ORDER);
+                            (int)pad, content, 1, PEER_ORDER);
             if (ConstantCompare(verify, input + msgSz - digestSz - pad - 1,
-                                digestSz) != 0) {
+                                (int)digestSz) != 0) {
                 WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
                 return VERIFY_MAC_ERROR;
             }
@@ -20709,7 +20709,7 @@ static WC_INLINE int VerifyMac(WOLFSSL* ssl, const byte* input, word32 msgSz,
     else if (ssl->specs.cipher_type == stream) {
         ret = ssl->hmac(ssl, verify, input, msgSz - digestSz, -1, content, 1,
                         PEER_ORDER);
-        if (ConstantCompare(verify, input + msgSz - digestSz, digestSz) != 0) {
+        if (ConstantCompare(verify, input + msgSz - digestSz, (int)digestSz) != 0) {
             WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
         }
@@ -20895,7 +20895,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
 
             /* get header or return error */
             if (!ssl->options.dtls) {
-                if ((ret = GetInputData(ssl, readSz)) < 0)
+                if ((ret = GetInputData(ssl, (word32)readSz)) < 0)
                     return ret;
             } else {
             #ifdef WOLFSSL_DTLS
@@ -20903,7 +20903,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                 used = ssl->buffers.inputBuffer.length -
                        ssl->buffers.inputBuffer.idx;
                 if (used < readSz) {
-                    if ((ret = GetInputData(ssl, readSz)) < 0)
+                    if ((ret = GetInputData(ssl, (word32)readSz)) < 0)
                         return ret;
                 }
             #endif
@@ -21993,7 +21993,7 @@ int SendChangeCipher(WOLFSSL* ssl)
         input[0] = 1;  /* turn it on */
     #ifdef WOLFSSL_DTLS
         if (IsDtlsNotSctpMode(ssl) &&
-                (ret = DtlsMsgPoolSave(ssl, input, inputSz, change_cipher_hs)) != 0) {
+                (ret = DtlsMsgPoolSave(ssl, input, (word32)inputSz, change_cipher_hs)) != 0) {
             return ret;
         }
     #endif
@@ -22006,7 +22006,7 @@ int SendChangeCipher(WOLFSSL* ssl)
     #ifdef WOLFSSL_DTLS
     else {
         if (IsDtlsNotSctpMode(ssl)) {
-            if ((ret = DtlsMsgPoolSave(ssl, output, sendSz, change_cipher_hs)) != 0)
+            if ((ret = DtlsMsgPoolSave(ssl, output, (word32)sendSz, change_cipher_hs)) != 0)
                 return ret;
             DtlsSEQIncrement(ssl, CUR_ORDER);
         }
@@ -22656,7 +22656,7 @@ int BuildMessage(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
             {
                 if (ssl->ctx->MacEncryptCb) {
                     ret = ssl->ctx->MacEncryptCb(ssl, output + args->idx,
-                                    output + args->headerSz + args->ivSz, inSz,
+                                    output + args->headerSz + args->ivSz, (unsigned int)inSz,
                                     type, 0, output + args->headerSz,
                                     output + args->headerSz, args->size,
                                     ssl->MacEncryptCtx);
@@ -22688,7 +22688,7 @@ int BuildMessage(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
                 #endif
 
                     ret = ssl->hmac(ssl, hmac,
-                                     output + args->headerSz + args->ivSz, inSz,
+                                     output + args->headerSz + args->ivSz, (word32)inSz,
                                      -1, type, 0, epochOrder);
                     XMEMCPY(output + args->idx, hmac, args->digestSz);
 
@@ -22700,7 +22700,7 @@ int BuildMessage(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
             #endif
                 {
                     ret = ssl->hmac(ssl, output + args->idx, output +
-                                args->headerSz + args->ivSz, inSz, -1, type, 0, epochOrder);
+                                args->headerSz + args->ivSz, (word32)inSz, -1, type, 0, epochOrder);
                 }
             }
         #endif /* WOLFSSL_AEAD_ONLY */
@@ -22853,7 +22853,7 @@ exit_buildmsg:
 
     /* return sz on success */
     if (ret == 0) {
-        ret = args->sz;
+        ret = (int)args->sz;
     }
     else {
         WOLFSSL_ERROR_VERBOSE(ret);
@@ -23281,7 +23281,7 @@ int SendCertificate(WOLFSSL* ssl)
 
     maxFragment = MAX_RECORD_SIZE;
 
-    maxFragment = wolfSSL_GetMaxFragSize(ssl, maxFragment);
+    maxFragment = (word32)wolfSSL_GetMaxFragSize(ssl, (int)maxFragment);
 
     while (length > 0 && ret == 0) {
         byte*  output = NULL;
@@ -23376,10 +23376,10 @@ int SendCertificate(WOLFSSL* ssl)
                 fragSz -= CERT_HEADER_SZ;
 
                 if (ssl->options.dtls || !IsEncryptionOn(ssl, 1)) {
-                    HashRaw(ssl, ssl->buffers.certificate->buffer, certSz);
+                    HashRaw(ssl, ssl->buffers.certificate->buffer, (int)certSz);
                     if (certChainSz)
                         HashRaw(ssl, ssl->buffers.certChain->buffer,
-                                      certChainSz);
+                                      (int)certChainSz);
                 }
             }
         }
@@ -23418,7 +23418,7 @@ int SendCertificate(WOLFSSL* ssl)
 
         if (IsEncryptionOn(ssl, 1)) {
             byte* input = NULL;
-            int   inputSz = i; /* build msg adds rec hdr */
+            int   inputSz = (int)i; /* build msg adds rec hdr */
             int   recordHeaderSz = RECORD_HEADER_SZ;
 
             if (ssl->options.dtls)
@@ -23447,7 +23447,7 @@ int SendCertificate(WOLFSSL* ssl)
                                                               handshake, 1, 0, 0, CUR_ORDER);
             else /* DTLS 1.2 has to ignore fragmentation in hashing so we need to
                   * calculate the hash ourselves above */ {
-                if ((ret = DtlsMsgPoolSave(ssl, input, inputSz, certificate)) != 0) {
+                if ((ret = DtlsMsgPoolSave(ssl, input, (word32)inputSz, certificate)) != 0) {
                     XFREE(input, ssl->heap, DYNAMIC_TYPE_IN_BUFFER);
                     return ret;
                 }
@@ -23462,10 +23462,10 @@ int SendCertificate(WOLFSSL* ssl)
                 return sendSz;
         }
         else {
-            sendSz = i;
+            sendSz = (int)i;
         #ifdef WOLFSSL_DTLS
             if (IsDtlsNotSctpMode(ssl)) {
-                if ((ret = DtlsMsgPoolSave(ssl, output, sendSz, certificate)) != 0)
+                if ((ret = DtlsMsgPoolSave(ssl, output, (word32)sendSz, certificate)) != 0)
                     return ret;
             }
             if (ssl->options.dtls)
@@ -23578,7 +23578,7 @@ int SendCertificateRequest(WOLFSSL* ssl)
     /* get output buffer */
     output = GetOutputBuffer(ssl);
 
-    AddHeaders(output, reqSz, certificate_request, ssl);
+    AddHeaders(output, (word32)reqSz, certificate_request, ssl);
 
     /* write to output */
     output[i++] = (byte)typeTotal;  /* # of types */
@@ -23645,7 +23645,7 @@ int SendCertificateRequest(WOLFSSL* ssl)
 
         if (IsEncryptionOn(ssl, 1)) {
             byte* input = NULL;
-            int   inputSz = i; /* build msg adds rec hdr */
+            int   inputSz = (int)i; /* build msg adds rec hdr */
             int   recordHeaderSz = RECORD_HEADER_SZ;
 
             if (ssl->options.dtls)
@@ -23664,7 +23664,7 @@ int SendCertificateRequest(WOLFSSL* ssl)
             XMEMCPY(input, output + recordHeaderSz, inputSz);
             #ifdef WOLFSSL_DTLS
             if (IsDtlsNotSctpMode(ssl) &&
-                    (ret = DtlsMsgPoolSave(ssl, input, inputSz, certificate_request)) != 0) {
+                    (ret = DtlsMsgPoolSave(ssl, input, (word32)inputSz, certificate_request)) != 0) {
                 XFREE(input, ssl->heap, DYNAMIC_TYPE_IN_BUFFER);
                 return ret;
             }
@@ -23676,10 +23676,10 @@ int SendCertificateRequest(WOLFSSL* ssl)
             if (sendSz < 0)
                 return sendSz;
         } else {
-            sendSz = i;
+            sendSz = (int)i;
             #ifdef WOLFSSL_DTLS
                 if (IsDtlsNotSctpMode(ssl)) {
-                    if ((ret = DtlsMsgPoolSave(ssl, output, sendSz, certificate_request)) != 0)
+                    if ((ret = DtlsMsgPoolSave(ssl, output, (word32)sendSz, certificate_request)) != 0)
                         return ret;
                 }
                 if (ssl->options.dtls)
@@ -23743,7 +23743,7 @@ static int BuildCertificateStatus(WOLFSSL* ssl, byte type, buffer* status,
             return 0;
     }
 
-    sendSz = idx + length;
+    sendSz = (int)(idx + length);
 
     if (ssl->keys.encryptionOn)
         sendSz += MAX_MSG_EXTRA;
@@ -23774,7 +23774,7 @@ static int BuildCertificateStatus(WOLFSSL* ssl, byte type, buffer* status,
 
         if (IsEncryptionOn(ssl, 1)) {
             byte* input;
-            int   inputSz = idx; /* build msg adds rec hdr */
+            int   inputSz = (int)idx; /* build msg adds rec hdr */
             int   recordHeaderSz = RECORD_HEADER_SZ;
 
             if (ssl->options.dtls)
@@ -23786,7 +23786,7 @@ static int BuildCertificateStatus(WOLFSSL* ssl, byte type, buffer* status,
 
             XMEMCPY(input, output + recordHeaderSz, inputSz);
             #ifdef WOLFSSL_DTLS
-                ret = DtlsMsgPoolSave(ssl, input, inputSz, certificate_status);
+                ret = DtlsMsgPoolSave(ssl, input, (word32)inputSz, certificate_status);
             #endif
             if (ret == 0)
                 sendSz = BuildMessage(ssl, output, sendSz, input, inputSz,
@@ -23799,7 +23799,7 @@ static int BuildCertificateStatus(WOLFSSL* ssl, byte type, buffer* status,
         else {
             #ifdef WOLFSSL_DTLS
                 if (ret == 0 && IsDtlsNotSctpMode(ssl))
-                    ret = DtlsMsgPoolSave(ssl, output, sendSz, certificate_status);
+                    ret = DtlsMsgPoolSave(ssl, output, (word32)sendSz, certificate_status);
                 if (ret == 0 && ssl->options.dtls)
                     DtlsSEQIncrement(ssl, CUR_ORDER);
             #endif
@@ -25457,7 +25457,7 @@ const char* wolfSSL_ERR_lib_error_string(unsigned long e)
 
 void SetErrorString(int error, char* str)
 {
-    XSTRNCPY(str, wolfSSL_ERR_reason_error_string(error), WOLFSSL_MAX_ERROR_SZ);
+    XSTRNCPY(str, wolfSSL_ERR_reason_error_string((unsigned long)error), WOLFSSL_MAX_ERROR_SZ);
     str[WOLFSSL_MAX_ERROR_SZ-1] = 0;
 }
 
@@ -26494,7 +26494,7 @@ static int ParseCipherList(Suites* suites,
                         substrCurrent[length] = '\0';
                     }
                     else {
-                        length = (int)XSTRLEN(substrCurrent);
+                        length = (word32)XSTRLEN(substrCurrent);
                     }
 
                     /* check if is a public key type */
@@ -27737,7 +27737,7 @@ int CreateDevPrivateKey(void** pkey, byte* data, word32 length, int hsType,
             ret = wc_InitRsaKey_Label(rsaKey, (char*)data, heap, devId);
         }
         else if (id) {
-            ret = wc_InitRsaKey_Id(rsaKey, data, length, heap, devId);
+            ret = wc_InitRsaKey_Id(rsaKey, data, (int)length, heap, devId);
         }
         if (ret == 0) {
             *pkey = (void*)rsaKey;
@@ -27760,7 +27760,7 @@ int CreateDevPrivateKey(void** pkey, byte* data, word32 length, int hsType,
             ret = wc_ecc_init_label(ecKey, (char*)data, heap, devId);
         }
         else if (id) {
-            ret = wc_ecc_init_id(ecKey, data, length, heap, devId);
+            ret = wc_ecc_init_id(ecKey, data, (int)length, heap, devId);
         }
         if (ret == 0) {
             *pkey = (void*)ecKey;
@@ -27849,7 +27849,7 @@ int DecodePrivateKey(WOLFSSL *ssl, word32* length)
             || wolfSSL_CTX_IsPrivatePkSet(ssl->ctx)
         #endif
         ) {
-            *length = GetPrivateKeySigSize(ssl);
+            *length = (word32)GetPrivateKeySigSize(ssl);
             return 0;
         }
         else
@@ -27899,7 +27899,7 @@ int DecodePrivateKey(WOLFSSL *ssl, word32* length)
                 }
 
                 /* Return the maximum signature length. */
-                *length = ssl->buffers.keySz;
+                *length = (word32)ssl->buffers.keySz;
             }
     #else
             ret = NOT_COMPILED_IN;
@@ -27925,7 +27925,7 @@ int DecodePrivateKey(WOLFSSL *ssl, word32* length)
                 }
 
                 /* Return the maximum signature length. */
-                *length = wc_ecc_sig_size_calc(ssl->buffers.keySz);
+                *length = (word32)wc_ecc_sig_size_calc(ssl->buffers.keySz);
             }
     #else
             ret = NOT_COMPILED_IN;
@@ -28053,7 +28053,7 @@ int DecodePrivateKey(WOLFSSL *ssl, word32* length)
             }
 
             /* Return the maximum signature length. */
-            *length = keySz;
+            *length = (word32)keySz;
 
             goto exit_dpk;
         }
@@ -28119,7 +28119,7 @@ int DecodePrivateKey(WOLFSSL *ssl, word32* length)
             }
 
             /* Return the maximum signature length. */
-            *length = wc_ecc_sig_size((ecc_key*)ssl->hsKey);
+            *length = (word32)wc_ecc_sig_size((ecc_key*)ssl->hsKey);
 
             goto exit_dpk;
         }
@@ -29048,7 +29048,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
         }
 #endif
         length = VERSION_SZ + RAN_LEN
-               + idSz + ENUM_LEN
+               + (word32)idSz + ENUM_LEN
                + SUITE_LEN
                + COMP_LEN + ENUM_LEN;
 #ifndef NO_FORCE_SCR_SAME_SUITE
@@ -29078,7 +29078,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
         if (extSz != 0)
             length += extSz + HELLO_EXT_SZ_SZ;
 #endif
-        sendSz = length + HANDSHAKE_HEADER_SZ + RECORD_HEADER_SZ;
+        sendSz = (int)length + HANDSHAKE_HEADER_SZ + RECORD_HEADER_SZ;
 
         if (ssl->arrays == NULL) {
             return BAD_FUNC_ARG;
@@ -29088,7 +29088,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
         if (ssl->options.dtls) {
             length += ENUM_LEN;   /* cookie */
             if (ssl->arrays->cookieSz != 0) length += ssl->arrays->cookieSz;
-            sendSz  = length + DTLS_HANDSHAKE_HEADER_SZ + DTLS_RECORD_HEADER_SZ;
+            sendSz  = (int)length + DTLS_HANDSHAKE_HEADER_SZ + DTLS_RECORD_HEADER_SZ;
             idx    += DTLS_HANDSHAKE_EXTRA + DTLS_RECORD_EXTRA;
         }
 #endif
@@ -29219,7 +29219,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
 
         if (IsEncryptionOn(ssl, 1)) {
             byte* input;
-            int   inputSz = idx; /* build msg adds rec hdr */
+            int   inputSz = (int)idx; /* build msg adds rec hdr */
             int   recordHeaderSz = RECORD_HEADER_SZ;
 
             if (ssl->options.dtls)
@@ -29232,7 +29232,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             XMEMCPY(input, output + recordHeaderSz, inputSz);
             #ifdef WOLFSSL_DTLS
             if (IsDtlsNotSctpMode(ssl) &&
-                    (ret = DtlsMsgPoolSave(ssl, input, inputSz, client_hello)) != 0) {
+                    (ret = DtlsMsgPoolSave(ssl, input, (word32)inputSz, client_hello)) != 0) {
                 XFREE(input, ssl->heap, DYNAMIC_TYPE_IN_BUFFER);
                 return ret;
             }
@@ -29246,7 +29246,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
         } else {
             #ifdef WOLFSSL_DTLS
                 if (IsDtlsNotSctpMode(ssl)) {
-                    if ((ret = DtlsMsgPoolSave(ssl, output, sendSz, client_hello)) != 0)
+                    if ((ret = DtlsMsgPoolSave(ssl, output, (word32)sendSz, client_hello)) != 0)
                         return ret;
                 }
                 if (ssl->options.dtls)
@@ -30563,7 +30563,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                     }
 
                     /* get PSK server hint from the wire */
-                    srvHintLen = min(length, MAX_PSK_ID_LEN);
+                    srvHintLen = (int)min(length, MAX_PSK_ID_LEN);
                     XMEMCPY(ssl->arrays->server_hint, input + args->idx,
                                                                     srvHintLen);
                     ssl->arrays->server_hint[srvHintLen] = '\0'; /* null term */
@@ -30606,7 +30606,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                     if ((curveOid = CheckCurveId(b)) < 0) {
                         ERROR_OUT(ECC_CURVE_ERROR, exit_dske);
                     }
-                    ssl->ecdhCurveOID = curveOid;
+                    ssl->ecdhCurveOID = (word32)curveOid;
                 #if defined(WOLFSSL_TLS13) || defined(HAVE_FFDHE)
                     ssl->namedGroup = 0;
                 #endif
@@ -30717,7 +30717,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                         }
                     }
 
-                    curveId = wc_ecc_get_oid(curveOid, NULL, NULL);
+                    curveId = wc_ecc_get_oid((word32)curveOid, NULL, NULL);
                     if (wc_ecc_import_x963_ex(input + args->idx, length,
                                         ssl->peerEccKey, curveId) != 0) {
                     #ifdef WOLFSSL_EXTRA_ALERTS
@@ -30750,7 +30750,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                     }
 
                     /* get PSK server hint from the wire */
-                    srvHintLen = min(length, MAX_PSK_ID_LEN);
+                    srvHintLen = (int)min(length, MAX_PSK_ID_LEN);
                     XMEMCPY(ssl->arrays->server_hint, input + args->idx,
                                                                 srvHintLen);
                     ssl->arrays->server_hint[srvHintLen] = '\0'; /* null term */
@@ -30783,7 +30783,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                     }
 
                     /* get PSK server hint from the wire */
-                    srvHintLen = min(length, MAX_PSK_ID_LEN);
+                    srvHintLen = (int)min(length, MAX_PSK_ID_LEN);
                     XMEMCPY(ssl->arrays->server_hint, input + args->idx,
                                                                     srvHintLen);
                     ssl->arrays->server_hint[srvHintLen] = '\0'; /* null term */
@@ -30806,7 +30806,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                     if ((curveOid = CheckCurveId(b)) < 0) {
                         ERROR_OUT(ECC_CURVE_ERROR, exit_dske);
                     }
-                    ssl->ecdhCurveOID = curveOid;
+                    ssl->ecdhCurveOID = (word32)curveOid;
 
                     length = input[args->idx++];
                     if ((args->idx - args->begin) + length > size) {
@@ -30914,7 +30914,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                         }
                     }
 
-                    curveId = wc_ecc_get_oid(curveOid, NULL, NULL);
+                    curveId = wc_ecc_get_oid((word32)curveOid, NULL, NULL);
                     if (wc_ecc_import_x963_ex(input + args->idx, length,
                         ssl->peerEccKey, curveId) != 0) {
                         ERROR_OUT(ECC_PEERKEY_ERROR, exit_dske);
@@ -32629,7 +32629,7 @@ int SendClientKeyExchange(WOLFSSL* ssl)
             }
 
             idx = HANDSHAKE_HEADER_SZ + RECORD_HEADER_SZ;
-            args->sendSz = args->encSz + tlsSz + idx;
+            args->sendSz = (int)(args->encSz + tlsSz + idx);
 
         #ifdef WOLFSSL_DTLS
             if (ssl->options.dtls) {
@@ -33838,7 +33838,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
         if (IsEncryptionOn(ssl, 1)) {
             byte* input;
-            int   inputSz = idx; /* build msg adds rec hdr */
+            int   inputSz = (int)idx; /* build msg adds rec hdr */
             int   recordHeaderSz = RECORD_HEADER_SZ;
 
             if (ssl->options.dtls)
@@ -33851,7 +33851,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             XMEMCPY(input, output + recordHeaderSz, inputSz);
             #ifdef WOLFSSL_DTLS
             if (IsDtlsNotSctpMode(ssl) &&
-                    (ret = DtlsMsgPoolSave(ssl, input, inputSz, server_hello)) != 0) {
+                    (ret = DtlsMsgPoolSave(ssl, input, (word32)inputSz, server_hello)) != 0) {
                 XFREE(input, ssl->heap, DYNAMIC_TYPE_IN_BUFFER);
                 return ret;
             }
@@ -33865,7 +33865,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         } else {
             #ifdef WOLFSSL_DTLS
                 if (IsDtlsNotSctpMode(ssl)) {
-                    if ((ret = DtlsMsgPoolSave(ssl, output, sendSz, server_hello)) != 0)
+                    if ((ret = DtlsMsgPoolSave(ssl, output, (word32)sendSz, server_hello)) != 0)
                         return ret;
                 }
                 if (ssl->options.dtls)
@@ -34658,7 +34658,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                         if (ssl->buffers.key == NULL) {
                         #ifdef HAVE_PK_CALLBACKS
                             if (wolfSSL_CTX_IsPrivatePkSet(ssl->ctx)) {
-                                args->tmpSigSz = GetPrivateKeySigSize(ssl);
+                                args->tmpSigSz = (word32)GetPrivateKeySigSize(ssl);
                                 if (args->tmpSigSz == 0) {
                                     ERROR_OUT(NO_PRIVATE_KEY, exit_sske);
                                 }
@@ -37072,9 +37072,9 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                     );
                     if (ret >= 0) {
                         if (ssl->options.peerSigAlgo == rsa_sa_algo)
-                            args->sendSz = ret;
+                            args->sendSz = (word32)ret;
                         else {
-                            args->sigSz = ret;
+                            args->sigSz = (word32)ret;
                             args->sendSz = ssl->buffers.digest.length;
                         }
                         ret = 0;
@@ -37390,7 +37390,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             XMEMCPY(input, output + recordHeaderSz, inputSz);
             #ifdef WOLFSSL_DTLS
             if (IsDtlsNotSctpMode(ssl) &&
-                    (ret = DtlsMsgPoolSave(ssl, input, inputSz, server_hello_done)) != 0) {
+                    (ret = DtlsMsgPoolSave(ssl, input, (word32)inputSz, server_hello_done)) != 0) {
                 XFREE(input, ssl->heap, DYNAMIC_TYPE_IN_BUFFER);
                 return ret;
             }
@@ -37404,7 +37404,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         } else {
             #ifdef WOLFSSL_DTLS
                 if (IsDtlsNotSctpMode(ssl)) {
-                    if ((ret = DtlsMsgPoolSave(ssl, output, sendSz, server_hello_done)) != 0)
+                    if ((ret = DtlsMsgPoolSave(ssl, output, (word32)sendSz, server_hello_done)) != 0)
                         return ret;
                 }
                 if (ssl->options.dtls)
@@ -38267,7 +38267,7 @@ cleanup:
         }
 
         length += ssl->session->ticketLen;
-        sendSz = length + HANDSHAKE_HEADER_SZ + RECORD_HEADER_SZ;
+        sendSz = (int)length + HANDSHAKE_HEADER_SZ + RECORD_HEADER_SZ;
 
         if (!ssl->options.dtls) {
             if (IsEncryptionOn(ssl, 1) && ssl->options.handShakeDone)
@@ -38309,7 +38309,7 @@ cleanup:
 
         if (IsEncryptionOn(ssl, 1) && ssl->options.handShakeDone) {
             byte* input;
-            int   inputSz = idx; /* build msg adds rec hdr */
+            int   inputSz = (int)idx; /* build msg adds rec hdr */
             int   recordHeaderSz = RECORD_HEADER_SZ;
 
             if (ssl->options.dtls)
@@ -38330,7 +38330,7 @@ cleanup:
         else {
             #ifdef WOLFSSL_DTLS
             if (ssl->options.dtls) {
-                if ((ret = DtlsMsgPoolSave(ssl, output, sendSz, session_ticket)) != 0)
+                if ((ret = DtlsMsgPoolSave(ssl, output, (word32)sendSz, session_ticket)) != 0)
                     return ret;
 
                 DtlsSEQIncrement(ssl, CUR_ORDER);
@@ -38984,7 +38984,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
             ssl->keys.dtls_sequence_number_hi = ssl->keys.curSeq_hi;
             ssl->keys.dtls_sequence_number_lo = ssl->keys.curSeq_lo;
         }
-        AddHeaders(output, length, hello_verify_request, ssl);
+        AddHeaders(output, (word32)length, hello_verify_request, ssl);
 
         output[idx++] = DTLS_MAJOR;
         output[idx++] = DTLS_MINOR;
@@ -39522,7 +39522,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                             ERROR_OUT(ECC_PEERKEY_ERROR, exit_dcke);
                         }
 
-                        ssl->arrays->preMasterSz = private_key->dp->size;
+                        ssl->arrays->preMasterSz = (word32)private_key->dp->size;
 
                         ssl->peerEccKeyPresent = 1;
 

--- a/src/keys.c
+++ b/src/keys.c
@@ -3668,7 +3668,8 @@ int SetKeysSide(WOLFSSL* ssl, enum encrypt_side side)
 /* TLS can call too */
 int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
 {
-    int sz, i = 0;
+    size_t sz;
+    int i = 0;
     Keys* keys = &ssl->keys;
 #ifdef WOLFSSL_DTLS
     /* In case of DTLS, ssl->keys is updated here */
@@ -3712,7 +3713,7 @@ int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
             XMEMCPY(keys->client_write_MAC_secret,&keyData[i], sz);
             XMEMCPY(keys->server_write_MAC_secret,&keyData[i], sz);
     #endif
-            i += sz;
+            i += (int)sz;
         }
         sz = ssl->specs.key_size;
     #ifdef WOLFSSL_DTLS
@@ -3725,7 +3726,7 @@ int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
     #endif
         XMEMCPY(keys->client_write_key, &keyData[i], sz);
         XMEMCPY(keys->server_write_key, &keyData[i], sz);
-        i += sz;
+        i += (int)sz;
 
         sz = ssl->specs.iv_size;
     #ifdef WOLFSSL_DTLS
@@ -3767,7 +3768,7 @@ int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
         #endif
             XMEMCPY(keys->client_write_MAC_secret,&keyData[i], sz);
     #endif
-            i += sz;
+            i += (int)sz;
         }
         if (side & PROVISION_SERVER) {
     #ifndef WOLFSSL_AEAD_ONLY
@@ -3778,7 +3779,7 @@ int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
         #endif
             XMEMCPY(keys->server_write_MAC_secret,&keyData[i], sz);
     #endif
-            i += sz;
+            i += (int)sz;
         }
     }
     sz = ssl->specs.key_size;
@@ -3789,7 +3790,7 @@ int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
                     keys->client_write_key, sz);
     #endif
         XMEMCPY(keys->client_write_key, &keyData[i], sz);
-        i += sz;
+        i += (int)sz;
     }
     if (side & PROVISION_SERVER) {
     #ifdef WOLFSSL_DTLS
@@ -3798,7 +3799,7 @@ int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
                     keys->server_write_key, sz);
     #endif
         XMEMCPY(keys->server_write_key, &keyData[i], sz);
-        i += sz;
+        i += (int)sz;
     }
 
     sz = ssl->specs.iv_size;
@@ -3809,7 +3810,7 @@ int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
                     keys->client_write_IV, sz);
     #endif
         XMEMCPY(keys->client_write_IV, &keyData[i], sz);
-        i += sz;
+        i += (int)sz;
     }
     if (side & PROVISION_SERVER) {
     #ifdef WOLFSSL_DTLS

--- a/src/pk.c
+++ b/src/pk.c
@@ -411,7 +411,7 @@ int EncryptDerKey(byte *der, int *derSz, const EVP_CIPHER* cipher,
         (*derSz) += (int)paddingSz;
 
         /* Encrypt DER buffer. */
-        ret = wc_BufferKeyEncrypt(info, der, *derSz, passwd, passwdSz, WC_MD5);
+        ret = wc_BufferKeyEncrypt(info, der, (word32)*derSz, passwd, passwdSz, WC_MD5);
         if (ret != 0) {
             WOLFSSL_MSG("encrypt key failed");
         }
@@ -5774,7 +5774,7 @@ static int wolfssl_dsa_key_to_pubkey_der(WOLFSSL_DSA* key, unsigned char** der,
     }
     if (sz > 0) {
         /* Encode public key to DER using wolfSSL.  */
-        sz = wc_DsaKeyToPublicDer((DsaKey*)key->internal, buf, sz);
+        sz = wc_DsaKeyToPublicDer((DsaKey*)key->internal, buf, (word32)sz);
         if (sz < 0) {
             WOLFSSL_MSG("wc_DsaKeyToPublicDer failed");
             sz = 0;
@@ -15076,7 +15076,7 @@ int wolfSSL_PEM_def_callback(char* buf, int num, int rwFlag, void* userData)
     /* We assume that the user passes a default password as userdata */
     if ((buf != NULL) && (userData != NULL)) {
         sz = (int)XSTRLEN((const char*)userData);
-        sz = min(sz, num);
+        sz = (int)min((word32)sz, (word32)num);
         XMEMCPY(buf, userData, sz);
     }
     else {
@@ -15656,7 +15656,7 @@ static int pem_read_data(char* pem, int pemLen, char **name, char **header,
         word32 derLen;
 
         /* Convert PEM body to DER. */
-        derLen = startEnd - PEM_END_SZ - start;
+        derLen = (word32)(startEnd - PEM_END_SZ - start);
         ret = Base64_Decode(der + start, derLen, der, &derLen);
         if (ret == 0) {
             /* Return the DER data. */
@@ -15839,7 +15839,7 @@ int wolfSSL_PEM_write_bio(WOLFSSL_BIO* bio, const char *name,
     }
 
     /* Write PEM into BIO. */
-    if ((!err) && (wolfSSL_BIO_write(bio, pem, pemLen) != (int)pemLen)) {
+    if ((!err) && (wolfSSL_BIO_write(bio, pem, (int)pemLen) != (int)pemLen)) {
         err = IO_FAILED_E;
     }
 
@@ -15930,7 +15930,7 @@ int wolfSSL_PEM_write(XFILE fp, const char *name, const char *header,
     }
 
     XFREE(pem, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    return pemLen;
+    return (int)pemLen;
 }
 #endif
 
@@ -16003,7 +16003,7 @@ int wolfSSL_PEM_do_header(EncryptedInfo* cipher, unsigned char* data, long* len,
 
     if (passwordSz > 0) {
         /* Ensure password is erased from memory. */
-        ForceZero(password, passwordSz);
+        ForceZero(password, (word32)passwordSz);
     }
 
     return ret;
@@ -16075,7 +16075,7 @@ static int pem_pkcs8_encrypt(WOLFSSL_EVP_PKEY* pkey,
                 key, keySz, passwd, passwdSz, PKCS5, PBES2, encAlgId,
                 NULL, 0, WC_PKCS12_ITT_DEFAULT, &rng, NULL);
             if (ret > 0) {
-                *keySz = ret;
+                *keySz = (word32)ret;
             }
         }
         /* Dispose of random number generator. */
@@ -16171,7 +16171,7 @@ static int pem_write_mem_pkcs8privatekey(byte** pem, int* pemSz,
             keySz += 128;
         }
         /* PEM encoding size from DER size. */
-        *pemSz  = (keySz + 2) / 3 * 4;
+        *pemSz  = (int)(keySz + 2) / 3 * 4;
         *pemSz += (*pemSz + 63) / 64;
         /* Header and footer. */
         if (enc != NULL) {
@@ -16184,7 +16184,7 @@ static int pem_write_mem_pkcs8privatekey(byte** pem, int* pemSz,
         }
 
         /* Allocate enough memory to hold PEM encoded encrypted key. */
-        *pem = (byte*)XMALLOC(*pemSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        *pem = (byte*)XMALLOC((size_t)*pemSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         if (*pem == NULL) {
             res = 0;
         }
@@ -16217,7 +16217,7 @@ static int pem_write_mem_pkcs8privatekey(byte** pem, int* pemSz,
 
         /* Zeroize the password from memory. */
         if ((password == passwd) && (passwdSz > 0)) {
-            ForceZero(password, passwdSz);
+            ForceZero(password, (word32)passwdSz);
         }
     }
     else if ((res == 1) && (enc == NULL)) {
@@ -16233,7 +16233,7 @@ static int pem_write_mem_pkcs8privatekey(byte** pem, int* pemSz,
 
     if (res == 1) {
         /* Encode PKCS#8 formatted key to PEM. */
-        ret = wc_DerToPemEx(key, keySz, *pem, *pemSz, NULL, type);
+        ret = wc_DerToPemEx(key, keySz, *pem, (word32)*pemSz, NULL, type);
         if (ret < 0) {
             res = 0;
         }
@@ -16328,7 +16328,7 @@ int wolfSSL_PEM_write_PKCS8PrivateKey(XFILE f, WOLFSSL_EVP_PKEY* pkey,
     }
 
     /* Write encoded key to file. */
-    if ((res >= 1) && (XFWRITE(pem, 1, pemSz, f) != (size_t)pemSz)) {
+    if ((res >= 1) && (XFWRITE(pem, 1, (size_t)pemSz, f) != (size_t)pemSz)) {
         res = 0;
     }
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1690,7 +1690,7 @@ const char* wolfSSL_get_shared_ciphers(WOLFSSL* ssl, char* buf, int len)
         return NULL;
 
     cipher = wolfSSL_get_cipher_name_iana(ssl);
-    len = min(len, (int)(XSTRLEN(cipher) + 1));
+    len = (int)min((word32)len, (int)(XSTRLEN(cipher) + 1));
     XMEMCPY(buf, cipher, len);
     return buf;
 }
@@ -2095,7 +2095,7 @@ int wolfSSL_export_dtls_srtp_keying_material(WOLFSSL* ssl,
         return EXT_MISSING;
     }
     if (out == NULL) {
-        *olen = profile->kdfBits;
+        *olen = (size_t)profile->kdfBits;
         return LENGTH_ONLY_E;
     }
 
@@ -3325,7 +3325,7 @@ int  wolfSSL_CTX_set1_groups(WOLFSSL_CTX* ctx, int* groups,
 #ifdef HAVE_ECC
         else {
             /* groups may be populated with curve NIDs */
-            int oid = nid2oid(groups[i], oidCurveType);
+            int oid = (int)nid2oid(groups[i], oidCurveType);
             int name = (int)GetCurveByOID(oid);
             if (name == 0) {
                 WOLFSSL_MSG("Invalid group name");
@@ -3360,7 +3360,7 @@ int  wolfSSL_set1_groups(WOLFSSL* ssl, int* groups, int count)
 #ifdef HAVE_ECC
         else {
             /* groups may be populated with curve NIDs */
-            int oid = nid2oid(groups[i], oidCurveType);
+            int oid = (int)nid2oid(groups[i], oidCurveType);
             int name = (int)GetCurveByOID(oid);
             if (name == 0) {
                 WOLFSSL_MSG("Invalid group name");
@@ -5232,7 +5232,7 @@ int AddTrustedPeer(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int verify)
             cert->excludedNames = NULL;
         #endif
 
-            row = TrustedPeerHashSigner(peerCert->subjectNameHash);
+            row = (int)TrustedPeerHashSigner(peerCert->subjectNameHash);
 
             if (wc_LockMutex(&cm->tpLock) == 0) {
                 peerCert->next = cm->tpTable[row];
@@ -6508,7 +6508,7 @@ static int d2iTryRsaKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
         }
     }
 
-    pkey->pkey_sz = keyIdx;
+    pkey->pkey_sz = (int)keyIdx;
     pkey->pkey.ptr = (char*)XMALLOC(memSz, NULL,
             priv ? DYNAMIC_TYPE_PRIVATE_KEY :
                    DYNAMIC_TYPE_PUBLIC_KEY);
@@ -6592,7 +6592,7 @@ static int d2iTryEccKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
         }
     }
 
-    pkey->pkey_sz = keyIdx;
+    pkey->pkey_sz = (int)keyIdx;
     pkey->pkey.ptr = (char*)XMALLOC(keyIdx, NULL,
             priv ? DYNAMIC_TYPE_PRIVATE_KEY :
                    DYNAMIC_TYPE_PUBLIC_KEY);
@@ -6680,7 +6680,7 @@ static int d2iTryDsaKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
         }
     }
 
-    pkey->pkey_sz = keyIdx;
+    pkey->pkey_sz = (int)keyIdx;
     pkey->pkey.ptr = (char*)XMALLOC(memSz, NULL,
             priv ? DYNAMIC_TYPE_PRIVATE_KEY :
                    DYNAMIC_TYPE_PUBLIC_KEY);
@@ -7188,7 +7188,7 @@ WOLFSSL_PKCS8_PRIV_KEY_INFO* wolfSSL_d2i_PKCS8_PKEY(
     }
     if (ret == 0) {
         XMEMCPY(pkcs8->pkey.ptr, der->buffer, der->length);
-        pkcs8->pkey_sz = der->length;
+        pkcs8->pkey_sz = (int)der->length;
     }
 
     FreeDer(&der);
@@ -7722,14 +7722,14 @@ WOLFSSL_API int wolfSSL_CTX_set_client_cert_type(WOLFSSL_CTX* ctx,
         return WOLFSSL_SUCCESS;
     }
 
-    if (!isArrayUnique(buf, bufLen))
+    if (!isArrayUnique(buf, (size_t)bufLen))
         return BAD_FUNC_ARG;
 
     for (i = 0; i < bufLen; i++){
         if (buf[i] != WOLFSSL_CERT_TYPE_RPK && buf[i] != WOLFSSL_CERT_TYPE_X509)
             return BAD_FUNC_ARG;
 
-        ctx->rpkConfig.preferred_ClientCertTypes[i] = buf[i];
+        ctx->rpkConfig.preferred_ClientCertTypes[i] = (byte)buf[i];
     }
     ctx->rpkConfig.preferred_ClientCertTypeCnt = bufLen;
 
@@ -7757,14 +7757,14 @@ WOLFSSL_API int wolfSSL_CTX_set_server_cert_type(WOLFSSL_CTX* ctx,
         return WOLFSSL_SUCCESS;
     }
 
-    if (!isArrayUnique(buf, bufLen))
+    if (!isArrayUnique(buf, (size_t)bufLen))
         return BAD_FUNC_ARG;
 
     for (i = 0; i < bufLen; i++){
         if (buf[i] != WOLFSSL_CERT_TYPE_RPK && buf[i] != WOLFSSL_CERT_TYPE_X509)
             return BAD_FUNC_ARG;
 
-        ctx->rpkConfig.preferred_ServerCertTypes[i] = buf[i];
+        ctx->rpkConfig.preferred_ServerCertTypes[i] = (byte)buf[i];
     }
     ctx->rpkConfig.preferred_ServerCertTypeCnt = bufLen;
 
@@ -7794,14 +7794,14 @@ WOLFSSL_API int wolfSSL_set_client_cert_type(WOLFSSL* ssl,
         return WOLFSSL_SUCCESS;
     }
 
-    if (!isArrayUnique(buf, bufLen))
+    if (!isArrayUnique(buf, (size_t)bufLen))
         return BAD_FUNC_ARG;
 
     for (i = 0; i < bufLen; i++){
         if (buf[i] != WOLFSSL_CERT_TYPE_RPK && buf[i] != WOLFSSL_CERT_TYPE_X509)
             return BAD_FUNC_ARG;
 
-        ssl->options.rpkConfig.preferred_ClientCertTypes[i] = buf[i];
+        ssl->options.rpkConfig.preferred_ClientCertTypes[i] = (byte)buf[i];
     }
     ssl->options.rpkConfig.preferred_ClientCertTypeCnt = bufLen;
 
@@ -7831,14 +7831,14 @@ WOLFSSL_API int wolfSSL_set_server_cert_type(WOLFSSL* ssl,
         return WOLFSSL_SUCCESS;
     }
 
-    if (!isArrayUnique(buf, bufLen))
+    if (!isArrayUnique(buf, (size_t)bufLen))
         return BAD_FUNC_ARG;
 
     for (i = 0; i < bufLen; i++){
         if (buf[i] != WOLFSSL_CERT_TYPE_RPK && buf[i] != WOLFSSL_CERT_TYPE_X509)
             return BAD_FUNC_ARG;
 
-        ssl->options.rpkConfig.preferred_ServerCertTypes[i] = buf[i];
+        ssl->options.rpkConfig.preferred_ServerCertTypes[i] = (byte)buf[i];
     }
     ssl->options.rpkConfig.preferred_ServerCertTypeCnt = bufLen;
 
@@ -8069,7 +8069,7 @@ void wolfSSL_set_verify_result(WOLFSSL *ssl, long v)
 
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || \
     defined(OPENSSL_ALL)
-    ssl->peerVerifyRet = v;
+    ssl->peerVerifyRet = (unsigned long)v;
 #else
     (void)v;
     WOLFSSL_STUB("wolfSSL_set_verify_result");
@@ -13326,7 +13326,7 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
 
         /* Create a DecodedCert object and copy fields into WOLFSSL_X509 object.
          */
-        InitDecodedCert(cert, (byte*)in, len, NULL);
+        InitDecodedCert(cert, (byte*)in, (word32)len, NULL);
         if ((ret = ParseCertRelative(cert, CERT_TYPE, 0, NULL)) == 0) {
         /* Check if x509 was not previously initialized by wolfSSL_X509_new() */
             if (x509->dynamicMemory != TRUE)
@@ -15030,12 +15030,12 @@ int wolfSSL_i2d_PublicKey(const WOLFSSL_EVP_PKEY *key, unsigned char **der)
         /* In this case, there was no buffered DER at all. This could be the
          * case where the key that was passed in was generated. So now we
          * have to create the local DER. */
-        local_derSz = wolfSSL_i2d_ECPrivateKey(key->ecc, &local_der);
+        local_derSz = (word32)wolfSSL_i2d_ECPrivateKey(key->ecc, &local_der);
         if (local_derSz == 0) {
             ret = WOLFSSL_FATAL_ERROR;
         }
     } else {
-        local_derSz = ret;
+        local_derSz = (word32)ret;
         ret = 0;
     }
 
@@ -15060,7 +15060,7 @@ int wolfSSL_i2d_PublicKey(const WOLFSSL_EVP_PKEY *key, unsigned char **der)
     }
 
     if (ret == 0) {
-        pub_derSz = wc_EccPublicKeyDerSize(eccKey, 0);
+        pub_derSz = (word32)wc_EccPublicKeyDerSize(eccKey, 0);
         if ((int)pub_derSz <= 0) {
             ret = WOLFSSL_FAILURE;
         }
@@ -15076,7 +15076,7 @@ int wolfSSL_i2d_PublicKey(const WOLFSSL_EVP_PKEY *key, unsigned char **der)
     }
 
     if (ret == 0) {
-        pub_derSz = wc_EccPublicKeyToDer(eccKey, pub_der, pub_derSz, 0);
+        pub_derSz = (word32)wc_EccPublicKeyToDer(eccKey, pub_der, pub_derSz, 0);
         if ((int)pub_derSz <= 0) {
             ret = WOLFSSL_FATAL_ERROR;
         }
@@ -15113,7 +15113,7 @@ int wolfSSL_i2d_PublicKey(const WOLFSSL_EVP_PKEY *key, unsigned char **der)
 #endif /* HAVE_ECC */
 
     if (ret == 0) {
-        return pub_derSz;
+        return (int)pub_derSz;
     }
 
     return ret;
@@ -16881,7 +16881,7 @@ int wolfSSL_cmp_peer_cert_to_file(WOLFSSL* ssl, const char *fname)
 
         if ((myBuffer != NULL) &&
             (sz > 0) &&
-            (XFREAD(myBuffer, 1, sz, file) == (size_t)sz) &&
+            (XFREAD(myBuffer, 1, (size_t)sz, file) == (size_t)sz) &&
             (PemToDer(myBuffer, (long)sz, CERT_TYPE,
                       &fileDer, ctx->heap, NULL, NULL) == 0) &&
             (fileDer->length != 0) &&
@@ -17413,8 +17413,8 @@ unsigned char *wolfSSL_OPENSSL_hexstr2buf(const char *str, long *len)
             continue;
         }
 
-        srcDigitHigh = wolfSSL_OPENSSL_hexchar2int(str[srcIdx++]);
-        srcDigitLow = wolfSSL_OPENSSL_hexchar2int(str[srcIdx++]);
+        srcDigitHigh = wolfSSL_OPENSSL_hexchar2int((unsigned char)str[srcIdx++]);
+        srcDigitLow = wolfSSL_OPENSSL_hexchar2int((unsigned char)str[srcIdx++]);
         if (srcDigitHigh < 0 || srcDigitLow < 0) {
             WOLFSSL_MSG("Invalid hex character.");
             XFREE(targetBuf, NULL, DYNAMIC_TYPE_OPENSSL);
@@ -18503,14 +18503,14 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
             WOLFSSL_MSG("NID not in table");
         #ifdef WOLFSSL_QT
             sName = NULL;
-            type = id;
+            type = (word32)id;
         #else
             return NULL;
         #endif
         }
 
     #ifdef HAVE_ECC
-         if (type == 0 && wc_ecc_get_oid(id, &oid, &oidSz) > 0) {
+         if (type == 0 && wc_ecc_get_oid((word32)id, &oid, &oidSz) > 0) {
              type = oidCurveType;
          }
     #endif /* HAVE_ECC */
@@ -18522,7 +18522,7 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
             }
         }
 
-        oid = OidFromId(id, type, &oidSz);
+        oid = OidFromId((word32)id, type, &oidSz);
 
         /* set object ID to buffer */
         if (obj == NULL){
@@ -18534,7 +18534,7 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
         }
         obj->nid     = nid;
         obj->type    = id;
-        obj->grp     = type;
+        obj->grp     = (int)type;
 
         obj->sName[0] = '\0';
         if (sName != NULL) {
@@ -18682,12 +18682,12 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
         else if (a->type == GEN_DNS || a->type == GEN_EMAIL ||
                  a->type == GEN_URI) {
             bufSz = (int)XSTRLEN((const char*)a->obj);
-            XMEMCPY(buf, a->obj, min(bufSz, bufLen));
+            XMEMCPY(buf, a->obj, min((word32)bufSz, (word32)bufLen));
         }
         else if ((bufSz = wolfssl_obj2txt_numeric(buf, bufLen, a)) > 0) {
             if ((desc = oid_translate_num_to_str(buf))) {
                 bufSz = (int)XSTRLEN(desc);
-                bufSz = min(bufSz, bufLen - 1);
+                bufSz = (int)min((word32)bufSz,(word32) bufLen - 1);
                 XMEMCPY(buf, desc, bufSz);
             }
         }
@@ -18780,7 +18780,7 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
             err = 1;
         }
         if (err == 0) {
-            ret = len;
+            ret = (size_t)len;
         }
 
         WOLFSSL_LEAVE("wolfSSL_OBJ_length", (int)ret);
@@ -19054,7 +19054,7 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
                 return NULL;
             }
             obj->dynamic |= WOLFSSL_ASN1_DYNAMIC_DATA;
-            i = SetObjectId(outSz, (byte*)obj->obj);
+            i = SetObjectId((int)outSz, (byte*)obj->obj);
             XMEMCPY((byte*)obj->obj + i, out, outSz);
             obj->objSz = i + outSz;
             return obj;
@@ -20608,7 +20608,7 @@ WOLF_STACK_OF(WOLFSSL_CIPHER) *wolfSSL_get_ciphers_compat(const WOLFSSL *ssl)
                             add->data.cipher.cipherSuite0 &&
                             cipher_names[j].cipherSuite ==
                                     add->data.cipher.cipherSuite) {
-                        add->data.cipher.offset = j;
+                        add->data.cipher.offset = (unsigned long)j;
                         break;
                     }
                 }
@@ -20670,7 +20670,7 @@ int wolfSSL_SSL_CTX_set_tmp_ecdh(WOLFSSL_CTX *ctx, WOLFSSL_EC_KEY *ecdh)
     if (ctx == NULL || ecdh == NULL)
         return BAD_FUNC_ARG;
 
-    ctx->ecdhCurveOID = ecdh->group->curve_oid;
+    ctx->ecdhCurveOID = (word32)ecdh->group->curve_oid;
 
     return WOLFSSL_SUCCESS;
 }
@@ -21119,7 +21119,7 @@ int wolfSSL_CTX_get_extra_chain_certs(WOLFSSL_CTX* ctx,
 
         /* Create a new X509 from DER encoded data. */
         node->data.x509 = wolfSSL_X509_d2i_ex(NULL,
-            ctx->certChain->buffer + idx, length, ctx->heap);
+            ctx->certChain->buffer + idx, (int)length, ctx->heap);
         if (node->data.x509 == NULL) {
             XFREE(node, NULL, DYNAMIC_TYPE_OPENSSL);
             /* Return as much of the chain as we created. */
@@ -21833,7 +21833,7 @@ int wolfSSL_set_alpn_protos(WOLFSSL* ssl,
     /* clears out all current ALPN extensions set */
     TLSX_Remove(&ssl->extensions, TLSX_APPLICATION_LAYER_PROTOCOL, ssl->heap);
 
-    if ((sz = wolfSSL_BIO_get_mem_data(bio, &pt)) > 0) {
+    if ((sz = (unsigned int)wolfSSL_BIO_get_mem_data(bio, &pt)) > 0) {
         wolfSSL_UseALPN(ssl, pt, sz, (byte) alpn_opt);
     }
     wolfSSL_BIO_free(bio);
@@ -22698,13 +22698,13 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PKCS8PrivateKey_bio(WOLFSSL_BIO* bio,
             passwordSz);
     #endif
 
-        ret = ToTraditionalEnc(der, len, password, passwordSz, &algId);
+        ret = ToTraditionalEnc(der, (word32)len, password, passwordSz, &algId);
         if (ret < 0) {
             XFREE(der, bio->heap, DYNAMIC_TYPE_OPENSSL);
             return NULL;
         }
 
-        ForceZero(password, passwordSz);
+        ForceZero(password, (word32)passwordSz);
     #ifdef WOLFSSL_CHECK_MEM_ZERO
         wc_MemZero_Check(password, passwordSz);
     #endif
@@ -22735,7 +22735,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_AutoPrivateKey(WOLFSSL_EVP_PKEY** pkey,
     /* Take off PKCS#8 wrapper if found. */
     if ((len = ToTraditionalInline_ex(der, &idx, keyLen, &algId)) >= 0) {
         der += idx;
-        keyLen = len;
+        keyLen = (word32)len;
     }
     idx = 0;
     len = 0;
@@ -23475,7 +23475,7 @@ int wolfSSL_BUF_MEM_grow_ex(WOLFSSL_BUF_MEM* buf, size_t len,
     }
     buf->data = tmp;
 
-    buf->max = mx;
+    buf->max = (size_t)mx;
     if (zeroFill)
         XMEMSET(&buf->data[buf->length], 0, len - buf->length);
     buf->length = len;
@@ -23517,7 +23517,7 @@ int wolfSSL_BUF_MEM_resize(WOLFSSL_BUF_MEM* buf, size_t len)
 
     buf->data = tmp;
     buf->length = len;
-    buf->max = mx;
+    buf->max = (size_t)mx;
 
     return (int)len;
 }
@@ -23722,7 +23722,7 @@ int wolfSSL_RAND_write_file(const char* fname)
             return 0;
         }
 
-        if (wc_RNG_GenerateBlock(&globalRNG, buf, bytes) != 0) {
+        if (wc_RNG_GenerateBlock(&globalRNG, buf, (word32)bytes) != 0) {
             WOLFSSL_MSG("Error generating random buffer");
             bytes = 0;
         }
@@ -23739,12 +23739,12 @@ int wolfSSL_RAND_write_file(const char* fname)
                 bytes = 0;
             }
             else {
-                size_t bytes_written = XFWRITE(buf, 1, bytes, f);
+                size_t bytes_written = XFWRITE(buf, 1, (size_t)bytes, f);
                 bytes = (int)bytes_written;
                 XFCLOSE(f);
             }
         }
-        ForceZero(buf, bytes);
+        ForceZero(buf, (word32)bytes);
     #ifdef WOLFSSL_SMALL_STACK
         XFREE(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     #elif defined(WOLFSSL_CHECK_MEM_ZERO)
@@ -23908,7 +23908,7 @@ int wolfSSL_RAND_egd(const char* nm)
     close(fd);
 
     if (ret == WOLFSSL_SUCCESS) {
-        return bytes;
+        return (int)bytes;
     }
     else {
         return ret;
@@ -24079,7 +24079,7 @@ int wolfSSL_RAND_bytes(unsigned char* buf, int num)
         }
 
         if (ret == 0 && num)
-            ret = wc_RNG_GenerateBlock(rng, buf, num);
+            ret = wc_RNG_GenerateBlock(rng, buf, (word32)num);
 
         if (ret != 0)
             WOLFSSL_MSG("Bad wc_RNG_GenerateBlock");
@@ -24585,7 +24585,7 @@ int wolfSSL_FIPS_drbg_init(WOLFSSL_DRBG_CTX *ctx, int type, unsigned int flags)
     if (ctx != NULL) {
         XMEMSET(ctx, 0, sizeof(WOLFSSL_DRBG_CTX));
         ctx->type = type;
-        ctx->xflags = flags;
+        ctx->xflags = (int)flags;
         ctx->status = DRBG_STATUS_UNINITIALISED;
         ret = WOLFSSL_SUCCESS;
     }

--- a/src/ssl_crypto.c
+++ b/src/ssl_crypto.c
@@ -2000,7 +2000,7 @@ unsigned char* wolfSSL_HMAC(const WOLFSSL_EVP_MD* evp_md, const void* key,
 #endif
     if (rc == 0)  {
         /* Get the HMAC output length. */
-        hmacLen = wolfssl_mac_len((unsigned char)type);
+        hmacLen = (int)wolfssl_mac_len((unsigned char)type);
         /* 0 indicates the digest is not supported. */
         if (hmacLen == 0) {
             rc = BAD_FUNC_ARG;
@@ -2009,16 +2009,16 @@ unsigned char* wolfSSL_HMAC(const WOLFSSL_EVP_MD* evp_md, const void* key,
     /* Initialize the wolfSSL HMAC object. */
     if ((rc == 0) && (wc_HmacInit(hmac, heap, INVALID_DEVID) == 0)) {
         /* Set the key into the wolfSSL HMAC object. */
-        rc = wc_HmacSetKey(hmac, type, (const byte*)key, key_len);
+        rc = wc_HmacSetKey(hmac, type, (const byte*)key, (word32)key_len);
         if (rc == 0) {
            /* Update the wolfSSL HMAC object with data. */
-            rc = wc_HmacUpdate(hmac, data, len);
+            rc = wc_HmacUpdate(hmac, data, (word32)len);
         }
         /* Finalize the wolfSSL HMAC object. */
         if ((rc == 0) && (wc_HmacFinal(hmac, md) == 0)) {
             /* Return the length of the HMAC output if required. */
             if (md_len != NULL) {
-                *md_len = hmacLen;
+                *md_len = (unsigned int)hmacLen;
             }
             /* Set the buffer to return. */
             ret = md;
@@ -2269,7 +2269,7 @@ int wolfSSL_CMAC_Final(WOLFSSL_CMAC_CTX* ctx, unsigned char* out, size_t* len)
             len32 = (word32)blockSize;
             /* Return size if required. */
             if (len != NULL) {
-                *len = blockSize;
+                *len = (size_t)blockSize;
             }
         }
     }

--- a/src/ssl_misc.c
+++ b/src/ssl_misc.c
@@ -480,7 +480,7 @@ static int wolfssl_read_file_static(const char* fname, StaticBuffer* content,
         ret = static_buffer_set_size(content, (word32)sz, heap, type);
     }
     /* Read data from file. */
-    if ((ret == 0) && ((size_t)XFREAD(content->buffer, 1, sz, file) !=
+    if ((ret == 0) && ((size_t)XFREAD(content->buffer, 1, (size_t)sz, file) !=
             (size_t)sz)) {
         ret = WOLFSSL_BAD_FILE;
     }

--- a/src/x509.c
+++ b/src/x509.c
@@ -177,19 +177,19 @@ int wolfSSL_X509_get_ext_count(const WOLFSSL_X509* passedCert)
             goto out;
         }
 
-        if (GetLength(input, &idx, &length, sz) < 0) {
+        if (GetLength(input, &idx, &length, (word32)sz) < 0) {
             WOLFSSL_MSG("\tfail: invalid length");
             goto out;
         }
     }
 
-    if (GetSequence(input, &idx, &length, sz) < 0) {
+    if (GetSequence(input, &idx, &length, (word32)sz) < 0) {
         WOLFSSL_MSG("\tfail: should be a SEQUENCE (1)");
         goto out;
     }
 
     while (idx < (word32)sz) {
-        if (GetSequence(input, &idx, &length, sz) < 0) {
+        if (GetSequence(input, &idx, &length, (word32)sz) < 0) {
             WOLFSSL_MSG("\tfail: should be a SEQUENCE");
             FreeDecodedCert(cert);
             return WOLFSSL_FAILURE;
@@ -643,7 +643,7 @@ static int wolfssl_dns_entry_othername_to_gn(DNS_entry* dns,
         wolfSSL_ASN1_OBJECT_free(obj);
         goto err;
     }
-    wolfSSL_ASN1_STRING_set(str, p, (word32)len);
+    wolfSSL_ASN1_STRING_set(str, p, (int)len);
 
     /* Wrap string in a WOLFSSL_ASN1_TYPE. */
     type = wolfSSL_ASN1_TYPE_new();
@@ -839,7 +839,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
             return NULL;
         }
 
-        if (GetLength(input, &idx, &length, sz) < 0) {
+        if (GetLength(input, &idx, &length, (word32)sz) < 0) {
             WOLFSSL_MSG("\tfail: invalid length");
             wolfSSL_X509_EXTENSION_free(ext);
             FreeDecodedCert(cert);
@@ -850,7 +850,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
         }
     }
 
-    if (GetSequence(input, &idx, &length, sz) < 0) {
+    if (GetSequence(input, &idx, &length, (word32)sz) < 0) {
         WOLFSSL_MSG("\tfail: should be a SEQUENCE (1)");
         wolfSSL_X509_EXTENSION_free(ext);
         FreeDecodedCert(cert);
@@ -863,7 +863,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
     while (idx < (word32)sz) {
         oid = 0;
 
-        if (GetSequence(input, &idx, &length, sz) < 0) {
+        if (GetSequence(input, &idx, &length, (word32)sz) < 0) {
             WOLFSSL_MSG("\tfail: should be a SEQUENCE");
             wolfSSL_X509_EXTENSION_free(ext);
             FreeDecodedCert(cert);
@@ -874,7 +874,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
         }
 
         tmpIdx = idx;
-        ret = GetObjectId(input, &idx, &oid, oidCertExtType, sz);
+        ret = GetObjectId(input, &idx, &oid, oidCertExtType, (word32)sz);
         if (ret < 0) {
             WOLFSSL_MSG("\tfail: OBJECT ID");
             wolfSSL_X509_EXTENSION_free(ext);
@@ -895,11 +895,11 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
         }
         /* extCount == loc. Now get the extension. */
         /* Check if extension has been set */
-        isSet = wolfSSL_X509_ext_isSet_by_NID((WOLFSSL_X509*)x509, nid);
+        isSet = wolfSSL_X509_ext_isSet_by_NID((WOLFSSL_X509*)x509, (int)nid);
 
-        if (wolfSSL_OBJ_nid2ln(nid) != NULL) {
+        if (wolfSSL_OBJ_nid2ln((int)nid) != NULL) {
             /* This is NOT an unknown OID. */
-            ext->obj = wolfSSL_OBJ_nid2obj(nid);
+            ext->obj = wolfSSL_OBJ_nid2obj((int)nid);
             if (ext->obj == NULL) {
                 WOLFSSL_MSG("\tfail: Invalid OBJECT");
                 wolfSSL_X509_EXTENSION_free(ext);
@@ -912,7 +912,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
         }
 
         if (ext->obj) {
-            ext->obj->nid = nid;
+            ext->obj->nid = (int)nid;
         }
 
         switch (oid) {
@@ -929,7 +929,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
                 #endif
                     return NULL;
                 }
-                a->length = x509->pathLength;
+                a->length = (int)x509->pathLength;
 
                 /* Save ASN1_INTEGER in x509 extension */
                 ext->obj->pathlen = a;
@@ -972,7 +972,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
                         return NULL;
                     }
                     obj->obj = (byte*)x509->authInfoCaIssuer;
-                    obj->objSz = x509->authInfoCaIssuerSz;
+                    obj->objSz = (unsigned int)x509->authInfoCaIssuerSz;
                     obj->grp = oidCertAuthInfoType;
                     obj->nid = NID_ad_ca_issuers;
 
@@ -1007,7 +1007,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
                         return NULL;
                     }
                     obj->obj = x509->authInfo;
-                    obj->objSz = x509->authInfoSz;
+                    obj->objSz = (unsigned int)x509->authInfoSz;
                     obj->grp = oidCertAuthInfoType;
                     obj->nid = NID_ad_OCSP;
 
@@ -1132,7 +1132,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
                  *  parsed oid for access in later function calls */
 
                 /* Get OID from input */
-                if (GetASNObjectId(input, &idx, &length, sz) != 0) {
+                if (GetASNObjectId(input, &idx, &length, (word32)sz) != 0) {
                     WOLFSSL_MSG("Failed to Get ASN Object Id");
                     wolfSSL_X509_EXTENSION_free(ext);
                     FreeDecodedCert(cert);
@@ -1171,7 +1171,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
                     }
                 }
 
-                ext->obj->objSz = objSz;
+                ext->obj->objSz = (unsigned int)objSz;
                 if(((ext->obj->dynamic & WOLFSSL_ASN1_DYNAMIC_DATA) != 0) ||
                    (ext->obj->obj == NULL)) {
                         ext->obj->obj =(byte*)XREALLOC((byte*)ext->obj->obj,
@@ -1215,7 +1215,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
 
                 tmpIdx++;
 
-                if (GetLength(input, &tmpIdx, &length, sz) <= 0) {
+                if (GetLength(input, &tmpIdx, &length, (word32)sz) <= 0) {
                     WOLFSSL_MSG("Error: Invalid Input Length.");
                     wolfSSL_ASN1_OBJECT_free(ext->obj);
                     wolfSSL_X509_EXTENSION_free(ext);
@@ -1283,7 +1283,7 @@ static int asn1_string_copy_to_buffer(WOLFSSL_ASN1_STRING* str, byte** buf,
             WOLFSSL_MSG("malloc error");
             return WOLFSSL_FAILURE;
         }
-        *len = str->length;
+        *len = (word32)str->length;
         XMEMCPY(*buf, str->data, str->length);
     }
 
@@ -1418,7 +1418,7 @@ int wolfSSL_X509_add_ext(WOLFSSL_X509 *x509, WOLFSSL_X509_EXTENSION *ext, int lo
             x509->isCa = (byte)ext->obj->ca;
             x509->basicConstCrit = (byte)ext->crit;
             if (ext->obj->pathlen)
-                x509->pathLength = ext->obj->pathlen->length;
+                x509->pathLength = (word32)ext->obj->pathlen->length;
             x509->basicConstSet = 1;
         }
         break;
@@ -1545,7 +1545,7 @@ int wolfSSL_X509V3_EXT_print(WOLFSSL_BIO *out, WOLFSSL_X509_EXTENSION *ext,
                         WOLFSSL_MSG("Memory error");
                         return rc;
                     }
-                    valLen = XSNPRINTF(val, len, "%*s%s", indent, "",
+                    valLen = XSNPRINTF(val, (size_t)len, "%*s%s", indent, "",
                             str->strData);
                     if ((valLen < 0) || (valLen >= len)
                             || ((tmpLen + valLen) >= tmpSz)) {
@@ -2108,13 +2108,13 @@ int wolfSSL_X509_get_ext_by_NID(const WOLFSSL_X509* x509, int nid, int lastPos)
             goto out;
         }
 
-        if (GetLength(input, &idx, &length, sz) < 0) {
+        if (GetLength(input, &idx, &length, (word32)sz) < 0) {
             WOLFSSL_MSG("\tfail: invalid length");
             goto out;
         }
     }
 
-    if (GetSequence(input, &idx, &length, sz) < 0) {
+    if (GetSequence(input, &idx, &length, (word32)sz) < 0) {
         WOLFSSL_MSG("\tfail: should be a SEQUENCE (1)");
         goto out;
     }
@@ -2122,13 +2122,13 @@ int wolfSSL_X509_get_ext_by_NID(const WOLFSSL_X509* x509, int nid, int lastPos)
     while (idx < (word32)sz) {
         oid = 0;
 
-        if (GetSequence(input, &idx, &length, sz) < 0) {
+        if (GetSequence(input, &idx, &length, (word32)sz) < 0) {
             WOLFSSL_MSG("\tfail: should be a SEQUENCE");
             goto out;
         }
 
         tmpIdx = idx;
-        ret = GetObjectId(input, &idx, &oid, oidCertExtType, sz);
+        ret = GetObjectId(input, &idx, &oid, oidCertExtType, (word32)sz);
         if (ret < 0) {
             WOLFSSL_MSG("\tfail: OBJECT ID");
             goto out;
@@ -2138,7 +2138,7 @@ int wolfSSL_X509_get_ext_by_NID(const WOLFSSL_X509* x509, int nid, int lastPos)
 
         if (extCount >= loc) {
             /* extCount >= loc. Now check if extension has been set */
-            isSet = wolfSSL_X509_ext_isSet_by_NID((WOLFSSL_X509*)x509, foundNID);
+            isSet = wolfSSL_X509_ext_isSet_by_NID((WOLFSSL_X509*)x509, (int)foundNID);
 
             if (isSet && ((word32)nid == foundNID)) {
                 found = 1;
@@ -2218,7 +2218,7 @@ void* wolfSSL_X509_get_ext_d2i(const WOLFSSL_X509* x509, int nid, int* c,
                     wolfSSL_BASIC_CONSTRAINTS_free(bc);
                     return NULL;
                 }
-                a->length = x509->pathLength;
+                a->length = (int)x509->pathLength;
 
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT) || \
         defined(WOLFSSL_APACHE_HTTPD)
@@ -2395,7 +2395,7 @@ void* wolfSSL_X509_get_ext_d2i(const WOLFSSL_X509* x509, int nid, int* c,
                 obj->type  = AUTH_INFO_OID;
                 obj->grp   = oidCertExtType;
                 obj->obj   = x509->authInfo;
-                obj->objSz = x509->authInfoSz;
+                obj->objSz = (unsigned int)x509->authInfoSz;
             }
             else {
                 WOLFSSL_MSG("No Auth Info set");
@@ -2684,7 +2684,7 @@ int wolfSSL_X509_add_altname_ex(WOLFSSL_X509* x509, const char* name,
 
     newAltName->next = x509->altNames;
     newAltName->type = type;
-    newAltName->len = nameSz;
+    newAltName->len = (int)nameSz;
     newAltName->name = nameCopy;
     x509->altNames = newAltName;
 
@@ -3296,7 +3296,7 @@ char* wolfSSL_X509_NAME_oneline(WOLFSSL_X509_NAME* name, char* in, int sz)
         return NULL;
     }
 
-    copySz = min(sz, name->sz);
+    copySz = (int)min((word32)sz, (word32)name->sz);
 
     WOLFSSL_ENTER("wolfSSL_X509_NAME_oneline");
     if (!name->sz) return in;
@@ -3500,7 +3500,7 @@ char* wolfSSL_X509_get_name_oneline(WOLFSSL_X509_NAME* name, char* in, int sz)
                 WOLFSSL_MSG("Memory error");
                 return NULL;
             }
-            if ((strLen = XSNPRINTF(str, strSz, "%s=%s, ", sn, buf))
+            if ((strLen = XSNPRINTF(str, (size_t)strSz, "%s=%s, ", sn, buf))
                 >= strSz)
             {
                 WOLFSSL_MSG("buffer overrun");
@@ -3518,7 +3518,7 @@ char* wolfSSL_X509_get_name_oneline(WOLFSSL_X509_NAME* name, char* in, int sz)
                 WOLFSSL_MSG("Memory error");
                 return NULL;
             }
-            if ((strLen = XSNPRINTF(str, strSz, "%s=%s", sn, buf)) >= strSz) {
+            if ((strLen = XSNPRINTF(str, (size_t)strSz, "%s=%s", sn, buf)) >= strSz) {
                 WOLFSSL_MSG("buffer overrun");
                 XFREE(str, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                 return NULL;
@@ -3608,7 +3608,7 @@ static WOLFSSL_X509* d2i_X509orX509REQ(WOLFSSL_X509** x509,
             return NULL;
     #endif
 
-        InitDecodedCert(cert, (byte*)in, len, heap);
+        InitDecodedCert(cert, (byte*)in, (word32)len, heap);
     #ifdef WOLFSSL_CERT_REQ
         cert->isCSR = (byte)req;
     #endif
@@ -3732,7 +3732,7 @@ int wolfSSL_X509_get_signature(WOLFSSL_X509* x509,
 
     if (buf != NULL)
         XMEMCPY(buf, x509->sig.buffer, x509->sig.length);
-    *bufSz = x509->sig.length;
+    *bufSz = (int)x509->sig.length;
 
     return WOLFSSL_SUCCESS;
 }
@@ -3780,7 +3780,7 @@ int wolfSSL_X509_get_pubkey_buffer(WOLFSSL_X509* x509,
 
     der = wolfSSL_X509_get_der(x509, &derSz);
     if (der != NULL) {
-        InitDecodedCert(cert, der, derSz, NULL);
+        InitDecodedCert(cert, der, (word32)derSz, NULL);
         ret = wc_GetPubX509(cert, 0, &badDate);
         if (ret >= 0) {
             word32 idx = cert->srcIdx;
@@ -3938,12 +3938,12 @@ const unsigned char* wolfSSL_X509_get_tbs(WOLFSSL_X509* x509, int* outSz)
         return NULL;
     }
 
-    if (GetSequence(der, &idx, &len, sz) < 0) {
+    if (GetSequence(der, &idx, &len, (word32)sz) < 0) {
         return NULL;
     }
     tbs = der + idx;
     tmpIdx = idx;
-    if (GetSequence(der, &idx, &len, sz) < 0) {
+    if (GetSequence(der, &idx, &len, (word32)sz) < 0) {
         return NULL;
     }
     *outSz = len + (idx - tmpIdx);
@@ -5119,7 +5119,7 @@ WOLFSSL_X509* wolfSSL_X509_d2i_fp(WOLFSSL_X509** x509, XFILE file)
 
         fileBuffer = (byte*)XMALLOC(sz, NULL, DYNAMIC_TYPE_FILE);
         if (fileBuffer != NULL) {
-            int ret = (int)XFREAD(fileBuffer, 1, sz, file);
+            int ret = (int)XFREAD(fileBuffer, 1, (size_t)sz, file);
             if (ret == sz) {
                 newX509 = wolfSSL_X509_d2i(NULL, fileBuffer, (int)sz);
             }
@@ -5189,7 +5189,7 @@ WOLFSSL_X509* wolfSSL_X509_load_certificate_file(const char* fname, int format)
         dynamic = 1;
     }
 
-    ret = (int)XFREAD(fileBuffer, 1, sz, file);
+    ret = (int)XFREAD(fileBuffer, 1, (size_t)sz, file);
     if (ret != sz) {
         XFCLOSE(file);
         if (dynamic)
@@ -5451,7 +5451,7 @@ int wolfSSL_X509_NAME_get_text_by_NID(WOLFSSL_X509_NAME* name,
 
     /* buf is not NULL from above */
     if (text != NULL) {
-        textSz = min(textSz + 1, len); /* + 1 to account for null char */
+        textSz = (int)min((word32)textSz + 1, (word32)len); /* + 1 to account for null char */
         if (textSz > 0) {
             XMEMCPY(buf, text, textSz - 1);
             buf[textSz - 1] = '\0';
@@ -5495,7 +5495,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_X509_get_pubkey(WOLFSSL_X509* x509)
                 return NULL;
             }
             XMEMCPY(key->pkey.ptr, x509->pubKey.buffer, x509->pubKey.length);
-            key->pkey_sz = x509->pubKey.length;
+            key->pkey_sz = (int)x509->pubKey.length;
 
             #ifdef HAVE_ECC
                 key->pkey_curve = (int)x509->pkCurveOID;
@@ -5735,8 +5735,8 @@ int wolfSSL_X509_cmp(const WOLFSSL_X509 *a, const WOLFSSL_X509 *b)
 
         if (x509 != NULL) {
             if (x509->authKeyIdSet) {
-                copySz = min(dstLen != NULL ? *dstLen : 0,
-                             (int)x509->authKeyIdSz);
+                copySz = (int)min(dstLen != NULL ? (word32)*dstLen : 0,
+                                  x509->authKeyIdSz);
                 id = x509->authKeyId;
             }
 
@@ -5762,8 +5762,8 @@ int wolfSSL_X509_cmp(const WOLFSSL_X509 *a, const WOLFSSL_X509 *b)
 
         if (x509 != NULL) {
             if (x509->subjKeyIdSet) {
-                copySz = min(dstLen != NULL ? *dstLen : 0,
-                                                        (int)x509->subjKeyIdSz);
+                copySz = (int)min(dstLen != NULL ? (word32) *dstLen : 0,
+                                  x509->subjKeyIdSz);
                 id = x509->subjKeyId;
             }
 
@@ -7079,7 +7079,7 @@ void wolfSSL_X509_get0_signature(const WOLFSSL_ASN1_BIT_STRING **psig,
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)
 const char* wolfSSL_X509_verify_cert_error_string(long err)
 {
-    return wolfSSL_ERR_reason_error_string(err);
+    return wolfSSL_ERR_reason_error_string((unsigned long)err);
 }
 #endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL */
 
@@ -7683,11 +7683,11 @@ static int verifyX509orX509REQ(WOLFSSL_X509* x509, WOLFSSL_EVP_PKEY* pkey, int r
 
 #ifdef WOLFSSL_CERT_REQ
     if (req)
-        ret = CheckCSRSignaturePubKey(der, derSz, x509->heap,
+        ret = CheckCSRSignaturePubKey(der, (word32)derSz, x509->heap,
                 (unsigned char*)pkey->pkey.ptr, pkey->pkey_sz, type);
     else
 #endif
-        ret = CheckCertSignaturePubKey(der, derSz, x509->heap,
+        ret = CheckCertSignaturePubKey(der, (word32)derSz, x509->heap,
                 (unsigned char*)pkey->pkey.ptr, pkey->pkey_sz, type);
     if (ret == 0) {
         return WOLFSSL_SUCCESS;
@@ -7739,7 +7739,7 @@ static void *wolfSSL_d2i_X509_fp_ex(XFILE file, void **x509, int type)
 
     fileBuffer = (byte *)XMALLOC(sz, NULL, DYNAMIC_TYPE_FILE);
     if (fileBuffer != NULL) {
-        if ((long)XFREAD(fileBuffer, 1, sz, file) != sz) {
+        if ((long)XFREAD(fileBuffer, 1, (size_t)sz, file) != sz) {
             WOLFSSL_MSG("File read failed");
             goto err_exit;
         }
@@ -7761,7 +7761,7 @@ static void *wolfSSL_d2i_X509_fp_ex(XFILE file, void **x509, int type)
             if ((newx509 = wc_PKCS12_new()) == NULL) {
                 goto err_exit;
             }
-            if (wc_d2i_PKCS12(fileBuffer, (int)sz, (WC_PKCS12*)newx509) < 0) {
+            if (wc_d2i_PKCS12(fileBuffer, (word32)sz, (WC_PKCS12*)newx509) < 0) {
                 goto err_exit;
             }
         }
@@ -8408,7 +8408,7 @@ static int X509CRLPrintExtensions(WOLFSSL_BIO* bio, WOLFSSL_X509_CRL* crl,
                 }
                 tmp[0] = '\0';
             }
-            if (XSNPRINTF(val, valSz, ":%02X", crl->crlList->extAuthKeyId[i])
+            if (XSNPRINTF(val, (size_t)valSz, ":%02X", crl->crlList->extAuthKeyId[i])
                 >= valSz)
             {
                 WOLFSSL_MSG("buffer overrun");
@@ -8794,7 +8794,7 @@ static int wolfSSL_X509_VERIFY_PARAM_inherit(WOLFSSL_X509_VERIFY_PARAM *to,
     if (isOverWrite ||
         (from->hostName[0] != 0 && (to->hostName[0] == 0 || isDefault))) {
             if (!(ret = wolfSSL_X509_VERIFY_PARAM_set1_host(to, from->hostName,
-                (int)XSTRLEN(from->hostName))))
+                (unsigned int)XSTRLEN(from->hostName))))
                 return ret;
         to->hostFlags = from->hostFlags;
     }
@@ -9196,7 +9196,7 @@ WOLFSSL_ASN1_INTEGER* wolfSSL_X509_get_serialNumber(WOLFSSL_X509* x509)
             wolfSSL_ASN1_INTEGER_free(a);
             return NULL;
         }
-        a->dataMax   = x509->serialSz + 2;
+        a->dataMax   = (unsigned int)x509->serialSz + 2;
         a->isDynamic = 1;
     } else {
         /* Use array instead of dynamic memory */
@@ -9722,7 +9722,7 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_X509_chain_up_ref(
 
         if (ret > 0) {
             /* strip off sequence, this gets added on certificate creation */
-            ret = GetSequence(der, &idx, &length, ret);
+            ret = GetSequence(der, &idx, &length, (word32)ret);
         }
 
         if (ret > 0) {
@@ -9765,7 +9765,7 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_X509_chain_up_ref(
     #ifdef WOLFSSL_CERT_EXT
             if (req->subjKeyIdSz != 0) {
                 XMEMCPY(cert->skid, req->subjKeyId, req->subjKeyIdSz);
-                cert->skidSz = req->subjKeyIdSz;
+                cert->skidSz = (int)req->subjKeyIdSz;
             }
             if (req->keyUsageSet)
                 cert->keyUsage = req->keyUsage;
@@ -9847,7 +9847,7 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_X509_chain_up_ref(
         }
 
         out[0] = (byte) t->type;
-        sz = SetLength(t->length, out + 1) + 1;  /* gen tag */
+        sz = (int)SetLength((word32)t->length, out + 1) + 1;  /* gen tag */
         for (i = 0; i < t->length; i++) {
             out[sz + i] = t->data[i];
         }
@@ -10626,7 +10626,7 @@ cleanup:
         ret = wc_InitRng(&rng);
         if (ret != 0)
             return ret;
-        ret = wc_SignCert_ex(certBodySz, sigType, der, derSz, type, key, &rng);
+        ret = wc_SignCert_ex(certBodySz, sigType, der, (word32)derSz, type, key, &rng);
         wc_FreeRng(&rng);
         if (ret < 0) {
             WOLFSSL_LEAVE("wolfSSL_X509_resign_cert", ret);
@@ -10640,20 +10640,20 @@ cleanup:
             int    len = 0;
 
             /* Read top level sequence */
-            if (GetSequence(der, &idx, &len, derSz) < 0) {
+            if (GetSequence(der, &idx, &len, (word32)derSz) < 0) {
                 WOLFSSL_MSG("GetSequence error");
                 return WOLFSSL_FATAL_ERROR;
             }
             /* Move idx to signature */
             idx += certBodySz;
             /* Read signature algo sequence */
-            if (GetSequence(der, &idx, &len, derSz) < 0) {
+            if (GetSequence(der, &idx, &len, (word32)derSz) < 0) {
                 WOLFSSL_MSG("GetSequence error");
                 return WOLFSSL_FATAL_ERROR;
             }
             idx += len;
             /* Read signature bit string */
-            if (CheckBitString(der, &idx, &len, derSz, 0, NULL) != 0) {
+            if (CheckBitString(der, &idx, &len, (word32)derSz, 0, NULL) != 0) {
                 WOLFSSL_MSG("CheckBitString error");
                 return WOLFSSL_FATAL_ERROR;
             }
@@ -10672,7 +10672,7 @@ cleanup:
                 return WOLFSSL_FATAL_ERROR;
             }
             XMEMCPY(x509->sig.buffer, der + idx, len);
-            x509->sig.length = len;
+            x509->sig.length = (unsigned int)len;
         }
 
         /* Put in the new certificate encoding into the x509 object. */
@@ -10683,10 +10683,10 @@ cleanup:
             type = CERTREQ_TYPE;
         }
     #endif
-        if (AllocDer(&x509->derCert, derSz, type, NULL) != 0)
+        if (AllocDer(&x509->derCert, (word32)derSz, type, NULL) != 0)
             return WOLFSSL_FATAL_ERROR;
         XMEMCPY(x509->derCert->buffer, der, derSz);
-        x509->derCert->length = derSz;
+        x509->derCert->length = (word32)derSz;
 
         return ret;
     }
@@ -11010,7 +11010,7 @@ int wolfSSL_i2d_X509_NAME(WOLFSSL_X509_NAME* name, unsigned char** out)
     }
 
     /* header */
-    idx = SetSequence(totalBytes, temp);
+    idx = (int)SetSequence((word32)totalBytes, temp);
     if (totalBytes + idx > ASN_NAME_MAX) {
 #ifdef WOLFSSL_SMALL_STACK
         XFREE(names, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -11038,7 +11038,7 @@ int wolfSSL_i2d_X509_NAME(WOLFSSL_X509_NAME* name, unsigned char** out)
     }
     output = *out;
 
-    idx = SetSequence(totalBytes, output);
+    idx = (int)SetSequence((word32)totalBytes, output);
     totalBytes += idx;
     for (i = 0; i < MAX_NAME_ENTRIES; i++) {
         if (names[i].used) {
@@ -11356,7 +11356,7 @@ cleanup:
         if((PemToDer(pem, pemSz, CRL_TYPE, &der, NULL, NULL, NULL)) < 0) {
             goto err;
         }
-        derSz = der->length;
+        derSz = (int)der->length;
         if((crl = wolfSSL_d2i_X509_CRL(x, der->buffer, derSz)) == NULL) {
             goto err;
         }
@@ -11429,7 +11429,7 @@ err:
         if (pem == NULL)
             return NULL;
 
-        if ((int)XFREAD((char *)pem, 1, pemSz, fp) != pemSz)
+        if ((int)XFREAD((char *)pem, 1, (size_t)pemSz, fp) != pemSz)
             goto err_exit;
 
         switch (type) {
@@ -11442,7 +11442,7 @@ err:
             case CRL_TYPE:
                 if ((PemToDer(pem, pemSz, CRL_TYPE, &der, NULL, NULL, NULL)) < 0)
                     goto err_exit;
-                derSz = der->length;
+                derSz = (int)der->length;
                 newx509 = (void*)wolfSSL_d2i_X509_CRL((WOLFSSL_X509_CRL **)x,
                     (const unsigned char *)der->buffer, derSz);
                 if (newx509 == NULL)
@@ -12407,7 +12407,7 @@ int wolfSSL_PEM_write_bio_X509_REQ(WOLFSSL_BIO *bp, WOLFSSL_X509 *x)
     }
 
     /* get PEM size */
-    pemSz = wc_DerToPemEx(der, derSz, NULL, 0, NULL, CERTREQ_TYPE);
+    pemSz = wc_DerToPemEx(der, (word32)derSz, NULL, 0, NULL, CERTREQ_TYPE);
     if (pemSz < 0) {
         return WOLFSSL_FAILURE;
     }
@@ -12417,7 +12417,7 @@ int wolfSSL_PEM_write_bio_X509_REQ(WOLFSSL_BIO *bp, WOLFSSL_X509 *x)
     if (pem == NULL) {
         return WOLFSSL_FAILURE;
     }
-    if (wc_DerToPemEx(der, derSz, pem, pemSz, NULL, CERTREQ_TYPE) < 0) {
+    if (wc_DerToPemEx(der, (word32)derSz, pem, pemSz, NULL, CERTREQ_TYPE) < 0) {
         XFREE(pem, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         return WOLFSSL_FAILURE;
     }
@@ -12457,7 +12457,7 @@ int wolfSSL_PEM_write_bio_X509_AUX(WOLFSSL_BIO *bp, WOLFSSL_X509 *x)
     }
 
     /* get PEM size */
-    pemSz = wc_DerToPemEx(der, derSz, NULL, 0, NULL, CERT_TYPE);
+    pemSz = wc_DerToPemEx(der, (word32)derSz, NULL, 0, NULL, CERT_TYPE);
     if (pemSz < 0) {
         return WOLFSSL_FAILURE;
     }
@@ -12467,7 +12467,7 @@ int wolfSSL_PEM_write_bio_X509_AUX(WOLFSSL_BIO *bp, WOLFSSL_X509 *x)
     if (pem == NULL) {
         return WOLFSSL_FAILURE;
     }
-    if (wc_DerToPemEx(der, derSz, pem, pemSz, NULL, CERT_TYPE) < 0) {
+    if (wc_DerToPemEx(der, (word32)derSz, pem, pemSz, NULL, CERT_TYPE) < 0) {
         XFREE(pem, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         return WOLFSSL_FAILURE;
     }
@@ -12505,7 +12505,7 @@ int wolfSSL_PEM_write_bio_X509(WOLFSSL_BIO *bio, WOLFSSL_X509 *cert)
     }
 
     /* get PEM size */
-    pemSz = wc_DerToPemEx(der, derSz, NULL, 0, NULL, CERT_TYPE);
+    pemSz = wc_DerToPemEx(der, (word32)derSz, NULL, 0, NULL, CERT_TYPE);
     if (pemSz < 0) {
         goto error;
     }
@@ -12515,7 +12515,7 @@ int wolfSSL_PEM_write_bio_X509(WOLFSSL_BIO *bio, WOLFSSL_X509 *cert)
     if (pem == NULL) {
         goto error;
     }
-    if (wc_DerToPemEx(der, derSz, pem, pemSz, NULL, CERT_TYPE) < 0) {
+    if (wc_DerToPemEx(der, (word32)derSz, pem, pemSz, NULL, CERT_TYPE) < 0) {
         goto error;
     }
 
@@ -13015,7 +13015,7 @@ static int wolfSSL_EscapeString_RFC2253(char* in, word32 inSz,
     }
     out[outIdx] = '\0';
 
-    return outIdx;
+    return (int)outIdx;
 }
 
 /*
@@ -13100,7 +13100,7 @@ int wolfSSL_X509_NAME_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509_NAME* name,
         }
 
         if (i < count - 1) {
-            if (XSNPRINTF(tmp, tmpSz, "%s=%s, ", buf, nameStr)
+            if (XSNPRINTF(tmp, (size_t)tmpSz, "%s=%s, ", buf, nameStr)
                 >= tmpSz)
             {
                 WOLFSSL_MSG("buffer overrun");
@@ -13111,7 +13111,7 @@ int wolfSSL_X509_NAME_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509_NAME* name,
             tmpSz = len + nameStrSz + 3; /* 3 for '=', comma space */
         }
         else {
-            if (XSNPRINTF(tmp, tmpSz, "%s=%s", buf, nameStr)
+            if (XSNPRINTF(tmp, (size_t)tmpSz, "%s=%s", buf, nameStr)
                 >= tmpSz)
             {
                 WOLFSSL_MSG("buffer overrun");
@@ -13715,7 +13715,7 @@ int wolfSSL_X509_get_signature_nid(const WOLFSSL_X509 *x)
     if (x == NULL)
         return 0;
 
-    return oid2nid(x->sigOID, oidSigType);
+    return oid2nid((word32)x->sigOID, oidSigType);
 }
 #endif  /* OPENSSL_EXTRA */
 
@@ -13947,7 +13947,7 @@ int wolfSSL_X509_set_pubkey(WOLFSSL_X509 *cert, WOLFSSL_EVP_PKEY *pkey)
             if (p == NULL)
                 return WOLFSSL_FAILURE;
 
-            if ((derSz = wc_RsaKeyToPublicDer(rsa, p, derSz)) <= 0) {
+            if ((derSz = wc_RsaKeyToPublicDer(rsa, p, (word32)derSz)) <= 0) {
                 XFREE(p, cert->heap, DYNAMIC_TYPE_PUBLIC_KEY);
                 return WOLFSSL_FAILURE;
             }
@@ -13971,7 +13971,7 @@ int wolfSSL_X509_set_pubkey(WOLFSSL_X509 *cert, WOLFSSL_EVP_PKEY *pkey)
             if (p == NULL)
                 return WOLFSSL_FAILURE;
 
-            if ((derSz = wc_DsaKeyToPublicDer(dsa, p, derSz)) <= 0) {
+            if ((derSz = wc_DsaKeyToPublicDer(dsa, p, (word32)derSz)) <= 0) {
                 XFREE(p, cert->heap, DYNAMIC_TYPE_PUBLIC_KEY);
                 return WOLFSSL_FAILURE;
             }
@@ -13996,7 +13996,7 @@ int wolfSSL_X509_set_pubkey(WOLFSSL_X509 *cert, WOLFSSL_EVP_PKEY *pkey)
             if (p == NULL)
                 return WOLFSSL_FAILURE;
 
-            if ((derSz = wc_EccPublicKeyToDer(ecc, p, derSz, 1)) <= 0) {
+            if ((derSz = wc_EccPublicKeyToDer(ecc, p, (word32)derSz, 1)) <= 0) {
                 XFREE(p, cert->heap, DYNAMIC_TYPE_PUBLIC_KEY);
                 return WOLFSSL_FAILURE;
             }
@@ -14008,7 +14008,7 @@ int wolfSSL_X509_set_pubkey(WOLFSSL_X509 *cert, WOLFSSL_EVP_PKEY *pkey)
         return WOLFSSL_FAILURE;
     }
     cert->pubKey.buffer = p;
-    cert->pubKey.length = derSz;
+    cert->pubKey.length = (unsigned int)derSz;
 
     return WOLFSSL_SUCCESS;
 }
@@ -14213,7 +14213,7 @@ static int regenX509REQDerBuffer(WOLFSSL_X509* x509)
 
     if (wolfssl_x509_make_der(x509, 1, der, &derSz, 0) == WOLFSSL_SUCCESS) {
         FreeDer(&x509->derCert);
-        if (AllocDer(&x509->derCert, derSz, CERT_TYPE, x509->heap) == 0) {
+        if (AllocDer(&x509->derCert, (word32)derSz, CERT_TYPE, x509->heap) == 0) {
             XMEMCPY(x509->derCert->buffer, der, derSz);
             ret = WOLFSSL_SUCCESS;
         }

--- a/tests/api.c
+++ b/tests/api.c
@@ -4221,7 +4221,7 @@ static int test_wolfSSL_FPKI(void)
     if (f != XBADFILE)
         XFCLOSE(f);
 
-    wc_InitDecodedCert(&cert, buf, bytes, NULL);
+    wc_InitDecodedCert(&cert, buf, (word32)bytes, NULL);
     ExpectIntEQ(wc_ParseCert(&cert, CERT_TYPE, 0, NULL), 0);
     ExpectIntEQ(wc_GetFASCNFromCert(&cert, NULL, &fascnSz), LENGTH_ONLY_E) ;
     ExpectNotNull(fascn = (byte*)XMALLOC(fascnSz, NULL,
@@ -4256,7 +4256,7 @@ static int test_wolfSSL_OtherName(void)
     if (f != XBADFILE)
         XFCLOSE(f);
 
-    wc_InitDecodedCert(&cert, buf, bytes, NULL);
+    wc_InitDecodedCert(&cert, buf, (word32)bytes, NULL);
     ExpectIntEQ(wc_ParseCert(&cert, CERT_TYPE, 0, NULL), 0);
     wc_FreeDecodedCert(&cert);
 #endif
@@ -4301,7 +4301,7 @@ static int test_wolfSSL_CertRsaPss(void)
         XFCLOSE(f);
         f = XBADFILE;
     }
-    wc_InitDecodedCert(&cert, buf, bytes, NULL);
+    wc_InitDecodedCert(&cert, buf, (word32)bytes, NULL);
     ExpectIntEQ(wc_ParseCert(&cert, CERT_TYPE, VERIFY, cm), 0);
     wc_FreeDecodedCert(&cert);
 
@@ -4311,7 +4311,7 @@ static int test_wolfSSL_CertRsaPss(void)
     ExpectIntGT(bytes = (int)XFREAD(buf, 1, sizeof(buf), f), 0);
     if (f != XBADFILE)
         XFCLOSE(f);
-    wc_InitDecodedCert(&cert, buf, bytes, NULL);
+    wc_InitDecodedCert(&cert, buf, (word32)bytes, NULL);
     ExpectIntEQ(wc_ParseCert(&cert, CERT_TYPE, VERIFY, cm), 0);
     wc_FreeDecodedCert(&cert);
 #endif
@@ -12779,7 +12779,7 @@ static int test_wolfSSL_PKCS8(void)
         (word32)sizeof(der), NULL)), 0);
     ret = wc_ecc_init(&key);
     if (ret == 0) {
-        ret = wc_EccPrivateKeyDecode(der, &x, &key, bytes);
+        ret = wc_EccPrivateKeyDecode(der, &x, &key, (word32)bytes);
         wc_ecc_free(&key);
     }
     ExpectIntEQ(ret, 0);
@@ -19469,10 +19469,10 @@ static int test_wc_Arc4SetKey(void)
     const char* key = "\x01\x23\x45\x67\x89\xab\xcd\xef";
     int keyLen = 8;
 
-    ExpectIntEQ(wc_Arc4SetKey(&arc, (byte*)key, keyLen), 0);
+    ExpectIntEQ(wc_Arc4SetKey(&arc, (byte*)key, (word32)keyLen), 0);
     /* Test bad args. */
-    ExpectIntEQ(wc_Arc4SetKey(NULL, (byte*)key, keyLen), BAD_FUNC_ARG);
-    ExpectIntEQ(wc_Arc4SetKey(&arc, NULL      , keyLen), BAD_FUNC_ARG);
+    ExpectIntEQ(wc_Arc4SetKey(NULL, (byte*)key, (word32)keyLen), BAD_FUNC_ARG);
+    ExpectIntEQ(wc_Arc4SetKey(&arc, NULL      , (word32)keyLen), BAD_FUNC_ARG);
     ExpectIntEQ(wc_Arc4SetKey(&arc, (byte*)key, 0     ), BAD_FUNC_ARG);
 #endif
     return EXPECT_RESULT();
@@ -19504,17 +19504,17 @@ static int test_wc_Arc4Process(void)
     ExpectIntEQ(wc_Arc4Init(&enc, NULL, INVALID_DEVID), 0);
     ExpectIntEQ(wc_Arc4Init(&dec, NULL, INVALID_DEVID), 0);
 
-    ExpectIntEQ(wc_Arc4SetKey(&enc, (byte*)key, keyLen), 0);
-    ExpectIntEQ(wc_Arc4SetKey(&dec, (byte*)key, keyLen), 0);
+    ExpectIntEQ(wc_Arc4SetKey(&enc, (byte*)key, (word32)keyLen), 0);
+    ExpectIntEQ(wc_Arc4SetKey(&dec, (byte*)key, (word32)keyLen), 0);
 
-    ExpectIntEQ(wc_Arc4Process(&enc, cipher, (byte*)input, keyLen), 0);
-    ExpectIntEQ(wc_Arc4Process(&dec, plain, cipher, keyLen), 0);
+    ExpectIntEQ(wc_Arc4Process(&enc, cipher, (byte*)input, (word32)keyLen), 0);
+    ExpectIntEQ(wc_Arc4Process(&dec, plain, cipher, (word32)keyLen), 0);
     ExpectIntEQ(XMEMCMP(plain, input, keyLen), 0);
 
     /* Bad args. */
-    ExpectIntEQ(wc_Arc4Process(NULL, plain, cipher, keyLen), BAD_FUNC_ARG);
-    ExpectIntEQ(wc_Arc4Process(&dec, NULL, cipher, keyLen), BAD_FUNC_ARG);
-    ExpectIntEQ(wc_Arc4Process(&dec, plain, NULL, keyLen), BAD_FUNC_ARG);
+    ExpectIntEQ(wc_Arc4Process(NULL, plain, cipher, (word32)keyLen), BAD_FUNC_ARG);
+    ExpectIntEQ(wc_Arc4Process(&dec, NULL, cipher, (word32)keyLen), BAD_FUNC_ARG);
+    ExpectIntEQ(wc_Arc4Process(&dec, plain, NULL, (word32)keyLen), BAD_FUNC_ARG);
 
     wc_Arc4Free(&enc);
     wc_Arc4Free(&dec);
@@ -19654,14 +19654,14 @@ static int test_wc_RsaPublicKeyDecode(void)
         f = XBADFILE;
     }
     idx = 0;
-    ExpectIntEQ(wc_RsaPublicKeyDecode_ex(buf, &idx, bytes, NULL, NULL, NULL,
+    ExpectIntEQ(wc_RsaPublicKeyDecode_ex(buf, &idx, (word32)bytes, NULL, NULL, NULL,
         NULL), 0);
     ExpectTrue((f = XFOPEN(rsaPssPubKeyNoParams, "rb")) != XBADFILE);
     ExpectIntGT(bytes = (int)XFREAD(buf, 1, sizeof(buf), f), 0);
     if (f != XBADFILE)
         XFCLOSE(f);
     idx = 0;
-    ExpectIntEQ(wc_RsaPublicKeyDecode_ex(buf, &idx, bytes, NULL, NULL, NULL,
+    ExpectIntEQ(wc_RsaPublicKeyDecode_ex(buf, &idx, (word32)bytes, NULL, NULL, NULL,
         NULL), 0);
 #endif
 
@@ -19958,17 +19958,17 @@ static int test_wc_RsaPSS_Verify(void)
         WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key, &rng), 0);
 
     /* Bad cases */
-    ExpectIntEQ(wc_RsaPSS_Verify(NULL, sz, pt, outLen,
+    ExpectIntEQ(wc_RsaPSS_Verify(NULL, (word32)sz, pt, outLen,
         WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key), BAD_FUNC_ARG);
     ExpectIntEQ(wc_RsaPSS_Verify(pSignature, 0, pt, outLen,
         WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key), BAD_FUNC_ARG);
-    ExpectIntEQ(wc_RsaPSS_Verify(pSignature, sz, NULL, outLen,
+    ExpectIntEQ(wc_RsaPSS_Verify(pSignature, (word32)sz, NULL, outLen,
         WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key), BAD_FUNC_ARG);
     ExpectIntEQ(wc_RsaPSS_Verify(NULL, 0, NULL, outLen,
         WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key), BAD_FUNC_ARG);
 
     /* Good case */
-    ExpectIntGT(wc_RsaPSS_Verify(pSignature, sz, pt, outLen,
+    ExpectIntGT(wc_RsaPSS_Verify(pSignature, (word32)sz, pt, outLen,
         WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key), 0);
 
     DoExpectIntEQ(wc_FreeRsaKey(&key), 0);
@@ -20005,25 +20005,25 @@ static int test_wc_RsaPSS_VerifyCheck(void)
     ExpectIntEQ(wc_InitRng(&rng), 0);
     ExpectIntEQ(wc_RsaSetRNG(&key, &rng), 0);
     ExpectIntEQ(wc_MakeRsaKey(&key, 2048, WC_RSA_EXPONENT, &rng), 0);
-    ExpectTrue((digestSz = wc_HashGetDigestSize(WC_HASH_TYPE_SHA256)) > 0);
-    ExpectIntEQ(wc_Hash(WC_HASH_TYPE_SHA256, pSignature, sz, digest, digestSz),
+    ExpectTrue((digestSz = (word32)wc_HashGetDigestSize(WC_HASH_TYPE_SHA256)) > 0);
+    ExpectIntEQ(wc_Hash(WC_HASH_TYPE_SHA256, pSignature, (word32)sz, digest, digestSz),
         0);
 
     ExpectIntGT(sz = wc_RsaPSS_Sign(digest, digestSz, pSignature, pSignatureSz,
         WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key, &rng), 0);
 
     /* Bad cases */
-    ExpectIntEQ(wc_RsaPSS_VerifyCheck(NULL, sz, pt, outLen, digest,
+    ExpectIntEQ(wc_RsaPSS_VerifyCheck(NULL, (word32)sz, pt, outLen, digest,
         digestSz, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key), BAD_FUNC_ARG);
     ExpectIntEQ(wc_RsaPSS_VerifyCheck(pSignature, 0, pt, outLen, digest,
         digestSz, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key), BAD_FUNC_ARG);
-    ExpectIntEQ(wc_RsaPSS_VerifyCheck(pSignature, sz, NULL, outLen, digest,
+    ExpectIntEQ(wc_RsaPSS_VerifyCheck(pSignature, (word32)sz, NULL, outLen, digest,
         digestSz, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key), BAD_FUNC_ARG);
     ExpectIntEQ(wc_RsaPSS_VerifyCheck(NULL, 0, NULL, outLen, digest,
         digestSz, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key), BAD_FUNC_ARG);
 
     /* Good case */
-    ExpectIntGT(wc_RsaPSS_VerifyCheck(pSignature, sz, pt, outLen, digest,
+    ExpectIntGT(wc_RsaPSS_VerifyCheck(pSignature, (word32)sz, pt, outLen, digest,
         digestSz, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key), 0);
 
     ExpectIntEQ(wc_FreeRsaKey(&key), 0);
@@ -20058,25 +20058,25 @@ static int test_wc_RsaPSS_VerifyCheckInline(void)
     ExpectIntEQ(wc_InitRng(&rng), 0);
     ExpectIntEQ(wc_RsaSetRNG(&key, &rng), 0);
     ExpectIntEQ(wc_MakeRsaKey(&key, 2048, WC_RSA_EXPONENT, &rng), 0);
-    ExpectTrue((digestSz = wc_HashGetDigestSize(WC_HASH_TYPE_SHA256)) > 0);
-    ExpectIntEQ(wc_Hash(WC_HASH_TYPE_SHA256, pSignature, sz, digest, digestSz),
+    ExpectTrue((digestSz = (word32)wc_HashGetDigestSize(WC_HASH_TYPE_SHA256)) > 0);
+    ExpectIntEQ(wc_Hash(WC_HASH_TYPE_SHA256, pSignature, (word32)sz, digest, digestSz),
         0);
 
     ExpectIntGT(sz = wc_RsaPSS_Sign(digest, digestSz, pSignature,
         sizeof(pSignature), WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key, &rng), 0);
 
     /* Bad Cases */
-    ExpectIntEQ(wc_RsaPSS_VerifyCheckInline(NULL, sz, &pt, digest,
+    ExpectIntEQ(wc_RsaPSS_VerifyCheckInline(NULL, (word32)sz, &pt, digest,
         digestSz, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key), BAD_FUNC_ARG);
     ExpectIntEQ(wc_RsaPSS_VerifyCheckInline(pSignature, 0, NULL, digest,
         digestSz, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key), BAD_FUNC_ARG);
     ExpectIntEQ(wc_RsaPSS_VerifyCheckInline(NULL, 0, &pt, digest,
         digestSz, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key), BAD_FUNC_ARG);
-    ExpectIntEQ(wc_RsaPSS_VerifyCheckInline(pSignature, sz, &pt, digest,
+    ExpectIntEQ(wc_RsaPSS_VerifyCheckInline(pSignature, (word32)sz, &pt, digest,
         digestSz, WC_HASH_TYPE_SHA, WC_MGF1SHA256, &key), BAD_FUNC_ARG);
 
     /* Good case */
-    ExpectIntGT(wc_RsaPSS_VerifyCheckInline(pSignature, sz, &pt, digest,
+    ExpectIntGT(wc_RsaPSS_VerifyCheckInline(pSignature, (word32)sz, &pt, digest,
         digestSz, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key), 0);
 
     DoExpectIntEQ(wc_FreeRsaKey(&key), 0);
@@ -20270,7 +20270,7 @@ static int test_wc_RsaPublicEncryptDecrypt(void)
     ExpectIntEQ(MAKE_RSA_KEY(&key, bits, WC_RSA_EXPONENT, &rng), 0);
 
     /* Encrypt. */
-    ExpectIntGT(cipherLenResult = wc_RsaPublicEncrypt(in, inLen, cipher,
+    ExpectIntGT(cipherLenResult = (word32)wc_RsaPublicEncrypt(in, inLen, cipher,
         cipherLen, &key, &rng), 0);
     /* Pass bad args - tested in another testing function.*/
 
@@ -21963,7 +21963,7 @@ static int test_wc_AesEaxEncryptAuth(void)
                                      ciphertext,
                                      msg, sizeof(msg),
                                      iv, sizeof(iv),
-                                     authtag, len,
+                                     authtag, (word32)len,
                                      aad, sizeof(aad)),
                                      0);
 
@@ -21972,42 +21972,42 @@ static int test_wc_AesEaxEncryptAuth(void)
                                      ciphertext,
                                      msg, sizeof(msg),
                                      iv, sizeof(iv),
-                                     authtag, len,
+                                     authtag, (word32)len,
                                      aad, sizeof(aad)),
                                      BAD_FUNC_ARG);
     ExpectIntEQ(wc_AesEaxEncryptAuth(key, sizeof(key),
                                      NULL,
                                      msg, sizeof(msg),
                                      iv, sizeof(iv),
-                                     authtag, len,
+                                     authtag, (word32)len,
                                      aad, sizeof(aad)),
                                      BAD_FUNC_ARG);
     ExpectIntEQ(wc_AesEaxEncryptAuth(key, sizeof(key),
                                      ciphertext,
                                      NULL, sizeof(msg),
                                      iv, sizeof(iv),
-                                     authtag, len,
+                                     authtag, (word32)len,
                                      aad, sizeof(aad)),
                                      BAD_FUNC_ARG);
     ExpectIntEQ(wc_AesEaxEncryptAuth(key, sizeof(key),
                                      ciphertext,
                                      msg, sizeof(msg),
                                      NULL, sizeof(iv),
-                                     authtag, len,
+                                     authtag, (word32)len,
                                      aad, sizeof(aad)),
                                      BAD_FUNC_ARG);
     ExpectIntEQ(wc_AesEaxEncryptAuth(key, sizeof(key),
                                      ciphertext,
                                      msg, sizeof(msg),
                                      iv, sizeof(iv),
-                                     NULL, len,
+                                     NULL, (word32)len,
                                      aad, sizeof(aad)),
                                      BAD_FUNC_ARG);
     ExpectIntEQ(wc_AesEaxEncryptAuth(key, sizeof(key),
                                      ciphertext,
                                      msg, sizeof(msg),
                                      iv, sizeof(iv),
-                                     authtag, len,
+                                     authtag, (word32)len,
                                      NULL, sizeof(aad)),
                                      BAD_FUNC_ARG);
 
@@ -22022,11 +22022,11 @@ static int test_wc_AesEaxEncryptAuth(void)
             exp_ret = BAD_FUNC_ARG;
         }
 
-        ExpectIntEQ(wc_AesEaxEncryptAuth(key, i,
+        ExpectIntEQ(wc_AesEaxEncryptAuth(key, (word32)i,
                                          ciphertext,
                                          msg, sizeof(msg),
                                          iv, sizeof(iv),
-                                         authtag, len,
+                                         authtag, (word32)len,
                                          aad, sizeof(aad)),
                                          exp_ret);
     }
@@ -22038,7 +22038,7 @@ static int test_wc_AesEaxEncryptAuth(void)
                                      ciphertext,
                                      msg, sizeof(msg),
                                      iv, sizeof(iv),
-                                     authtag, len,
+                                     authtag, (word32)len,
                                      aad, sizeof(aad)),
                                      BAD_FUNC_ARG);
 
@@ -22076,7 +22076,7 @@ static int test_wc_AesEaxDecryptAuth(void)
                                      plaintext,
                                      ct, sizeof(ct),
                                      iv, sizeof(iv),
-                                     tag, len,
+                                     tag, (word32)len,
                                      aad, sizeof(aad)),
                                      AES_EAX_AUTH_E);
 
@@ -22085,42 +22085,42 @@ static int test_wc_AesEaxDecryptAuth(void)
                                      plaintext,
                                      ct, sizeof(ct),
                                      iv, sizeof(iv),
-                                     tag, len,
+                                     tag, (word32)len,
                                      aad, sizeof(aad)),
                                      BAD_FUNC_ARG);
     ExpectIntEQ(wc_AesEaxDecryptAuth(key, sizeof(key),
                                      NULL,
                                      ct, sizeof(ct),
                                      iv, sizeof(iv),
-                                     tag, len,
+                                     tag, (word32)len,
                                      aad, sizeof(aad)),
                                      BAD_FUNC_ARG);
     ExpectIntEQ(wc_AesEaxDecryptAuth(key, sizeof(key),
                                      plaintext,
                                      NULL, sizeof(ct),
                                      iv, sizeof(iv),
-                                     tag, len,
+                                     tag, (word32)len,
                                      aad, sizeof(aad)),
                                      BAD_FUNC_ARG);
     ExpectIntEQ(wc_AesEaxDecryptAuth(key, sizeof(key),
                                      plaintext,
                                      ct, sizeof(ct),
                                      NULL, sizeof(iv),
-                                     tag, len,
+                                     tag, (word32)len,
                                      aad, sizeof(aad)),
                                      BAD_FUNC_ARG);
     ExpectIntEQ(wc_AesEaxDecryptAuth(key, sizeof(key),
                                      plaintext,
                                      ct, sizeof(ct),
                                      iv, sizeof(iv),
-                                     NULL, len,
+                                     NULL, (word32)len,
                                      aad, sizeof(aad)),
                                      BAD_FUNC_ARG);
     ExpectIntEQ(wc_AesEaxDecryptAuth(key, sizeof(key),
                                      plaintext,
                                      ct, sizeof(ct),
                                      iv, sizeof(iv),
-                                     tag, len,
+                                     tag, (word32)len,
                                      NULL, sizeof(aad)),
                                      BAD_FUNC_ARG);
 
@@ -22135,11 +22135,11 @@ static int test_wc_AesEaxDecryptAuth(void)
             exp_ret = BAD_FUNC_ARG;
         }
 
-        ExpectIntEQ(wc_AesEaxDecryptAuth(key, i,
+        ExpectIntEQ(wc_AesEaxDecryptAuth(key, (word32)i,
                                          plaintext,
                                          ct, sizeof(ct),
                                          iv, sizeof(iv),
-                                         tag, len,
+                                         tag, (word32)len,
                                          aad, sizeof(aad)),
                                          exp_ret);
     }
@@ -22151,7 +22151,7 @@ static int test_wc_AesEaxDecryptAuth(void)
                                      plaintext,
                                      ct, sizeof(ct),
                                      iv, sizeof(iv),
-                                     tag, len,
+                                     tag, (word32)len,
                                      aad, sizeof(aad)),
                                      BAD_FUNC_ARG);
 
@@ -22437,14 +22437,14 @@ static int test_wc_DsaKeyToPublicDer(void)
     ExpectIntEQ(wc_MakeDsaParameters(&rng, ONEK_BUF, &key), 0);
     ExpectIntEQ(wc_MakeDsaKey(&rng, &key), 0);
 
-    ExpectIntGE(sz = wc_DsaKeyToPublicDer(&key, der, ONEK_BUF), 0);
+    ExpectIntGE(sz = (word32)wc_DsaKeyToPublicDer(&key, der, ONEK_BUF), 0);
     wc_FreeDsaKey(&key);
 
     idx = 0;
     ExpectIntEQ(wc_DsaPublicKeyDecode(der, &idx, &key, sz), 0);
 
     /* Test without the SubjectPublicKeyInfo header */
-    ExpectIntGE(sz = wc_SetDsaPublicKey(der, &key, ONEK_BUF, 0), 0);
+    ExpectIntGE(sz = (word32)wc_SetDsaPublicKey(der, &key, ONEK_BUF, 0), 0);
     wc_FreeDsaKey(&key);
     idx = 0;
     ExpectIntEQ(wc_DsaPublicKeyDecode(der, &idx, &key, sz), 0);
@@ -22727,9 +22727,9 @@ static int test_wc_ed25519_make_key(void)
     ExpectIntEQ(wc_ed25519_init(&key), 0);
     ExpectIntEQ(wc_InitRng(&rng), 0);
 
-    ExpectIntEQ(wc_ed25519_make_public(&key, pubkey, pubkey_sz),
+    ExpectIntEQ(wc_ed25519_make_public(&key, pubkey, (word32)pubkey_sz),
         ECC_PRIV_KEY_E);
-    ExpectIntEQ(wc_ed25519_make_public(&key, pubkey+1, pubkey_sz),
+    ExpectIntEQ(wc_ed25519_make_public(&key, pubkey+1, (word32)pubkey_sz),
         ECC_PRIV_KEY_E);
     ExpectIntEQ(wc_ed25519_make_key(&rng, ED25519_KEY_SIZE, &key), 0);
 
@@ -25597,7 +25597,7 @@ static int test_wc_ecc_shared_secret_ssh(void)
     int     key2Sz = KEY24;
 #endif
     byte    secret[KEY32];
-    word32  secretLen = keySz;
+    word32  secretLen = (word32)keySz;
 
     /* Init stack variables. */
     XMEMSET(&key, 0, sizeof(ecc_key));
@@ -26586,7 +26586,7 @@ static int test_wc_EccPrivateKeyToDer(void)
     ExpectIntEQ(wc_EccPrivateKeyToDer(&eccKey, NULL, inLen), LENGTH_ONLY_E);
     ExpectIntEQ(wc_EccPrivateKeyToDer(&eccKey, output, 0), BAD_FUNC_ARG);
     /* Good Case */
-    ExpectIntGT(outLen = wc_EccPrivateKeyToDer(&eccKey, output, inLen), 0);
+    ExpectIntGT(outLen = (word32)wc_EccPrivateKeyToDer(&eccKey, output, inLen), 0);
 
     wc_ecc_free(&eccKey);
     DoExpectIntEQ(wc_FreeRng(&rng), 0);
@@ -26876,8 +26876,8 @@ static int test_wc_SetSubjectBuffer(void)
         XFCLOSE(file);
 
     ExpectIntEQ(wc_InitCert(&cert), 0);
-    ExpectIntEQ(wc_SetSubjectBuffer(&cert, der, derSz), 0);
-    ExpectIntEQ(wc_SetSubjectBuffer(NULL, der, derSz), BAD_FUNC_ARG);
+    ExpectIntEQ(wc_SetSubjectBuffer(&cert, der, (int)derSz), 0);
+    ExpectIntEQ(wc_SetSubjectBuffer(NULL, der, (int)derSz), BAD_FUNC_ARG);
 
     XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
@@ -27341,13 +27341,13 @@ static int test_wc_PKCS7_EncodeData(void)
     ExpectNotNull(pkcs7 = wc_PKCS7_New(HEAP_HINT, testDevId));
     ExpectIntEQ(wc_PKCS7_Init(pkcs7, HEAP_HINT, INVALID_DEVID), 0);
 
-    ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, (byte*)cert, certSz), 0);
+    ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, (byte*)cert, (word32)certSz), 0);
 
     if (pkcs7 != NULL) {
         pkcs7->content = data;
         pkcs7->contentSz = sizeof(data);
         pkcs7->privateKey = key;
-        pkcs7->privateKeySz = keySz;
+        pkcs7->privateKeySz = (word32)keySz;
     }
     ExpectIntGT(wc_PKCS7_EncodeData(pkcs7, output, (word32)sizeof(output)), 0);
 
@@ -27629,7 +27629,7 @@ static int test_wc_PKCS7_EncodeSignedData(void)
         ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, NULL, 0), 0);
 
         /* use exact signed buffer size since BER encoded */
-        ExpectIntEQ(wc_PKCS7_VerifySignedData(pkcs7, output, signedSz), 0);
+        ExpectIntEQ(wc_PKCS7_VerifySignedData(pkcs7, output, (word32)signedSz), 0);
         wc_PKCS7_Free(pkcs7);
 
         /* now try with using callbacks for IO */
@@ -27662,7 +27662,7 @@ static int test_wc_PKCS7_EncodeSignedData(void)
         ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, NULL, 0), 0);
 
         /* use exact signed buffer size since BER encoded */
-        ExpectIntEQ(wc_PKCS7_VerifySignedData(pkcs7, strm.out, signedSz), 0);
+        ExpectIntEQ(wc_PKCS7_VerifySignedData(pkcs7, strm.out, (word32)signedSz), 0);
     }
 #endif
 #ifndef NO_PKCS7_STREAM
@@ -27757,7 +27757,7 @@ static int test_wc_PKCS7_EncodeSignedData_ex(void)
     enum wc_HashType hashType = WC_HASH_TYPE_SHA;
 #endif
     byte        hashBuf[WC_MAX_DIGEST_SIZE];
-    word32      hashSz = wc_HashGetDigestSize(hashType);
+    word32      hashSz = (word32)wc_HashGetDigestSize(hashType);
 
 #ifndef NO_RSA
     #if defined(USE_CERT_BUFFERS_2048)
@@ -28319,7 +28319,7 @@ static int CreatePKCS7SignedData(unsigned char* output, int outputSz,
         ExpectIntEQ(wc_PKCS7_SetDetached(pkcs7, 1), 0);
     }
 
-    outputSz = wc_PKCS7_EncodeSignedData(pkcs7, output, outputSz);
+    outputSz = wc_PKCS7_EncodeSignedData(pkcs7, output, (word32)outputSz);
     ExpectIntGT(outputSz, 0);
     wc_PKCS7_Free(pkcs7);
     pkcs7 = NULL;
@@ -28329,7 +28329,7 @@ static int CreatePKCS7SignedData(unsigned char* output, int outputSz,
         pkcs7->content = data;
         pkcs7->contentSz = dataSz;
     }
-    ExpectIntEQ(wc_PKCS7_VerifySignedData(pkcs7, output, outputSz), 0);
+    ExpectIntEQ(wc_PKCS7_VerifySignedData(pkcs7, output, (word32)outputSz), 0);
 
     wc_PKCS7_Free(pkcs7);
     wc_FreeRng(&rng);
@@ -28362,7 +28362,7 @@ static int test_wc_PKCS7_VerifySignedData_RSA(void)
     enum wc_HashType hashType = WC_HASH_TYPE_SHA;
 #endif
     byte        hashBuf[WC_MAX_DIGEST_SIZE];
-    word32      hashSz = wc_HashGetDigestSize(hashType);
+    word32      hashSz = (word32)wc_HashGetDigestSize(hashType);
 #ifndef NO_RSA
     PKCS7DecodedAttrib* decodedAttrib = NULL;
     /* contentType OID (1.2.840.113549.1.9.3) */
@@ -28401,7 +28401,7 @@ static int test_wc_PKCS7_VerifySignedData_RSA(void)
     XMEMSET(&hash, 0, sizeof(wc_HashAlg));
 
     /* Success test with RSA certs/key */
-    ExpectIntGT((outputSz = CreatePKCS7SignedData(output, outputSz, data,
+    ExpectIntGT((outputSz = (word32)CreatePKCS7SignedData(output, (int)outputSz, data,
         (word32)sizeof(data), 0, 0, 0, RSA_TYPE)), 0);
 
     /* calculate hash for content, used later */
@@ -28518,7 +28518,7 @@ static int test_wc_PKCS7_VerifySignedData_RSA(void)
     /* Try RSA certs/key/sig first */
     outputSz = sizeof(output);
     XMEMSET(output, 0, outputSz);
-    ExpectIntGT((outputSz = CreatePKCS7SignedData(output, outputSz, data,
+    ExpectIntGT((outputSz = (word32)CreatePKCS7SignedData(output, (int)outputSz, data,
                                                   (word32)sizeof(data),
                                                   1, 1, 0, RSA_TYPE)), 0);
     ExpectNotNull(pkcs7 = wc_PKCS7_New(HEAP_HINT, testDevId));
@@ -28609,7 +28609,7 @@ static int test_wc_PKCS7_VerifySignedData_RSA(void)
 #ifndef NO_RSA
     outputSz = sizeof(output);
     XMEMSET(output, 0, outputSz);
-    ExpectIntGT((outputSz = CreatePKCS7SignedData(output, outputSz, data,
+    ExpectIntGT((outputSz = (word32)CreatePKCS7SignedData(output, (int)outputSz, data,
                                                   (word32)sizeof(data),
                                                   0, 0, 1, RSA_TYPE)), 0);
     ExpectNotNull(pkcs7 = wc_PKCS7_New(HEAP_HINT, testDevId));
@@ -28656,7 +28656,7 @@ static int test_wc_PKCS7_VerifySignedData_RSA(void)
         ExpectNotNull(buf = (byte*)XMALLOC(signedBundleSz, HEAP_HINT,
             DYNAMIC_TYPE_FILE));
         if (buf != NULL) {
-            ExpectIntEQ(XFREAD(buf, 1, signedBundleSz, signedBundle),
+            ExpectIntEQ(XFREAD(buf, 1, (size_t)signedBundleSz, signedBundle),
                 signedBundleSz);
         }
         if (signedBundle != XBADFILE) {
@@ -28670,7 +28670,7 @@ static int test_wc_PKCS7_VerifySignedData_RSA(void)
             for (i = 0; i < signedBundleSz;) {
                 int sz = (i + chunkSz > signedBundleSz)? signedBundleSz - i :
                     chunkSz;
-                rc = wc_PKCS7_VerifySignedData(pkcs7, buf + i, sz);
+                rc = wc_PKCS7_VerifySignedData(pkcs7, buf + i, (word32)sz);
                 if (rc < 0 ) {
                     if (rc == WC_PKCS7_WANT_READ_E) {
                         i += sz;
@@ -28695,7 +28695,7 @@ static int test_wc_PKCS7_VerifySignedData_RSA(void)
             for (i = 0; i < signedBundleSz;) {
                 int sz = (i + chunkSz > signedBundleSz)? signedBundleSz - i :
                     chunkSz;
-                rc = wc_PKCS7_VerifySignedData(pkcs7, buf + i, sz);
+                rc = wc_PKCS7_VerifySignedData(pkcs7, buf + i, (word32)sz);
                 if (rc < 0 ) {
                     if (rc == WC_PKCS7_WANT_READ_E) {
                         i += sz;
@@ -28743,14 +28743,14 @@ static int test_wc_PKCS7_VerifySignedData_ECC(void)
     enum wc_HashType hashType = WC_HASH_TYPE_SHA;
 #endif
     byte        hashBuf[WC_MAX_DIGEST_SIZE];
-    word32      hashSz = wc_HashGetDigestSize(hashType);
+    word32      hashSz = (word32)wc_HashGetDigestSize(hashType);
 
     XMEMSET(&hash, 0, sizeof(wc_HashAlg));
 
     /* Success test with ECC certs/key */
     outputSz = sizeof(output);
     XMEMSET(output, 0, outputSz);
-    ExpectIntGT((outputSz = CreatePKCS7SignedData(output, outputSz, data,
+    ExpectIntGT((outputSz = (word32)CreatePKCS7SignedData(output, (int)outputSz, data,
         (word32)sizeof(data), 0, 0, 0, ECC_TYPE)), 0);
 
     ExpectNotNull(pkcs7 = wc_PKCS7_New(HEAP_HINT, testDevId));
@@ -28783,7 +28783,7 @@ static int test_wc_PKCS7_VerifySignedData_ECC(void)
      * easily change content */
     outputSz = sizeof(output);
     XMEMSET(output, 0, outputSz);
-    ExpectIntGT((outputSz = CreatePKCS7SignedData(output, outputSz, data,
+    ExpectIntGT((outputSz = (word32)CreatePKCS7SignedData(output, (int)outputSz, data,
         (word32)sizeof(data), 1, 1, 0, ECC_TYPE)), 0);
     ExpectNotNull(pkcs7 = wc_PKCS7_New(HEAP_HINT, testDevId));
     ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, NULL, 0), 0);
@@ -28877,7 +28877,7 @@ static int test_wc_PKCS7_VerifySignedData_ECC(void)
     /* Test verify on signedData containing intermediate/root CA certs */
     outputSz = sizeof(output);
     XMEMSET(output, 0, outputSz);
-    ExpectIntGT((outputSz = CreatePKCS7SignedData(output, outputSz, data,
+    ExpectIntGT((outputSz = (word32)CreatePKCS7SignedData(output, (int)outputSz, data,
         (word32)sizeof(data), 0, 0, 1, ECC_TYPE)), 0);
     ExpectNotNull(pkcs7 = wc_PKCS7_New(HEAP_HINT, testDevId));
     ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, NULL, 0), 0);
@@ -28949,7 +28949,7 @@ static int myDecryptionFunc(PKCS7* pkcs7, int encryptOID, byte* iv, int ivSz,
     if (ret == 0) {
         ret = wc_AesSetKey(&aes, (byte*)usrCtx, 32, iv, AES_DECRYPTION);
         if (ret == 0)
-            ret = wc_AesCbcDecrypt(&aes, out, in, inSz);
+            ret = wc_AesCbcDecrypt(&aes, out, in, (word32)inSz);
         wc_AesFree(&aes);
     }
 
@@ -29454,7 +29454,7 @@ static int test_wc_PKCS7_EncodeDecodeEnvelopedData(void)
         ExpectIntEQ(wc_PKCS7_SetWrapCEKCb(pkcs7, myCEKwrapFunc), 0);
         ExpectIntEQ(wc_PKCS7_SetDecodeEncryptedCb(pkcs7, myDecryptionFunc), 0);
         ExpectIntGT((decodedSz = wc_PKCS7_DecodeEnvelopedData(pkcs7, output,
-                        envelopedSz, decoded, sizeof(decoded))), 0);
+                        (word32)envelopedSz, decoded, sizeof(decoded))), 0);
         wc_PKCS7_Free(pkcs7);
         pkcs7 = NULL;
     }
@@ -29614,7 +29614,7 @@ static int test_wc_PKCS7_EncodeEncryptedData(void)
 
         /* Decode encryptedData */
         ExpectIntGT(decodedSz = wc_PKCS7_DecodeEncryptedData(pkcs7, encrypted,
-            encryptedSz, decoded, sizeof(decoded)), 0);
+            (word32)encryptedSz, decoded, sizeof(decoded)), 0);
 
         ExpectIntEQ(XMEMCMP(decoded, data, decodedSz), 0);
         /* Keep values for last itr. */
@@ -29673,15 +29673,15 @@ static int test_wc_PKCS7_EncodeEncryptedData(void)
         pkcs7->encryptionKeySz = tmpWrd32;
     }
 
-    ExpectIntEQ(wc_PKCS7_DecodeEncryptedData(NULL, encrypted, encryptedSz,
+    ExpectIntEQ(wc_PKCS7_DecodeEncryptedData(NULL, encrypted, (word32)encryptedSz,
         decoded, sizeof(decoded)), BAD_FUNC_ARG);
-    ExpectIntEQ(wc_PKCS7_DecodeEncryptedData(pkcs7, NULL, encryptedSz,
+    ExpectIntEQ(wc_PKCS7_DecodeEncryptedData(pkcs7, NULL, (word32)encryptedSz,
         decoded, sizeof(decoded)), BAD_FUNC_ARG);
     ExpectIntEQ(wc_PKCS7_DecodeEncryptedData(pkcs7, encrypted, 0,
         decoded, sizeof(decoded)), BAD_FUNC_ARG);
-    ExpectIntEQ(wc_PKCS7_DecodeEncryptedData(pkcs7, encrypted, encryptedSz,
+    ExpectIntEQ(wc_PKCS7_DecodeEncryptedData(pkcs7, encrypted, (word32)encryptedSz,
         NULL, sizeof(decoded)), BAD_FUNC_ARG);
-    ExpectIntEQ(wc_PKCS7_DecodeEncryptedData(pkcs7, encrypted, encryptedSz,
+    ExpectIntEQ(wc_PKCS7_DecodeEncryptedData(pkcs7, encrypted, (word32)encryptedSz,
         decoded, 0), BAD_FUNC_ARG);
     /* Test struct fields */
 
@@ -29689,13 +29689,13 @@ static int test_wc_PKCS7_EncodeEncryptedData(void)
         tmpBytePtr = pkcs7->encryptionKey;
         pkcs7->encryptionKey = NULL;
     }
-    ExpectIntEQ(wc_PKCS7_DecodeEncryptedData(pkcs7, encrypted, encryptedSz,
+    ExpectIntEQ(wc_PKCS7_DecodeEncryptedData(pkcs7, encrypted, (word32)encryptedSz,
         decoded, sizeof(decoded)), BAD_FUNC_ARG);
     if (pkcs7 != NULL) {
         pkcs7->encryptionKey = tmpBytePtr;
         pkcs7->encryptionKeySz = 0;
     }
-    ExpectIntEQ(wc_PKCS7_DecodeEncryptedData(pkcs7, encrypted, encryptedSz,
+    ExpectIntEQ(wc_PKCS7_DecodeEncryptedData(pkcs7, encrypted, (word32)encryptedSz,
         decoded, sizeof(decoded)), BAD_FUNC_ARG);
 
     wc_PKCS7_Free(pkcs7);
@@ -30133,18 +30133,18 @@ static int test_wc_PKCS7_signed_enveloped(void)
     /* sign cert for envelope */
     ExpectNotNull(pkcs7 = wc_PKCS7_New(NULL, 0));
     ExpectIntEQ(wc_InitRng(&rng), 0);
-    ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, cert, certSz), 0);
+    ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, cert, (word32)certSz), 0);
     if (pkcs7 != NULL) {
         pkcs7->content    = cert;
-        pkcs7->contentSz  = certSz;
+        pkcs7->contentSz  = (word32)certSz;
         pkcs7->contentOID = DATA;
         pkcs7->privateKey   = key;
-        pkcs7->privateKeySz = keySz;
+        pkcs7->privateKeySz = (word32)keySz;
         pkcs7->encryptOID   = RSAk;
         pkcs7->hashOID      = SHA256h;
         pkcs7->rng          = &rng;
     }
-    ExpectIntGT((sigSz = wc_PKCS7_EncodeSignedData(pkcs7, sig, sigSz)), 0);
+    ExpectIntGT((sigSz = wc_PKCS7_EncodeSignedData(pkcs7, sig, (word32)sigSz)), 0);
     wc_PKCS7_Free(pkcs7);
     pkcs7 = NULL;
     DoExpectIntEQ(wc_FreeRng(&rng), 0);
@@ -30152,16 +30152,16 @@ static int test_wc_PKCS7_signed_enveloped(void)
 #ifdef HAVE_AES_CBC
     /* create envelope */
     ExpectNotNull(pkcs7 = wc_PKCS7_New(NULL, 0));
-    ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, cert, certSz), 0);
+    ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, cert, (word32)certSz), 0);
     if (pkcs7 != NULL) {
         pkcs7->content   = sig;
-        pkcs7->contentSz = sigSz;
+        pkcs7->contentSz = (word32)sigSz;
         pkcs7->contentOID = DATA;
         pkcs7->encryptOID = AES256CBCb;
         pkcs7->privateKey   = key;
-        pkcs7->privateKeySz = keySz;
+        pkcs7->privateKeySz = (word32)keySz;
     }
-    ExpectIntGT((envSz = wc_PKCS7_EncodeEnvelopedData(pkcs7, env, envSz)), 0);
+    ExpectIntGT((envSz = wc_PKCS7_EncodeEnvelopedData(pkcs7, env, (word32)envSz)), 0);
     ExpectIntLT(wc_PKCS7_EncodeEnvelopedData(pkcs7, env, 2), 0);
     wc_PKCS7_Free(pkcs7);
     pkcs7 = NULL;
@@ -30171,13 +30171,13 @@ static int test_wc_PKCS7_signed_enveloped(void)
     sigSz = FOURK_BUF * 2;
     ExpectNotNull(pkcs7 = wc_PKCS7_New(NULL, 0));
     ExpectIntEQ(wc_InitRng(&rng), 0);
-    ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, cert, certSz), 0);
+    ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, cert, (word32)certSz), 0);
     if (pkcs7 != NULL) {
         pkcs7->content    = env;
-        pkcs7->contentSz  = envSz;
+        pkcs7->contentSz  = (word32)envSz;
         pkcs7->contentOID = DATA;
         pkcs7->privateKey   = key;
-        pkcs7->privateKeySz = keySz;
+        pkcs7->privateKeySz = (word32)keySz;
         pkcs7->encryptOID   = RSAk;
         pkcs7->hashOID      = SHA256h;
         pkcs7->rng = &rng;
@@ -30189,14 +30189,14 @@ static int test_wc_PKCS7_signed_enveloped(void)
         ExpectIntEQ(wc_PKCS7_SetNoCerts(NULL, 1), BAD_FUNC_ARG);
         ExpectIntEQ(wc_PKCS7_GetNoCerts(pkcs7), 1);
     }
-    ExpectIntGT((sigSz = wc_PKCS7_EncodeSignedData(pkcs7, sig, sigSz)), 0);
+    ExpectIntGT((sigSz = wc_PKCS7_EncodeSignedData(pkcs7, sig, (word32)sigSz)), 0);
     wc_PKCS7_Free(pkcs7);
     pkcs7 = NULL;
 
     /* check verify fails */
     ExpectNotNull(pkcs7 = wc_PKCS7_New(NULL, 0));
     ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, NULL, 0), 0);
-    ExpectIntEQ(wc_PKCS7_VerifySignedData(pkcs7, sig, sigSz),
+    ExpectIntEQ(wc_PKCS7_VerifySignedData(pkcs7, sig, (word32)sigSz),
             PKCS7_SIGNEEDS_CHECK);
 
     /* try verifying the signature manually */
@@ -30208,7 +30208,7 @@ static int test_wc_PKCS7_signed_enveloped(void)
         int  digestSz = 0;
 
         ExpectIntEQ(wc_InitRsaKey(&rKey, HEAP_HINT), 0);
-        ExpectIntEQ(wc_RsaPrivateKeyDecode(key, &idx, &rKey, keySz), 0);
+        ExpectIntEQ(wc_RsaPrivateKeyDecode(key, &idx, &rKey, (word32)keySz), 0);
         ExpectIntGT(digestSz = wc_RsaSSL_Verify(pkcs7->signature,
             pkcs7->signatureSz, digest, sizeof(digest), &rKey), 0);
         ExpectIntEQ(digestSz, pkcs7->pkcs7DigestSz);
@@ -30222,14 +30222,14 @@ static int test_wc_PKCS7_signed_enveloped(void)
 
     /* initializing the PKCS7 struct with the signing certificate should pass */
     ExpectNotNull(pkcs7 = wc_PKCS7_New(NULL, 0));
-    ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, cert, certSz), 0);
-    ExpectIntEQ(wc_PKCS7_VerifySignedData(pkcs7, sig, sigSz), 0);
+    ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, cert, (word32)certSz), 0);
+    ExpectIntEQ(wc_PKCS7_VerifySignedData(pkcs7, sig, (word32)sigSz), 0);
 
 #ifndef NO_PKCS7_STREAM
     wc_PKCS7_Free(pkcs7);
     pkcs7 = NULL;
     ExpectNotNull(pkcs7 = wc_PKCS7_New(HEAP_HINT, testDevId));
-    ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, cert, certSz), 0);
+    ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, cert, (word32)certSz), 0);
 
     /* test for streaming */
     ret = -1;
@@ -30250,16 +30250,16 @@ static int test_wc_PKCS7_signed_enveloped(void)
     ExpectNotNull(pkcs7 = wc_PKCS7_New(NULL, 0));
     if (pkcs7 != NULL) {
         pkcs7->content    = env;
-        pkcs7->contentSz  = envSz;
+        pkcs7->contentSz  = (word32)envSz;
         pkcs7->contentOID = DATA;
         pkcs7->privateKey   = key;
-        pkcs7->privateKeySz = keySz;
+        pkcs7->privateKeySz = (word32)keySz;
         pkcs7->encryptOID   = RSAk;
         pkcs7->hashOID      = SHA256h;
         pkcs7->rng = &rng;
     }
     ExpectIntEQ(wc_PKCS7_SetSignerIdentifierType(pkcs7, DEGENERATE_SID), 0);
-    ExpectIntGT((sigSz = wc_PKCS7_EncodeSignedData(pkcs7, sig, sigSz)), 0);
+    ExpectIntGT((sigSz = wc_PKCS7_EncodeSignedData(pkcs7, sig, (word32)sigSz)), 0);
     wc_PKCS7_Free(pkcs7);
     pkcs7 = NULL;
     wc_FreeRng(&rng);
@@ -30267,7 +30267,7 @@ static int test_wc_PKCS7_signed_enveloped(void)
     /* check verify */
     ExpectNotNull(pkcs7 = wc_PKCS7_New(NULL, 0));
     ExpectIntEQ(wc_PKCS7_Init(pkcs7, HEAP_HINT, testDevId), 0);
-    ExpectIntEQ(wc_PKCS7_VerifySignedData(pkcs7, sig, sigSz), 0);
+    ExpectIntEQ(wc_PKCS7_VerifySignedData(pkcs7, sig, (word32)sigSz), 0);
     ExpectNotNull(pkcs7->content);
 
 #ifndef NO_PKCS7_STREAM
@@ -30279,16 +30279,16 @@ static int test_wc_PKCS7_signed_enveloped(void)
     ExpectNotNull(pkcs7 = wc_PKCS7_New(NULL, 0));
     if (pkcs7 != NULL) {
         pkcs7->content    = env;
-        pkcs7->contentSz  = envSz;
+        pkcs7->contentSz  = (word32)envSz;
         pkcs7->contentOID = DATA;
         pkcs7->privateKey   = key;
-        pkcs7->privateKeySz = keySz;
+        pkcs7->privateKeySz = (word32)keySz;
         pkcs7->encryptOID   = RSAk;
         pkcs7->hashOID      = SHA256h;
         pkcs7->rng = &rng;
     }
     ExpectIntEQ(wc_PKCS7_SetSignerIdentifierType(pkcs7, DEGENERATE_SID), 0);
-    ExpectIntGT((sigSz = wc_PKCS7_EncodeSignedData(pkcs7, sig, sigSz)), 0);
+    ExpectIntGT((sigSz = wc_PKCS7_EncodeSignedData(pkcs7, sig, (word32)sigSz)), 0);
     wc_PKCS7_Free(pkcs7);
     pkcs7 = NULL;
     wc_FreeRng(&rng);
@@ -30310,13 +30310,13 @@ static int test_wc_PKCS7_signed_enveloped(void)
 #ifdef HAVE_AES_CBC
     /* check decode */
     ExpectNotNull(inner = wc_PKCS7_New(NULL, 0));
-    ExpectIntEQ(wc_PKCS7_InitWithCert(inner, cert, certSz), 0);
+    ExpectIntEQ(wc_PKCS7_InitWithCert(inner, cert, (word32)certSz), 0);
     if (inner != NULL) {
         inner->privateKey   = key;
-        inner->privateKeySz = keySz;
+        inner->privateKeySz = (word32)keySz;
     }
     ExpectIntGT((decodedSz = wc_PKCS7_DecodeEnvelopedData(inner, pkcs7->content,
-                   pkcs7->contentSz, decoded, decodedSz)), 0);
+                   pkcs7->contentSz, decoded, (word32)decodedSz)), 0);
     wc_PKCS7_Free(inner);
     inner = NULL;
 #endif
@@ -30327,7 +30327,7 @@ static int test_wc_PKCS7_signed_enveloped(void)
     /* check cert set */
     ExpectNotNull(pkcs7 = wc_PKCS7_New(NULL, 0));
     ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, NULL, 0), 0);
-    ExpectIntEQ(wc_PKCS7_VerifySignedData(pkcs7, decoded, decodedSz), 0);
+    ExpectIntEQ(wc_PKCS7_VerifySignedData(pkcs7, decoded, (word32)decodedSz), 0);
     ExpectNotNull(pkcs7->singleCert);
     ExpectIntNE(pkcs7->singleCertSz, 0);
     wc_PKCS7_Free(pkcs7);
@@ -30513,7 +30513,7 @@ static int test_wc_i2d_PKCS12(void)
         XFCLOSE(f);
 
     ExpectNotNull(pkcs12 = wc_PKCS12_new());
-    ExpectIntEQ(wc_d2i_PKCS12(der, derSz, pkcs12), 0);
+    ExpectIntEQ(wc_d2i_PKCS12(der, (word32)derSz, pkcs12), 0);
     ExpectIntEQ(wc_i2d_PKCS12(pkcs12, NULL, &outSz), LENGTH_ONLY_E);
     ExpectIntEQ(outSz, derSz);
 
@@ -31998,7 +31998,7 @@ static int test_wolfSSL_ASN1_STRING_to_UTF8(void)
     ExpectNotNull(e = wolfSSL_X509_NAME_get_entry(subject, idx));
     ExpectNotNull(a = wolfSSL_X509_NAME_ENTRY_get_data(e));
     ExpectIntEQ((len = wolfSSL_ASN1_STRING_to_UTF8(&actual_output, a)), 15);
-    ExpectIntEQ(strncmp((const char*)actual_output, targetOutput, len), 0);
+    ExpectIntEQ(strncmp((const char*)actual_output, targetOutput, (size_t)len), 0);
     a = NULL;
 
     /* wolfSSL_ASN1_STRING_to_UTF8(NULL, valid) */
@@ -32133,8 +32133,8 @@ static int test_wolfSSL_ASN1_STRING_print(void)
     /* setup */
 
     for (i = 0; i < (int)sizeof(HELLO_DATA); i++) {
-        unprintableData[i]  = HELLO_DATA[i];
-        expected[i]         = HELLO_DATA[i];
+        unprintableData[i]  = (unsigned char)HELLO_DATA[i];
+        expected[i]         = (unsigned char)HELLO_DATA[i];
     }
 
     for (i = 0; i < (int)MAX_UNPRINTABLE_CHAR; i++) {
@@ -33875,7 +33875,7 @@ static int test_wc_PemToDer(void)
     XMEMSET(&info, 0, sizeof(info));
 
     ExpectIntEQ(ret = load_file(ca_cert, &cert_buf, &cert_sz), 0);
-    ExpectIntEQ(ret = wc_PemToDer(cert_buf, cert_sz, CERT_TYPE, &pDer, NULL,
+    ExpectIntEQ(ret = wc_PemToDer(cert_buf, (long int)cert_sz, CERT_TYPE, &pDer, NULL,
         &info, &eccKey), 0);
     wc_FreeDer(&pDer);
     pDer = NULL;
@@ -34014,7 +34014,7 @@ static int test_wc_KeyPemToDer(void)
 
     /* Test normal operation */
     cert_dersz = cert_sz; /* DER will be smaller than PEM */
-    ExpectNotNull(cert_der = (byte*)malloc(cert_dersz));
+    ExpectNotNull(cert_der = (byte*)malloc((size_t)cert_dersz));
     ExpectIntGE(ret = wc_KeyPemToDer(cert_buf, cert_sz, cert_der, cert_dersz,
         cert_pw), 0);
     ExpectIntLE(ret, cert_sz);
@@ -34028,7 +34028,7 @@ static int test_wc_KeyPemToDer(void)
     ExpectIntLE(ret, cert_sz);
     if (EXPECT_SUCCESS())
         cert_dersz = ret;
-    ExpectNotNull(cert_der = (byte*)malloc(cert_dersz));
+    ExpectNotNull(cert_der = (byte*)malloc((size_t)cert_dersz));
     ExpectIntGE(ret = wc_KeyPemToDer(cert_buf, cert_sz, cert_der, cert_dersz,
         cert_pw), 0);
     ExpectIntLE(ret, cert_sz);
@@ -34065,7 +34065,7 @@ static int test_wc_PubKeyPemToDer(void)
     /* Test NULL for DER buffer to return needed DER buffer size */
     ExpectIntGT(ret = wc_PubKeyPemToDer(cert_buf, (int)cert_sz, NULL, 0), 0);
     ExpectIntLE(ret, cert_sz);
-    cert_dersz = ret;
+    cert_dersz = (size_t)ret;
     ExpectNotNull(cert_der = (byte*)malloc(cert_dersz));
     ExpectIntGE(wc_PubKeyPemToDer(cert_buf, (int)cert_sz, cert_der,
         (int)cert_dersz), 0);
@@ -34708,7 +34708,7 @@ static int test_wolfSSL_private_keys(void)
 
     /* check striping PKCS8 header with wolfSSL_d2i_PrivateKey */
     bufSz = FOURK_BUF;
-    ExpectIntGT((bufSz = wc_CreatePKCS8Key(buf, &bufSz,
+    ExpectIntGT((bufSz = (word32)wc_CreatePKCS8Key(buf, &bufSz,
                     (byte*)server_key_der_2048, sizeof_server_key_der_2048,
                     RSAk, NULL, 0)), 0);
     server_key = (const unsigned char*)buf;
@@ -35519,9 +35519,9 @@ static int test_wolfSSL_PEM_PrivateKey(void)
 
         server_key = buf;
         pkey = NULL;
-        ExpectNull(d2i_PrivateKey(EVP_PKEY_RSA, &pkey, &server_key, bytes));
+        ExpectNull(d2i_PrivateKey(EVP_PKEY_RSA, &pkey, &server_key, (long int)bytes));
         ExpectNull(pkey);
-        ExpectNotNull(d2i_PrivateKey(EVP_PKEY_EC, &pkey, &server_key, bytes));
+        ExpectNotNull(d2i_PrivateKey(EVP_PKEY_EC, &pkey, &server_key, (long int)bytes));
         ExpectIntEQ(SSL_CTX_use_PrivateKey(ctx, pkey), SSL_SUCCESS);
 
         EVP_PKEY_free(pkey);
@@ -36043,7 +36043,7 @@ static int test_DSA_do_sign_verify(void)
     XMEMSET(digest, 202, sizeof(digest));
 
     ExpectNotNull(dsa = DSA_new());
-    ExpectIntEQ(DSA_LoadDer(dsa, tmp, bytes), 1);
+    ExpectIntEQ(DSA_LoadDer(dsa, tmp, (int)bytes), 1);
 
     ExpectIntEQ(wolfSSL_DSA_do_sign(digest, sigBin, dsa), 1);
     ExpectIntEQ(wolfSSL_DSA_do_verify(digest, sigBin, dsa, &dsacheck), 1);
@@ -37095,7 +37095,7 @@ static int test_wolfSSL_X509_Name_canon(void)
     /* When output buffer is NULL, should return necessary output buffer
      * length.*/
     ExpectIntGT(wolfSSL_i2d_X509_NAME_canon(name, NULL), 0);
-    ExpectIntGT((len = wolfSSL_i2d_X509_NAME_canon(name, &pbuf)), 0);
+    ExpectIntGT((len = (word32)wolfSSL_i2d_X509_NAME_canon(name, &pbuf)), 0);
     ExpectIntEQ(wc_ShaHash((const byte*)pbuf, (word32)len, digest), 0);
 
     hash = (((unsigned long)digest[3] << 24) |
@@ -37117,7 +37117,7 @@ static int test_wolfSSL_X509_Name_canon(void)
     ExpectNotNull(x509 = PEM_read_X509(file, NULL, NULL, NULL));
     ExpectNotNull(name = X509_get_issuer_name(x509));
 
-    ExpectIntGT((len = wolfSSL_i2d_X509_NAME_canon(name, &pbuf)), 0);
+    ExpectIntGT((len = (word32)wolfSSL_i2d_X509_NAME_canon(name, &pbuf)), 0);
     ExpectIntEQ(wc_ShaHash((const byte*)pbuf, (word32)len, digest), 0);
 
     hash = (((unsigned long)digest[3] << 24) |
@@ -41607,7 +41607,7 @@ static int test_wolfSSL_X509_sign(void)
     ExpectNotNull(name = X509_get_subject_name(ca));
     cnSz = X509_NAME_get_sz(name);
     ExpectNotNull(cn = (char*)XMALLOC(cnSz, HEAP_HINT, DYNAMIC_TYPE_OPENSSL));
-    ExpectNotNull(cn = X509_NAME_oneline(name, cn, cnSz));
+    ExpectNotNull(cn = X509_NAME_oneline(name, cn, (int)cnSz));
     ExpectIntEQ(0, XSTRNCMP(cn, dCert.subject, XSTRLEN(cn)));
     XFREE(cn, HEAP_HINT, DYNAMIC_TYPE_OPENSSL);
     cn = NULL;
@@ -41629,7 +41629,7 @@ static int test_wolfSSL_X509_sign(void)
     ExpectNotNull(name = X509_get_issuer_name(x509));
     cnSz = X509_NAME_get_sz(name);
     ExpectNotNull(cn = (char*)XMALLOC(cnSz, HEAP_HINT, DYNAMIC_TYPE_OPENSSL));
-    ExpectNotNull(cn = X509_NAME_oneline(name, cn, cnSz));
+    ExpectNotNull(cn = X509_NAME_oneline(name, cn, (int)cnSz));
     /* compare and don't include the multi-attrib "/OU=OU1/OU=OU2" above */
     ExpectIntEQ(0, XSTRNCMP(cn, dCert.issuer, XSTRLEN(dCert.issuer)));
     XFREE(cn, HEAP_HINT, DYNAMIC_TYPE_OPENSSL);
@@ -43767,7 +43767,7 @@ static int test_HMAC_CTX_helper(const EVP_MD* type, unsigned char* digest,
     ExpectIntEQ(digestSz, digestSz2);
     ExpectIntEQ(XMEMCMP(digest, digest2, digestSz), 0);
 
-    *sz = digestSz;
+    *sz = (int)digestSz;
     return EXPECT_RESULT();
 }
 #endif /* defined(OPENSSL_EXTRA) && !defined(NO_HMAC) */
@@ -45028,10 +45028,10 @@ static int test_wolfSSL_RC4(void)
             XMEMSET(dec, 0, sizeof(dec));
 
             /* Encrypt */
-            wolfSSL_RC4_set_key(&rc4Key, i, key);
+            wolfSSL_RC4_set_key(&rc4Key, (int)i, key);
             wolfSSL_RC4(&rc4Key, j, data, enc);
             /* Decrypt */
-            wolfSSL_RC4_set_key(&rc4Key, i, key);
+            wolfSSL_RC4_set_key(&rc4Key, (int)i, key);
             wolfSSL_RC4(&rc4Key, j, enc, dec);
 
             ExpectIntEQ(XMEMCMP(dec, data, j), 0);
@@ -49197,9 +49197,9 @@ static int test_wolfSSL_make_cert(void)
     ExpectIntEQ((idx = X509_NAME_get_index_by_NID(x509name, NID_domainComponent,
                     -1)), 5);
     ExpectIntEQ((idx = X509_NAME_get_index_by_NID(x509name, NID_domainComponent,
-                    idx)), 6);
+                    (int)idx)), 6);
     ExpectIntEQ((idx = X509_NAME_get_index_by_NID(x509name, NID_domainComponent,
-                    idx)), -1);
+                    (int)idx)), -1);
 #endif /* WOLFSSL_MULTI_ATTRIB */
 
     /* compare DN at index 0 */
@@ -49222,13 +49222,13 @@ static int test_wolfSSL_make_cert(void)
     /* get first and second DC and compare result */
     ExpectIntEQ((idx = X509_NAME_get_index_by_NID(x509name, NID_domainComponent,
                     -1)), 5);
-    ExpectNotNull(entry = X509_NAME_get_entry(x509name, idx));
+    ExpectNotNull(entry = X509_NAME_get_entry(x509name, (int)idx));
     ExpectNotNull(entryValue = X509_NAME_ENTRY_get_data(entry));
     ExpectStrEQ((const char *)ASN1_STRING_data(entryValue), "com");
 
     ExpectIntEQ((idx = X509_NAME_get_index_by_NID(x509name, NID_domainComponent,
-                   idx)), 6);
-    ExpectNotNull(entry = X509_NAME_get_entry(x509name, idx));
+                   (int)idx)), 6);
+    ExpectNotNull(entry = X509_NAME_get_entry(x509name, (int)idx));
     ExpectNotNull(entryValue = X509_NAME_ENTRY_get_data(entry));
     ExpectStrEQ((const char *)ASN1_STRING_data(entryValue), "wolfssl");
 #endif /* WOLFSSL_MULTI_ATTRIB */
@@ -49416,7 +49416,7 @@ static int test_wolfSSL_EVP_PKEY_set1_get1_DSA(void)
 
     XMEMSET(tmp, 0, sizeof(tmp));
     XMEMCPY(tmp, dsaKeyDer , dsaKeySz);
-    bytes = dsaKeySz;
+    bytes = (word32)dsaKeySz;
 #else
     byte    tmp[TWOK_BUF];
     const unsigned char* dsaKeyDer = (const unsigned char*)tmp;
@@ -51980,7 +51980,7 @@ static int test_wolfSSL_X509V3_EXT_print(void)
             /* X509_get_ext_by_NID should return 3 for now. If that changes then
              * update the index */
             ExpectIntEQ((idx = X509_get_ext_by_NID(x509, *n, -1)), 3);
-            ExpectNotNull(ext = X509_get_ext(x509, idx));
+            ExpectNotNull(ext = X509_get_ext(x509, (int)idx));
             ExpectIntEQ(X509V3_EXT_print(bio, ext, 0, 0), 1);
             ExpectIntGT(fprintf(stderr, "\n"), 0);
         }
@@ -52733,19 +52733,19 @@ static int test_wc_CreateEncryptedPKCS8Key(void)
     PRIVATE_KEY_UNLOCK();
     /* Call with NULL for out buffer to get necessary length. */
     ExpectIntEQ(wc_CreateEncryptedPKCS8Key((byte*)server_key_der_2048,
-        sizeof_server_key_der_2048, NULL, &encKeySz, password, passwordSz,
+        sizeof_server_key_der_2048, NULL, &encKeySz, password, (int)passwordSz,
         PKCS5, PBES2, AES256CBCb, NULL, 0, WC_PKCS12_ITT_DEFAULT, &rng, NULL),
         LENGTH_ONLY_E);
     ExpectNotNull(encKey = (byte*)XMALLOC(encKeySz, HEAP_HINT,
         DYNAMIC_TYPE_TMP_BUFFER));
     /* Call with the allocated out buffer. */
     ExpectIntGT(wc_CreateEncryptedPKCS8Key((byte*)server_key_der_2048,
-        sizeof_server_key_der_2048, encKey, &encKeySz, password, passwordSz,
+        sizeof_server_key_der_2048, encKey, &encKeySz, password, (int)passwordSz,
         PKCS5, PBES2, AES256CBCb, NULL, 0, WC_PKCS12_ITT_DEFAULT, &rng, NULL),
         0);
     /* Decrypt the encrypted PKCS8 key we just made. */
-    ExpectIntGT((decKeySz = wc_DecryptPKCS8Key(encKey, encKeySz, password,
-        passwordSz)), 0);
+    ExpectIntGT((decKeySz = (word32)wc_DecryptPKCS8Key(encKey, encKeySz, password,
+        (int)passwordSz)), 0);
     /* encKey now holds the decrypted key (decrypted in place). */
     ExpectIntGT(wc_GetPkcs8TraditionalOffset(encKey, &tradIdx, decKeySz), 0);
     /* Check that the decrypted key matches the key prior to encryption. */
@@ -52777,12 +52777,12 @@ static int test_wc_GetPkcs8TraditionalOffset(void)
 
     /* valid case */
     inOutIdx = 0;
-    ExpectIntGT(length = wc_GetPkcs8TraditionalOffset(der, &inOutIdx, derSz),
+    ExpectIntGT(length = wc_GetPkcs8TraditionalOffset(der, &inOutIdx, (word32)derSz),
         0);
 
     /* inOutIdx > sz */
     inOutIdx = 4000;
-    ExpectIntEQ(length = wc_GetPkcs8TraditionalOffset(der, &inOutIdx, derSz),
+    ExpectIntEQ(length = wc_GetPkcs8TraditionalOffset(der, &inOutIdx, (word32)derSz),
         BAD_FUNC_ARG);
 
     /* null input */
@@ -52793,7 +52793,7 @@ static int test_wc_GetPkcs8TraditionalOffset(void)
     /* invalid input, fill buffer with 1's */
     XMEMSET(der, 1, sizeof(der));
     inOutIdx = 0;
-    ExpectIntEQ(length = wc_GetPkcs8TraditionalOffset(der, &inOutIdx, derSz),
+    ExpectIntEQ(length = wc_GetPkcs8TraditionalOffset(der, &inOutIdx, (word32)derSz),
         ASN_PARSE_E);
 #endif /* NO_ASN */
     return EXPECT_RESULT();
@@ -53127,7 +53127,7 @@ static int test_MakeCertWithPathLen(void)
     ExpectIntGE(derSize = wc_SignCert(cert.bodySz, cert.sigType, der,
         FOURK_BUF, NULL, &key, &rng), 0);
 
-    wc_InitDecodedCert(&decodedCert, der, derSize, NULL);
+    wc_InitDecodedCert(&decodedCert, der, (word32)derSize, NULL);
     ExpectIntEQ(wc_ParseCert(&decodedCert, CERT_TYPE, NO_VERIFY, NULL), 0);
     ExpectIntEQ(decodedCert.pathLength, expectedPathLen);
 
@@ -54174,12 +54174,12 @@ static int test_wolfssl_PKCS7(void)
     byte*  out = NULL;
 #endif
 
-    ExpectIntGT((len = CreatePKCS7SignedData(data, len, content,
+    ExpectIntGT((len = (word32)CreatePKCS7SignedData(data, (int)len, content,
         (word32)sizeof(content), 0, 0, 0, RSA_TYPE)), 0);
 
-    ExpectNull(pkcs7 = d2i_PKCS7(NULL, NULL, len));
+    ExpectNull(pkcs7 = d2i_PKCS7(NULL, NULL, (int)len));
     ExpectNull(pkcs7 = d2i_PKCS7(NULL, &p, 0));
-    ExpectNotNull(pkcs7 = d2i_PKCS7(NULL, &p, len));
+    ExpectNotNull(pkcs7 = d2i_PKCS7(NULL, &p, (int)len));
     ExpectIntEQ(wolfSSL_PKCS7_verify(NULL, NULL, NULL, NULL, NULL,
         PKCS7_NOVERIFY), WOLFSSL_FAILURE);
     PKCS7_free(pkcs7);
@@ -54187,7 +54187,7 @@ static int test_wolfssl_PKCS7(void)
 
     /* fail case, without PKCS7_NOVERIFY */
     p = data;
-    ExpectNotNull(pkcs7 = d2i_PKCS7(NULL, &p, len));
+    ExpectNotNull(pkcs7 = d2i_PKCS7(NULL, &p, (int)len));
     ExpectIntEQ(wolfSSL_PKCS7_verify(pkcs7, NULL, NULL, NULL, NULL,
         0), WOLFSSL_FAILURE);
     PKCS7_free(pkcs7);
@@ -54195,7 +54195,7 @@ static int test_wolfssl_PKCS7(void)
 
     /* success case, with PKCS7_NOVERIFY */
     p = data;
-    ExpectNotNull(pkcs7 = d2i_PKCS7(NULL, &p, len));
+    ExpectNotNull(pkcs7 = d2i_PKCS7(NULL, &p, (int)len));
     ExpectIntEQ(wolfSSL_PKCS7_verify(pkcs7, NULL, NULL, NULL, NULL,
         PKCS7_NOVERIFY), WOLFSSL_SUCCESS);
 
@@ -54303,7 +54303,7 @@ static int test_wolfSSL_PKCS7_sign(void)
         /* verify with wc_PKCS7_VerifySignedData */
         ExpectNotNull(p7Ver = wc_PKCS7_New(HEAP_HINT, testDevId));
         ExpectIntEQ(wc_PKCS7_Init(p7Ver, HEAP_HINT, INVALID_DEVID), 0);
-        ExpectIntEQ(wc_PKCS7_VerifySignedData(p7Ver, out, outLen), 0);
+        ExpectIntEQ(wc_PKCS7_VerifySignedData(p7Ver, out, (word32)outLen), 0);
 
     #ifndef NO_PKCS7_STREAM
         /* verify with wc_PKCS7_VerifySignedData streaming */
@@ -54390,7 +54390,7 @@ static int test_wolfSSL_PKCS7_sign(void)
             p7Ver->content = data;
             p7Ver->contentSz = sizeof(data);
         }
-        ExpectIntEQ(wc_PKCS7_VerifySignedData(p7Ver, out, outLen), 0);
+        ExpectIntEQ(wc_PKCS7_VerifySignedData(p7Ver, out, (word32)outLen), 0);
         wc_PKCS7_Free(p7Ver);
         p7Ver = NULL;
 
@@ -54447,7 +54447,7 @@ static int test_wolfSSL_PKCS7_sign(void)
             p7Ver->content = data;
             p7Ver->contentSz = sizeof(data);
         }
-        ExpectIntEQ(wc_PKCS7_VerifySignedData(p7Ver, out, outLen), 0);
+        ExpectIntEQ(wc_PKCS7_VerifySignedData(p7Ver, out, (word32)outLen), 0);
         wc_PKCS7_Free(p7Ver);
         p7Ver = NULL;
 
@@ -55147,7 +55147,7 @@ static int verify_sig_cm(const char* ca, byte* cert_buf, size_t cert_sz,
     (void)ca;
 #endif
 
-    ret = wolfSSL_CertManagerVerifyBuffer(cm, cert_buf, cert_sz,
+    ret = wolfSSL_CertManagerVerifyBuffer(cm, cert_buf, (long int)cert_sz,
         WOLFSSL_FILETYPE_ASN1);
     /* Let ExpectIntEQ handle return code */
 
@@ -62633,14 +62633,14 @@ static int test_ECDSA_size_sign(void)
     ExpectIntEQ(ECDSA_sign(0, hash, sizeof(hash), sig, &sigSz, NULL), 0);
     ExpectIntEQ(ECDSA_sign(0, NULL, sizeof(hash), sig, &sigSz, key), 0);
     ExpectIntEQ(ECDSA_sign(0, hash, sizeof(hash), NULL, &sigSz, key), 0);
-    ExpectIntEQ(ECDSA_verify(0, hash, sizeof(hash), sig, sigSz, NULL), 0);
-    ExpectIntEQ(ECDSA_verify(0, NULL, sizeof(hash), sig, sigSz, key), 0);
-    ExpectIntEQ(ECDSA_verify(0, hash, sizeof(hash), NULL, sigSz, key), 0);
+    ExpectIntEQ(ECDSA_verify(0, hash, sizeof(hash), sig, (int)sigSz, NULL), 0);
+    ExpectIntEQ(ECDSA_verify(0, NULL, sizeof(hash), sig, (int)sigSz, key), 0);
+    ExpectIntEQ(ECDSA_verify(0, hash, sizeof(hash), NULL, (int)sigSz, key), 0);
 
     ExpectIntEQ(ECDSA_sign(0, hash, sizeof(hash), sig, &sigSz, key), 1);
     ExpectIntGE(ECDSA_size(key), sigSz);
-    ExpectIntEQ(ECDSA_verify(0, hash, sizeof(hash), sig, sigSz, key), 1);
-    ExpectIntEQ(ECDSA_verify(0, hash2, sizeof(hash2), sig, sigSz, key), 0);
+    ExpectIntEQ(ECDSA_verify(0, hash, sizeof(hash), sig, (int)sigSz, key), 1);
+    ExpectIntEQ(ECDSA_verify(0, hash2, sizeof(hash2), sig, (int)sigSz, key), 0);
 
     ExpectNull(ECDSA_do_sign(NULL, sizeof(hash), NULL));
     ExpectNull(ECDSA_do_sign(NULL, sizeof(hash), key));
@@ -67644,7 +67644,7 @@ static int test_remove_hs_msg_from_buffer(byte *buf, int *len, byte type,
     word32 hLength;
 
     idx = buf;
-    tail_len = *len;
+    tail_len = (unsigned int)*len;
     *found = 0;
     while (tail_len > _RECORD_HEADER_SZ) {
         curr = idx;

--- a/tests/quic.c
+++ b/tests/quic.c
@@ -569,10 +569,10 @@ static int ctx_session_ticket_cb(WOLFSSL* ssl,
     }
     memset(ctx->ticket, 0, sizeof(ctx->ticket));
     ctx->ticket_len = (word32)ticketSz;
-    memcpy(ctx->ticket, ticket, ticketSz);
+    memcpy(ctx->ticket, ticket, (size_t)ticketSz);
     if (ctx->verbose) {
         printf("Session Ticket[%s]: ", ctx->name);
-        dump_buffer("", ticket, ticketSz, 4);
+        dump_buffer("", ticket, (size_t)ticketSz, 4);
     }
     return 0;
 }
@@ -931,7 +931,7 @@ static int QuicConversation_start(QuicConversation *conv, const byte *data,
         if (ret < 0) {
             int err = wolfSSL_get_error(conv->client->ssl, ret);
             char lbuffer[1024];
-            printf("EARLY DATA ret = %d, error = %d, %s\n", ret, err, wolfSSL_ERR_error_string(err, lbuffer));
+            printf("EARLY DATA ret = %d, error = %d, %s\n", ret, err, wolfSSL_ERR_error_string((unsigned long)err, lbuffer));
             AssertTrue(0);
         }
         *pwritten = (size_t)written;
@@ -991,7 +991,7 @@ static int QuicConversation_step(QuicConversation *conv, int may_fail)
                 }
             }
             else if (n > 0) {
-                conv->early_data_len += n;
+                conv->early_data_len += (size_t)n;
                 if (conv->verbose)
                     printf("RECVed early data, len now=%d\n", (int)conv->early_data_len);
             }
@@ -1382,10 +1382,10 @@ static int test_quic_resumption(int verbose) {
      * a session works. */
     AssertTrue(tclient.ticket_len > 0);
     AssertNotNull(session = wolfSSL_get1_session(tclient.ssl));
-    AssertTrue((session_size = wolfSSL_i2d_SSL_SESSION(session, NULL)) > 0);
+    AssertTrue((session_size = (unsigned int)wolfSSL_i2d_SSL_SESSION(session, NULL)) > 0);
     AssertTrue((size_t)session_size < sizeof(session_buffer));
     session_data2 = session_data = session_buffer;
-    session_size = wolfSSL_i2d_SSL_SESSION(session, &session_data);
+    session_size = (unsigned int)wolfSSL_i2d_SSL_SESSION(session, &session_data);
     session_restored = wolfSSL_d2i_SSL_SESSION(NULL, &session_data2, session_size);
     AssertNotNull(session_restored);
 
@@ -1550,7 +1550,7 @@ static int new_session_cb(WOLFSSL *ssl, WOLFSSL_SESSION *session)
         return -1;
     }
     data = ctx->session;
-    ctx->session_len = wolfSSL_i2d_SSL_SESSION(session, &data);
+    ctx->session_len = (word32)wolfSSL_i2d_SSL_SESSION(session, &data);
     if (ctx->verbose) {
         printf("[%s]", ctx->name);
         dump_buffer(" new SESSION", ctx->session, ctx->session_len, 4);

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -154,7 +154,7 @@ static int IsValidCipherSuite(const char* line, char *suite, size_t suite_spc)
                 printf("suite too long!\n");
                 return 0;
             }
-            XMEMCPY(suite, begin, len);
+            XMEMCPY(suite, begin, (size_t) len);
             suite[len] = '\0';
         }
         else
@@ -660,7 +660,7 @@ static void test_harness(void* vargs)
         return;
     }
 
-    script = (char*)malloc(sz+1);
+    script = (char*)malloc((size_t)(sz+1));
     if (script == 0) {
         fprintf(stderr, "unable to allocate script buffer\n");
         fclose(file);
@@ -668,7 +668,7 @@ static void test_harness(void* vargs)
         return;
     }
 
-    len = fread(script, 1, sz, file);
+    len = (long) fread(script, 1, (size_t)sz, file);
     if (len != sz) {
         fprintf(stderr, "read error\n");
         fclose(file);

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -41,7 +41,7 @@ char* create_tmp_dir(char *tmpDir, int len)
 
     XMEMCPY(tmpDir, TMP_DIR_PREFIX, XSTR_SIZEOF(TMP_DIR_PREFIX));
 
-    if (mymktemp(tmpDir, len, len - XSTR_SIZEOF(TMP_DIR_PREFIX)) == NULL)
+    if (mymktemp(tmpDir, len, len - (int)XSTR_SIZEOF(TMP_DIR_PREFIX)) == NULL)
         return NULL;
 
 #ifdef _MSC_VER
@@ -196,7 +196,7 @@ static WC_INLINE int test_memio_write_cb(WOLFSSL *ssl, char *data, int sz,
         }
     }
 #endif
-    XMEMCPY(buf + *len, data, sz);
+    XMEMCPY(buf + *len, data, (size_t)sz);
     *len += sz;
 
     return sz;
@@ -226,8 +226,8 @@ static WC_INLINE int test_memio_read_cb(WOLFSSL *ssl, char *data, int sz,
 
     read_sz = sz < *len ? sz : *len;
 
-    XMEMCPY(data, buf, read_sz);
-    XMEMMOVE(buf, buf + read_sz, *len - read_sz);
+    XMEMCPY(data, buf, (size_t)read_sz);
+    XMEMMOVE(buf, buf + read_sz,(size_t) (*len - read_sz));
 
     *len -= read_sz;
 

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -615,7 +615,7 @@ void file_test(const char* file, byte* check)
             fclose(f);
             return;
         }
-        ret = wc_Sha256Update(&sha256, buf, i);
+        ret = wc_Sha256Update(&sha256, buf, (word32)i);
         if (ret != 0) {
             printf("Can't wc_Sha256Update %d\n", ret);
             fclose(f);

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -3018,7 +3018,7 @@ static void* benchmarks_do(void* args)
 
 #ifndef NO_FILESYSTEM
     if (hash_input) {
-        int    rawSz;
+        size_t rawSz;
         XFILE  file;
         file = XFOPEN(hash_input, "rb");
         if (file == XBADFILE)
@@ -3037,7 +3037,7 @@ static void* benchmarks_do(void* args)
 
         XFREE(bench_plain, HEAP_HINT, DYNAMIC_TYPE_WOLF_BIGINT);
 
-        rawSz = (int)bench_buf_size;
+        rawSz = (size_t)bench_buf_size;
         if (bench_buf_size % 16)
             bench_buf_size += 16 - (bench_buf_size % 16);
 
@@ -3052,7 +3052,7 @@ static void* benchmarks_do(void* args)
         }
 
         if ((size_t)XFREAD(bench_plain, 1, rawSz, file)
-                != (size_t)rawSz) {
+                != rawSz) {
             XFCLOSE(file);
             goto exit;
         }
@@ -3064,7 +3064,7 @@ static void* benchmarks_do(void* args)
     }
 
     if (cipher_input) {
-        int    rawSz;
+        size_t rawSz;
         XFILE  file;
         file = XFOPEN(cipher_input, "rb");
         if (file == XBADFILE)
@@ -3083,7 +3083,7 @@ static void* benchmarks_do(void* args)
 
         XFREE(bench_cipher, HEAP_HINT, DYNAMIC_TYPE_WOLF_BIGINT);
 
-        rawSz = (int)bench_buf_size;
+        rawSz = (size_t)bench_buf_size;
         if (bench_buf_size % 16)
             bench_buf_size += 16 - (bench_buf_size % 16);
 
@@ -3099,7 +3099,7 @@ static void* benchmarks_do(void* args)
         }
 
         if ((size_t)XFREAD(bench_cipher, 1, rawSz, file)
-                != (size_t)rawSz) {
+                != rawSz) {
             XFCLOSE(file);
             goto exit;
         }
@@ -4743,9 +4743,9 @@ static void bench_aesecb_internal(int useDeviceID,
     double start;
     DECLARE_MULTI_VALUE_STATS_VARS()
 #ifdef HAVE_FIPS
-    const int benchSz = AES_BLOCK_SIZE;
+    const word32 benchSz = AES_BLOCK_SIZE;
 #else
-    const int benchSz = (int)bench_size;
+    const word32 benchSz = bench_size;
 #endif
 
     WC_CALLOC_ARRAY(enc, Aes, BENCH_MAX_PENDING,
@@ -4768,7 +4768,7 @@ static void bench_aesecb_internal(int useDeviceID,
 
     bench_stats_start(&count, &start);
     do {
-        int outer_loop_limit = (((int)bench_size / benchSz) * 10) + 1;
+        int outer_loop_limit = (int)((bench_size / benchSz) * 10) + 1;
         for (times = 0;
              times < outer_loop_limit /* numBlocks */ || pending > 0;
             ) {
@@ -4821,7 +4821,7 @@ exit_aes_enc:
 
     bench_stats_start(&count, &start);
     do {
-        int outer_loop_limit = (10 * ((int)bench_size / benchSz)) + 1;
+        int outer_loop_limit = (int)(10 * (bench_size / benchSz)) + 1;
         for (times = 0; times < outer_loop_limit || pending > 0; ) {
             bench_async_poll(&pending);
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -37612,7 +37612,7 @@ int VerifyCRL_Signature(SignatureCtx* sigCtx, const byte* toBeSigned,
     InitSignatureCtx(sigCtx, heap, INVALID_DEVID);
     if (ConfirmSignature(sigCtx, toBeSigned, tbsSz, ca->publicKey,
                          ca->pubKeySize, ca->keyOID, signature, sigSz,
-                         signatureOID, sigParams, sigParamsSz, NULL) != 0) {
+                         signatureOID, sigParams, (word32)sigParamsSz, NULL) != 0) {
         WOLFSSL_MSG("CRL Confirm signature failed");
         WOLFSSL_ERROR_VERBOSE(ASN_CRL_CONFIRM_E);
         return ASN_CRL_CONFIRM_E;
@@ -38336,7 +38336,7 @@ end:
                     buff);
             dcrl->sigParamsIndex =
                 dataASN[CRLASN_IDX_SIGALGO_PARAMS].offset;
-            dcrl->sigParamsLength = sigParamsSz;
+            dcrl->sigParamsLength = (word32)sigParamsSz;
         }
     #endif
 

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -564,14 +564,14 @@ int wc_PRF_TLS(byte* digest, word32 digLen, const byte* secret, word32 secLen,
         const byte* info, word32 infoLen, int digest, void* heap)
     {
         int    ret = 0;
-        int    idx = 0;
-        int    len;
+        word32 idx = 0;
+        size_t len;
         byte   *data;
 
         (void)heap;
         /* okmLen (2) + protocol|label len (1) + info len(1) + protocollen +
          * labellen + infolen */
-        len = 4 + protocolLen + labelLen + infoLen;
+        len = (size_t)4 + protocolLen + labelLen + infoLen;
 
         data = (byte*)XMALLOC(len, heap, DYNAMIC_TYPE_TMP_BUFFER);
         if (data == NULL)

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -289,7 +289,7 @@ static int wc_PKCS7_AddDataToStream(PKCS7* pkcs7, byte* in, word32 inSz,
 
     /* try to store input data into stream buffer */
     if (inSz - rdSz > 0 && pkcs7->stream->length < expected) {
-        int len = min(inSz - rdSz, expected - pkcs7->stream->length);
+        int len = (int)min(inSz - rdSz, expected - pkcs7->stream->length);
 
         /* sanity check that the input buffer is not internal buffer */
         if (in == pkcs7->stream->buffer) {
@@ -357,11 +357,11 @@ static int wc_PKCS7_SetMaxStream(PKCS7* pkcs7, byte* in, word32 defSz)
         byte*   pt;
 
         if (pkcs7->stream->length > 0) {
-            length = pkcs7->stream->length;
+            length = (int)pkcs7->stream->length;
             pt     = pkcs7->stream->buffer;
         }
         else {
-            length = defSz;
+            length = (int)defSz;
             pt     = in;
         }
         maxIdx = (word32)length;
@@ -504,7 +504,7 @@ static void wc_PKCS7_ChangeState(PKCS7* pkcs7, int newState)
             pkcs7->state, wc_PKCS7_GetStateName(pkcs7->state),
             newState, wc_PKCS7_GetStateName(newState));
 #endif
-    pkcs7->state = newState;
+    pkcs7->state = (word32)newState;
 }
 
 #define MAX_PKCS7_DIGEST_SZ (MAX_SEQ_SZ + MAX_ALGO_SZ + \
@@ -630,7 +630,7 @@ static int wc_SetContentType(int pkcs7TypeOID, byte* output, word32 outputSz)
         return BAD_FUNC_ARG;
     }
 
-    idSz  = SetLength(typeSz, ID_Length);
+    idSz  = (int)SetLength(typeSz, ID_Length);
     output[idx++] = ASN_OBJECT_ID;
     XMEMCPY(output + idx, ID_Length, idSz);
     idx += idSz;
@@ -1169,9 +1169,9 @@ int wc_PKCS7_InitWithCert(PKCS7* pkcs7, byte* derCert, word32 derCertSz)
         pkcs7->publicKeyOID = dCert->keyOID;
         XMEMCPY(pkcs7->issuerHash, dCert->issuerHash, KEYID_SIZE);
         pkcs7->issuer = dCert->issuerRaw;
-        pkcs7->issuerSz = dCert->issuerRawLen;
+        pkcs7->issuerSz = (word32)dCert->issuerRawLen;
         XMEMCPY(pkcs7->issuerSn, dCert->serial, dCert->serialSz);
-        pkcs7->issuerSnSz = dCert->serialSz;
+        pkcs7->issuerSnSz = (word32)dCert->serialSz;
         XMEMCPY(pkcs7->issuerSubjKeyId, dCert->extSubjKeyId, KEYID_SIZE);
 
         /* default to IssuerAndSerialNumber for SignerIdentifier */
@@ -1308,7 +1308,7 @@ static int wc_PKCS7_SignerInfoSetSID(PKCS7* pkcs7, byte* in, int inSz)
         return MEMORY_E;
     }
     XMEMCPY(pkcs7->signerInfo->sid, in, inSz);
-    pkcs7->signerInfo->sidSz = inSz;
+    pkcs7->signerInfo->sidSz = (word32)inSz;
     return 0;
 }
 
@@ -1556,7 +1556,7 @@ static int EncodeAttributes(EncodedAttrib* ea, int eaSz,
                                             PKCS7Attrib* attribs, int attribsSz)
 {
     int i;
-    int maxSz = min(eaSz, attribsSz);
+    int maxSz = (int)min((word32)eaSz, attribsSz);
     int allAttribsSz = 0;
 
     for (i = 0; i < maxSz; i++)
@@ -1566,14 +1566,14 @@ static int EncodeAttributes(EncodedAttrib* ea, int eaSz,
         ea[i].value = attribs[i].value;
         ea[i].valueSz = attribs[i].valueSz;
         attribSz += ea[i].valueSz;
-        ea[i].valueSetSz = SetSet(attribSz, ea[i].valueSet);
+        ea[i].valueSetSz = SetSet((word32)attribSz, ea[i].valueSet);
         attribSz += ea[i].valueSetSz;
         ea[i].oid = attribs[i].oid;
         ea[i].oidSz = attribs[i].oidSz;
         attribSz += ea[i].oidSz;
-        ea[i].valueSeqSz = SetSequence(attribSz, ea[i].valueSeq);
+        ea[i].valueSeqSz = SetSequence((word32)attribSz, ea[i].valueSeq);
         attribSz += ea[i].valueSeqSz;
-        ea[i].totalSz = attribSz;
+        ea[i].totalSz = (word32)attribSz;
 
         allAttribsSz += attribSz;
     }
@@ -1616,7 +1616,7 @@ static void FreeAttribArray(PKCS7* pkcs7, FlatAttrib** arr, int rows)
                 XFREE(arr[i], pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
             }
         }
-        ForceZero(arr, rows);
+        ForceZero(arr, (word32)rows);
         XFREE(arr, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
     }
     (void)pkcs7;
@@ -1639,12 +1639,12 @@ static int SortAttribArray(FlatAttrib** arr, int rows)
     for (i = 0; i < rows; i++) {
         a = arr[i];
         minSz = a->dataSz;
-        minIdx = i;
+        minIdx = (word32)i;
         for (j = i+1; j < rows; j++) {
             b = arr[j];
             if (b->dataSz < minSz) {
                 minSz = b->dataSz;
-                minIdx = j;
+                minIdx = (word32)j;
             }
         }
         if (minSz < a->dataSz) {
@@ -1697,7 +1697,7 @@ static int FlattenEncodedAttribs(PKCS7* pkcs7, FlatAttrib** derArr, int rows,
 
         fa = derArr[i];
         fa->data = output;
-        fa->dataSz = sz;
+        fa->dataSz = (word32)sz;
     }
 
     return 0;
@@ -1717,12 +1717,12 @@ static int FlattenAttributes(PKCS7* pkcs7, byte* output, EncodedAttrib* ea,
     }
 
     /* create array of FlatAttrib struct pointers to hold DER attribs */
-    derArr = (FlatAttrib**) XMALLOC(eaSz * sizeof(FlatAttrib*), pkcs7->heap,
+    derArr = (FlatAttrib**) XMALLOC((unsigned long)eaSz * sizeof(FlatAttrib*), pkcs7->heap,
                                     DYNAMIC_TYPE_TMP_BUFFER);
     if (derArr == NULL) {
         return MEMORY_E;
     }
-    XMEMSET(derArr, 0, eaSz * sizeof(FlatAttrib*));
+    XMEMSET(derArr, 0, (unsigned long)eaSz * sizeof(FlatAttrib*));
 
     for (i = 0; i < eaSz; i++) {
         derArr[i] = NewAttrib(pkcs7->heap);
@@ -2070,7 +2070,7 @@ static int wc_PKCS7_BuildSignedAttributes(PKCS7* pkcs7, ESD* esd,
             cannedAttribs[idx].oid     = signingTimeOid;
             cannedAttribs[idx].oidSz   = signingTimeOidSz;
             cannedAttribs[idx].value   = signingTime;
-            cannedAttribs[idx].valueSz = timeSz;
+            cannedAttribs[idx].valueSz = (word32)timeSz;
             idx++;
         }
     #endif
@@ -2080,13 +2080,13 @@ static int wc_PKCS7_BuildSignedAttributes(PKCS7* pkcs7, ESD* esd,
             cannedAttribs[idx].oid     = messageDigestOid;
             cannedAttribs[idx].oidSz   = messageDigestOidSz;
             cannedAttribs[idx].value   = esd->contentDigest;
-            cannedAttribs[idx].valueSz = hashSz + 2;  /* ASN.1 heading */
+            cannedAttribs[idx].valueSz = (word32)hashSz + 2;  /* ASN.1 heading */
             idx++;
         }
 
         esd->signedAttribsCount += cannedAttribsCount;
         esd->signedAttribsSz += EncodeAttributes(&esd->signedAttribs[atrIdx],
-            idx, cannedAttribs, cannedAttribsCount);
+            (int)idx, cannedAttribs, cannedAttribsCount);
         atrIdx += idx;
     } else {
         esd->signedAttribsCount = 0;
@@ -2332,7 +2332,7 @@ static int wc_PKCS7_BuildDigestInfo(PKCS7* pkcs7, byte* flatSignedAttribs,
     XMEMCPY(digestInfo + digIdx, esd->contentAttribsDigest, hashSz);
     digIdx += hashSz;
 
-    *digestInfoSz = digIdx;
+    *digestInfoSz = (word32)digIdx;
 
     return 0;
 }
@@ -2428,7 +2428,7 @@ static int wc_PKCS7_SignedDataBuildSignature(PKCS7* pkcs7,
             /* CMS with ECDSA does not sign DigestInfo structure
              * like PKCS#7 with RSA does */
             ret = wc_PKCS7_EcdsaSign(pkcs7, esd->contentAttribsDigest,
-                                     hashSz, esd);
+                                     (word32)hashSz, esd);
             break;
 #endif
 
@@ -2479,21 +2479,21 @@ static int wc_PKCS7_EncodeContentStreamHelper(PKCS7* pkcs7, int cipherType,
             XMEMCPY(encContentOut, contentData, contentDataSz);
             if (esd && esd->contentDigestSet != 1) {
                 ret = wc_HashUpdate(&esd->hash, esd->hashType,
-                    contentData, contentDataSz);
+                    contentData, (word32)contentDataSz);
             }
             break;
 
     #ifndef NO_AES
         case WC_CIPHER_AES_CBC:
             ret = wc_AesCbcEncrypt(aes, encContentOut,
-                contentData, contentDataSz);
+                contentData, (word32)contentDataSz);
             break;
     #endif
 
     #ifdef WOLFSSL_AESGCM_STREAM
         case WC_CIPHER_AES_GCM:
             ret = wc_AesGcmEncryptUpdate(aes, encContentOut,
-                    contentData, contentDataSz, NULL, 0);
+                    contentData, (word32)contentDataSz, NULL, 0);
             break;
     #endif
     }
@@ -2506,12 +2506,12 @@ static int wc_PKCS7_EncodeContentStreamHelper(PKCS7* pkcs7, int cipherType,
     #endif
 
     if (ret == 0) {
-        encContentOutOctSz = SetOctetString(contentDataSz, encContentOutOct);
+        encContentOutOctSz = SetOctetString((word32)contentDataSz, encContentOutOct);
         wc_PKCS7_WriteOut(pkcs7, (out)? out + *outIdx: NULL,
                           encContentOutOct, encContentOutOctSz);
         *outIdx += encContentOutOctSz;
         wc_PKCS7_WriteOut(pkcs7, (out)? out + *outIdx : NULL,
-                                            encContentOut, contentDataSz);
+                                            encContentOut, (word32)contentDataSz);
         *outIdx += contentDataSz;
     }
 
@@ -2553,7 +2553,7 @@ static int wc_PKCS7_EncodeContentStream(PKCS7* pkcs7, ESD* esd, void* aes,
 
         if (cipherType != WC_CIPHER_NONE) {
             padSz = wc_PKCS7_GetPadSize(pkcs7->contentSz,
-                   wc_PKCS7_GetOIDBlockSize(pkcs7->encryptOID));
+                   (word32)wc_PKCS7_GetOIDBlockSize(pkcs7->encryptOID));
         }
 
         if (cipherType == WC_CIPHER_NONE && esd && esd->contentDigestSet != 1) {
@@ -2635,7 +2635,7 @@ static int wc_PKCS7_EncodeContentStream(PKCS7* pkcs7, ESD* esd, void* aes,
 
                 /* copy over any remaining data */
                 XMEMCPY(contentData, buf + sz, contentDataRead);
-                idx = contentDataRead;
+                idx = (word32)contentDataRead;
             }
             else {
                 /* was not on an octet boundary, copy full
@@ -2663,7 +2663,7 @@ static int wc_PKCS7_EncodeContentStream(PKCS7* pkcs7, ESD* esd, void* aes,
 
         /* encrypt and flush out remainder of content data */
         ret = wc_PKCS7_EncodeContentStreamHelper(pkcs7, cipherType, aes,
-                    encContentOut, contentData, idx, out, &outIdx, esd);
+                    encContentOut, contentData, (int)idx, out, &outIdx, esd);
         if (ret == 0) {
             if (cipherType == WC_CIPHER_NONE && esd &&
                     esd->contentDigestSet != 1) {
@@ -2690,7 +2690,7 @@ static int wc_PKCS7_EncodeContentStream(PKCS7* pkcs7, ESD* esd, void* aes,
                     ret = wc_HashInit(&esd->hash, esd->hashType);
                     if (ret == 0)
                         ret = wc_HashUpdate(&esd->hash, esd->hashType, in,
-                                            inSz);
+                                            (word32)inSz);
                     if (ret == 0)
                         ret = wc_HashFinal(&esd->hash, esd->hashType,
                                            esd->contentDigest + 2);
@@ -2700,13 +2700,13 @@ static int wc_PKCS7_EncodeContentStream(PKCS7* pkcs7, ESD* esd, void* aes,
 
         #ifndef NO_AES
             case WC_CIPHER_AES_CBC:
-                ret = wc_AesCbcEncrypt(aes, out, in, inSz);
+                ret = wc_AesCbcEncrypt(aes, out, in, (word32)inSz);
                 break;
         #endif
 
         #ifdef WOLFSSL_AESGCM_STREAM
             case WC_CIPHER_AES_GCM:
-                ret = wc_AesGcmEncryptUpdate(aes, out, in, inSz, NULL, 0);
+                ret = wc_AesGcmEncryptUpdate(aes, out, in, (word32)inSz, NULL, 0);
                 break;
         #endif
         }
@@ -2831,7 +2831,7 @@ static int PKCS7_EncodeSigned(PKCS7* pkcs7,
             idx = ret;
             goto out;
         }
-        pkcs7->contentTypeSz = ret;
+        pkcs7->contentTypeSz = (word32)ret;
     }
 
     /* set signedData outer content type */
@@ -2840,7 +2840,7 @@ static int PKCS7_EncodeSigned(PKCS7* pkcs7,
         idx = ret;
         goto out;
     }
-    signedDataOidSz = ret;
+    signedDataOidSz = (word32)ret;
 
     if (pkcs7->sidType != DEGENERATE_SID) {
         esd->hashType = wc_OidGetHash(pkcs7->hashOID);
@@ -2886,7 +2886,7 @@ static int PKCS7_EncodeSigned(PKCS7* pkcs7,
     /* SignerIdentifier */
     if (pkcs7->sidType == CMS_ISSUER_AND_SERIAL_NUMBER) {
         /* IssuerAndSerialNumber */
-        esd->issuerSnSz = SetSerialNumber(pkcs7->issuerSn, pkcs7->issuerSnSz,
+        esd->issuerSnSz = (word32)SetSerialNumber(pkcs7->issuerSn, pkcs7->issuerSnSz,
                                           esd->issuerSn, MAX_SN_SZ, MAX_SN_SZ);
         signerInfoSz += esd->issuerSnSz;
         esd->issuerNameSz = SetSequence(pkcs7->issuerSz, esd->issuerName);
@@ -2896,22 +2896,22 @@ static int PKCS7_EncodeSigned(PKCS7* pkcs7,
 
         if (pkcs7->version == 3) {
             /* RFC 4108 version MUST be 3 for firmware package signer */
-            esd->signerVersionSz = SetMyVersion(3, esd->signerVersion, 0);
+            esd->signerVersionSz = (word32)SetMyVersion(3, esd->signerVersion, 0);
         }
         else {
             /* version MUST be 1 otherwise*/
-            esd->signerVersionSz = SetMyVersion(1, esd->signerVersion, 0);
+            esd->signerVersionSz = (word32)SetMyVersion(1, esd->signerVersion, 0);
         }
 
     } else if (pkcs7->sidType == CMS_SKID) {
         /* SubjectKeyIdentifier */
-        esd->issuerSKIDSz = SetOctetString(keyIdSize, esd->issuerSKID);
+        esd->issuerSKIDSz = SetOctetString((word32)keyIdSize, esd->issuerSKID);
         esd->issuerSKIDSeqSz = SetExplicit(0, esd->issuerSKIDSz + keyIdSize,
                                            esd->issuerSKIDSeq, 0);
         signerInfoSz += (esd->issuerSKIDSz + esd->issuerSKIDSeqSz + keyIdSize);
 
         /* version MUST be 3 */
-        esd->signerVersionSz = SetMyVersion(3, esd->signerVersion, 0);
+        esd->signerVersionSz = (word32)SetMyVersion(3, esd->signerVersion, 0);
     } else if (pkcs7->sidType == DEGENERATE_SID) {
         /* no signer info added */
     } else {
@@ -2968,7 +2968,8 @@ static int PKCS7_EncodeSigned(PKCS7* pkcs7,
         }
 
         if (pkcs7->publicKeyOID != ECDSAk && hashBuf == NULL) {
-            ret = esd->encContentDigestSz = wc_PKCS7_GetSignSize(pkcs7);
+            ret = wc_PKCS7_GetSignSize(pkcs7);
+            esd->encContentDigestSz = (word32)ret;
         }
         else {
             ret = wc_PKCS7_SignedDataBuildSignature(pkcs7, flatSignedAttribs,
@@ -3013,10 +3014,10 @@ static int PKCS7_EncodeSigned(PKCS7* pkcs7,
 
     if (pkcs7->version == 3) {
         /* RFC 4108 version MUST be 3 for firmware package signer */
-        esd->versionSz = SetMyVersion(3, esd->version, 0);
+        esd->versionSz = (word32)SetMyVersion(3, esd->version, 0);
     }
     else {
-        esd->versionSz = SetMyVersion(1, esd->version, 0);
+        esd->versionSz = (word32)SetMyVersion(1, esd->version, 0);
     }
 
     totalSz = esd->versionSz + esd->singleDigAlgoIdSz + esd->digAlgoIdSetSz +
@@ -3098,7 +3099,7 @@ static int PKCS7_EncodeSigned(PKCS7* pkcs7,
             }
         #endif
             *outputSz = totalSz;
-            idx = totalSz;
+            idx = (int)totalSz;
             goto out;
         }
         idx = BUFFER_E;
@@ -3151,7 +3152,7 @@ static int PKCS7_EncodeSigned(PKCS7* pkcs7,
 
     /* support returning header and footer without content */
     if (output2 && output2Sz) {
-        *outputSz = idx;
+        *outputSz = (word32)idx;
         idx = 0;
     }
     else {
@@ -3245,7 +3246,7 @@ static int PKCS7_EncodeSigned(PKCS7* pkcs7,
                 esd->issuerSKID, esd->issuerSKIDSz);
         idx += esd->issuerSKIDSz;
         wc_PKCS7_WriteOut(pkcs7, (output2)? (output2 + idx) : NULL,
-                pkcs7->issuerSubjKeyId, keyIdSize);
+                pkcs7->issuerSubjKeyId, (word32)keyIdSize);
         idx += keyIdSize;
     } else if (pkcs7->sidType == DEGENERATE_SID) {
         /* no signer infos in degenerate case */
@@ -3343,11 +3344,11 @@ static int PKCS7_EncodeSigned(PKCS7* pkcs7,
 #endif
 
     if (output2Sz) {
-        *output2Sz = idx;
+        *output2Sz = (word32)idx;
         idx = 0; /* success */
     }
     else {
-        *outputSz = idx;
+        *outputSz = (word32)idx;
     }
 
   out:
@@ -3519,7 +3520,7 @@ int wc_PKCS7_EncodeSignedData(PKCS7* pkcs7, byte* output, word32 outputSz)
             wc_HashFree(&hash, hashType);
         }
         if (ret == 0) {
-            ret = PKCS7_EncodeSigned(pkcs7, hashBuf, hashSz,
+            ret = PKCS7_EncodeSigned(pkcs7, hashBuf, (word32)hashSz,
                 output, &outputSz, NULL, NULL);
         }
     }
@@ -3671,7 +3672,7 @@ int wc_PKCS7_EncodeSignedEncryptedFPD(PKCS7* pkcs7, byte* encryptKey,
 
     ret = wc_InitRng_ex(&rng, pkcs7->heap, pkcs7->devId);
     if (ret != 0) {
-        ForceZero(encrypted, encryptedSz);
+        ForceZero(encrypted, (word32)encryptedSz);
         XFREE(encrypted, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         return ret;
     }
@@ -3679,7 +3680,7 @@ int wc_PKCS7_EncodeSignedEncryptedFPD(PKCS7* pkcs7, byte* encryptKey,
     /* 2: build up SignedData, encapsulating EncryptedData */
     pkcs7->rng = &rng;
     pkcs7->content = encrypted;
-    pkcs7->contentSz = encryptedSz;
+    pkcs7->contentSz = (word32)encryptedSz;
     pkcs7->contentOID = ENCRYPTED_DATA;
     pkcs7->hashOID = hashOID;
     pkcs7->encryptOID = signOID;
@@ -3693,7 +3694,7 @@ int wc_PKCS7_EncodeSignedEncryptedFPD(PKCS7* pkcs7, byte* encryptKey,
         WOLFSSL_MSG("Error encoding CMS SignedData content type");
     }
 
-    ForceZero(encrypted, encryptedSz);
+    ForceZero(encrypted, (word32)encryptedSz);
     XFREE(encrypted, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
     pkcs7->rng = NULL;
     wc_FreeRng(&rng);
@@ -4043,7 +4044,7 @@ static int wc_PKCS7_RsaVerify(PKCS7* pkcs7, byte* sig, int sigSz,
                 WC_ASYNC_FLAG_CALL_AGAIN);
     #endif
             if (ret >= 0) {
-                ret = wc_RsaSSL_Verify(sig, sigSz, digest, MAX_PKCS7_DIGEST_SZ,
+                ret = wc_RsaSSL_Verify(sig, (word32)sigSz, digest, MAX_PKCS7_DIGEST_SZ,
                     key);
             }
     #ifdef WOLFSSL_ASYNC_CRYPT
@@ -4171,7 +4172,7 @@ static int wc_PKCS7_EcdsaVerify(PKCS7* pkcs7, byte* sig, int sigSz,
                 WC_ASYNC_FLAG_CALL_AGAIN);
     #endif
             if (ret >= 0) {
-                ret = wc_ecc_verify_hash(sig, sigSz, hash, hashSz, &res, key);
+                ret = wc_ecc_verify_hash(sig, (word32)sigSz, hash, hashSz, &res, key);
             }
     #ifdef WOLFSSL_ASYNC_CRYPT
         } while (ret == WC_PENDING_E);
@@ -4250,7 +4251,7 @@ static int wc_PKCS7_BuildSignedDataDigest(PKCS7* pkcs7, byte* signedAttrib,
     ret = wc_HashGetDigestSize(hashType);
     if (ret < 0)
         return ret;
-    hashSz = ret;
+    hashSz = (word32)ret;
 
     if (signedAttribSz > 0) {
         if (signedAttrib == NULL)
@@ -4331,7 +4332,7 @@ static int wc_PKCS7_BuildSignedDataDigest(PKCS7* pkcs7, byte* signedAttrib,
     digIdx += hashSz;
 
     XMEMCPY(pkcs7Digest, digestInfo, digIdx);
-    *pkcs7DigestSz = digIdx;
+    *pkcs7DigestSz = (word32)digIdx;
 
     /* set plain digest pointer */
     *plainDigest = pkcs7Digest + digIdx - hashSz;
@@ -4423,7 +4424,7 @@ static int wc_PKCS7_VerifyContentMessageDigest(PKCS7* pkcs7,
         XMEMSET(digest, 0, MAX_PKCS7_DIGEST_SZ);
 
         content = pkcs7->content;
-        contentLen = pkcs7->contentSz;
+        contentLen = (int)pkcs7->contentSz;
 
         if (pkcs7->contentIsPkcs7Type == 1) {
             /* Content follows PKCS#7 RFC, which defines type as ANY. CMS
@@ -4436,7 +4437,7 @@ static int wc_PKCS7_VerifyContentMessageDigest(PKCS7* pkcs7,
             }
 
             if (GetLength_ex(content, &contentIdx, &contentLen,
-                    contentLen, 1) < 0) {
+                    (word32)contentLen, 1) < 0) {
                 #ifdef WOLFSSL_SMALL_STACK
                     XFREE(digest, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
                 #endif
@@ -4444,7 +4445,7 @@ static int wc_PKCS7_VerifyContentMessageDigest(PKCS7* pkcs7,
             }
         }
 
-        ret = wc_Hash(hashType, content + contentIdx, contentLen, digest,
+        ret = wc_Hash(hashType, content + contentIdx, (word32)contentLen, digest,
                       MAX_PKCS7_DIGEST_SZ);
         if (ret < 0) {
             WOLFSSL_MSG("Error hashing PKCS7 content for verification");
@@ -4625,11 +4626,11 @@ static int wc_PKCS7_SignedDataVerifySignature(PKCS7* pkcs7, byte* sig,
 
 #ifndef NO_RSA
         case RSAk:
-            ret = wc_PKCS7_RsaVerify(pkcs7, sig, sigSz, pkcs7Digest,
+            ret = wc_PKCS7_RsaVerify(pkcs7, sig, (int)sigSz, pkcs7Digest,
                                      pkcs7DigestSz);
             if (ret < 0) {
                 WOLFSSL_MSG("PKCS#7 verification failed, trying CMS");
-                ret = wc_PKCS7_RsaVerify(pkcs7, sig, sigSz, plainDigest,
+                ret = wc_PKCS7_RsaVerify(pkcs7, sig, (int)sigSz, plainDigest,
                                          plainDigestSz);
             }
             break;
@@ -4637,7 +4638,7 @@ static int wc_PKCS7_SignedDataVerifySignature(PKCS7* pkcs7, byte* sig,
 
 #ifdef HAVE_ECC
         case ECDSAk:
-            ret = wc_PKCS7_EcdsaVerify(pkcs7, sig, sigSz, plainDigest,
+            ret = wc_PKCS7_EcdsaVerify(pkcs7, sig, (int)sigSz, plainDigest,
                                        plainDigestSz);
             break;
 #endif
@@ -4683,7 +4684,7 @@ static int wc_PKCS7_SetPublicKeyOID(PKCS7* pkcs7, int sigOID)
 
         /* if sigOID is already RSAk */
         case RSAk:
-            pkcs7->publicKeyOID = sigOID;
+            pkcs7->publicKeyOID = (word32)sigOID;
             break;
     #endif
 
@@ -4695,7 +4696,7 @@ static int wc_PKCS7_SetPublicKeyOID(PKCS7* pkcs7, int sigOID)
 
         /* if sigOID is already DSAk */
         case DSAk:
-            pkcs7->publicKeyOID = sigOID;
+            pkcs7->publicKeyOID = (word32)sigOID;
             break;
     #endif
 
@@ -4715,7 +4716,7 @@ static int wc_PKCS7_SetPublicKeyOID(PKCS7* pkcs7, int sigOID)
 
         /* if sigOID is already ECDSAk */
         case ECDSAk:
-            pkcs7->publicKeyOID = sigOID;
+            pkcs7->publicKeyOID = (word32)sigOID;
             break;
     #endif
 
@@ -4759,7 +4760,7 @@ static int wc_PKCS7_ParseAttribs(PKCS7* pkcs7, byte* in, int inSz)
         int oidIdx;
         PKCS7DecodedAttrib* attrib;
 
-        if (GetSequence(in, &idx, &length, inSz) < 0)
+        if (GetSequence(in, &idx, &length, (word32)inSz) < 0)
             return ASN_PARSE_E;
 
         attrib = (PKCS7DecodedAttrib*)XMALLOC(sizeof(PKCS7DecodedAttrib),
@@ -4769,8 +4770,8 @@ static int wc_PKCS7_ParseAttribs(PKCS7* pkcs7, byte* in, int inSz)
         }
         XMEMSET(attrib, 0, sizeof(PKCS7DecodedAttrib));
 
-        oidIdx = idx;
-        if (GetObjectId(in, &idx, &oid, oidIgnoreType, inSz)
+        oidIdx = (int)idx;
+        if (GetObjectId(in, &idx, &oid, oidIgnoreType, (word32)inSz)
                 < 0) {
             XFREE(attrib, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
             return ASN_PARSE_E;
@@ -4785,7 +4786,7 @@ static int wc_PKCS7_ParseAttribs(PKCS7* pkcs7, byte* in, int inSz)
         XMEMCPY(attrib->oid, in + oidIdx, attrib->oidSz);
 
         /* Get Set that contains the printable string value */
-        if (GetSet(in, &idx, &length, inSz) < 0) {
+        if (GetSet(in, &idx, &length, (word32)inSz) < 0) {
             XFREE(attrib->oid, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
             XFREE(attrib, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
             return ASN_PARSE_E;
@@ -4994,7 +4995,7 @@ static int wc_PKCS7_ParseSignerInfo(PKCS7* pkcs7, byte* in, word32 inSz,
 
         /* store public key type based on digestEncryptionAlgorithm */
         if (ret == 0) {
-            ret = wc_PKCS7_SetPublicKeyOID(pkcs7, sigOID);
+            ret = wc_PKCS7_SetPublicKeyOID(pkcs7, (int)sigOID);
             if (ret < 0) {
                 WOLFSSL_MSG("Failed to set public key OID from signature");
             }
@@ -5089,8 +5090,8 @@ static int wc_PKCS7_HandleOctetStrings(PKCS7* pkcs7, byte* in, word32 inSz,
                 }
 
                 /* set up for next octet string */
-                pkcs7->stream->currContSz    = length;
-                pkcs7->stream->currContRmnSz = length;
+                pkcs7->stream->currContSz    = (word32)length;
+                pkcs7->stream->currContRmnSz = (word32)length;
                 pkcs7->stream->expected      = min(pkcs7->stream->currContRmnSz,
                                                    MAX_PKCS7_STREAM_BUFFER);
 
@@ -5116,7 +5117,7 @@ static int wc_PKCS7_HandleOctetStrings(PKCS7* pkcs7, byte* in, word32 inSz,
                  * in-definite length encoding.
                  * number of indef is stored in pkcs7->stream->cntIdfCnt.
                  */
-                pkcs7->stream->expected = (ASN_TAG_SZ + TRAILING_ZERO) *
+                pkcs7->stream->expected = (word32)(ASN_TAG_SZ + TRAILING_ZERO) *
                                                     pkcs7->stream->cntIdfCnt;
 
                 /* dec idx by one since already consumed to get ASN_EOC */
@@ -5477,7 +5478,7 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
                                                                           < 0)
                     ret = ASN_PARSE_E;
 
-                pkcs7->hashOID = hashOID;
+                pkcs7->hashOID = (int)hashOID;
                 /* get hash type */
                 hashType = wc_OidGetHash(pkcs7->hashOID);
 
@@ -5710,8 +5711,8 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
                         #ifndef NO_PKCS7_STREAM
                             pkcs7->stream->multi         = multiPart;
                             pkcs7->stream->currContIdx   = localIdx;
-                            pkcs7->stream->currContSz    = length;
-                            pkcs7->stream->currContRmnSz = length;
+                            pkcs7->stream->currContSz    = (word32)length;
+                            pkcs7->stream->currContRmnSz = (word32)length;
                         #endif
                             /* reset length to outer OCTET_STRING for bundle
                              * size check below */
@@ -5738,8 +5739,8 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
                     if (ret == 0) {
                         pkcs7->stream->multi         = multiPart;
                         pkcs7->stream->currContIdx   = localIdx;
-                        pkcs7->stream->currContSz    = length;
-                        pkcs7->stream->currContRmnSz = length;
+                        pkcs7->stream->currContSz    = (word32)length;
+                        pkcs7->stream->currContRmnSz = (word32)length;
                     }
                 #endif
                 }
@@ -5823,7 +5824,7 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
             if ((ret = wc_PKCS7_StreamEndCase(pkcs7, &stateIdx, &idx)) != 0) {
                 break;
             }
-            wc_PKCS7_StreamStoreVar(pkcs7, pkiMsg2Sz, localIdx, length);
+            wc_PKCS7_StreamStoreVar(pkcs7, pkiMsg2Sz, (int)localIdx, length);
 
 
         #endif /* !NO_PKCS7_STREAM */
@@ -6083,7 +6084,7 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
             }
             wc_PKCS7_StreamStoreVar(pkcs7, pkiMsg2Sz, 0, length);
             if (length > 0) {
-                pkcs7->stream->expected = length;
+                pkcs7->stream->expected = (word32)length;
             }
             else {
                 pkcs7->stream->expected = MAX_SEQ_SZ;
@@ -6121,7 +6122,7 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
 
             /* restore content */
             content   = pkcs7->stream->content;
-            contentSz = pkcs7->stream->contentSz;
+            contentSz = (int)pkcs7->stream->contentSz;
 
             /* restore detached flag */
             detached = pkcs7->stream->detached;
@@ -6141,7 +6142,7 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
                 }
                 XMEMCPY(pkcs7->stream->tmpCert, pkiMsg2 + idx, length);
                 pkiMsg2 = pkcs7->stream->tmpCert;
-                pkiMsg2Sz = length;
+                pkiMsg2Sz = (word32)length;
                 idx = 0;
             }
         #else
@@ -6211,7 +6212,7 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
                         pkcs7->isDynamic = isDynamic;
                         /* This will reset PKCS7 structure and then set the
                          * certificate */
-                        ret = wc_PKCS7_InitWithCert(pkcs7, cert, certSz);
+                        ret = wc_PKCS7_InitWithCert(pkcs7, cert, (word32)certSz);
 
                         /* Restore pkcs7->contentDynamic from above, will be
                          * freed by application with wc_PKCS7_Free() */
@@ -6240,7 +6241,7 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
                         int i;
 
                         pkcs7->cert[0]   = cert;
-                        pkcs7->certSz[0] = certSz;
+                        pkcs7->certSz[0] = (word32)certSz;
                         certIdx = idx + certSz;
 
                         for (i = 1; i < MAX_PKCS7_CERTS &&
@@ -6413,7 +6414,7 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
 
             if (in2 && in2Sz > 0 && hashBuf && hashSz > 0) {
                 if (length > 0) {
-                    pkcs7->stream->expected = length;
+                    pkcs7->stream->expected = (word32)length;
                 }
                 else {
                     pkcs7->stream->expected = 0;
@@ -6428,10 +6429,10 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
              * zero's should exist at the end of the bundle.
              */
             if (pkcs7->stream->indefLen == 1) {
-                pkcs7->stream->expected = length + 3 * ASN_INDEF_END_SZ;
+                pkcs7->stream->expected = (word32)length + 3 * ASN_INDEF_END_SZ;
             }
             else  {
-                pkcs7->stream->expected = length;
+                pkcs7->stream->expected = (word32)length;
             }
 
             wc_PKCS7_ChangeState(pkcs7, WC_PKCS7_VERIFY_STAGE7);
@@ -6462,7 +6463,7 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
 
             /* restore content */
             content   = pkcs7->stream->content;
-            contentSz = pkcs7->stream->contentSz;
+            contentSz = (int)pkcs7->stream->contentSz;
         #endif
 
             ret = wc_PKCS7_ParseSignerInfo(pkcs7, pkiMsg2, pkiMsg2Sz, &idx,
@@ -6491,11 +6492,11 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
                 }
 
                 pkcs7->content = content;
-                pkcs7->contentSz = contentSz;
+                pkcs7->contentSz = (word32)contentSz;
 
                 if (ret == 0) {
-                    ret = wc_PKCS7_SignedDataVerifySignature(pkcs7, sig, sigSz,
-                                                   signedAttrib, signedAttribSz,
+                    ret = wc_PKCS7_SignedDataVerifySignature(pkcs7, sig, (word32)sigSz,
+                                                   signedAttrib, (word32)signedAttribSz,
                                                    hashBuf, hashSz);
                 }
             }
@@ -7039,7 +7040,7 @@ static int wc_PKCS7_KariGenerateSharedInfo(WC_PKCS7_KARI* kari, int keyWrapOID)
         return BAD_FUNC_ARG;
 
     /* kekOctet */
-    kekOctetSz = SetOctetString(sizeof(word32), kekOctet);
+    kekOctetSz = (int)SetOctetString(sizeof(word32), kekOctet);
     sharedInfoSz += (kekOctetSz + sizeof(word32));
 
     /* suppPubInfo */
@@ -7050,7 +7051,7 @@ static int wc_PKCS7_KariGenerateSharedInfo(WC_PKCS7_KARI* kari, int keyWrapOID)
 
     /* optional ukm/entityInfo */
     if (kari->ukmSz > 0) {
-        entityUInfoOctetSz = SetOctetString(kari->ukmSz, entityUInfoOctet);
+        entityUInfoOctetSz = (int)SetOctetString(kari->ukmSz, entityUInfoOctet);
         sharedInfoSz += (entityUInfoOctetSz + kari->ukmSz);
 
         entityUInfoExplicitSz = SetExplicit(0, entityUInfoOctetSz +
@@ -7060,11 +7061,11 @@ static int wc_PKCS7_KariGenerateSharedInfo(WC_PKCS7_KARI* kari, int keyWrapOID)
     }
 
     /* keyInfo */
-    keyInfoSz = SetAlgoID(keyWrapOID, keyInfo, oidKeyWrapType, 0);
+    keyInfoSz = (int)SetAlgoID(keyWrapOID, keyInfo, oidKeyWrapType, 0);
     sharedInfoSz += keyInfoSz;
 
     /* sharedInfo */
-    sharedInfoSeqSz = SetSequence(sharedInfoSz, sharedInfoSeq);
+    sharedInfoSeqSz = (int)SetSequence((word32)sharedInfoSz, sharedInfoSeq);
     sharedInfoSz += sharedInfoSeqSz;
 
     kari->sharedInfo = (byte*)XMALLOC(sharedInfoSz, kari->heap,
@@ -7072,7 +7073,7 @@ static int wc_PKCS7_KariGenerateSharedInfo(WC_PKCS7_KARI* kari, int keyWrapOID)
     if (kari->sharedInfo == NULL)
         return MEMORY_E;
 
-    kari->sharedInfoSz = sharedInfoSz;
+    kari->sharedInfoSz = (word32)sharedInfoSz;
 
     XMEMCPY(kari->sharedInfo + idx, sharedInfoSeq, sharedInfoSeqSz);
     idx += sharedInfoSeqSz;
@@ -7134,7 +7135,7 @@ static int wc_PKCS7_KariGenerateKEK(WC_PKCS7_KARI* kari, WC_RNG* rng,
         return ret;
 
     /* generate shared secret */
-    secretSz = kari->senderKey->dp->size;
+    secretSz = (word32)kari->senderKey->dp->size;
     secret = (byte*)XMALLOC(secretSz, kari->heap, DYNAMIC_TYPE_PKCS7);
     if (secret == NULL)
         return MEMORY_E;
@@ -7323,7 +7324,7 @@ int wc_PKCS7_AddRecipient_KARI(PKCS7* pkcs7, const byte* cert, word32 certSz,
     }
 
     /* generate random content encryption key, if needed */
-    ret = PKCS7_GenerateContentEncryptionKey(pkcs7, blockKeySz);
+    ret = PKCS7_GenerateContentEncryptionKey(pkcs7, (word32)blockKeySz);
     if (ret < 0) {
 #ifdef WOLFSSL_SMALL_STACK
         XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
@@ -7422,11 +7423,11 @@ int wc_PKCS7_AddRecipient_KARI(PKCS7* pkcs7, const byte* cert, word32 certSz,
     /* Start of RecipientEncryptedKeys */
 
     /* EncryptedKey */
-    encryptedKeyOctetSz = SetOctetString(encryptedKeySz, encryptedKeyOctet);
+    encryptedKeyOctetSz = (int)SetOctetString(encryptedKeySz, encryptedKeyOctet);
     totalSz += (encryptedKeyOctetSz + encryptedKeySz);
 
     /* SubjectKeyIdentifier */
-    subjKeyIdOctetSz = SetOctetString(keyIdSize, subjKeyIdOctet);
+    subjKeyIdOctetSz = (int)SetOctetString((word32)keyIdSize, subjKeyIdOctet);
     totalSz += (subjKeyIdOctetSz + keyIdSize);
 
     /* RecipientKeyIdentifier IMPLICIT [0] */
@@ -7435,17 +7436,17 @@ int wc_PKCS7_AddRecipient_KARI(PKCS7* pkcs7, const byte* cert, word32 certSz,
     totalSz += recipKeyIdSeqSz;
 
     /* RecipientEncryptedKey */
-    recipEncKeySeqSz = SetSequence(totalSz, recipEncKeySeq);
+    recipEncKeySeqSz = (int)SetSequence((word32)totalSz, recipEncKeySeq);
     totalSz += recipEncKeySeqSz;
 
     /* RecipientEncryptedKeys */
-    recipEncKeysSeqSz = SetSequence(totalSz, recipEncKeysSeq);
+    recipEncKeysSeqSz = (int)SetSequence((word32)totalSz, recipEncKeysSeq);
     totalSz += recipEncKeysSeqSz;
 
     /* Start of optional UserKeyingMaterial */
 
     if (kari->ukmSz > 0) {
-        ukmOctetSz = SetOctetString(kari->ukmSz, ukmOctetStr);
+        ukmOctetSz = (int)SetOctetString(kari->ukmSz, ukmOctetStr);
         totalSz += (ukmOctetSz + kari->ukmSz);
 
         ukmExplicitSz = SetExplicit(1, ukmOctetSz + kari->ukmSz,
@@ -7456,11 +7457,11 @@ int wc_PKCS7_AddRecipient_KARI(PKCS7* pkcs7, const byte* cert, word32 certSz,
     /* Start of KeyEncryptionAlgorithmIdentifier */
 
     /* KeyWrapAlgorithm */
-    keyWrapAlgSz = SetAlgoID(keyWrapOID, keyWrapAlg, oidKeyWrapType, 0);
+    keyWrapAlgSz = (int)SetAlgoID(keyWrapOID, keyWrapAlg, oidKeyWrapType, 0);
     totalSz += keyWrapAlgSz;
 
     /* KeyEncryptionAlgorithmIdentifier */
-    keyEncryptAlgoIdSz = SetAlgoID(keyAgreeOID, keyEncryptAlgoId,
+    keyEncryptAlgoIdSz = (int)SetAlgoID(keyAgreeOID, keyEncryptAlgoId,
                                    oidCmsKeyAgreeType, keyWrapAlgSz);
     totalSz += keyEncryptAlgoIdSz;
 
@@ -7469,25 +7470,25 @@ int wc_PKCS7_AddRecipient_KARI(PKCS7* pkcs7, const byte* cert, word32 certSz,
     /* recipient ECPoint, public key */
     XMEMSET(origPubKeyStr, 0, sizeof(origPubKeyStr)); /* no unused bits */
     origPubKeyStr[0] = ASN_BIT_STRING;
-    origPubKeyStrSz = SetLength(kari->senderKeyExportSz + 1,
+    origPubKeyStrSz = (int)SetLength(kari->senderKeyExportSz + 1,
                                 origPubKeyStr + 1) + 2;
     totalSz += (origPubKeyStrSz + kari->senderKeyExportSz);
 
     /* Originator AlgorithmIdentifier, params set to NULL for interop
        compatibility */
-    origAlgIdSz = SetAlgoID(ECDSAk, origAlgId, oidKeyType, 2);
+    origAlgIdSz = (int)SetAlgoID(ECDSAk, origAlgId, oidKeyType, 2);
     origAlgId[origAlgIdSz++] = ASN_TAG_NULL;
     origAlgId[origAlgIdSz++] = 0;
     totalSz += origAlgIdSz;
 
     /* outer OriginatorPublicKey IMPLICIT [1] */
-    origPubKeySeqSz = SetImplicit(ASN_SEQUENCE, 1,
+    origPubKeySeqSz = (int)SetImplicit(ASN_SEQUENCE, 1,
                                   origAlgIdSz + origPubKeyStrSz +
                                   kari->senderKeyExportSz, origPubKeySeq, 0);
     totalSz += origPubKeySeqSz;
 
     /* outer OriginatorIdentifierOrKey IMPLICIT [0] */
-    origIdOrKeySeqSz = SetImplicit(ASN_SEQUENCE, 0,
+    origIdOrKeySeqSz = (int)SetImplicit(ASN_SEQUENCE, 0,
                                    origPubKeySeqSz + origAlgIdSz +
                                    origPubKeyStrSz + kari->senderKeyExportSz,
                                    origIdOrKeySeq, 0);
@@ -7499,7 +7500,7 @@ int wc_PKCS7_AddRecipient_KARI(PKCS7* pkcs7, const byte* cert, word32 certSz,
     recip->recipVersion = 3;
 
     /* outer IMPLICIT [1] kari */
-    kariSeqSz = SetImplicit(ASN_SEQUENCE, 1, totalSz, kariSeq, 0);
+    kariSeqSz = (int)SetImplicit(ASN_SEQUENCE, 1, (word32)totalSz, kariSeq, 0);
     totalSz += kariSeqSz;
 
     if (totalSz > MAX_RECIP_SZ) {
@@ -7585,7 +7586,7 @@ int wc_PKCS7_AddRecipient_KARI(PKCS7* pkcs7, const byte* cert, word32 certSz,
 
     (void)options;
 
-    return idx;
+    return (int)idx;
 }
 
 #endif /* HAVE_ECC */
@@ -7706,7 +7707,7 @@ int wc_PKCS7_AddRecipient_KTRI(PKCS7* pkcs7, const byte* cert, word32 certSz,
     }
 
     /* generate random content encryption key, if needed */
-    ret = PKCS7_GenerateContentEncryptionKey(pkcs7, blockKeySz);
+    ret = PKCS7_GenerateContentEncryptionKey(pkcs7, (word32)blockKeySz);
     if (ret < 0) {
 #ifdef WOLFSSL_SMALL_STACK
         XFREE(serial,       pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
@@ -7759,7 +7760,7 @@ int wc_PKCS7_AddRecipient_KTRI(PKCS7* pkcs7, const byte* cert, word32 certSz,
             return -1;
         }
         issuerSz    = decoded->issuerRawLen;
-        issuerSeqSz = SetSequence(issuerSz, issuerSeq);
+        issuerSeqSz = (int)SetSequence((word32)issuerSz, issuerSeq);
 
         if (decoded->serialSz == 0) {
             WOLFSSL_MSG("DecodedCert missing serial number");
@@ -7795,7 +7796,7 @@ int wc_PKCS7_AddRecipient_KTRI(PKCS7* pkcs7, const byte* cert, word32 certSz,
         verSz = SetMyVersion(2, ver, 0);
         recip->recipVersion = 2;
 
-        issuerSKIDSz = SetLength(keyIdSize, issuerSKID);
+        issuerSKIDSz = SetLength((word32)keyIdSize, issuerSKID);
     } else {
         FreeDecodedCert(decoded);
 #ifdef WOLFSSL_SMALL_STACK
@@ -7929,13 +7930,13 @@ int wc_PKCS7_AddRecipient_KTRI(PKCS7* pkcs7, const byte* cert, word32 certSz,
         XFREE(recip, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         return ret;
     }
-    encryptedKeySz = ret;
+    encryptedKeySz = (word32)ret;
 
-    encKeyOctetStrSz = SetOctetString(encryptedKeySz, encKeyOctetStr);
+    encKeyOctetStrSz = (int)SetOctetString(encryptedKeySz, encKeyOctetStr);
 
     /* RecipientInfo */
     if (sidType == CMS_ISSUER_AND_SERIAL_NUMBER) {
-        recipSeqSz = SetSequence(verSz + issuerSerialSeqSz + issuerSeqSz +
+        recipSeqSz = (int)SetSequence(verSz + issuerSerialSeqSz + issuerSeqSz +
                                  issuerSz + snSz + keyEncAlgSz +
                                  encKeyOctetStrSz + encryptedKeySz, recipSeq);
 
@@ -8026,7 +8027,7 @@ int wc_PKCS7_AddRecipient_KTRI(PKCS7* pkcs7, const byte* cert, word32 certSz,
         lastRecip->next = recip;
     }
 
-    return idx;
+    return (int)idx;
 }
 
 #endif /* !NO_RSA */
@@ -8139,7 +8140,7 @@ static int wc_PKCS7_EncryptContent(PKCS7* pkcs7, int encryptOID, byte* key,
 #endif
             ret = wc_AesInit(aes, heap, devId);
             if (ret == 0) {
-                ret = wc_AesSetKey(aes, key, keySz, iv, AES_ENCRYPTION);
+                ret = wc_AesSetKey(aes, key, (word32)keySz, iv, AES_ENCRYPTION);
                 if (ret == 0) {
                     ret = wc_PKCS7_EncodeContentStream(pkcs7, NULL, aes, in,
                         inSz, out, WC_CIPHER_AES_CBC);
@@ -8173,7 +8174,7 @@ static int wc_PKCS7_EncryptContent(PKCS7* pkcs7, int encryptOID, byte* key,
 #endif
             ret = wc_AesInit(aes, heap, devId);
             if (ret == 0) {
-                ret = wc_AesGcmSetKey(aes, key, keySz);
+                ret = wc_AesGcmSetKey(aes, key, (word32)keySz);
                 if (ret == 0) {
                 #ifndef WOLFSSL_AESGCM_STREAM
                     if (pkcs7->encodeStream) {
@@ -8190,7 +8191,7 @@ static int wc_PKCS7_EncryptContent(PKCS7* pkcs7, int encryptOID, byte* key,
                     #endif
                     }
                 #else
-                    ret = wc_AesGcmEncryptInit(aes, key, keySz, iv, ivSz);
+                    ret = wc_AesGcmEncryptInit(aes, key, (word32)keySz, iv, ivSz);
                     if (ret == 0) {
                         ret = wc_AesGcmEncryptUpdate(aes, NULL, NULL, 0, aad,
                             aadSz);
@@ -8240,9 +8241,9 @@ static int wc_PKCS7_EncryptContent(PKCS7* pkcs7, int encryptOID, byte* key,
 #endif
             ret = wc_AesInit(aes, heap, devId);
             if (ret == 0) {
-                ret = wc_AesCcmSetKey(aes, key, keySz);
+                ret = wc_AesCcmSetKey(aes, key, (word32)keySz);
                 if (ret == 0) {
-                    ret = wc_AesCcmEncrypt(aes, out, in, inSz, iv, ivSz,
+                    ret = wc_AesCcmEncrypt(aes, out, in, (word32)inSz, iv, ivSz,
                                            authTag, authTagSz, aad, aadSz);
                 #ifdef WOLFSSL_ASYNC_CRYPT
                     /* async encrypt not available here, so block till done */
@@ -8270,7 +8271,7 @@ static int wc_PKCS7_EncryptContent(PKCS7* pkcs7, int encryptOID, byte* key,
 
             ret = wc_Des_SetKey(&des, key, iv, DES_ENCRYPTION);
             if (ret == 0)
-                ret = wc_Des_CbcEncrypt(&des, out, in, inSz);
+                ret = wc_Des_CbcEncrypt(&des, out, in, (word32)inSz);
 
             break;
 
@@ -8287,7 +8288,7 @@ static int wc_PKCS7_EncryptContent(PKCS7* pkcs7, int encryptOID, byte* key,
             if (ret == 0) {
                 ret = wc_Des3_SetKey(&des3, key, iv, DES_ENCRYPTION);
                 if (ret == 0) {
-                    ret = wc_Des3_CbcEncrypt(&des3, out, in, inSz);
+                    ret = wc_Des3_CbcEncrypt(&des3, out, in, (word32)inSz);
                 #ifdef WOLFSSL_ASYNC_CRYPT
                     /* async encrypt not available here, so block till done */
                     ret = wc_AsyncWait(ret, &des3.asyncDev, WC_ASYNC_FLAG_NONE);
@@ -8374,9 +8375,9 @@ static int wc_PKCS7_DecryptContent(PKCS7* pkcs7, int encryptOID, byte* key,
 #endif
             ret = wc_AesInit(aes, heap, devId);
             if (ret == 0) {
-                ret = wc_AesSetKey(aes, key, keySz, iv, AES_DECRYPTION);
+                ret = wc_AesSetKey(aes, key, (word32)keySz, iv, AES_DECRYPTION);
                 if (ret == 0) {
-                    ret = wc_AesCbcDecrypt(aes, out, in, inSz);
+                    ret = wc_AesCbcDecrypt(aes, out, in, (word32)inSz);
                 #ifdef WOLFSSL_ASYNC_CRYPT
                     /* async decrypt not available here, so block till done */
                     ret = wc_AsyncWait(ret, &aes->asyncDev, WC_ASYNC_FLAG_NONE);
@@ -8411,9 +8412,9 @@ static int wc_PKCS7_DecryptContent(PKCS7* pkcs7, int encryptOID, byte* key,
 #endif
             ret = wc_AesInit(aes, heap, devId);
             if (ret == 0) {
-                ret = wc_AesGcmSetKey(aes, key, keySz);
+                ret = wc_AesGcmSetKey(aes, key, (word32)keySz);
                 if (ret == 0) {
-                    ret = wc_AesGcmDecrypt(aes, out, in, inSz, iv, ivSz,
+                    ret = wc_AesGcmDecrypt(aes, out, in, (word32)inSz, iv, ivSz,
                                            authTag, authTagSz, aad, aadSz);
                 #ifdef WOLFSSL_ASYNC_CRYPT
                     /* async decrypt not available here, so block till done */
@@ -8450,9 +8451,9 @@ static int wc_PKCS7_DecryptContent(PKCS7* pkcs7, int encryptOID, byte* key,
 #endif
             ret = wc_AesInit(aes, heap, devId);
             if (ret == 0) {
-                ret = wc_AesCcmSetKey(aes, key, keySz);
+                ret = wc_AesCcmSetKey(aes, key, (word32)keySz);
                 if (ret == 0) {
-                    ret = wc_AesCcmDecrypt(aes, out, in, inSz, iv, ivSz,
+                    ret = wc_AesCcmDecrypt(aes, out, in, (word32)inSz, iv, ivSz,
                                            authTag, authTagSz, aad, aadSz);
                 #ifdef WOLFSSL_ASYNC_CRYPT
                     /* async decrypt not available here, so block till done */
@@ -8475,7 +8476,7 @@ static int wc_PKCS7_DecryptContent(PKCS7* pkcs7, int encryptOID, byte* key,
 
             ret = wc_Des_SetKey(&des, key, iv, DES_DECRYPTION);
             if (ret == 0)
-                ret = wc_Des_CbcDecrypt(&des, out, in, inSz);
+                ret = wc_Des_CbcDecrypt(&des, out, in, (word32)inSz);
 
             break;
         case DES3b:
@@ -8486,7 +8487,7 @@ static int wc_PKCS7_DecryptContent(PKCS7* pkcs7, int encryptOID, byte* key,
             if (ret == 0) {
                 ret = wc_Des3_SetKey(&des3, key, iv, DES_DECRYPTION);
                 if (ret == 0) {
-                    ret = wc_Des3_CbcDecrypt(&des3, out, in, inSz);
+                    ret = wc_Des3_CbcDecrypt(&des3, out, in, (word32)inSz);
                 #ifdef WOLFSSL_ASYNC_CRYPT
                     /* async decrypt not available here, so block till done */
                     ret = wc_AsyncWait(ret, &des3.asyncDev, WC_ASYNC_FLAG_NONE);
@@ -8684,7 +8685,7 @@ int wc_PKCS7_AddRecipient_ORI(PKCS7* pkcs7, CallbackOriEncrypt oriEncryptCb,
     }
 
     /* generate random content encryption key, if needed */
-    ret = PKCS7_GenerateContentEncryptionKey(pkcs7, blockKeySz);
+    ret = PKCS7_GenerateContentEncryptionKey(pkcs7, (word32)blockKeySz);
     if (ret < 0) {
         XFREE(recip, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         return ret;
@@ -8699,7 +8700,7 @@ int wc_PKCS7_AddRecipient_ORI(PKCS7* pkcs7, CallbackOriEncrypt oriEncryptCb,
         return ret;
     }
 
-    oriTypeLenSz = SetLength(oriTypeSz, oriTypeLen);
+    oriTypeLenSz = (int)SetLength(oriTypeSz, oriTypeLen);
 
     recipSeqSz = SetImplicit(ASN_SEQUENCE, 4, 1 + oriTypeLenSz + oriTypeSz +
                              oriValueSz, recipSeq, 0);
@@ -8736,7 +8737,7 @@ int wc_PKCS7_AddRecipient_ORI(PKCS7* pkcs7, CallbackOriEncrypt oriEncryptCb,
 
     (void)options;
 
-    return idx;
+    return (int)idx;
 }
 
 #if !defined(NO_PWDBASED) && !defined(NO_SHA)
@@ -8756,8 +8757,8 @@ static int wc_PKCS7_GenerateKEK_PWRI(PKCS7* pkcs7, byte* passwd, word32 pLen,
 
         case PBKDF2_OID:
 
-            ret = wc_PBKDF2(out, passwd, pLen, salt, saltSz, iterations,
-                            outSz, prfOID);
+            ret = wc_PBKDF2(out, passwd, (int)pLen, salt, saltSz, iterations,
+                            (int)outSz, prfOID);
             if (ret != 0) {
                 return ret;
             }
@@ -8808,7 +8809,7 @@ static int wc_PKCS7_PwriKek_KeyWrap(PKCS7* pkcs7, const byte* kek, word32 kekSz,
 
     /* if user set out to NULL, give back required length */
     if (out == NULL) {
-        *outSz = outLen;
+        *outSz = (word32)outLen;
         return LENGTH_ONLY_E;
     }
 
@@ -8831,21 +8832,21 @@ static int wc_PKCS7_PwriKek_KeyWrap(PKCS7* pkcs7, const byte* kek, word32 kekSz,
 
     if (ret == 0) {
         /* encrypt, normal */
-        ret = wc_PKCS7_EncryptContent(pkcs7, algID, (byte*)kek, kekSz,
-                                      (byte*)iv, ivSz, NULL, 0, NULL, 0, out,
+        ret = wc_PKCS7_EncryptContent(pkcs7, algID, (byte*)kek, (int)kekSz,
+                                      (byte*)iv, (int)ivSz, NULL, 0, NULL, 0, out,
                                       outLen, out);
     }
 
     if (ret == 0) {
         /* encrypt again, using last ciphertext block as IV */
         lastBlock = out + (((outLen / blockSz) - 1) * blockSz);
-        ret = wc_PKCS7_EncryptContent(pkcs7, algID, (byte*)kek, kekSz,
+        ret = wc_PKCS7_EncryptContent(pkcs7, algID, (byte*)kek, (int)kekSz,
                                       lastBlock, blockSz, NULL, 0, NULL, 0, out,
                                       outLen, out);
     }
 
     if (ret == 0) {
-        *outSz = outLen;
+        *outSz = (word32)outLen;
     } else {
         outLen = ret;
     }
@@ -8901,21 +8902,21 @@ static int wc_PKCS7_PwriKek_KeyUnWrap(PKCS7* pkcs7, const byte* kek,
     tmpIv = lastBlock - blockSz;
 
     /* decrypt last block */
-    ret = wc_PKCS7_DecryptContent(pkcs7, algID, (byte*)kek, kekSz, tmpIv,
+    ret = wc_PKCS7_DecryptContent(pkcs7, algID, (byte*)kek, (int)kekSz, tmpIv,
             blockSz, NULL, 0, NULL, 0, lastBlock, blockSz,
             outTmp + inSz - blockSz, pkcs7->devId, pkcs7->heap);
 
     if (ret == 0) {
         /* using last decrypted block as IV, decrypt [0 ... n-1] blocks */
         lastBlock = outTmp + inSz - blockSz;
-        ret = wc_PKCS7_DecryptContent(pkcs7, algID, (byte*)kek, kekSz,
+        ret = wc_PKCS7_DecryptContent(pkcs7, algID, (byte*)kek, (int)kekSz,
                 lastBlock, blockSz, NULL, 0, NULL, 0, (byte*)in, inSz - blockSz,
                 outTmp, pkcs7->devId, pkcs7->heap);
     }
 
     if (ret == 0) {
         /* decrypt using original kek and iv */
-        ret = wc_PKCS7_DecryptContent(pkcs7, algID, (byte*)kek, kekSz,
+        ret = wc_PKCS7_DecryptContent(pkcs7, algID, (byte*)kek, (int)kekSz,
                 (byte*)iv, ivSz, NULL, 0, NULL, 0, outTmp, inSz, outTmp,
                 pkcs7->devId, pkcs7->heap);
     }
@@ -9037,12 +9038,12 @@ int wc_PKCS7_AddRecipient_PWRI(PKCS7* pkcs7, byte* passwd, word32 pLen,
         return kekBlockSz;
 
     /* generate random CEK */
-    ret = PKCS7_GenerateContentEncryptionKey(pkcs7, cekKeySz);
+    ret = PKCS7_GenerateContentEncryptionKey(pkcs7, (word32)cekKeySz);
     if (ret < 0)
         return ret;
 
     /* generate random IV */
-    ret = wc_PKCS7_GenerateBlock(pkcs7, NULL, tmpIv, kekBlockSz);
+    ret = wc_PKCS7_GenerateBlock(pkcs7, NULL, tmpIv, (word32)kekBlockSz);
     if (ret != 0)
         return ret;
 
@@ -9074,7 +9075,7 @@ int wc_PKCS7_AddRecipient_PWRI(PKCS7* pkcs7, byte* passwd, word32 pLen,
     /* generate KEK: expand password into KEK */
     ret = wc_PKCS7_GenerateKEK_PWRI(pkcs7, passwd, pLen, salt, saltSz,
                                     kdfOID, hashOID, iterations, kek,
-                                    kekKeySz);
+                                    (word32)kekKeySz);
     if (ret < 0) {
         XFREE(recip, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         XFREE(kek, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
@@ -9083,23 +9084,23 @@ int wc_PKCS7_AddRecipient_PWRI(PKCS7* pkcs7, byte* passwd, word32 pLen,
     }
 
     /* generate encrypted key: encrypt CEK with KEK */
-    ret = wc_PKCS7_PwriKek_KeyWrap(pkcs7, kek, kekKeySz, pkcs7->cek,
+    ret = wc_PKCS7_PwriKek_KeyWrap(pkcs7, kek, (word32)kekKeySz, pkcs7->cek,
                                    pkcs7->cekSz, encryptedKey, &encryptedKeySz,
-                                   tmpIv, kekBlockSz, encryptOID);
+                                   tmpIv, (word32)kekBlockSz, encryptOID);
     if (ret < 0) {
         XFREE(recip, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         XFREE(kek, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         return ret;
     }
-    encryptedKeySz = ret;
+    encryptedKeySz = (word32)ret;
 
     /* put together encrypted key OCTET STRING */
     encKeyOctetStrSz = SetOctetString(encryptedKeySz, encKeyOctetStr);
     totalSz += (encKeyOctetStrSz + encryptedKeySz);
 
     /* put together IV OCTET STRING */
-    ivOctetStringSz = SetOctetString(kekBlockSz, ivOctetString);
+    ivOctetStringSz = SetOctetString((word32)kekBlockSz, ivOctetString);
     totalSz += (ivOctetStringSz + kekBlockSz);
 
     /* set PWRIAlgorithms AlgorithmIdentifier, adding (ivOctetStringSz +
@@ -9116,7 +9117,7 @@ int wc_PKCS7_AddRecipient_PWRI(PKCS7* pkcs7, byte* passwd, word32 pLen,
         XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         return ret;
     }
-    keyEncAlgoIdSz = ret;
+    keyEncAlgoIdSz = (word32)ret;
     totalSz += keyEncAlgoIdSz;
 
     /* KeyEncryptionAlgorithm SEQ */
@@ -9130,7 +9131,7 @@ int wc_PKCS7_AddRecipient_PWRI(PKCS7* pkcs7, byte* passwd, word32 pLen,
     totalSz += (kdfSaltOctetStrSz + saltSz);
 
     /* set KDF iteration count */
-    kdfIterationsSz = SetMyVersion(iterations, kdfIterations, 0);
+    kdfIterationsSz = (word32)SetMyVersion((word32)iterations, kdfIterations, 0);
     totalSz += kdfIterationsSz;
 
     /* set KDF params SEQ */
@@ -9146,7 +9147,7 @@ int wc_PKCS7_AddRecipient_PWRI(PKCS7* pkcs7, byte* passwd, word32 pLen,
         XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         return ret;
     }
-    kdfAlgoIdSz = ret;
+    kdfAlgoIdSz = (word32)ret;
     totalSz += kdfAlgoIdSz;
 
     /* set KeyDerivationAlgorithmIdentifier EXPLICIT [0] SEQ */
@@ -9156,7 +9157,7 @@ int wc_PKCS7_AddRecipient_PWRI(PKCS7* pkcs7, byte* passwd, word32 pLen,
     totalSz += kdfAlgoIdSeqSz;
 
     /* set PasswordRecipientInfo CMSVersion, MUST be 0 */
-    verSz = SetMyVersion(0, ver, 0);
+    verSz = (word32)SetMyVersion(0, ver, 0);
     totalSz += verSz;
     recip->recipVersion = 0;
 
@@ -9204,7 +9205,7 @@ int wc_PKCS7_AddRecipient_PWRI(PKCS7* pkcs7, byte* passwd, word32 pLen,
     XMEMCPY(recip->recip + idx, encryptedKey, encryptedKeySz);
     idx += encryptedKeySz;
 
-    ForceZero(kek, kekBlockSz);
+    ForceZero(kek, (word32)kekBlockSz);
     ForceZero(encryptedKey, encryptedKeySz);
     XFREE(kek, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
     XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
@@ -9226,7 +9227,7 @@ int wc_PKCS7_AddRecipient_PWRI(PKCS7* pkcs7, byte* passwd, word32 pLen,
 
     (void)options;
 
-    return idx;
+    return (int)idx;
 }
 
 /* Import password and KDF settings into a PKCS7 structure. Used for setting
@@ -9317,7 +9318,7 @@ int wc_PKCS7_AddRecipient_KEKRI(PKCS7* pkcs7, int keyWrapOID, byte* kek,
     }
 
     /* generate random content encryption key, if needed */
-    ret = PKCS7_GenerateContentEncryptionKey(pkcs7, blockKeySz);
+    ret = PKCS7_GenerateContentEncryptionKey(pkcs7, (word32)blockKeySz);
     if (ret < 0) {
         XFREE(recip, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         return ret;
@@ -9342,7 +9343,7 @@ int wc_PKCS7_AddRecipient_KEKRI(PKCS7* pkcs7, int keyWrapOID, byte* kek,
     #endif
 
     encryptedKeySz = wc_PKCS7_KeyWrap(pkcs7->cek, pkcs7->cekSz, kek, kekSz,
-                                      encryptedKey, encryptedKeySz, keyWrapOID,
+                                      encryptedKey, (word32)encryptedKeySz, keyWrapOID,
                                       direction);
     if (encryptedKeySz < 0) {
     #ifdef WOLFSSL_SMALL_STACK
@@ -9360,7 +9361,7 @@ int wc_PKCS7_AddRecipient_KEKRI(PKCS7* pkcs7, int keyWrapOID, byte* kek,
         return WC_KEY_SIZE_E;
     }
 
-    encKeyOctetStrSz = SetOctetString(encryptedKeySz, encKeyOctetStr);
+    encKeyOctetStrSz = SetOctetString((word32)encryptedKeySz, encKeyOctetStr);
     totalSz += (encKeyOctetStrSz + encryptedKeySz);
 
     /* KeyEncryptionAlgorithmIdentifier */
@@ -9399,7 +9400,7 @@ int wc_PKCS7_AddRecipient_KEKRI(PKCS7* pkcs7, int keyWrapOID, byte* kek,
     totalSz += kekIdSeqSz;
 
     /* version */
-    verSz = SetMyVersion(4, ver, 0);
+    verSz = (word32)SetMyVersion(4, ver, 0);
     totalSz += verSz;
     recip->recipVersion = 4;
 
@@ -9466,7 +9467,7 @@ int wc_PKCS7_AddRecipient_KEKRI(PKCS7* pkcs7, int keyWrapOID, byte* kek,
 
     (void)options;
 
-    return idx;
+    return (int)idx;
 }
 
 
@@ -9585,7 +9586,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     }
 
     /* generate random content encryption key */
-    ret = PKCS7_GenerateContentEncryptionKey(pkcs7, blockKeySz);
+    ret = PKCS7_GenerateContentEncryptionKey(pkcs7, (word32)blockKeySz);
     if (ret != 0) {
         return ret;
     }
@@ -9628,7 +9629,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
         WOLFSSL_MSG("You must add at least one CMS recipient");
         return PKCS7_RECIP_E;
     }
-    recipSetSz = SetSet(recipSz, recipSet);
+    recipSetSz = (int)SetSet((word32)recipSz, recipSet);
 
     /* version, defined in Section 6.1 of RFC 5652 */
     kariVersion = wc_PKCS7_GetCMSVersion(pkcs7, ENVELOPED_DATA);
@@ -9638,7 +9639,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
         return PKCS7_RECIP_E;
     }
 
-    verSz = SetMyVersion(kariVersion, ver, 0);
+    verSz = SetMyVersion((word32)kariVersion, ver, 0);
 
     ret = wc_InitRng_ex(&rng, pkcs7->heap, pkcs7->devId);
     if (ret != 0) {
@@ -9647,7 +9648,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     }
 
     /* generate IV for block cipher */
-    ret = wc_PKCS7_GenerateBlock(pkcs7, &rng, tmpIv, blockSz);
+    ret = wc_PKCS7_GenerateBlock(pkcs7, &rng, tmpIv, (word32)blockSz);
     wc_FreeRng(&rng);
     if (ret != 0) {
         wc_PKCS7_FreeEncodedRecipientSet(pkcs7);
@@ -9665,7 +9666,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     contentTypeSz = ret;
 
     /* allocate encrypted content buffer and PKCS#7 padding */
-    padSz = wc_PKCS7_GetPadSize(pkcs7->contentSz, blockSz);
+    padSz = wc_PKCS7_GetPadSize(pkcs7->contentSz, (word32)blockSz);
     if (padSz < 0) {
         wc_PKCS7_FreeEncodedRecipientSet(pkcs7);
         return padSz;
@@ -9684,7 +9685,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
         }
 
         ret = wc_PKCS7_PadData(pkcs7->content, pkcs7->contentSz, plain,
-                               encryptedOutSz, blockSz);
+                               (word32)encryptedOutSz, blockSz);
         if (ret < 0) {
             XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
             wc_PKCS7_FreeEncodedRecipientSet(pkcs7);
@@ -9707,11 +9708,11 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     }
 
     /* put together IV OCTET STRING */
-    ivOctetStringSz = SetOctetString(blockSz, ivOctetString);
+    ivOctetStringSz = (int)SetOctetString((word32)blockSz, ivOctetString);
 
     /* build up our ContentEncryptionAlgorithmIdentifier sequence,
      * adding (ivOctetStringSz + blockSz) for IV OCTET STRING */
-    contentEncAlgoSz = SetAlgoID(pkcs7->encryptOID, contentEncAlgo,
+    contentEncAlgoSz = (int)SetAlgoID(pkcs7->encryptOID, contentEncAlgo,
                                  oidBlkType, ivOctetStringSz + blockSz);
 
     if (contentEncAlgoSz == 0) {
@@ -9721,9 +9722,9 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
         return BAD_FUNC_ARG;
     }
 
-    encContentOctetSz = SetImplicit(ASN_OCTET_STRING, 0, encryptedOutSz,
+    encContentOctetSz = (int)SetImplicit(ASN_OCTET_STRING, 0, (word32)encryptedOutSz,
                                 encContentOctet, pkcs7->encodeStream);
-    encContentSeqSz = SetSequenceEx(contentTypeSz + contentEncAlgoSz +
+    encContentSeqSz = (int)SetSequenceEx(contentTypeSz + contentEncAlgoSz +
                               ivOctetStringSz + blockSz +
                               encContentOctetSz + encryptedOutSz,
                               encContentSeq, pkcs7->encodeStream);
@@ -9745,7 +9746,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
         totalSz += ASN_INDEF_END_SZ;
 
         /* account for asn1 syntax around octet strings */
-        StreamOctetString(NULL, encryptedOutSz, NULL, &streamSz, &tmpIdx);
+        StreamOctetString(NULL, (word32)encryptedOutSz, NULL, &streamSz, &tmpIdx);
         totalSz += (streamSz - encryptedOutSz);
 
         /* resize encrypted content buffer */
@@ -9761,7 +9762,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
         }
     }
 #endif
-    envDataSeqSz = SetSequenceEx(totalSz, envDataSeq, pkcs7->encodeStream);
+    envDataSeqSz = (int)SetSequenceEx((word32)totalSz, envDataSeq, pkcs7->encodeStream);
     totalSz += envDataSeqSz;
 #ifdef ASN_BER_TO_DER
     if (pkcs7->encodeStream) {
@@ -9770,7 +9771,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
 #endif
 
     /* outer content */
-    outerContentSz = SetExplicit(0, totalSz, outerContent, pkcs7->encodeStream);
+    outerContentSz = (int)SetExplicit(0, (word32)totalSz, outerContent, pkcs7->encodeStream);
 #ifdef ASN_BER_TO_DER
     if (pkcs7->encodeStream) {
         totalSz += ASN_INDEF_END_SZ;
@@ -9781,7 +9782,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
 
     if (pkcs7->contentOID != FIRMWARE_PKG_DATA) {
         /* ContentInfo */
-        contentInfoSeqSz = SetSequenceEx(totalSz, contentInfoSeq,
+        contentInfoSeqSz = (int)SetSequenceEx((word32)totalSz, contentInfoSeq,
             pkcs7->encodeStream);
         totalSz += contentInfoSeqSz;
     #ifdef ASN_BER_TO_DER
@@ -9806,24 +9807,24 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     /* begin writing out PKCS7 bundle */
     if (pkcs7->contentOID != FIRMWARE_PKG_DATA) {
         wc_PKCS7_WriteOut(pkcs7, (output)? (output + idx) : NULL,
-            contentInfoSeq, contentInfoSeqSz);
+            contentInfoSeq, (word32)contentInfoSeqSz);
         idx += contentInfoSeqSz;
         wc_PKCS7_WriteOut(pkcs7, (output)? (output + idx) : NULL,
-            outerContentType, outerContentTypeSz);
+            outerContentType, (word32)outerContentTypeSz);
         idx += outerContentTypeSz;
         wc_PKCS7_WriteOut(pkcs7, (output)? (output + idx) : NULL,
-            outerContent, outerContentSz);
+            outerContent, (word32)outerContentSz);
         idx += outerContentSz;
     }
 
     wc_PKCS7_WriteOut(pkcs7, (output)? (output + idx) : NULL,
-            envDataSeq, envDataSeqSz);
+            envDataSeq, (word32)envDataSeqSz);
     idx += envDataSeqSz;
     wc_PKCS7_WriteOut(pkcs7, (output)? (output + idx) : NULL,
-            ver, verSz);
+            ver, (word32)verSz);
     idx += verSz;
     wc_PKCS7_WriteOut(pkcs7, (output)? (output + idx) : NULL,
-            recipSet, recipSetSz);
+            recipSet, (word32)recipSetSz);
     idx += recipSetSz;
     /* copy in recipients from list */
     tmpRecip = pkcs7->recipList;
@@ -9836,22 +9837,22 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     wc_PKCS7_FreeEncodedRecipientSet(pkcs7);
 
     wc_PKCS7_WriteOut(pkcs7, (output)? (output + idx) : NULL,
-            encContentSeq, encContentSeqSz);
+            encContentSeq, (word32)encContentSeqSz);
     idx += encContentSeqSz;
     wc_PKCS7_WriteOut(pkcs7, (output)? (output + idx) : NULL,
-            contentType, contentTypeSz);
+            contentType, (word32)contentTypeSz);
     idx += contentTypeSz;
     wc_PKCS7_WriteOut(pkcs7, (output)? (output + idx) : NULL,
-            contentEncAlgo, contentEncAlgoSz);
+            contentEncAlgo, (word32)contentEncAlgoSz);
     idx += contentEncAlgoSz;
     wc_PKCS7_WriteOut(pkcs7, (output)? (output + idx) : NULL,
-            ivOctetString, ivOctetStringSz);
+            ivOctetString, (word32)ivOctetStringSz);
     idx += ivOctetStringSz;
     wc_PKCS7_WriteOut(pkcs7, (output)? (output + idx) : NULL,
-            tmpIv, blockSz);
+            tmpIv, (word32)blockSz);
     idx += blockSz;
     wc_PKCS7_WriteOut(pkcs7, (output)? (output + idx) : NULL,
-            encContentOctet, encContentOctetSz);
+            encContentOctet, (word32)encContentOctetSz);
     idx += encContentOctetSz;
 
     /* encrypt content */
@@ -10037,7 +10038,7 @@ static int wc_PKCS7_DecryptKtri(PKCS7* pkcs7, byte* in, word32 inSz,
                         return ret;
                 }
 
-                pkcs7->stream->expected = sz + MAX_ALGO_SZ + ASN_TAG_SZ +
+                pkcs7->stream->expected = (word32)sz + MAX_ALGO_SZ + ASN_TAG_SZ +
                                           MAX_LENGTH_SZ;
                 if (pkcs7->stream->length > 0 &&
                         pkcs7->stream->length < pkcs7->stream->expected) {
@@ -10052,7 +10053,7 @@ static int wc_PKCS7_DecryptKtri(PKCS7* pkcs7, byte* in, word32 inSz,
                 if (GetSequence(pkiMsg, idx, &length, pkiMsgSz) < 0)
                     return ASN_PARSE_E;
 
-                if (GetNameHash_ex(pkiMsg, idx, issuerHash, pkiMsgSz,
+                if (GetNameHash_ex(pkiMsg, idx, issuerHash, (int)pkiMsgSz,
                                    pkcs7->publicKeyOID) < 0)
                     return ASN_PARSE_E;
 
@@ -10158,8 +10159,8 @@ static int wc_PKCS7_DecryptKtri(PKCS7* pkcs7, byte* in, word32 inSz,
             if ((ret = wc_PKCS7_StreamEndCase(pkcs7, &tmpIdx, idx)) != 0) {
                     break;
             }
-            wc_PKCS7_StreamStoreVar(pkcs7, encryptedKeySz, sidType, version);
-            pkcs7->stream->expected = encryptedKeySz;
+            wc_PKCS7_StreamStoreVar(pkcs7, (word32)encryptedKeySz, sidType, version);
+            pkcs7->stream->expected = (word32)encryptedKeySz;
         #endif
             wc_PKCS7_ChangeState(pkcs7, WC_PKCS7_DECRYPT_KTRI_3);
             FALL_THROUGH;
@@ -10170,7 +10171,7 @@ static int wc_PKCS7_DecryptKtri(PKCS7* pkcs7, byte* in, word32 inSz,
                             pkcs7->stream->expected, &pkiMsg, idx)) != 0) {
                 return ret;
             }
-            encryptedKeySz = pkcs7->stream->expected;
+            encryptedKeySz = (int)pkcs7->stream->expected;
         #endif
 
             /* Always allocate to ensure aligned use with RSA */
@@ -10241,12 +10242,12 @@ static int wc_PKCS7_DecryptKtri(PKCS7* pkcs7, byte* in, word32 inSz,
                     if (encOID != RSAESOAEPk) {
             #endif
                         keySz = wc_RsaPrivateDecryptInline(encryptedKey,
-                                                        encryptedKeySz, &outKey,
+                                                        (word32)encryptedKeySz, &outKey,
                                                         privKey);
             #ifndef WC_NO_RSA_OAEP
                     }
                     else {
-                        word32 outLen = wc_RsaEncryptSize(privKey);
+                        word32 outLen = (word32)wc_RsaEncryptSize(privKey);
                         outKey = (byte*)XMALLOC(outLen, pkcs7->heap,
                                                     DYNAMIC_TYPE_TMP_BUFFER);
                         if (!outKey) {
@@ -10263,7 +10264,7 @@ static int wc_PKCS7_DecryptKtri(PKCS7* pkcs7, byte* in, word32 inSz,
                         }
 
                         keySz = wc_RsaPrivateDecrypt_ex(encryptedKey,
-                                encryptedKeySz, outKey, outLen, privKey,
+                                (word32)encryptedKeySz, outKey, outLen, privKey,
                                 WC_RSA_OAEP_PAD,
                                 WC_HASH_TYPE_SHA, WC_MGF1SHA1, NULL, 0);
                     }
@@ -10281,7 +10282,7 @@ static int wc_PKCS7_DecryptKtri(PKCS7* pkcs7, byte* in, word32 inSz,
             wc_FreeRsaKey(privKey);
 
             if (keySz <= 0 || outKey == NULL) {
-                ForceZero(encryptedKey, encryptedKeySz);
+                ForceZero(encryptedKey, (word32)encryptedKeySz);
                 XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_WOLF_BIGINT);
         #ifdef WOLFSSL_SMALL_STACK
                 XFREE(privKey, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
@@ -10295,9 +10296,9 @@ static int wc_PKCS7_DecryptKtri(PKCS7* pkcs7, byte* in, word32 inSz,
         #endif
                 return keySz;
             } else {
-                *decryptedKeySz = keySz;
+                *decryptedKeySz = (word32)keySz;
                 XMEMCPY(decryptedKey, outKey, keySz);
-                ForceZero(encryptedKey, encryptedKeySz);
+                ForceZero(encryptedKey, (word32)encryptedKeySz);
             }
 
             XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_WOLF_BIGINT);
@@ -10472,7 +10473,7 @@ static int wc_PKCS7_KariGetUserKeyingMaterial(WC_PKCS7_KARI* kari,
     }
 
     (*idx) += length;
-    kari->ukmSz = length;
+    kari->ukmSz = (word32)length;
 
     return 0;
 }
@@ -10605,7 +10606,7 @@ static int wc_PKCS7_KariGetIssuerAndSerialNumber(WC_PKCS7_KARI* kari,
     if (GetSequence(pkiMsg, idx, &length, pkiMsgSz) < 0)
         return ASN_PARSE_E;
 
-    if (GetNameHash_ex(pkiMsg, idx, rid, pkiMsgSz,
+    if (GetNameHash_ex(pkiMsg, idx, rid, (int)pkiMsgSz,
                        kari->decoded->signatureOID) < 0) {
         return ASN_PARSE_E;
     }
@@ -10996,14 +10997,14 @@ static int wc_PKCS7_DecryptPwri(PKCS7* pkcs7, byte* in, word32 inSz,
                 return ASN_PARSE_E;
             }
 
-            blockSz = wc_PKCS7_GetOIDBlockSize(pwriEncAlgoId);
+            blockSz = wc_PKCS7_GetOIDBlockSize((int)pwriEncAlgoId);
             if (blockSz < 0) {
                 XFREE(salt, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
                 return blockSz;
             }
 
             /* get content-encryption key size, based on algorithm */
-            kekKeySz = wc_PKCS7_GetOIDKeySize(pwriEncAlgoId);
+            kekKeySz = wc_PKCS7_GetOIDKeySize((int)pwriEncAlgoId);
             if (kekKeySz < 0) {
                 XFREE(salt, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
                 return kekKeySz;
@@ -11051,7 +11052,7 @@ static int wc_PKCS7_DecryptPwri(PKCS7* pkcs7, byte* in, word32 inSz,
             }
 
             /* allocate temporary space for decrypted key */
-            cekSz = length;
+            cekSz = (word32)length;
             cek = (byte*)XMALLOC(cekSz, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
             if (cek == NULL) {
                 XFREE(salt, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
@@ -11067,8 +11068,8 @@ static int wc_PKCS7_DecryptPwri(PKCS7* pkcs7, byte* in, word32 inSz,
             }
 
             ret = wc_PKCS7_GenerateKEK_PWRI(pkcs7, pkcs7->pass, pkcs7->passSz,
-                                            salt, saltSz, kdfAlgoId, hashOID,
-                                            iterations, kek, kekKeySz);
+                                            salt, (word32)saltSz, kdfAlgoId, hashOID,
+                                            iterations, kek, (word32)kekKeySz);
             if (ret < 0) {
                 XFREE(salt, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
                 XFREE(kek, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
@@ -11077,17 +11078,17 @@ static int wc_PKCS7_DecryptPwri(PKCS7* pkcs7, byte* in, word32 inSz,
             }
 
             /* decrypt CEK with KEK */
-            ret = wc_PKCS7_PwriKek_KeyUnWrap(pkcs7, kek, kekKeySz,
-                                             pkiMsg + (*idx), length, cek,
-                                             cekSz, tmpIv, blockSz,
-                                             pwriEncAlgoId);
+            ret = wc_PKCS7_PwriKek_KeyUnWrap(pkcs7, kek, (word32)kekKeySz,
+                                             pkiMsg + (*idx), (word32)length, cek,
+                                             cekSz, tmpIv, (word32)blockSz,
+                                             (int)pwriEncAlgoId);
             if (ret < 0) {
                 XFREE(salt, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
                 XFREE(kek, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
                 XFREE(cek, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
                 return ret;
             }
-            cekSz = ret;
+            cekSz = (word32)ret;
 
             if (*decryptedKeySz < cekSz) {
                 WOLFSSL_MSG("Decrypted key buffer too small for CEK");
@@ -11160,7 +11161,7 @@ static int wc_PKCS7_DecryptKekri(PKCS7* pkcs7, byte* in, word32 inSz,
             if (GetSequence(pkiMsg, idx, &length, pkiMsgSz) < 0)
                 return ASN_PARSE_E;
 
-            kekIdSz = length;
+            kekIdSz = (word32)length;
 
             if (GetASNTag(pkiMsg, idx, &tag, pkiMsgSz) < 0)
                 return ASN_PARSE_E;
@@ -11173,14 +11174,14 @@ static int wc_PKCS7_DecryptKekri(PKCS7* pkcs7, byte* in, word32 inSz,
 
             /* save keyIdentifier and length */
             keyId = pkiMsg + *idx;
-            keyIdSz = length;
+            keyIdSz = (word32)length;
             *idx += keyIdSz;
 
             /* may have OPTIONAL GeneralizedTime */
             localIdx = *idx;
             if ((*idx < kekIdSz) && GetASNTag(pkiMsg, &localIdx, &tag,
                         pkiMsgSz) == 0 && tag == ASN_GENERALIZED_TIME) {
-                if (wc_GetDateInfo(pkiMsg + *idx, pkiMsgSz, &datePtr, &dateFormat,
+                if (wc_GetDateInfo(pkiMsg + *idx, (int)pkiMsgSz, &datePtr, &dateFormat,
                                    &dateLen) != 0) {
                     return ASN_PARSE_E;
                 }
@@ -11229,15 +11230,15 @@ static int wc_PKCS7_DecryptKekri(PKCS7* pkcs7, byte* in, word32 inSz,
 
             /* decrypt CEK with KEK */
             if (pkcs7->wrapCEKCb) {
-                keySz = pkcs7->wrapCEKCb(pkcs7, pkiMsg + *idx, length, keyId,
+                keySz = pkcs7->wrapCEKCb(pkcs7, pkiMsg + *idx, (word32)length, keyId,
                                      keyIdSz, NULL, 0, decryptedKey,
-                                     *decryptedKeySz, keyWrapOID,
+                                     *decryptedKeySz, (int)keyWrapOID,
                                      (int)PKCS7_KEKRI, direction);
             }
             else {
-                keySz = wc_PKCS7_KeyWrap(pkiMsg + *idx, length, pkcs7->privateKey,
+                keySz = wc_PKCS7_KeyWrap(pkiMsg + *idx, (word32)length, pkcs7->privateKey,
                                      pkcs7->privateKeySz, decryptedKey, *decryptedKeySz,
-                                     keyWrapOID, direction);
+                                     (int)keyWrapOID, direction);
             }
             if (keySz <= 0)
                 return keySz;
@@ -11380,7 +11381,7 @@ static int wc_PKCS7_DecryptKari(PKCS7* pkcs7, byte* in, word32 inSz,
 
             /* if user has not explicitly set keyAgreeOID, set from one in bundle */
             if (pkcs7->keyAgreeOID == 0)
-                pkcs7->keyAgreeOID = keyAgreeOID;
+                pkcs7->keyAgreeOID = (int)keyAgreeOID;
 
             /* set direction based on key wrap algorithm */
             switch (keyWrapOID) {
@@ -11458,10 +11459,10 @@ static int wc_PKCS7_DecryptKari(PKCS7* pkcs7, byte* in, word32 inSz,
                 }
                 tmpKeySz = (word32)ret;
 
-                keySz = pkcs7->wrapCEKCb(pkcs7, encryptedKey, encryptedKeySz,
-                        rid, keyIdSize, tmpKeyDer, tmpKeySz,
+                keySz = pkcs7->wrapCEKCb(pkcs7, encryptedKey, (word32)encryptedKeySz,
+                        rid, (word32)keyIdSize, tmpKeyDer, tmpKeySz,
                         decryptedKey, *decryptedKeySz,
-                        keyWrapOID, (int)PKCS7_KARI, direction);
+                        (int)keyWrapOID, (int)PKCS7_KARI, direction);
                 XFREE(tmpKeyDer, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 
                 if (keySz  > 0) {
@@ -11474,7 +11475,7 @@ static int wc_PKCS7_DecryptKari(PKCS7* pkcs7, byte* in, word32 inSz,
             }
             else {
                 /* create KEK */
-                ret = wc_PKCS7_KariGenerateKEK(kari, pkcs7->rng, keyWrapOID,
+                ret = wc_PKCS7_KariGenerateKEK(kari, pkcs7->rng, (int)keyWrapOID,
                                                pkcs7->keyAgreeOID);
                 if (ret != 0) {
                     wc_PKCS7_KariFree(kari);
@@ -11485,9 +11486,9 @@ static int wc_PKCS7_DecryptKari(PKCS7* pkcs7, byte* in, word32 inSz,
                 }
 
                 /* decrypt CEK with KEK */
-                keySz = wc_PKCS7_KeyWrap(encryptedKey, encryptedKeySz, kari->kek,
+                keySz = wc_PKCS7_KeyWrap(encryptedKey, (word32)encryptedKeySz, kari->kek,
                                          kari->kekSz, decryptedKey, *decryptedKeySz,
-                                         keyWrapOID, direction);
+                                         (int)keyWrapOID, direction);
             }
             if (keySz <= 0) {
                 wc_PKCS7_KariFree(kari);
@@ -11962,7 +11963,7 @@ static int wc_PKCS7_ParseToRecipientInfoSet(PKCS7* pkcs7, byte* in,
                 break;
             }
 
-            pkcs7->stream->varOne = version;
+            pkcs7->stream->varOne = (word32)version;
         #endif
             wc_PKCS7_ChangeState(pkcs7, WC_PKCS7_INFOSET_END);
             FALL_THROUGH;
@@ -11974,7 +11975,7 @@ static int wc_PKCS7_ParseToRecipientInfoSet(PKCS7* pkcs7, byte* in,
                 return ret;
             }
             pkiMsgSz = (pkcs7->stream->length > 0)? pkcs7->stream->length: inSz;
-            version = pkcs7->stream->varOne;
+            version = (int)pkcs7->stream->varOne;
         #endif
 
             if (type == ENVELOPED_DATA) {
@@ -12222,7 +12223,7 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* in,
             }
 
             if (ret == 0) {
-                pkcs7->contentOID = contentType;
+                pkcs7->contentOID = (int)contentType;
             }
 
             if (ret == 0 && GetAlgoId(pkiMsg, &idx, &encOID, oidBlkType,
@@ -12230,12 +12231,12 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* in,
                 ret = ASN_PARSE_E;
             }
 
-            blockKeySz = wc_PKCS7_GetOIDKeySize(encOID);
+            blockKeySz = wc_PKCS7_GetOIDKeySize((int)encOID);
             if (ret == 0 && blockKeySz < 0) {
                 ret = blockKeySz;
             }
 
-            expBlockSz = wc_PKCS7_GetOIDBlockSize(encOID);
+            expBlockSz = wc_PKCS7_GetOIDBlockSize((int)encOID);
             if (ret == 0 && expBlockSz < 0) {
                 ret = expBlockSz;
             }
@@ -12266,8 +12267,8 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* in,
                 break;
             }
             wc_PKCS7_StreamStoreVar(pkcs7, encOID, expBlockSz, length);
-            pkcs7->stream->contentSz = blockKeySz;
-            pkcs7->stream->expected = length + MAX_LENGTH_SZ + MAX_LENGTH_SZ +
+            pkcs7->stream->contentSz = (word32)blockKeySz;
+            pkcs7->stream->expected = (word32)length + MAX_LENGTH_SZ + MAX_LENGTH_SZ +
                 ASN_TAG_SZ + ASN_TAG_SZ;
         #endif
             wc_PKCS7_ChangeState(pkcs7, WC_PKCS7_ENV_4);
@@ -12322,7 +12323,7 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* in,
             if ((ret = wc_PKCS7_StreamEndCase(pkcs7, &tmpIdx, &idx)) != 0) {
                 break;
             }
-            pkcs7->stream->expected = encryptedContentTotalSz;
+            pkcs7->stream->expected = (word32)encryptedContentTotalSz;
             wc_PKCS7_StreamGetVar(pkcs7, &encOID, &expBlockSz, 0);
             wc_PKCS7_StreamStoreVar(pkcs7, encOID, expBlockSz, explicitOctet);
         #endif
@@ -12339,12 +12340,12 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* in,
 
             wc_PKCS7_StreamGetVar(pkcs7, &encOID, &expBlockSz, &explicitOctet);
             tmpIv = pkcs7->stream->tmpIv;
-            encryptedContentTotalSz = pkcs7->stream->expected;
+            encryptedContentTotalSz = (int)pkcs7->stream->expected;
 
             /* restore decrypted key */
             decryptedKey   = pkcs7->stream->aad;
             decryptedKeySz = pkcs7->stream->aadSz;
-            blockKeySz = pkcs7->stream->contentSz;
+            blockKeySz = (int)pkcs7->stream->contentSz;
         #else
             ret = 0;
         #endif
@@ -12371,7 +12372,7 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* in,
 
                     if (ret == 0) {
                         ret = PKCS7_CacheEncryptedContent(pkcs7, &pkiMsg[idx],
-                                                          encryptedContentSz);
+                                                          (word32)encryptedContentSz);
                     }
 
                     if (ret != 0) {
@@ -12389,7 +12390,7 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* in,
             } else {
                 /* cache encrypted content, no OCTET STRING */
                 ret = PKCS7_CacheEncryptedContent(pkcs7, &pkiMsg[idx],
-                                                  encryptedContentTotalSz);
+                                                  (word32)encryptedContentTotalSz);
                 if (ret != 0) {
                     break;
                 }
@@ -12398,10 +12399,10 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* in,
 
             /* use cached content */
             encryptedContent = pkcs7->cachedEncryptedContent;
-            encryptedContentSz = pkcs7->cachedEncryptedContentSz;
+            encryptedContentSz = (int)pkcs7->cachedEncryptedContentSz;
 
             /* decrypt encryptedContent */
-            ret = wc_PKCS7_DecryptContent(pkcs7, encOID, decryptedKey,
+            ret = wc_PKCS7_DecryptContent(pkcs7, (int)encOID, decryptedKey,
                     blockKeySz, tmpIv, expBlockSz, NULL, 0, NULL, 0,
                     encryptedContent, encryptedContentSz, encryptedContent,
                     pkcs7->devId, pkcs7->heap);
@@ -12596,7 +12597,7 @@ int wc_PKCS7_EncodeAuthEnvelopedData(PKCS7* pkcs7, byte* output,
     verSz = SetMyVersion(0, ver, 0);
 
     /* generate random content encryption key */
-    ret = PKCS7_GenerateContentEncryptionKey(pkcs7, blockKeySz);
+    ret = PKCS7_GenerateContentEncryptionKey(pkcs7, (word32)blockKeySz);
     if (ret != 0) {
         return ret;
     }
@@ -12639,7 +12640,7 @@ int wc_PKCS7_EncodeAuthEnvelopedData(PKCS7* pkcs7, byte* output,
         WOLFSSL_MSG("You must add at least one CMS recipient");
         return PKCS7_RECIP_E;
     }
-    recipSetSz = SetSet(recipSz, recipSet);
+    recipSetSz = (int)SetSet((word32)recipSz, recipSet);
 
     /* generate random nonce and IV for encryption */
     switch (pkcs7->encryptOID) {
@@ -12711,7 +12712,7 @@ int wc_PKCS7_EncodeAuthEnvelopedData(PKCS7* pkcs7, byte* output,
                                 sizeof(contentTypeValue));
         if (ret > 0) {
             contentTypeAttrib.value = contentTypeValue;
-            contentTypeAttrib.valueSz = ret;
+            contentTypeAttrib.valueSz = (word32)ret;
 
         /* otherwise, try to set from custom content type */
         } else {
@@ -12749,7 +12750,7 @@ int wc_PKCS7_EncodeAuthEnvelopedData(PKCS7* pkcs7, byte* output,
         }
 
         ret = FlattenAttributes(pkcs7, flatAuthAttribs, authAttribs,
-                          authAttribsCount);
+                          (int)authAttribsCount);
         if (ret != 0) {
             wc_PKCS7_FreeEncodedRecipientSet(pkcs7);
             XFREE(flatAuthAttribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
@@ -12801,7 +12802,7 @@ int wc_PKCS7_EncodeAuthEnvelopedData(PKCS7* pkcs7, byte* output,
         }
 
         FlattenAttributes(pkcs7, flatUnauthAttribs, unauthAttribs,
-                          unauthAttribsCount);
+                          (int)unauthAttribsCount);
         unauthAttribsSetSz = SetImplicit(ASN_SET, 2, unauthAttribsSz,
                                          unauthAttribSet, 0);
     }
@@ -12809,7 +12810,7 @@ int wc_PKCS7_EncodeAuthEnvelopedData(PKCS7* pkcs7, byte* output,
     /* AES-GCM/CCM does NOT require padding for plaintext content or
      * AAD inputs RFC 5084 section 3.1 and 3.2, but we must alloc
      * full blocks to ensure crypto only gets full blocks */
-    encryptedOutSz = pkcs7->contentSz;
+    encryptedOutSz = (int)pkcs7->contentSz;
     encryptedAllocSz = (encryptedOutSz % blockSz) ?
                            encryptedOutSz + blockSz -
                            (encryptedOutSz % blockSz) :
@@ -12887,10 +12888,10 @@ int wc_PKCS7_EncodeAuthEnvelopedData(PKCS7* pkcs7, byte* output,
     contentTypeSz = ret;
 
     /* put together nonce OCTET STRING */
-    nonceOctetStringSz = SetOctetString(nonceSz, nonceOctetString);
+    nonceOctetStringSz = (int)SetOctetString(nonceSz, nonceOctetString);
 
     /* put together aes-ICVlen INTEGER */
-    macIntSz = SetMyVersion(sizeof(authTag), macInt, 0);
+    macIntSz = (word32)SetMyVersion(sizeof(authTag), macInt, 0);
 
     /* add nonce and icv len into parameters string RFC5084 */
     algoParamSeqSz = SetSequence(nonceOctetStringSz + nonceSz + macIntSz,
@@ -12899,7 +12900,7 @@ int wc_PKCS7_EncodeAuthEnvelopedData(PKCS7* pkcs7, byte* output,
     /* build up our ContentEncryptionAlgorithmIdentifier sequence,
      * adding (nonceOctetStringSz + blockSz + macIntSz) for nonce OCTET STRING
      * and tag size */
-    contentEncAlgoSz = SetAlgoID(pkcs7->encryptOID, contentEncAlgo,
+    contentEncAlgoSz = (int)SetAlgoID(pkcs7->encryptOID, contentEncAlgo,
                                  oidBlkType, nonceOctetStringSz + nonceSz +
                                  macIntSz + algoParamSeqSz);
 
@@ -12913,14 +12914,14 @@ int wc_PKCS7_EncodeAuthEnvelopedData(PKCS7* pkcs7, byte* output,
         return BAD_FUNC_ARG;
     }
 
-    encContentOctetSz = SetImplicit(ASN_OCTET_STRING, 0, encryptedOutSz,
+    encContentOctetSz = (int)SetImplicit(ASN_OCTET_STRING, 0, (word32)encryptedOutSz,
                                     encContentOctet, 0);
-    encContentSeqSz = SetSequence(contentTypeSz + contentEncAlgoSz +
+    encContentSeqSz = (int)SetSequence(contentTypeSz + contentEncAlgoSz +
                                   nonceOctetStringSz + nonceSz + macIntSz +
                                   algoParamSeqSz + encContentOctetSz +
                                   encryptedOutSz, encContentSeq);
 
-    macOctetStringSz = SetOctetString(sizeof(authTag), macOctetString);
+    macOctetStringSz = (int)SetOctetString(sizeof(authTag), macOctetString);
 
     /* keep track of sizes for outer wrapper layering */
     totalSz = verSz + recipSetSz + recipSz + encContentSeqSz + contentTypeSz +
@@ -12930,16 +12931,16 @@ int wc_PKCS7_EncodeAuthEnvelopedData(PKCS7* pkcs7, byte* output,
               sizeof(authTag) + unauthAttribsSz + unauthAttribsSetSz;
 
     /* EnvelopedData */
-    envDataSeqSz = SetSequence(totalSz, envDataSeq);
+    envDataSeqSz = (int)SetSequence((word32)totalSz, envDataSeq);
     totalSz += envDataSeqSz;
 
     /* outer content */
-    outerContentSz = SetExplicit(0, totalSz, outerContent, 0);
+    outerContentSz = (int)SetExplicit(0, (word32)totalSz, outerContent, 0);
     totalSz += outerContentTypeSz;
     totalSz += outerContentSz;
 
     /* ContentInfo */
-    contentInfoSeqSz = SetSequence(totalSz, contentInfoSeq);
+    contentInfoSeqSz = (int)SetSequence((word32)totalSz, contentInfoSeq);
     totalSz += contentInfoSeqSz;
 
     if (totalSz > (int)outputSz) {
@@ -13185,7 +13186,7 @@ WOLFSSL_API int wc_PKCS7_DecodeAuthEnvelopedData(PKCS7* pkcs7, byte* in,
             }
 
             if (ret == 0) {
-                pkcs7->contentOID = contentType;
+                pkcs7->contentOID = (int)contentType;
             }
 
             if (ret == 0 && GetAlgoId(pkiMsg, &idx, &encOID, oidBlkType,
@@ -13194,14 +13195,14 @@ WOLFSSL_API int wc_PKCS7_DecodeAuthEnvelopedData(PKCS7* pkcs7, byte* in,
             }
 
             if (ret == 0) {
-                blockKeySz = wc_PKCS7_GetOIDKeySize(encOID);
+                blockKeySz = wc_PKCS7_GetOIDKeySize((int)encOID);
                 if (blockKeySz < 0) {
                     ret = blockKeySz;
                 }
             }
 
             if (ret == 0) {
-                expBlockSz = wc_PKCS7_GetOIDBlockSize(encOID);
+                expBlockSz = wc_PKCS7_GetOIDBlockSize((int)encOID);
                 if (expBlockSz < 0) {
                     ret = expBlockSz;
                 }
@@ -13317,7 +13318,7 @@ WOLFSSL_API int wc_PKCS7_DecodeAuthEnvelopedData(PKCS7* pkcs7, byte* in,
 
             /* store nonce for later */
             if (nonceSz > 0) {
-                pkcs7->stream->nonceSz = nonceSz;
+                pkcs7->stream->nonceSz = (word32)nonceSz;
                 pkcs7->stream->nonce = (byte*)XMALLOC(nonceSz, pkcs7->heap,
                         DYNAMIC_TYPE_PKCS7);
                 if (pkcs7->stream->nonce == NULL) {
@@ -13329,7 +13330,7 @@ WOLFSSL_API int wc_PKCS7_DecodeAuthEnvelopedData(PKCS7* pkcs7, byte* in,
                 }
             }
 
-            pkcs7->stream->expected = encryptedContentSz;
+            pkcs7->stream->expected = (word32)encryptedContentSz;
             wc_PKCS7_StreamStoreVar(pkcs7, encOID, blockKeySz,
                     encryptedContentSz);
         #endif
@@ -13346,7 +13347,7 @@ WOLFSSL_API int wc_PKCS7_DecodeAuthEnvelopedData(PKCS7* pkcs7, byte* in,
             }
             pkiMsgSz = (pkcs7->stream->length > 0)? pkcs7->stream->length: inSz;
 
-            encryptedContentSz = pkcs7->stream->expected;
+            encryptedContentSz = (int)pkcs7->stream->expected;
         #else
             pkiMsgSz = inSz;
         #endif
@@ -13358,7 +13359,7 @@ WOLFSSL_API int wc_PKCS7_DecodeAuthEnvelopedData(PKCS7* pkcs7, byte* in,
                 if (encOID == 0)
                     expBlockSz = 1;
                 else {
-                    expBlockSz = wc_PKCS7_GetOIDBlockSize(encOID);
+                    expBlockSz = wc_PKCS7_GetOIDBlockSize((int)encOID);
                     if (expBlockSz < 0) {
                         ret = expBlockSz;
                         break;
@@ -13399,7 +13400,7 @@ WOLFSSL_API int wc_PKCS7_DecodeAuthEnvelopedData(PKCS7* pkcs7, byte* in,
                 if (GetLength(pkiMsg, &idx, &length, pkiMsgSz) <= 0)
                     ret = ASN_PARSE_E;
             #ifndef NO_PKCS7_STREAM
-                pkcs7->stream->expected = length;
+                pkcs7->stream->expected = (word32)length;
             #endif
                 encodedAttribSz = length + (idx - encodedAttribIdx);
 
@@ -13444,7 +13445,7 @@ WOLFSSL_API int wc_PKCS7_DecodeAuthEnvelopedData(PKCS7* pkcs7, byte* in,
                 return ret;
             }
 
-            length = pkcs7->stream->expected;
+            length = (int)pkcs7->stream->expected;
             encodedAttribs = pkcs7->stream->aad;
     #endif
 
@@ -13532,7 +13533,7 @@ authenv_atrbend:
 
             /* store tag for later */
             if (authTagSz > 0) {
-                pkcs7->stream->tagSz = authTagSz;
+                pkcs7->stream->tagSz = (word32)authTagSz;
                 pkcs7->stream->tag = (byte*)XMALLOC(authTagSz, pkcs7->heap,
                         DYNAMIC_TYPE_PKCS7);
                 if (pkcs7->stream->tag == NULL) {
@@ -13557,7 +13558,7 @@ authenv_atrbend:
 
             /* restore all variables needed */
             if (pkcs7->stream->nonceSz > 0) {
-                nonceSz = pkcs7->stream->nonceSz;
+                nonceSz = (int)pkcs7->stream->nonceSz;
                 if (nonceSz > GCM_NONCE_MID_SZ) {
                     WOLFSSL_MSG("PKCS7 saved nonce is too large");
                     ret = BUFFER_E;
@@ -13569,7 +13570,7 @@ authenv_atrbend:
             }
 
             if (pkcs7->stream->tagSz > 0) {
-                authTagSz = pkcs7->stream->tagSz;
+                authTagSz = (int)pkcs7->stream->tagSz;
                 if (authTagSz > AES_BLOCK_SIZE) {
                     WOLFSSL_MSG("PKCS7 saved tag is too large");
                     ret = BUFFER_E;
@@ -13594,9 +13595,9 @@ authenv_atrbend:
         #endif
 
             /* decrypt encryptedContent */
-            ret = wc_PKCS7_DecryptContent(pkcs7, encOID, decryptedKey,
+            ret = wc_PKCS7_DecryptContent(pkcs7, (int)encOID, decryptedKey,
                     blockKeySz, nonce, nonceSz, encodedAttribs, encodedAttribSz,
-                    authTag, authTagSz, encryptedContent, encryptedContentSz,
+                    authTag, (word32)authTagSz, encryptedContent, encryptedContentSz,
                     encryptedContent, pkcs7->devId, pkcs7->heap);
             if (ret != 0) {
                 XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
@@ -13612,7 +13613,7 @@ authenv_atrbend:
             XMEMCPY(output, encryptedContent, encryptedContentSz);
 
             /* free memory, zero out keys */
-            ForceZero(encryptedContent, encryptedContentSz);
+            ForceZero(encryptedContent, (word32)encryptedContentSz);
             XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
             ForceZero(decryptedKey, MAX_ENCRYPTED_KEY_SZ);
         #ifdef WOLFSSL_SMALL_STACK
@@ -13741,7 +13742,7 @@ int wc_PKCS7_EncodeEncryptedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     if (blockSz < 0)
         return blockSz;
 
-    padSz = wc_PKCS7_GetPadSize(pkcs7->contentSz, blockSz);
+    padSz = wc_PKCS7_GetPadSize(pkcs7->contentSz, (word32)blockSz);
     if (padSz < 0)
         return padSz;
 
@@ -13753,7 +13754,7 @@ int wc_PKCS7_EncodeEncryptedData(PKCS7* pkcs7, byte* output, word32 outputSz)
         return MEMORY_E;
 
     ret = wc_PKCS7_PadData(pkcs7->content, pkcs7->contentSz, plain,
-                           encryptedOutSz, blockSz);
+                           (word32)encryptedOutSz, blockSz);
     if (ret < 0) {
         XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         return ret;
@@ -13767,11 +13768,11 @@ int wc_PKCS7_EncodeEncryptedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     }
 
     /* put together IV OCTET STRING */
-    ivOctetStringSz = SetOctetString(blockSz, ivOctetString);
+    ivOctetStringSz = (int)SetOctetString((word32)blockSz, ivOctetString);
 
     /* build up ContentEncryptionAlgorithmIdentifier sequence,
        adding (ivOctetStringSz + blockSz) for IV OCTET STRING */
-    contentEncAlgoSz = SetAlgoID(pkcs7->encryptOID, contentEncAlgo,
+    contentEncAlgoSz = (int)SetAlgoID(pkcs7->encryptOID, contentEncAlgo,
                                  oidBlkType, ivOctetStringSz + blockSz);
     if (contentEncAlgoSz == 0) {
         XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
@@ -13781,7 +13782,7 @@ int wc_PKCS7_EncodeEncryptedData(PKCS7* pkcs7, byte* output, word32 outputSz)
 
     /* encrypt content */
     WOLFSSL_MSG("Encrypting the content");
-    ret = wc_PKCS7_GenerateBlock(pkcs7, NULL, tmpIv, blockSz);
+    ret = wc_PKCS7_GenerateBlock(pkcs7, NULL, tmpIv, (word32)blockSz);
     if (ret != 0) {
         XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
@@ -13797,10 +13798,10 @@ int wc_PKCS7_EncodeEncryptedData(PKCS7* pkcs7, byte* output, word32 outputSz)
         return ret;
     }
 
-    encContentOctetSz = SetImplicit(ASN_OCTET_STRING, 0,
-                                    encryptedOutSz, encContentOctet, 0);
+    encContentOctetSz = (int)SetImplicit(ASN_OCTET_STRING, 0,
+                                    (word32)encryptedOutSz, encContentOctet, 0);
 
-    encContentSeqSz = SetSequence(contentTypeSz + contentEncAlgoSz +
+    encContentSeqSz = (int)SetSequence(contentTypeSz + contentEncAlgoSz +
                                   ivOctetStringSz + blockSz +
                                   encContentOctetSz + encryptedOutSz,
                                   encContentSeq);
@@ -13836,7 +13837,7 @@ int wc_PKCS7_EncodeEncryptedData(PKCS7* pkcs7, byte* output, word32 outputSz)
             return MEMORY_E;
         }
 
-        ret = FlattenAttributes(pkcs7, flatAttribs, attribs, attribsCount);
+        ret = FlattenAttributes(pkcs7, flatAttribs, attribs, (int)attribsCount);
         if (ret != 0) {
             XFREE(attribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
             XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
@@ -13857,16 +13858,16 @@ int wc_PKCS7_EncodeEncryptedData(PKCS7* pkcs7, byte* output, word32 outputSz)
               attribsSz + attribsSetSz;
 
     /* EncryptedData */
-    encDataSeqSz = SetSequence(totalSz, encDataSeq);
+    encDataSeqSz = (int)SetSequence((word32)totalSz, encDataSeq);
     totalSz += encDataSeqSz;
 
     if (pkcs7->version != 3) {
         /* outer content */
-        outerContentSz = SetExplicit(0, totalSz, outerContent, 0);
+        outerContentSz = (int)SetExplicit(0, (word32)totalSz, outerContent, 0);
         totalSz += outerContentTypeSz;
         totalSz += outerContentSz;
         /* ContentInfo */
-        contentInfoSeqSz = SetSequence(totalSz, contentInfoSeq);
+        contentInfoSeqSz = (int)SetSequence((word32)totalSz, contentInfoSeq);
         totalSz += contentInfoSeqSz;
     } else {
         contentInfoSeqSz = 0;
@@ -14103,27 +14104,27 @@ int wc_PKCS7_DecodeEncryptedData(PKCS7* pkcs7, byte* in, word32 inSz,
                 ret = ASN_PARSE_E;
 
             if (ret == 0) {
-                pkcs7->contentOID = contentType;
+                pkcs7->contentOID = (int)contentType;
             }
 
             if (ret == 0 && (ret = GetAlgoId(pkiMsg, &idx, &encOID, oidBlkType,
                         pkiMsgSz)) < 0)
                 ret = ASN_PARSE_E;
-            if (ret == 0 && (expBlockSz = wc_PKCS7_GetOIDBlockSize(encOID)) < 0)
+            if (ret == 0 && (expBlockSz = wc_PKCS7_GetOIDBlockSize((int)encOID)) < 0)
                 ret = expBlockSz;
 
             if (ret != 0) break;
 #ifndef NO_PKCS7_STREAM
             /* store expBlockSz for later */
-            pkcs7->stream->varOne = expBlockSz;
-            pkcs7->stream->varTwo = encOID;
+            pkcs7->stream->varOne = (word32)expBlockSz;
+            pkcs7->stream->varTwo = (int)encOID;
 
             if ((ret = wc_PKCS7_StreamEndCase(pkcs7, &tmpIdx, &idx)) != 0) {
                 break;
             }
 
             /* store version for later */
-            pkcs7->stream->vers = version;
+            pkcs7->stream->vers = (word32)version;
 #endif
             wc_PKCS7_ChangeState(pkcs7, WC_PKCS7_STAGE4);
             FALL_THROUGH;
@@ -14139,7 +14140,7 @@ int wc_PKCS7_DecodeEncryptedData(PKCS7* pkcs7, byte* in, word32 inSz,
             pkiMsgSz = (pkcs7->stream->length > 0)? pkcs7->stream->length: inSz;
 
             /* restore saved variables */
-            expBlockSz = pkcs7->stream->varOne;
+            expBlockSz = (int)pkcs7->stream->varOne;
 #endif
             if (ret == 0 && GetASNTag(pkiMsg, &idx, &tag, pkiMsgSz) < 0)
                 ret = ASN_PARSE_E;
@@ -14157,7 +14158,7 @@ int wc_PKCS7_DecodeEncryptedData(PKCS7* pkcs7, byte* in, word32 inSz,
             if (ret != 0) break;
 #ifndef NO_PKCS7_STREAM
             /* next chunk of data expected should have the IV */
-            pkcs7->stream->expected = length;
+            pkcs7->stream->expected = (word32)length;
 
             if ((ret = wc_PKCS7_StreamEndCase(pkcs7, &tmpIdx, &idx)) != 0) {
                 break;
@@ -14178,7 +14179,7 @@ int wc_PKCS7_DecodeEncryptedData(PKCS7* pkcs7, byte* in, word32 inSz,
 
             /* use IV buffer from stream structure */
             tmpIv  = pkcs7->stream->tmpIv;
-            length = pkcs7->stream->expected;
+            length = (int)pkcs7->stream->expected;
 #endif
             XMEMCPY(tmpIv, &pkiMsg[idx], length);
             idx += length;
@@ -14223,10 +14224,10 @@ int wc_PKCS7_DecodeEncryptedData(PKCS7* pkcs7, byte* in, word32 inSz,
             pkiMsgSz = (pkcs7->stream->length > 0)? pkcs7->stream->length: inSz;
 
             /* restore saved variables */
-            expBlockSz = pkcs7->stream->varOne;
-            encOID     = pkcs7->stream->varTwo;
+            expBlockSz = (int)pkcs7->stream->varOne;
+            encOID     = (word32)pkcs7->stream->varTwo;
             encryptedContentSz = pkcs7->stream->varThree;
-            version    = pkcs7->stream->vers;
+            version    = (int)pkcs7->stream->vers;
             tmpIv      = pkcs7->stream->tmpIv;
 #endif
             if (ret == 0 && (encryptedContent = (byte*)XMALLOC(
@@ -14240,7 +14241,7 @@ int wc_PKCS7_DecodeEncryptedData(PKCS7* pkcs7, byte* in, word32 inSz,
                 idx += encryptedContentSz;
 
                 /* decrypt encryptedContent */
-                ret = wc_PKCS7_DecryptContent(pkcs7, encOID,
+                ret = wc_PKCS7_DecryptContent(pkcs7, (int)encOID,
                             pkcs7->encryptionKey, pkcs7->encryptionKeySz, tmpIv,
                             expBlockSz, NULL, 0, NULL, 0, encryptedContent,
                             encryptedContentSz, encryptedContent,
@@ -14277,7 +14278,7 @@ int wc_PKCS7_DecodeEncryptedData(PKCS7* pkcs7, byte* in, word32 inSz,
                     ret = wc_PKCS7_DecodeUnprotectedAttributes(pkcs7, pkiMsg,
                                                        pkiMsgSz, &idx);
                     if (ret != 0) {
-                        ForceZero(encryptedContent, encryptedContentSz);
+                        ForceZero(encryptedContent, (word32)encryptedContentSz);
                         XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
                         ret = ASN_PARSE_E;
                     }
@@ -14285,7 +14286,7 @@ int wc_PKCS7_DecodeEncryptedData(PKCS7* pkcs7, byte* in, word32 inSz,
             }
 
             if (ret == 0) {
-                ForceZero(encryptedContent, encryptedContentSz);
+                ForceZero(encryptedContent, (word32)encryptedContentSz);
                 XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 
                 /* go back and check the version now that attribs have been processed */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -2174,7 +2174,7 @@ static wc_test_ret_t _SaveDerAndPem(const byte* der, int derSz,
     if (!derFile) {
         return WC_TEST_RET_ENC(calling_line, 0, WC_TEST_RET_TAG_I);
     }
-    ret = (int)XFWRITE(der, 1, derSz, derFile);
+    ret = (int)XFWRITE(der, 1, (size_t)derSz, derFile);
     XFCLOSE(derFile);
     if (ret != derSz) {
         return WC_TEST_RET_ENC(calling_line, 1, WC_TEST_RET_TAG_I);
@@ -2194,7 +2194,7 @@ static wc_test_ret_t _SaveDerAndPem(const byte* der, int derSz,
         int pemSz;
 
         /* calculate PEM size */
-        pemSz = wc_DerToPem(der, derSz, NULL, 0, pemType);
+        pemSz = wc_DerToPem(der, (word32)derSz, NULL, 0, pemType);
         if (pemSz < 0) {
             return WC_TEST_RET_ENC(calling_line, 2, WC_TEST_RET_TAG_I);
         }
@@ -2208,7 +2208,7 @@ static wc_test_ret_t _SaveDerAndPem(const byte* der, int derSz,
             return BAD_FUNC_ARG;
     #endif
         /* Convert to PEM */
-        pemSz = wc_DerToPem(der, derSz, pem, pemSz, pemType);
+        pemSz = wc_DerToPem(der, (word32)derSz, pem, pemSz, pemType);
         if (pemSz < 0) {
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             return WC_TEST_RET_ENC(calling_line, 4, WC_TEST_RET_TAG_I);
@@ -2219,7 +2219,7 @@ static wc_test_ret_t _SaveDerAndPem(const byte* der, int derSz,
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             return WC_TEST_RET_ENC(calling_line, 5, WC_TEST_RET_TAG_I);
         }
-        ret = (int)XFWRITE(pem, 1, pemSz, pemFile);
+        ret = (int)XFWRITE(pem, 1, (size_t)pemSz, pemFile);
         XFCLOSE(pemFile);
         if (ret != pemSz) {
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -3104,7 +3104,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t blake2b_test(void)
         if (ret != 0)
             return WC_TEST_RET_ENC_I(i);
 
-        ret = wc_Blake2bUpdate(&b2b, input, i);
+        ret = wc_Blake2bUpdate(&b2b, input, (word32)i);
         if (ret != 0)
             return WC_TEST_RET_ENC_I(i);
 
@@ -3166,7 +3166,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t blake2s_test(void)
         if (ret != 0)
             return WC_TEST_RET_ENC_I(i);
 
-        ret = wc_Blake2sUpdate(&b2s, input, i);
+        ret = wc_Blake2sUpdate(&b2s, input, (word32)i);
         if (ret != 0)
             return WC_TEST_RET_ENC_I(i);
 
@@ -5611,7 +5611,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hash_test(void)
             if (ret != BUFFER_E)
                 return WC_TEST_RET_ENC_I(i);
         }
-        ret = wc_Hash(typesGood[i], data, sizeof(data), hashOut, digestSz);
+        ret = wc_Hash(typesGood[i], data, sizeof(data), hashOut, (word32)digestSz);
         if (ret != exp_ret)
             return WC_TEST_RET_ENC_I(i);
         if (exp_ret == 0 && XMEMCMP(out, hashOut, digestSz) != 0)
@@ -6601,7 +6601,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hmac_sha3_test(void)
             ret = wc_HmacFinal(&hmac, hash);
             if (ret != 0)
                 return WC_TEST_RET_ENC_EC(ret);
-            if (XMEMCMP(hash, output[(i*jMax) + j], hashSz[j]) != 0)
+            if (XMEMCMP(hash, output[(i*jMax) + j], (size_t)hashSz[j]) != 0)
                 return WC_TEST_RET_ENC_NC;
 
             wc_HmacFree(&hmac);
@@ -7019,10 +7019,10 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t arc4_test(void)
         if (ret != 0)
             return WC_TEST_RET_ENC_EC(ret);
 
-        ret = wc_Arc4SetKey(&enc, (byte*)keys[i], keylen);
+        ret = wc_Arc4SetKey(&enc, (byte*)keys[i], (word32)keylen);
         if (ret != 0)
             return WC_TEST_RET_ENC_EC(ret);
-        ret = wc_Arc4SetKey(&dec, (byte*)keys[i], keylen);
+        ret = wc_Arc4SetKey(&dec, (byte*)keys[i], (word32)keylen);
         if (ret != 0)
             return WC_TEST_RET_ENC_EC(ret);
 
@@ -7370,8 +7370,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t chacha_test(void)
         if (ret != 0)
             return ret;
 
-        ret |= wc_Chacha_Process(&enc, cipher_big, plain_big , block_size);
-        ret |= wc_Chacha_Process(&dec, plain_big , cipher_big, block_size);
+        ret |= wc_Chacha_Process(&enc, cipher_big, plain_big , (word32)block_size);
+        ret |= wc_Chacha_Process(&dec, plain_big , cipher_big, (word32)block_size);
         if (ret != 0)
             return ret;
 
@@ -7401,19 +7401,19 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t chacha_test(void)
             return WC_TEST_RET_ENC_EC(ret);
 
         for (j = 0; j < CHACHA_BIG_TEST_SIZE - i; j+= i) {
-            ret = wc_Chacha_Process(&enc, cipher_big + j, plain_big + j, i);
+            ret = wc_Chacha_Process(&enc, cipher_big + j, plain_big + j, (word32)i);
             if (ret != 0)
                 return WC_TEST_RET_ENC_EC(ret);
-            ret = wc_Chacha_Process(&dec, plain_big + j, cipher_big + j, i);
+            ret = wc_Chacha_Process(&dec, plain_big + j, cipher_big + j, (word32)i);
             if (ret != 0)
                 return WC_TEST_RET_ENC_EC(ret);
         }
 
         rem = CHACHA_BIG_TEST_SIZE - j;
-        ret = wc_Chacha_Process(&enc, cipher_big + j, plain_big + j, rem);
+        ret = wc_Chacha_Process(&enc, cipher_big + j, plain_big + j, (word32)rem);
         if (ret != 0)
             return WC_TEST_RET_ENC_EC(ret);
-        ret = wc_Chacha_Process(&dec, plain_big + j, cipher_big + j, rem);
+        ret = wc_Chacha_Process(&dec, plain_big + j, cipher_big + j, (word32)rem);
         if (ret != 0)
             return WC_TEST_RET_ENC_EC(ret);
 
@@ -10218,7 +10218,7 @@ static wc_test_ret_t aes_xts_128_test(void)
             ret = wc_AesXtsSetKeyNoInit(aes, k1, sizeof(k1), AES_ENCRYPTION);
             if (ret != 0)
                 ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
-            ret = wc_AesXtsEncrypt(aes, large_input, large_input, j, i1,
+            ret = wc_AesXtsEncrypt(aes, large_input, large_input, (word32)j, i1,
                 sizeof(i1));
         #if defined(WOLFSSL_ASYNC_CRYPT)
             ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
@@ -10229,7 +10229,7 @@ static wc_test_ret_t aes_xts_128_test(void)
             ret = wc_AesXtsSetKeyNoInit(aes, k1, sizeof(k1), AES_DECRYPTION);
             if (ret != 0)
                 ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
-            ret = wc_AesXtsDecrypt(aes, large_input, large_input, j, i1,
+            ret = wc_AesXtsDecrypt(aes, large_input, large_input, (word32)j, i1,
                 sizeof(i1));
         #if defined(WOLFSSL_ASYNC_CRYPT)
             #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
@@ -11676,33 +11676,33 @@ static wc_test_ret_t aesctr_test(Aes* enc, Aes* dec, byte* cipher, byte* plain)
 
     for (i = 0; i < AES_CTR_TEST_LEN; i++) {
         if (testVec[i].key != NULL) {
-            ret = wc_AesSetKeyDirect(enc, testVec[i].key, testVec[i].keySz,
+            ret = wc_AesSetKeyDirect(enc, testVec[i].key, (word32)testVec[i].keySz,
                 testVec[i].iv, AES_ENCRYPTION);
             if (ret != 0) {
                 ERROR_OUT(WC_TEST_RET_ENC_I(i), out);
             }
             /* Ctr only uses encrypt, even on key setup */
-            ret = wc_AesSetKeyDirect(dec, testVec[i].key, testVec[i].keySz,
+            ret = wc_AesSetKeyDirect(dec, testVec[i].key, (word32)testVec[i].keySz,
                 testVec[i].iv, AES_ENCRYPTION);
             if (ret != 0) {
                 ERROR_OUT(WC_TEST_RET_ENC_I(i), out);
             }
         }
 
-        ret = wc_AesCtrEncrypt(enc, cipher, testVec[i].plain, testVec[i].len);
+        ret = wc_AesCtrEncrypt(enc, cipher, testVec[i].plain, (word32)testVec[i].len);
         if (ret != 0) {
             ERROR_OUT(WC_TEST_RET_ENC_I(i), out);
         }
-        ret = wc_AesCtrEncrypt(dec, plain, cipher, testVec[i].len);
+        ret = wc_AesCtrEncrypt(dec, plain, cipher, (word32)testVec[i].len);
         if (ret != 0) {
             ERROR_OUT(WC_TEST_RET_ENC_I(i), out);
         }
 
-        if (XMEMCMP(plain, ctrPlain, testVec[i].len)) {
+        if (XMEMCMP(plain, ctrPlain, (size_t)testVec[i].len)) {
             ERROR_OUT(WC_TEST_RET_ENC_I(i), out);
         }
 #if !(FIPS_VERSION_EQ(2,0) && defined(WOLFSSL_ARMASM))
-        if (XMEMCMP(cipher, testVec[i].cipher, testVec[i].len)) {
+        if (XMEMCMP(cipher, testVec[i].cipher, (size_t)testVec[i].len)) {
             ERROR_OUT(WC_TEST_RET_ENC_I(i), out);
         }
 #endif
@@ -12572,11 +12572,11 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes256_test(void)
     dec_inited = 1;
 #endif
 
-    ret = wc_AesSetKey(enc, key, keySz, iv, AES_ENCRYPTION);
+    ret = wc_AesSetKey(enc, key, (word32)keySz, iv, AES_ENCRYPTION);
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 #ifdef HAVE_AES_DECRYPT
-    ret = wc_AesSetKey(dec, key, keySz, iv, AES_DECRYPTION);
+    ret = wc_AesSetKey(dec, key, (word32)keySz, iv, AES_DECRYPTION);
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 #endif
@@ -12755,13 +12755,13 @@ static wc_test_ret_t aesgcm_default_test_helper(byte* key, int keySz, byte* iv, 
     else
         dec_inited = 1;
 
-    ret = wc_AesGcmSetKey(enc, key, keySz);
+    ret = wc_AesGcmSetKey(enc, key, (word32)keySz);
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
     /* AES-GCM encrypt and decrypt both use AES encrypt internally */
-    ret = wc_AesGcmEncrypt(enc, resultC, plain, plainSz, iv, ivSz,
-                                     resultT, tagSz, aad, aadSz);
+    ret = wc_AesGcmEncrypt(enc, resultC, plain, (word32)plainSz, iv, ivSz,
+                                     resultT, (word32)tagSz, aad, aadSz);
 #if defined(WOLFSSL_ASYNC_CRYPT)
     ret = wc_AsyncWait(ret, &enc->asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
@@ -12793,12 +12793,12 @@ static wc_test_ret_t aesgcm_default_test_helper(byte* key, int keySz, byte* iv, 
 #endif
 
 #ifdef HAVE_AES_DECRYPT
-    ret = wc_AesGcmSetKey(dec, key, keySz);
+    ret = wc_AesGcmSetKey(dec, key, (word32)keySz);
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
-    ret = wc_AesGcmDecrypt(dec, resultP, resultC, cipherSz,
-                   iv, ivSz, resultT, tagSz, aad, aadSz);
+    ret = wc_AesGcmDecrypt(dec, resultP, resultC, (word32)cipherSz,
+                   iv, (word32)ivSz, resultT, tagSz, aad, aadSz);
 #if defined(WOLFSSL_ASYNC_CRYPT)
     ret = wc_AsyncWait(ret, &dec->asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
@@ -13199,7 +13199,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aesgcm_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
 #ifdef WOLFSSL_AES_256
-    ret = wc_AesGcmSetKey(enc, k1, k1Sz);
+    ret = wc_AesGcmSetKey(enc, k1, (word32)k1Sz);
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
@@ -13219,7 +13219,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aesgcm_test(void)
 #endif
 
 #ifdef HAVE_AES_DECRYPT
-    ret = wc_AesGcmSetKey(dec, k1, k1Sz);
+    ret = wc_AesGcmSetKey(dec, k1, (word32)k1Sz);
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
@@ -13365,7 +13365,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aesgcm_test(void)
     for (plen=1; plen<BENCH_AESGCM_LARGE; plen++) {
         /* AES-GCM encrypt and decrypt both use AES encrypt internally */
         ret = wc_AesGcmEncrypt(enc, large_output, large_input,
-                                  plen, iv1, sizeof(iv1), resultT,
+                                  (word32)plen, iv1, sizeof(iv1), resultT,
                                   sizeof(t1), a, sizeof(a));
 #if defined(WOLFSSL_ASYNC_CRYPT)
         ret = wc_AsyncWait(ret, &enc->asyncDev, WC_ASYNC_FLAG_NONE);
@@ -13375,7 +13375,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aesgcm_test(void)
 
 #ifdef HAVE_AES_DECRYPT
         ret = wc_AesGcmDecrypt(dec, large_outdec, large_output,
-                                  plen, iv1, sizeof(iv1), resultT,
+                                  (word32)plen, iv1, sizeof(iv1), resultT,
                                   sizeof(t1), a, sizeof(a));
 #if defined(WOLFSSL_ASYNC_CRYPT)
         ret = wc_AsyncWait(ret, &dec->asyncDev, WC_ASYNC_FLAG_NONE);
@@ -13444,8 +13444,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aesgcm_test(void)
 
     /* Large buffer test */
 #ifdef BENCH_AESGCM_LARGE
-    wc_AesGcmSetKey(enc, k2, k3Sz);
-    wc_AesGcmSetKey(dec, k2, k3Sz);
+    wc_AesGcmSetKey(enc, k2, (word32)k3Sz);
+    wc_AesGcmSetKey(dec, k2, (word32)k3Sz);
     /* setup test buffer */
     for (alen=0; alen<BENCH_AESGCM_LARGE; alen++)
         large_input[alen] = (byte)alen;
@@ -13479,7 +13479,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aesgcm_test(void)
     XMEMSET(resultP, 0, sizeof(resultP));
 #endif /* WOLFSSL_AES_192 */
 #ifdef WOLFSSL_AES_128
-    wc_AesGcmSetKey(enc, k3, k3Sz);
+    wc_AesGcmSetKey(enc, k3, (word32)k3Sz);
     /* AES-GCM encrypt and decrypt both use AES encrypt internally */
     ret = wc_AesGcmEncrypt(enc, resultC, p3, sizeof(p3), iv3, sizeof(iv3),
                                         resultT, sizeof(t3), a3, sizeof(a3));
@@ -13509,8 +13509,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aesgcm_test(void)
 
     /* Large buffer test */
 #ifdef BENCH_AESGCM_LARGE
-    wc_AesGcmSetKey(enc, k3, k3Sz);
-    wc_AesGcmSetKey(dec, k3, k3Sz);
+    wc_AesGcmSetKey(enc, k3, (word32)k3Sz);
+    wc_AesGcmSetKey(dec, k3, (word32)k3Sz);
     /* setup test buffer */
     for (alen=0; alen<BENCH_AESGCM_LARGE; alen++)
         large_input[alen] = (byte)alen;
@@ -13549,7 +13549,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aesgcm_test(void)
     XMEMSET(resultC, 0, sizeof(resultC));
     XMEMSET(resultP, 0, sizeof(resultP));
 
-    wc_AesGcmSetKey(enc, k1, k1Sz);
+    wc_AesGcmSetKey(enc, k1, (word32)k1Sz);
     /* AES-GCM encrypt and decrypt both use AES encrypt internally */
     ret = wc_AesGcmEncrypt(enc, resultC, p, sizeof(p), iv1, sizeof(iv1),
                                 resultT + 1, sizeof(t1) - 1, a, sizeof(a));
@@ -13595,7 +13595,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aesgcm_test(void)
         XMEMSET(resultC, 0, sizeof(resultC));
         XMEMSET(resultP, 0, sizeof(resultP));
 
-        wc_AesGcmSetKey(enc, k1, k1Sz);
+        wc_AesGcmSetKey(enc, k1, (word32)k1Sz);
         ret = wc_AesGcmSetIV(enc, sizeof(randIV), NULL, 0, &rng);
         if (ret != 0)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -13622,7 +13622,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aesgcm_test(void)
         }
 
 #ifdef HAVE_AES_DECRYPT
-        wc_AesGcmSetKey(dec, k1, k1Sz);
+        wc_AesGcmSetKey(dec, k1, (word32)k1Sz);
         ret = wc_AesGcmSetIV(dec, sizeof(randIV), NULL, 0, &rng);
         if (ret != 0)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -13687,7 +13687,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aesgcm_test(void)
         for (plen = 0; plen < (int)sizeof(a); plen += alen)  {
             int len = sizeof(a) - plen;
             if (len > alen) len = alen;
-            ret = wc_AesGcmEncryptUpdate(enc, NULL, NULL, 0, a + plen, len);
+            ret = wc_AesGcmEncryptUpdate(enc, NULL, NULL, 0, a + plen, (word32)len);
             if (ret != 0)
                 ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
         }
@@ -13695,7 +13695,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aesgcm_test(void)
         for (plen = 0; plen < (int)sizeof(p); plen += alen)  {
             int len = sizeof(p) - plen;
             if (len > alen) len = alen;
-            ret = wc_AesGcmEncryptUpdate(enc, resultC + plen, p + plen, len,
+            ret = wc_AesGcmEncryptUpdate(enc, resultC + plen, p + plen, (word32)len,
                 NULL, 0);
             if (ret != 0)
                 ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -13719,7 +13719,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aesgcm_test(void)
         for (plen = 0; plen < (int)sizeof(a); plen += alen)  {
             int len = sizeof(a) - plen;
             if (len > alen) len = alen;
-            ret = wc_AesGcmDecryptUpdate(enc, NULL, NULL, 0, a + plen, len);
+            ret = wc_AesGcmDecryptUpdate(enc, NULL, NULL, 0, a + plen, (word32)len);
             if (ret != 0)
                 ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
         }
@@ -13727,7 +13727,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aesgcm_test(void)
         for (plen = 0; plen < (int)sizeof(c1); plen += alen)  {
             int len = sizeof(c1) - plen;
             if (len > alen) len = alen;
-            ret = wc_AesGcmDecryptUpdate(enc, resultP + plen, c1 + plen, len,
+            ret = wc_AesGcmDecryptUpdate(enc, resultP + plen, c1 + plen, (word32)len,
                 NULL, 0);
             if (ret != 0)
                 ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -14441,18 +14441,18 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes_eax_test(void)
         XMEMSET(ciphertext, 0, sizeof(ciphertext));
 
         len = sizeof(authtag);
-        ret = wc_AesEaxEncryptAuth(vectors[i].key, vectors[i].key_length,
+        ret = wc_AesEaxEncryptAuth(vectors[i].key, (word32)vectors[i].key_length,
                                    ciphertext,
-                                   vectors[i].msg, vectors[i].msg_length,
-                                   vectors[i].iv, vectors[i].iv_length,
-                                   authtag, len,
-                                   vectors[i].aad, vectors[i].aad_length);
+                                   vectors[i].msg, (word32)vectors[i].msg_length,
+                                   vectors[i].iv, (word32)vectors[i].iv_length,
+                                   authtag, (word32)len,
+                                   vectors[i].aad, (word32)vectors[i].aad_length);
         if (ret != 0) {
             return WC_TEST_RET_ENC_EC(ret);
         }
 
         /* check ciphertext matches vector */
-        if (XMEMCMP(ciphertext, vectors[i].ct, vectors[i].ct_length)) {
+        if (XMEMCMP(ciphertext, vectors[i].ct, (size_t)vectors[i].ct_length)) {
             return WC_TEST_RET_ENC_NC;
         }
 
@@ -14467,18 +14467,18 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes_eax_test(void)
 
         XMEMSET(ciphertext, 0, sizeof(ciphertext));
 
-        ret = wc_AesEaxDecryptAuth(vectors[i].key, vectors[i].key_length,
+        ret = wc_AesEaxDecryptAuth(vectors[i].key, (word32)vectors[i].key_length,
                                    ciphertext,
-                                   vectors[i].ct, vectors[i].ct_length,
-                                   vectors[i].iv, vectors[i].iv_length,
-                                   authtag, len,
-                                   vectors[i].aad, vectors[i].aad_length);
+                                   vectors[i].ct, (word32)vectors[i].ct_length,
+                                   vectors[i].iv, (word32)vectors[i].iv_length,
+                                   authtag, (word32)len,
+                                   vectors[i].aad, (word32)vectors[i].aad_length);
         if (ret != 0) {
             return WC_TEST_RET_ENC_EC(ret);
         }
 
         /* check decrypted ciphertext matches vector plaintext */
-        if (XMEMCMP(ciphertext, vectors[i].msg, vectors[i].msg_length)) {
+        if (XMEMCMP(ciphertext, vectors[i].msg, (size_t)vectors[i].msg_length)) {
             return WC_TEST_RET_ENC_NC;
         }
 
@@ -14681,7 +14681,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aeskeywrap_test(void)
             return WC_TEST_RET_ENC_NC;
 
         plainSz = wc_AesKeyUnWrap((byte*)test_wrap[i].kek, test_wrap[i].kekLen,
-                                  output, wrapSz,
+                                  output, (word32)wrapSz,
                                   plain, sizeof(plain), NULL);
 
         if ( (plainSz < 0) || (plainSz != (int)test_wrap[i].dataLen) )
@@ -17911,7 +17911,7 @@ static wc_test_ret_t rsa_pss_test(WC_RNG* rng, RsaKey* key)
         ret = wc_Hash(hash[j], in, inLen, digest, sizeof(digest));
         if (ret != 0)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_pss);
-        digestSz = wc_HashGetDigestSize(hash[j]);
+        digestSz = (word32)wc_HashGetDigestSize(hash[j]);
 
 #ifdef WOLFSSL_SE050
         /* SE050 only supports MGF matched to same hash type */
@@ -17998,7 +17998,7 @@ static wc_test_ret_t rsa_pss_test(WC_RNG* rng, RsaKey* key)
 /* SE050 generates salts internally only of hash length */
 #ifndef WOLFSSL_SE050
     /* Test that a salt length of zero works. */
-    digestSz = wc_HashGetDigestSize(hash[0]);
+    digestSz = (word32)wc_HashGetDigestSize(hash[0]);
     outSz = RSA_TEST_BYTES;
     do {
     #if defined(WOLFSSL_ASYNC_CRYPT)
@@ -18084,7 +18084,7 @@ static wc_test_ret_t rsa_pss_test(WC_RNG* rng, RsaKey* key)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_pss);
 
     /* Test bad salt lengths in various APIs. */
-    digestSz = wc_HashGetDigestSize(hash[0]);
+    digestSz = (word32)wc_HashGetDigestSize(hash[0]);
     outSz = RSA_TEST_BYTES;
 #ifndef WOLFSSL_PSS_SALT_LEN_DISCOVER
     len = -2;
@@ -18165,9 +18165,9 @@ static wc_test_ret_t rsa_pss_test(WC_RNG* rng, RsaKey* key)
     if (ret != PSS_SALTLEN_E)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_pss);
 #ifndef WOLFSSL_PSS_LONG_SALT
-    len = digestSz + 1;
+    len = (int)(digestSz + 1);
 #else
-    len = plainSz - digestSz - 1;
+    len = (int)(plainSz - digestSz - 1);
 #endif
 #if defined(HAVE_SELFTEST) && \
     (!defined(HAVE_SELFTEST_VERSION) || (HAVE_SELFTEST_VERSION < 2))
@@ -18299,7 +18299,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_no_pad_test(void)
     }
 
 #ifndef WOLFSSL_RSA_VERIFY_ONLY
-    inLen = wc_RsaEncryptSize(key);
+    inLen = (word32)wc_RsaEncryptSize(key);
     outSz   = inLen;
     plainSz = inLen;
     XMEMSET(tmp, 7, inLen);
@@ -18361,7 +18361,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_no_pad_test(void)
         ret = wc_AsyncWait(ret, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     #endif
         if (ret >= 0) {
-            ret = wc_RsaPublicEncrypt_ex(tmp, inLen, out, (int)outSz, key, &rng,
+            ret = wc_RsaPublicEncrypt_ex(tmp, inLen, out, outSz, key, &rng,
                 WC_RSA_NO_PAD, WC_HASH_TYPE_NONE, WC_MGF1NONE, NULL, 0);
         }
     } while (ret == WC_PENDING_E);
@@ -18377,7 +18377,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_no_pad_test(void)
         ret = wc_AsyncWait(ret, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     #endif
         if (ret >= 0) {
-            ret = wc_RsaPrivateDecrypt_ex(out, outSz, plain, (int)plainSz, key,
+            ret = wc_RsaPrivateDecrypt_ex(out, outSz, plain, plainSz, key,
                 WC_RSA_NO_PAD, WC_HASH_TYPE_NONE, WC_MGF1NONE, NULL, 0);
         }
     } while (ret == WC_PENDING_E);
@@ -18723,7 +18723,7 @@ static wc_test_ret_t rsa_certgen_test(RsaKey* key, RsaKey* keypub, WC_RNG* rng, 
     if (ret < 0) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
     }
-    certSz = (word32)ret;
+    certSz = (int)ret;
 
 #ifdef WOLFSSL_TEST_CERT
     InitDecodedCert(decode, der, certSz, HEAP_HINT);
@@ -18883,7 +18883,7 @@ static wc_test_ret_t rsa_certgen_test(RsaKey* key, RsaKey* keypub, WC_RNG* rng, 
     } while (ret == WC_PENDING_E);
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
-    certSz = (word32)ret;
+    certSz = (int)ret;
 
 #ifdef WOLFSSL_TEST_CERT
     InitDecodedCert(decode, der, certSz, HEAP_HINT);
@@ -19112,7 +19112,7 @@ static wc_test_ret_t rsa_ecc_certgen_test(WC_RNG* rng, byte* tmp)
     } while (ret == WC_PENDING_E);
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
-    certSz = (word32)ret;
+    certSz = (int)ret;
 
 #ifdef WOLFSSL_TEST_CERT
     InitDecodedCert(decode, der, certSz, 0);
@@ -19249,7 +19249,7 @@ static wc_test_ret_t rsa_keygen_test(WC_RNG* rng)
 #ifndef WOLFSSL_CRYPTOCELL
     idx = 0;
     /* The private key part of the key gen pairs from cryptocell can't be exported */
-    ret = wc_RsaPrivateKeyDecode(der, &idx, genKey, derSz);
+    ret = wc_RsaPrivateKeyDecode(der, &idx, genKey, (word32)derSz);
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
 #endif /* WOLFSSL_CRYPTOCELL */
@@ -20190,7 +20190,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_test(void)
         } while (ret == WC_PENDING_E);
         if (ret < 0)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
-        derSz = (word32)ret;
+        derSz = (int)ret;
 
         ret = SaveDerAndPem(der, derSz, certReqDerFile, certReqPemFile,
                             CERTREQ_TYPE);
@@ -21477,7 +21477,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t dsa_test(void)
     derIn_inited = 1;
 
     idx = 0;
-    ret = wc_DsaPrivateKeyDecode(der, &idx, derIn, derSz);
+    ret = wc_DsaPrivateKeyDecode(der, &idx, derIn, (word32)derSz);
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     }
@@ -24376,7 +24376,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_pkey1_test(void)
 #endif
 
     XMEMSET(cipher, 0, RSA_TEST_BYTES);
-    outlen = keyLenBits/8;
+    outlen = (size_t)(keyLenBits/8);
     if (EVP_PKEY_encrypt(enc, cipher, &outlen, msg, sizeof(msg)) < 0) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto openssl_pkey1_test_done;
@@ -25052,7 +25052,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hkdf_test(void)
 
 #ifndef NO_SHA
     ret = wc_HKDF(WC_SHA, ikm1, (word32)sizeof(ikm1), NULL, 0, NULL, 0,
-        okm1, L);
+        okm1, (word32)L);
     if (ret != 0)
         return WC_TEST_RET_ENC_EC(ret);
 
@@ -25063,7 +25063,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hkdf_test(void)
     /* fips can't have key size under 14 bytes, salt is key too */
     L = (int)sizeof(okm1);
     ret = wc_HKDF(WC_SHA, ikm1, 11, salt1, (word32)sizeof(salt1),
-        info1, (word32)sizeof(info1), okm1, L);
+        info1, (word32)sizeof(info1), okm1, (word32)L);
     if (ret != 0)
         return WC_TEST_RET_ENC_EC(ret);
 
@@ -25074,7 +25074,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hkdf_test(void)
 
 #ifndef NO_SHA256
     ret = wc_HKDF(WC_SHA256, ikm1, (word32)sizeof(ikm1), NULL, 0, NULL, 0,
-        okm1, L);
+        okm1, (word32)L);
     if (ret != 0)
         return WC_TEST_RET_ENC_EC(ret);
 
@@ -25084,7 +25084,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hkdf_test(void)
 #ifndef HAVE_FIPS
     /* fips can't have key size under 14 bytes, salt is key too */
     ret = wc_HKDF(WC_SHA256, ikm1, (word32)sizeof(ikm1),
-        salt1, (word32)sizeof(salt1), info1, (word32)sizeof(info1), okm1, L);
+        salt1, (word32)sizeof(salt1), info1, (word32)sizeof(info1), okm1, (word32)L);
     if (ret != 0)
         return WC_TEST_RET_ENC_EC(ret);
 
@@ -25295,7 +25295,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t prf_test(void)
     int lblsdL = LBSL;
     int hash_type = sha384_mac;
 
-    ret = wc_PRF(dig, digL, secret, secL, lablSd, lblsdL, hash_type,
+    ret = wc_PRF(dig, (word32)digL, secret, secL, lablSd, lblsdL, hash_type,
                  HEAP_HINT, INVALID_DEVID);
     if (ret != 0) {
         printf("Failed w/ code: %d\n", ret);
@@ -25941,7 +25941,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t tls13_kdf_test(void)
 
         hashAlgSz = wc_HashGetDigestSize(tv->hashAlg);
         if (hashAlgSz == BAD_FUNC_ARG) break;
-        ret = wc_Hash(tv->hashAlg, NULL, 0, hashZero, hashAlgSz);
+        ret = wc_Hash(tv->hashAlg, NULL, 0, hashZero, (word32)hashAlgSz);
         if (ret != 0) break;
 
         ret = wc_Tls13_HKDF_Extract(secret, NULL, 0,
@@ -25949,105 +25949,105 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t tls13_kdf_test(void)
                 tv->pskSz, tv->hashAlg);
         if (ret != 0) break;
 
-        ret = wc_Tls13_HKDF_Expand_Label(output, hashAlgSz,
-                secret, hashAlgSz,
+        ret = wc_Tls13_HKDF_Expand_Label(output, (word32)hashAlgSz,
+                secret, (word32)hashAlgSz,
                 (byte*)protocolLabel, (word32)XSTRLEN(protocolLabel),
                 (byte*)ceTrafficLabel, (word32)XSTRLEN(ceTrafficLabel),
-                tv->hashHello1, hashAlgSz, tv->hashAlg);
+                tv->hashHello1, (word32)hashAlgSz, tv->hashAlg);
         if (ret != 0) break;
 
         ret = XMEMCMP(tv->clientEarlyTrafficSecret, output, hashAlgSz);
         if (ret != 0) break;
 
-        ret = wc_Tls13_HKDF_Expand_Label(output, hashAlgSz,
-                secret, hashAlgSz,
+        ret = wc_Tls13_HKDF_Expand_Label(output, (word32)hashAlgSz,
+                secret, (word32)hashAlgSz,
                 (byte*)protocolLabel, (word32)XSTRLEN(protocolLabel),
                 (byte*)eExpMasterLabel, (word32)XSTRLEN(eExpMasterLabel),
-                tv->hashHello1, hashAlgSz, tv->hashAlg);
+                tv->hashHello1, (word32)hashAlgSz, tv->hashAlg);
         if (ret != 0) break;
 
         ret = XMEMCMP(tv->earlyExporterMasterSecret, output, hashAlgSz);
         if (ret != 0) break;
 
-        ret = wc_Tls13_HKDF_Expand_Label(salt, hashAlgSz,
-                secret, hashAlgSz,
+        ret = wc_Tls13_HKDF_Expand_Label(salt, (word32)hashAlgSz,
+                secret, (word32)hashAlgSz,
                 (byte*)protocolLabel, (word32)XSTRLEN(protocolLabel),
                 (byte*)derivedLabel, (word32)XSTRLEN(derivedLabel),
-                hashZero, hashAlgSz, tv->hashAlg);
+                hashZero, (word32)hashAlgSz, tv->hashAlg);
         if (ret != 0) break;
 
-        ret = wc_Tls13_HKDF_Extract(secret, salt, hashAlgSz,
+        ret = wc_Tls13_HKDF_Extract(secret, salt, (word32)(word32)hashAlgSz,
                 (tv->dheSz == 0) ? zeroes : (byte*)tv->dhe,
                 tv->dheSz, tv->hashAlg);
         if (ret != 0) break;
 
-        ret = wc_Tls13_HKDF_Expand_Label(output, hashAlgSz,
-                secret, hashAlgSz,
+        ret = wc_Tls13_HKDF_Expand_Label(output, (word32)hashAlgSz,
+                secret, (word32)hashAlgSz,
                 (byte*)protocolLabel, (word32)XSTRLEN(protocolLabel),
                 (byte*)cHsTrafficLabel, (word32)XSTRLEN(cHsTrafficLabel),
-                tv->hashHello2, hashAlgSz, tv->hashAlg);
+                tv->hashHello2, (word32)hashAlgSz, tv->hashAlg);
         if (ret != 0) break;
 
         ret = XMEMCMP(tv->clientHandshakeTrafficSecret,
                 output, hashAlgSz);
         if (ret != 0) break;
 
-        ret = wc_Tls13_HKDF_Expand_Label(output, hashAlgSz,
-                secret, hashAlgSz,
+        ret = wc_Tls13_HKDF_Expand_Label(output, (word32)hashAlgSz,
+                secret, (word32)hashAlgSz,
                 (byte*)protocolLabel, (word32)XSTRLEN(protocolLabel),
                 (byte*)sHsTrafficLabel, (word32)XSTRLEN(sHsTrafficLabel),
-                tv->hashHello2, hashAlgSz, tv->hashAlg);
+                tv->hashHello2, (word32)hashAlgSz, tv->hashAlg);
         if (ret != 0) break;
 
         ret = XMEMCMP(tv->serverHandshakeTrafficSecret, output, hashAlgSz);
         if (ret != 0) break;
 
-        ret = wc_Tls13_HKDF_Expand_Label(salt, hashAlgSz,
-                secret, hashAlgSz,
+        ret = wc_Tls13_HKDF_Expand_Label(salt, (word32)hashAlgSz,
+                secret, (word32)hashAlgSz,
                 (byte*)protocolLabel, (word32)XSTRLEN(protocolLabel),
                 (byte*)derivedLabel, (word32)XSTRLEN(derivedLabel),
-                hashZero, hashAlgSz, tv->hashAlg);
+                hashZero, (word32)hashAlgSz, tv->hashAlg);
         if (ret != 0) break;
 
-        ret = wc_Tls13_HKDF_Extract(secret, salt, hashAlgSz,
-                zeroes, hashAlgSz, tv->hashAlg);
+        ret = wc_Tls13_HKDF_Extract(secret, salt, (word32)(word32)hashAlgSz,
+                zeroes, (word32)(word32)hashAlgSz, tv->hashAlg);
         if (ret != 0) break;
 
-        ret = wc_Tls13_HKDF_Expand_Label(output, hashAlgSz,
-                secret, hashAlgSz,
+        ret = wc_Tls13_HKDF_Expand_Label(output, (word32)hashAlgSz,
+                secret, (word32)hashAlgSz,
                 (byte*)protocolLabel, (word32)XSTRLEN(protocolLabel),
                 (byte*)cAppTrafficLabel, (word32)XSTRLEN(cAppTrafficLabel),
-                tv->hashFinished1, hashAlgSz, tv->hashAlg);
+                tv->hashFinished1, (word32)hashAlgSz, tv->hashAlg);
         if (ret != 0) break;
 
         ret = XMEMCMP(tv->clientApplicationTrafficSecret, output, hashAlgSz);
         if (ret != 0) break;
 
-        ret = wc_Tls13_HKDF_Expand_Label(output, hashAlgSz,
-                secret, hashAlgSz,
+        ret = wc_Tls13_HKDF_Expand_Label(output, (word32)hashAlgSz,
+                secret, (word32)hashAlgSz,
                 (byte*)protocolLabel, (word32)XSTRLEN(protocolLabel),
                 (byte*)sAppTrafficLabel, (word32)XSTRLEN(sAppTrafficLabel),
-                tv->hashFinished1, hashAlgSz, tv->hashAlg);
+                tv->hashFinished1, (word32)hashAlgSz, tv->hashAlg);
         if (ret != 0) break;
 
         ret = XMEMCMP(tv->serverApplicationTrafficSecret, output, hashAlgSz);
         if (ret != 0) break;
 
-        ret = wc_Tls13_HKDF_Expand_Label(output, hashAlgSz,
-                secret, hashAlgSz,
+        ret = wc_Tls13_HKDF_Expand_Label(output, (word32)hashAlgSz,
+                secret, (word32)hashAlgSz,
                 (byte*)protocolLabel, (word32)XSTRLEN(protocolLabel),
                 (byte*)expMasterLabel, (word32)XSTRLEN(expMasterLabel),
-                tv->hashFinished1, hashAlgSz, tv->hashAlg);
+                tv->hashFinished1, (word32)hashAlgSz, tv->hashAlg);
         if (ret != 0) break;
 
         ret = XMEMCMP(tv->exporterMasterSecret, output, hashAlgSz);
         if (ret != 0) break;
 
-        ret = wc_Tls13_HKDF_Expand_Label(output, hashAlgSz,
-                secret, hashAlgSz,
+        ret = wc_Tls13_HKDF_Expand_Label(output, (word32)hashAlgSz,
+                secret, (word32)hashAlgSz,
                 (byte*)protocolLabel, (word32)XSTRLEN(protocolLabel),
                 (byte*)resMasterLabel, (word32)XSTRLEN(resMasterLabel),
-                tv->hashFinished2, hashAlgSz, tv->hashAlg);
+                tv->hashFinished2, (word32)hashAlgSz, tv->hashAlg);
         if (ret != 0) break;
 
         ret = XMEMCMP(tv->resumptionMasterSecret, output, hashAlgSz);
@@ -30619,7 +30619,7 @@ static wc_test_ret_t ecc_test_cert_gen(WC_RNG* rng)
     } while (ret == WC_PENDING_E);
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit);
-    certSz = (word32)ret;
+    certSz = (int)ret;
     TEST_SLEEP();
 
 #ifdef WOLFSSL_TEST_CERT
@@ -32688,11 +32688,11 @@ static wc_test_ret_t curve25519_check_public_test(void)
     for (i = 1; i < CURVE25519_KEYSIZE + 2; i++) {
         if (i == CURVE25519_KEYSIZE)
             continue;
-        if (wc_curve25519_check_public(good, i, EC25519_LITTLE_ENDIAN) !=
+        if (wc_curve25519_check_public(good, (word32)i, EC25519_LITTLE_ENDIAN) !=
                                                                 ECC_BAD_ARG_E) {
             return WC_TEST_RET_ENC_I(i);
         }
-        if (wc_curve25519_check_public(good, i, EC25519_BIG_ENDIAN) !=
+        if (wc_curve25519_check_public(good, (word32)i, EC25519_BIG_ENDIAN) !=
                                                                 ECC_BAD_ARG_E) {
             return WC_TEST_RET_ENC_I(i);
         }
@@ -33956,8 +33956,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ed25519_test(void)
 #endif
 
     /* helper functions for signature and key size */
-    keySz = wc_ed25519_size(&key);
-    sigSz = wc_ed25519_sig_size(&key);
+    keySz = (word32)wc_ed25519_size(&key);
+    sigSz = (word32)wc_ed25519_sig_size(&key);
 
 #if defined(HAVE_ED25519_SIGN) && defined(HAVE_ED25519_KEY_EXPORT) &&\
         defined(HAVE_ED25519_KEY_IMPORT)
@@ -34293,11 +34293,11 @@ static wc_test_ret_t curve448_check_public_test(void)
     for (i = 1; i < CURVE448_KEY_SIZE + 2; i++) {
         if (i == CURVE448_KEY_SIZE)
             continue;
-        if (wc_curve448_check_public(good, i, EC448_LITTLE_ENDIAN) !=
+        if (wc_curve448_check_public(good, (word32)i, EC448_LITTLE_ENDIAN) !=
                                                                 ECC_BAD_ARG_E) {
             return WC_TEST_RET_ENC_I(i);
         }
-        if (wc_curve448_check_public(good, i, EC448_BIG_ENDIAN) !=
+        if (wc_curve448_check_public(good, (word32)i, EC448_BIG_ENDIAN) !=
                                                                 ECC_BAD_ARG_E) {
             return WC_TEST_RET_ENC_I(i);
         }
@@ -35607,8 +35607,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ed448_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
     /* helper functions for signature and key size */
-    keySz = wc_ed448_size(key);
-    sigSz = wc_ed448_sig_size(key);
+    keySz = (word32)wc_ed448_size(key);
+    sigSz = (word32)wc_ed448_sig_size(key);
 
 #if defined(HAVE_ED448_SIGN) && defined(HAVE_ED448_KEY_EXPORT) &&\
         defined(HAVE_ED448_KEY_IMPORT)
@@ -41815,7 +41815,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t siphash_test(void)
         ret = wc_InitSipHash(&siphash, siphash_key, SIPHASH_MAC_SIZE_8);
         if (ret != 0)
             return WC_TEST_RET_ENC_I(i);
-        ret = wc_SipHashUpdate(&siphash, siphash_msg, i);
+        ret = wc_SipHashUpdate(&siphash, siphash_msg, (word32)i);
         if (ret != 0)
             return WC_TEST_RET_ENC_I(i);
         ret = wc_SipHashFinal(&siphash, res, SIPHASH_MAC_SIZE_8);
@@ -41823,7 +41823,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t siphash_test(void)
             return WC_TEST_RET_ENC_I(i);
         if (XMEMCMP(res, siphash_r8[i], SIPHASH_MAC_SIZE_8) != 0)
             return WC_TEST_RET_ENC_I(i);
-        ret = wc_SipHash(siphash_key, siphash_msg, i, res, SIPHASH_MAC_SIZE_8);
+        ret = wc_SipHash(siphash_key, siphash_msg, (word32)i, res, SIPHASH_MAC_SIZE_8);
         if (ret != 0)
             return WC_TEST_RET_ENC_I(i);
         if (XMEMCMP(res, siphash_r8[i], SIPHASH_MAC_SIZE_8) != 0)
@@ -41833,7 +41833,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t siphash_test(void)
         ret = wc_InitSipHash(&siphash, siphash_key, SIPHASH_MAC_SIZE_16);
         if (ret != 0)
             return WC_TEST_RET_ENC_I(i);
-        ret = wc_SipHashUpdate(&siphash, siphash_msg, i);
+        ret = wc_SipHashUpdate(&siphash, siphash_msg, (word32)i);
         if (ret != 0)
             return WC_TEST_RET_ENC_I(i);
         ret = wc_SipHashFinal(&siphash, res, SIPHASH_MAC_SIZE_16);
@@ -41841,7 +41841,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t siphash_test(void)
             return WC_TEST_RET_ENC_I(i);
         if (XMEMCMP(res, siphash_r16[i], SIPHASH_MAC_SIZE_16) != 0)
             return WC_TEST_RET_ENC_I(i);
-        ret = wc_SipHash(siphash_key, siphash_msg, i, res, SIPHASH_MAC_SIZE_16);
+        ret = wc_SipHash(siphash_key, siphash_msg, (word32)i, res, SIPHASH_MAC_SIZE_16);
         if (ret != 0)
             return WC_TEST_RET_ENC_I(i);
         if (XMEMCMP(res, siphash_r16[i], SIPHASH_MAC_SIZE_16) != 0)
@@ -42787,9 +42787,9 @@ static int myDecryptionFunc(PKCS7* pkcs7, int encryptOID, byte* iv, int ivSz,
 
     ret = wc_AesInit(aes, HEAP_HINT, INVALID_DEVID);
     if (ret == 0) {
-        ret = wc_AesSetKey(aes, key, keySz, iv, AES_DECRYPTION);
+        ret = wc_AesSetKey(aes, key, (word32)keySz, iv, AES_DECRYPTION);
         if (ret == 0)
-            ret = wc_AesCbcDecrypt(aes, out, in, inSz);
+            ret = wc_AesCbcDecrypt(aes, out, in, (word32)inSz);
         wc_AesFree(aes);
     }
 
@@ -43204,7 +43204,7 @@ static wc_test_ret_t pkcs7enveloped_run_vectors(byte* rsaCert, word32 rsaCertSz,
 
         /* decode envelopedData */
         pkcs7->contentOID = 0;
-        decodedSz = wc_PKCS7_DecodeEnvelopedData(pkcs7, enveloped, envelopedSz,
+        decodedSz = wc_PKCS7_DecodeEnvelopedData(pkcs7, enveloped, (word32)envelopedSz,
                                                  decoded, PKCS7_BUF_SIZE);
         if (pkcs7->contentOID != testVectors[i].contentOID ||
             decodedSz <= 0) {
@@ -43928,7 +43928,7 @@ static wc_test_ret_t pkcs7authenveloped_run_vectors(byte* rsaCert, word32 rsaCer
 #endif
         /* decode envelopedData */
         decodedSz = wc_PKCS7_DecodeAuthEnvelopedData(pkcs7, enveloped,
-                                                     envelopedSz, decoded,
+                                                     (word32)envelopedSz, decoded,
                                                      PKCS7_BUF_SIZE);
         if (decodedSz <= 0) {
             wc_PKCS7_Free(pkcs7);
@@ -44284,7 +44284,7 @@ static wc_test_ret_t generateBundle(byte* out, word32 *outSz, const byte* encryp
         if (ret <= 0) {
             return ret;
         }
-        attribs[1].valueSz = (int)ret;
+        attribs[1].valueSz = (word32)ret;
         attribNum++;
     }
 
@@ -44311,13 +44311,13 @@ static wc_test_ret_t generateBundle(byte* out, word32 *outSz, const byte* encryp
         ret = wc_PKCS7_EncodeSignedEncryptedFPD(pkcs7, (byte*)encryptKey,
                 encryptKeySz, key, keySz, AES128CBCb, RSAk, SHA256h,
                 (byte*)data, sizeof(data), NULL, 0,
-                attribs, attribNum, out, *outSz);
+                attribs, (word32)attribNum, out, *outSz);
     }
     else {
         ret = wc_PKCS7_EncodeSignedEncryptedFPD(pkcs7, (byte*)encryptKey,
                 encryptKeySz, key, keySz, AES256CBCb, RSAk, SHA256h,
                 (byte*)data, sizeof(data), NULL, 0,
-                attribs, attribNum, out, *outSz);
+                attribs, (word32)attribNum, out, *outSz);
     }
     if (ret <= 0) {
         printf("ERROR: wc_PKCS7_EncodeSignedEncryptedFPD() failed, "
@@ -44326,7 +44326,7 @@ static wc_test_ret_t generateBundle(byte* out, word32 *outSz, const byte* encryp
         return WC_TEST_RET_ENC_EC(ret);
 
     } else {
-        *outSz = (int)ret;
+        *outSz = (word32)ret;
     }
 
     wc_PKCS7_Free(pkcs7);
@@ -44426,7 +44426,7 @@ static wc_test_ret_t verifyBundle(byte* derBuf, word32 derSz, int keyHint)
         if (ret < 0)
             goto out;
         pkcs7->encryptionKey = key;
-        pkcs7->encryptionKeySz = (int)ret;
+        pkcs7->encryptionKeySz = (word32)ret;
     }
     else {
         decodedSz = PKCS7_BUF_SIZE;
@@ -44440,7 +44440,7 @@ static wc_test_ret_t verifyBundle(byte* derBuf, word32 derSz, int keyHint)
     }
 
     decodedSz = wc_PKCS7_DecodeEncryptedData(pkcs7, pkcs7->content,
-            pkcs7->contentSz, decoded, decodedSz);
+            pkcs7->contentSz, decoded, (word32)decodedSz);
     if (decodedSz < 0) {
         ret = decodedSz;
         goto out;
@@ -44717,7 +44717,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t pkcs7encrypted_test(void)
             }
         }
 #endif
-        decodedSz = wc_PKCS7_DecodeEncryptedData(pkcs7, encrypted, encryptedSz,
+        decodedSz = wc_PKCS7_DecodeEncryptedData(pkcs7, encrypted, (word32)encryptedSz,
                                                  decoded, PKCS7_BUF_SIZE);
         if (decodedSz <= 0){
             wc_PKCS7_Free(pkcs7);
@@ -45395,7 +45395,7 @@ static wc_test_ret_t pkcs7signed_run_vectors(
             int bufSz = 0;
 
             if (testVectors[i].signedAttribs != NULL) {
-                ret = wc_PKCS7_GetAttributeValue(pkcs7, oidPt, oidSz,
+                ret = wc_PKCS7_GetAttributeValue(pkcs7, oidPt, (word32)oidSz,
                     NULL, (word32*)&bufSz);
                 if (ret != LENGTH_ONLY_E)
                     ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -45405,7 +45405,7 @@ static wc_test_ret_t pkcs7signed_run_vectors(
             if (bufSz > (int)sizeof(buf))
                 ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
-            bufSz = wc_PKCS7_GetAttributeValue(pkcs7, oidPt, oidSz,
+            bufSz = wc_PKCS7_GetAttributeValue(pkcs7, oidPt, (word32)oidSz,
                     buf, (word32*)&bufSz);
             if ((testVectors[i].signedAttribs != NULL && bufSz < 0) ||
                 (testVectors[i].signedAttribs == NULL && bufSz > 0))
@@ -46161,10 +46161,10 @@ static wc_test_ret_t randNum(mp_int* n, int len, WC_RNG* rng, void* heap)
     (void)heap;
 
     do {
-        ret = wc_RNG_GenerateBlock(rng, d, len);
+        ret = wc_RNG_GenerateBlock(rng, d, (word32)len);
         if (ret != 0)
             return ret;
-        ret = mp_read_unsigned_bin(n, d, len);
+        ret = mp_read_unsigned_bin(n, d, (word32)len);
         if (ret != 0)
             return ret;
     } while (mp_iszero(n));
@@ -46523,7 +46523,7 @@ static wc_test_ret_t mp_test_read_to_bin(mp_int* a)
 
     for (i = 0; i < (int)sizeof(in); i++) {
         p = in + sizeof(in) - i;
-        ret = mp_read_unsigned_bin(a, p, i);
+        ret = mp_read_unsigned_bin(a, p, (word32)i);
         if (ret != 0)
             return WC_TEST_RET_ENC_EC(ret);
         for (j = i; j < (int)sizeof(out); j++) {
@@ -49225,7 +49225,7 @@ static wc_test_ret_t GenerateNextP(mp_int* p1, mp_int* p2, int k)
     if (ret != 0)
         ret = WC_TEST_RET_ENC_EC(ret);
     if (ret == 0) {
-        ret = mp_set(ki, k);
+        ret = mp_set(ki, (mp_digit)k);
         if (ret != 0)
             ret = WC_TEST_RET_ENC_EC(ret);
     }
@@ -49280,7 +49280,7 @@ static wc_test_ret_t GenerateP(mp_int* p1, mp_int* p2, mp_int* p3,
         goto out;
     }
     for (i = 0; ret == 0 && i < ecPairsSz; i++) {
-        ret = mp_read_unsigned_bin(x, ecPairs[i].coeff, ecPairs[i].coeffSz);
+        ret = mp_read_unsigned_bin(x, ecPairs[i].coeff, (word32)ecPairs[i].coeffSz);
         if (ret != 0) {
             ret = WC_TEST_RET_ENC_EC(ret);
             break;

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1002,11 +1002,11 @@ static WC_INLINE int PasswordCallBack(char* passwd, int sz, int rw, void* userda
     (void)rw;
     (void)userdata;
     if (userdata != NULL) {
-        strncpy(passwd, (char*)userdata, sz);
+        strncpy(passwd, (char*)userdata, (size_t) sz);
         return (int)XSTRLEN((char*)userdata);
     }
     else {
-        strncpy(passwd, "yassl123", sz);
+        strncpy(passwd, "yassl123", (size_t) sz);
         return 8;
     }
 }
@@ -1329,7 +1329,7 @@ static WC_INLINE void build_addr(SOCKADDR_IN_T* addr, const char* peer,
 
         if (entry) {
             XMEMCPY(&addr->sin_addr.s_addr, entry->h_addr_list[0],
-                   entry->h_length);
+                   (size_t) entry->h_length);
             useLookup = 1;
         }
     #else
@@ -1867,7 +1867,7 @@ static WC_INLINE unsigned int my_psk_client_cb(WOLFSSL* ssl, const char* hint,
         for (i = 0; i < 32; i++, b += 0x22) {
             if (b >= 0x100)
                 b = 0x01;
-            key[i] = b;
+            key[i] = (unsigned char) b;
         }
 
         ret = 32;   /* length of key in octets or 0 for error */
@@ -1911,7 +1911,7 @@ static WC_INLINE unsigned int my_psk_server_cb(WOLFSSL* ssl, const char* identit
         for (i = 0; i < 32; i++, b += 0x22) {
             if (b >= 0x100)
                 b = 0x01;
-            key[i] = b;
+            key[i] = (unsigned char) b;
         }
 
         ret = 32;   /* length of key in octets or 0 for error */
@@ -1944,7 +1944,7 @@ static WC_INLINE unsigned int my_psk_client_tls13_cb(WOLFSSL* ssl,
     for (i = 0; i < 32; i++, b += 0x22) {
         if (b >= 0x100)
             b = 0x01;
-        key[i] = b;
+        key[i] = (unsigned char) b;
     }
 
     *ciphersuite = userCipher ? userCipher : "TLS13-AES128-GCM-SHA256";
@@ -1967,7 +1967,7 @@ static WC_INLINE unsigned int my_psk_server_tls13_cb(WOLFSSL* ssl,
     unsigned int ret;
     int i;
     int b = 0x01;
-    int kIdLen = (int)XSTRLEN(kIdentityStr);
+    size_t kIdLen = XSTRLEN(kIdentityStr);
     const char* userCipher = (const char*)wolfSSL_get_psk_callback_ctx(ssl);
 
     (void)ssl;
@@ -1983,7 +1983,7 @@ static WC_INLINE unsigned int my_psk_server_tls13_cb(WOLFSSL* ssl,
     for (i = 0; i < 32; i++, b += 0x22) {
         if (b >= 0x100)
             b = 0x01;
-        key[i] = b;
+        key[i] = (unsigned char) b;
     }
 
     *ciphersuite = userCipher ? userCipher : "TLS13-AES128-GCM-SHA256";
@@ -2046,7 +2046,7 @@ static WC_INLINE int my_psk_use_session_cb(WOLFSSL* ssl,
         for (i = 0; i < 32; i++, b += 0x22) {
             if (b >= 0x100)
                 b = 0x01;
-            local_psk[i] = b;
+            local_psk[i] = (unsigned char) b;
         }
 
         *id = local_psk;
@@ -2099,7 +2099,7 @@ static WC_INLINE unsigned int my_psk_client_cs_cb(WOLFSSL* ssl,
     for (i = 0; i < 32; i++, b += 0x22) {
         if (b >= 0x100)
             b = 0x01;
-        key[i] = b;
+        key[i] = (unsigned char) b;
     }
 
     return 32;   /* length of key in octets or 0 for error */
@@ -2433,7 +2433,7 @@ static WC_INLINE int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
      */
 
     fprintf(stderr, "In verification callback, error = %d, %s\n", store->error,
-                                 wolfSSL_ERR_error_string(store->error, buffer));
+                                 wolfSSL_ERR_error_string((unsigned long) store->error, buffer));
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     peer = store->current_cert;
     if (peer) {
@@ -2724,7 +2724,7 @@ static WC_INLINE int myMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
     if (ret != 0)
         return ret;
     ret = wc_HmacSetKey(&hmac, wolfSSL_GetHmacType(ssl),
-               wolfSSL_GetMacSecret(ssl, macVerify), wolfSSL_GetHmacSize(ssl));
+               wolfSSL_GetMacSecret(ssl, macVerify), (word32) wolfSSL_GetHmacSize(ssl));
     if (ret != 0)
         return ret;
     ret = wc_HmacUpdate(&hmac, myInner, sizeof(myInner));
@@ -2758,7 +2758,7 @@ static WC_INLINE int myMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
             fprintf(stderr, "AesInit failed in myMacEncryptCb\n");
             return ret;
         }
-        ret = wc_AesSetKey(&encCtx->aes, key, keyLen, iv, AES_ENCRYPTION);
+        ret = wc_AesSetKey(&encCtx->aes, key, (word32) keyLen, iv, AES_ENCRYPTION);
         if (ret != 0) {
             fprintf(stderr, "AesSetKey failed in myMacEncryptCb\n");
             return ret;
@@ -2777,7 +2777,7 @@ static WC_INLINE int myDecryptVerifyCb(WOLFSSL* ssl,
 {
     AtomicDecCtx* decCtx = (AtomicDecCtx*)ctx;
     int ret      = 0;
-    int macInSz  = 0;
+    unsigned int macInSz  = 0;
     int ivExtra  = 0;
     int digestSz = wolfSSL_GetHmacSize(ssl);
     unsigned int pad     = 0;
@@ -2819,7 +2819,7 @@ static WC_INLINE int myDecryptVerifyCb(WOLFSSL* ssl,
             fprintf(stderr, "AesInit failed in myDecryptVerifyCb\n");
             return ret;
         }
-        ret = wc_AesSetKey(&decCtx->aes, key, keyLen, iv, AES_DECRYPTION);
+        ret = wc_AesSetKey(&decCtx->aes, key, (word32) keyLen, iv, AES_DECRYPTION);
         if (ret != 0) {
             fprintf(stderr, "AesSetKey failed in myDecryptVerifyCb\n");
             return ret;
@@ -2833,7 +2833,7 @@ static WC_INLINE int myDecryptVerifyCb(WOLFSSL* ssl,
         return ret;
 
     if (wolfSSL_GetCipherType(ssl) == WOLFSSL_AEAD_TYPE) {
-        *padSz = wolfSSL_GetAeadMacSize(ssl);
+        *padSz = (unsigned int)wolfSSL_GetAeadMacSize(ssl);
         return 0; /* hmac, not needed if aead mode */
     }
 
@@ -2844,8 +2844,8 @@ static WC_INLINE int myDecryptVerifyCb(WOLFSSL* ssl,
             ivExtra = wolfSSL_GetCipherBlockSize(ssl);
     }
 
-    *padSz  = wolfSSL_GetHmacSize(ssl) + pad + padByte;
-    macInSz = decSz - ivExtra - digestSz - pad - padByte;
+    *padSz  = (unsigned int)wolfSSL_GetHmacSize(ssl) + pad + padByte;
+    macInSz = decSz - (unsigned int)ivExtra - (unsigned int)digestSz - pad - padByte;
 
     wolfSSL_SetTlsHmacInner(ssl, myInner, macInSz, macContent, macVerify);
 
@@ -2853,7 +2853,7 @@ static WC_INLINE int myDecryptVerifyCb(WOLFSSL* ssl,
     if (ret != 0)
         return ret;
     ret = wc_HmacSetKey(&hmac, wolfSSL_GetHmacType(ssl),
-               wolfSSL_GetMacSecret(ssl, macVerify), digestSz);
+               wolfSSL_GetMacSecret(ssl, macVerify), (unsigned int) digestSz);
     if (ret != 0)
         return ret;
     ret = wc_HmacUpdate(&hmac, myInner, sizeof(myInner));
@@ -2867,7 +2867,7 @@ static WC_INLINE int myDecryptVerifyCb(WOLFSSL* ssl,
         return ret;
 
     if (XMEMCMP(verify, decOut + decSz - digestSz - pad - padByte,
-               digestSz) != 0) {
+               (size_t) digestSz) != 0) {
         printf("myDecryptVerify verify failed\n");
         return -1;
     }
@@ -2918,7 +2918,7 @@ static WC_INLINE int myEncryptMacCb(WOLFSSL* ssl, unsigned char* macOut,
             fprintf(stderr, "AesInit failed in myMacEncryptCb\n");
             return ret;
         }
-        ret = wc_AesSetKey(&encCtx->aes, key, keyLen, iv, AES_ENCRYPTION);
+        ret = wc_AesSetKey(&encCtx->aes, key, (word32) keyLen, iv, AES_ENCRYPTION);
         if (ret != 0) {
             fprintf(stderr, "AesSetKey failed in myMacEncryptCb\n");
             return ret;
@@ -2938,7 +2938,7 @@ static WC_INLINE int myEncryptMacCb(WOLFSSL* ssl, unsigned char* macOut,
     if (ret != 0)
         return ret;
     ret = wc_HmacSetKey(&hmac, wolfSSL_GetHmacType(ssl),
-               wolfSSL_GetMacSecret(ssl, macVerify), wolfSSL_GetHmacSize(ssl));
+               wolfSSL_GetMacSecret(ssl, macVerify), (word32) wolfSSL_GetHmacSize(ssl));
     if (ret != 0)
         return ret;
     ret = wc_HmacUpdate(&hmac, myInner, sizeof(myInner));
@@ -2982,7 +2982,7 @@ static WC_INLINE int myVerifyDecryptCb(WOLFSSL* ssl,
     if (ret != 0)
         return ret;
     ret = wc_HmacSetKey(&hmac, wolfSSL_GetHmacType(ssl),
-               wolfSSL_GetMacSecret(ssl, macVerify), digestSz);
+               wolfSSL_GetMacSecret(ssl, macVerify), (word32) digestSz);
     if (ret != 0)
         return ret;
     ret = wc_HmacUpdate(&hmac, myInner, sizeof(myInner));
@@ -2995,7 +2995,7 @@ static WC_INLINE int myVerifyDecryptCb(WOLFSSL* ssl,
     if (ret != 0)
         return ret;
 
-    if (XMEMCMP(verify, decOut + decSz, digestSz) != 0) {
+    if (XMEMCMP(verify, decOut + decSz, (size_t) digestSz) != 0) {
         printf("myDecryptVerify verify failed\n");
         return -1;
     }
@@ -3021,7 +3021,7 @@ static WC_INLINE int myVerifyDecryptCb(WOLFSSL* ssl,
             fprintf(stderr, "AesInit failed in myDecryptVerifyCb\n");
             return ret;
         }
-        ret = wc_AesSetKey(&decCtx->aes, key, keyLen, iv, AES_DECRYPTION);
+        ret = wc_AesSetKey(&decCtx->aes, key, (word32) keyLen, iv, AES_DECRYPTION);
         if (ret != 0) {
             fprintf(stderr, "AesSetKey failed in myDecryptVerifyCb\n");
             return ret;
@@ -3184,7 +3184,7 @@ static WC_INLINE int myEccKeyGen(WOLFSSL* ssl, ecc_key* key, word32 keySz,
         WC_RNG *rng = wolfSSL_GetRNG(ssl);
 
         /* create new key */
-        ret = wc_ecc_make_key_ex(rng, keySz, new_key, ecc_curve);
+        ret = wc_ecc_make_key_ex(rng, (int) keySz, new_key, ecc_curve);
 
     #ifdef TEST_PK_PRIVKEY
         if (ret == 0 && new_key != key) {
@@ -3380,7 +3380,7 @@ static WC_INLINE int myHkdfExtract(byte* prk, const byte* salt, word32 saltLen,
        byte* ikm, word32 ikmLen, int digest, void* ctx)
 {
     int ret;
-    int len = 0;
+    word32 len = 0;
 
     switch (digest) {
 #ifndef NO_SHA256
@@ -3511,7 +3511,7 @@ static WC_INLINE int myX25519KeyGen(WOLFSSL* ssl, curve25519_key* key,
     if (ret != 0)
         return ret;
 
-    ret = wc_curve25519_make_key(&rng, keySz, key);
+    ret = wc_curve25519_make_key(&rng, (int) keySz, key);
 
     wc_FreeRng(&rng);
 
@@ -3682,7 +3682,7 @@ static WC_INLINE int myX448KeyGen(WOLFSSL* ssl, curve448_key* key,
     if (ret != 0)
         return ret;
 
-    ret = wc_curve448_make_key(&rng, keySz, key);
+    ret = wc_curve448_make_key(&rng, (int) keySz, key);
 
     wc_FreeRng(&rng);
 
@@ -3815,7 +3815,7 @@ static WC_INLINE int myRsaSign(WOLFSSL* ssl, const byte* in, word32 inSz,
         if (ret == 0)
             ret = wc_RsaSSL_Sign(in, inSz, out, *outSz, &myKey, &rng);
         if (ret > 0) {  /* save and convert to 0 success */
-            *outSz = ret;
+            *outSz = (word32) ret;
             ret = 0;
         }
         wc_FreeRsaKey(&myKey);
@@ -3949,7 +3949,7 @@ static WC_INLINE int myRsaPssSign(WOLFSSL* ssl, const byte* in, word32 inSz,
                                  &rng);
         }
         if (ret > 0) {  /* save and convert to 0 success */
-            *outSz = ret;
+            *outSz = (word32) ret;
             ret = 0;
         }
         wc_FreeRsaKey(&myKey);
@@ -4100,7 +4100,7 @@ static WC_INLINE int myRsaEnc(WOLFSSL* ssl, const byte* in, word32 inSz,
         if (ret == 0) {
             ret = wc_RsaPublicEncrypt(in, inSz, out, *outSz, &myKey, &rng);
             if (ret > 0) {
-                *outSz = ret;
+                *outSz = (word32) ret;
                 ret = 0;  /* reset to success */
             }
         }


### PR DESCRIPTION
Fix issues related to `-Wconversion` and `-Wsign-conversion`. Most notably where a variable needs to be cast to a different type. Not including implicit type upgrades that happen in equations (ie: uint8 + uint16).