### PR TITLE
Add lock around static ECC ecc_oid_cache

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -1426,7 +1426,13 @@ size_t wc_ecc_get_sets_count(void) {
         byte oid[ECC_MAX_OID_LEN];
     } oid_cache_t;
     static oid_cache_t ecc_oid_cache[ECC_SET_COUNT];
+
+    static wolfSSL_Mutex ecc_oid_cache_lock
+        WOLFSSL_MUTEX_INITIALIZER_CLAUSE(ecc_oid_cache_lock);
+#ifndef WOLFSSL_MUTEX_INITIALIZER
+    static volatile int eccOidLockInit = 0;
 #endif
+#endif /* HAVE_OID_ENCODING */
 
 /* Forward declarations */
 #if defined(HAVE_COMP_KEY) && defined(HAVE_ECC_KEY_EXPORT)
@@ -15418,22 +15424,57 @@ static int wc_ecc_export_x963_compressed(ecc_key* key, byte* out, word32* outLen
 #endif /* HAVE_ECC_KEY_EXPORT */
 #endif /* HAVE_COMP_KEY */
 
+#ifdef HAVE_OID_ENCODING
+int wc_ecc_oid_cache_init(void)
+{
+    int ret = 0;
+#if !defined(SINGLE_THREADED) && !defined(WOLFSSL_MUTEX_INITIALIZER)
+    ret = wc_InitMutex(&ecc_oid_cache_lock);
+#endif
+    return ret;
+}
+
+void wc_ecc_oid_cache_free(void)
+{
+#if !defined(SINGLE_THREADED) && !defined(WOLFSSL_MUTEX_INITIALIZER)
+    wc_FreeMutex(&ecc_oid_cache_lock);
+#endif
+}
+#endif /* HAVE_OID_ENCODING */
 
 int wc_ecc_get_oid(word32 oidSum, const byte** oid, word32* oidSz)
 {
     int x;
+    int ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
+#ifdef HAVE_OID_ENCODING
+    oid_cache_t* o = NULL;
+#endif
 
     if (oidSum == 0) {
         return BAD_FUNC_ARG;
     }
 
+#ifdef HAVE_OID_ENCODING
+    #ifndef WOLFSSL_MUTEX_INITIALIZER
+        /* extra sanity check if wolfCrypt_Init not called */
+        if (eccOidLockInit == 0) {
+            wc_InitMutex(&ecc_oid_cache_lock);
+            eccOidLockInit = 1;
+        }
+    #endif
+
+    if (wc_LockMutex(&ecc_oid_cache_lock) != 0) {
+        return BAD_MUTEX_E;
+    }
+#endif
+
     /* find matching OID sum (based on encoded value) */
     for (x = 0; ecc_sets[x].size != 0; x++) {
         if (ecc_sets[x].oidSum == oidSum) {
         #ifdef HAVE_OID_ENCODING
-            int ret = 0;
             /* check cache */
-            oid_cache_t* o = &ecc_oid_cache[x];
+            ret = 0;
+            o = &ecc_oid_cache[x];
             if (o->oidSz == 0) {
                 o->oidSz = sizeof(o->oid);
                 ret = EncodeObjectId(ecc_sets[x].oid, ecc_sets[x].oidSz,
@@ -15445,11 +15486,12 @@ int wc_ecc_get_oid(word32 oidSum, const byte** oid, word32* oidSz)
             if (oid) {
                 *oid = o->oid;
             }
+
             /* on success return curve id */
             if (ret == 0) {
                 ret = ecc_sets[x].id;
             }
-            return ret;
+            break;
         #else
             if (oidSz) {
                 *oidSz = ecc_sets[x].oidSz;
@@ -15457,12 +15499,17 @@ int wc_ecc_get_oid(word32 oidSum, const byte** oid, word32* oidSz)
             if (oid) {
                 *oid = ecc_sets[x].oid;
             }
-            return ecc_sets[x].id;
+            ret = ecc_sets[x].id;
+            break;
         #endif
         }
     }
 
-    return NOT_COMPILED_IN;
+#ifdef HAVE_OID_ENCODING
+    wc_UnLockMutex(&ecc_oid_cache_lock);
+#endif
+
+    return ret;
 }
 
 #ifdef WOLFSSL_CUSTOM_CURVES

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -365,6 +365,13 @@ int wolfCrypt_Init(void)
             return ret;
         }
     #endif
+    #if defined(HAVE_OID_ENCODING) && (!defined(HAVE_FIPS) || \
+            (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(6,0)))
+        if ((ret = wc_ecc_oid_cache_init()) != 0) {
+            WOLFSSL_MSG("Error creating ECC oid cache");
+            return ret;
+        }
+    #endif
 #endif
 
 #ifdef WOLFSSL_SCE
@@ -455,6 +462,10 @@ int wolfCrypt_Cleanup(void)
     #endif
     #ifdef ECC_CACHE_CURVE
         wc_ecc_curve_cache_free();
+    #endif
+    #if defined(HAVE_OID_ENCODING) && (!defined(HAVE_FIPS) || \
+            (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(6,0)))
+        wc_ecc_oid_cache_free();
     #endif
 #endif /* HAVE_ECC */
 

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -1027,6 +1027,11 @@ WOLFSSL_API int wc_ecc_curve_cache_init(void);
 WOLFSSL_API void wc_ecc_curve_cache_free(void);
 #endif
 
+#ifdef HAVE_OID_ENCODING
+WOLFSSL_LOCAL int wc_ecc_oid_cache_init(void);
+WOLFSSL_LOCAL void wc_ecc_oid_cache_free(void);
+#endif
+
 WOLFSSL_API
 int wc_ecc_gen_k(WC_RNG* rng, int size, mp_int* k, mp_int* order);
 


### PR DESCRIPTION
# Description

This PR adds a lock around the static `ecc_oid_cache` that is used by `wc_ecc_get_oid()` in `wolfcrypt/src/ecc.c` when `HAVE_OID_ENCODING` is defined.

Threading issues around this were showing up in wolfSSL JNI testing, with exceptions/errors similar to the following:

```
    [junit] JNI Ecc Class
    [junit] 	threadedEccSharedSecretTest
    [junit] com.wolfssl.wolfcrypt.WolfCryptException: ASN oid error, unknown sum id
    [junit] 	eccCurveSizeFromName
    [junit] 	at com.wolfssl.wolfcrypt.Ecc.wc_EccPrivateKeyDecode(Native Method)
    [junit] 	threadedEccSignVerifyTest
    [junit] 	at com.wolfssl.wolfcrypt.Ecc.privateKeyDecode(Unknown Source)
    [junit] 	at com.wolfssl.wolfcrypt.test.EccTest$3.run(EccTest.java:463)
    [junit] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
    [junit] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
    [junit] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
    [junit] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
    [junit] 	at java.base/java.lang.Thread.run(Thread.java:1583)
```

# Testing

Tested via existing unit tests, and wolfSSL JNI threaded ECC tests which exposed this issue.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
