### PR TITLE
Use tar to preserve links

### DIFF
--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -26,11 +26,14 @@ jobs:
           configure: --enable-curl
           install: true
 
+      - name: tar build-dir
+        run: tar -zcf build-dir.tgz build-dir
+
       - name: Upload built lib
         uses: actions/upload-artifact@v4
         with:
           name: wolf-install-curl
-          path: build-dir
+          path: build-dir.tgz
           retention-days: 5
 
   test_curl:
@@ -54,7 +57,9 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: wolf-install-curl
-        path: build-dir
+
+      - name: untar build-dir
+        run: tar -xf build-dir.tgz
 
     - name: Build curl
       uses: wolfSSL/actions-build-autotools-project@v1

--- a/.github/workflows/cyrus-sasl.yml
+++ b/.github/workflows/cyrus-sasl.yml
@@ -29,11 +29,14 @@ jobs:
           # Don't run tests as this config is tested in many other places
           check: false
 
+      - name: tar build-dir
+        run: tar -zcf build-dir.tgz build-dir
+
       - name: Upload built lib
         uses: actions/upload-artifact@v4
         with:
           name: wolf-install-sasl
-          path: build-dir
+          path: build-dir.tgz
           retention-days: 5
 
   sasl_check:
@@ -60,7 +63,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wolf-install-sasl
-          path: build-dir
+
+      - name: untar build-dir
+        run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
         uses: actions/checkout@v4

--- a/.github/workflows/docker-OpenWrt.yml
+++ b/.github/workflows/docker-OpenWrt.yml
@@ -28,11 +28,15 @@ jobs:
             - uses: actions/checkout@v4
             - name: Compile libwolfssl.so
               run: ./autogen.sh && ./configure --enable-all && make
+              # 2024-08-05 - Something broke in the actions. They are no longer following links.
+            - name: tar libwolfssl.so
+              working-directory: src/.libs
+              run: tar -zcf libwolfssl.tgz libwolfssl.so*
             - name: Upload libwolfssl.so
               uses: actions/upload-artifact@v4
               with:
                 name: openwrt-libwolfssl.so
-                path: src/.libs/libwolfssl.so
+                path: src/.libs/libwolfssl.tgz
                 retention-days: 5
     compile_container:
         name: Compile container
@@ -50,7 +54,9 @@ jobs:
             - uses: actions/download-artifact@v4
               with:
                 name: openwrt-libwolfssl.so
-                path: Docker/OpenWrt/.
+                path: .
+            - name: untar libwolfssl.so
+              run: tar -xf libwolfssl.tgz -C Docker/OpenWrt
             - name: Build but dont push
               uses: docker/build-push-action@v5
               with:

--- a/.github/workflows/grpc.yml
+++ b/.github/workflows/grpc.yml
@@ -27,11 +27,14 @@ jobs:
           configure: --enable-all 'CPPFLAGS=-DWOLFSSL_RSA_KEY_CHECK -DHAVE_EX_DATA_CLEANUP_HOOKS'
           install: true
 
+      - name: tar build-dir
+        run: tar -zcf build-dir.tgz build-dir
+
       - name: Upload built lib
         uses: actions/upload-artifact@v4
         with:
           name: wolf-install-grpc
-          path: build-dir
+          path: build-dir.tgz
           retention-days: 5
 
   grpc_check:
@@ -65,7 +68,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wolf-install-grpc
-          path: build-dir
+
+      - name: untar build-dir
+        run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
         uses: actions/checkout@v4

--- a/.github/workflows/hitch.yml
+++ b/.github/workflows/hitch.yml
@@ -27,11 +27,14 @@ jobs:
           configure: --enable-hitch
           install: true
 
+      - name: tar build-dir
+        run: tar -zcf build-dir.tgz build-dir
+
       - name: Upload built lib
         uses: actions/upload-artifact@v4
         with:
           name: wolf-install-hitch
-          path: build-dir
+          path: build-dir.tgz
           retention-days: 5
 
   hitch_check:
@@ -53,7 +56,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wolf-install-hitch
-          path: build-dir
+
+      - name: untar build-dir
+        run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
         uses: actions/checkout@v4

