### PR TITLE
20241015-C89-pedantic-fixes

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -20858,7 +20858,7 @@ static const ASNItem subjDirAttrASN[] = {
 enum {
     SUBJDIRATTRASN_IDX_SEQ = 0,
     SUBJDIRATTRASN_IDX_OID,
-    SUBJDIRATTRASN_IDX_SET,
+    SUBJDIRATTRASN_IDX_SET
 };
 
 /* Number of items in ASN.1 template for BasicConstraints. */
@@ -23526,9 +23526,9 @@ typedef struct DecodeInstr {
     /* Tag expected. */
     byte tag;
     /* Operation to perform: step in or go over */
-    byte op:1;
+    WC_BITFIELD op:1;
     /* ASN.1 item is optional. */
-    byte optional:1;
+    WC_BITFIELD optional:1;
 } DecodeInstr;
 
 /* Step into ASN.1 item. */
@@ -40761,7 +40761,7 @@ enum {
     HOLDER_IDX_ISSUERSERIAL_SEQ,
     HOLDER_IDX_GN_SEQ,
     HOLDER_IDX_SERIAL_INT,
-    HOLDER_IDX_GN_SEQ_OPT1,
+    HOLDER_IDX_GN_SEQ_OPT1
 };
 
 /* Number of items in ASN template for an X509 Acert. */
@@ -40885,7 +40885,7 @@ static const ASNItem AttCertIssuerASN[] =
 };
 
 enum {
-    ATTCERTISSUER_IDX_GN_SEQ,
+    ATTCERTISSUER_IDX_GN_SEQ
 };
 
 /* Number of items in ASN template for an X509 Acert. */

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -118,12 +118,12 @@ struct PKCS7State {
     word32 peakUsed; /* most bytes used for struct at any one time */
     word32 peakRead; /* most bytes used by read buffer */
 #endif
-    byte   multi:1;  /* flag for if content is in multiple parts */
-    byte   flagOne:1;
-    byte   detached:1; /* flag to indicate detached signature is present */
-    byte   noContent:1;/* indicates content isn't included in bundle */
-    byte   degenerate:1;
-    byte   indefLen:1; /* flag to indicate indef-length encoding used */
+    WC_BITFIELD multi:1;  /* flag for if content is in multiple parts */
+    WC_BITFIELD flagOne:1;
+    WC_BITFIELD detached:1; /* flag to indicate detached signature is present */
+    WC_BITFIELD noContent:1;/* indicates content isn't included in bundle */
+    WC_BITFIELD degenerate:1;
+    WC_BITFIELD indefLen:1; /* flag to indicate indef-length encoding used */
 };
 
 
