### PR TITLE
Regression test fixes

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -834,7 +834,9 @@ exit_chain:
                                  (const char*)data, len, 0, ret);
     }
 
-    XFREE(frmt, front->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    if (front != NULL) {
+        XFREE(frmt, front->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
 
 #ifdef WOLFSSL_BASE64_ENCODE
     if (retB64 > 0 && ret > 0)

--- a/src/internal.c
+++ b/src/internal.c
@@ -6849,10 +6849,14 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         if (ssl->buffers.key != NULL) {
             FreeDer(&ssl->buffers.key);
         }
-        AllocCopyDer(&ssl->buffers.key, ctx->privateKey->buffer,
+        ret = AllocCopyDer(&ssl->buffers.key, ctx->privateKey->buffer,
             ctx->privateKey->length, ctx->privateKey->type,
             ctx->privateKey->heap);
+        if (ret != 0) {
+            return ret;
+        }
         ssl->buffers.weOwnKey = 1;
+        ret = WOLFSSL_SUCCESS;
     }
     else {
         ssl->buffers.key      = ctx->privateKey;
@@ -6862,9 +6866,12 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
 #endif
 #else
     if (ctx->privateKey != NULL) {
-        AllocCopyDer(&ssl->buffers.key, ctx->privateKey->buffer,
+        ret = AllocCopyDer(&ssl->buffers.key, ctx->privateKey->buffer,
             ctx->privateKey->length, ctx->privateKey->type,
             ctx->privateKey->heap);
+        if (ret != 0) {
+            return ret;
+        }
         ssl->buffers.weOwnKey = 1;
         /* Blind the private key for the SSL with new random mask. */
         wolfssl_priv_der_unblind(ssl->buffers.key, ctx->privateKeyMask);
@@ -6885,9 +6892,12 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
     ssl->buffers.altKey   = ctx->altPrivateKey;
 #else
     if (ctx->altPrivateKey != NULL) {
-        AllocCopyDer(&ssl->buffers.altkey, ctx->altPrivateKey->buffer,
+        ret = AllocCopyDer(&ssl->buffers.altkey, ctx->altPrivateKey->buffer,
             ctx->altPrivateKey->length, ctx->altPrivateKey->type,
             ctx->altPrivateKey->heap);
+        if (ret != 0) {
+            return ret;
+        }
         /* Blind the private key for the SSL with new random mask. */
         wolfssl_priv_der_unblind(ssl->buffers.altKey, ctx->altPrivateKeyMask);
         ret = wolfssl_priv_der_blind(ssl->rng, ssl->buffers.altKey,
@@ -6895,6 +6905,7 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         if (ret != 0) {
             return ret;
         }
+        ret = WOLFSSL_SUCCESS;
     }
 #endif
     ssl->buffers.altKeyType  = ctx->altPrivateKeyType;

--- a/src/ssl_asn1.c
+++ b/src/ssl_asn1.c
@@ -580,6 +580,7 @@ static void* d2i_generic(const WOLFSSL_ASN1_TEMPLATE* mem,
     if (impBuf != NULL) {
         tmp = *src + (tmp - impBuf); /* for the next calculation */
         XFREE(impBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        impBuf = NULL;
     }
     if (asnLen >= 0 && (int)(tmp - *src) != asnLen) {
         WOLFSSL_MSG("ptr not advanced enough");

--- a/src/x509.c
+++ b/src/x509.c
@@ -562,7 +562,6 @@ static int wolfssl_dns_entry_othername_to_gn(DNS_entry* dns,
     /* Create a WOLFSSL_ASN1_STRING from the DER. */
     str = wolfSSL_ASN1_STRING_type_new(tag);
     if (str == NULL) {
-        wolfSSL_ASN1_OBJECT_free(obj);
         goto err;
     }
     wolfSSL_ASN1_STRING_set(str, p, (int)len);
@@ -15431,12 +15430,14 @@ int wolfSSL_X509_REQ_add1_attr_by_NID(WOLFSSL_X509 *req,
                 req->reqAttributes->type = STACK_TYPE_X509_REQ_ATTR;
             }
         }
-        if (req->reqAttributes->type == STACK_TYPE_X509_REQ_ATTR) {
+        if ((req->reqAttributes != NULL) &&
+                (req->reqAttributes->type == STACK_TYPE_X509_REQ_ATTR)) {
             ret = wolfSSL_sk_push(req->reqAttributes, attr) > 0
                     ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
         }
-        else
+        else {
             ret = WOLFSSL_FAILURE;
+        }
         if (ret != WOLFSSL_SUCCESS)
             wolfSSL_X509_ATTRIBUTE_free(attr);
     }

--- a/tests/api.c
+++ b/tests/api.c
@@ -34819,15 +34819,6 @@ static int test_wc_dilithium_der(void)
     ExpectIntEQ(len = wc_Dilithium_PublicKeyToDer(key, der,
         DILITHIUM_MAX_DER_SIZE, 1), pubDerLen);
     idx = 0;
-{
-    fprintf(stderr, "\n");
-    for (int ii = 0; ii < pubDerLen; ii++) {
-        if ((ii % 8) == 0) fprintf(stderr, "    ");
-        fprintf(stderr, "0x%02x,", der[ii]);
-        if ((ii % 8) == 7) fprintf(stderr, "\n");
-        else               fprintf(stderr, " ");
-    }
-}
     ExpectIntEQ(wc_Dilithium_PublicKeyDecode(der, &idx, key, len), 0);
 
     ExpectIntEQ(len = wc_Dilithium_PrivateKeyToDer(key, der,
@@ -49034,6 +49025,7 @@ static int test_wc_PKCS7_EncodeSignedData(void)
     word32 badOutSz = 0;
     byte   data[] = "Test data to encode.";
 #ifndef NO_RSA
+    int    encryptOid = RSAk;
     #if defined(USE_CERT_BUFFERS_2048)
         byte        key[sizeof(client_key_der_2048)];
         byte        cert[sizeof(client_cert_der_2048)];
@@ -49076,6 +49068,7 @@ static int test_wc_PKCS7_EncodeSignedData(void)
             XFCLOSE(fp);
     #endif
 #elif defined(HAVE_ECC)
+    int    encryptOid = ECDSAk;
     #if defined(USE_CERT_BUFFERS_256)
         unsigned char    cert[sizeof(cliecc_cert_der_256)];
         unsigned char    key[sizeof(ecc_clikey_der_256)];
@@ -49123,7 +49116,7 @@ static int test_wc_PKCS7_EncodeSignedData(void)
         pkcs7->contentSz = (word32)sizeof(data);
         pkcs7->privateKey = key;
         pkcs7->privateKeySz = (word32)sizeof(key);
-        pkcs7->encryptOID = RSAk;
+        pkcs7->encryptOID = encryptOid;
     #ifdef NO_SHA
         pkcs7->hashOID = SHA256h;
     #else
@@ -49140,8 +49133,9 @@ static int test_wc_PKCS7_EncodeSignedData(void)
     ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, NULL, 0), 0);
     ExpectIntEQ(wc_PKCS7_VerifySignedData(pkcs7, output, outputSz), 0);
 
-#ifdef ASN_BER_TO_DER
+#if defined(ASN_BER_TO_DER) && !defined(NO_RSA)
     wc_PKCS7_Free(pkcs7);
+    pkcs7 = NULL;
 
     /* reinitialize and test setting stream mode */
     {
@@ -49158,7 +49152,7 @@ static int test_wc_PKCS7_EncodeSignedData(void)
             pkcs7->contentSz = (word32)sizeof(data);
             pkcs7->privateKey = key;
             pkcs7->privateKeySz = (word32)sizeof(key);
-            pkcs7->encryptOID = RSAk;
+            pkcs7->encryptOID = encryptOid;
         #ifdef NO_SHA
             pkcs7->hashOID = SHA256h;
         #else
@@ -49181,7 +49175,8 @@ static int test_wc_PKCS7_EncodeSignedData(void)
         ExpectIntEQ(wc_PKCS7_InitWithCert(pkcs7, NULL, 0), 0);
 
         /* use exact signed buffer size since BER encoded */
-        ExpectIntEQ(wc_PKCS7_VerifySignedData(pkcs7, output, (word32)signedSz), 0);
+        ExpectIntEQ(wc_PKCS7_VerifySignedData(pkcs7, output, (word32)signedSz),
+            0);
         wc_PKCS7_Free(pkcs7);
 
         /* now try with using callbacks for IO */
@@ -49194,7 +49189,7 @@ static int test_wc_PKCS7_EncodeSignedData(void)
             pkcs7->contentSz  = FOURK_BUF*2;
             pkcs7->privateKey = key;
             pkcs7->privateKeySz = (word32)sizeof(key);
-            pkcs7->encryptOID = RSAk;
+            pkcs7->encryptOID = encryptOid;
         #ifdef NO_SHA
             pkcs7->hashOID = SHA256h;
         #else
@@ -51551,10 +51546,10 @@ static int test_wc_PKCS7_BER(void)
     byte   decoded[2048];
 #endif
     word32 derSz = 0;
-#ifndef NO_PKCS7_STREAM
+#if !defined(NO_PKCS7_STREAM) && !defined(NO_RSA)
     word32 z;
     int ret;
-#endif /* !NO_PKCS7_STREAM */
+#endif /* !NO_PKCS7_STREAM && !NO_RSA */
 
     ExpectTrue((f = XFOPEN(fName, "rb")) != XBADFILE);
     ExpectTrue((derSz = (word32)XFREAD(der, 1, sizeof(der), f)) > 0);
@@ -54923,8 +54918,14 @@ static int test_wolfSSL_IMPLEMENT_ASN1_FUNCTIONS(void)
         group_obj = OBJ_nid2obj(NID_secp256k1);
         ExpectIntEQ(X509_ALGOR_set0(nested_asn1->key->alg, ec_obj,
                 V_ASN1_OBJECT, group_obj), 1);
-        ec_obj = NULL;
-        group_obj = NULL;
+        if (EXPECT_SUCCESS()) {
+            ec_obj = NULL;
+            group_obj = NULL;
+        }
+        else {
+            wolfSSL_ASN1_OBJECT_free(ec_obj);
+            wolfSSL_ASN1_OBJECT_free(group_obj);
+        }
         ExpectIntEQ(ASN1_BIT_STRING_set_bit(nested_asn1->key->pub_key, 50, 1),
                 1);
         /* nested_asn1->asn1_obj->key */
@@ -54932,8 +54933,14 @@ static int test_wolfSSL_IMPLEMENT_ASN1_FUNCTIONS(void)
         group_obj = OBJ_nid2obj(NID_secp256k1);
         ExpectIntEQ(X509_ALGOR_set0(nested_asn1->asn1_obj->key->alg, ec_obj,
                 V_ASN1_OBJECT, group_obj), 1);
-        ec_obj = NULL;
-        group_obj = NULL;
+        if (EXPECT_SUCCESS()) {
+            ec_obj = NULL;
+            group_obj = NULL;
+        }
+        else {
+            wolfSSL_ASN1_OBJECT_free(ec_obj);
+            wolfSSL_ASN1_OBJECT_free(group_obj);
+        }
         ExpectIntEQ(ASN1_BIT_STRING_set_bit(nested_asn1->asn1_obj->key->pub_key,
                 500, 1), 1);
         /* nested_asn1->asn1_obj->asnNum */
@@ -54951,13 +54958,18 @@ static int test_wolfSSL_IMPLEMENT_ASN1_FUNCTIONS(void)
             ExpectIntGT(
                     sk_ASN1_GENERALSTRING_push(nested_asn1->asn1_obj->strList,
                             genStr), 0);
+            if (EXPECT_FAIL()) {
+                ASN1_GENERALSTRING_free(genStr);
+            }
         }
         /* nested_asn1->asn1_obj->str */
         ExpectNotNull(nested_asn1->asn1_obj->str->d.str2
                 = ASN1_BIT_STRING_new());
         ExpectIntEQ(ASN1_BIT_STRING_set_bit(nested_asn1->asn1_obj->str->d.str2,
                 150, 1), 1);
-        nested_asn1->asn1_obj->str->type = 2;
+        if (nested_asn1 != NULL) {
+            nested_asn1->asn1_obj->str->type = 2;
+        }
 
         der = NULL;
         ExpectIntEQ(i2d_TEST_ASN1_NEST2(nested_asn1, &der), 285);
@@ -54988,6 +55000,9 @@ static int test_wolfSSL_IMPLEMENT_ASN1_FUNCTIONS(void)
             ExpectNotNull(asn1_num = ASN1_INTEGER_new());
             ExpectIntEQ(ASN1_INTEGER_set(asn1_num, i), 1);
             ExpectIntGT(wolfSSL_sk_insert(asn1_item, asn1_num, -1), 0);
+            if (EXPECT_FAIL()) {
+                ASN1_INTEGER_free(asn1_num);
+            }
         }
 
         der = NULL;
@@ -55027,6 +55042,9 @@ static int test_wolfSSL_i2d_ASN1_TYPE(void)
         ExpectNotNull(str = ASN1_STRING_type_new(V_ASN1_SEQUENCE));
         ExpectIntEQ(ASN1_STRING_set(str, str_bin, sizeof(str_bin)), 1);
         ExpectNotNull(asn1type = ASN1_TYPE_new());
+        if (EXPECT_FAIL()) {
+            ASN1_STRING_free(str);
+        }
         ASN1_TYPE_set(asn1type, V_ASN1_SEQUENCE, str);
     }
 
@@ -61460,6 +61478,7 @@ static int test_wolfSSL_BN_enc_dec(void)
 
     ExpectNotNull(BN_bin2bn(NULL, sizeof(binNum), a));
     BN_free(a);
+    a = NULL;
     ExpectNotNull(a = BN_new());
     ExpectIntEQ(BN_set_word(a, 2), 1);
     ExpectNull(BN_bin2bn(binNum, -1, a));
@@ -65547,7 +65566,9 @@ static int test_wolfSSL_ERR_print_errors(void)
     defined(DEBUG_WOLFSSL)
 static int test_wolfSSL_error_cb(const char *str, size_t len, void *u)
 {
-    wolfSSL_BIO_write((BIO*)u, str, (int)len);
+    if (u != NULL) {
+        wolfSSL_BIO_write((BIO*)u, str, (int)len);
+    }
     return 0;
 }
 #endif
@@ -68330,7 +68351,7 @@ static int test_GENERAL_NAME_set0_othername(void) {
     defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_REQ) && \
     defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ALT_NAMES) && \
     defined(WOLFSSL_CERT_EXT) && !defined(NO_FILESYSTEM) && \
-    defined(WOLFSSL_FPKI)
+    defined(WOLFSSL_FPKI) && !defined(NO_RSA)
     /* ./configure --enable-opensslall --enable-certgen --enable-certreq
      *  --enable-certext --enable-debug 'CPPFLAGS=-DWOLFSSL_CUSTOM_OID
      *  -DWOLFSSL_ALT_NAMES  -DWOLFSSL_FPKI' */
@@ -68414,7 +68435,7 @@ static int test_othername_and_SID_ext(void) {
     defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_REQ) && \
     defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ALT_NAMES) && \
     defined(WOLFSSL_CERT_EXT) && !defined(NO_FILESYSTEM) && \
-    defined(WOLFSSL_FPKI) && defined(WOLFSSL_ASN_TEMPLATE)
+    defined(WOLFSSL_FPKI) && defined(WOLFSSL_ASN_TEMPLATE) && !defined(NO_RSA)
     /* ./configure --enable-opensslall --enable-certgen --enable-certreq
      *  --enable-certext --enable-debug 'CPPFLAGS=-DWOLFSSL_CUSTOM_OID
      *  -DWOLFSSL_ALT_NAMES  -DWOLFSSL_FPKI' */
@@ -68526,6 +68547,7 @@ static int test_othername_and_SID_ext(void) {
     exts = NULL;
     ASN1_OBJECT_free(upn_oid);
     ASN1_OBJECT_free(sid_oid);
+    sid_oid = NULL;
     ASN1_OCTET_STRING_free(sid_data);
     X509_REQ_free(x509);
     EVP_PKEY_free(priv);
@@ -75539,7 +75561,8 @@ static int test_wolfSSL_OCSP_parse_url(void)
 }
 
 #if defined(OPENSSL_ALL) && defined(HAVE_OCSP) && \
-    defined(WOLFSSL_SIGNER_DER_CERT) && !defined(NO_FILESYSTEM)
+    defined(WOLFSSL_SIGNER_DER_CERT) && !defined(NO_FILESYSTEM) && \
+    !defined(NO_ASN_TIME)
 static time_t test_wolfSSL_OCSP_REQ_CTX_time_cb(time_t* t)
 {
     if (t != NULL) {
@@ -75761,10 +75784,12 @@ static int test_wolfSSL_OCSP_REQ_CTX(void)
     ExpectIntEQ(OCSP_sendreq_nbio(&rsp, ctx), -1);
     ExpectIntEQ(BIO_write(bio2, ocspRespBin, sizeof(ocspRespBin)),
             sizeof(ocspRespBin));
+#ifndef NO_ASN_TIME
     ExpectIntEQ(wc_SetTimeCb(test_wolfSSL_OCSP_REQ_CTX_time_cb), 0);
     ExpectIntEQ(OCSP_sendreq_nbio(&rsp, ctx), 1);
     ExpectIntEQ(wc_SetTimeCb(NULL), 0);
     ExpectNotNull(rsp);
+#endif
 
     OCSP_REQ_CTX_free(ctx);
     OCSP_REQUEST_free(req);
@@ -82290,6 +82315,14 @@ static int test_wolfSSL_RSA(void)
         unsigned char hash[SHA256_DIGEST_LENGTH];
         unsigned char signature[2048/8];
         unsigned int signatureLen = 0;
+        BIGNUM* n2 = NULL;
+        BIGNUM* e2 = NULL;
+        BIGNUM* d2 = NULL;
+        BIGNUM* p2 = NULL;
+        BIGNUM* q2 = NULL;
+        BIGNUM* dmp12 = NULL;
+        BIGNUM* dmq12 = NULL;
+        BIGNUM* iqmp2 = NULL;
 
         XMEMSET(hash, 0, sizeof(hash));
         RSA_get0_key(rsa, &n, &e, &d);
@@ -82303,42 +82336,121 @@ static int test_wolfSSL_RSA(void)
             signatureLen, rsa), 1);
 
         /* Verifying */
+        ExpectNotNull(n2 = BN_dup(n));
+        ExpectNotNull(e2 = BN_dup(e));
+        ExpectNotNull(p2 = BN_dup(p));
+        ExpectNotNull(q2 = BN_dup(q));
+        ExpectNotNull(dmp12 = BN_dup(dmp1));
+        ExpectNotNull(dmq12 = BN_dup(dmq1));
+        ExpectNotNull(iqmp2 = BN_dup(iqmp));
+
         ExpectNotNull(rsa2 = RSA_new());
-        ExpectIntEQ(RSA_set0_key(rsa2, BN_dup(n), BN_dup(e), NULL), 1);
+        ExpectIntEQ(RSA_set0_key(rsa2, n2, e2, NULL), 1);
+        if (EXPECT_SUCCESS()) {
+            n2 = NULL;
+            e2 = NULL;
+        }
         ExpectIntEQ(RSA_verify(NID_sha256, hash, sizeof(hash), signature,
             signatureLen, rsa2), 1);
-        ExpectIntEQ(RSA_set0_factors(rsa2, BN_dup(p), BN_dup(q)), 1);
+        ExpectIntEQ(RSA_set0_factors(rsa2, p2, q2), 1);
+        if (EXPECT_SUCCESS()) {
+            p2 = NULL;
+            q2 = NULL;
+        }
         ExpectIntEQ(RSA_verify(NID_sha256, hash, sizeof(hash), signature,
             signatureLen, rsa2), 1);
-        ExpectIntEQ(RSA_set0_crt_params(rsa2, BN_dup(dmp1), BN_dup(dmq1),
-                BN_dup(iqmp)), 1);
+        ExpectIntEQ(RSA_set0_crt_params(rsa2, dmp12, dmq12, iqmp2), 1);
+        if (EXPECT_SUCCESS()) {
+            dmp12 = NULL;
+            dmq12 = NULL;
+            iqmp2 = NULL;
+        }
         ExpectIntEQ(RSA_verify(NID_sha256, hash, sizeof(hash), signature,
             signatureLen, rsa2), 1);
         RSA_free(rsa2);
         rsa2 = NULL;
 
+        BN_free(iqmp2);
+        iqmp2 = NULL;
+        BN_free(dmq12);
+        dmq12 = NULL;
+        BN_free(dmp12);
+        dmp12 = NULL;
+        BN_free(q2);
+        q2 = NULL;
+        BN_free(p2);
+        p2 = NULL;
+        BN_free(e2);
+        e2 = NULL;
+        BN_free(n2);
+        n2 = NULL;
+
+        ExpectNotNull(n2 = BN_dup(n));
+        ExpectNotNull(e2 = BN_dup(e));
+        ExpectNotNull(d2 = BN_dup(d));
+        ExpectNotNull(p2 = BN_dup(p));
+        ExpectNotNull(q2 = BN_dup(q));
+        ExpectNotNull(dmp12 = BN_dup(dmp1));
+        ExpectNotNull(dmq12 = BN_dup(dmq1));
+        ExpectNotNull(iqmp2 = BN_dup(iqmp));
+
         /* Signing */
         XMEMSET(signature, 0, sizeof(signature));
         ExpectNotNull(rsa2 = RSA_new());
-        ExpectIntEQ(RSA_set0_key(rsa2, BN_dup(n), BN_dup(e), BN_dup(d)), 1);
+        ExpectIntEQ(RSA_set0_key(rsa2, n2, e2, d2), 1);
+        if (EXPECT_SUCCESS()) {
+            n2 = NULL;
+            e2 = NULL;
+            d2 = NULL;
+        }
+#if defined(WOLFSSL_SP_MATH) && !defined(RSA_LOW_MEM)
+        /* SP is not support signing without CRT parameters. */
+        ExpectIntEQ(RSA_sign(NID_sha256, hash, sizeof(hash), signature,
+            &signatureLen, rsa2), 0);
+        ExpectIntEQ(RSA_set0_factors(rsa2, p2, q2), 1);
+        if (EXPECT_SUCCESS()) {
+            p2 = NULL;
+            q2 = NULL;
+        }
+        ExpectIntEQ(RSA_sign(NID_sha256, hash, sizeof(hash), signature,
+            &signatureLen, rsa2), 0);
+#else
         ExpectIntEQ(RSA_sign(NID_sha256, hash, sizeof(hash), signature,
             &signatureLen, rsa2), 1);
         ExpectIntEQ(RSA_verify(NID_sha256, hash, sizeof(hash), signature,
             signatureLen, rsa), 1);
-        ExpectIntEQ(RSA_set0_factors(rsa2, BN_dup(p), BN_dup(q)), 1);
+        ExpectIntEQ(RSA_set0_factors(rsa2, p2, q2), 1);
+        if (EXPECT_SUCCESS()) {
+            p2 = NULL;
+            q2 = NULL;
+        }
         XMEMSET(signature, 0, sizeof(signature));
         ExpectIntEQ(RSA_sign(NID_sha256, hash, sizeof(hash), signature,
             &signatureLen, rsa2), 1);
         ExpectIntEQ(RSA_verify(NID_sha256, hash, sizeof(hash), signature,
             signatureLen, rsa), 1);
-        ExpectIntEQ(RSA_set0_crt_params(rsa2, BN_dup(dmp1), BN_dup(dmq1),
-                BN_dup(iqmp)), 1);
+#endif
+        ExpectIntEQ(RSA_set0_crt_params(rsa2, dmp12, dmq12, iqmp2), 1);
+        if (EXPECT_SUCCESS()) {
+            dmp12 = NULL;
+            dmq12 = NULL;
+            iqmp2 = NULL;
+        }
         ExpectIntEQ(RSA_sign(NID_sha256, hash, sizeof(hash), signature,
             &signatureLen, rsa2), 1);
         ExpectIntEQ(RSA_verify(NID_sha256, hash, sizeof(hash), signature,
             signatureLen, rsa), 1);
         RSA_free(rsa2);
         rsa2 = NULL;
+
+        BN_free(iqmp2);
+        BN_free(dmq12);
+        BN_free(dmp12);
+        BN_free(q2);
+        BN_free(p2);
+        BN_free(d2);
+        BN_free(e2);
+        BN_free(n2);
     }
 #endif
 
@@ -92513,8 +92625,7 @@ static int test_tls13_rpk_handshake(void)
      *  expecting default settings works and no negotiation performed.
      */
 
-    if (test_memio_do_handshake(ssl_c, ssl_s, 10, NULL) != 0)
-        return TEST_FAIL;
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
 
     /* confirm no negotiation occurred */
     ExpectIntEQ(wolfSSL_get_negotiated_client_cert_type(ssl_c, &tp),
@@ -92571,8 +92682,7 @@ static int test_tls13_rpk_handshake(void)
      *  expecting default settings works and no negotiation performed.
      */
 
-    if (test_memio_do_handshake(ssl_c, ssl_s, 10, NULL) != 0)
-        return TEST_FAIL;
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
 
     /* confirm no negotiation occurred */
     ExpectIntEQ(wolfSSL_get_negotiated_client_cert_type(ssl_c, &tp),
@@ -92641,8 +92751,7 @@ static int test_tls13_rpk_handshake(void)
     ExpectIntEQ(wolfSSL_set_server_cert_type(ssl_s, certType_s, typeCnt_s),
                                                         WOLFSSL_SUCCESS);
 
-    if (test_memio_do_handshake(ssl_c, ssl_s, 10, NULL) != 0)
-        return TEST_FAIL;
+    ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
 
     ExpectIntEQ(wolfSSL_get_negotiated_client_cert_type(ssl_c, &tp),
                                                         WOLFSSL_SUCCESS);
@@ -94188,9 +94297,11 @@ static int test_dtls_client_hello_timeout_downgrade(void)
             /* Drop the SH */
             dtlsRH = (DtlsRecordLayerHeader*)(test_ctx.c_buff);
             len = (size_t)((dtlsRH->length[0] << 8) | dtlsRH->length[1]);
-            XMEMMOVE(test_ctx.c_buff, test_ctx.c_buff +
+            if (EXPECT_SUCCESS()) {
+                XMEMMOVE(test_ctx.c_buff, test_ctx.c_buff +
                     sizeof(DtlsRecordLayerHeader) + len, test_ctx.c_len -
                    (sizeof(DtlsRecordLayerHeader) + len));
+            }
             test_ctx.c_len -= sizeof(DtlsRecordLayerHeader) + len;
             /* Read the remainder of the flight */
             ExpectIntEQ(wolfSSL_negotiate(ssl_c), -1);
@@ -94219,9 +94330,11 @@ static int test_dtls_client_hello_timeout_downgrade(void)
             /* Drop the SH */
             dtlsRH = (DtlsRecordLayerHeader*)(test_ctx.c_buff);
             len = (size_t)((dtlsRH->length[0] << 8) | dtlsRH->length[1]);
-            XMEMMOVE(test_ctx.c_buff, test_ctx.c_buff +
+            if (EXPECT_SUCCESS()) {
+                XMEMMOVE(test_ctx.c_buff, test_ctx.c_buff +
                     sizeof(DtlsRecordLayerHeader) + len, test_ctx.c_len -
                    (sizeof(DtlsRecordLayerHeader) + len));
+            }
             test_ctx.c_len -= sizeof(DtlsRecordLayerHeader) + len;
             /* Read the remainder of the flight */
             ExpectIntEQ(wolfSSL_negotiate(ssl_c), -1);


### PR DESCRIPTION
# Description

Fix unit tests to not compile when NO_RSA is defined and RSA used.
test_wc_PKCS7_EncodeSignedData: only RSA supported with streaming.
test_wolfSSL_RSA when SP math and SP: CRT parameters required.
test_wolfSSL_OCSP_REQ_CTX to compile with NO_ASN_TIME.
test_wolfSSL_IMPLEMENT_ASN1_FUNCTIONS: make sure all objects freed even on memory allocation failure.
test_wolfSSL_error_cb: don't use bio if is NULL.
test_wolfSSL_BN_enc_dec: don't free a twice on memory allocation error.
test_wc_dilithium_der: remove debug printing
test_othername_and_SID_ext: make sid_oid NULL after free to ensure no double free on later memory allocation failure.
test_wolfSSL_RSA: don't leak when BN_dup fails.
test_wolfSSL_i2d_ASN1_TYPE: free ASN1 string whn no ASN1 type to put it into.
test_tls13_rpk_handshake: don't leak on failure
test_dtls_client_hello_timeout_downgrade: only move memory when test is succeeding.

wolfSSL_certs_clear, wolfSSL_set_SSL_CTX, SetSSL_CTX: Check return from AllocCopyDer.
d2i_generic: make sure impBuf is only freed once.
wolfSSL_BIO_write: don't dereference front unless it is not NULL.
wolfssl_dns_entry_othername_to_gn: don't free obj twice
wolfSSL_X509_REQ_add1_attr_by_NID: don't access reqAttributes if NULL.


# Testing

Memory allocation failure testing.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
