### PR TITLE
20240719-test-hpke-PRIVATE_KEY_UNLOCK

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -1767,10 +1767,12 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 #endif
 
 #if defined(HAVE_HPKE) && defined(HAVE_ECC) && defined(HAVE_AESGCM)
+    PRIVATE_KEY_UNLOCK();
     if ( (ret = hpke_test()) != 0)
         TEST_FAIL("HPKE     test failed!\n", ret);
     else
         TEST_PASS("HPKE     test passed!\n");
+    PRIVATE_KEY_LOCK();
 #endif
 
 #if defined(WC_SRTP_KDF)

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -300,10 +300,16 @@ WOLFSSL_ABI WOLFSSL_API const char* wc_GetErrorString(int error);
 #ifdef WOLFSSL_DEBUG_TRACE_ERROR_CODES
     #define WC_NO_ERR_TRACE(label) (CONST_NUM_ERR_ ## label)
     #ifndef WC_ERR_TRACE
+        #ifdef NO_STDIO_FILESYSTEM
+        #define WC_ERR_TRACE(label)                           \
+            ( printf("ERR TRACE: %s L %d " #label " (%d)\n",  \
+                      __FILE__, __LINE__, label), label)
+        #else
         #define WC_ERR_TRACE(label)                           \
             ( fprintf(stderr,                                 \
                       "ERR TRACE: %s L %d " #label " (%d)\n", \
                       __FILE__, __LINE__, label), label)
+        #endif
     #endif
     #include <wolfssl/debug-trace-error-codes.h>
 #else


### PR DESCRIPTION
`wolfcrypt/test/test.c`: add missing `PRIVATE_KEY_UNLOCK()` for `hpke_test()`.

`wolfssl/wolfcrypt/error-crypt.h`: add `NO_STDIO_FILESYSTEM` definition for `WC_ERR_TRACE()`.

tested with `wolfssl-multi-test.sh ... linuxkm-fips-dev-static-hash-intelasm-LKCAPI-insmod-crypto-fuzzer`
