### PR TITLE
Update wolfcrypt settings.h for Espressif ESP-IDF, template update

### DIFF
--- a/IDE/Espressif/ESP-IDF/examples/template/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/template/CMakeLists.txt
@@ -1,9 +1,12 @@
 # wolfSSL Espressif Example Project CMakeLists.txt
-#   v1.0
+#   v1.2
 #
 # The following lines of boilerplate have to be in your project's
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
+
+# Optional no watchdog typically used for test & benchmark
+# add_compile_options(-DWOLFSSL_ESP_NO_WATCHDOG=1)
 
 # The wolfSSL CMake file should be able to find the source code.
 # Otherwise, assign an environment variable or set it here:
@@ -68,6 +71,8 @@ else()
     message(STATUS "No conflicting wolfSSL components found.")
 endif()
 
+# Not only is a project-level "set(COMPONENTS" not needed here, this will cause
+# an unintuitive error about  Unknown CMake command "esptool_py_flash_project_args".
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
 project(wolfssl_template)

--- a/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/CMakeLists.txt
@@ -19,16 +19,142 @@
 #
 # cmake for wolfssl Espressif projects
 #
-# Version 5.6.0.011 for detect test/benchmark
+# Version 5.7.2 Espressif ESP-IDF integration
 #
 # See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html
 #
-
+message(STATUS "Begin wolfssl ${CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT}")
 cmake_minimum_required(VERSION 3.16)
+
+set(VERBOSE_COMPONENT_MESSAGES 1)
+
+
+# function: IS_ESP_IDF_COMPONENT
+#  output:    RESULT = 1 (true) if this component is located in the ESP-IDF components
+#             otherwise 0 (false)
+function( IS_ESP_IDF_COMPONENT  RESULT )
+    # NOTE: Component location is based on the location of the CMakeList.txt
+    # and *not* the location of the wolfSSL source code. (which may be anywhere)
+
+    # Normalize the paths to remove any trailing slashes
+    get_filename_component(NORMALIZED_IDF_PATH  "${IDF_PATH}"      REALPATH)
+    get_filename_component(NORMALIZED_TEST_PATH "${COMPONENT_DIR}" REALPATH)
+
+    # Check if the test path starts with the IDF_PATH
+    string(FIND "${NORMALIZED_TEST_PATH}" "${NORMALIZED_IDF_PATH}" pos)
+
+    if(${pos} EQUAL 0)
+        message(STATUS "${COMPONENT_DIR} is within IDF_PATH.")
+        set(${RESULT} 1 PARENT_SCOPE)
+    else()
+        message(STATUS "${COMPONENT_DIR} is not within IDF_PATH.")
+        set(${RESULT} 0 PARENT_SCOPE)
+    endif()
+endfunction()
+
+# Determine if this cmake file is located in the ESP-IDF component directory or not,
+# and if so, if it is being ignored (allowing the use of a local project one, instead).
+IS_ESP_IDF_COMPONENT( IS_WOLSSL_ESP_IDF_COMPONENT )
+if( IS_WOLSSL_ESP_IDF_COMPONENT )
+    message(STATUS "This wolfSSL is a component in ESP-IDF.")
+    if ( CONFIG_IGNORE_ESP_IDF_WOLFSSL_COMPONENT )
+        idf_component_register()
+        message(STATUS "Warning: wolfSSL component in ESP-IDF is being ignored.")
+        return()
+    endif()
+endif()
+
+
+if( "${CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT}" STREQUAL "" )
+    # nothing to do
+else()
+    # Only forward slashes, or double backslashes are supported.
+    # By the time we get here the sdkconfig file has a value for wolfSSL source code root.
+    string(REPLACE "\\" "/" CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT ${CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT})
+    message(STATUS "Cleaned wolfssl path: ${CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT}")
+endif()
+
+# The scope of this CMAKE_C_FLAGS is just this component:
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWOLFSSL_USER_SETTINGS")
+
 set(CMAKE_CURRENT_SOURCE_DIR ".")
-set(COMPONENT_REQUIRES lwip) # we typically don't need lwip directly in wolfssl component
-set(WOLFSSL_ROOT "$ENV{WOLFSSL_ROOT}" )
+# set(COMPONENT_REQUIRES lwip) # we typically don't need lwip directly in wolfssl component
+
+# Optionally set your source to wolfSSL in your project CMakeLists.txt like this:
+# set(WOLFSSL_ROOT "c:/test/my_wolfssl" )
+
+if ( "${WOLFSSL_ROOT}" STREQUAL "")
+    set(WOLFSSL_ROOT "$ENV{WOLFSSL_ROOT}" )
+endif()
+
+if(  "$ENV{IDF_PATH}" STREQUAL "" )
+    message(FATAL_ERROR "IDF_PATH Environment variable not set!")
+else()
+    string(REPLACE "\\" "/" THIS_IDF_PATH "$ENV{IDF_PATH}")
+endif()
+
+# Optional compiler definitions to help with system name detection (typically printed by app diagnostics)
+if(VERBOSE_COMPONENT_MESSAGES)
+    if(WIN32)
+        # Windows-specific configuration here
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
+        message("Detected Windows")
+    endif()
+    if(CMAKE_HOST_UNIX)
+        message("Detected UNIX")
+    endif()
+    if(APPLE)
+        message("Detected APPLE")
+    endif()
+    if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
+        # Windows-specific configuration here
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
+        message("Detected WSL")
+    endif()
+    if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
+        # Windows-specific configuration here
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
+        message("Detected Linux")
+    endif()
+    if(APPLE)
+        # Windows-specific configuration here
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
+        message("Detected Apple")
+    endif()
+endif() # End optional WOLFSSL_CMAKE_SYSTEM_NAME
+
+message(STATUS "CONFIG_TARGET_PLATFORM = ${CONFIG_TARGET_PLATFORM}")
+
+# Check that there are not conflicting wolfSSL components
+# The ESP Registry Component will be in ./managed_components/wolfssl__wolfssl
+# The local component wolfSSL directory will be in ./components/wolfssl
+if( EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl" AND EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl" )
+    # These exclude statements don't seem to be honored by the $ENV{IDF_PATH}/tools/cmake/project.cmake'
+    # add_subdirectory("${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl" EXCLUDE_FROM_ALL)
+    # add_subdirectory("${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl/include" EXCLUDE_FROM_ALL)
+    # So we'll error out and let the user decide how to proceed:
+    message(WARNING "\nFound wolfSSL components in\n"
+                    "./managed_components/wolfssl__wolfssl\n"
+                    "and\n"
+                    "./components/wolfssl\n"
+                    "in project directory: \n"
+                    "${CMAKE_HOME_DIRECTORY}")
+    message(FATAL_ERROR "\nPlease use either the ESP Registry Managed Component or the wolfSSL component directory but not both.\n"
+                        "If removing the ./managed_components/wolfssl__wolfssl directory, remember to also remove "
+                        "or rename the idf_component.yml file typically found in ./main/")
+else()
+    message(STATUS "No conflicting wolfSSL components found.")
+endif()
+
+
+# Don't include lwip requirement for benchmark and test apps.
+if( ("${CMAKE_PROJECT_NAME}" STREQUAL "wolfssl_benchmark") OR ("${CMAKE_PROJECT_NAME}" STREQUAL "wolfssl_test") )
+    message(STATUS "Not including lwip for ${CMAKE_PROJECT_NAME}")
+else()
+    # benchmark and test do not need wifi, everything else probably does:
+    set(COMPONENT_REQUIRES lwip) # we typically don't need lwip directly in wolfssl component
+endif()
 
 # find the user name to search for possible "wolfssl-username"
 message(STATUS "USERNAME = $ENV{USERNAME}")
@@ -51,6 +177,25 @@ else()
     string(REPLACE "\\" "/" THIS_IDF_PATH "$ENV{IDF_PATH}")
 endif()
 
+# ENVIRONMENT_VAR_TO_MACRO
+# Check environment variable name EVARPARAM as [name]
+# If defined, and has a value of EVARVALUE as [value],
+# then assign a compiler definition "-D[name]=[value]"
+function(ENVIRONMENT_VAR_TO_MACRO EVARPARAM EVARVALUE)
+    # If the EVARPARAM environment variable name is set to EVARVALUE,
+    # set the compiler flag definition to enable CSV output.
+    if ( "$ENV{${EVARPARAM}}" STREQUAL "${EVARVALUE}")
+        message(STATUS "Appending compile definition: -D${EVARPARAM}=${EVARVALUE}")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D${EVARPARAM}=${EVARVALUE}")
+    else()
+        if(DEFINED ENV{${EVARPARAM}})
+            message(STATUS "Environment variable ${EVARPARAM} detected but set to $ENV{${EVARPARAM}}, not appending compile definition.")
+        else()
+            message(STATUS "Environment variable ${EVARPARAM} not detected, not appending compile definition.")
+        endif()
+    endif()
+endfunction()
+
 # COMPONENT_NAME = wolfssl
 # The component name is the directory name. "No feature to change this".
 # See https://github.com/espressif/esp-idf/issues/8978#issuecomment-1129892685
@@ -68,7 +213,8 @@ endif()
 # function: IS_WOLFSSL_SOURCE
 #  parameter: DIRECTORY_PARAMETER - the directory to test
 #  output:    RESULT = contains contents of DIRECTORY_PARAMETER for wolfssl directory, otherwise blank.
-function(IS_WOLFSSL_SOURCE DIRECTORY_PARAMETER RESULT)
+function( IS_WOLFSSL_SOURCE  DIRECTORY_PARAMETER
+          RESULT )
     if (EXISTS "${DIRECTORY_PARAMETER}/wolfcrypt/src")
         set(${RESULT} "${DIRECTORY_PARAMETER}" PARENT_SCOPE)
     else()
@@ -76,26 +222,70 @@ function(IS_WOLFSSL_SOURCE DIRECTORY_PARAMETER RESULT)
     endif()
 endfunction()
 
+# *********************************************************************************************
 # function: FIND_WOLFSSL_DIRECTORY
 #  parameter: OUTPUT_FOUND_WOLFSSL_DIRECTORY contains root of source code, otherwise blank
 #
