### PR TITLE
Regression testing: memory allocation failure

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -121,7 +121,7 @@ static int InitCRL_Entry(CRL_Entry* crle, DecodedCRL* dcrl, const byte* buff,
     wolfSSL_d2i_X509_NAME(&crle->issuer, (unsigned char**)&dcrl->issuer,
                           dcrl->issuerSz);
     if (crle->issuer == NULL) {
-        return WOLFSSL_FAILURE;
+        return -1;
     }
 #endif
 #ifdef CRL_STATIC_REVOKED_LIST

--- a/src/internal.c
+++ b/src/internal.c
@@ -13495,6 +13495,9 @@ int SetupStoreCtxCallback(WOLFSSL_X509_STORE_CTX** store_pt,
                 store->current_cert = x509;
                 *x509Free = 1;
             }
+            else {
+                goto mem_error;
+            }
         }
 #endif
 #ifdef SESSION_CERTS

--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -5202,6 +5202,8 @@ static int wolfssl_set_tmp_dh(WOLFSSL* ssl, unsigned char* p, int pSz,
 
     /* Allocate space for cipher suites. */
     if ((ret == 1) && (AllocateSuites(ssl) != 0)) {
+        ssl->buffers.serverDH_P.buffer = NULL;
+        ssl->buffers.serverDH_G.buffer = NULL;
         ret = 0;
     }
     if (ret == 1) {
@@ -5249,8 +5251,6 @@ int wolfSSL_SetTmpDH(WOLFSSL* ssl, const unsigned char* p, int pSz,
         pAlloc = (byte*)XMALLOC(pSz, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
         gAlloc = (byte*)XMALLOC(gSz, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
         if ((pAlloc == NULL) || (gAlloc == NULL)) {
-            XFREE(pAlloc, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-            XFREE(gAlloc, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
             ret = MEMORY_E;
         }
     }

--- a/src/x509.c
+++ b/src/x509.c
@@ -12852,6 +12852,7 @@ WOLF_STACK_OF(WOLFSSL_X509_NAME) *wolfSSL_dup_CA_list(
         if (name == NULL || WOLFSSL_SUCCESS != wolfSSL_sk_X509_NAME_push(copy, name)) {
             WOLFSSL_MSG("Memory error");
             wolfSSL_sk_X509_NAME_pop_free(copy, wolfSSL_X509_NAME_free);
+            wolfSSL_X509_NAME_free(name);
             return NULL;
         }
     }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -31685,6 +31685,8 @@ int wc_MakeSigWithBitStr(byte *sig, int sigSz, int sType, byte* buf,
 #endif
 
     if (ret <= 0) {
+        XFREE(certSignCtx->sig, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        certSignCtx->sig = NULL;
         return ret;
     }
 

--- a/wolfcrypt/src/wc_xmss_impl.c
+++ b/wolfcrypt/src/wc_xmss_impl.c
@@ -4055,6 +4055,7 @@ int wc_xmss_sigsleft(const XmssParams* params, unsigned char* sk)
     int ret = 0;
     wc_Idx idx;
 
+    WC_IDX_ZERO(idx);
     /* Read index from the secret key. */
     WC_IDX_DECODE(idx, params->idx_len, sk, ret);
     /* Check validity of index. */


### PR DESCRIPTION

# Description

Fixes from memory allocation failure testing.
Also:
fix asn.c to have ifdef protection around code compiled in with dual algorithm certificates.
  fix test_tls13_rpk_handshake() to support no TLS 1.2 or no TLS 1.3.
fix wc_xmss_sigsleft() to initialize the index to avoid compilation error.

# Testing

Regression testing include memory allocation failure testing.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
