### PR TITLE
Apply various Espressif compatibility updates

### DIFF
--- a/wolfcrypt/src/port/Espressif/esp32_aes.c
+++ b/wolfcrypt/src/port/Espressif/esp32_aes.c
@@ -637,7 +637,7 @@ int esp_hw_show_aes_metrics(void)
 #if defined(WOLFSSL_HW_METRICS)
 
     ESP_LOGI(TAG, "--------------------------------------------------------");
-    ESP_LOGI(TAG, "------------- wolfSSL ESP HW AES Metrics----------------");
+    ESP_LOGI(TAG, "-------------  wolfSSL ESP HW AES Metrics  -------------");
     ESP_LOGI(TAG, "--------------------------------------------------------");
 
     ESP_LOGI(TAG, "esp_aes_unsupported_length_usage_ct = %lu",

--- a/wolfcrypt/src/port/Espressif/esp32_sha.c
+++ b/wolfcrypt/src/port/Espressif/esp32_sha.c
@@ -2384,7 +2384,7 @@ int esp_hw_show_sha_metrics(void)
     int ret = 0;
 #if defined(WOLFSSL_ESP32_CRYPT) && !defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
     ESP_LOGI(TAG, "--------------------------------------------------------");
-    ESP_LOGI(TAG, "------------- wolfSSL ESP HW SHA Metrics----------------");
+    ESP_LOGI(TAG, "-------------  wolfSSL ESP HW SHA Metrics  -------------");
     ESP_LOGI(TAG, "--------------------------------------------------------");
 
     ESP_LOGI(TAG, "esp_sha_hw_copy_ct            = %lu",

--- a/wolfcrypt/src/port/Espressif/esp_crt_bundle/esp_crt_bundle.c
+++ b/wolfcrypt/src/port/Espressif/esp_crt_bundle/esp_crt_bundle.c
@@ -61,12 +61,17 @@ esp_err_t esp_crt_bundle_attach(void *conf)
 #include <wolfssl/wolfcrypt/asn.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
-#include <esp_tls.h> /* needed only for esp_tls_free_global_ca_store() */
+#ifdef WOLFSSL_CMAKE_REQUIRED_ESP_TLS
+    /* We're already here since CONFIG_ESP_TLS_USING_WOLFSSL is enabled,    */
+    /* but do we have a recent version of wolfSSL CMakeLists.txt to support */
+    /* using wolfSSL in ESP-IDF? If so, include the esp-tls component here: */
+    #include <esp_tls.h> /* needed only for esp_tls_free_global_ca_store()  */
+#endif
 
 /* There's a minimum version of wolfSSL needed for Certificate Bundle Support.
  *
  * See the latest code at:
- * https://github.com/wolfSSL/wolfssl or
+ * https://github.com/wolfSSL/wolfssl or Managed Components at
  * https://www.wolfssl.com/wolfssl-now-available-in-espressif-component-registry/
  */
 #if defined(WOLFSSL_ESPIDF_COMPONENT_VERSION)
@@ -186,12 +191,10 @@ typedef struct crt_bundle_t {
 static WOLFSSL_X509* store_cert = NULL; /* will point to existing param values*/
 static WOLFSSL_X509* bundle_cert = NULL; /* the iterating cert being reviewed.*/
 
-static const uint8_t **crts = NULL;
-static uint16_t num_certs = 0;
-
-
-/* Found in <esp_tls.h> */
-void esp_tls_free_global_ca_store(void);
+#ifdef CONFIG_WOLFSSL_CERTIFICATE_BUNDLE
+    static const uint8_t **crts = NULL;
+    static uint16_t num_certs = 0;
+#endif
 
 #ifdef CONFIG_WOLFSSL_CERTIFICATE_BUNDLE
 static esp_err_t wolfssl_esp_crt_bundle_init(const uint8_t *x509_bundle,
@@ -1514,7 +1517,12 @@ esp_err_t wolfSSL_bundle_cleanup(void)
         s_crt_bundle.crts = NULL;
     }
 
+#ifdef WOLFSSL_CMAKE_REQUIRED_ESP_TLS
+    /* When the esp-tls is linked as a requirement in CMake and used by the
+     * ESP-IDF in the esp-tls component, call at cleanup time: */
     esp_tls_free_global_ca_store();
+#endif
+
     /* Be sure to free the bundle_cert first, as it may be part of store. */
     if (bundle_cert != NULL) {
 #ifdef DEBUG_WOLFSSL_MALLOC

--- a/wolfcrypt/src/port/Espressif/esp_sdk_mem_lib.c
+++ b/wolfcrypt/src/port/Espressif/esp_sdk_mem_lib.c
@@ -25,10 +25,10 @@
 
 /* wolfSSL */
 /* Always include wolfcrypt/settings.h before any other wolfSSL file.    */
-/* Reminder: settings.h pulls in user_settings.h; don't include it here. */
-#ifdef WOLFSSL_USER_SETTINGS
-    #include <wolfssl/wolfcrypt/settings.h>
-#endif
+/* Be sure to define WOLFSSL_USER_SETTINGS, typically in CMakeLists.txt  */
+/* Reminder: settings.h pulls in user_settings.h                         */
+/*   Do not explicitly include user_settings.h here.                     */
+#include <wolfssl/wolfcrypt/settings.h>
 
 #if defined(WOLFSSL_ESPIDF) /* Entire file is only for Espressif EDP-IDF */
 
@@ -71,8 +71,6 @@ extern wc_ptr_t _rodata_start[];
 extern wc_ptr_t _rodata_end[];
 extern wc_ptr_t _bss_start[];
 extern wc_ptr_t _bss_end[];
-extern wc_ptr_t _rtc_data_start[];
-extern wc_ptr_t _rtc_data_end[];
 extern wc_ptr_t _rtc_bss_start[];
 extern wc_ptr_t _rtc_bss_end[];
 extern wc_ptr_t _iram_start[];
@@ -83,16 +81,24 @@ extern wc_ptr_t _init_end[];
 #endif
 extern wc_ptr_t _iram_text_start[];
 extern wc_ptr_t _iram_text_end[];
-extern wc_ptr_t _iram_bss_start[];
-extern wc_ptr_t _iram_bss_end[];
+#if defined(CONFIG_IDF_TARGET_ESP32S2)
+    /* TODO: Find ESP32-S2 equivalent */
+#else
+    extern wc_ptr_t _iram_bss_start[];
+    extern wc_ptr_t _iram_bss_end[];
+#endif
 extern wc_ptr_t _noinit_start[];
 extern wc_ptr_t _noinit_end[];
 extern wc_ptr_t _text_start[];
 extern wc_ptr_t _text_end[];
 extern wc_ptr_t _heap_start[];
 extern wc_ptr_t _heap_end[];
-extern wc_ptr_t _rtc_data_start[];
-extern wc_ptr_t _rtc_data_end[];
+#ifdef CONFIG_IDF_TARGET_ESP32C2
+    /* no rtc_data on ESP32-C2*/
+#else
+    extern wc_ptr_t _rtc_data_start[];
+    extern wc_ptr_t _rtc_data_end[];
+#endif
 
 #if defined(CONFIG_IDF_TARGET_ARCH_XTENSA) && CONFIG_IDF_TARGET_ARCH_XTENSA == 1
     extern void* _thread_local_start;
@@ -194,7 +200,11 @@ int sdk_init_meminfo(void) {
 #endif
     sdk_log_meminfo(data,          _data_start,         _data_end);
     sdk_log_meminfo(user_data_ram, USER_DATA_START,     USER_DATA_END);
+#if defined(CONFIG_IDF_TARGET_ESP32S2)
+    /* TODO: Find ESP32-S2 equivalent of bss */
+#else
     sdk_log_meminfo(bss,           _bss_start,          _bss_end);
+#endif
     sdk_log_meminfo(noinit,        _noinit_start,       _noinit_end);
     sdk_log_meminfo(ets_system,    ETS_SYS_START,       ETS_SYS_END);
     sdk_log_meminfo(rodata,        _rodata_start,       _rodata_end);
@@ -203,12 +213,20 @@ int sdk_init_meminfo(void) {
     sdk_log_meminfo(iramf2,        IRAMF2_START,        IRAMF2_END);
     sdk_log_meminfo(iram,          _iram_start,         _iram_end);
     sdk_log_meminfo(iram_text,     _iram_text_start,    _iram_text_end);
+#if defined(CONFIG_IDF_TARGET_ESP32S2)
+    /* No iram_bss on ESP32-C2 at this time. TODO: something equivalent? */
+#else
     sdk_log_meminfo(iram_bss,      _iram_bss_start,     _iram_bss_end);
+#endif
 #if defined(CONFIG_IDF_TARGET_ESP8266)
     sdk_log_meminfo(init,          _init_start,         _init_end);
 #endif
     sdk_log_meminfo(text,          _text_start,         _text_end);
+#if defined(CONFIG_IDF_TARGET_ESP32C2)
+    /* No rtc_data on ESP32-C2 at this time. TODO: something equivalent? */
+#else
     sdk_log_meminfo(rtc_data,      _rtc_data_start,     _rtc_data_end);
+#endif
     ESP_LOGI(TAG, "-----------------------------------------------------");
     sample_heap_var = malloc(1);
     if (sample_heap_var == NULL) {

--- a/wolfcrypt/src/port/Espressif/esp_sdk_wifi_lib.c
+++ b/wolfcrypt/src/port/Espressif/esp_sdk_wifi_lib.c
@@ -23,8 +23,11 @@
     #include <config.h>
 #endif
 
-/* Reminder: user_settings.h is needed and included from settings.h
- * Be sure to define WOLFSSL_USER_SETTINGS, typically in CMakeLists.txt */
+/* wolfSSL */
+/* Always include wolfcrypt/settings.h before any other wolfSSL file.    */
+/* Be sure to define WOLFSSL_USER_SETTINGS, typically in CMakeLists.txt  */
+/* Reminder: settings.h pulls in user_settings.h                         */
+/*   Do not explicitly include user_settings.h here.                     */
 #include <wolfssl/wolfcrypt/settings.h>
 
 #if defined(WOLFSSL_ESPIDF) /* Entire file is only for Espressif EDP-IDF */

--- a/wolfssl/wolfcrypt/port/Espressif/esp_crt_bundle.h
+++ b/wolfssl/wolfcrypt/port/Espressif/esp_crt_bundle.h
@@ -28,8 +28,9 @@
 #define __ESP_CRT_BUNDLE_wolfssl_LIB_H__
 
 /* This file is typically NOT directly used by applications utilizing the
- * wolfSSL libraries. It is used when the wolfssl libary component is configured
- * to be utilized by the Espressif ESP-IDF, specifically the esp-tls layer.
+ * wolfSSL libraries. It is used when the wolfssl library component is
+ * configured to be utilized by the Espressif ESP-IDF, specifically the
+ * esp-tls layer.
  *
  * See: esp-idf api-reference for esp_tls.
  * https://github.com/espressif/esp-idf/blob/master/components/esp-tls/esp_tls.h
@@ -53,7 +54,16 @@
  *   Normally on, this uses the compiler `inline` decorator for bundle functions
  *   to be optimized, since they are called during a TLS connection.
  *
- * See Kconfig file (or use idy.py menufconfig) for other bundle settings.
+ * See Kconfig file (or use idy.py menuconfig) for other bundle settings.
+ *
+ *******************************************************************************
+ ** Other Settings:
+ *******************************************************************************
+ * WOLFSSL_CMAKE_REQUIRED_ESP_TLS
+ *  This is defined in the wolfssl component cmake file when the esp-tls
+ *  component is required. This is typically when Certificate Bundles are
+ *  enabled, and the esp_tls_free_global_ca_store() in the esp-tls needs
+ *  to be called from the wolfSSL wolfSSL_bundle_cleanup().
  */
 
 /* wolfSSL */
@@ -121,14 +131,14 @@ esp_err_t esp_crt_bundle_attach(void *conf);
 
 #else
 /**
- * @brief      Return ESP_OK for valid bunder, otherwise ESP_FAIL.
+ * @brief      Return ESP_OK for valid bundle, otherwise ESP_FAIL.
  *
  * Specific to wolfSSL. Not used by ESP-IDF esp-tls layer.
  */
 esp_err_t esp_crt_bundle_is_valid(void);
 
 /**
- * @brief      Return 1 if Cert Bundle loaded, otheriwse 0.
+ * @brief      Return 1 if Cert Bundle loaded, otherwise 0.
  *
  * Specific to wolfSSL. Not used by ESP-IDF esp-tls layer.
  */
@@ -169,7 +179,7 @@ void esp_crt_bundle_detach(wolfssl_ssl_config *conf);
  *
  * @return
  *             - ESP_OK  if adding certificates was successful.
- *             - Other   if an error occured or an action must be taken
+ *             - Other   if an error occurred or an action must be taken
  *                       by the calling process.
  */
 esp_err_t esp_crt_bundle_set(const uint8_t *x509_bundle, size_t bundle_size);
@@ -179,7 +189,7 @@ esp_err_t esp_crt_bundle_set(const uint8_t *x509_bundle, size_t bundle_size);
  * @brief      Set the issuer and subject values given the current cert.
  *
  * Used internally by ESP-IDF esp-tls layer. Also helpful for debugging
- * and general visibiity to certificate attributes.
+ * and general visibility to certificate attributes.
  *
  * The CERT_TAG can be used at the esp-tls or application layer to indicate
  * the usage of the respective cert (e.g. the string "peer").


### PR DESCRIPTION
# Description

Updates wolfCrypt for various Espressif device and environment / version compatibility.

A non-obvious but critical update is the `WOLFSSL_CMAKE_REQUIRED_ESP_TLS` detection in the new esp-tls component and bundle support. When a compatible environment is found, the `esp-tls` component's respective `<esp_tls.h>` is included so that the non-wolfSSL `esp_tls_free_global_ca_store();` can be called during cleanup.

As wolfSSL support is defined in the respective ESP-IDF `CMakeLists.txt`, the `WOLFSSL_CMAKE_REQUIRED_ESP_TLS` is expected to be defined in that cmake file when the component support is added to the ESP-IDF.

See my [esp_http_client_example](https://github.com/gojimmypi/wolfssl/blob/8c0ead8496a90a682acf93a292762237eaf11719/IDE/Espressif/ESP-IDF/examples/esp_http_client_example/components/wolfssl/CMakeLists.txt#L431) for an example.

Also, during testing on multiple different flavors of the ESP32 / ESP8266, some attributes in the memory library are not available and are now gated out.

Includes various spelling corrections, comment updates, and more.


Fixes zd# n/a

# Testing

Tested on my [9-device jig](https://x.com/gojimmypi/status/1733644618049421602), Espressif only

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
