### PR TITLE
Improve wolfssl/options.h issues

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -12,6 +12,11 @@
     $ make check   # (optional, but highly recommended)
     $ sudo make install
 
+    Note: Building with configure generates a wolfssl/options.h file that contains
+    all the generated build options. This file needs to be included in your application
+    before any other wolfSSL headers. Optionally your application can define
+    WOLFSSL_USE_OPTIONS_H to do this automatically.
+
 2. Building on iOS
 
     Use on the xcode project in IDE/iOS/wolfssl.xcodeproj
@@ -74,7 +79,7 @@
 13. Porting to a new platform
 
     Please see section 2.4 in the manual:
-    http://www.wolfssl.com/yaSSL/Docs-cyassl-manual-2-building-cyassl.html
+    https://www.wolfssl.com/documentation/manuals/wolfssl/chapter02.html#customizing-or-porting-wolfssl
 
 14. Building with CMake
     Note: Primary development uses automake (./configure). The support for CMake
@@ -90,6 +95,11 @@
     line work flow. Regardless of your chosen workflow, cmake will generate
     a header options.h in the wolfssl directory that contains the options used
     to configure the build.
+
+    Note: Building with configure generates a wolfssl/options.h file that contains
+    all the generated build options. This file needs to be included in your application
+    before any other wolfSSL headers. Optionally your application can define
+    WOLFSSL_USE_OPTIONS_H to do this automatically.
 
     Unix-based Platforms
     ---

--- a/configure.ac
+++ b/configure.ac
@@ -10409,7 +10409,7 @@ fi # $silent != yes
 
 if test "$ENABLED_ASYNCCRYPT" = "yes" && ! test -s $srcdir/wolfcrypt/src/async.c
 then
-    AC_MSG_WARN([Make sure real async files are loaded. Contact wolfSSL for details on using the asynccrypt option.])
+    AC_MSG_WARN([Make sure real async files are loaded. See async-check.sh or the wolfssl/wolfAsyncCrypt GitHub repo.])
 fi
 
 # MinGW static vs shared library
@@ -10436,3 +10436,6 @@ if test -n "$WITH_MAX_ECC_BITS"; then
     fi
 fi
 
+echo "---"
+echo "Note: Make sure your application includes \"wolfssl/options.h\" before any other wolfSSL headers."
+echo "      You can define \"WOLFSSL_USE_OPTIONS_H\" in your application to include this automatically."

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -55,7 +55,7 @@
 /* This flag allows wolfSSL to include options.h instead of having client
  * projects do it themselves. This should *NEVER* be defined when building
  * wolfSSL as it can cause hard to debug problems. */
-#ifdef EXTERNAL_OPTS_OPENVPN
+#if defined(EXTERNAL_OPTS_OPENVPN) || defined(WOLFSSL_USE_OPTIONS_H)
 #include <wolfssl/options.h>
 #endif
 


### PR DESCRIPTION
# Description

* Improve wolfssl/options.h issues. Fixes #7853.
* Adds new `WOLFSSL_USE_OPTIONS_H` for use in the customers application to automatically include.

# Testing

Documentation changes.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
