### PR TITLE
20241126-FIPS-OPENSSL_COEXIST

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -24986,7 +24986,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
 
 #if defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION > 2)
     /* Expect failure with MD5 + HMAC when using FIPS 140-3. */
-    if (HMAC(EVP_md5(), "JefeJefeJefeJefe", 16, (byte*)c.input, (int)c.inLen,
+    if (wolfSSL_HMAC(wolfSSL_EVP_md5(), "JefeJefeJefeJefe", 16, (byte*)c.input, (int)c.inLen,
             hash, 0) != NULL)
 #else
     if (wolfSSL_HMAC(wolfSSL_EVP_md5(), "JefeJefeJefeJefe", 16, (byte*)c.input, (int)c.inLen,

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -117,6 +117,9 @@
         #include <openssl/hmac.h>
         #include <openssl/bn.h>
         #include <openssl/crypto.h>
+
+        #if !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || \
+            FIPS_VERSION3_GE(5,2,0))
         #include <openssl/aes.h>
         #include <openssl/blowfish.h>
         #include <openssl/camellia.h>
@@ -163,6 +166,10 @@
         #include <openssl/rc5.h>
         #include <openssl/ripemd.h>
         #include <openssl/rsa.h>
+        #if defined(HAVE_FIPS_VERSION) && FIPS_VERSION3_LT(7,0,0)
+            /* clear conflicting name */
+            #undef RSA_PKCS1_PADDING_SIZE
+        #endif
         #include <openssl/seed.h>
         #include <openssl/self_test.h>
         #include <openssl/sha.h>
@@ -173,6 +180,8 @@
         #include <openssl/txt_db.h>
         #include <openssl/ui.h>
         #include <openssl/whrlpool.h>
+        #endif /* !HAVE_SELFTEST && (!HAVE_FIPS || FIPS_VERSION3_GE(5,2,0)) */
+
     #endif
 
 #elif (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL))

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3660,6 +3660,11 @@ extern void uITRON4_free(void *p) ;
     #ifndef NO_OLD_WC_NAMES
         #define NO_OLD_WC_NAMES
     #endif
+    #if defined(HAVE_SELFTEST) || \
+        (defined(HAVE_FIPS) && FIPS_VERSION3_LT(5,0,0))
+        /* old FIPS needs this remapping. */
+        #define Sha3 wc_Sha3
+    #endif
 #endif
 
 #if defined(NO_OLD_WC_NAMES) || defined(OPENSSL_EXTRA)


### PR DESCRIPTION
fixes for `OPENSSL_COEXIST` with FIPS and with/without `TEST_OPENSSL_COEXIST`.

tested with
```
wolfssl-multi-test.sh ... 
all-crypto-openssl-extra-coexist-with-suites
all-crypto-openssl-extra-coexist-smallstack
defaults-openssl-coexist-fips-v2
all-crypto-openssl-extra-coexist-fips-v5-pilot
all-crypto-openssl-extra-coexist-fips-v6
all-crypto-openssl-extra-coexist-fips-dev
all-crypto-openssl-extra-coexist-TEST_OPENSSL_COEXIST
all-crypto-openssl-extra-coexist-smallstack-TEST_OPENSSL_COEXIST
defaults-openssl-coexist-TEST_OPENSSL_COEXIST-fips-v2
all-crypto-openssl-extra-coexist-TEST_OPENSSL_COEXIST-fips-v5-pilot
all-crypto-openssl-extra-coexist-TEST_OPENSSL_COEXIST-fips-v6
all-crypto-openssl-extra-coexist-TEST_OPENSSL_COEXIST-fips-dev
super-quick-check
```
(many of these are new scenarios added to test this PR)
