### PR TITLE
Zephyr V3.7 warning fix

### DIFF
--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -147,8 +147,8 @@
 #elif defined(WOLFSSL_ZEPHYR)
     #include <version.h>
     #ifndef SINGLE_THREADED
-        #ifndef CONFIG_PTHREAD_IPC
-            #error "Need CONFIG_PTHREAD_IPC for threading"
+        #if !defined(CONFIG_PTHREAD_IPC) && !defined(CONFIG_POSIX_THREADS)
+            #error "Threading needs CONFIG_PTHREAD_IPC / CONFIG_POSIX_THREADS"
         #endif
     #if KERNEL_VERSION_NUMBER >= 0x30100
         #include <zephyr/kernel.h>


### PR DESCRIPTION
Hi all,

The required feature flag `CONFIG_PTHREAD_IPC` for the Zephyr port will be deprecated in the upcoming Zephyr version 3.7. The new option for the required multithreading code is `CONFIG_POSIX_THREADS`. 

This PR clears the resulting warning when compiling for Zephyr V3.7. For older versions, nothing changes.

