### PR TITLE
Small Stack ECC Pairwise Consistency Test

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -10211,23 +10211,31 @@ static int _ecc_pairwise_consistency_test(ecc_key* key, WC_RNG* rng)
     }
 
     if (!err && (flags & WC_ECC_FLAG_DEC_SIGN)) {
+#ifndef WOLFSSL_SMALL_STACK
+        byte sig[MAX_ECC_BYTES + WC_SHA256_DIGEST_SIZE];
+#else
         byte* sig;
+#endif
         byte* digest;
         word32 sigLen, digestLen;
         int dynRng = 0, res = 0;
 
         sigLen = (word32)wc_ecc_sig_size(key);
         digestLen = WC_SHA256_DIGEST_SIZE;
-        sig = (byte*)XMALLOC(sigLen + digestLen, NULL, DYNAMIC_TYPE_ECC);
+#ifdef WOLFSSL_SMALL_STACK
+        sig = (byte*)XMALLOC(sigLen + digestLen, key->heap, DYNAMIC_TYPE_ECC);
         if (sig == NULL)
             return MEMORY_E;
+#endif
         digest = sig + sigLen;
 
         if (rng == NULL) {
             dynRng = 1;
-            rng = wc_rng_new(NULL, 0, NULL);
+            rng = wc_rng_new(NULL, 0, key->heap);
             if (rng == NULL) {
-                XFREE(sig, NULL, DYNAMIC_TYPE_ECC);
+#ifdef WOLFSSL_SMALL_STACK
+                XFREE(sig, key->heap, DYNAMIC_TYPE_ECC);
+#endif
                 return MEMORY_E;
             }
         }
@@ -10248,7 +10256,9 @@ static int _ecc_pairwise_consistency_test(ecc_key* key, WC_RNG* rng)
             wc_rng_free(rng);
         }
         ForceZero(sig, sigLen + digestLen);
-        XFREE(sig, NULL, DYNAMIC_TYPE_ECC);
+#ifdef WOLFSSL_SMALL_STACK
+        XFREE(sig, key->heap, DYNAMIC_TYPE_ECC);
+#endif
     }
     (void)rng;
 


### PR DESCRIPTION
# Description

Update the ECC PCT to use the key's heap when allocating buffers or an RNG for the test. This is how RSA's PCT does it. Also put the test buffers on the stack when not using the small-stack build.
(ZD 17705)

# Testing

Built with scan-build and gcc with address sanitize. Also ran it through valgrind.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
