### PR TITLE
gcc-4.0.x does not have __sync_synchronize() to be used for XFENCE

### DIFF
--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -1331,7 +1331,7 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
         #include <stdatomic.h>
         #define XFENCE() atomic_thread_fence(memory_order_seq_cst)
-    #elif defined(__GNUC__) && (__GNUC__ >= 4) && (__GNUC__ < 5)
+    #elif defined(__GNUC__) && (__GNUC__ == 4) && (__GNUC_MINOR__ > 0)
         #define XFENCE() __sync_synchronize()
     #elif (defined(__GNUC__) && (__GNUC__ >= 5)) || defined (__clang__)
         #define XFENCE() __atomic_thread_fence(__ATOMIC_SEQ_CST)


### PR DESCRIPTION
wc_port.h expects __sync_synchronize() in gcc-4.x, but it was introduced since gcc-4.1.0.

Please find the end of gcc/builtins.def in gcc-4.0 branch and gcc-4.1.0 (sorry, the changeset between gcc-4.0.4 and gcc-4.1.0 is too huge for github.com's comparison feature to display well).

[gcc-4.0.x gcc/builtins.def](https://github.com/gcc-mirror/gcc/blob/releases/gcc-4.0/gcc/builtins.def)
![image](https://github.com/user-attachments/assets/8a8fc2d5-2803-4d91-b004-7d8dff522145)

[gcc-4.1.0 gcc/builtins.def](https://github.com/gcc-mirror/gcc/blob/releases/gcc-4.1.0/gcc/builtins.def)
![image](https://github.com/user-attachments/assets/58b2b781-ead9-4c47-9956-373e2324cde3)


It would be safer to deal gcc-4.0 as gcc-3.x or older one.

# Description

To build wolfSSL by ancient gcc on ancient platform, the C preprocessor-based function availability classification is improved.

# Testing

Building wolfSSL with gcc-4.0.0 (on FreeBSD 5.5) finishes. Without this modification, the built libwolfssl.so would have an unresolvable reference to __sync_synchronize(), and it makes the linking of wolfcrypt/benchmark/benchmark failed as

> src/.libs/libwolfssl.so: undefined reference to `__sync_synchronize'

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
