### PR TITLE
Check for OPENSSL_VERSION_* definitions before defining

### DIFF
--- a/wolfssl/openssl/opensslv.h
+++ b/wolfssl/openssl/opensslv.h
@@ -30,6 +30,7 @@
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 
 /* api version compatibility */
+#ifndef OPENSSL_VERSION_NUMBER
 #if defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER == 0x009070dfL) ||\
     defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER == 0x0090810fL) ||\
     defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER == 0x10100000L) ||\
@@ -56,8 +57,11 @@
 #else
     #define OPENSSL_VERSION_NUMBER 0x0090810fL
 #endif
+#endif
 
+#ifndef OPENSSL_VERSION_TEXT
 #define OPENSSL_VERSION_TEXT             "wolfSSL " LIBWOLFSSL_VERSION_STRING
+#endif
 #define OPENSSL_VERSION                  0
 
 #ifndef OPENSSL_IS_WOLFSSL


### PR DESCRIPTION
# Description

When using WolfSSL side by side with OpenSSL, the `OPENSSL_VERSION_NUMBER` and `OPENSSL_VERSION_TEXT` macros get redefined, triggering compiler warnings. This patch adds definition checks in WolfSSL for these two.

For context, my specific usecase in the [Netatalk](https://github.com/Netatalk/netatalk) project we use WolfSSL for DHCAST128 encryption, but still rely on OpenSSL for certain symbols that aren't available in WolfSSL, e.g. `CAST_*` in [openssl/cast.h](https://github.com/openssl/openssl/blob/master/include/openssl/cast.h)

# Testing

Tested by building WolfSSL against Netatalk.

# Checklist

N/A (I think)
