### PR TITLE
Send BUFFER_ERROR if size does not meet minimum Requirements

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -14366,6 +14366,143 @@ int TLSX_ParseVersion(WOLFSSL* ssl, const byte* input, word16 length,
     return ret;
 }
 #endif
+/* Jump Table to check minimum size values for client case in TLSX_Parse */
+#ifndef NO_WOLFSSL_SERVER
+static word16 TLSX_GetMinSize_Client(word16* type)
+{
+    switch (*type) {
+        case TLSXT_SERVER_NAME:
+            return WOLFSSL_SNI_MIN_SIZE_CLIENT;
+        case TLSXT_EARLY_DATA:
+            return WOLFSSL_EDI_MIN_SIZE_CLIENT;
+        case TLSXT_MAX_FRAGMENT_LENGTH:
+            return WOLFSSL_MFL_MIN_SIZE_CLIENT;
+        case TLSXT_TRUSTED_CA_KEYS:
+            return WOLFSSL_TCA_MIN_SIZE_CLIENT;
+        case TLSXT_TRUNCATED_HMAC:
+            return WOLFSSL_THM_MIN_SIZE_CLIENT;
+        case TLSXT_STATUS_REQUEST:
+            return WOLFSSL_CSR_MIN_SIZE_CLIENT;
+        case TLSXT_SUPPORTED_GROUPS:
+            return WOLFSSL_EC_MIN_SIZE_CLIENT;
+        case TLSXT_EC_POINT_FORMATS:
+            return WOLFSSL_PF_MIN_SIZE_CLIENT;
+        case TLSXT_SIGNATURE_ALGORITHMS:
+            return WOLFSSL_SA_MIN_SIZE_CLIENT;
+        case TLSXT_USE_SRTP:
+            return WOLFSSL_SRTP_MIN_SIZE_CLIENT;
+        case TLSXT_APPLICATION_LAYER_PROTOCOL:
+            return WOLFSSL_ALPN_MIN_SIZE_CLIENT;
+        case TLSXT_STATUS_REQUEST_V2:
+            return WOLFSSL_CSR2_MIN_SIZE_CLIENT;
+        case TLSXT_CLIENT_CERTIFICATE:
+            return WOLFSSL_CCT_MIN_SIZE_CLIENT;
+        case TLSXT_SERVER_CERTIFICATE:
+            return WOLFSSL_SCT_MIN_SIZE_CLIENT;
+        case TLSXT_ENCRYPT_THEN_MAC:
+            return WOLFSSL_ETM_MIN_SIZE_CLIENT;
+        case TLSXT_SESSION_TICKET:
+            return WOLFSSL_STK_MIN_SIZE_CLIENT;
+        case TLSXT_PRE_SHARED_KEY:
+            return WOLFSSL_PSK_MIN_SIZE_CLIENT;
+        case TLSXT_COOKIE:
+            return WOLFSSL_CKE_MIN_SIZE_CLIENT;
+        case TLSXT_PSK_KEY_EXCHANGE_MODES:
+            return WOLFSSL_PKM_MIN_SIZE_CLIENT;
+        case TLSXT_CERTIFICATE_AUTHORITIES:
+            return WOLFSSL_CAN_MIN_SIZE_CLIENT;
+        case TLSXT_POST_HANDSHAKE_AUTH:
+            return WOLFSSL_PHA_MIN_SIZE_CLIENT;
+        case TLSXT_SIGNATURE_ALGORITHMS_CERT:
+            return WOLFSSL_SA_MIN_SIZE_CLIENT;
+        case TLSXT_KEY_SHARE:
+            return WOLFSSL_KS_MIN_SIZE_CLIENT;
+        case TLSXT_CONNECTION_ID:
+            return WOLFSSL_CID_MIN_SIZE_CLIENT;
+        case TLSXT_RENEGOTIATION_INFO:
+            return WOLFSSL_SCR_MIN_SIZE_CLIENT;
+        case TLSXT_KEY_QUIC_TP_PARAMS_DRAFT:
+            return WOLFSSL_QTP_MIN_SIZE_CLIENT;
+        case TLSXT_ECH:
+            return WOLFSSL_ECH_MIN_SIZE_CLIENT;
+        default:
+            return 0;
+    }
+}
+    #define TLSX_GET_MIN_SIZE_CLIENT TLSX_GetMinSize_Client
+#else
+    #define TLSX_GET_MIN_SIZE_CLIENT(...) 0
+#endif
+
+
+#ifndef NO_WOLFSSL_CLIENT
+/* Jump Table to check minimum size values for server case in TLSX_Parse */
+static word16 TLSX_GetMinSize_Server(const word16 *type)
+{
+    switch (*type) {
+        case TLSXT_SERVER_NAME:
+            return WOLFSSL_SNI_MIN_SIZE_SERVER;
+        case TLSXT_EARLY_DATA:
+            return WOLFSSL_EDI_MIN_SIZE_SERVER;
+        case TLSXT_MAX_FRAGMENT_LENGTH:
+            return WOLFSSL_MFL_MIN_SIZE_SERVER;
+        case TLSXT_TRUSTED_CA_KEYS:
+            return WOLFSSL_TCA_MIN_SIZE_SERVER;
+        case TLSXT_TRUNCATED_HMAC:
+            return WOLFSSL_THM_MIN_SIZE_SERVER;
+        case TLSXT_STATUS_REQUEST:
+            return WOLFSSL_CSR_MIN_SIZE_SERVER;
+        case TLSXT_SUPPORTED_GROUPS:
+            return WOLFSSL_EC_MIN_SIZE_SERVER;
+        case TLSXT_EC_POINT_FORMATS:
+            return WOLFSSL_PF_MIN_SIZE_SERVER;
+        case TLSXT_SIGNATURE_ALGORITHMS:
+            return WOLFSSL_SA_MIN_SIZE_SERVER;
+        case TLSXT_USE_SRTP:
+            return WOLFSSL_SRTP_MIN_SIZE_SERVER;
+        case TLSXT_APPLICATION_LAYER_PROTOCOL:
+            return WOLFSSL_ALPN_MIN_SIZE_SERVER;
+        case TLSXT_STATUS_REQUEST_V2:
+            return WOLFSSL_CSR2_MIN_SIZE_SERVER;
+        case TLSXT_CLIENT_CERTIFICATE:
+            return WOLFSSL_CCT_MIN_SIZE_SERVER;
+        case TLSXT_SERVER_CERTIFICATE:
+            return WOLFSSL_SCT_MIN_SIZE_SERVER;
+        case TLSXT_ENCRYPT_THEN_MAC:
+            return WOLFSSL_ETM_MIN_SIZE_SERVER;
+        case TLSXT_SESSION_TICKET:
+            return WOLFSSL_STK_MIN_SIZE_SERVER;
+        case TLSXT_PRE_SHARED_KEY:
+            return WOLFSSL_PSK_MIN_SIZE_SERVER;
+        case TLSXT_COOKIE:
+            return WOLFSSL_CKE_MIN_SIZE_SERVER;
+        case TLSXT_PSK_KEY_EXCHANGE_MODES:
+            return WOLFSSL_PKM_MIN_SIZE_SERVER;
+        case TLSXT_CERTIFICATE_AUTHORITIES:
+            return WOLFSSL_CAN_MIN_SIZE_SERVER;
+        case TLSXT_POST_HANDSHAKE_AUTH:
+            return WOLFSSL_PHA_MIN_SIZE_SERVER;
+        case TLSXT_SIGNATURE_ALGORITHMS_CERT:
+            return WOLFSSL_SA_MIN_SIZE_SERVER;
+        case TLSXT_KEY_SHARE:
+            return WOLFSSL_KS_MIN_SIZE_SERVER;
+        case TLSXT_CONNECTION_ID:
+            return WOLFSSL_CID_MIN_SIZE_SERVER;
+        case TLSXT_RENEGOTIATION_INFO:
+            return WOLFSSL_SCR_MIN_SIZE_SERVER;
+        case TLSXT_KEY_QUIC_TP_PARAMS_DRAFT:
+            return WOLFSSL_QTP_MIN_SIZE_SERVER;
+        case TLSXT_ECH:
+            return WOLFSSL_ECH_MIN_SIZE_SERVER;
+        default:
+            return 0;
+    }
+}
+    #define TLSX_GET_MIN_SIZE_SERVER TLSX_GetMinSize_Server
+#else
+    #define TLSX_GET_MIN_SIZE_SERVER(...) 0
+#endif
+
 
 /** Parses a buffer of TLS extensions. */
 int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
