### PR TITLE
Dilithium: fixes

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -28394,7 +28394,8 @@ int DecodePrivateKey(WOLFSSL *ssl, word32* length)
         }
     }
 #endif /* HAVE_FALCON */
-#if defined(HAVE_DILITHIUM) && !defined(WOLFSSL_DILITHIUM_NO_SIGN)
+#if defined(HAVE_DILITHIUM) && !defined(WOLFSSL_DILITHIUM_NO_SIGN) && \
+    !defined(WOLFSSL_DILITHIUM_NO_ASN1)
     #if !defined(NO_RSA) || defined(HAVE_ECC)
         FreeKey(ssl, ssl->hsType, (void**)&ssl->hsKey);
     #endif

--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -942,7 +942,8 @@ static int ProcessBufferTryDecodeFalcon(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
 }
 #endif
 
-#if defined(HAVE_DILITHIUM) && !defined(WOLFSSL_DILITHIUM_NO_SIGN)
+#if defined(HAVE_DILITHIUM) && !defined(WOLFSSL_DILITHIUM_NO_SIGN) && \
+    !defined(WOLFSSL_DILITHIUM_NO_ASN1)
 /* See if DER data is an Dilithium private key.
  *
  * Checks size meets minimum Falcon key size.
@@ -1151,7 +1152,8 @@ static int ProcessBufferTryDecode(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
             keyType, keySz);
     }
 #endif /* HAVE_FALCON */
-#if defined(HAVE_DILITHIUM) && !defined(WOLFSSL_DILITHIUM_NO_SIGN)
+#if defined(HAVE_DILITHIUM) && !defined(WOLFSSL_DILITHIUM_NO_SIGN) && \
+    !defined(WOLFSSL_DILITHIUM_NO_ASN1)
     /* Try Falcon if key format is Dilithium level 2k, 3k or 5k or yet unknown.
      */
     if ((ret == 0) && ((*keyFormat == 0) || (*keyFormat == DILITHIUM_LEVEL2k) ||

--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -7074,8 +7074,7 @@ int wc_dilithium_export_key(dilithium_key* key, byte* priv, word32 *privSz,
 
 #ifndef WOLFSSL_DILITHIUM_NO_ASN1
 
-#if defined(WOLFSSL_DILITHIUM_PRIVATE_KEY) && \
-    defined(WOLFSSL_DILITHIUM_PUBLIC_KEY)
+#if defined(WOLFSSL_DILITHIUM_PRIVATE_KEY)
 
 /* Decode the DER encoded Dilithium key.
  *
@@ -7135,13 +7134,13 @@ int wc_Dilithium_PrivateKeyDecode(const byte* input, word32* inOutIdx,
             privKeyLen -= DILITHIUM_LEVEL2_PUB_KEY_SIZE;
         }
         else if ((key->level == 3) &&
-                 (privKeyLen != DILITHIUM_LEVEL3_PRV_KEY_SIZE)) {
+                 (privKeyLen == DILITHIUM_LEVEL3_PRV_KEY_SIZE)) {
             pubKey = privKey + DILITHIUM_LEVEL3_KEY_SIZE;
             pubKeyLen = DILITHIUM_LEVEL3_PUB_KEY_SIZE;
             privKeyLen -= DILITHIUM_LEVEL3_PUB_KEY_SIZE;
         }
         else if ((key->level == 5) &&
-                 (privKeyLen != DILITHIUM_LEVEL5_PRV_KEY_SIZE)) {
+                 (privKeyLen == DILITHIUM_LEVEL5_PRV_KEY_SIZE)) {
             pubKey = privKey + DILITHIUM_LEVEL5_KEY_SIZE;
             pubKeyLen = DILITHIUM_LEVEL5_PUB_KEY_SIZE;
             privKeyLen -= DILITHIUM_LEVEL5_PUB_KEY_SIZE;
@@ -7150,16 +7149,24 @@ int wc_Dilithium_PrivateKeyDecode(const byte* input, word32* inOutIdx,
 
     if (ret == 0) {
         /* Check whether public key data was found. */
-        if (pubKeyLen == 0) {
+#if defined(WOLFSSL_DILITHIUM_PUBLIC_KEY)
+        if (pubKeyLen == 0)
+#endif
+        {
             /* No public key data, only import private key data. */
             ret = wc_dilithium_import_private(privKey, privKeyLen, key);
         }
+#if defined(WOLFSSL_DILITHIUM_PUBLIC_KEY)
         else {
             /* Import private and public key data. */
             ret = wc_dilithium_import_key(privKey, privKeyLen, pubKey,
                 pubKeyLen, key);
         }
+#endif
     }
+
+    (void)pubKey;
+    (void)pubKeyLen;
 
     return ret;
 }

--- a/wolfssl/wolfcrypt/dilithium.h
+++ b/wolfssl/wolfcrypt/dilithium.h
@@ -675,8 +675,7 @@ int wc_dilithium_export_key(dilithium_key* key, byte* priv, word32 *privSz,
 #endif
 
 #ifndef WOLFSSL_DILITHIUM_NO_ASN1
-#if defined(WOLFSSL_DILITHIUM_PRIVATE_KEY) && \
-    defined(WOLFSSL_DILITHIUM_PUBLIC_KEY)
+#if defined(WOLFSSL_DILITHIUM_PRIVATE_KEY)
 WOLFSSL_API int wc_Dilithium_PrivateKeyDecode(const byte* input,
     word32* inOutIdx, dilithium_key* key, word32 inSz);
 #endif
@@ -689,8 +688,7 @@ WOLFSSL_API int wc_Dilithium_PublicKeyDecode(const byte* input,
 WOLFSSL_API int wc_Dilithium_PublicKeyToDer(dilithium_key* key, byte* output,
     word32 inLen, int withAlg);
 #endif
-#if defined(WOLFSSL_DILITHIUM_PRIVATE_KEY) && \
-    defined(WOLFSSL_DILITHIUM_PUBLIC_KEY)
+#if defined(WOLFSSL_DILITHIUM_PRIVATE_KEY)
 WOLFSSL_API int wc_Dilithium_KeyToDer(dilithium_key* key, byte* output,
     word32 inLen);
 #endif


### PR DESCRIPTION
# Description

TLS uses DER API now and needs to be protected with the right #ifdefs. Do the right check of size in wc_Dilithium_PrivateKeyDecode(). Don't require public key when doing private DER.

# Testing

Regression tested Dilithium.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
