### PR TITLE
Introduce Espressif common CONFIG_WOLFSSL_EXAMPLE_NAME, Kconfig

### DIFF
--- a/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/Kconfig
+++ b/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/Kconfig
@@ -1,0 +1,366 @@
+# Kconfig template
+#
+# Copyright (C) 2006-2024 wolfSSL Inc.  All rights reserved.
+#
+# This file is part of wolfSSL.
+#
+# wolfSSL is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# wolfSSL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+#
+
+# Kconfig File Version 5.7.0.001 for wolfssl_test
+
+# Kconfig Format Rules
+#
+# See:
+#  https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/kconfig.html
+#
+# Format rules for Kconfig files are as follows:
+#
+# Option names in any menus should have consistent prefixes. The prefix
+# currently should have at least 3 characters.
+#
+# The unit of indentation should be 4 spaces. All sub-items belonging to a
+# parent item are indented by one level deeper. For example, menu is indented
+# by 0 spaces, config menu by 4 spaces, help in config by 8 spaces, and the
+# text under help by 12 spaces.
+#
+# No trailing spaces are allowed at the end of the lines.
+#
+# The maximum length of options is NOT 50 characters as documented.
+#   kconfcheck will complain that options should be 40 at most.
+#
+# Fix option lengths first. Superflous errors on other lines may occur.
+#
+# The maximum length of lines is 120 characters.
+#
+# python -m kconfcheck <path_to_kconfig_file>
+#
+# ---------------------------------------------------------------------------------------------------------------------
+# Begin main wolfSSL configuration menu
+# ---------------------------------------------------------------------------------------------------------------------
+menu "wolfSSL"
+    config TLS_STACK_WOLFSSL
+        bool "Include wolfSSL in ESP-TLS"
+        default y
+        select FREERTOS_ENABLE_BACKWARD_COMPATIBILITY
+        help
+            Includes wolfSSL in ESP-TLS so that it can be compiled with wolfSSL as its SSL/TLS library.
+
+    menu "Hardening"
+        config ESP_WOLFSSL_WC_NO_HARDEN
+            bool "Disable wolfSSL hardening"
+            default n
+            help
+                Sets WC_NO_HARDEN
+
+        config ESP_WOLFSSL_TFM_TIMING_RESISTANT
+            bool "Enable TFM Timing Resistant Code"
+            default n
+            help
+                Sets TFM_TIMING_RESISTANT.
+
+    endmenu # Hardening
+
+    config ESP_WOLFSSL_ENABLE_BENCHMARK
+        bool "Enable wolfSSL Benchmark Library"
+        default n
+        help
+            Enables wolfcrypt/benchmark/benchmark.c code for benchmark metrics. Disables NO_CRYPT_BENCHMARK.
+
+
+    menu "Benchmark Debug"
+        config ESP_DEBUG_WOLFSSL_BENCHMARK_TIMING
+            bool "Enable benchmark timing debug"
+            depends on ESP_WOLFSSL_ENABLE_BENCHMARK
+            default n
+            help
+                Enable wolfssl debug for benchmark metric timing (CPU Cycles, RTOS ticks, etc).
+
+        config ESP_WOLFSSL_BENCHMARK_TIMER_DEBUG
+            bool "Enable benchmark timer debug"
+            depends on ESP_WOLFSSL_ENABLE_BENCHMARK
+            default n
+            help
+                Turn on timer debugging (used when CPU cycles not available)
+
+    endmenu # Benchmark Debug
+
+    # -----------------------------------------------------------------------------------------------------------------
+    # wolfCrypt Test
+    # -----------------------------------------------------------------------------------------------------------------
+    config ESP_WOLFSSL_ENABLE_TEST
+        bool "Enable wolfCrypt test Library"
+        default n
+        help
+            Enables wolfcrypt/test/test.c code for testing. Disables NO_CRYPT_TEST.
+
+    menu "wolfCrypt tests"
+        config WOLFSSL_HAVE_WOLFCRYPT_TEST_OPTIONS
+            bool "Enable wolfCrypt Test Options"
+            depends on ESP_WOLFSSL_ENABLE_TEST
+            default n
+            help
+                Enables HAVE_WOLFCRYPT_TEST_OPTIONS
+    endmenu # wolfCrypt tests
+
+    # -----------------------------------------------------------------------------------------------------------------
+    # Apple HomeKit Options
+    # -----------------------------------------------------------------------------------------------------------------
+    menu "Apple HomeKit"
+        config WOLFSSL_APPLE_HOMEKIT
+            bool "Enable Apple HomeKit options"
+            default n
+            help
+                Enables FP_MAX_BITS (8192 * 2), SRP, ChaCha, Poly1305, Base64 encoding needed for Apple HomeKit.
+    endmenu # Apple HomeKit
+    # -----------------------------------------------------------------------------------------------------------------
+
+    config ESP_WOLFSSL_DISABLE_MY_ECC
+        bool "Disable ECC in my project"
+        default "n"
+        help
+            ECC is enabled by default. Select this option to disable.
+
+    config ESP_WOLFSSL_ENABLE_MY_USE_RSA
+        bool "Enable RSA in my project"
+        default "n"
+        help
+            RSA is disabled by default. Select this option to enable.
+
+    config ESP_WOLFSSL_BENCHMARK
+        bool "Enable wolfSSL Benchmark"
+        default n
+        help
+            Enables user settings relevant to benchmark code
+
+    config ESP_TLS_USING_WOLFSSL_SPECIFIED
+        bool "Use the specified wolfssl for ESP-TLS"
+        default Y
+        help
+            Includes wolfSSL from specified directory (not using esp-wolfssl).
+
+    config ESP_WOLFSSL_NO_USE_FAST_MATH
+        bool "Disable FAST_MATH library and all ESP32 Hardware Acceleration"
+        select ESP_WOLFSSL_NO_HW
+        select ESP_WOLFSSL_NO_HW_AES
+        select ESP_WOLFSSL_NO_HW_HASH
+        select ESP_WOLFSSL_NO_HW_RSA_PRI
+        select ESP_WOLFSSL_NO_HW_RSA_PRI_MP_MUL
+        select ESP_WOLFSSL_NO_HW_RSA_PRI_MULMOD
+        select ESP_WOLFSSL_NO_HW_RSA_PRI_EXPTMOD
+        default n
+        help
+            When disabling all hardware acceleration for smaller memory footprint,
+            disabling TFM fast math provides faster wolfSSL software algorithms in an
+            even smaller flash memory footprint.
+
+    menu "Protocol Config"
+        config WOLFSSL_HAVE_ALPN
+            bool "Enable ALPN (Application Layer Protocol Negotiation) in wolfSSL"
+            default y
+
+        config WOLFSSL_ALLOW_TLS12
+            bool "Allow TLS 1.2"
+            default n
+            help
+                Allow TLS to fallback to TLS1.2. Memory footprint will likely be larger for TLS1.2.
+                When disabled HTTPS and MQTT over TLS connections will fail if TLS1.3 not accepted.
+
+        config WOLFSSL_HAVE_OCSP
+            bool "Enable OCSP (Online Certificate Status Protocol) in wolfSSL"
+            default n
+    endmenu # Protocol Config
+    # -----------------------------------------------------------------------------------------------------------------
+
+    # -----------------------------------------------------------------------------------------------------------------
+    menu "wolfSSL ESP-TLS"
+        config TLS_STACK_WOLFSSL
+            bool "Include wolfSSL in ESP-TLS"
+            default y
+            select FREERTOS_ENABLE_BACKWARD_COMPATIBILITY
+            help
+                Includes wolfSSL in ESP-TLS so that it can be compiled with wolfSSL as its SSL/TLS library.
+    endmenu # wolfSSL ESP-TLS
+    # -----------------------------------------------------------------------------------------------------------------
+
+    # -----------------------------------------------------------------------------------------------------------------
+    config ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+        bool "Modify default hardware acceleration settings"
+        default n
+        help
+            Typically used for debugging, analysis, or optimizations. The default
+            hardware acceleration features can be each manually adjusted.
+
+    menu "wolfSSL Hardware Acceleration"
+
+        config ESP_WOLFSSL_NO_ESP32_CRYPT
+            bool "Disable all ESP32 Hardware Acceleration"
+            depends on ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+            default n
+            select ESP_WOLFSSL_NO_HW_AES
+            select ESP_WOLFSSL_NO_HW_HASH
+            select ESP_WOLFSSL_NO_HW_RSA_PRI
+            select ESP_WOLFSSL_NO_HW_RSA_PRI_MP_MUL
+            select ESP_WOLFSSL_NO_HW_RSA_PRI_MULMOD
+            select ESP_WOLFSSL_NO_HW_RSA_PRI_EXPTMOD
+            help
+                Hardware acceleration enabled by default. When selected defines: NO_ESP32_CRYPT.
+                Consider disabling FASTMATH (other libraries are faster in software and smaller)
+
+        config ESP_WOLFSSL_NO_HW_AES
+            bool "Disable all ESP32 AES Hardware Acceleration"
+            depends on ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+            default n
+            help
+                Hardware acceleration enabled by default.When selected defines: NO_HW_AES
+
+        config ESP_WOLFSSL_NO_HW_HASH
+            bool "Disable all ESP32 SHA Hash Hardware Acceleration"
+            depends on ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+            default n
+            help
+                Hardware acceleration enabled by default. When selected defines: NO_HW_HASH
+
+        config ESP_WOLFSSL_NO_HW_RSA_PRI
+            bool "Disable all ESP32 RSA Hardware Acceleration"
+            depends on ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+            default n
+            select ESP_WOLFSSL_NO_HW_PRI_MP_MUL
+            select ESP_WOLFSSL_NO_HW_RSA_PRI_MULMOD
+            select ESP_WOLFSSL_NO_HW_RSA_PRI_EXPTMOD
+            help
+                Hardware acceleration enabled by default. When selected defines: NO_HW_RSA_PRI
+
+        config ESP_WOLFSSL_NO_HW_RSA_PRI_MP_MUL
+            bool "Disable all ESP32 Multiplication Hardware Acceleration"
+            depends on ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+            default n
+            help
+                Hardware acceleration enabled by default. When selected defines: NO_HW_RSA_PRI_MP_MUL
+
+        config ESP_WOLFSSL_NO_HW_RSA_PRI_MULMOD
+            bool "Disable all ESP32 Modular Multiplication Hardware Acceleration"
+            depends on ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+            default n
+            help
+                Hardware acceleration enabled by default. When selected defines: NO_HW_RSA_PRI_MULMOD
+
+        config ESP_WOLFSSL_NO_HW_RSA_PRI_EXPTMOD
+            bool "Disable all ESP32 RSA Exponential Math Hardware Acceleration"
+            depends on ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+            default n
+            help
+                Hardware acceleration enabled by default.
+                Select this option to force disable: NO_HW_RSA_PRI_EXPTMOD
+
+    endmenu # wolfSSL Hardware Acceleration
+    # -----------------------------------------------------------------------------------------------------------------
+
+    # -----------------------------------------------------------------------------------------------------------------
+    menu "wolfSSL Experimental Options"
+
+        config ESP_WOLFSSL_EXPERIMENTAL_SETTINGS
+            bool "Enable wolfSSL Experimental Settings"
+            default n
+            help
+                Enables experimental settings for wolfSSL. See documentation.
+
+        config ESP_WOLFSSL_ENABLE_KYBER
+            bool "Enable wolfSSL Kyber"
+            default n
+            help
+                Enable debugging messages for wolfSSL. See user_settings.h for additional debug options.
+
+    endmenu # wolfSSL Experimental Options
+    # -----------------------------------------------------------------------------------------------------------------
+
+    # -----------------------------------------------------------------------------------------------------------------
+    menu "wolfSSL Debug Options"
+        config ESP_WOLFSSL_DEBUG_WOLFSSL
+            bool "Enable wolfSSL Debugging"
+            default n
+            help
+                Enable debugging messages for wolfSSL. See user_settings.h for additional debug options.
+    endmenu # wolfSSL Debug Options
+    # -----------------------------------------------------------------------------------------------------------------
+
+    # -----------------------------------------------------------------------------------------------------------------
+    menu "wolfSSL Customization"
+        config CUSTOM_SETTING_WOLFSSL_ROOT
+            string "Enter a path for wolfSSL source code"
+            default "~/workspace/wolfssl"
+            help
+                This option lets you specify a directory for the wolfSSL source code (typically a git clone).
+                Enter the path using forward slashes (e.g., C:/myfolder/mysubfolder) or double backslashes
+                (e.g., C:\\myfolder\\mysubfolder).
+
+    endmenu # wolfSSL Customization
+    # -----------------------------------------------------------------------------------------------------------------
+
+    # -----------------------------------------------------------------------------------------------------------------
+    menu "Component Config"
+        config IGNORE_ESP_IDF_WOLFSSL_COMPONENT
+            bool "Ignore the ESP-IDF component of wolfSSL (if present)"
+            default n
+            help
+                Ignores wolfSSL present in the esp-idf/components directory. Requires wolfssl as a local component.
+
+        config IGNORE_LOCAL_WOLFSSL_COMPONENT
+            bool "Ignore the local component of wolfSSL (if present)"
+            default n
+            help
+                Ignores wolfSSL present in the local project components directory.
+                Requires wolfssl as a ESP-IDF component.
+
+    endmenu # Component Config
+    # -----------------------------------------------------------------------------------------------------------------
+
+endmenu # wolfSSL
+# ---------------------------------------------------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+menu "wolfSSH"
+    config ESP_ENABLE_WOLFSSH
+        bool "Enable wolfSSH options"
+        default n
+        help
+            Enables WOLFSSH_TERM, WOLFSSL_KEY_GEN, WOLFSSL_PTHREADS, WOLFSSH_TEST_SERVER, WOLFSSH_TEST_THREADING
+
+    config ESP_WOLFSSL_DEBUG_WOLFSSH
+        bool "Enable wolfSSH debugging"
+        default n
+        help
+            Enable wolfSSH debugging macro. See user_settings.h
+
+endmenu # wolfSSH
+# ---------------------------------------------------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------------------------------------------------
+menu "wolfMQTT"
+    config ESP_ENABLE_WOLFMQTT
+        bool "Enable wolfMQTT options"
+        default n
+        help
+            Enables WOLFMQTT
+
+    config ESP_WOLFSSL_DEBUG_WOLFMQTT
+        bool "Enable wolfMQTT debugging"
+        default n
+        help
+            Enable wolfMQTT debugging macro. See user_settings.h
+
+endmenu # wolfMQTT
+# ---------------------------------------------------------------------------------------------------------------------

