### PR TITLE
Don't attempt to include system headers when not required

### DIFF
--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -59,7 +59,9 @@
 #endif /* WOLFSSL_LINUXKM */
 
 /* THREADING/MUTEX SECTION */
-#ifdef USE_WINDOWS_API
+#if defined(SINGLE_THREADED) && defined(NO_FILESYSTEM)
+    /* No system headers required for build. */
+#elif defined(USE_WINDOWS_API)
     #if defined(WOLFSSL_PTHREADS)
         #include <pthread.h>
     #endif


### PR DESCRIPTION
# Description

Some builds don't require system headers: no filesystem and single threaded.

# Testing

./configure '--disable-shared' '--disable-filesystem' '--enable-singlethreaded'

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
