### PR TITLE
Fix for TLS1.3 to 1.2 downgrade

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5298,6 +5298,13 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                     return ret;
             }
 #endif /* WOLFSSL_DTLS13 */
+
+#ifndef WOLFSSL_NO_TLS12
+            return DoServerHello(ssl, input, inOutIdx, helloSz);
+#else
+            SendAlert(ssl, alert_fatal, wolfssl_alert_protocol_version);
+            return VERSION_ERROR;
+#endif
         }
     }
 


### PR DESCRIPTION
# Description

Fix for TLS1.3 to 1.2 downgrade

Fixes zd#18074

# Testing

Reproducer in zd ticket

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
