### PR TITLE
20240605-rename-fe_x25519_128

### DIFF
--- a/IDE/ECLIPSE/DEOS/deos_wolfssl/.project
+++ b/IDE/ECLIPSE/DEOS/deos_wolfssl/.project
@@ -240,9 +240,9 @@
 			<locationURI>WOLFSSL_ROOT/wolfcrypt/src/fe_operations.c</locationURI>
 		</link>
 		<link>
-			<name>wolfcrypt/src/fe_x25519_128.i</name>
+			<name>wolfcrypt/src/fe_x25519_128.h</name>
 			<type>1</type>
-			<locationURI>WOLFSSL_ROOT/wolfcrypt/src/fe_x25519_128.i</locationURI>
+			<locationURI>WOLFSSL_ROOT/wolfcrypt/src/fe_x25519_128.h</locationURI>
 		</link>
 		<link>
 			<name>wolfcrypt/src/fp_mont_small.i</name>

--- a/IDE/XilinxSDK/2019_2/wolfCrypt_example/.project
+++ b/IDE/XilinxSDK/2019_2/wolfCrypt_example/.project
@@ -326,9 +326,9 @@
 			<locationURI>PARENT-4-PROJECT_LOC/wolfcrypt/src/fe_operations.c</locationURI>
 		</link>
 		<link>
-			<name>src/wolfcrypt/src/fe_x25519_128.i</name>
+			<name>src/wolfcrypt/src/fe_x25519_128.h</name>
 			<type>1</type>
-			<locationURI>PARENT-4-PROJECT_LOC/wolfcrypt/src/fe_x25519_128.i</locationURI>
+			<locationURI>PARENT-4-PROJECT_LOC/wolfcrypt/src/fe_x25519_128.h</locationURI>
 		</link>
 		<link>
 			<name>src/wolfcrypt/src/fp_mont_small.i</name>

--- a/IDE/XilinxSDK/2022_1/wolfCrypt_FreeRTOS_example/.project
+++ b/IDE/XilinxSDK/2022_1/wolfCrypt_FreeRTOS_example/.project
@@ -1016,9 +1016,9 @@
 			<locationURI>PARENT-3-WORKSPACE_LOC/wolfcrypt/src/fe_operations.c</locationURI>
 		</link>
 		<link>
-			<name>src/wolfcrypt/src/fe_x25519_128.i</name>
+			<name>src/wolfcrypt/src/fe_x25519_128.h</name>
 			<type>1</type>
-			<locationURI>PARENT-3-WORKSPACE_LOC/wolfcrypt/src/fe_x25519_128.i</locationURI>
+			<locationURI>PARENT-3-WORKSPACE_LOC/wolfcrypt/src/fe_x25519_128.h</locationURI>
 		</link>
 		<link>
 			<name>src/wolfcrypt/src/fp_mont_small.i</name>

--- a/IDE/XilinxSDK/2022_1/wolfCrypt_example/.project
+++ b/IDE/XilinxSDK/2022_1/wolfCrypt_example/.project
@@ -1016,9 +1016,9 @@
 			<locationURI>PARENT-3-WORKSPACE_LOC/wolfcrypt/src/fe_operations.c</locationURI>
 		</link>
 		<link>
-			<name>src/wolfcrypt/src/fe_x25519_128.i</name>
+			<name>src/wolfcrypt/src/fe_x25519_128.h</name>
 			<type>1</type>
-			<locationURI>PARENT-3-WORKSPACE_LOC/wolfcrypt/src/fe_x25519_128.i</locationURI>
+			<locationURI>PARENT-3-WORKSPACE_LOC/wolfcrypt/src/fe_x25519_128.h</locationURI>
 		</link>
 		<link>
 			<name>src/wolfcrypt/src/fp_mont_small.i</name>

--- a/wolfcrypt/src/fe_operations.c
+++ b/wolfcrypt/src/fe_operations.c
@@ -45,7 +45,7 @@
 #elif defined(WOLFSSL_ARMASM)
 /* Assembly code in fe_armv[78]_x25519.* */
 #elif defined(CURVED25519_128BIT)
-#include "fe_x25519_128.i"
+#include "fe_x25519_128.h"
 #else
 
 #if defined(HAVE_CURVE25519) || \

--- a/wolfcrypt/src/fe_x25519_128.h
+++ b/wolfcrypt/src/fe_x25519_128.h
@@ -1,6 +1,6 @@
-/* fe_x25519_128.i
+/* fe_x25519_128.h
  *
- * Copyright (C) 2006-2023 wolfSSL Inc.
+ * Copyright (C) 2006-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *
@@ -21,7 +21,7 @@
 
 /* Generated using (from wolfssl):
  *   cd ../scripts
- *   ruby ./x25519/fe_x25519_128_gen.rb > ../wolfssl/wolfcrypt/src/fe_x25519_128.i
+ *   ruby ./x25519/fe_x25519_128_gen.rb > ../wolfssl/wolfcrypt/src/fe_x25519_128.h
  */
 
 void fe_init(void)

--- a/wolfcrypt/src/include.am
+++ b/wolfcrypt/src/include.am
@@ -55,7 +55,7 @@ EXTRA_DIST += \
               wolfcrypt/src/fp_sqr_comba_8.i \
               wolfcrypt/src/fp_sqr_comba_9.i \
               wolfcrypt/src/fp_sqr_comba_small_set.i \
-              wolfcrypt/src/fe_x25519_128.i
+              wolfcrypt/src/fe_x25519_128.h
 
 EXTRA_DIST += wolfcrypt/src/port/ti/ti-aes.c \
               wolfcrypt/src/port/ti/ti-des3.c \


### PR DESCRIPTION
rename `wolfcrypt/src/fe_x25519_128.i` to `wolfcrypt/src/fe_x25519_128.h` to avoid appearance as a cleanable intermediate.

tested with `wolfssl-multi-test.sh ... super-quick-check`

audited with
```
find . -type f -print0 | xargs -0 fgrep -l 'fe_x25519_128.i'
```
