### PR TITLE
20240830-wolfSSL_ERR_reason_error_string-EnumCastOutOfRange

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -25165,11 +25165,13 @@ const char* wolfSSL_ERR_reason_error_string(unsigned long e)
         return wc_GetErrorString(error);
     }
 
-#ifdef OPENSSL_EXTRA
     if (error == 0) {
+#ifdef OPENSSL_EXTRA
         return "ok";
-    }
+#else
+        return "unknown error number";
 #endif
+    }
 
     switch ((enum wolfSSL_ErrorCodes)error) {
 


### PR DESCRIPTION
`src/internal.c`: in `wolfSSL_ERR_reason_error_string()`, return "unknown error number" when `error==0` and !`OPENSSL_EXTRA`, to avoid provoking `clang-analyzer-optin.core.EnumCastOutOfRange`.

tested with `wolfssl-multi-test.sh ... clang-tidy-defaults`
