### PR TITLE
Add option to skip all tests requiring an internet connection

### DIFF
--- a/scripts/external.test
+++ b/scripts/external.test
@@ -15,12 +15,7 @@ if ! ./examples/client/client -V | grep -q 3; then
     exit 77
 fi
 
-# These tests do not run by default, we will call these opt in. There are
-# additional default tests that require network connection, those are
-# opt out.
-# Not defining WOLFSSL_EXTERNAL_TEST runs only opt out.
-# Defining WOLFSSL_EXTERNAL_TEST!=0 runs opt out and opt in.
-# Defining WOLFSSL_EXTERNAL_TEST=0  does not run opt in or opt out.
+# cloudflare seems to change CAs quickly, disabled by default
 if ! test -n "$WOLFSSL_EXTERNAL_TEST"; then
     echo "WOLFSSL_EXTERNAL_TEST not set, won't run"
     exit 77
@@ -30,7 +25,7 @@ if test "$WOLFSSL_EXTERNAL_TEST" == "0"; then
     exit 77
 fi
 
-# cloudflare seems to change CAs quickly, disabled by default
+
 BUILD_FLAGS="$(./examples/client/client '-#')"
 if echo "$BUILD_FLAGS" | fgrep -q -e ' -DWOLFSSL_SNIFFER '; then
     echo 'skipping WOLFSSL_EXTERNAL_TEST because -DWOLFSSL_SNIFFER configuration of build is incompatible.'

--- a/scripts/external.test
+++ b/scripts/external.test
@@ -15,25 +15,34 @@ if ! ./examples/client/client -V | grep -q 3; then
     exit 77
 fi
 
-# cloudflare seems to change CAs quickly, disabled by default
-if test -n "$WOLFSSL_EXTERNAL_TEST"; then
-
-    BUILD_FLAGS="$(./examples/client/client '-#')"
-    if echo "$BUILD_FLAGS" | fgrep -q -e ' -DWOLFSSL_SNIFFER '; then
-        echo 'skipping WOLFSSL_EXTERNAL_TEST because -DWOLFSSL_SNIFFER configuration of build is incompatible.'
-        exit 77
-    fi
-
-    if echo "$BUILD_FLAGS" | fgrep -v -q -e ' -DHAVE_ECC '; then
-        echo 'skipping WOLFSSL_EXTERNAL_TEST because -UHAVE_ECC configuration of build is incompatible.'
-        exit 77
-    fi
-
-    echo "WOLFSSL_EXTERNAL_TEST set, running test..."
-else
-    echo "WOLFSSL_EXTERNAL_TEST NOT set, won't run"
+# These tests do not run by default, we will call these opt in. There are
+# additional default tests that require network connection, those are
+# opt out.
+# Not defining WOLFSSL_EXTERNAL_TEST runs only opt out.
+# Defining WOLFSSL_EXTERNAL_TEST!=0 runs opt out and opt in.
+# Defining WOLFSSL_EXTERNAL_TEST=0  does not run opt in or opt out.
+if [[ ! -v WOLFSSL_EXTERNAL_TEST ]]; then
+    echo "WOLFSSL_EXTERNAL_TEST not set, won't run"
     exit 77
 fi
+if [[ "$WOLFSSL_EXTERNAL_TEST" == "0" ]]; then
+    echo "WOLFSSL_EXTERNAL_TEST is defined to zero, won't run"
+    exit 77
+fi
+
+# cloudflare seems to change CAs quickly, disabled by default
+BUILD_FLAGS="$(./examples/client/client '-#')"
+if echo "$BUILD_FLAGS" | fgrep -q -e ' -DWOLFSSL_SNIFFER '; then
+    echo 'skipping WOLFSSL_EXTERNAL_TEST because -DWOLFSSL_SNIFFER configuration of build is incompatible.'
+    exit 77
+fi
+
+if echo "$BUILD_FLAGS" | fgrep -v -q -e ' -DHAVE_ECC '; then
+    echo 'skipping WOLFSSL_EXTERNAL_TEST because -UHAVE_ECC configuration of build is incompatible.'
+    exit 77
+fi
+
+echo "WOLFSSL_EXTERNAL_TEST set, running test..."
 
 # is our desired server there?
 "${SCRIPT_DIR}"/ping.test $server 2

--- a/scripts/external.test
+++ b/scripts/external.test
@@ -21,11 +21,11 @@ fi
 # Not defining WOLFSSL_EXTERNAL_TEST runs only opt out.
 # Defining WOLFSSL_EXTERNAL_TEST!=0 runs opt out and opt in.
 # Defining WOLFSSL_EXTERNAL_TEST=0  does not run opt in or opt out.
-if [[ ! -v WOLFSSL_EXTERNAL_TEST ]]; then
+if ! test -n "$WOLFSSL_EXTERNAL_TEST"; then
     echo "WOLFSSL_EXTERNAL_TEST not set, won't run"
     exit 77
 fi
-if [[ "$WOLFSSL_EXTERNAL_TEST" == "0" ]]; then
+if test "$WOLFSSL_EXTERNAL_TEST" == "0"; then
     echo "WOLFSSL_EXTERNAL_TEST is defined to zero, won't run"
     exit 77
 fi

--- a/scripts/google.test
+++ b/scripts/google.test
@@ -6,8 +6,18 @@ server=www.google.com
 
 [ ! -x ./examples/client/client ] && echo -e "\n\nClient doesn't exist" && exit 1
 
