### PR TITLE
memory: fix types in wc_LoadStaticMemory_ex()

### DIFF
--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -669,7 +669,7 @@ static int wc_partition_static_memory(byte* buffer, word32 sz, int flag,
 }
 
 static int wc_init_memory_heap(WOLFSSL_HEAP* heap, unsigned int listSz,
-        const unsigned int* sizeList, const unsigned int* distList)
+        const word32 *sizeList, const word32 *distList)
 {
     unsigned int i;
 
@@ -695,8 +695,8 @@ static int wc_init_memory_heap(WOLFSSL_HEAP* heap, unsigned int listSz,
 }
 
 int wc_LoadStaticMemory_ex(WOLFSSL_HEAP_HINT** pHint,
-        unsigned int listSz, const unsigned int* sizeList,
-        const unsigned int* distList, unsigned char* buf,
+        unsigned int listSz, const word32 *sizeList,
+        const word32 *distList, unsigned char *buf,
         unsigned int sz, int flag, int maxSz)
 {
     WOLFSSL_HEAP*      heap = NULL;
@@ -773,13 +773,8 @@ int wc_LoadStaticMemory_ex(WOLFSSL_HEAP_HINT** pHint,
 int wc_LoadStaticMemory(WOLFSSL_HEAP_HINT** pHint,
     unsigned char* buf, unsigned int sz, int flag, int maxSz)
 {
-#ifdef WOLFSSL_LEAN_STATIC_PSK
-    word16 sizeList[WOLFMEM_DEF_BUCKETS] = { WOLFMEM_BUCKETS };
-    byte   distList[WOLFMEM_DEF_BUCKETS] = { WOLFMEM_DIST };
-#else
     word32 sizeList[WOLFMEM_DEF_BUCKETS] = { WOLFMEM_BUCKETS };
     word32 distList[WOLFMEM_DEF_BUCKETS] = { WOLFMEM_DIST };
-#endif
     int ret = 0;
 
     WOLFSSL_ENTER("wc_LoadStaticMemory");
@@ -817,7 +812,7 @@ int wolfSSL_MemoryPaddingSz(void)
 /* Used to calculate memory size for optimum use with buckets.
    returns the suggested size rounded down to the nearest bucket. */
 int wolfSSL_StaticBufferSz_ex(unsigned int listSz,
-        const unsigned int *sizeList, const unsigned int *distList,
+        const word32 *sizeList, const word32 *distList,
         byte* buffer, word32 sz, int flag)
 {
     word32 ava = sz;

--- a/wolfssl/wolfcrypt/memory.h
+++ b/wolfssl/wolfcrypt/memory.h
@@ -219,8 +219,8 @@ WOLFSSL_API int wolfSSL_GetAllocators(wolfSSL_Malloc_cb* mf,
     #endif
 
     #ifdef WOLFSSL_STATIC_MEMORY_LEAN
-        word16   sizeList[WOLFMEM_MAX_BUCKETS];/* memory sizes in ava list */
-        byte     distList[WOLFMEM_MAX_BUCKETS];/* general distribution */
+        word32     sizeList[WOLFMEM_MAX_BUCKETS];/* memory sizes in ava list */
+        word32     distList[WOLFMEM_MAX_BUCKETS];/* general distribution */
     #else
         word32     maxHa;               /* max concurrent handshakes */
         word32     curHa;
@@ -258,8 +258,8 @@ WOLFSSL_API int wolfSSL_GetAllocators(wolfSSL_Malloc_cb* mf,
     WOLFSSL_API void* wolfSSL_SetGlobalHeapHint(void* heap);
     WOLFSSL_API void* wolfSSL_GetGlobalHeapHint(void);
     WOLFSSL_API int wc_LoadStaticMemory_ex(WOLFSSL_HEAP_HINT** pHint,
-            unsigned int listSz, const unsigned int *sizeList,
-            const unsigned int *distList, unsigned char* buf, unsigned int sz,
+            unsigned int listSz, const word32 *sizeList,
+            const word32 *distList, unsigned char* buf, unsigned int sz,
             int flag, int max);
 #ifdef WOLFSSL_STATIC_MEMORY_DEBUG_CALLBACK
     #define WOLFSSL_DEBUG_MEMORY_ALLOC 0
@@ -281,7 +281,7 @@ WOLFSSL_API int wolfSSL_GetAllocators(wolfSSL_Malloc_cb* mf,
     WOLFSSL_LOCAL int FreeFixedIO(WOLFSSL_HEAP* heap, wc_Memory** io);
 
     WOLFSSL_API int wolfSSL_StaticBufferSz_ex(unsigned int listSz,
-            const unsigned int *sizeList, const unsigned int *distList,
+            const word32 *sizeList, const word32 *distList,
             byte* buffer, word32 sz, int flag);
     WOLFSSL_API int wolfSSL_StaticBufferSz(byte* buffer, word32 sz, int flag);
     WOLFSSL_API int wolfSSL_MemoryPaddingSz(void);


### PR DESCRIPTION
# Description
Fix to use the right array type in wc_LoadStaticMemory_ex()
