### PR TITLE
POSIX does not request "date" command to support "-R" option.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ AS_IF([ test -n "$CFLAG_VISIBILITY" ], [
        AM_CFLAGS="$AM_CFLAGS $CFLAG_VISIBILITY"
        ])
 
-WOLFSSL_BUILD_DATE=$(date -R)
+WOLFSSL_BUILD_DATE=$(LC_TIME=C date +"%a, %d %b %Y %T %z")
 AC_SUBST([WOLFSSL_BUILD_DATE])
 
 


### PR DESCRIPTION
Currently configure script sets WOLFSSL_BUILD_DATE by "date -R", like:

```
WOLFSSL_BUILD_DATE=$(date -R)
```

According to POSIX specification [IEEE Std 1003.1-2024](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/date.html), "date" command can lack the "-R" option. In fact, online manuals for preinstalled "date" commands in some proprietary systems does not mention the "-R":
- [Solaris 11.4](https://docs.oracle.com/cd/E88353_01/html/E37839/date-1.html)
- [HP-UX 11.22](https://man.freebsd.org/cgi/man.cgi?query=date&apropos=0&sektion=0&manpath=HP-UX+11.22&arch=default&format=html)
- [AIX 7.3](https://www.ibm.com/docs/en/aix/7.3?topic=d-date-command)

Setting locale to C (to prevent localized weekday name like "月" for Monday) and spelling-out the format can make "configure" more portable.

```
diff --git a/configure.ac b/configure.ac
index 3f5f44a3c..ef18a574c 100644
--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ AS_IF([ test -n "$CFLAG_VISIBILITY" ], [
        AM_CFLAGS="$AM_CFLAGS $CFLAG_VISIBILITY"
        ])

-WOLFSSL_BUILD_DATE=$(date -R)
+WOLFSSL_BUILD_DATE=$(env LC_TIME=C date +"%a, %d %b %Y %T %z")
 AC_SUBST([WOLFSSL_BUILD_DATE])
```