### PR TITLE
20241125-linuxkm-aarch64-pie

### DIFF
--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -118,6 +118,11 @@
     _Pragma("GCC diagnostic ignored \"-Wcast-function-type\""); /* needed for kernel 4.14.336 */
 
     #include <linux/kconfig.h>
+
+    #if defined(__PIE__) && defined(CONFIG_ARM64)
+        #define alt_cb_patch_nops my__alt_cb_patch_nops
+    #endif
+
     #include <linux/kernel.h>
     #include <linux/ctype.h>
 
@@ -666,6 +671,18 @@
 
         #ifdef WOLFSSL_DEBUG_BACKTRACE_ERROR_CODES
         typeof(dump_stack) *dump_stack;
+        #endif
+
+        #ifdef CONFIG_ARM64
+        #ifdef __PIE__
+            /* alt_cb_patch_nops defined early to allow shimming in system
+             * headers, but now we need the native one.
+             */
+            #undef alt_cb_patch_nops
+            typeof(my__alt_cb_patch_nops) *alt_cb_patch_nops;
+        #else
+            typeof(alt_cb_patch_nops) *alt_cb_patch_nops;
+        #endif
         #endif
 
         const void *_last_slot;

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -595,6 +595,10 @@ static int set_up_wolfssl_linuxkm_pie_redirect_table(void) {
     wolfssl_linuxkm_pie_redirect_table.dump_stack = dump_stack;
 #endif
 
+#ifdef CONFIG_ARM64
+    wolfssl_linuxkm_pie_redirect_table.alt_cb_patch_nops = alt_cb_patch_nops;
+#endif
+
     /* runtime assert that the table has no null slots after initialization. */
     {
         unsigned long *i;

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -4238,3 +4238,13 @@ char* mystrnstr(const char* s1, const char* s2, unsigned int n)
 #endif /* Environment check */
 
 #endif /* not SINGLE_THREADED */
+
+#if defined(WOLFSSL_LINUXKM) && defined(CONFIG_ARM64) && \
+    defined(USE_WOLFSSL_LINUXKM_PIE_REDIRECT_TABLE)
+noinstr void my__alt_cb_patch_nops(struct alt_instr *alt, __le32 *origptr,
+                                   __le32 *updptr, int nr_inst)
+{
+    return (wolfssl_linuxkm_get_pie_redirect_table()->
+            alt_cb_patch_nops)(alt, origptr, updptr, nr_inst);
+}
+#endif


### PR DESCRIPTION
linuxkm: work around aarch64 dependency on `alt_cb_patch_nops` for enable-linuxkm-pie (FIPS support).

tested with `wolfssl-multi-test.sh ... 
linuxkm-all-cryptonly-pie-aarch64-LKCAPI-crypto-fuzzer-build check-source-text`
