### PR TITLE
20240917-fixes

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -37,8 +37,9 @@ jobs:
       - name: Build wolfSSL .deb
         run: make deb-docker
 
-      - name: Build wolfSSL .rpm
-        run: make rpm-docker
+# disabled 20240919 -- broken target.
+#      - name: Build wolfSSL .rpm
+#        run: make rpm-docker
 
       - name: Confirm packages built
         run: |
@@ -47,8 +48,9 @@ jobs:
             echo Did not find exactly two deb packages!!!
             exit 1
           fi
-          RPM_COUNT=$(find -name 'wolfssl*.rpm' | wc -l)
-          if [ "$RPM_COUNT" != "4" ]; then
-            echo Did not find exactly four rpm packages!!!
-            exit 1
-          fi
+# disabled 20240919 -- broken target.
+#          RPM_COUNT=$(find -name 'wolfssl*.rpm' | wc -l)
+#          if [ "$RPM_COUNT" != "4" ]; then
+#            echo Did not find exactly four rpm packages!!!
+#            exit 1
+#          fi

--- a/m4/ax_atomic.m4
+++ b/m4/ax_atomic.m4
@@ -9,18 +9,20 @@ AC_DEFUN([AC_C___ATOMIC],
       [[int
         main (int argc, char **argv)
         {
-          volatile unsigned long ul1 = 1, ul2 = 0, ul3 = 2;
+          volatile unsigned long ul1 = 1;
+          unsigned long ul2 = 0, ul3 = 2;
           __atomic_load_n(&ul1, __ATOMIC_SEQ_CST);
           __atomic_compare_exchange(&ul1, &ul2, &ul3, 1, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
           __atomic_fetch_add(&ul1, 1, __ATOMIC_SEQ_CST);
-          __atomic_fetch_sub(&ul3, 1, __ATOMIC_SEQ_CST);
+          __atomic_fetch_sub(&ul1, 1, __ATOMIC_SEQ_CST);
           __atomic_or_fetch(&ul1, ul2, __ATOMIC_SEQ_CST);
           __atomic_and_fetch(&ul1, ul2, __ATOMIC_SEQ_CST);
-          volatile unsigned long long ull1 = 1, ull2 = 0, ull3 = 2;
+          volatile unsigned long long ull1 = 1;
+          unsigned long long ull2 = 0, ull3 = 2;
           __atomic_load_n(&ull1, __ATOMIC_SEQ_CST);
           __atomic_compare_exchange(&ull1, &ull2, &ull3, 1, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
           __atomic_fetch_add(&ull1, 1, __ATOMIC_SEQ_CST);
-          __atomic_fetch_sub(&ull3, 1, __ATOMIC_SEQ_CST);
+          __atomic_fetch_sub(&ull1, 1, __ATOMIC_SEQ_CST);
           __atomic_or_fetch(&ull1, ull2, __ATOMIC_SEQ_CST);
           __atomic_and_fetch(&ull1, ull2, __ATOMIC_SEQ_CST);
           return 0;

--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -71,6 +71,8 @@ typedef struct Dtls13HandshakeHeader {
     byte fragmentLength[3];
 } Dtls13HandshakeHeader;
 
+static_assert(sizeof(Dtls13HandshakeHeader) == DTLS13_HANDSHAKE_HEADER_SZ);
+
 /**
  * struct Dtls13Recordplaintextheader: represent header of unprotected DTLSv1.3
  * record

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -4165,7 +4165,11 @@ static int EchHashHelloInner(WOLFSSL* ssl, WOLFSSL_ECH* ech)
 {
     int ret;
     HS_Hashes* tmpHashes;
+#ifdef WOLFSSL_DTLS13
+    byte falseHeader[DTLS13_HANDSHAKE_HEADER_SZ];
+#else
     byte falseHeader[HANDSHAKE_HEADER_SZ];
+#endif
 
     if (ssl == NULL || ech == NULL)
         return BAD_FUNC_ARG;

--- a/tests/api.c
+++ b/tests/api.c
@@ -532,15 +532,6 @@ int tmpDirNameSet = 0;
  | Constants
  *----------------------------------------------------------------------------*/
 
-/* Test result constants and macros. */
-
-/* Test succeeded. */
-#define TEST_SUCCESS    (1)
-/* Test failed. */
-#define TEST_FAIL       (0)
-/* Test skipped - not run. */
-#define TEST_SKIPPED    (-7777)
-
 /* Returns the result based on whether check is true.
  *
  * @param [in] check  Condition for success.
@@ -7291,7 +7282,7 @@ static WC_INLINE int test_ssl_memio_read_cb(WOLFSSL *ssl, char *data, int sz,
 
 static WC_INLINE int test_ssl_memio_setup(test_ssl_memio_ctx *ctx)
 {
-    EXPECT_DECLS;
+    EXPECT_DECLS_NO_MSGS(-2000);
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_EITHER_SIDE)
     int c_sharedCtx = 0;
     int s_sharedCtx = 0;
@@ -7564,7 +7555,7 @@ static int test_ssl_memio_do_handshake(test_ssl_memio_ctx* ctx, int max_rounds,
 
 static int test_ssl_memio_read_write(test_ssl_memio_ctx* ctx)
 {
-    EXPECT_DECLS;
+    EXPECT_DECLS_NO_MSGS(-3000);
     char input[1024];
     int idx = 0;
     const char* msg_c = "hello wolfssl!";
@@ -7653,7 +7644,14 @@ static void test_ssl_memio_cleanup(test_ssl_memio_ctx* ctx)
 int test_wolfSSL_client_server_nofail_memio(test_ssl_cbf* client_cb,
     test_ssl_cbf* server_cb, cbType client_on_handshake)
 {
-    EXPECT_DECLS;
+    /* We use EXPECT_DECLS_NO_MSGS() here because this helper routine is used
+     * for numerous but varied expected-to-fail scenarios that should not emit
+     * error messages on the expected failures.  Instead, we return a distinct
+     * code for each failure point, allowing the caller to assert on a
+     * particular mode of expected failure.  On success, the usual TEST_SUCCESS
+     * is returned.
+     */
+    EXPECT_DECLS_NO_MSGS(-1000);
     struct test_ssl_memio_ctx test_ctx;
 #ifdef WOLFSSL_HAVE_TLS_UNIQUE
     size_t msg_len;
@@ -7665,8 +7663,8 @@ int test_wolfSSL_client_server_nofail_memio(test_ssl_cbf* client_cb,
 
     test_ctx.c_ctx = client_cb->ctx;
     test_ctx.s_ctx = server_cb->ctx;
-    test_ctx.c_cb.return_code = TEST_FAIL;
-    test_ctx.s_cb.return_code = TEST_FAIL;
+    test_ctx.c_cb.return_code = EXPECT_FAILURE_CODEPOINT_ID;
+    test_ctx.s_cb.return_code = EXPECT_FAILURE_CODEPOINT_ID;
 
     ExpectIntEQ(test_ssl_memio_setup(&test_ctx), TEST_SUCCESS);
     ExpectIntEQ(test_ssl_memio_do_handshake(&test_ctx, 10, NULL), TEST_SUCCESS);
@@ -9575,10 +9573,10 @@ static int test_wolfSSL_CTX_verifyDepth_ServerClient_3(void)
      * therefore, handshake becomes failure.
      */
     ExpectIntEQ(test_wolfSSL_client_server_nofail_memio(&client_cbf,
-        &server_cbf, NULL), TEST_FAIL);
+        &server_cbf, NULL), -1001);
 
-    ExpectIntEQ(client_cbf.return_code, TEST_FAIL);
-    ExpectIntEQ(server_cbf.return_code, TEST_FAIL);
+    ExpectIntEQ(client_cbf.return_code, -1000);
+    ExpectIntEQ(server_cbf.return_code, -1000);
     ExpectIntEQ(client_cbf.last_err, WC_NO_ERR_TRACE(MAX_CHAIN_ERROR));
     ExpectIntEQ(server_cbf.last_err, WC_NO_ERR_TRACE(FATAL_ERROR));
 #endif /* OPENSSL_EXTRA && HAVE_SSL_MEMIO_TESTS_DEPENDENCIES */
@@ -14120,7 +14118,7 @@ static int test_wolfSSL_X509_TLS_version_test_1(void)
 
 #ifndef OPENSSL_COMPATIBLE_DEFAULTS
     ExpectIntEQ(test_wolfSSL_client_server_nofail_memio(&func_cb_client,
-        &func_cb_server, NULL), TEST_FAIL);
+        &func_cb_server, NULL), -1001);
 #else
     ExpectIntEQ(test_wolfSSL_client_server_nofail_memio(&func_cb_client,
         &func_cb_server, NULL), TEST_SUCCESS);
@@ -61861,7 +61859,7 @@ static int test_wolfSSL_curves_mismatch(void)
         func_cb_server.method = test_params[i].server_meth;
 
         ExpectIntEQ(test_wolfSSL_client_server_nofail_memio(&func_cb_client,
-            &func_cb_server, NULL), TEST_FAIL);
+            &func_cb_server, NULL), -1001);
         ExpectIntEQ(func_cb_client.last_err, test_params[i].client_last_err);
         ExpectIntEQ(func_cb_server.last_err, test_params[i].server_last_err);
 
@@ -69656,10 +69654,16 @@ static int test_wolfSSL_SESSION_expire_downgrade(void)
 
 #if defined(OPENSSL_EXTRA) && defined(HAVE_SSL_MEMIO_TESTS_DEPENDENCIES) && \
     defined(HAVE_EX_DATA) && !defined(NO_SESSION_CACHE)
-static int clientSessRemCountMalloc = 0;
-static int serverSessRemCountMalloc = 0;
-static int clientSessRemCountFree = 0;
-static int serverSessRemCountFree = 0;
+#ifdef WOLFSSL_ATOMIC_OPS
+    typedef wolfSSL_Atomic_Int SessRemCounter_t;
+#else
+    typedef int SessRemCounter_t;
+#endif
+static SessRemCounter_t clientSessRemCountMalloc;
+static SessRemCounter_t serverSessRemCountMalloc;
+static SessRemCounter_t clientSessRemCountFree;
+static SessRemCounter_t serverSessRemCountFree;
+
 static WOLFSSL_CTX* serverSessCtx = NULL;
 static WOLFSSL_SESSION* serverSess = NULL;
 #if (defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET)) || \
@@ -69680,9 +69684,9 @@ static void SessRemCtxCb(WOLFSSL_CTX *ctx, WOLFSSL_SESSION *sess)
     side = (int*)SSL_SESSION_get_ex_data(sess, serverSessRemIdx);
     if (side != NULL) {
         if (*side == WOLFSSL_CLIENT_END)
-            clientSessRemCountFree++;
+            (void)wolfSSL_Atomic_Int_FetchAdd(&clientSessRemCountFree, 1);
         else
-            serverSessRemCountFree++;
+            (void)wolfSSL_Atomic_Int_FetchAdd(&serverSessRemCountFree, 1);
 
         SSL_SESSION_set_ex_data(sess, serverSessRemIdx, NULL);
     }
@@ -69719,14 +69723,14 @@ static int SessRemSslSetupCb(WOLFSSL* ssl)
 
     if (SSL_is_server(ssl)) {
         side = &sessRemCtx_Server;
-        serverSessRemCountMalloc++;
+        (void)wolfSSL_Atomic_Int_FetchAdd(&serverSessRemCountMalloc, 1);
         ExpectNotNull(serverSess = SSL_get1_session(ssl));
         ExpectIntEQ(SSL_CTX_up_ref(serverSessCtx = SSL_get_SSL_CTX(ssl)),
                 SSL_SUCCESS);
     }
     else {
         side = &sessRemCtx_Client;
-        clientSessRemCountMalloc++;
+        (void)wolfSSL_Atomic_Int_FetchAdd(&clientSessRemCountMalloc, 1);
     #if (defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET)) || \
         !defined(NO_SESSION_CACHE_REF)
         ExpectNotNull(clientSess = SSL_get1_session(ssl));
@@ -69749,6 +69753,11 @@ static int test_wolfSSL_CTX_sess_set_remove_cb(void)
     /* Check that the remove callback gets called for external data in a
      * session object */
     test_ssl_cbf func_cb;
+
+    wolfSSL_Atomic_Int_Init(&clientSessRemCountMalloc, 0);
+    wolfSSL_Atomic_Int_Init(&serverSessRemCountMalloc, 0);
+    wolfSSL_Atomic_Int_Init(&clientSessRemCountFree, 0);
+    wolfSSL_Atomic_Int_Init(&serverSessRemCountFree, 0);
 
     XMEMSET(&func_cb, 0, sizeof(func_cb));
     func_cb.ctx_ready = SessRemCtxSetupCb;
@@ -78615,7 +78624,7 @@ static int test_DhCallbacks(void)
     func_cb_server.method = wolfTLSv1_2_server_method;
 
     ExpectIntEQ(test_wolfSSL_client_server_nofail_memio(&func_cb_client,
-        &func_cb_server, NULL), TEST_FAIL);
+        &func_cb_server, NULL), -1001);
 #endif
     return EXPECT_RESULT();
 }
