### PR TITLE
change optval type to match system

### DIFF
--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -416,7 +416,7 @@
         #endif
     #endif
     #ifndef XSOCKOPT_TYPE_OPTVAL_TYPE
-        #ifdef USE_WINDOWS_API
+        #ifndef USE_WINDOWS_API
             #define XSOCKOPT_TYPE_OPTVAL_TYPE void*
         #else
             #define XSOCKOPT_TYPE_OPTVAL_TYPE char*


### PR DESCRIPTION
Found when reviewing this PR https://github.com/wolfSSL/wolfssl/pull/8197

### Linux:
man getsockopt 
```
       int getsockopt(int sockfd, int level, int optname,
                      void *optval, socklen_t *optlen);
```

### Windows
https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockopt
```
int getsockopt(
  [in]      SOCKET s,
  [in]      int    level,
  [in]      int    optname,
  [out]     char   *optval,
  [in, out] int    *optlen
);
```