### PR TITLE
ARM32 ASM: regeneration after scripts changes

### DIFF
--- a/wolfcrypt/src/port/arm/armv8-32-aes-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-aes-asm_c.c
@@ -406,9 +406,9 @@ void AES_invert_key(unsigned char* ks_p, word32 rounds_p)
         "str	r8, [%[ks]], #4\n\t"
         "subs	r11, r11, #1\n\t"
         "bne	L_AES_invert_key_mix_loop_%=\n\t"
-        : [ks] "+r" (ks),  [rounds] "+r" (rounds),
-            [L_AES_ARM32_te] "+r" (L_AES_ARM32_te_c),
-            [L_AES_ARM32_td] "+r" (L_AES_ARM32_td_c)
+        : [ks] "+r" (ks), [rounds] "+r" (rounds),
+          [L_AES_ARM32_te] "+r" (L_AES_ARM32_te_c),
+          [L_AES_ARM32_td] "+r" (L_AES_ARM32_td_c)
         :
         : "memory", "cc", "r12", "lr", "r4", "r5", "r6", "r7", "r8", "r9",
             "r10", "r11"
@@ -933,9 +933,9 @@ void AES_set_encrypt_key(const unsigned char* key_p, word32 len_p,
         "bne	L_AES_set_encrypt_key_loop_128_%=\n\t"
         "\n"
     "L_AES_set_encrypt_key_end_%=: \n\t"
-        : [key] "+r" (key),  [len] "+r" (len),  [ks] "+r" (ks),
-            [L_AES_ARM32_te] "+r" (L_AES_ARM32_te_c),
-            [L_AES_ARM32_rcon] "+r" (L_AES_ARM32_rcon_c)
+        : [key] "+r" (key), [len] "+r" (len), [ks] "+r" (ks),
+          [L_AES_ARM32_te] "+r" (L_AES_ARM32_te_c),
+          [L_AES_ARM32_rcon] "+r" (L_AES_ARM32_rcon_c)
         :
         : "memory", "cc", "r12", "lr", "r5", "r6", "r7", "r8"
     );
@@ -1588,7 +1588,7 @@ void AES_encrypt_block(const uint32_t* te_p, int nr_p, int len_p,
         "eor	r5, r5, r9\n\t"
         "eor	r6, r6, r10\n\t"
         "eor	r7, r7, r11\n\t"
-        : [te] "+r" (te),  [nr] "+r" (nr),  [len] "+r" (len),  [ks] "+r" (ks)
+        : [te] "+r" (te), [nr] "+r" (nr), [len] "+r" (len), [ks] "+r" (ks)
         :
         : "memory", "cc", "lr"
     );
@@ -1841,8 +1841,8 @@ void AES_ECB_encrypt(const unsigned char* in_p, unsigned char* out_p,
         "\n"
     "L_AES_ECB_encrypt_end_%=: \n\t"
         "pop	{%[ks]}\n\t"
-        : [in] "+r" (in),  [out] "+r" (out),  [len] "+r" (len),  [ks] "+r" (ks),
-             [nr] "+r" (nr), [L_AES_ARM32_te_ecb] "+r" (L_AES_ARM32_te_ecb_c)
+        : [in] "+r" (in), [out] "+r" (out), [len] "+r" (len), [ks] "+r" (ks),
+          [nr] "+r" (nr), [L_AES_ARM32_te_ecb] "+r" (L_AES_ARM32_te_ecb_c)
         :
         : "memory", "cc", "r12", "lr", "r6", "r7", "r8", "r9", "r10", "r11"
     );
@@ -2114,9 +2114,9 @@ void AES_CBC_encrypt(const unsigned char* in_p, unsigned char* out_p,
     "L_AES_CBC_encrypt_end_%=: \n\t"
         "pop	{%[ks], r9}\n\t"
         "stm	r9, {r4, r5, r6, r7}\n\t"
-        : [in] "+r" (in),  [out] "+r" (out),  [len] "+r" (len),  [ks] "+r" (ks),
-             [nr] "+r" (nr),  [iv] "+r" (iv),
-            [L_AES_ARM32_te_cbc] "+r" (L_AES_ARM32_te_cbc_c)
+        : [in] "+r" (in), [out] "+r" (out), [len] "+r" (len), [ks] "+r" (ks),
+          [nr] "+r" (nr), [iv] "+r" (iv),
+          [L_AES_ARM32_te_cbc] "+r" (L_AES_ARM32_te_cbc_c)
         :
         : "memory", "cc", "r12", "lr", "r7", "r8", "r9", "r10", "r11"
     );
