### PR TITLE
dtls13: support either side DTLSv1_3 method

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -15606,6 +15606,26 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
         return m;
     }
     #endif /* !WOLFSSL_NO_TLS12 */
+    #ifdef WOLFSSL_DTLS13
+    WOLFSSL_METHOD* wolfDTLSv1_3_method(void)
+    {
+        return wolfDTLSv1_3_method_ex(NULL);
+    }
+    WOLFSSL_METHOD* wolfDTLSv1_3_method_ex(void* heap)
+    {
+        WOLFSSL_METHOD* m;
+        WOLFSSL_ENTER("DTLSv1_3_method");
+    #ifndef NO_WOLFSSL_CLIENT
+        m = wolfDTLSv1_3_client_method_ex(heap);
+    #else
+        m = wolfDTLSv1_3_server_method_ex(heap);
+    #endif
+        if (m != NULL) {
+            m->side = WOLFSSL_NEITHER_END;
+        }
+        return m;
+    }
+    #endif /* WOLFSSL_DTLS13 */
 #endif /* WOLFSSL_DTLS */
 #endif /* OPENSSL_EXTRA || WOLFSSL_EITHER_SIDE */
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -1194,6 +1194,9 @@ static int test_wolfSSL_Method_Allocators(void)
         #ifndef WOLFSSL_NO_TLS12
             TEST_VALID_METHOD_ALLOCATOR(wolfDTLSv1_2_method);
         #endif /* !WOLFSSL_NO_TLS12 */
+        #ifdef WOLFSSL_DTLS13
+            TEST_VALID_METHOD_ALLOCATOR(wolfDTLSv1_3_method);
+        #endif /* WOLFSSL_DTLS13 */
     #endif /* WOLFSSL_DTLS */
 #endif /* OPENSSL_EXTRA || WOLFSSL_EITHER_SIDE */
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -977,6 +977,10 @@ WOLFSSL_API WOLFSSL_METHOD *wolfSSLv23_method(void);
     WOLFSSL_API WOLFSSL_METHOD *wolfDTLSv1_3_server_method_ex(void* heap);
     WOLFSSL_API WOLFSSL_METHOD *wolfDTLSv1_3_server_method(void);
 #endif
+#if defined(WOLFSSL_EITHER_SIDE) || defined(OPENSSL_EXTRA)
+    WOLFSSL_API WOLFSSL_METHOD *wolfDTLSv1_3_method_ex(void* heap);
+    WOLFSSL_API WOLFSSL_METHOD *wolfDTLSv1_3_method(void);
+#endif
     WOLFSSL_API int wolfSSL_dtls13_has_pending_msg(WOLFSSL *ssl);
 #endif /* WOLFSSL_DTLS13 */
 


### PR DESCRIPTION
# Description

This adds a missing, version-specific method that supports either end for DTLSv1.3

Reported in #7898 