### PR TITLE
CMAKE: look for pthreads when importing wolfSSL if required

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,3 +1,9 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+if (@HAVE_PTHREAD@)
+  find_dependency(Threads)
+endif()
+
+
 include ( "${CMAKE_CURRENT_LIST_DIR}/wolfssl-targets.cmake" )


### PR DESCRIPTION
# Description

All required dependencies of a package must also be found in the package configuration file. Consumers of wolfSSL can't know if it was built with or without threads support. This change adds find_package(Threads) lookup in the file used for find_package(wolfssl) if wolfSSL was built with threads support.

# Testing


1. build wolfSSL with threads support
2. consume wolfSSL in the project with `find_package(wolfssl CONFIG REQUIRED)


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
