### PR TITLE
Modernized memory fence support for C11 and clang

### DIFF
--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -1266,8 +1266,13 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
 #ifndef WOLFSSL_NO_FENCE
     #ifdef XFENCE
         /* use user-supplied XFENCE definition. */
-    #elif defined(__GNUC__) && (__GNUC__ >= 4)
+    #elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+        #include <stdatomic.h>
+        #define XFENCE() atomic_thread_fence(__ATOMIC_SEQ_CST)
+    #elif defined(__GNUC__) && (__GNUC__ >= 4) && (__GNUC__ < 5)
         #define XFENCE() __sync_synchronize()
+    #elif (defined(__GNUC__) && (__GNUC__ >= 5)) || defined (__clang__)
+        #define XFENCE() __atomic_thread_fence(__ATOMIC_SEQ_CST)
     #elif defined (__i386__) || defined(__x86_64__)
         #define XFENCE() XASM_VOLATILE("lfence")
     #elif (defined (__arm__) && (__ARM_ARCH > 6)) || defined(__aarch64__)


### PR DESCRIPTION
# Description

This change adds detection for C11 support for stdatomic.h and changes the intrinsic fence command for GCC >=5 and clang to use __atomic_thread_fence.  

Fixes zd18463

# Testing

Testing was limited to MacOS aarch64 with clang and QNX 7.0.0 x86_64 (gcc-based).  Reaching out for more testing targets.  

# Checklist

 - [N/A] added tests
 - [N/A] updated/added doxygen
 - [N/A] updated appropriate READMEs
 - [N/A] Updated manual and documentation
