### PR TITLE
Libnds : Added more descriptive README for IDE/NDS and MelonDS C-flag

### DIFF
--- a/IDE/NDS/README.md
+++ b/IDE/NDS/README.md
@@ -2,11 +2,34 @@
 
 ## Requirements
 
-[Devkitpro](https://devkitpro.org/wiki/Getting_Started) with libnds.
+[Devkitpro](https://devkitpro.org/wiki/Getting_Started) with libnds, nds-tool and nds-dev.
 
 
 ## Building
 
+For MelonDS
+```
+$ ./configure \
+    --host=arm-none-eabi \
+    CC=$DEVKITARM/bin/arm-none-eabi-g++ \
+    AR=$DEVKITARM/bin/arm-none-eabi-ar \
+    STRIP=$DEVKITARM/bin/arm-none-eabi-strip \
+    RANLIB=$DEVKITARM/bin/arm-none-eabi-ranlib \
+    LIBS="-lfat -lnds9" \
+    LDFLAGS="-L/opt/devkitpro/libnds/lib" \
+    --prefix=$DEVKITPRO/portlibs/nds \
+    CFLAGS="-march=armv5te -mtune=arm946e-s \
+        --specs=ds_arm9.specs -DARM9 -DWOLFSSL_NDS \
+        -DWOLFSSL_MELONDS \
+        -DWOLFSSL_USER_IO \
+        -I$DEVKITPRO/libnds/include" \
+    --enable-fastmath --disable-benchmark \
+    --disable-shared --disable-examples --disable-ecc
+$ make
+$ sudo make install
+```
+
+For Hardware
 ```
 $ ./configure \
     --host=arm-none-eabi \
@@ -30,7 +53,58 @@ $ sudo make install
 ## Run the Tests
 
 To run the Crypttests type the following.
-1. Run `$ ndstool -9 ./wolfcrypt/test/testwolfcrypt  -c ./wolfcrypt/test/testwolfcrypt.nds`
-2. copy `./certs` to `your_nds_sd_card/_nds/certs`
+Run `$ ndstool -9 ./wolfcrypt/test/testwolfcrypt  -c ./wolfcrypt/test/testwolfcrypt.nds`
 
-3. Run the Rom (located in ./wolfcrypt/test/testwolfcrypt.nds) in an Emulator or real Hardware.
+copy `./certs` to `your_nds_sd_card/_nds/certs` (Follow Virtual SD card steps below for Emulator)
+
+Run the Rom (located in ./wolfcrypt/test/testwolfcrypt.nds) in an Emulator or real Hardware.
+
+If running on MelonDS it must be using the DSi mode in order to use certs from an SD card.
+
+## Making a virtual SD card (MacOS)
+
+```
+Create Virtual SD card image
+
+$ dd if=/dev/zero of=~/my_sd_card.img bs=1M count=64
+
+Format image to FAT32
+
+$ hdiutil attach -imagekey diskimage-class=CRawDiskImage -nomount ~/my_sd_card.img
+$ diskutil eraseDisk FAT32 MYSDCARD MBRFormat /dev/diskX
+$ hdiutil detach /dev/diskX
+
+Mount to Create Folder Structure and Copy Certs
+
+$ mkdir -p /Volumes/MYSDCARD/_nds
+$ cp -r ~/wolfssl/certs /Volumes/MYSDCARD/_nds/
+
+Unmount
+
+hdiutil detach /dev/diskX
+```
+
+## Making a virtual SD card (Linux)
+
+```
+Create Virtual SD card image
+
+$ dd if=/dev/zero of=~/my_sd_card.img bs=1M count=64
+
+Format image to FAT32
+
+$ sudo losetup -fP ~/my_sd_card.img
+$ sudo losetup -l
+$ sudo mkfs.vfat -F 32 /dev/loop0
+$ sudo losetup -d /dev/loop0
+
+Mount to Create Folder Structure and Copy Certs
+
+$ sudo mount ~/my_sd_card.img /mnt
+$ sudo mkdir -p /mnt/_nds
+$ sudo cp -r ~/wolfssl/certs /mnt/_nds/
+
+Unmount
+
+hdiutil detach /dev/diskX
+```

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -18114,7 +18114,11 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t memory_test(void)
     #define CERT_PATH_SEP "\\"
 #elif defined(WOLFSSL_NDS)
     #undef CERT_PREFIX
-    #define CERT_PREFIX "fat:/_nds/"
+    #ifndef WOLFSSL_MELONDS
+        #define CERT_PREFIX "fat:/_nds/"
+    #else
+        #define CERT_PREFIX "_nds/"
+    #endif
     #define CERT_PATH_SEP "/"
 #endif
 


### PR DESCRIPTION
# Description

Updated libnds (IDE/NDS) README for DS emulation. Included configuration for hardware or an emulator, this includes an added C-flag in wolf crypt/test/test.c to differentiates between hardware and emulation.


# Testing

Ran test.c on MelonDS and all tests passed. As well as made sure it failed when emulation flag wasn't thrown.
