### PR TITLE
wc_port: change wolfSSL_JoinThread to pass thread by pointer.

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -266,7 +266,7 @@ void FreeCRL(WOLFSSL_CRL* crl, int dynamic)
     if (crl->tid != INVALID_THREAD_VAL) {
         WOLFSSL_MSG("stopping monitor thread");
         if (StopMonitor(crl->mfd) == 0) {
-            if (wolfSSL_JoinThread(crl->tid) != 0)
+            if (wolfSSL_JoinThread(&crl->tid) != 0)
                 WOLFSSL_MSG("stop monitor failed in wolfSSL_JoinThread");
         }
         else {

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -190,7 +190,7 @@ void start_thread(THREAD_CB fun, func_args* args, THREAD_TYPE* thread)
  */
 void join_thread(THREAD_TYPE thread)
 {
-    THREAD_CHECK_RET(wolfSSL_JoinThread(thread));
+    THREAD_CHECK_RET(wolfSSL_JoinThread(&thread));
 }
 #endif /* SINGLE_THREADED */
 

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -3756,18 +3756,21 @@ char* mystrnstr(const char* s1, const char* s2, unsigned int n)
     }
 #endif
 
-    int wolfSSL_JoinThread(THREAD_TYPE thread)
+    int wolfSSL_JoinThread(THREAD_TYPE* thread)
     {
         int ret = 0;
 
-        if (thread == INVALID_THREAD_VAL)
+        if (thread == NULL)
+            return BAD_FUNC_ARG;
+
+        if (*thread == INVALID_THREAD_VAL)
             return BAD_FUNC_ARG;
 
         /* We still want to attempt to close the thread handle even on error */
-        if (WaitForSingleObject((HANDLE)thread, INFINITE) == WAIT_FAILED)
+        if (WaitForSingleObject((HANDLE)*thread, INFINITE) == WAIT_FAILED)
             ret = MEMORY_E;
 
-        if (CloseHandle((HANDLE)thread) == 0)
+        if (CloseHandle((HANDLE)*thread) == 0)
             ret = MEMORY_E;
 
         return ret;
@@ -3878,10 +3881,13 @@ char* mystrnstr(const char* s1, const char* s2, unsigned int n)
         return 0;
     }
 
-    int wolfSSL_JoinThread(THREAD_TYPE thread)
+    int wolfSSL_JoinThread(THREAD_TYPE* thread)
     {
+        if (thread == NULL)
+            return BAD_FUNC_ARG;
+
         while(1) {
-            if (Task_getMode(thread) == Task_Mode_TERMINATED) {
+            if (Task_getMode(*thread) == Task_Mode_TERMINATED) {
                 Task_sleep(5);
                 break;
             }
@@ -3942,11 +3948,14 @@ char* mystrnstr(const char* s1, const char* s2, unsigned int n)
         return 0;
     }
 
-    int wolfSSL_JoinThread(THREAD_TYPE thread)
+    int wolfSSL_JoinThread(THREAD_TYPE* thread)
     {
+        if (thread == NULL)
+            return BAD_FUNC_ARG;
+
         /* TODO: maybe have to use tx_thread_delete? */
-        XFREE(thread.threadStack, NULL, DYNAMIC_TYPE_OS_BUF);
-        thread.threadStack = NULL;
+        XFREE(thread->threadStack, NULL, DYNAMIC_TYPE_OS_BUF);
+        thread->threadStack = NULL;
         return 0;
     }
 
@@ -3989,26 +3998,29 @@ char* mystrnstr(const char* s1, const char* s2, unsigned int n)
         return 0;
     }
 
-    int wolfSSL_JoinThread(THREAD_TYPE thread)
+    int wolfSSL_JoinThread(THREAD_TYPE* thread)
     {
         int ret = 0;
         int err;
 
-        err = k_thread_join(&thread.tid, K_FOREVER);
+        if (thread == NULL)
+            return BAD_FUNC_ARG;
+
+        err = k_thread_join(&thread->tid, K_FOREVER);
         if (err != 0)
             ret = MEMORY_E;
 
         /* TODO: Use the following once k_thread_stack_free makes it into a
          * release.
-         * err = k_thread_stack_free(thread.threadStack);
+         * err = k_thread_stack_free(thread->threadStack);
          * if (err != 0)
          *     ret = MEMORY_E;
          */
-        XFREE(thread.threadStack, wolfsslThreadHeapHint,
+        XFREE(thread->threadStack, wolfsslThreadHeapHint,
                 DYNAMIC_TYPE_TMP_BUFFER);
-        thread.threadStack = NULL;
+        thread->threadStack = NULL;
 
-        /* No thread resources to free. Everything is stored in thread.tid */
+        /* No thread resources to free. Everything is stored in thread->tid */
 
         return ret;
     }
@@ -4046,12 +4058,15 @@ char* mystrnstr(const char* s1, const char* s2, unsigned int n)
         }
     #endif
 
-    int wolfSSL_JoinThread(THREAD_TYPE thread)
+    int wolfSSL_JoinThread(THREAD_TYPE* thread)
     {
-        if (thread == INVALID_THREAD_VAL)
+        if (thread == NULL)
             return BAD_FUNC_ARG;
 
-        if (pthread_join(thread, NULL) != 0)
+        if (*thread == INVALID_THREAD_VAL)
+            return BAD_FUNC_ARG;
+
+        if (pthread_join(*thread, NULL) != 0)
             return MEMORY_E;
 
         return 0;

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1568,7 +1568,7 @@ typedef struct w64wrapper {
             WOLFSSL_API int wolfSSL_NewThreadNoJoin(THREAD_CB_NOJOIN cb,
                     void* arg);
         #endif
-        WOLFSSL_API int wolfSSL_JoinThread(THREAD_TYPE thread);
+        WOLFSSL_API int wolfSSL_JoinThread(THREAD_TYPE* thread);
 
         #ifdef WOLFSSL_COND
             WOLFSSL_API int wolfSSL_CondInit(COND_TYPE* cond);

--- a/zephyr/samples/wolfssl_tls_sock/src/tls_sock.c
+++ b/zephyr/samples/wolfssl_tls_sock/src/tls_sock.c
@@ -518,7 +518,7 @@ int main()
      * to shut down to join it. */
     k_sleep(Z_TIMEOUT_TICKS(100));
 
-    if (wolfSSL_JoinThread(serverThread) != 0) {
+    if (wolfSSL_JoinThread(&serverThread) != 0) {
         printf("Failed to join server thread\n");
         return -1;
     }

--- a/zephyr/samples/wolfssl_tls_thread/src/tls_threaded.c
+++ b/zephyr/samples/wolfssl_tls_thread/src/tls_threaded.c
@@ -645,7 +645,7 @@ int main()
     printf("Client Return: %d\n", ret);
     printf("Client Error: %d\n", wolfSSL_get_error(client_ssl, ret));
 
-    if (wolfSSL_JoinThread(serverThread) != 0) {
+    if (wolfSSL_JoinThread(&serverThread) != 0) {
         printf("Failed to join server thread\n");
         return -1;
     }


### PR DESCRIPTION
# Description

Update wolfSSL_JoinThread to pass THREAD_TYPE by pointer. This is backward's compat breaking. Opening PR as draft for comparison.

Fixes coverity PASS_BY_VALUE issue in zd#17705.

# Testing

Tested with:
- https://github.com/wolfSSL/wolfssl/blob/master/zephyr/README.md#build-and-run-wolfssl-example-wolfssl_tls_thread
