### PR TITLE
wolfCLU added support for PKCS7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9093,6 +9093,12 @@ then
         ENABLED_DES3="yes"
     fi
 
+    # Has support for PKCS7
+    if test "$ENABLED_PKCS7" = "no"
+    then
+        ENABLED_PKCS7=yes
+    fi
+
     # Uses alt name
     ENABLED_ALTNAMES="yes"
 


### PR DESCRIPTION
https://github.com/wolfSSL/wolfCLU/pull/152

Add PKCS7 by default with easy wolfCLU config now that it is supported.