### PR TITLE
Fix STM32 Hash FIFO and add support for STM32U5A9xx

### DIFF
--- a/IDE/STM32Cube/default_conf.ftl
+++ b/IDE/STM32Cube/default_conf.ftl
@@ -148,11 +148,11 @@ extern ${variable.value} ${variable.name};
     #define HAL_CONSOLE_UART huart2
     #define NO_STM32_RNG
     #define WOLFSSL_GENSEED_FORTEST /* no HW RNG is available use test seed */
-#elif defined(STM32U575xx) || defined(STM32U585xx)
+#elif defined(STM32U575xx) || defined(STM32U585xx) || defined(STM32U5A9xx)
     #define HAL_CONSOLE_UART huart1
     #define WOLFSSL_STM32U5
     #define STM32_HAL_V2
-    #ifdef STM32U585xx
+    #if defined(STM32U585xx) || defined(STM32U5A9xx)
         #undef  NO_STM32_HASH
         #undef  NO_STM32_CRYPTO
         #define WOLFSSL_STM32_PKA

--- a/IDE/STM32Cube/wolfssl_example.c
+++ b/IDE/STM32Cube/wolfssl_example.c
@@ -284,7 +284,7 @@ typedef struct {
 typedef struct {
     int ret;
 
-    osThreadId threadId;
+    osThreadId_t threadId;
 #ifdef CMSIS_OS2_H_
     osSemaphoreId_t mutex;
 #else

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -2496,7 +2496,7 @@ int wc_Sha256GetHash(wc_Sha256* sha256, byte* hash)
     ret = wc_Sha256Copy(sha256, tmpSha256);
     if (ret == 0) {
         ret = wc_Sha256Final(tmpSha256, hash);
-        wc_Sha256Free(tmpSha256); /* TODO move outside brackets? */
+        wc_Sha256Free(tmpSha256);
     }
 
 

--- a/wolfssl/wolfcrypt/port/st/stm32.h
+++ b/wolfssl/wolfcrypt/port/st/stm32.h
@@ -71,26 +71,6 @@
 #define STM32_HASH_REG_SIZE  4
 #define STM32_HASH_FIFO_SIZE 16 /* FIFO is 16 deep 32-bits wide */
 
-#if (defined(WOLFSSL_STM32U5) || defined(WOLFSSL_STM32H5) || \
-    defined(WOLFSSL_STM32H7)) && !defined(NO_STM32_HASH_FIFO_WORKAROUND)
-    /* workaround for hash FIFO to write one extra to finalize */
-    /* RM: Message Data Feeding: Data are entered into the HASH
-     * one 32-bit word at a time, by writing them into the HASH_DIN register.
-     * The current contents of the HASH_DIN register are transferred to the
-     * 16 words input FIFO each time the register is written with new data.
-     * Hence HASH_DIN and the FIFO form a seventeen 32-bit words length FIFO. */
-    #undef  STM32_HASH_BUFFER_SIZE
-    #define STM32_HASH_BUFFER_SIZE 17
-
-    #undef  STM32_HASH_FIFO_WORKAROUND
-    #define STM32_HASH_FIFO_WORKAROUND
-#endif
-
-#ifndef STM32_HASH_BUFFER_SIZE
-#define STM32_HASH_BUFFER_SIZE STM32_HASH_FIFO_SIZE
-#endif
-
-
 /* STM32 Hash Context */
 typedef struct {
     /* Context switching registers */
@@ -100,13 +80,11 @@ typedef struct {
     uint32_t HASH_CSR[HASH_CR_SIZE];
 
     /* Hash state / buffers */
-    word32 buffer[STM32_HASH_BUFFER_SIZE]; /* partial word buffer */
+    word32 buffer[STM32_HASH_FIFO_SIZE+1]; /* partial word buffer */
     word32 buffLen; /* partial word remain */
     word32 loLen;   /* total update bytes
                  (only lsb 6-bits is used for nbr valid bytes in last word) */
-#ifdef STM32_HASH_FIFO_WORKAROUND
-    int    fifoBytes; /* number of currently filled FIFO bytes */
-#endif
+    word32 fifoBytes; /* number of currently filled FIFO bytes */
 } STM32_HASH_Context;
 
 

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -779,6 +779,7 @@ int  fp_sqr_comba64(fp_int *a, fp_int *b);
 #define MP_VAL  FP_VAL  /* invalid */
 #define MP_MEM  FP_MEM  /* memory error */
 #define MP_NOT_INF FP_NOT_INF /* point not at infinity */
+#define MP_RANGE FP_NOT_INF
 #define MP_OKAY FP_OKAY /* ok result    */
 #define MP_NO   FP_NO   /* yes/no result */
 #define MP_YES  FP_YES  /* yes/no result */


### PR DESCRIPTION
# Description

* Fix to resolve STM32 hash FIFO. Simplify logic for ensuring FIFO gets filled before doing a save/restore.
* Add support for STM32U5A9xx board. 
* Fix for building example with fast math (TFM) and CMSIS OS 2.

Fixes  ZD 18294

# Testing

Tested with STM32U5A9NJ-DK and STM32CubeIDE.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
