### PR TITLE
Fix ASAN warning with compatibility layer cipher list parsing

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -26526,8 +26526,11 @@ static int ParseCipherList(Suites* suites,
         return 0;
     }
 
-    if (next[0] == 0 || XSTRCMP(next, "ALL") == 0 ||
-        XSTRCMP(next, "DEFAULT") == 0 || XSTRCMP(next, "HIGH") == 0) {
+    if (next[0] == '\0' ||
+        XSTRCMP(next, "ALL") == 0 ||
+        XSTRCMP(next, "DEFAULT") == 0 ||
+        XSTRCMP(next, "HIGH") == 0)
+    {
         /* Add all ciphersuites except anonymous and null ciphers. Prefer RSA */
 #ifndef NO_RSA
         haveRSA = 1;
@@ -26539,7 +26542,8 @@ static int ParseCipherList(Suites* suites,
                 0,
 #endif
                 haveRSA, 1, 1, !haveRSA, 1, haveRSA, !haveRSA, 1, 1, 0, 0,
-                side);
+                side
+        );
         return 1; /* wolfSSL default */
     }
 
@@ -26559,6 +26563,8 @@ static int ParseCipherList(Suites* suites,
             if (length > currLen) {
                 length = currLen;
             }
+            if (currLen == 0)
+                break;
         }
 
     #if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)
@@ -26880,7 +26886,7 @@ static int ParseCipherList(Suites* suites,
             }
         }
     }
