### PR TITLE
error out if conflicting OPENSSL compat macros are defined

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3586,6 +3586,11 @@ extern void uITRON4_free(void *p) ;
     #endif
 #endif
 
+#if (defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)) && \
+    defined(OPENSSL_COEXIST)
+    #error "OPENSSL_EXTRA can not be defined with OPENSSL_COEXIST"
+#endif
+
 /* if configure.ac turned on this feature, HAVE_ENTROPY_MEMUSE will be set,
  * also define HAVE_WOLFENTROPY */
 #ifdef HAVE_ENTROPY_MEMUSE


### PR DESCRIPTION
Added to avoid this mistake again (https://github.com/wolfSSL/wolfssl/issues/7426)