### PR TITLE
Allow building with WOLFSSL_NO_MALLOC again

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -11299,6 +11299,7 @@ int wc_AesCcmEncrypt_ex(Aes* aes, byte* out, const byte* in, word32 sz,
 
 #endif /* HAVE_AESCCM */
 
+#ifndef WOLFSSL_NO_MALLOC
 Aes* wc_AesNew(void* heap, int devId)
 {
     Aes* aes = (Aes*)XMALLOC(sizeof(Aes), heap, DYNAMIC_TYPE_AES);
@@ -11313,6 +11314,7 @@ Aes* wc_AesNew(void* heap, int devId)
     }
     return aes;
 }
+#endif
 
 /* Initialize Aes for use with async hardware */
 int wc_AesInit(Aes* aes, void* heap, int devId)
@@ -11525,9 +11527,11 @@ void wc_AesFree(Aes* aes)
     wc_MemZero_Check(aes, sizeof(Aes));
 #endif
 
+#ifndef WOLFSSL_NO_MALLOC
     if (isAllocated) {
         XFREE(aes, heap, DYNAMIC_TYPE_AES);
     }
+#endif
 
 }
 

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -11451,14 +11451,18 @@ int wc_AesInit_Label(Aes* aes, const char* label, void* heap, int devId)
 void wc_AesFree(Aes* aes)
 {
     void* heap;
+#ifndef WOLFSSL_NO_MALLOC
     byte isAllocated;
+#endif
 
     if (aes == NULL) {
         return;
     }
 
+#ifndef WOLFSSL_NO_MALLOC
     heap = aes->heap;
     isAllocated = aes->isAllocated;
+#endif
 
 #ifdef WC_DEBUG_CIPHER_LIFECYCLE
     (void)wc_debug_CipherLifecycleFree(&aes->CipherLifecycleTag, heap, 1);
@@ -11532,6 +11536,7 @@ void wc_AesFree(Aes* aes)
         XFREE(aes, heap, DYNAMIC_TYPE_AES);
     }
 #endif
+    (void)heap;
 
 }
 

--- a/wolfcrypt/src/ed25519.c
+++ b/wolfcrypt/src/ed25519.c
@@ -1026,13 +1026,16 @@ int wc_ed25519_init(ed25519_key* key)
 void wc_ed25519_free(ed25519_key* key)
 {
     void* heap;
+#ifndef WOLFSSL_NO_MALLOC
     byte isAllocated = 0;
-
+#endif
     if (key == NULL)
         return;
 
+#ifndef WOLFSSL_NO_MALLOC
     heap = key->heap;
     isAllocated = key->isAllocated;
+#endif
 
 #ifdef WOLFSSL_ED25519_PERSISTENT_SHA
     ed25519_hash_free(key, &key->sha);
@@ -1050,9 +1053,9 @@ void wc_ed25519_free(ed25519_key* key)
 #ifndef WOLFSSL_NO_MALLOC
     if (isAllocated) {
         XFREE(key, heap, DYNAMIC_TYPE_ED25519);
-        (void)heap;
     }
 #endif
+    (void)heap;
 
 }
 

--- a/wolfcrypt/src/ed25519.c
+++ b/wolfcrypt/src/ed25519.c
@@ -968,6 +968,7 @@ int wc_ed25519ph_verify_msg(const byte* sig, word32 sigLen, const byte* msg,
 }
 #endif /* HAVE_ED25519_VERIFY */
 
+#ifndef WOLFSSL_NO_MALLOC
 ed25519_key* wc_ed25519_new(void* heap, int devId)
 {
     ed25519_key* key = (ed25519_key*)XMALLOC(sizeof(ed25519_key), heap,
@@ -983,6 +984,7 @@ ed25519_key* wc_ed25519_new(void* heap, int devId)
     }
     return key;
 }
+#endif
 
 /* initialize information and memory for key */
 int wc_ed25519_init_ex(ed25519_key* key, void* heap, int devId)
@@ -1045,10 +1047,13 @@ void wc_ed25519_free(ed25519_key* key)
     wc_MemZero_Check(key, sizeof(ed25519_key));
 #endif
 
+#ifndef WOLFSSL_NO_MALLOC
     if (isAllocated) {
         XFREE(key, heap, DYNAMIC_TYPE_ED25519);
         (void)heap;
     }
+#endif
+
 }
 
 

