### PR TITLE
20240608-WOLFSSL_DEBUG_TRACE_ERROR_CODES

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -200,6 +200,17 @@ AS_IF([test "$ax_enable_debug" = "yes"],
       [AM_CCASFLAGS="$DEBUG_CFLAGS $AM_CCASFLAGS"],
       [AM_CCASFLAGS="$AM_CCASFLAGS -DNDEBUG"])
 
+AC_ARG_ENABLE([debug-trace-errcodes],
+    [ AS_HELP_STRING([--enable-debug-trace-errcodes],[Print trace messages when library errors are thrown.]) ],
+    [ ENABLED_DEBUG_TRACE_ERRCODES=$enableval ],
+    [ ENABLED_DEBUG_TRACE_ERRCODES=no ]
+    )
+
+if test "$ENABLED_DEBUG_TRACE_ERRCODES" = "yes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DEBUG_TRACE_ERROR_CODES"
+fi
+
 # Start without certificates enabled and enable if a certificate algorithm is
 # enabled
 ENABLED_CERTS="no"
@@ -9787,6 +9798,11 @@ echo "" >> $OPTION_FILE
 echo "" >> $OPTION_FILE
 echo "#endif /* WOLFSSL_OPTIONS_H */" >> $OPTION_FILE
 echo "" >> $OPTION_FILE
+
+if test "$ENABLED_DEBUG_TRACE_ERRCODES" = "yes"
+then
+    support/gen-debug-trace-error-codes.sh || AC_MSG_ERROR([Header generation for debug-trace-errcodes failed.])
+fi
 
 if test "$ENABLED_OPENSSLEXTRA" = "yes" && test "$ENABLED_LINUXKM" = "no"
 then

