### PR TITLE
20240804-SetDNSEntry-double-free

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -9177,7 +9177,7 @@ int EncryptContent(byte* input, word32 inputSz, byte* out, word32* outSz,
     word32 seqSz;
     word32 innerSz;
     int    ret;
-    int    version, id, blockSz = 0;
+    int    version, id = PBE_NONE, blockSz = 0;
 #ifdef WOLFSSL_SMALL_STACK
     byte*  saltTmp = NULL;
     byte*  cbcIv   = NULL;
@@ -13550,7 +13550,6 @@ static int SetDNSEntry(DecodedCert* cert, const char* str, int strLen,
         dnsEntry->name = (char*)XMALLOC((size_t)strLen + 1, cert->heap,
                                                           DYNAMIC_TYPE_ALTNAME);
         if (dnsEntry->name == NULL) {
-            XFREE(dnsEntry, cert->heap, DYNAMIC_TYPE_ALTNAME);
             ret = MEMORY_E;
         }
     }

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -2760,7 +2760,9 @@ enum PBESTypes {
 
     PBES2              = 13,       /* algo ID */
     PBES1_MD5_DES      = 3,
-    PBES1_SHA1_DES     = 10
+    PBES1_SHA1_DES     = 10,
+
+    PBE_NONE           = 999
 };
 
 enum PKCSTypes {


### PR DESCRIPTION
`wolfcrypt/src/asn.c` and `wolfssl/wolfcrypt/asn.h`: in `SetDNSEntry()`, defer `XFREE(dnsEntry, ...)` until end (fixes double free); add `PBE_NONE` to `enum PBESTypes`; in `EncryptContent()`, initialize `id` to `PBE_NONE` to fix a `-Wmaybe-uninitialized` (`CheckAlgo()` can leave it unchanged even when returning success).

tested with `wolfssl-multi-test.sh ... super-quick-check`
