### PR TITLE
20241004-wc_static_assert

### DIFF
--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -71,7 +71,7 @@ typedef struct Dtls13HandshakeHeader {
     byte fragmentLength[3];
 } Dtls13HandshakeHeader;
 
-static_assert(sizeof(Dtls13HandshakeHeader) == DTLS13_HANDSHAKE_HEADER_SZ);
+wc_static_assert(sizeof(Dtls13HandshakeHeader) == DTLS13_HANDSHAKE_HEADER_SZ);
 
 /**
  * struct Dtls13Recordplaintextheader: represent header of unprotected DTLSv1.3

--- a/src/ssl_crypto.c
+++ b/src/ssl_crypto.c
@@ -2923,8 +2923,7 @@ void wolfSSL_DES_ecb_encrypt(WOLFSSL_DES_cblock* in, WOLFSSL_DES_cblock* out,
 static int wolfssl_aes_set_key(const unsigned char *key, const int bits,
     AES_KEY *aes, int enc)
 {
-    typedef char aes_test[sizeof(AES_KEY) >= sizeof(Aes) ? 1 : -1];
-    (void)sizeof(aes_test);
+    wc_static_assert(sizeof(AES_KEY) >= sizeof(Aes));
 
     /* Validate parameters. */
     if ((key == NULL) || (aes == NULL)) {
@@ -3438,8 +3437,7 @@ size_t wolfSSL_CRYPTO_cts128_decrypt(const unsigned char *in,
 void wolfSSL_RC4_set_key(WOLFSSL_RC4_KEY* key, int len,
     const unsigned char* data)
 {
-    typedef char rc4_test[sizeof(WOLFSSL_RC4_KEY) >= sizeof(Arc4) ? 1 : -1];
-    (void)sizeof(rc4_test);
+    wc_static_assert(sizeof(WOLFSSL_RC4_KEY) >= sizeof(Arc4));
 
     WOLFSSL_ENTER("wolfSSL_RC4_set_key");
 

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -10495,20 +10495,15 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
                                const WOLFSSL_EVP_MD* md)
     {
         int ret = WOLFSSL_SUCCESS;
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        wc_static_assert(WC_ASYNC_DEV_SIZE >= sizeof(WC_ASYNC_DEV));
+    #endif
 
         WOLFSSL_ENTER("EVP_DigestInit");
 
         if (ctx == NULL) {
             return WOLFSSL_FAILURE;
         }
-
-
-    #ifdef WOLFSSL_ASYNC_CRYPT
-        /* compile-time validation of ASYNC_CTX_SIZE */
-        typedef char async_test[WC_ASYNC_DEV_SIZE >= sizeof(WC_ASYNC_DEV) ?
-                                                                        1 : -1];
-        (void)sizeof(async_test);
-    #endif
 
         /* Set to 0 if no match */
         ctx->macType = EvpMd2MacType(md);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -841,11 +841,11 @@ static void render_error_message(const char* msg, wc_test_ret_t es)
  * stores an error string in the supplied buffer.  this is all most
  * infelicitous...
  */
-#if !defined(STRING_USER) && !defined(NO_ERROR_STRINGS) &&      \
+#if !defined(STRING_USER) && !defined(NO_ERROR_STRINGS) &&              \
     (defined(__STDC_VERSION__) && (__STDC_VERSION__ > 199901L)) &&      \
-    ((defined(__GLIBC__) && (__GLIBC__ >= 2)) ||                \
-     (defined(__USE_XOPEN2K) &&                                 \
-      defined(_POSIX_C_SOURCE) &&                               \
+    ((defined(__GLIBC__) && (__GLIBC__ >= 2) && defined(__USE_GNU)) ||  \
+     (defined(__USE_XOPEN2K) &&                                         \
+      defined(_POSIX_C_SOURCE) &&                                       \
       (_POSIX_C_SOURCE >= 200112L)))
 
         char errno_buf[64], *errno_string;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2071,18 +2071,9 @@ enum Misc {
 
 #define MAX_ENCRYPT_SZ ENCRYPT_LEN
 
-/* A static check to assert a relation between x and y */
-#define WOLFSSL_ASSERT_TEST(x, y, op) do {         \
-    typedef char _args_test_[(x) op (y) ? 1 : -1]; \
-    (void)sizeof(_args_test_);                     \
-} while(0)
+#define WOLFSSL_ASSERT_EQ(x, y) wc_static_assert((x) == (y))
 
-#define WOLFSSL_ASSERT_EQ(x, y) WOLFSSL_ASSERT_TEST(x, y, ==)
-
-#define WOLFSSL_ASSERT_SIZEOF_TEST(x, y, op) \
-    WOLFSSL_ASSERT_TEST(sizeof(x), sizeof(y), op)
-
-#define WOLFSSL_ASSERT_SIZEOF_GE(x, y) WOLFSSL_ASSERT_SIZEOF_TEST(x, y, >=)
+#define WOLFSSL_ASSERT_SIZEOF_GE(x, y) wc_static_assert(sizeof(x) >= sizeof(y))
 
 /* states. Adding state before HANDSHAKE_DONE will break session importing */
 enum states {

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -20,24 +20,17 @@
  */
 
 /*
- *   ************************************************************************
+ *   Note, this file should not be edited to activate/deactivate features.
  *
- *   ******************************** NOTICE ********************************
- *
- *   ************************************************************************
- *
- *   This method of uncommenting a line in settings.h is outdated.
- *
- *   Please use user_settings.h / WOLFSSL_USER_SETTINGS
+ *   Instead, add/edit user_settings.h, and compile with -DWOLFSSL_USER_SETTINGS
  *
  *         or
  *
- *   ./configure CFLAGS="-DFLAG"
+ *   ./configure CFLAGS="-DFEATURE_FLAG_TO_DEFINE -UFEATURE_FLAG_TO_CLEAR [...]"
  *
  *   For more information see:
  *
  *   https://www.wolfssl.com/how-do-i-manage-the-build-configuration-of-wolfssl/
- *
  */
 
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1693,15 +1693,22 @@ typedef struct w64wrapper {
         #define PRAGMA_DIAG_POP /* null expansion */
     #endif
 
-    #define WC_CPP_CAT_(a, b) a ## b
-    #define WC_CPP_CAT(a, b) WC_CPP_CAT_(a, b)
-    #if (defined(__cplusplus) && (__cplusplus >= 201103L)) || \
-          (defined(_MSVC_LANG) && (_MSVC_LANG >= 201103L))
-        #ifndef static_assert2
-            #define static_assert2 static_assert
-        #endif
-    #elif !defined(static_assert)
-        #if !defined(__cplusplus) &&                \
+    #ifndef wc_static_assert
+        #if (defined(__cplusplus) && (__cplusplus >= 201703L)) || \
+               (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 202311L)) || \
+               (defined(_MSVC_LANG) && (_MSVC_LANG >= 201103L))
+            /* directly usable variadic declaration */
+            #define wc_static_assert static_assert
+            #ifndef wc_static_assert2
+                #define wc_static_assert2 static_assert
+            #endif
+        #elif defined(_MSC_VER) && (__STDC_VERSION__ >= 201112L)
+            /* native 2-argument static_assert() */
+            #define wc_static_assert(expr) static_assert(expr, #expr)
+            #ifndef wc_static_assert2
+                #define wc_static_assert2(expr, msg) static_assert(expr, msg)
+            #endif
+        #elif !defined(__cplusplus) &&              \
                 !defined(__STRICT_ANSI__) &&        \
                 !defined(WOLF_C89) &&               \
                 defined(__STDC_VERSION__) &&        \
@@ -1709,19 +1716,20 @@ typedef struct w64wrapper {
                 ((defined(__GNUC__) &&              \
                   (__GNUC__ >= 5)) ||               \
                  defined(__clang__))
-            #define static_assert(expr) _Static_assert(expr, #expr)
-            #ifndef static_assert2
-                #define static_assert2(expr, msg) _Static_assert(expr, msg)
+            /* native 2-argument _Static_assert() */
+            #define wc_static_assert(expr) _Static_assert(expr, #expr)
+            #ifndef wc_static_assert2
+                #define wc_static_assert2(expr, msg) _Static_assert(expr, msg)
             #endif
         #else
-            #define static_assert(expr) \
-                struct WC_CPP_CAT(wc_dummy_struct_L, __LINE__)
-            #ifndef static_assert2
-                #define static_assert2(expr, msg) static_assert(expr)
+            /* fallback -- map wc_static_assert*() to do-nothing. */
+            #define wc_static_assert(expr) struct wc_static_assert_dummy_struct
+            #ifndef wc_static_assert2
+                #define wc_static_assert2(expr, msg) wc_static_assert(expr)
             #endif
         #endif
-    #elif !defined(static_assert2)
-         #define static_assert2(expr, msg) static_assert(expr)
+    #elif !defined(wc_static_assert2)
+         #define wc_static_assert2(expr, msg) wc_static_assert(expr)
     #endif
 
     #ifndef SAVE_VECTOR_REGISTERS


### PR DESCRIPTION
`wolfssl/wolfcrypt/types.h`: refactor `static_assert*()` as `wc_static_assert*()` to avoid conflicts with target-native `static_assert()`, and add additional coverage for C23 and MSVC C11.

`wolfcrypt/test/test.c`: in `render_error_message()`, in tests for `strerror_r()`, test for `__USE_GNU`.

tested with `wolfssl-multi-test.sh ... check-source-text all-gcc-c89 quantum-safe-wolfssl-all-gcc-latest-c23-debug quantum-safe-wolfssl-all-clang-latest-c23-debug quantum-safe-wolfssl-all-g++-latest-debug`
