### PR TITLE
20240606-clang-tidy-and-mingw-fixes

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -312,7 +312,7 @@ int wolfSSL_BIO_read(WOLFSSL_BIO* bio, void* buf, int len)
                     ret = (int)XFREAD(buf, 1, (size_t)len, (XFILE)bio->ptr);
                 }
                 else {
-                #if !defined(USE_WINDOWS_API) && !defined(NO_WOLFSSL_DIR) && \
+                #if defined(XREAD) && !defined(NO_WOLFSSL_DIR) && \
                     !defined(WOLFSSL_NUCLEUS) && !defined(WOLFSSL_NUCLEUS_1_2)
                     ret = (int)XREAD(bio->num, buf, (size_t)len);
                 #else
@@ -682,7 +682,7 @@ int wolfSSL_BIO_write(WOLFSSL_BIO* bio, const void* data, int len)
                     ret = (int)XFWRITE(data, 1, (size_t)len, (XFILE)bio->ptr);
                 }
                 else {
-                #if !defined(USE_WINDOWS_API) && !defined(NO_WOLFSSL_DIR) && \
+                #if defined(XWRITE) && !defined(NO_WOLFSSL_DIR) && \
                     !defined(WOLFSSL_NUCLEUS) && !defined(WOLFSSL_NUCLEUS_1_2)
                     ret = (int)XWRITE(bio->num, data, (size_t)len);
                 #else
@@ -1617,7 +1617,12 @@ int wolfSSL_BIO_write_filename(WOLFSSL_BIO *bio, char *name)
             XFCLOSE((XFILE)bio->ptr);
         }
 
-        bio->ptr = XFOPEN(name, "w");
+        /* 'b' flag is ignored on POSIX targets, but on Windows it assures
+         * inhibition of LF<->CRLF rewriting, so that there is consistency
+         * between the size and contents of the representation in memory and on
+         * disk.
+         */
+        bio->ptr = XFOPEN(name, "wb");
         if (((XFILE)bio->ptr) == XBADFILE) {
             return WOLFSSL_FAILURE;
         }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -23701,9 +23701,18 @@ const char* wolfSSL_RAND_file_name(char* fname, unsigned long len)
         const char ap[] = "/.rnd";
 
         WOLFSSL_MSG("Environment variable RANDFILE not set");
+
         if ((rt = XGETENV("HOME")) == NULL) {
+            #ifdef XALTHOMEVARNAME
+            if ((rt = XGETENV(XALTHOMEVARNAME)) == NULL) {
+                WOLFSSL_MSG("Environment variable HOME and " XALTHOMEVARNAME
+                            " not set");
+                return NULL;
+            }
+            #else
             WOLFSSL_MSG("Environment variable HOME not set");
             return NULL;
+            #endif
         }
 
         if (len > XSTRLEN(rt) + XSTRLEN(ap)) {
@@ -23713,7 +23722,7 @@ const char* wolfSSL_RAND_file_name(char* fname, unsigned long len)
             return fname;
         }
         else {
-            WOLFSSL_MSG("HOME too large for buffer");
+            WOLFSSL_MSG("Path too large for buffer");
             return NULL;
         }
     }

--- a/wolfcrypt/src/port/riscv/riscv-64-aes.c
+++ b/wolfcrypt/src/port/riscv/riscv-64-aes.c
@@ -1471,7 +1471,7 @@ static void wc_aes_ctr_encrypt_asm(Aes* aes, byte* out, const byte* in,
  * @param [in]  sz   Number of bytes to encrypt.
  * @return  0 on success.
  * @return  BAD_FUNC_ARG when aes, out or in is NULL.
- * @return  BAD_FUNC_ARG when key size in AES object is not supported. 
+ * @return  BAD_FUNC_ARG when key size in AES object is not supported.
  */
 int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
@@ -4231,7 +4231,7 @@ static WC_INLINE void IncrementAesCounter(byte* inOutCtr)
  * @param [in]  sz   Number of bytes to encrypt.
  * @return  0 on success.
  * @return  BAD_FUNC_ARG when aes, out or in is NULL.
- * @return  BAD_FUNC_ARG when key size in AES object is not supported. 
+ * @return  BAD_FUNC_ARG when key size in AES object is not supported.
  */
 int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {

--- a/wolfcrypt/src/wc_kyber_poly.c
+++ b/wolfcrypt/src/wc_kyber_poly.c
@@ -2785,8 +2785,8 @@ void kyber_decompress_5(sword16* p, const unsigned char* b)
  * @param  [in]   j    Index of bit in byte.
  */
 #define FROM_MSG_BIT(p, msg, i, j) \
-    (p)[8 * (i) + (j)] = (((sword16)0 - (sword16)(((msg)[i] >> (j)) & 1)) ^ \
-                          kyber_opt_blocker) & KYBER_Q_1_HALF
+    ((p)[8 * (i) + (j)] = (((sword16)0 - (sword16)(((msg)[i] >> (j)) & 1)) ^ \
+                          kyber_opt_blocker) & KYBER_Q_1_HALF)
 
 /* Convert message to polynomial.
  *

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -716,12 +716,16 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #if !defined(NO_WOLFSSL_DIR)\
         && !defined(WOLFSSL_NUCLEUS) && !defined(WOLFSSL_NUCLEUS_1_2)
         #if defined(USE_WINDOWS_API)
+            #include <io.h>
             #include <sys/stat.h>
             #ifndef XSTAT
                 #define XSTAT       _stat
             #endif
             #define XS_ISREG(s) (s & _S_IFREG)
             #define SEPARATOR_CHAR ';'
+            #define XWRITE      _write
+            #define XREAD       _read
+            #define XALTHOMEVARNAME "USERPROFILE"
 
         #elif defined(ARDUINO)
             #ifndef XSTAT


### PR DESCRIPTION
fixes for `USE_WINDOWS_API`:
* add `XWRITE` and `XREAD` definitions to `wc_port.h`;
* in `wolfSSL_BIO_read()`, implement Windows support for `XREAD` and `XWRITE`;
* in `wolfSSL_BIO_write_filename()`, add '`b`' flag to `XFOPEN` flags;
* in `wolfSSL_RAND_file_name()`, add support for `XALTHOMEVARNAME`, and add Windows definition for it to `wc_port.h` alongside `XWRITE` and `XREAD`.

fixes `test_wolfSSL_BIO`, `test_wolfSSL_X509_print`, `test_wolfSSL_RAND`, `test_wolfSSL_RSA_print` in `cross-mingw-all-crypto` scenario.

miscellaneous fixes to clear `wolfssl-multi-test.sh ... super-quick-check`:

`wolfcrypt/src/wc_kyber_poly.c`: fix `bugprone-macro-parentheses` for `FROM_MSG_BIT`.

`wolfcrypt/src/port/riscv/riscv-64-aes.c`: fix trailing whitespace.

tested with `wolfssl-multi-test.sh ... super-quick-check`, which includes `cross-mingw-all-crypto`, locally fixed to work right, i.e. to actually test `--enable-all-crypto`.
