### PR TITLE
20240806-debug-trace-errcodes-backtrace

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -217,9 +217,15 @@ AC_ARG_ENABLE([debug-trace-errcodes],
     [ ENABLED_DEBUG_TRACE_ERRCODES=no ]
     )
 
-if test "$ENABLED_DEBUG_TRACE_ERRCODES" = "yes"
+if test "$ENABLED_DEBUG_TRACE_ERRCODES" != "no"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DEBUG_TRACE_ERROR_CODES"
+fi
+
+if test "$ENABLED_DEBUG_TRACE_ERRCODES" = "backtrace"
+then
+    AM_CFLAGS="$AM_CFLAGS -g -funwind-tables -DWOLFSSL_DEBUG_BACKTRACE_ERROR_CODES"
+    AM_LDFLAGS="$AM_LDFLAGS -lbacktrace"
 fi
 
 # Start without certificates enabled and enable if a certificate algorithm is
@@ -9981,7 +9987,7 @@ echo "" >> $OPTION_FILE
 echo "#endif /* WOLFSSL_OPTIONS_H */" >> $OPTION_FILE
 echo "" >> $OPTION_FILE
 
-if test "$ENABLED_DEBUG_TRACE_ERRCODES" = "yes"
+if test "$ENABLED_DEBUG_TRACE_ERRCODES" != "no"
 then
     support/gen-debug-trace-error-codes.sh || AC_MSG_ERROR([Header generation for debug-trace-errcodes failed.])
 fi

--- a/src/internal.c
+++ b/src/internal.c
@@ -20653,7 +20653,11 @@ static void LogAlert(int type)
     typeStr = AlertTypeToString(type);
     if (typeStr != NULL) {
         char buff[60];
-        XSNPRINTF(buff, sizeof(buff), "Alert type: %s", typeStr);
+        if (XSNPRINTF(buff, sizeof(buff), "Alert type: %s", typeStr)
+            >= (int)sizeof(buff))
+        {
+            buff[sizeof(buff) - 1] = 0;
+        }
         WOLFSSL_MSG(buff);
     }
 #else

