### PR TITLE
Update PlatformIO examples to wolfssl 5.7.2

### DIFF
--- a/IDE/PlatformIO/examples/wolfssl_benchmark/platformio.ini
+++ b/IDE/PlatformIO/examples/wolfssl_benchmark/platformio.ini
@@ -17,4 +17,4 @@ monitor_port = COM19
 monitor_speed = 115200
 build_flags = -DWOLFSSL_USER_SETTINGS, -DWOLFSSL_ESP32
 monitor_filters = direct
-lib_deps = wolfssl/wolfSSL@^5.7.0-rev.3b
+lib_deps = wolfssl/wolfSSL@^5.7.2

--- a/IDE/PlatformIO/examples/wolfssl_test/platformio.ini
+++ b/IDE/PlatformIO/examples/wolfssl_test/platformio.ini
@@ -39,4 +39,4 @@ monitor_port = COM19
 monitor_speed = 115200
 build_flags = -DWOLFSSL_USER_SETTINGS, -DWOLFSSL_ESP32
 monitor_filters = direct
-lib_deps = wolfssl/wolfssl@^5.7.0-rev.3d
+lib_deps = wolfssl/wolfssl@^5.7.2


### PR DESCRIPTION
# Description

Updates the example PlatformIO apps `platformio.ini` files to use the recent wolfSSL 5.7.2 release  published today to:

https://registry.platformio.org/libraries/wolfssl/wolfssl

Fixes zd# n/a

# Testing

How did you test?

Tested in PlatformIO on Espressif only

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
