### PR TITLE
Update Espressif sha, util, mem, time helpers

### DIFF
--- a/wolfcrypt/src/port/Espressif/esp_sdk_mem_lib.c
+++ b/wolfcrypt/src/port/Espressif/esp_sdk_mem_lib.c
@@ -161,7 +161,7 @@ static const char* sdk_memory_segment_text[SDK_MEMORY_SEGMENT_COUNT + 1] = {
 int sdk_log_meminfo(enum sdk_memory_segment m, void* start, void* end)
 {
     const char* str;
-    int len = 0;
+    word32 len = 0;
     str = sdk_memory_segment_text[m];
     sdk_memory_segment_start[m] = start;
     sdk_memory_segment_end[m] = end;
@@ -173,7 +173,7 @@ int sdk_log_meminfo(enum sdk_memory_segment m, void* start, void* end)
         ESP_LOGI(TAG, "                  Start         End          Length");
     }
     else {
-        len = (uint32_t)end - (uint32_t)start;
+        len = (word32)end - (word32)start;
         ESP_LOGI(TAG, "%s: %p ~ %p : 0x%05x (%d)", str, start, end, len, len );
     }
     return ESP_OK;

--- a/wolfcrypt/src/port/Espressif/esp_sdk_time_lib.c
+++ b/wolfcrypt/src/port/Espressif/esp_sdk_time_lib.c
@@ -23,14 +23,19 @@
     #include <config.h>
 #endif
 
-/* Reminder: user_settings.h is needed and included from settings.h
- * Be sure to define WOLFSSL_USER_SETTINGS, typically in CMakeLists.txt */
-#include <wolfssl/wolfcrypt/settings.h>
+/* wolfSSL */
+/* Always include wolfcrypt/settings.h before any other wolfSSL file.    */
+/* Reminder: settings.h pulls in user_settings.h; don't include it here. */
+#ifdef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/wolfcrypt/settings.h>
+#endif
+
 
 #if defined(WOLFSSL_ESPIDF) /* Entire file is only for Espressif EDP-IDF */
+#include "sdkconfig.h" /* programmatically generated from sdkconfig */
+
 #if defined(USE_WOLFSSL_ESP_SDK_TIME)
 /* Espressif */
-#include "sdkconfig.h" /* programmatically generated from sdkconfig */
 #include <esp_log.h>
 #include <esp_err.h>
 
@@ -145,11 +150,11 @@ int set_fixed_default_time(void)
      * but let's set a default time, just in case */
     struct tm timeinfo = {
         .tm_year = 2024 - 1900,
-        .tm_mon  = 1,
-        .tm_mday = 05,
+        .tm_mon  =  9 - 1, /* Month, where 0 = Jan */
+        .tm_mday =  3 ,    /* Day of the month 30  */
         .tm_hour = 13,
-        .tm_min  = 01,
-        .tm_sec  = 05
+        .tm_min  =  1,
+        .tm_sec  =  5
     };
     struct timeval now;
     time_t interim_time;

--- a/wolfssl/wolfcrypt/port/Espressif/esp-sdk-lib.h
+++ b/wolfssl/wolfcrypt/port/Espressif/esp-sdk-lib.h
@@ -148,9 +148,13 @@ WOLFSSL_LOCAL esp_err_t sdk_var_whereis(const char* v_name, void* v);
 
 WOLFSSL_LOCAL intptr_t esp_sdk_stack_pointer(void);
 
+#if defined(USE_WOLFSSL_ESP_SDK_TIME)
+
 /******************************************************************************
 * Time helpers
 ******************************************************************************/
+WOLFSSL_LOCAL esp_err_t esp_sdk_time_mem_init(void);
+
 WOLFSSL_LOCAL esp_err_t esp_sdk_time_lib_init(void);
 
 /* a function to show the current data and time */
@@ -168,8 +172,9 @@ WOLFSSL_LOCAL esp_err_t set_time(void);
 
 /* wait NTP_RETRY_COUNT seconds before giving up on NTP time */
 WOLFSSL_LOCAL esp_err_t set_time_wait_for_ntp(void);
+#endif
 
-#ifndef NO_ESP_SDK_WIFI
+#if defined(USE_WOLFSSL_ESP_SDK_WIFI)
 
 /******************************************************************************
 * WiFi helpers
@@ -201,8 +206,7 @@ WOLFSSL_LOCAL esp_err_t esp_sdk_wifi_init_sta(void);
 
 WOLFSSL_LOCAL esp_err_t esp_sdk_wifi_show_ip(void);
 
-#endif /* !NO_ESP_SDK_WIFI */
-
+#endif /* USE_WOLFSSL_ESP_SDK_WIFI */
 
 /******************************************************************************
 * Debug helpers


### PR DESCRIPTION
# Description

This update polishes some of the  `wolfcrypt/src/port/Espressif` files:

- Improvement in multithread diagnostics and error checking 
- Add some various ESP32 flavor CPU frequency visibility.
- `WOLFSSL_ESPIDF_BLANKLINE_MESSAGE` as some environments cannot print empty string `""`.
- Update some variable types.
- Adjust default fallback, hard-coded "better than nothing" date.
- Use WiFi helper as desired ('USE_WOLFSSL_ESP_SDK_WIFI'), no longer enabled by default.
- Add comment, error checking, sanity checks.

Fixes zd# n/a

# Testing

How did you test?

These are changes that I've had in my development branch for some time. Tested primarily in Espressif ESP-IDF.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