@@ -2389,9 +2389,9 @@ void AES_CTR_encrypt(const unsigned char* in_p, unsigned char* out_p,
         "rev	r7, r7\n\t"
 #endif /* WOLFSSL_ARM_ARCH && WOLFSSL_ARM_ARCH < 6 */
         "stm	r8, {r4, r5, r6, r7}\n\t"
-        : [in] "+r" (in),  [out] "+r" (out),  [len] "+r" (len),  [ks] "+r" (ks),
-             [nr] "+r" (nr),  [ctr] "+r" (ctr),
-            [L_AES_ARM32_te_ctr] "+r" (L_AES_ARM32_te_ctr_c)
+        : [in] "+r" (in), [out] "+r" (out), [len] "+r" (len), [ks] "+r" (ks),
+          [nr] "+r" (nr), [ctr] "+r" (ctr),
+          [L_AES_ARM32_te_ctr] "+r" (L_AES_ARM32_te_ctr_c)
         :
         : "memory", "cc", "r12", "lr", "r7", "r8", "r9", "r10", "r11"
     );
@@ -3045,7 +3045,7 @@ void AES_decrypt_block(const uint32_t* td_p, int nr_p, const uint8_t* td4_p)
         "eor	r5, r5, r9\n\t"
         "eor	r6, r6, r10\n\t"
         "eor	r7, r7, r11\n\t"
-        : [td] "+r" (td),  [nr] "+r" (nr),  [td4] "+r" (td4)
+        : [td] "+r" (td), [nr] "+r" (nr), [td4] "+r" (td4)
         :
         : "memory", "cc", "lr"
     );
@@ -3331,9 +3331,9 @@ void AES_ECB_decrypt(const unsigned char* in_p, unsigned char* out_p,
         "bne	L_AES_ECB_decrypt_loop_block_128_%=\n\t"
         "\n"
     "L_AES_ECB_decrypt_end_%=: \n\t"
-        : [in] "+r" (in),  [out] "+r" (out),  [len] "+r" (len),  [ks] "+r" (ks),
-             [nr] "+r" (nr), [L_AES_ARM32_td_ecb] "+r" (L_AES_ARM32_td_ecb_c),
-            [L_AES_ARM32_td4] "+r" (L_AES_ARM32_td4_c)
+        : [in] "+r" (in), [out] "+r" (out), [len] "+r" (len), [ks] "+r" (ks),
+          [nr] "+r" (nr), [L_AES_ARM32_td_ecb] "+r" (L_AES_ARM32_td_ecb_c),
+          [L_AES_ARM32_td4] "+r" (L_AES_ARM32_td4_c)
         :
         : "memory", "cc", "r12", "lr", "r7", "r8", "r9", "r10", "r11"
     );
@@ -3971,10 +3971,10 @@ void AES_CBC_decrypt(const unsigned char* in_p, unsigned char* out_p,
         "\n"
     "L_AES_CBC_decrypt_end_%=: \n\t"
         "pop	{%[ks]-r4}\n\t"
-        : [in] "+r" (in),  [out] "+r" (out),  [len] "+r" (len),  [ks] "+r" (ks),
-             [nr] "+r" (nr),  [iv] "+r" (iv),
-            [L_AES_ARM32_td_ecb] "+r" (L_AES_ARM32_td_ecb_c),
-            [L_AES_ARM32_td4] "+r" (L_AES_ARM32_td4_c)
+        : [in] "+r" (in), [out] "+r" (out), [len] "+r" (len), [ks] "+r" (ks),
+          [nr] "+r" (nr), [iv] "+r" (iv),
+          [L_AES_ARM32_td_ecb] "+r" (L_AES_ARM32_td_ecb_c),
+          [L_AES_ARM32_td4] "+r" (L_AES_ARM32_td4_c)
         :
         : "memory", "cc", "r12", "lr", "r8", "r9", "r10", "r11"
     );
