### PR TITLE
20240626-EvictSessionFromCache-ticketNonce-data-leak

### DIFF
--- a/src/ssl_sess.c
+++ b/src/ssl_sess.c
@@ -215,6 +215,17 @@
 #ifdef HAVE_EX_DATA
         session->ownExData = save_ownExData;
 #endif
+
+#if defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET) &&                  \
+    defined(WOLFSSL_TICKET_NONCE_MALLOC) &&                                    \
+    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
+        if ((session->ticketNonce.data != NULL) &&
+            (session->ticketNonce.data != session->ticketNonce.dataStatic))
+        {
+            XFREE(session->ticketNonce.data, NULL, DYNAMIC_TYPE_SESSION_TICK);
+            session->ticketNonce.data = NULL;
+        }
+#endif
     }
 
 WOLFSSL_ABI


### PR DESCRIPTION
`src/ssl_sess.c`: in `EvictSessionFromCache()`, free `session->ticketNonce.data` if it was dynamically allocated.  fixes memory leak via `wolfSSL_Cleanup()`.

for history see 56d6087749 and 1106e5ff0e.

detected by `wolfssl-multi-test.sh ... all-noasm-valgrind-unittest`

tested with
```
LD_LIBRARY_PATH=./src/.libs saferun valgrind --tool=memcheck --leak-check=full --show-leak-kinds=all --show-reachable=yes --leak-resolution=high --track-fds=yes --track-origins=yes --fullpath-after= --error-exitcode=10 ./tests/.libs/unit.test
```

also tested with `wolfssl-multi-test.sh ... super-quick-check`
