### PR TITLE
Cortex-M/Thumb2 ASM: fix label

### DIFF
--- a/wolfcrypt/src/port/arm/thumb2-aes-asm.S
+++ b/wolfcrypt/src/port/arm/thumb2-aes-asm.S
@@ -670,7 +670,7 @@ L_AES_invert_key_mix_loop:
 	EOR	r8, r8, r9, ROR #24
 	STR	r8, [r0], #4
 	SUBS	r11, r11, #0x1
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_AES_invert_key_mix_loop
 #else
 	BNE.W	L_AES_invert_key_mix_loop
@@ -703,13 +703,13 @@ AES_set_encrypt_key:
 	LDR	r10, L_AES_Thumb2_te
 	ADR	lr, L_AES_Thumb2_rcon
 	CMP	r1, #0x80
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BEQ	L_AES_set_encrypt_key_start_128
 #else
 	BEQ.W	L_AES_set_encrypt_key_start_128
 #endif
 	CMP	r1, #0xc0
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BEQ	L_AES_set_encrypt_key_start_192
 #else
 	BEQ.W	L_AES_set_encrypt_key_start_192
@@ -1026,7 +1026,7 @@ L_AES_encrypt_block_nr:
 	EOR	r6, r6, r10
 	EOR	r7, r7, r11
 	SUBS	r1, r1, #0x1
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_AES_encrypt_block_nr
 #else
 	BNE.W	L_AES_encrypt_block_nr