--- a/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/include/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/include/user_settings.h
@@ -1,4 +1,4 @@
-/* user_settings.h
+/* wolfssl-component include/user_settings.h
  *
  * Copyright (C) 2006-2024 wolfSSL Inc.
  *
@@ -18,19 +18,52 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
+#define WOLFSSL_ESPIDF_COMPONENT_VERSION 0x
+
+/* The Espressif project config file. See also sdkconfig.defaults */
+#include "sdkconfig.h"
 
 /* This user_settings.h is for Espressif ESP-IDF
  *
  * Standardized wolfSSL Espressif ESP32 + ESP8266 user_settings.h V5.7.0-1
  *
- * Do not include any wolfssl headers here
+ * Do not include any wolfssl headers here.
  *
  * When editing this file:
- * ensure wolfssl_test and wolfssl_benchmark settings match.
+ * ensure all examples match. The template example is the reference.
  */
 
-/* The Espressif project config file. See also sdkconfig.defaults */
-#include "sdkconfig.h"
+/* Naming convention: (see also esp32-crypt.h for the reference source).
+ *
+ * CONFIG_
+ *      This prefix indicates the setting came from the sdkconfig / Kconfig.
+ *
+ *      May or may not be related to wolfSSL.
+ *
+ *      The name after this prefix must exactly match that in the Kconfig file.
+ *
+ * WOLFSSL_
+ *      Typical of many, but not all wolfSSL macro names.
+ *
+ *      Applies to all wolfSSL products such as wolfSSH, wolfMQTT, etc.
+ *
+ *      May or may not have a corresponding sdkconfig / Kconfig control.
+ *
+ * ESP_WOLFSSL_
+ *      These are NOT valid wolfSSL macro names. These are names only used in
+ *      the ESP-IDF Kconfig files. When parsed, they will have a "CONFIG_"
+ *      suffix added. See next section.
+ *
+ * CONFIG_ESP_WOLFSSL_
+ *      This is a wolfSSL-specific macro that has been defined in the ESP-IDF
+ *      via the sdkconfig / menuconfig. Any text after this prefix should
+ *      exactly match an existing wolfSSL macro name.
+ *
+ *      Applies to all wolfSSL products such as wolfSSH, wolfMQTT, etc.
+ *
+ *      These macros may also be specific to only the project or environment,
+ *      and possibly not used anywhere else in the wolfSSL libraries.
+ */
 
 /* The Espressif sdkconfig will have chipset info.
 **
@@ -46,33 +79,180 @@
 #undef  WOLFSSL_ESPIDF
 #define WOLFSSL_ESPIDF
 
-/* We don't use WiFi, so don't compile in the esp-sdk-lib WiFi helpers: */
-#define NO_ESP_SDK_WIFI
+/* Test various user_settings between applications by selecting example apps
+ * in `idf.py menuconfig` for Example wolfSSL Configuration settings: */
+
+/* wolfSSL Examples */
+#ifdef CONFIG_WOLFSSL_EXAMPLE_NAME_TEMPLATE
+    /* See https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/template */
+    /* We don't use WiFi, so don't compile in the esp-sdk-lib WiFi helpers: */
+    /* #define USE_WOLFSSL_ESP_SDK_WIFI */
+#elif CONFIG_WOLFSSL_EXAMPLE_NAME_TEST
+    /* See https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/wolfssl_test */
+    /* We don't use WiFi, so don't compile in the esp-sdk-lib WiFi helpers: */
+    /* #define USE_WOLFSSL_ESP_SDK_WIFI */
+    #define TEST_ESPIDF_ALL_WOLFSSL
+
+#elif CONFIG_WOLFSSL_EXAMPLE_NAME_BENCHMARK
+    /* See https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark */
+    /* We don't use WiFi, so don't compile in the esp-sdk-lib WiFi helpers: */
+    /* #define USE_WOLFSSL_ESP_SDK_WIFI */
+#elif CONFIG_WOLFSSL_EXAMPLE_NAME_TLS_CLIENT
+    /* See https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/wolfssl_client */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+#elif CONFIG_WOLFSSL_EXAMPLE_NAME_TLS_SERVER
+    /* See https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/wolfssl_server */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+
+/* wolfSSH Examples */
+#elif CONFIG_WOLFSSL_EXAMPLE_NAME_WOLFSSH_TEMPLATE
+    /* See https://github.com/wolfSSL/wolfssh/tree/master/ide/Espressif/ESP-IDF/examples/wolfssh_template */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+#elif CONFIG_WOLFSSL_EXAMPLE_NAME_WOLFSSH_ECHOSERVER
+    /* See https://github.com/wolfSSL/wolfssh/tree/master/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+#elif CONFIG_WOLFSSL_EXAMPLE_NAME_ESP32_SSH_SERVER
+    /* See https://github.com/wolfSSL/wolfssh-examples/tree/main/Espressif/ESP32/ESP32-SSH-Server */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+#elif CONFIG_WOLFSSL_EXAMPLE_NAME_ESP8266_SSH_SERVER
+    /* See https://github.com/wolfSSL/wolfssh-examples/tree/main/Espressif/ESP8266/ESP8266-SSH-Server */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+
+/* wolfMQTT Examples */
+#elif CONFIG_WOLFSSL_EXAMPLE_NAME_WOLFMQTT_TEMPLATE
+    /* See https://github.com/wolfSSL/wolfMQTT/tree/master/IDE/Espressif/ESP-IDF/examples/wolfmqtt_template */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+#elif CONFIG_WOLFSSL_EXAMPLE_NAME_WOLFMQTT_AWS_IOT_MQTT
+    /* See https://github.com/wolfSSL/wolfMQTT/tree/master/IDE/Espressif/ESP-IDF/examples/AWS_IoT_MQTT */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+
+/* wolfTPM Examples */
+#elif CONFIG_WOLFTPM_EXAMPLE_NAME_ESPRESSIF
+    /* See https://github.com/wolfSSL/wolfTPM/tree/master/IDE/Espressif */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+
+/* Apple HomeKit Examples */
+#elif CONFIG_WOLFSSL_APPLE_HOMEKIT
+    /* See https://github.com/AchimPieters/esp32-homekit-demo */
+
+/* no example selected */
+#elif CONFIG_WOLFSSL_EXAMPLE_NAME_NONE
+    /* We'll assume the app needs to use wolfSSL sdk lib function */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+
+/* Unknown config */
+#else
+    /* the code is older or does not have application name defined. */
+#endif /* Example wolfSSL Configuration app settings */
+
+
+#if defined(CONFIG_TLS_STACK_WOLFSSL) && (CONFIG_TLS_STACK_WOLFSSL)
+    /* When using ESP-TLS, some old algoritms such as SHA1 are no longer
+     * enabled in wolfSSL, except for the OpenSSL compatibility. So enable
+     * that here: */
+    #define OPENSSL_EXTRA
+#endif
 
 /* Experimental Kyber */
