### PR TITLE
allow sigParamsSz is zero and malloc(0) to return NULL

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -777,7 +777,8 @@ static CRL_Entry* DupCRL_Entry(const CRL_Entry* ent, void* heap)
     #endif
         if (dupl->toBeSigned == NULL || dupl->signature == NULL
         #ifdef WC_RSA_PSS
-            || dupl->sigParams == NULL
+            /* allow sigParamsSz is zero and malloc(0) to return NULL */
+            || (dupl->sigParams == NULL && dupl->sigParamsSz != 0)
         #endif
         ) {
             CRL_Entry_free(dupl, heap);


### PR DESCRIPTION
# Description

allow sigParamsSz is zero and malloc(0) to return NULL

Fixes zd#18481

# Testing

./configure CFLAGS="-DWC_RSA_PSS" --enable-crl --enable-opensslall
make check

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
