### PR TITLE
Add conditional repository_owner to workflow

### DIFF
--- a/.github/workflows/async.yml
+++ b/.github/workflows/async.yml
@@ -23,6 +23,7 @@ jobs:
           '--enable-ocsp CFLAGS="-DTEST_NONBLOCK_CERTS"',
         ]
     name: make check
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 6

--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   build_wolfssl:
     name: Build wolfSSL
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 4
@@ -38,6 +39,7 @@ jobs:
 
   test_curl:
     name: ${{ matrix.curl_ref }}
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 15

--- a/.github/workflows/cyrus-sasl.yml
+++ b/.github/workflows/cyrus-sasl.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   build_wolfssl:
     name: Build wolfSSL
+    if: github.repository_owner == 'wolfssl'
     # Just to keep it the same as the testing target
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
@@ -46,6 +47,7 @@ jobs:
         # List of releases to test
         ref: [ 2.1.28 ]
     name: ${{ matrix.ref }}
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 4

--- a/.github/workflows/disabled/haproxy.yml
+++ b/.github/workflows/disabled/haproxy.yml
@@ -20,6 +20,7 @@ jobs:
         # List of refs to test
         ref: [ master ]
     name: ${{ matrix.ref }}
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     steps:
       - name: Build wolfSSL

--- a/.github/workflows/disabled/hostap.yml
+++ b/.github/workflows/disabled/hostap.yml
@@ -22,6 +22,7 @@ jobs:
           - build_id: hostap-build2
             wolf_extra_config: --enable-brainpool --enable-wpas-dpp
     name: Build wolfSSL
+    if: github.repository_owner == 'wolfssl'
     # Just to keep it the same as the testing target
     runs-on: ubuntu-20.04
     # This should be a safe limit for the tests to run.
@@ -99,6 +100,7 @@ jobs:
               build_id: hostap-build2
             }
     name: hwsim test
+    if: github.repository_owner == 'wolfssl'
     # For openssl 1.1
     runs-on: ubuntu-20.04
     # This should be a safe limit for the tests to run.

--- a/.github/workflows/docker-Espressif.yml
+++ b/.github/workflows/docker-Espressif.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   espressif_latest:
     name: latest Docker container
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 12
@@ -25,6 +26,7 @@ jobs:
         run: . /opt/esp/idf/export.sh; IDE/Espressif/ESP-IDF/compileAllExamples.sh
   espressif_v4_4:
     name: v4.4 Docker container
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     container:
       image: espressif/idf:release-v4.4
@@ -34,6 +36,7 @@ jobs:
         run: . /opt/esp/idf/export.sh; IDE/Espressif/ESP-IDF/compileAllExamples.sh
   espressif_v5_0:
     name: v5.0 Docker container
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     container:
       image: espressif/idf:release-v5.0

--- a/.github/workflows/docker-OpenWrt.yml
+++ b/.github/workflows/docker-OpenWrt.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
     build_library:
         name: Compile libwolfssl.so
+        if: github.repository_owner == 'wolfssl'
         runs-on: ubuntu-latest
         # This should be a safe limit for the tests to run.
         timeout-minutes: 4
@@ -40,6 +41,7 @@ jobs:
                 retention-days: 5
     compile_container:
         name: Compile container
+        if: github.repository_owner == 'wolfssl'
         runs-on: ubuntu-latest
         # This should be a safe limit for the tests to run.
         timeout-minutes: 2

--- a/.github/workflows/grpc.yml
+++ b/.github/workflows/grpc.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   build_wolfssl:
     name: Build wolfSSL
+    if: github.repository_owner == 'wolfssl'
     # Just to keep it the same as the testing target
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
@@ -50,6 +51,7 @@ jobs:
               test_core_security_ssl_credentials_test test_cpp_end2end_ssl_credentials_test
               h2_ssl_cert_test h2_ssl_session_reuse_test
     name: ${{ matrix.ref }}
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 30

--- a/.github/workflows/hitch.yml
+++ b/.github/workflows/hitch.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   build_wolfssl:
     name: Build wolfSSL
