### PR TITLE
20240903-missing-WC_NO_ERR_TRACEs

### DIFF
--- a/linuxkm/lkcapi_glue.c
+++ b/linuxkm/lkcapi_glue.c
@@ -2025,7 +2025,7 @@ static int aes_xts_128_test(void)
     }
 
 #if defined(DEBUG_VECTOR_REGISTER_ACCESS) && defined(WC_C_DYNAMIC_FALLBACK)
-    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
     ret = wc_AesXtsEncrypt(aes, buf, p2, sizeof(p2), i2, sizeof(i2));
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
     if (ret != 0)
@@ -2068,7 +2068,7 @@ static int aes_xts_128_test(void)
     }
 
 #if defined(DEBUG_VECTOR_REGISTER_ACCESS) && defined(WC_C_DYNAMIC_FALLBACK)
-    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
     ret = wc_AesXtsEncrypt(aes, buf, p1, sizeof(p1), i1, sizeof(i1));
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
     if (ret != 0)
@@ -2090,7 +2090,7 @@ static int aes_xts_128_test(void)
     }
 
 #if defined(DEBUG_VECTOR_REGISTER_ACCESS) && defined(WC_C_DYNAMIC_FALLBACK)
-    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
     XMEMSET(cipher, 0, AES_XTS_128_TEST_BUF_SIZ);
     ret = wc_AesXtsEncrypt(aes, cipher, pp, sizeof(pp), i1, sizeof(i1));
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
@@ -2116,7 +2116,7 @@ static int aes_xts_128_test(void)
     }
 
 #if defined(DEBUG_VECTOR_REGISTER_ACCESS) && defined(WC_C_DYNAMIC_FALLBACK)
-    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
     XMEMSET(buf, 0, AES_XTS_128_TEST_BUF_SIZ);
     ret = wc_AesXtsDecrypt(aes, buf, cipher, sizeof(pp), i1, sizeof(i1));
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
@@ -2139,7 +2139,7 @@ static int aes_xts_128_test(void)
     }
 
 #if defined(DEBUG_VECTOR_REGISTER_ACCESS) && defined(WC_C_DYNAMIC_FALLBACK)
-    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
     XMEMSET(buf, 0, AES_XTS_128_TEST_BUF_SIZ);
     ret = wc_AesXtsDecrypt(aes, buf, c1, sizeof(c1), i1, sizeof(i1));
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);

