### PR TITLE
Fixes ZD 18204: check hashsigalgo matches ssl suites.

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -27400,13 +27400,8 @@ static int SupportedHashSigAlgo(WOLFSSL* ssl, const byte * hashSigAlgo)
     return 0;
 }
 
-int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
-{
-    return PickHashSigAlgo_ex(ssl, hashSigAlgo, hashSigAlgoSz, 0);
-}
-
-int PickHashSigAlgo_ex(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz,
-                       int matchSuites)
+int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz,
+                    int matchSuites)
 {
     word32 i;
     int ret = WC_NO_ERR_TRACE(MATCH_SUITE_ERROR);
@@ -30074,7 +30069,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             if ((len > size) || ((*inOutIdx - begin) + len > size))
                 return BUFFER_ERROR;
 
-            if (PickHashSigAlgo(ssl, input + *inOutIdx, len) != 0 &&
+            if (PickHashSigAlgo(ssl, input + *inOutIdx, len, 0) != 0 &&
                                              ssl->buffers.certificate &&
                                              ssl->buffers.certificate->buffer) {
             #ifdef HAVE_PK_CALLBACKS
@@ -35959,8 +35954,8 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         ret = SetCipherSpecs(ssl);
         if (ret != 0)
             return ret;
-        ret = PickHashSigAlgo_ex(ssl, peerSuites->hashSigAlgo,
-                                 peerSuites->hashSigAlgoSz, 1);
+        ret = PickHashSigAlgo(ssl, peerSuites->hashSigAlgo,
+                              peerSuites->hashSigAlgoSz, 1);
         if (ret != 0)
             return ret;
 
@@ -36323,7 +36318,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 ret = SetCipherSpecs(ssl);
                 if (ret == 0) {
                     ret = PickHashSigAlgo(ssl, clSuites->hashSigAlgo,
-                                               clSuites->hashSigAlgoSz);
+                                          clSuites->hashSigAlgoSz, 0);
                 }
             }
             else if (ret == 0) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -31104,6 +31104,15 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                             ERROR_OUT(BUFFER_ERROR, exit_dske);
                         }
 
+                        /* Check if hashSigAlgo in Server Key Exchange is supported
+                         * in our ssl->suites or ssl->ctx->suites. */
+                        if (!SupportedHashSigAlgo(ssl, &input[args->idx])) {
+                        #ifdef WOLFSSL_EXTRA_ALERTS
+                            SendAlert(ssl, alert_fatal, handshake_failure);
+                        #endif
+                            ERROR_OUT(MATCH_SUITE_ERROR, exit_dske);
+                        }
+
                         DecodeSigAlg(&input[args->idx], &ssl->options.peerHashAlgo,
                                      &sigAlgo);
                     #ifndef NO_RSA

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5740,7 +5740,7 @@ static int DoTls13CertificateRequest(WOLFSSL* ssl, const byte* input,
         #endif
             ) {
         if (PickHashSigAlgo(ssl, peerSuites.hashSigAlgo,
-                                               peerSuites.hashSigAlgoSz) != 0) {
+                            peerSuites.hashSigAlgoSz, 0) != 0) {
             WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
             return INVALID_PARAMETER;
         }

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2180,9 +2180,7 @@ WOLFSSL_LOCAL int  DoServerHello(WOLFSSL* ssl, const byte* input, word32* inOutI
 WOLFSSL_LOCAL int  CompleteServerHello(WOLFSSL *ssl);
 WOLFSSL_LOCAL int  CheckVersion(WOLFSSL *ssl, ProtocolVersion pv);
 WOLFSSL_LOCAL int  PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo,
-                                   word32 hashSigAlgoSz);
-WOLFSSL_LOCAL int  PickHashSigAlgo_ex(WOLFSSL* ssl, const byte* hashSigAlgo,
-                                      word32 hashSigAlgoSz, int matchSuites);
+                                   word32 hashSigAlgoSz, int matchSuites);
 #if defined(WOLF_PRIVATE_KEY_ID) && !defined(NO_CHECK_PRIVATE_KEY)
 WOLFSSL_LOCAL int  CreateDevPrivateKey(void** pkey, byte* data, word32 length,
                                        int hsType, int label, int id,

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2181,6 +2181,8 @@ WOLFSSL_LOCAL int  CompleteServerHello(WOLFSSL *ssl);
 WOLFSSL_LOCAL int  CheckVersion(WOLFSSL *ssl, ProtocolVersion pv);
 WOLFSSL_LOCAL int  PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo,
                                    word32 hashSigAlgoSz);
+WOLFSSL_LOCAL int  PickHashSigAlgo_ex(WOLFSSL* ssl, const byte* hashSigAlgo,
+                                      word32 hashSigAlgoSz, int matchSuites);
 #if defined(WOLF_PRIVATE_KEY_ID) && !defined(NO_CHECK_PRIVATE_KEY)
 WOLFSSL_LOCAL int  CreateDevPrivateKey(void** pkey, byte* data, word32 length,
                                        int hsType, int label, int id,


### PR DESCRIPTION
# Description

When picking a hash sig algo in MatchSuite, require that peer hash sig algo is supported in our ssl->suites or ssl->ctx->suites.

Fixes zd#18204.

# Testing

Reproducers in ticket.