### PR TITLE
20240823-WOLFSSL_DEBUG_TRACE_ERROR_CODES_ALWAYS

### DIFF
--- a/support/gen-debug-trace-error-codes.sh
+++ b/support/gen-debug-trace-error-codes.sh
@@ -19,8 +19,11 @@ BEGIN {
         split($0, errcode_a, "[[:space:]=,]+");
 
         if ((errcode_a[1] == "MIN_CODE_E") ||
+            (errcode_a[1] == "MAX_CODE_E") ||
+            (errcode_a[1] == "WC_FIRST_E") ||
             (errcode_a[1] == "WC_LAST_E") ||
-            (errcode_a[1] == "MAX_CODE_E"))
+            (errcode_a[1] == "WOLFSSL_FIRST_E") ||
+            (errcode_a[1] == "WOLFSSL_LAST_E"))
         {
             next;
         }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -37,6 +37,10 @@
 #endif
 #include <wolfssl/wolfcrypt/settings.h>
 
+#ifdef WOLFSSL_DEBUG_TRACE_ERROR_CODES
+    #define WOLFSSL_DEBUG_TRACE_ERROR_CODES_ALWAYS
+#endif
+
 #ifndef NO_CRYPT_TEST
 
 #include <wolfssl/version.h>
@@ -891,7 +895,7 @@ static void myFipsCb(int ok, int err, const char* hash)
     printf("message = %s\n", wc_GetErrorString(err));
     printf("hash = %s\n", hash);
 
-    if (err == IN_CORE_FIPS_E) {
+    if (err == WC_NO_ERR_TRACE(IN_CORE_FIPS_E)) {
         printf("In core integrity hash check failure, copy above hash\n");
         printf("into verifyCore[] in fips_test.c and rebuild\n");
     }
@@ -1263,11 +1267,11 @@ static WOLFSSL_TEST_SUBROUTINE wc_test_ret_t nist_sp80056c_kdf_test(void)
     /* negative tests */
     ret = wc_KDA_KDF_onestep(NULL, 0, (byte*)"fixed_info",
         sizeof("fixed_info"), 16, WC_HASH_TYPE_SHA256, output, 16);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_NC;
     ret = wc_KDA_KDF_onestep((byte*)"secret", sizeof("secret"), NULL, 1, 16,
         WC_HASH_TYPE_SHA256, output, 16);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_NC;
 
     /* allow empty FixedInfo */
@@ -2737,25 +2741,25 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t base64_test(void)
     /* Bad parameters. */
     outLen = 1;
     ret = Base64_Decode(good, sizeof(good), out, &outLen);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     outLen = sizeof(out);
     ret = Base64_Decode(badEOL, sizeof(badEOL), out, &outLen);
-    if (ret != ASN_INPUT_E)
+    if (ret != WC_NO_ERR_TRACE(ASN_INPUT_E))
         return WC_TEST_RET_ENC_EC(ret);
     outLen = sizeof(out);
     ret = Base64_Decode(badPadding, sizeof(badPadding), out, &outLen);
-    if (ret != ASN_INPUT_E)
+    if (ret != WC_NO_ERR_TRACE(ASN_INPUT_E))
         return WC_TEST_RET_ENC_EC(ret);
     /* Bad character at each offset 0-3. */
     for (i = 0; i < 4; i++) {
         outLen = sizeof(out);
         ret = Base64_Decode(badSmall + i, 4, out, &outLen);
-        if (ret != ASN_INPUT_E)
+        if (ret != WC_NO_ERR_TRACE(ASN_INPUT_E))
             return WC_TEST_RET_ENC_I(i);
         ret = Base64_Decode(badLarge + i, 4, out, &outLen);
-        if (ret != ASN_INPUT_E)
+        if (ret != WC_NO_ERR_TRACE(ASN_INPUT_E))
             return WC_TEST_RET_ENC_I(i);
     }
     /* Invalid character less than 0x2b */
@@ -2763,7 +2767,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t base64_test(void)
         outLen = sizeof(out);
         charTest[0] = (byte)i;
         ret = Base64_Decode(charTest, sizeof(charTest), out, &outLen);
-        if (ret != ASN_INPUT_E)
+        if (ret != WC_NO_ERR_TRACE(ASN_INPUT_E))
             return WC_TEST_RET_ENC_I(i);
     }
     /* Bad characters in range 0x2b - 0x7a. */
@@ -2771,7 +2775,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t base64_test(void)
         outLen = sizeof(out);
         charTest[0] = badChar[i];
         ret = Base64_Decode(charTest, sizeof(charTest), out, &outLen);
-        if (ret != ASN_INPUT_E)
+        if (ret != WC_NO_ERR_TRACE(ASN_INPUT_E))
             return WC_TEST_RET_ENC_I(i);
     }
     /* Invalid character greater than 0x7a */
@@ -2779,7 +2783,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t base64_test(void)
         outLen = sizeof(out);
         charTest[0] = (byte)i;
         ret = Base64_Decode(charTest, sizeof(charTest), out, &outLen);
-        if (ret != ASN_INPUT_E)
+        if (ret != WC_NO_ERR_TRACE(ASN_INPUT_E))
             return WC_TEST_RET_ENC_I(i);
     }
 
@@ -2792,7 +2796,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t base64_test(void)
         return WC_TEST_RET_ENC_EC(ret);
     outLen = sizeof(out);
     ret = Base64_Encode(data, dataLen, NULL, &outLen);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         return WC_TEST_RET_ENC_EC(ret);
     outLen = sizeof(out);
     ret = Base64_Encode(data, dataLen, out, &outLen);
@@ -2800,11 +2804,11 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t base64_test(void)
         return WC_TEST_RET_ENC_EC(ret);
     outLen = 7;
     ret = Base64_EncodeEsc(data, dataLen, out, &outLen);
-    if (ret != BUFFER_E)
+    if (ret != WC_NO_ERR_TRACE(BUFFER_E))
         return WC_TEST_RET_ENC_EC(ret);
     outLen = sizeof(out);
     ret = Base64_EncodeEsc(data, dataLen, NULL, &outLen);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         return WC_TEST_RET_ENC_EC(ret);
     outLen = sizeof(out);
     ret = Base64_EncodeEsc(data, dataLen, out, &outLen);
@@ -2899,9 +2903,9 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t asn_test(void)
 
 #ifndef NO_ASN_TIME
     /* Parameter Validation tests. */
