### PR TITLE
Detect 'isascii' at configuration stage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,9 @@ check_function_exists("socket" HAVE_SOCKET)
 check_function_exists("strftime" HAVE_STRFTIME)
 check_function_exists("__atomic_fetch_add" HAVE_C___ATOMIC)
 
+include(CheckSymbolExists)
+check_symbol_exists(isascii "ctype.h" HAVE_ISASCII)
+
 include(CheckTypeSize)
 
 check_type_size("__uint128_t" __UINT128_T)

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2504,7 +2504,6 @@ extern void uITRON4_free(void *p) ;
     #define WOLFSSL_DH_CONST
     #define WOLFSSL_HAVE_MAX
     #define NO_WRITEV
-    #define NO_STDLIB_ISASCII
 
     #define USE_FLAT_BENCHMARK_H
     #define USE_FLAT_TEST_H

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -983,7 +983,7 @@ typedef struct w64wrapper {
         #endif
         #if defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
         #define XISALNUM(c)     isalnum((c))
-        #ifdef NO_STDLIB_ISASCII
+        #ifndef HAVE_ISASCII
             #define XISASCII(c) (((c) >= 0 && (c) <= 127) ? 1 : 0)
         #else
             #define XISASCII(c) isascii((c))


### PR DESCRIPTION
# Description

Detect 'isascii' at configuration stage
    
Previously platforms without isascii had to manually
indicate it's absence with `NO_STDLIB_ISASCII` define.
    
It is trivial to detect function availability, so do that.


# Testing

Built on platform with no `isascii` available

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