@@ -14428,6 +14565,29 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
 
         if (length - offset < size)
             return BUFFER_ERROR;
+
+        /* Check minimum size required for TLSX, even if disabled */
+        switch (msgType) {
+            #ifndef NO_WOLFSSL_SERVER
+            case client_hello:
+                if (size < TLSX_GET_MIN_SIZE_CLIENT(&type)){
+                    WOLFSSL_MSG("Minimum TLSX Size Requirement not Satisfied");
+                    return BUFFER_ERROR;
+                }
+            break;
+            #endif
+            #ifndef NO_WOLFSSL_CLIENT
+            case server_hello:
+            case hello_retry_request:
+                if (size < TLSX_GET_MIN_SIZE_SERVER(&type)){
+                    WOLFSSL_MSG("Minimum TLSX Size Requirement not Satisfied");
+                    return BUFFER_ERROR;
+                }
+            break;
+            #endif
+            default:
+            break;
+        }
 
         switch (type) {
 #ifdef HAVE_SNI

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2820,74 +2820,108 @@ typedef struct Options Options;
 /** TLS Extensions - RFC 6066 */
 #ifdef HAVE_TLS_EXTENSIONS
 
+#define TLSXT_SERVER_NAME                0x0000 /* a.k.a. SNI  */
+#define TLSXT_MAX_FRAGMENT_LENGTH        0x0001
+#define TLSXT_TRUSTED_CA_KEYS            0x0003
+#define TLSXT_TRUNCATED_HMAC             0x0004
+#define TLSXT_STATUS_REQUEST             0x0005 /* a.k.a. OCSP stapling   */
+#define TLSXT_SUPPORTED_GROUPS           0x000a /* a.k.a. Supported Curves */
+#define TLSXT_EC_POINT_FORMATS           0x000b
+#define TLSXT_SIGNATURE_ALGORITHMS       0x000d /* HELLO_EXT_SIG_ALGO */
+#define TLSXT_USE_SRTP                   0x000e /* 14 */
+#define TLSXT_APPLICATION_LAYER_PROTOCOL 0x0010 /* a.k.a. ALPN */
+#define TLSXT_STATUS_REQUEST_V2          0x0011 /* a.k.a. OCSP stapling v2 */
+#define TLSXT_CLIENT_CERTIFICATE         0x0013 /* RFC8446 */
+#define TLSXT_SERVER_CERTIFICATE         0x0014 /* RFC8446 */
+#define TLSXT_ENCRYPT_THEN_MAC           0x0016 /* RFC 7366 */
+#define TLSXT_EXTENDED_MASTER_SECRET     0x0017 /* HELLO_EXT_EXTMS */
+#define TLSXT_SESSION_TICKET             0x0023
+#define TLSXT_PRE_SHARED_KEY             0x0029
+#define TLSXT_EARLY_DATA                 0x002a
+#define TLSXT_SUPPORTED_VERSIONS         0x002b
+#define TLSXT_COOKIE                     0x002c
+#define TLSXT_PSK_KEY_EXCHANGE_MODES     0x002d
+#define TLSXT_CERTIFICATE_AUTHORITIES    0x002f
+#define TLSXT_POST_HANDSHAKE_AUTH        0x0031
+#define TLSXT_SIGNATURE_ALGORITHMS_CERT  0x0032
+#define TLSXT_KEY_SHARE                  0x0033
+#define TLSXT_CONNECTION_ID              0x0036
+#define TLSXT_KEY_QUIC_TP_PARAMS         0x0039 /* RFC 9001, ch. 8.2 */
+#define TLSXT_ECH                        0xfe0d /* from */
+                                                /* draft-ietf-tls-esni-13 */
+/* The 0xFF section is experimental/custom/personal use */
+#define TLSXT_CKS                        0xff92 /* X9.146 */
+#define TLSXT_RENEGOTIATION_INFO         0xff01
+#define TLSXT_KEY_QUIC_TP_PARAMS_DRAFT   0xffa5 /* from */
+                                                /* draft-ietf-quic-tls-27 */
+
 typedef enum {
 #ifdef HAVE_SNI
-    TLSX_SERVER_NAME                = 0x0000, /* a.k.a. SNI  */
+    TLSX_SERVER_NAME                = TLSXT_SERVER_NAME,
 #endif
-    TLSX_MAX_FRAGMENT_LENGTH        = 0x0001,
-    TLSX_TRUSTED_CA_KEYS            = 0x0003,
-    TLSX_TRUNCATED_HMAC             = 0x0004,
-    TLSX_STATUS_REQUEST             = 0x0005, /* a.k.a. OCSP stapling   */
-    TLSX_SUPPORTED_GROUPS           = 0x000a, /* a.k.a. Supported Curves */
-    TLSX_EC_POINT_FORMATS           = 0x000b,
+    TLSX_MAX_FRAGMENT_LENGTH        = TLSXT_MAX_FRAGMENT_LENGTH,
+    TLSX_TRUSTED_CA_KEYS            = TLSXT_TRUSTED_CA_KEYS,
+    TLSX_TRUNCATED_HMAC             = TLSXT_TRUNCATED_HMAC,
+    TLSX_STATUS_REQUEST             = TLSXT_STATUS_REQUEST,
+    TLSX_SUPPORTED_GROUPS           = TLSXT_SUPPORTED_GROUPS,
+    TLSX_EC_POINT_FORMATS           = TLSXT_EC_POINT_FORMATS,
 #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
-    TLSX_SIGNATURE_ALGORITHMS       = 0x000d, /* HELLO_EXT_SIG_ALGO */
+    TLSX_SIGNATURE_ALGORITHMS       = TLSXT_SIGNATURE_ALGORITHMS,
 #endif
 #ifdef WOLFSSL_SRTP
-    TLSX_USE_SRTP                   = 0x000e, /* 14 */
+    TLSX_USE_SRTP                   = TLSXT_USE_SRTP,
 #endif
-    TLSX_APPLICATION_LAYER_PROTOCOL = 0x0010, /* a.k.a. ALPN */
-    TLSX_STATUS_REQUEST_V2          = 0x0011, /* a.k.a. OCSP stapling v2 */
+    TLSX_APPLICATION_LAYER_PROTOCOL = TLSXT_APPLICATION_LAYER_PROTOCOL,
+    TLSX_STATUS_REQUEST_V2          = TLSXT_STATUS_REQUEST_V2,
 #ifdef HAVE_RPK
-    TLSX_CLIENT_CERTIFICATE_TYPE    = 0x0013, /* RFC8446 */
-    TLSX_SERVER_CERTIFICATE_TYPE    = 0x0014, /* RFC8446 */
+    TLSX_CLIENT_CERTIFICATE_TYPE    = TLSXT_CLIENT_CERTIFICATE,
+    TLSX_SERVER_CERTIFICATE_TYPE    = TLSXT_SERVER_CERTIFICATE,
 #endif
 #if defined(HAVE_ENCRYPT_THEN_MAC) && !defined(WOLFSSL_AEAD_ONLY)
-    TLSX_ENCRYPT_THEN_MAC           = 0x0016, /* RFC 7366 */
+    TLSX_ENCRYPT_THEN_MAC           = TLSXT_ENCRYPT_THEN_MAC,
 #endif
-    TLSX_EXTENDED_MASTER_SECRET     = 0x0017, /* HELLO_EXT_EXTMS */
-    TLSX_SESSION_TICKET             = 0x0023,
+    TLSX_EXTENDED_MASTER_SECRET     = TLSXT_EXTENDED_MASTER_SECRET,
+    TLSX_SESSION_TICKET             = TLSXT_SESSION_TICKET,
 #ifdef WOLFSSL_TLS13
     #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
-    TLSX_PRE_SHARED_KEY             = 0x0029,
+    TLSX_PRE_SHARED_KEY             = TLSXT_PRE_SHARED_KEY,
     #endif
     #ifdef WOLFSSL_EARLY_DATA
-    TLSX_EARLY_DATA                 = 0x002a,
+    TLSX_EARLY_DATA                 = TLSXT_EARLY_DATA,
     #endif
-    TLSX_SUPPORTED_VERSIONS         = 0x002b,
+    TLSX_SUPPORTED_VERSIONS         = TLSXT_SUPPORTED_VERSIONS,
     #ifdef WOLFSSL_SEND_HRR_COOKIE
-    TLSX_COOKIE                     = 0x002c,
+    TLSX_COOKIE                     = TLSXT_COOKIE,
     #endif
     #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
-    TLSX_PSK_KEY_EXCHANGE_MODES     = 0x002d,
+    TLSX_PSK_KEY_EXCHANGE_MODES     = TLSXT_PSK_KEY_EXCHANGE_MODES,
     #endif
     #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_CA_NAMES)
-    TLSX_CERTIFICATE_AUTHORITIES    = 0x002f,
+    TLSX_CERTIFICATE_AUTHORITIES    = TLSXT_CERTIFICATE_AUTHORITIES,
     #endif
     #ifdef WOLFSSL_POST_HANDSHAKE_AUTH
-    TLSX_POST_HANDSHAKE_AUTH        = 0x0031,
+    TLSX_POST_HANDSHAKE_AUTH        = TLSXT_POST_HANDSHAKE_AUTH,
     #endif
     #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
-    TLSX_SIGNATURE_ALGORITHMS_CERT  = 0x0032,
+    TLSX_SIGNATURE_ALGORITHMS_CERT  = TLSXT_SIGNATURE_ALGORITHMS_CERT,
     #endif
-    TLSX_KEY_SHARE                  = 0x0033,
+    TLSX_KEY_SHARE                  = TLSXT_KEY_SHARE,
     #if defined(WOLFSSL_DTLS_CID)
-    TLSX_CONNECTION_ID              = 0x0036,
+    TLSX_CONNECTION_ID              = TLSXT_CONNECTION_ID,
     #endif /* defined(WOLFSSL_DTLS_CID) */
     #ifdef WOLFSSL_QUIC
-    TLSX_KEY_QUIC_TP_PARAMS         = 0x0039, /* RFC 9001, ch. 8.2 */
+    TLSX_KEY_QUIC_TP_PARAMS         = TLSXT_KEY_QUIC_TP_PARAMS,
     #endif
-    #ifdef WOLFSSL_DUAL_ALG_CERTS
-    TLSX_CKS                        = 0xff92, /* X9.146; ff indicates personal
-                                               * use and 92 is hex for 146. */
+    #ifdef HAVE_ECH
+    TLSX_ECH                        = TLSXT_ECH,
     #endif
 #endif
-    TLSX_RENEGOTIATION_INFO         = 0xff01,
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_DUAL_ALG_CERTS)
+    TLSX_CKS                        = TLSXT_CKS,
+#endif
+    TLSX_RENEGOTIATION_INFO         = TLSXT_RENEGOTIATION_INFO,
 #ifdef WOLFSSL_QUIC
-    TLSX_KEY_QUIC_TP_PARAMS_DRAFT   = 0xffa5, /* from draft-ietf-quic-tls-27 */
-#endif
-#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
-    TLSX_ECH                        = 0xfe0d, /* from draft-ietf-tls-esni-13 */
+    TLSX_KEY_QUIC_TP_PARAMS_DRAFT   = TLSXT_KEY_QUIC_TP_PARAMS_DRAFT,
 #endif
 } TLSX_Type;
 

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -1530,7 +1530,8 @@ typedef WOLFSSL_SRTP_PROTECTION_PROFILE      SRTP_PROTECTION_PROFILE;
 #define OPENSSL_STRING    WOLFSSL_STRING
 #define OPENSSL_CSTRING   WOLFSSL_STRING
 
-#define TLSEXT_TYPE_application_layer_protocol_negotiation    16
+#define TLSEXT_TYPE_application_layer_protocol_negotiation \
+    TLSXT_APPLICATION_LAYER_PROTOCOL
 
 #define OPENSSL_NPN_UNSUPPORTED 0
 #define OPENSSL_NPN_NEGOTIATED  1

--- a/wolfssl/openssl/tls1.h
+++ b/wolfssl/openssl/tls1.h
@@ -45,8 +45,10 @@
 
 #ifdef WOLFSSL_QUIC
 /* from rfc9001 */
-#define TLSEXT_TYPE_quic_transport_parameters_draft   0xffa5
-#define TLSEXT_TYPE_quic_transport_parameters         0x0039
+#define TLSEXT_TYPE_quic_transport_parameters_draft   \
+    TLSXT_KEY_QUIC_TP_PARAMS_DRAFT
+#define TLSEXT_TYPE_quic_transport_parameters         \
+    TLSXT_KEY_QUIC_TP_PARAMS
 #endif
 
 #endif /* WOLFSSL_OPENSSL_TLS1_H_ */


### PR DESCRIPTION
PR in response to #7275 

Send a BUFFER_ERROR if size does not meet the minimum requirement for the extension.
