### PR TITLE
More fixes for building x86 in Visual Studio for non-windows OS

### DIFF
--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -1634,7 +1634,8 @@ int wolfSSL_OCSP_REQ_CTX_nbio(WOLFSSL_OCSP_REQ_CTX *ctx)
         case ORIOS_WRITE:
         {
             const unsigned char *req;
-            int reqLen = wolfSSL_BIO_get_mem_data(ctx->reqResp, &req);
+            int reqLen = wolfSSL_BIO_get_mem_data(ctx->reqResp,
+                (unsigned char*)&req);
             if (reqLen <= 0) {
                 WOLFSSL_MSG("wolfSSL_BIO_get_mem_data error");
                 return WOLFSSL_FAILURE;
@@ -1710,7 +1711,8 @@ int wolfSSL_OCSP_sendreq_nbio(OcspResponse **presp, WOLFSSL_OCSP_REQ_CTX *ctx)
     if (ret != WOLFSSL_SUCCESS)
         return ret;
 
-    len = wolfSSL_BIO_get_mem_data(ctx->reqResp, &resp);
+    len = wolfSSL_BIO_get_mem_data(ctx->reqResp,
+        (unsigned char*)&resp);
     if (len <= 0)
         return WOLFSSL_FAILURE;
     return wolfSSL_d2i_OCSP_RESPONSE(presp, &resp, len) != NULL

--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -1634,8 +1634,7 @@ int wolfSSL_OCSP_REQ_CTX_nbio(WOLFSSL_OCSP_REQ_CTX *ctx)
         case ORIOS_WRITE:
         {
             const unsigned char *req;
-            int reqLen = wolfSSL_BIO_get_mem_data(ctx->reqResp,
-                (unsigned char*)&req);
+            int reqLen = wolfSSL_BIO_get_mem_data(ctx->reqResp, (void*)&req);
             if (reqLen <= 0) {
                 WOLFSSL_MSG("wolfSSL_BIO_get_mem_data error");
                 return WOLFSSL_FAILURE;
@@ -1711,8 +1710,7 @@ int wolfSSL_OCSP_sendreq_nbio(OcspResponse **presp, WOLFSSL_OCSP_REQ_CTX *ctx)
     if (ret != WOLFSSL_SUCCESS)
         return ret;
 
-    len = wolfSSL_BIO_get_mem_data(ctx->reqResp,
-        (unsigned char*)&resp);
+    len = wolfSSL_BIO_get_mem_data(ctx->reqResp, (void*)&resp);
     if (len <= 0)
         return WOLFSSL_FAILURE;
     return wolfSSL_d2i_OCSP_RESPONSE(presp, &resp, len) != NULL

--- a/src/ssl_asn1.c
+++ b/src/ssl_asn1.c
@@ -456,7 +456,7 @@ static void* d2i_obj(const WOLFSSL_ASN1_TEMPLATE* mem, const byte** src,
         mem->free_func(ret); /* never a stack so we can call this directly */
         return NULL;
     }
-    *len -= (tmp - *src);
+    *len -= (long)(tmp - *src);
     *src = tmp;
     return ret;
 }
@@ -586,7 +586,7 @@ static void* d2i_generic(const WOLFSSL_ASN1_TEMPLATE* mem,
         WOLFSSL_MSG("ptr not advanced enough");
         goto error;
     }
-    *len -= tmp - *src;
+    *len -= (long)(tmp - *src);
     *src = tmp;
     return ret;
 error:

--- a/src/tls.c
+++ b/src/tls.c
@@ -7174,9 +7174,9 @@ static int TLSX_CA_Names_Parse(WOLFSSL *ssl, const byte* input,
 
 #else
 
-#define CAN_GET_SIZE(...)  0
-#define CAN_WRITE(...)     0
-#define CAN_PARSE(...)     0
+#define CAN_GET_SIZE()  0
+#define CAN_WRITE()     0
+#define CAN_PARSE()     0
 
 #endif
 
@@ -14764,7 +14764,7 @@ static word16 TLSX_GetMinSize_Client(word16* type)
 }
     #define TLSX_GET_MIN_SIZE_CLIENT TLSX_GetMinSize_Client
 #else
-    #define TLSX_GET_MIN_SIZE_CLIENT(...) 0
+    #define TLSX_GET_MIN_SIZE_CLIENT() 0
 #endif
 
 
@@ -14833,7 +14833,7 @@ static word16 TLSX_GetMinSize_Server(const word16 *type)
 }
     #define TLSX_GET_MIN_SIZE_SERVER TLSX_GetMinSize_Server
 #else
-    #define TLSX_GET_MIN_SIZE_SERVER(...) 0
+    #define TLSX_GET_MIN_SIZE_SERVER() 0
 #endif
 
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -7168,15 +7168,16 @@ static int TLSX_CA_Names_Parse(WOLFSSL *ssl, const byte* input,
     return 0;
 }
 
-#define CAN_GET_SIZE  TLSX_CA_Names_GetSize
-#define CAN_WRITE     TLSX_CA_Names_Write
-#define CAN_PARSE     TLSX_CA_Names_Parse
+#define CAN_GET_SIZE(data)      TLSX_CA_Names_GetSize(data)
+#define CAN_WRITE(data, output) TLSX_CA_Names_Write(data, output)
+#define CAN_PARSE(ssl, input, length, isRequest) \
+                                TLSX_CA_Names_Parse(ssl, input, length, isRequest)
 
 #else
 
-#define CAN_GET_SIZE()  0
-#define CAN_WRITE()     0
-#define CAN_PARSE()     0
+#define CAN_GET_SIZE(data)                       0
+#define CAN_WRITE(data, output)                  0
+#define CAN_PARSE(ssl, input, length, isRequest) 0
 
 #endif
 
@@ -14762,9 +14763,9 @@ static word16 TLSX_GetMinSize_Client(word16* type)
             return 0;
     }
 }