--- a/.github/workflows/hostap-vm.yml
+++ b/.github/workflows/hostap-vm.yml
@@ -52,11 +52,14 @@ jobs:
             ${{ env.wolf_debug_flags }} ${{ matrix.wolf_extra_config }}
           install: true
 
+      - name: tar build-dir
+        run: tar -zcf build-dir.tgz build-dir
+
       - name: Upload built lib
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.build_id }}
-          path: build-dir
+          path: build-dir.tgz
           retention-days: 5
 
   build_uml_linux:
@@ -178,7 +181,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.config.build_id }}
-          path: build-dir
+
+      - name: untar build-dir
+        run: tar -xf build-dir.tgz
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ipmitool.yml
+++ b/.github/workflows/ipmitool.yml
@@ -30,11 +30,14 @@ jobs:
           # Don't run tests as this config is tested in many other places
           check: false
 
+      - name: tar build-dir
+        run: tar -zcf build-dir.tgz build-dir
+
       - name: Upload built lib
         uses: actions/upload-artifact@v4
         with:
           name: wolf-install-ipmitool
-          path: build-dir
+          path: build-dir.tgz
           retention-days: 5
 
   build_ipmitool:
@@ -50,7 +53,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wolf-install-ipmitool
-          path: build-dir
+
+      - name: untar build-dir
+        run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
         uses: actions/checkout@v4

--- a/.github/workflows/jwt-cpp.yml
+++ b/.github/workflows/jwt-cpp.yml
@@ -29,11 +29,14 @@ jobs:
           # Don't run tests as this config is tested in many other places
           check: false
 
+      - name: tar build-dir
+        run: tar -zcf build-dir.tgz build-dir
+
       - name: Upload built lib
         uses: actions/upload-artifact@v4
         with:
           name: wolf-install-jwt-cpp
-          path: build-dir
+          path: build-dir.tgz
           retention-days: 5
 
   build_pam-ipmi:
@@ -56,7 +59,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wolf-install-jwt-cpp
-          path: build-dir
+
+      - name: untar build-dir
+        run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
         uses: actions/checkout@v4

--- a/.github/workflows/krb5.yml
+++ b/.github/workflows/krb5.yml
@@ -31,11 +31,14 @@ jobs:
           configure: --enable-krb CC='gcc -fsanitize=address'
           install: true
 
+      - name: tar build-dir
+        run: tar -zcf build-dir.tgz build-dir
+
       - name: Upload built lib
         uses: actions/upload-artifact@v4
         with:
           name: wolf-install-krb5
-          path: build-dir
+          path: build-dir.tgz
           retention-days: 5
 
   krb5_check:
@@ -54,7 +57,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wolf-install-krb5
-          path: build-dir
+
+      - name: untar build-dir
+        run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
         uses: actions/checkout@v4

--- a/.github/workflows/libssh2.yml
+++ b/.github/workflows/libssh2.yml
@@ -28,11 +28,14 @@ jobs:
           check: false # config is already tested in many other PRB's
           install: true
 
+      - name: tar build-dir
+        run: tar -zcf build-dir.tgz build-dir
+
       - name: Upload built lib
         uses: actions/upload-artifact@v4
         with:
           name: wolf-install-libssh2
-          path: build-dir
+          path: build-dir.tgz
           retention-days: 5
 
   libssh2_check:
@@ -51,7 +54,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wolf-install-libssh2
-          path: build-dir
+
+      - name: untar build-dir
+        run: tar -xf build-dir.tgz
 
       - name: Build and test libssh2
         uses: wolfSSL/actions-build-autotools-project@v1

--- a/.github/workflows/libvncserver.yml
+++ b/.github/workflows/libvncserver.yml
@@ -29,11 +29,14 @@ jobs:
           # Don't run tests as this config is tested in many other places
           check: false
 
+      - name: tar build-dir
+        run: tar -zcf build-dir.tgz build-dir
+
       - name: Upload built lib
         uses: actions/upload-artifact@v4
         with:
           name: wolf-install-libvncserver
-          path: build-dir
+          path: build-dir.tgz
           retention-days: 5
 
   build_libvncserver:
@@ -49,7 +52,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wolf-install-libvncserver
-          path: build-dir
+
+      - name: untar build-dir
+        run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
         uses: actions/checkout@v4

