### PR TITLE
20240725-wc_DhAgree_ct

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -82334,6 +82334,30 @@ static int test_wolfSSL_DH(void)
     ExpectNotNull(dh->g);
     ExpectTrue(pt == buf);
     ExpectIntEQ(DH_generate_key(dh), 1);
+
+    /* first, test for expected successful key agreement. */
+    if (EXPECT_SUCCESS()) {
+        DH *dh2 = NULL;
+        unsigned char buf2[268];
+        int sz1 = 0, sz2 = 0;
+
+        ExpectNotNull(dh2 = d2i_DHparams(NULL, &pt, len));
+        ExpectIntEQ(DH_generate_key(dh2), 1);
+
+        ExpectIntGT(sz1=DH_compute_key(buf, dh2->pub_key, dh), 0);
+        ExpectIntGT(sz2=DH_compute_key(buf2, dh->pub_key, dh2), 0);
+        ExpectIntEQ(sz1, sz2);
+        ExpectIntEQ(XMEMCMP(buf, buf2, (size_t)sz1), 0);
+
+        ExpectIntNE(sz1 = DH_size(dh), 0);
+        ExpectIntEQ(DH_compute_key_padded(buf, dh2->pub_key, dh), sz1);
+        ExpectIntEQ(DH_compute_key_padded(buf2, dh->pub_key, dh2), sz1);
+        ExpectIntEQ(XMEMCMP(buf, buf2, (size_t)sz1), 0);
+
+        if (dh2 != NULL)
+            DH_free(dh2);
+    }
+
     ExpectIntEQ(DH_generate_key(dh), 1);
     ExpectIntEQ(DH_compute_key(NULL, NULL, NULL), -1);
     ExpectNotNull(pub = BN_new());

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -22785,6 +22785,38 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t dh_test(void)
     if (agreeSz != agreeSz2 || XMEMCMP(agree, agree2, agreeSz)) {
         ERROR_OUT(WC_TEST_RET_ENC_NC, done);
     }
+
+#if (!defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)) && \
+            !defined(HAVE_SELFTEST)
+    agreeSz = DH_TEST_BUF_SIZE;
+    agreeSz2 = DH_TEST_BUF_SIZE;
+
+    ret = wc_DhAgree_ct(key, agree, &agreeSz, priv, privSz, pub2, pubSz2);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
+
+    ret = wc_DhAgree_ct(key2, agree2, &agreeSz2, priv2, privSz2, pub, pubSz);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
+
+#ifdef WOLFSSL_PUBLIC_MP
+    if (agreeSz != (word32)mp_unsigned_bin_size(&key->p))
+    {
+        ERROR_OUT(WC_TEST_RET_ENC_NC, done);
+    }
+#endif
+
+    if (agreeSz != agreeSz2)
+    {
+        ERROR_OUT(WC_TEST_RET_ENC_NC, done);
+    }
+
+    if (XMEMCMP(agree, agree2, agreeSz) != 0)
+    {
+        ERROR_OUT(WC_TEST_RET_ENC_NC, done);
+    }
+#endif /* (!HAVE_FIPS || FIPS_VERSION_GE(7,0)) && !HAVE_SELFTEST */
+
 #endif /* !WC_NO_RNG */
 
 #if defined(WOLFSSL_KEY_GEN) && !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)

--- a/wolfssl/openssl/dh.h
+++ b/wolfssl/openssl/dh.h
@@ -67,6 +67,9 @@ WOLFSSL_API int wolfSSL_DH_size(WOLFSSL_DH* dh);
 WOLFSSL_API int wolfSSL_DH_generate_key(WOLFSSL_DH* dh);
 WOLFSSL_API int wolfSSL_DH_compute_key(unsigned char* key, const WOLFSSL_BIGNUM* pub,
                                      WOLFSSL_DH* dh);
+WOLFSSL_API int wolfSSL_DH_compute_key_padded(unsigned char* key,
+                                const WOLFSSL_BIGNUM* otherPub, WOLFSSL_DH* dh);
+
 WOLFSSL_API int wolfSSL_DH_LoadDer(WOLFSSL_DH* dh, const unsigned char* derBuf,
                                    int derSz);
 WOLFSSL_API int wolfSSL_DH_set_length(WOLFSSL_DH* dh, long len);
@@ -91,6 +94,7 @@ typedef WOLFSSL_DH                   DH;
 #define DH_size         wolfSSL_DH_size
 #define DH_generate_key wolfSSL_DH_generate_key
 #define DH_compute_key  wolfSSL_DH_compute_key
+#define DH_compute_key_padded wolfSSL_DH_compute_key_padded
 #define DH_set_length   wolfSSL_DH_set_length
 #define DH_set0_pqg     wolfSSL_DH_set0_pqg
 #define DH_get0_pqg     wolfSSL_DH_get0_pqg

--- a/wolfssl/wolfcrypt/dh.h
+++ b/wolfssl/wolfcrypt/dh.h
@@ -151,6 +151,9 @@ WOLFSSL_API int wc_DhGenerateKeyPair(DhKey* key, WC_RNG* rng, byte* priv,
 WOLFSSL_API int wc_DhAgree(DhKey* key, byte* agree, word32* agreeSz,
                        const byte* priv, word32 privSz, const byte* otherPub,
                        word32 pubSz);
+WOLFSSL_API int wc_DhAgree_ct(DhKey* key, byte* agree, word32* agreeSz,
+                       const byte* priv, word32 privSz, const byte* otherPub,
+                       word32 pubSz);
 
 WOLFSSL_API int wc_DhKeyDecode(const byte* input, word32* inOutIdx, DhKey* key,
                            word32 inSz); /* wc_DhKeyDecode is in asn.c */


### PR DESCRIPTION
add constant time DH key agreement APIs and related logic:
* `wc_DhAgree_ct()`
* `wolfSSL_DH_compute_key_padded()`

tested with `wolfssl-multi-test.sh ... super-quick-check all-enable-fastmath clang-tidy-intmath intmath-sanitizer`
