### PR TITLE
20240913-fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1021,7 +1021,9 @@ if test "$enable_all_crypto" = "yes" &&
    test "$HAVE_GNUC" = "yes" &&
    test "$enable_sp_asm" != "no" &&
    test "$enable_intelasm" != "no" &&
-   test "$enable_armasm" != "no"
+   test "$enable_armasm" != "no" &&
+   test "$enable_afalg" != "yes" &&
+   test "$ENABLED_32BIT" = "no"
 then
     DEFAULT_ENABLED_ALL_ASM=yes
 else
@@ -1187,7 +1189,8 @@ then
         test "$enable_shake128" = "" && enable_shake128=yes
         test "$enable_shake256" = "" && enable_shake256=yes
         test "$enable_compkey" = "" && test "$ENABLED_LINUXKM_DEFAULTS" != "yes" && enable_compkey=yes
-        test "$enable_srtp_kdf" = "" && enable_srtp_kdf=yes
+        # AFALG lacks AES-ECB
+        test "$enable_srtp_kdf" = "" && test "$enable_afalg" != "yes" && enable_srtp_kdf=yes
     fi
 
     if test "$ENABLED_FIPS" = "no" || test "$HAVE_FIPS_VERSION" -le 5; then

--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -464,6 +464,12 @@
             #ifdef HAVE_OCSP
                 struct Signer* GetCAByKeyHash(void* vp, const unsigned char* keyHash);
             #endif /* HAVE_OCSP */
+            #ifdef WOLFSSL_AKID_NAME
+                struct Signer* GetCAByAKID(void* vp, const unsigned char* issuer,
+                                           unsigned int issuerSz,
+                                           const unsigned char* serial,
+                                           unsigned int serialSz);
+            #endif
         #endif /* NO_SKID */
     #endif /* !WOLFCRYPT_ONLY && !NO_CERTS */
 
@@ -636,6 +642,9 @@
         typeof(GetCAByKeyHash) *GetCAByKeyHash;
         #endif /* HAVE_OCSP */
         #endif /* NO_SKID */
+        #ifdef WOLFSSL_AKID_NAME
+        typeof(GetCAByAKID) *GetCAByAKID;
+        #endif /* WOLFSSL_AKID_NAME */
         #endif /* !WOLFCRYPT_ONLY && !NO_CERTS */
 
         #ifdef WOLFSSL_DEBUG_BACKTRACE_ERROR_CODES
@@ -788,6 +797,9 @@
                 #define GetCAByKeyHash (wolfssl_linuxkm_get_pie_redirect_table()->GetCAByKeyHash)
             #endif /* HAVE_OCSP */
         #endif /* NO_SKID */
