### PR TITLE
20241104-fixes

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -27,4 +27,4 @@ jobs:
           # The exclude_file contains lines of code that should be ignored. This is useful for individual lines which have non-words that can safely be ignored.
         exclude_file: '.codespellexcludelines'
           # To skip files entirely from being processed, add it to the following list:
-        skip: '*.cproject,*.der,*.mtpj,*.pem,*.vcxproj,.git,*.launch,*.scfg,./IDE/Renesas/cs+/Projects/t4_demo/README_jp.txt'
+        skip: '*.cproject,*.der,*.mtpj,*.pem,*.vcxproj,.git,*.launch,*.scfg,*/README_jp.txt'

--- a/configure.ac
+++ b/configure.ac
@@ -7388,7 +7388,7 @@ then
         ENABLED_WOLFSSH="yes"
     fi
 
-    if test "x$ENABLED_OPENSSLEXTRA" = "xno" && test "x$ENABLED_OPENSSLCOEXIST" = "xno"
+    if test "x$ENABLED_OPENSSLEXTRA" = "xno"
     then
         ENABLED_OPENSSLEXTRA="yes"
     fi

--- a/tests/api.c
+++ b/tests/api.c
@@ -71021,10 +71021,10 @@ static int test_wolfSSL_SESSION(void)
         char buf[64] = {0};
         word32 bufSz = (word32)sizeof(buf);
 
-        ExpectIntEQ(SSL_SUCCESS,
+        ExpectIntEQ(WOLFSSL_SUCCESS,
             wolfSSL_set_SessionTicket(ssl, (byte *)ticket,
                 (word32)XSTRLEN(ticket)));
-        ExpectIntEQ(SSL_SUCCESS,
+        ExpectIntEQ(WOLFSSL_SUCCESS,
             wolfSSL_get_SessionTicket(ssl, (byte *)buf, &bufSz));
         ExpectStrEQ(ticket, buf);
     }

--- a/wolfcrypt/src/ASN_TEMPLATE.md
+++ b/wolfcrypt/src/ASN_TEMPLATE.md
@@ -18,7 +18,7 @@ static const ASNItem <template>[] = {
 /*  <ITEM_0> */ { <depth>, <ASN Type>, <constructed>, <header>, <optional> },
 ...
 };
-/* Named indeces for <template>. */
+/* Named indices for <template>. */
 enum {
     <TEMPLATE>_<ITEM_0> = 0,
     <TEMPLATE>_<ITEM_1>,


### PR DESCRIPTION
`configure.ac`: activate opensslextra for `--enable-curl` even if `ENABLED_OPENSSLCOEXIST`;

`tests/api.c`: in `test_wolfSSL_SESSION()`, use `WOLFSSL_SUCCESS`, not `SSL_SUCCESS`, in `HAVE_SESSION_TICKET` span reachable in non-`OPENSSL_EXTRA` builds;

`codespell` fixes.

tested with `wolfssl-multi-test.sh ... super-quick-check curl-master-with-wolfssl-coexist`
