### PR TITLE
SP Maths: PowerPC ASM fix

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -3942,7 +3942,7 @@ static WC_INLINE sp_int_digit sp_div_word(sp_int_digit hi, sp_int_digit lo,
     __asm__ __volatile__ (                               \
         "mulhwu	%[h], %[a], %[b]	\n\t"            \
         "mullw	%[l], %[a], %[b]	\n\t"            \
-        "li	%[o], 0			\n\t"            \
+        "xor	%[o], %[o], %[o]	\n\t"            \
         : [l] "+r" (vl), [h] "+r" (vh), [o] "=r" (vo)    \
         : [a] "r" (va), [b] "r" (vb)                     \
     )
@@ -4045,7 +4045,7 @@ static WC_INLINE sp_int_digit sp_div_word(sp_int_digit hi, sp_int_digit lo,
 #define SP_ASM_SUBB(vl, vh, va)                          \
     __asm__ __volatile__ (                               \
         "subfc	%[l], %[a], %[l]	\n\t"            \
-        "li	16, 0			\n\t"            \
+        "xor	16, 16, 16		\n\t"            \
         "subfe	%[h], 16, %[h]		\n\t"            \
         : [l] "+r" (vl), [h] "+r" (vh)                   \
         : [a] "r" (va)                                   \


### PR DESCRIPTION
# Description

The instruction 'li' is a pseduo instruction for 'load immediate'. With some compilers, the immediate was interpretted R0[0]. Change to use XOR instead.

Fixes zd#18516

# Testing

QEMU host powerpc.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
