### PR TITLE
Fixes in ASN1 and X509

### DIFF
--- a/src/ssl_asn1.c
+++ b/src/ssl_asn1.c
@@ -3510,14 +3510,17 @@ WOLFSSL_ASN1_TIME* wolfSSL_ASN1_TIME_to_generalizedtime(WOLFSSL_ASN1_TIME *t,
     if (ret != NULL) {
         /* Set the ASN.1 type and length of string. */
         ret->type = V_ASN1_GENERALIZEDTIME;
-        ret->length = ASN_GENERALIZED_TIME_SIZE;
 
         if (t->type == V_ASN1_GENERALIZEDTIME) {
+            ret->length = ASN_GENERALIZED_TIME_SIZE;
+
             /* Just copy as data already appropriately formatted. */
             XMEMCPY(ret->data, t->data, ASN_GENERALIZED_TIME_SIZE);
         }
         else {
             /* Convert UTC TIME to GENERALIZED TIME. */
+            ret->length = t->length + 2; /* Add two extra year digits */
+
             if (t->data[0] >= '5') {
                 /* >= 50 is 1900s.  */
                 ret->data[0] = '1'; ret->data[1] = '9';
@@ -3527,7 +3530,7 @@ WOLFSSL_ASN1_TIME* wolfSSL_ASN1_TIME_to_generalizedtime(WOLFSSL_ASN1_TIME *t,
                 ret->data[0] = '2'; ret->data[1] = '0';
             }
             /* Append rest of the data as it is the same. */
-            XMEMCPY(&ret->data[2], t->data, ASN_UTC_TIME_SIZE);
+            XMEMCPY(&ret->data[2], t->data, t->length);
         }
 
         /* Check for pointer to return result through. */

--- a/src/x509.c
+++ b/src/x509.c
@@ -12972,6 +12972,14 @@ static int get_dn_attr_by_nid(int n, const char** buf)
             str = "UID";
             len = 3;
             break;
+        case NID_serialNumber:
+            str = "serialNumber";
+            len = 12;
+            break;
+        case NID_title:
+            str = "title";
+            len = 5;
+            break;
         default:
             WOLFSSL_MSG("Attribute type not found");
             str = NULL;

--- a/src/x509.c
+++ b/src/x509.c
@@ -8236,7 +8236,8 @@ int wolfSSL_X509_CRL_get_signature(WOLFSSL_X509_CRL* crl,
 {
     WOLFSSL_ENTER("wolfSSL_X509_CRL_get_signature");
 
-    if (crl == NULL || crl->crlList == NULL || bufSz == NULL)
+    if (crl == NULL || crl->crlList == NULL ||
+        crl->crlList->signature == NULL || bufSz == NULL)
         return BAD_FUNC_ARG;
 
     if (buf != NULL)


### PR DESCRIPTION
# Description

* Fix wolfSSL_ASN1_TIME_to_generalizedtime with UTC time
* Check for null sig in wolfSSL_X509_CRL_get_signature
* Add attr to get_dn_attr_by_nid

Fixes zd#
18179
18180
18181

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
