### PR TITLE
Update to use memory_order_seq_cst instead of GCC internal for C11

### DIFF
--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -1268,7 +1268,7 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
         /* use user-supplied XFENCE definition. */
     #elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
         #include <stdatomic.h>
-        #define XFENCE() atomic_thread_fence(__ATOMIC_SEQ_CST)
+        #define XFENCE() atomic_thread_fence(memory_order_seq_cst)
     #elif defined(__GNUC__) && (__GNUC__ >= 4) && (__GNUC__ < 5)
         #define XFENCE() __sync_synchronize()
     #elif (defined(__GNUC__) && (__GNUC__ >= 5)) || defined (__clang__)


### PR DESCRIPTION
# Description

Update the memory order constant from the GCC-specific to the C11 standard enumeration identifier.

Fixes zd18640

# Testing

Tested on MacOS (clang) and IAR 8.6.0 compiler.  I suspect we may have additional compilers that may need different workarounds.

# Checklist

 - [ N/A ] added tests
 - [ N/A ] updated/added doxygen
 - [ N/A ] updated appropriate READMEs
 - [ N/A ] Updated manual and documentation
