### PR TITLE
Update to separate CMAC and AES conditional compiles.  Correct update.

### DIFF
--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -178,7 +178,6 @@ int wc_InitCmac_ex(Cmac* cmac, const byte* key, word32 keySz,
         break;
 #endif /* !NO_AES && WOLFSSL_AES_DIRECT */
     default:
-
         return BAD_FUNC_ARG;
     }
 
@@ -249,7 +248,7 @@ int wc_CmacUpdate(Cmac* cmac, const byte* in, word32 inSz)
         }
     }; break;
 #endif /* !NO_AES && WOLFSSL_AES_DIRECT */
-    default :
+    default:
         ret = BAD_FUNC_ARG;
     }
     return ret;
@@ -271,7 +270,7 @@ int wc_CmacFree(Cmac* cmac)
         wc_AesFree(&cmac->aes);
         break;
 #endif /* !NO_AES && WOLFSSL_AES_DIRECT */
-    default :
+    default:
         /* Nothing to do */
         (void)cmac;
     }
@@ -344,7 +343,7 @@ int wc_CmacFinalNoFree(Cmac* cmac, byte* out, word32* outSz)
             }
         }; break;
     #endif /* !NO_AES && WOLFSSL_AES_DIRECT */
-        default :
+        default:
             ret = BAD_FUNC_ARG;
         }
     }

--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -297,9 +297,11 @@ int wc_CmacFinalNoFree(Cmac* cmac, byte* out, word32* outSz)
         ret = wc_CryptoCb_Cmac(cmac, NULL, 0, NULL, 0, out, outSz, cmac->type, NULL);
         if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
+        /* Clear CRYPTOCB_UNAVAILABLE return code */
+       ret = 0;
+
         /* fall-through when unavailable */
     }
-    ret = 0;
 #endif
     switch (cmac->type) {
 #if !defined(NO_AES) && defined(WOLFSSL_AES_DIRECT)
@@ -343,7 +345,8 @@ int wc_CmacFinalNoFree(Cmac* cmac, byte* out, word32* outSz)
     return ret;
 }
 
