### PR TITLE
Fix for .c files to ensure macro guards for wildcard

### DIFF
--- a/wolfcrypt/src/port/autosar/cryif.c
+++ b/wolfcrypt/src/port/autosar/cryif.c
@@ -28,13 +28,15 @@
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>
+
+#ifdef WOLFSSL_AUTOSAR
+#ifndef NO_WOLFSSL_AUTOSAR_CRYIF
+
 #include <wolfssl/version.h>
 #include <wolfssl/wolfcrypt/port/autosar/Csm.h>
 #include <wolfssl/wolfcrypt/port/autosar/CryIf.h>
 #include <wolfssl/wolfcrypt/port/autosar/Crypto.h>
 
-#ifdef WOLFSSL_AUTOSAR
-#ifndef NO_WOLFSSL_AUTOSAR_CRYIF
 
 #include <wolfssl/wolfcrypt/logging.h>
 

--- a/wolfcrypt/src/port/autosar/crypto.c
+++ b/wolfcrypt/src/port/autosar/crypto.c
@@ -25,12 +25,12 @@
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>
-#include <wolfssl/wolfcrypt/port/autosar/Csm.h>
-#include <wolfssl/wolfcrypt/port/autosar/Crypto.h>
 
 #ifdef WOLFSSL_AUTOSAR
 #ifndef NO_WOLFSSL_AUTOSAR_CRYPTO
 
+#include <wolfssl/wolfcrypt/port/autosar/Csm.h>
+#include <wolfssl/wolfcrypt/port/autosar/Crypto.h>
 #include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/aes.h>
 #include <wolfssl/wolfcrypt/random.h>

--- a/wolfcrypt/src/port/autosar/csm.c
+++ b/wolfcrypt/src/port/autosar/csm.c
@@ -25,13 +25,14 @@
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>
+
+#ifdef WOLFSSL_AUTOSAR
+#ifndef NO_WOLFSSL_AUTOSAR_CSM
+
 #include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/version.h>
 #include <wolfssl/wolfcrypt/port/autosar/Csm.h>
 #include <wolfssl/wolfcrypt/port/autosar/CryIf.h>
-
-#ifdef WOLFSSL_AUTOSAR
-#ifndef NO_WOLFSSL_AUTOSAR_CSM
 
 
 /* AutoSAR 4.4 */

--- a/wolfcrypt/src/port/autosar/test.c
+++ b/wolfcrypt/src/port/autosar/test.c
@@ -24,6 +24,9 @@
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>
+
+#ifdef WOLFSSL_AUTOSAR
+
 #include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/port/autosar/Csm.h>
 #define BLOCK_SIZE 16
@@ -428,3 +431,5 @@ int main(int argc, char* argv[])
 #endif /* REDIRECTION_CONFIG */
     return ret;
 }
+
+#endif /* WOLFSSL_AUTOSAR */


### PR DESCRIPTION
# Description

Fix for .c files to ensure macro guards for wildcard.

# Testing

Makefile.testwildcard:

```
rwildcard=$(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(subst *,%,$2),$d))
SOURCES:=$(call rwildcard,certs,*.c) $(call rwildcard,ctaocrypt,*.c) $(call rwildcard,cyassl,*.c) $(call rwildcard,examples,*.c) $(call rwildcard,src,*.c) $(call rwildcard,wolfcrypt,*.c) $(call rwildcard,wolfssl,*.c) \
    $(call rwildcard,sslSniffer,*.c) $(call rwildcard,tests,*.c) $(call rwildcard,testsuite,*.c) $(call rwildcard,wrapper,*.c)
OBJECTS:= $(patsubst %.c, %.o, $(SOURCES))

.PHONY: all
all: $(OBJECTS)

%.o: %.c
	gcc -c -I. -DWOLFSSL_USER_SETTINGS -DHAVE_NETDB_H -o $@ $<
	@echo "CC	$<	-o $@"

clean:
	@rm -rf $(OBJECTS)
```

Run: `make -f Makefile.testwildcard`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
