### PR TITLE
fix for state of aes.gcm.H on re-use

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -8063,6 +8063,8 @@ static void GHASH_FINAL(Aes* aes, byte* s, word32 sSz)
     GHASH_LEN_BLOCK(aes);
     /* Copy the result into s. */
     XMEMCPY(s, AES_TAG(aes), sSz);
+    /* reset aes->gcm.H in case of re-use */
+    GHASH_INIT_EXTRA(aes);
 }
 #endif /* WOLFSSL_AESGCM_STREAM */
 


### PR DESCRIPTION
Discovered on Windows build and benchmark. Can be reproduced on Linux with

`./configure --enable-aesgcm-stream --enable-aesgcm=large && make && ./wolfcrypt/benchmark/benchmark -aes-gcm`


```
------------------------------------------------------------------------------
 wolfSSL version 5.7.2
------------------------------------------------------------------------------
Math: 	Multi-Precision: Wolf(SP) word-size=64 bits=4096 sp_int.c
wolfCrypt Benchmark (block bytes 1048576, min 1.0 sec each)
AES-128-GCM-enc             90 MiB took 1.045 seconds,   86.146 MiB/s Cycles per byte =  40.96
AES-128-GCM-dec             90 MiB took 1.042 seconds,   86.411 MiB/s Cycles per byte =  40.83
AES-192-GCM-enc             85 MiB took 1.018 seconds,   83.510 MiB/s Cycles per byte =  42.25
AES-192-GCM-dec             85 MiB took 1.027 seconds,   82.795 MiB/s Cycles per byte =  42.62
AES-256-GCM-enc             85 MiB took 1.058 seconds,   80.376 MiB/s Cycles per byte =  43.90
AES-256-GCM-dec             85 MiB took 1.059 seconds,   80.246 MiB/s Cycles per byte =  43.97
AES-128-GCM-STREAM-enc      90 MiB took 1.041 seconds,   86.443 MiB/s Cycles per byte =  40.82
AES-128-GCM-STREAM-dec       0 bytes took 0.012 seconds,    0.000 bytes/s Cycles per byte =   0.00
Benchmark AES-128-GCM-STREAM-dec failed: -180
bench_aesgcm failed: -180
AES-192-GCM-STREAM-enc      85 MiB took 1.017 seconds,   83.550 MiB/s Cycles per byte =  42.23
AES-192-GCM-STREAM-dec       0 bytes took 0.012 seconds,    0.000 bytes/s Cycles per byte =   0.00
Benchmark AES-192-GCM-STREAM-dec failed: -180
bench_aesgcm failed: -180
AES-256-GCM-STREAM-enc      80 MiB took 1.002 seconds,   79.860 MiB/s Cycles per byte =  44.18
AES-256-GCM-STREAM-dec       0 bytes took 0.012 seconds,    0.000 bytes/s Cycles per byte =   0.00
Benchmark AES-256-GCM-STREAM-dec failed: -180
bench_aesgcm failed: -180
GMAC Default               116 MiB took 1.001 seconds,  115.857 MiB/s Cycles per byte =  30.46
Benchmark complete

```