-#if 0
+#ifdef CONFIG_WOLFSSL_ENABLE_KYBER
     /* Kyber typically needs a minimum 10K stack */
     #define WOLFSSL_EXPERIMENTAL_SETTINGS
     #define WOLFSSL_HAVE_KYBER
     #define WOLFSSL_WC_KYBER
     #define WOLFSSL_SHA3
+    #if defined(CONFIG_IDF_TARGET_ESP8266)
+        /* With limited RAM, we'll disable some of the Kyber sizes: */
+        #define WOLFSSL_NO_KYBER1024
+        #define WOLFSSL_NO_KYBER768
+        #define NO_SESSION_CACHE
+    #endif
 #endif
+
+/* Pick a cert buffer size: */
+/* #define USE_CERT_BUFFERS_2048 */
+/* #define USE_CERT_BUFFERS_1024 */
+#define USE_CERT_BUFFERS_2048
+
+/* The Espressif sdkconfig will have chipset info.
+**
+** Some possible values:
+**
+**   CONFIG_IDF_TARGET_ESP32
+**   CONFIG_IDF_TARGET_ESP32S2
+**   CONFIG_IDF_TARGET_ESP32S3
+**   CONFIG_IDF_TARGET_ESP32C3
+**   CONFIG_IDF_TARGET_ESP32C6
+*/
+
+/* Optionally enable Apple HomeKit from compiler directive or Kconfig setting */
+#if defined(WOLFSSL_APPLE_HOMEKIT) || defined(CONFIG_WOLFSSL_APPLE_HOMEKIT)
+     /* SRP is known to need 8K; slow on some devices */
+     #define FP_MAX_BITS (8192 * 2)
+     #define WOLFCRYPT_HAVE_SRP
+     #define HAVE_CHACHA
+     #define HAVE_POLY1305
+     #define WOLFSSL_BASE64_ENCODE
+ #endif /* Apple HomeKit settings */
+
+#if defined(CONFIG_ESP_TLS_USING_WOLFSSL)
+    /* The ESP-TLS */
+    #define  HAVE_ALPN
+    #define  HAVE_SNI
+    #define  OPENSSL_EXTRA_X509_SMALL
+#endif
+
+/* Optionally enable some wolfSSH settings */
+#if defined(ESP_ENABLE_WOLFSSH) || defined(CONFIG_ESP_ENABLE_WOLFSSH)
+    /* The default SSH Windows size is massive for an embedded target.
+     * Limit it: */
+    #define DEFAULT_WINDOW_SZ 2000
+
+    /* These may be defined in cmake for other examples: */
+    #undef  WOLFSSH_TERM
+    #define WOLFSSH_TERM
+
+    /* optional debug */
+    /* #undef  DEBUG_WOLFSSH */
+    /* #define DEBUG_WOLFSSH */
+
+    #undef  WOLFSSL_KEY_GEN
+    #define WOLFSSL_KEY_GEN
+
+    #undef  WOLFSSL_PTHREADS
+    #define WOLFSSL_PTHREADS
+
+    #define WOLFSSH_TEST_SERVER
+    #define WOLFSSH_TEST_THREADING
+#endif /* ESP_ENABLE_WOLFSSH */
+
+
+/* Not yet using WiFi lib, so don't compile in the esp-sdk-lib WiFi helpers: */
+/* #define USE_WOLFSSL_ESP_SDK_WIFI */
 
 /*
  * ONE of these Espressif chip families will be detected from sdkconfig:
  *
  * WOLFSSL_ESP32
+ * WOLFSSL_ESPWROOM32SE
  * WOLFSSL_ESP8266
+ *
+ * following ifdef detection only for syntax highlighting:
  */
