### PR TITLE
Add STM32MP13 HAL support for more SHA types

### DIFF
--- a/IDE/STM32Cube/wolfssl_example.c
+++ b/IDE/STM32Cube/wolfssl_example.c
@@ -1760,6 +1760,7 @@ static int tls13_uart_client(void)
         printf("wolfSSL_UseKeyShare Error!!");
     }
 #endif
+#endif
 
     do {
         ret = wolfSSL_connect(ssl);

--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -137,6 +137,9 @@ static void wc_Stm32_Hash_SaveContext(STM32_HASH_Context* ctx)
     ctx->HASH_IMR = HASH->IMR;
     ctx->HASH_STR = HASH->STR;
     ctx->HASH_CR  = HASH->CR;
+#ifdef STM32_HASH_SHA3
+    ctx->SHA3CFGR  = HASH->SHA3CFGR;
+#endif
     for (i=0; i<HASH_CR_SIZE; i++) {
         ctx->HASH_CSR[i] = HASH->CSR[i];
     }
@@ -184,6 +187,9 @@ static void wc_Stm32_Hash_RestoreContext(STM32_HASH_Context* ctx, int algo)
         HASH->IMR = ctx->HASH_IMR;
         HASH->STR = ctx->HASH_STR;
         HASH->CR = ctx->HASH_CR;
+#ifdef STM32_HASH_SHA3
+        HASH->SHA3CFGR = ctx->SHA3CFGR;
+#endif
 
         /* Initialize the hash processor */
         HASH->CR |= HASH_CR_INIT;
@@ -329,11 +335,11 @@ int wc_Stm32_Hash_Update(STM32_HASH_Context* stmCtx, word32 algo,
     while (len) {
         word32 add;
 
-        /* fill the FIFO plus one additional to flush the block */
-        chunkSz = ((STM32_HASH_FIFO_SIZE + 1) * STM32_HASH_REG_SIZE);
-        /* account for extra bytes in the FIFO (use mask 0x3F to get remain) */
-        chunkSz -= (stmCtx->fifoBytes &
-            ((STM32_HASH_FIFO_SIZE * STM32_HASH_REG_SIZE)-1));
+        chunkSz = blockSize;
+        /* fill the FIFO plus one additional to flush the first block */
+        if (!stmCtx->fifoBytes) {
+            chunkSz += STM32_HASH_REG_SIZE;
+        }
 
         add = min(len, chunkSz - stmCtx->buffLen);
         XMEMCPY(&local[stmCtx->buffLen], data, add);

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -219,6 +219,66 @@
     {
         se050_hash_free(&sha512->se050Ctx);
     }
+#elif defined(STM32_HASH_SHA512)
+
+    /* Supports CubeMX HAL or Standard Peripheral Library */
+
+    int wc_InitSha512_ex(wc_Sha512* sha512, void* heap, int devId)
+    {
+        if (sha512 == NULL)
+            return BAD_FUNC_ARG;
+
+        (void)devId;
+        (void)heap;
+
+        XMEMSET(sha512, 0, sizeof(wc_Sha512));
+        wc_Stm32_Hash_Init(&sha512->stmCtx);
+        return 0;
+    }
+
+    int wc_Sha512Update(wc_Sha512* sha512, const byte* data, word32 len)
+    {
+        int ret = 0;
+
+        if (sha512 == NULL) {
+            return BAD_FUNC_ARG;
+        }
+        if (data == NULL && len == 0) {
+            /* valid, but do nothing */
+            return 0;
+        }
+        if (data == NULL) {
+            return BAD_FUNC_ARG;
+        }
+
+        ret = wolfSSL_CryptHwMutexLock();
+        if (ret == 0) {
+            ret = wc_Stm32_Hash_Update(&sha512->stmCtx,
+                HASH_ALGOSELECTION_SHA512, data, len, WC_SHA512_BLOCK_SIZE);
+            wolfSSL_CryptHwMutexUnLock();
+        }
+        return ret;
+    }
+
+    int wc_Sha512Final(wc_Sha512* sha512, byte* hash)
+    {
+        int ret = 0;
+
+        if (sha512 == NULL || hash == NULL) {
+            return BAD_FUNC_ARG;
+        }
+
+        ret = wolfSSL_CryptHwMutexLock();
+        if (ret == 0) {
+            ret = wc_Stm32_Hash_Final(&sha512->stmCtx,
+                HASH_ALGOSELECTION_SHA512, hash, WC_SHA512_DIGEST_SIZE);
+            wolfSSL_CryptHwMutexUnLock();
+        }
+
+        (void)wc_InitSha512(sha512); /* reset state */
+
+        return ret;
+    }
 
 #else
 
@@ -1174,7 +1234,7 @@ int wc_Sha512Update(wc_Sha512* sha512, const byte* data, word32 len)
 
 #elif defined(MAX3266X_SHA)
     /* Functions defined in wolfcrypt/src/port/maxim/max3266x.c */
-
+#elif defined(STM32_HASH_SHA512)
 #else
 
 static WC_INLINE int Sha512Final(wc_Sha512* sha512)
@@ -1337,7 +1397,7 @@ static WC_INLINE int Sha512Final(wc_Sha512* sha512)
 
 #elif defined(MAX3266X_SHA)
     /* Functions defined in wolfcrypt/src/port/maxim/max3266x.c */
-
+#elif defined(STM32_HASH_SHA512)
 #else
 
 static int Sha512FinalRaw(wc_Sha512* sha512, byte* hash, size_t digestSz)
@@ -1407,10 +1467,12 @@ static int Sha512_Family_Final(wc_Sha512* sha512, byte* hash, size_t digestSz,
     return initfp(sha512);
 }
 
+#ifndef STM32_HASH_SHA512
 int wc_Sha512Final(wc_Sha512* sha512, byte* hash)
 {
     return Sha512_Family_Final(sha512, hash, WC_SHA512_DIGEST_SIZE, InitSha512);
 }
+#endif
 
 #endif /* WOLFSSL_KCAPI_HASH */
 
@@ -1592,6 +1654,64 @@ int wc_Sha512Transform(wc_Sha512* sha, const unsigned char* data)
 
 #elif defined(MAX3266X_SHA)
     /* Functions defined in wolfcrypt/src/port/maxim/max3266x.c */
+#elif defined(STM32_HASH_SHA384)
+
+    int wc_InitSha384_ex(wc_Sha384* sha384, void* heap, int devId)
+    {
+        if (sha384 == NULL)
+            return BAD_FUNC_ARG;
+
+        (void)devId;
+        (void)heap;
+
+        XMEMSET(sha384, 0, sizeof(wc_Sha384));
+        wc_Stm32_Hash_Init(&sha384->stmCtx);
+        return 0;
+    }
+
+    int wc_Sha384Update(wc_Sha384* sha384, const byte* data, word32 len)
+    {
+        int ret = 0;
+
+        if (sha384 == NULL) {
+            return BAD_FUNC_ARG;
+        }
+        if (data == NULL && len == 0) {
+            /* valid, but do nothing */
+            return 0;
+        }
+        if (data == NULL) {
+            return BAD_FUNC_ARG;
+        }
+
+        ret = wolfSSL_CryptHwMutexLock();
+        if (ret == 0) {
+            ret = wc_Stm32_Hash_Update(&sha384->stmCtx,
+                HASH_ALGOSELECTION_SHA384, data, len, WC_SHA384_BLOCK_SIZE);
+            wolfSSL_CryptHwMutexUnLock();
+        }
+        return ret;
+    }
+
+    int wc_Sha384Final(wc_Sha384* sha384, byte* hash)
+    {
+        int ret = 0;
+
+        if (sha384 == NULL || hash == NULL) {
+            return BAD_FUNC_ARG;
+        }
+
+        ret = wolfSSL_CryptHwMutexLock();
+        if (ret == 0) {
+            ret = wc_Stm32_Hash_Final(&sha384->stmCtx,
+                HASH_ALGOSELECTION_SHA384, hash, WC_SHA384_DIGEST_SIZE);
+            wolfSSL_CryptHwMutexUnLock();
+        }
+
+        (void)wc_InitSha384(sha384); /* reset state */
+
+        return ret;
+    }
 
 #else
 
@@ -2011,17 +2131,75 @@ int wc_Sha512GetFlags(wc_Sha512* sha512, word32* flags)
 #if !defined(WOLFSSL_NOSHA512_224) && \
    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)) && !defined(HAVE_SELFTEST)
 
+#if defined(STM32_HASH_SHA512_224)
 
+int wc_InitSha512_224_ex(wc_Sha512* sha512, void* heap, int devId)
+{
+    if (sha512 == NULL)
+        return BAD_FUNC_ARG;
+
+    (void)devId;
+    (void)heap;
+
+    XMEMSET(sha512, 0, sizeof(wc_Sha512));
+    wc_Stm32_Hash_Init(&sha512->stmCtx);
+    return 0;
+}
+
+int wc_Sha512_224Update(wc_Sha512* sha512, const byte* data, word32 len)
+{
+    int ret = 0;
+
+    if (sha512 == NULL) {
+        return BAD_FUNC_ARG;
+    }
+    if (data == NULL && len == 0) {
+        /* valid, but do nothing */
+        return 0;
+    }
+    if (data == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    ret = wolfSSL_CryptHwMutexLock();
+    if (ret == 0) {
+        ret = wc_Stm32_Hash_Update(&sha512->stmCtx,
+            HASH_ALGOSELECTION_SHA512_224, data, len, WC_SHA512_224_BLOCK_SIZE);
+        wolfSSL_CryptHwMutexUnLock();
+    }
+    return ret;
+}
+
+int wc_Sha512_224Final(wc_Sha512* sha512, byte* hash)
+{
+    int ret = 0;
+
+    if (sha512 == NULL || hash == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    ret = wolfSSL_CryptHwMutexLock();
+    if (ret == 0) {
+        ret = wc_Stm32_Hash_Final(&sha512->stmCtx,
+            HASH_ALGOSELECTION_SHA512_224, hash, WC_SHA512_224_DIGEST_SIZE);
+        wolfSSL_CryptHwMutexUnLock();
+    }
+
+    (void)wc_InitSha512_224(sha512); /* reset state */
+
+    return ret;
+}
+#endif
 int wc_InitSha512_224(wc_Sha512* sha)
 {
     return wc_InitSha512_224_ex(sha, NULL, INVALID_DEVID);
 }
-
+#if !defined(STM32_HASH_SHA512_224)
 int wc_Sha512_224Update(wc_Sha512* sha, const byte* data, word32 len)
 {
     return wc_Sha512Update(sha, data, len);
 }
-
+#endif
 #if defined(WOLFSSL_KCAPI_HASH)
     /* functions defined in wolfcrypt/src/port/kcapi/kcapi_hash.c */
 #elif defined(WOLFSSL_RENESAS_RSIP) && \
@@ -2029,6 +2207,7 @@ int wc_Sha512_224Update(wc_Sha512* sha, const byte* data, word32 len)
     /* functions defined in wolfcrypt/src/port/Renesas/renesas_fspsm_sha.c */
 
 #elif defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
+#elif defined(STM32_HASH_SHA512_224)
 
 #else
 int wc_Sha512_224FinalRaw(wc_Sha512* sha, byte* hash)
@@ -2091,16 +2270,75 @@ int wc_Sha512_224Transform(wc_Sha512* sha, const unsigned char* data)
 
 #if !defined(WOLFSSL_NOSHA512_256) && \
    (!defined(HAVE_FIPS) || FIPS_VERSION_GE(5, 3)) && !defined(HAVE_SELFTEST)
+#if defined(STM32_HASH_SHA512_256)
 
+    int wc_InitSha512_256_ex(wc_Sha512* sha512, void* heap, int devId)
+    {
+        if (sha512 == NULL)
+            return BAD_FUNC_ARG;
+
+        (void)devId;
+        (void)heap;
+
+        XMEMSET(sha512, 0, sizeof(wc_Sha512));
+        wc_Stm32_Hash_Init(&sha512->stmCtx);
+        return 0;
+    }
+
+    int wc_Sha512_256Update(wc_Sha512* sha512, const byte* data, word32 len)
+    {
+        int ret = 0;
+
+        if (sha512 == NULL) {
+            return BAD_FUNC_ARG;
+        }
+        if (data == NULL && len == 0) {
+            /* valid, but do nothing */
+            return 0;
+        }
+        if (data == NULL) {
+            return BAD_FUNC_ARG;
+        }
+
+        ret = wolfSSL_CryptHwMutexLock();
+        if (ret == 0) {
+            ret = wc_Stm32_Hash_Update(&sha512->stmCtx,
+                HASH_ALGOSELECTION_SHA512_256, data, len, WC_SHA512_256_BLOCK_SIZE);
+            wolfSSL_CryptHwMutexUnLock();
+        }
+        return ret;
+    }
+
+    int wc_Sha512_256Final(wc_Sha512* sha512, byte* hash)
+    {
+        int ret = 0;
+
+        if (sha512 == NULL || hash == NULL) {
+            return BAD_FUNC_ARG;
+        }
+
+        ret = wolfSSL_CryptHwMutexLock();
+        if (ret == 0) {
+            ret = wc_Stm32_Hash_Final(&sha512->stmCtx,
+                HASH_ALGOSELECTION_SHA512_256, hash, WC_SHA512_256_DIGEST_SIZE);
+            wolfSSL_CryptHwMutexUnLock();
+        }
+
+        (void)wc_InitSha512_256(sha512); /* reset state */
+
+        return ret;
+    }
+#endif
 int wc_InitSha512_256(wc_Sha512* sha)
 {
     return wc_InitSha512_256_ex(sha, NULL, INVALID_DEVID);
 }
-
+#if !defined(STM32_HASH_SHA512_256)
 int wc_Sha512_256Update(wc_Sha512* sha, const byte* data, word32 len)
 {
     return wc_Sha512Update(sha, data, len);
 }
+#endif
 #if defined(WOLFSSL_KCAPI_HASH)
     /* functions defined in wolfcrypt/src/port/kcapi/kcapi_hash.c */
 #elif defined(WOLFSSL_RENESAS_RSIP) && \
@@ -2108,7 +2346,7 @@ int wc_Sha512_256Update(wc_Sha512* sha, const byte* data, word32 len)
     /* functions defined in wolfcrypt/src/port/Renesas/renesas_fspsm_sha.c */
 
 #elif defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
-
+#elif defined(STM32_HASH_SHA512_256)
 #else
 int wc_Sha512_256FinalRaw(wc_Sha512* sha, byte* hash)
 {
@@ -2176,6 +2414,7 @@ int wc_Sha512_256Transform(wc_Sha512* sha, const unsigned char* data)
     /* functions defined in wolfcrypt/src/port/renesas/renesas_fspsm_sha.c */
 #elif defined(MAX3266X_SHA)
     /* Functions defined in wolfcrypt/src/port/maxim/max3266x.c */
+
 #else
 
 int wc_Sha384GetHash(wc_Sha384* sha384, byte* hash)

--- a/wolfssl/wolfcrypt/sha3.h
+++ b/wolfssl/wolfcrypt/sha3.h
@@ -45,6 +45,10 @@
     #include <wolfssl/wolfcrypt/async.h>
 #endif
 
+#ifdef STM32_HASH
+    #include <wolfssl/wolfcrypt/port/st/stm32.h>
+#endif
+
 /* in bytes */
 enum {
     /* SHAKE-128 */
@@ -139,6 +143,9 @@ struct wc_Sha3 {
 #endif /* WOLFSSL_ASYNC_CRYPT */
 #ifdef WOLFSSL_HASH_FLAGS
     word32 flags; /* enum wc_HashFlags in hash.h */
+#endif
+#if defined(STM32_HASH_SHA3)
+    STM32_HASH_Context stmCtx;
 #endif
 };
 

--- a/wolfssl/wolfcrypt/sha512.h
+++ b/wolfssl/wolfcrypt/sha512.h
@@ -73,6 +73,10 @@
     #include "fsl_caam.h"
 #endif
 
+#ifdef STM32_HASH
+    #include <wolfssl/wolfcrypt/port/st/stm32.h>
+#endif
+
 #if defined(_MSC_VER)
     #define SHA512_NOINLINE __declspec(noinline)
 #elif defined(__IAR_SYSTEMS_ICC__) || defined(__GNUC__)
@@ -201,6 +205,9 @@ struct wc_Sha512 {
 #endif
 #ifdef HAVE_ARIA
     MC_HSESSION hSession;
+#endif
+#if defined(STM32_HASH_SHA512)
+    STM32_HASH_Context stmCtx;
 #endif
 #endif /* WOLFSSL_PSOC6_CRYPTO */
 };


### PR DESCRIPTION
# Description

This adds STM32 HAL support for:

* SHA384
* SHA512 (with -224 and -256)
* SHA3 (all variants apart from SHAKE)

The partial FIFO block calculations have been adjusted based in the STM32 code to support the larger hash sizes.

This should work with other chips such as the STM32U5xx, but is not enabled for that yet.

# Testing

Tested using the wolfCrypt test suite and benchmark suite on an STM32MP135F-DK.

```
error    test passed!
MEMORY   test passed!
base64   test passed!
asn      test passed!
RANDOM   test passed!
MD5      test passed!
SHA      test passed!
SHA-224  test passed!
SHA-256  test passed!
SHA-384  test passed!
SHA-512  test passed!
SHA-512/224  test passed!
SHA-512/256  test passed!
SHA-3    test passed!
Hash     test passed!
HMAC-MD5 test passed!
HMAC-SHA test passed!
HMAC-SHA224 test passed!
HMAC-SHA256 test passed!
HMAC-SHA384 test passed!
HMAC-SHA512 test passed!
HMAC-SHA3   test passed!
HMAC-KDF    test passed!
PRF         test passed!
TLSv1.3 KDF test passed!
GMAC     test passed!
Chacha   test passed!
POLY1305 test passed!
ChaCha20-Poly1305 AEAD test passed!
DES      test passed!
DES3     test passed!
AES      test passed!
AES192   test passed!
AES256   test passed!
AES-CBC  test passed!
AES-GCM  test passed!
RSA      test passed!
DH       test passed!
ECC      test passed!
ECC buffer test passed!
CURVE25519 test passed!
ED25519  test passed!
logging  test passed!
time     test passed!
mutex    test passed!
Test complete
```

```
SHA-384                     86 MiB took 1.000 seconds,   85.938 MiB/s
SHA-512                     86 MiB took 1.000 seconds,   85.840 MiB/s
SHA-512/224                 86 MiB took 1.000 seconds,   86.035 MiB/s
SHA-512/256                 86 MiB took 1.000 seconds,   85.938 MiB/s
SHA3-224                    84 MiB took 1.000 seconds,   84.473 MiB/s
SHA3-256                    85 MiB took 1.000 seconds,   85.156 MiB/s
SHA3-384                    89 MiB took 1.000 seconds,   89.453 MiB/s
SHA3-512                    92 MiB took 1.000 seconds,   91.699 MiB/s
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
