### PR TITLE
This is a WIP!

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -11269,7 +11269,7 @@ int wc_ecc_import_private_key_ex(const byte* priv, word32 privSz,
 #endif
 
 #ifdef WOLFSSL_MAXQ10XX_CRYPTO
-    if (ret == 0) {
+    if (ret == 0 && key->devId != INVALID_DEVID) {
         ret = wc_MAXQ10XX_EccSetKey(key, key->dp->size);
     }
 #elif defined(WOLFSSL_SILABS_SE_ACCEL)


### PR DESCRIPTION
- In wc_ecc_import_private_key_ex(), do not call wc_MAXQ10XX_EccSetKey() if the key is not a MAXQ key. Need this because KeyPairImport does not reside on MAXQ device so it will error out.
- in ecc_set_key() unlock before ECDSA_sign() and then lock after it because it will use the RNG and will try to acquire lock.
- Move maxq10xx_ecc_key_gen()  higher so it can be called by wolfSSL_MAXQ10XX_CryptoDevCb().  Note we still return CRYPTOCB_UNAVAILABLE because we don't actually get a shared secret.
- Refactor maxq10xx_tls12_ecc_shared_secret() to create new functio maxq10xx_compute_ecc_shared_secret() so that it can be called by wolfSSL_MAXQ10XX_CryptoDevCb(). Note we still return CRYPTOCB_UNAVAILABLE because we don't actually get a shared secret.

# Description

Please describe the scope of the fix or feature addition.

Fixes zd#

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
