### PR TITLE
alloc a buffer for NULL pointer

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -63464,6 +63464,16 @@ static int test_wolfSSL_ECDSA_SIG(void)
     ExpectIntEQ((p == outSig + 8), 1);
     ExpectIntEQ(XMEMCMP(sigData, outSig, 8), 0);
 
+    p = NULL;
+    ExpectIntEQ(wolfSSL_i2d_ECDSA_SIG(sig, &p), 8);
+#ifndef WOLFSSL_I2D_ECDSA_SIG_ALLOC
+    ExpectNull(p);
+#else
+    ExpectNotNull(p);
+    ExpectIntEQ(XMEMCMP(p, outSig, 8), 0);
+    XFREE(p, NULL, DYNAMIC_TYPE_OPENSSL);
+#endif
+
     wolfSSL_ECDSA_SIG_free(sig);
 #endif
     return EXPECT_RESULT();


### PR DESCRIPTION
# Description

allocate a buff when *pp is NULL for OpenSSL compatibility
Guarded by WOLFSSL_I2D_ECDSA_SIG_ALLOC for the backward compatibilitiy.

Fixes zd#17695

# Testing

Added the case in test_wolfSSL_ECDSA_SIG

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
