### PR TITLE
Fix conversion part2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3755,13 +3755,13 @@ then
 fi
 
 # ECC Minimum Key Size
-ENABLED_ECCMINSZ=224
 AC_ARG_WITH([eccminsz],
     [AS_HELP_STRING([--with-eccminsz=BITS],[Sets the ECC minimum key size (default: 224 bits)])],
     [
         ENABLED_ECCMINSZ=$withval
         AM_CFLAGS="$AM_CFLAGS -DECC_MIN_KEY_SZ=$withval"
-    ]
+    ],
+    [ ENABLED_ECCMINSZ=224 ]
 )
 
 # Compressed Key

--- a/configure.ac
+++ b/configure.ac
@@ -8308,7 +8308,7 @@ fi
 AC_ARG_WITH([max-ecc-bits],
     [AS_HELP_STRING([--with-max-ecc-bits=number],[number of bits to support for ECC algorithms])],
     [WITH_MAX_ECC_BITS=$withval],
-    [WITH_MAX_ECC_BITS="$DEFAULT_MAX_ECC_BITS"])
+    )
 
 if test -n "$WITH_MAX_ECC_BITS"; then
    if test "$WITH_MAX_ECC_BITS" -lt 112 -o "$WITH_MAX_ECC_BITS" -gt 1024; then

--- a/configure.ac
+++ b/configure.ac
@@ -10011,3 +10011,10 @@ if test "$MINGW_LIB_WARNING" = "yes"
 then
     AC_MSG_WARN([Building with shared and static library at the same time on this system may cause export/import problems when using non contemporary GNU tools.])
 fi
+
+if test -n "$WITH_MAX_ECC_BITS"; then
+    if test "$WITH_MAX_ECC_BITS" -lt "$ENABLED_ECCMINSZ"; then
+        AC_MSG_ERROR([--with-max-ecc-bits argument ($WITH_MAX_ECC_BITS) must be greater than --with-eccminsz argument ($ENABLED_ECCMINSZ)])
+    fi
+fi
+

--- a/configure.ac
+++ b/configure.ac
@@ -100,6 +100,9 @@ else
     REPRODUCIBLE_BUILD_DEFAULT=no
 fi
 
+# Fail when an option is passed that is not recognized
+m4_divert_once([DEFAULTS], [enable_option_checking=fatal])
+
 # Allow experimental settings
 AC_ARG_ENABLE([experimental],
     [AS_HELP_STRING([--enable-experimental],[Allow experimental settings in the configuration (default: disabled)])],

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -571,7 +571,7 @@ int wc_PRF_TLS(byte* digest, word32 digLen, const byte* secret, word32 secLen,
         (void)heap;
         /* okmLen (2) + protocol|label len (1) + info len(1) + protocollen +
          * labellen + infolen */
-        len = (size_t)4 + protocolLen + labelLen + infoLen;
+        len = 4U + protocolLen + labelLen + infoLen;
 
         data = (byte*)XMALLOC(len, heap, DYNAMIC_TYPE_TMP_BUFFER);
         if (data == NULL)


### PR DESCRIPTION
Addressing PR comments from -Wconversion.

Clean up of the ECC max/min bits size.

Add in OPTION_CHECKING by default.