### PR TITLE
Fixing CB needing HAVE_AES_ECB and SHA struct issue for MAX32666/5 port

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -2917,7 +2917,7 @@ static WARN_UNUSED_RESULT int wc_AesEncrypt(
                                     outBlock, (unsigned int)keySize);
     }
 #endif
-#ifdef MAX3266X_CB /* Can do a basic ECB block */
+#if defined(MAX3266X_CB) && defined(HAVE_AES_ECB) /* Can do a basic ECB block */
     #ifndef WOLF_CRYPTO_CB_FIND
     if (aes->devId != INVALID_DEVID)
     #endif
@@ -3668,7 +3668,7 @@ static WARN_UNUSED_RESULT int wc_AesDecrypt(
     }
 #endif
 
-#ifdef MAX3266X_CB /* Can do a basic ECB block */
+#if defined(MAX3266X_CB) && defined(HAVE_AES_ECB) /* Can do a basic ECB block */
     #ifndef WOLF_CRYPTO_CB_FIND
     if (aes->devId != INVALID_DEVID)
     #endif

--- a/wolfcrypt/src/port/maxim/max3266x.c
+++ b/wolfcrypt/src/port/maxim/max3266x.c
@@ -789,35 +789,35 @@ WOLFSSL_API int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
     }
     (void)heap;
     (void)devId;
-    return wc_MXC_TPU_SHA_Init((wc_MXC_Sha *)sha);
+    return wc_MXC_TPU_SHA_Init(&(sha->mxcCtx));
 }
 
 WOLFSSL_API int wc_ShaUpdate(wc_Sha* sha, const unsigned char* data,
                                         unsigned int len)
 {
-    return wc_MXC_TPU_SHA_Update(sha, data, len);
+    return wc_MXC_TPU_SHA_Update(&(sha->mxcCtx), data, len);
 }
 
 WOLFSSL_API int wc_ShaFinal(wc_Sha* sha, unsigned char* hash)
 {
-    return wc_MXC_TPU_SHA_Final((wc_MXC_Sha *)sha, hash,
+    return wc_MXC_TPU_SHA_Final(&(sha->mxcCtx), hash,
                                         MXC_TPU_HASH_SHA1);
 }
 
 WOLFSSL_API int wc_ShaGetHash(wc_Sha* sha, unsigned char* hash)
 {
-    return wc_MXC_TPU_SHA_GetHash((wc_MXC_Sha *)sha, hash,
+    return wc_MXC_TPU_SHA_GetHash(&(sha->mxcCtx), hash,
                                         MXC_TPU_HASH_SHA1);
 }
 
 WOLFSSL_API int wc_ShaCopy(wc_Sha* src, wc_Sha* dst)
 {
-    return wc_MXC_TPU_SHA_Copy((wc_MXC_Sha *)src, (wc_MXC_Sha *)dst);
+    return wc_MXC_TPU_SHA_Copy(&(src->mxcCtx), &(dst->mxcCtx));
 }
 
 WOLFSSL_API void wc_ShaFree(wc_Sha* sha)
 {
-    wc_MXC_TPU_SHA_Free((wc_MXC_Sha *)sha);
+    wc_MXC_TPU_SHA_Free(&(sha->mxcCtx));
     return;
 }
 
@@ -832,7 +832,7 @@ WOLFSSL_API int wc_InitSha224_ex(wc_Sha224* sha224, void* heap, int devId)
     }
     (void)heap;
     (void)devId;
-    return wc_MXC_TPU_SHA_Init((wc_MXC_Sha *)sha224);
+    return wc_MXC_TPU_SHA_Init(&(sha224->mxcCtx));
 }
 
 WOLFSSL_API int wc_InitSha224(wc_Sha224* sha224)
