### PR TITLE
wolfSSL_CTX_set_tlsext_use_srtp() should return 1 on failure and 0 up…

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2073,6 +2073,13 @@ int wolfSSL_CTX_set_tlsext_use_srtp(WOLFSSL_CTX* ctx, const char* profile_str)
     if (ctx != NULL) {
         ret = DtlsSrtpSelProfiles(&ctx->dtlsSrtpProfiles, profile_str);
     }
+
+    if (ret == WC_NO_ERR_TRACE(WOLFSSL_FAILURE)) {
+        ret = 1;
+    } else {
+        ret = 0;
+    }
+
     return ret;
 }
 int wolfSSL_set_tlsext_use_srtp(WOLFSSL* ssl, const char* profile_str)
@@ -2081,6 +2088,13 @@ int wolfSSL_set_tlsext_use_srtp(WOLFSSL* ssl, const char* profile_str)
     if (ssl != NULL) {
         ret = DtlsSrtpSelProfiles(&ssl->dtlsSrtpProfiles, profile_str);
     }
+
+    if (ret == WC_NO_ERR_TRACE(WOLFSSL_FAILURE)) {
+        ret = 1;
+    } else {
+        ret = 0;
+    }
+
     return ret;
 }
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -8461,6 +8461,13 @@ static int test_client_nofail(void* args, cbType cb)
         goto done;
     }
 
+#ifdef WOLFSSL_SRTP
+    /* make sure that NULL (error condition) returns 1 */
+    if (wolfSSL_CTX_set_tlsext_use_srtp(ctx, NULL) != 1) {
+         goto done;
+    }
+#endif
+
 #ifdef HAVE_CRL
     if (cbf != NULL && cbf->crlPemFile != NULL) {
         if (wolfSSL_CTX_EnableCRL(ctx, WOLFSSL_CRL_CHECKALL) != WOLFSSL_SUCCESS)
@@ -8502,6 +8509,13 @@ static int test_client_nofail(void* args, cbType cb)
                 "Please run from wolfSSL home dir");*/
         goto done;
     }
+
+#ifdef WOLFSSL_SRTP
+    /* make sure that NULL (error condition) returns 1 */
+    if (wolfSSL_set_tlsext_use_srtp(ssl, NULL) != 1) {
+         goto done;
+    }
+#endif
 
     if (!doUdp) {
         if (wolfSSL_set_fd(ssl, sockfd) != WOLFSSL_SUCCESS) {


### PR DESCRIPTION
…on success. Same with wolfSSL_set_tlsext_use_srtp().
Fixes ZD 19026