### PR TITLE
wc_port.c: NETOS defined section: Fix typo.

### DIFF
--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -3646,7 +3646,7 @@ char* mystrnstr(const char* s1, const char* s2, unsigned int n)
                            "wolfSSL thread",
                            (entry_functionType)cb, (ULONG)arg,
                            thread->threadStack,
-                           TESTSUITE_THREAD_STACK_SZ,
+                           WOLFSSL_NETOS_STACK_SZ,
                            2, 2,
                            1, TX_AUTO_START);
         if (result != TX_SUCCESS) {


### PR DESCRIPTION
This 1 line patch fixes a typo (or copy/paste error) in wc_port.c contained under a NETOS defined section.

TESTSUITE_THREAD_STACK_SZ is currently used in tx_thread_create() call for the size of the stack.

However, WOLFSSL_NETOS_STACK_SZ should be used instead.

The WOLFSSL_NETOS_STACK_SZ is used a few lines above to actually allocate the stack and its size, so the same value should be used to tell tx_thread_create() what the size of the stack is.

# Description

This 1 line patch fixes a typo (or copy/paste error) in wc_port.c contained under the NETOS section.

TESTSUITE_THREAD_STACK_SZ is currently used in tx_thread_create() call for the size of the stack.

However, WOLFSSL_NETOS_STACK_SZ should be used instead.

The WOLFSSL_NETOS_STACK_SZ is used a few lines above to actually allocate the stack and its size, so the same value should be used to tell tx_thread_create() what the size of the stack is.

Fixes zd#

# Testing

Without this change, the compile will fail when TESTSUITE_THREAD_STACK_SZ is not defined.
(It is not required to be defined)

With this change, the compile succeeds, and with the proper values.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