@@ -843,29 +843,29 @@ WOLFSSL_API int wc_InitSha224(wc_Sha224* sha224)
 WOLFSSL_API int wc_Sha224Update(wc_Sha224* sha224, const unsigned char* data,
                                         unsigned int len)
 {
-    return wc_MXC_TPU_SHA_Update(sha224, data, len);
+    return wc_MXC_TPU_SHA_Update(&(sha224->mxcCtx), data, len);
 }
 
 WOLFSSL_API int wc_Sha224Final(wc_Sha224* sha224, unsigned char* hash)
 {
-    return wc_MXC_TPU_SHA_Final((wc_MXC_Sha *)sha224, hash,
+    return wc_MXC_TPU_SHA_Final(&(sha224->mxcCtx), hash,
                                         MXC_TPU_HASH_SHA224);
 }
 
 WOLFSSL_API int wc_Sha224GetHash(wc_Sha224* sha224, unsigned char* hash)
 {
-    return wc_MXC_TPU_SHA_GetHash((wc_MXC_Sha *)sha224, hash,
+    return wc_MXC_TPU_SHA_GetHash(&(sha224->mxcCtx), hash,
                                         MXC_TPU_HASH_SHA224);
 }
 
 WOLFSSL_API int wc_Sha224Copy(wc_Sha224* src, wc_Sha224* dst)
 {
-    return wc_MXC_TPU_SHA_Copy((wc_MXC_Sha *)src, (wc_MXC_Sha *)dst);
+    return wc_MXC_TPU_SHA_Copy(&(src->mxcCtx), &(dst->mxcCtx));
 }
 
 WOLFSSL_API void wc_Sha224Free(wc_Sha224* sha224)
 {
-    wc_MXC_TPU_SHA_Free((wc_MXC_Sha *)sha224);
+    wc_MXC_TPU_SHA_Free(&(sha224->mxcCtx));
     return;
 }
 
@@ -880,7 +880,7 @@ WOLFSSL_API int wc_InitSha256_ex(wc_Sha256* sha256, void* heap, int devId)
     }
     (void)heap;
     (void)devId;
-    return wc_MXC_TPU_SHA_Init((wc_MXC_Sha *)sha256);
+    return wc_MXC_TPU_SHA_Init(&(sha256->mxcCtx));
 }
 
 WOLFSSL_API int wc_InitSha256(wc_Sha256* sha256)
@@ -891,29 +891,29 @@ WOLFSSL_API int wc_InitSha256(wc_Sha256* sha256)
 WOLFSSL_API int wc_Sha256Update(wc_Sha256* sha256, const unsigned char* data,
                                         unsigned int len)
 {
-    return wc_MXC_TPU_SHA_Update(sha256, data, len);
+    return wc_MXC_TPU_SHA_Update(&(sha256->mxcCtx), data, len);
 }
 
 WOLFSSL_API int wc_Sha256Final(wc_Sha256* sha256, unsigned char* hash)
 {
-    return wc_MXC_TPU_SHA_Final((wc_MXC_Sha *)sha256, hash,
+    return wc_MXC_TPU_SHA_Final(&(sha256->mxcCtx), hash,
                                         MXC_TPU_HASH_SHA256);
 }
 
 WOLFSSL_API int wc_Sha256GetHash(wc_Sha256* sha256, unsigned char* hash)
 {
-    return wc_MXC_TPU_SHA_GetHash((wc_MXC_Sha *)sha256, hash,
+    return wc_MXC_TPU_SHA_GetHash(&(sha256->mxcCtx), hash,
                                         MXC_TPU_HASH_SHA256);
 }
 
 WOLFSSL_API int wc_Sha256Copy(wc_Sha256* src, wc_Sha256* dst)
 {
-    return wc_MXC_TPU_SHA_Copy((wc_MXC_Sha *)src, (wc_MXC_Sha *)dst);
+    return wc_MXC_TPU_SHA_Copy(&(src->mxcCtx), &(dst->mxcCtx));
 }
 
 WOLFSSL_API void wc_Sha256Free(wc_Sha256* sha256)
 {
-    wc_MXC_TPU_SHA_Free((wc_MXC_Sha *)sha256);
+    wc_MXC_TPU_SHA_Free(&(sha256->mxcCtx));
     return;
 }
 
@@ -928,7 +928,7 @@ WOLFSSL_API int wc_InitSha384_ex(wc_Sha384* sha384, void* heap, int devId)
     }
     (void)heap;
     (void)devId;
-    return wc_MXC_TPU_SHA_Init((wc_MXC_Sha *)sha384);
+    return wc_MXC_TPU_SHA_Init(&(sha384->mxcCtx));
 }
 
 WOLFSSL_API int wc_InitSha384(wc_Sha384* sha384)
