### PR TITLE
20240916-wc_DhAgree_ct-sp-math

### DIFF
--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -137,6 +137,7 @@ static int DataToDerBuffer(const unsigned char* buff, word32 len, int format,
             FreeDer(der);
         }
     #else
+        (void)algId;
         ret = NOT_COMPILED_IN;
     #endif
     }


### PR DESCRIPTION
`wolfcrypt/src/dh.c`: in `wc_DhAgree_ct()`, implement failsafe constant-time key size fixup, to work around sp-math constant-time key clamping.

tested with `wolfssl-multi-test.sh ... super-quick-check`, plus a loop of over 3000 iters of `unit.test -test_wolfSSL_DH` to characterize the undersize-key rate (~.64%).
