### PR TITLE
20241114-wc_mp_sign_t

### DIFF
--- a/wolfcrypt/src/wolfmath.c
+++ b/wolfcrypt/src/wolfmath.c
@@ -149,10 +149,10 @@ int mp_cond_copy(mp_int* a, int copy, mp_int* b)
         for (; i < b->used; i++) {
             b->dp[i] ^= (get_digit(a, (int)i) ^ get_digit(b, (int)i)) & mask;
         }
-        b->used ^= (a->used ^ b->used) & (mp_size_t)mask;
+        b->used ^= (a->used ^ b->used) & (wc_mp_size_t)mask;
 #if (!defined(WOLFSSL_SP_MATH) && !defined(WOLFSSL_SP_MATH_ALL)) || \
     defined(WOLFSSL_SP_INT_NEGATIVE)
-        b->sign ^= (mp_sign_t)(a->sign ^ b->sign) & (mp_sign_t)mask;
+        b->sign ^= (wc_mp_sign_t)(a->sign ^ b->sign) & (wc_mp_sign_t)mask;
 #endif
     }
 
@@ -194,7 +194,7 @@ int mp_rand(mp_int* a, int digits, WC_RNG* rng)
         ret = BAD_FUNC_ARG;
     }
     if (ret == MP_OKAY) {
-        a->used = (mp_size_t)digits;
+        a->used = (wc_mp_size_t)digits;
     }
 #endif
     /* fill the data with random bytes */

--- a/wolfssl/wolfcrypt/integer.h
+++ b/wolfssl/wolfcrypt/integer.h
@@ -222,8 +222,8 @@ typedef int           mp_err;
     #define WOLF_BIGINT_DEFINED
 #endif
 
-#define mp_size_t int
-#define mp_sign_t int
+#define wc_mp_size_t int
+#define wc_mp_sign_t int
 
 /* the mp_int structure */
 typedef struct mp_int {

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -704,7 +704,7 @@ typedef struct sp_ecc_ctx {
         if ((a)->used > 0) {                                                   \
             for (ii = (int)(a)->used - 1; ii >= 0 && (a)->dp[ii] == 0; ii--) { \
             }                                                                  \
-            (a)->used = (mp_size_t)(ii + 1);                                   \
+            (a)->used = (wc_mp_size_t)(ii + 1);                                \
         }                                                                      \
     } while (0)
 
@@ -880,10 +880,10 @@ typedef unsigned int sp_size_t;
 #endif
 
 /* Type for number of digits. */
-#define mp_size_t    sp_size_t
+#define wc_mp_size_t sp_size_t
 #ifdef WOLFSSL_SP_INT_NEGATIVE
     typedef sp_uint8 sp_sign_t;
-    #define mp_sign_t    sp_sign_t
+    #define wc_mp_sign_t sp_sign_t
 #endif
 
 /**

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -379,8 +379,8 @@ while (0)
     #define WOLF_BIGINT_DEFINED
 #endif
 
-#define mp_size_t int
-#define mp_sign_t int
+#define wc_mp_size_t int
+#define wc_mp_sign_t int
 
 /* a FP type */
 typedef struct fp_int {


### PR DESCRIPTION
rename `mp_sign_t` to `wc_mp_sign_t` and `mp_size_t` to `wc_mp_size_t`.

note `mp_sign_t` added by 603c03c0be.

ZD#18959

tested with `wolfssl-multi-test.sh ... super-quick-check`
