### PR TITLE
20240930-clang-tidy

### DIFF
--- a/examples/pem/pem.c
+++ b/examples/pem/pem.c
@@ -1024,6 +1024,13 @@ int main(int argc, char* argv[])
     if (ret < 0) {
         fprintf(stderr, "%s\n", wc_GetErrorString(ret));
     }
+
+    if (in_file != stdin)
+        (void)fclose(in_file);
+
+    if (out_file != stdout)
+        (void)fclose(out_file);
+
     return (ret == 0) ? 0 : 1;
 }
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -23984,7 +23984,7 @@ int wolfSSL_RAND_seed(const void* seed, int len)
  */
 const char* wolfSSL_RAND_file_name(char* fname, unsigned long len)
 {
-#if !defined(NO_FILESYSTEM) && defined(XGETENV)
+#if !defined(NO_FILESYSTEM) && defined(XGETENV) && !defined(NO_GETENV)
     char* rt;
 
     WOLFSSL_ENTER("wolfSSL_RAND_file_name");
@@ -23995,6 +23995,7 @@ const char* wolfSSL_RAND_file_name(char* fname, unsigned long len)
 
     XMEMSET(fname, 0, len);
 
+/* // NOLINTBEGIN(concurrency-mt-unsafe) */
     if ((rt = XGETENV("RANDFILE")) != NULL) {
         if (len > XSTRLEN(rt)) {
             XMEMCPY(fname, rt, XSTRLEN(rt));
@@ -24004,6 +24005,7 @@ const char* wolfSSL_RAND_file_name(char* fname, unsigned long len)
             rt = NULL;
         }
     }
+/* // NOLINTEND(concurrency-mt-unsafe) */
 
     /* $RANDFILE was not set or is too large, check $HOME */
     if (rt == NULL) {
@@ -24011,6 +24013,7 @@ const char* wolfSSL_RAND_file_name(char* fname, unsigned long len)
 
         WOLFSSL_MSG("Environment variable RANDFILE not set");
 
+/* // NOLINTBEGIN(concurrency-mt-unsafe) */
         if ((rt = XGETENV("HOME")) == NULL) {
             #ifdef XALTHOMEVARNAME
             if ((rt = XGETENV(XALTHOMEVARNAME)) == NULL) {
@@ -24023,6 +24026,7 @@ const char* wolfSSL_RAND_file_name(char* fname, unsigned long len)
             return NULL;
             #endif
         }
+/* // NOLINTEND(concurrency-mt-unsafe) */
 
         if (len > XSTRLEN(rt) + XSTRLEN(ap)) {
             fname[0] = '\0';

--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -5099,7 +5099,7 @@ int wolfSSL_CTX_use_RSAPrivateKey(WOLFSSL_CTX* ctx, WOLFSSL_RSA* rsa)
 int wolfSSL_CTX_set_default_verify_paths(WOLFSSL_CTX* ctx)
 {
     int ret;
-#ifdef XGETENV
+#if defined(XGETENV) && !defined(NO_GETENV)
     char* certDir = NULL;
     char* certFile = NULL;
     word32 flags = 0;
@@ -5109,7 +5109,8 @@ int wolfSSL_CTX_set_default_verify_paths(WOLFSSL_CTX* ctx)
 
     WOLFSSL_ENTER("wolfSSL_CTX_set_default_verify_paths");
 
-#ifdef XGETENV
+#if defined(XGETENV) && !defined(NO_GETENV)
+    /* // NOLINTBEGIN(concurrency-mt-unsafe) */
     certDir = wc_strdup_ex(XGETENV("SSL_CERT_DIR"), DYNAMIC_TYPE_TMP_BUFFER);
     certFile = wc_strdup_ex(XGETENV("SSL_CERT_FILE"), DYNAMIC_TYPE_TMP_BUFFER);
     flags = WOLFSSL_LOAD_FLAG_PEM_CA_ONLY;
@@ -5133,6 +5134,7 @@ int wolfSSL_CTX_set_default_verify_paths(WOLFSSL_CTX* ctx)
             ret = 0;
         }
     }
+    /* // NOLINTEND(concurrency-mt-unsafe) */
     else
 #endif
 
@@ -5157,7 +5159,7 @@ int wolfSSL_CTX_set_default_verify_paths(WOLFSSL_CTX* ctx)
     #endif
     }
 
-#ifdef XGETENV
+#if defined(XGETENV) && !defined(NO_GETENV)
     XFREE(certFile, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     XFREE(certDir, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif

--- a/wolfssl/openssl/asn1.h
+++ b/wolfssl/openssl/asn1.h
@@ -270,8 +270,8 @@ typedef struct WOLFSSL_ASN1_ITEM WOLFSSL_ASN1_ITEM;
       (WolfsslAsn1FreeCb)member_type##_free, \
       (WolfsslAsn1i2dCb)i2d_##member_type, \
       (WolfsslAsn1d2iCb)d2i_##member_type, \
-      0, flags & ASN1_TFLG_TAG_MASK ? tag : -1, 0, \
-      !!(flags & ASN1_TFLG_EXPLICIT), TRUE }
+      0, (flags) & ASN1_TFLG_TAG_MASK ? (tag) : -1, 0, \
+      !!((flags) & ASN1_TFLG_EXPLICIT), TRUE }
 
 WOLFSSL_API void *wolfSSL_ASN1_item_new(const WOLFSSL_ASN1_ITEM *tpl);
 WOLFSSL_API void wolfSSL_ASN1_item_free(void *obj,
@@ -282,7 +282,7 @@ WOLFSSL_API void* wolfSSL_ASN1_item_d2i(void** dst, const byte **src, long len,
         const WOLFSSL_ASN1_ITEM* item);
 
 /* Need function declaration otherwise compiler complains */
-/* // NOLINTBEGIN(readability-named-parameter) */
+/* // NOLINTBEGIN(readability-named-parameter,bugprone-macro-parentheses) */
 #define IMPLEMENT_ASN1_FUNCTIONS(type) \
     type *type##_new(void); \
     type *type##_new(void){ \
@@ -303,7 +303,7 @@ WOLFSSL_API void* wolfSSL_ASN1_item_d2i(void** dst, const byte **src, long len,
         return (type*)wolfSSL_ASN1_item_d2i((void**)dst, src, len, \
                 &type##_template_data); \
     }
-/* // NOLINTEND(readability-named-parameter) */
+/* // NOLINTEND(readability-named-parameter,bugprone-macro-parentheses) */
 
 #endif /* OPENSSL_ALL */
 


### PR DESCRIPTION
fixes, coddling, and suppressions for new true-positive `clang-tidy` complaints:

`examples/pem/pem.c`: fix stdio stream leaks.

`src/ssl.c` and `src/ssl_load.c`: suppress `concurrency-mt-unsafe` around `getenv()`.  `getenv()` is threadsafe as long as no threads `putenv()` or `setenv()`.

`wolfssl/openssl/asn1.h`: add parentheses to fix `bugprone-macro-parentheses` in `ASN1_EX_TEMPLATE_TYPE()`, and suppress misfiring `bugprone-macro-parentheses` around `IMPLEMENT_ASN1_FUNCTIONS()`.

detected and tested with `wolfssl-multi-test.sh ... super-quick-check` with `sys-devel/clang-20.0.0_pre20240924`

note new suppression added to `wolfssl-multi-test.sh` for this:
```
-    export CLANG_TIDY_PER_FILE_CHECKS='^(src|wolfcrypt)/:concurrency-mt-unsafe ^examples/:-clang-analyzer-unix.Stream ^wolfcrypt/src/sp_(sm2_)?(arm|c|dsp|x86).*\.c:-readability-redundant-preprocessor,-bugprone-signed-char-misuse'
+    export CLANG_TIDY_PER_FILE_CHECKS='^(src|wolfcrypt)/:concurrency-mt-unsafe ^examples/:-clang-analyzer-unix.Stream,-clang-analyzer-unix.StdCLibraryFunctions ^tests/api\.c:-clang-analyzer-unix.StdCLibraryFunctions ^wolfcrypt/src/sp_(sm2_)?(arm|c|dsp|x86).*\.c:-readability-redundant-preprocessor,-bugprone-signed-char-misuse'
```

see also https://github.com/llvm/llvm-project/issues/110551
