### PR TITLE
Fixes for RSA TSIP RSA Sign/Verify

### DIFF
--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_tsip_unit_test.c
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_tsip_unit_test.c
@@ -408,10 +408,10 @@ static int tsip_aesgcm256_test(int prnt, tsip_aes_key_index_t* aes256_key)
         printf(" tsip_aes256_gcm_test() ");
     }
 
-    ForceZero(resultT, sizeof(resultT));
-    ForceZero(resultC, sizeof(resultC));
-    ForceZero(resultP, sizeof(resultP));
-    ForceZero(&userContext, sizeof(TsipUserCtx));
+    XMEMSET(resultT, 0, sizeof(resultT));
+    XMEMSET(resultC, 0, sizeof(resultC));
+    XMEMSET(resultP, 0, sizeof(resultP));
+    XMEMSET(&userContext, 0, sizeof(TsipUserCtx));
 
     if (wc_AesInit(enc, NULL, INVALID_DEVID) != 0) {
         ret = -1;
@@ -434,10 +434,11 @@ static int tsip_aesgcm256_test(int prnt, tsip_aes_key_index_t* aes256_key)
     }
 
     /* AES-GCM encrypt and decrypt both use AES encrypt internally */
-    result = wc_tsip_AesGcmEncrypt(enc, resultC, p, sizeof(p),
-                        (byte*)iv1, sizeof(iv1), resultT, sizeof(resultT),
-                        a, sizeof(a), &userContext);
-
+    result = wc_tsip_AesGcmEncrypt(enc,
+        resultC, p, sizeof(p),
+        (byte*)iv1, sizeof(iv1), resultT, sizeof(resultT),
+        a, sizeof(a), &userContext
+    );
     if (result != 0) {
         ret = -4;
         goto out;
@@ -451,9 +452,11 @@ static int tsip_aesgcm256_test(int prnt, tsip_aes_key_index_t* aes256_key)
         dec->ctx.keySize = enc->keylen;
     }
 
-    result = wc_tsip_AesGcmDecrypt(dec, resultP, resultC, sizeof(c1),
-                        iv1, sizeof(iv1), resultT, sizeof(resultT),
-                        a, sizeof(a), &userContext);
+    result = wc_tsip_AesGcmDecrypt(dec,
+        resultP, resultC, sizeof(c1),
+        iv1, sizeof(iv1), resultT, sizeof(resultT),
+        a, sizeof(a), &userContext
+    );
     if (result != 0){
         ret = -8;
         goto out;
@@ -469,18 +472,21 @@ static int tsip_aesgcm256_test(int prnt, tsip_aes_key_index_t* aes256_key)
 
     wc_AesGcmSetKey(enc, k1, sizeof(k1));
     /* AES-GCM encrypt and decrypt both use AES encrypt internally */
-    result = wc_tsip_AesGcmEncrypt(enc, resultC, p, sizeof(p), iv1, sizeof(iv1),
-                                resultT + 1, sizeof(resultT) - 1,
-                                a, sizeof(a), &userContext);
+    result = wc_tsip_AesGcmEncrypt(enc,
+        resultC, p, sizeof(p), iv1, sizeof(iv1),
+        resultT + 1, sizeof(resultT) - 1,
+        a, sizeof(a), &userContext
+    );
     if (result != 0) {
         ret = -10;
         goto out;
     }
 
-    result = wc_tsip_AesGcmDecrypt(enc, resultP, resultC, sizeof(p),
-                            iv1, sizeof(iv1), resultT + 1, sizeof(resultT) - 1,
-                            a, sizeof(a), &userContext);
-
+    result = wc_tsip_AesGcmDecrypt(enc,
+        resultP, resultC, sizeof(p),
+        iv1, sizeof(iv1), resultT + 1, sizeof(resultT) - 1,
+        a, sizeof(a), &userContext
+    );
     if (result != 0) {
         ret = -11;
         goto out;
@@ -568,9 +574,9 @@ static int tsip_aesgcm128_test(int prnt, tsip_aes_key_index_t* aes128_key)
         0x31, 0x2e, 0x2a, 0xf9, 0x57, 0x7a, 0x1e, 0xa6
     };
 
-    byte resultT[16];
-    byte resultP[60 + AES_BLOCK_SIZE];
-    byte resultC[60 + AES_BLOCK_SIZE];
+    byte resultT[sizeof(t3)];
+    byte resultP[sizeof(p3) + AES_BLOCK_SIZE];
+    byte resultC[sizeof(p3) + AES_BLOCK_SIZE];
     int  result = 0;
     int ret;
 
@@ -581,10 +587,10 @@ static int tsip_aesgcm128_test(int prnt, tsip_aes_key_index_t* aes128_key)
         printf(" tsip_aes128_gcm_test() ");
     }
 
