### PR TITLE
Used codespell and fixed some obvious typos.

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -2104,7 +2104,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #endif
 
 #ifdef WOLFSSL_DUAL_ALG_CERTS
-    /* Set our preference for verfication to be for both the native and
+    /* Set our preference for verification to be for both the native and
      * alternative chains. Ultimately, its the server's choice. This will be
      * used in the call to wolfSSL_UseCKS(). */
     byte cks_order[3] = {

--- a/src/pk.c
+++ b/src/pk.c
@@ -14423,7 +14423,7 @@ int wolfSSL_ED25519_generate_key(unsigned char *priv, unsigned int *privSz,
  * @param [in]      priv    ED25519 private key data.
  * @param [in]      privSz  Length in bytes of private key data.
  * @param [out]     sig     Signature buffer.
- * @param [in, out] sigSz   On in, the length of the siganture buffer in bytes.
+ * @param [in, out] sigSz   On in, the length of the signature buffer in bytes.
  *                          On out, the length of the signature in bytes.
  * @return  1 on success
  * @return  0 on failure.
@@ -14889,7 +14889,7 @@ int wolfSSL_ED448_generate_key(unsigned char *priv, unsigned int *privSz,
  * @param [in]      priv    ED448 private key data.
  * @param [in]      privSz  Length in bytes of private key data.
  * @param [out]     sig     Signature buffer.
- * @param [in, out] sigSz   On in, the length of the siganture buffer in bytes.
+ * @param [in, out] sigSz   On in, the length of the signature buffer in bytes.
  *                          On out, the length of the signature in bytes.
  * @return  1 on success
  * @return  0 on failure.
@@ -15143,7 +15143,7 @@ int wolfSSL_PEM_write_bio_PUBKEY(WOLFSSL_BIO* bio, WOLFSSL_EVP_PKEY* key)
  * @param [in] passwd  Password to use when encrypting.
  * @param [in] len     Length of password.
  * @param [in] cb      Password callback.
- * @param [in] arg     Password callback arguement.
+ * @param [in] arg     Password callback argument.
  * @return  1 on success.
  * @return  0 on failure.
  */
@@ -15254,7 +15254,7 @@ int wolfSSL_PEM_write_bio_PrivateKey(WOLFSSL_BIO* bio, WOLFSSL_EVP_PKEY* key,
  * @param [in]      bio   BIO to read from.
  * @param [in, out] key   Public key object. Object used if passed in.
  * @param [in]      cb    Password callback.
- * @param [in]      arg   Password callback arguement.
+ * @param [in]      arg   Password callback argument.
  * @return  A WOLFSSL_EVP_PKEY object on success.
  * @return  NULL on failure.
  */
@@ -15310,7 +15310,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_PEM_read_bio_PUBKEY(WOLFSSL_BIO* bio,
  * @param [in]      bio   BIO to read from.
  * @param [in, out] key   Private key object. Object used if passed in.
  * @param [in]      cb    Password callback.
- * @param [in]      arg   Password callback arguement.
+ * @param [in]      arg   Password callback argument.
  * @return  A WOLFSSL_EVP_PKEY object on success.
  * @return  NULL on failure.
  */
@@ -15391,7 +15391,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_PEM_read_bio_PrivateKey(WOLFSSL_BIO* bio,
  * @param [in]      fp    File pointer.
  * @param [in, out] key   Public key object. Object used if passed in.
  * @param [in]      cb    Password callback.
- * @param [in]      arg   Password callback arguement.
+ * @param [in]      arg   Password callback argument.
  * @return  A WOLFSSL_EVP_PKEY object on success.
  * @return  NULL on failure.
  */
@@ -15448,7 +15448,7 @@ WOLFSSL_EVP_PKEY *wolfSSL_PEM_read_PUBKEY(XFILE fp, WOLFSSL_EVP_PKEY **key,
  * @param [in]      fp    File pointer.
  * @param [in, out] key   Private key object. Object used if passed in.
  * @param [in]      cb    Password callback.
- * @param [in]      arg   Password callback arguement.
+ * @param [in]      arg   Password callback argument.
  * @return  A WOLFSSL_EVP_PKEY object on success.
  * @return  NULL on failure.
  */
@@ -15668,7 +15668,7 @@ static int pem_read_data(char* pem, int pemLen, char **name, char **header,
     return ret;
 }
 
-/* Encode the DER data in PEM foramt into a newly allocated buffer.
+/* Encode the DER data in PEM format into a newly allocated buffer.
  *
  * @param [in]  name       Header/footer name.
  * @param [in]  header     Encryption header.
@@ -15812,7 +15812,7 @@ int wolfSSL_PEM_read_bio(WOLFSSL_BIO* bio, char **name, char **header,
     return res;
 }
 
-/* Encode the DER data in PEM foramt into a BIO.
+/* Encode the DER data in PEM format into a BIO.
  *
  * @param [in] bio     BIO to write to.
  * @param [in] name    Header/footer name.
@@ -15894,7 +15894,7 @@ int wolfSSL_PEM_read(XFILE fp, char **name, char **header, unsigned char **data,
     return res;
 }
 
-/* Encode the DER data in PEM foramt into a file.
+/* Encode the DER data in PEM format into a file.
  *
  * @param [in] fp      File pointer to write to.
  * @param [in] name    Header/footer name.
@@ -16135,7 +16135,7 @@ static int pem_pkcs8_encode(WOLFSSL_EVP_PKEY* pkey, byte* key, word32* keySz)
  * @param [out] pemSz     Size of data in buffer in bytes.
  * @param [in]  pkey      Private key to write.
  * @param [in]  enc       Encryption information to use. May be NULL.
- * @param [in]  passwd    Pasword to use when encrypting. May be NULL.
+ * @param [in]  passwd    Password to use when encrypting. May be NULL.
  * @param [in]  passwdSz  Size of password in bytes.
  * @param [in]  cb        Password callback. Used when passwd is NULL. May be
  *                        NULL.
@@ -16256,7 +16256,7 @@ static int pem_write_mem_pkcs8privatekey(byte** pem, int* pemSz,
  * @param [in] bio       BIO to write to.
  * @param [in] pkey      Private key to write.
  * @param [in] enc       Encryption information to use. May be NULL.
- * @param [in] passwd    Pasword to use when encrypting. May be NULL.
+ * @param [in] passwd    Password to use when encrypting. May be NULL.
  * @param [in] passwdSz  Size of password in bytes.
  * @param [in] cb        Password callback. Used when passwd is NULL. May be
  *                       NULL.
@@ -16301,7 +16301,7 @@ int wolfSSL_PEM_write_bio_PKCS8PrivateKey(WOLFSSL_BIO* bio,
  * @param [in] f         File pointer.
  * @param [in] pkey      Private key to write.
  * @param [in] enc       Encryption information to use. May be NULL.
- * @param [in] passwd    Pasword to use when encrypting. May be NULL.
+ * @param [in] passwd    Password to use when encrypting. May be NULL.
  * @param [in] passwdSz  Size of password in bytes.
  * @param [in] cb        Password callback. Used when passwd is NULL. May be
  *                       NULL.

--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -1585,7 +1585,7 @@ static void ProcessBufferCertSetHave(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
 #ifndef WC_STRICT_SIG
     wolfssl_set_have_from_key_oid(ctx, ssl, cert->keyOID);
 #else
-    /* Set whether ECC is available baed on signature available. */
+    /* Set whether ECC is available based on signature available. */
     if (ssl != NULL) {
         ssl->options.haveECC = ssl->options.haveECDSAsig;
     }
@@ -5611,7 +5611,7 @@ long wolfSSL_CTX_set_tmp_dh(WOLFSSL_CTX* ctx, WOLFSSL_DH* dh)
  *
  * @param [in, out] ctx     SSL context object.
  * @param [in, out] ssl     SSL object.
- * @oaram [in]      buf     Buffer holding encoded DH parameters.
+ * @param [in]      buf     Buffer holding encoded DH parameters.
  * @param [in]      sz      Size of encoded DH parameters.
  * @param [in]      format  Format of data:
  *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
@@ -5724,7 +5724,7 @@ static int ws_ctx_ssl_set_tmp_dh(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
 /* Set the temporary DH parameters against the SSL.
  *
  * @param [in, out] ssl     SSL object.
- * @oaram [in]      buf     Buffer holding encoded DH parameters.
+ * @param [in]      buf     Buffer holding encoded DH parameters.
  * @param [in]      sz      Size of encoded DH parameters.
  * @param [in]      format  Format of data:
  *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
@@ -5743,7 +5743,7 @@ int wolfSSL_SetTmpDH_buffer(WOLFSSL* ssl, const unsigned char* buf, long sz,
 /* Set the temporary DH parameters against the SSL context.
  *
  * @param [in, out] ctx     SSL context object.
- * @oaram [in]      buf     Buffer holding encoded DH parameters.
+ * @param [in]      buf     Buffer holding encoded DH parameters.
  * @param [in]      sz      Size of encoded DH parameters.
  * @param [in]      format  Format of data:
  *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
@@ -5806,11 +5806,11 @@ static int ws_ctx_ssl_set_tmp_dh_file(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
     }
     if (res == 1) {
         if (ssl != NULL) {
-            /* Set encoded DH paramters into SSL. */
+            /* Set encoded DH parameters into SSL. */
             res = wolfSSL_SetTmpDH_buffer(ssl, dhFile.buffer, sz, format);
         }
         else {
-            /* Set encoded DH paramters into SSL context. */
+            /* Set encoded DH parameters into SSL context. */
             res = wolfSSL_CTX_SetTmpDH_buffer(ctx, dhFile.buffer, sz, format);
         }
     }

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -9073,7 +9073,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                 if ((ssl->hsType == DYNAMIC_TYPE_RSA) &&
                     (args->sigLen > MAX_SIG_DATA_SZ)) {
                     /* We store the RSA signature in the sigData buffer
-                        * temporarly, hence its size must be fitting. */
+                     * temporarily, hence its size must be fitting. */
                     sigLen = args->sigLen;
                 }
                 args->sigData = (byte*)XMALLOC(sigLen, ssl->heap,
@@ -9091,7 +9091,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                 if (ssl->hsAltType == DYNAMIC_TYPE_RSA &&
                     args->altSigLen > MAX_SIG_DATA_SZ) {
                     /* We store the RSA signature in the sigData buffer
-                     * temporarly, hence its size must be fitting. */
+                     * temporarily, hence its size must be fitting. */
                     sigLen = args->altSigLen;
                 }
                 args->altSigData = (byte*)XMALLOC(sigLen, ssl->heap,

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -318,7 +318,7 @@
      * enabled, all if the values in report are blank. */
     #ifdef CONFIG_NEWLIB_NANO_FORMAT
         #if CONFIG_NEWLIB_NANO_FORMAT == 1
-            #error "Nano newlib fomatting must not be enabled for benchmark"
+            #error "Nano newlib formatting must not be enabled for benchmark"
         #endif
     #endif
 
@@ -372,7 +372,7 @@
           defined(CONFIG_IDF_TARGET_ESP32S3)
         #include <xtensa/hal.h>
     #elif defined(CONFIG_IDF_TARGET_ESP8266)
-        /* no CPU HAL for ESP8266, we'll use RTOS tick calc extimates */
+        /* no CPU HAL for ESP8266, we'll use RTOS tick calc estimates */
         #include <FreeRTOS.h>
     #elif defined(CONFIG_IDF_TARGET_ESP32H2)
         /* TODO add ESP32-H2 benchmark support */
@@ -1410,7 +1410,7 @@ static const char* bench_result_words3[][5] = {
         uint64_t thisIncrement = 0; /* The adjusted increment amount.       */
         uint64_t expected_diff = 0; /* FreeRTOS estimated expected CPU diff.*/
     #ifdef DEBUG_WOLFSSL_BENCHMARK_TIMING
-        uint64_t tickCount = 0; /* Currrent rtos tick counter.              */
+        uint64_t tickCount = 0; /* Current rtos tick counter.               */
         uint64_t tickDiff = 0;  /* Tick difference from last check.         */
         uint64_t tickBeginDiff = 0; /* Tick difference from beginning.      */
     #endif

--- a/wolfcrypt/src/port/Espressif/esp32_sha.c
+++ b/wolfcrypt/src/port/Espressif/esp32_sha.c
@@ -502,7 +502,7 @@ int esp_sha_ctx_copy(struct wc_Sha* src, struct wc_Sha* dst)
 int esp_sha224_ctx_copy(struct wc_Sha256* src, struct wc_Sha256* dst)
 {
     /* There's no 224 hardware on ESP32.
-     * Initializer fo dst is this ctx address for use as a breadcrumb. */
+     * Initializer for dst is this ctx address for use as a breadcrumb. */
     dst->ctx.initializer = (uintptr_t)&dst->ctx;
     #if defined(ESP_MONITOR_HW_TASK_LOCK) && !defined(SINGLE_THREADED)
     {
@@ -1414,7 +1414,7 @@ int esp_sha_try_hw_lock(WC_ESP32SHA* ctx)
                 if (mutex_ctx_owner) {
                 #ifdef WOLFSSL_DEBUG_MUTEX
                     ESP_LOGW(TAG, "revert to SW since mutex_ctx_owner = %x"
-                                    " but we are currenty ctx = %x",
+                                    " but we are currently ctx = %x",
                                     mutex_ctx_owner, (intptr_t)ctx);
                 #endif
                 }

--- a/wolfcrypt/src/port/Espressif/esp_sdk_time_lib.c
+++ b/wolfcrypt/src/port/Espressif/esp_sdk_time_lib.c
@@ -241,7 +241,7 @@ int set_time_from_string(const char* time_buffer)
     int quote_offset = 0;
     int ret = 0;
 
-    /* perform some basic sanity checkes */
+    /* perform some basic sanity checks */
     ret = probably_valid_time_string(time_buffer);
     if (ret == ESP_OK) {
         /* we are expecting the string to be encapsulated in single quotes */
@@ -255,7 +255,7 @@ int set_time_from_string(const char* time_buffer)
                     &day, &hour, &minute, &second, &year, &offset);
 
         if (ret == 8) {
-            /* we found a match for all componets */
+            /* we found a match for all components */
 
             const char *months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
                                      "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
@@ -320,7 +320,7 @@ int set_time(void)
     esp_show_current_datetime();
 
 #ifdef LIBWOLFSSL_VERSION_GIT_HASH_DATE
-    /* initialy set a default approximate time from recent git commit */
+    /* initially set a default approximate time from recent git commit */
     ESP_LOGI(TAG, "Found git hash date, attempting to set system date: %s",
                    LIBWOLFSSL_VERSION_GIT_HASH_DATE);
     set_time_from_string(LIBWOLFSSL_VERSION_GIT_HASH_DATE"\0");
@@ -427,7 +427,7 @@ int set_time_wait_for_ntp(void)
 #endif
 
     if (ret == ESP_OK) {
-        ESP_LOGI(TAG, "Successfuly set time via NTP servers.");
+        ESP_LOGI(TAG, "Successfully set time via NTP servers.");
         }
     else {
         ESP_LOGW(TAG, "Warning: Failed to set time with NTP: "

--- a/wolfcrypt/src/port/Espressif/esp_sdk_wifi_lib.c
+++ b/wolfcrypt/src/port/Espressif/esp_sdk_wifi_lib.c
@@ -384,7 +384,7 @@ esp_err_t wc_wifi_init_sta(void)
             .ssid = EXAMPLE_ESP_WIFI_SSID,
             .password = EXAMPLE_ESP_WIFI_PASS,
             /* Authmode threshold resets to WPA2 as default if password matches
-             * WPA2 standards (pasword len => 8). If you want to connect the
+             * WPA2 standards (password len => 8). If you want to connect the
              * device to deprecated WEP/WPA networks, Please set the threshold
              * value WIFI_AUTH_WEP/WIFI_AUTH_WPA_PSK and set the password with
              * length and format matching to WIFI_AUTH_WEP/WIFI_AUTH_WPA_PSK


### PR DESCRIPTION
# Description

Fixed typos in:
- examples/
- src/
- wolfcrypt/ 