### PR TITLE
Fix cut detection in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9621,7 +9621,7 @@ echo "" >> $OPTION_FILE
 # note: cut requires an argument to exit with success.
 if colrm >/dev/null 2>&1 </dev/null; then
     TRIM="colrm 3"
-elif cut --version >/dev/null 2>&1 </dev/null; then
+elif echo "" | cut -c1 >/dev/null 2>&1 </dev/null; then
     TRIM="cut -c1-2"
 else
     AC_MSG_ERROR([Could not find colrm or cut to make options file])


### PR DESCRIPTION
# Description

Some versions of `cut` are missing the `--version` and `--help` options, so the `cut` detection command was failing even if the tool is available. This change checks the availability of the tool by testing the command with an empty string.

# Testing

Tested on macOS by forcing the usage of `cut` over `colrm` with the patch below. The configure command will fail but will succeed with this PR.

```
diff --git a/configure.ac b/configure.ac
index df2f74e12..6c5acdd4f 100644
--- a/configure.ac
+++ b/configure.ac
@@ -9327,9 +9314,9 @@ echo "" >> $OPTION_FILE
 
 # Check for supported command to trim option with.
 # note: cut requires an argument to exit with success.
-if colrm >/dev/null 2>&1 </dev/null; then
-    TRIM="colrm 3"
-elif cut --version >/dev/null 2>&1 </dev/null; then
+#if colrm >/dev/null 2>&1 </dev/null; then
+#    TRIM="colrm 3"
+if cut --version >/dev/null 2>&1 </dev/null; then
     TRIM="cut -c1-2"
 else
     AC_MSG_ERROR([Could not find colrm or cut to make options file])
```


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