-#undef WOLFSSL_ESPWROOM32SE
-#undef WOLFSSL_ESP8266
-#undef WOLFSSL_ESP32
+#ifdef WOLFSSL_ESPWROOM32SE
+    #undef WOLFSSL_ESPWROOM32SE
+#endif
+#ifdef WOLFSSL_ESP8266
+    #undef WOLFSSL_ESP8266
+#endif
+#ifdef WOLFSSL_ESP32
+    #undef WOLFSSL_ESP32
+#endif
 /* See below for chipset detection from sdkconfig.h */
 
 /* when you want to use SINGLE THREAD. Note Default ESP-IDF is FreeRTOS */
 /* #define SINGLE_THREADED */
 
-/* SMALL_SESSION_CACHE saves a lot of RAM for ClientCache and SessionCache.
+/* Small session cache saves a lot of RAM for ClientCache and SessionCache.
  * Memory requirement is about 5KB, otherwise 20K is needed when not specified.
  * If extra small footprint is needed, try MICRO_SESSION_CACHE (< 1K)
  * When really desperate or no TLS used, try NO_SESSION_CACHE.  */
@@ -92,8 +272,128 @@
 /* RSA_LOW_MEM: Half as much memory but twice as slow. */
 #define RSA_LOW_MEM
 
+/* Uncommon settings for testing only */
+#ifdef TEST_ESPIDF_ALL_WOLFSSL
+    #define WOLFSSL_MD2
+    #define HAVE_BLAKE2
+    #define HAVE_BLAKE2B
+    #define HAVE_BLAKE2S
 
