### PR TITLE
20241114-wolfSSL_CTX_UnloadIntermediateCerts-thread-safety

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -2297,7 +2297,7 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
         ctx->minDowngrade = WOLFSSL_MIN_DOWNGRADE;
     }
 
-    wolfSSL_RefInit(&ctx->ref, &ret);
+    wolfSSL_RefWithMutexInit(&ctx->ref, &ret);
 #ifdef WOLFSSL_REFCNT_ERROR_RETURN
     if (ret < 0) {
         WOLFSSL_MSG("Mutex error on CTX init");
@@ -2782,7 +2782,7 @@ void FreeSSL_Ctx(WOLFSSL_CTX* ctx)
 #endif
 
     /* decrement CTX reference count */
-    wolfSSL_RefDec(&ctx->ref, &isZero, &ret);
+    wolfSSL_RefWithMutexDec(&ctx->ref, &isZero, &ret);
 #ifdef WOLFSSL_REFCNT_ERROR_RETURN
     if (ret < 0) {
         /* check error state, if mutex error code then mutex init failed but

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -11124,7 +11124,8 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             ret = wolfSSL_CertManagerUnloadIntermediateCerts(ctx->cm);
         }
 
-        wolfSSL_RefWithMutexUnlock(&ctx->ref);
+        if (wolfSSL_RefWithMutexUnlock(&ctx->ref) != 0)
+            WOLFSSL_MSG("Failed to unlock mutex!");
 
         return ret;
     }

--- a/src/x509.c
+++ b/src/x509.c
@@ -1386,6 +1386,9 @@ int wolfSSL_X509_add_ext(WOLFSSL_X509 *x509, WOLFSSL_X509_EXTENSION *ext,
             if (ext->value.length == sizeof(word16)) {
                 /* if ext->value is already word16, set directly */
                 x509->keyUsage = *(word16*)ext->value.data;
+#ifdef BIG_ENDIAN_ORDER
+                x509->keyUsage = rotlFixed16(x509->keyUsage, 8U);
+#endif
                 x509->keyUsageCrit = (byte)ext->crit;
                 x509->keyUsageSet = 1;
             }
@@ -1406,7 +1409,7 @@ int wolfSSL_X509_add_ext(WOLFSSL_X509 *x509, WOLFSSL_X509_EXTENSION *ext,
     case WC_NID_ext_key_usage:
         if (ext && ext->value.data) {
             if (ext->value.length == sizeof(byte)) {
-                /* if ext->value is already word16, set directly */
+                /* if ext->value is already 1 byte, set directly */
                 x509->extKeyUsage = *(byte*)ext->value.data;
                 x509->extKeyUsageCrit = (byte)ext->crit;
             }

--- a/tests/api.c
+++ b/tests/api.c
@@ -83073,7 +83073,10 @@ static int test_wolfSSL_d2i_X509_REQ(void)
          * (PEM_read_X509_REQ)*/
         ExpectTrue((f = XFOPEN(csrDsaFile, "rb")) != XBADFILE);
         ExpectNull(PEM_read_X509_REQ(XBADFILE, &req, NULL, NULL));
-        ExpectNotNull(PEM_read_X509_REQ(f, &req, NULL, NULL));
+        if (EXPECT_SUCCESS())
+            ExpectNotNull(PEM_read_X509_REQ(f, &req, NULL, NULL));
+        else if (f != XBADFILE)
+            XFCLOSE(f);
         ExpectIntEQ(X509_REQ_verify(req, pub_key), 1);
 
         X509_free(req);

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -115,8 +115,6 @@ masking and clearing memory logic.
 
 #endif
 
-#ifdef WC_RC2
-
 /* This routine performs a left circular arithmetic shift of <x> by <y> value */
 WC_MISC_STATIC WC_INLINE word16 rotlFixed16(word16 x, word16 y)
 {
@@ -129,8 +127,6 @@ WC_MISC_STATIC WC_INLINE word16 rotrFixed16(word16 x, word16 y)
 {
     return (x >> y) | (x << (sizeof(x) * 8 - y));
 }
-
-#endif /* WC_RC2 */
 
 /* This routine performs a byte swap of 32-bit word value. */
 #if defined(__CCRX__) && !defined(NO_INLINE) /* shortest version for CC-RX */

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -1330,9 +1330,9 @@ int wolfSSL_RefWithMutexLock(wolfSSL_RefWithMutex* ref)
     return wc_LockMutex(&ref->mutex);
 }
 
-void wolfSSL_RefWithMutexUnlock(wolfSSL_RefWithMutex* ref)
+int wolfSSL_RefWithMutexUnlock(wolfSSL_RefWithMutex* ref)
 {
-    wc_UnLockMutex(&ref->mutex);
+    return wc_UnLockMutex(&ref->mutex);
 }
 
 void wolfSSL_RefWithMutexDec(wolfSSL_RefWithMutex* ref, int* isZero, int* err)

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -1232,7 +1232,7 @@ char* wc_strdup_ex(const char *src, int memType) {
 }
 #endif
 
-#ifdef WOLFSSL_ATOMIC_OPS
+#if defined(WOLFSSL_ATOMIC_OPS) && !defined(SINGLE_THREADED)
 
 #ifdef HAVE_C___ATOMIC
 /* Atomic ops using standard C lib */
@@ -1292,8 +1292,9 @@ int wolfSSL_Atomic_Int_FetchSub(wolfSSL_Atomic_Int* c, int i)
 
 #endif /* WOLFSSL_ATOMIC_OPS */
 
-#if !defined(SINGLE_THREADED) && !defined(WOLFSSL_ATOMIC_OPS)
-void wolfSSL_RefInit(wolfSSL_Ref* ref, int* err)
+#if !defined(SINGLE_THREADED)
+
+void wolfSSL_RefWithMutexInit(wolfSSL_RefWithMutex* ref, int* err)
 {
     int ret = wc_InitMutex(&ref->mutex);
     if (ret != 0) {
@@ -1304,14 +1305,14 @@ void wolfSSL_RefInit(wolfSSL_Ref* ref, int* err)
     *err = ret;
 }
 
-void wolfSSL_RefFree(wolfSSL_Ref* ref)
+void wolfSSL_RefWithMutexFree(wolfSSL_RefWithMutex* ref)
 {
     if (wc_FreeMutex(&ref->mutex) != 0) {
         WOLFSSL_MSG("Failed to free mutex of reference counting!");
     }
 }
 
-void wolfSSL_RefInc(wolfSSL_Ref* ref, int* err)
+void wolfSSL_RefWithMutexInc(wolfSSL_RefWithMutex* ref, int* err)
 {
     int ret = wc_LockMutex(&ref->mutex);
     if (ret != 0) {
@@ -1324,7 +1325,17 @@ void wolfSSL_RefInc(wolfSSL_Ref* ref, int* err)
     *err = ret;
 }
 
-void wolfSSL_RefDec(wolfSSL_Ref* ref, int* isZero, int* err)
+int wolfSSL_RefWithMutexLock(wolfSSL_RefWithMutex* ref)
+{
+    return wc_LockMutex(&ref->mutex);
+}
+
+void wolfSSL_RefWithMutexUnlock(wolfSSL_RefWithMutex* ref)
+{
+    wc_UnLockMutex(&ref->mutex);
+}
+
+void wolfSSL_RefWithMutexDec(wolfSSL_RefWithMutex* ref, int* isZero, int* err)
 {
     int ret = wc_LockMutex(&ref->mutex);
     if (ret != 0) {
@@ -1341,7 +1352,7 @@ void wolfSSL_RefDec(wolfSSL_Ref* ref, int* isZero, int* err)
     }
     *err = ret;
 }
-#endif
+#endif /* ! SINGLE_THREADED */
 
 #if WOLFSSL_CRYPT_HW_MUTEX
 /* Mutex for protection of cryptography hardware */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3724,7 +3724,7 @@ struct WOLFSSL_CTX {
 #ifdef SINGLE_THREADED
     WC_RNG*         rng;          /* to be shared with WOLFSSL w/o locking */
 #endif
-    wolfSSL_Ref     ref;
+    wolfSSL_RefWithMutex ref;
     int         err;              /* error code in case of mutex not created */
 #ifndef NO_DH
     buffer      serverDH_P;

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2759,15 +2759,19 @@ WOLFSSL_API void wolfSSL_ERR_print_errors(WOLFSSL_BIO *bio);
 enum { /* ssl Constants */
     WOLFSSL_ERROR_NONE      =  0,   /* for most functions */
     WOLFSSL_FAILURE         =  0,   /* for some functions */
+    WOLFSSL_SUCCESS         =  1,
 
     #if defined(WOLFSSL_DEBUG_TRACE_ERROR_CODES) && \
             (defined(BUILDING_WOLFSSL) || \
              defined(WOLFSSL_DEBUG_TRACE_ERROR_CODES_ALWAYS))
         #define WOLFSSL_FAILURE WC_ERR_TRACE(WOLFSSL_FAILURE)
         #define CONST_NUM_ERR_WOLFSSL_FAILURE 0
+        /* include CONST_NUM_ERR_ variants of the success codes, so that they
+         * can be harmlessly wrapped in WC_NO_ERR_TRACE().
+         */
+        #define CONST_NUM_ERR_WOLFSSL_ERROR_NONE 0
+        #define CONST_NUM_ERR_WOLFSSL_SUCCESS 1
     #endif
-
-    WOLFSSL_SUCCESS         =  1,
 
 /* WOLFSSL_SHUTDOWN_NOT_DONE is returned by wolfSSL_shutdown and
  * wolfSSL_SendUserCanceled when the other end

--- a/wolfssl/wolfcrypt/misc.h
+++ b/wolfssl/wolfcrypt/misc.h
@@ -46,12 +46,10 @@ word32 rotlFixed(word32 x, word32 y);
 WOLFSSL_LOCAL
 word32 rotrFixed(word32 x, word32 y);
 
-#ifdef WC_RC2
 WOLFSSL_LOCAL
 word16 rotlFixed16(word16 x, word16 y);
 WOLFSSL_LOCAL
 word16 rotrFixed16(word16 x, word16 y);
-#endif
 
 WOLFSSL_LOCAL
 word32 ByteReverseWord32(word32 value);

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -318,25 +318,6 @@ typedef struct w64wrapper {
     #define WOLFSSL_MAX_16BIT 0xffffU
     #define WOLFSSL_MAX_32BIT 0xffffffffU
 
-    #ifndef WARN_UNUSED_RESULT
-        #if defined(WOLFSSL_LINUXKM) && defined(__must_check)
-            #define WARN_UNUSED_RESULT __must_check
-        #elif (defined(__GNUC__) && (__GNUC__ >= 4)) || \
-            (defined(__IAR_SYSTEMS_ICC__) && (__VER__ >= 9040001))
-            #define WARN_UNUSED_RESULT __attribute__((warn_unused_result))
-        #else
-            #define WARN_UNUSED_RESULT
-        #endif
-    #endif /* WARN_UNUSED_RESULT */
-
-    #ifndef WC_MAYBE_UNUSED
-        #if (defined(__GNUC__) && (__GNUC__ >= 4)) || defined(__clang__) || defined(__IAR_SYSTEMS_ICC__)
-            #define WC_MAYBE_UNUSED __attribute__((unused))
-        #else
-            #define WC_MAYBE_UNUSED
-        #endif
-    #endif /* WC_MAYBE_UNUSED */
-
     #ifndef WC_DO_NOTHING
         #define WC_DO_NOTHING do {} while (0)
         #ifdef _MSC_VER
@@ -345,43 +326,6 @@ typedef struct w64wrapper {
              */
             #pragma warning(disable: 4127)
         #endif
-    #endif
-
-    /* use inlining if compiler allows */
-    #ifndef WC_INLINE
-    #ifndef NO_INLINE
-        #ifdef _MSC_VER
-            #define WC_INLINE __inline
-        #elif defined(__GNUC__)
-               #ifdef WOLFSSL_VXWORKS
-                   #define WC_INLINE __inline__
-               #else
-                   #define WC_INLINE inline
-               #endif
-        #elif defined(__IAR_SYSTEMS_ICC__)
-            #define WC_INLINE inline
-        #elif defined(THREADX)
-            #define WC_INLINE _Inline
-        #elif defined(__ghc__)
-            #ifndef __cplusplus
-                #define WC_INLINE __inline
-            #else
-                #define WC_INLINE inline
-            #endif
-        #elif defined(__CCRX__)
-            #define WC_INLINE inline
-        #elif defined(__DCC__)
-            #ifndef __cplusplus
-                #define WC_INLINE __inline__
-            #else
-                #define WC_INLINE inline
-            #endif
-        #else
-            #define WC_INLINE WC_MAYBE_UNUSED
-        #endif
-    #else
-        #define WC_INLINE WC_MAYBE_UNUSED
-    #endif
     #endif
 
     #if defined(HAVE_FIPS) || defined(HAVE_SELFTEST)

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -506,7 +506,7 @@ typedef struct wolfSSL_RefWithMutex wolfSSL_Ref;
 #define wolfSSL_RefWithMutexFree wolfSSL_RefFree
 #define wolfSSL_RefWithMutexInc wolfSSL_RefInc
 #define wolfSSL_RefWithMutexLock(ref) 0
-#define wolfSSL_RefWithMutexUnlock(ref) WC_DO_NOTHING
+#define wolfSSL_RefWithMutexUnlock(ref) 0
 #define wolfSSL_RefWithMutexDec wolfSSL_RefDec
 
 #else
@@ -517,7 +517,7 @@ WOLFSSL_LOCAL void wolfSSL_RefWithMutexFree(wolfSSL_RefWithMutex* ref);
 WOLFSSL_LOCAL void wolfSSL_RefWithMutexInc(wolfSSL_RefWithMutex* ref,
                                             int* err);
 WOLFSSL_LOCAL int wolfSSL_RefWithMutexLock(wolfSSL_RefWithMutex* ref);
-WOLFSSL_LOCAL void wolfSSL_RefWithMutexUnlock(wolfSSL_RefWithMutex* ref);
+WOLFSSL_LOCAL int wolfSSL_RefWithMutexUnlock(wolfSSL_RefWithMutex* ref);
 WOLFSSL_LOCAL void wolfSSL_RefWithMutexDec(wolfSSL_RefWithMutex* ref,
                                             int* isZero, int* err);
 


### PR DESCRIPTION
add `struct wolfSSL_RefWithMutex`, `wolfSSL_RefWithMutexLock`, and `wolfSSL_RefWithMutexUnlock`, and change `WOLFSSL_CTX.ref` from `wolfSSL_Ref` to `wolfSSL_RefWithMutex`.

in `wc_port.c`, rename mutexful implementations of `wolfSSL_Ref*()` to `wolfSSL_RefWithMutex*()`, and build them even if `defined(WOLFSSL_ATOMIC_OPS)`.

refactor `wolfSSL_CTX_UnloadIntermediateCerts()` to wrap the refcount check and deallocation with `wolfSSL_RefWithMutexLock()`...`wolfSSL_RefWithMutexUnlock()`.

move port-specific setup for `WARN_UNUSED_RESULT`, `WC_MAYBE_UNUSED`, and `WC_INLINE`, from `types.h` to `wc_port.h`, to make them usable by port-specific definitions later in `wc_port.h`.

when `defined(SINGLE_THREADED)` and `!defined(WOLFSSL_NO_ATOMICS)`, `typedef int wolfSSL_Atomic_Int`, so that access to `wolfSSL_Atomic_Int`s in `SINGLE_THREADED` builds is easy.

refactor fallback definitions of `wolfSSL_Atomic_Int_FetchAdd` and `wolfSSL_Atomic_Int_FetchSub` as `WC_INLINE` functions to avoid `-Wunused-result`.

tested with `wolfssl-multi-test.sh ... single-threaded no-atomics super-quick-check` with `single-threaded` enlarged to include `"${ENABLE_ALL_TEST_FLAGS[@]}"`, and `no-atomics` a new scenario with `"${ENABLE_ALL_TEST_FLAGS[@]}" CPPFLAGS=-DWOLFSSL_NO_ATOMICS`
