### PR TITLE
ECC Test Fix

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -10229,7 +10229,8 @@ static int _ecc_pairwise_consistency_test(ecc_key* key, WC_RNG* rng)
 
     if (!err && (flags & WC_ECC_FLAG_DEC_SIGN)) {
 #ifndef WOLFSSL_SMALL_STACK
-        byte sig[MAX_ECC_BYTES + WC_SHA256_DIGEST_SIZE];
+        #define SIG_SZ ((MAX_ECC_BYTES * 2) + SIG_HEADER_SZ + ECC_MAX_PAD_SZ)
+        byte sig[SIG_SZ + WC_SHA256_DIGEST_SIZE];
 #else
         byte* sig;
 #endif


### PR DESCRIPTION
# Description

The ECC key generation test was failing due not using large enough of a buffer. Fixed to use a better size. Set the shared digest/sig buffer size in _ecc_pairwise_consistency_test() to the maximum possible based on the math in wc_ecc_sig_sz().

# Testing

    ./configure CPPFLAGS="-DWOLFSSL_VALIDATE_ECC_IMPORT -DWOLFSSL_VALIDATE_ECC_KEYGEN" CC="clang -fsanitize=address" && make clean && make
    ./wolfcrypt/test/testwolfcrypt

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