+# Example usage:
+#   FIND_WOLFSSL_DIRECTORY(WOLFSSL_ROOT)
+# *********************************************************************************************
 function(FIND_WOLFSSL_DIRECTORY OUTPUT_FOUND_WOLFSSL_DIRECTORY)
-    message(STATUS "Starting FIND_WOLFSSL_DIRECTORY")
-    set(CURRENT_SEARCH_DIR "$ENV{WOLFSSL_ROOT}")
-    if( "${CURRENT_SEARCH_DIR}" STREQUAL "" )
-        message(STATUS "The WOLFSSL_ROOT environment variable is not set. Searching...")
+    message(STATUS "Starting FIND_WOLFSSL_DIRECTORY: ${${OUTPUT_FOUND_WOLFSSL_DIRECTORY}}")
+
+    if ( "${${OUTPUT_FOUND_WOLFSSL_DIRECTORY}}" STREQUAL "" )
+        # The parameter is empty, so we certainly need to search.
+        # First, see if there's an environment variable. This takes highest priority (unless already found as hard-coded, above)
+        set(CURRENT_SEARCH_DIR "$ENV{WOLFSSL_ROOT}")
+        if( "${CURRENT_SEARCH_DIR}" STREQUAL "" )
+            message(STATUS "The WOLFSSL_ROOT environment variable is not set. Searching...")
+            # Next, if not found, see if wolfSSL was selected for ESP-TLS Kconfig
+            if(CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT)
+                set(CURRENT_SEARCH_DIR ${CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT})
+                get_filename_component(CURRENT_SEARCH_DIR "${CURRENT_SEARCH_DIR}" ABSOLUTE)
+                message(STATUS "WOLFSSL_ROOT found in sdkconfig/KConfig: ${CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT}")
+            else()
+                message(STATUS "wolfSSL not defined in [Component Config] [wolfssl]. Continuing search...")
+                # If not specified as a search hint in OUTPUT_FOUND_WOLFSSL_DIRECTORY:
+                # This wolfSSL component CMakeLists.txt may be found EITHER in:
+                #   1) local project component
+                #   2) ESP-IDF share components
+                # We'll start in the CMAKE_CURRENT_SOURCE_DIR, typically [something]/projectname/components/wolfssl
+                # That option might find wolfSSL source code as a copy in the component directory (e.g. Managed Components)
+                # Unless cmake is in the ESP-IDF, in which case it is unlikely to find wolfSSL source in any parent.
+                message(STATUS "CMAKE_CURRENT_SOURCE_DIR = ${CMAKE_CURRENT_SOURCE_DIR}")
+                get_filename_component(CURRENT_SEARCH_DIR "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
+                message(STATUS "CURRENT_SEARCH_DIR = ${CURRENT_SEARCH_DIR}")
+                string(LENGTH ${CURRENT_SEARCH_DIR} CURRENT_SEARCH_DIR_LENGTH)
+            endif() # CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT
+        endif() # check environment var blank
     else()
-        get_filename_component(CURRENT_SEARCH_DIR "$ENV{WOLFSSL_ROOT}" ABSOLUTE)
+        message(STATUS "Parameter found for FIND_WOLFSSL_DIRECTORY")
+        message(STATUS "Setting wolfSSL search directory to: ${${OUTPUT_FOUND_WOLFSSL_DIRECTORY}}")
+        set(CURRENT_SEARCH_DIR "${${OUTPUT_FOUND_WOLFSSL_DIRECTORY}}")
+    endif() # parameter empty
+
+    # Check to see if we found a path in environment or config settings, above.
+    if( "${CURRENT_SEARCH_DIR}" STREQUAL "" )
+        message(STATUS "Source for wolfSSL not specified in path nor config settings.")
+        # We'll continue the search by recursing up the directory tree, below.
+    else()
+        # Setting found! Does it contain a valid path?
+        string(REPLACE "\\" "/" CURRENT_SEARCH_DIR ${CURRENT_SEARCH_DIR})
+        get_filename_component(CURRENT_SEARCH_DIR "${CURRENT_SEARCH_DIR}" ABSOLUTE)
         IS_WOLFSSL_SOURCE("${CURRENT_SEARCH_DIR}" FOUND_WOLFSSL)
         if( FOUND_WOLFSSL )
-            message(STATUS "Found WOLFSSL_ROOT via Environment Variable: ${CURRENT_SEARCH_DIR}")
+            message(STATUS "Found wolfSSL source code via setting: ${CURRENT_SEARCH_DIR}")
             set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} ${CURRENT_SEARCH_DIR} PARENT_SCOPE)
             return()
         else()
-            message(FATAL_ERROR "WOLFSSL_ROOT Environment Variable defined, but path not found:")
-            message(STATUS "$ENV{WOLFSSL_ROOT}")
+            if(WIN32)
+                message(STATUS "When specifying a path for Windows, use forward slahes, or double backslashes.")
+            endif()
+            message(STATUS "CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT sdkconfig setting = ${CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT}")
+            message(STATUS "WOLFSSL_ROOT Variable defined, but source code not found: ${CURRENT_SEARCH_DIR}")
         endif()
     endif()
+
 
     # we'll start in the CMAKE_CURRENT_SOURCE_DIR, typically [something]/projectname/components/wolfssl
     message(STATUS "CMAKE_CURRENT_SOURCE_DIR = ${CMAKE_CURRENT_SOURCE_DIR}")
@@ -114,16 +304,47 @@ function(FIND_WOLFSSL_DIRECTORY OUTPUT_FOUND_WOLFSSL_DIRECTORY)
             return()
         endif()
 
+        # Maintain CURRENT_SEARCH_DIR, but check various suffixes with CURRENT_SEARCH_DIR_ALT
         if( THIS_USER )
             # Check for "wolfssl-[username]" subdirectory as we recurse up the directory tree
             set(CURRENT_SEARCH_DIR_ALT ${CURRENT_SEARCH_DIR}/wolfssl-${THIS_USER})
-            message(STATUS "Looking in ${CURRENT_SEARCH_DIR}")
+            message(STATUS "Looking in ${CURRENT_SEARCH_DIR_ALT}")
 
-            #if(EXISTS ${CURRENT_SEARCH_DIR_ALT} AND IS_DIRECTORY ${CURRENT_SEARCH_DIR_ALT} AND EXISTS "${CURRENT_SEARCH_DIR_ALT}/wolfcrypt/src")
             IS_WOLFSSL_SOURCE("${CURRENT_SEARCH_DIR_ALT}" FOUND_WOLFSSL )
             if ( FOUND_WOLFSSL )
-               message(STATUS "Found wolfssl in user-suffix CURRENT_SEARCH_DIR_ALT = ${CURRENT_SEARCH_DIR_ALT}")
-                set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} ${CURRENT_SEARCH_DIR_ALT} PARENT_SCOPE)
+                message(STATUS "Found wolfssl in user-suffix CURRENT_SEARCH_DIR_ALT = ${CURRENT_SEARCH_DIR_ALT}")
+                set(CURRENT_SEARCH_DIR "${CURRENT_SEARCH_DIR_ALT}")
+                set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} ${CURRENT_SEARCH_DIR} PARENT_SCOPE)
+                return()
+            endif()
+        endif()
+
+        if ( FOUND_WOLFSSL )
+            # if we already found the source, skip attempt of "wolfssl-master"
+        else()
+            set(CURRENT_SEARCH_DIR_ALT ${CURRENT_SEARCH_DIR}/wolfssl-master)
+            message(STATUS "Looking in ${CURRENT_SEARCH_DIR_ALT}")
+
+            IS_WOLFSSL_SOURCE("${CURRENT_SEARCH_DIR_ALT}" FOUND_WOLFSSL )
+            if ( FOUND_WOLFSSL )
+                message(STATUS "Found wolfssl in master-suffix CURRENT_SEARCH_DIR_ALT = ${CURRENT_SEARCH_DIR_ALT}")
+                set(CURRENT_SEARCH_DIR "${CURRENT_SEARCH_DIR_ALT}")
+                set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} ${CURRENT_SEARCH_DIR} PARENT_SCOPE)
+                return()
+            endif()
+        endif()
+
+        if ( FOUND_WOLFSSL )
+            # if we already found the source, skip attempt of "wolfssl"
+        else()
+            set(CURRENT_SEARCH_DIR_ALT ${CURRENT_SEARCH_DIR}/wolfssl)
+            message(STATUS "Looking in ${CURRENT_SEARCH_DIR_ALT}")
+
+            IS_WOLFSSL_SOURCE("${CURRENT_SEARCH_DIR_ALT}" FOUND_WOLFSSL )
+            if ( FOUND_WOLFSSL )
+                message(STATUS "Found wolfssl in CURRENT_SEARCH_DIR_ALT = ${CURRENT_SEARCH_DIR_ALT}")
+                set(CURRENT_SEARCH_DIR "${CURRENT_SEARCH_DIR_ALT}")
+                set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} ${CURRENT_SEARCH_DIR} PARENT_SCOPE)
                 return()
             endif()
         endif()
@@ -143,7 +364,8 @@ function(FIND_WOLFSSL_DIRECTORY OUTPUT_FOUND_WOLFSSL_DIRECTORY)
         get_filename_component(CURRENT_SEARCH_DIR "${CURRENT_SEARCH_DIR}" DIRECTORY)
         message(STATUS "Next CURRENT_SEARCH_DIR = ${CURRENT_SEARCH_DIR}")
         if( "${PRIOR_SEARCH_DIR}" STREQUAL "${CURRENT_SEARCH_DIR}" )
-            # when the search directory is empty, we'll give up
+            # When the parent is current directory, cannot go any further. We didn't find wolfssl.
+            # When the search directory is empty, we'll give up.
             set(CURRENT_SEARCH_DIR "")
         endif()
     endwhile()
@@ -154,17 +376,52 @@ endfunction()
 
 
 # Example usage:
+#
+# Simply find the WOLFSSL_DIRECTORY by searching parent directories:
+#   FIND_WOLFSSL_DIRECTORY(WOLFSSL_ROOT)
+#
 
+message(STATUS "CONFIG_TARGET_PLATFORM = ${CONFIG_TARGET_PLATFORM}")
 