--- a/src/bio.c
+++ b/src/bio.c
@@ -403,7 +403,7 @@ static int wolfSSL_BIO_BASE64_write(WOLFSSL_BIO* bio, const void* data,
     /* get the encoded length */
     if (bio->flags & WOLFSSL_BIO_FLAG_BASE64_NO_NL) {
         if (Base64_Encode_NoNl((const byte*)data, inLen, NULL,
-                    &sz) != LENGTH_ONLY_E) {
+                    &sz) != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
             WOLFSSL_MSG("Error with base64 get length");
             return WOLFSSL_FATAL_ERROR;
         }

--- a/src/crl.c
+++ b/src/crl.c
@@ -503,7 +503,7 @@ int CheckCertCRL_ex(WOLFSSL_CRL* crl, byte* issuerHash, byte* serial,
     /* Loading <issuer-hash>.rN form CRL file if find at the folder,        */
     /* and try again checking Cert in the CRL list.                         */
     /* When not set the folder or not use hash_dir, do nothing.             */
-    if ((foundEntry == 0) && (ret != OCSP_WANT_READ)) {
+    if ((foundEntry == 0) && (ret != WC_NO_ERR_TRACE(OCSP_WANT_READ))) {
         if (crl->cm != NULL && crl->cm->x509_store_p != NULL) {
             ret = LoadCertByIssuer(crl->cm->x509_store_p,
                           (WOLFSSL_X509_NAME*)issuerName, X509_LU_CRL);
@@ -517,7 +517,7 @@ int CheckCertCRL_ex(WOLFSSL_CRL* crl, byte* issuerHash, byte* serial,
 #endif
     if (foundEntry == 0) {
         WOLFSSL_MSG("Couldn't find CRL for status check");
-        if (ret != CRL_CERT_DATE_ERR) {
+        if (ret != WC_NO_ERR_TRACE(CRL_CERT_DATE_ERR)) {
             ret = CRL_MISSING;
         }
 
@@ -655,13 +655,15 @@ int BufferLoadCRL(WOLFSSL_CRL* crl, const byte* buff, long sz, int type,
     InitDecodedCRL(dcrl, crl->heap);
     ret = ParseCRL(crl->currentEntry->certs, dcrl, myBuffer, (word32)sz,
                    verify, crl->cm);
-    if (ret != 0 && !(ret == ASN_CRL_NO_SIGNER_E && verify == NO_VERIFY)) {
+    if (ret != 0 && !(ret == WC_NO_ERR_TRACE(ASN_CRL_NO_SIGNER_E)
+                      && verify == NO_VERIFY)) {
         WOLFSSL_MSG("ParseCRL error");
         CRL_Entry_free(crl->currentEntry, crl->heap);
         crl->currentEntry = NULL;
     }
     else {
-        ret = AddCRL(crl, dcrl, myBuffer, ret != ASN_CRL_NO_SIGNER_E);
+        ret = AddCRL(crl, dcrl, myBuffer,
+                     ret != WC_NO_ERR_TRACE(ASN_CRL_NO_SIGNER_E));
         if (ret != 0) {
             WOLFSSL_MSG("AddCRL error");
             crl->currentEntry = NULL;

--- a/src/dtls.c
+++ b/src/dtls.c
@@ -107,14 +107,14 @@ int DtlsIgnoreError(int err)
 {
     /* Whitelist of errors not to ignore */
     switch (err) {
-    case MEMORY_E:
-    case MEMORY_ERROR:
-    case ASYNC_INIT_E:
-    case ASYNC_OP_E:
-    case SOCKET_ERROR_E:
-    case WANT_READ:
-    case WANT_WRITE:
-    case COOKIE_ERROR:
+    case WC_NO_ERR_TRACE(MEMORY_E):
+    case WC_NO_ERR_TRACE(MEMORY_ERROR):
+    case WC_NO_ERR_TRACE(ASYNC_INIT_E):
+    case WC_NO_ERR_TRACE(ASYNC_OP_E):
+    case WC_NO_ERR_TRACE(SOCKET_ERROR_E):
+    case WC_NO_ERR_TRACE(WANT_READ):
+    case WC_NO_ERR_TRACE(WANT_WRITE):
+    case WC_NO_ERR_TRACE(COOKIE_ERROR):
         return 0;
     default:
         return 1;
@@ -267,7 +267,7 @@ static int CheckDtlsCookie(const WOLFSSL* ssl, WolfSSL_CH* ch,
             return BUFFER_E;
         ret = TlsCheckCookie(ssl, ch->cookieExt.elements + OPAQUE16_LEN,
                 (word16)(ch->cookieExt.size - OPAQUE16_LEN));
-        if (ret < 0 && ret != HRR_COOKIE_ERROR)
+        if (ret < 0 && ret != WC_NO_ERR_TRACE(HRR_COOKIE_ERROR))
             return ret;
         *cookieGood = ret > 0;
         ret = 0;

--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -396,7 +396,8 @@ int Dtls13ProcessBufferedMessages(WOLFSSL* ssl)
          * WANT_WRITE means that we are done with processing the msg and we are
          * waiting to flush the output buffer. */
         if ((ret == 0 || ret == WANT_WRITE) || (msg->type == certificate_request &&
-                         ssl->options.handShakeDone && ret == WC_PENDING_E)) {
+                         ssl->options.handShakeDone &&
+                         ret == WC_NO_ERR_TRACE(WC_PENDING_E))) {
             if (IsAtLeastTLSv1_3(ssl->version))
                 Dtls13MsgWasProcessed(ssl, (enum HandShakeType)msg->type);
             else if (downgraded)

--- a/src/internal.c
+++ b/src/internal.c
@@ -12549,7 +12549,7 @@ int CheckForAltNames(DecodedCert* dCert, const char* domain, word32 domainLen,
 int CheckHostName(DecodedCert* dCert, const char *domainName, size_t domainNameLen)
 {
     int checkCN;
-    int ret;
+    int ret = WC_NO_ERR_TRACE(DOMAIN_NAME_MISMATCH);
 
     if (CheckForAltNames(dCert, domainName, (word32)domainNameLen,
                                             &checkCN) != 1) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -2167,7 +2167,7 @@ int wolfSSL_session_export_internal(WOLFSSL* ssl, byte* buf, word32* sz,
         }
     }
 
-    if (ret != 0 && ret != LENGTH_ONLY_E && buf != NULL) {
+    if (ret != 0 && ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E) && buf != NULL) {
         /*in a fail case clear the buffer which could contain partial key info*/
         XMEMSET(buf, 0, *sz);
     }
@@ -2810,7 +2810,7 @@ void FreeSSL_Ctx(WOLFSSL_CTX* ctx)
     if (ret < 0) {
         /* check error state, if mutex error code then mutex init failed but
          * CTX was still malloc'd */
-        if (ctx->err == CTX_INIT_MUTEX_E) {
+        if (ctx->err == WC_NO_ERR_TRACE(CTX_INIT_MUTEX_E)) {
             SSL_CtxResourceFree(ctx);
             XFREE(ctx, heap, DYNAMIC_TYPE_CTX);
         #ifdef WOLFSSL_STATIC_MEMORY
@@ -4920,7 +4920,7 @@ int RsaSign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (key && ret == WC_PENDING_E) {
+    if (key && ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -4940,7 +4940,7 @@ int RsaSign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
 int RsaVerify(WOLFSSL* ssl, byte* in, word32 inSz, byte** out, int sigAlgo,
               int hashAlgo, RsaKey* key, buffer* keyBufInfo)
 {
-    int ret = SIG_VERIFY_E;
+    int ret = WC_NO_ERR_TRACE(SIG_VERIFY_E);
 
 #ifdef HAVE_PK_CALLBACKS
     const byte* keyBuf = NULL;
@@ -4996,7 +4996,7 @@ int RsaVerify(WOLFSSL* ssl, byte* in, word32 inSz, byte** out, int sigAlgo,
         !defined(WOLFSSL_RENESAS_TSIP_TLS)
     else
     #else
-    if (!ssl->ctx->RsaVerifyCb || ret == CRYPTOCB_UNAVAILABLE)
+    if (!ssl->ctx->RsaVerifyCb || ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
     #endif
 #endif /*HAVE_PK_CALLBACKS */
     {
@@ -5005,7 +5005,7 @@ int RsaVerify(WOLFSSL* ssl, byte* in, word32 inSz, byte** out, int sigAlgo,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -5143,7 +5143,7 @@ int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig, word32 sigSz,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (key && ret == WC_PENDING_E) {
+    if (key && ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -5203,7 +5203,7 @@ int RsaDec(WOLFSSL* ssl, byte* in, word32 inSz, byte** out, word32* outSz,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -5223,7 +5223,7 @@ int RsaDec(WOLFSSL* ssl, byte* in, word32 inSz, byte** out, word32* outSz,
 int RsaEnc(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out, word32* outSz,
     RsaKey* key, buffer* keyBufInfo)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 #ifdef HAVE_PK_CALLBACKS
     const byte* keyBuf = NULL;
     word32 keySz = 0;
@@ -5255,7 +5255,7 @@ int RsaEnc(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out, word32* outSz,
         !defined(WOLFSSL_RENESAS_TSIP_TLS)
     else
     #else
-    if (!ssl->ctx->RsaEncCb || ret == CRYPTOCB_UNAVAILABLE)
+    if (!ssl->ctx->RsaEncCb || ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
     #endif
 #endif /* HAVE_PK_CALLBACKS */
     {
@@ -5264,7 +5264,7 @@ int RsaEnc(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out, word32* outSz,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -5324,7 +5324,7 @@ int EccSign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
         ret = ssl->ctx->EccSignCb(ssl, in, inSz, out, outSz, keyBuf,
             keySz, ctx);
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
-        if (ret == CRYPTOCB_UNAVAILABLE) {
+        if (ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
             ret = wc_ecc_sign_hash(in, inSz, out, outSz, ssl->rng, key);
         }
 #endif /* WOLFSSL_RENESAS_TSIP_TLS */
@@ -5337,7 +5337,7 @@ int EccSign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (key && ret == WC_PENDING_E) {
+    if (key && ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -5350,7 +5350,7 @@ int EccSign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
 int EccVerify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* out,
     word32 outSz, ecc_key* key, buffer* keyBufInfo)
 {
-    int ret = SIG_VERIFY_E;
+    int ret = WC_NO_ERR_TRACE(SIG_VERIFY_E);
 #ifdef HAVE_PK_CALLBACKS
     const byte* keyBuf = NULL;
     word32 keySz = 0;
@@ -5384,7 +5384,7 @@ int EccVerify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* out,
         !defined(WOLFSSL_MAXQ108X)
     else
     #else
-    if (!ssl->ctx->EccVerifyCb || ret == CRYPTOCB_UNAVAILABLE)
+    if (!ssl->ctx->EccVerifyCb || ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
     #endif
 #endif /* HAVE_PK_CALLBACKS  */
     {
@@ -5393,7 +5393,7 @@ int EccVerify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* out,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
     else
@@ -5466,7 +5466,7 @@ int EccSharedSecret(WOLFSSL* ssl, ecc_key* priv_key, ecc_key* pub_key,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -5543,7 +5543,7 @@ int EccMakeKey(WOLFSSL* ssl, ecc_key* key, ecc_key* peer)
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -5583,7 +5583,7 @@ int Sm2wSm3Verify(WOLFSSL* ssl, const byte* id, word32 idSz, const byte* sig,
     word32 sigSz, const byte* msg, word32 msgSz, ecc_key* key,
     buffer* keyBufInfo)
 {
-    int ret = SIG_VERIFY_E;
+    int ret = WC_NO_ERR_TRACE(SIG_VERIFY_E);
     byte hash[WC_SM3_DIGEST_SIZE];
 
     (void)ssl;
@@ -5706,7 +5706,7 @@ int Ed25519Sign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -5780,7 +5780,7 @@ int Ed25519Verify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* msg,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
     else
@@ -5806,7 +5806,6 @@ int Ed25519Verify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* msg,
      */
     static int X25519GetKey(WOLFSSL* ssl, curve25519_key** otherKey)
     {
-        int ret = NO_PEER_KEY;
         struct curve25519_key* tmpKey = NULL;
 
         if (ssl == NULL || otherKey == NULL) {
@@ -5829,10 +5828,11 @@ int Ed25519Verify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* msg,
 
         if (tmpKey) {
             *otherKey = (curve25519_key *)tmpKey;
-            ret = 0;
+            return 0;
         }
-
-        return ret;
+        else {
+            return NO_PEER_KEY;
+        }
     }
 #endif /* HAVE_PK_CALLBACKS */
 
@@ -5876,7 +5876,7 @@ static int X25519SharedSecret(WOLFSSL* ssl, curve25519_key* priv_key,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &priv_key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -5922,7 +5922,7 @@ static int X25519MakeKey(WOLFSSL* ssl, curve25519_key* key,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -6030,7 +6030,7 @@ int Ed448Sign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -6104,7 +6104,7 @@ int Ed448Verify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* msg,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
     else
@@ -6130,7 +6130,6 @@ int Ed448Verify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* msg,
      */
     static int X448GetKey(WOLFSSL* ssl, curve448_key** otherKey)
     {
-        int ret = NO_PEER_KEY;
         struct curve448_key* tmpKey = NULL;
 
         if (ssl == NULL || otherKey == NULL) {
@@ -6152,10 +6151,11 @@ int Ed448Verify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* msg,
 
         if (tmpKey) {
             *otherKey = (curve448_key *)tmpKey;
-            ret = 0;
+            return 0;
         }
-
-        return ret;
+        else {
+            return NO_PEER_KEY;
+        }
     }
 #endif /* HAVE_PK_CALLBACKS */
 
@@ -6200,7 +6200,7 @@ static int X448SharedSecret(WOLFSSL* ssl, curve448_key* priv_key,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &priv_key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -6245,7 +6245,7 @@ static int X448MakeKey(WOLFSSL* ssl, curve448_key* key, curve448_key* peer)
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -6282,7 +6282,7 @@ int DhGenKeyPair(WOLFSSL* ssl, DhKey* dhKey,
         ret = ssl->ctx->DhGenerateKeyPairCb(dhKey, ssl->rng, priv, privSz,
                                             pub, pubSz);
     }
-    if (ret == NOT_COMPILED_IN)
+    if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN))
 #endif
     {
         PRIVATE_KEY_UNLOCK();
@@ -6292,7 +6292,7 @@ int DhGenKeyPair(WOLFSSL* ssl, DhKey* dhKey,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &dhKey->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -6362,7 +6362,7 @@ int DhAgree(WOLFSSL* ssl, DhKey* dhKey,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &dhKey->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -7783,7 +7783,7 @@ void FreeKey(WOLFSSL* ssl, int type, void** pKey)
 
 int AllocKey(WOLFSSL* ssl, int type, void** pKey)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
     int sz = 0;
 #ifdef HAVE_ECC
     ecc_key* eccKey;
@@ -7802,7 +7802,7 @@ int AllocKey(WOLFSSL* ssl, int type, void** pKey)
         WOLFSSL_MSG("Key already present!");
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* allow calling this again for async reentry */
-        if (ssl->error == WC_PENDING_E) {
+        if (ssl->error == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             return 0;
         }
     #endif
@@ -9998,7 +9998,7 @@ int HashRaw(WOLFSSL* ssl, const byte* data, int sz)
 
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     ret = tsip_StoreMessage(ssl, data, sz);
-    if (ret != 0 && ret != CRYPTOCB_UNAVAILABLE) {
+    if (ret != 0 && ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
         return ret;
     }
 #endif /* WOLFSSL_RENESAS_TSIP_TLS */
@@ -11296,7 +11296,9 @@ static int GetDtlsRecordHeader(WOLFSSL* ssl, word32* inOutIdx,
         /* version 1.3 already negotiated */
         if (ssl->options.tls1_3) {
             ret = GetDtls13RecordHeader(ssl, inOutIdx, rh, size);
-            if (ret == 0 || ret != SEQUENCE_ERROR || ret != DTLS_CID_ERROR)
+            if (ret == 0 ||
+                ret != WC_NO_ERR_TRACE(SEQUENCE_ERROR) ||
+                ret != WC_NO_ERR_TRACE(DTLS_CID_ERROR))
                 return ret;
         }
 
@@ -11318,7 +11320,7 @@ static int GetDtlsRecordHeader(WOLFSSL* ssl, word32* inOutIdx,
     if (ssl->buffers.inputBuffer.length - *inOutIdx < DTLS_RECORD_HEADER_SZ) {
         ret = GetInputData(ssl, DTLS_RECORD_HEADER_SZ);
         /* Check if Dtls13RtxTimeout(ssl) returned socket error */
-        if (ret == SOCKET_ERROR_E)
+        if (ret == WC_NO_ERR_TRACE(SOCKET_ERROR_E))
             return ret;
         if (ret != 0)
             return LENGTH_ERROR;
@@ -12547,10 +12549,11 @@ int CheckForAltNames(DecodedCert* dCert, const char* domain, word32 domainLen,
 int CheckHostName(DecodedCert* dCert, const char *domainName, size_t domainNameLen)
 {
     int checkCN;
-    int ret = DOMAIN_NAME_MISMATCH;
+    int ret;
 
     if (CheckForAltNames(dCert, domainName, (word32)domainNameLen,
                                             &checkCN) != 1) {
+        ret = DOMAIN_NAME_MISMATCH;
         WOLFSSL_MSG("DomainName match on alt names failed");
     }
     else {
@@ -12564,6 +12567,7 @@ int CheckHostName(DecodedCert* dCert, const char *domainName, size_t domainNameL
             ret = 0;
         }
         else {
+            ret = DOMAIN_NAME_MISMATCH;
             WOLFSSL_MSG("DomainName match on common name failed");
         }
     }
@@ -13278,7 +13282,7 @@ static int ProcessCSR(WOLFSSL* ssl, byte* input, word32* inOutIdx,
        const unsigned char* keyDer, unsigned int keySz,
        int* result, void* ctx)
     {
-        int ret = NOT_COMPILED_IN;
+        int ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
         WOLFSSL* ssl = (WOLFSSL*)ctx;
 
         if (ssl && ssl->ctx->EccVerifyCb) {
@@ -13293,7 +13297,7 @@ static int ProcessCSR(WOLFSSL* ssl, byte* input, word32* inOutIdx,
        unsigned char** out, const unsigned char* keyDer, unsigned int keySz,
        void* ctx)
     {
-        int ret = NOT_COMPILED_IN;
+        int ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
         WOLFSSL* ssl = (WOLFSSL*)ctx;
 
         if (ssl && ssl->ctx->RsaVerifyCb) {
@@ -13355,24 +13359,26 @@ void DoCertFatalAlert(WOLFSSL* ssl, int ret)
 
     /* Determine alert reason */
     alertWhy = bad_certificate;
-    if (ret == ASN_AFTER_DATE_E || ret == ASN_BEFORE_DATE_E) {
+    if (ret == WC_NO_ERR_TRACE(ASN_AFTER_DATE_E) ||
+        ret == WC_NO_ERR_TRACE(ASN_BEFORE_DATE_E)) {
         alertWhy = certificate_expired;
     }
-    else if (ret == ASN_NO_SIGNER_E || ret == ASN_PATHLEN_INV_E ||
-            ret == ASN_PATHLEN_SIZE_E) {
+    else if (ret == WC_NO_ERR_TRACE(ASN_NO_SIGNER_E) ||
+             ret == WC_NO_ERR_TRACE(ASN_PATHLEN_INV_E) ||
+             ret == WC_NO_ERR_TRACE(ASN_PATHLEN_SIZE_E)) {
         alertWhy = unknown_ca;
     }
 #ifdef OPENSSL_EXTRA
-    else if (ret == CRL_CERT_REVOKED) {
+    else if (ret == WC_NO_ERR_TRACE(CRL_CERT_REVOKED)) {
         alertWhy = certificate_revoked;
     }
 #endif
 #if defined(HAVE_RPK)
-    else if (ret == UNSUPPORTED_CERTIFICATE) {
+    else if (ret == WC_NO_ERR_TRACE(UNSUPPORTED_CERTIFICATE)) {
         alertWhy = unsupported_certificate;
     }
 #endif /* HAVE_RPK */
-    else if (ret == NO_PEER_CERT) {
+    else if (ret == WC_NO_ERR_TRACE(NO_PEER_CERT)) {
 #ifdef WOLFSSL_TLS13
         if (ssl->options.tls1_3) {
             alertWhy = certificate_required;
@@ -14052,7 +14058,7 @@ PRAGMA_GCC_DIAG_POP
     /* check if returning from non-blocking OCSP */
     /* skip this section because cert is already initialized and parsed */
 #ifdef WOLFSSL_NONBLOCK_OCSP
-    if (args->lastErr == OCSP_WANT_READ) {
+    if (args->lastErr == WC_NO_ERR_TRACE(OCSP_WANT_READ)) {
         args->lastErr = 0; /* clear error */
         return 0;
     }
@@ -14158,7 +14164,9 @@ PRAGMA_GCC_DIAG_POP
 #endif /* HAVE_RPK */
 
     /* perform below checks for date failure cases */
-    if (ret == 0 || ret == ASN_BEFORE_DATE_E || ret == ASN_AFTER_DATE_E) {
+    if (ret == 0 ||
+        ret == WC_NO_ERR_TRACE(ASN_BEFORE_DATE_E) ||
+        ret == WC_NO_ERR_TRACE(ASN_AFTER_DATE_E)) {
         /* get subject and determine if already loaded */
     #ifndef NO_SKID
         if (args->dCert->extAuthKeyIdSet)
@@ -14181,7 +14189,7 @@ PRAGMA_GCC_DIAG_POP
         *pAlreadySigner = alreadySigner;
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl,
             args->dCert->sigCtx.asyncDev);
     }
@@ -14193,7 +14201,7 @@ PRAGMA_GCC_DIAG_POP
      * original return code is returned. */
     if (ssl->ctx && ssl->ctx->ProcessPeerCertCb) {
         int new_ret = ssl->ctx->ProcessPeerCertCb(ssl, args->dCert);
-        if (new_ret != NOT_COMPILED_IN) {
+        if (new_ret != WC_NO_ERR_TRACE(NOT_COMPILED_IN)) {
             ret = new_ret;
         }
     }
@@ -14371,7 +14379,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     args = (ProcPeerCertArgs*)ssl->async->args;
 #ifdef WOLFSSL_ASYNC_CRYPT
     ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* Check for error */
         if (ret < 0)
             goto exit_ppc;
@@ -14379,11 +14387,11 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     else
 #endif /* WOLFSSL_ASYNC_CRYPT */
 #ifdef WOLFSSL_NONBLOCK_OCSP
-    if (ssl->error == OCSP_WANT_READ) {
+    if (ssl->error == WC_NO_ERR_TRACE(OCSP_WANT_READ)) {
         /* Re-entry after non-blocking OCSP */
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* if async operationg not pending, reset error code */
-        if (ret == WC_NO_PENDING_E)
+        if (ret == WC_NO_ERR_TRACE(WC_NO_PENDING_E))
             ret = 0;
     #endif
     }
@@ -14719,7 +14727,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     (defined(WOLFSSL_CERT_REQ) || defined(WOLFSSL_CERT_EXT)) && \
     !defined(NO_FILESYSTEM) && !defined(NO_WOLFSSL_DIR) && \
     !defined(NO_STDIO_FILESYSTEM)
-                    if (ret == ASN_NO_SIGNER_E || ret == ASN_SELF_SIGNED_E) {
+                    if (ret == WC_NO_ERR_TRACE(ASN_NO_SIGNER_E) ||
+                        ret == WC_NO_ERR_TRACE(ASN_SELF_SIGNED_E)) {
                         WOLFSSL_MSG("try to load certificate if hash dir is set");
                         ret = LoadCertByIssuer(SSL_STORE(ssl),
                            (WOLFSSL_X509_NAME*)args->dCert->issuerName,
@@ -14739,14 +14748,15 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     }
 #endif
                 #ifdef WOLFSSL_ASYNC_CRYPT
-                    if (ret == WC_PENDING_E)
+                    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
                         goto exit_ppc;
                 #endif
                     if (ret == 0) {
                         ret = ProcessPeerCertCheckKey(ssl, args);
                     }
-                    else if (ret == ASN_PARSE_E || ret == BUFFER_E ||
-                             ret == MEMORY_E) {
+                    else if (ret == WC_NO_ERR_TRACE(ASN_PARSE_E) ||
+                             ret == WC_NO_ERR_TRACE(BUFFER_E) ||
+                             ret == WC_NO_ERR_TRACE(MEMORY_E)) {
                         WOLFSSL_MSG(
                             "Got Peer cert ASN PARSE_E, BUFFER E, MEMORY_E");
                         ERROR_OUT(ret, exit_ppc);
@@ -14793,7 +14803,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             ret = CheckCertOCSP_ex(SSL_CM(ssl)->ocsp,
                                                     args->dCert, ssl);
                         #ifdef WOLFSSL_NONBLOCK_OCSP
-                            if (ret == OCSP_WANT_READ) {
+                            if (ret == WC_NO_ERR_TRACE(OCSP_WANT_READ)) {
                                 args->lastErr = ret;
                                 goto exit_ppc;
                             }
@@ -14817,7 +14827,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                    responder, do a CRL lookup. If any other
                                    error, skip the CRL lookup and fail the
                                    certificate. */
-                                doCrlLookup = (ret == OCSP_CERT_UNKNOWN);
+                                doCrlLookup = (ret == WC_NO_ERR_TRACE(OCSP_CERT_UNKNOWN));
                             }
                         #endif /* HAVE_OCSP */
 
@@ -14830,7 +14840,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                  * same WOULD_BLOCK error code as OCSP's I/O
                                  * callback, and it is enabling it using the
                                  * same flag. */
-                                if (ret == OCSP_WANT_READ) {
+                                if (ret == WC_NO_ERR_TRACE(OCSP_WANT_READ)) {
                                     args->lastErr = ret;
                                     goto exit_ppc;
                                 }
@@ -14873,7 +14883,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         chain mode only requires that the peer certificate
                         validate to a trusted CA */
                     if (ret != 0 && args->dCert->isCA) {
-                        if (ret == ASN_NO_SIGNER_E || ret == ASN_SELF_SIGNED_E) {
+                        if (ret == WC_NO_ERR_TRACE(ASN_NO_SIGNER_E) ||
+                            ret == WC_NO_ERR_TRACE(ASN_SELF_SIGNED_E)) {
                             if (!ssl->options.usingAltCertChain) {
                                 WOLFSSL_MSG("Trying alternate cert chain");
                                 ssl->options.usingAltCertChain = 1;
@@ -14896,7 +14907,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                      * for a CA cert to fail validation here, as we will verify
                      * the entire chain when we hit the peer (leaf) cert */
                     if ((ssl->ctx->doAppleNativeCertValidationFlag)
-                        && (ret == ASN_NO_SIGNER_E)) {
+                        && (ret == WC_NO_ERR_TRACE(ASN_NO_SIGNER_E))) {
 
                         WOLFSSL_MSG("Bypassing errors to allow for Apple native"
                                     " CA validation");
@@ -14914,8 +14925,9 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     /* Do verify callback */
                     ret = DoVerifyCallback(SSL_CM(ssl), ssl, ret, args);
                     if (ssl->options.verifyNone &&
-                              (ret == CRL_MISSING || ret == CRL_CERT_REVOKED ||
-                               ret == CRL_CERT_DATE_ERR)) {
+                              (ret == WC_NO_ERR_TRACE(CRL_MISSING) ||
+                               ret == WC_NO_ERR_TRACE(CRL_CERT_REVOKED) ||
+                               ret == WC_NO_ERR_TRACE(CRL_CERT_DATE_ERR))) {
                         WOLFSSL_MSG("Ignoring CRL problem based on verify setting");
                         ret = ssl->error = 0;
                     }
@@ -15008,7 +15020,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     (defined(WOLFSSL_CERT_REQ) || defined(WOLFSSL_CERT_EXT)) && \
     !defined(NO_FILESYSTEM) && !defined(NO_WOLFSSL_DIR) && \
     !defined(NO_STDIO_FILESYSTEM)
-                    if (ret == ASN_NO_SIGNER_E || ret == ASN_SELF_SIGNED_E) {
+                    if (ret == WC_NO_ERR_TRACE(ASN_NO_SIGNER_E) ||
+                        ret == WC_NO_ERR_TRACE(ASN_SELF_SIGNED_E)) {
                         int lastErr = ret; /* save error from last time */
                         WOLFSSL_MSG("try to load certificate if hash dir is set");
                         ret = LoadCertByIssuer(SSL_STORE(ssl),
@@ -15029,7 +15042,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     }
 #endif
             #ifdef WOLFSSL_ASYNC_CRYPT
-                if (ret == WC_PENDING_E)
+                if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
                     goto exit_ppc;
             #endif
                 if (ret == 0) {
@@ -15086,8 +15099,10 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         args->fatal = 0;
                     }
                 }
-                else if (ret == ASN_PARSE_E || ret == BUFFER_E ||
-                         ret == MEMORY_E || ret == BAD_FUNC_ARG) {
+                else if (ret == WC_NO_ERR_TRACE(ASN_PARSE_E) ||
+                         ret == WC_NO_ERR_TRACE(BUFFER_E) ||
+                         ret == WC_NO_ERR_TRACE(MEMORY_E) ||
+                         ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
                     WOLFSSL_MSG("Got Peer cert ASN_PARSE_E, BUFFER_E, MEMORY_E,"
                                 " BAD_FUNC_ARG");
                 #if defined(WOLFSSL_EXTRA_ALERTS) || defined(OPENSSL_EXTRA) || \
@@ -15105,11 +15120,11 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 
                     #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
                     if (ssl->peerVerifyRet == 0) { /* Return first cert error here */
-                        if (ret == ASN_BEFORE_DATE_E) {
+                        if (ret == WC_NO_ERR_TRACE(ASN_BEFORE_DATE_E)) {
                             ssl->peerVerifyRet =
                            (unsigned long)WOLFSSL_X509_V_ERR_CERT_NOT_YET_VALID;
                         }
-                        else if (ret == ASN_AFTER_DATE_E) {
+                        else if (ret == WC_NO_ERR_TRACE(ASN_AFTER_DATE_E)) {
                             ssl->peerVerifyRet =
                             (unsigned long)WOLFSSL_X509_V_ERR_CERT_HAS_EXPIRED;
                         }
@@ -15247,11 +15262,11 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         ret = CheckCertOCSP_ex(SSL_CM(ssl)->ocsp,
                                                     args->dCert, ssl);
                     #ifdef WOLFSSL_NONBLOCK_OCSP
-                        if (ret == OCSP_WANT_READ) {
+                        if (ret == WC_NO_ERR_TRACE(OCSP_WANT_READ)) {
                             goto exit_ppc;
                         }
                     #endif
-                        doLookup = (ret == OCSP_CERT_UNKNOWN);
+                        doLookup = (ret == WC_NO_ERR_TRACE(OCSP_CERT_UNKNOWN));
                         if (ret != 0) {
                             WOLFSSL_MSG("\tOCSP Lookup not ok");
                             args->fatal = 0;
@@ -15277,7 +15292,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                          * same WOULD_BLOCK error code as OCSP's I/O
                          * callback, and it is enabling it using the
                          * same flag. */
-                        if (ret == OCSP_WANT_READ) {
+                        if (ret == WC_NO_ERR_TRACE(OCSP_WANT_READ)) {
                             goto exit_ppc;
                         }
                     #endif
@@ -15325,7 +15340,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     FreeX509(&ssl->peerCert);
                     InitX509(&ssl->peerCert, 0, ssl->heap);
                     copyRet = CopyDecodedToX509(&ssl->peerCert, args->dCert);
-                    if (copyRet == MEMORY_E) {
+                    if (copyRet == WC_NO_ERR_TRACE(MEMORY_E)) {
                         args->fatal = 1;
                     }
                 }
@@ -15917,8 +15932,9 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             ret = DoVerifyCallback(SSL_CM(ssl), ssl, ret, args);
 
             if (ssl->options.verifyNone &&
-                              (ret == CRL_MISSING || ret == CRL_CERT_REVOKED ||
-                               ret == CRL_CERT_DATE_ERR)) {
+                              (ret == WC_NO_ERR_TRACE(CRL_MISSING) ||
+                               ret == WC_NO_ERR_TRACE(CRL_CERT_REVOKED) ||
+                               ret == WC_NO_ERR_TRACE(CRL_CERT_DATE_ERR))) {
                 WOLFSSL_MSG("Ignoring CRL problem based on verify setting");
                 ret = ssl->error = 0;
             }
@@ -15965,7 +15981,8 @@ exit_ppc:
 
 
 #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
-    if (ret == WC_PENDING_E || ret == OCSP_WANT_READ) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E) ||
+        ret == WC_NO_ERR_TRACE(OCSP_WANT_READ)) {
         /* Mark message as not received so it can process again */
         ssl->msgsReceived.got_certificate = 0;
 
@@ -16011,7 +16028,8 @@ static int DoCertificate(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     /* Reset the session cert chain count in case the session resume failed,
      * do not reset if we are resuming after an async wait */
 #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
-    if (ssl->error != OCSP_WANT_READ && ssl->error != WC_PENDING_E)
+    if (ssl->error != WC_NO_ERR_TRACE(OCSP_WANT_READ) &&
+        ssl->error != WC_NO_ERR_TRACE(WC_PENDING_E))
 #endif
     {
         ssl->session->chain.count = 0;
@@ -17057,7 +17075,8 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                                IsAtLeastTLSv1_3(ssl->version)) {
 
         #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
-            if (ret != WC_PENDING_E && ret != OCSP_WANT_READ)
+            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E) &&
+                ret != WC_NO_ERR_TRACE(OCSP_WANT_READ))
         #endif
             {
                 ssl->options.cacheMessages = 0;
@@ -17139,7 +17158,8 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         if (ssl->options.resuming || !ssl->options.verifyPeer || \
                      !IsAtLeastTLSv1_2(ssl) || IsAtLeastTLSv1_3(ssl->version)) {
         #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
-            if (ret != WC_PENDING_E && ret != OCSP_WANT_READ)
+            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E) &&
+                ret != WC_NO_ERR_TRACE(OCSP_WANT_READ))
         #endif
             {
                 ssl->options.cacheMessages = 0;
@@ -17205,7 +17225,8 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 
 #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
     /* if async, offset index so this msg will be processed again */
-    if ((ret == WC_PENDING_E || ret == OCSP_WANT_READ) && *inOutIdx > 0) {
+    if ((ret == WC_NO_ERR_TRACE(WC_PENDING_E) ||
+         ret == WC_NO_ERR_TRACE(OCSP_WANT_READ)) && *inOutIdx > 0) {
         *inOutIdx -= HANDSHAKE_HEADER_SZ;
     #ifdef WOLFSSL_DTLS
         if (ssl->options.dtls) {
@@ -17215,7 +17236,8 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     }
 
     /* make sure async error is cleared */
-    if (ret == 0 && (ssl->error == WC_PENDING_E || ssl->error == OCSP_WANT_READ)) {
+    if (ret == 0 && (ssl->error == WC_NO_ERR_TRACE(WC_PENDING_E) ||
+                     ssl->error == WC_NO_ERR_TRACE(OCSP_WANT_READ))) {
         ssl->error = 0;
     }
 #endif /* WOLFSSL_ASYNC_CRYPT || WOLFSSL_NONBLOCK_OCSP */
@@ -17338,7 +17360,7 @@ static int DoHandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         }
 
     #ifdef WOLFSSL_ASYNC_CRYPT
-        if (ssl->error != WC_PENDING_E)
+        if (ssl->error != WC_NO_ERR_TRACE(WC_PENDING_E))
     #endif
         {
             /* for async this copy was already done, do not replace, since
@@ -17358,7 +17380,7 @@ static int DoHandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                      ssl->arrays->pendingMsgSz - idx,
                                      ssl->arrays->pendingMsgSz);
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 /* setup to process fragment again */
                 ssl->arrays->pendingMsgOffset -= inputLength;
                 *inOutIdx -= inputLength;
@@ -17390,41 +17412,41 @@ int SendFatalAlertOnly(WOLFSSL *ssl, int error)
 
     switch (error) {
         /* not fatal errors */
-    case WANT_WRITE:
-    case WANT_READ:
-    case ZERO_RETURN:
+    case WC_NO_ERR_TRACE(WANT_WRITE):
+    case WC_NO_ERR_TRACE(WANT_READ):
+    case WC_NO_ERR_TRACE(ZERO_RETURN):
 #ifdef WOLFSSL_NONBLOCK_OCSP
-    case OCSP_WANT_READ:
+    case WC_NO_ERR_TRACE(OCSP_WANT_READ):
 #endif
 #ifdef WOLFSSL_ASYNC_CRYPT
-    case WC_PENDING_E:
+    case WC_NO_ERR_TRACE(WC_PENDING_E):
 #endif
         return 0;
 
     /* peer already disconnected and ssl is possibly in bad state
      * don't try to send an alert */
-    case SOCKET_ERROR_E:
+    case WC_NO_ERR_TRACE(SOCKET_ERROR_E):
         return error;
 
-    case BUFFER_ERROR:
-    case ASN_PARSE_E:
-    case COMPRESSION_ERROR:
+    case WC_NO_ERR_TRACE(BUFFER_ERROR):
+    case WC_NO_ERR_TRACE(ASN_PARSE_E):
+    case WC_NO_ERR_TRACE(COMPRESSION_ERROR):
         why = decode_error;
         break;
-    case VERIFY_FINISHED_ERROR:
-    case SIG_VERIFY_E:
+    case WC_NO_ERR_TRACE(VERIFY_FINISHED_ERROR):
+    case WC_NO_ERR_TRACE(SIG_VERIFY_E):
         why = decrypt_error;
         break;
-    case DUPLICATE_MSG_E:
-    case NO_CHANGE_CIPHER_E:
-    case OUT_OF_ORDER_E:
+    case WC_NO_ERR_TRACE(DUPLICATE_MSG_E):
+    case WC_NO_ERR_TRACE(NO_CHANGE_CIPHER_E):
+    case WC_NO_ERR_TRACE(OUT_OF_ORDER_E):
         why = unexpected_message;
         break;
-    case ECC_OUT_OF_RANGE_E:
+    case WC_NO_ERR_TRACE(ECC_OUT_OF_RANGE_E):
         why = bad_record_mac;
         break;
-    case MATCH_SUITE_ERROR:
-    case VERSION_ERROR:
+    case WC_NO_ERR_TRACE(MATCH_SUITE_ERROR):
+    case WC_NO_ERR_TRACE(VERSION_ERROR):
     default:
         why = handshake_failure;
         break;
@@ -17908,12 +17930,12 @@ int DtlsMsgDrain(WOLFSSL* ssl)
             DtlsTxMsgListClean(ssl);
         }
         else if (!IsAtLeastTLSv1_3(ssl->version)) {
-            if (SendFatalAlertOnly(ssl, ret) == SOCKET_ERROR_E) {
+            if (SendFatalAlertOnly(ssl, ret) == WC_NO_ERR_TRACE(SOCKET_ERROR_E)) {
                 ret = SOCKET_ERROR_E;
             }
         }
     #ifdef WOLFSSL_ASYNC_CRYPT
-        if (ret == WC_PENDING_E) {
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             break;
         }
     #endif
@@ -18770,7 +18792,7 @@ static WC_INLINE int EncryptDo(WOLFSSL* ssl, byte* out, const byte* input,
 
             ret = wc_Des3_CbcEncrypt(ssl->encrypt.des3, out, input, sz);
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E && asyncOkay) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E) && asyncOkay) {
                 ret = wolfSSL_AsyncPush(ssl, asyncDev);
             }
         #endif
@@ -18788,7 +18810,7 @@ static WC_INLINE int EncryptDo(WOLFSSL* ssl, byte* out, const byte* input,
         #endif
             ret = wc_AesCbcEncrypt(ssl->encrypt.aes, out, input, sz);
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E && asyncOkay) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E) && asyncOkay) {
                 ret = wolfSSL_AsyncPush(ssl, asyncDev);
             }
         #endif
@@ -18859,7 +18881,7 @@ static WC_INLINE int EncryptDo(WOLFSSL* ssl, byte* out, const byte* input,
                          ssl->encrypt.additional, AEAD_AUTH_DATA_SZ);
             }
 
-            if (ret == NOT_COMPILED_IN)
+            if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN))
         #endif /* HAVE_PK_CALLBACKS */
             {
                 ret = aes_auth_fn(ssl->encrypt.aes,
@@ -18872,7 +18894,7 @@ static WC_INLINE int EncryptDo(WOLFSSL* ssl, byte* out, const byte* input,
             }
 
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E && asyncOkay) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E) && asyncOkay) {
                 ret = wolfSSL_AsyncPush(ssl, asyncDev);
             }
         #endif
@@ -18962,7 +18984,7 @@ static WC_INLINE int EncryptDo(WOLFSSL* ssl, byte* out, const byte* input,
         #endif
             ret = wc_Sm4CbcEncrypt(ssl->encrypt.sm4, out, input, sz);
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E && asyncOkay) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E) && asyncOkay) {
                 ret = wolfSSL_AsyncPush(ssl, asyncDev);
             }
         #endif
@@ -19026,7 +19048,7 @@ static WC_INLINE int EncryptDo(WOLFSSL* ssl, byte* out, const byte* input,
                     ssl->encrypt.additional, AEAD_AUTH_DATA_SZ);
 
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E && asyncOkay) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E) && asyncOkay) {
                 ret = wolfSSL_AsyncPush(ssl, asyncDev);
             }
         #endif
@@ -19056,7 +19078,7 @@ static WC_INLINE int EncryptDo(WOLFSSL* ssl, byte* out, const byte* input,
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     /* if async is not okay, then block */
-    if (ret == WC_PENDING_E && !asyncOkay) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E) && !asyncOkay) {
         ret = wc_AsyncWait(ret, asyncDev, event_flags);
     }
 #endif
@@ -19070,7 +19092,7 @@ static WC_INLINE int Encrypt(WOLFSSL* ssl, byte* out, const byte* input,
     int ret = 0;
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ssl->error == WC_PENDING_E) {
+    if (ssl->error == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ssl->error = 0; /* clear async */
     }
 #endif
@@ -19163,7 +19185,7 @@ static WC_INLINE int Encrypt(WOLFSSL* ssl, byte* out, const byte* input,
 
         #ifdef WOLFSSL_ASYNC_CRYPT
             /* If pending, then leave and return will resume below */
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 return ret;
             }
         #endif
@@ -19259,7 +19281,7 @@ static WC_INLINE int DecryptDo(WOLFSSL* ssl, byte* plain, const byte* input,
 
             ret = wc_Des3_CbcDecrypt(ssl->decrypt.des3, plain, input, sz);
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 ret = wolfSSL_AsyncPush(ssl, &ssl->decrypt.des3->asyncDev);
             }
         #endif
@@ -19277,7 +19299,7 @@ static WC_INLINE int DecryptDo(WOLFSSL* ssl, byte* plain, const byte* input,
         #endif
             ret = wc_AesCbcDecrypt(ssl->decrypt.aes, plain, input, sz);
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 ret = wolfSSL_AsyncPush(ssl, &ssl->decrypt.aes->asyncDev);
             }
         #endif
@@ -19343,7 +19365,7 @@ static WC_INLINE int DecryptDo(WOLFSSL* ssl, byte* plain, const byte* input,
                         ssl->decrypt.additional, AEAD_AUTH_DATA_SZ);
             }
 
-            if (ret == NOT_COMPILED_IN)
+            if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN))
         #endif /* HAVE_PK_CALLBACKS */
             {
                 if ((ret = aes_auth_fn(ssl->decrypt.aes,
@@ -19355,7 +19377,7 @@ static WC_INLINE int DecryptDo(WOLFSSL* ssl, byte* plain, const byte* input,
                             ssl->specs.aead_mac_size,
                             ssl->decrypt.additional, AEAD_AUTH_DATA_SZ)) < 0) {
                 #ifdef WOLFSSL_ASYNC_CRYPT
-                    if (ret == WC_PENDING_E) {
+                    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                         ret = wolfSSL_AsyncPush(ssl,
                                                 &ssl->decrypt.aes->asyncDev);
                     }
@@ -19441,7 +19463,7 @@ static WC_INLINE int DecryptDo(WOLFSSL* ssl, byte* plain, const byte* input,
         #endif
             ret = wc_Sm4CbcDecrypt(ssl->decrypt.sm4, plain, input, sz);
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 ret = wolfSSL_AsyncPush(ssl, &ssl->decrypt.aes->asyncDev);
             }
         #endif
@@ -19502,7 +19524,7 @@ static WC_INLINE int DecryptDo(WOLFSSL* ssl, byte* plain, const byte* input,
                         ssl->specs.aead_mac_size,
                         ssl->decrypt.additional, AEAD_AUTH_DATA_SZ)) < 0) {
             #ifdef WOLFSSL_ASYNC_CRYPT
-                if (ret == WC_PENDING_E) {
+                if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                     ret = wolfSSL_AsyncPush(ssl,
                                             &ssl->decrypt.sm4->asyncDev);
                 }
@@ -19542,9 +19564,9 @@ static int DecryptTls(WOLFSSL* ssl, byte* plain, const byte* input, word16 sz)
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     ret = wolfSSL_AsyncPop(ssl, &ssl->decrypt.state);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* check for still pending */
-        if (ret == WC_PENDING_E)
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
             return ret;
 
         ssl->error = 0; /* clear async */
@@ -19659,7 +19681,7 @@ static int DecryptTls(WOLFSSL* ssl, byte* plain, const byte* input, word16 sz)
 
         #ifdef WOLFSSL_ASYNC_CRYPT
             /* If pending, leave and return below */
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 return ret;
             }
         #endif
@@ -20772,11 +20794,13 @@ static WC_INLINE int VerifyMac(WOLFSSL* ssl, const byte* input, word32 msgSz,
                 ret = ssl->ctx->VerifyMacCb(ssl, input,
                            (msgSz - ivExtra) - digestSz - pad - 1,
                            digestSz, (word32)content, ctx);
-                if (ret != 0 && ret != PROTOCOLCB_UNAVAILABLE) {
+                if (ret != 0 &&
+                    ret != WC_NO_ERR_TRACE(PROTOCOLCB_UNAVAILABLE)) {
                     return ret;
                 }
             }
-            if (!ssl->ctx->VerifyMacCb || ret == PROTOCOLCB_UNAVAILABLE)
+            if (!ssl->ctx->VerifyMacCb ||
+                ret == WC_NO_ERR_TRACE(PROTOCOLCB_UNAVAILABLE))
 #endif
             ret = TimingPadVerify(ssl, input, pad, digestSz, msgSz - ivExtra,
                                   content);
@@ -20868,7 +20892,8 @@ static int DtlsShouldDrop(WOLFSSL* ssl, int retcode)
     }
 
     if ((ssl->options.handShakeDone && retcode != 0)
-        || retcode == SEQUENCE_ERROR || retcode == DTLS_CID_ERROR) {
+        || retcode == WC_NO_ERR_TRACE(SEQUENCE_ERROR)
+        || retcode == WC_NO_ERR_TRACE(DTLS_CID_ERROR)) {
         WOLFSSL_MSG_EX("Silently dropping DTLS message: %d", retcode);
         return 1;
     }
@@ -20928,7 +20953,8 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
     #ifdef WOLFSSL_NONBLOCK_OCSP
         && ssl->error != OCSP_WANT_READ
     #endif
-        && (allowSocketErr != 1 || ssl->error != SOCKET_ERROR_E)
+        && (allowSocketErr != 1 ||
+            ssl->error != WC_NO_ERR_TRACE(SOCKET_ERROR_E))
     ) {
         WOLFSSL_MSG("ProcessReply retry in error state, not allowed");
         return ssl->error;
@@ -20939,7 +20965,8 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
 #if defined(WOLFSSL_CHECK_ALERT_ON_ERR) && \
     (defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP))
     if (allowSocketErr == 1 && \
-        (ssl->error == WC_PENDING_E || ssl->error == OCSP_WANT_READ)) {
+        (ssl->error == WC_NO_ERR_TRACE(WC_PENDING_E) ||
+         ssl->error == WC_NO_ERR_TRACE(OCSP_WANT_READ))) {
         return ssl->error;
     }
 #endif
@@ -21120,7 +21147,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
 #endif
             if (ret != 0) {
                 switch (ret) {
-                case VERSION_ERROR:
+                case WC_NO_ERR_TRACE(VERSION_ERROR):
                     /* send alert per RFC5246 Appendix E. Backward
                      * Compatibility */
                     if (ssl->options.side == WOLFSSL_CLIENT_END)
@@ -21128,7 +21155,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                             wolfssl_alert_protocol_version);
                     break;
 #ifdef HAVE_MAX_FRAGMENT
-                case LENGTH_ERROR:
+                case WC_NO_ERR_TRACE(LENGTH_ERROR):
                     SendAlert(ssl, alert_fatal, record_overflow);
                     break;
 #endif /* HAVE_MAX_FRAGMENT */
@@ -21215,7 +21242,7 @@ default:
                                    ssl->buffers.inputBuffer.idx,
                                    ssl->curSize, ssl->curRL.type);
             #ifdef WOLFSSL_ASYNC_CRYPT
-                if (ret == WC_PENDING_E)
+                if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
                     return ret;
             #endif
                 if (ret < 0) {
@@ -21362,7 +21389,7 @@ default:
                 }
 
             #ifdef WOLFSSL_ASYNC_CRYPT
-                if (ret == WC_PENDING_E)
+                if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
                     return ret;
             #endif
 
@@ -21446,7 +21473,7 @@ default:
                                     ssl->curSize, ssl->curRL.type,
                                     &ssl->keys.padSz);
                 #ifdef WOLFSSL_ASYNC_CRYPT
-                    if (ret == WC_PENDING_E)
+                    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
                         return ret;
                 #endif
                     if (ret < 0) {
@@ -21597,14 +21624,15 @@ default:
                                 ssl->buffers.inputBuffer.buffer,
                                 &ssl->buffers.inputBuffer.idx,
                                 ssl->buffers.inputBuffer.length);
-                            if (ret == 0 || ret == WC_PENDING_E) {
+                            if (ret == 0 ||
+                                ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                                 /* Reset timeout as we have received a valid
                                  * DTLS handshake message */
                                 ssl->dtls_timeout = ssl->dtls_timeout_init;
                             }
                             else {
                                 if (SendFatalAlertOnly(ssl, ret)
-                                        == SOCKET_ERROR_E) {
+                                        == WC_NO_ERR_TRACE(SOCKET_ERROR_E)) {
                                     ret = SOCKET_ERROR_E;
                                 }
                             }
@@ -21645,7 +21673,8 @@ default:
                                             &ssl->buffers.inputBuffer.idx,
                                             ssl->buffers.inputBuffer.length);
                         if (ret != 0) {
-                            if (SendFatalAlertOnly(ssl, ret) == SOCKET_ERROR_E)
+                            if (SendFatalAlertOnly(ssl, ret) ==
+                                WC_NO_ERR_TRACE(SOCKET_ERROR_E))
                                 ret = SOCKET_ERROR_E;
                         }
 #else
@@ -21685,7 +21714,7 @@ default:
                      * Current message should have been DtlsMsgStore'ed and
                      * should be processed with DtlsMsgDrain */
                             && (!ssl->options.dtls
-                                || ret != WC_PENDING_E)
+                                || ret != WC_NO_ERR_TRACE(WC_PENDING_E))
 #endif
                     ) {
                         WOLFSSL_ERROR(ret);
@@ -21798,7 +21827,8 @@ default:
                         /* Check for duplicate CCS message in DTLS mode.
                          * DTLS allows for duplicate messages, and it should be
                          * skipped. Also skip if out of order. */
-                            if (ret != DUPLICATE_MSG_E && ret != OUT_OF_ORDER_E)
+                            if (ret != WC_NO_ERR_TRACE(DUPLICATE_MSG_E) &&
+                                ret != WC_NO_ERR_TRACE(OUT_OF_ORDER_E))
                                 return ret;
                             /* Reset error */
                             ret = 0;
@@ -21893,7 +21923,7 @@ default:
                         defined(HAVE_SECURE_RENEGOTIATION)
                         /* Not really an error. We will return after cleaning
                          * up the processReply state. */
-                        if (ret != APP_DATA_READY)
+                        if (ret != WC_NO_ERR_TRACE(APP_DATA_READY))
                     #endif
                             return ret;
                     }
@@ -22022,7 +22052,7 @@ default:
 #endif
 #if defined(WOLFSSL_DTLS13) || defined(HAVE_SECURE_RENEGOTIATION)
             /* Signal to user that we have application data ready to read */
-            if (ret == APP_DATA_READY)
+            if (ret == WC_NO_ERR_TRACE(APP_DATA_READY))
                 return ret;
 #endif
             /* It is safe to shrink the input buffer here now. local vars will
@@ -22213,7 +22243,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         ret = wc_Md5Final(&md5, result);
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* TODO: Make non-blocking */
-        if (ret == WC_PENDING_E) {
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             ret = wc_AsyncWait(ret, &md5.asyncDev, WC_ASYNC_FLAG_NONE);
         }
     #endif
@@ -22233,7 +22263,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         ret =  wc_Md5Final(&md5, digest);
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* TODO: Make non-blocking */
-        if (ret == WC_PENDING_E) {
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             ret = wc_AsyncWait(ret, &md5.asyncDev, WC_ASYNC_FLAG_NONE);
         }
     #endif
@@ -22263,7 +22293,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         ret = wc_ShaFinal(&sha, result);
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* TODO: Make non-blocking */
-        if (ret == WC_PENDING_E) {
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             ret = wc_AsyncWait(ret, &sha.asyncDev, WC_ASYNC_FLAG_NONE);
         }
     #endif
@@ -22283,7 +22313,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         ret =  wc_ShaFinal(&sha, digest);
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* TODO: Make non-blocking */
-        if (ret == WC_PENDING_E) {
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             ret = wc_AsyncWait(ret, &sha.asyncDev, WC_ASYNC_FLAG_NONE);
         }
     #endif
@@ -22516,7 +22546,7 @@ int BuildMessage(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
         args = &ssl->async->buildArgs;
 
         ret = wolfSSL_AsyncPop(ssl, &ssl->options.buildMsgState);
-        if (ret != WC_NO_PENDING_E) {
+        if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
             /* Check for error */
             if (ret < 0)
                 goto exit_buildmsg;
@@ -22530,7 +22560,7 @@ int BuildMessage(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
 
     /* Reset state */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_NO_PENDING_E)
+    if (ret == WC_NO_ERR_TRACE(WC_NO_PENDING_E))
 #endif
     {
         ret = 0;
@@ -22864,7 +22894,7 @@ int BuildMessage(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
 
             if (ret != 0) {
             #ifdef WOLFSSL_ASYNC_CRYPT
-                if (ret != WC_PENDING_E)
+                if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
             #endif
                 {
                     /* Zeroize plaintext. */
@@ -22941,7 +22971,7 @@ exit_buildmsg:
     WOLFSSL_LEAVE("BuildMessage", ret);
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         return ret;
     }
 #endif
@@ -23250,9 +23280,9 @@ int CreateOcspResponse(WOLFSSL* ssl, OcspRequest** ocspRequest,
                                ssl->heap);
 
         /* Suppressing, not critical */
-        if (ret == OCSP_CERT_REVOKED ||
-            ret == OCSP_CERT_UNKNOWN ||
-            ret == OCSP_LOOKUP_FAIL) {
+        if (ret == WC_NO_ERR_TRACE(OCSP_CERT_REVOKED) ||
+            ret == WC_NO_ERR_TRACE(OCSP_CERT_UNKNOWN) ||
+            ret == WC_NO_ERR_TRACE(OCSP_LOOKUP_FAIL)) {
             ret = 0;
         }
     }
@@ -23979,7 +24009,8 @@ int SendCertificateStatus(WOLFSSL* ssl)
             }
 
             /* Let's not error out the connection if we can't verify our cert */
-            if (ret == ASN_SELF_SIGNED_E || ret == ASN_NO_SIGNER_E)
+            if (ret == WC_NO_ERR_TRACE(ASN_SELF_SIGNED_E) ||
+                ret == WC_NO_ERR_TRACE(ASN_NO_SIGNER_E))
                 ret = 0;
 
             if (response.buffer) {
@@ -24062,9 +24093,9 @@ int SendCertificateStatus(WOLFSSL* ssl)
                                         request, &responses[i + 1], ssl->heap);
 
                             /* Suppressing, not critical */
-                            if (ret == OCSP_CERT_REVOKED ||
-                                ret == OCSP_CERT_UNKNOWN ||
-                                ret == OCSP_LOOKUP_FAIL) {
+                            if (ret == WC_NO_ERR_TRACE(OCSP_CERT_REVOKED) ||
+                                ret == WC_NO_ERR_TRACE(OCSP_CERT_UNKNOWN) ||
+                                ret == WC_NO_ERR_TRACE(OCSP_LOOKUP_FAIL)) {
                                 ret = 0;
                             }
 
@@ -24088,9 +24119,9 @@ int SendCertificateStatus(WOLFSSL* ssl)
                                            request, &responses[++i], ssl->heap);
 
                     /* Suppressing, not critical */
-                    if (ret == OCSP_CERT_REVOKED ||
-                        ret == OCSP_CERT_UNKNOWN ||
-                        ret == OCSP_LOOKUP_FAIL) {
+                    if (ret == WC_NO_ERR_TRACE(OCSP_CERT_REVOKED) ||
+                        ret == WC_NO_ERR_TRACE(OCSP_CERT_UNKNOWN) ||
+                        ret == WC_NO_ERR_TRACE(OCSP_LOOKUP_FAIL)) {
                         ret = 0;
                     }
                 }
@@ -24111,7 +24142,8 @@ int SendCertificateStatus(WOLFSSL* ssl)
             }
 
             /* Let's not error out the connection if we can't verify our cert */
-            if (ret == ASN_SELF_SIGNED_E || ret == ASN_NO_SIGNER_E)
+            if (ret == WC_NO_ERR_TRACE(ASN_SELF_SIGNED_E) ||
+                ret == WC_NO_ERR_TRACE(ASN_NO_SIGNER_E))
                 ret = 0;
 
             break;
@@ -24365,7 +24397,8 @@ int SendData(WOLFSSL* ssl, const void* data, int sz)
     }
 
     /* don't allow write after decrypt or mac error */
-    if (ssl->error == VERIFY_MAC_ERROR || ssl->error == DECRYPT_ERROR) {
+    if (ssl->error == WC_NO_ERR_TRACE(VERIFY_MAC_ERROR) ||
+        ssl->error == WC_NO_ERR_TRACE(DECRYPT_ERROR)) {
         /* For DTLS allow these possible errors and allow the session
             to continue despite them */
         if (ssl->options.dtls) {
@@ -24404,7 +24437,7 @@ int SendData(WOLFSSL* ssl, const void* data, int sz)
         if ( (err = wolfSSL_negotiate(ssl)) != WOLFSSL_SUCCESS) {
         #ifdef WOLFSSL_ASYNC_CRYPT
             /* if async would block return WANT_WRITE */
-            if (ssl->error == WC_PENDING_E) {
+            if (ssl->error == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 return WOLFSSL_CBIO_ERR_WANT_WRITE;
             }
         #endif
@@ -24421,8 +24454,8 @@ int SendData(WOLFSSL* ssl, const void* data, int sz)
         WOLFSSL_MSG("output buffer was full, trying to send again");
         if ( (ssl->error = SendBuffered(ssl)) < 0) {
             WOLFSSL_ERROR(ssl->error);
-            if (ssl->error == SOCKET_ERROR_E && (ssl->options.connReset ||
-                                                 ssl->options.isClosed)) {
+            if (ssl->error == WC_NO_ERR_TRACE(SOCKET_ERROR_E) &&
+                (ssl->options.connReset || ssl->options.isClosed)) {
                 ssl->error = SOCKET_PEER_CLOSED_E;
                 WOLFSSL_ERROR(ssl->error);
                 return 0;  /* peer reset or closed */
@@ -24568,7 +24601,7 @@ int SendData(WOLFSSL* ssl, const void* data, int sz)
         }
         if (sendSz < 0) {
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (sendSz == WC_PENDING_E)
+            if (sendSz == WC_NO_ERR_TRACE(WC_PENDING_E))
                 ssl->error = sendSz;
         #endif
             return BUILD_MSG_ERROR;
@@ -24585,8 +24618,8 @@ int SendData(WOLFSSL* ssl, const void* data, int sz)
                doesn't present like WANT_WRITE */
             ssl->buffers.plainSz  = buffSz;
             ssl->buffers.prevSent = sent;
-            if (ssl->error == SOCKET_ERROR_E && (ssl->options.connReset ||
-                                                 ssl->options.isClosed)) {
+            if (ssl->error == WC_NO_ERR_TRACE(SOCKET_ERROR_E) &&
+                (ssl->options.connReset || ssl->options.isClosed)) {
                 ssl->error = SOCKET_PEER_CLOSED_E;
                 WOLFSSL_ERROR(ssl->error);
                 return 0;  /* peer reset or closed */
@@ -24622,9 +24655,9 @@ int ReceiveData(WOLFSSL* ssl, byte* output, int sz, int peek)
     if (ssl->options.dtls) {
         /* In DTLS mode, we forgive some errors and allow the session
          * to continue despite them. */
-        if (ssl->error == VERIFY_MAC_ERROR ||
-            ssl->error == DECRYPT_ERROR ||
-            ssl->error == DTLS_SIZE_ERROR) {
+        if (ssl->error == WC_NO_ERR_TRACE(VERIFY_MAC_ERROR) ||
+            ssl->error == WC_NO_ERR_TRACE(DECRYPT_ERROR) ||
+            ssl->error == WC_NO_ERR_TRACE(DTLS_SIZE_ERROR)) {
 
             ssl->error = 0;
         }
@@ -24656,7 +24689,7 @@ int ReceiveData(WOLFSSL* ssl, byte* output, int sz, int peek)
             if ( (err = wolfSSL_negotiate(ssl)) != WOLFSSL_SUCCESS) {
             #ifdef WOLFSSL_ASYNC_CRYPT
                 /* if async would block return WANT_WRITE */
-                if (ssl->error == WC_PENDING_E) {
+                if (ssl->error == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                     return WOLFSSL_CBIO_ERR_WANT_READ;
                 }
             #endif
@@ -24683,7 +24716,7 @@ startScr:
                 WOLFSSL_MSG("Zero return, no more data coming");
                 return 0; /* no more data coming */
             }
-            if (ssl->error == SOCKET_ERROR_E) {
+            if (ssl->error == WC_NO_ERR_TRACE(SOCKET_ERROR_E)) {
                 if (ssl->options.connReset || ssl->options.isClosed) {
                     WOLFSSL_MSG("Peer reset or closed, connection done");
                     ssl->error = SOCKET_PEER_CLOSED_E;
@@ -24719,7 +24752,7 @@ startScr:
                 if ( (err = wolfSSL_negotiate(ssl)) != WOLFSSL_SUCCESS) {
                 #ifdef WOLFSSL_ASYNC_CRYPT
                     /* if async would block return WANT_WRITE */
-                    if (ssl->error == WC_PENDING_E) {
+                    if (ssl->error == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                         return WOLFSSL_CBIO_ERR_WANT_READ;
                     }
                 #endif
@@ -24988,6 +25021,10 @@ int SendAlert(WOLFSSL* ssl, int severity, int type)
 
     return SendAlert_ex(ssl, severity, type);
 }
+
+#ifdef WOLFSSL_DEBUG_TRACE_ERROR_CODES_H
+#include <wolfssl/debug-untrace-error-codes.h>
+#endif
 
 const char* wolfSSL_ERR_reason_error_string(unsigned long e)
 {
@@ -25526,6 +25563,10 @@ const char* wolfSSL_ERR_reason_error_string(unsigned long e)
 
 #endif /* NO_ERROR_STRINGS */
 }
+
+#ifdef WOLFSSL_DEBUG_TRACE_ERROR_CODES
+#include <wolfssl/debug-trace-error-codes.h>
+#endif
 
 const char* wolfSSL_ERR_func_error_string(unsigned long e)
 {
@@ -26468,7 +26509,7 @@ const char* wolfSSL_get_cipher_name_iana(WOLFSSL* ssl)
 int GetCipherSuiteFromName(const char* name, byte* cipherSuite0,
                            byte* cipherSuite, int* flags)
 {
-    int           ret = BAD_FUNC_ARG;
+    int           ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
     int           i;
     unsigned long len;
     const char*   nameDelim;
@@ -27393,7 +27434,7 @@ static byte MinHashAlgo(WOLFSSL* ssl)
 int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
 {
     word32 i;
-    int ret = MATCH_SUITE_ERROR;
+    int ret = WC_NO_ERR_TRACE(MATCH_SUITE_ERROR);
     byte minHash;
 
     /* set defaults */
@@ -27832,7 +27873,7 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
 int CreateDevPrivateKey(void** pkey, byte* data, word32 length, int hsType,
                         int label, int id, void* heap, int devId)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
 
     if (hsType == DYNAMIC_TYPE_RSA) {
 #ifndef NO_RSA
@@ -27946,7 +27987,7 @@ int CreateDevPrivateKey(void** pkey, byte* data, word32 length, int hsType,
  */
 int DecodePrivateKey(WOLFSSL *ssl, word32* length)
 {
-    int      ret = BAD_FUNC_ARG;
+    int      ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
     int      keySz;
     word32   idx;
 
@@ -28508,7 +28549,7 @@ exit_dpk:
  */
 int DecodeAltPrivateKey(WOLFSSL *ssl, word32* length)
 {
-    int      ret = BAD_FUNC_ARG;
+    int      ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
     int      keySz;
     word32   idx;
 
@@ -30227,7 +30268,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
 
     static int CheckCurveId(int tlsCurveId)
     {
-        int ret = ECC_CURVE_ERROR;
+        int ret = WC_NO_ERR_TRACE(ECC_CURVE_ERROR);
 
         switch (tlsCurveId) {
     #if (defined(HAVE_ECC160) || defined(HAVE_ALL_CURVES)) && ECC_MIN_KEY_SZ <= 160
@@ -30295,7 +30336,9 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             case WOLFSSL_ECC_SECP521R1: return ECC_SECP521R1_OID;
         #endif /* !NO_ECC_SECP */
     #endif
-            default: break;
+            default:
+                ret = WC_NO_ERR_TRACE(ECC_CURVE_ERROR);
+                break;
         }
 
         return ret;
@@ -30621,7 +30664,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
     args = (DskeArgs*)ssl->async->args;
 
     ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* Check for error */
         if (ret < 0)
             goto exit_dske;
@@ -30747,9 +30790,9 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                                 input + args->idx, length,
                                 EC25519_LITTLE_ENDIAN)) != 0) {
                         #ifdef WOLFSSL_EXTRA_ALERTS
-                            if (ret == BUFFER_E)
+                            if (ret == WC_NO_ERR_TRACE(BUFFER_E))
                                 SendAlert(ssl, alert_fatal, decode_error);
-                            else if (ret == ECC_OUT_OF_RANGE_E)
+                            else if (ret == WC_NO_ERR_TRACE(ECC_OUT_OF_RANGE_E))
                                 SendAlert(ssl, alert_fatal, bad_record_mac);
                             else {
                                 SendAlert(ssl, alert_fatal, illegal_parameter);
@@ -30790,9 +30833,9 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                                 input + args->idx, length,
                                 EC448_LITTLE_ENDIAN)) != 0) {
                         #ifdef WOLFSSL_EXTRA_ALERTS
-                            if (ret == BUFFER_E)
+                            if (ret == WC_NO_ERR_TRACE(BUFFER_E))
                                 SendAlert(ssl, alert_fatal, decode_error);
-                            else if (ret == ECC_OUT_OF_RANGE_E)
+                            else if (ret == WC_NO_ERR_TRACE(ECC_OUT_OF_RANGE_E))
                                 SendAlert(ssl, alert_fatal, bad_record_mac);
                             else {
                                 SendAlert(ssl, alert_fatal, illegal_parameter);
@@ -30944,9 +30987,9 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                                 input + args->idx, length,
                                 EC25519_LITTLE_ENDIAN)) != 0) {
                         #ifdef WOLFSSL_EXTRA_ALERTS
-                            if (ret == BUFFER_E)
+                            if (ret == WC_NO_ERR_TRACE(BUFFER_E))
                                 SendAlert(ssl, alert_fatal, decode_error);
-                            else if (ret == ECC_OUT_OF_RANGE_E)
+                            else if (ret == WC_NO_ERR_TRACE(ECC_OUT_OF_RANGE_E))
                                 SendAlert(ssl, alert_fatal, bad_record_mac);
                             else {
                                 SendAlert(ssl, alert_fatal, illegal_parameter);
@@ -30987,9 +31030,9 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                                 input + args->idx, length,
                                 EC448_LITTLE_ENDIAN)) != 0) {
                         #ifdef WOLFSSL_EXTRA_ALERTS
-                            if (ret == BUFFER_E)
+                            if (ret == WC_NO_ERR_TRACE(BUFFER_E))
                                 SendAlert(ssl, alert_fatal, decode_error);
-                            else if (ret == ECC_OUT_OF_RANGE_E)
+                            else if (ret == WC_NO_ERR_TRACE(ECC_OUT_OF_RANGE_E))
                                 SendAlert(ssl, alert_fatal, bad_record_mac);
                             else {
                                 SendAlert(ssl, alert_fatal, illegal_parameter);
@@ -31285,7 +31328,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                                 ret = 0;
                             }
                         #ifdef WOLFSSL_ASYNC_CRYPT
-                            if (ret != WC_PENDING_E)
+                            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
                         #endif
                             {
                                 /* peerRsaKey */
@@ -31313,7 +31356,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                                     (ssl->buffers.sig.length - SEED_LEN));
                             }
                         #endif /* HAVE_PK_CALLBACKS */
-                            if (ret == NOT_COMPILED_IN) {
+                            if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN)) {
                             #if defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3)
                                 if (ssl->options.peerSigAlgo == sm2_sa_algo) {
                                     ret = Sm2wSm3Verify(ssl,
@@ -31347,7 +31390,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                             }
 
                         #ifdef WOLFSSL_ASYNC_CRYPT
-                            if (ret != WC_PENDING_E)
+                            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
                         #endif
                             {
                                 /* peerEccDsaKey */
@@ -31377,7 +31420,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                             );
 
                         #ifdef WOLFSSL_ASYNC_CRYPT
-                            if (ret != WC_PENDING_E)
+                            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
                         #endif
                             {
                                 /* peerEccDsaKey */
@@ -31407,7 +31450,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                             );
 
                         #ifdef WOLFSSL_ASYNC_CRYPT
-                            if (ret != WC_PENDING_E)
+                            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
                         #endif
                             {
                                 /* peerEccDsaKey */
@@ -31624,7 +31667,7 @@ exit_dske:
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     /* Handle async operation */
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         /* Mark message as not received so it can process again */
         ssl->msgsReceived.got_server_key_exchange = 0;
 
@@ -31705,7 +31748,7 @@ int SendClientKeyExchange(WOLFSSL* ssl)
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* Check for error */
         if (ret < 0)
             goto exit_scke;
@@ -32005,11 +32048,13 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                         void* ctx = wolfSSL_GetGenPreMasterCtx(ssl);
                         ret = ssl->ctx->GenPreMasterCb(ssl,
                             ssl->arrays->preMasterSecret, ENCRYPT_LEN, ctx);
-                        if (ret != 0 && ret != PROTOCOLCB_UNAVAILABLE) {
+                        if (ret != 0 &&
+                            ret != WC_NO_ERR_TRACE(PROTOCOLCB_UNAVAILABLE)) {
                             goto exit_scke;
                         }
                     }
-                    if (!ssl->ctx->GenPreMasterCb || ret == PROTOCOLCB_UNAVAILABLE)
+                    if (!ssl->ctx->GenPreMasterCb ||
+                        ret == WC_NO_ERR_TRACE(PROTOCOLCB_UNAVAILABLE))
                     #endif
                     {
                         /* build PreMasterSecret with RNG data */
@@ -32104,7 +32149,7 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                         MAX_PSK_ID_LEN, ssl->arrays->psk_key, MAX_PSK_KEY_LEN);
                     if (ssl->arrays->psk_keySz == 0 ||
                             (ssl->arrays->psk_keySz > MAX_PSK_KEY_LEN &&
-                        (int)ssl->arrays->psk_keySz != USE_HW_PSK)) {
+                        (int)ssl->arrays->psk_keySz != WC_NO_ERR_TRACE(USE_HW_PSK))) {
                         ERROR_OUT(PSK_KEY_ERROR, exit_scke);
                     }
 
@@ -32149,7 +32194,7 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                         MAX_PSK_ID_LEN, ssl->arrays->psk_key, MAX_PSK_KEY_LEN);
                     if (ssl->arrays->psk_keySz == 0 ||
                             (ssl->arrays->psk_keySz > MAX_PSK_KEY_LEN &&
-                        (int)ssl->arrays->psk_keySz != USE_HW_PSK)) {
+                        (int)ssl->arrays->psk_keySz != WC_NO_ERR_TRACE(USE_HW_PSK))) {
                         ERROR_OUT(PSK_KEY_ERROR, exit_scke);
                     }
 
@@ -32232,7 +32277,7 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                         MAX_PSK_ID_LEN, ssl->arrays->psk_key, MAX_PSK_KEY_LEN);
                     if (ssl->arrays->psk_keySz == 0 ||
                             (ssl->arrays->psk_keySz > MAX_PSK_KEY_LEN &&
-                        (int)ssl->arrays->psk_keySz != USE_HW_PSK)) {
+                        (int)ssl->arrays->psk_keySz != WC_NO_ERR_TRACE(USE_HW_PSK))) {
                         ERROR_OUT(PSK_KEY_ERROR, exit_scke);
                     }
 
@@ -32507,7 +32552,7 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                         WOLFSSL_CLIENT_END
                     );
                 #ifdef WOLFSSL_ASYNC_CRYPT
-                    if (ret != WC_PENDING_E)
+                    if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
                 #endif
                     {
                         FreeKey(ssl, DYNAMIC_TYPE_ECC,
@@ -32872,7 +32917,7 @@ exit_scke:
 
 #ifdef WOLFSSL_ASYNC_IO
     /* Handle async operation */
-    if (ret == WC_PENDING_E || ret == WANT_WRITE) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E) || ret == WANT_WRITE) {
         if (ssl->options.buildingMsg)
             return ret;
         /* If we have completed all states then we will not enter this function
@@ -32972,10 +33017,10 @@ int SendCertificateVerify(WOLFSSL* ssl)
     args = (ScvArgs*)ssl->async->args;
 #ifdef WOLFSSL_ASYNC_CRYPT
     /* BuildMessage does its own Pop */
-    if (ssl->error != WC_PENDING_E ||
+    if (ssl->error != WC_NO_ERR_TRACE(WC_PENDING_E) ||
             ssl->options.asyncState != TLS_ASYNC_END)
         ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* Check for error */
         if (ret < 0)
             goto exit_scv;
@@ -33365,7 +33410,7 @@ int SendCertificateVerify(WOLFSSL* ssl)
                     );
 
                     /* free temporary buffer now */
-                    if (ret != WC_PENDING_E) {
+                    if (ret != WC_NO_ERR_TRACE(WC_PENDING_E)) {
                         XFREE(args->verifySig, ssl->heap, DYNAMIC_TYPE_SIGNATURE);
                         args->verifySig = NULL;
                     }
@@ -33719,23 +33764,23 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     int TranslateErrorToAlert(int err)
     {
         switch (err) {
-            case BUFFER_ERROR:
+            case WC_NO_ERR_TRACE(BUFFER_ERROR):
                 return decode_error;
-            case EXT_NOT_ALLOWED:
-            case PEER_KEY_ERROR:
-            case ECC_PEERKEY_ERROR:
-            case BAD_KEY_SHARE_DATA:
-            case PSK_KEY_ERROR:
-            case INVALID_PARAMETER:
-            case HRR_COOKIE_ERROR:
-            case BAD_BINDER:
+            case WC_NO_ERR_TRACE(EXT_NOT_ALLOWED):
+            case WC_NO_ERR_TRACE(PEER_KEY_ERROR):
+            case WC_NO_ERR_TRACE(ECC_PEERKEY_ERROR):
+            case WC_NO_ERR_TRACE(BAD_KEY_SHARE_DATA):
+            case WC_NO_ERR_TRACE(PSK_KEY_ERROR):
+            case WC_NO_ERR_TRACE(INVALID_PARAMETER):
+            case WC_NO_ERR_TRACE(HRR_COOKIE_ERROR):
+            case WC_NO_ERR_TRACE(BAD_BINDER):
                 return illegal_parameter;
-            case INCOMPLETE_DATA:
+            case WC_NO_ERR_TRACE(INCOMPLETE_DATA):
                 return missing_extension;
-            case MATCH_SUITE_ERROR:
-            case MISSING_HANDSHAKE_DATA:
+            case WC_NO_ERR_TRACE(MATCH_SUITE_ERROR):
+            case WC_NO_ERR_TRACE(MISSING_HANDSHAKE_DATA):
                 return handshake_failure;
-            case VERSION_ERROR:
+            case WC_NO_ERR_TRACE(VERSION_ERROR):
                 return wolfssl_alert_protocol_version;
             default:
                 return invalid_alert;
@@ -34102,7 +34147,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         args = (SskeArgs*)ssl->async->args;
     #ifdef WOLFSSL_ASYNC_CRYPT
         ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-        if (ret != WC_NO_PENDING_E) {
+        if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
             /* Check for error */
             if (ret < 0)
                 goto exit_sske;
@@ -34392,7 +34437,8 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                             if (ssl->eccTempKeyPresent == 0) {
                                 ret = X25519MakeKey(ssl,
                                         (curve25519_key*)ssl->eccTempKey, NULL);
-                                if (ret == 0 || ret == WC_PENDING_E) {
+                                if (ret == 0 ||
+                                    ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                                     ssl->eccTempKeyPresent =
                                         DYNAMIC_TYPE_CURVE25519;
                                 }
@@ -34419,7 +34465,8 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                             if (ssl->eccTempKeyPresent == 0) {
                                 ret = X448MakeKey(ssl,
                                           (curve448_key*)ssl->eccTempKey, NULL);
-                                if (ret == 0 || ret == WC_PENDING_E) {
+                                if (ret == 0 ||
+                                    ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                                     ssl->eccTempKeyPresent =
                                         DYNAMIC_TYPE_CURVE448;
                                 }
@@ -34444,7 +34491,8 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
                         if (ssl->eccTempKeyPresent == 0) {
                             ret = EccMakeKey(ssl, ssl->eccTempKey, NULL);
-                            if (ret == 0 || ret == WC_PENDING_E) {
+                            if (ret == 0 ||
+                                ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                                 ssl->eccTempKeyPresent = DYNAMIC_TYPE_ECC;
                             }
                         }
@@ -35802,7 +35850,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             int ret = TLSX_KeyShare_Choose(ssl, extensions, first, second,
                                            &cs->clientKSE, &searched);
 
-            if (ret == MEMORY_E) {
+            if (ret == WC_NO_ERR_TRACE(MEMORY_E)) {
                 WOLFSSL_MSG("TLSX_KeyShare_Choose() failed in "
                             "VerifyServerSuite() with MEMORY_E");
                 return 0;
@@ -35817,7 +35865,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 cs->doHelloRetry = 1;
             }
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E)
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
                 return ret;
         #endif
             if (!cs->doHelloRetry && ret != 0)
@@ -35884,7 +35932,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             for (i = 0; i < suites->suiteSz; i += 2) {
                 for (j = 0; j < peerSuites->suiteSz; j += 2) {
                     ret = CompareSuites(ssl, suites, peerSuites, i, j, cs, extensions);
-                    if (ret != MATCH_SUITE_ERROR)
+                    if (ret != WC_NO_ERR_TRACE(MATCH_SUITE_ERROR))
                         return ret;
                 }
             }
@@ -35894,7 +35942,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             for (j = 0; j < peerSuites->suiteSz; j += 2) {
                 for (i = 0; i < suites->suiteSz; i += 2) {
                     ret = CompareSuites(ssl, suites, peerSuites, i, j, cs, extensions);
-                    if (ret != MATCH_SUITE_ERROR)
+                    if (ret != WC_NO_ERR_TRACE(MATCH_SUITE_ERROR))
                         return ret;
                 }
             }
@@ -36372,7 +36420,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
                     /* propagate socket errors to avoid re-calling send alert */
                     err = SendAlert(ssl, alert_fatal, alertType);
-                    if (err == SOCKET_ERROR_E)
+                    if (err == WC_NO_ERR_TRACE(SOCKET_ERROR_E))
                         ret = SOCKET_ERROR_E;
                 }
                 *inOutIdx += helloSz;
@@ -37017,7 +37065,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         args = (DcvArgs*)ssl->async->args;
 
         ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-        if (ret != WC_NO_PENDING_E) {
+        if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
             /* Check for error */
             if (ret < 0)
                 goto exit_dcv;
@@ -37270,7 +37318,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
             #ifdef WOLFSSL_ASYNC_CRYPT
                 /* handle async pending */
-                if (ret == WC_PENDING_E)
+                if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
                     goto exit_dcv;
             #endif
 
@@ -37408,7 +37456,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* Handle async operation */
-        if (ret == WC_PENDING_E) {
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             /* Mark message as not received so it can process again */
             ssl->msgsReceived.got_certificate_verify = 0;
 
@@ -37416,9 +37464,9 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         }
     #endif /* WOLFSSL_ASYNC_CRYPT */
     #ifdef WOLFSSL_EXTRA_ALERTS
-        if (ret == BUFFER_ERROR)
+        if (ret == WC_NO_ERR_TRACE(BUFFER_ERROR))
             SendAlert(ssl, alert_fatal, decode_error);
-        else if (ret == SIG_VERIFY_E)
+        else if (ret == WC_NO_ERR_TRACE(SIG_VERIFY_E))
             SendAlert(ssl, alert_fatal, decrypt_error);
         else if (ret != 0)
             SendAlert(ssl, alert_fatal, bad_certificate);
@@ -37631,7 +37679,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         it = (InternalTicket*)et->enc_ticket;
 
     #ifdef WOLFSSL_ASYNC_CRYPT
-        if (ssl->error != WC_PENDING_E)
+        if (ssl->error != WC_NO_ERR_TRACE(WC_PENDING_E))
     #endif
         {
             XMEMSET(et, 0, sizeof(*et));
@@ -37738,7 +37786,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         }
         if (ret != WOLFSSL_TICKET_RET_OK) {
 #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 return ret;
             }
 #endif
@@ -37859,7 +37907,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         }
         if (ret != WOLFSSL_TICKET_RET_OK) {
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 return ret;
             }
         #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -39193,7 +39241,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
         args = (DckeArgs*)ssl->async->args;
 
         ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-        if (ret != WC_NO_PENDING_E) {
+        if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
             /* Check for error */
             if (ret < 0)
                 goto exit_dcke;
@@ -39415,7 +39463,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
 
                         if (ssl->arrays->psk_keySz == 0 ||
                             (ssl->arrays->psk_keySz > MAX_PSK_KEY_LEN &&
-                        (int)ssl->arrays->psk_keySz != USE_HW_PSK)) {
+                        (int)ssl->arrays->psk_keySz != WC_NO_ERR_TRACE(USE_HW_PSK))) {
                         #if defined(WOLFSSL_EXTRA_ALERTS) || \
                             defined(WOLFSSL_PSK_IDENTITY_ALERT)
                             SendAlert(ssl, alert_fatal,
@@ -39507,9 +39555,9 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                                     input + args->idx, args->length,
                                     EC25519_LITTLE_ENDIAN)) != 0) {
                         #ifdef WOLFSSL_EXTRA_ALERTS
-                                if (ret == BUFFER_E)
+                                if (ret == WC_NO_ERR_TRACE(BUFFER_E))
                                     SendAlert(ssl, alert_fatal, decode_error);
-                                else if (ret == ECC_OUT_OF_RANGE_E)
+                                else if (ret == WC_NO_ERR_TRACE(ECC_OUT_OF_RANGE_E))
                                     SendAlert(ssl, alert_fatal, bad_record_mac);
                                 else {
                                     SendAlert(ssl, alert_fatal,
@@ -39564,9 +39612,9 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                                     input + args->idx, args->length,
                                     EC448_LITTLE_ENDIAN)) != 0) {
                         #ifdef WOLFSSL_EXTRA_ALERTS
-                                if (ret == BUFFER_E)
+                                if (ret == WC_NO_ERR_TRACE(BUFFER_E))
                                     SendAlert(ssl, alert_fatal, decode_error);
-                                else if (ret == ECC_OUT_OF_RANGE_E)
+                                else if (ret == WC_NO_ERR_TRACE(ECC_OUT_OF_RANGE_E))
                                     SendAlert(ssl, alert_fatal, bad_record_mac);
                                 else {
                                     SendAlert(ssl, alert_fatal,
@@ -39809,9 +39857,9 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                                     input + args->idx, args->length,
                                     EC25519_LITTLE_ENDIAN)) != 0) {
                         #ifdef WOLFSSL_EXTRA_ALERTS
-                                if (ret == BUFFER_E)
+                                if (ret == WC_NO_ERR_TRACE(BUFFER_E))
                                     SendAlert(ssl, alert_fatal, decode_error);
-                                else if (ret == ECC_OUT_OF_RANGE_E)
+                                else if (ret == WC_NO_ERR_TRACE(ECC_OUT_OF_RANGE_E))
                                     SendAlert(ssl, alert_fatal, bad_record_mac);
                                 else {
                                     SendAlert(ssl, alert_fatal,
@@ -39868,9 +39916,9 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                                     input + args->idx, args->length,
                                     EC448_LITTLE_ENDIAN)) != 0) {
                         #ifdef WOLFSSL_EXTRA_ALERTS
-                                if (ret == BUFFER_E)
+                                if (ret == WC_NO_ERR_TRACE(BUFFER_E))
                                     SendAlert(ssl, alert_fatal, decode_error);
-                                else if (ret == ECC_OUT_OF_RANGE_E)
+                                else if (ret == WC_NO_ERR_TRACE(ECC_OUT_OF_RANGE_E))
                                     SendAlert(ssl, alert_fatal, bad_record_mac);
                                 else {
                                     SendAlert(ssl, alert_fatal,
@@ -39971,10 +40019,10 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                          *       RSA_BUFFER_E, RSA_PAD_E and RSA_PRIVATE_ERROR
                          */
                     #ifdef WOLFSSL_ASYNC_CRYPT
-                        if (ret == WC_PENDING_E)
+                        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
                             goto exit_dcke;
                     #endif
-                        if (ret == BAD_FUNC_ARG)
+                        if (ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG))
                             goto exit_dcke;
 
                         lenErrMask = 0 - (SECRET_LEN != args->sigSz);
@@ -40037,7 +40085,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                             WOLFSSL_SERVER_END
                         );
                     #ifdef WOLFSSL_ASYNC_CRYPT
-                        if (ret != WC_PENDING_E)
+                        if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
                     #endif
                         {
                             FreeKey(ssl, DYNAMIC_TYPE_ECC,
@@ -40093,7 +40141,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                                 WOLFSSL_SERVER_END
                             );
                         #ifdef WOLFSSL_ASYNC_CRYPT
-                            if (ret != WC_PENDING_E)
+                            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
                         #endif
                             {
                                 FreeKey(ssl, DYNAMIC_TYPE_CURVE25519,
@@ -40114,7 +40162,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                                 WOLFSSL_SERVER_END
                             );
                         #ifdef WOLFSSL_ASYNC_CRYPT
-                            if (ret != WC_PENDING_E)
+                            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
                         #endif
                             {
                                 FreeKey(ssl, DYNAMIC_TYPE_CURVE448,
@@ -40258,7 +40306,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
 
                         if (ssl->arrays->psk_keySz == 0 ||
                             (ssl->arrays->psk_keySz > MAX_PSK_KEY_LEN &&
-                        (int)ssl->arrays->psk_keySz != USE_HW_PSK)) {
+                        (int)ssl->arrays->psk_keySz != WC_NO_ERR_TRACE(USE_HW_PSK))) {
                         #if defined(WOLFSSL_EXTRA_ALERTS) || \
                             defined(WOLFSSL_PSK_IDENTITY_ALERT)
                             SendAlert(ssl, alert_fatal,
@@ -40304,7 +40352,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
 
                         if (ssl->arrays->psk_keySz == 0 ||
                             (ssl->arrays->psk_keySz > MAX_PSK_KEY_LEN &&
-                        (int)ssl->arrays->psk_keySz != USE_HW_PSK)) {
+                        (int)ssl->arrays->psk_keySz != WC_NO_ERR_TRACE(USE_HW_PSK))) {
                             ERROR_OUT(PSK_KEY_ERROR, exit_dcke);
                         }
                         /* SERVER: Pre-shared Key for peer authentication. */
@@ -40390,7 +40438,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
         WOLFSSL_END(WC_FUNC_CLIENT_KEY_EXCHANGE_DO);
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* Handle async operation */
-        if (ret == WC_PENDING_E) {
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             /* Mark message as not received so it can process again */
             ssl->msgsReceived.got_client_key_exchange = 0;
 
@@ -40482,7 +40530,8 @@ int wolfSSL_AsyncPop(WOLFSSL* ssl, byte* state)
         event = &asyncDev->event;
 
         ret = wolfAsync_EventPop(event, WOLF_EVENT_TYPE_ASYNC_WOLFSSL);
-        if (ret != WC_NO_PENDING_E && ret != WC_PENDING_E) {
+        if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E) &&
+            ret != WC_NO_ERR_TRACE(WC_PENDING_E)) {
             /* advance key share state if doesn't need called again */
             if (state && (asyncDev->event.flags & WC_ASYNC_FLAG_CALL_AGAIN) == 0) {
                 (*state)++;
@@ -40495,7 +40544,7 @@ int wolfSSL_AsyncPop(WOLFSSL* ssl, byte* state)
     #if (defined(WOLF_CRYPTO_CB) || defined(HAVE_PK_CALLBACKS)) && \
         !defined(WOLFSSL_ASYNC_CRYPT_SW) && !defined(HAVE_INTEL_QA) && \
         !defined(HAVE_CAVIUM)
-        else if (ret == WC_PENDING_E) {
+        else if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             /* Allow the underlying crypto API to be called again to trigger the
              * crypto or PK callback. The actual callback must be called, since
              * the completion is not detected in the poll like Intel QAT or

--- a/src/keys.c
+++ b/src/keys.c
@@ -3561,7 +3561,8 @@ int SetKeysSide(WOLFSSL* ssl, enum encrypt_side side)
         void* ctx = wolfSSL_GetEncryptKeysCtx(ssl);
         ret = ssl->ctx->EncryptKeysCb(ssl, ctx);
     }
-    if (!ssl->ctx->EncryptKeysCb || ret == PROTOCOLCB_UNAVAILABLE)
+    if (!ssl->ctx->EncryptKeysCb ||
+        ret == WC_NO_ERR_TRACE(PROTOCOLCB_UNAVAILABLE))
 #endif
     {
         ret = SetKeys(wc_encrypt, wc_decrypt, keys, &ssl->specs, ssl->options.side,

--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -144,7 +144,7 @@ static int xstat2err(int st)
 
 int CheckCertOCSP_ex(WOLFSSL_OCSP* ocsp, DecodedCert* cert, WOLFSSL* ssl)
 {
-    int ret = OCSP_LOOKUP_FAIL;
+    int ret = WC_NO_ERR_TRACE(OCSP_LOOKUP_FAIL);
 
 #ifdef WOLFSSL_SMALL_STACK
     OcspRequest* ocspRequest;
@@ -227,7 +227,7 @@ static int GetOcspStatus(WOLFSSL_OCSP* ocsp, OcspRequest* request,
                   OcspEntry* entry, CertStatus** status, buffer* responseBuffer,
                   void* heap)
 {
-    int ret = OCSP_INVALID_STATUS;
+    int ret = WC_NO_ERR_TRACE(OCSP_INVALID_STATUS);
 
     WOLFSSL_ENTER("GetOcspStatus");
 
@@ -410,10 +410,10 @@ end:
     if (ret == 0 && validated == 1) {
         WOLFSSL_MSG("New OcspResponse validated");
     }
-    else if (ret == OCSP_CERT_REVOKED) {
+    else if (ret == WC_NO_ERR_TRACE(OCSP_CERT_REVOKED)) {
         WOLFSSL_MSG("OCSP revoked");
     }
-    else if (ret == OCSP_CERT_UNKNOWN) {
+    else if (ret == WC_NO_ERR_TRACE(OCSP_CERT_UNKNOWN)) {
         WOLFSSL_MSG("OCSP unknown");
     }
     else {
@@ -466,7 +466,7 @@ int CheckOcspRequest(WOLFSSL_OCSP* ocsp, OcspRequest* ocspRequest,
 
     ret = GetOcspStatus(ocsp, ocspRequest, entry, &status, responseBuffer,
                         heap);
-    if (ret != OCSP_INVALID_STATUS)
+    if (ret != WC_NO_ERR_TRACE(OCSP_INVALID_STATUS))
         return ret;
 
     if (responseBuffer) {
@@ -1025,7 +1025,7 @@ OcspResponse* wolfSSL_d2i_OCSP_RESPONSE(OcspResponse** response,
     resp->maxIdx = (word32)len;
 
     ret = OcspResponseDecode(resp, NULL, NULL, 1);
-    if (ret != 0 && ret != ASN_OCSP_CONFIRM_E) {
+    if (ret != 0 && ret != WC_NO_ERR_TRACE(ASN_OCSP_CONFIRM_E)) {
         /* for just converting from a DER to an internal structure the CA may
          * not yet be known to this function for signature verification */
         wolfSSL_OCSP_RESPONSE_free(resp);

--- a/src/pk.c
+++ b/src/pk.c
@@ -1804,7 +1804,7 @@ int wolfSSL_RSA_LoadDer_ex(WOLFSSL_RSA* rsa, const unsigned char* derBuf,
             rsa->pkcs8HeaderSz = (word16)idx;
         }
         /* When decoding and not PKCS#8, return will be ASN_PARSE_E. */
-        else if (res != ASN_PARSE_E) {
+        else if (res != WC_NO_ERR_TRACE(ASN_PARSE_E)) {
             /* Something went wrong while decoding. */
             WOLFSSL_ERROR_MSG("Unexpected error with trying to remove PKCS#8 "
                               "header");
@@ -3384,7 +3384,7 @@ WOLFSSL_RSA* wolfSSL_RSA_generate_key(int bits, unsigned long e,
         ret = wolfssl_rsa_generate_key_native(rsa, bits, bn, NULL);
     #ifdef HAVE_FIPS
         /* Keep trying if failed to find a prime. */
-        if (ret == PRIME_GEN_E) {
+        if (ret == WC_NO_ERR_TRACE(PRIME_GEN_E)) {
             continue;
         }
     #endif
@@ -3435,7 +3435,7 @@ int wolfSSL_RSA_generate_key_ex(WOLFSSL_RSA* rsa, int bits, WOLFSSL_BIGNUM* e,
             int gen_ret = wolfssl_rsa_generate_key_native(rsa, bits, e, cb);
         #ifdef HAVE_FIPS
             /* Keep trying again if public key value didn't work. */
-            if (gen_ret == PRIME_GEN_E) {
+            if (gen_ret == WC_NO_ERR_TRACE(PRIME_GEN_E)) {
                 continue;
             }
         #endif
@@ -5630,7 +5630,7 @@ int wolfSSL_i2d_DSAparams(const WOLFSSL_DSA* dsa,
     if (ret == 0) {
         key = (DsaKey*)dsa->internal;
         ret = wc_DsaKeyToParamsDer_ex(key, NULL, &derLen);
-        if (ret == LENGTH_ONLY_E) {
+        if (ret == WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
             ret = 0;
         }
     }
@@ -7466,7 +7466,7 @@ int wolfSSL_i2d_DHparams(const WOLFSSL_DH *dh, unsigned char **out)
             *out += len;
         }
         /* An error occurred unless only length returned. */
-        else if (ret != LENGTH_ONLY_E) {
+        else if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
             err = 1;
         }
     }
@@ -7771,7 +7771,7 @@ static int wolfssl_dhparams_to_der(WOLFSSL_DH* dh, unsigned char** out,
         /* Use wolfSSL API to get length of DER encode DH parameters. */
         key = (DhKey*)dh->internal;
         ret = wc_DhParamsToDer(key, NULL, &derSz);
-        if (ret != LENGTH_ONLY_E) {
+        if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
             WOLFSSL_ERROR_MSG("Failed to get size of DH params");
             err = 1;
         }
@@ -10124,7 +10124,8 @@ int wolfSSL_ECPoint_i2d(const WOLFSSL_EC_GROUP *group,
         int ret = wc_ecc_export_point_der(group->curve_idx,
             (ecc_point*)point->internal, out, len);
         /* Check return. When out is NULL, return will be length only error. */
-        if ((ret != MP_OKAY) && ((out != NULL) || (ret != LENGTH_ONLY_E))) {
+        if ((ret != MP_OKAY) && ((out != NULL) ||
+                                 (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)))) {
             WOLFSSL_MSG("wolfSSL_ECPoint_i2d wc_ecc_export_point_der failed");
             res = 0;
         }
@@ -12259,7 +12260,7 @@ int wolfSSL_EC_KEY_LoadDer_ex(WOLFSSL_EC_KEY* key, const unsigned char* derBuf,
             res = 1;
         }
         /* Error out on parsing error. */
-        else if (ret != ASN_PARSE_E) {
+        else if (ret != WC_NO_ERR_TRACE(ASN_PARSE_E)) {
             WOLFSSL_MSG("Unexpected error with trying to remove PKCS8 header");
             res = -1;
         }
@@ -16259,7 +16260,7 @@ static int pem_write_mem_pkcs8privatekey(byte** pem, int* pemSz,
 
     if (res == 1) {
         /* Guestimate key size and PEM size. */
-        if (pem_pkcs8_encode(pkey, NULL, &keySz) != LENGTH_ONLY_E) {
+        if (pem_pkcs8_encode(pkey, NULL, &keySz) != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
             res = 0;
         }
     }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -980,7 +980,7 @@ int GetEchConfigsEx(WOLFSSL_EchConfig* configs, byte* output, word32* outputLen)
             workingOutputLen = *outputLen - totalLen;
 
         /* only error we break on, other 2 we need to keep finding length */
-        if (ret == BAD_FUNC_ARG)
+        if (ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG))
             return BAD_FUNC_ARG;
 
         workingConfig = workingConfig->next;
@@ -3532,12 +3532,14 @@ int wolfSSL_ALPN_FreePeerProtocol(WOLFSSL* ssl, char **list)
 /* user is forcing ability to use secure renegotiation, we discourage it */
 int wolfSSL_UseSecureRenegotiation(WOLFSSL* ssl)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret;
 #if defined(NO_TLS)
     (void)ssl;
 #else
     if (ssl)
         ret = TLSX_UseSecureRenegotiation(&ssl->extensions, ssl->heap);
+    else
+        ret = BAD_FUNC_ARG;
 
     if (ret == WOLFSSL_SUCCESS) {
         TLSX* extension = TLSX_Find(ssl->extensions, TLSX_RENEGOTIATION_INFO);
@@ -4039,13 +4041,14 @@ int wolfSSL_shutdown(WOLFSSL* ssl)
         /* call wolfSSL_shutdown again for bidirectional shutdown */
         if (ssl->options.sentNotify && !ssl->options.closeNotify) {
             ret = ProcessReply(ssl);
-            if ((ret == ZERO_RETURN) || (ret == SOCKET_ERROR_E)) {
+            if ((ret == ZERO_RETURN) ||
+                (ret == WC_NO_ERR_TRACE(SOCKET_ERROR_E))) {
                 /* simulate OpenSSL behavior */
                 ssl->options.shutdownDone = 1;
                 /* Clear error */
                 ssl->error = WOLFSSL_ERROR_NONE;
                 ret = WOLFSSL_SUCCESS;
-            } else if (ret == MEMORY_E) {
+            } else if (ret == WC_NO_ERR_TRACE(MEMORY_E)) {
                 ret = WOLFSSL_FATAL_ERROR;
             } else if (ssl->error == WOLFSSL_ERROR_NONE) {
                 ret = WOLFSSL_SHUTDOWN_NOT_DONE;
@@ -4103,7 +4106,7 @@ int wolfSSL_get_error(WOLFSSL* ssl, int ret)
     else if (ssl->error == ZERO_RETURN || ssl->options.shutdownDone)
         return WOLFSSL_ERROR_ZERO_RETURN;       /* convert to OpenSSL type */
 #ifdef OPENSSL_EXTRA
-    else if (ssl->error == SOCKET_PEER_CLOSED_E)
+    else if (ssl->error == WC_NO_ERR_TRACE(SOCKET_PEER_CLOSED_E))
         return WOLFSSL_ERROR_SYSCALL;           /* convert to OpenSSL type */
 #endif
     return ssl->error;
@@ -6259,7 +6262,7 @@ static int check_cert_key(DerBuffer* cert, DerBuffer* key, DerBuffer* altKey,
         ret = check_cert_key_dev(der->keyOID, buff, size, der->publicKey,
                                  der->pubKeySize, isKeyLabel, isKeyId, heap,
                                  devId);
-        if (ret != CRYPTOCB_UNAVAILABLE) {
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
             ret = (ret == 0) ? WOLFSSL_SUCCESS: WOLFSSL_FAILURE;
         }
     }
@@ -6268,7 +6271,7 @@ static int check_cert_key(DerBuffer* cert, DerBuffer* key, DerBuffer* altKey,
         ret = CRYPTOCB_UNAVAILABLE;
     }
 
-    if (ret == CRYPTOCB_UNAVAILABLE)
+    if (ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
 #endif /* WOLF_PRIVATE_KEY_ID */
     {
         ret = wc_CheckPrivateKeyCert(buff, size, der, 0);
@@ -6319,7 +6322,7 @@ static int check_cert_key(DerBuffer* cert, DerBuffer* key, DerBuffer* altKey,
                                          heap, altDevId);
             }
             XFREE(decodedPubKey, heap, DYNAMIC_TYPE_PUBLIC_KEY);
-            if (ret != CRYPTOCB_UNAVAILABLE) {
+            if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
                 ret = (ret == 0) ? WOLFSSL_SUCCESS: WOLFSSL_FAILURE;
             }
         }
@@ -6328,7 +6331,7 @@ static int check_cert_key(DerBuffer* cert, DerBuffer* key, DerBuffer* altKey,
             ret = CRYPTOCB_UNAVAILABLE;
         }
 
-        if (ret == CRYPTOCB_UNAVAILABLE)
+        if (ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
 #endif /* WOLF_PRIVATE_KEY_ID */
         {
             ret = wc_CheckPrivateKeyCert(buff, size, der, 1);
@@ -7416,7 +7419,7 @@ static WOLFSSL_EVP_PKEY* _d2i_PublicKey(int type, WOLFSSL_EVP_PKEY** out,
             (void)idx; /* not used */
         }
         else {
-            if (ret != ASN_PARSE_E) {
+            if (ret != WC_NO_ERR_TRACE(ASN_PARSE_E)) {
                 WOLFSSL_MSG("Unexpected error with trying to remove PKCS8 "
                     "header");
                 return NULL;
@@ -9463,7 +9466,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
                 #endif
 #ifdef WOLFSSL_EXTRA_ALERTS
                     if (ssl->error == NO_PEER_KEY ||
-                        ssl->error == PSK_KEY_ERROR) {
+                        ssl->error == WC_NO_ERR_TRACE(PSK_KEY_ERROR)) {
                         SendAlert(ssl, alert_fatal, handshake_failure);
                     }
 #endif
@@ -13182,7 +13185,8 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
     #ifdef WOLFSSL_HAVE_ERROR_QUEUE
         int ret = wc_PullErrorNode(file, NULL, line);
         if (ret < 0) {
-            if (ret == BAD_STATE_E) return 0; /* no errors in queue */
+            if (ret == WC_NO_ERR_TRACE(BAD_STATE_E))
+                return 0; /* no errors in queue */
             WOLFSSL_MSG("Issue getting error node");
             WOLFSSL_LEAVE("wolfSSL_ERR_get_error_line", ret);
             ret = 0 - ret; /* return absolute value of error */
@@ -13294,7 +13298,8 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
 
         ret = wc_PullErrorNode(file, data, line);
         if (ret < 0) {
-            if (ret == BAD_STATE_E) return 0; /* no errors in queue */
+            if (ret == WC_NO_ERR_TRACE(BAD_STATE_E))
+                return 0; /* no errors in queue */
             WOLFSSL_MSG("Error with pulling error node!");
             WOLFSSL_LEAVE("wolfSSL_ERR_get_error_line_data", ret);
             ret = 0 - ret; /* return absolute value of error */
@@ -15262,9 +15267,9 @@ int wolfSSL_ERR_GET_LIB(unsigned long err)
 
     value = (err & 0xFFFFFFL);
     switch (value) {
-    case -SSL_R_HTTP_REQUEST:
+    case -WC_NO_ERR_TRACE(PARSE_ERROR):
         return ERR_LIB_SSL;
-    case -ASN_NO_PEM_HEADER:
+    case -WC_NO_ERR_TRACE(ASN_NO_PEM_HEADER):
     case PEM_R_NO_START_LINE:
     case PEM_R_PROBLEMS_GETTING_PASSWORD:
     case PEM_R_BAD_PASSWORD_READ:
@@ -17837,7 +17842,7 @@ int  wolfSSL_get_chain_cert_pem(WOLFSSL_X509_CHAIN* chain, int idx,
     /* Null output buffer return size needed in outLen */
     if(!buf) {
         if(Base64_Encode(chain->certs[idx].buffer, chain->certs[idx].length,
-                    NULL, &szNeeded) != LENGTH_ONLY_E)
+                    NULL, &szNeeded) != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
             return WOLFSSL_FAILURE;
         *outLen = szNeeded + headerLen + footerLen;
         return LENGTH_ONLY_E;
@@ -18866,7 +18871,7 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
         if (o->nid > 0)
             return o->nid;
         if ((ret = GetObjectId(o->obj, &idx, &oid, o->grp, o->objSz)) < 0) {
-            if (ret == ASN_OBJECT_ID_E) {
+            if (ret == WC_NO_ERR_TRACE(ASN_OBJECT_ID_E)) {
                 /* Put ASN object tag in front and try again */
                 int len = SetObjectId(o->objSz, NULL) + o->objSz;
                 byte* buf = (byte*)XMALLOC(len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -20460,12 +20465,12 @@ int wolfSSL_AsyncPoll(WOLFSSL* ssl, WOLF_EVENT_FLAG flags)
 static int peek_ignore_err(int err)
 {
   switch(err) {
-    case -WANT_READ:
-    case -WANT_WRITE:
-    case -ZERO_RETURN:
+    case -WC_NO_ERR_TRACE(WANT_READ):
+    case -WC_NO_ERR_TRACE(WANT_WRITE):
+    case -WC_NO_ERR_TRACE(ZERO_RETURN):
     case -WOLFSSL_ERROR_ZERO_RETURN:
-    case -SOCKET_PEER_CLOSED_E:
-    case -SOCKET_ERROR_E:
+    case -WC_NO_ERR_TRACE(SOCKET_PEER_CLOSED_E):
+    case -WC_NO_ERR_TRACE(SOCKET_ERROR_E):
       return 1;
     default:
       return 0;
@@ -20480,15 +20485,15 @@ unsigned long wolfSSL_ERR_peek_error_line_data(const char **file, int *line,
     WOLFSSL_ENTER("wolfSSL_ERR_peek_error_line_data");
     err = wc_PeekErrorNodeLineData(file, line, data, flags, peek_ignore_err);
 
-    if (err == -ASN_NO_PEM_HEADER)
+    if (err == -WC_NO_ERR_TRACE(ASN_NO_PEM_HEADER))
         return (ERR_LIB_PEM << 24) | PEM_R_NO_START_LINE;
 #ifdef OPENSSL_ALL
     /* PARSE_ERROR is returned if an HTTP request is detected. */
-    else if (err == -SSL_R_HTTP_REQUEST)
+    else if (err == -WC_NO_ERR_TRACE(PARSE_ERROR))
         return (ERR_LIB_SSL << 24) | -SSL_R_HTTP_REQUEST;
 #endif
 #if defined(OPENSSL_ALL) && defined(WOLFSSL_PYTHON)
-    else if (err == ASN1_R_HEADER_TOO_LONG)
+    else if (err == WC_NO_ERR_TRACE(ASN1_R_HEADER_TOO_LONG))
         return (ERR_LIB_ASN1 << 24) | ASN1_R_HEADER_TOO_LONG;
 #endif
   return err;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3532,7 +3532,7 @@ int wolfSSL_ALPN_FreePeerProtocol(WOLFSSL* ssl, char **list)
 /* user is forcing ability to use secure renegotiation, we discourage it */
 int wolfSSL_UseSecureRenegotiation(WOLFSSL* ssl)
 {
-    int ret;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 #if defined(NO_TLS)
     (void)ssl;
 #else

--- a/src/ssl_asn1.c
+++ b/src/ssl_asn1.c
@@ -974,7 +974,8 @@ static int wolfssl_a2i_asn1_integer_clear_to_eol(char* str, int len, int* cont)
     nLen = 1;
     for (i = 0; i < len; i++) {
         /* Check if character is a hexadecimal character. */
-        if (Base16_Decode((const byte*)str + i, 1, &num, &nLen) == ASN_INPUT_E)
+        if (Base16_Decode((const byte*)str + i, 1, &num, &nLen) ==
+            WC_NO_ERR_TRACE(ASN_INPUT_E))
         {
             /* Found end of hexadecimal characters, return count. */
             len = i;

--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -353,7 +353,7 @@ static int ProcessUserChain(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
                    chain.buffer, &idx, (word32)maxSz);
             }
             /* PEM may have trailing data that can be ignored. */
-            if ((ret == ASN_NO_PEM_HEADER) && gotOne) {
+            if ((ret == WC_NO_ERR_TRACE(ASN_NO_PEM_HEADER)) && gotOne) {
                 WOLFSSL_MSG("We got one good cert, so stuff at end ok");
                 ret = 0;
                 break;
@@ -2363,7 +2363,7 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff, long sz,
             ret = ProcessUserChain(ctx, ssl, buff, sz, format, type, used, info,
                 verify);
             /* Additional chain is optional */
-            if (ret == ASN_NO_PEM_HEADER) {
+            if (ret == WC_NO_ERR_TRACE(ASN_NO_PEM_HEADER)) {
                 unsigned long pemErr = 0;
                 CLEAR_ASN_NO_PEM_HEADER_ERROR(pemErr);
                 ret = 0;
@@ -2459,7 +2459,7 @@ static int ProcessChainBuffer(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
         ret = ProcessBuffer(ctx, buff + used, sz - used, WOLFSSL_FILETYPE_PEM,
             type, ssl, &consumed, 0, verify);
         /* Memory allocation failure is fatal. */
-        if (ret == MEMORY_E) {
+        if (ret == WC_NO_ERR_TRACE(MEMORY_E)) {
             gotOne = 0;
         }
         /* Other error parsing. */
@@ -2658,7 +2658,7 @@ static int wolfssl_ctx_load_path_file(WOLFSSL_CTX* ctx, const char* name,
         /* When ignoring errors or loading PEM only and no PEM. don't fail. */
         if ((flags & WOLFSSL_LOAD_FLAG_IGNORE_ERR) ||
                 ((flags & WOLFSSL_LOAD_FLAG_PEM_CA_ONLY) &&
-                 (ret == ASN_NO_PEM_HEADER))) {
+                 (ret == WC_NO_ERR_TRACE(ASN_NO_PEM_HEADER)))) {
             unsigned long err = 0;
             CLEAR_ASN_NO_PEM_HEADER_ERROR(err);
         #if defined(WOLFSSL_QT)
@@ -2745,7 +2745,7 @@ static int wolfssl_ctx_load_path(WOLFSSL_CTX* ctx, const char* path,
             ret = fileRet;
         #if defined(WOLFSSL_QT) || defined(WOLFSSL_IGNORE_BAD_CERT_PATH)
             /* Ignore bad path error when flag set. */
-            if ((ret == BAD_PATH_ERROR) &&
+            if ((ret == WC_NO_ERR_TRACE(BAD_PATH_ERROR)) &&
                     (flags & WOLFSSL_LOAD_FLAG_IGNORE_BAD_PATH_ERR)) {
                /* QSslSocket always loads certs in system folder
                 * when it is initialized.

--- a/src/ssl_p7p12.c
+++ b/src/ssl_p7p12.c
@@ -1499,7 +1499,8 @@ int wolfSSL_SMIME_write_PKCS7(WOLFSSL_BIO* out, PKCS7* pkcs7, WOLFSSL_BIO* in,
 
     /* Base64 encode signedData bundle */
     if (ret > 0) {
-        if (Base64_Encode(p7out, (word32)len, NULL, &sigBase64Len) != LENGTH_ONLY_E) {
+        if (Base64_Encode(p7out, (word32)len, NULL, &sigBase64Len) !=
+            WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
             ret = 0;
         }
         else {

--- a/src/tls.c
+++ b/src/tls.c
@@ -212,7 +212,8 @@ int BuildTlsFinished(WOLFSSL* ssl, Hashes* hashes, const byte* sender)
             ret = ssl->ctx->TlsFinishedCb(ssl, side, handshake_hash, hashSz,
                                           (byte*)hashes, ctx);
         }
-        if (!ssl->ctx->TlsFinishedCb || ret == PROTOCOLCB_UNAVAILABLE)
+        if (!ssl->ctx->TlsFinishedCb ||
+            ret == WC_NO_ERR_TRACE(PROTOCOLCB_UNAVAILABLE))
 #endif
         {
             PRIVATE_KEY_UNLOCK();
@@ -488,7 +489,8 @@ int DeriveTlsKeys(WOLFSSL* ssl)
             void* ctx = wolfSSL_GetGenSessionKeyCtx(ssl);
             ret = ssl->ctx->GenSessionKeyCb(ssl, ctx);
         }
-        if (!ssl->ctx->GenSessionKeyCb || ret == PROTOCOLCB_UNAVAILABLE)
+        if (!ssl->ctx->GenSessionKeyCb ||
+            ret == WC_NO_ERR_TRACE(PROTOCOLCB_UNAVAILABLE))
 #endif
         ret = _DeriveTlsKeys(key_dig, (word32)key_dig_len,
                          ssl->arrays->masterSecret, SECRET_LEN,
@@ -668,7 +670,8 @@ int MakeTlsMasterSecret(WOLFSSL* ssl)
             void* ctx = wolfSSL_GetGenMasterSecretCtx(ssl);
             ret = ssl->ctx->GenMasterCb(ssl, ctx);
         }
-        if (!ssl->ctx->GenMasterCb || ret == PROTOCOLCB_UNAVAILABLE)
+        if (!ssl->ctx->GenMasterCb ||
+            ret == WC_NO_ERR_TRACE(PROTOCOLCB_UNAVAILABLE))
 #endif
         {
             ret = _MakeTlsMasterSecret(ssl->arrays->masterSecret,
@@ -782,7 +785,7 @@ int wolfSSL_SetTlsHmacInner(WOLFSSL* ssl, byte* inner, word32 sz, int content,
  */
 static int Hmac_HashUpdate(Hmac* hmac, const byte* data, word32 sz)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     switch (hmac->macType) {
     #ifndef NO_SHA
@@ -816,6 +819,7 @@ static int Hmac_HashUpdate(Hmac* hmac, const byte* data, word32 sz)
     #endif /* WOLFSSL_SM3 */
 
         default:
+            ret = BAD_FUNC_ARG;
             break;
     }
 
@@ -830,7 +834,7 @@ static int Hmac_HashUpdate(Hmac* hmac, const byte* data, word32 sz)
  */
 static int Hmac_HashFinalRaw(Hmac* hmac, unsigned char* hash)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     switch (hmac->macType) {
     #ifndef NO_SHA
@@ -864,6 +868,7 @@ static int Hmac_HashFinalRaw(Hmac* hmac, unsigned char* hash)
     #endif /* WOLFSSL_SM3 */
 
         default:
+            ret = BAD_FUNC_ARG;
             break;
     }
 
@@ -878,7 +883,7 @@ static int Hmac_HashFinalRaw(Hmac* hmac, unsigned char* hash)
  */
 static int Hmac_OuterHash(Hmac* hmac, unsigned char* mac)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret;
     wc_HashAlg hash;
     enum wc_HashType hashType = (enum wc_HashType)hmac->macType;
     int digestSz = wc_HashGetDigestSize(hashType);
@@ -887,6 +892,10 @@ static int Hmac_OuterHash(Hmac* hmac, unsigned char* mac)
     if ((digestSz >= 0) && (blockSz >= 0)) {
         ret = wc_HashInit(&hash, hashType);
     }
+    else {
+        ret = BAD_FUNC_ARG;
+    }
+
     if (ret == 0) {
         ret = wc_HashUpdate(&hash, hashType, (byte*)hmac->opad,
             (word32)blockSz);
@@ -3388,7 +3397,8 @@ static int TLSX_CSR_Parse(WOLFSSL* ssl, const byte* input, word16 length,
                 XFREE(cert, ssl->heap, DYNAMIC_TYPE_DCERT);
                 /* Let's not error out the connection if we can't verify our
                  * cert */
-                if (ret == ASN_SELF_SIGNED_E || ret == ASN_NO_SIGNER_E)
+                if (ret == WC_NO_ERR_TRACE(ASN_SELF_SIGNED_E) ||
+                    ret == WC_NO_ERR_TRACE(ASN_NO_SIGNER_E))
                     ret = 0;
                 return ret;
             }
@@ -4090,7 +4100,7 @@ static void TLSX_PointFormat_FreeAll(PointFormat* list, void* heap)
 static int TLSX_SupportedCurve_Append(SupportedCurve* list, word16 name,
                                                                      void* heap)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     while (list) {
         if (list->name == name) {
@@ -4111,7 +4121,7 @@ static int TLSX_SupportedCurve_Append(SupportedCurve* list, word16 name,
 
 static int TLSX_PointFormat_Append(PointFormat* list, byte format, void* heap)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     while (list) {
         if (list->format == format) {
@@ -4398,7 +4408,7 @@ int TLSX_SupportedCurve_Parse(const WOLFSSL* ssl, const byte* input,
         ret = TLSX_UseSupportedCurve(extensions, name, ssl->heap);
         /* If it is BAD_FUNC_ARG then it is a group we do not support, but
          * that is fine. */
-        if (ret != WOLFSSL_SUCCESS && ret != BAD_FUNC_ARG) {
+        if (ret != WOLFSSL_SUCCESS && ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
             return ret;
         }
     }
@@ -5303,7 +5313,7 @@ static word16 TLSX_SecureRenegotiation_Write(SecureRenegotiation* data,
 static int TLSX_SecureRenegotiation_Parse(WOLFSSL* ssl, const byte* input,
                                           word16 length, byte isRequest)
 {
-    int ret = SECURE_RENEGOTIATION_E;
+    int ret = WC_NO_ERR_TRACE(SECURE_RENEGOTIATION_E);
 
     if (length >= OPAQUE8_LEN) {
         if (isRequest) {
@@ -5313,7 +5323,7 @@ static int TLSX_SecureRenegotiation_Parse(WOLFSSL* ssl, const byte* input,
                 if (ret == WOLFSSL_SUCCESS)
                     ret = 0;
             }
-            if (ret != 0 && ret != SECURE_RENEGOTIATION_E) {
+            if (ret != 0 && ret != WC_NO_ERR_TRACE(SECURE_RENEGOTIATION_E)) {
             }
             else if (ssl->secure_renegotiation == NULL) {
             }
@@ -5383,6 +5393,12 @@ static int TLSX_SecureRenegotiation_Parse(WOLFSSL* ssl, const byte* input,
             }
         #endif
         }
+        else {
+            ret = SECURE_RENEGOTIATION_E;
+        }
+    }
+    else {
+        ret = SECURE_RENEGOTIATION_E;
     }
 
     if (ret != 0) {
@@ -5576,7 +5592,7 @@ static int TLSX_SessionTicket_Parse(WOLFSSL* ssl, const byte* input,
                 WOLFSSL_MSG("Process client ticket rejected, not using");
                 ssl->options.rejectTicket = 1;
                 ret = 0;  /* not fatal */
-            } else if (ret == VERSION_ERROR) {
+            } else if (ret == WC_NO_ERR_TRACE(VERSION_ERROR)) {
                 WOLFSSL_MSG("Process client ticket rejected, bad TLS version");
                 ssl->options.rejectTicket = 1;
                 ret = 0;  /* not fatal */
@@ -5878,7 +5894,7 @@ static void TLSX_UseSRTP_Free(TlsxSrtp *srtp, void* heap)
 static int TLSX_UseSRTP_Parse(WOLFSSL* ssl, const byte* input, word16 length,
     byte isRequest)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
     word16 profile_len = 0;
     word16 profile_value = 0;
     word16 offset = 0;
@@ -7251,7 +7267,7 @@ static int TLSX_KeyShare_GenDhKey(WOLFSSL *ssl, KeyShareEntry* kse)
                     kse->pubKey, &kse->pubKeyLen /* public */
                 );
             #ifdef WOLFSSL_ASYNC_CRYPT
-                if (ret == WC_PENDING_E) {
+                if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                     return ret;
                 }
             #endif
@@ -7564,7 +7580,7 @@ static int TLSX_KeyShare_GenEccKey(WOLFSSL *ssl, KeyShareEntry* kse)
 
         #if defined(WOLFSSL_RENESAS_TSIP_TLS)
             ret = tsip_Tls13GenEccKeyPair(ssl, kse);
-            if (ret != CRYPTOCB_UNAVAILABLE) {
+            if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
                 return ret;
             }
         #endif
@@ -7581,7 +7597,7 @@ static int TLSX_KeyShare_GenEccKey(WOLFSSL *ssl, KeyShareEntry* kse)
                 if (ret == 0) {
             #ifdef WOLFSSL_ASYNC_CRYPT
                     /* Detect when private key generation is done */
-                    if (ssl->error == WC_PENDING_E &&
+                    if (ssl->error == WC_NO_ERR_TRACE(WC_PENDING_E) &&
                             eccKey->type == ECC_PRIVATEKEY) {
                         ret = 0; /* ECC Key Generation is done */
                     }
@@ -7596,7 +7612,7 @@ static int TLSX_KeyShare_GenEccKey(WOLFSSL *ssl, KeyShareEntry* kse)
                     }
                 }
             #ifdef WOLFSSL_ASYNC_CRYPT
-                if (ret == WC_PENDING_E)
+                if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
                     return ret;
             #endif
             }
@@ -7759,7 +7775,7 @@ static int TLSX_KeyShare_GenPqcKey(WOLFSSL *ssl, KeyShareEntry* kse)
 
     findEccPqc(&ecc_group, &oqs_group, kse->group);
     ret = kyber_id2type(oqs_group, &type);
-    if (ret == NOT_COMPILED_IN) {
+    if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN)) {
         WOLFSSL_MSG("Invalid Kyber algorithm specified.");
         ret = BAD_FUNC_ARG;
     }
@@ -8120,7 +8136,7 @@ static int TLSX_KeyShare_ProcessDh(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
             NULL, 0
         );
     #ifdef WOLFSSL_ASYNC_CRYPT
-        if (ret == WC_PENDING_E) {
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             return ret;
         }
     #endif
@@ -8392,7 +8408,7 @@ static int TLSX_KeyShare_ProcessEcc(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
         }
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
         ret = tsip_Tls13GenSharedSecret(ssl, keyShareEntry);
-        if (ret != CRYPTOCB_UNAVAILABLE) {
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
             return ret;
         }
         ret = 0;
@@ -8434,7 +8450,7 @@ static int TLSX_KeyShare_ProcessEcc(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
             ssl->options.side
         );
     #ifdef WOLFSSL_ASYNC_CRYPT
-        if (ret == WC_PENDING_E)
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
             return ret;
     #endif
     }
@@ -8915,7 +8931,7 @@ int TLSX_KeyShare_Parse(WOLFSSL* ssl, const byte* input, word16 length,
 
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* only perform find and clear TLSX if not returning from async */
-        if (ssl->error != WC_PENDING_E)
+        if (ssl->error != WC_NO_ERR_TRACE(WC_PENDING_E))
     #endif
         {
             /* Check the selected group was supported by ClientHello extensions. */
@@ -9386,7 +9402,7 @@ static int TLSX_KeyShare_IsSupported(int namedGroup)
             int id;
             findEccPqc(NULL, &namedGroup, namedGroup);
             ret = kyber_id2type(namedGroup, &id);
-            if (ret == NOT_COMPILED_IN) {
+            if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN)) {
                 return 0;
             }
 
@@ -9557,7 +9573,7 @@ int TLSX_KeyShare_SetSupported(const WOLFSSL* ssl, TLSX** extensions)
         kse = (KeyShareEntry*)extension->data;
         /* We should not be computing keys if we are only going to advertise
          * our choice here. */
-        if (kse != NULL && kse->lastRet == WC_PENDING_E) {
+        if (kse != NULL && kse->lastRet == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
             return BAD_KEY_SHARE_DATA;
         }
@@ -9729,16 +9745,20 @@ int TLSX_KeyShare_Choose(const WOLFSSL *ssl, TLSX* extensions,
 
     if (extension && extension->resp == 1) {
         /* Outside of the async case this path should not be taken. */
-        int ret = INCOMPLETE_DATA;
+        int ret;
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* in async case make sure key generation is finalized */
         KeyShareEntry* serverKSE = (KeyShareEntry*)extension->data;
-        if (serverKSE && serverKSE->lastRet == WC_PENDING_E) {
+        if (serverKSE && serverKSE->lastRet == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             if (ssl->options.serverState == SERVER_HELLO_RETRY_REQUEST_COMPLETE)
                 *searched = 1;
             ret = TLSX_KeyShare_GenKey((WOLFSSL*)ssl, serverKSE);
         }
+        else
     #endif
+        {
+            ret = INCOMPLETE_DATA;
+        }
         return ret;
     }
 
@@ -9813,7 +9833,7 @@ int TLSX_KeyShare_Setup(WOLFSSL *ssl, KeyShareEntry* clientKSE)
             serverKSE = (KeyShareEntry*)extension->data;
             if (serverKSE != NULL) {
                 /* in async case make sure key generation is finalized */
-                if (serverKSE->lastRet == WC_PENDING_E)
+                if (serverKSE->lastRet == WC_NO_ERR_TRACE(WC_PENDING_E))
                     return TLSX_KeyShare_GenKey((WOLFSSL*)ssl, serverKSE);
                 else if (serverKSE->lastRet == 0)
                     return 0;
@@ -9925,7 +9945,7 @@ int TLSX_KeyShare_DeriveSecret(WOLFSSL *ssl)
 #ifdef WOLFSSL_ASYNC_CRYPT
     ret = wolfSSL_AsyncPop(ssl, NULL);
     /* Check for error */
-    if (ret != WC_NO_PENDING_E && ret < 0) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E) && ret < 0) {
         return ret;
     }
 #endif
@@ -11740,7 +11760,7 @@ static int TLSX_ECH_Write(WOLFSSL_ECH* ech, byte* writeBuf, word16* offset)
         /* get size then write */
         ret = GetEchConfigsEx(ech->echConfig, NULL, &configsLen);
 
-        if (ret != LENGTH_ONLY_E)
+        if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
             return ret;
 
         ret = GetEchConfigsEx(ech->echConfig, writeBuf, &configsLen);
@@ -11877,7 +11897,7 @@ static int TLSX_ECH_GetSize(WOLFSSL_ECH* ech)
         /* get the size of the raw configs */
         ret = GetEchConfigsEx(ech->echConfig, NULL, &size);
 
-        if (ret != LENGTH_ONLY_E)
+        if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
             return ret;
     }
     else if (ech->type == ECH_TYPE_INNER)
@@ -11960,7 +11980,7 @@ static int TLSX_ExtractEch(WOLFSSL_ECH* ech, WOLFSSL_EchConfig* echConfig,
     if (ret == 0)
         ret = GetEchConfig(echConfig, NULL, &rawConfigLen);
 
-    if (ret == LENGTH_ONLY_E)
+    if (ret == WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         ret = 0;
 
     /* create info */
@@ -13443,7 +13463,7 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
                     ssl->arrays->psk_keySz == 0 ||
                 #endif
                          (ssl->arrays->psk_keySz > MAX_PSK_KEY_LEN &&
-                     (int)ssl->arrays->psk_keySz != USE_HW_PSK)) {
+                     (int)ssl->arrays->psk_keySz != WC_NO_ERR_TRACE(USE_HW_PSK))) {
                 #ifndef OPENSSL_EXTRA
                     ret = PSK_KEY_ERROR;
                 #endif

--- a/src/tls.c
+++ b/src/tls.c
@@ -883,7 +883,7 @@ static int Hmac_HashFinalRaw(Hmac* hmac, unsigned char* hash)
  */
 static int Hmac_OuterHash(Hmac* hmac, unsigned char* mac)
 {
-    int ret;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
     wc_HashAlg hash;
     enum wc_HashType hashType = (enum wc_HashType)hmac->macType;
     int digestSz = wc_HashGetDigestSize(hashType);
@@ -9745,7 +9745,7 @@ int TLSX_KeyShare_Choose(const WOLFSSL *ssl, TLSX* extensions,
 
     if (extension && extension->resp == 1) {
         /* Outside of the async case this path should not be taken. */
-        int ret;
+        int ret = WC_NO_ERR_TRACE(INCOMPLETE_DATA);
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* in async case make sure key generation is finalized */
         KeyShareEntry* serverKSE = (KeyShareEntry*)extension->data;

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -205,7 +205,7 @@ static int Tls13HKDFExpandLabel(WOLFSSL* ssl, byte* okm, word32 okmLen,
                                 const byte* info, word32 infoLen,
                                 int digest)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
 
 #if defined(HAVE_PK_CALLBACKS)
     if (ssl->ctx && ssl->ctx->HKDFExpandLabelCb) {
@@ -216,7 +216,7 @@ static int Tls13HKDFExpandLabel(WOLFSSL* ssl, byte* okm, word32 okmLen,
                                           WOLFSSL_CLIENT_END /* ignored */);
     }
 
-    if (ret != NOT_COMPILED_IN)
+    if (ret != WC_NO_ERR_TRACE(NOT_COMPILED_IN))
         return ret;
 #endif
     (void)ssl;
@@ -257,7 +257,7 @@ static int Tls13HKDFExpandKeyLabel(WOLFSSL* ssl, byte* okm, word32 okmLen,
                                          info, infoLen,
                                          digest, side);
     }
-    if (ret != NOT_COMPILED_IN)
+    if (ret != WC_NO_ERR_TRACE(NOT_COMPILED_IN))
         return ret;
 #endif
 
@@ -308,7 +308,7 @@ static int DeriveKeyMsg(WOLFSSL* ssl, byte* output, int outputLen,
     const byte* protocol;
     word32      protocolLen;
     int         digestAlg = -1;
-    int         ret = BAD_FUNC_ARG;
+    int         ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     switch (hashAlgo) {
 #ifndef NO_WOLFSSL_SHA256
@@ -364,6 +364,7 @@ static int DeriveKeyMsg(WOLFSSL* ssl, byte* output, int outputLen,
             break;
 #endif
         default:
+            ret = BAD_FUNC_ARG;
             digestAlg = -1;
             break;
     }
@@ -1161,7 +1162,7 @@ int DeriveEarlySecret(WOLFSSL* ssl)
     }
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     ret = tsip_Tls13DeriveEarlySecret(ssl);
-    if (ret != CRYPTOCB_UNAVAILABLE)
+    if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
         return ret;
 #endif
     PRIVATE_KEY_UNLOCK();
@@ -1197,7 +1198,7 @@ int DeriveHandshakeSecret(WOLFSSL* ssl)
     }
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     ret = tsip_Tls13DeriveHandshakeSecret(ssl);
-    if (ret != CRYPTOCB_UNAVAILABLE)
+    if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
         return ret;
 #endif
 
@@ -1232,7 +1233,7 @@ int DeriveMasterSecret(WOLFSSL* ssl)
 
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     ret = tsip_Tls13DeriveMasterSecret(ssl);
-    if (ret != CRYPTOCB_UNAVAILABLE)
+    if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
         return ret;
 #endif
 
@@ -1355,7 +1356,7 @@ static int BuildTls13HandshakeHmac(WOLFSSL* ssl, byte* key, byte* hash,
 #endif
     int  hashType = WC_SHA256;
     int  hashSz = WC_SHA256_DIGEST_SIZE;
-    int  ret = BAD_FUNC_ARG;
+    int  ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     if (ssl == NULL || key == NULL || hash == NULL) {
         return BAD_FUNC_ARG;
@@ -1392,6 +1393,7 @@ static int BuildTls13HandshakeHmac(WOLFSSL* ssl, byte* key, byte* hash,
             break;
     #endif /* WOLFSSL_SM3 */
         default:
+            ret = BAD_FUNC_ARG;
             break;
     }
     if (ret != 0)
@@ -1466,7 +1468,7 @@ static const byte writeIVLabel[WRITE_IV_LABEL_SZ+1]   = "iv";
  */
 int DeriveTls13Keys(WOLFSSL* ssl, int secret, int side, int store)
 {
-    int   ret = BAD_FUNC_ARG; /* Assume failure */
+    int   ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG); /* Assume failure */
     int   i = 0;
 #ifdef WOLFSSL_SMALL_STACK
     byte* key_dig;
@@ -1477,10 +1479,10 @@ int DeriveTls13Keys(WOLFSSL* ssl, int secret, int side, int store)
 
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     ret = tsip_Tls13DeriveKeys(ssl, secret, side);
-    if (ret != CRYPTOCB_UNAVAILABLE) {
+    if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
         return ret;
     }
-    ret = BAD_FUNC_ARG; /* Assume failure */
+    ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG); /* Assume failure */
 #endif
 
 #ifdef WOLFSSL_SMALL_STACK
@@ -1553,6 +1555,7 @@ int DeriveTls13Keys(WOLFSSL* ssl, int secret, int side, int store)
             break;
 
         default:
+            ret = BAD_FUNC_ARG;
             break;
     }
 
@@ -2571,13 +2574,13 @@ static int EncryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
     (void)nonceSz;
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ssl->error == WC_PENDING_E) {
+    if (ssl->error == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ssl->error = 0; /* clear async */
     }
 #endif
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     ret = tsip_Tls13AesEncrypt(ssl, output, input, dataSz);
-    if (ret != CRYPTOCB_UNAVAILABLE) {
+    if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
         if (ret > 0) {
             ret = 0; /* tsip_Tls13AesEncrypt returns output size */
         }
@@ -2650,7 +2653,7 @@ static int EncryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
                                   output + dataSz, macSz,
                                   aad, aadSz);
                     }
-                    if (ret == NOT_COMPILED_IN)
+                    if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN))
                 #endif
                     {
 
@@ -2692,7 +2695,7 @@ static int EncryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
                                   output + dataSz, macSz,
                                   aad, aadSz);
                     }
-                    if (ret == NOT_COMPILED_IN)
+                    if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN))
                 #endif
                     {
                 #if ((defined(HAVE_FIPS) || defined(HAVE_SELFTEST)) && \
@@ -2754,7 +2757,7 @@ static int EncryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
             ssl->encrypt.state = CIPHER_STATE_END;
 
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 /* if async is not okay, then block */
                 if (!asyncOkay) {
                     ret = wc_AsyncWait(ret, asyncDev, event_flags);
@@ -2956,7 +2959,7 @@ int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     ret = tsip_Tls13AesDecrypt(ssl, output, input, sz);
 
-    if (ret != CRYPTOCB_UNAVAILABLE) {
+    if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
         #ifndef WOLFSSL_EARLY_DATA
         if (ret < 0) {
             ret = VERIFY_MAC_ERROR;
@@ -2969,9 +2972,9 @@ int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     ret = wolfSSL_AsyncPop(ssl, &ssl->decrypt.state);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* check for still pending */
-        if (ret == WC_PENDING_E)
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
             return ret;
 
         ssl->error = 0; /* clear async */
@@ -3052,7 +3055,7 @@ int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
                                   (byte *)(input + dataSz), macSz,
                                   aad, aadSz);
                     }
-                    if (ret == NOT_COMPILED_IN)
+                    if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN))
                 #endif
                     {
 
@@ -3061,7 +3064,7 @@ int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
                             input + dataSz, macSz, aad, aadSz);
 
                 #ifdef WOLFSSL_ASYNC_CRYPT
-                        if (ret == WC_PENDING_E) {
+                        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                             ret = wolfSSL_AsyncPush(ssl,
                                 &ssl->decrypt.aes->asyncDev);
                         }
@@ -3091,14 +3094,14 @@ int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
                                   (byte *)(input + dataSz), macSz,
                                   aad, aadSz);
                     }
-                    if (ret == NOT_COMPILED_IN)
+                    if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN))
                 #endif
                     {
                         ret = wc_AesCcmDecrypt(ssl->decrypt.aes, output, input,
                             dataSz, ssl->decrypt.nonce, nonceSz,
                             input + dataSz, macSz, aad, aadSz);
                 #ifdef WOLFSSL_ASYNC_CRYPT
-                        if (ret == WC_PENDING_E) {
+                        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                             ret = wolfSSL_AsyncPush(ssl,
                                 &ssl->decrypt.aes->asyncDev);
                         }
@@ -3148,7 +3151,7 @@ int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
 
         #ifdef WOLFSSL_ASYNC_CRYPT
             /* If pending, leave now */
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 return ret;
             }
         #endif
@@ -3246,7 +3249,7 @@ int BuildTls13Message(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
         args = (BuildMsg13Args*)ssl->async->args;
 
         ret = wolfSSL_AsyncPop(ssl, &ssl->options.buildMsgState);
-        if (ret != WC_NO_PENDING_E) {
+        if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
             /* Check for error */
             if (ret < 0)
                 goto exit_buildmsg;
@@ -3260,7 +3263,7 @@ int BuildTls13Message(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
 
     /* Reset state */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_NO_PENDING_E)
+    if (ret == WC_NO_ERR_TRACE(WC_NO_PENDING_E))
 #endif
     {
         ret = 0;
@@ -3380,7 +3383,7 @@ int BuildTls13Message(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
                                    (word16)args->headerSz, asyncOkay);
                 if (ret != 0) {
                 #ifdef WOLFSSL_ASYNC_CRYPT
-                    if (ret != WC_PENDING_E)
+                    if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
                 #endif
                     {
                         /* Zeroize plaintext. */
@@ -3406,7 +3409,7 @@ exit_buildmsg:
     WOLFSSL_LEAVE("BuildTls13Message", ret);
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         return ret;
     }
 #endif
@@ -3954,7 +3957,7 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
         }
         if (ssl->arrays->psk_keySz == 0 ||
                 (ssl->arrays->psk_keySz > MAX_PSK_KEY_LEN &&
-            (int)ssl->arrays->psk_keySz != USE_HW_PSK)) {
+            (int)ssl->arrays->psk_keySz != WC_NO_ERR_TRACE(USE_HW_PSK))) {
             WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
             return PSK_KEY_ERROR;
         }
@@ -4316,7 +4319,7 @@ int SendTls13ClientHello(WOLFSSL* ssl)
     args = (Sch13Args*)ssl->async->args;
 
     ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* Check for error */
         if (ret < 0)
             return ret;
@@ -5059,10 +5062,10 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     args = (Dsh13Args*)ssl->async->args;
 
     ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* Check for error */
         if (ret < 0) {
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 /* Mark message as not received so it can process again */
                 ssl->msgsReceived.got_server_hello = 0;
             }
@@ -5331,7 +5334,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         if (ret != 0) {
         #ifdef WOLFSSL_ASYNC_CRYPT
             /* Handle async operation */
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 /* Mark message as not received so it can process again */
                 ssl->msgsReceived.got_server_hello = 0;
             }
@@ -5860,7 +5863,7 @@ int FindPskSuite(const WOLFSSL* ssl, PreSharedKey* psk, byte* psk_key,
     }
     if (*found) {
         if (*psk_keySz > MAX_PSK_KEY_LEN &&
-            *((int*)psk_keySz) != USE_HW_PSK) {
+            *((int*)psk_keySz) != WC_NO_ERR_TRACE(USE_HW_PSK)) {
             WOLFSSL_MSG("Key len too long in FindPsk()");
             ret = PSK_KEY_ERROR;
             WOLFSSL_ERROR_VERBOSE(ret);
@@ -6014,7 +6017,7 @@ static int DoPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 inputSz,
         }
 
         #ifdef WOLFSSL_ASYNC_CRYPT
-        if (ret == WC_PENDING_E)
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
             return ret;
         #endif
 
@@ -6214,7 +6217,7 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
         if (ret != 0) {
 #ifdef HAVE_SESSION_TICKET
 #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret != WC_PENDING_E)
+            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
 #endif
                 CleanupClientTickets((PreSharedKey*)ext->data);
 #endif
@@ -6697,7 +6700,7 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     args = (Dch13Args*)ssl->async->args;
 
     ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* Check for error */
         if (ret < 0) {
             goto exit_dch;
@@ -7061,7 +7064,7 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     if (!args->usingPSK) {
         if ((ret = MatchSuite(ssl, args->clSuites)) < 0) {
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret != WC_PENDING_E)
+            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
         #endif
                 WOLFSSL_MSG("Unsupported cipher suite, ClientHello 1.3");
             goto exit_dch;
@@ -7078,7 +7081,7 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             if (ssl->options.serverState == SERVER_HELLO_RETRY_REQUEST_COMPLETE)
                 ERROR_OUT(INVALID_PARAMETER, exit_dch);
             ssl->options.serverState = SERVER_HELLO_RETRY_REQUEST_COMPLETE;
-            if (ret != WC_PENDING_E)
+            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
                 ret = 0; /* for hello_retry return 0 */
         }
         if (ret != 0)
@@ -7100,7 +7103,8 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     TLSX* extension = TLSX_Find(ssl->extensions, TLSX_KEY_SHARE);
     if (extension != NULL && extension->resp == 1) {
         KeyShareEntry* serverKSE = (KeyShareEntry*)extension->data;
-        if (serverKSE != NULL && serverKSE->lastRet == WC_PENDING_E) {
+        if (serverKSE != NULL &&
+            serverKSE->lastRet == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             ret = TLSX_KeyShare_GenKey(ssl, serverKSE);
             if (ret != 0)
                 goto exit_dch;
@@ -7233,7 +7237,7 @@ exit_dch:
     WOLFSSL_LEAVE("DoTls13ClientHello", ret);
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ssl->msgsReceived.got_client_hello = 0;
         return ret;
     }
@@ -8203,7 +8207,7 @@ int CreateRSAEncodedSig(byte* sig, byte* sigData, int sigDataSz,
 {
     Digest digest;
     int    hashSz = 0;
-    int    ret = BAD_FUNC_ARG;
+    int    ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
     byte*  hash;
 
     (void)sigAlgo;
@@ -8248,6 +8252,10 @@ int CreateRSAEncodedSig(byte* sig, byte* sigData, int sigDataSz,
             hashSz = WC_SHA512_DIGEST_SIZE;
             break;
 #endif
+       default:
+            ret = BAD_FUNC_ARG;
+            break;
+
     }
 
     if (ret != 0)
@@ -8269,7 +8277,7 @@ static int CreateECCEncodedSig(byte* sigData, int sigDataSz, int hashAlgo)
 {
     Digest digest;
     int    hashSz = 0;
-    int    ret = BAD_FUNC_ARG;
+    int    ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     /* Digest the signature data. */
     switch (hashAlgo) {
@@ -8310,6 +8318,7 @@ static int CreateECCEncodedSig(byte* sigData, int sigDataSz, int hashAlgo)
             break;
 #endif
         default:
+            ret = BAD_FUNC_ARG;
             break;
     }
 
@@ -8816,7 +8825,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
 
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     ret = tsip_Tls13SendCertVerify(ssl);
-    if (ret != CRYPTOCB_UNAVAILABLE) {
+    if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
         goto exit_scv;
     }
     ret = 0;
@@ -8842,7 +8851,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
     args = (Scv13Args*)ssl->async->args;
 
     ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* Check for error */
         if (ret < 0)
             goto exit_scv;
@@ -9577,7 +9586,7 @@ exit_scv:
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     /* Handle async operation */
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         return ret;
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -9829,7 +9838,7 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
 
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     ret = tsip_Tls13CertificateVerify(ssl, input, inOutIdx, totalSz);
-    if (ret != CRYPTOCB_UNAVAILABLE) {
+    if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
         goto exit_dcv;
     }
     ret = 0;
@@ -9846,7 +9855,7 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
     args = (Dcv13Args*)ssl->async->args;
 
     ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* Check for error */
         if (ret < 0)
             goto exit_dcv;
@@ -10559,7 +10568,7 @@ exit_dcv:
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     /* Handle async operation */
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         /* Mark message as not received so it can process again */
         ssl->msgsReceived.got_certificate_verify = 0;
 
@@ -10570,7 +10579,7 @@ exit_dcv:
     if (ret != 0) {
         WOLFSSL_ERROR_VERBOSE(ret);
 
-        if (ret != INVALID_PARAMETER) {
+        if (ret != WC_NO_ERR_TRACE(INVALID_PARAMETER)) {
             SendAlert(ssl, alert_fatal, decrypt_error);
         }
     }
@@ -10644,11 +10653,11 @@ int DoTls13Finished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         ssl->options.serverState = SERVER_FINISHED_COMPLETE;
         return ret;
     }
-    if (ret == VERIFY_FINISHED_ERROR) {
+    if (ret == WC_NO_ERR_TRACE(VERIFY_FINISHED_ERROR)) {
         SendAlert(ssl, alert_fatal, decrypt_error);
         return ret;
     }
-    if (ret != CRYPTOCB_UNAVAILABLE) {
+    if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
         /* other errors */
         return ret;
     }
@@ -10821,7 +10830,7 @@ static int SendTls13Finished(WOLFSSL* ssl)
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     if (ssl->options.side == WOLFSSL_CLIENT_END) {
         ret = tsip_Tls13SendFinished(ssl, output, outputSz, input, 1);
-        if (ret != CRYPTOCB_UNAVAILABLE) {
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
             return ret;
         }
         ret = 0;
@@ -11658,7 +11667,7 @@ static int SendTls13NewSessionTicket(WOLFSSL* ssl)
     }
     else
     #ifdef WOLFSSL_ASYNC_CRYPT
-        if (ssl->error != WC_PENDING_E)
+        if (ssl->error != WC_NO_ERR_TRACE(WC_PENDING_E))
     #endif
     {
             ssl->session->ticketNonce.data[0]++;
@@ -12338,7 +12347,7 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     /* sanity check msg received */
     if ((ret = SanityCheckTls13MsgReceived(ssl, type)) != 0) {
         WOLFSSL_MSG("Sanity Check on handshake message type received failed");
-        if (ret == VERSION_ERROR)
+        if (ret == WC_NO_ERR_TRACE(VERSION_ERROR))
             SendAlert(ssl, alert_fatal, wolfssl_alert_protocol_version);
         else
             SendAlert(ssl, alert_fatal, unexpected_message);
@@ -12446,7 +12455,8 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         #endif
                ) {
         #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
-            if (ret != WC_PENDING_E && ret != OCSP_WANT_READ)
+            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E) &&
+                ret != WC_NO_ERR_TRACE(OCSP_WANT_READ))
         #endif
             {
                 ssl->options.cacheMessages = 0;
@@ -12535,7 +12545,8 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_ASYNC_IO)
     /* if async, offset index so this msg will be processed again */
     /* NOTE: check this now before other calls can overwrite ret */
-    if ((ret == WC_PENDING_E || ret == OCSP_WANT_READ) && *inOutIdx > 0) {
+    if ((ret == WC_NO_ERR_TRACE(WC_PENDING_E) ||
+         ret == WC_NO_ERR_TRACE(OCSP_WANT_READ)) && *inOutIdx > 0) {
         /* DTLS always stores a message in a buffer when async is enable, so we
          * don't need to adjust for the extra bytes here (*inOutIdx is always
          * == 0) */
@@ -12543,7 +12554,9 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     }
 
     /* make sure async error is cleared */
-    if (ret == 0 && (ssl->error == WC_PENDING_E || ssl->error == OCSP_WANT_READ)) {
+    if (ret == 0 &&
+        (ssl->error == WC_NO_ERR_TRACE(WC_PENDING_E) ||
+         ssl->error == WC_NO_ERR_TRACE(OCSP_WANT_READ))) {
         ssl->error = 0;
     }
 #endif
@@ -12562,7 +12575,7 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         tmp = SendAlert(ssl, alert_fatal, alertType);
         /* propagate socket error instead of tls error to be sure the error is
          * not ignored by DTLS code */
-        if (tmp == SOCKET_ERROR_E)
+        if (tmp == WC_NO_ERR_TRACE(SOCKET_ERROR_E))
             ret = SOCKET_ERROR_E;
     }
 
@@ -12659,7 +12672,7 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 
                 if (wolfSSL_connect_TLSv13(ssl) != WOLFSSL_SUCCESS) {
                     ret = ssl->error;
-                    if (ret != WC_PENDING_E)
+                    if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
                         ret = POST_HAND_AUTH_ERROR;
                 }
             }
@@ -12804,7 +12817,7 @@ int DoTls13HandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                 ssl->arrays->pendingMsgSz - HANDSHAKE_HEADER_SZ,
                                 ssl->arrays->pendingMsgSz);
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 /* setup to process fragment again */
                 ssl->arrays->pendingMsgOffset -= inputLength;
                 *inOutIdx -= inputLength + ssl->keys.padSz;
@@ -13349,7 +13362,7 @@ int wolfSSL_UseKeyShare(WOLFSSL* ssl, word16 group)
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     ret = wolfSSL_AsyncPop(ssl, NULL);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* Check for error */
         if (ret < 0)
             return ret;
@@ -14563,7 +14576,7 @@ int wolfSSL_write_early_data(WOLFSSL* ssl, const void* data, int sz, int* outSz)
         return SIDE_ERROR;
 
     if (ssl->options.handShakeState == NULL_STATE) {
-        if (ssl->error != WC_PENDING_E)
+        if (ssl->error != WC_NO_ERR_TRACE(WC_PENDING_E))
             ssl->earlyData = expecting_early_data;
         ret = wolfSSL_connect_TLSv13(ssl);
         if (ret != WOLFSSL_SUCCESS)
@@ -14627,7 +14640,7 @@ int wolfSSL_read_early_data(WOLFSSL* ssl, void* data, int sz, int* outSz)
         return SIDE_ERROR;
 
     if (ssl->options.handShakeState == NULL_STATE) {
-        if (ssl->error != WC_PENDING_E)
+        if (ssl->error != WC_NO_ERR_TRACE(WC_PENDING_E))
             ssl->earlyData = expecting_early_data;
         /* this used to be: ret = wolfSSL_accept_TLSv13(ssl);
          * However, wolfSSL_accept_TLSv13() expects a certificate to

--- a/src/x509.c
+++ b/src/x509.c
@@ -3362,7 +3362,7 @@ static unsigned long X509NameHash(WOLFSSL_X509_NAME* name,
                 ((unsigned long)digest[1] <<  8) |
                 ((unsigned long)digest[0]));
     }
-    else if (rc == HASH_TYPE_E) {
+    else if (rc == WC_NO_ERR_TRACE(HASH_TYPE_E)) {
         WOLFSSL_ERROR_MSG("Hash function not compiled in");
     }
     else {

--- a/src/x509_str.c
+++ b/src/x509_str.c
@@ -208,25 +208,26 @@ void wolfSSL_X509_STORE_CTX_trusted_stack(WOLFSSL_X509_STORE_CTX *ctx, WOLF_STAC
 int GetX509Error(int e)
 {
     switch (e) {
-        case ASN_BEFORE_DATE_E:
+        case WC_NO_ERR_TRACE(ASN_BEFORE_DATE_E):
             return WOLFSSL_X509_V_ERR_CERT_NOT_YET_VALID;
-        case ASN_AFTER_DATE_E:
+        case WC_NO_ERR_TRACE(ASN_AFTER_DATE_E):
             return WOLFSSL_X509_V_ERR_CERT_HAS_EXPIRED;
-        case ASN_NO_SIGNER_E: /* get issuer error if no CA found locally */
+        case WC_NO_ERR_TRACE(ASN_NO_SIGNER_E):
+            /* get issuer error if no CA found locally */
             return WOLFSSL_X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY;
-        case ASN_SELF_SIGNED_E:
+        case WC_NO_ERR_TRACE(ASN_SELF_SIGNED_E):
             return WOLFSSL_X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT;
-        case ASN_PATHLEN_INV_E:
-        case ASN_PATHLEN_SIZE_E:
+        case WC_NO_ERR_TRACE(ASN_PATHLEN_INV_E):
+        case WC_NO_ERR_TRACE(ASN_PATHLEN_SIZE_E):
             return WOLFSSL_X509_V_ERR_PATH_LENGTH_EXCEEDED;
-        case ASN_SIG_OID_E:
-        case ASN_SIG_CONFIRM_E:
-        case ASN_SIG_HASH_E:
-        case ASN_SIG_KEY_E:
+        case WC_NO_ERR_TRACE(ASN_SIG_OID_E):
+        case WC_NO_ERR_TRACE(ASN_SIG_CONFIRM_E):
+        case WC_NO_ERR_TRACE(ASN_SIG_HASH_E):
+        case WC_NO_ERR_TRACE(ASN_SIG_KEY_E):
             return WOLFSSL_X509_V_ERR_CERT_SIGNATURE_FAILURE;
-        case CRL_CERT_REVOKED:
+        case WC_NO_ERR_TRACE(CRL_CERT_REVOKED):
             return WOLFSSL_X509_V_ERR_CERT_REVOKED;
-        case CRL_MISSING:
+        case WC_NO_ERR_TRACE(CRL_MISSING):
             return X509_V_ERR_UNABLE_TO_GET_CRL;
         case 0:
         case 1:
@@ -270,7 +271,8 @@ int wolfSSL_X509_verify_cert(WOLFSSL_X509_STORE_CTX* ctx)
         SetupStoreCtxError(ctx, ret);
 
     #ifndef NO_ASN_TIME
-        if (ret != ASN_BEFORE_DATE_E && ret != ASN_AFTER_DATE_E) {
+        if (ret != WC_NO_ERR_TRACE(ASN_BEFORE_DATE_E) &&
+            ret != WC_NO_ERR_TRACE(ASN_AFTER_DATE_E)) {
             /* wolfSSL_CertManagerVerifyBuffer only returns ASN_AFTER_DATE_E or
              ASN_BEFORE_DATE_E if there are no additional errors found in the
              cert. Therefore, check if the cert is expired or not yet valid

--- a/support/gen-debug-trace-error-codes.sh
+++ b/support/gen-debug-trace-error-codes.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+awk '
+BEGIN {
+    print("/* automatically generated, do not edit */") > "wolfssl/debug-trace-error-codes.h";
+    print("#ifndef WOLFSSL_DEBUG_TRACE_ERROR_CODES_H") >> "wolfssl/debug-trace-error-codes.h";
+    print("#define WOLFSSL_DEBUG_TRACE_ERROR_CODES_H") >> "wolfssl/debug-trace-error-codes.h";
+    print("") >> "wolfssl/debug-trace-error-codes.h";
+
+    print("/* automatically generated, do not edit */") > "wolfssl/debug-untrace-error-codes.h";
+    print("#ifdef WOLFSSL_DEBUG_TRACE_ERROR_CODES_H") >> "wolfssl/debug-untrace-error-codes.h";
+    print("#undef WOLFSSL_DEBUG_TRACE_ERROR_CODES_H") >> "wolfssl/debug-untrace-error-codes.h";
+}
+{
+    if (match($0, "^[[:space:]]+([A-Z][A-Z0-9_]+)[[:space:]]*=[[:space:]]*(-[0-9]+)[,[:space:]]", errcode_a)) {
+        if ((errcode_a[1] == "MIN_CODE_E") ||
+            (errcode_a[1] == "WC_LAST_E") ||
+            (errcode_a[1] == "MAX_CODE_E"))
+        {
+            next;
+        }
+        printf("#define %s WC_ERR_TRACE(%s)\n#define CONST_NUM_ERR_%s (%s)\n", errcode_a[1], errcode_a[1], errcode_a[1], errcode_a[2]) >> "wolfssl/debug-trace-error-codes.h";
+        printf("#undef %s\n#undef CONST_NUM_ERR_%s\n", errcode_a[1], errcode_a[1]) >> "wolfssl/debug-untrace-error-codes.h";
+    }
+}
+END {
+    print("") >> "wolfssl/debug-trace-error-codes.h";
+    print("#endif /* WOLFSSL_DEBUG_TRACE_ERROR_CODES_H */") >> "wolfssl/debug-trace-error-codes.h";
+
+    print("") >> "wolfssl/debug-untrace-error-codes.h";
+    print("#endif /* WOLFSSL_DEBUG_TRACE_ERROR_CODES_H */") >> "wolfssl/debug-untrace-error-codes.h";
+}' wolfssl/wolfcrypt/error-crypt.h wolfssl/error-ssl.h

--- a/support/include.am
+++ b/support/include.am
@@ -2,7 +2,8 @@
 # All paths should be given relative to the root
 #
 
-EXTRA_DIST += support/wolfssl.pc
+EXTRA_DIST += support/wolfssl.pc \
+              support/gen-debug-trace-error-codes.sh
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = support/wolfssl.pc

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -727,7 +727,8 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
                 return MEMORY_E;
 #endif
 
-            if (AES_set_encrypt_key_AESNI(userKey,bits,temp_key) == BAD_FUNC_ARG) {
+            if (AES_set_encrypt_key_AESNI(userKey,bits,temp_key)
+                == WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
 #ifdef WOLFSSL_SMALL_STACK
                 XFREE(temp_key, aes->heap, DYNAMIC_TYPE_AES);
 #endif
@@ -5514,7 +5515,7 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
         #endif
         {
             int crypto_cb_ret = wc_CryptoCb_AesCbcEncrypt(aes, out, in, sz);
-            if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
+            if (crypto_cb_ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                 return crypto_cb_ret;
             /* fall-through when unavailable */
         }
@@ -5683,7 +5684,7 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
         #endif
         {
             int crypto_cb_ret = wc_CryptoCb_AesCbcDecrypt(aes, out, in, sz);
-            if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
+            if (crypto_cb_ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                 return crypto_cb_ret;
             /* fall-through when unavailable */
         }
@@ -6073,7 +6074,7 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
             #endif
             {
                 int crypto_cb_ret = wc_CryptoCb_AesCtrEncrypt(aes, out, in, sz);
-                if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
+                if (crypto_cb_ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                     return crypto_cb_ret;
                 /* fall-through when unavailable */
             }
@@ -8324,7 +8325,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
         int crypto_cb_ret =
             wc_CryptoCb_AesGcmEncrypt(aes, out, in, sz, iv, ivSz, authTag,
                                       authTagSz, authIn, authInSz);
-        if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
+        if (crypto_cb_ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return crypto_cb_ret;
         /* fall-through when unavailable */
     }
@@ -8867,7 +8868,7 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
 {
     int ret;
 #ifdef WOLFSSL_AESNI
-    int res = AES_GCM_AUTH_E;
+    int res = WC_NO_ERR_TRACE(AES_GCM_AUTH_E);
 #endif
 
     /* argument checks */
@@ -8888,7 +8889,7 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
         int crypto_cb_ret =
             wc_CryptoCb_AesGcmDecrypt(aes, out, in, sz, iv, ivSz,
                                       authTag, authTagSz, authIn, authInSz);
-        if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
+        if (crypto_cb_ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return crypto_cb_ret;
         /* fall-through when unavailable */
     }
@@ -10773,7 +10774,7 @@ int wc_AesCcmEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
         int crypto_cb_ret =
             wc_CryptoCb_AesCcmEncrypt(aes, out, in, inSz, nonce, nonceSz,
                                       authTag, authTagSz, authIn, authInSz);
-        if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
+        if (crypto_cb_ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return crypto_cb_ret;
         /* fall-through when unavailable */
     }
@@ -10915,7 +10916,7 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
         int crypto_cb_ret =
             wc_CryptoCb_AesCcmDecrypt(aes, out, in, inSz, nonce, nonceSz,
             authTag, authTagSz, authIn, authInSz);
-        if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
+        if (crypto_cb_ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return crypto_cb_ret;
         /* fall-through when unavailable */
     }
@@ -11423,7 +11424,7 @@ static WARN_UNUSED_RESULT int _AesEcbEncrypt(
     #endif
     {
         ret = wc_CryptoCb_AesEcbEncrypt(aes, out, in, sz);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         ret = 0;
         /* fall-through when unavailable */
@@ -11475,7 +11476,7 @@ static WARN_UNUSED_RESULT int _AesEcbDecrypt(
     #endif
     {
         ret = wc_CryptoCb_AesEcbDecrypt(aes, out, in, sz);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         ret = 0;
         /* fall-through when unavailable */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -6933,7 +6933,7 @@ int ToTraditionalInline_ex(const byte* input, word32* inOutIdx, word32 sz,
 
     ret = GetOctetString(input, &idx, &length, sz);
     if (ret < 0) {
-        if (ret == BUFFER_E)
+        if (ret == WC_NO_ERR_TRACE(BUFFER_E))
             return ASN_PARSE_E;
         /* Some private keys don't expect an octet string */
         WOLFSSL_MSG("Couldn't find Octet string");
@@ -8647,7 +8647,7 @@ int TraditionalEnc(byte* key, word32 keySz, byte* out, word32* outSz,
     if (ret == 0) {
         ret = wc_CreatePKCS8Key(NULL, &pkcs8KeySz, key, keySz, algId, curveOid,
                                                                     curveOidSz);
-        if (ret == LENGTH_ONLY_E)
+        if (ret == WC_NO_ERR_TRACE(LENGTH_ONLY_E))
             ret = 0;
     }
     if (ret == 0) {
@@ -9957,7 +9957,7 @@ int wc_DhKeyDecode(const byte* input, word32* inOutIdx, DhKey* key, word32 inSz)
     #if !defined(HAVE_FIPS) || \
         (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION > 2))
     /* If ASN_DH_KEY_E: Check if input started at beginning of key */
-    if (ret == ASN_DH_KEY_E) {
+    if (ret == WC_NO_ERR_TRACE(ASN_DH_KEY_E)) {
         *inOutIdx = temp;
 
         /* the version (0) - private only (for public skip) */
@@ -10118,7 +10118,7 @@ int wc_DhKeyToDer(DhKey* key, byte* output, word32* outSz, int exportPriv)
     /* DH Parameters sequence with P and G */
     total = 0;
     ret = wc_DhParamsToDer(key, NULL, &total);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         return ret;
     idx += total;
 
@@ -10767,7 +10767,7 @@ int wc_DsaPrivateKeyDecode(const byte* input, word32* inOutIdx, DsaKey* key,
         }
     }
     /* An alternate pass if default certificate fails parsing */
-    if (ret == ASN_PARSE_E) {
+    if (ret == WC_NO_ERR_TRACE(ASN_PARSE_E)) {
         *inOutIdx = (word32)temp;
         if (GetMyVersion(input, inOutIdx, &version, inSz) < 0)
             return ASN_PARSE_E;
@@ -11800,7 +11800,7 @@ static int SetEccPublicKey(byte* output, ecc_key* key, int outLen,
     #endif
         PRIVATE_KEY_LOCK();
         /* LENGTH_ONLY_E on success. */
-        if (ret == LENGTH_ONLY_E) {
+        if (ret == WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
             ret = 0;
         }
     }
@@ -17252,7 +17252,8 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
                     !defined(WOLFSSL_RENESAS_TSIP_TLS)
                     else
                 #else
-                    if (!sigCtx->pkCbRsa || ret == CRYPTOCB_UNAVAILABLE)
+                    if (!sigCtx->pkCbRsa ||
+                        ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                 #endif /* WOLFSSL_RENESAS_FSPSM_TLS */
                 #endif /* HAVE_PK_CALLBACKS */
                     {
@@ -17326,7 +17327,8 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
                     !defined(WOLFSSL_RENESAS_TSIP_TLS)
                     else
                 #else
-                    if (!sigCtx->pkCbEcc || ret == CRYPTOCB_UNAVAILABLE)
+                    if (!sigCtx->pkCbEcc ||
+                        ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                 #endif /* WOLFSSL_RENESAS_FSPSM_TLS */
                 #endif /* HAVE_PK_CALLBACKS */
                     {
@@ -17396,7 +17398,7 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
             }  /* switch (keyOID) */
 
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 goto exit_cs;
             }
         #endif
@@ -17695,7 +17697,7 @@ exit_cs:
     WOLFSSL_LEAVE("ConfirmSignature", ret);
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E)
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
         return ret;
 #endif
 
@@ -19851,7 +19853,7 @@ static int DecodeExtKeyUsage(const byte* input, word32 sz, DecodedCert* cert)
 
     while (idx < (word32)sz) {
         ret = GetObjectId(input, &idx, &oid, oidCertKeyUseType, sz);
-        if (ret == ASN_UNKNOWN_OID_E)
+        if (ret == WC_NO_ERR_TRACE(ASN_UNKNOWN_OID_E))
             continue;
         else if (ret < 0)
             return ret;
@@ -19931,7 +19933,7 @@ static int DecodeExtKeyUsage(const byte* input, word32 sz, DecodedCert* cert)
         ret = GetASN_Items(keyPurposeIdASN, dataASN, keyPurposeIdASN_Length, 0,
                            input, &idx, sz);
         /* Skip unknown OIDs. */
-        if (ret == ASN_UNKNOWN_OID_E) {
+        if (ret == WC_NO_ERR_TRACE(ASN_UNKNOWN_OID_E)) {
             ret = 0;
         }
         else if (ret == 0) {
@@ -21455,7 +21457,7 @@ static int DecodeCertExtensions(DecodedCert* cert)
 
         ret = DecodeExtensionType(input + idx, (word32)length, oid, critical,
             cert, NULL);
-        if (ret == ASN_CRIT_EXT_E) {
+        if (ret == WC_NO_ERR_TRACE(ASN_CRIT_EXT_E)) {
             ret = 0;
             criticalFail = 1;
         }
@@ -21545,7 +21547,7 @@ end:
         }
         /* Don't fail criticality until all other extensions have been checked.
          */
-        if (ret == ASN_CRIT_EXT_E) {
+        if (ret == WC_NO_ERR_TRACE(ASN_CRIT_EXT_E)) {
             criticalRet = ASN_CRIT_EXT_E;
             ret = 0;
         }
@@ -22081,7 +22083,7 @@ static int DecodeCertInternal(DecodedCert* cert, int verify, int* criticalExt,
         /* Decode the extension data starting at [3]. */
         ret = DecodeCertExtensions(cert);
         if (criticalExt != NULL) {
-            if (ret == ASN_CRIT_EXT_E) {
+            if (ret == WC_NO_ERR_TRACE(ASN_CRIT_EXT_E)) {
                 /* Return critical extension not recognized. */
                 *criticalExt = ret;
                 ret = 0;
@@ -22272,7 +22274,7 @@ static int DecodeCertReqAttrValue(DecodedCert* cert, int* criticalExt,
 
             /* Decode and validate extensions. */
             ret = DecodeCertExtensions(cert);
-            if (ret == ASN_CRIT_EXT_E) {
+            if (ret == WC_NO_ERR_TRACE(ASN_CRIT_EXT_E)) {
                 /* Return critical extension not recognized. */
                 *criticalExt = ret;
                 ret = 0;
@@ -23415,7 +23417,8 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
         cert->badDate = 0;
         cert->criticalExt = 0;
         if ((ret = DecodeToKey(cert, verify)) < 0) {
-            if (ret == ASN_BEFORE_DATE_E || ret == ASN_AFTER_DATE_E) {
+            if (ret == WC_NO_ERR_TRACE(ASN_BEFORE_DATE_E) ||
+                ret == WC_NO_ERR_TRACE(ASN_AFTER_DATE_E)) {
                 cert->badDate = ret;
                 if (verify == VERIFY_SKIP_DATE)
                     ret = 0;
@@ -23578,7 +23581,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
                         cert->extensionsIdx = cert->srcIdx; /* for potential later use */
 
                         if ((ret = DecodeCertExtensions(cert)) < 0) {
-                            if (ret == ASN_CRIT_EXT_E) {
+                            if (ret == WC_NO_ERR_TRACE(ASN_CRIT_EXT_E)) {
                                 cert->criticalExt = ret;
                             }
                             else {
@@ -23612,7 +23615,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
             cert->extensionsIdx = cert->srcIdx;   /* for potential later use */
 
             if ((ret = DecodeCertExtensions(cert)) < 0) {
-                if (ret == ASN_CRIT_EXT_E)
+                if (ret == WC_NO_ERR_TRACE(ASN_CRIT_EXT_E))
                     cert->criticalExt = ret;
                 else
                     return ret;
@@ -23665,7 +23668,8 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
 #endif
         {
             ret = DecodeCert(cert, verify, &cert->criticalExt);
-            if (ret == ASN_BEFORE_DATE_E || ret == ASN_AFTER_DATE_E) {
+            if (ret == WC_NO_ERR_TRACE(ASN_BEFORE_DATE_E) ||
+                ret == WC_NO_ERR_TRACE(ASN_AFTER_DATE_E)) {
                 cert->badDate = ret;
                 if (verify == VERIFY_SKIP_DATE)
                     ret = 0;
@@ -23882,7 +23886,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
                         NULL, 0,
                     #endif
                         sce_tsip_encRsaKeyIdx)) != 0) {
-                    if (ret != WC_PENDING_E) {
+                    if (ret != WC_NO_ERR_TRACE(WC_PENDING_E)) {
                         WOLFSSL_MSG("Confirm signature failed");
                     }
                     WOLFSSL_ERROR_VERBOSE(ret);
@@ -23955,7 +23959,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
                     NULL, 0,
                 #endif
                     sce_tsip_encRsaKeyIdx)) != 0) {
-                if (ret != WC_PENDING_E) {
+                if (ret != WC_NO_ERR_TRACE(WC_PENDING_E)) {
                     WOLFSSL_MSG("Confirm signature failed");
                 }
                 WOLFSSL_ERROR_VERBOSE(ret);
@@ -24295,7 +24299,7 @@ int wc_GetSerialNumber(const byte* input, word32* inOutIdx,
 
 int AllocDer(DerBuffer** pDer, word32 length, int type, void* heap)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
     if (pDer) {
         int dynType = 0;
         DerBuffer* der;
@@ -24326,6 +24330,8 @@ int AllocDer(DerBuffer** pDer, word32 length, int type, void* heap)
         der->buffer = (byte*)der + sizeof(DerBuffer);
         der->length = length;
         ret = 0; /* Success */
+    } else {
+        ret = BAD_FUNC_ARG;
     }
     return ret;
 }
@@ -24474,7 +24480,7 @@ static WC_INLINE const char* SkipEndOfLineChars(const char* line,
 
 int wc_PemGetHeaderFooter(int type, const char** header, const char** footer)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     switch (type) {
         case CA_TYPE:       /* same as below */
@@ -24650,6 +24656,7 @@ int wc_PemGetHeaderFooter(int type, const char** header, const char** footer)
             ret = 0;
             break;
         default:
+            ret = BAD_FUNC_ARG;
             break;
     }
     return ret;
@@ -24952,7 +24959,7 @@ int wc_DerToPemEx(const byte* der, word32 derSz, byte* output, word32 outSz,
 #endif
         outLen = 0;
         if ((err = Base64_Encode(der, derSz, NULL, (word32*)&outLen))
-                != LENGTH_ONLY_E) {
+                != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
             WOLFSSL_ERROR_VERBOSE(err);
             return err;
         }
@@ -25896,7 +25903,7 @@ static DNS_entry* FindAltName(struct DecodedCert* cert, int nameType,
 /* returns 0 on success */
 int wc_GetUUIDFromCert(struct DecodedCert* cert, byte* uuid, word32* uuidSz)
 {
-    int ret = ALT_NAME_E;
+    int ret = WC_NO_ERR_TRACE(ALT_NAME_E);
     DNS_entry* id = NULL;
 
     do {
@@ -25933,7 +25940,7 @@ int wc_GetUUIDFromCert(struct DecodedCert* cert, byte* uuid, word32* uuidSz)
 /* returns 0 on success */
 int wc_GetFASCNFromCert(struct DecodedCert* cert, byte* fascn, word32* fascnSz)
 {
-    int ret = ALT_NAME_E;
+    int ret = WC_NO_ERR_TRACE(ALT_NAME_E);
     DNS_entry* id = NULL;
 
     do {
@@ -29881,7 +29888,7 @@ static int MakeSignature(CertSignCtx* certSignCtx, const byte* buf, word32 sz,
 exit_ms:
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         return ret;
     }
 #endif
@@ -31575,7 +31582,7 @@ static int SignCert(int requestSz, int sType, byte* buf, word32 buffSz,
         MAX_ENCODED_SIG_SZ, rsaKey, eccKey, ed25519Key, ed448Key,
         falconKey, dilithiumKey, sphincsKey, rng, (word32)sType, heap);
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (sigSz == WC_PENDING_E) {
+    if (sigSz == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         /* Not free'ing certSignCtx->sig here because it could still be in use
          * with async operations. */
         return sigSz;
@@ -31688,7 +31695,7 @@ int wc_MakeSigWithBitStr(byte *sig, int sigSz, int sType, byte* buf,
         MAX_ENCODED_SIG_SZ, rsaKey, eccKey, ed25519Key, ed448Key,
         falconKey, dilithiumKey, sphincsKey, rng, (word32)sType, heap);
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         /* Not free'ing certSignCtx->sig here because it could still be in use
          * with async operations. */
         return ret;
@@ -34385,7 +34392,7 @@ int wc_BuildEccKeyDer(ecc_key* key, byte* output, word32 *inLen,
         PRIVATE_KEY_UNLOCK();
         ret = wc_ecc_export_x963(key, NULL, &pubSz);
         PRIVATE_KEY_LOCK();
-        if (ret != LENGTH_ONLY_E) {
+        if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
         #ifndef WOLFSSL_NO_MALLOC
             XFREE(prv, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
         #endif
@@ -34509,7 +34516,7 @@ int wc_BuildEccKeyDer(ecc_key* key, byte* output, word32 *inLen,
             PRIVATE_KEY_UNLOCK();
             ret = wc_ecc_export_x963(key, NULL, &pubSz);
             PRIVATE_KEY_LOCK();
-            if (ret == LENGTH_ONLY_E)
+            if (ret == WC_NO_ERR_TRACE(LENGTH_ONLY_E))
                 ret = 0;
         }
     }
@@ -34611,7 +34618,7 @@ int wc_EccKeyDerSize(ecc_key* key, int pub)
 
     ret = wc_BuildEccKeyDer(key, NULL, &sz, pub, 1);
 
-    if (ret != LENGTH_ONLY_E) {
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
         return ret;
     }
     return (int)sz;
@@ -34678,7 +34685,7 @@ static int eccToPKCS8(ecc_key* key, byte* output, word32* outLen,
     /* get pkcs8 expected output size */
     ret = wc_CreatePKCS8Key(NULL, &pkcs8Sz, tmpDer, tmpDerSz, algoID,
                             curveOID, oidSz);
-    if (ret != LENGTH_ONLY_E) {
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
     #ifndef WOLFSSL_NO_MALLOC
         XFREE(tmpDer, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
     #endif
@@ -39322,7 +39329,7 @@ static void PrintObjectIdText(Asn1* asn1, Asn1PrintOptions* opts)
 
     /* Get the OID value for the OBJECT_ID. */
     if (GetObjectId(asn1->data + asn1->offset, &i, &oid, oidIgnoreType,
-            asn1->item.len + 2) == ASN_PARSE_E) {
+            asn1->item.len + 2) == WC_NO_ERR_TRACE(ASN_PARSE_E)) {
         known = 0;
     }
     else

--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -134,7 +134,7 @@ int wc_InitCmac_ex(Cmac* cmac, const byte* key, word32 keySz,
 
         ret = wc_CryptoCb_Cmac(cmac, key, keySz, NULL, 0, NULL, NULL,
                 type, unused);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
     }
@@ -202,7 +202,7 @@ int wc_CmacUpdate(Cmac* cmac, const byte* in, word32 inSz)
     {
         ret = wc_CryptoCb_Cmac(cmac, NULL, 0, in, inSz,
                 NULL, NULL, 0, NULL);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
     }
@@ -270,7 +270,7 @@ int wc_CmacFinalNoFree(Cmac* cmac, byte* out, word32* outSz)
     #endif
     {
         ret = wc_CryptoCb_Cmac(cmac, NULL, 0, NULL, 0, out, outSz, 0, NULL);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
     }
@@ -340,7 +340,7 @@ int wc_AesCmacGenerate_ex(Cmac* cmac,
 
         ret = wc_CryptoCb_Cmac(cmac, key, keySz, in, inSz, out, outSz,
                 WC_CMAC_AES, NULL);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
 
          /* Clear CRYPTOCB_UNAVAILABLE return code */

--- a/wolfcrypt/src/coding.c
+++ b/wolfcrypt/src/coding.c
@@ -181,7 +181,7 @@ int Base64_Decode(const byte* in, word32 inLen, byte* out, word32* outLen)
         byte e1, e2, e3, e4;
 
         if ((ret = Base64_SkipNewline(in, &inLen, &j)) != 0) {
-            if (ret == BUFFER_E) {
+            if (ret == WC_NO_ERR_TRACE(BUFFER_E)) {
                 /* Running out of buffer here is not an error */
                 break;
             }

--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -260,9 +260,9 @@ static CryptoCb* wc_CryptoCb_FindDeviceByIndex(int startIdx)
 
 static WC_INLINE int wc_CryptoCb_TranslateErrorCode(int ret)
 {
-    if (ret == NOT_COMPILED_IN) {
+    if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN)) {
         /* backwards compatibility for older NOT_COMPILED_IN syntax */
-        ret = CRYPTOCB_UNAVAILABLE;
+        ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     }
     return ret;
 }
@@ -344,8 +344,8 @@ int wc_CryptoCb_RegisterDevice(int devId, CryptoDevCallbackFunc cb, void* ctx)
             /* Success.  Update dev->ctx */
             dev->ctx = info.cmd.ctx;
         }
-        else if ((rc == CRYPTOCB_UNAVAILABLE) ||
-                 (rc == NOT_COMPILED_IN)) {
+        else if ((rc == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) ||
+                 (rc == WC_NO_ERR_TRACE(NOT_COMPILED_IN))) {
             /* Not implemented.  Return success*/
             rc = 0;
         }
@@ -391,7 +391,7 @@ void wc_CryptoCb_UnRegisterDevice(int devId)
 int wc_CryptoCb_Rsa(const byte* in, word32 inLen, byte* out,
     word32* outLen, int type, RsaKey* key, WC_RNG* rng)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     if (key == NULL)
@@ -421,7 +421,7 @@ int wc_CryptoCb_Rsa(const byte* in, word32 inLen, byte* out,
 #ifdef WOLFSSL_KEY_GEN
 int wc_CryptoCb_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     if (key == NULL)
@@ -449,7 +449,7 @@ int wc_CryptoCb_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
 int wc_CryptoCb_RsaCheckPrivKey(RsaKey* key, const byte* pubKey,
     word32 pubKeySz)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     if (key == NULL)
@@ -474,7 +474,7 @@ int wc_CryptoCb_RsaCheckPrivKey(RsaKey* key, const byte* pubKey,
 
 int wc_CryptoCb_RsaGetSize(const RsaKey* key, int* keySize)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     if (key == NULL)
@@ -500,7 +500,7 @@ int wc_CryptoCb_RsaGetSize(const RsaKey* key, int* keySize)
 #ifdef HAVE_ECC
 int wc_CryptoCb_MakeEccKey(WC_RNG* rng, int keySize, ecc_key* key, int curveId)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     if (key == NULL)
@@ -527,7 +527,7 @@ int wc_CryptoCb_MakeEccKey(WC_RNG* rng, int keySize, ecc_key* key, int curveId)
 int wc_CryptoCb_Ecdh(ecc_key* private_key, ecc_key* public_key,
     byte* out, word32* outlen)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     if (private_key == NULL)
@@ -554,7 +554,7 @@ int wc_CryptoCb_Ecdh(ecc_key* private_key, ecc_key* public_key,
 int wc_CryptoCb_EccSign(const byte* in, word32 inlen, byte* out,
     word32 *outlen, WC_RNG* rng, ecc_key* key)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     if (key == NULL)
@@ -583,7 +583,7 @@ int wc_CryptoCb_EccSign(const byte* in, word32 inlen, byte* out,
 int wc_CryptoCb_EccVerify(const byte* sig, word32 siglen,
     const byte* hash, word32 hashlen, int* res, ecc_key* key)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     if (key == NULL)
@@ -612,7 +612,7 @@ int wc_CryptoCb_EccVerify(const byte* sig, word32 siglen,
 int wc_CryptoCb_EccCheckPrivKey(ecc_key* key, const byte* pubKey,
     word32 pubKeySz)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     if (key == NULL)
@@ -640,7 +640,7 @@ int wc_CryptoCb_EccCheckPrivKey(ecc_key* key, const byte* pubKey,
 int wc_CryptoCb_Curve25519Gen(WC_RNG* rng, int keySize,
     curve25519_key* key)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     if (key == NULL)
@@ -666,7 +666,7 @@ int wc_CryptoCb_Curve25519Gen(WC_RNG* rng, int keySize,
 int wc_CryptoCb_Curve25519(curve25519_key* private_key,
     curve25519_key* public_key, byte* out, word32* outlen, int endian)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     if (private_key == NULL)
@@ -696,7 +696,7 @@ int wc_CryptoCb_Curve25519(curve25519_key* private_key,
 int wc_CryptoCb_Ed25519Gen(WC_RNG* rng, int keySize,
     ed25519_key* key)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     if (key == NULL)
@@ -723,7 +723,7 @@ int wc_CryptoCb_Ed25519Sign(const byte* in, word32 inLen, byte* out,
                             word32 *outLen, ed25519_key* key, byte type,
                             const byte* context, byte contextLen)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     if (key == NULL)
@@ -755,7 +755,7 @@ int wc_CryptoCb_Ed25519Verify(const byte* sig, word32 sigLen,
     const byte* msg, word32 msgLen, int* res, ed25519_key* key, byte type,
     const byte* context, byte contextLen)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     if (key == NULL)
@@ -805,7 +805,7 @@ int wc_CryptoCb_PqcKemGetDevId(int type, void* key)
 
 int wc_CryptoCb_MakePqcKemKey(WC_RNG* rng, int type, int keySize, void* key)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     int devId = INVALID_DEVID;
     CryptoCb* dev;
 
@@ -839,7 +839,7 @@ int wc_CryptoCb_PqcEncapsulate(byte* ciphertext, word32 ciphertextLen,
     byte* sharedSecret, word32 sharedSecretLen, WC_RNG* rng, int type,
     void* key)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     int devId = INVALID_DEVID;
     CryptoCb* dev;
 
@@ -875,7 +875,7 @@ int wc_CryptoCb_PqcEncapsulate(byte* ciphertext, word32 ciphertextLen,
 int wc_CryptoCb_PqcDecapsulate(const byte* ciphertext, word32 ciphertextLen,
     byte* sharedSecret, word32 sharedSecretLen, int type, void* key)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     int devId = INVALID_DEVID;
     CryptoCb* dev;
 
@@ -934,7 +934,7 @@ int wc_CryptoCb_PqcSigGetDevId(int type, void* key)
 int wc_CryptoCb_MakePqcSignatureKey(WC_RNG* rng, int type, int keySize,
     void* key)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     int devId = INVALID_DEVID;
     CryptoCb* dev;
 
@@ -967,7 +967,7 @@ int wc_CryptoCb_MakePqcSignatureKey(WC_RNG* rng, int type, int keySize,
 int wc_CryptoCb_PqcSign(const byte* in, word32 inlen, byte* out, word32 *outlen,
     WC_RNG* rng, int type, void* key)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     int devId = INVALID_DEVID;
     CryptoCb* dev;
 
@@ -1003,7 +1003,7 @@ int wc_CryptoCb_PqcSign(const byte* in, word32 inlen, byte* out, word32 *outlen,
 int wc_CryptoCb_PqcVerify(const byte* sig, word32 siglen, const byte* msg,
     word32 msglen, int* res, int type, void* key)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     int devId = INVALID_DEVID;
     CryptoCb* dev;
 
@@ -1039,7 +1039,7 @@ int wc_CryptoCb_PqcVerify(const byte* sig, word32 siglen, const byte* msg,
 int wc_CryptoCb_PqcSignatureCheckPrivKey(void* key, int type,
     const byte* pubKey, word32 pubKeySz)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     int devId = INVALID_DEVID;
     CryptoCb* dev;
 
@@ -1078,7 +1078,7 @@ int wc_CryptoCb_AesGcmEncrypt(Aes* aes, byte* out,
                                byte* authTag, word32 authTagSz,
                                const byte* authIn, word32 authInSz)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -1119,7 +1119,7 @@ int wc_CryptoCb_AesGcmDecrypt(Aes* aes, byte* out,
                                const byte* authTag, word32 authTagSz,
                                const byte* authIn, word32 authInSz)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -1162,7 +1162,7 @@ int wc_CryptoCb_AesCcmEncrypt(Aes* aes, byte* out,
                                byte* authTag, word32 authTagSz,
                                const byte* authIn, word32 authInSz)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -1203,7 +1203,7 @@ int wc_CryptoCb_AesCcmDecrypt(Aes* aes, byte* out,
                                const byte* authTag, word32 authTagSz,
                                const byte* authIn, word32 authInSz)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -1243,7 +1243,7 @@ int wc_CryptoCb_AesCcmDecrypt(Aes* aes, byte* out,
 int wc_CryptoCb_AesCbcEncrypt(Aes* aes, byte* out,
                                const byte* in, word32 sz)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -1275,7 +1275,7 @@ int wc_CryptoCb_AesCbcEncrypt(Aes* aes, byte* out,
 int wc_CryptoCb_AesCbcDecrypt(Aes* aes, byte* out,
                                const byte* in, word32 sz)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -1308,7 +1308,7 @@ int wc_CryptoCb_AesCbcDecrypt(Aes* aes, byte* out,
 int wc_CryptoCb_AesCtrEncrypt(Aes* aes, byte* out,
                                const byte* in, word32 sz)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -1341,7 +1341,7 @@ int wc_CryptoCb_AesCtrEncrypt(Aes* aes, byte* out,
 int wc_CryptoCb_AesEcbEncrypt(Aes* aes, byte* out,
                                const byte* in, word32 sz)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -1373,7 +1373,7 @@ int wc_CryptoCb_AesEcbEncrypt(Aes* aes, byte* out,
 int wc_CryptoCb_AesEcbDecrypt(Aes* aes, byte* out,
                                const byte* in, word32 sz)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -1408,7 +1408,7 @@ int wc_CryptoCb_AesEcbDecrypt(Aes* aes, byte* out,
 int wc_CryptoCb_Des3Encrypt(Des3* des3, byte* out,
                                const byte* in, word32 sz)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -1440,7 +1440,7 @@ int wc_CryptoCb_Des3Encrypt(Des3* des3, byte* out,
 int wc_CryptoCb_Des3Decrypt(Des3* des3, byte* out,
                                const byte* in, word32 sz)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -1474,7 +1474,7 @@ int wc_CryptoCb_Des3Decrypt(Des3* des3, byte* out,
 int wc_CryptoCb_ShaHash(wc_Sha* sha, const byte* in,
     word32 inSz, byte* digest)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -1507,7 +1507,7 @@ int wc_CryptoCb_ShaHash(wc_Sha* sha, const byte* in,
 int wc_CryptoCb_Sha256Hash(wc_Sha256* sha256, const byte* in,
     word32 inSz, byte* digest)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -1540,7 +1540,7 @@ int wc_CryptoCb_Sha256Hash(wc_Sha256* sha256, const byte* in,
 int wc_CryptoCb_Sha384Hash(wc_Sha384* sha384, const byte* in,
     word32 inSz, byte* digest)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -1576,7 +1576,7 @@ int wc_CryptoCb_Sha384Hash(wc_Sha384* sha384, const byte* in,
 int wc_CryptoCb_Sha512Hash(wc_Sha512* sha512, const byte* in,
     word32 inSz, byte* digest)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -1612,7 +1612,7 @@ int wc_CryptoCb_Sha512Hash(wc_Sha512* sha512, const byte* in,
 int wc_CryptoCb_Hmac(Hmac* hmac, int macType, const byte* in, word32 inSz,
     byte* digest)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     if (hmac == NULL)
@@ -1640,7 +1640,7 @@ int wc_CryptoCb_Hmac(Hmac* hmac, int macType, const byte* in, word32 inSz,
 #ifndef WC_NO_RNG
 int wc_CryptoCb_RandomBlock(WC_RNG* rng, byte* out, word32 sz)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -1668,7 +1668,7 @@ int wc_CryptoCb_RandomBlock(WC_RNG* rng, byte* out, word32 sz)
 
 int wc_CryptoCb_RandomSeed(OS_Seed* os, byte* seed, word32 sz)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -1692,7 +1692,7 @@ int wc_CryptoCb_Cmac(Cmac* cmac, const byte* key, word32 keySz,
         const byte* in, word32 inSz, byte* out, word32* outSz, int type,
         void* ctx)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     CryptoCb* dev;
 
     /* locate registered callback */

--- a/wolfcrypt/src/curve25519.c
+++ b/wolfcrypt/src/curve25519.c
@@ -238,7 +238,7 @@ int wc_curve25519_make_key(WC_RNG* rng, int keysize, curve25519_key* key)
 #ifdef WOLF_CRYPTO_CB
     if (key->devId != INVALID_DEVID) {
         ret = wc_CryptoCb_Curve25519Gen(rng, keysize, key);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
     }
@@ -299,7 +299,7 @@ int wc_curve25519_shared_secret_ex(curve25519_key* private_key,
     if (private_key->devId != INVALID_DEVID) {
         ret = wc_CryptoCb_Curve25519(private_key, public_key, out, outlen,
             endian);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
     }

--- a/wolfcrypt/src/des3.c
+++ b/wolfcrypt/src/des3.c
@@ -1602,7 +1602,7 @@
     #ifdef WOLF_CRYPTO_CB
         if (des->devId != INVALID_DEVID) {
             int ret = wc_CryptoCb_Des3Encrypt(des, out, in, sz);
-            if (ret != CRYPTOCB_UNAVAILABLE)
+            if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                 return ret;
             /* fall-through when unavailable */
         }
@@ -1653,7 +1653,7 @@
     #ifdef WOLF_CRYPTO_CB
         if (des->devId != INVALID_DEVID) {
             int ret = wc_CryptoCb_Des3Decrypt(des, out, in, sz);
-            if (ret != CRYPTOCB_UNAVAILABLE)
+            if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                 return ret;
             /* fall-through when unavailable */
         }

--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -75,7 +75,7 @@ int wc_dilithium_sign_msg(const byte* in, word32 inLen,
     {
         ret = wc_CryptoCb_PqcSign(in, inLen, out, outLen, rng,
                                   WC_PQC_SIG_TYPE_DILITHIUM, key);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
         ret = 0;
@@ -179,7 +179,7 @@ int wc_dilithium_verify_msg(const byte* sig, word32 sigLen, const byte* msg,
     {
         ret = wc_CryptoCb_PqcVerify(sig, sigLen, msg, msgLen, res,
                                     WC_PQC_SIG_TYPE_DILITHIUM, key);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
         ret = 0;

--- a/wolfcrypt/src/dsa.c
+++ b/wolfcrypt/src/dsa.c
@@ -930,33 +930,39 @@ int wc_DsaSign_ex(const byte* digest, word32 digestSz, byte* out, DsaKey* key,
 
 #ifdef WOLFSSL_SMALL_STACK
     if (k) {
-        if ((ret != MP_INIT_E) && (ret != MEMORY_E))
+        if ((ret != WC_NO_ERR_TRACE(MP_INIT_E)) &&
+            (ret != WC_NO_ERR_TRACE(MEMORY_E)))
             mp_forcezero(k);
         XFREE(k, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
     }
     if (kInv) {
-        if ((ret != MP_INIT_E) && (ret != MEMORY_E))
+        if ((ret != WC_NO_ERR_TRACE(MP_INIT_E)) &&
+            (ret != WC_NO_ERR_TRACE(MEMORY_E)))
             mp_forcezero(kInv);
         XFREE(kInv, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
     }
     if (r) {
-        if ((ret != MP_INIT_E) && (ret != MEMORY_E))
+        if ((ret != WC_NO_ERR_TRACE(MP_INIT_E)) &&
+            (ret != WC_NO_ERR_TRACE(MEMORY_E)))
             mp_clear(r);
         XFREE(r, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
     }
     if (s) {
-        if ((ret != MP_INIT_E) && (ret != MEMORY_E))
+        if ((ret != WC_NO_ERR_TRACE(MP_INIT_E)) &&
+            (ret != WC_NO_ERR_TRACE(MEMORY_E)))
             mp_clear(s);
         XFREE(s, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
     }
     if (H) {
-        if ((ret != MP_INIT_E) && (ret != MEMORY_E))
+        if ((ret != WC_NO_ERR_TRACE(MP_INIT_E)) &&
+            (ret != WC_NO_ERR_TRACE(MEMORY_E)))
             mp_clear(H);
         XFREE(H, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
     }
 #ifndef WOLFSSL_MP_INVMOD_CONSTANT_TIME
     if (b) {
-        if ((ret != MP_INIT_E) && (ret != MEMORY_E))
+        if ((ret != WC_NO_ERR_TRACE(MP_INIT_E)) &&
+            (ret != WC_NO_ERR_TRACE(MEMORY_E)))
             mp_forcezero(b);
         XFREE(b, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
     }
@@ -966,7 +972,7 @@ int wc_DsaSign_ex(const byte* digest, word32 digestSz, byte* out, DsaKey* key,
         XFREE(buffer, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
     }
 #else /* !WOLFSSL_SMALL_STACK */
-    if (ret != MP_INIT_E) {
+    if (ret != WC_NO_ERR_TRACE(MP_INIT_E)) {
         ForceZero(buffer, halfSz);
         mp_forcezero(kInv);
         mp_forcezero(k);
@@ -1106,37 +1112,37 @@ int wc_DsaVerify_ex(const byte* digest, word32 digestSz, const byte* sig,
 
 #ifdef WOLFSSL_SMALL_STACK
     if (s) {
-        if (ret != MP_INIT_E)
+        if (ret != WC_NO_ERR_TRACE(MP_INIT_E))
             mp_clear(s);
         XFREE(s, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
     }
     if (r) {
-        if (ret != MP_INIT_E)
+        if (ret != WC_NO_ERR_TRACE(MP_INIT_E))
             mp_clear(r);
         XFREE(r, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
     }
     if (u1) {
-        if (ret != MP_INIT_E)
+        if (ret != WC_NO_ERR_TRACE(MP_INIT_E))
             mp_clear(u1);
         XFREE(u1, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
     }
     if (u2) {
-        if (ret != MP_INIT_E)
+        if (ret != WC_NO_ERR_TRACE(MP_INIT_E))
             mp_clear(u2);
         XFREE(u2, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
     }
     if (w) {
-        if (ret != MP_INIT_E)
+        if (ret != WC_NO_ERR_TRACE(MP_INIT_E))
             mp_clear(w);
         XFREE(w, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
     }
     if (v) {
-        if (ret != MP_INIT_E)
+        if (ret != WC_NO_ERR_TRACE(MP_INIT_E))
             mp_clear(v);
         XFREE(v, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
     }
 #else
-    if (ret != MP_INIT_E) {
+    if (ret != WC_NO_ERR_TRACE(MP_INIT_E)) {
         mp_clear(s);
         mp_clear(r);
         mp_clear(u1);

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4681,7 +4681,7 @@ int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key, byte* out,
     #endif
     {
         err = wc_CryptoCb_Ecdh(private_key, public_key, out, outlen);
-        if (err != CRYPTOCB_UNAVAILABLE)
+        if (err != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return err;
         /* fall-through when unavailable */
     }
@@ -5069,7 +5069,7 @@ static int wc_ecc_shared_secret_gen_async(ecc_key* private_key,
         err = wc_ecc_shared_secret_gen_sync(private_key, point, out, outlen);
     }
 
-    if (err == WC_PENDING_E) {
+    if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         private_key->state++;
     }
 
@@ -5162,7 +5162,7 @@ int wc_ecc_shared_secret_ex(ecc_key* private_key, ecc_point* point,
     RESTORE_VECTOR_REGISTERS();
 
     /* if async pending then return and skip done cleanup below */
-    if (err == WC_PENDING_E) {
+    if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         return err;
     }
 
@@ -5679,7 +5679,7 @@ static int _ecc_make_key_ex(WC_RNG* rng, int keysize, ecc_key* key,
     #endif
     {
         err = wc_CryptoCb_MakeEccKey(rng, keysize, key, curve_id);
-        if (err != CRYPTOCB_UNAVAILABLE)
+        if (err != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return err;
         /* fall-through when unavailable */
     }
@@ -6691,7 +6691,7 @@ static int wc_ecc_sign_hash_async(const byte* in, word32 inlen, byte* out,
     }
 
     /* if async pending then return and skip done cleanup below */
-    if (err == WC_PENDING_E) {
+    if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         key->state++;
         return err;
     }
@@ -6733,7 +6733,7 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
     #endif
     {
         err = wc_CryptoCb_EccSign(in, inlen, out, outlen, rng, key);
-        if (err != CRYPTOCB_UNAVAILABLE)
+        if (err != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return err;
         /* fall-through when unavailable */
     }
@@ -6923,7 +6923,7 @@ static int ecc_sign_hash_sw(ecc_key* key, ecc_key* pubkey, WC_RNG* rng,
 
             err = wc_ecc_gen_k(rng, key->dp->size, b, curve->order);
         }
-        while (err == MP_ZERO_E);
+        while (err == WC_NO_ERR_TRACE(MP_ZERO_E));
         loop_check = 0;
     }
 #ifdef WOLFSSL_CHECK_MEM_ZERO
@@ -7284,7 +7284,7 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
 
 #if defined(WOLFSSL_HAVE_SP_ECC)
    err = ecc_sign_hash_sp(in, inlen, rng, key, r, s);
-   if (err != WC_KEY_SIZE_E) {
+   if (err != WC_NO_ERR_TRACE(WC_KEY_SIZE_E)) {
        return err;
    }
 #else
@@ -8472,7 +8472,7 @@ int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
     #endif
     {
         err = wc_CryptoCb_EccVerify(sig, siglen, hash, hashlen, res, key);
-        if (err != CRYPTOCB_UNAVAILABLE)
+        if (err != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return err;
         /* fall-through when unavailable */
     }
@@ -8580,7 +8580,7 @@ int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     /* if async pending then return and skip done cleanup below */
-    if (err == WC_PENDING_E) {
+    if (err == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         if (!isPrivateKeyOnly) /* do not advance state if doing make pub key */
             key->state++;
         return err;
@@ -9222,7 +9222,7 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
   }
 
   err = ecc_verify_hash_sp(r, s, hash, hashlen, res, key);
-  if (err != NOT_COMPILED_IN) {
+  if (err != WC_NO_ERR_TRACE(NOT_COMPILED_IN)) {
       if (curveLoaded) {
            wc_ecc_curve_free(curve);
            FREE_CURVE_SPECS();
@@ -11608,7 +11608,7 @@ static int wc_ecc_import_raw_private(ecc_key* key, const char* qx,
 #ifdef WOLFSSL_VALIDATE_ECC_IMPORT
     if (err == MP_OKAY) {
         err = wc_ecc_check_key(key);
-        if (err == IS_POINT_E && (mp_iszero(key->pubkey.x) ||
+        if (err == WC_NO_ERR_TRACE(IS_POINT_E) && (mp_iszero(key->pubkey.x) ||
                                   mp_iszero(key->pubkey.y))) {
             err = BAD_FUNC_ARG;
         }
@@ -14184,7 +14184,7 @@ int wc_ecc_encrypt_ex(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
                                                                      &sharedSz);
     #endif
     }
-    while (ret == WC_PENDING_E);
+    while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
 
     if (ret == 0) {
     #ifdef WOLFSSL_ECIES_ISO18033
@@ -14603,7 +14603,7 @@ int wc_ecc_decrypt(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
             ret = wc_ecc_shared_secret(privKey, pubKey, sharedSecret +
                                                           pubKeySz, &sharedSz);
         #endif
-        } while (ret == WC_PENDING_E);
+        } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     }
     if (ret == 0) {
     #ifdef WOLFSSL_ECIES_ISO18033
@@ -15236,57 +15236,57 @@ static int mp_sqrtmod_prime(mp_int* n, mp_int* prime, mp_int* ret)
 
 #ifdef WOLFSSL_SMALL_STACK
   if (t1) {
-    if (res != MP_INIT_E)
+    if (res != WC_NO_ERR_TRACE(MP_INIT_E))
       mp_clear(t1);
     XFREE(t1, NULL, DYNAMIC_TYPE_ECC_BUFFER);
   }
   if (C) {
-    if (res != MP_INIT_E)
+    if (res != WC_NO_ERR_TRACE(MP_INIT_E))
       mp_clear(C);
     XFREE(C, NULL, DYNAMIC_TYPE_ECC_BUFFER);
   }
   if (Q) {
-    if (res != MP_INIT_E)
+    if (res != WC_NO_ERR_TRACE(MP_INIT_E))
       mp_clear(Q);
     XFREE(Q, NULL, DYNAMIC_TYPE_ECC_BUFFER);
   }
   if (S) {
-    if (res != MP_INIT_E)
+    if (res != WC_NO_ERR_TRACE(MP_INIT_E))
       mp_clear(S);
     XFREE(S, NULL, DYNAMIC_TYPE_ECC_BUFFER);
   }
   if (Z) {
-    if (res != MP_INIT_E)
+    if (res != WC_NO_ERR_TRACE(MP_INIT_E))
       mp_clear(Z);
     XFREE(Z, NULL, DYNAMIC_TYPE_ECC_BUFFER);
   }
   if (M) {
-    if (res != MP_INIT_E)
+    if (res != WC_NO_ERR_TRACE(MP_INIT_E))
       mp_clear(M);
     XFREE(M, NULL, DYNAMIC_TYPE_ECC_BUFFER);
   }
   if (T) {
-    if (res != MP_INIT_E)
+    if (res != WC_NO_ERR_TRACE(MP_INIT_E))
       mp_clear(T);
     XFREE(T, NULL, DYNAMIC_TYPE_ECC_BUFFER);
   }
   if (R) {
-    if (res != MP_INIT_E)
+    if (res != WC_NO_ERR_TRACE(MP_INIT_E))
       mp_clear(R);
     XFREE(R, NULL, DYNAMIC_TYPE_ECC_BUFFER);
   }
   if (N) {
-    if (res != MP_INIT_E)
+    if (res != WC_NO_ERR_TRACE(MP_INIT_E))
       mp_clear(N);
     XFREE(N, NULL, DYNAMIC_TYPE_ECC_BUFFER);
   }
   if (two) {
-    if (res != MP_INIT_E)
+    if (res != WC_NO_ERR_TRACE(MP_INIT_E))
       mp_clear(two);
     XFREE(two, NULL, DYNAMIC_TYPE_ECC_BUFFER);
   }
 #else
-  if (res != MP_INIT_E) {
+  if (res != WC_NO_ERR_TRACE(MP_INIT_E)) {
     mp_clear(t1);
     mp_clear(C);
     mp_clear(Q);

--- a/wolfcrypt/src/eccsi.c
+++ b/wolfcrypt/src/eccsi.c
@@ -1447,7 +1447,7 @@ static int eccsi_mulmod_point_add(EccsiKey* key, const mp_int* n,
         ecc_point* point, ecc_point* a, ecc_point* res, mp_digit mp, int map)
 {
 #if defined(WOLFSSL_HAVE_SP_ECC) && !defined(WOLFSSL_SP_NO_256)
-    int err = NOT_COMPILED_IN;
+    int err = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
 
     if ((key->ecc.idx != ECC_CUSTOM_IDX) &&
             (ecc_sets[key->ecc.idx].id == ECC_SECP256R1)) {

--- a/wolfcrypt/src/ed25519.c
+++ b/wolfcrypt/src/ed25519.c
@@ -320,7 +320,7 @@ int wc_ed25519_make_key(WC_RNG* rng, int keySz, ed25519_key* key)
 #ifdef WOLF_CRYPTO_CB
     if (key->devId != INVALID_DEVID) {
         ret = wc_CryptoCb_Ed25519Gen(rng, keySz, key);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
     }
@@ -400,7 +400,7 @@ int wc_ed25519_sign_msg_ex(const byte* in, word32 inLen, byte* out,
     if (key->devId != INVALID_DEVID) {
         ret = wc_CryptoCb_Ed25519Sign(in, inLen, out, outLen, key, type,
             context, contextLen);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
     }
@@ -858,7 +858,7 @@ int wc_ed25519_verify_msg_ex(const byte* sig, word32 sigLen, const byte* msg,
     if (key->devId != INVALID_DEVID) {
         ret = wc_CryptoCb_Ed25519Verify(sig, sigLen, msg, msgLen, res, key,
             type, context, contextLen);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
     }
@@ -1383,7 +1383,7 @@ int wc_ed25519_check_key(ed25519_key* key)
                 }
             }
             /* Bits are all one up to last byte - check less than -19. */
-            if ((ret == PUBLIC_KEY_E) && (key->p[0] < 0xed)) {
+            if ((ret == WC_NO_ERR_TRACE(PUBLIC_KEY_E)) && (key->p[0] < 0xed)) {
                 ret = 0;
             }
         }

--- a/wolfcrypt/src/ed448.c
+++ b/wolfcrypt/src/ed448.c
@@ -1354,7 +1354,7 @@ int wc_ed448_check_key(ed448_key* key)
                     break;
                 }
             }
-            if (ret == PUBLIC_KEY_E) {
+            if (ret == WC_NO_ERR_TRACE(PUBLIC_KEY_E)) {
                 /* Check against 0xFE. */
                 if (key->p[ED448_PUB_KEY_SIZE/2] < 0xfe) {
                     ret = 0;
@@ -1368,7 +1368,8 @@ int wc_ed448_check_key(ed448_key* key)
                         }
                     }
                     /* Check last byte. */
-                    if ((ret == PUBLIC_KEY_E) && (key->p[0] < 0xff)) {
+                    if ((ret == WC_NO_ERR_TRACE(PUBLIC_KEY_E)) &&
+                        (key->p[0] < 0xff)) {
                         ret = 0;
                     }
                 }

--- a/wolfcrypt/src/error.c
+++ b/wolfcrypt/src/error.c
@@ -34,6 +34,11 @@
 #endif
 
 #ifndef NO_ERROR_STRINGS
+
+#ifdef WOLFSSL_DEBUG_TRACE_ERROR_CODES_H
+#include <wolfssl/debug-untrace-error-codes.h>
+#endif
+
 WOLFSSL_ABI
 const char* wc_GetErrorString(int error)
 {
@@ -630,6 +635,10 @@ const char* wc_GetErrorString(int error)
 
     }
 }
+
+#ifdef WOLFSSL_DEBUG_TRACE_ERROR_CODES
+#include <wolfssl/debug-trace-error-codes.h>
+#endif
 
 void wc_ErrorString(int error, char* buffer)
 {

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -8481,7 +8481,7 @@ void wolfSSL_EVP_init(void)
         }
 
         if (ret < 0) {
-            if (ret == AES_GCM_AUTH_E) {
+            if (ret == WC_NO_ERR_TRACE(AES_GCM_AUTH_E)) {
                 WOLFSSL_MSG("wolfSSL_EVP_Cipher failure: bad AES-GCM tag.");
             }
             WOLFSSL_MSG("wolfSSL_EVP_Cipher failure");
@@ -8559,7 +8559,7 @@ static int PopulateRSAEvpPkeyDer(WOLFSSL_EVP_PKEY *pkey)
             if (key->pkcs8HeaderSz) {
                 ret = wc_CreatePKCS8Key(NULL, &pkcs8Sz, NULL, (word32)derSz,
                     RSAk, NULL, 0);
-                if (ret == LENGTH_ONLY_E)
+                if (ret == WC_NO_ERR_TRACE(LENGTH_ONLY_E))
                     ret = 0;
             }
         #endif
@@ -8933,7 +8933,7 @@ int wolfSSL_EVP_PKEY_set1_DH(WOLFSSL_EVP_PKEY *pkey, WOLFSSL_DH *key)
         ret = wc_DhParamsToDer(dhkey,NULL,&derSz);
     }
 
-    if (derSz == 0 || ret != LENGTH_ONLY_E) {
+    if (derSz == 0 || ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
        WOLFSSL_MSG("Failed to get size of DH Key");
        return WOLFSSL_FAILURE;
     }
@@ -9076,7 +9076,7 @@ static int ECC_populate_EVP_PKEY(EVP_PKEY* pkey, WOLFSSL_EC_KEY *key)
 #ifdef HAVE_PKCS8
         if (key->pkcs8HeaderSz) {
             /* when key has pkcs8 header the pkey should too */
-            if (wc_EccKeyToPKCS8(ecc, NULL, (word32*)&derSz) == LENGTH_ONLY_E) {
+            if (wc_EccKeyToPKCS8(ecc, NULL, (word32*)&derSz) == WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
                 derBuf = (byte*)XMALLOC((size_t)derSz, pkey->heap,
                     DYNAMIC_TYPE_OPENSSL);
                 if (derBuf) {
@@ -9221,7 +9221,7 @@ const WOLFSSL_EVP_MD* wolfSSL_EVP_ripemd160(void)
 
 int wolfSSL_EVP_MD_pkey_type(const WOLFSSL_EVP_MD* type)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     WOLFSSL_ENTER("wolfSSL_EVP_MD_pkey_type");
 
@@ -9244,6 +9244,9 @@ int wolfSSL_EVP_MD_pkey_type(const WOLFSSL_EVP_MD* type)
         else if (XSTRCMP(type, "SHA512") == 0) {
             ret = NID_sha512WithRSAEncryption;
         }
+    }
+    else {
+        ret = BAD_FUNC_ARG;
     }
 
     WOLFSSL_LEAVE("wolfSSL_EVP_MD_pkey_type", ret);
@@ -12448,7 +12451,7 @@ int  wolfSSL_EVP_DecodeUpdate(WOLFSSL_EVP_ENCODE_CTX* ctx,
             (word32)(BASE64_DECODE_BLOCK_SIZE - ctx->remaining), (word32)inl);
 
         for ( i = 0; cpySz > 0 && inLen > 0; i++) {
-            if (Base64_SkipNewline(in, &inLen, &j) == ASN_INPUT_E) {
+            if (Base64_SkipNewline(in, &inLen, &j) == WC_NO_ERR_TRACE(ASN_INPUT_E)) {
                 return -1;  /* detected an illegal char in input */
             }
             c = in[j++];
@@ -12488,7 +12491,7 @@ int  wolfSSL_EVP_DecodeUpdate(WOLFSSL_EVP_ENCODE_CTX* ctx,
      */
     while (inLen > 3) {
         if ((res = Base64_SkipNewline(in, &inLen, &j)) != 0) {
-            if (res == BUFFER_E) {
+            if (res == WC_NO_ERR_TRACE(BUFFER_E)) {
                 break;
             }
             else {
@@ -12502,7 +12505,7 @@ int  wolfSSL_EVP_DecodeUpdate(WOLFSSL_EVP_ENCODE_CTX* ctx,
         }
         inLen--;
         if ((res = Base64_SkipNewline(in, &inLen, &j)) != 0) {
-            if (res == BUFFER_E) {
+            if (res == WC_NO_ERR_TRACE(BUFFER_E)) {
                 break;
             }
             else {
@@ -12513,7 +12516,7 @@ int  wolfSSL_EVP_DecodeUpdate(WOLFSSL_EVP_ENCODE_CTX* ctx,
         e[1] = in[j++];
         inLen--;
         if ((res = Base64_SkipNewline(in, &inLen, &j)) != 0) {
-            if (res == BUFFER_E) {
+            if (res == WC_NO_ERR_TRACE(BUFFER_E)) {
                 break;
             }
             else {
@@ -12524,7 +12527,7 @@ int  wolfSSL_EVP_DecodeUpdate(WOLFSSL_EVP_ENCODE_CTX* ctx,
         e[2] = in[j++];
         inLen--;
         if ((res = Base64_SkipNewline(in, &inLen, &j)) != 0) {
-            if (res == BUFFER_E) {
+            if (res == WC_NO_ERR_TRACE(BUFFER_E)) {
                 break;
             }
             else {
@@ -12631,8 +12634,10 @@ int  wolfSSL_EVP_DecodeFinal(WOLFSSL_EVP_ENCODE_CTX* ctx,
         inLen = (word32)ctx->remaining;
         if ((res = Base64_SkipNewline(ctx->data, &inLen, &j)) != 0) {
             *outl = 0;
-            if (res == BUFFER_E) /* means no valid data to decode in buffer */
+            if (res == WC_NO_ERR_TRACE(BUFFER_E)) {
+                /* means no valid data to decode in buffer */
                 return  1; /* returns as success with no output */
+            }
             else
                 return -1;
         }

--- a/wolfcrypt/src/ext_kyber.c
+++ b/wolfcrypt/src/ext_kyber.c
@@ -329,7 +329,7 @@ int wc_KyberKey_MakeKey(KyberKey* key, WC_RNG* rng)
     {
         ret = wc_CryptoCb_MakePqcKemKey(rng, WC_PQC_KEM_TYPE_KYBER,
                                         key->type, key);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
         ret = 0;
@@ -440,7 +440,7 @@ int wc_KyberKey_Encapsulate(KyberKey* key, unsigned char* ct, unsigned char* ss,
     ) {
         ret = wc_CryptoCb_PqcEncapsulate(ct, ctlen, ss, KYBER_SS_SZ, rng,
                                          WC_PQC_KEM_TYPE_KYBER, key);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
         ret = 0;
@@ -549,7 +549,7 @@ int wc_KyberKey_Decapsulate(KyberKey* key, unsigned char* ss,
     ) {
         ret = wc_CryptoCb_PqcDecapsulate(ct, ctlen, ss, KYBER_SS_SZ,
                                          WC_PQC_KEM_TYPE_KYBER, key);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
         ret = 0;

--- a/wolfcrypt/src/falcon.c
+++ b/wolfcrypt/src/falcon.c
@@ -75,7 +75,7 @@ int wc_falcon_sign_msg(const byte* in, word32 inLen,
     {
         ret = wc_CryptoCb_PqcSign(in, inLen, out, outLen, rng,
                                   WC_PQC_SIG_TYPE_FALCON, key);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
         ret = 0;
@@ -173,7 +173,7 @@ int wc_falcon_verify_msg(const byte* sig, word32 sigLen, const byte* msg,
     {
         ret = wc_CryptoCb_PqcVerify(sig, sigLen, msg, msgLen, res,
                                     WC_PQC_SIG_TYPE_FALCON, key);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
         ret = 0;

--- a/wolfcrypt/src/hash.c
+++ b/wolfcrypt/src/hash.c
@@ -145,7 +145,7 @@ enum wc_HashType wc_HashTypeConvert(int hashType)
 
 int wc_HashGetOID(enum wc_HashType hash_type)
 {
-    int oid = HASH_TYPE_E; /* Default to hash type error */
+    int oid = WC_NO_ERR_TRACE(HASH_TYPE_E); /* Default to hash type error */
     switch(hash_type)
     {
         case WC_HASH_TYPE_MD2:
@@ -317,7 +317,7 @@ enum wc_HashType wc_OidGetHash(int oid)
 /* Get Hash digest size */
 int wc_HashGetDigestSize(enum wc_HashType hash_type)
 {
-    int dig_size = HASH_TYPE_E; /* Default to hash type error */
+    int dig_size = WC_NO_ERR_TRACE(HASH_TYPE_E);
     switch(hash_type)
     {
         case WC_HASH_TYPE_MD2:
@@ -436,7 +436,7 @@ int wc_HashGetDigestSize(enum wc_HashType hash_type)
 /* Get Hash block size */
 int wc_HashGetBlockSize(enum wc_HashType hash_type)
 {
-    int block_size = HASH_TYPE_E; /* Default to hash type error */
+    int block_size = WC_NO_ERR_TRACE(HASH_TYPE_E);
     switch (hash_type)
     {
         case WC_HASH_TYPE_MD2:
@@ -555,7 +555,7 @@ int wc_HashGetBlockSize(enum wc_HashType hash_type)
 int wc_Hash_ex(enum wc_HashType hash_type, const byte* data,
     word32 data_len, byte* hash, word32 hash_len, void* heap, int devId)
 {
-    int ret = HASH_TYPE_E; /* Default to hash type error */
+    int ret = WC_NO_ERR_TRACE(HASH_TYPE_E); /* Default to hash type error */
     int dig_size;
 
     /* Validate hash buffer size */
@@ -689,7 +689,7 @@ int wc_Hash(enum wc_HashType hash_type, const byte* data,
 int wc_HashInit_ex(wc_HashAlg* hash, enum wc_HashType type, void* heap,
     int devId)
 {
-    int ret = HASH_TYPE_E; /* Default to hash type error */
+    int ret = WC_NO_ERR_TRACE(HASH_TYPE_E); /* Default to hash type error */
 
     if (hash == NULL)
         return BAD_FUNC_ARG;
@@ -801,7 +801,7 @@ int wc_HashInit(wc_HashAlg* hash, enum wc_HashType type)
 int wc_HashUpdate(wc_HashAlg* hash, enum wc_HashType type, const byte* data,
                   word32 dataSz)
 {
-    int ret = HASH_TYPE_E; /* Default to hash type error */
+    int ret = WC_NO_ERR_TRACE(HASH_TYPE_E); /* Default to hash type error */
 
     if (hash == NULL || (data == NULL && dataSz > 0))
         return BAD_FUNC_ARG;
@@ -904,7 +904,7 @@ int wc_HashUpdate(wc_HashAlg* hash, enum wc_HashType type, const byte* data,
 
 int wc_HashFinal(wc_HashAlg* hash, enum wc_HashType type, byte* out)
 {
-    int ret = HASH_TYPE_E; /* Default to hash type error */
+    int ret = WC_NO_ERR_TRACE(HASH_TYPE_E); /* Default to hash type error */
 
     if (hash == NULL || out == NULL)
         return BAD_FUNC_ARG;
@@ -1007,7 +1007,7 @@ int wc_HashFinal(wc_HashAlg* hash, enum wc_HashType type, byte* out)
 
 int wc_HashFree(wc_HashAlg* hash, enum wc_HashType type)
 {
-    int ret = HASH_TYPE_E; /* Default to hash type error */
+    int ret = WC_NO_ERR_TRACE(HASH_TYPE_E); /* Default to hash type error */
 
     if (hash == NULL)
         return BAD_FUNC_ARG;
@@ -1124,7 +1124,7 @@ int wc_HashFree(wc_HashAlg* hash, enum wc_HashType type)
 #ifdef WOLFSSL_HASH_FLAGS
 int wc_HashSetFlags(wc_HashAlg* hash, enum wc_HashType type, word32 flags)
 {
-    int ret = HASH_TYPE_E; /* Default to hash type error */
+    int ret = WC_NO_ERR_TRACE(HASH_TYPE_E); /* Default to hash type error */
 
     if (hash == NULL)
         return BAD_FUNC_ARG;
@@ -1203,7 +1203,7 @@ int wc_HashSetFlags(wc_HashAlg* hash, enum wc_HashType type, word32 flags)
 }
 int wc_HashGetFlags(wc_HashAlg* hash, enum wc_HashType type, word32* flags)
 {
-    int ret = HASH_TYPE_E; /* Default to hash type error */
+    int ret = WC_NO_ERR_TRACE(HASH_TYPE_E); /* Default to hash type error */
 
     if (hash == NULL)
         return BAD_FUNC_ARG;

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -711,7 +711,7 @@ int wc_HmacUpdate(Hmac* hmac, const byte* msg, word32 length)
 #ifdef WOLF_CRYPTO_CB
     if (hmac->devId != INVALID_DEVID) {
         ret = wc_CryptoCb_Hmac(hmac, hmac->macType, msg, length, NULL);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
         ret = 0; /* reset error code */
@@ -820,7 +820,7 @@ int wc_HmacFinal(Hmac* hmac, byte* hash)
 #ifdef WOLF_CRYPTO_CB
     if (hmac->devId != INVALID_DEVID) {
         ret = wc_CryptoCb_Hmac(hmac, hmac->macType, NULL, 0, hash);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
     }

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -659,7 +659,7 @@ typedef union {
 static
 int _HashInit(byte hashId, _hash* hash)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     switch (hashId) {
     #ifndef NO_SHA
@@ -684,6 +684,9 @@ int _HashInit(byte hashId, _hash* hash)
             ret = wc_InitSha512(&hash->sha512);
             break;
     #endif /* WOLFSSL_SHA512 */
+        default:
+            ret = BAD_FUNC_ARG;
+            break;
     }
 
     return ret;
@@ -693,7 +696,7 @@ static
 int _HashUpdate(byte hashId, _hash* hash,
         const byte* data, word32 dataSz)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     switch (hashId) {
     #ifndef NO_SHA
@@ -718,6 +721,9 @@ int _HashUpdate(byte hashId, _hash* hash,
             ret = wc_Sha512Update(&hash->sha512, data, dataSz);
             break;
     #endif /* WOLFSSL_SHA512 */
+        default:
+            ret = BAD_FUNC_ARG;
+            break;
     }
 
     return ret;
@@ -726,7 +732,7 @@ int _HashUpdate(byte hashId, _hash* hash,
 static
 int _HashFinal(byte hashId, _hash* hash, byte* digest)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     switch (hashId) {
     #ifndef NO_SHA
@@ -751,6 +757,9 @@ int _HashFinal(byte hashId, _hash* hash, byte* digest)
             ret = wc_Sha512Final(&hash->sha512, digest);
             break;
     #endif /* WOLFSSL_SHA512 */
+        default:
+            ret = BAD_FUNC_ARG;
+            break;
     }
 
     return ret;
@@ -1450,7 +1459,7 @@ int wc_KDA_KDF_onestep(const byte* z, word32 zSz, const byte* fixedInfo,
         return BAD_FUNC_ARG;
 
     hashOutSz = wc_HashGetDigestSize(hashType);
-    if (hashOutSz == HASH_TYPE_E)
+    if (hashOutSz == WC_NO_ERR_TRACE(HASH_TYPE_E))
         return BAD_FUNC_ARG;
 
     /* According to SP800_56C, table 1, the max input size (max_H_inputBits)

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -126,7 +126,10 @@ THREAD_LS_T void *StackSizeCheck_stackOffsetPointer = 0;
 
 /* Set these to default values initially. */
 static wolfSSL_Logging_cb log_function = NULL;
-static int loggingEnabled = 0;
+#ifndef WOLFSSL_LOGGINGENABLED_DEFAULT
+#define WOLFSSL_LOGGINGENABLED_DEFAULT 0
+#endif
+static int loggingEnabled = WOLFSSL_LOGGINGENABLED_DEFAULT;
 THREAD_LS_T const char* log_prefix = NULL;
 
 #if defined(WOLFSSL_APACHE_MYNEWT)
@@ -714,7 +717,7 @@ unsigned long wc_PeekErrorNodeLineData(const char **file, int *line,
 
     while (1) {
         int ret = wc_PeekErrorNode(0, file, NULL, line);
-        if (ret == BAD_STATE_E) {
+        if (ret == WC_NO_ERR_TRACE(BAD_STATE_E)) {
             WOLFSSL_MSG("Issue peeking at error node in queue");
             return 0;
         }
@@ -744,7 +747,7 @@ unsigned long wc_GetErrorNodeErr(void)
 
     ret = wc_PullErrorNode(NULL, NULL, NULL);
     if (ret < 0) {
-        if (ret == BAD_STATE_E) {
+        if (ret == WC_NO_ERR_TRACE(BAD_STATE_E)) {
             ret = 0; /* no errors in queue */
         }
         else {
@@ -1230,7 +1233,9 @@ unsigned long wc_PeekErrorNodeLineData(const char **file, int *line,
     idx = getErrorNodeCurrentIdx();
     while (1) {
         int ret = peekErrorNode(idx, file, NULL, line);
-        if (ret == BAD_MUTEX_E || ret == BAD_FUNC_ARG || ret == BAD_STATE_E) {
+        if (ret == WC_NO_ERR_TRACE(BAD_MUTEX_E) ||
+            ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG) ||
+            ret == WC_NO_ERR_TRACE(BAD_STATE_E)) {
             ERRQ_UNLOCK();
             WOLFSSL_MSG("Issue peeking at error node in queue");
             return 0;
@@ -1263,7 +1268,7 @@ unsigned long wc_GetErrorNodeErr(void)
 
     ret = pullErrorNode(NULL, NULL, NULL);
     if (ret < 0) {
-        if (ret == BAD_STATE_E) {
+        if (ret == WC_NO_ERR_TRACE(BAD_STATE_E)) {
             ret = 0; /* no errors in queue */
         }
         else {
@@ -1483,7 +1488,7 @@ void WOLFSSL_ERROR(int error)
 #endif
 {
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (error != WC_PENDING_E)
+    if (error != WC_NO_ERR_TRACE(WC_PENDING_E))
 #endif
     {
         char buffer[WOLFSSL_MAX_ERROR_SZ];
@@ -1501,7 +1506,8 @@ void WOLFSSL_ERROR(int error)
             #if defined(OPENSSL_EXTRA) && !defined(WOLFCRYPT_ONLY)
             /* If running in compatibility mode do not add want read and
                want right to error queue */
-            if (error != WANT_READ && error != WANT_WRITE) {
+            if (error != WC_NO_ERR_TRACE(WANT_READ) &&
+                error != WC_NO_ERR_TRACE(WANT_WRITE)) {
             #endif
             if (error < 0)
                 error = error - (2 * error); /* get absolute value */

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -297,7 +297,7 @@ static int GetSafeContent(WC_PKCS12* pkcs12, const byte* input,
 #ifdef ASN_BER_TO_DER
      if (pkcs12->indefinite) {
         if (wc_BerToDer(input, safe->dataSz, NULL,
-                        &pkcs12->safeDersz) != LENGTH_ONLY_E) {
+                        &pkcs12->safeDersz) != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
             WOLFSSL_MSG("Not BER sequence");
             return ASN_PARSE_E;
         }
@@ -711,7 +711,7 @@ int wc_d2i_PKCS12(const byte* der, word32 derSz, WC_PKCS12* pkcs12)
     #ifdef ASN_BER_TO_DER
      if (size == 0) {
          if (wc_BerToDer(der, totalSz, NULL,
-                         (word32*)&size) != LENGTH_ONLY_E) {
+                         (word32*)&size) != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
              WOLFSSL_MSG("Not BER sequence");
              return ASN_PARSE_E;
          }
@@ -1826,7 +1826,7 @@ static int wc_PKCS12_shroud_key(WC_PKCS12* pkcs12, WC_RNG* rng,
         ret = UnTraditionalEnc(key, keySz, pkcs8Key, &sz, pass, passSz,
                 vPKCS, vAlgo, NULL, 0, itt, rng, heap);
     }
-    if (ret == LENGTH_ONLY_E) {
+    if (ret == WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
         *outSz =  sz + MAX_LENGTH_SZ + 1;
         return LENGTH_ONLY_E;
     }
@@ -1883,7 +1883,7 @@ static int wc_PKCS12_create_key_bag(WC_PKCS12* pkcs12, WC_RNG* rng,
     /* get max size for shrouded key */
     ret =  wc_PKCS12_shroud_key(pkcs12, rng, NULL, &length, key, keySz,
             algo, pass, passSz, iter);
-    if (ret != LENGTH_ONLY_E && ret < 0) {
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E) && ret < 0) {
         return ret;
     }
 
@@ -2092,7 +2092,7 @@ static int wc_PKCS12_encrypt_content(WC_PKCS12* pkcs12, WC_RNG* rng,
         encSz = contentSz;
         if ((ret = EncryptContent(NULL, contentSz, NULL, &encSz,
                    pass, passSz, vPKCS, vAlgo, NULL, 0, iter, rng, heap)) < 0) {
-            if (ret != LENGTH_ONLY_E) {
+            if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
                 return ret;
             }
         }
@@ -2282,7 +2282,7 @@ static byte* PKCS12_create_key_content(WC_PKCS12* pkcs12, int nidKey,
     /* get max size for key bag */
     ret = wc_PKCS12_create_key_bag(pkcs12, rng, NULL, &keyBufSz, key, keySz,
             algo, iter, pass, (int)passSz);
-    if (ret != LENGTH_ONLY_E && ret < 0) {
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E) && ret < 0) {
         WOLFSSL_MSG("Error getting key bag size");
         return NULL;
     }
@@ -2319,7 +2319,7 @@ static byte* PKCS12_create_key_content(WC_PKCS12* pkcs12, int nidKey,
     #endif
     ret = wc_PKCS12_encrypt_content(pkcs12, rng, NULL, keyCiSz,
             NULL, keyBufSz, algo, pass, (int)passSz, iter, WC_PKCS12_DATA);
-    if (ret != LENGTH_ONLY_E) {
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
         XFREE(keyBuf, heap, DYNAMIC_TYPE_TMP_BUFFER);
         WOLFSSL_MSG("Error getting key encrypt content size");
         return NULL;
@@ -2404,7 +2404,7 @@ static byte* PKCS12_create_cert_content(WC_PKCS12* pkcs12, int nidCert,
 
     /* get max size of buffer needed */
     ret = wc_PKCS12_create_cert_bag(pkcs12, NULL, &certBufSz, cert, certSz);
-    if (ret != LENGTH_ONLY_E) {
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
         return NULL;
     }
 
@@ -2416,7 +2416,7 @@ static byte* PKCS12_create_cert_content(WC_PKCS12* pkcs12, int nidCert,
         while (current != NULL) {
             ret = wc_PKCS12_create_cert_bag(pkcs12, NULL, &curBufSz,
                     current->buffer, current->bufferSz);
-            if (ret != LENGTH_ONLY_E) {
+            if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
                 return NULL;
             }
             certBufSz += curBufSz;
@@ -2468,7 +2468,7 @@ static byte* PKCS12_create_cert_content(WC_PKCS12* pkcs12, int nidCert,
     /* get buffer size needed for content info */
     ret = wc_PKCS12_encrypt_content(pkcs12, rng, NULL, certCiSz,
             NULL, certBufSz, algo, pass, (int)passSz, iter, type);
-    if (ret != LENGTH_ONLY_E) {
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
         XFREE(certBuf, heap, DYNAMIC_TYPE_TMP_BUFFER);
         WOLFSSL_LEAVE("wc_PKCS12_create()", ret);
         return NULL;
@@ -2524,7 +2524,7 @@ static int PKCS12_create_safe(WC_PKCS12* pkcs12, byte* certCi, word32 certCiSz,
     /* add Content Info structs to safe, key first then cert */
     ret = wc_PKCS12_encrypt_content(pkcs12, rng, NULL, &safeDataSz,
             NULL, innerDataSz, 0, NULL, 0, 0, WC_PKCS12_DATA);
-    if (ret != LENGTH_ONLY_E) {
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
         return ret;
     }
 

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -284,7 +284,7 @@ static int wc_PKCS7_AddDataToStream(PKCS7* pkcs7, byte* in, word32 inSz,
     if (rdSz >= inSz) {
         /* no more input to read, reset input index and request more data */
         pkcs7->stream->idx = 0;
-        return WC_PKCS7_WANT_READ_E;
+        return WC_NO_ERR_TRACE(WC_PKCS7_WANT_READ_E);
     }
 
     /* try to store input data into stream buffer */
@@ -324,7 +324,7 @@ static int wc_PKCS7_AddDataToStream(PKCS7* pkcs7, byte* in, word32 inSz,
     /* if not enough data was read in then request more */
     if (pkcs7->stream->length < expected) {
         pkcs7->stream->idx = 0;
-        return WC_PKCS7_WANT_READ_E;
+        return WC_NO_ERR_TRACE(WC_PKCS7_WANT_READ_E);
     }
 
     /* adjust pointer to read from stored buffer */
@@ -379,8 +379,8 @@ static int wc_PKCS7_SetMaxStream(PKCS7* pkcs7, byte* in, word32 defSz)
     #ifdef ASN_BER_TO_DER
         if (length == 0 && ret == 0) {
             idx = 0;
-            if ((ret = wc_BerToDer(pt, maxIdx, NULL,
-                            (word32*)&length)) != LENGTH_ONLY_E) {
+            if ((ret = wc_BerToDer(pt, maxIdx, NULL, (word32*)&length))
+                != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
                 return ret;
             }
         }
@@ -1787,7 +1787,8 @@ static int wc_PKCS7_ImportRSA(PKCS7* pkcs7, RsaKey* privKey)
         #endif
             }
         #ifdef WOLF_CRYPTO_CB
-            else if (ret == ASN_PARSE_E && pkcs7->devId != INVALID_DEVID) {
+            else if (ret == WC_NO_ERR_TRACE(ASN_PARSE_E) &&
+                     pkcs7->devId != INVALID_DEVID) {
                 /* if using crypto callbacks, try public key decode */
                 idx = 0;
                 ret = wc_RsaPublicKeyDecode(pkcs7->privateKey, &idx, privKey,
@@ -1839,7 +1840,7 @@ static int wc_PKCS7_RsaSign(PKCS7* pkcs7, byte* in, word32 inSz, ESD* esd)
                                      privKey, pkcs7->rng);
             }
     #ifdef WOLFSSL_ASYNC_CRYPT
-        } while (ret == WC_PENDING_E);
+        } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     #endif
     }
 
@@ -1876,7 +1877,8 @@ static int wc_PKCS7_ImportECC(PKCS7* pkcs7, ecc_key* privKey)
                 }
             }
         #ifdef WOLF_CRYPTO_CB
-            else if (ret == ASN_PARSE_E && pkcs7->devId != INVALID_DEVID) {
+            else if (ret == WC_NO_ERR_TRACE(ASN_PARSE_E) &&
+                     pkcs7->devId != INVALID_DEVID) {
                 /* if using crypto callbacks, try public key decode */
                 idx = 0;
                 ret = wc_EccPublicKeyDecode(pkcs7->privateKey, &idx, privKey,
@@ -1929,7 +1931,7 @@ static int wc_PKCS7_EcdsaSign(PKCS7* pkcs7, byte* in, word32 inSz, ESD* esd)
                                        &outSz, pkcs7->rng, privKey);
             }
     #ifdef WOLFSSL_ASYNC_CRYPT
-        } while (ret == WC_PENDING_E);
+        } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     #endif
         if (ret == 0)
             ret = (int)outSz;
@@ -2470,7 +2472,7 @@ static int wc_PKCS7_EncodeContentStreamHelper(PKCS7* pkcs7, int cipherType,
     Aes* aes, byte* encContentOut, byte* contentData, int contentDataSz,
     byte* out, word32* outIdx, ESD* esd)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
     byte   encContentOutOct[MAX_OCTET_STR_SZ];
     word32 encContentOutOctSz = 0;
 
@@ -2500,7 +2502,8 @@ static int wc_PKCS7_EncodeContentStreamHelper(PKCS7* pkcs7, int cipherType,
 
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* async encrypt not available here, so block till done */
-        if (ret == WC_PENDING_E && cipherType != WC_CIPHER_NONE) {
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E) &&
+            cipherType != WC_CIPHER_NONE) {
             ret = wc_AsyncWait(ret, &aes->asyncDev, WC_ASYNC_FLAG_NONE);
         }
     #endif
@@ -4048,7 +4051,7 @@ static int wc_PKCS7_RsaVerify(PKCS7* pkcs7, byte* sig, int sigSz,
                     key);
             }
     #ifdef WOLFSSL_ASYNC_CRYPT
-        } while (ret == WC_PENDING_E);
+        } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     #endif
         FreeDecodedCert(dCert);
         wc_FreeRsaKey(key);
@@ -4175,7 +4178,7 @@ static int wc_PKCS7_EcdsaVerify(PKCS7* pkcs7, byte* sig, int sigSz,
                 ret = wc_ecc_verify_hash(sig, (word32)sigSz, hash, hashSz, &res, key);
             }
     #ifdef WOLFSSL_ASYNC_CRYPT
-        } while (ret == WC_PENDING_E);
+        } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     #endif
 
         FreeDecodedCert(dCert);
@@ -5103,7 +5106,7 @@ static int wc_PKCS7_HandleOctetStrings(PKCS7* pkcs7, byte* in, word32 inSz,
                 /* check if expected data is available in stream */
                 ret = wc_PKCS7_AddDataToStream(pkcs7, in, inSz,
                             pkcs7->stream->expected, &msg, idx);
-                if (ret == WC_PKCS7_WANT_READ_E) {
+                if (ret == WC_NO_ERR_TRACE(WC_PKCS7_WANT_READ_E)) {
                     break;  /* ask user more input */
                 }
 
@@ -5130,7 +5133,7 @@ static int wc_PKCS7_HandleOctetStrings(PKCS7* pkcs7, byte* in, word32 inSz,
                 /* check if expected data is available in stream */
                 ret = wc_PKCS7_AddDataToStream(pkcs7, in, inSz,
                             pkcs7->stream->expected, &msg, idx);
-                if (ret == WC_PKCS7_WANT_READ_E) {
+                if (ret == WC_NO_ERR_TRACE(WC_PKCS7_WANT_READ_E)) {
                     break;  /* ask user more input */
                 }
 
@@ -5167,7 +5170,7 @@ static int wc_PKCS7_HandleOctetStrings(PKCS7* pkcs7, byte* in, word32 inSz,
 
                 ret = wc_PKCS7_AddDataToStream(pkcs7, in, inSz,
                             pkcs7->stream->expected, &msg, idx);
-                if (ret == WC_PKCS7_WANT_READ_E) {
+                if (ret == WC_NO_ERR_TRACE(WC_PKCS7_WANT_READ_E)) {
                     break;
                 }
 
@@ -5374,7 +5377,7 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
                 word32 len = 0;
 
                 ret = wc_BerToDer(pkiMsg, pkiMsgSz, NULL, &len);
-                if (ret != LENGTH_ONLY_E)
+                if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
                     return ret;
                 pkcs7->der = (byte*)XMALLOC(len, pkcs7->heap,
                                                         DYNAMIC_TYPE_PKCS7);
@@ -6503,7 +6506,7 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
 
         #ifndef NO_PKCS7_STREAM
             /* make sure that terminating zero's follow */
-            if ((ret == PKCS7_SIGNEEDS_CHECK || ret >= 0) &&
+            if ((ret == WC_NO_ERR_TRACE(PKCS7_SIGNEEDS_CHECK) || ret >= 0) &&
                     pkcs7->stream->indefLen == 1) {
                 int i;
                 for (i = 0; i < 3 * ASN_INDEF_END_SZ; i++) {
@@ -6531,7 +6534,7 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
             ret = BAD_FUNC_ARG;
     }
 
-    if (ret != 0 && ret != WC_PKCS7_WANT_READ_E) {
+    if (ret != 0 && ret != WC_NO_ERR_TRACE(WC_PKCS7_WANT_READ_E)) {
     #ifndef NO_PKCS7_STREAM
         wc_PKCS7_ResetStream(pkcs7);
     #endif
@@ -7909,7 +7912,7 @@ int wc_PKCS7_AddRecipient_KTRI(PKCS7* pkcs7, const byte* cert, word32 certSz,
                               encryptedKeySz, pubKey, &rng);
         }
 #ifdef WOLFSSL_ASYNC_CRYPT
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
 #endif
     wc_FreeRsaKey(pubKey);
     wc_FreeRng(&rng);
@@ -10271,7 +10274,7 @@ static int wc_PKCS7_DecryptKtri(PKCS7* pkcs7, byte* in, word32 inSz,
             #endif
                 }
             #ifdef WOLFSSL_ASYNC_CRYPT
-                } while (keySz == WC_PENDING_E);
+                } while (keySz == WC_NO_ERR_TRACE(WC_PENDING_E));
             #endif
                 #ifdef WC_RSA_BLINDING
                     wc_FreeRng(&rng);
@@ -11433,7 +11436,7 @@ static int wc_PKCS7_DecryptKari(PKCS7* pkcs7, byte* in, word32 inSz,
                 PRIVATE_KEY_UNLOCK();
                 ret = wc_ecc_export_x963(kari->senderKey, NULL, &tmpKeySz);
                 PRIVATE_KEY_LOCK();
-                if (ret != LENGTH_ONLY_E) {
+                if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
                     return ret;
                 }
 
@@ -11860,7 +11863,7 @@ static int wc_PKCS7_ParseToRecipientInfoSet(PKCS7* pkcs7, byte* in,
                 len = 0;
 
                 ret = wc_BerToDer(pkiMsg, pkiMsgSz, NULL, &len);
-                if (ret != LENGTH_ONLY_E)
+                if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
                     return ret;
                 pkcs7->der = (byte*)XMALLOC(len, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
                 if (pkcs7->der == NULL)
@@ -12445,7 +12448,7 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* in,
     }
 
 #ifndef NO_PKCS7_STREAM
-    if (ret < 0 && ret != WC_PKCS7_WANT_READ_E) {
+    if (ret < 0 && ret != WC_NO_ERR_TRACE(WC_PKCS7_WANT_READ_E)) {
         wc_PKCS7_ResetStream(pkcs7);
         wc_PKCS7_ChangeState(pkcs7, WC_PKCS7_START);
         if (pkcs7->cachedEncryptedContent != NULL) {
@@ -13635,7 +13638,7 @@ authenv_atrbend:
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    if (ret != 0 && ret != WC_PKCS7_WANT_READ_E) {
+    if (ret != 0 && ret != WC_NO_ERR_TRACE(WC_PKCS7_WANT_READ_E)) {
         if (decryptedKey != NULL) {
             ForceZero(decryptedKey, MAX_ENCRYPTED_KEY_SZ);
         }
@@ -13643,7 +13646,7 @@ authenv_atrbend:
     }
 #endif
 #ifndef NO_PKCS7_STREAM
-    if (ret != 0 && ret != WC_PKCS7_WANT_READ_E) {
+    if (ret != 0 && ret != WC_NO_ERR_TRACE(WC_PKCS7_WANT_READ_E)) {
         wc_PKCS7_ResetStream(pkcs7);
     }
 #endif

--- a/wolfcrypt/src/port/Renesas/renesas_common.c
+++ b/wolfcrypt/src/port/Renesas/renesas_common.c
@@ -89,7 +89,7 @@ WOLFSSL_LOCAL int Renesas_cmn_RsaSignCb(WOLFSSL* ssl,
                                 const unsigned char* keyDer, unsigned int keySz,
                                 void* ctx)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     WOLFSSL_ENTER("Renesas_cmn_RsaSignCb");
 
     /* This is just a stub function that provides no logic */
@@ -108,7 +108,7 @@ WOLFSSL_LOCAL int Renesas_cmn_RsaSignCheckCb(WOLFSSL* ssl,
                                 const unsigned char* keyDer, unsigned int keySz,
                                 void* ctx)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     WOLFSSL_ENTER("Renesas_cmn_RsaSignCheckCb");
 
     #if defined(WOLFSSL_RENESAS_TSIP)
@@ -127,7 +127,7 @@ WOLFSSL_LOCAL int Renesas_cmn_EccSignCb(WOLFSSL* ssl,
                                 const unsigned char* keyDer, unsigned int keySz,
                                 void* ctx)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
     WOLFSSL_ENTER("Renesas_cmn_EccSignCb");
 
     /* This is just a stub function that provides no logic */
@@ -147,7 +147,7 @@ WOLFSSL_LOCAL int Renesas_cmn_EccSignCb(WOLFSSL* ssl,
  */
 static int Renesas_cmn_CryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
 {
-    int ret = NOT_COMPILED_IN; /* return this to bypass HW and use SW */
+    int ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN); /* return this to bypass HW and use SW */
 
     WOLFSSL_ENTER("Renesas_cmn_CryptoDevCb");
 
@@ -367,7 +367,7 @@ static int Renesas_cmn_CryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
                 cbInfo->keyflgs_crypt.bits.rsapub1024_installedkey_set ) {
 
                 ret = wc_fspsm_MakeRsaKey(info->pk.rsa.key, 0, cbInfo);
-                if (ret == CRYPTOCB_UNAVAILABLE)
+                if (ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                     return ret;
 
                 if (info->pk.rsa.type == RSA_PRIVATE_DECRYPT ||
@@ -882,7 +882,7 @@ WOLFSSL_LOCAL int Renesas_cmn_generatePremasterSecret(WOLFSSL* ssl,
  */
 WOLFSSL_LOCAL int Renesas_cmn_genMasterSecret(struct WOLFSSL* ssl, void* ctx)
 {
-    int ret = WOLFSSL_NOT_IMPLEMENTED;
+    int ret = WC_NO_ERR_TRACE(WOLFSSL_NOT_IMPLEMENTED);
 
     (void) ret;
     (void) ctx;

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_aes.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_aes.c
@@ -384,7 +384,7 @@ WOLFSSL_LOCAL int tsip_Tls13AesDecrypt(
 WOLFSSL_LOCAL int wc_tsip_AesCipher(int devIdArg, wc_CryptoInfo* info,
                                                                     void* ctx)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
     TsipUserCtx* cbInfo = (TsipUserCtx*)ctx;
 
     WOLFSSL_ENTER("wc_tsip_AesCipher");

--- a/wolfcrypt/src/port/aria/aria-cryptocb.c
+++ b/wolfcrypt/src/port/aria/aria-cryptocb.c
@@ -447,7 +447,7 @@ int wc_AriaDerive(ecc_key* private_key, ecc_key* public_key,
 
     int wc_AriaCryptoCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
     {
-        int ret = CRYPTOCB_UNAVAILABLE; /* return this to bypass HW and use SW */
+        int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE); /* return this to bypass HW and use SW */
         (void)ctx;
 
         if (info == NULL)
@@ -544,15 +544,18 @@ int wc_AriaDerive(ecc_key* private_key, ecc_key* public_key,
                     ret = wc_AriaInitSha(&(info->hash.sha256->hSession), MC_ALGID_SHA256);
                 }
 
-                if ((ret == 0) || (ret == CRYPTOCB_UNAVAILABLE)) {
+                if ((ret == 0) ||
+                    (ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))) {
                     ret = wc_AriaShaUpdate(info->hash.sha256->hSession,
                                         (byte *) info->hash.in, info->hash.inSz);
                 }
-                if ((ret == 0) || (ret == CRYPTOCB_UNAVAILABLE)) {
+                if ((ret == 0) ||
+                    (ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))) {
                     MC_UINT digestSz = 32;
                     ret = wc_AriaShaFinal(info->hash.sha256->hSession,
                                         info->hash.digest, &digestSz);
-                    if ((ret == 0) || (ret == CRYPTOCB_UNAVAILABLE))
+                    if ((ret == 0) ||
+                        (ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)))
                         ret = wc_AriaFree(&(info->hash.sha256->hSession),NULL);
                 }
                 if (ret != 0)
@@ -571,16 +574,21 @@ int wc_AriaDerive(ecc_key* private_key, ecc_key* public_key,
                     ret = wc_AriaInitSha(&(info->hash.sha384->hSession), MC_ALGID_SHA384);
                 }
 
-                if ((ret == 0) || (ret == CRYPTOCB_UNAVAILABLE)) {
+                if ((ret == 0) ||
+                    (ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))) {
                     ret = wc_AriaShaUpdate(info->hash.sha384->hSession,
                                         (byte *) info->hash.in, info->hash.inSz);
                 }
-                if ((ret == 0) || (ret == CRYPTOCB_UNAVAILABLE)) {
+                if ((ret == 0) ||
+                    (ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))) {
                     MC_UINT digestSz = 48;
                     ret = wc_AriaShaFinal(info->hash.sha384->hSession,
                                         info->hash.digest, &digestSz);
-                    if ((ret == 0) || (ret == CRYPTOCB_UNAVAILABLE))
+                    if ((ret == 0) ||
+                        (ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)))
+                    {
                         ret = wc_AriaFree(&(info->hash.sha384->hSession),NULL);
+                    }
                 }
                 if (ret != 0) ret = CRYPTOCB_UNAVAILABLE;
                 /* reset devId */

--- a/wolfcrypt/src/port/arm/armv8-sha512.c
+++ b/wolfcrypt/src/port/arm/armv8-sha512.c
@@ -628,7 +628,7 @@ static int Sha512_Family_Final(wc_Sha512* sha512, byte* hash,
 #ifdef WOLF_CRYPTO_CB
     if (sha512->devId != INVALID_DEVID) {
         ret = wc_CryptoCb_Sha512Hash(sha512, NULL, 0, hash);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
     }

--- a/wolfcrypt/src/port/caam/wolfcaam_hmac.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_hmac.c
@@ -59,7 +59,7 @@ int wc_CAAM_Hmac(Hmac* hmac, int macType, const byte* msg, int msgSz,
                     hmac->keyLen);
         if (ret != 0) {
             WOLFSSL_MSG("Error with set key");
-            if (ret == HASH_TYPE_E) {
+            if (ret == WC_NO_ERR_TRACE(HASH_TYPE_E)) {
                 ret = CRYPTOCB_UNAVAILABLE; /* that hash type is not supported*/
             }
         }

--- a/wolfcrypt/src/port/caam/wolfcaam_init.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_init.c
@@ -79,7 +79,7 @@ int wc_caamSetResource(IODevice ioDev)
 /* used to route crypto operations through crypto callback */
 static int wc_CAAM_router(int devId, wc_CryptoInfo* info, void* ctx)
 {
-    int ret = CRYPTOCB_UNAVAILABLE;
+    int ret = WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE);
 
     (void)ctx;
     (void)devId;

--- a/wolfcrypt/src/port/cavium/cavium_octeon_sync.c
+++ b/wolfcrypt/src/port/cavium/cavium_octeon_sync.c
@@ -775,7 +775,7 @@ static int Octeon_AesGcm_Decrypt(Aes* aes, byte* in, byte* out, word32 inSz,
 
 static int myCryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
 {
-    int ret = NOT_COMPILED_IN; /* return this to bypass HW and use SW */
+    int ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN); /* return this to bypass HW and use SW */
 
     if (info == NULL)
         return BAD_FUNC_ARG;

--- a/wolfcrypt/src/port/devcrypto/devcrypto_rsa.c
+++ b/wolfcrypt/src/port/devcrypto/devcrypto_rsa.c
@@ -322,7 +322,7 @@ static int _PublicOperation(const byte* in, word32 inlen, byte* out,
 int wc_DevCrypto_RsaDecrypt(const byte* in, word32 inlen,
         byte* out, word32 outlen, RsaKey* key, int type)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     switch (type) {
         case RSA_PUBLIC_DECRYPT:
@@ -331,6 +331,9 @@ int wc_DevCrypto_RsaDecrypt(const byte* in, word32 inlen,
 
         case RSA_PRIVATE_DECRYPT:
             ret = _PrivateOperation(in, inlen, out, outlen, key);
+            break;
+        default:
+            ret = BAD_FUNC_ARG;
             break;
     }
 
@@ -341,7 +344,7 @@ int wc_DevCrypto_RsaDecrypt(const byte* in, word32 inlen,
 int wc_DevCrypto_RsaEncrypt(const byte* in, word32 inlen, byte* out,
         word32* outlen, RsaKey *key, int type)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     switch (type) {
         case RSA_PUBLIC_ENCRYPT:
@@ -350,6 +353,9 @@ int wc_DevCrypto_RsaEncrypt(const byte* in, word32 inlen, byte* out,
 
         case RSA_PRIVATE_ENCRYPT:
             ret = _PrivateOperation(in, inlen, out, *outlen, key);
+            break;
+        default:
+            ret = BAD_FUNC_ARG;
             break;
     }
     if (ret == 0) {

--- a/wolfcrypt/src/port/intel/quickassist_sync.c
+++ b/wolfcrypt/src/port/intel/quickassist_sync.c
@@ -674,7 +674,7 @@ int IntelQaPoll(IntelQaDev* dev)
     }
 
     {
-        if (dev->ret != WC_PENDING_E) {
+        if (dev->ret != WC_NO_ERR_TRACE(WC_PENDING_E)) {
             /* perform cleanup */
             IntelQaFreeFunc freeFunc = dev->freeFunc;
             QLOG("IntelQaOpFree: Dev %p, FreeFunc %p\n", dev, freeFunc);

--- a/wolfcrypt/src/port/iotsafe/iotsafe.c
+++ b/wolfcrypt/src/port/iotsafe/iotsafe.c
@@ -620,7 +620,7 @@ static int iotsafe_gen_keypair(byte *wr_slot, unsigned long id_size,
                                ecc_key *key)
 {
     char *resp;
-    int ret = WC_HW_E;
+    int ret = WC_NO_ERR_TRACE(WC_HW_E);
     iotsafe_cmd_start(csim_cmd, IOTSAFE_CLASS, IOTSAFE_INS_GEN_KEYPAIR, 0, 0);
     iotsafe_cmd_add_tlv(csim_cmd, IOTSAFE_TAG_PRIVKEY_ID, id_size, wr_slot);
     iotsafe_cmd_complete(csim_cmd);
@@ -822,7 +822,7 @@ static int iotsafe_sign_hash(byte *privkey_idx, uint16_t id_size,
 {
     byte mode_of_operation = IOTSAFE_MOO_SIGN_ONLY;
     uint16_t hash_algo_be = XHTONS(hash_algo);
-    int ret = WC_HW_E;
+    int ret = WC_NO_ERR_TRACE(WC_HW_E);
     char *resp;
     char R[2 * IOTSAFE_ECC_KSIZE + 1];
     char S[2 * IOTSAFE_ECC_KSIZE + 1];

--- a/wolfcrypt/src/port/kcapi/kcapi_dh.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_dh.c
@@ -52,7 +52,7 @@ static int KcapiDh_SetParams(DhKey* key)
     word32 len;
 
     ret = wc_DhParamsToDer(key, NULL, &len);
-    if (ret == LENGTH_ONLY_E) {
+    if (ret == WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
         ret = 0;
         pkcs3 = (unsigned char*)XMALLOC(len, key->heap,
                                                        DYNAMIC_TYPE_TMP_BUFFER);

--- a/wolfcrypt/src/port/liboqs/liboqs.c
+++ b/wolfcrypt/src/port/liboqs/liboqs.c
@@ -119,14 +119,14 @@ int wolfSSL_liboqsRngMutexLock(WC_RNG* rng)
 
 int wolfSSL_liboqsRngMutexUnlock(void)
 {
-    int ret = BAD_MUTEX_E;
-
     liboqsCurrentRNG = &liboqsDefaultRNG;
 
     if (liboqs_init) {
-        ret = wc_UnLockMutex(&liboqsRNGMutex);
+        return wc_UnLockMutex(&liboqsRNGMutex);
     }
-    return ret;
+    else {
+        return BAD_MUTEX_E;
+    }
 }
 
 #endif /* HAVE_LIBOQS */

--- a/wolfcrypt/src/port/maxim/maxq10xx.c
+++ b/wolfcrypt/src/port/maxim/maxq10xx.c
@@ -1450,7 +1450,7 @@ int wolfSSL_MAXQ10XX_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
     }
 #endif /* WOLFSSL_MAXQ108X */
 
-    if (rc != 0 && rc != CRYPTOCB_UNAVAILABLE) {
+    if (rc != 0 && rc != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
         rc = WC_HW_E;
     }
 

--- a/wolfcrypt/src/port/st/stsafe.c
+++ b/wolfcrypt/src/port/st/stsafe.c
@@ -559,7 +559,7 @@ int wolfSSL_STSAFE_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
 #endif /* HAVE_ECC */
 
     /* need to return negative here for error */
-    if (rc != 0 && rc != CRYPTOCB_UNAVAILABLE) {
+    if (rc != 0 && rc != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
         WOLFSSL_MSG("STSAFE: CryptoCb failed");
     #ifdef USE_STSAFE_VERBOSE
         STSAFE_INTERFACE_PRINTF("STSAFE: CryptoCb failed %d\n", rc);

--- a/wolfcrypt/src/port/ti/ti-aes.c
+++ b/wolfcrypt/src/port/ti/ti-aes.c
@@ -465,7 +465,7 @@ static int AesAuthEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
 
     ret = AesAuthArgCheck(aes, out, in, inSz, nonce, nonceSz, authTag,
         authTagSz, &M, &L);
-    if (ret == BAD_FUNC_ARG) {
+    if (ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         return ret;
     }
 
@@ -565,7 +565,7 @@ static int AesAuthDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
 
     ret = AesAuthArgCheck(aes, out, in, inSz, nonce, nonceSz, authTag,
         authTagSz, &M, &L);
-    if (ret == BAD_FUNC_ARG) {
+    if (ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         return ret;
     }
 

--- a/wolfcrypt/src/port/xilinx/xil-versal-trng.c
+++ b/wolfcrypt/src/port/xilinx/xil-versal-trng.c
@@ -134,7 +134,7 @@ int wc_VersalTrngInit(byte* nonce, word32 nonceSz)
             .PersStrPresent = XTRNGPSV_FALSE
     };
 #endif
-    int ret = WC_HW_E;
+    int ret = WC_NO_ERR_TRACE(WC_HW_E);
     XTrngpsv_Config *cfg;
     sword32 xret = 0;
     if (trng.State == XTRNGPSV_HEALTHY) {
@@ -142,22 +142,29 @@ int wc_VersalTrngInit(byte* nonce, word32 nonceSz)
     }
     cfg = XTrngpsv_LookupConfig(WOLFSSL_PSV_TRNG_DEV_ID);
     if (!cfg) {
+        ret = WC_HW_E;
         WOLFSSL_MSG("Could not lookup TRNG config");
         goto out;
     }
     xret = XTrngpsv_CfgInitialize(&trng, cfg, cfg->BaseAddress);
-    if (xret)
+    if (xret) {
+        ret = WC_HW_E;
         goto out;
+    }
     xret = versal_trng_selftest();
-    if (xret)
+    if (xret) {
+        ret = WC_HW_E;
         goto out;
+    }
 #if !defined(HAVE_HASHDRBG)
     if (nonce)
         usercfg_add_nonce(&user_cfg, nonce, nonceSz);
 #endif
     xret = XTrngpsv_Instantiate(&trng, &user_cfg);
-    if (xret)
+    if (xret) {
+        ret = WC_HW_E;
         goto out;
+    }
 
     ret = 0;
 

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1470,7 +1470,7 @@ int wc_Entropy_Get(int bits, unsigned char* entropy, word32 len)
     Entropy_StopThread();
 #endif
 
-    if (ret != BAD_MUTEX_E) {
+    if (ret != WC_NO_ERR_TRACE(BAD_MUTEX_E)) {
         /* Unlock mutex now we are done. */
         wc_UnLockMutex(&entropy_mutex);
     }
@@ -1502,7 +1502,7 @@ int wc_Entropy_OnDemandTest(void)
         ret = Entropy_HealthTest_Startup();
     }
 
-    if (ret != BAD_MUTEX_E) {
+    if (ret != WC_NO_ERR_TRACE(BAD_MUTEX_E)) {
         /* Unlock mutex now we are done. */
         wc_UnLockMutex(&entropy_mutex);
     }
@@ -1868,7 +1868,7 @@ int wc_RNG_GenerateBlock(WC_RNG* rng, byte* output, word32 sz)
     #endif
     {
         ret = wc_CryptoCb_RandomBlock(rng, output, sz);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
     }
@@ -2676,7 +2676,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     #endif
     {
         ret = wc_CryptoCb_RandomSeed(os, output, sz);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
     }
@@ -3476,7 +3476,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
             }
 
             /* driver could be waiting for entropy */
-            if (ret != RAN_BLOCK_E && ret != 0) {
+            if (ret != WC_NO_ERR_TRACE(RAN_BLOCK_E) && ret != 0) {
                 return ret;
             }
 #ifndef WOLFSSL_IMXRT1170_CAAM
@@ -3909,14 +3909,14 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 
     int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     {
-        int ret = WC_HW_E;
+        int ret = WC_NO_ERR_TRACE(WC_HW_E);
 
         #ifndef WOLF_CRYPTO_CB_FIND
         if (os->devId != INVALID_DEVID)
         #endif
         {
             ret = wc_CryptoCb_RandomSeed(os, output, sz);
-            if (ret == CRYPTOCB_UNAVAILABLE) {
+            if (ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
                 ret = WC_HW_E;
             }
         }
@@ -3954,7 +3954,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         #endif
         {
             ret = wc_CryptoCb_RandomSeed(os, output, sz);
-            if (ret != CRYPTOCB_UNAVAILABLE)
+            if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                 return ret;
             /* fall-through when unavailable */
             ret = 0; /* reset error code */

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -627,13 +627,13 @@ static int _ifc_pairwise_consistency_test(RsaKey* key, WC_RNG* rng)
 #ifdef WOLFSSL_ASYNC_CRYPT
     /* Do blocking async calls here, caller does not support WC_PENDING_E */
     do {
-        if (ret == WC_PENDING_E)
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
             ret = wc_AsyncWait(ret, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
         if (ret >= 0)
 #endif
             ret = wc_RsaSSL_Sign((const byte*)msg, msgLen, sig, sigLen, key, rng);
 #ifdef WOLFSSL_ASYNC_CRYPT
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
 #endif
 
     if (ret > 0) {
@@ -641,13 +641,13 @@ static int _ifc_pairwise_consistency_test(RsaKey* key, WC_RNG* rng)
 #ifdef WOLFSSL_ASYNC_CRYPT
         /* Do blocking async calls here, caller does not support WC_PENDING_E */
         do {
-            if (ret == WC_PENDING_E)
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
                 ret = wc_AsyncWait(ret, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
             if (ret >= 0)
 #endif
                 ret = wc_RsaSSL_VerifyInline(sig, sigLen, &plain, key);
 #ifdef WOLFSSL_ASYNC_CRYPT
-        } while (ret == WC_PENDING_E);
+        } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
 #endif
     }
 
@@ -1784,7 +1784,7 @@ static int RsaUnPad_PSS(byte *pkcsBlock, unsigned int pkcsBlockLen,
 static int RsaUnPad(const byte *pkcsBlock, unsigned int pkcsBlockLen,
                     byte **output, byte padValue)
 {
-    int    ret = BAD_FUNC_ARG;
+    int    ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
     word16 i;
 
     if (output == NULL || pkcsBlockLen < 2 || pkcsBlockLen > 0xFFFF) {
@@ -2773,7 +2773,7 @@ static int wc_RsaFunctionSync(const byte* in, word32 inLen, byte* out,
 
 #ifdef WOLFSSL_HAVE_SP_RSA
     ret = RsaFunction_SP(in, inLen, out, outLen, type, key, rng);
-    if (ret != WC_KEY_SIZE_E)
+    if (ret != WC_NO_ERR_TRACE(WC_KEY_SIZE_E))
         return ret;
 #endif /* WOLFSSL_HAVE_SP_RSA */
 
@@ -2927,7 +2927,7 @@ int wc_RsaDirect(byte* in, word32 inLen, byte* out, word32* outSz,
             key->dataLen = *outSz;
 
             ret = wc_RsaFunction(in, inLen, out, &key->dataLen, type, key, rng);
-            if (ret >= 0 || ret == WC_PENDING_E) {
+            if (ret >= 0 || ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 key->state = (type == RSA_PRIVATE_ENCRYPT ||
                     type == RSA_PUBLIC_ENCRYPT) ? RSA_STATE_ENCRYPT_RES:
                                                   RSA_STATE_DECRYPT_RES;
@@ -3125,12 +3125,12 @@ static int wc_RsaFunction_ex(const byte* in, word32 inLen, byte* out,
     {
         ret = wc_CryptoCb_Rsa(in, inLen, out, outLen, type, key, rng);
         #ifndef WOLF_CRYPTO_CB_ONLY_RSA
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable and try using software */
         #endif
         #ifdef WOLF_CRYPTO_CB_ONLY_RSA
-        if (ret == CRYPTOCB_UNAVAILABLE) {
+        if (ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
             return NO_VALID_DEVID;
         }
         return ret;
@@ -3182,7 +3182,7 @@ static int wc_RsaFunction_ex(const byte* in, word32 inLen, byte* out,
         && ret != FP_WOULDBLOCK
     #endif
     ) {
-        if (ret == MP_EXPTMOD_E) {
+        if (ret == WC_NO_ERR_TRACE(MP_EXPTMOD_E)) {
             /* This can happen due to incorrectly set FP_MAX_BITS or missing XREALLOC */
             WOLFSSL_MSG("RSA_FUNCTION MP_EXPTMOD_E: memory/config problem");
         }
@@ -3319,7 +3319,7 @@ static int RsaPublicEncryptEx(const byte* in, word32 inLen, byte* out,
                 /* SCE supports 1024 and 2048 bits */
                 ret = wc_CryptoCb_Rsa(in, inLen, out,
                                     &outLen, rsa_type, key, rng);
-                if (ret != CRYPTOCB_UNAVAILABLE)
+                if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                     return ret;
                 /* fall-through when unavailable */
                 ret = 0; /* reset error code and try using software */
@@ -3344,7 +3344,7 @@ static int RsaPublicEncryptEx(const byte* in, word32 inLen, byte* out,
         ret = wc_RsaFunction(out, (word32)sz, out, &key->dataLen, rsa_type, key,
                              rng);
 
-        if (ret >= 0 || ret == WC_PENDING_E) {
+        if (ret >= 0 || ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             key->state = RSA_STATE_ENCRYPT_RES;
         }
         if (ret < 0) {
@@ -3404,7 +3404,7 @@ static int RsaPrivateDecryptEx(const byte* in, word32 inLen, byte* out,
                             byte* label, word32 labelSz, int saltLen,
                             WC_RNG* rng)
 {
-    int ret = RSA_WRONG_TYPE_E;
+    int ret = WC_NO_ERR_TRACE(RSA_WRONG_TYPE_E);
     byte* pad = NULL;
 
     if (in == NULL || inLen == 0 || out == NULL || key == NULL) {
@@ -3476,7 +3476,7 @@ static int RsaPrivateDecryptEx(const byte* in, word32 inLen, byte* out,
                 if (key->devId != INVALID_DEVID) {
                     ret = wc_CryptoCb_Rsa(in, inLen, out,
                                         &outLen, rsa_type, key, rng);
-                    if (ret != CRYPTOCB_UNAVAILABLE)
+                    if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                       return ret;
                     /* fall-through when unavailable */
                     ret = 0; /* reset error code and try using software */
@@ -3525,7 +3525,7 @@ static int RsaPrivateDecryptEx(const byte* in, word32 inLen, byte* out,
                                               rng, pad_type != WC_RSA_OAEP_PAD);
 #endif
 
-        if (ret >= 0 || ret == WC_PENDING_E) {
+        if (ret >= 0 || ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             key->state = RSA_STATE_DECRYPT_UNPAD;
         }
         if (ret < 0) {
@@ -4238,7 +4238,7 @@ int wc_RsaEncryptSize(const RsaKey* key)
 
 #ifdef WOLF_CRYPTO_CB
     if (ret == 0 && key->devId != INVALID_DEVID) {
-        if (wc_CryptoCb_RsaGetSize(key, &ret) == CRYPTOCB_UNAVAILABLE) {
+        if (wc_CryptoCb_RsaGetSize(key, &ret) == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
             ret = 2048/8; /* hardware handles, use 2048-bit as default */
         }
     }
@@ -4305,7 +4305,7 @@ int wc_RsaExportKey(RsaKey* key,
                     byte* d, word32* dSz, byte* p, word32* pSz,
                     byte* q, word32* qSz)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     if (key && e && eSz && n && nSz && d && dSz && p && pSz && q && qSz)
         ret = 0;
@@ -4766,12 +4766,12 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
     {
         err = wc_CryptoCb_MakeRsaKey(key, size, e, rng);
         #ifndef WOLF_CRYPTO_CB_ONLY_RSA
-        if (err != CRYPTOCB_UNAVAILABLE)
+        if (err != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             goto out;
         /* fall-through when unavailable */
         #endif
         #ifdef WOLF_CRYPTO_CB_ONLY_RSA
-        if (err == CRYPTOCB_UNAVAILABLE)
+        if (err == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             err = NO_VALID_DEVID;
             goto out;
         }

--- a/wolfcrypt/src/sakke.c
+++ b/wolfcrypt/src/sakke.c
@@ -327,14 +327,18 @@ static int sakke_load_base_point(SakkeKey* key)
 static int sakke_mulmod_base(SakkeKey* key, const mp_int* n, ecc_point* res,
         int map)
 {
-    int err = NOT_COMPILED_IN;
+    int err;
 
 #ifdef WOLFSSL_SP_1024
     if ((key->ecc.idx != ECC_CUSTOM_IDX) &&
             (ecc_sets[key->ecc.idx].id == ECC_SAKKE_1)) {
         err = sp_ecc_mulmod_base_1024(n, res, map, key->heap);
     }
+    else
 #endif
+    {
+        err = NOT_COMPILED_IN;
+    }
 
     return err;
 }
@@ -353,14 +357,18 @@ static int sakke_mulmod_base(SakkeKey* key, const mp_int* n, ecc_point* res,
 static int sakke_mulmod_base_add(SakkeKey* key, const mp_int* n,
         const ecc_point* a, ecc_point* res, int map)
 {
-    int err = NOT_COMPILED_IN;
+    int err;
 
 #ifdef WOLFSSL_SP_1024
     if ((key->ecc.idx != ECC_CUSTOM_IDX) &&
             (ecc_sets[key->ecc.idx].id == ECC_SAKKE_1)) {
         err = sp_ecc_mulmod_base_add_1024(n, a, 0, res, map, key->heap);
     }
+    else
 #endif
+    {
+        err = NOT_COMPILED_IN;
+    }
 
     return err;
 }
@@ -440,7 +448,7 @@ static int sakke_mulmod_base_add(SakkeKey* key, const mp_int* n, ecc_point* a,
 static int sakke_mulmod_point(SakkeKey* key, const mp_int* n,
         const ecc_point* p, byte* table, ecc_point* res, int map)
 {
-    int err = NOT_COMPILED_IN;
+    int err;
 
 #ifdef WOLFSSL_SP_1024
     if ((key->ecc.idx != ECC_CUSTOM_IDX) &&
@@ -452,7 +460,11 @@ static int sakke_mulmod_point(SakkeKey* key, const mp_int* n,
             err = sp_ecc_mulmod_table_1024(n, p, table, res, map, key->heap);
         }
     }
+    else
 #endif
+    {
+        err = NOT_COMPILED_IN;
+    }
 
     return err;
 }
@@ -1351,7 +1363,7 @@ int wc_GenerateSakkeRskTable(const SakkeKey* key, const ecc_point* rsk,
 static int sakke_pairing(const SakkeKey* key, const ecc_point* p,
     const ecc_point* q, mp_int* r, const byte* table, word32 len)
 {
-    int err = NOT_COMPILED_IN;
+    int err;
 
 #ifdef WOLFSSL_SP_1024
     if ((key->ecc.idx != ECC_CUSTOM_IDX) &&
@@ -1363,6 +1375,9 @@ static int sakke_pairing(const SakkeKey* key, const ecc_point* p,
             err = sp_Pairing_precomp_1024(p, q, r, table, len);
         }
     }
+    else {
+        err = NOT_COMPILED_IN;
+    }
 #else
     (void)key;
     (void)p;
@@ -1370,6 +1385,7 @@ static int sakke_pairing(const SakkeKey* key, const ecc_point* p,
     (void)r;
     (void)table;
     (void)len;
+    err = NOT_COMPILED_IN;
 #endif
 
     return err;
@@ -2523,14 +2539,18 @@ int wc_GetSakkeAuthSize(SakkeKey* key, word16* authSz)
 static int sakke_modexp(const SakkeKey* key, const mp_int* b, mp_int* e,
         mp_int* r)
 {
-    int err = NOT_COMPILED_IN;
+    int err;
 
 #ifdef WOLFSSL_SP_1024
     if ((key->ecc.idx != ECC_CUSTOM_IDX) &&
             (ecc_sets[key->ecc.idx].id == ECC_SAKKE_1)) {
         err = sp_ModExp_Fp_star_1024(b, e, r);
     }
+    else
 #endif
+    {
+        err = NOT_COMPILED_IN;
+    }
 
     return err;
 }
@@ -6551,7 +6571,7 @@ int wc_SetSakkePointITable(SakkeKey* key, byte* table, word32 len)
 #ifdef WOLFSSL_HAVE_SP_ECC
     if (err == 0) {
         err = sp_ecc_gen_table_1024(key->i.i, NULL, &sz, NULL);
-        if (err == LENGTH_ONLY_E) {
+        if (err == WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
             err = 0;
         }
     }

--- a/wolfcrypt/src/sakke.c
+++ b/wolfcrypt/src/sakke.c
@@ -327,7 +327,7 @@ static int sakke_load_base_point(SakkeKey* key)
 static int sakke_mulmod_base(SakkeKey* key, const mp_int* n, ecc_point* res,
         int map)
 {
-    int err;
+    int err = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
 
 #ifdef WOLFSSL_SP_1024
     if ((key->ecc.idx != ECC_CUSTOM_IDX) &&
@@ -357,7 +357,7 @@ static int sakke_mulmod_base(SakkeKey* key, const mp_int* n, ecc_point* res,
 static int sakke_mulmod_base_add(SakkeKey* key, const mp_int* n,
         const ecc_point* a, ecc_point* res, int map)
 {
-    int err;
+    int err = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
 
 #ifdef WOLFSSL_SP_1024
     if ((key->ecc.idx != ECC_CUSTOM_IDX) &&
@@ -448,7 +448,7 @@ static int sakke_mulmod_base_add(SakkeKey* key, const mp_int* n, ecc_point* a,
 static int sakke_mulmod_point(SakkeKey* key, const mp_int* n,
         const ecc_point* p, byte* table, ecc_point* res, int map)
 {
-    int err;
+    int err = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
 
 #ifdef WOLFSSL_SP_1024
     if ((key->ecc.idx != ECC_CUSTOM_IDX) &&
@@ -1363,7 +1363,7 @@ int wc_GenerateSakkeRskTable(const SakkeKey* key, const ecc_point* rsk,
 static int sakke_pairing(const SakkeKey* key, const ecc_point* p,
     const ecc_point* q, mp_int* r, const byte* table, word32 len)
 {
-    int err;
+    int err = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
 
 #ifdef WOLFSSL_SP_1024
     if ((key->ecc.idx != ECC_CUSTOM_IDX) &&
@@ -2539,7 +2539,7 @@ int wc_GetSakkeAuthSize(SakkeKey* key, word16* authSz)
 static int sakke_modexp(const SakkeKey* key, const mp_int* b, mp_int* e,
         mp_int* r)
 {
-    int err;
+    int err = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
 
 #ifdef WOLFSSL_SP_1024
     if ((key->ecc.idx != ECC_CUSTOM_IDX) &&

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -606,7 +606,7 @@ int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)
 #ifdef WOLF_CRYPTO_CB
     if (sha->devId != INVALID_DEVID) {
         ret = wc_CryptoCb_ShaHash(sha, data, len, NULL);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         ret = 0; /* reset ret */
         /* fall-through when unavailable */
@@ -825,7 +825,7 @@ int wc_ShaFinal(wc_Sha* sha, byte* hash)
 #ifdef WOLF_CRYPTO_CB
     if (sha->devId != INVALID_DEVID) {
         ret = wc_CryptoCb_ShaHash(sha, NULL, 0, hash);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
     }

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -1499,7 +1499,7 @@ static int InitSha256(wc_Sha256* sha256)
         #endif
         {
             int ret = wc_CryptoCb_Sha256Hash(sha256, data, len, NULL);
-            if (ret != CRYPTOCB_UNAVAILABLE)
+            if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                 return ret;
             /* fall-through when unavailable */
         }
@@ -1700,7 +1700,7 @@ static int InitSha256(wc_Sha256* sha256)
         #endif
         {
             ret = wc_CryptoCb_Sha256Hash(sha256, NULL, 0, hash);
-            if (ret != CRYPTOCB_UNAVAILABLE)
+            if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                 return ret;
             /* fall-through when unavailable */
         }

--- a/wolfcrypt/src/sha3.c
+++ b/wolfcrypt/src/sha3.c
@@ -851,7 +851,7 @@ static int wc_Sha3Update(wc_Sha3* sha3, const byte* data, word32 len, byte p)
         /* QAT only supports SHA3_256 */
         if (p == WC_SHA3_256_COUNT) {
             ret = IntelQaSymSha3(&sha3->asyncDev, NULL, data, len);
-            if (ret != NOT_COMPILED_IN)
+            if (ret != WC_NO_ERR_TRACE(NOT_COMPILED_IN))
                 return ret;
             /* fall-through when unavailable */
         }
@@ -887,7 +887,7 @@ static int wc_Sha3Final(wc_Sha3* sha3, byte* hash, byte p, byte len)
         /* QAT SHA-3 only supported on v2 (8970 or later cards) */
         if (len == WC_SHA3_256_DIGEST_SIZE) {
             ret = IntelQaSymSha3(&sha3->asyncDev, hash, NULL, len);
-            if (ret != NOT_COMPILED_IN)
+            if (ret != WC_NO_ERR_TRACE(NOT_COMPILED_IN))
                 return ret;
             /* fall-through when unavailable */
         }

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -1126,7 +1126,7 @@ int wc_Sha512Update(wc_Sha512* sha512, const byte* data, word32 len)
     #endif
     {
         int ret = wc_CryptoCb_Sha512Hash(sha512, data, len, NULL);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
     }
@@ -1358,7 +1358,7 @@ static int Sha512_Family_Final(wc_Sha512* sha512, byte* hash, size_t digestSz,
     {
         byte localHash[WC_SHA512_DIGEST_SIZE];
         ret = wc_CryptoCb_Sha512Hash(sha512, NULL, 0, localHash);
-        if (ret != CRYPTOCB_UNAVAILABLE) {
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
             XMEMCPY(hash, localHash, digestSz);
             return ret;
         }
@@ -1631,7 +1631,7 @@ int wc_Sha384Update(wc_Sha384* sha384, const byte* data, word32 len)
     #endif
     {
         int ret = wc_CryptoCb_Sha384Hash(sha384, data, len, NULL);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
     }
@@ -1683,7 +1683,7 @@ int wc_Sha384Final(wc_Sha384* sha384, byte* hash)
     #endif
     {
         ret = wc_CryptoCb_Sha384Hash(sha384, NULL, 0, hash);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
     }

--- a/wolfcrypt/src/signature.c
+++ b/wolfcrypt/src/signature.c
@@ -169,7 +169,7 @@ int wc_SignatureVerifyHash(
             if (ret >= 0)
                 ret = wc_ecc_verify_hash(sig, sig_len, hash_data, hash_len,
                     &is_valid_sig, (ecc_key*)key);
-            } while (ret == WC_PENDING_E);
+            } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
             if (ret != 0 || is_valid_sig != 1) {
                 ret = SIG_VERIFY_E;
             }
@@ -226,7 +226,7 @@ int wc_SignatureVerifyHash(
                 #endif
                 if (ret >= 0)
                         ret = wc_RsaSSL_VerifyInline(plain_data, sig_len, &plain_ptr, (RsaKey*)key);
-                } while (ret == WC_PENDING_E);
+                } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
                 if (ret >= 0 && plain_ptr) {
                     if ((word32)ret == hash_len &&
                             XMEMCMP(plain_ptr, hash_data, hash_len) == 0) {
@@ -395,7 +395,7 @@ int wc_SignatureGenerateHash_ex(
             if (ret >= 0)
                 ret = wc_ecc_sign_hash(hash_data, hash_len, sig, sig_len,
                     rng, (ecc_key*)key);
-            } while (ret == WC_PENDING_E);
+            } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
 #else
             ret = SIG_TYPE_E;
 #endif
@@ -426,7 +426,7 @@ int wc_SignatureGenerateHash_ex(
                 if (ret >= 0)
                     ret = wc_RsaSSL_Sign(hash_data, hash_len, sig, *sig_len,
                         (RsaKey*)key, rng);
-            } while (ret == WC_PENDING_E);
+            } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     #endif /* WOLFSSL_CRYPTOCELL */
             if (ret >= 0) {
                 *sig_len = (word32)ret;

--- a/wolfcrypt/src/srp.c
+++ b/wolfcrypt/src/srp.c
@@ -908,27 +908,27 @@ int wc_SrpComputeKey(Srp* srp, byte* clientPubKey, word32 clientPubKeySz,
     if (digest)
         XFREE(digest, srp->heap, DYNAMIC_TYPE_SRP);
     if (u) {
-        if (r != MP_INIT_E)
+        if (r != WC_NO_ERR_TRACE(MP_INIT_E))
             mp_clear(u);
         XFREE(u, srp->heap, DYNAMIC_TYPE_SRP);
     }
     if (s) {
-        if (r != MP_INIT_E)
+        if (r != WC_NO_ERR_TRACE(MP_INIT_E))
             mp_clear(s);
         XFREE(s, srp->heap, DYNAMIC_TYPE_SRP);
     }
     if (temp1) {
-        if (r != MP_INIT_E)
+        if (r != WC_NO_ERR_TRACE(MP_INIT_E))
             mp_clear(temp1);
         XFREE(temp1, srp->heap, DYNAMIC_TYPE_SRP);
     }
     if (temp2) {
-        if (r != MP_INIT_E)
+        if (r != WC_NO_ERR_TRACE(MP_INIT_E))
             mp_clear(temp2);
         XFREE(temp2, srp->heap, DYNAMIC_TYPE_SRP);
     }
 #else
-    if (r != MP_INIT_E) {
+    if (r != WC_NO_ERR_TRACE(MP_INIT_E)) {
         mp_clear(u);
         mp_clear(s);
         mp_clear(temp1);

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -244,7 +244,7 @@ int wc_Des3_CbcDecryptWithKey(byte* out, const byte* in, word32 sz,
 int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
     const byte* password, int passwordSz, int hashType)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
 #ifdef WOLFSSL_SMALL_STACK
     byte* key      = NULL;
 #else
@@ -318,7 +318,7 @@ int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
 int wc_BufferKeyEncrypt(EncryptedInfo* info, byte* der, word32 derSz,
     const byte* password, int passwordSz, int hashType)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
 #ifdef WOLFSSL_SMALL_STACK
     byte* key      = NULL;
 #else

--- a/wolfcrypt/src/wc_pkcs11.c
+++ b/wolfcrypt/src/wc_pkcs11.c
@@ -1355,7 +1355,7 @@ int wc_Pkcs11StoreKey(Pkcs11Token* token, int type, int clear, void* key)
                 int keyType;
 
                 ret = Pkcs11HmacTypes(hmac->macType, &mechType, &keyType);
-                if (ret == NOT_COMPILED_IN)
+                if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN))
                     break;
 
                 if (ret == 0)
@@ -1367,7 +1367,7 @@ int wc_Pkcs11StoreKey(Pkcs11Token* token, int type, int clear, void* key)
                                                 (unsigned char*)hmac->id,
                                                 hmac->idLen, hmac->label,
                                                 hmac->labelLen, CKA_SIGN);
-                    if (ret == WC_HW_E) {
+                    if (ret == WC_NO_ERR_TRACE(WC_HW_E)) {
                         ret = Pkcs11CreateSecretKey(&privKey, &session,
                                                    CKK_GENERIC_SECRET,
                                                    (unsigned char*)hmac->keyRaw,
@@ -1414,7 +1414,7 @@ int wc_Pkcs11StoreKey(Pkcs11Token* token, int type, int clear, void* key)
                     }
                 }
          #endif
-                if (ret == 0 || ret == NOT_COMPILED_IN) {
+                if (ret == 0 || ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN)) {
                     /* Try ECDSA mechanism next. */
                     ret2 = Pkcs11MechAvail(&session, CKM_ECDSA);
                     if (ret2 == 0) {
@@ -1428,7 +1428,7 @@ int wc_Pkcs11StoreKey(Pkcs11Token* token, int type, int clear, void* key)
                         }
                     }
                     /* OK for this to fail if set for ECDH. */
-                    if (ret == NOT_COMPILED_IN)
+                    if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN))
                         ret = ret2;
                 }
                 if (ret == 0 && clear)
@@ -2514,7 +2514,7 @@ static int Pkcs11ECDH(Pkcs11Session* session, wc_CryptoInfo* info)
         PRIVATE_KEY_UNLOCK();
         ret = wc_ecc_export_x963(info->pk.ecdh.public_key, NULL, &pointLen);
         PRIVATE_KEY_LOCK();
-        if (ret == LENGTH_ONLY_E) {
+        if (ret == WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
             point = (unsigned char*)XMALLOC(pointLen,
                                                  info->pk.ecdh.public_key->heap,
                                                        DYNAMIC_TYPE_ECC_BUFFER);
@@ -3604,7 +3604,7 @@ static int Pkcs11Hmac(Pkcs11Session* session, wc_CryptoInfo* info)
             ret = Pkcs11CreateSecretKey(&key, session, keyType,
                                     (unsigned char*)hmac->keyRaw, hmac->keyLen,
                                     NULL, 0, NULL, 0, CKA_SIGN);
-            if (ret == WC_HW_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_HW_E)) {
                 ret = Pkcs11CreateSecretKey(&key, session, CKK_GENERIC_SECRET,
                                     (unsigned char*)hmac->keyRaw, hmac->keyLen,
                                     NULL, 0, NULL, 0, CKA_SIGN);
@@ -3614,7 +3614,7 @@ static int Pkcs11Hmac(Pkcs11Session* session, wc_CryptoInfo* info)
         else if (ret == 0 && hmac->labelLen != 0) {
             ret = Pkcs11FindKeyByLabel(&key, CKO_SECRET_KEY, keyType, session,
                                        hmac->label, hmac->labelLen);
-            if (ret == WC_HW_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_HW_E)) {
                 ret = Pkcs11FindKeyByLabel(&key, CKO_SECRET_KEY,
                                            CKK_GENERIC_SECRET, session,
                                            hmac->label, hmac->labelLen);
@@ -3623,7 +3623,7 @@ static int Pkcs11Hmac(Pkcs11Session* session, wc_CryptoInfo* info)
         else if (ret == 0) {
             ret = Pkcs11FindKeyById(&key, CKO_SECRET_KEY, keyType, session,
                                     hmac->id, hmac->idLen);
-            if (ret == WC_HW_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_HW_E)) {
                 ret = Pkcs11FindKeyById(&key, CKO_SECRET_KEY,
                                         CKK_GENERIC_SECRET, session, hmac->id,
                                         hmac->idLen);

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -1303,9 +1303,8 @@ int wolfSSL_CryptHwMutexInit(void)
 }
 int wolfSSL_CryptHwMutexLock(void)
 {
-    int ret;
     /* Make sure HW Mutex has been initialized */
-    ret = wolfSSL_CryptHwMutexInit();
+    int ret = wolfSSL_CryptHwMutexInit();
     if (ret == 0) {
         ret = wc_LockMutex(&wcCryptHwMutex);
     }
@@ -1700,9 +1699,8 @@ int wolfSSL_CryptHwMutexUnLock(void)
 
     int maxq_CryptHwMutexTryLock()
     {
-        int ret;
         /* Make sure HW Mutex has been initialized */
-        ret = wolfSSL_CryptHwMutexInit();
+        int ret = wolfSSL_CryptHwMutexInit();
         if (ret == 0) {
             ret = maxq_LockMutex(&wcCryptHwMutex, 1);
         }

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -1303,7 +1303,7 @@ int wolfSSL_CryptHwMutexInit(void)
 }
 int wolfSSL_CryptHwMutexLock(void)
 {
-    int ret = BAD_MUTEX_E;
+    int ret;
     /* Make sure HW Mutex has been initialized */
     ret = wolfSSL_CryptHwMutexInit();
     if (ret == 0) {
@@ -1313,11 +1313,12 @@ int wolfSSL_CryptHwMutexLock(void)
 }
 int wolfSSL_CryptHwMutexUnLock(void)
 {
-    int ret = BAD_MUTEX_E;
     if (wcCryptHwMutexInit) {
-        ret = wc_UnLockMutex(&wcCryptHwMutex);
+        return wc_UnLockMutex(&wcCryptHwMutex);
     }
-    return ret;
+    else {
+        return BAD_MUTEX_E;
+    }
 }
 #endif /* WOLFSSL_CRYPT_HW_MUTEX */
 
@@ -1699,7 +1700,7 @@ int wolfSSL_CryptHwMutexUnLock(void)
 
     int maxq_CryptHwMutexTryLock()
     {
-        int ret = BAD_MUTEX_E;
+        int ret;
         /* Make sure HW Mutex has been initialized */
         ret = wolfSSL_CryptHwMutexInit();
         if (ret == 0) {

--- a/wolfcrypt/src/wc_xmss.c
+++ b/wolfcrypt/src/wc_xmss.c
@@ -385,10 +385,11 @@ static const wc_XmssString wc_xmss_alg[] = {
 static int wc_xmss_str_to_params(const char *s, word32* oid,
     const XmssParams** params)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret;
 #if WOLFSSL_XMSS_MIN_HEIGHT <= 20
     unsigned int i;
 
+    ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
     for (i = 0; i < WC_XMSS_ALG_LEN; i++) {
          if (XSTRCMP(s, wc_xmss_alg[i].str) == 0) {
              *oid = wc_xmss_alg[i].oid;
@@ -401,6 +402,7 @@ static int wc_xmss_str_to_params(const char *s, word32* oid,
     (void)s;
     (void)oid;
     (void)params;
+    ret = NOT_COMPILED_IN;
 #endif
 
     return ret;
@@ -612,10 +614,11 @@ static const wc_XmssString wc_xmssmt_alg[] = {
 static int wc_xmssmt_str_to_params(const char *s, word32* oid,
     const XmssParams** params)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret;
 #if WOLFSSL_XMSS_MAX_HEIGHT >= 20
     unsigned int i;
 
+    ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
     for (i = 0; i < WC_XMSSMT_ALG_LEN; i++) {
          if (XSTRCMP(s, wc_xmssmt_alg[i].str) == 0) {
              *oid = wc_xmssmt_alg[i].oid;
@@ -628,6 +631,7 @@ static int wc_xmssmt_str_to_params(const char *s, word32* oid,
     (void)s;
     (void)oid;
     (void)params;
+    ret = NOT_COMPILED_IN;
 #endif
 
     return ret;
@@ -756,7 +760,7 @@ static WC_INLINE int wc_xmsskey_signupdate(XmssKey* key, byte* sig,
             #else
                 ret = wc_xmssmt_sign(state, msg, msgLen, key->sk, sig);
             #endif
-                if (ret == KEY_EXHAUSTED_E) {
+                if (ret == WC_NO_ERR_TRACE(KEY_EXHAUSTED_E)) {
                     /* Signature space exhausted. */
                     key->state = WC_XMSS_STATE_NOSIGS;
                     WOLFSSL_MSG("error: no XMSS signatures remaining");

--- a/wolfcrypt/src/wc_xmss.c
+++ b/wolfcrypt/src/wc_xmss.c
@@ -385,7 +385,7 @@ static const wc_XmssString wc_xmss_alg[] = {
 static int wc_xmss_str_to_params(const char *s, word32* oid,
     const XmssParams** params)
 {
-    int ret;
+    int ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
 #if WOLFSSL_XMSS_MIN_HEIGHT <= 20
     unsigned int i;
 
@@ -614,7 +614,7 @@ static const wc_XmssString wc_xmssmt_alg[] = {
 static int wc_xmssmt_str_to_params(const char *s, word32* oid,
     const XmssParams** params)
 {
-    int ret;
+    int ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
 #if WOLFSSL_XMSS_MAX_HEIGHT >= 20
     unsigned int i;
 

--- a/wolfcrypt/src/wolfevent.c
+++ b/wolfcrypt/src/wolfevent.c
@@ -55,7 +55,7 @@ int wolfEvent_Init(WOLF_EVENT* event, WOLF_EVENT_TYPE type, void* context)
 
 int wolfEvent_Poll(WOLF_EVENT* event, WOLF_EVENT_FLAG flags)
 {
-    int ret = BAD_COND_E;
+    int ret = WC_NO_ERR_TRACE(BAD_COND_E);
 
     /* Check hardware */
 #ifdef WOLFSSL_ASYNC_CRYPT

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -30,6 +30,10 @@
     extern "C" {
 #endif
 
+#ifdef WOLFSSL_DEBUG_TRACE_ERROR_CODES_H
+    #include <wolfssl/debug-untrace-error-codes.h>
+#endif
+
 enum wolfSSL_ErrorCodes {
     INPUT_CASE_ERROR             = -301,   /* process input state error */
     PREFIX_ERROR                 = -302,   /* bad index to key rounds  */
@@ -211,6 +215,9 @@ enum wolfSSL_ErrorCodes {
 WOLFSSL_LOCAL
 void SetErrorString(int err, char* buff);
 
+#ifdef WOLFSSL_DEBUG_TRACE_ERROR_CODES
+    #include <wolfssl/debug-trace-error-codes.h>
+#endif
 
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/wolfssl/include.am
+++ b/wolfssl/include.am
@@ -31,3 +31,9 @@ noinst_HEADERS+=         wolfssl/options.h
 else
 nobase_include_HEADERS+= wolfssl/options.h
 endif
+
+wolfssl/debug-trace-error-codes.h wolfssl/debug-untrace-error-codes.h: wolfssl/wolfcrypt/error-crypt.h wolfssl/error-ssl.h
+	@support/gen-debug-trace-error-codes.sh
+
+DISTCLEANFILES += wolfssl/debug-trace-error-codes.h \
+                  wolfssl/debug-untrace-error-codes.h

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -294,6 +294,22 @@ WOLFSSL_API void wc_ErrorString(int err, char* buff);
 WOLFSSL_ABI WOLFSSL_API const char* wc_GetErrorString(int error);
 #endif
 
+#if defined(WOLFSSL_DEBUG_TRACE_ERROR_CODES) && !defined(BUILDING_WOLFSSL)
+    #undef WOLFSSL_DEBUG_TRACE_ERROR_CODES
+#endif
+#ifdef WOLFSSL_DEBUG_TRACE_ERROR_CODES
+    #define WC_NO_ERR_TRACE(label) (CONST_NUM_ERR_ ## label)
+    #ifndef WC_ERR_TRACE
+        #define WC_ERR_TRACE(label)                           \
+            ( fprintf(stderr,                                 \
+                      "ERR TRACE: %s L %d " #label " (%d)\n", \
+                      __FILE__, __LINE__, label), label)
+    #endif
+    #include <wolfssl/debug-trace-error-codes.h>
+#else
+    #define WC_NO_ERR_TRACE(label) (label)
+#endif
+
 #ifdef __cplusplus
     } /* extern "C" */
 #endif


### PR DESCRIPTION
New global debugging aid -- `--enable-debug-trace-errcodes` aka `-DWOLFSSL_DEBUG_TRACE_ERROR_CODES` causes the library to render to `stderr` a message with the filename, line number, error code name, and error number, for each and every error code throw.

Example log fragment from an application, with `--enable-debug` also enabled (they are independent of each other):
```
[...]
Processing CA PEM file
wolfSSL Entering ProcessBuffer
wolfSSL Entering PemToDer
Adding a CA
ERR TRACE: wolfcrypt/src/asn.c L 1598 ASN_OBJECT_ID_E (-144)
Date AFTER check failed
ERR TRACE: wolfcrypt/src/asn.c L 21754 ASN_AFTER_DATE_E (-151)
Getting Cert Name
wolfSSL Entering wolfSSL_X509_NAME_new_ex
wolfSSL Entering wolfSSL_X509_NAME_add_entry_by_NID
Found place for name entry
[...]
```

and another example, from `testwolfcrypt` output showing results from the SRTP-KDF expected-failure tests:
```
[...]
wolfSSL Entering srtpkdf_test
ERR TRACE: wolfcrypt/src/kdf.c L 1048 BAD_FUNC_ARG (-173)
ERR TRACE: wolfcrypt/src/kdf.c L 1152 BAD_FUNC_ARG (-173)
ERR TRACE: wolfcrypt/src/aes.c L 4358 BAD_FUNC_ARG (-173)
ERR TRACE: wolfcrypt/src/aes.c L 4358 BAD_FUNC_ARG (-173)
ERR TRACE: wolfcrypt/src/kdf.c L 1048 BAD_FUNC_ARG (-173)
ERR TRACE: wolfcrypt/src/kdf.c L 1152 BAD_FUNC_ARG (-173)
ERR TRACE: wolfcrypt/src/kdf.c L 1048 BAD_FUNC_ARG (-173)
ERR TRACE: wolfcrypt/src/kdf.c L 1152 BAD_FUNC_ARG (-173)
ERR TRACE: wolfcrypt/src/kdf.c L 1048 BAD_FUNC_ARG (-173)
ERR TRACE: wolfcrypt/src/kdf.c L 1152 BAD_FUNC_ARG (-173)
ERR TRACE: wolfcrypt/src/kdf.c L 1048 BAD_FUNC_ARG (-173)
ERR TRACE: wolfcrypt/src/kdf.c L 1152 BAD_FUNC_ARG (-173)
ERR TRACE: wolfcrypt/src/kdf.c L 1048 BAD_FUNC_ARG (-173)
ERR TRACE: wolfcrypt/src/kdf.c L 1152 BAD_FUNC_ARG (-173)
SRTP KDF test passed!
[...]
```

 `WC_ERR_TRACE(label)` can be overridden (e.g. from `user_settings.h`) with an embedded-friendly or otherwise specialized definition.

Note that error codes are instrumented only inside the library -- the shimming requires `defined(BUILDING_LIBWOLFSSL)`.  Thus the `WC_NO_ERR_TRACE()` macro (which is always a constant numeric value) is for internal use only.  Everything outside the library -- applications, of course, but also `testwolfcrypt`, `benchmark.c`, etc. -- always see the same numeric constant `enum` error codes as ever.

On non-autotools builds, manually running `support/gen-debug-trace-error-codes.sh` will be necessary by some mechanism.  It's fine to run manually and directly, and takes no args.

The nitty gritty:

add `--enable-debug-trace-errcodes`, `WOLFSSL_DEBUG_TRACE_ERROR_CODES`, `WC_ERR_TRACE()`, `WC_NO_ERR_TRACE()`, `support/gen-debug-trace-error-codes.sh`.

also add numerous deployments of `WC_NO_ERR_TRACE()` to inhibit frivolous/misleading errcode traces when `-DWOLFSSL_DEBUG_TRACE_ERROR_CODES`.

tested with `wolfssl-multi-test.sh ... quick-check all-gcc-debug-c99 cppcheck-force-source` with `all-gcc-debug-c99` tweaked to have `--enable-debug-trace-errcodes`.

additional notes:

* missing `WC_NO_ERR_TRACE()` annotations are benign even in `-DWOLFSSL_DEBUG_TRACE_ERROR_CODES` builds -- they just cause frivolous errcode traces to render, obviously self-explanatory to the developer because the file and line number are rendered.

* building `-UWOLFSSL_DEBUG_TRACE_ERROR_CODES` (the default) is identical to status quo, because the default definition of `WC_NO_ERR_TRACE()` is identity.  Several frivolous or otherwise unnecessary error code initializations have been removed, but even then most such initializations have been left in place with `WC_NO_ERR_TRACE()` wrappers.

* I used several scripts to autoconvert code for  `WC_NO_ERR_TRACE()` and identify code needing manual tweaks:

autoconvert comparisons to error codes:
```
for file in $(find src wolfcrypt/src -type f -name \*.c|xargs egrep -l '[!=]=[[:space:]]*([A-Z][A-Z0-9_]*_E|BAD_FUNC_ARG|NOT_COMPILED_IN|NO_PASSWORD|BAD_OCSP_RESPONDER|CRL_CERT_DATE_ERR|ASN_NO_PEM_HEADER|ASN_NO_SKID|ASN_NO_AKID|ASN_NO_KEYUSAGE|BAD_PATH_ERROR|ZLIB_INIT_ERROR|ZLIB_COMPRESS_ERROR|ZLIB_DECOMPRESS_ERROR|CRYPTOCB_UNAVAILABLE|PKCS7_SIGNEEDS_CHECK|CHACHA_POLY_OVERFLOW|MISSING_IV|MISSING_KEY|PROTOCOLCB_UNAVAILABLE|NO_VALID_DEVID|USE_HW_PSK|BUFFER_ERROR|DECRYPT_ERROR|DTLS_CID_ERROR|DTLS_SIZE_ERROR|HRR_COOKIE_ERROR|MATCH_SUITE_ERROR|PSK_KEY_ERROR|SEQUENCE_ERROR|VERIFY_FINISHED_ERROR|VERIFY_MAC_ERROR|VERSION_ERROR|CRL_MISSING|CRL_CERT_REVOKED|OCSP_WANT_READ|APP_DATA_READY|INVALID_PARAMETER|NO_PEER_CERT|OCSP_CERT_REVOKED|OCSP_CERT_UNKNOWN|OCSP_INVALID_STATUS|OCSP_LOOKUP_FAIL|OCSP_WANT_READ|UNSUPPORTED_CERTIFICATE)[ )]'); do sed --in-place=.bak-20240607 -E -e 's/([=!]=[[:space:]]*)([A-Z][A-Z0-9_]*_E|BAD_FUNC_ARG|NOT_COMPILED_IN|NO_PASSWORD|BAD_OCSP_RESPONDER|CRL_CERT_DATE_ERR|ASN_NO_PEM_HEADER|ASN_NO_SKID|ASN_NO_AKID|ASN_NO_KEYUSAGE|BAD_PATH_ERROR|ZLIB_INIT_ERROR|ZLIB_COMPRESS_ERROR|ZLIB_DECOMPRESS_ERROR|CRYPTOCB_UNAVAILABLE|PKCS7_SIGNEEDS_CHECK|CHACHA_POLY_OVERFLOW|MISSING_IV|MISSING_KEY|PROTOCOLCB_UNAVAILABLE|NO_VALID_DEVID|USE_HW_PSK|BUFFER_ERROR|DECRYPT_ERROR|DTLS_CID_ERROR|DTLS_SIZE_ERROR|HRR_COOKIE_ERROR|MATCH_SUITE_ERROR|PSK_KEY_ERROR|SEQUENCE_ERROR|VERIFY_FINISHED_ERROR|VERIFY_MAC_ERROR|VERSION_ERROR|CRL_MISSING|CRL_CERT_REVOKED|OCSP_WANT_READ|APP_DATA_READY|INVALID_PARAMETER|NO_PEER_CERT|OCSP_CERT_REVOKED|OCSP_CERT_UNKNOWN|OCSP_INVALID_STATUS|OCSP_LOOKUP_FAIL|OCSP_WANT_READ|UNSUPPORTED_CERTIFICATE)([ )])/\1WC_NO_ERR_TRACE(\2)\3/g' "$file" || break; done
```

find initializations to error codes (require manual mitigation):
```
find src wolfcrypt/src -name \*.c -type f -print | xargs egrep -n 'int +(ret|res|err) *= *[A-Z][A-Z0-9_]* *;' | egrep -v 'WOLFSSL_SUCCESS|WOLFSSL_FAILURE|WOLFSSL_FATAL_ERROR|FP_WOULDBLOCK|MP_|FP_|WOLFSSL_TICKET_RET_FATAL|WOLFSSL_BIO_|WC_READDIR_NOFILE|DRBG_FAILURE|ED448_.*_SIZE|ESP_OK|FALSE|ESP_FAIL|R_PROCESS_COMPLETE|FSP_SUCCESS|TSIP_SUCCESS|EOK|EBADMSG' | less
```

count and rank occurrences in `testwolfcrypt` output, to orient+prioritize auditing and manual mitigation of frivolous errcode traces:
```
wolfcrypt/test/testwolfcrypt 2>&1 | grep -F 'ERR TRACE' | sort | uniq -c | sort -nr | less
```
