### PR TITLE
Clarify WOLFSSL_ROOT location for ESP8266 make builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -413,6 +413,14 @@ user_settings_asm.h
 /IDE/Espressif/**/sdkconfig
 /IDE/Espressif/**/sdkconfig.old
 
+# ESP8266 RTOS SDK has a slightly different sdkconfig filename to exclude:
+/IDE/Espressif/**/sdkconfig.debug
+/IDE/Espressif/**/sdkconfig.release
+
+# Always include Espressif makefiles (typically only used for ESP8266)
+!/IDE/Espressif/**/Makefile
+!/IDE/Espressif/**/component.mk
+
 # MPLAB
 /IDE/MPLABX16/wolfssl.X/dist/default/
 /IDE/MPLABX16/wolfssl.X/.generated_files

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/Makefile
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/Makefile
@@ -39,6 +39,10 @@
 #
 PROJECT_NAME := wolfssl_client
 
+# Optionally include component source when print path (needs work to then properly build)
+#
+# include components/wolfssl/component.mk
+
 MY_PRIVATE_CONFIG ?= n
 USE_MY_PRIVATE_WSL_CONFIG ?= n
 USE_MY_PRIVATE_MAC_CONFIG ?= n
@@ -52,76 +56,76 @@ USE_MY_PRIVATE_WINDOWS_CONFIG ?= n
 $(info *************  wolfssl_client *************)
 
 ifeq ($(MY_PRIVATE_CONFIG),y)
