### PR TITLE
Support DTLS1.3 downgrade when server sends multiple handshakes in packet

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -13086,6 +13086,14 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
         case HELLO_AGAIN_REPLY:
             /* Get the response/s from the server. */
             while (ssl->options.serverState < SERVER_FINISHED_COMPLETE) {
+#ifdef WOLFSSL_DTLS13
+                if (!IsAtLeastTLSv1_3(ssl->version)) {
+        #ifndef WOLFSSL_NO_TLS12
+                    if (ssl->options.downgrade)
+                        return wolfSSL_connect(ssl);
+        #endif
+                }
+#endif /* WOLFSSL_DTLS13 */
                 if ((ssl->error = ProcessReply(ssl)) < 0) {
                         WOLFSSL_ERROR(ssl->error);
                         return WOLFSSL_FATAL_ERROR;


### PR DESCRIPTION

# Description

If the server sends Server Hello, Server Key Exchange and Server Hello Done in a single DTLS packet, but for DTLS1.2 in response to a client DTLS1.3 request, then FIRST_REPLAY state does not occur until the server re-sends the packet.  At this point wolfSSLconnect() gets used and all bursts into life.

When processing handshakes in wolfSSL_connect_TLSv13() for case HELLO_AGAIN_REPLY, downgrade to using  wolfSSLconnect() to continue processing the remaining handshakes in the packet.

# Testing

Found when using Mbed TLS for the server.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
