### PR TITLE
20241001-fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2985,6 +2985,7 @@ then
             AM_CCASFLAGS="$AM_CCASFLAGS -DEXTERNAL_OPTS_OPENVPN"
             ENABLED_ARMASM_CRYPTO=yes
             ENABLED_ARMASM_NEON=yes
+            ENABLED_ARM_64=yes
 
             # Check for and set -mstrict-align compiler flag
             # Used to set assumption that Aarch64 systems will not handle
@@ -3010,6 +3011,7 @@ then
             ENABLED_ARMASM_CRYPTO=no
             ENABLED_AESGCM_STREAM=no # not yet implemented
             ENABLED_ARMASM_NEON=yes
+            ENABLED_ARM_32=yes
             AC_MSG_NOTICE([32bit ARMv7-a found, setting mfpu to neon])
             if test "$ENABLED_FIPS" != "no" ||
                 test "$HAVE_FIPS_VERSION_MAJOR" -ge 5;
@@ -3028,6 +3030,8 @@ then
             ENABLED_ARMASM_CRYPTO=no
             ENABLED_AESGCM_STREAM=no # not yet implemented
             ENABLED_ARMASM_NEON=no
+            ENABLED_ARM_THUMB=yes
+            ENABLED_ARM_32=yes
             AC_MSG_NOTICE([32bit ARMv7-m found])
             if test "$ENABLED_FIPS" != "no" ||
                 test "$HAVE_FIPS_VERSION_MAJOR" -ge 5;
@@ -3044,6 +3048,7 @@ then
             ENABLED_ARMASM_CRYPTO=no
             ENABLED_AESGCM_STREAM=no # not yet implemented
             ENABLED_ARMASM_NEON=no
+            ENABLED_ARM_32=yes
             AC_MSG_NOTICE([32bit ARMv6 found])
             ;;
         armv4*)
@@ -3052,6 +3057,7 @@ then
             ENABLED_ARMASM_CRYPTO=no
             ENABLED_AESGCM_STREAM=no # not yet implemented
             ENABLED_ARMASM_NEON=no
+            ENABLED_ARM_32=yes
             AC_MSG_NOTICE([32bit ARMv4 found])
             ;;
         *)
@@ -3060,6 +3066,7 @@ then
             AM_CCASFLAGS="$AM_CCASFLAGS -DEXTERNAL_OPTS_OPENVPN"
             ENABLED_ARMASM_CRYPTO=yes
             ENABLED_ARMASM_NEON=yes
+            ENABLED_ARM_32=yes
             AC_MSG_NOTICE([32bit ARMv8 found, setting mfpu to crypto-neon-fp-armv8])
             ;;
         esac
@@ -8357,6 +8364,7 @@ if test "$ENABLED_SP_ASM" = "yes" && test "$ENABLED_SP" = "yes"; then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_ARM_CORTEX_M_ASM"
     AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_SP_ARM_CORTEX_M_ASM"
     ENABLED_SP_ARM_CORTEX_ASM=yes
+    ENABLED_ARM_THUMB=yes
     ;;
   *armv6*)
     if test "$ENABLED_ARMASM" = "no"; then
@@ -8935,6 +8943,7 @@ case $host_cpu in
   *arm*)
     if test "$host_alias" = "thumb" || test "$ARM_TARGET" = "thumb"; then
       AM_CFLAGS="$AM_CFLAGS -mthumb -march=armv6"
+      ENABLED_ARM_THUMB=yes
     else
       if test "$host_alias" = "cortex" || test "$ARM_TARGET" = "cortex"; then
         AM_CFLAGS="$AM_CFLAGS -mcpu=cortex-r5"
@@ -9755,6 +9764,10 @@ AM_CONDITIONAL([BUILD_ARMASM],[test "x$ENABLED_ARMASM" = "xyes"])
 AM_CONDITIONAL([BUILD_ARMASM_INLINE],[test "x$ENABLED_ARMASM_INLINE" = "xyes"])
 AM_CONDITIONAL([BUILD_ARMASM_CRYPTO],[test "x$ENABLED_ARMASM_CRYPTO" = "xyes"])
 AM_CONDITIONAL([BUILD_ARMASM_NEON],[test "x$ENABLED_ARMASM_NEON" = "xyes"])
