### PR TITLE
added check that checks if the SEQ's length is > than the buff's length

### DIFF
--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -160,6 +160,10 @@ static int DataToDerBuffer(const unsigned char* buff, word32 len, int format,
         else {
             ret = ASN_PARSE_E;
         }
+
+        if (info->consumed > (int)len) {
+            ret = ASN_PARSE_E;
+        }
         if (ret == 0) {
             ret = AllocCopyDer(der, buff, (word32)info->consumed, type, heap);
         }


### PR DESCRIPTION
# Description

added check that checks if the SEQ's length is > than the buff's length

# Testing

Tested running libFuzzer with 1 second for each test (`./fuzz.sh 1`) 

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
