### PR TITLE
20240621-fix-oqs_dilithium_make_key-leak

### DIFF
--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -5427,6 +5427,10 @@ static int oqs_dilithium_make_key(dilithium_key* key, WC_RNG* rng)
         key->pubKeySet = 1;
     }
 
+    if (oqssig != NULL) {
+        OQS_SIG_free(oqssig);
+    }
+
     return ret;
 }
 #endif /* WOLFSSL_DILITHIUM_NO_MAKE_KEY */


### PR DESCRIPTION
`wolfcrypt/src/dilithium.c`: add missing `OQS_SIG_free()` in `oqs_dilithium_make_key()` (liboqs wrapper).

detected by `wolfssl-multi-test.sh ... pq-all-sanitizer pq-hybrid-all-rpk-sanitizer`; tested with `wolfssl-multi-test.sh ... pcheck-source-text q-all-sanitizer pq-hybrid-all-rpk-sanitizer pq-hybrid-all-rpk-valgrind-unittest`
