### PR TITLE
sniffer: set ssl->curSize before invoking Do* routines

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -5006,6 +5006,7 @@ static const byte* DecryptMessage(WOLFSSL* ssl, const byte* input, word32 sz,
         return NULL;
     }
 
+    ssl->curSize = sz;
     ssl->keys.encryptSz = sz;
     if (ssl->options.tls1_1 && ssl->specs.cipher_type == block) {
         output += ssl->specs.block_size; /* go past TLSv1.1 IV */


### PR DESCRIPTION

# Description
commit 99a99e3d6e470c6eecb536d18f4042f6433afe93 changes DoApplication to use ssl->curSize as the size of the current decrypted record. Fix sniffer code to set this value.


