### PR TITLE
Fix conversion on various files

### DIFF
--- a/src/keys.c
+++ b/src/keys.c
@@ -3908,7 +3908,8 @@ int DeriveKeys(WOLFSSL* ssl)
             XMEMCPY(shaInput + idx, ssl->arrays->clientRandom, RAN_LEN);
             if (ret == 0) {
                 ret = wc_ShaUpdate(sha, shaInput,
-                    (KEY_PREFIX + SECRET_LEN + 2 * RAN_LEN) - KEY_PREFIX + j);
+                    (KEY_PREFIX + SECRET_LEN + 2 * RAN_LEN) - KEY_PREFIX +
+                        (word32)(j));
             }
             if (ret == 0) {
                 ret = wc_ShaFinal(sha, shaOutput);
@@ -3942,12 +3943,13 @@ int DeriveKeys(WOLFSSL* ssl)
 
 static int CleanPreMaster(WOLFSSL* ssl)
 {
-    int i, ret, sz = ssl->arrays->preMasterSz;
+    int i, ret, sz = (int)(ssl->arrays->preMasterSz);
 
     for (i = 0; i < sz; i++)
         ssl->arrays->preMasterSecret[i] = 0;
 
-    ret = wc_RNG_GenerateBlock(ssl->rng, ssl->arrays->preMasterSecret, sz);
+    ret = wc_RNG_GenerateBlock(ssl->rng, ssl->arrays->preMasterSecret,
+                                                            (word32)(sz));
     if (ret != 0)
         return ret;
 
@@ -4035,8 +4037,8 @@ static int MakeSslMasterSecret(WOLFSSL* ssl)
             }
 
             idx = 0;
-            XMEMCPY(shaInput, prefix, i + 1);
-            idx += i + 1;
+            XMEMCPY(shaInput, prefix, (size_t)(i + 1));
+            idx += (word32)(i + 1);
 
             XMEMCPY(shaInput + idx, ssl->arrays->preMasterSecret, pmsSz);
             idx += pmsSz;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1620,7 +1620,7 @@ int wolfSSL_get_ciphers(char* buf, int len)
     for (i = 0; i < ciphersSz; i++) {
         int cipherNameSz = (int)XSTRLEN(ciphers[i].name);
         if (cipherNameSz + 1 < len) {
-            XSTRNCPY(buf, ciphers[i].name, len);
+            XSTRNCPY(buf, ciphers[i].name, (size_t)len);
             buf += cipherNameSz;
 
             if (i < ciphersSz - 1)
@@ -1657,7 +1657,7 @@ int wolfSSL_get_ciphers_iana(char* buf, int len)
 #endif
         cipherNameSz = (int)XSTRLEN(ciphers[i].name_iana);
         if (cipherNameSz + 1 < len) {
-            XSTRNCPY(buf, ciphers[i].name_iana, len);
+            XSTRNCPY(buf, ciphers[i].name_iana, (size_t)len);
             buf += cipherNameSz;
 
             if (i < ciphersSz - 1)
@@ -1683,7 +1683,7 @@ const char* wolfSSL_get_shared_ciphers(WOLFSSL* ssl, char* buf, int len)
 
     cipher = wolfSSL_get_cipher_name_iana(ssl);
     len = (int)min((word32)len, (word32)(XSTRLEN(cipher) + 1));
-    XMEMCPY(buf, cipher, len);
+    XMEMCPY(buf, cipher, (size_t)len);
     return buf;
 }
 
@@ -2247,7 +2247,7 @@ int wolfSSL_export_dtls_srtp_keying_material(WOLFSSL* ssl,
         return BUFFER_E;
     }
 
-    return wolfSSL_export_keying_material(ssl, out, profile->kdfBits,
+    return wolfSSL_export_keying_material(ssl, out, (size_t)profile->kdfBits,
             DTLS_SRTP_KEYING_MATERIAL_LABEL,
             XSTR_SIZEOF(DTLS_SRTP_KEYING_MATERIAL_LABEL), NULL, 0, 0);
 }
@@ -3847,7 +3847,7 @@ int wolfSSL_ALPN_GetPeerProtocol(WOLFSSL* ssl, char **list, word16 *listSz)
             *list = NULL;
             return WOLFSSL_FAILURE;
         }
-        XMEMCPY(p, s + i, len);
+        XMEMCPY(p, s + i, (size_t)len);
     }
     *p = 0;
 
@@ -7337,7 +7337,7 @@ static int d2iTryRsaKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
     }
 
     pkey->pkey_sz = (int)keyIdx;
