### PR TITLE
Add sanity for case id'd in optesting review

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4103,18 +4103,6 @@ AC_ARG_ENABLE([ed448-stream],
     [ ENABLED_ED448_STREAM=no ]
     )
 
-if test "$ENABLED_ED448_STREAM" != "no"
-then
-    if test "$ENABLED_ED448" = "no"
-    then
-        AC_MSG_ERROR([ED448 verify streaming enabled but ED448 is disabled])
-    else
-        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ED448_STREAMING_VERIFY"
-        AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_ED448_STREAMING_VERIFY"
-    fi
-fi
-
-
 # FP ECC, Fixed Point cache ECC
 AC_ARG_ENABLE([fpecc],
     [AS_HELP_STRING([--enable-fpecc],[Enable Fixed Point cache ECC (default: disabled)])],
@@ -5613,6 +5601,18 @@ then
 
     ENABLED_CERTS=yes
 fi
+
+if test "$ENABLED_ED448_STREAM" != "no"
+then
+    if test "$ENABLED_ED448" = "no"
+    then
+        AC_MSG_ERROR([ED448 verify streaming enabled but ED448 is disabled])
+    else
+        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ED448_STREAMING_VERIFY"
+        AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_ED448_STREAMING_VERIFY"
+    fi
+fi
+
 
 # SRTP-KDF
 if test "$ENABLED_SRTP" = "yes"

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -10643,6 +10643,11 @@ static WARN_UNUSED_RESULT int roll_auth(
     word32 remainder;
     int ret;
 
+    /* Sanity check on authIn to prevent segfault in xorbuf() where
+     * variable 'in' is dereferenced as the mask 'm' in misc.c */
+    if (in == NULL)
+        return BAD_FUNC_ARG;
+
     /* encode the length in */
     if (inSz <= 0xFEFF) {
         authLenSz = 2;

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -10913,7 +10913,6 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
     if (authIn == NULL && authInSz > 0)
         return BAD_FUNC_ARG;
 
-
     /* sanity check on tag size */
     if (wc_AesCcmCheckTagSize((int)authTagSz) != 0) {
         return BAD_FUNC_ARG;

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -10643,11 +10643,6 @@ static WARN_UNUSED_RESULT int roll_auth(
     word32 remainder;
     int ret;
 
-    /* Sanity check on authIn to prevent segfault in xorbuf() where
-     * variable 'in' is dereferenced as the mask 'm' in misc.c */
-    if (in == NULL)
-        return BAD_FUNC_ARG;
-
     /* encode the length in */
     if (inSz <= 0xFEFF) {
         authLenSz = 2;
@@ -10764,6 +10759,11 @@ int wc_AesCcmEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
     if (aes == NULL || (inSz != 0 && (in == NULL || out == NULL)) ||
         nonce == NULL || authTag == NULL || nonceSz < 7 || nonceSz > 13 ||
             authTagSz > AES_BLOCK_SIZE)
+        return BAD_FUNC_ARG;
+
+    /* Sanity check on authIn to prevent segfault in xorbuf() where
+     * variable 'in' is dereferenced as the mask 'm' in misc.c */
+    if (authIn == NULL && authInSz > 0)
         return BAD_FUNC_ARG;
 
     /* sanity check on tag size */
@@ -10907,6 +10907,12 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
         nonce == NULL || authTag == NULL || nonceSz < 7 || nonceSz > 13 ||
         authTagSz > AES_BLOCK_SIZE)
         return BAD_FUNC_ARG;
+
+    /* Sanity check on authIn to prevent segfault in xorbuf() where
+     * variable 'in' is dereferenced as the mask 'm' in misc.c */
+    if (authIn == NULL && authInSz > 0)
+        return BAD_FUNC_ARG;
+
 
     /* sanity check on tag size */
     if (wc_AesCcmCheckTagSize((int)authTagSz) != 0) {


### PR DESCRIPTION
# Description

Catch a bad input prior to dereference

# Testing
Using the operational test app invalid cases.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
