### PR TITLE
infer: fix dead store, and uninitialized value errors.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -20411,7 +20411,6 @@ WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
         }
 
         ssl->buffers.weOwnCert = 1;
-        ret = WOLFSSL_SUCCESS;
     }
     if (ctx->certChain != NULL) {
         if (ssl->buffers.certChain != NULL) {
@@ -20425,7 +20424,6 @@ WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
         }
 
         ssl->buffers.weOwnCertChain = 1;
-        ret = WOLFSSL_SUCCESS;
     }
 #else
     /* ctx owns certificate, certChain and key */

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -8568,6 +8568,8 @@ static int SendTls13Certificate(WOLFSSL* ssl)
     WOLFSSL_START(WC_FUNC_CERTIFICATE_SEND);
     WOLFSSL_ENTER("SendTls13Certificate");
 
+    XMEMSET(extSz, 0, sizeof(extSz));
+
     ssl->options.buildingMsg = 1;
 
 #ifdef WOLFSSL_POST_HANDSHAKE_AUTH

--- a/tests/api.c
+++ b/tests/api.c
@@ -21014,7 +21014,7 @@ static int test_RsaDecryptBoundsCheck(void)
     WC_RNG rng;
     RsaKey key;
     byte flatC[256];
-    word32 flatCSz;
+    word32 flatCSz = 0;
     byte out[256];
     word32 outSz = sizeof(out);
 
@@ -23432,7 +23432,7 @@ static int test_wc_DsaSignVerify(void)
     byte   hash[WC_SHA_DIGEST_SIZE];
     word32 idx = 0;
     word32 bytes;
-    int    answer;
+    int    answer = 0;
 #ifdef USE_CERT_BUFFERS_1024
     byte   tmp[ONEK_BUF];
 
@@ -25778,7 +25778,7 @@ static int test_wc_ecc_params(void)
 #if !defined(NO_ECC256) && !defined(NO_ECC_SECP)
     /* Test for SECP256R1 curve */
     int curve_id = ECC_SECP256R1;
-    int curve_idx;
+    int curve_idx = 0;
 
     ExpectIntNE(curve_idx = wc_ecc_get_curve_idx(curve_id), ECC_CURVE_INVALID);
     ExpectNotNull(ecc_set = wc_ecc_get_curve_params(curve_idx));

--- a/tests/api.c
+++ b/tests/api.c
@@ -5031,7 +5031,7 @@ static int test_wolfSSL_CTX_use_certificate_chain_buffer_format(void)
     WOLFSSL* ssl = NULL;
     const char* cert = "./certs/server-cert.pem";
     unsigned char* buf = NULL;
-    size_t len;
+    size_t len = 0;
 
     ExpectIntEQ(load_file(cert, &buf, &len), 0);
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -25402,9 +25402,9 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
 {
     const char* header      = NULL;
     const char* footer      = NULL;
-    const char* headerEnd;
-    const char* footerEnd;
-    const char* consumedEnd;
+    const char* headerEnd   = NULL;
+    const char* footerEnd   = NULL;
+    const char* consumedEnd = NULL;
     const char* bufferEnd   = (const char*)(buff + longSz);
     long        neededSz;
     int         ret         = 0;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -15005,8 +15005,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aesgcm_test(void)
     byte resultC[sizeof(p) + AES_BLOCK_SIZE];
     wc_test_ret_t ret = 0;
 
-    int  alen;
-    int  plen;
+    int  alen = 0;
+    int  plen = 0;
 #if defined(WOLFSSL_XILINX_CRYPT_VERSAL)
     byte buf[sizeof(p) + AES_BLOCK_SIZE];
     byte bufA[sizeof(a) + 1];
@@ -21482,7 +21482,7 @@ exit_rsa:
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_test(void)
 {
     wc_test_ret_t ret;
-    size_t bytes;
+    size_t bytes = 0;
     WC_RNG rng;
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     byte*  tmp = NULL;
@@ -22781,7 +22781,11 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t dh_test(void)
 {
     wc_test_ret_t ret;
     word32 bytes;
-    word32 idx = 0, privSz, pubSz, privSz2, pubSz2;
+    word32 idx = 0;
+    word32 privSz = 0;
+    word32 pubSz = 0;
+    word32 privSz2 = 0;
+    word32 pubSz2 = 0;
 #ifndef WC_NO_RNG
     WC_RNG rng;
     int rngInit = 0;


### PR DESCRIPTION
# Description

Fixes about 28 errors reported across these files:
- src/ssl.c
- src/tls13.c
- tests/api.c
- wolfcrypt/src/asn.c
- wolfcrypt/test/test.c

# Testing

Tested with infer.