-    pkey->pkey.ptr = (char*)XMALLOC(memSz, NULL,
+    pkey->pkey.ptr = (char*)XMALLOC((size_t)memSz, NULL,
             priv ? DYNAMIC_TYPE_PRIVATE_KEY :
                    DYNAMIC_TYPE_PUBLIC_KEY);
     if (pkey->pkey.ptr == NULL) {
@@ -7509,7 +7509,7 @@ static int d2iTryDsaKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
     }
 
     pkey->pkey_sz = (int)keyIdx;
-    pkey->pkey.ptr = (char*)XMALLOC(memSz, NULL,
+    pkey->pkey.ptr = (char*)XMALLOC((size_t)memSz, NULL,
             priv ? DYNAMIC_TYPE_PRIVATE_KEY :
                    DYNAMIC_TYPE_PUBLIC_KEY);
     if (pkey->pkey.ptr == NULL) {
@@ -7593,14 +7593,14 @@ static int d2iTryDhKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
     }
 
     pkey->pkey_sz = (int)memSz;
-    pkey->pkey.ptr = (char*)XMALLOC(memSz, NULL,
+    pkey->pkey.ptr = (char*)XMALLOC((size_t)memSz, NULL,
             priv ? DYNAMIC_TYPE_PRIVATE_KEY :
                    DYNAMIC_TYPE_PUBLIC_KEY);
     if (pkey->pkey.ptr == NULL) {
         ret = 0;
     }
     if (ret == 1) {
-        XMEMCPY(pkey->pkey.ptr, mem, memSz);
+        XMEMCPY(pkey->pkey.ptr, mem, (size_t)memSz);
         pkey->type = WC_EVP_PKEY_DH;
 
         pkey->ownDh = 1;
@@ -7678,14 +7678,14 @@ static int d2iTryAltDhKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
     ret = 1;
     pkey->type     = WC_EVP_PKEY_DH;
     pkey->pkey_sz  = (int)memSz;
-    pkey->pkey.ptr = (char*)XMALLOC(memSz, NULL,
+    pkey->pkey.ptr = (char*)XMALLOC((size_t)memSz, NULL,
             priv ? DYNAMIC_TYPE_PRIVATE_KEY :
                    DYNAMIC_TYPE_PUBLIC_KEY);
     if (pkey->pkey.ptr == NULL) {
         ret = 0;
     }
     if (ret == 1) {
-        XMEMCPY(pkey->pkey.ptr, mem, memSz);
+        XMEMCPY(pkey->pkey.ptr, mem, (size_t)memSz);
         pkey->ownDh = 1;
         pkey->dh = wolfSSL_DH_new();
         if (pkey->dh == NULL) {
@@ -8006,16 +8006,16 @@ WOLFSSL_PKCS8_PRIV_KEY_INFO* wolfSSL_d2i_PKCS8_PKEY(
                 pkcs8Der->length, &algId);
         if (ret >= 0) {
             if (advanceLen == 0) /* Set only if not PEM */
-                advanceLen = inOutIdx + ret;
+                advanceLen = (int)inOutIdx + ret;
             if (algId == DHk) {
                 /* Special case for DH as we expect the DER buffer to be always
                  * be in PKCS8 format */
                 rawDer.buffer = pkcs8Der->buffer;
-                rawDer.length = inOutIdx + ret;
+                rawDer.length = inOutIdx + (word32)ret;
             }
             else {
                 rawDer.buffer = pkcs8Der->buffer + inOutIdx;
-                rawDer.length = ret;
+                rawDer.length = (word32)ret;
             }
             ret = 0; /* good DER */
         }
@@ -8077,7 +8077,7 @@ int wolfSSL_i2d_PKCS8_PKEY(WOLFSSL_PKCS8_PRIV_KEY_INFO* key, unsigned char** pp)
         return len;
 
     if (*pp == NULL) {
-        out = (unsigned char*)XMALLOC(len, NULL, DYNAMIC_TYPE_ASN1);
+        out = (unsigned char*)XMALLOC((size_t)len, NULL, DYNAMIC_TYPE_ASN1);
         if (out == NULL)
             return WOLFSSL_FATAL_ERROR;
     }
@@ -8167,7 +8167,8 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PUBKEY_bio(WOLFSSL_BIO* bio,
         return NULL;
     }
 
-    mem = (unsigned char*)XMALLOC(memSz, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    mem = (unsigned char*)XMALLOC((size_t)memSz, bio->heap,
+                                DYNAMIC_TYPE_TMP_BUFFER);
     if (mem == NULL) {
         return NULL;
     }
@@ -8226,15 +8227,16 @@ static int wolfSSL_EVP_PKEY_get_der(const WOLFSSL_EVP_PKEY* key,
         if (*der) {
             /* since this function signature has no size value passed in it is
              * assumed that the user has allocated a large enough buffer */
-            XMEMCPY(*der, pt + pkcs8HeaderSz, sz);
+            XMEMCPY(*der, pt + pkcs8HeaderSz, (size_t)sz);
             *der += sz;
         }
         else {
-            *der = (unsigned char*)XMALLOC(sz, NULL, DYNAMIC_TYPE_OPENSSL);
+            *der = (unsigned char*)XMALLOC((size_t)sz, NULL,
+                                                DYNAMIC_TYPE_OPENSSL);
             if (*der == NULL) {
                 return WOLFSSL_FATAL_ERROR;
             }
-            XMEMCPY(*der, pt + pkcs8HeaderSz, sz);
+            XMEMCPY(*der, pt + pkcs8HeaderSz, (size_t)sz);
         }
     }
     return sz;
@@ -8306,14 +8308,15 @@ static WOLFSSL_EVP_PKEY* _d2i_PublicKey(int type, WOLFSSL_EVP_PKEY** out,
     local->type     = type;
     local->pkey_sz  = (int)inSz;
     local->pkcs8HeaderSz = pkcs8HeaderSz;
-    local->pkey.ptr = (char*)XMALLOC(inSz, NULL, DYNAMIC_TYPE_PUBLIC_KEY);
+    local->pkey.ptr = (char*)XMALLOC((size_t)inSz, NULL,
+                                        DYNAMIC_TYPE_PUBLIC_KEY);
     if (local->pkey.ptr == NULL) {
         wolfSSL_EVP_PKEY_free(local);
         local = NULL;
         return NULL;
     }
     else {
-        XMEMCPY(local->pkey.ptr, *in, inSz);
+        XMEMCPY(local->pkey.ptr, *in, (size_t)inSz);
     }
 
     switch (type) {
@@ -12971,7 +12974,7 @@ cleanup:
     {
         WOLFSSL_ENTER("wolfSSL_ERR_get_error");
 #ifdef WOLFSSL_HAVE_ERROR_QUEUE
-        return wc_GetErrorNodeErr();
+        return (unsigned long)wc_GetErrorNodeErr();
 #else
         return (unsigned long)(0 - NOT_COMPILED_IN);
 #endif
@@ -13042,7 +13045,8 @@ cleanup:
         do {
         ret = wc_PeekErrorNode(0, &file, &reason, &line);
         if (ret >= 0) {
-            const char* r = wolfSSL_ERR_reason_error_string(0 - ret);
+            const char* r = wolfSSL_ERR_reason_error_string(
+                (unsigned long)(0 - ret));
             if (XSNPRINTF(buf, sizeof(buf),
                           "error:%d:wolfSSL library:%s:%s:%d\n",
                           ret, r, file, line)
@@ -14965,9 +14969,9 @@ WOLFSSL_X509* wolfSSL_get_certificate(WOLFSSL* ssl)
             }
             #ifndef WOLFSSL_X509_STORE_CERTS
             ssl->ourCert = wolfSSL_X509_d2i_ex(NULL,
-                                              ssl->buffers.certificate->buffer,
-                                              ssl->buffers.certificate->length,
-                                              ssl->heap);
+                                         ssl->buffers.certificate->buffer,
+                                         (int)ssl->buffers.certificate->length,
+                                         ssl->heap);
             #endif
         }
         return ssl->ourCert;
@@ -14981,9 +14985,9 @@ WOLFSSL_X509* wolfSSL_get_certificate(WOLFSSL* ssl)
                 }
                 #ifndef WOLFSSL_X509_STORE_CERTS
                 ssl->ctx->ourCert = wolfSSL_X509_d2i_ex(NULL,
-                                               ssl->ctx->certificate->buffer,
-                                               ssl->ctx->certificate->length,
-                                               ssl->heap);
+                                          ssl->ctx->certificate->buffer,
+                                          (int)ssl->ctx->certificate->length,
+                                          ssl->heap);
                 #endif
                 ssl->ctx->ownOurCert = 1;
             }
@@ -15005,7 +15009,8 @@ WOLFSSL_X509* wolfSSL_CTX_get0_certificate(WOLFSSL_CTX* ctx)
             #ifndef WOLFSSL_X509_STORE_CERTS
             ctx->ourCert = wolfSSL_X509_d2i_ex(NULL,
                                            ctx->certificate->buffer,
-                                           ctx->certificate->length, ctx->heap);
+                                           (int)ctx->certificate->length,
+                                           ctx->heap);
             #endif
             ctx->ownOurCert = 1;
         }
@@ -15804,42 +15809,42 @@ int wolfSSL_sk_CIPHER_description(WOLFSSL_CIPHER* cipher)
 
 
     /* Build up the string by copying onto the end. */
-    XSTRNCPY(dp, name, len);
+    XSTRNCPY(dp, name, (size_t)len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
     len -= strLen; dp += strLen;
 
-    XSTRNCPY(dp, " ", len);
+    XSTRNCPY(dp, " ", (size_t)len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
     len -= strLen; dp += strLen;
-    XSTRNCPY(dp, protocol, len);
-    dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= strLen; dp += strLen;
-
-    XSTRNCPY(dp, " Kx=", len);
-    dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= strLen; dp += strLen;
-    XSTRNCPY(dp, keaStr, len);
+    XSTRNCPY(dp, protocol, (size_t)len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
     len -= strLen; dp += strLen;
 
-    XSTRNCPY(dp, " Au=", len);
+    XSTRNCPY(dp, " Kx=", (size_t)len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
     len -= strLen; dp += strLen;
-    XSTRNCPY(dp, authStr, len);
-    dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= strLen; dp += strLen;
-
-    XSTRNCPY(dp, " Enc=", len);
-    dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= strLen; dp += strLen;
-    XSTRNCPY(dp, encStr, len);
+    XSTRNCPY(dp, keaStr, (size_t)len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
     len -= strLen; dp += strLen;
 
-    XSTRNCPY(dp, " Mac=", len);
+    XSTRNCPY(dp, " Au=", (size_t)len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
     len -= strLen; dp += strLen;
-    XSTRNCPY(dp, macStr, len);
+    XSTRNCPY(dp, authStr, (size_t)len);
+    dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
+    len -= strLen; dp += strLen;
+
+    XSTRNCPY(dp, " Enc=", (size_t)len);
+    dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
+    len -= strLen; dp += strLen;
+    XSTRNCPY(dp, encStr, (size_t)len);
+    dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
+    len -= strLen; dp += strLen;
+
+    XSTRNCPY(dp, " Mac=", (size_t)len);
+    dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
+    len -= strLen; dp += (size_t)strLen;
+    XSTRNCPY(dp, macStr, (size_t)len);
     dp[len-1] = '\0';
 
     return WOLFSSL_SUCCESS;
@@ -16097,7 +16102,7 @@ char* wolfSSL_CIPHER_description(const WOLFSSL_CIPHER* cipher, char* in,
      */
     if (cipher->in_stack == TRUE) {
         wolfSSL_sk_CIPHER_description((WOLFSSL_CIPHER*)cipher);
-        XSTRNCPY(in,cipher->description,len);
+        XSTRNCPY(in,cipher->description,(size_t)len);
         return ret;
     }
 #endif
@@ -16110,32 +16115,32 @@ char* wolfSSL_CIPHER_description(const WOLFSSL_CIPHER* cipher, char* in,
     macStr = wolfssl_mac_to_string(cipher->ssl->specs.mac_algorithm);
 
     /* Build up the string by copying onto the end. */
-    XSTRNCPY(in, wolfSSL_CIPHER_get_name(cipher), len);
+    XSTRNCPY(in, wolfSSL_CIPHER_get_name(cipher), (size_t)len);
     in[len-1] = '\0'; strLen = XSTRLEN(in); len -= (int)strLen; in += strLen;
 
-    XSTRNCPY(in, " ", len);
+    XSTRNCPY(in, " ", (size_t)len);
     in[len-1] = '\0'; strLen = XSTRLEN(in); len -= (int)strLen; in += strLen;
-    XSTRNCPY(in, wolfSSL_get_version(cipher->ssl), len);
-    in[len-1] = '\0'; strLen = XSTRLEN(in); len -= (int)strLen; in += strLen;
-
-    XSTRNCPY(in, " Kx=", len);
-    in[len-1] = '\0'; strLen = XSTRLEN(in); len -= (int)strLen; in += strLen;
-    XSTRNCPY(in, keaStr, len);
+    XSTRNCPY(in, wolfSSL_get_version(cipher->ssl), (size_t)len);
     in[len-1] = '\0'; strLen = XSTRLEN(in); len -= (int)strLen; in += strLen;
 
-    XSTRNCPY(in, " Au=", len);
+    XSTRNCPY(in, " Kx=", (size_t)len);
     in[len-1] = '\0'; strLen = XSTRLEN(in); len -= (int)strLen; in += strLen;
-    XSTRNCPY(in, authStr, len);
-    in[len-1] = '\0'; strLen = XSTRLEN(in); len -= (int)strLen; in += strLen;
-
-    XSTRNCPY(in, " Enc=", len);
-    in[len-1] = '\0'; strLen = XSTRLEN(in); len -= (int)strLen; in += strLen;
-    XSTRNCPY(in, encStr, len);
+    XSTRNCPY(in, keaStr, (size_t)len);
     in[len-1] = '\0'; strLen = XSTRLEN(in); len -= (int)strLen; in += strLen;
 
-    XSTRNCPY(in, " Mac=", len);
+    XSTRNCPY(in, " Au=", (size_t)len);
     in[len-1] = '\0'; strLen = XSTRLEN(in); len -= (int)strLen; in += strLen;
-    XSTRNCPY(in, macStr, len);
+    XSTRNCPY(in, authStr, (size_t)len);
+    in[len-1] = '\0'; strLen = XSTRLEN(in); len -= (int)strLen; in += strLen;
+
+    XSTRNCPY(in, " Enc=", (size_t)len);
+    in[len-1] = '\0'; strLen = XSTRLEN(in); len -= (int)strLen; in += strLen;
+    XSTRNCPY(in, encStr, (size_t)len);
+    in[len-1] = '\0'; strLen = XSTRLEN(in); len -= (int)strLen; in += strLen;
+
+    XSTRNCPY(in, " Mac=", (size_t)len);
+    in[len-1] = '\0'; strLen = XSTRLEN(in); len -= (int)strLen; in += strLen;
+    XSTRNCPY(in, macStr, (size_t)len);
     in[len-1] = '\0';
 
     return ret;
@@ -17265,8 +17270,8 @@ long wolfSSL_clear_options(WOLFSSL* ssl, long opt)
     WOLFSSL_ENTER("wolfSSL_clear_options");
     if(ssl == NULL)
         return WOLFSSL_FAILURE;
-    ssl->options.mask &= ~opt;
-    return ssl->options.mask;
+    ssl->options.mask &= (unsigned long)~opt;
+    return (long)ssl->options.mask;
 }
 
 #ifdef HAVE_PK_CALLBACKS
@@ -17532,7 +17537,7 @@ long wolfSSL_get_verify_result(const WOLFSSL *ssl)
         return WOLFSSL_FAILURE;
     }
 
-    return ssl->peerVerifyRet;
+    return (long)ssl->peerVerifyRet;
 }
 #endif
 
@@ -18246,7 +18251,7 @@ int wolfSSL_cmp_peer_cert_to_file(WOLFSSL* ssl, const char *fname)
 
         if (sz > (long)sizeof(staticBuffer)) {
             WOLFSSL_MSG("Getting dynamic buffer");
-            myBuffer = (byte*)XMALLOC(sz, ctx->heap, DYNAMIC_TYPE_FILE);
+            myBuffer = (byte*)XMALLOC((size_t)sz, ctx->heap, DYNAMIC_TYPE_FILE);
             dynamic = 1;
         }
 
@@ -19136,7 +19141,7 @@ WOLFSSL_X509* wolfSSL_get_chain_X509(WOLFSSL_X509_CHAIN* chain, int idx)
     #endif
         {
             InitDecodedCert(cert, chain->certs[idx].buffer,
-                                  chain->certs[idx].length, NULL);
+                                  (word32)chain->certs[idx].length, NULL);
 
             if ((ret = ParseCertRelative(cert, CERT_TYPE, 0, NULL, NULL)) != 0) {
                 WOLFSSL_MSG("Failed to parse cert");
@@ -19198,10 +19203,11 @@ int  wolfSSL_get_chain_cert_pem(WOLFSSL_X509_CHAIN* chain, int idx,
 
     /* Null output buffer return size needed in outLen */
     if(!buf) {
-        if(Base64_Encode(chain->certs[idx].buffer, chain->certs[idx].length,
+        if(Base64_Encode(chain->certs[idx].buffer,
+                    (word32)chain->certs[idx].length,
                     NULL, &szNeeded) != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
             return WOLFSSL_FAILURE;
-        *outLen = szNeeded + headerLen + footerLen;
+        *outLen = (int)szNeeded + headerLen + footerLen;
         return WC_NO_ERR_TRACE(LENGTH_ONLY_E);
     }
 
@@ -19210,7 +19216,7 @@ int  wolfSSL_get_chain_cert_pem(WOLFSSL_X509_CHAIN* chain, int idx,
         return BAD_FUNC_ARG;
 
     /* header */
-    if (XMEMCPY(buf, header, headerLen) == NULL)
+    if (XMEMCPY(buf, header, (size_t)headerLen) == NULL)
         return WOLFSSL_FATAL_ERROR;
 
     i = headerLen;
@@ -19218,14 +19224,15 @@ int  wolfSSL_get_chain_cert_pem(WOLFSSL_X509_CHAIN* chain, int idx,
     /* body */
     *outLen = inLen;  /* input to Base64_Encode */
     if ( (err = Base64_Encode(chain->certs[idx].buffer,
-                       chain->certs[idx].length, buf + i, (word32*)outLen)) < 0)
+                       (word32)chain->certs[idx].length, buf + i,
+                       (word32*)outLen)) < 0)
         return err;
     i += *outLen;
 
     /* footer */
     if ( (i + footerLen) > inLen)
         return BAD_FUNC_ARG;
-    if (XMEMCPY(buf + i, footer, footerLen) == NULL)
+    if (XMEMCPY(buf + i, footer, (size_t)footerLen) == NULL)
         return WOLFSSL_FATAL_ERROR;
     *outLen += headerLen + footerLen;
 
@@ -19968,7 +19975,7 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
                 obj->dynamic |= WOLFSSL_ASN1_DYNAMIC_DATA;
             }
             else {
-                obj->dynamic &= ~WOLFSSL_ASN1_DYNAMIC_DATA;
+                obj->dynamic &= (unsigned char)~WOLFSSL_ASN1_DYNAMIC_DATA;
             }
         }
         XMEMCPY((byte*)obj->obj, objBuf, obj->objSz);
@@ -20083,7 +20090,7 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
             bufSz = bufLen - 1;
         }
         if (bufSz) {
-            XMEMCPY(buf, name, bufSz);
+            XMEMCPY(buf, name, (size_t)bufSz);
         }
         else if (a->type == WOLFSSL_GEN_DNS || a->type == WOLFSSL_GEN_EMAIL ||
                  a->type == WOLFSSL_GEN_URI) {
@@ -20094,7 +20101,7 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
             if ((desc = oid_translate_num_to_str(buf))) {
                 bufSz = (int)XSTRLEN(desc);
                 bufSz = (int)min((word32)bufSz,(word32) bufLen - 1);
-                XMEMCPY(buf, desc, bufSz);
+                XMEMCPY(buf, desc, (size_t)bufSz);
             }
         }
         else {
@@ -20250,19 +20257,21 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
 
         if (o->nid > 0)
             return o->nid;
-        if ((ret = GetObjectId(o->obj, &idx, &oid, o->grp, o->objSz)) < 0) {
+        if ((ret = GetObjectId(o->obj, &idx, &oid,
+                                    (word32)o->grp, o->objSz)) < 0) {
             if (ret == WC_NO_ERR_TRACE(ASN_OBJECT_ID_E)) {
                 /* Put ASN object tag in front and try again */
-                int len = SetObjectId(o->objSz, NULL) + o->objSz;
-                byte* buf = (byte*)XMALLOC(len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                int len = SetObjectId((int)o->objSz, NULL) + (int)o->objSz;
+                byte* buf = (byte*)XMALLOC((size_t)len, NULL,
+                                            DYNAMIC_TYPE_TMP_BUFFER);
                 if (!buf) {
                     WOLFSSL_MSG("malloc error");
                     return WOLFSSL_FATAL_ERROR;
                 }
-                idx = SetObjectId(o->objSz, buf);
+                idx = (word32)SetObjectId((int)o->objSz, buf);
                 XMEMCPY(buf + idx, o->obj, o->objSz);
                 idx = 0;
-                ret = GetObjectId(buf, &idx, &oid, o->grp, len);
+                ret = GetObjectId(buf, &idx, &oid, (word32)o->grp, (word32)len);
                 XFREE(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                 if (ret < 0) {
                     WOLFSSL_MSG("Issue getting OID of object");
@@ -20401,13 +20410,13 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
             /* try as a short name */
             len = (int)XSTRLEN(s);
             if ((int)XSTRLEN(wolfssl_object_info[i].sName) == len &&
-                XSTRNCMP(wolfssl_object_info[i].sName, s, len) == 0) {
+                XSTRNCMP(wolfssl_object_info[i].sName, s, (word32)len) == 0) {
                 return wolfssl_object_info[i].nid;
             }
 
             /* try as a long name */
             if ((int)XSTRLEN(wolfssl_object_info[i].lName) == len &&
-                XSTRNCMP(wolfssl_object_info[i].lName, s, len) == 0) {
+                XSTRNCMP(wolfssl_object_info[i].lName, s, (word32)len) == 0) {
                 return wolfssl_object_info[i].nid;
             }
         }
@@ -20462,7 +20471,7 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
             obj->dynamic |= WOLFSSL_ASN1_DYNAMIC_DATA;
             i = SetObjectId((int)outSz, (byte*)obj->obj);
             XMEMCPY((byte*)obj->obj + i, out, outSz);
-            obj->objSz = i + outSz;
+            obj->objSz = (word32)i + outSz;
             return obj;
         }
 
@@ -21148,7 +21157,8 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PrivateKey_bio(WOLFSSL_BIO* bio,
         return NULL;
     }
 
-    mem = (unsigned char*)XMALLOC(memSz, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    mem = (unsigned char*)XMALLOC((size_t)memSz, bio->heap,
+                                    DYNAMIC_TYPE_TMP_BUFFER);
     if (mem == NULL) {
         WOLFSSL_MSG("Malloc failure");
         return NULL;
@@ -21173,7 +21183,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PrivateKey_bio(WOLFSSL_BIO* bio,
             int i;
             int j = 0;
 
-            extraBioMem = (unsigned char *)XMALLOC(extraBioMemSz, NULL,
+            extraBioMem = (unsigned char *)XMALLOC((size_t)extraBioMemSz, NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
             if (extraBioMem == NULL) {
                 WOLFSSL_MSG("Malloc failure");
@@ -23084,13 +23094,13 @@ int set_curves_list(WOLFSSL* ssl, WOLFSSL_CTX *ctx, const char* names,
         if (len > MAX_CURVE_NAME_SZ - 1)
             goto leave;
 
-        XMEMCPY(name, names + start, len);
+        XMEMCPY(name, names + start, (size_t)len);
         name[len] = 0;
         curve = WOLFSSL_NAMED_GROUP_INVALID;
 
         for (nist_name = kNistCurves; nist_name->name != NULL; nist_name++) {
             if (len == nist_name->name_len &&
-                    XSTRNCMP(name, nist_name->name, len) == 0) {
+                    XSTRNCMP(name, nist_name->name, (size_t)len) == 0) {
                 curve = nist_name->curve;
                 break;
             }
@@ -23113,7 +23123,7 @@ int set_curves_list(WOLFSSL* ssl, WOLFSSL_CTX *ctx, const char* names,
                 goto leave;
             }
 
-            curve = GetCurveByOID(eccSet->oidSum);
+            curve = GetCurveByOID((int)eccSet->oidSum);
         #else
             WOLFSSL_MSG("API not present to search farther using name");
             goto leave;
@@ -24244,7 +24254,7 @@ static int bio_get_data(WOLFSSL_BIO* bio, byte** data)
 
     ret = wolfSSL_BIO_get_len(bio);
     if (ret > 0) {
-        mem = (byte*)XMALLOC(ret, bio->heap, DYNAMIC_TYPE_OPENSSL);
+        mem = (byte*)XMALLOC((size_t)ret, bio->heap, DYNAMIC_TYPE_OPENSSL);
         if (mem == NULL) {
             WOLFSSL_MSG("Memory error");
             ret = MEMORY_E;
@@ -24337,7 +24347,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_AutoPrivateKey(WOLFSSL_EVP_PKEY** pkey,
      */
     ret = GetSequence(der, &idx, &len, keyLen);
     if (ret >= 0) {
-        word32 end = idx + len;
+        word32 end = idx + (word32)len;
         while (ret >= 0 && idx < end) {
             /* Skip type */
             idx++;
@@ -24345,10 +24355,10 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_AutoPrivateKey(WOLFSSL_EVP_PKEY** pkey,
             len = 0;
             ret = GetLength(der, &idx, &len, keyLen);
             if (ret >= 0) {
-                if (idx + len > end)
+                if (idx + (word32)len > end)
                     ret = ASN_PARSE_E;
                 else {
-                    idx += len;
+                    idx += (word32)len;
                     cnt++;
                 }
             }

--- a/src/ssl_crypto.c
+++ b/src/ssl_crypto.c
@@ -2543,21 +2543,23 @@ WOLFSSL_DES_LONG wolfSSL_DES_cbc_cksum(const unsigned char* in,
     if ((!err) && (dataSz % DES_BLOCK_SIZE)) {
         /* Allocate a buffer big enough to hold padded input. */
         dataSz += DES_BLOCK_SIZE - (dataSz % DES_BLOCK_SIZE);
-        data = (unsigned char*)XMALLOC(dataSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        data = (unsigned char*)XMALLOC((size_t)dataSz, NULL,
+        DYNAMIC_TYPE_TMP_BUFFER);
         if (data == NULL) {
             WOLFSSL_MSG("Issue creating temporary buffer");
             err = 1;
         }
         else {
             /* Copy input and pad with 0s. */
-            XMEMCPY(data, in, length);
-            XMEMSET(data + length, 0, dataSz - length);
+            XMEMCPY(data, in, (size_t)length);
+            XMEMSET(data + length, 0, (size_t)(dataSz - length));
         }
     }
 
     if (!err) {
         /* Allocate buffer to hold encrypted data. */
-        tmp = (unsigned char*)XMALLOC(dataSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        tmp = (unsigned char*)XMALLOC((size_t)dataSz, NULL,
+        DYNAMIC_TYPE_TMP_BUFFER);
         if (tmp == NULL) {
             WOLFSSL_MSG("Issue creating temporary buffer");
             err = 1;
@@ -2637,7 +2639,7 @@ void wolfSSL_DES_cbc_encrypt(const unsigned char* input, unsigned char* output,
             if (lb_sz != 0) {
                 /* Create a 0 padded block from remaining bytes. */
                 XMEMSET(lastBlock, 0, DES_BLOCK_SIZE);
-                XMEMCPY(lastBlock, input + len, lb_sz);
+                XMEMCPY(lastBlock, input + len, (size_t)lb_sz);
                 /* Encrypt last block into output. */
                 wc_Des_CbcEncrypt(des, output + len, lastBlock,
                     (word32)DES_BLOCK_SIZE);
@@ -2651,7 +2653,7 @@ void wolfSSL_DES_cbc_encrypt(const unsigned char* input, unsigned char* output,
                 wc_Des_CbcDecrypt(des, lastBlock, input + len,
                     (word32)DES_BLOCK_SIZE);
                 /* Copy out the required amount of the decrypted block. */
-                XMEMCPY(output + len, lastBlock, lb_sz);
+                XMEMCPY(output + len, lastBlock, (size_t)lb_sz);
             }
         }
     }
@@ -2775,7 +2777,7 @@ void wolfSSL_DES_ede3_cbc_encrypt(const unsigned char* input,
                 if (lb_sz != 0) {
                     /* Create a 0 padded block from remaining bytes. */
                     XMEMSET(lastBlock, 0, DES_BLOCK_SIZE);
-                    XMEMCPY(lastBlock, input + len, lb_sz);
+                    XMEMCPY(lastBlock, input + len, (size_t)lb_sz);
                     /* Encrypt last block into output. */
                     ret = wc_Des3_CbcEncrypt(des3, output + len, lastBlock,
                         (word32)DES_BLOCK_SIZE);
@@ -2825,7 +2827,7 @@ void wolfSSL_DES_ede3_cbc_encrypt(const unsigned char* input,
                     (void)ret;
                 #endif
                     /* Copy out the required amount of the decrypted block. */
-                    XMEMCPY(output + len, lastBlock, lb_sz);
+                    XMEMCPY(output + len, lastBlock, (size_t)lb_sz);
                 }
             }
         }
@@ -2940,7 +2942,7 @@ static int wolfssl_aes_set_key(const unsigned char *key, const int bits,
         return WOLFSSL_FATAL_ERROR;
     }
 
-    if (wc_AesSetKey((Aes*)aes, key, ((bits)/8), NULL, enc) != 0) {
+    if (wc_AesSetKey((Aes*)aes, key, (word32)((bits)/8), NULL, enc) != 0) {
         WOLFSSL_MSG("Error in setting AES key");
         return WOLFSSL_FATAL_ERROR;
     }

--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -134,7 +134,7 @@ static int DataToDerBuffer(const unsigned char* buff, word32 len, int format,
     /* Data in buffer has PEM format - extract DER data. */
     if (format == WOLFSSL_FILETYPE_PEM) {
     #ifdef WOLFSSL_PEM_TO_DER
-        ret = PemToDer(buff, len, type, der, heap, info, algId);
+        ret = PemToDer(buff, (long)(len), type, der, heap, info, algId);
         if (ret != 0) {
             FreeDer(der);
         }
@@ -1254,7 +1254,7 @@ static int ProcessBufferPrivPkcs8Dec(EncryptedInfo* info, DerBuffer* der,
     }
     if (ret >= 0) {
         /* Zero out encrypted data not overwritten. */
-        ForceZero(der->buffer + ret, der->length - ret);
+        ForceZero(der->buffer + ret, der->length - (word32)ret);
         /* Set decrypted data length. */
         der->length = (word32)ret;
     }
@@ -5228,7 +5228,8 @@ int wolfSSL_CTX_use_RSAPrivateKey(WOLFSSL_CTX* ctx, WOLFSSL_RSA* rsa)
 
     if (ret == 1) {
         /* Allocate memory to hold DER encoding.. */
-        der = (unsigned char*)XMALLOC(derSize, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        der = (unsigned char*)XMALLOC((size_t)derSize, NULL,
+                                            DYNAMIC_TYPE_TMP_BUFFER);
         if (der == NULL) {
             WOLFSSL_MSG("Malloc failure");
             ret = MEMORY_E;
@@ -5470,8 +5471,8 @@ int wolfSSL_SetTmpDH(WOLFSSL* ssl, const unsigned char* p, int pSz,
     }
     if (ret == 1) {
         /* Copy p and g into allocated buffers. */
-        XMEMCPY(pAlloc, p, pSz);
-        XMEMCPY(gAlloc, g, gSz);
+        XMEMCPY(pAlloc, p, (size_t)pSz);
+        XMEMCPY(gAlloc, g, (size_t)gSz);
         /* Set the buffers into SSL. */
         ret = wolfssl_set_tmp_dh(ssl, pAlloc, pSz, gAlloc, gSz);
     }
@@ -5629,8 +5630,8 @@ int wolfSSL_CTX_SetTmpDH(WOLFSSL_CTX* ctx, const unsigned char* p, int pSz,
 
     if (ret == 1) {
         /* Copy p and g into allocated buffers. */
-        XMEMCPY(pAlloc, p, pSz);
-        XMEMCPY(gAlloc, g, gSz);
+        XMEMCPY(pAlloc, p, (size_t)pSz);
+        XMEMCPY(gAlloc, g, (size_t)gSz);
         /* Set the buffers into SSL context. */
         ret = wolfssl_ctx_set_tmp_dh(ctx, pAlloc, pSz, gAlloc, gSz);
     }
@@ -5682,8 +5683,8 @@ long wolfSSL_set_tmp_dh(WOLFSSL *ssl, WOLFSSL_DH *dh)
 
     if (ret == 1) {
         /* Allocate buffers for p and g to be assigned into SSL. */
-        p = (byte*)XMALLOC(pSz, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-        g = (byte*)XMALLOC(gSz, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        p = (byte*)XMALLOC((size_t)pSz, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        g = (byte*)XMALLOC((size_t)gSz, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
         if ((p == NULL) || (g == NULL)) {
             ret = MEMORY_E;
         }
@@ -5748,8 +5749,8 @@ long wolfSSL_CTX_set_tmp_dh(WOLFSSL_CTX* ctx, WOLFSSL_DH* dh)
 
     if (ret == 1) {
         /* Allocate buffers for p and g to be assigned into SSL. */
-        p = (byte*)XMALLOC(pSz, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-        g = (byte*)XMALLOC(gSz, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        p = (byte*)XMALLOC((size_t)pSz, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        g = (byte*)XMALLOC((size_t)gSz, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
         if ((p == NULL) || (g == NULL)) {
             ret = MEMORY_E;
         }

--- a/src/ssl_sess.c
+++ b/src/ssl_sess.c
@@ -375,7 +375,7 @@ int wolfSSL_SetServerID(WOLFSSL* ssl, const byte* id, int len, int newSession)
         WOLFSSL_MSG("Valid ServerID not cached already");
 
         ssl->session->idLen = (word16)len;
-        XMEMCPY(ssl->session->serverID, id, len);
+        XMEMCPY(ssl->session->serverID, id, (size_t)len);
     }
 #ifdef HAVE_EXT_CACHE
     else {
@@ -1819,7 +1819,7 @@ int AddSessionToCache(WOLFSSL_CTX* ctx, WOLFSSL_SESSION* addSession,
     ticLen = addSession->ticketLen;
     /* Alloc Memory here to avoid syscalls during lock */
     if (ticLen > SESSION_TICKET_LEN) {
-        ticBuff = (byte*)XMALLOC(ticLen, NULL,
+        ticBuff = (byte*)XMALLOC((size_t)ticLen, NULL,
                 DYNAMIC_TYPE_SESSION_TICK);
         if (ticBuff == NULL) {
             return MEMORY_E;
@@ -1978,7 +1978,7 @@ int AddSessionToCache(WOLFSSL_CTX* ctx, WOLFSSL_SESSION* addSession,
         /* Copy in the certs from the session */
         addSession->chain.count = cacheSession->chain.count;
         XMEMCPY(addSession->chain.certs, cacheSession->chain.certs,
-                sizeof(x509_buffer) * cacheSession->chain.count);
+                sizeof(x509_buffer) * (size_t)cacheSession->chain.count);
     }
 #endif /* SESSION_CERTS */
 #if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
@@ -2669,7 +2669,8 @@ int wolfSSL_i2d_SSL_SESSION(WOLFSSL_SESSION* sess, unsigned char** p)
         unsigned char *data;
 
         if (*p == NULL)
-            *p = (unsigned char*)XMALLOC(size, NULL, DYNAMIC_TYPE_OPENSSL);
+            *p = (unsigned char*)XMALLOC((size_t)size, NULL,
+                                                DYNAMIC_TYPE_OPENSSL);
         if (*p == NULL)
             return 0;
         data = *p;
@@ -2693,7 +2694,7 @@ int wolfSSL_i2d_SSL_SESSION(WOLFSSL_SESSION* sess, unsigned char** p)
             c16toa((word16)sess->chain.certs[i].length, data + idx);
             idx += OPAQUE16_LEN;
             XMEMCPY(data + idx, sess->chain.certs[i].buffer,
-                    sess->chain.certs[i].length);
+                    (size_t)sess->chain.certs[i].length);
             idx += sess->chain.certs[i].length;
         }
 #endif
@@ -3524,7 +3525,7 @@ int wolfSSL_SESSION_get_master_key(const WOLFSSL_SESSION* ses,
         size = outSz;
     }
 
-    XMEMCPY(out, ses->masterSecret, size);
+    XMEMCPY(out, ses->masterSecret, (size_t)size);
     return size;
 }
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -1024,7 +1024,7 @@ int Tls13_Exporter(WOLFSSL* ssl, unsigned char *out, size_t outLen,
     ret = Tls13HKDFExpandLabel(ssl, firstExpand, hashLen,
             ssl->arrays->exporterSecret, hashLen,
             protocol, protocolLen, (byte*)label, (word32)labelLen,
-            emptyHash, hashLen, hashType);
+            emptyHash, hashLen, (int)hashType);
     if (ret != 0)
         return ret;
 
@@ -1035,7 +1035,7 @@ int Tls13_Exporter(WOLFSSL* ssl, unsigned char *out, size_t outLen,
 
     ret = Tls13HKDFExpandLabel(ssl, out, (word32)outLen, firstExpand, hashLen,
             protocol, protocolLen, exporterLabel, EXPORTER_LABEL_SZ,
-            hashOut, hashLen, hashType);
+            hashOut, hashLen, (int)hashType);
 
     return ret;
 }
@@ -7439,7 +7439,7 @@ int SendTls13ServerHello(WOLFSSL* ssl, byte extMsgType)
                 /* replace the last 8 bytes of server random with the accept */
                 if (((WOLFSSL_ECH*)echX->data)->state == ECH_PARSED_INTERNAL) {
                     ret = EchWriteAcceptance(ssl, output + RECORD_HEADER_SZ,
-                        serverRandomOffset - RECORD_HEADER_SZ,
+                        (int)serverRandomOffset - RECORD_HEADER_SZ,
                         sendSz - RECORD_HEADER_SZ);
 
                     /* remove ech so we don't keep sending it in write */
@@ -8470,7 +8470,7 @@ static word32 NextCert(byte* data, word32 length, word32* idx)
  * offset    index offset
  * returns   Total number of bytes written.
  */
-static word32 WriteCSRToBuffer(WOLFSSL* ssl, DerBuffer** certExts,
+static int WriteCSRToBuffer(WOLFSSL* ssl, DerBuffer** certExts,
                                 word16* extSz,  word16 extSz_num)
 {
     int    ret = 0;
@@ -8488,7 +8488,7 @@ static word32 WriteCSRToBuffer(WOLFSSL* ssl, DerBuffer** certExts,
 
     if (csr) {
         for (extIdx = 0; extIdx < (word16)(extSz_num); extIdx++) {
-            tmpSz = TLSX_CSR_GetSize_ex(csr, 0, extIdx);
+            tmpSz = TLSX_CSR_GetSize_ex(csr, 0, (int)extIdx);
 
             if (tmpSz > (OPAQUE8_LEN + OPAQUE24_LEN) &&
                 certExts[extIdx] == NULL) {
@@ -8523,7 +8523,7 @@ static word32 WriteCSRToBuffer(WOLFSSL* ssl, DerBuffer** certExts,
         /* chain cert empty extension size */
         totalSz += OPAQUE16_LEN * extSz_num;
     }
-    return totalSz;
+    return (int)totalSz;
 }
 #endif /* HAVE_CERTIFICATE_STATUS_REQUEST */
 /* Add certificate data and empty extension to output up to the fragment size.

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -1493,7 +1493,8 @@ int wolfIO_TcpConnect(SOCKET_T* sockfd, const char* ip, word16 port, int to_sec)
         sin = (SOCKADDR_IN *)&addr;
         sin->sin_family = AF_INET;
         sin->sin_port = XHTONS(port);
-        XMEMCPY(&sin->sin_addr.s_addr, entry->h_addr_list[0], entry->h_length);
+        XMEMCPY(&sin->sin_addr.s_addr, entry->h_addr_list[0],
+                (size_t)entry->h_length);
     #endif
     }
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -542,7 +542,7 @@ static int wolfssl_bio_s_fixed_mem_write(WOLFSSL_BIO* bio, const char* data,
         if (bio->wrSz - bio->wrIdx < len) {
             len = bio->wrSz - bio->wrIdx;
         }
-        XMEMCPY(bio->ptr.mem_buf_data + bio->wrIdx, data, len);
+        XMEMCPY(bio->ptr.mem_buf_data + bio->wrIdx, data, (size_t)len);
         bio->wrIdx += len;
     }
 
@@ -558,7 +558,7 @@ static int wolfssl_bio_s_fixed_mem_read(WOLFSSL_BIO* bio, char* data, int len)
         if (bio->wrSz - bio->rdIdx < len) {
             len = bio->wrSz - bio->rdIdx;
         }
-        XMEMCPY(data, bio->ptr.mem_buf_data + bio->rdIdx, len);
+        XMEMCPY(data, bio->ptr.mem_buf_data + bio->rdIdx, (size_t)len);
         bio->rdIdx += len;
     }
 
@@ -2320,7 +2320,7 @@ static int test_wolfSSL_CTX_load_verify_locations(void)
     /* Get cert cache size */
     ExpectIntGT(cacheSz = wolfSSL_CTX_get_cert_cache_memsize(ctx), 0);
 
-    ExpectNotNull(cache = (byte*)XMALLOC(cacheSz, NULL,
+    ExpectNotNull(cache = (byte*)XMALLOC((size_t)cacheSz, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER));
 
     ExpectIntEQ(wolfSSL_CTX_memsave_cert_cache(NULL, NULL, -1, NULL),
@@ -3114,7 +3114,7 @@ static int test_wolfSSL_CertManagerNameConstraint(void)
                 WOLFSSL_FILETYPE_ASN1));
     ExpectNotNull(pt = (byte*)wolfSSL_X509_get_tbs(x509, &derSz));
     if (EXPECT_SUCCESS() && (der != NULL)) {
-        XMEMCPY(der, pt, derSz);
+        XMEMCPY(der, pt, (size_t)derSz);
 
         /* find the name constraint extension and alter it */
         pt = der;

--- a/tests/quic.c
+++ b/tests/quic.c
@@ -606,7 +606,7 @@ static int ctx_send_alert(WOLFSSL *ssl, WOLFSSL_ENCRYPTION_LEVEL level, uint8_t 
     if (ctx->verbose) {
         printf("[%s] send_alert: level=%d, err=%d\n", ctx->name, level, err);
     }
-    ctx->alert_level = level;
+    ctx->alert_level = (int)level;
     ctx->alert = alert;
     return 1;
 }

--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -212,7 +212,7 @@ int wc_CmacUpdate(Cmac* cmac, const byte* in, word32 inSz)
     #endif
     {
         ret = wc_CryptoCb_Cmac(cmac, NULL, 0, in, inSz,
-                NULL, NULL, cmac->type, NULL);
+            NULL, NULL, (int)cmac->type, NULL);
         if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
@@ -294,8 +294,8 @@ int wc_CmacFinalNoFree(Cmac* cmac, byte* out, word32* outSz)
     if (cmac->devId != INVALID_DEVID)
     #endif
     {
-        ret = wc_CryptoCb_Cmac(cmac, NULL, 0, NULL, 0, out, outSz, cmac->type,
-                NULL);
+        ret = wc_CryptoCb_Cmac(cmac, NULL, 0, NULL, 0, out, outSz,
+            (int)cmac->type, NULL);
         if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -7520,7 +7520,7 @@ static int _HMAC_K(byte* K, word32 KSz, byte* V, word32 VSz,
 
     ret = init = wc_HmacInit(&hmac, heap, INVALID_DEVID);
     if (ret == 0)
-        ret = wc_HmacSetKey(&hmac, hashType, K, KSz);
+        ret = wc_HmacSetKey(&hmac, (int)hashType, K, KSz);
 
     if (ret == 0)
         ret = wc_HmacUpdate(&hmac, V, VSz);

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -814,7 +814,7 @@ int wc_SSH_KDF(byte hashId, byte keyId, byte* key, word32 keySz,
         return BAD_FUNC_ARG;
     }
 
-    ret = wc_HmacSizeByType(enmhashId);
+    ret = wc_HmacSizeByType((int)enmhashId);
     if (ret <= 0) {
         return BAD_FUNC_ARG;
     }

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -904,7 +904,7 @@ unsigned long wc_PeekErrorNodeLineData(const char **file, int *line,
  * Get the error value at the HEAD of the ERR queue or 0 if the queue
  * is empty. The HEAD entry is removed by this call.
  */
-unsigned long wc_GetErrorNodeErr(void)
+int wc_GetErrorNodeErr(void)
 {
     int ret;
 
@@ -923,7 +923,7 @@ unsigned long wc_GetErrorNodeErr(void)
             wc_ClearErrorNodes();
         }
     }
-    return (unsigned long)ret;
+    return ret;
 }
 
 #if !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)
@@ -1171,7 +1171,7 @@ int wc_AddErrorNode(int error, int line, char* buf, char* file)
             sz = WOLFSSL_MAX_ERROR_SZ - 1;
         }
         if (sz > 0) {
-            XMEMCPY(err->error, buf, sz);
+            XMEMCPY(err->error, buf, (size_t)sz);
         }
 
         sz = (int)XSTRLEN(file);
@@ -1179,7 +1179,7 @@ int wc_AddErrorNode(int error, int line, char* buf, char* file)
             sz = WOLFSSL_MAX_ERROR_SZ - 1;
         }
         if (sz > 0) {
-            XMEMCPY(err->file, file, sz);
+            XMEMCPY(err->file, file, (size_t)sz);
         }
 
         err->value = error;
@@ -1420,7 +1420,7 @@ unsigned long wc_PeekErrorNodeLineData(const char **file, int *line,
     }
 }
 
-unsigned long wc_GetErrorNodeErr(void)
+int wc_GetErrorNodeErr(void)
 {
     int ret;
 
@@ -1428,7 +1428,7 @@ unsigned long wc_GetErrorNodeErr(void)
 
     if (ERRQ_LOCK() != 0) {
         WOLFSSL_MSG("Lock debug mutex failed");
-        return (unsigned long)(0 - BAD_MUTEX_E);
+        return (0 - BAD_MUTEX_E);
     }
 
     ret = pullErrorNode(NULL, NULL, NULL);
@@ -1595,10 +1595,10 @@ unsigned long wc_PeekErrorNodeLineData(const char **file, int *line,
     return (unsigned long)(0 - NOT_COMPILED_IN);
 }
 
-unsigned long wc_GetErrorNodeErr(void)
+int wc_GetErrorNodeErr(void)
 {
     WOLFSSL_ENTER("wc_GetErrorNodeErr");
-    return (unsigned long)(0 - NOT_COMPILED_IN);
+    return (0 - NOT_COMPILED_IN);
 }
 
 #if !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -857,7 +857,7 @@ static void render_error_message(const char* msg, wc_test_ret_t es)
 #else
         err_sys_printf("%s error L=%d code=%d (%s)\n", msg,
                        WC_TEST_RET_DEC_LN(es), -WC_TEST_RET_DEC_I(es),
-                       wolfSSL_ERR_reason_error_string(-WC_TEST_RET_DEC_I(es))
+                       wolfSSL_ERR_reason_error_string((unsigned long)-WC_TEST_RET_DEC_I(es))
             );
 #endif
         break;
@@ -9466,7 +9466,7 @@ static wc_test_ret_t EVP_test(const WOLFSSL_EVP_CIPHER* type, const byte* key,
         return MEMORY_E;
 #endif
 
-    cipher = (byte*)XMALLOC(plainSz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    cipher = (byte*)XMALLOC((size_t)plainSz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     if (cipher == NULL) {
         ret = WC_TEST_RET_ENC_ERRNO;
         goto EVP_TEST_END;
@@ -9492,7 +9492,7 @@ static wc_test_ret_t EVP_test(const WOLFSSL_EVP_CIPHER* type, const byte* key,
     }
     cipherSz += idx;
 
-    if (XMEMCMP(cipher, expected, plainSz)) {
+    if (XMEMCMP(cipher, expected, (size_t)plainSz)) {
         ret = WC_TEST_RET_ENC_NC;
         goto EVP_TEST_END;
     }
@@ -9526,7 +9526,7 @@ static wc_test_ret_t EVP_test(const WOLFSSL_EVP_CIPHER* type, const byte* key,
     }
     cipherSz += idx;
 
-    if ((expectedSz != cipherSz) || XMEMCMP(plain, cipher, plainSz)) {
+    if ((expectedSz != cipherSz) || XMEMCMP(plain, cipher, (size_t)plainSz)) {
         ret = WC_TEST_RET_ENC_NC;
         goto EVP_TEST_END;
     }
@@ -11471,9 +11471,11 @@ static wc_test_ret_t aes_xts_128_test(void)
 
             for (k = 0; k < j; k += WC_AES_BLOCK_SIZE) {
                 if ((j - k) < WC_AES_BLOCK_SIZE*2)
-                    ret = wc_AesXtsEncryptFinal(aes, large_input + k, large_input + k, j - k, &stream);
+                    ret = wc_AesXtsEncryptFinal(aes, large_input + k,
+                        large_input + k, (word32)(j - k), &stream);
                 else
-                    ret = wc_AesXtsEncryptUpdate(aes, large_input + k, large_input + k, WC_AES_BLOCK_SIZE, &stream);
+                    ret = wc_AesXtsEncryptUpdate(aes, large_input + k,
+                        large_input + k, WC_AES_BLOCK_SIZE, &stream);
         #if defined(WOLFSSL_ASYNC_CRYPT)
                 ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
         #endif
@@ -11533,9 +11535,11 @@ static wc_test_ret_t aes_xts_128_test(void)
 
             for (k = 0; k < j; k += WC_AES_BLOCK_SIZE) {
                 if ((j - k) < WC_AES_BLOCK_SIZE*2)
-                    ret = wc_AesXtsDecryptFinal(aes, large_input + k, large_input + k, j - k, &stream);
+                    ret = wc_AesXtsDecryptFinal(aes, large_input + k,
+                        large_input + k, (word32)(j - k), &stream);
                 else
-                    ret = wc_AesXtsDecryptUpdate(aes, large_input + k, large_input + k, WC_AES_BLOCK_SIZE, &stream);
+                    ret = wc_AesXtsDecryptUpdate(aes, large_input + k,
+                        large_input + k, WC_AES_BLOCK_SIZE, &stream);
             #if defined(WOLFSSL_ASYNC_CRYPT)
                 #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
                 ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev,
@@ -12122,7 +12126,7 @@ static wc_test_ret_t aes_xts_192_test(void)
             ret = wc_AesXtsSetKeyNoInit(aes, k1, sizeof(k1), AES_ENCRYPTION);
             if (ret != 0)
                 ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
-            ret = wc_AesXtsEncrypt(aes, large_input, large_input, j, i1,
+            ret = wc_AesXtsEncrypt(aes, large_input, large_input, (word32)j, i1,
                 sizeof(i1));
         #if defined(WOLFSSL_ASYNC_CRYPT)
             ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
@@ -12133,7 +12137,7 @@ static wc_test_ret_t aes_xts_192_test(void)
             ret = wc_AesXtsSetKeyNoInit(aes, k1, sizeof(k1), AES_DECRYPTION);
             if (ret != 0)
                 ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
-            ret = wc_AesXtsDecrypt(aes, large_input, large_input, j, i1,
+            ret = wc_AesXtsDecrypt(aes, large_input, large_input, (word32)j, i1,
                 sizeof(i1));
         #if defined(WOLFSSL_ASYNC_CRYPT)
             #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
@@ -12171,9 +12175,11 @@ static wc_test_ret_t aes_xts_192_test(void)
 
             for (k = 0; k < j; k += WC_AES_BLOCK_SIZE) {
                 if ((j - k) < WC_AES_BLOCK_SIZE*2)
-                    ret = wc_AesXtsEncryptFinal(aes, large_input + k, large_input + k, j - k, &stream);
+                    ret = wc_AesXtsEncryptFinal(aes, large_input + k,
+                        large_input + k, (word32)(j - k), &stream);
                 else
-                    ret = wc_AesXtsEncryptUpdate(aes, large_input + k, large_input + k, WC_AES_BLOCK_SIZE, &stream);
+                    ret = wc_AesXtsEncryptUpdate(aes, large_input + k,
+                        large_input + k, WC_AES_BLOCK_SIZE, &stream);
         #if defined(WOLFSSL_ASYNC_CRYPT)
                 ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
         #endif
@@ -12233,9 +12239,11 @@ static wc_test_ret_t aes_xts_192_test(void)
 
             for (k = 0; k < j; k += WC_AES_BLOCK_SIZE) {
                 if ((j - k) < WC_AES_BLOCK_SIZE*2)
-                    ret = wc_AesXtsDecryptFinal(aes, large_input + k, large_input + k, j - k, &stream);
+                    ret = wc_AesXtsDecryptFinal(aes, large_input + k,
+                        large_input + k, (word32)(j - k), &stream);
                 else
-                    ret = wc_AesXtsDecryptUpdate(aes, large_input + k, large_input + k, WC_AES_BLOCK_SIZE, &stream);
+                    ret = wc_AesXtsDecryptUpdate(aes, large_input + k,
+                        large_input + k, WC_AES_BLOCK_SIZE, &stream);
             #if defined(WOLFSSL_ASYNC_CRYPT)
                 #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
                 ret = wc_AsyncWait(ret, &aes->aes_decrypt.asyncDev,
@@ -12578,7 +12586,7 @@ static wc_test_ret_t aes_xts_256_test(void)
             ret = wc_AesXtsSetKeyNoInit(aes, k1, sizeof(k1), AES_ENCRYPTION);
             if (ret != 0)
                 ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
-            ret = wc_AesXtsEncrypt(aes, large_input, large_input, j, i1,
+            ret = wc_AesXtsEncrypt(aes, large_input, large_input, (word32)j, i1,
                 sizeof(i1));
         #if defined(WOLFSSL_ASYNC_CRYPT)
             ret = wc_AsyncWait(ret, &aes->aes.asyncDev, WC_ASYNC_FLAG_NONE);
@@ -12589,7 +12597,7 @@ static wc_test_ret_t aes_xts_256_test(void)
             ret = wc_AesXtsSetKeyNoInit(aes, k1, sizeof(k1), AES_DECRYPTION);
             if (ret != 0)
                 ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
-            ret = wc_AesXtsDecrypt(aes, large_input, large_input, j, i1,
+            ret = wc_AesXtsDecrypt(aes, large_input, large_input, (word32)j, i1,
                 sizeof(i1));
         #if defined(WOLFSSL_ASYNC_CRYPT)
             #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS

--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -135,7 +135,7 @@ WOLFSSL_API void wolfSSL_SetLoggingPrefix(const char* prefix);
     WOLFSSL_LOCAL unsigned long wc_PeekErrorNodeLineData(
             const char **file, int *line, const char **data, int *flags,
             int (*ignore_err)(int err));
-    WOLFSSL_LOCAL unsigned long wc_GetErrorNodeErr(void);
+    WOLFSSL_LOCAL int wc_GetErrorNodeErr(void);
     #if !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)
         WOLFSSL_API void wc_ERR_print_errors_fp(XFILE fp);
         WOLFSSL_API void wc_ERR_print_errors_cb(int (*cb)(const char *str,


### PR DESCRIPTION
These ones were linux specific (x86_64 on Void Linux).
Most of them were automated using a shell script that I wrote locally, that uses a vim interactive shell.
Working on the next block of files.

Testing: "gcc (GCC) 13.2.0"

```
$ ./configure --enable-all CC=gcc 'CFLAGS=-Werror -Wno-pragmas -Wall -Wextra -Wunknown-pragmas --param=ssp-buffer-size=1 -Waddress -Warray-bounds -Wbad-function-cast -Wchar-subscripts -Wcomment -Wfloat-equal -Wformat-security -Wformat=2 -Wmaybe-uninitialized -Wmissing-field-initializers -Wmissing-noreturn -Wmissing-prototypes -Wnested-externs -Wnormalized=id -Woverride-init -Wpointer-arith -Wpointer-sign -Wshadow -Wsign-compare -Wstrict-overflow=1 -Wstrict-prototypes -Wswitch-enum -Wundef -Wunused -Wunused-result -Wunused-variable -Wwrite-strings -fwrapv -Wsign-conversion -fmax-errors=1'
$ make
```