--- a/src/bio.c
+++ b/src/bio.c
@@ -453,8 +453,9 @@ static int wolfSSL_BIO_BASE64_write(WOLFSSL_BIO* bio, const void* data,
         }
     }
     else {
-        if (Base64_Encode((const byte*)data, inLen, NULL, &sz) !=
-            LENGTH_ONLY_E) {
+        if (Base64_Encode((const byte*)data, inLen, NULL, &sz)
+              != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
+        {
             WOLFSSL_MSG("Error with base64 get length");
             return WOLFSSL_FATAL_ERROR;
         }

--- a/src/internal.c
+++ b/src/internal.c
@@ -40363,7 +40363,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
 
                         lenErrMask = 0 - (SECRET_LEN != args->sigSz);
                         args->lastErr = (ret & (~lenErrMask)) |
-                            (RSA_PAD_E & lenErrMask);
+                            (WC_NO_ERR_TRACE(RSA_PAD_E) & lenErrMask);
                         ret = 0;
                         break;
                     } /* rsa_kea */

--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -852,7 +852,7 @@ void wolfSSL_OCSP_BASICRESP_free(WOLFSSL_OCSP_BASICRESP* basicResponse)
 int wolfSSL_OCSP_basic_verify(WOLFSSL_OCSP_BASICRESP *bs,
     WOLF_STACK_OF(WOLFSSL_X509) *certs, WOLFSSL_X509_STORE *st, unsigned long flags)
 {
-    int         ret = WOLFSSL_FAILURE;
+    int         ret = WC_NO_ERR_TRACE(WOLFSSL_FAILURE);
 #ifdef WOLFSSL_SMALL_STACK
     DecodedCert *cert;
 #else

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2881,8 +2881,9 @@ static int wolfSSL_read_internal(WOLFSSL* ssl, void* data, int sz, int peek)
     /* make sure bidirectional TLS shutdown completes */
     if (ssl->error == WOLFSSL_ERROR_SYSCALL || ssl->options.shutdownDone) {
         /* ask the underlying transport the connection is closed */
-        if (ssl->CBIORecv(ssl, (char*)data, 0, ssl->IOCB_ReadCtx) ==
-                                            WOLFSSL_CBIO_ERR_CONN_CLOSE) {
+        if (ssl->CBIORecv(ssl, (char*)data, 0, ssl->IOCB_ReadCtx)
+            == WC_NO_ERR_TRACE(WOLFSSL_CBIO_ERR_CONN_CLOSE))
+        {
             ssl->options.isClosed = 1;
             ssl->error = WOLFSSL_ERROR_ZERO_RETURN;
         }
@@ -3400,7 +3401,7 @@ int wolfSSL_UseALPN(WOLFSSL* ssl, char *protocol_name_list,
     char    *list, *ptr, **token;
     word16  len;
     int     idx = 0;
-    int     ret = WOLFSSL_FAILURE;
+    int     ret = WC_NO_ERR_TRACE(WOLFSSL_FAILURE);
 
     WOLFSSL_ENTER("wolfSSL_UseALPN");
 
@@ -6209,7 +6210,7 @@ static int check_cert_key(DerBuffer* cert, DerBuffer* key, DerBuffer* altKey,
 #endif
     word32 size;
     byte*  buff;
-    int    ret = WOLFSSL_FAILURE;
+    int    ret = WC_NO_ERR_TRACE(WOLFSSL_FAILURE);
 
     WOLFSSL_ENTER("check_cert_key");
 
@@ -10466,7 +10467,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
     static int wolfSSL_ex_wrapper(WOLFSSL* ssl, HandShakeCallBack hsCb,
                                  TimeoutCallBack toCb, WOLFSSL_TIMEVAL timeout)
     {
-        int       ret        = WOLFSSL_FATAL_ERROR;
+        int       ret        = WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR);
         int       oldTimerOn = 0;   /* was timer already on */
         WOLFSSL_TIMEVAL startTime;
         WOLFSSL_TIMEVAL endTime;
@@ -12190,8 +12191,9 @@ int wolfSSL_get_peer_tmp_key(const WOLFSSL* ssl, WOLFSSL_EVP_PKEY** pkey)
         int sz;
 
         PRIVATE_KEY_UNLOCK();
-        if (wc_ecc_export_x963(ssl->peerEccKey, NULL, &derSz) !=
-                LENGTH_ONLY_E) {
+        if (wc_ecc_export_x963(ssl->peerEccKey, NULL, &derSz)
+              != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
+        {
             WOLFSSL_MSG("get ecc der size failed");
             PRIVATE_KEY_LOCK();
             return WOLFSSL_FAILURE;
@@ -15481,7 +15483,7 @@ int wolfSSL_ERR_GET_REASON(unsigned long err)
     /* Nginx looks for this error to know to stop parsing certificates.
      * Same for HAProxy. */
     if (err == ((ERR_LIB_PEM << 24) | PEM_R_NO_START_LINE) ||
-       ((err & 0xFFFFFFL) == -ASN_NO_PEM_HEADER) ||
+       ((err & 0xFFFFFFL) == -WC_NO_ERR_TRACE(ASN_NO_PEM_HEADER)) ||
        ((err & 0xFFFL) == PEM_R_NO_START_LINE ))
         return PEM_R_NO_START_LINE;
     if (err == ((ERR_LIB_SSL << 24) | -SSL_R_HTTP_REQUEST))

--- a/src/tls.c
+++ b/src/tls.c
@@ -1830,7 +1830,7 @@ static int TLSX_ALPN_ParseAndSet(WOLFSSL *ssl, const byte *input, word16 length,
                                  byte isRequest)
 {
     word16  size = 0, offset = 0, wlen;
-    int     r = BUFFER_ERROR;
+    int     r = WC_NO_ERR_TRACE(BUFFER_ERROR);
     const byte *s;
 
     if (OPAQUE16_LEN > length)

--- a/src/x509.c
+++ b/src/x509.c
@@ -7073,7 +7073,7 @@ int wolfSSL_X509_LOOKUP_load_file(WOLFSSL_X509_LOOKUP* lookup,
 {
 #if !defined(NO_FILESYSTEM) && \
     (defined(WOLFSSL_PEM_TO_DER) || defined(WOLFSSL_DER_TO_PEM))
-    int           ret = WOLFSSL_FAILURE;
+    int           ret = WC_NO_ERR_TRACE(WOLFSSL_FAILURE);
     XFILE         fp;
     long          sz;
     byte*         pem = NULL;

--- a/tests/api.c
+++ b/tests/api.c
@@ -2181,7 +2181,7 @@ static int test_wolfSSL_CTX_load_verify_locations(void)
     /* load ca cert */
 #ifdef NO_RSA
     ExpectIntEQ(wolfSSL_CTX_load_verify_locations(ctx, caCertFile, NULL),
-        WS_RETURN_CODE(ASN_UNKNOWN_OID_E,WOLFSSL_FAILURE));
+        WS_RETURN_CODE(WC_NO_ERR_TRACE(ASN_UNKNOWN_OID_E),WC_NO_ERR_TRACE(WOLFSSL_FAILURE)));
 #else /* Skip the following test without RSA certs. */
     ExpectIntEQ(wolfSSL_CTX_load_verify_locations(ctx, caCertFile, NULL),
         WOLFSSL_SUCCESS);
@@ -2741,7 +2741,7 @@ static int test_wolfSSL_CertManagerLoadCABuffer(void)
 #if defined(NO_WOLFSSL_CLIENT) && defined(NO_WOLFSSL_SERVER)
     ExpectIntEQ(ret, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR));
 #elif defined(NO_RSA)
-    ExpectIntEQ(ret, ASN_UNKNOWN_OID_E);
+    ExpectIntEQ(ret, WC_NO_ERR_TRACE(ASN_UNKNOWN_OID_E));
 #else
     ExpectIntEQ(ret, WOLFSSL_SUCCESS);
 #endif
@@ -2750,7 +2750,7 @@ static int test_wolfSSL_CertManagerLoadCABuffer(void)
 #if defined(NO_WOLFSSL_CLIENT) && defined(NO_WOLFSSL_SERVER)
     ExpectIntEQ(ret, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR));
 #elif defined(NO_RSA)
-    ExpectIntEQ(ret, ASN_UNKNOWN_OID_E);
+    ExpectIntEQ(ret, WC_NO_ERR_TRACE(ASN_UNKNOWN_OID_E));
 #elif !(WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS & WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY) && \
       !defined(NO_ASN_TIME)
     ExpectIntEQ(ret, WC_NO_ERR_TRACE(ASN_AFTER_DATE_E));
@@ -2774,7 +2774,7 @@ static int test_wolfSSL_CertManagerLoadCABuffer_ex(void)
 #if defined(NO_WOLFSSL_CLIENT) && defined(NO_WOLFSSL_SERVER)
     ExpectIntEQ(ret, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR));
 #elif defined(NO_RSA)
-    ExpectIntEQ(ret, ASN_UNKNOWN_OID_E);
+    ExpectIntEQ(ret, WC_NO_ERR_TRACE(ASN_UNKNOWN_OID_E));
 #else
     ExpectIntEQ(ret, WOLFSSL_SUCCESS);
 #endif
@@ -2784,7 +2784,7 @@ static int test_wolfSSL_CertManagerLoadCABuffer_ex(void)
 #if defined(NO_WOLFSSL_CLIENT) && defined(NO_WOLFSSL_SERVER)
     ExpectIntEQ(ret, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR));
 #elif defined(NO_RSA)
-    ExpectIntEQ(ret, ASN_UNKNOWN_OID_E);
+    ExpectIntEQ(ret, WC_NO_ERR_TRACE(ASN_UNKNOWN_OID_E));
 #elif !(WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS & WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY) && \
       !defined(NO_ASN_TIME) && defined(WOLFSSL_TRUST_PEER_CERT) && \
       defined(OPENSSL_COMPATIBLE_DEFAULTS)
@@ -13562,7 +13562,7 @@ static int test_override_x509(int preverify, WOLFSSL_X509_STORE_CTX* store)
 {
     EXPECT_DECLS;
 #ifndef OPENSSL_COMPATIBLE_DEFAULTS
-    ExpectIntEQ(store->error, ASN_VERSION_E);
+    ExpectIntEQ(store->error, WC_NO_ERR_TRACE(ASN_VERSION_E));
 #else
     ExpectIntEQ(store->error, 0);
 #endif
@@ -16569,7 +16569,7 @@ static int test_wc_Md5HmacSetKey(void)
 #if defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 5)
     ExpectIntEQ(ret, WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 #elif defined(HAVE_FIPS)
-    ExpectIntEQ(ret, HMAC_MIN_KEYLEN_E);
+    ExpectIntEQ(ret, WC_NO_ERR_TRACE(HMAC_MIN_KEYLEN_E));
 #else
     ExpectIntEQ(ret, 0);
 #endif
@@ -16620,7 +16620,7 @@ static int test_wc_ShaHmacSetKey(void)
 
     ret = wc_HmacSetKey(&hmac, WC_SHA, (byte*)keys[0], 0);
 #ifdef HAVE_FIPS
-    ExpectIntEQ(ret, HMAC_MIN_KEYLEN_E);
+    ExpectIntEQ(ret, WC_NO_ERR_TRACE(HMAC_MIN_KEYLEN_E));
 #else
     ExpectIntEQ(ret, 0);
 #endif
@@ -16668,7 +16668,7 @@ static int test_wc_Sha224HmacSetKey(void)
         (word32)XSTRLEN(keys[0])), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ret = wc_HmacSetKey(&hmac, WC_SHA224, (byte*)keys[0], 0);
 #ifdef HAVE_FIPS
-    ExpectIntEQ(ret, HMAC_MIN_KEYLEN_E);
+    ExpectIntEQ(ret, WC_NO_ERR_TRACE(HMAC_MIN_KEYLEN_E));
 #else
     ExpectIntEQ(ret, 0);
 #endif
@@ -16716,7 +16716,7 @@ static int test_wc_Sha256HmacSetKey(void)
         (word32)XSTRLEN(keys[0])), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ret = wc_HmacSetKey(&hmac, WC_SHA256, (byte*)keys[0], 0);
 #ifdef HAVE_FIPS
-    ExpectIntEQ(ret, HMAC_MIN_KEYLEN_E);
+    ExpectIntEQ(ret, WC_NO_ERR_TRACE(HMAC_MIN_KEYLEN_E));
 #else
     ExpectIntEQ(ret, 0);
 #endif
@@ -16765,7 +16765,7 @@ static int test_wc_Sha384HmacSetKey(void)
         (word32)XSTRLEN(keys[0])), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ret = wc_HmacSetKey(&hmac, WC_SHA384, (byte*)keys[0], 0);
 #ifdef HAVE_FIPS
-    ExpectIntEQ(ret, HMAC_MIN_KEYLEN_E);
+    ExpectIntEQ(ret, WC_NO_ERR_TRACE(HMAC_MIN_KEYLEN_E));
 #else
     ExpectIntEQ(ret, 0);
 #endif
@@ -18058,7 +18058,7 @@ static int test_wc_Sm4Gcm(void)
         GCM_NONCE_MIN_SZ, tag, SM4_BLOCK_SIZE, aad, sizeof(aad)), 0);
     ExpectIntEQ(wc_Sm4GcmDecrypt(&sm4, in, out, SM4_BLOCK_SIZE * 2, nonce,
         GCM_NONCE_MAX_SZ, tag, SM4_BLOCK_SIZE, aad, sizeof(aad)),
-        SM4_GCM_AUTH_E);
+        WC_NO_ERR_TRACE(SM4_GCM_AUTH_E));
 
     /* Check valid values of tag size - wc_Sm4GcmEncrypt/wc_Sm4GcmDecrypt. */
     for (i = WOLFSSL_MIN_AUTH_TAG_SZ; i < SM4_BLOCK_SIZE; i++) {
@@ -18234,7 +18234,7 @@ static int test_wc_Sm4Ccm(void)
     }
     ExpectIntEQ(wc_Sm4CcmDecrypt(&sm4, in, out, SM4_BLOCK_SIZE, nonce,
         CCM_NONCE_MIN_SZ, tag, SM4_BLOCK_SIZE, aad, sizeof(aad)),
-        SM4_CCM_AUTH_E);
+        WC_NO_ERR_TRACE(SM4_CCM_AUTH_E));
 
     /* Check invalid values of tag size - wc_Sm4CcmEncrypt/wc_Sm4CcmDecrypt. */
     for (i = 0; i < 4; i++) {
@@ -18849,15 +18849,15 @@ static int test_wc_Rc2SetKey(void)
     ExpectIntEQ(wc_Rc2SetKey(&rc2, NULL, (word32) sizeof(key40) / sizeof(byte),
         iv, 40), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     /* key size == 0 */
-    ExpectIntEQ(wc_Rc2SetKey(&rc2, key40, 0, iv, 40), WC_KEY_SIZE_E);
+    ExpectIntEQ(wc_Rc2SetKey(&rc2, key40, 0, iv, 40), WC_NO_ERR_TRACE(WC_KEY_SIZE_E));
     /* key size > 128 */
-    ExpectIntEQ(wc_Rc2SetKey(&rc2, key40, 129, iv, 40), WC_KEY_SIZE_E);
+    ExpectIntEQ(wc_Rc2SetKey(&rc2, key40, 129, iv, 40), WC_NO_ERR_TRACE(WC_KEY_SIZE_E));
     /* effective bits == 0 */
     ExpectIntEQ(wc_Rc2SetKey(&rc2, key40, (word32)sizeof(key40) / sizeof(byte),
-        iv, 0), WC_KEY_SIZE_E);
+        iv, 0), WC_NO_ERR_TRACE(WC_KEY_SIZE_E));
     /* effective bits > 1024 */
     ExpectIntEQ(wc_Rc2SetKey(&rc2, key40, (word32)sizeof(key40) / sizeof(byte),
-        iv, 1025), WC_KEY_SIZE_E);
+        iv, 1025), WC_NO_ERR_TRACE(WC_KEY_SIZE_E));
 #endif
     return EXPECT_RESULT();
 } /* END test_wc_Rc2SetKey */
