### PR TITLE
ECC: handle zero in wc_ecc_mulmod()

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4058,6 +4058,12 @@ exit:
 int wc_ecc_mulmod(const mp_int* k, ecc_point *G, ecc_point *R, mp_int* a,
                   mp_int* modulus, int map)
 {
+    if ((k != NULL) && (G != NULL) && (mp_iszero(k))) {
+        mp_zero(G->x);
+        mp_zero(G->y);
+        mp_zero(G->z);
+        return MP_OKAY;
+    }
     return wc_ecc_mulmod_ex(k, G, R, a, modulus, map, NULL);
 }
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4058,10 +4058,10 @@ exit:
 int wc_ecc_mulmod(const mp_int* k, ecc_point *G, ecc_point *R, mp_int* a,
                   mp_int* modulus, int map)
 {
-    if ((k != NULL) && (G != NULL) && (mp_iszero(k))) {
-        mp_zero(G->x);
-        mp_zero(G->y);
-        mp_zero(G->z);
+    if ((k != NULL) && (R != NULL) && (mp_iszero(k))) {
+        mp_zero(R->x);
+        mp_zero(R->y);
+        mp_zero(R->z);
         return MP_OKAY;
     }
     return wc_ecc_mulmod_ex(k, G, R, a, modulus, map, NULL);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -29328,6 +29328,9 @@ static wc_test_ret_t ecc_mulmod_test(ecc_key* key1)
     ecc_key    key2[1];
     ecc_key    key3[1];
 #endif
+#ifdef WOLFSSL_PUBLIC_MP
+    mp_int*    priv;
+#endif
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     if ((key2 == NULL) || (key3 == NULL))
@@ -29361,6 +29364,22 @@ static wc_test_ret_t ecc_mulmod_test(ecc_key* key1)
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
+
+#ifdef WOLFSSL_PUBLIC_MP
+    priv = wc_ecc_key_get_priv(key1);
+    mp_zero(priv);
+    ret = wc_ecc_mulmod(wc_ecc_key_get_priv(key1), &key2->pubkey, &key3->pubkey,
+                        wc_ecc_key_get_priv(key2), wc_ecc_key_get_priv(key3),
+                        1);
+    if (ret != 0) {
+        ret = WC_TEST_RET_ENC_EC(ret);
+        goto done;
+    }
+    if (!wc_ecc_point_is_at_infinity(&key2->pubkey)) {
+        ret = WC_TEST_RET_ENC_EC(ret);
+        goto done;
+    }
+#endif
 
 done:
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -29375,7 +29375,7 @@ static wc_test_ret_t ecc_mulmod_test(ecc_key* key1)
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
-    if (!wc_ecc_point_is_at_infinity(&key2->pubkey)) {
+    if (!wc_ecc_point_is_at_infinity(&key3->pubkey)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }


### PR DESCRIPTION
# Description

Public API needs to handle multiplying by zero as the underlying code doesn't and needn't.

Fixes #7530

# Testing

Added test case.
Failed before change made to wc_ecc_mulmod().

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