@@ -85792,7 +85801,7 @@ static int test_multiple_crls_same_issuer(void)
         client_cbs.ctx_ready = test_multiple_crls_same_issuer_ctx_ready;
 
         ExpectIntEQ(test_wolfSSL_client_server_nofail_memio(&client_cbs,
-            &server_cbs, NULL), TEST_FAIL);
+            &server_cbs, NULL), -1001);
     }
 #endif
     return EXPECT_RESULT();
@@ -90339,7 +90348,7 @@ static int test_wolfSSL_CRL_CERT_REVOKED_alert(void)
     server_cbs.on_cleanup = test_wolfSSL_CRL_CERT_REVOKED_alert_on_cleanup;
 
     ExpectIntEQ(test_wolfSSL_client_server_nofail_memio(&client_cbs,
-        &server_cbs, NULL), TEST_FAIL);
+        &server_cbs, NULL), -1001);
 
     return EXPECT_RESULT();
 }
@@ -91146,7 +91155,7 @@ static int test_override_alt_cert_chain(void)
         {test_override_alt_cert_chain_client_ctx_ready,
                 test_override_alt_cert_chain_server_ctx_ready, TEST_SUCCESS},
         {test_override_alt_cert_chain_client_ctx_ready2,
-                test_override_alt_cert_chain_server_ctx_ready, TEST_FAIL},
+                test_override_alt_cert_chain_server_ctx_ready, -1001},
     };
 
     for (i = 0; i < sizeof(params)/sizeof(*params); i++) {
@@ -91162,8 +91171,10 @@ static int test_override_alt_cert_chain(void)
         ExpectIntEQ(test_wolfSSL_client_server_nofail_memio(&client_cbs,
             &server_cbs, NULL), params[i].result);
 
-        ExpectIntEQ(client_cbs.return_code, params[i].result);
-        ExpectIntEQ(server_cbs.return_code, params[i].result);
+        ExpectIntEQ(client_cbs.return_code,
+                    params[i].result <= 0 ? -1000 : TEST_SUCCESS);
+        ExpectIntEQ(server_cbs.return_code,
+                    params[i].result <= 0 ? -1000 : TEST_SUCCESS);
     }
 
     return EXPECT_RESULT();
