### PR TITLE
Fix applying non-zero offset 1 to null pointer ASAN error

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -26546,6 +26546,14 @@ int GetCipherSuiteFromName(const char* name, byte* cipherSuite0,
     return ret;
 }
 
+static inline int IncrementUnlessNull(const char** ptr) {
+    if (*ptr == NULL) {
+        return 0;
+    }
+    *ptr += 1;
+    return 1;
+}
+
 /**
 Set the enabled cipher suites.
 
@@ -26940,7 +26948,7 @@ static int ParseCipherList(Suites* suites,
             }
         }
     }
-    while (next++); /* ++ needed to skip ':' */
+    while (IncrementUnlessNull(&next)); /* increment needed to skip ':' */
 
     if (ret) {
         int keySz = 0;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -8356,6 +8356,14 @@ int tlsShowSecrets(WOLFSSL* ssl, void* secret, int secretSz,
 
 #ifdef OPENSSL_EXTRA
 
+static inline int IncrementUnlessNull(char** ptr) {
+    if (*ptr == NULL) {
+        return 0;
+    }
+    *ptr += 1;
+    return 1;
+}
+
 /*
  * check if the list has TLS13 and pre-TLS13 suites
  * @param list cipher suite list that user want to set
@@ -8433,7 +8441,7 @@ static int CheckcipherList(const char* list)
             return 0;
         }
     }
-    while (next++); /* ++ needed to skip ':' */
+    while (IncrementUnlessNull(&next)); /* increment needed to skip ':' */
 
     if (findTLSv13Suites == 0 && findbeforeSuites == 1) {
         ret = 1;/* only before TLSv13 suites */


### PR DESCRIPTION
# Description
When swapping openssl for wolfssl I encountered the following crash when compiling with ASAN enabled:

wolfssl/src/ssl.c:11892:16: runtime error: applying non-zero offset 1 to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior wolfssl/src/ssl.c:11892:16 in

wolfssl/src/internal.c:26632:16: runtime error: applying non-zero offset 1 to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior wolfssl/src/internal.c:26632:16 in

The fix is to break the loop when next pointer is NULL.

ZD 18175