### PR TITLE
Misc cleanup: FreeX509 null pointer checks, and spelling cleanup.

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -4643,11 +4643,20 @@ void FreeX509(WOLFSSL_X509* x509)
         x509->altNames = NULL;
     }
 
-#ifdef WOLFSSL_DUAL_ALG_CERTS
-    XFREE(x509->sapkiDer, x509->heap, DYNAMIC_TYPE_X509_EXT);
-    XFREE(x509->altSigAlgDer, x509->heap, DYNAMIC_TYPE_X509_EXT);
-    XFREE(x509->altSigValDer, x509->heap, DYNAMIC_TYPE_X509_EXT);
-#endif /* WOLFSSL_DUAL_ALG_CERTS */
+    #ifdef WOLFSSL_DUAL_ALG_CERTS
+    if (x509->sapkiDer) {
+        XFREE(x509->sapkiDer, x509->heap, DYNAMIC_TYPE_X509_EXT);
+        x509->sapkiDer = NULL;
+    }
+    if (x509->altSigAlgDer) {
+        XFREE(x509->altSigAlgDer, x509->heap, DYNAMIC_TYPE_X509_EXT);
+        x509->altSigAlgDer = NULL;
+    }
+    if (x509->altSigValDer) {
+        XFREE(x509->altSigValDer, x509->heap, DYNAMIC_TYPE_X509_EXT);
+        x509->altSigValDer= NULL;
+    }
+    #endif /* WOLFSSL_DUAL_ALG_CERTS */
 
     #if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)
         wolfSSL_RefFree(&x509->ref);
@@ -11472,7 +11481,7 @@ static int GetRecordHeader(WOLFSSL* ssl, word32* inOutIdx,
         }
 #endif /* WOLFSSL_DTLS13 */
         /* Don't care about protocol version being lower than expected on alerts
-         * sent back before version negotitation. */
+         * sent back before version negotiation. */
         else if (!(ssl->options.side == WOLFSSL_CLIENT_END &&
                             ssl->options.connectState == CLIENT_HELLO_SENT &&
                             rh->type == alert &&

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -20228,7 +20228,7 @@ VerifyCallback wolfSSL_CTX_get_verify_callback(WOLFSSL_CTX* ctx)
 }
 
 #ifdef HAVE_SNI
-/* this is a compatibily function, consider using
+/* this is a compatibility function, consider using
  * wolfSSL_CTX_set_servername_callback */
 int wolfSSL_CTX_set_tlsext_servername_callback(WOLFSSL_CTX* ctx,
                                                CallbackSniRecv cb)

--- a/tests/api.c
+++ b/tests/api.c
@@ -1305,7 +1305,7 @@ static int test_dual_alg_support(void)
      * the alternative signature and then set negative_test to true for the
      * call to do_dual_alg_tls13_connection(). Its expecting a failed connection
      * because the signature won't verify. The exception is if
-     * WOLFSSL_TRUST_PEER_CERT is defined. In that case, no verfication happens
+     * WOLFSSL_TRUST_PEER_CERT is defined. In that case, no verification happens
      * and this is no longer a negative test. */
     if (EXPECT_SUCCESS()) {
         rootSz = do_dual_alg_root_certgen(&root, keyFile, sapkiFile,
@@ -45087,7 +45087,7 @@ static int test_wolfSSL_PEM_PrivateKey_ecc(void)
     ExpectIntEQ(PEM_write_bio_PrivateKey(bio, pkey, NULL, NULL, 0, NULL, NULL),
         WOLFSSL_SUCCESS);
     ExpectIntGT(BIO_pending(bio), 0);
-    /* No parmeters. */
+    /* No parameters. */
     ExpectIntEQ(BIO_pending(bio), 227);
     /* Check if the pubkey API writes only the public key */
 #ifdef WOLFSSL_KEY_GEN
@@ -73703,7 +73703,7 @@ static int test_stubs_are_stubs(void)
     CHECKZERO_RET(wolfSSL_CTX_sess_misses, ctx, ctxN);
     CHECKZERO_RET(wolfSSL_CTX_sess_timeouts, ctx, ctxN);
 
-    /* when implemented this should take WOLFSSL object insted, right now
+    /* when implemented this should take WOLFSSL object instead, right now
      * always returns 0 */
     ExpectPtrEq(SSL_get_current_expansion(NULL), NULL);
 

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -2177,7 +2177,7 @@ WOLFSSL_LOCAL int CheckCertSignaturePubKey(const byte* cert, word32 certSz,
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_SMALL_CERT_VERIFY)
     WOLFSSL_API int wc_CheckCertSignature(const byte* cert, word32 certSz,
                                           void* heap, void* cm);
-    /* Depricated public API name kept for backwards build compatibility */
+    /* Deprecated public API name kept for backwards build compatibility */
     #define CheckCertSignature(cert, certSz, heap, cm) \
         wc_CheckCertSignature(cert, certSz, heap, cm)
 

--- a/wolfssl/wolfcrypt/port/Espressif/esp-sdk-lib.h
+++ b/wolfssl/wolfcrypt/port/Espressif/esp-sdk-lib.h
@@ -116,7 +116,7 @@
     ** the config you want - ie #define EXAMPLE_WIFI_SSID "mywifissid"
     */
     #if defined(CONFIG_ESP_WIFI_SSID)
-        /* tyically from ESP32 with ESP-IDF v4 ot v5 */
+        /* tyically from ESP32 with ESP-IDF v4 or v5 */
         #define EXAMPLE_ESP_WIFI_SSID CONFIG_ESP_WIFI_SSID
     #elif defined(CONFIG_EXAMPLE_WIFI_SSID)
         /* typically from ESP8266 rtos-sdk/v3.4 */


### PR DESCRIPTION
# Description

- Missing null pointer checks in FreeX509().
- misc spelling cleanup.