### PR TITLE
ocsp: search CA by key hash instead of ext key id

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5102,6 +5102,36 @@ Signer* GetCA(void* vp, byte* hash)
     return ret;
 }
 
+#if defined(HAVE_OCSP)
+Signer* GetCAByKeyHash(void* vp, const byte* keyHash)
+{
+    WOLFSSL_CERT_MANAGER* cm = (WOLFSSL_CERT_MANAGER*)vp;
+    Signer* ret = NULL;
+    Signer* signers;
+    int row;
+
+    if (cm == NULL || keyHash == NULL)
+        return NULL;
+
+    if (wc_LockMutex(&cm->caLock) != 0)
+        return NULL;
+
+    /* Unfortunately we need to look through the entire table */
+    for (row = 0; row < CA_TABLE_SIZE && ret == NULL; row++) {
+        for (signers = cm->caTable[row]; signers != NULL;
+                signers = signers->next) {
+            if (XMEMCMP(signers->subjectKeyHash, keyHash, KEYID_SIZE)
+                    == 0) {
+                ret = signers;
+                break;
+            }
+        }
+    }
+
+    wc_UnLockMutex(&cm->caLock);
+    return ret;
+}
+#endif
 #ifdef WOLFSSL_AKID_NAME
 Signer* GetCAByAKID(void* vp, const byte* issuer, word32 issuerSz,
         const byte* serial, word32 serialSz)

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -36770,7 +36770,7 @@ static int DecodeBasicOcspResponse(byte* source, word32* ioIndex,
         int sigValid = -1;
 
         #ifndef NO_SKID
-            ca = GetCA(cm, resp->single->issuerKeyHash);
+            ca = GetCAByKeyHash(cm, resp->single->issuerKeyHash);
         #else
             ca = GetCA(cm, resp->single->issuerHash);
         #endif
@@ -36911,7 +36911,7 @@ static int DecodeBasicOcspResponse(byte* source, word32* ioIndex,
 
         /* Response didn't have a certificate - lookup CA. */
     #ifndef NO_SKID
-        ca = GetCA(cm, resp->single->issuerKeyHash);
+        ca = GetCAByKeyHash(cm, resp->single->issuerKeyHash);
     #else
         ca = GetCA(cm, resp->single->issuerHash);
     #endif

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -6460,6 +6460,9 @@ WOLFSSL_LOCAL WC_RNG* WOLFSSL_RSA_GetRNG(WOLFSSL_RSA *rsa, WC_RNG **tmpRNG,
         WOLFSSL_LOCAL Signer* GetCAByAKID(void* vp, const byte* issuer,
                 word32 issuerSz, const byte* serial, word32 serialSz);
     #endif
+    #ifdef HAVE_OCSP
+        WOLFSSL_LOCAL Signer* GetCAByKeyHash(void* vp, const byte* keyHash);
+    #endif
     #if !defined(NO_SKID) && !defined(GetCAByName)
         WOLFSSL_LOCAL Signer* GetCAByName(void* cm, byte* hash);
     #endif


### PR DESCRIPTION
# Description

Make OCSP code search issuer certificate by key hash, not using the key hash to match the certificate extension key id.
While Key id must depend on the certificate's public key, it can be different than the hash of the key (see let's encrypt e6 certificate). 

Fixes zd#18073
Fixes zd#18590

