### PR TITLE
fix for casting with add

### DIFF
--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -594,7 +594,7 @@ static WC_INLINE void array_add(byte* d, word32 dLen, const byte* s, word32 sLen
 
         dIdx = (int)dLen - 1;
         for (sIdx = (int)sLen - 1; sIdx >= 0; sIdx--) {
-            carry += (word16)(d[dIdx] + s[sIdx]);
+            carry += (word16)d[dIdx] + (word16)s[sIdx];
             d[dIdx] = (byte)carry;
             carry >>= 8;
             dIdx--;


### PR DESCRIPTION
The compiler for PIC18F treated this as adding two byte types (throwing out the overflow) and then casting it to a word16 type. i.e 0xFF + 0x01 = 0x00 (where 0x100 gets thrown out) and then casted 0x00 to word16 type. Casting each to word16 first and then adding avoids this.