### PR TITLE
Introduce IDE-FIPS directory

### DIFF
--- a/IDE-FIPS/README.md
+++ b/IDE-FIPS/README.md
@@ -1,0 +1,6 @@
+# IDE-FIPS
+
+This directory contains FIPS-only IDE builds to better isolate from non-FIPS environments.
+
+When adding a new environment, remember to edit the local [include.am](./include.am) file
+and probably create a new `IDE-FIPS/<NEW-OE>/include.am` file as well.

--- a/IDE-FIPS/include.am
+++ b/IDE-FIPS/include.am
@@ -1,0 +1,8 @@
+# vim:ft=automake
+# included from Top Level Makefile.am
+# All paths should be given relative to the root
+
+# For example, when WIN-SRTP-KDF-140-3 is ready:
+# include IDE-FIPS/WIN-SRTP-KDF-140-3/include.am
+
+EXTRA_DIST+= IDE-FIPS/README.md

--- a/INSTALL
+++ b/INSTALL
@@ -1,3 +1,5 @@
+For FIPS builds not found here, see the IDE-FIPS directory.
+
 0. Building on *nix from git repository
 
     Run the autogen script to generate configure, then proceed to step 1.

--- a/Makefile.am
+++ b/Makefile.am
@@ -198,6 +198,7 @@ include mcapi/wolfssl.X/nbproject/include.am
 include mcapi/zlib.X/nbproject/include.am
 include tirtos/include.am
 include IDE/include.am
+include IDE-FIPS/include.am
 endif
 include scripts/include.am
 


### PR DESCRIPTION
# Description

Upon reconsideration after the merge of https://github.com/wolfSSL/wolfssl/pull/8090, I think it would be best to move all project files to the respective [IDE/\<environment\>](https://github.com/wolfSSL/wolfssl/tree/master/IDE) directory, out of the respective source directories such as [wolfcrypt/benchmark](https://github.com/wolfSSL/wolfssl/tree/master/wolfcrypt/benchmark).

Additionally, it may be best to isolate FIPS and non-FIPS environments.

This PR proposes a new `IDE-FIPS` for all the FIPS-related builds in preparation for the moves.

Fixes zd# n/a

# Testing

Not tested.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