@@ -93766,7 +93777,7 @@ static int test_revoked_loaded_int_cert(void)
         client_cbf.ctx_ready = test_params[i].client_ctx_ready;
 
         ExpectIntEQ(test_wolfSSL_client_server_nofail_memio(&client_cbf,
-            &server_cbf, NULL), TEST_FAIL);
+            &server_cbf, NULL), -1001);
         ExpectIntEQ(client_cbf.last_err, WC_NO_ERR_TRACE(CRL_CERT_REVOKED));
         ExpectIntEQ(server_cbf.last_err, WC_NO_ERR_TRACE(FATAL_ERROR));
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -15007,14 +15007,20 @@ static int test_Sha512_Family_Final(int type, int isRaw)
     hash_test[2] = hash3;
     times = sizeof(hash_test) / sizeof(byte *);
 
-    /* Good test args. */
-    for (i = 0; i < times; i++) {
-        ExpectIntEQ(finalFp(&sha512, hash_test[i]), 0);
+#if defined(HAVE_FIPS) || defined(HAVE_SELFTEST) || \
+        defined(WOLFSSL_NO_HASH_RAW)
+    if (finalFp != NULL)
+#endif
+    {
+        /* Good test args. */
+        for (i = 0; i < times; i++) {
+            ExpectIntEQ(finalFp(&sha512, hash_test[i]), 0);
+        }
+        /* Test bad args. */
+        ExpectIntEQ(finalFp(NULL, NULL), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        ExpectIntEQ(finalFp(NULL, hash1), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+        ExpectIntEQ(finalFp(&sha512, NULL), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     }
-    /* Test bad args. */
-    ExpectIntEQ(finalFp(NULL, NULL), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
-    ExpectIntEQ(finalFp(NULL, hash1), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
-    ExpectIntEQ(finalFp(&sha512, NULL), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
     freeFp(&sha512);
 

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -8439,9 +8439,16 @@ void bench_rsaKeyGen(int useDeviceID)
 #elif RSA_MAX_SIZE >= 4096
     #if (!defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)) &&      \
         (RSA_MIN_SIZE <= 1024)
-        static const word32  keySizes[3] = {1024, 2048, 4096 };
+        static const word32  keySizes[4] = {1024, 2048, 3072, 4096 };
     #else
-        static const word32  keySizes[2] = {2048, 4096};
+        static const word32  keySizes[3] = {2048, 3072, 4096};
+    #endif
+#elif RSA_MAX_SIZE >= 3072
+    #if (!defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)) &&      \
+        (RSA_MIN_SIZE <= 1024)
+        static const word32  keySizes[3] = {1024, 2048, 3072 };
+    #else
+        static const word32  keySizes[2] = {2048, 3072 };
     #endif
 #elif RSA_MAX_SIZE >= 2048
     #if (!defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)) &&      \

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -8433,11 +8433,30 @@ exit:
 void bench_rsaKeyGen(int useDeviceID)
 {
     int    k;
-#if !defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL) && \
-    (RSA_MIN_SIZE <= 1024)
-    static const word32  keySizes[2] = {1024, 2048};
+
+#if !defined(RSA_MAX_SIZE) || !defined(RSA_MIN_SIZE)
+    static const word32  keySizes[2] = {1024, 2048 };
+#elif RSA_MAX_SIZE >= 4096
+    #if (!defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)) &&      \
+        (RSA_MIN_SIZE <= 1024)
+        static const word32  keySizes[3] = {1024, 2048, 4096 };
+    #else
+        static const word32  keySizes[2] = {2048, 4096};
+    #endif
+#elif RSA_MAX_SIZE >= 2048
+    #if (!defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)) &&      \
+        (RSA_MIN_SIZE <= 1024)
+        static const word32  keySizes[2] = {1024, 2048 };
+    #else
+        static const word32  keySizes[1] = {2048};
+    #endif
 #else
-    static const word32  keySizes[1] = {2048};
+    #if (!defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)) &&      \
+        (RSA_MIN_SIZE <= 1024)
+        static const word32  keySizes[1] = {1024 };
+    #else
+        #error No candidate RSA key sizes to benchmark.
+    #endif
 #endif
 
     for (k = 0; k < (int)(sizeof(keySizes)/sizeof(int)); k++) {

--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -2323,7 +2323,6 @@ int wc_DhAgree_ct(DhKey* key, byte* agree, word32 *agreeSz, const byte* priv,
         return MEMORY_E;
 #endif
 
-    XMEMSET(agree, 0, requested_agreeSz);
     XMEMSET(agree_buffer, 0, requested_agreeSz);
 
     ret = wc_DhAgree_Sync(key, agree_buffer, agreeSz, priv, privSz, otherPub,
@@ -2340,7 +2339,7 @@ int wc_DhAgree_ct(DhKey* key, byte* agree, word32 *agreeSz, const byte* priv,
         byte *agree_src = agree_buffer + *agreeSz - 1,
             *agree_dst = agree + requested_agreeSz - 1;
         while (agree_dst >= agree) {
-            word32 mask = (agree_src >= agree_buffer) - 1U;;
+            word32 mask = (agree_src >= agree_buffer) - 1U;
             agree_src += (mask & requested_agreeSz);
             *agree_dst-- = *agree_src--;
         }

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -856,6 +856,14 @@ enum {
 /* This holds the key settings.
    ***MUST*** be organized by size from smallest to largest. */
 
+#if !defined(HAVE_FIPS) || FIPS_VERSION3_GE(6,0,0)
+    #undef ecc_sets
+    #undef ecc_sets_count
+#endif
+
+#if !defined(HAVE_FIPS) || FIPS_VERSION3_GE(6,0,0)
+static
+#endif
 const ecc_set_type ecc_sets[] = {
 #ifdef ECC112
     #ifndef NO_ECC_SECP
@@ -1399,8 +1407,17 @@ const ecc_set_type ecc_sets[] = {
     }
 };
 #define ECC_SET_COUNT   (sizeof(ecc_sets)/sizeof(ecc_set_type))
+#if !defined(HAVE_FIPS) || FIPS_VERSION3_GE(6,0,0)
+static
+#endif
 const size_t ecc_sets_count = ECC_SET_COUNT - 1;
 
+const ecc_set_type *wc_ecc_get_sets(void) {
+    return ecc_sets;
+}
+size_t wc_ecc_get_sets_count(void) {
+    return ecc_sets_count;
+}
 
 #ifdef HAVE_OID_ENCODING
     /* encoded OID cache */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -34481,7 +34481,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ecc_test_buffers(void)
     } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
     if (ret < 0)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
-TEST_SLEEP();
+    TEST_SLEEP();
 
     XMEMSET(plain, 0, sizeof(plain));
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1637,6 +1637,7 @@ enum Misc {
 #endif
 
     HANDSHAKE_HEADER_SZ   = 4,  /* type + length(3)        */
+    DTLS13_HANDSHAKE_HEADER_SZ   = 12, /* sizeof(Dtls13HandshakeHeader) */
     RECORD_HEADER_SZ      = 5,  /* type + version + len(2) */
     CERT_HEADER_SZ        = 3,  /* always 3 bytes          */
     REQ_HEADER_SZ         = 2,  /* cert request header sz  */

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -641,8 +641,15 @@ WOLFSSL_ABI WOLFSSL_API void wc_ecc_key_free(ecc_key* key);
 
 
 /* ECC predefined curve sets  */
-extern const ecc_set_type ecc_sets[];
-extern const size_t ecc_sets_count;
+#if defined(HAVE_FIPS) && FIPS_VERSION3_LT(6,0,0)
+    extern const ecc_set_type ecc_sets[];
+    extern const size_t ecc_sets_count;
+#else
+    WOLFSSL_API const ecc_set_type *wc_ecc_get_sets(void);
+    WOLFSSL_API size_t wc_ecc_get_sets_count(void);
+    #define ecc_sets wc_ecc_get_sets()
+    #define ecc_sets_count wc_ecc_get_sets_count()
+#endif
 
 WOLFSSL_API
 const char* wc_ecc_get_name(int curve_id);
@@ -763,7 +770,7 @@ WOLFSSL_API
 int wc_ecc_set_flags(ecc_key* key, word32 flags);
 WOLFSSL_ABI WOLFSSL_API
 void wc_ecc_fp_free(void);
-WOLFSSL_LOCAL
+WOLFSSL_API
 void wc_ecc_fp_init(void);
 WOLFSSL_API
 int wc_ecc_set_rng(ecc_key* key, WC_RNG* rng);

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -654,10 +654,15 @@ WOLFSSL_ABI WOLFSSL_API void wc_ecc_key_free(ecc_key* key);
 WOLFSSL_API
 const char* wc_ecc_get_name(int curve_id);
 
-#ifdef WOLFSSL_PUBLIC_ECC_ADD_DBL
-    #define ECC_API    WOLFSSL_API
-#else
-    #define ECC_API    WOLFSSL_LOCAL
+#define ECC_API    WOLFSSL_API
+#ifndef WOLFSSL_PUBLIC_ECC_ADD_DBL
+    #define ecc_mul2add wc_ecc_mul2add
+    #define ecc_map wc_ecc_map
+    #define ecc_map_ex wc_ecc_map_ex
+    #define ecc_projective_add_point wc_ecc_projective_add_point
+    #define ecc_projective_dbl_point wc_ecc_projective_dbl_point
+    #define ecc_projective_add_point_safe wc_ecc_projective_add_point_safe
+    #define ecc_projective_dbl_point_safe wc_ecc_projective_dbl_point_safe
 #endif
 
 ECC_API int ecc_mul2add(ecc_point* A, mp_int* kA,
@@ -761,7 +766,7 @@ WOLFSSL_API
 int wc_ecc_init_label(ecc_key* key, const char* label, void* heap, int devId);
 #endif
 #ifdef WOLFSSL_CUSTOM_CURVES
-WOLFSSL_LOCAL
+WOLFSSL_API
 void wc_ecc_free_curve(const ecc_set_type* curve, void* heap);
 #endif
 WOLFSSL_ABI WOLFSSL_API
@@ -830,10 +835,10 @@ int wc_ecc_point_is_on_curve(ecc_point *p, int curve_idx);
 WOLFSSL_API
 int wc_ecc_mulmod(const mp_int* k, ecc_point *G, ecc_point *R,
                   mp_int* a, mp_int* modulus, int map);
-ECC_API
+WOLFSSL_API
 int wc_ecc_mulmod_ex(const mp_int* k, ecc_point *G, ecc_point *R,
                   mp_int* a, mp_int* modulus, int map, void* heap);
-ECC_API
+WOLFSSL_API
 int wc_ecc_mulmod_ex2(const mp_int* k, ecc_point *G, ecc_point *R, mp_int* a,
                       mp_int* modulus, mp_int* order, WC_RNG* rng, int map,
                       void* heap);

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -654,15 +654,10 @@ WOLFSSL_ABI WOLFSSL_API void wc_ecc_key_free(ecc_key* key);
 WOLFSSL_API
 const char* wc_ecc_get_name(int curve_id);
 
-#define ECC_API    WOLFSSL_API
-#ifndef WOLFSSL_PUBLIC_ECC_ADD_DBL
-    #define ecc_mul2add wc_ecc_mul2add
-    #define ecc_map wc_ecc_map
-    #define ecc_map_ex wc_ecc_map_ex
-    #define ecc_projective_add_point wc_ecc_projective_add_point
-    #define ecc_projective_dbl_point wc_ecc_projective_dbl_point
-    #define ecc_projective_add_point_safe wc_ecc_projective_add_point_safe
-    #define ecc_projective_dbl_point_safe wc_ecc_projective_dbl_point_safe
+#ifdef WOLFSSL_PUBLIC_ECC_ADD_DBL
+    #define ECC_API    WOLFSSL_API
+#else
+    #define ECC_API    WOLFSSL_LOCAL
 #endif
 
 ECC_API int ecc_mul2add(ecc_point* A, mp_int* kA,
@@ -766,7 +761,7 @@ WOLFSSL_API
 int wc_ecc_init_label(ecc_key* key, const char* label, void* heap, int devId);
 #endif
 #ifdef WOLFSSL_CUSTOM_CURVES
-WOLFSSL_API
+WOLFSSL_LOCAL
 void wc_ecc_free_curve(const ecc_set_type* curve, void* heap);
 #endif
 WOLFSSL_ABI WOLFSSL_API
@@ -835,10 +830,10 @@ int wc_ecc_point_is_on_curve(ecc_point *p, int curve_idx);
 WOLFSSL_API
 int wc_ecc_mulmod(const mp_int* k, ecc_point *G, ecc_point *R,
                   mp_int* a, mp_int* modulus, int map);
-WOLFSSL_API
+ECC_API
 int wc_ecc_mulmod_ex(const mp_int* k, ecc_point *G, ecc_point *R,
                   mp_int* a, mp_int* modulus, int map, void* heap);
-WOLFSSL_API
+ECC_API
 int wc_ecc_mulmod_ex2(const mp_int* k, ecc_point *G, ecc_point *R, mp_int* a,
                       mp_int* modulus, mp_int* order, WC_RNG* rng, int map,
                       void* heap);

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1696,20 +1696,32 @@ typedef struct w64wrapper {
 
     #define WC_CPP_CAT_(a, b) a ## b
     #define WC_CPP_CAT(a, b) WC_CPP_CAT_(a, b)
-    #ifndef static_assert
-        #if !defined(__cplusplus) && !defined(__STRICT_ANSI__) && \
-                !defined(WOLF_C89) && ((defined(__GNUC__) &&      \
-                __GNUC__ >= 5) || defined(__clang__))
-            #define __static_assert(expr, msg, ...) _Static_assert(expr, msg)
-            #define static_assert(expr, ...) \
-                __static_assert(expr, ##__VA_ARGS__, #expr)
-        #elif defined(__STRICT_ANSI__) || defined(WOLF_C89)
-            #define static_assert(expr) \
-                struct WC_CPP_CAT(dummy_struct_, __LINE__)
-        #else
-            #define static_assert(...) \
-                struct WC_CPP_CAT(wc_dummy_struct_L, __LINE__)
+    #if defined(__cplusplus) && (__cplusplus >= 201103L)
+        #ifndef static_assert2
+            #define static_assert2 static_assert
         #endif
+    #elif !defined(static_assert)
+        #if !defined(__cplusplus) &&                \
+                !defined(__STRICT_ANSI__) &&        \
+                !defined(WOLF_C89) &&               \
+                defined(__STDC_VERSION__) &&        \
+                (__STDC_VERSION__ >= 201112L) &&    \
+                ((defined(__GNUC__) &&              \
+                  (__GNUC__ >= 5)) ||               \
+                 defined(__clang__))
+            #define static_assert(expr) _Static_assert(expr, #expr)
+            #ifndef static_assert2
+                #define static_assert2(expr, msg) _Static_assert(expr, msg)
+            #endif
+        #else
+            #define static_assert(expr) \
+                struct WC_CPP_CAT(wc_dummy_struct_L, __LINE__)
+            #ifndef static_assert2
+                #define static_assert2(expr, msg) static_assert(expr)
+            #endif
+        #endif
+    #elif !defined(static_assert2)
+         #define static_assert2(expr, msg) static_assert(expr)
     #endif
 
     #ifndef SAVE_VECTOR_REGISTERS

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1694,6 +1694,24 @@ typedef struct w64wrapper {
         #define PRAGMA_DIAG_POP /* null expansion */
     #endif
 
+    #define WC_CPP_CAT_(a, b) a ## b
+    #define WC_CPP_CAT(a, b) WC_CPP_CAT_(a, b)
+    #ifndef static_assert
+        #if !defined(__cplusplus) && !defined(__STRICT_ANSI__) && \
+                !defined(WOLF_C89) && ((defined(__GNUC__) &&      \
+                __GNUC__ >= 5) || defined(__clang__))
+            #define __static_assert(expr, msg, ...) _Static_assert(expr, msg)
+            #define static_assert(expr, ...) \
+                __static_assert(expr, ##__VA_ARGS__, #expr)
+        #elif defined(__STRICT_ANSI__) || defined(WOLF_C89)
+            #define static_assert(expr) \
+                struct WC_CPP_CAT(dummy_struct_, __LINE__)
+        #else
+            #define static_assert(...) \
+                struct WC_CPP_CAT(wc_dummy_struct_L, __LINE__)
+        #endif
+    #endif
+
     #ifndef SAVE_VECTOR_REGISTERS
         #define SAVE_VECTOR_REGISTERS(...) WC_DO_NOTHING
     #endif


### PR DESCRIPTION
`wolfssl/wolfcrypt/types.h`: add `static_assert()` definitions;

`wolfssl/internal.h`: add `DTLS13_HANDSHAKE_HEADER_SZ`;

`src/tls13.c`: in `EchHashHelloInner()`, use `falseHeader[DTLS13_HANDSHAKE_HEADER_SZ]` to fix buffer overrun;

`src/dtls13.c`: add static assert for `DTLS13_HANDSHAKE_HEADER_SZ`.

`tests/api.c`:`test_Sha512_Family_Final()`: fix unreachable null pointer deref reported by clang-tidy in FIPS/Async configs.

`m4/ax_atomic.m4`: fixes for C++ compatibility.

`wolfssl/wolfcrypt/wc_port.h`: add `WOLFSSL_API` attribute to `wolfSSL_Atomic_Int_Init`, `wolfSSL_Atomic_Int_FetchAdd`, and `wolfSSL_Atomic_Int_FetchAdd`, and add fallback definitions for them, allowing elimination of `SINGLE_THREADED` implementations of `wolfSSL_Ref*()`, and allowing ungated use of `wolfSSL_Atomic_*` calls in `api.c`.

`wolfcrypt/src/dh.c`: in `wc_DhAgree_ct()`, remove frivolous `XMEMSET()` and stray semicolon.

`wolfcrypt/benchmark/benchmark.c`: fix `bench_rsaKeyGen()` to skip tests of key sizes below `RSA_MIN_SIZE`, and add 4096 bit benchmark if `RSA_MAX_SIZE` is big enough.

`tests/unit.h`:
* adopt definitions of `TEST_FAIL`, `TEST_SUCCESS`, and `TEST_SKIPPED` from `unit.c`, remap `TEST_SKIPPED` from `-7777` to `3`, and add `TEST_SUCCESS_NO_MSGS`, `TEST_SKIPPED_NO_MSGS`, `EXPECT_DECLS_NO_MSGS()`, and `EXPECT_FAILURE_CODEPOINT_ID`, to support existing and future expected-particular-failure test cases without log noise.
* rename outer gate from `CyaSSL_UNIT_H` to `TESTS_UNIT_H`.

`tests/api.c`:
* use `EXPECT_DECLS_NO_MSGS()` in `test_ssl_memio_setup()`, `test_ssl_memio_read_write()`, and `test_wolfSSL_client_server_nofail_memio()`, and globally update affected expected error codes to correspond.
* use atomics for `{client,server}SessRemCount{Malloc,free}` to fix races in `SessRemCtxCb()` and `SessRemSslSetupCb()`.

tested with `wolfssl-multi-test.sh ... super-quick-check` 