### PR TITLE
20240920-fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4083,7 +4083,7 @@ AC_ARG_ENABLE([compkey],
     )
 
 if (test "$ENABLED_WPAS" = "yes" || test "$ENABLED_OPENSSLALL" = "yes") &&
-   (test "$HAVE_FIPS_VERSION" != "5" || test "$FIPS_VERSION" = "v5-dev")
+   (test "$HAVE_FIPS_VERSION" != "5")
 then
     ENABLED_COMPKEY=yes
 fi
@@ -5434,7 +5434,7 @@ AS_CASE([$FIPS_VERSION],
             [ENABLED_KEYGEN="yes"; AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_KEY_GEN"])
 
         AS_IF([test "$ENABLED_COMPKEY" = "yes" &&
-               (test "$FIPS_VERSION" != "v5-dev" || test "$enable_compkey" != "yes")],
+               ! (test "$FIPS_VERSION" = "v5-dev" && test "$enable_compkey" = "yes")],
             [AC_MSG_WARN([Forcing off compkey for FIPS ${FIPS_VERSION}.])
              ENABLED_COMPKEY="no"])
 
@@ -5452,13 +5452,13 @@ AS_CASE([$FIPS_VERSION],
 
         # Shake128 is a SHA-3 algorithm outside the v5 FIPS algorithm list
         AS_IF([test "$ENABLED_SHAKE128" != "no" &&
-               (test "$FIPS_VERSION" != "v5-dev" || test "$enable_shake128" != "yes")],
+               ! (test "$FIPS_VERSION" = "v5-dev" && test "$enable_shake128" = "yes")],
             [AC_MSG_WARN([Forcing off shake128 for FIPS ${FIPS_VERSION}.])
              ENABLED_SHAKE128=no; AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_NO_SHAKE128"])
 
         # Shake256 is a SHA-3 algorithm outside the v5 FIPS algorithm list
         AS_IF([test "$ENABLED_SHAKE256" != "no" &&
-               (test "$FIPS_VERSION" != "v5-dev" || test "$enable_shake256" != "yes")],
+               ! (test "$FIPS_VERSION" = "v5-dev" && test "$enable_shake256" = "yes")],
             [AC_MSG_WARN([Forcing off shake256 for FIPS ${FIPS_VERSION}.])
              ENABLED_SHAKE256=no; AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_NO_SHAKE256"])
 
@@ -5470,7 +5470,7 @@ AS_CASE([$FIPS_VERSION],
             [ENABLED_AESCCM="yes"; AM_CFLAGS="$AM_CFLAGS -DHAVE_AESCCM"])
 
         AS_IF([test "$ENABLED_AESXTS" = "yes" &&
-               (test "$FIPS_VERSION" != "v5-dev" || test "$enable_aesxts" != "yes")],
+               ! (test "$FIPS_VERSION" = "v5-dev" && test "$enable_aesxts" = "yes")],
             [AC_MSG_WARN([Forcing off aesxts for FIPS ${FIPS_VERSION}.])
              ENABLED_AESXTS="no"])
 
@@ -5510,7 +5510,7 @@ AS_CASE([$FIPS_VERSION],
 
         # AES-GCM streaming isn't part of the v5 FIPS suite.
         AS_IF([test "$ENABLED_AESGCM_STREAM" = "yes" &&
-               (test "$FIPS_VERSION" != "v5-dev" || test "$enable_aesgcm_stream" != "yes")],
+               ! (test "$FIPS_VERSION" = "v5-dev" && test "$enable_aesgcm_stream" = "yes")],
             [AC_MSG_WARN([Forcing off aesgcm-stream for FIPS ${FIPS_VERSION}.])
              ENABLED_AESGCM_STREAM="no"])
 
@@ -5525,12 +5525,12 @@ AS_CASE([$FIPS_VERSION],
                 [ENABLED_AESOFB="yes"; AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_AES_OFB"])])
 
         AS_IF([test "$ENABLED_SRTP" != "no" &&
-               (test "$FIPS_VERSION" != "v5-dev" || test "$enable_srtp" != "yes")],
+               ! (test "$FIPS_VERSION" = "v5-dev" && test "$enable_srtp" = "yes")],
             [AC_MSG_WARN([Forcing off srtp for FIPS ${FIPS_VERSION}.])
              ENABLED_SRTP="no"])
 
         AS_IF([test "$ENABLED_SRTP_KDF" != "no" &&
-               (test "$FIPS_VERSION" != "v5-dev" || test "$enable_srtp_kdf" != "yes")],
+               ! (test "$FIPS_VERSION" = "v5-dev" && test "$enable_srtp_kdf" = "yes")],
             [AC_MSG_WARN([Forcing off srtp-kdf for FIPS ${FIPS_VERSION}.])
              ENABLED_SRTP_KDF="no"])
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -221,7 +221,7 @@ static int Tls13HKDFExpandLabel(WOLFSSL* ssl, byte* okm, word32 okmLen,
 #endif
     (void)ssl;
     PRIVATE_KEY_UNLOCK();
-#if !defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3))
+#if !defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(6,0))
     ret = wc_Tls13_HKDF_Expand_Label_ex(okm, okmLen, prk, prkLen,
                                      protocol, protocolLen,
                                      label, labelLen,
@@ -261,7 +261,7 @@ static int Tls13HKDFExpandKeyLabel(WOLFSSL* ssl, byte* okm, word32 okmLen,
         return ret;
 #endif
 
-#if !defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3))
+#if !defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(6,0))
     ret = wc_Tls13_HKDF_Expand_Label_ex(okm, okmLen, prk, prkLen,
                                       protocol, protocolLen,
                                       label, labelLen,
@@ -1137,7 +1137,7 @@ static int Tls13_HKDF_Extract(WOLFSSL *ssl, byte* prk, const byte* salt,
 #endif
     {
     #if !defined(HAVE_FIPS) || \
-        (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3))
+        (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(6,0))
         ret = wc_Tls13_HKDF_Extract_ex(prk, salt, (word32)saltLen, ikm, (word32)ikmLen, digest,
             ssl->heap, ssl->devId);
     #else
@@ -4840,7 +4840,7 @@ static int EchCheckAcceptance(WOLFSSL* ssl, const byte* input,
     if (ret == 0) {
         PRIVATE_KEY_UNLOCK();
     #if !defined(HAVE_FIPS) || \
-        (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3))
+        (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(6,0))
         ret = wc_HKDF_Extract_ex(digestType, zeros, (word32)digestSize,
             ssl->arrays->clientRandomInner, RAN_LEN, expandLabelPrk,
             ssl->heap, ssl->devId);
@@ -4978,7 +4978,7 @@ static int EchWriteAcceptance(WOLFSSL* ssl, byte* output,
     if (ret == 0) {
         PRIVATE_KEY_UNLOCK();
     #if !defined(HAVE_FIPS) || \
-        (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3))
+        (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(6,0))
         ret = wc_HKDF_Extract_ex(digestType, zeros, (word32)digestSize,
             ssl->arrays->clientRandom, RAN_LEN, expandLabelPrk,
             ssl->heap, ssl->devId);

--- a/wolfcrypt/src/error.c
+++ b/wolfcrypt/src/error.c
@@ -364,13 +364,13 @@ const char* wc_GetErrorString(int error)
         return "ECC is point on curve failed";
 
     case ECC_INF_E:
-        return " ECC point at infinity error";
+        return "ECC point at infinity error";
 
     case ECC_OUT_OF_RANGE_E:
-        return " ECC Qx or Qy out of range error";
+        return "ECC Qx or Qy out of range error";
 
     case ECC_PRIV_KEY_E:
-        return " ECC private key is not valid error";
+        return "ECC private key is not valid error";
 
     case SRP_CALL_ORDER_E:
         return "SRP function called in the wrong order error";

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -810,10 +810,16 @@ static void render_error_message(const char* msg, wc_test_ret_t es)
 #ifdef NO_ERROR_STRINGS
         err_sys_printf("%s error L=%d code=%d\n", msg,
                        WC_TEST_RET_DEC_LN(es), -WC_TEST_RET_DEC_I(es));
+#elif defined(WOLFCRYPT_ONLY) || !defined(WOLFSSL_TYPES_DEFINED)
+        err_sys_printf("%s error L=%d code=%d (%s)\n", msg,
+                       WC_TEST_RET_DEC_LN(es), -WC_TEST_RET_DEC_I(es),
+                       wc_GetErrorString(-WC_TEST_RET_DEC_I(es))
+            );
 #else
         err_sys_printf("%s error L=%d code=%d (%s)\n", msg,
                        WC_TEST_RET_DEC_LN(es), -WC_TEST_RET_DEC_I(es),
-                       wc_GetErrorString(-WC_TEST_RET_DEC_I(es)));
+                       wolfSSL_ERR_reason_error_string(-WC_TEST_RET_DEC_I(es))
+            );
 #endif
         break;
     case WC_TEST_RET_TAG_ERRNO:
@@ -29327,7 +29333,7 @@ static wc_test_ret_t ecc_test_deterministic_k(WC_RNG* rng)
                 0xA8
     };
 #endif
-#ifdef WOLFSSL_SHA384
+#if defined(WOLFSSL_SHA384) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(6,0))
     WOLFSSL_SMALL_STACK_STATIC const byte expSig384[] = {
         0x30, 0x44, /* CONSTRUCTED SEQUENCE: (0x20 | 0x10) = 68 bytes */
             0x02, 0x20, /* ASN_INTEGER = 0x02 (32 bytes) - SIG R */
@@ -29342,7 +29348,7 @@ static wc_test_ret_t ecc_test_deterministic_k(WC_RNG* rng)
                 0x26, 0x1f, 0x13, 0xab, 0xde, 0x94, 0x09, 0x54
     };
 #endif
-#ifdef WOLFSSL_SHA512
+#if defined(WOLFSSL_SHA512) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(6,0))
     WOLFSSL_SMALL_STACK_STATIC const byte expSig512[] = {
         0x30, 0x45, /* CONSTRUCTED SEQUENCE: (0x20 | 0x10) = 68 bytes */
             0x02, 0x21, /* ASN_INTEGER = 0x02 (32 bytes) - SIG R */
@@ -29385,7 +29391,7 @@ static wc_test_ret_t ecc_test_deterministic_k(WC_RNG* rng)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 #endif /* !NO_SHA256 */
 
-#ifdef WOLFSSL_SHA384
+#if defined(WOLFSSL_SHA384) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(6,0))
     /* Test for SHA2-384 */
     ret = ecdsa_test_deterministic_k_sig(key, WC_HASH_TYPE_SHA384, msg, rng,
         expSig384, sizeof(expSig384));
@@ -29393,7 +29399,7 @@ static wc_test_ret_t ecc_test_deterministic_k(WC_RNG* rng)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
 #endif /* WOLFSSL_SHA384 */
 
-#ifdef WOLFSSL_SHA512
+#if defined(WOLFSSL_SHA512) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(6,0))
     /* Test for SHA2-512 */
     ret = ecdsa_test_deterministic_k_sig(key, WC_HASH_TYPE_SHA512, msg, rng,
         expSig512, sizeof(expSig512));
@@ -29491,7 +29497,7 @@ static wc_test_ret_t ecc384_test_deterministic_k(WC_RNG* rng)
        "F3AA443FB107745BF4BD77CB3891674632068A10CA67E3D45DB2266FA7D1FEEB"
        "EFDC63ECCD1AC42EC0CB8668A4FA0AB0";
 #endif
-#ifdef WOLFSSL_SHA384
+#if defined(WOLFSSL_SHA384) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(6,0))
     WOLFSSL_SMALL_STACK_STATIC const char* expRstr384 =
         "94EDBB92A5ECB8AAD4736E56C691916B3F88140666CE9FA73D64C4EA95AD133C"
         "81A648152E44ACF96E36DD1E80FABE46";
@@ -29499,7 +29505,7 @@ static wc_test_ret_t ecc384_test_deterministic_k(WC_RNG* rng)
         "99EF4AEB15F178CEA1FE40DB2603138F130E740A19624526203B6351D0A3A94F"
         "A329C145786E679E7B82C71A38628AC8";
 #endif
-#ifdef WOLFSSL_SHA512
+#if defined(WOLFSSL_SHA512) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(6,0))
     WOLFSSL_SMALL_STACK_STATIC const char* expRstr512 =
         "ED0959D5880AB2D869AE7F6C2915C6D60F96507F9CB3E047C0046861DA4A799C"
         "FE30F35CC900056D7C99CD7882433709";
@@ -29549,27 +29555,27 @@ static wc_test_ret_t ecc384_test_deterministic_k(WC_RNG* rng)
     ret = ecdsa_test_deterministic_k_rs(key, WC_HASH_TYPE_SHA256, msg, rng,
         r, s, expR, expS);
     if (ret != 0)
-        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
+        ERROR_OUT(ret, done);
 #endif /* NO_SHA256 */
 
-#ifdef WOLFSSL_SHA384
+#if defined(WOLFSSL_SHA384) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(6,0))
     /* Test for SHA2-384 */
     mp_read_radix(expR, expRstr384, MP_RADIX_HEX);
     mp_read_radix(expS, expSstr384, MP_RADIX_HEX);
     ret = ecdsa_test_deterministic_k_rs(key, WC_HASH_TYPE_SHA384, msg, rng,
         r, s, expR, expS);
     if (ret != 0)
-        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
+        ERROR_OUT(ret, done);
 #endif /* WOLFSSL_SHA384 */
 
-#ifdef WOLFSSL_SHA512
+#if defined(WOLFSSL_SHA512) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(6,0))
     /* Test for SHA2-512 */
     mp_read_radix(expR, expRstr512, MP_RADIX_HEX);
     mp_read_radix(expS, expSstr512, MP_RADIX_HEX);
     ret = ecdsa_test_deterministic_k_rs(key, WC_HASH_TYPE_SHA512, msg, rng,
         r, s, expR, expS);
     if (ret != 0)
-        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
+        ERROR_OUT(ret, done);
 #endif /* WOLFSSL_SHA512 */
 
 done:
@@ -29630,7 +29636,7 @@ static wc_test_ret_t ecc521_test_deterministic_k(WC_RNG* rng)
         "E4F7A72930B1BC06DBE22CE3F58264AFD23704CBB63B29B931F7DE6C9D949A7E"
         "CFC";
 #endif
-#ifdef WOLFSSL_SHA384
+#if defined(WOLFSSL_SHA384) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(6,0))
     WOLFSSL_SMALL_STACK_STATIC const char* expRstr384 =
         "1EA842A0E17D2DE4F92C15315C63DDF72685C18195C2BB95E572B9C5136CA4B4"
         "B576AD712A52BE9730627D16054BA40CC0B8D3FF035B12AE75168397F5D50C67"
@@ -29640,7 +29646,7 @@ static wc_test_ret_t ecc521_test_deterministic_k(WC_RNG* rng)
         "FDE143FA85DC394A7DEE766523393784484BDF3E00114A1C857CDE1AA203DB65"
         "D61";
 #endif
-#ifdef WOLFSSL_SHA512
+#if defined(WOLFSSL_SHA512) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(6,0))
     WOLFSSL_SMALL_STACK_STATIC const char* expRstr512 =
         "0C328FAFCBD79DD77850370C46325D987CB525569FB63C5D3BC53950E6D4C5F1"
         "74E25A1EE9017B5D450606ADD152B534931D7D4E8455CC91F9B15BF05EC36E37"
@@ -29693,27 +29699,27 @@ static wc_test_ret_t ecc521_test_deterministic_k(WC_RNG* rng)
     ret = ecdsa_test_deterministic_k_rs(key, WC_HASH_TYPE_SHA256, msg, rng,
         r, s, expR, expS);
     if (ret != 0)
-        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
+        ERROR_OUT(ret, done);
 #endif /* NO_SHA256 */
 
-#ifdef WOLFSSL_SHA384
+#if defined(WOLFSSL_SHA384) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(6,0))
     /* Test for SHA2-384 */
     mp_read_radix(expR, expRstr384, MP_RADIX_HEX);
     mp_read_radix(expS, expSstr384, MP_RADIX_HEX);
     ret = ecdsa_test_deterministic_k_rs(key, WC_HASH_TYPE_SHA384, msg, rng,
         r, s, expR, expS);
     if (ret != 0)
-        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
+        ERROR_OUT(ret, done);
 #endif /* WOLFSSL_SHA384 */
 
-#ifdef WOLFSSL_SHA512
+#if defined(WOLFSSL_SHA512) && (!defined(HAVE_FIPS) || FIPS_VERSION_GE(6,0))
     /* Test for SHA2-512 */
     mp_read_radix(expR, expRstr512, MP_RADIX_HEX);
     mp_read_radix(expS, expSstr512, MP_RADIX_HEX);
     ret = ecdsa_test_deterministic_k_rs(key, WC_HASH_TYPE_SHA512, msg, rng,
         r, s, expR, expS);
     if (ret != 0)
-        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), done);
+        ERROR_OUT(ret, done);
 #endif /* WOLFSSL_SHA512 */
 
 done:
@@ -48821,7 +48827,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t cmac_test(void)
 
         XMEMSET(tag, 0, sizeof(tag));
         tagSz = sizeof(tag);
-#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)
+#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(6, 0)
         ret = wc_AesCmacGenerate_ex(cmac, tag, &tagSz, tc->m, tc->mSz,
                                tc->k, tc->kSz, NULL, devId);
 #else
@@ -48832,7 +48838,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t cmac_test(void)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
         if (XMEMCMP(tag, tc->t, AES_BLOCK_SIZE) != 0)
             ERROR_OUT(WC_TEST_RET_ENC_NC, out);
-#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)
+#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(6, 0)
         ret = wc_AesCmacVerify_ex(cmac, tc->t, tc->tSz, tc->m, tc->mSz,
                              tc->k, tc->kSz, HEAP_HINT, devId);
 #else
@@ -48842,7 +48848,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t cmac_test(void)
         if (ret != 0)
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
-#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)
+#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(6, 0)
         /* Test that keyless generate with init is the same */
         XMEMSET(tag, 0, sizeof(tag));
         tagSz = sizeof(tag);


### PR DESCRIPTION
FIPS v5 gating fixes:
`configure.ac`:
* fix logic in "Forcing off" test expressions, first flubbed in 19106a9510;
* fix auto-enable of compkey to exclude v5 even if `v5-dev`.

`src/tls13.c`: fix gating for HKDF _ex() variants (>=6.0, not >=5.3);

`wolfcrypt/src/error.c`: snip out stray spaces at start of several ECC error message strings;

`wolfcrypt/test/test.c`:
* in `render_error_message()`, use `wolfSSL_ERR_reason_error_string()` if available rather than `wc_GetErrorString()`, to render non-wolfcrypt error strings;
* in `ecc_test_deterministic_k()`, `ecc384_test_deterministic_k()`, `ecc521_test_deterministic_k()`, on FIPS <6.0, gate out SHA384 and SHA512 tests (FIPS v5 only supports SHA256 in `wc_ecc_gen_deterministic_k()`);
* in `cmac_test()`, gate use of `wc_AesCmacGenerate_ex()` and `wc_AesCmacVerify_ex()` on >=6.0, not >=5.3.

tested with `wolfssl-multi-test.sh ... fips-140-3-v5-ready-optest-acvp-sp-asm fips-140-3-v5-dev-all fips-140-3-dev-kcapi super-quick-check`
