### PR TITLE
Properly handling the shutdown when multiple ones go on EAGAIN back to back

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -25063,6 +25063,19 @@ static int SendAlert_ex(WOLFSSL* ssl, int severity, int type)
         }
     #endif
 
+    /*
+     * We check if we are trying to send a
+     * CLOSE_NOTIFY alert
+     * */
+    if (type == 0) {
+        if (!ssl->options.sentNotify) {
+            ssl->options.sentNotify = 1;
+        }  else {
+            /* CLOSE_NOTIFY already sent */
+            return 0;
+        }
+    }
+
     ssl->buffers.outputBuffer.length += sendSz;
 
     ret = SendBuffered(ssl);

--- a/src/internal.c
+++ b/src/internal.c
@@ -19,8 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
-
 #ifdef HAVE_CONFIG_H
     #include <config.h>
 #endif
@@ -25065,9 +25063,9 @@ static int SendAlert_ex(WOLFSSL* ssl, int severity, int type)
 
     /*
      * We check if we are trying to send a
-     * CLOSE_NOTIFY alert
+     * CLOSE_NOTIFY alert.
      * */
-    if (type == 0) {
+    if (type == close_notify) {
         if (!ssl->options.sentNotify) {
             ssl->options.sentNotify = 1;
         }  else {

--- a/src/internal.c
+++ b/src/internal.c
@@ -25068,7 +25068,8 @@ static int SendAlert_ex(WOLFSSL* ssl, int severity, int type)
     if (type == close_notify) {
         if (!ssl->options.sentNotify) {
             ssl->options.sentNotify = 1;
-        }  else {
+        }
+        else {
             /* CLOSE_NOTIFY already sent */
             return 0;
         }

--- a/tests/api.c
+++ b/tests/api.c
@@ -81204,7 +81204,6 @@ static int custom_wolfSSL_shutdown(WOLFSSL *ssl, char *buf,
 static int test_multiple_alerts_EAGAIN(void)
 {
     EXPECT_DECLS;
-    CallbackIOSend copy_current_io_cb = NULL;
     size_t size_of_last_packet = 0;
 
     /* declare wolfSSL objects */
@@ -81236,7 +81235,6 @@ static int test_multiple_alerts_EAGAIN(void)
      * We set the custom callback for the IO to emulate multiple EAGAINs
      * on shutdown, so we can check that we don't send multiple packets.
      * */
-    copy_current_io_cb = ssl_c->CBIOSend;
     wolfSSL_SSLSetIOSend(ssl_c, custom_wolfSSL_shutdown);
 
     /*
@@ -81253,8 +81251,6 @@ static int test_multiple_alerts_EAGAIN(void)
      * Finally we check the length of the output buffer.
      * */
     ExpectIntEQ((ssl_c->buffers.outputBuffer.length - size_of_last_packet), 0);
-
-    wolfSSL_SSLSetIOSend(ssl_c, copy_current_io_cb);
 
     /* Cleanup and return */
     wolfSSL_CTX_free(ctx_c);

--- a/tests/api.c
+++ b/tests/api.c
@@ -81244,7 +81244,10 @@ static int test_multiple_alerts_EAGAIN(void)
      * */
     wolfSSL_shutdown(ssl_c);
     wolfSSL_shutdown(ssl_c);
-    size_of_last_packet = ssl_c->buffers.outputBuffer.length;
+
+    if (ssl_c != NULL) {
+        size_of_last_packet = ssl_c->buffers.outputBuffer.length;
+    }
     wolfSSL_shutdown(ssl_c);
 
     /*

--- a/tests/api.c
+++ b/tests/api.c
@@ -81186,7 +81186,7 @@ static int test_extra_alerts_bad_psk(void)
 }
 #endif
 
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) && defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && !defined(WOLFSSL_NO_TLS12)
 /*
  * Emulates wolfSSL_shutdown that goes on EAGAIN,
  * by returning on output WOLFSSL_ERROR_WANT_WRITE.*/


### PR DESCRIPTION
# Description

Inhibit queueing redundant CLOSE_NOTIFY messages.

Fixes [7784](https://github.com/wolfSSL/wolfssl/issues/7784)

# Testing

`./testsuite/testsuite.test`

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
