### PR TITLE
ocsp: propagate ocsp cb return error

### DIFF
--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -536,6 +536,9 @@ int CheckOcspRequest(WOLFSSL_OCSP* ocsp, OcspRequest* ocspRequest,
     if (responseSz == WC_NO_ERR_TRACE(WOLFSSL_CBIO_ERR_WANT_READ)) {
         ret = OCSP_WANT_READ;
     }
+    else if (responseSz == WC_NO_ERR_TRACE(WOLFSSL_CBIO_ERR_TIMEOUT)){
+        ret = HTTP_TIMEOUT;
+    }
 
     XFREE(request, ocsp->cm->heap, DYNAMIC_TYPE_OCSP);
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -92179,7 +92179,7 @@ static int test_override_alt_cert_chain_ocsp_cb(void* ioCtx, const char* url,
     (void)request;
     (void)requestSz;
     (void)response;
-    return -1;
+    return WOLFSSL_CBIO_ERR_GENERAL;
 }
 
 static int test_override_alt_cert_chain_client_ctx_ready(WOLFSSL_CTX* ctx)
@@ -96685,7 +96685,7 @@ static int test_ocsp_callback_fails_cb(void* ctx, const char* url, int urlSz,
     (void)ocspReqBuf;
     (void)ocspReqSz;
     (void)ocspRespBuf;
-    return -1;
+    return WOLFSSL_CBIO_ERR_GENERAL;
 }
 static int test_ocsp_callback_fails(void)
 {


### PR DESCRIPTION
# Description

The error returned from OCSP cb is not propagated.
Propagating the error allows the verify callback to adopt a custom fallback policy regarding the error.

This is unfortunately a breaking change in this scenario:
- custom cb return a negative value different than OCSP_INVALID_STATUS
- verify cb relies on OCSP_INVALID_STATUS ret error.


