### PR TITLE
cmake: fix parsing WOLFSSL_DEFINITIONS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2335,7 +2335,7 @@ endif()
 
 foreach(DEF IN LISTS WOLFSSL_DEFINITIONS)
     string(REGEX MATCH "^(-D)?([^=]+)(=(.*))?$" DEF_MATCH ${DEF})
-    if (DEFINED CMAKE_MATCH_4)
+    if (NOT "${CMAKE_MATCH_4}" STREQUAL "")
         set(${CMAKE_MATCH_2} ${CMAKE_MATCH_4})
         # message("set(${CMAKE_MATCH_2} ${CMAKE_MATCH_4})")
     else()


### PR DESCRIPTION
# Description

There is a bug in the CMake code that parses `WOLFSSL_DEFINITIONS` at line 2336 in `CMakeLists.txt`. It uses
```
    if (DEFINED CMAKE_MATCH_4)
```

to check for a subgroup match. It stops working if there was a previous a previous regex match like this
```
string(REGEX MATCH "^(-D)?([^=]+)(=(.*))?$" outvar "-DVAR=VALUE")
```
which defines `CMAKE_MATCH_4`. The problem is that the next regex match does not undefine `CMAKE_MATCH_4`, it just sets it to the empty string.

To test it, insert
```
string(REGEX MATCH "^(-D)?([^=]+)(=(.*))?$" outvar "-DVAR=VALUE")
```
somewhere before the code and enable logging in lines 2340 and 2343.