### PR TITLE
New option to always copy over key to SSL object

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1237,7 +1237,7 @@ AC_ARG_WITH([liboqs],
                 tryliboqsdir="/usr/local"
             fi
 
-            CPPFLAGS="$AM_CPPFLAGS -DHAVE_LIBOQS -DHAVE_TLS_EXTENSIONS -I$tryliboqsdir/include"
+            CPPFLAGS="$AM_CPPFLAGS -DHAVE_LIBOQS -DHAVE_TLS_EXTENSIONS -I$tryliboqsdir/include -pthread"
             LDFLAGS="$AM_LDFLAGS $LDFLAGS -L$tryliboqsdir/lib"
 
             AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <oqs/common.h>]], [[ OQS_init(); ]])], [ liboqs_linked=yes ],[ liboqs_linked=no ])

--- a/src/internal.c
+++ b/src/internal.c
@@ -6829,7 +6829,14 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
     ssl->buffers.certChainCnt = ctx->certChainCnt;
 #endif
 #ifndef WOLFSSL_BLIND_PRIVATE_KEY
+#ifdef WOLFSSL_COPY_KEY
+    AllocCopyDer(&ssl->buffers.key, ctx->privateKey->buffer,
+        ctx->privateKey->length, ctx->privateKey->type,
+        ctx->privateKey->heap);
+    ssl->buffers.weOwnKey = 1;
+#else
     ssl->buffers.key      = ctx->privateKey;
+#endif
 #else
     if (ctx->privateKey != NULL) {
         AllocCopyDer(&ssl->buffers.key, ctx->privateKey->buffer,

--- a/src/internal.c
+++ b/src/internal.c
@@ -6830,10 +6830,18 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
 #endif
 #ifndef WOLFSSL_BLIND_PRIVATE_KEY
 #ifdef WOLFSSL_COPY_KEY
-    AllocCopyDer(&ssl->buffers.key, ctx->privateKey->buffer,
-        ctx->privateKey->length, ctx->privateKey->type,
-        ctx->privateKey->heap);
-    ssl->buffers.weOwnKey = 1;
+    if (ctx->privateKey != NULL) {
+        if (ssl->buffers.key != NULL) {
+            FreeDer(&ssl->buffers.key);
+        }
+        AllocCopyDer(&ssl->buffers.key, ctx->privateKey->buffer,
+            ctx->privateKey->length, ctx->privateKey->type,
+            ctx->privateKey->heap);
+        ssl->buffers.weOwnKey = 1;
+    }
+    else {
+        ssl->buffers.key      = ctx->privateKey;
+    }
 #else
     ssl->buffers.key      = ctx->privateKey;
 #endif

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -20410,7 +20410,14 @@ WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
     ssl->buffers.certChainCnt = ctx->certChainCnt;
 #endif
 #ifndef WOLFSSL_BLIND_PRIVATE_KEY
+#ifdef WOLFSSL_COPY_KEY
+    AllocCopyDer(&ssl->buffers.key, ctx->privateKey->buffer,
+        ctx->privateKey->length, ctx->privateKey->type,
+        ctx->privateKey->heap);
+    ssl->buffers.weOwnKey = 1;
+#else
     ssl->buffers.key      = ctx->privateKey;
+#endif
 #else
     if (ctx->privateKey != NULL) {
         AllocCopyDer(&ssl->buffers.key, ctx->privateKey->buffer,

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -20411,10 +20411,18 @@ WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
 #endif
 #ifndef WOLFSSL_BLIND_PRIVATE_KEY
 #ifdef WOLFSSL_COPY_KEY
-    AllocCopyDer(&ssl->buffers.key, ctx->privateKey->buffer,
-        ctx->privateKey->length, ctx->privateKey->type,
-        ctx->privateKey->heap);
-    ssl->buffers.weOwnKey = 1;
+    if (ctx->privateKey != NULL) {
+        if (ssl->buffers.key != NULL) {
+            FreeDer(&ssl->buffers.key);
+        }
+        AllocCopyDer(&ssl->buffers.key, ctx->privateKey->buffer,
+            ctx->privateKey->length, ctx->privateKey->type,
+            ctx->privateKey->heap);
+        ssl->buffers.weOwnKey = 1;
+    }
+    else {
+        ssl->buffers.key      = ctx->privateKey;
+    }
 #else
     ssl->buffers.key      = ctx->privateKey;
 #endif

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3581,6 +3581,11 @@ extern void uITRON4_free(void *p) ;
     #define WOLFSSL_COPY_CERT
 #endif
 
+#if defined(OPENSSL_ALL) && !defined(WOLFSSL_NO_COPY_KEY)
+    #undef WOLFSSL_COPY_KEY
+    #define WOLFSSL_COPY_KEY
+#endif
+
 /*
  * Keeps the "Finished" messages after a TLS handshake for use as the so-called
  * "tls-unique" channel binding. See comment in internal.h around clientFinished

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3576,11 +3576,17 @@ extern void uITRON4_free(void *p) ;
     #define KEEP_PEER_CERT
 #endif
 
+/* Always copy certificate(s) from SSL CTX to each SSL object on creation,
+ * if this is not defined then each SSL object shares a pointer to the
+ * original certificate buffer owned by the SSL CTX. */
 #if defined(OPENSSL_ALL) && !defined(WOLFSSL_NO_COPY_CERT)
     #undef WOLFSSL_COPY_CERT
     #define WOLFSSL_COPY_CERT
 #endif
 
+/* Always copy private key from SSL CTX to each SSL object on creation,
+ * if this is not defined then each SSL object shares a pointer to the
+ * original key buffer owned by the SSL CTX. */
 #if defined(OPENSSL_ALL) && !defined(WOLFSSL_NO_COPY_KEY)
     #undef WOLFSSL_COPY_KEY
     #define WOLFSSL_COPY_KEY


### PR DESCRIPTION
# Description

Initial implementation of new option to always copy over key to SSL ctx

Fixes zd 18662