### PR TITLE
Update HAVE_FIPS define guard in test.h.

### DIFF
--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -3342,8 +3342,9 @@ static WC_INLINE int myEccSharedSecret(WOLFSSL* ssl, ecc_key* otherKey,
         ret = BAD_FUNC_ARG;
     }
 
-#if defined(ECC_TIMING_RESISTANT) && !defined(HAVE_FIPS) && \
-                                                         !defined(HAVE_SELFTEST)
+#if defined(ECC_TIMING_RESISTANT) && (!defined(HAVE_FIPS) || \
+    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION != 2))) && \
+    !defined(HAVE_SELFTEST)
     if (ret == 0) {
         ret = wc_ecc_set_rng(privKey, wolfSSL_GetRNG(ssl));
     }


### PR DESCRIPTION
# Description

An outdated FIPS define guard in wolfssl/tests.h was preventing ecc privKey from having its rng member set when using pkcallbacks. This caused `./scripts/pkcallbacks.test` to fail.

Fixes zd#18594

# Testing

Reproducer in ticket.