### PR TITLE
Fix for setting wrong version in CSRs.

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -7070,7 +7070,7 @@ int wolfSSL_X509_REQ_print(WOLFSSL_BIO* bio, WOLFSSL_X509* x509)
     /* print version of cert.  Note that we increment by 1 because for REQs,
      * the value stored in x509->version is the actual value of the field; not
      * the version. */
-    if (X509PrintVersion(bio, wolfSSL_X509_REQ_get_version(x509) + 1, 8)
+    if (X509PrintVersion(bio, wolfSSL_X509_REQ_get_version(x509) + (long)1, 8)
             != WOLFSSL_SUCCESS) {
         return WOLFSSL_FAILURE;
     }

--- a/src/x509.c
+++ b/src/x509.c
@@ -7067,8 +7067,10 @@ int wolfSSL_X509_REQ_print(WOLFSSL_BIO* bio, WOLFSSL_X509* x509)
             return WOLFSSL_FAILURE;
     }
 
-    /* print version of cert */
-    if (X509PrintVersion(bio, wolfSSL_X509_version(x509), 8)
+    /* print version of cert.  Note that we increment by 1 because for REQs,
+     * the value stored in x509->version is the actual value of the field; not
+     * the version. */
+    if (X509PrintVersion(bio, wolfSSL_X509_REQ_get_version(x509) + 1, 8)
             != WOLFSSL_SUCCESS) {
         return WOLFSSL_FAILURE;
     }
@@ -14838,6 +14840,23 @@ WOLFSSL_X509* wolfSSL_X509_REQ_new(void)
 void wolfSSL_X509_REQ_free(WOLFSSL_X509* req)
 {
     wolfSSL_X509_free(req);
+}
+
+int wolfSSL_X509_REQ_set_version(WOLFSSL_X509 *x, long version) {
+    WOLFSSL_ENTER("wolfSSL_X509_REQ_set_version");
+    if ((x == NULL) || (version < 0) || (version >= INT_MAX)) {
+        return WOLFSSL_FAILURE;
+    }
+    x->version = (int)version;
+    return WOLFSSL_SUCCESS;
+}
+
+long wolfSSL_X509_REQ_get_version(const WOLFSSL_X509 *req) {
+    WOLFSSL_ENTER("wolfSSL_X509_REQ_get_version");
+    if (req == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+    return (long)req->version;
 }
 
 int wolfSSL_X509_REQ_sign(WOLFSSL_X509 *req, WOLFSSL_EVP_PKEY *pkey,

--- a/src/x509.c
+++ b/src/x509.c
@@ -14842,7 +14842,8 @@ void wolfSSL_X509_REQ_free(WOLFSSL_X509* req)
     wolfSSL_X509_free(req);
 }
 
-int wolfSSL_X509_REQ_set_version(WOLFSSL_X509 *x, long version) {
+int wolfSSL_X509_REQ_set_version(WOLFSSL_X509 *x, long version)
+{
     WOLFSSL_ENTER("wolfSSL_X509_REQ_set_version");
     if ((x == NULL) || (version < 0) || (version >= INT_MAX)) {
         return WOLFSSL_FAILURE;
@@ -14851,10 +14852,11 @@ int wolfSSL_X509_REQ_set_version(WOLFSSL_X509 *x, long version) {
     return WOLFSSL_SUCCESS;
 }
 
-long wolfSSL_X509_REQ_get_version(const WOLFSSL_X509 *req) {
+long wolfSSL_X509_REQ_get_version(const WOLFSSL_X509 *req)
+{
     WOLFSSL_ENTER("wolfSSL_X509_REQ_get_version");
     if (req == NULL) {
-        return WOLFSSL_FAILURE;
+        return 0; /* invalid arg */
     }
     return (long)req->version;
 }

--- a/src/x509.c
+++ b/src/x509.c
@@ -7070,7 +7070,7 @@ int wolfSSL_X509_REQ_print(WOLFSSL_BIO* bio, WOLFSSL_X509* x509)
     /* print version of cert.  Note that we increment by 1 because for REQs,
      * the value stored in x509->version is the actual value of the field; not
      * the version. */
-    if (X509PrintVersion(bio, wolfSSL_X509_REQ_get_version(x509) + (long)1, 8)
+    if (X509PrintVersion(bio, (int)wolfSSL_X509_REQ_get_version(x509) + 1, 8)
             != WOLFSSL_SUCCESS) {
         return WOLFSSL_FAILURE;
     }

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -509,7 +509,8 @@ typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS;
 #define X509_set1_notBefore             wolfSSL_X509_set1_notBefore
 #define X509_set_serialNumber           wolfSSL_X509_set_serialNumber
 #define X509_set_version                wolfSSL_X509_set_version
-#define X509_REQ_set_version            wolfSSL_X509_set_version
+#define X509_REQ_set_version            wolfSSL_X509_REQ_set_version
+#define X509_REQ_get_version            wolfSSL_X509_REQ_get_version
 #define X509_sign                       wolfSSL_X509_sign
 #define X509_sign_ctx                   wolfSSL_X509_sign_ctx
 #define X509_print                      wolfSSL_X509_print

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -4815,6 +4815,8 @@ WOLFSSL_API int wolfSSL_PEM_write_bio_X509(WOLFSSL_BIO *bp, WOLFSSL_X509 *x);
 WOLFSSL_API int wolfSSL_i2d_X509_REQ(WOLFSSL_X509* req, unsigned char** out);
 WOLFSSL_API WOLFSSL_X509* wolfSSL_X509_REQ_new(void);
 WOLFSSL_API void wolfSSL_X509_REQ_free(WOLFSSL_X509* req);
+WOLFSSL_API long wolfSSL_X509_REQ_get_version(const WOLFSSL_X509 *req);
+WOLFSSL_API int wolfSSL_X509_REQ_set_version(WOLFSSL_X509 *x, long version);
 WOLFSSL_API int wolfSSL_X509_REQ_sign(WOLFSSL_X509 *req, WOLFSSL_EVP_PKEY *pkey,
                                       const WOLFSSL_EVP_MD *md);
 WOLFSSL_API int wolfSSL_X509_REQ_sign_ctx(WOLFSSL_X509 *req,


### PR DESCRIPTION
Fixes ZD 18873

# Testing
```
$ cd wolfssl
$ ./configure --enable-wolfclu
$ make all check
$ sudo make install
$cd ../wolfCLU
$ ./configure (all tried with CFLAG=-DNO_WOLFSSL_REQ_PRINT) 
$ make all
$ ./wolfssl -genkey rsa -size 2048 -out temp.key -outform pem  -output KEYPAIR
$ ./wolfssl req -new -days 1095 -config csr.conf -key temp.key.priv -out service.csr  -outform PEM -sha256
$ openssl req -in service.csr -text
        Version: 1 (0x0)
$ ./wolfssl req -in service.csr  -noout -text
        Version: 1 (0x0)
```


