### PR TITLE
Test fixes

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -59747,9 +59747,9 @@ static int test_wolfSSL_SESSION(void)
 
     /* TLS v1.3 requires session tickets */
     /* CHACHA and POLY1305 required for myTicketEncCb */
-#if defined(WOLFSSL_TLS13) && (!defined(HAVE_SESSION_TICKET) && \
-    !defined(WOLFSSL_NO_TLS12) || !(defined(HAVE_CHACHA) && \
-            defined(HAVE_POLY1305) && !defined(HAVE_AESGCM)))
+#if !defined(WOLFSSL_NO_TLS12) && (!defined(WOLFSSL_TLS13) || \
+    !(defined(HAVE_SESSION_TICKET) && ((defined(HAVE_CHACHA) && \
+            defined(HAVE_POLY1305)) || defined(HAVE_AESGCM))))
     ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method()));
 #else
     ExpectNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()));
@@ -82532,7 +82532,13 @@ static int test_dtls13_bad_epoch_ch(void)
 }
 #endif
 
-#if defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && !defined(NO_SESSION_CACHE)
+#if ((defined(WOLFSSL_TLS13) && !defined(WOLFSSL_NO_DEF_TICKET_ENC_CB) && \
+      defined(HAVE_SESSION_TICKET) && defined(WOLFSSL_TICKET_HAVE_ID) && \
+      !defined(WOLFSSL_TLS13_MIDDLEBOX_COMPAT)) || \
+     (!defined(NO_OLD_TLS) && ((!defined(NO_AES) && !defined(NO_AES_CBC)) || \
+      !defined(NO_DES3))) || !defined(WOLFSSL_NO_TLS12)) && \
+    !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
+    defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && !defined(NO_SESSION_CACHE)
 static int test_short_session_id_ssl_ready(WOLFSSL* ssl)
 {
     EXPECT_DECLS;
@@ -82606,7 +82612,6 @@ static int test_short_session_id(void)
         ExpectIntEQ(test_wolfSSL_client_server_nofail_memio(&client_cbf,
             &server_cbf, NULL), TEST_SUCCESS);
     }
-
     return EXPECT_RESULT();
 }
 #else

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -13655,7 +13655,7 @@ static int _sp_exptmod_base_2(const sp_int* e, int digits, const sp_int* m,
 #ifndef WC_NO_HARDEN
     FREE_SP_INT_ARRAY(d, NULL);
 #else
-    FREE_SP_INT(tr, m->used * 2 + 1);
+    FREE_SP_INT(tr, NULL);
 #endif
     return err;
 }

--- a/wolfssl/wolfcrypt/ge_operations.h
+++ b/wolfssl/wolfcrypt/ge_operations.h
@@ -112,7 +112,6 @@ typedef struct {
   ge Z;
   ge T2d;
 } ge_cached;
-#endif /* !ED25519_SMALL */
 
 #ifdef CURVED25519_ASM
 void ge_p1p1_to_p2(ge_p2 *r, const ge_p1p1 *p);
@@ -124,6 +123,7 @@ void ge_msub(ge_p1p1 *r, const ge_p3 *p, const ge_precomp *q);
 void ge_add(ge_p1p1 *r, const ge_p3 *p, const ge_cached *q);
 void ge_sub(ge_p1p1 *r, const ge_p3 *p, const ge_cached *q);
 #endif
+#endif /* !ED25519_SMALL */
 
 #ifdef __cplusplus
     }    /* extern "C" */


### PR DESCRIPTION
# Description

api.c:
    Update #ifdefs.
sp_int.c:
    Fix free call when hardening is disabled.
ge_operations.h
    Don't define functions for ASM when building small.

# Testing

Disable harden.
Disable session ticket and disable TLSv12.
--enable-ed25519=small --enable-intelasm

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