+AM_CONDITIONAL([BUILD_ARM_THUMB],[test "$ENABLED_ARM_THUMB" = "yes"  || test "$ENABLED_USERSETTINGS" = "yes"])
+AM_CONDITIONAL([BUILD_ARM_NONTHUMB],[test "$ENABLED_ARM_THUMB" != "yes"  || test "$ENABLED_USERSETTINGS" = "yes"])
+AM_CONDITIONAL([BUILD_ARM_32],[test "$ENABLED_ARM_32" = "yes"  || test "$ENABLED_USERSETTINGS" = "yes"])
+AM_CONDITIONAL([BUILD_ARM_64],[test "$ENABLED_ARM_64" = "yes"  || test "$ENABLED_USERSETTINGS" = "yes"])
 AM_CONDITIONAL([BUILD_RISCV_ASM],[test "x$ENABLED_RISCV_ASM" = "xyes"])
 AM_CONDITIONAL([BUILD_XILINX],[test "x$ENABLED_XILINX" = "xyes"])
 AM_CONDITIONAL([BUILD_AESNI],[test "x$ENABLED_AESNI" = "xyes"])

--- a/examples/pem/pem.c
+++ b/examples/pem/pem.c
@@ -127,8 +127,6 @@ static int pemApp_ReadFile(FILE* fp, unsigned char** pdata, word32* plen)
             /* Set data to new pointer. */
             data = p;
         }
-        /* Done with file. */
-        fclose(fp);
     }
 
     if (data != NULL) {
@@ -161,8 +159,6 @@ static int WriteFile(FILE* fp, const char* data, word32 len)
        fprintf(stderr, "Failed to write\n");
        ret = 1;
     }
-    /* Close file. */
-    fclose(fp);
 
     return ret;
 }
@@ -766,7 +762,8 @@ int main(int argc, char* argv[])
             argv++;
             if (argc == 0) {
                 fprintf(stderr, "No type string provided\n");
-                return 1;
+                ret = 1;
+                goto out;
             }
             type_str = argv[0];
         }
@@ -776,16 +773,19 @@ int main(int argc, char* argv[])
             argv++;
             if (argc == 0) {
                 fprintf(stderr, "No filename provided\n");
-                return 1;
+                ret = 1;
+                goto out;
             }
             if (in_file != stdin) {
                 fprintf(stderr, "At most one input file can be supplied.\n");
-                return 1;
+                ret = 1;
+                goto out;
             }
             in_file = fopen(argv[0], "r");
             if (in_file == NULL) {
                 fprintf(stderr, "File not able to be read: %s\n", argv[0]);
-                return 1;
+                ret = 1;
+                goto out;
             }
         }
         /* Name of output file. */
@@ -794,7 +794,8 @@ int main(int argc, char* argv[])
             argv++;
             if (argc == 0) {
                 fprintf(stderr, "No filename provided\n");
-                return 1;
+                ret = 1;
+                goto out;
             }
             out_name = argv[0];
         }
@@ -805,7 +806,8 @@ int main(int argc, char* argv[])
             argv++;
             if (argc == 0) {
                 fprintf(stderr, "No filename provided\n");
-                return 1;
+                ret = 1;
+                goto out;
             }
             offset = (word32)strtoul(argv[0], NULL, 10);
         }
@@ -817,7 +819,8 @@ int main(int argc, char* argv[])
             argv++;
             if (argc == 0) {
                 fprintf(stderr, "No password provided\n");
-                return 1;
+                ret = 1;
+                goto out;
             }
             info.passwd_cb = password_from_userdata;
             info.passwd_userdata = argv[0];
@@ -846,10 +849,12 @@ int main(int argc, char* argv[])
             argv++;
             if (argc == 0) {
                 fprintf(stderr, "No PBE version provided\n");
-                return 1;
+                ret = 1;
+                goto out;
             }
             if (StringToPbeVer(argv[0], &pbe_ver) != 0) {
-                return 1;
+                ret = 1;
+                goto out;
             }
         }
         /* PBE algorithm. */
@@ -859,10 +864,12 @@ int main(int argc, char* argv[])
             argv++;
             if (argc == 0) {
                 fprintf(stderr, "No PBE provided\n");
-                return 1;
+                ret = 1;
+                goto out;
             }
             if (StringToPbe(argv[0], &pbe) != 0) {
-                return 1;
+                ret = 1;
+                goto out;
             }
         }
         /* PBES2 algorithm. */
