### PR TITLE
Fix issue with ARM ASM with AES CFB/OFB not initializing the "left" member

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -3726,8 +3726,8 @@ static WARN_UNUSED_RESULT int wc_AesDecrypt(
     #if !defined(WOLFSSL_STM32_CUBEMX) || defined(STM32_HAL_V2)
         ByteReverseWords(rk, rk, keylen);
     #endif
-    #if defined(WOLFSSL_AES_CFB) || defined(WOLFSSL_AES_COUNTER) || \
-        defined(WOLFSSL_AES_OFB)
+    #if defined(WOLFSSL_AES_COUNTER) || defined(WOLFSSL_AES_CFB) || \
+        defined(WOLFSSL_AES_OFB) || defined(WOLFSSL_AES_XTS)
         aes->left = 0;
     #endif
         return wc_AesSetIV(aes, iv);
@@ -3807,8 +3807,8 @@ static WARN_UNUSED_RESULT int wc_AesDecrypt(
         if (iv)
             XMEMCPY(aes->reg, iv, AES_BLOCK_SIZE);
 
-    #if defined(WOLFSSL_AES_CFB) || defined(WOLFSSL_AES_COUNTER) || \
-        defined(WOLFSSL_AES_OFB)
+    #if defined(WOLFSSL_AES_COUNTER) || defined(WOLFSSL_AES_CFB) || \
+        defined(WOLFSSL_AES_OFB) || defined(WOLFSSL_AES_XTS)
         aes->left = 0;
     #endif
 
@@ -3838,8 +3838,8 @@ static WARN_UNUSED_RESULT int wc_AesDecrypt(
         aes->rounds = keylen/4 + 6;
         XMEMCPY(aes->key, userKey, keylen);
 
-    #if defined(WOLFSSL_AES_CFB) || defined(WOLFSSL_AES_COUNTER) || \
-        defined(WOLFSSL_AES_OFB)
+    #if defined(WOLFSSL_AES_COUNTER) || defined(WOLFSSL_AES_CFB) || \
+        defined(WOLFSSL_AES_OFB) || defined(WOLFSSL_AES_XTS)
         aes->left = 0;
     #endif
 
@@ -3890,8 +3890,8 @@ static WARN_UNUSED_RESULT int wc_AesDecrypt(
         if (rk == NULL)
             return BAD_FUNC_ARG;
 
-    #if defined(WOLFSSL_AES_CFB) || defined(WOLFSSL_AES_COUNTER) || \
-        defined(WOLFSSL_AES_OFB)
+    #if defined(WOLFSSL_AES_COUNTER) || defined(WOLFSSL_AES_CFB) || \
+        defined(WOLFSSL_AES_OFB) || defined(WOLFSSL_AES_XTS)
         aes->left = 0;
     #endif
 
@@ -3971,8 +3971,8 @@ static WARN_UNUSED_RESULT int wc_AesDecrypt(
         XMEMCPY(aes->key, userKey, keylen);
         ret = nrf51_aes_set_key(userKey);
 
-    #if defined(WOLFSSL_AES_CFB) || defined(WOLFSSL_AES_COUNTER) || \
-        defined(WOLFSSL_AES_OFB)
+    #if defined(WOLFSSL_AES_COUNTER) || defined(WOLFSSL_AES_CFB) || \
+        defined(WOLFSSL_AES_OFB) || defined(WOLFSSL_AES_XTS)
         aes->left = 0;
     #endif
 
@@ -4028,7 +4028,8 @@ static WARN_UNUSED_RESULT int wc_AesDecrypt(
         aes->rounds = keylen/4 + 6;
 
         XMEMCPY(aes->key, userKey, keylen);
-        #if defined(WOLFSSL_AES_COUNTER)
+        #if defined(WOLFSSL_AES_COUNTER) || defined(WOLFSSL_AES_CFB) || \
+            defined(WOLFSSL_AES_OFB) || defined(WOLFSSL_AES_XTS)
             aes->left = 0;
         #endif
         return wc_AesSetIV(aes, iv);
@@ -4520,8 +4521,8 @@ static void AesSetKey_C(Aes* aes, const byte* key, word32 keySz, int dir)
         #endif
         }
 
-    #if defined(WOLFSSL_AES_CFB) || defined(WOLFSSL_AES_COUNTER) || \
-        defined(WOLFSSL_AES_OFB)
+    #if defined(WOLFSSL_AES_COUNTER) || defined(WOLFSSL_AES_CFB) || \
+        defined(WOLFSSL_AES_OFB) || defined(WOLFSSL_AES_XTS)
         aes->left = 0;
     #endif
 

--- a/wolfcrypt/src/port/Renesas/renesas_fspsm_aes.c
+++ b/wolfcrypt/src/port/Renesas/renesas_fspsm_aes.c
@@ -795,7 +795,8 @@ int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen,
         return BAD_FUNC_ARG;
     }
 
-#ifdef WOLFSSL_AES_COUNTER
+#if defined(WOLFSSL_AES_COUNTER) || defined(WOLFSSL_AES_CFB) || \
+    defined(WOLFSSL_AES_OFB) || defined(WOLFSSL_AES_XTS)
     aes->left = 0;
 #endif
 

--- a/wolfcrypt/src/port/arm/armv8-aes.c
+++ b/wolfcrypt/src/port/arm/armv8-aes.c
@@ -201,7 +201,8 @@ int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen,
     }
 #endif
 
-    #ifdef WOLFSSL_AES_COUNTER
+    #if defined(WOLFSSL_AES_COUNTER) || defined(WOLFSSL_AES_CFB) || \
+        defined(WOLFSSL_AES_OFB) || defined(WOLFSSL_AES_XTS)
         aes->left = 0;
     #endif /* WOLFSSL_AES_COUNTER */
 
@@ -16581,9 +16582,10 @@ int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen,
         XMEMCPY(aes->devKey, userKey, keylen);
     }
 #endif
-#ifdef WOLFSSL_AES_COUNTER
+#if defined(WOLFSSL_AES_COUNTER) || defined(WOLFSSL_AES_CFB) || \
+    defined(WOLFSSL_AES_OFB) || defined(WOLFSSL_AES_XTS)
     aes->left = 0;
-#endif /* WOLFSSL_AES_COUNTER */
+#endif
 
     aes->keylen = keylen;
     aes->rounds = keylen/4 + 6;

--- a/wolfcrypt/src/port/caam/caam_aes.c
+++ b/wolfcrypt/src/port/caam/caam_aes.c
@@ -93,7 +93,8 @@ int  wc_AesSetKey(Aes* aes, const byte* key, word32 len,
         return ret;
     }
 
-#ifdef WOLFSSL_AES_COUNTER
+#if defined(WOLFSSL_AES_COUNTER) || defined(WOLFSSL_AES_CFB) || \
+    defined(WOLFSSL_AES_OFB) || defined(WOLFSSL_AES_XTS)
     aes->left = 0;
 #endif
 

--- a/wolfcrypt/src/port/devcrypto/devcrypto_aes.c
+++ b/wolfcrypt/src/port/devcrypto/devcrypto_aes.c
@@ -125,7 +125,8 @@ int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen,
     aes->keylen = keylen;
     aes->rounds = keylen/4 + 6;
 
-#ifdef WOLFSSL_AES_COUNTER
+#if defined(WOLFSSL_AES_COUNTER) || defined(WOLFSSL_AES_CFB) || \
+    defined(WOLFSSL_AES_OFB) || defined(WOLFSSL_AES_XTS)
     aes->left = 0;
 #endif
     aes->ctx.cfd = -1;

--- a/wolfcrypt/src/port/riscv/riscv-64-aes.c
+++ b/wolfcrypt/src/port/riscv/riscv-64-aes.c
@@ -498,8 +498,8 @@ int wc_AesSetKey(Aes* aes, const byte* key, word32 keyLen, const byte* iv,
     if (ret == 0) {
         /* Finish setting the AES object. */
         aes->keylen = keyLen;
-#if defined(WOLFSSL_AES_CFB) || defined(WOLFSSL_AES_COUNTER) || \
-    defined(WOLFSSL_AES_OFB)
+#if defined(WOLFSSL_AES_COUNTER) || defined(WOLFSSL_AES_CFB) || \
+    defined(WOLFSSL_AES_OFB) || defined(WOLFSSL_AES_XTS)
         aes->left = 0;
 #endif
     }
@@ -1770,8 +1770,8 @@ int wc_AesSetKey(Aes* aes, const byte* key, word32 keyLen, const byte* iv,
     if (ret == 0) {
         /* Finish setting the AES object. */
         aes->keylen = keyLen;
-#if defined(WOLFSSL_AES_CFB) || defined(WOLFSSL_AES_COUNTER) || \
-    defined(WOLFSSL_AES_OFB)
+#if defined(WOLFSSL_AES_COUNTER) || defined(WOLFSSL_AES_CFB) || \
+    defined(WOLFSSL_AES_OFB) || defined(WOLFSSL_AES_XTS)
         aes->left = 0;
 #endif
     }
@@ -2978,8 +2978,8 @@ int wc_AesSetKey(Aes* aes, const byte* key, word32 keyLen, const byte* iv,
 
     if (ret == 0) {
         /* Initialize fields. */
-    #if defined(WOLFSSL_AES_CFB) || defined(WOLFSSL_AES_COUNTER) || \
-        defined(WOLFSSL_AES_OFB)
+    #if defined(WOLFSSL_AES_COUNTER) || defined(WOLFSSL_AES_CFB) || \
+        defined(WOLFSSL_AES_OFB) || defined(WOLFSSL_AES_XTS)
         aes->left = 0;
     #endif
         aes->keylen = (int)keyLen;

--- a/wolfcrypt/src/port/ti/ti-aes.c
+++ b/wolfcrypt/src/port/ti/ti-aes.c
@@ -99,7 +99,8 @@ int wc_AesSetKey(Aes* aes, const byte* key, word32 len, const byte* iv, int dir)
     aes->rounds = len / 4 + 6;
 
     XMEMCPY(aes->key, key, len);
-#ifdef WOLFSSL_AES_COUNTER
+#if defined(WOLFSSL_AES_COUNTER) || defined(WOLFSSL_AES_CFB) || \
+    defined(WOLFSSL_AES_OFB) || defined(WOLFSSL_AES_XTS)
     aes->left = 0;
 #endif
     return AesSetIV(aes, iv);


### PR DESCRIPTION
# Description

Fix issue with ARM ASM with AES CFB/OFB not initializing the "left" member. 

Consistency for initializing "left = 0" with various build option combinations.

Fixes ZD 18841.

# Testing

Tested on Raspberry Pi 5 with `./configure --enable-armasm --enable-aescfb CC="clang -fsanitize=address" && make && make check`

```
./configure CC="clang -fsanitize=address" --enable-armasm --enable-aescfb --disable-aesgcm --disable-aesctr --enable-cryptonly --disable-examples  && make
```

It was the wolfTPM use of AES CFB that found this issue.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