-    #define TLSX_GET_MIN_SIZE_CLIENT TLSX_GetMinSize_Client
+    #define TLSX_GET_MIN_SIZE_CLIENT(type) TLSX_GetMinSize_Client(type)
 #else
-    #define TLSX_GET_MIN_SIZE_CLIENT() 0
+    #define TLSX_GET_MIN_SIZE_CLIENT(type) 0
 #endif
 
 
@@ -14831,9 +14832,9 @@ static word16 TLSX_GetMinSize_Server(const word16 *type)
             return 0;
     }
 }
-    #define TLSX_GET_MIN_SIZE_SERVER TLSX_GetMinSize_Server
+    #define TLSX_GET_MIN_SIZE_SERVER(type) TLSX_GetMinSize_Server(type)
 #else
-    #define TLSX_GET_MIN_SIZE_SERVER() 0
+    #define TLSX_GET_MIN_SIZE_SERVER(type) 0
 #endif
 
 

--- a/src/x509.c
+++ b/src/x509.c
@@ -5926,8 +5926,8 @@ static int X509PrintDirType(char * dst, int max_len, const DNS_entry * entry)
                 /* Copy it in, decrement available space. */
                 XSTRNCPY(dst, pfx, bytes_left);
                 dst += XSTRLEN(pfx);
