### PR TITLE
Set RSA_MIN_SIZE default to 2048 bits

### DIFF
--- a/.github/workflows/no-malloc.yml
+++ b/.github/workflows/no-malloc.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         config: [
           # Add new configs here
-          '--enable-rsa --enable-keygen --disable-dh CFLAGS="-DWOLFSSL_NO_MALLOC"',
+          '--enable-rsa --enable-keygen --disable-dh CFLAGS="-DWOLFSSL_NO_MALLOC -DRSA_MIN_SIZE=1024"',
         ]
     name: make check
     runs-on: ubuntu-latest

--- a/.github/workflows/openssh.yml
+++ b/.github/workflows/openssh.yml
@@ -26,7 +26,7 @@ jobs:
           path: wolfssl
           configure: >-
             --enable-openssh --enable-dsa --with-max-rsa-bits=8192
-            --enable-intelasm --enable-sp-asm
+            --enable-intelasm --enable-sp-asm CFLAGS="-DRSA_MIN_SIZE=1024"
           install: true
 
       - name: tar build-dir

--- a/tests/api.c
+++ b/tests/api.c
@@ -565,13 +565,16 @@ int tmpDirNameSet = 0;
 #define TEST_STRING    "Everyone gets Friday off."
 #define TEST_STRING_SZ 25
 
+#ifndef NO_RSA
 #if (!defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)) && \
-    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 4))
+    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 4)) && \
+    (defined(RSA_MIN_SIZE) && (RSA_MIN_SIZE <= 1024))
 #define TEST_RSA_BITS 1024
 #else
 #define TEST_RSA_BITS 2048
 #endif
 #define TEST_RSA_BYTES (TEST_RSA_BITS/8)
+#endif /* !NO_RSA */
 
 #if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && \
     (!defined(NO_WOLFSSL_SERVER) || !defined(NO_WOLFSSL_CLIENT))
@@ -20294,7 +20297,8 @@ static int test_wc_MakeRsaKey(void)
     RsaKey genKey;
     WC_RNG rng;
 #if (!defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)) && \
-    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 4))
+    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 4)) && \
+    (defined(RSA_MIN_SIZE) && (RSA_MIN_SIZE <= 1024))
     int bits = 1024;
 #else
     int bits = 2048;
@@ -20695,7 +20699,8 @@ static int test_wc_RsaKeyToDer(void)
     WC_RNG rng;
     byte*  der = NULL;
 #if (!defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)) && \
-    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 4))
+    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 4)) && \
+    (defined(RSA_MIN_SIZE) && (RSA_MIN_SIZE <= 1024))
     int     bits = 1024;
     word32  derSz = 611;
     /* (2 x 128) + 2 (possible leading 00) + (5 x 64) + 5 (possible leading 00)
@@ -20749,7 +20754,8 @@ static int test_wc_RsaKeyToPublicDer(void)
     WC_RNG rng;
     byte*  der = NULL;
 #if (!defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)) && \
-    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 4))
+    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 4)) && \
+    (defined(RSA_MIN_SIZE) && (RSA_MIN_SIZE <= 1024))
     int    bits = 1024;
     word32 derLen = 162;
 #else
@@ -21013,7 +21019,8 @@ static int test_wc_RsaEncryptSize(void)
     ExpectIntEQ(wc_InitRng(&rng), 0);
 
 #if (!defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)) && \
-    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 4))
+    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 4)) && \
+    (defined(RSA_MIN_SIZE) && (RSA_MIN_SIZE <= 1024))
     ExpectIntEQ(MAKE_RSA_KEY(&key, 1024, WC_RSA_EXPONENT, &rng), 0);
 
     ExpectIntEQ(wc_RsaEncryptSize(&key), 128);
@@ -21047,7 +21054,8 @@ static int test_wc_RsaFlattenPublicKey(void)
     word32 eSz = sizeof(e);
     word32 nSz = sizeof(n);
     #if (!defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)) && \
-        (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 4))
+        (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 4)) && \
+        (defined(RSA_MIN_SIZE) && (RSA_MIN_SIZE <= 1024))
     int    bits = 1024;
     #else
     int    bits = 2048;

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -8433,7 +8433,8 @@ exit:
 void bench_rsaKeyGen(int useDeviceID)
 {
     int    k;
-#if !defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
+#if !defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL) && \
+    (RSA_MIN_SIZE <= 1024)
     static const word32  keySizes[2] = {1024, 2048};
 #else
     static const word32  keySizes[1] = {2048};

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -20891,7 +20891,8 @@ static wc_test_ret_t rsa_keygen_test(WC_RNG* rng)
     word32 idx = 0;
 #endif
     int    derSz = 0;
-#if !defined(WOLFSSL_SP_MATH) && !defined(HAVE_FIPS)
+#if !defined(WOLFSSL_SP_MATH) && !defined(HAVE_FIPS) && \
+    (defined(RSA_MIN_SIZE) && (RSA_MIN_SIZE <= 1024))
     int    keySz = 1024;
 #else
     int    keySz = 2048;

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -103,7 +103,7 @@ RSA keys can be used to encrypt, decrypt, sign and verify data.
 #endif
 
 #ifndef RSA_MIN_SIZE
-#define RSA_MIN_SIZE 1024
+#define RSA_MIN_SIZE 2048
 #endif
 
 #ifndef RSA_MAX_SIZE


### PR DESCRIPTION
# Description

Increase the minimum RSA size for generating keys to 2048 bits.

# Testing

Updated tests for new minimum. Will add config tests for RSA 1024 bit keys.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
