### PR TITLE
20241031-fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,9 @@ AC_PREREQ([2.69])
 AC_INIT([wolfssl],[5.7.4],[https://github.com/wolfssl/wolfssl/issues],[wolfssl],[https://www.wolfssl.com])
 AC_CONFIG_AUX_DIR([build-aux])
 
+# Inhibit unwanted regeneration of autotools artifacts by Makefile.
+AM_MAINTAINER_MODE([disable])
+
 # The following sets CFLAGS to empty if unset on command line.  We do not
 # want the default "-g -O2" that AC_PROG_CC sets automatically.
 : ${CFLAGS=""}
@@ -8902,6 +8905,8 @@ AC_ARG_ENABLE([dual-alg-certs],
 
 AS_IF([ test "$ENABLED_DUAL_ALG_CERTS" != "no" && test "$ENABLED_EXPERIMENTAL" != "yes" ],[ AC_MSG_ERROR([dual-alg-certs requires --enable-experimental.]) ])
 
+AS_IF([ test "$ENABLED_DUAL_ALG_CERTS" != "no" && test "$ENABLED_CRYPTONLY" = "yes" ],[ AC_MSG_ERROR([dual-alg-certs is incompatible with --enable-cryptonly.]) ])
+
 # Adds functionality to support Raw Public Key (RPK) RFC7250
 AC_ARG_ENABLE([rpk],
     [AS_HELP_STRING([--enable-rpk],[Enable support for Raw Public Key (RPK) RFC7250 (default: disabled)])],
@@ -9725,9 +9730,6 @@ if test "x$ENABLED_LINUXKM" = "xyes"; then
     AC_SUBST([ASFLAGS_FPUSIMD_DISABLE])
     AC_SUBST([ASFLAGS_FPUSIMD_ENABLE])
 
-    if test "$ENABLED_OPENSSLEXTRA" != "no" && test "$ENABLED_CRYPTONLY" = "no"; then
-        AC_MSG_ERROR([--enable-opensslextra without --enable-cryptonly is incompatible with --enable-linuxkm.])
-    fi
     if test "$ENABLED_FILESYSTEM" = "yes"; then
         AC_MSG_ERROR([--enable-filesystem is incompatible with --enable-linuxkm.])
     fi

--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -918,6 +918,13 @@
 
     #include <linux/limits.h>
 
+    #ifndef INT32_MAX
+        #define INT32_MAX INT_MAX
+    #endif
+    #ifndef UINT32_MAX
+        #define UINT32_MAX UINT_MAX
+    #endif
+
     /* Linux headers define these using C expressions, but we need
      * them to be evaluable by the preprocessor, for use in sp_int.h.
      */

--- a/linuxkm/module_exports.c.template
+++ b/linuxkm/module_exports.c.template
@@ -215,3 +215,6 @@
 #include <wolfssl/openssl/pem.h>
 #endif
 
+#if defined(OPENSSL_EXTRA) && !defined(WC_NO_RNG) && defined(HAVE_HASHDRBG)
+#include <wolfssl/openssl/fips_rand.h>
+#endif

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3491,6 +3491,7 @@ extern void uITRON4_free(void *p) ;
     #undef HAVE_STRINGS_H
     #undef HAVE_ERRNO_H
     #undef HAVE_THREAD_LS
+    #undef HAVE_ATEXIT
     #undef WOLFSSL_HAVE_MIN
     #undef WOLFSSL_HAVE_MAX
     #define SIZEOF_LONG         8

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1123,7 +1123,7 @@ typedef struct w64wrapper {
         DYNAMIC_TYPE_SNIFFER_KEY          = 1006,
         DYNAMIC_TYPE_SNIFFER_KEYLOG_NODE  = 1007,
         DYNAMIC_TYPE_SNIFFER_CHAIN_BUFFER = 1008,
-        DYNAMIC_TYPE_AES_EAX = 1009,
+        DYNAMIC_TYPE_AES_EAX = 1009
     };
 
     /* max error buffer string size */


### PR DESCRIPTION
`configure.ac`: add `AM_MAINTAINER_MODE([disable])`;

add config-time assert for "dual-alg-certs is incompatible with --enable-cryptonly.";

remove obsolete config-time check for "--enable-opensslextra without --enable-cryptonly is incompatible with --enable-linuxkm.";

`linuxkm/linuxkm_wc_port.h`: add fallback definitions for `INT32_MAX` and `UINT32_MAX`;

`linuxkm/module_exports.c.template`: add `wolfssl/openssl/fips_rand.h`;

`wolfssl/wolfcrypt/settings.h`: add `#undef HAVE_ATEXIT` to `WOLFSSL_LINUXKM` settings;

`wolfssl/wolfcrypt/types.h`: fix trailing comma in the `DYNAMIC_TYPE_*` `enum`.

`src/pk.c`: in `pem_read_bio_key()`, fix invalid read (ZD#18875).

tested with `wolfssl-multi-test.sh ... allcryptonly-gcc-c89 defaults-cryptonly-Wconversion-noasm-fips-140-3-dev-m32-build defaults-cryptonly-Wconversion-noasm-fips-140-3-v6-m32-build super-quick-check`
