### PR TITLE
Use context specific for PKCS7 encrypted data encoding

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -9156,7 +9156,7 @@ static const ASNItem p8EncPbes1ASN[] = {
 /* ENCALGO_PBEPARAM_SALT */             { 3, ASN_OCTET_STRING, 0, 0, 0 },
                         /* Iteration Count */
 /* ENCALGO_PBEPARAM_ITER */             { 3, ASN_INTEGER, 0, 0, 0 },
-/* ENCDATA               */     { 1, ASN_INDEF_LENGTH, 0, 0, 0 },
+/* ENCDATA               */     { 1, (ASN_CONTEXT_SPECIFIC | 0), 0, 0, 0 },
 };
 enum {
     P8ENCPBES1ASN_IDX_SEQ = 0,

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -9156,7 +9156,7 @@ static const ASNItem p8EncPbes1ASN[] = {
 /* ENCALGO_PBEPARAM_SALT */             { 3, ASN_OCTET_STRING, 0, 0, 0 },
                         /* Iteration Count */
 /* ENCALGO_PBEPARAM_ITER */             { 3, ASN_INTEGER, 0, 0, 0 },
-/* ENCDATA               */     { 1, ASN_OCTET_STRING, 0, 0, 0 },
+/* ENCDATA               */     { 1, ASN_INDEF_LENGTH, 0, 0, 0 },
 };
 enum {
     P8ENCPBES1ASN_IDX_SEQ = 0,


### PR DESCRIPTION
# Description
While the current encoding for PKCS8 PBE is within specification, openssl will only parse the indefinite length form which the old ASN code used to generate before the move to the ASN template. Modify ASN template for PKCS8 PBE encoding to use indefinite length, making it consistent with both old ASN code and openssl expectations. 

Fixes zd 18515
