### PR TITLE
20240524-pq-clang-tidy

### DIFF
--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -489,6 +489,7 @@ static int parse_private_key(const byte* priv, word32 privSz,
     /* At this point, it is still a PKCS8 private key. */
     if ((ret = ToTraditionalInline(priv, &idx, privSz)) < 0) {
         /* ignore error, did not have PKCS8 header */
+        (void)ret;
     }
 
     /* Now it is a octet_string(concat(priv,pub)) */

--- a/wolfcrypt/src/falcon.c
+++ b/wolfcrypt/src/falcon.c
@@ -470,6 +470,7 @@ static int parse_private_key(const byte* priv, word32 privSz,
     /* At this point, it is still a PKCS8 private key. */
     if ((ret = ToTraditionalInline(priv, &idx, privSz)) < 0) {
         /* ignore error, did not have PKCS8 header */
+        (void)ret;
     }
 
     /* Now it is a octet_string(concat(priv,pub)) */

--- a/wolfcrypt/src/sphincs.c
+++ b/wolfcrypt/src/sphincs.c
@@ -432,6 +432,7 @@ static int parse_private_key(const byte* priv, word32 privSz,
     /* At this point, it is still a PKCS8 private key. */
     if ((ret = ToTraditionalInline(priv, &idx, privSz)) < 0) {
         /* ignore error, did not have PKCS8 header */
+        (void)ret;
     }
 
     /* Now it is a octet_string(concat(priv,pub)) */


### PR DESCRIPTION
fix benign `clang-analyzer-deadcode.DeadStores` in pq crypto files introduced in 9a58301ab1.

found by and tested with `wolfssl-multi-test.sh ... pq-all-clang-tidy`
