### PR TITLE
Fixes for asynchronous release - SHA3/HMAC devId

### DIFF
--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -266,6 +266,7 @@ int wc_HmacSetKey_ex(Hmac* hmac, int type, const byte* key, word32 length,
         return BAD_FUNC_ARG;
     }
 
+    heap = hmac->heap;
 #if !defined(HAVE_FIPS) || FIPS_VERSION3_GE(6,0,0)
     /* if set key has already been run then make sure and free existing */
     /* This is for async and PIC32MZ situations, and just normally OK,
@@ -273,7 +274,13 @@ int wc_HmacSetKey_ex(Hmac* hmac, int type, const byte* key, word32 length,
        available in FIPS builds. In current FIPS builds, the hashes are
        not allocating resources. */
     if (hmac->macType != WC_HASH_TYPE_NONE) {
+    #ifdef WOLF_CRYPTO_CB
+        int devId = hmac->devId;
+    #endif
         wc_HmacFree(hmac);
+    #ifdef WOLF_CRYPTO_CB
+        hmac->devId = devId;
+    #endif
     }
 #endif
 

--- a/wolfcrypt/src/sha3.c
+++ b/wolfcrypt/src/sha3.c
@@ -820,10 +820,10 @@ static int wc_InitSha3(wc_Sha3* sha3, void* heap, int devId)
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_SHA3)
     ret = wolfAsync_DevCtxInit(&sha3->asyncDev,
                         WOLFSSL_ASYNC_MARKER_SHA3, sha3->heap, devId);
-#elif defined(WOLF_CRYPTO_CB)
+#endif
+#if defined(WOLF_CRYPTO_CB)
     sha3->devId = devId;
-#endif /* WOLFSSL_ASYNC_CRYPT */
-
+#endif
     (void)devId;
 
     return ret;


### PR DESCRIPTION
# Description

* Fixed SHA3 issue with possible uninitialized devId when building with async. 
* Fixed HMAC set key issue with devId/heap getting lost.

# Testing


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
