### PR TITLE
ASN macro simplification

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1992,7 +1992,7 @@ AC_ARG_ENABLE([ffmpeg],
     )
 
 
-#IP alternative name Support
+# IP alternative name Support
 AC_ARG_ENABLE([ip-alt-name],
     [AS_HELP_STRING([--enable-ip-alt-name],[Enable IP subject alternative name (default: disabled)])],
     [ ENABLE_IP_ALT_NAME=$enableval ],
@@ -2004,7 +2004,7 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_IP_ALT_NAME"
 fi
 
-#Qt Support
+# QT Support
 AC_ARG_ENABLE([qt],
     [AS_HELP_STRING([--enable-qt],[Enable qt (default: disabled)])],
     [ ENABLED_QT=$enableval ],
@@ -4744,43 +4744,52 @@ fi
 
 
 # ASN
+
 # turn off asn, which means no certs, no rsa, no dsa, no ecc,
 # and no big int (unless dh is on)
+
+# turn off ASN if leanpsk on
+if test "$ENABLED_LEANPSK" = "yes"
+then
+    enable_asn=no
+fi
+
 AC_ARG_ENABLE([asn],
     [AS_HELP_STRING([--enable-asn],[Enable ASN (default: enabled)])],
     [ ENABLED_ASN=$enableval ],
     [ ENABLED_ASN=yes ]
     )
 
-if test "$ENABLED_ASN" = "no"
-then
-    AM_CFLAGS="$AM_CFLAGS -DNO_ASN -DNO_ASN_CRYPT"
-    enable_pwdbased=no
-else
-    if test "$ENABLED_ASN" = "template"; then
-        ENABLED_ASN="yes"
-    fi
-    if test "$ENABLED_ASN" = "yes"; then
+for v in `echo $ENABLED_ASN | tr "," " "`
+do
+    case $v in
+    all)
+        # Enable all ASN features
+        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ASN_ALL"
+        ENABLED_ASN=yes
+        ;;
+    template | yes)
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ASN_TEMPLATE"
-    elif test "$ENABLED_ASN" = "original"; then
+        ENABLED_ASN=yes
+        ;;
+    original)
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ASN_ORIGINAL"
-    else
-        AC_MSG_ERROR([Invalid asn option. Valid are: template or original. Seen: $ENABLED_ASN.])
-    fi
-
-    # turn off ASN if leanpsk on
-    if test "$ENABLED_LEANPSK" = "yes"
-    then
-        AM_CFLAGS="$AM_CFLAGS -DNO_ASN -DNO_BIG_INT"
+        ENABLED_ASN=yes
+        ;;
+    nocrypt)
+        AM_CFLAGS="$AM_CFLAGS -DNO_ASN_CRYPT"
+        enable_pwdbased=no
+        ;;
+    no)
+        AM_CFLAGS="$AM_CFLAGS -DNO_ASN -DNO_ASN_CRYPT"
+        enable_pwdbased=no
         ENABLED_ASN=no
-    else
-        if test "$ENABLED_ASN" = "nocrypt"
-        then
-            AM_CFLAGS="$AM_CFLAGS -DNO_ASN_CRYPT"
-            enable_pwdbased=no
-        fi
-    fi
-fi
+        ;;
+    *)
+        AC_MSG_ERROR([Invalid asn option. Valid are: all, template/yes, original, nocrypt or no. Seen: $ENABLED_ASN.])
+        break;;
+esac
+done
 
 if test "$ENABLED_RSA" = "yes" && test "$ENABLED_RSAVFY" = "no" && \
    test "$ENABLED_ASN" = "no" && test "$ENABLED_LOWRESOURCE" = "no"

