### PR TITLE
20240723-AesGcmXcrypt-NULL-in-checks

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -8308,7 +8308,10 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     int ret;
 
     /* argument checks */
-    if (aes == NULL || authTagSz > AES_BLOCK_SIZE || ivSz == 0) {
+    if (aes == NULL || authTagSz > AES_BLOCK_SIZE || ivSz == 0 ||
+        ((authTagSz > 0) && (authTag == NULL)) ||
+        ((authInSz > 0) && (authIn == NULL)))
+    {
         return BAD_FUNC_ARG;
     }
 
@@ -8437,8 +8440,8 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
      * in and out are don't cares, as this is is the GMAC case. */
     if (aes == NULL || iv == NULL || (sz != 0 && (in == NULL || out == NULL)) ||
         authTag == NULL || authTagSz > AES_BLOCK_SIZE || authTagSz == 0 ||
-        ivSz == 0) {
-
+        ivSz == 0 || ((authInSz > 0) && (authIn == NULL)))
+    {
         return BAD_FUNC_ARG;
     }
 


### PR DESCRIPTION
`wolfcrypt/src/aes.c`: in `wc_AesGcmEncrypt()` and `wc_AesGcmDecrypt()`, check and return `BAD_FUNC_ARG` for nonzero sizes associated with null pointers.

detected and tested with `wolfssl-multi-test.sh ... fips-140-3-dev-optest-acvp-sp-asm` -- the x86 asm implementation has insufficient error checking, and the changes in this PR protect it.

see also https://github.com/wolfSSL/fips/pull/274 for `optest-140-3` that is clean on this PR.
