### PR TITLE
20240814-debug-trace-errcodes-MP

### DIFF
--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -632,6 +632,10 @@
         #endif
         #endif
 
+        #ifdef WOLFSSL_DEBUG_BACKTRACE_ERROR_CODES
+        typeof(dump_stack) *dump_stack;
+        #endif
+
         const void *_last_slot;
     };
 
@@ -775,6 +779,10 @@
         #ifndef NO_SKID
             #define GetCAByName (wolfssl_linuxkm_get_pie_redirect_table()->GetCAByName)
         #endif
+    #endif
+
+    #ifdef WOLFSSL_DEBUG_BACKTRACE_ERROR_CODES
+        #define dump_stack (wolfssl_linuxkm_get_pie_redirect_table()->dump_stack)
     #endif
 
     #endif /* __PIE__ */

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -580,6 +580,10 @@ static int set_up_wolfssl_linuxkm_pie_redirect_table(void) {
 #endif
 #endif
 
+#ifdef WOLFSSL_DEBUG_BACKTRACE_ERROR_CODES
+    wolfssl_linuxkm_pie_redirect_table.dump_stack = dump_stack;
+#endif
+
     /* runtime assert that the table has no null slots after initialization. */
     {
         unsigned long *i;

--- a/src/internal.c
+++ b/src/internal.c
@@ -25142,7 +25142,7 @@ const char* wolfSSL_ERR_reason_error_string(unsigned long e)
     }
 
     /* pass to wolfCrypt */
-    if (error < MAX_CODE_E && error > MIN_CODE_E) {
+    if (error <= WC_FIRST_E && error >= WC_LAST_E) {
         return wc_GetErrorString(error);
     }
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -15361,7 +15361,9 @@ int wolfSSL_ERR_GET_REASON(unsigned long err)
     ret = 0 - ret; /* setting as negative value */
     /* wolfCrypt range is less than MAX (-100)
        wolfSSL range is MIN (-300) and lower */
-    if (ret < MAX_CODE_E && ret > MIN_CODE_E) {
+    if ((ret <= WC_FIRST_E && ret >=  WC_LAST_E) ||
+        (ret <= WOLFSSL_FIRST_E && ret >= WOLFSSL_LAST_E))
+    {
         return ret;
     }
     else {

--- a/support/gen-debug-trace-error-codes.sh
+++ b/support/gen-debug-trace-error-codes.sh
@@ -12,7 +12,7 @@ BEGIN {
     print("#undef WOLFSSL_DEBUG_TRACE_ERROR_CODES_H") >> "wolfssl/debug-untrace-error-codes.h";
 }
 {
-    if (match($0, "^[[:space:]]+([A-Z][A-Z0-9_]+)[[:space:]]*=[[:space:]]*(-[0-9]+)[,[:space:]]")) {
+    if (match($0, "^[[:space:]]+([A-Z][A-Z0-9_]+)[[:space:]]*=[[:space:]]*(-[0-9]+)([,[:space:]]|$)")) {
 
         # for mawkward compatibility -- gawk allows errcode_a as the 3rd arg to match().
         gsub("^[[:space:]]+", "", $0);

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -2491,8 +2491,7 @@ static int _ecc_projective_dbl_point(ecc_point *P, ecc_point *R, mp_int* a,
    }
    if (err == MP_OKAY && mp_iszero((MP_INT_SIZE*)t2)) {
       /* T2 = X * X */
-      if (err == MP_OKAY)
-          err = mp_sqr(x, t2);
+      err = mp_sqr(x, t2);
       if (err == MP_OKAY)
           err = mp_montgomery_reduce(t2, modulus, mp);
       /* T1 = T2 + T1 */
@@ -2506,8 +2505,7 @@ static int _ecc_projective_dbl_point(ecc_point *P, ecc_point *R, mp_int* a,
       /* use "a" in calc */
 
       /* T2 = T1 * T1 */
-      if (err == MP_OKAY)
-          err = mp_sqr(t1, t2);
+      err = mp_sqr(t1, t2);
       if (err == MP_OKAY)
           err = mp_montgomery_reduce(t2, modulus, mp);
       /* T1 = T2 * a */

--- a/wolfcrypt/src/error.c
+++ b/wolfcrypt/src/error.c
@@ -44,6 +44,18 @@ const char* wc_GetErrorString(int error)
 {
     switch (error) {
 
+    case MP_MEM :
+        return "MP integer dynamic memory allocation failed";
+
+    case MP_VAL :
+        return "MP integer invalid argument";
+
+    case MP_WOULDBLOCK :
+        return "MP integer non-blocking operation would block";
+
+    case MP_NOT_INF:
+        return "MP point not at infinity";
+
     case OPEN_RAN_E :
         return "opening random device error";
 

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -1721,6 +1721,14 @@ void WOLFSSL_ERROR_MSG(const char* msg)
 
 #ifdef WOLFSSL_DEBUG_BACKTRACE_ERROR_CODES
 
+#ifdef WOLFSSL_LINUXKM
+
+void wc_backtrace_render(void) {
+    dump_stack();
+}
+
+#else /* !WOLFSSL_LINUXKM */
+
 #include <backtrace-supported.h>
 
 #if BACKTRACE_SUPPORTED != 1
@@ -1848,5 +1856,6 @@ void wc_backtrace_render(void) {
 
     wc_UnLockMutex(&backtrace_mutex);
 }
+#endif /* !WOLFSSL_LINUXKM */
 
 #endif /* WOLFSSL_DEBUG_BACKTRACE_ERROR_CODES */

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -31,6 +31,7 @@ This library provides single precision (SP) integer math functions.
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
 
 #if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
 

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -5685,9 +5685,9 @@ int mp_rand_prime(mp_int* a, int len, WC_RNG* rng, void* heap)
 
     err = fp_randprime(a, len, rng, heap);
     switch(err) {
-        case FP_VAL:
+        case WC_NO_ERR_TRACE(MP_VAL):
             return MP_VAL;
-        case FP_MEM:
+        case WC_NO_ERR_TRACE(MP_MEM):
             return MP_MEM;
         default:
             break;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -2623,40 +2623,54 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t error_test(void)
     int i;
     int j = 0;
     /* Values that are not or no longer error codes. */
-    int missing[] = { -124, -166, -167, -168, -169,   0 };
+    static const struct {
+        int first;
+        int last;
+    } missing[] = {
+        { -6, -100 },
+        { -124, -124 },
+        { -166, -169 }
+    };
 
     /* Check that all errors have a string and it's the same through the two
      * APIs. Check that the values that are not errors map to the unknown
      * string.
      */
-    for (i = MAX_CODE_E-1; i >= WC_LAST_E; i--) {
+    for (i = WC_FIRST_E; i >= WC_LAST_E; i--) {
+        int this_missing = 0;
+        for (j = 0; j < (int)XELEM_CNT(missing); ++j) {
+            if ((i <= missing[j].first) && (i >= missing[j].last)) {
+                this_missing = 1;
+                break;
+            }
+        }
         errStr = wc_GetErrorString(i);
         wc_ErrorString(i, out);
 
-        if (i != missing[j]) {
+        if (! this_missing) {
             if (XSTRCMP(errStr, unknownStr) == 0) {
                 WOLFSSL_MSG("errStr unknown");
-                return WC_TEST_RET_ENC_NC;
+                return WC_TEST_RET_ENC_I(-i);
             }
             if (XSTRCMP(out, unknownStr) == 0) {
                 WOLFSSL_MSG("out unknown");
-                return WC_TEST_RET_ENC_NC;
+                return WC_TEST_RET_ENC_I(-i);
             }
             if (XSTRCMP(errStr, out) != 0) {
                 WOLFSSL_MSG("errStr does not match output");
-                return WC_TEST_RET_ENC_NC;
+                return WC_TEST_RET_ENC_I(-i);
             }
             if (XSTRLEN(errStr) >= WOLFSSL_MAX_ERROR_SZ) {
                 WOLFSSL_MSG("errStr too long");
-                return WC_TEST_RET_ENC_NC;
+                return WC_TEST_RET_ENC_I(-i);
             }
         }
         else {
             j++;
             if (XSTRCMP(errStr, unknownStr) != 0)
-                return WC_TEST_RET_ENC_NC;
+                return WC_TEST_RET_ENC_I(-i);
             if (XSTRCMP(out, unknownStr) != 0)
-                return WC_TEST_RET_ENC_NC;
+                return WC_TEST_RET_ENC_I(-i);
         }
     }
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -2627,7 +2627,6 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t error_test(void)
         int first;
         int last;
     } missing[] = {
-        { -6, -100 },
         { -124, -124 },
         { -166, -169 }
     };

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -35,6 +35,8 @@
 #endif
 
 enum wolfSSL_ErrorCodes {
+    WOLFSSL_FIRST_E              = -301,
+
     INPUT_CASE_ERROR             = -301,   /* process input state error */
     PREFIX_ERROR                 = -302,   /* bad index to key rounds  */
     MEMORY_ERROR                 = -303,   /* out of memory            */
@@ -196,8 +198,11 @@ enum wolfSSL_ErrorCodes {
     KEY_SHARE_ERROR              = -503,   /* key share mismatch */
     POST_HAND_AUTH_ERROR         = -504,   /* client won't do post-hand auth */
     HRR_COOKIE_ERROR             = -505,   /* HRR msg cookie mismatch */
-    UNSUPPORTED_CERTIFICATE      = -506    /* unsupported certificate type */
+    UNSUPPORTED_CERTIFICATE      = -506,   /* unsupported certificate type */
     /* end negotiation parameter errors only 10 for now */
+
+    WOLFSSL_LAST_E               = -506
+
     /* add strings to wolfSSL_ERR_reason_error_string in internal.c !!!!! */
 
     /* no error strings go down here, add above negotiation errors !!!! */

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -220,7 +220,7 @@ enum wolfSSL_ErrorCodes {
 WOLFSSL_LOCAL
 void SetErrorString(int err, char* buff);
 
-#ifdef WOLFSSL_DEBUG_TRACE_ERROR_CODES
+#if defined(WOLFSSL_DEBUG_TRACE_ERROR_CODES) && defined(BUILDING_WOLFSSL)
     #include <wolfssl/debug-trace-error-codes.h>
 #endif
 

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -43,14 +43,14 @@ the error status.
 
 /* error codes, add string for new errors !!! */
 enum {
-    MAX_CODE_E         =   -1,  /* errors -2 - -299 */
-    WC_FIRST_E         =   -2,  /* errors -2 - -299 */
+    MAX_CODE_E         =  -96,  /* errors -97 - -299 */
+    WC_FIRST_E         =  -97,  /* errors -97 - -299 */
 
-    MP_MEM             =   -2,  /* MP dynamic memory allocation failed. */
-    MP_VAL             =   -3,  /* MP value passed is not able to be used. */
-    MP_WOULDBLOCK      =   -4,  /* MP non-blocking operation is returning after
+    MP_MEM             =  -97,  /* MP dynamic memory allocation failed. */
+    MP_VAL             =  -98,  /* MP value passed is not able to be used. */
+    MP_WOULDBLOCK      =  -99,  /* MP non-blocking operation is returning after
                                  * partial completion. */
-    MP_NOT_INF         =   -5,  /* MP point not at infinity */
+    MP_NOT_INF         = -100,  /* MP point not at infinity */
 
     OPEN_RAN_E         = -101,  /* opening random device error */
     READ_RAN_E         = -102,  /* reading random device error */
@@ -304,10 +304,7 @@ WOLFSSL_API void wc_ErrorString(int err, char* buff);
 WOLFSSL_ABI WOLFSSL_API const char* wc_GetErrorString(int error);
 #endif
 
-#if defined(WOLFSSL_DEBUG_TRACE_ERROR_CODES) && !defined(BUILDING_WOLFSSL)
-    #undef WOLFSSL_DEBUG_TRACE_ERROR_CODES
-#endif
-#ifdef WOLFSSL_DEBUG_TRACE_ERROR_CODES
+#if defined(WOLFSSL_DEBUG_TRACE_ERROR_CODES) && defined(BUILDING_WOLFSSL)
     extern void wc_backtrace_render(void);
     #define WC_NO_ERR_TRACE(label) (CONST_NUM_ERR_ ## label)
     #ifndef WOLFSSL_DEBUG_BACKTRACE_RENDER_CLAUSE

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -37,10 +37,21 @@ the error status.
     extern "C" {
 #endif
 
+#ifdef WOLFSSL_DEBUG_TRACE_ERROR_CODES_H
+#include <wolfssl/debug-untrace-error-codes.h>
+#endif
 
 /* error codes, add string for new errors !!! */
 enum {
-    MAX_CODE_E         = -100,  /* errors -101 - -299 */
+    MAX_CODE_E         =   -1,  /* errors -2 - -299 */
+    WC_FIRST_E         =   -2,  /* errors -2 - -299 */
+
+    MP_MEM             =   -2,  /* MP dynamic memory allocation failed. */
+    MP_VAL             =   -3,  /* MP value passed is not able to be used. */
+    MP_WOULDBLOCK      =   -4,  /* MP non-blocking operation is returning after
+                                 * partial completion. */
+    MP_NOT_INF         =   -5,  /* MP point not at infinity */
+
     OPEN_RAN_E         = -101,  /* opening random device error */
     READ_RAN_E         = -102,  /* reading random device error */
     WINCRYPT_E         = -103,  /* windows crypt init error */
@@ -276,12 +287,11 @@ enum {
     SM4_CCM_AUTH_E      = -299,  /* SM4-CCM Authentication check failure */
 
     WC_LAST_E           = -299,  /* Update this to indicate last error */
-    MIN_CODE_E          = -300   /* errors -101 - -299 */
+    MIN_CODE_E          = -300   /* errors -2 - -299 */
 
     /* add new companion error id strings for any new error codes
        wolfcrypt/src/error.c !!! */
 };
-
 
 #ifdef NO_ERROR_STRINGS
     #define wc_GetErrorString(error) "no support for error strings built in"

--- a/wolfssl/wolfcrypt/integer.h
+++ b/wolfssl/wolfcrypt/integer.h
@@ -42,6 +42,8 @@
 
 #else
 
+#include <wolfssl/wolfcrypt/types.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/random.h>
 
 #ifndef CHAR_BIT
@@ -162,9 +164,6 @@ extern "C" {
 #define MP_NEG        1   /* negative */
 
 #define MP_OKAY       0   /* ok result */
-#define MP_MEM       (-2) /* out of mem */
-#define MP_VAL       (-3) /* invalid input */
-#define MP_NOT_INF   (-4) /* point not at infinity */
 #define MP_RANGE      MP_NOT_INF
 
 #define MP_YES        1   /* yes response */

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -742,24 +742,18 @@ typedef struct sp_ecc_ctx {
 #define MP_LT    (-1)
 
 /* ERROR VALUES */
+
+/* MP_MEM, MP_VAL, MP_WOULDBLOCK, and MP_NOT_INF are defined in error-crypt.h */
+
 /** Error value on success. */
 #define MP_OKAY          0
-/** Error value when dynamic memory allocation fails. */
-#define MP_MEM          (-2)
-/** Error value when value passed is not able to be used. */
-#define MP_VAL          (-3)
-/** Error value when non-blocking operation is returning after partial
- * completion.
- */
-#define FP_WOULDBLOCK   (-4)
-/* Unused error. Defined for backward compatibility. */
-#define MP_NOT_INF      (-5)
+
+#define FP_WOULDBLOCK   MP_WOULDBLOCK
 /* Unused error. Defined for backward compatibility. */
 #define MP_RANGE        MP_NOT_INF
-
 #ifdef USE_FAST_MATH
 /* For old FIPS, need FP_MEM defined for old implementation. */
-#define FP_MEM          (-2)
+#define FP_MEM          MP_MEM
 #endif
 
 /* Number of bits in each word/digit. */

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -40,6 +40,7 @@
 #define WOLF_CRYPT_TFM_H
 
 #include <wolfssl/wolfcrypt/types.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
 #ifndef CHAR_BIT
     #include <limits.h>
 #endif
@@ -305,10 +306,10 @@
 
 /* return codes */
 #define FP_OKAY      0
-#define FP_VAL      (-1)
-#define FP_MEM      (-2)
-#define FP_NOT_INF  (-3)
-#define FP_WOULDBLOCK (-4)
+#define FP_VAL      MP_VAL
+#define FP_MEM      MP_MEM
+#define FP_NOT_INF  MP_NOT_INF
+#define FP_WOULDBLOCK MP_WOULDBLOCK
 
 /* equalities */
 #define FP_LT        (-1)   /* less than */
@@ -776,10 +777,7 @@ int  fp_sqr_comba64(fp_int *a, fp_int *b);
 #define MP_LT   FP_LT   /* less than    */
 #define MP_EQ   FP_EQ   /* equal to     */
 #define MP_GT   FP_GT   /* greater than */
-#define MP_VAL  FP_VAL  /* invalid */
-#define MP_MEM  FP_MEM  /* memory error */
-#define MP_NOT_INF FP_NOT_INF /* point not at infinity */
-#define MP_RANGE FP_NOT_INF
+#define MP_RANGE MP_NOT_INF
 #define MP_OKAY FP_OKAY /* ok result    */
 #define MP_NO   FP_NO   /* yes/no result */
 #define MP_YES  FP_YES  /* yes/no result */


### PR DESCRIPTION
move several MP error codes from `wolfssl/wolfcrypt/sp_int.h`, `wolfssl/wolfcrypt/tfm.h`, and `wolfssl/wolfcrypt/integer.h`, to `wolfssl/wolfcrypt/error-crypt.h`, harmonizing their names and numbers.

`wolfssl/wolfcrypt/error-crypt.h`: add `WC_FIRST_E`.

`wolfcrypt/src/error.c`: add MP error code strings.

`wolfssl/error-ssl.h`: add `WOLFSSL_FIRST_E` and `WOLFSSL_LAST_E`.

`wolfcrypt/test/test.c`: update `error_test()` for new error code layout, refactoring the "missing" check.

`src/internal.c`: use `WC_FIRST_E` and `WC_LAST_E ` in `wolfSSL_ERR_reason_error_string()`.

`src/ssl.c`: fix `wolfSSL_ERR_GET_REASON()` to identify in-range error codes using `WC_FIRST_E`, `WC_LAST_E`, `WOLFSSL_FIRST_E`, and `WOLFSSL_LAST_E`.

`wolfcrypt/src/ecc.c`: fix 2 `identicalInnerCondition`'s.


note, refactoring the sp error codes as enums adds helpful additional error checking by the compiler, and also helped `cppcheck` uncover the benign-but-true `identicalInnerCondition`s.

tested with `wolfssl-multi-test.sh ... super-quick-check int-math all-enable-fastmath` with the latter 2 tweaked to add `--enable-debug-trace-errcodes`.