+# Check for environment variable that may be assigned to macros
+ENVIRONMENT_VAR_TO_MACRO("GENERATE_MACHINE_PARSEABLE_REPORT" "1")
+ENVIRONMENT_VAR_TO_MACRO("WOLFSSL_BENCHMARK_FIXED_CSV"       "1")
 
+# Optional variable inspection
+if (0)
+    get_cmake_property(_variableNames VARIABLES)
+    list (SORT _variableNames)
+    message(STATUS "")
+    message(STATUS "ALL VARIABLES BEGIN")
+    message(STATUS "")
+    foreach (_variableName ${_variableNames})
+        message(STATUS "${_variableName}=${${_variableName}}")
+    endforeach()
+    message(STATUS "")
+    message(STATUS "ALL VARIABLES END")
+    message(STATUS "")
+endif()
+
+if ( ("${CONFIG_TARGET_PLATFORM}" STREQUAL "esp8266") OR ("${IDF_TARGET}" STREQUAL "esp8266") )
+    # There's no esp_timer, no driver components for the ESP8266
+    message(STATUS "Early expansion EXCLUDES esp_timer: ${THIS_INCLUDE_TIMER}")
+    message(STATUS "Early expansion EXCLUDES driver: ${THIS_INCLUDE_DRIVER}")
+    set(THIS_INCLUDE_TIMER "")
+    set(THIS_INCLUDE_DRIVER "")
+else()
+    message(STATUS "Early expansion includes esp_timer: ${THIS_INCLUDE_TIMER}")
+    message(STATUS "Early expansion includes driver: ${THIS_INCLUDE_DRIVER}")
+    set(THIS_INCLUDE_TIMER "esp_timer")
+    set(THIS_INCLUDE_DRIVER "driver")
+endif()
 
 if(CMAKE_BUILD_EARLY_EXPANSION)
     message(STATUS "wolfssl component CMAKE_BUILD_EARLY_EXPANSION:")
     idf_component_register(
                             REQUIRES "${COMPONENT_REQUIRES}"
                             PRIV_REQUIRES # esp_hw_support
-                                          # esp_timer
-                                          # driver # this will typically only be needed for wolfSSL benchmark
+                                          "${THIS_INCLUDE_TIMER}"
+                                          "${THIS_INCLUDE_DRIVER}" # this will typically only be needed for wolfSSL benchmark
                            )
 
 else()
@@ -173,48 +430,99 @@ else()
     message(STATUS "wolfssl component config:")
     message(STATUS "************************************************************************************************")
 
+    if ( "${CONFIG_TARGET_PLATFORM}" STREQUAL "esp8266")
+        # There's no esp_timer, no driver components for the ESP8266
+        set(THIS_INCLUDE_TIMER "")
+        set(THIS_INCLUDE_DRIVER "")
+    else()
+        set(THIS_INCLUDE_TIMER "esp_timer")
+        set(THIS_INCLUDE_DRIVER "driver")
+    endif()
+
     # search for wolfSSL
     FIND_WOLFSSL_DIRECTORY(WOLFSSL_ROOT)
     if(WOLFSSL_ROOT)
-        message(STATUS "NEW Found wolfssl directory at: ${WOLFSSL_ROOT}")
+        IS_WOLFSSL_SOURCE("${WOLFSSL_ROOT}" FOUND_WOLFSSL)
+        if(FOUND_WOLFSSL)
+            message(STATUS "Found WOLFSSL_ROOT via CMake specification.")
+        else()
+            # WOLFSSL_ROOT Path specified in CMakeLists.txt is not a valid path
+            message(FATAL_ERROR "WOLFSSL_ROOT CMake Variable defined, but path not found: ${WOLFSSL_ROOT}\n"
+                                "Try correcting WOLFSSL_ROOT in your project CMakeFile.txt or setting environment variable.")
+            # Abort CMake after fatal error.
+        endif()
     else()
-        message(STATUS "NEW wolfssl directory not found.")
+        message(STATUS "Source code for wolfSSL still not found.")
+        message(STATUS "Searching from project home: ${CMAKE_HOME_DIRECTORY} ...")
+        set(WOLFSSL_ROOT "${CMAKE_HOME_DIRECTORY}")
+        FIND_WOLFSSL_DIRECTORY(WOLFSSL_ROOT)
+    endif()
+
+
+    if(WOLFSSL_ROOT)
+        message(STATUS "Confirmed wolfssl directory at: ${WOLFSSL_ROOT}")
+    else()
+        # Try to allow a more intuitive error that the source code was not found in cmake:
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_WARNING_SOURCE_NOT_FOUND")
+
+        message(STATUS "Failed: wolfssl source code directory not found.")
         # Abort. We need wolfssl _somewhere_.
-        message(FATAL_ERROR "Could not find wolfssl in ${WOLFSSL_ROOT}.\n"
-                            "Try setting WOLFSSL_ROOT environment variable or git clone.")
+        message(STATUS "")
+        message(STATUS "")
+        message(STATUS "Could not find wolfssl in any parent directory named wolfssl-${THIS_USER}, wolfssl-master, or wolfssl.\n"
+                       "Try setting WOLFSSL_ROOT environment variable, cmake variable in project, copy source, or use managed components.")
+        message(STATUS "")
+        message(STATUS "")
+        # Abort CMake after fatal error. (or not?)
     endif()
 
     set(INCLUDE_PATH ${WOLFSSL_ROOT})
 
     set(WOLFSSL_EXTRA_PROJECT_DIR "${WOLFSSL_ROOT}/src/")
 
-    if( ${CMAKE_PROJECT_NAME} STREQUAL "wolfssl_benchmark" )
-        set(WOLFSSL_EXTRA_PROJECT_DIR "${WOLFSSL_ROOT}/wolfcrypt/benchmark")
+    # During regression tests, optionally copy source locally and use: set(USE_LOCAL_TEST_BENCH 1)
+    set(USE_LOCAL_TEST_BENCH 0)
+    if(NOT USE_LOCAL_TEST_BENCH)
+        if( "${CMAKE_PROJECT_NAME}" STREQUAL "hello-world" )
+            message(STATUS "Include ${WOLFSSL_ROOT}/wolfcrypt/benchmark")
+            set(WOLFSSL_EXTRA_PROJECT_DIR "${WOLFSSL_ROOT}/wolfcrypt/benchmark")
+        endif()
+
+        if( "${CMAKE_PROJECT_NAME}" STREQUAL "wolfssl_benchmark" )
+            message(STATUS "Include ${WOLFSSL_ROOT}/wolfcrypt/benchmark")
+            set(WOLFSSL_EXTRA_PROJECT_DIR "${WOLFSSL_ROOT}/wolfcrypt/benchmark")
+        endif()
+
+        if( "${CMAKE_PROJECT_NAME}" STREQUAL "wolfssl_test" )
+            message(STATUS "Include ${WOLFSSL_ROOT}/wolfcrypt/test")
+            set(WOLFSSL_EXTRA_PROJECT_DIR "${WOLFSSL_ROOT}/wolfcrypt/test")
+        endif()
     endif()
 
-    if( ${CMAKE_PROJECT_NAME} STREQUAL "wolfssl_test" )
-        set(WOLFSSL_EXTRA_PROJECT_DIR "${WOLFSSL_ROOT}/wolfcrypt/test")
-    endif()
-
+    message(STATUS "WOLFSSL_EXTRA_PROJECT_DIR = ${WOLFSSL_EXTRA_PROJECT_DIR}")
     set(COMPONENT_SRCDIRS "\"${WOLFSSL_ROOT}/src/\""
                           "\"${WOLFSSL_ROOT}/wolfcrypt/src\""
                           "\"${WOLFSSL_ROOT}/wolfcrypt/src/port/Espressif\""
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/src/port/Espressif/esp_crt_bundle\""
                           "\"${WOLFSSL_ROOT}/wolfcrypt/src/port/atmel\""
                           "\"${WOLFSSL_EXTRA_PROJECT_DIR}\""
                          ) # COMPONENT_SRCDIRS
 
     message(STATUS "This COMPONENT_SRCDIRS = ${COMPONENT_SRCDIRS}")
 
