### PR TITLE
Kyber: fix NULL check before XFREE

### DIFF
--- a/wolfcrypt/src/wc_kyber.c
+++ b/wolfcrypt/src/wc_kyber.c
@@ -285,8 +285,10 @@ int wc_KyberKey_MakeKeyWithRandom(KyberKey* key, const unsigned char* rand,
         key->flags |= KYBER_FLAG_PRIV_SET | KYBER_FLAG_PUB_SET;
     }
 
-    /* Free dynamic memory allocated in function. */
-    XFREE(a, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    if (key != NULL) {
+        /* Free dynamic memory allocated in function. */
+        XFREE(a, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
 
     return ret;
 }
@@ -889,8 +891,10 @@ int wc_KyberKey_Decapsulate(KyberKey* key, unsigned char* ss,
     }
 
 #ifndef USE_INTEL_SPEEDUP
-    /* Dispose of dynamic memory allocated in function. */
-    XFREE(cmp, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    if (key != NULL) {
+        /* Dispose of dynamic memory allocated in function. */
+        XFREE(cmp, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
 #endif
 
     return ret;


### PR DESCRIPTION
# Description

Was checking a is NULL which meant when key is NULL it didn't get to XFREE.
Need key check if no a check.

# Testing

./configure '--disable-shared' '--enable-experimental' '--enable-kyber'

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