@@ -4576,8 +4576,8 @@ void GCM_gmult_len(unsigned char* x_p, const unsigned char** m_p,
         "subs	%[len], %[len], #16\n\t"
         "add	%[data], %[data], #16\n\t"
         "bne	L_GCM_gmult_len_start_block_%=\n\t"
-        : [x] "+r" (x),  [m] "+r" (m),  [data] "+r" (data),  [len] "+r" (len),
-            [L_GCM_gmult_len_r] "+r" (L_GCM_gmult_len_r_c)
+        : [x] "+r" (x), [m] "+r" (m), [data] "+r" (data), [len] "+r" (len),
+          [L_GCM_gmult_len_r] "+r" (L_GCM_gmult_len_r_c)
         :
         : "memory", "cc", "r12", "lr", "r5", "r6", "r7", "r8", "r9", "r10",
             "r11"
@@ -4840,9 +4840,9 @@ void AES_GCM_encrypt(const unsigned char* in_p, unsigned char* out_p,
         "rev	r7, r7\n\t"
 #endif /* WOLFSSL_ARM_ARCH && WOLFSSL_ARM_ARCH < 6 */
         "stm	r8, {r4, r5, r6, r7}\n\t"
-        : [in] "+r" (in),  [out] "+r" (out),  [len] "+r" (len),  [ks] "+r" (ks),
-             [nr] "+r" (nr),  [ctr] "+r" (ctr),
-            [L_AES_ARM32_te_gcm] "+r" (L_AES_ARM32_te_gcm_c)
+        : [in] "+r" (in), [out] "+r" (out), [len] "+r" (len), [ks] "+r" (ks),
+          [nr] "+r" (nr), [ctr] "+r" (ctr),
+          [L_AES_ARM32_te_gcm] "+r" (L_AES_ARM32_te_gcm_c)
         :
         : "memory", "cc", "r12", "lr", "r7", "r8", "r9", "r10", "r11"
     );

--- a/wolfcrypt/src/port/arm/armv8-32-chacha-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-chacha-asm_c.c
@@ -71,7 +71,7 @@ void wc_chacha_setiv(word32* x_p, const byte* iv_p, word32 counter_p)
         "rev	lr, lr\n\t"
 #endif /* BIG_ENDIAN_ORDER */
         "stm	r3, {r4, r12, lr}\n\t"
-        : [x] "+r" (x),  [iv] "+r" (iv),  [counter] "+r" (counter)
+        : [x] "+r" (x), [iv] "+r" (iv), [counter] "+r" (counter)
         :
         : "memory", "cc", "r3", "r12", "lr", "r4"
     );
@@ -119,8 +119,8 @@ void wc_chacha_setkey(word32* x_p, const byte* key_p, word32 keySz_p)
         "\n"
     "L_chacha_arm32_setkey_same_keyb_ytes_%=: \n\t"
         "stm	%[x], {r4, r5, r12, lr}\n\t"
-        : [x] "+r" (x),  [key] "+r" (key),  [keySz] "+r" (keySz),
-            [L_chacha_arm32_constants] "+r" (L_chacha_arm32_constants_c)
+        : [x] "+r" (x), [key] "+r" (key), [keySz] "+r" (keySz),
+          [L_chacha_arm32_constants] "+r" (L_chacha_arm32_constants_c)
         :
         : "memory", "cc", "r12", "lr", "r4", "r5"
     );
@@ -484,7 +484,7 @@ void wc_chacha_crypt_bytes(ChaCha* ctx_p, byte* c_p, const byte* m_p,
         "\n"
     "L_chacha_arm32_crypt_done_%=: \n\t"
         "add	sp, sp, #52\n\t"
-        : [ctx] "+r" (ctx),  [c] "+r" (c),  [m] "+r" (m),  [len] "+r" (len)
+        : [ctx] "+r" (ctx), [c] "+r" (c), [m] "+r" (m), [len] "+r" (len)
         :
         : "memory", "cc", "r12", "lr", "r4", "r5", "r6", "r7", "r8", "r9",
             "r10", "r11"
@@ -557,8 +557,8 @@ void wc_chacha_use_over(byte* over_p, byte* output_p, const byte* input_p,
         "b	L_chacha_arm32_over_byte_loop_%=\n\t"
         "\n"
     "L_chacha_arm32_over_done_%=: \n\t"
-        : [over] "+r" (over),  [output] "+r" (output),  [input] "+r" (input),
-             [len] "+r" (len)
+        : [over] "+r" (over), [output] "+r" (output), [input] "+r" (input),
+          [len] "+r" (len)
         :
         : "memory", "cc", "r12", "lr", "r4", "r5", "r6", "r7", "r8", "r9"
     );

--- a/wolfcrypt/src/port/arm/armv8-32-curve25519_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-curve25519_c.c
@@ -335,7 +335,7 @@ void fe_sub(fe r_p, const fe a_p, const fe b_p)
 
     __asm__ __volatile__ (
         "bl	fe_sub_op\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b)
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
         : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
             "r11", "r12", "lr"
@@ -393,7 +393,7 @@ void fe_add(fe r_p, const fe a_p, const fe b_p)
 
     __asm__ __volatile__ (
         "bl	fe_add_op\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b)
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
         : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
             "r11", "r12", "lr"
@@ -428,7 +428,7 @@ void fe_frombytes(fe out_p, const unsigned char* in_p)
         "str	r7, [%[out], #20]\n\t"
         "str	r8, [%[out], #24]\n\t"
         "str	r9, [%[out], #28]\n\t"
-        : [out] "+r" (out),  [in] "+r" (in)
+        : [out] "+r" (out), [in] "+r" (in)
         :
         : "memory", "cc", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9"
     );
@@ -472,7 +472,7 @@ void fe_tobytes(unsigned char* out_p, const fe n_p)
         "str	r7, [%[out], #20]\n\t"
         "str	r8, [%[out], #24]\n\t"
         "str	r9, [%[out], #28]\n\t"
-        : [out] "+r" (out),  [n] "+r" (n)
+        : [out] "+r" (out), [n] "+r" (n)
         :
         : "memory", "cc", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r12"
     );
@@ -575,7 +575,7 @@ void fe_copy(fe r_p, const fe a_p)
 #else
         "strd	r4, r5, [%[r], #24]\n\t"
 #endif
-        : [r] "+r" (r),  [a] "+r" (a)
+        : [r] "+r" (r), [a] "+r" (a)
         :
         : "memory", "cc", "r2", "r3", "r4", "r5"
     );
