### PR TITLE
fix interim return variable name when DH enabled

### DIFF
--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/client-tls.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/client-tls.c
@@ -297,8 +297,8 @@ WOLFSSL_ESP_TASK tls_smp_client_task(void* args)
 
 /* see user_settings PROJECT_DH for HAVE_DH and HAVE_FFDHE_2048 */
 #ifndef NO_DH
-    ret = wolfSSL_CTX_SetMinDhKey_Sz(ctx, (word16)minDhKeyBits);
-     if (ret != WOLFSSL_SUCCESS) {
+    ret_i = wolfSSL_CTX_SetMinDhKey_Sz(ctx, (word16)minDhKeyBits);
+     if (ret_i != WOLFSSL_SUCCESS) {
         ESP_LOGE(TAG, "Error setting minimum DH key size");
     }
 #endif


### PR DESCRIPTION
# Description

Please describe the scope of the fix or feature addition.

When using a `user_settings.h` such as [this one](https://github.com/gojimmypi/wolfssl/blob/dd833e17375bb9fa8f98e768514bd77933cdf0eb/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/include/user_settings.h#L262) that turns on DH with `#define HAVE_DH`, the Espressif TLS Client example currently fails to compile.  

```
.../IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/client-tls.c:300:5: error: 'ret' undeclared (first use in this function)
  300 |     ret = wolfSSL_CTX_SetMinDhKey_Sz(ctx, (word16)minDhKeyBits);
      |     ^~~
```

The example otherwise works with the `user_settings.h` that it has.

This is related to coming up with a common `user_settings.h` in the [template example](https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl) that will be copied to the published [Espressif wolfSSL Managed Component](https://components.espressif.com/components/wolfssl/wolfssl).

I do have major updates to the Espressif examples and cmake files, not ready for PR.

Fixes zd# n/a

# Testing

How did you test?

Tested only on Espressif platform.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