@@ -19457,7 +19457,7 @@ static int test_wc_AesGcmEncryptDecrypt(void)
     #if (defined(HAVE_FIPS) && FIPS_VERSION_LE(2,0) && defined(WOLFSSL_ARMASM))
     ExpectIntEQ(wc_AesGcmDecrypt(&aes, dec, enc, sizeof(enc)/sizeof(byte), iv,
         sizeof(iv)/sizeof(byte), resultT, sizeof(resultT) + 1, a, sizeof(a)),
-        AES_GCM_AUTH_E);
+        WC_NO_ERR_TRACE(AES_GCM_AUTH_E));
     #else
     ExpectIntEQ(wc_AesGcmDecrypt(&aes, dec, enc, sizeof(enc)/sizeof(byte), iv,
         sizeof(iv)/sizeof(byte), resultT, sizeof(resultT) + 1, a, sizeof(a)),
@@ -32104,7 +32104,7 @@ static int test_wc_dilithium_sign(void)
         0);
     ExpectIntEQ(wc_dilithium_sign_msg(msg, 32, sig, &sigLen, key, &rng), 0);
 #ifdef WOLFSSL_DILITHIUM_CHECK_KEY
-    ExpectIntEQ(wc_dilithium_check_key(importKey), PUBLIC_KEY_E);
+    ExpectIntEQ(wc_dilithium_check_key(importKey), WC_NO_ERR_TRACE(PUBLIC_KEY_E));
 #endif
     wc_dilithium_free(importKey);
 
@@ -32556,14 +32556,14 @@ static int test_wc_dilithium_check_key(void)
             WC_NO_ERR_TRACE(BAD_FUNC_ARG));
         ExpectIntEQ(wc_dilithium_import_key(privCheckKey,
             privCheckKeyLen, pubCheckKey, pubCheckKeyLen, checkKey), 0);
-        ExpectIntEQ(wc_dilithium_check_key(checkKey), PUBLIC_KEY_E);
+        ExpectIntEQ(wc_dilithium_check_key(checkKey), WC_NO_ERR_TRACE(PUBLIC_KEY_E));
         pubCheckKey[0] ^= 0x80;
 
         /* Modify encoded t1. */
         pubCheckKey[48] ^= 0x80;
         ExpectIntEQ(wc_dilithium_import_key(privCheckKey,
             privCheckKeyLen,pubCheckKey, pubCheckKeyLen, checkKey), 0);
-        ExpectIntEQ(wc_dilithium_check_key(checkKey), PUBLIC_KEY_E);
+        ExpectIntEQ(wc_dilithium_check_key(checkKey), WC_NO_ERR_TRACE(PUBLIC_KEY_E));
         pubCheckKey[48] ^= 0x80;
     }
 
@@ -33443,7 +33443,7 @@ static int test_wc_dilithium_der(void)
     ExpectIntEQ(wc_Dilithium_PublicKeyToDer(NULL, der , DILITHIUM_MAX_DER_SIZE,
         0), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_Dilithium_PublicKeyToDer(key , der , 0                     ,
-        0), BUFFER_E    );
+        0), WC_NO_ERR_TRACE(BUFFER_E));
     /* Get length only. */
     ExpectIntEQ(wc_Dilithium_PublicKeyToDer(key , NULL, 0                     ,
         0), pubLen);
@@ -33481,7 +33481,7 @@ static int test_wc_dilithium_der(void)
     ExpectIntEQ(wc_Dilithium_KeyToDer(NULL, der , DILITHIUM_MAX_DER_SIZE),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_Dilithium_KeyToDer(key , der , 0                     ),
-        BUFFER_E    );
+        WC_NO_ERR_TRACE(BUFFER_E));
     /* Get length only. */
     ExpectIntEQ(wc_Dilithium_KeyToDer(key , NULL, DILITHIUM_MAX_DER_SIZE),
         keyDerLen);
@@ -45980,7 +45980,7 @@ static int test_wc_PKCS7_BER(void)
 #ifndef NO_RSA
 #ifdef WOLFSSL_SP_MATH
     ExpectIntEQ(wc_PKCS7_DecodeEnvelopedData(pkcs7, berContent,
-        sizeof(berContent), decoded, sizeof(decoded)), WC_KEY_SIZE_E);
+        sizeof(berContent), decoded, sizeof(decoded)), WC_NO_ERR_TRACE(WC_KEY_SIZE_E));
 #else
     ExpectIntGT(wc_PKCS7_DecodeEnvelopedData(pkcs7, berContent,
         sizeof(berContent), decoded, sizeof(decoded)), 0);
@@ -81510,7 +81510,7 @@ static void test_AEAD_limit_client(WOLFSSL* ssl)
     /* Connection should fail with a DECRYPT_ERROR */
     ret = wolfSSL_read(ssl, msgBuf, sizeof(msgBuf));
     AssertIntEQ(ret, WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR));
-    AssertIntEQ(wolfSSL_get_error(ssl, ret), DECRYPT_ERROR);
+    AssertIntEQ(wolfSSL_get_error(ssl, ret), WC_NO_ERR_TRACE(DECRYPT_ERROR));
 
     test_AEAD_done = 1;
 }
@@ -86009,7 +86009,7 @@ static int test_harden_no_secure_renegotiation(void)
     test_wolfSSL_client_server_nofail(&client_cbs, &server_cbs);
 
     ExpectIntEQ(client_cbs.return_code, TEST_FAIL);
-    ExpectIntEQ(client_cbs.last_err, SECURE_RENEGOTIATION_E);
+    ExpectIntEQ(client_cbs.last_err, WC_NO_ERR_TRACE(SECURE_RENEGOTIATION_E));
     ExpectIntEQ(server_cbs.return_code, TEST_FAIL);
     ExpectTrue(server_cbs.last_err == WC_NO_ERR_TRACE(SOCKET_ERROR_E) ||
                server_cbs.last_err == WC_NO_ERR_TRACE(FATAL_ERROR));
@@ -87363,7 +87363,7 @@ static int test_wolfSSL_dtls13_null_cipher(void)
         *ptr = 'H';
         /* bad messages should be ignored in DTLS */
         ExpectIntEQ(wolfSSL_read(ssl_s, buf, sizeof(buf)), -1);
-        ExpectIntEQ(ssl_s->error, WANT_READ);
+        ExpectIntEQ(ssl_s->error, WC_NO_ERR_TRACE(WANT_READ));
     }
 
     wolfSSL_free(ssl_c);
@@ -88040,7 +88040,7 @@ static void test_dtls_downgrade_scr_server_on_result(WOLFSSL* ssl)
     char msgBuf[sizeof(testMsg)];
     if (wolfSSL_is_server(ssl)) {
         AssertIntEQ(wolfSSL_Rehandshake(ssl), WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR));
