### PR TITLE
Fix missing error codes when NO_SOCK and USER_IO are in use

### DIFF
--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -30,6 +30,10 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
+#ifdef HAVE_ERRNO_H
+    #include <errno.h>
+#endif
+
 #ifndef WOLFCRYPT_ONLY
 
 #ifdef _WIN32_WCE


### PR DESCRIPTION
# Description

Functions in `wolfio.c` unconditionally reference SOCKET_* error codes, even if `errno.h` is conditionally included in wolfio.h.

When compiled with at least WOLFSSL_NO_SOCK + WOLFSSO_USER_IO `wolfio.h` decides not to include `errno.h` and therefore SOCKET_* symbols are missing.

Instead of changing "decision tree" in `wolfio.h` and risking breaking it on platforms I couldn't test, use "last resort" include of 'errno.h' in the wolfio.c if configure process detected its presence.

# Testing

Built with WOLFSSL_USER_IO and WOLFSSL_NO_SOCK


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
