### PR TITLE
20240927-fixes2

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -4759,7 +4759,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
 
 #ifdef WC_C_DYNAMIC_FALLBACK
 
-#define VECTOR_REGISTERS_PUSH { \
+#define VECTOR_REGISTERS_PUSH {                                      \
         int orig_use_aesni = aes->use_aesni;                         \
         if (aes->use_aesni && (SAVE_VECTOR_REGISTERS2() != 0)) {     \
             aes->use_aesni = 0;                                      \
@@ -4771,6 +4771,15 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
             RESTORE_VECTOR_REGISTERS();                              \
         else                                                         \
             aes->use_aesni = orig_use_aesni;                         \
+    }                                                                \
+    WC_DO_NOTHING
+
+#elif defined(SAVE_VECTOR_REGISTERS2_DOES_NOTHING)
+
+#define VECTOR_REGISTERS_PUSH { \
+        WC_DO_NOTHING
+
+#define VECTOR_REGISTERS_POP                                         \
     }                                                                \
     WC_DO_NOTHING
 
@@ -9796,7 +9805,7 @@ static WARN_UNUSED_RESULT int AesGcmDecryptUpdate_aesni(
     ASSERT_SAVED_VECTOR_REGISTERS();
 
     /* Hash in A, the Authentication Data */
-    ret = AesGcmAadUpdate_aesni(aes, a, aSz, (cSz > 0) && (c != NULL));
+    ret = AesGcmAadUpdate_aesni(aes, a, aSz, cSz > 0);
     if (ret != 0)
         return ret;
 

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -211,6 +211,52 @@ WC_MISC_STATIC WC_INLINE void ByteReverseWords(word32* out, const word32* in,
 
 #if defined(WORD64_AVAILABLE) && !defined(WOLFSSL_NO_WORD64_OPS)
 
+WC_MISC_STATIC WC_INLINE word64 readUnalignedWord64(const byte *in)
+{
+    if (((wc_ptr_t)in & (wc_ptr_t)(sizeof(word64) - 1U)) == (wc_ptr_t)0)
+        return *(word64 *)in;
+    else {
+        word64 out;
+        XMEMCPY(&out, in, sizeof(word64));
+        return out;
+    }
+}
+
+WC_MISC_STATIC WC_INLINE word64 writeUnalignedWord64(void *out, word64 in)
+{
+    if (((wc_ptr_t)out & (wc_ptr_t)(sizeof(word64) - 1U)) == (wc_ptr_t)0)
+        *(word64 *)out = in;
+    else {
+        XMEMCPY(out, &in, sizeof(word64));
+    }
+    return in;
+}
+
+WC_MISC_STATIC WC_INLINE void readUnalignedWords64(word64 *out, const byte *in,
+                                                   size_t count)
+{
+    if (((wc_ptr_t)in & (wc_ptr_t)(sizeof(word64) - 1U)) == (wc_ptr_t)0) {
+        const word64 *in_word64 = (const word64 *)in;
+        while (count-- > 0)
+            *out++ = *in_word64++;
+    }
+    else {
+        XMEMCPY(out, in, count * sizeof(word64));
+    }
+}
+
+WC_MISC_STATIC WC_INLINE void writeUnalignedWords64(byte *out, const word64 *in,
+                                                    size_t count)
+{
+    if (((wc_ptr_t)out & (wc_ptr_t)(sizeof(word64) - 1U)) == (wc_ptr_t)0) {
+        word64 *out_word64 = (word64 *)out;
+        while (count-- > 0)
+            *out_word64++ = *in++;
+    }
+    else {
+        XMEMCPY(out, in, count * sizeof(word64));
+    }
+}
 
 WC_MISC_STATIC WC_INLINE word64 rotlFixed64(word64 x, word64 y)
 {

--- a/wolfssl/wolfcrypt/misc.h
+++ b/wolfssl/wolfcrypt/misc.h
@@ -76,6 +76,14 @@ int ConstantCompare(const byte* a, const byte* b, int length);
 
 #ifdef WORD64_AVAILABLE
 WOLFSSL_LOCAL
+word64 readUnalignedWord64(const byte *in);
+WOLFSSL_LOCAL
+word64 writeUnalignedWord64(void *out, word64 in);
+WOLFSSL_LOCAL
+void readUnalignedWords64(word64 *out, const byte *in, size_t count);
+WOLFSSL_LOCAL
+void writeUnalignedWords64(byte *out, const word64 *in, size_t count);
+WOLFSSL_LOCAL
 word64 rotlFixed64(word64 x, word64 y);
 WOLFSSL_LOCAL
 word64 rotrFixed64(word64 x, word64 y);

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1729,9 +1729,11 @@ typedef struct w64wrapper {
     #endif
     #ifndef SAVE_VECTOR_REGISTERS2
         #define SAVE_VECTOR_REGISTERS2() 0
+        #define SAVE_VECTOR_REGISTERS2_DOES_NOTHING
     #endif
     #ifndef CAN_SAVE_VECTOR_REGISTERS
         #define CAN_SAVE_VECTOR_REGISTERS() 1
+        #define CAN_SAVE_VECTOR_REGISTERS_ALWAYS_TRUE
     #endif
     #ifndef WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL
         #define WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(x) WC_DO_NOTHING


### PR DESCRIPTION
`wolfssl/wolfcrypt/types.h`: when defining fallback do-nothing `SAVE_VECTOR_REGISTERS2()`, also define `SAVE_VECTOR_REGISTERS2_DOES_NOTHING`, and likewise for fallback `CAN_SAVE_VECTOR_REGISTERS`, define `CAN_SAVE_VECTOR_REGISTERS_ALWAYS_TRUE`;

`wolfcrypt/src/aes.c`:
* when `SAVE_VECTOR_REGISTERS2_DOES_NOTHING`, define do-nothing `VECTOR_REGISTERS_PUSH` and `VECTOR_REGISTERS_POP`, to mollify Coverity `CONSTANT_EXPRESSION_RESULT`;
* in `AesGcmDecryptUpdate_aesni()`, omit ` && (c != NULL)` clause from computation of `endA` argument to `AesGcmAadUpdate_aesni()`, to mollify Coverity `FORWARD_NULL` (impermissible nullness is already checked and `BAD_FUNC_ARG`ed by the sole caller, `wc_AesGcmDecryptUpdate()`);

`wolfcrypt/src/misc.c`: add `readUnalignedWord64()`, `writeUnalignedWord64()`, `readUnalignedWords64()`, and `writeUnalignedWords64()`, for safe `word64` access to possibly-unaligned data;

`wolfcrypt/src/wc_kyber_poly.c`: use `readUnalignedWords64()` and `readUnalignedWord64()` to mitigate sanitizer-reported "load of misaligned address".

tested with `wolfssl-multi-test.sh ... super-quick-check quantum-safe-wolfssl-all-cross-aarch64-armasm-unittest-sanitizer quantum-safe-wolfssl-all-noasm-sanitizer quantum-safe-wolfssl-all-noasm-noinline-sanitizer quantum-safe-wolfssl-all-intelasm-sp-asm-valgrind`
