### PR TITLE
add feature for write/read data reusing the buffer passed in

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2846,13 +2846,64 @@ int wolfSSL_write(WOLFSSL* ssl, const void* data, int sz)
         return ret;
 }
 
-static int wolfSSL_read_internal(WOLFSSL* ssl, void* data, int sz, int peek)
+
+/* does encryption and creation of TLS packet inline on buffer 'data'
+ * can only handle one fragment at a time */
+int wolfSSL_write_inline(WOLFSSL* ssl, const void* data, int dataSz, int maxSz)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_write_inline");
+
+    if (ssl == NULL || data == NULL || dataSz < 0)
+        return BAD_FUNC_ARG;
+
+    /* only support a single TLS fragment */
+    if (wolfSSL_GetMaxFragSize(ssl, dataSz) > dataSz)
+        return BAD_FUNC_ARG;
+
+#ifdef WOLFSSL_QUIC
+    if (WOLFSSL_IS_QUIC(ssl)) {
+        WOLFSSL_MSG("SSL_write() on QUIC not allowed");
+        return BAD_FUNC_ARG;
+    }
+#endif
+
+#ifdef HAVE_ERRNO_H
+    errno = 0;
+#endif
+
+    if (SetOutputBuffer(ssl, (byte*)data, maxSz) != WOLFSSL_SUCCESS) {
+        return WOLFSSL_FAILURE;
+    }
+
+#ifdef OPENSSL_EXTRA
+    if (ssl->CBIS != NULL) {
+        ssl->CBIS(ssl, SSL_CB_WRITE, WOLFSSL_SUCCESS);
+        ssl->cbmode = SSL_CB_WRITE;
+    }
+#endif
+    ret = SendData(ssl, data, dataSz);
+
+    WOLFSSL_LEAVE("wolfSSL_write_inline", ret);
+
+    if (ret < 0)
+        return WOLFSSL_FATAL_ERROR;
+    else
+        return ret;
+}
+
+static int wolfSSL_read_internal(WOLFSSL* ssl, void** data, int sz, int peek)
 {
     int ret;
 
     WOLFSSL_ENTER("wolfSSL_read_internal");
 
     if (ssl == NULL || data == NULL || sz < 0)
+        return BAD_FUNC_ARG;
+
+    if (ssl->buffers.inputBuffer.dynamicFlag != WOLFSSL_EXTERNAL_IO_BUFFER &&
+            *data == NULL)
         return BAD_FUNC_ARG;
 
 #ifdef WOLFSSL_QUIC
@@ -2896,7 +2947,7 @@ static int wolfSSL_read_internal(WOLFSSL* ssl, void* data, int sz, int peek)
         errno = 0;
 #endif
 
-    ret = ReceiveData(ssl, (byte*)data, sz, peek);
+    ret = ReceiveData(ssl, (byte**)data, sz, peek);
 
 #ifdef HAVE_WRITE_DUP
     if (ssl->dupWrite) {
@@ -2929,7 +2980,7 @@ int wolfSSL_peek(WOLFSSL* ssl, void* data, int sz)
 {
     WOLFSSL_ENTER("wolfSSL_peek");
 
-    return wolfSSL_read_internal(ssl, data, sz, TRUE);
+    return wolfSSL_read_internal(ssl, &data, sz, TRUE);
 }
 
 
@@ -2947,7 +2998,39 @@ int wolfSSL_read(WOLFSSL* ssl, void* data, int sz)
         ssl->cbmode = SSL_CB_READ;
     }
     #endif
-    return wolfSSL_read_internal(ssl, data, sz, FALSE);
+    return wolfSSL_read_internal(ssl, &data, sz, FALSE);
+}
+
+
+/* 'buf' is the full buffer available when reading data from the peer
+ * 'data' pointer gets pointed to the location of 'buf' where the data has been
+ *        decrypted on success
+ *
+ * returns the amount of clear text data available on success and negative
+ *         values on failure
+ */
+int  wolfSSL_read_inline(WOLFSSL* ssl, void* buf, int bufSz, void** data,
+        int dataSz)
+{
+    WOLFSSL_ENTER("wolfSSL_read");
+
+    #ifdef OPENSSL_EXTRA
+    if (ssl == NULL) {
+        return BAD_FUNC_ARG;
+    }
+    if (ssl->CBIS != NULL) {
+        ssl->CBIS(ssl, SSL_CB_READ, WOLFSSL_SUCCESS);
+        ssl->cbmode = SSL_CB_READ;
+    }
+    #endif
+
+    /* ShrinkInputBuffer will reset the internal buffer back to the static
+     * buffer and does not zero out or free 'buf' */
+    if (SetInputBuffer(ssl, buf, bufSz) != WOLFSSL_SUCCESS) {
+        return WOLFSSL_FAILURE;
+    }
+
+    return wolfSSL_read_internal(ssl, data, dataSz, FALSE);
 }
 
 
@@ -2962,7 +3045,7 @@ int wolfSSL_mcast_read(WOLFSSL* ssl, word16* id, void* data, int sz)
     if (ssl == NULL)
         return BAD_FUNC_ARG;
 
