### PR TITLE
misc cleanup: extra spaces, typos.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -10197,7 +10197,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
             WOLFSSL_LEAVE("wolfSSL_accept", WOLFSSL_SUCCESS);
             return WOLFSSL_SUCCESS;
 
-        default :
+        default:
             WOLFSSL_MSG("Unknown accept state ERROR");
             return WOLFSSL_FATAL_ERROR;
         }

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -14490,7 +14490,7 @@ int wolfSSL_accept_TLSv13(WOLFSSL* ssl)
             WOLFSSL_LEAVE("wolfSSL_accept", WOLFSSL_SUCCESS);
             return WOLFSSL_SUCCESS;
 
-        default :
+        default:
             WOLFSSL_MSG("Unknown accept state ERROR");
             return WOLFSSL_FATAL_ERROR;
     }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -29284,7 +29284,7 @@ static wc_test_ret_t ecdsa_test_deterministic_k_sig(ecc_key *key,
         goto done;
     }
 
-    /* Verificiation */
+    /* Verification */
     verify = 0;
     do {
     #if defined(WOLFSSL_ASYNC_CRYPT)
@@ -29451,7 +29451,7 @@ static wc_test_ret_t ecdsa_test_deterministic_k_rs(ecc_key *key,
         ERROR_OUT(WC_TEST_RET_ENC_NC, done);
     }
 
-    /* Verificiation */
+    /* Verification */
     verify = 0;
     ret = wc_ecc_verify_hash_ex(r, s, hash, wc_HashGetDigestSize(hashType),
         &verify, key);

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -515,7 +515,7 @@
      * in the Kconfig file. At cmake time, the Kconfig is processed and an
      * sdkconfig.h file is created by the ESP-IDF. Any configured options are
      * named CONFIG_[Kconfig name] and thus CONFIG_[macro name]. Those that
-     * are expected to be ESP-IDF specific and may be ambigous can named
+     * are expected to be ESP-IDF specific and may be ambiguous can named
      * with an ESP prefix, for example CONFIG_[ESP_(Kconfig name)]
      *
      * Note there are some inconsistent macro names that may have been
@@ -582,7 +582,7 @@
     #endif
 
     #if defined(CONFIG_TLS_STACK_WOLFSSL) && (CONFIG_TLS_STACK_WOLFSSL)
-        /* When using ESP-TLS, some old algoritms such as SHA1 are no longer
+        /* When using ESP-TLS, some old algorithms such as SHA1 are no longer
          * enabled in wolfSSL, except for the OpenSSL compatibility. So enable
          * that here: */
         #define OPENSSL_EXTRA
@@ -4035,7 +4035,7 @@ extern void uITRON4_free(void *p) ;
 
 #if defined(CONFIG_WOLFSSL_NO_ASN_STRICT) && !defined(WOLFSSL_NO_ASN_STRICT)
     /* The settings.h and/or user_settings.h should have detected config
-     * valuse from Kconfig and set the appropriate wolfSSL macro: */
+     * values from Kconfig and set the appropriate wolfSSL macro: */
     #error "CONFIG_WOLFSSL_NO_ASN_STRICT found without WOLFSSL_NO_ASN_STRICT"
 #endif
 

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -450,7 +450,7 @@ WOLFSSL_LOCAL void wolfSSL_RefDec(wolfSSL_Ref* ref, int* isZero, int* err);
 
 #if defined(WOLFSSL_ALGO_HW_MUTEX) && (defined(NO_RNG_MUTEX) && \
         defined(NO_AES_MUTEX) && defined(NO_HASH_MUTEX) && defined(NO_PK_MUTEX))
-        #error WOLFSSL_ALGO_HW_MUTEX does not support having all mutexs off
+        #error WOLFSSL_ALGO_HW_MUTEX does not support having all mutexes off
 #endif
 /* To support HW that can do different Crypto in parallel */
 #if WOLFSSL_CRYPT_HW_MUTEX && defined(WOLFSSL_ALGO_HW_MUTEX)

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -520,7 +520,7 @@ WOLFSSL_API  int wolfIO_RecvFrom(SOCKET_T sd, WOLFSSL_BIO_ADDR *addr, char *buf,
 #endif
 #endif /* WOLFSSL_NO_SOCK */
 
-/* Preseve API previously exposed */
+/* Preserve API previously exposed */
 WOLFSSL_API int BioSend(WOLFSSL* ssl, char *buf, int sz, void *ctx);
 WOLFSSL_API int BioReceive(WOLFSSL* ssl, char* buf, int sz, void* ctx);
 


### PR DESCRIPTION
# Description

- Remove extra spaces
- Fix typos


# Testing

```
$grep -r "default :" * --include=*.{c,h}
src/ssl.c:        default :
src/tls13.c:        default :
```

```
$codespell wolfssl/
...bunch of output...
```

```
$codespell wolfcrypt/
...bunch of output...
```