+    # wolfSSL user_settings.h may be in the local project.
+    # TODO check if exists and possibly set to ESP-IDF
     set(WOLFSSL_PROJECT_DIR "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
-    add_definitions(-DWOLFSSL_USER_SETTINGS_DIR="${WOLFSSL_PROJECT_DIR}/include/user_settings.h")
 
-
+    string(REPLACE "/" "//" STR_WOLFSSL_PROJECT_DIR "${WOLFSSL_PROJECT_DIR}")
+    add_definitions(-DWOLFSSL_USER_SETTINGS_DIR="${STR_WOLFSSL_PROJECT_DIR}/include/user_settings.h")
+    message(STATUS "Added definition for user_settings.h: -DWOLFSSL_USER_SETTINGS_DIR=\"${STR_WOLFSSL_PROJECT_DIR}//include//user_settings.h\"")
     # Espressif may take several passes through this makefile. Check to see if we found IDF
     string(COMPARE EQUAL "${PROJECT_SOURCE_DIR}" "" WOLFSSL_FOUND_IDF)
 
     # get a list of all wolfcrypt assembly files; we'll exclude them as they don't target Xtensa
     file(GLOB EXCLUDE_ASM *.S)
-    file(GLOB_RECURSE EXCLUDE_ASM ${CMAKE_SOURCE_DIR} "${WOLFSSL_ROOT}/wolfcrypt/src/*.S")
+    file(GLOB EXCLUDE_ASM ${CMAKE_SOURCE_DIR} "${WOLFSSL_ROOT}/wolfcrypt/src/*.S")
 
     message(STATUS "IDF_PATH = $ENV{IDF_PATH}")
     message(STATUS "PROJECT_SOURCE_DIR = ${PROJECT_SOURCE_DIR}")
@@ -237,10 +545,11 @@ else()
         message(STATUS "Remove either the local project component: ${WOLFSSL_PROJECT_DIR} ")
         message(STATUS "or the Espressif shared component installed at: $ENV{IDF_PATH}/components/wolfssl/ ")
         message(STATUS "")
-        message(FATAL_ERROR "Please use wolfSSL in either local project or Espressif components, but not both.")
         message(STATUS "")
         message(STATUS "**************************************************************************************")
         message(STATUS "")
+
+        message(STATUS "Please use wolfSSL in either local project or Espressif components, but not both.")
 
         # Optional: if you change the above FATAL_ERROR to STATUS you can warn at runtime with this macro definition:
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_MULTI_INSTALL_WARNING")
@@ -291,6 +600,7 @@ else()
                         message(FATAL_ERROR "Found stray wolfSSL user_settings.h in "
                                             "${WOLFSSL_ROOT}/include/user_settings.h "
                                             " (please move it to ${WOLFSSL_PROJECT_DIR}/include/user_settings.h )")
+                        # Abort CMake after fatal error.
                     else()
                         # we won't overwrite an existing user settings file, just note that we already have one:
                         if( EXISTS "${WOLFSSL_PROJECT_DIR}/include/user_settings.h" )
@@ -347,7 +657,9 @@ else()
     # depending on the environment, we may need to swap backslashes with forward slashes
     string(REPLACE "\\" "/" RTOS_IDF_PATH "$ENV{IDF_PATH}/components/freertos/FreeRTOS-Kernel/include/freertos")
 
-    string(REPLACE "\\" "/" WOLFSSL_ROOT ${WOLFSSL_ROOT})
+	if(WOLFSSL_ROOT)
+	    string(REPLACE "\\" "/" WOLFSSL_ROOT ${WOLFSSL_ROOT})
+	endif()
 
     if(IS_DIRECTORY "${RTOS_IDF_PATH}")
         message(STATUS "Found current RTOS path: ${RTOS_IDF_PATH}")
@@ -360,13 +672,14 @@ else()
             message(STATUS "Could not find RTOS path")
         endif()
     endif()
-
-
+    message(STATUS "THIS_IDF_PATH = $THIS_IDF_PATH")
+    # wolfSSL-specific include directories
     set(COMPONENT_ADD_INCLUDEDIRS
-        "./include" # this is the location of wolfssl user_settings.h
+        "./include" # this is the location of local project wolfssl user_settings.h
         "\"${WOLFSSL_ROOT}/\""
         "\"${WOLFSSL_ROOT}/wolfssl/\""
         "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/\""
+        "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/port/Espressif\""
         "\"${RTOS_IDF_PATH}/\""
         # wolfSSL release after v5.7 includes WiFi, time, and mem/debug helpers
         "${THIS_IDF_PATH}/components/esp_event/include"
@@ -374,7 +687,7 @@ else()
         "${THIS_IDF_PATH}/components/esp_wifi/include"
         )
 
-
+    # Optionally include cryptoauthlib if present
     if(IS_DIRECTORY ${IDF_PATH}/components/cryptoauthlib)
         list(APPEND COMPONENT_ADD_INCLUDEDIRS "../cryptoauthlib/lib")
     endif()
@@ -383,7 +696,7 @@ else()
     list(APPEND COMPONENT_ADD_INCLUDEDIRS "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/\"")
 
 
-
+    # Some files are known to be included elsewhere, or not used for Espressif
     set(COMPONENT_SRCEXCLUDE
         "\"${WOLFSSL_ROOT}/src/bio.c\""
         "\"${WOLFSSL_ROOT}/src/conf.c\""
@@ -399,6 +712,8 @@ else()
         "\"${WOLFSSL_ROOT}/src/ssl_sess.c\""    # included by ssl.c
         "\"${WOLFSSL_ROOT}/src/x509.c\""
         "\"${WOLFSSL_ROOT}/src/x509_str.c\""
+        "\"${WOLFSSL_ROOT}/wolfcrypt/src/ext_kyber.c\""     # external non-wolfssl Kyber disabled by default
+        "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/ext_kyber.h\"" # external non-wolfssl Kyber disabled by default
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/evp.c\""
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/misc.c\""
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/sp_sm2_arm32.c\""
@@ -409,6 +724,7 @@ else()
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/sp_sm2_cortexm.c\""
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/sp_sm2_x86_64.c\""
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/sp_sm2_x86_64_asm.S\""
+        "\"${WOLFSSL_ROOT}/examples\"" # Examples are distributed in Managed Components, but not part of a project.
         "\"${EXCLUDE_ASM}\""
         )
 
@@ -430,22 +746,140 @@ else()
     # see https://docs.espressif.com/projects/esp-idf/en/stable/esp32/migration-guides/release-5.x/build-system.html?highlight=space%20path
     #
     set(EXTRA_COMPONENT_DIRS "${COMPONENT_SRCDIRS}")
-    idf_component_register(
-                            SRC_DIRS "${COMPONENT_SRCDIRS}"
-                            INCLUDE_DIRS "${COMPONENT_ADD_INCLUDEDIRS}"
-                            REQUIRES "${COMPONENT_REQUIRES}"
-                            EXCLUDE_SRCS "${COMPONENT_SRCEXCLUDE}"
-                            PRIV_REQUIRES esp_timer driver # this will typically only be needed for wolfSSL benchmark
-                           )
-    # some optional diagnostics
-    if (1)
+
+    if(WOLFSSL_ROOT)
+        # Only register the component if we found wolfSSL source.
+        # This is important to allow Cmake to finish to completion, otherwise the UI
+        # may not be able to display the Kconfig settings to fix a bad or missing source.
+        idf_component_register(
+                                SRC_DIRS "${COMPONENT_SRCDIRS}"
+                                INCLUDE_DIRS "${COMPONENT_ADD_INCLUDEDIRS}"
+                                REQUIRES "${COMPONENT_REQUIRES}"
+                                EXCLUDE_SRCS "${COMPONENT_SRCEXCLUDE}"
+                                PRIV_REQUIRES
+                                  "${THIS_INCLUDE_TIMER}"
+                                  "${THIS_INCLUDE_DRIVER}" # this will typically only be needed for wolfSSL benchmark
+                               )
+    else()
+        # Register the component simply to allow CMake to complete, but there's no wolfSSL source.
+        # Expect many other errors, but the project should at least be loadable and UI can edit Kconfig settings.
+        idf_component_register()
+        message(STATUS "Warning: wolfSSL component not registered as no source code found (WOLFSSL_ROOT is blank)")
+    endif()
+
+# function(WOLFSSL_INIT_CERT_BUNDLE)
+if(CONFIG_WOLFSSL_CERTIFICATE_BUNDLE AND NOT CONFIG_WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_NONE)
+    if (CMAKE_BUILD_EARLY_EXPANSION)
+        message(ERROR "Bundle Cert initialization must occur during CMAKE_BUILD_EARLY_EXPANSION")
+    endif()
+    # reminder: we need a value for wolfSSL root first!
+    if( "${WOLFSSL_ROOT}" STREQUAL "" )
+        message(ERROR "Certificate bundles need a value for WOLFSSL_ROOT")
+    endif()
+    set(WOLFSSL_ESP_CRT_BUNDLE_DIR ${WOLFSSL_ROOT}/wolfcrypt/src/port/Espressif/esp_crt_bundle)
+    message(STATUS "WOLFSSL_ESP_CRT_BUNDLE_DIR=${WOLFSSL_ESP_CRT_BUNDLE_DIR}")
+    if(EXISTS "${WOLFSSL_ESP_CRT_BUNDLE_DIR}")
+        set(bundle_name "x509_crt_bundle_wolfssl")
+
+        # For now the certs are in the same directory
+        set(DEFAULT_CRT_DIR "${WOLFSSL_ESP_CRT_BUNDLE_DIR}")
+
+        # Generate custom certificate bundle using the generate_cert_bundle utility
+        set(GENERATE_CERT_BUNDLEPY ${python} ${WOLFSSL_ESP_CRT_BUNDLE_DIR}/gen_crt_bundle.py)
+
+        if(CONFIG_WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_FULL)
+            list(APPEND crt_paths ${DEFAULT_CRT_DIR}/cacrt_all.pem ${DEFAULT_CRT_DIR}/cacrt_local.pem)
+        elseif(CONFIG_WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_CMN)
+            list(APPEND crt_paths ${DEFAULT_CRT_DIR}/cacrt_all.pem ${DEFAULT_CRT_DIR}/cacrt_local.pem)
+            list(APPEND args --filter ${DEFAULT_CRT_DIR}/cmn_crt_authorities.csv)
+        endif()
+
+        # Add deprecated root certs if enabled. This config is not visible if the default cert
+        # bundle is not selected
+        if(CONFIG_WOLFSSL_CERTIFICATE_BUNDLE_DEPRECATED_LIST)
+            list(APPEND crt_paths ${DEFAULT_CRT_DIR}/cacrt_deprecated.pem)
+        endif()
+
+        if(CONFIG_WOLFSSL_CUSTOM_CERTIFICATE_BUNDLE)
+            get_filename_component(custom_bundle_path
+              ${CONFIG_WOLFSSL_CUSTOM_CERTIFICATE_BUNDLE_PATH} ABSOLUTE BASE_DIR "${project_dir}")
+            list(APPEND crt_paths ${custom_bundle_path})
+            message(STATUS "Using a custom wolfSSL bundle path: ${custom_bundle_path}")
+        else()
+            message(STATUS "Not using a custom wolfSSL bundle path.")
+        endif()
+        list(APPEND args --input ${crt_paths} -q)
+
+        message(STATUS "CMAKE_CURRENT_BINARY_DIR: ${CMAKE_CURRENT_BINARY_DIR}")
+        get_filename_component(crt_bundle
+            ${bundle_name}
+            ABSOLUTE BASE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+
+        message(STATUS "Setting up bundle generate: ${GENERATE_CERT_BUNDLEPY} ${args}")
+        message(STATUS "Depends on custom bundle path: ${custom_bundle_path}")
+        message(STATUS "crt_bundle ${crt_bundle}")
+        message(STATUS "COMPONENT_LIB ${COMPONENT_LIB}")
+        message(STATUS "GENERATE_CERT_BUNDLEPY ${GENERATE_CERT_BUNDLEPY}")
+        message(STATUS "args ${args}")
+        message(STATUS "cert_bundle ${cert_bundle}")
+
+        # Generate bundle according to config
+        # File is generated at build time, not cmake load
+        add_custom_command(OUTPUT ${crt_bundle}
+            COMMAND ${GENERATE_CERT_BUNDLEPY} ARGS ${args}
+            DEPENDS ${custom_bundle_path}
+            VERBATIM)
+
+        if(EXISTS "${crt_bundle}")
+            message(STATUS "Bundle file exists from prior build: ${crt_bundle}")
+        else()
+            message(STATUS "Bundle file expected during next build: ${crt_bundle}")
+        endif()
+
+        # Reminder the file is generated at build time, not cmake load time.
+        message(STATUS "wolfSSL Cert Bundle File to be created at build time in: ${crt_bundle}")
+
+        add_custom_target(custom_wolfssl_bundle DEPENDS ${cert_bundle})
+
+        # the wolfSSL crtificate bundle is baked into wolfSSL
+        add_dependencies(${COMPONENT_LIB} custom_wolfssl_bundle)
+
+        # COMPONENT_LIB may vary: __idf_wolfssl, __idf_esp_wolfssl, etc
+        # target_add_binary_data(__idf_wolfssl ${crt_bundle} BINARY)
+        target_add_binary_data(${COMPONENT_LIB} ${crt_bundle} BINARY)
+        set_property(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                     APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+                     "${crt_bundle}")
+    else()
+        message(STATUS "WARNING: CONFIG_WOLFSSL_CERTIFICATE_BUNDLE enabled but directory not found: ${WOLFSSL_ESP_CRT_BUNDLE_DIR}")
+    endif()
+endif()
+
+# endfunction() # WOLFSSL_INIT_CERT_BUNDLE
+
+    # Some optional diagnostics. Verbose ones are truncated.
+    if (VERBOSE_COMPONENT_MESSAGES)
         get_cmake_property(_variableNames VARIABLES)
         list (SORT _variableNames)
         message(STATUS "")
         message(STATUS "ALL VARIABLES BEGIN")
         message(STATUS "")
         foreach (_variableName ${_variableNames})
-            message(STATUS "${_variableName}=${${_variableName}}")
+            if (      ("${_variableName}" STREQUAL "bootloader_binary_files")
+                    OR ("${_variableName}" STREQUAL "Component paths")
+                    OR ("${_variableName}" STREQUAL "component_targets")
+                    OR ("${_variableName}" STREQUAL "__COMPONENT_TARGETS")
+                    OR ("${_variableName}" STREQUAL "CONFIGS_LIST")
+                    OR ("${_variableName}" STREQUAL "__CONFIG_VARIABLES")
+                    OR ("${_variableName}" STREQUAL "val")
+                    OR ("${_variableName}" MATCHES "^__idf_")
+               )
+                # Truncate the displayed value:
+                string(SUBSTRING "${${_variableName}}" 0 70 truncatedValue)
+                message(STATUS "${_variableName} = ${truncatedValue} ... (truncated)")
+            else()
+                message(STATUS "${_variableName}=${${_variableName}}")
+            endif()
         endforeach()
         message(STATUS "")
         message(STATUS "ALL VARIABLES END")
@@ -453,6 +887,12 @@ else()
     endif()
 
     # target_sources(wolfssl PRIVATE  "\"${WOLFSSL_ROOT}/wolfssl/\""  "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt\"")
+    message(STATUS "DETECTED_PROJECT_NAME=${CMAKE_PROJECT_NAME}")
+    message(STATUS "COMPONENT_TARGET=${COMPONENT_TARGET}")
+    target_compile_definitions(${COMPONENT_TARGET} PRIVATE DETECTED_PROJECT_NAME="${CMAKE_PROJECT_NAME}")
+    if( "${CMAKE_PROJECT_NAME}" STREQUAL "esp_http_client_example" )
+        target_compile_definitions(${COMPONENT_TARGET} PRIVATE APP_ESP_HTTP_CLIENT_EXAMPLE="y")
+    endif()
 
 endif() # CMAKE_BUILD_EARLY_EXPANSION
 
@@ -508,31 +948,77 @@ endfunction() # LIBWOLFSSL_SAVE_INFO
 
 # create some programmatic #define values that will be used by ShowExtendedSystemInfo().
 # see wolfcrypt\src\port\Espressif\esp32_utl.c
-if(NOT CMAKE_BUILD_EARLY_EXPANSION)
+if(NOT CMAKE_BUILD_EARLY_EXPANSION AND WOLFSSL_ROOT)
     set (git_cmd "git")
     message(STATUS "Adding macro definitions:")
 
     # LIBWOLFSSL_VERSION_GIT_ORIGIN: git config --get remote.origin.url
-    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "config" "--get" "remote.origin.url" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "config" "--get" "remote.origin.url"
+                    OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
     LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_ORIGIN "${TMP_OUT}" "${TMP_RES}")
 
     # LIBWOLFSSL_VERSION_GIT_BRANCH: git rev-parse --abbrev-ref HEAD
-    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "--abbrev-ref" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "--abbrev-ref" "HEAD"
+                    OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
     LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_BRANCH "${TMP_OUT}" "${TMP_RES}")
 
     # LIBWOLFSSL_VERSION_GIT_HASH: git rev-parse HEAD