@@ -602,7 +602,7 @@ void fe_neg(fe r_p, const fe a_p)
         "sbcs	r4, lr, r4\n\t"
         "sbc	r5, r12, r5\n\t"
         "stm	%[r]!, {r2, r3, r4, r5}\n\t"
-        : [r] "+r" (r),  [a] "+r" (a)
+        : [r] "+r" (r), [a] "+r" (a)
         :
         : "memory", "cc", "r2", "r3", "r4", "r5", "r12", "lr"
     );
@@ -2407,7 +2407,7 @@ void fe_cmov_table(fe* r_p, fe* base_p, signed char b_p)
 #else
         "strd	r8, r9, [%[r], #88]\n\t"
 #endif
-        : [r] "+r" (r),  [base] "+r" (base),  [b] "+r" (b)
+        : [r] "+r" (r), [base] "+r" (base), [b] "+r" (b)
         :
         : "memory", "cc", "r4", "r5", "r6", "r7", "r8", "r9", "r3", "r10",
             "r11", "r12", "lr"
@@ -2528,7 +2528,7 @@ void fe_cmov_table(fe* r_p, fe* base_p, signed char b_p)
         "and	r7, r7, lr\n\t"
         "stm	%[r]!, {r4, r5, r6, r7}\n\t"
         "sub	%[base], %[base], %[b]\n\t"
-        : [r] "+r" (r),  [base] "+r" (base),  [b] "+r" (b)
+        : [r] "+r" (r), [base] "+r" (base), [b] "+r" (b)
         :
         : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
             "r11", "r12", "lr"
@@ -3074,7 +3074,7 @@ void fe_mul(fe r_p, const fe a_p, const fe b_p)
 
     __asm__ __volatile__ (
         "bl	fe_mul_op\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b)
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
         : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
             "r11", "r12", "lr"
@@ -3495,7 +3495,7 @@ void fe_sq(fe r_p, const fe a_p)
 
     __asm__ __volatile__ (
         "bl	fe_sq_op\n\t"
-        : [r] "+r" (r),  [a] "+r" (a)
+        : [r] "+r" (r), [a] "+r" (a)
         :
         : "memory", "cc", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r12",
             "lr", "r10", "r11"
@@ -3572,7 +3572,7 @@ void fe_mul121666(fe r_p, fe a_p)
         "adcs	r8, r8, #0\n\t"
         "adc	r9, r9, #0\n\t"
         "stm	%[r], {r2, r3, r4, r5, r6, r7, r8, r9}\n\t"
-        : [r] "+r" (r),  [a] "+r" (a)
+        : [r] "+r" (r), [a] "+r" (a)
         :
         : "memory", "cc", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r12",
             "lr", "r10"
@@ -3635,7 +3635,7 @@ void fe_mul121666(fe r_p, fe a_p)
         "adcs	r8, r8, #0\n\t"
         "adc	r9, r9, #0\n\t"
         "stm	%[r], {r2, r3, r4, r5, r6, r7, r8, r9}\n\t"
-        : [r] "+r" (r),  [a] "+r" (a)
+        : [r] "+r" (r), [a] "+r" (a)
         :
         : "memory", "cc", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r12",
             "lr", "r10"
@@ -4026,7 +4026,7 @@ int curve25519(byte* r_p, const byte* n_p, const byte* a_p)
         "bl	fe_mul_op\n\t"
         "mov	r0, #0\n\t"
         "add	sp, sp, #0xbc\n\t"
-        : [r] "+r" (r),  [n] "+r" (n),  [a] "+r" (a)
+        : [r] "+r" (r), [n] "+r" (n), [a] "+r" (a)
         :
         : "memory", "cc", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11",
             "r3", "r12", "lr"
@@ -4340,7 +4340,7 @@ int curve25519(byte* r_p, const byte* n_p, const byte* a_p)
         "stm	%[r], {r4, r5, r6, r7, r8, r9, r10, r11}\n\t"
         "mov	r0, #0\n\t"
         "add	sp, sp, #0xc0\n\t"
-        : [r] "+r" (r),  [n] "+r" (n),  [a] "+r" (a)
+        : [r] "+r" (r), [n] "+r" (n), [a] "+r" (a)
         :
         : "memory", "cc", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11",
             "r3", "r12", "lr"
@@ -4515,7 +4515,7 @@ void fe_invert(fe r_p, const fe a_p)
         "ldr	%[a], [sp, #132]\n\t"
         "ldr	%[r], [sp, #128]\n\t"
         "add	sp, sp, #0x88\n\t"
-        : [r] "+r" (r),  [a] "+r" (a)
+        : [r] "+r" (r), [a] "+r" (a)
         :
         : "memory", "cc", "lr", "r12", "r2", "r3", "r4", "r5", "r6", "r7", "r8",
             "r9", "r10", "r11"
@@ -4836,7 +4836,7 @@ void fe_sq2(fe r_p, const fe a_p)
         "ldr	r0, [sp, #64]\n\t"
         "stm	r0, {r1, r2, r3, r4, r5, r6, r7, r8}\n\t"
         "add	sp, sp, #0x44\n\t"
-        : [r] "+r" (r),  [a] "+r" (a)
+        : [r] "+r" (r), [a] "+r" (a)
         :
         : "memory", "cc", "lr"
     );
@@ -5015,7 +5015,7 @@ void fe_sq2(fe r_p, const fe a_p)
         "stm	r12, {r0, r1, r2, r3, r4, r5, r6, r7}\n\t"
         "mov	r0, r12\n\t"
         "mov	r1, lr\n\t"
-        : [r] "+r" (r),  [a] "+r" (a)
+        : [r] "+r" (r), [a] "+r" (a)
         :
         : "memory", "cc", "lr"
     );