+    #define WC_RC2
+    #define WOLFSSL_ALLOW_RC4
 
+    #define HAVE_POLY1305
+
+    #define WOLFSSL_AES_128
+    #define WOLFSSL_AES_OFB
+    #define WOLFSSL_AES_CFB
+    #define WOLFSSL_AES_XTS
+
+    /* #define WC_SRTP_KDF */
+    /* TODO Causes failure with Espressif AES HW Enabled */
+    /* #define HAVE_AES_ECB */
+    /* #define HAVE_AESCCM  */
+    /* TODO sanity check when missing HAVE_AES_ECB */
+    #define WOLFSSL_WOLFSSH
+
+    #define HAVE_AESGCM
+    #define WOLFSSL_AES_COUNTER
+
+    #define HAVE_FFDHE
+    #define HAVE_FFDHE_2048
+    #if defined(CONFIG_IDF_TARGET_ESP8266)
+        /* TODO Full size SRP is disabled on the ESP8266 at this time.
+         * Low memory issue? */
+        #define WOLFCRYPT_HAVE_SRP
+        /* MIN_FFDHE_FP_MAX_BITS = (MIN_FFDHE_BITS * 2); see settings.h */
+        #define FP_MAX_BITS MIN_FFDHE_FP_MAX_BITS
+    #elif defined(CONFIG_IDF_TARGET_ESP32)   || \
+          defined(CONFIG_IDF_TARGET_ESP32S2) || \
+          defined(CONFIG_IDF_TARGET_ESP32S3)
+        #define WOLFCRYPT_HAVE_SRP
+        #define FP_MAX_BITS (8192 * 2)
+    #elif defined(CONFIG_IDF_TARGET_ESP32C3) || \
+          defined(CONFIG_IDF_TARGET_ESP32H2)
+        /* SRP Known to be working on this target::*/
+        #define WOLFCRYPT_HAVE_SRP
+        #define FP_MAX_BITS (8192 * 2)
+    #else
+        /* For everything else, give a try and see if SRP working: */
+        #define WOLFCRYPT_HAVE_SRP
+        #define FP_MAX_BITS (8192 * 2)
+    #endif
+
+    #define HAVE_DH
+
+    /* TODO: there may be a problem with HAVE_CAMELLIA with HW AES disabled.
+     * Do not define NO_WOLFSSL_ESP32_CRYPT_AES when enabled: */
+    /* #define HAVE_CAMELLIA */
+
+    /* DSA requires old SHA */
+    #define HAVE_DSA
+
+    /* Needs SHA512 ? */
+    #define HAVE_HPKE
+
+    /* Not for Espressif? */
+    #if defined(CONFIG_IDF_TARGET_ESP32C2) || \
+        defined(CONFIG_IDF_TARGET_ESP8684) || \
+        defined(CONFIG_IDF_TARGET_ESP32H2) || \
+        defined(CONFIG_IDF_TARGET_ESP8266)
+
+        #if defined(CONFIG_IDF_TARGET_ESP8266)
+            #undef HAVE_ECC
+            #undef HAVE_ECC_CDH
+            #undef HAVE_CURVE25519
+
+            /* TODO does CHACHA also need alignment? Failing on ESP8266
+             * See SHA256 __attribute__((aligned(4))); and WC_SHA256_ALIGN */
+            #ifdef HAVE_CHACHA
+                #error "HAVE_CHACHA not supported on ESP8266"
+            #endif
+            #ifdef HAVE_XCHACHA
+                #error "HAVE_XCHACHA not supported on ESP8266"
+            #endif
+        #else
+            #define HAVE_XCHACHA
+            #define HAVE_CHACHA
+            /* TODO Not enabled at this time, needs further testing:
+             *   #define WC_SRTP_KDF
+             *   #define HAVE_COMP_KEY
+             *   #define WOLFSSL_HAVE_XMSS
+             */
+        #endif
+        /* TODO AES-EAX not working on this platform */
+
+        /* Optionally disable DH
+         *   #undef HAVE_DH
+         *   #undef HAVE_FFDHE
+         */
+
+        /* ECC_SHAMIR out of memory on ESP32-C2 during ECC  */
+        #ifndef HAVE_ECC
+            #define ECC_SHAMIR
+        #endif
+    #else
+        #define WOLFSSL_AES_EAX
+
+        #define ECC_SHAMIR
+    #endif
+
+    /* Only for WOLFSSL_IMX6_CAAM / WOLFSSL_QNX_CAAM ? */
+    /* #define WOLFSSL_CAAM      */
+    /* #define WOLFSSL_CAAM_BLOB */
+
+    #define WOLFSSL_AES_SIV
+    #define WOLFSSL_CMAC
+
+    #define WOLFSSL_CERT_PIV
+
+    /* HAVE_SCRYPT may turn on HAVE_PBKDF2 see settings.h */
+    /* #define HAVE_SCRYPT */
+    #define SCRYPT_TEST_ALL
+    #define HAVE_X963_KDF
+#endif
 
 /* optionally turn off SHA512/224 SHA512/256 */
 /* #define WOLFSSL_NOSHA512_224 */
