### PR TITLE
Use verify callback before checking dates

### DIFF
--- a/src/x509_str.c
+++ b/src/x509_str.c
@@ -269,6 +269,10 @@ int wolfSSL_X509_verify_cert(WOLFSSL_X509_STORE_CTX* ctx)
                 ctx->current_cert->derCert->length,
                 WOLFSSL_FILETYPE_ASN1);
         SetupStoreCtxError(ctx, ret);
+    #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
+        if (ctx->store && ctx->store->verify_cb)
+            ret = ctx->store->verify_cb(ret >= 0 ? 1 : 0, ctx) == 1 ? 0 : ret;
+    #endif
 
     #ifndef NO_ASN_TIME
         if (ret != WC_NO_ERR_TRACE(ASN_BEFORE_DATE_E) &&
@@ -289,12 +293,12 @@ int wolfSSL_X509_verify_cert(WOLFSSL_X509_STORE_CTX* ctx)
                 ret = ASN_BEFORE_DATE_E;
             }
             SetupStoreCtxError(ctx, ret);
+        #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
+            if (ctx->store && ctx->store->verify_cb)
+                ret = ctx->store->verify_cb(ret >= 0 ? 1 : 0,
+                                            ctx) == 1 ? 0 : -1;
+        #endif
         }
-    #endif
-
-    #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
-        if (ctx->store && ctx->store->verify_cb)
-            ret = ctx->store->verify_cb(ret >= 0 ? 1 : 0, ctx) == 1 ? 0 : -1;
     #endif
 
         return ret >= 0 ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;


### PR DESCRIPTION
# Description

In `wolfSSL_X509_verify_cert`, after an error has been set is can be overwritten by the subsequent date check. If the callback is being used to override date errors, then the invalid cert gets treated as verified. This change adds a call to the verify callback before the date check. This way the application can handle the error(s) appropriately.

Fixes zd18433

# Testing

Set system time to before cert validity of `./certs/intermediate/ca-int2-cert.pem`. Call `X509_verify_cert`, similar to `test_X509_STORE_untrusted_certs` test. Observe ASN_SIGNER_ERROR being overwritten with date error.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
