### PR TITLE
20241102-fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9757,6 +9757,9 @@ if test "x$ENABLED_LINUXKM" = "xyes"; then
     AC_SUBST([ASFLAGS_FPUSIMD_DISABLE])
     AC_SUBST([ASFLAGS_FPUSIMD_ENABLE])
 
+    if test "$ENABLED_OPENSSLEXTRA" != "no" && test "$ENABLED_LINUXKM_PIE" = "yes" && test "$ENABLED_CRYPTONLY" = "no"; then
+        AC_MSG_ERROR([--enable-opensslextra with --enable-linuxkm-pie and without --enable-cryptonly is incompatible with --enable-linuxkm.])
+    fi
     if test "$ENABLED_FILESYSTEM" = "yes"; then
         AC_MSG_ERROR([--enable-filesystem is incompatible with --enable-linuxkm.])
     fi

--- a/src/internal.c
+++ b/src/internal.c
@@ -33808,7 +33808,7 @@ int SendCertificateVerify(WOLFSSL* ssl)
                 return 0;  /* sent blank cert, can't verify */
             }
 
-            args->sendSz = MAX_CERT_VERIFY_SZ + MAX_MSG_EXTRA;
+            args->sendSz = WC_MAX_CERT_VERIFY_SZ + MAX_MSG_EXTRA;
             if (IsEncryptionOn(ssl, 1)) {
                 args->sendSz += MAX_MSG_EXTRA;
             }

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -9000,7 +9000,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                 return 0;  /* sent blank cert, can't verify */
             }
 
-            args->sendSz = MAX_CERT_VERIFY_SZ + MAX_MSG_EXTRA;
+            args->sendSz = WC_MAX_CERT_VERIFY_SZ + MAX_MSG_EXTRA;
             /* Always encrypted.  */
             args->sendSz += MAX_MSG_EXTRA;
 