+    if: github.repository_owner == 'wolfssl'
     # Just to keep it the same as the testing target
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
@@ -47,6 +48,7 @@ jobs:
             ignore-tests: >-
               test13-r82.sh test15-proxy-v2-npn.sh test39-client-cert-proxy.sh
     name: ${{ matrix.ref }}
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 4

--- a/.github/workflows/hostap-vm.yml
+++ b/.github/workflows/hostap-vm.yml
@@ -27,6 +27,7 @@ jobs:
               --enable-wpas-dpp --enable-brainpool --with-eccminsz=192
               --enable-tlsv10 --enable-oldtls
     name: Build wolfSSL
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 10
@@ -64,6 +65,7 @@ jobs:
 
   build_uml_linux:
     name: Build UML (UserMode Linux)
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 10
@@ -140,6 +142,7 @@ jobs:
             }
     name: hwsim test
     # For openssl 1.1
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 45

--- a/.github/workflows/ipmitool.yml
+++ b/.github/workflows/ipmitool.yml
@@ -18,6 +18,7 @@ jobs:
     name: Build wolfSSL
     # Just to keep it the same as the testing target
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'wolfssl'
     # This should be a safe limit for the tests to run.
     timeout-minutes: 4
     steps:
@@ -46,6 +47,7 @@ jobs:
       matrix:
         git_ref: [ c3939dac2c060651361fc71516806f9ab8c38901 ]
     name: ${{ matrix.git_ref }}
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     needs: build_wolfssl
     steps:

--- a/.github/workflows/jwt-cpp.yml
+++ b/.github/workflows/jwt-cpp.yml
@@ -16,6 +16,7 @@ jobs:
   build_wolfssl:
     name: Build wolfSSL
     # Just to keep it the same as the testing target
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 4
@@ -45,6 +46,7 @@ jobs:
       matrix:
         ref: [ 0.6.0 ]
     name: ${{ matrix.ref }}
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     needs: build_wolfssl
     steps:

--- a/.github/workflows/krb5.yml
+++ b/.github/workflows/krb5.yml
@@ -16,6 +16,7 @@ jobs:
   build_wolfssl:
     name: Build wolfSSL
     # Just to keep it the same as the testing target
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 5
@@ -48,6 +49,7 @@ jobs:
         # List of releases to test
         ref: [ 1.21.1 ]
     name: ${{ matrix.ref }}
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 8

--- a/.github/workflows/libssh2.yml
+++ b/.github/workflows/libssh2.yml
@@ -16,6 +16,7 @@ jobs:
   build_wolfssl:
     name: Build wolfSSL
     # Just to keep it the same as the testing target
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 4
@@ -45,6 +46,7 @@ jobs:
         # List of releases to test
         ref: [ 1.11.0 ]
     name: ${{ matrix.ref }}
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 8

--- a/.github/workflows/libvncserver.yml
+++ b/.github/workflows/libvncserver.yml
@@ -16,6 +16,7 @@ jobs:
   build_wolfssl:
     name: Build wolfSSL
     # Just to keep it the same as the testing target
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 4
@@ -45,6 +46,7 @@ jobs:
       matrix:
         ref: [ 0.9.13 ]
     name: ${{ matrix.ref }}
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     needs: build_wolfssl
     steps:

--- a/.github/workflows/memcached.yml
+++ b/.github/workflows/memcached.yml
@@ -16,6 +16,7 @@ jobs:
   build_wolfssl:
     name: Build wolfSSL
     # Just to keep it the same as the testing target
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     steps:
       - name: Build wolfSSL
@@ -46,6 +47,7 @@ jobs:
         include:
           - ref: 1.6.22
     name: ${{ matrix.ref }}
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     needs: build_wolfssl
     steps:

--- a/.github/workflows/mosquitto.yml
+++ b/.github/workflows/mosquitto.yml
@@ -16,6 +16,7 @@ jobs:
   build_wolfssl:
     name: Build wolfSSL
     # Just to keep it the same as the testing target
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 4
@@ -43,6 +44,7 @@ jobs:
       matrix:
         ref: [ 2.0.18 ]
     name: ${{ matrix.ref }}
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 4

