### PR TITLE
Poly1305 AArch64: unique naming of asm funcs

### DIFF
--- a/wolfssl/wolfcrypt/poly1305.h
+++ b/wolfssl/wolfcrypt/poly1305.h
@@ -132,9 +132,12 @@ WOLFSSL_API int wc_Poly1305_MAC(Poly1305* ctx, const byte* additional,
     word32 addSz, const byte* input, word32 sz, byte* tag, word32 tagSz);
 
 #if defined(__aarch64__ ) && defined(WOLFSSL_ARMASM)
-void poly1305_blocks(Poly1305* ctx, const unsigned char *m,
+#define poly1305_blocks     poly1305_blocks_aarch64
+#define poly1305_block      poly1305_block_aarch64
+
+void poly1305_blocks_aarch64(Poly1305* ctx, const unsigned char *m,
                             size_t bytes);
-void poly1305_block(Poly1305* ctx, const unsigned char *m);
+void poly1305_block_aarch64(Poly1305* ctx, const unsigned char *m);
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
# Description

Change function names to ensure no clash with OpenSSL.
Specifically: poly1305_blocks()

Fixes: #7724

# Testing

./configure '--disable-shared' 'LDFLAGS=--static' '--host=aarch64' 'CC=aarch64-linux-gnu-gcc' '--enable-armasm'
make
poly1305_blocks() no longer a function name in wolfSSL.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
