### PR TITLE
Fix coverity errors

### DIFF
--- a/src/ssl_asn1.c
+++ b/src/ssl_asn1.c
@@ -282,7 +282,7 @@ static int wolfssl_i2d_asn1_items(const void* obj, byte* buf,
             len = 0;
             break;
         }
-        if (buf != NULL && !mem->ex && mem->tag >= 0) {
+        if (buf != NULL && tmp != NULL && !mem->ex && mem->tag >= 0) {
             /* Encode the implicit tag */
             byte imp[ASN_TAG_SZ + MAX_LENGTH_SZ];
             SetImplicit(tmp[0], mem->tag, 0, imp, 0);

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -13698,6 +13698,7 @@ authenv_atrbend:
             /* free memory, zero out keys */
             ForceZero(encryptedContent, (word32)encryptedContentSz);
             XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+            encryptedContent = NULL;
             ForceZero(decryptedKey, MAX_ENCRYPTED_KEY_SZ);
         #ifdef WOLFSSL_SMALL_STACK
             XFREE(decryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
@@ -13726,8 +13727,11 @@ authenv_atrbend:
     }
 #else
     if (ret < 0) {
-        ForceZero(encryptedContent, (word32)encryptedContentSz);
-        XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+        if (encryptedContent != NULL) {
+            ForceZero(encryptedContent, (word32)encryptedContentSz);
+            XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+            encryptedContent = NULL;
+        }
         ForceZero(decryptedKey, MAX_ENCRYPTED_KEY_SZ);
     }
 #endif

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -56315,16 +56315,24 @@ static wc_test_ret_t mp_test_mont(mp_int* a, mp_int* m, mp_int* n, mp_int* r, WC
         /* a = 2^(bits*2) - 1 */
         mp_zero(a);
         mp_set_bit(a, bits[i] * 2);
-        mp_sub_d(a, 1, a);
+        ret = mp_sub_d(a, 1, a);
+        if (ret != MP_OKAY)
+            return WC_TEST_RET_ENC_EC(ret);
+
         /* m = 2^(bits) - 1 */
         mp_zero(m);
         mp_set_bit(m, bits[i]);
-        mp_sub_d(m, 1, m);
+        ret = mp_sub_d(m, 1, m);
+        if (ret != MP_OKAY)
+            return WC_TEST_RET_ENC_EC(ret);
+
         mp = 1;
         /* result = r = 2^(bits) - 1 */
         mp_zero(r);
         mp_set_bit(r, bits[i]);
-        mp_sub_d(r, 1, r);
+        ret = mp_sub_d(r, 1, r);
+        if (ret != MP_OKAY)
+            return WC_TEST_RET_ENC_EC(ret);
 
         ret = mp_montgomery_reduce(a, m, mp);
         if (ret != MP_OKAY)


### PR DESCRIPTION
# Description

Fix miscellaneous things:
- check return value of mp_sub_d in wolfcrypt test.c
- check tmp != NULL before dereferencing in src ssl_asn1.c. tmp is assigned from buf, but then later buf pointer is potentially altered, making it unclear if tmp is guaranteed to != NULL (hence adding explicit check).
- fix potential double free or deref of freed encryptedContent in wolfcrypt pkcs7.c

# Testing

Coverity scan.