### PR TITLE
Fix compilation error for RSA_MAX_SIZE

### DIFF
--- a/wolfssl/openssl/rsa.h
+++ b/wolfssl/openssl/rsa.h
@@ -28,6 +28,7 @@
 #include <wolfssl/openssl/bn.h>
 #include <wolfssl/openssl/err.h>
 #include <wolfssl/wolfcrypt/types.h>
+#include <wolfssl/wolfcrypt/rsa.h>
 
 #ifdef __cplusplus
     extern "C" {


### PR DESCRIPTION
Fixes the error:
```
/var/lib/jenkins/workspace/wolfSSL/nightly-OSP-OpenSSH-test-v2/wolf-install-dir/include/wolfssl/openssl/rsa.h:243:38: error: ‘RSA_MAX_SIZE’ undeclared (first use in this function); did you mean ‘DH_MAX_SIZE’?
  243 | #define OPENSSL_RSA_MAX_MODULUS_BITS RSA_MAX_SIZE
```