### PR TITLE
Cortex-M inline assembly: labels with unique number appended

### DIFF
--- a/wolfcrypt/src/port/arm/thumb2-aes-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-aes-asm_c.c
@@ -218,7 +218,7 @@ void AES_invert_key(unsigned char* ks, word32 rounds)
         "ADD	r10, %[ks], %[rounds], LSL #4\n\t"
         "MOV	r11, %[rounds]\n\t"
         "\n"
-    "L_AES_invert_key_loop:\n\t"
+    "L_AES_invert_key_loop%=:\n\t"
         "LDM	%[ks], {r2, r3, r4, r5}\n\t"
         "LDM	r10, {r6, r7, r8, r9}\n\t"
         "STM	r10, {r2, r3, r4, r5}\n\t"
@@ -226,15 +226,15 @@ void AES_invert_key(unsigned char* ks, word32 rounds)
         "SUBS	r11, r11, #0x2\n\t"
         "SUB	r10, r10, #0x10\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_AES_invert_key_loop\n\t"
+        "BNE	L_AES_invert_key_loop%=\n\t"
 #else
-        "BNE.N	L_AES_invert_key_loop\n\t"
+        "BNE.N	L_AES_invert_key_loop%=\n\t"
 #endif
         "SUB	%[ks], %[ks], %[rounds], LSL #3\n\t"
         "ADD	%[ks], %[ks], #0x10\n\t"
         "SUB	r11, %[rounds], #0x1\n\t"
         "\n"
-    "L_AES_invert_key_mix_loop:\n\t"
+    "L_AES_invert_key_mix_loop%=:\n\t"
         "LDM	%[ks], {r2, r3, r4, r5}\n\t"
         "UBFX	r6, r2, #0, #8\n\t"
         "UBFX	r7, r2, #8, #8\n\t"
@@ -302,9 +302,9 @@ void AES_invert_key(unsigned char* ks, word32 rounds)
         "STR	r8, [%[ks]], #4\n\t"
         "SUBS	r11, r11, #0x1\n\t"
 #ifdef __GNUC__
-        "BNE	L_AES_invert_key_mix_loop\n\t"
+        "BNE	L_AES_invert_key_mix_loop%=\n\t"
 #else
-        "BNE.W	L_AES_invert_key_mix_loop\n\t"
+        "BNE.W	L_AES_invert_key_mix_loop%=\n\t"
 #endif
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
         : [ks] "+r" (ks), [rounds] "+r" (rounds),