-        AssertIntEQ(wolfSSL_get_error(ssl, -1), APP_DATA_READY);
+        AssertIntEQ(wolfSSL_get_error(ssl, -1), WC_NO_ERR_TRACE(APP_DATA_READY));
         AssertIntEQ(wolfSSL_read(ssl, msgBuf, sizeof(msgBuf)), sizeof(msgBuf));
         AssertIntEQ(wolfSSL_Rehandshake(ssl), WOLFSSL_SUCCESS);
         AssertIntEQ(wolfSSL_write(ssl, testMsg, sizeof(testMsg)),
@@ -88100,7 +88100,7 @@ static void test_dtls_downgrade_scr_on_result(WOLFSSL* ssl)
     char msgBuf[sizeof(testMsg)];
     if (wolfSSL_is_server(ssl)) {
         AssertIntEQ(wolfSSL_Rehandshake(ssl), WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR));
-        AssertIntEQ(wolfSSL_get_error(ssl, -1), APP_DATA_READY);
+        AssertIntEQ(wolfSSL_get_error(ssl, -1), WC_NO_ERR_TRACE(APP_DATA_READY));
         AssertIntEQ(wolfSSL_read(ssl, msgBuf, sizeof(msgBuf)), sizeof(msgBuf));
         AssertIntEQ(wolfSSL_Rehandshake(ssl), WOLFSSL_SUCCESS);
         AssertIntEQ(wolfSSL_write(ssl, testMsg, sizeof(testMsg)),
@@ -89171,7 +89171,7 @@ static int test_tls13_early_data(void)
 
             if (params[i].isUdp) {
                 ExpectIntEQ(wolfSSL_connect(ssl_c), -1);
-                ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), APP_DATA_READY);
+                ExpectIntEQ(wolfSSL_get_error(ssl_c, -1), WC_NO_ERR_TRACE(APP_DATA_READY));
 
                 /* Read server 0.5-RTT data */
                 ExpectIntEQ(wolfSSL_read(ssl_c, msgBuf, sizeof(msgBuf)), sizeof(msg4));
@@ -89490,7 +89490,7 @@ static int test_write_dup(void)
 
             ExpectNotNull(ssl_c2 = wolfSSL_write_dup(ssl_c));
             ExpectIntEQ(wolfSSL_write(ssl_c, hiWorld, sizeof(hiWorld)),
-                    WRITE_DUP_WRITE_E);
+                    WC_NO_ERR_TRACE(WRITE_DUP_WRITE_E));
             ExpectIntEQ(wolfSSL_write(ssl_c2, hiWorld, sizeof(hiWorld)),
                     sizeof(hiWorld));
 
@@ -89500,7 +89500,7 @@ static int test_write_dup(void)
                     sizeof(hiWorld));
 
             ExpectIntEQ(wolfSSL_read(ssl_c2, readData, sizeof(readData)),
-                    WRITE_DUP_READ_E);
+                    WC_NO_ERR_TRACE(WRITE_DUP_READ_E));
             ExpectIntEQ(wolfSSL_read(ssl_c, readData, sizeof(readData)),
                     sizeof(hiWorld));
 

--- a/tests/quic.c
+++ b/tests/quic.c
@@ -944,7 +944,7 @@ static int QuicConversation_start(QuicConversation *conv, const byte *data,
     else {
         ret = wolfSSL_connect(conv->client->ssl);
         if (ret != WOLFSSL_SUCCESS) {
-            AssertIntEQ(wolfSSL_get_error(conv->client->ssl, 0), SSL_ERROR_WANT_READ);
+            AssertIntEQ(wolfSSL_get_error(conv->client->ssl, 0), WC_NO_ERR_TRACE(SSL_ERROR_WANT_READ));
         }
         if (pwritten) *pwritten = 0;
     }
@@ -959,9 +959,9 @@ static int QuicConversation_step(QuicConversation *conv, int may_fail)
     if (!conv->started) {
         n = wolfSSL_connect(conv->client->ssl);
         if (n != WOLFSSL_SUCCESS
-            && wolfSSL_get_error(conv->client->ssl, 0) != SSL_ERROR_WANT_READ) {
+            && wolfSSL_get_error(conv->client->ssl, 0) != WC_NO_ERR_TRACE(SSL_ERROR_WANT_READ)) {
             if (may_fail) return 0;
-            AssertIntEQ(SSL_ERROR_WANT_READ, wolfSSL_get_error(conv->client->ssl, 0));
+            AssertIntEQ(WC_NO_ERR_TRACE(SSL_ERROR_WANT_READ), wolfSSL_get_error(conv->client->ssl, 0));
         }
         conv->started = 1;
     }
@@ -969,9 +969,9 @@ static int QuicConversation_step(QuicConversation *conv, int may_fail)
         QuicTestContext_forward(conv->server, conv->client, conv->rec_log, sizeof(conv->rec_log));
         n = wolfSSL_quic_read_write(conv->client->ssl);
         if (n != WOLFSSL_SUCCESS
-            && wolfSSL_get_error(conv->client->ssl, 0) != SSL_ERROR_WANT_READ) {
+            && wolfSSL_get_error(conv->client->ssl, 0) != WC_NO_ERR_TRACE(SSL_ERROR_WANT_READ)) {
             if (may_fail) return 0;
-            AssertIntEQ(SSL_ERROR_WANT_READ, wolfSSL_get_error(conv->client->ssl, 0));
+            AssertIntEQ(WC_NO_ERR_TRACE(SSL_ERROR_WANT_READ), wolfSSL_get_error(conv->client->ssl, 0));
         }
         return 1;
     }
@@ -985,9 +985,9 @@ static int QuicConversation_step(QuicConversation *conv, int may_fail)
                                         (int)(sizeof(conv->early_data) - conv->early_data_len),
                                         &written);
             if (n < 0) {
-                if (wolfSSL_get_error(conv->server->ssl, 0) != SSL_ERROR_WANT_READ) {
+                if (wolfSSL_get_error(conv->server->ssl, 0) != WC_NO_ERR_TRACE(SSL_ERROR_WANT_READ)) {
                     if (may_fail) return 0;
-                    AssertIntEQ(wolfSSL_get_error(conv->server->ssl, 0), SSL_ERROR_WANT_READ);
+                    AssertIntEQ(wolfSSL_get_error(conv->server->ssl, 0), WC_NO_ERR_TRACE(SSL_ERROR_WANT_READ));
                 }
             }
             else if (n > 0) {
@@ -1001,9 +1001,9 @@ static int QuicConversation_step(QuicConversation *conv, int may_fail)
         {
             n = wolfSSL_quic_read_write(conv->server->ssl);
             if (n != WOLFSSL_SUCCESS
-                && wolfSSL_get_error(conv->server->ssl, 0) != SSL_ERROR_WANT_READ) {
+                && wolfSSL_get_error(conv->server->ssl, 0) != WC_NO_ERR_TRACE(SSL_ERROR_WANT_READ)) {
                 if (may_fail) return 0;
-                AssertIntEQ(wolfSSL_get_error(conv->server->ssl, 0), SSL_ERROR_WANT_READ);
+                AssertIntEQ(wolfSSL_get_error(conv->server->ssl, 0), WC_NO_ERR_TRACE(SSL_ERROR_WANT_READ));
             }
         }
         return 1;
@@ -1065,7 +1065,7 @@ static int test_quic_client_hello(int verbose) {
     /* Without any QUIC transport params, this needs to fail */
     AssertTrue(wolfSSL_set_quic_transport_params(tctx.ssl, NULL, 0) == WOLFSSL_SUCCESS);
     AssertTrue(wolfSSL_quic_read_write(tctx.ssl) != 0);
-    AssertIntEQ(wolfSSL_get_error(tctx.ssl, 0), QUIC_TP_MISSING_E);
+    AssertIntEQ(wolfSSL_get_error(tctx.ssl, 0), WC_NO_ERR_TRACE(QUIC_TP_MISSING_E));
     QuicTestContext_free(&tctx);
 
     /* Set transport params, expect both extensions */
@@ -1075,7 +1075,7 @@ static int test_quic_client_hello(int verbose) {
                    "wolfssl.com", sizeof("wolfssl.com")-1);
 #endif
     AssertTrue(wolfSSL_connect(tctx.ssl) != 0);
-    AssertIntEQ(wolfSSL_get_error(tctx.ssl, 0), SSL_ERROR_WANT_READ);
+    AssertIntEQ(wolfSSL_get_error(tctx.ssl, 0), WC_NO_ERR_TRACE(SSL_ERROR_WANT_READ));
     check_quic_client_hello_tp(&tctx.output, 1, 1);
     QuicTestContext_free(&tctx);
 
@@ -1339,8 +1339,8 @@ static int test_quic_key_share(int verbose) {
                == WOLFSSL_SUCCESS);
     QuicConversation_init(&conv, &tclient, &tserver);
     QuicConversation_fail(&conv);
-    AssertIntEQ(wolfSSL_get_error(tserver.ssl, 0), SSL_ERROR_WANT_READ);
-    AssertIntEQ(wolfSSL_get_error(tclient.ssl, 0), BAD_KEY_SHARE_DATA);
+    AssertIntEQ(wolfSSL_get_error(tserver.ssl, 0), WC_NO_ERR_TRACE(SSL_ERROR_WANT_READ));
+    AssertIntEQ(wolfSSL_get_error(tclient.ssl, 0), WC_NO_ERR_TRACE(BAD_KEY_SHARE_DATA));
     QuicTestContext_free(&tclient);
     QuicTestContext_free(&tserver);
     printf("    test_quic_key_share: no match ok\n");

--- a/tests/srp.c
+++ b/tests/srp.c
@@ -126,11 +126,11 @@ static void test_SrpInit(void)
     Srp srp;
 
     /* invalid params */
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpInit(NULL, SRP_TYPE_TEST_DEFAULT,
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpInit(NULL, SRP_TYPE_TEST_DEFAULT,
                                          SRP_CLIENT_SIDE));
     /* // NOLINTBEGIN(clang-analyzer-optin.core.EnumCastOutOfRange) */
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpInit(&srp, (SrpType)255, SRP_CLIENT_SIDE));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpInit(&srp, SRP_TYPE_TEST_DEFAULT,
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpInit(&srp, (SrpType)255, SRP_CLIENT_SIDE));
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpInit(&srp, SRP_TYPE_TEST_DEFAULT,
                                          (SrpSide)255));
     /* // NOLINTEND(clang-analyzer-optin.core.EnumCastOutOfRange) */
 
@@ -147,8 +147,8 @@ static void test_SrpSetUsername(void)
     AssertIntEQ(0, wc_SrpInit(&srp, SRP_TYPE_TEST_DEFAULT, SRP_CLIENT_SIDE));
 
     /* invalid params */
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpSetUsername(NULL, username, usernameSz));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpSetUsername(&srp, NULL, usernameSz));
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpSetUsername(NULL, username, usernameSz));
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpSetUsername(&srp, NULL, usernameSz));
 
     /* success */
     AssertIntEQ(0, wc_SrpSetUsername(&srp, username, usernameSz));
