### PR TITLE
Fix test environment

### DIFF
--- a/.github/workflows/docker-Espressif.yml
+++ b/.github/workflows/docker-Espressif.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Initialize Espressif IDE and build examples
-        run: . /opt/esp/idf/export.sh; IDE/Espressif/ESP-IDF/compileAllExamples.sh
+        run: cd /opt/esp/idf && . ./export.sh && cd $GITHUB_WORKSPACE; IDE/Espressif/ESP-IDF/compileAllExamples.sh
   espressif_v4_4:
     name: v4.4 Docker container
     if: github.repository_owner == 'wolfssl'
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Initialize Espressif IDE and build examples
-        run: . /opt/esp/idf/export.sh; IDE/Espressif/ESP-IDF/compileAllExamples.sh
+        run: cd /opt/esp/idf && . ./export.sh && cd $GITHUB_WORKSPACE; IDE/Espressif/ESP-IDF/compileAllExamples.sh
   espressif_v5_0:
     name: v5.0 Docker container
     if: github.repository_owner == 'wolfssl'
@@ -43,4 +43,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Initialize Espressif IDE and build examples
-        run: . /opt/esp/idf/export.sh; IDE/Espressif/ESP-IDF/compileAllExamples.sh
+        run: cd /opt/esp/idf && . ./export.sh && cd $GITHUB_WORKSPACE; IDE/Espressif/ESP-IDF/compileAllExamples.sh


### PR DESCRIPTION
New updates on the Espressif IDF container have issues using the `export.sh` script being called from a different folder.