### PR TITLE
20240531-linuxkm-6v10-updates

### DIFF
--- a/linuxkm/Makefile
+++ b/linuxkm/Makefile
@@ -62,12 +62,11 @@ libwolfssl.ko:
 	@if test -z "$(KERNEL_ROOT)"; then echo '$$KERNEL_ROOT is unset' >&2; exit 1; fi
 	@if test -z "$(AM_CFLAGS)$(CFLAGS)"; then echo '$$AM_CFLAGS and $$CFLAGS are both unset.' >&2; exit 1; fi
 	@if test -z "$(src_libwolfssl_la_OBJECTS)"; then echo '$$src_libwolfssl_la_OBJECTS is unset.' >&2; exit 1; fi
-	@mkdir -p linuxkm src wolfcrypt/src wolfcrypt/test
 	@if test ! -h $(SRC_TOP)/Kbuild; then ln -s $(MODULE_TOP)/Kbuild $(SRC_TOP)/Kbuild; fi
         # after commit 9a0ebe5011 (6.10), sources must be in $(obj).  work around this by making links to all needed sources:
+	@mkdir -p linuxkm
 	@cp --no-dereference --symbolic-link --update=none '$(MODULE_TOP)'/*.[ch] '$(MODULE_TOP)'/linuxkm/
-	@cp --no-dereference --symbolic-link --update=none --recursive '$(SRC_TOP)'/wolfcrypt/src '$(MODULE_TOP)'/wolfcrypt/
-	@cp --no-dereference --symbolic-link --update=none --recursive '$(SRC_TOP)'/wolfcrypt/test '$(MODULE_TOP)'/wolfcrypt/
+	@cp --no-dereference --symbolic-link --update=none --recursive '$(SRC_TOP)'/wolfcrypt '$(MODULE_TOP)'/
 	@cp --no-dereference --symbolic-link --update=none --recursive '$(SRC_TOP)'/src '$(MODULE_TOP)'/
 ifeq "$(ENABLED_LINUXKM_PIE)" "yes"
 	+$(MAKE) -C $(KERNEL_ROOT) M=$(MODULE_TOP) $(KBUILD_EXTRA_FLAGS) CC_FLAGS_FTRACE=


### PR DESCRIPTION
`linuxkm/Makefile`: copy link tree of `wolfcrypt/` as a whole, rather than just `wolfcrypt/src/` and `wolfcrypt/test/`, to pull in `wolfcrypt/benchmark/`.

tested with `wolfssl-multi-test.sh ... check-source-text make-dist-clean-check linuxkm-benchmarks-insmod linuxkm-benchmarks-insmod-kmemleak linuxkm-benchmarks-insmod-ksanitize`
