### PR TITLE
/dev/crypto auth error fix/adjustment for benchmark

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1991,6 +1991,11 @@ static const char* bench_result_words2[][5] = {
 #endif
 
 
+
+#if defined(WOLFSSL_DEVCRYPTO) && defined(WOLFSSL_AUTHSZ_BENCH)
+    #warning Large/Unalligned AuthSz could result in errors with /dev/crypto
+#endif
+
 /* use kB instead of mB for embedded benchmarking */
 #ifdef BENCH_EMBEDDED
     #ifndef BENCH_NTIMES
@@ -4798,6 +4803,14 @@ void bench_gmac(int useDeviceID)
     const char* gmacStr = "GMAC Default";
 #endif
 
+/* Implementations of /Dev/Crypto will error out if the size of Auth in is */
+/* greater than the system's page size */
+#if defined(WOLFSSL_DEVCRYPTO) && defined(WOLFSSL_AUTHSZ_BENCH)
+    bench_size = WOLFSSL_AUTHSZ_BENCH;
+#elif defined(WOLFSSL_DEVCRYPTO)
+    bench_size = sysconf(_SC_PAGESIZE);
+#endif
+
     /* init keys */
     XMEMSET(bench_plain, 0, bench_size);
     XMEMSET(tag, 0, sizeof(tag));
@@ -4828,7 +4841,13 @@ void bench_gmac(int useDeviceID)
 #ifdef MULTI_VALUE_STATISTICS
     bench_multi_value_stats(max, min, sum, squareSum, runs);
 #endif
-
+#if defined(WOLFSSL_DEVCRYPTO)
+    if (ret != 0 && (bench_size > sysconf(_SC_PAGESIZE))) {
+        printf("authIn Buffer Size[%d] greater than System Page Size[%ld]\n",
+                        bench_size, sysconf(_SC_PAGESIZE));
+    }
+    bench_size = BENCH_SIZE;
+#endif
 }
 
 #endif /* HAVE_AESGCM */

--- a/wolfcrypt/src/port/devcrypto/devcrypto_aes.c
+++ b/wolfcrypt/src/port/devcrypto/devcrypto_aes.c
@@ -324,6 +324,11 @@ static int wc_DevCrypto_AesGcm(Aes* aes, byte* out, byte* in, word32 sz,
                       dir, (byte*)authIn, authInSz, authTag, authTagSz);
     ret = ioctl(aes->ctx.cfd, CIOCAUTHCRYPT, &crt);
     if (ret != 0) {
+        #ifdef WOLFSSL_DEBUG
+        if (authInSz > sysconf(_SC_PAGESIZE)) {
+            WOLFSSL_MSG("authIn Buffer greater than System Page Size");
+        }
+        #endif
         if (dir == COP_DECRYPT) {
             return AES_GCM_AUTH_E;
         }


### PR DESCRIPTION
When configuring wolfSSL to use `/dev/crypto` and running our benchmark tool, GMAC benchmarks will throw the `-265` error code after calling this [line](https://github.com/wolfSSL/wolfssl/blob/42825e82d2ee849526a8c1405f9cd256ccfb5a5d/wolfcrypt/src/port/devcrypto/devcrypto_aes.c#L325).

This is because is due to this [line](https://github.com/cryptodev-linux/cryptodev-linux/blob/277d4574c10bb8e16ab6ab3f38b8e1cb6cd6c678/authenc.c#L708) in `/dev/crypto` driver.

This PR adds better debugging and will set size when running GMAC to that of the system's page size. It also allows for an override for this size by setting the macro `WOLFSSL_AUTHSZ_BENCH`
