### PR TITLE
Use signed variable for length calculation in SendTls13Certificate

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -8459,12 +8459,13 @@ static int SendTls13Certificate(WOLFSSL* ssl)
     int    ret = 0;
     word32 certSz, certChainSz, headerSz, listSz, payloadSz;
     word16 extSz = 0;
-    word32 length, maxFragment;
+    word32 maxFragment;
     word32 len = 0;
     word32 idx = 0;
     word32 offset = OPAQUE16_LEN;
     byte*  p = NULL;
     byte   certReqCtxLen = 0;
+    sword32 length;
 #ifdef WOLFSSL_POST_HANDSHAKE_AUTH
     byte*  certReqCtx = NULL;
 #endif
@@ -8510,7 +8511,7 @@ static int SendTls13Certificate(WOLFSSL* ssl)
         listSz = 0;
     }
     else {
-        if (!ssl->buffers.certificate) {
+        if (!ssl->buffers.certificate || !ssl->buffers.certificate) {
             WOLFSSL_MSG("Send Cert missing certificate buffer");
             return NO_CERT_ERROR;
         }

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -8511,7 +8511,7 @@ static int SendTls13Certificate(WOLFSSL* ssl)
         listSz = 0;
     }
     else {
-        if (!ssl->buffers.certificate || !ssl->buffers.certificate) {
+        if (!ssl->buffers.certificate || !ssl->buffers.certificate->buffer) {
             WOLFSSL_MSG("Send Cert missing certificate buffer");
             return NO_CERT_ERROR;
         }

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -8602,7 +8602,7 @@ static int SendTls13Certificate(WOLFSSL* ssl)
 #endif /* WOLFSSL_DTLS13 */
         }
         else {
-            fragSz = min(length, maxFragment);
+            fragSz = min((word32)length, maxFragment);
             sendSz += fragSz;
         }
 


### PR DESCRIPTION
# Description

Use signed variable for length calculation in SendTls13Certificate. Current code uses unsigned len which only works when decremented exactly to zero. Any mistakes in the length handling will underflow and keep looping, allocating memory until the system runs out. 

Additional fix brought up by ZD 18267

