### PR TITLE
Add option for using a custom salt for ourselves

### DIFF
--- a/doc/dox_comments/header_files/ecc.h
+++ b/doc/dox_comments/header_files/ecc.h
@@ -1722,7 +1722,7 @@ int wc_ecc_ctx_set_peer_salt(ecEncCtx* ctx, const byte* salt);
 
     \param ctx pointer to the ecEncCtx for which to set the salt
     \param salt pointer to salt buffer
-    \param len length salt in bytes
+    \param sz length salt in bytes
 
     _Example_
     \code
@@ -1742,7 +1742,7 @@ int wc_ecc_ctx_set_peer_salt(ecEncCtx* ctx, const byte* salt);
     \sa wc_ecc_ctx_get_peer_salt
 */
 
-int wc_ecc_ctx_set_kdf_salt(ecEncCtx* ctx, const byte* salt, word32 len);
+int wc_ecc_ctx_set_kdf_salt(ecEncCtx* ctx, const byte* salt, word32 sz);
 
 /*!
     \ingroup ECC

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -13830,7 +13830,7 @@ int wc_ecc_ctx_set_peer_salt(ecEncCtx* ctx, const byte* salt)
  *
  * @param  [in, out]  ctx   ECIES context object.
  * @param  [in]       salt  Salt to use with KDF.
- * @param  [in]       len   Length of salt in bytes.
+ * @param  [in]       sz    Length of salt in bytes.
  * @return  0 on success.
  * @return  BAD_FUNC_ARG when ctx is NULL or salt is NULL and len is not 0.
  */
@@ -13852,9 +13852,37 @@ int wc_ecc_ctx_set_kdf_salt(ecEncCtx* ctx, const byte* salt, word32 len)
     return 0;
 }
 
+/* Set your own salt. By default we generate a random salt for ourselves.
+ * This allows overriding that after init or reset.
+ *
+ * @param  [in, out]  ctx   ECIES context object.
+ * @param  [in]       salt  Salt to use for ourselves
+ * @param  [in]       sz    Length of salt in bytes.
+ * @return  0 on success.
+ * @return  BAD_FUNC_ARG when ctx is NULL or salt is NULL and len is not 0.
+ */
+int wc_ecc_ctx_set_own_salt(ecEncCtx* ctx, const byte* salt, word32 sz)
+{
+    byte* saltBuffer;
+
+    if (ctx == NULL || ctx->protocol == 0 || salt == NULL)
+        return BAD_FUNC_ARG;
+
+    if (sz > EXCHANGE_SALT_SZ)
+        sz = EXCHANGE_SALT_SZ;
+    saltBuffer = (ctx->protocol == REQ_RESP_CLIENT) ?
+        ctx->clientSalt :
+        ctx->serverSalt;
+    XMEMSET(saltBuffer, 0, EXCHANGE_SALT_SZ);
+    XMEMCPY(saltBuffer, salt, sz);
+
+    return 0;
+}
+
+
 static int ecc_ctx_set_salt(ecEncCtx* ctx, int flags)
 {
-    byte* saltBuffer = NULL;
+    byte* saltBuffer;
 
     if (ctx == NULL || flags == 0)
         return BAD_FUNC_ARG;
@@ -13863,7 +13891,6 @@ static int ecc_ctx_set_salt(ecEncCtx* ctx, int flags)
 
     return wc_RNG_GenerateBlock(ctx->rng, saltBuffer, EXCHANGE_SALT_SZ);
 }
-
 
 static void ecc_ctx_init(ecEncCtx* ctx, int flags, WC_RNG* rng)
 {

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -13834,13 +13834,13 @@ int wc_ecc_ctx_set_peer_salt(ecEncCtx* ctx, const byte* salt)
  * @return  0 on success.
  * @return  BAD_FUNC_ARG when ctx is NULL or salt is NULL and len is not 0.
  */
-int wc_ecc_ctx_set_kdf_salt(ecEncCtx* ctx, const byte* salt, word32 len)
+int wc_ecc_ctx_set_kdf_salt(ecEncCtx* ctx, const byte* salt, word32 sz)
 {
-    if (ctx == NULL || (salt == NULL && len != 0))
+    if (ctx == NULL || (salt == NULL && sz != 0))
         return BAD_FUNC_ARG;
 
     ctx->kdfSalt   = salt;
-    ctx->kdfSaltSz = len;
+    ctx->kdfSaltSz = sz;
 
     if (ctx->protocol == REQ_RESP_CLIENT) {
         ctx->cliSt = ecCLI_SALT_SET;

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -978,6 +978,8 @@ const byte* wc_ecc_ctx_get_own_salt(ecEncCtx* ctx);
 WOLFSSL_API
 int wc_ecc_ctx_set_peer_salt(ecEncCtx* ctx, const byte* salt);
 WOLFSSL_API
+int wc_ecc_ctx_set_own_salt(ecEncCtx* ctx, const byte* salt, word32 sz);
+WOLFSSL_API
 int wc_ecc_ctx_set_kdf_salt(ecEncCtx* ctx, const byte* salt, word32 sz);
 WOLFSSL_API
 int wc_ecc_ctx_set_info(ecEncCtx* ctx, const byte* info, int sz);


### PR DESCRIPTION
# Description

Add option for using a custom salt for ourselves. 
TODO: Add test

ZD 17988

# Testing

```
./configure --enable-eccencrypt && make
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
