### PR TITLE
Build SHA3 assembly with INTEL_SPEEDUP

### DIFF
--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -399,6 +399,10 @@ function(generate_lib_src_list LIB_SOURCES)
 
               if(BUILD_SHA3)
                    list(APPEND LIB_SOURCES wolfcrypt/src/sha3.c)
+
+                   if(BUILD_INTELASM)
+                        list(APPEND LIB_SOURCES wolfcrypt/src/sha3_asm.S)
+                   endif()
               endif()
 
               if(BUILD_DH)
@@ -582,6 +586,10 @@ function(generate_lib_src_list LIB_SOURCES)
 
          if(NOT BUILD_FIPS_V2 AND BUILD_SHA3)
               list(APPEND LIB_SOURCES wolfcrypt/src/sha3.c)
+
+              if(BUILD_INTELASM)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/sha3_asm.S)
+              endif()
          endif()
     endif()
 


### PR DESCRIPTION
Make sure the file `sha3_asm.S` is compiled when `WOLFSSL_INTEL_ASM` is enabled using CMake.