@@ -939,29 +939,29 @@ WOLFSSL_API int wc_InitSha384(wc_Sha384* sha384)
 WOLFSSL_API int wc_Sha384Update(wc_Sha384* sha384, const unsigned char* data,
                                         unsigned int len)
 {
-    return wc_MXC_TPU_SHA_Update(sha384, data, len);
+    return wc_MXC_TPU_SHA_Update(&(sha384->mxcCtx), data, len);
 }
 
 WOLFSSL_API int wc_Sha384Final(wc_Sha384* sha384, unsigned char* hash)
 {
-    return wc_MXC_TPU_SHA_Final((wc_MXC_Sha *)sha384, hash,
+    return wc_MXC_TPU_SHA_Final(&(sha384->mxcCtx), hash,
                                         MXC_TPU_HASH_SHA384);
 }
 
 WOLFSSL_API int wc_Sha384GetHash(wc_Sha384* sha384, unsigned char* hash)
 {
-    return wc_MXC_TPU_SHA_GetHash((wc_MXC_Sha *)sha384, hash,
+    return wc_MXC_TPU_SHA_GetHash(&(sha384->mxcCtx), hash,
                                         MXC_TPU_HASH_SHA384);
 }
 
 WOLFSSL_API int wc_Sha384Copy(wc_Sha384* src, wc_Sha384* dst)
 {
-    return wc_MXC_TPU_SHA_Copy((wc_MXC_Sha *)src, (wc_MXC_Sha *)dst);
+    return wc_MXC_TPU_SHA_Copy(&(src->mxcCtx), &(dst->mxcCtx));
 }
 
 WOLFSSL_API void wc_Sha384Free(wc_Sha384* sha384)
 {
-    wc_MXC_TPU_SHA_Free((wc_MXC_Sha *)sha384);
+    wc_MXC_TPU_SHA_Free(&(sha384->mxcCtx));
     return;
 }
 
@@ -976,7 +976,7 @@ WOLFSSL_API int wc_InitSha512_ex(wc_Sha512* sha512, void* heap, int devId)
     }
     (void)heap;
     (void)devId;
-    return wc_MXC_TPU_SHA_Init((wc_MXC_Sha *)sha512);
+    return wc_MXC_TPU_SHA_Init(&(sha512->mxcCtx));
 }
 
 WOLFSSL_API int wc_InitSha512(wc_Sha512* sha512)
