### PR TITLE
20241023-fixes

### DIFF
--- a/IDE/STM32Cube/default_conf.ftl
+++ b/IDE/STM32Cube/default_conf.ftl
@@ -539,7 +539,7 @@ extern ${variable.value} ${variable.name};
     //#define USE_SLOW_SHA512
 
     #define WOLFSSL_SHA512
-    #define HAVE_SHA512 /* freeRTOS settings.h requires this */
+    #define HAVE_SHA512 /* old freeRTOS settings.h requires this */
 #endif
 
 /* Sha2-384 */

--- a/IDE/iotsafe/user_settings.h
+++ b/IDE/iotsafe/user_settings.h
@@ -150,8 +150,10 @@ static inline long XTIME(long *x) { return jiffies;}
 #define WOLFSSL_AES_DIRECT
 
 /* Hashing */
-#define HAVE_SHA384
-#define HAVE_SHA512
+#define WOLFSSL_SHA384
+#define HAVE_SHA384 /* old freeRTOS settings.h requires this */
+#define WOLFSSL_SHA512
+#define HAVE_SHA512 /* old freeRTOS settings.h requires this */
 #define HAVE_HKDF
 
 /* TLS */

--- a/examples/configs/user_settings_stm32.h
+++ b/examples/configs/user_settings_stm32.h
@@ -602,7 +602,7 @@ extern "C" {
     //#define USE_SLOW_SHA512
 
     #define WOLFSSL_SHA512
-    #define HAVE_SHA512 /* freeRTOS settings.h requires this */
+    #define HAVE_SHA512 /* old freeRTOS settings.h requires this */
 #endif
 
 /* Sha2-384 */


### PR DESCRIPTION
fix `HAVE_SHA*` configurations in `IDE/iotsafe/user_settings.h` to also set `WOLFSSL_SHA*`, and in `IDE/STM32Cube/default_conf.ftl`, `IDE/iotsafe/user_settings.h`, and `examples/configs/user_settings_stm32.h`, comment `HAVE_SHA*` as "old freeRTOS settings.h requires this".
