### PR TITLE
Kyber: fix kyber_from_msg()

### DIFF
--- a/wolfcrypt/src/wc_kyber.c
+++ b/wolfcrypt/src/wc_kyber.c
@@ -59,6 +59,11 @@
 
 /******************************************************************************/
 
+/* Declare variable to make compiler not optimize code in kyber_from_msg(). */
+volatile sword16 kyber_opt_blocker = 0;
+
+/******************************************************************************/
+
 /**
  * Initialize the Kyber key.
  *

--- a/wolfcrypt/src/wc_kyber_poly.c
+++ b/wolfcrypt/src/wc_kyber_poly.c
@@ -34,6 +34,9 @@
 
 #ifdef WOLFSSL_WC_KYBER
 
+/* Declared in wc_kyber.c to stop compiler optimizer from simplifying. */
+extern volatile sword16 kyber_opt_blocker;
+
 #ifdef USE_INTEL_SPEEDUP
 static word32 cpuid_flags = 0;
 #endif
@@ -2773,6 +2776,8 @@ void kyber_decompress_5(sword16* p, const unsigned char* b)
 /* Convert bit from byte to 0 or (KYBER_Q + 1) / 2.
  *
  * Constant time implementation.
+ * XOR in kyber_opt_blocker to ensure optimizer doesn't know what will be ANDed
+ * with KYBER_Q_1_HALF and can't optimize to non-constant time code.
  *
  * @param  [out]  p    Polynomial to hold converted value.
  * @param  [in]   msg  Message to get bit from byte from.
@@ -2780,7 +2785,8 @@ void kyber_decompress_5(sword16* p, const unsigned char* b)
  * @param  [in]   j    Index of bit in byte.
  */
 #define FROM_MSG_BIT(p, msg, i, j) \
-    p[8 * (i) + (j)] = ((sword16)0 - (sword16)(((msg)[i] >> (j)) & 1)) & KYBER_Q_1_HALF
+    (p)[8 * (i) + (j)] = (((sword16)0 - (sword16)(((msg)[i] >> (j)) & 1)) ^ \
+                          kyber_opt_blocker) & KYBER_Q_1_HALF
 
 /* Convert message to polynomial.
  *


### PR DESCRIPTION
# Description

New compilers with specific optimization levels will produce non-constant time code for kyber_from_msg().
Add in an optimization blocker that stops the compiler from assuming anything about the value to be ANDed with KYBER_Q_1_HALF.

Fixes zd#18075

# Testing

./configure '--disable-shared' '--enable-experimental' '--enable-kyber'

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
