### PR TITLE
Let script setup.sh exit 0 when job is done

### DIFF
--- a/IDE/Espressif/ESP-IDF/setup.sh
+++ b/IDE/Espressif/ESP-IDF/setup.sh
@@ -159,4 +159,3 @@ if [ "${WOLFSSL_SETUP_VERBOSE}" == "true" ]; then
   echo "Copy complete!"
 fi
 
-exit 1


### PR DESCRIPTION
# Description

When the ESP-IDF setup process terminates successfully, it seems more intuitive to let the script "setup.sh" `exit 0` to indicate success. It would also help avoid breakage when invoking the script in automation.

# Testing

Run the following commands

```bash
source /PATH/TO/ESP-IDF/export.sh
cd wolfssl/IDE/Espressif/ESP-IDF/
./setup.sh
echo $? # Should return 0 
```
# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
