### PR TITLE
Check if it has been defined before defining _GNU_SOURCE

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -24,7 +24,7 @@
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>
-#if defined(OPENSSL_EXTRA) && !defined(_WIN32)
+#if defined(OPENSSL_EXTRA) && !defined(_WIN32) && !defined(_GNU_SOURCE)
     /* turn on GNU extensions for XVASPRINTF with wolfSSL_BIO_printf */
     #undef  _GNU_SOURCE
     #define _GNU_SOURCE

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -25,7 +25,7 @@
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>
-#if defined(OPENSSL_EXTRA) && !defined(_WIN32)
+#if defined(OPENSSL_EXTRA) && !defined(_WIN32) && !defined(_GNU_SOURCE)
     /* turn on GNU extensions for XISASCII */
     #undef  _GNU_SOURCE
     #define _GNU_SOURCE


### PR DESCRIPTION
# Description

Do a check for the `_GNU_SOURCE` macro before defining it.

Fixes #7957

# Testing

Tested by building WolfSSL 5.7.2 against Netatalk.

# Checklist

N/A
