### PR TITLE
20240714-asn-Wconversion

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -2306,7 +2306,7 @@ int GetLength_ex(const byte* input, word32* inOutIdx, int* len, word32 maxIdx,
         }
 
         /* Check the number of bytes required are available. */
-        if ((idx + bytes) > maxIdx) {
+        if ((idx + (word32)bytes) > maxIdx) {
             WOLFSSL_MSG("GetLength - bad long length");
             return BUFFER_E;
         }


### PR DESCRIPTION
`wolfcrypt/src/asn.c`: fix `-Wconversion` in `GetLength_ex()` added in fea7a89b86.

found by and tested with `wolfssl-multi-test.sh ... defaults-cryptonly-Wconversion-intelasm-build defaults-cryptonly-Wconversion-intelasm-fips-140-3-dev-build defaults-cryptonly-Wconversion-noasm-fips-140-3-dev-build defaults-cryptonly-Wconversion-noasm-fips-140-3-dev-m32-build defaults-cryptonly-Wconversion-noasm-fips-140-3-v6-m32-build allcryptonly-Wconversion-intelasm-build defaults-cryptonly-c99-Wconversion-build allcryptonly-c99-Wconversion-build defaults-cryptonly-c99-Wconversion-m32-build allcryptonly-c99-Wconversion-m32-build defaults-cryptonly-c89-Wconversion-build defaults-cryptonly-c89-Wconversion-m32-build allcryptonly-c89-Wconversion-build allcryptonly-c89-Wconversion-m32-build cross-amd64-mingw-all-crypto-Wconversion`