@@ -165,7 +165,7 @@ static void test_SrpSetParams(void)
     AssertIntEQ(0, wc_SrpInit(&srp, SRP_TYPE_TEST_DEFAULT, SRP_CLIENT_SIDE));
 
     /* invalid call order */
-    AssertIntEQ(SRP_CALL_ORDER_E, wc_SrpSetParams(&srp,
+    AssertIntEQ(WC_NO_ERR_TRACE(SRP_CALL_ORDER_E), wc_SrpSetParams(&srp,
                                                   srp_N,    sizeof(srp_N),
                                                   srp_g,    sizeof(srp_g),
                                                   srp_salt, sizeof(srp_salt)));
@@ -174,19 +174,19 @@ static void test_SrpSetParams(void)
     AssertIntEQ(0, wc_SrpSetUsername(&srp, username, usernameSz));
 
     /* invalid params */
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpSetParams(NULL,
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpSetParams(NULL,
                                               srp_N,    sizeof(srp_N),
                                               srp_g,    sizeof(srp_g),
                                               srp_salt, sizeof(srp_salt)));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpSetParams(&srp,
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpSetParams(&srp,
                                               NULL,     sizeof(srp_N),
                                               srp_g,    sizeof(srp_g),
                                               srp_salt, sizeof(srp_salt)));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpSetParams(&srp,
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpSetParams(&srp,
                                               srp_N,    sizeof(srp_N),
                                               NULL,      sizeof(srp_g),
                                               srp_salt, sizeof(srp_salt)));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpSetParams(&srp,
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpSetParams(&srp,
                                               srp_N,    sizeof(srp_N),
                                               srp_g,    sizeof(srp_g),
                                               NULL,     sizeof(srp_salt)));
@@ -215,9 +215,9 @@ static void test_SrpSetPassword(void)
     AssertIntEQ(0, wc_SrpSetUsername(&srp, username, usernameSz));
 
     /* invalid call order */
-    AssertIntEQ(SRP_CALL_ORDER_E,
+    AssertIntEQ(WC_NO_ERR_TRACE(SRP_CALL_ORDER_E),
                 wc_SrpSetPassword(&srp, password, passwordSz));
-    AssertIntEQ(SRP_CALL_ORDER_E,
+    AssertIntEQ(WC_NO_ERR_TRACE(SRP_CALL_ORDER_E),
                 wc_SrpGetVerifier(&srp, v, &vSz));
 
     /* fix call order */
@@ -226,16 +226,16 @@ static void test_SrpSetPassword(void)
                                          srp_salt, sizeof(srp_salt)));
 
     /* invalid params */
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpSetPassword(NULL, password, passwordSz));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpSetPassword(&srp, NULL,     passwordSz));
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpSetPassword(NULL, password, passwordSz));
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpSetPassword(&srp, NULL,     passwordSz));
 
     /* success */
     AssertIntEQ(0, wc_SrpSetPassword(&srp, password, passwordSz));
 
     /* invalid params */
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpGetVerifier(NULL, v,    &vSz));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpGetVerifier(&srp, NULL, &vSz));
-    AssertIntEQ(BUFFER_E,     wc_SrpGetVerifier(&srp, v,    &vSz));
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpGetVerifier(NULL, v,    &vSz));
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpGetVerifier(&srp, NULL, &vSz));
+    AssertIntEQ(WC_NO_ERR_TRACE(BUFFER_E),     wc_SrpGetVerifier(&srp, v,    &vSz));
 
     /* success */
     vSz = sizeof(v);
@@ -244,14 +244,14 @@ static void test_SrpSetPassword(void)
     AssertIntEQ(0, XMEMCMP(srp_verifier, v, vSz));
 
     /* invalid params - client side srp */
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpSetVerifier(&srp, v, vSz));
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpSetVerifier(&srp, v, vSz));
 
     wc_SrpTerm(&srp);
     AssertIntEQ(0, wc_SrpInit(&srp, SRP_TYPE_SHA, SRP_SERVER_SIDE));
 
     /* invalid params */
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpSetVerifier(NULL, v,    vSz));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpSetVerifier(&srp, NULL, vSz));
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpSetVerifier(NULL, v,    vSz));
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpSetVerifier(&srp, NULL, vSz));
 
     /* success */
     AssertIntEQ(0, wc_SrpSetVerifier(&srp, v, vSz));
@@ -273,16 +273,16 @@ static void test_SrpGetPublic(void)
                                          srp_salt, sizeof(srp_salt)));
 
     /* invalid call order */
-    AssertIntEQ(SRP_CALL_ORDER_E, wc_SrpGetPublic(&srp, pub, &pubSz));
+    AssertIntEQ(WC_NO_ERR_TRACE(SRP_CALL_ORDER_E), wc_SrpGetPublic(&srp, pub, &pubSz));
 
     /* fix call order */
     AssertIntEQ(0, wc_SrpSetPassword(&srp, password, passwordSz));
 
     /* invalid params */
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpGetPublic(NULL, pub, &pubSz));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpGetPublic(&srp, NULL,   &pubSz));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpGetPublic(&srp, pub, NULL));
-    AssertIntEQ(BUFFER_E,     wc_SrpGetPublic(&srp, pub, &pubSz));
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpGetPublic(NULL, pub, &pubSz));
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpGetPublic(&srp, NULL,   &pubSz));
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpGetPublic(&srp, pub, NULL));
+    AssertIntEQ(WC_NO_ERR_TRACE(BUFFER_E),     wc_SrpGetPublic(&srp, pub, &pubSz));
 
     /* success */
     pubSz = sizeof(pub);
@@ -300,7 +300,7 @@ static void test_SrpGetPublic(void)
                                          srp_salt, sizeof(srp_salt)));
 
     /* invalid call order */
-    AssertIntEQ(SRP_CALL_ORDER_E, wc_SrpGetPublic(&srp, pub, &pubSz));
+    AssertIntEQ(WC_NO_ERR_TRACE(SRP_CALL_ORDER_E), wc_SrpGetPublic(&srp, pub, &pubSz));
 
     /* fix call order */
     AssertIntEQ(0, wc_SrpSetVerifier(&srp, srp_verifier, sizeof(srp_verifier)));
@@ -328,7 +328,7 @@ static void test_SrpComputeKey(void)
     AssertIntEQ(0, wc_SrpInit(&srv, SRP_TYPE_SHA, SRP_SERVER_SIDE));
 
     /* invalid call order */
