### PR TITLE
Fix WOLFSSL_NO_TLS12 build error

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3628,7 +3628,7 @@ static int _Rehandshake(WOLFSSL* ssl)
 
         ssl->secure_renegotiation->cache_status = SCR_CACHE_NEEDED;
 
-#if !defined(NO_WOLFSSL_SERVER)
+#if !defined(NO_WOLFSSL_SERVER) && !defined(WOLFSSL_NO_TLS12)
         if (ssl->options.side == WOLFSSL_SERVER_END) {
             ret = SendHelloRequest(ssl);
             if (ret != 0) {
@@ -3636,7 +3636,7 @@ static int _Rehandshake(WOLFSSL* ssl)
                 return WOLFSSL_FATAL_ERROR;
             }
         }
-#endif /* !NO_WOLFSSL_SERVER */
+#endif /* !NO_WOLFSSL_SERVER && !WOLFSSL_NO_TLS12 */
 
         ret = InitHandshakeHashes(ssl);
         if (ret != 0) {


### PR DESCRIPTION
# Description

Fix build error with
```
./configure --enable-tls13 --disable-tlsv12 --enable-secure-renegotiation --enable-nullcipher CFLAGS="-DNO_WOLFSSL_CLIENT"
```
```
make
/usr/bin/ld: src/.libs/libwolfssl_la-ssl.o: in function `wolfSSL_Rehandshake':
ssl.c:(.text+0x568a): undefined reference to `SendHelloRequest'
/usr/bin/ld: src/.libs/libwolfssl.so.42.2.0: hidden symbol `SendHelloRequest' isn't defined
/usr/bin/ld: final link failed: bad value
```

Fixes zd18539

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