+        #ifdef WOLFSSL_AKID_NAME
+            #define GetCAByAKID (wolfssl_linuxkm_get_pie_redirect_table()->GetCAByAKID)
+        #endif
     #endif /* !WOLFCRYPT_ONLY && !NO_CERTS */
 
     #ifdef WOLFSSL_DEBUG_BACKTRACE_ERROR_CODES

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -578,9 +578,12 @@ static int set_up_wolfssl_linuxkm_pie_redirect_table(void) {
 #ifndef NO_SKID
     wolfssl_linuxkm_pie_redirect_table.GetCAByName = GetCAByName;
 #ifdef HAVE_OCSP
-wolfssl_linuxkm_pie_redirect_table.GetCAByKeyHash = GetCAByKeyHash;
+    wolfssl_linuxkm_pie_redirect_table.GetCAByKeyHash = GetCAByKeyHash;
 #endif /* HAVE_OCSP */
 #endif /* NO_SKID */
+#ifdef WOLFSSL_AKID_NAME
+    wolfssl_linuxkm_pie_redirect_table.GetCAByAKID = GetCAByAKID;
+#endif /* WOLFSSL_AKID_NAME */
 #endif /* !WOLFCRYPT_ONLY && !NO_CERTS */
 
 #ifdef WOLFSSL_DEBUG_BACKTRACE_ERROR_CODES

--- a/src/x509.c
+++ b/src/x509.c
@@ -14230,7 +14230,7 @@ int wolfSSL_X509_set_version(WOLFSSL_X509* x509, long v)
 
 #endif /* (OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL) && WOLFSSL_CERT_GEN */
 
-#if defined(OPENSSL_ALL) && \
+#if (defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA)) &&           \
     defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_REQ)
 
 void wolfSSL_X509V3_set_ctx(WOLFSSL_X509V3_CTX* ctx, WOLFSSL_X509* issuer,

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -13370,7 +13370,7 @@ static int GenerateDNSEntryIPString(DNS_entry* entry, void* heap)
 {
     int ret = 0;
     size_t nameSz = 0;
-    char tmpName[WOLFSSL_MAX_IPSTR] = {0};
+    char tmpName[WOLFSSL_MAX_IPSTR];
     unsigned char* ip;
 
     if (entry == NULL || entry->type != ASN_IP_TYPE) {
@@ -13383,6 +13383,8 @@ static int GenerateDNSEntryIPString(DNS_entry* entry, void* heap)
         return BAD_FUNC_ARG;
     }
     ip = (unsigned char*)entry->name;
+
+    XMEMSET(tmpName, 0, sizeof(tmpName));
 
     /* store IP addresses as a string */
     if (entry->len == WOLFSSL_IP4_ADDR_LEN) {

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -6462,7 +6462,7 @@ WOLFSSL_LOCAL WC_RNG* WOLFSSL_RSA_GetRNG(WOLFSSL_RSA *rsa, WC_RNG **tmpRNG,
     #ifndef GetCA
         WOLFSSL_LOCAL Signer* GetCA(void* vp, byte* hash);
     #endif
-    #ifdef WOLFSSL_AKID_NAME
+    #if defined(WOLFSSL_AKID_NAME) && !defined(GetCAByAKID)
         WOLFSSL_LOCAL Signer* GetCAByAKID(void* vp, const byte* issuer,
                 word32 issuerSz, const byte* serial, word32 serialSz);
     #endif

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -398,7 +398,7 @@ typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS;
 #define SSL_SESSION_get_master_key_length wolfSSL_SESSION_get_master_key_length
 #define SSL_SESSION_get_max_early_data  wolfSSL_SESSION_get_max_early_data
 
-#if defined(WOLFSSL_QT) || defined(OPENSSL_ALL)
+#if defined(WOLFSSL_QT) || defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA)
     #define SSL_MODE_RELEASE_BUFFERS     0x00000010U
     #define ASN1_BOOLEAN                 WOLFSSL_ASN1_BOOLEAN
     #define X509_get_ext                 wolfSSL_X509_get_ext

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2320,6 +2320,12 @@ extern void uITRON4_free(void *p) ;
     #define HAVE_AESGCM
 #endif
 
+/* Detect Cortex M3 (no UMAAL) */
+#if defined(WOLFSSL_SP_ARM_CORTEX_M_ASM) && defined(__ARM_ARCH_7M__)
+    #undef  WOLFSSL_SP_NO_UMAAL
+    #define WOLFSSL_SP_NO_UMAAL
+#endif
+
 #if defined(WOLFSSL_XILINX_CRYPT) || defined(WOLFSSL_AFALG_XILINX)
     #if defined(WOLFSSL_ARMASM)
         #error can not use both ARMv8 instructions and XILINX hardened crypto

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -178,13 +178,6 @@ extern "C" {
 #define WOLFSSL_SP_DIV_WORD_HALF
 #endif
 
-/* Detect Cortex M3 (no UMAAL) */
-#if defined(WOLFSSL_SP_ARM_CORTEX_M_ASM) && defined(__ARM_ARCH_7M__)
-    #undef  WOLFSSL_SP_NO_UMAAL
-    #define WOLFSSL_SP_NO_UMAAL
-#endif
-
-
 /* Make sure WOLFSSL_SP_ASM build option defined when requested */
 #if !defined(WOLFSSL_SP_ASM) && ( \
       defined(WOLFSSL_SP_X86_64_ASM) || defined(WOLFSSL_SP_ARM32_ASM) || \


### PR DESCRIPTION
`configure.ac`:
* set `DEFAULT_ENABLED_ALL_ASM=no` if `enable_afalg` or `ENABLED_32BIT`;
* omit `enable_srtp_kdf` from `enable-all-crypto` if `enable_afalg`.

linuxkm: add `GetCAByAKID` to `wolfssl_linuxkm_pie_redirect_table`.

`src/x509.c`: in `GenerateDNSEntryIPString()`, use `XMEMSET()` to initialize `tmpName`, not = `{0}`, to avoid unmaskable compiler emission of `memset()` call.

`wolfssl/openssl/ssl.h`: add `OPENSSL_EXTRA` to an existing `OPENSSL_ALL`-gated section, consistent with gating of corresponding section in `wolfssl/ssl.h`.

`wolfssl/wolfcrypt/settings.h`: adopt setup for `WOLFSSL_SP_NO_UMAAL` from `wolfssl/wolfcrypt/sp_int.h` now that it's used by `wolfcrypt/src/port/arm/thumb2-poly1305-asm.S`.

tested with `wolfssl-multi-test.sh ... super-quick-check cross-mingw-all-crypto all-afalg wolfsm-all-clang-tidy linuxkm-all-fips-140-3 all-clang all-sp-m32 linuxkm-all-cryptonly-pie-aarch64-LKCAPI-crypto-fuzzer-build cross-armv7m-armasm-thumb-sp-asm-all-crypto-only cross-riscv64-sp-math-asm cross-aarch64_be-all-sp-asm-unittest-sanitizer cross-aarch64-armasm-fips-140-3-dev-all-unittest-sanitizer clang-tidy-fips-140-3-all` with various fixes to `wolfssl-multi-test.sh` to accommodate deployment of asm configurations to enable-all builds.

note that `cross-mingw-all-crypto` is currently failing two unit tests even with the above fixes.
