### PR TITLE
Update --enable-jni to define SESSION_CERTS for wolfJSSE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6480,6 +6480,12 @@ then
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALT_CERT_CHAINS"
     fi
 
+    if test "x$ENABLED_SESSIONCERTS" = "xno"
+    then
+        ENABLED_SESSIONCERTS="yes"
+        AM_CFLAGS="$AM_CFLAGS -DSESSION_CERTS"
+    fi
+
     # cert gen requires alt names
     ENABLED_ALTNAMES="yes"
 fi


### PR DESCRIPTION
# Description

This PR updates `--enable-jni` to define `SESSION_CERTS`.

This is needed for wolfJSSE `SSLSession.getPeerCertificate()` to return cert chain post handshake.

# Testing

Exposed through SunJSSE tests, specifically `SSLEngine.ConnectionTest`.  This has also been recommended to support users frequently, so should reduce a few minor JSSE support cases.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