@@ -987,29 +987,29 @@ WOLFSSL_API int wc_InitSha512(wc_Sha512* sha512)
 WOLFSSL_API int wc_Sha512Update(wc_Sha512* sha512, const unsigned char* data,
                                         unsigned int len)
 {
-    return wc_MXC_TPU_SHA_Update(sha512, data, len);
+    return wc_MXC_TPU_SHA_Update(&(sha512->mxcCtx), data, len);
 }
 
 WOLFSSL_API int wc_Sha512Final(wc_Sha512* sha512, unsigned char* hash)
 {
-    return wc_MXC_TPU_SHA_Final((wc_MXC_Sha *)sha512, hash,
+    return wc_MXC_TPU_SHA_Final(&(sha512->mxcCtx), hash,
                                         MXC_TPU_HASH_SHA512);
 }
 
 WOLFSSL_API int wc_Sha512GetHash(wc_Sha512* sha512, unsigned char* hash)
 {
-    return wc_MXC_TPU_SHA_GetHash((wc_MXC_Sha *)sha512, hash,
+    return wc_MXC_TPU_SHA_GetHash(&(sha512->mxcCtx), hash,
                                         MXC_TPU_HASH_SHA512);
 }
 
 WOLFSSL_API int wc_Sha512Copy(wc_Sha512* src, wc_Sha512* dst)
 {
-    return wc_MXC_TPU_SHA_Copy((wc_MXC_Sha *)src, (wc_MXC_Sha *)dst);
+    return wc_MXC_TPU_SHA_Copy(&(src->mxcCtx), &(dst->mxcCtx));
 }
 
 WOLFSSL_API void wc_Sha512Free(wc_Sha512* sha512)
 {
-    wc_MXC_TPU_SHA_Free((wc_MXC_Sha *)sha512);
+    wc_MXC_TPU_SHA_Free(&(sha512->mxcCtx));
     return;
 }
 

--- a/wolfssl/wolfcrypt/port/maxim/max3266x.h
+++ b/wolfssl/wolfcrypt/port/maxim/max3266x.h
@@ -236,21 +236,16 @@
 
 #if defined(MAX3266X_SHA) || defined(MAX3266X_SHA_CB)
 
+    /* Need to update this struct accordingly if other SHA Structs change */
+    /* This is a generic struct to use so only this is needed */
+
     typedef struct {
         unsigned char   *msg;
         unsigned int    used;
         unsigned int    size;
-        #ifdef WOLFSSL_HASH_FLAGS
-        unsigned int    flags; /* enum wc_HashFlags in hash.h */
-        #endif
     } wc_MXC_Sha;
 
     #if !defined(NO_SHA)
-    #ifndef MAX3266X_SHA_CB
-        typedef wc_MXC_Sha wc_Sha;
-        #define WC_SHA_TYPE_DEFINED
-    #endif /* !MAX3266X_SHA_CB */
-
         /* Define the SHA digest for an empty string */
         /* as a constant byte array */
         static const unsigned char MXC_EMPTY_DIGEST_SHA1[20] = {
@@ -260,11 +255,6 @@
     #endif /* NO_SHA */
 
     #if defined(WOLFSSL_SHA224)
-    #ifndef MAX3266X_SHA_CB
-        typedef wc_MXC_Sha wc_Sha224;
-        #define WC_SHA224_TYPE_DEFINED
-    #endif /* !MAX3266X_SHA_CB */
-
         /* Define the SHA-224 digest for an empty string */
         /* as a constant byte array */
         static const unsigned char MXC_EMPTY_DIGEST_SHA224[28] = {
@@ -275,11 +265,6 @@
     #endif /* WOLFSSL_SHA224 */
 
     #if !defined(NO_SHA256)
-    #ifndef MAX3266X_SHA_CB
-        typedef wc_MXC_Sha wc_Sha256;
-        #define WC_SHA256_TYPE_DEFINED
-    #endif /* !MAX3266X_SHA_CB */
-
         /* Define the SHA-256 digest for an empty string */
         /* as a constant byte array */
         static const unsigned char MXC_EMPTY_DIGEST_SHA256[32] = {
@@ -290,11 +275,6 @@
     #endif /* NO_SHA256 */
 
     #if defined(WOLFSSL_SHA384)
-    #ifndef MAX3266X_SHA_CB
-        typedef wc_MXC_Sha wc_Sha384;
-        #define WC_SHA384_TYPE_DEFINED
-    #endif /* !MAX3266X_SHA_CB */
-
         /* Define the SHA-384 digest for an empty string */
         /* as a constant byte array */
         static const unsigned char MXC_EMPTY_DIGEST_SHA384[48] = {
@@ -307,13 +287,6 @@
     #endif /* WOLFSSL_SHA384 */
 
     #if defined(WOLFSSL_SHA512)
-    #ifndef MAX3266X_SHA_CB
-        typedef wc_MXC_Sha wc_Sha512;
-        typedef wc_MXC_Sha wc_Sha512_224;
-        typedef wc_MXC_Sha wc_Sha512_256;
-        #define WC_SHA512_TYPE_DEFINED
-    #endif /* !MAX3266X_SHA_CB */
-
         /* Does not support these SHA512 Macros */
         #ifndef WOLFSSL_NOSHA512_224
             #warning "MAX3266X Port does not support SHA-512/224"

--- a/wolfssl/wolfcrypt/sha.h
+++ b/wolfssl/wolfcrypt/sha.h
@@ -163,7 +163,7 @@ struct wc_Sha {
     int    devId;
     void*  devCtx; /* generic crypto callback context */
 #endif
-#ifdef MAX3266X_SHA_CB
+#if defined(MAX3266X_SHA_CB) || defined(MAX3266X_SHA)
     wc_MXC_Sha mxcCtx;
 #endif
 #ifdef WOLFSSL_IMXRT1170_CAAM

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -213,7 +213,7 @@ struct wc_Sha256 {
 #ifdef WOLFSSL_DEVCRYPTO_HASH
     WC_CRYPTODEV ctx;
 #endif
-#ifdef MAX3266X_SHA_CB
+#if defined(MAX3266X_SHA_CB) || defined(MAX3266X_SHA)
     wc_MXC_Sha mxcCtx;
 #endif
 #if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)

--- a/wolfssl/wolfcrypt/sha512.h
+++ b/wolfssl/wolfcrypt/sha512.h
@@ -189,7 +189,7 @@ struct wc_Sha512 {
     int    devId;
     void*  devCtx; /* generic crypto callback context */
 #endif
-#ifdef MAX3266X_SHA_CB
+#if defined(MAX3266X_SHA_CB) || defined(MAX3266X_SHA)
     wc_MXC_Sha mxcCtx;
 #endif
 #ifdef WOLFSSL_HASH_FLAGS


### PR DESCRIPTION
# Description

Refactors to have hw sha struct inside each respective struct for sha, instead of replacing them. This is similar to have the callback works already.

Also fixed the issue of need HAVE_AES_ECB to have CB work.
