### PR TITLE
Fixes for building wolfBoot sources for PQ LMS/XMSS

### DIFF
--- a/wolfcrypt/src/ext_lms.c
+++ b/wolfcrypt/src/ext_lms.c
@@ -27,7 +27,8 @@
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/logging.h>
 
-#ifdef WOLFSSL_HAVE_LMS
+#if defined(WOLFSSL_HAVE_LMS) && defined(HAVE_LIBLMS)
+
 #include <wolfssl/wolfcrypt/ext_lms.h>
 
 #ifdef NO_INLINE
@@ -1048,4 +1049,4 @@ int wc_LmsKey_Verify(LmsKey * key, const byte * sig, word32 sigSz,
     return 0;
 }
 
-#endif /* WOLFSSL_HAVE_LMS */
+#endif /* WOLFSSL_HAVE_LMS && HAVE_LIBLMS */

--- a/wolfcrypt/src/ext_xmss.c
+++ b/wolfcrypt/src/ext_xmss.c
@@ -28,7 +28,8 @@
 #include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/sha256.h>
 
-#ifdef WOLFSSL_HAVE_XMSS
+#if defined(WOLFSSL_HAVE_XMSS) && defined(HAVE_LIBXMSS)
+
 #include <wolfssl/wolfcrypt/ext_xmss.h>
 
 #ifdef NO_INLINE
@@ -1042,4 +1043,4 @@ int wc_XmssKey_Verify(XmssKey * key, const byte * sig, word32 sigLen,
     return ret;
 }
 
-#endif /* WOLFSSL_HAVE_XMSS */
+#endif /* WOLFSSL_HAVE_XMSS && HAVE_LIBXMSS */

--- a/wolfssl/wolfcrypt/ext_lms.h
+++ b/wolfssl/wolfcrypt/ext_lms.h
@@ -22,12 +22,9 @@
 #ifndef EXT_LMS_H
 #define EXT_LMS_H
 
-#ifdef WOLFSSL_HAVE_LMS
-#include <wolfssl/wolfcrypt/lms.h>
+#if defined(WOLFSSL_HAVE_LMS) && defined(HAVE_LIBLMS)
 
-#if !defined(HAVE_LIBLMS)
-#error "This code requires liblms"
-#endif
+#include <wolfssl/wolfcrypt/lms.h>
 
 /* hash-sigs LMS HSS includes */
 #include <hss.h>

--- a/wolfssl/wolfcrypt/ext_xmss.h
+++ b/wolfssl/wolfcrypt/ext_xmss.h
@@ -22,12 +22,9 @@
 #ifndef EXT_XMSS_H
 #define EXT_XMSS_H
 
-#ifdef WOLFSSL_HAVE_XMSS
-#include <wolfssl/wolfcrypt/xmss.h>
+#if defined(WOLFSSL_HAVE_XMSS) && defined(HAVE_LIBXMSS)
 
-#if !defined(HAVE_LIBXMSS)
-    #error "This code requires libxmss"
-#endif
+#include <wolfssl/wolfcrypt/xmss.h>
 
 #include <xmss.h>
 #include <params.h>


### PR DESCRIPTION
# Description

Fixes for building wolfBoot sources for PQ LMS/XMSS
* Don't throw `#error "This code requires libxmss"`, just gate ext_xmss on `HAVE_LIBXMSS`. Same for LMS. This happens when wildcard *.c is being used for compilation.

# Testing

Building wolfBoot on Xilinx Vitis SDK with LMS and XMSS.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