@@ -5186,7 +5186,7 @@ void fe_pow22523(fe r_p, const fe a_p)
         "ldr	%[a], [sp, #100]\n\t"
         "ldr	%[r], [sp, #96]\n\t"
         "add	sp, sp, #0x68\n\t"
-        : [r] "+r" (r),  [a] "+r" (a)
+        : [r] "+r" (r), [a] "+r" (a)
         :
         : "memory", "cc", "lr", "r12", "r2", "r3", "r4", "r5", "r6", "r7", "r8",
             "r9", "r10", "r11"
@@ -5217,7 +5217,7 @@ void ge_p1p1_to_p2(ge_p2 * r_p, const ge_p1p1 * p_p)
         "add	r0, r0, #0x40\n\t"
         "bl	fe_mul_op\n\t"
         "add	sp, sp, #8\n\t"
-        : [r] "+r" (r),  [p] "+r" (p)
+        : [r] "+r" (r), [p] "+r" (p)
         :
         : "memory", "cc", "lr", "r2", "r3", "r12", "r4", "r5", "r6", "r7", "r8",
             "r9", "r10", "r11"
@@ -5253,7 +5253,7 @@ void ge_p1p1_to_p3(ge_p3 * r_p, const ge_p1p1 * p_p)
         "add	r0, r0, #0x60\n\t"
         "bl	fe_mul_op\n\t"
         "add	sp, sp, #8\n\t"
-        : [r] "+r" (r),  [p] "+r" (p)
+        : [r] "+r" (r), [p] "+r" (p)
         :
         : "memory", "cc", "lr", "r2", "r3", "r12", "r4", "r5", "r6", "r7", "r8",
             "r9", "r10", "r11"
@@ -5301,7 +5301,7 @@ void ge_p2_dbl(ge_p1p1 * r_p, const ge_p2 * p_p)
         "mov	r1, r0\n\t"
         "bl	fe_sub_op\n\t"
         "add	sp, sp, #8\n\t"
-        : [r] "+r" (r),  [p] "+r" (p)
+        : [r] "+r" (r), [p] "+r" (p)
         :
         : "memory", "cc", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
             "r11", "r12", "lr"
@@ -5388,7 +5388,7 @@ void ge_madd(ge_p1p1 * r_p, const ge_p3 * p_p, const ge_precomp * q_p)
         "add	r1, r0, #32\n\t"
         "bl	fe_add_sub_op\n\t"
         "add	sp, sp, #12\n\t"
-        : [r] "+r" (r),  [p] "+r" (p),  [q] "+r" (q)
+        : [r] "+r" (r), [p] "+r" (p), [q] "+r" (q)
         :
         : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
             "r11", "r12", "lr"
