### PR TITLE
Update to use C99 instead of C11 because of lack of SGX support

### DIFF
--- a/IDE/LINUX-SGX/sgx_t_static.mk
+++ b/IDE/LINUX-SGX/sgx_t_static.mk
@@ -115,7 +115,7 @@ ifeq ($(HAVE_WOLFSSL_SP), 1)
 endif
 
 
-Flags_Just_For_C := -Wno-implicit-function-declaration -std=c11
+Flags_Just_For_C := -Wno-implicit-function-declaration -std=c99
 Common_C_Cpp_Flags := $(SGX_COMMON_CFLAGS) -nostdinc -fvisibility=hidden -fpie -fstack-protector $(Wolfssl_Include_Paths) -fno-builtin-printf -I.
 Wolfssl_C_Flags := $(Flags_Just_For_C) $(Common_C_Cpp_Flags) $(Wolfssl_C_Extra_Flags)
 


### PR DESCRIPTION
# Description

After adding C11 memory fence support, the SGX nightly test failed with a missing stdatomic.h file.  Our IDE/LINUX-SGX makefile erroneously forced C11 standard compliance, but SGX is only compatible with C99 and C++11.  This change corrects the C standard to be C99 to match the libc that is embedded within the SGX include libraries.

Fixes job nightly-SGX_Linux-v2. 

Note: I'm apply the same correction to wolfssl-examples SGX_LINUX.

# Testing

Tested using boz-sgx, which is Ubuntu 18 with SGX SDK and matched build commands with script.  

# Checklist

 - [ X ] added tests -CORRECTED tests
 - [ N/A ] updated/added doxygen
 - [ N/A ] updated appropriate READMEs
 - [ N/A ] Updated manual and documentation