--- a/wolfcrypt/src/hash.c
+++ b/wolfcrypt/src/hash.c
@@ -712,7 +712,9 @@ int wc_HashInit_ex(wc_HashAlg* hash, enum wc_HashType type, void* heap,
     if (hash == NULL)
         return BAD_FUNC_ARG;
 
+#ifndef WOLFSSL_NO_MALLOC
     hash->isAllocated = 0;
+#endif
     hash->type = type;
 
     switch (type) {
@@ -1044,10 +1046,12 @@ int wc_HashFree(wc_HashAlg* hash, enum wc_HashType type)
 {
     int ret = WC_NO_ERR_TRACE(HASH_TYPE_E); /* Default to hash type error */
     void* heap = NULL;
+#ifndef WOLFSSL_NO_MALLOC
     byte isAllocated = 0;
-
+#endif
     if (hash == NULL)
         return BAD_FUNC_ARG;
+
 
 #ifdef DEBUG_WOLFSSL
     if (hash->type != type) {
@@ -1056,7 +1060,9 @@ int wc_HashFree(wc_HashAlg* hash, enum wc_HashType type)
     }
 #endif
 
+#ifndef WOLFSSL_NO_MALLOC
     isAllocated = hash->isAllocated;
+#endif
 
     switch (type) {
         case WC_HASH_TYPE_MD5:
@@ -1175,9 +1181,9 @@ int wc_HashFree(wc_HashAlg* hash, enum wc_HashType type)
 #ifndef WOLFSSL_NO_MALLOC
     if (isAllocated) {
         XFREE(hash, heap, DYNAMIC_TYPE_HASHES);
-        (void)heap;
     }
 #endif
+    (void)heap;
 
     return ret;
 }

--- a/wolfcrypt/src/hash.c
+++ b/wolfcrypt/src/hash.c
@@ -686,6 +686,7 @@ int wc_Hash(enum wc_HashType hash_type, const byte* data,
         NULL, INVALID_DEVID);
 }
 
+#ifndef WOLFSSL_NO_MALLOC
 wc_HashAlg* wc_HashNew(enum wc_HashType type, void* heap, int devId)
 {
     wc_HashAlg* hash = (wc_HashAlg*)XMALLOC(sizeof(wc_HashAlg), heap,
@@ -701,6 +702,7 @@ wc_HashAlg* wc_HashNew(enum wc_HashType type, void* heap, int devId)
     }
     return hash;
 }
+#endif
 
 int wc_HashInit_ex(wc_HashAlg* hash, enum wc_HashType type, void* heap,
     int devId)
@@ -1170,10 +1172,12 @@ int wc_HashFree(wc_HashAlg* hash, enum wc_HashType type)
             ret = BAD_FUNC_ARG;
     };
 
+#ifndef WOLFSSL_NO_MALLOC
     if (isAllocated) {
         XFREE(hash, heap, DYNAMIC_TYPE_HASHES);
         (void)heap;
     }
+#endif
 
     return ret;
 }

--- a/wolfssl/wolfcrypt/sha.h
+++ b/wolfssl/wolfcrypt/sha.h
@@ -151,8 +151,8 @@ struct wc_Sha {
     #else
     word32  digest[WC_SHA_DIGEST_SIZE / sizeof(word32)];
     #endif
-    void*   heap;
 #endif
+    void*   heap;
 #ifdef WOLFSSL_PIC32MZ_HASH
     hashUpdCache cache; /* cache for updates */
 #endif

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -194,13 +194,13 @@ struct wc_Sha256 {
     word32  buffLen;   /* in bytes          */
     word32  loLen;     /* length in bytes   */
     word32  hiLen;     /* length in bytes   */
-    void*   heap;
 
 #ifdef WC_C_DYNAMIC_FALLBACK
     int sha_method;
 #endif
 
 #endif
+    void*   heap;
 #ifdef WOLFSSL_PIC32MZ_HASH
     hashUpdCache cache; /* cache for updates */
 #endif

--- a/wolfssl/wolfcrypt/sha512.h
+++ b/wolfssl/wolfcrypt/sha512.h
@@ -144,6 +144,7 @@ struct wc_Sha512 {
     cy_stc_crypto_sha_state_t hash_state;
     cy_en_crypto_sha_mode_t sha_mode;
     cy_stc_crypto_v2_sha512_buffers_t sha_buffers;
+    void*   heap;
 #else
     word64  digest[WC_SHA512_DIGEST_SIZE / sizeof(word64)];
     word64  buffer[WC_SHA512_BLOCK_SIZE  / sizeof(word64)];

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -943,7 +943,8 @@ typedef struct w64wrapper {
         WOLFSSL_API int wc_strncasecmp(const char *s1, const char *s2, size_t n);
     #endif
 
-    #if !defined(XSTRDUP) && !defined(USE_WOLF_STRDUP)
+    #if !defined(XSTRDUP) && !defined(USE_WOLF_STRDUP) &&\
+            !defined (WOLFSSL_NO_MALLOC)
         #define USE_WOLF_STRDUP
     #endif
     #ifdef USE_WOLF_STRDUP


### PR DESCRIPTION
# Description

A few malloc calls added since the last release are preventing simple builds with nostdlib, e.g. using WOLFCRYPT_ONLY and WOLFSSL_NO_MALLOC.

# Testing

Spotted while updating submodules in wolfboot:
https://github.com/wolfSSL/wolfBoot/actions/runs/11247180283/job/31270223935?pr=507