-    if ((ret = wc_GetTime(NULL, sizeof(now))) != BAD_FUNC_ARG)
+    if ((ret = wc_GetTime(NULL, sizeof(now))) != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
-    if ((ret = wc_GetTime(&now, 0)) != BUFFER_E)
+    if ((ret = wc_GetTime(&now, 0)) != WC_NO_ERR_TRACE(BUFFER_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     now = 0;
@@ -5920,37 +5924,37 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hash_test(void)
 
     /* Parameter Validation testing. */
     ret = wc_HashInit(NULL, WC_HASH_TYPE_SHA256);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_HashUpdate(NULL, WC_HASH_TYPE_SHA256, NULL, sizeof(data));
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_HashUpdate(&hash, WC_HASH_TYPE_SHA256, NULL, sizeof(data));
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_HashUpdate(NULL, WC_HASH_TYPE_SHA256, data, sizeof(data));
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_HashFinal(NULL, WC_HASH_TYPE_SHA256, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_HashFinal(&hash, WC_HASH_TYPE_SHA256, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_HashFinal(NULL, WC_HASH_TYPE_SHA256, out);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     /* Try invalid hash algorithms. */
     for (i = 0; i < (int)(sizeof(typesBad)/sizeof(*typesBad)); i++) {
         ret = wc_HashInit(&hash, typesBad[i]);
-        if (ret != BAD_FUNC_ARG)
+        if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
             return WC_TEST_RET_ENC_I(i);
         ret = wc_HashUpdate(&hash, typesBad[i], data, sizeof(data));
-        if (ret != BAD_FUNC_ARG)
+        if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
             return WC_TEST_RET_ENC_I(i);
         ret = wc_HashFinal(&hash, typesBad[i], out);
-        if (ret != BAD_FUNC_ARG)
+        if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
             return WC_TEST_RET_ENC_I(i);
         wc_HashFree(&hash, typesBad[i]);
     }
@@ -5982,7 +5986,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hash_test(void)
         if (exp_ret == 0) {
             ret = wc_Hash(typesGood[i], data, sizeof(data), hashOut,
                                                                   digestSz - 1);
-            if (ret != BUFFER_E)
+            if (ret != WC_NO_ERR_TRACE(BUFFER_E))
                 return WC_TEST_RET_ENC_I(i);
         }
         ret = wc_Hash(typesGood[i], data, sizeof(data), hashOut, (word32)digestSz);
@@ -5999,9 +6003,9 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hash_test(void)
 
 #if !defined(NO_ASN) || !defined(NO_DH) || defined(HAVE_ECC)
         ret = wc_HashGetOID(typesGood[i]);
-        if (ret == BAD_FUNC_ARG ||
-                (exp_ret == 0 && ret == HASH_TYPE_E) ||
-                (exp_ret != 0 && ret != HASH_TYPE_E)) {
+        if (ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG) ||
+                (exp_ret == 0 && ret == WC_NO_ERR_TRACE(HASH_TYPE_E)) ||
+                (exp_ret != 0 && ret != WC_NO_ERR_TRACE(HASH_TYPE_E))) {
             return WC_TEST_RET_ENC_I(i);
         }
 
@@ -6013,17 +6017,24 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hash_test(void)
 
     for (i = 0; i < (int)(sizeof(typesHashBad)/sizeof(*typesHashBad)); i++) {
         ret = wc_Hash(typesHashBad[i], data, sizeof(data), out, sizeof(out));
-        if ((ret != BAD_FUNC_ARG) && (ret != BUFFER_E) && (ret != HASH_TYPE_E))
+        if ((ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) &&
+            (ret != WC_NO_ERR_TRACE(BUFFER_E)) &&
+            (ret != WC_NO_ERR_TRACE(HASH_TYPE_E)))
+        {
             return WC_TEST_RET_ENC_I(i);
+        }
     }
 
 #if !defined(NO_ASN) || !defined(NO_DH) || defined(HAVE_ECC)
     ret = wc_HashGetOID(WC_HASH_TYPE_MD2);
 #ifdef WOLFSSL_MD2
-    if (ret == HASH_TYPE_E || ret == BAD_FUNC_ARG)
+    if (ret == WC_NO_ERR_TRACE(HASH_TYPE_E) ||
+        ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+    {
         return WC_TEST_RET_ENC_EC(ret);
+    }
 #else
-    if (ret != HASH_TYPE_E)
+    if (ret != WC_NO_ERR_TRACE(HASH_TYPE_E))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
     hashType = wc_OidGetHash(646); /* Md2h */
@@ -6037,17 +6048,20 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hash_test(void)
 
     ret = wc_HashGetOID(WC_HASH_TYPE_MD5_SHA);
 #ifndef NO_MD5
-    if (ret == HASH_TYPE_E || ret == BAD_FUNC_ARG)
+    if (ret == WC_NO_ERR_TRACE(HASH_TYPE_E) ||
+        ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+    {
         return WC_TEST_RET_ENC_EC(ret);
+    }
 #else
-    if (ret != HASH_TYPE_E)
+    if (ret != WC_NO_ERR_TRACE(HASH_TYPE_E))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
     ret = wc_HashGetOID(WC_HASH_TYPE_MD4);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_HashGetOID(WC_HASH_TYPE_NONE);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     hashType = wc_OidGetHash(0);
@@ -6057,68 +6071,89 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hash_test(void)
 
     ret = wc_HashGetBlockSize(WC_HASH_TYPE_MD2);
 #ifdef WOLFSSL_MD2
-    if (ret == HASH_TYPE_E || ret == BAD_FUNC_ARG)
+    if (ret == WC_NO_ERR_TRACE(HASH_TYPE_E) ||
+        ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+    {
         return WC_TEST_RET_ENC_EC(ret);
+    }
 #else
-    if (ret != HASH_TYPE_E)
+    if (ret != WC_NO_ERR_TRACE(HASH_TYPE_E))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
     ret = wc_HashGetDigestSize(WC_HASH_TYPE_MD2);
 #ifdef WOLFSSL_MD2
-    if (ret == HASH_TYPE_E || ret == BAD_FUNC_ARG)
+    if (ret == WC_NO_ERR_TRACE(HASH_TYPE_E) ||
+        ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+    {
         return WC_TEST_RET_ENC_EC(ret);
+    }
 #else
-    if (ret != HASH_TYPE_E)
+    if (ret != WC_NO_ERR_TRACE(HASH_TYPE_E))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
     ret = wc_HashGetBlockSize(WC_HASH_TYPE_MD4);
 #ifndef NO_MD4
-    if (ret == HASH_TYPE_E || ret == BAD_FUNC_ARG)
+    if (ret == WC_NO_ERR_TRACE(HASH_TYPE_E) ||
+        ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+    {
         return WC_TEST_RET_ENC_EC(ret);
+    }
 #else
-    if (ret != HASH_TYPE_E)
+    if (ret != WC_NO_ERR_TRACE(HASH_TYPE_E))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
     ret = wc_HashGetDigestSize(WC_HASH_TYPE_MD4);
 #ifndef NO_MD4
-    if (ret == HASH_TYPE_E || ret == BAD_FUNC_ARG)
+    if (ret == WC_NO_ERR_TRACE(HASH_TYPE_E) ||
+        ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+    {
         return WC_TEST_RET_ENC_EC(ret);
+    }
 #else
-    if (ret != HASH_TYPE_E)
+    if (ret != WC_NO_ERR_TRACE(HASH_TYPE_E))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
     ret = wc_HashGetBlockSize(WC_HASH_TYPE_MD5_SHA);
 #if !defined(NO_MD5) && !defined(NO_SHA)
-    if (ret == HASH_TYPE_E || ret == BAD_FUNC_ARG)
+    if (ret == WC_NO_ERR_TRACE(HASH_TYPE_E) ||
+        ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+    {
         return WC_TEST_RET_ENC_EC(ret);
+    }
 #else
-    if (ret != HASH_TYPE_E)
+    if (ret != WC_NO_ERR_TRACE(HASH_TYPE_E))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
     ret = wc_HashGetBlockSize(WC_HASH_TYPE_BLAKE2B);
 #if defined(HAVE_BLAKE2) || defined(HAVE_BLAKE2S)
-    if (ret == HASH_TYPE_E || ret == BAD_FUNC_ARG)
+    if (ret == WC_NO_ERR_TRACE(HASH_TYPE_E) ||
+        ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+    {
         return WC_TEST_RET_ENC_EC(ret);
+    }
 #else
-    if (ret != HASH_TYPE_E)
+    if (ret != WC_NO_ERR_TRACE(HASH_TYPE_E))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
     ret = wc_HashGetDigestSize(WC_HASH_TYPE_BLAKE2B);
 #if defined(HAVE_BLAKE2) || defined(HAVE_BLAKE2S)
-    if (ret == HASH_TYPE_E || ret == BAD_FUNC_ARG)
+    if (ret == WC_NO_ERR_TRACE(HASH_TYPE_E) ||
+        ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+    {
         return WC_TEST_RET_ENC_EC(ret);
+    }
 #else
-    if (ret != HASH_TYPE_E)
+    if (ret != WC_NO_ERR_TRACE(HASH_TYPE_E))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
     ret = wc_HashGetBlockSize(WC_HASH_TYPE_NONE);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_HashGetDigestSize(WC_HASH_TYPE_NONE);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
 #if !defined(NO_CERTS) && !defined(NO_ASN)
@@ -6341,7 +6376,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hmac_sha_test(void)
             (word32)XSTRLEN(keys[i]));
 #if FIPS_VERSION3_GE(6,0,0)
         if (i == 1) {
-            if (ret != HMAC_MIN_KEYLEN_E)
+            if (ret != WC_NO_ERR_TRACE(HMAC_MIN_KEYLEN_E))
                 return WC_TEST_RET_ENC_EC(ret);
             /* Now use the ex and allow short keys with FIPS option */
             ret = wc_HmacSetKey_ex(&hmac, WC_SHA, (byte*) keys[i],
@@ -6589,9 +6624,9 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hmac_sha256_test(void)
     if ((ret = wc_HmacSizeByType(WC_SHA256)) != WC_SHA256_DIGEST_SIZE)
         return WC_TEST_RET_ENC_EC(ret);
 #if FIPS_VERSION3_GE(6,0,0)
-    if ((ret = wc_HmacSizeByType(21)) != HMAC_KAT_FIPS_E)
+    if ((ret = wc_HmacSizeByType(21)) != WC_NO_ERR_TRACE(HMAC_KAT_FIPS_E))
 #else
-    if ((ret = wc_HmacSizeByType(21)) != BAD_FUNC_ARG)
+    if ((ret = wc_HmacSizeByType(21)) != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
 #endif
     {
         return WC_TEST_RET_ENC_EC(ret);
@@ -8218,53 +8253,53 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t chacha20_poly1305_aead_test(void)
     /* Encrypt */
     err = wc_ChaCha20Poly1305_Encrypt(NULL, iv1, aad1, sizeof(aad1), plaintext1,
             sizeof(plaintext1), generatedCiphertext, generatedAuthTag);
-    if (err != BAD_FUNC_ARG)
+    if (err != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(err);
     err = wc_ChaCha20Poly1305_Encrypt(key1, NULL, aad1, sizeof(aad1),
             plaintext1, sizeof(plaintext1), generatedCiphertext,
             generatedAuthTag);
-    if (err != BAD_FUNC_ARG)
+    if (err != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(err);
     err = wc_ChaCha20Poly1305_Encrypt(key1, iv1, aad1, sizeof(aad1), NULL,
             sizeof(plaintext1), generatedCiphertext, generatedAuthTag);
-    if (err != BAD_FUNC_ARG)
+    if (err != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(err);
     err = wc_ChaCha20Poly1305_Encrypt(key1, iv1, aad1, sizeof(aad1), plaintext1,
             sizeof(plaintext1), NULL, generatedAuthTag);
-    if (err != BAD_FUNC_ARG)
+    if (err != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(err);
     err = wc_ChaCha20Poly1305_Encrypt(key1, iv1, aad1, sizeof(aad1), plaintext1,
             sizeof(plaintext1), generatedCiphertext, NULL);
-    if (err != BAD_FUNC_ARG)
+    if (err != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(err);
     err = wc_ChaCha20Poly1305_Encrypt(key1, iv1, aad1, sizeof(aad1), NULL,
             sizeof(plaintext1), generatedCiphertext, generatedAuthTag);
-    if (err != BAD_FUNC_ARG)
+    if (err != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(err);
     /* Decrypt */
     err = wc_ChaCha20Poly1305_Decrypt(NULL, iv2, aad2, sizeof(aad2), cipher2,
             sizeof(cipher2), authTag2, generatedPlaintext);
-    if (err != BAD_FUNC_ARG)
+    if (err != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(err);
     err = wc_ChaCha20Poly1305_Decrypt(key2, NULL, aad2, sizeof(aad2), cipher2,
             sizeof(cipher2), authTag2, generatedPlaintext);
-    if (err != BAD_FUNC_ARG)
+    if (err != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(err);
     err = wc_ChaCha20Poly1305_Decrypt(key2, iv2, aad2, sizeof(aad2), NULL,
             sizeof(cipher2), authTag2, generatedPlaintext);
-    if (err != BAD_FUNC_ARG)
+    if (err != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(err);
     err = wc_ChaCha20Poly1305_Decrypt(key2, iv2, aad2, sizeof(aad2), cipher2,
             sizeof(cipher2), NULL, generatedPlaintext);
-    if (err != BAD_FUNC_ARG)
+    if (err != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(err);
     err = wc_ChaCha20Poly1305_Decrypt(key2, iv2, aad2, sizeof(aad2), cipher2,
             sizeof(cipher2), authTag2, NULL);
-    if (err != BAD_FUNC_ARG)
+    if (err != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(err);
     err = wc_ChaCha20Poly1305_Decrypt(key2, iv2, aad2, sizeof(aad2), NULL,
             sizeof(cipher2), authTag2, generatedPlaintext);
-    if (err != BAD_FUNC_ARG)
+    if (err != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(err);
 
 
@@ -8336,39 +8371,39 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t chacha20_poly1305_aead_test(void)
     /* AEAD init/update/final - bad argument tests */
     err = wc_ChaCha20Poly1305_Init(NULL, key1, iv1,
         CHACHA20_POLY1305_AEAD_DECRYPT);
-    if (err != BAD_FUNC_ARG)
+    if (err != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(err);
     err = wc_ChaCha20Poly1305_Init(&aead, NULL, iv1,
         CHACHA20_POLY1305_AEAD_DECRYPT);
-    if (err != BAD_FUNC_ARG)
+    if (err != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(err);
     err = wc_ChaCha20Poly1305_Init(&aead, key1, NULL,
         CHACHA20_POLY1305_AEAD_DECRYPT);
-    if (err != BAD_FUNC_ARG)
+    if (err != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(err);
     err = wc_ChaCha20Poly1305_UpdateAad(NULL, aad1, sizeof(aad1));
-    if (err != BAD_FUNC_ARG)
+    if (err != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(err);
     err = wc_ChaCha20Poly1305_UpdateAad(&aead, NULL, sizeof(aad1));
-    if (err != BAD_FUNC_ARG)
+    if (err != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(err);
     err = wc_ChaCha20Poly1305_UpdateData(NULL, generatedPlaintext,
         generatedPlaintext, sizeof(plaintext1));
-    if (err != BAD_FUNC_ARG)
+    if (err != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(err);
     err = wc_ChaCha20Poly1305_UpdateData(&aead, generatedPlaintext, NULL,
         sizeof(plaintext1));
-    if (err != BAD_FUNC_ARG)
+    if (err != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(err);
     err = wc_ChaCha20Poly1305_UpdateData(&aead, NULL, generatedPlaintext,
         sizeof(plaintext1));
-    if (err != BAD_FUNC_ARG)
+    if (err != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(err);
     err = wc_ChaCha20Poly1305_Final(NULL, generatedAuthTag);
-    if (err != BAD_FUNC_ARG)
+    if (err != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(err);
     err = wc_ChaCha20Poly1305_Final(&aead, NULL);
-    if (err != BAD_FUNC_ARG)
+    if (err != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(err);
 
     /* AEAD init/update/final - bad state tests */
@@ -8379,24 +8414,24 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t chacha20_poly1305_aead_test(void)
     XMEMSET(&aead, 0, sizeof(aead));
     aead.state = CHACHA20_POLY1305_STATE_INIT;
     err = wc_ChaCha20Poly1305_UpdateAad(&aead, aad1, sizeof(aad1));
-    if (err != BAD_STATE_E)
+    if (err != WC_NO_ERR_TRACE(BAD_STATE_E))
         return WC_TEST_RET_ENC_EC(err);
     aead.state = CHACHA20_POLY1305_STATE_DATA;
     err = wc_ChaCha20Poly1305_UpdateAad(&aead, aad1, sizeof(aad1));
-    if (err != BAD_STATE_E)
+    if (err != WC_NO_ERR_TRACE(BAD_STATE_E))
         return WC_TEST_RET_ENC_EC(err);
     aead.state = CHACHA20_POLY1305_STATE_INIT;
     err = wc_ChaCha20Poly1305_UpdateData(&aead, generatedPlaintext,
         generatedPlaintext, sizeof(plaintext1));
-    if (err != BAD_STATE_E)
+    if (err != WC_NO_ERR_TRACE(BAD_STATE_E))
         return WC_TEST_RET_ENC_EC(err);
     aead.state = CHACHA20_POLY1305_STATE_INIT;
     err = wc_ChaCha20Poly1305_Final(&aead, generatedAuthTag);
-    if (err != BAD_STATE_E)
+    if (err != WC_NO_ERR_TRACE(BAD_STATE_E))
         return WC_TEST_RET_ENC_EC(err);
     aead.state = CHACHA20_POLY1305_STATE_READY;
     err = wc_ChaCha20Poly1305_Final(&aead, generatedAuthTag);
-    if (err != BAD_STATE_E)
+    if (err != WC_NO_ERR_TRACE(BAD_STATE_E))
         return WC_TEST_RET_ENC_EC(err);
 
     XMEMSET(generatedCiphertext, 0, sizeof(generatedCiphertext));
@@ -8628,7 +8663,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t des_test(void)
         /* Test invalid info ptr */
         ret = wc_BufferKeyEncrypt(NULL, cipher, sizeof(cipher), key,
                 sizeof(key), WC_HASH_TYPE_SHA);
-        if (ret != BAD_FUNC_ARG)
+        if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
             return WC_TEST_RET_ENC_EC(ret);
 
     #ifndef NO_PWDBASED
@@ -10120,7 +10155,7 @@ static wc_test_ret_t aes_key_size_test(void)
     /* w/ FIPS v1 (cert 2425) wc_AesInit just returns 0 always as it's not
      * supported with that FIPS version */
     ret = wc_AesInit(NULL, HEAP_HINT, devId);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 #endif
 
@@ -10132,17 +10167,17 @@ static wc_test_ret_t aes_key_size_test(void)
 #ifndef HAVE_FIPS
     /* Parameter Validation testing. */
     ret = wc_AesGetKeySize(NULL, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesGetKeySize(aes, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesGetKeySize(NULL, &keySize);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     /* Crashes in FIPS */
     ret = wc_AesSetKey(NULL, key16, sizeof(key16), iv, AES_ENCRYPTION);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 #endif
     /* NULL IV indicates to use all zeros IV. */
@@ -10150,11 +10185,11 @@ static wc_test_ret_t aes_key_size_test(void)
 #ifdef WOLFSSL_AES_128
     if (ret != 0)
 #else
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
 #endif
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesSetKey(aes, key32, sizeof(key32) - 1, iv, AES_ENCRYPTION);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 /* CryptoCell handles rounds internally */
 #if !defined(HAVE_FIPS) && !defined(WOLFSSL_CRYPTOCELL)
@@ -10163,7 +10198,7 @@ static wc_test_ret_t aes_key_size_test(void)
     /* Force invalid rounds */
     aes->rounds = 16;
     ret = wc_AesGetKeySize(aes, &keySize);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 #endif
 #endif
@@ -10172,7 +10207,7 @@ static wc_test_ret_t aes_key_size_test(void)
 #ifdef WOLFSSL_AES_128
     if (ret != 0)
 #else
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
 #endif
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 #if !defined(HAVE_FIPS) && defined(WOLFSSL_AES_128)
@@ -10186,7 +10221,7 @@ static wc_test_ret_t aes_key_size_test(void)
 #ifdef WOLFSSL_AES_192
     if (ret != 0)
 #else
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
 #endif
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 #if !defined(HAVE_FIPS) && defined(WOLFSSL_AES_192)
@@ -10199,7 +10234,7 @@ static wc_test_ret_t aes_key_size_test(void)
 #ifdef WOLFSSL_AES_256
     if (ret != 0)
 #else
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
 #endif
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 #if !defined(HAVE_FIPS) && defined(WOLFSSL_AES_256)
@@ -12514,11 +12549,11 @@ static wc_test_ret_t aes_cbc_test(void)
 
     /* Parameter Validation testing. */
     ret = wc_AesCbcEncryptWithKey(cipher, msg, AES_BLOCK_SIZE, key, 17, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 #ifdef HAVE_AES_DECRYPT
     ret = wc_AesCbcDecryptWithKey(plain, cipher, AES_BLOCK_SIZE, key, 17, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
@@ -15567,7 +15602,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t gmac_test(void)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
         ret = wc_GmacVerify(k1, sizeof(k1), iv1, sizeof(iv1), a1, sizeof(a1),
                     badT, sizeof(badT));
-        if (ret != AES_GCM_AUTH_E)
+        if (ret != WC_NO_ERR_TRACE(AES_GCM_AUTH_E))
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
         ret = wc_GmacVerify(k2, sizeof(k2), iv2, sizeof(iv2), a2, sizeof(a2),
                     t2, sizeof(t2));
@@ -15902,23 +15937,23 @@ static wc_test_ret_t aesccm_128_test(void)
     ret = wc_AesCcmEncrypt(enc, pl2 /* out */, NULL /* in */, 1 /* inSz */,
                               iv, sizeof(iv), t_empty2, sizeof(t_empty2),
                               a, sizeof(a));
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesCcmEncrypt(enc, NULL /* out */, (const byte *)"" /* in */, 1 /* inSz */,
                               iv, sizeof(iv), t_empty2, sizeof(t_empty2),
                               a, sizeof(a));
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 #ifdef HAVE_AES_DECRYPT
     ret = wc_AesCcmDecrypt(enc, pl2, NULL /* in */, 1 /* inSz */,
                               iv, sizeof(iv), t_empty2, sizeof(t_empty2), a,
                               sizeof(a));
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     ret = wc_AesCcmDecrypt(enc, NULL /* out */, (const byte *)"" /* in */, 1 /* inSz */,
                               iv, sizeof(iv), t_empty2, sizeof(t_empty2), a,
                               sizeof(a));
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 #endif
 
@@ -15928,7 +15963,7 @@ static wc_test_ret_t aesccm_128_test(void)
     ret = wc_AesCcmEncrypt(enc, NULL /* out */, NULL /* in */, 0 /* inSz */,
                               iv, sizeof(iv), t_empty2, sizeof(t_empty2),
                               a, sizeof(a));
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         if (ret != 0)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
         if (XMEMCMP(t_empty, t_empty2, sizeof(t_empty2)))
@@ -17408,23 +17443,23 @@ static wc_test_ret_t _rng_test(WC_RNG* rng, int errorOffset)
 
     /* Parameter validation testing. */
     ret = wc_RNG_GenerateBlock(NULL, block, sizeof(block));
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ret = 4;
         goto exit;
     }
     ret = wc_RNG_GenerateBlock(rng, NULL, sizeof(block));
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ret = 5;
         goto exit;
     }
 
     ret = wc_RNG_GenerateByte(NULL, block);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ret = 6;
         goto exit;
     }
     ret = wc_RNG_GenerateByte(rng, NULL);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ret = 7;
         goto exit;
     }
@@ -18298,7 +18333,7 @@ static wc_test_ret_t cert_asn1_test(void)
     InitDecodedCert(&cert, badCert, len[0], 0);
     ret = ParseCert(&cert, CERT_TYPE, NO_VERIFY, NULL);
     FreeDecodedCert(&cert);
-    if (ret != ASN_PARSE_E) {
+    if (ret != WC_NO_ERR_TRACE(ASN_PARSE_E)) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     }
     XFREE(badCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -18435,7 +18470,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t cert_test(void)
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 #else
-    if (ret != ASN_CRIT_EXT_E) {
+    if (ret != WC_NO_ERR_TRACE(ASN_CRIT_EXT_E)) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     }
     ret = 0;
@@ -18700,7 +18735,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t decodedCertCache_test(void)
 
     if (ret == 0) {
         ret = wc_SetSubjectBuffer(NULL, der, derSz);
-        if (ret == BAD_FUNC_ARG)
+        if (ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG))
             ret = 0;
         else
             ret = WC_TEST_RET_ENC_EC(ret);
@@ -18714,7 +18749,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t decodedCertCache_test(void)
 
     if (ret == 0) {
         ret = wc_SetSubjectRaw(NULL, der, derSz);
-        if (ret == BAD_FUNC_ARG)
+        if (ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG))
             ret = 0;
         else
             ret = WC_TEST_RET_ENC_EC(ret);
@@ -18728,7 +18763,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t decodedCertCache_test(void)
 
     if (ret == 0) {
         ret = wc_SetIssuerBuffer(NULL, der, derSz);
-        if (ret == BAD_FUNC_ARG)
+        if (ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG))
             ret = 0;
         else
             ret = WC_TEST_RET_ENC_EC(ret);
@@ -18742,7 +18777,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t decodedCertCache_test(void)
 
     if (ret == 0) {
         ret = wc_SetIssuerRaw(NULL, der, derSz);
-        if (ret == BAD_FUNC_ARG)
+        if (ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG))
             ret = 0;
         else
             ret = WC_TEST_RET_ENC_EC(ret);
@@ -18757,7 +18792,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t decodedCertCache_test(void)
 
     if (ret == 0) {
         ret = wc_SetAltNamesBuffer(NULL, der, derSz);
-        if (ret == BAD_FUNC_ARG)
+        if (ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG))
             ret = 0;
         else
             ret = WC_TEST_RET_ENC_EC(ret);
@@ -18771,7 +18806,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t decodedCertCache_test(void)
 
     if (ret == 0) {
         ret = wc_SetDatesBuffer(NULL, der, derSz);
-        if (ret == BAD_FUNC_ARG)
+        if (ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG))
             ret = 0;
         else
             ret = WC_TEST_RET_ENC_EC(ret);
@@ -18786,7 +18821,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t decodedCertCache_test(void)
 
     if (ret == 0) {
         ret = wc_SetAuthKeyIdFromCert(NULL, der, derSz);
-        if (ret == BAD_FUNC_ARG)
+        if (ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG))
             ret = 0;
         else
             ret = WC_TEST_RET_ENC_NC;
@@ -18819,23 +18854,23 @@ static wc_test_ret_t rsa_flatten_test(RsaKey* key)
 
     /* Parameter Validation testing. */
     ret = wc_RsaFlattenPublicKey(NULL, e, &eSz, n, &nSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_RsaFlattenPublicKey(key, NULL, &eSz, n, &nSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_RsaFlattenPublicKey(key, e, NULL, n, &nSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_RsaFlattenPublicKey(key, e, &eSz, NULL, &nSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_RsaFlattenPublicKey(key, e, &eSz, n, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_RsaFlattenPublicKey(key, e, &eSz, n, &nSz);
@@ -18844,13 +18879,13 @@ static wc_test_ret_t rsa_flatten_test(RsaKey* key)
 
     eSz = 0;
     ret = wc_RsaFlattenPublicKey(key, e, &eSz, n, &nSz);
-    if (ret != RSA_BUFFER_E)
+    if (ret != WC_NO_ERR_TRACE(RSA_BUFFER_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     eSz = sizeof(e);
     nSz = 0;
     ret = wc_RsaFlattenPublicKey(key, e, &eSz, n, &nSz);
-    if (ret != RSA_BUFFER_E)
+    if (ret != WC_NO_ERR_TRACE(RSA_BUFFER_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     return 0;
@@ -18875,54 +18910,54 @@ static wc_test_ret_t rsa_export_key_test(RsaKey* key)
     word32 zero = 0;
 
     ret = wc_RsaExportKey(NULL, e, &eSz, n, &nSz, d, &dSz, p, &pSz, q, &qSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_RsaExportKey(key, NULL, &eSz, n, &nSz, d, &dSz, p, &pSz, q, &qSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_RsaExportKey(key, e, NULL, n, &nSz, d, &dSz, p, &pSz, q, &qSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_RsaExportKey(key, e, &eSz, NULL, &nSz, d, &dSz, p, &pSz, q, &qSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_RsaExportKey(key, e, &eSz, n, NULL, d, &dSz, p, &pSz, q, &qSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_RsaExportKey(key, e, &eSz, n, &nSz, NULL, &dSz, p, &pSz, q, &qSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_RsaExportKey(key, e, &eSz, n, &nSz, d, NULL, p, &pSz, q, &qSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_RsaExportKey(key, e, &eSz, n, &nSz, d, &dSz, NULL, &pSz, q, &qSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_RsaExportKey(key, e, &eSz, n, &nSz, d, &dSz, p, NULL, q, &qSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_RsaExportKey(key, e, &eSz, n, &nSz, d, &dSz, p, &pSz, NULL, &qSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_RsaExportKey(key, e, &eSz, n, &nSz, d, &dSz, p, &pSz, q, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_RsaExportKey(key, e, &zero, n, &nSz, d, &dSz, p, &pSz, q, &qSz);
-    if (ret != RSA_BUFFER_E)
+    if (ret != WC_NO_ERR_TRACE(RSA_BUFFER_E))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_RsaExportKey(key, e, &eSz, n, &zero, d, &dSz, p, &pSz, q, &qSz);
-    if (ret != RSA_BUFFER_E)
+    if (ret != WC_NO_ERR_TRACE(RSA_BUFFER_E))
         return WC_TEST_RET_ENC_EC(ret);
 #ifndef WOLFSSL_RSA_PUBLIC_ONLY
     ret = wc_RsaExportKey(key, e, &eSz, n, &nSz, d, &zero, p, &pSz, q, &qSz);
-    if (ret != RSA_BUFFER_E)
+    if (ret != WC_NO_ERR_TRACE(RSA_BUFFER_E))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_RsaExportKey(key, e, &eSz, n, &nSz, d, &dSz, p, &zero, q, &qSz);
-    if (ret != RSA_BUFFER_E)
+    if (ret != WC_NO_ERR_TRACE(RSA_BUFFER_E))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_RsaExportKey(key, e, &eSz, n, &nSz, d, &dSz, p, &pSz, q, &zero);
-    if (ret != RSA_BUFFER_E)
+    if (ret != WC_NO_ERR_TRACE(RSA_BUFFER_E))
         return WC_TEST_RET_ENC_EC(ret);
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
 
@@ -18961,36 +18996,36 @@ static wc_test_ret_t rsa_sig_test(RsaKey* key, word32 keyLen, int modLen, WC_RNG
 
     /* Parameter Validation testing. */
     ret = wc_SignatureGetSize(WC_SIGNATURE_TYPE_NONE, key, keyLen);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SignatureGetSize(WC_SIGNATURE_TYPE_RSA, key, 0);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     sigSz = (word32)modLen;
     ret = wc_SignatureGenerate(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA, NULL,
                                inLen, out, &sigSz, key, keyLen, rng);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SignatureGenerate(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA, in,
                                0, out, &sigSz, key, keyLen, rng);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SignatureGenerate(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA, in,
                                inLen, NULL, &sigSz, key, keyLen, rng);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SignatureGenerate(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA, in,
                                inLen, out, NULL, key, keyLen, rng);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SignatureGenerate(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA, in,
                                inLen, out, &sigSz, NULL, keyLen, rng);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SignatureGenerate(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA, in,
                                inLen, out, &sigSz, key, 0, rng);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SignatureGenerate(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA, in,
                                inLen, out, &sigSz, key, keyLen, NULL);
@@ -19000,56 +19035,56 @@ static wc_test_ret_t rsa_sig_test(RsaKey* key, word32 keyLen, int modLen, WC_RNG
 #elif defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLF_CRYPTO_CB)
     /* async may not require RNG */
     #if defined(WOLF_CRYPTO_CB_ONLY_RSA)
-    if (ret != NO_VALID_DEVID)
+    if (ret != WC_NO_ERR_TRACE(NO_VALID_DEVID))
     #else
-    if (ret != 0 && ret != MISSING_RNG_E)
+    if (ret != 0 && ret != WC_NO_ERR_TRACE(MISSING_RNG_E))
     #endif
 #elif defined(HAVE_FIPS) || !defined(WC_RSA_BLINDING)
     /* FIPS140 implementation does not do blinding */
     if (ret != 0)
 #elif defined(WOLFSSL_RSA_PUBLIC_ONLY) || defined(WOLFSSL_RSA_VERIFY_ONLY)
-    if (ret != SIG_TYPE_E)
+    if (ret != WC_NO_ERR_TRACE(SIG_TYPE_E))
 #elif defined(WOLFSSL_CRYPTOCELL) || defined(WOLFSSL_SE050)
     /* RNG is handled by hardware */
     if (ret != 0)
 #else
-    if (ret != MISSING_RNG_E)
+    if (ret != WC_NO_ERR_TRACE(MISSING_RNG_E))
 #endif
         return WC_TEST_RET_ENC_EC(ret);
     sigSz = 0;
     ret = wc_SignatureGenerate(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA, in,
                                inLen, out, &sigSz, key, keyLen, rng);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_SignatureVerify(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA, NULL,
                              inLen, out, (word32)modLen, key, keyLen);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SignatureVerify(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA, in,
                              0, out, (word32)modLen, key, keyLen);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SignatureVerify(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA, in,
                              inLen, NULL, (word32)modLen, key, keyLen);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SignatureVerify(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA, in,
                              inLen, out, 0, key, keyLen);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SignatureVerify(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA, in,
                              inLen, out, (word32)modLen, NULL, keyLen);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SignatureVerify(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA, in,
                              inLen, out, (word32)modLen, key, 0);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
 #ifndef HAVE_ECC
     ret = wc_SignatureGetSize(WC_SIGNATURE_TYPE_ECC, key, keyLen);
-    if (ret != SIG_TYPE_E)
+    if (ret != WC_NO_ERR_TRACE(SIG_TYPE_E))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 #if defined(WOLF_CRYPTO_CB_ONLY_RSA)
@@ -19268,17 +19303,17 @@ static wc_test_ret_t rsa_decode_test(RsaKey* keyPub)
 
     /* Parameter Validation testing. */
     ret = wc_RsaPublicKeyDecodeRaw(NULL, sizeof(n), e, sizeof(e), keyPub);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     ret = wc_RsaPublicKeyDecodeRaw(n, sizeof(n), NULL, sizeof(e), keyPub);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     ret = wc_RsaPublicKeyDecodeRaw(n, sizeof(n), e, sizeof(e), NULL);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
@@ -19286,7 +19321,7 @@ static wc_test_ret_t rsa_decode_test(RsaKey* keyPub)
 #if defined(USE_INTEGER_HEAP_MATH)
     if (ret != 0)
 #else
-    if (ret != ASN_GETINT_E)
+    if (ret != WC_NO_ERR_TRACE(ASN_GETINT_E))
 #endif
     {
         ret = WC_TEST_RET_ENC_EC(ret);
@@ -19300,7 +19335,7 @@ static wc_test_ret_t rsa_decode_test(RsaKey* keyPub)
 #if defined(USE_INTEGER_HEAP_MATH)
     if (ret != 0)
 #else
-    if (ret != ASN_GETINT_E)
+    if (ret != WC_NO_ERR_TRACE(ASN_GETINT_E))
 #endif
     {
         ret = WC_TEST_RET_ENC_EC(ret);
@@ -19325,17 +19360,17 @@ static wc_test_ret_t rsa_decode_test(RsaKey* keyPub)
     /* Parameter Validation testing. */
     inSz = sizeof(good);
     ret = wc_RsaPublicKeyDecode(NULL, &inOutIdx, keyPub, inSz);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     ret = wc_RsaPublicKeyDecode(good, NULL, keyPub, inSz);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     ret = wc_RsaPublicKeyDecode(good, &inOutIdx, NULL, inSz);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
@@ -19344,14 +19379,14 @@ static wc_test_ret_t rsa_decode_test(RsaKey* keyPub)
     inOutIdx = 2;
     inSz = sizeof(good) - inOutIdx;
     ret = wc_RsaPublicKeyDecode(good, &inOutIdx, keyPub, inSz);
-    if (ret != ASN_PARSE_E) {
+    if (ret != WC_NO_ERR_TRACE(ASN_PARSE_E)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     inOutIdx = 2;
     inSz = sizeof(goodAlgId) - inOutIdx;
     ret = wc_RsaPublicKeyDecode(goodAlgId, &inOutIdx, keyPub, inSz);
-    if (ret != ASN_PARSE_E) {
+    if (ret != WC_NO_ERR_TRACE(ASN_PARSE_E)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
@@ -19359,9 +19394,9 @@ static wc_test_ret_t rsa_decode_test(RsaKey* keyPub)
     inSz = sizeof(goodAlgId);
     ret = wc_RsaPublicKeyDecode(goodAlgId, &inOutIdx, keyPub, inSz);
 #ifndef WOLFSSL_NO_DECODE_EXTRA
-    if (ret != ASN_PARSE_E)
+    if (ret != WC_NO_ERR_TRACE(ASN_PARSE_E))
 #else
-    if (ret != ASN_RSA_KEY_E)
+    if (ret != WC_NO_ERR_TRACE(ASN_RSA_KEY_E))
 #endif
     {
         ret = WC_TEST_RET_ENC_EC(ret);
@@ -19371,49 +19406,55 @@ static wc_test_ret_t rsa_decode_test(RsaKey* keyPub)
     inSz = sizeof(badAlgIdNull);
     inOutIdx = 0;
     ret = wc_RsaPublicKeyDecode(badAlgIdNull, &inOutIdx, keyPub, inSz);
-    if (ret != ASN_EXPECT_0_E) {
+    if (ret != WC_NO_ERR_TRACE(ASN_EXPECT_0_E)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     inSz = sizeof(badNotBitString);
     inOutIdx = 0;
     ret = wc_RsaPublicKeyDecode(badNotBitString, &inOutIdx, keyPub, inSz);
-    if (ret != ASN_BITSTR_E) {
+    if (ret != WC_NO_ERR_TRACE(ASN_BITSTR_E)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     inSz = sizeof(badBitStringLen);
     inOutIdx = 0;
     ret = wc_RsaPublicKeyDecode(badBitStringLen, &inOutIdx, keyPub, inSz);
-    if (ret != ASN_PARSE_E) {
+    if (ret != WC_NO_ERR_TRACE(ASN_PARSE_E)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     inSz = sizeof(badNoSeq);
     inOutIdx = 0;
     ret = wc_RsaPublicKeyDecode(badNoSeq, &inOutIdx, keyPub, inSz);
-    if (ret != ASN_PARSE_E) {
+    if (ret != WC_NO_ERR_TRACE(ASN_PARSE_E)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     inSz = sizeof(badNoObj);
     inOutIdx = 0;
     ret = wc_RsaPublicKeyDecode(badNoObj, &inOutIdx, keyPub, inSz);
-    if (ret != ASN_PARSE_E && ret != ASN_OBJECT_ID_E) {
+    if (ret != WC_NO_ERR_TRACE(ASN_PARSE_E) &&
+        ret != WC_NO_ERR_TRACE(ASN_OBJECT_ID_E))
+    {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     inSz = sizeof(badIntN);
     inOutIdx = 0;
     ret = wc_RsaPublicKeyDecode(badIntN, &inOutIdx, keyPub, inSz);
-    if (ret != ASN_RSA_KEY_E && ret != ASN_PARSE_E) {
+    if (ret != WC_NO_ERR_TRACE(ASN_RSA_KEY_E) &&
+        ret != WC_NO_ERR_TRACE(ASN_PARSE_E))
+    {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     inSz = sizeof(badNotIntE);
     inOutIdx = 0;
     ret = wc_RsaPublicKeyDecode(badNotIntE, &inOutIdx, keyPub, inSz);
-    if (ret != ASN_RSA_KEY_E && ret != ASN_PARSE_E) {
+    if (ret != WC_NO_ERR_TRACE(ASN_RSA_KEY_E) &&
+        ret != WC_NO_ERR_TRACE(ASN_PARSE_E))
+    {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
@@ -19424,7 +19465,7 @@ static wc_test_ret_t rsa_decode_test(RsaKey* keyPub)
 #ifndef WOLFSSL_ASN_TEMPLATE
     if (ret != 0)
 #else
-    if (ret != ASN_PARSE_E)
+    if (ret != WC_NO_ERR_TRACE(ASN_PARSE_E))
 #endif
     {
         ret = WC_TEST_RET_ENC_EC(ret);
@@ -19439,7 +19480,9 @@ static wc_test_ret_t rsa_decode_test(RsaKey* keyPub)
     inSz = sizeof(badBitStrNoZero);
     inOutIdx = 0;
     ret = wc_RsaPublicKeyDecode(badBitStrNoZero, &inOutIdx, keyPub, inSz);
-    if (ret != ASN_EXPECT_0_E && ret != ASN_PARSE_E) {
+    if (ret != WC_NO_ERR_TRACE(ASN_EXPECT_0_E) &&
+        ret != WC_NO_ERR_TRACE(ASN_PARSE_E))
+    {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
@@ -19589,7 +19632,7 @@ static wc_test_ret_t rsa_pss_test(WC_RNG* rng, RsaKey* key)
                     ret = wc_RsaPSS_Sign_ex(digest, digestSz, out, outSz,
                         hash[j], mgf[i], -1, key, rng);
                 }
-            } while (ret == WC_PENDING_E);
+            } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
             if (ret <= 0)
                 ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_pss);
             outSz = (word32)ret;
@@ -19607,7 +19650,7 @@ static wc_test_ret_t rsa_pss_test(WC_RNG* rng, RsaKey* key)
                     ret = wc_RsaPSS_VerifyInline_ex(sig, outSz, &plain, hash[j],
                         mgf[i], -1, key);
                 }
-            } while (ret == WC_PENDING_E);
+            } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
             if (ret <= 0)
                 ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_pss);
             plainSz = (word32)ret;
@@ -19644,7 +19687,7 @@ static wc_test_ret_t rsa_pss_test(WC_RNG* rng, RsaKey* key)
                             ret = wc_RsaPSS_VerifyInline_ex(sig, outSz,
                                 (byte**)&plain, hash[l], mgf[k], -1, key);
                         }
-                    } while (ret == WC_PENDING_E);
+                    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
                     if (ret >= 0)
                         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_pss);
                 }
@@ -19669,7 +19712,7 @@ static wc_test_ret_t rsa_pss_test(WC_RNG* rng, RsaKey* key)
             ret = wc_RsaPSS_Sign_ex(digest, digestSz, out, outSz, hash[0],
                 mgf[0], 0, key, rng);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret <= 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_pss);
     outSz = (word32)ret;
@@ -19684,7 +19727,7 @@ static wc_test_ret_t rsa_pss_test(WC_RNG* rng, RsaKey* key)
             ret = wc_RsaPSS_Verify_ex(out, outSz, sig, outSz, hash[0], mgf[0],
                 0, key);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret <= 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_pss);
     plainSz = (word32)ret;
@@ -19708,7 +19751,7 @@ static wc_test_ret_t rsa_pss_test(WC_RNG* rng, RsaKey* key)
                 hash[0], 0, 0, HEAP_HINT);
 #endif
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_pss);
 
@@ -19723,7 +19766,7 @@ static wc_test_ret_t rsa_pss_test(WC_RNG* rng, RsaKey* key)
             ret = wc_RsaPSS_VerifyInline_ex(sig, outSz, &plain, hash[0], mgf[0],
                 0, key);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret <= 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_pss);
     plainSz = (word32)ret;
@@ -19760,8 +19803,8 @@ static wc_test_ret_t rsa_pss_test(WC_RNG* rng, RsaKey* key)
             ret = wc_RsaPSS_Sign_ex(digest, digestSz, out, outSz, hash[0],
                 mgf[0], len, key, rng);
         }
-    } while (ret == WC_PENDING_E);
-    if (ret != PSS_SALTLEN_E)
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
+    if (ret != WC_NO_ERR_TRACE(PSS_SALTLEN_E))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_pss);
 
     do {
@@ -19773,8 +19816,8 @@ static wc_test_ret_t rsa_pss_test(WC_RNG* rng, RsaKey* key)
             ret = wc_RsaPSS_Sign_ex(digest, digestSz, out, outSz, hash[0],
                 mgf[0], digestSz + 1, key, rng);
         }
-    } while (ret == WC_PENDING_E);
-    if (ret != PSS_SALTLEN_E)
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
+    if (ret != WC_NO_ERR_TRACE(PSS_SALTLEN_E))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_pss);
     TEST_SLEEP();
 
@@ -19787,8 +19830,8 @@ static wc_test_ret_t rsa_pss_test(WC_RNG* rng, RsaKey* key)
             ret = wc_RsaPSS_VerifyInline_ex(sig, outSz, &plain, hash[0],
                 mgf[0], -2, key);
         }
-    } while (ret == WC_PENDING_E);
-    if (ret != PSS_SALTLEN_E)
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
+    if (ret != WC_NO_ERR_TRACE(PSS_SALTLEN_E))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_pss);
     TEST_SLEEP();
 
@@ -19801,8 +19844,8 @@ static wc_test_ret_t rsa_pss_test(WC_RNG* rng, RsaKey* key)
             ret = wc_RsaPSS_VerifyInline_ex(sig, outSz, &plain, hash[0], mgf[0],
                 digestSz + 1, key);
         }
-    } while (ret == WC_PENDING_E);
-    if (ret != PSS_SALTLEN_E)
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
+    if (ret != WC_NO_ERR_TRACE(PSS_SALTLEN_E))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_pss);
     TEST_SLEEP();
 
@@ -19822,7 +19865,7 @@ static wc_test_ret_t rsa_pss_test(WC_RNG* rng, RsaKey* key)
     ret = wc_RsaPSS_CheckPadding_ex2(digest, digestSz, plain, plainSz, hash[0],
                                     len, 0, HEAP_HINT);
 #endif
-    if (ret != PSS_SALTLEN_E)
+    if (ret != WC_NO_ERR_TRACE(PSS_SALTLEN_E))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_pss);
 #ifndef WOLFSSL_PSS_LONG_SALT
     len = (int)(digestSz + 1);
@@ -19833,17 +19876,17 @@ static wc_test_ret_t rsa_pss_test(WC_RNG* rng, RsaKey* key)
     (!defined(HAVE_SELFTEST_VERSION) || (HAVE_SELFTEST_VERSION < 2))
             ret = wc_RsaPSS_CheckPadding_ex(digest, digestSz, plain, plainSz,
                                          hash[0], len);
-    if (ret != PSS_SALTLEN_E)
+    if (ret != WC_NO_ERR_TRACE(PSS_SALTLEN_E))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_pss);
 #elif defined(HAVE_SELFTEST) && (HAVE_SELFTEST_VERSION == 2)
             ret = wc_RsaPSS_CheckPadding_ex(digest, digestSz, plain, plainSz,
                                          hash[0], len, 0);
-    if (ret != BAD_PADDING_E)
+    if (ret != WC_NO_ERR_TRACE(BAD_PADDING_E))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_pss);
 #else
     ret = wc_RsaPSS_CheckPadding_ex2(digest, digestSz, plain, plainSz, hash[0],
                                     len, 0, HEAP_HINT);
-    if (ret != PSS_SALTLEN_E)
+    if (ret != WC_NO_ERR_TRACE(PSS_SALTLEN_E))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_pss);
 #endif
 
@@ -19971,7 +20014,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_no_pad_test(void)
             ret = wc_RsaDirect(tmp, inLen, out, &outSz, key,
                     RSA_PRIVATE_ENCRYPT, &rng);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret <= 0) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_nopadding);
     }
@@ -19991,7 +20034,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_no_pad_test(void)
             ret = wc_RsaDirect(out, outSz, plain, &plainSz, key,
                     RSA_PUBLIC_DECRYPT, &rng);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret <= 0) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_nopadding);
     }
@@ -20004,7 +20047,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_no_pad_test(void)
 
 #ifdef WC_RSA_BLINDING
     ret = wc_RsaSetRNG(NULL, &rng);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_nopadding);
     }
 
@@ -20024,7 +20067,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_no_pad_test(void)
             ret = wc_RsaPublicEncrypt_ex(tmp, inLen, out, outSz, key, &rng,
                 WC_RSA_NO_PAD, WC_HASH_TYPE_NONE, WC_MGF1NONE, NULL, 0);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_nopadding);
     }
@@ -20040,7 +20083,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_no_pad_test(void)
             ret = wc_RsaPrivateDecrypt_ex(out, outSz, plain, plainSz, key,
                 WC_RSA_NO_PAD, WC_HASH_TYPE_NONE, WC_MGF1NONE, NULL, 0);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_nopadding);
     }
@@ -20054,25 +20097,25 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_no_pad_test(void)
     /* test some bad arguments */
     ret = wc_RsaDirect(out, outSz, plain, &plainSz, key, -1,
             &rng);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_nopadding);
     }
 
     ret = wc_RsaDirect(out, outSz, plain, &plainSz, NULL, RSA_PUBLIC_DECRYPT,
             &rng);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_nopadding);
     }
 
     ret = wc_RsaDirect(out, outSz, NULL, &plainSz, key, RSA_PUBLIC_DECRYPT,
             &rng);
-    if (ret != LENGTH_ONLY_E || plainSz != inLen) {
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E) || plainSz != inLen) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_nopadding);
     }
 
     ret = wc_RsaDirect(out, outSz - 10, plain, &plainSz, key,
             RSA_PUBLIC_DECRYPT, &rng);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_nopadding);
     }
 
@@ -20211,12 +20254,15 @@ static wc_test_ret_t rsa_even_mod_test(WC_RNG* rng, RsaKey* key)
     outSz   = wc_RsaEncryptSize(key);
     XMEMSET(tmp, 7, plainSz);
     ret = wc_RsaSSL_Sign(tmp, inLen, out, outSz, key, rng);
-    if (ret != MP_VAL && ret != MP_EXPTMOD_E && ret != MP_INVMOD_E) {
+    if (ret != WC_NO_ERR_TRACE(MP_VAL) &&
+        ret != WC_NO_ERR_TRACE(MP_EXPTMOD_E) &&
+        ret != WC_NO_ERR_TRACE(MP_INVMOD_E))
+    {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_even_mod);
     }
 
     ret = wc_RsaSSL_Verify(out, outSz, tmp, inLen, key);
-    if (ret != MP_VAL && ret != MP_EXPTMOD_E) {
+    if (ret != MP_VAL && ret != WC_NO_ERR_TRACE(MP_EXPTMOD_E)) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_even_mod);
     }
 #endif
@@ -20231,14 +20277,17 @@ static wc_test_ret_t rsa_even_mod_test(WC_RNG* rng, RsaKey* key)
     /* test encrypt and decrypt using WC_RSA_NO_PAD */
 #if !defined(WOLFSSL_RSA_VERIFY_ONLY) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)
     ret = wc_RsaPublicEncrypt(tmp, inLen, out, (int)outSz, key, rng);
-    if (ret != MP_VAL && ret != MP_EXPTMOD_E) {
+    if (ret != MP_VAL && ret != WC_NO_ERR_TRACE(MP_EXPTMOD_E)) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_even_mod);
     }
 #endif /* WOLFSSL_RSA_VERIFY_ONLY */
 
 #ifndef WOLFSSL_RSA_PUBLIC_ONLY
     ret = wc_RsaPrivateDecrypt(out, outSz, plain, (int)plainSz, key);
-    if (ret != MP_VAL && ret != MP_EXPTMOD_E && ret != MP_INVMOD_E) {
+    if (ret != WC_NO_ERR_TRACE(MP_VAL) &&
+        ret != WC_NO_ERR_TRACE(MP_EXPTMOD_E) &&
+        ret != WC_NO_ERR_TRACE(MP_INVMOD_E))
+    {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa_even_mod);
     }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
@@ -20379,7 +20428,7 @@ static wc_test_ret_t rsa_certgen_test(RsaKey* key, RsaKey* keypub, WC_RNG* rng, 
         if (ret >= 0) {
             ret = wc_MakeSelfCert(myCert, der, FOURK_BUF, key, rng);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
     }
@@ -20540,7 +20589,7 @@ static wc_test_ret_t rsa_certgen_test(RsaKey* key, RsaKey* keypub, WC_RNG* rng, 
             ret = wc_SignCert(myCert->bodySz, myCert->sigType, der, FOURK_BUF,
                       caKey, NULL, rng);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
     certSz = (int)ret;
@@ -20768,7 +20817,7 @@ static wc_test_ret_t rsa_ecc_certgen_test(WC_RNG* rng, byte* tmp)
             ret = wc_SignCert(myCert->bodySz, myCert->sigType, der,
                               FOURK_BUF, caKey, NULL, rng);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
     certSz = (int)ret;
@@ -20867,7 +20916,7 @@ static wc_test_ret_t rsa_keygen_test(WC_RNG* rng)
         ret = wc_AsyncWait(ret, &genKey->asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
 #ifdef HAVE_FIPS
-        if (ret == PRIME_GEN_E)
+        if (ret == WC_NO_ERR_TRACE(PRIME_GEN_E))
             continue;
         break;
     }
@@ -20972,7 +21021,7 @@ static wc_test_ret_t rsa_oaep_padding_test(RsaKey* key, WC_RNG* rng)
             ret = wc_RsaPublicEncrypt_ex(in, inLen, out, outSz, key, rng,
                        WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA, WC_MGF1SHA1, NULL, 0);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
     TEST_SLEEP();
@@ -20987,7 +21036,7 @@ static wc_test_ret_t rsa_oaep_padding_test(RsaKey* key, WC_RNG* rng)
             ret = wc_RsaPrivateDecrypt_ex(out, idx, plain, plainSz, key,
                        WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA, WC_MGF1SHA1, NULL, 0);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
 
@@ -21008,7 +21057,7 @@ static wc_test_ret_t rsa_oaep_padding_test(RsaKey* key, WC_RNG* rng)
             ret = wc_RsaPublicEncrypt_ex(in, inLen, out, outSz, key, rng,
                   WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, NULL, 0);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
     TEST_SLEEP();
@@ -21023,7 +21072,7 @@ static wc_test_ret_t rsa_oaep_padding_test(RsaKey* key, WC_RNG* rng)
             ret = wc_RsaPrivateDecrypt_ex(out, idx, plain, plainSz, key,
                   WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, NULL, 0);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
 
@@ -21042,7 +21091,7 @@ static wc_test_ret_t rsa_oaep_padding_test(RsaKey* key, WC_RNG* rng)
             ret = wc_RsaPrivateDecryptInline_ex(out, idx, &res, key,
                 WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, NULL, 0);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
     if (ret != (int)inLen) {
@@ -21064,7 +21113,7 @@ static wc_test_ret_t rsa_oaep_padding_test(RsaKey* key, WC_RNG* rng)
             ret = wc_RsaPublicEncrypt_ex(in, inLen, out, outSz, key, rng,
                   WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, NULL, 0);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
     TEST_SLEEP();
@@ -21083,7 +21132,7 @@ static wc_test_ret_t rsa_oaep_padding_test(RsaKey* key, WC_RNG* rng)
             ret = wc_RsaPrivateDecrypt_ex(out, idx, plain, plainSz, key,
                WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, in, inLen);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret > 0) { /* in this case decrypt should fail */
         ERROR_OUT(WC_TEST_RET_ENC_NC, exit_rsa);
     }
@@ -21101,7 +21150,7 @@ static wc_test_ret_t rsa_oaep_padding_test(RsaKey* key, WC_RNG* rng)
             ret = wc_RsaPublicEncrypt_ex(in, inLen, out, outSz, key, rng,
                WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, in, inLen);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
     TEST_SLEEP();
@@ -21116,7 +21165,7 @@ static wc_test_ret_t rsa_oaep_padding_test(RsaKey* key, WC_RNG* rng)
             ret = wc_RsaPrivateDecrypt_ex(out, idx, plain, plainSz, key,
                WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, in, inLen);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
 
@@ -21137,7 +21186,7 @@ static wc_test_ret_t rsa_oaep_padding_test(RsaKey* key, WC_RNG* rng)
                 ret = wc_RsaPublicEncrypt_ex(in, inLen, out, outSz, key, rng,
                     WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA, WC_MGF1SHA1, in, inLen);
             }
-        } while (ret == WC_PENDING_E);
+        } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
         if (ret < 0)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
         TEST_SLEEP();
@@ -21155,7 +21204,7 @@ static wc_test_ret_t rsa_oaep_padding_test(RsaKey* key, WC_RNG* rng)
                     WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256,
                     in, inLen);
             }
-        } while (ret == WC_PENDING_E);
+        } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
         if (ret > 0) { /* should fail */
             ERROR_OUT(WC_TEST_RET_ENC_NC, exit_rsa);
         }
@@ -21180,7 +21229,7 @@ static wc_test_ret_t rsa_oaep_padding_test(RsaKey* key, WC_RNG* rng)
                 ret = wc_RsaPublicEncrypt_ex(in, inLen, out, outSz, key, rng,
                   WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA512, WC_MGF1SHA512, NULL, 0);
             }
-        } while (ret == WC_PENDING_E);
+        } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
         if (ret < 0)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
         TEST_SLEEP();
@@ -21195,7 +21244,7 @@ static wc_test_ret_t rsa_oaep_padding_test(RsaKey* key, WC_RNG* rng)
                 ret = wc_RsaPrivateDecrypt_ex(out, idx, plain, plainSz, key,
                   WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA512, WC_MGF1SHA512, NULL, 0);
             }
-        } while (ret == WC_PENDING_E);
+        } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
         if (ret < 0)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
 
@@ -21217,7 +21266,7 @@ static wc_test_ret_t rsa_oaep_padding_test(RsaKey* key, WC_RNG* rng)
             ret = wc_RsaPublicEncrypt_ex(in, inLen, out, outSz, key, rng,
                   WC_RSA_PKCSV15_PAD, WC_HASH_TYPE_NONE, 0, NULL, 0);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
     TEST_SLEEP();
@@ -21232,7 +21281,7 @@ static wc_test_ret_t rsa_oaep_padding_test(RsaKey* key, WC_RNG* rng)
             ret = wc_RsaPrivateDecrypt_ex(out, idx, plain, plainSz, key,
                   WC_RSA_PKCSV15_PAD, WC_HASH_TYPE_NONE, 0, NULL, 0);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
 
@@ -21461,7 +21510,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_test(void)
         if (ret >= 0) {
             ret = wc_RsaPublicEncrypt(in, inLen, out, outSz, key, &rng);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
     TEST_SLEEP();
@@ -21484,7 +21533,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_test(void)
         if (ret >= 0) {
             ret = wc_RsaPrivateDecrypt(out, idx, plain, plainSz, key);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
 
@@ -21500,7 +21549,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_test(void)
         if (ret >= 0) {
             ret = wc_RsaPrivateDecryptInline(out, idx, &res, key);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
     if (ret != (int)inLen) {
@@ -21518,7 +21567,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_test(void)
         if (ret >= 0) {
             ret = wc_RsaSSL_Sign(in, inLen, out, outSz, key, &rng);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
     TEST_SLEEP();
@@ -21599,7 +21648,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_test(void)
             }
 #endif
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
 
@@ -21843,7 +21892,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_test(void)
                 ret = wc_SignCert(req->bodySz, req->sigType, der, FOURK_BUF,
                           key, NULL, &rng);
             }
-        } while (ret == WC_PENDING_E);
+        } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
         if (ret < 0)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_rsa);
         derSz = (int)ret;
@@ -22052,22 +22101,22 @@ static wc_test_ret_t dh_fips_generate_test(WC_RNG *rng)
 
     /* Parameter Validation testing. */
     ret = wc_DhGenerateKeyPair(NULL, rng, priv, &privSz, pub, &pubSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_gen_test);
     ret = wc_DhGenerateKeyPair(key, NULL, priv, &privSz, pub, &pubSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_gen_test);
     ret = wc_DhGenerateKeyPair(key, rng, NULL, &privSz, pub, &pubSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_gen_test);
     ret = wc_DhGenerateKeyPair(key, rng, priv, NULL, pub, &pubSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_gen_test);
     ret = wc_DhGenerateKeyPair(key, rng, priv, &privSz, NULL, &pubSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_gen_test);
     ret = wc_DhGenerateKeyPair(key, rng, priv, &privSz, pub, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_gen_test);
 
     ret = wc_InitDhKey_ex(key, HEAP_HINT, devId);
@@ -22121,7 +22170,7 @@ static wc_test_ret_t dh_fips_generate_test(WC_RNG *rng)
     /* Taint the public key so the check fails. */
     pub[0]++;
     ret = wc_DhCheckKeyPair(key, pub, pubSz, priv, privSz);
-    if (ret != MP_CMP_E) {
+    if (ret != WC_NO_ERR_TRACE(MP_CMP_E)) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_gen_test);
     }
 
@@ -22199,28 +22248,28 @@ static wc_test_ret_t dh_generate_test(WC_RNG *rng)
 
     /* Parameter Validation testing. */
     ret = wc_InitDhKey_ex(NULL, HEAP_HINT, devId);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     wc_FreeDhKey(NULL);
 
     ret = wc_DhSetKey(NULL, p, sizeof(p), g, sizeof(g));
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_gen_test);
     }
     ret = wc_DhSetKey(smallKey, NULL, sizeof(p), g, sizeof(g));
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_gen_test);
     }
     ret = wc_DhSetKey(smallKey, p, 0, g, sizeof(g));
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_gen_test);
     }
     ret = wc_DhSetKey(smallKey, p, sizeof(p), NULL, sizeof(g));
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_gen_test);
     }
     ret = wc_DhSetKey(smallKey, p, sizeof(p), g, 0);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_gen_test);
     }
     ret = wc_DhSetKey(smallKey, p, sizeof(p), g, sizeof(g));
@@ -22338,7 +22387,7 @@ static wc_test_ret_t dh_test_check_pubvalue(void)
     for (i = 0; i < sizeof(dh_pubval_fail) / sizeof(*dh_pubval_fail); i++) {
         ret = wc_DhCheckPubValue(prime, sizeof(prime), dh_pubval_fail[i].data,
                                                          dh_pubval_fail[i].len);
-        if (ret != MP_VAL)
+        if (ret != WC_NO_ERR_TRACE(MP_VAL))
             return WC_TEST_RET_ENC_I(i);
     }
 
@@ -22493,7 +22542,9 @@ static wc_test_ret_t dh_ffdhe_test(WC_RNG *rng, int name)
 #if defined(WOLFSSL_ASYNC_CRYPT)
     ret = wc_AsyncWait(ret, &key->asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
-    if (ret != MP_VAL && ret != MP_EXPTMOD_E) {
+    if (ret != WC_NO_ERR_TRACE(MP_VAL) &&
+        ret != WC_NO_ERR_TRACE(MP_EXPTMOD_E))
+    {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     }
 
@@ -22501,14 +22552,20 @@ static wc_test_ret_t dh_ffdhe_test(WC_RNG *rng, int name)
 #if defined(WOLFSSL_ASYNC_CRYPT)
     ret = wc_AsyncWait(ret, &key->asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
-    if (ret != MP_VAL && ret != MP_EXPTMOD_E && ret != ASYNC_OP_E) {
+    if (ret != WC_NO_ERR_TRACE(MP_VAL) &&
+        ret != WC_NO_ERR_TRACE(MP_EXPTMOD_E) &&
+        ret != WC_NO_ERR_TRACE(ASYNC_OP_E))
+    {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     }
 
 #ifndef HAVE_SELFTEST
     ret = wc_DhCheckKeyPair(key, pub, pubSz, priv, privSz);
-    if (ret != MP_VAL && ret != MP_EXPTMOD_E && ret != MP_CMP_E &&
-            ret != ASYNC_OP_E) {
+    if (ret != WC_NO_ERR_TRACE(MP_VAL) &&
+        ret != WC_NO_ERR_TRACE(MP_EXPTMOD_E) &&
+        ret != WC_NO_ERR_TRACE(MP_CMP_E) &&
+        ret != WC_NO_ERR_TRACE(ASYNC_OP_E))
+    {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     }
 #endif
@@ -22742,7 +22799,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t dh_test(void)
 
 #if defined(WOLFSSL_KEY_GEN) && !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
     ret = wc_DhCheckPrivKey(NULL, NULL, 0);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
     ret = wc_DhCheckPrivKey(key, priv, privSz);
@@ -22750,12 +22807,12 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t dh_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
     ret = wc_DhExportParamsRaw(NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     {
         word32 pSz, qSz, gSz;
         ret = wc_DhExportParamsRaw(key, NULL, &pSz, NULL, &qSz, NULL, &gSz);
-        if (ret != LENGTH_ONLY_E)
+        if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     }
 #endif
@@ -25487,7 +25544,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
         if (wolfSSL_EVP_DecryptFinal_ex(NULL, NULL, NULL) != WOLFSSL_FAILURE)
             return WC_TEST_RET_ENC_NC;
 
-        if (EVP_CIPHER_CTX_block_size(NULL) != BAD_FUNC_ARG)
+        if (EVP_CIPHER_CTX_block_size(NULL) != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
             return WC_TEST_RET_ENC_NC;
 
         if (wolfSSL_EVP_CIPHER_CTX_cleanup(en) != WOLFSSL_SUCCESS)
@@ -25498,7 +25555,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
         if (EVP_CIPHER_CTX_block_size(en) != en->block_size)
             return WC_TEST_RET_ENC_NC;
 
-        if (EVP_CIPHER_block_size(NULL) != BAD_FUNC_ARG)
+        if (EVP_CIPHER_block_size(NULL) != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
             return WC_TEST_RET_ENC_NC;
 
         if (EVP_CIPHER_block_size(EVP_aes_128_cbc()) != AES_BLOCK_SIZE)
@@ -25515,8 +25572,11 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
         if (en->flags != 42)
             return WC_TEST_RET_ENC_NC;
 
-        if (EVP_CIPHER_CTX_set_padding(NULL, 0) != BAD_FUNC_ARG)
+        if (EVP_CIPHER_CTX_set_padding(NULL, 0) !=
+            WC_NO_ERR_TRACE(BAD_FUNC_ARG))
+        {
             return WC_TEST_RET_ENC_NC;
+        }
         if (EVP_CIPHER_CTX_set_padding(en, 0) != WOLFSSL_SUCCESS)
             return WC_TEST_RET_ENC_NC;
         if (EVP_CIPHER_CTX_set_padding(en, 1) != WOLFSSL_SUCCESS)
@@ -26334,7 +26394,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t scrypt_test(void)
     /* Test case with parallel overflowing */
     ret = wc_scrypt(derived, (byte*)"password", 16, (byte*)"NaCl", 16, 2, 4, 8388608,
                     sizeof(verify1));
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     /* Don't run these test on embedded, since they use large mallocs */
@@ -26559,7 +26619,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t pkcs12_test(void)
     }
 
     ret = wc_i2d_PKCS12(pkcs12, NULL, &pkcs12derSz);
-    if (ret != LENGTH_ONLY_E) {
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
         if (ret == 0)
             ret = WC_TEST_RET_ENC_NC;
         else
@@ -26994,7 +27054,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t tls12_kdf_test(void)
             (const byte*)label, (word32)XSTRLEN(label), seed, seedSz,
             1, sha256_mac, NULL, INVALID_DEVID);
     if (ret != 0) {
-        if (ret == FIPS_PRIVATE_KEY_LOCKED_E) {
+        if (ret == WC_NO_ERR_TRACE(FIPS_PRIVATE_KEY_LOCKED_E)) {
             printf("    wc_PRF_TLSv12: Private key locked.\n");
         }
         return WC_TEST_RET_ENC_NC;
@@ -27579,7 +27639,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t tls13_kdf_test(void)
         XMEMSET(zeroes, 0, sizeof zeroes);
 
         hashAlgSz = wc_HashGetDigestSize(tv->hashAlg);
-        if (hashAlgSz == BAD_FUNC_ARG) break;
+        if (hashAlgSz == WC_NO_ERR_TRACE(BAD_FUNC_ARG)) break;
         ret = wc_Hash(tv->hashAlg, NULL, 0, hashZero, (word32)hashAlgSz);
         if (ret != 0) break;
 
@@ -27938,7 +27998,7 @@ static wc_test_ret_t hpke_test_single(Hpke* hpke)
     /* Negative test case with NULL argument */
     if (ret == 0) {
         ret = wc_HpkeGenerateKeyPair(NULL, &receiverKey, rng);
-        if (ret != BAD_FUNC_ARG)
+        if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
             ret = WC_TEST_RET_ENC_EC(ret);
         else
             ret = 0;
@@ -27946,7 +28006,7 @@ static wc_test_ret_t hpke_test_single(Hpke* hpke)
 
     if (ret == 0) {
         ret = wc_HpkeGenerateKeyPair(hpke, NULL, rng);
-        if (ret != BAD_FUNC_ARG)
+        if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
             ret = WC_TEST_RET_ENC_EC(ret);
         else
             ret = 0;
@@ -27954,7 +28014,7 @@ static wc_test_ret_t hpke_test_single(Hpke* hpke)
 
     if (ret == 0) {
         ret = wc_HpkeGenerateKeyPair(hpke, &receiverKey, NULL);
-        if (ret != BAD_FUNC_ARG)
+        if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
             ret = WC_TEST_RET_ENC_EC(ret);
         else
             ret = 0;
@@ -28050,13 +28110,13 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hpke_test(void)
         HPKE_AES_256_GCM, NULL);
 
     /* HPKE does not support X448 yet, so expect failure */
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = hpke_test_single(hpke);
 
     /* HPKE does not support X448 yet, so expect failure */
-    if (WC_TEST_RET_DEC_EC(ret) != BAD_FUNC_ARG)
+    if (WC_TEST_RET_DEC_EC(ret) != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return ret;
     ret = 0; /* reset error code */
 #endif
@@ -28440,78 +28500,78 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t srtpkdf_test(void)
     ret = wc_SRTP_KDF(tv[i].key, 33, tv[i].salt, tv[i].saltSz,
         tv[i].kdfIdx, tv[i].index, keyE, tv[i].keSz, keyA, tv[i].kaSz,
         keyS, tv[i].ksSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SRTCP_KDF(tv[i].key, 33, tv[i].salt, tv[i].saltSz,
         tv[i].kdfIdx, tv[i].index_c, keyE, tv[i].keSz, keyA, tv[i].kaSz,
         keyS, tv[i].ksSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_SRTP_KDF(tv[i].key, 15, tv[i].salt, tv[i].saltSz,
         tv[i].kdfIdx, tv[i].index, keyE, tv[i].keSz, keyA, tv[i].kaSz,
         keyS, tv[i].ksSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SRTCP_KDF(tv[i].key, 15, tv[i].salt, tv[i].saltSz,
         tv[i].kdfIdx, tv[i].index_c, keyE, tv[i].keSz, keyA, tv[i].kaSz,
         keyS, tv[i].ksSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_SRTP_KDF(tv[i].key, tv[i].keySz, tv[i].salt, 15,
         tv[i].kdfIdx, tv[i].index, keyE, tv[i].keSz, keyA, tv[i].kaSz,
         keyS, tv[i].ksSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SRTCP_KDF(tv[i].key, tv[i].keySz, tv[i].salt, 15,
         tv[i].kdfIdx, tv[i].index_c, keyE, tv[i].keSz, keyA, tv[i].kaSz,
         keyS, tv[i].ksSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_SRTP_KDF(NULL, tv[i].keySz, tv[i].salt, tv[i].saltSz,
         tv[i].kdfIdx, tv[i].index, keyE, tv[i].keSz, keyA, tv[i].kaSz,
         keyS, tv[i].ksSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SRTCP_KDF(NULL, tv[i].keySz, tv[i].salt, tv[i].saltSz,
         tv[i].kdfIdx, tv[i].index_c, keyE, tv[i].keSz, keyA, tv[i].kaSz,
         keyS, tv[i].ksSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_SRTP_KDF(tv[i].key, tv[i].keySz, NULL, tv[i].saltSz,
             tv[i].kdfIdx, tv[i].index, keyE, tv[i].keSz, keyA, tv[i].kaSz,
             keyS, tv[i].ksSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SRTCP_KDF(tv[i].key, tv[i].keySz, NULL, tv[i].saltSz,
         tv[i].kdfIdx, tv[i].index_c, keyE, tv[i].keSz, keyA, tv[i].kaSz,
         keyS, tv[i].ksSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_SRTP_KDF(tv[i].key, tv[i].keySz, tv[i].salt, tv[i].saltSz,
         25, tv[i].index, keyE, tv[i].keSz, keyA, tv[i].kaSz,
         keyS, tv[i].ksSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SRTCP_KDF(tv[i].key, tv[i].keySz, tv[i].salt, tv[i].saltSz,
         25, tv[i].index_c, keyE, tv[i].keSz, keyA, tv[i].kaSz,
         keyS, tv[i].ksSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_SRTP_KDF(tv[i].key, tv[i].keySz, tv[i].salt, tv[i].saltSz,
         -2, tv[i].index, keyE, tv[i].keSz, keyA, tv[i].kaSz,
         keyS, tv[i].ksSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SRTCP_KDF(tv[i].key, tv[i].keySz, tv[i].salt, tv[i].saltSz,
         -2, tv[i].index_c, keyE, tv[i].keSz, keyA, tv[i].kaSz,
         keyS, tv[i].ksSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_SRTP_KDF(tv[i].key, tv[i].keySz, tv[i].salt, tv[i].saltSz,
@@ -28692,12 +28752,12 @@ static wc_test_ret_t ecc_test_vector_item(const eccVector* vector)
 
     ret = wc_ecc_init_ex(userA, HEAP_HINT, devId);
     if (ret != 0)
-        goto done;
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
     ret = wc_ecc_import_raw(userA, vector->Qx, vector->Qy,
                                                   vector->d, vector->curveName);
     if (ret != 0)
-        goto done;
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
 #if !defined(NO_ASN)
     XMEMSET(sig, 0, ECC_SIG_SIZE);
@@ -28712,7 +28772,7 @@ static wc_test_ret_t ecc_test_vector_item(const eccVector* vector)
     ret = wc_ecc_rs_raw_to_sig(vector->r, vector->rSz, vector->s, vector->sSz,
                                                              sigRaw, &sigRawSz);
     if (ret != 0)
-        goto done;
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     if (sigSz != sigRawSz || XMEMCMP(sig, sigRaw, sigSz) != 0) {
         ret = WC_TEST_RET_ENC_NC;
         goto done;
@@ -28720,7 +28780,7 @@ static wc_test_ret_t ecc_test_vector_item(const eccVector* vector)
 
     ret = wc_ecc_sig_to_rs(sig, sigSz, r, &rSz, s, &sSz);
     if (ret != 0)
-        goto done;
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     if (rSz != vector->rSz || XMEMCMP(r, vector->r, rSz) != 0 ||
         sSz != vector->sSz || XMEMCMP(s, vector->s, sSz) != 0) {
         ret = WC_TEST_RET_ENC_NC;
@@ -28746,9 +28806,9 @@ static wc_test_ret_t ecc_test_vector_item(const eccVector* vector)
         if (ret == 0)
             ret = wc_ecc_verify_hash(sig, sigSz, (byte*)vector->msg,
                                                vector->msgLen, &verify, userA);
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret != 0)
-        goto done;
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     TEST_SLEEP();
 
     if (verify != 1)
@@ -29000,7 +29060,9 @@ static wc_test_ret_t ecc_test_vector(int keySize)
         break;
 #endif /* HAVE_ECC521 */
     default:
-        return NOT_COMPILED_IN; /* Invalid key size / Not supported */
+        return WC_TEST_RET_ENC_EC(NOT_COMPILED_IN); /* Invalid key size /
+                                                     * Not supported
+                                                     */
     }; /* Switch */
 
     ret = ecc_test_vector_item(&vec);
@@ -29031,9 +29093,8 @@ static wc_test_ret_t ecdsa_test_deterministic_k_sig(ecc_key *key,
     ret = wc_Hash(hashType,
         (byte*)msg, (word32)XSTRLEN(msg),
         hash, sizeof(hash));
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
     /* Sign test */
     sigSz = sizeof(sig);
@@ -29044,10 +29105,9 @@ static wc_test_ret_t ecdsa_test_deterministic_k_sig(ecc_key *key,
         if (ret == 0)
             ret = wc_ecc_sign_hash(hash, wc_HashGetDigestSize(hashType),
                 sig, &sigSz, rng, key);
-    } while (ret == WC_PENDING_E);
-    if (ret != 0) {
-        goto done;
-    }
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     TEST_SLEEP();
 
     /* Compare test vector */
@@ -29069,10 +29129,9 @@ static wc_test_ret_t ecdsa_test_deterministic_k_sig(ecc_key *key,
         if (ret == 0)
             ret = wc_ecc_verify_hash(sig, sigSz,
                 hash, wc_HashGetDigestSize(hashType), &verify, key);
-    } while (ret == WC_PENDING_E);
-    if (ret != 0) {
-        goto done;
-    }
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     if (verify != 1) {
         ERROR_OUT(WC_TEST_RET_ENC_NC, done);
     }
@@ -29152,45 +29211,39 @@ static wc_test_ret_t ecc_test_deterministic_k(WC_RNG* rng)
 #endif
 
     ret = wc_ecc_init_ex(key, HEAP_HINT, devId);
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     key_inited = 1;
     ret = wc_ecc_import_raw(key, QIUTx, QIUTy, dIUT, "SECP256R1");
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
     ret = wc_ecc_set_deterministic(key, 1);
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
 #ifndef NO_SHA256
     /* Test for SHA2-256 */
     ret = ecdsa_test_deterministic_k_sig(key, WC_HASH_TYPE_SHA256, msg, rng,
         expSig256, sizeof(expSig256));
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 #endif /* !NO_SHA256 */
 
 #ifdef WOLFSSL_SHA384
     /* Test for SHA2-384 */
     ret = ecdsa_test_deterministic_k_sig(key, WC_HASH_TYPE_SHA384, msg, rng,
         expSig384, sizeof(expSig384));
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 #endif /* WOLFSSL_SHA384 */
 
 #ifdef WOLFSSL_SHA512
     /* Test for SHA2-512 */
     ret = ecdsa_test_deterministic_k_sig(key, WC_HASH_TYPE_SHA512, msg, rng,
         expSig512, sizeof(expSig512));
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 #endif /* WOLFSSL_SHA512 */
 
 done:
@@ -29218,18 +29271,16 @@ static wc_test_ret_t ecdsa_test_deterministic_k_rs(ecc_key *key,
     ret = wc_Hash(hashType,
         (byte*)msg, (word32)XSTRLEN(msg),
         hash, sizeof(hash));
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
     ret = wc_ecc_sign_hash_ex(hash, wc_HashGetDigestSize(hashType), rng, key,
         r, s);
 #if defined(WOLFSSL_ASYNC_CRYPT)
     ret = wc_AsyncWait(ret, &key->asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     TEST_SLEEP();
 
     if (mp_cmp(r, expR) != MP_EQ && mp_cmp(s, expS) != MP_EQ) {
@@ -29243,9 +29294,8 @@ static wc_test_ret_t ecdsa_test_deterministic_k_rs(ecc_key *key,
 #if defined(WOLFSSL_ASYNC_CRYPT)
     ret = wc_AsyncWait(ret, &key->asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     if (verify != 1) {
         ERROR_OUT(WC_TEST_RET_ENC_NC, done);
     }
@@ -29316,31 +29366,26 @@ static wc_test_ret_t ecc384_test_deterministic_k(WC_RNG* rng)
         (expR == NULL) ||
         (expS == NULL))
     {
-        ret = MEMORY_E;
-        goto done;
+        ERROR_OUT(WC_TEST_RET_ENC_EC(MEMORY_E), done);
     }
 #endif
 
     ret = mp_init_multi(r, s, expR, expS, NULL, NULL);
-    if (ret != MP_OKAY) {
-        goto done;
-    }
+    if (ret != MP_OKAY)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     tmp_mp_ints_inited = 1;
     ret = wc_ecc_init_ex(key, HEAP_HINT, devId);
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     key_inited = 1;
 
     ret = wc_ecc_import_raw(key, QIUTx, QIUTy, dIUT, "SECP384R1");
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
     ret = wc_ecc_set_deterministic(key, 1);
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
 #ifndef NO_SHA256
     /* Test for SHA2-256 */
@@ -29348,9 +29393,8 @@ static wc_test_ret_t ecc384_test_deterministic_k(WC_RNG* rng)
     mp_read_radix(expS, expSstr256, MP_RADIX_HEX);
     ret = ecdsa_test_deterministic_k_rs(key, WC_HASH_TYPE_SHA256, msg, rng,
         r, s, expR, expS);
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 #endif /* NO_SHA256 */
 
 #ifdef WOLFSSL_SHA384
@@ -29359,9 +29403,8 @@ static wc_test_ret_t ecc384_test_deterministic_k(WC_RNG* rng)
     mp_read_radix(expS, expSstr384, MP_RADIX_HEX);
     ret = ecdsa_test_deterministic_k_rs(key, WC_HASH_TYPE_SHA384, msg, rng,
         r, s, expR, expS);
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 #endif /* WOLFSSL_SHA384 */
 
 #ifdef WOLFSSL_SHA512
@@ -29370,9 +29413,8 @@ static wc_test_ret_t ecc384_test_deterministic_k(WC_RNG* rng)
     mp_read_radix(expS, expSstr512, MP_RADIX_HEX);
     ret = ecdsa_test_deterministic_k_rs(key, WC_HASH_TYPE_SHA512, msg, rng,
         r, s, expR, expS);
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 #endif /* WOLFSSL_SHA512 */
 
 done:
@@ -29467,31 +29509,27 @@ static wc_test_ret_t ecc521_test_deterministic_k(WC_RNG* rng)
         (expR == NULL) ||
         (expS == NULL))
     {
-        ret = MEMORY_E;
+        ret = WC_TEST_RET_ENC_EC(MEMORY_E);
         goto done;
     }
 #endif
 
     ret = mp_init_multi(r, s, expR, expS, NULL, NULL);
-    if (ret != MP_OKAY) {
-        goto done;
-    }
+    if (ret != MP_OKAY)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     tmp_mp_ints_inited = 1;
     ret = wc_ecc_init_ex(key, HEAP_HINT, devId);
-    if (ret != 0) {
-        return WC_TEST_RET_ENC_EC(ret);
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     key_inited = 1;
 
     ret = wc_ecc_import_raw(key, QIUTx, QIUTy, dIUT, "SECP521R1");
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
     ret = wc_ecc_set_deterministic(key, 1);
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
 #ifndef NO_SHA256
     /* Test for SHA2-256 */
@@ -29499,9 +29537,8 @@ static wc_test_ret_t ecc521_test_deterministic_k(WC_RNG* rng)
     mp_read_radix(expS, expSstr256, MP_RADIX_HEX);
     ret = ecdsa_test_deterministic_k_rs(key, WC_HASH_TYPE_SHA256, msg, rng,
         r, s, expR, expS);
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 #endif /* NO_SHA256 */
 
 #ifdef WOLFSSL_SHA384
@@ -29510,9 +29547,8 @@ static wc_test_ret_t ecc521_test_deterministic_k(WC_RNG* rng)
     mp_read_radix(expS, expSstr384, MP_RADIX_HEX);
     ret = ecdsa_test_deterministic_k_rs(key, WC_HASH_TYPE_SHA384, msg, rng,
         r, s, expR, expS);
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 #endif /* WOLFSSL_SHA384 */
 
 #ifdef WOLFSSL_SHA512
@@ -29521,9 +29557,8 @@ static wc_test_ret_t ecc521_test_deterministic_k(WC_RNG* rng)
     mp_read_radix(expS, expSstr512, MP_RADIX_HEX);
     ret = ecdsa_test_deterministic_k_rs(key, WC_HASH_TYPE_SHA512, msg, rng,
         r, s, expR, expS);
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 #endif /* WOLFSSL_SHA512 */
 
 done:
@@ -29588,24 +29623,21 @@ static wc_test_ret_t ecc_test_sign_vectors(WC_RNG* rng)
 #endif
 
     ret = wc_ecc_init_ex(key, HEAP_HINT, devId);
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     key_inited = 1;
 
     ret = wc_ecc_import_raw(key, QIUTx, QIUTy, dIUT, "SECP256R1");
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 #if (!defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) \
     && (HAVE_FIPS_VERSION > 2)))
     wc_ecc_set_flags(key, WC_ECC_FLAG_DEC_SIGN);
 #endif
 
     ret = wc_ecc_sign_set_k(k, sizeof(k), key);
-    if (ret != 0) {
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
     sigSz = sizeof(sig);
     do {
@@ -29614,10 +29646,9 @@ static wc_test_ret_t ecc_test_sign_vectors(WC_RNG* rng)
     #endif
         if (ret == 0)
             ret = wc_ecc_sign_hash(hash, sizeof(hash), sig, &sigSz, rng, key);
-    } while (ret == WC_PENDING_E);
-    if (ret != 0) {
-        goto done;
-    }
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     TEST_SLEEP();
 
     if (sigSz != sizeof(expSig)) {
@@ -29636,10 +29667,9 @@ static wc_test_ret_t ecc_test_sign_vectors(WC_RNG* rng)
     #endif
         if (ret == 0)
             ret = wc_ecc_sign_hash(hash, sizeof(hash), sig, &sigSz, rng, key);
-    } while (ret == WC_PENDING_E);
-    if (ret != 0) {
-        goto done;
-    }
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     TEST_SLEEP();
 
 done:
@@ -29676,7 +29706,7 @@ static wc_test_ret_t ecc_test_cdh_vectors(WC_RNG* rng)
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     if ((pub_key == NULL) ||
         (priv_key == NULL)) {
-        ret = MEMORY_E;
+        ret = WC_TEST_RET_ENC_EC(MEMORY_E);
         goto done;
     }
 #endif
@@ -29687,25 +29717,25 @@ static wc_test_ret_t ecc_test_cdh_vectors(WC_RNG* rng)
     /* setup private and public keys */
     ret = wc_ecc_init_ex(pub_key, HEAP_HINT, devId);
     if (ret != 0)
-        goto done;
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     ret = wc_ecc_init_ex(priv_key, HEAP_HINT, devId);
     if (ret != 0)
-        goto done;
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     wc_ecc_set_flags(pub_key, WC_ECC_FLAG_COFACTOR);
     wc_ecc_set_flags(priv_key, WC_ECC_FLAG_COFACTOR);
     ret = wc_ecc_import_raw(pub_key, QCAVSx, QCAVSy, NULL, "SECP256R1");
     if (ret != 0)
-        goto done;
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     ret = wc_ecc_import_raw(priv_key, QIUTx, QIUTy, dIUT, "SECP256R1");
     if (ret != 0)
-        goto done;
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
 #if defined(ECC_TIMING_RESISTANT) && (!defined(HAVE_FIPS) || \
     (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION != 2))) && \
     !defined(HAVE_SELFTEST)
     ret = wc_ecc_set_rng(priv_key, rng);
     if (ret != 0)
-        goto done;
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 #else
     (void)rng;
 #endif
@@ -29718,17 +29748,16 @@ static wc_test_ret_t ecc_test_cdh_vectors(WC_RNG* rng)
     #endif
         if (ret == 0)
             ret = wc_ecc_shared_secret(priv_key, pub_key, sharedA, &x);
-    } while (ret == WC_PENDING_E);
-    if (ret != 0) {
-        goto done;
-    }
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     TEST_SLEEP();
 
     /* read in expected Z */
     z = sizeof(sharedB);
     ret = Base16_Decode((const byte*)ZIUT, (word32)XSTRLEN(ZIUT), sharedB, &z);
     if (ret != 0)
-        goto done;
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
     /* compare results */
     if (x != z || XMEMCMP(sharedA, sharedB, x)) {
@@ -29932,7 +29961,7 @@ static wc_test_ret_t ecc_test_make_pub(WC_RNG* rng)
             ret = wc_ecc_sign_hash(msg, (word32)XSTRLEN((const char* )msg), tmp,
                 &tmpSz, rng, key);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     TEST_SLEEP();
@@ -29948,7 +29977,7 @@ static wc_test_ret_t ecc_test_make_pub(WC_RNG* rng)
             ret = wc_ecc_verify_hash(tmp, tmpSz, msg,
                 (word32)XSTRLEN((const char*)msg), &verify, key);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
@@ -30020,7 +30049,7 @@ static wc_test_ret_t ecc_test_make_pub(WC_RNG* rng)
         if (ret == 0) {
             ret = wc_ecc_shared_secret(key, pub, exportBuf, &x);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     wc_ecc_free(pub);
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
@@ -30353,12 +30382,12 @@ static wc_test_ret_t ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerif
     ret = wc_AsyncWait(ret, &userA->asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
 #ifdef WOLF_CRYPTO_CB_ONLY_ECC
-    if (ret == NO_VALID_DEVID) {
+    if (ret == WC_NO_ERR_TRACE(NO_VALID_DEVID)) {
         ret = 0;
         goto done; /* no software case */
     }
 #endif
-    if (ret == ECC_CURVE_OID_E)
+    if (ret == WC_NO_ERR_TRACE(ECC_CURVE_OID_E))
         goto done; /* catch case, where curve is not supported */
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
@@ -30410,7 +30439,7 @@ static wc_test_ret_t ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerif
     #endif
         if (ret == 0)
             ret = wc_ecc_shared_secret(userA, userB, sharedA, &x);
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     TEST_SLEEP();
@@ -30422,7 +30451,7 @@ static wc_test_ret_t ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerif
     #endif
         if (ret == 0)
             ret = wc_ecc_shared_secret(userB, userA, sharedB, &y);
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
@@ -30445,7 +30474,7 @@ static wc_test_ret_t ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerif
     #endif
         if (ret == 0)
             ret = wc_ecc_shared_secret(userA, userB, sharedA, &x);
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     TEST_SLEEP();
@@ -30457,7 +30486,7 @@ static wc_test_ret_t ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerif
     #endif
         if (ret == 0)
             ret = wc_ecc_shared_secret(userB, userA, sharedB, &y);
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
@@ -30502,7 +30531,7 @@ static wc_test_ret_t ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerif
     #endif
         if (ret == 0)
             ret = wc_ecc_shared_secret(userB, pubKey, sharedB, &y);
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
@@ -30541,7 +30570,7 @@ static wc_test_ret_t ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerif
         #endif
             if (ret == 0)
                 ret = wc_ecc_shared_secret(userB, pubKey, sharedB, &y);
-        } while (ret == WC_PENDING_E);
+        } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
         if (ret != 0)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
@@ -30579,7 +30608,7 @@ static wc_test_ret_t ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerif
         if (ret == 0)
             ret = wc_ecc_sign_hash(digest, ECC_DIGEST_SIZE, sig, &x, rng,
                                                                         userA);
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     TEST_SLEEP();
@@ -30594,7 +30623,7 @@ static wc_test_ret_t ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerif
             if (ret == 0)
                 ret = wc_ecc_verify_hash(sig, x, digest, ECC_DIGEST_SIZE,
                                                                &verify, userA);
-        } while (ret == WC_PENDING_E);
+        } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
         if (ret != 0)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
         if (verify != 1)
@@ -30616,7 +30645,7 @@ static wc_test_ret_t ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerif
     #endif
         if (ret == 0)
             ret = wc_ecc_sign_hash(digest, ECC_DIGEST_SIZE, sig, &x, rng, userA);
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     TEST_SLEEP();
@@ -30630,7 +30659,7 @@ static wc_test_ret_t ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerif
         #endif
             if (ret == 0)
                 ret = wc_ecc_verify_hash(sig, x, digest, ECC_DIGEST_SIZE, &verify, userA);
-        } while (ret == WC_PENDING_E);
+        } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
         if (ret != 0)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
         if (verify != 1)
@@ -30712,7 +30741,7 @@ static wc_test_ret_t ecc_test_curve(WC_RNG* rng, int keySize, int curve_id)
     ret = ecc_test_curve_size(rng, keySize, ECC_TEST_VERIFY_COUNT, curve_id,
         NULL);
     if (ret < 0) {
-        if (ret == ECC_CURVE_OID_E) {
+        if (ret == WC_NO_ERR_TRACE(ECC_CURVE_OID_E)) {
             /* ignore error for curves not found */
             /* some curve sizes are only available with:
                 HAVE_ECC_SECPR2, HAVE_ECC_SECPR3, HAVE_ECC_BRAINPOOL
@@ -30745,7 +30774,7 @@ static wc_test_ret_t ecc_test_curve(WC_RNG* rng, int keySize, int curve_id)
     !defined(NO_ASN_CRYPT) && !defined(WC_NO_RNG)
     ret = ecc_test_key_decode(rng, keySize);
     if (ret < 0) {
-        if (ret == ECC_CURVE_OID_E) {
+        if (ret == WC_NO_ERR_TRACE(ECC_CURVE_OID_E)) {
             /* ignore error for curves not found */
         }
         else {
@@ -30758,7 +30787,7 @@ static wc_test_ret_t ecc_test_curve(WC_RNG* rng, int keySize, int curve_id)
 #if defined(HAVE_ECC_KEY_EXPORT) && !defined(NO_ASN_CRYPT) && !defined(WC_NO_RNG)
     ret = ecc_test_key_gen(rng, keySize);
     if (ret < 0) {
-        if (ret == ECC_CURVE_OID_E) {
+        if (ret == WC_NO_ERR_TRACE(ECC_CURVE_OID_E)) {
             /* ignore error for curves not found */
         }
         else {
@@ -30854,90 +30883,86 @@ static wc_test_ret_t ecc_point_test(void)
     /* Parameter Validation testing. */
     wc_ecc_del_point(NULL);
     ret = wc_ecc_import_point_der(NULL, sizeof(der), curve_idx, point);
-    if (ret != ECC_BAD_ARG_E) {
+    if (ret != WC_NO_ERR_TRACE(ECC_BAD_ARG_E)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     ret = wc_ecc_import_point_der(der, sizeof(der), ECC_CURVE_INVALID, point);
-    if (ret != ECC_BAD_ARG_E) {
+    if (ret != WC_NO_ERR_TRACE(ECC_BAD_ARG_E)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     ret = wc_ecc_import_point_der(der, sizeof(der), curve_idx, NULL);
-    if (ret != ECC_BAD_ARG_E) {
+    if (ret != WC_NO_ERR_TRACE(ECC_BAD_ARG_E)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     ret = wc_ecc_export_point_der(-1, point, out, &outLen);
-    if (ret != ECC_BAD_ARG_E) {
+    if (ret != WC_NO_ERR_TRACE(ECC_BAD_ARG_E)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     ret = wc_ecc_export_point_der(curve_idx, NULL, out, &outLen);
-    if (ret != ECC_BAD_ARG_E) {
+    if (ret != WC_NO_ERR_TRACE(ECC_BAD_ARG_E)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     ret = wc_ecc_export_point_der(curve_idx, point, NULL, &outLen);
-    if (ret != LENGTH_ONLY_E || outLen != sizeof(out)) {
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E) || outLen != sizeof(out)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     ret = wc_ecc_export_point_der(curve_idx, point, out, NULL);
-    if (ret != ECC_BAD_ARG_E) {
+    if (ret != WC_NO_ERR_TRACE(ECC_BAD_ARG_E)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     outLen = 0;
     ret = wc_ecc_export_point_der(curve_idx, point, out, &outLen);
-    if (ret != BUFFER_E) {
+    if (ret != WC_NO_ERR_TRACE(BUFFER_E)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     ret = wc_ecc_copy_point(NULL, NULL);
-    if (ret != ECC_BAD_ARG_E) {
+    if (ret != WC_NO_ERR_TRACE(ECC_BAD_ARG_E)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     ret = wc_ecc_copy_point(NULL, point2);
-    if (ret != ECC_BAD_ARG_E) {
+    if (ret != WC_NO_ERR_TRACE(ECC_BAD_ARG_E)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     ret = wc_ecc_copy_point(point, NULL);
-    if (ret != ECC_BAD_ARG_E) {
+    if (ret != WC_NO_ERR_TRACE(ECC_BAD_ARG_E)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     ret = wc_ecc_cmp_point(NULL, NULL);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     ret = wc_ecc_cmp_point(NULL, point2);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     ret = wc_ecc_cmp_point(point, NULL);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
 
     /* Use API. */
     ret = wc_ecc_import_point_der(der, sizeof(der), curve_idx, point);
-    if (ret != 0) {
-        ret = WC_TEST_RET_ENC_EC(ret);
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
     outLen = sizeof(out);
     ret = wc_ecc_export_point_der(curve_idx, point, out, &outLen);
-    if (ret != 0) {
-        ret = WC_TEST_RET_ENC_EC(ret);
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     if (outLen != sizeof(der)) {
         ret = WC_TEST_RET_ENC_NC;
         goto done;
@@ -30959,10 +30984,8 @@ static wc_test_ret_t ecc_point_test(void)
     }
 
     ret = wc_ecc_import_point_der(altDer, sizeof(altDer), curve_idx, point2);
-    if (ret != 0) {
-        ret = WC_TEST_RET_ENC_EC(ret);
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     ret = wc_ecc_cmp_point(point2, point);
     if (ret != MP_GT) {
         ret = WC_TEST_RET_ENC_EC(ret);
@@ -30972,16 +30995,12 @@ static wc_test_ret_t ecc_point_test(void)
 #if defined(HAVE_COMP_KEY) && (!defined(HAVE_FIPS) && !defined(HAVE_SELFTEST) || \
     (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION > 2)))
     ret = wc_ecc_import_point_der(derComp0, sizeof(derComp0)*2-1, curve_idx, point3);
-    if (ret != 0) {
-        ret = WC_TEST_RET_ENC_EC(ret);
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
     ret = wc_ecc_import_point_der_ex(derComp0, sizeof(derComp0), curve_idx, point4, 0);
-    if (ret != 0) {
-        ret = WC_TEST_RET_ENC_EC(ret);
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
     ret = wc_ecc_cmp_point(point3, point4);
     if (ret != MP_EQ) {
@@ -30990,16 +31009,12 @@ static wc_test_ret_t ecc_point_test(void)
     }
 
     ret = wc_ecc_import_point_der(derComp1, sizeof(derComp1)*2-1, curve_idx, point3);
-    if (ret != 0) {
-        ret = WC_TEST_RET_ENC_EC(ret);
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
     ret = wc_ecc_import_point_der_ex(derComp1, sizeof(derComp1), curve_idx, point4, 0);
-    if (ret != 0) {
-        ret = WC_TEST_RET_ENC_EC(ret);
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
     ret = wc_ecc_cmp_point(point3, point4);
     if (ret != MP_EQ) {
@@ -31104,31 +31119,23 @@ static wc_test_ret_t ecc_exp_imp_test(ecc_key* key)
 
     privLen = sizeof(priv);
     ret = wc_ecc_export_private_only(key, priv, &privLen);
-    if (ret != 0) {
-        ret = WC_TEST_RET_ENC_EC(ret);
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     pubLen = sizeof(pub);
     ret = wc_ecc_export_point_der(key->idx, &key->pubkey, pub, &pubLen);
-    if (ret != 0) {
-        ret = WC_TEST_RET_ENC_EC(ret);
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
     ret = wc_ecc_import_private_key(priv, privLen, pub, pubLen, keyImp);
-    if (ret != 0) {
-        ret = WC_TEST_RET_ENC_EC(ret);
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
     wc_ecc_free(keyImp);
     wc_ecc_init_ex(keyImp, HEAP_HINT, devId);
 
     ret = wc_ecc_import_raw_ex(keyImp, qx, qy, d, ECC_SECP256R1);
-    if (ret != 0) {
-        ret = WC_TEST_RET_ENC_EC(ret);
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
     wc_ecc_free(keyImp);
     wc_ecc_init_ex(keyImp, HEAP_HINT, devId);
@@ -31142,10 +31149,8 @@ static wc_test_ret_t ecc_exp_imp_test(ecc_key* key)
     /* test import private only */
     ret = wc_ecc_import_private_key_ex(priv, privLen, NULL, 0, keyImp,
                                        curve_id);
-    if (ret != 0) {
-        ret = WC_TEST_RET_ENC_EC(ret);
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
     wc_ecc_free(keyImp);
     wc_ecc_init_ex(keyImp, HEAP_HINT, devId);
@@ -31153,18 +31158,14 @@ static wc_test_ret_t ecc_exp_imp_test(ecc_key* key)
     /* test export public raw */
     pubLenX = pubLenY = 32;
     ret = wc_ecc_export_public_raw(key, pub, &pubLenX, &pub[32], &pubLenY);
-    if (ret != 0) {
-        ret = WC_TEST_RET_ENC_EC(ret);
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
 #ifndef HAVE_SELFTEST
     /* test import of public */
     ret = wc_ecc_import_unsigned(keyImp, pub, &pub[32], NULL, ECC_SECP256R1);
-    if (ret != 0) {
-        ret = WC_TEST_RET_ENC_EC(ret);
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 #endif
 
     wc_ecc_free(keyImp);
@@ -31174,18 +31175,14 @@ static wc_test_ret_t ecc_exp_imp_test(ecc_key* key)
     pubLenX = pubLenY = privLen = 32;
     ret = wc_ecc_export_private_raw(key, pub, &pubLenX, &pub[32], &pubLenY,
         priv, &privLen);
-    if (ret != 0) {
-        ret = WC_TEST_RET_ENC_EC(ret);
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
 #ifndef HAVE_SELFTEST
     /* test import of private and public */
     ret = wc_ecc_import_unsigned(keyImp, pub, &pub[32], priv, ECC_SECP256R1);
-    if (ret != 0) {
-        ret = WC_TEST_RET_ENC_EC(ret);
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 #endif
 
 done:
@@ -31247,10 +31244,8 @@ static wc_test_ret_t ecc_mulmod_test(ecc_key* key1)
     ret = wc_ecc_mulmod(wc_ecc_key_get_priv(key1), &key2->pubkey, &key3->pubkey,
                         wc_ecc_key_get_priv(key2), wc_ecc_key_get_priv(key3),
                         1);
-    if (ret != 0) {
-        ret = WC_TEST_RET_ENC_EC(ret);
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
 #ifdef WOLFSSL_PUBLIC_MP
     priv = wc_ecc_key_get_priv(key1);
@@ -31258,10 +31253,8 @@ static wc_test_ret_t ecc_mulmod_test(ecc_key* key1)
     ret = wc_ecc_mulmod(wc_ecc_key_get_priv(key1), &key2->pubkey, &key3->pubkey,
                         wc_ecc_key_get_priv(key2), wc_ecc_key_get_priv(key3),
                         1);
-    if (ret != 0) {
-        ret = WC_TEST_RET_ENC_EC(ret);
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     if (!wc_ecc_point_is_at_infinity(&key3->pubkey)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
@@ -31304,16 +31297,16 @@ static wc_test_ret_t ecc_ssh_test(ecc_key* key, WC_RNG* rng)
 
     /* Parameter Validation testing. */
     ret = wc_ecc_shared_secret_ssh(NULL, &key->pubkey, out, &outLen);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ecc_shared_secret_ssh(key, NULL, out, &outLen);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ecc_shared_secret_ssh(key, &key->pubkey, NULL, &outLen);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ecc_shared_secret_ssh(key, &key->pubkey, out, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
 #if defined(ECC_TIMING_RESISTANT) && (!defined(HAVE_FIPS) || \
@@ -31334,7 +31327,7 @@ static wc_test_ret_t ecc_ssh_test(ecc_key* key, WC_RNG* rng)
     #endif
         if (ret == 0)
             ret = wc_ecc_shared_secret_ssh(key, &key->pubkey, out, &outLen);
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret != 0)
         return WC_TEST_RET_ENC_EC(ret);
 
@@ -31366,15 +31359,13 @@ static wc_test_ret_t ecc_def_curve_test(WC_RNG *rng)
 
     /* Use API */
     ret = wc_ecc_set_flags(NULL, 0);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     ret = wc_ecc_set_flags(key, 0);
-    if (ret != 0) {
-        ret = WC_TEST_RET_ENC_EC(ret);
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 #ifndef WOLF_CRYPTO_CB_ONLY_ECC
 #ifndef WC_NO_RNG
     ret = wc_ecc_make_key(rng, ECC_KEYGEN_SIZE, key);
@@ -31523,22 +31514,22 @@ static wc_test_ret_t ecc_decode_test(void)
 
     inSz = sizeof(good);
     ret = wc_EccPublicKeyDecode(NULL, &inOutIdx, key, inSz);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     ret = wc_EccPublicKeyDecode(good, NULL, key, inSz);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     ret = wc_EccPublicKeyDecode(good, &inOutIdx, NULL, inSz);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     ret = wc_EccPublicKeyDecode(good, &inOutIdx, key, 0);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
@@ -31547,14 +31538,14 @@ static wc_test_ret_t ecc_decode_test(void)
     inOutIdx = 2;
     inSz = sizeof(good) - inOutIdx;
     ret = wc_EccPublicKeyDecode(good, &inOutIdx, key, inSz);
-    if (ret != ASN_PARSE_E) {
+    if (ret != WC_NO_ERR_TRACE(ASN_PARSE_E)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     inOutIdx = 4;
     inSz = sizeof(good) - inOutIdx;
     ret = wc_EccPublicKeyDecode(good, &inOutIdx, key, inSz);
-    if (ret != ASN_PARSE_E) {
+    if (ret != WC_NO_ERR_TRACE(ASN_PARSE_E)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
@@ -31562,56 +31553,66 @@ static wc_test_ret_t ecc_decode_test(void)
     inSz = sizeof(badNoObjId);
     inOutIdx = 0;
     ret = wc_EccPublicKeyDecode(badNoObjId, &inOutIdx, key, inSz);
-    if (ret != ASN_OBJECT_ID_E && ret != ASN_PARSE_E) {
+    if (ret != WC_NO_ERR_TRACE(ASN_OBJECT_ID_E) &&
+        ret != WC_NO_ERR_TRACE(ASN_PARSE_E))
+    {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     inSz = sizeof(badOneObjId);
     inOutIdx = 0;
     ret = wc_EccPublicKeyDecode(badOneObjId, &inOutIdx, key, inSz);
-    if (ret != ASN_OBJECT_ID_E && ret != ASN_PARSE_E) {
+    if (ret != WC_NO_ERR_TRACE(ASN_OBJECT_ID_E) &&
+        ret != WC_NO_ERR_TRACE(ASN_PARSE_E))
+    {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     inSz = sizeof(badObjId1Len);
     inOutIdx = 0;
     ret = wc_EccPublicKeyDecode(badObjId1Len, &inOutIdx, key, inSz);
-    if (ret != ASN_PARSE_E) {
+    if (ret != WC_NO_ERR_TRACE(ASN_PARSE_E)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     inSz = sizeof(badObj2d1Len);
     inOutIdx = 0;
     ret = wc_EccPublicKeyDecode(badObj2d1Len, &inOutIdx, key, inSz);
-    if (ret != ASN_PARSE_E) {
+    if (ret != WC_NO_ERR_TRACE(ASN_PARSE_E)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     inSz = sizeof(badNotBitStr);
     inOutIdx = 0;
     ret = wc_EccPublicKeyDecode(badNotBitStr, &inOutIdx, key, inSz);
-    if (ret != ASN_BITSTR_E && ret != ASN_PARSE_E) {
+    if (ret != WC_NO_ERR_TRACE(ASN_BITSTR_E) &&
+        ret != WC_NO_ERR_TRACE(ASN_PARSE_E))
+    {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     inSz = sizeof(badBitStrLen);
     inOutIdx = 0;
     ret = wc_EccPublicKeyDecode(badBitStrLen, &inOutIdx, key, inSz);
-    if (ret != ASN_PARSE_E) {
+    if (ret != WC_NO_ERR_TRACE(ASN_PARSE_E)) {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     inSz = sizeof(badNoBitStrZero);
     inOutIdx = 0;
     ret = wc_EccPublicKeyDecode(badNoBitStrZero, &inOutIdx, key, inSz);
-    if (ret != ASN_EXPECT_0_E && ret != ASN_PARSE_E) {
+    if (ret != WC_NO_ERR_TRACE(ASN_EXPECT_0_E) &&
+        ret != WC_NO_ERR_TRACE(ASN_PARSE_E))
+    {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
     inSz = sizeof(badPoint);
     inOutIdx = 0;
     ret = wc_EccPublicKeyDecode(badPoint, &inOutIdx, key, inSz);
-    if (ret != ASN_ECC_KEY_E && ret != ASN_PARSE_E) {
+    if (ret != WC_NO_ERR_TRACE(ASN_ECC_KEY_E) &&
+        ret != WC_NO_ERR_TRACE(ASN_PARSE_E))
+    {
         ret = WC_TEST_RET_ENC_EC(ret);
         goto done;
     }
@@ -31619,10 +31620,8 @@ static wc_test_ret_t ecc_decode_test(void)
     inSz = sizeof(good);
     inOutIdx = 0;
     ret = wc_EccPublicKeyDecode(good, &inOutIdx, key, inSz);
-    if (ret != 0) {
-        ret = WC_TEST_RET_ENC_EC(ret);
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
 done:
 
@@ -31753,10 +31752,8 @@ static wc_test_ret_t ecc_test_custom_curves(WC_RNG* rng)
 #endif
 
     ret = wc_ecc_init_ex(key, HEAP_HINT, devId);
-    if (ret != 0) {
-        ret = WC_TEST_RET_ENC_EC(ret);
-        goto done;
-    }
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
     inOutIdx = 0;
     ret = wc_EccPublicKeyDecode(eccKeyExplicitCurve, &inOutIdx, key,
@@ -32045,7 +32042,7 @@ static int ecc_sm2_test_curve(WC_RNG* rng, int testVerifyCount)
 
 #ifndef WC_NO_RNG
     ret = wc_ecc_sm2_make_key(rng, userA, WC_ECC_FLAG_NONE);
-    if (ret == ECC_CURVE_OID_E)
+    if (ret == WC_NO_ERR_TRACE(ECC_CURVE_OID_E))
         goto done; /* catch case, where curve is not supported */
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
@@ -32550,7 +32547,7 @@ static wc_test_ret_t ecc_test_cert_gen(WC_RNG* rng)
             ret = wc_SignCert(myCert->bodySz, myCert->sigType, der,
                               FOURK_BUF, NULL, caEccKey, rng);
         }
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit);
     certSz = (int)ret;
@@ -34326,7 +34323,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ecc_test_buffers(void)
     #endif
         if (ret == 0)
             ret = wc_ecc_sign_hash(in, inLen, out, &x, &rng, cliKey);
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 TEST_SLEEP();
@@ -34340,7 +34337,7 @@ TEST_SLEEP();
         if (ret == 0)
             ret = wc_ecc_verify_hash(out, x, in, inLen, &verify,
                 cliKey);
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
     if (verify != 1)
@@ -34600,19 +34597,19 @@ static wc_test_ret_t curve25519_check_public_test(void)
     /* Parameter checks */
     /* NULL pointer */
     ret = wc_curve25519_check_public(NULL, 0, EC25519_LITTLE_ENDIAN);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         return WC_TEST_RET_ENC_EC(ret);
     }
     ret = wc_curve25519_check_public(NULL, 0, EC25519_BIG_ENDIAN);
-    if (ret != BAD_FUNC_ARG) {
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
         return WC_TEST_RET_ENC_EC(ret);
     }
     /* Length of 0 treated differently to other invalid lengths for TLS */
     ret = wc_curve25519_check_public(good, 0, EC25519_LITTLE_ENDIAN);
-    if (ret != BUFFER_E)
+    if (ret != WC_NO_ERR_TRACE(BUFFER_E))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_curve25519_check_public(good, 0, EC25519_BIG_ENDIAN);
-    if (ret != BUFFER_E)
+    if (ret != WC_NO_ERR_TRACE(BUFFER_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     /* Length not CURVE25519_KEYSIZE */
@@ -34620,11 +34617,11 @@ static wc_test_ret_t curve25519_check_public_test(void)
         if (i == CURVE25519_KEYSIZE)
             continue;
         if (wc_curve25519_check_public(good, (word32)i, EC25519_LITTLE_ENDIAN) !=
-                                                                ECC_BAD_ARG_E) {
+                WC_NO_ERR_TRACE(ECC_BAD_ARG_E)) {
             return WC_TEST_RET_ENC_I(i);
         }
         if (wc_curve25519_check_public(good, (word32)i, EC25519_BIG_ENDIAN) !=
-                                                                ECC_BAD_ARG_E) {
+                WC_NO_ERR_TRACE(ECC_BAD_ARG_E)) {
             return WC_TEST_RET_ENC_I(i);
         }
     }
@@ -35179,14 +35176,14 @@ static wc_test_ret_t ed25519_test_check_key(void)
 
     /* Load bad public key only and perform checks. */
     ret = wc_ed25519_import_public(key_bad_y, ED25519_PUB_KEY_SIZE + 1, &key);
-    if (ret != PUBLIC_KEY_E) {
+    if (ret != WC_NO_ERR_TRACE(PUBLIC_KEY_E)) {
         res = WC_TEST_RET_ENC_NC;
     }
     if (res == 0) {
         /* Load bad public key only and perform checks. */
         ret = wc_ed25519_import_public(key_bad_y_max, ED25519_PUB_KEY_SIZE + 1,
             &key);
-        if (ret != PUBLIC_KEY_E) {
+        if (ret != WC_NO_ERR_TRACE(PUBLIC_KEY_E)) {
             res = WC_TEST_RET_ENC_NC;
         }
     }
@@ -35194,7 +35191,7 @@ static wc_test_ret_t ed25519_test_check_key(void)
         /* Load bad public key only and perform checks. */
         ret = wc_ed25519_import_public(key_bad_y_is_p, ED25519_PUB_KEY_SIZE + 1,
             &key);
-        if (ret != PUBLIC_KEY_E) {
+        if (ret != WC_NO_ERR_TRACE(PUBLIC_KEY_E)) {
             res = WC_TEST_RET_ENC_NC;
         }
     }
@@ -36017,22 +36014,22 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ed25519_test(void)
 
         ret = wc_ed25519_verify_msg(rareEd1, sizeof(rareEd1), msgs[0], msgSz[0],
                 &verify, &key);
-        if (ret != BAD_FUNC_ARG)
+        if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
             return ret;
 
         ret = wc_ed25519_verify_msg(rareEd2, sizeof(rareEd2), msgs[0], msgSz[0],
                 &verify, &key);
-        if (ret != BAD_FUNC_ARG)
+        if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
             return ret;
 
         ret = wc_ed25519_verify_msg(rareEd3, sizeof(rareEd3), msgs[0], msgSz[0],
                 &verify, &key);
-        if (ret != BAD_FUNC_ARG)
+        if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
             return ret;
 
         ret = wc_ed25519_verify_msg(rareEd4, sizeof(rareEd4), msgs[0], msgSz[0],
                 &verify, &key);
-        if (ret != SIG_VERIFY_E)
+        if (ret != WC_NO_ERR_TRACE(SIG_VERIFY_E))
             return ret;
     }
 
@@ -36058,7 +36055,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ed25519_test(void)
         return WC_TEST_RET_ENC_NC;
 
     ret = wc_ed25519_sign_msg(msgs[0], msgSz[0], out, &outlen, &key3);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     /* try with a buffer size that is too large */
@@ -36205,17 +36202,17 @@ static wc_test_ret_t curve448_check_public_test(void)
     /* Parameter checks */
     /* NULL pointer */
     ret = wc_curve448_check_public(NULL, 0, EC448_LITTLE_ENDIAN);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_curve448_check_public(NULL, 0, EC448_BIG_ENDIAN);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     /* Length of 0 treated differently to other invalid lengths for TLS */
     ret = wc_curve448_check_public(good, 0, EC448_LITTLE_ENDIAN);
-    if (ret != BUFFER_E)
+    if (ret != WC_NO_ERR_TRACE(BUFFER_E))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_curve448_check_public(good, 0, EC448_BIG_ENDIAN);
-    if (ret != BUFFER_E)
+    if (ret != WC_NO_ERR_TRACE(BUFFER_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     /* Length not CURVE448_KEY_SIZE */
@@ -36223,11 +36220,11 @@ static wc_test_ret_t curve448_check_public_test(void)
         if (i == CURVE448_KEY_SIZE)
             continue;
         if (wc_curve448_check_public(good, (word32)i, EC448_LITTLE_ENDIAN) !=
-                                                                ECC_BAD_ARG_E) {
+                WC_NO_ERR_TRACE(ECC_BAD_ARG_E)) {
             return WC_TEST_RET_ENC_I(i);
         }
         if (wc_curve448_check_public(good, (word32)i, EC448_BIG_ENDIAN) !=
-                                                                ECC_BAD_ARG_E) {
+                WC_NO_ERR_TRACE(ECC_BAD_ARG_E)) {
             return WC_TEST_RET_ENC_I(i);
         }
     }
@@ -36709,14 +36706,14 @@ static wc_test_ret_t ed448_test_check_key(void)
 
     /* Load bad public key only and perform checks. */
     ret = wc_ed448_import_public(key_bad_y, ED448_PUB_KEY_SIZE + 1, &key);
-    if (ret != PUBLIC_KEY_E) {
+    if (ret != WC_NO_ERR_TRACE(PUBLIC_KEY_E)) {
         res = WC_TEST_RET_ENC_NC;
     }
     if (ret == 0) {
         /* Load bad public key only and perform checks. */
         ret = wc_ed448_import_public(key_bad_y_max, ED448_PUB_KEY_SIZE + 1,
             &key);
-        if (ret != PUBLIC_KEY_E) {
+        if (ret != WC_NO_ERR_TRACE(PUBLIC_KEY_E)) {
             res = WC_TEST_RET_ENC_NC;
         }
     }
@@ -36724,7 +36721,7 @@ static wc_test_ret_t ed448_test_check_key(void)
         /* Load bad public key only and perform checks. */
         ret = wc_ed448_import_public(key_bad_y_is_p, ED448_PUB_KEY_SIZE + 1,
             &key);
-        if (ret != PUBLIC_KEY_E) {
+        if (ret != WC_NO_ERR_TRACE(PUBLIC_KEY_E)) {
             res = WC_TEST_RET_ENC_NC;
         }
     }
@@ -37661,7 +37658,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ed448_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
     ret = wc_ed448_sign_msg(msgs[0], msgSz[0], out, &outlen, key3, NULL, 0);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
     idx = 0;
@@ -42539,7 +42536,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t xmss_test(void)
 
             ret2 = wc_XmssKey_Verify(&verifyKey, sig, sigSz, (byte *) msg,
                                      msgSz);
-            if ((ret2 != -1) && (ret2 != SIG_VERIFY_E)) {
+            if ((ret2 != -1) && (ret2 != WC_NO_ERR_TRACE(SIG_VERIFY_E))) {
                 /* Verify passed when it should have failed. */
                 return WC_TEST_RET_ENC_I(j);
             }
@@ -42997,7 +42994,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t xmss_test_verify_only(void)
     xmss_msg[sizeof(xmss_msg) / 2] ^= 1;
     ret2 = wc_XmssKey_Verify(&verifyKey, xmss_sig, sizeof(xmss_sig),
                              (byte *) xmss_msg, sizeof(xmss_msg));
-    if ((ret2 != -1) && (ret2 != SIG_VERIFY_E)) {
+    if ((ret2 != -1) && (ret2 != WC_NO_ERR_TRACE(SIG_VERIFY_E))) {
         printf("error: wc_XmssKey_Verify returned %d, expected -1\n", ret2);
         return WC_TEST_RET_ENC_EC(ret2);
     }
@@ -43018,7 +43015,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t xmss_test_verify_only(void)
 
         ret2 = wc_XmssKey_Verify(&verifyKey, xmss_sig, sizeof(xmss_sig),
                                  (byte *) xmss_msg, sizeof(xmss_msg));
-        if ((ret2 != -1) && (ret2 != SIG_VERIFY_E)) {
+        if ((ret2 != -1) && (ret2 != WC_NO_ERR_TRACE(SIG_VERIFY_E))) {
             /* Verify passed when it should have failed. */
             return WC_TEST_RET_ENC_I(j);
         }
@@ -43168,7 +43165,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t lms_test(void)
 
             ret2 = wc_LmsKey_Verify(&verifyKey, sig, sigSz, (byte *) msg,
                                      msgSz);
-            if ((ret2 != -1) && (ret2 != SIG_VERIFY_E)) {
+            if ((ret2 != -1) && (ret2 != WC_NO_ERR_TRACE(SIG_VERIFY_E))) {
                 /* Verify passed when it should have failed. */
                 return WC_TEST_RET_ENC_I(j);
             }
@@ -43509,7 +43506,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t lms_test_verify_only(void)
     lms_msg[msgSz / 2] ^= 1;
     ret2 = wc_LmsKey_Verify(&verifyKey, lms_L1H10W8_sig, LMS_L1H10W8_SIGLEN,
                             (byte *) lms_msg, msgSz);
-    if ((ret2 != -1) && (ret2 != SIG_VERIFY_E)) {
+    if ((ret2 != -1) && (ret2 != WC_NO_ERR_TRACE(SIG_VERIFY_E))) {
         printf("error: wc_LmsKey_Verify returned %d, expected -1\n", ret2);
         return WC_TEST_RET_ENC_EC(ret);
     }
@@ -43531,7 +43528,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t lms_test_verify_only(void)
         ret2 = wc_LmsKey_Verify(&verifyKey, lms_L1H10W8_sig,
                                 LMS_L1H10W8_SIGLEN,
                                 (byte *) lms_msg, msgSz);
-        if ((ret2 != -1) && (ret2 != SIG_VERIFY_E)) {
+        if ((ret2 != -1) && (ret2 != WC_NO_ERR_TRACE(SIG_VERIFY_E))) {
             /* Verify passed when it should have failed. */
             return WC_TEST_RET_ENC_I(j);
         }
@@ -43566,17 +43563,17 @@ static wc_test_ret_t eccsi_api_test(WC_RNG* rng, EccsiKey* key, mp_int* ssk,
     word32 sigSz;
 
     ret = wc_InitEccsiKey_ex(NULL, 32, ECC_SECP256R1, HEAP_HINT, INVALID_DEVID);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_InitEccsiKey_ex(NULL, 32, ECC_SECP256R1, HEAP_HINT, INVALID_DEVID);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_InitEccsiKey(NULL, NULL, INVALID_DEVID);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_InitEccsiKey(NULL, HEAP_HINT, INVALID_DEVID);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     wc_FreeEccsiKey(NULL);
@@ -43587,373 +43584,373 @@ static wc_test_ret_t eccsi_api_test(WC_RNG* rng, EccsiKey* key, mp_int* ssk,
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_MakeEccsiKey(NULL, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeEccsiKey(key, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeEccsiKey(NULL, rng);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_MakeEccsiPair(NULL, NULL, WC_HASH_TYPE_SHA256, NULL, 1, NULL,
             NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeEccsiPair(key, rng, WC_HASH_TYPE_SHA256, id, 1, ssk, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeEccsiPair(key, rng, WC_HASH_TYPE_SHA256, id, 1, NULL, pvt);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeEccsiPair(key, rng, WC_HASH_TYPE_SHA256, NULL, 1, ssk, pvt);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeEccsiPair(key, NULL, WC_HASH_TYPE_SHA256, id, 1, ssk, pvt);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeEccsiPair(NULL, rng, WC_HASH_TYPE_SHA256, id, 1, ssk, pvt);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     /* No key set */
     ret = wc_MakeEccsiPair(key, rng, WC_HASH_TYPE_SHA256, id, 1, ssk, pvt);
-    if (ret != BAD_STATE_E)
+    if (ret != WC_NO_ERR_TRACE(BAD_STATE_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_ValidateEccsiPair(NULL, WC_HASH_TYPE_SHA256, NULL, 1, NULL, NULL,
             NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ValidateEccsiPair(key, WC_HASH_TYPE_SHA256, id, 1, ssk, pvt,
             NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ValidateEccsiPair(key, WC_HASH_TYPE_SHA256, id, 1, ssk, NULL,
             &valid);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ValidateEccsiPair(key, WC_HASH_TYPE_SHA256, id, 1, NULL, pvt,
             &valid);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ValidateEccsiPair(key, WC_HASH_TYPE_SHA256, NULL, 1, ssk, pvt,
             &valid);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ValidateEccsiPair(NULL, WC_HASH_TYPE_SHA256, id, 1, ssk, pvt,
             &valid);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     /* No key set */
     ret = wc_ValidateEccsiPair(key, WC_HASH_TYPE_SHA256, id, 1, ssk, pvt,
             &valid);
-    if (ret != BAD_STATE_E)
+    if (ret != WC_NO_ERR_TRACE(BAD_STATE_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_ValidateEccsiPvt(NULL, NULL, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ValidateEccsiPvt(key, NULL, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ValidateEccsiPvt(NULL, pvt, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ValidateEccsiPvt(NULL, NULL, &valid);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ValidateEccsiPvt(key, pvt, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ValidateEccsiPvt(key, NULL, &valid);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ValidateEccsiPvt(NULL, pvt, &valid);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_EncodeEccsiPair(NULL, NULL, NULL, data, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_EncodeEccsiPair(key, ssk, pvt, data, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_EncodeEccsiPair(key, ssk, NULL, data, &sz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_EncodeEccsiPair(key, NULL, pvt, data, &sz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_EncodeEccsiPair(NULL, ssk, pvt, data, &sz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     /* No key created so no curve information. */
     ret = wc_EncodeEccsiPair(key, ssk, pvt, NULL, &sz);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_EncodeEccsiSsk(NULL, NULL, data, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_EncodeEccsiSsk(key, ssk, data, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_EncodeEccsiSsk(key, NULL, data, &sz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_EncodeEccsiSsk(NULL, ssk, data, &sz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_EncodeEccsiPvt(NULL, NULL, data, NULL, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_EncodeEccsiPvt(key, pvt, data, NULL, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_EncodeEccsiPvt(key, NULL, data, &sz, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_EncodeEccsiPvt(NULL, pvt, data, &sz, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_DecodeEccsiPair(NULL, NULL, 0, NULL, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DecodeEccsiPair(key, data, 0, ssk, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DecodeEccsiPair(key, data, 0, NULL, pvt);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DecodeEccsiPair(key, NULL, 0, ssk, pvt);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DecodeEccsiPair(NULL, data, 0, ssk, pvt);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_DecodeEccsiSsk(NULL, NULL, 0, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DecodeEccsiSsk(key, data, 0, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DecodeEccsiSsk(key, NULL, 0, ssk);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DecodeEccsiSsk(NULL, data, 0, ssk);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DecodeEccsiPvt(NULL, NULL, 0, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DecodeEccsiPvt(key, data, 0, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DecodeEccsiPvt(key, NULL, 0, pvt);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DecodeEccsiPvt(NULL, data, 0, pvt);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_DecodeEccsiPvtFromSig(NULL, NULL, 0, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DecodeEccsiPvtFromSig(key, data, 0, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DecodeEccsiPvtFromSig(key, NULL, 0, pvt);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DecodeEccsiPvtFromSig(NULL, data, 0, pvt);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_ExportEccsiKey(NULL, data, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ExportEccsiKey(key, data, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ExportEccsiKey(NULL, data, &sz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     /* No key to export */
     ret = wc_ExportEccsiKey(key, NULL, &sz);
-    if (ret != BAD_STATE_E)
+    if (ret != WC_NO_ERR_TRACE(BAD_STATE_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_ImportEccsiKey(NULL, NULL, 0);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ImportEccsiKey(key, NULL, 0);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ImportEccsiKey(NULL, data, 0);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_ExportEccsiPrivateKey(NULL, data, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ExportEccsiPrivateKey(key, data, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ExportEccsiPrivateKey(NULL, data, &sz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     /* No key to export */
     ret = wc_ExportEccsiPrivateKey(key, NULL, &sz);
-    if (ret != BAD_STATE_E)
+    if (ret != WC_NO_ERR_TRACE(BAD_STATE_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_ImportEccsiPrivateKey(NULL, NULL, 0);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ImportEccsiPrivateKey(key, NULL, 0);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ImportEccsiPrivateKey(NULL, data, 0);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ExportEccsiPublicKey(NULL, data, NULL, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ExportEccsiPublicKey(key, data, NULL, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ExportEccsiPublicKey(NULL, data, &sz, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     /* No key to export */
     ret = wc_ExportEccsiPublicKey(key, data, &sz, 1);
-    if (ret != BAD_STATE_E)
+    if (ret != WC_NO_ERR_TRACE(BAD_STATE_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_ImportEccsiPublicKey(NULL, NULL, 0, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ImportEccsiPublicKey(key, NULL, 0, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ImportEccsiPublicKey(NULL, data, 0, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_HashEccsiId(NULL, WC_HASH_TYPE_SHA256, NULL, 1, NULL, NULL, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_HashEccsiId(key, WC_HASH_TYPE_SHA256, id, 1, pvt, hash, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_HashEccsiId(key, WC_HASH_TYPE_SHA256, id, 1, pvt, NULL, &hashSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_HashEccsiId(key, WC_HASH_TYPE_SHA256, id, 1, NULL, hash, &hashSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_HashEccsiId(key, WC_HASH_TYPE_SHA256, NULL, 1, pvt, hash,
             &hashSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_HashEccsiId(NULL, WC_HASH_TYPE_SHA256, id, 1, pvt, hash, &hashSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_HashEccsiId(key, WC_HASH_TYPE_SHA256, id, 1, pvt, hash, &hashSz);
-    if (ret != BAD_STATE_E)
+    if (ret != WC_NO_ERR_TRACE(BAD_STATE_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_SetEccsiHash(NULL, NULL, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetEccsiHash(key, NULL, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetEccsiHash(NULL, hash, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_SetEccsiPair(NULL, NULL, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetEccsiPair(key, NULL, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetEccsiPair(NULL, ssk, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetEccsiPair(NULL, NULL, pvt);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetEccsiPair(key, ssk, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetEccsiPair(key, NULL, pvt);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetEccsiPair(NULL, ssk, pvt);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SignEccsiHash(NULL, NULL, WC_HASH_TYPE_SHA256, NULL, 0, sig, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SignEccsiHash(key, rng, WC_HASH_TYPE_SHA256, data, 0, sig, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SignEccsiHash(key, rng, WC_HASH_TYPE_SHA256, NULL, 0, sig,
             &sigSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SignEccsiHash(key, NULL, WC_HASH_TYPE_SHA256, data, 0, sig,
             &sigSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SignEccsiHash(NULL, rng, WC_HASH_TYPE_SHA256, data, 0, sig,
             &sigSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     /* Key not set. */
     ret = wc_SignEccsiHash(key, rng, WC_HASH_TYPE_SHA256, data, 0, NULL,
             &sigSz);
-    if (ret != BAD_STATE_E)
+    if (ret != WC_NO_ERR_TRACE(BAD_STATE_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_VerifyEccsiHash(NULL, WC_HASH_TYPE_SHA256, NULL, 0, NULL, 0, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_VerifyEccsiHash(key, WC_HASH_TYPE_SHA256, NULL, 0, NULL, 0, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_VerifyEccsiHash(NULL, WC_HASH_TYPE_SHA256, data, 0, NULL, 0, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_VerifyEccsiHash(NULL, WC_HASH_TYPE_SHA256, NULL, 0, sig, 0, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_VerifyEccsiHash(NULL, WC_HASH_TYPE_SHA256, NULL, 0, NULL, 0,
             &valid);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_VerifyEccsiHash(key, WC_HASH_TYPE_SHA256, data, 0, sig, 0, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_VerifyEccsiHash(key, WC_HASH_TYPE_SHA256, data, 0, NULL, 0,
             &valid);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_VerifyEccsiHash(key, WC_HASH_TYPE_SHA256, NULL, 0, sig, 0,
             &valid);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_VerifyEccsiHash(NULL, WC_HASH_TYPE_SHA256, data, 0, sig, 0,
             &valid);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_VerifyEccsiHash(key, WC_HASH_TYPE_SHA256, data, 0, sig, 0,
             &valid);
-    if (ret != BAD_STATE_E)
+    if (ret != WC_NO_ERR_TRACE(BAD_STATE_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_SetEccsiPair(key, ssk, pvt);
@@ -43962,7 +43959,7 @@ static wc_test_ret_t eccsi_api_test(WC_RNG* rng, EccsiKey* key, mp_int* ssk,
     /* Identity hash not set. */
     ret = wc_SignEccsiHash(key, rng, WC_HASH_TYPE_SHA256, data, 0, NULL,
             &sigSz);
-    if (ret != BAD_STATE_E)
+    if (ret != WC_NO_ERR_TRACE(BAD_STATE_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     wc_FreeEccsiKey(key);
@@ -44077,7 +44074,7 @@ static wc_test_ret_t eccsi_enc_dec_pair_test(EccsiKey* priv, mp_int* ssk, ecc_po
         ERROR_OUT(WC_TEST_RET_ENC_ERRNO, out);
 
     ret = wc_EncodeEccsiPair(priv, ssk, pvt, NULL, &sz);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     if (sz != 32 * 3)
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
@@ -44097,7 +44094,7 @@ static wc_test_ret_t eccsi_enc_dec_pair_test(EccsiKey* priv, mp_int* ssk, ecc_po
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
     ret = wc_EncodeEccsiSsk(priv, ssk, NULL, &sz);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     if (sz != 32)
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
@@ -44114,7 +44111,7 @@ static wc_test_ret_t eccsi_enc_dec_pair_test(EccsiKey* priv, mp_int* ssk, ecc_po
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     ret = wc_EncodeEccsiPvt(priv, pvt, NULL, &sz, 1);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     if (sz != 32 * 2)
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
@@ -44162,7 +44159,7 @@ static wc_test_ret_t eccsi_imp_exp_key_test(EccsiKey* priv)
     word32 sz;
 
     ret = wc_ExportEccsiKey(priv, NULL, &sz);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         return WC_TEST_RET_ENC_EC(ret);
     if (sz != 32 * 3)
         return WC_TEST_RET_ENC_NC;
@@ -44173,7 +44170,7 @@ static wc_test_ret_t eccsi_imp_exp_key_test(EccsiKey* priv)
     if (ret != 0)
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ExportEccsiKey(priv, NULL, &sz);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         return WC_TEST_RET_ENC_EC(ret);
     if (sz != 32 * 3)
         return WC_TEST_RET_ENC_NC;
@@ -44186,7 +44183,7 @@ static wc_test_ret_t eccsi_imp_exp_key_test(EccsiKey* priv)
         return WC_TEST_RET_ENC_NC;
 
     ret = wc_ExportEccsiPrivateKey(priv, NULL, &sz);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         return WC_TEST_RET_ENC_EC(ret);
     if (sz != 32)
         return WC_TEST_RET_ENC_NC;
@@ -44197,7 +44194,7 @@ static wc_test_ret_t eccsi_imp_exp_key_test(EccsiKey* priv)
     if (ret != 0)
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ExportEccsiPrivateKey(priv, NULL, &sz);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         return WC_TEST_RET_ENC_EC(ret);
     if (sz != 32)
         return WC_TEST_RET_ENC_NC;
@@ -44220,7 +44217,7 @@ static wc_test_ret_t eccsi_imp_exp_pubkey_test(EccsiKey* key1, EccsiKey* key2)
     word32 sz;
 
     ret = wc_ExportEccsiPublicKey(key1, NULL, &sz, 1);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         return WC_TEST_RET_ENC_EC(ret);
     if (sz != 32 * 2)
         return WC_TEST_RET_ENC_NC;
@@ -44316,7 +44313,7 @@ static wc_test_ret_t eccsi_sign_verify_test(EccsiKey* priv, EccsiKey* pub, WC_RN
 #ifdef WOLFSSL_SHA384
     ret = wc_HashEccsiId(priv, WC_HASH_TYPE_SHA384, id, idSz, pvt, hashPriv,
             &hashSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
     ret = wc_HashEccsiId(priv, WC_HASH_TYPE_SHA256, id, idSz, pvt, hashPriv,
@@ -44344,7 +44341,7 @@ static wc_test_ret_t eccsi_sign_verify_test(EccsiKey* priv, EccsiKey* pub, WC_RN
 
     ret = wc_SignEccsiHash(priv, rng, WC_HASH_TYPE_SHA256, msg, msgSz, NULL,
             &sigSz);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         return WC_TEST_RET_ENC_EC(ret);
     if (sigSz != 129)
         return WC_TEST_RET_ENC_NC;
@@ -44576,10 +44573,10 @@ static wc_test_ret_t sakke_api_test(WC_RNG* rng, SakkeKey* key, ecc_point* rsk)
     word32 len;
 
     ret = wc_InitSakkeKey_ex(NULL, 128, ECC_SAKKE_1, NULL, INVALID_DEVID);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_InitSakkeKey_ex(NULL, 128, ECC_SAKKE_1, HEAP_HINT, INVALID_DEVID);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     wc_FreeSakkeKey(NULL);
@@ -44592,386 +44589,386 @@ static wc_test_ret_t sakke_api_test(WC_RNG* rng, SakkeKey* key, ecc_point* rsk)
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_MakeSakkeKey(NULL, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeSakkeKey(key, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeSakkeKey(NULL, rng);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_MakeSakkePublicKey(NULL, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeSakkePublicKey(key, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeSakkePublicKey(NULL, rsk);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_MakeSakkeRsk(NULL, NULL, 1, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeSakkeRsk(key, id, 1, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeSakkeRsk(key, NULL, 1, rsk);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeSakkeRsk(NULL, id, 1, rsk);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_ValidateSakkeRsk(NULL, NULL, 1, NULL, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ValidateSakkeRsk(key, id, 1, rsk, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ValidateSakkeRsk(NULL, id, 1, rsk, &valid);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_ExportSakkeKey(NULL, NULL, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ExportSakkeKey(key, data, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ExportSakkeKey(NULL, data, &sz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_ImportSakkeKey(NULL, NULL, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ImportSakkeKey(key, NULL, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ImportSakkeKey(NULL, data, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_ExportSakkePrivateKey(NULL, NULL, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ExportSakkePrivateKey(key, data, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ExportSakkePrivateKey(NULL, data, &sz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_ImportSakkePrivateKey(NULL, NULL, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ImportSakkePrivateKey(key, NULL, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ImportSakkePrivateKey(NULL, data, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     sz = sizeof(data);
     ret = wc_EncodeSakkeRsk(NULL, NULL, data, NULL, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_EncodeSakkeRsk(key, rsk, data, NULL, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_EncodeSakkeRsk(key, NULL, data, &sz, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_EncodeSakkeRsk(NULL, rsk, data, &sz, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_DecodeSakkeRsk(NULL, NULL, sz, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DecodeSakkeRsk(key, data, sz, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DecodeSakkeRsk(key, NULL, sz, rsk);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DecodeSakkeRsk(NULL, data, sz, rsk);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_ImportSakkeRsk(NULL, NULL, sz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ImportSakkeRsk(key, NULL, sz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ImportSakkeRsk(NULL, data, sz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ImportSakkeRsk(key, data, 1);
-    if (ret != BUFFER_E)
+    if (ret != WC_NO_ERR_TRACE(BUFFER_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_GenerateSakkeRskTable(NULL, NULL, data, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_GenerateSakkeRskTable(key, NULL, data, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_GenerateSakkeRskTable(NULL, rsk, data, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_GenerateSakkeRskTable(NULL, NULL, data, &len);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_GenerateSakkeRskTable(key, rsk, data, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_GenerateSakkeRskTable(key, NULL, data, &len);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_GenerateSakkeRskTable(NULL, rsk, data, &len);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_GenerateSakkeRskTable(key, rsk, NULL, &len);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         return WC_TEST_RET_ENC_EC(ret);
     len--;
     ret = wc_GenerateSakkeRskTable(key, rsk, data, &len);
-    if (ret != BUFFER_E)
+    if (ret != WC_NO_ERR_TRACE(BUFFER_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_ExportSakkePublicKey(NULL, data, NULL, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ExportSakkePublicKey(key, data, NULL, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ExportSakkePublicKey(NULL, data, &sz, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_ImportSakkePublicKey(NULL, NULL, sz, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ImportSakkePublicKey(key, NULL, sz, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_ImportSakkePublicKey(NULL, data, sz, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_GetSakkeAuthSize(NULL, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_GetSakkeAuthSize(key, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_GetSakkeAuthSize(NULL, &authSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_MakeSakkePointI(NULL, NULL, SAKKE_ID_MAX_SIZE + 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeSakkePointI(key, NULL, SAKKE_ID_MAX_SIZE + 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeSakkePointI(NULL, id, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeSakkePointI(NULL, NULL, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeSakkePointI(key, id, SAKKE_ID_MAX_SIZE + 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeSakkePointI(key, NULL, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeSakkePointI(NULL, id, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_GenerateSakkePointITable(NULL, data, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_GenerateSakkePointITable(key, data, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_GenerateSakkePointITable(NULL, data, &len);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_GenerateSakkePointITable(key, NULL, &len);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         return WC_TEST_RET_ENC_EC(ret);
     len--;
     ret = wc_GenerateSakkePointITable(key, data, &len);
-    if (ret != BUFFER_E)
+    if (ret != WC_NO_ERR_TRACE(BUFFER_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_SetSakkePointITable(NULL, NULL, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetSakkePointITable(key, NULL, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetSakkePointITable(NULL, data, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetSakkePointITable(key, data, 1);
-    if (ret != BUFFER_E)
+    if (ret != WC_NO_ERR_TRACE(BUFFER_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_ClearSakkePointITable(NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_GetSakkePointI(NULL, data, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_GetSakkePointI(key, data, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_GetSakkePointI(NULL, data, &sz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     sz = 1;
     ret = wc_GetSakkePointI(key, data, &sz);
-    if (ret != BUFFER_E)
+    if (ret != WC_NO_ERR_TRACE(BUFFER_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     sz = 256;
     ret = wc_SetSakkePointI(NULL, NULL, 1, NULL, sz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetSakkePointI(key, NULL, 1, NULL, sz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetSakkePointI(NULL, id, 1, NULL, sz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetSakkePointI(NULL, NULL, 1, data, sz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetSakkePointI(key, id, 1, NULL, sz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetSakkePointI(key, NULL, 1, data, sz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetSakkePointI(NULL, id, 1, data, sz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetSakkePointI(key, id, SAKKE_ID_MAX_SIZE + 1, data, sz);
-    if (ret != BUFFER_E)
+    if (ret != WC_NO_ERR_TRACE(BUFFER_E))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetSakkePointI(key, id, 1, data, sz - 1);
-    if (ret != BUFFER_E)
+    if (ret != WC_NO_ERR_TRACE(BUFFER_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_SetSakkeIdentity(NULL, NULL, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetSakkeIdentity(key, NULL, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetSakkeIdentity(NULL, id, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ssvSz = sizeof(ssv);
     ret = wc_MakeSakkeEncapsulatedSSV(NULL, WC_HASH_TYPE_SHA256, NULL, ssvSz,
             auth, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeSakkeEncapsulatedSSV(key, WC_HASH_TYPE_SHA256, NULL, ssvSz,
             auth, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeSakkeEncapsulatedSSV(NULL, WC_HASH_TYPE_SHA256, ssv, ssvSz,
             auth, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeSakkeEncapsulatedSSV(NULL, WC_HASH_TYPE_SHA256, NULL, ssvSz,
             auth, &authSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeSakkeEncapsulatedSSV(key, WC_HASH_TYPE_SHA256, ssv, ssvSz,
             auth, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeSakkeEncapsulatedSSV(key, WC_HASH_TYPE_SHA256, NULL, ssvSz,
             auth, &authSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeSakkeEncapsulatedSSV(NULL, WC_HASH_TYPE_SHA256, ssv, ssvSz,
             auth, &authSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_MakeSakkeEncapsulatedSSV(key, WC_HASH_TYPE_SHA256, ssv, ssvSz,
             auth, &authSz);
-    if (ret != BAD_STATE_E)
+    if (ret != WC_NO_ERR_TRACE(BAD_STATE_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_GenerateSakkeSSV(NULL, NULL, data, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_GenerateSakkeSSV(key, rng, data, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_GenerateSakkeSSV(key, NULL, data, &ssvSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_GenerateSakkeSSV(NULL, rng, data, &ssvSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_SetSakkeRsk(NULL, NULL, data, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetSakkeRsk(key, NULL, data, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetSakkeRsk(NULL, rsk, data, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ssvSz = sizeof(ssv);
     authSz = sizeof(auth);
     ret = wc_DeriveSakkeSSV(NULL, WC_HASH_TYPE_SHA256, NULL, ssvSz, NULL,
             authSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DeriveSakkeSSV(key, WC_HASH_TYPE_SHA256, NULL, ssvSz, NULL,
             authSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DeriveSakkeSSV(NULL, WC_HASH_TYPE_SHA256, ssv, ssvSz, NULL,
             authSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DeriveSakkeSSV(NULL, WC_HASH_TYPE_SHA256, NULL, ssvSz, auth,
             authSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DeriveSakkeSSV(key, WC_HASH_TYPE_SHA256, ssv, ssvSz, NULL,
             authSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DeriveSakkeSSV(key, WC_HASH_TYPE_SHA256, NULL, ssvSz, auth,
             authSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DeriveSakkeSSV(NULL, WC_HASH_TYPE_SHA256, ssv, ssvSz, auth,
             authSz);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DeriveSakkeSSV(key, WC_HASH_TYPE_SHA256, ssv, ssvSz, auth,
             authSz);
-    if (ret != BAD_STATE_E)
+    if (ret != WC_NO_ERR_TRACE(BAD_STATE_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_SetSakkeIdentity(key, id, 1);
@@ -44979,7 +44976,7 @@ static wc_test_ret_t sakke_api_test(WC_RNG* rng, SakkeKey* key, ecc_point* rsk)
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DeriveSakkeSSV(key, WC_HASH_TYPE_SHA256, ssv, ssvSz, auth,
             authSz);
-    if (ret != BAD_STATE_E)
+    if (ret != WC_NO_ERR_TRACE(BAD_STATE_E))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SetSakkeIdentity(key, id, 0);
     if (ret != 0)
@@ -44990,7 +44987,7 @@ static wc_test_ret_t sakke_api_test(WC_RNG* rng, SakkeKey* key, ecc_point* rsk)
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_DeriveSakkeSSV(key, WC_HASH_TYPE_SHA256, ssv, ssvSz, auth,
             authSz);
-    if (ret != BAD_STATE_E)
+    if (ret != WC_NO_ERR_TRACE(BAD_STATE_E))
         return WC_TEST_RET_ENC_EC(ret);
 
     wc_FreeSakkeKey(key);
@@ -45162,7 +45159,7 @@ static wc_test_ret_t sakke_kat_derive_test(SakkeKey* key, ecc_point* rsk)
         return WC_TEST_RET_ENC_EC(ret);
     iTableLen = 0;
     ret = wc_GenerateSakkePointITable(key, NULL, &iTableLen);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         return WC_TEST_RET_ENC_EC(ret);
     if (iTableLen != 0) {
         iTable = (byte*)XMALLOC(iTableLen, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -45174,7 +45171,7 @@ static wc_test_ret_t sakke_kat_derive_test(SakkeKey* key, ecc_point* rsk)
     }
     len = 0;
     ret = wc_GenerateSakkeRskTable(key, rsk, NULL, &len);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         return WC_TEST_RET_ENC_EC(ret);
     if (len > 0) {
         table = (byte*)XMALLOC(len, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -45366,7 +45363,7 @@ static wc_test_ret_t sakke_make_key_test(SakkeKey* priv, SakkeKey* pub, SakkeKey
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_ExportSakkeKey(priv, NULL, &sz);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         return WC_TEST_RET_ENC_EC(ret);
     if (sz != 384)
         return WC_TEST_RET_ENC_NC;
@@ -45393,7 +45390,7 @@ static wc_test_ret_t sakke_make_key_test(SakkeKey* priv, SakkeKey* pub, SakkeKey
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_ExportSakkePrivateKey(priv, NULL, &sz);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         return WC_TEST_RET_ENC_EC(ret);
     if (sz != 128)
         return WC_TEST_RET_ENC_NC;
@@ -45419,7 +45416,7 @@ static wc_test_ret_t sakke_make_key_test(SakkeKey* priv, SakkeKey* pub, SakkeKey
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_ExportSakkePublicKey(priv, NULL, &sz, 1);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         return WC_TEST_RET_ENC_EC(ret);
     if (sz != 256)
         return WC_TEST_RET_ENC_NC;
@@ -45505,7 +45502,7 @@ static wc_test_ret_t sakke_op_test(SakkeKey* priv, SakkeKey* pub, WC_RNG* rng,
     word32 sz;
 
     ret = wc_GenerateSakkeSSV(pub, rng, NULL, &ssvSz);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         return WC_TEST_RET_ENC_EC(ret);
     if (ssvSz != 16)
         return WC_TEST_RET_ENC_NC;
@@ -45531,7 +45528,7 @@ static wc_test_ret_t sakke_op_test(SakkeKey* priv, SakkeKey* pub, WC_RNG* rng,
 
     ret = wc_MakeSakkeEncapsulatedSSV(pub, WC_HASH_TYPE_SHA256, ssv, ssvSz,
             NULL, &authSz);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         return WC_TEST_RET_ENC_EC(ret);
     if (authSz != 257)
         return WC_TEST_RET_ENC_NC;
@@ -45550,7 +45547,7 @@ static wc_test_ret_t sakke_op_test(SakkeKey* priv, SakkeKey* pub, WC_RNG* rng,
         return WC_TEST_RET_ENC_NC;
 
     ret = wc_GetSakkePointI(pub, NULL, &sz);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         return WC_TEST_RET_ENC_EC(ret);
     if (sz != 256)
         return WC_TEST_RET_ENC_NC;
@@ -45591,7 +45588,7 @@ static wc_test_ret_t sakke_op_test(SakkeKey* priv, SakkeKey* pub, WC_RNG* rng,
     ssv[0] ^= 0x80;
     ret = wc_DeriveSakkeSSV(priv, WC_HASH_TYPE_SHA256, ssv, ssvSz, auth,
             authSz);
-    if (ret != SAKKE_VERIFY_FAIL_E)
+    if (ret != WC_NO_ERR_TRACE(SAKKE_VERIFY_FAIL_E))
         return WC_TEST_RET_ENC_EC(ret);
     ssv[0] ^= 0x80;
 
@@ -46247,53 +46244,53 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t siphash_test(void)
 
     /* Testing bad parameters. */
     ret = wc_InitSipHash(NULL, NULL, SIPHASH_MAC_SIZE_8);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_InitSipHash(NULL, siphash_key, SIPHASH_MAC_SIZE_8);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_InitSipHash(&siphash, NULL, SIPHASH_MAC_SIZE_8);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_InitSipHash(&siphash, siphash_key, 7);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_InitSipHash(&siphash, siphash_key, SIPHASH_MAC_SIZE_8);
     if (ret != 0)
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SipHashUpdate(NULL, NULL, 0);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SipHashUpdate(&siphash, NULL, 1);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SipHashFinal(NULL, NULL, SIPHASH_MAC_SIZE_8);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SipHashFinal(&siphash, NULL, SIPHASH_MAC_SIZE_8);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SipHashFinal(NULL, res, SIPHASH_MAC_SIZE_8);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SipHashFinal(&siphash, res, SIPHASH_MAC_SIZE_16);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = wc_SipHash(NULL, NULL, 0, NULL, SIPHASH_MAC_SIZE_16);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SipHash(siphash_key, NULL, 0, NULL, SIPHASH_MAC_SIZE_16);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SipHash(NULL, NULL, 0, res, SIPHASH_MAC_SIZE_16);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SipHash(siphash_key, NULL, 0, res, 15);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_SipHash(siphash_key, NULL, 1, res, SIPHASH_MAC_SIZE_16);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     /* Test cache with multiple non blocksize bytes */
@@ -47115,7 +47112,7 @@ static int myDecryptionFunc(PKCS7* pkcs7, int encryptOID, byte* iv, int ivSz,
     /* if needing to find keyIdSz can call with NULL */
     ret = wc_PKCS7_GetAttributeValue(pkcs7, OID, sizeof(OID), NULL,
             &keyIdSz);
-    if (ret != LENGTH_ONLY_E) {
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
         printf("Unexpected error %d when getting keyIdSz\n", ret);
         printf("Possibly no KEY ID attribute set\n");
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
@@ -47618,7 +47615,9 @@ static wc_test_ret_t pkcs7enveloped_run_vectors(byte* rsaCert, word32 rsaCertSz,
             for (z = 0; z < envelopedSz; z++) {
                 decodedSz = wc_PKCS7_DecodeEnvelopedData(pkcs7, enveloped + z, 1,
                                                  decoded, PKCS7_BUF_SIZE);
-                if (decodedSz <= 0 && decodedSz != WC_PKCS7_WANT_READ_E) {
+                if (decodedSz <= 0 &&
+                    decodedSz != WC_NO_ERR_TRACE(WC_PKCS7_WANT_READ_E))
+                {
                     printf("unexpected error %d\n", decodedSz);
                     ERROR_OUT(WC_TEST_RET_ENC_EC(decodedSz), out);
                 }
@@ -48304,7 +48303,9 @@ static wc_test_ret_t pkcs7authenveloped_run_vectors(byte* rsaCert, word32 rsaCer
             for (z = 0; z < envelopedSz; z++) {
                 decodedSz = wc_PKCS7_DecodeAuthEnvelopedData(pkcs7,
                         enveloped + z, 1, decoded, PKCS7_BUF_SIZE);
-                if (decodedSz <= 0 && decodedSz != WC_PKCS7_WANT_READ_E) {
+                if (decodedSz <= 0 &&
+                    decodedSz != WC_NO_ERR_TRACE(WC_PKCS7_WANT_READ_E))
+                {
                     printf("unexpected error %d\n", decodedSz);
                     ERROR_OUT(WC_TEST_RET_ENC_EC(decodedSz), out);
                 }
@@ -48545,7 +48546,7 @@ static wc_test_ret_t getFirmwareKey(PKCS7* pkcs7, byte* key, word32 keySz)
     /* find keyID in fwWrappedFirmwareKey */
     ret = wc_PKCS7_GetAttributeValue(pkcs7, fwWrappedFirmwareKey,
             sizeof(fwWrappedFirmwareKey), NULL, &atrSz);
-    if (ret == LENGTH_ONLY_E) {
+    if (ret == WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
         XMEMSET(atr, 0, sizeof(atr));
         ret = wc_PKCS7_GetAttributeValue(pkcs7, fwWrappedFirmwareKey,
                 sizeof(fwWrappedFirmwareKey), atr, &atrSz);
@@ -48790,7 +48791,7 @@ static wc_test_ret_t verifyBundle(byte* derBuf, word32 derSz, int keyHint)
 
     /* Get size of SID and print it out */
     ret = wc_PKCS7_GetSignerSID(pkcs7, NULL, &sidSz);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         goto out;
 
     sid = (byte*)XMALLOC(sidSz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -49089,7 +49090,9 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t pkcs7encrypted_test(void)
             for (z = 0; z < encryptedSz; z++) {
                 decodedSz = wc_PKCS7_DecodeEncryptedData(pkcs7, encrypted + z, 1,
                                                  decoded, PKCS7_BUF_SIZE);
-                if (decodedSz <= 0 && decodedSz != WC_PKCS7_WANT_READ_E) {
+                if (decodedSz <= 0 &&
+                    decodedSz != WC_NO_ERR_TRACE(WC_PKCS7_WANT_READ_E))
+                {
                     printf("unexpected error %d\n", decodedSz);
                     ERROR_OUT(WC_TEST_RET_ENC_EC(decodedSz), out);
                 }
@@ -49779,7 +49782,7 @@ static wc_test_ret_t pkcs7signed_run_vectors(
             if (testVectors[i].signedAttribs != NULL) {
                 ret = wc_PKCS7_GetAttributeValue(pkcs7, oidPt, (word32)oidSz,
                     NULL, (word32*)&bufSz);
-                if (ret != LENGTH_ONLY_E)
+                if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
                     ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
                 ret = 0;
             }
@@ -50256,7 +50259,7 @@ static wc_test_ret_t pkcs7signed_run_SingleShotVectors(
             word32 z;
             for (z = 0; z < outSz && ret != 0; z++) {
                 ret = wc_PKCS7_VerifySignedData(pkcs7, out + z, 1);
-                if (ret < 0 && ret != WC_PKCS7_WANT_READ_E) {
+                if (ret < 0 && ret != WC_NO_ERR_TRACE(WC_PKCS7_WANT_READ_E)) {
                     printf("unexpected error %d\n", ret);
                     ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
                 }
@@ -50679,10 +50682,10 @@ static wc_test_ret_t mp_test_radix_10(mp_int* a, mp_int* r, WC_RNG* rng)
     }
 
     ret = mp_read_radix(r, badStr1, MP_RADIX_DEC);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_read_radix(r, badStr2, MP_RADIX_DEC);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_read_radix(r, empty2, MP_RADIX_DEC);
     if (ret != MP_OKAY)
@@ -50756,7 +50759,7 @@ static wc_test_ret_t mp_test_radix_16(mp_int* a, mp_int* r, WC_RNG* rng)
     if (ret != MP_OKAY)
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_read_radix(r, badStr2, MP_RADIX_HEX);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
     mp_set(r, 1);
@@ -50772,7 +50775,7 @@ static wc_test_ret_t mp_test_radix_16(mp_int* a, mp_int* r, WC_RNG* rng)
     XMEMSET(longStr+1, '0', sizeof(longStr) - 2);
     longStr[sizeof(longStr)-1] = '\0';
     ret = mp_read_radix(r, longStr, MP_RADIX_HEX);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
@@ -50799,10 +50802,10 @@ static wc_test_ret_t mp_test_radix_16(mp_int* a, mp_int* r, WC_RNG* rng)
 
 #ifdef WOLFSSL_SP_MATH
     ret = mp_toradix(a, str, 8);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_radix_size(a, 8, &size);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
@@ -50921,7 +50924,7 @@ static wc_test_ret_t mp_test_read_to_bin(mp_int* a)
 
     /* Length too small. */
     ret = mp_to_unsigned_bin_len(a, out, 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = mp_read_unsigned_bin(a, NULL, 0);
@@ -51003,7 +51006,7 @@ static wc_test_ret_t mp_test_param(mp_int* a, mp_int* b, mp_int* r, WC_RNG* rng)
     (void)r;
 
     ret = mp_init(NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
 #if !defined(WOLFSSL_RSA_PUBLIC_ONLY) || (!defined(NO_DH) || defined(HAVE_ECC))
@@ -51016,7 +51019,7 @@ static wc_test_ret_t mp_test_param(mp_int* a, mp_int* b, mp_int* r, WC_RNG* rng)
 
 #if !defined(WOLFSSL_RSA_VERIFY_ONLY) || !defined(NO_DH) || defined(HAVE_ECC)
     ret = mp_grow(NULL, 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #ifdef WOLFSSL_SP_MATH
     ret = mp_grow(a, SP_INT_DIGITS + 1);
@@ -51028,13 +51031,13 @@ static wc_test_ret_t mp_test_param(mp_int* a, mp_int* b, mp_int* r, WC_RNG* rng)
     mp_clear(NULL);
 
     ret = mp_abs(NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_abs(a, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_abs(NULL, b);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = mp_unsigned_bin_size(NULL);
@@ -51045,35 +51048,35 @@ static wc_test_ret_t mp_test_param(mp_int* a, mp_int* b, mp_int* r, WC_RNG* rng)
     XMEMSET(buffer, 0, sizeof(buffer));
 
     ret = mp_read_unsigned_bin(NULL, NULL, sizeof(buffer));
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_read_unsigned_bin(NULL, buffer, sizeof(buffer));
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_read_unsigned_bin(a, NULL, sizeof(buffer));
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_read_unsigned_bin(a, buffer, SP_INT_DIGITS * SP_WORD_SIZEOF + 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
 #if defined(HAVE_ECC) || defined(WOLFSSL_SP_MATH_ALL)
     ret = mp_read_radix(NULL, NULL, 16);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_read_radix(a, NULL, 16);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_read_radix(NULL, hexStr, 16);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #ifndef WOLFSSL_SP_INT_NEGATIVE
     ret = mp_read_radix(a, negStr, 16);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #ifdef WOLFSSL_SP_MATH_ALL
     ret = mp_read_radix(a, negStr, 10);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif /* WOLFSSL_SP_MATH_ALL */
 #endif /* WOLFSSL_SP_INT_NEGATIVE */
@@ -51081,12 +51084,12 @@ static wc_test_ret_t mp_test_param(mp_int* a, mp_int* b, mp_int* r, WC_RNG* rng)
 #ifndef WOLFSSL_SP_MATH_ALL
     /* Radix 10 only supported with ALL. */
     ret = mp_read_radix(a, decStr, 10);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
     /* Radix 8 not supported SP_INT. */
     ret = mp_read_radix(a, "0123", 8);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = mp_count_bits(NULL);
@@ -51109,43 +51112,43 @@ static wc_test_ret_t mp_test_param(mp_int* a, mp_int* b, mp_int* r, WC_RNG* rng)
     defined(HAVE_ECC) || defined(WOLFSSL_KEY_GEN) || defined(OPENSSL_EXTRA) || \
     !defined(NO_RSA)
     ret = mp_set_bit(NULL, 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if !defined(NO_DH) || defined(HAVE_ECC) || defined(WC_RSA_BLINDING) || \
     !defined(WOLFSSL_RSA_VERIFY_ONLY)
     ret = mp_to_unsigned_bin(NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_to_unsigned_bin(a, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_to_unsigned_bin(NULL, buffer);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
     ret = mp_to_unsigned_bin_len(NULL, NULL, 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_to_unsigned_bin_len(a, NULL, 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_to_unsigned_bin_len(NULL, buffer, 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
 #if defined(WOLFSSL_SP_MATH_ALL) && !defined(NO_RSA) && \
     !defined(WOLFSSL_RSA_VERIFY_ONLY)
     ret = mp_to_unsigned_bin_at_pos(0, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_to_unsigned_bin_at_pos(0, a, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_to_unsigned_bin_at_pos(0, NULL, buffer);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_to_unsigned_bin_at_pos(0, a, buffer);
     if (ret != MP_OKAY)
@@ -51154,24 +51157,24 @@ static wc_test_ret_t mp_test_param(mp_int* a, mp_int* b, mp_int* r, WC_RNG* rng)
 
 #if !defined(WOLFSSL_RSA_VERIFY_ONLY) || (!defined(NO_DH) || defined(HAVE_ECC))
     ret = mp_copy(NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_copy(a, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_copy(NULL, b);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if defined(WOLFSSL_KEY_GEN) || !defined(NO_DH)
     ret = sp_2expt(NULL, 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
     ret = mp_set(NULL, 0);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = mp_cmp_d(NULL, 0);
@@ -51197,489 +51200,489 @@ static wc_test_ret_t mp_test_param(mp_int* a, mp_int* b, mp_int* r, WC_RNG* rng)
 #if !defined(NO_DH) || defined(HAVE_ECC) || defined(WC_RSA_BLINDING) || \
     !defined(WOLFSSL_RSA_VERIFY_ONLY)
     ret = mp_lshd(NULL, 0);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_lshd(a, SP_INT_DIGITS + 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if defined(WOLFSSL_SP_MATH_ALL)
     ret = mp_div(NULL, NULL, a, b);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_div(a, NULL, a, b);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_div(NULL, b, a, b);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_div(a, b, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if defined(WOLFSSL_SP_MATH_ALL) || !defined(NO_DH) || defined(HAVE_ECC) || \
     (!defined(NO_RSA) && !defined(WOLFSSL_RSA_VERIFY_ONLY))
     ret = mp_mod(NULL, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mod(a, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mod(NULL, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mod(NULL, NULL, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mod(a, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mod(a, NULL, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mod(NULL, b, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if !defined(NO_RSA) || defined(WOLFSSL_SP_MATH_ALL)
     ret = mp_set_int(NULL, 0);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if !defined(NO_RSA) || !defined(NO_DSA) || !defined(NO_DH) || \
     (defined(HAVE_ECC) && defined(HAVE_COMP_KEY)) || defined(OPENSSL_EXTRA)
     ret = mp_exptmod_ex(NULL, NULL, 1, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_ex(a, NULL, 1, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_ex(NULL, a, 1, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_ex(NULL, NULL, 1, a, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_ex(NULL, NULL, 1, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_ex(a, a, 1, a, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_ex(a, a, 1, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_ex(a, NULL, 1, a, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_ex(NULL, a, 1, a, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = mp_exptmod_nct(NULL, NULL, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_nct(a, NULL, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_nct(NULL, a, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_nct(NULL, NULL, a, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_nct(NULL, NULL, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_nct(a, a, a, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_nct(a, a, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_nct(a, NULL, a, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_nct(NULL, a, a, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if defined(WOLFSSL_KEY_GEN) && (!defined(NO_DH) || !defined(NO_DSA)) && \
     !defined(WC_NO_RNG)
     ret = mp_rand_prime(NULL, 32, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_rand_prime(a, 32, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_rand_prime(NULL, 32, rng, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_rand_prime(a, 0, rng, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)
     ret = mp_mul(NULL, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mul(a, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mul(NULL, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mul(NULL, NULL, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mul(a, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mul(a, NULL, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mul(NULL, b, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if defined(WOLFSSL_SP_MATH_ALL) || defined(WOLFSSL_HAVE_SP_DH) || \
     defined(HAVE_ECC) || (!defined(NO_RSA) && !defined(WOLFSSL_RSA_VERIFY_ONLY))
     ret = mp_sqr(NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_sqr(a, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_sqr(NULL, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if !defined(WOLFSSL_RSA_VERIFY_ONLY)
     ret = mp_sqrmod(NULL, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_sqrmod(a, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_sqrmod(NULL, a, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_sqrmod(NULL, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_sqrmod(a, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_sqrmod(a, NULL, b);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_sqrmod(NULL, a, b);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = mp_mulmod(NULL, NULL, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mulmod(a, NULL, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mulmod(NULL, a, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mulmod(NULL, NULL, a, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mulmod(NULL, NULL, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mulmod(a, b, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mulmod(a, b, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mulmod(a, NULL, b, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mulmod(NULL, b, b, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if !defined(NO_PWDBASED) || defined(WOLFSSL_KEY_GEN) || !defined(NO_DH) || \
     !defined(NO_RSA) || !defined(NO_DSA)
     ret = mp_add_d(NULL, 1, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_add_d(a, 1, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_add_d(NULL, 1, b);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if (!defined(NO_RSA) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
     !defined(NO_DH) || defined(HAVE_ECC) || !defined(NO_DSA)
     ret = mp_sub_d(NULL, 1, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_sub_d(a, 1, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_sub_d(NULL, 1, b);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
     defined(WOLFSSL_KEY_GEN) || defined(HAVE_COMP_KEY)
     ret = mp_div_d(NULL, 0, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_div_d(a, 0, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_div_d(NULL, 1, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if (defined(HAVE_ECC) && defined(HAVE_COMP_KEY)) || \
                             (defined(OPENSSL_EXTRA) && defined(WOLFSSL_KEY_GEN))
     ret = mp_mod_d(NULL, 0, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mod_d(a, 0, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mod_d(NULL, 0, &rd);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if defined(WOLFSSL_SP_MATH_ALL) && !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN)
     ret = mp_gcd(NULL, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_gcd(a, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_gcd(NULL, a, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_gcd(NULL, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_gcd(a, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_gcd(a, NULL, b);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_gcd(NULL, a, b);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if !defined(WOLFSSL_SP_MATH) && defined(HAVE_ECC)
     ret = mp_div_2_mod_ct(NULL, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_div_2_mod_ct(a, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_div_2_mod_ct(NULL, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_div_2_mod_ct(NULL, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_div_2_mod_ct(a, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_div_2_mod_ct(a, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_div_2_mod_ct(NULL, b, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = mp_div_2(NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_div_2(a, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_div_2(NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if (!defined(NO_RSA) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
     defined(HAVE_ECC) || !defined(NO_DSA) || defined(OPENSSL_EXTRA)
     ret = mp_invmod(NULL, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_invmod(a, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_invmod(NULL, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_invmod(NULL, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_invmod(a, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_invmod(a, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_invmod(NULL, b, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if !defined(WOLFSSL_SP_MATH) && defined(HAVE_ECC)
     ret = mp_invmod_mont_ct(NULL, NULL, NULL, 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_invmod_mont_ct(a, NULL, NULL, 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_invmod_mont_ct(NULL, b, NULL, 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_invmod_mont_ct(NULL, NULL, a, 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_invmod_mont_ct(a, b, NULL, 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_invmod_mont_ct(a, NULL, a, 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_invmod_mont_ct(NULL, b, a, 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN) && !defined(WC_RSA_BLINDING)
     ret = mp_lcm(NULL, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_lcm(a, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_lcm(NULL, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_lcm(NULL, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_lcm(a, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_lcm(a, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_lcm(NULL, b, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if defined(WOLFSSL_SP_MATH_ALL) || defined(WOLFSSL_HAVE_SP_DH)
     ret = mp_exptmod_ex(NULL, NULL, 1, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_ex(a, NULL, 1, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_ex(NULL, b, 1, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_ex(NULL, NULL, 1, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_ex(NULL, NULL, 1, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_ex(a, b, 1, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_ex(a, b, 1, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_ex(a, NULL, 1, b, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_ex(NULL, b, 1, b, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = mp_exptmod(NULL, NULL, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod(a, NULL, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod(NULL, b, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod(NULL, NULL, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod(NULL, NULL, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod(a, b, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod(a, b, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod(a, NULL, b, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod(NULL, b, b, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = mp_exptmod_nct(NULL, NULL, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_nct(a, NULL, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_nct(NULL, b, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_nct(NULL, NULL, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_nct(NULL, NULL, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_nct(a, b, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_nct(a, b, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_nct(a, NULL, b, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_nct(NULL, b, b, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
@@ -51691,115 +51694,115 @@ static wc_test_ret_t mp_test_param(mp_int* a, mp_int* b, mp_int* r, WC_RNG* rng)
 
 #if defined(WOLFSSL_SP_MATH_ALL) || defined(WOLFSSL_HAVE_SP_DH)
     ret = mp_prime_is_prime(NULL, 1, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_prime_is_prime(a, 1, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_prime_is_prime(NULL, 1, &result);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_prime_is_prime(a, 0, &result);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_prime_is_prime(a, 1024, &result);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = mp_prime_is_prime_ex(NULL, 1, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_prime_is_prime_ex(a, 1, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_prime_is_prime_ex(NULL, 1, &result, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_prime_is_prime_ex(NULL, 1, NULL, rng);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_prime_is_prime_ex(a, 1, &result, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_prime_is_prime_ex(a, 1, NULL, rng);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_prime_is_prime_ex(NULL, 1, &result, rng);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if defined(WOLFSSL_SP_MATH_ALL) || !defined(NO_DH) || !defined(NO_DSA)
     ret = mp_exch(NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exch(a, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exch(NULL, b);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if (defined(WOLFSSL_KEY_GEN) && !defined(NO_RSA)) || \
                                                     defined(WOLFSSL_SP_MATH_ALL)
     ret = mp_mul_d(NULL, 1, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mul_d(a, 1, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mul_d(NULL, 1, b);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if !defined(WOLFSSL_RSA_VERIFY_ONLY)
     ret = mp_add(NULL, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_add(a, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_add(NULL, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_add(NULL, NULL, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_add(a, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_add(a, NULL, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_add(NULL, b, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if defined(WOLFSSL_SP_MATH_ALL) || !defined(NO_DH) || defined(HAVE_ECC) || \
     (!defined(NO_RSA) && !defined(WOLFSSL_RSA_VERIFY_ONLY))
     ret = mp_sub(NULL, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_sub(a, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_sub(NULL, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_sub(NULL, NULL, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_sub(a, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_sub(a, NULL, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_sub(NULL, b, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
@@ -51807,126 +51810,126 @@ static wc_test_ret_t mp_test_param(mp_int* a, mp_int* b, mp_int* r, WC_RNG* rng)
 #if defined(WOLFSSL_SP_MATH_ALL) || (!defined(WOLFSSL_SP_MATH) && \
                                      defined(WOLFSSL_CUSTOM_CURVES))
     ret = mp_addmod(NULL, NULL, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_addmod(a, NULL, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_addmod(NULL, b, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_addmod(NULL, NULL, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_addmod(NULL, NULL, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_addmod(a, b, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_addmod(a, b, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_addmod(a, NULL, b, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_addmod(NULL, b, b, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #ifdef WOLFSSL_SP_MATH_ALL
     ret = mp_submod(NULL, NULL, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_submod(a, NULL, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_submod(NULL, b, NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_submod(NULL, NULL, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_submod(NULL, NULL, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_submod(a, b, b, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_submod(a, b, NULL, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_submod(a, NULL, b, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_submod(NULL, b, b, a);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #ifdef WOLFSSL_SP_MATH_ALL
     ret = mp_div_2d(NULL, 1, a, b);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = mp_mod_2d(NULL, 1, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mod_2d(a, 1, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mod_2d(NULL, 1, b);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = mp_mul_2d(NULL, 1, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mul_2d(a, 1, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mul_2d(NULL, 1, b);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if defined(WOLFSSL_SP_MATH_ALL) || defined(WOLFSSL_HAVE_SP_DH) || \
     defined(HAVE_ECC) || (!defined(NO_RSA) && !defined(WOLFSSL_RSA_VERIFY_ONLY))
     ret = mp_montgomery_reduce(NULL, NULL, 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_montgomery_reduce(a, NULL, 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_montgomery_reduce(NULL, b, 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     mp_zero(b);
     ret = mp_montgomery_reduce(a, b, 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #ifdef WOLFSSL_SP_MATH_ALL
     ret = mp_montgomery_setup(NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_montgomery_setup(a, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_montgomery_setup(NULL, &rho);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = mp_montgomery_calc_normalization(NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_montgomery_calc_normalization(a, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_montgomery_calc_normalization(NULL, b);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
@@ -51936,53 +51939,53 @@ static wc_test_ret_t mp_test_param(mp_int* a, mp_int* b, mp_int* r, WC_RNG* rng)
 
 #if defined(WC_MP_TO_RADIX) || defined(WOLFSSL_SP_MATH_ALL)
     ret = mp_tohex(NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_tohex(a, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_tohex(NULL, hexStr);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #if defined(WOLFSSL_KEY_GEN) || defined(HAVE_COMP_KEY)
     ret = mp_todecimal(NULL, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_todecimal(a, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_todecimal(NULL, decStr);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
 #ifdef WOLFSSL_SP_MATH_ALL
     ret = mp_toradix(NULL, NULL, MP_RADIX_HEX);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_toradix(a, NULL, MP_RADIX_HEX);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_toradix(NULL, hexStr, MP_RADIX_HEX);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_toradix(a, hexStr, 3);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
     ret = mp_radix_size(NULL, MP_RADIX_HEX, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_radix_size(a, MP_RADIX_HEX, NULL);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_radix_size(NULL, MP_RADIX_HEX, &size);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_radix_size(a, 3, &size);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
@@ -52067,11 +52070,11 @@ static wc_test_ret_t mp_test_set_is_bit(mp_int* a)
         i = SP_INT_MAX_BITS + j;
         if (mp_is_bit_set(a, i))
             return WC_TEST_RET_ENC_NC;
-        if (mp_set_bit(a, i) != MP_VAL)
+        if (mp_set_bit(a, i) != WC_NO_ERR_TRACE(MP_VAL))
             return WC_TEST_RET_ENC_NC;
     #ifdef WOLFSSL_KEY_GEN
         ret = mp_2expt(a, i);
-        if (ret != MP_VAL)
+        if (ret != WC_NO_ERR_TRACE(MP_VAL))
             return WC_TEST_RET_ENC_EC(ret);
     #endif
     }
@@ -52302,7 +52305,7 @@ static wc_test_ret_t mp_test_div(mp_int* a, mp_int* d, mp_int* r, mp_int* rem,
     mp_zero(d);
 
     ret = mp_div(a, d, r, rem);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
     mp_set(d, 1);
@@ -52441,7 +52444,7 @@ static wc_test_ret_t mp_test_prime(mp_int* a, WC_RNG* rng)
     if (ret != 0)
         return WC_TEST_RET_ENC_EC(ret);
 #else
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_NC;
 #endif
 #ifndef WOLFSSL_SP_MATH
@@ -52461,13 +52464,13 @@ static wc_test_ret_t mp_test_prime(mp_int* a, WC_RNG* rng)
 #endif
 
     ret = mp_prime_is_prime(a, 0, &res);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_prime_is_prime(a, -1, &res);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_prime_is_prime(a, 257, &res);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
     mp_set(a, 1);
@@ -52550,13 +52553,13 @@ static wc_test_ret_t mp_test_lcm_gcd(mp_int* a, mp_int* b, mp_int* r, mp_int* ex
     mp_set(a, 0);
     mp_set(b, 1);
     ret = mp_lcm(a, a, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_lcm(a, b, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_lcm(b, a, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
     for (i = 0; i < (int)(sizeof(kat) / sizeof(*kat)); i++) {
@@ -52612,7 +52615,7 @@ static wc_test_ret_t mp_test_lcm_gcd(mp_int* a, mp_int* b, mp_int* r, mp_int* ex
     if (ret != MP_EQ)
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_gcd(b, b, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
     return 0;
@@ -52721,7 +52724,7 @@ static wc_test_ret_t mp_test_mod_d(mp_int* a, WC_RNG* rng)
     if (ret != MP_OKAY)
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_mod_d(a, 0, &r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
     mp_zero(a);
@@ -52851,25 +52854,25 @@ static wc_test_ret_t mp_test_invmod(mp_int* a, mp_int* m, mp_int* r)
     mp_set(a, 0);
     mp_set(m, 1);
     ret = mp_invmod(a, m, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_invmod(m, a, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     mp_set(a, 2);
     mp_set(m, 4);
     ret = mp_invmod(a, m, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     mp_set(a, 3);
     mp_set(m, 6);
     ret = mp_invmod(a, m, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     mp_set(a, 5*9);
     mp_set(m, 6*9);
     ret = mp_invmod(a, m, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     mp_set(a, 1);
     mp_set(m, 4);
@@ -52903,7 +52906,7 @@ static wc_test_ret_t mp_test_invmod(mp_int* a, mp_int* m, mp_int* r)
     mp_set(m, 0);
     mp_set_bit(m, (r->size / 2) * SP_WORD_SIZE);
     ret = mp_invmod(a, m, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     /* Maximum modulus - even. */
     mp_set(m, 0);
@@ -52924,22 +52927,22 @@ static wc_test_ret_t mp_test_invmod(mp_int* a, mp_int* m, mp_int* r)
     mp_set(a, 0);
     mp_set(m, 3);
     ret = mp_invmod_mont_ct(a, m, r, 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     mp_set(a, 1);
     mp_set(m, 0);
     ret = mp_invmod_mont_ct(a, m, r, 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     mp_set(a, 1);
     mp_set(m, 1);
     ret = mp_invmod_mont_ct(a, m, r, 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     mp_set(a, 1);
     mp_set(m, 2);
     ret = mp_invmod_mont_ct(a, m, r, 1);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
     mp_set(a, 1);
@@ -52963,10 +52966,10 @@ static wc_test_ret_t mp_test_exptmod(mp_int* b, mp_int* e, mp_int* m, mp_int* r)
     mp_set(e, 0x3);
     mp_set(m, 0x0);
     ret = mp_exptmod_ex(b, e, 1, m, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_nct(b, e, m, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 
 
@@ -53071,10 +53074,10 @@ static wc_test_ret_t mp_test_exptmod(mp_int* b, mp_int* e, mp_int* m, mp_int* r)
     mp_mul_2d(m, SP_WORD_SIZE * SP_INT_DIGITS / 2, m);
     mp_add_d(m, 0x01, m);
     ret = mp_exptmod_ex(b, e, 1, m, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_nct(b, e, m, r);
-    if (ret != MP_VAL)
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
@@ -53332,7 +53335,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t mp_test(void)
              *        - if p and a are even it will fail.
              */
             ret = mp_invmod(a, p, r1);
-            if (ret != 0 && ret != MP_VAL)
+            if (ret != 0 && ret != WC_NO_ERR_TRACE(MP_VAL))
                 ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 
         #ifndef WOLFSSL_SP_MATH
@@ -53915,7 +53918,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t berder_test(void)
 
     for (i = 0; i < (int)(sizeof(testData) / sizeof(*testData)); i++) {
         ret = wc_BerToDer(testData[i].in, testData[i].inSz, NULL, &len);
-        if (ret != LENGTH_ONLY_E)
+        if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
             return WC_TEST_RET_ENC_I(i);
         if (len != testData[i].outSz)
             return WC_TEST_RET_ENC_I(i);
@@ -53928,44 +53931,44 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t berder_test(void)
 
         for (l = 1; l < testData[i].inSz; l++) {
             ret = wc_BerToDer(testData[i].in, l, NULL, &len);
-            if (ret != ASN_PARSE_E)
+            if (ret != WC_NO_ERR_TRACE(ASN_PARSE_E))
                  return WC_TEST_RET_ENC_EC(ret);
             len = testData[i].outSz;
             ret = wc_BerToDer(testData[i].in, l, out, &len);
-            if (ret != ASN_PARSE_E)
+            if (ret != WC_NO_ERR_TRACE(ASN_PARSE_E))
                  return WC_TEST_RET_ENC_EC(ret);
         }
 
         for (l = 0; l < testData[i].outSz-1; l++) {
             ret = wc_BerToDer(testData[i].in, testData[i].inSz, out, &l);
-            if (ret != BUFFER_E)
+            if (ret != WC_NO_ERR_TRACE(BUFFER_E))
                  return WC_TEST_RET_ENC_EC(ret);
         }
     }
 
     ret = wc_BerToDer(NULL, 4, NULL, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_BerToDer(out, 4, NULL, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_BerToDer(NULL, 4, NULL, &len);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_BerToDer(NULL, 4, out, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_BerToDer(out, 4, out, NULL);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_BerToDer(NULL, 4, out, &len);
-    if (ret != BAD_FUNC_ARG)
+    if (ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG))
         return WC_TEST_RET_ENC_EC(ret);
 
     for (l = 1; l < sizeof(good4_out); l++) {
         len = l;
         ret = wc_BerToDer(good4_in, sizeof(good4_in), out, &len);
-        if (ret != BUFFER_E)
+        if (ret != WC_NO_ERR_TRACE(BUFFER_E))
             return WC_TEST_RET_ENC_EC(ret);
     }
 
@@ -54040,11 +54043,11 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t logging_test(void)
 #else
     WOLFSSL_ENTER("logging_test");
     ret = wolfSSL_Debugging_ON();
-    if (ret != NOT_COMPILED_IN)
+    if (ret != WC_NO_ERR_TRACE(NOT_COMPILED_IN))
         return WC_TEST_RET_ENC_EC(ret);
     wolfSSL_Debugging_OFF();
     ret = wolfSSL_SetLoggingCb(NULL);
-    if (ret != NOT_COMPILED_IN)
+    if (ret != WC_NO_ERR_TRACE(NOT_COMPILED_IN))
         return WC_TEST_RET_ENC_EC(ret);
 #endif /* DEBUG_WOLFSSL */
     return 0;
@@ -54099,7 +54102,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t mutex_test(void)
     /* trying to free a locked mutex is not portable behavior with pthread */
     /* Attempting to destroy a locked mutex results in undefined behavior */
     ret = wc_FreeMutex(&m);
-    if (ret != BAD_MUTEX_E)
+    if (ret != WC_NO_ERR_TRACE(BAD_MUTEX_E))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
     ret = wc_UnLockMutex(&m);
@@ -54111,10 +54114,10 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t mutex_test(void)
 #if !defined(WOLFSSL_SOLARIS) && defined(ENABLE_PTHREAD_LOCKFREE_TESTS)
     /* Trying to use a pthread after free'ing is not portable behavior */
     ret = wc_LockMutex(&m);
-    if (ret != BAD_MUTEX_E)
+    if (ret != WC_NO_ERR_TRACE(BAD_MUTEX_E))
         return WC_TEST_RET_ENC_EC(ret);
     ret = wc_UnLockMutex(&m);
-    if (ret != BAD_MUTEX_E)
+    if (ret != WC_NO_ERR_TRACE(BAD_MUTEX_E))
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 #endif
@@ -54442,7 +54445,7 @@ static wc_test_ret_t rsa_onlycb_test(myCryptoDevCtx *ctx)
     */
     ctx->exampleVar = 1;
     ret = wc_MakeRsaKey(key, keySz, WC_RSA_EXPONENT, rng);
-    if (ret != NO_VALID_DEVID) {
+    if (ret != WC_NO_ERR_TRACE(NO_VALID_DEVID)) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_onlycb);
     } else
         /* reset return code */
@@ -54478,7 +54481,7 @@ static wc_test_ret_t rsa_onlycb_test(myCryptoDevCtx *ctx)
         ctx->exampleVar = 1;
         ret = wc_SignatureGenerate(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA,
                             in, inLen, out, &sigSz, key, sizeof(*key), NULL);
-        if (ret != NO_VALID_DEVID) {
+        if (ret != WC_NO_ERR_TRACE(NO_VALID_DEVID)) {
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_onlycb);
         } else
             /* reset return code */
@@ -54602,7 +54605,7 @@ static wc_test_ret_t ecc_onlycb_test(myCryptoDevCtx *ctx)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_onlycb);
     ctx->exampleVar = 1;
     ret = wc_ecc_make_key(&rng, ECC_KEYGEN_SIZE, key);
-    if (ret != NO_VALID_DEVID) {
+    if (ret != WC_NO_ERR_TRACE(NO_VALID_DEVID)) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_onlycb);
     } else
         /* reset return code */
@@ -54627,7 +54630,7 @@ static wc_test_ret_t ecc_onlycb_test(myCryptoDevCtx *ctx)
     if (ret == 0) {
         ret = wc_ecc_sign_hash(in, inLen, out, &outLen, &rng, key);
     }
-    if (ret != NO_VALID_DEVID) {
+    if (ret != WC_NO_ERR_TRACE(NO_VALID_DEVID)) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_onlycb);
     }
     else
@@ -54645,7 +54648,7 @@ static wc_test_ret_t ecc_onlycb_test(myCryptoDevCtx *ctx)
     if (ret == 0) {
         ret = wc_ecc_verify_hash(in, inLen, out, outLen, &verify, key);
     }
-    if (ret != NO_VALID_DEVID) {
+    if (ret != WC_NO_ERR_TRACE(NO_VALID_DEVID)) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_onlycb);
     }
     else
@@ -54666,7 +54669,7 @@ static wc_test_ret_t ecc_onlycb_test(myCryptoDevCtx *ctx)
     if (ret == 0) {
         ret = wc_ecc_shared_secret(key, pub, out, &outLen);
     }
-    if (ret != NO_VALID_DEVID) {
+    if (ret != WC_NO_ERR_TRACE(NO_VALID_DEVID)) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), exit_onlycb);
     }
     else
@@ -54821,7 +54824,8 @@ exit_onlycb:
 /* Example crypto dev callback function that calls software version */
 static int myCryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
 {
-    int ret = NOT_COMPILED_IN; /* return this to bypass HW and use SW */
+    int ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN); /* return this to bypass HW and
+                                                   use SW */
     myCryptoDevCtx* myCtx = (myCryptoDevCtx*)ctx;
 
     if (info == NULL)
@@ -54926,7 +54930,7 @@ static int myCryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
                 ret = wc_MakeRsaKey(info->pk.rsakg.key, info->pk.rsakg.size,
                     info->pk.rsakg.e, info->pk.rsakg.rng);
 #ifdef HAVE_FIPS
-                if (ret == PRIME_GEN_E)
+                if (ret == WC_NO_ERR_TRACE(PRIME_GEN_E))
                     continue;
                 break;
             }

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -220,7 +220,9 @@ enum wolfSSL_ErrorCodes {
 WOLFSSL_LOCAL
 void SetErrorString(int err, char* buff);
 
-#if defined(WOLFSSL_DEBUG_TRACE_ERROR_CODES) && defined(BUILDING_WOLFSSL)
+#if defined(WOLFSSL_DEBUG_TRACE_ERROR_CODES) && \
+        (defined(BUILDING_WOLFSSL) || \
+         defined(WOLFSSL_DEBUG_TRACE_ERROR_CODES_ALWAYS))
     #include <wolfssl/debug-trace-error-codes.h>
 #endif
 

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -304,7 +304,9 @@ WOLFSSL_API void wc_ErrorString(int err, char* buff);
 WOLFSSL_ABI WOLFSSL_API const char* wc_GetErrorString(int error);
 #endif
 
-#if defined(WOLFSSL_DEBUG_TRACE_ERROR_CODES) && defined(BUILDING_WOLFSSL)
+#if defined(WOLFSSL_DEBUG_TRACE_ERROR_CODES) && \
+        (defined(BUILDING_WOLFSSL) || \
+         defined(WOLFSSL_DEBUG_TRACE_ERROR_CODES_ALWAYS))
     extern void wc_backtrace_render(void);
     #define WC_NO_ERR_TRACE(label) (CONST_NUM_ERR_ ## label)
     #ifndef WOLFSSL_DEBUG_BACKTRACE_RENDER_CLAUSE


### PR DESCRIPTION
add `WOLFSSL_DEBUG_TRACE_ERROR_CODES_ALWAYS` flag for optional errcode tracing in apps, define it in `wolfcrypt/test/test.c` when `defined(WOLFSSL_DEBUG_TRACE_ERROR_CODES)`, and deploy `WC_NO_ERR_TRACE()` to `test.c` where needed.

note, `test.c` is included in the linuxkm with `--enable-crypttests` as part of the library (module), so these changes fix preexisting `test.c` trace noise in the linuxkm.

tested with `wolfssl-multi-test.sh ... check-source-text quantum-safe-wolfssl-all-clang-tidy linuxkm-mainline-intelasm-sp-asm-pie-gcc-latest-insmod` (note that `linuxkm-mainline-intelasm-sp-asm-pie-gcc-latest-insmod` includes `--enable-debug-trace-errcodes`.)
