### PR TITLE
20241126-WC_NO_COMPAT_AES_BLOCK_SIZE

### DIFF
--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -189,7 +189,15 @@ enum {
 #endif
 
     WC_AES_BLOCK_SIZE      = 16,
-#ifndef OPENSSL_COEXIST
+#ifdef OPENSSL_COEXIST
+    /* allow OPENSSL_COEXIST applications to detect absence of AES_BLOCK_SIZE
+     * and presence of WC_AES_BLOCK_SIZE.
+     *
+     * if WC_NO_COMPAT_AES_BLOCK_SIZE is defined, WC_AES_BLOCK_SIZE is
+     * available, otherwise AES_BLOCK_SIZE is available.
+     */
+    #define WC_NO_COMPAT_AES_BLOCK_SIZE
+#else
     #define AES_BLOCK_SIZE WC_AES_BLOCK_SIZE
 #endif
 


### PR DESCRIPTION
`wolfssl/wolfcrypt/aes.h`: `#define WC_NO_COMPAT_AES_BLOCK_SIZE` in `OPENSSL_COEXIST` builds.  see comment in source code with usage instructions.
