### PR TITLE
make function signature match declaration

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -14091,14 +14091,14 @@ const char* wolfSSL_get_cipher_name(WOLFSSL* ssl)
     return wolfSSL_get_cipher_name_internal(ssl);
 }
 
-const char* wolfSSL_get_cipher_name_from_suite(const byte cipherSuite0,
-    const byte cipherSuite)
+const char* wolfSSL_get_cipher_name_from_suite(byte cipherSuite0,
+    byte cipherSuite)
 {
     return GetCipherNameInternal(cipherSuite0, cipherSuite);
 }
 
-const char* wolfSSL_get_cipher_name_iana_from_suite(const byte cipherSuite0,
-        const byte cipherSuite)
+const char* wolfSSL_get_cipher_name_iana_from_suite(byte cipherSuite0,
+        byte cipherSuite)
 {
     return GetCipherNameIana(cipherSuite0, cipherSuite);
 }


### PR DESCRIPTION
Caught when compiling with MCC18 compiler. The function declarations in wolfssl/ssl.h do not have `const` for the arguments.