### PR TITLE
20241022-cleanups

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -573,16 +573,15 @@ then
         AM_CFLAGS="$AM_CFLAGS -ffile-prefix-map=\$(abs_top_srcdir)/= -ffile-prefix-map=\$(top_srcdir)/="
     fi
 
-    # opportunistically use linker option --build-id=none
-
-    if "$CC" -Wl,--build-id=none -x c - -o /dev/null >/dev/null 2>&1 <<'        EOF'
+    # opportunistically force linker option --build-id=sha1 (usually the default)
+    if "$CC" -Wl,--build-id=sha1 -x c - -o /dev/null >/dev/null 2>&1 <<'        EOF'
         #include <stdlib.h>
         int main(int argc, char **argv) {
             (void)argc; (void)argv; return 0;
         }
         EOF
     then
-        AM_LDFLAGS="$AM_LDFLAGS -Wl,--build-id=none"
+        AM_LDFLAGS="$AM_LDFLAGS -Wl,--build-id=sha1"
     fi
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1155,7 +1155,8 @@ then
         test "$enable_dsa" = "" && test "$enable_sha" != "no" && enable_dsa=yes
         if test "$ENABLED_FIPS" = "no" || test "$HAVE_FIPS_VERSION" -le 5; then
             test "$enable_ecccustcurves" = "" && enable_ecccustcurves=yes
-            test "$enable_brainpool" = "" && enable_brainpool=yes
+            test "$enable_ecccustcurves" != "no" && test "$enable_brainpool" = "" && enable_brainpool=yes
+            test "$enable_ecccustcurves" != "no" && AM_CFLAGS="$AM_CFLAGS -DHAVE_ECC_CDH -DHAVE_ECC_KOBLITZ -DHAVE_ECC_SECPR2 -DHAVE_ECC_SECPR3"
         fi
         test "$enable_srp" = "" && enable_srp=yes
     fi
@@ -1194,6 +1195,7 @@ then
 
     if test "$ENABLED_FIPS" = "no" || test "$HAVE_FIPS_VERSION" -le 5; then
         test "$enable_des3" = "" && enable_des3=yes
+        test "$enable_des3" != "no" && AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DES_ECB"
     fi
 
     AM_CFLAGS="$AM_CFLAGS -DHAVE_AES_DECRYPT -DHAVE_AES_ECB -DWOLFSSL_ALT_NAMES"

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -15108,7 +15108,7 @@ static WC_INLINE const char* wolfssl_mac_to_string(int mac)
             macStr = "SHA1";
             break;
 #endif
-#ifdef HAVE_SHA224
+#ifdef WOLFSSL_SHA224
         case sha224_mac:
             macStr = "SHA224";
             break;
@@ -15118,12 +15118,12 @@ static WC_INLINE const char* wolfssl_mac_to_string(int mac)
             macStr = "SHA256";
             break;
 #endif
-#ifdef HAVE_SHA384
+#ifdef WOLFSSL_SHA384
         case sha384_mac:
             macStr = "SHA384";
             break;
 #endif
-#ifdef HAVE_SHA512
+#ifdef WOLFSSL_SHA512
         case sha512_mac:
             macStr = "SHA512";
             break;

--- a/tests/api.c
+++ b/tests/api.c
@@ -68600,7 +68600,7 @@ static int test_GENERAL_NAME_set0_othername(void) {
 /* Note the lack of wolfSSL_ prefix...this is a compatibility layer test. */
 static int test_othername_and_SID_ext(void) {
     EXPECT_DECLS;
-#if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && \
+#if defined(OPENSSL_ALL) && !defined(NO_CERTS) && \
     defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_REQ) && \
     defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ALT_NAMES) && \
     defined(WOLFSSL_CERT_EXT) && !defined(NO_FILESYSTEM) && \

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -30198,7 +30198,7 @@ static int MakeSignature(CertSignCtx* certSignCtx, const byte* buf, word32 sz,
 
     case CERTSIGN_STATE_DO:
         certSignCtx->state = CERTSIGN_STATE_DO;
-        ret = ALGO_ID_E; /* default to error */
+        ret = -1; /* default to error, reassigned to ALGO_ID_E below. */
 
     #ifndef NO_RSA
         if (rsaKey) {
@@ -30280,6 +30280,9 @@ static int MakeSignature(CertSignCtx* certSignCtx, const byte* buf, word32 sz,
                 ret = outSz;
         }
     #endif /* HAVE_SPHINCS */
+
+        if (ret == -1)
+            ret = ALGO_ID_E;
 
         break;
     }

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4554,13 +4554,11 @@ int wc_ecc_get_curve_id_from_oid(const byte* oid, word32 len)
     }
 #endif
 
-#if !defined(HAVE_OID_ENCODING) && !defined(HAVE_OID_DECODING)
     if (len == 0) {
         /* SAKKE has zero oidSz and will otherwise match with len==0. */
         WOLFSSL_MSG("zero oidSz");
         return ECC_CURVE_INVALID;
     }
-#endif
 
     for (curve_idx = 0; ecc_sets[curve_idx].size != 0; curve_idx++) {
     #if defined(HAVE_OID_ENCODING) && !defined(HAVE_OID_DECODING)

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1481,7 +1481,7 @@ extern void uITRON4_free(void *p) ;
     #ifndef NO_WRITEV
         #define NO_WRITEV
     #endif
-    #ifndef HAVE_SHA512
+    #ifndef WOLFSSL_SHA512
         #ifndef NO_SHA512
             #define NO_SHA512
         #endif


### PR DESCRIPTION
fix references to misnamed `HAVE_SHA224`, `HAVE_SHA384`, `HAVE_SHA512` (correct names have `WOLFSSL_` prefixes).

`wolfcrypt/src/ecc.c`: in `wc_ecc_get_curve_id_from_oid()`, deconditionalize guard against zero-length `len` added in 03a6eed037, to fix `test_wc_ecc_get_curve_id_from_oid()` failing in `cross-mingw-all-crypto`.

`configure.ac`: for reproducible-build, use `--build-id=sha1`, not `--build-id=none`, to support users relying on build-id in the linked object.

`configure.ac`: add several missing low level crypto algorithms to `all-crypto` that are already included indirectly in `enable-all`.

`wolfcrypt/src/asn.c`: tweak `ret` handling in `MakeSignature()` `CERTSIGN_STATE_DO` section for the benefit of `WOLFSSL_DEBUG_TRACE_ERROR_CODES`.

`tests/api.c`: gate `test_GENERAL_NAME_set0_othername()` on `OPENSSL_ALL`, not `OPENSSL_EXTRA`, as it fails with `--enable-all-crypto --enable-opensslextra`, and is commented to require `--enable-opensslall`.

tested with `wolfssl-multi-test.sh ... super-quick-check`
