### PR TITLE
20241016-dtls13-cleanup

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -11471,8 +11471,8 @@ static int GetDtlsRecordHeader(WOLFSSL* ssl, word32* inOutIdx,
         if (ssl->options.tls1_3) {
             ret = GetDtls13RecordHeader(ssl, inOutIdx, rh, size);
             if (ret == 0 ||
-                ret != WC_NO_ERR_TRACE(SEQUENCE_ERROR) ||
-                ret != WC_NO_ERR_TRACE(DTLS_CID_ERROR))
+                ((ret != WC_NO_ERR_TRACE(SEQUENCE_ERROR)) &&
+                 (ret != WC_NO_ERR_TRACE(DTLS_CID_ERROR))))
                 return ret;
         }
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -90819,7 +90819,9 @@ static int test_wolfSSL_dtls_stateless_maxfrag(void)
         WOLFSSL_SUCCESS);
     wolfSSL_SetIOWriteCtx(ssl_c2, &test_ctx);
     wolfSSL_SetIOReadCtx(ssl_c2, &test_ctx);
-    max_fragment = ssl_s->max_fragment;
+    if (EXPECT_SUCCESS()) {
+        max_fragment = ssl_s->max_fragment;
+    }
     /* send CH */
     ExpectTrue((wolfSSL_connect(ssl_c2) == WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR)) &&
         (ssl_c2->error == WC_NO_ERR_TRACE(WANT_READ)));

--- a/tests/api.c
+++ b/tests/api.c
@@ -87647,6 +87647,7 @@ static void test_AEAD_limit_client(WOLFSSL* ssl)
         /* Test the sending limit for AEAD ciphers */
         Dtls13GetEpoch(ssl, ssl->dtls13Epoch)->nextSeqNumber = sendLimit;
         test_AEAD_seq_num = 1;
+        XMEMSET(msgBuf, 0, sizeof(msgBuf));
         ret = wolfSSL_write(ssl, msgBuf, sizeof(msgBuf));
         AssertIntGT(ret, 0);
         didReKey = 0;
@@ -90812,14 +90813,13 @@ static int test_wolfSSL_dtls_stateless_maxfrag(void)
     XMEMSET(&test_ctx, 0, sizeof(test_ctx));
     ExpectIntEQ(test_memio_setup(&test_ctx, &ctx_c, &ctx_s, &ssl_c, &ssl_s,
         wolfDTLSv1_2_client_method, wolfDTLSv1_2_server_method), 0);
+    ExpectNotNull(ssl_s);
     ExpectNotNull(ssl_c2 = wolfSSL_new(ctx_c));
     ExpectIntEQ(wolfSSL_UseMaxFragment(ssl_c2, WOLFSSL_MFL_2_8),
         WOLFSSL_SUCCESS);
     wolfSSL_SetIOWriteCtx(ssl_c2, &test_ctx);
     wolfSSL_SetIOReadCtx(ssl_c2, &test_ctx);
-    if (ssl_s != NULL) {
-        max_fragment = ssl_s->max_fragment;
-    }
+    max_fragment = ssl_s->max_fragment;
     /* send CH */
     ExpectTrue((wolfSSL_connect(ssl_c2) == WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR)) &&
         (ssl_c2->error == WC_NO_ERR_TRACE(WANT_READ)));
@@ -95173,11 +95173,12 @@ static int test_dtls_frag_ch(void)
     /* Limit options to make the CH a fixed length */
     /* See wolfSSL_parse_cipher_list for reason why we provide 1.3 AND 1.2
      * ciphersuite. This is only necessary when building with OPENSSL_EXTRA. */
-    ExpectTrue(wolfSSL_set_cipher_list(ssl_c, "TLS13-AES256-GCM-SHA384"
 #ifdef OPENSSL_EXTRA
-            ":DHE-RSA-AES256-GCM-SHA384"
+    ExpectTrue(wolfSSL_set_cipher_list(ssl_c, "TLS13-AES256-GCM-SHA384"
+                                       ":DHE-RSA-AES256-GCM-SHA384"));
+#else
+    ExpectTrue(wolfSSL_set_cipher_list(ssl_c, "TLS13-AES256-GCM-SHA384"));
 #endif
-            ));
 
     /* CH1 */
     ExpectIntEQ(wolfSSL_negotiate(ssl_c), -1);


### PR DESCRIPTION
analyzer-driven cleanups of `--enable-dtls13 --enable-dtls-mtu --enable-dtls-frag-ch`:

`Dtls13HashClientHello()`: fix `wc_HashType` handling;

`Dtls13SendFragment()`: fix `identicalConditionAfterEarlyExit`;

`GetDtlsRecordHeader()`: fix error handling around `GetDtls13RecordHeader() (incorrectLogicOperator)`;

`test_wolfSSL_dtls_stateless_maxfrag()`: fix a `clang-analyzer-core.NullDereference`,
`test_dtls_frag_ch()`: fix a `clang-diagnostic-embedded-directive`,
`test_AEAD_limit_client()`: fix an united-data defect found by `valgrind`.

tested with `wolfssl-multi-test.sh ... super-quick-check` with `ENABLE_ALL_TEST_FLAGS` tweaked to add `--enable-dtls13 --enable-dtls-mtu --enable-dtls-frag-ch`.
