### PR TITLE
Fix for #7606: ESP_LOGI typo in esp32_sha.c

### DIFF
--- a/wolfcrypt/src/port/Espressif/esp32_sha.c
+++ b/wolfcrypt/src/port/Espressif/esp32_sha.c
@@ -1520,9 +1520,9 @@ int esp_sha_hw_unlock(WC_ESP32SHA* ctx)
     }
 
 #if defined(ESP_MONITOR_HW_TASK_LOCK) && defined(WOLFSSL_ESP32_HW_LOCK_DEBUG)
-    SP_LOGI(TAG, "3) esp_sha_hw_unlock Lock depth @ %d = %d "
+   ESP_LOGI(TAG, "3) esp_sha_hw_unlock Lock depth @ %d = %d "
                  "for WC_ESP32SHA @ %0x\n",
-                 __LINE__, ctx->lockDepth, (unsigned)ctx);
+                 __LINE__, ctx->lockDepth, (uintptr_t)ctx);
 #endif
 
     if (0 != ctx->lockDepth) {


### PR DESCRIPTION
# Description

Thank you @Jreuningschererhubbell for reporting the ESP32 typo.

Fixes https://github.com/wolfSSL/wolfssl/issues/7606 

Edit: also consistently casts `(uintptr_t)ctx` instead of `(unsigned)ctx` for the same statement.

Fixes zd# n/a

# Testing

How did you test?

Manually defined `#define WOLFSSL_ESP32_HW_LOCK_DEBUG` in the [wolfssl_test user_settings.h](https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl/include) and confirmed compile success.

Searched for other instances of  ` SP_LOG` with a leading space. None found.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
