### PR TITLE
Sha3.c wc_Sha3Update and  wc_Sha3Final Hash Type Change

### DIFF
--- a/wolfcrypt/src/sha3.c
+++ b/wolfcrypt/src/sha3.c
@@ -806,7 +806,7 @@ static int Sha3Final(wc_Sha3* sha3, byte padChar, byte* hash, byte p, word32 l)
  * devId  Device identifier for asynchronous operation.
  * returns 0 on success.
  */
-static int wc_InitSha3(wc_Sha3* sha3, int type, void* heap, int devId)
+static int wc_InitSha3(wc_Sha3* sha3, void* heap, int devId)
 {
     int ret = 0;
 
@@ -823,12 +823,9 @@ static int wc_InitSha3(wc_Sha3* sha3, int type, void* heap, int devId)
                         WOLFSSL_ASYNC_MARKER_SHA3, sha3->heap, devId);
 #elif defined(WOLF_CRYPTO_CB)
     sha3->devId = devId;
-    sha3->type = type;
-
 #endif /* WOLFSSL_ASYNC_CRYPT */
 
     (void)devId;
-    (void)type;
 
     return ret;
 }
@@ -859,7 +856,15 @@ static int wc_Sha3Update(wc_Sha3* sha3, const byte* data, word32 len, byte p)
     if (sha3->devId != INVALID_DEVID)
     #endif
     {
-        ret = wc_CryptoCb_Sha3Hash(sha3, sha3->type, data, len, NULL);
+        int hash_type = WC_HASH_TYPE_NONE;
+        switch (p) {
+            case WC_SHA3_224_COUNT: hash_type = WC_HASH_TYPE_SHA3_224; break;
+            case WC_SHA3_256_COUNT: hash_type = WC_HASH_TYPE_SHA3_256; break;
+            case WC_SHA3_384_COUNT: hash_type = WC_HASH_TYPE_SHA3_384; break;
+            case WC_SHA3_512_COUNT: hash_type = WC_HASH_TYPE_SHA3_512; break;
+            default: return BAD_FUNC_ARG;
+        }
+        ret = wc_CryptoCb_Sha3Hash(sha3, hash_type, data, len, NULL);
         if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
@@ -905,7 +910,15 @@ static int wc_Sha3Final(wc_Sha3* sha3, byte* hash, byte p, byte len)
     if (sha3->devId != INVALID_DEVID)
     #endif
     {
-        ret = wc_CryptoCb_Sha3Hash(sha3, sha3->type, NULL, 0, hash);
+        int hash_type = WC_HASH_TYPE_NONE;
+        switch (p) {
+            case WC_SHA3_224_COUNT: hash_type = WC_HASH_TYPE_SHA3_224; break;
+            case WC_SHA3_256_COUNT: hash_type = WC_HASH_TYPE_SHA3_256; break;
+            case WC_SHA3_384_COUNT: hash_type = WC_HASH_TYPE_SHA3_384; break;
+            case WC_SHA3_512_COUNT: hash_type = WC_HASH_TYPE_SHA3_512; break;
+            default: return BAD_FUNC_ARG;
+        }
+        ret = wc_CryptoCb_Sha3Hash(sha3, hash_type, NULL, 0, hash);
         if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
@@ -1012,7 +1025,7 @@ static int wc_Sha3GetHash(wc_Sha3* sha3, byte* hash, byte p, byte len)
  */
 int wc_InitSha3_224(wc_Sha3* sha3, void* heap, int devId)
 {
-    return wc_InitSha3(sha3, WC_HASH_TYPE_SHA3_224, heap, devId);
+    return wc_InitSha3(sha3, heap, devId);
 }
 
 /* Update the SHA3-224 hash state with message data.
@@ -1084,7 +1097,7 @@ int wc_Sha3_224_Copy(wc_Sha3* src, wc_Sha3* dst)
  */
 int wc_InitSha3_256(wc_Sha3* sha3, void* heap, int devId)
 {
-    return wc_InitSha3(sha3, WC_HASH_TYPE_SHA3_256, heap, devId);
+    return wc_InitSha3(sha3, heap, devId);
 }
 
 /* Update the SHA3-256 hash state with message data.
@@ -1156,7 +1169,7 @@ int wc_Sha3_256_Copy(wc_Sha3* src, wc_Sha3* dst)
  */
 int wc_InitSha3_384(wc_Sha3* sha3, void* heap, int devId)
 {
-    return wc_InitSha3(sha3, WC_HASH_TYPE_SHA3_384, heap, devId);
+    return wc_InitSha3(sha3, heap, devId);
 }
 
 /* Update the SHA3-384 hash state with message data.
@@ -1228,7 +1241,7 @@ int wc_Sha3_384_Copy(wc_Sha3* src, wc_Sha3* dst)
  */
 int wc_InitSha3_512(wc_Sha3* sha3, void* heap, int devId)
 {
-    return wc_InitSha3(sha3, WC_HASH_TYPE_SHA3_512, heap, devId);
+    return wc_InitSha3(sha3, heap, devId);
 }
 
 /* Update the SHA3-512 hash state with message data.
@@ -1317,7 +1330,7 @@ int wc_Sha3_GetFlags(wc_Sha3* sha3, word32* flags)
  */
 int wc_InitShake128(wc_Shake* shake, void* heap, int devId)
 {
-    return wc_InitSha3(shake, WC_HASH_TYPE_SHAKE128, heap, devId);
+    return wc_InitSha3(shake, heap, devId);
 }
 
 /* Update the SHAKE128 hash state with message data.
@@ -1461,7 +1474,7 @@ int wc_Shake128_Copy(wc_Shake* src, wc_Shake* dst)
  */
 int wc_InitShake256(wc_Shake* shake, void* heap, int devId)
 {
-    return wc_InitSha3(shake, WC_HASH_TYPE_SHAKE256, heap, devId);
+    return wc_InitSha3(shake, heap, devId);
 }
 
 /* Update the SHAKE256 hash state with message data.

--- a/wolfssl/wolfcrypt/sha3.h
+++ b/wolfssl/wolfcrypt/sha3.h
@@ -126,7 +126,6 @@ struct wc_Sha3 {
 
 #ifdef WOLF_CRYPTO_CB
     int    devId;
-    int    type; /* enum wc_HashType */
 #endif
 
 #ifdef WC_C_DYNAMIC_FALLBACK


### PR DESCRIPTION
# Description

Reverts changes to `wc_Sha3Update` and `wc_Sha3Final`, so that crypto callback hash type is determined in the processing functions in sha3.c. 

# Testing

```
./configure --enable-cryptocb --enable-sha3 CFLAGS="-DDEBUG_CRYPTOCB" --enable-debug
make 
./wolfcrypt/test/testwolfcrypt
```