--- a/.github/workflows/multi-arch.yml
+++ b/.github/workflows/multi-arch.yml
@@ -36,6 +36,7 @@ jobs:
             CFLAGS: -marm -DWOLFSSL_SP_ARM_ARCH=6
             ARCH: armel
             EXTRA_OPTS: --enable-sp-asm
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 10

--- a/.github/workflows/multi-compiler.yml
+++ b/.github/workflows/multi-compiler.yml
@@ -46,6 +46,7 @@ jobs:
           - CC: clang-14
             CXX: clang++-14
             OS: ubuntu-latest
+    if: github.repository_owner == 'wolfssl'
     runs-on: ${{ matrix.OS }}
     # This should be a safe limit for the tests to run.
     timeout-minutes: 4

--- a/.github/workflows/net-snmp.yml
+++ b/.github/workflows/net-snmp.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   build_wolfssl:
     name: Build wolfSSL
+    if: github.repository_owner == 'wolfssl'
     # Just to keep it the same as the testing target
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
@@ -46,6 +47,7 @@ jobs:
           - ref: 5.9.3
             test_opts: -e 'agentxperl'
     name: ${{ matrix.ref }}
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 4

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   build_wolfssl:
     name: Build wolfSSL
+    if: github.repository_owner == 'wolfssl'
     # Just to keep it the same as the testing target
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
@@ -105,6 +106,7 @@ jobs:
               stream_proxy_protocol_ssl.t stream_proxy_ssl_conf_command.t stream_proxy_ssl.t
               stream_proxy_ssl_verify.t
     name: ${{ matrix.ref }}
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 6

--- a/.github/workflows/no-malloc.yml
+++ b/.github/workflows/no-malloc.yml
@@ -21,6 +21,7 @@ jobs:
           '--enable-rsa --enable-keygen --disable-dh CFLAGS="-DWOLFSSL_NO_MALLOC -DRSA_MIN_SIZE=1024"',
         ]
     name: make check
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 6

--- a/.github/workflows/ntp.yml
+++ b/.github/workflows/ntp.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   build_wolfssl:
     name: Build wolfSSL
+    if: github.repository_owner == 'wolfssl'
     # Just to keep it the same as the testing target
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
@@ -45,6 +46,7 @@ jobs:
         # List of releases to test
         ref: [ 4.2.8p15 ]
     name: ${{ matrix.ref }}
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 10

--- a/.github/workflows/ocsp.yml
+++ b/.github/workflows/ocsp.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   ocsp_stapling:
     name: ocsp stapling
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/openssh.yml
+++ b/.github/workflows/openssh.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   build_wolfssl:
     name: Build wolfSSL
+    if: github.repository_owner == 'wolfssl'
     # Just to keep it the same as the testing target
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
@@ -47,6 +48,7 @@ jobs:
           - git_ref: 'V_9_6_P1'
             osp_ver: '9.6'
     name: ${{ matrix.ref }}
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     needs: build_wolfssl
     steps:

--- a/.github/workflows/openvpn.yml
+++ b/.github/workflows/openvpn.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   build_wolfssl:
     name: Build wolfSSL
+    if: github.repository_owner == 'wolfssl'
     # Just to keep it the same as the testing target
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
@@ -44,6 +45,7 @@ jobs:
         # List of refs to test
         ref: [ release/2.6, v2.6.0, master ]
     name: ${{ matrix.ref }}
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 10

--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -40,6 +40,7 @@ jobs:
            --enable-dtls-mtu',
         ]
     name: make check
+    if: github.repository_owner == 'wolfssl'
     runs-on: ${{ matrix.os }}
     # This should be a safe limit for the tests to run.
     timeout-minutes: 14
@@ -60,6 +61,7 @@ jobs:
           'examples/configs/user_settings_all.h',
         ]
     name: make user_setting.h
+    if: github.repository_owner == 'wolfssl'
     runs-on: ${{ matrix.os }}
     # This should be a safe limit for the tests to run.
     timeout-minutes: 14
