### PR TITLE
Name VS2022 binary output wolfssl via project name

### DIFF
--- a/wolfssl-VS2022.vcxproj
+++ b/wolfssl-VS2022.vcxproj
@@ -54,6 +54,7 @@
     <ProjectGuid>{12226DBE-7278-4DFA-A119-5A0294CF0B33}</ProjectGuid>
     <RootNamespace>wolfssl</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <ProjectName>wolfssl</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">


### PR DESCRIPTION
# Description

This is a no-code-change PR that updates the project name of the new VS 2022 project files introduced in https://github.com/wolfSSL/wolfssl/pull/8090.

Currently the  output binary name would be `wolfssl-VS2022.lib` and/or `wolfssl-VS2022.dll`.

The new name will be `wolfssl.lib` and/or `wolfssl.dll`.

For instance, when compiling the [benchmark example](https://github.com/wolfSSL/wolfssl/tree/master/wolfcrypt/benchmark), note the new output file when compiling the wolfssl project is instead `wolfssl.lib` with this PR. 

```
1>Generating Code...
1>wolfssl-VS2022.vcxproj -> C:\workspace\wolfssl-gojimmypi-pr\wolfcrypt\benchmark\Debug\x64\wolfssl.lib
2>------ Rebuild All started: Project: benchmark-VS2022, Configuration: Debug x64 ------
2>benchmark.c
2>benchmark-VS2022.vcxproj -> C:\workspace\wolfssl-gojimmypi-pr\wolfcrypt\benchmark\x64\Debug\benchmark-VS2022.exe
========== Rebuild All: 2 succeeded, 0 failed, 0 skipped ==========
========== Rebuild completed at 9:33 AM and took 07.492 seconds ==========
```


Fixes zd# n/a

# Testing

Tested on Windows 11, Visual Studio 2022

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
