### PR TITLE
ECC: when multiplying by zero, set z to 1

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4061,7 +4061,7 @@ int wc_ecc_mulmod(const mp_int* k, ecc_point *G, ecc_point *R, mp_int* a,
     if ((k != NULL) && (R != NULL) && (mp_iszero(k))) {
         mp_zero(R->x);
         mp_zero(R->y);
-        mp_zero(R->z);
+        mp_set(R->z, 1);
         return MP_OKAY;
     }
     return wc_ecc_mulmod_ex(k, G, R, a, modulus, map, NULL);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -31085,6 +31085,10 @@ static wc_test_ret_t ecc_mulmod_test(ecc_key* key1)
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
+    if (mp_cmp_d(key3->pubkey.z, 1) != MP_EQ) {
+        ret = WC_TEST_RET_ENC_EC(ret);
+        goto done;
+    }
 #endif
 
 done:


### PR DESCRIPTION
# Description

Make sure zero times a point is infinity but z is 1 as it is assumed later on.

Fixes #7530

# Testing

./configure '--disable-shared' 'CFLAGS=-DWOLFSSL_PUBLIC_MP'

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
