### PR TITLE
dilithium: small cleanup to support wolfboot.

### DIFF
--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -70,7 +70,7 @@
  *   but is slower.
  * WOLFSSL_DILITHIUM_SMALL_MEM_POLY64                         Default: OFF
  *   Compiles the small memory implementations to use a 64-bit polynomial.
- *   Uses 2KB of memory but is slighlty quicker (2.75-7%).
+ *   Uses 2KB of memory but is slightly quicker (2.75-7%).
  *
  * WOLFSSL_DILITHIUM_ALIGNMENT                                Default: 8
  *   Use to indicate whether loading and storing of words needs to be aligned.

--- a/wolfssl/wolfcrypt/dilithium.h
+++ b/wolfssl/wolfcrypt/dilithium.h
@@ -765,6 +765,7 @@ int wc_dilithium_export_public(dilithium_key* key, byte* out, word32* outLen);
 #ifdef WOLFSSL_DILITHIUM_PRIVATE_KEY
 WOLFSSL_API
 int wc_dilithium_export_private(dilithium_key* key, byte* out, word32* outLen);
+#define wc_dilithium_export_private_only    wc_dilithium_export_private
 #endif
 #ifdef WOLFSSL_DILITHIUM_PRIVATE_KEY
 WOLFSSL_API
@@ -841,7 +842,7 @@ WOLFSSL_API int wc_Dilithium_PrivateKeyToDer(dilithium_key* key, byte* output,
 #define wc_MlDsaKey_ExportPrivRaw(key, out, outLen)             \
     wc_dilithium_export_private_only(key, out, outLen)
 #define wc_MlDsaKey_ImportPrivRaw(key, in, inLen)               \
-    wc_dilithium_import_private_only(out, outLen, key)
+    wc_dilithium_import_private_only(in, inLen, key)
 #define wc_MlDsaKey_Sign(key, sig, sigSz, msg, msgSz, rng)      \
     wc_dilithium_sign_msg(msg, msgSz, sig, sigSz, key, rng)
 #define wc_MlDsaKey_Free(key)                                   \
@@ -849,7 +850,7 @@ WOLFSSL_API int wc_Dilithium_PrivateKeyToDer(dilithium_key* key, byte* output,
 #define wc_MlDsaKey_ExportPubRaw(key, out, outLen)              \
     wc_dilithium_export_public(key, out, outLen)
 #define wc_MlDsaKey_ImportPubRaw(key, in, inLen)                \
-    wc_dilithium_import_public(out, outLen, key)
+    wc_dilithium_import_public(in, inLen, key)
 #define wc_MlDsaKey_Verify(key, sig, sigSz, msg, msgSz, res)    \
     wc_dilithium_verify_msg(sig, sigSz, msg, msgSz, res, key)
 


### PR DESCRIPTION
# Description

dilithium cleanup:
- Missing `wc_dilithium_export_private_only` define in dilithium.h. Also fixed some define args.
- Some API not covered in tests.
- typo in dilithium.c

Discovered when building wolfboot with ML-DSA/dilithium.