### PR TITLE
Add new option to always copy cert buffer for each SSL object

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -6816,6 +6816,7 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
             return ret;
         }
 
+        ssl->buffers.weOwnCert = TRUE;
         ret = WOLFSSL_SUCCESS;
     }
     if (ctx->certChain != NULL) {
@@ -6829,6 +6830,7 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
             return ret;
         }
 
+        ssl->buffers.weOwnCertChain = TRUE;
         ret = WOLFSSL_SUCCESS;
     }
 #else

--- a/src/internal.c
+++ b/src/internal.c
@@ -6803,9 +6803,39 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
 #endif /* HAVE_RPK */
 
 #ifndef NO_CERTS
+#ifdef WOLFSSL_COPY_CERT
+    /* If WOLFSSL_COPY_CERT is defined, always copy the cert */
+    if (ctx->certificate != NULL) {
+        if (ssl->buffers.certificate != NULL) {
+            FreeDer(&ssl->buffers.certificate);
+        }
+        ret = AllocCopyDer(&ssl->buffers.certificate, ctx->certificate->buffer,
+            ctx->certificate->length, ctx->certificate->type,
+            ctx->certificate->heap);
+        if (ret != 0) {
+            return ret;
+        }
+
+        ret = WOLFSSL_SUCCESS;
+    }
+    if (ctx->certChain != NULL) {
+        if (ssl->buffers.certChain != NULL) {
+            FreeDer(&ssl->buffers.certChain);
+        }
+        ret = AllocCopyDer(&ssl->buffers.certChain, ctx->certChain->buffer,
+            ctx->certChain->length, ctx->certChain->type,
+            ctx->certChain->heap);
+        if (ret != 0) {
+            return ret;
+        }
+
+        ret = WOLFSSL_SUCCESS;
+    }
+#else
     /* ctx still owns certificate, certChain, key, dh, and cm */
     ssl->buffers.certificate = ctx->certificate;
     ssl->buffers.certChain = ctx->certChain;
+#endif
 #ifdef WOLFSSL_TLS13
     ssl->buffers.certChainCnt = ctx->certChainCnt;
 #endif

--- a/src/internal.c
+++ b/src/internal.c
@@ -6816,7 +6816,7 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
             return ret;
         }
 
-        ssl->buffers.weOwnCert = TRUE;
+        ssl->buffers.weOwnCert = 1;
         ret = WOLFSSL_SUCCESS;
     }
     if (ctx->certChain != NULL) {
@@ -6830,7 +6830,7 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
             return ret;
         }
 
-        ssl->buffers.weOwnCertChain = TRUE;
+        ssl->buffers.weOwnCertChain = 1;
         ret = WOLFSSL_SUCCESS;
     }
 #else

--- a/src/internal.c
+++ b/src/internal.c
@@ -6806,9 +6806,6 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
 #ifdef WOLFSSL_COPY_CERT
     /* If WOLFSSL_COPY_CERT is defined, always copy the cert */
     if (ctx->certificate != NULL) {
-        if (ssl->buffers.certificate != NULL) {
-            FreeDer(&ssl->buffers.certificate);
-        }
         ret = AllocCopyDer(&ssl->buffers.certificate, ctx->certificate->buffer,
             ctx->certificate->length, ctx->certificate->type,
             ctx->certificate->heap);
@@ -6820,9 +6817,6 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         ret = WOLFSSL_SUCCESS;
     }
     if (ctx->certChain != NULL) {
-        if (ssl->buffers.certChain != NULL) {
-            FreeDer(&ssl->buffers.certChain);
-        }
         ret = AllocCopyDer(&ssl->buffers.certChain, ctx->certChain->buffer,
             ctx->certChain->length, ctx->certChain->type,
             ctx->certChain->heap);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -20164,7 +20164,7 @@ WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
             return NULL;
         }
 
-        ssl->buffers.weOwnCert = TRUE;
+        ssl->buffers.weOwnCert = 1;
         ret = WOLFSSL_SUCCESS;
     }
     if (ctx->certChain != NULL) {
@@ -20178,7 +20178,7 @@ WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
             return NULL;
         }
 
