### PR TITLE
Remove HAVE_NULL_CIPHER from --enable-openssh

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3570,11 +3570,6 @@ AC_ARG_ENABLE([nullcipher],
     [ ENABLED_NULL_CIPHER=no ]
     )
 
-if test "$ENABLED_OPENSSH" = "yes"
-then
-    ENABLED_NULL_CIPHER="yes"
-fi
-
 if test "$ENABLED_NULL_CIPHER" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_NULL_CIPHER"


### PR DESCRIPTION
# Description

HAVE_NULL_CIPHER is TLS functionality which shouldn't be necessary for openSSH

Fixes zd#18356

# Testing

Tested using OSP openSSH build test

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
