### PR TITLE
Update generate_documentation.sh

### DIFF
--- a/doc/generate_documentation.sh
+++ b/doc/generate_documentation.sh
@@ -8,29 +8,23 @@ GEN_PDF=false
 GEN_ALL=false
 INSTALL_DOX=false
 
-command -v g++
-if [ $? -ne "0" ]; then
-echo "Please install g++"
-exit 1
-fi
+find_cmd () {
+    missing=""
 
-command -v cmake
-if [ $? -ne "0" ]; then
-echo "Please install cmake"
-exit 1
-fi
+    for cmd in "$@" ; do
+        command -V $cmd 2> /dev/null
+        if [ $? -ne "0" ]; then
+            missing="$missing $cmd"
+        fi
+    done
 
-command -v git
-if [ $? -ne "0" ]; then
-echo "Please install git"
-exit 1
-fi
-
-command -v make
-if [ $? -ne "0" ]; then
-echo "Please install make"
-exit 1
-fi
+    if [ -n "$missing"  ]; then
+        echo
+        echo "The following executables are missing. Please install:"
+        echo " $missing"
+        exit 1
+    fi
+}
 
 # Checking arguments and setting appropriate option variables
 
@@ -59,54 +53,57 @@ done
 # True - doxygen from "which doxygen" is used to generate documentation
 # False - clones doxygen Release_1_8_13 and ./build/bin/ added to PATH
 
-if [ $INSTALL_DOX = true ] && [ ! "$(which doxygen)" ]; then
-mkdir -p build
-cd build
-echo "cloning doxygen 1.8.13..."
-git clone --depth 1 --branch Release_1_8_13 https://github.com/doxygen/doxygen
-cmake -G "Unix Makefiles" doxygen/
-make
-cd ..
-export PATH="./build/bin/:$PATH"
+if [ $INSTALL_DOX = true ] && [ ! "$(which doxygen 2>/dev/null)" ]; then
+    find_cmd git cmake g++ make
+    mkdir -p build
+    cd build
+    echo "cloning doxygen 1.8.13..."
+    git clone --depth 1 --branch Release_1_8_13 https://github.com/doxygen/doxygen
+    cmake -G "Unix Makefiles" doxygen/
+    make
+    cd ..
+    export PATH="./build/bin/:$PATH"
 fi
 
 # Runs script to check that all API with documentation match wolfSSL API
 if [ $CHECK_API = true ]; then
-./check_api.sh
+    ./check_api.sh
 fi
 
 if [ $? = 1 ]; then
-echo "Not all API match"
-exit 1
+    echo "Not all API match"
+    exit 1
 fi
 
 #HTML GENERATION
 if [ $GEN_HTML = true ] || [ $GEN_ALL = true ]; then
-cp -r formats/html/* ./
-echo "generating html..."
-doxygen Doxyfile
-cp html_changes/search/* html/search/
-cp html_changes/*.css html/
-cp html_changes/*.js html/
-rm footer.html header.html
-rm -rf html_changes
-rm mainpage.dox
-rm Doxyfile
-echo "finished generating html..."
-echo "To view the html files use a browser to open the index.html file located at doc/html/index.html"
+    find_cmd doxygen
+    cp -r formats/html/* ./
+    echo "generating html..."
+    doxygen Doxyfile
+    cp html_changes/search/* html/search/
+    cp html_changes/*.css html/
+    cp html_changes/*.js html/
+    rm footer.html header.html
+    rm -rf html_changes
+    rm mainpage.dox
+    rm Doxyfile
+    echo "finished generating html..."
+    echo "To view the html files use a browser to open the index.html file located at doc/html/index.html"
 fi
 
 #PDF GENERATION
 if [ $GEN_PDF = true ] || [ $GEN_ALL = true ]; then
-cp -r formats/pdf/* ./
-echo "generating pdf..."
-doxygen Doxyfile
-cd latex/
-make
-mv refman.pdf ../
-cd ..
-rm -rf latex/
-rm Doxyfile
-rm header.tex
-echo "finished generating pdf..."
+    find_cmd make doxygen
+    cp -r formats/pdf/* ./
+    echo "generating pdf..."
+    doxygen Doxyfile
+    cd latex/
+    make
+    mv refman.pdf ../
+    cd ..
+    rm -rf latex/
+    rm Doxyfile
+    rm header.tex
+    echo "finished generating pdf..."
 fi


### PR DESCRIPTION
check for required executables only when needed

# Description

Modify generate_documentation.sh so it only checks for required exectuables when they are actually needed.

Fixes zd#7857

# Testing

How did you test?
Tested by intentionally adding/removing select executables and noted how the script failed or succeeded.

NOTE: Because this script uses bash in the shebang, a linux-like environment was assumed.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
