### PR TITLE
Init SoftHSMv2 support

### DIFF
--- a/.github/workflows/softhsm.yml
+++ b/.github/workflows/softhsm.yml
@@ -1,0 +1,94 @@
+name: SoftHSMv2 Tests
+
+# START OF COMMON SECTION
+on:
+  push:
+    branches: [ 'master', 'main', 'release/**' ]
+  pull_request:
+    branches: [ '*' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+# END OF COMMON SECTION
+
+jobs:
+  build_wolfssl:
+    name: Build wolfSSL
+    if: github.repository_owner == 'wolfssl'
+    # Just to keep it the same as the testing target
+    runs-on: ubuntu-latest
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 10
+    steps:
+      - name: Build wolfSSL
+        uses: wolfSSL/actions-build-autotools-project@v1
+        with:
+          path: wolfssl
+          configure: --enable-all CFLAGS=-DRSA_MIN_SIZE=1024
+          install: true
+          check: false
+
+      - name: tar build-dir
+        run: tar -zcf build-dir.tgz build-dir
+
+      - name: Upload built lib
+        uses: actions/upload-artifact@v4
+        with:
+          name: wolf-install-softhsm
+          path: build-dir.tgz
+          retention-days: 5
+
+  softhsm_check:
+    strategy:
+      fail-fast: false
+      matrix:
+        # List of releases to test
+        ref: [ 2.6.1 ]
+    name: ${{ matrix.ref }}
+    if: github.repository_owner == 'wolfssl'
+    runs-on: ubuntu-latest
+    # This should be a safe limit for the tests to run.
+    timeout-minutes: 20
+    needs: build_wolfssl
+    steps:
+      - name: Install dependencies
+        run: |
+          # Don't prompt for anything
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          sudo apt-get install -y libcppunit-dev
+
+      - name: Download lib
+        uses: actions/download-artifact@v4
+        with:
+          name: wolf-install-softhsm
+
+      - name: untar build-dir
+        run: tar -xf build-dir.tgz
+
+      - name: Checkout OSP
+        uses: actions/checkout@v4
+        with:
+          repository: wolfssl/osp
+          path: osp
+
+      - name: Checkout SoftHSMv2
+        uses: actions/checkout@v4
+        with:
+          repository: opendnssec/SoftHSMv2
+          path: softhsm
+          ref: ${{ matrix.ref }}
+
+      # Not using wolfSSL/actions-build-autotools-project@v1 because autogen.sh doesn't work
+      - name: Build softhsm
+        working-directory: softhsm
+        run: |
+          patch -p1 < $GITHUB_WORKSPACE/osp/softhsm/${{ matrix.ref }}.patch
+          autoreconf -if
+          ./configure --with-crypto-backend=wolfssl WOLFSSL_INSTALL_DIR=$GITHUB_WORKSPACE/build-dir
+          make -j
+
+      - name: Test softhsm
+        working-directory: softhsm
+        run: make -j check

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -7175,6 +7175,15 @@ int ToTraditionalInline_ex2(const byte* input, word32* inOutIdx, word32 sz,
                 }
                 break;
         #endif
+        #ifndef NO_DH
+            case DHk:
+                /* Neither NULL item nor OBJECT_ID item allowed. */
+                if ((dataASN[PKCS8KEYASN_IDX_PKEY_ALGO_NULL].tag != 0) ||
+                    (dataASN[PKCS8KEYASN_IDX_PKEY_ALGO_OID_CURVE].tag != 0)) {
+                    ret = ASN_PARSE_E;
+                }
+                break;
+        #endif
             /* DSAk not supported. */
             /* Falcon, Dilithium and Sphincs not supported. */
             /* Ignore OID lookup failures. */

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4262,7 +4262,7 @@ int wc_ecc_get_curve_idx(int curve_id)
 
 int wc_ecc_get_curve_id(int curve_idx)
 {
-    if (wc_ecc_is_valid_idx(curve_idx)) {
+    if (wc_ecc_is_valid_idx(curve_idx) && curve_idx >= 0) {
         return ecc_sets[curve_idx].id;
     }
     return ECC_CURVE_INVALID;

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -9051,7 +9051,7 @@ int wolfSSL_EVP_PKEY_set1_DH(WOLFSSL_EVP_PKEY *pkey, WOLFSSL_DH *key)
     /* Get size of DER buffer only */
     if (havePublic && !havePrivate) {
         ret = wc_DhPubKeyToDer(dhkey, NULL, &derSz);
-    } else if (havePrivate && !havePublic) {
+    } else if (havePrivate) {
         ret = wc_DhPrivKeyToDer(dhkey, NULL, &derSz);
     } else {
         ret = wc_DhParamsToDer(dhkey,NULL,&derSz);
@@ -9071,7 +9071,7 @@ int wolfSSL_EVP_PKEY_set1_DH(WOLFSSL_EVP_PKEY *pkey, WOLFSSL_DH *key)
     /* Fill DER buffer */
     if (havePublic && !havePrivate) {
         ret = wc_DhPubKeyToDer(dhkey, derBuf, &derSz);
-    } else if (havePrivate && !havePublic) {
+    } else if (havePrivate) {
         ret = wc_DhPrivKeyToDer(dhkey, derBuf, &derSz);
     } else {
         ret = wc_DhParamsToDer(dhkey,derBuf,&derSz);
@@ -9770,7 +9770,12 @@ WOLFSSL_EVP_PKEY* wolfSSL_EVP_PKCS82PKEY(const WOLFSSL_PKCS8_PRIV_KEY_INFO* p8)
 /* this function just casts and returns pointer */
 WOLFSSL_PKCS8_PRIV_KEY_INFO* wolfSSL_EVP_PKEY2PKCS8(const WOLFSSL_EVP_PKEY* pkey)
 {
-    return (WOLFSSL_PKCS8_PRIV_KEY_INFO*)pkey;
+    if (pkey == NULL || pkey->pkey.ptr == NULL) {
+        return NULL;
+    }
+
+    return wolfSSL_d2i_PrivateKey_EVP(NULL, (unsigned char**)&pkey->pkey.ptr,
+        pkey->pkey_sz);
 }
 #endif
 

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -5128,6 +5128,12 @@ static void _sp_mont_setup(const sp_int* m, sp_int_digit* rho);
 #define WOLFSSL_SP_PRIME_GEN
 #endif
 
+#if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
+    (defined(WOLFSSL_KEY_GEN) && !defined(NO_RSA)) || defined(OPENSSL_EXTRA)
+/* Determine when mp_mul_d is required */
+#define WOLFSSL_SP_MUL_D
+#endif
+
 /* Set the multi-precision number to zero.
  *
  * Assumes a is not NULL.
@@ -6553,7 +6559,8 @@ int sp_sub_d(const sp_int* a, sp_int_digit d, sp_int* r)
     !defined(NO_DH) || defined(HAVE_ECC) || \
     (!defined(NO_RSA) && !defined(WOLFSSL_RSA_VERIFY_ONLY) && \
      !defined(WOLFSSL_RSA_PUBLIC_ONLY))) || \
-    (defined(WOLFSSL_KEY_GEN) && !defined(NO_RSA))
+    (defined(WOLFSSL_KEY_GEN) && !defined(NO_RSA)) || \
+    defined(WOLFSSL_SP_MUL_D)
 /* Multiply a by digit n and put result into r shifting up o digits.
  *   r = (a * n) << (o * SP_WORD_SIZE)
  *
@@ -6636,8 +6643,7 @@ static int _sp_mul_d(const sp_int* a, sp_int_digit d, sp_int* r, unsigned int o)
 #endif /* (WOLFSSL_SP_MATH_ALL && !WOLFSSL_RSA_VERIFY_ONLY) ||
         *  WOLFSSL_SP_SMALL || (WOLFSSL_KEY_GEN && !NO_RSA) */
 
-#if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
-    (defined(WOLFSSL_KEY_GEN) && !defined(NO_RSA))
+#ifdef WOLFSSL_SP_MUL_D
 /* Multiply a by digit n and put result into r. r = a * n
  *
  * @param  [in]   a  SP integer to multiply.
@@ -6675,8 +6681,7 @@ int sp_mul_d(const sp_int* a, sp_int_digit d, sp_int* r)
 
     return err;
 }
-#endif /* (WOLFSSL_SP_MATH_ALL && !WOLFSSL_RSA_VERIFY_ONLY) ||
-        * (WOLFSSL_KEY_GEN && !NO_RSA) */
+#endif /* WOLFSSL_SP_MUL_D */
 
 /* Predefine complicated rules of when to compile in sp_div_d and sp_mod_d. */
 #if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -7114,6 +7114,12 @@ WOLFSSL_LOCAL int wolfssl_asn1_obj_set(WOLFSSL_ASN1_OBJECT* obj,
         const byte* der, word32 len, int addHdr);
 #endif
 
+WOLFSSL_LOCAL int pkcs8_encode(WOLFSSL_EVP_PKEY* pkey, byte* key,
+        word32* keySz);
+WOLFSSL_LOCAL int pkcs8_encrypt(WOLFSSL_EVP_PKEY* pkey,
+        const WOLFSSL_EVP_CIPHER* enc, char* passwd, int passwdSz, byte* key,
+        word32* keySz);
+
 #ifdef __cplusplus
     }  /* extern "C" */
 #endif

--- a/wolfssl/openssl/bn.h
+++ b/wolfssl/openssl/bn.h
@@ -150,6 +150,7 @@ WOLFSSL_API int wolfSSL_BN_lshift(WOLFSSL_BIGNUM* r, const WOLFSSL_BIGNUM* bn,
                                   int n);
 WOLFSSL_API int wolfSSL_BN_add_word(WOLFSSL_BIGNUM* bn, WOLFSSL_BN_ULONG w);
 WOLFSSL_API int wolfSSL_BN_sub_word(WOLFSSL_BIGNUM* bn, WOLFSSL_BN_ULONG w);
+WOLFSSL_API int wolfSSL_BN_mul_word(WOLFSSL_BIGNUM *bn, WOLFSSL_BN_ULONG w);
 WOLFSSL_API int wolfSSL_BN_set_bit(WOLFSSL_BIGNUM* bn, int n);
 WOLFSSL_API int wolfSSL_BN_clear_bit(WOLFSSL_BIGNUM* bn, int n);
 WOLFSSL_API int wolfSSL_BN_set_word(WOLFSSL_BIGNUM* bn, WOLFSSL_BN_ULONG w);
@@ -254,6 +255,7 @@ typedef WOLFSSL_BN_GENCB BN_GENCB;
 
 #define BN_lshift wolfSSL_BN_lshift
 #define BN_add_word wolfSSL_BN_add_word
+#define BN_mul_word wolfSSL_BN_mul_word
 #define BN_sub_word wolfSSL_BN_sub_word
 #define BN_add wolfSSL_BN_add
 #define BN_mod_add wolfSSL_BN_mod_add

--- a/wolfssl/openssl/dh.h
+++ b/wolfssl/openssl/dh.h
@@ -26,6 +26,7 @@
 #define WOLFSSL_DH_H_
 
 #include <wolfssl/openssl/bn.h>
+#include <wolfssl/openssl/ssl.h>
 #include <wolfssl/openssl/opensslv.h>
 
 #ifdef __cplusplus
@@ -101,6 +102,8 @@ typedef WOLFSSL_DH                   DH;
 #define DH_get0_key     wolfSSL_DH_get0_key
 #define DH_set0_key     wolfSSL_DH_set0_key
 #define DH_bits(x)      (BN_num_bits((x)->p))
+
+#define OPENSSL_DH_MAX_MODULUS_BITS     DH_MAX_SIZE
 
 #define DH_GENERATOR_2                  2
 #define DH_CHECK_P_NOT_PRIME            0x01

--- a/wolfssl/openssl/dsa.h
+++ b/wolfssl/openssl/dsa.h
@@ -26,6 +26,7 @@
 #define WOLFSSL_DSA_H_
 
 #include <wolfssl/openssl/bn.h>
+#include <wolfssl/openssl/compat_types.h>
 
 #ifdef __cplusplus
     extern "C" {
@@ -118,6 +119,8 @@ WOLFSSL_API WOLFSSL_DSA* wolfSSL_d2i_DSAparams(
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 
 typedef WOLFSSL_DSA                   DSA;
+
+#define OPENSSL_DSA_MAX_MODULUS_BITS 3072
 
 #define WOLFSSL_DSA_LOAD_PRIVATE 1
 #define WOLFSSL_DSA_LOAD_PUBLIC  2

--- a/wolfssl/openssl/ec.h
+++ b/wolfssl/openssl/ec.h
@@ -25,6 +25,7 @@
 #define WOLFSSL_EC_H_
 
 #include <wolfssl/wolfcrypt/types.h>
+#include <wolfssl/openssl/compat_types.h>
 #include <wolfssl/openssl/bn.h>
 #include <wolfssl/openssl/compat_types.h>
 #include <wolfssl/wolfcrypt/asn.h>
@@ -431,6 +432,7 @@ typedef WOLFSSL_EC_KEY_METHOD         EC_KEY_METHOD;
 #define EC_KEY_set_conv_form            wolfSSL_EC_KEY_set_conv_form
 #define EC_KEY_get_conv_form            wolfSSL_EC_KEY_get_conv_form
 #define d2i_ECPKParameters              wolfSSL_d2i_ECPKParameters
+#define i2d_ECPKParameters              wolfSSL_i2d_ECPKParameters
 
 #define EC_POINT_point2hex              wolfSSL_EC_POINT_point2hex
 #define EC_POINT_hex2point              wolfSSL_EC_POINT_hex2point

--- a/wolfssl/openssl/pem.h
+++ b/wolfssl/openssl/pem.h
@@ -69,6 +69,8 @@ WOLFSSL_EC_GROUP *wolfSSL_d2i_ECPKParameters(WOLFSSL_EC_GROUP **out,
                                              const unsigned char **in,
                                              long len);
 WOLFSSL_API
+int wolfSSL_i2d_ECPKParameters(const WOLFSSL_EC_GROUP* grp, unsigned char** pp);
+WOLFSSL_API
 int wolfSSL_PEM_write_mem_RSAPrivateKey(WOLFSSL_RSA* rsa,
                                         const WOLFSSL_EVP_CIPHER* cipher,
                                         unsigned char* passwd, int len,
@@ -179,6 +181,11 @@ WOLFSSL_EVP_PKEY* wolfSSL_PEM_read_bio_PrivateKey(WOLFSSL_BIO* bio,
                                                   WOLFSSL_EVP_PKEY** key,
                                                   wc_pem_password_cb* cb,
                                                   void* pass);
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+WOLFSSL_API
+PKCS8_PRIV_KEY_INFO* wolfSSL_PEM_read_bio_PKCS8_PRIV_KEY_INFO(WOLFSSL_BIO* bio,
+        PKCS8_PRIV_KEY_INFO** key, wc_pem_password_cb* cb, void* arg);
+#endif
 WOLFSSL_API
 WOLFSSL_EVP_PKEY *wolfSSL_PEM_read_bio_PUBKEY(WOLFSSL_BIO* bio,
                                               WOLFSSL_EVP_PKEY **key,
@@ -278,6 +285,9 @@ int wolfSSL_PEM_write_DHparams(XFILE fp, WOLFSSL_DH* dh);
 #define PEM_read_PUBKEY                 wolfSSL_PEM_read_PUBKEY
 #define PEM_read_bio_PUBKEY             wolfSSL_PEM_read_bio_PUBKEY
 #define PEM_write_bio_PUBKEY            wolfSSL_PEM_write_bio_PUBKEY
+
+#define PEM_write_bio_PKCS8_PRIV_KEY_INFO wolfSSL_PEM_write_bio_PKCS8_PRIV_KEY_INFO
+#define PEM_read_bio_PKCS8_PRIV_KEY_INFO wolfSSL_PEM_read_bio_PKCS8_PRIV_KEY_INFO
 
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/wolfssl/openssl/rsa.h
+++ b/wolfssl/openssl/rsa.h
@@ -27,6 +27,7 @@
 
 #include <wolfssl/openssl/bn.h>
 #include <wolfssl/openssl/err.h>
+#include <wolfssl/openssl/compat_types.h>
 #include <wolfssl/wolfcrypt/types.h>
 #include <wolfssl/wolfcrypt/rsa.h>
 
@@ -190,6 +191,8 @@ WOLFSSL_API int wolfSSL_RSA_set_ex_data_with_cleanup(
 #endif
 
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+#define OPENSSL_RSA_MAX_MODULUS_BITS RSA_MAX_SIZE
+
 #define WOLFSSL_RSA_LOAD_PRIVATE 1
 #define WOLFSSL_RSA_LOAD_PUBLIC  2
 #define WOLFSSL_RSA_F4           0x10001L

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -207,7 +207,7 @@ typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS;
 #define SSL_use_certificate_ASN1        wolfSSL_use_certificate_ASN1
 #define d2i_PKCS8_PRIV_KEY_INFO_bio     wolfSSL_d2i_PKCS8_PKEY_bio
 #define d2i_PKCS8_PRIV_KEY_INFO         wolfSSL_d2i_PKCS8_PKEY
-#define i2d_PKCS8_PRIV_KEY_INFO         wolfSSL_i2d_PrivateKey
+#define i2d_PKCS8_PRIV_KEY_INFO         wolfSSL_i2d_PKCS8_PKEY
 #define d2i_PKCS8PrivateKey_bio         wolfSSL_d2i_PKCS8PrivateKey_bio
 #define i2d_PKCS8PrivateKey_bio         wolfSSL_PEM_write_bio_PKCS8PrivateKey
 #define PKCS8_PRIV_KEY_INFO_free        wolfSSL_EVP_PKEY_free
@@ -1009,7 +1009,9 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #define RSA_print_fp                    wolfSSL_RSA_print_fp
 #define RSA_bits                        wolfSSL_RSA_bits
 #define RSA_up_ref                      wolfSSL_RSA_up_ref
+#define RSA_padding_add_PKCS1_PSS_mgf1  wolfSSL_RSA_padding_add_PKCS1_PSS_mgf1
 #define RSA_padding_add_PKCS1_PSS       wolfSSL_RSA_padding_add_PKCS1_PSS
+#define RSA_verify_PKCS1_PSS_mgf1       wolfSSL_RSA_verify_PKCS1_PSS_mgf1
 #define RSA_verify_PKCS1_PSS            wolfSSL_RSA_verify_PKCS1_PSS
 
 #define PEM_def_callback                wolfSSL_PEM_def_callback

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1269,11 +1269,18 @@ WOLFSSL_API int  wolfSSL_SetServerID(WOLFSSL* ssl, const unsigned char* id, int 
 WOLFSSL_API int  wolfSSL_BIO_new_bio_pair(WOLFSSL_BIO** bio1_p, size_t writebuf1,
                      WOLFSSL_BIO** bio2_p, size_t writebuf2);
 
+WOLFSSL_API int wolfSSL_RSA_padding_add_PKCS1_PSS_mgf1(WOLFSSL_RSA *rsa,
+        unsigned char *em, const unsigned char *mHash,
+        const WOLFSSL_EVP_MD *hashAlg, const WOLFSSL_EVP_MD *mgf1Hash,
+        int saltLen);
 WOLFSSL_API int wolfSSL_RSA_padding_add_PKCS1_PSS(WOLFSSL_RSA *rsa,
                                                   unsigned char *EM,
                                                   const unsigned char *mHash,
                                                   const WOLFSSL_EVP_MD *hashAlg,
                                                   int saltLen);
+WOLFSSL_API int wolfSSL_RSA_verify_PKCS1_PSS_mgf1(WOLFSSL_RSA *rsa,
+        const unsigned char *mHash, const WOLFSSL_EVP_MD *hashAlg,
+        const WOLFSSL_EVP_MD *mgf1Hash, const unsigned char *em, int saltLen);
 WOLFSSL_API int wolfSSL_RSA_verify_PKCS1_PSS(WOLFSSL_RSA *rsa, const unsigned char *mHash,
                                           const WOLFSSL_EVP_MD *hashAlg,
                                           const unsigned char *EM, int saltLen);
@@ -2088,6 +2095,8 @@ WOLFSSL_API WOLFSSL_PKCS8_PRIV_KEY_INFO* wolfSSL_d2i_PKCS8_PKEY_bio(
         WOLFSSL_BIO* bio, WOLFSSL_PKCS8_PRIV_KEY_INFO** pkey);
 WOLFSSL_API WOLFSSL_PKCS8_PRIV_KEY_INFO* wolfSSL_d2i_PKCS8_PKEY(
         WOLFSSL_PKCS8_PRIV_KEY_INFO** pkey, const unsigned char** keyBuf, long keyLen);
+WOLFSSL_API int wolfSSL_i2d_PKCS8_PKEY(WOLFSSL_PKCS8_PRIV_KEY_INFO* key,
+        unsigned char** pp);
 WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_d2i_PUBKEY_bio(WOLFSSL_BIO* bio,
                                          WOLFSSL_EVP_PKEY** out);
 WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_d2i_PUBKEY(WOLFSSL_EVP_PKEY** key,
@@ -5382,6 +5391,8 @@ WOLFSSL_API int wolfSSL_X509_get_signature_nid(const WOLFSSL_X509* x);
 WOLFSSL_API int wolfSSL_PEM_write_bio_PKCS8PrivateKey(WOLFSSL_BIO* bio,
     WOLFSSL_EVP_PKEY* pkey, const WOLFSSL_EVP_CIPHER* enc, char* passwd,
     int passwdSz, wc_pem_password_cb* cb, void* ctx);
+WOLFSSL_API int wolfSSL_PEM_write_bio_PKCS8_PRIV_KEY_INFO(WOLFSSL_BIO* bio,
+        PKCS8_PRIV_KEY_INFO* keyInfo);
 #if !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)
 WOLFSSL_API int wolfSSL_PEM_write_PKCS8PrivateKey(
     XFILE fp, WOLFSSL_EVP_PKEY* pkey, const WOLFSSL_EVP_CIPHER* enc,

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -951,13 +951,14 @@ enum Misc_ASN {
 #else
     KEYID_SIZE          = WC_SHA_DIGEST_SIZE,
 #endif
-#if !defined(WOLFSSL_RSA_PUBLIC_ONLY) && (defined(WOLFSSL_KEY_GEN) || defined(OPENSSL_EXTRA) || !defined(RSA_LOW_MEM))
-    RSA_INTS            =   8,     /* RSA ints in private key */
-#elif !defined(WOLFSSL_RSA_PUBLIC_ONLY)
-    RSA_INTS            =   5,     /* RSA ints in private key */
-#else
-    RSA_INTS            =   2,     /* RSA ints in private key */
+    RSA_INTS            =   2      /* RSA ints in private key */
+#ifndef WOLFSSL_RSA_PUBLIC_ONLY
+                            + 3
+#if defined(WOLFSSL_KEY_GEN) || defined(OPENSSL_EXTRA) || !defined(RSA_LOW_MEM)
+                            + 3
 #endif
+#endif
+                            ,
     DSA_PARAM_INTS      =   3,     /* DSA parameter ints */
     RSA_PUB_INTS        =   2,     /* RSA ints in public key */
     DSA_PUB_INTS        =   4,     /* DSA ints in public key */


### PR DESCRIPTION
Depends on https://github.com/wolfSSL/wolfssl/pull/7781
- wolfSSL_EVP_PKEY_set1_DH: If both private and public present, output private key
- ToTraditionalInline_ex2: Add DH checking
- wc_ecc_get_curve_id: check index is not negative
- Fix i2d_PKCS8_PRIV_KEY_INFO to actually output pkcs8 instead of just der
- wolfSSL_EVP_PKEY2PKCS8: Create duplicate to avoid double free
- wolfSSL_DH_generate_key: Fix case where not enough buffer was allocated for 128 bit case
- pkcs8_encode: Add DSA and DH support
- wolfSSL_d2i_PKCS8_PKEY: Correctly advance buffer
- Define
  - OPENSSL_DH_MAX_MODULUS_BITS
  - OPENSSL_DSA_MAX_MODULUS_BITS
  - OPENSSL_RSA_MAX_MODULUS_BITS
- Implement
  - BN_mul_word
  - i2d_ECPKParameters
  - PEM_write_bio_PKCS8_PRIV_KEY_INFO
  - PEM_read_bio_PKCS8_PRIV_KEY_INFO
  - i2d_PKCS8_PRIV_KEY_INFO
  - RSA_padding_add_PKCS1_PSS_mgf1
  - RSA_verify_PKCS1_PSS_mgf1