### PR TITLE
20240617-fix-wc_Sha256-overalignment

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3086,12 +3086,6 @@ extern void uITRON4_free(void *p) ;
     #define OPENSSL_EXTRA_X509_SMALL
 #endif /* OPENSSL_EXTRA */
 
-/* compatibility for EVP_CipherUpdate with AES-GCM */
-#if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)
-    #undef  WOLFSSL_AESGCM_STREAM
-    #define WOLFSSL_AESGCM_STREAM
-#endif
-
 /* support for converting DER to PEM */
 #if (defined(WOLFSSL_KEY_GEN) && !defined(WOLFSSL_NO_DER_TO_PEM)) || \
     defined(WOLFSSL_CERT_GEN) || defined(OPENSSL_EXTRA)

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -179,9 +179,14 @@ struct wc_Sha256 {
 #elif defined(WOLFSSL_HAVE_PSA) && !defined(WOLFSSL_PSA_NO_HASH)
     psa_hash_operation_t psa_ctx;
 #else
+#ifdef WC_64BIT_CPU
     /* alignment on digest and buffer speeds up ARMv8 crypto operations */
     ALIGN16 word32  digest[WC_SHA256_DIGEST_SIZE / sizeof(word32)];
     ALIGN16 word32  buffer[WC_SHA256_BLOCK_SIZE  / sizeof(word32)];
+#else
+    word32  digest[WC_SHA256_DIGEST_SIZE / sizeof(word32)];
+    word32  buffer[WC_SHA256_BLOCK_SIZE  / sizeof(word32)];
+#endif
     word32  buffLen;   /* in bytes          */
     word32  loLen;     /* length in bytes   */
     word32  hiLen;     /* length in bytes   */


### PR DESCRIPTION
`wolfssl/wolfcrypt/sha256.h`: in definition of `struct wc_Sha256`, conditionalize alignment optimization of `digest` and `buffer` slots on `defined(WC_64BIT_CPU)`, to avoid overalignment warnings on 32 bit targets.  this also fixes overalignment of `struct Hmac`.

see https://www.wolfssl.com/forums/topic2125-armcc-byte-alignment-cannot-be-greater-than-8-bytes-warning.html

`ARMCC` reports
```
wolfcrypt\src\kdf.c(87): warning:  #1041-D: alignment for an auto object may not be larger than 8
```

With this patch, the alignment of `struct Hmac` drops from 16 to 8 on 32 bit targets.

tested with `wolfssl-multi-test.sh ... sanitizer-all-intelasm-c-fallback-fuzzer cross-aarch64-all-armasm-unittest-sanitizer cross-aarch64-all-noasm-unittest-sanitizer cross-armv7a-all-armasm-testsuite-sanitizer super-quick-check`
