### PR TITLE
Kyber: Fix wolfSSL_get_curve_name()

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -14667,19 +14667,19 @@ const char* wolfSSL_get_curve_name(WOLFSSL* ssl)
         case WOLFSSL_P521_KYBER_LEVEL5:
             return "P521_KYBER_LEVEL5";
 #elif defined(WOLFSSL_WC_KYBER)
-    #ifdef WOLFSSL_KYBER512
+    #ifndef WOLFSSL_NO_KYBER512
         case WOLFSSL_KYBER_LEVEL1:
             return "KYBER_LEVEL1";
         case WOLFSSL_P256_KYBER_LEVEL1:
             return "P256_KYBER_LEVEL1";
     #endif
-    #ifdef WOLFSSL_KYBER768
+    #ifndef WOLFSSL_NO_KYBER768
         case WOLFSSL_KYBER_LEVEL3:
             return "KYBER_LEVEL3";
         case WOLFSSL_P384_KYBER_LEVEL3:
             return "P384_KYBER_LEVEL3";
     #endif
-    #ifdef WOLFSSL_KYBER1024
+    #ifndef WOLFSSL_NO_KYBER1024
         case WOLFSSL_KYBER_LEVEL5:
             return "KYBER_LEVEL5";
         case WOLFSSL_P521_KYBER_LEVEL5:


### PR DESCRIPTION
# Description

Fix protection around Kyber hybrid strings when compiling for original with wolfSSL implementation.

Fixes zd#18923

# Testing

./configure --disable-shared --enable-kyber=all,original
./examples/server/server -v 4 -l TLS13-AES256-GCM-SHA384 --pqc P521_KYBER_LEVEL5 &
./examples/client/client -v 4 -l TLS13-AES256-GCM-SHA384 --pqc P521_KYBER_LEVEL5


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
