### PR TITLE
SSL default ticket encryption callback: check in len on decrypt

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -38842,6 +38842,10 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
 
     WOLFSSL_ENTER("DefTicketEncCb");
 
+    if ((!enc) && (inLen != sizeof(InternalTicket))) {
+        return BUFFER_E;
+    }
+
     /* Check we have setup the RNG, name and primary key. */
     if (keyCtx->expirary[0] == 0) {
 #ifndef SINGLE_THREADED


### PR DESCRIPTION
# Description

Make sure that the length of the data to decrypt is correct for the default ticket encryption implementation.

Fixes zd#18205

# Testing

./configure --disable-shared --enable-session-ticket
Still passes tests with length check in.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