-    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "HEAD"
+                    OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
     LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH "${TMP_OUT}" "${TMP_RES}")
 
     # LIBWOLFSSL_VERSION_GIT_SHORT_HASH: git rev-parse --short HEAD
-    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "--short" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET )
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "--short" "HEAD"
+                    OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET )
     LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_SHORT_HASH "${TMP_OUT}" "${TMP_RES}")
 
     # LIBWOLFSSL_VERSION_GIT_HASH_DATE git show --no-patch --no-notes --pretty=\'\%cd\'
-    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "show" "--no-patch" "--no-notes" "--pretty=\'\%cd\'" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES  )
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd}
+                    "show" "--no-patch" "--no-notes" "--pretty=\'\%cd\'"
+                    OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES  )
     LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH_DATE "${TMP_OUT}" "${TMP_RES}")
 
-    message(STATUS "************************************************************************************************")
-    message(STATUS "wolfssl component config complete!")
-    message(STATUS "************************************************************************************************")
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_WOLFSSL_ROOT "${WOLFSSL_ROOT}" "${TMP_RES}")
+
 endif()
+
+# Ensure flag "-DWOLFSSL_ESPIDF" is already in CMAKE_C_FLAGS if not yet found from project
+string(FIND "${CMAKE_C_FLAGS}" "-DWOLFSSL_ESPIDF" FLAG_ALRREADY_FOUND_WOLFSSL_ESPIDF)
+
+if(FLAG_ALRREADY_FOUND_WOLFSSL_ESPIDF EQUAL -1)
+    # Flag not found, append it
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_ESPIDF")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
+endif()
+
+if(WOLFSSL_ROOT)
+    message(STATUS "Using wolfSSL in ${WOLFSSL_ROOT}")
+
+    # PlatformIO does not process script from from the Espressif cmake process.
+    # We need to know where wolfSSL source code was found, so save it in the
+    # PIO_WOLFSSL_ROOT environment variable to later be read by extra_script.py
+
+    set(ENV{PIO_WOLFSSL_ROOT} "${WOLFSSL_ROOT}")
+    message(STATUS "PIO_WOLFSSL_ROOT =  $ENV{PIO_WOLFSSL_ROOT}")
+    message(STATUS "PLATFORMIO_BUILD_DIR = $ENV{PLATFORMIO_BUILD_DIR}")
+    file(WRITE "tada.txt" "${WOLFSSL_ROOT}\n")
+    # See esp-tls Kconfig; menu "ESP-TLS", ESP_TLS_LIBRARY_CHOOSE
+    if(CONFIG_ESP_TLS_USING_WOLFSSL)
+        message(STATUS "wolfSSL will be used for ESP-TLS")
+    else()
+        message(STATUS "WARNING: wolfSSL NOT selected for ESP-TLS. Features and performance will be limited.")
+    endif()
+else()
+    message(STATUS "")
+    message(STATUS "Consider setting WOLFSSL_ROOT environment variable, use Kconfig setting, or set manually in this cmake file, above.")
+    message(STATUS "")
+    message(STATUS "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+    message(STATUS "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+    message(STATUS "ERROR: Could not find wolfSSL Source Code")
+    message(STATUS "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+    message(STATUS "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+endif()
+
+message(STATUS "************************************************************************************************")
+message(STATUS "wolfSSL component config complete!")
+message(STATUS "************************************************************************************************")

--- a/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/Kconfig
+++ b/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/Kconfig
@@ -19,7 +19,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 #
 
-# Kconfig File Version 5.7.0.001 for wolfssl_test
+# Kconfig File Version 5.7.2.001 for esp-idf integration
 
 # Kconfig Format Rules
 #
@@ -50,13 +50,9 @@
 # ---------------------------------------------------------------------------------------------------------------------
 # Begin main wolfSSL configuration menu
 # ---------------------------------------------------------------------------------------------------------------------
+#   See ESP-IDF esp-tls component for config TLS_STACK_WOLFSSL
+
 menu "wolfSSL"
-    config TLS_STACK_WOLFSSL
-        bool "Include wolfSSL in ESP-TLS"
-        default y
-        select FREERTOS_ENABLE_BACKWARD_COMPATIBILITY
-        help
-            Includes wolfSSL in ESP-TLS so that it can be compiled with wolfSSL as its SSL/TLS library.
 
     menu "Hardening"
         config ESP_WOLFSSL_WC_NO_HARDEN
@@ -101,7 +97,7 @@ menu "wolfSSL"
     # wolfCrypt Test
     # -----------------------------------------------------------------------------------------------------------------
     config ESP_WOLFSSL_ENABLE_TEST
-        bool "Enable wolfCrypt test Library"
+        bool "Enable wolfCrypt Test Library"
         default n
         help
             Enables wolfcrypt/test/test.c code for testing. Disables NO_CRYPT_TEST.
@@ -113,6 +109,14 @@ menu "wolfSSL"
             default n
             help
                 Enables HAVE_WOLFCRYPT_TEST_OPTIONS
+
+        config TEST_ESPIDF_ALL_WOLFSSL
+            bool "Enable all features to use in tests"
+            depends on ESP_WOLFSSL_ENABLE_TEST
+            default n
+            help
+                Enables TEST_ESPIDF_ALL_WOLFSSL
+
     endmenu # wolfCrypt tests
 
     # -----------------------------------------------------------------------------------------------------------------
@@ -171,6 +175,13 @@ menu "wolfSSL"
             bool "Enable ALPN (Application Layer Protocol Negotiation) in wolfSSL"
             default y
 
+        config WOLFSSL_ALLOW_TLS13
+            bool "Allow TLS 1.3"
+            default y
+            help
+                Allow TLS to fallback to TLS1.2. Memory footprint will likely be larger for TLS1.2.
+                When disabled HTTPS and MQTT over TLS connections will fail if TLS1.3 not accepted.
+
         config WOLFSSL_ALLOW_TLS12
             bool "Allow TLS 1.2"
             default n
@@ -178,20 +189,123 @@ menu "wolfSSL"
                 Allow TLS to fallback to TLS1.2. Memory footprint will likely be larger for TLS1.2.
                 When disabled HTTPS and MQTT over TLS connections will fail if TLS1.3 not accepted.
 
+        config WOLFSSL_HAVE_TLS_EXTENSIONS
+            bool "Enable TLS Extensions"
+            default y
+            help
+                Sets HAVE_TLS_EXTENSIONS which is needed for TLS 1.3, SNI, ALPN, and more.
+
+        config WOLFSSL_ALT_CERT_CHAINS
+            bool "Enable Alternate Certificate Chains"
+            default n
+            help
+                The option relaxes the default strict wolfSSL certificate chain processing. This
+                will typically need to be enabled when loading only a CA file. Typically solves
+                the -188 ASN_NO_SIGNER_E error. Use with caution.
+
         config WOLFSSL_HAVE_OCSP
             bool "Enable OCSP (Online Certificate Status Protocol) in wolfSSL"
             default n
+            help
+                Sets HAVE_OCSP
+
     endmenu # Protocol Config
     # -----------------------------------------------------------------------------------------------------------------
 
     # -----------------------------------------------------------------------------------------------------------------
+    config TLS_STACK_WOLFSSL
+        # Invisible option that locks TLS_STACK_WOLFSSL to ESP_TLS_USING_WOLFSSL
+        bool
+        default n
+        select FREERTOS_ENABLE_BACKWARD_COMPATIBILITY
+        help
+            Includes wolfSSL in ESP-TLS so that it can be compiled with wolfSSL as its SSL/TLS library.
+            Enabled when wolfSSL is selected in ESP_TLS_LIBRARY_CHOOSE.
+
     menu "wolfSSL ESP-TLS"
-        config TLS_STACK_WOLFSSL
-            bool "Include wolfSSL in ESP-TLS"
-            default y
-            select FREERTOS_ENABLE_BACKWARD_COMPATIBILITY
-            help
-                Includes wolfSSL in ESP-TLS so that it can be compiled with wolfSSL as its SSL/TLS library.
+        depends on ESP_TLS_USING_WOLFSSL
+
+        menu "Certificate Bundle"
+            depends on ESP_TLS_USING_WOLFSSL
+
+            config WOLFSSL_CERTIFICATE_BUNDLE
+                bool "Enable trusted root certificate bundle"
+                default y if ESP_TLS_USING_WOLFSSL
+                default n
+                depends on ESP_TLS_USING_WOLFSSL
+                help
+                    Enable support for large number of default root certificates
+
+                    When enabled this option allows user to store default as well
+                    as customer specific root certificates in compressed format rather
+                    than storing full certificate. For the root certificates the public key and the subject name
+                    will be stored.
+
+            config WOLFSSL_NO_ASN_STRICT
+                bool "Relax Certificate ASN Strict Checks"
+                default n
+                depends on ESP_TLS_USING_WOLFSSL
+                help
+                    Allows sub-optimal certificate ASN checks. Unless using a bundle with known issues,
+                    it is recommended to NOT enable this.
+
+            config WOLFSSL_ASN_ALLOW_0_SERIAL
+                bool "Allow cert missing an ASN Serial Number"
+                default y
+                depends on ESP_TLS_USING_WOLFSSL
+                help
+                    Although not recommended, there may be certificates in the bundle that are missing
+                    a serial number. This option allows the missing value without having to fully
+                    disable strict ASN checking with WOLFSSL_NO_ASN_STRICT.
+
+            choice WOLFSSL_DEFAULT_CERTIFICATE_BUNDLE
+                bool "Default certificate bundle options"
+                depends on WOLFSSL_CERTIFICATE_BUNDLE && ESP_TLS_USING_WOLFSSL
+                default WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_FULL
+
+                config WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_FULL
+                    bool "Use the full default certificate bundle"
+                config WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_CMN
+                    bool "Use only the most common certificates from the default bundles"
+                    help
+                        Use only the most common certificates from the default bundles, reducing the size with 50%,
+                        while still having around 99% coverage.
+                config WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_NONE
+                    bool "Do not use the default certificate bundle"
+            endchoice
+
+            config WOLFSSL_CUSTOM_CERTIFICATE_BUNDLE
+                depends on WOLFSSL_CERTIFICATE_BUNDLE && ESP_TLS_USING_WOLFSSL
+                default n
+                bool "Add custom certificates to the default bundle"
+            config WOLFSSL_CUSTOM_CERTIFICATE_BUNDLE_PATH
+                depends on WOLFSSL_CUSTOM_CERTIFICATE_BUNDLE && ESP_TLS_USING_WOLFSSL
+                string "Custom certificate bundle path"
+                help
+                    Name of the custom certificate directory or file. This path is evaluated
+                    relative to the project root directory.
+
+            config WOLFSSL_CERTIFICATE_BUNDLE_DEPRECATED_LIST
+                bool "Add deprecated root certificates"
+                depends on WOLFSSL_CERTIFICATE_BUNDLE && ESP_TLS_USING_WOLFSSL && !WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_NONE
+                help
+                    Include the deprecated list of root certificates in the bundle.
+                    This list gets updated when a certificate is removed from the Mozilla's
+                    NSS root certificate store. This config can be enabled if you would like
+                    to ensure that none of the certificates that were deployed in the product
+                    are affected because of the update to bundle. In turn, enabling this
+                    config keeps expired, retracted certificates in the bundle and it may
+                    pose a security risk.
+
+                    - Deprecated cert list may grow based based on sync with upstream bundle
+                    - Deprecated certs would be be removed in ESP-IDF (next) major release
+
+            config WOLFSSL_CERTIFICATE_BUNDLE_MAX_CERTS
+                int "Maximum no of certificates allowed in certificate bundle"
+                default 200
+                depends on WOLFSSL_CERTIFICATE_BUNDLE && ESP_TLS_USING_WOLFSSL
+
+        endmenu
     endmenu # wolfSSL ESP-TLS
     # -----------------------------------------------------------------------------------------------------------------
 
@@ -200,6 +314,9 @@ menu "wolfSSL"
         bool "Modify default hardware acceleration settings"
         default n
         help
+            When disabling all hardware acceleration for smaller memory footprint,
+            disabling TFM fast math provides faster wolfSSL software algorithms in an
+            even smaller flash memory footprint.
             Typically used for debugging, analysis, or optimizations. The default
             hardware acceleration features can be each manually adjusted.
 
@@ -327,6 +444,21 @@ menu "wolfSSL"
     endmenu # Component Config
     # -----------------------------------------------------------------------------------------------------------------
 
+    # -----------------------------------------------------------------------------------------------------------------
+    menu "Utility Config"
+        config USE_WOLFSSL_ESP_SDK_TIME
+            bool "Enable wolfSSL time helper functions"
+            default n
+            help
+                Enables use of various time and date setting functions found in the esp-sdk-lib.h file.
+
+        config USE_WOLFSSL_ESP_SDK_WIFI
+            bool "Enable wolfSSL WiFi helper functions"
+            default n
+            help
+                Enables use of various time and date setting functions found in the esp-sdk-lib.h file.
+
+    endmenu # Utility Config
 endmenu # wolfSSL
 # ---------------------------------------------------------------------------------------------------------------------
 

--- a/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/include/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/include/user_settings.h
@@ -18,7 +18,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
-#define WOLFSSL_ESPIDF_COMPONENT_VERSION 0x
+#define WOLFSSL_ESPIDF_COMPONENT_VERSION 0x01
 
 /* The Espressif project config file. See also sdkconfig.defaults */
 #include "sdkconfig.h"
@@ -82,76 +82,119 @@
 /* Test various user_settings between applications by selecting example apps
  * in `idf.py menuconfig` for Example wolfSSL Configuration settings: */
 
-/* wolfSSL Examples */
-#ifdef CONFIG_WOLFSSL_EXAMPLE_NAME_TEMPLATE
+/* Turn on messages that are useful to see only in examples. */
+#define WOLFSSL_EXAMPLE_VERBOSITY
+
+/* wolfSSL Examples: set macros used in example applications.
+ *
+ * These Settings NOT available in ESP-IDF (e.g. esp-tls)
+ *
+ * Any settings needed by ESP-IDF components should be explicitly set,
+ * and not by these example-specific settings via CONFIG_WOLFSSL_EXAMPLE_n
+ *
+ * ESP-IDF settings should be Kconfig "CONFIG_[name]" values when possible. */
+#if defined(CONFIG_WOLFSSL_EXAMPLE_NAME_TEMPLATE)
     /* See https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/template */
     /* We don't use WiFi, so don't compile in the esp-sdk-lib WiFi helpers: */
     /* #define USE_WOLFSSL_ESP_SDK_WIFI */
-#elif CONFIG_WOLFSSL_EXAMPLE_NAME_TEST
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_TEST)
     /* See https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/wolfssl_test */
     /* We don't use WiFi, so don't compile in the esp-sdk-lib WiFi helpers: */
     /* #define USE_WOLFSSL_ESP_SDK_WIFI */
     #define TEST_ESPIDF_ALL_WOLFSSL
 
-#elif CONFIG_WOLFSSL_EXAMPLE_NAME_BENCHMARK
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_BENCHMARK)
     /* See https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark */
     /* We don't use WiFi, so don't compile in the esp-sdk-lib WiFi helpers: */
     /* #define USE_WOLFSSL_ESP_SDK_WIFI */