-    ForceZero(resultT, sizeof(resultT));
-    ForceZero(resultC, sizeof(resultC));
-    ForceZero(resultP, sizeof(resultP));
-    ForceZero(&userContext, sizeof(TsipUserCtx));
+    XMEMSET(resultT, 0, sizeof(resultT));
+    XMEMSET(resultC, 0, sizeof(resultC));
+    XMEMSET(resultP, 0, sizeof(resultP));
+    XMEMSET(&userContext, 0, sizeof(TsipUserCtx));
 
     if (wc_AesInit(enc, NULL, INVALID_DEVID) != 0) {
         ret = -1;
@@ -607,21 +613,27 @@ static int tsip_aesgcm128_test(int prnt, tsip_aes_key_index_t* aes128_key)
         enc->ctx.keySize = enc->keylen;
     }
     /* AES-GCM encrypt and decrypt both use AES encrypt internally */
-    result = wc_tsip_AesGcmEncrypt(enc, resultC, p3, sizeof(p3),
-                                        iv3, sizeof(iv3),
-                                        resultT, sizeof(t3),
-                                        a3, sizeof(a3), &userContext);
+    result = wc_tsip_AesGcmEncrypt(enc,
+        resultC, p3, sizeof(p3),
+        iv3, sizeof(iv3),
+        resultT, sizeof(t3),
+        a3, sizeof(a3), &userContext
+    );
     if (result != 0) {
         ret = -4;
         goto out;
     }
-    result = wc_tsip_AesGcmDecrypt(enc, resultP, resultC, sizeof(c3),
-                                iv3, sizeof(iv3), resultT, sizeof(resultT),
-                                a3, sizeof(a3), &userContext);
+
+    result = wc_tsip_AesGcmDecrypt(enc,
+        resultP, resultC, sizeof(c3),
+        iv3, sizeof(iv3), resultT, sizeof(resultT),
+        a3, sizeof(a3), &userContext
+    );
     if (result != 0) {
         ret = -5;
         goto out;
     }
+
     if (XMEMCMP(p3, resultP, sizeof(p3))) {
         ret = -6;
         goto out;

--- a/wolfcrypt/src/port/Renesas/renesas_common.c
+++ b/wolfcrypt/src/port/Renesas/renesas_common.c
@@ -279,6 +279,16 @@ static int Renesas_cmn_CryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
             }
         #endif
         }
+        if (info->pk.type == WC_PK_TYPE_RSA_GET_SIZE) {
+            if (cbInfo->wrappedKeyType == TSIP_KEY_TYPE_RSA2048) {
+                *info->pk.rsa_get_size.keySize = 256;
+                ret = 0;
+            }
+            else if (cbInfo->wrappedKeyType == TSIP_KEY_TYPE_RSA1024) {
+                *info->pk.rsa_get_size.keySize = 128;
+                ret = 0;
+            }
+        }
     #endif /* !NO_RSA */
     #if defined(HAVE_ECC)
         #if defined(WOLFSSL_RENESAS_TSIP_TLS)

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_rsa.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_rsa.c
@@ -234,7 +234,7 @@ int wc_tsip_RsaFunction(wc_CryptoInfo* info, TsipUserCtx* tuc)
                 plain.pdata = (uint8_t*)info->pk.rsa.in;
                 plain.data_length = info->pk.rsa.inLen;
                 cipher.pdata = (uint8_t*)info->pk.rsa.out;
