### PR TITLE
Check Intermediate cert OCSP when using tls1.3 for client side

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -15232,7 +15232,13 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         else /* skips OCSP and force CRL check */
                     #endif /* HAVE_CERTIFICATE_STATUS_REQUEST_V2 */
                     #if defined(HAVE_CERTIFICATE_STATUS_REQUEST)
-                        if (IsAtLeastTLSv1_3(ssl->version)) {
+                        if (IsAtLeastTLSv1_3(ssl->version) &&
+                            ssl->options.side == WOLFSSL_CLIENT_END &&
+                            ssl->status_request) {
+                            /* We check CSR in Certificate message sent from
+                             * Server. Server side will check client
+                             * certificates by traditional OCSP if enabled
+                             */
                             ret = TLSX_CSR_InitRequest_ex(ssl->extensions,
                                     args->dCert, ssl->heap, args->certIdx);
                         }


### PR DESCRIPTION
# Description
Check CSR in Certificate message sent from Server. 
Server side will check client certificates by traditional OCSP if enabled

Fixes zd#18141

# Testing

reproducible program

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
