### PR TITLE
20240718-cppcheck-2v14v2-suppressions

### DIFF
--- a/src/ssl_sess.c
+++ b/src/ssl_sess.c
@@ -1413,7 +1413,7 @@ int wolfSSL_GetSessionFromCache(WOLFSSL* ssl, WOLFSSL_SESSION* output)
             output->ticketLen = 0;
         }
         if (error == WOLFSSL_SUCCESS) {
-            XMEMCPY(output->ticket, tmpTicket, output->ticketLen);
+            XMEMCPY(output->ticket, tmpTicket, output->ticketLen); /* cppcheck-suppress uninitvar */
         }
     }
 #ifdef WOLFSSL_SMALL_STACK

--- a/src/tls.c
+++ b/src/tls.c
@@ -1056,7 +1056,7 @@ static int Hmac_UpdateFinal_CT(Hmac* hmac, byte* digest, const byte* in,
             hashBlock[j] = b;
         }
 
-        ret = Hmac_HashUpdate(hmac, hashBlock, (word32)blockSz);
+        ret = Hmac_HashUpdate(hmac, hashBlock, (word32)blockSz); /* cppcheck-suppress uninitvar */
         if (ret != 0)
             return ret;
         ret = Hmac_HashFinalRaw(hmac, hashBlock);

--- a/src/x509.c
+++ b/src/x509.c
@@ -3550,7 +3550,7 @@ char* wolfSSL_X509_get_name_oneline(WOLFSSL_X509_NAME* name, char* in, int sz)
         }
     }
 
-    XMEMCPY(in, tmpBuf, totalLen);
+    XMEMCPY(in, tmpBuf, totalLen); /* cppcheck-suppress uninitvar */
     in[totalLen] = '\0';
 
     return in;

--- a/wolfcrypt/src/md2.c
+++ b/wolfcrypt/src/md2.c
@@ -123,7 +123,7 @@ void wc_Md2Final(Md2* md2, byte* hash)
     for (i = 0; i < padLen; i++)
         padding[i] = (byte)padLen;
 
-    wc_Md2Update(md2, padding, padLen);
+    wc_Md2Update(md2, padding, padLen); /* cppcheck-suppress uninitvar */
     wc_Md2Update(md2, md2->C, MD2_BLOCK_SIZE);
 
     XMEMCPY(hash, md2->X, MD2_DIGEST_SIZE);


### PR DESCRIPTION
suppress 4 `uninitvar` warnings, all associated with passing partially written arrays (true but benign positives).  newly detected by `cppcheck` 2.14.2.

tested with `wolfssl-multi-test.sh ... cppcheck-all` with `cppcheck` 2.14.2 and `--check-level=exhaustive` added to `CPPCHECK_COMMON_ARGS`[].
