### PR TITLE
Fix for Compressed Keys with FIPS

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -11973,8 +11973,7 @@ static int SetEccPublicKey(byte* output, ecc_key* key, int outLen,
     if (ret == 0) {
         /* Calculate the size of the encoded public point. */
         PRIVATE_KEY_UNLOCK();
-    #if defined(HAVE_COMP_KEY) && defined(HAVE_FIPS) && \
-            defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION == 2)
+    #if defined(HAVE_COMP_KEY) && defined(HAVE_FIPS) && FIPS_VERSION3_LT(6,0,0)
         /* in earlier versions of FIPS the get length functionality is not
          * available with compressed keys */
         pubSz = key->dp ? key->dp->size : MAX_ECC_BYTES;


### PR DESCRIPTION
# Description

The macro guard that was edited in this PR should have accounted for HAVE_FIPS_VERSION=5 as well as HAVE_FIPS_VERSION=2, since neither versions have the get length functionality available with compressed keys

Fixes zd#

# Testing

wolfCrypt tests with `./configure --enable-fips=v5 CFLAGS=-DHAVE_COMP_KEY` fails before this PR

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
