### PR TITLE
Stop stripping out the sequence header on the AltSigAlg extension.

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -20983,6 +20983,7 @@ static int DecodeAltSigAlg(const byte* input, int sz, DecodedCert* cert)
         (void)cert;
     }
 
+    /* We do this to make sure the format of the extension is correct. */
     if (ret == 0) {
         GetASN_OID(&dataASN[ALTSIG_ALGOID_OID], oidSigType);
 
@@ -20992,8 +20993,8 @@ static int DecodeAltSigAlg(const byte* input, int sz, DecodedCert* cert)
     }
 
     if (ret == 0) {
-        cert->altSigAlgDer = dataASN[ALTSIG_ALGOID_SEQ].data.u8;
-        cert->altSigAlgLen = dataASN[ALTSIG_ALGOID_SEQ].length;
+        cert->altSigAlgDer = (byte *)input;
+        cert->altSigAlgLen = sz;
         cert->altSigAlgOID = dataASN[ALTSIG_ALGOID_OID].data.oid.sum;
     }
 


### PR DESCRIPTION
Fixes a problem found during interop testing. 

# Testing
Dumped the preTBS and inspected the extension. 