@@ -872,10 +879,12 @@ int main(int argc, char* argv[])
             argv++;
             if (argc == 0) {
                 fprintf(stderr, "No PBE algorithm provided\n");
-                return 1;
+                ret = 1;
+                goto out;
             }
             if (StringToPbeAlg(argv[0], &pbe_alg) != 0) {
-                return 1;
+                ret = 1;
+                goto out;
             }
         }
         /* Number of PBE iterations. */
@@ -885,7 +894,8 @@ int main(int argc, char* argv[])
             argv++;
             if (argc == 0) {
                 fprintf(stderr, "No filename provided\n");
-                return 1;
+                ret = 1;
+                goto out;
             }
             iterations = (unsigned int)strtoul(argv[0], NULL, 10);
         }
@@ -896,13 +906,15 @@ int main(int argc, char* argv[])
             argv++;
             if (argc == 0) {
                 fprintf(stderr, "No salt size provided\n");
-                return 1;
+                ret = 1;
+                goto out;
             }
             salt_sz = (unsigned int)strtoul(argv[0], NULL, 10);
             if (salt_sz > SALT_MAX_LEN) {
                 fprintf(stderr, "Salt size must be no bigger than %d: %d\n",
                     SALT_MAX_LEN, salt_sz);
-                return 1;
+                ret = 1;
+                goto out;
             }
         }
 #endif /* WOLFSSL_ENCRYPTED_KEYS !NO_PWDBASED */
@@ -918,12 +930,14 @@ int main(int argc, char* argv[])
         else if ((strcmp(argv[0], "-?") == 0) ||
                  (strcmp(argv[0], "--help") == 0)) {
             Usage();
-            return 0;
+            ret = 0;
+            goto out;
         }
         else {
             fprintf(stderr, "Bad option: %s\n", argv[0]);
             Usage();
-            return 1;
+            ret = 1;
+            goto out;
         }
 
         /* Move on to next command line argument. */
@@ -1005,6 +1019,7 @@ int main(int argc, char* argv[])
         }
     }
 
+out:
     /* Dispose of allocated data. */
     if (der != NULL) {
         wc_FreeDer(&der);
@@ -1025,10 +1040,10 @@ int main(int argc, char* argv[])
         fprintf(stderr, "%s\n", wc_GetErrorString(ret));
     }
 
-    if (in_file != stdin)
+    if ((in_file != stdin) && (in_file != NULL))
         (void)fclose(in_file);
 
-    if (out_file != stdout)
+    if ((out_file != stdout) && (out_file != NULL))
         (void)fclose(out_file);
 
     return (ret == 0) ? 0 : 1;

--- a/src/include.am
+++ b/src/include.am
@@ -172,11 +172,19 @@ endif !BUILD_ARMASM_INLINE
 else
 if BUILD_ARMASM
 if BUILD_ARMASM_INLINE
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-aes-asm_c.c
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-aes-asm_c.c
+endif
 else
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-aes-asm.S
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-aes-asm.S
+endif
 endif !BUILD_ARMASM_INLINE
 endif BUILD_ARMASM
 endif !BUILD_ARMASM_NEON
@@ -211,11 +219,19 @@ else
 if BUILD_ARMASM
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha256.c
 if BUILD_ARMASM_INLINE
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha256-asm_c.c
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-sha256-asm_c.c
+endif
 else
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha256-asm.S
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-sha256-asm.S
+endif
 endif !BUILD_ARMASM_INLINE
 else
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha256.c
@@ -248,11 +264,19 @@ else
 if BUILD_ARMASM
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha512.c
 if BUILD_ARMASM_INLINE
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha512-asm_c.c
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-sha512-asm_c.c
+endif
 else
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha512-asm.S
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-sha512-asm.S
+endif
 endif !BUILD_ARMASM_INLINE
 else
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha512.c
@@ -277,11 +301,19 @@ endif !BUILD_ARMASM_INLINE
 endif BUILD_ARMASM_NEON
 if BUILD_ARMASM
 if BUILD_ARMASM_INLINE
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha3-asm_c.c
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-sha3-asm_c.c
+endif
 else
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha3-asm.S
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-sha3-asm.S
+endif
 endif !BUILD_ARMASM_INLINE
 endif BUILD_ARMASM
 if BUILD_RISCV_ASM
