### PR TITLE
Add settings.h check: DSA needs SHA1

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3591,6 +3591,10 @@ extern void uITRON4_free(void *p) ;
     #error "OPENSSL_EXTRA can not be defined with OPENSSL_COEXIST"
 #endif
 
+#if !defined(NO_DSA) && defined(NO_SHA)
+    #error "Please disable DSA if disabling SHA-1"
+#endif
+
 /* if configure.ac turned on this feature, HAVE_ENTROPY_MEMUSE will be set,
  * also define HAVE_WOLFENTROPY */
 #ifdef HAVE_ENTROPY_MEMUSE


### PR DESCRIPTION
# Description

Adds a `settings.h` sanity check to ensure if DSA is enabled, that SHA1 is also enabled.

I started going down the road of gating out *all* the DSA code when not enabled, but the further I got, the more complex it became. I gave up when I found [MakeAnyCert()](https://github.com/wolfSSL/wolfssl/blob/219a338107b3e60d4a360dca960542dc89b616d1/wolfcrypt/src/asn.c#L29995) that has a DSA parameter. It is certainly _possible_ to code around this, and I can do so if desired. For now we have the sanity check,

Otherwise, without this change: when DSA is enabled and SHA1 is disabled (e.g. `#define NO_SHA`) , unintuitive compile time errors may occur such as this:

```
C:/workspace/wolfssl-gojimmypi-pr/wolfcrypt/src/dsa.c: In function 'wc_DsaSign':
C:/workspace/wolfssl-gojimmypi-pr/wolfcrypt/src/dsa.c:653:34: error: 'WC_SHA_DIGEST_SIZE' undeclared (first use in this function); did you mean 'WC_SHA384_DIGEST_SIZE'?
  653 |     return wc_DsaSign_ex(digest, WC_SHA_DIGEST_SIZE, out, key, rng);
      |                                  ^~~~~~~~~~~~~~~~~~
      |                                  WC_SHA384_DIGEST_SIZE
C:/workspace/wolfssl-gojimmypi-pr/wolfcrypt/src/dsa.c:653:34: note: each undeclared identifier is reported only once for each function it appears in
C:/workspace/wolfssl-gojimmypi-pr/wolfcrypt/src/dsa.c: In function 'wc_DsaVerify':
C:/workspace/wolfssl-gojimmypi-pr/wolfcrypt/src/dsa.c:988:36: error: 'WC_SHA_DIGEST_SIZE' undeclared (first use in this function); did you mean 'WC_SHA384_DIGEST_SIZE'?
  988 |     return wc_DsaVerify_ex(digest, WC_SHA_DIGEST_SIZE, sig, key, answer);
      |                                    ^~~~~~~~~~~~~~~~~~
      |                                    WC_SHA384_DIGEST_SIZE
C:/workspace/wolfssl-gojimmypi-pr/wolfcrypt/src/dsa.c: In function 'wc_DsaSign':
C:/workspace/wolfssl-gojimmypi-pr/wolfcrypt/src/dsa.c:654:1: error: control reaches end of non-void function [-Werror=return-type]
  654 | }
      | ^
C:/workspace/wolfssl-gojimmypi-pr/wolfcrypt/src/dsa.c: In function 'wc_DsaVerify':
C:/workspace/wolfssl-gojimmypi-pr/wolfcrypt/src/dsa.c:989:1: error: control reaches end of non-void function [-Werror=return-type]
  989 | }
      | ^
```

Fixes zd# n/a

# Testing

Limited testing only with embedded target. 

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
