### PR TITLE
ret will be set to 1 (WOLFSSL_SUCCESS), the rest checks for 'ret == 0'

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -36659,8 +36659,12 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
             /* check for TLS_EMPTY_RENEGOTIATION_INFO_SCSV suite */
             ret = TLSX_AddEmptyRenegotiationInfo(&ssl->extensions, ssl->heap);
-            if (ret != WOLFSSL_SUCCESS)
+            if (ret != WOLFSSL_SUCCESS) {
+                ret = SECURE_RENEGOTIATION_E;
                 goto out;
+            } else {
+                ret = 0;
+            }
 
             extension = TLSX_Find(ssl->extensions, TLSX_RENEGOTIATION_INFO);
             if (extension) {


### PR DESCRIPTION
Need to use another type of return code

This came up as an issue uncovered with our TLSFuzzer. A [piece of code was fixed](https://github.com/wolfSSL/wolfssl/commit/617eda9d449a3755e9791ae8a8ce26ff43a7304b#diff-1c4e2f5adfa1ad30618e78ff459b2c0758ecf34278459ad0a8d58db4fec622eaL29958) that wasn't checking if `ret != 0` and set it to something else. Then subsequent code would work correctly because now `ret == 0`. When that code was fixed, this issue popped up where the cipher suite was being returned as TLS_NULL_WITH_NULL_NULL.