### PR TITLE
Fix mingw32 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2411,8 +2411,7 @@ target_link_libraries(wolfssl PUBLIC ${WOLFSSL_LINK_LIBS})
 
 if(WIN32)
     # For Windows link ws2_32
-    target_link_libraries(wolfssl PUBLIC
-        $<$<PLATFORM_ID:Windows>:ws2_32 crypt32>)
+    target_link_libraries(wolfssl PUBLIC ws2_32 crypt32)
 elseif(APPLE)
     if(WOLFSSL_SYS_CA_CERTS)
         target_link_libraries(wolfssl PUBLIC


### PR DESCRIPTION
# Description

Small change to fix mingw32 build which is failing for me with the following error `i686-w64-mingw32-gcc: error: $<1:ws2_32: No such file or directory`. 

Since the changed statement is under the `if (WIN32)` condition there's no benefit to using `PLATFORM_ID`. 


Fixes zd#

# Testing

mingw32 build completed successfully.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