@@ -347,15 +347,15 @@ void AES_set_encrypt_key(const unsigned char* key, word32 len, unsigned char* ks
         "MOV	lr, %[L_AES_Thumb2_rcon]\n\t"
         "CMP	%[len], #0x80\n\t"
 #ifdef __GNUC__
-        "BEQ	L_AES_set_encrypt_key_start_128\n\t"
+        "BEQ	L_AES_set_encrypt_key_start_128%=\n\t"
 #else
-        "BEQ.W	L_AES_set_encrypt_key_start_128\n\t"
+        "BEQ.W	L_AES_set_encrypt_key_start_128%=\n\t"
 #endif
         "CMP	%[len], #0xc0\n\t"
 #ifdef __GNUC__
-        "BEQ	L_AES_set_encrypt_key_start_192\n\t"
+        "BEQ	L_AES_set_encrypt_key_start_192%=\n\t"
 #else
-        "BEQ.W	L_AES_set_encrypt_key_start_192\n\t"
+        "BEQ.W	L_AES_set_encrypt_key_start_192%=\n\t"
 #endif
         "LDR	r4, [%[key]]\n\t"
         "LDR	r5, [%[key], #4]\n\t"
@@ -378,7 +378,7 @@ void AES_set_encrypt_key(const unsigned char* key, word32 len, unsigned char* ks
         "SUB	%[ks], %[ks], #0x10\n\t"
         "MOV	r12, #0x6\n\t"
         "\n"
-    "L_AES_set_encrypt_key_loop_256:\n\t"
+    "L_AES_set_encrypt_key_loop_256%=:\n\t"
         "UBFX	r4, r7, #0, #8\n\t"
         "UBFX	r5, r7, #8, #8\n\t"
         "UBFX	r6, r7, #16, #8\n\t"
@@ -422,9 +422,9 @@ void AES_set_encrypt_key(const unsigned char* key, word32 len, unsigned char* ks
         "SUB	%[ks], %[ks], #0x10\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_AES_set_encrypt_key_loop_256\n\t"
+        "BNE	L_AES_set_encrypt_key_loop_256%=\n\t"
 #else
-        "BNE.N	L_AES_set_encrypt_key_loop_256\n\t"
+        "BNE.N	L_AES_set_encrypt_key_loop_256%=\n\t"
 #endif
         "UBFX	r4, r7, #0, #8\n\t"
         "UBFX	r5, r7, #8, #8\n\t"
@@ -448,12 +448,12 @@ void AES_set_encrypt_key(const unsigned char* key, word32 len, unsigned char* ks
         "STM	%[ks], {r4, r5, r6, r7}\n\t"
         "SUB	%[ks], %[ks], #0x10\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_AES_set_encrypt_key_end\n\t"
+        "B	L_AES_set_encrypt_key_end%=\n\t"
 #else
-        "B.N	L_AES_set_encrypt_key_end\n\t"
+        "B.N	L_AES_set_encrypt_key_end%=\n\t"
 #endif
         "\n"
-    "L_AES_set_encrypt_key_start_192:\n\t"
+    "L_AES_set_encrypt_key_start_192%=:\n\t"
         "LDR	r4, [%[key]]\n\t"
         "LDR	r5, [%[key], #4]\n\t"
         "LDR	r6, [%[key], #8]\n\t"
@@ -471,7 +471,7 @@ void AES_set_encrypt_key(const unsigned char* key, word32 len, unsigned char* ks
         "MOV	r7, r9\n\t"
         "MOV	r12, #0x7\n\t"
         "\n"
-    "L_AES_set_encrypt_key_loop_192:\n\t"
+    "L_AES_set_encrypt_key_loop_192%=:\n\t"
         "UBFX	r4, r9, #0, #8\n\t"
         "UBFX	r5, r9, #8, #8\n\t"
         "UBFX	r6, r9, #16, #8\n\t"
@@ -495,9 +495,9 @@ void AES_set_encrypt_key(const unsigned char* key, word32 len, unsigned char* ks
         "STM	%[ks], {r4, r5, r6, r7, r8, r9}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_AES_set_encrypt_key_loop_192\n\t"
+        "BNE	L_AES_set_encrypt_key_loop_192%=\n\t"
 #else
-        "BNE.N	L_AES_set_encrypt_key_loop_192\n\t"
+        "BNE.N	L_AES_set_encrypt_key_loop_192%=\n\t"
 #endif
         "UBFX	r4, r9, #0, #8\n\t"
         "UBFX	r5, r9, #8, #8\n\t"
@@ -519,12 +519,12 @@ void AES_set_encrypt_key(const unsigned char* key, word32 len, unsigned char* ks
         "EOR	r7, r7, r6\n\t"
         "STM	%[ks], {r4, r5, r6, r7}\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_AES_set_encrypt_key_end\n\t"
+        "B	L_AES_set_encrypt_key_end%=\n\t"
 #else
-        "B.N	L_AES_set_encrypt_key_end\n\t"
+        "B.N	L_AES_set_encrypt_key_end%=\n\t"
 #endif
         "\n"
-    "L_AES_set_encrypt_key_start_128:\n\t"
+    "L_AES_set_encrypt_key_start_128%=:\n\t"
         "LDR	r4, [%[key]]\n\t"
         "LDR	r5, [%[key], #4]\n\t"
         "LDR	r6, [%[key], #8]\n\t"
@@ -536,7 +536,7 @@ void AES_set_encrypt_key(const unsigned char* key, word32 len, unsigned char* ks
         "STM	%[ks], {r4, r5, r6, r7}\n\t"
         "MOV	r12, #0xa\n\t"
         "\n"
-    "L_AES_set_encrypt_key_loop_128:\n\t"
+    "L_AES_set_encrypt_key_loop_128%=:\n\t"
         "UBFX	r4, r7, #0, #8\n\t"
         "UBFX	r5, r7, #8, #8\n\t"
         "UBFX	r6, r7, #16, #8\n\t"
@@ -558,12 +558,12 @@ void AES_set_encrypt_key(const unsigned char* key, word32 len, unsigned char* ks
         "STM	%[ks], {r4, r5, r6, r7}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_AES_set_encrypt_key_loop_128\n\t"
+        "BNE	L_AES_set_encrypt_key_loop_128%=\n\t"
 #else
-        "BNE.N	L_AES_set_encrypt_key_loop_128\n\t"
+        "BNE.N	L_AES_set_encrypt_key_loop_128%=\n\t"
 #endif
         "\n"
-    "L_AES_set_encrypt_key_end:\n\t"
+    "L_AES_set_encrypt_key_end%=:\n\t"
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
         : [key] "+r" (key), [len] "+r" (len), [ks] "+r" (ks),
           [L_AES_Thumb2_te] "+r" (L_AES_Thumb2_te_c), [L_AES_Thumb2_rcon] "+r" (L_AES_Thumb2_rcon_c)
@@ -593,7 +593,7 @@ void AES_encrypt_block(const uint32_t* te, int nr, int len, const uint32_t* ks)
 
     __asm__ __volatile__ (
         "\n"
-    "L_AES_encrypt_block_nr:\n\t"
+    "L_AES_encrypt_block_nr%=:\n\t"
         "UBFX	r8, r5, #16, #8\n\t"
         "LSR	r11, r4, #24\n\t"
         "UBFX	lr, r6, #8, #8\n\t"
@@ -696,9 +696,9 @@ void AES_encrypt_block(const uint32_t* te, int nr, int len, const uint32_t* ks)
         "EOR	r7, r7, r11\n\t"
         "SUBS	%[nr], %[nr], #0x1\n\t"
 #ifdef __GNUC__
-        "BNE	L_AES_encrypt_block_nr\n\t"
+        "BNE	L_AES_encrypt_block_nr%=\n\t"
 #else
-        "BNE.W	L_AES_encrypt_block_nr\n\t"
+        "BNE.W	L_AES_encrypt_block_nr%=\n\t"
 #endif
         "UBFX	r8, r5, #16, #8\n\t"
         "LSR	r11, r4, #24\n\t"
@@ -838,18 +838,18 @@ void AES_ECB_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "PUSH	{%[ks]}\n\t"
         "CMP	r12, #0xa\n\t"
 #ifdef __GNUC__
-        "BEQ	L_AES_ECB_encrypt_start_block_128\n\t"
+        "BEQ	L_AES_ECB_encrypt_start_block_128%=\n\t"
 #else
-        "BEQ.W	L_AES_ECB_encrypt_start_block_128\n\t"
+        "BEQ.W	L_AES_ECB_encrypt_start_block_128%=\n\t"
 #endif
         "CMP	r12, #0xc\n\t"
 #ifdef __GNUC__
-        "BEQ	L_AES_ECB_encrypt_start_block_192\n\t"
+        "BEQ	L_AES_ECB_encrypt_start_block_192%=\n\t"
 #else
-        "BEQ.W	L_AES_ECB_encrypt_start_block_192\n\t"
+        "BEQ.W	L_AES_ECB_encrypt_start_block_192%=\n\t"
 #endif
         "\n"
-    "L_AES_ECB_encrypt_loop_block_256:\n\t"
+    "L_AES_ECB_encrypt_loop_block_256%=:\n\t"
         "LDR	r4, [lr]\n\t"
         "LDR	r5, [lr, #4]\n\t"
         "LDR	r6, [lr, #8]\n\t"
@@ -881,19 +881,19 @@ void AES_ECB_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
 #ifdef __GNUC__
-        "BNE	L_AES_ECB_encrypt_loop_block_256\n\t"
+        "BNE	L_AES_ECB_encrypt_loop_block_256%=\n\t"
 #else
-        "BNE.W	L_AES_ECB_encrypt_loop_block_256\n\t"
+        "BNE.W	L_AES_ECB_encrypt_loop_block_256%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_AES_ECB_encrypt_end\n\t"
+        "B	L_AES_ECB_encrypt_end%=\n\t"
 #else
-        "B.N	L_AES_ECB_encrypt_end\n\t"
+        "B.N	L_AES_ECB_encrypt_end%=\n\t"
 #endif
         "\n"
-    "L_AES_ECB_encrypt_start_block_192:\n\t"
+    "L_AES_ECB_encrypt_start_block_192%=:\n\t"
         "\n"
-    "L_AES_ECB_encrypt_loop_block_192:\n\t"
+    "L_AES_ECB_encrypt_loop_block_192%=:\n\t"
         "LDR	r4, [lr]\n\t"
         "LDR	r5, [lr, #4]\n\t"
         "LDR	r6, [lr, #8]\n\t"
@@ -925,19 +925,19 @@ void AES_ECB_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
 #ifdef __GNUC__
-        "BNE	L_AES_ECB_encrypt_loop_block_192\n\t"
+        "BNE	L_AES_ECB_encrypt_loop_block_192%=\n\t"
 #else
-        "BNE.W	L_AES_ECB_encrypt_loop_block_192\n\t"
+        "BNE.W	L_AES_ECB_encrypt_loop_block_192%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_AES_ECB_encrypt_end\n\t"
+        "B	L_AES_ECB_encrypt_end%=\n\t"
 #else
-        "B.N	L_AES_ECB_encrypt_end\n\t"
+        "B.N	L_AES_ECB_encrypt_end%=\n\t"
 #endif
         "\n"
-    "L_AES_ECB_encrypt_start_block_128:\n\t"
+    "L_AES_ECB_encrypt_start_block_128%=:\n\t"
         "\n"
-    "L_AES_ECB_encrypt_loop_block_128:\n\t"
+    "L_AES_ECB_encrypt_loop_block_128%=:\n\t"
         "LDR	r4, [lr]\n\t"
         "LDR	r5, [lr, #4]\n\t"
         "LDR	r6, [lr, #8]\n\t"
@@ -969,12 +969,12 @@ void AES_ECB_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
 #ifdef __GNUC__
-        "BNE	L_AES_ECB_encrypt_loop_block_128\n\t"
+        "BNE	L_AES_ECB_encrypt_loop_block_128%=\n\t"
 #else
-        "BNE.W	L_AES_ECB_encrypt_loop_block_128\n\t"
+        "BNE.W	L_AES_ECB_encrypt_loop_block_128%=\n\t"
 #endif
         "\n"
-    "L_AES_ECB_encrypt_end:\n\t"
+    "L_AES_ECB_encrypt_end%=:\n\t"
         "POP	{%[ks]}\n\t"
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
         : [in] "+r" (in), [out] "+r" (out), [len] "+r" (len), [ks] "+r" (ks), [nr] "+r" (nr),
@@ -1029,18 +1029,18 @@ void AES_CBC_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "PUSH	{%[ks], r9}\n\t"
         "CMP	r8, #0xa\n\t"
 #ifdef __GNUC__
-        "BEQ	L_AES_CBC_encrypt_start_block_128\n\t"
+        "BEQ	L_AES_CBC_encrypt_start_block_128%=\n\t"
 #else
-        "BEQ.W	L_AES_CBC_encrypt_start_block_128\n\t"
+        "BEQ.W	L_AES_CBC_encrypt_start_block_128%=\n\t"
 #endif
         "CMP	r8, #0xc\n\t"
 #ifdef __GNUC__
-        "BEQ	L_AES_CBC_encrypt_start_block_192\n\t"
+        "BEQ	L_AES_CBC_encrypt_start_block_192%=\n\t"
 #else
-        "BEQ.W	L_AES_CBC_encrypt_start_block_192\n\t"
+        "BEQ.W	L_AES_CBC_encrypt_start_block_192%=\n\t"
 #endif
         "\n"
-    "L_AES_CBC_encrypt_loop_block_256:\n\t"
+    "L_AES_CBC_encrypt_loop_block_256%=:\n\t"
         "LDR	r8, [lr]\n\t"
         "LDR	r9, [lr, #4]\n\t"
         "LDR	r10, [lr, #8]\n\t"
@@ -1076,19 +1076,19 @@ void AES_CBC_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
 #ifdef __GNUC__
-        "BNE	L_AES_CBC_encrypt_loop_block_256\n\t"
+        "BNE	L_AES_CBC_encrypt_loop_block_256%=\n\t"
 #else
-        "BNE.W	L_AES_CBC_encrypt_loop_block_256\n\t"
+        "BNE.W	L_AES_CBC_encrypt_loop_block_256%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_AES_CBC_encrypt_end\n\t"
+        "B	L_AES_CBC_encrypt_end%=\n\t"
 #else
-        "B.N	L_AES_CBC_encrypt_end\n\t"
+        "B.N	L_AES_CBC_encrypt_end%=\n\t"
 #endif
         "\n"
-    "L_AES_CBC_encrypt_start_block_192:\n\t"
+    "L_AES_CBC_encrypt_start_block_192%=:\n\t"
         "\n"
-    "L_AES_CBC_encrypt_loop_block_192:\n\t"
+    "L_AES_CBC_encrypt_loop_block_192%=:\n\t"
         "LDR	r8, [lr]\n\t"
         "LDR	r9, [lr, #4]\n\t"
         "LDR	r10, [lr, #8]\n\t"
@@ -1124,19 +1124,19 @@ void AES_CBC_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
 #ifdef __GNUC__
-        "BNE	L_AES_CBC_encrypt_loop_block_192\n\t"
+        "BNE	L_AES_CBC_encrypt_loop_block_192%=\n\t"
 #else
-        "BNE.W	L_AES_CBC_encrypt_loop_block_192\n\t"
+        "BNE.W	L_AES_CBC_encrypt_loop_block_192%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_AES_CBC_encrypt_end\n\t"
+        "B	L_AES_CBC_encrypt_end%=\n\t"
 #else
-        "B.N	L_AES_CBC_encrypt_end\n\t"
+        "B.N	L_AES_CBC_encrypt_end%=\n\t"
 #endif
         "\n"
-    "L_AES_CBC_encrypt_start_block_128:\n\t"
+    "L_AES_CBC_encrypt_start_block_128%=:\n\t"
         "\n"
-    "L_AES_CBC_encrypt_loop_block_128:\n\t"
+    "L_AES_CBC_encrypt_loop_block_128%=:\n\t"
         "LDR	r8, [lr]\n\t"
         "LDR	r9, [lr, #4]\n\t"
         "LDR	r10, [lr, #8]\n\t"
@@ -1172,12 +1172,12 @@ void AES_CBC_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
 #ifdef __GNUC__
-        "BNE	L_AES_CBC_encrypt_loop_block_128\n\t"
+        "BNE	L_AES_CBC_encrypt_loop_block_128%=\n\t"
 #else
-        "BNE.W	L_AES_CBC_encrypt_loop_block_128\n\t"
+        "BNE.W	L_AES_CBC_encrypt_loop_block_128%=\n\t"
 #endif
         "\n"
-    "L_AES_CBC_encrypt_end:\n\t"
+    "L_AES_CBC_encrypt_end%=:\n\t"
         "POP	{%[ks], r9}\n\t"
         "STM	r9, {r4, r5, r6, r7}\n\t"
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1241,18 +1241,18 @@ void AES_CTR_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "PUSH	{%[ks], r8}\n\t"
         "CMP	r12, #0xa\n\t"
 #ifdef __GNUC__
-        "BEQ	L_AES_CTR_encrypt_start_block_128\n\t"
+        "BEQ	L_AES_CTR_encrypt_start_block_128%=\n\t"
 #else
-        "BEQ.W	L_AES_CTR_encrypt_start_block_128\n\t"
+        "BEQ.W	L_AES_CTR_encrypt_start_block_128%=\n\t"
 #endif
         "CMP	r12, #0xc\n\t"
 #ifdef __GNUC__
-        "BEQ	L_AES_CTR_encrypt_start_block_192\n\t"
+        "BEQ	L_AES_CTR_encrypt_start_block_192%=\n\t"
 #else
-        "BEQ.W	L_AES_CTR_encrypt_start_block_192\n\t"
+        "BEQ.W	L_AES_CTR_encrypt_start_block_192%=\n\t"
 #endif
         "\n"
-    "L_AES_CTR_encrypt_loop_block_256:\n\t"
+    "L_AES_CTR_encrypt_loop_block_256%=:\n\t"
         "PUSH	{r1, %[len], lr}\n\t"
         "LDR	lr, [sp, #16]\n\t"
         "ADDS	r11, r7, #0x1\n\t"
@@ -1292,19 +1292,19 @@ void AES_CTR_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
 #ifdef __GNUC__
-        "BNE	L_AES_CTR_encrypt_loop_block_256\n\t"
+        "BNE	L_AES_CTR_encrypt_loop_block_256%=\n\t"
 #else
-        "BNE.W	L_AES_CTR_encrypt_loop_block_256\n\t"
+        "BNE.W	L_AES_CTR_encrypt_loop_block_256%=\n\t"
 #endif
 #ifdef __GNUC__
-        "B	L_AES_CTR_encrypt_end\n\t"
+        "B	L_AES_CTR_encrypt_end%=\n\t"
 #else
-        "B.W	L_AES_CTR_encrypt_end\n\t"
+        "B.W	L_AES_CTR_encrypt_end%=\n\t"
 #endif
         "\n"
-    "L_AES_CTR_encrypt_start_block_192:\n\t"
+    "L_AES_CTR_encrypt_start_block_192%=:\n\t"
         "\n"
-    "L_AES_CTR_encrypt_loop_block_192:\n\t"
+    "L_AES_CTR_encrypt_loop_block_192%=:\n\t"
         "PUSH	{r1, %[len], lr}\n\t"
         "LDR	lr, [sp, #16]\n\t"
         "ADDS	r11, r7, #0x1\n\t"
@@ -1344,19 +1344,19 @@ void AES_CTR_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
 #ifdef __GNUC__
-        "BNE	L_AES_CTR_encrypt_loop_block_192\n\t"
+        "BNE	L_AES_CTR_encrypt_loop_block_192%=\n\t"
 #else
-        "BNE.W	L_AES_CTR_encrypt_loop_block_192\n\t"
+        "BNE.W	L_AES_CTR_encrypt_loop_block_192%=\n\t"
 #endif
 #ifdef __GNUC__
-        "B	L_AES_CTR_encrypt_end\n\t"
+        "B	L_AES_CTR_encrypt_end%=\n\t"
 #else
-        "B.W	L_AES_CTR_encrypt_end\n\t"
+        "B.W	L_AES_CTR_encrypt_end%=\n\t"
 #endif
         "\n"
-    "L_AES_CTR_encrypt_start_block_128:\n\t"
+    "L_AES_CTR_encrypt_start_block_128%=:\n\t"
         "\n"
-    "L_AES_CTR_encrypt_loop_block_128:\n\t"
+    "L_AES_CTR_encrypt_loop_block_128%=:\n\t"
         "PUSH	{r1, %[len], lr}\n\t"
         "LDR	lr, [sp, #16]\n\t"
         "ADDS	r11, r7, #0x1\n\t"
@@ -1396,12 +1396,12 @@ void AES_CTR_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
 #ifdef __GNUC__
-        "BNE	L_AES_CTR_encrypt_loop_block_128\n\t"
+        "BNE	L_AES_CTR_encrypt_loop_block_128%=\n\t"
 #else
-        "BNE.W	L_AES_CTR_encrypt_loop_block_128\n\t"
+        "BNE.W	L_AES_CTR_encrypt_loop_block_128%=\n\t"
 #endif
         "\n"
-    "L_AES_CTR_encrypt_end:\n\t"
+    "L_AES_CTR_encrypt_end%=:\n\t"
         "POP	{%[ks], r8}\n\t"
         "REV	r4, r4\n\t"
         "REV	r5, r5\n\t"
@@ -1445,7 +1445,7 @@ void AES_decrypt_block(const uint32_t* td, int nr, const uint8_t* td4)
 
     __asm__ __volatile__ (
         "\n"
-    "L_AES_decrypt_block_nr:\n\t"
+    "L_AES_decrypt_block_nr%=:\n\t"
         "UBFX	r8, r7, #16, #8\n\t"
         "LSR	r11, r4, #24\n\t"
         "UBFX	r12, r6, #8, #8\n\t"
@@ -1548,9 +1548,9 @@ void AES_decrypt_block(const uint32_t* td, int nr, const uint8_t* td4)
         "EOR	r7, r7, r11\n\t"
         "SUBS	%[nr], %[nr], #0x1\n\t"
 #ifdef __GNUC__
-        "BNE	L_AES_decrypt_block_nr\n\t"
+        "BNE	L_AES_decrypt_block_nr%=\n\t"
 #else
-        "BNE.W	L_AES_decrypt_block_nr\n\t"
+        "BNE.W	L_AES_decrypt_block_nr%=\n\t"
 #endif
         "UBFX	r8, r7, #16, #8\n\t"
         "LSR	r11, r4, #24\n\t"
@@ -1725,18 +1725,18 @@ void AES_ECB_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "MOV	r2, %[L_AES_Thumb2_td4]\n\t"
         "CMP	r8, #0xa\n\t"
 #ifdef __GNUC__
-        "BEQ	L_AES_ECB_decrypt_start_block_128\n\t"
+        "BEQ	L_AES_ECB_decrypt_start_block_128%=\n\t"
 #else
-        "BEQ.W	L_AES_ECB_decrypt_start_block_128\n\t"
+        "BEQ.W	L_AES_ECB_decrypt_start_block_128%=\n\t"
 #endif
         "CMP	r8, #0xc\n\t"
 #ifdef __GNUC__
-        "BEQ	L_AES_ECB_decrypt_start_block_192\n\t"
+        "BEQ	L_AES_ECB_decrypt_start_block_192%=\n\t"
 #else
-        "BEQ.W	L_AES_ECB_decrypt_start_block_192\n\t"
+        "BEQ.W	L_AES_ECB_decrypt_start_block_192%=\n\t"
 #endif
         "\n"
-    "L_AES_ECB_decrypt_loop_block_256:\n\t"
+    "L_AES_ECB_decrypt_loop_block_256%=:\n\t"
         "LDR	r4, [lr]\n\t"
         "LDR	r5, [lr, #4]\n\t"
         "LDR	r6, [lr, #8]\n\t"
@@ -1767,19 +1767,19 @@ void AES_ECB_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
 #ifdef __GNUC__
-        "BNE	L_AES_ECB_decrypt_loop_block_256\n\t"
+        "BNE	L_AES_ECB_decrypt_loop_block_256%=\n\t"
 #else
-        "BNE.W	L_AES_ECB_decrypt_loop_block_256\n\t"
+        "BNE.W	L_AES_ECB_decrypt_loop_block_256%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_AES_ECB_decrypt_end\n\t"
+        "B	L_AES_ECB_decrypt_end%=\n\t"
 #else
-        "B.N	L_AES_ECB_decrypt_end\n\t"
+        "B.N	L_AES_ECB_decrypt_end%=\n\t"
 #endif
         "\n"
-    "L_AES_ECB_decrypt_start_block_192:\n\t"
+    "L_AES_ECB_decrypt_start_block_192%=:\n\t"
         "\n"
-    "L_AES_ECB_decrypt_loop_block_192:\n\t"
+    "L_AES_ECB_decrypt_loop_block_192%=:\n\t"
         "LDR	r4, [lr]\n\t"
         "LDR	r5, [lr, #4]\n\t"
         "LDR	r6, [lr, #8]\n\t"
@@ -1810,19 +1810,19 @@ void AES_ECB_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
 #ifdef __GNUC__
-        "BNE	L_AES_ECB_decrypt_loop_block_192\n\t"
+        "BNE	L_AES_ECB_decrypt_loop_block_192%=\n\t"
 #else
-        "BNE.W	L_AES_ECB_decrypt_loop_block_192\n\t"
+        "BNE.W	L_AES_ECB_decrypt_loop_block_192%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_AES_ECB_decrypt_end\n\t"
+        "B	L_AES_ECB_decrypt_end%=\n\t"
 #else
-        "B.N	L_AES_ECB_decrypt_end\n\t"
+        "B.N	L_AES_ECB_decrypt_end%=\n\t"
 #endif
         "\n"
-    "L_AES_ECB_decrypt_start_block_128:\n\t"
+    "L_AES_ECB_decrypt_start_block_128%=:\n\t"
         "\n"
-    "L_AES_ECB_decrypt_loop_block_128:\n\t"
+    "L_AES_ECB_decrypt_loop_block_128%=:\n\t"
         "LDR	r4, [lr]\n\t"
         "LDR	r5, [lr, #4]\n\t"
         "LDR	r6, [lr, #8]\n\t"
@@ -1853,12 +1853,12 @@ void AES_ECB_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
 #ifdef __GNUC__
-        "BNE	L_AES_ECB_decrypt_loop_block_128\n\t"
+        "BNE	L_AES_ECB_decrypt_loop_block_128%=\n\t"
 #else
-        "BNE.W	L_AES_ECB_decrypt_loop_block_128\n\t"
+        "BNE.W	L_AES_ECB_decrypt_loop_block_128%=\n\t"
 #endif
         "\n"
-    "L_AES_ECB_decrypt_end:\n\t"
+    "L_AES_ECB_decrypt_end%=:\n\t"
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
         : [in] "+r" (in), [out] "+r" (out), [len] "+r" (len), [ks] "+r" (ks), [nr] "+r" (nr),
           [L_AES_Thumb2_td_ecb] "+r" (L_AES_Thumb2_td_ecb_c), [L_AES_Thumb2_td4] "+r" (L_AES_Thumb2_td4_c)
@@ -1914,18 +1914,18 @@ void AES_CBC_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "PUSH	{%[ks], r4}\n\t"
         "CMP	r8, #0xa\n\t"
 #ifdef __GNUC__
-        "BEQ	L_AES_CBC_decrypt_loop_block_128\n\t"
+        "BEQ	L_AES_CBC_decrypt_loop_block_128%=\n\t"
 #else
-        "BEQ.W	L_AES_CBC_decrypt_loop_block_128\n\t"
+        "BEQ.W	L_AES_CBC_decrypt_loop_block_128%=\n\t"
 #endif
         "CMP	r8, #0xc\n\t"
 #ifdef __GNUC__
-        "BEQ	L_AES_CBC_decrypt_loop_block_192\n\t"
+        "BEQ	L_AES_CBC_decrypt_loop_block_192%=\n\t"
 #else
-        "BEQ.W	L_AES_CBC_decrypt_loop_block_192\n\t"
+        "BEQ.W	L_AES_CBC_decrypt_loop_block_192%=\n\t"
 #endif
         "\n"
-    "L_AES_CBC_decrypt_loop_block_256:\n\t"
+    "L_AES_CBC_decrypt_loop_block_256%=:\n\t"
         "PUSH	{r1, r12, lr}\n\t"
         "LDR	r4, [lr]\n\t"
         "LDR	r5, [lr, #4]\n\t"
@@ -1966,9 +1966,9 @@ void AES_CBC_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
 #ifdef __GNUC__
-        "BEQ	L_AES_CBC_decrypt_end_odd\n\t"
+        "BEQ	L_AES_CBC_decrypt_end_odd%=\n\t"
 #else
-        "BEQ.W	L_AES_CBC_decrypt_end_odd\n\t"
+        "BEQ.W	L_AES_CBC_decrypt_end_odd%=\n\t"
 #endif
         "PUSH	{r1, r12, lr}\n\t"
         "LDR	r4, [lr]\n\t"
@@ -2011,17 +2011,17 @@ void AES_CBC_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
 #ifdef __GNUC__
-        "BNE	L_AES_CBC_decrypt_loop_block_256\n\t"
+        "BNE	L_AES_CBC_decrypt_loop_block_256%=\n\t"
 #else
-        "BNE.W	L_AES_CBC_decrypt_loop_block_256\n\t"
+        "BNE.W	L_AES_CBC_decrypt_loop_block_256%=\n\t"
 #endif
 #ifdef __GNUC__
-        "B	L_AES_CBC_decrypt_end\n\t"
+        "B	L_AES_CBC_decrypt_end%=\n\t"
 #else
-        "B.W	L_AES_CBC_decrypt_end\n\t"
+        "B.W	L_AES_CBC_decrypt_end%=\n\t"
 #endif
         "\n"
-    "L_AES_CBC_decrypt_loop_block_192:\n\t"
+    "L_AES_CBC_decrypt_loop_block_192%=:\n\t"
         "PUSH	{r1, r12, lr}\n\t"
         "LDR	r4, [lr]\n\t"
         "LDR	r5, [lr, #4]\n\t"
@@ -2062,9 +2062,9 @@ void AES_CBC_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
 #ifdef __GNUC__
-        "BEQ	L_AES_CBC_decrypt_end_odd\n\t"
+        "BEQ	L_AES_CBC_decrypt_end_odd%=\n\t"
 #else
-        "BEQ.W	L_AES_CBC_decrypt_end_odd\n\t"
+        "BEQ.W	L_AES_CBC_decrypt_end_odd%=\n\t"
 #endif
         "PUSH	{r1, r12, lr}\n\t"
         "LDR	r4, [lr]\n\t"
@@ -2107,17 +2107,17 @@ void AES_CBC_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
 #ifdef __GNUC__
-        "BNE	L_AES_CBC_decrypt_loop_block_192\n\t"
+        "BNE	L_AES_CBC_decrypt_loop_block_192%=\n\t"
 #else
-        "BNE.W	L_AES_CBC_decrypt_loop_block_192\n\t"
+        "BNE.W	L_AES_CBC_decrypt_loop_block_192%=\n\t"
 #endif
 #ifdef __GNUC__
-        "B	L_AES_CBC_decrypt_end\n\t"
+        "B	L_AES_CBC_decrypt_end%=\n\t"
 #else
-        "B.W	L_AES_CBC_decrypt_end\n\t"
+        "B.W	L_AES_CBC_decrypt_end%=\n\t"
 #endif
         "\n"
-    "L_AES_CBC_decrypt_loop_block_128:\n\t"
+    "L_AES_CBC_decrypt_loop_block_128%=:\n\t"
         "PUSH	{r1, r12, lr}\n\t"
         "LDR	r4, [lr]\n\t"
         "LDR	r5, [lr, #4]\n\t"
@@ -2158,9 +2158,9 @@ void AES_CBC_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
 #ifdef __GNUC__
-        "BEQ	L_AES_CBC_decrypt_end_odd\n\t"
+        "BEQ	L_AES_CBC_decrypt_end_odd%=\n\t"
 #else
-        "BEQ.W	L_AES_CBC_decrypt_end_odd\n\t"
+        "BEQ.W	L_AES_CBC_decrypt_end_odd%=\n\t"
 #endif
         "PUSH	{r1, r12, lr}\n\t"
         "LDR	r4, [lr]\n\t"
@@ -2203,24 +2203,24 @@ void AES_CBC_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
 #ifdef __GNUC__
-        "BNE	L_AES_CBC_decrypt_loop_block_128\n\t"
+        "BNE	L_AES_CBC_decrypt_loop_block_128%=\n\t"
 #else
-        "BNE.W	L_AES_CBC_decrypt_loop_block_128\n\t"
+        "BNE.W	L_AES_CBC_decrypt_loop_block_128%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_AES_CBC_decrypt_end\n\t"
+        "B	L_AES_CBC_decrypt_end%=\n\t"
 #else
-        "B.N	L_AES_CBC_decrypt_end\n\t"
+        "B.N	L_AES_CBC_decrypt_end%=\n\t"
 #endif
         "\n"
-    "L_AES_CBC_decrypt_end_odd:\n\t"
+    "L_AES_CBC_decrypt_end_odd%=:\n\t"
         "LDR	r4, [sp, #4]\n\t"
         "LDRD	r8, r9, [r4, #16]\n\t"
         "LDRD	r10, r11, [r4, #24]\n\t"
         "STRD	r8, r9, [r4]\n\t"
         "STRD	r10, r11, [r4, #8]\n\t"
         "\n"
-    "L_AES_CBC_decrypt_end:\n\t"
+    "L_AES_CBC_decrypt_end%=:\n\t"
         "POP	{%[ks], r4}\n\t"
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
         : [in] "+r" (in), [out] "+r" (out), [len] "+r" (len), [ks] "+r" (ks), [nr] "+r" (nr), [iv] "+r" (iv),
@@ -2271,7 +2271,7 @@ void GCM_gmult_len(unsigned char* x, const unsigned char** m, const unsigned cha
     __asm__ __volatile__ (
         "MOV	lr, %[L_GCM_gmult_len_r]\n\t"
         "\n"
-    "L_GCM_gmult_len_start_block:\n\t"
+    "L_GCM_gmult_len_start_block%=:\n\t"
         "PUSH	{r3}\n\t"
         "LDR	r12, [r0, #12]\n\t"
         "LDR	%[len], [r2, #12]\n\t"
@@ -2817,9 +2817,9 @@ void GCM_gmult_len(unsigned char* x, const unsigned char** m, const unsigned cha
         "SUBS	%[len], %[len], #0x10\n\t"
         "ADD	%[data], %[data], #0x10\n\t"
 #ifdef __GNUC__
-        "BNE	L_GCM_gmult_len_start_block\n\t"
+        "BNE	L_GCM_gmult_len_start_block%=\n\t"
 #else
-        "BNE.W	L_GCM_gmult_len_start_block\n\t"
+        "BNE.W	L_GCM_gmult_len_start_block%=\n\t"
 #endif
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
         : [x] "+r" (x), [m] "+r" (m), [data] "+r" (data), [len] "+r" (len),
@@ -2875,18 +2875,18 @@ void AES_GCM_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "PUSH	{%[ks], r8}\n\t"
         "CMP	r12, #0xa\n\t"
 #ifdef __GNUC__
-        "BEQ	L_AES_GCM_encrypt_start_block_128\n\t"
+        "BEQ	L_AES_GCM_encrypt_start_block_128%=\n\t"
 #else
-        "BEQ.W	L_AES_GCM_encrypt_start_block_128\n\t"
+        "BEQ.W	L_AES_GCM_encrypt_start_block_128%=\n\t"
 #endif
         "CMP	r12, #0xc\n\t"
 #ifdef __GNUC__
-        "BEQ	L_AES_GCM_encrypt_start_block_192\n\t"
+        "BEQ	L_AES_GCM_encrypt_start_block_192%=\n\t"
 #else
-        "BEQ.W	L_AES_GCM_encrypt_start_block_192\n\t"
+        "BEQ.W	L_AES_GCM_encrypt_start_block_192%=\n\t"
 #endif
         "\n"
-    "L_AES_GCM_encrypt_loop_block_256:\n\t"
+    "L_AES_GCM_encrypt_loop_block_256%=:\n\t"
         "PUSH	{r1, %[len], lr}\n\t"
         "LDR	lr, [sp, #16]\n\t"
         "ADD	r7, r7, #0x1\n\t"
@@ -2923,19 +2923,19 @@ void AES_GCM_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
 #ifdef __GNUC__
-        "BNE	L_AES_GCM_encrypt_loop_block_256\n\t"
+        "BNE	L_AES_GCM_encrypt_loop_block_256%=\n\t"
 #else
-        "BNE.W	L_AES_GCM_encrypt_loop_block_256\n\t"
+        "BNE.W	L_AES_GCM_encrypt_loop_block_256%=\n\t"
 #endif
 #ifdef __GNUC__
-        "B	L_AES_GCM_encrypt_end\n\t"
+        "B	L_AES_GCM_encrypt_end%=\n\t"
 #else
-        "B.W	L_AES_GCM_encrypt_end\n\t"
+        "B.W	L_AES_GCM_encrypt_end%=\n\t"
 #endif
         "\n"
-    "L_AES_GCM_encrypt_start_block_192:\n\t"
+    "L_AES_GCM_encrypt_start_block_192%=:\n\t"
         "\n"
-    "L_AES_GCM_encrypt_loop_block_192:\n\t"
+    "L_AES_GCM_encrypt_loop_block_192%=:\n\t"
         "PUSH	{r1, %[len], lr}\n\t"
         "LDR	lr, [sp, #16]\n\t"
         "ADD	r7, r7, #0x1\n\t"
@@ -2972,19 +2972,19 @@ void AES_GCM_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
 #ifdef __GNUC__
-        "BNE	L_AES_GCM_encrypt_loop_block_192\n\t"
+        "BNE	L_AES_GCM_encrypt_loop_block_192%=\n\t"
 #else
-        "BNE.W	L_AES_GCM_encrypt_loop_block_192\n\t"
+        "BNE.W	L_AES_GCM_encrypt_loop_block_192%=\n\t"
 #endif
 #ifdef __GNUC__
-        "B	L_AES_GCM_encrypt_end\n\t"
+        "B	L_AES_GCM_encrypt_end%=\n\t"
 #else
-        "B.W	L_AES_GCM_encrypt_end\n\t"
+        "B.W	L_AES_GCM_encrypt_end%=\n\t"
 #endif
         "\n"
-    "L_AES_GCM_encrypt_start_block_128:\n\t"
+    "L_AES_GCM_encrypt_start_block_128%=:\n\t"
         "\n"
-    "L_AES_GCM_encrypt_loop_block_128:\n\t"
+    "L_AES_GCM_encrypt_loop_block_128%=:\n\t"
         "PUSH	{r1, %[len], lr}\n\t"
         "LDR	lr, [sp, #16]\n\t"
         "ADD	r7, r7, #0x1\n\t"
@@ -3021,12 +3021,12 @@ void AES_GCM_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
 #ifdef __GNUC__
-        "BNE	L_AES_GCM_encrypt_loop_block_128\n\t"
+        "BNE	L_AES_GCM_encrypt_loop_block_128%=\n\t"
 #else
-        "BNE.W	L_AES_GCM_encrypt_loop_block_128\n\t"
+        "BNE.W	L_AES_GCM_encrypt_loop_block_128%=\n\t"
 #endif
         "\n"
-    "L_AES_GCM_encrypt_end:\n\t"
+    "L_AES_GCM_encrypt_end%=:\n\t"
         "POP	{%[ks], r8}\n\t"
         "REV	r4, r4\n\t"
         "REV	r5, r5\n\t"

--- a/wolfcrypt/src/port/arm/thumb2-curve25519_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-curve25519_c.c
@@ -2796,9 +2796,9 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "MOV	%[a], #0x1c\n\t"
         "STR	%[a], [sp, #176]\n\t"
         "\n"
-    "L_curve25519_words:\n\t"
+    "L_curve25519_words%=:\n\t"
         "\n"
-    "L_curve25519_bits:\n\t"
+    "L_curve25519_bits%=:\n\t"
         "LDR	%[n], [sp, #164]\n\t"
         "LDR	%[a], [%[n], r2]\n\t"
         "LDR	%[n], [sp, #180]\n\t"
@@ -2979,18 +2979,18 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "SUBS	%[n], %[n], #0x1\n\t"
         "STR	%[n], [sp, #180]\n\t"
 #ifdef __GNUC__
-        "BGE	L_curve25519_bits\n\t"
+        "BGE	L_curve25519_bits%=\n\t"
 #else
-        "BGE.W	L_curve25519_bits\n\t"
+        "BGE.W	L_curve25519_bits%=\n\t"
 #endif
         "MOV	%[n], #0x1f\n\t"
         "STR	%[n], [sp, #180]\n\t"
         "SUBS	%[a], %[a], #0x4\n\t"
         "STR	%[a], [sp, #176]\n\t"
 #ifdef __GNUC__
-        "BGE	L_curve25519_words\n\t"
+        "BGE	L_curve25519_words%=\n\t"
 #else
-        "BGE.W	L_curve25519_words\n\t"
+        "BGE.W	L_curve25519_words%=\n\t"
 #endif
         /* Invert */
         "ADD	r1, sp, #0x0\n\t"
@@ -3022,7 +3022,7 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x4\n\t"
         "\n"
-    "L_curve25519_inv_1:\n\t"
+    "L_curve25519_inv_1%=:\n\t"
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
@@ -3030,9 +3030,9 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_1\n\t"
+        "BNE	L_curve25519_inv_1%=\n\t"
 #else
-        "BNE.N	L_curve25519_inv_1\n\t"
+        "BNE.N	L_curve25519_inv_1%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3043,7 +3043,7 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x9\n\t"
         "\n"
-    "L_curve25519_inv_2:\n\t"
+    "L_curve25519_inv_2%=:\n\t"
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
@@ -3051,9 +3051,9 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_2\n\t"
+        "BNE	L_curve25519_inv_2%=\n\t"
 #else
-        "BNE.N	L_curve25519_inv_2\n\t"
+        "BNE.N	L_curve25519_inv_2%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3064,7 +3064,7 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x13\n\t"
         "\n"
-    "L_curve25519_inv_3:\n\t"
+    "L_curve25519_inv_3%=:\n\t"
         "ADD	r1, sp, #0x80\n\t"
         "ADD	r0, sp, #0x80\n\t"
         "PUSH	{r12}\n\t"
@@ -3072,9 +3072,9 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_3\n\t"
+        "BNE	L_curve25519_inv_3%=\n\t"
 #else
-        "BNE.N	L_curve25519_inv_3\n\t"
+        "BNE.N	L_curve25519_inv_3%=\n\t"
 #endif
         "ADD	r2, sp, #0x60\n\t"
         "ADD	r1, sp, #0x80\n\t"
@@ -3082,7 +3082,7 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0xa\n\t"
         "\n"
-    "L_curve25519_inv_4:\n\t"
+    "L_curve25519_inv_4%=:\n\t"
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
@@ -3090,9 +3090,9 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_4\n\t"
+        "BNE	L_curve25519_inv_4%=\n\t"
 #else
-        "BNE.N	L_curve25519_inv_4\n\t"
+        "BNE.N	L_curve25519_inv_4%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3103,7 +3103,7 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x31\n\t"
         "\n"
-    "L_curve25519_inv_5:\n\t"
+    "L_curve25519_inv_5%=:\n\t"
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
@@ -3111,9 +3111,9 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_5\n\t"
+        "BNE	L_curve25519_inv_5%=\n\t"
 #else
-        "BNE.N	L_curve25519_inv_5\n\t"
+        "BNE.N	L_curve25519_inv_5%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3124,7 +3124,7 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x63\n\t"
         "\n"
-    "L_curve25519_inv_6:\n\t"
+    "L_curve25519_inv_6%=:\n\t"
         "ADD	r1, sp, #0x80\n\t"
         "ADD	r0, sp, #0x80\n\t"
         "PUSH	{r12}\n\t"
@@ -3132,9 +3132,9 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_6\n\t"
+        "BNE	L_curve25519_inv_6%=\n\t"
 #else
-        "BNE.N	L_curve25519_inv_6\n\t"
+        "BNE.N	L_curve25519_inv_6%=\n\t"
 #endif
         "ADD	r2, sp, #0x60\n\t"
         "ADD	r1, sp, #0x80\n\t"
@@ -3142,7 +3142,7 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0x32\n\t"
         "\n"
-    "L_curve25519_inv_7:\n\t"
+    "L_curve25519_inv_7%=:\n\t"
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
@@ -3150,9 +3150,9 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_7\n\t"
+        "BNE	L_curve25519_inv_7%=\n\t"
 #else
-        "BNE.N	L_curve25519_inv_7\n\t"
+        "BNE.N	L_curve25519_inv_7%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3160,7 +3160,7 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0x5\n\t"
         "\n"
-    "L_curve25519_inv_8:\n\t"
+    "L_curve25519_inv_8%=:\n\t"
         "ADD	r1, sp, #0x40\n\t"
         "ADD	r0, sp, #0x40\n\t"
         "PUSH	{r12}\n\t"
@@ -3168,9 +3168,9 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_8\n\t"
+        "BNE	L_curve25519_inv_8%=\n\t"
 #else
-        "BNE.N	L_curve25519_inv_8\n\t"
+        "BNE.N	L_curve25519_inv_8%=\n\t"
 #endif
         "ADD	r2, sp, #0x20\n\t"
         "ADD	r1, sp, #0x40\n\t"
@@ -3234,7 +3234,7 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "STM	r3, {r4, r5, r6, r7, r8, r9, r10, r11}\n\t"
         "MOV	%[a], #0xfe\n\t"
         "\n"
-    "L_curve25519_bits:\n\t"
+    "L_curve25519_bits%=:\n\t"
         "STR	%[a], [sp, #168]\n\t"
         "LDR	%[n], [sp, #160]\n\t"
         "AND	r4, %[a], #0x1f\n\t"
@@ -3320,9 +3320,9 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "LDR	%[a], [sp, #168]\n\t"
         "SUBS	%[a], %[a], #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGE	L_curve25519_bits\n\t"
+        "BGE	L_curve25519_bits%=\n\t"
 #else
-        "BGE.N	L_curve25519_bits\n\t"
+        "BGE.N	L_curve25519_bits%=\n\t"
 #endif
         /*   Cycle Count: 171 */
         "LDR	%[n], [sp, #184]\n\t"
@@ -3359,7 +3359,7 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x4\n\t"
         "\n"
-    "L_curve25519_inv_1:\n\t"
+    "L_curve25519_inv_1%=:\n\t"
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
@@ -3367,9 +3367,9 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_1\n\t"
+        "BNE	L_curve25519_inv_1%=\n\t"
 #else
-        "BNE.N	L_curve25519_inv_1\n\t"
+        "BNE.N	L_curve25519_inv_1%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3380,7 +3380,7 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x9\n\t"
         "\n"
-    "L_curve25519_inv_2:\n\t"
+    "L_curve25519_inv_2%=:\n\t"
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
@@ -3388,9 +3388,9 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_2\n\t"
+        "BNE	L_curve25519_inv_2%=\n\t"
 #else
-        "BNE.N	L_curve25519_inv_2\n\t"
+        "BNE.N	L_curve25519_inv_2%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3401,7 +3401,7 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x13\n\t"
         "\n"
-    "L_curve25519_inv_3:\n\t"
+    "L_curve25519_inv_3%=:\n\t"
         "ADD	r1, sp, #0x80\n\t"
         "ADD	r0, sp, #0x80\n\t"
         "PUSH	{r12}\n\t"
@@ -3409,9 +3409,9 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_3\n\t"
+        "BNE	L_curve25519_inv_3%=\n\t"
 #else
-        "BNE.N	L_curve25519_inv_3\n\t"
+        "BNE.N	L_curve25519_inv_3%=\n\t"
 #endif
         "ADD	r2, sp, #0x60\n\t"
         "ADD	r1, sp, #0x80\n\t"
@@ -3419,7 +3419,7 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0xa\n\t"
         "\n"
-    "L_curve25519_inv_4:\n\t"
+    "L_curve25519_inv_4%=:\n\t"
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
@@ -3427,9 +3427,9 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_4\n\t"
+        "BNE	L_curve25519_inv_4%=\n\t"
 #else
-        "BNE.N	L_curve25519_inv_4\n\t"
+        "BNE.N	L_curve25519_inv_4%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3440,7 +3440,7 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x31\n\t"
         "\n"
-    "L_curve25519_inv_5:\n\t"
+    "L_curve25519_inv_5%=:\n\t"
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
@@ -3448,9 +3448,9 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_5\n\t"
+        "BNE	L_curve25519_inv_5%=\n\t"
 #else
-        "BNE.N	L_curve25519_inv_5\n\t"
+        "BNE.N	L_curve25519_inv_5%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3461,7 +3461,7 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x63\n\t"
         "\n"
-    "L_curve25519_inv_6:\n\t"
+    "L_curve25519_inv_6%=:\n\t"
         "ADD	r1, sp, #0x80\n\t"
         "ADD	r0, sp, #0x80\n\t"
         "PUSH	{r12}\n\t"
@@ -3469,9 +3469,9 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_6\n\t"
+        "BNE	L_curve25519_inv_6%=\n\t"
 #else
-        "BNE.N	L_curve25519_inv_6\n\t"
+        "BNE.N	L_curve25519_inv_6%=\n\t"
 #endif
         "ADD	r2, sp, #0x60\n\t"
         "ADD	r1, sp, #0x80\n\t"
@@ -3479,7 +3479,7 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0x32\n\t"
         "\n"
-    "L_curve25519_inv_7:\n\t"
+    "L_curve25519_inv_7%=:\n\t"
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
@@ -3487,9 +3487,9 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_7\n\t"
+        "BNE	L_curve25519_inv_7%=\n\t"
 #else
-        "BNE.N	L_curve25519_inv_7\n\t"
+        "BNE.N	L_curve25519_inv_7%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3497,7 +3497,7 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0x5\n\t"
         "\n"
-    "L_curve25519_inv_8:\n\t"
+    "L_curve25519_inv_8%=:\n\t"
         "ADD	r1, sp, #0x40\n\t"
         "ADD	r0, sp, #0x40\n\t"
         "PUSH	{r12}\n\t"
@@ -3505,9 +3505,9 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_8\n\t"
+        "BNE	L_curve25519_inv_8%=\n\t"
 #else
-        "BNE.N	L_curve25519_inv_8\n\t"
+        "BNE.N	L_curve25519_inv_8%=\n\t"
 #endif
         "ADD	r2, sp, #0x20\n\t"
         "ADD	r1, sp, #0x40\n\t"
@@ -3589,7 +3589,7 @@ void fe_invert(fe r, const fe a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x4\n\t"
         "\n"
-    "L_fe_invert1:\n\t"
+    "L_fe_invert1%=:\n\t"
         "ADD	r1, sp, #0x40\n\t"
         "ADD	r0, sp, #0x40\n\t"
         "PUSH	{r12}\n\t"
@@ -3597,9 +3597,9 @@ void fe_invert(fe r, const fe a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_invert1\n\t"
+        "BNE	L_fe_invert1%=\n\t"
 #else
-        "BNE.N	L_fe_invert1\n\t"
+        "BNE.N	L_fe_invert1%=\n\t"
 #endif
         "ADD	r2, sp, #0x20\n\t"
         "ADD	r1, sp, #0x40\n\t"
@@ -3610,7 +3610,7 @@ void fe_invert(fe r, const fe a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x9\n\t"
         "\n"
-    "L_fe_invert2:\n\t"
+    "L_fe_invert2%=:\n\t"
         "ADD	r1, sp, #0x40\n\t"
         "ADD	r0, sp, #0x40\n\t"
         "PUSH	{r12}\n\t"
@@ -3618,9 +3618,9 @@ void fe_invert(fe r, const fe a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_invert2\n\t"
+        "BNE	L_fe_invert2%=\n\t"
 #else
-        "BNE.N	L_fe_invert2\n\t"
+        "BNE.N	L_fe_invert2%=\n\t"
 #endif
         "ADD	r2, sp, #0x20\n\t"
         "ADD	r1, sp, #0x40\n\t"
@@ -3631,7 +3631,7 @@ void fe_invert(fe r, const fe a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x13\n\t"
         "\n"
-    "L_fe_invert3:\n\t"
+    "L_fe_invert3%=:\n\t"
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
@@ -3639,9 +3639,9 @@ void fe_invert(fe r, const fe a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_invert3\n\t"
+        "BNE	L_fe_invert3%=\n\t"
 #else
-        "BNE.N	L_fe_invert3\n\t"
+        "BNE.N	L_fe_invert3%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3649,7 +3649,7 @@ void fe_invert(fe r, const fe a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0xa\n\t"
         "\n"
-    "L_fe_invert4:\n\t"
+    "L_fe_invert4%=:\n\t"
         "ADD	r1, sp, #0x40\n\t"
         "ADD	r0, sp, #0x40\n\t"
         "PUSH	{r12}\n\t"
@@ -3657,9 +3657,9 @@ void fe_invert(fe r, const fe a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_invert4\n\t"
+        "BNE	L_fe_invert4%=\n\t"
 #else
-        "BNE.N	L_fe_invert4\n\t"
+        "BNE.N	L_fe_invert4%=\n\t"
 #endif
         "ADD	r2, sp, #0x20\n\t"
         "ADD	r1, sp, #0x40\n\t"
@@ -3670,7 +3670,7 @@ void fe_invert(fe r, const fe a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x31\n\t"
         "\n"
-    "L_fe_invert5:\n\t"
+    "L_fe_invert5%=:\n\t"
         "ADD	r1, sp, #0x40\n\t"
         "ADD	r0, sp, #0x40\n\t"
         "PUSH	{r12}\n\t"
@@ -3678,9 +3678,9 @@ void fe_invert(fe r, const fe a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_invert5\n\t"
+        "BNE	L_fe_invert5%=\n\t"
 #else
-        "BNE.N	L_fe_invert5\n\t"
+        "BNE.N	L_fe_invert5%=\n\t"
 #endif
         "ADD	r2, sp, #0x20\n\t"
         "ADD	r1, sp, #0x40\n\t"
@@ -3691,7 +3691,7 @@ void fe_invert(fe r, const fe a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x63\n\t"
         "\n"
-    "L_fe_invert6:\n\t"
+    "L_fe_invert6%=:\n\t"
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
@@ -3699,9 +3699,9 @@ void fe_invert(fe r, const fe a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_invert6\n\t"
+        "BNE	L_fe_invert6%=\n\t"
 #else
-        "BNE.N	L_fe_invert6\n\t"
+        "BNE.N	L_fe_invert6%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3709,7 +3709,7 @@ void fe_invert(fe r, const fe a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0x32\n\t"
         "\n"
-    "L_fe_invert7:\n\t"
+    "L_fe_invert7%=:\n\t"
         "ADD	r1, sp, #0x40\n\t"
         "ADD	r0, sp, #0x40\n\t"
         "PUSH	{r12}\n\t"
@@ -3717,9 +3717,9 @@ void fe_invert(fe r, const fe a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_invert7\n\t"
+        "BNE	L_fe_invert7%=\n\t"
 #else
-        "BNE.N	L_fe_invert7\n\t"
+        "BNE.N	L_fe_invert7%=\n\t"
 #endif
         "ADD	r2, sp, #0x20\n\t"
         "ADD	r1, sp, #0x40\n\t"
@@ -3727,7 +3727,7 @@ void fe_invert(fe r, const fe a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0x5\n\t"
         "\n"
-    "L_fe_invert8:\n\t"
+    "L_fe_invert8%=:\n\t"
         "ADD	r1, sp, #0x20\n\t"
         "ADD	r0, sp, #0x20\n\t"
         "PUSH	{r12}\n\t"
@@ -3735,9 +3735,9 @@ void fe_invert(fe r, const fe a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_invert8\n\t"
+        "BNE	L_fe_invert8%=\n\t"
 #else
-        "BNE.N	L_fe_invert8\n\t"
+        "BNE.N	L_fe_invert8%=\n\t"
 #endif
         "MOV	r2, sp\n\t"
         "ADD	r1, sp, #0x20\n\t"
@@ -4275,7 +4275,7 @@ void fe_pow22523(fe r, const fe a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x4\n\t"
         "\n"
-    "L_fe_pow22523_1:\n\t"
+    "L_fe_pow22523_1%=:\n\t"
         "ADD	r1, sp, #0x20\n\t"
         "ADD	r0, sp, #0x20\n\t"
         "PUSH	{r12}\n\t"
@@ -4283,9 +4283,9 @@ void fe_pow22523(fe r, const fe a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_pow22523_1\n\t"
+        "BNE	L_fe_pow22523_1%=\n\t"
 #else
-        "BNE.N	L_fe_pow22523_1\n\t"
+        "BNE.N	L_fe_pow22523_1%=\n\t"
 #endif
         "MOV	r2, sp\n\t"
         "ADD	r1, sp, #0x20\n\t"
@@ -4296,7 +4296,7 @@ void fe_pow22523(fe r, const fe a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x9\n\t"
         "\n"
-    "L_fe_pow22523_2:\n\t"
+    "L_fe_pow22523_2%=:\n\t"
         "ADD	r1, sp, #0x20\n\t"
         "ADD	r0, sp, #0x20\n\t"
         "PUSH	{r12}\n\t"
@@ -4304,9 +4304,9 @@ void fe_pow22523(fe r, const fe a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_pow22523_2\n\t"
+        "BNE	L_fe_pow22523_2%=\n\t"
 #else
-        "BNE.N	L_fe_pow22523_2\n\t"
+        "BNE.N	L_fe_pow22523_2%=\n\t"
 #endif
         "MOV	r2, sp\n\t"
         "ADD	r1, sp, #0x20\n\t"
@@ -4317,7 +4317,7 @@ void fe_pow22523(fe r, const fe a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x13\n\t"
         "\n"
-    "L_fe_pow22523_3:\n\t"
+    "L_fe_pow22523_3%=:\n\t"
         "ADD	r1, sp, #0x40\n\t"
         "ADD	r0, sp, #0x40\n\t"
         "PUSH	{r12}\n\t"
@@ -4325,9 +4325,9 @@ void fe_pow22523(fe r, const fe a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_pow22523_3\n\t"
+        "BNE	L_fe_pow22523_3%=\n\t"
 #else
-        "BNE.N	L_fe_pow22523_3\n\t"
+        "BNE.N	L_fe_pow22523_3%=\n\t"
 #endif
         "ADD	r2, sp, #0x20\n\t"
         "ADD	r1, sp, #0x40\n\t"
@@ -4335,7 +4335,7 @@ void fe_pow22523(fe r, const fe a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0xa\n\t"
         "\n"
-    "L_fe_pow22523_4:\n\t"
+    "L_fe_pow22523_4%=:\n\t"
         "ADD	r1, sp, #0x20\n\t"
         "ADD	r0, sp, #0x20\n\t"
         "PUSH	{r12}\n\t"
@@ -4343,9 +4343,9 @@ void fe_pow22523(fe r, const fe a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_pow22523_4\n\t"
+        "BNE	L_fe_pow22523_4%=\n\t"
 #else
-        "BNE.N	L_fe_pow22523_4\n\t"
+        "BNE.N	L_fe_pow22523_4%=\n\t"
 #endif
         "MOV	r2, sp\n\t"
         "ADD	r1, sp, #0x20\n\t"
@@ -4356,7 +4356,7 @@ void fe_pow22523(fe r, const fe a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x31\n\t"
         "\n"
-    "L_fe_pow22523_5:\n\t"
+    "L_fe_pow22523_5%=:\n\t"
         "ADD	r1, sp, #0x20\n\t"
         "ADD	r0, sp, #0x20\n\t"
         "PUSH	{r12}\n\t"
@@ -4364,9 +4364,9 @@ void fe_pow22523(fe r, const fe a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_pow22523_5\n\t"
+        "BNE	L_fe_pow22523_5%=\n\t"
 #else
-        "BNE.N	L_fe_pow22523_5\n\t"
+        "BNE.N	L_fe_pow22523_5%=\n\t"
 #endif
         "MOV	r2, sp\n\t"
         "ADD	r1, sp, #0x20\n\t"
@@ -4377,7 +4377,7 @@ void fe_pow22523(fe r, const fe a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x63\n\t"
         "\n"
-    "L_fe_pow22523_6:\n\t"
+    "L_fe_pow22523_6%=:\n\t"
         "ADD	r1, sp, #0x40\n\t"
         "ADD	r0, sp, #0x40\n\t"
         "PUSH	{r12}\n\t"
@@ -4385,9 +4385,9 @@ void fe_pow22523(fe r, const fe a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_pow22523_6\n\t"
+        "BNE	L_fe_pow22523_6%=\n\t"
 #else
-        "BNE.N	L_fe_pow22523_6\n\t"
+        "BNE.N	L_fe_pow22523_6%=\n\t"
 #endif
         "ADD	r2, sp, #0x20\n\t"
         "ADD	r1, sp, #0x40\n\t"
@@ -4395,7 +4395,7 @@ void fe_pow22523(fe r, const fe a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0x32\n\t"
         "\n"
-    "L_fe_pow22523_7:\n\t"
+    "L_fe_pow22523_7%=:\n\t"
         "ADD	r1, sp, #0x20\n\t"
         "ADD	r0, sp, #0x20\n\t"
         "PUSH	{r12}\n\t"
@@ -4403,9 +4403,9 @@ void fe_pow22523(fe r, const fe a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_pow22523_7\n\t"
+        "BNE	L_fe_pow22523_7%=\n\t"
 #else
-        "BNE.N	L_fe_pow22523_7\n\t"
+        "BNE.N	L_fe_pow22523_7%=\n\t"
 #endif
         "MOV	r2, sp\n\t"
         "ADD	r1, sp, #0x20\n\t"
@@ -4413,7 +4413,7 @@ void fe_pow22523(fe r, const fe a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0x2\n\t"
         "\n"
-    "L_fe_pow22523_8:\n\t"
+    "L_fe_pow22523_8%=:\n\t"
         "MOV	r1, sp\n\t"
         "MOV	r0, sp\n\t"
         "PUSH	{r12}\n\t"
@@ -4421,9 +4421,9 @@ void fe_pow22523(fe r, const fe a)
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_pow22523_8\n\t"
+        "BNE	L_fe_pow22523_8%=\n\t"
 #else
-        "BNE.N	L_fe_pow22523_8\n\t"
+        "BNE.N	L_fe_pow22523_8%=\n\t"
 #endif
         "LDR	r2, [sp, #100]\n\t"
         "MOV	r1, sp\n\t"

--- a/wolfcrypt/src/port/arm/thumb2-sha256-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-sha256-asm_c.c
@@ -101,7 +101,7 @@ void Transform_Sha256_Len(wc_Sha256* sha256, const byte* data, word32 len)
         "STRD	r10, r11, [sp, #88]\n\t"
         /* Start of loop processing a block */
         "\n"
-    "L_SHA256_transform_len_begin:\n\t"
+    "L_SHA256_transform_len_begin%=:\n\t"
         /* Load, Reverse and Store W - 64 bytes */
         "LDR	r4, [%[data]]\n\t"
         "LDR	r5, [%[data], #4]\n\t"
@@ -149,7 +149,7 @@ void Transform_Sha256_Len(wc_Sha256* sha256, const byte* data, word32 len)
         "MOV	r12, #0x3\n\t"
         /* Start of 16 rounds */
         "\n"
-    "L_SHA256_transform_len_start:\n\t"
+    "L_SHA256_transform_len_start%=:\n\t"
         /* Round 0 */
         "LDR	r5, [%[sha256], #16]\n\t"
         "LDR	r6, [%[sha256], #20]\n\t"
@@ -905,9 +905,9 @@ void Transform_Sha256_Len(wc_Sha256* sha256, const byte* data, word32 len)
         "ADD	r3, r3, #0x40\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #ifdef __GNUC__
-        "BNE	L_SHA256_transform_len_start\n\t"
+        "BNE	L_SHA256_transform_len_start%=\n\t"
 #else
-        "BNE.W	L_SHA256_transform_len_start\n\t"
+        "BNE.W	L_SHA256_transform_len_start%=\n\t"
 #endif
         /* Round 0 */
         "LDR	r5, [%[sha256], #16]\n\t"
@@ -1450,9 +1450,9 @@ void Transform_Sha256_Len(wc_Sha256* sha256, const byte* data, word32 len)
         "SUB	r3, r3, #0xc0\n\t"
         "ADD	%[data], %[data], #0x40\n\t"
 #ifdef __GNUC__
-        "BNE	L_SHA256_transform_len_begin\n\t"
+        "BNE	L_SHA256_transform_len_begin%=\n\t"
 #else
-        "BNE.W	L_SHA256_transform_len_begin\n\t"
+        "BNE.W	L_SHA256_transform_len_begin%=\n\t"
 #endif
         "ADD	sp, sp, #0xc0\n\t"
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG

--- a/wolfcrypt/src/port/arm/thumb2-sha512-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-sha512-asm_c.c
@@ -133,7 +133,7 @@ void Transform_Sha512_Len(wc_Sha512* sha512, const byte* data, word32 len)
         "STRD	r10, r11, [sp, #184]\n\t"
         /* Start of loop processing a block */
         "\n"
-    "L_SHA512_transform_len_begin:\n\t"
+    "L_SHA512_transform_len_begin%=:\n\t"
         /* Load, Reverse and Store W */
         "LDR	r4, [%[data]]\n\t"
         "LDR	r5, [%[data], #4]\n\t"
@@ -239,7 +239,7 @@ void Transform_Sha512_Len(wc_Sha512* sha512, const byte* data, word32 len)
         "MOV	r12, #0x4\n\t"
         /* Start of 16 rounds */
         "\n"
-    "L_SHA512_transform_len_start:\n\t"
+    "L_SHA512_transform_len_start%=:\n\t"
         /* Round 0 */
         "LDRD	r4, r5, [%[sha512], #32]\n\t"
         "LSRS	r6, r4, #14\n\t"
@@ -2227,9 +2227,9 @@ void Transform_Sha512_Len(wc_Sha512* sha512, const byte* data, word32 len)
         "ADD	r3, r3, #0x80\n\t"
         "SUBS	r12, r12, #0x1\n\t"
 #ifdef __GNUC__
-        "BNE	L_SHA512_transform_len_start\n\t"
+        "BNE	L_SHA512_transform_len_start%=\n\t"
 #else
-        "BNE.W	L_SHA512_transform_len_start\n\t"
+        "BNE.W	L_SHA512_transform_len_start%=\n\t"
 #endif
         /* Round 0 */
         "LDRD	r4, r5, [%[sha512], #32]\n\t"
@@ -3564,9 +3564,9 @@ void Transform_Sha512_Len(wc_Sha512* sha512, const byte* data, word32 len)
         "SUB	r3, r3, #0x200\n\t"
         "ADD	%[data], %[data], #0x80\n\t"
 #ifdef __GNUC__
-        "BNE	L_SHA512_transform_len_begin\n\t"
+        "BNE	L_SHA512_transform_len_begin%=\n\t"
 #else
-        "BNE.W	L_SHA512_transform_len_begin\n\t"
+        "BNE.W	L_SHA512_transform_len_begin%=\n\t"
 #endif
         "EOR	r0, r0, r0\n\t"
         "ADD	sp, sp, #0xc0\n\t"

--- a/wolfcrypt/src/sp_cortexm.c
+++ b/wolfcrypt/src/sp_cortexm.c
@@ -2211,7 +2211,7 @@ static sp_digit sp_2048_add_64(sp_digit* r, const sp_digit* a, const sp_digit* b
         "MOV	r3, #0x0\n\t"
         "ADD	r12, %[a], #0x100\n\t"
         "\n"
-    "L_sp_2048_add_64_word:\n\t"
+    "L_sp_2048_add_64_word%=:\n\t"
         "ADDS	r3, r3, #0xffffffff\n\t"
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
         "LDM	%[b]!, {r8, r9, r10, r11}\n\t"
@@ -2224,9 +2224,9 @@ static sp_digit sp_2048_add_64(sp_digit* r, const sp_digit* a, const sp_digit* b
         "ADC	r3, r4, #0x0\n\t"
         "CMP	%[a], r12\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_2048_add_64_word\n\t"
+        "BNE	L_sp_2048_add_64_word%=\n\t"
 #else
-        "BNE.N	L_sp_2048_add_64_word\n\t"
+        "BNE.N	L_sp_2048_add_64_word%=\n\t"
 #endif
         "MOV	%[r], r3\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -2258,7 +2258,7 @@ static sp_digit sp_2048_sub_in_place_64(sp_digit* a, const sp_digit* b)
         "MOV	r10, #0x0\n\t"
         "ADD	r11, %[a], #0x100\n\t"
         "\n"
-    "L_sp_2048_sub_in_pkace_64_word:\n\t"
+    "L_sp_2048_sub_in_pkace_64_word%=:\n\t"
         "RSBS	r10, r10, #0x0\n\t"
         "LDM	%[a], {r2, r3, r4, r5}\n\t"
         "LDM	%[b]!, {r6, r7, r8, r9}\n\t"
@@ -2270,9 +2270,9 @@ static sp_digit sp_2048_sub_in_place_64(sp_digit* a, const sp_digit* b)
         "SBC	r10, r10, r10\n\t"
         "CMP	%[a], r11\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_2048_sub_in_pkace_64_word\n\t"
+        "BNE	L_sp_2048_sub_in_pkace_64_word%=\n\t"
 #else
-        "BNE.N	L_sp_2048_sub_in_pkace_64_word\n\t"
+        "BNE.N	L_sp_2048_sub_in_pkace_64_word%=\n\t"
 #endif
         "MOV	%[a], r10\n\t"
         : [a] "+r" (a), [b] "+r" (b)
@@ -2312,13 +2312,13 @@ static void sp_2048_mul_64(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_2048_mul_64_outer:\n\t"
+    "L_sp_2048_mul_64_outer%=:\n\t"
         "SUBS	r3, r5, #0xfc\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_2048_mul_64_inner:\n\t"
+    "L_sp_2048_mul_64_inner%=:\n\t"
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -2335,14 +2335,14 @@ static void sp_2048_mul_64(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_2048_mul_64_inner_done\n\t"
+        "BGT	L_sp_2048_mul_64_inner_done%=\n\t"
 #else
-        "BGT.N	L_sp_2048_mul_64_inner_done\n\t"
+        "BGT.N	L_sp_2048_mul_64_inner_done%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mul_64_inner\n\t"
+        "BLT	L_sp_2048_mul_64_inner%=\n\t"
 #else
-        "BLT.N	L_sp_2048_mul_64_inner\n\t"
+        "BLT.N	L_sp_2048_mul_64_inner%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r3]\n\t"
@@ -2351,7 +2351,7 @@ static void sp_2048_mul_64(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_2048_mul_64_inner_done:\n\t"
+    "L_sp_2048_mul_64_inner_done%=:\n\t"
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
@@ -2359,9 +2359,9 @@ static void sp_2048_mul_64(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x1f4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_2048_mul_64_outer\n\t"
+        "BLE	L_sp_2048_mul_64_outer%=\n\t"
 #else
-        "BLE.N	L_sp_2048_mul_64_outer\n\t"
+        "BLE.N	L_sp_2048_mul_64_outer%=\n\t"
 #endif
         "LDR	lr, [%[a], #252]\n\t"
         "LDR	r11, [%[b], #252]\n\t"
@@ -2370,14 +2370,14 @@ static void sp_2048_mul_64(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_2048_mul_64_store:\n\t"
+    "L_sp_2048_mul_64_store%=:\n\t"
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_2048_mul_64_store\n\t"
+        "BGT	L_sp_2048_mul_64_store%=\n\t"
 #else
-        "BGT.N	L_sp_2048_mul_64_store\n\t"
+        "BGT.N	L_sp_2048_mul_64_store%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
@@ -2410,13 +2410,13 @@ static void sp_2048_sqr_64(sp_digit* r, const sp_digit* a)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_2048_sqr_64_outer:\n\t"
+    "L_sp_2048_sqr_64_outer%=:\n\t"
         "SUBS	r3, r5, #0xfc\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_2048_sqr_64_inner:\n\t"
+    "L_sp_2048_sqr_64_inner%=:\n\t"
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[a], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -2430,14 +2430,14 @@ static void sp_2048_sqr_64(sp_digit* r, const sp_digit* a)
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_2048_sqr_64_inner_done\n\t"
+        "BGT	L_sp_2048_sqr_64_inner_done%=\n\t"
 #else
-        "BGT.N	L_sp_2048_sqr_64_inner_done\n\t"
+        "BGT.N	L_sp_2048_sqr_64_inner_done%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_sqr_64_inner\n\t"
+        "BLT	L_sp_2048_sqr_64_inner%=\n\t"
 #else
-        "BLT.N	L_sp_2048_sqr_64_inner\n\t"
+        "BLT.N	L_sp_2048_sqr_64_inner%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "UMULL	r9, r10, lr, lr\n\t"
@@ -2445,7 +2445,7 @@ static void sp_2048_sqr_64(sp_digit* r, const sp_digit* a)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_2048_sqr_64_inner_done:\n\t"
+    "L_sp_2048_sqr_64_inner_done%=:\n\t"
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
@@ -2453,9 +2453,9 @@ static void sp_2048_sqr_64(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x1f4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_2048_sqr_64_outer\n\t"
+        "BLE	L_sp_2048_sqr_64_outer%=\n\t"
 #else
-        "BLE.N	L_sp_2048_sqr_64_outer\n\t"
+        "BLE.N	L_sp_2048_sqr_64_outer%=\n\t"
 #endif
         "LDR	lr, [%[a], #252]\n\t"
         "UMLAL	r6, r7, lr, lr\n\t"
@@ -2463,14 +2463,14 @@ static void sp_2048_sqr_64(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_2048_sqr_64_store:\n\t"
+    "L_sp_2048_sqr_64_store%=:\n\t"
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_2048_sqr_64_store\n\t"
+        "BGT	L_sp_2048_sqr_64_store%=\n\t"
 #else
-        "BGT.N	L_sp_2048_sqr_64_store\n\t"
+        "BGT.N	L_sp_2048_sqr_64_store%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a)
         :
@@ -2520,7 +2520,7 @@ static sp_digit sp_2048_add_32(sp_digit* r, const sp_digit* a, const sp_digit* b
         "MOV	r3, #0x0\n\t"
         "ADD	r12, %[a], #0x80\n\t"
         "\n"
-    "L_sp_2048_add_32_word:\n\t"
+    "L_sp_2048_add_32_word%=:\n\t"
         "ADDS	r3, r3, #0xffffffff\n\t"
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
         "LDM	%[b]!, {r8, r9, r10, r11}\n\t"
@@ -2533,9 +2533,9 @@ static sp_digit sp_2048_add_32(sp_digit* r, const sp_digit* a, const sp_digit* b
         "ADC	r3, r4, #0x0\n\t"
         "CMP	%[a], r12\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_2048_add_32_word\n\t"
+        "BNE	L_sp_2048_add_32_word%=\n\t"
 #else
-        "BNE.N	L_sp_2048_add_32_word\n\t"
+        "BNE.N	L_sp_2048_add_32_word%=\n\t"
 #endif
         "MOV	%[r], r3\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -2567,7 +2567,7 @@ static sp_digit sp_2048_sub_in_place_32(sp_digit* a, const sp_digit* b)
         "MOV	r10, #0x0\n\t"
         "ADD	r11, %[a], #0x80\n\t"
         "\n"
-    "L_sp_2048_sub_in_pkace_32_word:\n\t"
+    "L_sp_2048_sub_in_pkace_32_word%=:\n\t"
         "RSBS	r10, r10, #0x0\n\t"
         "LDM	%[a], {r2, r3, r4, r5}\n\t"
         "LDM	%[b]!, {r6, r7, r8, r9}\n\t"
@@ -2579,9 +2579,9 @@ static sp_digit sp_2048_sub_in_place_32(sp_digit* a, const sp_digit* b)
         "SBC	r10, r10, r10\n\t"
         "CMP	%[a], r11\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_2048_sub_in_pkace_32_word\n\t"
+        "BNE	L_sp_2048_sub_in_pkace_32_word%=\n\t"
 #else
-        "BNE.N	L_sp_2048_sub_in_pkace_32_word\n\t"
+        "BNE.N	L_sp_2048_sub_in_pkace_32_word%=\n\t"
 #endif
         "MOV	%[a], r10\n\t"
         : [a] "+r" (a), [b] "+r" (b)
@@ -2621,13 +2621,13 @@ static void sp_2048_mul_32(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_2048_mul_32_outer:\n\t"
+    "L_sp_2048_mul_32_outer%=:\n\t"
         "SUBS	r3, r5, #0x7c\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_2048_mul_32_inner:\n\t"
+    "L_sp_2048_mul_32_inner%=:\n\t"
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -2644,14 +2644,14 @@ static void sp_2048_mul_32(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_2048_mul_32_inner_done\n\t"
+        "BGT	L_sp_2048_mul_32_inner_done%=\n\t"
 #else
-        "BGT.N	L_sp_2048_mul_32_inner_done\n\t"
+        "BGT.N	L_sp_2048_mul_32_inner_done%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mul_32_inner\n\t"
+        "BLT	L_sp_2048_mul_32_inner%=\n\t"
 #else
-        "BLT.N	L_sp_2048_mul_32_inner\n\t"
+        "BLT.N	L_sp_2048_mul_32_inner%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r3]\n\t"
@@ -2660,7 +2660,7 @@ static void sp_2048_mul_32(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_2048_mul_32_inner_done:\n\t"
+    "L_sp_2048_mul_32_inner_done%=:\n\t"
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
@@ -2668,9 +2668,9 @@ static void sp_2048_mul_32(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0xf4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_2048_mul_32_outer\n\t"
+        "BLE	L_sp_2048_mul_32_outer%=\n\t"
 #else
-        "BLE.N	L_sp_2048_mul_32_outer\n\t"
+        "BLE.N	L_sp_2048_mul_32_outer%=\n\t"
 #endif
         "LDR	lr, [%[a], #124]\n\t"
         "LDR	r11, [%[b], #124]\n\t"
@@ -2679,14 +2679,14 @@ static void sp_2048_mul_32(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_2048_mul_32_store:\n\t"
+    "L_sp_2048_mul_32_store%=:\n\t"
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_2048_mul_32_store\n\t"
+        "BGT	L_sp_2048_mul_32_store%=\n\t"
 #else
-        "BGT.N	L_sp_2048_mul_32_store\n\t"
+        "BGT.N	L_sp_2048_mul_32_store%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
@@ -2719,13 +2719,13 @@ static void sp_2048_sqr_32(sp_digit* r, const sp_digit* a)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_2048_sqr_32_outer:\n\t"
+    "L_sp_2048_sqr_32_outer%=:\n\t"
         "SUBS	r3, r5, #0x7c\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_2048_sqr_32_inner:\n\t"
+    "L_sp_2048_sqr_32_inner%=:\n\t"
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[a], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -2739,14 +2739,14 @@ static void sp_2048_sqr_32(sp_digit* r, const sp_digit* a)
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_2048_sqr_32_inner_done\n\t"
+        "BGT	L_sp_2048_sqr_32_inner_done%=\n\t"
 #else
-        "BGT.N	L_sp_2048_sqr_32_inner_done\n\t"
+        "BGT.N	L_sp_2048_sqr_32_inner_done%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_sqr_32_inner\n\t"
+        "BLT	L_sp_2048_sqr_32_inner%=\n\t"
 #else
-        "BLT.N	L_sp_2048_sqr_32_inner\n\t"
+        "BLT.N	L_sp_2048_sqr_32_inner%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "UMULL	r9, r10, lr, lr\n\t"
@@ -2754,7 +2754,7 @@ static void sp_2048_sqr_32(sp_digit* r, const sp_digit* a)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_2048_sqr_32_inner_done:\n\t"
+    "L_sp_2048_sqr_32_inner_done%=:\n\t"
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
@@ -2762,9 +2762,9 @@ static void sp_2048_sqr_32(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0xf4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_2048_sqr_32_outer\n\t"
+        "BLE	L_sp_2048_sqr_32_outer%=\n\t"
 #else
-        "BLE.N	L_sp_2048_sqr_32_outer\n\t"
+        "BLE.N	L_sp_2048_sqr_32_outer%=\n\t"
 #endif
         "LDR	lr, [%[a], #124]\n\t"
         "UMLAL	r6, r7, lr, lr\n\t"
@@ -2772,14 +2772,14 @@ static void sp_2048_sqr_32(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_2048_sqr_32_store:\n\t"
+    "L_sp_2048_sqr_32_store%=:\n\t"
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_2048_sqr_32_store\n\t"
+        "BGT	L_sp_2048_sqr_32_store%=\n\t"
 #else
-        "BGT.N	L_sp_2048_sqr_32_store\n\t"
+        "BGT.N	L_sp_2048_sqr_32_store%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a)
         :
@@ -2838,7 +2838,7 @@ static void sp_2048_mul_d_64(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "MOV	r9, #0x4\n\t"
         "\n"
-    "L_sp_2048_mul_d_64_word:\n\t"
+    "L_sp_2048_mul_d_64_word%=:\n\t"
         /* A[i] * B */
         "LDR	r8, [%[a], r9]\n\t"
         "UMULL	r6, r7, %[b], r8\n\t"
@@ -2852,9 +2852,9 @@ static void sp_2048_mul_d_64(sp_digit* r, const sp_digit* a, sp_digit b)
         "ADD	r9, r9, #0x4\n\t"
         "CMP	r9, #0x100\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mul_d_64_word\n\t"
+        "BLT	L_sp_2048_mul_d_64_word%=\n\t"
 #else
-        "BLT.N	L_sp_2048_mul_d_64_word\n\t"
+        "BLT.N	L_sp_2048_mul_d_64_word%=\n\t"
 #endif
         "STR	r3, [%[r], #256]\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -3252,7 +3252,7 @@ static sp_digit sp_2048_cond_sub_32(sp_digit* r, const sp_digit* a, const sp_dig
         "MOV	r4, #0x0\n\t"
         "MOV	r5, #0x0\n\t"
         "\n"
-    "L_sp_2048_cond_sub_32_words:\n\t"
+    "L_sp_2048_cond_sub_32_words%=:\n\t"
         "SUBS	r4, r8, r4\n\t"
         "LDR	r6, [%[a], r5]\n\t"
         "LDR	r7, [%[b], r5]\n\t"
@@ -3263,9 +3263,9 @@ static sp_digit sp_2048_cond_sub_32(sp_digit* r, const sp_digit* a, const sp_dig
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x80\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_cond_sub_32_words\n\t"
+        "BLT	L_sp_2048_cond_sub_32_words%=\n\t"
 #else
-        "BLT.N	L_sp_2048_cond_sub_32_words\n\t"
+        "BLT.N	L_sp_2048_cond_sub_32_words%=\n\t"
 #endif
         "MOV	%[r], r4\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -3448,7 +3448,7 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "LDR	r4, [%[a]]\n\t"
         "LDR	r5, [%[a], #4]\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_32_word:\n\t"
+    "L_sp_2048_mont_reduce_32_word%=:\n\t"
         /* mu = a[i] * mp */
         "MUL	r10, %[mp], r4\n\t"
         /* a[i+0] += m[0] * mu */
@@ -3711,9 +3711,9 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r11, #0x80\n\t"
 #ifdef __GNUC__
-        "BLT	L_sp_2048_mont_reduce_32_word\n\t"
+        "BLT	L_sp_2048_mont_reduce_32_word%=\n\t"
 #else
-        "BLT.W	L_sp_2048_mont_reduce_32_word\n\t"
+        "BLT.W	L_sp_2048_mont_reduce_32_word%=\n\t"
 #endif
         /* Loop Done */
         "STR	r4, [%[a]]\n\t"
@@ -3752,7 +3752,7 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         /* ca = 0 */
         "MOV	r3, #0x0\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_32_word:\n\t"
+    "L_sp_2048_mont_reduce_32_word%=:\n\t"
         /* mu = a[i] * mp */
         "LDR	r10, [%[a]]\n\t"
         "MUL	r8, %[mp], r10\n\t"
@@ -3760,7 +3760,7 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "MOV	r12, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_32_mul:\n\t"
+    "L_sp_2048_mont_reduce_32_mul%=:\n\t"
         /* a[i+j+0] += m[j+0] * mu */
         "LDR	r7, [%[m], r12]\n\t"
         "LDR	r10, [%[a], r12]\n\t"
@@ -3803,9 +3803,9 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "ADD	r12, r12, #0x4\n\t"
         "CMP	r12, #0x80\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mont_reduce_32_mul\n\t"
+        "BLT	L_sp_2048_mont_reduce_32_mul%=\n\t"
 #else
-        "BLT.N	L_sp_2048_mont_reduce_32_mul\n\t"
+        "BLT.N	L_sp_2048_mont_reduce_32_mul%=\n\t"
 #endif
         "LDR	r10, [%[a], #128]\n\t"
         "ADDS	r4, r4, r3\n\t"
@@ -3819,9 +3819,9 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r9, #0x80\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mont_reduce_32_word\n\t"
+        "BLT	L_sp_2048_mont_reduce_32_word%=\n\t"
 #else
-        "BLT.N	L_sp_2048_mont_reduce_32_word\n\t"
+        "BLT.N	L_sp_2048_mont_reduce_32_word%=\n\t"
 #endif
         /* Loop Done */
         "MOV	%[mp], r3\n\t"
@@ -3863,7 +3863,7 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "LDR	r9, [%[a], #12]\n\t"
         "LDR	r10, [%[a], #16]\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_32_word:\n\t"
+    "L_sp_2048_mont_reduce_32_word%=:\n\t"
         /* mu = a[i] * mp */
         "MUL	lr, %[mp], r6\n\t"
         /* a[i+0] += m[0] * mu */
@@ -4031,9 +4031,9 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r4, #0x80\n\t"
 #ifdef __GNUC__
-        "BLT	L_sp_2048_mont_reduce_32_word\n\t"
+        "BLT	L_sp_2048_mont_reduce_32_word%=\n\t"
 #else
-        "BLT.W	L_sp_2048_mont_reduce_32_word\n\t"
+        "BLT.W	L_sp_2048_mont_reduce_32_word%=\n\t"
 #endif
         /* Loop Done */
         "STR	r6, [%[a]]\n\t"
@@ -4075,7 +4075,7 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         /* ca = 0 */
         "MOV	r3, #0x0\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_32_word:\n\t"
+    "L_sp_2048_mont_reduce_32_word%=:\n\t"
         /* mu = a[i] * mp */
         "LDR	r10, [%[a]]\n\t"
         "MUL	r8, %[mp], r10\n\t"
@@ -4083,7 +4083,7 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "MOV	r12, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_32_mul:\n\t"
+    "L_sp_2048_mont_reduce_32_mul%=:\n\t"
         /* a[i+j+0] += m[j+0] * mu */
         "LDR	r7, [%[m], r12]\n\t"
         "LDR	r10, [%[a], r12]\n\t"
@@ -4114,9 +4114,9 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "ADD	r12, r12, #0x4\n\t"
         "CMP	r12, #0x80\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mont_reduce_32_mul\n\t"
+        "BLT	L_sp_2048_mont_reduce_32_mul%=\n\t"
 #else
-        "BLT.N	L_sp_2048_mont_reduce_32_mul\n\t"
+        "BLT.N	L_sp_2048_mont_reduce_32_mul%=\n\t"
 #endif
         "LDR	r10, [%[a], #128]\n\t"
         "ADDS	r4, r4, r3\n\t"
@@ -4130,9 +4130,9 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r9, #0x80\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mont_reduce_32_word\n\t"
+        "BLT	L_sp_2048_mont_reduce_32_word%=\n\t"
 #else
-        "BLT.N	L_sp_2048_mont_reduce_32_word\n\t"
+        "BLT.N	L_sp_2048_mont_reduce_32_word%=\n\t"
 #endif
         /* Loop Done */
         "MOV	%[mp], r3\n\t"
@@ -4203,7 +4203,7 @@ static void sp_2048_mul_d_32(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "MOV	r9, #0x4\n\t"
         "\n"
-    "L_sp_2048_mul_d_32_word:\n\t"
+    "L_sp_2048_mul_d_32_word%=:\n\t"
         /* A[i] * B */
         "LDR	r8, [%[a], r9]\n\t"
         "UMULL	r6, r7, %[b], r8\n\t"
@@ -4217,9 +4217,9 @@ static void sp_2048_mul_d_32(sp_digit* r, const sp_digit* a, sp_digit b)
         "ADD	r9, r9, #0x4\n\t"
         "CMP	r9, #0x80\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mul_d_32_word\n\t"
+        "BLT	L_sp_2048_mul_d_32_word%=\n\t"
 #else
-        "BLT.N	L_sp_2048_mul_d_32_word\n\t"
+        "BLT.N	L_sp_2048_mul_d_32_word%=\n\t"
 #endif
         "STR	r3, [%[r], #128]\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -4517,7 +4517,7 @@ SP_NOINLINE static sp_digit div_2048_word_32(sp_digit d1, sp_digit d0, sp_digit 
         /* Next 30 bits */
         "MOV	r4, #0x1d\n\t"
         "\n"
-    "L_div_2048_word_32_bit:\n\t"
+    "L_div_2048_word_32_bit%=:\n\t"
         "LSLS	r6, r6, #1\n\t"
         "ADC	r7, r7, r7\n\t"
         "SUBS	r8, r5, r7\n\t"
@@ -4527,7 +4527,7 @@ SP_NOINLINE static sp_digit div_2048_word_32(sp_digit d1, sp_digit d0, sp_digit 
         "AND	r8, r8, r5\n\t"
         "SUBS	r7, r7, r8\n\t"
         "SUBS	r4, r4, #0x1\n\t"
-        "bpl	L_div_2048_word_32_bit\n\t"
+        "bpl	L_div_2048_word_32_bit%=\n\t"
         "ADD	r3, r3, r3\n\t"
         "ADD	r3, r3, #0x1\n\t"
         "UMULL	r6, r7, r3, %[div]\n\t"
@@ -4579,7 +4579,7 @@ static sp_int32 sp_2048_cmp_32(const sp_digit* a, const sp_digit* b)
 #ifdef WOLFSSL_SP_SMALL
         "MOV	r6, #0x7c\n\t"
         "\n"
-    "L_sp_2048_cmp_32_words:\n\t"
+    "L_sp_2048_cmp_32_words%=:\n\t"
         "LDR	r4, [%[a], r6]\n\t"
         "LDR	r5, [%[b], r6]\n\t"
         "AND	r4, r4, r3\n\t"
@@ -4592,7 +4592,7 @@ static sp_int32 sp_2048_cmp_32(const sp_digit* a, const sp_digit* b)
         "IT	ne\n\t"
         "movne	r3, r7\n\t"
         "SUBS	r6, r6, #0x4\n\t"
-        "bcs	L_sp_2048_cmp_32_words\n\t"
+        "bcs	L_sp_2048_cmp_32_words%=\n\t"
         "EOR	r2, r2, r3\n\t"
 #else
         "LDR	r4, [%[a], #124]\n\t"
@@ -5380,7 +5380,7 @@ static sp_digit sp_2048_cond_sub_64(sp_digit* r, const sp_digit* a, const sp_dig
         "MOV	r4, #0x0\n\t"
         "MOV	r5, #0x0\n\t"
         "\n"
-    "L_sp_2048_cond_sub_64_words:\n\t"
+    "L_sp_2048_cond_sub_64_words%=:\n\t"
         "SUBS	r4, r8, r4\n\t"
         "LDR	r6, [%[a], r5]\n\t"
         "LDR	r7, [%[b], r5]\n\t"
@@ -5391,9 +5391,9 @@ static sp_digit sp_2048_cond_sub_64(sp_digit* r, const sp_digit* a, const sp_dig
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x100\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_cond_sub_64_words\n\t"
+        "BLT	L_sp_2048_cond_sub_64_words%=\n\t"
 #else
-        "BLT.N	L_sp_2048_cond_sub_64_words\n\t"
+        "BLT.N	L_sp_2048_cond_sub_64_words%=\n\t"
 #endif
         "MOV	%[r], r4\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -5688,7 +5688,7 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         "LDR	r4, [%[a]]\n\t"
         "LDR	r5, [%[a], #4]\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_64_word:\n\t"
+    "L_sp_2048_mont_reduce_64_word%=:\n\t"
         /* mu = a[i] * mp */
         "MUL	r10, %[mp], r4\n\t"
         /* a[i+0] += m[0] * mu */
@@ -6207,9 +6207,9 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r11, #0x100\n\t"
 #ifdef __GNUC__
-        "BLT	L_sp_2048_mont_reduce_64_word\n\t"
+        "BLT	L_sp_2048_mont_reduce_64_word%=\n\t"
 #else
-        "BLT.W	L_sp_2048_mont_reduce_64_word\n\t"
+        "BLT.W	L_sp_2048_mont_reduce_64_word%=\n\t"
 #endif
         /* Loop Done */
         "STR	r4, [%[a]]\n\t"
@@ -6248,7 +6248,7 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         /* ca = 0 */
         "MOV	r3, #0x0\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_64_word:\n\t"
+    "L_sp_2048_mont_reduce_64_word%=:\n\t"
         /* mu = a[i] * mp */
         "LDR	r10, [%[a]]\n\t"
         "MUL	r8, %[mp], r10\n\t"
@@ -6256,7 +6256,7 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         "MOV	r12, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_64_mul:\n\t"
+    "L_sp_2048_mont_reduce_64_mul%=:\n\t"
         /* a[i+j+0] += m[j+0] * mu */
         "LDR	r7, [%[m], r12]\n\t"
         "LDR	r10, [%[a], r12]\n\t"
@@ -6299,9 +6299,9 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         "ADD	r12, r12, #0x4\n\t"
         "CMP	r12, #0x100\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mont_reduce_64_mul\n\t"
+        "BLT	L_sp_2048_mont_reduce_64_mul%=\n\t"
 #else
-        "BLT.N	L_sp_2048_mont_reduce_64_mul\n\t"
+        "BLT.N	L_sp_2048_mont_reduce_64_mul%=\n\t"
 #endif
         "LDR	r10, [%[a], #256]\n\t"
         "ADDS	r4, r4, r3\n\t"
@@ -6315,9 +6315,9 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r9, #0x100\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mont_reduce_64_word\n\t"
+        "BLT	L_sp_2048_mont_reduce_64_word%=\n\t"
 #else
-        "BLT.N	L_sp_2048_mont_reduce_64_word\n\t"
+        "BLT.N	L_sp_2048_mont_reduce_64_word%=\n\t"
 #endif
         /* Loop Done */
         "MOV	%[mp], r3\n\t"
@@ -6359,7 +6359,7 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         "LDR	r9, [%[a], #12]\n\t"
         "LDR	r10, [%[a], #16]\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_64_word:\n\t"
+    "L_sp_2048_mont_reduce_64_word%=:\n\t"
         /* mu = a[i] * mp */
         "MUL	lr, %[mp], r6\n\t"
         /* a[i+0] += m[0] * mu */
@@ -6687,9 +6687,9 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r4, #0x100\n\t"
 #ifdef __GNUC__
-        "BLT	L_sp_2048_mont_reduce_64_word\n\t"
+        "BLT	L_sp_2048_mont_reduce_64_word%=\n\t"
 #else
-        "BLT.W	L_sp_2048_mont_reduce_64_word\n\t"
+        "BLT.W	L_sp_2048_mont_reduce_64_word%=\n\t"
 #endif
         /* Loop Done */
         "STR	r6, [%[a]]\n\t"
@@ -6731,7 +6731,7 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         /* ca = 0 */
         "MOV	r3, #0x0\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_64_word:\n\t"
+    "L_sp_2048_mont_reduce_64_word%=:\n\t"
         /* mu = a[i] * mp */
         "LDR	r10, [%[a]]\n\t"
         "MUL	r8, %[mp], r10\n\t"
@@ -6739,7 +6739,7 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         "MOV	r12, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_64_mul:\n\t"
+    "L_sp_2048_mont_reduce_64_mul%=:\n\t"
         /* a[i+j+0] += m[j+0] * mu */
         "LDR	r7, [%[m], r12]\n\t"
         "LDR	r10, [%[a], r12]\n\t"
@@ -6770,9 +6770,9 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         "ADD	r12, r12, #0x4\n\t"
         "CMP	r12, #0x100\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mont_reduce_64_mul\n\t"
+        "BLT	L_sp_2048_mont_reduce_64_mul%=\n\t"
 #else
-        "BLT.N	L_sp_2048_mont_reduce_64_mul\n\t"
+        "BLT.N	L_sp_2048_mont_reduce_64_mul%=\n\t"
 #endif
         "LDR	r10, [%[a], #256]\n\t"
         "ADDS	r4, r4, r3\n\t"
@@ -6786,9 +6786,9 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r9, #0x100\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mont_reduce_64_word\n\t"
+        "BLT	L_sp_2048_mont_reduce_64_word%=\n\t"
 #else
-        "BLT.N	L_sp_2048_mont_reduce_64_word\n\t"
+        "BLT.N	L_sp_2048_mont_reduce_64_word%=\n\t"
 #endif
         /* Loop Done */
         "MOV	%[mp], r3\n\t"
@@ -6854,7 +6854,7 @@ static sp_digit sp_2048_sub_64(sp_digit* r, const sp_digit* a, const sp_digit* b
         "MOV	r11, #0x0\n\t"
         "ADD	r12, %[a], #0x100\n\t"
         "\n"
-    "L_sp_2048_sub_64_word:\n\t"
+    "L_sp_2048_sub_64_word%=:\n\t"
         "RSBS	r11, r11, #0x0\n\t"
         "LDM	%[a]!, {r3, r4, r5, r6}\n\t"
         "LDM	%[b]!, {r7, r8, r9, r10}\n\t"
@@ -6866,9 +6866,9 @@ static sp_digit sp_2048_sub_64(sp_digit* r, const sp_digit* a, const sp_digit* b
         "SBC	r11, r3, r3\n\t"
         "CMP	%[a], r12\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_2048_sub_64_word\n\t"
+        "BNE	L_sp_2048_sub_64_word%=\n\t"
 #else
-        "BNE.N	L_sp_2048_sub_64_word\n\t"
+        "BNE.N	L_sp_2048_sub_64_word%=\n\t"
 #endif
         "MOV	%[r], r11\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -7121,7 +7121,7 @@ SP_NOINLINE static sp_digit div_2048_word_64(sp_digit d1, sp_digit d0, sp_digit 
         /* Next 30 bits */
         "MOV	r4, #0x1d\n\t"
         "\n"
-    "L_div_2048_word_64_bit:\n\t"
+    "L_div_2048_word_64_bit%=:\n\t"
         "LSLS	r6, r6, #1\n\t"
         "ADC	r7, r7, r7\n\t"
         "SUBS	r8, r5, r7\n\t"
@@ -7131,7 +7131,7 @@ SP_NOINLINE static sp_digit div_2048_word_64(sp_digit d1, sp_digit d0, sp_digit 
         "AND	r8, r8, r5\n\t"
         "SUBS	r7, r7, r8\n\t"
         "SUBS	r4, r4, #0x1\n\t"
-        "bpl	L_div_2048_word_64_bit\n\t"
+        "bpl	L_div_2048_word_64_bit%=\n\t"
         "ADD	r3, r3, r3\n\t"
         "ADD	r3, r3, #0x1\n\t"
         "UMULL	r6, r7, r3, %[div]\n\t"
@@ -7286,7 +7286,7 @@ static sp_int32 sp_2048_cmp_64(const sp_digit* a, const sp_digit* b)
 #ifdef WOLFSSL_SP_SMALL
         "MOV	r6, #0xfc\n\t"
         "\n"
-    "L_sp_2048_cmp_64_words:\n\t"
+    "L_sp_2048_cmp_64_words%=:\n\t"
         "LDR	r4, [%[a], r6]\n\t"
         "LDR	r5, [%[b], r6]\n\t"
         "AND	r4, r4, r3\n\t"
@@ -7299,7 +7299,7 @@ static sp_int32 sp_2048_cmp_64(const sp_digit* a, const sp_digit* b)
         "IT	ne\n\t"
         "movne	r3, r7\n\t"
         "SUBS	r6, r6, #0x4\n\t"
-        "bcs	L_sp_2048_cmp_64_words\n\t"
+        "bcs	L_sp_2048_cmp_64_words%=\n\t"
         "EOR	r2, r2, r3\n\t"
 #else
         "LDR	r4, [%[a], #252]\n\t"
@@ -8562,7 +8562,7 @@ static sp_digit sp_2048_cond_add_32(sp_digit* r, const sp_digit* a, const sp_dig
         "MOV	r8, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_2048_cond_add_32_words:\n\t"
+    "L_sp_2048_cond_add_32_words%=:\n\t"
         "ADDS	r5, r5, #0xffffffff\n\t"
         "LDR	r6, [%[a], r4]\n\t"
         "LDR	r7, [%[b], r4]\n\t"
@@ -8573,9 +8573,9 @@ static sp_digit sp_2048_cond_add_32(sp_digit* r, const sp_digit* a, const sp_dig
         "ADD	r4, r4, #0x4\n\t"
         "CMP	r4, #0x80\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_cond_add_32_words\n\t"
+        "BLT	L_sp_2048_cond_add_32_words%=\n\t"
 #else
-        "BLT.N	L_sp_2048_cond_add_32_words\n\t"
+        "BLT.N	L_sp_2048_cond_add_32_words%=\n\t"
 #endif
         "MOV	%[r], r5\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -12948,7 +12948,7 @@ static sp_digit sp_3072_add_96(sp_digit* r, const sp_digit* a, const sp_digit* b
         "MOV	r3, #0x0\n\t"
         "ADD	r12, %[a], #0x180\n\t"
         "\n"
-    "L_sp_3072_add_96_word:\n\t"
+    "L_sp_3072_add_96_word%=:\n\t"
         "ADDS	r3, r3, #0xffffffff\n\t"
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
         "LDM	%[b]!, {r8, r9, r10, r11}\n\t"
@@ -12961,9 +12961,9 @@ static sp_digit sp_3072_add_96(sp_digit* r, const sp_digit* a, const sp_digit* b
         "ADC	r3, r4, #0x0\n\t"
         "CMP	%[a], r12\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_3072_add_96_word\n\t"
+        "BNE	L_sp_3072_add_96_word%=\n\t"
 #else
-        "BNE.N	L_sp_3072_add_96_word\n\t"
+        "BNE.N	L_sp_3072_add_96_word%=\n\t"
 #endif
         "MOV	%[r], r3\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -12995,7 +12995,7 @@ static sp_digit sp_3072_sub_in_place_96(sp_digit* a, const sp_digit* b)
         "MOV	r10, #0x0\n\t"
         "ADD	r11, %[a], #0x180\n\t"
         "\n"
-    "L_sp_3072_sub_in_pkace_96_word:\n\t"
+    "L_sp_3072_sub_in_pkace_96_word%=:\n\t"
         "RSBS	r10, r10, #0x0\n\t"
         "LDM	%[a], {r2, r3, r4, r5}\n\t"
         "LDM	%[b]!, {r6, r7, r8, r9}\n\t"
@@ -13007,9 +13007,9 @@ static sp_digit sp_3072_sub_in_place_96(sp_digit* a, const sp_digit* b)
         "SBC	r10, r10, r10\n\t"
         "CMP	%[a], r11\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_3072_sub_in_pkace_96_word\n\t"
+        "BNE	L_sp_3072_sub_in_pkace_96_word%=\n\t"
 #else
-        "BNE.N	L_sp_3072_sub_in_pkace_96_word\n\t"
+        "BNE.N	L_sp_3072_sub_in_pkace_96_word%=\n\t"
 #endif
         "MOV	%[a], r10\n\t"
         : [a] "+r" (a), [b] "+r" (b)
@@ -13049,13 +13049,13 @@ static void sp_3072_mul_96(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_3072_mul_96_outer:\n\t"
+    "L_sp_3072_mul_96_outer%=:\n\t"
         "SUBS	r3, r5, #0x17c\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_3072_mul_96_inner:\n\t"
+    "L_sp_3072_mul_96_inner%=:\n\t"
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -13072,14 +13072,14 @@ static void sp_3072_mul_96(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_3072_mul_96_inner_done\n\t"
+        "BGT	L_sp_3072_mul_96_inner_done%=\n\t"
 #else
-        "BGT.N	L_sp_3072_mul_96_inner_done\n\t"
+        "BGT.N	L_sp_3072_mul_96_inner_done%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mul_96_inner\n\t"
+        "BLT	L_sp_3072_mul_96_inner%=\n\t"
 #else
-        "BLT.N	L_sp_3072_mul_96_inner\n\t"
+        "BLT.N	L_sp_3072_mul_96_inner%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r3]\n\t"
@@ -13088,7 +13088,7 @@ static void sp_3072_mul_96(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_3072_mul_96_inner_done:\n\t"
+    "L_sp_3072_mul_96_inner_done%=:\n\t"
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
@@ -13096,9 +13096,9 @@ static void sp_3072_mul_96(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x2f4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_3072_mul_96_outer\n\t"
+        "BLE	L_sp_3072_mul_96_outer%=\n\t"
 #else
-        "BLE.N	L_sp_3072_mul_96_outer\n\t"
+        "BLE.N	L_sp_3072_mul_96_outer%=\n\t"
 #endif
         "LDR	lr, [%[a], #380]\n\t"
         "LDR	r11, [%[b], #380]\n\t"
@@ -13107,14 +13107,14 @@ static void sp_3072_mul_96(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_3072_mul_96_store:\n\t"
+    "L_sp_3072_mul_96_store%=:\n\t"
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_3072_mul_96_store\n\t"
+        "BGT	L_sp_3072_mul_96_store%=\n\t"
 #else
-        "BGT.N	L_sp_3072_mul_96_store\n\t"
+        "BGT.N	L_sp_3072_mul_96_store%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
@@ -13147,13 +13147,13 @@ static void sp_3072_sqr_96(sp_digit* r, const sp_digit* a)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_3072_sqr_96_outer:\n\t"
+    "L_sp_3072_sqr_96_outer%=:\n\t"
         "SUBS	r3, r5, #0x17c\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_3072_sqr_96_inner:\n\t"
+    "L_sp_3072_sqr_96_inner%=:\n\t"
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[a], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -13167,14 +13167,14 @@ static void sp_3072_sqr_96(sp_digit* r, const sp_digit* a)
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_3072_sqr_96_inner_done\n\t"
+        "BGT	L_sp_3072_sqr_96_inner_done%=\n\t"
 #else
-        "BGT.N	L_sp_3072_sqr_96_inner_done\n\t"
+        "BGT.N	L_sp_3072_sqr_96_inner_done%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_sqr_96_inner\n\t"
+        "BLT	L_sp_3072_sqr_96_inner%=\n\t"
 #else
-        "BLT.N	L_sp_3072_sqr_96_inner\n\t"
+        "BLT.N	L_sp_3072_sqr_96_inner%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "UMULL	r9, r10, lr, lr\n\t"
@@ -13182,7 +13182,7 @@ static void sp_3072_sqr_96(sp_digit* r, const sp_digit* a)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_3072_sqr_96_inner_done:\n\t"
+    "L_sp_3072_sqr_96_inner_done%=:\n\t"
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
@@ -13190,9 +13190,9 @@ static void sp_3072_sqr_96(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x2f4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_3072_sqr_96_outer\n\t"
+        "BLE	L_sp_3072_sqr_96_outer%=\n\t"
 #else
-        "BLE.N	L_sp_3072_sqr_96_outer\n\t"
+        "BLE.N	L_sp_3072_sqr_96_outer%=\n\t"
 #endif
         "LDR	lr, [%[a], #380]\n\t"
         "UMLAL	r6, r7, lr, lr\n\t"
@@ -13200,14 +13200,14 @@ static void sp_3072_sqr_96(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_3072_sqr_96_store:\n\t"
+    "L_sp_3072_sqr_96_store%=:\n\t"
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_3072_sqr_96_store\n\t"
+        "BGT	L_sp_3072_sqr_96_store%=\n\t"
 #else
-        "BGT.N	L_sp_3072_sqr_96_store\n\t"
+        "BGT.N	L_sp_3072_sqr_96_store%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a)
         :
@@ -13257,7 +13257,7 @@ static sp_digit sp_3072_add_48(sp_digit* r, const sp_digit* a, const sp_digit* b
         "MOV	r3, #0x0\n\t"
         "ADD	r12, %[a], #0xc0\n\t"
         "\n"
-    "L_sp_3072_add_48_word:\n\t"
+    "L_sp_3072_add_48_word%=:\n\t"
         "ADDS	r3, r3, #0xffffffff\n\t"
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
         "LDM	%[b]!, {r8, r9, r10, r11}\n\t"
@@ -13270,9 +13270,9 @@ static sp_digit sp_3072_add_48(sp_digit* r, const sp_digit* a, const sp_digit* b
         "ADC	r3, r4, #0x0\n\t"
         "CMP	%[a], r12\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_3072_add_48_word\n\t"
+        "BNE	L_sp_3072_add_48_word%=\n\t"
 #else
-        "BNE.N	L_sp_3072_add_48_word\n\t"
+        "BNE.N	L_sp_3072_add_48_word%=\n\t"
 #endif
         "MOV	%[r], r3\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -13304,7 +13304,7 @@ static sp_digit sp_3072_sub_in_place_48(sp_digit* a, const sp_digit* b)
         "MOV	r10, #0x0\n\t"
         "ADD	r11, %[a], #0xc0\n\t"
         "\n"
-    "L_sp_3072_sub_in_pkace_48_word:\n\t"
+    "L_sp_3072_sub_in_pkace_48_word%=:\n\t"
         "RSBS	r10, r10, #0x0\n\t"
         "LDM	%[a], {r2, r3, r4, r5}\n\t"
         "LDM	%[b]!, {r6, r7, r8, r9}\n\t"
@@ -13316,9 +13316,9 @@ static sp_digit sp_3072_sub_in_place_48(sp_digit* a, const sp_digit* b)
         "SBC	r10, r10, r10\n\t"
         "CMP	%[a], r11\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_3072_sub_in_pkace_48_word\n\t"
+        "BNE	L_sp_3072_sub_in_pkace_48_word%=\n\t"
 #else
-        "BNE.N	L_sp_3072_sub_in_pkace_48_word\n\t"
+        "BNE.N	L_sp_3072_sub_in_pkace_48_word%=\n\t"
 #endif
         "MOV	%[a], r10\n\t"
         : [a] "+r" (a), [b] "+r" (b)
@@ -13358,13 +13358,13 @@ static void sp_3072_mul_48(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_3072_mul_48_outer:\n\t"
+    "L_sp_3072_mul_48_outer%=:\n\t"
         "SUBS	r3, r5, #0xbc\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_3072_mul_48_inner:\n\t"
+    "L_sp_3072_mul_48_inner%=:\n\t"
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -13381,14 +13381,14 @@ static void sp_3072_mul_48(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_3072_mul_48_inner_done\n\t"
+        "BGT	L_sp_3072_mul_48_inner_done%=\n\t"
 #else
-        "BGT.N	L_sp_3072_mul_48_inner_done\n\t"
+        "BGT.N	L_sp_3072_mul_48_inner_done%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mul_48_inner\n\t"
+        "BLT	L_sp_3072_mul_48_inner%=\n\t"
 #else
-        "BLT.N	L_sp_3072_mul_48_inner\n\t"
+        "BLT.N	L_sp_3072_mul_48_inner%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r3]\n\t"
@@ -13397,7 +13397,7 @@ static void sp_3072_mul_48(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_3072_mul_48_inner_done:\n\t"
+    "L_sp_3072_mul_48_inner_done%=:\n\t"
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
@@ -13405,9 +13405,9 @@ static void sp_3072_mul_48(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x174\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_3072_mul_48_outer\n\t"
+        "BLE	L_sp_3072_mul_48_outer%=\n\t"
 #else
-        "BLE.N	L_sp_3072_mul_48_outer\n\t"
+        "BLE.N	L_sp_3072_mul_48_outer%=\n\t"
 #endif
         "LDR	lr, [%[a], #188]\n\t"
         "LDR	r11, [%[b], #188]\n\t"
@@ -13416,14 +13416,14 @@ static void sp_3072_mul_48(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_3072_mul_48_store:\n\t"
+    "L_sp_3072_mul_48_store%=:\n\t"
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_3072_mul_48_store\n\t"
+        "BGT	L_sp_3072_mul_48_store%=\n\t"
 #else
-        "BGT.N	L_sp_3072_mul_48_store\n\t"
+        "BGT.N	L_sp_3072_mul_48_store%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
@@ -13456,13 +13456,13 @@ static void sp_3072_sqr_48(sp_digit* r, const sp_digit* a)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_3072_sqr_48_outer:\n\t"
+    "L_sp_3072_sqr_48_outer%=:\n\t"
         "SUBS	r3, r5, #0xbc\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_3072_sqr_48_inner:\n\t"
+    "L_sp_3072_sqr_48_inner%=:\n\t"
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[a], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -13476,14 +13476,14 @@ static void sp_3072_sqr_48(sp_digit* r, const sp_digit* a)
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_3072_sqr_48_inner_done\n\t"
+        "BGT	L_sp_3072_sqr_48_inner_done%=\n\t"
 #else
-        "BGT.N	L_sp_3072_sqr_48_inner_done\n\t"
+        "BGT.N	L_sp_3072_sqr_48_inner_done%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_sqr_48_inner\n\t"
+        "BLT	L_sp_3072_sqr_48_inner%=\n\t"
 #else
-        "BLT.N	L_sp_3072_sqr_48_inner\n\t"
+        "BLT.N	L_sp_3072_sqr_48_inner%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "UMULL	r9, r10, lr, lr\n\t"
@@ -13491,7 +13491,7 @@ static void sp_3072_sqr_48(sp_digit* r, const sp_digit* a)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_3072_sqr_48_inner_done:\n\t"
+    "L_sp_3072_sqr_48_inner_done%=:\n\t"
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
@@ -13499,9 +13499,9 @@ static void sp_3072_sqr_48(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x174\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_3072_sqr_48_outer\n\t"
+        "BLE	L_sp_3072_sqr_48_outer%=\n\t"
 #else
-        "BLE.N	L_sp_3072_sqr_48_outer\n\t"
+        "BLE.N	L_sp_3072_sqr_48_outer%=\n\t"
 #endif
         "LDR	lr, [%[a], #188]\n\t"
         "UMLAL	r6, r7, lr, lr\n\t"
@@ -13509,14 +13509,14 @@ static void sp_3072_sqr_48(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_3072_sqr_48_store:\n\t"
+    "L_sp_3072_sqr_48_store%=:\n\t"
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_3072_sqr_48_store\n\t"
+        "BGT	L_sp_3072_sqr_48_store%=\n\t"
 #else
-        "BGT.N	L_sp_3072_sqr_48_store\n\t"
+        "BGT.N	L_sp_3072_sqr_48_store%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a)
         :
@@ -13575,7 +13575,7 @@ static void sp_3072_mul_d_96(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "MOV	r9, #0x4\n\t"
         "\n"
-    "L_sp_3072_mul_d_96_word:\n\t"
+    "L_sp_3072_mul_d_96_word%=:\n\t"
         /* A[i] * B */
         "LDR	r8, [%[a], r9]\n\t"
         "UMULL	r6, r7, %[b], r8\n\t"
@@ -13589,9 +13589,9 @@ static void sp_3072_mul_d_96(sp_digit* r, const sp_digit* a, sp_digit b)
         "ADD	r9, r9, #0x4\n\t"
         "CMP	r9, #0x180\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mul_d_96_word\n\t"
+        "BLT	L_sp_3072_mul_d_96_word%=\n\t"
 #else
-        "BLT.N	L_sp_3072_mul_d_96_word\n\t"
+        "BLT.N	L_sp_3072_mul_d_96_word%=\n\t"
 #endif
         "STR	r3, [%[r], #384]\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -14149,7 +14149,7 @@ static sp_digit sp_3072_cond_sub_48(sp_digit* r, const sp_digit* a, const sp_dig
         "MOV	r4, #0x0\n\t"
         "MOV	r5, #0x0\n\t"
         "\n"
-    "L_sp_3072_cond_sub_48_words:\n\t"
+    "L_sp_3072_cond_sub_48_words%=:\n\t"
         "SUBS	r4, r8, r4\n\t"
         "LDR	r6, [%[a], r5]\n\t"
         "LDR	r7, [%[b], r5]\n\t"
@@ -14160,9 +14160,9 @@ static sp_digit sp_3072_cond_sub_48(sp_digit* r, const sp_digit* a, const sp_dig
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0xc0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_cond_sub_48_words\n\t"
+        "BLT	L_sp_3072_cond_sub_48_words%=\n\t"
 #else
-        "BLT.N	L_sp_3072_cond_sub_48_words\n\t"
+        "BLT.N	L_sp_3072_cond_sub_48_words%=\n\t"
 #endif
         "MOV	%[r], r4\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -14401,7 +14401,7 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         "LDR	r4, [%[a]]\n\t"
         "LDR	r5, [%[a], #4]\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_48_word:\n\t"
+    "L_sp_3072_mont_reduce_48_word%=:\n\t"
         /* mu = a[i] * mp */
         "MUL	r10, %[mp], r4\n\t"
         /* a[i+0] += m[0] * mu */
@@ -14792,9 +14792,9 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r11, #0xc0\n\t"
 #ifdef __GNUC__
-        "BLT	L_sp_3072_mont_reduce_48_word\n\t"
+        "BLT	L_sp_3072_mont_reduce_48_word%=\n\t"
 #else
-        "BLT.W	L_sp_3072_mont_reduce_48_word\n\t"
+        "BLT.W	L_sp_3072_mont_reduce_48_word%=\n\t"
 #endif
         /* Loop Done */
         "STR	r4, [%[a]]\n\t"
@@ -14833,7 +14833,7 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         /* ca = 0 */
         "MOV	r3, #0x0\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_48_word:\n\t"
+    "L_sp_3072_mont_reduce_48_word%=:\n\t"
         /* mu = a[i] * mp */
         "LDR	r10, [%[a]]\n\t"
         "MUL	r8, %[mp], r10\n\t"
@@ -14841,7 +14841,7 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         "MOV	r12, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_48_mul:\n\t"
+    "L_sp_3072_mont_reduce_48_mul%=:\n\t"
         /* a[i+j+0] += m[j+0] * mu */
         "LDR	r7, [%[m], r12]\n\t"
         "LDR	r10, [%[a], r12]\n\t"
@@ -14884,9 +14884,9 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         "ADD	r12, r12, #0x4\n\t"
         "CMP	r12, #0xc0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mont_reduce_48_mul\n\t"
+        "BLT	L_sp_3072_mont_reduce_48_mul%=\n\t"
 #else
-        "BLT.N	L_sp_3072_mont_reduce_48_mul\n\t"
+        "BLT.N	L_sp_3072_mont_reduce_48_mul%=\n\t"
 #endif
         "LDR	r10, [%[a], #192]\n\t"
         "ADDS	r4, r4, r3\n\t"
@@ -14900,9 +14900,9 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r9, #0xc0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mont_reduce_48_word\n\t"
+        "BLT	L_sp_3072_mont_reduce_48_word%=\n\t"
 #else
-        "BLT.N	L_sp_3072_mont_reduce_48_word\n\t"
+        "BLT.N	L_sp_3072_mont_reduce_48_word%=\n\t"
 #endif
         /* Loop Done */
         "MOV	%[mp], r3\n\t"
@@ -14944,7 +14944,7 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         "LDR	r9, [%[a], #12]\n\t"
         "LDR	r10, [%[a], #16]\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_48_word:\n\t"
+    "L_sp_3072_mont_reduce_48_word%=:\n\t"
         /* mu = a[i] * mp */
         "MUL	lr, %[mp], r6\n\t"
         /* a[i+0] += m[0] * mu */
@@ -15192,9 +15192,9 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r4, #0xc0\n\t"
 #ifdef __GNUC__
-        "BLT	L_sp_3072_mont_reduce_48_word\n\t"
+        "BLT	L_sp_3072_mont_reduce_48_word%=\n\t"
 #else
-        "BLT.W	L_sp_3072_mont_reduce_48_word\n\t"
+        "BLT.W	L_sp_3072_mont_reduce_48_word%=\n\t"
 #endif
         /* Loop Done */
         "STR	r6, [%[a]]\n\t"
@@ -15236,7 +15236,7 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         /* ca = 0 */
         "MOV	r3, #0x0\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_48_word:\n\t"
+    "L_sp_3072_mont_reduce_48_word%=:\n\t"
         /* mu = a[i] * mp */
         "LDR	r10, [%[a]]\n\t"
         "MUL	r8, %[mp], r10\n\t"
@@ -15244,7 +15244,7 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         "MOV	r12, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_48_mul:\n\t"
+    "L_sp_3072_mont_reduce_48_mul%=:\n\t"
         /* a[i+j+0] += m[j+0] * mu */
         "LDR	r7, [%[m], r12]\n\t"
         "LDR	r10, [%[a], r12]\n\t"
@@ -15275,9 +15275,9 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         "ADD	r12, r12, #0x4\n\t"
         "CMP	r12, #0xc0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mont_reduce_48_mul\n\t"
+        "BLT	L_sp_3072_mont_reduce_48_mul%=\n\t"
 #else
-        "BLT.N	L_sp_3072_mont_reduce_48_mul\n\t"
+        "BLT.N	L_sp_3072_mont_reduce_48_mul%=\n\t"
 #endif
         "LDR	r10, [%[a], #192]\n\t"
         "ADDS	r4, r4, r3\n\t"
@@ -15291,9 +15291,9 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r9, #0xc0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mont_reduce_48_word\n\t"
+        "BLT	L_sp_3072_mont_reduce_48_word%=\n\t"
 #else
-        "BLT.N	L_sp_3072_mont_reduce_48_word\n\t"
+        "BLT.N	L_sp_3072_mont_reduce_48_word%=\n\t"
 #endif
         /* Loop Done */
         "MOV	%[mp], r3\n\t"
@@ -15364,7 +15364,7 @@ static void sp_3072_mul_d_48(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "MOV	r9, #0x4\n\t"
         "\n"
-    "L_sp_3072_mul_d_48_word:\n\t"
+    "L_sp_3072_mul_d_48_word%=:\n\t"
         /* A[i] * B */
         "LDR	r8, [%[a], r9]\n\t"
         "UMULL	r6, r7, %[b], r8\n\t"
@@ -15378,9 +15378,9 @@ static void sp_3072_mul_d_48(sp_digit* r, const sp_digit* a, sp_digit b)
         "ADD	r9, r9, #0x4\n\t"
         "CMP	r9, #0xc0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mul_d_48_word\n\t"
+        "BLT	L_sp_3072_mul_d_48_word%=\n\t"
 #else
-        "BLT.N	L_sp_3072_mul_d_48_word\n\t"
+        "BLT.N	L_sp_3072_mul_d_48_word%=\n\t"
 #endif
         "STR	r3, [%[r], #192]\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -15758,7 +15758,7 @@ SP_NOINLINE static sp_digit div_3072_word_48(sp_digit d1, sp_digit d0, sp_digit 
         /* Next 30 bits */
         "MOV	r4, #0x1d\n\t"
         "\n"
-    "L_div_3072_word_48_bit:\n\t"
+    "L_div_3072_word_48_bit%=:\n\t"
         "LSLS	r6, r6, #1\n\t"
         "ADC	r7, r7, r7\n\t"
         "SUBS	r8, r5, r7\n\t"
@@ -15768,7 +15768,7 @@ SP_NOINLINE static sp_digit div_3072_word_48(sp_digit d1, sp_digit d0, sp_digit 
         "AND	r8, r8, r5\n\t"
         "SUBS	r7, r7, r8\n\t"
         "SUBS	r4, r4, #0x1\n\t"
-        "bpl	L_div_3072_word_48_bit\n\t"
+        "bpl	L_div_3072_word_48_bit%=\n\t"
         "ADD	r3, r3, r3\n\t"
         "ADD	r3, r3, #0x1\n\t"
         "UMULL	r6, r7, r3, %[div]\n\t"
@@ -15820,7 +15820,7 @@ static sp_int32 sp_3072_cmp_48(const sp_digit* a, const sp_digit* b)
 #ifdef WOLFSSL_SP_SMALL
         "MOV	r6, #0xbc\n\t"
         "\n"
-    "L_sp_3072_cmp_48_words:\n\t"
+    "L_sp_3072_cmp_48_words%=:\n\t"
         "LDR	r4, [%[a], r6]\n\t"
         "LDR	r5, [%[b], r6]\n\t"
         "AND	r4, r4, r3\n\t"
@@ -15833,7 +15833,7 @@ static sp_int32 sp_3072_cmp_48(const sp_digit* a, const sp_digit* b)
         "IT	ne\n\t"
         "movne	r3, r7\n\t"
         "SUBS	r6, r6, #0x4\n\t"
-        "bcs	L_sp_3072_cmp_48_words\n\t"
+        "bcs	L_sp_3072_cmp_48_words%=\n\t"
         "EOR	r2, r2, r3\n\t"
 #else
         "LDR	r4, [%[a], #188]\n\t"
@@ -16797,7 +16797,7 @@ static sp_digit sp_3072_cond_sub_96(sp_digit* r, const sp_digit* a, const sp_dig
         "MOV	r4, #0x0\n\t"
         "MOV	r5, #0x0\n\t"
         "\n"
-    "L_sp_3072_cond_sub_96_words:\n\t"
+    "L_sp_3072_cond_sub_96_words%=:\n\t"
         "SUBS	r4, r8, r4\n\t"
         "LDR	r6, [%[a], r5]\n\t"
         "LDR	r7, [%[b], r5]\n\t"
@@ -16808,9 +16808,9 @@ static sp_digit sp_3072_cond_sub_96(sp_digit* r, const sp_digit* a, const sp_dig
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x180\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_cond_sub_96_words\n\t"
+        "BLT	L_sp_3072_cond_sub_96_words%=\n\t"
 #else
-        "BLT.N	L_sp_3072_cond_sub_96_words\n\t"
+        "BLT.N	L_sp_3072_cond_sub_96_words%=\n\t"
 #endif
         "MOV	%[r], r4\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -17217,7 +17217,7 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         "LDR	r4, [%[a]]\n\t"
         "LDR	r5, [%[a], #4]\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_96_word:\n\t"
+    "L_sp_3072_mont_reduce_96_word%=:\n\t"
         /* mu = a[i] * mp */
         "MUL	r10, %[mp], r4\n\t"
         /* a[i+0] += m[0] * mu */
@@ -17992,9 +17992,9 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r11, #0x180\n\t"
 #ifdef __GNUC__
-        "BLT	L_sp_3072_mont_reduce_96_word\n\t"
+        "BLT	L_sp_3072_mont_reduce_96_word%=\n\t"
 #else
-        "BLT.W	L_sp_3072_mont_reduce_96_word\n\t"
+        "BLT.W	L_sp_3072_mont_reduce_96_word%=\n\t"
 #endif
         /* Loop Done */
         "STR	r4, [%[a]]\n\t"
@@ -18033,7 +18033,7 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         /* ca = 0 */
         "MOV	r3, #0x0\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_96_word:\n\t"
+    "L_sp_3072_mont_reduce_96_word%=:\n\t"
         /* mu = a[i] * mp */
         "LDR	r10, [%[a]]\n\t"
         "MUL	r8, %[mp], r10\n\t"
@@ -18041,7 +18041,7 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         "MOV	r12, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_96_mul:\n\t"
+    "L_sp_3072_mont_reduce_96_mul%=:\n\t"
         /* a[i+j+0] += m[j+0] * mu */
         "LDR	r7, [%[m], r12]\n\t"
         "LDR	r10, [%[a], r12]\n\t"
@@ -18084,9 +18084,9 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         "ADD	r12, r12, #0x4\n\t"
         "CMP	r12, #0x180\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mont_reduce_96_mul\n\t"
+        "BLT	L_sp_3072_mont_reduce_96_mul%=\n\t"
 #else
-        "BLT.N	L_sp_3072_mont_reduce_96_mul\n\t"
+        "BLT.N	L_sp_3072_mont_reduce_96_mul%=\n\t"
 #endif
         "LDR	r10, [%[a], #384]\n\t"
         "ADDS	r4, r4, r3\n\t"
@@ -18100,9 +18100,9 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r9, #0x180\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mont_reduce_96_word\n\t"
+        "BLT	L_sp_3072_mont_reduce_96_word%=\n\t"
 #else
-        "BLT.N	L_sp_3072_mont_reduce_96_word\n\t"
+        "BLT.N	L_sp_3072_mont_reduce_96_word%=\n\t"
 #endif
         /* Loop Done */
         "MOV	%[mp], r3\n\t"
@@ -18144,7 +18144,7 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         "LDR	r9, [%[a], #12]\n\t"
         "LDR	r10, [%[a], #16]\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_96_word:\n\t"
+    "L_sp_3072_mont_reduce_96_word%=:\n\t"
         /* mu = a[i] * mp */
         "MUL	lr, %[mp], r6\n\t"
         /* a[i+0] += m[0] * mu */
@@ -18632,9 +18632,9 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r4, #0x180\n\t"
 #ifdef __GNUC__
-        "BLT	L_sp_3072_mont_reduce_96_word\n\t"
+        "BLT	L_sp_3072_mont_reduce_96_word%=\n\t"
 #else
-        "BLT.W	L_sp_3072_mont_reduce_96_word\n\t"
+        "BLT.W	L_sp_3072_mont_reduce_96_word%=\n\t"
 #endif
         /* Loop Done */
         "STR	r6, [%[a]]\n\t"
@@ -18676,7 +18676,7 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         /* ca = 0 */
         "MOV	r3, #0x0\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_96_word:\n\t"
+    "L_sp_3072_mont_reduce_96_word%=:\n\t"
         /* mu = a[i] * mp */
         "LDR	r10, [%[a]]\n\t"
         "MUL	r8, %[mp], r10\n\t"
@@ -18684,7 +18684,7 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         "MOV	r12, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_96_mul:\n\t"
+    "L_sp_3072_mont_reduce_96_mul%=:\n\t"
         /* a[i+j+0] += m[j+0] * mu */
         "LDR	r7, [%[m], r12]\n\t"
         "LDR	r10, [%[a], r12]\n\t"
@@ -18715,9 +18715,9 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         "ADD	r12, r12, #0x4\n\t"
         "CMP	r12, #0x180\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mont_reduce_96_mul\n\t"
+        "BLT	L_sp_3072_mont_reduce_96_mul%=\n\t"
 #else
-        "BLT.N	L_sp_3072_mont_reduce_96_mul\n\t"
+        "BLT.N	L_sp_3072_mont_reduce_96_mul%=\n\t"
 #endif
         "LDR	r10, [%[a], #384]\n\t"
         "ADDS	r4, r4, r3\n\t"
@@ -18731,9 +18731,9 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r9, #0x180\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mont_reduce_96_word\n\t"
+        "BLT	L_sp_3072_mont_reduce_96_word%=\n\t"
 #else
-        "BLT.N	L_sp_3072_mont_reduce_96_word\n\t"
+        "BLT.N	L_sp_3072_mont_reduce_96_word%=\n\t"
 #endif
         /* Loop Done */
         "MOV	%[mp], r3\n\t"
@@ -18799,7 +18799,7 @@ static sp_digit sp_3072_sub_96(sp_digit* r, const sp_digit* a, const sp_digit* b
         "MOV	r11, #0x0\n\t"
         "ADD	r12, %[a], #0x180\n\t"
         "\n"
-    "L_sp_3072_sub_96_word:\n\t"
+    "L_sp_3072_sub_96_word%=:\n\t"
         "RSBS	r11, r11, #0x0\n\t"
         "LDM	%[a]!, {r3, r4, r5, r6}\n\t"
         "LDM	%[b]!, {r7, r8, r9, r10}\n\t"
@@ -18811,9 +18811,9 @@ static sp_digit sp_3072_sub_96(sp_digit* r, const sp_digit* a, const sp_digit* b
         "SBC	r11, r3, r3\n\t"
         "CMP	%[a], r12\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_3072_sub_96_word\n\t"
+        "BNE	L_sp_3072_sub_96_word%=\n\t"
 #else
-        "BNE.N	L_sp_3072_sub_96_word\n\t"
+        "BNE.N	L_sp_3072_sub_96_word%=\n\t"
 #endif
         "MOV	%[r], r11\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -19122,7 +19122,7 @@ SP_NOINLINE static sp_digit div_3072_word_96(sp_digit d1, sp_digit d0, sp_digit 
         /* Next 30 bits */
         "MOV	r4, #0x1d\n\t"
         "\n"
-    "L_div_3072_word_96_bit:\n\t"
+    "L_div_3072_word_96_bit%=:\n\t"
         "LSLS	r6, r6, #1\n\t"
         "ADC	r7, r7, r7\n\t"
         "SUBS	r8, r5, r7\n\t"
@@ -19132,7 +19132,7 @@ SP_NOINLINE static sp_digit div_3072_word_96(sp_digit d1, sp_digit d0, sp_digit 
         "AND	r8, r8, r5\n\t"
         "SUBS	r7, r7, r8\n\t"
         "SUBS	r4, r4, #0x1\n\t"
-        "bpl	L_div_3072_word_96_bit\n\t"
+        "bpl	L_div_3072_word_96_bit%=\n\t"
         "ADD	r3, r3, r3\n\t"
         "ADD	r3, r3, #0x1\n\t"
         "UMULL	r6, r7, r3, %[div]\n\t"
@@ -19287,7 +19287,7 @@ static sp_int32 sp_3072_cmp_96(const sp_digit* a, const sp_digit* b)
 #ifdef WOLFSSL_SP_SMALL
         "MOV	r6, #0x17c\n\t"
         "\n"
-    "L_sp_3072_cmp_96_words:\n\t"
+    "L_sp_3072_cmp_96_words%=:\n\t"
         "LDR	r4, [%[a], r6]\n\t"
         "LDR	r5, [%[b], r6]\n\t"
         "AND	r4, r4, r3\n\t"
@@ -19300,7 +19300,7 @@ static sp_int32 sp_3072_cmp_96(const sp_digit* a, const sp_digit* b)
         "IT	ne\n\t"
         "movne	r3, r7\n\t"
         "SUBS	r6, r6, #0x4\n\t"
-        "bcs	L_sp_3072_cmp_96_words\n\t"
+        "bcs	L_sp_3072_cmp_96_words%=\n\t"
         "EOR	r2, r2, r3\n\t"
 #else
         "LDR	r4, [%[a], #380]\n\t"
@@ -20915,7 +20915,7 @@ static sp_digit sp_3072_cond_add_48(sp_digit* r, const sp_digit* a, const sp_dig
         "MOV	r8, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_3072_cond_add_48_words:\n\t"
+    "L_sp_3072_cond_add_48_words%=:\n\t"
         "ADDS	r5, r5, #0xffffffff\n\t"
         "LDR	r6, [%[a], r4]\n\t"
         "LDR	r7, [%[b], r4]\n\t"
@@ -20926,9 +20926,9 @@ static sp_digit sp_3072_cond_add_48(sp_digit* r, const sp_digit* a, const sp_dig
         "ADD	r4, r4, #0x4\n\t"
         "CMP	r4, #0xc0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_cond_add_48_words\n\t"
+        "BLT	L_sp_3072_cond_add_48_words%=\n\t"
 #else
-        "BLT.N	L_sp_3072_cond_add_48_words\n\t"
+        "BLT.N	L_sp_3072_cond_add_48_words%=\n\t"
 #endif
         "MOV	%[r], r5\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -23059,7 +23059,7 @@ static sp_digit sp_4096_add_128(sp_digit* r, const sp_digit* a, const sp_digit* 
         "MOV	r3, #0x0\n\t"
         "ADD	r12, %[a], #0x200\n\t"
         "\n"
-    "L_sp_4096_add_128_word:\n\t"
+    "L_sp_4096_add_128_word%=:\n\t"
         "ADDS	r3, r3, #0xffffffff\n\t"
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
         "LDM	%[b]!, {r8, r9, r10, r11}\n\t"
@@ -23072,9 +23072,9 @@ static sp_digit sp_4096_add_128(sp_digit* r, const sp_digit* a, const sp_digit* 
         "ADC	r3, r4, #0x0\n\t"
         "CMP	%[a], r12\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_4096_add_128_word\n\t"
+        "BNE	L_sp_4096_add_128_word%=\n\t"
 #else
-        "BNE.N	L_sp_4096_add_128_word\n\t"
+        "BNE.N	L_sp_4096_add_128_word%=\n\t"
 #endif
         "MOV	%[r], r3\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -23106,7 +23106,7 @@ static sp_digit sp_4096_sub_in_place_128(sp_digit* a, const sp_digit* b)
         "MOV	r10, #0x0\n\t"
         "ADD	r11, %[a], #0x200\n\t"
         "\n"
-    "L_sp_4096_sub_in_pkace_128_word:\n\t"
+    "L_sp_4096_sub_in_pkace_128_word%=:\n\t"
         "RSBS	r10, r10, #0x0\n\t"
         "LDM	%[a], {r2, r3, r4, r5}\n\t"
         "LDM	%[b]!, {r6, r7, r8, r9}\n\t"
@@ -23118,9 +23118,9 @@ static sp_digit sp_4096_sub_in_place_128(sp_digit* a, const sp_digit* b)
         "SBC	r10, r10, r10\n\t"
         "CMP	%[a], r11\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_4096_sub_in_pkace_128_word\n\t"
+        "BNE	L_sp_4096_sub_in_pkace_128_word%=\n\t"
 #else
-        "BNE.N	L_sp_4096_sub_in_pkace_128_word\n\t"
+        "BNE.N	L_sp_4096_sub_in_pkace_128_word%=\n\t"
 #endif
         "MOV	%[a], r10\n\t"
         : [a] "+r" (a), [b] "+r" (b)
@@ -23160,13 +23160,13 @@ static void sp_4096_mul_128(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_4096_mul_128_outer:\n\t"
+    "L_sp_4096_mul_128_outer%=:\n\t"
         "SUBS	r3, r5, #0x1fc\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_4096_mul_128_inner:\n\t"
+    "L_sp_4096_mul_128_inner%=:\n\t"
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -23183,14 +23183,14 @@ static void sp_4096_mul_128(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_4096_mul_128_inner_done\n\t"
+        "BGT	L_sp_4096_mul_128_inner_done%=\n\t"
 #else
-        "BGT.N	L_sp_4096_mul_128_inner_done\n\t"
+        "BGT.N	L_sp_4096_mul_128_inner_done%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_4096_mul_128_inner\n\t"
+        "BLT	L_sp_4096_mul_128_inner%=\n\t"
 #else
-        "BLT.N	L_sp_4096_mul_128_inner\n\t"
+        "BLT.N	L_sp_4096_mul_128_inner%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r3]\n\t"
@@ -23199,7 +23199,7 @@ static void sp_4096_mul_128(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_4096_mul_128_inner_done:\n\t"
+    "L_sp_4096_mul_128_inner_done%=:\n\t"
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
@@ -23207,9 +23207,9 @@ static void sp_4096_mul_128(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x3f4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_4096_mul_128_outer\n\t"
+        "BLE	L_sp_4096_mul_128_outer%=\n\t"
 #else
-        "BLE.N	L_sp_4096_mul_128_outer\n\t"
+        "BLE.N	L_sp_4096_mul_128_outer%=\n\t"
 #endif
         "LDR	lr, [%[a], #508]\n\t"
         "LDR	r11, [%[b], #508]\n\t"
@@ -23218,14 +23218,14 @@ static void sp_4096_mul_128(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_4096_mul_128_store:\n\t"
+    "L_sp_4096_mul_128_store%=:\n\t"
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_4096_mul_128_store\n\t"
+        "BGT	L_sp_4096_mul_128_store%=\n\t"
 #else
-        "BGT.N	L_sp_4096_mul_128_store\n\t"
+        "BGT.N	L_sp_4096_mul_128_store%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
@@ -23258,13 +23258,13 @@ static void sp_4096_sqr_128(sp_digit* r, const sp_digit* a)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_4096_sqr_128_outer:\n\t"
+    "L_sp_4096_sqr_128_outer%=:\n\t"
         "SUBS	r3, r5, #0x1fc\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_4096_sqr_128_inner:\n\t"
+    "L_sp_4096_sqr_128_inner%=:\n\t"
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[a], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -23278,14 +23278,14 @@ static void sp_4096_sqr_128(sp_digit* r, const sp_digit* a)
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_4096_sqr_128_inner_done\n\t"
+        "BGT	L_sp_4096_sqr_128_inner_done%=\n\t"
 #else
-        "BGT.N	L_sp_4096_sqr_128_inner_done\n\t"
+        "BGT.N	L_sp_4096_sqr_128_inner_done%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_4096_sqr_128_inner\n\t"
+        "BLT	L_sp_4096_sqr_128_inner%=\n\t"
 #else
-        "BLT.N	L_sp_4096_sqr_128_inner\n\t"
+        "BLT.N	L_sp_4096_sqr_128_inner%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "UMULL	r9, r10, lr, lr\n\t"
@@ -23293,7 +23293,7 @@ static void sp_4096_sqr_128(sp_digit* r, const sp_digit* a)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_4096_sqr_128_inner_done:\n\t"
+    "L_sp_4096_sqr_128_inner_done%=:\n\t"
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
@@ -23301,9 +23301,9 @@ static void sp_4096_sqr_128(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x3f4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_4096_sqr_128_outer\n\t"
+        "BLE	L_sp_4096_sqr_128_outer%=\n\t"
 #else
-        "BLE.N	L_sp_4096_sqr_128_outer\n\t"
+        "BLE.N	L_sp_4096_sqr_128_outer%=\n\t"
 #endif
         "LDR	lr, [%[a], #508]\n\t"
         "UMLAL	r6, r7, lr, lr\n\t"
@@ -23311,14 +23311,14 @@ static void sp_4096_sqr_128(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_4096_sqr_128_store:\n\t"
+    "L_sp_4096_sqr_128_store%=:\n\t"
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_4096_sqr_128_store\n\t"
+        "BGT	L_sp_4096_sqr_128_store%=\n\t"
 #else
-        "BGT.N	L_sp_4096_sqr_128_store\n\t"
+        "BGT.N	L_sp_4096_sqr_128_store%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a)
         :
@@ -23375,7 +23375,7 @@ static void sp_4096_mul_d_128(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "MOV	r9, #0x4\n\t"
         "\n"
-    "L_sp_4096_mul_d_128_word:\n\t"
+    "L_sp_4096_mul_d_128_word%=:\n\t"
         /* A[i] * B */
         "LDR	r8, [%[a], r9]\n\t"
         "UMULL	r6, r7, %[b], r8\n\t"
@@ -23389,9 +23389,9 @@ static void sp_4096_mul_d_128(sp_digit* r, const sp_digit* a, sp_digit b)
         "ADD	r9, r9, #0x4\n\t"
         "CMP	r9, #0x200\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_4096_mul_d_128_word\n\t"
+        "BLT	L_sp_4096_mul_d_128_word%=\n\t"
 #else
-        "BLT.N	L_sp_4096_mul_d_128_word\n\t"
+        "BLT.N	L_sp_4096_mul_d_128_word%=\n\t"
 #endif
         "STR	r3, [%[r], #512]\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -24110,7 +24110,7 @@ static sp_digit sp_4096_cond_sub_128(sp_digit* r, const sp_digit* a, const sp_di
         "MOV	r4, #0x0\n\t"
         "MOV	r5, #0x0\n\t"
         "\n"
-    "L_sp_4096_cond_sub_128_words:\n\t"
+    "L_sp_4096_cond_sub_128_words%=:\n\t"
         "SUBS	r4, r8, r4\n\t"
         "LDR	r6, [%[a], r5]\n\t"
         "LDR	r7, [%[b], r5]\n\t"
@@ -24121,9 +24121,9 @@ static sp_digit sp_4096_cond_sub_128(sp_digit* r, const sp_digit* a, const sp_di
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x200\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_4096_cond_sub_128_words\n\t"
+        "BLT	L_sp_4096_cond_sub_128_words%=\n\t"
 #else
-        "BLT.N	L_sp_4096_cond_sub_128_words\n\t"
+        "BLT.N	L_sp_4096_cond_sub_128_words%=\n\t"
 #endif
         "MOV	%[r], r4\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -24642,7 +24642,7 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         "LDR	r4, [%[a]]\n\t"
         "LDR	r5, [%[a], #4]\n\t"
         "\n"
-    "L_sp_4096_mont_reduce_128_word:\n\t"
+    "L_sp_4096_mont_reduce_128_word%=:\n\t"
         /* mu = a[i] * mp */
         "MUL	r10, %[mp], r4\n\t"
         /* a[i+0] += m[0] * mu */
@@ -25673,9 +25673,9 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r11, #0x200\n\t"
 #ifdef __GNUC__
-        "BLT	L_sp_4096_mont_reduce_128_word\n\t"
+        "BLT	L_sp_4096_mont_reduce_128_word%=\n\t"
 #else
-        "BLT.W	L_sp_4096_mont_reduce_128_word\n\t"
+        "BLT.W	L_sp_4096_mont_reduce_128_word%=\n\t"
 #endif
         /* Loop Done */
         "STR	r4, [%[a]]\n\t"
@@ -25714,7 +25714,7 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         /* ca = 0 */
         "MOV	r3, #0x0\n\t"
         "\n"
-    "L_sp_4096_mont_reduce_128_word:\n\t"
+    "L_sp_4096_mont_reduce_128_word%=:\n\t"
         /* mu = a[i] * mp */
         "LDR	r10, [%[a]]\n\t"
         "MUL	r8, %[mp], r10\n\t"
@@ -25722,7 +25722,7 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         "MOV	r12, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_4096_mont_reduce_128_mul:\n\t"
+    "L_sp_4096_mont_reduce_128_mul%=:\n\t"
         /* a[i+j+0] += m[j+0] * mu */
         "LDR	r7, [%[m], r12]\n\t"
         "LDR	r10, [%[a], r12]\n\t"
@@ -25765,9 +25765,9 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         "ADD	r12, r12, #0x4\n\t"
         "CMP	r12, #0x200\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_4096_mont_reduce_128_mul\n\t"
+        "BLT	L_sp_4096_mont_reduce_128_mul%=\n\t"
 #else
-        "BLT.N	L_sp_4096_mont_reduce_128_mul\n\t"
+        "BLT.N	L_sp_4096_mont_reduce_128_mul%=\n\t"
 #endif
         "LDR	r10, [%[a], #512]\n\t"
         "ADDS	r4, r4, r3\n\t"
@@ -25781,9 +25781,9 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r9, #0x200\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_4096_mont_reduce_128_word\n\t"
+        "BLT	L_sp_4096_mont_reduce_128_word%=\n\t"
 #else
-        "BLT.N	L_sp_4096_mont_reduce_128_word\n\t"
+        "BLT.N	L_sp_4096_mont_reduce_128_word%=\n\t"
 #endif
         /* Loop Done */
         "MOV	%[mp], r3\n\t"
@@ -25825,7 +25825,7 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         "LDR	r9, [%[a], #12]\n\t"
         "LDR	r10, [%[a], #16]\n\t"
         "\n"
-    "L_sp_4096_mont_reduce_128_word:\n\t"
+    "L_sp_4096_mont_reduce_128_word%=:\n\t"
         /* mu = a[i] * mp */
         "MUL	lr, %[mp], r6\n\t"
         /* a[i+0] += m[0] * mu */
@@ -26473,9 +26473,9 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r4, #0x200\n\t"
 #ifdef __GNUC__
-        "BLT	L_sp_4096_mont_reduce_128_word\n\t"
+        "BLT	L_sp_4096_mont_reduce_128_word%=\n\t"
 #else
-        "BLT.W	L_sp_4096_mont_reduce_128_word\n\t"
+        "BLT.W	L_sp_4096_mont_reduce_128_word%=\n\t"
 #endif
         /* Loop Done */
         "STR	r6, [%[a]]\n\t"
@@ -26517,7 +26517,7 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         /* ca = 0 */
         "MOV	r3, #0x0\n\t"
         "\n"
-    "L_sp_4096_mont_reduce_128_word:\n\t"
+    "L_sp_4096_mont_reduce_128_word%=:\n\t"
         /* mu = a[i] * mp */
         "LDR	r10, [%[a]]\n\t"
         "MUL	r8, %[mp], r10\n\t"
@@ -26525,7 +26525,7 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         "MOV	r12, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_4096_mont_reduce_128_mul:\n\t"
+    "L_sp_4096_mont_reduce_128_mul%=:\n\t"
         /* a[i+j+0] += m[j+0] * mu */
         "LDR	r7, [%[m], r12]\n\t"
         "LDR	r10, [%[a], r12]\n\t"
@@ -26556,9 +26556,9 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         "ADD	r12, r12, #0x4\n\t"
         "CMP	r12, #0x200\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_4096_mont_reduce_128_mul\n\t"
+        "BLT	L_sp_4096_mont_reduce_128_mul%=\n\t"
 #else
-        "BLT.N	L_sp_4096_mont_reduce_128_mul\n\t"
+        "BLT.N	L_sp_4096_mont_reduce_128_mul%=\n\t"
 #endif
         "LDR	r10, [%[a], #512]\n\t"
         "ADDS	r4, r4, r3\n\t"
@@ -26572,9 +26572,9 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r9, #0x200\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_4096_mont_reduce_128_word\n\t"
+        "BLT	L_sp_4096_mont_reduce_128_word%=\n\t"
 #else
-        "BLT.N	L_sp_4096_mont_reduce_128_word\n\t"
+        "BLT.N	L_sp_4096_mont_reduce_128_word%=\n\t"
 #endif
         /* Loop Done */
         "MOV	%[mp], r3\n\t"
@@ -26640,7 +26640,7 @@ static sp_digit sp_4096_sub_128(sp_digit* r, const sp_digit* a, const sp_digit* 
         "MOV	r11, #0x0\n\t"
         "ADD	r12, %[a], #0x200\n\t"
         "\n"
-    "L_sp_4096_sub_128_word:\n\t"
+    "L_sp_4096_sub_128_word%=:\n\t"
         "RSBS	r11, r11, #0x0\n\t"
         "LDM	%[a]!, {r3, r4, r5, r6}\n\t"
         "LDM	%[b]!, {r7, r8, r9, r10}\n\t"
@@ -26652,9 +26652,9 @@ static sp_digit sp_4096_sub_128(sp_digit* r, const sp_digit* a, const sp_digit* 
         "SBC	r11, r3, r3\n\t"
         "CMP	%[a], r12\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_4096_sub_128_word\n\t"
+        "BNE	L_sp_4096_sub_128_word%=\n\t"
 #else
-        "BNE.N	L_sp_4096_sub_128_word\n\t"
+        "BNE.N	L_sp_4096_sub_128_word%=\n\t"
 #endif
         "MOV	%[r], r11\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -27019,7 +27019,7 @@ SP_NOINLINE static sp_digit div_4096_word_128(sp_digit d1, sp_digit d0, sp_digit
         /* Next 30 bits */
         "MOV	r4, #0x1d\n\t"
         "\n"
-    "L_div_4096_word_128_bit:\n\t"
+    "L_div_4096_word_128_bit%=:\n\t"
         "LSLS	r6, r6, #1\n\t"
         "ADC	r7, r7, r7\n\t"
         "SUBS	r8, r5, r7\n\t"
@@ -27029,7 +27029,7 @@ SP_NOINLINE static sp_digit div_4096_word_128(sp_digit d1, sp_digit d0, sp_digit
         "AND	r8, r8, r5\n\t"
         "SUBS	r7, r7, r8\n\t"
         "SUBS	r4, r4, #0x1\n\t"
-        "bpl	L_div_4096_word_128_bit\n\t"
+        "bpl	L_div_4096_word_128_bit%=\n\t"
         "ADD	r3, r3, r3\n\t"
         "ADD	r3, r3, #0x1\n\t"
         "UMULL	r6, r7, r3, %[div]\n\t"
@@ -27184,7 +27184,7 @@ static sp_int32 sp_4096_cmp_128(const sp_digit* a, const sp_digit* b)
 #ifdef WOLFSSL_SP_SMALL
         "MOV	r6, #0x1fc\n\t"
         "\n"
-    "L_sp_4096_cmp_128_words:\n\t"
+    "L_sp_4096_cmp_128_words%=:\n\t"
         "LDR	r4, [%[a], r6]\n\t"
         "LDR	r5, [%[b], r6]\n\t"
         "AND	r4, r4, r3\n\t"
@@ -27197,7 +27197,7 @@ static sp_int32 sp_4096_cmp_128(const sp_digit* a, const sp_digit* b)
         "IT	ne\n\t"
         "movne	r3, r7\n\t"
         "SUBS	r6, r6, #0x4\n\t"
-        "bcs	L_sp_4096_cmp_128_words\n\t"
+        "bcs	L_sp_4096_cmp_128_words%=\n\t"
         "EOR	r2, r2, r3\n\t"
 #else
         "LDR	r4, [%[a], #508]\n\t"
@@ -29164,7 +29164,7 @@ static sp_digit sp_4096_cond_add_64(sp_digit* r, const sp_digit* a, const sp_dig
         "MOV	r8, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_4096_cond_add_64_words:\n\t"
+    "L_sp_4096_cond_add_64_words%=:\n\t"
         "ADDS	r5, r5, #0xffffffff\n\t"
         "LDR	r6, [%[a], r4]\n\t"
         "LDR	r7, [%[b], r4]\n\t"
@@ -29175,9 +29175,9 @@ static sp_digit sp_4096_cond_add_64(sp_digit* r, const sp_digit* a, const sp_dig
         "ADD	r4, r4, #0x4\n\t"
         "CMP	r4, #0x100\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_4096_cond_add_64_words\n\t"
+        "BLT	L_sp_4096_cond_add_64_words%=\n\t"
 #else
-        "BLT.N	L_sp_4096_cond_add_64_words\n\t"
+        "BLT.N	L_sp_4096_cond_add_64_words%=\n\t"
 #endif
         "MOV	%[r], r5\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -30857,13 +30857,13 @@ static void sp_256_mul_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_256_mul_8_outer:\n\t"
+    "L_sp_256_mul_8_outer%=:\n\t"
         "SUBS	r3, r5, #0x1c\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_256_mul_8_inner:\n\t"
+    "L_sp_256_mul_8_inner%=:\n\t"
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -30880,14 +30880,14 @@ static void sp_256_mul_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_256_mul_8_inner_done\n\t"
+        "BGT	L_sp_256_mul_8_inner_done%=\n\t"
 #else
-        "BGT.N	L_sp_256_mul_8_inner_done\n\t"
+        "BGT.N	L_sp_256_mul_8_inner_done%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_256_mul_8_inner\n\t"
+        "BLT	L_sp_256_mul_8_inner%=\n\t"
 #else
-        "BLT.N	L_sp_256_mul_8_inner\n\t"
+        "BLT.N	L_sp_256_mul_8_inner%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r3]\n\t"
@@ -30896,7 +30896,7 @@ static void sp_256_mul_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_256_mul_8_inner_done:\n\t"
+    "L_sp_256_mul_8_inner_done%=:\n\t"
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
@@ -30904,9 +30904,9 @@ static void sp_256_mul_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x34\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_256_mul_8_outer\n\t"
+        "BLE	L_sp_256_mul_8_outer%=\n\t"
 #else
-        "BLE.N	L_sp_256_mul_8_outer\n\t"
+        "BLE.N	L_sp_256_mul_8_outer%=\n\t"
 #endif
         "LDR	lr, [%[a], #28]\n\t"
         "LDR	r11, [%[b], #28]\n\t"
@@ -30915,14 +30915,14 @@ static void sp_256_mul_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_256_mul_8_store:\n\t"
+    "L_sp_256_mul_8_store%=:\n\t"
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_256_mul_8_store\n\t"
+        "BGT	L_sp_256_mul_8_store%=\n\t"
 #else
-        "BGT.N	L_sp_256_mul_8_store\n\t"
+        "BGT.N	L_sp_256_mul_8_store%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
@@ -31455,13 +31455,13 @@ static void sp_256_sqr_8(sp_digit* r, const sp_digit* a)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_256_sqr_8_outer:\n\t"
+    "L_sp_256_sqr_8_outer%=:\n\t"
         "SUBS	r3, r5, #0x1c\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_256_sqr_8_inner:\n\t"
+    "L_sp_256_sqr_8_inner%=:\n\t"
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[a], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -31475,14 +31475,14 @@ static void sp_256_sqr_8(sp_digit* r, const sp_digit* a)
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_256_sqr_8_inner_done\n\t"
+        "BGT	L_sp_256_sqr_8_inner_done%=\n\t"
 #else
-        "BGT.N	L_sp_256_sqr_8_inner_done\n\t"
+        "BGT.N	L_sp_256_sqr_8_inner_done%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_256_sqr_8_inner\n\t"
+        "BLT	L_sp_256_sqr_8_inner%=\n\t"
 #else
-        "BLT.N	L_sp_256_sqr_8_inner\n\t"
+        "BLT.N	L_sp_256_sqr_8_inner%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "UMULL	r9, r10, lr, lr\n\t"
@@ -31490,7 +31490,7 @@ static void sp_256_sqr_8(sp_digit* r, const sp_digit* a)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_256_sqr_8_inner_done:\n\t"
+    "L_sp_256_sqr_8_inner_done%=:\n\t"
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
@@ -31498,9 +31498,9 @@ static void sp_256_sqr_8(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x34\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_256_sqr_8_outer\n\t"
+        "BLE	L_sp_256_sqr_8_outer%=\n\t"
 #else
-        "BLE.N	L_sp_256_sqr_8_outer\n\t"
+        "BLE.N	L_sp_256_sqr_8_outer%=\n\t"
 #endif
         "LDR	lr, [%[a], #28]\n\t"
         "UMLAL	r6, r7, lr, lr\n\t"
@@ -31508,14 +31508,14 @@ static void sp_256_sqr_8(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_256_sqr_8_store:\n\t"
+    "L_sp_256_sqr_8_store%=:\n\t"
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_256_sqr_8_store\n\t"
+        "BGT	L_sp_256_sqr_8_store%=\n\t"
 #else
-        "BGT.N	L_sp_256_sqr_8_store\n\t"
+        "BGT.N	L_sp_256_sqr_8_store%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a)
         :
@@ -31915,7 +31915,7 @@ static sp_digit sp_256_add_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r3, #0x0\n\t"
         "ADD	r12, %[a], #0x20\n\t"
         "\n"
-    "L_sp_256_add_8_word:\n\t"
+    "L_sp_256_add_8_word%=:\n\t"
         "ADDS	r3, r3, #0xffffffff\n\t"
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
         "LDM	%[b]!, {r8, r9, r10, r11}\n\t"
@@ -31928,9 +31928,9 @@ static sp_digit sp_256_add_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADC	r3, r4, #0x0\n\t"
         "CMP	%[a], r12\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_256_add_8_word\n\t"
+        "BNE	L_sp_256_add_8_word%=\n\t"
 #else
-        "BNE.N	L_sp_256_add_8_word\n\t"
+        "BNE.N	L_sp_256_add_8_word%=\n\t"
 #endif
         "MOV	%[r], r3\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -33938,7 +33938,7 @@ static sp_int32 sp_256_cmp_8(const sp_digit* a, const sp_digit* b)
 #ifdef WOLFSSL_SP_SMALL
         "MOV	r6, #0x1c\n\t"
         "\n"
-    "L_sp_256_cmp_8_words:\n\t"
+    "L_sp_256_cmp_8_words%=:\n\t"
         "LDR	r4, [%[a], r6]\n\t"
         "LDR	r5, [%[b], r6]\n\t"
         "AND	r4, r4, r3\n\t"
@@ -33951,7 +33951,7 @@ static sp_int32 sp_256_cmp_8(const sp_digit* a, const sp_digit* b)
         "IT	ne\n\t"
         "movne	r3, r7\n\t"
         "SUBS	r6, r6, #0x4\n\t"
-        "bcs	L_sp_256_cmp_8_words\n\t"
+        "bcs	L_sp_256_cmp_8_words%=\n\t"
         "EOR	r2, r2, r3\n\t"
 #else
         "LDR	r4, [%[a], #28]\n\t"
@@ -34085,7 +34085,7 @@ static sp_digit sp_256_cond_sub_8(sp_digit* r, const sp_digit* a, const sp_digit
         "MOV	r4, #0x0\n\t"
         "MOV	r5, #0x0\n\t"
         "\n"
-    "L_sp_256_cond_sub_8_words:\n\t"
+    "L_sp_256_cond_sub_8_words%=:\n\t"
         "SUBS	r4, r8, r4\n\t"
         "LDR	r6, [%[a], r5]\n\t"
         "LDR	r7, [%[b], r5]\n\t"
@@ -34096,9 +34096,9 @@ static sp_digit sp_256_cond_sub_8(sp_digit* r, const sp_digit* a, const sp_digit
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x20\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_256_cond_sub_8_words\n\t"
+        "BLT	L_sp_256_cond_sub_8_words%=\n\t"
 #else
-        "BLT.N	L_sp_256_cond_sub_8_words\n\t"
+        "BLT.N	L_sp_256_cond_sub_8_words%=\n\t"
 #endif
         "MOV	%[r], r4\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -34199,7 +34199,7 @@ SP_NOINLINE static void sp_256_mont_reduce_8(sp_digit* a, const sp_digit* m, sp_
         "LDR	r4, [%[a]]\n\t"
         "LDR	r5, [%[a], #4]\n\t"
         "\n"
-    "L_sp_256_mont_reduce_8_word:\n\t"
+    "L_sp_256_mont_reduce_8_word%=:\n\t"
         /* mu = a[i] * mp */
         "MUL	r10, %[mp], r4\n\t"
         /* a[i+0] += m[0] * mu */
@@ -34270,9 +34270,9 @@ SP_NOINLINE static void sp_256_mont_reduce_8(sp_digit* a, const sp_digit* m, sp_
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r11, #0x20\n\t"
 #ifdef __GNUC__
-        "BLT	L_sp_256_mont_reduce_8_word\n\t"
+        "BLT	L_sp_256_mont_reduce_8_word%=\n\t"
 #else
-        "BLT.W	L_sp_256_mont_reduce_8_word\n\t"
+        "BLT.W	L_sp_256_mont_reduce_8_word%=\n\t"
 #endif
         /* Loop Done */
         "STR	r4, [%[a]]\n\t"
@@ -34314,7 +34314,7 @@ SP_NOINLINE static void sp_256_mont_reduce_8(sp_digit* a, const sp_digit* m, sp_
         "LDR	r9, [%[a], #12]\n\t"
         "LDR	r10, [%[a], #16]\n\t"
         "\n"
-    "L_sp_256_mont_reduce_8_word:\n\t"
+    "L_sp_256_mont_reduce_8_word%=:\n\t"
         /* mu = a[i] * mp */
         "MUL	lr, %[mp], r6\n\t"
         /* a[i+0] += m[0] * mu */
@@ -34362,9 +34362,9 @@ SP_NOINLINE static void sp_256_mont_reduce_8(sp_digit* a, const sp_digit* m, sp_
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r4, #0x20\n\t"
 #ifdef __GNUC__
-        "BLT	L_sp_256_mont_reduce_8_word\n\t"
+        "BLT	L_sp_256_mont_reduce_8_word%=\n\t"
 #else
-        "BLT.W	L_sp_256_mont_reduce_8_word\n\t"
+        "BLT.W	L_sp_256_mont_reduce_8_word%=\n\t"
 #endif
         /* Loop Done */
         "STR	r6, [%[a]]\n\t"
@@ -34573,7 +34573,7 @@ SP_NOINLINE static void sp_256_mont_reduce_order_8(sp_digit* a, const sp_digit* 
         "LDR	r4, [%[a]]\n\t"
         "LDR	r5, [%[a], #4]\n\t"
         "\n"
-    "L_sp_256_mont_reduce_order_8_word:\n\t"
+    "L_sp_256_mont_reduce_order_8_word%=:\n\t"
         /* mu = a[i] * mp */
         "MUL	r10, %[mp], r4\n\t"
         /* a[i+0] += m[0] * mu */
@@ -34644,9 +34644,9 @@ SP_NOINLINE static void sp_256_mont_reduce_order_8(sp_digit* a, const sp_digit* 
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r11, #0x20\n\t"
 #ifdef __GNUC__
-        "BLT	L_sp_256_mont_reduce_order_8_word\n\t"
+        "BLT	L_sp_256_mont_reduce_order_8_word%=\n\t"
 #else
-        "BLT.W	L_sp_256_mont_reduce_order_8_word\n\t"
+        "BLT.W	L_sp_256_mont_reduce_order_8_word%=\n\t"
 #endif
         /* Loop Done */
         "STR	r4, [%[a]]\n\t"
@@ -34688,7 +34688,7 @@ SP_NOINLINE static void sp_256_mont_reduce_order_8(sp_digit* a, const sp_digit* 
         "LDR	r9, [%[a], #12]\n\t"
         "LDR	r10, [%[a], #16]\n\t"
         "\n"
-    "L_sp_256_mont_reduce_order_8_word:\n\t"
+    "L_sp_256_mont_reduce_order_8_word%=:\n\t"
         /* mu = a[i] * mp */
         "MUL	lr, %[mp], r6\n\t"
         /* a[i+0] += m[0] * mu */
@@ -34736,9 +34736,9 @@ SP_NOINLINE static void sp_256_mont_reduce_order_8(sp_digit* a, const sp_digit* 
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r4, #0x20\n\t"
 #ifdef __GNUC__
-        "BLT	L_sp_256_mont_reduce_order_8_word\n\t"
+        "BLT	L_sp_256_mont_reduce_order_8_word%=\n\t"
 #else
-        "BLT.W	L_sp_256_mont_reduce_order_8_word\n\t"
+        "BLT.W	L_sp_256_mont_reduce_order_8_word%=\n\t"
 #endif
         /* Loop Done */
         "STR	r6, [%[a]]\n\t"
@@ -39075,7 +39075,7 @@ static sp_digit sp_256_sub_in_place_8(sp_digit* a, const sp_digit* b)
         "MOV	r10, #0x0\n\t"
         "ADD	r11, %[a], #0x20\n\t"
         "\n"
-    "L_sp_256_sub_in_pkace_8_word:\n\t"
+    "L_sp_256_sub_in_pkace_8_word%=:\n\t"
         "RSBS	r10, r10, #0x0\n\t"
         "LDM	%[a], {r2, r3, r4, r5}\n\t"
         "LDM	%[b]!, {r6, r7, r8, r9}\n\t"
@@ -39087,9 +39087,9 @@ static sp_digit sp_256_sub_in_place_8(sp_digit* a, const sp_digit* b)
         "SBC	r10, r10, r10\n\t"
         "CMP	%[a], r11\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_256_sub_in_pkace_8_word\n\t"
+        "BNE	L_sp_256_sub_in_pkace_8_word%=\n\t"
 #else
-        "BNE.N	L_sp_256_sub_in_pkace_8_word\n\t"
+        "BNE.N	L_sp_256_sub_in_pkace_8_word%=\n\t"
 #endif
         "MOV	%[a], r10\n\t"
         : [a] "+r" (a), [b] "+r" (b)
@@ -39168,7 +39168,7 @@ static void sp_256_mul_d_8(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "MOV	r9, #0x4\n\t"
         "\n"
-    "L_sp_256_mul_d_8_word:\n\t"
+    "L_sp_256_mul_d_8_word%=:\n\t"
         /* A[i] * B */
         "LDR	r8, [%[a], r9]\n\t"
         "UMULL	r6, r7, %[b], r8\n\t"
@@ -39182,9 +39182,9 @@ static void sp_256_mul_d_8(sp_digit* r, const sp_digit* a, sp_digit b)
         "ADD	r9, r9, #0x4\n\t"
         "CMP	r9, #0x20\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_256_mul_d_8_word\n\t"
+        "BLT	L_sp_256_mul_d_8_word%=\n\t"
 #else
-        "BLT.N	L_sp_256_mul_d_8_word\n\t"
+        "BLT.N	L_sp_256_mul_d_8_word%=\n\t"
 #endif
         "STR	r3, [%[r], #32]\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -39362,7 +39362,7 @@ SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1, sp_digit d0, sp_digit di
         /* Next 30 bits */
         "MOV	r4, #0x1d\n\t"
         "\n"
-    "L_div_256_word_8_bit:\n\t"
+    "L_div_256_word_8_bit%=:\n\t"
         "LSLS	r6, r6, #1\n\t"
         "ADC	r7, r7, r7\n\t"
         "SUBS	r8, r5, r7\n\t"
@@ -39372,7 +39372,7 @@ SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1, sp_digit d0, sp_digit di
         "AND	r8, r8, r5\n\t"
         "SUBS	r7, r7, r8\n\t"
         "SUBS	r4, r4, #0x1\n\t"
-        "bpl	L_div_256_word_8_bit\n\t"
+        "bpl	L_div_256_word_8_bit%=\n\t"
         "ADD	r3, r3, r3\n\t"
         "ADD	r3, r3, #0x1\n\t"
         "UMULL	r6, r7, r3, %[div]\n\t"
@@ -40066,7 +40066,7 @@ static sp_digit sp_256_sub_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r11, #0x0\n\t"
         "ADD	r12, %[a], #0x20\n\t"
         "\n"
-    "L_sp_256_sub_8_word:\n\t"
+    "L_sp_256_sub_8_word%=:\n\t"
         "RSBS	r11, r11, #0x0\n\t"
         "LDM	%[a]!, {r3, r4, r5, r6}\n\t"
         "LDM	%[b]!, {r7, r8, r9, r10}\n\t"
@@ -40078,9 +40078,9 @@ static sp_digit sp_256_sub_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "SBC	r11, r3, r3\n\t"
         "CMP	%[a], r12\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_256_sub_8_word\n\t"
+        "BNE	L_sp_256_sub_8_word%=\n\t"
 #else
-        "BNE.N	L_sp_256_sub_8_word\n\t"
+        "BNE.N	L_sp_256_sub_8_word%=\n\t"
 #endif
         "MOV	%[r], r11\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -40200,9 +40200,9 @@ static void sp_256_div2_mod_8(sp_digit* r, const sp_digit* a, const sp_digit* m)
         "LDM	%[a]!, {r4}\n\t"
         "ANDS	r3, r4, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_256_div2_mod_8_even\n\t"
+        "BEQ	L_sp_256_div2_mod_8_even%=\n\t"
 #else
-        "BEQ.N	L_sp_256_div2_mod_8_even\n\t"
+        "BEQ.N	L_sp_256_div2_mod_8_even%=\n\t"
 #endif
         "LDM	%[a]!, {r5, r6, r7}\n\t"
         "LDM	%[m]!, {r8, r9, r10, r11}\n\t"
@@ -40219,16 +40219,16 @@ static void sp_256_div2_mod_8(sp_digit* r, const sp_digit* a, const sp_digit* m)
         "ADCS	r7, r7, r11\n\t"
         "ADC	r3, r12, r12\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_256_div2_mod_8_div2\n\t"
+        "B	L_sp_256_div2_mod_8_div2%=\n\t"
 #else
-        "B.N	L_sp_256_div2_mod_8_div2\n\t"
+        "B.N	L_sp_256_div2_mod_8_div2%=\n\t"
 #endif
         "\n"
-    "L_sp_256_div2_mod_8_even:\n\t"
+    "L_sp_256_div2_mod_8_even%=:\n\t"
         "LDRD	r4, r5, [%[a], #12]\n\t"
         "LDRD	r6, r7, [%[a], #20]\n\t"
         "\n"
-    "L_sp_256_div2_mod_8_div2:\n\t"
+    "L_sp_256_div2_mod_8_div2%=:\n\t"
         "LSR	r8, r4, #1\n\t"
         "AND	r4, r4, #0x1\n\t"
         "LSR	r9, r5, #1\n\t"
@@ -40271,128 +40271,128 @@ static int sp_256_num_bits_8(const sp_digit* a)
         "LDR	r1, [%[a], #28]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_256_num_bits_8_7\n\t"
+        "BEQ	L_sp_256_num_bits_8_7%=\n\t"
 #else
-        "BEQ.N	L_sp_256_num_bits_8_7\n\t"
+        "BEQ.N	L_sp_256_num_bits_8_7%=\n\t"
 #endif
         "MOV	r2, #0x100\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_256_num_bits_8_9\n\t"
+        "B	L_sp_256_num_bits_8_9%=\n\t"
 #else
-        "B.N	L_sp_256_num_bits_8_9\n\t"
+        "B.N	L_sp_256_num_bits_8_9%=\n\t"
 #endif
         "\n"
-    "L_sp_256_num_bits_8_7:\n\t"
+    "L_sp_256_num_bits_8_7%=:\n\t"
         "LDR	r1, [%[a], #24]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_256_num_bits_8_6\n\t"
+        "BEQ	L_sp_256_num_bits_8_6%=\n\t"
 #else
-        "BEQ.N	L_sp_256_num_bits_8_6\n\t"
+        "BEQ.N	L_sp_256_num_bits_8_6%=\n\t"
 #endif
         "MOV	r2, #0xe0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_256_num_bits_8_9\n\t"
+        "B	L_sp_256_num_bits_8_9%=\n\t"
 #else
-        "B.N	L_sp_256_num_bits_8_9\n\t"
+        "B.N	L_sp_256_num_bits_8_9%=\n\t"
 #endif
         "\n"
-    "L_sp_256_num_bits_8_6:\n\t"
+    "L_sp_256_num_bits_8_6%=:\n\t"
         "LDR	r1, [%[a], #20]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_256_num_bits_8_5\n\t"
+        "BEQ	L_sp_256_num_bits_8_5%=\n\t"
 #else
-        "BEQ.N	L_sp_256_num_bits_8_5\n\t"
+        "BEQ.N	L_sp_256_num_bits_8_5%=\n\t"
 #endif
         "MOV	r2, #0xc0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_256_num_bits_8_9\n\t"
+        "B	L_sp_256_num_bits_8_9%=\n\t"
 #else
-        "B.N	L_sp_256_num_bits_8_9\n\t"
+        "B.N	L_sp_256_num_bits_8_9%=\n\t"
 #endif
         "\n"
-    "L_sp_256_num_bits_8_5:\n\t"
+    "L_sp_256_num_bits_8_5%=:\n\t"
         "LDR	r1, [%[a], #16]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_256_num_bits_8_4\n\t"
+        "BEQ	L_sp_256_num_bits_8_4%=\n\t"
 #else
-        "BEQ.N	L_sp_256_num_bits_8_4\n\t"
+        "BEQ.N	L_sp_256_num_bits_8_4%=\n\t"
 #endif
         "MOV	r2, #0xa0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_256_num_bits_8_9\n\t"
+        "B	L_sp_256_num_bits_8_9%=\n\t"
 #else
-        "B.N	L_sp_256_num_bits_8_9\n\t"
+        "B.N	L_sp_256_num_bits_8_9%=\n\t"
 #endif
         "\n"
-    "L_sp_256_num_bits_8_4:\n\t"
+    "L_sp_256_num_bits_8_4%=:\n\t"
         "LDR	r1, [%[a], #12]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_256_num_bits_8_3\n\t"
+        "BEQ	L_sp_256_num_bits_8_3%=\n\t"
 #else
-        "BEQ.N	L_sp_256_num_bits_8_3\n\t"
+        "BEQ.N	L_sp_256_num_bits_8_3%=\n\t"
 #endif
         "MOV	r2, #0x80\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_256_num_bits_8_9\n\t"
+        "B	L_sp_256_num_bits_8_9%=\n\t"
 #else
-        "B.N	L_sp_256_num_bits_8_9\n\t"
+        "B.N	L_sp_256_num_bits_8_9%=\n\t"
 #endif
         "\n"
-    "L_sp_256_num_bits_8_3:\n\t"
+    "L_sp_256_num_bits_8_3%=:\n\t"
         "LDR	r1, [%[a], #8]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_256_num_bits_8_2\n\t"
+        "BEQ	L_sp_256_num_bits_8_2%=\n\t"
 #else
-        "BEQ.N	L_sp_256_num_bits_8_2\n\t"
+        "BEQ.N	L_sp_256_num_bits_8_2%=\n\t"
 #endif
         "MOV	r2, #0x60\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_256_num_bits_8_9\n\t"
+        "B	L_sp_256_num_bits_8_9%=\n\t"
 #else
-        "B.N	L_sp_256_num_bits_8_9\n\t"
+        "B.N	L_sp_256_num_bits_8_9%=\n\t"
 #endif
         "\n"
-    "L_sp_256_num_bits_8_2:\n\t"
+    "L_sp_256_num_bits_8_2%=:\n\t"
         "LDR	r1, [%[a], #4]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_256_num_bits_8_1\n\t"
+        "BEQ	L_sp_256_num_bits_8_1%=\n\t"
 #else
-        "BEQ.N	L_sp_256_num_bits_8_1\n\t"
+        "BEQ.N	L_sp_256_num_bits_8_1%=\n\t"
 #endif
         "MOV	r2, #0x40\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_256_num_bits_8_9\n\t"
+        "B	L_sp_256_num_bits_8_9%=\n\t"
 #else
-        "B.N	L_sp_256_num_bits_8_9\n\t"
+        "B.N	L_sp_256_num_bits_8_9%=\n\t"
 #endif
         "\n"
-    "L_sp_256_num_bits_8_1:\n\t"
+    "L_sp_256_num_bits_8_1%=:\n\t"
         "LDR	r1, [%[a]]\n\t"
         "MOV	r2, #0x20\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
         "\n"
-    "L_sp_256_num_bits_8_9:\n\t"
+    "L_sp_256_num_bits_8_9%=:\n\t"
         "MOV	%[a], r4\n\t"
         : [a] "+r" (a)
         :
@@ -41515,13 +41515,13 @@ static void sp_384_mul_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_384_mul_12_outer:\n\t"
+    "L_sp_384_mul_12_outer%=:\n\t"
         "SUBS	r3, r5, #0x2c\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_384_mul_12_inner:\n\t"
+    "L_sp_384_mul_12_inner%=:\n\t"
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -41538,14 +41538,14 @@ static void sp_384_mul_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_384_mul_12_inner_done\n\t"
+        "BGT	L_sp_384_mul_12_inner_done%=\n\t"
 #else
-        "BGT.N	L_sp_384_mul_12_inner_done\n\t"
+        "BGT.N	L_sp_384_mul_12_inner_done%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_384_mul_12_inner\n\t"
+        "BLT	L_sp_384_mul_12_inner%=\n\t"
 #else
-        "BLT.N	L_sp_384_mul_12_inner\n\t"
+        "BLT.N	L_sp_384_mul_12_inner%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r3]\n\t"
@@ -41554,7 +41554,7 @@ static void sp_384_mul_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_384_mul_12_inner_done:\n\t"
+    "L_sp_384_mul_12_inner_done%=:\n\t"
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
@@ -41562,9 +41562,9 @@ static void sp_384_mul_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x54\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_384_mul_12_outer\n\t"
+        "BLE	L_sp_384_mul_12_outer%=\n\t"
 #else
-        "BLE.N	L_sp_384_mul_12_outer\n\t"
+        "BLE.N	L_sp_384_mul_12_outer%=\n\t"
 #endif
         "LDR	lr, [%[a], #44]\n\t"
         "LDR	r11, [%[b], #44]\n\t"
@@ -41573,14 +41573,14 @@ static void sp_384_mul_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_384_mul_12_store:\n\t"
+    "L_sp_384_mul_12_store%=:\n\t"
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_384_mul_12_store\n\t"
+        "BGT	L_sp_384_mul_12_store%=\n\t"
 #else
-        "BGT.N	L_sp_384_mul_12_store\n\t"
+        "BGT.N	L_sp_384_mul_12_store%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
@@ -42643,13 +42643,13 @@ static void sp_384_sqr_12(sp_digit* r, const sp_digit* a)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_384_sqr_12_outer:\n\t"
+    "L_sp_384_sqr_12_outer%=:\n\t"
         "SUBS	r3, r5, #0x2c\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_384_sqr_12_inner:\n\t"
+    "L_sp_384_sqr_12_inner%=:\n\t"
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[a], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -42663,14 +42663,14 @@ static void sp_384_sqr_12(sp_digit* r, const sp_digit* a)
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_384_sqr_12_inner_done\n\t"
+        "BGT	L_sp_384_sqr_12_inner_done%=\n\t"
 #else
-        "BGT.N	L_sp_384_sqr_12_inner_done\n\t"
+        "BGT.N	L_sp_384_sqr_12_inner_done%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_384_sqr_12_inner\n\t"
+        "BLT	L_sp_384_sqr_12_inner%=\n\t"
 #else
-        "BLT.N	L_sp_384_sqr_12_inner\n\t"
+        "BLT.N	L_sp_384_sqr_12_inner%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "UMULL	r9, r10, lr, lr\n\t"
@@ -42678,7 +42678,7 @@ static void sp_384_sqr_12(sp_digit* r, const sp_digit* a)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_384_sqr_12_inner_done:\n\t"
+    "L_sp_384_sqr_12_inner_done%=:\n\t"
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
@@ -42686,9 +42686,9 @@ static void sp_384_sqr_12(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x54\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_384_sqr_12_outer\n\t"
+        "BLE	L_sp_384_sqr_12_outer%=\n\t"
 #else
-        "BLE.N	L_sp_384_sqr_12_outer\n\t"
+        "BLE.N	L_sp_384_sqr_12_outer%=\n\t"
 #endif
         "LDR	lr, [%[a], #44]\n\t"
         "UMLAL	r6, r7, lr, lr\n\t"
@@ -42696,14 +42696,14 @@ static void sp_384_sqr_12(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_384_sqr_12_store:\n\t"
+    "L_sp_384_sqr_12_store%=:\n\t"
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_384_sqr_12_store\n\t"
+        "BGT	L_sp_384_sqr_12_store%=\n\t"
 #else
-        "BGT.N	L_sp_384_sqr_12_store\n\t"
+        "BGT.N	L_sp_384_sqr_12_store%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a)
         :
@@ -43436,7 +43436,7 @@ static sp_digit sp_384_add_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r3, #0x0\n\t"
         "ADD	r12, %[a], #0x30\n\t"
         "\n"
-    "L_sp_384_add_12_word:\n\t"
+    "L_sp_384_add_12_word%=:\n\t"
         "ADDS	r3, r3, #0xffffffff\n\t"
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
         "LDM	%[b]!, {r8, r9, r10, r11}\n\t"
@@ -43449,9 +43449,9 @@ static sp_digit sp_384_add_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADC	r3, r4, #0x0\n\t"
         "CMP	%[a], r12\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_384_add_12_word\n\t"
+        "BNE	L_sp_384_add_12_word%=\n\t"
 #else
-        "BNE.N	L_sp_384_add_12_word\n\t"
+        "BNE.N	L_sp_384_add_12_word%=\n\t"
 #endif
         "MOV	%[r], r3\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -43836,7 +43836,7 @@ static sp_digit sp_384_cond_sub_12(sp_digit* r, const sp_digit* a, const sp_digi
         "MOV	r4, #0x0\n\t"
         "MOV	r5, #0x0\n\t"
         "\n"
-    "L_sp_384_cond_sub_12_words:\n\t"
+    "L_sp_384_cond_sub_12_words%=:\n\t"
         "SUBS	r4, r8, r4\n\t"
         "LDR	r6, [%[a], r5]\n\t"
         "LDR	r7, [%[b], r5]\n\t"
@@ -43847,9 +43847,9 @@ static sp_digit sp_384_cond_sub_12(sp_digit* r, const sp_digit* a, const sp_digi
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x30\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_384_cond_sub_12_words\n\t"
+        "BLT	L_sp_384_cond_sub_12_words%=\n\t"
 #else
-        "BLT.N	L_sp_384_cond_sub_12_words\n\t"
+        "BLT.N	L_sp_384_cond_sub_12_words%=\n\t"
 #endif
         "MOV	%[r], r4\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -43963,7 +43963,7 @@ SP_NOINLINE static void sp_384_mont_reduce_12(sp_digit* a, const sp_digit* m, sp
         "LDR	r4, [%[a]]\n\t"
         "LDR	r5, [%[a], #4]\n\t"
         "\n"
-    "L_sp_384_mont_reduce_12_word:\n\t"
+    "L_sp_384_mont_reduce_12_word%=:\n\t"
         /* mu = a[i] * mp */
         "MUL	r10, %[mp], r4\n\t"
         /* a[i+0] += m[0] * mu */
@@ -44066,9 +44066,9 @@ SP_NOINLINE static void sp_384_mont_reduce_12(sp_digit* a, const sp_digit* m, sp
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r11, #0x30\n\t"
 #ifdef __GNUC__
-        "BLT	L_sp_384_mont_reduce_12_word\n\t"
+        "BLT	L_sp_384_mont_reduce_12_word%=\n\t"
 #else
-        "BLT.W	L_sp_384_mont_reduce_12_word\n\t"
+        "BLT.W	L_sp_384_mont_reduce_12_word%=\n\t"
 #endif
         /* Loop Done */
         "STR	r4, [%[a]]\n\t"
@@ -44110,7 +44110,7 @@ SP_NOINLINE static void sp_384_mont_reduce_12(sp_digit* a, const sp_digit* m, sp
         "LDR	r9, [%[a], #12]\n\t"
         "LDR	r10, [%[a], #16]\n\t"
         "\n"
-    "L_sp_384_mont_reduce_12_word:\n\t"
+    "L_sp_384_mont_reduce_12_word%=:\n\t"
         /* mu = a[i] * mp */
         "MUL	lr, %[mp], r6\n\t"
         /* a[i+0] += m[0] * mu */
@@ -44178,9 +44178,9 @@ SP_NOINLINE static void sp_384_mont_reduce_12(sp_digit* a, const sp_digit* m, sp
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r4, #0x30\n\t"
 #ifdef __GNUC__
-        "BLT	L_sp_384_mont_reduce_12_word\n\t"
+        "BLT	L_sp_384_mont_reduce_12_word%=\n\t"
 #else
-        "BLT.W	L_sp_384_mont_reduce_12_word\n\t"
+        "BLT.W	L_sp_384_mont_reduce_12_word%=\n\t"
 #endif
         /* Loop Done */
         "STR	r6, [%[a]]\n\t"
@@ -44365,7 +44365,7 @@ static sp_int32 sp_384_cmp_12(const sp_digit* a, const sp_digit* b)
 #ifdef WOLFSSL_SP_SMALL
         "MOV	r6, #0x2c\n\t"
         "\n"
-    "L_sp_384_cmp_12_words:\n\t"
+    "L_sp_384_cmp_12_words%=:\n\t"
         "LDR	r4, [%[a], r6]\n\t"
         "LDR	r5, [%[b], r6]\n\t"
         "AND	r4, r4, r3\n\t"
@@ -44378,7 +44378,7 @@ static sp_int32 sp_384_cmp_12(const sp_digit* a, const sp_digit* b)
         "IT	ne\n\t"
         "movne	r3, r7\n\t"
         "SUBS	r6, r6, #0x4\n\t"
-        "bcs	L_sp_384_cmp_12_words\n\t"
+        "bcs	L_sp_384_cmp_12_words%=\n\t"
         "EOR	r2, r2, r3\n\t"
 #else
         "LDR	r4, [%[a], #44]\n\t"
@@ -44668,7 +44668,7 @@ static sp_digit sp_384_sub_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r11, #0x0\n\t"
         "ADD	r12, %[a], #0x30\n\t"
         "\n"
-    "L_sp_384_sub_12_word:\n\t"
+    "L_sp_384_sub_12_word%=:\n\t"
         "RSBS	r11, r11, #0x0\n\t"
         "LDM	%[a]!, {r3, r4, r5, r6}\n\t"
         "LDM	%[b]!, {r7, r8, r9, r10}\n\t"
@@ -44680,9 +44680,9 @@ static sp_digit sp_384_sub_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "SBC	r11, r3, r3\n\t"
         "CMP	%[a], r12\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_384_sub_12_word\n\t"
+        "BNE	L_sp_384_sub_12_word%=\n\t"
 #else
-        "BNE.N	L_sp_384_sub_12_word\n\t"
+        "BNE.N	L_sp_384_sub_12_word%=\n\t"
 #endif
         "MOV	%[r], r11\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -44769,7 +44769,7 @@ static sp_digit sp_384_cond_add_12(sp_digit* r, const sp_digit* a, const sp_digi
         "MOV	r8, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_384_cond_add_12_words:\n\t"
+    "L_sp_384_cond_add_12_words%=:\n\t"
         "ADDS	r5, r5, #0xffffffff\n\t"
         "LDR	r6, [%[a], r4]\n\t"
         "LDR	r7, [%[b], r4]\n\t"
@@ -44780,9 +44780,9 @@ static sp_digit sp_384_cond_add_12(sp_digit* r, const sp_digit* a, const sp_digi
         "ADD	r4, r4, #0x4\n\t"
         "CMP	r4, #0x30\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_384_cond_add_12_words\n\t"
+        "BLT	L_sp_384_cond_add_12_words%=\n\t"
 #else
-        "BLT.N	L_sp_384_cond_add_12_words\n\t"
+        "BLT.N	L_sp_384_cond_add_12_words%=\n\t"
 #endif
         "MOV	%[r], r5\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -48974,7 +48974,7 @@ static sp_digit sp_384_sub_in_place_12(sp_digit* a, const sp_digit* b)
         "MOV	r10, #0x0\n\t"
         "ADD	r11, %[a], #0x30\n\t"
         "\n"
-    "L_sp_384_sub_in_pkace_12_word:\n\t"
+    "L_sp_384_sub_in_pkace_12_word%=:\n\t"
         "RSBS	r10, r10, #0x0\n\t"
         "LDM	%[a], {r2, r3, r4, r5}\n\t"
         "LDM	%[b]!, {r6, r7, r8, r9}\n\t"
@@ -48986,9 +48986,9 @@ static sp_digit sp_384_sub_in_place_12(sp_digit* a, const sp_digit* b)
         "SBC	r10, r10, r10\n\t"
         "CMP	%[a], r11\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_384_sub_in_pkace_12_word\n\t"
+        "BNE	L_sp_384_sub_in_pkace_12_word%=\n\t"
 #else
-        "BNE.N	L_sp_384_sub_in_pkace_12_word\n\t"
+        "BNE.N	L_sp_384_sub_in_pkace_12_word%=\n\t"
 #endif
         "MOV	%[a], r10\n\t"
         : [a] "+r" (a), [b] "+r" (b)
@@ -49074,7 +49074,7 @@ static void sp_384_mul_d_12(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "MOV	r9, #0x4\n\t"
         "\n"
-    "L_sp_384_mul_d_12_word:\n\t"
+    "L_sp_384_mul_d_12_word%=:\n\t"
         /* A[i] * B */
         "LDR	r8, [%[a], r9]\n\t"
         "UMULL	r6, r7, %[b], r8\n\t"
@@ -49088,9 +49088,9 @@ static void sp_384_mul_d_12(sp_digit* r, const sp_digit* a, sp_digit b)
         "ADD	r9, r9, #0x4\n\t"
         "CMP	r9, #0x30\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_384_mul_d_12_word\n\t"
+        "BLT	L_sp_384_mul_d_12_word%=\n\t"
 #else
-        "BLT.N	L_sp_384_mul_d_12_word\n\t"
+        "BLT.N	L_sp_384_mul_d_12_word%=\n\t"
 #endif
         "STR	r3, [%[r], #48]\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -49288,7 +49288,7 @@ SP_NOINLINE static sp_digit div_384_word_12(sp_digit d1, sp_digit d0, sp_digit d
         /* Next 30 bits */
         "MOV	r4, #0x1d\n\t"
         "\n"
-    "L_div_384_word_12_bit:\n\t"
+    "L_div_384_word_12_bit%=:\n\t"
         "LSLS	r6, r6, #1\n\t"
         "ADC	r7, r7, r7\n\t"
         "SUBS	r8, r5, r7\n\t"
@@ -49298,7 +49298,7 @@ SP_NOINLINE static sp_digit div_384_word_12(sp_digit d1, sp_digit d0, sp_digit d
         "AND	r8, r8, r5\n\t"
         "SUBS	r7, r7, r8\n\t"
         "SUBS	r4, r4, #0x1\n\t"
-        "bpl	L_div_384_word_12_bit\n\t"
+        "bpl	L_div_384_word_12_bit%=\n\t"
         "ADD	r3, r3, r3\n\t"
         "ADD	r3, r3, #0x1\n\t"
         "UMULL	r6, r7, r3, %[div]\n\t"
@@ -49962,9 +49962,9 @@ static void sp_384_div2_mod_12(sp_digit* r, const sp_digit* a, const sp_digit* m
         "LDM	%[a]!, {r4}\n\t"
         "ANDS	r3, r4, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_div2_mod_12_even\n\t"
+        "BEQ	L_sp_384_div2_mod_12_even%=\n\t"
 #else
-        "BEQ.N	L_sp_384_div2_mod_12_even\n\t"
+        "BEQ.N	L_sp_384_div2_mod_12_even%=\n\t"
 #endif
         "MOV	r12, #0x0\n\t"
         "LDM	%[a]!, {r5, r6, r7}\n\t"
@@ -49990,12 +49990,12 @@ static void sp_384_div2_mod_12(sp_digit* r, const sp_digit* a, const sp_digit* m
         "STM	%[r]!, {r4, r5, r6, r7}\n\t"
         "ADC	r3, r12, r12\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_div2_mod_12_div2\n\t"
+        "B	L_sp_384_div2_mod_12_div2%=\n\t"
 #else
-        "B.N	L_sp_384_div2_mod_12_div2\n\t"
+        "B.N	L_sp_384_div2_mod_12_div2%=\n\t"
 #endif
         "\n"
-    "L_sp_384_div2_mod_12_even:\n\t"
+    "L_sp_384_div2_mod_12_even%=:\n\t"
         "LDM	%[a]!, {r5, r6, r7}\n\t"
         "STM	%[r]!, {r4, r5, r6, r7}\n\t"
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
@@ -50003,7 +50003,7 @@ static void sp_384_div2_mod_12(sp_digit* r, const sp_digit* a, const sp_digit* m
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
         "STM	%[r]!, {r4, r5, r6, r7}\n\t"
         "\n"
-    "L_sp_384_div2_mod_12_div2:\n\t"
+    "L_sp_384_div2_mod_12_div2%=:\n\t"
         "SUB	%[r], %[r], #0x30\n\t"
         "LDRD	r8, r9, [%[r]]\n\t"
         "LSR	r8, r8, #1\n\t"
@@ -50072,196 +50072,196 @@ static int sp_384_num_bits_12(const sp_digit* a)
         "LDR	r1, [%[a], #44]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_num_bits_12_11\n\t"
+        "BEQ	L_sp_384_num_bits_12_11%=\n\t"
 #else
-        "BEQ.N	L_sp_384_num_bits_12_11\n\t"
+        "BEQ.N	L_sp_384_num_bits_12_11%=\n\t"
 #endif
         "MOV	r2, #0x180\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_num_bits_12_13\n\t"
+        "B	L_sp_384_num_bits_12_13%=\n\t"
 #else
-        "B.N	L_sp_384_num_bits_12_13\n\t"
+        "B.N	L_sp_384_num_bits_12_13%=\n\t"
 #endif
         "\n"
-    "L_sp_384_num_bits_12_11:\n\t"
+    "L_sp_384_num_bits_12_11%=:\n\t"
         "LDR	r1, [%[a], #40]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_num_bits_12_10\n\t"
+        "BEQ	L_sp_384_num_bits_12_10%=\n\t"
 #else
-        "BEQ.N	L_sp_384_num_bits_12_10\n\t"
+        "BEQ.N	L_sp_384_num_bits_12_10%=\n\t"
 #endif
         "MOV	r2, #0x160\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_num_bits_12_13\n\t"
+        "B	L_sp_384_num_bits_12_13%=\n\t"
 #else
-        "B.N	L_sp_384_num_bits_12_13\n\t"
+        "B.N	L_sp_384_num_bits_12_13%=\n\t"
 #endif
         "\n"
-    "L_sp_384_num_bits_12_10:\n\t"
+    "L_sp_384_num_bits_12_10%=:\n\t"
         "LDR	r1, [%[a], #36]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_num_bits_12_9\n\t"
+        "BEQ	L_sp_384_num_bits_12_9%=\n\t"
 #else
-        "BEQ.N	L_sp_384_num_bits_12_9\n\t"
+        "BEQ.N	L_sp_384_num_bits_12_9%=\n\t"
 #endif
         "MOV	r2, #0x140\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_num_bits_12_13\n\t"
+        "B	L_sp_384_num_bits_12_13%=\n\t"
 #else
-        "B.N	L_sp_384_num_bits_12_13\n\t"
+        "B.N	L_sp_384_num_bits_12_13%=\n\t"
 #endif
         "\n"
-    "L_sp_384_num_bits_12_9:\n\t"
+    "L_sp_384_num_bits_12_9%=:\n\t"
         "LDR	r1, [%[a], #32]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_num_bits_12_8\n\t"
+        "BEQ	L_sp_384_num_bits_12_8%=\n\t"
 #else
-        "BEQ.N	L_sp_384_num_bits_12_8\n\t"
+        "BEQ.N	L_sp_384_num_bits_12_8%=\n\t"
 #endif
         "MOV	r2, #0x120\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_num_bits_12_13\n\t"
+        "B	L_sp_384_num_bits_12_13%=\n\t"
 #else
-        "B.N	L_sp_384_num_bits_12_13\n\t"
+        "B.N	L_sp_384_num_bits_12_13%=\n\t"
 #endif
         "\n"
-    "L_sp_384_num_bits_12_8:\n\t"
+    "L_sp_384_num_bits_12_8%=:\n\t"
         "LDR	r1, [%[a], #28]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_num_bits_12_7\n\t"
+        "BEQ	L_sp_384_num_bits_12_7%=\n\t"
 #else
-        "BEQ.N	L_sp_384_num_bits_12_7\n\t"
+        "BEQ.N	L_sp_384_num_bits_12_7%=\n\t"
 #endif
         "MOV	r2, #0x100\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_num_bits_12_13\n\t"
+        "B	L_sp_384_num_bits_12_13%=\n\t"
 #else
-        "B.N	L_sp_384_num_bits_12_13\n\t"
+        "B.N	L_sp_384_num_bits_12_13%=\n\t"
 #endif
         "\n"
-    "L_sp_384_num_bits_12_7:\n\t"
+    "L_sp_384_num_bits_12_7%=:\n\t"
         "LDR	r1, [%[a], #24]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_num_bits_12_6\n\t"
+        "BEQ	L_sp_384_num_bits_12_6%=\n\t"
 #else
-        "BEQ.N	L_sp_384_num_bits_12_6\n\t"
+        "BEQ.N	L_sp_384_num_bits_12_6%=\n\t"
 #endif
         "MOV	r2, #0xe0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_num_bits_12_13\n\t"
+        "B	L_sp_384_num_bits_12_13%=\n\t"
 #else
-        "B.N	L_sp_384_num_bits_12_13\n\t"
+        "B.N	L_sp_384_num_bits_12_13%=\n\t"
 #endif
         "\n"
-    "L_sp_384_num_bits_12_6:\n\t"
+    "L_sp_384_num_bits_12_6%=:\n\t"
         "LDR	r1, [%[a], #20]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_num_bits_12_5\n\t"
+        "BEQ	L_sp_384_num_bits_12_5%=\n\t"
 #else
-        "BEQ.N	L_sp_384_num_bits_12_5\n\t"
+        "BEQ.N	L_sp_384_num_bits_12_5%=\n\t"
 #endif
         "MOV	r2, #0xc0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_num_bits_12_13\n\t"
+        "B	L_sp_384_num_bits_12_13%=\n\t"
 #else
-        "B.N	L_sp_384_num_bits_12_13\n\t"
+        "B.N	L_sp_384_num_bits_12_13%=\n\t"
 #endif
         "\n"
-    "L_sp_384_num_bits_12_5:\n\t"
+    "L_sp_384_num_bits_12_5%=:\n\t"
         "LDR	r1, [%[a], #16]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_num_bits_12_4\n\t"
+        "BEQ	L_sp_384_num_bits_12_4%=\n\t"
 #else
-        "BEQ.N	L_sp_384_num_bits_12_4\n\t"
+        "BEQ.N	L_sp_384_num_bits_12_4%=\n\t"
 #endif
         "MOV	r2, #0xa0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_num_bits_12_13\n\t"
+        "B	L_sp_384_num_bits_12_13%=\n\t"
 #else
-        "B.N	L_sp_384_num_bits_12_13\n\t"
+        "B.N	L_sp_384_num_bits_12_13%=\n\t"
 #endif
         "\n"
-    "L_sp_384_num_bits_12_4:\n\t"
+    "L_sp_384_num_bits_12_4%=:\n\t"
         "LDR	r1, [%[a], #12]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_num_bits_12_3\n\t"
+        "BEQ	L_sp_384_num_bits_12_3%=\n\t"
 #else
-        "BEQ.N	L_sp_384_num_bits_12_3\n\t"
+        "BEQ.N	L_sp_384_num_bits_12_3%=\n\t"
 #endif
         "MOV	r2, #0x80\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_num_bits_12_13\n\t"
+        "B	L_sp_384_num_bits_12_13%=\n\t"
 #else
-        "B.N	L_sp_384_num_bits_12_13\n\t"
+        "B.N	L_sp_384_num_bits_12_13%=\n\t"
 #endif
         "\n"
-    "L_sp_384_num_bits_12_3:\n\t"
+    "L_sp_384_num_bits_12_3%=:\n\t"
         "LDR	r1, [%[a], #8]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_num_bits_12_2\n\t"
+        "BEQ	L_sp_384_num_bits_12_2%=\n\t"
 #else
-        "BEQ.N	L_sp_384_num_bits_12_2\n\t"
+        "BEQ.N	L_sp_384_num_bits_12_2%=\n\t"
 #endif
         "MOV	r2, #0x60\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_num_bits_12_13\n\t"
+        "B	L_sp_384_num_bits_12_13%=\n\t"
 #else
-        "B.N	L_sp_384_num_bits_12_13\n\t"
+        "B.N	L_sp_384_num_bits_12_13%=\n\t"
 #endif
         "\n"
-    "L_sp_384_num_bits_12_2:\n\t"
+    "L_sp_384_num_bits_12_2%=:\n\t"
         "LDR	r1, [%[a], #4]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_num_bits_12_1\n\t"
+        "BEQ	L_sp_384_num_bits_12_1%=\n\t"
 #else
-        "BEQ.N	L_sp_384_num_bits_12_1\n\t"
+        "BEQ.N	L_sp_384_num_bits_12_1%=\n\t"
 #endif
         "MOV	r2, #0x40\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_num_bits_12_13\n\t"
+        "B	L_sp_384_num_bits_12_13%=\n\t"
 #else
-        "B.N	L_sp_384_num_bits_12_13\n\t"
+        "B.N	L_sp_384_num_bits_12_13%=\n\t"
 #endif
         "\n"
-    "L_sp_384_num_bits_12_1:\n\t"
+    "L_sp_384_num_bits_12_1%=:\n\t"
         "LDR	r1, [%[a]]\n\t"
         "MOV	r2, #0x20\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
         "\n"
-    "L_sp_384_num_bits_12_13:\n\t"
+    "L_sp_384_num_bits_12_13%=:\n\t"
         "MOV	%[a], r4\n\t"
         : [a] "+r" (a)
         :
@@ -51430,13 +51430,13 @@ static void sp_521_mul_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_521_mul_17_outer:\n\t"
+    "L_sp_521_mul_17_outer%=:\n\t"
         "SUBS	r3, r5, #0x40\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_521_mul_17_inner:\n\t"
+    "L_sp_521_mul_17_inner%=:\n\t"
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -51453,14 +51453,14 @@ static void sp_521_mul_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_521_mul_17_inner_done\n\t"
+        "BGT	L_sp_521_mul_17_inner_done%=\n\t"
 #else
-        "BGT.N	L_sp_521_mul_17_inner_done\n\t"
+        "BGT.N	L_sp_521_mul_17_inner_done%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_521_mul_17_inner\n\t"
+        "BLT	L_sp_521_mul_17_inner%=\n\t"
 #else
-        "BLT.N	L_sp_521_mul_17_inner\n\t"
+        "BLT.N	L_sp_521_mul_17_inner%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r3]\n\t"
@@ -51469,7 +51469,7 @@ static void sp_521_mul_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_521_mul_17_inner_done:\n\t"
+    "L_sp_521_mul_17_inner_done%=:\n\t"
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
@@ -51477,9 +51477,9 @@ static void sp_521_mul_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x7c\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_521_mul_17_outer\n\t"
+        "BLE	L_sp_521_mul_17_outer%=\n\t"
 #else
-        "BLE.N	L_sp_521_mul_17_outer\n\t"
+        "BLE.N	L_sp_521_mul_17_outer%=\n\t"
 #endif
         "LDR	lr, [%[a], #64]\n\t"
         "LDR	r11, [%[b], #64]\n\t"
@@ -51491,14 +51491,14 @@ static void sp_521_mul_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "STM	%[r]!, {r6, r7}\n\t"
         "SUB	r5, r5, #0x8\n\t"
         "\n"
-    "L_sp_521_mul_17_store:\n\t"
+    "L_sp_521_mul_17_store%=:\n\t"
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_521_mul_17_store\n\t"
+        "BGT	L_sp_521_mul_17_store%=\n\t"
 #else
-        "BGT.N	L_sp_521_mul_17_store\n\t"
+        "BGT.N	L_sp_521_mul_17_store%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
@@ -53575,13 +53575,13 @@ static void sp_521_sqr_17(sp_digit* r, const sp_digit* a)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_521_sqr_17_outer:\n\t"
+    "L_sp_521_sqr_17_outer%=:\n\t"
         "SUBS	r3, r5, #0x40\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_521_sqr_17_inner:\n\t"
+    "L_sp_521_sqr_17_inner%=:\n\t"
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[a], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -53595,14 +53595,14 @@ static void sp_521_sqr_17(sp_digit* r, const sp_digit* a)
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_521_sqr_17_inner_done\n\t"
+        "BGT	L_sp_521_sqr_17_inner_done%=\n\t"
 #else
-        "BGT.N	L_sp_521_sqr_17_inner_done\n\t"
+        "BGT.N	L_sp_521_sqr_17_inner_done%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_521_sqr_17_inner\n\t"
+        "BLT	L_sp_521_sqr_17_inner%=\n\t"
 #else
-        "BLT.N	L_sp_521_sqr_17_inner\n\t"
+        "BLT.N	L_sp_521_sqr_17_inner%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "UMULL	r9, r10, lr, lr\n\t"
@@ -53610,7 +53610,7 @@ static void sp_521_sqr_17(sp_digit* r, const sp_digit* a)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_521_sqr_17_inner_done:\n\t"
+    "L_sp_521_sqr_17_inner_done%=:\n\t"
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
@@ -53618,9 +53618,9 @@ static void sp_521_sqr_17(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x7c\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_521_sqr_17_outer\n\t"
+        "BLE	L_sp_521_sqr_17_outer%=\n\t"
 #else
-        "BLE.N	L_sp_521_sqr_17_outer\n\t"
+        "BLE.N	L_sp_521_sqr_17_outer%=\n\t"
 #endif
         "LDR	lr, [%[a], #64]\n\t"
         "UMLAL	r6, r7, lr, lr\n\t"
@@ -53631,14 +53631,14 @@ static void sp_521_sqr_17(sp_digit* r, const sp_digit* a)
         "STM	%[r]!, {r6, r7}\n\t"
         "SUB	r5, r5, #0x8\n\t"
         "\n"
-    "L_sp_521_sqr_17_store:\n\t"
+    "L_sp_521_sqr_17_store%=:\n\t"
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_521_sqr_17_store\n\t"
+        "BGT	L_sp_521_sqr_17_store%=\n\t"
 #else
-        "BGT.N	L_sp_521_sqr_17_store\n\t"
+        "BGT.N	L_sp_521_sqr_17_store%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a)
         :
@@ -54955,7 +54955,7 @@ static sp_digit sp_521_add_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r3, #0x0\n\t"
         "ADD	r12, %[a], #0x40\n\t"
         "\n"
-    "L_sp_521_add_17_word:\n\t"
+    "L_sp_521_add_17_word%=:\n\t"
         "ADDS	r3, r3, #0xffffffff\n\t"
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
         "LDM	%[b]!, {r8, r9, r10, r11}\n\t"
@@ -54968,9 +54968,9 @@ static sp_digit sp_521_add_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADC	r3, r4, #0x0\n\t"
         "CMP	%[a], r12\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_521_add_17_word\n\t"
+        "BNE	L_sp_521_add_17_word%=\n\t"
 #else
-        "BNE.N	L_sp_521_add_17_word\n\t"
+        "BNE.N	L_sp_521_add_17_word%=\n\t"
 #endif
         "ADDS	r3, r3, #0xffffffff\n\t"
         "LDM	%[a], {r4}\n\t"
@@ -55288,7 +55288,7 @@ static sp_digit sp_521_cond_sub_17(sp_digit* r, const sp_digit* a, const sp_digi
         "MOV	r4, #0x0\n\t"
         "MOV	r5, #0x0\n\t"
         "\n"
-    "L_sp_521_cond_sub_17_words:\n\t"
+    "L_sp_521_cond_sub_17_words%=:\n\t"
         "SUBS	r4, r8, r4\n\t"
         "LDR	r6, [%[a], r5]\n\t"
         "LDR	r7, [%[b], r5]\n\t"
@@ -55299,9 +55299,9 @@ static sp_digit sp_521_cond_sub_17(sp_digit* r, const sp_digit* a, const sp_digi
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x44\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_521_cond_sub_17_words\n\t"
+        "BLT	L_sp_521_cond_sub_17_words%=\n\t"
 #else
-        "BLT.N	L_sp_521_cond_sub_17_words\n\t"
+        "BLT.N	L_sp_521_cond_sub_17_words%=\n\t"
 #endif
         "MOV	%[r], r4\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -55568,19 +55568,19 @@ SP_NOINLINE static void sp_521_mont_reduce_order_17(sp_digit* a, const sp_digit*
         "LDR	r4, [%[a]]\n\t"
         "LDR	r5, [%[a], #4]\n\t"
         "\n"
-    "L_sp_521_mont_reduce_order_17_word:\n\t"
+    "L_sp_521_mont_reduce_order_17_word%=:\n\t"
         /* mu = a[i] * mp */
         "MUL	r10, %[mp], r4\n\t"
         "CMP	r11, #0x40\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_521_mont_reduce_order_17_nomask\n\t"
+        "BNE	L_sp_521_mont_reduce_order_17_nomask%=\n\t"
 #else
-        "BNE.N	L_sp_521_mont_reduce_order_17_nomask\n\t"
+        "BNE.N	L_sp_521_mont_reduce_order_17_nomask%=\n\t"
 #endif
         "MOV	r9, #0x1ff\n\t"
         "AND	r10, r10, r9\n\t"
         "\n"
-    "L_sp_521_mont_reduce_order_17_nomask:\n\t"
+    "L_sp_521_mont_reduce_order_17_nomask%=:\n\t"
         /* a[i+0] += m[0] * mu */
         "MOV	r7, #0x0\n\t"
         "UMLAL	r4, r7, r10, lr\n\t"
@@ -55722,9 +55722,9 @@ SP_NOINLINE static void sp_521_mont_reduce_order_17(sp_digit* a, const sp_digit*
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r11, #0x44\n\t"
 #ifdef __GNUC__
-        "BLT	L_sp_521_mont_reduce_order_17_word\n\t"
+        "BLT	L_sp_521_mont_reduce_order_17_word%=\n\t"
 #else
-        "BLT.W	L_sp_521_mont_reduce_order_17_word\n\t"
+        "BLT.W	L_sp_521_mont_reduce_order_17_word%=\n\t"
 #endif
         /* Loop Done */
         "STR	r4, [%[a]]\n\t"
@@ -55836,19 +55836,19 @@ SP_NOINLINE static void sp_521_mont_reduce_order_17(sp_digit* a, const sp_digit*
         "LDR	r9, [%[a], #12]\n\t"
         "LDR	r10, [%[a], #16]\n\t"
         "\n"
-    "L_sp_521_mont_reduce_order_17_word:\n\t"
+    "L_sp_521_mont_reduce_order_17_word%=:\n\t"
         /* mu = a[i] * mp */
         "MUL	lr, %[mp], r6\n\t"
         "CMP	r4, #0x40\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_521_mont_reduce_order_17_nomask\n\t"
+        "BNE	L_sp_521_mont_reduce_order_17_nomask%=\n\t"
 #else
-        "BNE.N	L_sp_521_mont_reduce_order_17_nomask\n\t"
+        "BNE.N	L_sp_521_mont_reduce_order_17_nomask%=\n\t"
 #endif
         "MOV	r12, #0x1ff\n\t"
         "AND	lr, lr, r12\n\t"
         "\n"
-    "L_sp_521_mont_reduce_order_17_nomask:\n\t"
+    "L_sp_521_mont_reduce_order_17_nomask%=:\n\t"
         /* a[i+0] += m[0] * mu */
         "LDR	r12, [%[m]]\n\t"
         "MOV	r3, #0x0\n\t"
@@ -55940,9 +55940,9 @@ SP_NOINLINE static void sp_521_mont_reduce_order_17(sp_digit* a, const sp_digit*
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r4, #0x44\n\t"
 #ifdef __GNUC__
-        "BLT	L_sp_521_mont_reduce_order_17_word\n\t"
+        "BLT	L_sp_521_mont_reduce_order_17_word%=\n\t"
 #else
-        "BLT.W	L_sp_521_mont_reduce_order_17_word\n\t"
+        "BLT.W	L_sp_521_mont_reduce_order_17_word%=\n\t"
 #endif
         /* Loop Done */
         "STR	r6, [%[a]]\n\t"
@@ -56194,7 +56194,7 @@ static sp_int32 sp_521_cmp_17(const sp_digit* a, const sp_digit* b)
 #ifdef WOLFSSL_SP_SMALL
         "MOV	r6, #0x40\n\t"
         "\n"
-    "L_sp_521_cmp_17_words:\n\t"
+    "L_sp_521_cmp_17_words%=:\n\t"
         "LDR	r4, [%[a], r6]\n\t"
         "LDR	r5, [%[b], r6]\n\t"
         "AND	r4, r4, r3\n\t"
@@ -56207,7 +56207,7 @@ static sp_int32 sp_521_cmp_17(const sp_digit* a, const sp_digit* b)
         "IT	ne\n\t"
         "movne	r3, r7\n\t"
         "SUBS	r6, r6, #0x4\n\t"
-        "bcs	L_sp_521_cmp_17_words\n\t"
+        "bcs	L_sp_521_cmp_17_words%=\n\t"
         "EOR	r2, r2, r3\n\t"
 #else
         "LDR	r4, [%[a], #64]\n\t"
@@ -61995,7 +61995,7 @@ static sp_digit sp_521_sub_in_place_17(sp_digit* a, const sp_digit* b)
         "MOV	r10, #0x0\n\t"
         "ADD	r11, %[a], #0x40\n\t"
         "\n"
-    "L_sp_521_sub_in_pkace_17_word:\n\t"
+    "L_sp_521_sub_in_pkace_17_word%=:\n\t"
         "RSBS	r10, r10, #0x0\n\t"
         "LDM	%[a], {r2, r3, r4, r5}\n\t"
         "LDM	%[b]!, {r6, r7, r8, r9}\n\t"
@@ -62007,9 +62007,9 @@ static sp_digit sp_521_sub_in_place_17(sp_digit* a, const sp_digit* b)
         "SBC	r10, r10, r10\n\t"
         "CMP	%[a], r11\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_521_sub_in_pkace_17_word\n\t"
+        "BNE	L_sp_521_sub_in_pkace_17_word%=\n\t"
 #else
-        "BNE.N	L_sp_521_sub_in_pkace_17_word\n\t"
+        "BNE.N	L_sp_521_sub_in_pkace_17_word%=\n\t"
 #endif
         "RSBS	r10, r10, #0x0\n\t"
         "LDM	%[a], {r2}\n\t"
@@ -62111,7 +62111,7 @@ static void sp_521_mul_d_17(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "MOV	r9, #0x4\n\t"
         "\n"
-    "L_sp_521_mul_d_17_word:\n\t"
+    "L_sp_521_mul_d_17_word%=:\n\t"
         /* A[i] * B */
         "LDR	r8, [%[a], r9]\n\t"
         "UMULL	r6, r7, %[b], r8\n\t"
@@ -62125,9 +62125,9 @@ static void sp_521_mul_d_17(sp_digit* r, const sp_digit* a, sp_digit b)
         "ADD	r9, r9, #0x4\n\t"
         "CMP	r9, #0x44\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_521_mul_d_17_word\n\t"
+        "BLT	L_sp_521_mul_d_17_word%=\n\t"
 #else
-        "BLT.N	L_sp_521_mul_d_17_word\n\t"
+        "BLT.N	L_sp_521_mul_d_17_word%=\n\t"
 #endif
         "STR	r3, [%[r], #68]\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -62350,7 +62350,7 @@ SP_NOINLINE static sp_digit div_521_word_17(sp_digit d1, sp_digit d0, sp_digit d
         /* Next 30 bits */
         "MOV	r4, #0x1d\n\t"
         "\n"
-    "L_div_521_word_17_bit:\n\t"
+    "L_div_521_word_17_bit%=:\n\t"
         "LSLS	r6, r6, #1\n\t"
         "ADC	r7, r7, r7\n\t"
         "SUBS	r8, r5, r7\n\t"
@@ -62360,7 +62360,7 @@ SP_NOINLINE static sp_digit div_521_word_17(sp_digit d1, sp_digit d0, sp_digit d
         "AND	r8, r8, r5\n\t"
         "SUBS	r7, r7, r8\n\t"
         "SUBS	r4, r4, #0x1\n\t"
-        "bpl	L_div_521_word_17_bit\n\t"
+        "bpl	L_div_521_word_17_bit%=\n\t"
         "ADD	r3, r3, r3\n\t"
         "ADD	r3, r3, #0x1\n\t"
         "UMULL	r6, r7, r3, %[div]\n\t"
@@ -63055,7 +63055,7 @@ static sp_digit sp_521_sub_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r11, #0x0\n\t"
         "ADD	r12, %[a], #0x40\n\t"
         "\n"
-    "L_sp_521_sub_17_word:\n\t"
+    "L_sp_521_sub_17_word%=:\n\t"
         "RSBS	r11, r11, #0x0\n\t"
         "LDM	%[a]!, {r3, r4, r5, r6}\n\t"
         "LDM	%[b]!, {r7, r8, r9, r10}\n\t"
@@ -63067,9 +63067,9 @@ static sp_digit sp_521_sub_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "SBC	r11, r3, r3\n\t"
         "CMP	%[a], r12\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_521_sub_17_word\n\t"
+        "BNE	L_sp_521_sub_17_word%=\n\t"
 #else
-        "BNE.N	L_sp_521_sub_17_word\n\t"
+        "BNE.N	L_sp_521_sub_17_word%=\n\t"
 #endif
         "RSBS	r11, r11, #0x0\n\t"
         "LDM	%[a]!, {r3}\n\t"
@@ -63167,9 +63167,9 @@ static void sp_521_div2_mod_17(sp_digit* r, const sp_digit* a, const sp_digit* m
         "LDM	%[a]!, {r4}\n\t"
         "ANDS	r3, r4, #0x1\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_div2_mod_17_even\n\t"
+        "BEQ	L_sp_521_div2_mod_17_even%=\n\t"
 #else
-        "BEQ.N	L_sp_521_div2_mod_17_even\n\t"
+        "BEQ.N	L_sp_521_div2_mod_17_even%=\n\t"
 #endif
         "MOV	r12, #0x0\n\t"
         "LDM	%[a]!, {r5, r6, r7}\n\t"
@@ -63206,12 +63206,12 @@ static void sp_521_div2_mod_17(sp_digit* r, const sp_digit* a, const sp_digit* m
         "STM	%[r]!, {r4}\n\t"
         "ADC	r3, r12, r12\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_div2_mod_17_div2\n\t"
+        "B	L_sp_521_div2_mod_17_div2%=\n\t"
 #else
-        "B.N	L_sp_521_div2_mod_17_div2\n\t"
+        "B.N	L_sp_521_div2_mod_17_div2%=\n\t"
 #endif
         "\n"
-    "L_sp_521_div2_mod_17_even:\n\t"
+    "L_sp_521_div2_mod_17_even%=:\n\t"
         "LDM	%[a]!, {r5, r6, r7}\n\t"
         "STM	%[r]!, {r4, r5, r6, r7}\n\t"
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
@@ -63223,7 +63223,7 @@ static void sp_521_div2_mod_17(sp_digit* r, const sp_digit* a, const sp_digit* m
         "LDM	%[a]!, {r4}\n\t"
         "STM	%[r]!, {r4}\n\t"
         "\n"
-    "L_sp_521_div2_mod_17_div2:\n\t"
+    "L_sp_521_div2_mod_17_div2%=:\n\t"
         "SUB	%[r], %[r], #0x44\n\t"
         "LDRD	r8, r9, [%[r]]\n\t"
         "LSR	r8, r8, #1\n\t"
@@ -63312,281 +63312,281 @@ static int sp_521_num_bits_17(const sp_digit* a)
         "LDR	r1, [%[a], #64]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_16\n\t"
+        "BEQ	L_sp_521_num_bits_17_16%=\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_16\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_16%=\n\t"
 #endif
         "MOV	r2, #0x220\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18\n\t"
+        "B	L_sp_521_num_bits_17_18%=\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18\n\t"
+        "B.N	L_sp_521_num_bits_17_18%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_16:\n\t"
+    "L_sp_521_num_bits_17_16%=:\n\t"
         "LDR	r1, [%[a], #60]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_15\n\t"
+        "BEQ	L_sp_521_num_bits_17_15%=\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_15\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_15%=\n\t"
 #endif
         "MOV	r2, #0x200\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18\n\t"
+        "B	L_sp_521_num_bits_17_18%=\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18\n\t"
+        "B.N	L_sp_521_num_bits_17_18%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_15:\n\t"
+    "L_sp_521_num_bits_17_15%=:\n\t"
         "LDR	r1, [%[a], #56]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_14\n\t"
+        "BEQ	L_sp_521_num_bits_17_14%=\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_14\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_14%=\n\t"
 #endif
         "MOV	r2, #0x1e0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18\n\t"
+        "B	L_sp_521_num_bits_17_18%=\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18\n\t"
+        "B.N	L_sp_521_num_bits_17_18%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_14:\n\t"
+    "L_sp_521_num_bits_17_14%=:\n\t"
         "LDR	r1, [%[a], #52]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_13\n\t"
+        "BEQ	L_sp_521_num_bits_17_13%=\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_13\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_13%=\n\t"
 #endif
         "MOV	r2, #0x1c0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18\n\t"
+        "B	L_sp_521_num_bits_17_18%=\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18\n\t"
+        "B.N	L_sp_521_num_bits_17_18%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_13:\n\t"
+    "L_sp_521_num_bits_17_13%=:\n\t"
         "LDR	r1, [%[a], #48]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_12\n\t"
+        "BEQ	L_sp_521_num_bits_17_12%=\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_12\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_12%=\n\t"
 #endif
         "MOV	r2, #0x1a0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18\n\t"
+        "B	L_sp_521_num_bits_17_18%=\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18\n\t"
+        "B.N	L_sp_521_num_bits_17_18%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_12:\n\t"
+    "L_sp_521_num_bits_17_12%=:\n\t"
         "LDR	r1, [%[a], #44]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_11\n\t"
+        "BEQ	L_sp_521_num_bits_17_11%=\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_11\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_11%=\n\t"
 #endif
         "MOV	r2, #0x180\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18\n\t"
+        "B	L_sp_521_num_bits_17_18%=\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18\n\t"
+        "B.N	L_sp_521_num_bits_17_18%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_11:\n\t"
+    "L_sp_521_num_bits_17_11%=:\n\t"
         "LDR	r1, [%[a], #40]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_10\n\t"
+        "BEQ	L_sp_521_num_bits_17_10%=\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_10\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_10%=\n\t"
 #endif
         "MOV	r2, #0x160\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18\n\t"
+        "B	L_sp_521_num_bits_17_18%=\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18\n\t"
+        "B.N	L_sp_521_num_bits_17_18%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_10:\n\t"
+    "L_sp_521_num_bits_17_10%=:\n\t"
         "LDR	r1, [%[a], #36]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_9\n\t"
+        "BEQ	L_sp_521_num_bits_17_9%=\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_9\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_9%=\n\t"
 #endif
         "MOV	r2, #0x140\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18\n\t"
+        "B	L_sp_521_num_bits_17_18%=\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18\n\t"
+        "B.N	L_sp_521_num_bits_17_18%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_9:\n\t"
+    "L_sp_521_num_bits_17_9%=:\n\t"
         "LDR	r1, [%[a], #32]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_8\n\t"
+        "BEQ	L_sp_521_num_bits_17_8%=\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_8\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_8%=\n\t"
 #endif
         "MOV	r2, #0x120\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18\n\t"
+        "B	L_sp_521_num_bits_17_18%=\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18\n\t"
+        "B.N	L_sp_521_num_bits_17_18%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_8:\n\t"
+    "L_sp_521_num_bits_17_8%=:\n\t"
         "LDR	r1, [%[a], #28]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_7\n\t"
+        "BEQ	L_sp_521_num_bits_17_7%=\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_7\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_7%=\n\t"
 #endif
         "MOV	r2, #0x100\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18\n\t"
+        "B	L_sp_521_num_bits_17_18%=\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18\n\t"
+        "B.N	L_sp_521_num_bits_17_18%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_7:\n\t"
+    "L_sp_521_num_bits_17_7%=:\n\t"
         "LDR	r1, [%[a], #24]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_6\n\t"
+        "BEQ	L_sp_521_num_bits_17_6%=\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_6\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_6%=\n\t"
 #endif
         "MOV	r2, #0xe0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18\n\t"
+        "B	L_sp_521_num_bits_17_18%=\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18\n\t"
+        "B.N	L_sp_521_num_bits_17_18%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_6:\n\t"
+    "L_sp_521_num_bits_17_6%=:\n\t"
         "LDR	r1, [%[a], #20]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_5\n\t"
+        "BEQ	L_sp_521_num_bits_17_5%=\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_5\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_5%=\n\t"
 #endif
         "MOV	r2, #0xc0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18\n\t"
+        "B	L_sp_521_num_bits_17_18%=\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18\n\t"
+        "B.N	L_sp_521_num_bits_17_18%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_5:\n\t"
+    "L_sp_521_num_bits_17_5%=:\n\t"
         "LDR	r1, [%[a], #16]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_4\n\t"
+        "BEQ	L_sp_521_num_bits_17_4%=\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_4\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_4%=\n\t"
 #endif
         "MOV	r2, #0xa0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18\n\t"
+        "B	L_sp_521_num_bits_17_18%=\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18\n\t"
+        "B.N	L_sp_521_num_bits_17_18%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_4:\n\t"
+    "L_sp_521_num_bits_17_4%=:\n\t"
         "LDR	r1, [%[a], #12]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_3\n\t"
+        "BEQ	L_sp_521_num_bits_17_3%=\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_3\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_3%=\n\t"
 #endif
         "MOV	r2, #0x80\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18\n\t"
+        "B	L_sp_521_num_bits_17_18%=\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18\n\t"
+        "B.N	L_sp_521_num_bits_17_18%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_3:\n\t"
+    "L_sp_521_num_bits_17_3%=:\n\t"
         "LDR	r1, [%[a], #8]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_2\n\t"
+        "BEQ	L_sp_521_num_bits_17_2%=\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_2\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_2%=\n\t"
 #endif
         "MOV	r2, #0x60\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18\n\t"
+        "B	L_sp_521_num_bits_17_18%=\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18\n\t"
+        "B.N	L_sp_521_num_bits_17_18%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_2:\n\t"
+    "L_sp_521_num_bits_17_2%=:\n\t"
         "LDR	r1, [%[a], #4]\n\t"
         "CMP	r1, #0x0\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_1\n\t"
+        "BEQ	L_sp_521_num_bits_17_1%=\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_1\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_1%=\n\t"
 #endif
         "MOV	r2, #0x40\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18\n\t"
+        "B	L_sp_521_num_bits_17_18%=\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18\n\t"
+        "B.N	L_sp_521_num_bits_17_18%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_1:\n\t"
+    "L_sp_521_num_bits_17_1%=:\n\t"
         "LDR	r1, [%[a]]\n\t"
         "MOV	r2, #0x20\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
         "\n"
-    "L_sp_521_num_bits_17_18:\n\t"
+    "L_sp_521_num_bits_17_18%=:\n\t"
         "MOV	%[a], r4\n\t"
         : [a] "+r" (a)
         :
@@ -67981,13 +67981,13 @@ static void sp_1024_mul_32(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_1024_mul_32_outer:\n\t"
+    "L_sp_1024_mul_32_outer%=:\n\t"
         "SUBS	r3, r5, #0x7c\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_1024_mul_32_inner:\n\t"
+    "L_sp_1024_mul_32_inner%=:\n\t"
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -68004,14 +68004,14 @@ static void sp_1024_mul_32(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_1024_mul_32_inner_done\n\t"
+        "BGT	L_sp_1024_mul_32_inner_done%=\n\t"
 #else
-        "BGT.N	L_sp_1024_mul_32_inner_done\n\t"
+        "BGT.N	L_sp_1024_mul_32_inner_done%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_1024_mul_32_inner\n\t"
+        "BLT	L_sp_1024_mul_32_inner%=\n\t"
 #else
-        "BLT.N	L_sp_1024_mul_32_inner\n\t"
+        "BLT.N	L_sp_1024_mul_32_inner%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r3]\n\t"
@@ -68020,7 +68020,7 @@ static void sp_1024_mul_32(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_1024_mul_32_inner_done:\n\t"
+    "L_sp_1024_mul_32_inner_done%=:\n\t"
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
@@ -68028,9 +68028,9 @@ static void sp_1024_mul_32(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0xf4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_1024_mul_32_outer\n\t"
+        "BLE	L_sp_1024_mul_32_outer%=\n\t"
 #else
-        "BLE.N	L_sp_1024_mul_32_outer\n\t"
+        "BLE.N	L_sp_1024_mul_32_outer%=\n\t"
 #endif
         "LDR	lr, [%[a], #124]\n\t"
         "LDR	r11, [%[b], #124]\n\t"
@@ -68039,14 +68039,14 @@ static void sp_1024_mul_32(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_1024_mul_32_store:\n\t"
+    "L_sp_1024_mul_32_store%=:\n\t"
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_1024_mul_32_store\n\t"
+        "BGT	L_sp_1024_mul_32_store%=\n\t"
 #else
-        "BGT.N	L_sp_1024_mul_32_store\n\t"
+        "BGT.N	L_sp_1024_mul_32_store%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
@@ -68079,13 +68079,13 @@ static void sp_1024_sqr_32(sp_digit* r, const sp_digit* a)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_1024_sqr_32_outer:\n\t"
+    "L_sp_1024_sqr_32_outer%=:\n\t"
         "SUBS	r3, r5, #0x7c\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_1024_sqr_32_inner:\n\t"
+    "L_sp_1024_sqr_32_inner%=:\n\t"
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[a], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -68099,14 +68099,14 @@ static void sp_1024_sqr_32(sp_digit* r, const sp_digit* a)
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_1024_sqr_32_inner_done\n\t"
+        "BGT	L_sp_1024_sqr_32_inner_done%=\n\t"
 #else
-        "BGT.N	L_sp_1024_sqr_32_inner_done\n\t"
+        "BGT.N	L_sp_1024_sqr_32_inner_done%=\n\t"
 #endif
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_1024_sqr_32_inner\n\t"
+        "BLT	L_sp_1024_sqr_32_inner%=\n\t"
 #else
-        "BLT.N	L_sp_1024_sqr_32_inner\n\t"
+        "BLT.N	L_sp_1024_sqr_32_inner%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "UMULL	r9, r10, lr, lr\n\t"
@@ -68114,7 +68114,7 @@ static void sp_1024_sqr_32(sp_digit* r, const sp_digit* a)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_1024_sqr_32_inner_done:\n\t"
+    "L_sp_1024_sqr_32_inner_done%=:\n\t"
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
@@ -68122,9 +68122,9 @@ static void sp_1024_sqr_32(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0xf4\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_1024_sqr_32_outer\n\t"
+        "BLE	L_sp_1024_sqr_32_outer%=\n\t"
 #else
-        "BLE.N	L_sp_1024_sqr_32_outer\n\t"
+        "BLE.N	L_sp_1024_sqr_32_outer%=\n\t"
 #endif
         "LDR	lr, [%[a], #124]\n\t"
         "UMLAL	r6, r7, lr, lr\n\t"
@@ -68132,14 +68132,14 @@ static void sp_1024_sqr_32(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_1024_sqr_32_store:\n\t"
+    "L_sp_1024_sqr_32_store%=:\n\t"
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_1024_sqr_32_store\n\t"
+        "BGT	L_sp_1024_sqr_32_store%=\n\t"
 #else
-        "BGT.N	L_sp_1024_sqr_32_store\n\t"
+        "BGT.N	L_sp_1024_sqr_32_store%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a)
         :
@@ -68254,7 +68254,7 @@ static sp_digit sp_1024_sub_in_place_32(sp_digit* a, const sp_digit* b)
         "MOV	r10, #0x0\n\t"
         "ADD	r11, %[a], #0x80\n\t"
         "\n"
-    "L_sp_1024_sub_in_pkace_32_word:\n\t"
+    "L_sp_1024_sub_in_pkace_32_word%=:\n\t"
         "RSBS	r10, r10, #0x0\n\t"
         "LDM	%[a], {r2, r3, r4, r5}\n\t"
         "LDM	%[b]!, {r6, r7, r8, r9}\n\t"
@@ -68266,9 +68266,9 @@ static sp_digit sp_1024_sub_in_place_32(sp_digit* a, const sp_digit* b)
         "SBC	r10, r10, r10\n\t"
         "CMP	%[a], r11\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_1024_sub_in_pkace_32_word\n\t"
+        "BNE	L_sp_1024_sub_in_pkace_32_word%=\n\t"
 #else
-        "BNE.N	L_sp_1024_sub_in_pkace_32_word\n\t"
+        "BNE.N	L_sp_1024_sub_in_pkace_32_word%=\n\t"
 #endif
         "MOV	%[a], r10\n\t"
         : [a] "+r" (a), [b] "+r" (b)
@@ -68306,7 +68306,7 @@ static sp_digit sp_1024_cond_sub_32(sp_digit* r, const sp_digit* a, const sp_dig
         "MOV	r4, #0x0\n\t"
         "MOV	r5, #0x0\n\t"
         "\n"
-    "L_sp_1024_cond_sub_32_words:\n\t"
+    "L_sp_1024_cond_sub_32_words%=:\n\t"
         "SUBS	r4, r8, r4\n\t"
         "LDR	r6, [%[a], r5]\n\t"
         "LDR	r7, [%[b], r5]\n\t"
@@ -68317,9 +68317,9 @@ static sp_digit sp_1024_cond_sub_32(sp_digit* r, const sp_digit* a, const sp_dig
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x80\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_1024_cond_sub_32_words\n\t"
+        "BLT	L_sp_1024_cond_sub_32_words%=\n\t"
 #else
-        "BLT.N	L_sp_1024_cond_sub_32_words\n\t"
+        "BLT.N	L_sp_1024_cond_sub_32_words%=\n\t"
 #endif
         "MOV	%[r], r4\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -68497,7 +68497,7 @@ static sp_digit sp_1024_add_32(sp_digit* r, const sp_digit* a, const sp_digit* b
         "MOV	r3, #0x0\n\t"
         "ADD	r12, %[a], #0x80\n\t"
         "\n"
-    "L_sp_1024_add_32_word:\n\t"
+    "L_sp_1024_add_32_word%=:\n\t"
         "ADDS	r3, r3, #0xffffffff\n\t"
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
         "LDM	%[b]!, {r8, r9, r10, r11}\n\t"
@@ -68510,9 +68510,9 @@ static sp_digit sp_1024_add_32(sp_digit* r, const sp_digit* a, const sp_digit* b
         "ADC	r3, r4, #0x0\n\t"
         "CMP	%[a], r12\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_1024_add_32_word\n\t"
+        "BNE	L_sp_1024_add_32_word%=\n\t"
 #else
-        "BNE.N	L_sp_1024_add_32_word\n\t"
+        "BNE.N	L_sp_1024_add_32_word%=\n\t"
 #endif
         "MOV	%[r], r3\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -68551,7 +68551,7 @@ static void sp_1024_mul_d_32(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "MOV	r9, #0x4\n\t"
         "\n"
-    "L_sp_1024_mul_d_32_word:\n\t"
+    "L_sp_1024_mul_d_32_word%=:\n\t"
         /* A[i] * B */
         "LDR	r8, [%[a], r9]\n\t"
         "UMULL	r6, r7, %[b], r8\n\t"
@@ -68565,9 +68565,9 @@ static void sp_1024_mul_d_32(sp_digit* r, const sp_digit* a, sp_digit b)
         "ADD	r9, r9, #0x4\n\t"
         "CMP	r9, #0x80\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_1024_mul_d_32_word\n\t"
+        "BLT	L_sp_1024_mul_d_32_word%=\n\t"
 #else
-        "BLT.N	L_sp_1024_mul_d_32_word\n\t"
+        "BLT.N	L_sp_1024_mul_d_32_word%=\n\t"
 #endif
         "STR	r3, [%[r], #128]\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -68865,7 +68865,7 @@ SP_NOINLINE static sp_digit div_1024_word_32(sp_digit d1, sp_digit d0, sp_digit 
         /* Next 30 bits */
         "MOV	r4, #0x1d\n\t"
         "\n"
-    "L_div_1024_word_32_bit:\n\t"
+    "L_div_1024_word_32_bit%=:\n\t"
         "LSLS	r6, r6, #1\n\t"
         "ADC	r7, r7, r7\n\t"
         "SUBS	r8, r5, r7\n\t"
@@ -68875,7 +68875,7 @@ SP_NOINLINE static sp_digit div_1024_word_32(sp_digit d1, sp_digit d0, sp_digit 
         "AND	r8, r8, r5\n\t"
         "SUBS	r7, r7, r8\n\t"
         "SUBS	r4, r4, #0x1\n\t"
-        "bpl	L_div_1024_word_32_bit\n\t"
+        "bpl	L_div_1024_word_32_bit%=\n\t"
         "ADD	r3, r3, r3\n\t"
         "ADD	r3, r3, #0x1\n\t"
         "UMULL	r6, r7, r3, %[div]\n\t"
@@ -68957,7 +68957,7 @@ static sp_int32 sp_1024_cmp_32(const sp_digit* a, const sp_digit* b)
 #ifdef WOLFSSL_SP_SMALL
         "MOV	r6, #0x7c\n\t"
         "\n"
-    "L_sp_1024_cmp_32_words:\n\t"
+    "L_sp_1024_cmp_32_words%=:\n\t"
         "LDR	r4, [%[a], r6]\n\t"
         "LDR	r5, [%[b], r6]\n\t"
         "AND	r4, r4, r3\n\t"
@@ -68970,7 +68970,7 @@ static sp_int32 sp_1024_cmp_32(const sp_digit* a, const sp_digit* b)
         "IT	ne\n\t"
         "movne	r3, r7\n\t"
         "SUBS	r6, r6, #0x4\n\t"
-        "bcs	L_sp_1024_cmp_32_words\n\t"
+        "bcs	L_sp_1024_cmp_32_words%=\n\t"
         "EOR	r2, r2, r3\n\t"
 #else
         "LDR	r4, [%[a], #124]\n\t"
@@ -69690,7 +69690,7 @@ SP_NOINLINE static void sp_1024_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "LDR	r4, [%[a]]\n\t"
         "LDR	r5, [%[a], #4]\n\t"
         "\n"
-    "L_sp_1024_mont_reduce_32_word:\n\t"
+    "L_sp_1024_mont_reduce_32_word%=:\n\t"
         /* mu = a[i] * mp */
         "MUL	r10, %[mp], r4\n\t"
         /* a[i+0] += m[0] * mu */
@@ -69953,9 +69953,9 @@ SP_NOINLINE static void sp_1024_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r11, #0x80\n\t"
 #ifdef __GNUC__
-        "BLT	L_sp_1024_mont_reduce_32_word\n\t"
+        "BLT	L_sp_1024_mont_reduce_32_word%=\n\t"
 #else
-        "BLT.W	L_sp_1024_mont_reduce_32_word\n\t"
+        "BLT.W	L_sp_1024_mont_reduce_32_word%=\n\t"
 #endif
         /* Loop Done */
         "STR	r4, [%[a]]\n\t"
@@ -70002,7 +70002,7 @@ SP_NOINLINE static void sp_1024_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "LDR	r9, [%[a], #12]\n\t"
         "LDR	r10, [%[a], #16]\n\t"
         "\n"
-    "L_sp_1024_mont_reduce_32_word:\n\t"
+    "L_sp_1024_mont_reduce_32_word%=:\n\t"
         /* mu = a[i] * mp */
         "MUL	lr, %[mp], r6\n\t"
         /* a[i+0] += m[0] * mu */
@@ -70170,9 +70170,9 @@ SP_NOINLINE static void sp_1024_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r4, #0x80\n\t"
 #ifdef __GNUC__
-        "BLT	L_sp_1024_mont_reduce_32_word\n\t"
+        "BLT	L_sp_1024_mont_reduce_32_word%=\n\t"
 #else
-        "BLT.W	L_sp_1024_mont_reduce_32_word\n\t"
+        "BLT.W	L_sp_1024_mont_reduce_32_word%=\n\t"
 #endif
         /* Loop Done */
         "STR	r6, [%[a]]\n\t"
@@ -71187,7 +71187,7 @@ static sp_digit sp_1024_cond_add_32(sp_digit* r, const sp_digit* a, const sp_dig
         "MOV	r8, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_1024_cond_add_32_words:\n\t"
+    "L_sp_1024_cond_add_32_words%=:\n\t"
         "ADDS	r5, r5, #0xffffffff\n\t"
         "LDR	r6, [%[a], r4]\n\t"
         "LDR	r7, [%[b], r4]\n\t"
@@ -71198,9 +71198,9 @@ static sp_digit sp_1024_cond_add_32(sp_digit* r, const sp_digit* a, const sp_dig
         "ADD	r4, r4, #0x4\n\t"
         "CMP	r4, #0x80\n\t"
 #if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_1024_cond_add_32_words\n\t"
+        "BLT	L_sp_1024_cond_add_32_words%=\n\t"
 #else
-        "BLT.N	L_sp_1024_cond_add_32_words\n\t"
+        "BLT.N	L_sp_1024_cond_add_32_words%=\n\t"
 #endif
         "MOV	%[r], r5\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)


### PR DESCRIPTION
# Description

When functions are inlined, the labels need to be unique. Putting '%=' on the end of the label ensures that the compilers appends a unique number to the end.

Fixes #7645

# Testing

./configure '--disable-shared' 'LDFLAGS=--static' '--host=armv7m' 'CC=arm-linux-gnueabi-gcc' '--enable-sp' '--enable-sp-asm' '--enable-armasm=inline' 'host_alias=armv7m'

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
