### PR TITLE
Only run the google test if the WOLFSSL_EXTERNAL_TEST env var is set. 

### DIFF
--- a/scripts/google.test
+++ b/scripts/google.test
@@ -6,6 +6,11 @@ server=www.google.com
 
 [ ! -x ./examples/client/client ] && echo -e "\n\nClient doesn't exist" && exit 1
 
+if test -n "$WOLFSSL_NO_GOOGLE_TEST"; then
+    echo "WOLFSSL_NO_GOOGLE_TEST set, won't run"
+    exit 77
+fi
+
 if ! ./examples/client/client -V | grep -q 3; then
     echo 'skipping google.test because TLS1.2 is not available.' 1>&2
     exit 77

--- a/scripts/google.test
+++ b/scripts/google.test
@@ -6,8 +6,8 @@ server=www.google.com
 
 [ ! -x ./examples/client/client ] && echo -e "\n\nClient doesn't exist" && exit 1
 
-if test -n "$WOLFSSL_NO_GOOGLE_TEST"; then
-    echo "WOLFSSL_NO_GOOGLE_TEST set, won't run"
+if ! test -n "$WOLFSSL_EXTERNAL_TEST"; then
+    echo "WOLFSSL_EXTERNAL_TEST not set, won't run"
     exit 77
 fi
 


### PR DESCRIPTION
Fixes ZD18374

# Testing
Run: 
WOLFSSL_EXTERNAL_TEST=1 make check 

Then run: 
make check

Compare the difference. 
