### PR TITLE
Various fixes for dual algorithm certificates

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -7526,10 +7526,23 @@ int wolfSSL_i2d_X509(WOLFSSL_X509* x509, unsigned char** out)
 int wc_GeneratePreTBS(DecodedCert* cert, byte *der, int derSz) {
     int ret = 0;
     WOLFSSL_X509 *x = NULL;
+    byte certOwnsAltNames = 0;
+    byte certIsCSR = 0;
 
     if ((cert == NULL) || (der == NULL) || (derSz <= 0)) {
         return BAD_FUNC_ARG;
     }
+
+    /* The call to CopyDecodedToX509() transfers ownership of the altNames in
+     * the DecodedCert to the temporary X509 object, causing the list to be
+     * freed in wolfSSL_X509_free(). As this is an unintended side-effect, we
+     * have to save the ownerFlag here and transfer ownership back to the
+     * DecodedCert prior to freeing the X509 object. */
+    certOwnsAltNames = cert->weOwnAltNames;
+
+#ifdef WOLFSSL_CERT_REQ
+    certIsCSR = cert->isCSR;
+#endif
 
     x = wolfSSL_X509_new();
     if (x == NULL) {
@@ -7539,6 +7552,9 @@ int wc_GeneratePreTBS(DecodedCert* cert, byte *der, int derSz) {
         ret = CopyDecodedToX509(x, cert);
     }
 
+    /* CopyDecodedToX509() clears cert->weOwnAltNames. Restore it. */
+    cert->weOwnAltNames = certOwnsAltNames;
+
     if (ret == 0) {
         /* Remove the altsigval extension. */
         XFREE(x->altSigValDer, x->heap, DYNAMIC_TYPE_X509_EXT);
@@ -7547,13 +7563,16 @@ int wc_GeneratePreTBS(DecodedCert* cert, byte *der, int derSz) {
         /* Remove sigOID so it won't be encoded. */
         x->sigOID = 0;
         /* We now have a PreTBS. Encode it. */
-        ret = wolfssl_x509_make_der(x, 0, der, &derSz, 0);
+        ret = wolfssl_x509_make_der(x, certIsCSR, der, &derSz, 0);
         if (ret == WOLFSSL_SUCCESS) {
             ret = derSz;
         }
     }
 
     if (x != NULL) {
+        /* Safe the altNames list from being freed unitentionally. */
+        x->altNames = NULL;
+
         wolfSSL_X509_free(x);
     }
 


### PR DESCRIPTION
Hi all, 

This commit adds various fixes for the implementation of hybrid certificates with two algorithms:
* Support for Certificate Signing Requests (both creating hybrid ones and also verifying ones)
* Fix for SAN fields in the DecodedCert and PreTBS generation
* Fix related to WOLFSSL_SMALL_STACK
