### PR TITLE
Improvements to RSA padding to expose Pad/Unpad API's

### DIFF
--- a/examples/async/include.am
+++ b/examples/async/include.am
@@ -2,19 +2,24 @@
 # All paths should be given relative to the root
 
 if BUILD_ASYNCCRYPT
+
 noinst_HEADERS += examples/async/async_tls.h
 
+if BUILD_EXAMPLE_CLIENTS
 noinst_PROGRAMS += examples/async/async_client
 examples_async_async_client_SOURCES      = examples/async/async_client.c examples/async/async_tls.c
 examples_async_async_client_LDADD        = src/libwolfssl@LIBSUFFIX@.la $(LIB_STATIC_ADD)
 examples_async_async_client_DEPENDENCIES = src/libwolfssl@LIBSUFFIX@.la
 examples_async_async_client_CFLAGS       = $(AM_CFLAGS)
+endif
 
+if BUILD_EXAMPLE_SERVERS
 noinst_PROGRAMS += examples/async/async_server
 examples_async_async_server_SOURCES      = examples/async/async_server.c examples/async/async_tls.c
 examples_async_async_server_LDADD        = src/libwolfssl@LIBSUFFIX@.la $(LIB_STATIC_ADD)
 examples_async_async_server_DEPENDENCIES = src/libwolfssl@LIBSUFFIX@.la
 examples_async_async_server_CFLAGS       = $(AM_CFLAGS)
+endif
 endif
 
 dist_example_DATA+= examples/async/async_server.c

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -242,8 +242,8 @@ struct RsaKey {
     char label[RSA_MAX_LABEL_LEN];
     int  labelLen;
 #endif
-#if defined(WOLFSSL_ASYNC_CRYPT) || !defined(WOLFSSL_RSA_VERIFY_INLINE) && \
-    !defined(WOLFSSL_NO_MALLOC)
+#if !defined(WOLFSSL_NO_MALLOC) && (defined(WOLFSSL_ASYNC_CRYPT) || \
+    (!defined(WOLFSSL_RSA_VERIFY_ONLY) && !defined(WOLFSSL_RSA_VERIFY_INLINE)))
     byte   dataIsAlloc;
 #endif
 #ifdef WC_RSA_NONBLOCK
@@ -441,14 +441,13 @@ WOLFSSL_API int wc_RsaExportKey(RsaKey* key,
                                           int nlen, int* isPrime);
 #endif
 
-WOLFSSL_LOCAL int wc_RsaPad_ex(const byte* input, word32 inputLen, byte* pkcsBlock,
-        word32 pkcsBlockLen, byte padValue, WC_RNG* rng, int padType,
-        enum wc_HashType hType, int mgf, byte* optLabel, word32 labelLen,
-        int saltLen, int bits, void* heap);
-WOLFSSL_LOCAL int wc_RsaUnPad_ex(byte* pkcsBlock, word32 pkcsBlockLen, byte** out,
-                                   byte padValue, int padType, enum wc_HashType hType,
-                                   int mgf, byte* optLabel, word32 labelLen, int saltLen,
-                                   int bits, void* heap);
+WOLFSSL_API int wc_RsaPad_ex(const byte* input, word32 inputLen,
+    byte* pkcsBlock, word32 pkcsBlockLen, byte padValue,
+    WC_RNG* rng, int padType, enum wc_HashType hType, int mgf,
+    byte* optLabel, word32 labelLen, int saltLen, int bits, void* heap);
+WOLFSSL_API int wc_RsaUnPad_ex(byte* pkcsBlock, word32 pkcsBlockLen,
+    byte** out, byte padValue, int padType, enum wc_HashType hType, int mgf,
+    byte* optLabel, word32 labelLen, int saltLen, int bits, void* heap);
 
 WOLFSSL_LOCAL int wc_hash2mgf(enum wc_HashType hType);
 WOLFSSL_LOCAL int RsaFunctionCheckIn(const byte* in, word32 inLen, RsaKey* key,


### PR DESCRIPTION
# Description

Improve the macro checks on the RSA dataIsAlloc
Expose API's to support external pad/unpad.

ZD 18052

# Testing

TODO: Add tests for direct Pad/Unpad API's.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
