### PR TITLE
Update default RSA min to 1024

### DIFF
--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -103,7 +103,7 @@ RSA keys can be used to encrypt, decrypt, sign and verify data.
 #endif
 
 #ifndef RSA_MIN_SIZE
-#define RSA_MIN_SIZE 512
+#define RSA_MIN_SIZE 1024
 #endif
 
 #ifndef RSA_MAX_SIZE


### PR DESCRIPTION
# Description

Increase the default minimum RSA key size. This will affect RSA key generation. The default can be overridden in the configuration by defining `RSA_MIN_SIZE`.

Reviewed documentation and examples for issues with this change.

# Testing

CI tests

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
