### PR TITLE
20240819-shebang-bash-env

### DIFF
--- a/Docker/buildAndPush.sh
+++ b/Docker/buildAndPush.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Assume we're in wolfssl/Docker
 WOLFSSL_DIR=$(builtin cd ${BASH_SOURCE%/*}/..; pwd)

--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Running with \"${*}\"..."
 

--- a/Docker/yocto/buildAndPush.sh
+++ b/Docker/yocto/buildAndPush.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Assume we're in wolfssl/Docker/yocto
 WOLFSSL_DIR=$(builtin cd ${BASH_SOURCE%/*}/../..; pwd)

--- a/IDE/ARDUINO/sketches/wolfssl_server/README.md
+++ b/IDE/ARDUINO/sketches/wolfssl_server/README.md
@@ -35,7 +35,7 @@ press the reset button or power cycle the Arduino before making a connection.
 Here's one possible script to test the server from a command-line client:
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 echo "client log " > client_log.txt
 counter=1
 THIS_ERR=0

--- a/IDE/Espressif/ESP-IDF/compileAllExamples.sh
+++ b/IDE/Espressif/ESP-IDF/compileAllExamples.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # testing script: compileAllExamples
 #

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_test/testAll.sh
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_test/testAll.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # testAll.sh [keyword suffix]
 #

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_test/testMonitor.sh
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_test/testMonitor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Syntax:
 #   ./testMonitor.sh <example_name> <target> <keyword>

--- a/IDE/Espressif/ESP-IDF/setup.sh
+++ b/IDE/Espressif/ESP-IDF/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # check if IDF_PATH is set
 if [ -z "$IDF_PATH" ]; then

--- a/IDE/HEXAGON/build.sh
+++ b/IDE/HEXAGON/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ -z $1 ]; then
 	echo "./build <Debug | Release>"
 	exit 1

--- a/IDE/Renesas/e2studio/Projects/tools/generate_rsa_keypair.sh
+++ b/IDE/Renesas/e2studio/Projects/tools/generate_rsa_keypair.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function usage(){
     cat << _EOT_

--- a/IDE/Renesas/e2studio/Projects/tools/genhexbuf.pl
+++ b/IDE/Renesas/e2studio/Projects/tools/genhexbuf.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # genhexbuf.pl
 # Copyright (C) 2020 wolfSSL Inc.

--- a/IDE/Renesas/e2studio/Projects/tools/rsa_pss_sign.sh
+++ b/IDE/Renesas/e2studio/Projects/tools/rsa_pss_sign.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SIGOPT=rsa_padding_mode:pss
 SIGOPT2=rsa_pss_saltlen:-1

--- a/IDE/apple-universal/build-wolfssl-framework.sh
+++ b/IDE/apple-universal/build-wolfssl-framework.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # build-wolfssl-framework.sh
 #

--- a/IDE/mynewt/setup.sh
+++ b/IDE/mynewt/setup.sh
@@ -1,7 +1,9 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 
-# this scrypt deploy wolfssl and wolfcrypto source code to mynewt project
+# this script deploys wolfssl and wolfcrypto source code to the mynewt project.
 # run as bash "mynewt project root directory path"
+
+set -e
 
 SCRIPTDIR=`dirname $0`
 SCRIPTDIR=`cd $SCRIPTDIR && pwd -P`

--- a/RTOS/nuttx/wolfssl/setup-wolfssl.sh
+++ b/RTOS/nuttx/wolfssl/setup-wolfssl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e # exit on any command failure
 if [ ! -d wolfssl ]; then

--- a/async-check.sh
+++ b/async-check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script creates symbolic links to the required asynchronous
 # file for using the asynchronous simulator and make check

--- a/certs/crl/gencrls.sh
+++ b/certs/crl/gencrls.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # gencrls, crl config already done, see taoCerts.txt for setup
 check_result(){

--- a/certs/ecc/genecc.sh
+++ b/certs/ecc/genecc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # run from wolfssl root
 

--- a/certs/ed25519/gen-ed25519-certs.sh
+++ b/certs/ed25519/gen-ed25519-certs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 check_result(){
     if [ $1 -ne 0 ]; then

--- a/certs/ed25519/gen-ed25519.sh
+++ b/certs/ed25519/gen-ed25519.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 EXAMPLE=$1
 echo "This uses ed25519 certificate generator from wolfssl-examples github"

--- a/certs/ed448/gen-ed448-certs.sh
+++ b/certs/ed448/gen-ed448-certs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 check_result(){
     if [ $1 -ne 0 ]; then

--- a/certs/gen_revoked.sh
+++ b/certs/gen_revoked.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
     ###########################################################
     ########## update and sign server-revoked-key.pem ################

--- a/certs/p521/gen-p521-certs.sh
+++ b/certs/p521/gen-p521-certs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 check_result(){
     if [ $1 -ne 0 ]; then

--- a/certs/renewcerts.sh
+++ b/certs/renewcerts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # renewcerts.sh
 #
 # renews the following certs:

--- a/certs/rsapss/renew-rsapss-certs.sh
+++ b/certs/rsapss/renew-rsapss-certs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 check_result(){
     if [ $1 -ne 0 ]; then

--- a/certs/sm2/gen-sm2-certs.sh
+++ b/certs/sm2/gen-sm2-certs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 check_result(){
     if [ $1 -ne 0 ]; then

--- a/certs/statickeys/gen-static.sh
+++ b/certs/statickeys/gen-static.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # run from wolfssl root
 

--- a/certs/test-pathlen/assemble-chains.sh
+++ b/certs/test-pathlen/assemble-chains.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # assemble-chains.sh
 # Create certs and assemble all the certificate CA path test cert chains.

--- a/certs/test-pathlen/refreshkeys.sh
+++ b/certs/test-pathlen/refreshkeys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 keyList=(
             chainA-ICA1-key.pem chainA-entity-key.pem

--- a/certs/test/gen-badsig.sh
+++ b/certs/test/gen-badsig.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 generate() {
     # read in certificate and alter the last part of the signature

--- a/commit-tests.sh
+++ b/commit-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #commit-tests.sh
 

--- a/doc/generate_documentation.sh
+++ b/doc/generate_documentation.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # This script depends on g++, cmake, git, and make to be installed
 
 POSIXLY_CORRECT=1

--- a/fips-check.sh
+++ b/fips-check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # fips-check.sh
 # This script checks the current revision of the code against the

--- a/fips-hash.sh
+++ b/fips-hash.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if test ! -x ./wolfcrypt/test/testwolfcrypt
 then
@@ -18,4 +18,3 @@ then
     cp wolfcrypt/src/fips_test.c wolfcrypt/src/fips_test.c.bak
     sed "s/^\".*\";/\"${NEWHASH}\";/" wolfcrypt/src/fips_test.c.bak >wolfcrypt/src/fips_test.c
 fi
-

--- a/gencertbuf.pl
+++ b/gencertbuf.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # gencertbuf.pl
 # version 1.1

--- a/pull_to_vagrant.sh
+++ b/pull_to_vagrant.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 SRC=vagrant
 DST=wolfssl
 

--- a/scripts/aria-cmake-build-test.sh
+++ b/scripts/aria-cmake-build-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # aria_cmake_build_test.sh
 #

--- a/scripts/benchmark_compare.sh
+++ b/scripts/benchmark_compare.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script is designed to compare the output of wolfcrypt/benchmark test
 # application. If the file has an extension ".csv", then it will parse the
 # comma separated format, otherwise it will use the standard output format. The

--- a/scripts/crl-revoked.test
+++ b/scripts/crl-revoked.test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #crl.test
 # if we can, isolate the network namespace to eliminate port collisions.

--- a/scripts/dertoc.pl
+++ b/scripts/dertoc.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # dertoc.pl
 # version 1.0

--- a/scripts/dtls.test
+++ b/scripts/dtls.test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script can be run with several environment variables set dictating its
 # run. You can set the following to what you like:

--- a/scripts/dtlscid.test
+++ b/scripts/dtlscid.test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # dtlscid.test
 # Copyright wolfSSL 2022-2024

--- a/scripts/external.test
+++ b/scripts/external.test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # external.test
 

--- a/scripts/google.test
+++ b/scripts/google.test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # google.test
 

--- a/scripts/makedistsmall.sh
+++ b/scripts/makedistsmall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #set -v
 
 # Script to produce a small source/header only package (with CMake support)

--- a/scripts/memtest.sh
+++ b/scripts/memtest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Run this script from the wolfSSL root as `./scripts/memtest.sh`.
 
@@ -14,7 +14,7 @@ make
 
 for i in {1..1000}
 do
-    echo "Trying $i...\n"
+    echo -e "Trying ${i}...\n"
 
         ./tests/unit.test > ./scripts/memtest.txt 2>&1
 

--- a/scripts/ocsp-stapling-with-ca-as-responder.test
+++ b/scripts/ocsp-stapling-with-ca-as-responder.test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # ocsp-stapling-with-ca-as-responder.test
 

--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # ocsp-stapling.test
 # Test requires HAVE_OCSP and HAVE_CERTIFICATE_STATUS_REQUEST

--- a/scripts/ocsp-stapling2.test
+++ b/scripts/ocsp-stapling2.test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # ocsp-stapling2.test
 # Test requires HAVE_OCSP and HAVE_CERTIFICATE_STATUS_REQUEST_V2

--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # openssl.test
 

--- a/scripts/openssl_srtp.test
+++ b/scripts/openssl_srtp.test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Test WolfSSL/OpenSSL srtp interoperability
 #
 # TODO: add OpenSSL client with WolfSSL server

--- a/scripts/pem.test
+++ b/scripts/pem.test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # pem.test
 # Copyright wolfSSL 2023-2023

--- a/scripts/ping.test
+++ b/scripts/ping.test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # ping.test
 

--- a/scripts/pkcallbacks.test
+++ b/scripts/pkcallbacks.test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #pkcallbacks.test
 

--- a/scripts/psk.test
+++ b/scripts/psk.test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # psk.test
 # copyright wolfSSL 2016

--- a/scripts/resume.test
+++ b/scripts/resume.test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #resume.test
 

--- a/scripts/sniffer-gen.sh
+++ b/scripts/sniffer-gen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #set -x
 
 # Run this script from the wolfSSL root

--- a/scripts/sniffer-testsuite.test
+++ b/scripts/sniffer-testsuite.test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #sniffer-testsuite.test
 

--- a/scripts/stm32l4-v4_0_1_build.sh
+++ b/scripts/stm32l4-v4_0_1_build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 WOLF_ROOT=$(eval "pwd")
 echo "WOLF_ROOT set to: \"$WOLF_ROOT\""
 cd ../ || exit 5

--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # tls13.test
 # Copyright wolfSSL 2016-2021

--- a/scripts/trusted_peer.test
+++ b/scripts/trusted_peer.test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # trusted_peer.test
 # copyright wolfSSL 2016


### PR DESCRIPTION
portability enhancement: use `#!/usr/bin/env <interpreter>` on all `perl` scripts and shell scripts that use `bash` extensions, and use "#!/bin/sh" on the rest.

tested with `wolfssl-multi-test.sh ... check-shell-scripts`

note that `shellcheck` is smart enough to decipher the correct shell dialect from shebangs that use `/usr/bin/env`.

I used `shellcheck -s sh --severity=warning` to identify scripts that can use POSIX `#!/bin/sh`.