--- a/.github/workflows/memcached.yml
+++ b/.github/workflows/memcached.yml
@@ -28,11 +28,14 @@ jobs:
       - name: Bundle Docker entry point
         run: cp wolfssl/.github/workflows/memcached.sh build-dir/bin
 
+      - name: tar build-dir
+        run: tar -zcf build-dir.tgz build-dir
+
       - name: Upload built lib
         uses: actions/upload-artifact@v4
         with:
           name: wolf-install-memcached
-          path: build-dir
+          path: build-dir.tgz
           retention-days: 5
 
   memcached_check:
@@ -50,7 +53,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wolf-install-memcached
-          path: build-dir
+
+      - name: untar build-dir
+        run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
         uses: actions/checkout@v4

--- a/.github/workflows/mosquitto.yml
+++ b/.github/workflows/mosquitto.yml
@@ -27,11 +27,14 @@ jobs:
           configure: --enable-mosquitto CFLAGS="-DALLOW_INVALID_CERTSIGN"
           install: true
 
+      - name: tar build-dir
+        run: tar -zcf build-dir.tgz build-dir
+
       - name: Upload built lib
         uses: actions/upload-artifact@v4
         with:
           name: wolf-install-mosquitto
-          path: build-dir
+          path: build-dir.tgz
           retention-days: 5
 
   mosquitto_check:
@@ -49,7 +52,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wolf-install-mosquitto
-          path: build-dir
+
+      - name: untar build-dir
+        run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
         uses: actions/checkout@v4

--- a/.github/workflows/net-snmp.yml
+++ b/.github/workflows/net-snmp.yml
@@ -27,11 +27,14 @@ jobs:
           configure: --enable-net-snmp
           install: true
 
+      - name: tar build-dir
+        run: tar -zcf build-dir.tgz build-dir
+
       - name: Upload built lib
         uses: actions/upload-artifact@v4
         with:
           name: wolf-install-net-snmp
-          path: build-dir
+          path: build-dir.tgz
           retention-days: 5
 
   net-snmp_check:
@@ -52,7 +55,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wolf-install-net-snmp
-          path: build-dir
+
+      - name: untar build-dir
+        run: tar -xf build-dir.tgz
     
       - name: Checkout OSP
         uses: actions/checkout@v4

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -33,11 +33,14 @@ jobs:
           configure: --enable-nginx ${{ env.wolf_debug_flags }}
           install: true
 
+      - name: tar build-dir
+        run: tar -zcf build-dir.tgz build-dir
+
       - name: Upload built lib
         uses: actions/upload-artifact@v4
         with:
           name: wolf-install-nginx
-          path: build-dir
+          path: build-dir.tgz
           retention-days: 5
 
   nginx_check:
@@ -111,7 +114,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wolf-install-nginx
-          path: build-dir
+
+      - name: untar build-dir
+        run: tar -xf build-dir.tgz
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ntp.yml
+++ b/.github/workflows/ntp.yml
@@ -28,11 +28,14 @@ jobs:
           install: true
           check: false
 
+      - name: tar build-dir
+        run: tar -zcf build-dir.tgz build-dir
+
       - name: Upload built lib
         uses: actions/upload-artifact@v4
         with:
           name: wolf-install-ntp
-          path: build-dir
+          path: build-dir.tgz
           retention-days: 5
 
   ntp_check:
@@ -51,7 +54,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wolf-install-ntp
-          path: build-dir
+
+      - name: untar build-dir
+        run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
         uses: actions/checkout@v4

--- a/.github/workflows/openssh.yml
+++ b/.github/workflows/openssh.yml
@@ -29,11 +29,14 @@ jobs:
             --enable-intelasm --enable-sp-asm
           install: true
 
+      - name: tar build-dir
+        run: tar -zcf build-dir.tgz build-dir
+
       - name: Upload built lib
         uses: actions/upload-artifact@v4
         with:
           name: wolf-install-openssh
-          path: build-dir
+          path: build-dir.tgz
           retention-days: 5
 
   openssh_check:
@@ -51,7 +54,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wolf-install-openssh
-          path: build-dir
+
+      - name: untar build-dir
+        run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
         uses: actions/checkout@v4