@@ -1154,13 +1154,13 @@ AES_ECB_encrypt:
 	LDR	r12, [sp, #36]
 	PUSH	{r3}
 	CMP	r12, #0xa
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BEQ	L_AES_ECB_encrypt_start_block_128
 #else
 	BEQ.W	L_AES_ECB_encrypt_start_block_128
 #endif
 	CMP	r12, #0xc
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BEQ	L_AES_ECB_encrypt_start_block_192
 #else
 	BEQ.W	L_AES_ECB_encrypt_start_block_192
@@ -1196,7 +1196,7 @@ L_AES_ECB_encrypt_loop_block_256:
 	SUBS	r2, r2, #0x10
 	ADD	lr, lr, #0x10
 	ADD	r1, r1, #0x10
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_AES_ECB_encrypt_loop_block_256
 #else
 	BNE.W	L_AES_ECB_encrypt_loop_block_256
@@ -1238,7 +1238,7 @@ L_AES_ECB_encrypt_loop_block_192:
 	SUBS	r2, r2, #0x10
 	ADD	lr, lr, #0x10
 	ADD	r1, r1, #0x10
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_AES_ECB_encrypt_loop_block_192
 #else
 	BNE.W	L_AES_ECB_encrypt_loop_block_192
@@ -1280,7 +1280,7 @@ L_AES_ECB_encrypt_loop_block_128:
 	SUBS	r2, r2, #0x10
 	ADD	lr, lr, #0x10
 	ADD	r1, r1, #0x10
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_AES_ECB_encrypt_loop_block_128
 #else
 	BNE.W	L_AES_ECB_encrypt_loop_block_128
@@ -1305,13 +1305,13 @@ AES_CBC_encrypt:
 	LDM	r9, {r4, r5, r6, r7}
 	PUSH	{r3, r9}
 	CMP	r8, #0xa
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BEQ	L_AES_CBC_encrypt_start_block_128
 #else
 	BEQ.W	L_AES_CBC_encrypt_start_block_128
 #endif
 	CMP	r8, #0xc
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BEQ	L_AES_CBC_encrypt_start_block_192
 #else
 	BEQ.W	L_AES_CBC_encrypt_start_block_192
@@ -1351,7 +1351,7 @@ L_AES_CBC_encrypt_loop_block_256:
 	SUBS	r2, r2, #0x10
 	ADD	lr, lr, #0x10
 	ADD	r1, r1, #0x10
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_AES_CBC_encrypt_loop_block_256
 #else
 	BNE.W	L_AES_CBC_encrypt_loop_block_256
@@ -1397,7 +1397,7 @@ L_AES_CBC_encrypt_loop_block_192:
 	SUBS	r2, r2, #0x10
 	ADD	lr, lr, #0x10
 	ADD	r1, r1, #0x10
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_AES_CBC_encrypt_loop_block_192
 #else
 	BNE.W	L_AES_CBC_encrypt_loop_block_192
@@ -1443,7 +1443,7 @@ L_AES_CBC_encrypt_loop_block_128:
 	SUBS	r2, r2, #0x10
 	ADD	lr, lr, #0x10
 	ADD	r1, r1, #0x10
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_AES_CBC_encrypt_loop_block_128
 #else
 	BNE.W	L_AES_CBC_encrypt_loop_block_128
@@ -1474,13 +1474,13 @@ AES_CTR_encrypt:
 	STM	r8, {r4, r5, r6, r7}
 	PUSH	{r3, r8}
 	CMP	r12, #0xa
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BEQ	L_AES_CTR_encrypt_start_block_128
 #else
 	BEQ.W	L_AES_CTR_encrypt_start_block_128
 #endif
 	CMP	r12, #0xc
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BEQ	L_AES_CTR_encrypt_start_block_192
 #else
 	BEQ.W	L_AES_CTR_encrypt_start_block_192
@@ -1524,12 +1524,12 @@ L_AES_CTR_encrypt_loop_block_256:
 	SUBS	r2, r2, #0x10
 	ADD	lr, lr, #0x10
 	ADD	r1, r1, #0x10
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_AES_CTR_encrypt_loop_block_256
 #else
 	BNE.W	L_AES_CTR_encrypt_loop_block_256
 #endif
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	B	L_AES_CTR_encrypt_end
 #else
 	B.W	L_AES_CTR_encrypt_end
@@ -1574,12 +1574,12 @@ L_AES_CTR_encrypt_loop_block_192:
 	SUBS	r2, r2, #0x10
 	ADD	lr, lr, #0x10
 	ADD	r1, r1, #0x10
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_AES_CTR_encrypt_loop_block_192
 #else
 	BNE.W	L_AES_CTR_encrypt_loop_block_192
 #endif
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	B	L_AES_CTR_encrypt_end
 #else
 	B.W	L_AES_CTR_encrypt_end
@@ -1624,7 +1624,7 @@ L_AES_CTR_encrypt_loop_block_128:
 	SUBS	r2, r2, #0x10
 	ADD	lr, lr, #0x10
 	ADD	r1, r1, #0x10
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_AES_CTR_encrypt_loop_block_128
 #else
 	BNE.W	L_AES_CTR_encrypt_loop_block_128
@@ -1750,7 +1750,7 @@ L_AES_decrypt_block_nr:
 	EOR	r6, r6, r10
 	EOR	r7, r7, r11
 	SUBS	r1, r1, #0x1
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_AES_decrypt_block_nr
 #else
 	BNE.W	L_AES_decrypt_block_nr
@@ -2138,13 +2138,13 @@ AES_ECB_decrypt:
 	MOV	r12, r2
 	ADR	r2, L_AES_Thumb2_td4
 	CMP	r8, #0xa
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BEQ	L_AES_ECB_decrypt_start_block_128
 #else
 	BEQ.W	L_AES_ECB_decrypt_start_block_128
 #endif
 	CMP	r8, #0xc
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BEQ	L_AES_ECB_decrypt_start_block_192
 #else
 	BEQ.W	L_AES_ECB_decrypt_start_block_192
@@ -2179,7 +2179,7 @@ L_AES_ECB_decrypt_loop_block_256:
 	SUBS	r12, r12, #0x10
 	ADD	lr, lr, #0x10
 	ADD	r1, r1, #0x10
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_AES_ECB_decrypt_loop_block_256
 #else
 	BNE.W	L_AES_ECB_decrypt_loop_block_256
@@ -2220,7 +2220,7 @@ L_AES_ECB_decrypt_loop_block_192:
 	SUBS	r12, r12, #0x10
 	ADD	lr, lr, #0x10
 	ADD	r1, r1, #0x10
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_AES_ECB_decrypt_loop_block_192
 #else
 	BNE.W	L_AES_ECB_decrypt_loop_block_192
@@ -2261,7 +2261,7 @@ L_AES_ECB_decrypt_loop_block_128:
 	SUBS	r12, r12, #0x10
 	ADD	lr, lr, #0x10
 	ADD	r1, r1, #0x10
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_AES_ECB_decrypt_loop_block_128
 #else
 	BNE.W	L_AES_ECB_decrypt_loop_block_128
@@ -2286,13 +2286,13 @@ AES_CBC_decrypt:
 	ADR	r2, L_AES_Thumb2_td4
 	PUSH	{r3, r4}
 	CMP	r8, #0xa
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BEQ	L_AES_CBC_decrypt_loop_block_128
 #else
 	BEQ.W	L_AES_CBC_decrypt_loop_block_128
 #endif
 	CMP	r8, #0xc
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BEQ	L_AES_CBC_decrypt_loop_block_192
 #else
 	BEQ.W	L_AES_CBC_decrypt_loop_block_192
@@ -2337,7 +2337,7 @@ L_AES_CBC_decrypt_loop_block_256:
 	SUBS	r12, r12, #0x10
 	ADD	lr, lr, #0x10
 	ADD	r1, r1, #0x10
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BEQ	L_AES_CBC_decrypt_end_odd
 #else
 	BEQ.W	L_AES_CBC_decrypt_end_odd
@@ -2382,12 +2382,12 @@ L_AES_CBC_decrypt_loop_block_256:
 	SUBS	r12, r12, #0x10
 	ADD	lr, lr, #0x10
 	ADD	r1, r1, #0x10
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_AES_CBC_decrypt_loop_block_256
 #else
 	BNE.W	L_AES_CBC_decrypt_loop_block_256
 #endif
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	B	L_AES_CBC_decrypt_end
 #else
 	B.W	L_AES_CBC_decrypt_end
@@ -2432,7 +2432,7 @@ L_AES_CBC_decrypt_loop_block_192:
 	SUBS	r12, r12, #0x10
 	ADD	lr, lr, #0x10
 	ADD	r1, r1, #0x10
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BEQ	L_AES_CBC_decrypt_end_odd
 #else
 	BEQ.W	L_AES_CBC_decrypt_end_odd
@@ -2477,12 +2477,12 @@ L_AES_CBC_decrypt_loop_block_192:
 	SUBS	r12, r12, #0x10
 	ADD	lr, lr, #0x10
 	ADD	r1, r1, #0x10
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_AES_CBC_decrypt_loop_block_192
 #else
 	BNE.W	L_AES_CBC_decrypt_loop_block_192
 #endif
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	B	L_AES_CBC_decrypt_end
 #else
 	B.W	L_AES_CBC_decrypt_end
@@ -2527,7 +2527,7 @@ L_AES_CBC_decrypt_loop_block_128:
 	SUBS	r12, r12, #0x10
 	ADD	lr, lr, #0x10
 	ADD	r1, r1, #0x10
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BEQ	L_AES_CBC_decrypt_end_odd
 #else
 	BEQ.W	L_AES_CBC_decrypt_end_odd
@@ -2572,7 +2572,7 @@ L_AES_CBC_decrypt_loop_block_128:
 	SUBS	r12, r12, #0x10
 	ADD	lr, lr, #0x10
 	ADD	r1, r1, #0x10
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_AES_CBC_decrypt_loop_block_128
 #else
 	BNE.W	L_AES_CBC_decrypt_loop_block_128
@@ -3170,7 +3170,7 @@ L_GCM_gmult_len_start_block:
 	POP	{r3}
 	SUBS	r3, r3, #0x10
 	ADD	r2, r2, #0x10
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_GCM_gmult_len_start_block
 #else
 	BNE.W	L_GCM_gmult_len_start_block
@@ -3202,13 +3202,13 @@ AES_GCM_encrypt:
 	STM	r8, {r4, r5, r6, r7}
 	PUSH	{r3, r8}
 	CMP	r12, #0xa
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BEQ	L_AES_GCM_encrypt_start_block_128
 #else
 	BEQ.W	L_AES_GCM_encrypt_start_block_128
 #endif
 	CMP	r12, #0xc
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BEQ	L_AES_GCM_encrypt_start_block_192
 #else
 	BEQ.W	L_AES_GCM_encrypt_start_block_192
@@ -3249,12 +3249,12 @@ L_AES_GCM_encrypt_loop_block_256:
 	SUBS	r2, r2, #0x10
 	ADD	lr, lr, #0x10
 	ADD	r1, r1, #0x10
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_AES_GCM_encrypt_loop_block_256
 #else
 	BNE.W	L_AES_GCM_encrypt_loop_block_256
 #endif
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	B	L_AES_GCM_encrypt_end
 #else
 	B.W	L_AES_GCM_encrypt_end
@@ -3296,12 +3296,12 @@ L_AES_GCM_encrypt_loop_block_192:
 	SUBS	r2, r2, #0x10
 	ADD	lr, lr, #0x10
 	ADD	r1, r1, #0x10
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_AES_GCM_encrypt_loop_block_192
 #else
 	BNE.W	L_AES_GCM_encrypt_loop_block_192
 #endif
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	B	L_AES_GCM_encrypt_end
 #else
 	B.W	L_AES_GCM_encrypt_end
@@ -3343,7 +3343,7 @@ L_AES_GCM_encrypt_loop_block_128:
 	SUBS	r2, r2, #0x10
 	ADD	lr, lr, #0x10
 	ADD	r1, r1, #0x10
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_AES_GCM_encrypt_loop_block_128
 #else
 	BNE.W	L_AES_GCM_encrypt_loop_block_128

--- a/wolfcrypt/src/port/arm/thumb2-aes-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-aes-asm_c.c
@@ -211,23 +211,33 @@ void AES_invert_key(unsigned char* ks, word32 rounds)
         "ADD	r10, %[ks], %[rounds], LSL #4\n\t"
         "MOV	r11, %[rounds]\n\t"
         "\n"
-    "L_AES_invert_key_loop%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_invert_key_loop:\n\t"
+#else
+    "L_AES_invert_key_loop_%=:\n\t"
+#endif
         "LDM	%[ks], {r2, r3, r4, r5}\n\t"
         "LDM	r10, {r6, r7, r8, r9}\n\t"
         "STM	r10, {r2, r3, r4, r5}\n\t"
         "STM	%[ks]!, {r6, r7, r8, r9}\n\t"
         "SUBS	r11, r11, #0x2\n\t"
         "SUB	r10, r10, #0x10\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_AES_invert_key_loop%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_invert_key_loop_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_AES_invert_key_loop\n\t"
 #else
-        "BNE.N	L_AES_invert_key_loop%=\n\t"
+        "BNE.N	L_AES_invert_key_loop_%=\n\t"
 #endif
         "SUB	%[ks], %[ks], %[rounds], LSL #3\n\t"
         "ADD	%[ks], %[ks], #0x10\n\t"
         "SUB	r11, %[rounds], #0x1\n\t"
         "\n"
-    "L_AES_invert_key_mix_loop%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_invert_key_mix_loop:\n\t"
+#else
+    "L_AES_invert_key_mix_loop_%=:\n\t"
+#endif
         "LDM	%[ks], {r2, r3, r4, r5}\n\t"
         "UBFX	r6, r2, #0, #8\n\t"
         "UBFX	r7, r2, #8, #8\n\t"
@@ -294,10 +304,12 @@ void AES_invert_key(unsigned char* ks, word32 rounds)
         "EOR	r8, r8, r9, ROR #24\n\t"
         "STR	r8, [%[ks]], #4\n\t"
         "SUBS	r11, r11, #0x1\n\t"
-#ifdef __GNUC__
-        "BNE	L_AES_invert_key_mix_loop%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_invert_key_mix_loop_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_AES_invert_key_mix_loop\n\t"
 #else
-        "BNE.W	L_AES_invert_key_mix_loop%=\n\t"
+        "BNE.W	L_AES_invert_key_mix_loop_%=\n\t"
 #endif
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
         : [ks] "+r" (ks), [rounds] "+r" (rounds),
@@ -339,16 +351,20 @@ void AES_set_encrypt_key(const unsigned char* key, word32 len, unsigned char* ks
         "MOV	r10, %[L_AES_Thumb2_te]\n\t"
         "MOV	lr, %[L_AES_Thumb2_rcon]\n\t"
         "CMP	%[len], #0x80\n\t"
-#ifdef __GNUC__
-        "BEQ	L_AES_set_encrypt_key_start_128%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_AES_set_encrypt_key_start_128_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.W	L_AES_set_encrypt_key_start_128\n\t"
 #else
-        "BEQ.W	L_AES_set_encrypt_key_start_128%=\n\t"
+        "BEQ.W	L_AES_set_encrypt_key_start_128_%=\n\t"
 #endif
         "CMP	%[len], #0xc0\n\t"
-#ifdef __GNUC__
-        "BEQ	L_AES_set_encrypt_key_start_192%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_AES_set_encrypt_key_start_192_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.W	L_AES_set_encrypt_key_start_192\n\t"
 #else
-        "BEQ.W	L_AES_set_encrypt_key_start_192%=\n\t"
+        "BEQ.W	L_AES_set_encrypt_key_start_192_%=\n\t"
 #endif
         "LDR	r4, [%[key]]\n\t"
         "LDR	r5, [%[key], #4]\n\t"
@@ -371,7 +387,11 @@ void AES_set_encrypt_key(const unsigned char* key, word32 len, unsigned char* ks
         "SUB	%[ks], %[ks], #0x10\n\t"
         "MOV	r12, #0x6\n\t"
         "\n"
-    "L_AES_set_encrypt_key_loop_256%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_set_encrypt_key_loop_256:\n\t"
+#else
+    "L_AES_set_encrypt_key_loop_256_%=:\n\t"
+#endif
         "UBFX	r4, r7, #0, #8\n\t"
         "UBFX	r5, r7, #8, #8\n\t"
         "UBFX	r6, r7, #16, #8\n\t"
@@ -414,10 +434,12 @@ void AES_set_encrypt_key(const unsigned char* key, word32 len, unsigned char* ks
         "STM	%[ks], {r4, r5, r6, r7}\n\t"
         "SUB	%[ks], %[ks], #0x10\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_AES_set_encrypt_key_loop_256%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_set_encrypt_key_loop_256_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_AES_set_encrypt_key_loop_256\n\t"
 #else
-        "BNE.N	L_AES_set_encrypt_key_loop_256%=\n\t"
+        "BNE.N	L_AES_set_encrypt_key_loop_256_%=\n\t"
 #endif
         "UBFX	r4, r7, #0, #8\n\t"
         "UBFX	r5, r7, #8, #8\n\t"
@@ -440,13 +462,19 @@ void AES_set_encrypt_key(const unsigned char* key, word32 len, unsigned char* ks
         "ADD	%[ks], %[ks], #0x10\n\t"
         "STM	%[ks], {r4, r5, r6, r7}\n\t"
         "SUB	%[ks], %[ks], #0x10\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_AES_set_encrypt_key_end%=\n\t"
+#if defined(__GNUC__)
+        "B	L_AES_set_encrypt_key_end_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_AES_set_encrypt_key_end\n\t"
 #else
-        "B.N	L_AES_set_encrypt_key_end%=\n\t"
+        "B.N	L_AES_set_encrypt_key_end_%=\n\t"
 #endif
         "\n"
-    "L_AES_set_encrypt_key_start_192%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_set_encrypt_key_start_192:\n\t"
+#else
+    "L_AES_set_encrypt_key_start_192_%=:\n\t"
+#endif
         "LDR	r4, [%[key]]\n\t"
         "LDR	r5, [%[key], #4]\n\t"
         "LDR	r6, [%[key], #8]\n\t"
@@ -464,7 +492,11 @@ void AES_set_encrypt_key(const unsigned char* key, word32 len, unsigned char* ks
         "MOV	r7, r9\n\t"
         "MOV	r12, #0x7\n\t"
         "\n"
-    "L_AES_set_encrypt_key_loop_192%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_set_encrypt_key_loop_192:\n\t"
+#else
+    "L_AES_set_encrypt_key_loop_192_%=:\n\t"
+#endif
         "UBFX	r4, r9, #0, #8\n\t"
         "UBFX	r5, r9, #8, #8\n\t"
         "UBFX	r6, r9, #16, #8\n\t"
@@ -487,10 +519,12 @@ void AES_set_encrypt_key(const unsigned char* key, word32 len, unsigned char* ks
         "EOR	r9, r9, r8\n\t"
         "STM	%[ks], {r4, r5, r6, r7, r8, r9}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_AES_set_encrypt_key_loop_192%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_set_encrypt_key_loop_192_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_AES_set_encrypt_key_loop_192\n\t"
 #else
-        "BNE.N	L_AES_set_encrypt_key_loop_192%=\n\t"
+        "BNE.N	L_AES_set_encrypt_key_loop_192_%=\n\t"
 #endif
         "UBFX	r4, r9, #0, #8\n\t"
         "UBFX	r5, r9, #8, #8\n\t"
@@ -511,13 +545,19 @@ void AES_set_encrypt_key(const unsigned char* key, word32 len, unsigned char* ks
         "EOR	r6, r6, r5\n\t"
         "EOR	r7, r7, r6\n\t"
         "STM	%[ks], {r4, r5, r6, r7}\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_AES_set_encrypt_key_end%=\n\t"
+#if defined(__GNUC__)
+        "B	L_AES_set_encrypt_key_end_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_AES_set_encrypt_key_end\n\t"
 #else
-        "B.N	L_AES_set_encrypt_key_end%=\n\t"
+        "B.N	L_AES_set_encrypt_key_end_%=\n\t"
 #endif
         "\n"
-    "L_AES_set_encrypt_key_start_128%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_set_encrypt_key_start_128:\n\t"
+#else
+    "L_AES_set_encrypt_key_start_128_%=:\n\t"
+#endif
         "LDR	r4, [%[key]]\n\t"
         "LDR	r5, [%[key], #4]\n\t"
         "LDR	r6, [%[key], #8]\n\t"
@@ -529,7 +569,11 @@ void AES_set_encrypt_key(const unsigned char* key, word32 len, unsigned char* ks
         "STM	%[ks], {r4, r5, r6, r7}\n\t"
         "MOV	r12, #0xa\n\t"
         "\n"
-    "L_AES_set_encrypt_key_loop_128%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_set_encrypt_key_loop_128:\n\t"
+#else
+    "L_AES_set_encrypt_key_loop_128_%=:\n\t"
+#endif
         "UBFX	r4, r7, #0, #8\n\t"
         "UBFX	r5, r7, #8, #8\n\t"
         "UBFX	r6, r7, #16, #8\n\t"
@@ -550,13 +594,19 @@ void AES_set_encrypt_key(const unsigned char* key, word32 len, unsigned char* ks
         "EOR	r7, r7, r6\n\t"
         "STM	%[ks], {r4, r5, r6, r7}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_AES_set_encrypt_key_loop_128%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_set_encrypt_key_loop_128_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_AES_set_encrypt_key_loop_128\n\t"
 #else
-        "BNE.N	L_AES_set_encrypt_key_loop_128%=\n\t"
+        "BNE.N	L_AES_set_encrypt_key_loop_128_%=\n\t"
 #endif
         "\n"
-    "L_AES_set_encrypt_key_end%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_set_encrypt_key_end:\n\t"
+#else
+    "L_AES_set_encrypt_key_end_%=:\n\t"
+#endif
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
         : [key] "+r" (key), [len] "+r" (len), [ks] "+r" (ks),
           [L_AES_Thumb2_te] "+r" (L_AES_Thumb2_te_c), [L_AES_Thumb2_rcon] "+r" (L_AES_Thumb2_rcon_c)
@@ -586,7 +636,11 @@ void AES_encrypt_block(const uint32_t* te, int nr, int len, const uint32_t* ks)
 
     __asm__ __volatile__ (
         "\n"
-    "L_AES_encrypt_block_nr%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_encrypt_block_nr:\n\t"
+#else
+    "L_AES_encrypt_block_nr_%=:\n\t"
+#endif
         "UBFX	r8, r5, #16, #8\n\t"
         "LSR	r11, r4, #24\n\t"
         "UBFX	lr, r6, #8, #8\n\t"
@@ -688,10 +742,12 @@ void AES_encrypt_block(const uint32_t* te, int nr, int len, const uint32_t* ks)
         "EOR	r6, r6, r10\n\t"
         "EOR	r7, r7, r11\n\t"
         "SUBS	%[nr], %[nr], #0x1\n\t"
-#ifdef __GNUC__
-        "BNE	L_AES_encrypt_block_nr%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_encrypt_block_nr_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_AES_encrypt_block_nr\n\t"
 #else
-        "BNE.W	L_AES_encrypt_block_nr%=\n\t"
+        "BNE.W	L_AES_encrypt_block_nr_%=\n\t"
 #endif
         "UBFX	r8, r5, #16, #8\n\t"
         "LSR	r11, r4, #24\n\t"
@@ -830,19 +886,27 @@ void AES_ECB_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         "PUSH	{%[ks]}\n\t"
         "CMP	r12, #0xa\n\t"
-#ifdef __GNUC__
-        "BEQ	L_AES_ECB_encrypt_start_block_128%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_AES_ECB_encrypt_start_block_128_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.W	L_AES_ECB_encrypt_start_block_128\n\t"
 #else
-        "BEQ.W	L_AES_ECB_encrypt_start_block_128%=\n\t"
+        "BEQ.W	L_AES_ECB_encrypt_start_block_128_%=\n\t"
 #endif
         "CMP	r12, #0xc\n\t"
-#ifdef __GNUC__
-        "BEQ	L_AES_ECB_encrypt_start_block_192%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_AES_ECB_encrypt_start_block_192_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.W	L_AES_ECB_encrypt_start_block_192\n\t"
 #else
-        "BEQ.W	L_AES_ECB_encrypt_start_block_192%=\n\t"
+        "BEQ.W	L_AES_ECB_encrypt_start_block_192_%=\n\t"
 #endif
         "\n"
-    "L_AES_ECB_encrypt_loop_block_256%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_ECB_encrypt_loop_block_256:\n\t"
+#else
+    "L_AES_ECB_encrypt_loop_block_256_%=:\n\t"
+#endif
         "LDR	r4, [lr]\n\t"
         "LDR	r5, [lr, #4]\n\t"
         "LDR	r6, [lr, #8]\n\t"
@@ -873,20 +937,32 @@ void AES_ECB_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "SUBS	%[len], %[len], #0x10\n\t"
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
-#ifdef __GNUC__
-        "BNE	L_AES_ECB_encrypt_loop_block_256%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_ECB_encrypt_loop_block_256_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_AES_ECB_encrypt_loop_block_256\n\t"
 #else
-        "BNE.W	L_AES_ECB_encrypt_loop_block_256%=\n\t"
+        "BNE.W	L_AES_ECB_encrypt_loop_block_256_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_AES_ECB_encrypt_end%=\n\t"
+#if defined(__GNUC__)
+        "B	L_AES_ECB_encrypt_end_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_AES_ECB_encrypt_end\n\t"
 #else
-        "B.N	L_AES_ECB_encrypt_end%=\n\t"
+        "B.N	L_AES_ECB_encrypt_end_%=\n\t"
 #endif
         "\n"
-    "L_AES_ECB_encrypt_start_block_192%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_ECB_encrypt_start_block_192:\n\t"
+#else
+    "L_AES_ECB_encrypt_start_block_192_%=:\n\t"
+#endif
         "\n"
-    "L_AES_ECB_encrypt_loop_block_192%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_ECB_encrypt_loop_block_192:\n\t"
+#else
+    "L_AES_ECB_encrypt_loop_block_192_%=:\n\t"
+#endif
         "LDR	r4, [lr]\n\t"
         "LDR	r5, [lr, #4]\n\t"
         "LDR	r6, [lr, #8]\n\t"
@@ -917,20 +993,32 @@ void AES_ECB_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "SUBS	%[len], %[len], #0x10\n\t"
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
-#ifdef __GNUC__
-        "BNE	L_AES_ECB_encrypt_loop_block_192%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_ECB_encrypt_loop_block_192_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_AES_ECB_encrypt_loop_block_192\n\t"
 #else
-        "BNE.W	L_AES_ECB_encrypt_loop_block_192%=\n\t"
+        "BNE.W	L_AES_ECB_encrypt_loop_block_192_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_AES_ECB_encrypt_end%=\n\t"
+#if defined(__GNUC__)
+        "B	L_AES_ECB_encrypt_end_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_AES_ECB_encrypt_end\n\t"
 #else
-        "B.N	L_AES_ECB_encrypt_end%=\n\t"
+        "B.N	L_AES_ECB_encrypt_end_%=\n\t"
 #endif
         "\n"
-    "L_AES_ECB_encrypt_start_block_128%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_ECB_encrypt_start_block_128:\n\t"
+#else
+    "L_AES_ECB_encrypt_start_block_128_%=:\n\t"
+#endif
         "\n"
-    "L_AES_ECB_encrypt_loop_block_128%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_ECB_encrypt_loop_block_128:\n\t"
+#else
+    "L_AES_ECB_encrypt_loop_block_128_%=:\n\t"
+#endif
         "LDR	r4, [lr]\n\t"
         "LDR	r5, [lr, #4]\n\t"
         "LDR	r6, [lr, #8]\n\t"
@@ -961,13 +1049,19 @@ void AES_ECB_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "SUBS	%[len], %[len], #0x10\n\t"
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
-#ifdef __GNUC__
-        "BNE	L_AES_ECB_encrypt_loop_block_128%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_ECB_encrypt_loop_block_128_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_AES_ECB_encrypt_loop_block_128\n\t"
 #else
-        "BNE.W	L_AES_ECB_encrypt_loop_block_128%=\n\t"
+        "BNE.W	L_AES_ECB_encrypt_loop_block_128_%=\n\t"
 #endif
         "\n"
-    "L_AES_ECB_encrypt_end%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_ECB_encrypt_end:\n\t"
+#else
+    "L_AES_ECB_encrypt_end_%=:\n\t"
+#endif
         "POP	{%[ks]}\n\t"
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
         : [in] "+r" (in), [out] "+r" (out), [len] "+r" (len), [ks] "+r" (ks), [nr] "+r" (nr),
@@ -1021,19 +1115,27 @@ void AES_CBC_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "LDM	r9, {r4, r5, r6, r7}\n\t"
         "PUSH	{%[ks], r9}\n\t"
         "CMP	r8, #0xa\n\t"
-#ifdef __GNUC__
-        "BEQ	L_AES_CBC_encrypt_start_block_128%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_AES_CBC_encrypt_start_block_128_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.W	L_AES_CBC_encrypt_start_block_128\n\t"
 #else
-        "BEQ.W	L_AES_CBC_encrypt_start_block_128%=\n\t"
+        "BEQ.W	L_AES_CBC_encrypt_start_block_128_%=\n\t"
 #endif
         "CMP	r8, #0xc\n\t"
-#ifdef __GNUC__
-        "BEQ	L_AES_CBC_encrypt_start_block_192%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_AES_CBC_encrypt_start_block_192_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.W	L_AES_CBC_encrypt_start_block_192\n\t"
 #else
-        "BEQ.W	L_AES_CBC_encrypt_start_block_192%=\n\t"
+        "BEQ.W	L_AES_CBC_encrypt_start_block_192_%=\n\t"
 #endif
         "\n"
-    "L_AES_CBC_encrypt_loop_block_256%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_CBC_encrypt_loop_block_256:\n\t"
+#else
+    "L_AES_CBC_encrypt_loop_block_256_%=:\n\t"
+#endif
         "LDR	r8, [lr]\n\t"
         "LDR	r9, [lr, #4]\n\t"
         "LDR	r10, [lr, #8]\n\t"
@@ -1068,20 +1170,32 @@ void AES_CBC_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "SUBS	%[len], %[len], #0x10\n\t"
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
-#ifdef __GNUC__
-        "BNE	L_AES_CBC_encrypt_loop_block_256%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_CBC_encrypt_loop_block_256_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_AES_CBC_encrypt_loop_block_256\n\t"
 #else
-        "BNE.W	L_AES_CBC_encrypt_loop_block_256%=\n\t"
+        "BNE.W	L_AES_CBC_encrypt_loop_block_256_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_AES_CBC_encrypt_end%=\n\t"
+#if defined(__GNUC__)
+        "B	L_AES_CBC_encrypt_end_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_AES_CBC_encrypt_end\n\t"
 #else
-        "B.N	L_AES_CBC_encrypt_end%=\n\t"
+        "B.N	L_AES_CBC_encrypt_end_%=\n\t"
 #endif
         "\n"
-    "L_AES_CBC_encrypt_start_block_192%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_CBC_encrypt_start_block_192:\n\t"
+#else
+    "L_AES_CBC_encrypt_start_block_192_%=:\n\t"
+#endif
         "\n"
-    "L_AES_CBC_encrypt_loop_block_192%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_CBC_encrypt_loop_block_192:\n\t"
+#else
+    "L_AES_CBC_encrypt_loop_block_192_%=:\n\t"
+#endif
         "LDR	r8, [lr]\n\t"
         "LDR	r9, [lr, #4]\n\t"
         "LDR	r10, [lr, #8]\n\t"
@@ -1116,20 +1230,32 @@ void AES_CBC_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "SUBS	%[len], %[len], #0x10\n\t"
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
-#ifdef __GNUC__
-        "BNE	L_AES_CBC_encrypt_loop_block_192%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_CBC_encrypt_loop_block_192_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_AES_CBC_encrypt_loop_block_192\n\t"
 #else
-        "BNE.W	L_AES_CBC_encrypt_loop_block_192%=\n\t"
+        "BNE.W	L_AES_CBC_encrypt_loop_block_192_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_AES_CBC_encrypt_end%=\n\t"
+#if defined(__GNUC__)
+        "B	L_AES_CBC_encrypt_end_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_AES_CBC_encrypt_end\n\t"
 #else
-        "B.N	L_AES_CBC_encrypt_end%=\n\t"
+        "B.N	L_AES_CBC_encrypt_end_%=\n\t"
 #endif
         "\n"
-    "L_AES_CBC_encrypt_start_block_128%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_CBC_encrypt_start_block_128:\n\t"
+#else
+    "L_AES_CBC_encrypt_start_block_128_%=:\n\t"
+#endif
         "\n"
-    "L_AES_CBC_encrypt_loop_block_128%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_CBC_encrypt_loop_block_128:\n\t"
+#else
+    "L_AES_CBC_encrypt_loop_block_128_%=:\n\t"
+#endif
         "LDR	r8, [lr]\n\t"
         "LDR	r9, [lr, #4]\n\t"
         "LDR	r10, [lr, #8]\n\t"
@@ -1164,13 +1290,19 @@ void AES_CBC_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "SUBS	%[len], %[len], #0x10\n\t"
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
-#ifdef __GNUC__
-        "BNE	L_AES_CBC_encrypt_loop_block_128%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_CBC_encrypt_loop_block_128_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_AES_CBC_encrypt_loop_block_128\n\t"
 #else
-        "BNE.W	L_AES_CBC_encrypt_loop_block_128%=\n\t"
+        "BNE.W	L_AES_CBC_encrypt_loop_block_128_%=\n\t"
 #endif
         "\n"
-    "L_AES_CBC_encrypt_end%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_CBC_encrypt_end:\n\t"
+#else
+    "L_AES_CBC_encrypt_end_%=:\n\t"
+#endif
         "POP	{%[ks], r9}\n\t"
         "STM	r9, {r4, r5, r6, r7}\n\t"
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1233,19 +1365,27 @@ void AES_CTR_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "STM	r8, {r4, r5, r6, r7}\n\t"
         "PUSH	{%[ks], r8}\n\t"
         "CMP	r12, #0xa\n\t"
-#ifdef __GNUC__
-        "BEQ	L_AES_CTR_encrypt_start_block_128%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_AES_CTR_encrypt_start_block_128_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.W	L_AES_CTR_encrypt_start_block_128\n\t"
 #else
-        "BEQ.W	L_AES_CTR_encrypt_start_block_128%=\n\t"
+        "BEQ.W	L_AES_CTR_encrypt_start_block_128_%=\n\t"
 #endif
         "CMP	r12, #0xc\n\t"
-#ifdef __GNUC__
-        "BEQ	L_AES_CTR_encrypt_start_block_192%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_AES_CTR_encrypt_start_block_192_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.W	L_AES_CTR_encrypt_start_block_192\n\t"
 #else
-        "BEQ.W	L_AES_CTR_encrypt_start_block_192%=\n\t"
+        "BEQ.W	L_AES_CTR_encrypt_start_block_192_%=\n\t"
 #endif
         "\n"
-    "L_AES_CTR_encrypt_loop_block_256%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_CTR_encrypt_loop_block_256:\n\t"
+#else
+    "L_AES_CTR_encrypt_loop_block_256_%=:\n\t"
+#endif
         "PUSH	{r1, %[len], lr}\n\t"
         "LDR	lr, [sp, #16]\n\t"
         "ADDS	r11, r7, #0x1\n\t"
@@ -1284,20 +1424,32 @@ void AES_CTR_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "SUBS	%[len], %[len], #0x10\n\t"
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
-#ifdef __GNUC__
-        "BNE	L_AES_CTR_encrypt_loop_block_256%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_CTR_encrypt_loop_block_256_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_AES_CTR_encrypt_loop_block_256\n\t"
 #else
-        "BNE.W	L_AES_CTR_encrypt_loop_block_256%=\n\t"
+        "BNE.W	L_AES_CTR_encrypt_loop_block_256_%=\n\t"
 #endif
-#ifdef __GNUC__
-        "B	L_AES_CTR_encrypt_end%=\n\t"
+#if defined(__GNUC__)
+        "B	L_AES_CTR_encrypt_end_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.W	L_AES_CTR_encrypt_end\n\t"
 #else
-        "B.W	L_AES_CTR_encrypt_end%=\n\t"
+        "B.W	L_AES_CTR_encrypt_end_%=\n\t"
 #endif
         "\n"
-    "L_AES_CTR_encrypt_start_block_192%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_CTR_encrypt_start_block_192:\n\t"
+#else
+    "L_AES_CTR_encrypt_start_block_192_%=:\n\t"
+#endif
         "\n"
-    "L_AES_CTR_encrypt_loop_block_192%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_CTR_encrypt_loop_block_192:\n\t"
+#else
+    "L_AES_CTR_encrypt_loop_block_192_%=:\n\t"
+#endif
         "PUSH	{r1, %[len], lr}\n\t"
         "LDR	lr, [sp, #16]\n\t"
         "ADDS	r11, r7, #0x1\n\t"
@@ -1336,20 +1488,32 @@ void AES_CTR_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "SUBS	%[len], %[len], #0x10\n\t"
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
-#ifdef __GNUC__
-        "BNE	L_AES_CTR_encrypt_loop_block_192%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_CTR_encrypt_loop_block_192_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_AES_CTR_encrypt_loop_block_192\n\t"
 #else
-        "BNE.W	L_AES_CTR_encrypt_loop_block_192%=\n\t"
+        "BNE.W	L_AES_CTR_encrypt_loop_block_192_%=\n\t"
 #endif
-#ifdef __GNUC__
-        "B	L_AES_CTR_encrypt_end%=\n\t"
+#if defined(__GNUC__)
+        "B	L_AES_CTR_encrypt_end_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.W	L_AES_CTR_encrypt_end\n\t"
 #else
-        "B.W	L_AES_CTR_encrypt_end%=\n\t"
+        "B.W	L_AES_CTR_encrypt_end_%=\n\t"
 #endif
         "\n"
-    "L_AES_CTR_encrypt_start_block_128%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_CTR_encrypt_start_block_128:\n\t"
+#else
+    "L_AES_CTR_encrypt_start_block_128_%=:\n\t"
+#endif
         "\n"
-    "L_AES_CTR_encrypt_loop_block_128%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_CTR_encrypt_loop_block_128:\n\t"
+#else
+    "L_AES_CTR_encrypt_loop_block_128_%=:\n\t"
+#endif
         "PUSH	{r1, %[len], lr}\n\t"
         "LDR	lr, [sp, #16]\n\t"
         "ADDS	r11, r7, #0x1\n\t"
@@ -1388,13 +1552,19 @@ void AES_CTR_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "SUBS	%[len], %[len], #0x10\n\t"
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
-#ifdef __GNUC__
-        "BNE	L_AES_CTR_encrypt_loop_block_128%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_CTR_encrypt_loop_block_128_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_AES_CTR_encrypt_loop_block_128\n\t"
 #else
-        "BNE.W	L_AES_CTR_encrypt_loop_block_128%=\n\t"
+        "BNE.W	L_AES_CTR_encrypt_loop_block_128_%=\n\t"
 #endif
         "\n"
-    "L_AES_CTR_encrypt_end%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_CTR_encrypt_end:\n\t"
+#else
+    "L_AES_CTR_encrypt_end_%=:\n\t"
+#endif
         "POP	{%[ks], r8}\n\t"
         "REV	r4, r4\n\t"
         "REV	r5, r5\n\t"
@@ -1438,7 +1608,11 @@ void AES_decrypt_block(const uint32_t* td, int nr, const uint8_t* td4)
 
     __asm__ __volatile__ (
         "\n"
-    "L_AES_decrypt_block_nr%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_decrypt_block_nr:\n\t"
+#else
+    "L_AES_decrypt_block_nr_%=:\n\t"
+#endif
         "UBFX	r8, r7, #16, #8\n\t"
         "LSR	r11, r4, #24\n\t"
         "UBFX	r12, r6, #8, #8\n\t"
@@ -1540,10 +1714,12 @@ void AES_decrypt_block(const uint32_t* td, int nr, const uint8_t* td4)
         "EOR	r6, r6, r10\n\t"
         "EOR	r7, r7, r11\n\t"
         "SUBS	%[nr], %[nr], #0x1\n\t"
-#ifdef __GNUC__
-        "BNE	L_AES_decrypt_block_nr%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_decrypt_block_nr_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_AES_decrypt_block_nr\n\t"
 #else
-        "BNE.W	L_AES_decrypt_block_nr%=\n\t"
+        "BNE.W	L_AES_decrypt_block_nr_%=\n\t"
 #endif
         "UBFX	r8, r7, #16, #8\n\t"
         "LSR	r11, r4, #24\n\t"
@@ -1717,19 +1893,27 @@ void AES_ECB_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "MOV	r12, %[len]\n\t"
         "MOV	r2, %[L_AES_Thumb2_td4]\n\t"
         "CMP	r8, #0xa\n\t"
-#ifdef __GNUC__
-        "BEQ	L_AES_ECB_decrypt_start_block_128%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_AES_ECB_decrypt_start_block_128_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.W	L_AES_ECB_decrypt_start_block_128\n\t"
 #else
-        "BEQ.W	L_AES_ECB_decrypt_start_block_128%=\n\t"
+        "BEQ.W	L_AES_ECB_decrypt_start_block_128_%=\n\t"
 #endif
         "CMP	r8, #0xc\n\t"
-#ifdef __GNUC__
-        "BEQ	L_AES_ECB_decrypt_start_block_192%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_AES_ECB_decrypt_start_block_192_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.W	L_AES_ECB_decrypt_start_block_192\n\t"
 #else
-        "BEQ.W	L_AES_ECB_decrypt_start_block_192%=\n\t"
+        "BEQ.W	L_AES_ECB_decrypt_start_block_192_%=\n\t"
 #endif
         "\n"
-    "L_AES_ECB_decrypt_loop_block_256%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_ECB_decrypt_loop_block_256:\n\t"
+#else
+    "L_AES_ECB_decrypt_loop_block_256_%=:\n\t"
+#endif
         "LDR	r4, [lr]\n\t"
         "LDR	r5, [lr, #4]\n\t"
         "LDR	r6, [lr, #8]\n\t"
@@ -1759,20 +1943,32 @@ void AES_ECB_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "SUBS	r12, r12, #0x10\n\t"
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
-#ifdef __GNUC__
-        "BNE	L_AES_ECB_decrypt_loop_block_256%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_ECB_decrypt_loop_block_256_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_AES_ECB_decrypt_loop_block_256\n\t"
 #else
-        "BNE.W	L_AES_ECB_decrypt_loop_block_256%=\n\t"
+        "BNE.W	L_AES_ECB_decrypt_loop_block_256_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_AES_ECB_decrypt_end%=\n\t"
+#if defined(__GNUC__)
+        "B	L_AES_ECB_decrypt_end_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_AES_ECB_decrypt_end\n\t"
 #else
-        "B.N	L_AES_ECB_decrypt_end%=\n\t"
+        "B.N	L_AES_ECB_decrypt_end_%=\n\t"
 #endif
         "\n"
-    "L_AES_ECB_decrypt_start_block_192%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_ECB_decrypt_start_block_192:\n\t"
+#else
+    "L_AES_ECB_decrypt_start_block_192_%=:\n\t"
+#endif
         "\n"
-    "L_AES_ECB_decrypt_loop_block_192%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_ECB_decrypt_loop_block_192:\n\t"
+#else
+    "L_AES_ECB_decrypt_loop_block_192_%=:\n\t"
+#endif
         "LDR	r4, [lr]\n\t"
         "LDR	r5, [lr, #4]\n\t"
         "LDR	r6, [lr, #8]\n\t"
@@ -1802,20 +1998,32 @@ void AES_ECB_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "SUBS	r12, r12, #0x10\n\t"
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
-#ifdef __GNUC__
-        "BNE	L_AES_ECB_decrypt_loop_block_192%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_ECB_decrypt_loop_block_192_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_AES_ECB_decrypt_loop_block_192\n\t"
 #else
-        "BNE.W	L_AES_ECB_decrypt_loop_block_192%=\n\t"
+        "BNE.W	L_AES_ECB_decrypt_loop_block_192_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_AES_ECB_decrypt_end%=\n\t"
+#if defined(__GNUC__)
+        "B	L_AES_ECB_decrypt_end_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_AES_ECB_decrypt_end\n\t"
 #else
-        "B.N	L_AES_ECB_decrypt_end%=\n\t"
+        "B.N	L_AES_ECB_decrypt_end_%=\n\t"
 #endif
         "\n"
-    "L_AES_ECB_decrypt_start_block_128%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_ECB_decrypt_start_block_128:\n\t"
+#else
+    "L_AES_ECB_decrypt_start_block_128_%=:\n\t"
+#endif
         "\n"
-    "L_AES_ECB_decrypt_loop_block_128%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_ECB_decrypt_loop_block_128:\n\t"
+#else
+    "L_AES_ECB_decrypt_loop_block_128_%=:\n\t"
+#endif
         "LDR	r4, [lr]\n\t"
         "LDR	r5, [lr, #4]\n\t"
         "LDR	r6, [lr, #8]\n\t"
@@ -1845,13 +2053,19 @@ void AES_ECB_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "SUBS	r12, r12, #0x10\n\t"
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
-#ifdef __GNUC__
-        "BNE	L_AES_ECB_decrypt_loop_block_128%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_ECB_decrypt_loop_block_128_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_AES_ECB_decrypt_loop_block_128\n\t"
 #else
-        "BNE.W	L_AES_ECB_decrypt_loop_block_128%=\n\t"
+        "BNE.W	L_AES_ECB_decrypt_loop_block_128_%=\n\t"
 #endif
         "\n"
-    "L_AES_ECB_decrypt_end%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_ECB_decrypt_end:\n\t"
+#else
+    "L_AES_ECB_decrypt_end_%=:\n\t"
+#endif
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
         : [in] "+r" (in), [out] "+r" (out), [len] "+r" (len), [ks] "+r" (ks), [nr] "+r" (nr),
           [L_AES_Thumb2_td_ecb] "+r" (L_AES_Thumb2_td_ecb_c), [L_AES_Thumb2_td4] "+r" (L_AES_Thumb2_td4_c)
@@ -1906,19 +2120,27 @@ void AES_CBC_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "MOV	r2, %[L_AES_Thumb2_td4]\n\t"
         "PUSH	{%[ks], r4}\n\t"
         "CMP	r8, #0xa\n\t"
-#ifdef __GNUC__
-        "BEQ	L_AES_CBC_decrypt_loop_block_128%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_AES_CBC_decrypt_loop_block_128_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.W	L_AES_CBC_decrypt_loop_block_128\n\t"
 #else
-        "BEQ.W	L_AES_CBC_decrypt_loop_block_128%=\n\t"
+        "BEQ.W	L_AES_CBC_decrypt_loop_block_128_%=\n\t"
 #endif
         "CMP	r8, #0xc\n\t"
-#ifdef __GNUC__
-        "BEQ	L_AES_CBC_decrypt_loop_block_192%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_AES_CBC_decrypt_loop_block_192_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.W	L_AES_CBC_decrypt_loop_block_192\n\t"
 #else
-        "BEQ.W	L_AES_CBC_decrypt_loop_block_192%=\n\t"
+        "BEQ.W	L_AES_CBC_decrypt_loop_block_192_%=\n\t"
 #endif
         "\n"
-    "L_AES_CBC_decrypt_loop_block_256%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_CBC_decrypt_loop_block_256:\n\t"
+#else
+    "L_AES_CBC_decrypt_loop_block_256_%=:\n\t"
+#endif
         "PUSH	{r1, r12, lr}\n\t"
         "LDR	r4, [lr]\n\t"
         "LDR	r5, [lr, #4]\n\t"
@@ -1958,10 +2180,12 @@ void AES_CBC_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "SUBS	r12, r12, #0x10\n\t"
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
-#ifdef __GNUC__
-        "BEQ	L_AES_CBC_decrypt_end_odd%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_AES_CBC_decrypt_end_odd_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.W	L_AES_CBC_decrypt_end_odd\n\t"
 #else
-        "BEQ.W	L_AES_CBC_decrypt_end_odd%=\n\t"
+        "BEQ.W	L_AES_CBC_decrypt_end_odd_%=\n\t"
 #endif
         "PUSH	{r1, r12, lr}\n\t"
         "LDR	r4, [lr]\n\t"
@@ -2003,18 +2227,26 @@ void AES_CBC_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "SUBS	r12, r12, #0x10\n\t"
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
-#ifdef __GNUC__
-        "BNE	L_AES_CBC_decrypt_loop_block_256%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_CBC_decrypt_loop_block_256_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_AES_CBC_decrypt_loop_block_256\n\t"
 #else
-        "BNE.W	L_AES_CBC_decrypt_loop_block_256%=\n\t"
+        "BNE.W	L_AES_CBC_decrypt_loop_block_256_%=\n\t"
 #endif
-#ifdef __GNUC__
-        "B	L_AES_CBC_decrypt_end%=\n\t"
+#if defined(__GNUC__)
+        "B	L_AES_CBC_decrypt_end_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.W	L_AES_CBC_decrypt_end\n\t"
 #else
-        "B.W	L_AES_CBC_decrypt_end%=\n\t"
+        "B.W	L_AES_CBC_decrypt_end_%=\n\t"
 #endif
         "\n"
-    "L_AES_CBC_decrypt_loop_block_192%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_CBC_decrypt_loop_block_192:\n\t"
+#else
+    "L_AES_CBC_decrypt_loop_block_192_%=:\n\t"
+#endif
         "PUSH	{r1, r12, lr}\n\t"
         "LDR	r4, [lr]\n\t"
         "LDR	r5, [lr, #4]\n\t"
@@ -2054,10 +2286,12 @@ void AES_CBC_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "SUBS	r12, r12, #0x10\n\t"
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
-#ifdef __GNUC__
-        "BEQ	L_AES_CBC_decrypt_end_odd%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_AES_CBC_decrypt_end_odd_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.W	L_AES_CBC_decrypt_end_odd\n\t"
 #else
-        "BEQ.W	L_AES_CBC_decrypt_end_odd%=\n\t"
+        "BEQ.W	L_AES_CBC_decrypt_end_odd_%=\n\t"
 #endif
         "PUSH	{r1, r12, lr}\n\t"
         "LDR	r4, [lr]\n\t"
@@ -2099,18 +2333,26 @@ void AES_CBC_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "SUBS	r12, r12, #0x10\n\t"
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
-#ifdef __GNUC__
-        "BNE	L_AES_CBC_decrypt_loop_block_192%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_CBC_decrypt_loop_block_192_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_AES_CBC_decrypt_loop_block_192\n\t"
 #else
-        "BNE.W	L_AES_CBC_decrypt_loop_block_192%=\n\t"
+        "BNE.W	L_AES_CBC_decrypt_loop_block_192_%=\n\t"
 #endif
-#ifdef __GNUC__
-        "B	L_AES_CBC_decrypt_end%=\n\t"
+#if defined(__GNUC__)
+        "B	L_AES_CBC_decrypt_end_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.W	L_AES_CBC_decrypt_end\n\t"
 #else
-        "B.W	L_AES_CBC_decrypt_end%=\n\t"
+        "B.W	L_AES_CBC_decrypt_end_%=\n\t"
 #endif
         "\n"
-    "L_AES_CBC_decrypt_loop_block_128%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_CBC_decrypt_loop_block_128:\n\t"
+#else
+    "L_AES_CBC_decrypt_loop_block_128_%=:\n\t"
+#endif
         "PUSH	{r1, r12, lr}\n\t"
         "LDR	r4, [lr]\n\t"
         "LDR	r5, [lr, #4]\n\t"
@@ -2150,10 +2392,12 @@ void AES_CBC_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "SUBS	r12, r12, #0x10\n\t"
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
-#ifdef __GNUC__
-        "BEQ	L_AES_CBC_decrypt_end_odd%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_AES_CBC_decrypt_end_odd_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.W	L_AES_CBC_decrypt_end_odd\n\t"
 #else
-        "BEQ.W	L_AES_CBC_decrypt_end_odd%=\n\t"
+        "BEQ.W	L_AES_CBC_decrypt_end_odd_%=\n\t"
 #endif
         "PUSH	{r1, r12, lr}\n\t"
         "LDR	r4, [lr]\n\t"
@@ -2195,25 +2439,37 @@ void AES_CBC_decrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "SUBS	r12, r12, #0x10\n\t"
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
-#ifdef __GNUC__
-        "BNE	L_AES_CBC_decrypt_loop_block_128%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_CBC_decrypt_loop_block_128_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_AES_CBC_decrypt_loop_block_128\n\t"
 #else
-        "BNE.W	L_AES_CBC_decrypt_loop_block_128%=\n\t"
+        "BNE.W	L_AES_CBC_decrypt_loop_block_128_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_AES_CBC_decrypt_end%=\n\t"
+#if defined(__GNUC__)
+        "B	L_AES_CBC_decrypt_end_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_AES_CBC_decrypt_end\n\t"
 #else
-        "B.N	L_AES_CBC_decrypt_end%=\n\t"
+        "B.N	L_AES_CBC_decrypt_end_%=\n\t"
 #endif
         "\n"
-    "L_AES_CBC_decrypt_end_odd%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_CBC_decrypt_end_odd:\n\t"
+#else
+    "L_AES_CBC_decrypt_end_odd_%=:\n\t"
+#endif
         "LDR	r4, [sp, #4]\n\t"
         "LDRD	r8, r9, [r4, #16]\n\t"
         "LDRD	r10, r11, [r4, #24]\n\t"
         "STRD	r8, r9, [r4]\n\t"
         "STRD	r10, r11, [r4, #8]\n\t"
         "\n"
-    "L_AES_CBC_decrypt_end%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_CBC_decrypt_end:\n\t"
+#else
+    "L_AES_CBC_decrypt_end_%=:\n\t"
+#endif
         "POP	{%[ks], r4}\n\t"
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
         : [in] "+r" (in), [out] "+r" (out), [len] "+r" (len), [ks] "+r" (ks), [nr] "+r" (nr), [iv] "+r" (iv),
@@ -2264,7 +2520,11 @@ void GCM_gmult_len(unsigned char* x, const unsigned char** m, const unsigned cha
     __asm__ __volatile__ (
         "MOV	lr, %[L_GCM_gmult_len_r]\n\t"
         "\n"
-    "L_GCM_gmult_len_start_block%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_GCM_gmult_len_start_block:\n\t"
+#else
+    "L_GCM_gmult_len_start_block_%=:\n\t"
+#endif
         "PUSH	{r3}\n\t"
         "LDR	r12, [r0, #12]\n\t"
         "LDR	%[len], [r2, #12]\n\t"
@@ -2809,10 +3069,12 @@ void GCM_gmult_len(unsigned char* x, const unsigned char** m, const unsigned cha
         "POP	{r3}\n\t"
         "SUBS	%[len], %[len], #0x10\n\t"
         "ADD	%[data], %[data], #0x10\n\t"
-#ifdef __GNUC__
-        "BNE	L_GCM_gmult_len_start_block%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_GCM_gmult_len_start_block_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_GCM_gmult_len_start_block\n\t"
 #else
-        "BNE.W	L_GCM_gmult_len_start_block%=\n\t"
+        "BNE.W	L_GCM_gmult_len_start_block_%=\n\t"
 #endif
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
         : [x] "+r" (x), [m] "+r" (m), [data] "+r" (data), [len] "+r" (len),
@@ -2867,19 +3129,27 @@ void AES_GCM_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "STM	r8, {r4, r5, r6, r7}\n\t"
         "PUSH	{%[ks], r8}\n\t"
         "CMP	r12, #0xa\n\t"
-#ifdef __GNUC__
-        "BEQ	L_AES_GCM_encrypt_start_block_128%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_AES_GCM_encrypt_start_block_128_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.W	L_AES_GCM_encrypt_start_block_128\n\t"
 #else
-        "BEQ.W	L_AES_GCM_encrypt_start_block_128%=\n\t"
+        "BEQ.W	L_AES_GCM_encrypt_start_block_128_%=\n\t"
 #endif
         "CMP	r12, #0xc\n\t"
-#ifdef __GNUC__
-        "BEQ	L_AES_GCM_encrypt_start_block_192%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_AES_GCM_encrypt_start_block_192_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.W	L_AES_GCM_encrypt_start_block_192\n\t"
 #else
-        "BEQ.W	L_AES_GCM_encrypt_start_block_192%=\n\t"
+        "BEQ.W	L_AES_GCM_encrypt_start_block_192_%=\n\t"
 #endif
         "\n"
-    "L_AES_GCM_encrypt_loop_block_256%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_GCM_encrypt_loop_block_256:\n\t"
+#else
+    "L_AES_GCM_encrypt_loop_block_256_%=:\n\t"
+#endif
         "PUSH	{r1, %[len], lr}\n\t"
         "LDR	lr, [sp, #16]\n\t"
         "ADD	r7, r7, #0x1\n\t"
@@ -2915,20 +3185,32 @@ void AES_GCM_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "SUBS	%[len], %[len], #0x10\n\t"
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
-#ifdef __GNUC__
-        "BNE	L_AES_GCM_encrypt_loop_block_256%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_GCM_encrypt_loop_block_256_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_AES_GCM_encrypt_loop_block_256\n\t"
 #else
-        "BNE.W	L_AES_GCM_encrypt_loop_block_256%=\n\t"
+        "BNE.W	L_AES_GCM_encrypt_loop_block_256_%=\n\t"
 #endif
-#ifdef __GNUC__
-        "B	L_AES_GCM_encrypt_end%=\n\t"
+#if defined(__GNUC__)
+        "B	L_AES_GCM_encrypt_end_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.W	L_AES_GCM_encrypt_end\n\t"
 #else
-        "B.W	L_AES_GCM_encrypt_end%=\n\t"
+        "B.W	L_AES_GCM_encrypt_end_%=\n\t"
 #endif
         "\n"
-    "L_AES_GCM_encrypt_start_block_192%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_GCM_encrypt_start_block_192:\n\t"
+#else
+    "L_AES_GCM_encrypt_start_block_192_%=:\n\t"
+#endif
         "\n"
-    "L_AES_GCM_encrypt_loop_block_192%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_GCM_encrypt_loop_block_192:\n\t"
+#else
+    "L_AES_GCM_encrypt_loop_block_192_%=:\n\t"
+#endif
         "PUSH	{r1, %[len], lr}\n\t"
         "LDR	lr, [sp, #16]\n\t"
         "ADD	r7, r7, #0x1\n\t"
@@ -2964,20 +3246,32 @@ void AES_GCM_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "SUBS	%[len], %[len], #0x10\n\t"
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
-#ifdef __GNUC__
-        "BNE	L_AES_GCM_encrypt_loop_block_192%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_GCM_encrypt_loop_block_192_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_AES_GCM_encrypt_loop_block_192\n\t"
 #else
-        "BNE.W	L_AES_GCM_encrypt_loop_block_192%=\n\t"
+        "BNE.W	L_AES_GCM_encrypt_loop_block_192_%=\n\t"
 #endif
-#ifdef __GNUC__
-        "B	L_AES_GCM_encrypt_end%=\n\t"
+#if defined(__GNUC__)
+        "B	L_AES_GCM_encrypt_end_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.W	L_AES_GCM_encrypt_end\n\t"
 #else
-        "B.W	L_AES_GCM_encrypt_end%=\n\t"
+        "B.W	L_AES_GCM_encrypt_end_%=\n\t"
 #endif
         "\n"
-    "L_AES_GCM_encrypt_start_block_128%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_GCM_encrypt_start_block_128:\n\t"
+#else
+    "L_AES_GCM_encrypt_start_block_128_%=:\n\t"
+#endif
         "\n"
-    "L_AES_GCM_encrypt_loop_block_128%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_GCM_encrypt_loop_block_128:\n\t"
+#else
+    "L_AES_GCM_encrypt_loop_block_128_%=:\n\t"
+#endif
         "PUSH	{r1, %[len], lr}\n\t"
         "LDR	lr, [sp, #16]\n\t"
         "ADD	r7, r7, #0x1\n\t"
@@ -3013,13 +3307,19 @@ void AES_GCM_encrypt(const unsigned char* in, unsigned char* out, unsigned long 
         "SUBS	%[len], %[len], #0x10\n\t"
         "ADD	lr, lr, #0x10\n\t"
         "ADD	%[out], %[out], #0x10\n\t"
-#ifdef __GNUC__
-        "BNE	L_AES_GCM_encrypt_loop_block_128%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_AES_GCM_encrypt_loop_block_128_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_AES_GCM_encrypt_loop_block_128\n\t"
 #else
-        "BNE.W	L_AES_GCM_encrypt_loop_block_128%=\n\t"
+        "BNE.W	L_AES_GCM_encrypt_loop_block_128_%=\n\t"
 #endif
         "\n"
-    "L_AES_GCM_encrypt_end%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_AES_GCM_encrypt_end:\n\t"
+#else
+    "L_AES_GCM_encrypt_end_%=:\n\t"
+#endif
         "POP	{%[ks], r8}\n\t"
         "REV	r4, r4\n\t"
         "REV	r5, r5\n\t"

--- a/wolfcrypt/src/port/arm/thumb2-curve25519.S
+++ b/wolfcrypt/src/port/arm/thumb2-curve25519.S
@@ -2741,7 +2741,7 @@ L_curve25519_bits:
 	LDR	r1, [sp, #180]
 	SUBS	r1, r1, #0x1
 	STR	r1, [sp, #180]
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BGE	L_curve25519_bits
 #else
 	BGE.W	L_curve25519_bits
@@ -2750,7 +2750,7 @@ L_curve25519_bits:
 	STR	r1, [sp, #180]
 	SUBS	r2, r2, #0x4
 	STR	r2, [sp, #176]
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BGE	L_curve25519_words
 #else
 	BGE.W	L_curve25519_words

--- a/wolfcrypt/src/port/arm/thumb2-curve25519_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-curve25519_c.c
@@ -2789,9 +2789,17 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "MOV	%[a], #0x1c\n\t"
         "STR	%[a], [sp, #176]\n\t"
         "\n"
-    "L_curve25519_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_curve25519_words:\n\t"
+#else
+    "L_curve25519_words_%=:\n\t"
+#endif
         "\n"
-    "L_curve25519_bits%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_curve25519_bits:\n\t"
+#else
+    "L_curve25519_bits_%=:\n\t"
+#endif
         "LDR	%[n], [sp, #164]\n\t"
         "LDR	%[a], [%[n], r2]\n\t"
         "LDR	%[n], [sp, #180]\n\t"
@@ -2971,19 +2979,23 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "LDR	%[n], [sp, #180]\n\t"
         "SUBS	%[n], %[n], #0x1\n\t"
         "STR	%[n], [sp, #180]\n\t"
-#ifdef __GNUC__
-        "BGE	L_curve25519_bits%=\n\t"
+#if defined(__GNUC__)
+        "BGE	L_curve25519_bits_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGE.W	L_curve25519_bits\n\t"
 #else
-        "BGE.W	L_curve25519_bits%=\n\t"
+        "BGE.W	L_curve25519_bits_%=\n\t"
 #endif
         "MOV	%[n], #0x1f\n\t"
         "STR	%[n], [sp, #180]\n\t"
         "SUBS	%[a], %[a], #0x4\n\t"
         "STR	%[a], [sp, #176]\n\t"
-#ifdef __GNUC__
-        "BGE	L_curve25519_words%=\n\t"
+#if defined(__GNUC__)
+        "BGE	L_curve25519_words_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGE.W	L_curve25519_words\n\t"
 #else
-        "BGE.W	L_curve25519_words%=\n\t"
+        "BGE.W	L_curve25519_words_%=\n\t"
 #endif
         /* Invert */
         "ADD	r1, sp, #0x0\n\t"
@@ -3015,17 +3027,23 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x4\n\t"
         "\n"
-    "L_curve25519_inv_1%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_curve25519_inv_1:\n\t"
+#else
+    "L_curve25519_inv_1_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_1%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_curve25519_inv_1_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_curve25519_inv_1\n\t"
 #else
-        "BNE.N	L_curve25519_inv_1%=\n\t"
+        "BNE.N	L_curve25519_inv_1_%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3036,17 +3054,23 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x9\n\t"
         "\n"
-    "L_curve25519_inv_2%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_curve25519_inv_2:\n\t"
+#else
+    "L_curve25519_inv_2_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_2%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_curve25519_inv_2_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_curve25519_inv_2\n\t"
 #else
-        "BNE.N	L_curve25519_inv_2%=\n\t"
+        "BNE.N	L_curve25519_inv_2_%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3057,17 +3081,23 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x13\n\t"
         "\n"
-    "L_curve25519_inv_3%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_curve25519_inv_3:\n\t"
+#else
+    "L_curve25519_inv_3_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x80\n\t"
         "ADD	r0, sp, #0x80\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_3%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_curve25519_inv_3_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_curve25519_inv_3\n\t"
 #else
-        "BNE.N	L_curve25519_inv_3%=\n\t"
+        "BNE.N	L_curve25519_inv_3_%=\n\t"
 #endif
         "ADD	r2, sp, #0x60\n\t"
         "ADD	r1, sp, #0x80\n\t"
@@ -3075,17 +3105,23 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0xa\n\t"
         "\n"
-    "L_curve25519_inv_4%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_curve25519_inv_4:\n\t"
+#else
+    "L_curve25519_inv_4_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_4%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_curve25519_inv_4_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_curve25519_inv_4\n\t"
 #else
-        "BNE.N	L_curve25519_inv_4%=\n\t"
+        "BNE.N	L_curve25519_inv_4_%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3096,17 +3132,23 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x31\n\t"
         "\n"
-    "L_curve25519_inv_5%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_curve25519_inv_5:\n\t"
+#else
+    "L_curve25519_inv_5_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_5%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_curve25519_inv_5_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_curve25519_inv_5\n\t"
 #else
-        "BNE.N	L_curve25519_inv_5%=\n\t"
+        "BNE.N	L_curve25519_inv_5_%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3117,17 +3159,23 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x63\n\t"
         "\n"
-    "L_curve25519_inv_6%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_curve25519_inv_6:\n\t"
+#else
+    "L_curve25519_inv_6_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x80\n\t"
         "ADD	r0, sp, #0x80\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_6%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_curve25519_inv_6_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_curve25519_inv_6\n\t"
 #else
-        "BNE.N	L_curve25519_inv_6%=\n\t"
+        "BNE.N	L_curve25519_inv_6_%=\n\t"
 #endif
         "ADD	r2, sp, #0x60\n\t"
         "ADD	r1, sp, #0x80\n\t"
@@ -3135,17 +3183,23 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0x32\n\t"
         "\n"
-    "L_curve25519_inv_7%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_curve25519_inv_7:\n\t"
+#else
+    "L_curve25519_inv_7_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_7%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_curve25519_inv_7_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_curve25519_inv_7\n\t"
 #else
-        "BNE.N	L_curve25519_inv_7%=\n\t"
+        "BNE.N	L_curve25519_inv_7_%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3153,17 +3207,23 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0x5\n\t"
         "\n"
-    "L_curve25519_inv_8%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_curve25519_inv_8:\n\t"
+#else
+    "L_curve25519_inv_8_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x40\n\t"
         "ADD	r0, sp, #0x40\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_8%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_curve25519_inv_8_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_curve25519_inv_8\n\t"
 #else
-        "BNE.N	L_curve25519_inv_8%=\n\t"
+        "BNE.N	L_curve25519_inv_8_%=\n\t"
 #endif
         "ADD	r2, sp, #0x20\n\t"
         "ADD	r1, sp, #0x40\n\t"
@@ -3227,7 +3287,11 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "STM	r3, {r4, r5, r6, r7, r8, r9, r10, r11}\n\t"
         "MOV	%[a], #0xfe\n\t"
         "\n"
-    "L_curve25519_bits%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_curve25519_bits:\n\t"
+#else
+    "L_curve25519_bits_%=:\n\t"
+#endif
         "STR	%[a], [sp, #168]\n\t"
         "LDR	%[n], [sp, #160]\n\t"
         "AND	r4, %[a], #0x1f\n\t"
@@ -3312,10 +3376,12 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_mul_op\n\t"
         "LDR	%[a], [sp, #168]\n\t"
         "SUBS	%[a], %[a], #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGE	L_curve25519_bits%=\n\t"
+#if defined(__GNUC__)
+        "BGE	L_curve25519_bits_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGE.N	L_curve25519_bits\n\t"
 #else
-        "BGE.N	L_curve25519_bits%=\n\t"
+        "BGE.N	L_curve25519_bits_%=\n\t"
 #endif
         /*   Cycle Count: 171 */
         "LDR	%[n], [sp, #184]\n\t"
@@ -3352,17 +3418,23 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x4\n\t"
         "\n"
-    "L_curve25519_inv_1%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_curve25519_inv_1:\n\t"
+#else
+    "L_curve25519_inv_1_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_1%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_curve25519_inv_1_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_curve25519_inv_1\n\t"
 #else
-        "BNE.N	L_curve25519_inv_1%=\n\t"
+        "BNE.N	L_curve25519_inv_1_%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3373,17 +3445,23 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x9\n\t"
         "\n"
-    "L_curve25519_inv_2%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_curve25519_inv_2:\n\t"
+#else
+    "L_curve25519_inv_2_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_2%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_curve25519_inv_2_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_curve25519_inv_2\n\t"
 #else
-        "BNE.N	L_curve25519_inv_2%=\n\t"
+        "BNE.N	L_curve25519_inv_2_%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3394,17 +3472,23 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x13\n\t"
         "\n"
-    "L_curve25519_inv_3%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_curve25519_inv_3:\n\t"
+#else
+    "L_curve25519_inv_3_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x80\n\t"
         "ADD	r0, sp, #0x80\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_3%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_curve25519_inv_3_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_curve25519_inv_3\n\t"
 #else
-        "BNE.N	L_curve25519_inv_3%=\n\t"
+        "BNE.N	L_curve25519_inv_3_%=\n\t"
 #endif
         "ADD	r2, sp, #0x60\n\t"
         "ADD	r1, sp, #0x80\n\t"
@@ -3412,17 +3496,23 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0xa\n\t"
         "\n"
-    "L_curve25519_inv_4%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_curve25519_inv_4:\n\t"
+#else
+    "L_curve25519_inv_4_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_4%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_curve25519_inv_4_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_curve25519_inv_4\n\t"
 #else
-        "BNE.N	L_curve25519_inv_4%=\n\t"
+        "BNE.N	L_curve25519_inv_4_%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3433,17 +3523,23 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x31\n\t"
         "\n"
-    "L_curve25519_inv_5%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_curve25519_inv_5:\n\t"
+#else
+    "L_curve25519_inv_5_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_5%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_curve25519_inv_5_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_curve25519_inv_5\n\t"
 #else
-        "BNE.N	L_curve25519_inv_5%=\n\t"
+        "BNE.N	L_curve25519_inv_5_%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3454,17 +3550,23 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x63\n\t"
         "\n"
-    "L_curve25519_inv_6%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_curve25519_inv_6:\n\t"
+#else
+    "L_curve25519_inv_6_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x80\n\t"
         "ADD	r0, sp, #0x80\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_6%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_curve25519_inv_6_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_curve25519_inv_6\n\t"
 #else
-        "BNE.N	L_curve25519_inv_6%=\n\t"
+        "BNE.N	L_curve25519_inv_6_%=\n\t"
 #endif
         "ADD	r2, sp, #0x60\n\t"
         "ADD	r1, sp, #0x80\n\t"
@@ -3472,17 +3574,23 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0x32\n\t"
         "\n"
-    "L_curve25519_inv_7%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_curve25519_inv_7:\n\t"
+#else
+    "L_curve25519_inv_7_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_7%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_curve25519_inv_7_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_curve25519_inv_7\n\t"
 #else
-        "BNE.N	L_curve25519_inv_7%=\n\t"
+        "BNE.N	L_curve25519_inv_7_%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3490,17 +3598,23 @@ int curve25519(byte* r, const byte* n, const byte* a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0x5\n\t"
         "\n"
-    "L_curve25519_inv_8%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_curve25519_inv_8:\n\t"
+#else
+    "L_curve25519_inv_8_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x40\n\t"
         "ADD	r0, sp, #0x40\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_curve25519_inv_8%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_curve25519_inv_8_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_curve25519_inv_8\n\t"
 #else
-        "BNE.N	L_curve25519_inv_8%=\n\t"
+        "BNE.N	L_curve25519_inv_8_%=\n\t"
 #endif
         "ADD	r2, sp, #0x20\n\t"
         "ADD	r1, sp, #0x40\n\t"
@@ -3582,17 +3696,23 @@ void fe_invert(fe r, const fe a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x4\n\t"
         "\n"
-    "L_fe_invert1%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_fe_invert1:\n\t"
+#else
+    "L_fe_invert1_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x40\n\t"
         "ADD	r0, sp, #0x40\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_invert1%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_fe_invert1_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_fe_invert1\n\t"
 #else
-        "BNE.N	L_fe_invert1%=\n\t"
+        "BNE.N	L_fe_invert1_%=\n\t"
 #endif
         "ADD	r2, sp, #0x20\n\t"
         "ADD	r1, sp, #0x40\n\t"
@@ -3603,17 +3723,23 @@ void fe_invert(fe r, const fe a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x9\n\t"
         "\n"
-    "L_fe_invert2%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_fe_invert2:\n\t"
+#else
+    "L_fe_invert2_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x40\n\t"
         "ADD	r0, sp, #0x40\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_invert2%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_fe_invert2_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_fe_invert2\n\t"
 #else
-        "BNE.N	L_fe_invert2%=\n\t"
+        "BNE.N	L_fe_invert2_%=\n\t"
 #endif
         "ADD	r2, sp, #0x20\n\t"
         "ADD	r1, sp, #0x40\n\t"
@@ -3624,17 +3750,23 @@ void fe_invert(fe r, const fe a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x13\n\t"
         "\n"
-    "L_fe_invert3%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_fe_invert3:\n\t"
+#else
+    "L_fe_invert3_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_invert3%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_fe_invert3_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_fe_invert3\n\t"
 #else
-        "BNE.N	L_fe_invert3%=\n\t"
+        "BNE.N	L_fe_invert3_%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3642,17 +3774,23 @@ void fe_invert(fe r, const fe a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0xa\n\t"
         "\n"
-    "L_fe_invert4%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_fe_invert4:\n\t"
+#else
+    "L_fe_invert4_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x40\n\t"
         "ADD	r0, sp, #0x40\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_invert4%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_fe_invert4_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_fe_invert4\n\t"
 #else
-        "BNE.N	L_fe_invert4%=\n\t"
+        "BNE.N	L_fe_invert4_%=\n\t"
 #endif
         "ADD	r2, sp, #0x20\n\t"
         "ADD	r1, sp, #0x40\n\t"
@@ -3663,17 +3801,23 @@ void fe_invert(fe r, const fe a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x31\n\t"
         "\n"
-    "L_fe_invert5%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_fe_invert5:\n\t"
+#else
+    "L_fe_invert5_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x40\n\t"
         "ADD	r0, sp, #0x40\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_invert5%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_fe_invert5_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_fe_invert5\n\t"
 #else
-        "BNE.N	L_fe_invert5%=\n\t"
+        "BNE.N	L_fe_invert5_%=\n\t"
 #endif
         "ADD	r2, sp, #0x20\n\t"
         "ADD	r1, sp, #0x40\n\t"
@@ -3684,17 +3828,23 @@ void fe_invert(fe r, const fe a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x63\n\t"
         "\n"
-    "L_fe_invert6%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_fe_invert6:\n\t"
+#else
+    "L_fe_invert6_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x60\n\t"
         "ADD	r0, sp, #0x60\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_invert6%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_fe_invert6_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_fe_invert6\n\t"
 #else
-        "BNE.N	L_fe_invert6%=\n\t"
+        "BNE.N	L_fe_invert6_%=\n\t"
 #endif
         "ADD	r2, sp, #0x40\n\t"
         "ADD	r1, sp, #0x60\n\t"
@@ -3702,17 +3852,23 @@ void fe_invert(fe r, const fe a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0x32\n\t"
         "\n"
-    "L_fe_invert7%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_fe_invert7:\n\t"
+#else
+    "L_fe_invert7_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x40\n\t"
         "ADD	r0, sp, #0x40\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_invert7%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_fe_invert7_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_fe_invert7\n\t"
 #else
-        "BNE.N	L_fe_invert7%=\n\t"
+        "BNE.N	L_fe_invert7_%=\n\t"
 #endif
         "ADD	r2, sp, #0x20\n\t"
         "ADD	r1, sp, #0x40\n\t"
@@ -3720,17 +3876,23 @@ void fe_invert(fe r, const fe a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0x5\n\t"
         "\n"
-    "L_fe_invert8%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_fe_invert8:\n\t"
+#else
+    "L_fe_invert8_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x20\n\t"
         "ADD	r0, sp, #0x20\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_invert8%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_fe_invert8_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_fe_invert8\n\t"
 #else
-        "BNE.N	L_fe_invert8%=\n\t"
+        "BNE.N	L_fe_invert8_%=\n\t"
 #endif
         "MOV	r2, sp\n\t"
         "ADD	r1, sp, #0x20\n\t"
@@ -4268,17 +4430,23 @@ void fe_pow22523(fe r, const fe a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x4\n\t"
         "\n"
-    "L_fe_pow22523_1%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_fe_pow22523_1:\n\t"
+#else
+    "L_fe_pow22523_1_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x20\n\t"
         "ADD	r0, sp, #0x20\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_pow22523_1%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_fe_pow22523_1_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_fe_pow22523_1\n\t"
 #else
-        "BNE.N	L_fe_pow22523_1%=\n\t"
+        "BNE.N	L_fe_pow22523_1_%=\n\t"
 #endif
         "MOV	r2, sp\n\t"
         "ADD	r1, sp, #0x20\n\t"
@@ -4289,17 +4457,23 @@ void fe_pow22523(fe r, const fe a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x9\n\t"
         "\n"
-    "L_fe_pow22523_2%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_fe_pow22523_2:\n\t"
+#else
+    "L_fe_pow22523_2_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x20\n\t"
         "ADD	r0, sp, #0x20\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_pow22523_2%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_fe_pow22523_2_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_fe_pow22523_2\n\t"
 #else
-        "BNE.N	L_fe_pow22523_2%=\n\t"
+        "BNE.N	L_fe_pow22523_2_%=\n\t"
 #endif
         "MOV	r2, sp\n\t"
         "ADD	r1, sp, #0x20\n\t"
@@ -4310,17 +4484,23 @@ void fe_pow22523(fe r, const fe a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x13\n\t"
         "\n"
-    "L_fe_pow22523_3%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_fe_pow22523_3:\n\t"
+#else
+    "L_fe_pow22523_3_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x40\n\t"
         "ADD	r0, sp, #0x40\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_pow22523_3%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_fe_pow22523_3_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_fe_pow22523_3\n\t"
 #else
-        "BNE.N	L_fe_pow22523_3%=\n\t"
+        "BNE.N	L_fe_pow22523_3_%=\n\t"
 #endif
         "ADD	r2, sp, #0x20\n\t"
         "ADD	r1, sp, #0x40\n\t"
@@ -4328,17 +4508,23 @@ void fe_pow22523(fe r, const fe a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0xa\n\t"
         "\n"
-    "L_fe_pow22523_4%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_fe_pow22523_4:\n\t"
+#else
+    "L_fe_pow22523_4_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x20\n\t"
         "ADD	r0, sp, #0x20\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_pow22523_4%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_fe_pow22523_4_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_fe_pow22523_4\n\t"
 #else
-        "BNE.N	L_fe_pow22523_4%=\n\t"
+        "BNE.N	L_fe_pow22523_4_%=\n\t"
 #endif
         "MOV	r2, sp\n\t"
         "ADD	r1, sp, #0x20\n\t"
@@ -4349,17 +4535,23 @@ void fe_pow22523(fe r, const fe a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x31\n\t"
         "\n"
-    "L_fe_pow22523_5%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_fe_pow22523_5:\n\t"
+#else
+    "L_fe_pow22523_5_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x20\n\t"
         "ADD	r0, sp, #0x20\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_pow22523_5%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_fe_pow22523_5_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_fe_pow22523_5\n\t"
 #else
-        "BNE.N	L_fe_pow22523_5%=\n\t"
+        "BNE.N	L_fe_pow22523_5_%=\n\t"
 #endif
         "MOV	r2, sp\n\t"
         "ADD	r1, sp, #0x20\n\t"
@@ -4370,17 +4562,23 @@ void fe_pow22523(fe r, const fe a)
         "BL	fe_sq_op\n\t"
         "MOV	r12, #0x63\n\t"
         "\n"
-    "L_fe_pow22523_6%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_fe_pow22523_6:\n\t"
+#else
+    "L_fe_pow22523_6_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x40\n\t"
         "ADD	r0, sp, #0x40\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_pow22523_6%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_fe_pow22523_6_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_fe_pow22523_6\n\t"
 #else
-        "BNE.N	L_fe_pow22523_6%=\n\t"
+        "BNE.N	L_fe_pow22523_6_%=\n\t"
 #endif
         "ADD	r2, sp, #0x20\n\t"
         "ADD	r1, sp, #0x40\n\t"
@@ -4388,17 +4586,23 @@ void fe_pow22523(fe r, const fe a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0x32\n\t"
         "\n"
-    "L_fe_pow22523_7%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_fe_pow22523_7:\n\t"
+#else
+    "L_fe_pow22523_7_%=:\n\t"
+#endif
         "ADD	r1, sp, #0x20\n\t"
         "ADD	r0, sp, #0x20\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_pow22523_7%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_fe_pow22523_7_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_fe_pow22523_7\n\t"
 #else
-        "BNE.N	L_fe_pow22523_7%=\n\t"
+        "BNE.N	L_fe_pow22523_7_%=\n\t"
 #endif
         "MOV	r2, sp\n\t"
         "ADD	r1, sp, #0x20\n\t"
@@ -4406,17 +4610,23 @@ void fe_pow22523(fe r, const fe a)
         "BL	fe_mul_op\n\t"
         "MOV	r12, #0x2\n\t"
         "\n"
-    "L_fe_pow22523_8%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_fe_pow22523_8:\n\t"
+#else
+    "L_fe_pow22523_8_%=:\n\t"
+#endif
         "MOV	r1, sp\n\t"
         "MOV	r0, sp\n\t"
         "PUSH	{r12}\n\t"
         "BL	fe_sq_op\n\t"
         "POP	{r12}\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_fe_pow22523_8%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_fe_pow22523_8_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_fe_pow22523_8\n\t"
 #else
-        "BNE.N	L_fe_pow22523_8%=\n\t"
+        "BNE.N	L_fe_pow22523_8_%=\n\t"
 #endif
         "LDR	r2, [sp, #100]\n\t"
         "MOV	r1, sp\n\t"

--- a/wolfcrypt/src/port/arm/thumb2-sha256-asm.S
+++ b/wolfcrypt/src/port/arm/thumb2-sha256-asm.S
@@ -925,7 +925,7 @@ L_SHA256_transform_len_start:
 	STR	r9, [sp, #60]
 	ADD	r3, r3, #0x40
 	SUBS	r12, r12, #0x1
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_SHA256_transform_len_start
 #else
 	BNE.W	L_SHA256_transform_len_start
@@ -1470,7 +1470,7 @@ L_SHA256_transform_len_start:
 	SUBS	r2, r2, #0x40
 	SUB	r3, r3, #0xc0
 	ADD	r1, r1, #0x40
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_SHA256_transform_len_begin
 #else
 	BNE.W	L_SHA256_transform_len_begin

--- a/wolfcrypt/src/port/arm/thumb2-sha256-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-sha256-asm_c.c
@@ -94,7 +94,11 @@ void Transform_Sha256_Len(wc_Sha256* sha256, const byte* data, word32 len)
         "STRD	r10, r11, [sp, #88]\n\t"
         /* Start of loop processing a block */
         "\n"
-    "L_SHA256_transform_len_begin%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_SHA256_transform_len_begin:\n\t"
+#else
+    "L_SHA256_transform_len_begin_%=:\n\t"
+#endif
         /* Load, Reverse and Store W - 64 bytes */
         "LDR	r4, [%[data]]\n\t"
         "LDR	r5, [%[data], #4]\n\t"
@@ -142,7 +146,11 @@ void Transform_Sha256_Len(wc_Sha256* sha256, const byte* data, word32 len)
         "MOV	r12, #0x3\n\t"
         /* Start of 16 rounds */
         "\n"
-    "L_SHA256_transform_len_start%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_SHA256_transform_len_start:\n\t"
+#else
+    "L_SHA256_transform_len_start_%=:\n\t"
+#endif
         /* Round 0 */
         "LDR	r5, [%[sha256], #16]\n\t"
         "LDR	r6, [%[sha256], #20]\n\t"
@@ -897,10 +905,12 @@ void Transform_Sha256_Len(wc_Sha256* sha256, const byte* data, word32 len)
         "STR	r9, [sp, #60]\n\t"
         "ADD	r3, r3, #0x40\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#ifdef __GNUC__
-        "BNE	L_SHA256_transform_len_start%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_SHA256_transform_len_start_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_SHA256_transform_len_start\n\t"
 #else
-        "BNE.W	L_SHA256_transform_len_start%=\n\t"
+        "BNE.W	L_SHA256_transform_len_start_%=\n\t"
 #endif
         /* Round 0 */
         "LDR	r5, [%[sha256], #16]\n\t"
@@ -1442,10 +1452,12 @@ void Transform_Sha256_Len(wc_Sha256* sha256, const byte* data, word32 len)
         "SUBS	%[len], %[len], #0x40\n\t"
         "SUB	r3, r3, #0xc0\n\t"
         "ADD	%[data], %[data], #0x40\n\t"
-#ifdef __GNUC__
-        "BNE	L_SHA256_transform_len_begin%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_SHA256_transform_len_begin_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_SHA256_transform_len_begin\n\t"
 #else
-        "BNE.W	L_SHA256_transform_len_begin%=\n\t"
+        "BNE.W	L_SHA256_transform_len_begin_%=\n\t"
 #endif
         "ADD	sp, sp, #0xc0\n\t"
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG

--- a/wolfcrypt/src/port/arm/thumb2-sha3-asm.S
+++ b/wolfcrypt/src/port/arm/thumb2-sha3-asm.S
@@ -1157,7 +1157,7 @@ L_sha3_thumb2_begin:
 	STR	lr, [r0, #164]
 	LDR	r2, [sp, #200]
 	SUBS	r2, r2, #0x1
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_sha3_thumb2_begin
 #else
 	BNE.W	L_sha3_thumb2_begin

--- a/wolfcrypt/src/port/arm/thumb2-sha3-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-sha3-asm_c.c
@@ -77,7 +77,11 @@ void BlockSha3(word64* state)
         "MOV	r1, %[L_sha3_thumb2_rt]\n\t"
         "MOV	r2, #0xc\n\t"
         "\n"
-    "L_sha3_thumb2_begin%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sha3_thumb2_begin:\n\t"
+#else
+    "L_sha3_thumb2_begin_%=:\n\t"
+#endif
         "STR	r2, [sp, #200]\n\t"
         /* Round even */
         /* Calc b[4] */
@@ -1137,10 +1141,12 @@ void BlockSha3(word64* state)
         "STR	lr, [%[state], #164]\n\t"
         "LDR	r2, [sp, #200]\n\t"
         "SUBS	r2, r2, #0x1\n\t"
-#ifdef __GNUC__
-        "BNE	L_sha3_thumb2_begin%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sha3_thumb2_begin_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_sha3_thumb2_begin\n\t"
 #else
-        "BNE.W	L_sha3_thumb2_begin%=\n\t"
+        "BNE.W	L_sha3_thumb2_begin_%=\n\t"
 #endif
         "ADD	sp, sp, #0xcc\n\t"
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG

--- a/wolfcrypt/src/port/arm/thumb2-sha512-asm.S
+++ b/wolfcrypt/src/port/arm/thumb2-sha512-asm.S
@@ -2319,7 +2319,7 @@ L_SHA512_transform_len_start:
 	STRD	r4, r5, [sp, #120]
 	ADD	r3, r3, #0x80
 	SUBS	r12, r12, #0x1
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_SHA512_transform_len_start
 #else
 	BNE.W	L_SHA512_transform_len_start
@@ -3656,7 +3656,7 @@ L_SHA512_transform_len_start:
 	SUBS	r2, r2, #0x80
 	SUB	r3, r3, #0x200
 	ADD	r1, r1, #0x80
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
 	BNE	L_SHA512_transform_len_begin
 #else
 	BNE.W	L_SHA512_transform_len_begin

--- a/wolfcrypt/src/port/arm/thumb2-sha512-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-sha512-asm_c.c
@@ -126,7 +126,11 @@ void Transform_Sha512_Len(wc_Sha512* sha512, const byte* data, word32 len)
         "STRD	r10, r11, [sp, #184]\n\t"
         /* Start of loop processing a block */
         "\n"
-    "L_SHA512_transform_len_begin%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_SHA512_transform_len_begin:\n\t"
+#else
+    "L_SHA512_transform_len_begin_%=:\n\t"
+#endif
         /* Load, Reverse and Store W */
         "LDR	r4, [%[data]]\n\t"
         "LDR	r5, [%[data], #4]\n\t"
@@ -232,7 +236,11 @@ void Transform_Sha512_Len(wc_Sha512* sha512, const byte* data, word32 len)
         "MOV	r12, #0x4\n\t"
         /* Start of 16 rounds */
         "\n"
-    "L_SHA512_transform_len_start%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_SHA512_transform_len_start:\n\t"
+#else
+    "L_SHA512_transform_len_start_%=:\n\t"
+#endif
         /* Round 0 */
         "LDRD	r4, r5, [%[sha512], #32]\n\t"
         "LSRS	r6, r4, #14\n\t"
@@ -2219,10 +2227,12 @@ void Transform_Sha512_Len(wc_Sha512* sha512, const byte* data, word32 len)
         "STRD	r4, r5, [sp, #120]\n\t"
         "ADD	r3, r3, #0x80\n\t"
         "SUBS	r12, r12, #0x1\n\t"
-#ifdef __GNUC__
-        "BNE	L_SHA512_transform_len_start%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_SHA512_transform_len_start_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_SHA512_transform_len_start\n\t"
 #else
-        "BNE.W	L_SHA512_transform_len_start%=\n\t"
+        "BNE.W	L_SHA512_transform_len_start_%=\n\t"
 #endif
         /* Round 0 */
         "LDRD	r4, r5, [%[sha512], #32]\n\t"
@@ -3556,10 +3566,12 @@ void Transform_Sha512_Len(wc_Sha512* sha512, const byte* data, word32 len)
         "SUBS	%[len], %[len], #0x80\n\t"
         "SUB	r3, r3, #0x200\n\t"
         "ADD	%[data], %[data], #0x80\n\t"
-#ifdef __GNUC__
-        "BNE	L_SHA512_transform_len_begin%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_SHA512_transform_len_begin_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.W	L_SHA512_transform_len_begin\n\t"
 #else
-        "BNE.W	L_SHA512_transform_len_begin%=\n\t"
+        "BNE.W	L_SHA512_transform_len_begin_%=\n\t"
 #endif
         "EOR	r0, r0, r0\n\t"
         "ADD	sp, sp, #0xc0\n\t"

--- a/wolfcrypt/src/sp_cortexm.c
+++ b/wolfcrypt/src/sp_cortexm.c
@@ -2211,7 +2211,11 @@ static sp_digit sp_2048_add_64(sp_digit* r, const sp_digit* a, const sp_digit* b
         "MOV	r3, #0x0\n\t"
         "ADD	r12, %[a], #0x100\n\t"
         "\n"
-    "L_sp_2048_add_64_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_add_64_word:\n\t"
+#else
+    "L_sp_2048_add_64_word_%=:\n\t"
+#endif
         "ADDS	r3, r3, #0xffffffff\n\t"
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
         "LDM	%[b]!, {r8, r9, r10, r11}\n\t"
@@ -2223,10 +2227,12 @@ static sp_digit sp_2048_add_64(sp_digit* r, const sp_digit* a, const sp_digit* b
         "MOV	r4, #0x0\n\t"
         "ADC	r3, r4, #0x0\n\t"
         "CMP	%[a], r12\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_2048_add_64_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_2048_add_64_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_2048_add_64_word\n\t"
 #else
-        "BNE.N	L_sp_2048_add_64_word%=\n\t"
+        "BNE.N	L_sp_2048_add_64_word_%=\n\t"
 #endif
         "MOV	%[r], r3\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -2258,7 +2264,11 @@ static sp_digit sp_2048_sub_in_place_64(sp_digit* a, const sp_digit* b)
         "MOV	r10, #0x0\n\t"
         "ADD	r11, %[a], #0x100\n\t"
         "\n"
-    "L_sp_2048_sub_in_pkace_64_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_sub_in_pkace_64_word:\n\t"
+#else
+    "L_sp_2048_sub_in_pkace_64_word_%=:\n\t"
+#endif
         "RSBS	r10, r10, #0x0\n\t"
         "LDM	%[a], {r2, r3, r4, r5}\n\t"
         "LDM	%[b]!, {r6, r7, r8, r9}\n\t"
@@ -2269,10 +2279,12 @@ static sp_digit sp_2048_sub_in_place_64(sp_digit* a, const sp_digit* b)
         "STM	%[a]!, {r2, r3, r4, r5}\n\t"
         "SBC	r10, r10, r10\n\t"
         "CMP	%[a], r11\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_2048_sub_in_pkace_64_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_2048_sub_in_pkace_64_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_2048_sub_in_pkace_64_word\n\t"
 #else
-        "BNE.N	L_sp_2048_sub_in_pkace_64_word%=\n\t"
+        "BNE.N	L_sp_2048_sub_in_pkace_64_word_%=\n\t"
 #endif
         "MOV	%[a], r10\n\t"
         : [a] "+r" (a), [b] "+r" (b)
@@ -2312,13 +2324,21 @@ static void sp_2048_mul_64(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_2048_mul_64_outer%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_mul_64_outer:\n\t"
+#else
+    "L_sp_2048_mul_64_outer_%=:\n\t"
+#endif
         "SUBS	r3, r5, #0xfc\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_2048_mul_64_inner%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_mul_64_inner:\n\t"
+#else
+    "L_sp_2048_mul_64_inner_%=:\n\t"
+#endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -2334,15 +2354,19 @@ static void sp_2048_mul_64(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r3, r3, #0x4\n\t"
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_2048_mul_64_inner_done%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_2048_mul_64_inner_done_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_2048_mul_64_inner_done\n\t"
 #else
-        "BGT.N	L_sp_2048_mul_64_inner_done%=\n\t"
+        "BGT.N	L_sp_2048_mul_64_inner_done_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mul_64_inner%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_2048_mul_64_inner_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_2048_mul_64_inner\n\t"
 #else
-        "BLT.N	L_sp_2048_mul_64_inner%=\n\t"
+        "BLT.N	L_sp_2048_mul_64_inner_%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r3]\n\t"
@@ -2351,17 +2375,23 @@ static void sp_2048_mul_64(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_2048_mul_64_inner_done%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_mul_64_inner_done:\n\t"
+#else
+    "L_sp_2048_mul_64_inner_done_%=:\n\t"
+#endif
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
         "MOV	r8, #0x0\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x1f4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_2048_mul_64_outer%=\n\t"
+#if defined(__GNUC__)
+        "BLE	L_sp_2048_mul_64_outer_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLE.N	L_sp_2048_mul_64_outer\n\t"
 #else
-        "BLE.N	L_sp_2048_mul_64_outer%=\n\t"
+        "BLE.N	L_sp_2048_mul_64_outer_%=\n\t"
 #endif
         "LDR	lr, [%[a], #252]\n\t"
         "LDR	r11, [%[b], #252]\n\t"
@@ -2370,14 +2400,20 @@ static void sp_2048_mul_64(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_2048_mul_64_store%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_mul_64_store:\n\t"
+#else
+    "L_sp_2048_mul_64_store_%=:\n\t"
+#endif
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_2048_mul_64_store%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_2048_mul_64_store_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_2048_mul_64_store\n\t"
 #else
-        "BGT.N	L_sp_2048_mul_64_store%=\n\t"
+        "BGT.N	L_sp_2048_mul_64_store_%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
@@ -2410,13 +2446,21 @@ static void sp_2048_sqr_64(sp_digit* r, const sp_digit* a)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_2048_sqr_64_outer%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_sqr_64_outer:\n\t"
+#else
+    "L_sp_2048_sqr_64_outer_%=:\n\t"
+#endif
         "SUBS	r3, r5, #0xfc\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_2048_sqr_64_inner%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_sqr_64_inner:\n\t"
+#else
+    "L_sp_2048_sqr_64_inner_%=:\n\t"
+#endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[a], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -2429,15 +2473,19 @@ static void sp_2048_sqr_64(sp_digit* r, const sp_digit* a)
         "ADD	r3, r3, #0x4\n\t"
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_2048_sqr_64_inner_done%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_2048_sqr_64_inner_done_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_2048_sqr_64_inner_done\n\t"
 #else
-        "BGT.N	L_sp_2048_sqr_64_inner_done%=\n\t"
+        "BGT.N	L_sp_2048_sqr_64_inner_done_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_sqr_64_inner%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_2048_sqr_64_inner_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_2048_sqr_64_inner\n\t"
 #else
-        "BLT.N	L_sp_2048_sqr_64_inner%=\n\t"
+        "BLT.N	L_sp_2048_sqr_64_inner_%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "UMULL	r9, r10, lr, lr\n\t"
@@ -2445,17 +2493,23 @@ static void sp_2048_sqr_64(sp_digit* r, const sp_digit* a)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_2048_sqr_64_inner_done%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_sqr_64_inner_done:\n\t"
+#else
+    "L_sp_2048_sqr_64_inner_done_%=:\n\t"
+#endif
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
         "MOV	r8, #0x0\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x1f4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_2048_sqr_64_outer%=\n\t"
+#if defined(__GNUC__)
+        "BLE	L_sp_2048_sqr_64_outer_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLE.N	L_sp_2048_sqr_64_outer\n\t"
 #else
-        "BLE.N	L_sp_2048_sqr_64_outer%=\n\t"
+        "BLE.N	L_sp_2048_sqr_64_outer_%=\n\t"
 #endif
         "LDR	lr, [%[a], #252]\n\t"
         "UMLAL	r6, r7, lr, lr\n\t"
@@ -2463,14 +2517,20 @@ static void sp_2048_sqr_64(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_2048_sqr_64_store%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_sqr_64_store:\n\t"
+#else
+    "L_sp_2048_sqr_64_store_%=:\n\t"
+#endif
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_2048_sqr_64_store%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_2048_sqr_64_store_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_2048_sqr_64_store\n\t"
 #else
-        "BGT.N	L_sp_2048_sqr_64_store%=\n\t"
+        "BGT.N	L_sp_2048_sqr_64_store_%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a)
         :
@@ -2520,7 +2580,11 @@ static sp_digit sp_2048_add_32(sp_digit* r, const sp_digit* a, const sp_digit* b
         "MOV	r3, #0x0\n\t"
         "ADD	r12, %[a], #0x80\n\t"
         "\n"
-    "L_sp_2048_add_32_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_add_32_word:\n\t"
+#else
+    "L_sp_2048_add_32_word_%=:\n\t"
+#endif
         "ADDS	r3, r3, #0xffffffff\n\t"
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
         "LDM	%[b]!, {r8, r9, r10, r11}\n\t"
@@ -2532,10 +2596,12 @@ static sp_digit sp_2048_add_32(sp_digit* r, const sp_digit* a, const sp_digit* b
         "MOV	r4, #0x0\n\t"
         "ADC	r3, r4, #0x0\n\t"
         "CMP	%[a], r12\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_2048_add_32_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_2048_add_32_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_2048_add_32_word\n\t"
 #else
-        "BNE.N	L_sp_2048_add_32_word%=\n\t"
+        "BNE.N	L_sp_2048_add_32_word_%=\n\t"
 #endif
         "MOV	%[r], r3\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -2567,7 +2633,11 @@ static sp_digit sp_2048_sub_in_place_32(sp_digit* a, const sp_digit* b)
         "MOV	r10, #0x0\n\t"
         "ADD	r11, %[a], #0x80\n\t"
         "\n"
-    "L_sp_2048_sub_in_pkace_32_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_sub_in_pkace_32_word:\n\t"
+#else
+    "L_sp_2048_sub_in_pkace_32_word_%=:\n\t"
+#endif
         "RSBS	r10, r10, #0x0\n\t"
         "LDM	%[a], {r2, r3, r4, r5}\n\t"
         "LDM	%[b]!, {r6, r7, r8, r9}\n\t"
@@ -2578,10 +2648,12 @@ static sp_digit sp_2048_sub_in_place_32(sp_digit* a, const sp_digit* b)
         "STM	%[a]!, {r2, r3, r4, r5}\n\t"
         "SBC	r10, r10, r10\n\t"
         "CMP	%[a], r11\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_2048_sub_in_pkace_32_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_2048_sub_in_pkace_32_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_2048_sub_in_pkace_32_word\n\t"
 #else
-        "BNE.N	L_sp_2048_sub_in_pkace_32_word%=\n\t"
+        "BNE.N	L_sp_2048_sub_in_pkace_32_word_%=\n\t"
 #endif
         "MOV	%[a], r10\n\t"
         : [a] "+r" (a), [b] "+r" (b)
@@ -2621,13 +2693,21 @@ static void sp_2048_mul_32(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_2048_mul_32_outer%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_mul_32_outer:\n\t"
+#else
+    "L_sp_2048_mul_32_outer_%=:\n\t"
+#endif
         "SUBS	r3, r5, #0x7c\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_2048_mul_32_inner%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_mul_32_inner:\n\t"
+#else
+    "L_sp_2048_mul_32_inner_%=:\n\t"
+#endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -2643,15 +2723,19 @@ static void sp_2048_mul_32(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r3, r3, #0x4\n\t"
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_2048_mul_32_inner_done%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_2048_mul_32_inner_done_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_2048_mul_32_inner_done\n\t"
 #else
-        "BGT.N	L_sp_2048_mul_32_inner_done%=\n\t"
+        "BGT.N	L_sp_2048_mul_32_inner_done_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mul_32_inner%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_2048_mul_32_inner_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_2048_mul_32_inner\n\t"
 #else
-        "BLT.N	L_sp_2048_mul_32_inner%=\n\t"
+        "BLT.N	L_sp_2048_mul_32_inner_%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r3]\n\t"
@@ -2660,17 +2744,23 @@ static void sp_2048_mul_32(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_2048_mul_32_inner_done%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_mul_32_inner_done:\n\t"
+#else
+    "L_sp_2048_mul_32_inner_done_%=:\n\t"
+#endif
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
         "MOV	r8, #0x0\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0xf4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_2048_mul_32_outer%=\n\t"
+#if defined(__GNUC__)
+        "BLE	L_sp_2048_mul_32_outer_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLE.N	L_sp_2048_mul_32_outer\n\t"
 #else
-        "BLE.N	L_sp_2048_mul_32_outer%=\n\t"
+        "BLE.N	L_sp_2048_mul_32_outer_%=\n\t"
 #endif
         "LDR	lr, [%[a], #124]\n\t"
         "LDR	r11, [%[b], #124]\n\t"
@@ -2679,14 +2769,20 @@ static void sp_2048_mul_32(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_2048_mul_32_store%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_mul_32_store:\n\t"
+#else
+    "L_sp_2048_mul_32_store_%=:\n\t"
+#endif
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_2048_mul_32_store%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_2048_mul_32_store_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_2048_mul_32_store\n\t"
 #else
-        "BGT.N	L_sp_2048_mul_32_store%=\n\t"
+        "BGT.N	L_sp_2048_mul_32_store_%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
@@ -2719,13 +2815,21 @@ static void sp_2048_sqr_32(sp_digit* r, const sp_digit* a)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_2048_sqr_32_outer%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_sqr_32_outer:\n\t"
+#else
+    "L_sp_2048_sqr_32_outer_%=:\n\t"
+#endif
         "SUBS	r3, r5, #0x7c\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_2048_sqr_32_inner%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_sqr_32_inner:\n\t"
+#else
+    "L_sp_2048_sqr_32_inner_%=:\n\t"
+#endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[a], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -2738,15 +2842,19 @@ static void sp_2048_sqr_32(sp_digit* r, const sp_digit* a)
         "ADD	r3, r3, #0x4\n\t"
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_2048_sqr_32_inner_done%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_2048_sqr_32_inner_done_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_2048_sqr_32_inner_done\n\t"
 #else
-        "BGT.N	L_sp_2048_sqr_32_inner_done%=\n\t"
+        "BGT.N	L_sp_2048_sqr_32_inner_done_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_sqr_32_inner%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_2048_sqr_32_inner_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_2048_sqr_32_inner\n\t"
 #else
-        "BLT.N	L_sp_2048_sqr_32_inner%=\n\t"
+        "BLT.N	L_sp_2048_sqr_32_inner_%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "UMULL	r9, r10, lr, lr\n\t"
@@ -2754,17 +2862,23 @@ static void sp_2048_sqr_32(sp_digit* r, const sp_digit* a)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_2048_sqr_32_inner_done%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_sqr_32_inner_done:\n\t"
+#else
+    "L_sp_2048_sqr_32_inner_done_%=:\n\t"
+#endif
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
         "MOV	r8, #0x0\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0xf4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_2048_sqr_32_outer%=\n\t"
+#if defined(__GNUC__)
+        "BLE	L_sp_2048_sqr_32_outer_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLE.N	L_sp_2048_sqr_32_outer\n\t"
 #else
-        "BLE.N	L_sp_2048_sqr_32_outer%=\n\t"
+        "BLE.N	L_sp_2048_sqr_32_outer_%=\n\t"
 #endif
         "LDR	lr, [%[a], #124]\n\t"
         "UMLAL	r6, r7, lr, lr\n\t"
@@ -2772,14 +2886,20 @@ static void sp_2048_sqr_32(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_2048_sqr_32_store%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_sqr_32_store:\n\t"
+#else
+    "L_sp_2048_sqr_32_store_%=:\n\t"
+#endif
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_2048_sqr_32_store%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_2048_sqr_32_store_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_2048_sqr_32_store\n\t"
 #else
-        "BGT.N	L_sp_2048_sqr_32_store%=\n\t"
+        "BGT.N	L_sp_2048_sqr_32_store_%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a)
         :
@@ -2838,7 +2958,11 @@ static void sp_2048_mul_d_64(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "MOV	r9, #0x4\n\t"
         "\n"
-    "L_sp_2048_mul_d_64_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_mul_d_64_word:\n\t"
+#else
+    "L_sp_2048_mul_d_64_word_%=:\n\t"
+#endif
         /* A[i] * B */
         "LDR	r8, [%[a], r9]\n\t"
         "UMULL	r6, r7, %[b], r8\n\t"
@@ -2851,10 +2975,12 @@ static void sp_2048_mul_d_64(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "ADD	r9, r9, #0x4\n\t"
         "CMP	r9, #0x100\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mul_d_64_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_2048_mul_d_64_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_2048_mul_d_64_word\n\t"
 #else
-        "BLT.N	L_sp_2048_mul_d_64_word%=\n\t"
+        "BLT.N	L_sp_2048_mul_d_64_word_%=\n\t"
 #endif
         "STR	r3, [%[r], #256]\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -3252,7 +3378,11 @@ static sp_digit sp_2048_cond_sub_32(sp_digit* r, const sp_digit* a, const sp_dig
         "MOV	r4, #0x0\n\t"
         "MOV	r5, #0x0\n\t"
         "\n"
-    "L_sp_2048_cond_sub_32_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_cond_sub_32_words:\n\t"
+#else
+    "L_sp_2048_cond_sub_32_words_%=:\n\t"
+#endif
         "SUBS	r4, r8, r4\n\t"
         "LDR	r6, [%[a], r5]\n\t"
         "LDR	r7, [%[b], r5]\n\t"
@@ -3262,10 +3392,12 @@ static sp_digit sp_2048_cond_sub_32(sp_digit* r, const sp_digit* a, const sp_dig
         "STR	r6, [%[r], r5]\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x80\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_cond_sub_32_words%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_2048_cond_sub_32_words_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_2048_cond_sub_32_words\n\t"
 #else
-        "BLT.N	L_sp_2048_cond_sub_32_words%=\n\t"
+        "BLT.N	L_sp_2048_cond_sub_32_words_%=\n\t"
 #endif
         "MOV	%[r], r4\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -3448,7 +3580,11 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "LDR	r4, [%[a]]\n\t"
         "LDR	r5, [%[a], #4]\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_32_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_mont_reduce_32_word:\n\t"
+#else
+    "L_sp_2048_mont_reduce_32_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "MUL	r10, %[mp], r4\n\t"
         /* a[i+0] += m[0] * mu */
@@ -3710,10 +3846,12 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "ADD	r11, r11, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r11, #0x80\n\t"
-#ifdef __GNUC__
-        "BLT	L_sp_2048_mont_reduce_32_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_2048_mont_reduce_32_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.W	L_sp_2048_mont_reduce_32_word\n\t"
 #else
-        "BLT.W	L_sp_2048_mont_reduce_32_word%=\n\t"
+        "BLT.W	L_sp_2048_mont_reduce_32_word_%=\n\t"
 #endif
         /* Loop Done */
         "STR	r4, [%[a]]\n\t"
@@ -3752,7 +3890,11 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         /* ca = 0 */
         "MOV	r3, #0x0\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_32_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_mont_reduce_32_word:\n\t"
+#else
+    "L_sp_2048_mont_reduce_32_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "LDR	r10, [%[a]]\n\t"
         "MUL	r8, %[mp], r10\n\t"
@@ -3760,7 +3902,11 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "MOV	r12, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_32_mul%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_mont_reduce_32_mul:\n\t"
+#else
+    "L_sp_2048_mont_reduce_32_mul_%=:\n\t"
+#endif
         /* a[i+j+0] += m[j+0] * mu */
         "LDR	r7, [%[m], r12]\n\t"
         "LDR	r10, [%[a], r12]\n\t"
@@ -3802,10 +3948,12 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         /* j += 1 */
         "ADD	r12, r12, #0x4\n\t"
         "CMP	r12, #0x80\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mont_reduce_32_mul%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_2048_mont_reduce_32_mul_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_2048_mont_reduce_32_mul\n\t"
 #else
-        "BLT.N	L_sp_2048_mont_reduce_32_mul%=\n\t"
+        "BLT.N	L_sp_2048_mont_reduce_32_mul_%=\n\t"
 #endif
         "LDR	r10, [%[a], #128]\n\t"
         "ADDS	r4, r4, r3\n\t"
@@ -3818,10 +3966,12 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "ADD	r9, r9, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r9, #0x80\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mont_reduce_32_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_2048_mont_reduce_32_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_2048_mont_reduce_32_word\n\t"
 #else
-        "BLT.N	L_sp_2048_mont_reduce_32_word%=\n\t"
+        "BLT.N	L_sp_2048_mont_reduce_32_word_%=\n\t"
 #endif
         /* Loop Done */
         "MOV	%[mp], r3\n\t"
@@ -3863,7 +4013,11 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "LDR	r9, [%[a], #12]\n\t"
         "LDR	r10, [%[a], #16]\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_32_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_mont_reduce_32_word:\n\t"
+#else
+    "L_sp_2048_mont_reduce_32_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "MUL	lr, %[mp], r6\n\t"
         /* a[i+0] += m[0] * mu */
@@ -4030,10 +4184,12 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "ADD	r4, r4, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r4, #0x80\n\t"
-#ifdef __GNUC__
-        "BLT	L_sp_2048_mont_reduce_32_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_2048_mont_reduce_32_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.W	L_sp_2048_mont_reduce_32_word\n\t"
 #else
-        "BLT.W	L_sp_2048_mont_reduce_32_word%=\n\t"
+        "BLT.W	L_sp_2048_mont_reduce_32_word_%=\n\t"
 #endif
         /* Loop Done */
         "STR	r6, [%[a]]\n\t"
@@ -4075,7 +4231,11 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         /* ca = 0 */
         "MOV	r3, #0x0\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_32_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_mont_reduce_32_word:\n\t"
+#else
+    "L_sp_2048_mont_reduce_32_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "LDR	r10, [%[a]]\n\t"
         "MUL	r8, %[mp], r10\n\t"
@@ -4083,7 +4243,11 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "MOV	r12, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_32_mul%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_mont_reduce_32_mul:\n\t"
+#else
+    "L_sp_2048_mont_reduce_32_mul_%=:\n\t"
+#endif
         /* a[i+j+0] += m[j+0] * mu */
         "LDR	r7, [%[m], r12]\n\t"
         "LDR	r10, [%[a], r12]\n\t"
@@ -4113,10 +4277,12 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         /* j += 1 */
         "ADD	r12, r12, #0x4\n\t"
         "CMP	r12, #0x80\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mont_reduce_32_mul%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_2048_mont_reduce_32_mul_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_2048_mont_reduce_32_mul\n\t"
 #else
-        "BLT.N	L_sp_2048_mont_reduce_32_mul%=\n\t"
+        "BLT.N	L_sp_2048_mont_reduce_32_mul_%=\n\t"
 #endif
         "LDR	r10, [%[a], #128]\n\t"
         "ADDS	r4, r4, r3\n\t"
@@ -4129,10 +4295,12 @@ SP_NOINLINE static void sp_2048_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "ADD	r9, r9, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r9, #0x80\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mont_reduce_32_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_2048_mont_reduce_32_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_2048_mont_reduce_32_word\n\t"
 #else
-        "BLT.N	L_sp_2048_mont_reduce_32_word%=\n\t"
+        "BLT.N	L_sp_2048_mont_reduce_32_word_%=\n\t"
 #endif
         /* Loop Done */
         "MOV	%[mp], r3\n\t"
@@ -4203,7 +4371,11 @@ static void sp_2048_mul_d_32(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "MOV	r9, #0x4\n\t"
         "\n"
-    "L_sp_2048_mul_d_32_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_mul_d_32_word:\n\t"
+#else
+    "L_sp_2048_mul_d_32_word_%=:\n\t"
+#endif
         /* A[i] * B */
         "LDR	r8, [%[a], r9]\n\t"
         "UMULL	r6, r7, %[b], r8\n\t"
@@ -4216,10 +4388,12 @@ static void sp_2048_mul_d_32(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "ADD	r9, r9, #0x4\n\t"
         "CMP	r9, #0x80\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mul_d_32_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_2048_mul_d_32_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_2048_mul_d_32_word\n\t"
 #else
-        "BLT.N	L_sp_2048_mul_d_32_word%=\n\t"
+        "BLT.N	L_sp_2048_mul_d_32_word_%=\n\t"
 #endif
         "STR	r3, [%[r], #128]\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -4517,7 +4691,11 @@ SP_NOINLINE static sp_digit div_2048_word_32(sp_digit d1, sp_digit d0, sp_digit 
         /* Next 30 bits */
         "MOV	r4, #0x1d\n\t"
         "\n"
-    "L_div_2048_word_32_bit%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_div_2048_word_32_bit:\n\t"
+#else
+    "L_div_2048_word_32_bit_%=:\n\t"
+#endif
         "LSLS	r6, r6, #1\n\t"
         "ADC	r7, r7, r7\n\t"
         "SUBS	r8, r5, r7\n\t"
@@ -4527,7 +4705,13 @@ SP_NOINLINE static sp_digit div_2048_word_32(sp_digit d1, sp_digit d0, sp_digit 
         "AND	r8, r8, r5\n\t"
         "SUBS	r7, r7, r8\n\t"
         "SUBS	r4, r4, #0x1\n\t"
-        "bpl	L_div_2048_word_32_bit%=\n\t"
+#if defined(__GNUC__)
+        "BPL	L_div_2048_word_32_bit_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BPL.N	L_div_2048_word_32_bit\n\t"
+#else
+        "BPL.N	L_div_2048_word_32_bit_%=\n\t"
+#endif
         "ADD	r3, r3, r3\n\t"
         "ADD	r3, r3, #0x1\n\t"
         "UMULL	r6, r7, r3, %[div]\n\t"
@@ -4579,7 +4763,11 @@ static sp_int32 sp_2048_cmp_32(const sp_digit* a, const sp_digit* b)
 #ifdef WOLFSSL_SP_SMALL
         "MOV	r6, #0x7c\n\t"
         "\n"
-    "L_sp_2048_cmp_32_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_cmp_32_words:\n\t"
+#else
+    "L_sp_2048_cmp_32_words_%=:\n\t"
+#endif
         "LDR	r4, [%[a], r6]\n\t"
         "LDR	r5, [%[b], r6]\n\t"
         "AND	r4, r4, r3\n\t"
@@ -4592,7 +4780,7 @@ static sp_int32 sp_2048_cmp_32(const sp_digit* a, const sp_digit* b)
         "IT	ne\n\t"
         "movne	r3, r7\n\t"
         "SUBS	r6, r6, #0x4\n\t"
-        "bcs	L_sp_2048_cmp_32_words%=\n\t"
+        "bcs	L_sp_2048_cmp_32_words\n\t"
         "EOR	r2, r2, r3\n\t"
 #else
         "LDR	r4, [%[a], #124]\n\t"
@@ -5380,7 +5568,11 @@ static sp_digit sp_2048_cond_sub_64(sp_digit* r, const sp_digit* a, const sp_dig
         "MOV	r4, #0x0\n\t"
         "MOV	r5, #0x0\n\t"
         "\n"
-    "L_sp_2048_cond_sub_64_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_cond_sub_64_words:\n\t"
+#else
+    "L_sp_2048_cond_sub_64_words_%=:\n\t"
+#endif
         "SUBS	r4, r8, r4\n\t"
         "LDR	r6, [%[a], r5]\n\t"
         "LDR	r7, [%[b], r5]\n\t"
@@ -5390,10 +5582,12 @@ static sp_digit sp_2048_cond_sub_64(sp_digit* r, const sp_digit* a, const sp_dig
         "STR	r6, [%[r], r5]\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x100\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_cond_sub_64_words%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_2048_cond_sub_64_words_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_2048_cond_sub_64_words\n\t"
 #else
-        "BLT.N	L_sp_2048_cond_sub_64_words%=\n\t"
+        "BLT.N	L_sp_2048_cond_sub_64_words_%=\n\t"
 #endif
         "MOV	%[r], r4\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -5688,7 +5882,11 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         "LDR	r4, [%[a]]\n\t"
         "LDR	r5, [%[a], #4]\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_64_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_mont_reduce_64_word:\n\t"
+#else
+    "L_sp_2048_mont_reduce_64_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "MUL	r10, %[mp], r4\n\t"
         /* a[i+0] += m[0] * mu */
@@ -6206,10 +6404,12 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         "ADD	r11, r11, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r11, #0x100\n\t"
-#ifdef __GNUC__
-        "BLT	L_sp_2048_mont_reduce_64_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_2048_mont_reduce_64_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.W	L_sp_2048_mont_reduce_64_word\n\t"
 #else
-        "BLT.W	L_sp_2048_mont_reduce_64_word%=\n\t"
+        "BLT.W	L_sp_2048_mont_reduce_64_word_%=\n\t"
 #endif
         /* Loop Done */
         "STR	r4, [%[a]]\n\t"
@@ -6248,7 +6448,11 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         /* ca = 0 */
         "MOV	r3, #0x0\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_64_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_mont_reduce_64_word:\n\t"
+#else
+    "L_sp_2048_mont_reduce_64_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "LDR	r10, [%[a]]\n\t"
         "MUL	r8, %[mp], r10\n\t"
@@ -6256,7 +6460,11 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         "MOV	r12, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_64_mul%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_mont_reduce_64_mul:\n\t"
+#else
+    "L_sp_2048_mont_reduce_64_mul_%=:\n\t"
+#endif
         /* a[i+j+0] += m[j+0] * mu */
         "LDR	r7, [%[m], r12]\n\t"
         "LDR	r10, [%[a], r12]\n\t"
@@ -6298,10 +6506,12 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         /* j += 1 */
         "ADD	r12, r12, #0x4\n\t"
         "CMP	r12, #0x100\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mont_reduce_64_mul%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_2048_mont_reduce_64_mul_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_2048_mont_reduce_64_mul\n\t"
 #else
-        "BLT.N	L_sp_2048_mont_reduce_64_mul%=\n\t"
+        "BLT.N	L_sp_2048_mont_reduce_64_mul_%=\n\t"
 #endif
         "LDR	r10, [%[a], #256]\n\t"
         "ADDS	r4, r4, r3\n\t"
@@ -6314,10 +6524,12 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         "ADD	r9, r9, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r9, #0x100\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mont_reduce_64_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_2048_mont_reduce_64_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_2048_mont_reduce_64_word\n\t"
 #else
-        "BLT.N	L_sp_2048_mont_reduce_64_word%=\n\t"
+        "BLT.N	L_sp_2048_mont_reduce_64_word_%=\n\t"
 #endif
         /* Loop Done */
         "MOV	%[mp], r3\n\t"
@@ -6359,7 +6571,11 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         "LDR	r9, [%[a], #12]\n\t"
         "LDR	r10, [%[a], #16]\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_64_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_mont_reduce_64_word:\n\t"
+#else
+    "L_sp_2048_mont_reduce_64_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "MUL	lr, %[mp], r6\n\t"
         /* a[i+0] += m[0] * mu */
@@ -6686,10 +6902,12 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         "ADD	r4, r4, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r4, #0x100\n\t"
-#ifdef __GNUC__
-        "BLT	L_sp_2048_mont_reduce_64_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_2048_mont_reduce_64_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.W	L_sp_2048_mont_reduce_64_word\n\t"
 #else
-        "BLT.W	L_sp_2048_mont_reduce_64_word%=\n\t"
+        "BLT.W	L_sp_2048_mont_reduce_64_word_%=\n\t"
 #endif
         /* Loop Done */
         "STR	r6, [%[a]]\n\t"
@@ -6731,7 +6949,11 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         /* ca = 0 */
         "MOV	r3, #0x0\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_64_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_mont_reduce_64_word:\n\t"
+#else
+    "L_sp_2048_mont_reduce_64_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "LDR	r10, [%[a]]\n\t"
         "MUL	r8, %[mp], r10\n\t"
@@ -6739,7 +6961,11 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         "MOV	r12, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_2048_mont_reduce_64_mul%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_mont_reduce_64_mul:\n\t"
+#else
+    "L_sp_2048_mont_reduce_64_mul_%=:\n\t"
+#endif
         /* a[i+j+0] += m[j+0] * mu */
         "LDR	r7, [%[m], r12]\n\t"
         "LDR	r10, [%[a], r12]\n\t"
@@ -6769,10 +6995,12 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         /* j += 1 */
         "ADD	r12, r12, #0x4\n\t"
         "CMP	r12, #0x100\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mont_reduce_64_mul%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_2048_mont_reduce_64_mul_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_2048_mont_reduce_64_mul\n\t"
 #else
-        "BLT.N	L_sp_2048_mont_reduce_64_mul%=\n\t"
+        "BLT.N	L_sp_2048_mont_reduce_64_mul_%=\n\t"
 #endif
         "LDR	r10, [%[a], #256]\n\t"
         "ADDS	r4, r4, r3\n\t"
@@ -6785,10 +7013,12 @@ SP_NOINLINE static void sp_2048_mont_reduce_64(sp_digit* a, const sp_digit* m, s
         "ADD	r9, r9, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r9, #0x100\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_mont_reduce_64_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_2048_mont_reduce_64_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_2048_mont_reduce_64_word\n\t"
 #else
-        "BLT.N	L_sp_2048_mont_reduce_64_word%=\n\t"
+        "BLT.N	L_sp_2048_mont_reduce_64_word_%=\n\t"
 #endif
         /* Loop Done */
         "MOV	%[mp], r3\n\t"
@@ -6854,7 +7084,11 @@ static sp_digit sp_2048_sub_64(sp_digit* r, const sp_digit* a, const sp_digit* b
         "MOV	r11, #0x0\n\t"
         "ADD	r12, %[a], #0x100\n\t"
         "\n"
-    "L_sp_2048_sub_64_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_sub_64_word:\n\t"
+#else
+    "L_sp_2048_sub_64_word_%=:\n\t"
+#endif
         "RSBS	r11, r11, #0x0\n\t"
         "LDM	%[a]!, {r3, r4, r5, r6}\n\t"
         "LDM	%[b]!, {r7, r8, r9, r10}\n\t"
@@ -6865,10 +7099,12 @@ static sp_digit sp_2048_sub_64(sp_digit* r, const sp_digit* a, const sp_digit* b
         "STM	%[r]!, {r3, r4, r5, r6}\n\t"
         "SBC	r11, r3, r3\n\t"
         "CMP	%[a], r12\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_2048_sub_64_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_2048_sub_64_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_2048_sub_64_word\n\t"
 #else
-        "BNE.N	L_sp_2048_sub_64_word%=\n\t"
+        "BNE.N	L_sp_2048_sub_64_word_%=\n\t"
 #endif
         "MOV	%[r], r11\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -7121,7 +7357,11 @@ SP_NOINLINE static sp_digit div_2048_word_64(sp_digit d1, sp_digit d0, sp_digit 
         /* Next 30 bits */
         "MOV	r4, #0x1d\n\t"
         "\n"
-    "L_div_2048_word_64_bit%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_div_2048_word_64_bit:\n\t"
+#else
+    "L_div_2048_word_64_bit_%=:\n\t"
+#endif
         "LSLS	r6, r6, #1\n\t"
         "ADC	r7, r7, r7\n\t"
         "SUBS	r8, r5, r7\n\t"
@@ -7131,7 +7371,13 @@ SP_NOINLINE static sp_digit div_2048_word_64(sp_digit d1, sp_digit d0, sp_digit 
         "AND	r8, r8, r5\n\t"
         "SUBS	r7, r7, r8\n\t"
         "SUBS	r4, r4, #0x1\n\t"
-        "bpl	L_div_2048_word_64_bit%=\n\t"
+#if defined(__GNUC__)
+        "BPL	L_div_2048_word_64_bit_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BPL.N	L_div_2048_word_64_bit\n\t"
+#else
+        "BPL.N	L_div_2048_word_64_bit_%=\n\t"
+#endif
         "ADD	r3, r3, r3\n\t"
         "ADD	r3, r3, #0x1\n\t"
         "UMULL	r6, r7, r3, %[div]\n\t"
@@ -7286,7 +7532,11 @@ static sp_int32 sp_2048_cmp_64(const sp_digit* a, const sp_digit* b)
 #ifdef WOLFSSL_SP_SMALL
         "MOV	r6, #0xfc\n\t"
         "\n"
-    "L_sp_2048_cmp_64_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_cmp_64_words:\n\t"
+#else
+    "L_sp_2048_cmp_64_words_%=:\n\t"
+#endif
         "LDR	r4, [%[a], r6]\n\t"
         "LDR	r5, [%[b], r6]\n\t"
         "AND	r4, r4, r3\n\t"
@@ -7299,7 +7549,7 @@ static sp_int32 sp_2048_cmp_64(const sp_digit* a, const sp_digit* b)
         "IT	ne\n\t"
         "movne	r3, r7\n\t"
         "SUBS	r6, r6, #0x4\n\t"
-        "bcs	L_sp_2048_cmp_64_words%=\n\t"
+        "bcs	L_sp_2048_cmp_64_words\n\t"
         "EOR	r2, r2, r3\n\t"
 #else
         "LDR	r4, [%[a], #252]\n\t"
@@ -8562,7 +8812,11 @@ static sp_digit sp_2048_cond_add_32(sp_digit* r, const sp_digit* a, const sp_dig
         "MOV	r8, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_2048_cond_add_32_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_2048_cond_add_32_words:\n\t"
+#else
+    "L_sp_2048_cond_add_32_words_%=:\n\t"
+#endif
         "ADDS	r5, r5, #0xffffffff\n\t"
         "LDR	r6, [%[a], r4]\n\t"
         "LDR	r7, [%[b], r4]\n\t"
@@ -8572,10 +8826,12 @@ static sp_digit sp_2048_cond_add_32(sp_digit* r, const sp_digit* a, const sp_dig
         "STR	r6, [%[r], r4]\n\t"
         "ADD	r4, r4, #0x4\n\t"
         "CMP	r4, #0x80\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_2048_cond_add_32_words%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_2048_cond_add_32_words_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_2048_cond_add_32_words\n\t"
 #else
-        "BLT.N	L_sp_2048_cond_add_32_words%=\n\t"
+        "BLT.N	L_sp_2048_cond_add_32_words_%=\n\t"
 #endif
         "MOV	%[r], r5\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -12948,7 +13204,11 @@ static sp_digit sp_3072_add_96(sp_digit* r, const sp_digit* a, const sp_digit* b
         "MOV	r3, #0x0\n\t"
         "ADD	r12, %[a], #0x180\n\t"
         "\n"
-    "L_sp_3072_add_96_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_add_96_word:\n\t"
+#else
+    "L_sp_3072_add_96_word_%=:\n\t"
+#endif
         "ADDS	r3, r3, #0xffffffff\n\t"
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
         "LDM	%[b]!, {r8, r9, r10, r11}\n\t"
@@ -12960,10 +13220,12 @@ static sp_digit sp_3072_add_96(sp_digit* r, const sp_digit* a, const sp_digit* b
         "MOV	r4, #0x0\n\t"
         "ADC	r3, r4, #0x0\n\t"
         "CMP	%[a], r12\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_3072_add_96_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_3072_add_96_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_3072_add_96_word\n\t"
 #else
-        "BNE.N	L_sp_3072_add_96_word%=\n\t"
+        "BNE.N	L_sp_3072_add_96_word_%=\n\t"
 #endif
         "MOV	%[r], r3\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -12995,7 +13257,11 @@ static sp_digit sp_3072_sub_in_place_96(sp_digit* a, const sp_digit* b)
         "MOV	r10, #0x0\n\t"
         "ADD	r11, %[a], #0x180\n\t"
         "\n"
-    "L_sp_3072_sub_in_pkace_96_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_sub_in_pkace_96_word:\n\t"
+#else
+    "L_sp_3072_sub_in_pkace_96_word_%=:\n\t"
+#endif
         "RSBS	r10, r10, #0x0\n\t"
         "LDM	%[a], {r2, r3, r4, r5}\n\t"
         "LDM	%[b]!, {r6, r7, r8, r9}\n\t"
@@ -13006,10 +13272,12 @@ static sp_digit sp_3072_sub_in_place_96(sp_digit* a, const sp_digit* b)
         "STM	%[a]!, {r2, r3, r4, r5}\n\t"
         "SBC	r10, r10, r10\n\t"
         "CMP	%[a], r11\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_3072_sub_in_pkace_96_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_3072_sub_in_pkace_96_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_3072_sub_in_pkace_96_word\n\t"
 #else
-        "BNE.N	L_sp_3072_sub_in_pkace_96_word%=\n\t"
+        "BNE.N	L_sp_3072_sub_in_pkace_96_word_%=\n\t"
 #endif
         "MOV	%[a], r10\n\t"
         : [a] "+r" (a), [b] "+r" (b)
@@ -13049,13 +13317,21 @@ static void sp_3072_mul_96(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_3072_mul_96_outer%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_mul_96_outer:\n\t"
+#else
+    "L_sp_3072_mul_96_outer_%=:\n\t"
+#endif
         "SUBS	r3, r5, #0x17c\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_3072_mul_96_inner%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_mul_96_inner:\n\t"
+#else
+    "L_sp_3072_mul_96_inner_%=:\n\t"
+#endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -13071,15 +13347,19 @@ static void sp_3072_mul_96(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r3, r3, #0x4\n\t"
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_3072_mul_96_inner_done%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_3072_mul_96_inner_done_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_3072_mul_96_inner_done\n\t"
 #else
-        "BGT.N	L_sp_3072_mul_96_inner_done%=\n\t"
+        "BGT.N	L_sp_3072_mul_96_inner_done_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mul_96_inner%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_3072_mul_96_inner_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_3072_mul_96_inner\n\t"
 #else
-        "BLT.N	L_sp_3072_mul_96_inner%=\n\t"
+        "BLT.N	L_sp_3072_mul_96_inner_%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r3]\n\t"
@@ -13088,17 +13368,23 @@ static void sp_3072_mul_96(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_3072_mul_96_inner_done%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_mul_96_inner_done:\n\t"
+#else
+    "L_sp_3072_mul_96_inner_done_%=:\n\t"
+#endif
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
         "MOV	r8, #0x0\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x2f4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_3072_mul_96_outer%=\n\t"
+#if defined(__GNUC__)
+        "BLE	L_sp_3072_mul_96_outer_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLE.N	L_sp_3072_mul_96_outer\n\t"
 #else
-        "BLE.N	L_sp_3072_mul_96_outer%=\n\t"
+        "BLE.N	L_sp_3072_mul_96_outer_%=\n\t"
 #endif
         "LDR	lr, [%[a], #380]\n\t"
         "LDR	r11, [%[b], #380]\n\t"
@@ -13107,14 +13393,20 @@ static void sp_3072_mul_96(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_3072_mul_96_store%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_mul_96_store:\n\t"
+#else
+    "L_sp_3072_mul_96_store_%=:\n\t"
+#endif
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_3072_mul_96_store%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_3072_mul_96_store_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_3072_mul_96_store\n\t"
 #else
-        "BGT.N	L_sp_3072_mul_96_store%=\n\t"
+        "BGT.N	L_sp_3072_mul_96_store_%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
@@ -13147,13 +13439,21 @@ static void sp_3072_sqr_96(sp_digit* r, const sp_digit* a)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_3072_sqr_96_outer%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_sqr_96_outer:\n\t"
+#else
+    "L_sp_3072_sqr_96_outer_%=:\n\t"
+#endif
         "SUBS	r3, r5, #0x17c\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_3072_sqr_96_inner%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_sqr_96_inner:\n\t"
+#else
+    "L_sp_3072_sqr_96_inner_%=:\n\t"
+#endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[a], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -13166,15 +13466,19 @@ static void sp_3072_sqr_96(sp_digit* r, const sp_digit* a)
         "ADD	r3, r3, #0x4\n\t"
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_3072_sqr_96_inner_done%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_3072_sqr_96_inner_done_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_3072_sqr_96_inner_done\n\t"
 #else
-        "BGT.N	L_sp_3072_sqr_96_inner_done%=\n\t"
+        "BGT.N	L_sp_3072_sqr_96_inner_done_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_sqr_96_inner%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_3072_sqr_96_inner_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_3072_sqr_96_inner\n\t"
 #else
-        "BLT.N	L_sp_3072_sqr_96_inner%=\n\t"
+        "BLT.N	L_sp_3072_sqr_96_inner_%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "UMULL	r9, r10, lr, lr\n\t"
@@ -13182,17 +13486,23 @@ static void sp_3072_sqr_96(sp_digit* r, const sp_digit* a)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_3072_sqr_96_inner_done%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_sqr_96_inner_done:\n\t"
+#else
+    "L_sp_3072_sqr_96_inner_done_%=:\n\t"
+#endif
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
         "MOV	r8, #0x0\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x2f4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_3072_sqr_96_outer%=\n\t"
+#if defined(__GNUC__)
+        "BLE	L_sp_3072_sqr_96_outer_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLE.N	L_sp_3072_sqr_96_outer\n\t"
 #else
-        "BLE.N	L_sp_3072_sqr_96_outer%=\n\t"
+        "BLE.N	L_sp_3072_sqr_96_outer_%=\n\t"
 #endif
         "LDR	lr, [%[a], #380]\n\t"
         "UMLAL	r6, r7, lr, lr\n\t"
@@ -13200,14 +13510,20 @@ static void sp_3072_sqr_96(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_3072_sqr_96_store%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_sqr_96_store:\n\t"
+#else
+    "L_sp_3072_sqr_96_store_%=:\n\t"
+#endif
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_3072_sqr_96_store%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_3072_sqr_96_store_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_3072_sqr_96_store\n\t"
 #else
-        "BGT.N	L_sp_3072_sqr_96_store%=\n\t"
+        "BGT.N	L_sp_3072_sqr_96_store_%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a)
         :
@@ -13257,7 +13573,11 @@ static sp_digit sp_3072_add_48(sp_digit* r, const sp_digit* a, const sp_digit* b
         "MOV	r3, #0x0\n\t"
         "ADD	r12, %[a], #0xc0\n\t"
         "\n"
-    "L_sp_3072_add_48_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_add_48_word:\n\t"
+#else
+    "L_sp_3072_add_48_word_%=:\n\t"
+#endif
         "ADDS	r3, r3, #0xffffffff\n\t"
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
         "LDM	%[b]!, {r8, r9, r10, r11}\n\t"
@@ -13269,10 +13589,12 @@ static sp_digit sp_3072_add_48(sp_digit* r, const sp_digit* a, const sp_digit* b
         "MOV	r4, #0x0\n\t"
         "ADC	r3, r4, #0x0\n\t"
         "CMP	%[a], r12\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_3072_add_48_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_3072_add_48_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_3072_add_48_word\n\t"
 #else
-        "BNE.N	L_sp_3072_add_48_word%=\n\t"
+        "BNE.N	L_sp_3072_add_48_word_%=\n\t"
 #endif
         "MOV	%[r], r3\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -13304,7 +13626,11 @@ static sp_digit sp_3072_sub_in_place_48(sp_digit* a, const sp_digit* b)
         "MOV	r10, #0x0\n\t"
         "ADD	r11, %[a], #0xc0\n\t"
         "\n"
-    "L_sp_3072_sub_in_pkace_48_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_sub_in_pkace_48_word:\n\t"
+#else
+    "L_sp_3072_sub_in_pkace_48_word_%=:\n\t"
+#endif
         "RSBS	r10, r10, #0x0\n\t"
         "LDM	%[a], {r2, r3, r4, r5}\n\t"
         "LDM	%[b]!, {r6, r7, r8, r9}\n\t"
@@ -13315,10 +13641,12 @@ static sp_digit sp_3072_sub_in_place_48(sp_digit* a, const sp_digit* b)
         "STM	%[a]!, {r2, r3, r4, r5}\n\t"
         "SBC	r10, r10, r10\n\t"
         "CMP	%[a], r11\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_3072_sub_in_pkace_48_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_3072_sub_in_pkace_48_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_3072_sub_in_pkace_48_word\n\t"
 #else
-        "BNE.N	L_sp_3072_sub_in_pkace_48_word%=\n\t"
+        "BNE.N	L_sp_3072_sub_in_pkace_48_word_%=\n\t"
 #endif
         "MOV	%[a], r10\n\t"
         : [a] "+r" (a), [b] "+r" (b)
@@ -13358,13 +13686,21 @@ static void sp_3072_mul_48(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_3072_mul_48_outer%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_mul_48_outer:\n\t"
+#else
+    "L_sp_3072_mul_48_outer_%=:\n\t"
+#endif
         "SUBS	r3, r5, #0xbc\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_3072_mul_48_inner%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_mul_48_inner:\n\t"
+#else
+    "L_sp_3072_mul_48_inner_%=:\n\t"
+#endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -13380,15 +13716,19 @@ static void sp_3072_mul_48(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r3, r3, #0x4\n\t"
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_3072_mul_48_inner_done%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_3072_mul_48_inner_done_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_3072_mul_48_inner_done\n\t"
 #else
-        "BGT.N	L_sp_3072_mul_48_inner_done%=\n\t"
+        "BGT.N	L_sp_3072_mul_48_inner_done_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mul_48_inner%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_3072_mul_48_inner_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_3072_mul_48_inner\n\t"
 #else
-        "BLT.N	L_sp_3072_mul_48_inner%=\n\t"
+        "BLT.N	L_sp_3072_mul_48_inner_%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r3]\n\t"
@@ -13397,17 +13737,23 @@ static void sp_3072_mul_48(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_3072_mul_48_inner_done%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_mul_48_inner_done:\n\t"
+#else
+    "L_sp_3072_mul_48_inner_done_%=:\n\t"
+#endif
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
         "MOV	r8, #0x0\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x174\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_3072_mul_48_outer%=\n\t"
+#if defined(__GNUC__)
+        "BLE	L_sp_3072_mul_48_outer_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLE.N	L_sp_3072_mul_48_outer\n\t"
 #else
-        "BLE.N	L_sp_3072_mul_48_outer%=\n\t"
+        "BLE.N	L_sp_3072_mul_48_outer_%=\n\t"
 #endif
         "LDR	lr, [%[a], #188]\n\t"
         "LDR	r11, [%[b], #188]\n\t"
@@ -13416,14 +13762,20 @@ static void sp_3072_mul_48(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_3072_mul_48_store%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_mul_48_store:\n\t"
+#else
+    "L_sp_3072_mul_48_store_%=:\n\t"
+#endif
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_3072_mul_48_store%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_3072_mul_48_store_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_3072_mul_48_store\n\t"
 #else
-        "BGT.N	L_sp_3072_mul_48_store%=\n\t"
+        "BGT.N	L_sp_3072_mul_48_store_%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
@@ -13456,13 +13808,21 @@ static void sp_3072_sqr_48(sp_digit* r, const sp_digit* a)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_3072_sqr_48_outer%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_sqr_48_outer:\n\t"
+#else
+    "L_sp_3072_sqr_48_outer_%=:\n\t"
+#endif
         "SUBS	r3, r5, #0xbc\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_3072_sqr_48_inner%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_sqr_48_inner:\n\t"
+#else
+    "L_sp_3072_sqr_48_inner_%=:\n\t"
+#endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[a], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -13475,15 +13835,19 @@ static void sp_3072_sqr_48(sp_digit* r, const sp_digit* a)
         "ADD	r3, r3, #0x4\n\t"
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_3072_sqr_48_inner_done%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_3072_sqr_48_inner_done_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_3072_sqr_48_inner_done\n\t"
 #else
-        "BGT.N	L_sp_3072_sqr_48_inner_done%=\n\t"
+        "BGT.N	L_sp_3072_sqr_48_inner_done_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_sqr_48_inner%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_3072_sqr_48_inner_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_3072_sqr_48_inner\n\t"
 #else
-        "BLT.N	L_sp_3072_sqr_48_inner%=\n\t"
+        "BLT.N	L_sp_3072_sqr_48_inner_%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "UMULL	r9, r10, lr, lr\n\t"
@@ -13491,17 +13855,23 @@ static void sp_3072_sqr_48(sp_digit* r, const sp_digit* a)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_3072_sqr_48_inner_done%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_sqr_48_inner_done:\n\t"
+#else
+    "L_sp_3072_sqr_48_inner_done_%=:\n\t"
+#endif
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
         "MOV	r8, #0x0\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x174\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_3072_sqr_48_outer%=\n\t"
+#if defined(__GNUC__)
+        "BLE	L_sp_3072_sqr_48_outer_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLE.N	L_sp_3072_sqr_48_outer\n\t"
 #else
-        "BLE.N	L_sp_3072_sqr_48_outer%=\n\t"
+        "BLE.N	L_sp_3072_sqr_48_outer_%=\n\t"
 #endif
         "LDR	lr, [%[a], #188]\n\t"
         "UMLAL	r6, r7, lr, lr\n\t"
@@ -13509,14 +13879,20 @@ static void sp_3072_sqr_48(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_3072_sqr_48_store%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_sqr_48_store:\n\t"
+#else
+    "L_sp_3072_sqr_48_store_%=:\n\t"
+#endif
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_3072_sqr_48_store%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_3072_sqr_48_store_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_3072_sqr_48_store\n\t"
 #else
-        "BGT.N	L_sp_3072_sqr_48_store%=\n\t"
+        "BGT.N	L_sp_3072_sqr_48_store_%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a)
         :
@@ -13575,7 +13951,11 @@ static void sp_3072_mul_d_96(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "MOV	r9, #0x4\n\t"
         "\n"
-    "L_sp_3072_mul_d_96_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_mul_d_96_word:\n\t"
+#else
+    "L_sp_3072_mul_d_96_word_%=:\n\t"
+#endif
         /* A[i] * B */
         "LDR	r8, [%[a], r9]\n\t"
         "UMULL	r6, r7, %[b], r8\n\t"
@@ -13588,10 +13968,12 @@ static void sp_3072_mul_d_96(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "ADD	r9, r9, #0x4\n\t"
         "CMP	r9, #0x180\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mul_d_96_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_3072_mul_d_96_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_3072_mul_d_96_word\n\t"
 #else
-        "BLT.N	L_sp_3072_mul_d_96_word%=\n\t"
+        "BLT.N	L_sp_3072_mul_d_96_word_%=\n\t"
 #endif
         "STR	r3, [%[r], #384]\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -14149,7 +14531,11 @@ static sp_digit sp_3072_cond_sub_48(sp_digit* r, const sp_digit* a, const sp_dig
         "MOV	r4, #0x0\n\t"
         "MOV	r5, #0x0\n\t"
         "\n"
-    "L_sp_3072_cond_sub_48_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_cond_sub_48_words:\n\t"
+#else
+    "L_sp_3072_cond_sub_48_words_%=:\n\t"
+#endif
         "SUBS	r4, r8, r4\n\t"
         "LDR	r6, [%[a], r5]\n\t"
         "LDR	r7, [%[b], r5]\n\t"
@@ -14159,10 +14545,12 @@ static sp_digit sp_3072_cond_sub_48(sp_digit* r, const sp_digit* a, const sp_dig
         "STR	r6, [%[r], r5]\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0xc0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_cond_sub_48_words%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_3072_cond_sub_48_words_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_3072_cond_sub_48_words\n\t"
 #else
-        "BLT.N	L_sp_3072_cond_sub_48_words%=\n\t"
+        "BLT.N	L_sp_3072_cond_sub_48_words_%=\n\t"
 #endif
         "MOV	%[r], r4\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -14401,7 +14789,11 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         "LDR	r4, [%[a]]\n\t"
         "LDR	r5, [%[a], #4]\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_48_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_mont_reduce_48_word:\n\t"
+#else
+    "L_sp_3072_mont_reduce_48_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "MUL	r10, %[mp], r4\n\t"
         /* a[i+0] += m[0] * mu */
@@ -14791,10 +15183,12 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         "ADD	r11, r11, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r11, #0xc0\n\t"
-#ifdef __GNUC__
-        "BLT	L_sp_3072_mont_reduce_48_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_3072_mont_reduce_48_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.W	L_sp_3072_mont_reduce_48_word\n\t"
 #else
-        "BLT.W	L_sp_3072_mont_reduce_48_word%=\n\t"
+        "BLT.W	L_sp_3072_mont_reduce_48_word_%=\n\t"
 #endif
         /* Loop Done */
         "STR	r4, [%[a]]\n\t"
@@ -14833,7 +15227,11 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         /* ca = 0 */
         "MOV	r3, #0x0\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_48_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_mont_reduce_48_word:\n\t"
+#else
+    "L_sp_3072_mont_reduce_48_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "LDR	r10, [%[a]]\n\t"
         "MUL	r8, %[mp], r10\n\t"
@@ -14841,7 +15239,11 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         "MOV	r12, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_48_mul%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_mont_reduce_48_mul:\n\t"
+#else
+    "L_sp_3072_mont_reduce_48_mul_%=:\n\t"
+#endif
         /* a[i+j+0] += m[j+0] * mu */
         "LDR	r7, [%[m], r12]\n\t"
         "LDR	r10, [%[a], r12]\n\t"
@@ -14883,10 +15285,12 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         /* j += 1 */
         "ADD	r12, r12, #0x4\n\t"
         "CMP	r12, #0xc0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mont_reduce_48_mul%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_3072_mont_reduce_48_mul_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_3072_mont_reduce_48_mul\n\t"
 #else
-        "BLT.N	L_sp_3072_mont_reduce_48_mul%=\n\t"
+        "BLT.N	L_sp_3072_mont_reduce_48_mul_%=\n\t"
 #endif
         "LDR	r10, [%[a], #192]\n\t"
         "ADDS	r4, r4, r3\n\t"
@@ -14899,10 +15303,12 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         "ADD	r9, r9, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r9, #0xc0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mont_reduce_48_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_3072_mont_reduce_48_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_3072_mont_reduce_48_word\n\t"
 #else
-        "BLT.N	L_sp_3072_mont_reduce_48_word%=\n\t"
+        "BLT.N	L_sp_3072_mont_reduce_48_word_%=\n\t"
 #endif
         /* Loop Done */
         "MOV	%[mp], r3\n\t"
@@ -14944,7 +15350,11 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         "LDR	r9, [%[a], #12]\n\t"
         "LDR	r10, [%[a], #16]\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_48_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_mont_reduce_48_word:\n\t"
+#else
+    "L_sp_3072_mont_reduce_48_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "MUL	lr, %[mp], r6\n\t"
         /* a[i+0] += m[0] * mu */
@@ -15191,10 +15601,12 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         "ADD	r4, r4, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r4, #0xc0\n\t"
-#ifdef __GNUC__
-        "BLT	L_sp_3072_mont_reduce_48_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_3072_mont_reduce_48_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.W	L_sp_3072_mont_reduce_48_word\n\t"
 #else
-        "BLT.W	L_sp_3072_mont_reduce_48_word%=\n\t"
+        "BLT.W	L_sp_3072_mont_reduce_48_word_%=\n\t"
 #endif
         /* Loop Done */
         "STR	r6, [%[a]]\n\t"
@@ -15236,7 +15648,11 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         /* ca = 0 */
         "MOV	r3, #0x0\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_48_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_mont_reduce_48_word:\n\t"
+#else
+    "L_sp_3072_mont_reduce_48_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "LDR	r10, [%[a]]\n\t"
         "MUL	r8, %[mp], r10\n\t"
@@ -15244,7 +15660,11 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         "MOV	r12, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_48_mul%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_mont_reduce_48_mul:\n\t"
+#else
+    "L_sp_3072_mont_reduce_48_mul_%=:\n\t"
+#endif
         /* a[i+j+0] += m[j+0] * mu */
         "LDR	r7, [%[m], r12]\n\t"
         "LDR	r10, [%[a], r12]\n\t"
@@ -15274,10 +15694,12 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         /* j += 1 */
         "ADD	r12, r12, #0x4\n\t"
         "CMP	r12, #0xc0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mont_reduce_48_mul%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_3072_mont_reduce_48_mul_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_3072_mont_reduce_48_mul\n\t"
 #else
-        "BLT.N	L_sp_3072_mont_reduce_48_mul%=\n\t"
+        "BLT.N	L_sp_3072_mont_reduce_48_mul_%=\n\t"
 #endif
         "LDR	r10, [%[a], #192]\n\t"
         "ADDS	r4, r4, r3\n\t"
@@ -15290,10 +15712,12 @@ SP_NOINLINE static void sp_3072_mont_reduce_48(sp_digit* a, const sp_digit* m, s
         "ADD	r9, r9, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r9, #0xc0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mont_reduce_48_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_3072_mont_reduce_48_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_3072_mont_reduce_48_word\n\t"
 #else
-        "BLT.N	L_sp_3072_mont_reduce_48_word%=\n\t"
+        "BLT.N	L_sp_3072_mont_reduce_48_word_%=\n\t"
 #endif
         /* Loop Done */
         "MOV	%[mp], r3\n\t"
@@ -15364,7 +15788,11 @@ static void sp_3072_mul_d_48(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "MOV	r9, #0x4\n\t"
         "\n"
-    "L_sp_3072_mul_d_48_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_mul_d_48_word:\n\t"
+#else
+    "L_sp_3072_mul_d_48_word_%=:\n\t"
+#endif
         /* A[i] * B */
         "LDR	r8, [%[a], r9]\n\t"
         "UMULL	r6, r7, %[b], r8\n\t"
@@ -15377,10 +15805,12 @@ static void sp_3072_mul_d_48(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "ADD	r9, r9, #0x4\n\t"
         "CMP	r9, #0xc0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mul_d_48_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_3072_mul_d_48_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_3072_mul_d_48_word\n\t"
 #else
-        "BLT.N	L_sp_3072_mul_d_48_word%=\n\t"
+        "BLT.N	L_sp_3072_mul_d_48_word_%=\n\t"
 #endif
         "STR	r3, [%[r], #192]\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -15758,7 +16188,11 @@ SP_NOINLINE static sp_digit div_3072_word_48(sp_digit d1, sp_digit d0, sp_digit 
         /* Next 30 bits */
         "MOV	r4, #0x1d\n\t"
         "\n"
-    "L_div_3072_word_48_bit%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_div_3072_word_48_bit:\n\t"
+#else
+    "L_div_3072_word_48_bit_%=:\n\t"
+#endif
         "LSLS	r6, r6, #1\n\t"
         "ADC	r7, r7, r7\n\t"
         "SUBS	r8, r5, r7\n\t"
@@ -15768,7 +16202,13 @@ SP_NOINLINE static sp_digit div_3072_word_48(sp_digit d1, sp_digit d0, sp_digit 
         "AND	r8, r8, r5\n\t"
         "SUBS	r7, r7, r8\n\t"
         "SUBS	r4, r4, #0x1\n\t"
-        "bpl	L_div_3072_word_48_bit%=\n\t"
+#if defined(__GNUC__)
+        "BPL	L_div_3072_word_48_bit_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BPL.N	L_div_3072_word_48_bit\n\t"
+#else
+        "BPL.N	L_div_3072_word_48_bit_%=\n\t"
+#endif
         "ADD	r3, r3, r3\n\t"
         "ADD	r3, r3, #0x1\n\t"
         "UMULL	r6, r7, r3, %[div]\n\t"
@@ -15820,7 +16260,11 @@ static sp_int32 sp_3072_cmp_48(const sp_digit* a, const sp_digit* b)
 #ifdef WOLFSSL_SP_SMALL
         "MOV	r6, #0xbc\n\t"
         "\n"
-    "L_sp_3072_cmp_48_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_cmp_48_words:\n\t"
+#else
+    "L_sp_3072_cmp_48_words_%=:\n\t"
+#endif
         "LDR	r4, [%[a], r6]\n\t"
         "LDR	r5, [%[b], r6]\n\t"
         "AND	r4, r4, r3\n\t"
@@ -15833,7 +16277,7 @@ static sp_int32 sp_3072_cmp_48(const sp_digit* a, const sp_digit* b)
         "IT	ne\n\t"
         "movne	r3, r7\n\t"
         "SUBS	r6, r6, #0x4\n\t"
-        "bcs	L_sp_3072_cmp_48_words%=\n\t"
+        "bcs	L_sp_3072_cmp_48_words\n\t"
         "EOR	r2, r2, r3\n\t"
 #else
         "LDR	r4, [%[a], #188]\n\t"
@@ -16797,7 +17241,11 @@ static sp_digit sp_3072_cond_sub_96(sp_digit* r, const sp_digit* a, const sp_dig
         "MOV	r4, #0x0\n\t"
         "MOV	r5, #0x0\n\t"
         "\n"
-    "L_sp_3072_cond_sub_96_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_cond_sub_96_words:\n\t"
+#else
+    "L_sp_3072_cond_sub_96_words_%=:\n\t"
+#endif
         "SUBS	r4, r8, r4\n\t"
         "LDR	r6, [%[a], r5]\n\t"
         "LDR	r7, [%[b], r5]\n\t"
@@ -16807,10 +17255,12 @@ static sp_digit sp_3072_cond_sub_96(sp_digit* r, const sp_digit* a, const sp_dig
         "STR	r6, [%[r], r5]\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x180\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_cond_sub_96_words%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_3072_cond_sub_96_words_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_3072_cond_sub_96_words\n\t"
 #else
-        "BLT.N	L_sp_3072_cond_sub_96_words%=\n\t"
+        "BLT.N	L_sp_3072_cond_sub_96_words_%=\n\t"
 #endif
         "MOV	%[r], r4\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -17217,7 +17667,11 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         "LDR	r4, [%[a]]\n\t"
         "LDR	r5, [%[a], #4]\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_96_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_mont_reduce_96_word:\n\t"
+#else
+    "L_sp_3072_mont_reduce_96_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "MUL	r10, %[mp], r4\n\t"
         /* a[i+0] += m[0] * mu */
@@ -17991,10 +18445,12 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         "ADD	r11, r11, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r11, #0x180\n\t"
-#ifdef __GNUC__
-        "BLT	L_sp_3072_mont_reduce_96_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_3072_mont_reduce_96_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.W	L_sp_3072_mont_reduce_96_word\n\t"
 #else
-        "BLT.W	L_sp_3072_mont_reduce_96_word%=\n\t"
+        "BLT.W	L_sp_3072_mont_reduce_96_word_%=\n\t"
 #endif
         /* Loop Done */
         "STR	r4, [%[a]]\n\t"
@@ -18033,7 +18489,11 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         /* ca = 0 */
         "MOV	r3, #0x0\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_96_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_mont_reduce_96_word:\n\t"
+#else
+    "L_sp_3072_mont_reduce_96_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "LDR	r10, [%[a]]\n\t"
         "MUL	r8, %[mp], r10\n\t"
@@ -18041,7 +18501,11 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         "MOV	r12, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_96_mul%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_mont_reduce_96_mul:\n\t"
+#else
+    "L_sp_3072_mont_reduce_96_mul_%=:\n\t"
+#endif
         /* a[i+j+0] += m[j+0] * mu */
         "LDR	r7, [%[m], r12]\n\t"
         "LDR	r10, [%[a], r12]\n\t"
@@ -18083,10 +18547,12 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         /* j += 1 */
         "ADD	r12, r12, #0x4\n\t"
         "CMP	r12, #0x180\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mont_reduce_96_mul%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_3072_mont_reduce_96_mul_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_3072_mont_reduce_96_mul\n\t"
 #else
-        "BLT.N	L_sp_3072_mont_reduce_96_mul%=\n\t"
+        "BLT.N	L_sp_3072_mont_reduce_96_mul_%=\n\t"
 #endif
         "LDR	r10, [%[a], #384]\n\t"
         "ADDS	r4, r4, r3\n\t"
@@ -18099,10 +18565,12 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         "ADD	r9, r9, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r9, #0x180\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mont_reduce_96_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_3072_mont_reduce_96_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_3072_mont_reduce_96_word\n\t"
 #else
-        "BLT.N	L_sp_3072_mont_reduce_96_word%=\n\t"
+        "BLT.N	L_sp_3072_mont_reduce_96_word_%=\n\t"
 #endif
         /* Loop Done */
         "MOV	%[mp], r3\n\t"
@@ -18144,7 +18612,11 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         "LDR	r9, [%[a], #12]\n\t"
         "LDR	r10, [%[a], #16]\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_96_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_mont_reduce_96_word:\n\t"
+#else
+    "L_sp_3072_mont_reduce_96_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "MUL	lr, %[mp], r6\n\t"
         /* a[i+0] += m[0] * mu */
@@ -18631,10 +19103,12 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         "ADD	r4, r4, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r4, #0x180\n\t"
-#ifdef __GNUC__
-        "BLT	L_sp_3072_mont_reduce_96_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_3072_mont_reduce_96_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.W	L_sp_3072_mont_reduce_96_word\n\t"
 #else
-        "BLT.W	L_sp_3072_mont_reduce_96_word%=\n\t"
+        "BLT.W	L_sp_3072_mont_reduce_96_word_%=\n\t"
 #endif
         /* Loop Done */
         "STR	r6, [%[a]]\n\t"
@@ -18676,7 +19150,11 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         /* ca = 0 */
         "MOV	r3, #0x0\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_96_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_mont_reduce_96_word:\n\t"
+#else
+    "L_sp_3072_mont_reduce_96_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "LDR	r10, [%[a]]\n\t"
         "MUL	r8, %[mp], r10\n\t"
@@ -18684,7 +19162,11 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         "MOV	r12, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_3072_mont_reduce_96_mul%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_mont_reduce_96_mul:\n\t"
+#else
+    "L_sp_3072_mont_reduce_96_mul_%=:\n\t"
+#endif
         /* a[i+j+0] += m[j+0] * mu */
         "LDR	r7, [%[m], r12]\n\t"
         "LDR	r10, [%[a], r12]\n\t"
@@ -18714,10 +19196,12 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         /* j += 1 */
         "ADD	r12, r12, #0x4\n\t"
         "CMP	r12, #0x180\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mont_reduce_96_mul%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_3072_mont_reduce_96_mul_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_3072_mont_reduce_96_mul\n\t"
 #else
-        "BLT.N	L_sp_3072_mont_reduce_96_mul%=\n\t"
+        "BLT.N	L_sp_3072_mont_reduce_96_mul_%=\n\t"
 #endif
         "LDR	r10, [%[a], #384]\n\t"
         "ADDS	r4, r4, r3\n\t"
@@ -18730,10 +19214,12 @@ SP_NOINLINE static void sp_3072_mont_reduce_96(sp_digit* a, const sp_digit* m, s
         "ADD	r9, r9, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r9, #0x180\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_mont_reduce_96_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_3072_mont_reduce_96_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_3072_mont_reduce_96_word\n\t"
 #else
-        "BLT.N	L_sp_3072_mont_reduce_96_word%=\n\t"
+        "BLT.N	L_sp_3072_mont_reduce_96_word_%=\n\t"
 #endif
         /* Loop Done */
         "MOV	%[mp], r3\n\t"
@@ -18799,7 +19285,11 @@ static sp_digit sp_3072_sub_96(sp_digit* r, const sp_digit* a, const sp_digit* b
         "MOV	r11, #0x0\n\t"
         "ADD	r12, %[a], #0x180\n\t"
         "\n"
-    "L_sp_3072_sub_96_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_sub_96_word:\n\t"
+#else
+    "L_sp_3072_sub_96_word_%=:\n\t"
+#endif
         "RSBS	r11, r11, #0x0\n\t"
         "LDM	%[a]!, {r3, r4, r5, r6}\n\t"
         "LDM	%[b]!, {r7, r8, r9, r10}\n\t"
@@ -18810,10 +19300,12 @@ static sp_digit sp_3072_sub_96(sp_digit* r, const sp_digit* a, const sp_digit* b
         "STM	%[r]!, {r3, r4, r5, r6}\n\t"
         "SBC	r11, r3, r3\n\t"
         "CMP	%[a], r12\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_3072_sub_96_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_3072_sub_96_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_3072_sub_96_word\n\t"
 #else
-        "BNE.N	L_sp_3072_sub_96_word%=\n\t"
+        "BNE.N	L_sp_3072_sub_96_word_%=\n\t"
 #endif
         "MOV	%[r], r11\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -19122,7 +19614,11 @@ SP_NOINLINE static sp_digit div_3072_word_96(sp_digit d1, sp_digit d0, sp_digit 
         /* Next 30 bits */
         "MOV	r4, #0x1d\n\t"
         "\n"
-    "L_div_3072_word_96_bit%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_div_3072_word_96_bit:\n\t"
+#else
+    "L_div_3072_word_96_bit_%=:\n\t"
+#endif
         "LSLS	r6, r6, #1\n\t"
         "ADC	r7, r7, r7\n\t"
         "SUBS	r8, r5, r7\n\t"
@@ -19132,7 +19628,13 @@ SP_NOINLINE static sp_digit div_3072_word_96(sp_digit d1, sp_digit d0, sp_digit 
         "AND	r8, r8, r5\n\t"
         "SUBS	r7, r7, r8\n\t"
         "SUBS	r4, r4, #0x1\n\t"
-        "bpl	L_div_3072_word_96_bit%=\n\t"
+#if defined(__GNUC__)
+        "BPL	L_div_3072_word_96_bit_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BPL.N	L_div_3072_word_96_bit\n\t"
+#else
+        "BPL.N	L_div_3072_word_96_bit_%=\n\t"
+#endif
         "ADD	r3, r3, r3\n\t"
         "ADD	r3, r3, #0x1\n\t"
         "UMULL	r6, r7, r3, %[div]\n\t"
@@ -19287,7 +19789,11 @@ static sp_int32 sp_3072_cmp_96(const sp_digit* a, const sp_digit* b)
 #ifdef WOLFSSL_SP_SMALL
         "MOV	r6, #0x17c\n\t"
         "\n"
-    "L_sp_3072_cmp_96_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_cmp_96_words:\n\t"
+#else
+    "L_sp_3072_cmp_96_words_%=:\n\t"
+#endif
         "LDR	r4, [%[a], r6]\n\t"
         "LDR	r5, [%[b], r6]\n\t"
         "AND	r4, r4, r3\n\t"
@@ -19300,7 +19806,7 @@ static sp_int32 sp_3072_cmp_96(const sp_digit* a, const sp_digit* b)
         "IT	ne\n\t"
         "movne	r3, r7\n\t"
         "SUBS	r6, r6, #0x4\n\t"
-        "bcs	L_sp_3072_cmp_96_words%=\n\t"
+        "bcs	L_sp_3072_cmp_96_words\n\t"
         "EOR	r2, r2, r3\n\t"
 #else
         "LDR	r4, [%[a], #380]\n\t"
@@ -20915,7 +21421,11 @@ static sp_digit sp_3072_cond_add_48(sp_digit* r, const sp_digit* a, const sp_dig
         "MOV	r8, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_3072_cond_add_48_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_3072_cond_add_48_words:\n\t"
+#else
+    "L_sp_3072_cond_add_48_words_%=:\n\t"
+#endif
         "ADDS	r5, r5, #0xffffffff\n\t"
         "LDR	r6, [%[a], r4]\n\t"
         "LDR	r7, [%[b], r4]\n\t"
@@ -20925,10 +21435,12 @@ static sp_digit sp_3072_cond_add_48(sp_digit* r, const sp_digit* a, const sp_dig
         "STR	r6, [%[r], r4]\n\t"
         "ADD	r4, r4, #0x4\n\t"
         "CMP	r4, #0xc0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_3072_cond_add_48_words%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_3072_cond_add_48_words_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_3072_cond_add_48_words\n\t"
 #else
-        "BLT.N	L_sp_3072_cond_add_48_words%=\n\t"
+        "BLT.N	L_sp_3072_cond_add_48_words_%=\n\t"
 #endif
         "MOV	%[r], r5\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -23059,7 +23571,11 @@ static sp_digit sp_4096_add_128(sp_digit* r, const sp_digit* a, const sp_digit* 
         "MOV	r3, #0x0\n\t"
         "ADD	r12, %[a], #0x200\n\t"
         "\n"
-    "L_sp_4096_add_128_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_4096_add_128_word:\n\t"
+#else
+    "L_sp_4096_add_128_word_%=:\n\t"
+#endif
         "ADDS	r3, r3, #0xffffffff\n\t"
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
         "LDM	%[b]!, {r8, r9, r10, r11}\n\t"
@@ -23071,10 +23587,12 @@ static sp_digit sp_4096_add_128(sp_digit* r, const sp_digit* a, const sp_digit* 
         "MOV	r4, #0x0\n\t"
         "ADC	r3, r4, #0x0\n\t"
         "CMP	%[a], r12\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_4096_add_128_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_4096_add_128_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_4096_add_128_word\n\t"
 #else
-        "BNE.N	L_sp_4096_add_128_word%=\n\t"
+        "BNE.N	L_sp_4096_add_128_word_%=\n\t"
 #endif
         "MOV	%[r], r3\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -23106,7 +23624,11 @@ static sp_digit sp_4096_sub_in_place_128(sp_digit* a, const sp_digit* b)
         "MOV	r10, #0x0\n\t"
         "ADD	r11, %[a], #0x200\n\t"
         "\n"
-    "L_sp_4096_sub_in_pkace_128_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_4096_sub_in_pkace_128_word:\n\t"
+#else
+    "L_sp_4096_sub_in_pkace_128_word_%=:\n\t"
+#endif
         "RSBS	r10, r10, #0x0\n\t"
         "LDM	%[a], {r2, r3, r4, r5}\n\t"
         "LDM	%[b]!, {r6, r7, r8, r9}\n\t"
@@ -23117,10 +23639,12 @@ static sp_digit sp_4096_sub_in_place_128(sp_digit* a, const sp_digit* b)
         "STM	%[a]!, {r2, r3, r4, r5}\n\t"
         "SBC	r10, r10, r10\n\t"
         "CMP	%[a], r11\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_4096_sub_in_pkace_128_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_4096_sub_in_pkace_128_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_4096_sub_in_pkace_128_word\n\t"
 #else
-        "BNE.N	L_sp_4096_sub_in_pkace_128_word%=\n\t"
+        "BNE.N	L_sp_4096_sub_in_pkace_128_word_%=\n\t"
 #endif
         "MOV	%[a], r10\n\t"
         : [a] "+r" (a), [b] "+r" (b)
@@ -23160,13 +23684,21 @@ static void sp_4096_mul_128(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_4096_mul_128_outer%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_4096_mul_128_outer:\n\t"
+#else
+    "L_sp_4096_mul_128_outer_%=:\n\t"
+#endif
         "SUBS	r3, r5, #0x1fc\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_4096_mul_128_inner%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_4096_mul_128_inner:\n\t"
+#else
+    "L_sp_4096_mul_128_inner_%=:\n\t"
+#endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -23182,15 +23714,19 @@ static void sp_4096_mul_128(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r3, r3, #0x4\n\t"
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_4096_mul_128_inner_done%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_4096_mul_128_inner_done_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_4096_mul_128_inner_done\n\t"
 #else
-        "BGT.N	L_sp_4096_mul_128_inner_done%=\n\t"
+        "BGT.N	L_sp_4096_mul_128_inner_done_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_4096_mul_128_inner%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_4096_mul_128_inner_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_4096_mul_128_inner\n\t"
 #else
-        "BLT.N	L_sp_4096_mul_128_inner%=\n\t"
+        "BLT.N	L_sp_4096_mul_128_inner_%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r3]\n\t"
@@ -23199,17 +23735,23 @@ static void sp_4096_mul_128(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_4096_mul_128_inner_done%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_4096_mul_128_inner_done:\n\t"
+#else
+    "L_sp_4096_mul_128_inner_done_%=:\n\t"
+#endif
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
         "MOV	r8, #0x0\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x3f4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_4096_mul_128_outer%=\n\t"
+#if defined(__GNUC__)
+        "BLE	L_sp_4096_mul_128_outer_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLE.N	L_sp_4096_mul_128_outer\n\t"
 #else
-        "BLE.N	L_sp_4096_mul_128_outer%=\n\t"
+        "BLE.N	L_sp_4096_mul_128_outer_%=\n\t"
 #endif
         "LDR	lr, [%[a], #508]\n\t"
         "LDR	r11, [%[b], #508]\n\t"
@@ -23218,14 +23760,20 @@ static void sp_4096_mul_128(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_4096_mul_128_store%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_4096_mul_128_store:\n\t"
+#else
+    "L_sp_4096_mul_128_store_%=:\n\t"
+#endif
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_4096_mul_128_store%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_4096_mul_128_store_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_4096_mul_128_store\n\t"
 #else
-        "BGT.N	L_sp_4096_mul_128_store%=\n\t"
+        "BGT.N	L_sp_4096_mul_128_store_%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
@@ -23258,13 +23806,21 @@ static void sp_4096_sqr_128(sp_digit* r, const sp_digit* a)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_4096_sqr_128_outer%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_4096_sqr_128_outer:\n\t"
+#else
+    "L_sp_4096_sqr_128_outer_%=:\n\t"
+#endif
         "SUBS	r3, r5, #0x1fc\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_4096_sqr_128_inner%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_4096_sqr_128_inner:\n\t"
+#else
+    "L_sp_4096_sqr_128_inner_%=:\n\t"
+#endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[a], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -23277,15 +23833,19 @@ static void sp_4096_sqr_128(sp_digit* r, const sp_digit* a)
         "ADD	r3, r3, #0x4\n\t"
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_4096_sqr_128_inner_done%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_4096_sqr_128_inner_done_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_4096_sqr_128_inner_done\n\t"
 #else
-        "BGT.N	L_sp_4096_sqr_128_inner_done%=\n\t"
+        "BGT.N	L_sp_4096_sqr_128_inner_done_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_4096_sqr_128_inner%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_4096_sqr_128_inner_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_4096_sqr_128_inner\n\t"
 #else
-        "BLT.N	L_sp_4096_sqr_128_inner%=\n\t"
+        "BLT.N	L_sp_4096_sqr_128_inner_%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "UMULL	r9, r10, lr, lr\n\t"
@@ -23293,17 +23853,23 @@ static void sp_4096_sqr_128(sp_digit* r, const sp_digit* a)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_4096_sqr_128_inner_done%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_4096_sqr_128_inner_done:\n\t"
+#else
+    "L_sp_4096_sqr_128_inner_done_%=:\n\t"
+#endif
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
         "MOV	r8, #0x0\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x3f4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_4096_sqr_128_outer%=\n\t"
+#if defined(__GNUC__)
+        "BLE	L_sp_4096_sqr_128_outer_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLE.N	L_sp_4096_sqr_128_outer\n\t"
 #else
-        "BLE.N	L_sp_4096_sqr_128_outer%=\n\t"
+        "BLE.N	L_sp_4096_sqr_128_outer_%=\n\t"
 #endif
         "LDR	lr, [%[a], #508]\n\t"
         "UMLAL	r6, r7, lr, lr\n\t"
@@ -23311,14 +23877,20 @@ static void sp_4096_sqr_128(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_4096_sqr_128_store%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_4096_sqr_128_store:\n\t"
+#else
+    "L_sp_4096_sqr_128_store_%=:\n\t"
+#endif
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_4096_sqr_128_store%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_4096_sqr_128_store_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_4096_sqr_128_store\n\t"
 #else
-        "BGT.N	L_sp_4096_sqr_128_store%=\n\t"
+        "BGT.N	L_sp_4096_sqr_128_store_%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a)
         :
@@ -23375,7 +23947,11 @@ static void sp_4096_mul_d_128(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "MOV	r9, #0x4\n\t"
         "\n"
-    "L_sp_4096_mul_d_128_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_4096_mul_d_128_word:\n\t"
+#else
+    "L_sp_4096_mul_d_128_word_%=:\n\t"
+#endif
         /* A[i] * B */
         "LDR	r8, [%[a], r9]\n\t"
         "UMULL	r6, r7, %[b], r8\n\t"
@@ -23388,10 +23964,12 @@ static void sp_4096_mul_d_128(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "ADD	r9, r9, #0x4\n\t"
         "CMP	r9, #0x200\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_4096_mul_d_128_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_4096_mul_d_128_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_4096_mul_d_128_word\n\t"
 #else
-        "BLT.N	L_sp_4096_mul_d_128_word%=\n\t"
+        "BLT.N	L_sp_4096_mul_d_128_word_%=\n\t"
 #endif
         "STR	r3, [%[r], #512]\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -24110,7 +24688,11 @@ static sp_digit sp_4096_cond_sub_128(sp_digit* r, const sp_digit* a, const sp_di
         "MOV	r4, #0x0\n\t"
         "MOV	r5, #0x0\n\t"
         "\n"
-    "L_sp_4096_cond_sub_128_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_4096_cond_sub_128_words:\n\t"
+#else
+    "L_sp_4096_cond_sub_128_words_%=:\n\t"
+#endif
         "SUBS	r4, r8, r4\n\t"
         "LDR	r6, [%[a], r5]\n\t"
         "LDR	r7, [%[b], r5]\n\t"
@@ -24120,10 +24702,12 @@ static sp_digit sp_4096_cond_sub_128(sp_digit* r, const sp_digit* a, const sp_di
         "STR	r6, [%[r], r5]\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x200\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_4096_cond_sub_128_words%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_4096_cond_sub_128_words_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_4096_cond_sub_128_words\n\t"
 #else
-        "BLT.N	L_sp_4096_cond_sub_128_words%=\n\t"
+        "BLT.N	L_sp_4096_cond_sub_128_words_%=\n\t"
 #endif
         "MOV	%[r], r4\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -24642,7 +25226,11 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         "LDR	r4, [%[a]]\n\t"
         "LDR	r5, [%[a], #4]\n\t"
         "\n"
-    "L_sp_4096_mont_reduce_128_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_4096_mont_reduce_128_word:\n\t"
+#else
+    "L_sp_4096_mont_reduce_128_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "MUL	r10, %[mp], r4\n\t"
         /* a[i+0] += m[0] * mu */
@@ -25672,10 +26260,12 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         "ADD	r11, r11, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r11, #0x200\n\t"
-#ifdef __GNUC__
-        "BLT	L_sp_4096_mont_reduce_128_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_4096_mont_reduce_128_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.W	L_sp_4096_mont_reduce_128_word\n\t"
 #else
-        "BLT.W	L_sp_4096_mont_reduce_128_word%=\n\t"
+        "BLT.W	L_sp_4096_mont_reduce_128_word_%=\n\t"
 #endif
         /* Loop Done */
         "STR	r4, [%[a]]\n\t"
@@ -25714,7 +26304,11 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         /* ca = 0 */
         "MOV	r3, #0x0\n\t"
         "\n"
-    "L_sp_4096_mont_reduce_128_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_4096_mont_reduce_128_word:\n\t"
+#else
+    "L_sp_4096_mont_reduce_128_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "LDR	r10, [%[a]]\n\t"
         "MUL	r8, %[mp], r10\n\t"
@@ -25722,7 +26316,11 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         "MOV	r12, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_4096_mont_reduce_128_mul%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_4096_mont_reduce_128_mul:\n\t"
+#else
+    "L_sp_4096_mont_reduce_128_mul_%=:\n\t"
+#endif
         /* a[i+j+0] += m[j+0] * mu */
         "LDR	r7, [%[m], r12]\n\t"
         "LDR	r10, [%[a], r12]\n\t"
@@ -25764,10 +26362,12 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         /* j += 1 */
         "ADD	r12, r12, #0x4\n\t"
         "CMP	r12, #0x200\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_4096_mont_reduce_128_mul%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_4096_mont_reduce_128_mul_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_4096_mont_reduce_128_mul\n\t"
 #else
-        "BLT.N	L_sp_4096_mont_reduce_128_mul%=\n\t"
+        "BLT.N	L_sp_4096_mont_reduce_128_mul_%=\n\t"
 #endif
         "LDR	r10, [%[a], #512]\n\t"
         "ADDS	r4, r4, r3\n\t"
@@ -25780,10 +26380,12 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         "ADD	r9, r9, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r9, #0x200\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_4096_mont_reduce_128_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_4096_mont_reduce_128_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_4096_mont_reduce_128_word\n\t"
 #else
-        "BLT.N	L_sp_4096_mont_reduce_128_word%=\n\t"
+        "BLT.N	L_sp_4096_mont_reduce_128_word_%=\n\t"
 #endif
         /* Loop Done */
         "MOV	%[mp], r3\n\t"
@@ -25825,7 +26427,11 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         "LDR	r9, [%[a], #12]\n\t"
         "LDR	r10, [%[a], #16]\n\t"
         "\n"
-    "L_sp_4096_mont_reduce_128_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_4096_mont_reduce_128_word:\n\t"
+#else
+    "L_sp_4096_mont_reduce_128_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "MUL	lr, %[mp], r6\n\t"
         /* a[i+0] += m[0] * mu */
@@ -26472,10 +27078,12 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         "ADD	r4, r4, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r4, #0x200\n\t"
-#ifdef __GNUC__
-        "BLT	L_sp_4096_mont_reduce_128_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_4096_mont_reduce_128_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.W	L_sp_4096_mont_reduce_128_word\n\t"
 #else
-        "BLT.W	L_sp_4096_mont_reduce_128_word%=\n\t"
+        "BLT.W	L_sp_4096_mont_reduce_128_word_%=\n\t"
 #endif
         /* Loop Done */
         "STR	r6, [%[a]]\n\t"
@@ -26517,7 +27125,11 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         /* ca = 0 */
         "MOV	r3, #0x0\n\t"
         "\n"
-    "L_sp_4096_mont_reduce_128_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_4096_mont_reduce_128_word:\n\t"
+#else
+    "L_sp_4096_mont_reduce_128_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "LDR	r10, [%[a]]\n\t"
         "MUL	r8, %[mp], r10\n\t"
@@ -26525,7 +27137,11 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         "MOV	r12, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_4096_mont_reduce_128_mul%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_4096_mont_reduce_128_mul:\n\t"
+#else
+    "L_sp_4096_mont_reduce_128_mul_%=:\n\t"
+#endif
         /* a[i+j+0] += m[j+0] * mu */
         "LDR	r7, [%[m], r12]\n\t"
         "LDR	r10, [%[a], r12]\n\t"
@@ -26555,10 +27171,12 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         /* j += 1 */
         "ADD	r12, r12, #0x4\n\t"
         "CMP	r12, #0x200\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_4096_mont_reduce_128_mul%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_4096_mont_reduce_128_mul_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_4096_mont_reduce_128_mul\n\t"
 #else
-        "BLT.N	L_sp_4096_mont_reduce_128_mul%=\n\t"
+        "BLT.N	L_sp_4096_mont_reduce_128_mul_%=\n\t"
 #endif
         "LDR	r10, [%[a], #512]\n\t"
         "ADDS	r4, r4, r3\n\t"
@@ -26571,10 +27189,12 @@ SP_NOINLINE static void sp_4096_mont_reduce_128(sp_digit* a, const sp_digit* m, 
         "ADD	r9, r9, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r9, #0x200\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_4096_mont_reduce_128_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_4096_mont_reduce_128_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_4096_mont_reduce_128_word\n\t"
 #else
-        "BLT.N	L_sp_4096_mont_reduce_128_word%=\n\t"
+        "BLT.N	L_sp_4096_mont_reduce_128_word_%=\n\t"
 #endif
         /* Loop Done */
         "MOV	%[mp], r3\n\t"
@@ -26640,7 +27260,11 @@ static sp_digit sp_4096_sub_128(sp_digit* r, const sp_digit* a, const sp_digit* 
         "MOV	r11, #0x0\n\t"
         "ADD	r12, %[a], #0x200\n\t"
         "\n"
-    "L_sp_4096_sub_128_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_4096_sub_128_word:\n\t"
+#else
+    "L_sp_4096_sub_128_word_%=:\n\t"
+#endif
         "RSBS	r11, r11, #0x0\n\t"
         "LDM	%[a]!, {r3, r4, r5, r6}\n\t"
         "LDM	%[b]!, {r7, r8, r9, r10}\n\t"
@@ -26651,10 +27275,12 @@ static sp_digit sp_4096_sub_128(sp_digit* r, const sp_digit* a, const sp_digit* 
         "STM	%[r]!, {r3, r4, r5, r6}\n\t"
         "SBC	r11, r3, r3\n\t"
         "CMP	%[a], r12\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_4096_sub_128_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_4096_sub_128_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_4096_sub_128_word\n\t"
 #else
-        "BNE.N	L_sp_4096_sub_128_word%=\n\t"
+        "BNE.N	L_sp_4096_sub_128_word_%=\n\t"
 #endif
         "MOV	%[r], r11\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -27019,7 +27645,11 @@ SP_NOINLINE static sp_digit div_4096_word_128(sp_digit d1, sp_digit d0, sp_digit
         /* Next 30 bits */
         "MOV	r4, #0x1d\n\t"
         "\n"
-    "L_div_4096_word_128_bit%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_div_4096_word_128_bit:\n\t"
+#else
+    "L_div_4096_word_128_bit_%=:\n\t"
+#endif
         "LSLS	r6, r6, #1\n\t"
         "ADC	r7, r7, r7\n\t"
         "SUBS	r8, r5, r7\n\t"
@@ -27029,7 +27659,13 @@ SP_NOINLINE static sp_digit div_4096_word_128(sp_digit d1, sp_digit d0, sp_digit
         "AND	r8, r8, r5\n\t"
         "SUBS	r7, r7, r8\n\t"
         "SUBS	r4, r4, #0x1\n\t"
-        "bpl	L_div_4096_word_128_bit%=\n\t"
+#if defined(__GNUC__)
+        "BPL	L_div_4096_word_128_bit_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BPL.N	L_div_4096_word_128_bit\n\t"
+#else
+        "BPL.N	L_div_4096_word_128_bit_%=\n\t"
+#endif
         "ADD	r3, r3, r3\n\t"
         "ADD	r3, r3, #0x1\n\t"
         "UMULL	r6, r7, r3, %[div]\n\t"
@@ -27184,7 +27820,11 @@ static sp_int32 sp_4096_cmp_128(const sp_digit* a, const sp_digit* b)
 #ifdef WOLFSSL_SP_SMALL
         "MOV	r6, #0x1fc\n\t"
         "\n"
-    "L_sp_4096_cmp_128_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_4096_cmp_128_words:\n\t"
+#else
+    "L_sp_4096_cmp_128_words_%=:\n\t"
+#endif
         "LDR	r4, [%[a], r6]\n\t"
         "LDR	r5, [%[b], r6]\n\t"
         "AND	r4, r4, r3\n\t"
@@ -27197,7 +27837,7 @@ static sp_int32 sp_4096_cmp_128(const sp_digit* a, const sp_digit* b)
         "IT	ne\n\t"
         "movne	r3, r7\n\t"
         "SUBS	r6, r6, #0x4\n\t"
-        "bcs	L_sp_4096_cmp_128_words%=\n\t"
+        "bcs	L_sp_4096_cmp_128_words\n\t"
         "EOR	r2, r2, r3\n\t"
 #else
         "LDR	r4, [%[a], #508]\n\t"
@@ -29164,7 +29804,11 @@ static sp_digit sp_4096_cond_add_64(sp_digit* r, const sp_digit* a, const sp_dig
         "MOV	r8, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_4096_cond_add_64_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_4096_cond_add_64_words:\n\t"
+#else
+    "L_sp_4096_cond_add_64_words_%=:\n\t"
+#endif
         "ADDS	r5, r5, #0xffffffff\n\t"
         "LDR	r6, [%[a], r4]\n\t"
         "LDR	r7, [%[b], r4]\n\t"
@@ -29174,10 +29818,12 @@ static sp_digit sp_4096_cond_add_64(sp_digit* r, const sp_digit* a, const sp_dig
         "STR	r6, [%[r], r4]\n\t"
         "ADD	r4, r4, #0x4\n\t"
         "CMP	r4, #0x100\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_4096_cond_add_64_words%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_4096_cond_add_64_words_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_4096_cond_add_64_words\n\t"
 #else
-        "BLT.N	L_sp_4096_cond_add_64_words%=\n\t"
+        "BLT.N	L_sp_4096_cond_add_64_words_%=\n\t"
 #endif
         "MOV	%[r], r5\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -30857,13 +31503,21 @@ static void sp_256_mul_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_256_mul_8_outer%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_mul_8_outer:\n\t"
+#else
+    "L_sp_256_mul_8_outer_%=:\n\t"
+#endif
         "SUBS	r3, r5, #0x1c\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_256_mul_8_inner%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_mul_8_inner:\n\t"
+#else
+    "L_sp_256_mul_8_inner_%=:\n\t"
+#endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -30879,15 +31533,19 @@ static void sp_256_mul_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r3, r3, #0x4\n\t"
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_256_mul_8_inner_done%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_256_mul_8_inner_done_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_256_mul_8_inner_done\n\t"
 #else
-        "BGT.N	L_sp_256_mul_8_inner_done%=\n\t"
+        "BGT.N	L_sp_256_mul_8_inner_done_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_256_mul_8_inner%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_256_mul_8_inner_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_256_mul_8_inner\n\t"
 #else
-        "BLT.N	L_sp_256_mul_8_inner%=\n\t"
+        "BLT.N	L_sp_256_mul_8_inner_%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r3]\n\t"
@@ -30896,17 +31554,23 @@ static void sp_256_mul_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_256_mul_8_inner_done%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_mul_8_inner_done:\n\t"
+#else
+    "L_sp_256_mul_8_inner_done_%=:\n\t"
+#endif
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
         "MOV	r8, #0x0\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x34\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_256_mul_8_outer%=\n\t"
+#if defined(__GNUC__)
+        "BLE	L_sp_256_mul_8_outer_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLE.N	L_sp_256_mul_8_outer\n\t"
 #else
-        "BLE.N	L_sp_256_mul_8_outer%=\n\t"
+        "BLE.N	L_sp_256_mul_8_outer_%=\n\t"
 #endif
         "LDR	lr, [%[a], #28]\n\t"
         "LDR	r11, [%[b], #28]\n\t"
@@ -30915,14 +31579,20 @@ static void sp_256_mul_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_256_mul_8_store%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_mul_8_store:\n\t"
+#else
+    "L_sp_256_mul_8_store_%=:\n\t"
+#endif
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_256_mul_8_store%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_256_mul_8_store_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_256_mul_8_store\n\t"
 #else
-        "BGT.N	L_sp_256_mul_8_store%=\n\t"
+        "BGT.N	L_sp_256_mul_8_store_%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
@@ -31455,13 +32125,21 @@ static void sp_256_sqr_8(sp_digit* r, const sp_digit* a)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_256_sqr_8_outer%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_sqr_8_outer:\n\t"
+#else
+    "L_sp_256_sqr_8_outer_%=:\n\t"
+#endif
         "SUBS	r3, r5, #0x1c\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_256_sqr_8_inner%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_sqr_8_inner:\n\t"
+#else
+    "L_sp_256_sqr_8_inner_%=:\n\t"
+#endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[a], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -31474,15 +32152,19 @@ static void sp_256_sqr_8(sp_digit* r, const sp_digit* a)
         "ADD	r3, r3, #0x4\n\t"
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_256_sqr_8_inner_done%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_256_sqr_8_inner_done_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_256_sqr_8_inner_done\n\t"
 #else
-        "BGT.N	L_sp_256_sqr_8_inner_done%=\n\t"
+        "BGT.N	L_sp_256_sqr_8_inner_done_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_256_sqr_8_inner%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_256_sqr_8_inner_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_256_sqr_8_inner\n\t"
 #else
-        "BLT.N	L_sp_256_sqr_8_inner%=\n\t"
+        "BLT.N	L_sp_256_sqr_8_inner_%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "UMULL	r9, r10, lr, lr\n\t"
@@ -31490,17 +32172,23 @@ static void sp_256_sqr_8(sp_digit* r, const sp_digit* a)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_256_sqr_8_inner_done%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_sqr_8_inner_done:\n\t"
+#else
+    "L_sp_256_sqr_8_inner_done_%=:\n\t"
+#endif
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
         "MOV	r8, #0x0\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x34\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_256_sqr_8_outer%=\n\t"
+#if defined(__GNUC__)
+        "BLE	L_sp_256_sqr_8_outer_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLE.N	L_sp_256_sqr_8_outer\n\t"
 #else
-        "BLE.N	L_sp_256_sqr_8_outer%=\n\t"
+        "BLE.N	L_sp_256_sqr_8_outer_%=\n\t"
 #endif
         "LDR	lr, [%[a], #28]\n\t"
         "UMLAL	r6, r7, lr, lr\n\t"
@@ -31508,14 +32196,20 @@ static void sp_256_sqr_8(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_256_sqr_8_store%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_sqr_8_store:\n\t"
+#else
+    "L_sp_256_sqr_8_store_%=:\n\t"
+#endif
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_256_sqr_8_store%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_256_sqr_8_store_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_256_sqr_8_store\n\t"
 #else
-        "BGT.N	L_sp_256_sqr_8_store%=\n\t"
+        "BGT.N	L_sp_256_sqr_8_store_%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a)
         :
@@ -31915,7 +32609,11 @@ static sp_digit sp_256_add_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r3, #0x0\n\t"
         "ADD	r12, %[a], #0x20\n\t"
         "\n"
-    "L_sp_256_add_8_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_add_8_word:\n\t"
+#else
+    "L_sp_256_add_8_word_%=:\n\t"
+#endif
         "ADDS	r3, r3, #0xffffffff\n\t"
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
         "LDM	%[b]!, {r8, r9, r10, r11}\n\t"
@@ -31927,10 +32625,12 @@ static sp_digit sp_256_add_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r4, #0x0\n\t"
         "ADC	r3, r4, #0x0\n\t"
         "CMP	%[a], r12\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_256_add_8_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_256_add_8_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_256_add_8_word\n\t"
 #else
-        "BNE.N	L_sp_256_add_8_word%=\n\t"
+        "BNE.N	L_sp_256_add_8_word_%=\n\t"
 #endif
         "MOV	%[r], r3\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -33938,7 +34638,11 @@ static sp_int32 sp_256_cmp_8(const sp_digit* a, const sp_digit* b)
 #ifdef WOLFSSL_SP_SMALL
         "MOV	r6, #0x1c\n\t"
         "\n"
-    "L_sp_256_cmp_8_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_cmp_8_words:\n\t"
+#else
+    "L_sp_256_cmp_8_words_%=:\n\t"
+#endif
         "LDR	r4, [%[a], r6]\n\t"
         "LDR	r5, [%[b], r6]\n\t"
         "AND	r4, r4, r3\n\t"
@@ -33951,7 +34655,7 @@ static sp_int32 sp_256_cmp_8(const sp_digit* a, const sp_digit* b)
         "IT	ne\n\t"
         "movne	r3, r7\n\t"
         "SUBS	r6, r6, #0x4\n\t"
-        "bcs	L_sp_256_cmp_8_words%=\n\t"
+        "bcs	L_sp_256_cmp_8_words\n\t"
         "EOR	r2, r2, r3\n\t"
 #else
         "LDR	r4, [%[a], #28]\n\t"
@@ -34085,7 +34789,11 @@ static sp_digit sp_256_cond_sub_8(sp_digit* r, const sp_digit* a, const sp_digit
         "MOV	r4, #0x0\n\t"
         "MOV	r5, #0x0\n\t"
         "\n"
-    "L_sp_256_cond_sub_8_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_cond_sub_8_words:\n\t"
+#else
+    "L_sp_256_cond_sub_8_words_%=:\n\t"
+#endif
         "SUBS	r4, r8, r4\n\t"
         "LDR	r6, [%[a], r5]\n\t"
         "LDR	r7, [%[b], r5]\n\t"
@@ -34095,10 +34803,12 @@ static sp_digit sp_256_cond_sub_8(sp_digit* r, const sp_digit* a, const sp_digit
         "STR	r6, [%[r], r5]\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x20\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_256_cond_sub_8_words%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_256_cond_sub_8_words_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_256_cond_sub_8_words\n\t"
 #else
-        "BLT.N	L_sp_256_cond_sub_8_words%=\n\t"
+        "BLT.N	L_sp_256_cond_sub_8_words_%=\n\t"
 #endif
         "MOV	%[r], r4\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -34199,7 +34909,11 @@ SP_NOINLINE static void sp_256_mont_reduce_8(sp_digit* a, const sp_digit* m, sp_
         "LDR	r4, [%[a]]\n\t"
         "LDR	r5, [%[a], #4]\n\t"
         "\n"
-    "L_sp_256_mont_reduce_8_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_mont_reduce_8_word:\n\t"
+#else
+    "L_sp_256_mont_reduce_8_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "MUL	r10, %[mp], r4\n\t"
         /* a[i+0] += m[0] * mu */
@@ -34269,10 +34983,12 @@ SP_NOINLINE static void sp_256_mont_reduce_8(sp_digit* a, const sp_digit* m, sp_
         "ADD	r11, r11, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r11, #0x20\n\t"
-#ifdef __GNUC__
-        "BLT	L_sp_256_mont_reduce_8_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_256_mont_reduce_8_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.W	L_sp_256_mont_reduce_8_word\n\t"
 #else
-        "BLT.W	L_sp_256_mont_reduce_8_word%=\n\t"
+        "BLT.W	L_sp_256_mont_reduce_8_word_%=\n\t"
 #endif
         /* Loop Done */
         "STR	r4, [%[a]]\n\t"
@@ -34314,7 +35030,11 @@ SP_NOINLINE static void sp_256_mont_reduce_8(sp_digit* a, const sp_digit* m, sp_
         "LDR	r9, [%[a], #12]\n\t"
         "LDR	r10, [%[a], #16]\n\t"
         "\n"
-    "L_sp_256_mont_reduce_8_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_mont_reduce_8_word:\n\t"
+#else
+    "L_sp_256_mont_reduce_8_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "MUL	lr, %[mp], r6\n\t"
         /* a[i+0] += m[0] * mu */
@@ -34361,10 +35081,12 @@ SP_NOINLINE static void sp_256_mont_reduce_8(sp_digit* a, const sp_digit* m, sp_
         "ADD	r4, r4, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r4, #0x20\n\t"
-#ifdef __GNUC__
-        "BLT	L_sp_256_mont_reduce_8_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_256_mont_reduce_8_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.W	L_sp_256_mont_reduce_8_word\n\t"
 #else
-        "BLT.W	L_sp_256_mont_reduce_8_word%=\n\t"
+        "BLT.W	L_sp_256_mont_reduce_8_word_%=\n\t"
 #endif
         /* Loop Done */
         "STR	r6, [%[a]]\n\t"
@@ -34573,7 +35295,11 @@ SP_NOINLINE static void sp_256_mont_reduce_order_8(sp_digit* a, const sp_digit* 
         "LDR	r4, [%[a]]\n\t"
         "LDR	r5, [%[a], #4]\n\t"
         "\n"
-    "L_sp_256_mont_reduce_order_8_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_mont_reduce_order_8_word:\n\t"
+#else
+    "L_sp_256_mont_reduce_order_8_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "MUL	r10, %[mp], r4\n\t"
         /* a[i+0] += m[0] * mu */
@@ -34643,10 +35369,12 @@ SP_NOINLINE static void sp_256_mont_reduce_order_8(sp_digit* a, const sp_digit* 
         "ADD	r11, r11, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r11, #0x20\n\t"
-#ifdef __GNUC__
-        "BLT	L_sp_256_mont_reduce_order_8_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_256_mont_reduce_order_8_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.W	L_sp_256_mont_reduce_order_8_word\n\t"
 #else
-        "BLT.W	L_sp_256_mont_reduce_order_8_word%=\n\t"
+        "BLT.W	L_sp_256_mont_reduce_order_8_word_%=\n\t"
 #endif
         /* Loop Done */
         "STR	r4, [%[a]]\n\t"
@@ -34688,7 +35416,11 @@ SP_NOINLINE static void sp_256_mont_reduce_order_8(sp_digit* a, const sp_digit* 
         "LDR	r9, [%[a], #12]\n\t"
         "LDR	r10, [%[a], #16]\n\t"
         "\n"
-    "L_sp_256_mont_reduce_order_8_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_mont_reduce_order_8_word:\n\t"
+#else
+    "L_sp_256_mont_reduce_order_8_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "MUL	lr, %[mp], r6\n\t"
         /* a[i+0] += m[0] * mu */
@@ -34735,10 +35467,12 @@ SP_NOINLINE static void sp_256_mont_reduce_order_8(sp_digit* a, const sp_digit* 
         "ADD	r4, r4, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r4, #0x20\n\t"
-#ifdef __GNUC__
-        "BLT	L_sp_256_mont_reduce_order_8_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_256_mont_reduce_order_8_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.W	L_sp_256_mont_reduce_order_8_word\n\t"
 #else
-        "BLT.W	L_sp_256_mont_reduce_order_8_word%=\n\t"
+        "BLT.W	L_sp_256_mont_reduce_order_8_word_%=\n\t"
 #endif
         /* Loop Done */
         "STR	r6, [%[a]]\n\t"
@@ -39075,7 +39809,11 @@ static sp_digit sp_256_sub_in_place_8(sp_digit* a, const sp_digit* b)
         "MOV	r10, #0x0\n\t"
         "ADD	r11, %[a], #0x20\n\t"
         "\n"
-    "L_sp_256_sub_in_pkace_8_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_sub_in_pkace_8_word:\n\t"
+#else
+    "L_sp_256_sub_in_pkace_8_word_%=:\n\t"
+#endif
         "RSBS	r10, r10, #0x0\n\t"
         "LDM	%[a], {r2, r3, r4, r5}\n\t"
         "LDM	%[b]!, {r6, r7, r8, r9}\n\t"
@@ -39086,10 +39824,12 @@ static sp_digit sp_256_sub_in_place_8(sp_digit* a, const sp_digit* b)
         "STM	%[a]!, {r2, r3, r4, r5}\n\t"
         "SBC	r10, r10, r10\n\t"
         "CMP	%[a], r11\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_256_sub_in_pkace_8_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_256_sub_in_pkace_8_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_256_sub_in_pkace_8_word\n\t"
 #else
-        "BNE.N	L_sp_256_sub_in_pkace_8_word%=\n\t"
+        "BNE.N	L_sp_256_sub_in_pkace_8_word_%=\n\t"
 #endif
         "MOV	%[a], r10\n\t"
         : [a] "+r" (a), [b] "+r" (b)
@@ -39168,7 +39908,11 @@ static void sp_256_mul_d_8(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "MOV	r9, #0x4\n\t"
         "\n"
-    "L_sp_256_mul_d_8_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_mul_d_8_word:\n\t"
+#else
+    "L_sp_256_mul_d_8_word_%=:\n\t"
+#endif
         /* A[i] * B */
         "LDR	r8, [%[a], r9]\n\t"
         "UMULL	r6, r7, %[b], r8\n\t"
@@ -39181,10 +39925,12 @@ static void sp_256_mul_d_8(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "ADD	r9, r9, #0x4\n\t"
         "CMP	r9, #0x20\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_256_mul_d_8_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_256_mul_d_8_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_256_mul_d_8_word\n\t"
 #else
-        "BLT.N	L_sp_256_mul_d_8_word%=\n\t"
+        "BLT.N	L_sp_256_mul_d_8_word_%=\n\t"
 #endif
         "STR	r3, [%[r], #32]\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -39362,7 +40108,11 @@ SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1, sp_digit d0, sp_digit di
         /* Next 30 bits */
         "MOV	r4, #0x1d\n\t"
         "\n"
-    "L_div_256_word_8_bit%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_div_256_word_8_bit:\n\t"
+#else
+    "L_div_256_word_8_bit_%=:\n\t"
+#endif
         "LSLS	r6, r6, #1\n\t"
         "ADC	r7, r7, r7\n\t"
         "SUBS	r8, r5, r7\n\t"
@@ -39372,7 +40122,13 @@ SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1, sp_digit d0, sp_digit di
         "AND	r8, r8, r5\n\t"
         "SUBS	r7, r7, r8\n\t"
         "SUBS	r4, r4, #0x1\n\t"
-        "bpl	L_div_256_word_8_bit%=\n\t"
+#if defined(__GNUC__)
+        "BPL	L_div_256_word_8_bit_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BPL.N	L_div_256_word_8_bit\n\t"
+#else
+        "BPL.N	L_div_256_word_8_bit_%=\n\t"
+#endif
         "ADD	r3, r3, r3\n\t"
         "ADD	r3, r3, #0x1\n\t"
         "UMULL	r6, r7, r3, %[div]\n\t"
@@ -40066,7 +40822,11 @@ static sp_digit sp_256_sub_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r11, #0x0\n\t"
         "ADD	r12, %[a], #0x20\n\t"
         "\n"
-    "L_sp_256_sub_8_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_sub_8_word:\n\t"
+#else
+    "L_sp_256_sub_8_word_%=:\n\t"
+#endif
         "RSBS	r11, r11, #0x0\n\t"
         "LDM	%[a]!, {r3, r4, r5, r6}\n\t"
         "LDM	%[b]!, {r7, r8, r9, r10}\n\t"
@@ -40077,10 +40837,12 @@ static sp_digit sp_256_sub_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "STM	%[r]!, {r3, r4, r5, r6}\n\t"
         "SBC	r11, r3, r3\n\t"
         "CMP	%[a], r12\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_256_sub_8_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_256_sub_8_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_256_sub_8_word\n\t"
 #else
-        "BNE.N	L_sp_256_sub_8_word%=\n\t"
+        "BNE.N	L_sp_256_sub_8_word_%=\n\t"
 #endif
         "MOV	%[r], r11\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -40199,10 +40961,12 @@ static void sp_256_div2_mod_8(sp_digit* r, const sp_digit* a, const sp_digit* m)
         "MOV	r12, #0x0\n\t"
         "LDM	%[a]!, {r4}\n\t"
         "ANDS	r3, r4, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_256_div2_mod_8_even%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_256_div2_mod_8_even_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_256_div2_mod_8_even\n\t"
 #else
-        "BEQ.N	L_sp_256_div2_mod_8_even%=\n\t"
+        "BEQ.N	L_sp_256_div2_mod_8_even_%=\n\t"
 #endif
         "LDM	%[a]!, {r5, r6, r7}\n\t"
         "LDM	%[m]!, {r8, r9, r10, r11}\n\t"
@@ -40218,17 +40982,27 @@ static void sp_256_div2_mod_8(sp_digit* r, const sp_digit* a, const sp_digit* m)
         "ADCS	r6, r6, r10\n\t"
         "ADCS	r7, r7, r11\n\t"
         "ADC	r3, r12, r12\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_256_div2_mod_8_div2%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_256_div2_mod_8_div2_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_256_div2_mod_8_div2\n\t"
 #else
-        "B.N	L_sp_256_div2_mod_8_div2%=\n\t"
+        "B.N	L_sp_256_div2_mod_8_div2_%=\n\t"
 #endif
         "\n"
-    "L_sp_256_div2_mod_8_even%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_div2_mod_8_even:\n\t"
+#else
+    "L_sp_256_div2_mod_8_even_%=:\n\t"
+#endif
         "LDRD	r4, r5, [%[a], #12]\n\t"
         "LDRD	r6, r7, [%[a], #20]\n\t"
         "\n"
-    "L_sp_256_div2_mod_8_div2%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_div2_mod_8_div2:\n\t"
+#else
+    "L_sp_256_div2_mod_8_div2_%=:\n\t"
+#endif
         "LSR	r8, r4, #1\n\t"
         "AND	r4, r4, #0x1\n\t"
         "LSR	r9, r5, #1\n\t"
@@ -40270,129 +41044,189 @@ static int sp_256_num_bits_8(const sp_digit* a)
     __asm__ __volatile__ (
         "LDR	r1, [%[a], #28]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_256_num_bits_8_7%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_256_num_bits_8_7_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_256_num_bits_8_7\n\t"
 #else
-        "BEQ.N	L_sp_256_num_bits_8_7%=\n\t"
+        "BEQ.N	L_sp_256_num_bits_8_7_%=\n\t"
 #endif
         "MOV	r2, #0x100\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_256_num_bits_8_9%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_256_num_bits_8_9_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_256_num_bits_8_9\n\t"
 #else
-        "B.N	L_sp_256_num_bits_8_9%=\n\t"
+        "B.N	L_sp_256_num_bits_8_9_%=\n\t"
 #endif
         "\n"
-    "L_sp_256_num_bits_8_7%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_num_bits_8_7:\n\t"
+#else
+    "L_sp_256_num_bits_8_7_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #24]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_256_num_bits_8_6%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_256_num_bits_8_6_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_256_num_bits_8_6\n\t"
 #else
-        "BEQ.N	L_sp_256_num_bits_8_6%=\n\t"
+        "BEQ.N	L_sp_256_num_bits_8_6_%=\n\t"
 #endif
         "MOV	r2, #0xe0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_256_num_bits_8_9%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_256_num_bits_8_9_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_256_num_bits_8_9\n\t"
 #else
-        "B.N	L_sp_256_num_bits_8_9%=\n\t"
+        "B.N	L_sp_256_num_bits_8_9_%=\n\t"
 #endif
         "\n"
-    "L_sp_256_num_bits_8_6%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_num_bits_8_6:\n\t"
+#else
+    "L_sp_256_num_bits_8_6_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #20]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_256_num_bits_8_5%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_256_num_bits_8_5_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_256_num_bits_8_5\n\t"
 #else
-        "BEQ.N	L_sp_256_num_bits_8_5%=\n\t"
+        "BEQ.N	L_sp_256_num_bits_8_5_%=\n\t"
 #endif
         "MOV	r2, #0xc0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_256_num_bits_8_9%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_256_num_bits_8_9_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_256_num_bits_8_9\n\t"
 #else
-        "B.N	L_sp_256_num_bits_8_9%=\n\t"
+        "B.N	L_sp_256_num_bits_8_9_%=\n\t"
 #endif
         "\n"
-    "L_sp_256_num_bits_8_5%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_num_bits_8_5:\n\t"
+#else
+    "L_sp_256_num_bits_8_5_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #16]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_256_num_bits_8_4%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_256_num_bits_8_4_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_256_num_bits_8_4\n\t"
 #else
-        "BEQ.N	L_sp_256_num_bits_8_4%=\n\t"
+        "BEQ.N	L_sp_256_num_bits_8_4_%=\n\t"
 #endif
         "MOV	r2, #0xa0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_256_num_bits_8_9%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_256_num_bits_8_9_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_256_num_bits_8_9\n\t"
 #else
-        "B.N	L_sp_256_num_bits_8_9%=\n\t"
+        "B.N	L_sp_256_num_bits_8_9_%=\n\t"
 #endif
         "\n"
-    "L_sp_256_num_bits_8_4%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_num_bits_8_4:\n\t"
+#else
+    "L_sp_256_num_bits_8_4_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #12]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_256_num_bits_8_3%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_256_num_bits_8_3_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_256_num_bits_8_3\n\t"
 #else
-        "BEQ.N	L_sp_256_num_bits_8_3%=\n\t"
+        "BEQ.N	L_sp_256_num_bits_8_3_%=\n\t"
 #endif
         "MOV	r2, #0x80\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_256_num_bits_8_9%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_256_num_bits_8_9_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_256_num_bits_8_9\n\t"
 #else
-        "B.N	L_sp_256_num_bits_8_9%=\n\t"
+        "B.N	L_sp_256_num_bits_8_9_%=\n\t"
 #endif
         "\n"
-    "L_sp_256_num_bits_8_3%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_num_bits_8_3:\n\t"
+#else
+    "L_sp_256_num_bits_8_3_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #8]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_256_num_bits_8_2%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_256_num_bits_8_2_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_256_num_bits_8_2\n\t"
 #else
-        "BEQ.N	L_sp_256_num_bits_8_2%=\n\t"
+        "BEQ.N	L_sp_256_num_bits_8_2_%=\n\t"
 #endif
         "MOV	r2, #0x60\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_256_num_bits_8_9%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_256_num_bits_8_9_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_256_num_bits_8_9\n\t"
 #else
-        "B.N	L_sp_256_num_bits_8_9%=\n\t"
+        "B.N	L_sp_256_num_bits_8_9_%=\n\t"
 #endif
         "\n"
-    "L_sp_256_num_bits_8_2%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_num_bits_8_2:\n\t"
+#else
+    "L_sp_256_num_bits_8_2_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #4]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_256_num_bits_8_1%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_256_num_bits_8_1_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_256_num_bits_8_1\n\t"
 #else
-        "BEQ.N	L_sp_256_num_bits_8_1%=\n\t"
+        "BEQ.N	L_sp_256_num_bits_8_1_%=\n\t"
 #endif
         "MOV	r2, #0x40\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_256_num_bits_8_9%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_256_num_bits_8_9_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_256_num_bits_8_9\n\t"
 #else
-        "B.N	L_sp_256_num_bits_8_9%=\n\t"
+        "B.N	L_sp_256_num_bits_8_9_%=\n\t"
 #endif
         "\n"
-    "L_sp_256_num_bits_8_1%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_num_bits_8_1:\n\t"
+#else
+    "L_sp_256_num_bits_8_1_%=:\n\t"
+#endif
         "LDR	r1, [%[a]]\n\t"
         "MOV	r2, #0x20\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
         "\n"
-    "L_sp_256_num_bits_8_9%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_256_num_bits_8_9:\n\t"
+#else
+    "L_sp_256_num_bits_8_9_%=:\n\t"
+#endif
         "MOV	%[a], r4\n\t"
         : [a] "+r" (a)
         :
@@ -41515,13 +42349,21 @@ static void sp_384_mul_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_384_mul_12_outer%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_mul_12_outer:\n\t"
+#else
+    "L_sp_384_mul_12_outer_%=:\n\t"
+#endif
         "SUBS	r3, r5, #0x2c\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_384_mul_12_inner%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_mul_12_inner:\n\t"
+#else
+    "L_sp_384_mul_12_inner_%=:\n\t"
+#endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -41537,15 +42379,19 @@ static void sp_384_mul_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r3, r3, #0x4\n\t"
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_384_mul_12_inner_done%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_384_mul_12_inner_done_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_384_mul_12_inner_done\n\t"
 #else
-        "BGT.N	L_sp_384_mul_12_inner_done%=\n\t"
+        "BGT.N	L_sp_384_mul_12_inner_done_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_384_mul_12_inner%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_384_mul_12_inner_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_384_mul_12_inner\n\t"
 #else
-        "BLT.N	L_sp_384_mul_12_inner%=\n\t"
+        "BLT.N	L_sp_384_mul_12_inner_%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r3]\n\t"
@@ -41554,17 +42400,23 @@ static void sp_384_mul_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_384_mul_12_inner_done%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_mul_12_inner_done:\n\t"
+#else
+    "L_sp_384_mul_12_inner_done_%=:\n\t"
+#endif
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
         "MOV	r8, #0x0\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x54\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_384_mul_12_outer%=\n\t"
+#if defined(__GNUC__)
+        "BLE	L_sp_384_mul_12_outer_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLE.N	L_sp_384_mul_12_outer\n\t"
 #else
-        "BLE.N	L_sp_384_mul_12_outer%=\n\t"
+        "BLE.N	L_sp_384_mul_12_outer_%=\n\t"
 #endif
         "LDR	lr, [%[a], #44]\n\t"
         "LDR	r11, [%[b], #44]\n\t"
@@ -41573,14 +42425,20 @@ static void sp_384_mul_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_384_mul_12_store%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_mul_12_store:\n\t"
+#else
+    "L_sp_384_mul_12_store_%=:\n\t"
+#endif
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_384_mul_12_store%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_384_mul_12_store_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_384_mul_12_store\n\t"
 #else
-        "BGT.N	L_sp_384_mul_12_store%=\n\t"
+        "BGT.N	L_sp_384_mul_12_store_%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
@@ -42643,13 +43501,21 @@ static void sp_384_sqr_12(sp_digit* r, const sp_digit* a)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_384_sqr_12_outer%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_sqr_12_outer:\n\t"
+#else
+    "L_sp_384_sqr_12_outer_%=:\n\t"
+#endif
         "SUBS	r3, r5, #0x2c\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_384_sqr_12_inner%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_sqr_12_inner:\n\t"
+#else
+    "L_sp_384_sqr_12_inner_%=:\n\t"
+#endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[a], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -42662,15 +43528,19 @@ static void sp_384_sqr_12(sp_digit* r, const sp_digit* a)
         "ADD	r3, r3, #0x4\n\t"
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_384_sqr_12_inner_done%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_384_sqr_12_inner_done_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_384_sqr_12_inner_done\n\t"
 #else
-        "BGT.N	L_sp_384_sqr_12_inner_done%=\n\t"
+        "BGT.N	L_sp_384_sqr_12_inner_done_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_384_sqr_12_inner%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_384_sqr_12_inner_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_384_sqr_12_inner\n\t"
 #else
-        "BLT.N	L_sp_384_sqr_12_inner%=\n\t"
+        "BLT.N	L_sp_384_sqr_12_inner_%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "UMULL	r9, r10, lr, lr\n\t"
@@ -42678,17 +43548,23 @@ static void sp_384_sqr_12(sp_digit* r, const sp_digit* a)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_384_sqr_12_inner_done%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_sqr_12_inner_done:\n\t"
+#else
+    "L_sp_384_sqr_12_inner_done_%=:\n\t"
+#endif
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
         "MOV	r8, #0x0\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x54\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_384_sqr_12_outer%=\n\t"
+#if defined(__GNUC__)
+        "BLE	L_sp_384_sqr_12_outer_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLE.N	L_sp_384_sqr_12_outer\n\t"
 #else
-        "BLE.N	L_sp_384_sqr_12_outer%=\n\t"
+        "BLE.N	L_sp_384_sqr_12_outer_%=\n\t"
 #endif
         "LDR	lr, [%[a], #44]\n\t"
         "UMLAL	r6, r7, lr, lr\n\t"
@@ -42696,14 +43572,20 @@ static void sp_384_sqr_12(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_384_sqr_12_store%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_sqr_12_store:\n\t"
+#else
+    "L_sp_384_sqr_12_store_%=:\n\t"
+#endif
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_384_sqr_12_store%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_384_sqr_12_store_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_384_sqr_12_store\n\t"
 #else
-        "BGT.N	L_sp_384_sqr_12_store%=\n\t"
+        "BGT.N	L_sp_384_sqr_12_store_%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a)
         :
@@ -43436,7 +44318,11 @@ static sp_digit sp_384_add_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r3, #0x0\n\t"
         "ADD	r12, %[a], #0x30\n\t"
         "\n"
-    "L_sp_384_add_12_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_add_12_word:\n\t"
+#else
+    "L_sp_384_add_12_word_%=:\n\t"
+#endif
         "ADDS	r3, r3, #0xffffffff\n\t"
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
         "LDM	%[b]!, {r8, r9, r10, r11}\n\t"
@@ -43448,10 +44334,12 @@ static sp_digit sp_384_add_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r4, #0x0\n\t"
         "ADC	r3, r4, #0x0\n\t"
         "CMP	%[a], r12\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_384_add_12_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_384_add_12_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_384_add_12_word\n\t"
 #else
-        "BNE.N	L_sp_384_add_12_word%=\n\t"
+        "BNE.N	L_sp_384_add_12_word_%=\n\t"
 #endif
         "MOV	%[r], r3\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -43836,7 +44724,11 @@ static sp_digit sp_384_cond_sub_12(sp_digit* r, const sp_digit* a, const sp_digi
         "MOV	r4, #0x0\n\t"
         "MOV	r5, #0x0\n\t"
         "\n"
-    "L_sp_384_cond_sub_12_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_cond_sub_12_words:\n\t"
+#else
+    "L_sp_384_cond_sub_12_words_%=:\n\t"
+#endif
         "SUBS	r4, r8, r4\n\t"
         "LDR	r6, [%[a], r5]\n\t"
         "LDR	r7, [%[b], r5]\n\t"
@@ -43846,10 +44738,12 @@ static sp_digit sp_384_cond_sub_12(sp_digit* r, const sp_digit* a, const sp_digi
         "STR	r6, [%[r], r5]\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x30\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_384_cond_sub_12_words%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_384_cond_sub_12_words_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_384_cond_sub_12_words\n\t"
 #else
-        "BLT.N	L_sp_384_cond_sub_12_words%=\n\t"
+        "BLT.N	L_sp_384_cond_sub_12_words_%=\n\t"
 #endif
         "MOV	%[r], r4\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -43963,7 +44857,11 @@ SP_NOINLINE static void sp_384_mont_reduce_12(sp_digit* a, const sp_digit* m, sp
         "LDR	r4, [%[a]]\n\t"
         "LDR	r5, [%[a], #4]\n\t"
         "\n"
-    "L_sp_384_mont_reduce_12_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_mont_reduce_12_word:\n\t"
+#else
+    "L_sp_384_mont_reduce_12_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "MUL	r10, %[mp], r4\n\t"
         /* a[i+0] += m[0] * mu */
@@ -44065,10 +44963,12 @@ SP_NOINLINE static void sp_384_mont_reduce_12(sp_digit* a, const sp_digit* m, sp
         "ADD	r11, r11, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r11, #0x30\n\t"
-#ifdef __GNUC__
-        "BLT	L_sp_384_mont_reduce_12_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_384_mont_reduce_12_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.W	L_sp_384_mont_reduce_12_word\n\t"
 #else
-        "BLT.W	L_sp_384_mont_reduce_12_word%=\n\t"
+        "BLT.W	L_sp_384_mont_reduce_12_word_%=\n\t"
 #endif
         /* Loop Done */
         "STR	r4, [%[a]]\n\t"
@@ -44110,7 +45010,11 @@ SP_NOINLINE static void sp_384_mont_reduce_12(sp_digit* a, const sp_digit* m, sp
         "LDR	r9, [%[a], #12]\n\t"
         "LDR	r10, [%[a], #16]\n\t"
         "\n"
-    "L_sp_384_mont_reduce_12_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_mont_reduce_12_word:\n\t"
+#else
+    "L_sp_384_mont_reduce_12_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "MUL	lr, %[mp], r6\n\t"
         /* a[i+0] += m[0] * mu */
@@ -44177,10 +45081,12 @@ SP_NOINLINE static void sp_384_mont_reduce_12(sp_digit* a, const sp_digit* m, sp
         "ADD	r4, r4, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r4, #0x30\n\t"
-#ifdef __GNUC__
-        "BLT	L_sp_384_mont_reduce_12_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_384_mont_reduce_12_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.W	L_sp_384_mont_reduce_12_word\n\t"
 #else
-        "BLT.W	L_sp_384_mont_reduce_12_word%=\n\t"
+        "BLT.W	L_sp_384_mont_reduce_12_word_%=\n\t"
 #endif
         /* Loop Done */
         "STR	r6, [%[a]]\n\t"
@@ -44365,7 +45271,11 @@ static sp_int32 sp_384_cmp_12(const sp_digit* a, const sp_digit* b)
 #ifdef WOLFSSL_SP_SMALL
         "MOV	r6, #0x2c\n\t"
         "\n"
-    "L_sp_384_cmp_12_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_cmp_12_words:\n\t"
+#else
+    "L_sp_384_cmp_12_words_%=:\n\t"
+#endif
         "LDR	r4, [%[a], r6]\n\t"
         "LDR	r5, [%[b], r6]\n\t"
         "AND	r4, r4, r3\n\t"
@@ -44378,7 +45288,7 @@ static sp_int32 sp_384_cmp_12(const sp_digit* a, const sp_digit* b)
         "IT	ne\n\t"
         "movne	r3, r7\n\t"
         "SUBS	r6, r6, #0x4\n\t"
-        "bcs	L_sp_384_cmp_12_words%=\n\t"
+        "bcs	L_sp_384_cmp_12_words\n\t"
         "EOR	r2, r2, r3\n\t"
 #else
         "LDR	r4, [%[a], #44]\n\t"
@@ -44668,7 +45578,11 @@ static sp_digit sp_384_sub_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r11, #0x0\n\t"
         "ADD	r12, %[a], #0x30\n\t"
         "\n"
-    "L_sp_384_sub_12_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_sub_12_word:\n\t"
+#else
+    "L_sp_384_sub_12_word_%=:\n\t"
+#endif
         "RSBS	r11, r11, #0x0\n\t"
         "LDM	%[a]!, {r3, r4, r5, r6}\n\t"
         "LDM	%[b]!, {r7, r8, r9, r10}\n\t"
@@ -44679,10 +45593,12 @@ static sp_digit sp_384_sub_12(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "STM	%[r]!, {r3, r4, r5, r6}\n\t"
         "SBC	r11, r3, r3\n\t"
         "CMP	%[a], r12\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_384_sub_12_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_384_sub_12_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_384_sub_12_word\n\t"
 #else
-        "BNE.N	L_sp_384_sub_12_word%=\n\t"
+        "BNE.N	L_sp_384_sub_12_word_%=\n\t"
 #endif
         "MOV	%[r], r11\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -44769,7 +45685,11 @@ static sp_digit sp_384_cond_add_12(sp_digit* r, const sp_digit* a, const sp_digi
         "MOV	r8, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_384_cond_add_12_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_cond_add_12_words:\n\t"
+#else
+    "L_sp_384_cond_add_12_words_%=:\n\t"
+#endif
         "ADDS	r5, r5, #0xffffffff\n\t"
         "LDR	r6, [%[a], r4]\n\t"
         "LDR	r7, [%[b], r4]\n\t"
@@ -44779,10 +45699,12 @@ static sp_digit sp_384_cond_add_12(sp_digit* r, const sp_digit* a, const sp_digi
         "STR	r6, [%[r], r4]\n\t"
         "ADD	r4, r4, #0x4\n\t"
         "CMP	r4, #0x30\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_384_cond_add_12_words%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_384_cond_add_12_words_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_384_cond_add_12_words\n\t"
 #else
-        "BLT.N	L_sp_384_cond_add_12_words%=\n\t"
+        "BLT.N	L_sp_384_cond_add_12_words_%=\n\t"
 #endif
         "MOV	%[r], r5\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -48974,7 +49896,11 @@ static sp_digit sp_384_sub_in_place_12(sp_digit* a, const sp_digit* b)
         "MOV	r10, #0x0\n\t"
         "ADD	r11, %[a], #0x30\n\t"
         "\n"
-    "L_sp_384_sub_in_pkace_12_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_sub_in_pkace_12_word:\n\t"
+#else
+    "L_sp_384_sub_in_pkace_12_word_%=:\n\t"
+#endif
         "RSBS	r10, r10, #0x0\n\t"
         "LDM	%[a], {r2, r3, r4, r5}\n\t"
         "LDM	%[b]!, {r6, r7, r8, r9}\n\t"
@@ -48985,10 +49911,12 @@ static sp_digit sp_384_sub_in_place_12(sp_digit* a, const sp_digit* b)
         "STM	%[a]!, {r2, r3, r4, r5}\n\t"
         "SBC	r10, r10, r10\n\t"
         "CMP	%[a], r11\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_384_sub_in_pkace_12_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_384_sub_in_pkace_12_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_384_sub_in_pkace_12_word\n\t"
 #else
-        "BNE.N	L_sp_384_sub_in_pkace_12_word%=\n\t"
+        "BNE.N	L_sp_384_sub_in_pkace_12_word_%=\n\t"
 #endif
         "MOV	%[a], r10\n\t"
         : [a] "+r" (a), [b] "+r" (b)
@@ -49074,7 +50002,11 @@ static void sp_384_mul_d_12(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "MOV	r9, #0x4\n\t"
         "\n"
-    "L_sp_384_mul_d_12_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_mul_d_12_word:\n\t"
+#else
+    "L_sp_384_mul_d_12_word_%=:\n\t"
+#endif
         /* A[i] * B */
         "LDR	r8, [%[a], r9]\n\t"
         "UMULL	r6, r7, %[b], r8\n\t"
@@ -49087,10 +50019,12 @@ static void sp_384_mul_d_12(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "ADD	r9, r9, #0x4\n\t"
         "CMP	r9, #0x30\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_384_mul_d_12_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_384_mul_d_12_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_384_mul_d_12_word\n\t"
 #else
-        "BLT.N	L_sp_384_mul_d_12_word%=\n\t"
+        "BLT.N	L_sp_384_mul_d_12_word_%=\n\t"
 #endif
         "STR	r3, [%[r], #48]\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -49288,7 +50222,11 @@ SP_NOINLINE static sp_digit div_384_word_12(sp_digit d1, sp_digit d0, sp_digit d
         /* Next 30 bits */
         "MOV	r4, #0x1d\n\t"
         "\n"
-    "L_div_384_word_12_bit%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_div_384_word_12_bit:\n\t"
+#else
+    "L_div_384_word_12_bit_%=:\n\t"
+#endif
         "LSLS	r6, r6, #1\n\t"
         "ADC	r7, r7, r7\n\t"
         "SUBS	r8, r5, r7\n\t"
@@ -49298,7 +50236,13 @@ SP_NOINLINE static sp_digit div_384_word_12(sp_digit d1, sp_digit d0, sp_digit d
         "AND	r8, r8, r5\n\t"
         "SUBS	r7, r7, r8\n\t"
         "SUBS	r4, r4, #0x1\n\t"
-        "bpl	L_div_384_word_12_bit%=\n\t"
+#if defined(__GNUC__)
+        "BPL	L_div_384_word_12_bit_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BPL.N	L_div_384_word_12_bit\n\t"
+#else
+        "BPL.N	L_div_384_word_12_bit_%=\n\t"
+#endif
         "ADD	r3, r3, r3\n\t"
         "ADD	r3, r3, #0x1\n\t"
         "UMULL	r6, r7, r3, %[div]\n\t"
@@ -49961,10 +50905,12 @@ static void sp_384_div2_mod_12(sp_digit* r, const sp_digit* a, const sp_digit* m
     __asm__ __volatile__ (
         "LDM	%[a]!, {r4}\n\t"
         "ANDS	r3, r4, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_div2_mod_12_even%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_384_div2_mod_12_even_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_384_div2_mod_12_even\n\t"
 #else
-        "BEQ.N	L_sp_384_div2_mod_12_even%=\n\t"
+        "BEQ.N	L_sp_384_div2_mod_12_even_%=\n\t"
 #endif
         "MOV	r12, #0x0\n\t"
         "LDM	%[a]!, {r5, r6, r7}\n\t"
@@ -49989,13 +50935,19 @@ static void sp_384_div2_mod_12(sp_digit* r, const sp_digit* a, const sp_digit* m
         "ADCS	r7, r7, r11\n\t"
         "STM	%[r]!, {r4, r5, r6, r7}\n\t"
         "ADC	r3, r12, r12\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_div2_mod_12_div2%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_384_div2_mod_12_div2_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_384_div2_mod_12_div2\n\t"
 #else
-        "B.N	L_sp_384_div2_mod_12_div2%=\n\t"
+        "B.N	L_sp_384_div2_mod_12_div2_%=\n\t"
 #endif
         "\n"
-    "L_sp_384_div2_mod_12_even%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_div2_mod_12_even:\n\t"
+#else
+    "L_sp_384_div2_mod_12_even_%=:\n\t"
+#endif
         "LDM	%[a]!, {r5, r6, r7}\n\t"
         "STM	%[r]!, {r4, r5, r6, r7}\n\t"
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
@@ -50003,7 +50955,11 @@ static void sp_384_div2_mod_12(sp_digit* r, const sp_digit* a, const sp_digit* m
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
         "STM	%[r]!, {r4, r5, r6, r7}\n\t"
         "\n"
-    "L_sp_384_div2_mod_12_div2%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_div2_mod_12_div2:\n\t"
+#else
+    "L_sp_384_div2_mod_12_div2_%=:\n\t"
+#endif
         "SUB	%[r], %[r], #0x30\n\t"
         "LDRD	r8, r9, [%[r]]\n\t"
         "LSR	r8, r8, #1\n\t"
@@ -50071,197 +51027,289 @@ static int sp_384_num_bits_12(const sp_digit* a)
     __asm__ __volatile__ (
         "LDR	r1, [%[a], #44]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_num_bits_12_11%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_384_num_bits_12_11_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_384_num_bits_12_11\n\t"
 #else
-        "BEQ.N	L_sp_384_num_bits_12_11%=\n\t"
+        "BEQ.N	L_sp_384_num_bits_12_11_%=\n\t"
 #endif
         "MOV	r2, #0x180\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_num_bits_12_13%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_384_num_bits_12_13_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_384_num_bits_12_13\n\t"
 #else
-        "B.N	L_sp_384_num_bits_12_13%=\n\t"
+        "B.N	L_sp_384_num_bits_12_13_%=\n\t"
 #endif
         "\n"
-    "L_sp_384_num_bits_12_11%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_num_bits_12_11:\n\t"
+#else
+    "L_sp_384_num_bits_12_11_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #40]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_num_bits_12_10%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_384_num_bits_12_10_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_384_num_bits_12_10\n\t"
 #else
-        "BEQ.N	L_sp_384_num_bits_12_10%=\n\t"
+        "BEQ.N	L_sp_384_num_bits_12_10_%=\n\t"
 #endif
         "MOV	r2, #0x160\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_num_bits_12_13%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_384_num_bits_12_13_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_384_num_bits_12_13\n\t"
 #else
-        "B.N	L_sp_384_num_bits_12_13%=\n\t"
+        "B.N	L_sp_384_num_bits_12_13_%=\n\t"
 #endif
         "\n"
-    "L_sp_384_num_bits_12_10%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_num_bits_12_10:\n\t"
+#else
+    "L_sp_384_num_bits_12_10_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #36]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_num_bits_12_9%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_384_num_bits_12_9_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_384_num_bits_12_9\n\t"
 #else
-        "BEQ.N	L_sp_384_num_bits_12_9%=\n\t"
+        "BEQ.N	L_sp_384_num_bits_12_9_%=\n\t"
 #endif
         "MOV	r2, #0x140\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_num_bits_12_13%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_384_num_bits_12_13_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_384_num_bits_12_13\n\t"
 #else
-        "B.N	L_sp_384_num_bits_12_13%=\n\t"
+        "B.N	L_sp_384_num_bits_12_13_%=\n\t"
 #endif
         "\n"
-    "L_sp_384_num_bits_12_9%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_num_bits_12_9:\n\t"
+#else
+    "L_sp_384_num_bits_12_9_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #32]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_num_bits_12_8%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_384_num_bits_12_8_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_384_num_bits_12_8\n\t"
 #else
-        "BEQ.N	L_sp_384_num_bits_12_8%=\n\t"
+        "BEQ.N	L_sp_384_num_bits_12_8_%=\n\t"
 #endif
         "MOV	r2, #0x120\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_num_bits_12_13%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_384_num_bits_12_13_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_384_num_bits_12_13\n\t"
 #else
-        "B.N	L_sp_384_num_bits_12_13%=\n\t"
+        "B.N	L_sp_384_num_bits_12_13_%=\n\t"
 #endif
         "\n"
-    "L_sp_384_num_bits_12_8%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_num_bits_12_8:\n\t"
+#else
+    "L_sp_384_num_bits_12_8_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #28]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_num_bits_12_7%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_384_num_bits_12_7_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_384_num_bits_12_7\n\t"
 #else
-        "BEQ.N	L_sp_384_num_bits_12_7%=\n\t"
+        "BEQ.N	L_sp_384_num_bits_12_7_%=\n\t"
 #endif
         "MOV	r2, #0x100\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_num_bits_12_13%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_384_num_bits_12_13_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_384_num_bits_12_13\n\t"
 #else
-        "B.N	L_sp_384_num_bits_12_13%=\n\t"
+        "B.N	L_sp_384_num_bits_12_13_%=\n\t"
 #endif
         "\n"
-    "L_sp_384_num_bits_12_7%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_num_bits_12_7:\n\t"
+#else
+    "L_sp_384_num_bits_12_7_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #24]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_num_bits_12_6%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_384_num_bits_12_6_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_384_num_bits_12_6\n\t"
 #else
-        "BEQ.N	L_sp_384_num_bits_12_6%=\n\t"
+        "BEQ.N	L_sp_384_num_bits_12_6_%=\n\t"
 #endif
         "MOV	r2, #0xe0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_num_bits_12_13%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_384_num_bits_12_13_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_384_num_bits_12_13\n\t"
 #else
-        "B.N	L_sp_384_num_bits_12_13%=\n\t"
+        "B.N	L_sp_384_num_bits_12_13_%=\n\t"
 #endif
         "\n"
-    "L_sp_384_num_bits_12_6%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_num_bits_12_6:\n\t"
+#else
+    "L_sp_384_num_bits_12_6_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #20]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_num_bits_12_5%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_384_num_bits_12_5_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_384_num_bits_12_5\n\t"
 #else
-        "BEQ.N	L_sp_384_num_bits_12_5%=\n\t"
+        "BEQ.N	L_sp_384_num_bits_12_5_%=\n\t"
 #endif
         "MOV	r2, #0xc0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_num_bits_12_13%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_384_num_bits_12_13_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_384_num_bits_12_13\n\t"
 #else
-        "B.N	L_sp_384_num_bits_12_13%=\n\t"
+        "B.N	L_sp_384_num_bits_12_13_%=\n\t"
 #endif
         "\n"
-    "L_sp_384_num_bits_12_5%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_num_bits_12_5:\n\t"
+#else
+    "L_sp_384_num_bits_12_5_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #16]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_num_bits_12_4%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_384_num_bits_12_4_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_384_num_bits_12_4\n\t"
 #else
-        "BEQ.N	L_sp_384_num_bits_12_4%=\n\t"
+        "BEQ.N	L_sp_384_num_bits_12_4_%=\n\t"
 #endif
         "MOV	r2, #0xa0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_num_bits_12_13%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_384_num_bits_12_13_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_384_num_bits_12_13\n\t"
 #else
-        "B.N	L_sp_384_num_bits_12_13%=\n\t"
+        "B.N	L_sp_384_num_bits_12_13_%=\n\t"
 #endif
         "\n"
-    "L_sp_384_num_bits_12_4%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_num_bits_12_4:\n\t"
+#else
+    "L_sp_384_num_bits_12_4_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #12]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_num_bits_12_3%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_384_num_bits_12_3_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_384_num_bits_12_3\n\t"
 #else
-        "BEQ.N	L_sp_384_num_bits_12_3%=\n\t"
+        "BEQ.N	L_sp_384_num_bits_12_3_%=\n\t"
 #endif
         "MOV	r2, #0x80\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_num_bits_12_13%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_384_num_bits_12_13_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_384_num_bits_12_13\n\t"
 #else
-        "B.N	L_sp_384_num_bits_12_13%=\n\t"
+        "B.N	L_sp_384_num_bits_12_13_%=\n\t"
 #endif
         "\n"
-    "L_sp_384_num_bits_12_3%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_num_bits_12_3:\n\t"
+#else
+    "L_sp_384_num_bits_12_3_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #8]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_num_bits_12_2%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_384_num_bits_12_2_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_384_num_bits_12_2\n\t"
 #else
-        "BEQ.N	L_sp_384_num_bits_12_2%=\n\t"
+        "BEQ.N	L_sp_384_num_bits_12_2_%=\n\t"
 #endif
         "MOV	r2, #0x60\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_num_bits_12_13%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_384_num_bits_12_13_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_384_num_bits_12_13\n\t"
 #else
-        "B.N	L_sp_384_num_bits_12_13%=\n\t"
+        "B.N	L_sp_384_num_bits_12_13_%=\n\t"
 #endif
         "\n"
-    "L_sp_384_num_bits_12_2%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_num_bits_12_2:\n\t"
+#else
+    "L_sp_384_num_bits_12_2_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #4]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_384_num_bits_12_1%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_384_num_bits_12_1_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_384_num_bits_12_1\n\t"
 #else
-        "BEQ.N	L_sp_384_num_bits_12_1%=\n\t"
+        "BEQ.N	L_sp_384_num_bits_12_1_%=\n\t"
 #endif
         "MOV	r2, #0x40\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_384_num_bits_12_13%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_384_num_bits_12_13_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_384_num_bits_12_13\n\t"
 #else
-        "B.N	L_sp_384_num_bits_12_13%=\n\t"
+        "B.N	L_sp_384_num_bits_12_13_%=\n\t"
 #endif
         "\n"
-    "L_sp_384_num_bits_12_1%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_num_bits_12_1:\n\t"
+#else
+    "L_sp_384_num_bits_12_1_%=:\n\t"
+#endif
         "LDR	r1, [%[a]]\n\t"
         "MOV	r2, #0x20\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
         "\n"
-    "L_sp_384_num_bits_12_13%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_384_num_bits_12_13:\n\t"
+#else
+    "L_sp_384_num_bits_12_13_%=:\n\t"
+#endif
         "MOV	%[a], r4\n\t"
         : [a] "+r" (a)
         :
@@ -51430,13 +52478,21 @@ static void sp_521_mul_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_521_mul_17_outer%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_mul_17_outer:\n\t"
+#else
+    "L_sp_521_mul_17_outer_%=:\n\t"
+#endif
         "SUBS	r3, r5, #0x40\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_521_mul_17_inner%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_mul_17_inner:\n\t"
+#else
+    "L_sp_521_mul_17_inner_%=:\n\t"
+#endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -51452,15 +52508,19 @@ static void sp_521_mul_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r3, r3, #0x4\n\t"
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_521_mul_17_inner_done%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_521_mul_17_inner_done_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_521_mul_17_inner_done\n\t"
 #else
-        "BGT.N	L_sp_521_mul_17_inner_done%=\n\t"
+        "BGT.N	L_sp_521_mul_17_inner_done_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_521_mul_17_inner%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_521_mul_17_inner_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_521_mul_17_inner\n\t"
 #else
-        "BLT.N	L_sp_521_mul_17_inner%=\n\t"
+        "BLT.N	L_sp_521_mul_17_inner_%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r3]\n\t"
@@ -51469,17 +52529,23 @@ static void sp_521_mul_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_521_mul_17_inner_done%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_mul_17_inner_done:\n\t"
+#else
+    "L_sp_521_mul_17_inner_done_%=:\n\t"
+#endif
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
         "MOV	r8, #0x0\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x7c\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_521_mul_17_outer%=\n\t"
+#if defined(__GNUC__)
+        "BLE	L_sp_521_mul_17_outer_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLE.N	L_sp_521_mul_17_outer\n\t"
 #else
-        "BLE.N	L_sp_521_mul_17_outer%=\n\t"
+        "BLE.N	L_sp_521_mul_17_outer_%=\n\t"
 #endif
         "LDR	lr, [%[a], #64]\n\t"
         "LDR	r11, [%[b], #64]\n\t"
@@ -51491,14 +52557,20 @@ static void sp_521_mul_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "STM	%[r]!, {r6, r7}\n\t"
         "SUB	r5, r5, #0x8\n\t"
         "\n"
-    "L_sp_521_mul_17_store%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_mul_17_store:\n\t"
+#else
+    "L_sp_521_mul_17_store_%=:\n\t"
+#endif
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_521_mul_17_store%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_521_mul_17_store_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_521_mul_17_store\n\t"
 #else
-        "BGT.N	L_sp_521_mul_17_store%=\n\t"
+        "BGT.N	L_sp_521_mul_17_store_%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
@@ -53575,13 +54647,21 @@ static void sp_521_sqr_17(sp_digit* r, const sp_digit* a)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_521_sqr_17_outer%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_sqr_17_outer:\n\t"
+#else
+    "L_sp_521_sqr_17_outer_%=:\n\t"
+#endif
         "SUBS	r3, r5, #0x40\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_521_sqr_17_inner%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_sqr_17_inner:\n\t"
+#else
+    "L_sp_521_sqr_17_inner_%=:\n\t"
+#endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[a], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -53594,15 +54674,19 @@ static void sp_521_sqr_17(sp_digit* r, const sp_digit* a)
         "ADD	r3, r3, #0x4\n\t"
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_521_sqr_17_inner_done%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_521_sqr_17_inner_done_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_521_sqr_17_inner_done\n\t"
 #else
-        "BGT.N	L_sp_521_sqr_17_inner_done%=\n\t"
+        "BGT.N	L_sp_521_sqr_17_inner_done_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_521_sqr_17_inner%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_521_sqr_17_inner_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_521_sqr_17_inner\n\t"
 #else
-        "BLT.N	L_sp_521_sqr_17_inner%=\n\t"
+        "BLT.N	L_sp_521_sqr_17_inner_%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "UMULL	r9, r10, lr, lr\n\t"
@@ -53610,17 +54694,23 @@ static void sp_521_sqr_17(sp_digit* r, const sp_digit* a)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_521_sqr_17_inner_done%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_sqr_17_inner_done:\n\t"
+#else
+    "L_sp_521_sqr_17_inner_done_%=:\n\t"
+#endif
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
         "MOV	r8, #0x0\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x7c\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_521_sqr_17_outer%=\n\t"
+#if defined(__GNUC__)
+        "BLE	L_sp_521_sqr_17_outer_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLE.N	L_sp_521_sqr_17_outer\n\t"
 #else
-        "BLE.N	L_sp_521_sqr_17_outer%=\n\t"
+        "BLE.N	L_sp_521_sqr_17_outer_%=\n\t"
 #endif
         "LDR	lr, [%[a], #64]\n\t"
         "UMLAL	r6, r7, lr, lr\n\t"
@@ -53631,14 +54721,20 @@ static void sp_521_sqr_17(sp_digit* r, const sp_digit* a)
         "STM	%[r]!, {r6, r7}\n\t"
         "SUB	r5, r5, #0x8\n\t"
         "\n"
-    "L_sp_521_sqr_17_store%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_sqr_17_store:\n\t"
+#else
+    "L_sp_521_sqr_17_store_%=:\n\t"
+#endif
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_521_sqr_17_store%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_521_sqr_17_store_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_521_sqr_17_store\n\t"
 #else
-        "BGT.N	L_sp_521_sqr_17_store%=\n\t"
+        "BGT.N	L_sp_521_sqr_17_store_%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a)
         :
@@ -54955,7 +56051,11 @@ static sp_digit sp_521_add_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r3, #0x0\n\t"
         "ADD	r12, %[a], #0x40\n\t"
         "\n"
-    "L_sp_521_add_17_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_add_17_word:\n\t"
+#else
+    "L_sp_521_add_17_word_%=:\n\t"
+#endif
         "ADDS	r3, r3, #0xffffffff\n\t"
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
         "LDM	%[b]!, {r8, r9, r10, r11}\n\t"
@@ -54967,10 +56067,12 @@ static sp_digit sp_521_add_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r4, #0x0\n\t"
         "ADC	r3, r4, #0x0\n\t"
         "CMP	%[a], r12\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_521_add_17_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_521_add_17_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_521_add_17_word\n\t"
 #else
-        "BNE.N	L_sp_521_add_17_word%=\n\t"
+        "BNE.N	L_sp_521_add_17_word_%=\n\t"
 #endif
         "ADDS	r3, r3, #0xffffffff\n\t"
         "LDM	%[a], {r4}\n\t"
@@ -55288,7 +56390,11 @@ static sp_digit sp_521_cond_sub_17(sp_digit* r, const sp_digit* a, const sp_digi
         "MOV	r4, #0x0\n\t"
         "MOV	r5, #0x0\n\t"
         "\n"
-    "L_sp_521_cond_sub_17_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_cond_sub_17_words:\n\t"
+#else
+    "L_sp_521_cond_sub_17_words_%=:\n\t"
+#endif
         "SUBS	r4, r8, r4\n\t"
         "LDR	r6, [%[a], r5]\n\t"
         "LDR	r7, [%[b], r5]\n\t"
@@ -55298,10 +56404,12 @@ static sp_digit sp_521_cond_sub_17(sp_digit* r, const sp_digit* a, const sp_digi
         "STR	r6, [%[r], r5]\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x44\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_521_cond_sub_17_words%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_521_cond_sub_17_words_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_521_cond_sub_17_words\n\t"
 #else
-        "BLT.N	L_sp_521_cond_sub_17_words%=\n\t"
+        "BLT.N	L_sp_521_cond_sub_17_words_%=\n\t"
 #endif
         "MOV	%[r], r4\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -55568,19 +56676,29 @@ SP_NOINLINE static void sp_521_mont_reduce_order_17(sp_digit* a, const sp_digit*
         "LDR	r4, [%[a]]\n\t"
         "LDR	r5, [%[a], #4]\n\t"
         "\n"
-    "L_sp_521_mont_reduce_order_17_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_mont_reduce_order_17_word:\n\t"
+#else
+    "L_sp_521_mont_reduce_order_17_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "MUL	r10, %[mp], r4\n\t"
         "CMP	r11, #0x40\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_521_mont_reduce_order_17_nomask%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_521_mont_reduce_order_17_nomask_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_521_mont_reduce_order_17_nomask\n\t"
 #else
-        "BNE.N	L_sp_521_mont_reduce_order_17_nomask%=\n\t"
+        "BNE.N	L_sp_521_mont_reduce_order_17_nomask_%=\n\t"
 #endif
         "MOV	r9, #0x1ff\n\t"
         "AND	r10, r10, r9\n\t"
         "\n"
-    "L_sp_521_mont_reduce_order_17_nomask%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_mont_reduce_order_17_nomask:\n\t"
+#else
+    "L_sp_521_mont_reduce_order_17_nomask_%=:\n\t"
+#endif
         /* a[i+0] += m[0] * mu */
         "MOV	r7, #0x0\n\t"
         "UMLAL	r4, r7, r10, lr\n\t"
@@ -55721,10 +56839,12 @@ SP_NOINLINE static void sp_521_mont_reduce_order_17(sp_digit* a, const sp_digit*
         "ADD	r11, r11, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r11, #0x44\n\t"
-#ifdef __GNUC__
-        "BLT	L_sp_521_mont_reduce_order_17_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_521_mont_reduce_order_17_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.W	L_sp_521_mont_reduce_order_17_word\n\t"
 #else
-        "BLT.W	L_sp_521_mont_reduce_order_17_word%=\n\t"
+        "BLT.W	L_sp_521_mont_reduce_order_17_word_%=\n\t"
 #endif
         /* Loop Done */
         "STR	r4, [%[a]]\n\t"
@@ -55836,19 +56956,29 @@ SP_NOINLINE static void sp_521_mont_reduce_order_17(sp_digit* a, const sp_digit*
         "LDR	r9, [%[a], #12]\n\t"
         "LDR	r10, [%[a], #16]\n\t"
         "\n"
-    "L_sp_521_mont_reduce_order_17_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_mont_reduce_order_17_word:\n\t"
+#else
+    "L_sp_521_mont_reduce_order_17_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "MUL	lr, %[mp], r6\n\t"
         "CMP	r4, #0x40\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_521_mont_reduce_order_17_nomask%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_521_mont_reduce_order_17_nomask_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_521_mont_reduce_order_17_nomask\n\t"
 #else
-        "BNE.N	L_sp_521_mont_reduce_order_17_nomask%=\n\t"
+        "BNE.N	L_sp_521_mont_reduce_order_17_nomask_%=\n\t"
 #endif
         "MOV	r12, #0x1ff\n\t"
         "AND	lr, lr, r12\n\t"
         "\n"
-    "L_sp_521_mont_reduce_order_17_nomask%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_mont_reduce_order_17_nomask:\n\t"
+#else
+    "L_sp_521_mont_reduce_order_17_nomask_%=:\n\t"
+#endif
         /* a[i+0] += m[0] * mu */
         "LDR	r12, [%[m]]\n\t"
         "MOV	r3, #0x0\n\t"
@@ -55939,10 +57069,12 @@ SP_NOINLINE static void sp_521_mont_reduce_order_17(sp_digit* a, const sp_digit*
         "ADD	r4, r4, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r4, #0x44\n\t"
-#ifdef __GNUC__
-        "BLT	L_sp_521_mont_reduce_order_17_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_521_mont_reduce_order_17_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.W	L_sp_521_mont_reduce_order_17_word\n\t"
 #else
-        "BLT.W	L_sp_521_mont_reduce_order_17_word%=\n\t"
+        "BLT.W	L_sp_521_mont_reduce_order_17_word_%=\n\t"
 #endif
         /* Loop Done */
         "STR	r6, [%[a]]\n\t"
@@ -56194,7 +57326,11 @@ static sp_int32 sp_521_cmp_17(const sp_digit* a, const sp_digit* b)
 #ifdef WOLFSSL_SP_SMALL
         "MOV	r6, #0x40\n\t"
         "\n"
-    "L_sp_521_cmp_17_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_cmp_17_words:\n\t"
+#else
+    "L_sp_521_cmp_17_words_%=:\n\t"
+#endif
         "LDR	r4, [%[a], r6]\n\t"
         "LDR	r5, [%[b], r6]\n\t"
         "AND	r4, r4, r3\n\t"
@@ -56207,7 +57343,7 @@ static sp_int32 sp_521_cmp_17(const sp_digit* a, const sp_digit* b)
         "IT	ne\n\t"
         "movne	r3, r7\n\t"
         "SUBS	r6, r6, #0x4\n\t"
-        "bcs	L_sp_521_cmp_17_words%=\n\t"
+        "bcs	L_sp_521_cmp_17_words\n\t"
         "EOR	r2, r2, r3\n\t"
 #else
         "LDR	r4, [%[a], #64]\n\t"
@@ -61995,7 +63131,11 @@ static sp_digit sp_521_sub_in_place_17(sp_digit* a, const sp_digit* b)
         "MOV	r10, #0x0\n\t"
         "ADD	r11, %[a], #0x40\n\t"
         "\n"
-    "L_sp_521_sub_in_pkace_17_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_sub_in_pkace_17_word:\n\t"
+#else
+    "L_sp_521_sub_in_pkace_17_word_%=:\n\t"
+#endif
         "RSBS	r10, r10, #0x0\n\t"
         "LDM	%[a], {r2, r3, r4, r5}\n\t"
         "LDM	%[b]!, {r6, r7, r8, r9}\n\t"
@@ -62006,10 +63146,12 @@ static sp_digit sp_521_sub_in_place_17(sp_digit* a, const sp_digit* b)
         "STM	%[a]!, {r2, r3, r4, r5}\n\t"
         "SBC	r10, r10, r10\n\t"
         "CMP	%[a], r11\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_521_sub_in_pkace_17_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_521_sub_in_pkace_17_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_521_sub_in_pkace_17_word\n\t"
 #else
-        "BNE.N	L_sp_521_sub_in_pkace_17_word%=\n\t"
+        "BNE.N	L_sp_521_sub_in_pkace_17_word_%=\n\t"
 #endif
         "RSBS	r10, r10, #0x0\n\t"
         "LDM	%[a], {r2}\n\t"
@@ -62111,7 +63253,11 @@ static void sp_521_mul_d_17(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "MOV	r9, #0x4\n\t"
         "\n"
-    "L_sp_521_mul_d_17_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_mul_d_17_word:\n\t"
+#else
+    "L_sp_521_mul_d_17_word_%=:\n\t"
+#endif
         /* A[i] * B */
         "LDR	r8, [%[a], r9]\n\t"
         "UMULL	r6, r7, %[b], r8\n\t"
@@ -62124,10 +63270,12 @@ static void sp_521_mul_d_17(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "ADD	r9, r9, #0x4\n\t"
         "CMP	r9, #0x44\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_521_mul_d_17_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_521_mul_d_17_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_521_mul_d_17_word\n\t"
 #else
-        "BLT.N	L_sp_521_mul_d_17_word%=\n\t"
+        "BLT.N	L_sp_521_mul_d_17_word_%=\n\t"
 #endif
         "STR	r3, [%[r], #68]\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -62350,7 +63498,11 @@ SP_NOINLINE static sp_digit div_521_word_17(sp_digit d1, sp_digit d0, sp_digit d
         /* Next 30 bits */
         "MOV	r4, #0x1d\n\t"
         "\n"
-    "L_div_521_word_17_bit%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_div_521_word_17_bit:\n\t"
+#else
+    "L_div_521_word_17_bit_%=:\n\t"
+#endif
         "LSLS	r6, r6, #1\n\t"
         "ADC	r7, r7, r7\n\t"
         "SUBS	r8, r5, r7\n\t"
@@ -62360,7 +63512,13 @@ SP_NOINLINE static sp_digit div_521_word_17(sp_digit d1, sp_digit d0, sp_digit d
         "AND	r8, r8, r5\n\t"
         "SUBS	r7, r7, r8\n\t"
         "SUBS	r4, r4, #0x1\n\t"
-        "bpl	L_div_521_word_17_bit%=\n\t"
+#if defined(__GNUC__)
+        "BPL	L_div_521_word_17_bit_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BPL.N	L_div_521_word_17_bit\n\t"
+#else
+        "BPL.N	L_div_521_word_17_bit_%=\n\t"
+#endif
         "ADD	r3, r3, r3\n\t"
         "ADD	r3, r3, #0x1\n\t"
         "UMULL	r6, r7, r3, %[div]\n\t"
@@ -63055,7 +64213,11 @@ static sp_digit sp_521_sub_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r11, #0x0\n\t"
         "ADD	r12, %[a], #0x40\n\t"
         "\n"
-    "L_sp_521_sub_17_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_sub_17_word:\n\t"
+#else
+    "L_sp_521_sub_17_word_%=:\n\t"
+#endif
         "RSBS	r11, r11, #0x0\n\t"
         "LDM	%[a]!, {r3, r4, r5, r6}\n\t"
         "LDM	%[b]!, {r7, r8, r9, r10}\n\t"
@@ -63066,10 +64228,12 @@ static sp_digit sp_521_sub_17(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "STM	%[r]!, {r3, r4, r5, r6}\n\t"
         "SBC	r11, r3, r3\n\t"
         "CMP	%[a], r12\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_521_sub_17_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_521_sub_17_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_521_sub_17_word\n\t"
 #else
-        "BNE.N	L_sp_521_sub_17_word%=\n\t"
+        "BNE.N	L_sp_521_sub_17_word_%=\n\t"
 #endif
         "RSBS	r11, r11, #0x0\n\t"
         "LDM	%[a]!, {r3}\n\t"
@@ -63166,10 +64330,12 @@ static void sp_521_div2_mod_17(sp_digit* r, const sp_digit* a, const sp_digit* m
     __asm__ __volatile__ (
         "LDM	%[a]!, {r4}\n\t"
         "ANDS	r3, r4, #0x1\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_div2_mod_17_even%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_521_div2_mod_17_even_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_521_div2_mod_17_even\n\t"
 #else
-        "BEQ.N	L_sp_521_div2_mod_17_even%=\n\t"
+        "BEQ.N	L_sp_521_div2_mod_17_even_%=\n\t"
 #endif
         "MOV	r12, #0x0\n\t"
         "LDM	%[a]!, {r5, r6, r7}\n\t"
@@ -63205,13 +64371,19 @@ static void sp_521_div2_mod_17(sp_digit* r, const sp_digit* a, const sp_digit* m
         "ADCS	r4, r4, r8\n\t"
         "STM	%[r]!, {r4}\n\t"
         "ADC	r3, r12, r12\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_div2_mod_17_div2%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_521_div2_mod_17_div2_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_521_div2_mod_17_div2\n\t"
 #else
-        "B.N	L_sp_521_div2_mod_17_div2%=\n\t"
+        "B.N	L_sp_521_div2_mod_17_div2_%=\n\t"
 #endif
         "\n"
-    "L_sp_521_div2_mod_17_even%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_div2_mod_17_even:\n\t"
+#else
+    "L_sp_521_div2_mod_17_even_%=:\n\t"
+#endif
         "LDM	%[a]!, {r5, r6, r7}\n\t"
         "STM	%[r]!, {r4, r5, r6, r7}\n\t"
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
@@ -63223,7 +64395,11 @@ static void sp_521_div2_mod_17(sp_digit* r, const sp_digit* a, const sp_digit* m
         "LDM	%[a]!, {r4}\n\t"
         "STM	%[r]!, {r4}\n\t"
         "\n"
-    "L_sp_521_div2_mod_17_div2%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_div2_mod_17_div2:\n\t"
+#else
+    "L_sp_521_div2_mod_17_div2_%=:\n\t"
+#endif
         "SUB	%[r], %[r], #0x44\n\t"
         "LDRD	r8, r9, [%[r]]\n\t"
         "LSR	r8, r8, #1\n\t"
@@ -63311,282 +64487,414 @@ static int sp_521_num_bits_17(const sp_digit* a)
     __asm__ __volatile__ (
         "LDR	r1, [%[a], #64]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_16%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_521_num_bits_17_16_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_521_num_bits_17_16\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_16%=\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_16_%=\n\t"
 #endif
         "MOV	r2, #0x220\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_521_num_bits_17_18_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_521_num_bits_17_18\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18%=\n\t"
+        "B.N	L_sp_521_num_bits_17_18_%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_16%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_num_bits_17_16:\n\t"
+#else
+    "L_sp_521_num_bits_17_16_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #60]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_15%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_521_num_bits_17_15_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_521_num_bits_17_15\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_15%=\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_15_%=\n\t"
 #endif
         "MOV	r2, #0x200\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_521_num_bits_17_18_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_521_num_bits_17_18\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18%=\n\t"
+        "B.N	L_sp_521_num_bits_17_18_%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_15%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_num_bits_17_15:\n\t"
+#else
+    "L_sp_521_num_bits_17_15_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #56]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_14%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_521_num_bits_17_14_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_521_num_bits_17_14\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_14%=\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_14_%=\n\t"
 #endif
         "MOV	r2, #0x1e0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_521_num_bits_17_18_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_521_num_bits_17_18\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18%=\n\t"
+        "B.N	L_sp_521_num_bits_17_18_%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_14%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_num_bits_17_14:\n\t"
+#else
+    "L_sp_521_num_bits_17_14_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #52]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_13%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_521_num_bits_17_13_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_521_num_bits_17_13\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_13%=\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_13_%=\n\t"
 #endif
         "MOV	r2, #0x1c0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_521_num_bits_17_18_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_521_num_bits_17_18\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18%=\n\t"
+        "B.N	L_sp_521_num_bits_17_18_%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_13%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_num_bits_17_13:\n\t"
+#else
+    "L_sp_521_num_bits_17_13_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #48]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_12%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_521_num_bits_17_12_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_521_num_bits_17_12\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_12%=\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_12_%=\n\t"
 #endif
         "MOV	r2, #0x1a0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_521_num_bits_17_18_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_521_num_bits_17_18\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18%=\n\t"
+        "B.N	L_sp_521_num_bits_17_18_%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_12%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_num_bits_17_12:\n\t"
+#else
+    "L_sp_521_num_bits_17_12_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #44]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_11%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_521_num_bits_17_11_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_521_num_bits_17_11\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_11%=\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_11_%=\n\t"
 #endif
         "MOV	r2, #0x180\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_521_num_bits_17_18_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_521_num_bits_17_18\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18%=\n\t"
+        "B.N	L_sp_521_num_bits_17_18_%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_11%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_num_bits_17_11:\n\t"
+#else
+    "L_sp_521_num_bits_17_11_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #40]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_10%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_521_num_bits_17_10_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_521_num_bits_17_10\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_10%=\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_10_%=\n\t"
 #endif
         "MOV	r2, #0x160\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_521_num_bits_17_18_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_521_num_bits_17_18\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18%=\n\t"
+        "B.N	L_sp_521_num_bits_17_18_%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_10%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_num_bits_17_10:\n\t"
+#else
+    "L_sp_521_num_bits_17_10_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #36]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_9%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_521_num_bits_17_9_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_521_num_bits_17_9\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_9%=\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_9_%=\n\t"
 #endif
         "MOV	r2, #0x140\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_521_num_bits_17_18_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_521_num_bits_17_18\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18%=\n\t"
+        "B.N	L_sp_521_num_bits_17_18_%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_9%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_num_bits_17_9:\n\t"
+#else
+    "L_sp_521_num_bits_17_9_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #32]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_8%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_521_num_bits_17_8_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_521_num_bits_17_8\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_8%=\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_8_%=\n\t"
 #endif
         "MOV	r2, #0x120\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_521_num_bits_17_18_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_521_num_bits_17_18\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18%=\n\t"
+        "B.N	L_sp_521_num_bits_17_18_%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_8%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_num_bits_17_8:\n\t"
+#else
+    "L_sp_521_num_bits_17_8_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #28]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_7%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_521_num_bits_17_7_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_521_num_bits_17_7\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_7%=\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_7_%=\n\t"
 #endif
         "MOV	r2, #0x100\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_521_num_bits_17_18_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_521_num_bits_17_18\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18%=\n\t"
+        "B.N	L_sp_521_num_bits_17_18_%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_7%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_num_bits_17_7:\n\t"
+#else
+    "L_sp_521_num_bits_17_7_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #24]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_6%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_521_num_bits_17_6_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_521_num_bits_17_6\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_6%=\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_6_%=\n\t"
 #endif
         "MOV	r2, #0xe0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_521_num_bits_17_18_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_521_num_bits_17_18\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18%=\n\t"
+        "B.N	L_sp_521_num_bits_17_18_%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_6%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_num_bits_17_6:\n\t"
+#else
+    "L_sp_521_num_bits_17_6_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #20]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_5%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_521_num_bits_17_5_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_521_num_bits_17_5\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_5%=\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_5_%=\n\t"
 #endif
         "MOV	r2, #0xc0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_521_num_bits_17_18_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_521_num_bits_17_18\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18%=\n\t"
+        "B.N	L_sp_521_num_bits_17_18_%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_5%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_num_bits_17_5:\n\t"
+#else
+    "L_sp_521_num_bits_17_5_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #16]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_4%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_521_num_bits_17_4_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_521_num_bits_17_4\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_4%=\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_4_%=\n\t"
 #endif
         "MOV	r2, #0xa0\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_521_num_bits_17_18_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_521_num_bits_17_18\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18%=\n\t"
+        "B.N	L_sp_521_num_bits_17_18_%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_4%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_num_bits_17_4:\n\t"
+#else
+    "L_sp_521_num_bits_17_4_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #12]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_3%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_521_num_bits_17_3_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_521_num_bits_17_3\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_3%=\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_3_%=\n\t"
 #endif
         "MOV	r2, #0x80\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_521_num_bits_17_18_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_521_num_bits_17_18\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18%=\n\t"
+        "B.N	L_sp_521_num_bits_17_18_%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_3%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_num_bits_17_3:\n\t"
+#else
+    "L_sp_521_num_bits_17_3_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #8]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_2%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_521_num_bits_17_2_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_521_num_bits_17_2\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_2%=\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_2_%=\n\t"
 #endif
         "MOV	r2, #0x60\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_521_num_bits_17_18_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_521_num_bits_17_18\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18%=\n\t"
+        "B.N	L_sp_521_num_bits_17_18_%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_2%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_num_bits_17_2:\n\t"
+#else
+    "L_sp_521_num_bits_17_2_%=:\n\t"
+#endif
         "LDR	r1, [%[a], #4]\n\t"
         "CMP	r1, #0x0\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BEQ	L_sp_521_num_bits_17_1%=\n\t"
+#if defined(__GNUC__)
+        "BEQ	L_sp_521_num_bits_17_1_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BEQ.N	L_sp_521_num_bits_17_1\n\t"
 #else
-        "BEQ.N	L_sp_521_num_bits_17_1%=\n\t"
+        "BEQ.N	L_sp_521_num_bits_17_1_%=\n\t"
 #endif
         "MOV	r2, #0x40\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "B	L_sp_521_num_bits_17_18%=\n\t"
+#if defined(__GNUC__)
+        "B	L_sp_521_num_bits_17_18_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "B.N	L_sp_521_num_bits_17_18\n\t"
 #else
-        "B.N	L_sp_521_num_bits_17_18%=\n\t"
+        "B.N	L_sp_521_num_bits_17_18_%=\n\t"
 #endif
         "\n"
-    "L_sp_521_num_bits_17_1%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_num_bits_17_1:\n\t"
+#else
+    "L_sp_521_num_bits_17_1_%=:\n\t"
+#endif
         "LDR	r1, [%[a]]\n\t"
         "MOV	r2, #0x20\n\t"
         "CLZ	r4, r1\n\t"
         "SUB	r4, r2, r4\n\t"
         "\n"
-    "L_sp_521_num_bits_17_18%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_521_num_bits_17_18:\n\t"
+#else
+    "L_sp_521_num_bits_17_18_%=:\n\t"
+#endif
         "MOV	%[a], r4\n\t"
         : [a] "+r" (a)
         :
@@ -67981,13 +69289,21 @@ static void sp_1024_mul_32(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_1024_mul_32_outer%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_1024_mul_32_outer:\n\t"
+#else
+    "L_sp_1024_mul_32_outer_%=:\n\t"
+#endif
         "SUBS	r3, r5, #0x7c\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_1024_mul_32_inner%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_1024_mul_32_inner:\n\t"
+#else
+    "L_sp_1024_mul_32_inner_%=:\n\t"
+#endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -68003,15 +69319,19 @@ static void sp_1024_mul_32(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r3, r3, #0x4\n\t"
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_1024_mul_32_inner_done%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_1024_mul_32_inner_done_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_1024_mul_32_inner_done\n\t"
 #else
-        "BGT.N	L_sp_1024_mul_32_inner_done%=\n\t"
+        "BGT.N	L_sp_1024_mul_32_inner_done_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_1024_mul_32_inner%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_1024_mul_32_inner_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_1024_mul_32_inner\n\t"
 #else
-        "BLT.N	L_sp_1024_mul_32_inner%=\n\t"
+        "BLT.N	L_sp_1024_mul_32_inner_%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[b], r3]\n\t"
@@ -68020,17 +69340,23 @@ static void sp_1024_mul_32(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_1024_mul_32_inner_done%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_1024_mul_32_inner_done:\n\t"
+#else
+    "L_sp_1024_mul_32_inner_done_%=:\n\t"
+#endif
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
         "MOV	r8, #0x0\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0xf4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_1024_mul_32_outer%=\n\t"
+#if defined(__GNUC__)
+        "BLE	L_sp_1024_mul_32_outer_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLE.N	L_sp_1024_mul_32_outer\n\t"
 #else
-        "BLE.N	L_sp_1024_mul_32_outer%=\n\t"
+        "BLE.N	L_sp_1024_mul_32_outer_%=\n\t"
 #endif
         "LDR	lr, [%[a], #124]\n\t"
         "LDR	r11, [%[b], #124]\n\t"
@@ -68039,14 +69365,20 @@ static void sp_1024_mul_32(sp_digit* r, const sp_digit* a, const sp_digit* b)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_1024_mul_32_store%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_1024_mul_32_store:\n\t"
+#else
+    "L_sp_1024_mul_32_store_%=:\n\t"
+#endif
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_1024_mul_32_store%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_1024_mul_32_store_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_1024_mul_32_store\n\t"
 #else
-        "BGT.N	L_sp_1024_mul_32_store%=\n\t"
+        "BGT.N	L_sp_1024_mul_32_store_%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
@@ -68079,13 +69411,21 @@ static void sp_1024_sqr_32(sp_digit* r, const sp_digit* a)
         "MOV	r8, #0x0\n\t"
         "MOV	r5, #0x4\n\t"
         "\n"
-    "L_sp_1024_sqr_32_outer%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_1024_sqr_32_outer:\n\t"
+#else
+    "L_sp_1024_sqr_32_outer_%=:\n\t"
+#endif
         "SUBS	r3, r5, #0x7c\n\t"
         "IT	cc\n\t"
         "MOVCC	r3, #0x0\n\t"
         "SUB	r4, r5, r3\n\t"
         "\n"
-    "L_sp_1024_sqr_32_inner%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_1024_sqr_32_inner:\n\t"
+#else
+    "L_sp_1024_sqr_32_inner_%=:\n\t"
+#endif
         "LDR	lr, [%[a], r3]\n\t"
         "LDR	r11, [%[a], r4]\n\t"
         "UMULL	r9, r10, lr, r11\n\t"
@@ -68098,15 +69438,19 @@ static void sp_1024_sqr_32(sp_digit* r, const sp_digit* a)
         "ADD	r3, r3, #0x4\n\t"
         "SUB	r4, r4, #0x4\n\t"
         "CMP	r3, r4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_1024_sqr_32_inner_done%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_1024_sqr_32_inner_done_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_1024_sqr_32_inner_done\n\t"
 #else
-        "BGT.N	L_sp_1024_sqr_32_inner_done%=\n\t"
+        "BGT.N	L_sp_1024_sqr_32_inner_done_%=\n\t"
 #endif
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_1024_sqr_32_inner%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_1024_sqr_32_inner_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_1024_sqr_32_inner\n\t"
 #else
-        "BLT.N	L_sp_1024_sqr_32_inner%=\n\t"
+        "BLT.N	L_sp_1024_sqr_32_inner_%=\n\t"
 #endif
         "LDR	lr, [%[a], r3]\n\t"
         "UMULL	r9, r10, lr, lr\n\t"
@@ -68114,17 +69458,23 @@ static void sp_1024_sqr_32(sp_digit* r, const sp_digit* a)
         "ADCS	r7, r7, r10\n\t"
         "ADC	r8, r8, #0x0\n\t"
         "\n"
-    "L_sp_1024_sqr_32_inner_done%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_1024_sqr_32_inner_done:\n\t"
+#else
+    "L_sp_1024_sqr_32_inner_done_%=:\n\t"
+#endif
         "STR	r6, [sp, r5]\n\t"
         "MOV	r6, r7\n\t"
         "MOV	r7, r8\n\t"
         "MOV	r8, #0x0\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0xf4\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLE	L_sp_1024_sqr_32_outer%=\n\t"
+#if defined(__GNUC__)
+        "BLE	L_sp_1024_sqr_32_outer_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLE.N	L_sp_1024_sqr_32_outer\n\t"
 #else
-        "BLE.N	L_sp_1024_sqr_32_outer%=\n\t"
+        "BLE.N	L_sp_1024_sqr_32_outer_%=\n\t"
 #endif
         "LDR	lr, [%[a], #124]\n\t"
         "UMLAL	r6, r7, lr, lr\n\t"
@@ -68132,14 +69482,20 @@ static void sp_1024_sqr_32(sp_digit* r, const sp_digit* a)
         "ADD	r5, r5, #0x4\n\t"
         "STR	r7, [sp, r5]\n\t"
         "\n"
-    "L_sp_1024_sqr_32_store%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_1024_sqr_32_store:\n\t"
+#else
+    "L_sp_1024_sqr_32_store_%=:\n\t"
+#endif
         "LDM	sp!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "STM	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "SUBS	r5, r5, #0x20\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BGT	L_sp_1024_sqr_32_store%=\n\t"
+#if defined(__GNUC__)
+        "BGT	L_sp_1024_sqr_32_store_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BGT.N	L_sp_1024_sqr_32_store\n\t"
 #else
-        "BGT.N	L_sp_1024_sqr_32_store%=\n\t"
+        "BGT.N	L_sp_1024_sqr_32_store_%=\n\t"
 #endif
         : [r] "+r" (r), [a] "+r" (a)
         :
@@ -68254,7 +69610,11 @@ static sp_digit sp_1024_sub_in_place_32(sp_digit* a, const sp_digit* b)
         "MOV	r10, #0x0\n\t"
         "ADD	r11, %[a], #0x80\n\t"
         "\n"
-    "L_sp_1024_sub_in_pkace_32_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_1024_sub_in_pkace_32_word:\n\t"
+#else
+    "L_sp_1024_sub_in_pkace_32_word_%=:\n\t"
+#endif
         "RSBS	r10, r10, #0x0\n\t"
         "LDM	%[a], {r2, r3, r4, r5}\n\t"
         "LDM	%[b]!, {r6, r7, r8, r9}\n\t"
@@ -68265,10 +69625,12 @@ static sp_digit sp_1024_sub_in_place_32(sp_digit* a, const sp_digit* b)
         "STM	%[a]!, {r2, r3, r4, r5}\n\t"
         "SBC	r10, r10, r10\n\t"
         "CMP	%[a], r11\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_1024_sub_in_pkace_32_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_1024_sub_in_pkace_32_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_1024_sub_in_pkace_32_word\n\t"
 #else
-        "BNE.N	L_sp_1024_sub_in_pkace_32_word%=\n\t"
+        "BNE.N	L_sp_1024_sub_in_pkace_32_word_%=\n\t"
 #endif
         "MOV	%[a], r10\n\t"
         : [a] "+r" (a), [b] "+r" (b)
@@ -68306,7 +69668,11 @@ static sp_digit sp_1024_cond_sub_32(sp_digit* r, const sp_digit* a, const sp_dig
         "MOV	r4, #0x0\n\t"
         "MOV	r5, #0x0\n\t"
         "\n"
-    "L_sp_1024_cond_sub_32_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_1024_cond_sub_32_words:\n\t"
+#else
+    "L_sp_1024_cond_sub_32_words_%=:\n\t"
+#endif
         "SUBS	r4, r8, r4\n\t"
         "LDR	r6, [%[a], r5]\n\t"
         "LDR	r7, [%[b], r5]\n\t"
@@ -68316,10 +69682,12 @@ static sp_digit sp_1024_cond_sub_32(sp_digit* r, const sp_digit* a, const sp_dig
         "STR	r6, [%[r], r5]\n\t"
         "ADD	r5, r5, #0x4\n\t"
         "CMP	r5, #0x80\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_1024_cond_sub_32_words%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_1024_cond_sub_32_words_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_1024_cond_sub_32_words\n\t"
 #else
-        "BLT.N	L_sp_1024_cond_sub_32_words%=\n\t"
+        "BLT.N	L_sp_1024_cond_sub_32_words_%=\n\t"
 #endif
         "MOV	%[r], r4\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
@@ -68497,7 +69865,11 @@ static sp_digit sp_1024_add_32(sp_digit* r, const sp_digit* a, const sp_digit* b
         "MOV	r3, #0x0\n\t"
         "ADD	r12, %[a], #0x80\n\t"
         "\n"
-    "L_sp_1024_add_32_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_1024_add_32_word:\n\t"
+#else
+    "L_sp_1024_add_32_word_%=:\n\t"
+#endif
         "ADDS	r3, r3, #0xffffffff\n\t"
         "LDM	%[a]!, {r4, r5, r6, r7}\n\t"
         "LDM	%[b]!, {r8, r9, r10, r11}\n\t"
@@ -68509,10 +69881,12 @@ static sp_digit sp_1024_add_32(sp_digit* r, const sp_digit* a, const sp_digit* b
         "MOV	r4, #0x0\n\t"
         "ADC	r3, r4, #0x0\n\t"
         "CMP	%[a], r12\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BNE	L_sp_1024_add_32_word%=\n\t"
+#if defined(__GNUC__)
+        "BNE	L_sp_1024_add_32_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BNE.N	L_sp_1024_add_32_word\n\t"
 #else
-        "BNE.N	L_sp_1024_add_32_word%=\n\t"
+        "BNE.N	L_sp_1024_add_32_word_%=\n\t"
 #endif
         "MOV	%[r], r3\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -68551,7 +69925,11 @@ static void sp_1024_mul_d_32(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "MOV	r9, #0x4\n\t"
         "\n"
-    "L_sp_1024_mul_d_32_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_1024_mul_d_32_word:\n\t"
+#else
+    "L_sp_1024_mul_d_32_word_%=:\n\t"
+#endif
         /* A[i] * B */
         "LDR	r8, [%[a], r9]\n\t"
         "UMULL	r6, r7, %[b], r8\n\t"
@@ -68564,10 +69942,12 @@ static void sp_1024_mul_d_32(sp_digit* r, const sp_digit* a, sp_digit b)
         "MOV	r5, #0x0\n\t"
         "ADD	r9, r9, #0x4\n\t"
         "CMP	r9, #0x80\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_1024_mul_d_32_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_1024_mul_d_32_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_1024_mul_d_32_word\n\t"
 #else
-        "BLT.N	L_sp_1024_mul_d_32_word%=\n\t"
+        "BLT.N	L_sp_1024_mul_d_32_word_%=\n\t"
 #endif
         "STR	r3, [%[r], #128]\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
@@ -68865,7 +70245,11 @@ SP_NOINLINE static sp_digit div_1024_word_32(sp_digit d1, sp_digit d0, sp_digit 
         /* Next 30 bits */
         "MOV	r4, #0x1d\n\t"
         "\n"
-    "L_div_1024_word_32_bit%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_div_1024_word_32_bit:\n\t"
+#else
+    "L_div_1024_word_32_bit_%=:\n\t"
+#endif
         "LSLS	r6, r6, #1\n\t"
         "ADC	r7, r7, r7\n\t"
         "SUBS	r8, r5, r7\n\t"
@@ -68875,7 +70259,13 @@ SP_NOINLINE static sp_digit div_1024_word_32(sp_digit d1, sp_digit d0, sp_digit 
         "AND	r8, r8, r5\n\t"
         "SUBS	r7, r7, r8\n\t"
         "SUBS	r4, r4, #0x1\n\t"
-        "bpl	L_div_1024_word_32_bit%=\n\t"
+#if defined(__GNUC__)
+        "BPL	L_div_1024_word_32_bit_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BPL.N	L_div_1024_word_32_bit\n\t"
+#else
+        "BPL.N	L_div_1024_word_32_bit_%=\n\t"
+#endif
         "ADD	r3, r3, r3\n\t"
         "ADD	r3, r3, #0x1\n\t"
         "UMULL	r6, r7, r3, %[div]\n\t"
@@ -68957,7 +70347,11 @@ static sp_int32 sp_1024_cmp_32(const sp_digit* a, const sp_digit* b)
 #ifdef WOLFSSL_SP_SMALL
         "MOV	r6, #0x7c\n\t"
         "\n"
-    "L_sp_1024_cmp_32_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_1024_cmp_32_words:\n\t"
+#else
+    "L_sp_1024_cmp_32_words_%=:\n\t"
+#endif
         "LDR	r4, [%[a], r6]\n\t"
         "LDR	r5, [%[b], r6]\n\t"
         "AND	r4, r4, r3\n\t"
@@ -68970,7 +70364,7 @@ static sp_int32 sp_1024_cmp_32(const sp_digit* a, const sp_digit* b)
         "IT	ne\n\t"
         "movne	r3, r7\n\t"
         "SUBS	r6, r6, #0x4\n\t"
-        "bcs	L_sp_1024_cmp_32_words%=\n\t"
+        "bcs	L_sp_1024_cmp_32_words\n\t"
         "EOR	r2, r2, r3\n\t"
 #else
         "LDR	r4, [%[a], #124]\n\t"
@@ -69690,7 +71084,11 @@ SP_NOINLINE static void sp_1024_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "LDR	r4, [%[a]]\n\t"
         "LDR	r5, [%[a], #4]\n\t"
         "\n"
-    "L_sp_1024_mont_reduce_32_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_1024_mont_reduce_32_word:\n\t"
+#else
+    "L_sp_1024_mont_reduce_32_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "MUL	r10, %[mp], r4\n\t"
         /* a[i+0] += m[0] * mu */
@@ -69952,10 +71350,12 @@ SP_NOINLINE static void sp_1024_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "ADD	r11, r11, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r11, #0x80\n\t"
-#ifdef __GNUC__
-        "BLT	L_sp_1024_mont_reduce_32_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_1024_mont_reduce_32_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.W	L_sp_1024_mont_reduce_32_word\n\t"
 #else
-        "BLT.W	L_sp_1024_mont_reduce_32_word%=\n\t"
+        "BLT.W	L_sp_1024_mont_reduce_32_word_%=\n\t"
 #endif
         /* Loop Done */
         "STR	r4, [%[a]]\n\t"
@@ -70002,7 +71402,11 @@ SP_NOINLINE static void sp_1024_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "LDR	r9, [%[a], #12]\n\t"
         "LDR	r10, [%[a], #16]\n\t"
         "\n"
-    "L_sp_1024_mont_reduce_32_word%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_1024_mont_reduce_32_word:\n\t"
+#else
+    "L_sp_1024_mont_reduce_32_word_%=:\n\t"
+#endif
         /* mu = a[i] * mp */
         "MUL	lr, %[mp], r6\n\t"
         /* a[i+0] += m[0] * mu */
@@ -70169,10 +71573,12 @@ SP_NOINLINE static void sp_1024_mont_reduce_32(sp_digit* a, const sp_digit* m, s
         "ADD	r4, r4, #0x4\n\t"
         "ADD	%[a], %[a], #0x4\n\t"
         "CMP	r4, #0x80\n\t"
-#ifdef __GNUC__
-        "BLT	L_sp_1024_mont_reduce_32_word%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_1024_mont_reduce_32_word_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.W	L_sp_1024_mont_reduce_32_word\n\t"
 #else
-        "BLT.W	L_sp_1024_mont_reduce_32_word%=\n\t"
+        "BLT.W	L_sp_1024_mont_reduce_32_word_%=\n\t"
 #endif
         /* Loop Done */
         "STR	r6, [%[a]]\n\t"
@@ -71187,7 +72593,11 @@ static sp_digit sp_1024_cond_add_32(sp_digit* r, const sp_digit* a, const sp_dig
         "MOV	r8, #0x0\n\t"
         "MOV	r4, #0x0\n\t"
         "\n"
-    "L_sp_1024_cond_add_32_words%=:\n\t"
+#if defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+    "L_sp_1024_cond_add_32_words:\n\t"
+#else
+    "L_sp_1024_cond_add_32_words_%=:\n\t"
+#endif
         "ADDS	r5, r5, #0xffffffff\n\t"
         "LDR	r6, [%[a], r4]\n\t"
         "LDR	r7, [%[b], r4]\n\t"
@@ -71197,10 +72607,12 @@ static sp_digit sp_1024_cond_add_32(sp_digit* r, const sp_digit* a, const sp_dig
         "STR	r6, [%[r], r4]\n\t"
         "ADD	r4, r4, #0x4\n\t"
         "CMP	r4, #0x80\n\t"
-#if defined(__GNUC__) || defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
-        "BLT	L_sp_1024_cond_add_32_words%=\n\t"
+#if defined(__GNUC__)
+        "BLT	L_sp_1024_cond_add_32_words_%=\n\t"
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ < 9000000)
+        "BLT.N	L_sp_1024_cond_add_32_words\n\t"
 #else
-        "BLT.N	L_sp_1024_cond_add_32_words%=\n\t"
+        "BLT.N	L_sp_1024_cond_add_32_words_%=\n\t"
 #endif
         "MOV	%[r], r5\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)


### PR DESCRIPTION
# Description

IAR doesn't like %=.
Fix code to be consistent in use of labels and branch instructions.

Fixes zd#18315

# Testing


./configure '--disable-shared' '--enable-all' '--enable-sp-asm' '--enable-armasm' 'LDFLAGS=--static' '--host=armv7m' 'CC=arm-linux-gnueabi-gcc' '--disable-crl-monitor'
./configure '--disable-shared' '--enable-all' '--enable-sp-asm' '--enable-armasm=inline' 'LDFLAGS=--static' '--host=armv7m' 'CC=arm-linux-gnueabi-gcc' '--disable-crl-monitor'

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
