### PR TITLE
KeyShareEntry: include private key fields for KYBER

### DIFF
--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3539,7 +3539,7 @@ typedef struct KeyShareEntry {
     word32                keyLen;    /* Key size (bytes)                  */
     byte*                 pubKey;    /* Public key                        */
     word32                pubKeyLen; /* Public key length                 */
-#if !defined(NO_DH) || defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
+#if !defined(NO_DH) || defined(WOLFSSL_HAVE_KYBER)
     byte*                 privKey;   /* Private key - DH and PQ KEMs only */
     word32                privKeyLen;/* Only for PQ KEMs. */
 #endif


### PR DESCRIPTION
# Description

Originallt HAVE_PQC and then changed to HAVE_FALCON and HAVE_DILITHIUM. The KEM PQC algorithm is actually KYBER.

Fixes zd#18923

# Testing

./configure --enable-kyber --disable-dh
make

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
