### PR TITLE
Fixes for building with SP RSA small and RSA Public only

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8261,10 +8261,12 @@ if test "$ENABLED_SP_RSA" = "yes" || test "$ENABLED_SP_DH" = "yes"; then
 
     case $host_cpu in
     *x86_64* | *aarch64* | *amd64*)
-      AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_LARGE_CODE"
-      ;;
+        if test "$ENABLED_SP_SMALL" = "no"; then
+            AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_LARGE_CODE"
+        fi
+        ;;
     *)
-      ;;
+        ;;
     esac
 fi
 if test "$ENABLED_ECC" != "no" && test "$ENABLED_SP_ECC" = "yes"; then

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -5087,52 +5087,6 @@ static int _sp_mont_red(sp_int* a, const sp_int* m, sp_int_digit mp, int ct);
 static void _sp_mont_setup(const sp_int* m, sp_int_digit* rho);
 #endif
 
-/* Determine when mp_add_d is required. */
-#if !defined(NO_PWDBASED) || defined(WOLFSSL_KEY_GEN) || !defined(NO_DH) || \
-    !defined(NO_DSA) || defined(HAVE_ECC) || \
-    (!defined(NO_RSA) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
-    defined(OPENSSL_EXTRA)
-#define WOLFSSL_SP_ADD_D
-#endif
-/* Determine when mp_sub_d is required. */
-#if (!defined(NO_RSA) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
-    !defined(NO_DH) || defined(HAVE_ECC) || !defined(NO_DSA)
-#define WOLFSSL_SP_SUB_D
-#endif
-/* Determine when mp_read_radix with a radix of 10 is required. */
-#if (defined(WOLFSSL_SP_MATH_ALL) && !defined(NO_RSA) && \
-    !defined(WOLFSSL_RSA_VERIFY_ONLY)) || defined(HAVE_ECC) || \
-    !defined(NO_DSA) || defined(OPENSSL_EXTRA)
-#define WOLFSSL_SP_READ_RADIX_16
-#endif
-/* Determine when mp_read_radix with a radix of 10 is required. */
-#if defined(WOLFSSL_SP_MATH_ALL) && !defined(NO_RSA) && \
-    !defined(WOLFSSL_RSA_VERIFY_ONLY)
-#define WOLFSSL_SP_READ_RADIX_10
-#endif
-/* Determine when mp_invmod is required. */
-#if defined(HAVE_ECC) || !defined(NO_DSA) || defined(OPENSSL_EXTRA) || \
-    (!defined(NO_RSA) && !defined(WOLFSSL_RSA_VERIFY_ONLY) && \
-     !defined(WOLFSSL_RSA_PUBLIC_ONLY))
-#define WOLFSSL_SP_INVMOD
-#endif
-/* Determine when mp_invmod_mont_ct is required. */
-#if defined(WOLFSSL_SP_MATH_ALL) && defined(HAVE_ECC)
-#define WOLFSSL_SP_INVMOD_MONT_CT
-#endif
-
-/* Determine when mp_prime_gen is required. */
-#if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY) && \
-    !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || !defined(NO_DH) || \
-    (!defined(NO_RSA) && defined(WOLFSSL_KEY_GEN))
-#define WOLFSSL_SP_PRIME_GEN
-#endif
-
-#if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
-    (defined(WOLFSSL_KEY_GEN) && !defined(NO_RSA)) || defined(OPENSSL_EXTRA)
-/* Determine when mp_mul_d is required */
-#define WOLFSSL_SP_MUL_D
-#endif
 
 /* Set the multi-precision number to zero.
  *
@@ -14058,7 +14012,8 @@ int sp_exptmod_ex(const sp_int* b, const sp_int* e, int digits, const sp_int* m,
     if ((!done) && (err == MP_OKAY)) {
         /* Use code optimized for specific sizes if possible */
 #if (defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)) && \
