### PR TITLE
PKCS#11 RSA Padding Offload

### DIFF
--- a/wolfssl/wolfcrypt/pkcs11.h
+++ b/wolfssl/wolfcrypt/pkcs11.h
@@ -138,14 +138,22 @@ extern "C" {
 #define CKA_HAS_RESET                         0x00000302UL
 
 #define CKM_RSA_PKCS_KEY_PAIR_GEN             0x00000000UL
+#define CKM_RSA_PKCS                          0x00000001UL
 #define CKM_RSA_X_509                         0x00000003UL
+#define CKM_RSA_PKCS_OAEP                     0x00000009UL
+#define CKM_RSA_PKCS_PSS                      0x0000000DUL
 #define CKM_DH_PKCS_KEY_PAIR_GEN              0x00000020UL
 #define CKM_DH_PKCS_DERIVE                    0x00000021UL
 #define CKM_MD5_HMAC                          0x00000211UL
+#define CKM_SHA_1                             0x00000220UL
 #define CKM_SHA_1_HMAC                        0x00000221UL
+#define CKM_SHA256                            0x00000250UL
 #define CKM_SHA256_HMAC                       0x00000251UL
+#define CKM_SHA224                            0x00000255UL
 #define CKM_SHA224_HMAC                       0x00000256UL
+#define CKM_SHA384                            0x00000260UL
 #define CKM_SHA384_HMAC                       0x00000261UL
+#define CKM_SHA512                            0x00000270UL
 #define CKM_SHA512_HMAC                       0x00000271UL
 #define CKM_GENERIC_SECRET_KEY_GEN            0x00000350UL
 #define CKM_EC_KEY_PAIR_GEN                   0x00001040UL
@@ -156,12 +164,19 @@ extern "C" {
 #define CKM_AES_CBC                           0x00001082UL
 #define CKM_AES_GCM                           0x00001087UL
 
+#define CKG_MGF1_SHA1 0x00000001UL
+#define CKG_MGF1_SHA224 0x00000005UL
+#define CKG_MGF1_SHA256 0x00000002UL
+#define CKG_MGF1_SHA384 0x00000003UL
+#define CKG_MGF1_SHA512 0x00000004UL
+
+
 #define CKR_OK                                0x00000000UL
 #define CKR_MECHANISM_INVALID                 0x00000070UL
 #define CKR_SIGNATURE_INVALID                 0x000000C0UL
 
 #define CKD_NULL                              0x00000001UL
-
+#define CKZ_DATA_SPECIFIED                    0x00000001UL
 
 typedef unsigned char     CK_BYTE;
 typedef CK_BYTE           CK_CHAR;
@@ -338,6 +353,26 @@ typedef struct CK_GCM_PARAMS {
     CK_ULONG          ulTagBits;
 } CK_GCM_PARAMS;
 typedef CK_GCM_PARAMS* CK_GCM_PARAMS_PTR;
+
+typedef CK_ULONG CK_RSA_PKCS_MGF_TYPE;
+
+typedef struct CK_RSA_PKCS_PSS_PARAMS {
+    CK_MECHANISM_TYPE hashAlg;
+    CK_RSA_PKCS_MGF_TYPE mgf;
+    CK_ULONG sLen;
+} CK_RSA_PKCS_PSS_PARAMS;
+typedef CK_RSA_PKCS_PSS_PARAMS *CK_RSA_PKCS_PSS_PARAMS_PTR;
+
+typedef CK_ULONG CK_RSA_PKCS_OAEP_SOURCE_TYPE;
+
+typedef struct CK_RSA_PKCS_OAEP_PARAMS {
+    CK_MECHANISM_TYPE hashAlg;
+    CK_RSA_PKCS_MGF_TYPE mgf;
+    CK_RSA_PKCS_OAEP_SOURCE_TYPE source;
+    CK_VOID_PTR pSourceData;
+    CK_ULONG ulSourceDataLen;
+} CK_RSA_PKCS_OAEP_PARAMS;
+typedef CK_RSA_PKCS_OAEP_PARAMS *CK_RSA_PKCS_OAEP_PARAMS_PTR;
 
 /* Function list types. */
 typedef struct CK_FUNCTION_LIST CK_FUNCTION_LIST;
@@ -538,4 +573,3 @@ struct CK_FUNCTION_LIST {
 #endif
 
 #endif /* _PKCS11_H_ */
-


### PR DESCRIPTION
# Description

This PR# allows tokens to perform `CKM_RSA_PKCS` (sign/encrypt), `CKM_RSA_PKCS_PSS` (sign), `CKM_RSA_PKCS_OAEP` (encrypt). These mechanims are the post-hash versions: i.e. wolfCrypt has already created the message digest.

It is for use cases where tokens do not expose `CKM_RSA_X_509`, eg., LUNA in FIPS-mode

The changes to callback and pkcs#11 can be gated by `-DWOLF_CRYPTO_CB_NOPAD -DNO_PKCS11_RSA_PAD`.

Breaks ABI? Might do so as it changes the size of some structs.

# Testing

There is a test set here: https://github.com/user-attachments/files/16215326/testing-v2.zip
It includes:
- pure software RSA test (regression checking)
- token RSA test (raw / PKCS / PKCS-PSS / PKCS-OAEP) 

Without PR - token should only see CKM_RSA_X_509.
With PR - token should see CKM_RSA_PKCS / CKM_RSA_PKCS_PSS / CKM_RSA_PKCS_OAEP

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation

# Updates
- the other two crypto callbacks are  `wc_AriaCryptoCb` and `wc_CAAM_router`:
    - Aria doesn't seem to do RSA — so is probably unaffected
    - CAAM does RSA — not clear whether it has padding capability
- `make check` now passes
- `make check` also passes when PKCS-offload is disabled (`CFLAGS=-DWOLF_CRYPTO_CB_NOPAD …`)
- `scan-build` is leaving one warning

        wolfcrypt/src/rsa.c:3179:95: warning: The left operand of '!=' is a garbage value   [core.UndefinedBinaryOperatorResult]
         3179 |         if ((type == RSA_PUBLIC_ENCRYPT || type == RSA_PRIVATE_ENCRYPT) &&  (padding->pad_type != WC_RSA_NO_PAD)) {
              |                                                                             ~~~~~~~~~~~~~~~~~ ^
        1 warning generated.
- code formatting (line length <= 80 chars)
