### PR TITLE
Run coverity workflow only for wolfssl owner

### DIFF
--- a/.github/workflows/coverity-scan-fixes.yml
+++ b/.github/workflows/coverity-scan-fixes.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   coverity:
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
# Description

The coverity job does not need to run by default in forks.

Fixes zd# n/a

# Testing

How did you test?

No testing completed.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
