### PR TITLE
Fix missing cast

### DIFF
--- a/src/x509_str.c
+++ b/src/x509_str.c
@@ -1453,7 +1453,8 @@ int wolfSSL_X509_STORE_set_default_paths(WOLFSSL_X509_STORE* store)
 int X509StoreLoadCertBuffer(WOLFSSL_X509_STORE *str,
                                         byte *buf, word32 bufLen, int type)
 {
-    int ret = WC_NO_ERR_TRACE(WOLFSSL_SUCCESS);
+    int ret = WOLFSSL_SUCCESS;
+
     WOLFSSL_X509 *x509 = NULL;
 
     if (str == NULL || buf == NULL) {

--- a/tests/api.c
+++ b/tests/api.c
@@ -76347,7 +76347,7 @@ static int test_wolfSSL_X509V3_EXT_aia(void)
         sk = NULL;
     }
     /* Extension stack set but empty. */
-    ExpectNotNull(aia = wolfSSL_X509V3_EXT_d2i(ext));
+    ExpectNotNull(aia = (WOLFSSL_AUTHORITY_INFO_ACCESS *)wolfSSL_X509V3_EXT_d2i(ext));
     wolfSSL_AUTHORITY_INFO_ACCESS_free(aia);
     aia = NULL;
 
@@ -76367,7 +76367,7 @@ static int test_wolfSSL_X509V3_EXT_aia(void)
             node = NULL;
         }
     }
-    ExpectNotNull(aia = wolfSSL_X509V3_EXT_d2i(ext));
+    ExpectNotNull(aia = (WOLFSSL_AUTHORITY_INFO_ACCESS *)wolfSSL_X509V3_EXT_d2i(ext));
     wolfSSL_ACCESS_DESCRIPTION_free(NULL);
 
     wolfSSL_AUTHORITY_INFO_ACCESS_pop_free(aia,


### PR DESCRIPTION
# Description

Introduced in PR #8176. Shows up in wolfSSL/job/nightly-g++-test-v2/1399/parsed_console/ test.
```
In file included from tests/api.c:32:
tests/api.c: In function ‘int test_wolfSSL_X509V3_EXT_aia()’:

tests/api.c:76350:47: error: invalid conversion from ‘void*’ to ‘WOLFSSL_AUTHORITY_INFO_ACCESS*’ {aka ‘WOLFSSL_STACK*’} [-fpermissive]
76350 |     ExpectNotNull(aia = wolfSSL_X509V3_EXT_d2i(ext));
      |                         ~~~~~~~~~~~~~~~~~~~~~~^~~~~
      |                                               |
      |                                               void*
./tests/unit.h:182:15: note: in definition of macro ‘Expect’
  182 |         if (!(test))                                                         \
      |               ^~~~
tests/api.c:76350:5: note: in expansion of macro ‘ExpectNotNull’
76350 |     ExpectNotNull(aia = wolfSSL_X509V3_EXT_d2i(ext));
      |     ^~~~~~~~~~~~~

tests/api.c:76370:47: error: invalid conversion from ‘void*’ to ‘WOLFSSL_AUTHORITY_INFO_ACCESS*’ {aka ‘WOLFSSL_STACK*’} [-fpermissive]
76370 |     ExpectNotNull(aia = wolfSSL_X509V3_EXT_d2i(ext));
      |                         ~~~~~~~~~~~~~~~~~~~~~~^~~~~
      |                                               |
      |                                               void*
./tests/unit.h:182:15: note: in definition of macro ‘Expect’
  182 |         if (!(test))                                                         \
      |               ^~~~
tests/api.c:76370:5: note: in expansion of macro ‘ExpectNotNull’
76370 |     ExpectNotNull(aia = wolfSSL_X509V3_EXT_d2i(ext));
      |     ^~~~~~~~~~~~~
```

# Testing

Tested patch on same server which can reproduce it.