--- a/src/internal.c
+++ b/src/internal.c
@@ -12540,13 +12540,13 @@ int CheckForAltNames(DecodedCert* dCert, const char* domain, word32 domainLen,
     while (altName) {
         WOLFSSL_MSG("\tindividual AltName check");
 
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME)
+#ifdef WOLFSSL_IP_ALT_NAME
         if (altName->type == ASN_IP_TYPE) {
             buf = altName->ipString;
             len = (word32)XSTRLEN(buf);
         }
         else
-#endif /* OPENSSL_ALL || WOLFSSL_IP_ALT_NAME */
+#endif /* WOLFSSL_IP_ALT_NAME */
         {
             buf = altName->name;
             len = (word32)altName->len;
@@ -12817,6 +12817,7 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
 int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
 {
     int ret = 0;
+    int minSz;
 
     if (x509 == NULL || dCert == NULL ||
         dCert->subjectCNLen < 0)
@@ -12866,49 +12867,45 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
 #endif /* WOLFSSL_CERT_REQ */
 
 #ifdef WOLFSSL_SEP
-    {
-        int minSz = min(dCert->deviceTypeSz, EXTERNAL_SERIAL_SIZE);
-        if (minSz > 0) {
-            x509->deviceTypeSz = minSz;
-            XMEMCPY(x509->deviceType, dCert->deviceType, minSz);
-        }
-        else
-            x509->deviceTypeSz = 0;
-        minSz = min(dCert->hwTypeSz, EXTERNAL_SERIAL_SIZE);
-        if (minSz > 0) {
-            x509->hwTypeSz = minSz;
-            XMEMCPY(x509->hwType, dCert->hwType, minSz);
-        }
-        else
-            x509->hwTypeSz = 0;
-        minSz = min(dCert->hwSerialNumSz, EXTERNAL_SERIAL_SIZE);
-        if (minSz > 0) {
-            x509->hwSerialNumSz = minSz;
-            XMEMCPY(x509->hwSerialNum, dCert->hwSerialNum, minSz);
-        }
-        else
-            x509->hwSerialNumSz = 0;
+    minSz = min(dCert->deviceTypeSz, EXTERNAL_SERIAL_SIZE);
+    if (minSz > 0) {
+        x509->deviceTypeSz = minSz;
+        XMEMCPY(x509->deviceType, dCert->deviceType, minSz);
     }
+    else
+        x509->deviceTypeSz = 0;
+    minSz = min(dCert->hwTypeSz, EXTERNAL_SERIAL_SIZE);
+    if (minSz > 0) {
+        x509->hwTypeSz = minSz;
+        XMEMCPY(x509->hwType, dCert->hwType, minSz);
+    }
+    else
+        x509->hwTypeSz = 0;
+    minSz = min(dCert->hwSerialNumSz, EXTERNAL_SERIAL_SIZE);
+    if (minSz > 0) {
+        x509->hwSerialNumSz = minSz;
+        XMEMCPY(x509->hwSerialNum, dCert->hwSerialNum, minSz);
+    }
+    else
+        x509->hwSerialNumSz = 0;
 #endif /* WOLFSSL_SEP */
-    {
-        int minSz;
-        if (dCert->beforeDateLen > 0) {
-            minSz = (int)min(dCert->beforeDate[1], MAX_DATE_SZ);
-            x509->notBefore.type = dCert->beforeDate[0];
-            x509->notBefore.length = minSz;
-            XMEMCPY(x509->notBefore.data, &dCert->beforeDate[2], minSz);
-        }
-        else
-            x509->notBefore.length = 0;
-        if (dCert->afterDateLen > 0) {
-            minSz = (int)min(dCert->afterDate[1], MAX_DATE_SZ);
-            x509->notAfter.type = dCert->afterDate[0];
-            x509->notAfter.length = minSz;
-            XMEMCPY(x509->notAfter.data, &dCert->afterDate[2], minSz);
-        }
-        else
-            x509->notAfter.length = 0;
+
+    if (dCert->beforeDateLen > 0) {
+        minSz = (int)min(dCert->beforeDate[1], MAX_DATE_SZ);
+        x509->notBefore.type = dCert->beforeDate[0];
+        x509->notBefore.length = minSz;
+        XMEMCPY(x509->notBefore.data, &dCert->beforeDate[2], minSz);
     }
+    else
+        x509->notBefore.length = 0;
+    if (dCert->afterDateLen > 0) {
+        minSz = (int)min(dCert->afterDate[1], MAX_DATE_SZ);
+        x509->notAfter.type = dCert->afterDate[0];
+        x509->notAfter.length = minSz;
+        XMEMCPY(x509->notAfter.data, &dCert->afterDate[2], minSz);
+    }
+    else
+        x509->notAfter.length = 0;
 
     if (dCert->publicKey != NULL && dCert->pubKeySize != 0) {
         x509->pubKey.buffer = (byte*)XMALLOC(
@@ -13047,7 +13044,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
             ret = MEMORY_E;
         }
     }
-    #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
+    #ifdef WOLFSSL_ASN_CA_ISSUER
     if (dCert->extAuthInfoCaIssuer != NULL && dCert->extAuthInfoCaIssuerSz > 0) {
         x509->authInfoCaIssuer = (byte*)XMALLOC(dCert->extAuthInfoCaIssuerSz, x509->heap,
                 DYNAMIC_TYPE_X509_EXT);
@@ -13133,10 +13130,10 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
     #ifndef IGNORE_NETSCAPE_CERT_TYPE
     x509->nsCertType = dCert->nsCertType;
     #endif
-    #if defined(WOLFSSL_SEP) || defined(WOLFSSL_QT)
+    #ifdef WOLFSSL_SEP
         x509->certPolicySet = dCert->extCertPolicySet;
         x509->certPolicyCrit = dCert->extCertPolicyCrit;
-    #endif /* WOLFSSL_SEP || WOLFSSL_QT */
+    #endif
     #ifdef WOLFSSL_CERT_EXT
         {
             int i;

--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -702,8 +702,10 @@ int wolfSSL_OCSP_resp_find_status(WOLFSSL_OCSP_BASICRESP *bs,
     if (nextupd != NULL)
         *nextupd = &single->status->nextDateParsed;
 #else
-    (void)thisupd;
-    (void)nextupd;
+    if (thisupd != NULL)
+        *thisupd = NULL;
+    if (nextupd != NULL)
+        *nextupd = NULL;
 #endif
 
     /* TODO: Not needed for Nginx or httpd */
@@ -1348,11 +1350,17 @@ int wolfSSL_OCSP_single_get0_status(WOLFSSL_OCSP_SINGLERESP *single,
     if (single == NULL)
         return WOLFSSL_FAILURE;
 
+#ifdef WOLFSSL_OCSP_PARSE_STATUS
     if (thisupd != NULL)
         *thisupd = &single->status->thisDateParsed;
     if (nextupd != NULL)
         *nextupd = &single->status->nextDateParsed;
-
+#else
+    if (thisupd != NULL)
+        *thisupd = NULL;
+    if (nextupd != NULL)
+        *nextupd = NULL;
+#endif
     if (reason != NULL)
         *reason = 0;
     if (revtime != NULL)

--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -284,7 +284,7 @@ static int GetOcspStatus(WOLFSSL_OCSP* ocsp, OcspRequest* request,
  * ocsp           Context object for OCSP status.
  * response       OCSP response message data.
  * responseSz     Length of OCSP response message data.
- * reponseBuffer  Buffer object to return the response with.
+ * responseBuffer Buffer object to return the response with.
  * status         The certificate status object.
  * entry          The OCSP entry for this certificate.
  * ocspRequest    Request corresponding to response.
@@ -880,10 +880,8 @@ int wolfSSL_OCSP_basic_verify(WOLFSSL_OCSP_BASICRESP *bs,
         return WOLFSSL_FAILURE;
 #endif
 
-#ifdef OPENSSL_EXTRA
     if (bs->verifyError != OCSP_VERIFY_ERROR_NONE)
         goto out;
-#endif
 
     if (flags & OCSP_TRUSTOTHER) {
         for (idx = 0; idx < wolfSSL_sk_X509_num(certs); idx++) {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5359,8 +5359,7 @@ int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify)
 
     InitDecodedCert(cert, der->buffer, der->length, cm->heap);
 
-#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) && \
-    defined(HAVE_OID_DECODING)
+#ifdef WC_ASN_UNKNOWN_EXT_CB
     if (cm->unknownExtCallback != NULL) {
         wc_SetUnknownExtCallback(cert, cm->unknownExtCallback);
     }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -22731,7 +22731,7 @@ void wolfSSL_ERR_remove_state(unsigned long id)
     }
 }
 
-#endif  /* OPENSSL_EXTRA */
+#endif /* OPENSSL_EXTRA */
 
 #ifdef OPENSSL_ALL
 

--- a/src/ssl_certman.c
+++ b/src/ssl_certman.c
@@ -609,8 +609,7 @@ void wolfSSL_CertManagerSetVerify(WOLFSSL_CERT_MANAGER* cm, VerifyCallback vc)
 }
 #endif /* NO_WOLFSSL_CM_VERIFY */
 
-#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
-    && defined(HAVE_OID_DECODING)
+#ifdef WC_ASN_UNKNOWN_EXT_CB
 void wolfSSL_CertManagerSetUnknownExtCallback(WOLFSSL_CERT_MANAGER* cm,
         wc_UnknownExtCallback cb)
 {
@@ -620,7 +619,7 @@ void wolfSSL_CertManagerSetUnknownExtCallback(WOLFSSL_CERT_MANAGER* cm,
     }
 
 }
-#endif /* WOLFSSL_CUSTOM_OID && WOLFSSL_ASN_TEMPLATE && HAVE_OID_DECODING */
+#endif /* WC_ASN_UNKNOWN_EXT_CB */
 
 #if !defined(NO_WOLFSSL_CLIENT) || !defined(WOLFSSL_NO_CLIENT_AUTH)
 /* Verify the certificate.
@@ -690,8 +689,7 @@ int CM_VerifyBuffer_ex(WOLFSSL_CERT_MANAGER* cm, const unsigned char* buff,
         /* Create a decoded certificate with DER buffer. */
         InitDecodedCert(cert, buff, (word32)sz, cm->heap);
 
-#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
-    && defined(HAVE_OID_DECODING)
+#ifdef WC_ASN_UNKNOWN_EXT_CB
         if (cm->unknownExtCallback != NULL)
             wc_SetUnknownExtCallback(cert, cm->unknownExtCallback);
 #endif

--- a/src/x509.c
+++ b/src/x509.c
@@ -1426,6 +1426,11 @@ int wolfSSL_X509_add_ext(WOLFSSL_X509 *x509, WOLFSSL_X509_EXTENSION *ext, int lo
         break;
     default:
 #ifdef WOLFSSL_CUSTOM_OID
+    {
+        char *oid = NULL;
+        byte *val = NULL;
+        int err = 0;
+
         if ((ext->obj == NULL) || (ext->value.length == 0)) {
             WOLFSSL_MSG("Extension has insufficient information.");
             return WOLFSSL_FAILURE;
@@ -1438,12 +1443,10 @@ int wolfSSL_X509_add_ext(WOLFSSL_X509 *x509, WOLFSSL_X509_EXTENSION *ext, int lo
         }
 
         /* This is a viable custom extension. */
-        char *oid = XMALLOC(MAX_OID_STRING_SZ, x509->heap,
-                            DYNAMIC_TYPE_X509_EXT);
-        byte *val = XMALLOC(ext->value.length, x509->heap,
-                            DYNAMIC_TYPE_X509_EXT);
-        int err = 0;
-
+        oid = (char*)XMALLOC(MAX_OID_STRING_SZ, x509->heap,
+            DYNAMIC_TYPE_X509_EXT);
+        val = (byte*)XMALLOC(ext->value.length, x509->heap,
+            DYNAMIC_TYPE_X509_EXT);
         if ((oid == NULL) || (val == NULL)) {
             WOLFSSL_MSG("Memory allocation failure.\n");
             err = 1;
@@ -1468,12 +1471,13 @@ int wolfSSL_X509_add_ext(WOLFSSL_X509 *x509, WOLFSSL_X509_EXTENSION *ext, int lo
         x509->custom_exts[x509->customExtCount].val = val;
         x509->custom_exts[x509->customExtCount].valSz = ext->value.length;
         x509->customExtCount++;
+        break;
+    }
 #else
         WOLFSSL_MSG("Unsupported extension to add");
         return WOLFSSL_FAILURE;
 #endif /* WOLFSSL_CUSTOM_OID */
-        break;
-    }
+    } /* switch (nid) */
 
     return WOLFSSL_SUCCESS;
 }

--- a/src/x509.c
+++ b/src/x509.c
@@ -1067,7 +1067,9 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
             case CERT_POLICY_OID:
                 if (!isSet)
                     break;
+            #ifdef WOLFSSL_SEP
                 ext->crit = x509->certPolicyCrit;
+            #endif
                 break;
 
             case KEY_USAGE_OID:
@@ -2504,7 +2506,8 @@ void* wolfSSL_X509_get_ext_d2i(const WOLFSSL_X509* x509, int nid, int* c,
             else {
                 WOLFSSL_MSG("No Cert Policy set");
             }
-        #elif defined(WOLFSSL_SEP)
+        #endif /* WOLFSSL_CERT_EXT */
+        #ifdef WOLFSSL_SEP
             if (x509->certPolicySet) {
                 if (c != NULL) {
                     *c = x509->certPolicyCrit;
@@ -2520,8 +2523,6 @@ void* wolfSSL_X509_get_ext_d2i(const WOLFSSL_X509* x509, int nid, int* c,
             else {
                 WOLFSSL_MSG("No Cert Policy set");
             }
-        #else
-            WOLFSSL_MSG("wolfSSL not built with WOLFSSL_SEP or WOLFSSL_CERT_EXT");
         #endif
             break;
         }
@@ -3711,7 +3712,7 @@ char* wolfSSL_X509_get_next_altname(WOLFSSL_X509* cert)
     }
 
     ret = cert->altNamesNext->name;
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME)
+#ifdef WOLFSSL_IP_ALT_NAME
     /* return the IP address as a string */
     if (cert->altNamesNext->type == ASN_IP_TYPE) {
         ret = cert->altNamesNext->ipString;
@@ -5668,9 +5669,9 @@ int wolfSSL_X509_cmp(const WOLFSSL_X509 *a, const WOLFSSL_X509 *b)
                 case NID_key_usage: crit = x509->keyUsageCrit; break;
                 case NID_crl_distribution_points: crit= x509->CRLdistCrit; break;
                 case NID_ext_key_usage: crit= x509->extKeyUsageCrit; break;
-                #if defined(WOLFSSL_SEP) || defined(WOLFSSL_QT)
-                    case NID_certificate_policies: crit = x509->certPolicyCrit; break;
-                #endif /* WOLFSSL_SEP || WOLFSSL_QT */
+            #ifdef WOLFSSL_SEP
+                case NID_certificate_policies: crit = x509->certPolicyCrit; break;
+            #endif /* WOLFSSL_SEP */
             }
         }
 
@@ -5873,7 +5874,7 @@ static int X509PrintSubjAltName(WOLFSSL_BIO* bio, WOLFSSL_X509* x509,
                         break;
                     }
                 }
-            #if defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME)
+            #ifdef WOLFSSL_IP_ALT_NAME
                 else if (entry->type == ASN_IP_TYPE) {
                     len = XSNPRINTF(scratch, MAX_WIDTH, "IP Address:%s",
                             entry->ipString);

--- a/tests/api.c
+++ b/tests/api.c
@@ -4268,8 +4268,8 @@ static int test_wolfSSL_CertManagerCheckOCSPResponse(void)
 static int test_wolfSSL_CheckOCSPResponse(void)
 {
     EXPECT_DECLS;
-#if defined(HAVE_OCSP) && !defined(NO_RSA) && !defined(NO_SHA) && \
-       defined(OPENSSL_ALL)
+#if defined(HAVE_OCSP) && defined(OPENSSL_EXTRA) && \
+    !defined(NO_RSA) && !defined(NO_SHA)
     const char* responseFile = "./certs/ocsp/test-response.der";
     const char* responseMultiFile = "./certs/ocsp/test-multi-response.der";
     const char* responseNoInternFile =
@@ -53340,7 +53340,7 @@ static int test_wolfSSL_X509_sign(void)
     ExpectIntEQ(wolfSSL_X509_add_altname(x509,
                 "Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch",
                 ASN_DNS_TYPE), SSL_SUCCESS);
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME)
+#ifdef WOLFSSL_IP_ALT_NAME
     {
         unsigned char ip4_type[] = {127,128,0,255};
         unsigned char ip6_type[] = {0xdd, 0xcc, 0xba, 0xab,
@@ -53373,7 +53373,7 @@ static int test_wolfSSL_X509_sign(void)
 #if defined(OPENSSL_ALL) && defined(WOLFSSL_ALT_NAMES)
     ExpectIntEQ(X509_get_ext_count(x509), 1);
 #endif
-#if defined(WOLFSSL_ALT_NAMES) && (defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME))
+#if defined(WOLFSSL_ALT_NAMES) && defined(WOLFSSL_IP_ALT_NAME)
     ExpectIntEQ(wolfSSL_X509_check_ip_asc(x509, "127.128.0.255", 0), 1);
     ExpectIntEQ(wolfSSL_X509_check_ip_asc(x509, "DDCC:BAAB:FFEE:9988:7766:5544:0033:2211", 0), 1);
 #endif
@@ -53389,7 +53389,7 @@ static int test_wolfSSL_X509_sign(void)
 #ifndef WOLFSSL_ALT_NAMES
     /* Valid case - size should be 781-786 with 16 byte serial number */
     ExpectTrue((781 + snSz <= ret) && (ret <= 781 + 5 + snSz));
-#elif defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME)
+#elif defined(WOLFSSL_IP_ALT_NAME)
     /* Valid case - size should be 955-960 with 16 byte serial number */
     ExpectTrue((939 + snSz <= ret) && (ret <= 939 + 5 + snSz));
 #else
@@ -64446,7 +64446,7 @@ static int test_wolfSSL_OCSP_id_cmp(void)
 static int test_wolfSSL_OCSP_SINGLERESP_get0_id(void)
 {
     EXPECT_DECLS;
-#if defined(OPENSSL_ALL) && defined(HAVE_OCSP)
+#if defined(HAVE_OCSP) && defined(OPENSSL_EXTRA)
     WOLFSSL_OCSP_SINGLERESP single;
     const WOLFSSL_OCSP_CERTID* certId;
 
@@ -64463,7 +64463,8 @@ static int test_wolfSSL_OCSP_SINGLERESP_get0_id(void)
 static int test_wolfSSL_OCSP_single_get0_status(void)
 {
     EXPECT_DECLS;
-#if defined(OPENSSL_ALL) && defined(HAVE_OCSP)
+#if defined(HAVE_OCSP) && defined(OPENSSL_EXTRA) && \
+    defined(WOLFSSL_OCSP_PARSE_STATUS)
     WOLFSSL_OCSP_SINGLERESP single;
     CertStatus certStatus;
     WOLFSSL_ASN1_TIME* thisDate;
@@ -64498,7 +64499,7 @@ static int test_wolfSSL_OCSP_single_get0_status(void)
 static int test_wolfSSL_OCSP_resp_count(void)
 {
     EXPECT_DECLS;
-#if defined(OPENSSL_ALL) && defined(HAVE_OCSP)
+#if defined(HAVE_OCSP) && defined(OPENSSL_EXTRA)
     WOLFSSL_OCSP_BASICRESP basicResp;
     WOLFSSL_OCSP_SINGLERESP singleRespOne;
     WOLFSSL_OCSP_SINGLERESP singleRespTwo;
@@ -64519,7 +64520,7 @@ static int test_wolfSSL_OCSP_resp_count(void)
 static int test_wolfSSL_OCSP_resp_get0(void)
 {
     EXPECT_DECLS;
-#if defined(OPENSSL_ALL) && defined(HAVE_OCSP)
+#if defined(HAVE_OCSP) && defined(OPENSSL_EXTRA)
     WOLFSSL_OCSP_BASICRESP basicResp;
     WOLFSSL_OCSP_SINGLERESP singleRespOne;
     WOLFSSL_OCSP_SINGLERESP singleRespTwo;

--- a/tests/api.c
+++ b/tests/api.c
@@ -57494,8 +57494,8 @@ static int test_GENERAL_NAME_set0_othername(void) {
     ExpectIntGT(X509_sign(x509, priv, EVP_sha256()), 0);
     sk_GENERAL_NAME_pop_free(gns, GENERAL_NAME_free);
     gns = NULL;
-    ExpectNotNull(gns = X509_get_ext_d2i(x509, NID_subject_alt_name, NULL,
-        NULL));
+    ExpectNotNull(gns = (GENERAL_NAMES*)X509_get_ext_d2i(x509,
+        NID_subject_alt_name, NULL, NULL));
 
     ExpectIntEQ(sk_GENERAL_NAME_num(gns), 3);
 
@@ -57658,8 +57658,8 @@ static int test_othername_and_SID_ext(void) {
                 0);
 
     /* Cleanup */
-    ExpectNotNull(gns = X509_get_ext_d2i(x509, NID_subject_alt_name, NULL,
-                                         NULL));
+    ExpectNotNull(gns = (GENERAL_NAMES*)X509_get_ext_d2i(x509,
+        NID_subject_alt_name, NULL, NULL));
     ExpectIntEQ(sk_GENERAL_NAME_num(gns), 1);
     ExpectNotNull(gn = sk_GENERAL_NAME_value(gns, 0));
     ExpectIntEQ(gn->type, 0);

--- a/tests/api.c
+++ b/tests/api.c
@@ -36,21 +36,289 @@
 #include <wolfssl/wolfcrypt/settings.h>
 #undef TEST_OPENSSL_COEXIST /* can't use this option with this example */
 
-#ifndef FOURK_BUF
-    #define FOURK_BUF 4096
-#endif
-#ifndef TWOK_BUF
-    #define TWOK_BUF 2048
-#endif
-#ifndef ONEK_BUF
-    #define ONEK_BUF 1024
-#endif
+#include <wolfssl/wolfcrypt/logging.h>
+#include <wolfssl/wolfcrypt/hash.h>
+
 #if defined(WOLFSSL_STATIC_MEMORY)
     #include <wolfssl/wolfcrypt/memory.h>
+#endif
+#ifdef WOLFSSL_ASNC_CRYPT
+    #include <wolfssl/wolfcrypt/async.h>
+#endif
+#ifdef HAVE_ECC
+    #include <wolfssl/wolfcrypt/ecc.h>   /* wc_ecc_fp_free */
+    #ifdef WOLFSSL_SM2
+        #include <wolfssl/wolfcrypt/sm2.h>
+    #endif
+#endif
+#ifndef NO_ASN
+    #include <wolfssl/wolfcrypt/asn_public.h>
+#endif
+
+#include <stdlib.h>
+#include <wolfssl/ssl.h>  /* compatibility layer */
+#include <wolfssl/error-ssl.h>
+
+#include <wolfssl/test.h>
+#include <tests/unit.h>
+#include <tests/utils.h>
+
+/* for testing compatibility layer callbacks */
+#include "examples/server/server.h"
+
+#ifndef NO_MD5
+    #include <wolfssl/wolfcrypt/md5.h>
+#endif
+#ifndef NO_SHA
+    #include <wolfssl/wolfcrypt/sha.h>
+#endif
+#ifndef NO_SHA256
+    #include <wolfssl/wolfcrypt/sha256.h>
+#endif
+#ifdef WOLFSSL_SHA512
+    #include <wolfssl/wolfcrypt/sha512.h>
+#endif
+#ifdef WOLFSSL_SHA384
+    #include <wolfssl/wolfcrypt/sha512.h>
+#endif
+#ifdef WOLFSSL_SHA3
+    #include <wolfssl/wolfcrypt/sha3.h>
+#endif
+#ifdef WOLFSSL_SM3
+    #include <wolfssl/wolfcrypt/sm3.h>
+#endif
+#ifndef NO_AES
+    #include <wolfssl/wolfcrypt/aes.h>
+    #ifdef HAVE_AES_DECRYPT
+        #include <wolfssl/wolfcrypt/wc_encrypt.h>
+    #endif
+#endif
+#ifdef WOLFSSL_SM4
+    #include <wolfssl/wolfcrypt/sm4.h>
+#endif
+#ifdef WOLFSSL_RIPEMD
+    #include <wolfssl/wolfcrypt/ripemd.h>
+#endif
+#ifndef NO_DES3
+    #include <wolfssl/wolfcrypt/des3.h>
+    #include <wolfssl/wolfcrypt/wc_encrypt.h>
+#endif
+#ifdef WC_RC2
+    #include <wolfssl/wolfcrypt/rc2.h>
+#endif
+
+#ifndef NO_HMAC
+    #include <wolfssl/wolfcrypt/hmac.h>
+#endif
+
+#ifdef HAVE_CHACHA
+    #include <wolfssl/wolfcrypt/chacha.h>
+#endif
+
+#ifdef HAVE_POLY1305
+    #include <wolfssl/wolfcrypt/poly1305.h>
+#endif
+
+#if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
+    #include <wolfssl/wolfcrypt/chacha20_poly1305.h>
+#endif
+
+#ifdef HAVE_CAMELLIA
+    #include <wolfssl/wolfcrypt/camellia.h>
+#endif
+
+#ifndef NO_RC4
+    #include <wolfssl/wolfcrypt/arc4.h>
+#endif
+
+#ifdef HAVE_BLAKE2
+    #include <wolfssl/wolfcrypt/blake2.h>
+#endif
+
+#ifndef NO_RSA
+    #include <wolfssl/wolfcrypt/rsa.h>
+#endif
+
+#ifndef NO_SIG_WRAPPER
+    #include <wolfssl/wolfcrypt/signature.h>
+#endif
+
+#ifdef HAVE_AESCCM
+    #include <wolfssl/wolfcrypt/aes.h>
+#endif
+
+#ifdef HAVE_PKCS7
+    #include <wolfssl/wolfcrypt/pkcs7.h>
+    #include <wolfssl/wolfcrypt/asn.h>
+    #ifdef HAVE_LIBZ
+        #include <wolfssl/wolfcrypt/compress.h>
+    #endif
+#endif
+
+#ifdef WOLFSSL_SMALL_CERT_VERIFY
+    #include <wolfssl/wolfcrypt/asn.h>
+#endif
+
+#ifndef NO_DSA
+    #include <wolfssl/wolfcrypt/dsa.h>
+#endif
+
+#ifdef WOLFSSL_CMAC
+    #include <wolfssl/wolfcrypt/cmac.h>
+#endif
+
+#ifdef HAVE_ED25519
+    #include <wolfssl/wolfcrypt/ed25519.h>
+#endif
+#ifdef HAVE_CURVE25519
+    #include <wolfssl/wolfcrypt/curve25519.h>
+#endif
+#ifdef HAVE_ED448
+    #include <wolfssl/wolfcrypt/ed448.h>
+#endif
+#ifdef HAVE_CURVE448
+    #include <wolfssl/wolfcrypt/curve448.h>
+#endif
+
+#ifdef WOLFSSL_HAVE_KYBER
+    #include <wolfssl/wolfcrypt/kyber.h>
+#ifdef WOLFSSL_WC_KYBER
+    #include <wolfssl/wolfcrypt/wc_kyber.h>
+#endif
+#endif
+#ifdef HAVE_DILITHIUM
+    #include <wolfssl/wolfcrypt/dilithium.h>
+#endif
+
+#ifdef HAVE_PKCS12
+    #include <wolfssl/wolfcrypt/pkcs12.h>
+#endif
+
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || \
+    defined(OPENSSL_ALL)
+    #include <wolfssl/openssl/ssl.h>
+    #ifndef NO_ASN
+        /* for ASN_COMMON_NAME DN_tags enum */
+        #include <wolfssl/wolfcrypt/asn.h>
+    #endif
+    #ifdef HAVE_OCSP
+        #include <wolfssl/openssl/ocsp.h>
+    #endif
+#endif
+#ifdef OPENSSL_EXTRA
+    #include <wolfssl/openssl/cmac.h>
+    #include <wolfssl/openssl/x509v3.h>
+    #include <wolfssl/openssl/asn1.h>
+    #include <wolfssl/openssl/crypto.h>
+    #include <wolfssl/openssl/pkcs12.h>
+    #include <wolfssl/openssl/evp.h>
+    #include <wolfssl/openssl/dh.h>
+    #include <wolfssl/openssl/bn.h>
+    #include <wolfssl/openssl/buffer.h>
+    #include <wolfssl/openssl/pem.h>
+    #include <wolfssl/openssl/ec.h>
+    #include <wolfssl/openssl/ecdh.h>
+    #include <wolfssl/openssl/engine.h>
+    #include <wolfssl/openssl/hmac.h>
+    #include <wolfssl/openssl/objects.h>
+    #include <wolfssl/openssl/rand.h>
+    #include <wolfssl/openssl/modes.h>
+    #include <wolfssl/openssl/fips_rand.h>
+    #include <wolfssl/openssl/kdf.h>
+#ifdef OPENSSL_ALL
+    #include <wolfssl/openssl/txt_db.h>
+    #include <wolfssl/openssl/lhash.h>
+#endif
+#ifndef NO_AES
+    #include <wolfssl/openssl/aes.h>
+#endif
+#ifndef NO_DES3
+    #include <wolfssl/openssl/des.h>
+#endif
+#ifndef NO_RC4
+    #include <wolfssl/openssl/rc4.h>
+#endif
+#ifdef HAVE_ECC
+    #include <wolfssl/openssl/ecdsa.h>
+#endif
+#ifdef HAVE_PKCS7
+    #include <wolfssl/openssl/pkcs7.h>
+#endif
+#ifdef HAVE_CURVE25519
+    #include <wolfssl/openssl/ec25519.h>
+#endif
+#ifdef HAVE_ED25519
+    #include <wolfssl/openssl/ed25519.h>
+#endif
+#ifdef HAVE_CURVE448
+    #include <wolfssl/openssl/ec448.h>
+#endif
+#ifdef HAVE_ED448
+    #include <wolfssl/openssl/ed448.h>
+#endif
+#endif /* OPENSSL_EXTRA */
+
+#if defined(OPENSSL_EXTRA) && defined(WOLFCRYPT_HAVE_SRP) && \
+    !defined(NO_SHA256) && !defined(RC_NO_RNG)
+        #include <wolfssl/wolfcrypt/srp.h>
+#endif
+
+#if (defined(SESSION_CERTS) && defined(TEST_PEER_CERT_CHAIN)) || \
+    defined(HAVE_SESSION_TICKET) || (defined(OPENSSL_EXTRA) && \
+    defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_CERT_GEN)) || \
+    defined(WOLFSSL_TEST_STATIC_BUILD) || defined(WOLFSSL_DTLS) || \
+    defined(HAVE_ECH) || defined(HAVE_EX_DATA) || !defined(NO_SESSION_CACHE) \
+    || !defined(WOLFSSL_NO_TLS12) || defined(WOLFSSL_TLS13)
+    /* for testing SSL_get_peer_cert_chain, or SESSION_TICKET_HINT_DEFAULT,
+     * for setting authKeyIdSrc in WOLFSSL_X509, or testing DTLS sequence
+     * number tracking */
+    #include "wolfssl/internal.h"
+#endif
+
+/* force enable test buffers */
+#ifndef USE_CERT_BUFFERS_2048
+    #define USE_CERT_BUFFERS_2048
+#endif
+#ifndef USE_CERT_BUFFERS_256
+    #define USE_CERT_BUFFERS_256
+#endif
+#include <wolfssl/certs_test.h>
+
+/* include misc.c here regardless of NO_INLINE, because misc.c implementations
+ * have default (hidden) visibility, and in the absence of visibility, it's
+ * benign to mask out the library implementation.
+ */
+#define WOLFSSL_MISC_INCLUDED
+#include <wolfcrypt/src/misc.c>
+
+
+
+#if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && \
+    !defined(NO_RSA)        && !defined(SINGLE_THREADED) && \
+    !defined(NO_WOLFSSL_SERVER) && !defined(NO_WOLFSSL_CLIENT)
+    #define HAVE_IO_TESTS_DEPENDENCIES
+#endif
+
+#if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && !defined(NO_RSA) && \
+    !defined(NO_WOLFSSL_SERVER) && !defined(NO_WOLFSSL_CLIENT) && \
+    !defined(WOLFSSL_TIRTOS)
+    #define HAVE_SSL_MEMIO_TESTS_DEPENDENCIES
+#endif
+
+#if !defined(NO_RSA) && !defined(NO_SHA) && !defined(NO_FILESYSTEM) && \
+    !defined(NO_CERTS) && (!defined(NO_WOLFSSL_CLIENT) || \
+    !defined(WOLFSSL_NO_CLIENT_AUTH))
+    #define HAVE_CERT_CHAIN_VALIDATION
+#endif
+
+#ifndef WOLFSSL_HAVE_ECC_KEY_GET_PRIV
+    /* FIPS build has replaced ecc.h. */
+    #define wc_ecc_key_get_priv(key) (&((key)->k))
+    #define WOLFSSL_HAVE_ECC_KEY_GET_PRIV
+#endif
 
 #if defined(WOLFSSL_STATIC_MEMORY) && !defined(WOLFCRYPT_ONLY)
-    #if (defined(HAVE_ECC) && !defined(ALT_ECC_SIZE)) || \
-         defined(SESSION_CERTS)
+    #if (defined(HAVE_ECC) && !defined(ALT_ECC_SIZE)) || defined(SESSION_CERTS)
         #ifdef OPENSSL_EXTRA
             #define TEST_TLS_STATIC_MEMSZ (400000)
         #else
@@ -61,15 +329,7 @@
     #endif
 #endif
 
-#endif /* WOLFSSL_STATIC_MEMORY */
-#ifndef HEAP_HINT
-    #define HEAP_HINT NULL
-#endif /* WOLFSSL_STAIC_MEMORY */
-#ifdef WOLFSSL_ASNC_CRYPT
-    #include <wolfssl/wolfcrypt/async.h>
-#endif
 #ifdef HAVE_ECC
-    #include <wolfssl/wolfcrypt/ecc.h>   /* wc_ecc_fp_free */
     #ifndef ECC_ASN963_MAX_BUF_SZ
         #define ECC_ASN963_MAX_BUF_SZ 133
     #endif
@@ -137,137 +397,9 @@
     #if !defined(DER_SZ)
         #define DER_SZ(ks) ((ks) * 2 + 1)
     #endif
-    #ifdef WOLFSSL_SM2
-        #include <wolfssl/wolfcrypt/sm2.h>
-    #endif
-#endif
-#ifndef NO_ASN
-    #include <wolfssl/wolfcrypt/asn_public.h>
-#endif
-#include <wolfssl/error-ssl.h>
-
-#include <stdlib.h>
-#include <wolfssl/ssl.h>  /* compatibility layer */
-#include <wolfssl/test.h>
-#include <tests/unit.h>
-#include "examples/server/server.h"
-     /* for testing compatibility layer callbacks */
-
-#ifndef NO_MD5
-    #include <wolfssl/wolfcrypt/md5.h>
-#endif
-#ifndef NO_SHA
-    #include <wolfssl/wolfcrypt/sha.h>
-#endif
-#ifndef NO_SHA256
-    #include <wolfssl/wolfcrypt/sha256.h>
-#endif
-#ifdef WOLFSSL_SHA512
-    #include <wolfssl/wolfcrypt/sha512.h>
-#endif
-#ifdef WOLFSSL_SHA384
-    #include <wolfssl/wolfcrypt/sha512.h>
-#endif
-
-#ifdef WOLFSSL_SHA3
-    #include <wolfssl/wolfcrypt/sha3.h>
-    #ifndef HEAP_HINT
-        #define HEAP_HINT   NULL
-    #endif
-#endif
-
-#ifdef WOLFSSL_SM3
-    #include <wolfssl/wolfcrypt/sm3.h>
-#endif
-
-#ifndef NO_AES
-    #include <wolfssl/wolfcrypt/aes.h>
-    #ifdef HAVE_AES_DECRYPT
-        #include <wolfssl/wolfcrypt/wc_encrypt.h>
-    #endif
-#endif
-#ifdef WOLFSSL_SM4
-    #include <wolfssl/wolfcrypt/sm4.h>
-#endif
-#ifdef WOLFSSL_RIPEMD
-    #include <wolfssl/wolfcrypt/ripemd.h>
-#endif
-#ifndef NO_DES3
-    #include <wolfssl/wolfcrypt/des3.h>
-    #include <wolfssl/wolfcrypt/wc_encrypt.h>
-#endif
-#ifdef WC_RC2
-    #include <wolfssl/wolfcrypt/rc2.h>
-#endif
-
-#ifndef NO_HMAC
-    #include <wolfssl/wolfcrypt/hmac.h>
-#endif
-
-#ifdef HAVE_CHACHA
-    #include <wolfssl/wolfcrypt/chacha.h>
-#endif
-
-#ifdef HAVE_POLY1305
-    #include <wolfssl/wolfcrypt/poly1305.h>
-#endif
-
-#if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
-    #include <wolfssl/wolfcrypt/chacha20_poly1305.h>
-#endif
-
-#ifdef HAVE_CAMELLIA
-    #include <wolfssl/wolfcrypt/camellia.h>
-#endif
-
-#ifndef NO_RC4
-    #include <wolfssl/wolfcrypt/arc4.h>
-#endif
-
-#ifdef HAVE_BLAKE2
-    #include <wolfssl/wolfcrypt/blake2.h>
-#endif
-
-#include <wolfssl/wolfcrypt/hash.h>
-#ifndef NO_RSA
-    #include <wolfssl/wolfcrypt/rsa.h>
-
-    #define FOURK_BUF 4096
-    #define GEN_BUF  294
-#endif
-
-#ifndef NO_SIG_WRAPPER
-    #include <wolfssl/wolfcrypt/signature.h>
-#endif
-
-
-#ifdef HAVE_AESCCM
-    #include <wolfssl/wolfcrypt/aes.h>
-#endif
-
-#ifdef HAVE_PKCS7
-    #include <wolfssl/wolfcrypt/pkcs7.h>
-    #include <wolfssl/wolfcrypt/asn.h>
-    #ifdef HAVE_LIBZ
-    #include <wolfssl/wolfcrypt/compress.h>
-    #endif
-#endif
-
-#ifdef WOLFSSL_SMALL_CERT_VERIFY
-    #include <wolfssl/wolfcrypt/asn.h>
-#endif
+#endif /* HAVE_ECC */
 
 #ifndef NO_DSA
-    #include <wolfssl/wolfcrypt/dsa.h>
-    #ifndef ONEK_BUF
-        #define ONEK_BUF 1024
-    #endif
-    #ifndef TWOK_BUF
-        #define TWOK_BUF 2048
-    #endif
-    #ifndef FOURK_BUF
-        #define FOURK_BUF 4096
-    #endif
     #ifndef DSA_SIG_SIZE
         #define DSA_SIG_SIZE 40
     #endif
@@ -276,142 +408,26 @@
     #endif
 #endif
 
-#ifdef WOLFSSL_CMAC
-    #include <wolfssl/wolfcrypt/cmac.h>
+#ifndef NO_RSA
+    #define GEN_BUF  294
 #endif
 
-#ifdef HAVE_ED25519
-    #include <wolfssl/wolfcrypt/ed25519.h>
+#ifndef ONEK_BUF
+    #define ONEK_BUF 1024
 #endif
-#ifdef HAVE_CURVE25519
-    #include <wolfssl/wolfcrypt/curve25519.h>
+#ifndef TWOK_BUF
+    #define TWOK_BUF 2048
 #endif
-#ifdef HAVE_ED448
-    #include <wolfssl/wolfcrypt/ed448.h>
-#endif
-#ifdef HAVE_CURVE448
-    #include <wolfssl/wolfcrypt/curve448.h>
+#ifndef FOURK_BUF
+    #define FOURK_BUF 4096
 #endif
 
-#ifdef WOLFSSL_HAVE_KYBER
-    #include <wolfssl/wolfcrypt/kyber.h>
-#ifdef WOLFSSL_WC_KYBER
-    #include <wolfssl/wolfcrypt/wc_kyber.h>
-#endif
-#endif
-#ifdef HAVE_DILITHIUM
-    #include <wolfssl/wolfcrypt/dilithium.h>
+#ifndef HEAP_HINT
+    #define HEAP_HINT NULL
 #endif
 
-#ifdef HAVE_PKCS12
-    #include <wolfssl/wolfcrypt/pkcs12.h>
-#endif
 
-#include <wolfssl/wolfcrypt/logging.h>
 
-#if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || defined(OPENSSL_ALL))
-    #include <wolfssl/openssl/ssl.h>
-    #ifndef NO_ASN
-        /* for ASN_COMMON_NAME DN_tags enum */
-        #include <wolfssl/wolfcrypt/asn.h>
-    #endif
-    #ifdef HAVE_OCSP
-        #include <wolfssl/openssl/ocsp.h>
-    #endif
-#endif
-#ifdef OPENSSL_EXTRA
-    #include <wolfssl/openssl/cmac.h>
-    #include <wolfssl/openssl/x509v3.h>
-    #include <wolfssl/openssl/asn1.h>
-    #include <wolfssl/openssl/crypto.h>
-    #include <wolfssl/openssl/pkcs12.h>
-    #include <wolfssl/openssl/evp.h>
-    #include <wolfssl/openssl/dh.h>
-    #include <wolfssl/openssl/bn.h>
-    #include <wolfssl/openssl/buffer.h>
-    #include <wolfssl/openssl/pem.h>
-    #include <wolfssl/openssl/ec.h>
-    #include <wolfssl/openssl/ecdh.h>
-    #include <wolfssl/openssl/engine.h>
-    #include <wolfssl/openssl/hmac.h>
-    #include <wolfssl/openssl/objects.h>
-    #include <wolfssl/openssl/rand.h>
-    #include <wolfssl/openssl/modes.h>
-    #include <wolfssl/openssl/fips_rand.h>
-    #include <wolfssl/openssl/kdf.h>
-#ifdef OPENSSL_ALL
-    #include <wolfssl/openssl/txt_db.h>
-    #include <wolfssl/openssl/lhash.h>
-#endif
-#ifndef NO_AES
-    #include <wolfssl/openssl/aes.h>
-#endif
-#ifndef NO_DES3
-    #include <wolfssl/openssl/des.h>
-#endif
-#ifndef NO_RC4
-    #include <wolfssl/openssl/rc4.h>
-#endif
-#ifdef HAVE_ECC
-    #include <wolfssl/openssl/ecdsa.h>
-#endif
-#ifdef HAVE_PKCS7
-    #include <wolfssl/openssl/pkcs7.h>
-#endif
-#ifdef HAVE_CURVE25519
-    #include <wolfssl/openssl/ec25519.h>
-#endif
-#ifdef HAVE_ED25519
-    #include <wolfssl/openssl/ed25519.h>
-#endif
-#ifdef HAVE_CURVE448
-    #include <wolfssl/openssl/ec448.h>
-#endif
-#ifdef HAVE_ED448
-    #include <wolfssl/openssl/ed448.h>
-#endif
-#endif /* OPENSSL_EXTRA */
-
-#if defined(OPENSSL_EXTRA) && defined(WOLFCRYPT_HAVE_SRP) \
-    && !defined(NO_SHA256) && !defined(RC_NO_RNG)
-        #include <wolfssl/wolfcrypt/srp.h>
-#endif
-
-#if (defined(SESSION_CERTS) && defined(TEST_PEER_CERT_CHAIN)) || \
-    defined(HAVE_SESSION_TICKET) || (defined(OPENSSL_EXTRA) && \
-    defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_CERT_GEN)) || \
-    defined(WOLFSSL_TEST_STATIC_BUILD) || defined(WOLFSSL_DTLS) || \
-    defined(HAVE_ECH) || defined(HAVE_EX_DATA) || !defined(NO_SESSION_CACHE) \
-    || !defined(WOLFSSL_NO_TLS12) || defined(WOLFSSL_TLS13)
-    /* for testing SSL_get_peer_cert_chain, or SESSION_TICKET_HINT_DEFAULT,
-     * for setting authKeyIdSrc in WOLFSSL_X509, or testing DTLS sequence
-     * number tracking */
-#include "wolfssl/internal.h"
-#endif
-
-/* force enable test buffers */
-#ifndef USE_CERT_BUFFERS_2048
-    #define USE_CERT_BUFFERS_2048
-#endif
-#ifndef USE_CERT_BUFFERS_256
-    #define USE_CERT_BUFFERS_256
-#endif
-#include <wolfssl/certs_test.h>
-
-#include "tests/utils.h"
-
-/* include misc.c here regardless of NO_INLINE, because misc.c implementations
- * have default (hidden) visibility, and in the absence of visibility, it's
- * benign to mask out the library implementation.
- */
-#define WOLFSSL_MISC_INCLUDED
-#include <wolfcrypt/src/misc.c>
-
-#ifndef WOLFSSL_HAVE_ECC_KEY_GET_PRIV
-    /* FIPS build has replaced ecc.h. */
-    #define wc_ecc_key_get_priv(key) (&((key)->k))
-    #define WOLFSSL_HAVE_ECC_KEY_GET_PRIV
-#endif
 
 typedef struct testVector {
     const char* input;
@@ -580,17 +596,6 @@ static int testDevId = WOLFSSL_CAAM_DEVID;
 static int testDevId = INVALID_DEVID;
 #endif
 
-#if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && \
-    !defined(NO_RSA)        && !defined(SINGLE_THREADED) && \
-    !defined(NO_WOLFSSL_SERVER) && !defined(NO_WOLFSSL_CLIENT)
-#define HAVE_IO_TESTS_DEPENDENCIES
-#endif
-
-#if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && !defined(NO_RSA) && \
-    !defined(NO_WOLFSSL_SERVER) && !defined(NO_WOLFSSL_CLIENT) && \
-    !defined(WOLFSSL_TIRTOS)
-#define HAVE_SSL_MEMIO_TESTS_DEPENDENCIES
-#endif
 
 /*----------------------------------------------------------------------------*
  | BIO with fixed read/write size
@@ -4508,6 +4513,7 @@ static int test_wolfSSL_OtherName(void)
     return EXPECT_RESULT();
 }
 
+#ifdef HAVE_CERT_CHAIN_VALIDATION
 static int test_wolfSSL_CertRsaPss(void)
 {
     EXPECT_DECLS;
@@ -4565,6 +4571,7 @@ static int test_wolfSSL_CertRsaPss(void)
 
     return EXPECT_RESULT();
 }
+#endif
 
 static int test_wolfSSL_CTX_load_verify_locations_ex(void)
 {
@@ -64724,7 +64731,8 @@ static int test_wc_CreateEncryptedPKCS8Key(void)
 {
     EXPECT_DECLS;
 #if defined(HAVE_PKCS8) && !defined(NO_PWDBASED) && defined(WOLFSSL_AES_256) \
- && !defined(NO_AES_CBC) && !defined(NO_RSA) && !defined(NO_SHA)
+ && !defined(NO_AES_CBC) && !defined(NO_RSA) && !defined(NO_SHA) && \
+    !defined(NO_ASN_CRYPT)
     WC_RNG rng;
     byte* encKey = NULL;
     word32 encKeySz = 0;
@@ -67249,6 +67257,10 @@ static int test_RsaSigFailure_cm(void)
 #if defined(NO_WOLFSSL_CLIENT) && defined(NO_WOLFSSL_SERVER)
         ExpectIntEQ(verify_sig_cm(ca_cert, cert_buf, cert_sz, TESTING_RSA),
            WOLFSSL_FATAL_ERROR);
+#elif defined(NO_ASN_CRYPT)
+        /* RSA verify is not called when ASN crypt support is disabled */
+        ExpectIntEQ(verify_sig_cm(ca_cert, cert_buf, cert_sz, TESTING_RSA),
+           WOLFSSL_SUCCESS);
 #else
         ExpectIntEQ(verify_sig_cm(ca_cert, cert_buf, cert_sz, TESTING_RSA),
            ASN_SIG_CONFIRM_E);
@@ -67282,6 +67294,10 @@ static int test_EccSigFailure_cm(void)
 #if defined(NO_WOLFSSL_CLIENT) && defined(NO_WOLFSSL_SERVER)
         ExpectIntEQ(verify_sig_cm(ca_cert, cert_buf, cert_sz, TESTING_ECC),
            WOLFSSL_FATAL_ERROR);
+#elif defined(NO_ASN_CRYPT)
+        /* ECC verify is not called when ASN crypt support is disabled */
+        ExpectIntEQ(verify_sig_cm(ca_cert, cert_buf, cert_sz, TESTING_ECC),
+           WOLFSSL_SUCCESS);
 #else
         ExpectIntEQ(verify_sig_cm(ca_cert, cert_buf, cert_sz, TESTING_ECC),
            ASN_SIG_CONFIRM_E);
@@ -76390,9 +76406,7 @@ static int test_wolfSSL_dtls_stateless(void)
 #endif /* WOLFSSL_DTLS13 && WOLFSSL_SEND_HRR_COOKIE &&
         * HAVE_IO_TESTS_DEPENDENCIES && !SINGLE_THREADED */
 
-#if !defined(NO_RSA) && !defined(NO_SHA) && !defined(NO_FILESYSTEM) && \
-    !defined(NO_CERTS) && (!defined(NO_WOLFSSL_CLIENT) || \
-    !defined(WOLFSSL_NO_CLIENT_AUTH))
+#ifdef HAVE_CERT_CHAIN_VALIDATION
 static int load_ca_into_cm(WOLFSSL_CERT_MANAGER* cm, char* certA)
 {
     int ret;
@@ -85358,9 +85372,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_CertManagerCRL),
     TEST_DECL(test_wolfSSL_CertManagerCheckOCSPResponse),
     TEST_DECL(test_wolfSSL_CheckOCSPResponse),
-#if !defined(NO_RSA) && !defined(NO_SHA) && !defined(NO_FILESYSTEM) && \
-    !defined(NO_CERTS) && (!defined(NO_WOLFSSL_CLIENT) || \
-                           !defined(WOLFSSL_NO_CLIENT_AUTH))
+#ifdef HAVE_CERT_CHAIN_VALIDATION
     TEST_DECL(test_various_pathlen_chains),
 #endif
 
@@ -85450,7 +85462,9 @@ TEST_CASE testCases[] = {
     /* Large number of memory allocations. */
     TEST_DECL(test_wolfSSL_CTX_load_system_CA_certs),
 
+#ifdef HAVE_CERT_CHAIN_VALIDATION
     TEST_DECL(test_wolfSSL_CertRsaPss),
+#endif
     TEST_DECL(test_wolfSSL_CTX_load_verify_locations_ex),
     TEST_DECL(test_wolfSSL_CTX_load_verify_buffer_ex),
     TEST_DECL(test_wolfSSL_CTX_load_verify_chain_buffer_format),

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -251,16 +251,14 @@ int unit_test(int argc, char** argv)
         SrpTest();
     }
 
-#ifndef NO_WOLFSSL_CIPHER_SUITE_TEST
-#if !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER)
-#ifndef SINGLE_THREADED
+#if !defined(NO_WOLFSSL_CIPHER_SUITE_TEST) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    !defined(SINGLE_THREADED)
     if ((ret = SuiteTest(argc, argv)) != 0) {
         fprintf(stderr, "suite test failed with %d\n", ret);
         goto exit;
     }
 #endif
-#endif
-#endif /* NO_WOLFSSL_CIPHER_SUITE_TEST */
 
 exit:
 #ifdef HAVE_WNR

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1977,7 +1977,9 @@ static int    numBlocks  = NUM_BLOCKS;
 static word32 bench_size = BENCH_SIZE;
 static int base2 = 1;
 static int digest_stream = 1;
+#ifdef HAVE_CHACHA
 static int encrypt_only = 0;
+#endif
 #ifdef HAVE_AES_CBC
 static int cipher_same_buffer = 0;
 #endif
@@ -14725,8 +14727,10 @@ int wolfcrypt_benchmark_main(int argc, char** argv)
 #endif
         else if (string_matches(argv[1], "-dgst_full"))
             digest_stream = 0;
+#ifdef HAVE_CHACHA
         else if (string_matches(argv[1], "-enc_only"))
             encrypt_only = 1;
+#endif
 #ifndef NO_RSA
         else if (string_matches(argv[1], "-rsa_sign"))
             rsa_sign_verify = 1;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -20412,7 +20412,8 @@ static int DecodeNameConstraints(const byte* input, word32 sz,
 }
 #endif /* IGNORE_NAME_CONSTRAINTS */
 
-#ifdef WOLFSSL_CERT_EXT
+#if defined(WOLFSSL_CERT_EXT) || \
+    defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 
 /* Decode ITU-T X.690 OID format to a string representation
  * return string length */
@@ -20464,7 +20465,7 @@ int DecodePolicyOID(char *out, word32 outSz, const byte *in, word32 inSz)
 exit:
     return w;
 }
-#endif /* WOLFSSL_CERT_EXT */
+#endif /* WOLFSSL_CERT_EXT || OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
 
 #if defined(WOLFSSL_SEP) || defined(WOLFSSL_CERT_EXT)
 #ifdef WOLFSSL_ASN_TEMPLATE

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -3660,7 +3660,7 @@ int StreamOctetString(const byte* inBuf, word32 inBufSz, byte* out, word32* outS
 
 /* Convert BER to DER */
 
-/* Pull informtation from the ASN.1 BER encoded item header */
+/* Pull information from the ASN.1 BER encoded item header */
 static int GetBerHeader(const byte* data, word32* idx, word32 maxIdx,
                         byte* pTag, word32* pLen, int* indef)
 {
@@ -6226,7 +6226,8 @@ static int RsaPssHashOidToMgf1(word32 oid, int* mgf)
     return ret;
 }
 
-#ifndef NO_CERTS
+#if !defined(NO_CERTS) && !defined(NO_ASN_CRYPT)
+
 /* Convert a hash OID to a fake signature OID.
  *
  * @param  [in]   oid     Hash OID.
@@ -21407,8 +21408,7 @@ enum {
 #define certExtASN_Length (sizeof(certExtASN) / sizeof(ASNItem))
 #endif
 
-#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
-    && defined(HAVE_OID_DECODING)
+#ifdef WC_ASN_UNKNOWN_EXT_CB
 int wc_SetUnknownExtCallback(DecodedCert* cert,
                              wc_UnknownExtCallback cb) {
     if (cert == NULL) {
@@ -21429,7 +21429,7 @@ int wc_SetUnknownExtCallbackEx(DecodedCert* cert,
     cert->unknownExtCallbackExCtx = ctx;
     return 0;
 }
-#endif
+#endif /* WC_ASN_UNKNOWN_EXT_CB */
 
 /*
  *  Processing the Certificate Extensions. This does not modify the current
@@ -21583,7 +21583,7 @@ end:
             /* Decode the extension by type. */
             ret = DecodeExtensionType(input + idx, length, oid, critical, cert,
                                       &isUnknownExt);
-#if defined(WOLFSSL_CUSTOM_OID) && defined(HAVE_OID_DECODING)
+#ifdef WC_ASN_UNKNOWN_EXT_CB
             if (isUnknownExt && (cert->unknownExtCallback != NULL ||
                                  cert->unknownExtCallbackEx != NULL)) {
                 word16 decOid[MAX_OID_SZ];
@@ -21612,8 +21612,9 @@ end:
                               cert->unknownExtCallbackExCtx);
                 }
             }
-#endif
+#else
             (void)isUnknownExt;
+#endif
 
             /* Move index on to next extension. */
             idx += length;
@@ -34482,7 +34483,7 @@ int wc_EccPublicKeyDecode(const byte* input, word32* inOutIdx,
 #endif /* WOLFSSL_ASN_TEMPLATE */
 }
 
-#if defined(HAVE_ECC_KEY_EXPORT) && !defined(NO_ASN_CRYPT)
+#ifdef HAVE_ECC_KEY_EXPORT
 /* build DER formatted ECC key, include optional public key if requested,
  * return length on success, negative on error */
 int wc_BuildEccKeyDer(ecc_key* key, byte* output, word32 *inLen,
@@ -34913,7 +34914,7 @@ int wc_EccKeyToPKCS8(ecc_key* key, byte* output,
     return eccToPKCS8(key, output, outLen, 1);
 }
 #endif /* HAVE_PKCS8 */
-#endif /* HAVE_ECC_KEY_EXPORT && !NO_ASN_CRYPT */
+#endif /* HAVE_ECC_KEY_EXPORT */
 #endif /* HAVE_ECC */
 
 #ifdef WC_ENABLE_ASYM_KEY_IMPORT

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -6278,7 +6278,7 @@ static int RsaPssHashOidToSigOid(word32 oid, word32* sigOid)
 #endif
 
 #ifdef WOLFSSL_ASN_TEMPLATE
-/* ASN tag for hashAlgorigthm. */
+/* ASN tag for hashAlgorithm. */
 #define ASN_TAG_RSA_PSS_HASH        (ASN_CONTEXT_SPECIFIC | 0)
 /* ASN tag for maskGenAlgorithm. */
 #define ASN_TAG_RSA_PSS_MGF         (ASN_CONTEXT_SPECIFIC | 1)
@@ -6326,7 +6326,7 @@ enum {
 /* Number of items in ASN.1 template for an algorithm identifier. */
 #define rsaPssParamsASN_Length (sizeof(rsaPssParamsASN) / sizeof(ASNItem))
 #else
-/* ASN tag for hashAlgorigthm. */
+/* ASN tag for hashAlgorithm. */
 #define ASN_TAG_RSA_PSS_HASH        (ASN_CONTEXT_SPECIFIC | ASN_CONSTRUCTED | 0)
 /* ASN tag for maskGenAlgorithm. */
 #define ASN_TAG_RSA_PSS_MGF         (ASN_CONTEXT_SPECIFIC | ASN_CONSTRUCTED | 1)
@@ -17748,6 +17748,9 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
 
 exit_cs:
 
+#else
+    /* Warning: The NO_ASN_CRYPT option skips signature checking! */
+    ret = 0; /* allow unchecked signature */
 #endif /* !NO_ASN_CRYPT */
 
     (void)keyOID;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -16612,7 +16612,7 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
     const byte* sigParams, word32 sigParamsSz,
     byte* rsaKeyIdx)
 {
-    int ret = 0;
+    int ret = ASN_SIG_CONFIRM_E; /* default to failure */
 #if defined(WOLFSSL_RENESAS_TSIP_TLS) || defined(WOLFSSL_RENESAS_FSPSM_TLS)
     CertAttribute* certatt = NULL;
 #endif
@@ -17749,8 +17749,8 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
 exit_cs:
 
 #else
-    /* Warning: The NO_ASN_CRYPT option skips signature checking! */
-    ret = 0; /* allow unchecked signature */
+    /* For NO_ASN_CRYPT return "not compiled in" */
+    ret = NOT_COMPILED_IN;
 #endif /* !NO_ASN_CRYPT */
 
     (void)keyOID;

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -15437,9 +15437,8 @@ int wc_ecc_get_oid(word32 oidSum, const byte** oid, word32* oidSz)
     /* find matching OID sum (based on encoded value) */
     for (x = 0; ecc_sets[x].size != 0; x++) {
         if (ecc_sets[x].oidSum == oidSum) {
-            int ret;
         #ifdef HAVE_OID_ENCODING
-            ret = 0;
+            int ret = 0;
             /* check cache */
             oid_cache_t* o = &ecc_oid_cache[x];
             if (o->oidSz == 0) {
@@ -15457,6 +15456,7 @@ int wc_ecc_get_oid(word32 oidSum, const byte** oid, word32* oidSz)
             if (ret == 0) {
                 ret = ecc_sets[x].id;
             }
+            return ret;
         #else
             if (oidSz) {
                 *oidSz = ecc_sets[x].oidSz;
@@ -15464,9 +15464,8 @@ int wc_ecc_get_oid(word32 oidSum, const byte** oid, word32* oidSz)
             if (oid) {
                 *oid = ecc_sets[x].oid;
             }
-            ret = ecc_sets[x].id;
+            return ecc_sets[x].id;
         #endif
-            return ret;
         }
     }
 

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -830,8 +830,7 @@ int wc_PKCS7_Init(PKCS7* pkcs7, void* heap, int devId)
     return 0;
 }
 
-#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
-    && defined(HAVE_OID_DECODING)
+#ifdef WC_ASN_UNKNOWN_EXT_CB
 void wc_PKCS7_SetUnknownExtCallback(PKCS7* pkcs7, wc_UnknownExtCallback cb)
 {
     if (pkcs7 != NULL) {
@@ -1083,8 +1082,7 @@ int wc_PKCS7_InitWithCert(PKCS7* pkcs7, byte* derCert, word32 derCertSz)
     int devId;
     Pkcs7Cert* cert;
     Pkcs7Cert* lastCert;
-#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
-    && defined(HAVE_OID_DECODING)
+#ifdef WC_ASN_UNKNOWN_EXT_CB
     wc_UnknownExtCallback cb;
 #endif
 
@@ -1095,16 +1093,14 @@ int wc_PKCS7_InitWithCert(PKCS7* pkcs7, byte* derCert, word32 derCertSz)
     heap = pkcs7->heap;
     devId = pkcs7->devId;
     cert = pkcs7->certList;
-#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
-    && defined(HAVE_OID_DECODING)
-    cb = pkcs7->unknownExtCallback;
+#ifdef WC_ASN_UNKNOWN_EXT_CB
+    cb = pkcs7->unknownExtCallback; /* save / restore callback */
 #endif
     ret = wc_PKCS7_Init(pkcs7, heap, devId);
     if (ret != 0)
         return ret;
 
-#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
-    && defined(HAVE_OID_DECODING)
+#ifdef WC_ASN_UNKNOWN_EXT_CB
     pkcs7->unknownExtCallback = cb;
 #endif
     pkcs7->certList = cert;
@@ -1155,8 +1151,7 @@ int wc_PKCS7_InitWithCert(PKCS7* pkcs7, byte* derCert, word32 derCertSz)
         }
 
         InitDecodedCert(dCert, derCert, derCertSz, pkcs7->heap);
-#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
-    && defined(HAVE_OID_DECODING)
+#ifdef WC_ASN_UNKNOWN_EXT_CB
         if (pkcs7->unknownExtCallback != NULL)
             wc_SetUnknownExtCallback(dCert, pkcs7->unknownExtCallback);
 #endif

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -711,9 +711,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t mp_test(void);
 #if defined(WOLFSSL_PUBLIC_MP) && defined(WOLFSSL_KEY_GEN)
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t prime_test(void);
 #endif
-#if defined(ASN_BER_TO_DER) && \
-    (defined(WOLFSSL_TEST_CERT) || defined(OPENSSL_EXTRA) || \
-     defined(OPENSSL_EXTRA_X509_SMALL))
+#ifdef ASN_BER_TO_DER
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t berder_test(void);
 #endif
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t logging_test(void);
@@ -53957,9 +53955,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t prime_test(void)
 #endif /* WOLFSSL_PUBLIC_MP */
 
 
-#if defined(ASN_BER_TO_DER) && \
-    (defined(WOLFSSL_TEST_CERT) || defined(OPENSSL_EXTRA) || \
-     defined(OPENSSL_EXTRA_X509_SMALL))
+#ifdef ASN_BER_TO_DER
 /* wc_BerToDer is only public facing in the case of test cert or opensslextra */
 typedef struct berDerTestData {
     const byte *in;
@@ -54075,7 +54071,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t berder_test(void)
 
     return 0;
 }
-#endif
+#endif /* ASN_BER_TO_DER */
 
 #ifdef DEBUG_WOLFSSL
 static THREAD_LS_T int log_cnt = 0;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -5176,13 +5176,9 @@ struct WOLFSSL_X509 {
     byte             hwType[EXTERNAL_SERIAL_SIZE];
     int              hwSerialNumSz;
     byte             hwSerialNum[EXTERNAL_SERIAL_SIZE];
-#endif /* WOLFSSL_SEP */
-#if (defined(WOLFSSL_SEP) || defined(WOLFSSL_QT) || defined(OPENSSL_ALL) || \
-    defined (OPENSSL_EXTRA)) && \
-    (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL))
     byte             certPolicySet;
     byte             certPolicyCrit;
-#endif /* (WOLFSSL_SEP || WOLFSSL_QT) && (OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL) */
+#endif /* WOLFSSL_SEP */
 #if defined(WOLFSSL_QT) || defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA)
     WOLFSSL_STACK* ext_sk; /* Store X509_EXTENSIONS from wolfSSL_X509_get_ext */
     WOLFSSL_STACK* ext_sk_full; /* Store X509_EXTENSIONS from wolfSSL_X509_get0_extensions */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2650,8 +2650,7 @@ struct WOLFSSL_CERT_MANAGER {
 #ifdef HAVE_DILITHIUM
     short           minDilithiumKeySz;  /* minimum allowed Dilithium key size */
 #endif
-#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
-    && defined(HAVE_OID_DECODING)
+#ifdef WC_ASN_UNKNOWN_EXT_CB
     wc_UnknownExtCallback unknownExtCallback;
 #endif
 };

--- a/wolfssl/ocsp.h
+++ b/wolfssl/ocsp.h
@@ -67,13 +67,11 @@ WOLFSSL_LOCAL int CheckOcspResponse(WOLFSSL_OCSP *ocsp, byte *response, int resp
 WOLFSSL_LOCAL int CheckOcspResponder(OcspResponse *bs, DecodedCert *cert,
                                      void* vp);
 
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) || \
-    defined(WOLFSSL_APACHE_HTTPD) || defined(HAVE_LIGHTY)
-
-    WOLFSSL_API int wolfSSL_OCSP_resp_find_status(WOLFSSL_OCSP_BASICRESP *bs,
-                                                  WOLFSSL_OCSP_CERTID *id, int *status, int *reason,
-                                                  WOLFSSL_ASN1_TIME **revtime, WOLFSSL_ASN1_TIME **thisupd,
-                                                  WOLFSSL_ASN1_TIME **nextupd);
+#ifdef OPENSSL_EXTRA
+WOLFSSL_API int wolfSSL_OCSP_resp_find_status(WOLFSSL_OCSP_BASICRESP *bs,
+                                              WOLFSSL_OCSP_CERTID *id, int *status, int *reason,
+                                              WOLFSSL_ASN1_TIME **revtime, WOLFSSL_ASN1_TIME **thisupd,
+                                              WOLFSSL_ASN1_TIME **nextupd);
 WOLFSSL_API const char *wolfSSL_OCSP_cert_status_str(long s);
 WOLFSSL_API int wolfSSL_OCSP_check_validity(WOLFSSL_ASN1_TIME* thisupd,
     WOLFSSL_ASN1_TIME* nextupd, long sec, long maxsec);
@@ -132,8 +130,6 @@ WOLFSSL_API int wolfSSL_OCSP_resp_count(WOLFSSL_OCSP_BASICRESP *bs);
 WOLFSSL_API WOLFSSL_OCSP_SINGLERESP* wolfSSL_OCSP_resp_get0(
     WOLFSSL_OCSP_BASICRESP *bs, int idx);
 
-#endif
-#ifdef OPENSSL_EXTRA
 WOLFSSL_API int wolfSSL_OCSP_REQUEST_add_ext(OcspRequest* req,
         WOLFSSL_X509_EXTENSION* ext, int idx);
 WOLFSSL_API OcspResponse* wolfSSL_OCSP_response_create(int status,
@@ -148,7 +144,7 @@ WOLFSSL_API int wolfSSL_OCSP_request_add1_nonce(OcspRequest* req,
         unsigned char* val, int sz);
 WOLFSSL_API int wolfSSL_OCSP_check_nonce(OcspRequest* req,
         WOLFSSL_OCSP_BASICRESP* bs);
-#endif
+#endif /* OPENSSL_EXTRA */
 
 
 #ifdef __cplusplus

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3690,8 +3690,7 @@ WOLFSSL_API void wolfSSL_CTX_SetPerformTlsRecordProcessingCb(WOLFSSL_CTX* ctx,
     WOLFSSL_API void wolfSSL_CertManagerFree(WOLFSSL_CERT_MANAGER* cm);
     WOLFSSL_API int wolfSSL_CertManager_up_ref(WOLFSSL_CERT_MANAGER* cm);
 
-#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
-    && defined(HAVE_OID_DECODING)
+#ifdef WC_ASN_UNKNOWN_EXT_CB
     WOLFSSL_API void wolfSSL_CertManagerSetUnknownExtCallback(
         WOLFSSL_CERT_MANAGER* cm,
         wc_UnknownExtCallback cb);

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1418,10 +1418,10 @@ struct DNS_entry {
     int        type;   /* i.e. ASN_DNS_TYPE */
     int        len;    /* actual DNS len */
     char*      name;   /* actual DNS name */
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME)
+#ifdef WOLFSSL_IP_ALT_NAME
     char*      ipString; /* human readable form of IP address */
 #endif
-#if defined(OPENSSL_ALL)
+#ifdef WOLFSSL_RID_ALT_NAME
     char*      ridString; /* human readable form of registeredID */
 #endif
 
@@ -1714,7 +1714,7 @@ struct DecodedCert {
     word32  extensionsIdx;           /* if want to go back and parse later */
     const byte* extAuthInfo;         /* Authority Information Access URI */
     int     extAuthInfoSz;           /* length of the URI                */
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
+#ifdef WOLFSSL_ASN_CA_ISSUER
     const byte* extAuthInfoCaIssuer; /* Authority Info Access caIssuer URI */
     int     extAuthInfoCaIssuerSz;   /* length of the caIssuer URI         */
 #endif
@@ -1804,7 +1804,7 @@ struct DecodedCert {
     char*   subjectSN;
     int     subjectSNLen;
     char    subjectSNEnc;
-    #ifdef WOLFSSL_CERT_NAME_ALL
+#ifdef WOLFSSL_CERT_NAME_ALL
     char*   subjectN;
     int     subjectNLen;
     char    subjectNEnc;
@@ -1817,7 +1817,7 @@ struct DecodedCert {
     char*   subjectDNQ;
     int     subjectDNQLen;
     char    subjectDNQEnc;
-    #endif /*WOLFSSL_CERT_NAME_ALL */
+#endif /* WOLFSSL_CERT_NAME_ALL */
     char*   subjectC;
     int     subjectCLen;
     char    subjectCEnc;
@@ -1882,7 +1882,7 @@ struct DecodedCert {
     char*   issuerEmail;
     int     issuerEmailLen;
 #endif /* WOLFSSL_HAVE_ISSUER_NAMES */
-#endif /* defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT) */
+#endif /* WOLFSSL_CERT_GEN || WOLFSSL_CERT_EXT */
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     /* WOLFSSL_X509_NAME structures (used void* to avoid including ssl.h) */
     void* issuerName;
@@ -1962,7 +1962,7 @@ struct DecodedCert {
     byte extSubjAltNameSet : 1;
     byte inhibitAnyOidSet : 1;
     byte selfSigned : 1;           /* Indicates subject and issuer are same */
-#if defined(WOLFSSL_SEP) || defined(WOLFSSL_QT)
+#ifdef WOLFSSL_SEP
     byte extCertPolicySet : 1;
 #endif
     byte extCRLdistCrit : 1;
@@ -1988,7 +1988,7 @@ struct DecodedCert {
     byte extAltSigAlgSet : 1;
     byte extAltSigValSet : 1;
 #endif /* WOLFSSL_DUAL_ALG_CERTS */
-#if defined(WOLFSSL_SEP) || defined(WOLFSSL_QT)
+#ifdef WOLFSSL_SEP
     byte extCertPolicyCrit : 1;
 #endif
 #ifdef WOLFSSL_CERT_REQ
@@ -2040,7 +2040,7 @@ struct Signer {
 #ifndef IGNORE_NAME_CONSTRAINTS
         Base_entry* permittedNames;
         Base_entry* excludedNames;
-#endif /* IGNORE_NAME_CONSTRAINTS */
+#endif /* !IGNORE_NAME_CONSTRAINTS */
     byte    subjectNameHash[SIGNER_DIGEST_SIZE];
                                      /* sha hash of names in certificate */
     #if defined(HAVE_OCSP) || defined(HAVE_CRL)
@@ -2263,8 +2263,7 @@ WOLFSSL_LOCAL int wc_GetKeyOID(byte* key, word32 keySz, const byte** curveOID,
         word32* oidSz, int* algoID, void* heap);
 
 typedef struct tm wolfssl_tm;
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_MYSQL_COMPATIBLE) || defined(OPENSSL_EXTRA) || \
-    defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
+#ifdef WOLFSSL_ASN_TIME_STRING
 WOLFSSL_LOCAL int GetTimeString(byte* date, int format, char* buf, int len);
 #endif
 #if !defined(NO_ASN_TIME) && !defined(USER_TIME) && \
@@ -2431,13 +2430,12 @@ WOLFSSL_LOCAL int AllocCopyDer(DerBuffer** der, const unsigned char* buff,
     word32 length, int type, void* heap);
 WOLFSSL_LOCAL void FreeDer(DerBuffer** der);
 
-#if (defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_EXT)) || \
-    (defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA))
+#ifdef WOLFSSL_ASN_PARSE_KEYUSAGE
 WOLFSSL_LOCAL int ParseKeyUsageStr(const char* value, word16* keyUsage,
         void* heap);
 WOLFSSL_LOCAL int ParseExtKeyUsageStr(const char* value, byte* extKeyUsage,
         void* heap);
-#endif /* (CERT_GEN && CERT_EXT) || (OPENSSL_ALL || OPENSSL_EXTRA) */
+#endif
 
 #endif /* !NO_CERTS */
 
@@ -2529,8 +2527,7 @@ struct CertStatus {
     byte nextDate[MAX_DATE_SIZE];
     byte thisDateFormat;
     byte nextDateFormat;
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || \
-    defined(WOLFSSL_HAPROXY) || defined(HAVE_LIGHTY)
+#ifdef WOLFSSL_OCSP_PARSE_STATUS
     WOLFSSL_ASN1_TIME thisDateParsed;
     WOLFSSL_ASN1_TIME nextDateParsed;
     byte* thisDateAsn;
@@ -2615,10 +2612,6 @@ struct OcspRequest {
     int    serialSz;
 #ifdef OPENSSL_EXTRA
     WOLFSSL_ASN1_INTEGER* serialInt;
-#endif
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || \
-    defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_APACHE_HTTPD) || \
-    defined(HAVE_LIGHTY)
     void* cid; /* WOLFSSL_OCSP_CERTID kept to free */
 #endif
     byte*  url;      /* copy of the extAuthInfo in source cert */

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1660,8 +1660,7 @@ typedef struct TrustedPeerCert TrustedPeerCert;
 typedef struct SignatureCtx SignatureCtx;
 typedef struct CertSignCtx  CertSignCtx;
 
-#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
-    && defined(HAVE_OID_DECODING)
+#ifdef WC_ASN_UNKNOWN_EXT_CB
 typedef int (*wc_UnknownExtCallback)(const word16* oid, word32 oidSz, int crit,
                                      const unsigned char* der, word32 derSz);
 typedef int (*wc_UnknownExtCallbackEx)(const word16* oid, word32 oidSz,
@@ -1887,7 +1886,7 @@ struct DecodedCert {
     /* WOLFSSL_X509_NAME structures (used void* to avoid including ssl.h) */
     void* issuerName;
     void* subjectName;
-#endif /* OPENSSL_EXTRA */
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
 #ifdef WOLFSSL_SEP
     int     deviceTypeSz;
     byte*   deviceType;
@@ -1997,8 +1996,7 @@ struct DecodedCert {
 #ifdef HAVE_RPK
     byte isRPK : 1;   /* indicate the cert is Raw-Public-Key cert in RFC7250 */
 #endif
-#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
-    && defined(HAVE_OID_DECODING)
+#ifdef WC_ASN_UNKNOWN_EXT_CB
     wc_UnknownExtCallback unknownExtCallback;
     wc_UnknownExtCallbackEx unknownExtCallbackEx;
     void *unknownExtCallbackExCtx;
@@ -2141,15 +2139,16 @@ typedef enum MimeStatus
 } MimeStatus;
 #endif /* HAVE_SMIME */
 
-
 WOLFSSL_LOCAL int HashIdAlg(word32 oidSum);
 WOLFSSL_LOCAL int CalcHashId(const byte* data, word32 len, byte* hash);
 WOLFSSL_LOCAL int CalcHashId_ex(const byte* data, word32 len, byte* hash,
     int hashAlg);
 WOLFSSL_LOCAL int GetName(DecodedCert* cert, int nameType, int maxIdx);
 
-WOLFSSL_ASN_API int wc_BerToDer(const byte* ber, word32 berSz, byte* der,
+#ifdef ASN_BER_TO_DER
+WOLFSSL_API int wc_BerToDer(const byte* ber, word32 berSz, byte* der,
                                 word32* derSz);
+#endif
 WOLFSSL_LOCAL int StreamOctetString(const byte* inBuf, word32 inBufSz,
     byte* out, word32* outSz, word32* idx);
 
@@ -2167,11 +2166,10 @@ WOLFSSL_ASN_API void FreeDecodedCert(DecodedCert* cert);
 WOLFSSL_ASN_API int  ParseCert(DecodedCert* cert, int type, int verify,
                                void* cm);
 
-#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
-    && defined(HAVE_OID_DECODING)
-WOLFSSL_ASN_API int wc_SetUnknownExtCallback(DecodedCert* cert,
+#ifdef WC_ASN_UNKNOWN_EXT_CB
+WOLFSSL_API int wc_SetUnknownExtCallback(DecodedCert* cert,
                                              wc_UnknownExtCallback cb);
-WOLFSSL_ASN_API int wc_SetUnknownExtCallbackEx(DecodedCert* cert,
+WOLFSSL_API int wc_SetUnknownExtCallbackEx(DecodedCert* cert,
                                                wc_UnknownExtCallbackEx cb,
                                                void *ctx);
 #endif

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -361,7 +361,6 @@ typedef struct WOLFSSL_ASN1_INTEGER {
 #endif
 #endif /* WOLFSSL_CERT_GEN || WOLFSSL_CERT_EXT */
 
-#if defined(WOLFSSL_CERT_GEN) || defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 #ifdef WOLFSSL_MULTI_ATTRIB
 #ifndef CTC_MAX_ATTRIB
     #define CTC_MAX_ATTRIB 4
@@ -375,7 +374,6 @@ typedef struct NameAttrib {
     char value[CTC_NAME_SIZE];   /* name */
 } NameAttrib;
 #endif /* WOLFSSL_MULTI_ATTRIB */
-#endif /* WOLFSSL_CERT_GEN || OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
 
 #ifdef WOLFSSL_CUSTOM_OID
 typedef struct CertOidField {

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -345,8 +345,7 @@ struct PKCS7 {
     word32 plainDigestSz;
     word32 pkcs7DigestSz;
 
-#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
-    && defined(HAVE_OID_DECODING)
+#ifdef WC_ASN_UNKNOWN_EXT_CB
     wc_UnknownExtCallback unknownExtCallback;
 #endif
 
@@ -363,8 +362,7 @@ struct PKCS7 {
 };
 
 WOLFSSL_API PKCS7* wc_PKCS7_New(void* heap, int devId);
-#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
-    && defined(HAVE_OID_DECODING)
+#ifdef WC_ASN_UNKNOWN_EXT_CB
     WOLFSSL_API void wc_PKCS7_SetUnknownExtCallback(PKCS7* pkcs7,
         wc_UnknownExtCallback cb);
 #endif

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3023,13 +3023,15 @@ extern void uITRON4_free(void *p) ;
 #endif
 
 /* ASN Unknown Extension Callback support */
-#if defined(WOLFSSL_CUSTOM_OID) && defined(HAVE_OID_DECODING)
+#if defined(WOLFSSL_CUSTOM_OID) && defined(HAVE_OID_DECODING) && \
+    defined(WOLFSSL_ASN_TEMPLATE)
     #undef  WC_ASN_UNKNOWN_EXT_CB
     #define WC_ASN_UNKNOWN_EXT_CB
-#endif
-
-#if defined(WC_ASN_UNKNOWN_EXT_CB) && !defined(WOLFSSL_ASN_TEMPLATE)
-    #error ASN unknown extension callback is only supported with ASN template
+#else
+    /* if user supplied build option and not using ASN template, raise error */
+    #if defined(WC_ASN_UNKNOWN_EXT_CB) && !defined(WOLFSSL_ASN_TEMPLATE)
+        #error ASN unknown extension callback is only supported with ASN template
+    #endif
 #endif
 
 

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2889,6 +2889,116 @@ extern void uITRON4_free(void *p) ;
     #define WOLFSSL_ASN_TEMPLATE
 #endif
 
+
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
+    #undef  WOLFSSL_ASN_ALL
+    #define WOLFSSL_ASN_ALL
+#endif
+
+/* Enable all parsing features for ASN */
+#ifdef WOLFSSL_ASN_ALL
+    /* Alternate Names */
+    #undef  WOLFSSL_ALT_NAMES
+    #define WOLFSSL_ALT_NAMES
+
+    /* Alternate Name: human readable form of IP address*/
+    #undef  WOLFSSL_IP_ALT_NAME
+    #define WOLFSSL_IP_ALT_NAME
+
+    /* Alternate name: human readable form of registered ID */
+    #undef  WOLFSSL_RID_ALT_NAME
+    #define WOLFSSL_RID_ALT_NAME
+
+    /* CA Issuer URI */
+    #undef  WOLFSSL_ASN_CA_ISSUER
+    #define WOLFSSL_ASN_CA_ISSUER
+
+    /* FPKI (Federal PKI) extensions */
+    #undef  WOLFSSL_FPKI
+    #define WOLFSSL_FPKI
+
+    /* Certificate policies */
+    #undef  WOLFSSL_SEP
+    #define WOLFSSL_SEP
+
+    /* Support for full AuthorityKeyIdentifier extension.
+     * Only supports copying full AKID from an existing certificate */
+    #undef  WOLFSSL_AKID_NAME
+    #define WOLFSSL_AKID_NAME
+
+    #undef  WOLFSSL_CERT_EXT
+    #define WOLFSSL_CERT_EXT
+
+    /* Support for SubjectDirectoryAttributes extension */
+    #undef  WOLFSSL_SUBJ_DIR_ATTR
+    #define WOLFSSL_SUBJ_DIR_ATTR
+
+    /* Support for SubjectInfoAccess extension */
+    #undef  WOLFSSL_SUBJ_INFO_ACC
+    #define WOLFSSL_SUBJ_INFO_ACC
+
+    #undef  WOLFSSL_CERT_NAME_ALL
+    #define WOLFSSL_CERT_NAME_ALL
+
+    #undef  WOLFSSL_HAVE_ISSUER_NAMES
+    #define WOLFSSL_HAVE_ISSUER_NAMES
+
+    #undef  WOLFSSL_MULTI_ATTRIB
+    #define WOLFSSL_MULTI_ATTRIB
+
+    #undef  ASN_BER_TO_DER
+    #define ASN_BER_TO_DER
+
+    #undef  WOLFSSL_CUSTOM_OID
+    #define WOLFSSL_CUSTOM_OID
+
+    #undef  HAVE_OID_ENCODING
+    #define HAVE_OID_ENCODING
+
+    #undef  HAVE_OID_DECODING
+    #define HAVE_OID_DECODING
+
+    #undef  HAVE_SMIME
+    #define HAVE_SMIME
+
+    #undef  WOLFSSL_ASN_TIME_STRING
+    #define WOLFSSL_ASN_TIME_STRING
+
+    #undef  WOLFSSL_ASN_PARSE_KEYUSAGE
+    #define WOLFSSL_ASN_PARSE_KEYUSAGE
+
+    #undef  WOLFSSL_OCSP_PARSE_STATUS
+    #define WOLFSSL_OCSP_PARSE_STATUS
+#endif
+
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_MYSQL_COMPATIBLE) || \
+    defined(OPENSSL_EXTRA) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
+    #undef  WOLFSSL_ASN_TIME_STRING
+    #define WOLFSSL_ASN_TIME_STRING
+#endif
+
+#if (defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_EXT)) || \
+    (defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA))
+    #undef  WOLFSSL_ASN_PARSE_KEYUSAGE
+    #define WOLFSSL_ASN_PARSE_KEYUSAGE
+#endif
+
+#if defined(HAVE_OCSP) && !defined(WOLFCRYPT_ONLY) && \
+    (defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || \
+     defined(WOLFSSL_HAPROXY) || defined(HAVE_LIGHTY) || \
+     defined(WOLFSSL_APACHE_HTTPD))
+    #undef  WOLFSSL_OCSP_PARSE_STATUS
+    #define WOLFSSL_OCSP_PARSE_STATUS
+#endif
+
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || \
+    defined(WOLFSSL_CERT_GEN)
+    #undef  WOLFSSL_MULTI_ATTRIB
+    #define WOLFSSL_MULTI_ATTRIB
+#endif
+
+
+/* Linux Kernel Module */
 #ifdef WOLFSSL_LINUXKM
     #ifdef HAVE_CONFIG_H
         #include <config.h>

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -415,36 +415,31 @@
  * ---------------------------------------------------------------------------
  */
 #ifdef WOLFSSL_DUAL_ALG_CERTS
+    #ifdef NO_RSA
+        #error "Need RSA or else dual alg cert example will not work."
+    #endif
 
-#ifndef WOLFSSL_ASN_TEMPLATE
-    #error "Dual alg cert support requires the ASN.1 template feature."
-#endif
+    #ifndef HAVE_ECC
+        #error "Need ECDSA or else dual alg cert example will not work."
+    #endif
 
-#ifdef NO_RSA
-    #error "Need RSA or else dual alg cert example will not work."
-#endif
+    #undef WOLFSSL_CERT_GEN
+    #define WOLFSSL_CERT_GEN
 
-#ifndef HAVE_ECC
-    #error "Need ECDSA or else dual alg cert example will not work."
-#endif
+    #undef WOLFSSL_CUSTOM_OID
+    #define WOLFSSL_CUSTOM_OID
 
-#undef WOLFSSL_CERT_GEN
-#define WOLFSSL_CERT_GEN
+    #undef HAVE_OID_ENCODING
+    #define HAVE_OID_ENCODING
 
-#undef WOLFSSL_CUSTOM_OID
-#define WOLFSSL_CUSTOM_OID
+    #undef WOLFSSL_CERT_EXT
+    #define WOLFSSL_CERT_EXT
 
-#undef HAVE_OID_ENCODING
-#define HAVE_OID_ENCODING
+    #undef OPENSSL_EXTRA
+    #define OPENSSL_EXTRA
 
-#undef WOLFSSL_CERT_EXT
-#define WOLFSSL_CERT_EXT
-
-#undef OPENSSL_EXTRA
-#define OPENSSL_EXTRA
-
-#undef HAVE_OID_DECODING
-#define HAVE_OID_DECODING
+    #undef HAVE_OID_DECODING
+    #define HAVE_OID_DECODING
 #endif /* WOLFSSL_DUAL_ALG_CERTS */
 
 
@@ -1648,6 +1643,7 @@ extern void uITRON4_free(void *p) ;
     #define WOLFSSL_STATIC_PSK
     /* Server side support to be added at a later date. */
     #define NO_WOLFSSL_SERVER
+
     /* Need WOLFSSL_PUBLIC_ASN to use ProcessPeerCert callback. */
     #define WOLFSSL_PUBLIC_ASN
 
@@ -2889,6 +2885,9 @@ extern void uITRON4_free(void *p) ;
     #define WOLFSSL_ASN_TEMPLATE
 #endif
 
+#if defined(WOLFSSL_DUAL_ALG_CERTS) && !defined(WOLFSSL_ASN_TEMPLATE)
+    #error "Dual alg cert support requires the ASN.1 template feature."
+#endif
 
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
     #undef  WOLFSSL_ASN_ALL
@@ -2926,6 +2925,7 @@ extern void uITRON4_free(void *p) ;
     #undef  WOLFSSL_AKID_NAME
     #define WOLFSSL_AKID_NAME
 
+    /* Extended ASN.1 parsing support (typically used with cert gen) */
     #undef  WOLFSSL_CERT_EXT
     #define WOLFSSL_CERT_EXT
 
@@ -2940,35 +2940,50 @@ extern void uITRON4_free(void *p) ;
     #undef  WOLFSSL_CERT_NAME_ALL
     #define WOLFSSL_CERT_NAME_ALL
 
+    /* Store pointers to issuer name components and their lengths and encodings. */
     #undef  WOLFSSL_HAVE_ISSUER_NAMES
     #define WOLFSSL_HAVE_ISSUER_NAMES
 
+    /* Additional ASN.1 encoded name fields. See CTC_MAX_ATTRIB for max limit */
     #undef  WOLFSSL_MULTI_ATTRIB
     #define WOLFSSL_MULTI_ATTRIB
 
+    /* Parsing of indefinite length encoded ASN.1
+     * Optionally used by PKCS7/PKCS12 */
     #undef  ASN_BER_TO_DER
     #define ASN_BER_TO_DER
 
+    /* Enable custom OID support for subject and request extensions */
     #undef  WOLFSSL_CUSTOM_OID
     #define WOLFSSL_CUSTOM_OID
 
+    /* Support for full OID (not just sum) encoding */
     #undef  HAVE_OID_ENCODING
     #define HAVE_OID_ENCODING
 
+    /* Support for full OID (not just sum) decoding */
     #undef  HAVE_OID_DECODING
     #define HAVE_OID_DECODING
 
+    /* S/MIME - Secure Multipurpose Internet Mail Extension (used with PKCS7) */
     #undef  HAVE_SMIME
     #define HAVE_SMIME
 
+    /* Enable compatibility layer function for getting time string */
     #undef  WOLFSSL_ASN_TIME_STRING
     #define WOLFSSL_ASN_TIME_STRING
 
+    /* Support for parsing key usage */
     #undef  WOLFSSL_ASN_PARSE_KEYUSAGE
     #define WOLFSSL_ASN_PARSE_KEYUSAGE
 
+    /* Support for parsing OCSP status */
     #undef  WOLFSSL_OCSP_PARSE_STATUS
     #define WOLFSSL_OCSP_PARSE_STATUS
+
+    /* Extended Key Usage */
+    #undef  WOLFSSL_EKU_OID
+    #define WOLFSSL_EKU_OID
 #endif
 
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_MYSQL_COMPATIBLE) || \
@@ -2995,6 +3010,26 @@ extern void uITRON4_free(void *p) ;
     defined(WOLFSSL_CERT_GEN)
     #undef  WOLFSSL_MULTI_ATTRIB
     #define WOLFSSL_MULTI_ATTRIB
+#endif
+
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+    #undef  WOLFSSL_EKU_OID
+    #define WOLFSSL_EKU_OID
+#endif
+
+/* Disable time checking if no timer */
+#if defined(NO_ASN_TIME)
+    #define NO_ASN_TIME_CHECK
+#endif
+
+/* ASN Unknown Extension Callback support */
+#if defined(WOLFSSL_CUSTOM_OID) && defined(HAVE_OID_DECODING)
+    #undef  WC_ASN_UNKNOWN_EXT_CB
+    #define WC_ASN_UNKNOWN_EXT_CB
+#endif
+
+#if defined(WC_ASN_UNKNOWN_EXT_CB) && !defined(WOLFSSL_ASN_TEMPLATE)
+    #error ASN unknown extension callback is only supported with ASN template
 #endif
 
 
@@ -3124,28 +3159,13 @@ extern void uITRON4_free(void *p) ;
     #define WOLFSSL_SESSION_ID_CTX
 #endif /* OPENSSL_EXTRA && !OPENSSL_COEXIST */
 
-/* ---------------------------------------------------------------------------
- * Special small OpenSSL compat layer for certs
- * ---------------------------------------------------------------------------
- */
 #ifdef OPENSSL_EXTRA_X509_SMALL
-    #undef WOLFSSL_EKU_OID
-    #define WOLFSSL_EKU_OID
-
-    #undef WOLFSSL_MULTI_ATTRIB
-    #define WOLFSSL_MULTI_ATTRIB
-
     #undef WOLFSSL_NO_OPENSSL_RAND_CB
     #define WOLFSSL_NO_OPENSSL_RAND_CB
-#endif /* OPENSSL_EXTRA_X509_SMALL */
+#endif
 
 #ifdef HAVE_SNI
     #define SSL_CTRL_SET_TLSEXT_HOSTNAME 55
-#endif
-
-/* Disable time checking if no timer */
-#if defined(NO_ASN_TIME)
-    #define NO_ASN_TIME_CHECK
 #endif
 
 /* both CURVE and ED small math should be enabled */

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2940,7 +2940,7 @@ extern void uITRON4_free(void *p) ;
     #undef  WOLFSSL_CERT_NAME_ALL
     #define WOLFSSL_CERT_NAME_ALL
 
-    /* Store pointers to issuer name components and their lengths and encodings. */
+    /* Store pointers to issuer name components (lengths and encodings) */
     #undef  WOLFSSL_HAVE_ISSUER_NAMES
     #define WOLFSSL_HAVE_ISSUER_NAMES
 
@@ -3030,7 +3030,8 @@ extern void uITRON4_free(void *p) ;
 #else
     /* if user supplied build option and not using ASN template, raise error */
     #if defined(WC_ASN_UNKNOWN_EXT_CB) && !defined(WOLFSSL_ASN_TEMPLATE)
-        #error ASN unknown extension callback is only supported with ASN template
+        #error ASN unknown extension callback is only supported \
+            with ASN template
     #endif
 #endif
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -832,7 +832,7 @@ typedef struct w64wrapper {
                 #include <stdio.h>
                 #define XSPRINTF sprintf
                 /* snprintf not available for C89, so remap using macro */
-                #define XSNPRINTF(f, len, ...) sprintf(f, ...)
+                #define XSNPRINTF(f, len, ...) sprintf(f, __VA_ARGS__)
             #else
                 #include <stdio.h>
                 #define XSNPRINTF snprintf

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -875,7 +875,8 @@ typedef struct w64wrapper {
         #endif /* !XSNPRINTF */
 
         #if defined(WOLFSSL_CERT_EXT) || defined(OPENSSL_EXTRA) || \
-            defined(HAVE_ALPN) || defined(WOLFSSL_SNIFFER)
+            defined(HAVE_ALPN) || defined(WOLFSSL_SNIFFER) || \
+            defined(WOLFSSL_ASN_PARSE_KEYUSAGE)
             /* use only Thread Safe version of strtok */
             #if defined(USE_WOLF_STRTOK)
                 #define XSTRTOK(s1,d,ptr) wc_strtok((s1),(d),(ptr))


### PR DESCRIPTION
# Description

ASN macro simplification. 
* Added new `--enable-asn=all` and `WOLFSSL_ASN_ALL` option. 
* Added granular macros for ASN features like: `WOLFSSL_ASN_CA_ISSUER`, `WOLFSSL_ASN_PARSE_KEYUSAGE`, `WOLFSSL_ASN_TIME_STRING`, `WOLFSSL_OCSP_PARSE_STATUS`.
* Fixed issues with `SetDNSEntry` and `GenerateDNSEntryRIDString` with possible leaks and return code checking.
* Split up the WOLFSSL_SEP and WOLFSSL_CERT_EXT logic so they can be used individually.
* Fix bad C89 XSNPRINTF remap.
* Improved logic on `ASN_BER_TO_DER`. 
* Improved logic on unknown extension callback (new `WC_ASN_UNKNOWN_EXT_CB` gate).
* Fail with NOT_COMPILED_IN if someone tries to use ConfirmSignature with NO_ASN_CRYPT.
* Fixed benchmark.c error without ChaCha and unused encrypt_only.

# Testing

```
./configure --enable-asn=all && make check
./configure --enable-asn=all --enable-opensslall && make check
./configure --enable-asn=all --enable-all && make check

./configure --enable-asn=all,original && make check
./configure --enable-asn=all,original --enable-opensslall && make check
./configure --enable-asn=all,original --enable-all && make check

./configure --enable-asn=all --enable-cryptonly && make check
./configure --enable-asn=all,original --enable-cryptonly && make check

./configure --disable-shared --enable-asn=template,nocrypt --enable-cryptonly && make check
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
