### PR TITLE
Code Coverage for hpke.c test case HAVE_CURVE448 using test.c

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -27628,14 +27628,12 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hpke_test(void)
 /* added this code to hit code coverage on lines 219-225 on hpke.c*/
 #if defined(HAVE_CURVE448) && \
     (defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512))
-    /* have_curve448 */
+    /* test with_curve448 */
     ret = wc_HpkeInit(hpke, DHKEM_X448_HKDF_SHA512, HKDF_SHA512,
         HPKE_AES_128_GCM, NULL);
-    printf("ERROR RIGHT HERE %d\n",ret);
-    if (ret == 0)
-        return WC_TEST_RET_ENC_EC(ret);
 
-    ret = hpke_test_single(hpke);
+    if (ret != BAD_FUNC_ARG) /* Curve448 is not supported yet */
+        return WC_TEST_RET_ENC_EC(ret);
 
     if (ret == 0)
         return ret;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -27625,6 +27625,22 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hpke_test(void)
     #endif
 #endif
 
+/* added this code to hit code coverage on lines 219-225 on hpke.c*/
+#if defined(HAVE_CURVE448) && \
+    (defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512))
+    /* have_curve448 */
+    ret = wc_HpkeInit(hpke, DHKEM_X448_HKDF_SHA512, HKDF_SHA512,
+        HPKE_AES_128_GCM, NULL);
+    printf("ERROR RIGHT HERE %d\n",ret);
+    if (ret == 0)
+        return WC_TEST_RET_ENC_EC(ret);
+
+    ret = hpke_test_single(hpke);
+
+    if (ret == 0)
+        return ret;
+#endif
+
 #if defined(HAVE_CURVE25519)
     /* test with curve25519 and aes256 */
     ret = wc_HpkeInit(hpke, DHKEM_X25519_HKDF_SHA256, HKDF_SHA256,

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -27625,24 +27625,24 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hpke_test(void)
     #endif
 #endif
 
-/* added this code to hit code coverage on lines 219-225 on hpke.c*/
+/* Test coverage for wc_HpkeInit with Curve448, even though it is not supported */
 #if defined(HAVE_CURVE448) && \
     (defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512))
     /* test with_curve448 */
     ret = wc_HpkeInit(hpke, DHKEM_X448_HKDF_SHA512, HKDF_SHA512,
-        HPKE_AES_128_GCM, NULL);
+        HPKE_AES_256_GCM, NULL);
 
     if (ret != BAD_FUNC_ARG) /* Curve448 is not supported yet */
-        return WC_TEST_RET_ENC_EC(ret);
-
-    if (ret == 0)
-        return ret;
+        ret = WC_TEST_RET_ENC_EC(ret);
+    else
+        ret = 0;
 #endif
 
 #if defined(HAVE_CURVE25519)
     /* test with curve25519 and aes256 */
-    ret = wc_HpkeInit(hpke, DHKEM_X25519_HKDF_SHA256, HKDF_SHA256,
-        HPKE_AES_256_GCM, NULL);
+    if (ret == 0)
+        ret = wc_HpkeInit(hpke, DHKEM_X25519_HKDF_SHA256, HKDF_SHA256,
+                HPKE_AES_256_GCM, NULL);
 
     if (ret != 0)
         return WC_TEST_RET_ENC_EC(ret);


### PR DESCRIPTION
# Description

Goal was to have code coverage for the HAVE_CURVE448 case in hpke.c, I achieved this by adding a new test case into test.c that hit those lines of code in hpke.c.