### PR TITLE
20241115-macro-fixes

### DIFF
--- a/IDE/apple-universal/wolfssl-multiplatform/wolfssl-multiplatform/simple_client_example.h
+++ b/IDE/apple-universal/wolfssl-multiplatform/wolfssl-multiplatform/simple_client_example.h
@@ -19,9 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#ifndef simple_client_example_h
-#define simple_client_example_h
+#ifndef SIMPLE_CLIENT_EXAMPLE_H
+#define SIMPLE_CLIENT_EXAMPLE_H
 
 int simple_client_example(void);
 
-#endif /* simple_client_example_h */
+#endif /* SIMPLE_CLIENT_EXAMPLE_H */

--- a/IDE/apple-universal/wolfssl-multiplatform/wolfssl-multiplatform/wolfssl_test_driver.h
+++ b/IDE/apple-universal/wolfssl-multiplatform/wolfssl-multiplatform/wolfssl_test_driver.h
@@ -19,9 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#ifndef wolfssl_test_driver_h
-#define wolfssl_test_driver_h
+#ifndef WOLFSSL_TEST_DRIVER_H
+#define WOLFSSL_TEST_DRIVER_H
 
 void wolfssl_test(void);
 
-#endif /* wolfssl_test_driver_h */
+#endif /* WOLFSSL_TEST_DRIVER_H */

--- a/src/internal.c
+++ b/src/internal.c
@@ -36291,7 +36291,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                                     goto exit_sske;
                                 }
                             }
-                            #if defined(HAVE_E25519) || defined(HAVE_ED448)
+                            #if defined(HAVE_ED25519) || defined(HAVE_ED448)
                             FALL_THROUGH;
                             #endif
                         #endif /*  WOLFSSL_CHECK_SIG_FAULTS */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -17528,7 +17528,7 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
     #ifdef WOLFSSL_MD2
         { WC_NID_md2, MD2h, oidHashType, "MD2", "md2"},
     #endif
-    #ifdef WOLFSSL_MD5
+    #ifndef NO_MD5
         { WC_NID_md5, MD5h, oidHashType, "MD5", "md5"},
     #endif
     #ifndef NO_SHA

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -34332,7 +34332,7 @@ int wc_EccPrivateKeyDecode(const byte* input, word32* inOutIdx, ecc_key* key,
     byte version = 0;
     int ret = 0;
     int curve_id = ECC_CURVE_DEF;
-#if defined(HAVE_PKCS8) || defined(HAVE_PKCS12) || defined(SM2)
+#if defined(HAVE_PKCS8) || defined(HAVE_PKCS12) || defined(WOLFSSL_SM2)
     word32 algId = 0;
     word32 eccOid = 0;
 #endif
@@ -34342,7 +34342,7 @@ int wc_EccPrivateKeyDecode(const byte* input, word32* inOutIdx, ecc_key* key,
         ret = BAD_FUNC_ARG;
     }
 
-#if defined(HAVE_PKCS8) || defined(HAVE_PKCS12) || defined(SM2)
+#if defined(HAVE_PKCS8) || defined(HAVE_PKCS12) || defined(WOLFSSL_SM2)
     /* if has pkcs8 header skip it */
     if (ToTraditionalInline_ex2(input, inOutIdx, inSz, &algId, &eccOid) < 0) {
         /* ignore error, did not have pkcs8 header */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -21930,9 +21930,6 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_test(void)
 #endif
 
 #ifdef WOLFSSL_TEST_CERT
-#if defined(WOLFSSL_MDK_ARM)
-    #define sizeof(s) XSTRLEN((char *)(s))
-#endif
 
 #ifdef USE_CERT_BUFFERS_1024
     XMEMCPY(tmp, client_cert_der_1024, (size_t)sizeof_client_cert_der_1024);
@@ -21961,9 +21958,6 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_test(void)
     ERROR_OUT(WC_TEST_RET_ENC_NC, exit_rsa);
 #endif
 
-#ifdef sizeof
-    #undef sizeof
-#endif
     InitDecodedCert(cert, tmp, (word32)bytes, NULL);
 
     ret = ParseCert(cert, CERT_TYPE, NO_VERIFY, NULL);

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -973,6 +973,25 @@
     #define NO_AESGCM_AEAD
 #endif
 
+#if defined(BUILD_TLS_RSA_WITH_AES_128_CCM_8) || \
+    defined(BUILD_TLS_RSA_WITH_AES_256_CCM_8) || \
+    defined(BUILD_TLS_PSK_WITH_AES_128_CCM_8) || \
+    defined(BUILD_TLS_PSK_WITH_AES_128_CCM) || \
+    defined(BUILD_TLS_PSK_WITH_AES_256_CCM_8) || \
+    defined(BUILD_TLS_PSK_WITH_AES_256_CCM) || \
+    defined(BUILD_TLS_DHE_PSK_WITH_AES_128_CCM) || \
+    defined(BUILD_TLS_DHE_PSK_WITH_AES_256_CCM) || \
+    defined(BUILD_TLS_ECDHE_ECDSA_WITH_AES_128_CCM) || \
+    defined(BUILD_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8) || \
+    defined(BUILD_TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8) || \
+    defined(BUILD_TLS_AES_128_CCM_SHA256) || \
+    defined(BUILD_TLS_AES_128_CCM_8_SHA256)
+    #define BUILD_AESCCM
+#else
+    /* No AES-CCM cipher suites available with build */
+    #define NO_AESCCM_AEAD
+#endif
+
 #if defined(BUILD_TLS_ECDHE_ECDSA_WITH_ARIA_128_GCM_SHA256) || \
     defined(BUILD_TLS_ECDHE_ECDSA_WITH_ARIA_256_GCM_SHA384)
     #define BUILD_ARIA

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -77,6 +77,7 @@ decouple library dependencies with standard string, memory and so on.
     #endif
 
     #ifndef WOLFSSL_TYPES
+        #define WOLFSSL_TYPES
         #ifndef byte
             /* If using C++ C17 or later and getting:
              *   "error: reference to 'byte' is ambiguous", this is caused by


### PR DESCRIPTION
fixes for misspelled/malformed macro names, and add missing `BUILD_AESCCM` setup in `wolfssl/internal.h`

tested with `wolfssl-multi-test.sh ... wolfsm-all-gcc-latest quantum-safe-wolfssl-all-gcc-latest super-quick-check`
