### PR TITLE
Ability to bypass './configure' as some tests/scripts run it anyway

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -61436,7 +61436,7 @@ static int test_wolfSSL_X509_NID(void)
 #if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)) && \
     !defined(NO_RSA) && defined(USE_CERT_BUFFERS_2048) && !defined(NO_ASN)
     int   sigType;
-    int   nameSz;
+    int   nameSz = 0;
 
     X509*  cert = NULL;
     EVP_PKEY*  pubKeyTmp = NULL;


### PR DESCRIPTION
Need a way to just get the FIPS repo set up without doing anything else.