### PR TITLE
`InitSuites` Changes To Order

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -3300,17 +3300,17 @@ void InitSuites(Suites* suites, ProtocolVersion pv, int keySz, word16 haveRSA,
         return;      /* trust user settings, don't override */
 
 #ifdef WOLFSSL_TLS13
-#ifdef BUILD_TLS_AES_128_GCM_SHA256
-    if (tls1_3) {
-        suites->suites[idx++] = TLS13_BYTE;
-        suites->suites[idx++] = TLS_AES_128_GCM_SHA256;
-    }
-#endif
-
 #ifdef BUILD_TLS_AES_256_GCM_SHA384
     if (tls1_3) {
         suites->suites[idx++] = TLS13_BYTE;
         suites->suites[idx++] = TLS_AES_256_GCM_SHA384;
+    }
+#endif
+
+#ifdef BUILD_TLS_AES_128_GCM_SHA256
+    if (tls1_3) {
+        suites->suites[idx++] = TLS13_BYTE;
+        suites->suites[idx++] = TLS_AES_128_GCM_SHA256;
     }
 #endif
 


### PR DESCRIPTION
# Description

`InitSuites` changes to order making `BUILD_TLS_AES_256_GCM_SHA384` be prioritized over `BUILD_TLS_AES_128_GCM_SHA256`. Matches preference of TLS 1.2. 

# Testing

```
./configure --enable-all --enable-debug --disable-shared --enable-tls13 && make
```