@@ -133,29 +433,59 @@
 /* when you want to use SHA384 */
 #define WOLFSSL_SHA384
 
-/* when you want to use SHA512 */
-#define WOLFSSL_SHA512
-
-/* when you want to use SHA3 */
-#define WOLFSSL_SHA3
-
- /* ED25519 requires SHA512 */
-#define HAVE_ED25519
-
 /* Some features not enabled for ESP8266: */
 #if defined(CONFIG_IDF_TARGET_ESP8266) || \
     defined(CONFIG_IDF_TARGET_ESP32C2)
+    /* Some known low-memory devices have features not enabled by default. */
     /* TODO determine low memory configuration for ECC. */
 #else
-    #define HAVE_ECC
-    #define HAVE_CURVE25519
-    #define CURVE25519_SMALL
+    /* when you want to use SHA512 */
+    #define WOLFSSL_SHA512
+
+    /* when you want to use SHA3 */
+    #define WOLFSSL_SHA3
+
+    /* ED25519 requires SHA512 */
+    #define HAVE_ED25519
 #endif
 
-#define HAVE_ED25519
+#define MY_USE_ECC 1
+#define MY_USE_RSA 0
 
-/* Optional OPENSSL compatibility */
-#define OPENSSL_EXTRA
+/* We can use either or both ECC and RSA, but must use at least one. */
+#if MY_USE_ECC || MY_USE_RSA
+    #if MY_USE_ECC
+        /* ---- ECDSA / ECC ---- */
+        #define HAVE_ECC
+        #define HAVE_CURVE25519
+        #define HAVE_ED25519
+
+        /*
+        #define HAVE_ECC384
+        #define CURVE25519_SMALL
+        */
+    #else
+        #define WOLFSSH_NO_ECC
+        /* WOLFSSH_NO_ECDSA is typically defined automatically,
+         * here for clarity: */
+        #define WOLFSSH_NO_ECDSA
+    #endif
+
+    #if MY_USE_RSA
+        /* ---- RSA ----- */
+        /* #define RSA_LOW_MEM */
+
+        /* DH disabled by default, needed if ECDSA/ECC also turned off */
+        #define HAVE_DH
+    #else
+        #define WOLFSSH_NO_RSA
+    #endif
+#else
+    #error "Either RSA or ECC must be enabled"
+#endif
+
+/* Optional OpenSSL compatibility */
+/* #define OPENSSL_EXTRA */
 
 /* #Optional HAVE_PKCS7 */
 /* #define HAVE_PKCS7 */
@@ -208,7 +538,7 @@
 #define USE_FAST_MATH
 
 /*****      Use SP_MATH      *****/
-/* #undef USE_FAST_MATH          */
+/* #undef  USE_FAST_MATH         */
 /* #define SP_MATH               */
 /* #define WOLFSSL_SP_MATH_ALL   */
 /* #define WOLFSSL_SP_RISCV32    */
@@ -217,6 +547,14 @@
 /* #undef USE_FAST_MATH          */
 /* #define USE_INTEGER_HEAP_MATH */
 
+/* Just syntax highlighting to check math libraries: */
+#if defined(SP_MATH)               || \
+    defined(USE_INTEGER_HEAP_MATH) || \
+    defined(USE_INTEGER_HEAP_MATH) || \
+    defined(USE_FAST_MATH)         || \
+    defined(WOLFSSL_SP_MATH_ALL)   || \
+    defined(WOLFSSL_SP_RISCV32)
+#endif
 
 #define WOLFSSL_SMALL_STACK
 
@@ -224,7 +562,9 @@
 #define HAVE_VERSION_EXTENDED_INFO
 /* #define HAVE_WC_INTROSPECTION */
 
-#define  HAVE_SESSION_TICKET
+#ifndef NO_SESSION_CACHE
+    #define  HAVE_SESSION_TICKET
+#endif
 
 /* #define HAVE_HASHDRBG */
 
@@ -255,10 +595,62 @@
 --enable-asn-template
 */
 
+/* optional SM4 Ciphers. See https://github.com/wolfSSL/wolfsm */
+/*
+#define WOLFSSL_SM2
+#define WOLFSSL_SM3
+#define WOLFSSL_SM4
+*/
+
+#if defined(WOLFSSL_SM2) || defined(WOLFSSL_SM3) || defined(WOLFSSL_SM4)
+    /* SM settings, possible cipher suites:
+
+        TLS13-AES128-GCM-SHA256
+        TLS13-CHACHA20-POLY1305-SHA256
+        TLS13-SM4-GCM-SM3
+        TLS13-SM4-CCM-SM3
+
+    #define WOLFSSL_ESP32_CIPHER_SUITE "TLS13-SM4-GCM-SM3"
+    #define WOLFSSL_ESP32_CIPHER_SUITE "TLS13-SM4-CCM-SM3"
+    #define WOLFSSL_ESP32_CIPHER_SUITE "ECDHE-ECDSA-SM4-CBC-SM3"
+    #define WOLFSSL_ESP32_CIPHER_SUITE "ECDHE-ECDSA-SM4-GCM-SM3"
+    #define WOLFSSL_ESP32_CIPHER_SUITE "ECDHE-ECDSA-SM4-CCM-SM3"
+    #define WOLFSSL_ESP32_CIPHER_SUITE "TLS13-SM4-GCM-SM3:" \
+                                       "TLS13-SM4-CCM-SM3:"
+    */
+
+    #undef  WOLFSSL_BASE16
+    #define WOLFSSL_BASE16 /* required for WOLFSSL_SM2 */
+
+    #undef  WOLFSSL_SM4_ECB
+    #define WOLFSSL_SM4_ECB
+
+    #undef  WOLFSSL_SM4_CBC
+    #define WOLFSSL_SM4_CBC
+
+    #undef  WOLFSSL_SM4_CTR
+    #define WOLFSSL_SM4_CTR
+
+    #undef  WOLFSSL_SM4_GCM
+    #define WOLFSSL_SM4_GCM
+
+    #undef  WOLFSSL_SM4_CCM
+    #define WOLFSSL_SM4_CCM
+
+    #define HAVE_POLY1305
+    #define HAVE_CHACHA
+
+    #undef  HAVE_AESGCM
+    #define HAVE_AESGCM
+#else
+    /* default settings */
+    #define USE_CERT_BUFFERS_2048
+#endif
+
 /* Chipset detection from sdkconfig.h
  * Default is HW enabled unless turned off.
  * Uncomment lines to force SW instead of HW acceleration */