@@ -342,11 +374,19 @@ endif !BUILD_ARMASM_INLINE
 else
 if BUILD_ARMASM
 if BUILD_ARMASM_INLINE
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-aes-asm_c.c
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-aes-asm_c.c
+endif
 else
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-aes-asm.S
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-aes-asm.S
+endif
 endif !BUILD_ARMASM_INLINE
 endif BUILD_ARMASM
 endif !BUILD_ARMASM_NEON
@@ -377,11 +417,19 @@ else
 if BUILD_ARMASM
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha256.c
 if BUILD_ARMASM_INLINE
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha256-asm_c.c
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-sha256-asm_c.c
+endif
 else
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha256-asm.S
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-sha256-asm.S
+endif
 endif !BUILD_ARMASM_INLINE
 else
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha256.c
@@ -412,11 +460,19 @@ else
 if BUILD_ARMASM
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha512.c
 if BUILD_ARMASM_INLINE
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha512-asm_c.c
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-sha512-asm_c.c
+endif
 else
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha512-asm.S
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-sha512-asm.S
+endif
 endif !BUILD_ARMASM_INLINE
 else
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha512.c
@@ -439,11 +495,19 @@ endif !BUILD_ARMASM_INLINE
 endif BUILD_ARMASM_NEON
 if BUILD_ARMASM
 if BUILD_ARMASM_INLINE
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha3-asm_c.c
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-sha3-asm_c.c
+endif
 else
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha3-asm.S
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-sha3-asm.S
+endif
 endif !BUILD_ARMASM_INLINE
 endif BUILD_ARMASM
 if BUILD_RISCV_ASM
@@ -489,13 +553,29 @@ src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-curve25519.
 endif !BUILD_ARMASM_INLINE
 else
 if BUILD_ARMASM_INLINE
+if BUILD_ARM_NONTHUMB
+if BUILD_ARM_32
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-curve25519_c.c
-src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-curve25519_c.c
+endif
+if BUILD_ARM_64
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-curve25519_c.c
+endif
+endif
+if BUILD_ARM_THUMB
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-curve25519_c.c
+endif
 else
+if BUILD_ARM_NONTHUMB
+if BUILD_ARM_32
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-curve25519.S
-src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-curve25519.S
+endif
+if BUILD_ARM_64
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-curve25519.S
+endif
+endif
+if BUILD_ARM_THUMB
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-curve25519.S
+endif
 endif !BUILD_ARMASM_INLINE
 endif !BUILD_ARMASM_NEON
 endif BUILD_ARMASM
@@ -599,11 +679,19 @@ else
 if BUILD_ARMASM
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha256.c
 if BUILD_ARMASM_INLINE
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha256-asm_c.c
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-sha256-asm_c.c
+endif
 else
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha256-asm.S
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-sha256-asm.S
+endif
 endif !BUILD_ARMASM_INLINE
 else
 if !BUILD_X86_ASM
@@ -698,20 +786,36 @@ src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-aes.c
 endif BUILD_ARMASM
 if BUILD_ARMASM_NEON
 if BUILD_ARMASM_INLINE
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-aes-asm_c.c
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-aes-asm_c.c
+endif
 else
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-aes-asm.S
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-aes-asm.S
+endif
 endif !BUILD_ARMASM_INLINE
 else
 if BUILD_ARMASM
 if BUILD_ARMASM_INLINE
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-aes-asm_c.c
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-aes-asm_c.c
+endif
 else
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-aes-asm.S
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-aes-asm.S
+endif
 endif !BUILD_ARMASM_INLINE
 endif BUILD_ARMASM
 endif !BUILD_ARMASM_NEON
@@ -762,11 +866,19 @@ else
 if BUILD_ARMASM
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha512.c
 if BUILD_ARMASM_INLINE
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha512-asm_c.c
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-sha512-asm_c.c
+endif
 else
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha512-asm.S
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-sha512-asm.S
+endif
 endif !BUILD_ARMASM_INLINE
 else
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/sha512.c
@@ -793,11 +905,19 @@ endif !BUILD_ARMASM_INLINE
 endif BUILD_ARMASM_NEON
 if BUILD_ARMASM
 if BUILD_ARMASM_INLINE
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha3-asm_c.c
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-sha3-asm_c.c
+endif
 else
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-sha3-asm.S
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-sha3-asm.S
+endif
 endif !BUILD_ARMASM_INLINE
 endif BUILD_ARMASM
 if BUILD_RISCV_ASM
