### PR TITLE
Fixes for earlier macOS

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -1100,7 +1100,11 @@ static int StopMonitor(wolfSSL_CRL_mfd_t mfd)
     struct kevent change;
 
     /* trigger custom shutdown */
+#if defined(NOTE_TRIGGER)
     EV_SET(&change, CRL_CUSTOM_FD, EVFILT_USER, 0, NOTE_TRIGGER, 0, NULL);
+#elif defined(EV_TRIGGER)
+    EV_SET(&change, CRL_CUSTOM_FD, EVFILT_USER, EV_TRIGGER, 0, 0, NULL);
+#endif
     if (kevent(mfd, &change, 1, NULL, 0, NULL) < 0) {
         WOLFSSL_MSG("kevent trigger customer event failed");
         return -1;

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -34,6 +34,10 @@ decouple library dependencies with standard string, memory and so on.
     #include <wolfssl/wolfcrypt/settings.h>
     #include <wolfssl/wolfcrypt/wc_port.h>
 
+    #ifdef __APPLE__
+        #include <AvailabilityMacros.h>
+    #endif
+
     #ifdef __cplusplus
         extern "C" {
     #endif
@@ -1490,17 +1494,18 @@ typedef struct w64wrapper {
         typedef size_t        THREAD_TYPE;
         #define WOLFSSL_THREAD
     #elif defined(WOLFSSL_PTHREADS)
-        #ifndef __MACH__
-            #include <pthread.h>
-            typedef struct COND_TYPE {
-                pthread_mutex_t mutex;
-                pthread_cond_t cond;
-            } COND_TYPE;
-        #else
+        #if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED >= 1060 \
+            && !defined(__ppc__)
             #include <dispatch/dispatch.h>
             typedef struct COND_TYPE {
                 wolfSSL_Mutex mutex;
                 dispatch_semaphore_t cond;
+            } COND_TYPE;
+        #else
+            #include <pthread.h>
+            typedef struct COND_TYPE {
+                pthread_mutex_t mutex;
+                pthread_cond_t cond;
             } COND_TYPE;
         #endif
         typedef void*         THREAD_RETURN;


### PR DESCRIPTION
# Description

This addresses two issues:

1. Current code simply assumes `libdispatch` is available on macOS. This is not always true though: it does not exist prior to 10.6, and is not really tested on `ppc` on 10.6 (there are also potential related problem here: for example, blocks are not supported in gcc, as of now, while clang is broken on `ppc`).
Instead, use `libdispatch` where it exists for sure and is known to work, and otherwise use genetic POSIX. The code is unchanged, this simply changes the condition so that the right implementation is picked. There is no effect for non-Apple platforms.

2. `NOTE_TRIGGER` may not be available. If it is not present, but `EV_TRIGGER` is, use that one.