### PR TITLE
Fix cryptodev debug output

### DIFF
--- a/wolfcrypt/src/port/devcrypto/wc_devcrypto.c
+++ b/wolfcrypt/src/port/devcrypto/wc_devcrypto.c
@@ -175,8 +175,13 @@ int wc_DevCryptoCreate(WC_CRYPTODEV* ctx, int type, byte* key, word32 keySz)
         WOLFSSL_MSG("Error getting session info");
         return WC_DEVCRYPTO_E;
     }
-    printf("Using %s with driver %s\n", sesInfo.hash_info.cra_name,
-        sesInfo.hash_info.cra_driver_name);
+    if (ctx->sess.cipher == 0) {
+        printf("Using %s with driver %s\n", sesInfo.hash_info.cra_name,
+            sesInfo.hash_info.cra_driver_name);
+    } else {
+        printf("Using %s with driver %s\n", sesInfo.cipher_info.cra_name,
+            sesInfo.cipher_info.cra_driver_name);
+    }
 #endif
     (void)key;
     (void)keySz;


### PR DESCRIPTION
# Description

Cryptodev has two sections for the session info struct, cipher and hash. Our debug mode was using hash for the output even if we were using cipher, so would output random data. Simple 'if' statement to do the correct thing.

# Testing

Enabling cryptodev and `DEBUG_DEVCRYPTO` on an STM32MP13 with OpenSTLinux and running wolfcrypt benchmark to check both hash and cipher outputs work.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
