### PR TITLE
Update to remove HAVE_RSA references.  Correct NO_MALLOC RSA test bug.

### DIFF
--- a/IDE/Renesas/e2studio/RA6M3/common/user_settings.h
+++ b/IDE/Renesas/e2studio/RA6M3/common/user_settings.h
@@ -50,7 +50,6 @@
 #define HAVE_CHACHA
 #define HAVE_POLY1305
 #define HAVE_ECC
-#define HAVE_RSA
 #define HAVE_SHA256
 #define HAVE_SUPPORTED_CURVES
 #define HAVE_TLS_EXTENSIONS

--- a/examples/configs/user_settings_wolfboot_keytools.h
+++ b/examples/configs/user_settings_wolfboot_keytools.h
@@ -57,7 +57,6 @@
 #define WOLFSSL_SHAKE256
 
 /* RSA */
-#define HAVE_RSA
 #define WOLFSSL_HAVE_SP_RSA
 #define WC_RSA_BLINDING
 #define WOLFSSL_KEY_GEN

--- a/tests/api.c
+++ b/tests/api.c
@@ -42805,7 +42805,7 @@ static int test_wc_SetSubjectKeyIdFromPublicKey_ex(void)
 #if defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_CERT_GEN)
     WC_RNG      rng;
     Cert        cert;
-#if !defined(NO_RSA)
+#if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN)
     RsaKey      rsaKey;
     int         bits = 2048;
 #endif
@@ -42887,7 +42887,7 @@ static int test_wc_SetAuthKeyIdFromPublicKey_ex(void)
 #if defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_CERT_GEN)
     WC_RNG      rng;
     Cert        cert;
-#if !defined(NO_RSA)
+#if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN)
     RsaKey      rsaKey;
     int         bits = 2048;
 #endif

--- a/tests/api.c
+++ b/tests/api.c
@@ -42805,7 +42805,7 @@ static int test_wc_SetSubjectKeyIdFromPublicKey_ex(void)
 #if defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_CERT_GEN)
     WC_RNG      rng;
     Cert        cert;
-#if !defined(NO_RSA) && defined(HAVE_RSA)
+#if !defined(NO_RSA)
     RsaKey      rsaKey;
     int         bits = 2048;
 #endif
@@ -42828,7 +42828,7 @@ static int test_wc_SetSubjectKeyIdFromPublicKey_ex(void)
 
     ExpectIntEQ(wc_InitCert(&cert), 0);
 
-#if !defined(NO_RSA) && defined(HAVE_RSA) && defined(WOLFSSL_KEY_GEN)
+#if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN)
     /* RSA */
     XMEMSET(&rsaKey, 0, sizeof(RsaKey));
     ExpectIntEQ(wc_InitRsaKey(&rsaKey, HEAP_HINT), 0);
@@ -42887,7 +42887,7 @@ static int test_wc_SetAuthKeyIdFromPublicKey_ex(void)
 #if defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_CERT_GEN)
     WC_RNG      rng;
     Cert        cert;
-#if !defined(NO_RSA) && defined(HAVE_RSA)
+#if !defined(NO_RSA)
     RsaKey      rsaKey;
     int         bits = 2048;
 #endif
@@ -42910,7 +42910,7 @@ static int test_wc_SetAuthKeyIdFromPublicKey_ex(void)
 
     ExpectIntEQ(wc_InitCert(&cert), 0);
 
-#if !defined(NO_RSA) && defined(HAVE_RSA) && defined(WOLFSSL_KEY_GEN)
+#if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN)
     /* RSA */
     XMEMSET(&rsaKey, 0, sizeof(RsaKey));
     ExpectIntEQ(wc_InitRsaKey(&rsaKey, HEAP_HINT), 0);

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -1346,7 +1346,7 @@ int SuiteTest(int argc, char** argv)
         args.return_code = EXIT_FAILURE;
         goto exit;
     }
-#endif /* HAVE_RSA and HAVE_ECC */
+#endif /* !NO__RSA and HAVE_ECC */
 #endif /* !WC_STRICT_SIG */
 #if defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3) && \
     (defined(WOLFSSL_SM4_GCM) || defined(WOLFSSL_SM4_CCM))

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -20875,7 +20875,7 @@ static wc_test_ret_t rsa_keygen_test(WC_RNG* rng)
 #ifndef WOLFSSL_NO_MALLOC
     byte*  der = NULL;
 #else
-    byte der[1024];
+    byte der[1280];
 #endif
 #ifndef WOLFSSL_CRYPTOCELL
     word32 idx = 0;
@@ -20926,8 +20926,11 @@ static wc_test_ret_t rsa_keygen_test(WC_RNG* rng)
     if (der == NULL) {
         ERROR_OUT(WC_TEST_RET_ENC_ERRNO, exit_rsa);
     }
+    derSz = FOURK_BUF;
+#else
+    derSz = sizeof(der);
 #endif
-    derSz = wc_RsaKeyToDer(genKey, der, FOURK_BUF);
+    derSz = wc_RsaKeyToDer(genKey, der, derSz);
     if (derSz < 0) {
         ERROR_OUT(WC_TEST_RET_ENC_EC(derSz), exit_rsa);
     }


### PR DESCRIPTION
# Description

1. Remove references to HAVE_RSA in wolfssl source.  Note this removal now reenables a few api.c tests.
2. Correct a WOLFSSL_NO_MALLOC bug within wolfcrypttest that sometimes failed due to a buffer overflow.

# Testing

Testing with NO_MALLOC locally on MacOS with wolfHSM as well as commit-tests.sh.  I expect the nightlies may exercise the RSA api.c test so we may have some additional findings on different configurations.

# Checklist

 - [ N/A ] added tests.  This change reenables some API tests.  We are still missing full NO_MALLOC coverage.
 - [ N/A ] updated/added doxygen
 - [ N/A ] updated appropriate READMEs
 - [ N/A ] Updated manual and documentation
