### PR TITLE
Fix for using sprintf in test.h

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -3345,21 +3345,22 @@ int wolfSSL_BIO_dump(WOLFSSL_BIO *bio, const char *buf, int length)
             return wolfSSL_BIO_write(bio, "\tNULL", 5);
         }
 
-        XSPRINTF(line, "%04x - ", lineOffset);
+        (void)XSNPRINTF(line, sizeof(line), "%04x - ", lineOffset);
         o = 7;
         for (i = 0; i < BIO_DUMP_LINE_LEN; i++) {
             if (i < length)
-                XSPRINTF(line + o,"%02x ", (unsigned char)buf[i]);
+                (void)XSNPRINTF(line + o, (int)sizeof(line) - o,
+                    "%02x ", (unsigned char)buf[i]);
             else
-                XSPRINTF(line + o, "   ");
+                (void)XSNPRINTF(line + o, (int)sizeof(line) - o, "   ");
             if (i == 7)
-                XSPRINTF(line + o + 2, "-");
+                (void)XSNPRINTF(line + o + 2, (int)sizeof(line) - (o + 2), "-");
             o += 3;
         }
-        XSPRINTF(line + o, "  ");
+        (void)XSNPRINTF(line + o, (int)sizeof(line) - o, "  ");
         o += 2;
         for (i = 0; (i < BIO_DUMP_LINE_LEN) && (i < length); i++) {
-            XSPRINTF(line + o, "%c",
+            (void)XSNPRINTF(line + o, (int)sizeof(line) - o, "%c",
                      ((31 < buf[i]) && (buf[i] < 127)) ? buf[i] : '.');
             o++;
         }

--- a/tests/api.c
+++ b/tests/api.c
@@ -58278,7 +58278,7 @@ static int test_wolfSSL_BIO_connect(void)
     server_args.signal = &ready;
     start_thread(test_server_nofail, &server_args, &serverThread);
     wait_tcp_ready(&server_args);
-    ExpectIntGT(XSPRINTF(buff, "%d", ready.port), 0);
+    ExpectIntGT(XSNPRINTF(buff, sizeof(buff), "%d", ready.port), 0);
 
     /* Start the test proper */
     /* Setup the TCP BIO */
@@ -58325,7 +58325,7 @@ static int test_wolfSSL_BIO_connect(void)
     server_args.signal = &ready;
     start_thread(test_server_nofail, &server_args, &serverThread);
     wait_tcp_ready(&server_args);
-    ExpectIntGT(XSPRINTF(buff, "%d", ready.port), 0);
+    ExpectIntGT(XSNPRINTF(buff, sizeof(buff), "%d", ready.port), 0);
 
     ExpectNotNull(sslBio = BIO_new_ssl_connect(ctx));
     ExpectIntEQ(BIO_set_conn_hostname(sslBio, (char*)wolfSSLIP), 1);

--- a/tests/quic.c
+++ b/tests/quic.c
@@ -848,7 +848,7 @@ static void check_crypto_records(QuicTestContext *from, OutputBuffer *out, int i
                 rec_name = "Finished";
                 break;
             default:
-                sprintf(lbuffer, "%d", rec_type);
+                (void)XSNPRINTF(lbuffer, sizeof(lbuffer), "%d", rec_type);
                 rec_name = lbuffer;
                 break;
         }

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -300,7 +300,7 @@ static int test_crl_monitor(void)
 
     printf("\nRunning CRL monitor test\n");
 
-    sprintf(rounds, "%d", CRL_MONITOR_TEST_ROUNDS);
+    (void)XSNPRINTF(rounds, sizeof(rounds), "%d", CRL_MONITOR_TEST_ROUNDS);
 
     XMEMSET(&server_args, 0, sizeof(func_args));
     XMEMSET(&client_args, 0, sizeof(func_args));
@@ -320,18 +320,19 @@ static int test_crl_monitor(void)
     InitTcpReady(&ready);
     start_thread(server_test, &server_args, &serverThread);
     wait_tcp_ready(&server_args);
-    sprintf(portNum, "%d", server_args.signal->port);
+    (void)XSNPRINTF(portNum, sizeof(portNum), "%d", server_args.signal->port);
 
     for (i = 0; i < CRL_MONITOR_TEST_ROUNDS; i++) {
         int expectFail;
         if (i % 2 == 0) {
+
             /* succeed on even rounds */
-            sprintf(buf, "%s/%s", tmpDir, "crl.pem");
+            (void)XSNPRINTF(buf, sizeof(buf), "%s/%s", tmpDir, "crl.pem");
             if (STAGE_FILE("certs/crl/crl.pem", buf) != 0) {
                 fprintf(stderr, "[%d] Failed to copy file to %s\n", i, buf);
                 goto cleanup;
             }
-            sprintf(buf, "%s/%s", tmpDir, "crl.revoked");
+            (void)XSNPRINTF(buf, sizeof(buf), "%s/%s", tmpDir, "crl.revoked");
             /* The monitor can be holding the file handle and this will cause
              * the remove call to fail. Let's give the monitor a some time to
              * finish up. */
@@ -349,12 +350,12 @@ static int test_crl_monitor(void)
         }
         else {
             /* fail on odd rounds */
-            sprintf(buf, "%s/%s", tmpDir, "crl.revoked");
+            (void)XSNPRINTF(buf, sizeof(buf), "%s/%s", tmpDir, "crl.revoked");
             if (STAGE_FILE("certs/crl/crl.revoked", buf) != 0) {
                 fprintf(stderr, "[%d] Failed to copy file to %s\n", i, buf);
                 goto cleanup;
             }
-            sprintf(buf, "%s/%s", tmpDir, "crl.pem");
+            (void)XSNPRINTF(buf, sizeof(buf), "%s/%s", tmpDir, "crl.pem");
             /* The monitor can be holding the file handle and this will cause
              * the remove call to fail. Let's give the monitor a some time to
              * finish up. */
@@ -395,9 +396,9 @@ static int test_crl_monitor(void)
 cleanup:
     if (ret != 0 && i >= 0)
         fprintf(stderr, "test_crl_monitor failed on iteration %d\n", i);
-    sprintf(buf, "%s/%s", tmpDir, "crl.pem");
+    (void)XSNPRINTF(buf, sizeof(buf), "%s/%s", tmpDir, "crl.pem");
     rem_file(buf);
-    sprintf(buf, "%s/%s", tmpDir, "crl.revoked");
+    (void)XSNPRINTF(buf, sizeof(buf), "%s/%s", tmpDir, "crl.revoked");
     rem_file(buf);
     (void)rem_dir(tmpDir);
     return ret;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -15071,19 +15071,13 @@ int GetFormattedTime(void* currTime, byte* buf, word32 len)
         hour = ts->tm_hour;
         mini = ts->tm_min;
         sec  = ts->tm_sec;
-    #if defined(WOLF_C89)
         if (len < ASN_UTC_TIME_SIZE) {
             WOLFSSL_MSG("buffer for GetFormattedTime is too short.");
             return BUFFER_E;
         }
-        ret = XSPRINTF((char*)buf,
-                        "%02d%02d%02d%02d%02d%02dZ", year, mon, day,
-                        hour, mini, sec);
-    #else
         ret = XSNPRINTF((char*)buf, len,
                         "%02d%02d%02d%02d%02d%02dZ", year, mon, day,
                         hour, mini, sec);
-    #endif
     }
     else {
         /* GeneralizedTime */
@@ -15093,19 +15087,13 @@ int GetFormattedTime(void* currTime, byte* buf, word32 len)
         hour = ts->tm_hour;
         mini = ts->tm_min;
         sec  = ts->tm_sec;
-    #if defined(WOLF_C89)
         if (len < ASN_GENERALIZED_TIME_SIZE) {
             WOLFSSL_MSG("buffer for GetFormattedTime is too short.");
             return BUFFER_E;
         }
-        ret = XSPRINTF((char*)buf,
-                        "%4d%02d%02d%02d%02d%02dZ", year, mon, day,
-                        hour, mini, sec);
-    #else
         ret = XSNPRINTF((char*)buf, len,
                         "%4d%02d%02d%02d%02d%02dZ", year, mon, day,
                         hour, mini, sec);
-    #endif
     }
 
     return ret;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -49806,11 +49806,7 @@ static wc_test_ret_t pkcs7signed_run_vectors(
         #endif
 
             for (j = 0, k = 2; j < (int)sizeof(digest); j++, k += 2) {
-                #if defined(WOLF_C89)
-                    XSPRINTF((char*)&transId[k], "%02x", digest[j]);
-                #else
-                    (void)XSNPRINTF((char*)&transId[k], 3, "%02x", digest[j]);
-                #endif
+                (void)XSNPRINTF((char*)&transId[k], 3, "%02x", digest[j]);
             }
         }
 

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1099,10 +1099,11 @@ static WC_INLINE void ShowX509Ex(WOLFSSL_X509* x509, const char* hdr,
         char serialMsg[80];
 
         /* testsuite has multiple threads writing to stdout, get output
-           message ready to write once */
-        strLen = sprintf(serialMsg, " %s", words[3]);
+         * message ready to write once */
+        strLen = XSNPRINTF(serialMsg, sizeof(serialMsg), " %s", words[3]);
         for (i = 0; i < sz; i++)
-            sprintf(serialMsg + strLen + (i*3), ":%02x ", serial[i]);
+            strLen = XSNPRINTF(serialMsg + strLen, sizeof(serialMsg) - strLen,
+                ":%02x ", serial[i]);
         printf("%s\n", serialMsg);
     }
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -831,6 +831,8 @@ typedef struct w64wrapper {
             #elif defined(WOLF_C89)
                 #include <stdio.h>
                 #define XSPRINTF sprintf
+                /* snprintf not available for C89, so remap using macro */
+                #define XSNPRINTF(f, len, ...) sprintf(f, ...)
             #else
                 #include <stdio.h>
                 #define XSNPRINTF snprintf


### PR DESCRIPTION
# Description

Fix for using sprintf in test.h

Resolves warning: 

```
./configure CC="gcc -fsanitize=address" && make
In file included from ./wolfclu/clu_header_main.h:71:
/usr/local/include/wolfssl/test.h:1103:18: error: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations]
        strLen = sprintf(serialMsg, " %s", words[3]);
                 ^
```

# Testing

wolfSSL: `./configure --enable-wolfclu --enable-crl --enable-dsa && make && sudo make install`
wolfCLU: `./configure CC="gcc -fsanitize=address" && make`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
