### PR TITLE
20240511-clang-analyzer-unix.Stream

### DIFF
--- a/examples/asn1/asn1.c
+++ b/examples/asn1/asn1.c
@@ -73,6 +73,11 @@ static int asn1App_ReadFile(FILE* fp, unsigned char** pdata, word32* plen)
         while ((read_len = fread(data + len, 1, DATA_INC_LEN, fp)) != 0) {
             unsigned char* p;
 
+            if (ferror(fp)) {
+                free(data);
+                return IO_FAILED_E;
+            }
+
             /* Add read data amount to length. */
             len += (word32)read_len;
 
@@ -446,6 +451,10 @@ int main(int argc, char* argv[])
             return 1;
         }
         else {
+            if (fp != stdin) {
+                fprintf(stderr, "At most one input file can be supplied.\n");
+                return 1;
+            }
             /* Name of file to read. */
             fp = fopen(argv[0], "r");
             if (fp == NULL) {

--- a/examples/pem/pem.c
+++ b/examples/pem/pem.c
@@ -778,6 +778,10 @@ int main(int argc, char* argv[])
                 fprintf(stderr, "No filename provided\n");
                 return 1;
             }
+            if (in_file != stdin) {
+                fprintf(stderr, "At most one input file can be supplied.\n");
+                return 1;
+            }
             in_file = fopen(argv[0], "r");
             if (in_file == NULL) {
                 fprintf(stderr, "File not able to be read: %s\n", argv[0]);

--- a/tests/api.c
+++ b/tests/api.c
@@ -54505,6 +54505,7 @@ static int test_wolfSSL_PEM_write_bio_PKCS7(void)
 }
 
 #ifdef HAVE_SMIME
+/* // NOLINTBEGIN(clang-analyzer-unix.Stream) */
 static int test_wolfSSL_SMIME_read_PKCS7(void)
 {
     EXPECT_DECLS;
@@ -54530,7 +54531,10 @@ static int test_wolfSSL_SMIME_read_PKCS7(void)
     ExpectNotNull(pkcs7);
     ExpectIntEQ(wolfSSL_PKCS7_verify(pkcs7, NULL, NULL, bcont, NULL,
         PKCS7_NOVERIFY), SSL_SUCCESS);
-    XFCLOSE(smimeTestFile);
+    if (smimeTestFile != XBADFILE) {
+        XFCLOSE(smimeTestFile);
+        smimeTestFile = XBADFILE;
+    }
     if (bcont) BIO_free(bcont);
     bcont = NULL;
     wolfSSL_PKCS7_free(pkcs7);
@@ -54538,12 +54542,16 @@ static int test_wolfSSL_SMIME_read_PKCS7(void)
 
     /* smime-test-multipart.p7s */
     smimeTestFile = XFOPEN("./certs/test/smime-test-multipart.p7s", "r");
+    ExpectFalse(smimeTestFile == XBADFILE);
     ExpectIntEQ(wolfSSL_BIO_set_fp(bio, smimeTestFile, BIO_CLOSE), SSL_SUCCESS);
     pkcs7 = wolfSSL_SMIME_read_PKCS7(bio, &bcont);
     ExpectNotNull(pkcs7);
     ExpectIntEQ(wolfSSL_PKCS7_verify(pkcs7, NULL, NULL, bcont, NULL,
         PKCS7_NOVERIFY), SSL_SUCCESS);
-    XFCLOSE(smimeTestFile);
+    if (smimeTestFile != XBADFILE) {
+        XFCLOSE(smimeTestFile);
+        smimeTestFile = XBADFILE;
+    }
     if (bcont) BIO_free(bcont);
     bcont = NULL;
     wolfSSL_PKCS7_free(pkcs7);
@@ -54551,12 +54559,16 @@ static int test_wolfSSL_SMIME_read_PKCS7(void)
 
     /* smime-test-multipart-badsig.p7s */
     smimeTestFile = XFOPEN("./certs/test/smime-test-multipart-badsig.p7s", "r");
+    ExpectFalse(smimeTestFile == XBADFILE);
     ExpectIntEQ(wolfSSL_BIO_set_fp(bio, smimeTestFile, BIO_CLOSE), SSL_SUCCESS);
     pkcs7 = wolfSSL_SMIME_read_PKCS7(bio, &bcont);
     ExpectNotNull(pkcs7); /* can read in the unverified smime bundle */
     ExpectIntEQ(wolfSSL_PKCS7_verify(pkcs7, NULL, NULL, bcont, NULL,
         PKCS7_NOVERIFY), SSL_FAILURE);
-    XFCLOSE(smimeTestFile);
+    if (smimeTestFile != XBADFILE) {
+        XFCLOSE(smimeTestFile);
+        smimeTestFile = XBADFILE;
+    }
     if (bcont) BIO_free(bcont);
     bcont = NULL;
     wolfSSL_PKCS7_free(pkcs7);
@@ -54564,12 +54576,16 @@ static int test_wolfSSL_SMIME_read_PKCS7(void)
 
     /* smime-test-canon.p7s */
     smimeTestFile = XFOPEN("./certs/test/smime-test-canon.p7s", "r");
+    ExpectFalse(smimeTestFile == XBADFILE);
     ExpectIntEQ(wolfSSL_BIO_set_fp(bio, smimeTestFile, BIO_CLOSE), SSL_SUCCESS);
     pkcs7 = wolfSSL_SMIME_read_PKCS7(bio, &bcont);
     ExpectNotNull(pkcs7);
     ExpectIntEQ(wolfSSL_PKCS7_verify(pkcs7, NULL, NULL, bcont, NULL,
         PKCS7_NOVERIFY), SSL_SUCCESS);
-    XFCLOSE(smimeTestFile);
+    if (smimeTestFile != XBADFILE) {
+        XFCLOSE(smimeTestFile);
+        smimeTestFile = XBADFILE;
+    }
     if (bcont) BIO_free(bcont);
     bcont = NULL;
     wolfSSL_PKCS7_free(pkcs7);
@@ -54577,6 +54593,7 @@ static int test_wolfSSL_SMIME_read_PKCS7(void)
 
     /* Test PKCS7_TEXT, PKCS7_verify() should remove Content-Type: text/plain */
     smimeTestFile = XFOPEN("./certs/test/smime-test-canon.p7s", "r");
+    ExpectFalse(smimeTestFile == XBADFILE);
     ExpectIntEQ(wolfSSL_BIO_set_fp(bio, smimeTestFile, BIO_CLOSE), SSL_SUCCESS);
     pkcs7 = wolfSSL_SMIME_read_PKCS7(bio, &bcont);
     ExpectNotNull(pkcs7);
@@ -54596,6 +54613,7 @@ static int test_wolfSSL_SMIME_read_PKCS7(void)
 #endif
     return EXPECT_RESULT();
 }
+/* // NOLINTEND(clang-analyzer-unix.Stream) */
 
 static int test_wolfSSL_SMIME_write_PKCS7(void)
 {

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -99,8 +99,12 @@ int copy_file(const char* in, const char* out)
         goto cleanup;
 
     while ((sz = XFREAD(buf, 1, sizeof(buf), inFile)) != 0) {
+        if (XFERROR(inFile))
+            goto cleanup;
         if (XFWRITE(buf, 1, sz, outFile) != sz)
             goto cleanup;
+        if (XFEOF(inFile))
+            break;
     }
 
     ret = 0;

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -610,12 +610,19 @@ void file_test(const char* file, byte* check)
         return;
     }
     while( ( i = (int)fread(buf, 1, sizeof(buf), f )) > 0 ) {
+        if (ferror(f)) {
+            printf("I/O error reading %s\n", file);
+            fclose(f);
+            return;
+        }
         ret = wc_Sha256Update(&sha256, buf, i);
         if (ret != 0) {
             printf("Can't wc_Sha256Update %d\n", ret);
             fclose(f);
             return;
         }
+        if (feof(f))
+            break;
     }
 
     ret = wc_Sha256Final(&sha256, shasum);

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -709,6 +709,9 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XFGETS     fgets
     #define XFPRINTF   fprintf
     #define XFFLUSH    fflush
+    #define XFEOF(fp)  feof(fp)
+    #define XFERROR(fp) ferror(fp)
+    #define XCLEARERR(fp) clearerr(fp)
 
     #if !defined(NO_WOLFSSL_DIR)\
         && !defined(WOLFSSL_NUCLEUS) && !defined(WOLFSSL_NUCLEUS_1_2)
@@ -772,6 +775,15 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #endif
     #ifndef MAX_PATH
         #define MAX_PATH (260 + 1)
+    #endif
+    #ifndef XFEOF
+        #define XFEOF(fp)  0
+    #endif
+    #ifndef XFERROR
+        #define XFERROR(fp) 0
+    #endif
+    #ifndef XCLEARERR
+        #define XCLEARERR(fp) WC_DO_NOTHING
     #endif
 
     WOLFSSL_LOCAL int wc_FileLoad(const char* fname, unsigned char** buf,


### PR DESCRIPTION
fixes and suppressions for defects reported by `clang-analyzer-unix.Stream` (new in `llvm-19.0.0_pre20240504`):

* added POSIX definitions for `XFEOF()`, `XFERROR()`, and `XCLEARERR()`, currently with no-op fallbacks for !POSIX.
* added missing file handle checks in `testsuite/testsuite.c`:`file_test()` and `tests/utils.h`:`copy_file()`.
* added fixes and suppression around `tests/api.c`:`test_wolfSSL_SMIME_read_PKCS7()`.
* added various fixes in `examples/asn1/asn1.c` and `examples/pem/pem.c`.

tested with `wolfssl-multi-test.sh ... super-quick-check`
