### PR TITLE
Testing fixes

### DIFF
--- a/src/pk.c
+++ b/src/pk.c
@@ -16526,6 +16526,7 @@ int pkcs8_encode(WOLFSSL_EVP_PKEY* pkey, byte* key, word32* keySz)
         curveOid = NULL;
         oidSz = 0;
     }
+#ifndef NO_DH
     else if (pkey->type == WC_EVP_PKEY_DH) {
         if (pkey->dh == NULL)
             return BAD_FUNC_ARG;
@@ -16548,6 +16549,7 @@ int pkcs8_encode(WOLFSSL_EVP_PKEY* pkey, byte* key, word32* keySz)
         curveOid = NULL;
         oidSz = 0;
     }
+#endif
     else {
         ret = NOT_COMPILED_IN;
     }

--- a/tests/quic.c
+++ b/tests/quic.c
@@ -19,11 +19,13 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
 #ifdef HAVE_CONFIG_H
     #include <config.h>
 #endif
 
+#ifndef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/options.h>
+#endif
 #include <wolfssl/wolfcrypt/settings.h>
 
 #include <tests/unit.h>

--- a/tests/unit.h
+++ b/tests/unit.h
@@ -27,11 +27,10 @@
     #include <config.h>
 #endif
 
-#include <wolfssl/wolfcrypt/settings.h>
-
 #ifndef WOLFSSL_USER_SETTINGS
     #include <wolfssl/options.h>
 #endif
+#include <wolfssl/wolfcrypt/settings.h>
 
 #undef TEST_OPENSSL_COEXIST /* can't use this option with unit tests */
 #undef OPENSSL_COEXIST /* can't use this option with unit tests */


### PR DESCRIPTION
# Description

Fix header inclusion: settings.h after options.h.
pkcs8_encode(): dh is not available if NO_DH is defined.

# Testing

./configure --enable-all CFLAGS=-DNO_ASN_TIME
./configure --enable-opensslall --disable-rsa --disable-dh

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
