### PR TITLE
20241021-wc_FreeRsaKey-WOLFSSL_XILINX_CRYPT

### DIFF
--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -601,7 +601,7 @@ int wc_FreeRsaKey(RsaKey* key)
     mp_clear(&key->n);
 
 #ifdef WOLFSSL_XILINX_CRYPT
-    XFREE(key->mod, heap, DYNAMIC_TYPE_KEY);
+    XFREE(key->mod, key->heap, DYNAMIC_TYPE_KEY);
     key->mod = NULL;
 #endif
 


### PR DESCRIPTION
`wolfcrypt/src/rsa.c`: fix `wc_FreeRsaKey()` `WOLFSSL_XILINX_CRYPT` `XFREE()` call to pass `key->heap` as before.
