### PR TITLE
20240717-fixes

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -8705,7 +8705,7 @@ static int TLSX_KeyShare_ProcessPqc(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
     (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION != 2))) && \
     !defined(HAVE_SELFTEST)
         if (ret == 0) {
-            ret = wc_ecc_set_rng(keyShareEntry->key, ssl->rng);
+            ret = wc_ecc_set_rng((ecc_key *)keyShareEntry->key, ssl->rng);
             if (ret != 0) {
                 WOLFSSL_MSG("Failure to set the ECC private key RNG.");
             }
@@ -8714,8 +8714,8 @@ static int TLSX_KeyShare_ProcessPqc(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
 
         if (ret == 0) {
             PRIVATE_KEY_UNLOCK();
-            ret = wc_ecc_shared_secret(keyShareEntry->key, &eccpubkey,
-                sharedSecret, &outlen);
+            ret = wc_ecc_shared_secret((ecc_key *)keyShareEntry->key,
+                &eccpubkey, sharedSecret, &outlen);
             PRIVATE_KEY_LOCK();
             if (outlen != sharedSecretLen - ssSz) {
                 WOLFSSL_MSG("ECC shared secret derivation error.");
@@ -9193,14 +9193,14 @@ static int server_generate_pqc_ciphertext(WOLFSSL* ssl,
     (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION != 2))) && \
     !defined(HAVE_SELFTEST)
         if (ret == 0) {
-            ret = wc_ecc_set_rng(ecc_kse->key, ssl->rng);
+            ret = wc_ecc_set_rng((ecc_key *)ecc_kse->key, ssl->rng);
         }
 #endif
 
         if (ret == 0) {
             outlen = ecc_kse->keyLen;
             PRIVATE_KEY_UNLOCK();
-            ret = wc_ecc_shared_secret(ecc_kse->key, &eccpubkey,
+            ret = wc_ecc_shared_secret((ecc_key *)ecc_kse->key, &eccpubkey,
                                        sharedSecret,
                                        &outlen);
             PRIVATE_KEY_LOCK();

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -9586,7 +9586,7 @@ static int lms_read_key_mem(byte* priv, word32 privSz, void* context)
 }
 static byte lms_priv[HSS_MAX_PRIVATE_KEY_LEN];
 
-static void bench_lms_keygen(int parm, byte* pub)
+static void bench_lms_keygen(enum wc_LmsParm parm, byte* pub)
 {
     WC_RNG      rng;
     LmsKey      key;
@@ -9698,7 +9698,7 @@ exit_lms_keygen:
     wc_FreeRng(&rng);
 }
 
-static void bench_lms_sign_verify(int parm, byte* pub)
+static void bench_lms_sign_verify(enum wc_LmsParm parm, byte* pub)
 {
     LmsKey       key;
     int          ret = 0;
@@ -9762,6 +9762,31 @@ static void bench_lms_sign_verify(int parm, byte* pub)
     case WC_LMS_PARM_L1_H15_W4:
     case WC_LMS_PARM_L2_H10_W8:
     case WC_LMS_PARM_L3_H5_W2:
+    case WC_LMS_PARM_L1_H5_W1:
+    case WC_LMS_PARM_L1_H5_W2:
+    case WC_LMS_PARM_L1_H5_W4:
+    case WC_LMS_PARM_L1_H5_W8:
+    case WC_LMS_PARM_L1_H10_W2:
+    case WC_LMS_PARM_L1_H10_W4:
+    case WC_LMS_PARM_L1_H10_W8:
+    case WC_LMS_PARM_L1_H15_W8:
+    case WC_LMS_PARM_L1_H20_W2:
+    case WC_LMS_PARM_L1_H20_W4:
+    case WC_LMS_PARM_L1_H20_W8:
+    case WC_LMS_PARM_L2_H5_W2:
+    case WC_LMS_PARM_L2_H5_W4:
+    case WC_LMS_PARM_L2_H5_W8:
+    case WC_LMS_PARM_L2_H15_W2:
+    case WC_LMS_PARM_L2_H15_W4:
+    case WC_LMS_PARM_L2_H15_W8:
+    case WC_LMS_PARM_L2_H20_W2:
+    case WC_LMS_PARM_L2_H20_W4:
+    case WC_LMS_PARM_L2_H20_W8:
+    case WC_LMS_PARM_L3_H10_W8:
+    case WC_LMS_PARM_L4_H5_W2:
+    case WC_LMS_PARM_L4_H5_W4:
+    case WC_LMS_PARM_L4_H10_W4:
+    case WC_LMS_PARM_L4_H10_W8:
     default:
         XMEMCPY(key.pub, pub, HSS_MAX_PUBLIC_KEY_LEN);
         break;
@@ -9853,7 +9878,7 @@ static void bench_lms_sign_verify(int parm, byte* pub)
 
     loaded = 1;
 
-    sig = XMALLOC(sigSz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    sig = (byte *)XMALLOC(sigSz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     if (sig == NULL) {
         printf("bench_lms_sign_verify malloc failed\n");
         goto exit_lms_sign_verify;

--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -2035,7 +2035,7 @@ static int dilithium_expand_a(wc_Shake* shake128, const byte* pub_seed, byte k,
 #define DILITHIUM_COEFF_S_VALID_ETA2(b) \
     ((b) < DILITHIUM_ETA_2_MOD)
 
-static const byte dilithium_coeff_eta2[] = {
+static const char dilithium_coeff_eta2[] = {
     2, 1, 0, -1, -2,
     2, 1, 0, -1, -2,
     2, 1, 0, -1, -2

--- a/wolfcrypt/src/wc_lms.c
+++ b/wolfcrypt/src/wc_lms.c
@@ -629,7 +629,7 @@ int wc_LmsKey_MakeKey(LmsKey* key, WC_RNG* rng)
         const LmsParams* params = key->params;
 
         /* Allocate memory for the private key data. */
-        key->priv_data = XMALLOC(LMS_PRIV_DATA_LEN(params->levels,
+        key->priv_data = (byte *)XMALLOC(LMS_PRIV_DATA_LEN(params->levels,
             params->height, params->p, params->rootLevels, params->cacheBits),
             key->heap, DYNAMIC_TYPE_LMS);
         /* Check pointer is valid. */
@@ -728,7 +728,7 @@ int wc_LmsKey_Reload(LmsKey* key)
         const LmsParams* params = key->params;
 
         /* Allocate memory for the private key data. */
-        key->priv_data = XMALLOC(LMS_PRIV_DATA_LEN(params->levels,
+        key->priv_data = (byte *)XMALLOC(LMS_PRIV_DATA_LEN(params->levels,
             params->height, params->p, params->rootLevels, params->cacheBits),
             key->heap, DYNAMIC_TYPE_LMS);
         /* Check pointer is valid. */

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -595,7 +595,7 @@ struct ecc_key {
 #if defined(WOLFSSL_ECDSA_DETERMINISTIC_K) || \
     defined(WOLFSSL_ECDSA_DETERMINISTIC_K_VARIANT)
     byte deterministic:1;
-    int hashType;
+    enum wc_HashType hashType;
 #endif
 
 #if defined(WOLFSSL_SMALL_STACK_CACHE) && !defined(WOLFSSL_ECC_NO_SMALL_STACK)
@@ -720,7 +720,8 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
 WOLFSSL_API
 int wc_ecc_set_deterministic(ecc_key* key, byte flag);
 WOLFSSL_API
-int wc_ecc_set_deterministic_ex(ecc_key* key, byte flag, int hashType);
+int wc_ecc_set_deterministic_ex(ecc_key* key, byte flag,
+        enum wc_HashType hashType);
 WOLFSSL_API
 int wc_ecc_gen_deterministic_k(const byte* hash, word32 hashSz,
         enum wc_HashType hashType, mp_int* priv, mp_int* k, mp_int* order,


### PR DESCRIPTION
fixes for defects identified by nightly testing:

* `ecc.c`: in `wc_ecc_free()`, fix gating around handling for `key->sign_k` to resolve memory leak, and in `wc_ecc_gen_deterministic_k()`, fix `-Wconversion`.

* `test.c`: add missing `mp_free()`s to `ecdsa_test_deterministic_k_rs()` and `ecc521_test_deterministic_k()`.

* `wc_HashType`: change several occurrences of `int` to `enum wc_HashType`, including `ecc_key.hashType` and API `wc_ecc_set_deterministic_ex()`, to resolve C++ warnings.

* fixes for various C++ warnings/errors in crypto and TLS layers and test and benchmark code -- implicit casts, negative initializers for unsigned type, jumped initializers, and missing enums in switch()es.

detected and tested with `wolfssl-multi-test.sh ... quantum-safe-wolfssl-all-intelasm-sp-asm-sanitizer 'quantum-safe-wolfssl-all-g\+\+-latest' allcryptonly-Wconversion-intelasm-build allcryptonly-c99-Wconversion-build allcryptonly-c99-Wconversion-m32-build allcryptonly-c89-Wconversion-build allcryptonly-c89-Wconversion-m32-build 'all-g\+\+-gnu17' lms-xmss-wolfssl-all-clang-sanitizer intmath-sanitizer`

also tested with `wolfssl-multi-test.sh ... super-quick-check`
