### PR TITLE
Add STM32MP13 to Cube IDE

### DIFF
--- a/IDE/STM32Cube/README.md
+++ b/IDE/STM32Cube/README.md
@@ -37,6 +37,9 @@ You need both the STM32 IDE and the STM32 initialization code generator (STM32Cu
 8. The Benchmark example uses float. To enable go to "Project Properties" -> "C/C++ Build" -> "Settings" -> "Tool Settings" -> "MCU Settings" -> Check "Use float with printf".
 9. To enable printf make the `main.c` changes below in the [STM32 Printf](#stm32-printf) section.
 
+
+**Note:** The STM32MP13 will likely require you to use DDR RAM, as well as enabling MMU and caches for optimum performance. Please see the `STM32MP13.md` file in `wolfcrypt/src/port/st` for more information on how to do this.
+
 ### Creating your own STM32CubeMX configuration
 
 If none of the examples fit your STM32 type then you can create your own in STM32CubeMX by doing the following:
@@ -90,10 +93,11 @@ The section for "Hardware platform" may need to be adjusted depending on your pr
 * To enable STM32WL support define `WOLFSSL_STM32WL`.
 * To enable STM32U5 support define `WOLFSSL_STM32U5`.
 * To enable STM32H5 support define `WOLFSSL_STM32H5`.
+* To enable STM32MP13 support define `WOLFSSL_STM32MP13`.
 
 To use the STM32 Cube HAL support make sure `WOLFSSL_STM32_CUBEMX` is defined.
 
-The PKA acceleration for ECC is available on some U5, L5 and WB55 chips.
+The PKA acceleration for ECC is available on some U5, L5, WB55 and MP13 chips.
 This is enabled with `WOLFSSL_STM32_PKA`. You can see some of the benchmarks [here](STM32_Benchmarks.md).
 
 To disable hardware crypto acceleration you can define:

--- a/IDE/STM32Cube/default_conf.ftl
+++ b/IDE/STM32Cube/default_conf.ftl
@@ -165,14 +165,22 @@ extern ${variable.value} ${variable.name};
     #define HAL_CONSOLE_UART huart3
     #define STM32_HAL_V2
     #undef  NO_STM32_HASH
-
+#elif defined(STM32MP135Fxx)
+    #define WOLFSSL_STM32MP13
+    #define HAL_CONSOLE_UART huart4
+    #define STM32_HAL_V2
+    #undef NO_STM32_HASH
+    #undef NO_STM32_CRYPTO
+    #define WOLFSSL_STM32_PKA
+    #define WOLFSSL_STM32_PKA_V2
 #else
     #warning Please define a hardware platform!
     /* This means there is not a pre-defined platform for your board/CPU */
     /* You need to define a CPU type, HW crypto and debug UART */
     /* CPU Type: WOLFSSL_STM32F1, WOLFSSL_STM32F2, WOLFSSL_STM32F4,
         WOLFSSL_STM32F7, WOLFSSL_STM32H7, WOLFSSL_STM32L4, WOLFSSL_STM32L5,
-        WOLFSSL_STM32G0, WOLFSSL_STM32G4, WOLFSSL_STM32WB and WOLFSSL_STM32U5 */
+        WOLFSSL_STM32G0, WOLFSSL_STM32G4, WOLFSSL_STM32WB, WOLFSSL_STM32U5 and
+        WOLFSSL_STM32MP13 */
     #define WOLFSSL_STM32F4
 
     /* Debug UART used for printf */


### PR DESCRIPTION
# Description

Adds STM32MP13 to Cube IDE, it is recommended that #8231 lands before this.

# Testing

In STM32CubeIDE with a patch to the `.pdsc` file coming soon (@dgarske is aware of that change).

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
