### PR TITLE
20241017-wc-delete-methods

### DIFF
--- a/src/keys.c
+++ b/src/keys.c
@@ -3318,9 +3318,7 @@ int SetKeys(Ciphers* enc, Ciphers* dec, Keys* keys, CipherSpecs* specs,
                                                            DYNAMIC_TYPE_CIPHER);
                 if (enc->hmac == NULL)
                     return MEMORY_E;
-            }
 
-            if (enc) {
                 if (wc_HmacInit(enc->hmac, heap, devId) != 0) {
                     WOLFSSL_MSG("HmacInit failed in SetKeys");
                     XFREE(enc->hmac, heap, DYNAMIC_TYPE_CIPHER);
@@ -3334,9 +3332,7 @@ int SetKeys(Ciphers* enc, Ciphers* dec, Keys* keys, CipherSpecs* specs,
                                                            DYNAMIC_TYPE_CIPHER);
                 if (dec->hmac == NULL)
                     return MEMORY_E;
-            }
 
-            if (dec) {
                 if (wc_HmacInit(dec->hmac, heap, devId) != 0) {
                     WOLFSSL_MSG("HmacInit failed in SetKeys");
                     XFREE(dec->hmac, heap, DYNAMIC_TYPE_CIPHER);

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -2534,7 +2534,6 @@ static int Tls13IntegrityOnly_Encrypt(WOLFSSL* ssl, byte* output,
     /* Copy the input to output if not the same buffer */
     if (ret == 0 && output != input)
         XMEMCPY(output, input, sz);
-
     return ret;
 }
 #endif
@@ -2930,7 +2929,6 @@ static int Tls13IntegrityOnly_Decrypt(WOLFSSL* ssl, byte* output,
     /* Copy the input to output if not the same buffer */
     if (ret == 0 && output != input)
         XMEMCPY(output, input, sz);
-
     return ret;
 }
 #endif
@@ -3612,7 +3610,7 @@ int CreateCookieExt(const WOLFSSL* ssl, byte* hash, word16 hashSz,
     macSz = WC_SHA256_DIGEST_SIZE;
 #endif /* NO_SHA256 */
 
-    ret = wc_HmacInit(&cookieHmac, ssl->heap, INVALID_DEVID);
+    ret = wc_HmacInit(&cookieHmac, ssl->heap, ssl->devId);
     if (ret == 0) {
         ret = wc_HmacSetKey(&cookieHmac, cookieType,
                             ssl->buffers.tls13CookieSecret.buffer,
@@ -6394,7 +6392,7 @@ int TlsCheckCookie(const WOLFSSL* ssl, const byte* cookie, word16 cookieSz)
         return HRR_COOKIE_ERROR;
     cookieSz -= macSz;
 
-    ret = wc_HmacInit(&cookieHmac, ssl->heap, INVALID_DEVID);
+    ret = wc_HmacInit(&cookieHmac, ssl->heap, ssl->devId);
     if (ret == 0) {
         ret = wc_HmacSetKey(&cookieHmac, cookieType,
                             ssl->buffers.tls13CookieSecret.buffer,

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -10542,7 +10542,7 @@ int wc_Gmac(const byte* key, word32 keySz, byte* iv, word32 ivSz,
                                   authTag, authTagSz, authIn, authInSz);
 
 #ifdef WOLFSSL_SMALL_STACK
-    wc_AesDelete(&aes);
+    wc_AesDelete(aes, NULL);
 #else
     wc_AesFree(aes);
 #endif
@@ -10582,7 +10582,7 @@ int wc_GmacVerify(const byte* key, word32 keySz,
 
     }
 #ifdef WOLFSSL_SMALL_STACK
-    wc_AesDelete(&aes);
+    wc_AesDelete(aes, NULL);
 #else
     wc_AesFree(aes);
 #endif
@@ -11318,13 +11318,14 @@ Aes* wc_AesNew(void* heap, int devId, int *result_code)
     return aes;
 }
 
-int wc_AesDelete(Aes** aes)
+int wc_AesDelete(Aes *aes, Aes** aes_p)
 {
-    if ((aes == NULL) || (*aes == NULL))
+    if (aes == NULL)
         return BAD_FUNC_ARG;
-    wc_AesFree(*aes);
-    XFREE(*aes, (*aes)->heap, DYNAMIC_TYPE_AES);
-    *aes = NULL;
+    wc_AesFree(aes);
+    XFREE(aes, aes->heap, DYNAMIC_TYPE_AES);
+    if (aes_p != NULL)
+        *aes_p = NULL;
     return 0;
 }
 #endif /* !WC_NO_CONSTRUCTORS */
@@ -14028,7 +14029,7 @@ static WARN_UNUSED_RESULT int AesSivCipher(
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    wc_AesDelete(&aes);
+    wc_AesDelete(aes, NULL);
 #else
     wc_AesFree(aes);
 #endif

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -10026,7 +10026,8 @@ int wc_AesGcmInit(Aes* aes, const byte* key, word32 len, const byte* iv,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_AESNI)
     if ((ret == 0) && (aes->streamData == NULL)) {
         /* Allocate buffers for streaming. */
-        aes->streamData = (byte*)XMALLOC(5 * AES_BLOCK_SIZE, aes->heap,
+        aes->streamData_sz = 5 * AES_BLOCK_SIZE;
+        aes->streamData = (byte*)XMALLOC(aes->streamData_sz, aes->heap,
                                                               DYNAMIC_TYPE_AES);
         if (aes->streamData == NULL) {
             ret = MEMORY_E;
@@ -10513,7 +10514,7 @@ int wc_Gmac(const byte* key, word32 keySz, byte* iv, word32 ivSz,
             byte* authTag, word32 authTagSz, WC_RNG* rng)
 {
 #ifdef WOLFSSL_SMALL_STACK
-    Aes *aes = NULL;
+    Aes *aes;
 #else
     Aes aes[1];
 #endif
@@ -10526,25 +10527,24 @@ int wc_Gmac(const byte* key, word32 keySz, byte* iv, word32 ivSz,
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    if ((aes = (Aes *)XMALLOC(sizeof *aes, NULL,
-                              DYNAMIC_TYPE_AES)) == NULL)
-        return MEMORY_E;
-#endif
-
+    aes = wc_AesNew(NULL, INVALID_DEVID, &ret);
+#else
     ret = wc_AesInit(aes, NULL, INVALID_DEVID);
-    if (ret == 0) {
-        ret = wc_AesGcmSetKey(aes, key, keySz);
-        if (ret == 0)
-            ret = wc_AesGcmSetIV(aes, ivSz, NULL, 0, rng);
-        if (ret == 0)
-            ret = wc_AesGcmEncrypt_ex(aes, NULL, NULL, 0, iv, ivSz,
+#endif
+    if (ret != 0)
+        return ret;
+
+    ret = wc_AesGcmSetKey(aes, key, keySz);
+    if (ret == 0)
+        ret = wc_AesGcmSetIV(aes, ivSz, NULL, 0, rng);
+    if (ret == 0)
+        ret = wc_AesGcmEncrypt_ex(aes, NULL, NULL, 0, iv, ivSz,
                                   authTag, authTagSz, authIn, authInSz);
-        aes->isAllocated = 0;
-        wc_AesFree(aes);
-    }
-    ForceZero(aes, sizeof *aes);
+
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(aes, NULL, DYNAMIC_TYPE_AES);
+    wc_AesDelete(&aes);
+#else
+    wc_AesFree(aes);
 #endif
 
     return ret;
@@ -10570,24 +10570,21 @@ int wc_GmacVerify(const byte* key, word32 keySz,
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    if ((aes = (Aes *)XMALLOC(sizeof *aes, NULL,
-                              DYNAMIC_TYPE_AES)) == NULL)
-        return MEMORY_E;
-#endif
-
+    aes = wc_AesNew(NULL, INVALID_DEVID, &ret);
+#else
     ret = wc_AesInit(aes, NULL, INVALID_DEVID);
+#endif
     if (ret == 0) {
         ret = wc_AesGcmSetKey(aes, key, keySz);
         if (ret == 0)
             ret = wc_AesGcmDecrypt(aes, NULL, NULL, 0, iv, ivSz,
                                   authTag, authTagSz, authIn, authInSz);
 
-        aes->isAllocated = 0;
-        wc_AesFree(aes);
     }
-    ForceZero(aes, sizeof *aes);
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(aes, NULL, DYNAMIC_TYPE_AES);
+    wc_AesDelete(&aes);
+#else
+    wc_AesFree(aes);
 #endif
 #else
     (void)key;
@@ -11300,18 +11297,24 @@ int wc_AesCcmEncrypt_ex(Aes* aes, byte* out, const byte* in, word32 sz,
 #endif /* HAVE_AESCCM */
 
 #ifndef WC_NO_CONSTRUCTORS
-Aes* wc_AesNew(void* heap, int devId)
+Aes* wc_AesNew(void* heap, int devId, int *result_code)
 {
+    int ret;
     Aes* aes = (Aes*)XMALLOC(sizeof(Aes), heap, DYNAMIC_TYPE_AES);
-    if (aes != NULL) {
-        if (wc_AesInit(aes, heap, devId) != 0) {
+    if (aes == NULL) {
+        ret = MEMORY_E;
+    }
+    else {
+        ret = wc_AesInit(aes, heap, devId);
+        if (ret != 0) {
             XFREE(aes, heap, DYNAMIC_TYPE_AES);
             aes = NULL;
         }
-        else {
-            aes->isAllocated = 1;
-        }
     }
+
+    if (result_code != NULL)
+        *result_code = ret;
+
     return aes;
 }
 
@@ -11326,7 +11329,7 @@ int wc_AesDelete(Aes** aes)
 }
 #endif /* !WC_NO_CONSTRUCTORS */
 
-/* Initialize Aes for use with async hardware */
+/* Initialize Aes */
 int wc_AesInit(Aes* aes, void* heap, int devId)
 {
     int ret = 0;
@@ -11334,18 +11337,12 @@ int wc_AesInit(Aes* aes, void* heap, int devId)
     if (aes == NULL)
         return BAD_FUNC_ARG;
 
-    aes->isAllocated = 0;
-    aes->heap = heap;
-    aes->rounds = 0;
+    XMEMSET(aes, 0, sizeof(*aes));
 
-#ifdef WOLFSSL_AESNI
-    /* clear here for the benefit of wc_AesGcmInit(). */
-    aes->use_aesni = 0;
-#endif
+    aes->heap = heap;
 
 #ifdef WOLF_CRYPTO_CB
     aes->devId = devId;
-    aes->devCtx = NULL;
 #else
     (void)devId;
 #endif
@@ -11358,49 +11355,16 @@ int wc_AesInit(Aes* aes, void* heap, int devId)
     aes->alFd = WC_SOCK_NOTSET;
     aes->rdFd = WC_SOCK_NOTSET;
 #endif
-#ifdef WOLFSSL_KCAPI_AES
-    aes->handle = NULL;
-    aes->init   = 0;
-#endif
 #if defined(WOLFSSL_DEVCRYPTO) && \
    (defined(WOLFSSL_DEVCRYPTO_AES) || defined(WOLFSSL_DEVCRYPTO_CBC))
     aes->ctx.cfd = -1;
-#endif
-#if defined(WOLFSSL_CRYPTOCELL) && defined(WOLFSSL_CRYPTOCELL_AES)
-    XMEMSET(&aes->ctx, 0, sizeof(aes->ctx));
 #endif
 #if defined(WOLFSSL_IMXRT_DCP)
     DCPAesInit(aes);
 #endif
 
-#ifdef WOLFSSL_MAXQ10XX_CRYPTO
-    XMEMSET(&aes->maxq_ctx, 0, sizeof(aes->maxq_ctx));
-#endif
-
-#ifdef HAVE_AESGCM
-#ifdef OPENSSL_EXTRA
-    XMEMSET(aes->gcm.aadH, 0, sizeof(aes->gcm.aadH));
-    aes->gcm.aadLen = 0;
-#endif
-#endif
-
-#ifdef WOLFSSL_AESGCM_STREAM
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_AESNI)
-    aes->streamData = NULL;
-#endif
-    aes->keylen = 0;
-    aes->nonceSz = 0;
-    aes->gcmKeySet = 0;
-    aes->nonceSet = 0;
-    aes->ctrSet = 0;
-#endif
-
 #if defined(WOLFSSL_HAVE_PSA) && !defined(WOLFSSL_PSA_NO_AES)
     ret = wc_psa_aes_init(aes);
-#endif
-
-#if defined(WOLFSSL_RENESAS_FSPSM)
-    XMEMSET(&aes->ctx, 0, sizeof(aes->ctx));
 #endif
 
 #ifdef WC_DEBUG_CIPHER_LIFECYCLE
@@ -11457,7 +11421,7 @@ int wc_AesInit_Label(Aes* aes, const char* label, void* heap, int devId)
 }
 #endif
 
-/* Free Aes from use with async hardware */
+/* Free Aes resources */
 void wc_AesFree(Aes* aes)
 {
     if (aes == NULL) {
@@ -11503,8 +11467,11 @@ void wc_AesFree(Aes* aes)
 #endif
 #if defined(WOLFSSL_AESGCM_STREAM) && defined(WOLFSSL_SMALL_STACK) && \
     !defined(WOLFSSL_AESNI)
-    XFREE(aes->streamData, aes->heap, DYNAMIC_TYPE_AES);
-    aes->streamData = NULL;
+    if (aes->streamData != NULL) {
+        ForceZero(aes->streamData, aes->streamData_sz);
+        XFREE(aes->streamData, aes->heap, DYNAMIC_TYPE_AES);
+        aes->streamData = NULL;
+    }
 #endif
 
 #if defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_CRYPT)
@@ -11526,6 +11493,8 @@ void wc_AesFree(Aes* aes)
     !defined(NO_WOLFSSL_RENESAS_FSPSM_AES))
     wc_fspsm_Aesfree(aes);
 #endif
+
+    ForceZero(aes, sizeof(Aes));
 
 #ifdef WOLFSSL_CHECK_MEM_ZERO
     wc_MemZero_Check(aes, sizeof(Aes));
@@ -14018,28 +13987,16 @@ static WARN_UNUSED_RESULT int AesSivCipher(
         }
     }
 
+    if (ret == 0) {
 #ifdef WOLFSSL_SMALL_STACK
-    if (ret == 0) {
-        aes = (Aes*)XMALLOC(sizeof(Aes), NULL, DYNAMIC_TYPE_AES);
-        if (aes == NULL) {
-            ret = MEMORY_E;
-        }
-    }
-#endif
-
-    if (ret == 0) {
+        aes = wc_AesNew(NULL, INVALID_DEVID, &ret);
+#else
         ret = wc_AesInit(aes, NULL, INVALID_DEVID);
+#endif
         if (ret != 0) {
             WOLFSSL_MSG("Failed to initialized AES object.");
         }
     }
-
-#ifndef WOLFSSL_SMALL_STACK
-    /* make aes has heap hint and isAllocated initialized for cleanup below */
-    if (ret != 0) {
-        XMEMSET(aes, 0, sizeof(Aes));
-    }
-#endif
 
     if (ret == 0 && dataSz > 0) {
         sivTmp[12] &= 0x7f;
@@ -14071,14 +14028,10 @@ static WARN_UNUSED_RESULT int AesSivCipher(
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    if (aes != NULL)
+    wc_AesDelete(&aes);
+#else
+    wc_AesFree(aes);
 #endif
-    {
-        wc_AesFree(aes);
-    #ifdef WOLFSSL_SMALL_STACK
-        XFREE(aes, NULL, DYNAMIC_TYPE_AES);
-    #endif
-    }
 
     return ret;
 }

--- a/wolfcrypt/src/curve25519.c
+++ b/wolfcrypt/src/curve25519.c
@@ -678,12 +678,13 @@ curve25519_key* wc_curve25519_new(void* heap, int devId, int *result_code)
     return key;
 }
 
-int wc_curve25519_delete(curve25519_key** key) {
-    if ((key == NULL) || (*key == NULL))
+int wc_curve25519_delete(curve25519_key* key, curve25519_key** key_p) {
+    if (key == NULL)
         return BAD_FUNC_ARG;
-    wc_curve25519_free(*key);
-    XFREE(*key, (*key)->heap, DYNAMIC_TYPE_CURVE25519);
-    *key = NULL;
+    wc_curve25519_free(key);
+    XFREE(key, key->heap, DYNAMIC_TYPE_CURVE25519);
+    if (key_p != NULL)
+        *key_p = NULL;
     return 0;
 }
 #endif /* !WC_NO_CONSTRUCTORS */

--- a/wolfcrypt/src/curve25519.c
+++ b/wolfcrypt/src/curve25519.c
@@ -655,6 +655,7 @@ int wc_curve25519_import_private_ex(const byte* priv, word32 privSz,
 
 #endif /* HAVE_CURVE25519_KEY_IMPORT */
 
+#ifndef WC_NO_CONSTRUCTORS
 curve25519_key* wc_curve25519_new(void* heap, int devId)
 {
     curve25519_key* key = (curve25519_key*)XMALLOC(sizeof(curve25519_key), heap,
@@ -670,6 +671,16 @@ curve25519_key* wc_curve25519_new(void* heap, int devId)
     }
     return key;
 }
+
+int wc_curve25519_delete(curve25519_key** key) {
+    if ((key == NULL) || (*key == NULL))
+        return BAD_FUNC_ARG;
+    wc_curve25519_free(*key);
+    XFREE(*key, (*key)->heap, DYNAMIC_TYPE_CURVE25519);
+    *key = NULL;
+    return 0;
+}
+#endif /* !WC_NO_CONSTRUCTORS */
 
 int wc_curve25519_init_ex(curve25519_key* key, void* heap, int devId)
 {
@@ -707,14 +718,8 @@ int wc_curve25519_init(curve25519_key* key)
 /* Clean the memory of a key */
 void wc_curve25519_free(curve25519_key* key)
 {
-    void* heap;
-    byte isAllocated = 0;
-
     if (key == NULL)
        return;
-
-    heap = key->heap;
-    isAllocated = key->isAllocated;
 
 #ifdef WOLFSSL_SE050
     se050_curve25519_free_key(key);
@@ -729,11 +734,6 @@ void wc_curve25519_free(curve25519_key* key)
 #ifdef WOLFSSL_CHECK_MEM_ZERO
     wc_MemZero_Check(key, sizeof(curve25519_key));
 #endif
-
-    if (isAllocated) {
-        XFREE(key, heap, DYNAMIC_TYPE_CURVE25519);
-        (void)heap;
-    }
 }
 
 /* get key size */

--- a/wolfcrypt/src/ed25519.c
+++ b/wolfcrypt/src/ed25519.c
@@ -991,12 +991,13 @@ ed25519_key* wc_ed25519_new(void* heap, int devId, int *result_code)
     return key;
 }
 
-int wc_ed25519_delete(ed25519_key** key) {
-    if ((key == NULL) || (*key == NULL))
+int wc_ed25519_delete(ed25519_key* key, ed25519_key** key_p) {
+    if (key == NULL)
         return BAD_FUNC_ARG;
-    wc_ed25519_free(*key);
-    XFREE(*key, (*key)->heap, DYNAMIC_TYPE_ED25519);
-    *key = NULL;
+    wc_ed25519_free(key);
+    XFREE(key, key->heap, DYNAMIC_TYPE_ED25519);
+    if (key_p != NULL)
+        *key_p = NULL;
     return 0;
 }
 #endif /* !WC_NO_CONSTRUCTORS */

--- a/wolfcrypt/src/ed25519.c
+++ b/wolfcrypt/src/ed25519.c
@@ -968,7 +968,7 @@ int wc_ed25519ph_verify_msg(const byte* sig, word32 sigLen, const byte* msg,
 }
 #endif /* HAVE_ED25519_VERIFY */
 
-#ifndef WOLFSSL_NO_MALLOC
+#ifndef WC_NO_CONSTRUCTORS
 ed25519_key* wc_ed25519_new(void* heap, int devId)
 {
     ed25519_key* key = (ed25519_key*)XMALLOC(sizeof(ed25519_key), heap,
@@ -984,7 +984,16 @@ ed25519_key* wc_ed25519_new(void* heap, int devId)
     }
     return key;
 }
-#endif
+
+int wc_ed25519_delete(ed25519_key** key) {
+    if ((key == NULL) || (*key == NULL))
+        return BAD_FUNC_ARG;
+    wc_ed25519_free(*key);
+    XFREE(*key, (*key)->heap, DYNAMIC_TYPE_ED25519);
+    *key = NULL;
+    return 0;
+}
+#endif /* !WC_NO_CONSTRUCTORS */
 
 /* initialize information and memory for key */
 int wc_ed25519_init_ex(ed25519_key* key, void* heap, int devId)
@@ -1025,14 +1034,8 @@ int wc_ed25519_init(ed25519_key* key)
 /* clear memory of key */
 void wc_ed25519_free(ed25519_key* key)
 {
-    void* heap;
-    byte isAllocated = 0;
-
     if (key == NULL)
         return;
-
-    heap = key->heap;
-    isAllocated = key->isAllocated;
 
 #ifdef WOLFSSL_ED25519_PERSISTENT_SHA
     ed25519_hash_free(key, &key->sha);
@@ -1046,12 +1049,6 @@ void wc_ed25519_free(ed25519_key* key)
 #ifdef WOLFSSL_CHECK_MEM_ZERO
     wc_MemZero_Check(key, sizeof(ed25519_key));
 #endif
-
-    if (isAllocated) {
-        XFREE(key, heap, DYNAMIC_TYPE_ED25519);
-        (void)heap;
-    }
-
 }
 
 

--- a/wolfcrypt/src/ed25519.c
+++ b/wolfcrypt/src/ed25519.c
@@ -969,19 +969,25 @@ int wc_ed25519ph_verify_msg(const byte* sig, word32 sigLen, const byte* msg,
 #endif /* HAVE_ED25519_VERIFY */
 
 #ifndef WC_NO_CONSTRUCTORS
-ed25519_key* wc_ed25519_new(void* heap, int devId)
+ed25519_key* wc_ed25519_new(void* heap, int devId, int *result_code)
 {
+    int ret;
     ed25519_key* key = (ed25519_key*)XMALLOC(sizeof(ed25519_key), heap,
                         DYNAMIC_TYPE_ED25519);
-    if (key != NULL) {
-        if (wc_ed25519_init_ex(key, heap, devId) != 0) {
+    if (key == NULL) {
+        ret = MEMORY_E;
+    }
+    else {
+        ret = wc_ed25519_init_ex(key, heap, devId);
+        if (ret != 0) {
             XFREE(key, heap, DYNAMIC_TYPE_ED25519);
             key = NULL;
         }
-        else {
-            key->isAllocated = 1;
-        }
     }
+
+    if (result_code != NULL)
+        *result_code = ret;
+
     return key;
 }
 

--- a/wolfcrypt/src/hash.c
+++ b/wolfcrypt/src/hash.c
@@ -687,19 +687,26 @@ int wc_Hash(enum wc_HashType hash_type, const byte* data,
 }
 
 #ifndef WC_NO_CONSTRUCTORS
-wc_HashAlg* wc_HashNew(enum wc_HashType type, void* heap, int devId)
+wc_HashAlg* wc_HashNew(enum wc_HashType type, void* heap, int devId,
+                       int *result_code)
 {
+    int ret;
     wc_HashAlg* hash = (wc_HashAlg*)XMALLOC(sizeof(wc_HashAlg), heap,
                         DYNAMIC_TYPE_HASHES);
-    if (hash != NULL) {
-        if (wc_HashInit_ex(hash, type, heap, devId) != 0) {
+    if (hash == NULL) {
+        ret = MEMORY_E;
+    }
+    else {
+        ret = wc_HashInit_ex(hash, type, heap, devId);
+        if (ret != 0) {
             XFREE(hash, heap, DYNAMIC_TYPE_HASHES);
             hash = NULL;
         }
-        else {
-            hash->isAllocated = 1;
-        }
     }
+
+    if (result_code != NULL)
+        *result_code = ret;
+
     return hash;
 }
 

--- a/wolfcrypt/src/hash.c
+++ b/wolfcrypt/src/hash.c
@@ -686,7 +686,7 @@ int wc_Hash(enum wc_HashType hash_type, const byte* data,
         NULL, INVALID_DEVID);
 }
 
-#ifndef WOLFSSL_NO_MALLOC
+#ifndef WC_NO_CONSTRUCTORS
 wc_HashAlg* wc_HashNew(enum wc_HashType type, void* heap, int devId)
 {
     wc_HashAlg* hash = (wc_HashAlg*)XMALLOC(sizeof(wc_HashAlg), heap,
@@ -702,7 +702,19 @@ wc_HashAlg* wc_HashNew(enum wc_HashType type, void* heap, int devId)
     }
     return hash;
 }
-#endif
+
+int wc_HashDelete(wc_HashAlg **hash) {
+    int ret;
+    if ((hash == NULL) || (*hash == NULL))
+        return BAD_FUNC_ARG;
+    ret = wc_HashFree(*hash, (*hash)->type);
+    if (ret < 0)
+        return ret;
+    XFREE(*hash, (*hash)->heap, DYNAMIC_TYPE_HASHES);
+    *hash = NULL;
+    return 0;
+}
+#endif /* !WC_NO_CONSTRUCTORS */
 
 int wc_HashInit_ex(wc_HashAlg* hash, enum wc_HashType type, void* heap,
     int devId)
@@ -712,8 +724,13 @@ int wc_HashInit_ex(wc_HashAlg* hash, enum wc_HashType type, void* heap,
     if (hash == NULL)
         return BAD_FUNC_ARG;
 
-    hash->isAllocated = 0;
     hash->type = type;
+
+#ifdef WC_NO_CONSTRUCTORS
+    (void)heap;
+#else
+    hash->heap = heap;
+#endif
 
     switch (type) {
         case WC_HASH_TYPE_MD5:
@@ -808,7 +825,6 @@ int wc_HashInit_ex(wc_HashAlg* hash, enum wc_HashType type, void* heap,
             ret = BAD_FUNC_ARG;
     };
 
-    (void)heap;
     (void)devId;
 
     return ret;
@@ -1043,8 +1059,6 @@ int wc_HashFinal(wc_HashAlg* hash, enum wc_HashType type, byte* out)
 int wc_HashFree(wc_HashAlg* hash, enum wc_HashType type)
 {
     int ret = WC_NO_ERR_TRACE(HASH_TYPE_E); /* Default to hash type error */
-    void* heap = NULL;
-    byte isAllocated = 0;
 
     if (hash == NULL)
         return BAD_FUNC_ARG;
@@ -1056,47 +1070,39 @@ int wc_HashFree(wc_HashAlg* hash, enum wc_HashType type)
     }
 #endif
 
-    isAllocated = hash->isAllocated;
-
     switch (type) {
         case WC_HASH_TYPE_MD5:
 #ifndef NO_MD5
-            heap = hash->alg.md5.heap;
             wc_Md5Free(&hash->alg.md5);
             ret = 0;
 #endif
             break;
         case WC_HASH_TYPE_SHA:
 #ifndef NO_SHA
-            heap = hash->alg.sha.heap;
             wc_ShaFree(&hash->alg.sha);
             ret = 0;
 #endif
             break;
         case WC_HASH_TYPE_SHA224:
 #ifdef WOLFSSL_SHA224
-            heap = hash->alg.sha224.heap;
             wc_Sha224Free(&hash->alg.sha224);
             ret = 0;
 #endif
             break;
         case WC_HASH_TYPE_SHA256:
 #ifndef NO_SHA256
-            heap = hash->alg.sha256.heap;
             wc_Sha256Free(&hash->alg.sha256);
             ret = 0;
 #endif
             break;
         case WC_HASH_TYPE_SHA384:
 #ifdef WOLFSSL_SHA384
-            heap = hash->alg.sha384.heap;
             wc_Sha384Free(&hash->alg.sha384);
             ret = 0;
 #endif
             break;
         case WC_HASH_TYPE_SHA512:
 #ifdef WOLFSSL_SHA512
-            heap = hash->alg.sha512.heap;
             wc_Sha512Free(&hash->alg.sha512);
             ret = 0;
 #endif
@@ -1123,7 +1129,6 @@ int wc_HashFree(wc_HashAlg* hash, enum wc_HashType type)
     #endif
         case WC_HASH_TYPE_SHA3_224:
 #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_224)
-            heap = hash->alg.sha3.heap;
             wc_Sha3_224_Free(&hash->alg.sha3);
             ret = 0;
 #endif
@@ -1149,7 +1154,6 @@ int wc_HashFree(wc_HashAlg* hash, enum wc_HashType type)
 
     #ifdef WOLFSSL_SM3
         case WC_HASH_TYPE_SM3:
-            heap = hash->alg.sm3.heap;
             wc_Sm3Free(&hash->alg.sm3);
             ret = 0;
             break;
@@ -1171,11 +1175,6 @@ int wc_HashFree(wc_HashAlg* hash, enum wc_HashType type)
         default:
             ret = BAD_FUNC_ARG;
     };
-
-    if (isAllocated) {
-        XFREE(hash, heap, DYNAMIC_TYPE_HASHES);
-        (void)heap;
-    }
 
     return ret;
 }

--- a/wolfcrypt/src/hash.c
+++ b/wolfcrypt/src/hash.c
@@ -710,15 +710,16 @@ wc_HashAlg* wc_HashNew(enum wc_HashType type, void* heap, int devId,
     return hash;
 }
 
-int wc_HashDelete(wc_HashAlg **hash) {
+int wc_HashDelete(wc_HashAlg *hash, wc_HashAlg **hash_p) {
     int ret;
-    if ((hash == NULL) || (*hash == NULL))
+    if (hash == NULL)
         return BAD_FUNC_ARG;
-    ret = wc_HashFree(*hash, (*hash)->type);
+    ret = wc_HashFree(hash, hash->type);
     if (ret < 0)
         return ret;
-    XFREE(*hash, (*hash)->heap, DYNAMIC_TYPE_HASHES);
-    *hash = NULL;
+    XFREE(hash, hash->heap, DYNAMIC_TYPE_HASHES);
+    if (hash_p != NULL)
+        *hash_p = NULL;
     return 0;
 }
 #endif /* !WC_NO_CONSTRUCTORS */

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -155,18 +155,24 @@ static void wc_RsaCleanup(RsaKey* key)
 }
 
 #ifndef WC_NO_CONSTRUCTORS
-RsaKey* wc_NewRsaKey(void* heap, int devId)
+RsaKey* wc_NewRsaKey(void* heap, int devId, int *result_code)
 {
+    int ret;
     RsaKey* key = (RsaKey*)XMALLOC(sizeof(RsaKey), heap, DYNAMIC_TYPE_RSA);
-    if (key != NULL) {
-        if (wc_InitRsaKey_ex(key, heap, devId) != 0) {
+    if (key == NULL) {
+        ret = MEMORY_E;
+    }
+    else {
+        ret = wc_InitRsaKey_ex(key, heap, devId);
+        if (ret != 0) {
             XFREE(key, heap, DYNAMIC_TYPE_RSA);
             key = NULL;
         }
-        else {
-            key->isAllocated = 1;
-        }
     }
+
+    if (result_code != NULL)
+        *result_code = ret;
+
     return key;
 }
 

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -176,13 +176,14 @@ RsaKey* wc_NewRsaKey(void* heap, int devId, int *result_code)
     return key;
 }
 
-int wc_DeleteRsaKey(RsaKey** key)
+int wc_DeleteRsaKey(RsaKey* key, RsaKey** key_p)
 {
-    if ((key == NULL) || (*key == NULL))
+    if (key == NULL)
         return BAD_FUNC_ARG;
-    wc_FreeRsaKey(*key);
-    XFREE(*key, (*key)->heap, DYNAMIC_TYPE_RSA);
-    *key = NULL;
+    wc_FreeRsaKey(key);
+    XFREE(key, key->heap, DYNAMIC_TYPE_RSA);
+    if (key_p != NULL)
+        *key_p = NULL;
     return 0;
 }
 #endif /* !WC_NO_CONSTRUCTORS */

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -154,6 +154,7 @@ static void wc_RsaCleanup(RsaKey* key)
 #endif
 }
 
+#ifndef WC_NO_CONSTRUCTORS
 RsaKey* wc_NewRsaKey(void* heap, int devId)
 {
     RsaKey* key = (RsaKey*)XMALLOC(sizeof(RsaKey), heap, DYNAMIC_TYPE_RSA);
@@ -168,6 +169,17 @@ RsaKey* wc_NewRsaKey(void* heap, int devId)
     }
     return key;
 }
+
+int wc_DeleteRsaKey(RsaKey** key)
+{
+    if ((key == NULL) || (*key == NULL))
+        return BAD_FUNC_ARG;
+    wc_FreeRsaKey(*key);
+    XFREE(*key, (*key)->heap, DYNAMIC_TYPE_RSA);
+    *key = NULL;
+    return 0;
+}
+#endif /* !WC_NO_CONSTRUCTORS */
 
 int wc_InitRsaKey_ex(RsaKey* key, void* heap, int devId)
 {
@@ -542,15 +554,10 @@ int wc_RsaGetKeyId(RsaKey* key, word32* keyId)
 int wc_FreeRsaKey(RsaKey* key)
 {
     int ret = 0;
-    void* heap;
-    byte isAllocated = 0;
 
     if (key == NULL) {
         return BAD_FUNC_ARG;
     }
-
-    heap = key->heap;
-    isAllocated = key->isAllocated;
 
     wc_RsaCleanup(key);
 
@@ -614,11 +621,6 @@ int wc_FreeRsaKey(RsaKey* key)
 #if defined(WOLFSSL_RENESAS_FSPSM_CRYPTONLY)
     wc_fspsm_RsaKeyFree(key);
 #endif
-
-    if (isAllocated) {
-        XFREE(key, heap, DYNAMIC_TYPE_RSA);
-        (void)heap;
-    }
 
     return ret;
 }

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -327,7 +327,7 @@ struct Aes {
     int alFd; /* server socket to bind to */
     int rdFd; /* socket to read from */
     struct msghdr msg;
-    int dir;  /* flag for encrpyt or decrypt */
+    int dir;  /* flag for encrypt or decrypt */
 #ifdef WOLFSSL_AFALG_XILINX_AES
     word32 msgBuf[CMSG_SPACE(4) + CMSG_SPACE(sizeof(struct af_alg_iv) +
                   GCM_NONCE_MID_SZ)];
@@ -382,6 +382,7 @@ struct Aes {
     ALIGN16 byte streamData[5 * AES_BLOCK_SIZE];
 #else
     byte*        streamData;
+    word32       streamData_sz;
 #endif
     word32       aSz;
     word32       cSz;
@@ -392,7 +393,6 @@ struct Aes {
     WC_BITFIELD  nonceSet:1;
     WC_BITFIELD  ctrSet:1;
 #endif
-    WC_BITFIELD  isAllocated:1; /* flag indicates if structure was allocated */
 #ifdef WC_DEBUG_CIPHER_LIFECYCLE
     void *CipherLifecycleTag; /* used for dummy allocation and initialization,
                                * trackable by sanitizers.
@@ -728,7 +728,7 @@ WOLFSSL_API int  wc_AesInit_Label(Aes* aes, const char* label, void* heap,
 #endif
 WOLFSSL_API void wc_AesFree(Aes* aes);
 #ifndef WC_NO_CONSTRUCTORS
-WOLFSSL_API Aes* wc_AesNew(void* heap, int devId);
+WOLFSSL_API Aes* wc_AesNew(void* heap, int devId, int *result_code);
 WOLFSSL_API int wc_AesDelete(Aes** aes);
 #endif
 

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -726,8 +726,11 @@ WOLFSSL_API int  wc_AesInit_Id(Aes* aes, unsigned char* id, int len, void* heap,
 WOLFSSL_API int  wc_AesInit_Label(Aes* aes, const char* label, void* heap,
         int devId);
 #endif
-WOLFSSL_API Aes* wc_AesNew(void* heap, int devId);
 WOLFSSL_API void wc_AesFree(Aes* aes);
+#ifndef WC_NO_CONSTRUCTORS
+WOLFSSL_API Aes* wc_AesNew(void* heap, int devId);
+WOLFSSL_API int wc_AesDelete(Aes** aes);
+#endif
 
 #ifdef WOLFSSL_AES_SIV
 typedef struct AesSivAssoc {

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -729,7 +729,7 @@ WOLFSSL_API int  wc_AesInit_Label(Aes* aes, const char* label, void* heap,
 WOLFSSL_API void wc_AesFree(Aes* aes);
 #ifndef WC_NO_CONSTRUCTORS
 WOLFSSL_API Aes* wc_AesNew(void* heap, int devId, int *result_code);
-WOLFSSL_API int wc_AesDelete(Aes** aes);
+WOLFSSL_API int wc_AesDelete(Aes* aes, Aes** aes_p);
 #endif
 
 #ifdef WOLFSSL_AES_SIV

--- a/wolfssl/wolfcrypt/curve25519.h
+++ b/wolfssl/wolfcrypt/curve25519.h
@@ -99,9 +99,6 @@ struct curve25519_key {
     /* bit fields */
     WC_BITFIELD pubSet:1;
     WC_BITFIELD privSet:1;
-#ifndef WC_NO_CONSTRUCTORS
-    WC_BITFIELD isAllocated:1;
-#endif
 };
 
 enum {
@@ -144,10 +141,11 @@ void wc_curve25519_free(curve25519_key* key);
 
 #ifndef WC_NO_CONSTRUCTORS
 WOLFSSL_API
-curve25519_key* wc_curve25519_new(void* heap, int devId);
+curve25519_key* wc_curve25519_new(void* heap, int devId, int *result_code);
 WOLFSSL_API
 int wc_curve25519_delete(curve25519_key** key);
 #endif
+WOLFSSL_API
 
 /* raw key helpers */
 WOLFSSL_API

--- a/wolfssl/wolfcrypt/curve25519.h
+++ b/wolfssl/wolfcrypt/curve25519.h
@@ -143,7 +143,7 @@ void wc_curve25519_free(curve25519_key* key);
 WOLFSSL_API
 curve25519_key* wc_curve25519_new(void* heap, int devId, int *result_code);
 WOLFSSL_API
-int wc_curve25519_delete(curve25519_key** key);
+int wc_curve25519_delete(curve25519_key* key, curve25519_key** key_p);
 #endif
 WOLFSSL_API
 

--- a/wolfssl/wolfcrypt/curve25519.h
+++ b/wolfssl/wolfcrypt/curve25519.h
@@ -99,7 +99,9 @@ struct curve25519_key {
     /* bit fields */
     WC_BITFIELD pubSet:1;
     WC_BITFIELD privSet:1;
-    WC_BITFIELD isAllocated:1; /* flag indicates if structure was allocated */
+#ifndef WC_NO_CONSTRUCTORS
+    WC_BITFIELD isAllocated:1;
+#endif
 };
 
 enum {
@@ -133,8 +135,6 @@ int wc_curve25519_shared_secret_ex(curve25519_key* private_key,
                                    byte* out, word32* outlen, int endian);
 
 WOLFSSL_API
-curve25519_key* wc_curve25519_new(void* heap, int devId);
-WOLFSSL_API
 int wc_curve25519_init(curve25519_key* key);
 WOLFSSL_API
 int wc_curve25519_init_ex(curve25519_key* key, void* heap, int devId);
@@ -142,6 +142,12 @@ int wc_curve25519_init_ex(curve25519_key* key, void* heap, int devId);
 WOLFSSL_API
 void wc_curve25519_free(curve25519_key* key);
 
+#ifndef WC_NO_CONSTRUCTORS
+WOLFSSL_API
+curve25519_key* wc_curve25519_new(void* heap, int devId);
+WOLFSSL_API
+int wc_curve25519_delete(curve25519_key** key);
+#endif
 
 /* raw key helpers */
 WOLFSSL_API

--- a/wolfssl/wolfcrypt/ed25519.h
+++ b/wolfssl/wolfcrypt/ed25519.h
@@ -97,8 +97,9 @@ struct ed25519_key {
     WC_BITFIELD privKeySet:1;
     WC_BITFIELD pubKeySet:1;
     WC_BITFIELD sha_clean_flag:1; /* only used if WOLFSSL_ED25519_PERSISTENT_SHA */
-    /* flag indicates if structure was allocated */
+#ifndef WC_NO_CONSTRUCTORS
     WC_BITFIELD isAllocated:1;
+#endif
 #ifdef WOLFSSL_ASYNC_CRYPT
     WC_ASYNC_DEV asyncDev;
 #endif
@@ -178,13 +179,18 @@ int wc_ed25519_verify_msg_final(const byte* sig, word32 sigLen, int* res,
 #endif /* HAVE_ED25519_VERIFY */
 
 WOLFSSL_API
-ed25519_key* wc_ed25519_new(void* heap, int devId);
-WOLFSSL_API
 int wc_ed25519_init(ed25519_key* key);
 WOLFSSL_API
 int wc_ed25519_init_ex(ed25519_key* key, void* heap, int devId);
 WOLFSSL_API
 void wc_ed25519_free(ed25519_key* key);
+#ifndef WC_NO_CONSTRUCTORS
+WOLFSSL_API
+ed25519_key* wc_ed25519_new(void* heap, int devId);
+WOLFSSL_API
+int wc_ed25519_delete(ed25519_key** key);
+#endif
+
 #ifdef HAVE_ED25519_KEY_IMPORT
 WOLFSSL_API
 int wc_ed25519_import_public(const byte* in, word32 inLen, ed25519_key* key);

--- a/wolfssl/wolfcrypt/ed25519.h
+++ b/wolfssl/wolfcrypt/ed25519.h
@@ -97,9 +97,6 @@ struct ed25519_key {
     WC_BITFIELD privKeySet:1;
     WC_BITFIELD pubKeySet:1;
     WC_BITFIELD sha_clean_flag:1; /* only used if WOLFSSL_ED25519_PERSISTENT_SHA */
-#ifndef WC_NO_CONSTRUCTORS
-    WC_BITFIELD isAllocated:1;
-#endif
 #ifdef WOLFSSL_ASYNC_CRYPT
     WC_ASYNC_DEV asyncDev;
 #endif
@@ -186,10 +183,11 @@ WOLFSSL_API
 void wc_ed25519_free(ed25519_key* key);
 #ifndef WC_NO_CONSTRUCTORS
 WOLFSSL_API
-ed25519_key* wc_ed25519_new(void* heap, int devId);
+ed25519_key* wc_ed25519_new(void* heap, int devId, int *result_code);
 WOLFSSL_API
 int wc_ed25519_delete(ed25519_key** key);
 #endif
+WOLFSSL_API
 
 #ifdef HAVE_ED25519_KEY_IMPORT
 WOLFSSL_API

--- a/wolfssl/wolfcrypt/ed25519.h
+++ b/wolfssl/wolfcrypt/ed25519.h
@@ -185,7 +185,7 @@ void wc_ed25519_free(ed25519_key* key);
 WOLFSSL_API
 ed25519_key* wc_ed25519_new(void* heap, int devId, int *result_code);
 WOLFSSL_API
-int wc_ed25519_delete(ed25519_key** key);
+int wc_ed25519_delete(ed25519_key* key, ed25519_key** key_p);
 #endif
 WOLFSSL_API
 

--- a/wolfssl/wolfcrypt/hash.h
+++ b/wolfssl/wolfcrypt/hash.h
@@ -195,7 +195,7 @@ WOLFSSL_API int wc_HashFree(wc_HashAlg* hash, enum wc_HashType type);
 #ifndef WC_NO_CONSTRUCTORS
 WOLFSSL_API wc_HashAlg* wc_HashNew(enum wc_HashType type, void* heap,
                                    int devId, int *result_code);
-WOLFSSL_API int wc_HashDelete(wc_HashAlg **hash);
+WOLFSSL_API int wc_HashDelete(wc_HashAlg *hash, wc_HashAlg **hash_p);
 #endif
 
 #ifdef WOLFSSL_HASH_FLAGS

--- a/wolfssl/wolfcrypt/hash.h
+++ b/wolfssl/wolfcrypt/hash.h
@@ -125,7 +125,10 @@ typedef union {
 typedef struct {
     wc_Hashes alg;
     enum wc_HashType type; /* sanity check */
-    WC_BITFIELD isAllocated:1; /* flag indicates if structure was allocated */
+#ifndef WC_NO_CONSTRUCTORS
+    void *heap;
+    WC_BITFIELD isAllocated:1;
+#endif
 } wc_HashAlg;
 #endif /* !NO_HASH_WRAPPER */
 
@@ -182,8 +185,6 @@ WOLFSSL_API int wc_Hash_ex(enum wc_HashType hash_type,
     byte* hash, word32 hash_len, void* heap, int devId);
 
 /* generic hash operation wrappers */
-WOLFSSL_API wc_HashAlg* wc_HashNew(enum wc_HashType type, void* heap,
-                                   int devId);
 WOLFSSL_API int wc_HashInit_ex(wc_HashAlg* hash, enum wc_HashType type,
     void* heap, int devId);
 WOLFSSL_API int wc_HashInit(wc_HashAlg* hash, enum wc_HashType type);
@@ -192,6 +193,11 @@ WOLFSSL_API int wc_HashUpdate(wc_HashAlg* hash, enum wc_HashType type,
 WOLFSSL_API int wc_HashFinal(wc_HashAlg* hash, enum wc_HashType type,
     byte* out);
 WOLFSSL_API int wc_HashFree(wc_HashAlg* hash, enum wc_HashType type);
+#ifndef WC_NO_CONSTRUCTORS
+WOLFSSL_API wc_HashAlg* wc_HashNew(enum wc_HashType type, void* heap,
+                                   int devId);
+WOLFSSL_API int wc_HashDelete(wc_HashAlg **hash);
+#endif
 
 #ifdef WOLFSSL_HASH_FLAGS
     WOLFSSL_API int wc_HashSetFlags(wc_HashAlg* hash, enum wc_HashType type,

--- a/wolfssl/wolfcrypt/hash.h
+++ b/wolfssl/wolfcrypt/hash.h
@@ -127,7 +127,6 @@ typedef struct {
     enum wc_HashType type; /* sanity check */
 #ifndef WC_NO_CONSTRUCTORS
     void *heap;
-    WC_BITFIELD isAllocated:1;
 #endif
 } wc_HashAlg;
 #endif /* !NO_HASH_WRAPPER */
@@ -195,7 +194,7 @@ WOLFSSL_API int wc_HashFinal(wc_HashAlg* hash, enum wc_HashType type,
 WOLFSSL_API int wc_HashFree(wc_HashAlg* hash, enum wc_HashType type);
 #ifndef WC_NO_CONSTRUCTORS
 WOLFSSL_API wc_HashAlg* wc_HashNew(enum wc_HashType type, void* heap,
-                                   int devId);
+                                   int devId, int *result_code);
 WOLFSSL_API int wc_HashDelete(wc_HashAlg **hash);
 #endif
 

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -297,7 +297,7 @@ WOLFSSL_API int  wc_InitRsaKey_ex(RsaKey* key, void* heap, int devId);
 WOLFSSL_API int  wc_FreeRsaKey(RsaKey* key);
 #ifndef WC_NO_CONSTRUCTORS
 WOLFSSL_API RsaKey* wc_NewRsaKey(void* heap, int devId, int *result_code);
-WOLFSSL_API int  wc_DeleteRsaKey(RsaKey** key);
+WOLFSSL_API int  wc_DeleteRsaKey(RsaKey* key, RsaKey** key_p);
 #endif
 
 #ifdef WOLF_PRIVATE_KEY_ID

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -269,9 +269,6 @@ struct RsaKey {
 #if defined(WOLFSSL_RENESAS_FSPSM)
     FSPSM_RSA_CTX ctx;
 #endif
-#ifndef WC_NO_CONSTRUCTORS
-    WC_BITFIELD isAllocated:1;
-#endif
 };
 
 #ifndef WC_RSAKEY_TYPE_DEFINED
@@ -299,7 +296,7 @@ WOLFSSL_API int  wc_InitRsaKey(RsaKey* key, void* heap);
 WOLFSSL_API int  wc_InitRsaKey_ex(RsaKey* key, void* heap, int devId);
 WOLFSSL_API int  wc_FreeRsaKey(RsaKey* key);
 #ifndef WC_NO_CONSTRUCTORS
-WOLFSSL_API RsaKey* wc_NewRsaKey(void* heap, int devId);
+WOLFSSL_API RsaKey* wc_NewRsaKey(void* heap, int devId, int *result_code);
 WOLFSSL_API int  wc_DeleteRsaKey(RsaKey** key);
 #endif
 

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -269,7 +269,9 @@ struct RsaKey {
 #if defined(WOLFSSL_RENESAS_FSPSM)
     FSPSM_RSA_CTX ctx;
 #endif
-    WC_BITFIELD isAllocated:1; /* flag indicates if structure was allocated */
+#ifndef WC_NO_CONSTRUCTORS
+    WC_BITFIELD isAllocated:1;
+#endif
 };
 
 #ifndef WC_RSAKEY_TYPE_DEFINED
@@ -293,10 +295,14 @@ struct RsaPadding {
 typedef struct RsaPadding RsaPadding;
 #endif
 
-WOLFSSL_API RsaKey* wc_NewRsaKey(void* heap, int devId);
 WOLFSSL_API int  wc_InitRsaKey(RsaKey* key, void* heap);
 WOLFSSL_API int  wc_InitRsaKey_ex(RsaKey* key, void* heap, int devId);
 WOLFSSL_API int  wc_FreeRsaKey(RsaKey* key);
+#ifndef WC_NO_CONSTRUCTORS
+WOLFSSL_API RsaKey* wc_NewRsaKey(void* heap, int devId);
+WOLFSSL_API int  wc_DeleteRsaKey(RsaKey** key);
+#endif
+
 #ifdef WOLF_PRIVATE_KEY_ID
 WOLFSSL_API int wc_InitRsaKey_Id(RsaKey* key, unsigned char* id, int len,
                                  void* heap, int devId);

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -612,6 +612,10 @@ typedef struct w64wrapper {
         #endif /* WOLFSSL_STATIC_MEMORY */
     #endif
 
+    #if defined(WOLFSSL_SMALL_STACK) && defined(WC_NO_CONSTRUCTORS)
+        #error WOLFSSL_SMALL_STACK requires constructors.
+    #endif
+
     #include <wolfssl/wolfcrypt/memory.h>
 
     /* declare/free variable handling for async and smallstack */

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -522,6 +522,12 @@ typedef struct w64wrapper {
     #elif defined(NO_WOLFSSL_MEMORY)
         #ifdef WOLFSSL_NO_MALLOC
             /* this platform does not support heap use */
+            #ifdef WOLFSSL_SMALL_STACK
+                #error WOLFSSL_SMALL_STACK requires a heap implementation.
+            #endif
+            #ifndef WC_NO_CONSTRUCTORS
+                #define WC_NO_CONSTRUCTORS
+            #endif
             #ifdef WOLFSSL_MALLOC_CHECK
                 #ifndef NO_STDIO_FILESYSTEM
                 #include <stdio.h>

--- a/wrapper/CSharp/wolfSSL_CSharp/wolfCrypt.cs
+++ b/wrapper/CSharp/wolfSSL_CSharp/wolfCrypt.cs
@@ -119,7 +119,9 @@ namespace wolfSSL.CSharp
          * RSA
          */
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr wc_NewRsaKey(IntPtr heap, int devId);
+        private static extern IntPtr wc_NewRsaKey(IntPtr heap, int devId, IntPtr result_code);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_DeleteRsaKey(IntPtr key, IntPtr key_p);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private extern static int wc_InitRsaKey(IntPtr key, IntPtr heap);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
@@ -153,7 +155,9 @@ namespace wolfSSL.CSharp
          * ED25519
          */
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr wc_ed25519_new(IntPtr heap, int devId);
+        private static extern IntPtr wc_ed25519_new(IntPtr heap, int devId, IntPtr result_code);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_ed25519_delete(IntPtr key, IntPtr key_p);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private static extern int wc_ed25519_init(IntPtr key);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
@@ -194,7 +198,9 @@ namespace wolfSSL.CSharp
          * Curve25519
          */
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr wc_curve25519_new(IntPtr heap, int devId);
+        private static extern IntPtr wc_curve25519_new(IntPtr heap, int devId, IntPtr result_code);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int wc_curve25519_delete(IntPtr key, IntPtr key_p);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private extern static int wc_curve25519_init(IntPtr key);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
@@ -235,7 +241,9 @@ namespace wolfSSL.CSharp
          * AES-GCM
          */
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
-        private extern static IntPtr wc_AesNew(IntPtr heap, int devId);
+        private extern static IntPtr wc_AesNew(IntPtr heap, int devId, IntPtr result_code);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private extern static int wc_AesDelete(IntPtr aes, IntPtr aes_p);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private extern static int wc_AesFree(IntPtr aes);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
@@ -254,7 +262,9 @@ namespace wolfSSL.CSharp
          * HASH
          */
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
-        private extern static IntPtr wc_HashNew(uint hashType, IntPtr heap, int devId);
+        private extern static IntPtr wc_HashNew(uint hashType, IntPtr heap, int devId, IntPtr result_code);
+        [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
+        private extern static int wc_HashDelete(IntPtr hash, IntPtr hash_p);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
         private extern static int wc_HashInit(IntPtr hash, uint hashType);
         [DllImport(wolfssl_dll, CallingConvention = CallingConvention.Cdecl)]
@@ -1322,7 +1332,7 @@ namespace wolfSSL.CSharp
             try
             {
                 /* Allocate and init new RSA key structure */
-                key = wc_NewRsaKey(heap, devId);
+                key = wc_NewRsaKey(heap, devId, IntPtr.Zero);
                 if (key != IntPtr.Zero)
                 {
                     rng = RandomNew();
@@ -1370,7 +1380,7 @@ namespace wolfSSL.CSharp
 
             try
             {
-                key = wc_NewRsaKey(IntPtr.Zero, INVALID_DEVID);
+                key = wc_NewRsaKey(IntPtr.Zero, INVALID_DEVID, IntPtr.Zero);
                 if (key != IntPtr.Zero)
                 {
                     IntPtr idx = Marshal.AllocHGlobal(sizeof(uint));
@@ -1548,7 +1558,8 @@ namespace wolfSSL.CSharp
         {
             if (key != IntPtr.Zero)
             {
-                wc_FreeRsaKey(key);
+                wc_DeleteRsaKey(key, IntPtr.Zero);
+                key = IntPtr.Zero;
             }
         }
         /* END RSA */
@@ -1578,7 +1589,7 @@ namespace wolfSSL.CSharp
                     throw new Exception("Failed to create RNG.");
                 }
 
-                key = wc_ed25519_new(heap, devId);
+                key = wc_ed25519_new(heap, devId, IntPtr.Zero);
                 if (key != IntPtr.Zero)
                 {
                     ret = wc_ed25519_make_key(rng, 32, key);
@@ -1595,7 +1606,7 @@ namespace wolfSSL.CSharp
                 if (rng != IntPtr.Zero) RandomFree(rng);
                 if (ret != 0)
                 {
-                    wc_ed25519_free(key);
+                    wc_ed25519_delete(key, IntPtr.Zero);
                     key = IntPtr.Zero;
                 }
             }
@@ -1700,7 +1711,7 @@ namespace wolfSSL.CSharp
 
             try
             {
-                key = wc_ed25519_new(IntPtr.Zero, INVALID_DEVID);
+                key = wc_ed25519_new(IntPtr.Zero, INVALID_DEVID, IntPtr.Zero);
                 if (key != IntPtr.Zero)
                 {
                     ret = wc_Ed25519PrivateKeyDecode(input, ref idx, key, (uint)input.Length);
@@ -1734,7 +1745,7 @@ namespace wolfSSL.CSharp
 
             try
             {
-                key = wc_ed25519_new(IntPtr.Zero, INVALID_DEVID);
+                key = wc_ed25519_new(IntPtr.Zero, INVALID_DEVID, IntPtr.Zero);
                 if (key != IntPtr.Zero)
                 {
                     ret = wc_Ed25519PublicKeyDecode(input, ref idx, key, (uint)input.Length);
@@ -1878,7 +1889,8 @@ namespace wolfSSL.CSharp
         /// <param name="key">Key to be freed</param>
         public static void Ed25519FreeKey(IntPtr key)
         {
-            wc_ed25519_free(key);
+            wc_ed25519_delete(key, IntPtr.Zero);
+            key = IntPtr.Zero;
         }
         /* END ED25519 */
 
@@ -2104,7 +2116,7 @@ namespace wolfSSL.CSharp
                     throw new Exception("Failed to create RNG.");
                 }
 
-                key = wc_curve25519_new(heap, devId);
+                key = wc_curve25519_new(heap, devId, IntPtr.Zero);
                 if (key != IntPtr.Zero)
                 {
                     ret = wc_curve25519_make_key(rng, 32, key);
@@ -2121,7 +2133,7 @@ namespace wolfSSL.CSharp
                 if (rng != IntPtr.Zero) RandomFree(rng);
                 if (ret != 0)
                 {
-                    wc_curve25519_free(key);
+                    wc_curve25519_delete(key, IntPtr.Zero);
                     key = IntPtr.Zero;
                 }
             }
@@ -2142,7 +2154,7 @@ namespace wolfSSL.CSharp
 
             try
             {
-                key = wc_ed25519_new(IntPtr.Zero, INVALID_DEVID);
+                key = wc_ed25519_new(IntPtr.Zero, INVALID_DEVID, IntPtr.Zero);
                 if (key != IntPtr.Zero)
                 {
                     ret = wc_Ed25519PrivateKeyDecode(input, ref idx, key, (uint)input.Length);
@@ -2176,7 +2188,7 @@ namespace wolfSSL.CSharp
 
             try
             {
-                key = wc_curve25519_new(IntPtr.Zero, INVALID_DEVID);
+                key = wc_curve25519_new(IntPtr.Zero, INVALID_DEVID, IntPtr.Zero);
                 if (key != IntPtr.Zero)
                 {
                     ret = wc_Curve25519PublicKeyDecode(input, ref idx, key, (uint)input.Length);
@@ -2280,7 +2292,8 @@ namespace wolfSSL.CSharp
         /// <param name="key">Key to be freed</param>
         public static void Curve25519FreeKey(IntPtr key)
         {
-            wc_curve25519_free(key);
+            wc_curve25519_delete(key, IntPtr.Zero);
+            key = IntPtr.Zero;
         }
         /* END Curve25519 */
 
@@ -2449,7 +2462,7 @@ namespace wolfSSL.CSharp
 
             try
             {
-                aesPtr = wc_AesNew(heap, devId);
+                aesPtr = wc_AesNew(heap, devId, IntPtr.Zero);
 
                 if (aesPtr == IntPtr.Zero)
                 {
@@ -2676,7 +2689,8 @@ namespace wolfSSL.CSharp
         {
             if (aes != IntPtr.Zero)
             {
-                wc_AesFree(aes);
+                wc_AesDelete(aes, IntPtr.Zero);
+                aes = IntPtr.Zero;
             }
         }
         /* END AES-GCM */
@@ -2700,7 +2714,7 @@ namespace wolfSSL.CSharp
             try
             {
                 /* Allocate new hash */
-                hash = wc_HashNew(hashType, heap, devId);
+                hash = wc_HashNew(hashType, heap, devId, IntPtr.Zero);
                 if (hash == IntPtr.Zero)
                 {
                     throw new Exception("Failed to allocate new hash context.");
@@ -2740,7 +2754,10 @@ namespace wolfSSL.CSharp
             {
                 /* Cleanup */
                 log(ERROR_LOG, "InitHash Exception: " + e.ToString());
-                if (hash != IntPtr.Zero) wc_HashFree(hash, hashType);
+                if (hash != IntPtr.Zero) {
+                    wc_HashDelete(hash, IntPtr.Zero);
+                    hash = IntPtr.Zero;
+                }
             }
 
             return ret;
@@ -2856,7 +2873,8 @@ namespace wolfSSL.CSharp
                     throw new Exception("Hash context is null, cannot free.");
 
                 /* Free hash */
-                ret = wc_HashFree(hash, hashType);
+                ret = wc_HashDelete(hash, IntPtr.Zero);
+                hash = IntPtr.Zero;
                 if (ret != 0)
                 {
                     throw new Exception($"Failed to free hash context. Error code: {ret}");


### PR DESCRIPTION
refactor wolfcrypt constructors:

add delete APIs, matching recently added `wc_AesNew`, `wc_curve25519_new`, `wc_ed25519_new`, `wc_HashNew`, and `wc_NewRsaKey`:
* `wc_AesDelete()`
* `wc_HashDelete()`
* `wc_DeleteRsaKey()`
* `wc_curve25519_delete()`
* `wc_ed25519_delete()`

* remove handling in corresponding preexisting free APIs for recently added `.isAllocated` member -- this restores preexisting semantics;

* add `WC_NO_CONSTRUCTORS` gate, and auto-activate it when `NO_WOLFSSL_MEMORY` && `WOLFSSL_NO_MALLOC` (unless preempted by `XMALLOC_USER` or `XMALLOC_OVERRIDE`);

* exclude recently added `.isAllocated` members from wolfcrypt structs when `defined(WC_NO_CONSTRUCTORS)`.

tested with `wolfssl-multi-test.sh ... check-source-text quantum-safe-wolfssl-all-g++-latest-debug quantum-safe-wolfssl-all-cppcheck fortify-source-all-asm fortify-source-all-noasm clang-tidy-all-sp-all sanitizer-all-intelasm-c-fallback-fuzzer all-gcc-c99-asn-original cryptonly-opensslextra-gcc-c99 allcryptonly-no-malloc allcryptonly-no-malloc-no-wolf-memory allcryptonly-gcc-c89 quantum-safe-wolfssl-all-valgrind quantum-safe-wolfssl-all-smallstack-valgrind cppcheck-all-smallstack`