-if ! test -n "$WOLFSSL_EXTERNAL_TEST"; then
+# These tests do not run by default, we will call these opt in. There are
+# additional default tests that require network connection, those are
+# opt out.
+# Not defining WOLFSSL_EXTERNAL_TEST runs only opt out.
+# Defining WOLFSSL_EXTERNAL_TEST!=0 runs opt out and opt in.
+# Defining WOLFSSL_EXTERNAL_TEST=0  does not run opt in or opt out.
+if [[ ! -v WOLFSSL_EXTERNAL_TEST ]]; then
     echo "WOLFSSL_EXTERNAL_TEST not set, won't run"
+    exit 77
+fi
+if [[ "$WOLFSSL_EXTERNAL_TEST" == "0" ]]; then
+    echo "WOLFSSL_EXTERNAL_TEST is defined to zero, won't run"
     exit 77
 fi
 

--- a/scripts/google.test
+++ b/scripts/google.test
@@ -6,12 +6,6 @@ server=www.google.com
 
 [ ! -x ./examples/client/client ] && echo -e "\n\nClient doesn't exist" && exit 1
 
-# These tests do not run by default, we will call these opt in. There are
-# additional default tests that require network connection, those are
-# opt out.
-# Not defining WOLFSSL_EXTERNAL_TEST runs only opt out.
-# Defining WOLFSSL_EXTERNAL_TEST!=0 runs opt out and opt in.
-# Defining WOLFSSL_EXTERNAL_TEST=0  does not run opt in or opt out.
 if ! test -n "$WOLFSSL_EXTERNAL_TEST"; then
     echo "WOLFSSL_EXTERNAL_TEST not set, won't run"
     exit 77

--- a/scripts/google.test
+++ b/scripts/google.test
@@ -12,11 +12,11 @@ server=www.google.com
 # Not defining WOLFSSL_EXTERNAL_TEST runs only opt out.
 # Defining WOLFSSL_EXTERNAL_TEST!=0 runs opt out and opt in.
 # Defining WOLFSSL_EXTERNAL_TEST=0  does not run opt in or opt out.
-if [[ ! -v WOLFSSL_EXTERNAL_TEST ]]; then
+if ! test -n "$WOLFSSL_EXTERNAL_TEST"; then
     echo "WOLFSSL_EXTERNAL_TEST not set, won't run"
     exit 77
 fi
-if [[ "$WOLFSSL_EXTERNAL_TEST" == "0" ]]; then
+if test "$WOLFSSL_EXTERNAL_TEST" == "0"; then
     echo "WOLFSSL_EXTERNAL_TEST is defined to zero, won't run"
     exit 77
 fi

--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -11,8 +11,15 @@ if [[ -z "${RETRIES_REMAINING-}" ]]; then
     export RETRIES_REMAINING=2
 fi
 
-if test -n "$WOLFSSL_NO_EXTERNAL_NETWORK_TESTS"; then
-    echo 'skipping oscp-stapling.test because WOLFSSL_NO_EXTERNAL_NETWORK_TESTS defined.'
+# These tests do run by default, we will call these opt out. There are
+# additional non-default tests that require network connection, those are
+# opt in.
+# Not defining WOLFSSL_EXTERNAL_TEST runs only opt out.
+# Defining WOLFSSL_EXTERNAL_TEST!=0 runs opt out and opt in.
+# Defining WOLFSSL_EXTERNAL_TEST=0  does not run opt in or opt out.
+if [[ "$WOLFSSL_EXTERNAL_TEST" == "0" ]]; then
+    echo 'skipping oscp-stapling.test because WOLFSSL_EXTERNAL_TEST is \
+    defined to the value 0.'
     exit 77
 fi
 

--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -11,6 +11,11 @@ if [[ -z "${RETRIES_REMAINING-}" ]]; then
     export RETRIES_REMAINING=2
 fi
 
+if test -n "$WOLFSSL_NO_EXTERNAL_NETWORK_TESTS"; then
+    echo 'skipping oscp-stapling.test because WOLFSSL_NO_EXTERNAL_NETWORK_TESTS defined.'
+    exit 77
+fi
+
 if ! ./examples/client/client -V | grep -q 3; then
     echo 'skipping ocsp-stapling.test because TLS1.2 is not available.' 1>&2
     exit 77

--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -11,12 +11,6 @@ if [[ -z "${RETRIES_REMAINING-}" ]]; then
     export RETRIES_REMAINING=2
 fi
 
-# These tests do run by default, we will call these opt out. There are
-# additional non-default tests that require network connection, those are
-# opt in.
-# Not defining WOLFSSL_EXTERNAL_TEST runs only opt out.
-# Defining WOLFSSL_EXTERNAL_TEST!=0 runs opt out and opt in.
-# Defining WOLFSSL_EXTERNAL_TEST=0  does not run opt in or opt out.
 if test "$WOLFSSL_EXTERNAL_TEST" == "0"; then
     echo 'skipping oscp-stapling.test because WOLFSSL_EXTERNAL_TEST is \
     defined to the value 0.'

--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -17,7 +17,7 @@ fi
 # Not defining WOLFSSL_EXTERNAL_TEST runs only opt out.
 # Defining WOLFSSL_EXTERNAL_TEST!=0 runs opt out and opt in.
 # Defining WOLFSSL_EXTERNAL_TEST=0  does not run opt in or opt out.
-if [[ "$WOLFSSL_EXTERNAL_TEST" == "0" ]]; then
+if test "$WOLFSSL_EXTERNAL_TEST" == "0"; then
     echo 'skipping oscp-stapling.test because WOLFSSL_EXTERNAL_TEST is \
     defined to the value 0.'
     exit 77


### PR DESCRIPTION
# Description

New environment variable WOLFSSL_NO_EXTERNAL_NETWORK_TESTS to specify to not run tests requiring internet connection. 

Fixes github issue #7900 


