### PR TITLE
LMS: SHA-256/192 parameters

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1545,6 +1545,12 @@ do
   small)
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_WC_LMS_SMALL"
     ;;
+  no-sha256-256)
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_NO_LMS_SHA256_256"
+    ;;
+  sha256-192)
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_LMS_SHA256_192"
+    ;;
   *)
     AC_MSG_ERROR([Invalid choice for LMS []: $ENABLED_LMS.])
     break;;

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1692,7 +1692,8 @@ static const char* bench_result_words3[][5] = {
     defined(HAVE_CURVE448) || defined(HAVE_ED448) || \
     defined(HAVE_ECC) || !defined(NO_DH) || \
     !defined(NO_RSA) || defined(HAVE_SCRYPT) || \
-    defined(WOLFSSL_HAVE_KYBER) || defined(HAVE_DILITHIUM)
+    defined(WOLFSSL_HAVE_KYBER) || defined(HAVE_DILITHIUM) || \
+    defined(WOLFSSL_HAVE_LMS)
     #define BENCH_ASYM
 #endif
 
@@ -1700,7 +1701,8 @@ static const char* bench_result_words3[][5] = {
 #if defined(HAVE_ECC) || !defined(NO_RSA) || !defined(NO_DH) || \
     defined(HAVE_CURVE25519) || defined(HAVE_ED25519) || \
     defined(HAVE_CURVE448) || defined(HAVE_ED448) || \
-    defined(WOLFSSL_HAVE_KYBER) || defined(HAVE_DILITHIUM)
+    defined(WOLFSSL_HAVE_KYBER) || defined(HAVE_DILITHIUM) || \
+    defined(WOLFSSL_HAVE_LMS)
 static const char* bench_result_words2[][5] = {
 #ifdef BENCH_MICROSECOND
     { "ops took", "μsec"     , "avg" , "ops/μsec", NULL },   /* 0 English
@@ -2656,7 +2658,8 @@ static void bench_stats_sym_finish(const char* desc, int useDeviceID,
 #if defined(HAVE_ECC) || !defined(NO_RSA) || !defined(NO_DH) || \
     defined(HAVE_CURVE25519) || defined(HAVE_ED25519) || \
     defined(HAVE_CURVE448) || defined(HAVE_ED448) || \
-    defined(WOLFSSL_HAVE_KYBER) || defined(HAVE_DILITHIUM)
+    defined(WOLFSSL_HAVE_KYBER) || defined(HAVE_DILITHIUM) || \
+    defined(WOLFSSL_HAVE_LMS)
 static void bench_stats_asym_finish_ex(const char* algo, int strength,
     const char* desc, const char* desc_extra, int useDeviceID, int count,
     double start, int ret)
@@ -9442,6 +9445,7 @@ void bench_kyber(int type)
 #endif
 
 #if defined(WOLFSSL_HAVE_LMS) && !defined(WOLFSSL_LMS_VERIFY_ONLY)
+#ifndef WOLFSSL_NO_LMS_SHA256_256
 /* WC_LMS_PARM_L2_H10_W2
  * signature length: 9300 */
 static const byte lms_priv_L2_H10_W2[64] =
@@ -9597,6 +9601,7 @@ static const byte lms_pub_L4_H5_W8[60] =
     0x85,0x1A,0x7A,0xD8,0xD5,0x46,0x74,0x3B,
     0x74,0x24,0x12,0xC8
 };
+#endif
 
 static int lms_write_key_mem(const byte* priv, word32 privSz, void* context)
 {
@@ -9757,6 +9762,7 @@ static void bench_lms_sign_verify(enum wc_LmsParm parm, byte* pub)
     }
 
     switch (parm) {
+#ifndef WOLFSSL_NO_LMS_SHA256_256
     case WC_LMS_PARM_L2_H10_W2:
         XMEMCPY(lms_priv, lms_priv_L2_H10_W2, sizeof(lms_priv_L2_H10_W2));
         XMEMCPY(key.pub, lms_pub_L2_H10_W2, HSS_MAX_PUBLIC_KEY_LEN);
@@ -9817,6 +9823,28 @@ static void bench_lms_sign_verify(enum wc_LmsParm parm, byte* pub)
     case WC_LMS_PARM_L4_H5_W4:
     case WC_LMS_PARM_L4_H10_W4:
     case WC_LMS_PARM_L4_H10_W8:
+#endif
+
+#ifdef WOLFSSL_LMS_SHA256_192
+    case WC_LMS_PARM_SHA256_192_L1_H5_W1:
+    case WC_LMS_PARM_SHA256_192_L1_H5_W2:
+    case WC_LMS_PARM_SHA256_192_L1_H5_W4:
+    case WC_LMS_PARM_SHA256_192_L1_H5_W8:
+    case WC_LMS_PARM_SHA256_192_L1_H10_W2:
+    case WC_LMS_PARM_SHA256_192_L1_H10_W4:
+    case WC_LMS_PARM_SHA256_192_L1_H10_W8:
+    case WC_LMS_PARM_SHA256_192_L1_H15_W2:
+    case WC_LMS_PARM_SHA256_192_L1_H15_W4:
+    case WC_LMS_PARM_SHA256_192_L2_H10_W2:
+    case WC_LMS_PARM_SHA256_192_L2_H10_W4:
+    case WC_LMS_PARM_SHA256_192_L2_H10_W8:
+    case WC_LMS_PARM_SHA256_192_L3_H5_W2:
+    case WC_LMS_PARM_SHA256_192_L3_H5_W4:
+    case WC_LMS_PARM_SHA256_192_L3_H5_W8:
+    case WC_LMS_PARM_SHA256_192_L3_H10_W4:
+    case WC_LMS_PARM_SHA256_192_L4_H5_W8:
+#endif
+
     default:
         XMEMCPY(key.pub, pub, HSS_MAX_PUBLIC_KEY_LEN);
         break;
@@ -9991,6 +10019,7 @@ void bench_lms(void)
 {
     byte pub[HSS_MAX_PUBLIC_KEY_LEN];
 
+#ifndef WOLFSSL_NO_LMS_SHA256_256
 #ifdef BENCH_LMS_SLOW_KEYGEN
 #if !defined(WOLFSSL_WC_LMS) || (LMS_MAX_HEIGHT >= 15)
     bench_lms_keygen(WC_LMS_PARM_L1_H15_W2, pub);
@@ -10036,6 +10065,55 @@ void bench_lms(void)
     bench_lms_keygen(WC_LMS_PARM_L1_H5_W1, pub);
     bench_lms_sign_verify(WC_LMS_PARM_L1_H5_W1, pub);
 #endif
+#endif /* !WOLFSSL_NO_LMS_SHA256_256 */
+
+#ifdef WOLFSSL_LMS_SHA256_192
+#ifdef BENCH_LMS_SLOW_KEYGEN
+#if !defined(WOLFSSL_WC_LMS) || (LMS_MAX_HEIGHT >= 15)
+    bench_lms_keygen(WC_LMS_PARM_SHA256_192_L1_H15_W2, pub);
+    bench_lms_sign_verify(WC_LMS_PARM_SHA256_192_L1_H15_W2, pub);
+    bench_lms_keygen(WC_LMS_PARM_SHA256_192_L1_H15_W4, pub);
+    bench_lms_sign_verify(WC_LMS_PARM_SHA256_192_L1_H15_W4, pub);
+    #undef LMS_PARAMS_BENCHED
+    #define LMS_PARAMS_BENCHED
+#endif
+#endif
+#if !defined(WOLFSSL_WC_LMS) || ((LMS_MAX_LEVELS >= 2) && \
+        (LMS_MAX_HEIGHT >= 10))
+    bench_lms_keygen(WC_LMS_PARM_SHA256_192_L2_H10_W2, pub);
+    bench_lms_sign_verify(WC_LMS_PARM_SHA256_192_L2_H10_W2, pub);
+    bench_lms_keygen(WC_LMS_PARM_SHA256_192_L2_H10_W4, pub);
+    bench_lms_sign_verify(WC_LMS_PARM_SHA256_192_L2_H10_W4, pub);
+    #undef LMS_PARAMS_BENCHED
+    #define LMS_PARAMS_BENCHED
+#ifdef BENCH_LMS_SLOW_KEYGEN
+    bench_lms_keygen(WC_LMS_PARM_SHA256_192_L2_H10_W8, pub);
+    bench_lms_sign_verify(WC_LMS_PARM_SHA256_192_L2_H10_W8, pub);
+#endif
+#endif
+#if !defined(WOLFSSL_WC_LMS) || (LMS_MAX_LEVELS >= 3)
+    bench_lms_keygen(WC_LMS_PARM_SHA256_192_L3_H5_W4, pub);
+    bench_lms_sign_verify(WC_LMS_PARM_SHA256_192_L3_H5_W4, pub);
+    bench_lms_keygen(WC_LMS_PARM_SHA256_192_L3_H5_W8, pub);
+    bench_lms_sign_verify(WC_LMS_PARM_SHA256_192_L3_H5_W8, pub);
+    #undef LMS_PARAMS_BENCHED
+    #define LMS_PARAMS_BENCHED
+#endif
+#if !defined(WOLFSSL_WC_LMS) || ((LMS_MAX_LEVELS >= 3) && \
+        (LMS_MAX_HEIGHT >= 10))
+    bench_lms_keygen(WC_LMS_PARM_SHA256_192_L3_H10_W4, pub);
+    bench_lms_sign_verify(WC_LMS_PARM_SHA256_192_L3_H10_W4, pub);
+#endif
+#if !defined(WOLFSSL_WC_LMS) || (LMS_MAX_LEVELS >= 4)
+    bench_lms_keygen(WC_LMS_PARM_SHA256_192_L4_H5_W8, pub);
+    bench_lms_sign_verify(WC_LMS_PARM_SHA256_192_L4_H5_W8, pub);
+#endif
+
+#if defined(WOLFSSL_WC_LMS) && !defined(LMS_PARAMS_BENCHED)
+    bench_lms_keygen(WC_LMS_PARM_SHA256_192_L1_H5_W1, pub);
+    bench_lms_sign_verify(WC_LMS_PARM_SHA256_192_L1_H5_W1, pub);
+#endif
+#endif /* WOLFSSL_LMS_SHA256_192 */
 
     return;
 }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -656,8 +656,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t scrypt_test(void);
 #endif
 #if defined(WOLFSSL_HAVE_LMS)
     #if !defined(WOLFSSL_SMALL_STACK)
-        #if (defined(WOLFSSL_WC_LMS) && (LMS_MAX_HEIGHT >= 10)) || \
-             defined(HAVE_LIBLMS)
+        #if (defined(WOLFSSL_WC_LMS) && (LMS_MAX_HEIGHT >= 10) && \
+             !defined(WOLFSSL_NO_LMS_SHA256_256)) || defined(HAVE_LIBLMS)
     WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  lms_test_verify_only(void);
         #endif
     #endif
