### PR TITLE
Fix '--depth=1' repos

### DIFF
--- a/fips-check.sh
+++ b/fips-check.sh
@@ -334,6 +334,9 @@ function copy_fips_files() {
     done
 }
 
+# Check to make sure this is not a shallow repo
+$GIT fetch --unshallow 2>/dev/null
+
 if ! $GIT clone . "$TEST_DIR"; then
     echo "fips-check: Couldn't duplicate current working directory."
     exit 1


### PR DESCRIPTION
When the repo was checked out as a shallow copy, we need to unshallow so FIPS builds can successfully find all the required tags and branches.