### PR TITLE
Dilithium: fix check hint

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -32389,6 +32389,12 @@ static int test_wc_dilithium_verify(void)
             0);
         ExpectIntEQ(res, 0);
         sig[100] ^= 0x80;
+
+        /* Set all indeces to 0. */
+        XMEMSET(sig + sigLen - 4, 0, 4);
+        ExpectIntEQ(wc_dilithium_verify_msg(sig, sigLen, msg, 32, &res, key),
+            SIG_VERIFY_E);
+        ExpectIntEQ(res, 0);
     }
 #endif
 

--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -3183,11 +3183,11 @@ static int dilithium_check_hint(const byte* h, byte k, byte omega)
     unsigned int i;
 
     /* Skip polynomial index while count is 0. */
-    while ((h[omega + o] == 0) && (o < k)) {
+    while ((o < k) && (h[omega + o] == 0)) {
         o++;
     }
     /* Check all possible hints. */
-    for (i = 1; i < omega; i++) {
+    for (i = 1; (o < k) && (i < omega); i++) {
         /* Done with polynomial if index equals count of hints. */
         if (i == h[omega + o]) {
             /* Next polynomial index while count is index. */


### PR DESCRIPTION
# Description

When all indeces are 0, then don't check hints against indeces.

# Testing

./configure '--disable-shared' '--enable-experimental' '--enable-dilithium'
valgrind ./tests/unit.test -test_wc_dilithium_verify
(new test case in test_wc_dilithium_verify() will have buffer overrun without fix)

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