@@ -85,6 +87,7 @@ jobs:
           'examples/configs/user_settings_tls12.h',
         ]
     name: make user_setting.h (testwolfcrypt only)
+    if: github.repository_owner == 'wolfssl'
     runs-on: ${{ matrix.os }}
     # This should be a safe limit for the tests to run.
     timeout-minutes: 14
@@ -106,6 +109,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
     name: make user_setting.h (with sed)
+    if: github.repository_owner == 'wolfssl'
     runs-on: ${{ matrix.os }}
     # This should be a safe limit for the tests to run.
     timeout-minutes: 14
@@ -124,6 +128,7 @@ jobs:
 
   windows_build:
     name: Windows Build Test
+    if: github.repository_owner == 'wolfssl'
     runs-on: windows-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 6

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   build_wolfssl:
     name: Package wolfSSL
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 10

--- a/.github/workflows/pam-ipmi.yml
+++ b/.github/workflows/pam-ipmi.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   build_wolfssl:
     name: Build wolfSSL
+    if: github.repository_owner == 'wolfssl'
     # Just to keep it the same as the testing target
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
@@ -46,6 +47,7 @@ jobs:
       matrix:
         git_ref: [ e4b13e6725abb178f62ee897fe1c0e81b06a9431 ]
     name: ${{ matrix.git_ref }}
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     needs: build_wolfssl
     steps:

--- a/.github/workflows/rng-tools.yml
+++ b/.github/workflows/rng-tools.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   build_wolfssl:
     name: Build wolfSSL
+    if: github.repository_owner == 'wolfssl'
     # Just to keep it the same as the testing target
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
@@ -45,6 +46,7 @@ jobs:
         # List of releases to test
         ref: [ 6.16 ]
     name: ${{ matrix.ref }}
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 4

--- a/.github/workflows/socat.yml
+++ b/.github/workflows/socat.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   build_wolfssl:
     name: Build wolfSSL
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     timeout-minutes: 4
     steps:
@@ -37,8 +38,7 @@ jobs:
 
 
   socat_check:
-    strategy:
-      fail-fast: false
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 30

--- a/.github/workflows/stunnel.yml
+++ b/.github/workflows/stunnel.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   build_wolfssl:
     name: Build wolfSSL
+    if: github.repository_owner == 'wolfssl'
     # Just to keep it the same as the testing target
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
@@ -44,6 +45,7 @@ jobs:
         # List of releases to test
         ref: [ 5.67 ]
     name: ${{ matrix.ref }}
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 4

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -25,6 +25,7 @@ jobs:
             zephyr-sdk: 0.16.3
           - zephyr-ref: v2.7.4
             zephyr-sdk: 0.16.3
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     # This should be a safe limit for the tests to run.
     timeout-minutes: 25


### PR DESCRIPTION
# Description

This PR adds a workflow condition to only run the workflow on wolfssl-owned repositories (in this case, [async.yml](https://github.com/wolfSSL/wolfssl/compare/master...gojimmypi:wolfssl:pr-repo-owner-check?expand=1#diff-0a009bf1c1ebe9e868237e406808864f41ee3af04b3b371e70a86a1f5a53027d)). I propose doing this on all workflows, but this PR is only for the first one to open a discussion and code review. I'm happy to make the changes for others.

Why?

I've recently begun implementing automated Espressif CI testing. One of the things that has been annoying and even problematic has been all the upstream workflows running in my fork, such as this sync from upstream:

![image](https://github.com/user-attachments/assets/daff7acc-ef74-4b68-983b-2aeada39481f)

Worse, some of them appear to never stop:

![image](https://github.com/user-attachments/assets/fcd75187-990f-4efa-8d05-670ccde2fd23)

Although I think that's actually a GitHub bug, as the ones from last month are not actually running:

![image](https://github.com/user-attachments/assets/7922729b-7036-4be3-9307-584ed51d72b7)


Fixes zd# n/a

# Testing

How did you test?

not tested.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