-    AssertIntEQ(SRP_CALL_ORDER_E, wc_SrpComputeKey(&cli,
+    AssertIntEQ(WC_NO_ERR_TRACE(SRP_CALL_ORDER_E), wc_SrpComputeKey(&cli,
                                                    clientPubKey, clientPubKeySz,
                                                    serverPubKey, serverPubKeySz));
 
@@ -354,19 +354,19 @@ static void test_SrpComputeKey(void)
     AssertIntEQ(0, XMEMCMP(serverPubKey, srp_B, serverPubKeySz));
 
     /* invalid params */
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpComputeKey(NULL,
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpComputeKey(NULL,
                                                clientPubKey, clientPubKeySz,
                                                serverPubKey, serverPubKeySz));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpComputeKey(&cli,
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpComputeKey(&cli,
                                                NULL,         clientPubKeySz,
                                                serverPubKey, serverPubKeySz));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpComputeKey(&cli,
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpComputeKey(&cli,
                                                clientPubKey, 0,
                                                serverPubKey, serverPubKeySz));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpComputeKey(&cli,
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpComputeKey(&cli,
                                                clientPubKey, clientPubKeySz,
                                                NULL,         serverPubKeySz));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpComputeKey(&cli,
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpComputeKey(&cli,
                                                clientPubKey, clientPubKeySz,
                                                serverPubKey, 0));
 
@@ -432,16 +432,16 @@ static void test_SrpGetProofAndVerify(void)
 
     /* invalid params */
     serverProofSz = 0;
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpGetProof(NULL, clientProof,&clientProofSz));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpGetProof(&cli, NULL,       &clientProofSz));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpGetProof(&cli, clientProof,NULL));
-    AssertIntEQ(BUFFER_E,     wc_SrpGetProof(&srv, serverProof,&serverProofSz));
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpGetProof(NULL, clientProof,&clientProofSz));
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpGetProof(&cli, NULL,       &clientProofSz));
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG), wc_SrpGetProof(&cli, clientProof,NULL));
+    AssertIntEQ(WC_NO_ERR_TRACE(BUFFER_E),     wc_SrpGetProof(&srv, serverProof,&serverProofSz));
 
-    AssertIntEQ(BAD_FUNC_ARG,
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG),
                 wc_SrpVerifyPeersProof(NULL, clientProof, clientProofSz));
