### PR TITLE
20240618-linuxkm-4.14.336LTS

### DIFF
--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -115,6 +115,7 @@
     _Pragma("GCC diagnostic ignored \"-Wdiscarded-qualifiers\"");
     _Pragma("GCC diagnostic ignored \"-Wtype-limits\"");
     _Pragma("GCC diagnostic ignored \"-Wswitch-enum\"");
+    _Pragma("GCC diagnostic ignored \"-Wcast-function-type\""); /* needed for kernel 4.14.336 */
 
     #include <linux/kconfig.h>
     #include <linux/kernel.h>


### PR DESCRIPTION
`linuxkm/linuxkm_wc_port.h`: add a suppression needed for targeting LTS kernel version 4.14.336.

tested with `wolfssl-multi-test.sh ... linuxkm-legacy-4.14-insmod`