@@ -5476,7 +5476,7 @@ void ge_msub(ge_p1p1 * r_p, const ge_p3 * p_p, const ge_precomp * q_p)
         "add	r0, r0, #32\n\t"
         "bl	fe_add_sub_op\n\t"
         "add	sp, sp, #12\n\t"
-        : [r] "+r" (r),  [p] "+r" (p),  [q] "+r" (q)
+        : [r] "+r" (r), [p] "+r" (p), [q] "+r" (q)
         :
         : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
             "r11", "r12", "lr"
@@ -5564,7 +5564,7 @@ void ge_add(ge_p1p1 * r_p, const ge_p3 * p_p, const ge_cached* q_p)
         "add	r0, r0, #32\n\t"
         "bl	fe_add_sub_op\n\t"
         "add	sp, sp, #44\n\t"
-        : [r] "+r" (r),  [p] "+r" (p),  [q] "+r" (q)
+        : [r] "+r" (r), [p] "+r" (p), [q] "+r" (q)
         :
         : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
             "r11", "r12", "lr"
@@ -5652,7 +5652,7 @@ void ge_sub(ge_p1p1 * r_p, const ge_p3 * p_p, const ge_cached* q_p)
         "add	r0, r0, #0x40\n\t"
         "bl	fe_add_sub_op\n\t"
         "add	sp, sp, #44\n\t"
-        : [r] "+r" (r),  [p] "+r" (p),  [q] "+r" (q)
+        : [r] "+r" (r), [p] "+r" (p), [q] "+r" (q)
         :
         : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
             "r11", "r12", "lr"
@@ -8528,7 +8528,7 @@ void sc_muladd(byte* s_p, const byte* a_p, const byte* b_p, const byte* c_p)
         "str	r8, [%[s], #24]\n\t"
         "str	r9, [%[s], #28]\n\t"
         "add	sp, sp, #0x50\n\t"
-        : [s] "+r" (s),  [a] "+r" (a),  [b] "+r" (b),  [c] "+r" (c)
+        : [s] "+r" (s), [a] "+r" (a), [b] "+r" (b), [c] "+r" (c)
         :
         : "memory", "cc", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11",
             "r12", "lr"
@@ -9413,7 +9413,7 @@ void sc_muladd(byte* s_p, const byte* a_p, const byte* b_p, const byte* c_p)
         "str	r8, [%[s], #24]\n\t"
         "str	r9, [%[s], #28]\n\t"
         "add	sp, sp, #0x50\n\t"
-        : [s] "+r" (s),  [a] "+r" (a),  [b] "+r" (b),  [c] "+r" (c)
+        : [s] "+r" (s), [a] "+r" (a), [b] "+r" (b), [c] "+r" (c)
         :
         : "memory", "cc", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11",
             "r12", "lr"

--- a/wolfcrypt/src/port/arm/armv8-32-kyber-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-kyber-asm_c.c
@@ -3312,7 +3312,7 @@ void kyber_arm32_ntt(sword16* r_p)
         "bne	L_kyber_arm32_ntt_loop_567_%=\n\t"
         "add	sp, sp, #8\n\t"
         : [r] "+r" (r),
-            [L_kyber_arm32_ntt_zetas] "+r" (L_kyber_arm32_ntt_zetas_c)
+          [L_kyber_arm32_ntt_zetas] "+r" (L_kyber_arm32_ntt_zetas_c)
         :
         : "memory", "cc", "r2", "r3", "r12", "lr", "r4", "r5", "r6", "r7", "r8",
             "r9", "r10", "r11"
@@ -8076,7 +8076,7 @@ void kyber_arm32_invntt(sword16* r_p)
         "bne	L_kyber_arm32_invntt_loop_321_%=\n\t"
         "add	sp, sp, #8\n\t"
         : [r] "+r" (r),
-            [L_kyber_arm32_invntt_zetas_inv] "+r" (L_kyber_arm32_invntt_zetas_inv_c)
+          [L_kyber_arm32_invntt_zetas_inv] "+r" (L_kyber_arm32_invntt_zetas_inv_c)
         :
         : "memory", "cc", "r2", "r3", "r12", "lr", "r4", "r5", "r6", "r7", "r8",
             "r9", "r10", "r11"
@@ -8405,8 +8405,8 @@ void kyber_arm32_basemul_mont(sword16* r_p, const sword16* a_p,
         "stm	%[r]!, {r4, r5}\n\t"
         "pop	{r8}\n\t"
         "bne	L_kyber_arm32_basemul_mont_loop_%=\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b),
-            [L_kyber_arm32_basemul_mont_zetas] "+r" (L_kyber_arm32_basemul_mont_zetas_c)
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b),
+          [L_kyber_arm32_basemul_mont_zetas] "+r" (L_kyber_arm32_basemul_mont_zetas_c)
         :
         : "memory", "cc", "r12", "lr", "r4", "r5", "r6", "r7", "r8", "r9",
             "r10", "r11"
