### PR TITLE
[scripts/ocsp.test] Remove ${SCRIPT_DIR} from the pathname to ca-google-root.pem.

### DIFF
--- a/scripts/ocsp.test
+++ b/scripts/ocsp.test
@@ -50,7 +50,7 @@ else
 fi
 
 server=www.google.com
-ca=${SCRIPT_DIR}/../certs/external/ca-google-root.pem
+ca=certs/external/ca-google-root.pem
 
 if [ "$AM_BWRAPPED" != "yes" ]; then
     # is our desired server there?


### PR DESCRIPTION
# Description

ocsp.test does 2 tests, the 1st is to www.globalsign.com, the 2nd is to www.google.com. The pathname to CA file for the 1st test is ```certs/external/...```, but the pathname for the 2nd test is ```${SCRIPT_DIR}/../certs/external...```. In the case that the source directory and building directory are different, ```make WOLFSSL_OCSP_TEST=1 check``` successfully finishes in the 1st test, but fails in the 2nd test. Thus, the former style (without ```${SCRIPT_DIR}/..```) could be better. Here I propose to apply the former style to the latter pathname.

# Testing
After ```./autogen.sh```,
```
mkdir build-test
cd build-test
../configure --enable-ocsp && make && make WOLFSSL_OCSP_TEST=1 check
```
and
```
./configure --enable-ocsp && make && make WOLFSSL_OCSP_TEST=1 check
```
finished successfully.