### PR TITLE
use WOLFSSL_NETOS_STACK_SZ for stack size when creating tx thread

### DIFF
--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -3646,7 +3646,7 @@ char* mystrnstr(const char* s1, const char* s2, unsigned int n)
                            "wolfSSL thread",
                            (entry_functionType)cb, (ULONG)arg,
                            thread->threadStack,
-                           TESTSUITE_THREAD_STACK_SZ,
+                           WOLFSSL_NETOS_STACK_SZ,
                            2, 2,
                            1, TX_AUTO_START);
         if (result != TX_SUCCESS) {


### PR DESCRIPTION
Thanks for the report @skilau https://github.com/wolfSSL/wolfssl/pull/7632