### PR TITLE
PQC macro protection quickfixes

### DIFF
--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1620,7 +1620,8 @@ struct SignatureCtx {
     byte* sigCpy;
 #endif
 #if defined(HAVE_ECC) || defined(HAVE_ED25519) || defined(HAVE_ED448) || \
-    !defined(NO_DSA)
+    !defined(NO_DSA) || defined(HAVE_DILITHIUM) || defined(HAVE_FALCON) || \
+    defined(HAVE_SPHINCS)
     int verify;
 #endif
     union {
@@ -1898,12 +1899,14 @@ struct DecodedCert {
     #endif
 #endif /* WOLFSSL_SUBJ_INFO_ACC */
 
-#if defined(HAVE_ECC) || defined(HAVE_ED25519) || defined(HAVE_ED448)
+#if defined(HAVE_ECC) || defined(HAVE_ED25519) || defined(HAVE_ED448) || \
+    defined(HAVE_DILITHIUM) || defined(HAVE_FALCON) || defined(HAVE_SPHINCS)
     word32  pkCurveOID;           /* Public Key's curve OID */
     #ifdef WOLFSSL_CUSTOM_CURVES
         int  pkCurveSize;         /* Public Key's curve size */
     #endif
-#endif /* HAVE_ECC */
+#endif /* HAVE_ECC || HAVE_ED25519 || HAVE_ED448 || HAVE_DILITHIUM ||
+        * HAVE_FALCON || HAVE_SPHINCS */
     const byte* beforeDate;
     int     beforeDateLen;
     const byte* afterDate;

--- a/wolfssl/wolfcrypt/cryptocb.h
+++ b/wolfssl/wolfcrypt/cryptocb.h
@@ -50,6 +50,9 @@
 #ifndef NO_SHA256
     #include <wolfssl/wolfcrypt/sha256.h>
 #endif
+#ifdef WOLFSSL_SHA3
+    #include <wolfssl/wolfcrypt/sha3.h>
+#endif
 #ifndef NO_HMAC
     #include <wolfssl/wolfcrypt/hmac.h>
 #endif


### PR DESCRIPTION
# Description

- Fixes macro protection of a few struct elements in `asn.h` that are used by PQC code in `asn.c` causing build errors when not compiled with ECC support. 
- Fixes missing include in `cryptocb.h` that could cause build errors in some circumstances (wolfBoot + ML-DSA)

