### PR TITLE
Fix template DecodeSubjDirAttr to set extSubjDirAttr data

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -20804,6 +20804,11 @@ static int DecodeSubjDirAttr(const byte* input, word32 sz, DecodedCert* cert)
 
     WOLFSSL_ENTER("DecodeSubjDirAttr");
 
+#ifdef OPENSSL_ALL
+    cert->extSubjDirAttrSrc = input;
+    cert->extSubjDirAttrSz = sz;
+#endif /* OPENSSL_ALL */
+
     CALLOC_ASNGETDATA(dataASN, subjDirAttrASN_Length, ret, cert->heap);
 
     /* Strip outer SEQUENCE. */


### PR DESCRIPTION
# Description

Fix template DecodeSubjDirAttr to set extSubjDirAttr data

Fixes zd18417

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