-    ret = wolfSSL_read_internal(ssl, data, sz, FALSE);
+    ret = wolfSSL_read_internal(ssl, &data, sz, FALSE);
     if (ssl->options.dtls && ssl->options.haveMcast && id != NULL)
         *id = ssl->keys.curPeerId;
     return ret;

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -14647,7 +14647,7 @@ int wolfSSL_read_early_data(WOLFSSL* ssl, void* data, int sz, int* outSz)
             return WOLFSSL_FATAL_ERROR;
     }
     if (ssl->options.handShakeState == SERVER_FINISHED_COMPLETE) {
-        ret = ReceiveData(ssl, (byte*)data, sz, FALSE);
+        ret = ReceiveData(ssl, (byte**)&data, sz, FALSE);
         if (ret > 0)
             *outSz = ret;
         if (ssl->error == ZERO_RETURN) {

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2342,13 +2342,15 @@ enum {
     #define STATIC_BUFFER_LEN RECORD_HEADER_SZ
 #endif
 
+#define WOLFSSL_DYNMAIC_IO_BUFFER  1
+#define WOLFSSL_EXTERNAL_IO_BUFFER 2
 typedef struct {
     ALIGN16 byte staticBuffer[STATIC_BUFFER_LEN];
     byte*  buffer;       /* place holder for static or dynamic buffer */
     word32 length;       /* total buffer length used */
     word32 idx;          /* idx to part of length already consumed */
     word32 bufferSize;   /* current buffer size */
-    byte   dynamicFlag;  /* dynamic memory currently in use */
+    byte   dynamicFlag;  /* dynamic(1) or external(2) memory currently in use */
     byte   offset;       /* alignment offset attempt */
 } bufferStatic;
 
@@ -6244,7 +6246,7 @@ WOLFSSL_LOCAL int SendHelloRequest(WOLFSSL* ssl);
 WOLFSSL_LOCAL int SendCertificateStatus(WOLFSSL* ssl);
 WOLFSSL_LOCAL int SendServerKeyExchange(WOLFSSL* ssl);
 WOLFSSL_LOCAL int SendBuffered(WOLFSSL* ssl);
-WOLFSSL_LOCAL int ReceiveData(WOLFSSL* ssl, byte* output, int sz, int peek);
+WOLFSSL_LOCAL int ReceiveData(WOLFSSL* ssl, byte** output, int sz, int peek);
 WOLFSSL_LOCAL int SendFinished(WOLFSSL* ssl);
 WOLFSSL_LOCAL int RetrySendAlert(WOLFSSL* ssl);
 WOLFSSL_LOCAL int SendAlert(WOLFSSL* ssl, int severity, int type);
@@ -6273,6 +6275,8 @@ WOLFSSL_LOCAL void FreeHandshakeResources(WOLFSSL* ssl);
 WOLFSSL_LOCAL void ShrinkInputBuffer(WOLFSSL* ssl, int forcedFree);
 WOLFSSL_LOCAL void ShrinkOutputBuffer(WOLFSSL* ssl);
 WOLFSSL_LOCAL byte* GetOutputBuffer(WOLFSSL* ssl);
+WOLFSSL_LOCAL int SetOutputBuffer(WOLFSSL* ssl, byte* buf, int bufSz);
+WOLFSSL_LOCAL int SetInputBuffer(WOLFSSL* ssl, byte* buf, int bufSz);
 
 WOLFSSL_LOCAL int CipherRequires(byte first, byte second, int requirement);
 WOLFSSL_LOCAL int VerifyClientSuite(word16 havePSK, byte cipherSuite0,

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1185,6 +1185,10 @@ WOLFSSL_ABI WOLFSSL_API int  wolfSSL_connect(WOLFSSL* ssl);
 WOLFSSL_ABI WOLFSSL_API int  wolfSSL_write(
     WOLFSSL* ssl, const void* data, int sz);
 WOLFSSL_ABI WOLFSSL_API int  wolfSSL_read(WOLFSSL* ssl, void* data, int sz);
+WOLFSSL_API int  wolfSSL_write_inline( WOLFSSL* ssl, const void* data,
+    int dataSz, int maxSz);
+WOLFSSL_API int  wolfSSL_read_inline(WOLFSSL* ssl, void* buf, int bufSz,
+    void** data, int dataSz);
 WOLFSSL_API int  wolfSSL_peek(WOLFSSL* ssl, void* data, int sz);
 WOLFSSL_ABI WOLFSSL_API int  wolfSSL_accept(WOLFSSL* ssl);
 WOLFSSL_API int  wolfSSL_CTX_mutual_auth(WOLFSSL_CTX* ctx, int req);


### PR DESCRIPTION
Part of the PIC18f effort to reduce memory used. This avoids having the application allocate a plain text buffer to then pass to wolfSSL and have copied over to an internal 'send' buffer. And on the receiving side avoids having an internal 'recv' buffer in addition to the applications buffer for holding plain text data received. Helping to reduce the overall memory used.

i.e. Sending a 50 byte data message before would use 50 bytes in an application buffer created, plus 50 + record header + Mac output buffer in wolfSSL internally. Now it's one 50 + record header + Mac buffer created in the application and passed to wolfSSL that gets reused.