### PR TITLE
Dilithium: fixes

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -34565,6 +34565,7 @@ static int test_wc_dilithium_make_key_from_seed(void)
     ExpectIntEQ(XMEMCMP(key->k, sk_87, sizeof(sk_87)), 0);
 #endif
 
+    wc_dilithium_free(key);
     XFREE(key, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
     return EXPECT_RESULT();
@@ -36710,6 +36711,7 @@ static int test_wc_dilithium_verify_kats(void)
     ExpectIntEQ(res, 1);
 #endif
 
+    wc_dilithium_free(key);
     XFREE(key, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
     return EXPECT_RESULT();

--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -2825,8 +2825,7 @@ static int dilithium_check_low(const sword32* a, sword32 hi)
     return ret;
 }
 
-#if (!defined(WOLFSSL_DILITHIUM_NO_VERIFY) && \
-     !defined(WOLFSSL_DILITHIUM_VERIFY_SMALL_MEM)) || \
+#if !defined(WOLFSSL_DILITHIUM_NO_VERIFY) || \
     (!defined(WOLFSSL_DILITHIUM_NO_SIGN) && \
      !defined(WOLFSSL_DILITHIUM_SIGN_SMALL_MEM))
 /* Check that the values of the vector are in range.


### PR DESCRIPTION
# Description

Fix inclusion of functions dilithium_vec_check_low() in build:-
  --enable-dilithium=verify-only,44,65,87
CFLAGS=-DWOLFSSL_DILITHIUM_VERIFY_SMALL_MEM
Fix memory leaks in unit.test:
  --enable-dilithium CFLAGS=-DWC_DILITHIUM_CACHE_MATRIX_A 'CC=clang -fsanitize=address'

# Testing

./configure --enable-dilithium=verify-only,44,65,87
make

./configure --enable-dilithium CFLAGS=-DWC_DILITHIUM_CACHE_MATRIX_A 'CC=clang -fsanitize=address'
make
./tests/unit.test

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