@@ -8738,8 +8738,8 @@ void kyber_arm32_basemul_mont_add(sword16* r_p, const sword16* a_p,
         "stm	%[r]!, {r4, r5}\n\t"
         "pop	{r8}\n\t"
         "bne	L_kyber_arm32_basemul_mont_add_loop_%=\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b),
-            [L_kyber_arm32_basemul_mont_zetas] "+r" (L_kyber_arm32_basemul_mont_zetas_c)
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b),
+          [L_kyber_arm32_basemul_mont_zetas] "+r" (L_kyber_arm32_basemul_mont_zetas_c)
         :
         : "memory", "cc", "r12", "lr", "r4", "r5", "r6", "r7", "r8", "r9",
             "r10", "r11"
@@ -8948,7 +8948,7 @@ void kyber_arm32_csubq(sword16* p_p)
         "subs	r1, r1, #8\n\t"
         "bne	L_kyber_arm32_csubq_loop_%=\n\t"
         : [p] "+r" (p),
-            [L_kyber_arm32_basemul_mont_zetas] "+r" (L_kyber_arm32_basemul_mont_zetas_c)
+          [L_kyber_arm32_basemul_mont_zetas] "+r" (L_kyber_arm32_basemul_mont_zetas_c)
         :
         : "memory", "cc", "r2", "r3", "r12", "lr", "r4", "r5", "r6", "r7", "r8",
             "r9", "r10", "r11"
@@ -9220,8 +9220,8 @@ unsigned int kyber_arm32_rej_uniform(sword16* p_p, unsigned int len_p,
         "\n"
     "L_kyber_arm32_rej_uniform_done_%=: \n\t"
         "lsr	r0, r12, #1\n\t"
-        : [p] "+r" (p),  [len] "+r" (len),  [r] "+r" (r),  [rLen] "+r" (rLen),
-            [L_kyber_arm32_basemul_mont_zetas] "+r" (L_kyber_arm32_basemul_mont_zetas_c)
+        : [p] "+r" (p), [len] "+r" (len), [r] "+r" (r), [rLen] "+r" (rLen),
+          [L_kyber_arm32_basemul_mont_zetas] "+r" (L_kyber_arm32_basemul_mont_zetas_c)
         :
         : "memory", "cc", "r12", "lr", "r5", "r6", "r7", "r8"
     );

--- a/wolfcrypt/src/port/arm/armv8-32-poly1305-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-poly1305-asm_c.c
@@ -270,8 +270,8 @@ void poly1305_blocks_arm32_16(Poly1305* ctx_p, const byte* m_p, word32 len_p,
         "\n"
     "L_poly1305_arm32_16_done_%=: \n\t"
         "add	sp, sp, #28\n\t"
-        : [ctx] "+r" (ctx),  [m] "+r" (m),  [len] "+r" (len),
-             [notLast] "+r" (notLast)
+        : [ctx] "+r" (ctx), [m] "+r" (m), [len] "+r" (len),
+          [notLast] "+r" (notLast)
         :
         : "memory", "cc", "r12", "lr", "r4", "r5", "r6", "r7", "r8", "r9",
             "r10", "r11"
@@ -321,8 +321,8 @@ void poly1305_set_key(Poly1305* ctx_p, const byte* key_p)
         "stm	lr, {r5, r6, r7, r8, r12}\n\t"
         /* Zero leftover */
         "str	r5, [%[ctx], #52]\n\t"
-        : [ctx] "+r" (ctx),  [key] "+r" (key),
-            [L_poly1305_arm32_clamp] "+r" (L_poly1305_arm32_clamp_c)
+        : [ctx] "+r" (ctx), [key] "+r" (key),
+          [L_poly1305_arm32_clamp] "+r" (L_poly1305_arm32_clamp_c)
         :
         : "memory", "cc", "r3", "r12", "lr", "r4", "r5", "r6", "r7", "r8"
     );
@@ -377,7 +377,7 @@ void poly1305_final(Poly1305* ctx_p, byte* mac_p)
         /* Zero out padding. */
         "add	r9, %[ctx], #36\n\t"
         "stm	r9, {r4, r5, r6, r7}\n\t"
-        : [ctx] "+r" (ctx),  [mac] "+r" (mac)
+        : [ctx] "+r" (ctx), [mac] "+r" (mac)
         :
         : "memory", "cc", "r2", "r3", "r12", "lr", "r4", "r5", "r6", "r7", "r8",
             "r9"