-#elif CONFIG_WOLFSSL_EXAMPLE_NAME_TLS_CLIENT
+    #define WOLFSSL_BENCHMARK_FIXED_UNITS_KB
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_TLS_CLIENT)
     /* See https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/wolfssl_client */
     #define USE_WOLFSSL_ESP_SDK_WIFI
-#elif CONFIG_WOLFSSL_EXAMPLE_NAME_TLS_SERVER
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_TLS_SERVER)
     /* See https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/wolfssl_server */
     #define USE_WOLFSSL_ESP_SDK_WIFI
 
 /* wolfSSH Examples */
-#elif CONFIG_WOLFSSL_EXAMPLE_NAME_WOLFSSH_TEMPLATE
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_WOLFSSH_TEMPLATE)
     /* See https://github.com/wolfSSL/wolfssh/tree/master/ide/Espressif/ESP-IDF/examples/wolfssh_template */
     #define USE_WOLFSSL_ESP_SDK_WIFI
-#elif CONFIG_WOLFSSL_EXAMPLE_NAME_WOLFSSH_ECHOSERVER
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_WOLFSSH_ECHOSERVER)
     /* See https://github.com/wolfSSL/wolfssh/tree/master/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver */
     #define USE_WOLFSSL_ESP_SDK_WIFI
