### PR TITLE
20240904-fix-test_wolfSSL_EVP_sm3

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -83432,7 +83432,7 @@ static int test_wolfSSL_EVP_sm3(void)
     ExpectTrue(mdCtx != NULL);
 
     /* Invalid Parameters */
-    ExpectIntEQ(EVP_DigestInit(NULL, md), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+    ExpectIntEQ(EVP_DigestInit(NULL, md), WC_NO_ERR_TRACE(WOLFSSL_FAILURE));
     /* Valid Parameters */
     ExpectIntEQ(EVP_DigestInit(mdCtx, md), WOLFSSL_SUCCESS);
 


### PR DESCRIPTION
`tests/api.c`: fix expected retval from `EVP_DigestInit()` in `test_wolfSSL_EVP_sm3()` -- before 2c9a3c5c1c, `EVP_DigestInit()` incorrectly returned `BAD_FUNC_ARG` when passed a null `ctx`.

tested with `wolfssl-multi-test.sh ... wolfsm-all-gcc-latest wolfsm-all-clang-tidy wolfsm-all-sanitizer wolfsm-all-cross-aarch64-armasm-unittest-sanitizer`
