### PR TITLE
Add Coverity scan workflow

### DIFF
--- a/.github/workflows/coverity-scan-fixes.yml
+++ b/.github/workflows/coverity-scan-fixes.yml
@@ -1,0 +1,40 @@
+name: Coverity Scan master branch on a weekly basis
+
+#on:
+#  workflow_dispatch:
+#  schedule:
+#    - cron: "7 3 * * 3"
+on:
+  push:
+    branches: [ 'master', 'main', 'release/**' ]
+
+jobs:
+  coverity:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: master
+
+    - name: Configure wolfSSL
+      run: |
+        ./autogen.sh
+        ./configure --enable-all
+
+    - name: Check secrets
+      env:
+        token_var: ${{ secrets.COVERITY_SCAN_TOKEN }}
+        email_var: ${{ secrets.COVERITY_SCAN_EMAIL }}
+      run: |
+        token_len=${#token_var}
+        echo "$token_len"
+        email_len=${#email_var}
+        echo "$email_len"
+
+    - uses: vapier/coverity-scan-action@v1
+      with:
+        build_language: 'cxx'
+        project: "wolfSSL/wolfssl"
+        token: ${{ secrets.COVERITY_SCAN_TOKEN }}
+        email: ${{ secrets.COVERITY_SCAN_EMAIL }}
+        command: "make"

--- a/.github/workflows/coverity-scan-fixes.yml
+++ b/.github/workflows/coverity-scan-fixes.yml
@@ -1,12 +1,13 @@
 name: Coverity Scan master branch on a weekly basis
 
-#on:
-#  workflow_dispatch:
-#  schedule:
-#    - cron: "7 3 * * 3"
 on:
-  push:
-    branches: [ 'master', 'main', 'release/**' ]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0,12 * * *"
+#    - cron: "0 0 * * 1"
+#on:
+#  push:
+#    branches: [ 'master', 'main', 'release/**' ]
 
 jobs:
   coverity:


### PR DESCRIPTION
# Description

Add a workflow to generate a weekly Coverity scan. 

Relies on GitHub secrets:
```
COVERITY_SCAN_TOKEN
COVERITY_SCAN_EMAIL
```

Uses a third party workflow script:
https://github.com/vapier/coverity-scan-action

# Testing

_This is the test!!!_

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
