### PR TITLE
Fix possible memory overrun in tests

### DIFF
--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -58,8 +58,8 @@ jobs:
       with:
         name: wolf-install-curl
 
-      - name: untar build-dir
-        run: tar -xf build-dir.tgz
+    - name: untar build-dir
+      run: tar -xf build-dir.tgz
 
     - name: Build curl
       uses: wolfSSL/actions-build-autotools-project@v1

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -18501,11 +18501,13 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t certext_test(void)
         return WC_TEST_RET_ENC_EC(ret);
 
     /* check the SKID from a RSA certificate */
-    if (XMEMCMP(skid_rsa, cert.extSubjKeyId, sizeof(cert.extSubjKeyId)))
+    if ((sizeof(skid_rsa) - 1 != cert.extSubjKeyIdSz) ||
+        (XMEMCMP(skid_rsa, cert.extSubjKeyId, cert.extSubjKeyIdSz)))
         return WC_TEST_RET_ENC_NC;
 
     /* check the AKID from an RSA certificate */
-    if (XMEMCMP(akid_rsa, cert.extAuthKeyId, sizeof(cert.extAuthKeyId)))
+    if ((sizeof(akid_rsa) - 1 != cert.extAuthKeyIdSz) ||
+            (XMEMCMP(akid_rsa, cert.extAuthKeyId, cert.extAuthKeyIdSz)))
         return WC_TEST_RET_ENC_NC;
 
     /* check the Key Usage from an RSA certificate */
@@ -18552,7 +18554,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t certext_test(void)
     /* check the SKID from a ECC certificate - generated dynamically */
 
     /* check the AKID from an ECC certificate */
-    if (XMEMCMP(akid_ecc, cert.extAuthKeyId, sizeof(cert.extAuthKeyId)))
+    if ((sizeof(akid_ecc) - 1 != cert.extAuthKeyIdSz) ||
+            (XMEMCMP(akid_ecc, cert.extAuthKeyId, cert.extAuthKeyIdSz)))
         return WC_TEST_RET_ENC_NC;
 
     /* check the Key Usage from an ECC certificate */
@@ -18600,11 +18603,13 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t certext_test(void)
         return WC_TEST_RET_ENC_EC(ret);
 
     /* check the SKID from a CA certificate */
-    if (XMEMCMP(kid_ca, cert.extSubjKeyId, sizeof(cert.extSubjKeyId)))
+    if ((sizeof(kid_ca) - 1 != cert.extSubjKeyIdSz) ||
+            (XMEMCMP(kid_ca, cert.extSubjKeyId, cert.extSubjKeyIdSz)))
         return WC_TEST_RET_ENC_NC;
 
     /* check the AKID from an CA certificate */
-    if (XMEMCMP(kid_ca, cert.extAuthKeyId, sizeof(cert.extAuthKeyId)))
+    if ((sizeof(kid_ca) - 1 != cert.extAuthKeyIdSz) ||
+            (XMEMCMP(kid_ca, cert.extAuthKeyId, cert.extAuthKeyIdSz)))
         return WC_TEST_RET_ENC_NC;
 
     /* check the Key Usage from CA certificate */


### PR DESCRIPTION
Found by one of our other tests:
```
In file included from wolfcrypt/test/test.c:43:
wolfcrypt/test/test.c: In function ‘certext_test’:
./wolfssl/wolfcrypt/types.h:722:39: error: ‘__builtin_memcmp_eq’ specified bound 32 exceeds source size 21 [-Werror=stringop-overread]
  722 |             #define XMEMCMP(s1,s2,n)  memcmp((s1),(s2),(n))
      |                                       ^~~~~~~~~~~~~~~~~~~~~
wolfcrypt/test/test.c:18504:9: note: in expansion of macro ‘XMEMCMP’
18504 |     if (XMEMCMP(skid_rsa, cert.extSubjKeyId, sizeof(cert.extSubjKeyId)))
      |         ^~~~~~~
wolfcrypt/test/test.c:18456:10: note: source object declared here
18456 |     byte skid_rsa[]   = "\x33\xD8\x45\x66\xD7\x68\x87\x18\x7E\x54"
      |          ^~~~~~~~
```