### PR TITLE
Use only one or the other

### DIFF
--- a/tests/quic.c
+++ b/tests/quic.c
@@ -21,10 +21,10 @@
 
 #ifdef HAVE_CONFIG_H
     #include <config.h>
-#endif
-
+#else
 #ifndef WOLFSSL_USER_SETTINGS
     #include <wolfssl/options.h>
+#endif
 #endif
 #include <wolfssl/wolfcrypt/settings.h>
 


### PR DESCRIPTION
Commmit #8151 broke nightly-cmake-default-build-v2/1208/parsed_console/:
```
In file included from /extend/var/lib/jenkins/workspace/wolfSSL/nightly-cmake-default-build-v2/tests/unit.h:27,
                 from /extend/var/lib/jenkins/workspace/wolfSSL/nightly-cmake-default-build-v2/tests/quic.c:31:
/extend/var/lib/jenkins/workspace/wolfSSL/nightly-cmake-default-build-v2/build/config.h:29: error: "HAVE_PTHREAD" redefined [-Werror]
   29 | #define HAVE_PTHREAD 1
      | 
In file included from /extend/var/lib/jenkins/workspace/wolfSSL/nightly-cmake-default-build-v2/tests/quic.c:27:
/extend/var/lib/jenkins/workspace/wolfSSL/nightly-cmake-default-build-v2/build/wolfssl/options.h:134: note: this is the location of the previous definition
  134 | #define HAVE_PTHREAD
```