### PR TITLE
Clear ctx in wolfSSL_EVP_DigestInit

### DIFF
--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -10505,6 +10505,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
             return WOLFSSL_FAILURE;
         }
 
+        wolfSSL_EVP_MD_CTX_init(ctx);
+
         /* Set to 0 if no match */
         ctx->macType = EvpMd2MacType(md);
         if (md == NULL) {


### PR DESCRIPTION
# Description

Clear the ctx structure before starting the digest operation.

Fixes zd18758

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
