### PR TITLE
Kyber original: fix to work

### DIFF
--- a/wolfcrypt/src/wc_kyber.c
+++ b/wolfcrypt/src/wc_kyber.c
@@ -630,7 +630,11 @@ int wc_KyberKey_EncapsulateWithRandom(KyberKey* key, unsigned char* ct,
 
     if (ret == 0) {
         /* Encapsulate the message using the key and the seed (coins). */
+#ifdef WOLFSSL_KYBER_ORIGINAL
+        ret = kyberkey_encapsulate(key, msg, kr + KYBER_SYM_SZ, ct);
+#else
         ret = kyberkey_encapsulate(key, rand, kr + KYBER_SYM_SZ, ct);
+#endif
     }
 
 #ifdef WOLFSSL_KYBER_ORIGINAL


### PR DESCRIPTION
# Description

Encapsulate the message (hash of rand) for original. Final of FIPS 203 uses rand.

Fixes #8023

# Testing

./configure --disable-shared --enable-kyber=yes,original

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