@@ -2192,8 +2192,8 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 
 #if defined(WOLFSSL_HAVE_LMS)
     #if !defined(WOLFSSL_SMALL_STACK)
-        #if (defined(WOLFSSL_WC_LMS) && (LMS_MAX_HEIGHT >= 10)) || \
-             defined(HAVE_LIBLMS)
+        #if (defined(WOLFSSL_WC_LMS) && (LMS_MAX_HEIGHT >= 10) && \
+             !defined(WOLFSSL_NO_LMS_SHA256_256)) || defined(HAVE_LIBLMS)
     if ( (ret = lms_test_verify_only()) != 0)
         TEST_FAIL("LMS Vfy  test failed!\n", ret);
     else
@@ -45960,7 +45960,11 @@ static int lms_read_key_mem(byte * priv, word32 privSz, void *context)
 
 /* LMS signature sizes are a function of their parameters. This
  * test has a signature of 8688 bytes. */
+#ifndef WOLFSSL_NO_LMS_SHA256_256
 #define WC_TEST_LMS_SIG_LEN (8688)
+#else
+#define WC_TEST_LMS_SIG_LEN (4984)
+#endif
 
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t lms_test(void)
 {
@@ -46103,8 +46107,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t lms_test(void)
 #endif /* if defined(WOLFSSL_HAVE_LMS) && !defined(WOLFSSL_LMS_VERIFY_ONLY) */
 
 #if defined(WOLFSSL_HAVE_LMS) && !defined(WOLFSSL_SMALL_STACK)
-#if (defined(WOLFSSL_WC_LMS) && (LMS_MAX_HEIGHT >= 10)) || \
-             defined(HAVE_LIBLMS)
+#if (defined(WOLFSSL_WC_LMS) && (LMS_MAX_HEIGHT >= 10) && \
+     !defined(WOLFSSL_NO_LMS_SHA256_256)) || defined(HAVE_LIBLMS)
 
 /* A simple LMS verify only test.
  *

--- a/wolfssl/wolfcrypt/lms.h
+++ b/wolfssl/wolfcrypt/lms.h
@@ -78,6 +78,7 @@ enum wc_LmsRc {
  * Not predefining many sets with Winternitz=1, because the signatures
  * will be large. */
 enum wc_LmsParm {
+#ifndef WOLFSSL_NO_LMS_SHA256_256
     WC_LMS_PARM_NONE = 0,
     WC_LMS_PARM_L1_H5_W1 = 1,
     WC_LMS_PARM_L1_H5_W2 = 2,
@@ -114,6 +115,27 @@ enum wc_LmsParm {
     WC_LMS_PARM_L4_H5_W8 = 33,
     WC_LMS_PARM_L4_H10_W4 = 34,
     WC_LMS_PARM_L4_H10_W8 = 35,
+#endif
+
+#ifdef WOLFSSL_LMS_SHA256_192
+    WC_LMS_PARM_SHA256_192_L1_H5_W1  = 36,
+    WC_LMS_PARM_SHA256_192_L1_H5_W2  = 37,
+    WC_LMS_PARM_SHA256_192_L1_H5_W4  = 38,
+    WC_LMS_PARM_SHA256_192_L1_H5_W8  = 39,
+    WC_LMS_PARM_SHA256_192_L1_H10_W2 = 40,
+    WC_LMS_PARM_SHA256_192_L1_H10_W4 = 41,
+    WC_LMS_PARM_SHA256_192_L1_H10_W8 = 42,
+    WC_LMS_PARM_SHA256_192_L1_H15_W2 = 43,
+    WC_LMS_PARM_SHA256_192_L1_H15_W4 = 44,
+    WC_LMS_PARM_SHA256_192_L2_H10_W2 = 45,
+    WC_LMS_PARM_SHA256_192_L2_H10_W4 = 46,
+    WC_LMS_PARM_SHA256_192_L2_H10_W8 = 47,
+    WC_LMS_PARM_SHA256_192_L3_H5_W2  = 48,
+    WC_LMS_PARM_SHA256_192_L3_H5_W4  = 49,
+    WC_LMS_PARM_SHA256_192_L3_H5_W8  = 50,
+    WC_LMS_PARM_SHA256_192_L3_H10_W4 = 51,
+    WC_LMS_PARM_SHA256_192_L4_H5_W8  = 52,
+#endif
 };
 
 /* enum wc_LmsState is to help track the state of an LMS/HSS Key. */


### PR DESCRIPTION
# Description

Add support for parameter sets with SHA-256/192.

# Testing

Regression tested LMS.
--enable-lms=sha256-192
--enable-lms=sha256-192,no-sha256-256

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
