### PR TITLE
fix typo with NO_CERTS macro

### DIFF
--- a/examples/configs/user_settings_wolfboot_keytools.h
+++ b/examples/configs/user_settings_wolfboot_keytools.h
@@ -86,7 +86,7 @@
 #define NO_RABBIT
 #define NO_MD5
 #define NO_SIG_WRAPPER
-#define NO_CERT
+#define NO_CERTS
 #define NO_SESSION_CACHE
 #define NO_HC128
 #define NO_DES3

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -23273,7 +23273,7 @@ wolfSSL_CTX_keylog_cb_func wolfSSL_CTX_get_keylog_callback(
 
 #endif /* OPENSSL_EXTRA */
 
-#ifndef NO_CERT
+#ifndef NO_CERTS
 #define WOLFSSL_X509_INCLUDED
 #include "src/x509.c"
 #endif

--- a/src/x509.c
+++ b/src/x509.c
@@ -14583,7 +14583,7 @@ void wolfSSL_X509_ATTRIBUTE_free(WOLFSSL_X509_ATTRIBUTE* attr)
 }
 #endif
 
-#endif /* !NO_CERT */
+#endif /* !NO_CERTS */
 
 #endif /* !WOLFCRYPT_ONLY */
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -3534,7 +3534,7 @@ int CheckBitString(const byte* input, word32* inOutIdx, int* len,
     ((defined(HAVE_ED25519) || defined(HAVE_ED448)) && \
      (defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_KEY_GEN) || \
       defined(OPENSSL_EXTRA))) || \
-    (defined(WC_ENABLE_ASYM_KEY_EXPORT) && !defined(NO_CERT)) || \
+    (defined(WC_ENABLE_ASYM_KEY_EXPORT) && !defined(NO_CERTS)) || \
     (!defined(NO_DSA) && !defined(HAVE_SELFTEST) && defined(WOLFSSL_KEY_GEN)) || \
     (!defined(NO_DH) && defined(WOLFSSL_DH_EXTRA))
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -26112,6 +26112,7 @@ int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 inLen,
 
 #endif /* !NO_RSA && (WOLFSSL_CERT_GEN || WOLFSSL_KCAPI_RSA ||
             ((OPENSSL_EXTRA || WOLFSSL_KEY_GEN))) */
+#endif /* NO_CERTS */
 
 #if (defined(WOLFSSL_KEY_GEN) || defined(OPENSSL_EXTRA) || \
      defined(WOLFSSL_KCAPI_RSA) || defined(WOLFSSL_SE050)) && \
@@ -26282,6 +26283,7 @@ int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen)
 
 #endif /* (WOLFSSL_KEY_GEN || OPENSSL_EXTRA) && !NO_RSA */
 
+#ifndef NO_CERTS
 
 #ifdef WOLFSSL_CERT_GEN
 


### PR DESCRIPTION
Noticed in src/ssl.c with PIC18F effort.

Found other instances with `git grep NO_CERT | grep -v NO_CERTS`