--- a/wolfcrypt/src/port/arm/armv8-32-sha256-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-sha256-asm_c.c
@@ -1732,8 +1732,8 @@ void Transform_Sha256_Len(wc_Sha256* sha256_p, const byte* data_p, word32 len_p)
         "add	%[data], %[data], #0x40\n\t"
         "bne	L_SHA256_transform_len_begin_%=\n\t"
         "add	sp, sp, #0xc0\n\t"
-        : [sha256] "+r" (sha256),  [data] "+r" (data),  [len] "+r" (len),
-            [L_SHA256_transform_len_k] "+r" (L_SHA256_transform_len_k_c)
+        : [sha256] "+r" (sha256), [data] "+r" (data), [len] "+r" (len),
+          [L_SHA256_transform_len_k] "+r" (L_SHA256_transform_len_k_c)
         :
         : "memory", "cc", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11",
             "r12"
@@ -2797,8 +2797,8 @@ void Transform_Sha256_Len(wc_Sha256* sha256_p, const byte* data_p, word32 len_p)
         "str	r10, [sp, #8]\n\t"
         "bne	L_SHA256_transform_neon_len_begin_%=\n\t"
         "add	sp, sp, #24\n\t"
-        : [sha256] "+r" (sha256),  [data] "+r" (data),  [len] "+r" (len),
-            [L_SHA256_transform_neon_len_k] "+r" (L_SHA256_transform_neon_len_k_c)
+        : [sha256] "+r" (sha256), [data] "+r" (data), [len] "+r" (len),
+          [L_SHA256_transform_neon_len_k] "+r" (L_SHA256_transform_neon_len_k_c)
         :
         : "memory", "cc", "r4", "r5", "r6", "r7", "r8", "r9", "r12", "lr",
             "r10", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",

--- a/wolfcrypt/src/port/arm/armv8-32-sha3-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-sha3-asm_c.c
@@ -334,7 +334,7 @@ void BlockSha3(word64* state_p)
         "vst1.8	{d24}, [%[state]]\n\t"
         "add	sp, sp, #16\n\t"
         : [state] "+r" (state),
-            [L_sha3_arm2_neon_rt] "+r" (L_sha3_arm2_neon_rt_c)
+          [L_sha3_arm2_neon_rt] "+r" (L_sha3_arm2_neon_rt_c)
         :
         : "memory", "cc", "r2", "r3", "d0", "d1", "d2", "d3", "d4", "d5", "d6",
             "d7", "d8", "d9", "d10", "d11", "d12", "d13", "d14", "d15", "d16",

--- a/wolfcrypt/src/port/arm/armv8-32-sha512-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-sha512-asm_c.c
@@ -7601,8 +7601,8 @@ void Transform_Sha512_Len(wc_Sha512* sha512_p, const byte* data_p, word32 len_p)
         "bne	L_SHA512_transform_len_begin_%=\n\t"
         "eor	r0, r0, r0\n\t"
         "add	sp, sp, #0xc0\n\t"
-        : [sha512] "+r" (sha512),  [data] "+r" (data),  [len] "+r" (len),
-            [L_SHA512_transform_len_k] "+r" (L_SHA512_transform_len_k_c)
+        : [sha512] "+r" (sha512), [data] "+r" (data), [len] "+r" (len),
+          [L_SHA512_transform_len_k] "+r" (L_SHA512_transform_len_k_c)
         :
         : "memory", "cc", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11",
             "r12"
@@ -9154,8 +9154,8 @@ void Transform_Sha512_Len(wc_Sha512* sha512_p, const byte* data_p, word32 len_p)
         "subs	%[len], %[len], #0x80\n\t"
         "sub	r3, r3, #0x280\n\t"
         "bne	L_SHA512_transform_neon_len_begin_%=\n\t"
-        : [sha512] "+r" (sha512),  [data] "+r" (data),  [len] "+r" (len),
-            [L_SHA512_transform_neon_len_k] "+r" (L_SHA512_transform_neon_len_k_c)
+        : [sha512] "+r" (sha512), [data] "+r" (data), [len] "+r" (len),
+          [L_SHA512_transform_neon_len_k] "+r" (L_SHA512_transform_neon_len_k_c)
         :
         : "memory", "cc", "r12", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7",
             "d8", "d9", "d10", "d11", "d12", "d13", "d14", "d15", "q8", "q9",


### PR DESCRIPTION
# Description

Scripts changed to make generated code not go over 80 characters per line but SP not updated.
Fix input register formatting in all ARM32 C assembly code.

# Testing

Regression tested ARM32 asm.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
