### PR TITLE
20240905-mp_sign_t

### DIFF
--- a/wolfcrypt/src/wolfmath.c
+++ b/wolfcrypt/src/wolfmath.c
@@ -152,7 +152,7 @@ int mp_cond_copy(mp_int* a, int copy, mp_int* b)
         b->used ^= (a->used ^ b->used) & (mp_size_t)mask;
 #if (!defined(WOLFSSL_SP_MATH) && !defined(WOLFSSL_SP_MATH_ALL)) || \
     defined(WOLFSSL_SP_INT_NEGATIVE)
-        b->sign ^= (a->sign ^ b->sign) & (mp_size_t)mask;
+        b->sign ^= (mp_sign_t)(a->sign ^ b->sign) & (mp_sign_t)mask;
 #endif
     }
 

--- a/wolfssl/wolfcrypt/integer.h
+++ b/wolfssl/wolfcrypt/integer.h
@@ -223,6 +223,7 @@ typedef int           mp_err;
 #endif
 
 #define mp_size_t int
+#define mp_sign_t int
 
 /* the mp_int structure */
 typedef struct mp_int {

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -875,6 +875,10 @@ typedef unsigned int sp_size_t;
 
 /* Type for number of digits. */
 #define mp_size_t    sp_size_t
+#ifdef WOLFSSL_SP_INT_NEGATIVE
+    typedef sp_uint8 sp_sign_t;
+    #define mp_sign_t    sp_sign_t
+#endif
 
 /**
  * SP integer.
@@ -888,7 +892,7 @@ typedef struct sp_int {
     sp_size_t    size;
 #ifdef WOLFSSL_SP_INT_NEGATIVE
     /** Indicates whether number is 0/positive or negative.  */
-    sp_uint8     sign;
+    sp_sign_t    sign;
 #endif
 #ifdef HAVE_WOLF_BIGINT
     /** Unsigned binary (big endian) representation of number. */

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -380,6 +380,7 @@ while (0)
 #endif
 
 #define mp_size_t int
+#define mp_sign_t int
 
 /* a FP type */
 typedef struct fp_int {


### PR DESCRIPTION
MPI: add `mp_sign_t` and `sp_sign_t`.

fixes
```
[defaults-cryptonly-Wconversion-intelasm-fips-140-3-dev-build] [21 of 281] [a3fea482db]
    setting up FIPS "dev"... 
    refreshing fips master... [caching link to git@github.com... done]  done, now at d7293bd01d
    setting up FIPS "dev"... done [fips="master" (d7293bd01d), wolfCrypt=current OID under test (a3fea482db)]
    configure...   real 0m10.305s  user 0m3.899s  sys 0m7.471s
    build...wolfcrypt/src/wolfmath.c: In function ‘mp_cond_copy’:
88c3e0af22 (<sean@wolfssl.com> 2024-08-26 11:48:37 +1000 155)         b->sign ^= (a->sign ^ b->sign) & (mp_size_t)mask;
wolfcrypt/src/wolfmath.c:155:20: error: conversion from ‘int’ to ‘sp_uint8’ {aka ‘unsigned char’} may change value [-Werror=conversion]
  155 |         b->sign ^= (a->sign ^ b->sign) & (mp_size_t)mask;
      |                    ^
```

tested with `wolfssl-multi-test.sh ... defaults-cryptonly-Wconversion-intelasm-fips-140-3-dev-build all-enable-fastmath all-int-math`