-#if defined(CONFIG_IDF_TARGET_ESP32)
+#if defined(CONFIG_IDF_TARGET_ESP32) || defined(WOLFSSL_ESPWROOM32SE)
     #define WOLFSSL_ESP32
     /*  Alternatively, if there's an ECC Secure Element present: */
     /* #define WOLFSSL_ESPWROOM32SE */
@@ -445,8 +837,11 @@ See wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h for details on debug options
 #define WOLFSSL_TEST_STRAY 1
 #define USE_ESP_DPORT_ACCESS_READ_BUFFER
 #define WOLFSSL_ESP32_HW_LOCK_DEBUG
+#define WOLFSSL_DEBUG_MUTEX
 #define WOLFSSL_DEBUG_ESP_RSA_MULM_BITS
 #define ESP_DISABLE_HW_TASK_LOCK
+#define ESP_MONITOR_HW_TASK_LOCK
+#define USE_ESP_DPORT_ACCESS_READ_BUFFER
 
 See wolfcrypt/benchmark/benchmark.c for debug and other settings:
 
@@ -458,7 +853,7 @@ Turn on timer debugging (used when CPU cycles not available)
 */
 
 /* Pause in a loop rather than exit. */
-#define WOLFSSL_ESPIDF_ERROR_PAUSE
+/* #define WOLFSSL_ESPIDF_ERROR_PAUSE */
 
 #define WOLFSSL_HW_METRICS
 
@@ -506,6 +901,12 @@ Turn on timer debugging (used when CPU cycles not available)
  *
  * There are various certificate examples in this header file:
  * https://github.com/wolfSSL/wolfssl/blob/master/wolfssl/certs_test.h
+ *
+ * To use the sample certificates in code (not recommended for production!):
+ *
+ *    #if defined(USE_CERT_BUFFERS_2048) || defined(USE_CERT_BUFFERS_1024)
+ *        #include <wolfssl/certs_test.h>
+ *    #endif
  *
  * To use the sets of macros below, define *one* of these:
  *
@@ -584,6 +985,7 @@ Turn on timer debugging (used when CPU cycles not available)
     #define WOLFSSL_BASE16
 #else
     #if defined(USE_CERT_BUFFERS_2048)
+        #define USE_CERT_BUFFERS_256
         /* Be sure to include in app when using example certs: */
         /* #include <wolfssl/certs_test.h>                     */
         #define CTX_CA_CERT          ca_cert_der_2048
@@ -605,6 +1007,7 @@ Turn on timer debugging (used when CPU cycles not available)
         #define CTX_CLIENT_KEY_TYPE  WOLFSSL_FILETYPE_ASN1
 
     #elif defined(USE_CERT_BUFFERS_1024)
+        #define USE_CERT_BUFFERS_256
         /* Be sure to include in app when using example certs: */
         /* #include <wolfssl/certs_test.h>                     */
         #define CTX_CA_CERT          ca_cert_der_1024
@@ -629,3 +1032,34 @@ Turn on timer debugging (used when CPU cycles not available)
         #error "Must define USE_CERT_BUFFERS_2048 or USE_CERT_BUFFERS_1024"
     #endif
 #endif /* Conditional key and cert constant names */
+
+/******************************************************************************
+** Sanity Checks
+******************************************************************************/
+#if defined(CONFIG_ESP_MAIN_TASK_STACK_SIZE)
+    #if defined(WOLFCRYPT_HAVE_SRP)
+        #if defined(FP_MAX_BITS)
+            #if FP_MAX_BITS <  (8192 * 2)
+                #define ESP_SRP_MINIMUM_STACK_8K (24 * 1024)
+            #else
+                #define ESP_SRP_MINIMUM_STACK_8K (28 * 1024)
+            #endif
+        #else
+            #error "Please define FP_MAX_BITS when using WOLFCRYPT_HAVE_SRP."
+        #endif
+
+        #if (CONFIG_ESP_MAIN_TASK_STACK_SIZE < ESP_SRP_MINIMUM_STACK)
+            #warning "WOLFCRYPT_HAVE_SRP enabled with small stack size"
+        #endif
+    #endif
+#else
+    #warning "CONFIG_ESP_MAIN_TASK_STACK_SIZE not defined!"
+#endif
+/* See settings.h for some of the possible hardening options:
+ *
+ *  #define NO_ESPIDF_DEFAULT
+ *  #define WC_NO_CACHE_RESISTANT
+ *  #define WC_AES_BITSLICED
+ *  #define HAVE_AES_ECB
+ *  #define HAVE_AES_DIRECT
+ */

