### PR TITLE
BN API: fix BN_bin2bn to handle NULL data properly

### DIFF
--- a/src/ssl_bn.c
+++ b/src/ssl_bn.c
@@ -516,12 +516,14 @@ WOLFSSL_BIGNUM* wolfSSL_BN_bin2bn(const unsigned char* data, int len,
                 ret = NULL;
             }
             else {
-                /* Don't free bn as we may be returning it. */
+                /* Don't free bn as we are returning it. */
                 bn = NULL;
             }
         }
         else if (data == NULL) {
             wolfSSL_BN_zero(ret);
+            /* Don't free bn as we are returning it. */
+            bn = NULL;
         }
     }
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -61606,6 +61606,11 @@ static int test_wolfSSL_BN_enc_dec(void)
     ExpectNull(BN_bn2dec(NULL));
     ExpectNull(BN_bn2dec(&emptyBN));
 
+    ExpectNotNull(c = BN_bin2bn(NULL, 0, NULL));
+    BN_clear(c);
+    BN_free(c);
+    c = NULL;
+
     ExpectNotNull(BN_bin2bn(NULL, sizeof(binNum), a));
     BN_free(a);
     ExpectNotNull(a = BN_new());


### PR DESCRIPTION
# Description

BN_bin2bn was freeing the BN and returning it.
Added test for this.

# Testing

Added explicit test:
./configure --enable-opensslall
./tests/unit.test -test_wolfSSL_BN_enc_dec

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