-    CFLAGS += -DMY_PRIVATE_CONFIG
-    $(info Enabled MY_PRIVATE_CONFIG")
+	CFLAGS += -DMY_PRIVATE_CONFIG
+	$(info Enabled MY_PRIVATE_CONFIG")
 endif
 
 # Check for Windows environment variable: USE_MY_PRIVATE_WINDOWS_CONFIG
 ifeq ($(USE_MY_PRIVATE_WINDOWS_CONFIG),y)
-    # This hard coded MY_CONFIG_FILE value must match that in the header file.
-    MY_CONFIG_FILE := /workspace/my_private_config.h
-    ifeq ($(wildcard $(MY_CONFIG_FILE)),)
-        $(info File does not exist: $(MY_CONFIG_FILE))
-    else
-        CFLAGS += -DUSE_MY_PRIVATE_WINDOWS_CONFIG
-        $(info Using private config file for: Windows)
-    endif
+	# This hard coded MY_CONFIG_FILE value must match that in the header file.
+	MY_CONFIG_FILE := /workspace/my_private_config.h
+	ifeq ($(wildcard $(MY_CONFIG_FILE)),)
+		$(info File does not exist: $(MY_CONFIG_FILE))
+	else
+		CFLAGS += -DUSE_MY_PRIVATE_WINDOWS_CONFIG
+		$(info Using private config file for: Windows)
+	endif
 endif
 
 # Check for WSL environment variable: USE_MY_PRIVATE_WSL_CONFIG
 ifeq ($(USE_MY_PRIVATE_WSL_CONFIG),y)
-    # This hard coded MY_CONFIG_FILE value must match that in the header file.
-    MY_CONFIG_FILE := /mnt/c/workspace/my_private_config.h
-    ifeq ($(wildcard $(MY_CONFIG_FILE)),)
-        $(info File does not exist: $(MY_CONFIG_FILE))
-    else
-        CFLAGS += -DUSE_MY_PRIVATE_WSL_CONFIG
-        $(info Using private config file for: WSL)
-    endif
+	# This hard coded MY_CONFIG_FILE value must match that in the header file.
+	MY_CONFIG_FILE := /mnt/c/workspace/my_private_config.h
+	ifeq ($(wildcard $(MY_CONFIG_FILE)),)
+		$(info File does not exist: $(MY_CONFIG_FILE))
+	else
+		CFLAGS += -DUSE_MY_PRIVATE_WSL_CONFIG
+		$(info Using private config file for: WSL)
+	endif
 endif
 
 # Check for Linux environment variable: USE_MY_PRIVATE_LINUX_CONFIG
 ifeq ($(USE_MY_PRIVATE_LINUX_CONFIG),y)
-    # This hard coded MY_CONFIG_FILE value must match that in the header file.
-    MY_CONFIG_FILE := ~/workspace/my_private_config.h
-    ifeq ($(wildcard $(MY_CONFIG_FILE)),)
-        $(info File does not exist: $(MY_CONFIG_FILE))
-    else
-        CFLAGS += -DUSE_MY_PRIVATE_LINUX_CONFIG
-        $(info Using private config file for: Linux)
-    endif
+	# This hard coded MY_CONFIG_FILE value must match that in the header file.
+	MY_CONFIG_FILE := ~/workspace/my_private_config.h
+	ifeq ($(wildcard $(MY_CONFIG_FILE)),)
+		$(info File does not exist: $(MY_CONFIG_FILE))
+	else
+		CFLAGS += -DUSE_MY_PRIVATE_LINUX_CONFIG
+		$(info Using private config file for: Linux)
+	endif
 endif
 
 # Check for Mac environment variable: USE_MY_PRIVATE_MAC_CONFIG
 ifeq ($(USE_MY_PRIVATE_MAC_CONFIG),y)
-    # This hard coded MY_CONFIG_FILE value must match that in the header file.
-    MY_CONFIG_FILE := ~/Documents/my_private_config.h
-    ifeq ($(wildcard $(MY_CONFIG_FILE)),)
-        $(info File does not exist: $(MY_CONFIG_FILE))
-    else
-        CFLAGS += -DUSE_MY_PRIVATE_MAC_CONFIG
-        $(info Using private config file for: Mac)
-    endif
+	# This hard coded MY_CONFIG_FILE value must match that in the header file.
+	MY_CONFIG_FILE := ~/Documents/my_private_config.h
+	ifeq ($(wildcard $(MY_CONFIG_FILE)),)
+		$(info File does not exist: $(MY_CONFIG_FILE))
+	else
+		CFLAGS += -DUSE_MY_PRIVATE_MAC_CONFIG
+		$(info Using private config file for: Mac)
+	endif
 endif
 
 ifneq ($(OS),MY_PRIVATE_CONFIG)
-    CFLAGS += -DMY_PRIVATE_CONFIG="$(MY_PRIVATE_CONFIG)"
+	CFLAGS += -DMY_PRIVATE_CONFIG="$(MY_PRIVATE_CONFIG)"
 else
-    ifeq ($(OS),Linux)
-        CFLAGS += -DOS_LINUX
-    endif
-    ifeq ($(OS),Windows_NT)
-        CFLAGS += -DWOLFSSL_MAKE_SYSTEM_NAME_WINDOWS
-    endif
-    ifeq ($(OS),Darwin)
-        CFLAGS += -DWOLFSSL_MAKE_SYSTEM_NAME_APPLE
-    endif
-    ifneq (,$(findstring MINGW,$(OS)))
-        CFLAGS += -DWOLFSSL_MAKE_SYSTEM_NAME_MINGW
-    endif
-    ifneq (,$(findstring CYGWIN,$(OS)))
-        CFLAGS += -DWOLFSSL_MAKE_SYSTEM_NAME_CYGWIN
-    endif
+	ifeq ($(OS),Linux)
+		CFLAGS += -DOS_LINUX
+	endif
+	ifeq ($(OS),Windows_NT)
+		CFLAGS += -DWOLFSSL_MAKE_SYSTEM_NAME_WINDOWS
+	endif
+	ifeq ($(OS),Darwin)
+		CFLAGS += -DWOLFSSL_MAKE_SYSTEM_NAME_APPLE
+	endif
+	ifneq (,$(findstring MINGW,$(OS)))
+		CFLAGS += -DWOLFSSL_MAKE_SYSTEM_NAME_MINGW
+	endif
+	ifneq (,$(findstring CYGWIN,$(OS)))
+		CFLAGS += -DWOLFSSL_MAKE_SYSTEM_NAME_CYGWIN
+	endif
 endif
 
 # It is essential that the build process sees the WOLFSSL_USER_SETTINGS
@@ -132,3 +136,4 @@ EXTRA_COMPONENT_DIRS = $(IDF_PATH)/examples/common_components/protocol_examples_
 
 # The Standard Espressif IDF include:
 include $(IDF_PATH)/make/project.mk
+

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/README.md
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/README.md
@@ -83,11 +83,75 @@ Reminder that we build with `make` and not `cmake` in VisualGDB.
 
 Build files will be created in `[project directory]\build`
 
-## ESP-IDF make Commandline (version 3.5 or earlier for the ESP8266)
+See notes below if building a project in a directory other than the examples.
+
+Problems?
+
+- Try deleting any existing `sdkconfig` file and/or `./build` directory to start fresh.
+- Be sure the RTOS SDK is installed and properly configured.
+
+## ESP-IDF `make` Commandline (version 3.5 or earlier for the ESP8266)
+
+In-place example build:
+
+```bash
+export IDF_PATH=~/esp/ESP8266_RTOS_SDK
+export PATH="$PATH:$HOME/esp/xtensa-lx106-elf/bin"
+cd /mnt/c/workspace/wolfssl-master/IDE/Espressif/ESP-IDF/examples/wolfssl_client
+make clean
+make
+```
+
+When building a in a *different directory*, for example assuming the `wolfssl_client` in the wolfssl examples
+directory is copied to the `C:\test\demo` directory in Windows. (aka ` /mnt/c/test/demo` in WSL),
+with a clone of wolfSSL `master` branch in `C:\workspace\wolfssl-master`:
+
+```bash
+cp -r /mnt/c/workspace/wolfssl-master/IDE/Espressif/ESP-IDF/examples/wolfssl_client/* /mnt/c/test/demo
+```
+
+Modify the project `./components/wolfssl/component.mk` file. Adjust `WOLFSSL_ROOT` setting, in this case to a value of:
+
+`WOLFSSL_ROOT := ../../../../workspace/wolfssl-master`
+
+Ensure the path is *relative* to the project `component.mk` file location and *not* absolute.
+
+Note the location of the component makefile in this case is `c:\test\demo\components\wolfssl\component.mk`.
+Thus we need to navigate up 4 parents to the root of `C:\` to find `/mnt/c` in WSL.
+
+Proceed to run `make` from the project directory as usual:
+
+```bash
+# setup environment as needed
+export IDF_PATH=~/esp/ESP8266_RTOS_SDK
+export PATH="$PATH:$HOME/esp/xtensa-lx106-elf/bin"
+
+# copy and navigate to project directory
+mkdir -p /mnt/c/test/demo  
+cp -r /mnt/c/workspace/wolfssl-master/IDE/Espressif/ESP-IDF/examples/wolfssl_client/* /mnt/c/test/demo  
+cd /mnt/c/test/demo
+
+# Clean
+rm -rf ./build
+rm sdkconfig
+make clean
+
+# Edit ./components/wolfssl/component.mk and set WOLFSSL_ROOT value
+# WOLFSSL_ROOT := ../../../../workspace/wolfssl-master
+
+# build the example project
+make
+```
+
+When using `make` there should be details in the build log to indicate
+the assigned path, and the equivalent, fully-qualified path of `WOLFSSL_ROOT`.
 
 ```
-export IDF_PATH=~/esp/ESP8266_RTOS_SDK
-
+*************  wolfssl_client *************
+***********  wolfssl component ************
+WOLFSSL_ROOT defined: ../../../../workspace/wolfssl-master
+WOLFSSL_ROOT actual:  /mnt/c/workspace/wolfssl-master
+********** end wolfssl component **********
 ```
 
 
@@ -158,7 +222,7 @@ Command:
 
 ```
 cd /mnt/c/workspace/wolfssl-$USER/IDE/Espressif/ESP-IDF/examples/wolfssl_server
-. /mnt/c/SysGCC/esp32/esp-idf/v5.1/export.sh
+. /mnt/c/SysGCC/esp32/esp-idf/v5.2/export.sh
 idf.py flash -p /dev/ttyS19 -b 115200 monitor
 ```
 

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/components/wolfssl/component.mk
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/components/wolfssl/component.mk
@@ -18,7 +18,9 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 #
 
-#
+$(info ***********  wolfssl component ************)
+
+ #
 # Component Makefile
 #
 #
@@ -53,8 +55,41 @@ CFLAGS +=-DWOLFSSL_USER_SETTINGS
 # In the wolfSSL GitHub examples for Espressif:
 #   https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples
 # When this wolfssl component.mk makefile is in [project]/components/wolfssl
-# The root is 7 directories up from here:
+# The root is 7 directories up from here (the location of of this component.mk):
 WOLFSSL_ROOT := ../../../../../../..
+
+# To set the location of a different location, it is best to use relative paths.
+#
+# Set WOLFSSL_ROOT to a relative path from the current component directory.
+# For example, if the wolfssl_client is copied from the examples to test:
+#
+# cp -r /IDE/Espressif/ESP-IDF/examples/wolfssl_client/* /mnt/c/test/demo
+#
+# we run make in   /mnt/c/test/demo
+# component is in  /mnt/c/test/demo/components/wolfssl
+# wolfssl is in    /mnt/c/workspace/wolfssl-master
+#
+# "/mnt/c" is 4 directories up:
+#             2 for `./test/demo` from where we run `make`, plus
+#             2 more from the location of `component.mk` located
+#               in `[currect directory]/components/wolfssl`.
+#
+# Thus we need 4 parent reference to find the relative path to wolfSSL:
+# WOLFSSL_ROOT := ../../../../workspace/wolfssl-master
+
+# Optional CFLAGS (make works without these; for reference only)
+# CFLAGS += -I$(WOLFSSL_ROOT)/wolfssl
+# CFLAGS += -I$(WOLFSSL_ROOT)/wolfssl/wolfcrypt
+# CFLAGS += -I$(WOLFSSL_ROOT)/wolfssl/wolfcrypt/port/Espressif
+
+abs_WOLFSSL_ROOT := $(shell realpath $(WOLFSSL_ROOT))
+
+# print-wolfssl-path-value:
+#	@echo "WOLFSSL_ROOT defined: $(WOLFSSL_ROOT)"
+#	@echo "WOLFSSL_ROOT actual:  $(abs_WOLFSSL_ROOT)"
+
+$(info WOLFSSL_ROOT defined: $(WOLFSSL_ROOT))
+$(info WOLFSSL_ROOT actual:  $(abs_WOLFSSL_ROOT))
 
 # NOTE: The wolfSSL include directory (e.g. user_settings.h) is
 # located HERE in THIS project, and *not* in the wolfSSL root.
@@ -64,7 +99,6 @@ COMPONENT_ADD_INCLUDEDIRS += $(WOLFSSL_ROOT)/.
 COMPONENT_ADD_INCLUDEDIRS += $(WOLFSSL_ROOT)/wolfssl
 COMPONENT_ADD_INCLUDEDIRS += $(WOLFSSL_ROOT)/wolfssl/wolfcrypt
 COMPONENT_ADD_INCLUDEDIRS += $(WOLFSSL_ROOT)/wolfssl/wolfcrypt/port/Espressif
-COMPONENT_ADD_INCLUDEDIRS += $(WOLFSSL_ROOT)wolfssl/wolfcrypt/port/Espressif
 # COMPONENT_ADD_INCLUDEDIRS += $ENV(IDF_PATH)/components/freertos/include/freertos
 # COMPONENT_ADD_INCLUDEDIRS += "$ENV(IDF_PATH)/soc/esp32s3/include/soc"
 
@@ -144,7 +178,7 @@ COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ed25519.o
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ed448.o
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/error.o
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/evp.o
-# COMPONENT_OBJS += $(WOLFSSL_ROOT)wolfcrypt/src/ext_kyber.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ext_kyber.o
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ext_lms.o
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ext_xmss.o
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/falcon.o
@@ -246,5 +280,7 @@ COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/port/Espressif/esp_sdk_wifi_lib.
 ##
 ## wolfcrypt
 ##
-# COMPONENT_PRIV_INCLUDEDIRS += $(PROJECT_PATH)/components/wolfssl/include
-COMPONENT_SRCDIRS += $(WOLFSSL_ROOT)wolfcrypt/src
+## COMPONENT_PRIV_INCLUDEDIRS += $(PROJECT_PATH)/components/wolfssl/include
+## COMPONENT_SRCDIRS += $(WOLFSSL_ROOT)/wolfcrypt/src
+
+$(info ********** end wolfssl component **********)

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/components/wolfssl/component.mk
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/components/wolfssl/component.mk
@@ -50,6 +50,16 @@ $(info ***********  wolfssl component ************)
 # define it here:
 CFLAGS +=-DWOLFSSL_USER_SETTINGS
 
+# Note that 4 source files created by autogen are excluded here.
+#
+# See these files commented out, below. Adjust as needed for your application:
+#
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/async.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/selftest.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wolfcrypt_first.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wolfcrypt_last.o
+
+
 # NOTICE: the WOLFSSL_ROOT setting MUST be relative!
 # See https://docs.espressif.com/projects/esp8266-rtos-sdk/en/latest/api-guides/build-system.html?highlight=must+relative#optional-component-specific-variables
 # In the wolfSSL GitHub examples for Espressif:
@@ -154,7 +164,7 @@ COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/aes.o
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/arc4.o
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/asm.o
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/asn.o
-COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/async.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/async.o # autogen exclusion
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/blake2b.o
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/blake2s.o
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/camellia.o
@@ -210,7 +220,7 @@ COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/rc2.o
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ripemd.o
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/rsa.o
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sakke.o
-COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/selftest.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/selftest.o # autogen exclusion
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sha.o
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sha256.o
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sha3.o
@@ -247,8 +257,8 @@ COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wc_lms.o
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wc_pkcs11.o
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wc_port.o
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wc_xmss.o
-COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wolfcrypt_first.o
-COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wolfcrypt_last.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wolfcrypt_first.o # autogen exclusion
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wolfcrypt_last.o  # autogen exclusion
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wolfevent.o
 COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wolfmath.o
 


### PR DESCRIPTION
# Description

Applies only to ESP8266 `make` builds.

Adds clarification in `wolfssl_client`  example for Espressif ESP8266 builds on how the `WOLFSSL_ROOT` value should be used (relative, not absolute), in both the README and `component.mk` file comments.  

Replaces spaces with tabs in project `Makefile`

Also updates `.gitignore` to explicitly:

- always include `Makefile` and `component.mk` files in the `/IDE/Espressif` path.
- always exclude `sdkconfig.debug` and `sdkconfig.release` files, also in the `/IDE/Espressif` path.

To aid in identification of path used, addition details are printed at build time. For example:

```
***********  wolfssl component ************
WOLFSSL_ROOT defined: ../../../../workspace/wolfssl-master
WOLFSSL_ROOT actual:  /mnt/c/workspace/wolfssl-master
********** end wolfssl component **********
```

### Edit:
I've added [20e0e12](https://github.com/wolfSSL/wolfssl/pull/7636/commits/20e0e12185da2235dabe3ba2bf24682fa70d9593) as a separate commit to exclude ESP8266 binaries from source files generated by [autogen](https://github.com/wolfSSL/wolfssl/blob/master/autogen.sh) & build process. This allows a freshly cloned wolfssl to be used during RTOS SDK `make` _without_ these files:

```
# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/async.o
# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/selftest.o
# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wolfcrypt_first.o
# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wolfcrypt_last.o
```
Once this PR approved, I will create a separate PR for the other examples.

Fixes zd# 18102

# Testing

How did you test?

Tested only for the ESP8266, and only manually for in-place, and relocated  `wolfssl_client` build with RTOS SDK `make` builds.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