--- a/IDE/Espressif/ESP-IDF/examples/template/main/Kconfig.projbuild
+++ b/IDE/Espressif/ESP-IDF/examples/template/main/Kconfig.projbuild
@@ -1,0 +1,123 @@
+# Kconfig main
+#
+# Copyright (C) 2006-2024 wolfSSL Inc.  All rights reserved.
+#
+# This file is part of wolfSSL.
+#
+# wolfSSL is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# wolfSSL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+#
+
+# Kconfig File Version 5.7.2.001 for wolfssl_template
+
+menu "Example wolfSSL Configuration"
+
+choice WOLFSSL_EXAMPLE_CHOOSE
+    prompt "Choose Example (See wolfssl/include/user_settings.h)"
+    default WOLFSSL_EXAMPLE_NAME_NONE
+    help
+        The user settings file can be adjusted to specific wolfSSL examples.
+
+    config WOLFSSL_EXAMPLE_NAME_TEMPLATE
+        bool "wolfSSL Template"
+        help
+            The sample template app compiles in wolfSSL and prints the current wolfSSL Version. Nothing more.
+
+    config WOLFSSL_EXAMPLE_NAME_TEST
+        bool "wolfSSL Test"
+        help
+            This app tests all cryptographic functions currently enabled. See also Benchmark performance app.
+
+    config WOLFSSL_EXAMPLE_NAME_BENCHMARK
+        bool "wolfSSL Benchmark"
+        help
+            Benchmark performance app. See also cryptographic test.
+
+    config WOLFSSL_EXAMPLE_NAME_TLS_CLIENT
+        bool "TLS Client"
+        help
+            TLS Client Example app. Needs WiFi and a listening server on port 11111.
+
+    config WOLFSSL_EXAMPLE_NAME_TLS_SERVER
+        bool "TLS Server"
+        help
+            TLS Server Example app. Needs WiFi. More interesting with a TLS client using port 11111.
+
+    config WOLFSSL_EXAMPLE_NAME_WOLFSSH_TEMPLATE
+        bool "SSH Template App"
+        help
+            Bare-bones Hellow World app that only compiles in wolfSSL and wolfSSH.
+            See wolfSSL/wolfssh on GitHub.
+
+    config WOLFSSL_EXAMPLE_NAME_WOLFSSH_ECHOSERVER
+        bool "SSH Echo Server"
+        help
+            See wolfSSL/wolfssh on GitHub.
+
+    config WOLFSSL_EXAMPLE_NAME_WOLFSSH_ECHOSERVER
+        bool "SSH Echo Server"
+        help
+            See wolfSSL/wolfssh on GitHub.
+
+    config WOLFSSL_EXAMPLE_NAME_ESP32_SSH_SERVER
+        bool "SSH to UART Server for the ESP32"
+        help
+            See wolfSSL/wolfssh-examples on GitHub.
+
+    config WOLFSSL_EXAMPLE_NAME_ESP8266_SSH_SERVER
+        bool "SSH to UART Server for the ESP8266"
+        help
+            See wolfSSL/wolfssh-examples on GitHub.
+
+    config WOLFSSL_EXAMPLE_NAME_WOLFMQTT_TEMPLATE
+        bool "MQTT Template"
+        help
+            See wolfSSL/wolfmqtt on GitHub.
+
+    config WOLFSSL_EXAMPLE_NAME_WOLFMQTT_AWS_IOT_MQTT
+        bool "MQTT AWS IoT"
+        help
+            See wolfSSL/wolfmqtt on GitHub.
+
+    config WOLFTPM_EXAMPLE_NAME_ESPRESSIF
+        bool "TPM Test Example for the ESP32"
+        help
+            See wolfSSL/wolfTPM on GitHub.
+
+    config WOLFSSL_APPLE_HOMEKIT
+        bool "Apple HomeKit for the ESP32"
+        help
+            See AchimPieters/esp32-homekit-demo on GitHub.
+
+
+    config WOLFSSL_EXAMPLE_NAME_NONE
+        bool "Other"
+        help
+            A specific example app is not defined.
+
+endchoice
+
+config WOLFSSL_TARGET_HOST
+    string "Target host"
+    default "127.0.0.1"
+    help
+        host address for the example to connect
+
+config WOLFSSL_TARGET_PORT
+    int "Target port"
+    default 11111
+    help
+        host port for the example to connect
+
+endmenu

--- a/IDE/Espressif/ESP-IDF/examples/template/main/main.c
+++ b/IDE/Espressif/ESP-IDF/examples/template/main/main.c
@@ -50,6 +50,11 @@ void app_main(void)
 #ifdef WOLFSSL_ESPIDF_VERBOSE_EXIT_MESSAGE
     int ret = 0;
 #endif
+
+#if !defined(CONFIG_WOLFSSL_EXAMPLE_NAME_TEMPLATE)
+    ESP_LOGW(TAG, "Warning: Example wolfSSL misconfigured? Check menuconfig.");
+#endif
+
     ESP_LOGI(TAG, "Hello wolfSSL!");
 
 #ifdef HAVE_VERSION_EXTENDED_INFO

--- a/IDE/Espressif/ESP-IDF/examples/template/sdkconfig.defaults
+++ b/IDE/Espressif/ESP-IDF/examples/template/sdkconfig.defaults
@@ -1,3 +1,6 @@
+# Set the known example app config to template example (see user_settings.h)
+CONFIG_WOLFSSL_EXAMPLE_NAME_TEMPLATE=y
+
 CONFIG_FREERTOS_HZ=1000
 CONFIG_ESP32_DEFAULT_CPU_FREQ_240=y
 

--- a/IDE/Espressif/include.am
+++ b/IDE/Espressif/include.am
@@ -22,7 +22,9 @@ EXTRA_DIST+= IDE/Espressif/ESP-IDF/user_settings.h
 # Template
 EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/CMakeLists.txt
 EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/components
+EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/Kconfig
 EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/main
+EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/main/Kconfig.projbuild
 EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/partitions_singleapp_large.csv
 EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/README.md
 EXTRA_DIST+= IDE/Espressif/ESP-IDF/examples/template/sdkconfig.defaults


### PR DESCRIPTION
# Description

This PR introduces  common KConfig and user setting files for the Espressif [template app](https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/template) as it is the most basic example and least intrusive to change.  

The intent is that all wolfSSL examples in all repos will have common `user_settings.h` , `CMakeLists.txt` and `KConfig` files, with only the `sdkconfig.defaults` varying. Rather than propose all changes to all examples at once, this PR for only the `template` example is for simplified code review.

Note that new configuration settings specific to ESP-IDF versions integrating wolfSSL are also included here. There's likely little to no effect on ESP-IDF versions that do not support the new features. As of the date of this PR, many features are only available on my [ESP-IDF v5.2.2 fork](https://github.com/gojimmypi/esp-idf/tree/my_522).

The  objective is to not only simplify the configuration of the `user_settings.h` file by utilizing the `menuconfig` capabilities, but in doing so will also prevent changes from being needed when using the [wolfSSL Managed Component](https://components.espressif.com/components/wolfssl/wolfssl). Recall that making changes, such as to the `user_settings.h` file, causes the component manager to complain about changes.  This forces the user to convert the Managed Component to a regular component, defeating the purpose and value of having a managed component in the first place.

Here's the new `idf.py menuconfig` as viewed in VisualGDB. Note the dropdown also increases end-user awareness to the other examples available:

![image](https://github.com/user-attachments/assets/d2209d91-2786-4fb0-8431-1394a8a56549)


Fixes zd#: Not "fixing" but related to 18228.

# Testing

How did you test?

Tested only on Espressif targets.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