-                cipher.data_length = info->pk.rsa.outLen;
+                cipher.data_length = *(info->pk.rsa.outLen);
 
                 if (keySize == TSIP_KEY_TYPE_RSA1024) {
                     ret = R_TSIP_RsaesPkcs1024Encrypt(&plain, &cipher,
@@ -250,13 +250,13 @@ int wc_tsip_RsaFunction(wc_CryptoInfo* info, TsipUserCtx* tuc)
                     return BAD_FUNC_ARG;
                 }
                 if (ret == 0) {
-                    info->pk.rsa.outLen = cipher.data_length;
+                    *(info->pk.rsa.outLen) = cipher.data_length;
                 }
             }
             else if (type == RSA_PRIVATE_DECRYPT || type == RSA_PRIVATE_ENCRYPT)
             {
                 plain.pdata = (uint8_t*)info->pk.rsa.out;
-                plain.data_length = info->pk.rsa.outLen;
+                plain.data_length = *(info->pk.rsa.outLen);
                 cipher.pdata = (uint8_t*)info->pk.rsa.in;
                 cipher.data_length = info->pk.rsa.inLen;
 
@@ -274,7 +274,7 @@ int wc_tsip_RsaFunction(wc_CryptoInfo* info, TsipUserCtx* tuc)
                     return BAD_FUNC_ARG;
                 }
                 if (ret == 0) {
-                    info->pk.rsa.outLen = plain.data_length;
+                    *(info->pk.rsa.outLen) = plain.data_length;
                 }
             }
             tsip_hw_unlock();
@@ -314,13 +314,13 @@ int wc_tsip_RsaVerifyPkcs(wc_CryptoInfo* info, TsipUserCtx* tuc)
     }
 
     if (tsip_RsakeyImport(tuc) == 0) {
-        hashData.pdata = (uint8_t*)info->pk.rsa.in;
-        hashData.data_length = info->pk.rsa.inLen;
+        hashData.pdata = (uint8_t*)info->pk.rsa.out;
+        hashData.data_length = *(info->pk.rsa.outLen);
         hashData.data_type =
             tuc->keyflgs_crypt.bits.message_type;/* message 0, hash 1 */
 
-        sigData.pdata = (uint8_t*)info->pk.rsa.out;
-        sigData.data_length = info->pk.rsa.outLen;
+        sigData.pdata = (uint8_t*)info->pk.rsa.in;
+        sigData.data_length = info->pk.rsa.inLen;
 
         if ((ret = tsip_hw_lock()) == 0) {
             switch (tuc->wrappedKeyType) {

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1497,6 +1497,10 @@ typedef struct w64wrapper {
         #if !defined(__MINGW32__)
             #define WOLFSSL_THREAD_NO_JOIN __cdecl
         #endif
+    #elif defined(THREADX)
+        typedef unsigned int   THREAD_RETURN;
+        typedef TX_THREAD      THREAD_TYPE;
+        #define WOLFSSL_THREAD
     #else
         typedef unsigned int  THREAD_RETURN;
         typedef size_t        THREAD_TYPE;


### PR DESCRIPTION
# Description

* Fixes for RSA TSIP RSA Sign/Verify.
* Fix for RX TSIP AES GCM 128 unit test resultP/C sizes causing failure.
* Added THREADX threading support.

Fixes customer issue with Renesas RX TSIP.

# Testing

Tested on RX72N EnvisionKit. 

```
Start wolf tsip crypt Test

 simple crypt test by using TSIP
 sha_test() passed 
 sha256_test() passed 
 tsip_aes_cbc_test()  passed 
 tsip_aes256_test()  passed 
 tsip_aes128_gcm_test()  passed 
 tsip_aes256_gcm_test()  passed 
 tsip_rsa_test(2048) passed 
 tsip_rsa_SignVerify_test(2048) passed 

End wolf tsip crypt Test
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
