### PR TITLE
20240722-fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -894,7 +894,6 @@ then
     test "$enable_blake2s" = "" && enable_blake2s=yes
     test "$enable_md2" = "" && enable_md2=yes
     test "$enable_md4" = "" && enable_md4=yes
-    test "$enable_cryptocb" = "" && enable_cryptocb=yes
     test "$enable_anon" = "" && enable_anon=yes
     test "$enable_ssh" = "" && test "$enable_hmac" != "no" && enable_ssh=yes
 
@@ -960,6 +959,7 @@ then
 
     if test "$ENABLED_FIPS" = "no"
     then
+        test "$enable_cryptocb" = "" && enable_cryptocb=yes
         test "$enable_pkcallbacks" = "" && enable_pkcallbacks=yes
         test "$enable_xchacha" = "" && test "$enable_chacha" != "no" && enable_xchacha=yes
         test "$enable_scep" = "" && enable_scep=yes
@@ -1085,7 +1085,6 @@ then
     test "$enable_blake2s" = "" && enable_blake2s=yes
     test "$enable_md2" = "" && enable_md2=yes
     test "$enable_md4" = "" && enable_md4=yes
-    test "$enable_cryptocb" = "" && enable_cryptocb=yes
     test "$enable_anon" = "" && enable_anon=yes
     test "$enable_ssh" = "" && test "$enable_hmac" != "no" && enable_ssh=yes
     test "$enable_srtp_kdf" = "" && enable_srtp_kdf=yes
@@ -1107,6 +1106,7 @@ then
 
     if test "$ENABLED_FIPS" = "no"
     then
+        test "$enable_cryptocb" = "" && enable_cryptocb=yes
         test "$enable_pkcallbacks" = "" && enable_pkcallbacks=yes
         test "$enable_xchacha" = "" && test "$enable_chacha" != "no" && enable_xchacha=yes
         test "$enable_pkcs7" = "" && enable_pkcs7=yes

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -33683,9 +33683,9 @@ static int EccSpecifiedECDomainDecode(const byte* input, word32 inSz,
     #else
     if (ret == 0) {
         /* Base X-ordinate */
-        DataToHexString(base + 1, curve->size, curve->Gx);
+        DataToHexString(base + 1, (word32)curve->size, curve->Gx);
         /* Base Y-ordinate */
-        DataToHexString(base + 1 + curve->size, curve->size, curve->Gy);
+        DataToHexString(base + 1 + curve->size, (word32)curve->size, curve->Gy);
         /* Prime */
         DataToHexString(dataASN[ECCSPECIFIEDASN_IDX_PRIME_P].data.ref.data,
                         dataASN[ECCSPECIFIEDASN_IDX_PRIME_P].data.ref.length,

--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -1153,7 +1153,7 @@ static int GeneratePrivateDh186(DhKey* key, WC_RNG* rng, byte* priv,
     }
 
 #ifdef WOLFSSL_CHECK_MEM_ZERO
-    wc_MemZero_Add("GeneratePrivateDh186 cBuf", cBuf, cSz);
+    wc_MemZero_Add("GeneratePrivateDh186 cBuf", cBuf, cSz); /* cppcheck-suppress uninitvar */
     mp_memzero_add("GeneratePrivateDh186 tmpX", tmpX);
 #endif
     do {

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -51147,6 +51147,9 @@ static wc_test_ret_t mp_test_param(mp_int* a, mp_int* b, mp_int* r, WC_RNG* rng)
     if (ret != 0)
         return WC_TEST_RET_ENC_EC(ret);
 
+    /* clear buffer to avoid provoking uninitvar errors. */
+    XMEMSET(buffer, 0, sizeof(buffer));
+
     ret = mp_read_unsigned_bin(NULL, NULL, sizeof(buffer));
     if (ret != MP_VAL)
         return WC_TEST_RET_ENC_EC(ret);


### PR DESCRIPTION
`wolfcrypt/src/asn.c`: in `EccSpecifiedECDomainDecode()`, in calls to `DataToHexString()`, cast `curve->size` to `word32` to resolve `-Wconversion`.

`wolfcrypt/src/dh.c`: in `GeneratePrivateDh186()`, add explicit suppression of `uninitvar` for `cBuf` arg that isn't fully initialized.

`wolfcrypt/test/test.c`: in `mp_test_param()`, explicitly initialize `buffer` to avoid `uninitvar` warning.

`configure.ac`: in FIPS builds, don't include `enable_cryptocb` in `--enable-all` or `--enable-all-crypto`.  (they can still be enabled explicitly in FIPS builds with `--enable-cryptocb`, but the combination is not currently supported.)

tested with `wolfssl-multi-test.sh ... super-quick-check`