@@ -1523,7 +1523,7 @@ typedef struct ESD {
     wc_HashAlg  hash;
     enum wc_HashType hashType;
     byte contentDigest[WC_MAX_DIGEST_SIZE + 2]; /* content only + ASN.1 heading */
-    byte contentDigestSet:1;
+    WC_BITFIELD contentDigestSet:1;
     byte contentAttribsDigest[WC_MAX_DIGEST_SIZE];
     byte encContentDigest[MAX_ENCRYPTED_KEY_SZ];
 
@@ -6829,9 +6829,9 @@ typedef struct WC_PKCS7_KARI {
     word32   sharedInfoSz;         /* size of ECC-CMS-SharedInfo encoded */
     byte     ukmOwner;             /* do we own ukm buffer? 1:yes, 0:no */
     byte     direction;            /* WC_PKCS7_ENCODE | WC_PKCS7_DECODE */
-    byte     decodedInit : 1;      /* indicates decoded was initialized */
-    byte     recipKeyInit : 1;     /* indicates recipKey was initialized */
-    byte     senderKeyInit : 1;    /* indicates senderKey was initialized */
+    WC_BITFIELD decodedInit:1;     /* indicates decoded was initialized */
+    WC_BITFIELD recipKeyInit:1;    /* indicates recipKey was initialized */
+    WC_BITFIELD senderKeyInit:1;   /* indicates senderKey was initialized */
 } WC_PKCS7_KARI;
 
 

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -388,11 +388,11 @@ struct Aes {
     byte         over;
     byte         aOver;
     byte         cOver;
-    byte         gcmKeySet:1;
-    byte         nonceSet:1;
-    byte         ctrSet:1;
+    WC_BITFIELD  gcmKeySet:1;
+    WC_BITFIELD  nonceSet:1;
+    WC_BITFIELD  ctrSet:1;
 #endif
-    byte         isAllocated:1; /* flag indicates if structure was allocated */
+    WC_BITFIELD  isAllocated:1; /* flag indicates if structure was allocated */
 #ifdef WC_DEBUG_CIPHER_LIFECYCLE
     void *CipherLifecycleTag; /* used for dummy allocation and initialization,
                                * trackable by sanitizers.

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -224,11 +224,11 @@ typedef struct ASNItem {
     /* BER/DER tag to expect. */
     byte tag;
     /* Whether the ASN.1 item is constructed. */
-    byte constructed:1;
+    WC_BITFIELD constructed:1;
     /* Whether to parse the header only or skip data. If
      * ASNSetData.data.buffer.data is supplied then this option gets
      * overwritten and the child nodes get ignored. */
-    byte headerOnly:1;
+    WC_BITFIELD headerOnly:1;
     /* Whether ASN.1 item is optional.
      *  - 0 means not optional
      *  - 1 means is optional
@@ -1273,8 +1273,9 @@ enum Extensions_Sum {
 #ifdef WOLFSSL_DUAL_ALG_CERTS
     SUBJ_ALT_PUB_KEY_INFO_OID = 186, /* 2.5.29.72 subject alt public key info */
     ALT_SIG_ALG_OID           = 187, /* 2.5.29.73 alt sig alg */
-    ALT_SIG_VAL_OID           = 188  /* 2.5.29.74 alt sig val */
+    ALT_SIG_VAL_OID           = 188,  /* 2.5.29.74 alt sig val */
 #endif
+    WOLF_ENUM_DUMMY_LAST_ELEMENT(Extensions_Sum)
 };
 
 enum CertificatePolicy_Sum {
@@ -1941,63 +1942,63 @@ struct DecodedCert {
     int criticalExt;
 
     /* Option Bits */
-    byte subjectCNStored : 1;      /* have we saved a copy we own */
-    byte extSubjKeyIdSet : 1;      /* Set when the SKID was read from cert */
-    byte extAuthKeyIdSet : 1;      /* Set when the AKID was read from cert */
+    WC_BITFIELD subjectCNStored:1;      /* have we saved a copy we own */
+    WC_BITFIELD extSubjKeyIdSet:1;      /* Set when the SKID was read from cert */
+    WC_BITFIELD extAuthKeyIdSet:1;      /* Set when the AKID was read from cert */
 #ifndef IGNORE_NAME_CONSTRAINTS
-    byte extNameConstraintSet : 1;
+    WC_BITFIELD extNameConstraintSet:1;
 #endif
-    byte isCA : 1;                 /* CA basic constraint true */
-    byte pathLengthSet : 1;        /* CA basic const path length set */
-    byte weOwnAltNames : 1;        /* altNames haven't been given to copy */
-    byte extKeyUsageSet : 1;
-    byte extExtKeyUsageSet : 1;    /* Extended Key Usage set */
+    WC_BITFIELD isCA:1;                 /* CA basic constraint true */
+    WC_BITFIELD pathLengthSet:1;        /* CA basic const path length set */
+    WC_BITFIELD weOwnAltNames:1;        /* altNames haven't been given to copy */
+    WC_BITFIELD extKeyUsageSet:1;
+    WC_BITFIELD extExtKeyUsageSet:1;    /* Extended Key Usage set */
 #ifdef HAVE_OCSP
-    byte ocspNoCheckSet : 1;       /* id-pkix-ocsp-nocheck set */
+    WC_BITFIELD ocspNoCheckSet:1;       /* id-pkix-ocsp-nocheck set */
 #endif
-    byte extCRLdistSet : 1;
-    byte extAuthInfoSet : 1;
-    byte extBasicConstSet : 1;
-    byte extPolicyConstSet : 1;
-    byte extPolicyConstRxpSet : 1; /* requireExplicitPolicy set */
-    byte extPolicyConstIpmSet : 1; /* inhibitPolicyMapping set */
-    byte extSubjAltNameSet : 1;
-    byte inhibitAnyOidSet : 1;
-    byte selfSigned : 1;           /* Indicates subject and issuer are same */
+    WC_BITFIELD extCRLdistSet:1;
+    WC_BITFIELD extAuthInfoSet:1;
+    WC_BITFIELD extBasicConstSet:1;
+    WC_BITFIELD extPolicyConstSet:1;
+    WC_BITFIELD extPolicyConstRxpSet:1; /* requireExplicitPolicy set */
+    WC_BITFIELD extPolicyConstIpmSet:1; /* inhibitPolicyMapping set */
+    WC_BITFIELD extSubjAltNameSet:1;
+    WC_BITFIELD inhibitAnyOidSet:1;
+    WC_BITFIELD selfSigned:1;           /* Indicates subject and issuer are same */
 #ifdef WOLFSSL_SEP
-    byte extCertPolicySet : 1;
+    WC_BITFIELD extCertPolicySet:1;
 #endif
-    byte extCRLdistCrit : 1;
-    byte extAuthInfoCrit : 1;
-    byte extBasicConstCrit : 1;
-    byte extPolicyConstCrit : 1;
-    byte extSubjAltNameCrit : 1;
-    byte extAuthKeyIdCrit : 1;
+    WC_BITFIELD extCRLdistCrit:1;
+    WC_BITFIELD extAuthInfoCrit:1;
+    WC_BITFIELD extBasicConstCrit:1;
+    WC_BITFIELD extPolicyConstCrit:1;
+    WC_BITFIELD extSubjAltNameCrit:1;
+    WC_BITFIELD extAuthKeyIdCrit:1;
 #ifndef IGNORE_NAME_CONSTRAINTS
-    byte extNameConstraintCrit : 1;
+    WC_BITFIELD extNameConstraintCrit:1;
 #endif
-    byte extSubjKeyIdCrit : 1;
-    byte extKeyUsageCrit : 1;
-    byte extExtKeyUsageCrit : 1;
+    WC_BITFIELD extSubjKeyIdCrit:1;
+    WC_BITFIELD extKeyUsageCrit:1;
+    WC_BITFIELD extExtKeyUsageCrit:1;
 #ifdef WOLFSSL_SUBJ_DIR_ATTR
-    byte extSubjDirAttrSet : 1;
+    WC_BITFIELD extSubjDirAttrSet:1;
 #endif
 #ifdef WOLFSSL_SUBJ_INFO_ACC
-    byte extSubjInfoAccSet : 1;
+    WC_BITFIELD extSubjInfoAccSet:1;
 #endif
 #ifdef WOLFSSL_DUAL_ALG_CERTS
-    byte extSapkiSet : 1;
-    byte extAltSigAlgSet : 1;
-    byte extAltSigValSet : 1;
+    WC_BITFIELD extSapkiSet:1;
+    WC_BITFIELD extAltSigAlgSet:1;
+    WC_BITFIELD extAltSigValSet:1;
 #endif /* WOLFSSL_DUAL_ALG_CERTS */
 #ifdef WOLFSSL_SEP
-    byte extCertPolicyCrit : 1;
+    WC_BITFIELD extCertPolicyCrit:1;
 #endif
 #ifdef WOLFSSL_CERT_REQ
-    byte isCSR : 1;                /* Do we intend on parsing a CSR? */
+    WC_BITFIELD isCSR:1;                /* Do we intend on parsing a CSR? */
 #endif
 #ifdef HAVE_RPK
-    byte isRPK : 1;   /* indicate the cert is Raw-Public-Key cert in RFC7250 */
+    WC_BITFIELD isRPK:1;   /* indicate the cert is Raw-Public-Key cert in RFC7250 */
 #endif
 #ifdef WC_ASN_UNKNOWN_EXT_CB
     wc_UnknownExtCallback unknownExtCallback;
@@ -2034,7 +2035,7 @@ struct Signer {
     word32  keyOID;                  /* key type */
     word16  keyUsage;
     byte    maxPathLen;
-    byte    selfSigned : 1;
+    WC_BITFIELD selfSigned:1;
     const byte* publicKey;
     int     nameLen;
     char*   name;                    /* common name */
@@ -2572,10 +2573,10 @@ struct OcspEntry
     byte* rawCertId;                      /* raw bytes of the CertID   */
     int rawCertIdSize;                    /* num bytes in raw CertID   */
     /* option bits - using 32-bit for alignment */
-    word32 ownStatus:1;                   /* do we need to free the status
+    WC_BITFIELD ownStatus:1;              /* do we need to free the status
                                            * response list */
-    word32 isDynamic:1;                   /* was dynamically allocated */
-    word32 used:1;                        /* entry used                */
+    WC_BITFIELD isDynamic:1;              /* was dynamically allocated */
+    WC_BITFIELD used:1;                   /* entry used                */
 };
 
 /* TODO: Long-term, it would be helpful if we made this struct and other OCSP

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -332,7 +332,7 @@ typedef struct EncryptedInfo {
     char     name[NAME_SZ];    /* cipher name, such as "DES-CBC" */
     byte     iv[IV_SZ];        /* salt or encrypted IV */
 
-    word16   set:1;            /* if encryption set */
+    WC_BITFIELD set:1;         /* if encryption set */
 #endif
 } EncryptedInfo;
 
@@ -347,7 +347,7 @@ typedef struct WOLFSSL_ASN1_INTEGER {
 
     unsigned char* data;
     unsigned int   dataMax;   /* max size of data buffer */
-    unsigned int   isDynamic:1; /* flag for if data pointer dynamic (1 is yes 0 is no) */
+    WC_BITFIELD    isDynamic:1; /* flag for if data pointer dynamic (1 is yes 0 is no) */
 
     int length;   /* Length of DER encoding. */
     int type;     /* ASN.1 type. Includes negative flag. */
@@ -549,13 +549,13 @@ typedef struct Cert {
     void*   decodedCert;      /* internal DecodedCert allocated from heap */
     byte*   der;              /* Pointer to buffer of current DecodedCert cache */
     void*   heap;             /* heap hint */
-    byte    basicConstSet:1;  /* Indicator for when Basic Constraint is set */
+    WC_BITFIELD basicConstSet:1;  /* Indicator for when Basic Constraint is set */
 #ifdef WOLFSSL_ALLOW_ENCODING_CA_FALSE
-    byte    isCaSet:1;        /* Indicator for when isCA is set */
+    WC_BITFIELD isCaSet:1;        /* Indicator for when isCA is set */
 #endif
-    byte    pathLenSet:1;     /* Indicator for when path length is set */
+    WC_BITFIELD pathLenSet:1;     /* Indicator for when path length is set */
 #ifdef WOLFSSL_ALT_NAMES
-    byte    altNamesCrit:1;   /* Indicator of criticality of SAN extension */
+    WC_BITFIELD altNamesCrit:1;   /* Indicator of criticality of SAN extension */
 #endif
 } Cert;
 
@@ -937,9 +937,9 @@ typedef struct _wc_CertPIV {
     word32       signedNonceSz; /* Identiv Only */
 
     /* flags */
-    word16       compression:2;
-    word16       isX509:1;
-    word16       isIdentiv:1;
+    WC_BITFIELD  compression:2;
+    WC_BITFIELD  isX509:1;
+    WC_BITFIELD  isIdentiv:1;
 } wc_CertPIV;
 
 WOLFSSL_API int wc_ParseCertPIV(wc_CertPIV* cert, const byte* buf, word32 totalSz);
@@ -1007,7 +1007,7 @@ enum Asn1PrintOpt {
     /* Don't show text representations of primitive types. */
     ASN1_PRINT_OPT_SHOW_NO_TEXT,
     /* Don't show dump text representations of primitive types. */
-    ASN1_PRINT_OPT_SHOW_NO_DUMP_TEXT,
+    ASN1_PRINT_OPT_SHOW_NO_DUMP_TEXT
 };
 
 /* ASN.1 print options. */
@@ -1019,17 +1019,17 @@ typedef struct Asn1PrintOptions {
     /* Number of spaces to indent for each change in depth. */
     word8 indent;
     /* Draw branches instead of indenting. */
-    word8 draw_branch:1;
+    WC_BITFIELD draw_branch:1;
     /* Show raw data of primitive types as octets. */
-    word8 show_data:1;
+    WC_BITFIELD show_data:1;
     /* Show header data as octets. */
-    word8 show_header_data:1;
+    WC_BITFIELD show_header_data:1;
     /* Show the wolfSSL OID value for OBJECT_ID. */
-    word8 show_oid:1;
+    WC_BITFIELD show_oid:1;
     /* Don't show text representations of primitive types. */
-    word8 show_no_text:1;
+    WC_BITFIELD show_no_text:1;
     /* Don't show dump text representations of primitive types. */
-    word8 show_no_dump_text:1;
+    WC_BITFIELD show_no_dump_text:1;
 } Asn1PrintOptions;
 
 /* ASN.1 item data. */

--- a/wolfssl/wolfcrypt/chacha20_poly1305.h
+++ b/wolfssl/wolfcrypt/chacha20_poly1305.h
@@ -72,7 +72,7 @@ typedef struct ChaChaPoly_Aead {
     word32   dataLen;
 
     byte     state;
-    byte     isEncrypt:1;
+    WC_BITFIELD isEncrypt:1;
 } ChaChaPoly_Aead;
 
 

--- a/wolfssl/wolfcrypt/curve25519.h
+++ b/wolfssl/wolfcrypt/curve25519.h
@@ -97,9 +97,9 @@ struct curve25519_key {
 #endif
 
     /* bit fields */
-    byte pubSet:1;
-    byte privSet:1;
-    byte isAllocated:1; /* flag indicates if structure was allocated */
+    WC_BITFIELD pubSet:1;
+    WC_BITFIELD privSet:1;
+    WC_BITFIELD isAllocated:1; /* flag indicates if structure was allocated */
 };
 
 enum {

--- a/wolfssl/wolfcrypt/curve448.h
+++ b/wolfssl/wolfcrypt/curve448.h
@@ -58,8 +58,8 @@ struct curve448_key {
 #endif
 
     /* bit fields */
-    byte pubSet:1;
-    byte privSet:1;
+    WC_BITFIELD pubSet:1;
+    WC_BITFIELD privSet:1;
 };
 
 enum {

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -467,7 +467,7 @@ struct ecc_point {
 #if defined(WOLFSSL_SMALL_STACK_CACHE) && !defined(WOLFSSL_ECC_NO_SMALL_STACK)
     ecc_key* key;
 #endif
-    byte isAllocated:1;
+    WC_BITFIELD isAllocated:1;
 };
 
 /* ECC Flags */
@@ -590,12 +590,12 @@ struct ecc_key {
     mp_int* sign_k;
 #else
     mp_int sign_k[1];
-    byte sign_k_set:1;
+    WC_BITFIELD sign_k_set:1;
 #endif
 #endif
 #if defined(WOLFSSL_ECDSA_DETERMINISTIC_K) || \
     defined(WOLFSSL_ECDSA_DETERMINISTIC_K_VARIANT)
-    byte deterministic:1;
+    WC_BITFIELD deterministic:1;
     enum wc_HashType hashType;
 #endif
 

--- a/wolfssl/wolfcrypt/eccsi.h
+++ b/wolfssl/wolfcrypt/eccsi.h
@@ -62,15 +62,15 @@ typedef struct EccsiKeyParams {
     ecc_point* base;
 
     /** Bit indicates order (q) is set as an MP integer in ECCSI key. */
-    byte haveOrder:1;
+    WC_BITFIELD haveOrder:1;
     /** Bit indicates A is set as an MP integer in ECCSI key. */
-    byte haveA:1;
+    WC_BITFIELD haveA:1;
     /** Bit indicates B is set as an MP integer in ECCSI key. */
-    byte haveB:1;
+    WC_BITFIELD haveB:1;
     /** Bit indicates prime is set as an MP integer in ECCSI key. */
-    byte havePrime:1;
+    WC_BITFIELD havePrime:1;
     /** Bit indicates base point is set as an MP integer in ECCSI key. */
-    byte haveBase:1;
+    WC_BITFIELD haveBase:1;
 } EccsiKeyParams;
 
 /**
@@ -104,7 +104,7 @@ typedef struct EccsiKey {
     /** Heap hint for dynamic memory allocation. */
     void* heap;
     /** Bit indicates KPAK (public key) is in montgomery form. */
-    word16 kpakMont:1;
+    WC_BITFIELD kpakMont:1;
 } EccsiKey;
 
 #ifdef __cplusplus

--- a/wolfssl/wolfcrypt/ed25519.h
+++ b/wolfssl/wolfcrypt/ed25519.h
@@ -94,8 +94,11 @@ struct ed25519_key {
     word32 flags;
     byte   keyIdSet;
 #endif
-    word16 privKeySet:1;
-    word16 pubKeySet:1;
+    WC_BITFIELD privKeySet:1;
+    WC_BITFIELD pubKeySet:1;
+    WC_BITFIELD sha_clean_flag:1; /* only used if WOLFSSL_ED25519_PERSISTENT_SHA */
+    /* flag indicates if structure was allocated */
+    WC_BITFIELD isAllocated:1;
 #ifdef WOLFSSL_ASYNC_CRYPT
     WC_ASYNC_DEV asyncDev;
 #endif
@@ -106,10 +109,7 @@ struct ed25519_key {
     void *heap;
 #ifdef WOLFSSL_ED25519_PERSISTENT_SHA
     wc_Sha512 sha;
-    byte sha_clean_flag : 1;
 #endif
-    /* flag indicates if structure was allocated */
-    byte isAllocated : 1;
 };
 
 #ifndef WC_ED25519KEY_TYPE_DEFINED

--- a/wolfssl/wolfcrypt/ed448.h
+++ b/wolfssl/wolfcrypt/ed448.h
@@ -85,8 +85,8 @@ struct ed448_key {
     byte pointX[ED448_KEY_SIZE]; /* recovered X coordinate */
     byte pointY[ED448_KEY_SIZE]; /* Y coordinate is the public key with The most significant bit of the final octet always zero. */
 #endif
-    word16 privKeySet:1;
-    word16 pubKeySet:1;
+    WC_BITFIELD privKeySet:1;
+    WC_BITFIELD pubKeySet:1;
 #ifdef WOLFSSL_ASYNC_CRYPT
     WC_ASYNC_DEV asyncDev;
 #endif

--- a/wolfssl/wolfcrypt/hash.h
+++ b/wolfssl/wolfcrypt/hash.h
@@ -80,7 +80,7 @@ enum wc_MACAlgorithm {
     sha512_mac,
     rmd_mac,
     blake2b_mac,
-    sm3_mac,
+    sm3_mac
 };
 
 enum wc_HashFlags {
@@ -125,7 +125,7 @@ typedef union {
 typedef struct {
     wc_Hashes alg;
     enum wc_HashType type; /* sanity check */
-    byte isAllocated:1; /* flag indicates if structure was allocated */
+    WC_BITFIELD isAllocated:1; /* flag indicates if structure was allocated */
 } wc_HashAlg;
 #endif /* !NO_HASH_WRAPPER */
 

--- a/wolfssl/wolfcrypt/kdf.h
+++ b/wolfssl/wolfcrypt/kdf.h
@@ -140,7 +140,7 @@ WOLFSSL_API int wc_SSH_KDF(byte hashId, byte keyId,
 /* Indicators */
 enum {
     WC_SRTCP_32BIT_IDX = 0,
-    WC_SRTCP_48BIT_IDX = 1,
+    WC_SRTCP_48BIT_IDX = 1
 };
 
 /* Maximum length of salt that can be used with SRTP/SRTCP. */

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -257,8 +257,8 @@ struct PKCS7 {
     CallbackStreamOut  streamOutCb;
     void*  streamCtx; /* passed to getcontentCb and streamOutCb */
 #endif
-    byte   encodeStream:1;        /* use BER when encoding */
-    byte   noCerts:1;             /* if certificates should be added into bundle
+    WC_BITFIELD encodeStream:1;   /* use BER when encoding */
+    WC_BITFIELD noCerts:1;        /* if certificates should be added into bundle
                                      during creation */
     byte*  cert[MAX_PKCS7_CERTS]; /* array of certs parsed from bundle */
     byte*  verifyCert;            /* cert from array used for verify */
@@ -296,9 +296,9 @@ struct PKCS7 {
     word32 certSz[MAX_PKCS7_CERTS];
 
      /* flags - up to 16-bits */
-    word16 isDynamic:1;
-    word16 noDegenerate:1; /* allow degenerate case in verify function */
-    word16 detached:1;     /* generate detached SignedData signature bundles */
+    WC_BITFIELD isDynamic:1;
+    WC_BITFIELD noDegenerate:1;   /* allow degenerate case in verify function */
+    WC_BITFIELD detached:1;       /* generate detached SignedData signature bundles */
 
     byte contentType[MAX_OID_SZ]; /* custom contentType byte array */
     word32 contentTypeSz;         /* size of contentType, bytes */
@@ -356,9 +356,9 @@ struct PKCS7 {
     /* used by DecodeEnvelopedData with multiple encrypted contents */
     byte*  cachedEncryptedContent;
     word32 cachedEncryptedContentSz;
-    word16 contentCRLF:1; /* have content line endings been converted to CRLF */
-    word16 contentIsPkcs7Type:1; /* eContent follows PKCS#7 RFC not CMS */
-    word16 hashParamsAbsent:1;
+    WC_BITFIELD contentCRLF:1; /* have content line endings been converted to CRLF */
+    WC_BITFIELD contentIsPkcs7Type:1; /* eContent follows PKCS#7 RFC not CMS */
+    WC_BITFIELD hashParamsAbsent:1;
 
     /* RFC 5280 section-4.2.1.2 lists a possible method for creating the SKID as
      * a SHA1 hash of the public key, but leaves it open to other methods as

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -269,7 +269,7 @@ struct RsaKey {
 #if defined(WOLFSSL_RENESAS_FSPSM)
     FSPSM_RSA_CTX ctx;
 #endif
-    byte isAllocated:1; /* flag indicates if structure was allocated */
+    WC_BITFIELD isAllocated:1; /* flag indicates if structure was allocated */
 };
 
 #ifndef WC_RSAKEY_TYPE_DEFINED

--- a/wolfssl/wolfcrypt/sakke.h
+++ b/wolfssl/wolfcrypt/sakke.h
@@ -64,15 +64,15 @@ typedef struct SakkeKeyParams {
     ecc_point* base;
 
     /** Bit indicate prime is set as an MP integer in SAKKE key. */
-    byte havePrime:1;
+    WC_BITFIELD havePrime:1;
     /** Bit indicates q (order) is set as an MP integer in SAKKE key. */
-    byte haveQ:1;
+    WC_BITFIELD haveQ:1;
     /** Bit indicates g (pairing base) is set as an MP integer in SAKKE key. */
-    byte haveG:1;
+    WC_BITFIELD haveG:1;
     /** Bit indicates a is set as an MP integer in SAKKE key. */
-    byte haveA:1;
+    WC_BITFIELD haveA:1;
     /** Bit indicates base point is set as an ECC point in SAKKE key. */
-    byte haveBase:1;
+    WC_BITFIELD haveBase:1;
 } SakkeKeyParams;
 
 /** Temporary values to use in SAKKE calculations. */
@@ -116,7 +116,7 @@ typedef struct SakkeKeyRsk {
     /** Length of table */
     word32 tableLen;
     /** Indicates whether an RSK value has been set. */
-    byte set:1;
+    WC_BITFIELD set:1;
 } SakkeKeyRsk;
 #endif
 
@@ -153,9 +153,9 @@ typedef struct SakkeKey {
     void* heap;
 
     /** Bit indicates Z, public key, is in montgomery form. */
-    byte zMont:1;
+    WC_BITFIELD zMont:1;
     /** Bit indicate MP integers have been initialized. */
-    byte mpInit:1;
+    WC_BITFIELD mpInit:1;
 } SakkeKey;
 
 #ifdef __cplusplus

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2743,7 +2743,7 @@ extern void uITRON4_free(void *p) ;
     #undef WOLFSSL_SP_INT_DIGIT_ALIGN
     #define WOLFSSL_SP_INT_DIGIT_ALIGN
 #endif
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(WOLF_C89)
     #define WOLFSSL_SP_NO_DYN_STACK
 #endif
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -112,6 +112,10 @@ decouple library dependencies with standard string, memory and so on.
         typedef const char* const wcchar;
     #endif
 
+    #ifndef WC_BITFIELD
+        #define WC_BITFIELD byte
+    #endif
+
     #ifndef HAVE_ANONYMOUS_INLINE_AGGREGATES
         /* if a version is available, pivot on the version, otherwise guess it's
          * allowed, subject to override.
@@ -1108,7 +1112,7 @@ typedef struct w64wrapper {
         DYNAMIC_TYPE_SNIFFER_NAMED_KEY   = 1005,
         DYNAMIC_TYPE_SNIFFER_KEY         = 1006,
         DYNAMIC_TYPE_SNIFFER_KEYLOG_NODE = 1007,
-        DYNAMIC_TYPE_AES_EAX = 1008,
+        DYNAMIC_TYPE_AES_EAX = 1008
     };
 
     /* max error buffer string size */


### PR DESCRIPTION
clean up wolfcrypt code base for `-std=c89 -pedantic`: add `WC_BITFIELD` macro to avoid `-Wpedantic`s for "type of bit-field ... is a GCC extension", with overrideable default definition `byte`, and replace parent types of all bitfields with `WC_BITFIELD`;

fix numerous trailing commas in `enum`s, mostly by removing them, but one (in `asn.h`, `enum Extensions_Sum`) using `WOLF_ENUM_DUMMY_LAST_ELEMENT()`;

rearrange bitfields in `struct ed25519_key` for contiguity;

always define `WOLFSSL_SP_NO_DYN_STACK` when `defined(WOLF_C89)`.

tested with `wolfssl-multi-test.sh ... allcryptonly-gcc-c89` with `allcryptonly-gcc-c89` updated to test this configuration:
```
./configure --enable-sp-math-all --disable-inline --enable-cryptonly --enable-all-crypto --disable-examples --disable-crypttests --disable-benchmark CC=gcc CFLAGS="-std=c89 -pedantic -DWOLF_C89 -Wvla -Wdeclaration-after-statement -Wno-variadic-macros -DWOLFCRYPT_TEST_LINT -DWC_BITFIELD=unsigned"
```

also tested with `wolfssl-multi-test.sh ... super-quick-check`


re ZD#18760
