### PR TITLE
20240529-linuxkm-6v10-updates

### DIFF
--- a/linuxkm/Kbuild
+++ b/linuxkm/Kbuild
@@ -172,14 +172,14 @@ ifneq "$(quiet)" "silent_"
 	@echo '  wolfCrypt .{text,data,rodata} sections containerized to .{text,data,rodata}.wolfcrypt'
 endif
 
-$(src)/linuxkm/module_exports.c: rename-pie-text-and-data-sections
+$(obj)/linuxkm/module_exports.c: rename-pie-text-and-data-sections
 
 endif
 
 
 # auto-generate the exported symbol list, leveraging the WOLFSSL_API visibility tags.
 # exclude symbols that don't match wc_* or wolf*.
-$(src)/linuxkm/module_exports.c: $(src)/linuxkm/module_exports.c.template $(WOLFSSL_OBJ_TARGETS)
+$(obj)/linuxkm/module_exports.c: $(src)/module_exports.c.template $(WOLFSSL_OBJ_TARGETS)
 	@cp $< $@
 	@readelf --symbols --wide $(WOLFSSL_OBJ_TARGETS) |				\
 		awk '/^ *[0-9]+: / {							\
@@ -190,4 +190,4 @@ $(src)/linuxkm/module_exports.c: $(src)/linuxkm/module_exports.c.template $(WOLF
 		}' >> $@
 	@echo -e '#ifndef NO_CRYPT_TEST\nEXPORT_SYMBOL_NS_GPL(wolfcrypt_test, WOLFSSL);\n#endif' >> $@
 
-clean-files := module_exports.c linuxkm src wolfcrypt/src wolfcrypt/test wolfcrypt
+clean-files := linuxkm src wolfcrypt

--- a/linuxkm/Makefile
+++ b/linuxkm/Makefile
@@ -64,10 +64,15 @@ libwolfssl.ko:
 	@if test -z "$(src_libwolfssl_la_OBJECTS)"; then echo '$$src_libwolfssl_la_OBJECTS is unset.' >&2; exit 1; fi
 	@mkdir -p linuxkm src wolfcrypt/src wolfcrypt/test
 	@if test ! -h $(SRC_TOP)/Kbuild; then ln -s $(MODULE_TOP)/Kbuild $(SRC_TOP)/Kbuild; fi
+        # after commit 9a0ebe5011 (6.10), sources must be in $(obj).  work around this by making links to all needed sources:
+	@cp --no-dereference --symbolic-link --update=none '$(MODULE_TOP)'/*.[ch] '$(MODULE_TOP)'/linuxkm/
+	@cp --no-dereference --symbolic-link --update=none --recursive '$(SRC_TOP)'/wolfcrypt/src '$(MODULE_TOP)'/wolfcrypt/
+	@cp --no-dereference --symbolic-link --update=none --recursive '$(SRC_TOP)'/wolfcrypt/test '$(MODULE_TOP)'/wolfcrypt/
+	@cp --no-dereference --symbolic-link --update=none --recursive '$(SRC_TOP)'/src '$(MODULE_TOP)'/
 ifeq "$(ENABLED_LINUXKM_PIE)" "yes"
-	+$(MAKE) -C $(KERNEL_ROOT) M=$(MODULE_TOP) src=$(SRC_TOP) $(KBUILD_EXTRA_FLAGS) CC_FLAGS_FTRACE=
+	+$(MAKE) -C $(KERNEL_ROOT) M=$(MODULE_TOP) $(KBUILD_EXTRA_FLAGS) CC_FLAGS_FTRACE=
 else
-	+$(MAKE) -C $(KERNEL_ROOT) M=$(MODULE_TOP) src=$(SRC_TOP) $(KBUILD_EXTRA_FLAGS)
+	+$(MAKE) -C $(KERNEL_ROOT) M=$(MODULE_TOP) $(KBUILD_EXTRA_FLAGS)
 endif
 
 libwolfssl.ko.signed: libwolfssl.ko

--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -532,22 +532,31 @@
 
         const unsigned char *_ctype;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0)
+        typeof(kmalloc_noprof) *kmalloc_noprof;
+        typeof(krealloc_noprof) *krealloc_noprof;
+        typeof(kzalloc_noprof) *kzalloc_noprof;
+        typeof(kvmalloc_node_noprof) *kvmalloc_node_noprof;
+        typeof(kmalloc_trace_noprof) *kmalloc_trace_noprof;
+#else /* <6.10.0 */
         typeof(kmalloc) *kmalloc;
-        typeof(kfree) *kfree;
-        typeof(ksize) *ksize;
         typeof(krealloc) *krealloc;
         #ifdef HAVE_KVMALLOC
         typeof(kvmalloc_node) *kvmalloc_node;
-        typeof(kvfree) *kvfree;
         #endif
-        typeof(is_vmalloc_addr) *is_vmalloc_addr;
-
         #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
             typeof(kmalloc_trace) *kmalloc_trace;
         #else
             typeof(kmem_cache_alloc_trace) *kmem_cache_alloc_trace;
             typeof(kmalloc_order_trace) *kmalloc_order_trace;
         #endif
+#endif /* <6.10.0 */
+        #ifdef HAVE_KVMALLOC
+        typeof(kvfree) *kvfree;
+        #endif
+        typeof(kfree) *kfree;
+        typeof(ksize) *ksize;
+        typeof(is_vmalloc_addr) *is_vmalloc_addr;
 
         typeof(get_random_bytes) *get_random_bytes;
         #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 0, 0)
