### PR TITLE
Add cmake support for WOLFSSL_CUSTOM_CURVES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -945,12 +945,28 @@ if(WOLFSSL_ECC)
     endif()
 endif()
 
-# TODO: - ECC custom curves
-#       - Compressed key
+# TODO: - Compressed key
 #       - FP ECC, fixed point cache ECC
 #       - ECC encrypt
 #       - PSK
 #       - Single PSK identity
+
+# ECC custom curves
+add_option("WOLFSSL_ECCCUSTCURVES"
+    "Enable ECC Custom Curves (default: disabled)"
+    "no" "yes;no;all")
+
+if(WOLFSSL_ECCCUSTCURVES)
+    if("${WOLFSSL_ECCCUSTCURVES}" STREQUAL "all")
+        list(APPEND WOLFSSL_DEFINITIONS "-DHAVE_ECC_SECPR2")
+        list(APPEND WOLFSSL_DEFINITIONS "-DHAVE_ECC_SECPR3")
+        list(APPEND WOLFSSL_DEFINITIONS "-DHAVE_ECC_BRAINPOOL")
+        list(APPEND WOLFSSL_DEFINITIONS "-DHAVE_ECC_KOBLITZ")
+        list(APPEND WOLFSSL_DEFINITIONS "-DHAVE_ECC_CDH")
+    endif()
+
+    list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_CUSTOM_CURVES")
+endif()
 
 # CURVE25519
 set(WOLFSSL_CURVE25519_SMALL "no")

--- a/cmake/options.h.in
+++ b/cmake/options.h.in
@@ -86,6 +86,8 @@ extern "C" {
 #cmakedefine HAVE_CRL
 #undef HAVE_CRL_IO
 #cmakedefine HAVE_CRL_IO
+#undef WOLFSSL_CUSTOM_CURVES
+#cmakedefine WOLFSSL_CUSTOM_CURVES
 #undef HAVE_CURVE25519
 #cmakedefine HAVE_CURVE25519
 #undef HAVE_CURVE448
@@ -368,6 +370,16 @@ extern "C" {
 #cmakedefine WOLFSSL_WC_KYBER
 #undef NO_WOLFSSL_STUB
 #cmakedefine NO_WOLFSSL_STUB
+#undef HAVE_ECC_SECPR2
+#cmakedefine HAVE_ECC_SECPR2
+#undef HAVE_ECC_SECPR3
+#cmakedefine HAVE_ECC_SECPR3
+#undef HAVE_ECC_BRAINPOOL
+#cmakedefine HAVE_ECC_BRAINPOOL
+#undef HAVE_ECC_KOBLITZ
+#cmakedefine HAVE_ECC_KOBLITZ
+#undef HAVE_ECC_CDH
+#cmakedefine HAVE_ECC_CDH
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
# Description

Add support for the `WOLFSSL_CUSTOM_CURVES` define in the cmake build.

Fixes zd18558

# Testing


```
mkdir build && cd build
cmake -DWOLFSSL_ECCCUSTCURVES=all ..
cmake --build .
sudo cmake --build . --target install
```

Build ECC examples in https://github.com/wolfSSL/wolfssl-examples/tree/master/ecc
Then run ecc-verify example and see that `Not compiled in...`  error is not displayed.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
