### PR TITLE
Log error code in TranslateIoReturnCode.

### DIFF
--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -251,7 +251,7 @@ static int TranslateIoReturnCode(int err, SOCKET_T sd, int direction)
         NULL);
     WOLFSSL_MSG(errstr);
 #else
-    WOLFSSL_MSG("\tGeneral error");
+    WOLFSSL_MSG_EX("\tGeneral error: %d", err);
 #endif
     return WOLFSSL_CBIO_ERR_GENERAL;
 }


### PR DESCRIPTION
# Description
Log the actual return code in the "General error" case.  An ongoing support issue has been figuring out the error from send/recv/etc when it is not covered by the other cases in TranslateIoReturnCode.  This should hopefully fix that.

# Testing

Built in tests

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