@@ -915,14 +1035,26 @@ if !BUILD_FIPS_RAND
 
 if BUILD_POLY1305
 if BUILD_ARMASM
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-poly1305.c
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-poly1305.c
+endif
 if BUILD_ARMASM_INLINE
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-poly1305-asm_c.c
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-poly1305-asm_c.c
+endif
 else
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-poly1305-asm.S
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-poly1305-asm.S
+endif
 endif !BUILD_ARMASM_INLINE
 endif
 if BUILD_RISCV_ASM
@@ -996,14 +1128,26 @@ endif
 if BUILD_CHACHA
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/chacha.c
 if BUILD_ARMASM
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-chacha.c
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-chacha.c
+endif
 if BUILD_ARMASM_INLINE
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-chacha-asm_c.c
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-chacha-asm_c.c
+endif
 else
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-chacha-asm.S
+endif
+if BUILD_ARM_THUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-chacha-asm.S
+endif
 endif !BUILD_ARMASM_INLINE
 else
 if BUILD_RISCV_ASM
@@ -1099,21 +1243,45 @@ if BUILD_ARMASM
 if !BUILD_FIPS_V6
 if BUILD_ARMASM_NEON
 if BUILD_ARMASM_INLINE
+if BUILD_ARM_32
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-curve25519_c.c
+endif
+if BUILD_ARM_64
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-curve25519_c.c
+endif
 else
+if BUILD_ARM_32
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-curve25519.S
+endif
+if BUILD_ARM_64
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-curve25519.S
+endif
 endif !BUILD_ARMASM_INLINE
 else
 if BUILD_ARMASM_INLINE
+if BUILD_ARM_NONTHUMB
+if BUILD_ARM_32
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-curve25519_c.c
-src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-curve25519_c.c
+endif
+if BUILD_ARM_64
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-curve25519_c.c
+endif
+endif
+if BUILD_ARM_THUMB
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-curve25519_c.c
+endif
 else
+if BUILD_ARM_NONTHUMB
+if BUILD_ARM_32
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-32-curve25519.S
-src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-curve25519.S
+endif
+if BUILD_ARM_64
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-curve25519.S
+endif
+endif
+if BUILD_ARM_THUMB
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-curve25519.S
+endif
 endif !BUILD_ARMASM_INLINE
 endif !BUILD_ARMASM_NEON
 endif !BUILD_FIPS_V6
@@ -1145,11 +1313,19 @@ src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-curve25519.
 endif !BUILD_ARMASM_INLINE
 else
 if BUILD_ARMASM_INLINE
-src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-curve25519_c.c
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-curve25519_c.c
+endif
+if BUILD_ARM_THUMB
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-curve25519_c.c
+endif
 else
-src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-curve25519.S
+if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-curve25519.S
+endif
+if BUILD_ARM_THUMB
+src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/thumb2-curve25519.S
+endif
 endif !BUILD_ARMASM_INLINE
 endif !BUILD_ARMASM_NEON
 else


### PR DESCRIPTION
`examples/pem/pem.c`: fix `double-free` introduced in 65853a41b9;

`configure.ac` and `src/include.am`: add `ENABLED_ARM_THUMB`, `BUILD_ARM_THUMB`, `BUILD_ARM_NONTHUMB`, `ENABLED_ARM_64`, `BUILD_ARM_64`, `ENABLED_ARM_32`. and `BUILD_ARM_32`, and use them to gate building of ARM asm files, to fix "ISO C forbids an empty translation unit" warnings (the warning only affects inline asm files, but the gating is deployed more widely).

tested with `wolfssl-multi-test.sh ... quantum-safe-wolfssl-all-clang-tidy quantum-safe-wolfssl-all-intelasm-sp-asm-sanitizer quantum-safe-wolfssl-all-cross-aarch64-armasm-unittest-sanitizer cross-armv6zk-all cross-armv7a-all cross-armv7m-armasm-thumb-sp-asm-all-crypto-only cross-armv7m-armasm-thumb-fips-140-3-dev-sp-asm-all-crypto-only cross-armv6zk-thumb-all-asm check-source-text check-source-text-fips-dev check-configure`
