### PR TITLE
spelling: tiny cleanup.

### DIFF
--- a/certs/taoCert.txt
+++ b/certs/taoCert.txt
@@ -95,7 +95,7 @@ to use PKCS#5 v2 instead of v1.5 which is default add
 
 -v2 des3       # file Pkcs8Enc2
 
-to use PKCS#12 instead use -v1 witch a 12 algo like
+to use PKCS#12 instead use -v1 which a 12 algo like
 
 -v1 PBE-SHA1-3DES   # file Pkcs8Enc12 , see man pkcs8 for more info
 -v1 PBE-SHA1-RC4-128   # no longer file Pkcs8Enc12, arc4 now off by default

--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -11251,7 +11251,7 @@ int wolfSSL_ALPN_GetPeerProtocol(WOLFSSL* ssl, char **list,
     \return MEMORY_E is the error returned when there is not enough memory.
 
     \param ssl pointer to a SSL object, created with wolfSSL_new().
-    \param mfl indicates witch is the Maximum Fragment Length requested for the
+    \param mfl indicates which is the Maximum Fragment Length requested for the
     session. The available options are: enum { WOLFSSL_MFL_2_9  = 1, 512 bytes
     WOLFSSL_MFL_2_10 = 2, 1024 bytes WOLFSSL_MFL_2_11 = 3, 2048 bytes
     WOLFSSL_MFL_2_12 = 4, 4096 bytes WOLFSSL_MFL_2_13 = 5, 8192


### PR DESCRIPTION
# Description

Use which, not witch. 



# Testing

```
$grep -r " witch" *
certs/taoCert.txt:to use PKCS#12 instead use -v1 witch a 12 algo like
doc/dox_comments/header_files/ssl.h:    \param mfl indicates witch is the Maximum Fragment Length requested for the
```
