### PR TITLE
Kyber: fix TLS usage

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -398,24 +398,43 @@ static void SetKeyShare(WOLFSSL* ssl, int onlyKeyShare, int useX25519,
         if (usePqc) {
             int group = 0;
 
+        #ifndef WOLFSSL_NO_KYBER512
             if (XSTRCMP(pqcAlg, "KYBER_LEVEL1") == 0) {
                 group = WOLFSSL_KYBER_LEVEL1;
             }
-            else if (XSTRCMP(pqcAlg, "KYBER_LEVEL3") == 0) {
+            else
+        #endif
+        #ifndef WOLFSSL_NO_KYBER768
+            if (XSTRCMP(pqcAlg, "KYBER_LEVEL3") == 0) {
                 group = WOLFSSL_KYBER_LEVEL3;
             }
-            else if (XSTRCMP(pqcAlg, "KYBER_LEVEL5") == 0) {
+            else
+        #endif
+        #ifndef WOLFSSL_NO_KYBER1024
+            if (XSTRCMP(pqcAlg, "KYBER_LEVEL5") == 0) {
                 group = WOLFSSL_KYBER_LEVEL5;
             }
-            else if (XSTRCMP(pqcAlg, "P256_KYBER_LEVEL1") == 0) {
+            else
+        #endif
+        #ifndef WOLFSSL_NO_KYBER512
+            if (XSTRCMP(pqcAlg, "P256_KYBER_LEVEL1") == 0) {
                 group = WOLFSSL_P256_KYBER_LEVEL1;
             }
-            else if (XSTRCMP(pqcAlg, "P384_KYBER_LEVEL3") == 0) {
+            else
+        #endif
+        #ifndef WOLFSSL_NO_KYBER768
+            if (XSTRCMP(pqcAlg, "P384_KYBER_LEVEL3") == 0) {
                 group = WOLFSSL_P384_KYBER_LEVEL3;
             }
-            else if (XSTRCMP(pqcAlg, "P521_KYBER_LEVEL5") == 0) {
+            else
+        #endif
+        #ifndef WOLFSSL_NO_KYBER1024
+            if (XSTRCMP(pqcAlg, "P521_KYBER_LEVEL5") == 0) {
                 group = WOLFSSL_P521_KYBER_LEVEL5;
-            } else {
+            }
+            else
+        #endif
+            {
                 err_sys("invalid post-quantum KEM specified");
             }
 

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -710,23 +710,44 @@ static void SetKeyShare(WOLFSSL* ssl, int onlyKeyShare, int useX25519,
         else if (usePqc == 1) {
     #ifdef HAVE_PQC
             groups[count] = 0;
+        #ifndef WOLFSSL_NO_KYBER512
             if (XSTRCMP(pqcAlg, "KYBER_LEVEL1") == 0) {
                 groups[count] = WOLFSSL_KYBER_LEVEL1;
             }
-            else if (XSTRCMP(pqcAlg, "KYBER_LEVEL3") == 0) {
+            else
+        #endif
+        #ifndef WOLFSSL_NO_KYBER768
+            if (XSTRCMP(pqcAlg, "KYBER_LEVEL3") == 0) {
                 groups[count] = WOLFSSL_KYBER_LEVEL3;
             }
-            else if (XSTRCMP(pqcAlg, "KYBER_LEVEL5") == 0) {
+            else
+        #endif
+        #ifndef WOLFSSL_NO_KYBER1024
+            if (XSTRCMP(pqcAlg, "KYBER_LEVEL5") == 0) {
                 groups[count] = WOLFSSL_KYBER_LEVEL5;
             }
-            else if (XSTRCMP(pqcAlg, "P256_KYBER_LEVEL1") == 0) {
+            else
+        #endif
+        #ifndef WOLFSSL_NO_KYBER512
+            if (XSTRCMP(pqcAlg, "P256_KYBER_LEVEL1") == 0) {
                 groups[count] = WOLFSSL_P256_KYBER_LEVEL1;
             }
-            else if (XSTRCMP(pqcAlg, "P384_KYBER_LEVEL3") == 0) {
+            else
+        #endif
+        #ifndef WOLFSSL_NO_KYBER768
+            if (XSTRCMP(pqcAlg, "P384_KYBER_LEVEL3") == 0) {
                 groups[count] = WOLFSSL_P384_KYBER_LEVEL3;
             }
-            else if (XSTRCMP(pqcAlg, "P521_KYBER_LEVEL5") == 0) {
+            else
+        #endif
+        #ifndef WOLFSSL_NO_KYBER1024
+            if (XSTRCMP(pqcAlg, "P521_KYBER_LEVEL5") == 0) {
                 groups[count] = WOLFSSL_P521_KYBER_LEVEL5;
+            }
+            else
+        #endif
+            {
+                err_sys("invalid post-quantum KEM specified");
             }
 
             if (groups[count] == 0) {

--- a/src/tls.c
+++ b/src/tls.c
@@ -13141,7 +13141,7 @@ static int TLSX_PopulateSupportedGroups(WOLFSSL* ssl, TLSX** extensions)
         ret = TLSX_UseSupportedCurve(extensions, WOLFSSL_P384_KYBER_LEVEL3,
                                      ssl->heap);
 #endif
-#ifdef WOLFSSL_KYBER768
+#ifdef WOLFSSL_KYBER1024
     if (ret == WOLFSSL_SUCCESS)
         ret = TLSX_UseSupportedCurve(extensions, WOLFSSL_KYBER_LEVEL5,
                                      ssl->heap);

--- a/tests/api.c
+++ b/tests/api.c
@@ -72803,7 +72803,13 @@ static int test_tls13_apis(void)
 #if defined(HAVE_ECC) && defined(HAVE_SUPPORTED_CURVES)
     int          groups[2] = { WOLFSSL_ECC_SECP256R1,
 #ifdef WOLFSSL_HAVE_KYBER
+    #ifndef WOLFSSL_NO_KYBER512
                                WOLFSSL_KYBER_LEVEL1
+    #elif !defined(WOLFSSL_NO_KYBER768)
+                               WOLFSSL_KYBER_LEVEL3
+    #else
+                               WOLFSSL_KYBER_LEVEL5
+    #endif
 #else
                                WOLFSSL_ECC_SECP256R1
 #endif
@@ -72831,15 +72837,30 @@ static int test_tls13_apis(void)
 #if (!defined(NO_ECC256)  || defined(HAVE_ALL_CURVES)) && ECC_MIN_KEY_SZ <= 256
             "P-256:secp256r1"
 #if defined(WOLFSSL_HAVE_KYBER)
+    #ifndef WOLFSSL_NO_KYBER512
             ":P256_KYBER_LEVEL1"
+    #elif !defined(WOLFSSL_NO_KYBER768)
+            ":P256_KYBER_LEVEL3"
+    #else
+            ":P256_KYBER_LEVEL5"
+    #endif
 #endif
 #endif
 #endif /* !defined(NO_ECC_SECP) */
 #if defined(WOLFSSL_HAVE_KYBER)
+    #ifndef WOLFSSL_NO_KYBER512
             ":KYBER_LEVEL1"
+    #elif !defined(WOLFSSL_NO_KYBER768)
+            ":KYBER_LEVEL3"
+    #else
+            ":KYBER_LEVEL5"
+    #endif
 #endif
             "";
 #endif /* defined(OPENSSL_EXTRA) && defined(HAVE_ECC) */
+#if defined(WOLFSSL_HAVE_KYBER)
+    int kyberLevel;
+#endif
 
     (void)ret;
 
@@ -72969,17 +72990,24 @@ static int test_tls13_apis(void)
 #endif
 
 #if defined(WOLFSSL_HAVE_KYBER)
-    ExpectIntEQ(wolfSSL_UseKeyShare(NULL, WOLFSSL_KYBER_LEVEL3), BAD_FUNC_ARG);
+#ifndef WOLFSSL_NO_KYBER768
+    kyberLevel = WOLFSSL_KYBER_LEVEL3;
+#elif !defined(WOLFSSL_NO_KYBER1024)
+    kyberLevel = WOLFSSL_KYBER_LEVEL5;
+#else
+    kyberLevel = WOLFSSL_KYBER_LEVEL1;
+#endif
+    ExpectIntEQ(wolfSSL_UseKeyShare(NULL, kyberLevel), BAD_FUNC_ARG);
 #ifndef NO_WOLFSSL_SERVER
-    ExpectIntEQ(wolfSSL_UseKeyShare(serverSsl, WOLFSSL_KYBER_LEVEL3),
+    ExpectIntEQ(wolfSSL_UseKeyShare(serverSsl, kyberLevel),
         WOLFSSL_SUCCESS);
 #endif
 #ifndef NO_WOLFSSL_CLIENT
 #ifndef WOLFSSL_NO_TLS12
-    ExpectIntEQ(wolfSSL_UseKeyShare(clientTls12Ssl, WOLFSSL_KYBER_LEVEL3),
+    ExpectIntEQ(wolfSSL_UseKeyShare(clientTls12Ssl, kyberLevel),
         BAD_FUNC_ARG);
 #endif
-    ExpectIntEQ(wolfSSL_UseKeyShare(clientSsl, WOLFSSL_KYBER_LEVEL3),
+    ExpectIntEQ(wolfSSL_UseKeyShare(clientSsl, kyberLevel),
         WOLFSSL_SUCCESS);
 #endif
 #endif

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -172,6 +172,41 @@ static int IsValidCipherSuite(const char* line, char *suite, size_t suite_spc)
     return valid;
 }
 
+#ifdef WOLFSSL_HAVE_KYBER
+static int IsKyberLevelAvailable(const char* line)
+{
+    int available = 0;
+    const char* find = "--pqc ";
+    const char* begin = strstr(line, find);
+    const char* end;
+
+    if (begin != NULL) {
+        begin += 6;
+        end = XSTRSTR(begin, " ");
+
+        if ((size_t)end - (size_t)begin == 12) {
+        #ifndef WOLFSSL_NO_KYBER512
+            if (XSTRNCMP(begin, "KYBER_LEVEL1", 12) == 0) {
+                available = 1;
+            }
+        #endif
+        #ifndef WOLFSSL_NO_KYBER768
+            if (XSTRNCMP(begin, "KYBER_LEVEL3", 12) == 0) {
+                available = 1;
+            }
+        #endif
+        #ifndef WOLFSSL_NO_KYBER1024
+            if (XSTRNCMP(begin, "KYBER_LEVEL5", 12) == 0) {
+                available = 1;
+            }
+        #endif
+        }
+    }
+
+    return (begin == NULL) || available;
+}
+#endif
+
 static int IsValidCert(const char* line)
 {
     int ret = 1;
@@ -356,6 +391,14 @@ static int execute_test_case(int svr_argc, char** svr_argv,
         #endif
         return NOT_BUILT_IN;
     }
+#ifdef WOLFSSL_HAVE_KYBER
+    if (!IsKyberLevelAvailable(commandLine)) {
+        #ifdef DEBUG_SUITE_TESTS
+            printf("Kyber level not supported in build: %s\n", commandLine);
+        #endif
+        return NOT_BUILT_IN;
+    }
+#endif
     if (!IsValidCert(commandLine)) {
         #ifdef DEBUG_SUITE_TESTS
             printf("certificate %s not supported in build\n", commandLine);


### PR DESCRIPTION
# Description

Allow only select parameter sets to be compiled in. Fixed unit.test to recognize when level is supported.

Fixes zd#18521

# Testing

Regression tested Kyber.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
