### PR TITLE
tests api: fix inconsistent do_acert_verify_test guards.

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -13739,7 +13739,7 @@ static int test_wolfSSL_X509_verify(void)
 }
 
 #if defined(WOLFSSL_ACERT) && !defined(NO_CERTS) && !defined(NO_RSA) && \
-    !defined(NO_FILESYSTEM) && defined(OPENSSL_EXTRA)
+    defined(WC_RSA_PSS) && !defined(NO_FILESYSTEM) && defined(OPENSSL_EXTRA)
 /* Given acert file and its pubkey file, read them and then
  * attempt to verify signed acert.
  *


### PR DESCRIPTION
# Description

Inconsistent define guards around an acert test.

Fixes build error in zd#18875.

# Testing

Instructions in ticket.