--- a/.github/workflows/openvpn.yml
+++ b/.github/workflows/openvpn.yml
@@ -27,11 +27,14 @@ jobs:
           configure: --enable-openvpn
           install: true
 
+      - name: tar build-dir
+        run: tar -zcf build-dir.tgz build-dir
+
       - name: Upload built lib
         uses: actions/upload-artifact@v4
         with:
           name: wolf-install-openvpn
-          path: build-dir
+          path: build-dir.tgz
           retention-days: 5
 
   openvpn_check:
@@ -50,7 +53,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wolf-install-openvpn
-          path: build-dir
+
+      - name: untar build-dir
+        run: tar -xf build-dir.tgz
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pam-ipmi.yml
+++ b/.github/workflows/pam-ipmi.yml
@@ -30,11 +30,14 @@ jobs:
           # Don't run tests as this config is tested in many other places
           check: false
 
+      - name: tar build-dir
+        run: tar -zcf build-dir.tgz build-dir
+
       - name: Upload built lib
         uses: actions/upload-artifact@v4
         with:
           name: wolf-install-pam-ipmi
-          path: build-dir
+          path: build-dir.tgz
           retention-days: 5
 
   build_pam-ipmi:
@@ -58,7 +61,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wolf-install-pam-ipmi
-          path: build-dir
+
+      - name: untar build-dir
+        run: tar -xf build-dir.tgz
 
       - name: Checkout OSP
         uses: actions/checkout@v4

--- a/.github/workflows/rng-tools.yml
+++ b/.github/workflows/rng-tools.yml
@@ -28,11 +28,14 @@ jobs:
           install: true
           check: false
 
+      - name: tar build-dir
+        run: tar -zcf build-dir.tgz build-dir
+
       - name: Upload built lib
         uses: actions/upload-artifact@v4
         with:
           name: wolf-install-rng-tools
-          path: build-dir
+          path: build-dir.tgz
           retention-days: 5
 
   rng-tools_check:
@@ -58,7 +61,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wolf-install-rng-tools
-          path: build-dir
+
+      - name: untar build-dir
+        run: tar -xf build-dir.tgz
     
       - name: Checkout OSP
         uses: actions/checkout@v4

--- a/.github/workflows/socat.yml
+++ b/.github/workflows/socat.yml
@@ -25,12 +25,15 @@ jobs:
           configure: --enable-maxfragment --enable-opensslall --enable-opensslextra --enable-dtls --enable-oldtls --enable-tlsv10 --enable-ipv6 'CPPFLAGS=-DWOLFSSL_NO_DTLS_SIZE_CHECK -DOPENSSL_COMPATIBLE_DEFAULTS'
           install: true
 
+      - name: tar build-dir
+        run: tar -zcf build-dir.tgz build-dir
+
       - name: Upload built lib
         uses: actions/upload-artifact@v4
         with:
           name: wolf-install-socat
-          path: build-dir
-          retention-days: 3
+          path: build-dir.tgz
+          retention-days: 5
 
 
   socat_check:
@@ -49,7 +52,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wolf-install-socat
-          path: build-dir
+
+      - name: untar build-dir
+        run: tar -xf build-dir.tgz
 
       - name: Download socat
         run: curl -O http://www.dest-unreach.org/socat/download/socat-1.8.0.0.tar.gz && tar xvf socat-1.8.0.0.tar.gz

--- a/.github/workflows/stunnel.yml
+++ b/.github/workflows/stunnel.yml
@@ -27,11 +27,14 @@ jobs:
           configure: --enable-stunnel
           install: true
 
+      - name: tar build-dir
+        run: tar -zcf build-dir.tgz build-dir
+
       - name: Upload built lib
         uses: actions/upload-artifact@v4
         with:
           name: wolf-install-stunnel
-          path: build-dir
+          path: build-dir.tgz
           retention-days: 5
 
   stunnel_check:
@@ -50,7 +53,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wolf-install-stunnel
-          path: build-dir
+
+      - name: untar build-dir
+        run: tar -xf build-dir.tgz
     
       - name: Checkout OSP
         uses: actions/checkout@v4


### PR DESCRIPTION
Something broke in the actions/download-artifact action and it is not preserving symbolic links. It didn't get a new release so my guess is that something was updated in the node environment or in npm. This is a future proof solution to preserve the fs structure between upload and download.