-    while (next++); /* ++ needed to skip ':' */
+    while (next++); /* increment to skip ':' */
 
     if (ret) {
         int keySz = 0;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -8354,6 +8354,7 @@ int tlsShowSecrets(WOLFSSL* ssl, void* secret, int secretSz,
 /*
  * check if the list has TLS13 and pre-TLS13 suites
  * @param list cipher suite list that user want to set
+ *         (caller required to check for NULL)
  * @return mixed: 0, only pre-TLS13: 1, only TLS13: 2
  */
 static int CheckcipherList(const char* list)
@@ -8376,6 +8377,9 @@ static int CheckcipherList(const char* list)
 
         current_length = (!next) ? (word32)XSTRLEN(current)
                                  : (word32)(next - current);
+        if (current_length == 0) {
+            break;
+        }
 
         if (current_length < length) {
             length = current_length;
@@ -8383,8 +8387,10 @@ static int CheckcipherList(const char* list)
         XMEMCPY(name, current, length);
         name[length] = 0;
 
-        if (XSTRCMP(name, "ALL") == 0 || XSTRCMP(name, "DEFAULT") == 0 ||
-                XSTRCMP(name, "HIGH") == 0) {
+        if (XSTRCMP(name, "ALL") == 0 ||
+            XSTRCMP(name, "DEFAULT") == 0 ||
+            XSTRCMP(name, "HIGH") == 0)
+        {
             findTLSv13Suites = 1;
             findbeforeSuites = 1;
             break;
@@ -8412,7 +8418,7 @@ static int CheckcipherList(const char* list)
                 subStrNext = XSTRSTR(subStr, "+");
 
                 if ((XSTRCMP(subStr, "ECDHE") == 0) ||
-                        (XSTRCMP(subStr, "RSA") == 0)) {
+                    (XSTRCMP(subStr, "RSA") == 0)) {
                     return 0;
                 }
 
@@ -8428,7 +8434,7 @@ static int CheckcipherList(const char* list)
             return 0;
         }
     }
-    while (next++); /* ++ needed to skip ':' */
+    while (next++); /* increment to skip ':' */
 
     if (findTLSv13Suites == 0 && findbeforeSuites == 1) {
         ret = 1;/* only before TLSv13 suites */

--- a/tests/api.c
+++ b/tests/api.c
@@ -581,7 +581,8 @@ static int testDevId = INVALID_DEVID;
 #endif
 
 #if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && !defined(NO_RSA) && \
-    !defined(NO_WOLFSSL_SERVER) && !defined(NO_WOLFSSL_CLIENT)
+    !defined(NO_WOLFSSL_SERVER) && !defined(NO_WOLFSSL_CLIENT) && \
+    !defined(WOLFSSL_TIRTOS)
 #define HAVE_SSL_MEMIO_TESTS_DEPENDENCIES
 #endif
 
@@ -8820,8 +8821,7 @@ static int test_wolfSSL_reuse_WOLFSSLobj(void)
     return EXPECT_RESULT();
 }
 
-#if defined(OPENSSL_EXTRA) && !defined(WOLFSSL_TIRTOS) && \
-    defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES)
+#if defined(OPENSSL_EXTRA) && defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES)
 static int test_wolfSSL_CTX_verifyDepth_ServerClient_1_ctx_ready(
     WOLFSSL_CTX* ctx)
 {
@@ -8835,8 +8835,7 @@ static int test_wolfSSL_CTX_verifyDepth_ServerClient_1_ctx_ready(
 static int test_wolfSSL_CTX_verifyDepth_ServerClient_1(void)
 {
     EXPECT_DECLS;
-#if defined(OPENSSL_EXTRA) && !defined(WOLFSSL_TIRTOS) && \
-    defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES)
+#if defined(OPENSSL_EXTRA) && defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES)
     test_ssl_cbf client_cbf;
     test_ssl_cbf server_cbf;
 
@@ -8855,14 +8854,12 @@ static int test_wolfSSL_CTX_verifyDepth_ServerClient_1(void)
 
     ExpectIntEQ(client_cbf.return_code, TEST_SUCCESS);
     ExpectIntEQ(server_cbf.return_code, TEST_SUCCESS);
-#endif /* OPENSSL_EXTRA && !WOLFSSL_TIRTOS &&
-        * HAVE_SSL_MEMIO_TESTS_DEPENDENCIES */
+#endif /* OPENSSL_EXTRA && HAVE_SSL_MEMIO_TESTS_DEPENDENCIES */
 
     return EXPECT_RESULT();
 }
 
-#if defined(OPENSSL_EXTRA) && !defined(WOLFSSL_TIRTOS) && \
-    defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES)
+#if defined(OPENSSL_EXTRA) && defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES)
 static int test_wolfSSL_CTX_verifyDepth_ServerClient_2_ctx_ready(
     WOLFSSL_CTX* ctx)
 {
@@ -8876,8 +8873,7 @@ static int test_wolfSSL_CTX_verifyDepth_ServerClient_2_ctx_ready(
 static int test_wolfSSL_CTX_verifyDepth_ServerClient_2(void)
 {
     EXPECT_DECLS;
-#if defined(OPENSSL_EXTRA) && !defined(WOLFSSL_TIRTOS) && \
-    defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES)
+#if defined(OPENSSL_EXTRA) && defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES)
     test_ssl_cbf client_cbf;
     test_ssl_cbf server_cbf;
 
@@ -8900,14 +8896,12 @@ static int test_wolfSSL_CTX_verifyDepth_ServerClient_2(void)
 
     ExpectIntEQ(client_cbf.return_code, TEST_SUCCESS);
     ExpectIntEQ(server_cbf.return_code, TEST_SUCCESS);
-#endif /* OPENSSL_EXTRA && !WOLFSSL_TIRTOS &&
-        * HAVE_SSL_MEMIO_TESTS_DEPENDENCIES */
+#endif /* OPENSSL_EXTRA && HAVE_SSL_MEMIO_TESTS_DEPENDENCIES */
 
     return EXPECT_RESULT();
 }
 
-#if defined(OPENSSL_EXTRA) && !defined(WOLFSSL_TIRTOS) && \
-    defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES)
+#if defined(OPENSSL_EXTRA) && defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES)
 static int test_wolfSSL_CTX_verifyDepth_ServerClient_3_ctx_ready(
     WOLFSSL_CTX* ctx)
 {
@@ -8921,8 +8915,7 @@ static int test_wolfSSL_CTX_verifyDepth_ServerClient_3_ctx_ready(
 static int test_wolfSSL_CTX_verifyDepth_ServerClient_3(void)
 {
     EXPECT_DECLS;
-#if defined(OPENSSL_EXTRA) && !defined(WOLFSSL_TIRTOS) && \
-    defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES)
+#if defined(OPENSSL_EXTRA) && defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES)
     test_ssl_cbf client_cbf;
     test_ssl_cbf server_cbf;
 
@@ -8947,15 +8940,14 @@ static int test_wolfSSL_CTX_verifyDepth_ServerClient_3(void)
     ExpectIntEQ(server_cbf.return_code, TEST_FAIL);
     ExpectIntEQ(client_cbf.last_err, MAX_CHAIN_ERROR);
     ExpectIntEQ(server_cbf.last_err, FATAL_ERROR);
-#endif /* OPENSSL_EXTRA && !WOLFSSL_TIRTOS &&
-        * HAVE_SSL_MEMIO_TESTS_DEPENDENCIES */
+#endif /* OPENSSL_EXTRA && HAVE_SSL_MEMIO_TESTS_DEPENDENCIES */
 
     return EXPECT_RESULT();
 }
 
 #if defined(OPENSSL_ALL) && defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && \
-    !defined(WOLFSSL_TIRTOS) && !defined(NO_AES) && !defined(WOLFSSL_NO_TLS12) \
-    && !defined(NO_SHA256) && defined(HAVE_ECC)
+    !defined(WOLFSSL_NO_TLS12) && \
+    defined(HAVE_ECC) && !defined(NO_AES) && !defined(NO_SHA256)
 static int test_wolfSSL_CTX_set_cipher_list_server_ctx_ready(WOLFSSL_CTX* ctx)
 {
     EXPECT_DECLS;
@@ -8975,8 +8967,9 @@ static int test_wolfSSL_CTX_set_cipher_list(void)
 {
     EXPECT_DECLS;
 #if defined(OPENSSL_ALL) && defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && \
-    !defined(WOLFSSL_TIRTOS) && !defined(NO_AES) && !defined(WOLFSSL_NO_TLS12) \
-    && !defined(NO_SHA256) && defined(HAVE_ECC)
+    defined(HAVE_ECC) && !defined(NO_AES) && !defined(NO_SHA256)
+
+    #if !defined(WOLFSSL_NO_TLS12)
     WOLFSSL_CTX* ctxClient = NULL;
     WOLFSSL*     sslClient = NULL;
     test_ssl_cbf client_cbf;
@@ -8998,7 +8991,8 @@ static int test_wolfSSL_CTX_set_cipher_list(void)
 
     /* check with cipher string that has '+' */
     ExpectNotNull((ctxClient = wolfSSL_CTX_new(wolfTLSv1_2_client_method())));
-    ExpectTrue(wolfSSL_CTX_set_cipher_list(ctxClient, "ECDHE+AESGCM"));
+    /* Use trailing : with nothing to test for ASAN */
+    ExpectTrue(wolfSSL_CTX_set_cipher_list(ctxClient, "ECDHE+AESGCM:"));
     ExpectNotNull((sslClient = wolfSSL_new(ctxClient)));
 
     /* check for the existence of an ECDHE ECDSA cipher suite */
@@ -9026,6 +9020,8 @@ static int test_wolfSSL_CTX_set_cipher_list(void)
 
     wolfSSL_free(sslClient);
     wolfSSL_CTX_free(ctxClient);
+
+    #endif /* !WOLFSSL_NO_TLS12 */
 #endif
     return EXPECT_RESULT();
 }


### PR DESCRIPTION
# Description

* Fix for ASAN warning with compatibility layer cipher lists in `ParseCipherList` and `CheckcipherList`.

```
wolfssl/src/ssl.c:11892:16: runtime error: applying non-zero offset 1 to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior wolfssl/src/ssl.c:11892:16 in

wolfssl/src/internal.c:26632:16: runtime error: applying non-zero offset 1 to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior wolfssl/src/internal.c:26632:16 in
```

ZD 18175

* Added test case for ASAN to trigger NULL + 1 warning. 
* Cleanup messy `WOLFSSL_TIRTOS` in api.c.

# Testing

`./configure CC="clang -fsanitize=address" --enable-all && make check`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
