### PR TITLE
Using ">>" with no command in configure can be ambigious for some ancient /bin/sh.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9925,7 +9925,7 @@ AX_AM_JOBSERVER([yes])
 
 # See Automake 9.4.1 Built Sources Example
 AC_DEFUN([AX_OUT_OF_TREE_FILE],[
-  AC_CONFIG_COMMANDS([$1], [test ! -f $srcdir/$1 && >> $srcdir/$1])
+  AC_CONFIG_COMMANDS([$1], [test ! -f $srcdir/$1 && echo -n >> $srcdir/$1])
 ])
 
 AX_OUT_OF_TREE_FILE([wolfssl/wolfcrypt/async.h])


### PR DESCRIPTION
Current configure script uses ambiguous syntax. Bash executes it correctly, but ancient Bourne shell may be confused. For example, an execution on FreeBSD 9.2 (2013) aborts like:

```
creating wolfssl-config - generic 5.7.2 for -lwolfssl -lpthread
checking the number of available CPUs... 2
configure: adding automake macro support
configure: creating aminclude.am
configure: added jobserver support to make for 3 jobs
checking that generated files are newer than configure... done
configure: creating ./config.status
./config.status: 2414: Syntax error: ";;" unexpected
```

The claimed part in config.status is a redirection ">>" with no command, like,
```
    "wolfssl/wolfcrypt/async.h":C) test ! -f $srcdir/wolfssl/wolfcrypt/async.h && >> $srcdir/wolfssl/wolfcrypt/async.h ;;
    "wolfssl/wolfcrypt/fips.h":C) test ! -f $srcdir/wolfssl/wolfcrypt/fips.h && >> $srcdir/wolfssl/wolfcrypt/fips.h ;;
    "wolfssl/wolfcrypt/port/cavium/cavium_nitrox.h":C) test ! -f $srcdir/wolfssl/wolfcrypt/port/cavium/cavium_nitrox.h && >> $srcdir/wolfssl/wolfcrypt/port/cavium/cavium_nitrox.h ;;
    "wolfssl/wolfcrypt/port/intel/quickassist.h":C) test ! -f $srcdir/wolfssl/wolfcrypt/port/intel/quickassist.h && >> $srcdir/wolfssl/wolfcrypt/port/intel/quickassist.h ;;
    "wolfssl/wolfcrypt/port/intel/quickassist_mem.h":C) test ! -f $srcdir/wolfssl/wolfcrypt/port/intel/quickassist_mem.h && >> $srcdir/wolfssl/wolfcrypt/port/intel/quickassist_mem.h ;;

```

This part is expanded from AX_OUT_OF_TREE_FILE in configure.ac:

```
# See Automake 9.4.1 Built Sources Example
AC_DEFUN([AX_OUT_OF_TREE_FILE],[
  AC_CONFIG_COMMANDS([$1], [test ! -f $srcdir/$1 && >> $srcdir/$1])
])
```
A redirection ">>" with no leading command would be acceptable (I confirmed "> test.txt" causes no error on FreeBSD 9.2 /bin/sh), but using it in a case-esac statement can confuse the parser in some ancient /bin/sh. Maybe some /bin/sh try to capture the command after "&&", and misunderstand ";;" as the command to be executed (and failed).

Rewriting AC_CONFIG_COMMANDS to "test ! -f $srcdir/$1 && echo -n >> $srcdir/$1" would work for same result.