-#elif CONFIG_WOLFSSL_EXAMPLE_NAME_ESP32_SSH_SERVER
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_ESP32_SSH_SERVER)
     /* See https://github.com/wolfSSL/wolfssh-examples/tree/main/Espressif/ESP32/ESP32-SSH-Server */
     #define USE_WOLFSSL_ESP_SDK_WIFI
-#elif CONFIG_WOLFSSL_EXAMPLE_NAME_ESP8266_SSH_SERVER
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_ESP8266_SSH_SERVER)
     /* See https://github.com/wolfSSL/wolfssh-examples/tree/main/Espressif/ESP8266/ESP8266-SSH-Server */
     #define USE_WOLFSSL_ESP_SDK_WIFI
 
 /* wolfMQTT Examples */
-#elif CONFIG_WOLFSSL_EXAMPLE_NAME_WOLFMQTT_TEMPLATE
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_WOLFMQTT_TEMPLATE)
     /* See https://github.com/wolfSSL/wolfMQTT/tree/master/IDE/Espressif/ESP-IDF/examples/wolfmqtt_template */
     #define USE_WOLFSSL_ESP_SDK_WIFI
-#elif CONFIG_WOLFSSL_EXAMPLE_NAME_WOLFMQTT_AWS_IOT_MQTT
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_WOLFMQTT_AWS_IOT_MQTT)
     /* See https://github.com/wolfSSL/wolfMQTT/tree/master/IDE/Espressif/ESP-IDF/examples/AWS_IoT_MQTT */
     #define USE_WOLFSSL_ESP_SDK_WIFI
 
 /* wolfTPM Examples */
-#elif CONFIG_WOLFTPM_EXAMPLE_NAME_ESPRESSIF
+#elif defined(CONFIG_WOLFTPM_EXAMPLE_NAME_ESPRESSIF)
     /* See https://github.com/wolfSSL/wolfTPM/tree/master/IDE/Espressif */
     #define USE_WOLFSSL_ESP_SDK_WIFI
 
 /* Apple HomeKit Examples */
-#elif CONFIG_WOLFSSL_APPLE_HOMEKIT
+#elif defined(CONFIG_WOLFSSL_APPLE_HOMEKIT)
     /* See https://github.com/AchimPieters/esp32-homekit-demo */
 
 /* no example selected */
-#elif CONFIG_WOLFSSL_EXAMPLE_NAME_NONE
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_NONE)
     /* We'll assume the app needs to use wolfSSL sdk lib function */
     #define USE_WOLFSSL_ESP_SDK_WIFI
 
-/* Unknown config */
+/* Other applications detected by cmake */
+#elif defined(APP_ESP_HTTP_CLIENT_EXAMPLE)
+    /* The wolfSSL Version */
+    #define FP_MAX_BITS (8192 * 2)
+    #define HAVE_ALPN
+    #define HAVE_SNI
+    #define OPENSSL_EXTRA_X509_SMALL
+    #define HAVE_TLS_EXTENSIONS
+    #define HAVE_SUPPORTED_CURVES
+    #define OPENSSL_EXTRA
+    #ifndef WOLFSSL_ALWAYS_VERIFY_CB
+       #define WOLFSSL_ALWAYS_VERIFY_CB
+    #endif
+    #ifndef WOLFSSL_VERIFY_CB_ALL_CERTS
+        #define WOLFSSL_VERIFY_CB_ALL_CERTS
+    #endif
+    #ifndef KEEP_PEER_CERT
+        #define KEEP_PEER_CERT
+    #endif
+
+#elif defined(APP_ESP_HTTP_CLIENT)
+    /* The ESP-IDF Version */
+    #define FP_MAX_BITS (8192 * 2)
+    #define HAVE_ALPN
+    #define HAVE_SNI
+    #define OPENSSL_EXTRA_X509_SMALL
+    #define HAVE_TLS_EXTENSIONS
+    #define HAVE_SUPPORTED_CURVES
+    #define OPENSSL_EXTRA
+    #ifndef WOLFSSL_ALWAYS_VERIFY_CB
+       #define WOLFSSL_ALWAYS_VERIFY_CB
+    #endif
+    #ifndef WOLFSSL_VERIFY_CB_ALL_CERTS
+        #define WOLFSSL_VERIFY_CB_ALL_CERTS
+    #endif
+    #ifndef KEEP_PEER_CERT
+        #define KEEP_PEER_CERT
+    #endif
 #else
+    #ifdef WOLFSSL_ESPIDF
+        /* #warning "App config undetected" */
+    #endif
     /* the code is older or does not have application name defined. */
 #endif /* Example wolfSSL Configuration app settings */
-
-
-#if defined(CONFIG_TLS_STACK_WOLFSSL) && (CONFIG_TLS_STACK_WOLFSSL)
-    /* When using ESP-TLS, some old algoritms such as SHA1 are no longer
-     * enabled in wolfSSL, except for the OpenSSL compatibility. So enable
-     * that here: */
-    #define OPENSSL_EXTRA
-#endif
 
 /* Experimental Kyber */
 #ifdef CONFIG_WOLFSSL_ENABLE_KYBER
@@ -194,11 +237,16 @@
      #define WOLFSSL_BASE64_ENCODE
  #endif /* Apple HomeKit settings */
 
+/* Used by ESP-IDF components: */
 #if defined(CONFIG_ESP_TLS_USING_WOLFSSL)
     /* The ESP-TLS */
-    #define  HAVE_ALPN
-    #define  HAVE_SNI
-    #define  OPENSSL_EXTRA_X509_SMALL
+    #define FP_MAX_BITS (8192 * 2)
+    #define HAVE_ALPN
+    #define HAVE_SNI
+    #define OPENSSL_EXTRA_X509_SMALL
+
+    #define HAVE_TLS_EXTENSIONS
+    #define HAVE_SUPPORTED_CURVES
 #endif
 
 /* Optionally enable some wolfSSH settings */
@@ -250,7 +298,7 @@
 /* See below for chipset detection from sdkconfig.h */
 
 /* when you want to use SINGLE THREAD. Note Default ESP-IDF is FreeRTOS */
-/* #define SINGLE_THREADED */
+#define SINGLE_THREADED
 
 /* Small session cache saves a lot of RAM for ClientCache and SessionCache.
  * Memory requirement is about 5KB, otherwise 20K is needed when not specified.
@@ -272,129 +320,6 @@
 /* RSA_LOW_MEM: Half as much memory but twice as slow. */
 #define RSA_LOW_MEM
 
