### PR TITLE
acert: fix holder entityName parsing.

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -15356,7 +15356,9 @@ void wolfSSL_X509_ATTRIBUTE_free(WOLFSSL_X509_ATTRIBUTE* attr)
  * */
 WOLFSSL_X509_ACERT * wolfSSL_X509_ACERT_new_ex(void* heap)
 {
-    WOLFSSL_X509_ACERT* x509;
+    WOLFSSL_X509_ACERT * x509 = NULL;
+
+    WOLFSSL_ENTER("wolfSSL_X509_ACERT_new");
 
     x509 = (WOLFSSL_X509_ACERT*) XMALLOC(sizeof(WOLFSSL_X509_ACERT), heap,
                                          DYNAMIC_TYPE_X509_ACERT);
@@ -15386,6 +15388,8 @@ WOLFSSL_X509_ACERT * wolfSSL_X509_ACERT_new(void)
  * */
 void wolfSSL_X509_ACERT_init(WOLFSSL_X509_ACERT * x509, int dynamic, void* heap)
 {
+    WOLFSSL_ENTER("wolfSSL_X509_ACERT_init");
+
     if (x509 == NULL) {
         WOLFSSL_MSG("error: InitX509Acert: null parameter");
         return;
@@ -15411,6 +15415,8 @@ void wolfSSL_X509_ACERT_free(WOLFSSL_X509_ACERT * x509)
     int    dynamic = 0;
     void * heap = NULL;
 
+    WOLFSSL_ENTER("wolfSSL_X509_ACERT_free");
+
     if (x509 == NULL) {
         WOLFSSL_MSG("error: wolfSSL_X509_ACERT_free: null parameter");
         return;
@@ -15423,6 +15429,11 @@ void wolfSSL_X509_ACERT_free(WOLFSSL_X509_ACERT * x509)
     if (x509->holderIssuerName) {
         FreeAltNames(x509->holderIssuerName, heap);
         x509->holderIssuerName = NULL;
+    }
+
+    if (x509->holderEntityName) {
+        FreeAltNames(x509->holderEntityName, heap);
+        x509->holderEntityName = NULL;
     }
 
     if (x509->AttCertIssuerName) {

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -40615,11 +40615,11 @@ int wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz, const byte* e,
 void InitDecodedAcert(DecodedAcert* acert, const byte* source, word32 inSz,
                       void* heap)
 {
+    WOLFSSL_MSG("InitDecodedAcert");
+
     if (acert == NULL) {
         return;
     }
-
-    WOLFSSL_MSG("InitDecodedAcert");
 
     XMEMSET(acert, 0, sizeof(DecodedAcert));
     acert->heap = heap;
@@ -40638,11 +40638,11 @@ void InitDecodedAcert(DecodedAcert* acert, const byte* source, word32 inSz,
  */
 void FreeDecodedAcert(DecodedAcert * acert)
 {
+    WOLFSSL_MSG("FreeDecodedAcert");
+
     if (acert == NULL) {
         return;
     }
-
-    WOLFSSL_MSG("FreeDecodedAcert");
 
     if (acert->holderIssuerName) {
         FreeAltNames(acert->holderIssuerName, acert->heap);
@@ -40811,6 +40811,7 @@ static int DecodeAcertGeneralName(const byte* input, word32* inOutIdx,
  *
  * @param [in]      input    Buffer holding encoded data.
  * @param [in]      sz       Size of encoded data in bytes.
+ * @param [in]      tag      ASN.1 tag value expected in header.
  * @param [in, out] cert     Decoded certificate object.
  * @param [in, out] entries  Linked list of DNS name entries.
  *
@@ -40822,7 +40823,7 @@ static int DecodeAcertGeneralName(const byte* input, word32* inOutIdx,
  * @return  MEMORY_E when dynamic memory allocation fails.
  */
 static int DecodeAcertGeneralNames(const byte* input, word32 sz,
-                                   DecodedAcert* acert,
+                                   byte tag, DecodedAcert* acert,
                                    DNS_entry** entries)
 {
     word32 idx = 0;
@@ -40830,28 +40831,31 @@ static int DecodeAcertGeneralNames(const byte* input, word32 sz,
     int    ret = 0;
     word32 numNames = 0;
 
-    /* Get SEQUENCE and expect all data to be accounted for. */
-    if (GetASN_Sequence(input, &idx, &length, sz, 1) != 0) {
-        WOLFSSL_MSG("\tBad Sequence");
+    if (GetASNHeader(input, tag, &idx, &length, sz) <= 0) {
+        WOLFSSL_MSG("error: acert general names: bad header");
         return ASN_PARSE_E;
     }
 
     if (length == 0) {
-        /* There is supposed to be a non-empty sequence here. */
-        WOLFSSL_ERROR_VERBOSE(ASN_PARSE_E);
+        WOLFSSL_MSG("error: acert general names: zero length");
         return ASN_PARSE_E;
     }
 
     if ((word32)length + idx != sz) {
+        WOLFSSL_MSG_EX("error: acert general names: got %d, expected %d",
+                       (word32)length + idx, sz);
         return ASN_PARSE_E;
     }
 
     while ((ret == 0) && (idx < sz)) {
         ASNGetData dataASN[altNameASN_Length];
 
+        /* Not sure what a reasonable max would be for attribute certs,
+         * therefore observing WOLFSSL_MAX_ALT_NAMES limit. */
         numNames++;
         if (numNames > WOLFSSL_MAX_ALT_NAMES) {
-            WOLFSSL_MSG("error: acert: too many subject alternative names");
+            WOLFSSL_MSG_EX("error: acert general names: too many names, %d",
+                           numNames);
             ret = ASN_ALT_NAME_E;
             break;
         }
@@ -40907,13 +40911,15 @@ static const ASNItem HolderASN[] =
                      /* Holder root sequence. */
 /* HOLDER_SEQ  */    { 0, ASN_SEQUENCE, 1, 1, 0 },
                          /* Holder Option 0:*/
+                         /* baseCertificateID   [0] IssuerSerial OPTIONAL */
 /* ISSUERSERIAL_SEQ  */  { 1, ASN_CONTEXT_SPECIFIC | 0, 1, 1, 2 },
                              /* issuer         GeneralNames, */
 /* GN_SEQ  */                { 2, ASN_SEQUENCE, 1, 0, 0 },
                              /* serial     CertificateSerialNumber */
 /* SERIAL_INT  */            { 2, ASN_INTEGER, 0, 0, 0 },
-                         /* Holder Option 1:*/
-/* GN_SEQ  */            { 1,  ASN_CONTEXT_SPECIFIC | 1, 1, 0, 2 },
+                         /* Holder Option 1: */
+                         /* entityName          [1] GeneralNames OPTIONAL */
+/* ENTITYNAME_SEQ  */  { 1, ASN_CONTEXT_SPECIFIC | 1, 1, 1, 2 },
 };
 
 enum {
@@ -40921,7 +40927,7 @@ enum {
     HOLDER_IDX_ISSUERSERIAL_SEQ,
     HOLDER_IDX_GN_SEQ,
     HOLDER_IDX_SERIAL_INT,
-    HOLDER_IDX_GN_SEQ_OPT1
+    HOLDER_IDX_GN_SEQ_OPT1,
 };
 
 /* Number of items in ASN template for an X509 Acert. */
@@ -40951,6 +40957,10 @@ static int DecodeHolder(const byte* input, word32 len, DecodedAcert* acert)
     if (input == NULL || len <= 0 || acert == NULL) {
         return BUFFER_E;
     }
+
+    #ifdef WOLFSSL_DEBUG_ASN_TEMPLATE
+    printf("debug: decode holder: holder len: %d\n", len);
+    #endif /* WOLFSSL_DEBUG_ASN_TEMPLATE */
 
     CALLOC_ASNGETDATA(dataASN, HolderASN_Length, ret, acert->heap);
 
@@ -40985,20 +40995,42 @@ static int DecodeHolder(const byte* input, word32 len, DecodedAcert* acert)
          * Use the HOLDER_IDX_GN_SEQ offset for input. */
         const byte * gn_input = NULL;
         word32       gn_len = 0;
-        word32       holder_index = HOLDER_IDX_GN_SEQ;
+        byte         tag = 0x00;
 
         /* Determine which tag was seen. */
         if (dataASN[HOLDER_IDX_GN_SEQ].tag != 0) {
-            gn_input = input + dataASN[holder_index].offset;
-            gn_len = dataASN[holder_index].length + 2;
-        }
-        else {
-            gn_input = input;
-            gn_len = len;
+            gn_input = input + dataASN[HOLDER_IDX_GN_SEQ].offset;
+            gn_len = dataASN[HOLDER_IDX_GN_SEQ].length;
+            tag = dataASN[HOLDER_IDX_GN_SEQ].tag;
+
+            if (gn_len >= ASN_LONG_LENGTH) { gn_len += 3; }
+            else {gn_len += 2; }
+
+            #ifdef WOLFSSL_DEBUG_ASN_TEMPLATE
+            printf("debug: decode holder: holder index: %d\n",
+                   HOLDER_IDX_GN_SEQ);
+            #endif /* WOLFSSL_DEBUG_ASN_TEMPLATE */
+
+            ret = DecodeAcertGeneralNames(gn_input, gn_len, tag, acert,
+                                          &acert->holderIssuerName);
         }
 
-        ret = DecodeAcertGeneralNames(gn_input, gn_len, acert,
-                                      &acert->holderIssuerName);
+        if (dataASN[HOLDER_IDX_GN_SEQ_OPT1].tag != 0) {
+            gn_input = input + dataASN[HOLDER_IDX_GN_SEQ_OPT1].offset;
+            gn_len = dataASN[HOLDER_IDX_GN_SEQ_OPT1].length;
+            tag = dataASN[HOLDER_IDX_GN_SEQ_OPT1].tag;
+
+            if (gn_len >= ASN_LONG_LENGTH) { gn_len += 3; }
+            else {gn_len += 2; }
+
+            #ifdef WOLFSSL_DEBUG_ASN_TEMPLATE
+            printf("debug: decode holder: holder index: %d\n",
+                   HOLDER_IDX_GN_SEQ_OPT1);
+            #endif /* WOLFSSL_DEBUG_ASN_TEMPLATE */
+
+            ret = DecodeAcertGeneralNames(gn_input, gn_len, tag, acert,
+                                          &acert->holderEntityName);
+        }
 
         if (ret != 0) {
             WOLFSSL_MSG("error: Holder: DecodeAcertGeneralNames failed");
@@ -41011,7 +41043,14 @@ static int DecodeHolder(const byte* input, word32 len, DecodedAcert* acert)
     return 0;
 }
 
-/* From RFC 5755.
+/* Note on AttCertIssuer field. ACERTs are supposed to follow
+ * v2form, but some (acert_bc1.pem) follow v1form. Because
+ * of the limited set of example ACERTs, the v1form will be
+ * tolerated for now but the field will not be parsed.
+ *
+ * More info from RFC below:
+ *
+ * From RFC 5755.
  * 4.2.3.  Issuer
  *
  * ACs conforming to this profile MUST use the v2Form choice, which MUST
@@ -41053,7 +41092,6 @@ enum {
 
 /* Decode the AttCertIssuer Field of an x509 attribute certificate.
  *
- *
  * @param [in]      input     Buffer containing encoded AttCertIssuer field.
  * @param [in]      len       Length of Holder field.
  * @param [in]      cert      Decoded certificate object.
@@ -41073,6 +41111,7 @@ static int DecodeAttCertIssuer(const byte* input, word32 len,
     word32       idx = 0;
     const byte * gn_input = NULL;
     word32       gn_len = 0;
+    byte         tag = 0x00;
 
     if (input == NULL || len <= 0 || cert == NULL) {
         return BUFFER_E;
@@ -41096,9 +41135,13 @@ static int DecodeAttCertIssuer(const byte* input, word32 len,
     /* Now parse the GeneralNames field.
      * Use the HOLDER_IDX_GN_SEQ offset for input. */
     gn_input = input + dataASN[ATTCERTISSUER_IDX_GN_SEQ].offset;
-    gn_len = dataASN[ATTCERTISSUER_IDX_GN_SEQ].length + 2;
+    gn_len = dataASN[ATTCERTISSUER_IDX_GN_SEQ].length;
+    tag = dataASN[ATTCERTISSUER_IDX_GN_SEQ].tag;
 
-    ret = DecodeAcertGeneralNames(gn_input, gn_len, cert,
+    if (gn_len >= ASN_LONG_LENGTH) { gn_len += 3; }
+    else { gn_len += 2; }
+
+    ret = DecodeAcertGeneralNames(gn_input, gn_len, tag, cert,
                                   &cert->AttCertIssuerName);
 
     if (ret != 0) {
@@ -41126,8 +41169,10 @@ static const ASNItem AcertASN[] =
                                   /* holder   Holder */
 /* ACINFO_HOLDER_SEQ  */          { 2, ASN_SEQUENCE, 1, 0, 0 },
                                   /* issuer   AttCertIssuer */
-/* ACINFO_CHOICE_SEQ  */          { 2, ASN_CONTEXT_SPECIFIC | 0, 1, 0, 2 },
-/* ACINFO_ISSUER_SEQ  */          { 2, ASN_SEQUENCE | 0, 1, 0, 2 },
+                                  /* v2Form   [0] V2Form  */
+/* ACINFO_ISSUER_V2FORM */        { 2, ASN_CONTEXT_SPECIFIC | 0, 1, 0, 2 },
+                                  /* v1Form   GeneralNames */
+/* ACINFO_ISSUER_V1FORM  */       { 2, ASN_SEQUENCE | 0, 1, 0, 2 },
                                   /* signature    AlgorithmIdentifier */
                                   /* AlgorithmIdentifier ::= SEQUENCE */
 /* ACINFO_ALGOID_SEQ */           { 2, ASN_SEQUENCE, 1, 1, 0 },
@@ -41173,8 +41218,9 @@ enum {
     ACERT_IDX_ACINFO_VER_INT,
     /* ACINFO holder and issuer */
     ACERT_IDX_ACINFO_HOLDER_SEQ,
-    ACERT_IDX_ACINFO_CHOICE_SEQ,
-    ACERT_IDX_ACINFO_ISSUER_SEQ,
+    /* The issuer should be in V2 form, but tolerate V1 for now. */
+    ACERT_IDX_ACINFO_ISSUER_V2,
+    ACERT_IDX_ACINFO_ISSUER_V1,
     /* ACINFO sig alg*/
     ACERT_IDX_ACINFO_ALGOID_SEQ,
     ACERT_IDX_ACINFO_ALGOID_OID,
@@ -41231,6 +41277,8 @@ int ParseX509Acert(DecodedAcert* acert, int verify)
     int    badDate = 0;
     byte   version = 0;
     word32 serialSz = EXTERNAL_SERIAL_SIZE;
+
+    WOLFSSL_MSG("ParseX509Acert");
 
     if (acert == NULL) {
         return BAD_FUNC_ARG;
@@ -41380,8 +41428,14 @@ int ParseX509Acert(DecodedAcert* acert, int verify)
 
         /* Determine which issuer tag was seen. We need this to determine
          * the holder_input. */
-        i_issuer = (dataASN[ACERT_IDX_ACINFO_CHOICE_SEQ].tag != 0) ?
-                    ACERT_IDX_ACINFO_CHOICE_SEQ : ACERT_IDX_ACINFO_ISSUER_SEQ;
+        i_issuer = (dataASN[ACERT_IDX_ACINFO_ISSUER_V2].tag != 0) ?
+                    ACERT_IDX_ACINFO_ISSUER_V2 : ACERT_IDX_ACINFO_ISSUER_V1;
+
+        #ifdef WOLFSSL_DEBUG_ASN_TEMPLATE
+        printf("debug: parse acert: issuer index: %d\n", i_issuer);
+        printf("debug: parse acert: issuer seq offset: %d\n",
+               dataASN[i_issuer].offset);
+        #endif /* WOLFSSL_DEBUG_ASN_TEMPLATE */
 
         holder_input = acert->source + dataASN[i_holder].offset;
         holder_len = dataASN[i_issuer].offset - dataASN[i_holder].offset;
@@ -41393,13 +41447,9 @@ int ParseX509Acert(DecodedAcert* acert, int verify)
             return ret;
         }
 
-        #ifdef WOLFSSL_DEBUG_ASN_TEMPLATE
-        printf("debug: parse acert:issuer index: %d\n", i_issuer);
-        #endif /* WOLFSSL_DEBUG_ASN_TEMPLATE */
-
         GetASN_GetConstRef(&dataASN[i_issuer], &issuer_input, &issuer_len);
 
-        if (i_issuer == ACERT_IDX_ACINFO_CHOICE_SEQ && issuer_len > 0) {
+        if (i_issuer == ACERT_IDX_ACINFO_ISSUER_V2 && issuer_len > 0) {
             /* Try to decode the AttCertIssuer as well. */
             ret = DecodeAttCertIssuer(issuer_input, issuer_len, acert);
 
@@ -41517,6 +41567,8 @@ int VerifyX509Acert(const byte* der, word32 derSz,
     word32         sigOID = 0;
     const byte *   sigParams = NULL;
     word32         sigParamsSz = 0;
+
+    WOLFSSL_MSG("ParseX509Acert");
 
     if (der == NULL || pubKey == NULL || derSz == 0 || pubKeySz == 0) {
         WOLFSSL_MSG("error: VerifyX509Acert: bad args");

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -40927,7 +40927,7 @@ enum {
     HOLDER_IDX_ISSUERSERIAL_SEQ,
     HOLDER_IDX_GN_SEQ,
     HOLDER_IDX_SERIAL_INT,
-    HOLDER_IDX_GN_SEQ_OPT1,
+    HOLDER_IDX_GN_SEQ_OPT1
 };
 
 /* Number of items in ASN template for an X509 Acert. */
@@ -41003,8 +41003,12 @@ static int DecodeHolder(const byte* input, word32 len, DecodedAcert* acert)
             gn_len = dataASN[HOLDER_IDX_GN_SEQ].length;
             tag = dataASN[HOLDER_IDX_GN_SEQ].tag;
 
-            if (gn_len >= ASN_LONG_LENGTH) { gn_len += 3; }
-            else {gn_len += 2; }
+            if (gn_len >= ASN_LONG_LENGTH) {
+                gn_len += 3;
+            }
+            else {
+                gn_len += 2;
+            }
 
             #ifdef WOLFSSL_DEBUG_ASN_TEMPLATE
             printf("debug: decode holder: holder index: %d\n",
@@ -41020,8 +41024,12 @@ static int DecodeHolder(const byte* input, word32 len, DecodedAcert* acert)
             gn_len = dataASN[HOLDER_IDX_GN_SEQ_OPT1].length;
             tag = dataASN[HOLDER_IDX_GN_SEQ_OPT1].tag;
 
-            if (gn_len >= ASN_LONG_LENGTH) { gn_len += 3; }
-            else {gn_len += 2; }
+            if (gn_len >= ASN_LONG_LENGTH) {
+                gn_len += 3;
+            }
+            else {
+                gn_len += 2;
+            }
 
             #ifdef WOLFSSL_DEBUG_ASN_TEMPLATE
             printf("debug: decode holder: holder index: %d\n",
@@ -41138,8 +41146,12 @@ static int DecodeAttCertIssuer(const byte* input, word32 len,
     gn_len = dataASN[ATTCERTISSUER_IDX_GN_SEQ].length;
     tag = dataASN[ATTCERTISSUER_IDX_GN_SEQ].tag;
 
-    if (gn_len >= ASN_LONG_LENGTH) { gn_len += 3; }
-    else { gn_len += 2; }
+    if (gn_len >= ASN_LONG_LENGTH) {
+        gn_len += 3;
+    }
+    else {
+        gn_len += 2;
+    }
 
     ret = DecodeAcertGeneralNames(gn_input, gn_len, tag, cert,
                                   &cert->AttCertIssuerName);
@@ -41172,7 +41184,7 @@ static const ASNItem AcertASN[] =
                                   /* v2Form   [0] V2Form  */
 /* ACINFO_ISSUER_V2FORM */        { 2, ASN_CONTEXT_SPECIFIC | 0, 1, 0, 2 },
                                   /* v1Form   GeneralNames */
-/* ACINFO_ISSUER_V1FORM  */       { 2, ASN_SEQUENCE | 0, 1, 0, 2 },
+/* ACINFO_ISSUER_V1FORM  */       { 2, ASN_SEQUENCE, 1, 0, 2 },
                                   /* signature    AlgorithmIdentifier */
                                   /* AlgorithmIdentifier ::= SEQUENCE */
 /* ACINFO_ALGOID_SEQ */           { 2, ASN_SEQUENCE, 1, 1, 0 },

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -801,6 +801,7 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #define X509_CRL_get_version            wolfSSL_X509_CRL_version
 #define X509_load_crl_file              wolfSSL_X509_load_crl_file
 
+#define X509_ACERT_new                  wolfSSL_X509_ACERT_new
 #define X509_ACERT_free                 wolfSSL_X509_ACERT_free
 #define X509_ACERT_get_version          wolfSSL_X509_ACERT_get_version
 #define X509_ACERT_get_signature_nid    wolfSSL_X509_ACERT_get_signature_nid


### PR DESCRIPTION
# Description

- Fix holder entityName parsing.
- Add better testing on holder fields.
- Some light cleanup, more comments, and better debug logging.
- Add X509_ACERT_new, wolfSSL_X509_ACERT_new_ex, and wolfSSL_X509_ACERT_sign (stub) test.

Fixes zd#18889.

# Testing

- Expanded test_wolfSSL_X509_ACERT_asn in tests/api.c.
- Tested with https://github.com/philljj/acert-test.
- Tested with reproducer in ticket.

Printing before:
```
$./test/test_acert -f certs/acert_ietf.pem -p
...
        Holder:
            Issuer: CN=CA
            Serial Number: 2 (0x2)
        Issuer: CN=Attribute Certificate Issuer
...
```

Printing after:
```
$./test/test_acert -f certs/acert_ietf.pem -p
...
        Holder:
            Name: CN=server.example
            Issuer: CN=CA
            Serial Number: 2 (0x2)
        Issuer: CN=Attribute Certificate Issuer
...
```
