### PR TITLE
20240622-SHA3-CRYPTO_CB

### DIFF
--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -1606,7 +1606,7 @@ int wc_CryptoCb_Sha512Hash(wc_Sha512* sha512, const byte* in,
 }
 #endif /* WOLFSSL_SHA512 */
 
-#ifdef WOLFSSL_SHA3
+#if defined(WOLFSSL_SHA3) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(6, 0))
 int wc_CryptoCb_Sha3Hash(wc_Sha3* sha3, int type, const byte* in,
     word32 inSz, byte* digest)
 {
@@ -1638,7 +1638,7 @@ int wc_CryptoCb_Sha3Hash(wc_Sha3* sha3, int type, const byte* in,
 
     return wc_CryptoCb_TranslateErrorCode(ret);
 }
-#endif /* WOLFSSL_SHA3 */
+#endif /* WOLFSSL_SHA3 && (!HAVE_FIPS || FIPS_VERSION_GE(6, 0)) */
 
 #ifndef NO_HMAC
 int wc_CryptoCb_Hmac(Hmac* hmac, int macType, const byte* in, word32 inSz,

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -54802,7 +54802,7 @@ static int myCryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
         }
         else
     #endif
-    #ifdef WOLFSSL_SHA3
+    #if defined(WOLFSSL_SHA3) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(6, 0))
         if (info->hash.type == WC_HASH_TYPE_SHA3_224) {
             if (info->hash.sha3 == NULL)
                 return NOT_COMPILED_IN;


### PR DESCRIPTION
`WOLF_CRYPTO_CB` && `WOLFSSL_SHA3`: add FIPS gating to `wc_CryptoCb_Sha3Hash()` and test routine `myCryptoDevCb()`.

tested with `wolfssl-multi-test.sh ... check-source-text fips-140-3-all linuxkm-all-fips-140-3 fips-140-3-RC12 clang-tidy-fips-140-3-pilot-all cppcheck-all-fips-dev fips-140-3-dev-all`