-/* Uncommon settings for testing only */
-#ifdef TEST_ESPIDF_ALL_WOLFSSL
-    #define WOLFSSL_MD2
-    #define HAVE_BLAKE2
-    #define HAVE_BLAKE2B
-    #define HAVE_BLAKE2S
-
-    #define WC_RC2
-    #define WOLFSSL_ALLOW_RC4
-
-    #define HAVE_POLY1305
-
-    #define WOLFSSL_AES_128
-    #define WOLFSSL_AES_OFB
-    #define WOLFSSL_AES_CFB
-    #define WOLFSSL_AES_XTS
-
-    /* #define WC_SRTP_KDF */
-    /* TODO Causes failure with Espressif AES HW Enabled */
-    /* #define HAVE_AES_ECB */
-    /* #define HAVE_AESCCM  */
-    /* TODO sanity check when missing HAVE_AES_ECB */
-    #define WOLFSSL_WOLFSSH
-
-    #define HAVE_AESGCM
-    #define WOLFSSL_AES_COUNTER
-
-    #define HAVE_FFDHE
-    #define HAVE_FFDHE_2048
-    #if defined(CONFIG_IDF_TARGET_ESP8266)
-        /* TODO Full size SRP is disabled on the ESP8266 at this time.
-         * Low memory issue? */
-        #define WOLFCRYPT_HAVE_SRP
-        /* MIN_FFDHE_FP_MAX_BITS = (MIN_FFDHE_BITS * 2); see settings.h */
-        #define FP_MAX_BITS MIN_FFDHE_FP_MAX_BITS
-    #elif defined(CONFIG_IDF_TARGET_ESP32)   || \
-          defined(CONFIG_IDF_TARGET_ESP32S2) || \
-          defined(CONFIG_IDF_TARGET_ESP32S3)
-        #define WOLFCRYPT_HAVE_SRP
-        #define FP_MAX_BITS (8192 * 2)
-    #elif defined(CONFIG_IDF_TARGET_ESP32C3) || \
-          defined(CONFIG_IDF_TARGET_ESP32H2)
-        /* SRP Known to be working on this target::*/
-        #define WOLFCRYPT_HAVE_SRP
-        #define FP_MAX_BITS (8192 * 2)
-    #else
-        /* For everything else, give a try and see if SRP working: */
-        #define WOLFCRYPT_HAVE_SRP
-        #define FP_MAX_BITS (8192 * 2)
-    #endif
-
-    #define HAVE_DH
-
-    /* TODO: there may be a problem with HAVE_CAMELLIA with HW AES disabled.
-     * Do not define NO_WOLFSSL_ESP32_CRYPT_AES when enabled: */
-    /* #define HAVE_CAMELLIA */
-
-    /* DSA requires old SHA */
-    #define HAVE_DSA
-
-    /* Needs SHA512 ? */
-    #define HAVE_HPKE
-
-    /* Not for Espressif? */
-    #if defined(CONFIG_IDF_TARGET_ESP32C2) || \
-        defined(CONFIG_IDF_TARGET_ESP8684) || \
-        defined(CONFIG_IDF_TARGET_ESP32H2) || \
-        defined(CONFIG_IDF_TARGET_ESP8266)
-
-        #if defined(CONFIG_IDF_TARGET_ESP8266)
-            #undef HAVE_ECC
-            #undef HAVE_ECC_CDH
-            #undef HAVE_CURVE25519
-
-            /* TODO does CHACHA also need alignment? Failing on ESP8266
-             * See SHA256 __attribute__((aligned(4))); and WC_SHA256_ALIGN */
-            #ifdef HAVE_CHACHA
-                #error "HAVE_CHACHA not supported on ESP8266"
-            #endif
-            #ifdef HAVE_XCHACHA
-                #error "HAVE_XCHACHA not supported on ESP8266"
-            #endif
-        #else
-            #define HAVE_XCHACHA
-            #define HAVE_CHACHA
-            /* TODO Not enabled at this time, needs further testing:
-             *   #define WC_SRTP_KDF
-             *   #define HAVE_COMP_KEY
-             *   #define WOLFSSL_HAVE_XMSS
-             */
-        #endif
-        /* TODO AES-EAX not working on this platform */
-
-        /* Optionally disable DH
-         *   #undef HAVE_DH
-         *   #undef HAVE_FFDHE
-         */
-
-        /* ECC_SHAMIR out of memory on ESP32-C2 during ECC  */
-        #ifndef HAVE_ECC
-            #define ECC_SHAMIR
-        #endif
-    #else
-        #define WOLFSSL_AES_EAX
-
-        #define ECC_SHAMIR
-    #endif
-
-    /* Only for WOLFSSL_IMX6_CAAM / WOLFSSL_QNX_CAAM ? */
-    /* #define WOLFSSL_CAAM      */
-    /* #define WOLFSSL_CAAM_BLOB */
-
-    #define WOLFSSL_AES_SIV
-    #define WOLFSSL_CMAC
-
-    #define WOLFSSL_CERT_PIV
-
-    /* HAVE_SCRYPT may turn on HAVE_PBKDF2 see settings.h */
-    /* #define HAVE_SCRYPT */
-    #define SCRYPT_TEST_ALL
-    #define HAVE_X963_KDF
-#endif
-
 /* optionally turn off SHA512/224 SHA512/256 */
 /* #define WOLFSSL_NOSHA512_224 */
 /* #define WOLFSSL_NOSHA512_256 */
@@ -409,14 +334,33 @@
 #define BENCH_EMBEDDED
 
 /* TLS 1.3                                 */
-#define WOLFSSL_TLS13
-#define HAVE_TLS_EXTENSIONS
-#define WC_RSA_PSS
-#define HAVE_HKDF
-#define HAVE_AEAD
-#define HAVE_SUPPORTED_CURVES
+#ifdef CONFIG_WOLFSSL_ALLOW_TLS13
+    #define WOLFSSL_TLS13
+    #define HAVE_TLS_EXTENSIONS
+    #define HAVE_HKDF
 
-#define WOLFSSL_BENCHMARK_FIXED_UNITS_KB
+    /* May be required */
+    #ifndef HAVE_AEAD
+    #endif
+
+    /* Required for ECC */
+    #define HAVE_SUPPORTED_CURVES
+
+    /* Required for RSA */
+    #define WC_RSA_PSS
+
+    /* TLS 1.3 normally requires HAVE_FFDHE. For now just syntax highlight: */
+    #if defined(HAVE_FFDHE_2048) || \
+        defined(HAVE_FFDHE_3072) || \
+        defined(HAVE_FFDHE_4096) || \
+        defined(HAVE_FFDHE_6144) || \
+        defined(HAVE_FFDHE_8192)
+    #else
+        /* #error "TLS 1.3 requires HAVE_FFDHE_[nnnn]" */
+    #endif
+#endif
+
+
 
 #define NO_FILESYSTEM
 
@@ -443,14 +387,19 @@
     #define WOLFSSL_SHA512
 
     /* when you want to use SHA3 */
-    #define WOLFSSL_SHA3
+    /* #define WOLFSSL_SHA3 */
 
     /* ED25519 requires SHA512 */
     #define HAVE_ED25519
 #endif
 
-#define MY_USE_ECC 1
-#define MY_USE_RSA 0
+#if defined(CONFIG_IDF_TARGET_ESP8266) || defined(CONFIG_IDF_TARGET_ESP32C2)
+    #define MY_USE_ECC 0
+    #define MY_USE_RSA 1
+#else
+    #define MY_USE_ECC 1
+    #define MY_USE_RSA 0
+#endif
 
 /* We can use either or both ECC and RSA, but must use at least one. */
 #if MY_USE_ECC || MY_USE_RSA
@@ -459,7 +408,7 @@
         #define HAVE_ECC
         #define HAVE_CURVE25519
         #define HAVE_ED25519
-
+        #define WOLFSSL_SHA512
         /*
         #define HAVE_ECC384
         #define CURVE25519_SMALL
@@ -568,14 +517,26 @@
 
 /* #define HAVE_HASHDRBG */
 
+#if 0
+/* Example for additional cert functions */
 #define WOLFSSL_KEY_GEN
-#define WOLFSSL_CERT_REQ
-#define WOLFSSL_CERT_GEN
-#define WOLFSSL_CERT_EXT
-#define WOLFSSL_SYS_CA_CERTS
+    #define WOLFSSL_CERT_REQ
+    #define WOLFSSL_CERT_GEN
+    #define WOLFSSL_CERT_EXT
+    #define WOLFSSL_SYS_CA_CERTS
 
 
-#define WOLFSSL_CERT_TEXT
+    #define WOLFSSL_CERT_TEXT
+
+    /* command-line options
+    --enable-keygen
+    --enable-certgen
+    --enable-certreq
+    --enable-certext
+    --enable-asn-template
+    */
+
+#endif
 
 #define WOLFSSL_ASN_TEMPLATE
 
@@ -827,10 +788,19 @@
 /* Debug options:
 See wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h for details on debug options
 
+optionally increase error message size for very long paths.
+#define WOLFSSL_MAX_ERROR_SZ 500
+
+Turn debugging on/off:
+    wolfSSL_Debugging_ON();
+    wolfSSL_Debugging_OFF();
+
 #define ESP_VERIFY_MEMBLOCK
 #define DEBUG_WOLFSSL
 #define DEBUG_WOLFSSL_VERBOSE
 #define DEBUG_WOLFSSL_SHA_MUTEX
+#define WOLFSSL_DEBUG_IGNORE_ASN_TIME
+#define WOLFSSL_DEBUG_CERT_BUNDLE
 #define WOLFSSL_ESP32_CRYPT_DEBUG
 #define WOLFSSL_ESP32_CRYPT_HASH_SHA224_DEBUG
 #define NO_RECOVER_SOFTWARE_CALC
@@ -854,6 +824,7 @@ Turn on timer debugging (used when CPU cycles not available)
 
 /* Pause in a loop rather than exit. */
 /* #define WOLFSSL_ESPIDF_ERROR_PAUSE */
+/* #define WOLFSSL_ESP32_HW_LOCK_DEBUG */
 
 #define WOLFSSL_HW_METRICS
 

--- a/IDE/Espressif/ESP-IDF/examples/template/sdkconfig.defaults
+++ b/IDE/Espressif/ESP-IDF/examples/template/sdkconfig.defaults
@@ -4,6 +4,8 @@ CONFIG_WOLFSSL_EXAMPLE_NAME_TEMPLATE=y
 CONFIG_FREERTOS_HZ=1000
 CONFIG_ESP32_DEFAULT_CPU_FREQ_240=y
 
+# Set the known example app config to TLS Client (see user_settings.h)
+CONFIG_WOLFSSL_EXAMPLE_NAME_TEMPLATE=y
 #
 # Default main stack size
 #


### PR DESCRIPTION
# Description

Building on the capabilities introduced in https://github.com/wolfSSL/wolfssl/pull/7936, https://github.com/wolfSSL/wolfssl/pull/7893, https://github.com/wolfSSL/wolfssl/pull/7866 this PR moves some of the common Espressif Kconfig settings and feature detection from `user_settings.h` to the wolfcrypt `settings.h` file.

Included is a minor update & code sync to the reference `template` application. See the respective `user_settings.h` for an example of how `Kconfig` settings (via `sdkconfig.h`) are used.

I'm planning on updates to all of the other Espressif examples (test, benchmark, client, server) very soon, hopefully in time for the next release.

The intention is for all wolfSSL examples and reference code to have exactly the same component `user_settings.h`, `Kconfig`,  and `CMakeLists.txt` files. All the application-specific settings can then be assigned via the respective `sdkconfig.defaults` files and/or changed via `idf.py menuconfig` rather than manual edits to `user_settings.h`. This is important for the [wolfssl Managed Component](https://components.espressif.com/components/wolfssl/wolfssl) that doesn't like source code edits, including changes to the `user_settings.h`.

There's no adverse effect for non-Managed Component apps. The `user_settings.h` _can_ still be edited. There's still a peripheral benefit of having consistent files throughout all the examples.

Fixes zd# n/a

# Testing

How did you test?

Primarily tested in the Espressif environment, with a quick `make clean` and `make test` before PR submission.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
