### PR TITLE
Ada binding: correct Alire manifest and fix build

### DIFF
--- a/wrapper/Ada/alire.toml
+++ b/wrapper/Ada/alire.toml
@@ -1,8 +1,8 @@
 name = "wolfssl"
 description = "WolfSSL encryption library and its Ada bindings"
-version = "5.7.0"
+version = "5.7.2"
 
-authors = ["Fernando Oleo Blanco"]
+authors = ["WolfSSL Team <support@wolfssl.com>"]
 maintainers = ["Fernando Oleo Blanco <irvise@irvise.xyz>"]
 maintainers-logins = ["Irvise"]
 licenses = "GPL-2.0-only"

--- a/wrapper/Ada/user_settings.h
+++ b/wrapper/Ada/user_settings.h
@@ -34,6 +34,8 @@
 extern "C" {
 #endif
 
+#include <stdint.h>
+
 /* Usually comes from configure -> config.h */
 #define HAVE_SYS_TIME_H
 


### PR DESCRIPTION
# Description

This is a minor fix to enable the correct compilation of WolfSSL with the Ada wrapper (`wolfio.c` needs `stdint.h`) and fix Alire's authorship :)