### PR TITLE
acert: correct XFREE call.

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -7355,7 +7355,7 @@ void wolfSSL_X509_ACERT_free(WOLFSSL_X509_ACERT* x509)
 
     /* Finally memset and free x509 acert structure. */
     XMEMSET(x509, 0, sizeof(*x509));
-    XFREE(x509, x509->heap, NULL);
+    XFREE(x509, NULL, DYNAMIC_TYPE_X509_ACERT);
 
     return;
 }


### PR DESCRIPTION
# Description

Fix an XFREE call in wolfSSL_X509_ACERT_free(). It should reference the `DYNAMIC_TYPE_X509_ACERT` type used.

This fixes a static-memory + acert + opensslextra build error.

# Testing

```
#!/bin/bash
cd src || exit 1

./configure \
  --enable-staticmemory \
  --enable-acert \
  --enable-rsapss \
  --enable-opensslextra \
  C_EXTRA_FLAGS="-DWOLFSSL_DEBUG_MEMORY" \                                       
  || exit 1                                                                      
                                                                                 
make || exit 1                                                                   
sudo make install
```

Tested with acert-test example:
- https://github.com/philljj/acert-test