-        ssl->buffers.weOwnCertChain = TRUE;
+        ssl->buffers.weOwnCertChain = 1;
         ret = WOLFSSL_SUCCESS;
     }
 #else

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -20152,10 +20152,11 @@ WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
 
 #ifndef NO_CERTS
 #ifdef WOLFSSL_COPY_CERT
-    /* If WOLFSSL_COPY_CERT defined, make new copy of cert from ctx
-     * unless SSL object already has a cert */
-    if ((ctx->certificate != NULL) &&
-        (ssl->buffers.certificate == NULL)) {
+    /* If WOLFSSL_COPY_CERT defined, always make new copy of cert from ctx */
+    if (ctx->certificate != NULL) {
+        if (ssl->buffers.certificate != NULL) {
+            FreeDer(&ssl->buffers.certificate);
+        }
         ret = AllocCopyDer(&ssl->buffers.certificate, ctx->certificate->buffer,
             ctx->certificate->length, ctx->certificate->type,
             ctx->certificate->heap);
@@ -20166,8 +20167,10 @@ WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
         ssl->buffers.weOwnCert = 1;
         ret = WOLFSSL_SUCCESS;
     }
-    if ((ctx->certChain != NULL) &&
-        (ssl->buffers.certChain == NULL)) {
+    if (ctx->certChain != NULL) {
+        if (ssl->buffers.certChain != NULL) {
+            FreeDer(&ssl->buffers.certChain);
+        }
         ret = AllocCopyDer(&ssl->buffers.certChain, ctx->certChain->buffer,
             ctx->certChain->length, ctx->certChain->type,
             ctx->certChain->heap);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -10806,11 +10806,6 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             return BAD_FUNC_ARG;
         }
 
-    #ifdef WOLFSSL_COPY_CERT
-        /* If WOLFSSL_COPY_CERT defined, always free cert buffers in SSL obj */
-        FreeDer(&ssl->buffers.certificate);
-        FreeDer(&ssl->buffers.certChain);
-    #endif
         if (ssl->buffers.weOwnCert && !ssl->keepCert) {
             WOLFSSL_MSG("Unloading cert");
             FreeDer(&ssl->buffers.certificate);
@@ -19554,11 +19549,6 @@ void wolfSSL_certs_clear(WOLFSSL* ssl)
     /* ctx still owns certificate, certChain, key, dh, and cm */
     if (ssl->buffers.weOwnCert)
         FreeDer(&ssl->buffers.certificate);
-#ifdef WOLFSSL_COPY_CERT
-    /* If WOLFSSL_COPY_CERT defined, always free cert buffers in SSL obj */
-    FreeDer(&ssl->buffers.certificate);
-    FreeDer(&ssl->buffers.certChain);
-#endif
     ssl->buffers.certificate = NULL;
     if (ssl->buffers.weOwnCertChain)
         FreeDer(&ssl->buffers.certChain);
@@ -20174,6 +20164,7 @@ WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
             return NULL;
         }
 
+        ssl->buffers.weOwnCert = TRUE;
         ret = WOLFSSL_SUCCESS;
     }
     if (ctx->certChain != NULL) {
@@ -20187,6 +20178,7 @@ WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
             return NULL;
         }
 
+        ssl->buffers.weOwnCertChain = TRUE;
         ret = WOLFSSL_SUCCESS;
     }
 #else

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -20152,11 +20152,10 @@ WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
 
 #ifndef NO_CERTS
 #ifdef WOLFSSL_COPY_CERT
