### PR TITLE
Fix Espressif SHA512 SW fallback endianness

### DIFF
--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -990,17 +990,19 @@ static WC_INLINE int Sha512Update(wc_Sha512* sha512, const byte* data, word32 le
          defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA512)
             ret = Transform_Sha512(sha512);
     #else
-            if(sha512->ctx.mode == ESP32_SHA_INIT) {
+            if (sha512->ctx.mode == ESP32_SHA_INIT) {
                 esp_sha_try_hw_lock(&sha512->ctx);
             }
-            ret = esp_sha512_process(sha512);
-            if(ret == 0 && sha512->ctx.mode == ESP32_SHA_SW){
+            if (sha512->ctx.mode == ESP32_SHA_SW) {
                 ByteReverseWords64(sha512->buffer, sha512->buffer,
                                                          WC_SHA512_BLOCK_SIZE);
                 ret = Transform_Sha512(sha512);
             }
+            else {
+                ret = esp_sha512_process(sha512);
+            }
     #endif
-            if (ret == 0)
+            if (ret == ESP_OK)
                 sha512->buffLen = 0;
             else
                 len = 0;
@@ -1884,7 +1886,8 @@ int wc_Sha512Copy(wc_Sha512* src, wc_Sha512* dst)
     ret = wolfAsync_DevCopy(&src->asyncDev, &dst->asyncDev);
 #endif
 
-#if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
+#if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW) && \
+   !defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA512)
     #if defined(CONFIG_IDF_TARGET_ESP32)
     if (ret == 0) {
         ret = esp_sha512_ctx_copy(src, dst);
@@ -2169,7 +2172,8 @@ int wc_Sha384Copy(wc_Sha384* src, wc_Sha384* dst)
     ret = wolfAsync_DevCopy(&src->asyncDev, &dst->asyncDev);
 #endif
 
-#if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW)
+#if defined(WOLFSSL_USE_ESP32_CRYPT_HASH_HW) && \
+   !defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA384)
     #if defined(CONFIG_IDF_TARGET_ESP32)
         esp_sha384_ctx_copy(src, dst);
     #elif defined(CONFIG_IDF_TARGET_ESP32C2) || \

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -1002,7 +1002,7 @@ static WC_INLINE int Sha512Update(wc_Sha512* sha512, const byte* data, word32 le
                 ret = esp_sha512_process(sha512);
             }
     #endif
-            if (ret == ESP_OK)
+            if (ret == 0)
                 sha512->buffLen = 0;
             else
                 len = 0;


### PR DESCRIPTION
# Description

Related to https://github.com/wolfSSL/wolfssl/pull/7505 this update fixes Espressif SHA512 HW/SW interleaving. Specifically when a hardware hash is in progress, and a separate concurrent instance of the same SHA512 is initiated. The second instance needs to fall back to software. On the Xtensa architecture, this means changing the endianness. In the RISC-V, it does not. 

Note that some chipsets support _hardware interleaving_. That feature is not implemented yet. This PR only affects mixed hardware and software interleaving.

This PR properly first _checks_ the HW/SW mode and _then_ performs the SHA transformation.

Missing, is apparently a proper SHA512 interleaving test, similar to the one implemented for SHA256. Although both are implemented in `test.c.` and _thought_ to be previously detecting this interleave issue; The SHA256 works properly, but the SHA512 test fails to find the problem.

I had previously fixed this problem, but the change did not make it into  https://github.com/wolfSSL/wolfssl/pull/7505. The problem was hidden as the respective `user_settings.h` for the affected platforms was missing the `WOLFCRYPT_HAVE_SRP` setting. That's also corrected in this PR.

Finally, there's a slight polish in the sha copy for `NO_WOLFSSL_ESP32_CRYPT_HASH_SHA512` and `NO_WOLFSSL_ESP32_CRYPT_HASH_SHA384`.

Fixes zd# n/a

# Testing

How did you test? 

Tested only on Espressif using my 9-device jig.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