@@ -675,22 +684,35 @@
 
     #define _ctype (wolfssl_linuxkm_get_pie_redirect_table()->_ctype)
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0)
+    /* see include/linux/alloc_tag.h and include/linux/slab.h */
+    #define kmalloc_noprof (wolfssl_linuxkm_get_pie_redirect_table()->kmalloc_noprof)
+    #define krealloc_noprof (wolfssl_linuxkm_get_pie_redirect_table()->krealloc_noprof)
+    #define kzalloc_noprof (wolfssl_linuxkm_get_pie_redirect_table()->kzalloc_noprof)
+    #define kvmalloc_node_noprof (wolfssl_linuxkm_get_pie_redirect_table()->kvmalloc_node_noprof)
+    #define kmalloc_trace_noprof (wolfssl_linuxkm_get_pie_redirect_table()->kmalloc_trace_noprof)
+#else /* <6.10.0 */
     #define kmalloc (wolfssl_linuxkm_get_pie_redirect_table()->kmalloc)
-    #define kfree (wolfssl_linuxkm_get_pie_redirect_table()->kfree)
-    #define ksize (wolfssl_linuxkm_get_pie_redirect_table()->ksize)
     #define krealloc (wolfssl_linuxkm_get_pie_redirect_table()->krealloc)
     #define kzalloc(size, flags) kmalloc(size, (flags) | __GFP_ZERO)
     #ifdef HAVE_KVMALLOC
         #define kvmalloc_node (wolfssl_linuxkm_get_pie_redirect_table()->kvmalloc_node)
-        #define kvfree (wolfssl_linuxkm_get_pie_redirect_table()->kvfree)
     #endif
-    #define is_vmalloc_addr (wolfssl_linuxkm_get_pie_redirect_table()->is_vmalloc_addr)
     #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
         #define kmalloc_trace (wolfssl_linuxkm_get_pie_redirect_table()->kmalloc_trace)
     #else
         #define kmem_cache_alloc_trace (wolfssl_linuxkm_get_pie_redirect_table()->kmem_cache_alloc_trace)
         #define kmalloc_order_trace (wolfssl_linuxkm_get_pie_redirect_table()->kmalloc_order_trace)
     #endif
+#endif /* <6.10.0 */
+
+    #define kfree (wolfssl_linuxkm_get_pie_redirect_table()->kfree)
+    #ifdef HAVE_KVMALLOC
+        #define kvfree (wolfssl_linuxkm_get_pie_redirect_table()->kvfree)
+    #endif
+    #define ksize (wolfssl_linuxkm_get_pie_redirect_table()->ksize)
+
+    #define is_vmalloc_addr (wolfssl_linuxkm_get_pie_redirect_table()->is_vmalloc_addr)
 
     #define get_random_bytes (wolfssl_linuxkm_get_pie_redirect_table()->get_random_bytes)
     #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 0, 0)

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -459,15 +459,18 @@ static int set_up_wolfssl_linuxkm_pie_redirect_table(void) {
 
     wolfssl_linuxkm_pie_redirect_table._ctype = _ctype;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0)
+    wolfssl_linuxkm_pie_redirect_table.kmalloc_noprof = kmalloc_noprof;
+    wolfssl_linuxkm_pie_redirect_table.krealloc_noprof = krealloc_noprof;
+    wolfssl_linuxkm_pie_redirect_table.kzalloc_noprof = kzalloc_noprof;
+    wolfssl_linuxkm_pie_redirect_table.kvmalloc_node_noprof = kvmalloc_node_noprof;
+    wolfssl_linuxkm_pie_redirect_table.kmalloc_trace_noprof = kmalloc_trace_noprof;
+#else
     wolfssl_linuxkm_pie_redirect_table.kmalloc = kmalloc;
-    wolfssl_linuxkm_pie_redirect_table.kfree = kfree;
-    wolfssl_linuxkm_pie_redirect_table.ksize = ksize;
     wolfssl_linuxkm_pie_redirect_table.krealloc = krealloc;
 #ifdef HAVE_KVMALLOC
     wolfssl_linuxkm_pie_redirect_table.kvmalloc_node = kvmalloc_node;
-    wolfssl_linuxkm_pie_redirect_table.kvfree = kvfree;
 #endif
-    wolfssl_linuxkm_pie_redirect_table.is_vmalloc_addr = is_vmalloc_addr;
     #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
         wolfssl_linuxkm_pie_redirect_table.kmalloc_trace =
             kmalloc_trace;
@@ -477,6 +480,14 @@ static int set_up_wolfssl_linuxkm_pie_redirect_table(void) {
         wolfssl_linuxkm_pie_redirect_table.kmalloc_order_trace =
             kmalloc_order_trace;
     #endif
+#endif
+
+    wolfssl_linuxkm_pie_redirect_table.kfree = kfree;
+    wolfssl_linuxkm_pie_redirect_table.ksize = ksize;
+#ifdef HAVE_KVMALLOC
+    wolfssl_linuxkm_pie_redirect_table.kvfree = kvfree;
+#endif
+    wolfssl_linuxkm_pie_redirect_table.is_vmalloc_addr = is_vmalloc_addr;
 
     wolfssl_linuxkm_pie_redirect_table.get_random_bytes = get_random_bytes;
     #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 0, 0)


### PR DESCRIPTION
linuxkm: updates for kernel 6.10: use new `_noprof` names for newly macro-shimmed `kmalloc`, `krealloc`, `kzmalloc`, `kvmalloc_node`, and `kmalloc_trace`, and refactor `linuxkm/Makefile` and `linuxkm/Kbuild` to set up links to sources in the dest tree (works around breakage from linux commit 9a0ebe5011).

tested with `wolfssl-multi-test.sh ... check-source-text make-dist-clean-check linuxkm-all-aesni-insmod linuxkm-fips-dev-static-hash-intelasm-LKCAPI-insmod-crypto-fuzzer linuxkm-mainline-intelasm-sp-asm-pie-gcc-latest-insmod linuxkm-legacy-6.1-insmod`
