### PR TITLE
gate test mp_read_radix on OPENSSL_EXTRA or !NO_DSA or HAVE_ECC

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -55026,6 +55026,7 @@ static wc_test_ret_t mp_test_cmp(mp_int* a, mp_int* b)
     if (ret != MP_GT)
         return WC_TEST_RET_ENC_NC;
 
+#if defined(OPENSSL_EXTRA) || !defined(NO_DSA) || defined(HAVE_ECC)
     mp_read_radix(b, "1234567890123456789", MP_RADIX_HEX);
     ret = mp_cmp_d(b, -1);
     if (ret != MP_GT)
@@ -55040,9 +55041,12 @@ static wc_test_ret_t mp_test_cmp(mp_int* a, mp_int* b)
     ret = mp_cmp(b, b);
     if (ret != MP_EQ)
         return WC_TEST_RET_ENC_NC;
+#endif
 
 #if (!defined(WOLFSSL_SP_MATH) && !defined(WOLFSSL_SP_MATH_ALL)) || \
     defined(WOLFSSL_SP_INT_NEGATIVE)
+
+#if defined(OPENSSL_EXTRA) || !defined(NO_DSA) || defined(HAVE_ECC)
     mp_read_radix(a, "-1", MP_RADIX_HEX);
     mp_read_radix(a, "1", MP_RADIX_HEX);
     ret = mp_cmp(a, b);
@@ -55059,11 +55063,14 @@ static wc_test_ret_t mp_test_cmp(mp_int* a, mp_int* b)
     ret = mp_cmp(b, a);
     if (ret != MP_LT)
         return WC_TEST_RET_ENC_NC;
+#endif
 
+#if defined(OPENSSL_EXTRA) || !defined(NO_DSA) || defined(HAVE_ECC)
     mp_read_radix(a, "-2", MP_RADIX_HEX);
     ret = mp_cmp(a, b);
     if (ret != MP_EQ)
         return WC_TEST_RET_ENC_NC;
+#endif
 #endif
 
 #if defined(HAVE_ECC) && !defined(WC_NO_RNG) && \
@@ -55824,10 +55831,14 @@ static wc_test_ret_t mp_test_invmod(mp_int* a, mp_int* m, mp_int* r)
 #endif
 
 #if !defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_INT_NEGATIVE)
+
+#if defined(OPENSSL_EXTRA) || !defined(NO_DSA) || defined(HAVE_ECC)
     mp_read_radix(a, "-3", 16);
     ret = mp_invmod(a, m, r);
     if (ret != MP_OKAY)
         return WC_TEST_RET_ENC_EC(ret);
+#endif
+
 #endif
 
 #if defined(WOLFSSL_SP_MATH_ALL) && defined(HAVE_ECC)


### PR DESCRIPTION
# Description


TFM [conditionally defines](https://github.com/wolfSSL/wolfssl/blob/72711b4e15f68a49968c8ed674d95852ebc9d744/wolfssl/wolfcrypt/tfm.h#L873) `mp_read_radix`:

```
#if defined(OPENSSL_EXTRA) || !defined(NO_DSA) || defined(HAVE_ECC)
    MP_API int mp_read_radix(mp_int* a, const char* str, int radix);
#endif
```

In a `user_settings.h` file, I have `NO_DSA` defined, no `OPENSSL_EXTRA` and no `HAVE_ECC`.

While compiling for the ESP8266, I see this error:

```
test.c
/mnt/c/workspace/wolfssl-gojimmypi/wolfcrypt/test/test.c: In function 'mp_test_cmp':
/mnt/c/workspace/wolfssl-gojimmypi/wolfcrypt/test/test.c:55029:5: error: implicit declaration of function 'mp_read_radix'; did you mean 'mp_toradix'? [-Werror=implicit-function-declaration]
     mp_read_radix(b, "1234567890123456789", MP_RADIX_HEX);
     ^~~~~~~~~~~~~
     mp_toradix
cc1: some warnings being treated as errors
ninja: build stopped: subcommand failed.
ninja failed with exit code 1
```

This PR gates the `mp_read_radix` in the wolfcrypt test on the same criteria as the API in `tfm.h`.

Fixes zd#

# Testing

How did you test?

Tested only in Espressif envrionment. 

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
