### PR TITLE
Update Arduino publishing script for 5.7.2 release

### DIFF
--- a/IDE/ARDUINO/Arduino_README_prepend.md
+++ b/IDE/ARDUINO/Arduino_README_prepend.md
@@ -10,4 +10,6 @@ See the [Arduino-wolfSSL logs](https://downloads.arduino.cc/libraries/logs/githu
 
 The first Official wolfSSL Arduino Library is `5.6.6-Arduino.1`: a slightly modified, post [release 5.6.6](https://github.com/wolfSSL/wolfssl/releases/tag/v5.6.6-stable) version update.
 
+The next Official wolfSSL Arduino Library is [5.7.0](https://github.com/wolfSSL/wolfssl/releases/tag/v5.7.0-stable)
+
 See other [wolfSSL releases versions](https://github.com/wolfSSL/wolfssl/releases). The `./wolfssl-arduino.sh INSTALL` [script](https://github.com/wolfSSL/wolfssl/tree/master/IDE/ARDUINO) can be used to install specific GitHub versions as needed.


### PR DESCRIPTION
# Description

Minor changes to the `IDE/ARDUINO/wolfssl-arduino.sh` publishing script that was used to create https://github.com/wolfSSL/Arduino-wolfSSL/pull/8.

Fixes zd# n/a

# Testing

How did you test?

Tested only during publish of Arduino to [Arduino-wolfSSL](https://github.com/wolfSSL/Arduino-wolfSSL) repo.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
