### PR TITLE
wc_port: change zephyr struct k_thread tid member to pointer.

### DIFF
--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -3966,6 +3966,14 @@ char* mystrnstr(const char* s1, const char* s2, unsigned int n)
 
         XMEMSET(thread, 0, sizeof(*thread));
 
+        thread->tid = (struct k_thread*)XMALLOC(
+                Z_KERNEL_STACK_SIZE_ADJUST(sizeof(struct k_thread)),
+                wolfsslThreadHeapHint, DYNAMIC_TYPE_TMP_BUFFER);
+        if (thread->tid == NULL) {
+            WOLFSSL_MSG("error: XMALLOC thread->tid failed");
+            return MEMORY_E;
+        }
+
         /* TODO: Use the following once k_thread_stack_alloc makes it into a
          * release.
          * thread->threadStack = k_thread_stack_alloc(WOLFSSL_ZEPHYR_STACK_SZ,
@@ -3975,14 +3983,18 @@ char* mystrnstr(const char* s1, const char* s2, unsigned int n)
                 Z_KERNEL_STACK_SIZE_ADJUST(WOLFSSL_ZEPHYR_STACK_SZ),
                 wolfsslThreadHeapHint, DYNAMIC_TYPE_TMP_BUFFER);
         if (thread->threadStack == NULL) {
-            WOLFSSL_MSG("error: XMALLOC failed");
+            XFREE(thread->tid, wolfsslThreadHeapHint,
+                    DYNAMIC_TYPE_TMP_BUFFER);
+            thread->tid = NULL;
+
+            WOLFSSL_MSG("error: XMALLOC thread->threadStack failed");
             return MEMORY_E;
         }
 
         /* k_thread_create does not return any error codes */
         /* Casting to k_thread_entry_t should be fine since we just ignore the
          * extra arguments being passed in */
-        k_thread_create(&thread->tid, thread->threadStack,
+        k_thread_create(thread->tid, thread->threadStack,
                 WOLFSSL_ZEPHYR_STACK_SZ, (k_thread_entry_t)cb, arg, NULL, NULL,
                 5, 0, K_NO_WAIT);
 
@@ -3994,9 +4006,13 @@ char* mystrnstr(const char* s1, const char* s2, unsigned int n)
         int ret = 0;
         int err;
 
-        err = k_thread_join(&thread.tid, K_FOREVER);
+        err = k_thread_join(thread.tid, K_FOREVER);
         if (err != 0)
             ret = MEMORY_E;
+
+        XFREE(thread.tid, wolfsslThreadHeapHint,
+                DYNAMIC_TYPE_TMP_BUFFER);
+        thread.tid = NULL;
 
         /* TODO: Use the following once k_thread_stack_free makes it into a
          * release.

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1437,7 +1437,8 @@ typedef struct w64wrapper {
         typedef void            THREAD_RETURN;
         #define WOLFSSL_THREAD_VOID_RETURN
         typedef struct {
-            struct k_thread tid;
+            /* Zephyr k_thread can be large, > 128 bytes. */
+            struct k_thread* tid;
             k_thread_stack_t* threadStack;
         } THREAD_TYPE;
         #define WOLFSSL_THREAD


### PR DESCRIPTION
# Description

Update Zephyr THREAD_TYPE struct k_thread tid member to be pointer rather than value. Less intrusive alternative to https://github.com/wolfSSL/wolfssl/pull/8234.

Fixes coverity PASS_BY_VALUE issue in zd#17705.

The struct `struct k_thread {` [(defined here)](https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/kernel/thread.h#L259) is potentially large and shouldn't be passed by value.
# Testing

Tested with:
- https://github.com/wolfSSL/wolfssl/blob/master/zephyr/README.md#build-and-run-wolfssl-example-wolfssl_tls_thread