### PR TITLE
20241004-WOLFSSL_ARM_ARCH_7M

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2399,7 +2399,10 @@ extern void uITRON4_free(void *p) ;
 #endif
 
 /* Detect Cortex M3 (no UMAAL) */
-#if defined(WOLFSSL_SP_ARM_CORTEX_M_ASM) && defined(__ARM_ARCH_7M__)
+#if defined(__ARM_ARCH_7M__) && !defined(WOLFSSL_ARM_ARCH_7M)
+    #define WOLFSSL_ARM_ARCH_7M
+#endif
+#if defined(WOLFSSL_SP_ARM_CORTEX_M_ASM) && defined(WOLFSSL_ARM_ARCH_7M)
     #undef  WOLFSSL_SP_NO_UMAAL
     #define WOLFSSL_SP_NO_UMAAL
 #endif


### PR DESCRIPTION
`wolfssl/wolfcrypt/settings.h`: add setup for `WOLFSSL_ARM_ARCH_7M`.

tested with `wolfssl-multi-test.sh ... cross-armv7m-armasm-thumb-sp-asm-all-crypto-only cross-armv7m-armasm-thumb-fips-140-3-dev-sp-asm-all-crypto-only check-source-text`
