### PR TITLE
remove trailing exit code

### DIFF
--- a/IDE/Espressif/ESP-IDF/setup.sh
+++ b/IDE/Espressif/ESP-IDF/setup.sh
@@ -159,4 +159,3 @@ if [ "${WOLFSSL_SETUP_VERBOSE}" == "true" ]; then
   echo "Copy complete!"
 fi
 
-exit 1


### PR DESCRIPTION
# Description

Removes trailing exit error code `1` value as noted in https://github.com/wolfSSL/wolfssl/pull/8062 

There's no known reason to always exit with a non-zero error during setup.

@syncom sorry for delay on this; good observation & suggestion for change.

Fixes zd# n/a

# Testing

How did you test?

not tested.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
