### PR TITLE
Add missing config.h on .c files

### DIFF
--- a/examples/async/async_client.c
+++ b/examples/async/async_client.c
@@ -22,6 +22,10 @@
 /* TLS client demonstrating asynchronous cryptography features and optionally
  * using the crypto or PK callbacks */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 /* std */
 #include <stdlib.h>
 #include <stdio.h>

--- a/examples/async/async_server.c
+++ b/examples/async/async_server.c
@@ -22,6 +22,10 @@
 /* TLS server demonstrating asynchronous cryptography features and optionally
  * using the crypto or PK callbacks */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 /* std */
 #include <stdlib.h>
 #include <stdio.h>

--- a/examples/async/async_tls.c
+++ b/examples/async/async_tls.c
@@ -19,6 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #ifndef WOLFSSL_USER_SETTINGS
 #include <wolfssl/options.h>
 #endif

--- a/examples/sctp/sctp-client-dtls.c
+++ b/examples/sctp/sctp-client-dtls.c
@@ -19,6 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 /* wolfssl */
 #ifndef WOLFSSL_USER_SETTINGS

--- a/examples/sctp/sctp-client.c
+++ b/examples/sctp/sctp-client.c
@@ -19,6 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #ifndef WOLFSSL_USER_SETTINGS
     #include <wolfssl/options.h>
 #endif

--- a/examples/sctp/sctp-server-dtls.c
+++ b/examples/sctp/sctp-server-dtls.c
@@ -19,6 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 /* wolfssl */
 #ifndef WOLFSSL_USER_SETTINGS
     #include <wolfssl/options.h>

--- a/examples/sctp/sctp-server.c
+++ b/examples/sctp/sctp-server.c
@@ -19,6 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #ifndef WOLFSSL_USER_SETTINGS
     #include <wolfssl/options.h>
 #endif

--- a/mcapi/mcapi_test.c
+++ b/mcapi/mcapi_test.c
@@ -23,7 +23,9 @@
 
 /* Tests Microchip CRYPTO API layer */
 
-
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 /* mc api header */
 #include <wolfssl/wolfcrypt/settings.h>

--- a/wolfcrypt/src/port/Renesas/renesas_common.c
+++ b/wolfcrypt/src/port/Renesas/renesas_common.c
@@ -19,6 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolfssl/wolfcrypt/settings.h>
 
 #if defined(WOLFSSL_RENESAS_FSPSM_TLS) || \

--- a/wolfcrypt/src/port/Renesas/renesas_fspsm_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_fspsm_util.c
@@ -18,8 +18,12 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
-#include <wolfssl/wolfcrypt/types.h>
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/wolfcrypt/types.h>
 
 #if defined(WOLFSSL_RENESAS_RSIP) || \
     defined(WOLFSSL_RENESAS_SCEPROTECT)

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_util.c
@@ -18,6 +18,11 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolfssl/wolfcrypt/settings.h>
 
 #if defined(WOLFSSL_RENESAS_TSIP)

--- a/wolfcrypt/src/port/caam/caam_driver.c
+++ b/wolfcrypt/src/port/caam/caam_driver.c
@@ -19,6 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #if (defined(__INTEGRITY) || defined(INTEGRITY)) || \
     (defined(__QNX__) || defined(__QNXNTO__))
 

--- a/wolfcrypt/src/port/caam/caam_error.c
+++ b/wolfcrypt/src/port/caam/caam_error.c
@@ -19,6 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #if (defined(__INTEGRITY) || defined(INTEGRITY)) || \
     (defined(__QNX__) || defined(__QNXNTO__))
 

--- a/wolfcrypt/src/port/mynewt/mynewt_port.c
+++ b/wolfcrypt/src/port/mynewt/mynewt_port.c
@@ -19,8 +19,14 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#if defined(WOLFSSL_APACHE_MYNEWT)
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#ifdef WOLFSSL_APACHE_MYNEWT
+
 #ifndef NO_FILESYSTEM
+
 #include "fs/fs.h"
 #define FILE struct fs_file
 
@@ -142,5 +148,5 @@ int mynewt_fclose(FILE *stream)
     return 0;
 }
 
-#endif /* NO_FILESYSTEM*/
-#endif /* if defined(WOLFSSL_APACHE_MYNEWT) */
+#endif /* !NO_FILESYSTEM */
+#endif /* WOLFSSL_APACHE_MYNEWT */

--- a/wolfcrypt/src/port/st/stsafe.c
+++ b/wolfcrypt/src/port/st/stsafe.c
@@ -19,6 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolfssl/wolfcrypt/types.h>
 #include <wolfssl/wolfcrypt/port/st/stsafe.h>
 #include <wolfssl/wolfcrypt/logging.h>

--- a/wolfcrypt/src/wc_kyber_poly.c
+++ b/wolfcrypt/src/wc_kyber_poly.c
@@ -57,6 +57,10 @@
  *   some platforms and is smaller in code size.
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolfssl/wolfcrypt/wc_kyber.h>
 #include <wolfssl/wolfcrypt/cpuid.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>

--- a/wolfcrypt/src/wc_lms_impl.c
+++ b/wolfcrypt/src/wc_lms_impl.c
@@ -37,6 +37,10 @@
  *   Enable when memory is limited.
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolfssl/wolfcrypt/wc_lms.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -695,7 +695,6 @@
     #define NO_DEV_RANDOM
     #define NO_FILESYSTEM
     #define TFM_TIMING_RESISTANT
-    #define NO_BIG_INT
 #endif
 
 #ifdef WOLFSSL_MICROCHIP_PIC32MZ

--- a/wrapper/Ada/ada_binding.c
+++ b/wrapper/Ada/ada_binding.c
@@ -19,6 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 /* wolfSSL */
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/ssl.h>


### PR DESCRIPTION
# Description

* Add missing config.h on some .c files.
* Fix to remove NO_BIG_INT from `MICROCHIP_PIC32` in settings.h.

# Testing

Microchip MPLABX

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
