### PR TITLE
20240521-fix-overshifts

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -21564,7 +21564,10 @@ int set_curves_list(WOLFSSL* ssl, WOLFSSL_CTX *ctx, const char* names,
     for (i = 0; i < groups_len; ++i) {
         /* Switch the bit to off and therefore is enabled. */
         curve = (word16)groups[i];
-        if (curve >= 32) {
+        if (curve >= 64) {
+            WC_DO_NOTHING;
+        }
+        else if (curve >= 32) {
             /* 0 is for invalid and 1-14 aren't used otherwise. */
             disabled &= ~(1U << (curve - 32));
         }

--- a/wolfcrypt/src/wc_xmss_impl.c
+++ b/wolfcrypt/src/wc_xmss_impl.c
@@ -3926,7 +3926,7 @@ static int wc_xmssmt_sign_next_idx(XmssState* state, BdsState* bds, XmssIdx idx,
              * next leaf in alt state is not last. */
             if ((ret == 0) && (i > 0) && (updates > 0) &&
                     (idx_tree < ((XmssIdx)1 << (h - (hs * (i + 1))))) &&
-                    (bds[alt_i].next < ((word32)1 << h))) {
+                    (bds[alt_i].next < ((XmssIdx)1 << h))) {
                 xmss_idx_set_addr_tree(idx_tree, state->addr);
                 /* Update alternative BDS state. */
                 wc_xmss_bds_update(state, &bds[alt_i], sk_seed, pk_seed,


### PR DESCRIPTION
`wolfcrypt/src/wc_xmss_impl.c`:`wc_xmssmt_sign_next_idx()`: use `(XmssIdx)1`, not `(word32)1`, for a shift-by-height operand;

`src/ssl.c`:`set_curves_list()`: don't attempt to enable curves that are out-of-range for `word32 disabled`.

tested with `wolfssl-multi-test.sh ... super-quick-check pq-all-sanitizer pq-hybrid-all-rpk-sanitizer quantum-safe-wolfssl-all-intelasm-sp-asm-sanitizer quantum-safe-wolfssl-all-noasm-sanitizer quantum-safe-wolfssl-all-cross-aarch64-armasm-unittest-sanitizer quantum-safe-wolfssl-all-crypto-only-benchmark-sanitizer`
