### PR TITLE
Fix Renesas test

### DIFF
--- a/IDE/Renesas/e2studio/RA6M4/test/src/SEGGER_RTT/myprint.c
+++ b/IDE/Renesas/e2studio/RA6M4/test/src/SEGGER_RTT/myprint.c
@@ -18,6 +18,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
+
+#include <stdarg.h>
 #include "SEGGER_RTT.h"
 
 #define SEGGER_INDEX            (0)

--- a/IDE/Renesas/e2studio/RA6M4/test/src/wolf_client.c
+++ b/IDE/Renesas/e2studio/RA6M4/test/src/wolf_client.c
@@ -23,6 +23,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdarg.h> /* var_arg */
 #include <sys/time.h>
 #include "wolfssl/wolfcrypt/settings.h"
 #include "wolfssl/ssl.h"

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_demo.c
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_demo.c
@@ -23,9 +23,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-
-
-
+#include <stdarg.h>
 
 #include <wolfssl/wolfcrypt/settings.h>
 #include "wolfssl/ssl.h"

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -476,6 +476,7 @@
     #endif
 #elif defined(WOLFSSL_ZEPHYR)
     #include <stdio.h>
+    #include <stdarg.h>
     #define BENCH_EMBEDDED
     #define printf printfk
     static int printfk(const char *fmt, ...)

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3051,15 +3051,18 @@ WOLFSSL_API WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_set_peer_cert_chain(WOLFSSL* ss
 WOLFSSL_API int wolfSSL_want_read(WOLFSSL* ssl);
 WOLFSSL_API int wolfSSL_want_write(WOLFSSL* ssl);
 
-#include <stdarg.h> /* var_arg */
+
 #ifdef OPENSSL_EXTRA
 WOLFSSL_API int wolfSSL_want(WOLFSSL* ssl);
 
 WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_CTX_get0_privatekey(const WOLFSSL_CTX* ctx);
 
+#include <stdarg.h> /* var_arg */
 WOLFSSL_API int wolfSSL_BIO_vprintf(WOLFSSL_BIO* bio, const char* format,
                                                             va_list args);
 WOLFSSL_API int wolfSSL_BIO_printf(WOLFSSL_BIO* bio, const char* format, ...);
+
+
 WOLFSSL_API int wolfSSL_BIO_dump(WOLFSSL_BIO *bio, const char* buf, int length);
 WOLFSSL_API int wolfSSL_ASN1_UTCTIME_print(WOLFSSL_BIO* bio,
                                          const WOLFSSL_ASN1_UTCTIME* a);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3051,12 +3051,12 @@ WOLFSSL_API WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_set_peer_cert_chain(WOLFSSL* ss
 WOLFSSL_API int wolfSSL_want_read(WOLFSSL* ssl);
 WOLFSSL_API int wolfSSL_want_write(WOLFSSL* ssl);
 
+#include <stdarg.h> /* var_arg */
 #ifdef OPENSSL_EXTRA
 WOLFSSL_API int wolfSSL_want(WOLFSSL* ssl);
 
 WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_CTX_get0_privatekey(const WOLFSSL_CTX* ctx);
 
-#include <stdarg.h> /* var_arg */
 WOLFSSL_API int wolfSSL_BIO_vprintf(WOLFSSL_BIO* bio, const char* format,
                                                             va_list args);
 WOLFSSL_API int wolfSSL_BIO_printf(WOLFSSL_BIO* bio, const char* format, ...);

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1520,8 +1520,12 @@ extern void uITRON4_free(void *p) ;
 #ifdef FREERTOS_TCP
     #if !defined(NO_WOLFSSL_MEMORY) && !defined(XMALLOC_USER) && \
         !defined(WOLFSSL_STATIC_MEMORY)
-        #define XMALLOC(s, h, type)  pvPortMalloc((s)) /* native heap */
-        #define XFREE(p, h, type)    vPortFree((p)) /* native heap */
+        #ifndef XMALLOC
+            #define XMALLOC(s, h, type)  pvPortMalloc((s)) /* native heap */
+        #endif
+        #ifndef XFREE
+            #define XFREE(p, h, type)    vPortFree((p)) /* native heap */
+        #endif
     #endif
 
     #define WOLFSSL_GENSEED_FORTEST

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -768,7 +768,7 @@ typedef struct w64wrapper {
         #ifndef USE_WINDOWS_API
             #if defined(WOLFSSL_ESPIDF) && \
                 (!defined(NO_ASN_TIME) && defined(HAVE_PKCS7))
-                    #include<stdarg.h>
+                    #include <stdarg.h>
                     /* later gcc than 7.1 introduces -Wformat-truncation    */
                     /* In cases when truncation is expected the caller needs*/
                     /* to check the return value from the function so that  */
@@ -819,17 +819,18 @@ typedef struct w64wrapper {
             #if defined(_MSC_VER) || defined(__CYGWIN__) || defined(__MINGW32__)
                 #if defined(_MSC_VER) && (_MSC_VER >= 1900)
                     /* Beginning with the UCRT in Visual Studio 2015 and
-                       Windows 10, snprintf is no longer identical to
-                       _snprintf. The snprintf function behavior is now
-                       C99 standard compliant. */
+                     * Windows 10, snprintf is no longer identical to
+                     * _snprintf. The snprintf function behavior is now
+                     * C99 standard compliant. */
                     #include <stdio.h>
                     #define XSNPRINTF snprintf
                 #else
                     /* 4996 warning to use MS extensions e.g., _sprintf_s
-                       instead of _snprintf */
+                     * instead of _snprintf */
                     #if !defined(__MINGW32__)
                     #pragma warning(disable: 4996)
                     #endif
+                    #include <stdarg.h>
                     static WC_INLINE
                     int xsnprintf(char *buffer, size_t bufsize,
                             const char *format, ...) {


### PR DESCRIPTION
In PR #8182 this line was accidentally wrapped in `#ifdef OPENSSL_EXTRA`.