-    /* If WOLFSSL_COPY_CERT defined, always make new copy of cert */
-    if (ctx->certificate != NULL) {
-        if (ssl->buffers.certificate != NULL) {
-            FreeDer(&ssl->buffers.certificate);
-        }
+    /* If WOLFSSL_COPY_CERT defined, make new copy of cert from ctx
+     * unless SSL object already has a cert */
+    if ((ctx->certificate != NULL) &&
+        (ssl->buffers.certificate == NULL)) {
         ret = AllocCopyDer(&ssl->buffers.certificate, ctx->certificate->buffer,
             ctx->certificate->length, ctx->certificate->type,
             ctx->certificate->heap);
@@ -20167,10 +20166,8 @@ WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
         ssl->buffers.weOwnCert = 1;
         ret = WOLFSSL_SUCCESS;
     }
-    if (ctx->certChain != NULL) {
-        if (ssl->buffers.certChain != NULL) {
-            FreeDer(&ssl->buffers.certChain);
-        }
+    if ((ctx->certChain != NULL) &&
+        (ssl->buffers.certChain == NULL)) {
         ret = AllocCopyDer(&ssl->buffers.certChain, ctx->certChain->buffer,
             ctx->certChain->length, ctx->certChain->type,
             ctx->certChain->heap);

--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -236,6 +236,9 @@ static int ProcessUserChainRetain(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
     /* Store in SSL object if available. */
     if (ssl != NULL) {
         /* Dispose of old chain if not reference to context's. */
+    #ifdef WOLFSSL_COPY_CERT
+        FreeDer(&ssl->buffers.certChain);
+    #endif
         if (ssl->buffers.weOwnCertChain) {
             FreeDer(&ssl->buffers.certChain);
         }
@@ -2079,6 +2082,10 @@ static int ProcessBufferCertHandleDer(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
     /* Leaf certificate - our certificate. */
     else if (type == CERT_TYPE) {
         if (ssl != NULL) {
+#ifdef WOLFSSL_COPY_CERT
+            /* Always Free previously set if WOLFSSL_COPY_CERT defined */
+            FreeDer(&ssl->buffers.certificate);
+#endif
             /* Free previous certificate if we own it. */
             if (ssl->buffers.weOwnCert) {
                 FreeDer(&ssl->buffers.certificate);
@@ -4559,6 +4566,10 @@ static int wolfssl_add_to_chain(DerBuffer** chain, int weOwn, const byte* cert,
         /* Append length and DER encoded certificate. */
         c32to24(certSz, newChain->buffer + len);
         XMEMCPY(newChain->buffer + len + CERT_HEADER_SZ, cert, certSz);
+
+#ifdef WOLFSSL_COPY_CERT
+        FreeDer(chain);
+#endif
 
         /* Dispose of old chain if we own it. */
         if (weOwn) {

--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -236,9 +236,6 @@ static int ProcessUserChainRetain(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
     /* Store in SSL object if available. */
     if (ssl != NULL) {
         /* Dispose of old chain if not reference to context's. */
-    #ifdef WOLFSSL_COPY_CERT
-        FreeDer(&ssl->buffers.certChain);
-    #endif
         if (ssl->buffers.weOwnCertChain) {
             FreeDer(&ssl->buffers.certChain);
         }
@@ -2082,10 +2079,6 @@ static int ProcessBufferCertHandleDer(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
     /* Leaf certificate - our certificate. */
     else if (type == CERT_TYPE) {
         if (ssl != NULL) {
-#ifdef WOLFSSL_COPY_CERT
-            /* Always Free previously set if WOLFSSL_COPY_CERT defined */
-            FreeDer(&ssl->buffers.certificate);
-#endif
             /* Free previous certificate if we own it. */
             if (ssl->buffers.weOwnCert) {
                 FreeDer(&ssl->buffers.certificate);
@@ -4566,10 +4559,6 @@ static int wolfssl_add_to_chain(DerBuffer** chain, int weOwn, const byte* cert,
         /* Append length and DER encoded certificate. */
         c32to24(certSz, newChain->buffer + len);
         XMEMCPY(newChain->buffer + len + CERT_HEADER_SZ, cert, certSz);
-
-#ifdef WOLFSSL_COPY_CERT
-        FreeDer(chain);
-#endif
 
         /* Dispose of old chain if we own it. */
         if (weOwn) {

--- a/tests/api.c
+++ b/tests/api.c
@@ -77291,8 +77291,17 @@ static int test_wolfSSL_set_SSL_CTX(void)
 #ifdef WOLFSSL_SESSION_ID_CTX
     ExpectIntEQ(XMEMCMP(ssl->sessionCtx, session_id2, 4), 0);
 #endif
+#ifdef WOLFSSL_COPY_CERT
+    if (ctx2->certificate != NULL) {
+        ExpectFalse(ssl->buffers.certificate == ctx2->certificate);
+    }
+    if (ctx2->certChain != NULL) {
+        ExpectFalse(ssl->buffers.certChain == ctx2->certChain);
+    }
+#else
     ExpectTrue(ssl->buffers.certificate == ctx2->certificate);
     ExpectTrue(ssl->buffers.certChain == ctx2->certChain);
+#endif
 #endif
 
 #ifdef HAVE_SESSION_TICKET
@@ -77310,8 +77319,17 @@ static int test_wolfSSL_set_SSL_CTX(void)
 #endif
     /* MUST change */
 #ifdef WOLFSSL_INT_H
+#ifdef WOLFSSL_COPY_CERT
+    if (ctx1->certificate != NULL) {
+        ExpectFalse(ssl->buffers.certificate == ctx1->certificate);
+    }
+    if (ctx1->certChain != NULL) {
+        ExpectFalse(ssl->buffers.certChain == ctx1->certChain);
+    }
+#else
     ExpectTrue(ssl->buffers.certificate == ctx1->certificate);
     ExpectTrue(ssl->buffers.certChain == ctx1->certChain);
+#endif
 #ifdef WOLFSSL_SESSION_ID_CTX
     ExpectIntEQ(XMEMCMP(ssl->sessionCtx, session_id1, 4), 0);
 #endif

--- a/tests/api.c
+++ b/tests/api.c
@@ -77292,10 +77292,10 @@ static int test_wolfSSL_set_SSL_CTX(void)
     ExpectIntEQ(XMEMCMP(ssl->sessionCtx, session_id2, 4), 0);
 #endif
 #ifdef WOLFSSL_COPY_CERT
-    if (ctx2->certificate != NULL) {
+    if (ctx2 != NULL && ctx2->certificate != NULL) {
         ExpectFalse(ssl->buffers.certificate == ctx2->certificate);
     }
-    if (ctx2->certChain != NULL) {
+    if (ctx2 != NULL && ctx2->certChain != NULL) {
         ExpectFalse(ssl->buffers.certChain == ctx2->certChain);
     }
 #else
@@ -77320,10 +77320,10 @@ static int test_wolfSSL_set_SSL_CTX(void)
     /* MUST change */
 #ifdef WOLFSSL_INT_H
 #ifdef WOLFSSL_COPY_CERT
-    if (ctx1->certificate != NULL) {
+    if (ctx1 != NULL && ctx1->certificate != NULL) {
         ExpectFalse(ssl->buffers.certificate == ctx1->certificate);
     }
-    if (ctx1->certChain != NULL) {
+    if (ctx1 != NULL && ctx1->certChain != NULL) {
         ExpectFalse(ssl->buffers.certChain == ctx1->certChain);
     }
 #else

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3261,6 +3261,11 @@ extern void uITRON4_free(void *p) ;
     #define KEEP_PEER_CERT
 #endif
 
+#if defined(OPENSSL_ALL) && !defined(WOLFSSL_NO_COPY_CERT)
+    #undef WOLFSSL_COPY_CERT
+    #define WOLFSSL_COPY_CERT
+#endif
+
 /*
  * Keeps the "Finished" messages after a TLS handshake for use as the so-called
  * "tls-unique" channel binding. See comment in internal.h around clientFinished


### PR DESCRIPTION
# Description
 Adds new flag WOLFSSL_COPY_CERT to enable option to copy cert and cert chain buffers over to each new SSL object created. 

Fixes ZD 18267