### PR TITLE
Initialize vars & change types to appease Windows/VS

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -1371,7 +1371,7 @@ long wolfSSL_BIO_get_mem_ptr(WOLFSSL_BIO *bio, WOLFSSL_BUF_MEM **ptr)
                                 int closeFlag)
     {
         if (!bio || !bufMem ||
-            (closeFlag != BIO_NOCLOSE && closeFlag != BIO_CLOSE))
+           (closeFlag != WOLFSSL_BIO_NOCLOSE && closeFlag != WOLFSSL_BIO_CLOSE))
             return BAD_FUNC_ARG;
 
         if (bio->mem_buf)
@@ -1379,7 +1379,7 @@ long wolfSSL_BIO_get_mem_ptr(WOLFSSL_BIO *bio, WOLFSSL_BUF_MEM **ptr)
                 wolfSSL_BUF_MEM_free(bio->mem_buf);
 
         bio->mem_buf = bufMem;
-        bio->shutdown = closeFlag;
+        bio->shutdown = closeFlag ? WOLFSSL_BIO_CLOSE : WOLFSSL_BIO_NOCLOSE;
 
         bio->wrSz = (int)bio->mem_buf->length;
         bio->wrSzReset = bio->wrSz;

--- a/src/pk.c
+++ b/src/pk.c
@@ -3562,7 +3562,7 @@ int wolfSSL_RSA_padding_add_PKCS1_PSS_mgf1(WOLFSSL_RSA *rsa, unsigned char *em,
         const WOLFSSL_EVP_MD *mgf1Hash, int saltLen)
 {
     int ret = 1;
-    enum wc_HashType hashType;
+    enum wc_HashType hashType = WC_HASH_TYPE_NONE;
     int hashLen = 0;
     int emLen = 0;
     int mgf = 0;
@@ -7876,7 +7876,7 @@ static int wolfssl_dhparams_to_der(WOLFSSL_DH* dh, unsigned char** out,
     int ret = WC_NO_ERR_TRACE(WOLFSSL_FATAL_ERROR);
     int err = 0;
     byte* der = NULL;
-    word32 derSz;
+    word32 derSz = 0;
     DhKey* key = NULL;
 
     (void)heap;
@@ -7933,7 +7933,7 @@ static int wolfssl_dhparams_to_der(WOLFSSL_DH* dh, unsigned char** out,
 int wolfSSL_PEM_write_DHparams(XFILE fp, WOLFSSL_DH* dh)
 {
     int ret = 1;
-    int derSz;
+    int derSz = 0;
     byte* derBuf = NULL;
     void* heap = NULL;
 
@@ -16501,7 +16501,7 @@ int pkcs8_encode(WOLFSSL_EVP_PKEY* pkey, byte* key, word32* keySz)
 {
     int ret = 0;
     int algId = 0;
-    const byte* curveOid;
+    const byte* curveOid = 0;
     word32 oidSz = 0;
 
     /* Get the details of the private key. */
@@ -16587,7 +16587,7 @@ static int pem_write_mem_pkcs8privatekey(byte** pem, int* pemSz,
     int ret = 0;
     char password[NAME_SZ];
     byte* key = NULL;
-    word32 keySz;
+    word32 keySz = 0;
     int type = PKCS8_PRIVATEKEY_TYPE;
 
     /* Validate parameters. */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2171,7 +2171,7 @@ int wolfSSL_CTX_mcast_set_member_id(WOLFSSL_CTX* ctx, word16 id)
 
     WOLFSSL_ENTER("wolfSSL_CTX_mcast_set_member_id");
 
-    if (ctx == NULL || id > 255)
+    if (ctx == NULL || id > WOLFSSL_MAX_8BIT)
         ret = BAD_FUNC_ARG;
 
     if (ret == 0) {
@@ -2306,7 +2306,7 @@ int wolfSSL_mcast_peer_add(WOLFSSL* ssl, word16 peerId, int sub)
     int i;
 
     WOLFSSL_ENTER("wolfSSL_mcast_peer_add");
-    if (ssl == NULL || peerId > 255)
+    if (ssl == NULL || peerId > WOLFSSL_MAX_8BIT)
         return BAD_FUNC_ARG;
 
     if (!sub) {
@@ -2362,7 +2362,7 @@ int wolfSSL_mcast_peer_known(WOLFSSL* ssl, unsigned short peerId)
 
     WOLFSSL_ENTER("wolfSSL_mcast_peer_known");
 
-    if (ssl == NULL || peerId > 255) {
+    if (ssl == NULL || peerId > WOLFSSL_MAX_8BIT) {
         return BAD_FUNC_ARG;
     }
 

--- a/src/ssl_asn1.c
+++ b/src/ssl_asn1.c
@@ -282,10 +282,12 @@ static int wolfssl_i2d_asn1_items(const void* obj, byte* buf,
             len = 0;
             break;
         }
+
         if (buf != NULL && tmp != NULL && !mem->ex && mem->tag >= 0) {
-            /* Encode the implicit tag */
             byte imp[ASN_TAG_SZ + MAX_LENGTH_SZ];
-            SetImplicit(tmp[0], mem->tag, 0, imp, 0);
+            /* Encode the implicit tag; There's other stuff in the upper bits
+             * of the integer tag, so strip out everything else for value. */
+            SetImplicit(tmp[0], (byte)(mem->tag), 0, imp, 0);
             tmp[0] = imp[0];
         }
         len += ret;

--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -5023,7 +5023,7 @@ int wolfSSL_CTX_use_certificate_ASN1(WOLFSSL_CTX *ctx, int derSz,
 int wolfSSL_CTX_use_RSAPrivateKey(WOLFSSL_CTX* ctx, WOLFSSL_RSA* rsa)
 {
     int ret = 1;
-    int derSize;
+    int derSize = 0;
     unsigned char* der = NULL;
     unsigned char* p;
 

--- a/src/ssl_p7p12.c
+++ b/src/ssl_p7p12.c
@@ -948,7 +948,7 @@ int wolfSSL_PEM_write_bio_PKCS7(WOLFSSL_BIO* bio, PKCS7* p7)
     int    pemSz = -1;
     enum wc_HashType hashType;
     byte hashBuf[WC_MAX_DIGEST_SIZE];
-    word32 hashSz = -1;
+    word32 hashSz = 0;
 
     WOLFSSL_ENTER("wolfSSL_PEM_write_bio_PKCS7");
 

--- a/src/ssl_sess.c
+++ b/src/ssl_sess.c
@@ -3748,7 +3748,7 @@ static int wolfSSL_DupSessionEx(const WOLFSSL_SESSION* input,
     byte* ticketNonceLen, byte* preallocUsed)
 {
 #ifdef HAVE_SESSION_TICKET
-    int   ticLenAlloc = 0;
+    word16 ticLenAlloc = 0;
     byte *ticBuff = NULL;
 #endif
     const size_t copyOffset = OFFSETOF(WOLFSSL_SESSION, heap) +
@@ -4164,7 +4164,8 @@ int wolfSSL_SESSION_set1_id(WOLFSSL_SESSION *s,
     if (sid_len > ID_LEN) {
         return WOLFSSL_FAILURE;
     }
-    s->sessionIDSz = sid_len;
+
+    s->sessionIDSz = (byte)sid_len;
     if (sid != s->sessionID) {
         XMEMCPY(s->sessionID, sid, sid_len);
     }
@@ -4180,7 +4181,7 @@ int wolfSSL_SESSION_set1_id_context(WOLFSSL_SESSION *s,
     if (sid_ctx_len > ID_LEN) {
         return WOLFSSL_FAILURE;
     }
-    s->sessionCtxSz = sid_ctx_len;
+    s->sessionCtxSz = (byte)sid_ctx_len;
     if (sid_ctx != s->sessionCtx) {
         XMEMCPY(s->sessionCtx, sid_ctx, sid_ctx_len);
     }

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -4018,6 +4018,10 @@ static int WritePSKBinders(WOLFSSL* ssl, byte* output, word32 idx)
 
     WOLFSSL_ENTER("WritePSKBinders");
 
+    if (idx > WOLFSSL_MAX_16BIT) {
+        return INPUT_SIZE_E;
+    }
+
     ext = TLSX_Find(ssl->extensions, TLSX_PRE_SHARED_KEY);
     if (ext == NULL)
         return SANITY_MSG_E;
@@ -4033,7 +4037,7 @@ static int WritePSKBinders(WOLFSSL* ssl, byte* output, word32 idx)
 #ifdef WOLFSSL_DTLS13
     if (ssl->options.dtls)
         ret = Dtls13HashHandshake(ssl, output + Dtls13GetRlHeaderLength(ssl, 0),
-            idx - Dtls13GetRlHeaderLength(ssl, 0));
+                                 (word16)idx - Dtls13GetRlHeaderLength(ssl, 0));
     else
 #endif /* WOLFSSL_DTLS13 */
         ret = HashOutput(ssl, output, (int)idx, 0);
@@ -6270,7 +6274,7 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
         return ret;
 
     if (*usingPSK != 0) {
-        word16 modes;
+        word32 modes;
     #ifdef WOLFSSL_EARLY_DATA
         TLSX*  extEarlyData;
 
@@ -10856,14 +10860,18 @@ int DoTls13Finished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
     if (sniff == NO_SNIFF) {
         ret = BuildTls13HandshakeHmac(ssl, secret, mac, &finishedSz);
+
+        if (finishedSz > WOLFSSL_MAX_8BIT) {
+            return BUFFER_ERROR;
+        }
     #ifdef WOLFSSL_HAVE_TLS_UNIQUE
         if (ssl->options.side == WOLFSSL_CLIENT_END) {
             XMEMCPY(ssl->serverFinished, mac, finishedSz);
-            ssl->serverFinished_len = finishedSz;
+            ssl->serverFinished_len = (byte)finishedSz;
         }
         else {
             XMEMCPY(ssl->clientFinished, mac, finishedSz);
-            ssl->clientFinished_len = finishedSz;
+            ssl->clientFinished_len = (byte)finishedSz;
         }
     #endif /* WOLFSSL_HAVE_TLS_UNIQUE */
         if (ret != 0)
@@ -10945,7 +10953,7 @@ int DoTls13Finished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
  */
 static int SendTls13Finished(WOLFSSL* ssl)
 {
-    int   finishedSz = ssl->specs.hash_size;
+    byte  finishedSz = ssl->specs.hash_size;
     byte* input;
     byte* output;
     int   ret;
@@ -11805,9 +11813,9 @@ static int SendTls13NewSessionTicket(WOLFSSL* ssl)
 {
     byte*  output;
     int    ret;
+    word32 length;
     int    sendSz;
     word16 extSz;
-    word32 length;
     word32 idx = RECORD_HEADER_SZ + HANDSHAKE_HEADER_SZ;
 
     WOLFSSL_START(WC_FUNC_NEW_SESSION_TICKET_SEND);
@@ -11878,7 +11886,7 @@ static int SendTls13NewSessionTicket(WOLFSSL* ssl)
     /* Nonce */
     length += TICKET_NONCE_LEN_SZ + DEF_TICKET_NONCE_SZ;
 
-    sendSz = (int)(idx + length + MAX_MSG_EXTRA);
+    sendSz = (word16)(idx + length + MAX_MSG_EXTRA);
 
     /* Check buffers are big enough and grow if needed. */
     if ((ret = CheckAvailableSize(ssl, sendSz)) != 0)
@@ -11934,6 +11942,10 @@ static int SendTls13NewSessionTicket(WOLFSSL* ssl)
     idx += EXTS_SZ;
 #endif
 
+    if (idx > WOLFSSL_MAX_16BIT) {
+        return BAD_LENGTH_E;
+    }
+
     ssl->options.haveSessionId = 1;
 
     SetupSession(ssl);
@@ -11946,12 +11958,15 @@ static int SendTls13NewSessionTicket(WOLFSSL* ssl)
 
 #ifdef WOLFSSL_DTLS13
     if (ssl->options.dtls)
-        return Dtls13HandshakeSend(ssl, output, sendSz, idx, session_ticket, 0);
+        return Dtls13HandshakeSend(ssl, output, (word16)sendSz,
+                                   (word16)idx, session_ticket, 0);
 #endif /* WOLFSSL_DTLS13 */
 
     /* This message is always encrypted. */
-    sendSz = BuildTls13Message(ssl, output, sendSz, output + RECORD_HEADER_SZ,
-                               idx - RECORD_HEADER_SZ, handshake, 0, 0, 0);
+    sendSz = BuildTls13Message(ssl, output, sendSz,
+                               output + RECORD_HEADER_SZ,
+                               (word16)idx - RECORD_HEADER_SZ,
+                               handshake, 0, 0, 0);
     if (sendSz < 0)
         return sendSz;
 

--- a/src/x509.c
+++ b/src/x509.c
@@ -1478,9 +1478,14 @@ int wolfSSL_X509_add_ext(WOLFSSL_X509 *x509, WOLFSSL_X509_EXTENSION *ext,
             return WOLFSSL_FAILURE;
         }
 
+        /* ext->crit is WOLFSSL_ASN1_BOOLEAN */
+        if (ext->crit != 0 && ext->crit != -1) {
+            return WOLFSSL_FAILURE;
+        }
+
         /* x509->custom_exts now owns the buffers and they must be managed. */
         x509->custom_exts[x509->customExtCount].oid = oid;
-        x509->custom_exts[x509->customExtCount].crit = ext->crit;
+        x509->custom_exts[x509->customExtCount].crit = (byte)ext->crit;
         x509->custom_exts[x509->customExtCount].val = val;
         x509->custom_exts[x509->customExtCount].valSz = ext->value.length;
         x509->customExtCount++;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -13548,7 +13548,7 @@ static int GenerateDNSEntryIPString(DNS_entry* entry, void* heap)
 static int GenerateDNSEntryRIDString(DNS_entry* entry, void* heap)
 {
     int i, j, ret   = 0;
-    int nameSz      = 0;
+    word16 nameSz   = 0;
 #if !defined(WOLFCRYPT_ONLY) && defined(OPENSSL_EXTRA)
     int nid         = 0;
 #endif
@@ -13557,7 +13557,7 @@ static int GenerateDNSEntryRIDString(DNS_entry* entry, void* heap)
     word32 idx      = 0;
     word16 tmpName[MAX_OID_SZ];
     char   oidName[MAX_OID_SZ];
-    char*  finalName;
+    char*  finalName = NULL;
 
     if (entry == NULL || entry->type != ASN_RID_TYPE) {
         return BAD_FUNC_ARG;
@@ -13615,7 +13615,10 @@ static int GenerateDNSEntryRIDString(DNS_entry* entry, void* heap)
     }
 
     if (ret == 0) {
-        nameSz = (int)XSTRLEN((const char*)finalName);
+        nameSz = (word16)XSTRLEN((const char*)finalName);
+        if (nameSz > MAX_OID_SZ) {
+            return BUFFER_E;
+        }
 
         entry->ridString = (char*)XMALLOC((word32)(nameSz + 1), heap,
                 DYNAMIC_TYPE_ALTNAME);

--- a/wolfcrypt/src/dsa.c
+++ b/wolfcrypt/src/dsa.c
@@ -173,7 +173,7 @@ int wc_MakeDsaKey(WC_RNG *rng, DsaKey *dsa)
         return MEMORY_E;
     }
 
-    SAVE_VECTOR_REGISTERS();
+    SAVE_VECTOR_REGISTERS(;);
 
 #ifdef WOLFSSL_SMALL_STACK
     if ((tmpQ = (mp_int *)XMALLOC(sizeof(*tmpQ), NULL, DYNAMIC_TYPE_WOLF_BIGINT)) == NULL)

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -12593,20 +12593,22 @@ static int build_lut(int idx, mp_int* a, mp_int* modulus, mp_digit mp,
 
    /* make all single bit entries */
    for (x = 1; x < FP_LUT; x++) {
-      if ((mp_copy(fp_cache[idx].LUT[1<<(x-1)]->x,
-                   fp_cache[idx].LUT[1<<x]->x) != MP_OKAY) ||
-          (mp_copy(fp_cache[idx].LUT[1<<(x-1)]->y,
-                   fp_cache[idx].LUT[1<<x]->y) != MP_OKAY) ||
-          (mp_copy(fp_cache[idx].LUT[1<<(x-1)]->z,
-                   fp_cache[idx].LUT[1<<x]->z) != MP_OKAY)){
+      if ((mp_copy(fp_cache[idx].LUT[(unsigned int)(1 << (x-1))]->x,
+                   fp_cache[idx].LUT[(unsigned int)(1 <<  x   )]->x) != MP_OKAY) ||
+          (mp_copy(fp_cache[idx].LUT[(unsigned int)(1 << (x-1))]->y,
+                   fp_cache[idx].LUT[(unsigned int)(1 <<  x   )]->y) != MP_OKAY) ||
+          (mp_copy(fp_cache[idx].LUT[(unsigned int)(1 << (x-1))]->z,
+                   fp_cache[idx].LUT[(unsigned int)(1 <<  x   )]->z) != MP_OKAY)) {
           err = MP_INIT_E;
           goto errout;
       } else {
 
          /* now double it bitlen/FP_LUT times */
          for (y = 0; y < lut_gap; y++) {
-             if ((err = ecc_projective_dbl_point_safe(fp_cache[idx].LUT[1<<x],
-                            fp_cache[idx].LUT[1<<x], a, modulus, mp)) != MP_OKAY) {
+             if ((err = ecc_projective_dbl_point_safe(
+                                      fp_cache[idx].LUT[(unsigned int)(1<<x)],
+                                      fp_cache[idx].LUT[(unsigned int)(1<<x)],
+                                      a, modulus, mp)) != MP_OKAY) {
                  goto errout;
              }
          }
@@ -13173,7 +13175,7 @@ int ecc_mul2add(ecc_point* A, mp_int* kA,
                 ecc_point* C, mp_int* a, mp_int* modulus, void* heap)
 {
    int  idx1 = -1, idx2 = -1, err, mpInit = 0;
-   mp_digit mp;
+   mp_digit mp = 0;
 #ifdef WOLFSSL_SMALL_STACK
    mp_int   *mu = (mp_int *)XMALLOC(sizeof *mu, NULL, DYNAMIC_TYPE_ECC_BUFFER);
 
@@ -13321,7 +13323,7 @@ int wc_ecc_mulmod_ex(const mp_int* k, ecc_point *G, ecc_point *R, mp_int* a,
 {
 #if !defined(WOLFSSL_SP_MATH)
    int   idx, err = MP_OKAY;
-   mp_digit mp;
+   mp_digit mp = 0;
 #ifdef WOLFSSL_SMALL_STACK
    mp_int   *mu = NULL;
 #else
@@ -13497,7 +13499,7 @@ int wc_ecc_mulmod_ex2(const mp_int* k, ecc_point *G, ecc_point *R, mp_int* a,
 {
 #if !defined(WOLFSSL_SP_MATH)
    int   idx, err = MP_OKAY;
-   mp_digit mp;
+   mp_digit mp = 0;
 #ifdef WOLFSSL_SMALL_STACK
    mp_int   *mu = NULL;
 #else

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -5113,7 +5113,7 @@ static int wc_PKCS7_ParseSignerInfo(wc_PKCS7* pkcs7, byte* in, word32 inSz,
 static int wc_PKCS7_HandleOctetStrings(wc_PKCS7* pkcs7, byte* in, word32 inSz,
                                 word32* tmpIdx, word32* idx, int keepContent)
 {
-    int ret, length;
+    int ret, length = 0;
     word32 msgSz, i, contBufSz;
     byte tag;
     byte* msg = NULL;
@@ -5345,7 +5345,7 @@ static int PKCS7_VerifySignedData(wc_PKCS7* pkcs7, const byte* hashBuf,
     word32 hashSz, byte* in, word32 inSz,
     byte* in2, word32 in2Sz)
 {
-    word32 idx, maxIdx = inSz, outerContentType, contentTypeSz = 0, totalSz = 0;
+    word32 idx, maxIdx = inSz, outerContentType = 0, contentTypeSz = 0, totalSz = 0;
     int length = 0, version = 0, ret = 0;
     byte* content = NULL;
     byte* contentDynamic = NULL;
@@ -11872,11 +11872,11 @@ static int wc_PKCS7_ParseToRecipientInfoSet(wc_PKCS7* pkcs7, byte* in,
                                             word32 inSz, word32* idx,
                                             int type)
 {
-    int version = 0, length, ret = 0;
-    word32 contentType;
-    byte* pkiMsg = in;
+    int version = 0, length = 0, ret = 0;
+    word32 contentType= 0;
     word32 pkiMsgSz = inSz;
-    byte  tag;
+    byte*  pkiMsg = in;
+    byte   tag = 0;
 #ifndef NO_PKCS7_STREAM
     word32 tmpIdx = 0;
 #endif
@@ -13155,7 +13155,7 @@ WOLFSSL_API int wc_PKCS7_DecodeAuthEnvelopedData(wc_PKCS7* pkcs7, byte* in,
     byte* authAttrib = NULL;
     int authAttribSz = 0;
     word32 localIdx;
-    byte tag;
+    byte tag = 0;
 
     if (pkcs7 == NULL)
         return BAD_FUNC_ARG;
@@ -14059,7 +14059,7 @@ static int wc_PKCS7_DecodeUnprotectedAttributes(wc_PKCS7* pkcs7, byte* pkiMsg,
 int wc_PKCS7_DecodeEncryptedData(wc_PKCS7* pkcs7, byte* in, word32 inSz,
                                  byte* output, word32 outputSz)
 {
-    int ret = 0, version, length = 0, haveAttribs = 0;
+    int ret = 0, version = 0, length = 0, haveAttribs = 0;
     word32 idx = 0;
 
 #ifndef NO_PKCS7_STREAM
@@ -14077,7 +14077,7 @@ int wc_PKCS7_DecodeEncryptedData(wc_PKCS7* pkcs7, byte* in, word32 inSz,
 
     byte* pkiMsg = in;
     word32 pkiMsgSz = inSz;
-    byte  tag;
+    byte  tag = 0;
 
     if (pkcs7 == NULL ||
             ((pkcs7->encryptionKey == NULL || pkcs7->encryptionKeySz == 0) &&

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -316,6 +316,7 @@ typedef struct w64wrapper {
         WOLFSSL_WORD_BITS  = WOLFSSL_WORD_SIZE * WOLFSSL_BIT_SIZE
     };
 
+    #define WOLFSSL_MAX_8BIT  0xffU
     #define WOLFSSL_MAX_16BIT 0xffffU
     #define WOLFSSL_MAX_32BIT 0xffffffffU
 


### PR DESCRIPTION
# Description

Addresses these warnings encountered during a Windows / Visual Studio build:

* edit: also introduces `#define WOLFSSL_MAX_8BIT 0xffU` in `type.h`

```
1>C:\workspace\wolfssl\wolfssl\wolfcrypt\curve25519.h(151,1): warning C4141: 'dllexport': used more than once
1>C:\workspace\wolfssl\wolfssl\wolfcrypt\curve25519.h(151,1): warning C4141: 'dllexport': used more than once
1>C:\workspace\wolfssl\src\dtls.c(721,36): warning C4244: 'function': conversion from 'word32' to 'word16', possible loss of data
1>C:\workspace\wolfssl\src\dtls.c(732,67): warning C4244: 'function': conversion from 'word32' to 'word16', possible loss of data
1>C:\workspace\wolfssl\wolfssl\wolfcrypt\curve25519.h(151,1): warning C4141: 'dllexport': used more than once
1>C:\workspace\wolfssl\wolfssl\wolfcrypt\curve25519.h(151,1): warning C4141: 'dllexport': used more than once
1>C:\workspace\wolfssl\wolfssl\wolfcrypt\curve25519.h(151,1): warning C4141: 'dllexport': used more than once
1>C:\workspace\wolfssl\wolfssl\wolfcrypt\curve25519.h(151,1): warning C4141: 'dllexport': used more than once
1>C:\workspace\wolfssl\src\ssl_sess.c(3891,46): warning C4244: '=': conversion from 'int' to 'word16', possible loss of data
1>C:\workspace\wolfssl\src\ssl_sess.c(4167,22): warning C4244: '=': conversion from 'unsigned int' to 'byte', possible loss of data
1>C:\workspace\wolfssl\src\ssl_sess.c(4183,23): warning C4244: '=': conversion from 'unsigned int' to 'byte', possible loss of data
1>C:\workspace\wolfssl\src\ssl_asn1.c(288,36): warning C4244: 'function': conversion from 'const int' to 'byte', possible loss of data
1>C:\workspace\wolfssl\src\bio.c(1382,25): warning C4244: '=': conversion from 'int' to 'byte', possible loss of data
1>C:\workspace\wolfssl\src\x509.c(1476,59): warning C4244: '=': conversion from 'int' to 'byte', possible loss of data
1>C:\workspace\wolfssl\src\ssl_p7p12.c(951,21): warning C4245: 'initializing': conversion from 'int' to 'word32', signed/unsigned mismatch
1>C:\workspace\wolfssl\wolfssl\wolfcrypt\curve25519.h(151,1): warning C4141: 'dllexport': used more than once
1>C:\workspace\wolfssl\wolfssl\wolfcrypt\curve25519.h(151,1): warning C4141: 'dllexport': used more than once
1>C:\workspace\wolfssl\src\tls13.c(4036,17): warning C4244: 'function': conversion from 'word32' to 'word16', possible loss of data
1>C:\workspace\wolfssl\src\tls13.c(6316,20): warning C4244: '=': conversion from 'word32' to 'word16', possible loss of data
1>C:\workspace\wolfssl\src\tls13.c(10862,39): warning C4244: '=': conversion from 'word32' to 'byte', possible loss of data
1>C:\workspace\wolfssl\src\tls13.c(10866,39): warning C4244: '=': conversion from 'word32' to 'byte', possible loss of data
1>C:\workspace\wolfssl\src\tls13.c(11036,39): warning C4244: '=': conversion from 'int' to 'byte', possible loss of data
1>C:\workspace\wolfssl\src\tls13.c(11040,39): warning C4244: '=': conversion from 'int' to 'byte', possible loss of data
1>C:\workspace\wolfssl\src\tls13.c(11949,49): warning C4244: 'function': conversion from 'int' to 'word16', possible loss of data
1>C:\workspace\wolfssl\src\tls13.c(11949,57): warning C4244: 'function': conversion from 'word32' to 'word16', possible loss of data
1>C:\workspace\wolfssl\wolfssl\wolfcrypt\curve25519.h(151,1): warning C4141: 'dllexport': used more than once
1>C:\workspace\wolfssl\wolfssl\wolfcrypt\curve25519.h(151,1): warning C4141: 'dllexport': used more than once
1>C:\workspace\wolfssl\wolfcrypt\src\asn.c(13614,1): warning C4701: potentially uninitialized local variable 'finalName' used
1>C:\workspace\wolfssl\wolfcrypt\src\asn.c(13614,1): warning C4703: potentially uninitialized local pointer variable 'finalName' used
1>C:\workspace\wolfssl\src\pk.c(3666,1): warning C4701: potentially uninitialized local variable 'hashType' used
1>C:\workspace\wolfssl\src\pk.c(7961,1): warning C4701: potentially uninitialized local variable 'derSz' used
1>C:\workspace\wolfssl\src\pk.c(16559,1): warning C4701: potentially uninitialized local variable 'curveOid' used
1>C:\workspace\wolfssl\src\pk.c(16559,1): warning C4703: potentially uninitialized local pointer variable 'curveOid' used
1>C:\workspace\wolfssl\src\ssl_load.c(5045,1): warning C4701: potentially uninitialized local variable 'derSize' used
1>C:\workspace\wolfssl\src\pk.c(7901,1): warning C4701: potentially uninitialized local variable 'derSz' used
1>C:\workspace\wolfssl\src\pk.c(16607,1): warning C4701: potentially uninitialized local variable 'keySz' used
1>C:\workspace\wolfssl\wolfssl\wolfcrypt\curve25519.h(151,1): warning C4141: 'dllexport': used more than once
1>C:\workspace\wolfssl\wolfcrypt\src\dsa.c(176,5): warning C4003: not enough arguments for function-like macro invocation 'SAVE_VECTOR_REGISTERS'
1>C:\workspace\wolfssl\wolfcrypt\src\ecc.c(12596,39): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
1>C:\workspace\wolfssl\wolfcrypt\src\ecc.c(12597,39): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
1>C:\workspace\wolfssl\wolfcrypt\src\ecc.c(12598,39): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
1>C:\workspace\wolfssl\wolfcrypt\src\ecc.c(12599,39): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
1>C:\workspace\wolfssl\wolfcrypt\src\ecc.c(12600,39): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
1>C:\workspace\wolfssl\wolfcrypt\src\ecc.c(12601,39): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
1>C:\workspace\wolfssl\wolfcrypt\src\ecc.c(12608,74): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
1>C:\workspace\wolfssl\wolfcrypt\src\ecc.c(12609,48): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
1>C:\workspace\wolfssl\wolfcrypt\src\ecc.c(13590,1): warning C4701: potentially uninitialized local variable 'mp' used
1>C:\workspace\wolfssl\wolfcrypt\src\ecc.c(13275,1): warning C4701: potentially uninitialized local variable 'mp' used
1>C:\workspace\wolfssl\wolfcrypt\src\ecc.c(13413,1): warning C4701: potentially uninitialized local variable 'mp' used
1>C:\workspace\wolfssl\wolfcrypt\src\pkcs7.c(13303,1): warning C4701: potentially uninitialized local variable 'tag' used
1>C:\workspace\wolfssl\wolfcrypt\src\pkcs7.c(14151,1): warning C4701: potentially uninitialized local variable 'tag' used
1>C:\workspace\wolfssl\wolfcrypt\src\pkcs7.c(14219,1): warning C4701: potentially uninitialized local variable 'version' used
1>C:\workspace\wolfssl\wolfcrypt\src\pkcs7.c(5513,1): warning C4701: potentially uninitialized local variable 'outerContentType' used
1>C:\workspace\wolfssl\wolfcrypt\src\pkcs7.c(12110,1): warning C4701: potentially uninitialized local variable 'length' used
1>C:\workspace\wolfssl\wolfcrypt\src\pkcs7.c(12000,1): warning C4701: potentially uninitialized local variable 'contentType' used
1>C:\workspace\wolfssl\wolfcrypt\src\pkcs7.c(12013,1): warning C4701: potentially uninitialized local variable 'tag' used
1>C:\workspace\wolfssl\wolfcrypt\src\pkcs7.c(5177,1): warning C4701: potentially uninitialized local variable 'length' used
```

* edit: This PR does _not_ include fixes for the `warning C4141: 'dllexport': used more than once`, noted above.
 
Fixes zd# n/a

# Testing

Confirmed working with benchmark and test apps.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