-                total_len += XSTRLEN(pfx);
-                bytes_left -= XSTRLEN(pfx);
+                total_len += (int)XSTRLEN(pfx);
+                bytes_left -= (int)XSTRLEN(pfx);
 
                 if (fld_len > bytes_left) {
                     /* Not enough space left. */

--- a/wolfcrypt/src/curve25519.c
+++ b/wolfcrypt/src/curve25519.c
@@ -54,7 +54,7 @@
 #if defined(WOLFSSL_LINUXKM) && !defined(USE_INTEL_SPEEDUP)
     /* force off unneeded vector register save/restore. */
     #undef SAVE_VECTOR_REGISTERS
-    #define SAVE_VECTOR_REGISTERS(...) WC_DO_NOTHING
+    #define SAVE_VECTOR_REGISTERS(fail_clause) WC_DO_NOTHING
     #undef RESTORE_VECTOR_REGISTERS
     #define RESTORE_VECTOR_REGISTERS() WC_DO_NOTHING
 #endif

--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -67,7 +67,7 @@
 #if defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_SP_ASM)
     /* force off unneeded vector register save/restore. */
     #undef SAVE_VECTOR_REGISTERS
-    #define SAVE_VECTOR_REGISTERS(...) WC_DO_NOTHING
+    #define SAVE_VECTOR_REGISTERS(fail_clause) WC_DO_NOTHING
     #undef RESTORE_VECTOR_REGISTERS
     #define RESTORE_VECTOR_REGISTERS() WC_DO_NOTHING
 #endif

--- a/wolfcrypt/src/dsa.c
+++ b/wolfcrypt/src/dsa.c
@@ -45,7 +45,7 @@
 #if defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_SP_ASM)
     /* force off unneeded vector register save/restore. */
     #undef SAVE_VECTOR_REGISTERS
-    #define SAVE_VECTOR_REGISTERS(...) WC_DO_NOTHING
+    #define SAVE_VECTOR_REGISTERS(fail_clause) WC_DO_NOTHING
     #undef RESTORE_VECTOR_REGISTERS
     #define RESTORE_VECTOR_REGISTERS() WC_DO_NOTHING
 #endif

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -231,7 +231,7 @@ ECC Curve Sizes:
 #if defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_SP_ASM)
     /* force off unneeded vector register save/restore. */
     #undef SAVE_VECTOR_REGISTERS
-    #define SAVE_VECTOR_REGISTERS(...) WC_DO_NOTHING
+    #define SAVE_VECTOR_REGISTERS(fail_clause) WC_DO_NOTHING
     #undef RESTORE_VECTOR_REGISTERS
     #define RESTORE_VECTOR_REGISTERS() WC_DO_NOTHING
 #endif

--- a/wolfcrypt/src/eccsi.c
+++ b/wolfcrypt/src/eccsi.c
@@ -46,7 +46,7 @@
 #if defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_SP_ASM)
     /* force off unneeded vector register save/restore. */
     #undef SAVE_VECTOR_REGISTERS
-    #define SAVE_VECTOR_REGISTERS(...) WC_DO_NOTHING
+    #define SAVE_VECTOR_REGISTERS(fail_clause) WC_DO_NOTHING
     #undef RESTORE_VECTOR_REGISTERS
     #define RESTORE_VECTOR_REGISTERS() WC_DO_NOTHING
 #endif

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -63,7 +63,7 @@ RSA keys can be used to encrypt, decrypt, sign and verify data.
 #if defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_SP_ASM)
     /* force off unneeded vector register save/restore. */
     #undef SAVE_VECTOR_REGISTERS
-    #define SAVE_VECTOR_REGISTERS(...) WC_DO_NOTHING
+    #define SAVE_VECTOR_REGISTERS(fail_clause) WC_DO_NOTHING
     #undef RESTORE_VECTOR_REGISTERS
     #define RESTORE_VECTOR_REGISTERS() WC_DO_NOTHING
 #endif

--- a/wolfcrypt/src/sakke.c
+++ b/wolfcrypt/src/sakke.c
@@ -47,7 +47,7 @@
 #if defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_SP_ASM)
     /* force off unneeded vector register save/restore. */
     #undef SAVE_VECTOR_REGISTERS
-    #define SAVE_VECTOR_REGISTERS(...) WC_DO_NOTHING
+    #define SAVE_VECTOR_REGISTERS(fail_clause) WC_DO_NOTHING
     #undef RESTORE_VECTOR_REGISTERS
     #define RESTORE_VECTOR_REGISTERS() WC_DO_NOTHING
 #endif

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -119,7 +119,7 @@ This library provides single precision (SP) integer math functions.
 #if defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_SP_ASM)
     /* force off unneeded vector register save/restore. */
     #undef SAVE_VECTOR_REGISTERS
-    #define SAVE_VECTOR_REGISTERS(...) WC_DO_NOTHING
+    #define SAVE_VECTOR_REGISTERS(fail_clause) WC_DO_NOTHING
     #undef RESTORE_VECTOR_REGISTERS
     #define RESTORE_VECTOR_REGISTERS() WC_DO_NOTHING
 #endif

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -3604,7 +3604,8 @@ time_t stm32_hal_time(time_t *t1)
 
 #endif /* !NO_ASN_TIME */
 
-#if !defined(WOLFSSL_LEANPSK) && !defined(STRING_USER)
+#if (!defined(WOLFSSL_LEANPSK) && !defined(STRING_USER)) || \
+    defined(USE_WOLF_STRNSTR)
 char* mystrnstr(const char* s1, const char* s2, unsigned int n)
 {
     unsigned int s2_len = (unsigned int)XSTRLEN(s2);

--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -178,7 +178,7 @@ WOLFSSL_API void wolfSSL_SetLoggingPrefix(const char* prefix);
     WOLFSSL_API void WOLFSSL_MSG_EX(const char* fmt, ...);
     #define HAVE_WOLFSSL_MSG_EX
 #else
-    #define WOLFSSL_MSG_EX(...) WC_DO_NOTHING
+    #define WOLFSSL_MSG_EX() WC_DO_NOTHING
 #endif
     WOLFSSL_API void WOLFSSL_MSG(const char* msg);
 #ifdef WOLFSSL_DEBUG_CODEPOINTS

--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -178,7 +178,11 @@ WOLFSSL_API void wolfSSL_SetLoggingPrefix(const char* prefix);
     WOLFSSL_API void WOLFSSL_MSG_EX(const char* fmt, ...);
     #define HAVE_WOLFSSL_MSG_EX
 #else
-    #define WOLFSSL_MSG_EX() WC_DO_NOTHING
+    #ifdef __WATCOMC__ /* does not allow variadic macros */
+        #define WOLFSSL_MSG_EX()    WC_DO_NOTHING
+    #else
+        #define WOLFSSL_MSG_EX(...) WC_DO_NOTHING
+    #endif
 #endif
     WOLFSSL_API void WOLFSSL_MSG(const char* msg);
 #ifdef WOLFSSL_DEBUG_CODEPOINTS
@@ -209,7 +213,11 @@ WOLFSSL_API void wolfSSL_SetLoggingPrefix(const char* prefix);
     #define WOLFSSL_STUB(m)       WC_DO_NOTHING
     #define WOLFSSL_IS_DEBUG_ON() 0
 
-    #define WOLFSSL_MSG_EX(...)   WC_DO_NOTHING
+    #ifdef __WATCOMC__ /* does not allow variadic macros */
+        #define WOLFSSL_MSG_EX()    WC_DO_NOTHING
+    #else
+        #define WOLFSSL_MSG_EX(...) WC_DO_NOTHING
+    #endif
     #define WOLFSSL_MSG(m)        WC_DO_NOTHING
     #define WOLFSSL_BUFFER(b, l)  WC_DO_NOTHING
 

--- a/wolfssl/wolfcrypt/memory.h
+++ b/wolfssl/wolfcrypt/memory.h
@@ -449,7 +449,7 @@ WOLFSSL_LOCAL int wc_debug_CipherLifecycleFree(void **CipherLifecycleTag,
 
 #endif
 
-    #define ASSERT_SAVED_VECTOR_REGISTERS(fail_clause) do {         \
+    #define ASSERT_SAVED_VECTOR_REGISTERS() do {                    \
         if (wc_svr_count <= 0) {                                    \
             fprintf(stderr,                                         \
                     ("ASSERT_SAVED_VECTOR_REGISTERS : %s @ L%d : "  \
@@ -460,7 +460,6 @@ WOLFSSL_LOCAL int wc_debug_CipherLifecycleFree(void **CipherLifecycleTag,
                     wc_svr_last_file,                               \
                     wc_svr_last_line);                              \
             DEBUG_VECTOR_REGISTERS_EXTRA_FAIL_CLAUSE                \
-            { fail_clause }                                         \
         }                                                           \
     } while (0)
     #define ASSERT_RESTORED_VECTOR_REGISTERS(fail_clause) do {      \
@@ -477,7 +476,7 @@ WOLFSSL_LOCAL int wc_debug_CipherLifecycleFree(void **CipherLifecycleTag,
             { fail_clause }                                         \
         }                                                           \
     } while (0)
-    #define RESTORE_VECTOR_REGISTERS(...) do {                      \
+    #define RESTORE_VECTOR_REGISTERS() do {                         \
         --wc_svr_count;                                             \
         if ((wc_svr_count > 4) || (wc_svr_count < 0)) {             \
             fprintf(stderr,                                         \

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1358,10 +1358,13 @@
         #define NO_SESSION_CACHE
 #endif
 
-/* Micrium will use Visual Studio for compilation but not the Win32 API */
+/* For platforms where the target OS is not Windows, but compilation is
+ * done on Windows/Visual Studio, enable a way to disable USE_WINDOWS_API.
+ * Examples: Micrium, TenAsus INtime, uTasker, FreeRTOS simulator */
 #if defined(_WIN32) && !defined(MICRIUM) && !defined(FREERTOS) && \
     !defined(FREERTOS_TCP) && !defined(EBSNET) && !defined(WOLFSSL_EROAD) && \
-    !defined(WOLFSSL_UTASKER) && !defined(INTIME_RTOS)
+    !defined(WOLFSSL_UTASKER) && !defined(INTIME_RTOS) && \
+    !defined(WOLFSSL_NOT_WINDOWS_API)
     #define USE_WINDOWS_API
 #endif
 

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -30,8 +30,9 @@ This library provides single precision (SP) integer math functions.
 #ifndef WOLFSSL_LINUXKM
 #include <limits.h>
 #endif
-#include  <wolfssl/wolfcrypt/settings.h>
-#include  <wolfssl/wolfcrypt/hash.h>
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/types.h>
+#include <wolfssl/wolfcrypt/hash.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -100,6 +101,15 @@ extern "C" {
     #error "Size of unsigned int not detected"
 #endif
 
+#if defined(__WATCOMC__) && defined(__WATCOM_INT64__)
+    /* For older Watcom C compiler force types */
+    #define SP_ULLONG_BITS    64
+    typedef unsigned __int64 sp_uint64;
+    typedef          __int64  sp_int64;
+
+#else
+
+/* 32-bit type */
 #if defined(WOLF_C89) && !defined(NO_64BIT) && \
         ULONG_MAX == 18446744073709551615UL
     #define SP_ULONG_BITS    64
@@ -108,8 +118,8 @@ extern "C" {
     typedef          long  sp_int64;
 #elif !defined(WOLF_C89) && !defined(NO_64BIT) && \
         ULONG_MAX == 18446744073709551615ULL && \
-        4294967295UL != 18446744073709551615ULL /* verify pre-processor supports
-                                                 * 64-bit ULL types */
+        /* sanity check pre-processor supports 64-bit ULL types */ \
+        4294967295UL != 18446744073709551615ULL
     #define SP_ULONG_BITS    64
 
     typedef unsigned long sp_uint64;
@@ -132,6 +142,7 @@ extern "C" {
     #error "Size of unsigned long not detected"
 #endif
 
+/* 64-bit type */
 #ifdef ULLONG_MAX
     #if defined(WOLF_C89) && ULLONG_MAX == 18446744073709551615UL
         #define SP_ULLONG_BITS    64
@@ -165,6 +176,7 @@ extern "C" {
         #error "Size of unsigned long long not detected"
     #endif
 #elif (SP_ULONG_BITS == 32) && !defined(NO_64BIT)
+    #define SP_ULLONG_BITS    64
     /* Speculatively use long long as the 64-bit type as we don't have one
      * otherwise. */
     typedef unsigned long long sp_uint64;
@@ -173,6 +185,7 @@ extern "C" {
     #define SP_ULLONG_BITS    0
 #endif
 
+#endif /* __WATCOMC__ */
 
 #ifdef WOLFSSL_SP_DIV_32
 #define WOLFSSL_SP_DIV_WORD_HALF

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -182,7 +182,10 @@ decouple library dependencies with standard string, memory and so on.
          #endif
     #endif
 
-    #if defined(_MSC_VER) || defined(__BCPLUSPLUS__)
+    #if (defined(_MSC_VER) && !defined(WOLFSSL_NOT_WINDOWS_API)) || \
+           defined(__BCPLUSPLUS__) || \
+           (defined(__WATCOMC__) && defined(__WATCOM_INT64__))
+        /* windows types */
         #define WORD64_AVAILABLE
         #define W64LIT(x) x##ui64
         #define SW64LIT(x) x##i64
@@ -379,8 +382,8 @@ typedef struct w64wrapper {
     #endif
 
     /* set up rotate style */
-    #if (defined(_MSC_VER) || defined(__BCPLUSPLUS__)) && \
-        !defined(WOLFSSL_SGX) && !defined(INTIME_RTOS)
+    #if ((defined(_MSC_VER) && !defined(WOLFSSL_NOT_WINDOWS_API)) || \
+        defined(__BCPLUSPLUS__)) && !defined(WOLFSSL_SGX) && !defined(INTIME_RTOS)
         #define INTEL_INTRINSICS
         #define FAST_ROTATE
     #elif defined(__MWERKS__) && TARGET_CPU_PPC
@@ -426,16 +429,6 @@ typedef struct w64wrapper {
         /* use stub for fall through by default or for Microchip compiler */
         #undef  FALL_THROUGH
         #define FALL_THROUGH
-    #endif
-
-    /* For platforms where the target OS is not Windows, but compilation is
-     * done on Windows/Visual Studio, enable a way to disable USE_WINDOWS_API.
-     * Examples: Micrium, TenAsus INtime, uTasker, FreeRTOS simulator */
-    #if defined(_WIN32) && !defined(MICRIUM) && !defined(FREERTOS) && \
-        !defined(FREERTOS_TCP) && !defined(EBSNET) && \
-        !defined(WOLFSSL_UTASKER) && !defined(INTIME_RTOS) && \
-        !defined(WOLFSSL_NOT_WINDOWS_API)
-        #define USE_WINDOWS_API
     #endif
 
     #define XSTR_SIZEOF(x) (sizeof(x) - 1) /* -1 to not count the null char */
@@ -1757,7 +1750,11 @@ typedef struct w64wrapper {
     #endif
 
     #ifndef SAVE_VECTOR_REGISTERS
+        #ifdef __WATCOMC__
+        #define SAVE_VECTOR_REGISTERS() WC_DO_NOTHING
+        #else
         #define SAVE_VECTOR_REGISTERS(...) WC_DO_NOTHING
+        #endif
     #endif
     #ifndef SAVE_VECTOR_REGISTERS2
         #define SAVE_VECTOR_REGISTERS2() 0

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1750,11 +1750,7 @@ typedef struct w64wrapper {
     #endif
 
     #ifndef SAVE_VECTOR_REGISTERS
-        #ifdef __WATCOMC__
-        #define SAVE_VECTOR_REGISTERS() WC_DO_NOTHING
-        #else
-        #define SAVE_VECTOR_REGISTERS(...) WC_DO_NOTHING
-        #endif
+        #define SAVE_VECTOR_REGISTERS(fail_clause) WC_DO_NOTHING
     #endif
     #ifndef SAVE_VECTOR_REGISTERS2
         #define SAVE_VECTOR_REGISTERS2() 0
@@ -1768,10 +1764,10 @@ typedef struct w64wrapper {
         #define WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(x) WC_DO_NOTHING
     #endif
     #ifndef ASSERT_SAVED_VECTOR_REGISTERS
-        #define ASSERT_SAVED_VECTOR_REGISTERS(...) WC_DO_NOTHING
+        #define ASSERT_SAVED_VECTOR_REGISTERS(fail_clause) WC_DO_NOTHING
     #endif
     #ifndef ASSERT_RESTORED_VECTOR_REGISTERS
-        #define ASSERT_RESTORED_VECTOR_REGISTERS(...) WC_DO_NOTHING
+        #define ASSERT_RESTORED_VECTOR_REGISTERS(fail_clause) WC_DO_NOTHING
     #endif
     #ifndef RESTORE_VECTOR_REGISTERS
         #define RESTORE_VECTOR_REGISTERS() WC_DO_NOTHING

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1764,7 +1764,7 @@ typedef struct w64wrapper {
         #define WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(x) WC_DO_NOTHING
     #endif
     #ifndef ASSERT_SAVED_VECTOR_REGISTERS
-        #define ASSERT_SAVED_VECTOR_REGISTERS(fail_clause) WC_DO_NOTHING
+        #define ASSERT_SAVED_VECTOR_REGISTERS() WC_DO_NOTHING
     #endif
     #ifndef ASSERT_RESTORED_VECTOR_REGISTERS
         #define ASSERT_RESTORED_VECTOR_REGISTERS(fail_clause) WC_DO_NOTHING

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -75,7 +75,7 @@
         #ifndef WIN32_LEAN_AND_MEAN
             #define WIN32_LEAN_AND_MEAN
         #endif
-        #ifndef WOLFSSL_SGX
+        #if !defined(WOLFSSL_SGX) && !defined(WOLFSSL_NOT_WINDOWS_API)
             #if defined(_WIN32_WCE) || defined(WIN32_LEAN_AND_MEAN)
                 /* On WinCE winsock2.h must be included before windows.h */
                 #include <winsock2.h>
@@ -346,7 +346,7 @@
     #define WOLFSSL_ATOMIC_OPS
     #endif /* WOLFSSL_HAVE_ATOMIC_H */
 #endif
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) && !defined(WOLFSSL_NOT_WINDOWS_API)
     /* Use MSVC compiler intrinsics for atomic ops */
     #ifdef _WIN32_WCE
         #include <armintr.h>
@@ -1273,7 +1273,8 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
 #endif /* !NO_ASN_TIME */
 
 
-#ifndef WOLFSSL_LEANPSK
+#if (!defined(WOLFSSL_LEANPSK) && !defined(STRING_USER)) || \
+    defined(USE_WOLF_STRNSTR)
     char* mystrnstr(const char* s1, const char* s2, unsigned int n);
 #endif
 


### PR DESCRIPTION
# Description

More fixes for building x86 in Visual Studio for non-windows OS (Watcom C compiler). Followup to PR #7884. Fixes ZD 18465
* Consolidate the USE_WINDOWS_API to a single place.
* Expand the `WOLFSSL_NOT_WINDOWS_API` improvement for intrinsics and word sizes. 
* Fix for macro variadic `...` when no variables are used (some compilers like Watcom C have issue with this).
* Fix for Watcom C compiler "long long" -> "__int64".
* Fix a couple of minor cast warnings reported from VS.
* Fixes for consistency in `SAVE_VECTOR_REGISTERS `, `ASSERT_SAVED_VECTOR_REGISTERS` and `RESTORE_VECTOR_REGISTERS`.

# Testing

Worked with customer

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
