### PR TITLE
20241002-fix-for-cppcheck-force-source

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -21730,16 +21730,19 @@ default:
                 else
 #endif
                 {
-#ifdef HAVE_ENCRYPT_THEN_MAC
-                    word16 startedETMRead = ssl->options.startedETMRead;
-#else
-                    word16 startedETMRead = 0;
-#endif
                     /* With atomicUser the callback should have already included
                      * the mac in the padding size. The ETM callback doesn't do
                      * this for some reason. */
-                    if (ssl->specs.cipher_type != aead &&
-                            (!atomicUser || startedETMRead)) {
+                    if (ssl->specs.cipher_type != aead
+#ifdef ATOMIC_USER
+                             && (!atomicUser
+#ifdef HAVE_ENCRYPT_THEN_MAC
+                                 || ssl->options.startedETMRead
+#endif /* HAVE_ENCRYPT_THEN_MAC */
+                                )
+#endif /* !ATOMIC_USER */
+                       )
+                    {
                         /* consider MAC as padding */
                         ssl->keys.padSz += MacSize(ssl);
                     }


### PR DESCRIPTION
`src/internal.c`: in `ProcessReplyEx()` in the `verifyMessage` case, refactor some gating/conditionalization around `ATOMIC_USER`, `HAVE_ENCRYPT_THEN_MAC`, `atomicUser`, and `ssl->options.startedETMRead`, to avoid "Logical disjunction always evaluates to true" from `cppcheck` `incorrectLogicOperator` (via multi-test `cppcheck-force-source`) (warned code introduced by 99a99e3d6e).

tested with `wolfssl-multi-test.sh ... super-quick-check cppcheck-force-source`