@@ -9657,7 +9657,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
             if (ssl->options.dtls) {
                 ssl->options.buildingMsg = 0;
                 ret = Dtls13HandshakeSend(ssl, args->output,
-                    MAX_CERT_VERIFY_SZ + MAX_MSG_EXTRA + MAX_MSG_EXTRA,
+                    WC_MAX_CERT_VERIFY_SZ + MAX_MSG_EXTRA + MAX_MSG_EXTRA,
                     (word16)args->sendSz, certificate_verify, 1);
                 if (ret != 0)
                     goto exit_scv;
@@ -9668,7 +9668,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
 
             /* This message is always encrypted. */
             ret = BuildTls13Message(ssl, args->output,
-                                    MAX_CERT_VERIFY_SZ + MAX_MSG_EXTRA,
+                                    WC_MAX_CERT_VERIFY_SZ + MAX_MSG_EXTRA,
                                     args->output + RECORD_HEADER_SZ,
                                     args->sendSz - RECORD_HEADER_SZ, handshake,
                                     1, 0, 0);

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -6412,7 +6412,7 @@ enum {
     RSAPSSPARAMSASN_IDX_SALTLEN,
     RSAPSSPARAMSASN_IDX_SALTLENINT,
     RSAPSSPARAMSASN_IDX_TRAILER,
-    RSAPSSPARAMSASN_IDX_TRAILERINT,
+    RSAPSSPARAMSASN_IDX_TRAILERINT
 };
 
 /* Number of items in ASN.1 template for an algorithm identifier. */
@@ -24158,16 +24158,16 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm, Signer 
                 if ((ret == 0) && cert->extAltSigAlgSet &&
                     cert->extAltSigValSet) {
                 #ifndef WOLFSSL_SMALL_STACK
-                    byte der[MAX_CERT_VERIFY_SZ];
+                    byte der[WC_MAX_CERT_VERIFY_SZ];
                 #else
-                    byte *der = (byte*)XMALLOC(MAX_CERT_VERIFY_SZ, cert->heap,
+                    byte *der = (byte*)XMALLOC(WC_MAX_CERT_VERIFY_SZ, cert->heap,
                                             DYNAMIC_TYPE_DCERT);
                     if (der == NULL) {
                         ret = MEMORY_E;
                     } else
                 #endif /* ! WOLFSSL_SMALL_STACK */
                     {
-                        ret = wc_GeneratePreTBS(cert, der, MAX_CERT_VERIFY_SZ);
+                        ret = wc_GeneratePreTBS(cert, der, WC_MAX_CERT_VERIFY_SZ);
 
                         if (ret > 0) {
                             ret = ConfirmSignature(&cert->sigCtx, der, ret,
@@ -24231,16 +24231,16 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm, Signer 
             if ((ret == 0) && cert->extAltSigAlgSet &&
                 cert->extAltSigValSet) {
             #ifndef WOLFSSL_SMALL_STACK
-                byte der[MAX_CERT_VERIFY_SZ];
+                byte der[WC_MAX_CERT_VERIFY_SZ];
             #else
-                byte *der = (byte*)XMALLOC(MAX_CERT_VERIFY_SZ, cert->heap,
+                byte *der = (byte*)XMALLOC(WC_MAX_CERT_VERIFY_SZ, cert->heap,
                                         DYNAMIC_TYPE_DCERT);
                 if (der == NULL) {
                     ret = MEMORY_E;
                 } else
             #endif /* ! WOLFSSL_SMALL_STACK */
                 {
-                    ret = wc_GeneratePreTBS(cert, der, MAX_CERT_VERIFY_SZ);
+                    ret = wc_GeneratePreTBS(cert, der, WC_MAX_CERT_VERIFY_SZ);
 
                     if (ret > 0) {
                         ret = ConfirmSignature(&cert->sigCtx, der, ret,

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_util.c
@@ -1702,7 +1702,7 @@ WOLFSSL_LOCAL int tsip_Tls13SendCertVerify(WOLFSSL* ssl)
     }
 
     if (ret == 0) {
-        recordSz = MAX_CERT_VERIFY_SZ + MAX_MSG_EXTRA * 2;
+        recordSz = WC_MAX_CERT_VERIFY_SZ + MAX_MSG_EXTRA * 2;
         /* check for available size */
         ret = CheckAvailableSize(ssl, recordSz);
         recordSz = 0;

--- a/wolfcrypt/src/port/arm/armv8-aes.c
+++ b/wolfcrypt/src/port/arm/armv8-aes.c
@@ -16972,9 +16972,11 @@ int wc_AesCcmEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
     word32 wordSz = (word32)sizeof(word32);
 
     /* sanity check on arguments */
-    if (aes == NULL || out == NULL || in == NULL || nonce == NULL
-            || authTag == NULL || nonceSz < 7 || nonceSz > 13)
+    if (aes == NULL || out == NULL || ((inSz > 0) && (in == NULL)) ||
+        nonce == NULL || authTag == NULL || nonceSz < 7 || nonceSz > 13)
+    {
         return BAD_FUNC_ARG;
+    }
 
     if (wc_AesCcmCheckTagSize(authTagSz) != 0) {
         return BAD_FUNC_ARG;
@@ -17044,9 +17046,11 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
     word32 wordSz = (word32)sizeof(word32);
 
     /* sanity check on arguments */
-    if (aes == NULL || out == NULL || in == NULL || nonce == NULL
-            || authTag == NULL || nonceSz < 7 || nonceSz > 13)
+    if (aes == NULL || out == NULL || ((inSz > 0) && (in == NULL)) ||
+        nonce == NULL || authTag == NULL || nonceSz < 7 || nonceSz > 13)
+    {
         return BAD_FUNC_ARG;
+    }
 
     if (wc_AesCcmCheckTagSize(authTagSz) != 0) {
         return BAD_FUNC_ARG;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1338,24 +1338,6 @@ enum {
     #define MAX_EARLY_DATA_SZ  4096
 #endif
 
-#ifndef NO_RSA
-    #ifndef WOLFSSL_MAX_RSA_BITS
-        #ifdef USE_FAST_MATH
-            /* FP implementation support numbers up to FP_MAX_BITS / 2 bits. */
-            #define WOLFSSL_MAX_RSA_BITS    (FP_MAX_BITS / 2)
-        #elif defined(WOLFSSL_SP_MATH_ALL) || defined(WOLFSSL_SP_MATH)
-            /* SP implementation supports numbers of SP_INT_BITS bits. */
-            #define WOLFSSL_MAX_RSA_BITS    (((SP_INT_BITS + 7) / 8) * 8)
-        #else
-            /* Integer maths is dynamic but we only go up to 4096 bits. */
-            #define WOLFSSL_MAX_RSA_BITS 4096
-        #endif
-    #endif
-    #if (WOLFSSL_MAX_RSA_BITS % 8)
-        #error RSA maximum bit size must be multiple of 8
-    #endif
-#endif
-
 
 #if !defined(NO_RSA) || !defined(NO_DH) || defined(HAVE_ECC)
     /* MySQL wants to be able to use 8192-bit numbers. */
@@ -1383,9 +1365,9 @@ enum {
             #error "MySQL needs FP_MAX_BITS at least at 16384"
         #endif
 
-        #if !defined(NO_RSA) && defined(WOLFSSL_MAX_RSA_BITS) && \
-            WOLFSSL_MAX_RSA_BITS > ENCRYPT_BASE_BITS
-            #error "FP_MAX_BITS too small for WOLFSSL_MAX_RSA_BITS"
+        #if !defined(NO_RSA) && defined(WC_MAX_RSA_BITS) && \
+            WC_MAX_RSA_BITS > ENCRYPT_BASE_BITS
+            #error "FP_MAX_BITS too small for WC_MAX_RSA_BITS"
         #endif
     #elif defined(WOLFSSL_SP_MATH_ALL) || defined(WOLFSSL_SP_MATH)
         /* Use the SP size up to 8192-bit and down to a min of 1024-bit. */
@@ -1411,9 +1393,9 @@ enum {
             #error "MySQL needs SP_INT_BITS at least at 8192"
         #endif
 
-        #if !defined(NO_RSA) && defined(WOLFSSL_MAX_RSA_BITS) && \
-            WOLFSSL_MAX_RSA_BITS > SP_INT_BITS
-            #error "SP_INT_BITS too small for WOLFSSL_MAX_RSA_BITS"
+        #if !defined(NO_RSA) && defined(WC_MAX_RSA_BITS) && \
+            WC_MAX_RSA_BITS > SP_INT_BITS
+            #error "SP_INT_BITS too small for WC_MAX_RSA_BITS"
         #endif
     #else
         /* Integer/heap maths - support 4096-bit. */
@@ -1836,21 +1818,6 @@ enum Misc {
     MIN_RSA_SHA512_PSS_BITS = 512 * 2 + 8 * 8, /* Min key size */
     MIN_RSA_SHA384_PSS_BITS = 384 * 2 + 8 * 8, /* Min key size */
 
-#if defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
-    MAX_CERT_VERIFY_SZ = 6000,            /* For Dilithium */
-#elif defined(WOLFSSL_CERT_EXT)
-    MAX_CERT_VERIFY_SZ = 2048,            /* For larger extensions */
-#elif !defined(NO_RSA) && defined(WOLFSSL_MAX_RSA_BITS)
-    MAX_CERT_VERIFY_SZ = WOLFSSL_MAX_RSA_BITS / 8, /* max RSA bytes */
-#elif defined(HAVE_ECC)
-    MAX_CERT_VERIFY_SZ = ECC_MAX_SIG_SIZE, /* max ECC  */
-#elif defined(HAVE_ED448)
-    MAX_CERT_VERIFY_SZ = ED448_SIG_SIZE,   /* max Ed448  */
-#elif defined(HAVE_ED25519)
-    MAX_CERT_VERIFY_SZ = ED25519_SIG_SIZE, /* max Ed25519  */
-#else
-    MAX_CERT_VERIFY_SZ = 1024, /* max default  */
-#endif
     CLIENT_HELLO_FIRST =  35,  /* Protocol + RAN_LEN + sizeof(id_len) */
     MAX_SUITE_NAME     =  48,  /* maximum length of cipher suite string */
 


### PR DESCRIPTION
rename `MAX_CERT_VERIFY_SZ` to `WC_MAX_CERT_VERIFY_SZ`, and move its setup from `wolfssl/internal.h` to `wolfssl/wolfcrypt/asn.h`.

rename `WOLFSSL_MAX_RSA_BITS` to `WC_MAX_RSA_BITS`, and move its setup from `wolfssl/internal.h` to `wolfssl/wolfcrypt/asn.h`, preceding setup for `WC_MAX_CERT_VERIFY_SZ`.

`configure.ac`: restore opensslextra-linuxkm assertion, with a twist: "--enable-opensslextra with --enable-linuxkm-pie and without --enable-cryptonly is incompatible with --enable-linuxkm."

`wolfcrypt/src/asn.c`: fix trailing comma in `enum`.

`wolfcrypt/src/port/arm/armv8-aes.c`: fix `wc_AesCcmEncrypt()` and `wc_AesCcmDecrypt()` for `test_wolfssl_EVP_aes_ccm_zeroLen()`.

tested with `wolfssl-multi-test.sh ... super-quick-check allcryptonly-gcc-c89 fips-140-2-optest fips-140-2-openssl-all quantum-safe-wolfssl-all-cross-armv7a-armasm-unittest quantum-safe-wolfssl-all-cross-armv7a-armasm-unittest-Os quantum-safe-wolfssl-all-cross-armv7a-armasm-unittest-Os-smallstack`