-    AssertIntEQ(BAD_FUNC_ARG,
+    AssertIntEQ(WC_NO_ERR_TRACE(BAD_FUNC_ARG),
                 wc_SrpVerifyPeersProof(&cli, NULL,        clientProofSz));
-    AssertIntEQ(BUFFER_E,
+    AssertIntEQ(WC_NO_ERR_TRACE(BUFFER_E),
                 wc_SrpVerifyPeersProof(&srv, serverProof, serverProofSz));
     serverProofSz = SRP_MAX_DIGEST_SIZE;
 

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -3671,7 +3671,7 @@ static void* benchmarks_do(void* args)
             #endif
 
                 if (wc_ecc_get_curve_size_from_id(curveId) !=
-                        ECC_BAD_ARG_E) {
+                        WC_NO_ERR_TRACE(ECC_BAD_ARG_E)) {
                     bench_ecc_curve(curveId);
                     if (csv_format != 1) {
                         printf("\n");

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -236,14 +236,6 @@ ECC Curve Sizes:
     #define RESTORE_VECTOR_REGISTERS() WC_DO_NOTHING
 #endif
 
-#if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
-    #define GEN_MEM_ERR MP_MEM
-#elif defined(USE_FAST_MATH)
-    #define GEN_MEM_ERR FP_MEM
-#else
-    #define GEN_MEM_ERR MP_MEM
-#endif
-
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
     !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_SILABS_SE_ACCEL) && \
     !defined(WOLFSSL_KCAPI_ECC) && !defined(WOLFSSL_SE050) && \
@@ -8204,12 +8196,12 @@ int ecc_mul2add(ecc_point* A, mp_int* kA,
   /* allocate memory */
   tA = (unsigned char*)XMALLOC(ECC_BUFSIZE, heap, DYNAMIC_TYPE_ECC_BUFFER);
   if (tA == NULL) {
-     return GEN_MEM_ERR;
+     return MP_MEM;
   }
   tB = (unsigned char*)XMALLOC(ECC_BUFSIZE, heap, DYNAMIC_TYPE_ECC_BUFFER);
   if (tB == NULL) {
      XFREE(tA, heap, DYNAMIC_TYPE_ECC_BUFFER);
-     return GEN_MEM_ERR;
+     return MP_MEM;
   }
 #endif
 
@@ -8218,7 +8210,7 @@ int ecc_mul2add(ecc_point* A, mp_int* kA,
   if (key == NULL) {
      XFREE(tB, heap, DYNAMIC_TYPE_ECC_BUFFER);
      XFREE(tA, heap, DYNAMIC_TYPE_ECC_BUFFER);
-     return GEN_MEM_ERR;
+     return MP_MEM;
   }
 #endif
 #ifdef WOLFSSL_SMALL_STACK
@@ -8230,7 +8222,7 @@ int ecc_mul2add(ecc_point* A, mp_int* kA,
   #ifdef WOLFSSL_SMALL_STACK_CACHE
      XFREE(key, heap, DYNAMIC_TYPE_ECC_BUFFER);
   #endif
-     return GEN_MEM_ERR;
+     return MP_MEM;
   }
 #endif
 #ifdef WOLFSSL_SMALL_STACK_CACHE
@@ -12471,7 +12463,7 @@ static int add_entry(int idx, ecc_point *g)
    /* allocate base and LUT */
    fp_cache[idx].g = wc_ecc_new_point();
    if (fp_cache[idx].g == NULL) {
-      return GEN_MEM_ERR;
+      return MP_MEM;
    }
 
    /* copy x and y */
@@ -12480,7 +12472,7 @@ static int add_entry(int idx, ecc_point *g)
        (mp_copy(g->z, fp_cache[idx].g->z) != MP_OKAY)) {
       wc_ecc_del_point(fp_cache[idx].g);
       fp_cache[idx].g = NULL;
-      return GEN_MEM_ERR;
+      return MP_MEM;
    }
 
    for (x = 0; x < (1U<<FP_LUT); x++) {
@@ -12493,7 +12485,7 @@ static int add_entry(int idx, ecc_point *g)
          wc_ecc_del_point(fp_cache[idx].g);
          fp_cache[idx].g         = NULL;
          fp_cache[idx].lru_count = 0;
-         return GEN_MEM_ERR;
+         return MP_MEM;
       }
    }
 
@@ -12529,7 +12521,7 @@ static int build_lut(int idx, mp_int* a, mp_int* modulus, mp_digit mp,
 
    err = mp_init(tmp);
    if (err != MP_OKAY) {
-       err = GEN_MEM_ERR;
+       err = MP_MEM;
        goto errout;
    }
 
@@ -12805,7 +12797,7 @@ static int accel_fp_mul(int idx, const mp_int* k, ecc_point *R, mp_int* a,
              if ((mp_copy(fp_cache[idx].LUT[z]->x, R->x) != MP_OKAY) ||
                  (mp_copy(fp_cache[idx].LUT[z]->y, R->y) != MP_OKAY) ||
                  (mp_copy(&fp_cache[idx].mu,       R->z) != MP_OKAY)) {
-                 err = GEN_MEM_ERR;
+                 err = MP_MEM;
                  break;
              }
              first = 0;
@@ -13069,7 +13061,7 @@ static int accel_fp_mul2add(int idx1, int idx2,
                  if ((mp_copy(fp_cache[idx1].LUT[zA]->x, R->x) != MP_OKAY) ||
                      (mp_copy(fp_cache[idx1].LUT[zA]->y, R->y) != MP_OKAY) ||
                      (mp_copy(&fp_cache[idx1].mu,        R->z) != MP_OKAY)) {
-                     err = GEN_MEM_ERR;
+                     err = MP_MEM;
                      break;
                  }
                     first = 0;
@@ -13084,7 +13076,7 @@ static int accel_fp_mul2add(int idx1, int idx2,
                  if ((mp_copy(fp_cache[idx2].LUT[zB]->x, R->x) != MP_OKAY) ||
                      (mp_copy(fp_cache[idx2].LUT[zB]->y, R->y) != MP_OKAY) ||
                      (mp_copy(&fp_cache[idx2].mu,        R->z) != MP_OKAY)) {
-                     err = GEN_MEM_ERR;
+                     err = MP_MEM;
                      break;
                  }
                     first = 0;

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -3835,8 +3835,9 @@ static int DH_param_check(WOLFSSL_DH* dh_key)
         dh_key->q != NULL)
     {
         if (ret == WOLFSSL_SUCCESS &&
-            wolfSSL_BN_mod_exp(num1, dh_key->g, dh_key->q, dh_key->p, ctx) ==
-            WOLFSSL_FAILURE) {
+            wolfSSL_BN_mod_exp(num1, dh_key->g, dh_key->q, dh_key->p, ctx)
+               == WC_NO_ERR_TRACE(WOLFSSL_FAILURE))
+        {
             WOLFSSL_MSG("BN_mod_exp failed");
             ret = WOLFSSL_FAILURE;
         }
@@ -4561,7 +4562,7 @@ int wolfSSL_EVP_DigestSignFinal(WOLFSSL_EVP_MD_CTX *ctx, unsigned char *sig,
 {
     unsigned char digest[WC_MAX_DIGEST_SIZE];
     unsigned int  hashLen;
-    int           ret = WOLFSSL_FAILURE;
+    int           ret = WC_NO_ERR_TRACE(WOLFSSL_FAILURE);
 
     WOLFSSL_ENTER("EVP_DigestSignFinal");
 
@@ -11345,7 +11346,7 @@ static int PrintPubKeyRSA(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
     int indent, int bitlen, ASN1_PCTX* pctx)
 {
     byte   buff[8] = { 0 };
-    int    res = WOLFSSL_FAILURE;
+    int    res = WC_NO_ERR_TRACE(WOLFSSL_FAILURE);
     word32 inOutIdx = 0;
     word32 nSz;             /* size of modulus */
     word32 eSz;             /* size of public exponent */
@@ -11697,7 +11698,7 @@ static int PrintPubKeyDSA(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
 
     byte    buff[8] = { 0 };
     int     length;
-    int     res = WOLFSSL_FAILURE;
+    int     res = WC_NO_ERR_TRACE(WOLFSSL_FAILURE);
     word32  inOutIdx = 0;
     word32  oid;
     byte    tagFound;
@@ -11915,7 +11916,7 @@ static int PrintPubKeyDH(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
 {
 
     byte    buff[8] = { 0 };
-    int     res = WOLFSSL_FAILURE;
+    int     res = WC_NO_ERR_TRACE(WOLFSSL_FAILURE);
     word32  length;
     word32  inOutIdx;
     word32  oid;

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -321,7 +321,7 @@ int fp_mul(fp_int *A, fp_int *B, fp_int *C)
                 goto clean; /* success */
                 break;
 
-            case WC_HW_WAIT_E: /* MP_HW_BUSY math HW busy, fall back */
+            case WC_NO_ERR_TRACE(WC_HW_WAIT_E): /* MP_HW_BUSY math HW busy, fall back */
             case MP_HW_FALLBACK:    /* forced fallback from HW to SW */
             case MP_HW_VALIDATION_ACTIVE: /* use SW to compare to HW */
                 /* fall back to software, below */
@@ -3125,9 +3125,9 @@ int fp_exptmod(fp_int * G, fp_int * X, fp_int * P, fp_int * Y)
             return retHW;
             break;
 
-         case WC_HW_WAIT_E: /* MP_HW_BUSY math HW busy, fall back */
+         case WC_NO_ERR_TRACE(WC_HW_WAIT_E): /* MP_HW_BUSY math HW busy, fall back */
          case MP_HW_FALLBACK:    /* forced fallback from HW to SW */
-         case MP_HW_VALIDATION_ACTIVE: /* use SW to compare to HW */
+         case WC_NO_ERR_TRACE(MP_HW_VALIDATION_ACTIVE): /* use SW to compare to HW */
             /* use software calc */
             break;
 
@@ -3227,7 +3227,7 @@ int fp_exptmod_ex(fp_int * G, fp_int * X, int digits, fp_int * P, fp_int * Y)
          return retHW;
          break;
 
-      case WC_HW_WAIT_E: /* MP_HW_BUSY math HW busy, fall back */
+      case WC_NO_ERR_TRACE(WC_HW_WAIT_E): /* MP_HW_BUSY math HW busy, fall back */
       case MP_HW_FALLBACK:    /* forced fallback from HW to SW */
       case MP_HW_VALIDATION_ACTIVE: /* use SW to compare to HW */
          /* use software calc */
@@ -3328,7 +3328,7 @@ int fp_exptmod_nct(fp_int * G, fp_int * X, fp_int * P, fp_int * Y)
          return retHW;
          break;
 
-      case WC_HW_WAIT_E: /* MP_HW_BUSY math HW busy, fall back */
+      case WC_NO_ERR_TRACE(WC_HW_WAIT_E): /* MP_HW_BUSY math HW busy, fall back */
       case MP_HW_FALLBACK:    /* forced fallback from HW to SW */
       case MP_HW_VALIDATION_ACTIVE: /* use SW to compare to HW */
          /* use software calc */
@@ -3440,7 +3440,7 @@ int fp_sqr(fp_int *A, fp_int *B)
                 goto clean; /* success */
                 break;
 
-            case WC_HW_WAIT_E: /* MP_HW_BUSY math HW busy, fall back */
+            case WC_NO_ERR_TRACE(WC_HW_WAIT_E): /* MP_HW_BUSY math HW busy, fall back */
             case MP_HW_FALLBACK:    /* forced fallback from HW to SW */
             case MP_HW_VALIDATION_ACTIVE: /* use SW to compare to HW */
                 /* fall back to software, below */
@@ -4698,7 +4698,7 @@ int mp_mulmod (mp_int * a, mp_int * b, mp_int * c, mp_int * d)
          /* successfully computed in HW */
          break;
 
-      case WC_HW_WAIT_E: /* MP_HW_BUSY math HW busy, fall back */
+      case WC_NO_ERR_TRACE(WC_HW_WAIT_E): /* MP_HW_BUSY math HW busy, fall back */
       case MP_HW_FALLBACK:    /* forced fallback from HW to SW */
       case MP_HW_VALIDATION_ACTIVE: /* use SW to compare to HW */
          /* use software calc */

--- a/wolfcrypt/src/wc_pkcs11.c
+++ b/wolfcrypt/src/wc_pkcs11.c
@@ -1413,7 +1413,7 @@ int wc_Pkcs11StoreKey(Pkcs11Token* token, int type, int clear, void* key)
     #ifdef HAVE_ECC
             case PKCS11_KEY_TYPE_EC: {
                 ecc_key* eccKey = (ecc_key*)key;
-                int      ret2 = NOT_COMPILED_IN;
+                int      ret2 = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
 
         #ifndef NO_PKCS11_ECDH
                 if ((eccKey->flags & WC_ECC_FLAG_DEC_SIGN) == 0) {

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -2617,8 +2617,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t error_test(void)
      * The string is that error strings are not available.
      */
     WOLFSSL_ENTER("error_test NO_ERROR_STRINGS");
-    errStr = wc_GetErrorString(OPEN_RAN_E);
-    wc_ErrorString(OPEN_RAN_E, out);
+    errStr = wc_GetErrorString(WC_NO_ERR_TRACE(OPEN_RAN_E));
+    wc_ErrorString(WC_NO_ERR_TRACE(OPEN_RAN_E), out);
     if (XSTRCMP(errStr, unknownStr) != 0)
         return WC_TEST_RET_ENC_NC;
     if (XSTRCMP(out, unknownStr) != 0)
@@ -10433,7 +10433,7 @@ static wc_test_ret_t aes_xts_128_test(void)
 
 #if defined(DEBUG_VECTOR_REGISTER_ACCESS_AESXTS) && \
         defined(WC_C_DYNAMIC_FALLBACK)
-    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
     ret = wc_AesXtsEncrypt(aes, buf, p2, sizeof(p2), i2, sizeof(i2));
 #if defined(WOLFSSL_ASYNC_CRYPT)
     ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
@@ -10487,7 +10487,7 @@ static wc_test_ret_t aes_xts_128_test(void)
 
 #if defined(DEBUG_VECTOR_REGISTER_ACCESS_AESXTS) && \
         defined(WC_C_DYNAMIC_FALLBACK)
-    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
     ret = wc_AesXtsEncrypt(aes, buf, p1, sizeof(p1), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
     ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
@@ -10538,7 +10538,7 @@ static wc_test_ret_t aes_xts_128_test(void)
 
 #if defined(DEBUG_VECTOR_REGISTER_ACCESS_AESXTS) && \
         defined(WC_C_DYNAMIC_FALLBACK)
-    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
     XMEMSET(cipher, 0, sizeof(cipher));
     ret = wc_AesXtsEncrypt(aes, cipher, pp, sizeof(pp), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
@@ -10590,7 +10590,7 @@ static wc_test_ret_t aes_xts_128_test(void)
 
 #if defined(DEBUG_VECTOR_REGISTER_ACCESS_AESXTS) && \
         defined(WC_C_DYNAMIC_FALLBACK)
-    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
     XMEMSET(buf, 0, sizeof(buf));
     ret = wc_AesXtsDecrypt(aes, buf, cipher, sizeof(pp), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
@@ -10643,7 +10643,7 @@ static wc_test_ret_t aes_xts_128_test(void)
 
 #if defined(DEBUG_VECTOR_REGISTER_ACCESS_AESXTS) && \
         defined(WC_C_DYNAMIC_FALLBACK)
-    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
     XMEMSET(buf, 0, sizeof(buf));
     ret = wc_AesXtsDecrypt(aes, buf, c1, sizeof(c1), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
@@ -11133,7 +11133,7 @@ static wc_test_ret_t aes_xts_192_test(void)
 
 #if defined(DEBUG_VECTOR_REGISTER_ACCESS_AESXTS) && \
         defined(WC_C_DYNAMIC_FALLBACK)
-    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
     ret = wc_AesXtsEncrypt(aes, buf, p2, sizeof(p2), i2, sizeof(i2));
 #if defined(WOLFSSL_ASYNC_CRYPT)
     ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
@@ -11187,7 +11187,7 @@ static wc_test_ret_t aes_xts_192_test(void)
 
 #if defined(DEBUG_VECTOR_REGISTER_ACCESS_AESXTS) && \
         defined(WC_C_DYNAMIC_FALLBACK)
-    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
     ret = wc_AesXtsEncrypt(aes, buf, p1, sizeof(p1), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
     ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
@@ -11238,7 +11238,7 @@ static wc_test_ret_t aes_xts_192_test(void)
 
 #if defined(DEBUG_VECTOR_REGISTER_ACCESS_AESXTS) && \
         defined(WC_C_DYNAMIC_FALLBACK)
-    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
     XMEMSET(cipher, 0, sizeof(cipher));
     ret = wc_AesXtsEncrypt(aes, cipher, pp, sizeof(pp), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
@@ -11290,7 +11290,7 @@ static wc_test_ret_t aes_xts_192_test(void)
 
 #if defined(DEBUG_VECTOR_REGISTER_ACCESS_AESXTS) && \
         defined(WC_C_DYNAMIC_FALLBACK)
-    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
     XMEMSET(buf, 0, sizeof(buf));
     ret = wc_AesXtsDecrypt(aes, buf, cipher, sizeof(pp), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
@@ -11343,7 +11343,7 @@ static wc_test_ret_t aes_xts_192_test(void)
 
 #if defined(DEBUG_VECTOR_REGISTER_ACCESS_AESXTS) && \
         defined(WC_C_DYNAMIC_FALLBACK)
-    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
     XMEMSET(buf, 0, sizeof(buf));
     ret = wc_AesXtsDecrypt(aes, buf, c1, sizeof(c1), i1, sizeof(i1));
 #if defined(WOLFSSL_ASYNC_CRYPT)
@@ -12640,12 +12640,12 @@ static wc_test_ret_t aesecb_test(void)
 
 #if defined(DEBUG_VECTOR_REGISTER_ACCESS) && defined(WC_C_DYNAMIC_FALLBACK)
         XMEMSET(cipher, 0, AES_BLOCK_SIZE);
-        WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+        WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
         ret = wc_AesSetKey(enc, niKey, sizeof(niKey), cipher, AES_ENCRYPTION);
         WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
         if (ret != 0)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
-        WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+        WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
         ret = wc_AesEcbEncrypt(enc, cipher, niPlain, AES_BLOCK_SIZE);
         WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
         if (ret != 0)
@@ -12662,7 +12662,7 @@ static wc_test_ret_t aesecb_test(void)
 
         XMEMSET(cipher, 0, AES_BLOCK_SIZE);
         ret = wc_AesSetKey(enc, niKey, sizeof(niKey), cipher, AES_ENCRYPTION);
-        WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+        WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
         ret = wc_AesEcbEncrypt(enc, cipher, niPlain, AES_BLOCK_SIZE);
         WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
         if (ret != 0)
@@ -12683,12 +12683,12 @@ static wc_test_ret_t aesecb_test(void)
 
 #if defined(DEBUG_VECTOR_REGISTER_ACCESS) && defined(WC_C_DYNAMIC_FALLBACK)
         XMEMSET(plain, 0, AES_BLOCK_SIZE);
-        WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+        WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
         ret = wc_AesSetKey(dec, niKey, sizeof(niKey), plain, AES_DECRYPTION);
         WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
         if (ret != 0)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
-        WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+        WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
         ret = wc_AesEcbDecrypt(dec, plain, niCipher, AES_BLOCK_SIZE);
         WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
         if (ret != 0)
@@ -12707,7 +12707,7 @@ static wc_test_ret_t aesecb_test(void)
         ret = wc_AesSetKey(dec, niKey, sizeof(niKey), plain, AES_DECRYPTION);
         if (ret != 0)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
-        WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+        WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
         ret = wc_AesEcbDecrypt(dec, plain, niCipher, AES_BLOCK_SIZE);
         WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
         if (ret != 0)
@@ -13363,13 +13363,13 @@ static wc_test_ret_t aesctr_test(Aes* enc, Aes* dec, byte* cipher, byte* plain)
             }
         }
 
-        WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+        WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
         ret = wc_AesCtrEncrypt(enc, cipher, testVec[i].plain, testVec[i].len);
         WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
         if (ret != 0) {
             ERROR_OUT(WC_TEST_RET_ENC_I(i), out);
         }
-        WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+        WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
         ret = wc_AesCtrEncrypt(dec, plain, cipher, testVec[i].len);
         WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
         if (ret != 0) {
@@ -13388,7 +13388,7 @@ static wc_test_ret_t aesctr_test(Aes* enc, Aes* dec, byte* cipher, byte* plain)
 
     for (i = 0; i < AES_CTR_TEST_LEN; i++) {
         if (testVec[i].key != NULL) {
-            WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+            WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
             ret = wc_AesSetKeyDirect(enc, testVec[i].key, testVec[i].keySz,
                 testVec[i].iv, AES_ENCRYPTION);
             WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
@@ -13396,7 +13396,7 @@ static wc_test_ret_t aesctr_test(Aes* enc, Aes* dec, byte* cipher, byte* plain)
                 ERROR_OUT(WC_TEST_RET_ENC_I(i), out);
             }
             /* Ctr only uses encrypt, even on key setup */
-            WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+            WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
             ret = wc_AesSetKeyDirect(dec, testVec[i].key, testVec[i].keySz,
                 testVec[i].iv, AES_ENCRYPTION);
             WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
@@ -13750,7 +13750,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes_test(void)
 #if defined(DEBUG_VECTOR_REGISTER_ACCESS) && defined(WC_C_DYNAMIC_FALLBACK)
         /* Iterate from one AES_BLOCK_SIZE of bigMsg through the whole
          * message by AES_BLOCK_SIZE for each size of AES key. */
-        WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+        WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
         for (keySz = 16; keySz <= 32; keySz += 8) {
             for (msgSz = AES_BLOCK_SIZE;
                  msgSz <= sizeof(bigMsg);
@@ -14320,7 +14320,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes256_test(void)
 #endif
 
     XMEMSET(cipher, 0, AES_BLOCK_SIZE);
-    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
     ret = wc_AesCbcEncrypt(enc, cipher, msg, (int) sizeof(msg));
 #if defined(WOLFSSL_ASYNC_CRYPT)
     ret = wc_AsyncWait(ret, &enc->asyncDev, WC_ASYNC_FLAG_NONE);
@@ -14330,7 +14330,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes256_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 #ifdef HAVE_AES_DECRYPT
     XMEMSET(plain, 0, AES_BLOCK_SIZE);
-    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
     ret = wc_AesCbcDecrypt(dec, plain, cipher, (int) sizeof(cipher));
 #if defined(WOLFSSL_ASYNC_CRYPT)
     ret = wc_AsyncWait(ret, &dec->asyncDev, WC_ASYNC_FLAG_NONE);
@@ -14347,13 +14347,13 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes256_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 #endif
 
-    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
     ret = wc_AesSetKey(enc, key, keySz, iv, AES_ENCRYPTION);
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
     if (ret != 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 #ifdef HAVE_AES_DECRYPT
-    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
     ret = wc_AesSetKey(dec, key, keySz, iv, AES_DECRYPTION);
     WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(0);
     if (ret != 0)
@@ -14479,7 +14479,7 @@ static wc_test_ret_t aesgcm_default_test_helper(byte* key, int keySz, byte* iv, 
         ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
 #if defined(DEBUG_VECTOR_REGISTER_ACCESS) && defined(WC_C_DYNAMIC_FALLBACK)
-    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
     ret = wc_AesGcmEncrypt(enc, resultC, plain, plainSz, iv, ivSz,
                                      resultT, tagSz, aad, aadSz);
 #if defined(WOLFSSL_ASYNC_CRYPT)
@@ -14514,7 +14514,7 @@ static wc_test_ret_t aesgcm_default_test_helper(byte* key, int keySz, byte* iv, 
     }
 
 #if defined(DEBUG_VECTOR_REGISTER_ACCESS) && defined(WC_C_DYNAMIC_FALLBACK)
-    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(SYSLIB_FAILED_E);
+    WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(WC_NO_ERR_TRACE(SYSLIB_FAILED_E));
     ret = wc_AesGcmDecrypt(dec, resultP, resultC, cipherSz,
                    iv, ivSz, resultT, tagSz, aad, aadSz);
 #if defined(WOLFSSL_ASYNC_CRYPT)


### PR DESCRIPTION
backfill more missing `WC_NO_ERR_TRACE()`s on error code operands, and refactor away the obsolete `GEN_MEM_ERR` macro mechanism in `wolfcrypt/src/ecc.c`.

tested with `wolfssl-multi-test.sh ... super-quick-check all-gcc-c99-backtrace linuxkm-legacy-5.10-insmod wolfsm-all-gcc-latest`
