### PR TITLE
20240814-linuxkm-kyber-asm

### DIFF
--- a/linuxkm/Kbuild
+++ b/linuxkm/Kbuild
@@ -115,7 +115,8 @@ $(obj)/wolfcrypt/benchmark/benchmark.o: asflags-y = $(WOLFSSL_ASFLAGS) $(ASFLAGS
 asflags-y := $(WOLFSSL_ASFLAGS) $(ASFLAGS_FPUSIMD_DISABLE)
 
 # vectorized implementations that are kernel-safe are listed here.
-# these are known kernel-compatible, but they still irritate objtool.
+# these are known kernel-compatible, but need the vector instructions enabled in the assembler,
+# and most of them still irritate objtool.
 $(obj)/wolfcrypt/src/aes_asm.o: asflags-y = $(WOLFSSL_ASFLAGS) $(ASFLAGS_FPU_DISABLE_SIMD_ENABLE)
 $(obj)/wolfcrypt/src/aes_asm.o: OBJECT_FILES_NON_STANDARD := y
 $(obj)/wolfcrypt/src/aes_gcm_asm.o: asflags-y = $(WOLFSSL_ASFLAGS) $(ASFLAGS_FPU_DISABLE_SIMD_ENABLE)
@@ -134,6 +135,7 @@ $(obj)/wolfcrypt/src/chacha_asm.o: asflags-y = $(WOLFSSL_ASFLAGS) $(ASFLAGS_FPU_
 $(obj)/wolfcrypt/src/chacha_asm.o: OBJECT_FILES_NON_STANDARD := y
 $(obj)/wolfcrypt/src/poly1305_asm.o: asflags-y = $(WOLFSSL_ASFLAGS) $(ASFLAGS_FPU_DISABLE_SIMD_ENABLE)
 $(obj)/wolfcrypt/src/poly1305_asm.o: OBJECT_FILES_NON_STANDARD := y
+$(obj)/wolfcrypt/src/wc_kyber_asm.o: asflags-y = $(WOLFSSL_ASFLAGS) $(ASFLAGS_FPU_DISABLE_SIMD_ENABLE)
 
 ifeq "$(ENABLED_LINUXKM_PIE)" "yes"
 

--- a/linuxkm/module_exports.c.template
+++ b/linuxkm/module_exports.c.template
@@ -171,6 +171,9 @@
     #include <wolfssl/wolfcrypt/wc_lms.h>
 #endif
 #endif
+#ifdef HAVE_DILITHIUM
+    #include <wolfssl/wolfcrypt/dilithium.h>
+#endif
 
 #ifdef OPENSSL_EXTRA
   #ifndef WOLFCRYPT_ONLY

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -613,6 +613,10 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
         #define AESNI_ALIGN 16
     #endif
 
+    /* note that all write access to these static variables must be idempotent,
+     * as arranged by Check_CPU_support_AES(), else they will be susceptible to
+     * data races.
+     */
     static int checkedAESNI = 0;
     static int haveAESNI  = 0;
     static word32 intel_flags = 0;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -19717,13 +19717,14 @@ static int DecodeAuthKeyId(const byte* input, word32 sz, DecodedCert* cert)
         return ASN_PARSE_E;
     }
 
+    cert->extAuthKeyIdSz = length;
+
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 #ifdef WOLFSSL_AKID_NAME
     cert->extRawAuthKeyIdSrc = input;
     cert->extRawAuthKeyIdSz = sz;
 #endif
     cert->extAuthKeyIdSrc = &input[idx];
-    cert->extAuthKeyIdSz = length;
 #endif /* OPENSSL_EXTRA */
 
     return GetHashId(input + idx, length, cert->extAuthKeyId,
@@ -19819,9 +19820,9 @@ static int DecodeSubjKeyId(const byte* input, word32 sz, DecodedCert* cert)
 
     ret = GetOctetString(input, &idx, &length, sz);
     if (ret > 0) {
+        cert->extSubjKeyIdSz = (word32)length;
     #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
         cert->extSubjKeyIdSrc = &input[idx];
-        cert->extSubjKeyIdSz = (word32)length;
     #endif /* OPENSSL_EXTRA */
 
         /* Get the hash or hash of the hash if wrong size. */

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -408,6 +408,10 @@ static int InitSha256(wc_Sha256* sha256)
                        SHA256_SSE2, SHA256_C };
 
 #ifndef WC_C_DYNAMIC_FALLBACK
+    /* note that all write access to this static variable must be idempotent,
+     * as arranged by Sha256_SetTransform(), else it will be susceptible to
+     * data races.
+     */
     static enum sha_methods sha_method = SHA256_UNSET;
 #endif
 

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -489,6 +489,10 @@ static int InitSha512_256(wc_Sha512* sha512)
                        SHA512_AVX1_RORX, SHA512_AVX2_RORX, SHA512_C };
 
 #ifndef WC_C_DYNAMIC_FALLBACK
+    /* note that all write access to this static variable must be idempotent,
+     * as arranged by Sha512_SetTransform(), else it will be susceptible to
+     * data races.
+     */
     static enum sha_methods sha_method = SHA512_UNSET;
 #endif
 

--- a/wolfcrypt/src/wc_kyber.c
+++ b/wolfcrypt/src/wc_kyber.c
@@ -407,14 +407,8 @@ static int kyberkey_encapsulate(KyberKey* key, const byte* msg, byte* coins,
 
     if (ret == 0) {
         /* Allocate dynamic memory for all matrices, vectors and polynomials. */
-#ifndef USE_INTEL_SPEEDUP
         at = (sword16*)XMALLOC(((kp + 3) * kp + 3) * KYBER_N * sizeof(sword16),
             key->heap, DYNAMIC_TYPE_TMP_BUFFER);
-#else
-        at = (sword16*)XMALLOC(
-            ((KYBER_MAX_K + 3) * KYBER_MAX_K + 3) * KYBER_N * sizeof(sword16),
-            key->heap, DYNAMIC_TYPE_TMP_BUFFER);
-#endif
         if (at == NULL) {
             ret = MEMORY_E;
         }

--- a/wolfcrypt/src/wc_kyber.c
+++ b/wolfcrypt/src/wc_kyber.c
@@ -377,11 +377,7 @@ static int kyberkey_encapsulate(KyberKey* key, const byte* msg, byte* coins,
     sword16* epp = NULL;
     unsigned int kp = 0;
     unsigned int compVecSz = 0;
-#ifndef USE_INTEL_SPEEDUP
     sword16* at = NULL;
-#else
-    sword16 at[((KYBER_MAX_K + 3) * KYBER_MAX_K + 3) * KYBER_N];
-#endif
 
     /* Establish parameters based on key type. */
     switch (key->type) {
@@ -409,16 +405,20 @@ static int kyberkey_encapsulate(KyberKey* key, const byte* msg, byte* coins,
         break;
     }
 
-#ifndef USE_INTEL_SPEEDUP
     if (ret == 0) {
         /* Allocate dynamic memory for all matrices, vectors and polynomials. */
+#ifndef USE_INTEL_SPEEDUP
         at = (sword16*)XMALLOC(((kp + 3) * kp + 3) * KYBER_N * sizeof(sword16),
             key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+#else
+        at = (sword16*)XMALLOC(
+            ((KYBER_MAX_K + 3) * KYBER_MAX_K + 3) * KYBER_N * sizeof(sword16),
+            key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
         if (at == NULL) {
             ret = MEMORY_E;
         }
     }
-#endif
 
     if (ret == 0) {
         /* Assign allocated dynamic memory to pointers.
@@ -472,10 +472,8 @@ static int kyberkey_encapsulate(KyberKey* key, const byte* msg, byte* coins,
     #endif
     }
 
-#ifndef USE_INTEL_SPEEDUP
     /* Dispose of dynamic memory allocated in function. */
     XFREE(at, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
-#endif
 
     return ret;
 }

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1724,7 +1724,9 @@ struct DecodedCert {
     const byte* extCrlInfo;          /* CRL Distribution Points          */
     int     extCrlInfoSz;            /* length of the URI                */
     byte    extSubjKeyId[KEYID_SIZE]; /* Subject Key ID                  */
+    word32  extSubjKeyIdSz;
     byte    extAuthKeyId[KEYID_SIZE]; /* Authority Key ID                */
+    word32  extAuthKeyIdSz;
 #ifdef WOLFSSL_AKID_NAME
     const byte* extAuthKeyIdIssuer;  /* Authority Key ID authorityCertIssuer */
     word32  extAuthKeyIdIssuerSz;    /* Authority Key ID authorityCertIssuer length */
@@ -1751,9 +1753,7 @@ struct DecodedCert {
     word32  extRawAuthKeyIdSz;
 #endif
     const byte* extAuthKeyIdSrc;
-    word32  extAuthKeyIdSz;
     const byte* extSubjKeyIdSrc;
-    word32  extSubjKeyIdSz;
 #endif
 #ifdef OPENSSL_ALL
     const byte* extSubjAltNameSrc;


### PR DESCRIPTION
linuxkm: add intelasm support for Kyber.

ASN: move `DecodedCert.extSubjKeyIdSz` and `.extAuthKeyIdSz` out of the `OPENSSL_EXTRA` gate.  fixes `test.c`:`certext_test()`, broken by f8c968d8d1, detected by nightly scenarios `linuxkm-defaults-all-fips-140-3`, `linuxkm-defaults-all-fips-140-3-pilot`, `linuxkm-defaults-all-no-asm`, `linuxkm-defaults-all-intelasm`, and `all-linuxkm-defaults-error-code-openssl`.

add comments explaining dependence on idempotency for race-free dynamics re `checkedAESNI`, `haveAESNI`, `intel_flags`, and `sha_method`.  see #7863.

tested with `wolfssl-multi-test.sh ... super-quick-check linuxkm-defaults-all-fips-140-3 linuxkm-defaults-all-no-asm all-g\\+\\+ quantum-safe-wolfssl-all-crypto-only-intelasm-sp-asm-linuxkm-insmod`
