### PR TITLE
cmake: new add_option_defs helper, add KEYLOG_EXPORT build param

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -873,7 +873,7 @@ endif()
 #       - SEP
 
 add_option("WOLFSSL_KEYGEN"
-    "Enable key generation (default: disabled)])"
+    "Enable key generation (default: disabled)"
     "no" "yes;no")
 
 add_option("WOLFSSL_CERTGEN"
@@ -2278,6 +2278,11 @@ if (ENABLE_SCCACHE AND (NOT WOLFSSL_SCCACHE_ALREADY_SET_FLAG))
         set(WOLFSSL_SCCACHE_ALREADY_SET_FLAG ON)
     endif()
 endif()
+
+add_option_defs(NAME WOLFSSL_KEYLOG_EXPORT
+    HELP_STRING "Enable insecure export of TLS secrets to an NSS keylog file"
+    VALUES no yes
+    DEFINITIONS SHOW_SECRETS HAVE_SECRET_CALLBACK WOLFSSL_SSLKEYLOGFILE WOLFSSL_KEYLOG_EXPORT_WARNED)
 
 
 file(REMOVE ${OPTION_FILE})


### PR DESCRIPTION
# Description

Add `add_option_defs` helper which cover simple case of setting compile definitions when build option is selected. New helper uses named arguments and adds following QoL improvements:
- optionally infer default values from list of possible values. First possible value becomes default.
- optionally append default value to helper string. Helper string and default values can't go out of sync
- support adding defines if build option is set. It covers many simple cases like new `WOLFSSL_KEYLOG_EXPORT`

Fixes #8165

# Testing

1. Build before and after patch, diffed CMakeCache.txt files to find only new WOLFSSL_KEYLOG_EXPORT function is different.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