-int wc_CmacFinal(Cmac* cmac, byte* out, word32* outSz) {
+int wc_CmacFinal(Cmac* cmac, byte* out, word32* outSz)
+{
     int ret = 0;
 
     if (cmac == NULL)

--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -239,7 +239,8 @@ int wc_CmacUpdate(Cmac* cmac, const byte* in, word32 inSz)
                 if (cmac->totalSz != 0) {
                     xorbuf(cmac->buffer, cmac->digest, AES_BLOCK_SIZE);
                 }
-                ret = wc_AesEncryptDirect(&cmac->aes, cmac->digest, cmac->buffer);
+                ret = wc_AesEncryptDirect(&cmac->aes, cmac->digest,
+                        cmac->buffer);
                 if (ret == 0) {
                     cmac->totalSz += AES_BLOCK_SIZE;
                     cmac->bufferSz = 0;
@@ -294,7 +295,8 @@ int wc_CmacFinalNoFree(Cmac* cmac, byte* out, word32* outSz)
     if (cmac->devId != INVALID_DEVID)
     #endif
     {
-        ret = wc_CryptoCb_Cmac(cmac, NULL, 0, NULL, 0, out, outSz, cmac->type, NULL);
+        ret = wc_CryptoCb_Cmac(cmac, NULL, 0, NULL, 0, out, outSz, cmac->type,
+                NULL);
         if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* Clear CRYPTOCB_UNAVAILABLE return code */
@@ -324,7 +326,8 @@ int wc_CmacFinalNoFree(Cmac* cmac, byte* out, word32* outSz)
                 remainder = AES_BLOCK_SIZE;
             }
             if (remainder > 1) {
-                XMEMSET(cmac->buffer + AES_BLOCK_SIZE - remainder, 0, remainder);
+                XMEMSET(cmac->buffer + AES_BLOCK_SIZE - remainder, 0,
+                        remainder);
             }
 
             cmac->buffer[AES_BLOCK_SIZE - remainder] = 0x80;
@@ -472,7 +475,8 @@ int wc_AesCmacVerify_ex(Cmac* cmac,
     word32 aSz = sizeof(a);
     int compareRet;
 
-    if (cmac == NULL || check == NULL || checkSz == 0 || (in == NULL && inSz != 0)) {
+    if (cmac == NULL || check == NULL || checkSz == 0 ||
+            (in == NULL && inSz != 0)) {
         return BAD_FUNC_ARG;
     }
 

--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -318,7 +318,8 @@ int wc_CmacFinalNoFree(Cmac* cmac, byte* out, word32* outSz)
         else {
             /* ensure we will have a valid remainder value */
             if (cmac->bufferSz > AES_BLOCK_SIZE) {
-                return BAD_STATE_E;
+                ret = BAD_STATE_E;
+                break;
             }
             remainder = AES_BLOCK_SIZE - cmac->bufferSz;
 

--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -32,7 +32,7 @@
 #include <wolfssl/wolfcrypt/hash.h>
 #endif
 
-#if defined(WOLFSSL_CMAC) && !defined(NO_AES) && defined(WOLFSSL_AES_DIRECT)
+#if defined(WOLFSSL_CMAC)
 
 #if defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)
     /* set NO_WRAPPERS before headers, use direct internal f()s not wrappers */
@@ -80,7 +80,7 @@ int wc_CMAC_Grow(Cmac* cmac, const byte* in, int inSz)
 }
 #endif /* WOLFSSL_HASH_KEEP */
 
-
+#if !defined(NO_AES) && defined(WOLFSSL_AES_DIRECT)
 /* Used by AES-SIV. See aes.c. */
 void ShiftAndXorRb(byte* out, byte* in)
 {
@@ -100,6 +100,7 @@ void ShiftAndXorRb(byte* out, byte* in)
         }
     }
 }
+#endif /* !NO_AES && WOLFSSL_AES_DIRECT */
 
 /* returns 0 on success */
 int wc_InitCmac_ex(Cmac* cmac, const byte* key, word32 keySz,
@@ -146,30 +147,41 @@ int wc_InitCmac_ex(Cmac* cmac, const byte* key, word32 keySz,
         return BAD_FUNC_ARG;
     }
 
-    ret = wc_AesInit(&cmac->aes, heap, devId);
+    switch (type) {
+#if !defined (NO_AES) && defined(WOLFSSL_AES_DIRECT)
+    case WC_CMAC_AES:
+        cmac->type = WC_CMAC_AES;
+        ret = wc_AesInit(&cmac->aes, heap, devId);
 
-#if defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_CRYPT)
-    cmac->useSWCrypt = useSW;
-    if (cmac->useSWCrypt == 1) {
-        cmac->aes.useSWCrypt = 1;
-    }
-#endif
-
-    if (ret == 0) {
-        ret = wc_AesSetKey(&cmac->aes, key, keySz, NULL, AES_ENCRYPTION);
-    }
-
-    if (ret == 0) {
-        byte l[AES_BLOCK_SIZE];
-
-        XMEMSET(l, 0, AES_BLOCK_SIZE);
-        ret = wc_AesEncryptDirect(&cmac->aes, l, l);
-        if (ret == 0) {
-            ShiftAndXorRb(cmac->k1, l);
-            ShiftAndXorRb(cmac->k2, cmac->k1);
-            ForceZero(l, AES_BLOCK_SIZE);
+    #if defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_CRYPT)
+        cmac->useSWCrypt = useSW;
+        if (cmac->useSWCrypt == 1) {
+            cmac->aes.useSWCrypt = 1;
         }
+    #endif
+
+        if (ret == 0) {
+            ret = wc_AesSetKey(&cmac->aes, key, keySz, NULL, AES_ENCRYPTION);
+        }
+
+        if (ret == 0) {
+            byte l[AES_BLOCK_SIZE];
+
+            XMEMSET(l, 0, AES_BLOCK_SIZE);
+            ret = wc_AesEncryptDirect(&cmac->aes, l, l);
+            if (ret == 0) {
+                ShiftAndXorRb(cmac->k1, l);
+                ShiftAndXorRb(cmac->k2, cmac->k1);
+                ForceZero(l, AES_BLOCK_SIZE);
+            }
+        }
+        break;
+#endif /* !NO_AES && WOLFSSL_AES_DIRECT */
+    default:
+
+        return BAD_FUNC_ARG;
     }
+
     return ret;
 }
 
@@ -201,7 +213,7 @@ int wc_CmacUpdate(Cmac* cmac, const byte* in, word32 inSz)
     #endif
     {
         ret = wc_CryptoCb_Cmac(cmac, NULL, 0, in, inSz,
-                NULL, NULL, 0, NULL);
+                NULL, NULL, cmac->type, NULL);
         if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
@@ -211,26 +223,34 @@ int wc_CmacUpdate(Cmac* cmac, const byte* in, word32 inSz)
     /* Clear CRYPTOCB_UNAVAILABLE return code */
     ret = 0;
 
-    while ((ret == 0) && (inSz != 0)) {
-        word32 add = min(inSz, AES_BLOCK_SIZE - cmac->bufferSz);
-        XMEMCPY(&cmac->buffer[cmac->bufferSz], in, add);
+    switch (cmac->type) {
+#if !defined(NO_AES) && defined(WOLFSSL_AES_DIRECT)
+    case WC_CMAC_AES:
+    {
+        while ((ret == 0) && (inSz != 0)) {
+            word32 add = min(inSz, AES_BLOCK_SIZE - cmac->bufferSz);
+            XMEMCPY(&cmac->buffer[cmac->bufferSz], in, add);
 
-        cmac->bufferSz += add;
-        in += add;
-        inSz -= add;
+            cmac->bufferSz += add;
+            in += add;
+            inSz -= add;
 
-        if (cmac->bufferSz == AES_BLOCK_SIZE && inSz != 0) {
-            if (cmac->totalSz != 0) {
-                xorbuf(cmac->buffer, cmac->digest, AES_BLOCK_SIZE);
-            }
-            ret = wc_AesEncryptDirect(&cmac->aes, cmac->digest, cmac->buffer);
-            if (ret == 0) {
-                cmac->totalSz += AES_BLOCK_SIZE;
-                cmac->bufferSz = 0;
+            if (cmac->bufferSz == AES_BLOCK_SIZE && inSz != 0) {
+                if (cmac->totalSz != 0) {
+                    xorbuf(cmac->buffer, cmac->digest, AES_BLOCK_SIZE);
+                }
+                ret = wc_AesEncryptDirect(&cmac->aes, cmac->digest, cmac->buffer);
+                if (ret == 0) {
+                    cmac->totalSz += AES_BLOCK_SIZE;
+                    cmac->bufferSz = 0;
+                }
             }
         }
+    }; break;
+#endif /* !NO_AES && WOLFSSL_AES_DIRECT */
+    default :
+        ret = BAD_FUNC_ARG;
     }
-
     return ret;
 }
 
@@ -244,7 +264,16 @@ int wc_CmacFree(Cmac* cmac)
      * wc_CmacFinal() not called. */
     XFREE(cmac->msg, cmac->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
-    wc_AesFree(&cmac->aes);
+    switch (cmac->type) {
+#if !defined(NO_AES) && defined(WOLFSSL_AES_DIRECT)
+    case WC_CMAC_AES:
+        wc_AesFree(&cmac->aes);
+        break;
+#endif /* !NO_AES && WOLFSSL_AES_DIRECT */
+    default :
+        /* Nothing to do */
+        (void)cmac;
+    }
     ForceZero(cmac, sizeof(Cmac));
     return 0;
 }
@@ -252,8 +281,6 @@ int wc_CmacFree(Cmac* cmac)
 int wc_CmacFinalNoFree(Cmac* cmac, byte* out, word32* outSz)
 {
     int ret = 0;
-    const byte* subKey;
-    word32 remainder;
 
     if (cmac == NULL || out == NULL || outSz == NULL) {
         return BAD_FUNC_ARG;
@@ -267,41 +294,53 @@ int wc_CmacFinalNoFree(Cmac* cmac, byte* out, word32* outSz)
     if (cmac->devId != INVALID_DEVID)
     #endif
     {
-        ret = wc_CryptoCb_Cmac(cmac, NULL, 0, NULL, 0, out, outSz, 0, NULL);
+        ret = wc_CryptoCb_Cmac(cmac, NULL, 0, NULL, 0, out, outSz, cmac->type, NULL);
         if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
     }
+    ret = 0;
 #endif
+    switch (cmac->type) {
+#if !defined(NO_AES) && defined(WOLFSSL_AES_DIRECT)
+    case WC_CMAC_AES:
+    {
+        const byte* subKey;
+        word32 remainder;
 
-    if (cmac->bufferSz == AES_BLOCK_SIZE) {
-        subKey = cmac->k1;
-    }
-    else {
-        /* ensure we will have a valid remainder value */
-        if (cmac->bufferSz > AES_BLOCK_SIZE) {
-            return BAD_STATE_E;
+        if (cmac->bufferSz == AES_BLOCK_SIZE) {
+            subKey = cmac->k1;
         }
-        remainder = AES_BLOCK_SIZE - cmac->bufferSz;
+        else {
+            /* ensure we will have a valid remainder value */
+            if (cmac->bufferSz > AES_BLOCK_SIZE) {
+                return BAD_STATE_E;
+            }
+            remainder = AES_BLOCK_SIZE - cmac->bufferSz;
 
-        if (remainder == 0) {
-            remainder = AES_BLOCK_SIZE;
+            if (remainder == 0) {
+                remainder = AES_BLOCK_SIZE;
+            }
+            if (remainder > 1) {
+                XMEMSET(cmac->buffer + AES_BLOCK_SIZE - remainder, 0, remainder);
+            }
+
+            cmac->buffer[AES_BLOCK_SIZE - remainder] = 0x80;
+            subKey = cmac->k2;
         }
-        if (remainder > 1) {
-            XMEMSET(cmac->buffer + AES_BLOCK_SIZE - remainder, 0, remainder);
+        xorbuf(cmac->buffer, cmac->digest, AES_BLOCK_SIZE);
+        xorbuf(cmac->buffer, subKey, AES_BLOCK_SIZE);
+        ret = wc_AesEncryptDirect(&cmac->aes, cmac->digest, cmac->buffer);
+        if (ret == 0) {
+            XMEMCPY(out, cmac->digest, *outSz);
         }
-
-        cmac->buffer[AES_BLOCK_SIZE - remainder] = 0x80;
-        subKey = cmac->k2;
-    }
-    xorbuf(cmac->buffer, cmac->digest, AES_BLOCK_SIZE);
-    xorbuf(cmac->buffer, subKey, AES_BLOCK_SIZE);
-    ret = wc_AesEncryptDirect(&cmac->aes, cmac->digest, cmac->buffer);
-    if (ret == 0) {
-        XMEMCPY(out, cmac->digest, *outSz);
+    }; break;
+#endif /* !NO_AES && WOLFSSL_AES_DIRECT */
+    default :
+        ret = BAD_FUNC_ARG;
     }
 
-    return 0;
+    return ret;
 }
 
 int wc_CmacFinal(Cmac* cmac, byte* out, word32* outSz) {
@@ -314,7 +353,7 @@ int wc_CmacFinal(Cmac* cmac, byte* out, word32* outSz) {
     return ret;
 }
 
-
+#if !defined(NO_AES) && defined(WOLFSSL_AES_DIRECT)
 int wc_AesCmacGenerate_ex(Cmac* cmac,
                           byte* out, word32* outSz,
                           const byte* in, word32 inSz,
@@ -334,8 +373,6 @@ int wc_AesCmacGenerate_ex(Cmac* cmac,
     if (devId != INVALID_DEVID)
     #endif
     {
-        cmac->devCtx = NULL;
-
         ret = wc_CryptoCb_Cmac(cmac, key, keySz, in, inSz, out, outSz,
                 WC_CMAC_AES, NULL);
         if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
@@ -498,5 +535,6 @@ int wc_AesCmacVerify(const byte* check, word32 checkSz,
 
     return ret;
 }
+#endif /* !NO_AES && WOLFSSL_AES_DIRECT */
 
-#endif /* WOLFSSL_CMAC && NO_AES && WOLFSSL_AES_DIRECT */
+#endif /* WOLFSSL_CMAC */

--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -144,7 +144,7 @@ static const char* GetHashTypeStr(int hash)
     return NULL;
 }
 
-#ifdef WOLFSSL_CMAC 
+#ifdef WOLFSSL_CMAC
 static const char* GetCmacTypeStr(int type)
 {
     switch (type) {

--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -85,6 +85,7 @@ static const char* GetAlgoTypeStr(int algo)
         case WC_ALGO_TYPE_RNG:    return "RNG";
         case WC_ALGO_TYPE_SEED:   return "Seed";
         case WC_ALGO_TYPE_HMAC:   return "HMAC";
+        case WC_ALGO_TYPE_CMAC:   return "CMAC";
     }
     return NULL;
 }
@@ -104,6 +105,7 @@ static const char* GetPkTypeStr(int pk)
     }
     return NULL;
 }
+#if !defined(NO_AES) || !defined(NO_DES3)
 static const char* GetCipherTypeStr(int cipher)
 {
     switch (cipher) {
@@ -119,6 +121,7 @@ static const char* GetCipherTypeStr(int cipher)
     }
     return NULL;
 }
+#endif /* !NO_AES || !NO_DES3 */
 static const char* GetHashTypeStr(int hash)
 {
     switch (hash) {
@@ -140,6 +143,16 @@ static const char* GetHashTypeStr(int hash)
     }
     return NULL;
 }
+
+#ifdef WOLFSSL_CMAC 
+static const char* GetCmacTypeStr(int type)
+{
+    switch (type) {
+        case WC_CMAC_AES: return "AES";
+    }
+    return NULL;
+}
+#endif  /* WOLFSSL_CMAC */
 
 #ifndef NO_RSA
 static const char* GetRsaType(int type)
@@ -186,12 +199,14 @@ WOLFSSL_API void wc_CryptoCb_InfoString(wc_CryptoInfo* info)
                 GetPkTypeStr(info->pk.type), info->pk.type);
         }
     }
+#if !defined(NO_AES) || !defined(NO_DES3)
     else if (info->algo_type == WC_ALGO_TYPE_CIPHER) {
         printf("Crypto CB: %s %s (%d) (%p ctx)\n",
             GetAlgoTypeStr(info->algo_type),
             GetCipherTypeStr(info->cipher.type),
             info->cipher.type, info->cipher.ctx);
     }
+#endif /* !NO_AES || !NO_DES3 */
     else if (info->algo_type == WC_ALGO_TYPE_HASH) {
         printf("Crypto CB: %s %s (%d) (%p ctx) %s\n",
             GetAlgoTypeStr(info->algo_type),
@@ -206,6 +221,17 @@ WOLFSSL_API void wc_CryptoCb_InfoString(wc_CryptoInfo* info)
             info->hmac.macType, info->hmac.hmac,
             (info->hmac.in != NULL) ? "Update" : "Final");
     }
+#ifdef WOLFSSL_CMAC
+    else if (info->algo_type == WC_ALGO_TYPE_CMAC) {
+        printf("Crypto CB: %s %s (%d) (%p ctx) %s %s %s\n",
+            GetAlgoTypeStr(info->algo_type),
+            GetCmacTypeStr(info->cmac.type),
+            info->cmac.type, info->cmac.cmac,
+            (info->cmac.key != NULL) ? "Init " : "",
+            (info->cmac.in != NULL) ? "Update " : "",
+            (info->cmac.out != NULL) ? "Final" : "");
+    }
+#endif
 #ifdef WOLF_CRYPTO_CB_CMD
     else if (info->algo_type == WC_ALGO_TYPE_NONE) {
         printf("Crypto CB: %s %s (%d)\n",
@@ -1775,7 +1801,8 @@ int wc_CryptoCb_RandomSeed(OS_Seed* os, byte* seed, word32 sz)
     return wc_CryptoCb_TranslateErrorCode(ret);
 }
 #endif /* !WC_NO_RNG */
-#ifdef WOLFSSL_CMAC
+
+#if defined(WOLFSSL_CMAC)
 int wc_CryptoCb_Cmac(Cmac* cmac, const byte* key, word32 keySz,
         const byte* in, word32 inSz, byte* out, word32* outSz, int type,
         void* ctx)
@@ -1791,7 +1818,6 @@ int wc_CryptoCb_Cmac(Cmac* cmac, const byte* key, word32 keySz,
         /* locate first callback and try using it */
         dev = wc_CryptoCb_FindDeviceByIndex(0);
     }
-
     if (dev && dev->cb) {
         wc_CryptoInfo cryptoInfo;
         XMEMSET(&cryptoInfo, 0, sizeof(cryptoInfo));
@@ -1812,7 +1838,7 @@ int wc_CryptoCb_Cmac(Cmac* cmac, const byte* key, word32 keySz,
 
     return wc_CryptoCb_TranslateErrorCode(ret);
 }
-#endif
+#endif /* WOLFSSL_CMAC && !NO_AES */
 
 /* returns the default dev id for the current build */
 int wc_CryptoCb_DefaultDevID(void)

--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -1838,7 +1838,7 @@ int wc_CryptoCb_Cmac(Cmac* cmac, const byte* key, word32 keySz,
 
     return wc_CryptoCb_TranslateErrorCode(ret);
 }
-#endif /* WOLFSSL_CMAC && !NO_AES */
+#endif /* WOLFSSL_CMAC */
 
 /* returns the default dev id for the current build */
 int wc_CryptoCb_DefaultDevID(void)

--- a/wolfssl/wolfcrypt/cmac.h
+++ b/wolfssl/wolfcrypt/cmac.h
@@ -24,9 +24,10 @@
 #define WOLF_CRYPT_CMAC_H
 
 #include <wolfssl/wolfcrypt/types.h>
-#include <wolfssl/wolfcrypt/aes.h>
 
-#if !defined(NO_AES) && defined(WOLFSSL_CMAC)
+#ifdef WOLFSSL_CMAC
+
+#include <wolfssl/wolfcrypt/aes.h>
 
 #if defined(HAVE_FIPS) && \
     defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)
@@ -40,16 +41,23 @@
 /* avoid redefinition of structs */
 #if !defined(HAVE_FIPS) || FIPS_VERSION3_GE(2,0,0)
 
+typedef enum CmacType {
+    WC_CMAC_AES = 1
+} CmacType;
+
 #ifndef WC_CMAC_TYPE_DEFINED
     typedef struct Cmac Cmac;
     #define WC_CMAC_TYPE_DEFINED
 #endif
 struct Cmac {
+    CmacType type;
+#ifndef NO_AES
     Aes aes;
     byte buffer[AES_BLOCK_SIZE]; /* partially stored block */
     byte digest[AES_BLOCK_SIZE]; /* running digest */
     byte k1[AES_BLOCK_SIZE];
     byte k2[AES_BLOCK_SIZE];
+#endif
     word32 bufferSz;
     word32 totalSz;
 #ifdef WOLF_CRYPTO_CB
@@ -74,12 +82,15 @@ struct Cmac {
 
 
 
-typedef enum CmacType {
-    WC_CMAC_AES = 1
-} CmacType;
 
+#ifndef NO_AES
 #define WC_CMAC_TAG_MAX_SZ AES_BLOCK_SIZE
 #define WC_CMAC_TAG_MIN_SZ (AES_BLOCK_SIZE/4)
+#else
+/* Reasonable defaults */
+#define WC_CMAC_TAG_MAX_SZ 16
+#define WC_CMAC_TAG_MIN_SZ 4
+#endif
 
 #if FIPS_VERSION3_GE(6,0,0)
     extern const unsigned int wolfCrypt_FIPS_cmac_ro_sanity[2];
@@ -111,6 +122,7 @@ int wc_CmacFinal(Cmac* cmac,
 WOLFSSL_API
 int wc_CmacFree(Cmac* cmac);
 
+#ifndef NO_AES
 WOLFSSL_API
 int wc_AesCmacGenerate(byte* out, word32* outSz,
                        const byte* in, word32 inSz,
@@ -134,9 +146,10 @@ int wc_AesCmacVerify_ex(Cmac* cmac,
                         const byte* key, word32 keySz,
                         void* heap,
                         int devId);
-
 WOLFSSL_LOCAL
 void ShiftAndXorRb(byte* out, byte* in);
+
+#endif /* !NO_AES */
 
 #ifdef WOLFSSL_HASH_KEEP
 WOLFSSL_API
@@ -148,6 +161,6 @@ int wc_CMAC_Grow(Cmac* cmac, const byte* in, int inSz);
 #endif
 
 
-#endif /* NO_AES && WOLFSSL_CMAC */
+#endif /* WOLFSSL_CMAC */
 #endif /* WOLF_CRYPT_CMAC_H */
 

--- a/wolfssl/wolfcrypt/cmac.h
+++ b/wolfssl/wolfcrypt/cmac.h
@@ -52,7 +52,6 @@ typedef enum CmacType {
     #define WC_CMAC_TYPE_DEFINED
 #endif
 struct Cmac {
-    CmacType type;
 #ifndef NO_AES
     Aes aes;
     byte buffer[AES_BLOCK_SIZE]; /* partially stored block */
@@ -80,6 +79,7 @@ struct Cmac {
 #ifdef WOLFSSL_SE050
     byte   useSWCrypt; /* Use SW crypt instead of SE050, before SCP03 auth */
 #endif
+    CmacType type;
 };
 
 

--- a/wolfssl/wolfcrypt/cmac.h
+++ b/wolfssl/wolfcrypt/cmac.h
@@ -27,7 +27,9 @@
 
 #ifdef WOLFSSL_CMAC
 
+#ifndef NO_AES
 #include <wolfssl/wolfcrypt/aes.h>
+#endif
 
 #if defined(HAVE_FIPS) && \
     defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)


### PR DESCRIPTION
# Description

This provides a few cryptocb and CMAC updates:
1. Correct cryptocb debug prints to correctly handle when NO_AES is defined
2. Correct cryptocb CMAC update to NOT set devCtx to NULL
3. Update CMAC to correctly support NO_AES and allow alternate crypto types
4. Update internal usage to ensure NO_AES and WOLFSSL_CMAC are independent

Note that for proper functionality with AES CMAC, the defines WOLFSSL_CMAC, WOLFSSL_AES_DIRECT must be set, while NO_AES cannot be set.  This matches current functionality.

# Testing
1. Numerous configurations with and without NO_AES using wolfHSM
2. testwolfcrypt with --enable-all
3. commit-tests.sh

# Checklist

 - [ N/A ] added tests
 - [ N/A ] updated/added doxygen
 - [ N/A ] updated appropriate READMEs
 - [ N/A ] Updated manual and documentation
