### PR TITLE
Espressif Managed Component wolfSSL 5.7.4 post-release update

### DIFF
--- a/IDE/Espressif/ESP-IDF/examples/template/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/template/CMakeLists.txt
@@ -3,10 +3,12 @@
 #
 # The following lines of boilerplate have to be in your project's
 # CMakeLists in this exact order for cmake to work correctly
+message(STATUS "Begin project ${CMAKE_PROJECT_NAME}")
+
 cmake_minimum_required(VERSION 3.16)
 
 # Optional no watchdog typically used for test & benchmark
-add_compile_options(-DWOLFSSL_ESP_NO_WATCHDOG=1)
+add_compile_definitions(WOLFSSL_ESP_NO_WATCHDOG=1)
 
 # The wolfSSL CMake file should be able to find the source code.
 # Otherwise, assign an environment variable or set it here:
@@ -25,34 +27,63 @@ add_compile_options(-DWOLFSSL_ESP_NO_WATCHDOG=1)
 if(WIN32)
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
-    message("Detected Windows")
+    message(STATUS "Detected Windows")
 endif()
 if(CMAKE_HOST_UNIX)
-    message("Detected UNIX")
+    message(STATUS "Detected UNIX")
 endif()
 if(APPLE)
-    message("Detected APPLE")
+    message(STATUS "Detected APPLE")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
-    message("Detected WSL")
+    message(STATUS "Detected WSL")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
-    message("Detected Linux")
+    message(STATUS "Detected Linux")
 endif()
 if(APPLE)
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
-    message("Detected Apple")
+    message(STATUS "Detected Apple")
 endif()
 # End optional WOLFSSL_CMAKE_SYSTEM_NAME
