### PR TITLE
Fixes for building the compatibility layer with no realloc

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -14182,10 +14182,13 @@ void bench_sphincsKeySign(byte level, byte optim)
     * Use care when repeatedly calling calling. See implementation. */
     double current_time(int reset)
     {
-        portTickType tickCount;
-        /* tick count == ms, if configTICK_RATE_HZ is set to 1000 */
-        tickCount = xTaskGetTickCount();
+        portTickType tickCount = xTaskGetTickCount();
+        /* if configTICK_RATE_HZ is available use if (default is 1000) */
+    #ifdef configTICK_RATE_HZ
+        return (double)tickCount / configTICK_RATE_HZ;
+    #else
         return (double)tickCount / 1000;
+    #endif
     }
 #endif
 

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -711,8 +711,19 @@ static int evpCipherBlock(WOLFSSL_EVP_CIPHER_CTX *ctx,
 static int wolfSSL_EVP_CipherUpdate_GCM_AAD(WOLFSSL_EVP_CIPHER_CTX *ctx,
         const unsigned char *in, int inl) {
     if (in && inl > 0) {
-        byte* tmp = (byte*)XREALLOC(ctx->authIn,
+        byte* tmp;
+    #ifdef WOLFSSL_NO_REALLOC
+        tmp = (byte*)XMALLOC((size_t)(ctx->authInSz + inl), NULL,
+                DYNAMIC_TYPE_OPENSSL);
+        if (tmp != NULL) {
+            XMEMCPY(tmp, ctx->authIn, (size_t)ctx->authInSz);
+            XFREE(ctx->authIn, NULL, DYNAMIC_TYPE_OPENSSL);
+            ctx->authIn = NULL;
+        }
+    #else
+        tmp = (byte*)XREALLOC(ctx->authIn,
                 (size_t)(ctx->authInSz + inl), NULL, DYNAMIC_TYPE_OPENSSL);
+    #endif
         if (tmp) {
             ctx->authIn = tmp;
             XMEMCPY(ctx->authIn + ctx->authInSz, in, (size_t)inl);
@@ -745,9 +756,19 @@ static int wolfSSL_EVP_CipherUpdate_GCM(WOLFSSL_EVP_CIPHER_CTX *ctx,
             /* Buffer input for one-shot API */
             if (inl > 0) {
                 byte* tmp;
+            #ifdef WOLFSSL_NO_REALLOC
+                tmp = (byte*)XMALLOC((size_t)(ctx->authBufferLen + inl), NULL,
+                        DYNAMIC_TYPE_OPENSSL);
+                if (tmp != NULL) {
+                    XMEMCPY(tmp, ctx->authBuffer, (size_t)ctx->authBufferLen);
+                    XFREE(ctx->authBuffer, NULL, DYNAMIC_TYPE_OPENSSL);
+                    ctx->authBuffer = NULL;
+                }
+            #else
                 tmp = (byte*)XREALLOC(ctx->authBuffer,
                         (size_t)(ctx->authBufferLen + inl), NULL,
                         DYNAMIC_TYPE_OPENSSL);
+            #endif
                 if (tmp) {
                     XMEMCPY(tmp + ctx->authBufferLen, in, (size_t)inl);
                     ctx->authBufferLen += inl;
@@ -817,8 +838,19 @@ static int wolfSSL_EVP_CipherUpdate_GCM(WOLFSSL_EVP_CIPHER_CTX *ctx,
 static int wolfSSL_EVP_CipherUpdate_CCM_AAD(WOLFSSL_EVP_CIPHER_CTX *ctx,
         const unsigned char *in, int inl) {
     if (in && inl > 0) {
-        byte* tmp = (byte*)XREALLOC(ctx->authIn,
+        byte* tmp;
+    #ifdef WOLFSSL_NO_REALLOC
+        tmp = (byte*)XMALLOC((size_t)(ctx->authInSz + inl), NULL,
+                DYNAMIC_TYPE_OPENSSL);
+        if (tmp != NULL) {
+            XMEMCPY(tmp, ctx->authIn, (size_t)ctx->authInSz);
+            XFREE(ctx->authIn, NULL, DYNAMIC_TYPE_OPENSSL);
+            ctx->authIn = NULL;
+        }
+    #else
+        tmp = (byte*)XREALLOC(ctx->authIn,
                 (size_t)(ctx->authInSz + inl), NULL, DYNAMIC_TYPE_OPENSSL);
+    #endif
         if (tmp) {
             ctx->authIn = tmp;
             XMEMCPY(ctx->authIn + ctx->authInSz, in, (size_t)inl);
@@ -843,9 +875,19 @@ static int wolfSSL_EVP_CipherUpdate_CCM(WOLFSSL_EVP_CIPHER_CTX *ctx,
         /* Buffer input for one-shot API */
         if (inl > 0) {
             byte* tmp;
+        #ifdef WOLFSSL_NO_REALLOC
+            tmp = (byte*)XMALLOC((size_t)(ctx->authBufferLen + inl), NULL,
+                    DYNAMIC_TYPE_OPENSSL);
+            if (tmp != NULL) {
+                XMEMCPY(tmp, ctx->authBuffer, (size_t)ctx->authBufferLen);
+                XFREE(ctx->authBuffer, NULL, DYNAMIC_TYPE_OPENSSL);
+                ctx->authBuffer = NULL;
+            }
+        #else
             tmp = (byte*)XREALLOC(ctx->authBuffer,
                     (size_t)(ctx->authBufferLen + inl), NULL,
                     DYNAMIC_TYPE_OPENSSL);
+        #endif
             if (tmp) {
                 XMEMCPY(tmp + ctx->authBufferLen, in, (size_t)inl);
                 ctx->authBufferLen += inl;
@@ -875,8 +917,19 @@ static int wolfSSL_EVP_CipherUpdate_AriaGCM_AAD(WOLFSSL_EVP_CIPHER_CTX *ctx,
         const unsigned char *in, int inl)
 {
     if (in && inl > 0) {
-        byte* tmp = (byte*)XREALLOC(ctx->authIn,
+        byte* tmp;
+    #ifdef WOLFSSL_NO_REALLOC
+        tmp = (byte*)XMALLOC((size_t)ctx->authInSz + inl, NULL,
+                DYNAMIC_TYPE_OPENSSL);
+        if (tmp != NULL) {
+            XMEMCPY(tmp, ctx->authIn, (size_t)ctx->authInSz);
+            XFREE(ctx->authIn, NULL, DYNAMIC_TYPE_OPENSSL);
+            ctx->authIn = NULL;
+        }
+    #else
+        tmp = (byte*)XREALLOC(ctx->authIn,
                 (size_t)ctx->authInSz + inl, NULL, DYNAMIC_TYPE_OPENSSL);
+    #endif
         if (tmp) {
             ctx->authIn = tmp;
             XMEMCPY(ctx->authIn + ctx->authInSz, in, (size_t)inl);
@@ -905,9 +958,18 @@ static int wolfSSL_EVP_CipherUpdate_AriaGCM(WOLFSSL_EVP_CIPHER_CTX *ctx,
             if (ctx->enc == 0) { /* Append extra space for the tag */
                 size = WC_ARIA_GCM_GET_CIPHERTEXT_SIZE(size);
             }
-            tmp = (byte*)XREALLOC(ctx->authBuffer,
-                    (size_t)size, NULL,
-                    DYNAMIC_TYPE_OPENSSL);
+        #ifdef WOLFSSL_NO_REALLOC
+            tmp = (byte*)XMALLOC((size_t)size, NULL,
+                DYNAMIC_TYPE_OPENSSL);
+            if (tmp != NULL) {
+                XMEMCPY(tmp, ctx->authBuffer, (size_t)ctx->authBufferLen);
+                XFREE(ctx->authBuffer, NULL, DYNAMIC_TYPE_OPENSSL);
+                ctx->authBuffer = NULL;
+            }
+        #else
+            tmp = (byte*)XREALLOC(ctx->authBuffer, (size_t)size, NULL,
+                DYNAMIC_TYPE_OPENSSL);
+        #endif
             if (tmp) {
                 XMEMCPY(tmp + ctx->authBufferLen, in, (size_t)inl);
                 ctx->authBufferLen += inl;
@@ -2693,9 +2755,19 @@ int wolfSSL_EVP_PKEY_CTX_add1_hkdf_info(WOLFSSL_EVP_PKEY_CTX* ctx,
     if (ret == WOLFSSL_SUCCESS && info != NULL && infoSz > 0) {
         unsigned char* p;
         /* If there's already info in the buffer, append. */
+    #ifdef WOLFSSL_NO_REALLOC
+        p = (byte*)XMALLOC((size_t)(ctx->pkey->hkdfInfoSz + (word32)infoSz), NULL,
+            DYNAMIC_TYPE_INFO);
+        if (p != NULL) {
+            XMEMCPY(p, ctx->pkey->hkdfInfo, (size_t)ctx->pkey->hkdfInfoSz);
+            XFREE(ctx->pkey->hkdfInfo, NULL, DYNAMIC_TYPE_INFO);
+            ctx->pkey->hkdfInfo = NULL;
+        }
+    #else
         p = (byte*)XREALLOC(ctx->pkey->hkdfInfo,
             (size_t)(ctx->pkey->hkdfInfoSz + (word32)infoSz), NULL,
             DYNAMIC_TYPE_INFO);
+    #endif
         if (p == NULL) {
             WOLFSSL_MSG("Failed to reallocate larger HKDF info buffer.");
             ret = WOLFSSL_FAILURE;
@@ -9128,8 +9200,17 @@ static int ECC_populate_EVP_PKEY(EVP_PKEY* pkey, WOLFSSL_EC_KEY *key)
     }
     else if (ecc->type == ECC_PUBLICKEY) {
         if ((derSz = wc_EccPublicKeyDerSize(ecc, 1)) > 0) {
-            derBuf = (byte*)XREALLOC(pkey->pkey.ptr, (size_t)derSz, NULL,
+        #ifdef WOLFSSL_NO_REALLOC
+            derBuf = (byte*)XMALLOC((size_t)derSz, pkey->heap, DYNAMIC_TYPE_OPENSSL);
+            if (derBuf != NULL) {
+                XMEMCPY(derBuf, pkey->pkey.ptr, (size_t)pkey->pkey_sz);
+                XFREE(pkey->pkey.ptr, pkey->heap, DYNAMIC_TYPE_OPENSSL);
+                pkey->pkey.ptr = NULL;
+            }
+        #else
+            derBuf = (byte*)XREALLOC(pkey->pkey.ptr, (size_t)derSz, pkey->heap,
                     DYNAMIC_TYPE_OPENSSL);
+        #endif
             if (derBuf != NULL) {
                 pkey->pkey.ptr = (char*)derBuf;
                 if ((derSz = wc_EccPublicKeyToDer(ecc, derBuf, (word32)derSz,

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -53600,8 +53600,8 @@ static void *my_Realloc_cb(void *ptr, size_t size)
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t memcb_test(void)
 {
     wc_test_ret_t ret = 0;
-#if !defined(WOLFSSL_NO_MALLOC) && !defined(WOLFSSL_LINUXKM) && \
-    !defined(WOLFSSL_STATIC_MEMORY)
+#if !defined(WOLFSSL_NO_MALLOC) && !defined(WOLFSSL_NO_REALLOC) && \
+    !defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_STATIC_MEMORY)
     byte* b = NULL;
 #endif
     wolfSSL_Malloc_cb  mc;
@@ -53614,8 +53614,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t memcb_test(void)
     if (ret != 0)
         return WC_TEST_RET_ENC_EC(ret);
 
-#if !defined(WOLFSSL_NO_MALLOC) && !defined(WOLFSSL_LINUXKM) && \
-    !defined(WOLFSSL_STATIC_MEMORY)
+#if !defined(WOLFSSL_NO_MALLOC) && !defined(WOLFSSL_NO_REALLOC) && \
+    !defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_STATIC_MEMORY)
 
     /* test realloc */
     b = (byte*)XREALLOC(b, 1024, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -53650,8 +53650,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t memcb_test(void)
         ret = WC_TEST_RET_ENC_NC;
 #endif /* !WOLFSSL_NO_MALLOC */
 
-#if !defined(WOLFSSL_NO_MALLOC) && !defined(WOLFSSL_LINUXKM) && \
-    !defined(WOLFSSL_STATIC_MEMORY)
+#if !defined(WOLFSSL_NO_MALLOC) && !defined(WOLFSSL_NO_REALLOC) && \
+    !defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_STATIC_MEMORY)
 exit_memcb:
 
     /* reset malloc/free/realloc counts */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -17917,9 +17917,9 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t memory_test(void)
         #endif
         if (b)
             XFREE(b, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-        if ((b == NULL)
+        if (b == NULL
         #ifndef WOLFSSL_NO_REALLOC
-                || (c == NULL)
+                || c == NULL
         #endif
         ) {
             return WC_TEST_RET_ENC_ERRNO;


### PR DESCRIPTION
# Description

* Fixes for building the compatibility layer with `WOLFSSL_NO_REALLOC`.

* Improve benchmark FreeRTOS default tick rate logic. For example Xilinx FreeRTOS uses 10ms tick (not default 1ms), so include `configTICK_RATE_HZ` in calculation if available. 

* Fix test.c warning around too many parens with no realloc.

ZD 18224

# Testing

```
./configure --enable-opensslall CFLAGS="-DWOLFSSL_NO_REALLOC" && make check
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
