### PR TITLE
20240725-array_add-Wconversion

### DIFF
--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -594,7 +594,7 @@ static WC_INLINE void array_add(byte* d, word32 dLen, const byte* s, word32 sLen
 
         dIdx = (int)dLen - 1;
         for (sIdx = (int)sLen - 1; sIdx >= 0; sIdx--) {
-            carry += (word16)d[dIdx] + (word16)s[sIdx];
+            carry += (word16)((word16)d[dIdx] + (word16)s[sIdx]);
             d[dIdx] = (byte)carry;
             carry >>= 8;
             dIdx--;


### PR DESCRIPTION
`wolfcrypt/src/random.c`: restore outer cast in `array_add()` to avoid `-Wconversion` added in b28e22aef0, itself a fix for a defect added in ed11669f3c (root cause of warning is implicit type promotion).

tested with `wolfssl-multi-test.sh ... allcryptonly-Wconversion-intelasm-build cross-amd64-mingw-all-crypto-Wconversion`