+
+# This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
+# set (PROTOCOL_EXAMPLES_DIR $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
+string(REPLACE "\\" "/" PROTOCOL_EXAMPLES_DIR "$ENV{IDF_PATH}/examples/common_components/protocol_examples_common")
+
+if (EXISTS "${PROTOCOL_EXAMPLES_DIR}")
+    message(STATUS "Found PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
+    set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DFOUND_PROTOCOL_EXAMPLES_DIR")
+else()
+    message(STATUS "NOT FOUND: PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
+endif()
+
+# Find the user name to search for possible "wolfssl-username"
+# Reminder: Windows is  %USERNAME%, Linux is $USER
+message(STATUS "USERNAME = $ENV{USERNAME}")
+if(  "$ENV{USER}" STREQUAL "" ) # the bash user
+    if(  "$ENV{USERNAME}" STREQUAL "" ) # the Windows user
+        message(STATUS "could not find USER or USERNAME")
+    else()
+        # the bash user is not blank, so we'll use it.
+        set(THIS_USER "$ENV{USERNAME}")
+    endif()
+else()
+    # the bash user is not blank, so we'll use it.
+    set(THIS_USER "$ENV{USER}")
+endif()
+message(STATUS "THIS_USER = ${THIS_USER}")
 
 # Check that there are not conflicting wolfSSL components
 # The ESP Registry Component will be in ./managed_components/wolfssl__wolfssl
 # The local component wolfSSL directory will be in ./components/wolfssl
+message(STATUS "Checking for wolfSSL as Managed Component or not... ${CMAKE_HOME_DIRECTORY}")
 if( EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl" AND EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl" )
     # These exclude statements don't seem to be honored by the $ENV{IDF_PATH}/tools/cmake/project.cmake'
     # add_subdirectory("${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl" EXCLUDE_FROM_ALL)
@@ -67,16 +98,46 @@ if( EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl" AND EXI
     message(FATAL_ERROR "\nPlease use either the ESP Registry Managed Component or the wolfSSL component directory but not both.\n"
                         "If removing the ./managed_components/wolfssl__wolfssl directory, remember to also remove "
                         "or rename the idf_component.yml file typically found in ./main/")
-else()
+elseif(EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
+    # A standard project component (not a Managed Component)
     message(STATUS "No conflicting wolfSSL components found.")
+    set(WOLFSSL_PATH "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
+elseif(EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl")
+    # The official Managed Component called wolfssl from the wolfssl user.
+    message(STATUS "No conflicting wolfSSL components found as a Managed Component.")
+    set(WOLFSSL_PATH "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl")
+elseif(EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/gojimmypi__mywolfssl")
+    # There is a known gojimmypi staging component available for anyone:
+    message(STATUS "No conflicting wolfSSL components found as a gojimmypi staging Managed Component.")
+elseif(EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/${THIS_USER}__mywolfssl")
+    # Other users with permissions might publish their own mywolfssl staging Managed Component
+    message(STATUS "No conflicting wolfSSL components found as a Managed Component.")
+    set(WOLFSSL_PATH "${CMAKE_HOME_DIRECTORY}/managed_components/${THIS_USER}__mywolfssl")
+else()
+    message(STATUS "WARNING: wolfssl component directory not found.")
 endif()
 
-# Ensure the this wolfSSL component directory is included
-set(WOLFSSL_PATH "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
-list(APPEND EXTRA_COMPONENT_DIRS ${WOLFSSL_PATH})
+# message(STATUS "EXTRA_COMPONENT_DIRS WOLFSSL_PATH: ${WOLFSSL_PATH}")
+# list(APPEND EXTRA_COMPONENT_DIRS ${WOLFSSL_PATH})
 
 # Not only is a project-level "set(COMPONENTS" not needed here, this will cause
 # an unintuitive error about  Unknown CMake command "esptool_py_flash_project_args".
+
+message(STATUS "begin optional PROTOCOL_EXAMPLES_DIR include")
+if(0)
+    # This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
+    set (PROTOCOL_EXAMPLES_DIR $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
+
+    if (EXISTS "${PROTOCOL_EXAMPLES_DIR}")
+        message(STATUS "Found PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
+        set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DFOUND_PROTOCOL_EXAMPLES_DIR")
+    else()
+        message(STATUS "NOT FOUND: PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
+    endif()
+endif()
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+message(STATUS "end optional include")
 
 project(wolfssl_template)
+message(STATUS "end project")

--- a/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/CMakeLists.txt
@@ -102,28 +102,28 @@ if(VERBOSE_COMPONENT_MESSAGES)
     if(WIN32)
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
-        message("Detected Windows")
+        message(STATUS "Detected Windows")
     endif()
     if(CMAKE_HOST_UNIX)
-        message("Detected UNIX")
+        message(STATUS "Detected UNIX")
     endif()
     if(APPLE)
-        message("Detected APPLE")
+        message(STATUS "Detected APPLE")
     endif()
     if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
-        message("Detected WSL")
+        message(STATUS "Detected WSL")
     endif()
     if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
-        message("Detected Linux")
+        message(STATUS "Detected Linux")
     endif()
     if(APPLE)
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
-        message("Detected Apple")
+        message(STATUS "Detected Apple")
     endif()
 endif() # End optional WOLFSSL_CMAKE_SYSTEM_NAME
 
@@ -159,7 +159,8 @@ else()
     set(COMPONENT_REQUIRES lwip "${THIS_ESP_TLS}") # we typically don't need lwip directly in wolfssl component
 endif()
 
-# find the user name to search for possible "wolfssl-username"
+# Find the user name to search for possible "wolfssl-username"
+# Reminder: Windows is  %USERNAME%, Linux is $USER
 message(STATUS "USERNAME = $ENV{USERNAME}")
 if(  "$ENV{USER}" STREQUAL "" ) # the bash user
     if(  "$ENV{USERNAME}" STREQUAL "" ) # the Windows user
@@ -524,7 +525,7 @@ else()
     set(WOLFSSL_PROJECT_DIR "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
 
     string(REPLACE "/" "//" STR_WOLFSSL_PROJECT_DIR "${WOLFSSL_PROJECT_DIR}")
-    add_definitions(-DWOLFSSL_USER_SETTINGS_DIR="${STR_WOLFSSL_PROJECT_DIR}/include/user_settings.h")
+    add_compile_definitions(WOLFSSL_USER_SETTINGS_DIR="${STR_WOLFSSL_PROJECT_DIR}/include/user_settings.h")
     message(STATUS "Added definition for user_settings.h: -DWOLFSSL_USER_SETTINGS_DIR=\"${STR_WOLFSSL_PROJECT_DIR}//include//user_settings.h\"")
     # Espressif may take several passes through this makefile. Check to see if we found IDF
     string(COMPARE EQUAL "${PROJECT_SOURCE_DIR}" "" WOLFSSL_FOUND_IDF)
@@ -951,7 +952,7 @@ function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
         message(STATUS "Found ${VAR_OUPUT}=${VAR_VALUE}")
 
         # the interesting part is defining the VAR_OUPUT name a value to use in the app
-        add_definitions(-D${VAR_OUPUT}=\"${VAR_VALUE}\")
+        add_compile_definitions(${VAR_OUPUT}=\"${VAR_VALUE}\")
     else()
         # if we get here, check the execute_process command and parameters.
         message(STATUS "LIBWOLFSSL_SAVE_INFO encountered a non-zero VAR_RESULT")
@@ -959,9 +960,16 @@ function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
     endif()
 endfunction() # LIBWOLFSSL_SAVE_INFO
 
+execute_process(
+    COMMAND ${git_cmd} "rev-parse" "--is-inside-work-tree"
+    OUTPUT_VARIABLE IS_GIT_REPO
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+
 # create some programmatic #define values that will be used by ShowExtendedSystemInfo().
 # see wolfcrypt\src\port\Espressif\esp32_utl.c
-if(NOT CMAKE_BUILD_EARLY_EXPANSION AND WOLFSSL_ROOT)
+if(NOT CMAKE_BUILD_EARLY_EXPANSION AND WOLFSSL_ROOT AND (IS_GIT_REPO STREQUAL "true"))
     set (git_cmd "git")
     message(STATUS "Adding macro definitions:")
 

--- a/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/Kconfig
+++ b/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/Kconfig
@@ -41,7 +41,7 @@
 # The maximum length of options is NOT 50 characters as documented.
 #   kconfcheck will complain that options should be 40 at most.
 #
-# Fix option lengths first. Superflous errors on other lines may occur.
+# Fix option lengths first. Superfluous errors on other lines may occur.
 #
 # The maximum length of lines is 120 characters.
 #

--- a/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/component.mk
+++ b/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/component.mk
@@ -82,7 +82,7 @@ WOLFSSL_ROOT := ../../../../../../..
 # "/mnt/c" is 4 directories up:
 #             2 for `./test/demo` from where we run `make`, plus
 #             2 more from the location of `component.mk` located
-#               in `[currect directory]/components/wolfssl`.
+#               in `[current directory]/components/wolfssl`.
 #
 # Thus we need 4 parent reference to find the relative path to wolfSSL:
 # WOLFSSL_ROOT := ../../../../workspace/wolfssl-master

--- a/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/include/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/examples/template/components/wolfssl/include/user_settings.h
@@ -786,7 +786,7 @@
     /***** END CONFIG_IDF_TARGET_ESP8684 *****/
 
 #else
-    /* Anything else encountered, disable HW accleration */
+    /* Anything else encountered, disable HW acceleration */
     #warning "Unexpected CONFIG_IDF_TARGET_NN value"
     #define NO_ESP32_CRYPT
     #define NO_WOLFSSL_ESP32_CRYPT_HASH

--- a/IDE/Espressif/ESP-IDF/examples/template/main/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/template/main/CMakeLists.txt
@@ -3,33 +3,34 @@
 #
 # wolfssl template
 #
+message(STATUS "Begin wolfSSL main CMakeLists.txt")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
 
 if(WIN32)
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
-    message("Detected Windows")
+    message(STATUS "Detected Windows")
 endif()
 if(CMAKE_HOST_UNIX)
-    message("Detected UNIX")
+    message(STATUS "Detected UNIX")
 endif()
 if(APPLE)
-    message("Detected APPLE")
+    message(STATUS "Detected APPLE")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
-    message("Detected WSL")
+    message(STATUS "Detected WSL")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
-    message("Detected Linux")
+    message(STATUS "Detected Linux")
 endif()
 if(APPLE)
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
-    message("Detected Apple")
+    message(STATUS "Detected Apple")
 endif()
 set (git_cmd "git")
 
@@ -43,10 +44,20 @@ if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/" AND EXISTS "$ENV{IDF_PA
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_MULTI_INSTALL_WARNING")
 endif()
 
+# The wolfSL component name is named "mywolfssl" on the staging site for Managed Components.
+if( NOT EXISTS "../components/wolfssl" AND ("$ENV{IDF_COMPONENT_REGISTRY_URL}" STREQUAL "https://components-staging.espressif.com") )
+    message(STATUS "WARNING: Using a staging instance of wolfssl.")
+    set(MAIN_WOLFSSL_COMPONENT_NAME "mywolfssl")
+else()
+    message(STATUS "Using release wolfssl component.")
+    set(MAIN_WOLFSSL_COMPONENT_NAME "wolfssl")
+endif()
+
 ## register_component()
 idf_component_register(SRCS main.c
                        INCLUDE_DIRS "."
-                                    "./include")
+                            "./include"
+                       PRIV_REQUIRES driver "${MAIN_WOLFSSL_COMPONENT_NAME}")
 
 #
 # LIBWOLFSSL_SAVE_INFO(VAR_OUPUT THIS_VAR VAR_RESULT)
@@ -76,15 +87,24 @@ function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
         message(STATUS "Found ${VAR_OUPUT}=${VAR_VALUE}")
 
         # the interesting part is defining the VAR_OUPUT name a value to use in the app
-        add_definitions(-D${VAR_OUPUT}=\"${VAR_VALUE}\")
+        add_compile_definitions(${VAR_OUPUT}=\"${VAR_VALUE}\")
     else()
         # if we get here, check the execute_process command and parameters.
-        message(STATUS "LIBWOLFSSL_SAVE_INFO encountered a non-zero VAR_RESULT")
+        message(STATUS "LIBWOLFSSL_SAVE_INFO encountered a non-zero VAR_RESULT.")
+        message(STATUS "Setting ${VAR_OUPUT} to \"Unknown\"")
         set(${VAR_OUPUT} "Unknown")
     endif()
 endfunction() # LIBWOLFSSL_SAVE_INFO
 
-if(NOT CMAKE_BUILD_EARLY_EXPANSION)
+execute_process(
+    COMMAND ${git_cmd} "rev-parse" "--is-inside-work-tree"
+    OUTPUT_VARIABLE IS_GIT_REPO
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+
+# Save some project-specific details. Repo may be different than component, or may not even be a repo at all:
+if(NOT CMAKE_BUILD_EARLY_EXPANSION AND (IS_GIT_REPO STREQUAL "true"))
     # LIBWOLFSSL_VERSION_GIT_HASH
     execute_process(COMMAND ${git_cmd} "rev-parse" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET )
     LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH "${TMP_OUT}" "${TMP_RES}")
@@ -100,3 +120,4 @@ endif()
 
 message(STATUS "")
 
+message(STATUS "End wolfSSL main CMakeLists.txt")

--- a/IDE/Espressif/ESP-IDF/examples/template/main/Kconfig.projbuild
+++ b/IDE/Espressif/ESP-IDF/examples/template/main/Kconfig.projbuild
@@ -57,7 +57,7 @@ choice WOLFSSL_EXAMPLE_CHOOSE
     config WOLFSSL_EXAMPLE_NAME_WOLFSSH_TEMPLATE
         bool "SSH Template App"
         help
-            Bare-bones Hellow World app that only compiles in wolfSSL and wolfSSH.
+            Bare-bones Hello World app that only compiles in wolfSSL and wolfSSH.
             See wolfSSL/wolfssh on GitHub.
 
     config WOLFSSL_EXAMPLE_NAME_WOLFSSH_ECHOSERVER

--- a/IDE/Espressif/ESP-IDF/examples/template/sdkconfig.defaults
+++ b/IDE/Espressif/ESP-IDF/examples/template/sdkconfig.defaults
@@ -1,10 +1,13 @@
 # Set the known example app config to template example (see user_settings.h)
 CONFIG_WOLFSSL_EXAMPLE_NAME_TEMPLATE=y
+# CONFIG_EXAMPLE_WIFI_SSID="myssid"
+# CONFIG_EXAMPLE_WIFI_PASSWORD="mypassword"
 
 # Some wolfSSL helpers
 CONFIG_USE_WOLFSSL_ESP_SDK_TIME=y
 
-
+# sdkconfig.defaults for ESP8266 + ESP32
+# See separate sdkconfig.defaults.esp8266
 # FreeRTOS ticks at 1ms interval
 CONFIG_FREERTOS_UNICORE=y
 CONFIG_FREERTOS_HZ=1000
@@ -18,9 +21,10 @@ CONFIG_ESP32_DEFAULT_CPU_FREQ_240=y
 #
 # For wolfSSL SMALL_STACK, 3072 bytes should be sufficient for benchmark app.
 # When using RSA, assign at least 10500 bytes, otherwise 5500 usually works for others
-CONFIG_ESP_MAIN_TASK_STACK_SIZE=3584
-# Legacy stack size for older ESP-IDF versions
-CONFIG_MAIN_TASK_STACK_SIZE=3584
+# We set this to 28672 for use in the "test everything possible" in the wolfssl_test app.
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=10500
+# Legacy stack size name for older ESP-IDF versions
+CONFIG_MAIN_TASK_STACK_SIZE=10500
 
 #
 # Benchmark must not have CONFIG_NEWLIB_NANO_FORMAT enabled
@@ -61,8 +65,8 @@ CONFIG_HEAP_DISABLE_IRAM=y
 CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
 
 # Enable wolfSSL TLS in esp-tls
-CONFIG_ESP_TLS_USING_WOLFSSL=y
-CONFIG_TLS_STACK_WOLFSSL=y
+# CONFIG_ESP_TLS_USING_WOLFSSL=y
+# CONFIG_TLS_STACK_WOLFSSL=y
 
 # Bundles take up flash space and are disabled unless otherwise known to be needed
 CONFIG_WOLFSSL_CERTIFICATE_BUNDLE=n
@@ -86,6 +90,13 @@ CONFIG_HEAP_DISABLE_IRAM=y
 
 # Performance
 # CONFIG_COMPILER_OPTIMIZATION_PERF=y
+
+# Set max COU frequency (falls back as needed for lower maximum)
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
+
+# FreeRTOS ticks at 1ms interval
+CONFIG_FREERTOS_UNICORE=y
+CONFIG_FREERTOS_HZ=1000
 
 # Ensure mbedTLS options are disabled
 # CONFIG_MBEDTLS_TLS_SERVER_AND_CLIENT=n

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/CMakeLists.txt
@@ -3,10 +3,12 @@
 #
 # The following lines of boilerplate have to be in your project's
 # CMakeLists in this exact order for cmake to work correctly
+message(STATUS "Begin project ${CMAKE_PROJECT_NAME}")
+
 cmake_minimum_required(VERSION 3.16)
 
 # Optional no watchdog typically used for test & benchmark
-add_compile_options(-DWOLFSSL_ESP_NO_WATCHDOG=1)
+add_compile_definitions(WOLFSSL_ESP_NO_WATCHDOG=1)
 
 # The wolfSSL CMake file should be able to find the source code.
 # Otherwise, assign an environment variable or set it here:
@@ -25,34 +27,35 @@ add_compile_options(-DWOLFSSL_ESP_NO_WATCHDOG=1)
 if(WIN32)
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
-    message("Detected Windows")
+    message(STATUS "Detected Windows")
 endif()
 if(CMAKE_HOST_UNIX)
-    message("Detected UNIX")
+    message(STATUS "Detected UNIX")
 endif()
 if(APPLE)
-    message("Detected APPLE")
+    message(STATUS "Detected APPLE")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
-    message("Detected WSL")
+    message(STATUS "Detected WSL")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
-    message("Detected Linux")
+    message(STATUS "Detected Linux")
 endif()
 if(APPLE)
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
-    message("Detected Apple")
+    message(STATUS "Detected Apple")
 endif()
 # End optional WOLFSSL_CMAKE_SYSTEM_NAME
 
 # Check that there are not conflicting wolfSSL components
 # The ESP Registry Component will be in ./managed_components/wolfssl__wolfssl
 # The local component wolfSSL directory will be in ./components/wolfssl
+message(STATUS "Checking for wolfSSL as Managed Component or not... ${CMAKE_HOME_DIRECTORY}")
 if( EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl" AND EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl" )
     # These exclude statements don't seem to be honored by the $ENV{IDF_PATH}/tools/cmake/project.cmake'
     # add_subdirectory("${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl" EXCLUDE_FROM_ALL)
@@ -67,16 +70,46 @@ if( EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl" AND EXI
     message(FATAL_ERROR "\nPlease use either the ESP Registry Managed Component or the wolfSSL component directory but not both.\n"
                         "If removing the ./managed_components/wolfssl__wolfssl directory, remember to also remove "
                         "or rename the idf_component.yml file typically found in ./main/")
-else()
+elseif(EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
+    # A standard project component (not a Managed Component)
     message(STATUS "No conflicting wolfSSL components found.")
+    set(WOLFSSL_PATH "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
+elseif(EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl")
+    # The official Managed Component called wolfssl from the wolfssl user.
+    message(STATUS "No conflicting wolfSSL components found as a Managed Component.")
+    set(WOLFSSL_PATH "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl")
+elseif(EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/gojimmypi__mywolfssl")
+    # There is a known gojimmypi staging component available for anyone:
+    message(STATUS "No conflicting wolfSSL components found as a gojimmypi staging Managed Component.")
+elseif(EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/${THIS_USER}__mywolfssl")
+    # Other users with permissions might publish their own mywolfssl staging Managed Component
+    message(STATUS "No conflicting wolfSSL components found as a Managed Component.")
+    set(WOLFSSL_PATH "${CMAKE_HOME_DIRECTORY}/managed_components/${THIS_USER}__mywolfssl")
+else()
+    message(STATUS "WARNING: wolfssl component directory not found.")
 endif()
 
-# Ensure the this wolfSSL component directory is included
-set(WOLFSSL_PATH "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
-list(APPEND EXTRA_COMPONENT_DIRS ${WOLFSSL_PATH})
+# message(STATUS "EXTRA_COMPONENT_DIRS WOLFSSL_PATH: ${WOLFSSL_PATH}")
+# list(APPEND EXTRA_COMPONENT_DIRS ${WOLFSSL_PATH})
 
 # Not only is a project-level "set(COMPONENTS" not needed here, this will cause
 # an unintuitive error about  Unknown CMake command "esptool_py_flash_project_args".
+
+message(STATUS "begin optional PROTOCOL_EXAMPLES_DIR include")
+if(0)
+    # This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
+    set (PROTOCOL_EXAMPLES_DIR $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
+
+    if (EXISTS "${PROTOCOL_EXAMPLES_DIR}")
+        message(STATUS "Found PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
+        set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DFOUND_PROTOCOL_EXAMPLES_DIR")
+    else()
+        message(STATUS "NOT FOUND: PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
+    endif()
+endif()
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+message(STATUS "end optional include")
 
 project(wolfssl_benchmark)
+message(STATUS "end project")

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/components/wolfssl/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/components/wolfssl/CMakeLists.txt
@@ -102,28 +102,28 @@ if(VERBOSE_COMPONENT_MESSAGES)
     if(WIN32)
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
-        message("Detected Windows")
+        message(STATUS "Detected Windows")
     endif()
     if(CMAKE_HOST_UNIX)
-        message("Detected UNIX")
+        message(STATUS "Detected UNIX")
     endif()
     if(APPLE)
-        message("Detected APPLE")
+        message(STATUS "Detected APPLE")
     endif()
     if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
-        message("Detected WSL")
+        message(STATUS "Detected WSL")
     endif()
     if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
-        message("Detected Linux")
+        message(STATUS "Detected Linux")
     endif()
     if(APPLE)
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
-        message("Detected Apple")
+        message(STATUS "Detected Apple")
     endif()
 endif() # End optional WOLFSSL_CMAKE_SYSTEM_NAME
 
@@ -524,7 +524,7 @@ else()
     set(WOLFSSL_PROJECT_DIR "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
 
     string(REPLACE "/" "//" STR_WOLFSSL_PROJECT_DIR "${WOLFSSL_PROJECT_DIR}")
-    add_definitions(-DWOLFSSL_USER_SETTINGS_DIR="${STR_WOLFSSL_PROJECT_DIR}/include/user_settings.h")
+    add_compile_definitions(WOLFSSL_USER_SETTINGS_DIR="${STR_WOLFSSL_PROJECT_DIR}/include/user_settings.h")
     message(STATUS "Added definition for user_settings.h: -DWOLFSSL_USER_SETTINGS_DIR=\"${STR_WOLFSSL_PROJECT_DIR}//include//user_settings.h\"")
     # Espressif may take several passes through this makefile. Check to see if we found IDF
     string(COMPARE EQUAL "${PROJECT_SOURCE_DIR}" "" WOLFSSL_FOUND_IDF)
@@ -951,7 +951,7 @@ function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
         message(STATUS "Found ${VAR_OUPUT}=${VAR_VALUE}")
 
         # the interesting part is defining the VAR_OUPUT name a value to use in the app
-        add_definitions(-D${VAR_OUPUT}=\"${VAR_VALUE}\")
+        add_compile_definitions(${VAR_OUPUT}=\"${VAR_VALUE}\")
     else()
         # if we get here, check the execute_process command and parameters.
         message(STATUS "LIBWOLFSSL_SAVE_INFO encountered a non-zero VAR_RESULT")
@@ -959,9 +959,16 @@ function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
     endif()
 endfunction() # LIBWOLFSSL_SAVE_INFO
 
+execute_process(
+    COMMAND ${git_cmd} "rev-parse" "--is-inside-work-tree"
+    OUTPUT_VARIABLE IS_GIT_REPO
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+
 # create some programmatic #define values that will be used by ShowExtendedSystemInfo().
 # see wolfcrypt\src\port\Espressif\esp32_utl.c
-if(NOT CMAKE_BUILD_EARLY_EXPANSION AND WOLFSSL_ROOT)
+if(NOT CMAKE_BUILD_EARLY_EXPANSION AND WOLFSSL_ROOT AND (IS_GIT_REPO STREQUAL "true"))
     set (git_cmd "git")
     message(STATUS "Adding macro definitions:")
 

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/components/wolfssl/Kconfig
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/components/wolfssl/Kconfig
@@ -41,7 +41,7 @@
 # The maximum length of options is NOT 50 characters as documented.
 #   kconfcheck will complain that options should be 40 at most.
 #
-# Fix option lengths first. Superflous errors on other lines may occur.
+# Fix option lengths first. Superfluous errors on other lines may occur.
 #
 # The maximum length of lines is 120 characters.
 #

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/components/wolfssl/component.mk
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/components/wolfssl/component.mk
@@ -82,7 +82,7 @@ WOLFSSL_ROOT := ../../../../../../..
 # "/mnt/c" is 4 directories up:
 #             2 for `./test/demo` from where we run `make`, plus
 #             2 more from the location of `component.mk` located
-#               in `[currect directory]/components/wolfssl`.
+#               in `[current directory]/components/wolfssl`.
 #
 # Thus we need 4 parent reference to find the relative path to wolfSSL:
 # WOLFSSL_ROOT := ../../../../workspace/wolfssl-master

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/components/wolfssl/include/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/components/wolfssl/include/user_settings.h
@@ -786,7 +786,7 @@
     /***** END CONFIG_IDF_TARGET_ESP8684 *****/
 
 #else
-    /* Anything else encountered, disable HW accleration */
+    /* Anything else encountered, disable HW acceleration */
     #warning "Unexpected CONFIG_IDF_TARGET_NN value"
     #define NO_ESP32_CRYPT
     #define NO_WOLFSSL_ESP32_CRYPT_HASH

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/main/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/main/CMakeLists.txt
@@ -8,6 +8,32 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
 set(COMPONENT_SRCS "main.c")
 set(COMPONENT_ADD_INCLUDEDIRS ".")
 
+if(WIN32)
+    # Windows-specific configuration here
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
+    message(STATUS "Detected Windows")
+endif()
+if(CMAKE_HOST_UNIX)
+    message(STATUS "Detected UNIX")
+endif()
+if(APPLE)
+    message(STATUS "Detected APPLE")
+endif()
+if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
+    # Windows-specific configuration here
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
+    message(STATUS "Detected WSL")
+endif()
+if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
+    # Windows-specific configuration here
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
+    message(STATUS "Detected Linux")
+endif()
+if(APPLE)
+    # Windows-specific configuration here
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
+    message(STATUS "Detected Apple")
+endif()
 set (git_cmd "git")
 
 if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/" AND EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
@@ -20,9 +46,20 @@ if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/" AND EXISTS "$ENV{IDF_PA
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_MULTI_INSTALL_WARNING")
 endif()
 
+# The wolfSL component name is named "mywolfssl" on the staging site for Managed Components.
+if( NOT EXISTS "../components/wolfssl" AND ("$ENV{IDF_COMPONENT_REGISTRY_URL}" STREQUAL "https://components-staging.espressif.com") )
+    message(STATUS "WARNING: Using a staging instance of wolfssl.")
+    set(MAIN_WOLFSSL_COMPONENT_NAME "mywolfssl")
+else()
+    message(STATUS "Using release wolfssl component.")
+    set(MAIN_WOLFSSL_COMPONENT_NAME "wolfssl")
+endif()
+
+## register_component()
 idf_component_register(SRCS main.c
                        INCLUDE_DIRS "."
-                       "./include")
+                            "./include"
+                       PRIV_REQUIRES driver "${MAIN_WOLFSSL_COMPONENT_NAME}")
 
 #
 # LIBWOLFSSL_SAVE_INFO(VAR_OUPUT THIS_VAR VAR_RESULT)
@@ -52,15 +89,24 @@ function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
         message(STATUS "Found ${VAR_OUPUT}=${VAR_VALUE}")
 
         # the interesting part is defining the VAR_OUPUT name a value to use in the app
-        add_definitions(-D${VAR_OUPUT}=\"${VAR_VALUE}\")
+        add_compile_definitions(${VAR_OUPUT}=\"${VAR_VALUE}\")
     else()
         # if we get here, check the execute_process command and parameters.
-        message(STATUS "LIBWOLFSSL_SAVE_INFO encountered a non-zero VAR_RESULT")
+        message(STATUS "LIBWOLFSSL_SAVE_INFO encountered a non-zero VAR_RESULT.")
+        message(STATUS "Setting ${VAR_OUPUT} to \"Unknown\"")
         set(${VAR_OUPUT} "Unknown")
     endif()
 endfunction() # LIBWOLFSSL_SAVE_INFO
 
-if(NOT CMAKE_BUILD_EARLY_EXPANSION)
+execute_process(
+    COMMAND ${git_cmd} "rev-parse" "--is-inside-work-tree"
+    OUTPUT_VARIABLE IS_GIT_REPO
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+
+# Save some project-specific details. Repo may be different than component, or may not even be a repo at all:
+if(NOT CMAKE_BUILD_EARLY_EXPANSION AND (IS_GIT_REPO STREQUAL "true"))
     # LIBWOLFSSL_VERSION_GIT_HASH
     execute_process(COMMAND ${git_cmd} "rev-parse" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET )
     LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH "${TMP_OUT}" "${TMP_RES}")
@@ -76,3 +122,4 @@ endif()
 
 message(STATUS "")
 
+message(STATUS "End wolfSSL main CMakeLists.txt")

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/sdkconfig.defaults
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/sdkconfig.defaults
@@ -1,12 +1,13 @@
 # Set the known example app config to template example (see user_settings.h)
 CONFIG_WOLFSSL_EXAMPLE_NAME_WOLFSSL_BENCHMARK=y
+# CONFIG_EXAMPLE_WIFI_SSID="myssid"
+# CONFIG_EXAMPLE_WIFI_PASSWORD="mypassword"
 
 # Some wolfSSL helpers
 CONFIG_USE_WOLFSSL_ESP_SDK_TIME=y
 
 # sdkconfig.defaults for ESP8266 + ESP32
 # Note that during the build process, settings from sdkconfig.defaults will not override those already in sdkconfig.
-# See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
 CONFIG_BENCH_ARGV="-lng 0"
 # FreeRTOS ticks at 1ms interval
 CONFIG_FREERTOS_UNICORE=y
@@ -24,7 +25,7 @@ CONFIG_ESP32_DEFAULT_CPU_FREQ_240=y
 # We set this to 28672 for use in the "test everything possible" in the wolfssl_test app.
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=28672
 
-# Legacy stack size for older ESP-IDF versions
+# Legacy stack size name for older ESP-IDF versions
 CONFIG_MAIN_TASK_STACK_SIZE=28672
 
 #
@@ -66,8 +67,8 @@ CONFIG_HEAP_DISABLE_IRAM=y
 CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
 
 # Enable wolfSSL TLS in esp-tls
-CONFIG_ESP_TLS_USING_WOLFSSL=y
-CONFIG_TLS_STACK_WOLFSSL=y
+# CONFIG_ESP_TLS_USING_WOLFSSL=y
+# CONFIG_TLS_STACK_WOLFSSL=y
 
 # Bundles take up flash space and are disabled unless otherwise known to be needed
 CONFIG_WOLFSSL_CERTIFICATE_BUNDLE=n
@@ -98,6 +99,26 @@ CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
 # FreeRTOS ticks at 1ms interval
 CONFIG_FREERTOS_UNICORE=y
 CONFIG_FREERTOS_HZ=1000
+
+# Ensure mbedTLS options are disabled
+# CONFIG_MBEDTLS_TLS_SERVER_AND_CLIENT=n
+# CONFIG_MBEDTLS_TLS_CLIENT_ONLY=n
+# CONFIG_MBEDTLS_TLS_SERVER=n
+# CONFIG_MBEDTLS_TLS_CLIENT=n
+# CONFIG_MBEDTLS_HARDWARE_AES=n
+# CONFIG_MBEDTLS_HARDWARE_MPI=n
+# CONFIG_MBEDTLS_HARDWARE_SHA=n
+# CONFIG_MBEDTLS_ROM_MD5=n
+# CONFIG_MBEDTLS_SSL_RENEGOTIATION=n
+# CONFIG_MBEDTLS_SSL_PROTO_TLS1_2=n
+# CONFIG_MBEDTLS_SSL_PROTO_GMTSSL1_1=n
+# CONFIG_MBEDTLS_SSL_ALPN=n
+# CONFIG_MBEDTLS_CLIENT_SSL_SESSION_TICKETS=n
+# CONFIG_MBEDTLS_SERVER_SSL_SESSION_TICKETS=n
+
+# The same-name config is used for both WiFi and client/server TLS, so we cannot disable:
+# CONFIG_MBEDTLS_TLS_ENABLED=n
+# CONFIG_MBEDTLS_TLS_DISABLED=y
 
 #
 # Compiler options

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/CMakeLists.txt
@@ -1,11 +1,14 @@
 # wolfSSL Espressif Example Project CMakeLists.txt
-#   v1.0
+#   v1.3
 #
 # The following lines of boilerplate have to be in your project's
 # CMakeLists in this exact order for cmake to work correctly
 message(STATUS "Begin project ${CMAKE_PROJECT_NAME}")
 
 cmake_minimum_required(VERSION 3.16)
+
+# Optional no watchdog typically used for test & benchmark
+add_compile_definitions(WOLFSSL_ESP_NO_WATCHDOG=1)
 
 # The wolfSSL CMake file should be able to find the source code.
 # Otherwise, assign an environment variable or set it here:
@@ -24,28 +27,28 @@ cmake_minimum_required(VERSION 3.16)
 if(WIN32)
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
-    message("Detected Windows")
+    message(STATUS "Detected Windows")
 endif()
 if(CMAKE_HOST_UNIX)
-    message("Detected UNIX")
+    message(STATUS "Detected UNIX")
 endif()
 if(APPLE)
-    message("Detected APPLE")
+    message(STATUS "Detected APPLE")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
-    message("Detected WSL")
+    message(STATUS "Detected WSL")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
-    message("Detected Linux")
+    message(STATUS "Detected Linux")
 endif()
 if(APPLE)
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
-    message("Detected Apple")
+    message(STATUS "Detected Apple")
 endif()
 # End optional WOLFSSL_CMAKE_SYSTEM_NAME
 
@@ -54,16 +57,33 @@ endif()
 string(REPLACE "\\" "/" PROTOCOL_EXAMPLES_DIR "$ENV{IDF_PATH}/examples/common_components/protocol_examples_common")
 
 if (EXISTS "${PROTOCOL_EXAMPLES_DIR}")
-    message("Found PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
+    message(STATUS "Found PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
     set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DFOUND_PROTOCOL_EXAMPLES_DIR")
 else()
-    message("NOT FOUND: PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
+    message(STATUS "NOT FOUND: PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
 endif()
+
+# Find the user name to search for possible "wolfssl-username"
+# Reminder: Windows is  %USERNAME%, Linux is $USER
+message(STATUS "USERNAME = $ENV{USERNAME}")
+if(  "$ENV{USER}" STREQUAL "" ) # the bash user
+    if(  "$ENV{USERNAME}" STREQUAL "" ) # the Windows user
+        message(STATUS "could not find USER or USERNAME")
+    else()
+        # the bash user is not blank, so we'll use it.
+        set(THIS_USER "$ENV{USERNAME}")
+    endif()
+else()
+    # the bash user is not blank, so we'll use it.
+    set(THIS_USER "$ENV{USER}")
+endif()
+message(STATUS "THIS_USER = ${THIS_USER}")
 
 # Check that there are not conflicting wolfSSL components
 # The ESP Registry Component will be in ./managed_components/wolfssl__wolfssl
 # The local component wolfSSL directory will be in ./components/wolfssl
+message(STATUS "Checking for wolfSSL as Managed Component or not... ${CMAKE_HOME_DIRECTORY}")
 if( EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl" AND EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl" )
     # These exclude statements don't seem to be honored by the $ENV{IDF_PATH}/tools/cmake/project.cmake'
     # add_subdirectory("${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl" EXCLUDE_FROM_ALL)
@@ -78,25 +98,46 @@ if( EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl" AND EXI
     message(FATAL_ERROR "\nPlease use either the ESP Registry Managed Component or the wolfSSL component directory but not both.\n"
                         "If removing the ./managed_components/wolfssl__wolfssl directory, remember to also remove "
                         "or rename the idf_component.yml file typically found in ./main/")
-else()
+elseif(EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
+    # A standard project component (not a Managed Component)
     message(STATUS "No conflicting wolfSSL components found.")
+    set(WOLFSSL_PATH "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
+elseif(EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl")
+    # The official Managed Component called wolfssl from the wolfssl user.
+    message(STATUS "No conflicting wolfSSL components found as a Managed Component.")
+    set(WOLFSSL_PATH "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl")
+elseif(EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/gojimmypi__mywolfssl")
+    # There is a known gojimmypi staging component available for anyone:
+    message(STATUS "No conflicting wolfSSL components found as a gojimmypi staging Managed Component.")
+elseif(EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/${THIS_USER}__mywolfssl")
+    # Other users with permissions might publish their own mywolfssl staging Managed Component
+    message(STATUS "No conflicting wolfSSL components found as a Managed Component.")
+    set(WOLFSSL_PATH "${CMAKE_HOME_DIRECTORY}/managed_components/${THIS_USER}__mywolfssl")
+else()
+    message(STATUS "WARNING: wolfssl component directory not found.")
 endif()
 
+# message(STATUS "EXTRA_COMPONENT_DIRS WOLFSSL_PATH: ${WOLFSSL_PATH}")
+# list(APPEND EXTRA_COMPONENT_DIRS ${WOLFSSL_PATH})
 
-message(STATUS "begin include")
+# Not only is a project-level "set(COMPONENTS" not needed here, this will cause
+# an unintuitive error about  Unknown CMake command "esptool_py_flash_project_args".
+
 if(0)
+    message(STATUS "begin optional PROTOCOL_EXAMPLES_DIR include")
     # This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
     set (PROTOCOL_EXAMPLES_DIR $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
 
     if (EXISTS "${PROTOCOL_EXAMPLES_DIR}")
-        message("Found PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
+        message(STATUS "Found PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
         set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DFOUND_PROTOCOL_EXAMPLES_DIR")
     else()
-        message("NOT FOUND: PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
+        message(STATUS "NOT FOUND: PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
     endif()
+    message(STATUS "end optional include")
 endif()
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-message(STATUS "end include")
+
 project(wolfssl_client)
 message(STATUS "end project")

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/README_server_sm.md
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/README_server_sm.md
@@ -167,7 +167,7 @@ I (735) system_api: read default base MAC address from EFUSE
 I (755) wifi:wifi firmware version: 0d470ef
 I (755) wifi:wifi certification version: v7.0
 I (755) wifi:config NVS flash: enabled
-I (755) wifi:config nano formating: disabled
+I (755) wifi:config nano formatting: disabled
 I (755) wifi:Init data frame dynamic rx buffer num: 32
 I (765) wifi:Init management frame dynamic rx buffer num: 32
 I (765) wifi:Init management short buffer num: 32

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/components/wolfssl/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/components/wolfssl/CMakeLists.txt
@@ -102,28 +102,28 @@ if(VERBOSE_COMPONENT_MESSAGES)
     if(WIN32)
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
-        message("Detected Windows")
+        message(STATUS "Detected Windows")
     endif()
     if(CMAKE_HOST_UNIX)
-        message("Detected UNIX")
+        message(STATUS "Detected UNIX")
     endif()
     if(APPLE)
-        message("Detected APPLE")
+        message(STATUS "Detected APPLE")
     endif()
     if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
-        message("Detected WSL")
+        message(STATUS "Detected WSL")
     endif()
     if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
-        message("Detected Linux")
+        message(STATUS "Detected Linux")
     endif()
     if(APPLE)
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
-        message("Detected Apple")
+        message(STATUS "Detected Apple")
     endif()
 endif() # End optional WOLFSSL_CMAKE_SYSTEM_NAME
 
@@ -524,7 +524,7 @@ else()
     set(WOLFSSL_PROJECT_DIR "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
 
     string(REPLACE "/" "//" STR_WOLFSSL_PROJECT_DIR "${WOLFSSL_PROJECT_DIR}")
-    add_definitions(-DWOLFSSL_USER_SETTINGS_DIR="${STR_WOLFSSL_PROJECT_DIR}/include/user_settings.h")
+    add_compile_definitions(WOLFSSL_USER_SETTINGS_DIR="${STR_WOLFSSL_PROJECT_DIR}/include/user_settings.h")
     message(STATUS "Added definition for user_settings.h: -DWOLFSSL_USER_SETTINGS_DIR=\"${STR_WOLFSSL_PROJECT_DIR}//include//user_settings.h\"")
     # Espressif may take several passes through this makefile. Check to see if we found IDF
     string(COMPARE EQUAL "${PROJECT_SOURCE_DIR}" "" WOLFSSL_FOUND_IDF)
@@ -951,7 +951,7 @@ function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
         message(STATUS "Found ${VAR_OUPUT}=${VAR_VALUE}")
 
         # the interesting part is defining the VAR_OUPUT name a value to use in the app
-        add_definitions(-D${VAR_OUPUT}=\"${VAR_VALUE}\")
+        add_compile_definitions(${VAR_OUPUT}=\"${VAR_VALUE}\")
     else()
         # if we get here, check the execute_process command and parameters.
         message(STATUS "LIBWOLFSSL_SAVE_INFO encountered a non-zero VAR_RESULT")
@@ -959,9 +959,16 @@ function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
     endif()
 endfunction() # LIBWOLFSSL_SAVE_INFO
 
+execute_process(
+    COMMAND ${git_cmd} "rev-parse" "--is-inside-work-tree"
+    OUTPUT_VARIABLE IS_GIT_REPO
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+
 # create some programmatic #define values that will be used by ShowExtendedSystemInfo().
 # see wolfcrypt\src\port\Espressif\esp32_utl.c
-if(NOT CMAKE_BUILD_EARLY_EXPANSION AND WOLFSSL_ROOT)
+if(NOT CMAKE_BUILD_EARLY_EXPANSION AND WOLFSSL_ROOT AND (IS_GIT_REPO STREQUAL "true"))
     set (git_cmd "git")
     message(STATUS "Adding macro definitions:")
 

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/components/wolfssl/Kconfig
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/components/wolfssl/Kconfig
@@ -41,7 +41,7 @@
 # The maximum length of options is NOT 50 characters as documented.
 #   kconfcheck will complain that options should be 40 at most.
 #
-# Fix option lengths first. Superflous errors on other lines may occur.
+# Fix option lengths first. Superfluous errors on other lines may occur.
 #
 # The maximum length of lines is 120 characters.
 #

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/components/wolfssl/component.mk
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/components/wolfssl/component.mk
@@ -82,7 +82,7 @@ WOLFSSL_ROOT := ../../../../../../..
 # "/mnt/c" is 4 directories up:
 #             2 for `./test/demo` from where we run `make`, plus
 #             2 more from the location of `component.mk` located
-#               in `[currect directory]/components/wolfssl`.
+#               in `[current directory]/components/wolfssl`.
 #
 # Thus we need 4 parent reference to find the relative path to wolfSSL:
 # WOLFSSL_ROOT := ../../../../workspace/wolfssl-master

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/components/wolfssl/include/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/components/wolfssl/include/user_settings.h
@@ -786,7 +786,7 @@
     /***** END CONFIG_IDF_TARGET_ESP8684 *****/
 
 #else
-    /* Anything else encountered, disable HW accleration */
+    /* Anything else encountered, disable HW acceleration */
     #warning "Unexpected CONFIG_IDF_TARGET_NN value"
     #define NO_ESP32_CRYPT
     #define NO_WOLFSSL_ESP32_CRYPT_HASH

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/CMakeLists.txt
@@ -1,36 +1,36 @@
 # wolfSSL Espressif Example Project/main CMakeLists.txt
-#   v1.0
+#   v1.1
 #
 # wolfssl client test
 #
-message("Begin wolfSSL main CMakeLists.txt")
+message(STATUS "Begin wolfSSL main CMakeLists.txt")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
 
 if(WIN32)
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
-    message("Detected Windows")
+    message(STATUS "Detected Windows")
 endif()
 if(CMAKE_HOST_UNIX)
-    message("Detected UNIX")
+    message(STATUS "Detected UNIX")
 endif()
 if(APPLE)
-    message("Detected APPLE")
+    message(STATUS "Detected APPLE")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
-    message("Detected WSL")
+    message(STATUS "Detected WSL")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
-    message("Detected Linux")
+    message(STATUS "Detected Linux")
 endif()
 if(APPLE)
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
-    message("Detected Apple")
+    message(STATUS "Detected Apple")
 endif()
 set (git_cmd "git")
 
@@ -44,14 +44,26 @@ if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/" AND EXISTS "$ENV{IDF_PA
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_MULTI_INSTALL_WARNING")
 endif()
 
+# The wolfSL component name is named "mywolfssl" on the staging site for Managed Components.
+if( NOT EXISTS "../components/wolfssl" AND ("$ENV{IDF_COMPONENT_REGISTRY_URL}" STREQUAL "https://components-staging.espressif.com") )
+    message(STATUS "WARNING: Using a staging instance of wolfssl.")
+    set(MAIN_WOLFSSL_COMPONENT_NAME "mywolfssl")
+else()
+    message(STATUS "Using release wolfssl component.")
+    set(MAIN_WOLFSSL_COMPONENT_NAME "wolfssl")
+endif()
+
 ## register_component()
 idf_component_register(SRCS main.c
                             wifi_connect.c
                             time_helper.c
                             client-tls.c
                        INCLUDE_DIRS "."
-                                    "./include")
-#
+                            "./include"
+                       PRIV_REQUIRES "${MAIN_WOLFSSL_COMPONENT_NAME}"
+                                     driver
+                                     nvs_flash
+                                     protocol_examples_common)
 
 #
 # LIBWOLFSSL_SAVE_INFO(VAR_OUPUT THIS_VAR VAR_RESULT)
@@ -81,7 +93,7 @@ function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
         message(STATUS "Found ${VAR_OUPUT}=${VAR_VALUE}")
 
         # the interesting part is defining the VAR_OUPUT name a value to use in the app
-        add_definitions(-D${VAR_OUPUT}=\"${VAR_VALUE}\")
+        add_compile_definitions(${VAR_OUPUT}=\"${VAR_VALUE}\")
     else()
         # if we get here, check the execute_process command and parameters.
         message(STATUS "LIBWOLFSSL_SAVE_INFO encountered a non-zero VAR_RESULT.")
@@ -90,21 +102,28 @@ function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
     endif()
 endfunction() # LIBWOLFSSL_SAVE_INFO
 
+execute_process(
+    COMMAND ${git_cmd} "rev-parse" "--is-inside-work-tree"
+    OUTPUT_VARIABLE IS_GIT_REPO
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+
 # Save some project-specific details. Repo may be different than component, or may not even be a repo at all:
-if(NOT CMAKE_BUILD_EARLY_EXPANSION)
-    # WOLFSSL_EXAMPLE_VERSION_GIT_HASH
+if(NOT CMAKE_BUILD_EARLY_EXPANSION AND (IS_GIT_REPO STREQUAL "true"))
+    # LIBWOLFSSL_VERSION_GIT_HASH
     execute_process(COMMAND ${git_cmd} "rev-parse" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET )
-    LIBWOLFSSL_SAVE_INFO(WOLFSSL_EXAMPLE_VERSION_GIT_HASH "${TMP_OUT}" "${TMP_RES}")
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH "${TMP_OUT}" "${TMP_RES}")
 
-    # WOLFSSL_EXAMPLE_VERSION_GIT_SHORT_HASH
+    # LIBWOLFSSL_VERSION_GIT_SHORT_HASH
     execute_process(COMMAND ${git_cmd} "rev-parse" "--short" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET )
-    LIBWOLFSSL_SAVE_INFO(WOLFSSL_EXAMPLE_VERSION_GIT_SHORT_HASH "${TMP_OUT}" "${TMP_RES}")
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_SHORT_HASH "${TMP_OUT}" "${TMP_RES}")
 
-    # WOLFSSL_EXAMPLE_VERSION_GIT_HASH_DATE
+    # LIBWOLFSSL_VERSION_GIT_HASH_DATE
     execute_process(COMMAND ${git_cmd} "show" "--no-patch" "--no-notes" "--pretty=\'\%cd\'" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES  )
-    LIBWOLFSSL_SAVE_INFO(WOLFSSL_EXAMPLE_VERSION_GIT_HASH_DATE "${TMP_OUT}" "${TMP_RES}")
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH_DATE "${TMP_OUT}" "${TMP_RES}")
 endif()
 
 message(STATUS "")
-message("End wolfSSL main CMakeLists.txt")
 
+message(STATUS "End wolfSSL main CMakeLists.txt")

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/Kconfig.projbuild
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/Kconfig.projbuild
@@ -34,7 +34,7 @@ choice WOLFSSL_EXAMPLE_CHOOSE
     config WOLFSSL_EXAMPLE_NAME_WOLFSSH_TEMPLATE
         bool "SSH Template App"
         help
-            Bare-bones Hellow World app that only compiles in wolfSSL and wolfSSH.
+            Bare-bones Hello World app that only compiles in wolfSSL and wolfSSH.
             See wolfSSL/wolfssh on GitHub.
 
     config WOLFSSL_EXAMPLE_NAME_WOLFSSH_ECHOSERVER

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/client-tls.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/client-tls.c
@@ -307,11 +307,11 @@ WOLFSSL_ESP_TASK tls_smp_client_task(void* args)
 
     /* no peer check */
     if (doPeerCheck == 0) {
-        ESP_LOGW(TAG, "doPeerCheck == 0");
+        ESP_LOGW(TAG, "doPeerCheck == 0; WOLFSSL_VERIFY_NONE");
         wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_NONE, 0);
     }
     else {
-        ESP_LOGW(TAG, "doPeerCheck != 0");
+        ESP_LOGI(TAG, "doPeerCheck != 0");
         WOLFSSL_MSG("Loading... our cert");
         /* load our certificate */
         ret_i = wolfSSL_CTX_use_certificate_chain_buffer_format(ctx,

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/include/client-tls.h
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/include/client-tls.h
@@ -59,7 +59,7 @@
         #define TLS_SMP_CLIENT_TASK_BYTES (12 * 1024)
     #else
         /* Minimum ESP32 stack size = 8K without Kyber */
-        #define TLS_SMP_CLIENT_TASK_BYTES (8 * 1024)
+        #define TLS_SMP_CLIENT_TASK_BYTES (10 * 1024)
     #endif
 #endif
 
@@ -87,7 +87,7 @@ WOLFSSL_ESP_TASK tls_smp_client_task(void* args);
 
 /* init will create an RTOS task, otherwise server is simply function call. */
 #if defined(SINGLE_THREADED)
-    /* no init neded */
+    /* no init needed */
 #else
     WOLFSSL_ESP_TASK tls_smp_client_init(void* args);
 #endif

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/main.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/main.c
@@ -149,7 +149,7 @@ void app_main(void)
 #if !defined(CONFIG_WOLFSSL_EXAMPLE_NAME_TLS_CLIENT)
     ESP_LOGW(TAG, "Warning: Example wolfSSL misconfigured? Check menuconfig.");
 #endif
-#ifdef ESP_SDK_MEM_LIB_VERSION
+#if defined(ESP_SDK_MEM_LIB_VERSION) && defined(DEBUG_WOLFSSL)
     sdk_init_meminfo();
 #endif
 #ifdef ESP_TASK_MAIN_STACK

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/time_helper.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/time_helper.c
@@ -204,7 +204,7 @@ int set_time_from_string(const char* time_buffer)
     int quote_offset = 0;
     int ret = 0;
 
-    /* perform some basic sanity checkes */
+    /* perform some basic sanity checks */
     ret = probably_valid_time_string(time_buffer);
     if (ret == ESP_OK) {
         /* we are expecting the string to be encapsulated in single quotes */
@@ -218,7 +218,7 @@ int set_time_from_string(const char* time_buffer)
                     &day, &hour, &minute, &second, &year, &offset);
 
         if (ret == 8) {
-            /* we found a match for all componets */
+            /* we found a match for all components */
 
             const char *months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
                                      "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
@@ -282,7 +282,7 @@ int set_time(void)
     esp_show_current_datetime();
 
 #ifdef LIBWOLFSSL_VERSION_GIT_HASH_DATE
-    /* initialy set a default approximate time from recent git commit */
+    /* initially set a default approximate time from recent git commit */
     ESP_LOGI(TAG, "Found git hash date, attempting to set system date: %s",
                    LIBWOLFSSL_VERSION_GIT_HASH_DATE);
     set_time_from_string(LIBWOLFSSL_VERSION_GIT_HASH_DATE"\0");

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/wifi_connect.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/wifi_connect.c
@@ -147,7 +147,7 @@ int wifi_init_sta(void)
     };
 
     /* Setting a password implies station will connect to all security modes including WEP/WPA.
-        * However these modes are deprecated and not advisable to be used. Incase your Access point
+        * However these modes are deprecated and not advisable to be used. In case your Access point
         * doesn't support WPA2, these mode can be enabled by commenting below line */
 
     if (strlen((char *)wifi_config.sta.password)) {
@@ -325,7 +325,7 @@ int wifi_init_sta(void)
             .ssid = EXAMPLE_ESP_WIFI_SSID,
             .password = EXAMPLE_ESP_WIFI_PASS,
             /* Authmode threshold resets to WPA2 as default if password matches
-             * WPA2 standards (pasword len => 8). If you want to connect the
+             * WPA2 standards (password len => 8). If you want to connect the
              * device to deprecated WEP/WPA networks, Please set the threshold
              * value WIFI_AUTH_WEP/WIFI_AUTH_WPA_PSK and set the password with
              * length and format matching to WIFI_AUTH_WEP/WIFI_AUTH_WPA_PSK

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/sdkconfig.defaults
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/sdkconfig.defaults
@@ -6,22 +6,25 @@ CONFIG_WOLFSSL_EXAMPLE_NAME_TLS_CLIENT=y
 # Some wolfSSL helpers
 CONFIG_USE_WOLFSSL_ESP_SDK_TIME=y
 
+# sdkconfig.defaults for ESP8266 + ESP32
+
 # FreeRTOS ticks at 1ms interval
 CONFIG_FREERTOS_UNICORE=y
 CONFIG_FREERTOS_HZ=1000
 CONFIG_ESP32_DEFAULT_CPU_FREQ_240=y
 
 #
-# Default main stack size
+# Default main stack size. See user_settings.h
 #
 # This is typically bigger than needed for stack size.
 # Units are words, not bytes. See user_settings.h
 #
 # For wolfSSL SMALL_STACK, 3072 bytes should be sufficient for benchmark app.
 # When using RSA, assign at least 10500 bytes, otherwise 5500 usually works for others
+# We set this to 28672 for use in the "test everything possible" in the wolfssl_test app.
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=10500
 
-# Legacy stack size for older ESP-IDF versions
+# Legacy stack size name for older ESP-IDF versions
 CONFIG_MAIN_TASK_STACK_SIZE=10500
 
 #
@@ -63,8 +66,8 @@ CONFIG_HEAP_DISABLE_IRAM=y
 CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
 
 # Enable wolfSSL TLS in esp-tls
-CONFIG_ESP_TLS_USING_WOLFSSL=y
-CONFIG_TLS_STACK_WOLFSSL=y
+# CONFIG_ESP_TLS_USING_WOLFSSL=y
+# CONFIG_TLS_STACK_WOLFSSL=y
 
 # Bundles take up flash space and are disabled unless otherwise known to be needed
 CONFIG_WOLFSSL_CERTIFICATE_BUNDLE=n
@@ -76,6 +79,25 @@ CONFIG_WOLFSSL_CERTIFICATE_BUNDLE=n
 CONFIG_ESP_TLS_USING_MBEDTLS=n
 CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n
 
+# Some wolfSSL helpers
+CONFIG_USE_WOLFSSL_ESP_SDK_TIME=n
+
+# CONFIG_ESP_HTTP_CLIENT_ENABLE_HTTPS is not set
+CONFIG_ESP_HTTP_CLIENT_ENABLE_HTTPS=n
+
+# ESP8266 Memory
+CONFIG_FREERTOS_GLOBAL_DATA_LINK_IRAM=y
+CONFIG_HEAP_DISABLE_IRAM=y
+
+# Performance
+# CONFIG_COMPILER_OPTIMIZATION_PERF=y
+
+# Set max COU frequency (falls back as needed for lower maximum)
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
+
+# FreeRTOS ticks at 1ms interval
+CONFIG_FREERTOS_UNICORE=y
+CONFIG_FREERTOS_HZ=1000
 
 # Ensure mbedTLS options are disabled
 # CONFIG_MBEDTLS_TLS_SERVER_AND_CLIENT=n

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/CMakeLists.txt
@@ -1,11 +1,14 @@
 # wolfSSL Espressif Example Project CMakeLists.txt
-#   v1.0
+#   v1.3
 #
 # The following lines of boilerplate have to be in your project's
 # CMakeLists in this exact order for cmake to work correctly
 message(STATUS "Begin project ${CMAKE_PROJECT_NAME}")
 
 cmake_minimum_required(VERSION 3.16)
+
+# Optional no watchdog typically used for test & benchmark
+add_compile_definitions(WOLFSSL_ESP_NO_WATCHDOG=1)
 
 # The wolfSSL CMake file should be able to find the source code.
 # Otherwise, assign an environment variable or set it here:
@@ -24,28 +27,28 @@ cmake_minimum_required(VERSION 3.16)
 if(WIN32)
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
-    message("Detected Windows")
+    message(STATUS "Detected Windows")
 endif()
 if(CMAKE_HOST_UNIX)
-    message("Detected UNIX")
+    message(STATUS "Detected UNIX")
 endif()
 if(APPLE)
-    message("Detected APPLE")
+    message(STATUS "Detected APPLE")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
-    message("Detected WSL")
+    message(STATUS "Detected WSL")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
-    message("Detected Linux")
+    message(STATUS "Detected Linux")
 endif()
 if(APPLE)
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
-    message("Detected Apple")
+    message(STATUS "Detected Apple")
 endif()
 # End optional WOLFSSL_CMAKE_SYSTEM_NAME
 
@@ -54,16 +57,33 @@ endif()
 string(REPLACE "\\" "/" PROTOCOL_EXAMPLES_DIR "$ENV{IDF_PATH}/examples/common_components/protocol_examples_common")
 
 if (EXISTS "${PROTOCOL_EXAMPLES_DIR}")
-    message("Found PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
+    message(STATUS "Found PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
     set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DFOUND_PROTOCOL_EXAMPLES_DIR")
 else()
-    message("NOT FOUND: PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
+    message(STATUS "NOT FOUND: PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
 endif()
+
+# Find the user name to search for possible "wolfssl-username"
+# Reminder: Windows is  %USERNAME%, Linux is $USER
+message(STATUS "USERNAME = $ENV{USERNAME}")
+if(  "$ENV{USER}" STREQUAL "" ) # the bash user
+    if(  "$ENV{USERNAME}" STREQUAL "" ) # the Windows user
+        message(STATUS "could not find USER or USERNAME")
+    else()
+        # the bash user is not blank, so we'll use it.
+        set(THIS_USER "$ENV{USERNAME}")
+    endif()
+else()
+    # the bash user is not blank, so we'll use it.
+    set(THIS_USER "$ENV{USER}")
+endif()
+message(STATUS "THIS_USER = ${THIS_USER}")
 
 # Check that there are not conflicting wolfSSL components
 # The ESP Registry Component will be in ./managed_components/wolfssl__wolfssl
 # The local component wolfSSL directory will be in ./components/wolfssl
+message(STATUS "Checking for wolfSSL as Managed Component or not... ${CMAKE_HOME_DIRECTORY}")
 if( EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl" AND EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl" )
     # These exclude statements don't seem to be honored by the $ENV{IDF_PATH}/tools/cmake/project.cmake'
     # add_subdirectory("${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl" EXCLUDE_FROM_ALL)
@@ -78,25 +98,46 @@ if( EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl" AND EXI
     message(FATAL_ERROR "\nPlease use either the ESP Registry Managed Component or the wolfSSL component directory but not both.\n"
                         "If removing the ./managed_components/wolfssl__wolfssl directory, remember to also remove "
                         "or rename the idf_component.yml file typically found in ./main/")
-else()
+elseif(EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
+    # A standard project component (not a Managed Component)
     message(STATUS "No conflicting wolfSSL components found.")
+    set(WOLFSSL_PATH "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
+elseif(EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl")
+    # The official Managed Component called wolfssl from the wolfssl user.
+    message(STATUS "No conflicting wolfSSL components found as a Managed Component.")
+    set(WOLFSSL_PATH "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl")
+elseif(EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/gojimmypi__mywolfssl")
+    # There is a known gojimmypi staging component available for anyone:
+    message(STATUS "No conflicting wolfSSL components found as a gojimmypi staging Managed Component.")
+elseif(EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/${THIS_USER}__mywolfssl")
+    # Other users with permissions might publish their own mywolfssl staging Managed Component
+    message(STATUS "No conflicting wolfSSL components found as a Managed Component.")
+    set(WOLFSSL_PATH "${CMAKE_HOME_DIRECTORY}/managed_components/${THIS_USER}__mywolfssl")
+else()
+    message(STATUS "WARNING: wolfssl component directory not found.")
 endif()
 
+# message(STATUS "EXTRA_COMPONENT_DIRS WOLFSSL_PATH: ${WOLFSSL_PATH}")
+# list(APPEND EXTRA_COMPONENT_DIRS ${WOLFSSL_PATH})
 
-message(STATUS "begin include")
+# Not only is a project-level "set(COMPONENTS" not needed here, this will cause
+# an unintuitive error about  Unknown CMake command "esptool_py_flash_project_args".
+
+message(STATUS "begin optional PROTOCOL_EXAMPLES_DIR include")
 if(0)
     # This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
     set (PROTOCOL_EXAMPLES_DIR $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
 
     if (EXISTS "${PROTOCOL_EXAMPLES_DIR}")
-        message("Found PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
+        message(STATUS "Found PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
         set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DFOUND_PROTOCOL_EXAMPLES_DIR")
     else()
-        message("NOT FOUND: PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
+        message(STATUS "NOT FOUND: PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
     endif()
 endif()
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 message(STATUS "end include")
+
 project(wolfssl_server)
 message(STATUS "end project")

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/README.md
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/README.md
@@ -82,7 +82,7 @@ After the server exits, remove the port proxy forward:
 netsh interface portproxy delete v4tov4 listenport=11111 listenaddress=0.0.0.0
 ```
 
-Cipers to consider
+Ciphers to consider
 
 ```
 TLS13-AES128-GCM-SHA256:

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/README_server_sm.md
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/README_server_sm.md
@@ -167,7 +167,7 @@ I (735) system_api: read default base MAC address from EFUSE
 I (755) wifi:wifi firmware version: 0d470ef
 I (755) wifi:wifi certification version: v7.0
 I (755) wifi:config NVS flash: enabled
-I (755) wifi:config nano formating: disabled
+I (755) wifi:config nano formatting: disabled
 I (755) wifi:Init data frame dynamic rx buffer num: 32
 I (765) wifi:Init management frame dynamic rx buffer num: 32
 I (765) wifi:Init management short buffer num: 32

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/components/wolfssl/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/components/wolfssl/CMakeLists.txt
@@ -102,28 +102,28 @@ if(VERBOSE_COMPONENT_MESSAGES)
     if(WIN32)
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
-        message("Detected Windows")
+        message(STATUS "Detected Windows")
     endif()
     if(CMAKE_HOST_UNIX)
-        message("Detected UNIX")
+        message(STATUS "Detected UNIX")
     endif()
     if(APPLE)
-        message("Detected APPLE")
+        message(STATUS "Detected APPLE")
     endif()
     if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
-        message("Detected WSL")
+        message(STATUS "Detected WSL")
     endif()
     if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
-        message("Detected Linux")
+        message(STATUS "Detected Linux")
     endif()
     if(APPLE)
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
-        message("Detected Apple")
+        message(STATUS "Detected Apple")
     endif()
 endif() # End optional WOLFSSL_CMAKE_SYSTEM_NAME
 
@@ -524,7 +524,7 @@ else()
     set(WOLFSSL_PROJECT_DIR "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
 
     string(REPLACE "/" "//" STR_WOLFSSL_PROJECT_DIR "${WOLFSSL_PROJECT_DIR}")
-    add_definitions(-DWOLFSSL_USER_SETTINGS_DIR="${STR_WOLFSSL_PROJECT_DIR}/include/user_settings.h")
+    add_compile_definitions(WOLFSSL_USER_SETTINGS_DIR="${STR_WOLFSSL_PROJECT_DIR}/include/user_settings.h")
     message(STATUS "Added definition for user_settings.h: -DWOLFSSL_USER_SETTINGS_DIR=\"${STR_WOLFSSL_PROJECT_DIR}//include//user_settings.h\"")
     # Espressif may take several passes through this makefile. Check to see if we found IDF
     string(COMPARE EQUAL "${PROJECT_SOURCE_DIR}" "" WOLFSSL_FOUND_IDF)
@@ -951,7 +951,7 @@ function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
         message(STATUS "Found ${VAR_OUPUT}=${VAR_VALUE}")
 
         # the interesting part is defining the VAR_OUPUT name a value to use in the app
-        add_definitions(-D${VAR_OUPUT}=\"${VAR_VALUE}\")
+        add_compile_definitions(${VAR_OUPUT}=\"${VAR_VALUE}\")
     else()
         # if we get here, check the execute_process command and parameters.
         message(STATUS "LIBWOLFSSL_SAVE_INFO encountered a non-zero VAR_RESULT")
@@ -959,9 +959,16 @@ function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
     endif()
 endfunction() # LIBWOLFSSL_SAVE_INFO
 
+execute_process(
+    COMMAND ${git_cmd} "rev-parse" "--is-inside-work-tree"
+    OUTPUT_VARIABLE IS_GIT_REPO
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+
 # create some programmatic #define values that will be used by ShowExtendedSystemInfo().
 # see wolfcrypt\src\port\Espressif\esp32_utl.c
-if(NOT CMAKE_BUILD_EARLY_EXPANSION AND WOLFSSL_ROOT)
+if(NOT CMAKE_BUILD_EARLY_EXPANSION AND WOLFSSL_ROOT AND (IS_GIT_REPO STREQUAL "true"))
     set (git_cmd "git")
     message(STATUS "Adding macro definitions:")
 

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/components/wolfssl/Kconfig
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/components/wolfssl/Kconfig
@@ -41,7 +41,7 @@
 # The maximum length of options is NOT 50 characters as documented.
 #   kconfcheck will complain that options should be 40 at most.
 #
-# Fix option lengths first. Superflous errors on other lines may occur.
+# Fix option lengths first. Superfluous errors on other lines may occur.
 #
 # The maximum length of lines is 120 characters.
 #

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/components/wolfssl/component.mk
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/components/wolfssl/component.mk
@@ -82,7 +82,7 @@ WOLFSSL_ROOT := ../../../../../../..
 # "/mnt/c" is 4 directories up:
 #             2 for `./test/demo` from where we run `make`, plus
 #             2 more from the location of `component.mk` located
-#               in `[currect directory]/components/wolfssl`.
+#               in `[current directory]/components/wolfssl`.
 #
 # Thus we need 4 parent reference to find the relative path to wolfSSL:
 # WOLFSSL_ROOT := ../../../../workspace/wolfssl-master

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/components/wolfssl/include/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/components/wolfssl/include/user_settings.h
@@ -786,7 +786,7 @@
     /***** END CONFIG_IDF_TARGET_ESP8684 *****/
 
 #else
-    /* Anything else encountered, disable HW accleration */
+    /* Anything else encountered, disable HW acceleration */
     #warning "Unexpected CONFIG_IDF_TARGET_NN value"
     #define NO_ESP32_CRYPT
     #define NO_WOLFSSL_ESP32_CRYPT_HASH

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/CMakeLists.txt
@@ -1,36 +1,36 @@
 # wolfSSL Espressif Example Project/main CMakeLists.txt
-#   v1.0
+#   v1.1
 #
 # wolfssl server test
 #
-message("Begin wolfSSL main CMakeLists.txt")
+message(STATUS "Begin wolfSSL main CMakeLists.txt")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
 
 if(WIN32)
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
-    message("Detected Windows")
+    message(STATUS "Detected Windows")
 endif()
 if(CMAKE_HOST_UNIX)
-    message("Detected UNIX")
+    message(STATUS "Detected UNIX")
 endif()
 if(APPLE)
-    message("Detected APPLE")
+    message(STATUS "Detected APPLE")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
-    message("Detected WSL")
+    message(STATUS "Detected WSL")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
-    message("Detected Linux")
+    message(STATUS "Detected Linux")
 endif()
 if(APPLE)
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
-    message("Detected Apple")
+    message(STATUS "Detected Apple")
 endif()
 set (git_cmd "git")
 
@@ -44,14 +44,26 @@ if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/" AND EXISTS "$ENV{IDF_PA
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_MULTI_INSTALL_WARNING")
 endif()
 
+# The wolfSL component name is named "mywolfssl" on the staging site for Managed Components.
+if( NOT EXISTS "../components/wolfssl" AND ("$ENV{IDF_COMPONENT_REGISTRY_URL}" STREQUAL "https://components-staging.espressif.com") )
+    message(STATUS "WARNING: Using a staging instance of wolfssl.")
+    set(MAIN_WOLFSSL_COMPONENT_NAME "mywolfssl")
+else()
+    message(STATUS "Using release wolfssl component.")
+    set(MAIN_WOLFSSL_COMPONENT_NAME "wolfssl")
+endif()
+
 ## register_component()
 idf_component_register(SRCS main.c
                             wifi_connect.c
                             time_helper.c
                             server-tls.c
                        INCLUDE_DIRS "."
-                                    "./include")
-#
+                            "./include"
+                       PRIV_REQUIRES "${MAIN_WOLFSSL_COMPONENT_NAME}"
+                                     driver
+                                     nvs_flash
+                                     protocol_examples_common)
 
 #
 # LIBWOLFSSL_SAVE_INFO(VAR_OUPUT THIS_VAR VAR_RESULT)
@@ -81,7 +93,7 @@ function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
         message(STATUS "Found ${VAR_OUPUT}=${VAR_VALUE}")
 
         # the interesting part is defining the VAR_OUPUT name a value to use in the app
-        add_definitions(-D${VAR_OUPUT}=\"${VAR_VALUE}\")
+        add_compile_definitions(${VAR_OUPUT}=\"${VAR_VALUE}\")
     else()
         # if we get here, check the execute_process command and parameters.
         message(STATUS "LIBWOLFSSL_SAVE_INFO encountered a non-zero VAR_RESULT.")
@@ -90,21 +102,28 @@ function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
     endif()
 endfunction() # LIBWOLFSSL_SAVE_INFO
 
+execute_process(
+    COMMAND ${git_cmd} "rev-parse" "--is-inside-work-tree"
+    OUTPUT_VARIABLE IS_GIT_REPO
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+
 # Save some project-specific details. Repo may be different than component, or may not even be a repo at all:
-if(NOT CMAKE_BUILD_EARLY_EXPANSION)
-    # WOLFSSL_EXAMPLE_VERSION_GIT_HASH
+if(NOT CMAKE_BUILD_EARLY_EXPANSION AND (IS_GIT_REPO STREQUAL "true"))
+    # LIBWOLFSSL_VERSION_GIT_HASH
     execute_process(COMMAND ${git_cmd} "rev-parse" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET )
     LIBWOLFSSL_SAVE_INFO(WOLFSSL_EXAMPLE_VERSION_GIT_HASH "${TMP_OUT}" "${TMP_RES}")
 
-    # WOLFSSL_EXAMPLE_VERSION_GIT_SHORT_HASH
+    # LIBWOLFSSL_VERSION_GIT_SHORT_HASH
     execute_process(COMMAND ${git_cmd} "rev-parse" "--short" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET )
-    LIBWOLFSSL_SAVE_INFO(WOLFSSL_EXAMPLE_VERSION_GIT_SHORT_HASH "${TMP_OUT}" "${TMP_RES}")
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_SHORT_HASH "${TMP_OUT}" "${TMP_RES}")
 
-    # WOLFSSL_EXAMPLE_VERSION_GIT_HASH_DATE
+    # LIBWOLFSSL_VERSION_GIT_HASH_DATE
     execute_process(COMMAND ${git_cmd} "show" "--no-patch" "--no-notes" "--pretty=\'\%cd\'" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES  )
-    LIBWOLFSSL_SAVE_INFO(WOLFSSL_EXAMPLE_VERSION_GIT_HASH_DATE "${TMP_OUT}" "${TMP_RES}")
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH_DATE "${TMP_OUT}" "${TMP_RES}")
 endif()
 
 message(STATUS "")
-message("End wolfSSL main CMakeLists.txt")
 
+message(STATUS "End wolfSSL main CMakeLists.txt")

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/Kconfig.projbuild
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/Kconfig.projbuild
@@ -34,7 +34,7 @@ choice WOLFSSL_EXAMPLE_CHOOSE
     config WOLFSSL_EXAMPLE_NAME_WOLFSSH_TEMPLATE
         bool "SSH Template App"
         help
-            Bare-bones Hellow World app that only compiles in wolfSSL and wolfSSH.
+            Bare-bones Hello World app that only compiles in wolfSSL and wolfSSH.
             See wolfSSL/wolfssh on GitHub.
 
     config WOLFSSL_EXAMPLE_NAME_WOLFSSH_ECHOSERVER

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/include/server-tls.h
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/include/server-tls.h
@@ -53,7 +53,7 @@ WOLFSSL_ESP_TASK tls_smp_server_task(void *args);
 
 /* init will create an RTOS task, otherwise server is simply function call. */
 #if defined(SINGLE_THREADED)
-    /* no init neded */
+    /* no init needed */
 #else
     WOLFSSL_ESP_TASK tls_smp_server_init(void* args);
 #endif

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/main.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/main.c
@@ -131,9 +131,13 @@ void my_atmel_free(int slotId)
 /* Entry for FreeRTOS */
 void app_main(void)
 {
-    int stack_start = 0;
-    int this_heap = 0;
     esp_err_t ret = 0;
+#ifndef SINGLE_THREADED
+    int this_heap = 0;
+    #ifdef INCLUDE_uxTaskGetStackHighWaterMark
+        int stack_start = 0;
+    #endif
+#endif
     ESP_LOGI(TAG, "---------------- wolfSSL TLS Server Example ------------");
     ESP_LOGI(TAG, "--------------------------------------------------------");
     ESP_LOGI(TAG, "--------------------------------------------------------");
@@ -143,7 +147,7 @@ void app_main(void)
 #if !defined(CONFIG_WOLFSSL_EXAMPLE_NAME_TLS_SERVER)
     ESP_LOGW(TAG, "Warning: Example wolfSSL misconfigured? Check menuconfig.");
 #endif
-#ifdef ESP_SDK_MEM_LIB_VERSION
+#if defined(ESP_SDK_MEM_LIB_VERSION) && defined(DEBUG_WOLFSSL)
     sdk_init_meminfo();
 #endif
 #ifdef ESP_TASK_MAIN_STACK

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/time_helper.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/time_helper.c
@@ -185,7 +185,7 @@ int set_time_from_string(const char* time_buffer)
     int quote_offset = 0;
     int ret = 0;
 
-    /* perform some basic sanity checkes */
+    /* perform some basic sanity checks */
     ret = probably_valid_time_string(time_buffer);
     if (ret == ESP_OK) {
         /* we are expecting the string to be encapsulated in single quotes */
@@ -199,7 +199,7 @@ int set_time_from_string(const char* time_buffer)
                     &day, &hour, &minute, &second, &year, &offset);
 
         if (ret == 8) {
-            /* we found a match for all componets */
+            /* we found a match for all components */
 
             const char *months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
                                      "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
@@ -263,7 +263,7 @@ int set_time(void)
     esp_show_current_datetime();
 
 #ifdef LIBWOLFSSL_VERSION_GIT_HASH_DATE
-    /* initialy set a default approximate time from recent git commit */
+    /* initially set a default approximate time from recent git commit */
     ESP_LOGI(TAG, "Found git hash date, attempting to set system date: %s",
                    LIBWOLFSSL_VERSION_GIT_HASH_DATE);
     set_time_from_string(LIBWOLFSSL_VERSION_GIT_HASH_DATE"\0");

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/wifi_connect.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/wifi_connect.c
@@ -146,7 +146,7 @@ int wifi_init_sta(void)
     };
 
     /* Setting a password implies station will connect to all security modes including WEP/WPA.
-        * However these modes are deprecated and not advisable to be used. Incase your Access point
+        * However these modes are deprecated and not advisable to be used. In case your Access point
         * doesn't support WPA2, these mode can be enabled by commenting below line */
 
     if (strlen((char *)wifi_config.sta.password)) {
@@ -324,7 +324,7 @@ int wifi_init_sta(void)
             .ssid = EXAMPLE_ESP_WIFI_SSID,
             .password = EXAMPLE_ESP_WIFI_PASS,
             /* Authmode threshold resets to WPA2 as default if password matches
-             * WPA2 standards (pasword len => 8). If you want to connect the
+             * WPA2 standards (password len => 8). If you want to connect the
              * device to deprecated WEP/WPA networks, Please set the threshold
              * value WIFI_AUTH_WEP/WIFI_AUTH_WPA_PSK and set the password with
              * length and format matching to WIFI_AUTH_WEP/WIFI_AUTH_WPA_PSK

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/sdkconfig.defaults
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/sdkconfig.defaults
@@ -7,21 +7,23 @@ CONFIG_WOLFSSL_EXAMPLE_NAME_TLS_SERVER=y
 # Some wolfSSL helpers
 CONFIG_USE_WOLFSSL_ESP_SDK_TIME=y
 
+# sdkconfig.defaults for ESP8266 + ESP32
+# See separate sdkconfig.defaults.esp8266
 # FreeRTOS ticks at 1ms interval
 CONFIG_FREERTOS_UNICORE=y
 CONFIG_FREERTOS_HZ=1000
 CONFIG_ESP32_DEFAULT_CPU_FREQ_240=y
 
 #
-# Default main stack size
+# Default main stack size. See user_settings.h
 #
 # This is typically bigger than needed for stack size.
 # Units are words, not bytes. See user_settings.h
 #
 # For wolfSSL SMALL_STACK, 3072 bytes should be sufficient for benchmark app.
 # When using RSA, assign at least 10500 bytes, otherwise 5500 usually works for others
+# We set this to 28672 for use in the "test everything possible" in the wolfssl_test app.
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=10500
-
 # Legacy stack size for older ESP-IDF versions
 CONFIG_MAIN_TASK_STACK_SIZE=10500
 
@@ -64,8 +66,8 @@ CONFIG_HEAP_DISABLE_IRAM=y
 CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
 
 # Enable wolfSSL TLS in esp-tls
-CONFIG_ESP_TLS_USING_WOLFSSL=y
-CONFIG_TLS_STACK_WOLFSSL=y
+# CONFIG_ESP_TLS_USING_WOLFSSL=y
+# CONFIG_TLS_STACK_WOLFSSL=y
 
 # Bundles take up flash space and are disabled unless otherwise known to be needed
 CONFIG_WOLFSSL_CERTIFICATE_BUNDLE=n
@@ -77,6 +79,25 @@ CONFIG_WOLFSSL_CERTIFICATE_BUNDLE=n
 CONFIG_ESP_TLS_USING_MBEDTLS=n
 CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n
 
+# Some wolfSSL helpers
+CONFIG_USE_WOLFSSL_ESP_SDK_TIME=n
+
+# CONFIG_ESP_HTTP_CLIENT_ENABLE_HTTPS is not set
+CONFIG_ESP_HTTP_CLIENT_ENABLE_HTTPS=n
+
+# ESP8266 Memory
+CONFIG_FREERTOS_GLOBAL_DATA_LINK_IRAM=y
+CONFIG_HEAP_DISABLE_IRAM=y
+
+# Performance
+# CONFIG_COMPILER_OPTIMIZATION_PERF=y
+
+# Set max COU frequency (falls back as needed for lower maximum)
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
+
+# FreeRTOS ticks at 1ms interval
+CONFIG_FREERTOS_UNICORE=y
+CONFIG_FREERTOS_HZ=1000
 
 # Ensure mbedTLS options are disabled
 # CONFIG_MBEDTLS_TLS_SERVER_AND_CLIENT=n

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_test/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_test/CMakeLists.txt
@@ -3,10 +3,12 @@
 #
 # The following lines of boilerplate have to be in your project's
 # CMakeLists in this exact order for cmake to work correctly
+message(STATUS "Begin project ${CMAKE_PROJECT_NAME}")
+
 cmake_minimum_required(VERSION 3.16)
 
 # Optional no watchdog typically used for test & benchmark
-add_compile_options(-DWOLFSSL_ESP_NO_WATCHDOG=1)
+add_compile_definitions(WOLFSSL_ESP_NO_WATCHDOG=1)
 
 # The wolfSSL CMake file should be able to find the source code.
 # Otherwise, assign an environment variable or set it here:
@@ -25,34 +27,63 @@ add_compile_options(-DWOLFSSL_ESP_NO_WATCHDOG=1)
 if(WIN32)
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
-    message("Detected Windows")
+    message(STATUS "Detected Windows")
 endif()
 if(CMAKE_HOST_UNIX)
-    message("Detected UNIX")
+    message(STATUS "Detected UNIX")
 endif()
 if(APPLE)
-    message("Detected APPLE")
+    message(STATUS "Detected APPLE")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
-    message("Detected WSL")
+    message(STATUS "Detected WSL")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
-    message("Detected Linux")
+    message(STATUS "Detected Linux")
 endif()
 if(APPLE)
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
-    message("Detected Apple")
+    message(STATUS "Detected Apple")
 endif()
 # End optional WOLFSSL_CMAKE_SYSTEM_NAME
+
+# This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
+# set (PROTOCOL_EXAMPLES_DIR $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
+string(REPLACE "\\" "/" PROTOCOL_EXAMPLES_DIR "$ENV{IDF_PATH}/examples/common_components/protocol_examples_common")
+
+if (EXISTS "${PROTOCOL_EXAMPLES_DIR}")
+    message(STATUS "Found PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
+    set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DFOUND_PROTOCOL_EXAMPLES_DIR")
+else()
+    message(STATUS "NOT FOUND: PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
+endif()
+
+# Find the user name to search for possible "wolfssl-username"
+# Reminder: Windows is  %USERNAME%, Linux is $USER
+message(STATUS "USERNAME = $ENV{USERNAME}")
+if(  "$ENV{USER}" STREQUAL "" ) # the bash user
+    if(  "$ENV{USERNAME}" STREQUAL "" ) # the Windows user
+        message(STATUS "could not find USER or USERNAME")
+    else()
+        # the bash user is not blank, so we'll use it.
+        set(THIS_USER "$ENV{USERNAME}")
+    endif()
+else()
+    # the bash user is not blank, so we'll use it.
+    set(THIS_USER "$ENV{USER}")
+endif()
+message(STATUS "THIS_USER = ${THIS_USER}")
 
 # Check that there are not conflicting wolfSSL components
 # The ESP Registry Component will be in ./managed_components/wolfssl__wolfssl
 # The local component wolfSSL directory will be in ./components/wolfssl
+message(STATUS "Checking for wolfSSL as Managed Component or not... ${CMAKE_HOME_DIRECTORY}")
 if( EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl" AND EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl" )
     # These exclude statements don't seem to be honored by the $ENV{IDF_PATH}/tools/cmake/project.cmake'
     # add_subdirectory("${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl" EXCLUDE_FROM_ALL)
@@ -67,16 +98,46 @@ if( EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl" AND EXI
     message(FATAL_ERROR "\nPlease use either the ESP Registry Managed Component or the wolfSSL component directory but not both.\n"
                         "If removing the ./managed_components/wolfssl__wolfssl directory, remember to also remove "
                         "or rename the idf_component.yml file typically found in ./main/")
-else()
+elseif(EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
+    # A standard project component (not a Managed Component)
     message(STATUS "No conflicting wolfSSL components found.")
+    set(WOLFSSL_PATH "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
+elseif(EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl")
+    # The official Managed Component called wolfssl from the wolfssl user.
+    message(STATUS "No conflicting wolfSSL components found as a Managed Component.")
+    set(WOLFSSL_PATH "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl")
+elseif(EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/gojimmypi__mywolfssl")
+    # There is a known gojimmypi staging component available for anyone:
+    message(STATUS "No conflicting wolfSSL components found as a gojimmypi staging Managed Component.")
+elseif(EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/${THIS_USER}__mywolfssl")
+    # Other users with permissions might publish their own mywolfssl staging Managed Component
+    message(STATUS "No conflicting wolfSSL components found as a Managed Component.")
+    set(WOLFSSL_PATH "${CMAKE_HOME_DIRECTORY}/managed_components/${THIS_USER}__mywolfssl")
+else()
+    message(STATUS "WARNING: wolfssl component directory not found.")
 endif()
 
-# Ensure the this wolfSSL component directory is included
-set(WOLFSSL_PATH "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
-list(APPEND EXTRA_COMPONENT_DIRS ${WOLFSSL_PATH})
+# message(STATUS "EXTRA_COMPONENT_DIRS WOLFSSL_PATH: ${WOLFSSL_PATH}")
+# list(APPEND EXTRA_COMPONENT_DIRS ${WOLFSSL_PATH})
 
 # Not only is a project-level "set(COMPONENTS" not needed here, this will cause
 # an unintuitive error about  Unknown CMake command "esptool_py_flash_project_args".
+
+message(STATUS "begin optional PROTOCOL_EXAMPLES_DIR include")
+if(0)
+    # This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
+    set (PROTOCOL_EXAMPLES_DIR $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
+
+    if (EXISTS "${PROTOCOL_EXAMPLES_DIR}")
+        message(STATUS "Found PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
+        set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DFOUND_PROTOCOL_EXAMPLES_DIR")
+    else()
+        message(STATUS "NOT FOUND: PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
+    endif()
+endif()
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+message(STATUS "end optional include")
 
 project(wolfssl_test)
+message(STATUS "end project")

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl/CMakeLists.txt
@@ -102,28 +102,28 @@ if(VERBOSE_COMPONENT_MESSAGES)
     if(WIN32)
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
-        message("Detected Windows")
+        message(STATUS "Detected Windows")
     endif()
     if(CMAKE_HOST_UNIX)
-        message("Detected UNIX")
+        message(STATUS "Detected UNIX")
     endif()
     if(APPLE)
-        message("Detected APPLE")
+        message(STATUS "Detected APPLE")
     endif()
     if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
-        message("Detected WSL")
+        message(STATUS "Detected WSL")
     endif()
     if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
-        message("Detected Linux")
+        message(STATUS "Detected Linux")
     endif()
     if(APPLE)
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
-        message("Detected Apple")
+        message(STATUS "Detected Apple")
     endif()
 endif() # End optional WOLFSSL_CMAKE_SYSTEM_NAME
 
@@ -524,7 +524,7 @@ else()
     set(WOLFSSL_PROJECT_DIR "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
 
     string(REPLACE "/" "//" STR_WOLFSSL_PROJECT_DIR "${WOLFSSL_PROJECT_DIR}")
-    add_definitions(-DWOLFSSL_USER_SETTINGS_DIR="${STR_WOLFSSL_PROJECT_DIR}/include/user_settings.h")
+    add_compile_definitions(WOLFSSL_USER_SETTINGS_DIR="${STR_WOLFSSL_PROJECT_DIR}/include/user_settings.h")
     message(STATUS "Added definition for user_settings.h: -DWOLFSSL_USER_SETTINGS_DIR=\"${STR_WOLFSSL_PROJECT_DIR}//include//user_settings.h\"")
     # Espressif may take several passes through this makefile. Check to see if we found IDF
     string(COMPARE EQUAL "${PROJECT_SOURCE_DIR}" "" WOLFSSL_FOUND_IDF)
@@ -951,7 +951,7 @@ function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
         message(STATUS "Found ${VAR_OUPUT}=${VAR_VALUE}")
 
         # the interesting part is defining the VAR_OUPUT name a value to use in the app
-        add_definitions(-D${VAR_OUPUT}=\"${VAR_VALUE}\")
+        add_compile_definitions(${VAR_OUPUT}=\"${VAR_VALUE}\")
     else()
         # if we get here, check the execute_process command and parameters.
         message(STATUS "LIBWOLFSSL_SAVE_INFO encountered a non-zero VAR_RESULT")
@@ -959,9 +959,16 @@ function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
     endif()
 endfunction() # LIBWOLFSSL_SAVE_INFO
 
+execute_process(
+    COMMAND ${git_cmd} "rev-parse" "--is-inside-work-tree"
+    OUTPUT_VARIABLE IS_GIT_REPO
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+
 # create some programmatic #define values that will be used by ShowExtendedSystemInfo().
 # see wolfcrypt\src\port\Espressif\esp32_utl.c
-if(NOT CMAKE_BUILD_EARLY_EXPANSION AND WOLFSSL_ROOT)
+if(NOT CMAKE_BUILD_EARLY_EXPANSION AND WOLFSSL_ROOT AND (IS_GIT_REPO STREQUAL "true"))
     set (git_cmd "git")
     message(STATUS "Adding macro definitions:")
 

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl/Kconfig
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl/Kconfig
@@ -41,7 +41,7 @@
 # The maximum length of options is NOT 50 characters as documented.
 #   kconfcheck will complain that options should be 40 at most.
 #
-# Fix option lengths first. Superflous errors on other lines may occur.
+# Fix option lengths first. Superfluous errors on other lines may occur.
 #
 # The maximum length of lines is 120 characters.
 #

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl/component.mk
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl/component.mk
@@ -82,7 +82,7 @@ WOLFSSL_ROOT := ../../../../../../..
 # "/mnt/c" is 4 directories up:
 #             2 for `./test/demo` from where we run `make`, plus
 #             2 more from the location of `component.mk` located
-#               in `[currect directory]/components/wolfssl`.
+#               in `[current directory]/components/wolfssl`.
 #
 # Thus we need 4 parent reference to find the relative path to wolfSSL:
 # WOLFSSL_ROOT := ../../../../workspace/wolfssl-master
@@ -291,5 +291,5 @@ COMPONENT_SRCDIRS += $(WOLFSSL_ROOT)/wolfcrypt/test
 ## wolfcrypt
 ##
 # COMPONENT_PRIV_INCLUDEDIRS += $(PROJECT_PATH)/components/wolfssl/include
-COMPONENT_SRCDIRS += $(WOLFSSL_ROOT)wolfcrypt/src
+COMPONENT_SRCDIRS += $(WOLFSSL_ROOT)/wolfcrypt/src
 $(info ********** end wolfssl component **********)

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl/include/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_test/components/wolfssl/include/user_settings.h
@@ -786,7 +786,7 @@
     /***** END CONFIG_IDF_TARGET_ESP8684 *****/
 
 #else
-    /* Anything else encountered, disable HW accleration */
+    /* Anything else encountered, disable HW acceleration */
     #warning "Unexpected CONFIG_IDF_TARGET_NN value"
     #define NO_ESP32_CRYPT
     #define NO_WOLFSSL_ESP32_CRYPT_HASH

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_test/main/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_test/main/CMakeLists.txt
@@ -3,9 +3,121 @@
 #
 # wolfssl crypt test
 #
+message(STATUS "Begin wolfSSL main CMakeLists.txt")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
 
-idf_component_register(SRCS
-                         "main.c"
-                       INCLUDE_DIRS
-                         ".")
+if(WIN32)
+    # Windows-specific configuration here
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
+    message(STATUS "Detected Windows")
+endif()
+if(CMAKE_HOST_UNIX)
+    message(STATUS "Detected UNIX")
+endif()
+if(APPLE)
+    message(STATUS "Detected APPLE")
+endif()
+if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
+    # Windows-specific configuration here
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
+    message(STATUS "Detected WSL")
+endif()
+if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
+    # Windows-specific configuration here
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
+    message(STATUS "Detected Linux")
+endif()
+if(APPLE)
+    # Windows-specific configuration here
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
+    message(STATUS "Detected Apple")
+endif()
+set (git_cmd "git")
+
+if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssl/" AND EXISTS "$ENV{IDF_PATH}/components/wolfssl/" )
+    #
+    # wolfSSL found in both ESP-IDF and local project - needs to be resolved by user
+    #
+    message(STATUS "")
+    message(STATUS "WARNING: Found components/wolfssl in both local project and IDF_PATH")
+    message(STATUS "")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_MULTI_INSTALL_WARNING")
+endif()
+
+# The wolfSL component name is named "mywolfssl" on the staging site for Managed Components.
+if( NOT EXISTS "../components/wolfssl" AND ("$ENV{IDF_COMPONENT_REGISTRY_URL}" STREQUAL "https://components-staging.espressif.com") )
+    message(STATUS "WARNING: Using a staging instance of wolfssl.")
+    set(MAIN_WOLFSSL_COMPONENT_NAME "mywolfssl")
+else()
+    message(STATUS "Using release wolfssl component.")
+    set(MAIN_WOLFSSL_COMPONENT_NAME "wolfssl")
+endif()
+
+## register_component()
+idf_component_register(SRCS main.c
+                       INCLUDE_DIRS "."
+                            "./include"
+                       PRIV_REQUIRES driver "${MAIN_WOLFSSL_COMPONENT_NAME}")
+
+#
+# LIBWOLFSSL_SAVE_INFO(VAR_OUPUT THIS_VAR VAR_RESULT)
+#
+# Save the THIS_VAR as a string in a macro called VAR_OUPUT
+#
+# VAR_OUPUT:  the name of the macro to define
+# THIS_VAR:   the OUTPUT_VARIABLE result from a execute_process()
+# VAR_RESULT: the RESULT_VARIABLE from a execute_process(); "0" if successful.
+#
+function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
+    # is the RESULT_VARIABLE output value 0? If so, IS_VALID_VALUE is true.
+    string(COMPARE EQUAL "${VAR_RESULT}" "0" IS_VALID_VALUE)
+
+    # if we had a successful operation, save the THIS_VAR in VAR_OUPUT
+    if(${IS_VALID_VALUE})
+        # strip newline chars in THIS_VAR parameter and save in VAR_VALUE
+        string(REPLACE "\n" ""  VAR_VALUE  ${THIS_VAR})
+
+        # we'll could percolate the value to the parent for possible later use
+        # set(${VAR_OUPUT} ${VAR_VALUE} PARENT_SCOPE)
+
+        # but we're only using it here in this function
+        set(${VAR_OUPUT} ${VAR_VALUE})
+
+        # we'll print what we found to the console
+        message(STATUS "Found ${VAR_OUPUT}=${VAR_VALUE}")
+
+        # the interesting part is defining the VAR_OUPUT name a value to use in the app
+        add_compile_definitions(${VAR_OUPUT}=\"${VAR_VALUE}\")
+    else()
+        # if we get here, check the execute_process command and parameters.
+        message(STATUS "LIBWOLFSSL_SAVE_INFO encountered a non-zero VAR_RESULT.")
+        message(STATUS "Setting ${VAR_OUPUT} to \"Unknown\"")
+        set(${VAR_OUPUT} "Unknown")
+    endif()
+endfunction() # LIBWOLFSSL_SAVE_INFO
+
+execute_process(
+    COMMAND ${git_cmd} "rev-parse" "--is-inside-work-tree"
+    OUTPUT_VARIABLE IS_GIT_REPO
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+
+# Save some project-specific details. Repo may be different than component, or may not even be a repo at all:
+if(NOT CMAKE_BUILD_EARLY_EXPANSION AND (IS_GIT_REPO STREQUAL "true"))
+    # LIBWOLFSSL_VERSION_GIT_HASH
+    execute_process(COMMAND ${git_cmd} "rev-parse" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_SHORT_HASH
+    execute_process(COMMAND ${git_cmd} "rev-parse" "--short" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_SHORT_HASH "${TMP_OUT}" "${TMP_RES}")
+
+    # LIBWOLFSSL_VERSION_GIT_HASH_DATE
+    execute_process(COMMAND ${git_cmd} "show" "--no-patch" "--no-notes" "--pretty=\'\%cd\'" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES  )
+    LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH_DATE "${TMP_OUT}" "${TMP_RES}")
+endif()
+
+message(STATUS "")
+
+message(STATUS "End wolfSSL main CMakeLists.txt")

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_test/partitions_singleapp_large.csv
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_test/partitions_singleapp_large.csv
@@ -13,7 +13,7 @@ factory, app,  factory, 0x10000, 1500K,
 # For other settings, see:
 # https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html#creating-custom-tables
 #
-# Here is the summary printed for the “Single factory app, no OTA” configuration:
+# Here is the summary printed for the "Single factory app, no OTA" configuration:
 #
 # # ESP-IDF Partition Table
 # # Name,   Type, SubType, Offset,  Size, Flags
@@ -22,7 +22,7 @@ factory, app,  factory, 0x10000, 1500K,
 # factory,  app,  factory, 0x10000, 1M,
 #
 #
-# Here is the summary printed for the “Factory app, two OTA definitions” configuration:
+# Here is the summary printed for the "Factory app, two OTA definitions" configuration:
 #
 # # ESP-IDF Partition Table
 # # Name,   Type, SubType, Offset,  Size, Flags

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_test/sdkconfig.defaults
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_test/sdkconfig.defaults
@@ -1,13 +1,14 @@
 # Set the known example app config to template example (see user_settings.h)
 CONFIG_WOLFSSL_EXAMPLE_NAME_WOLFSSL_TEST=y
+# CONFIG_EXAMPLE_WIFI_SSID="myssid"
+# CONFIG_EXAMPLE_WIFI_PASSWORD="mypassword"
 
 # Some wolfSSL helpers
 CONFIG_USE_WOLFSSL_ESP_SDK_TIME=y
 
-# sdkconfig.defaults for ESP32. 
+# sdkconfig.defaults for ESP8266 + ESP32
 # See separate sdkconfig.defaults.esp8266
 # Note that during the build process, settings from sdkconfig.defaults will not override those already in sdkconfig.
-# See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults
 CONFIG_BENCH_ARGV="-lng 0"
 # FreeRTOS ticks at 1ms interval
 CONFIG_FREERTOS_UNICORE=y
@@ -24,8 +25,7 @@ CONFIG_ESP32_DEFAULT_CPU_FREQ_240=y
 # When using RSA, assign at least 10500 bytes, otherwise 5500 usually works for others
 # We set this to 28672 for use in the "test everything possible" in the wolfssl_test app.
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=28672
-
-# Legacy stack size for older ESP-IDF versions
+# Legacy stack size name for older ESP-IDF versions
 CONFIG_MAIN_TASK_STACK_SIZE=28672
 
 #
@@ -67,8 +67,8 @@ CONFIG_HEAP_DISABLE_IRAM=y
 CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
 
 # Enable wolfSSL TLS in esp-tls
-CONFIG_ESP_TLS_USING_WOLFSSL=y
-CONFIG_TLS_STACK_WOLFSSL=y
+# CONFIG_ESP_TLS_USING_WOLFSSL=y
+# CONFIG_TLS_STACK_WOLFSSL=y
 
 # Bundles take up flash space and are disabled unless otherwise known to be needed
 CONFIG_WOLFSSL_CERTIFICATE_BUNDLE=n
@@ -99,6 +99,26 @@ CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
 # FreeRTOS ticks at 1ms interval
 CONFIG_FREERTOS_UNICORE=y
 CONFIG_FREERTOS_HZ=1000
+
+# Ensure mbedTLS options are disabled
+# CONFIG_MBEDTLS_TLS_SERVER_AND_CLIENT=n
+# CONFIG_MBEDTLS_TLS_CLIENT_ONLY=n
+# CONFIG_MBEDTLS_TLS_SERVER=n
+# CONFIG_MBEDTLS_TLS_CLIENT=n
+# CONFIG_MBEDTLS_HARDWARE_AES=n
+# CONFIG_MBEDTLS_HARDWARE_MPI=n
+# CONFIG_MBEDTLS_HARDWARE_SHA=n
+# CONFIG_MBEDTLS_ROM_MD5=n
+# CONFIG_MBEDTLS_SSL_RENEGOTIATION=n
+# CONFIG_MBEDTLS_SSL_PROTO_TLS1_2=n
+# CONFIG_MBEDTLS_SSL_PROTO_GMTSSL1_1=n
+# CONFIG_MBEDTLS_SSL_ALPN=n
+# CONFIG_MBEDTLS_CLIENT_SSL_SESSION_TICKETS=n
+# CONFIG_MBEDTLS_SERVER_SSL_SESSION_TICKETS=n
+
+# The same-name config is used for both WiFi and client/server TLS, so we cannot disable:
+# CONFIG_MBEDTLS_TLS_ENABLED=n
+# CONFIG_MBEDTLS_TLS_DISABLED=y
 
 #
 # Compiler options

--- a/IDE/Espressif/ESP-IDF/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/user_settings.h
@@ -331,7 +331,7 @@
     #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
     /***** END CONFIG_IDF_TARGET_ESP266 *****/
 #else
-    /* Anything else encountered, disable HW accleration */
+    /* Anything else encountered, disable HW acceleration */
     #define NO_ESP32_CRYPT
     #define NO_WOLFSSL_ESP32_CRYPT_HASH
     #define NO_WOLFSSL_ESP32_CRYPT_AES
@@ -359,7 +359,7 @@
 
 /* #define HASH_SIZE_LIMIT */ /* for test.c */
 
-/* #define NO_HW_MATH_TEST */ /* Optionall turn off HW math checks */
+/* #define NO_HW_MATH_TEST */ /* Optionally turn off HW math checks */
 
 /* Optionally include alternate HW test library: alt_hw_test.h */
 /* When enabling, the ./components/wolfssl/CMakeLists.txt file


### PR DESCRIPTION
# Description

This PR updates the [Espressif examples](https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples) and builds on the updates in https://github.com/wolfSSL/wolfssl/pull/8076. Enclosed are changes essential for the [wolfSSL Managed Component](https://components.espressif.com/components/wolfssl/wolfssl/) examples to work properly with the [v5.7.4-stable release of wolfssl](https://github.com/wolfSSL/wolfssl/releases/tag/v5.7.4-stable).

Primary changes are to `CMakeLists.txt` and `sdkconfig.defaults`. Only minor changes made to example code.

Note this PR is based on the `bdd62314` release commit, and DOES NOT INCLUDE other wolfSSL post-release updates.

The result will be an as-published wolfSSL 5.7.4 with only the changes needed for Espressif example updates. See my [pr-post-release-bdd62314-espressif branch](https://github.com/gojimmypi/wolfssl/tree/pr-post-release-bdd62314-espressif).

In particular, this PR addresses the new esp-tls and Certificate Bundle Support features introduced in https://github.com/wolfSSL/wolfssl/pull/7936 and the respective interaction with Managed Components.
 
As not all versions of the ESP-IDF support the new `esp-tls` integration with wolfSSL, all of the examples now have the settings disabled by default in the respective `dkconfig.defaults` files:

```
# CONFIG_ESP_TLS_USING_WOLFSSL=y
# CONFIG_TLS_STACK_WOLFSSL=y
```

See my [ESP-IDF v5.3.1](https://github.com/gojimmypi/esp-idf/tree/my_531) work and the respective [release for PlatformIO](https://github.com/gojimmypi/esp-idf/releases/tag/v5.3.1.20240930a).

To use it with PlatformIO, adjust this line in the `platformio.ini` file:

```
platform_packages = framework-espidf @ https://github.com/gojimmypi/esp-idf/releases/download/v5.3.1.20240926c/esp-idf-v5.3.1.20240926c.zip
```

I have an example with my [esp_http_client_example](https://github.com/gojimmypi/wolfssl/tree/ED25519_SHA2_fix/IDE/Espressif/ESP-IDF/examples/esp_http_client_example).

### Other Changes

- There are some corrections to cmake `add_compile_definitions` syntax.

- Improved checks for Managed Component names (e.g. staging site user names & `mywolfssl`)

- Adds new `IS_GIT_REPO` check to avoid attempts to glean attributes from non-git directories, such as those in Managed Component examples.

- `client-tls.c` changed the `NoPeerCheck != 0` to be information, not a warning.

- `TLS_SMP_CLIENT_TASK_BYTES` bumped up to 10K default, rather than 8K.

- `sdk_init_meminfo();` is only disabled when available and `DEBUG_WOLFSSL` enabled.

- The server example now gates out `this_heap` and `stack_start` variables not used as appropriate.

- While testing and editing the cmake files, I also discovered instances of `message("text")` that were being sent to `stderr`.
I replaced those with `message(STATUS "text")`


- Various spelling corrections

- Addresses zd# 18228

# Testing

Much of the testing occurred with the [staging instance](https://components-staging.espressif.com/components/gojimmypi/mywolfssl/versions/5.7.2/examples/wolfssl_client?language=en) under my user name.

At the moment, the [staging site](https://components-staging.espressif.com/components/gojimmypi/mywolfssl/versions/5.7.2) is giving me a "Bad Gateway" error.

See also the internal wolfSSL scripts. I've added additional diagnostics and automated testing.


# Release

As of the date of this PR creation, the release wolfSSL Managed Component has NOT yet been published. I plan to publish preview releases soon. 


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