-    (defined(WOLFSSL_HAVE_SP_RSA) || defined(WOLFSSL_HAVE_SP_DH))
+    ((defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || \
+        defined(WOLFSSL_HAVE_SP_DH))
     #ifndef WOLFSSL_SP_NO_2048
         if ((mBits == 1024) && sp_isodd(m) && (bBits <= 1024) &&
                 (eBits <= 1024)) {

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -13753,11 +13753,12 @@ static wc_test_ret_t aes_direct_test(Aes* enc, Aes* dec, byte* cipher, byte* pla
             ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 #endif /* HAVE_AES_DECRYPT */
     }
-    (void)dec;
-    (void)plain;
-#endif /* WOLFSSL_AES_256 */
-
 out:
+#endif /* WOLFSSL_AES_256 */
+    (void)enc;
+    (void)dec;
+    (void)cipher;
+    (void)plain;
     return ret;
 }
 #endif /* WOLFSSL_AES_DIRECT */
@@ -54765,7 +54766,7 @@ static wc_test_ret_t mp_test_param(mp_int* a, mp_int* b, mp_int* r, WC_RNG* rng)
     mp_digit rho;
     int size;
 #endif
-#if defined(WOLFSSL_SP_MATH_ALL) || defined(WOLFSSL_HAVE_SP_DH)
+#ifdef WOLFSSL_SP_PRIME_GEN
     int result;
 #endif
 #if (defined(HAVE_ECC) && defined(HAVE_COMP_KEY)) || \
@@ -55463,7 +55464,7 @@ static wc_test_ret_t mp_test_param(mp_int* a, mp_int* b, mp_int* r, WC_RNG* rng)
         return WC_TEST_RET_ENC_EC(ret);
 #endif
 
-#if defined(WOLFSSL_SP_MATH_ALL) || defined(WOLFSSL_HAVE_SP_DH)
+#ifdef WOLFSSL_SP_PRIME_GEN
     ret = mp_prime_is_prime(NULL, 1, NULL);
     if (ret != WC_NO_ERR_TRACE(MP_VAL))
         return WC_TEST_RET_ENC_EC(ret);

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2835,6 +2835,58 @@ extern void uITRON4_free(void *p) ;
 #endif
 /*----------------------------------------------------------------------------*/
 
+/* SP Math specific options */
+/* Determine when mp_add_d is required. */
+#if !defined(NO_PWDBASED) || defined(WOLFSSL_KEY_GEN) || !defined(NO_DH) || \
+    !defined(NO_DSA) || defined(HAVE_ECC) || \
+    (!defined(NO_RSA) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
+    defined(OPENSSL_EXTRA)
+    #define WOLFSSL_SP_ADD_D
+#endif
+
+/* Determine when mp_sub_d is required. */
+#if (!defined(NO_RSA) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
+    !defined(NO_DH) || defined(HAVE_ECC) || !defined(NO_DSA)
+    #define WOLFSSL_SP_SUB_D
+#endif
+
+/* Determine when mp_read_radix with a radix of 10 is required. */
+#if (defined(WOLFSSL_SP_MATH_ALL) && !defined(NO_RSA) && \
+    !defined(WOLFSSL_RSA_VERIFY_ONLY)) || defined(HAVE_ECC) || \
+    !defined(NO_DSA) || defined(OPENSSL_EXTRA)
+    #define WOLFSSL_SP_READ_RADIX_16
+#endif
+
+/* Determine when mp_read_radix with a radix of 10 is required. */
+#if defined(WOLFSSL_SP_MATH_ALL) && !defined(NO_RSA) && \
+    !defined(WOLFSSL_RSA_VERIFY_ONLY)
+    #define WOLFSSL_SP_READ_RADIX_10
+#endif
+
+/* Determine when mp_invmod is required. */
+#if defined(HAVE_ECC) || !defined(NO_DSA) || defined(OPENSSL_EXTRA) || \
+    (!defined(NO_RSA) && !defined(WOLFSSL_RSA_VERIFY_ONLY) && \
+     !defined(WOLFSSL_RSA_PUBLIC_ONLY))
+    #define WOLFSSL_SP_INVMOD
+#endif
+
+/* Determine when mp_invmod_mont_ct is required. */
+#if defined(WOLFSSL_SP_MATH_ALL) && defined(HAVE_ECC)
+    #define WOLFSSL_SP_INVMOD_MONT_CT
+#endif
+
+/* Determine when mp_prime_gen is required. */
+#if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY) && \
+    !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || !defined(NO_DH) || \
+    (!defined(NO_RSA) && defined(WOLFSSL_KEY_GEN))
+    #define WOLFSSL_SP_PRIME_GEN
+#endif
+
+#if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
+    (defined(WOLFSSL_KEY_GEN) && !defined(NO_RSA)) || defined(OPENSSL_EXTRA)
+    /* Determine when mp_mul_d is required */
+    #define WOLFSSL_SP_MUL_D
+#endif
 
 
 /* user can specify what curves they want with ECC_USER_CURVES otherwise


### PR DESCRIPTION
# Description

Fixes for building with SP RSA small and RSA Public only. 

Moved some of the SP build gates into settings.h so other parts of the code can leverage them too (for example: `WOLFSSL_SP_PRIME_GEN`).

ZD 18996

# Testing

```
./configure --prefix=$PWD/../wolf-install CFLAGS="-DWOLFSSL_SP_SMALL -DUSE_SLOW_SHA256 -DNO_SIG_WRAPPER -DNO_AES_192 -DNO_AES_256 -DWOLFSSL_RSA_PUBLIC_ONLY -DNO_CHECK_PRIVATE_KEY  -DNO_FILESYSTEM -DWOLFSSL_PUBLIC_MP -DWOLFSSL_NO_MALLOC -DWOLFSSL_SP_NO_MALLOC -DNO_ASN_TIME  -DIGNORE_NAME_CONSTRAINTS  -ffunction-sections -fdata-sections -fno-builtin" --enable-cryptonly --enable-aescfb --enable-rsapss --disable-pkcs8 --disable-pkcs11 --disable-pkcs12 --disable-dh --disable-errorstrings --disable-poly1305 --disable-chacha --disable-sha --disable-sha224 --disable-sha512 --disable-sha3 --disable-md5 --disable-aescbc --disable-aesgcm --disable-aesccm --disable-oldnames --disable-coding --disable-inline --disable-memory --disable-harden --disable-asm --disable-errorqueue --disable-error-queue-per-thread --disable-tls13 --disable-tlsv12 --disable-tlsv10 --disable-optflags --disable-memory --disable-oldtls --disable-filesystem --enable-singlethreaded --enable-static --disable-shared --enable-sp=smallrsa2048
make
make install
./wolfcrypt/test/testwolfcrypt
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