--- a/src/pk.c
+++ b/src/pk.c
@@ -4691,7 +4691,9 @@ int wolfSSL_RSA_GenAdd(WOLFSSL_RSA* rsa)
     mp_clear(t);
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(tmp, rsa->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    if (rsa != NULL) {
+        XFREE(tmp, rsa->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
 #endif
 
     return ret;

--- a/support/gen-debug-trace-error-codes.sh
+++ b/support/gen-debug-trace-error-codes.sh
@@ -12,7 +12,12 @@ BEGIN {
     print("#undef WOLFSSL_DEBUG_TRACE_ERROR_CODES_H") >> "wolfssl/debug-untrace-error-codes.h";
 }
 {
-    if (match($0, "^[[:space:]]+([A-Z][A-Z0-9_]+)[[:space:]]*=[[:space:]]*(-[0-9]+)[,[:space:]]", errcode_a)) {
+    if (match($0, "^[[:space:]]+([A-Z][A-Z0-9_]+)[[:space:]]*=[[:space:]]*(-[0-9]+)[,[:space:]]")) {
+
+        # for mawkward compatibility -- gawk allows errcode_a as the 3rd arg to match().
+        gsub("^[[:space:]]+", "", $0);
+        split($0, errcode_a, "[[:space:]=,]+");
+
         if ((errcode_a[1] == "MIN_CODE_E") ||
             (errcode_a[1] == "WC_LAST_E") ||
             (errcode_a[1] == "MAX_CODE_E"))

--- a/tests/api.c
+++ b/tests/api.c
@@ -78089,9 +78089,11 @@ static int load_pem_key_file_as_der(const char* privKeyFile, DerBuffer** pDer,
     (void)encInfo; /* not used in this test */
 
 #ifdef DEBUG_WOLFSSL
-    fprintf(stderr, "%s (%d): Loading PEM %s (len %d) to DER (len %d)\n",
-        (ret == 0) ? "Success" : "Failure", ret, privKeyFile, (int)key_sz,
-        (*pDer)->length);
+    if (*pDer != NULL) {
+        fprintf(stderr, "%s (%d): Loading PEM %s (len %d) to DER (len %d)\n",
+                (ret == 0) ? "Success" : "Failure", ret, privKeyFile,
+                (int)key_sz, (*pDer)->length);
+    }
 #endif
 
     return ret;

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1663,18 +1663,6 @@ static const char* bench_result_words3[][5] = {
                                           const char *desc_extra);
 #endif
 
-#if defined(DEBUG_WOLFSSL) && !defined(HAVE_VALGRIND) && \
-        !defined(HAVE_STACK_SIZE)
-#ifdef __cplusplus
-    extern "C" {
-#endif
-    WOLFSSL_API int wolfSSL_Debugging_ON(void);
-    WOLFSSL_API void wolfSSL_Debugging_OFF(void);
-#ifdef __cplusplus
-    }  /* extern "C" */
-#endif
-#endif
-
 #if !defined(WC_NO_RNG) && \
         ((!defined(NO_RSA) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) \
         || !defined(NO_DH) || defined(WOLFSSL_KEY_GEN) || defined(HAVE_ECC) \

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -471,26 +471,48 @@ void WOLFSSL_BUFFER(const byte* buffer, word32 length)
 
     while (buflen > 0) {
         int bufidx = 0;
-        XSNPRINTF(&line[bufidx], sizeof(line)-bufidx, "\t");
+        if (XSNPRINTF(&line[bufidx], sizeof(line)-bufidx, "\t")
+            >= (int)sizeof(line) - bufidx)
+        {
+            return;
+        }
         bufidx++;
 
         for (i = 0; i < LINE_LEN; i++) {
             if (i < buflen) {
-                XSNPRINTF(&line[bufidx], sizeof(line)-bufidx, "%02x ", buffer[i]);
+                if (XSNPRINTF(&line[bufidx], sizeof(line)-bufidx, "%02x ",
+                              buffer[i]) >= (int)sizeof(line) - bufidx)
+                {
+                    return;
+                }
             }
             else {
-                XSNPRINTF(&line[bufidx], sizeof(line)-bufidx, "   ");
+                if (XSNPRINTF(&line[bufidx], sizeof(line)-bufidx, "   ")
+                    >= (int)sizeof(line) - bufidx)
+                {
+                    return;
+                }
             }
             bufidx += 3;
         }
 
-        XSNPRINTF(&line[bufidx], sizeof(line)-bufidx, "| ");
+        if (XSNPRINTF(&line[bufidx], sizeof(line)-bufidx, "| ")
+            >= (int)sizeof(line) - bufidx)
+        {
+            return;
+        }
         bufidx++;
 
         for (i = 0; i < LINE_LEN; i++) {
             if (i < buflen) {
-                XSNPRINTF(&line[bufidx], sizeof(line)-bufidx,
-                     "%c", 31 < buffer[i] && buffer[i] < 127 ? buffer[i] : '.');
+                if (XSNPRINTF(&line[bufidx], sizeof(line)-bufidx,
+                              "%c", 31 < buffer[i] && buffer[i] < 127
+                              ? buffer[i]
+                              : '.')
+                    >= (int)sizeof(line) - bufidx)
+                {
+                    return;
+                }
                 bufidx++;
             }
         }
@@ -506,7 +528,11 @@ void WOLFSSL_ENTER(const char* msg)
 {
     if (loggingEnabled) {
         char buffer[WOLFSSL_MAX_ERROR_SZ];
-        XSNPRINTF(buffer, sizeof(buffer), "wolfSSL Entering %s", msg);
+        if (XSNPRINTF(buffer, sizeof(buffer), "wolfSSL Entering %s", msg)
+            >= (int)sizeof(buffer))
+        {
+            buffer[sizeof(buffer) - 1] = 0;
+        }
         wolfssl_log(ENTER_LOG, NULL, 0, buffer);
     }
 }
@@ -516,7 +542,11 @@ void WOLFSSL_ENTER2(const char *file, int line, const char* msg)
 {
     if (loggingEnabled) {
         char buffer[WOLFSSL_MAX_ERROR_SZ];
-        XSNPRINTF(buffer, sizeof(buffer), "wolfSSL Entering %s", msg);
+        if (XSNPRINTF(buffer, sizeof(buffer), "wolfSSL Entering %s", msg)
+            >= (int)sizeof(buffer))
+        {
+            buffer[sizeof(buffer) - 1] = 0;
+        }
         wolfssl_log(ENTER_LOG, file, line, buffer);
     }
 }
@@ -527,8 +557,12 @@ void WOLFSSL_LEAVE(const char* msg, int ret)
 {
     if (loggingEnabled) {
         char buffer[WOLFSSL_MAX_ERROR_SZ];
-        XSNPRINTF(buffer, sizeof(buffer), "wolfSSL Leaving %s, return %d",
-                msg, ret);
+        if (XSNPRINTF(buffer, sizeof(buffer), "wolfSSL Leaving %s, return %d",
+                      msg, ret)
+            >= (int)sizeof(buffer))
+        {
+            buffer[sizeof(buffer) - 1] = 0;
+        }
         wolfssl_log(LEAVE_LOG, NULL, 0, buffer);
     }
 }
@@ -538,8 +572,12 @@ void WOLFSSL_LEAVE2(const char *file, int line, const char* msg, int ret)
 {
     if (loggingEnabled) {
         char buffer[WOLFSSL_MAX_ERROR_SZ];
-        XSNPRINTF(buffer, sizeof(buffer), "wolfSSL Leaving %s, return %d",
-                msg, ret);
+        if (XSNPRINTF(buffer, sizeof(buffer), "wolfSSL Leaving %s, return %d",
+                      msg, ret)
+            >= (int)sizeof(buffer))
+        {
+            buffer[sizeof(buffer) - 1] = 0;
+        }
         wolfssl_log(LEAVE_LOG, file, line, buffer);
     }
 }

--- a/wolfcrypt/src/wc_kyber.c
+++ b/wolfcrypt/src/wc_kyber.c
@@ -286,7 +286,9 @@ int wc_KyberKey_MakeKeyWithRandom(KyberKey* key, const unsigned char* rand,
     }
 
     /* Free dynamic memory allocated in function. */
-    XFREE(a, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    if (key != NULL) {
+        XFREE(a, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
 
     return ret;
 }
@@ -890,7 +892,9 @@ int wc_KyberKey_Decapsulate(KyberKey* key, unsigned char* ss,
 
 #ifndef USE_INTEL_SPEEDUP
     /* Dispose of dynamic memory allocated in function. */
-    XFREE(cmp, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    if (key != NULL) {
+        XFREE(cmp, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
 #endif
 
     return ret;

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -298,17 +298,31 @@ WOLFSSL_ABI WOLFSSL_API const char* wc_GetErrorString(int error);
     #undef WOLFSSL_DEBUG_TRACE_ERROR_CODES
 #endif
 #ifdef WOLFSSL_DEBUG_TRACE_ERROR_CODES
+    extern void wc_backtrace_render(void);
     #define WC_NO_ERR_TRACE(label) (CONST_NUM_ERR_ ## label)
+    #ifndef WOLFSSL_DEBUG_BACKTRACE_RENDER_CLAUSE
+        #ifdef WOLFSSL_DEBUG_BACKTRACE_ERROR_CODES
+            #define WOLFSSL_DEBUG_BACKTRACE_RENDER_CLAUSE wc_backtrace_render()
+        #else
+            #define WOLFSSL_DEBUG_BACKTRACE_RENDER_CLAUSE (void)0
+        #endif
+    #endif
     #ifndef WC_ERR_TRACE
         #ifdef NO_STDIO_FILESYSTEM
         #define WC_ERR_TRACE(label)                           \
-            ( printf("ERR TRACE: %s L %d " #label " (%d)\n",  \
-                      __FILE__, __LINE__, label), label)
+            ( printf("ERR TRACE: %s L %d %s (%d)\n",          \
+                      __FILE__, __LINE__, #label, label),     \
+              WOLFSSL_DEBUG_BACKTRACE_RENDER_CLAUSE,          \
+              label                                           \
+            )
         #else
         #define WC_ERR_TRACE(label)                           \
             ( fprintf(stderr,                                 \
-                      "ERR TRACE: %s L %d " #label " (%d)\n", \
-                      __FILE__, __LINE__, label), label)
+                      "ERR TRACE: %s L %d %s (%d)\n",         \
+                      __FILE__, __LINE__, #label, label),     \
+              WOLFSSL_DEBUG_BACKTRACE_RENDER_CLAUSE,          \
+              label                                           \
+            )
         #endif
     #endif
     #include <wolfssl/debug-trace-error-codes.h>


### PR DESCRIPTION
add `--enable-debug-trace-errcodes=backtrace`.
    * uses libbacktrace to enhance existing "ERR TRACE" messages with backtraces, rendered in same format as the sanitizers.
    * adds `wc_backtrace_render()` and some related callbacks to `wolfcrypt/src/logging.c`.
    * adds an overrideable `WOLFSSL_DEBUG_BACKTRACE_RENDER_CLAUSE` to the `WC_ERR_TRACE()` mechanism in `wolfssl/wolfcrypt/error-crypt.h`.

also: fixes for defects identified by `cppcheck` and `clang-tidy` on `--enable-debug` builds: null deref in `tests/api.c:load_pem_key_file_as_der()`, redundant declarations in `wolfcrypt/benchmark/benchmark.c`, and numerous unchecked `XSNPRINTF()`s in `wolfcrypt/src/logging.c` and `src/internal.c`.

tested with `wolfssl-multi-test.sh ... all-gcc-debug-c99-backtrace cppcheck-all-debug-backtrace clang-tidy-all-debug-backtrace super-quick-check`. (`*-backtrace` are new optional scenarios added to test this PR.)


note that use of this feature requires installation of [libbacktrace](https://github.com/ianlancetaylor/libbacktrace) into the build environment.  `autoreconf -fi && ./configure && make && sudo make install` worked for me.
