### PR TITLE
Fix PlatformIO freertos semphr.h include

### DIFF
--- a/wolfcrypt/src/port/Espressif/esp_sdk_mem_lib.c
+++ b/wolfcrypt/src/port/Espressif/esp_sdk_mem_lib.c
@@ -41,6 +41,14 @@
     CFLAGS +=-DWOLFSSL_USER_SETTINGS"
 #endif
 
+#ifndef SINGLE_THREADED
+    #ifdef PLATFORMIO
+        #include <freertos/semphr.h>
+    #else
+        #include "semphr.h"
+    #endif
+#endif
+
 /* Espressif */
 #include "sdkconfig.h" /* programmatically generated from sdkconfig */
 #include <esp_log.h>
@@ -257,9 +265,6 @@ esp_err_t esp_sdk_mem_lib_init(void)
     ESP_LOGI(TAG, "esp_sdk_mem_lib_init Ver %d", ESP_SDK_MEM_LIB_VERSION);
     return ret;
 }
-    #ifndef SINGLE_THREADED
-        #include "semphr.h"
-    #endif
 
 void* wc_debug_pvPortMalloc(size_t size,
                            const char* file, int line, const char* fname) {

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1116,7 +1116,11 @@ extern void uITRON4_free(void *p) ;
     #endif
 
     #ifndef SINGLE_THREADED
-        #include "semphr.h"
+        #ifdef PLATFORMIO
+            #include <freertos/semphr.h>
+        #else
+            #include "semphr.h"
+        #endif
     #endif
 #endif
 


### PR DESCRIPTION
# Description

Fixes PlatfomIO-specific include of FreeRTOS `semphr.h` noted in https://github.com/wolfSSL/wolfssl/issues/7533.

Apparently PlatfomIO (which apparently is not using `cmake` for Espressif builds)... otherwise fails to find `semphr.h` when not otherwise explicitly prefixed with `<freertos/semphr.h>`.

Fixes zd# n/a

# Testing

Tested only in Espressif / PlatformIO environments.

Note that I added a PlatformIO-specific include, as I'm not certain why it was only `"semphr.h"`.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
