### PR TITLE
Fixes for Segger emNet to handle non-blocking want read/want write

### DIFF
--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -153,6 +153,11 @@ static WC_INLINE int TranslateReturnCode(int old, int sd)
         if (errno == RTCSERR_TCP_TIMED_OUT)
             errno = SOCKET_EAGAIN;
     }
+#elif defined(WOLFSSL_EMNET)
+    if (old < 0) { /* SOCKET_ERROR */
+        /* Get the real socket error */
+        IP_SOCK_getsockopt(sd, SOL_SOCKET, SO_ERROR, &old, (int)sizeof(old));
+    }
 #endif
 
     return old;
@@ -166,7 +171,7 @@ static WC_INLINE int wolfSSL_LastError(int err)
     return WSAGetLastError();
 #elif defined(EBSNET)
     return xn_getlasterror();
-#elif defined(WOLFSSL_LINUXKM)
+#elif defined(WOLFSSL_LINUXKM) || defined(WOLFSSL_EMNET)
     return err; /* Return provided error value */
 #elif defined(FUSION_RTOS)
     #include <fclerrno.h>

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -150,6 +150,8 @@
         #include <sys/fcltypes.h>
         #include <fclerrno.h>
         #include <fclfcntl.h>
+    #elif defined(WOLFSSL_EMNET)
+        #include <IP/IP.h>
     #elif !defined(WOLFSSL_NO_SOCK)
         #include <sys/types.h>
         #include <errno.h>
@@ -305,7 +307,7 @@
     #define SOCKET_ECONNREFUSED ERR_CONN
     #define SOCKET_ECONNABORTED ERR_ABRT
 #elif defined(WOLFSSL_EMNET)
-    #include <IP/IP.h>
+    #define XSOCKLENT           int
     #define SOCKET_EWOULDBLOCK  IP_ERR_WOULD_BLOCK
     #define SOCKET_EAGAIN       IP_ERR_WOULD_BLOCK
     #define SOCKET_ECONNRESET   IP_ERR_CONN_RESET


### PR DESCRIPTION
# Description

Fix for EMNET with non-blocking to handle want read/want write. Fix to not include standard POSIX headers like `unistd.h` for EMNET.

Fixes ZD 18012

# Testing

Customer tested

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
