### PR TITLE
Force SHA3 on with FIPS V5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5144,6 +5144,9 @@ AS_CASE([$FIPS_VERSION],
         AS_IF([test "$ENABLED_SHA224" != "yes" && (test "$FIPS_VERSION" != "v5-dev" || test "$enable_sha224" != "no")],
             [ENABLED_SHA224="yes"; AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SHA224"])
 
+        AS_IF([test "$ENABLED_SHA3" != "yes" && (test "$FIPS_VERSION" != "v5-dev" || test "$enable_sha3" != "no")],
+            [ENABLED_SHA3="yes"; AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SHA3"])
+
         AS_IF([test "$ENABLED_WOLFSSH" != "yes" && (test "$FIPS_VERSION" != "v5-dev" || test "$enable_ssh" != "no")],
             [enable_ssh="yes"])
 


### PR DESCRIPTION
# Description

Force SHA3 on with FIPS V5. On autotools build, SHA3 defaulted to disabled on `"$host_cpu" = "arm"` even with FIPS v5. 


# Testing

Tested on `"$host_cpu" = "arm"` system

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
