### PR TITLE
20241204-more-C89-expansion

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -6509,7 +6509,7 @@ static WC_INLINE void RIGHTSHIFTX(byte* x)
 {
     int i;
     int carryIn = 0;
-    byte borrow = (0x00 - (x[15] & 0x01)) & 0xE1;
+    byte borrow = (byte)((0x00U - (x[15] & 0x01U)) & 0xE1U);
 
     for (i = 0; i < WC_AES_BLOCK_SIZE; i++) {
         int carryOut = (x[i] & 0x01) << 7;
@@ -8037,13 +8037,13 @@ static void GHASH_UPDATE(Aes* aes, const byte* a, word32 aSz, const byte* c,
         /* Check if we have unprocessed data. */
         if (aes->aOver > 0) {
             /* Calculate amount we can use - fill up the block. */
-            byte sz = WC_AES_BLOCK_SIZE - aes->aOver;
+            byte sz = (byte)(WC_AES_BLOCK_SIZE - aes->aOver);
             if (sz > aSz) {
                 sz = (byte)aSz;
             }
             /* Copy extra into last GHASH block array and update count. */
             XMEMCPY(AES_LASTGBLOCK(aes) + aes->aOver, a, sz);
-            aes->aOver += sz;
+            aes->aOver = (byte)(aes->aOver + sz);
             if (aes->aOver == WC_AES_BLOCK_SIZE) {
                 /* We have filled up the block and can process. */
                 GHASH_ONE_BLOCK(aes, AES_LASTGBLOCK(aes));
@@ -8072,7 +8072,7 @@ static void GHASH_UPDATE(Aes* aes, const byte* a, word32 aSz, const byte* c,
     if (aes->aOver > 0 && cSz > 0 && c != NULL) {
         /* No more AAD coming and we have a partial block. */
         /* Fill the rest of the block with zeros. */
-        byte sz = WC_AES_BLOCK_SIZE - aes->aOver;
+        byte sz = (byte)(WC_AES_BLOCK_SIZE - aes->aOver);
         XMEMSET(AES_LASTGBLOCK(aes) + aes->aOver, 0, sz);
         /* GHASH last AAD block. */
         GHASH_ONE_BLOCK(aes, AES_LASTGBLOCK(aes));
@@ -8086,13 +8086,13 @@ static void GHASH_UPDATE(Aes* aes, const byte* a, word32 aSz, const byte* c,
         aes->cSz += cSz;
         if (aes->cOver > 0) {
             /* Calculate amount we can use - fill up the block. */
-            byte sz = WC_AES_BLOCK_SIZE - aes->cOver;
+            byte sz = (byte)(WC_AES_BLOCK_SIZE - aes->cOver);
             if (sz > cSz) {
                 sz = (byte)cSz;
             }
             XMEMCPY(AES_LASTGBLOCK(aes) + aes->cOver, c, sz);
             /* Update count of unused encrypted counter. */
-            aes->cOver += sz;
+            aes->cOver = (byte)(aes->cOver + sz);
             if (aes->cOver == WC_AES_BLOCK_SIZE) {
                 /* We have filled up the block and can process. */
                 GHASH_ONE_BLOCK(aes, AES_LASTGBLOCK(aes));
@@ -8139,7 +8139,7 @@ static void GHASH_FINAL(Aes* aes, byte* s, word32 sSz)
     }
     if (over > 0) {
         /* Zeroize the unused part of the block. */
-        XMEMSET(AES_LASTGBLOCK(aes) + over, 0, WC_AES_BLOCK_SIZE - over);
+        XMEMSET(AES_LASTGBLOCK(aes) + over, 0, (size_t)WC_AES_BLOCK_SIZE - over);
         /* Hash the last block of cipher text. */
         GHASH_ONE_BLOCK(aes, AES_LASTGBLOCK(aes));
     }
@@ -9352,7 +9352,7 @@ static WARN_UNUSED_RESULT int AesGcmCryptUpdate_C(
 
     /* Check if previous encrypted block was not used up. */
     if (aes->over > 0) {
-        byte pSz = WC_AES_BLOCK_SIZE - aes->over;
+        byte pSz = (byte)(WC_AES_BLOCK_SIZE - aes->over);
         if (pSz > sz) pSz = (byte)sz;
 
         /* Use some/all of last encrypted block. */
@@ -9579,13 +9579,13 @@ static WARN_UNUSED_RESULT int AesGcmAadUpdate_aesni(
         /* Check if we have unprocessed data. */
         if (aes->aOver > 0) {
             /* Calculate amount we can use - fill up the block. */
-            byte sz = WC_AES_BLOCK_SIZE - aes->aOver;
+            byte sz = (byte)(WC_AES_BLOCK_SIZE - aes->aOver);
             if (sz > aSz) {
                 sz = (byte)aSz;
             }
             /* Copy extra into last GHASH block array and update count. */
             XMEMCPY(AES_LASTGBLOCK(aes) + aes->aOver, a, sz);
-            aes->aOver += sz;
+            aes->aOver = (byte)(aes->aOver + sz);
             if (aes->aOver == WC_AES_BLOCK_SIZE) {
                 /* We have filled up the block and can process. */
             #ifdef HAVE_INTEL_AVX2
@@ -9650,7 +9650,7 @@ static WARN_UNUSED_RESULT int AesGcmAadUpdate_aesni(
         /* No more AAD coming and we have a partial block. */
         /* Fill the rest of the block with zeros. */
         XMEMSET(AES_LASTGBLOCK(aes) + aes->aOver, 0,
-                WC_AES_BLOCK_SIZE - aes->aOver);
+                (size_t)WC_AES_BLOCK_SIZE - aes->aOver);
         /* GHASH last AAD block. */
     #ifdef HAVE_INTEL_AVX2
         if (IS_INTEL_AVX2(intel_flags)) {
@@ -9708,7 +9708,7 @@ static WARN_UNUSED_RESULT int AesGcmEncryptUpdate_aesni(
         aes->cSz += cSz;
         if (aes->cOver > 0) {
             /* Calculate amount we can use - fill up the block. */
-            byte sz = WC_AES_BLOCK_SIZE - aes->cOver;
+            byte sz = (byte)(WC_AES_BLOCK_SIZE - aes->cOver);
             if (sz > cSz) {
                 sz = (byte)cSz;
             }
@@ -9716,7 +9716,7 @@ static WARN_UNUSED_RESULT int AesGcmEncryptUpdate_aesni(
             xorbuf(AES_LASTGBLOCK(aes) + aes->cOver, p, sz);
             XMEMCPY(c, AES_LASTGBLOCK(aes) + aes->cOver, sz);
             /* Update count of unused encrypted counter. */
-            aes->cOver += sz;
+            aes->cOver = (byte)(aes->cOver + sz);
             if (aes->cOver == WC_AES_BLOCK_SIZE) {
                 /* We have filled up the block and can process. */
             #ifdef HAVE_INTEL_AVX2
@@ -9832,7 +9832,7 @@ static WARN_UNUSED_RESULT int AesGcmEncryptFinal_aesni(
     }
     if (over > 0) {
         /* Fill the rest of the block with zeros. */
-        XMEMSET(AES_LASTGBLOCK(aes) + over, 0, WC_AES_BLOCK_SIZE - over);
+        XMEMSET(AES_LASTGBLOCK(aes) + over, 0, (size_t)WC_AES_BLOCK_SIZE - over);
         /* GHASH last cipher block. */
     #ifdef HAVE_INTEL_AVX2
         if (IS_INTEL_AVX2(intel_flags)) {
@@ -9939,7 +9939,7 @@ static WARN_UNUSED_RESULT int AesGcmDecryptUpdate_aesni(
         aes->cSz += cSz;
         if (aes->cOver > 0) {
             /* Calculate amount we can use - fill up the block. */
-            byte sz = WC_AES_BLOCK_SIZE - aes->cOver;
+            byte sz = (byte)(WC_AES_BLOCK_SIZE - aes->cOver);
             if (sz > cSz) {
                 sz = (byte)cSz;
             }
@@ -9949,7 +9949,7 @@ static WARN_UNUSED_RESULT int AesGcmDecryptUpdate_aesni(
             xorbuf(AES_LASTGBLOCK(aes) + aes->cOver, c, sz);
             XMEMCPY(p, AES_LASTGBLOCK(aes) + aes->cOver, sz);
             /* Update count of unused encrypted counter. */
-            aes->cOver += sz;
+            aes->cOver = (byte)(aes->cOver + sz);
             if (aes->cOver == WC_AES_BLOCK_SIZE) {
                 /* We have filled up the block and can process. */
             #ifdef HAVE_INTEL_AVX2
@@ -10072,7 +10072,7 @@ static WARN_UNUSED_RESULT int AesGcmDecryptFinal_aesni(
     }
     if (over > 0) {
         /* Zeroize the unused part of the block. */
-        XMEMSET(lastBlock + over, 0, WC_AES_BLOCK_SIZE - over);
+        XMEMSET(lastBlock + over, 0, (size_t)WC_AES_BLOCK_SIZE - over);
         /* Hash the last block of cipher text. */
     #ifdef HAVE_INTEL_AVX2
         if (IS_INTEL_AVX2(intel_flags)) {
@@ -11044,14 +11044,14 @@ static WC_INLINE void AesCcmCtrIncSet4(byte* B, word32 lenSz)
     for (i = 0; i < lenSz; i++) {
         if (++B[WC_AES_BLOCK_SIZE * 2 - 1 - i] != 0) break;
     }
-    B[WC_AES_BLOCK_SIZE * 3 - 1] += 2;
-    if (B[WC_AES_BLOCK_SIZE * 3 - 1] < 2) {
+    B[WC_AES_BLOCK_SIZE * 3 - 1] = (byte)(B[WC_AES_BLOCK_SIZE * 3 - 1] + 2U);
+    if (B[WC_AES_BLOCK_SIZE * 3 - 1] < 2U) {
         for (i = 1; i < lenSz; i++) {
             if (++B[WC_AES_BLOCK_SIZE * 3 - 1 - i] != 0) break;
         }
     }
-    B[WC_AES_BLOCK_SIZE * 4 - 1] += 3;
-    if (B[WC_AES_BLOCK_SIZE * 4 - 1] < 3) {
+    B[WC_AES_BLOCK_SIZE * 4 - 1] = (byte)(B[WC_AES_BLOCK_SIZE * 4 - 1] + 3U);
+    if (B[WC_AES_BLOCK_SIZE * 4 - 1] < 3U) {
         for (i = 1; i < lenSz; i++) {
             if (++B[WC_AES_BLOCK_SIZE * 4 - 1 - i] != 0) break;
         }
@@ -11062,8 +11062,8 @@ static WC_INLINE void AesCcmCtrInc4(byte* B, word32 lenSz)
 {
     word32 i;
 
-    B[WC_AES_BLOCK_SIZE - 1] += 4;
-    if (B[WC_AES_BLOCK_SIZE - 1] < 4) {
+    B[WC_AES_BLOCK_SIZE - 1] = (byte)(B[WC_AES_BLOCK_SIZE - 1] + 4U);
+    if (B[WC_AES_BLOCK_SIZE - 1] < 4U) {
         for (i = 1; i < lenSz; i++) {
             if (++B[WC_AES_BLOCK_SIZE - 1 - i] != 0) break;
         }
@@ -11123,7 +11123,7 @@ int wc_AesCcmEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
 
     XMEMSET(A, 0, sizeof(A));
     XMEMCPY(B+1, nonce, nonceSz);
-    lenSz = WC_AES_BLOCK_SIZE - 1 - (byte)nonceSz;
+    lenSz = (byte)(WC_AES_BLOCK_SIZE - 1U - nonceSz);
     B[0] = (byte)((authInSz > 0 ? 64 : 0)
                   + (8 * (((byte)authTagSz - 2) / 2))
                   + (lenSz - 1));
@@ -11153,7 +11153,7 @@ int wc_AesCcmEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
     if (ret == 0) {
         XMEMCPY(authTag, A, authTagSz);
 
-        B[0] = lenSz - 1;
+        B[0] = (byte)(lenSz - 1U);
         for (i = 0; i < lenSz; i++)
             B[WC_AES_BLOCK_SIZE - 1 - i] = 0;
         ret = wc_AesEncrypt(aes, B, A);
@@ -11272,9 +11272,9 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
     oSz = inSz;
     XMEMSET(A, 0, sizeof A);
     XMEMCPY(B+1, nonce, nonceSz);
-    lenSz = WC_AES_BLOCK_SIZE - 1 - (byte)nonceSz;
+    lenSz = (byte)(WC_AES_BLOCK_SIZE - 1U - nonceSz);
 
-    B[0] = lenSz - 1;
+    B[0] = (byte)(lenSz - 1U);
     for (i = 0; i < lenSz; i++)
         B[WC_AES_BLOCK_SIZE - 1 - i] = 0;
     B[15] = 1;
@@ -11353,7 +11353,7 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
         ret = roll_x(aes, o, oSz, A);
 
     if (ret == 0) {
-        B[0] = lenSz - 1;
+        B[0] = (byte)(lenSz - 1U);
         for (i = 0; i < lenSz; i++)
             B[WC_AES_BLOCK_SIZE - 1 - i] = 0;
         ret = wc_AesEncrypt(aes, B, B);
@@ -12175,11 +12175,11 @@ static void shiftLeftArray(byte* ary, byte shift)
     else {
         /* shifting over by 7 or less bits */
         for (i = 0; i < WC_AES_BLOCK_SIZE - 1; i++) {
-            byte carry = ary[i+1] & (0XFF << (WOLFSSL_BIT_SIZE - shift));
-            carry >>= (WOLFSSL_BIT_SIZE - shift);
+            byte carry = (byte)(ary[i+1] & (0XFF << (WOLFSSL_BIT_SIZE - shift)));
+            carry = (byte)(carry >> (WOLFSSL_BIT_SIZE - shift));
             ary[i] = (byte)((ary[i] << shift) + carry);
         }
-        ary[i] = ary[i] << shift;
+        ary[i] = (byte)(ary[i] << shift);
     }
 }
 
@@ -12265,19 +12265,19 @@ static WARN_UNUSED_RESULT int wc_AesFeedbackCFB1(
             pt = (byte*)aes->reg;
 
             /* LSB + CAT */
-            tmp = (0X01 << bit) & in[0];
-            tmp = tmp >> bit;
+            tmp = (byte)((0X01U << bit) & in[0]);
+            tmp = (byte)(tmp >> bit);
             tmp &= 0x01;
             shiftLeftArray((byte*)aes->reg, 1);
             pt[WC_AES_BLOCK_SIZE - 1] |= tmp;
         }
 
         /* MSB  + XOR */
-        tmp = (0X01 << bit) & in[0];
+        tmp = (byte)((0X01U << bit) & in[0]);
         pt = (byte*)aes->tmp;
-        tmp = (pt[0] >> 7) ^ (tmp >> bit);
+        tmp = (byte)((pt[0] >> 7) ^ (tmp >> bit));
         tmp &= 0x01;
-        cur |= (tmp << bit);
+        cur = (byte)(cur | (tmp << bit));
 
 
         if (dir == AES_ENCRYPTION) {
@@ -12294,7 +12294,7 @@ static WARN_UNUSED_RESULT int wc_AesFeedbackCFB1(
             out += 1;
             in  += 1;
             sz  -= 1;
-            bit = 7;
+            bit = 7U;
             cur = 0;
         }
         else {
@@ -14062,7 +14062,7 @@ static WARN_UNUSED_RESULT int S2V(
             if (ret != 0)
                 break;
             xorbuf(tmp[1-tmpi], tmp[tmpi], WC_AES_BLOCK_SIZE);
-            tmpi = 1 - tmpi;
+            tmpi = (byte)(1 - tmpi);
         }
 
         /* Add nonce as final AD. See RFC 5297 Section 3. */
@@ -14073,7 +14073,7 @@ static WARN_UNUSED_RESULT int S2V(
             if (ret == 0) {
                 xorbuf(tmp[1-tmpi], tmp[tmpi], WC_AES_BLOCK_SIZE);
             }
-            tmpi = 1 - tmpi;
+            tmpi = (byte)(1U - tmpi);
         }
 
         /* For simplicity of the remaining code, make sure the "final" result

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -1273,8 +1273,8 @@ static int GetASN_StoreData(const ASNItem* asn, ASNGetData* data,
             /* Fill number with all of data. */
             *data->data.u16 = 0;
             for (i = 0; i < len; i++) {
-                *data->data.u16 <<= 8;
-                *data->data.u16 |= input[idx + (word32)i] ;
+                *data->data.u16 = (word16)(*data->data.u16 << 8U);
+                *data->data.u16 = (word16)(*data->data.u16 | input[idx + (word32)i]);
             }
             break;
         case ASN_DATA_TYPE_WORD32:
@@ -8640,12 +8640,12 @@ int wc_EncryptPKCS8Key(byte* key, word32 keySz, byte* out, word32* outSz,
             pbeOidBuf = pbes2;
             pbeOidBufSz = sizeof(pbes2);
             /* kdf = OBJ pbkdf2 [ SEQ innerLen ] */
-            kdfLen = 2 + sizeof(pbkdf2Oid) + 2 + innerLen;
+            kdfLen = 2U + (word32)sizeof(pbkdf2Oid) + 2U + innerLen;
             /* enc = OBJ enc_alg OCT iv */
-            encLen = 2 + (word32)encOidSz + 2 + (word32)blockSz;
+            encLen = 2U + (word32)encOidSz + 2U + (word32)blockSz;
             /* pbe = OBJ pbse2 SEQ [ SEQ [ kdf ] SEQ [ enc ] ] */
-            pbeLen = (word32)(2 + sizeof(pbes2) + 2 + 2 + (size_t)kdfLen + 2 +
-                              (size_t)encLen);
+            pbeLen = 2U + (word32)sizeof(pbes2) + 2U + 2U + kdfLen + 2U +
+                encLen;
 
             ret = wc_RNG_GenerateBlock(rng, cbcIv, (word32)blockSz);
         }
@@ -8715,7 +8715,7 @@ int wc_EncryptPKCS8Key(byte* key, word32 keySz, byte* out, word32* outSz,
             idx += SetSequence(kdfLen, out + idx);
             idx += (word32)SetObjectId((int)sizeof(pbkdf2Oid), out + idx);
             XMEMCPY(out + idx, pbkdf2Oid, sizeof(pbkdf2Oid));
-            idx += sizeof(pbkdf2Oid);
+            idx += (word32)sizeof(pbkdf2Oid);
         }
         idx += SetSequence(innerLen, out + idx);
         idx += SetOctetString(saltSz, out + idx);
@@ -24085,7 +24085,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm, Signer 
                     }
                 }
                 else {
-                    cert->maxPathLen = (byte)min(cert->ca->maxPathLen - 1,
+                    cert->maxPathLen = (byte)min(cert->ca->maxPathLen - 1U,
                                            cert->maxPathLen);
                 }
             }
@@ -27020,7 +27020,7 @@ static int wc_SetCert_LoadDer(Cert* cert, const byte* der, word32 derSz,
 #ifndef NO_ASN_TIME
 static WC_INLINE byte itob(int number)
 {
-    return (byte)number + 0x30;
+    return (byte)(number + 0x30);
 }
 
 
@@ -33432,7 +33432,8 @@ int EncodePolicyOID(byte *out, word32 *outSz, const char *in, void* heap)
                 return BUFFER_E;
             }
 
-            out[idx++] += (byte)val;
+            out[idx] = (byte)(out[idx] + val);
+            ++idx;
         }
         else {
             word32  tb = 0;

--- a/wolfcrypt/src/coding.c
+++ b/wolfcrypt/src/coding.c
@@ -99,7 +99,7 @@ static WC_INLINE byte Base64_Char2Val(byte c)
     byte v;
     byte mask;
 
-    c -= BASE64_MIN;
+    c = (byte)(c - BASE64_MIN);
     mask = (byte)((((byte)(0x3f - c)) >> 7) - 1);
     /* Load a value from the first cache line and use when mask set. */
     v  = (byte)(base64Decode[ c & 0x3f        ] &   mask);
@@ -507,7 +507,7 @@ int Base16_Decode(const byte* in, word32 inLen, byte* out, word32* outLen)
         return BAD_FUNC_ARG;
 
     if (inLen == 1 && *outLen && in) {
-        byte b = in[inIdx++] - BASE16_MIN;  /* 0 starts at 0x30 */
+        byte b = (byte)(in[inIdx++] - BASE16_MIN);  /* 0 starts at 0x30 */
 
         /* sanity check */
         if (b >=  sizeof(hexDecode)/sizeof(hexDecode[0]))
@@ -531,8 +531,8 @@ int Base16_Decode(const byte* in, word32 inLen, byte* out, word32* outLen)
         return BAD_FUNC_ARG;
 
     while (inLen) {
-        byte b  = in[inIdx++] - BASE16_MIN;  /* 0 starts at 0x30 */
-        byte b2 = in[inIdx++] - BASE16_MIN;
+        byte b  = (byte)(in[inIdx++] - BASE16_MIN);  /* 0 starts at 0x30 */
+        byte b2 = (byte)(in[inIdx++] - BASE16_MIN);
 
         /* sanity checks */
         if (b >=  sizeof(hexDecode)/sizeof(hexDecode[0]))
@@ -570,14 +570,14 @@ int Base16_Encode(const byte* in, word32 inLen, byte* out, word32* outLen)
         byte lb = in[i] & 0x0f;
 
         /* ASCII value */
-        hb += '0';
+        hb = (byte)(hb + '0');
         if (hb > '9')
-            hb += 7;
+            hb = (byte)(hb + 7U);
 
         /* ASCII value */
-        lb += '0';
+        lb = (byte)(lb + '0');
         if (lb>'9')
-            lb += 7;
+            lb = (byte)(lb + 7U);
 
         out[outIdx++] = hb;
         out[outIdx++] = lb;

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -1642,7 +1642,7 @@ static void wc_ecc_curve_cache_free_spec_item(ecc_curve_spec* curve, mp_int* ite
     #endif
         mp_clear(item);
     }
-    curve->load_mask &= ~mask;
+    curve->load_mask = (byte)(curve->load_mask & ~mask);
 }
 static void wc_ecc_curve_cache_free_spec(ecc_curve_spec* curve)
 {
@@ -12811,7 +12811,7 @@ static int accel_fp_mul(int idx, const mp_int* k, ecc_point *R, mp_int* a,
              by x bits from the start */
           bitpos = (unsigned)x;
           for (y = z = 0; y < FP_LUT; y++) {
-             z |= ((kb[bitpos>>3] >> (bitpos&7)) & 1) << y;
+             z |= (((word32)kb[bitpos>>3U] >> (bitpos&7U)) & 1U) << y;
              bitpos += lut_gap;  /* it's y*lut_gap + x, but here we can avoid
                                     the mult in each loop */
           }
@@ -13064,8 +13064,8 @@ static int accel_fp_mul2add(int idx1, int idx2,
              offset by x bits from the start */
           bitpos = (unsigned)x;
           for (y = zA = zB = 0; y < FP_LUT; y++) {
-             zA |= ((kb[0][bitpos>>3] >> (bitpos&7)) & 1) << y;
-             zB |= ((kb[1][bitpos>>3] >> (bitpos&7)) & 1) << y;
+             zA |= (((word32)kb[0][bitpos>>3U] >> (bitpos&7U)) & 1U) << y;
+             zB |= (((word32)kb[1][bitpos>>3U] >> (bitpos&7U)) & 1U) << y;
              bitpos += lut_gap;    /* it's y*lut_gap + x, but here we can avoid
                                       the mult in each loop */
           }

--- a/wolfcrypt/src/fe_x25519_128.h
+++ b/wolfcrypt/src/fe_x25519_128.h
@@ -120,30 +120,30 @@ void fe_tobytes(unsigned char *out, const fe n)
     out[ 3] = (((byte)((in[0] >> 24)       ))      );
     out[ 4] = (((byte)((in[0] >> 32)       ))      );
     out[ 5] = (((byte)((in[0] >> 40)       ))      );
-    out[ 6] = (((byte)((in[0] >> 48) & 0x07))      )
-            | (((byte)((in[1]      ) & 0x1f)) <<  3);
+    out[ 6] = (byte)((((byte)((in[0] >> 48) & 0x07)))
+                   | (((byte)((in[1]      ) & 0x1f)) <<  3));
     out[ 7] = (((byte)((in[1] >>  5)       ))      );
     out[ 8] = (((byte)((in[1] >> 13)       ))      );
     out[ 9] = (((byte)((in[1] >> 21)       ))      );
     out[10] = (((byte)((in[1] >> 29)       ))      );
     out[11] = (((byte)((in[1] >> 37)       ))      );
-    out[12] = (((byte)((in[1] >> 45) & 0x3f))      )
-            | (((byte)((in[2]      ) & 0x03)) <<  6);
+    out[12] = (byte)((((byte)((in[1] >> 45) & 0x3f)))
+                   | (((byte)((in[2]      ) & 0x03)) <<  6));
     out[13] = (((byte)((in[2] >>  2)       ))      );
     out[14] = (((byte)((in[2] >> 10)       ))      );
     out[15] = (((byte)((in[2] >> 18)       ))      );
     out[16] = (((byte)((in[2] >> 26)       ))      );
     out[17] = (((byte)((in[2] >> 34)       ))      );
     out[18] = (((byte)((in[2] >> 42)       ))      );
-    out[19] = (((byte)((in[2] >> 50) & 0x01))      )
-            | (((byte)((in[3]      ) & 0x7f)) <<  1);
+    out[19] = (byte)((((byte)((in[2] >> 50) & 0x01)))
+                   | (((byte)((in[3]      ) & 0x7f)) <<  1));
     out[20] = (((byte)((in[3] >>  7)       ))      );
     out[21] = (((byte)((in[3] >> 15)       ))      );
     out[22] = (((byte)((in[3] >> 23)       ))      );
     out[23] = (((byte)((in[3] >> 31)       ))      );
     out[24] = (((byte)((in[3] >> 39)       ))      );
-    out[25] = (((byte)((in[3] >> 47) & 0x0f))      )
-            | (((byte)((in[4]      ) & 0x0f)) <<  4);
+    out[25] = (byte)((((byte)((in[3] >> 47) & 0x0f)))
+                   | (((byte)((in[4]      ) & 0x0f)) <<  4));
     out[26] = (((byte)((in[4] >>  4)       ))      );
     out[27] = (((byte)((in[4] >> 12)       ))      );
     out[28] = (((byte)((in[4] >> 20)       ))      );
@@ -427,7 +427,7 @@ int curve25519(byte* r, const byte* n, const byte* a)
 
     swap = 0;
     for (pos = 254;pos >= 0;--pos) {
-        b = n[pos / 8] >> (pos & 7);
+        b = (unsigned int)(n[pos / 8] >> (pos & 7));
         b &= 1;
         swap ^= b;
         fe_cswap(x2, x3, (int)swap);

--- a/wolfcrypt/src/ge_448.c
+++ b/wolfcrypt/src/ge_448.c
@@ -464,120 +464,120 @@ void sc448_reduce(byte* b)
     word64 o;
 
     /* Load from bytes */
-    t[ 0] =  ((sword64) (b[ 0]) <<  0)
-          |  ((sword64) (b[ 1]) <<  8)
-          |  ((sword64) (b[ 2]) << 16)
-          |  ((sword64) (b[ 3]) << 24)
-          |  ((sword64) (b[ 4]) << 32)
-          |  ((sword64) (b[ 5]) << 40)
-          |  ((sword64) (b[ 6]) << 48);
-    t[ 1] =  ((sword64) (b[ 7]) <<  0)
-          |  ((sword64) (b[ 8]) <<  8)
-          |  ((sword64) (b[ 9]) << 16)
-          |  ((sword64) (b[10]) << 24)
-          |  ((sword64) (b[11]) << 32)
-          |  ((sword64) (b[12]) << 40)
-          |  ((sword64) (b[13]) << 48);
-    t[ 2] =  ((sword64) (b[14]) <<  0)
-          |  ((sword64) (b[15]) <<  8)
-          |  ((sword64) (b[16]) << 16)
-          |  ((sword64) (b[17]) << 24)
-          |  ((sword64) (b[18]) << 32)
-          |  ((sword64) (b[19]) << 40)
-          |  ((sword64) (b[20]) << 48);
-    t[ 3] =  ((sword64) (b[21]) <<  0)
-          |  ((sword64) (b[22]) <<  8)
-          |  ((sword64) (b[23]) << 16)
-          |  ((sword64) (b[24]) << 24)
-          |  ((sword64) (b[25]) << 32)
-          |  ((sword64) (b[26]) << 40)
-          |  ((sword64) (b[27]) << 48);
-    t[ 4] =  ((sword64) (b[28]) <<  0)
-          |  ((sword64) (b[29]) <<  8)
-          |  ((sword64) (b[30]) << 16)
-          |  ((sword64) (b[31]) << 24)
-          |  ((sword64) (b[32]) << 32)
-          |  ((sword64) (b[33]) << 40)
-          |  ((sword64) (b[34]) << 48);
-    t[ 5] =  ((sword64) (b[35]) <<  0)
-          |  ((sword64) (b[36]) <<  8)
-          |  ((sword64) (b[37]) << 16)
-          |  ((sword64) (b[38]) << 24)
-          |  ((sword64) (b[39]) << 32)
-          |  ((sword64) (b[40]) << 40)
-          |  ((sword64) (b[41]) << 48);
-    t[ 6] =  ((sword64) (b[42]) <<  0)
-          |  ((sword64) (b[43]) <<  8)
-          |  ((sword64) (b[44]) << 16)
-          |  ((sword64) (b[45]) << 24)
-          |  ((sword64) (b[46]) << 32)
-          |  ((sword64) (b[47]) << 40)
-          |  ((sword64) (b[48]) << 48);
-    t[ 7] =  ((sword64) (b[49]) <<  0)
-          |  ((sword64) (b[50]) <<  8)
-          |  ((sword64) (b[51]) << 16)
-          |  ((sword64) (b[52]) << 24)
-          |  ((sword64) (b[53]) << 32)
-          |  ((sword64) (b[54]) << 40)
-          |  ((sword64) (b[55]) << 48);
-    t[ 8] =  ((sword64) (b[56]) <<  0)
-          |  ((sword64) (b[57]) <<  8)
-          |  ((sword64) (b[58]) << 16)
-          |  ((sword64) (b[59]) << 24)
-          |  ((sword64) (b[60]) << 32)
-          |  ((sword64) (b[61]) << 40)
-          |  ((sword64) (b[62]) << 48);
-    t[ 9] =  ((sword64) (b[63]) <<  0)
-          |  ((sword64) (b[64]) <<  8)
-          |  ((sword64) (b[65]) << 16)
-          |  ((sword64) (b[66]) << 24)
-          |  ((sword64) (b[67]) << 32)
-          |  ((sword64) (b[68]) << 40)
-          |  ((sword64) (b[69]) << 48);
-    t[10] =  ((sword64) (b[70]) <<  0)
-          |  ((sword64) (b[71]) <<  8)
-          |  ((sword64) (b[72]) << 16)
-          |  ((sword64) (b[73]) << 24)
-          |  ((sword64) (b[74]) << 32)
-          |  ((sword64) (b[75]) << 40)
-          |  ((sword64) (b[76]) << 48);
-    t[11] =  ((sword64) (b[77]) <<  0)
-          |  ((sword64) (b[78]) <<  8)
-          |  ((sword64) (b[79]) << 16)
-          |  ((sword64) (b[80]) << 24)
-          |  ((sword64) (b[81]) << 32)
-          |  ((sword64) (b[82]) << 40)
-          |  ((sword64) (b[83]) << 48);
-    t[12] =  ((sword64) (b[84]) <<  0)
-          |  ((sword64) (b[85]) <<  8)
-          |  ((sword64) (b[86]) << 16)
-          |  ((sword64) (b[87]) << 24)
-          |  ((sword64) (b[88]) << 32)
-          |  ((sword64) (b[89]) << 40)
-          |  ((sword64) (b[90]) << 48);
-    t[13] =  ((sword64) (b[91]) <<  0)
-          |  ((sword64) (b[92]) <<  8)
-          |  ((sword64) (b[93]) << 16)
-          |  ((sword64) (b[94]) << 24)
-          |  ((sword64) (b[95]) << 32)
-          |  ((sword64) (b[96]) << 40)
-          |  ((sword64) (b[97]) << 48);
-    t[14] =  ((sword64) (b[98]) <<  0)
-          |  ((sword64) (b[99]) <<  8)
-          |  ((sword64) (b[100]) << 16)
-          |  ((sword64) (b[101]) << 24)
-          |  ((sword64) (b[102]) << 32)
-          |  ((sword64) (b[103]) << 40)
-          |  ((sword64) (b[104]) << 48);
-    t[15] =  ((sword64) (b[105]) <<  0)
-          |  ((sword64) (b[106]) <<  8)
-          |  ((sword64) (b[107]) << 16)
-          |  ((sword64) (b[108]) << 24)
-          |  ((sword64) (b[109]) << 32)
-          |  ((sword64) (b[110]) << 40)
-          |  ((sword64) (b[111]) << 48);
-    t[16] =  ((sword64) (b[112]) <<  0)
-          |  ((sword64) (b[113]) <<  8);
+    t[ 0] =  (word64)((sword64) (b[ 0]) <<  0)
+          |  (word64)((sword64) (b[ 1]) <<  8)
+          |  (word64)((sword64) (b[ 2]) << 16)
+          |  (word64)((sword64) (b[ 3]) << 24)
+          |  (word64)((sword64) (b[ 4]) << 32)
+          |  (word64)((sword64) (b[ 5]) << 40)
+          |  (word64)((sword64) (b[ 6]) << 48);
+    t[ 1] =  (word64)((sword64) (b[ 7]) <<  0)
+          |  (word64)((sword64) (b[ 8]) <<  8)
+          |  (word64)((sword64) (b[ 9]) << 16)
+          |  (word64)((sword64) (b[10]) << 24)
+          |  (word64)((sword64) (b[11]) << 32)
+          |  (word64)((sword64) (b[12]) << 40)
+          |  (word64)((sword64) (b[13]) << 48);
+    t[ 2] =  (word64)((sword64) (b[14]) <<  0)
+          |  (word64)((sword64) (b[15]) <<  8)
+          |  (word64)((sword64) (b[16]) << 16)
+          |  (word64)((sword64) (b[17]) << 24)
+          |  (word64)((sword64) (b[18]) << 32)
+          |  (word64)((sword64) (b[19]) << 40)
+          |  (word64)((sword64) (b[20]) << 48);
+    t[ 3] =  (word64)((sword64) (b[21]) <<  0)
+          |  (word64)((sword64) (b[22]) <<  8)
+          |  (word64)((sword64) (b[23]) << 16)
+          |  (word64)((sword64) (b[24]) << 24)
+          |  (word64)((sword64) (b[25]) << 32)
+          |  (word64)((sword64) (b[26]) << 40)
+          |  (word64)((sword64) (b[27]) << 48);
+    t[ 4] =  (word64)((sword64) (b[28]) <<  0)
+          |  (word64)((sword64) (b[29]) <<  8)
+          |  (word64)((sword64) (b[30]) << 16)
+          |  (word64)((sword64) (b[31]) << 24)
+          |  (word64)((sword64) (b[32]) << 32)
+          |  (word64)((sword64) (b[33]) << 40)
+          |  (word64)((sword64) (b[34]) << 48);
+    t[ 5] =  (word64)((sword64) (b[35]) <<  0)
+          |  (word64)((sword64) (b[36]) <<  8)
+          |  (word64)((sword64) (b[37]) << 16)
+          |  (word64)((sword64) (b[38]) << 24)
+          |  (word64)((sword64) (b[39]) << 32)
+          |  (word64)((sword64) (b[40]) << 40)
+          |  (word64)((sword64) (b[41]) << 48);
+    t[ 6] =  (word64)((sword64) (b[42]) <<  0)
+          |  (word64)((sword64) (b[43]) <<  8)
+          |  (word64)((sword64) (b[44]) << 16)
+          |  (word64)((sword64) (b[45]) << 24)
+          |  (word64)((sword64) (b[46]) << 32)
+          |  (word64)((sword64) (b[47]) << 40)
+          |  (word64)((sword64) (b[48]) << 48);
+    t[ 7] =  (word64)((sword64) (b[49]) <<  0)
+          |  (word64)((sword64) (b[50]) <<  8)
+          |  (word64)((sword64) (b[51]) << 16)
+          |  (word64)((sword64) (b[52]) << 24)
+          |  (word64)((sword64) (b[53]) << 32)
+          |  (word64)((sword64) (b[54]) << 40)
+          |  (word64)((sword64) (b[55]) << 48);
+    t[ 8] =  (word64)((sword64) (b[56]) <<  0)
+          |  (word64)((sword64) (b[57]) <<  8)
+          |  (word64)((sword64) (b[58]) << 16)
+          |  (word64)((sword64) (b[59]) << 24)
+          |  (word64)((sword64) (b[60]) << 32)
+          |  (word64)((sword64) (b[61]) << 40)
+          |  (word64)((sword64) (b[62]) << 48);
+    t[ 9] =  (word64)((sword64) (b[63]) <<  0)
+          |  (word64)((sword64) (b[64]) <<  8)
+          |  (word64)((sword64) (b[65]) << 16)
+          |  (word64)((sword64) (b[66]) << 24)
+          |  (word64)((sword64) (b[67]) << 32)
+          |  (word64)((sword64) (b[68]) << 40)
+          |  (word64)((sword64) (b[69]) << 48);
+    t[10] =  (word64)((sword64) (b[70]) <<  0)
+          |  (word64)((sword64) (b[71]) <<  8)
+          |  (word64)((sword64) (b[72]) << 16)
+          |  (word64)((sword64) (b[73]) << 24)
+          |  (word64)((sword64) (b[74]) << 32)
+          |  (word64)((sword64) (b[75]) << 40)
+          |  (word64)((sword64) (b[76]) << 48);
+    t[11] =  (word64)((sword64) (b[77]) <<  0)
+          |  (word64)((sword64) (b[78]) <<  8)
+          |  (word64)((sword64) (b[79]) << 16)
+          |  (word64)((sword64) (b[80]) << 24)
+          |  (word64)((sword64) (b[81]) << 32)
+          |  (word64)((sword64) (b[82]) << 40)
+          |  (word64)((sword64) (b[83]) << 48);
+    t[12] =  (word64)((sword64) (b[84]) <<  0)
+          |  (word64)((sword64) (b[85]) <<  8)
+          |  (word64)((sword64) (b[86]) << 16)
+          |  (word64)((sword64) (b[87]) << 24)
+          |  (word64)((sword64) (b[88]) << 32)
+          |  (word64)((sword64) (b[89]) << 40)
+          |  (word64)((sword64) (b[90]) << 48);
+    t[13] =  (word64)((sword64) (b[91]) <<  0)
+          |  (word64)((sword64) (b[92]) <<  8)
+          |  (word64)((sword64) (b[93]) << 16)
+          |  (word64)((sword64) (b[94]) << 24)
+          |  (word64)((sword64) (b[95]) << 32)
+          |  (word64)((sword64) (b[96]) << 40)
+          |  (word64)((sword64) (b[97]) << 48);
+    t[14] =  (word64)((sword64) (b[98]) <<  0)
+          |  (word64)((sword64) (b[99]) <<  8)
+          |  (word64)((sword64) (b[100]) << 16)
+          |  (word64)((sword64) (b[101]) << 24)
+          |  (word64)((sword64) (b[102]) << 32)
+          |  (word64)((sword64) (b[103]) << 40)
+          |  (word64)((sword64) (b[104]) << 48);
+    t[15] =  (word64)((sword64) (b[105]) <<  0)
+          |  (word64)((sword64) (b[106]) <<  8)
+          |  (word64)((sword64) (b[107]) << 16)
+          |  (word64)((sword64) (b[108]) << 24)
+          |  (word64)((sword64) (b[109]) << 32)
+          |  (word64)((sword64) (b[110]) << 40)
+          |  (word64)((sword64) (b[111]) << 48);
+    t[16] =  (word64)((sword64) (b[112]) <<  0)
+          |  (word64)((sword64) (b[113]) <<  8);
 
     /* Mod curve order */
     /* 2^446 - 0x8335dc163bb124b65129c96fde933d8d723a70aadc873d6d54a7bb0d */
@@ -747,241 +747,241 @@ void sc448_muladd(byte* r, const byte* a, const byte* b, const byte* d)
     sword64 u;
 
     /* Load from bytes */
-    ad[ 0] =  ((sword64) (a[ 0]) <<  0)
-           |  ((sword64) (a[ 1]) <<  8)
-           |  ((sword64) (a[ 2]) << 16)
-           |  ((sword64) (a[ 3]) << 24)
-           |  ((sword64) (a[ 4]) << 32)
-           |  ((sword64) (a[ 5]) << 40)
-           |  ((sword64) (a[ 6]) << 48);
-    ad[ 1] =  ((sword64) (a[ 7]) <<  0)
-           |  ((sword64) (a[ 8]) <<  8)
-           |  ((sword64) (a[ 9]) << 16)
-           |  ((sword64) (a[10]) << 24)
-           |  ((sword64) (a[11]) << 32)
-           |  ((sword64) (a[12]) << 40)
-           |  ((sword64) (a[13]) << 48);
-    ad[ 2] =  ((sword64) (a[14]) <<  0)
-           |  ((sword64) (a[15]) <<  8)
-           |  ((sword64) (a[16]) << 16)
-           |  ((sword64) (a[17]) << 24)
-           |  ((sword64) (a[18]) << 32)
-           |  ((sword64) (a[19]) << 40)
-           |  ((sword64) (a[20]) << 48);
-    ad[ 3] =  ((sword64) (a[21]) <<  0)
-           |  ((sword64) (a[22]) <<  8)
-           |  ((sword64) (a[23]) << 16)
-           |  ((sword64) (a[24]) << 24)
-           |  ((sword64) (a[25]) << 32)
-           |  ((sword64) (a[26]) << 40)
-           |  ((sword64) (a[27]) << 48);
-    ad[ 4] =  ((sword64) (a[28]) <<  0)
-           |  ((sword64) (a[29]) <<  8)
-           |  ((sword64) (a[30]) << 16)
-           |  ((sword64) (a[31]) << 24)
-           |  ((sword64) (a[32]) << 32)
-           |  ((sword64) (a[33]) << 40)
-           |  ((sword64) (a[34]) << 48);
-    ad[ 5] =  ((sword64) (a[35]) <<  0)
-           |  ((sword64) (a[36]) <<  8)
-           |  ((sword64) (a[37]) << 16)
-           |  ((sword64) (a[38]) << 24)
-           |  ((sword64) (a[39]) << 32)
-           |  ((sword64) (a[40]) << 40)
-           |  ((sword64) (a[41]) << 48);
-    ad[ 6] =  ((sword64) (a[42]) <<  0)
-           |  ((sword64) (a[43]) <<  8)
-           |  ((sword64) (a[44]) << 16)
-           |  ((sword64) (a[45]) << 24)
-           |  ((sword64) (a[46]) << 32)
-           |  ((sword64) (a[47]) << 40)
-           |  ((sword64) (a[48]) << 48);
-    ad[ 7] =  ((sword64) (a[49]) <<  0)
-           |  ((sword64) (a[50]) <<  8)
-           |  ((sword64) (a[51]) << 16)
-           |  ((sword64) (a[52]) << 24)
-           |  ((sword64) (a[53]) << 32)
-           |  ((sword64) (a[54]) << 40)
-           |  ((sword64) (a[55]) << 48);
+    ad[ 0] =  (word64)((sword64) (a[ 0]) <<  0)
+           |  (word64)((sword64) (a[ 1]) <<  8)
+           |  (word64)((sword64) (a[ 2]) << 16)
+           |  (word64)((sword64) (a[ 3]) << 24)
+           |  (word64)((sword64) (a[ 4]) << 32)
+           |  (word64)((sword64) (a[ 5]) << 40)
+           |  (word64)((sword64) (a[ 6]) << 48);
+    ad[ 1] =  (word64)((sword64) (a[ 7]) <<  0)
+           |  (word64)((sword64) (a[ 8]) <<  8)
+           |  (word64)((sword64) (a[ 9]) << 16)
+           |  (word64)((sword64) (a[10]) << 24)
+           |  (word64)((sword64) (a[11]) << 32)
+           |  (word64)((sword64) (a[12]) << 40)
+           |  (word64)((sword64) (a[13]) << 48);
+    ad[ 2] =  (word64)((sword64) (a[14]) <<  0)
+           |  (word64)((sword64) (a[15]) <<  8)
+           |  (word64)((sword64) (a[16]) << 16)
+           |  (word64)((sword64) (a[17]) << 24)
+           |  (word64)((sword64) (a[18]) << 32)
+           |  (word64)((sword64) (a[19]) << 40)
+           |  (word64)((sword64) (a[20]) << 48);
+    ad[ 3] =  (word64)((sword64) (a[21]) <<  0)
+           |  (word64)((sword64) (a[22]) <<  8)
+           |  (word64)((sword64) (a[23]) << 16)
+           |  (word64)((sword64) (a[24]) << 24)
+           |  (word64)((sword64) (a[25]) << 32)
+           |  (word64)((sword64) (a[26]) << 40)
+           |  (word64)((sword64) (a[27]) << 48);
+    ad[ 4] =  (word64)((sword64) (a[28]) <<  0)
+           |  (word64)((sword64) (a[29]) <<  8)
+           |  (word64)((sword64) (a[30]) << 16)
+           |  (word64)((sword64) (a[31]) << 24)
+           |  (word64)((sword64) (a[32]) << 32)
+           |  (word64)((sword64) (a[33]) << 40)
+           |  (word64)((sword64) (a[34]) << 48);
+    ad[ 5] =  (word64)((sword64) (a[35]) <<  0)
+           |  (word64)((sword64) (a[36]) <<  8)
+           |  (word64)((sword64) (a[37]) << 16)
+           |  (word64)((sword64) (a[38]) << 24)
+           |  (word64)((sword64) (a[39]) << 32)
+           |  (word64)((sword64) (a[40]) << 40)
+           |  (word64)((sword64) (a[41]) << 48);
+    ad[ 6] =  (word64)((sword64) (a[42]) <<  0)
+           |  (word64)((sword64) (a[43]) <<  8)
+           |  (word64)((sword64) (a[44]) << 16)
+           |  (word64)((sword64) (a[45]) << 24)
+           |  (word64)((sword64) (a[46]) << 32)
+           |  (word64)((sword64) (a[47]) << 40)
+           |  (word64)((sword64) (a[48]) << 48);
+    ad[ 7] =  (word64)((sword64) (a[49]) <<  0)
+           |  (word64)((sword64) (a[50]) <<  8)
+           |  (word64)((sword64) (a[51]) << 16)
+           |  (word64)((sword64) (a[52]) << 24)
+           |  (word64)((sword64) (a[53]) << 32)
+           |  (word64)((sword64) (a[54]) << 40)
+           |  (word64)((sword64) (a[55]) << 48);
     /* Load from bytes */
-    bd[ 0] =  ((sword64) (b[ 0]) <<  0)
-           |  ((sword64) (b[ 1]) <<  8)
-           |  ((sword64) (b[ 2]) << 16)
-           |  ((sword64) (b[ 3]) << 24)
-           |  ((sword64) (b[ 4]) << 32)
-           |  ((sword64) (b[ 5]) << 40)
-           |  ((sword64) (b[ 6]) << 48);
-    bd[ 1] =  ((sword64) (b[ 7]) <<  0)
-           |  ((sword64) (b[ 8]) <<  8)
-           |  ((sword64) (b[ 9]) << 16)
-           |  ((sword64) (b[10]) << 24)
-           |  ((sword64) (b[11]) << 32)
-           |  ((sword64) (b[12]) << 40)
-           |  ((sword64) (b[13]) << 48);
-    bd[ 2] =  ((sword64) (b[14]) <<  0)
-           |  ((sword64) (b[15]) <<  8)
-           |  ((sword64) (b[16]) << 16)
-           |  ((sword64) (b[17]) << 24)
-           |  ((sword64) (b[18]) << 32)
-           |  ((sword64) (b[19]) << 40)
-           |  ((sword64) (b[20]) << 48);
-    bd[ 3] =  ((sword64) (b[21]) <<  0)
-           |  ((sword64) (b[22]) <<  8)
-           |  ((sword64) (b[23]) << 16)
-           |  ((sword64) (b[24]) << 24)
-           |  ((sword64) (b[25]) << 32)
-           |  ((sword64) (b[26]) << 40)
-           |  ((sword64) (b[27]) << 48);
-    bd[ 4] =  ((sword64) (b[28]) <<  0)
-           |  ((sword64) (b[29]) <<  8)
-           |  ((sword64) (b[30]) << 16)
-           |  ((sword64) (b[31]) << 24)
-           |  ((sword64) (b[32]) << 32)
-           |  ((sword64) (b[33]) << 40)
-           |  ((sword64) (b[34]) << 48);
-    bd[ 5] =  ((sword64) (b[35]) <<  0)
-           |  ((sword64) (b[36]) <<  8)
-           |  ((sword64) (b[37]) << 16)
-           |  ((sword64) (b[38]) << 24)
-           |  ((sword64) (b[39]) << 32)
-           |  ((sword64) (b[40]) << 40)
-           |  ((sword64) (b[41]) << 48);
-    bd[ 6] =  ((sword64) (b[42]) <<  0)
-           |  ((sword64) (b[43]) <<  8)
-           |  ((sword64) (b[44]) << 16)
-           |  ((sword64) (b[45]) << 24)
-           |  ((sword64) (b[46]) << 32)
-           |  ((sword64) (b[47]) << 40)
-           |  ((sword64) (b[48]) << 48);
-    bd[ 7] =  ((sword64) (b[49]) <<  0)
-           |  ((sword64) (b[50]) <<  8)
-           |  ((sword64) (b[51]) << 16)
-           |  ((sword64) (b[52]) << 24)
-           |  ((sword64) (b[53]) << 32)
-           |  ((sword64) (b[54]) << 40)
-           |  ((sword64) (b[55]) << 48);
+    bd[ 0] =  (word64)((sword64) (b[ 0]) <<  0)
+           |  (word64)((sword64) (b[ 1]) <<  8)
+           |  (word64)((sword64) (b[ 2]) << 16)
+           |  (word64)((sword64) (b[ 3]) << 24)
+           |  (word64)((sword64) (b[ 4]) << 32)
+           |  (word64)((sword64) (b[ 5]) << 40)
+           |  (word64)((sword64) (b[ 6]) << 48);
+    bd[ 1] =  (word64)((sword64) (b[ 7]) <<  0)
+           |  (word64)((sword64) (b[ 8]) <<  8)
+           |  (word64)((sword64) (b[ 9]) << 16)
+           |  (word64)((sword64) (b[10]) << 24)
+           |  (word64)((sword64) (b[11]) << 32)
+           |  (word64)((sword64) (b[12]) << 40)
+           |  (word64)((sword64) (b[13]) << 48);
+    bd[ 2] =  (word64)((sword64) (b[14]) <<  0)
+           |  (word64)((sword64) (b[15]) <<  8)
+           |  (word64)((sword64) (b[16]) << 16)
+           |  (word64)((sword64) (b[17]) << 24)
+           |  (word64)((sword64) (b[18]) << 32)
+           |  (word64)((sword64) (b[19]) << 40)
+           |  (word64)((sword64) (b[20]) << 48);
+    bd[ 3] =  (word64)((sword64) (b[21]) <<  0)
+           |  (word64)((sword64) (b[22]) <<  8)
+           |  (word64)((sword64) (b[23]) << 16)
+           |  (word64)((sword64) (b[24]) << 24)
+           |  (word64)((sword64) (b[25]) << 32)
+           |  (word64)((sword64) (b[26]) << 40)
+           |  (word64)((sword64) (b[27]) << 48);
+    bd[ 4] =  (word64)((sword64) (b[28]) <<  0)
+           |  (word64)((sword64) (b[29]) <<  8)
+           |  (word64)((sword64) (b[30]) << 16)
+           |  (word64)((sword64) (b[31]) << 24)
+           |  (word64)((sword64) (b[32]) << 32)
+           |  (word64)((sword64) (b[33]) << 40)
+           |  (word64)((sword64) (b[34]) << 48);
+    bd[ 5] =  (word64)((sword64) (b[35]) <<  0)
+           |  (word64)((sword64) (b[36]) <<  8)
+           |  (word64)((sword64) (b[37]) << 16)
+           |  (word64)((sword64) (b[38]) << 24)
+           |  (word64)((sword64) (b[39]) << 32)
+           |  (word64)((sword64) (b[40]) << 40)
+           |  (word64)((sword64) (b[41]) << 48);
+    bd[ 6] =  (word64)((sword64) (b[42]) <<  0)
+           |  (word64)((sword64) (b[43]) <<  8)
+           |  (word64)((sword64) (b[44]) << 16)
+           |  (word64)((sword64) (b[45]) << 24)
+           |  (word64)((sword64) (b[46]) << 32)
+           |  (word64)((sword64) (b[47]) << 40)
+           |  (word64)((sword64) (b[48]) << 48);
+    bd[ 7] =  (word64)((sword64) (b[49]) <<  0)
+           |  (word64)((sword64) (b[50]) <<  8)
+           |  (word64)((sword64) (b[51]) << 16)
+           |  (word64)((sword64) (b[52]) << 24)
+           |  (word64)((sword64) (b[53]) << 32)
+           |  (word64)((sword64) (b[54]) << 40)
+           |  (word64)((sword64) (b[55]) << 48);
     /* Load from bytes */
-    dd[ 0] =  ((sword64) (d[ 0]) <<  0)
-           |  ((sword64) (d[ 1]) <<  8)
-           |  ((sword64) (d[ 2]) << 16)
-           |  ((sword64) (d[ 3]) << 24)
-           |  ((sword64) (d[ 4]) << 32)
-           |  ((sword64) (d[ 5]) << 40)
-           |  ((sword64) (d[ 6]) << 48);
-    dd[ 1] =  ((sword64) (d[ 7]) <<  0)
-           |  ((sword64) (d[ 8]) <<  8)
-           |  ((sword64) (d[ 9]) << 16)
-           |  ((sword64) (d[10]) << 24)
-           |  ((sword64) (d[11]) << 32)
-           |  ((sword64) (d[12]) << 40)
-           |  ((sword64) (d[13]) << 48);
-    dd[ 2] =  ((sword64) (d[14]) <<  0)
-           |  ((sword64) (d[15]) <<  8)
-           |  ((sword64) (d[16]) << 16)
-           |  ((sword64) (d[17]) << 24)
-           |  ((sword64) (d[18]) << 32)
-           |  ((sword64) (d[19]) << 40)
-           |  ((sword64) (d[20]) << 48);
-    dd[ 3] =  ((sword64) (d[21]) <<  0)
-           |  ((sword64) (d[22]) <<  8)
-           |  ((sword64) (d[23]) << 16)
-           |  ((sword64) (d[24]) << 24)
-           |  ((sword64) (d[25]) << 32)
-           |  ((sword64) (d[26]) << 40)
-           |  ((sword64) (d[27]) << 48);
-    dd[ 4] =  ((sword64) (d[28]) <<  0)
-           |  ((sword64) (d[29]) <<  8)
-           |  ((sword64) (d[30]) << 16)
-           |  ((sword64) (d[31]) << 24)
-           |  ((sword64) (d[32]) << 32)
-           |  ((sword64) (d[33]) << 40)
-           |  ((sword64) (d[34]) << 48);
-    dd[ 5] =  ((sword64) (d[35]) <<  0)
-           |  ((sword64) (d[36]) <<  8)
-           |  ((sword64) (d[37]) << 16)
-           |  ((sword64) (d[38]) << 24)
-           |  ((sword64) (d[39]) << 32)
-           |  ((sword64) (d[40]) << 40)
-           |  ((sword64) (d[41]) << 48);
-    dd[ 6] =  ((sword64) (d[42]) <<  0)
-           |  ((sword64) (d[43]) <<  8)
-           |  ((sword64) (d[44]) << 16)
-           |  ((sword64) (d[45]) << 24)
-           |  ((sword64) (d[46]) << 32)
-           |  ((sword64) (d[47]) << 40)
-           |  ((sword64) (d[48]) << 48);
-    dd[ 7] =  ((sword64) (d[49]) <<  0)
-           |  ((sword64) (d[50]) <<  8)
-           |  ((sword64) (d[51]) << 16)
-           |  ((sword64) (d[52]) << 24)
-           |  ((sword64) (d[53]) << 32)
-           |  ((sword64) (d[54]) << 40)
-           |  ((sword64) (d[55]) << 48);
+    dd[ 0] =  (word64)((sword64) (d[ 0]) <<  0)
+           |  (word64)((sword64) (d[ 1]) <<  8)
+           |  (word64)((sword64) (d[ 2]) << 16)
+           |  (word64)((sword64) (d[ 3]) << 24)
+           |  (word64)((sword64) (d[ 4]) << 32)
+           |  (word64)((sword64) (d[ 5]) << 40)
+           |  (word64)((sword64) (d[ 6]) << 48);
+    dd[ 1] =  (word64)((sword64) (d[ 7]) <<  0)
+           |  (word64)((sword64) (d[ 8]) <<  8)
+           |  (word64)((sword64) (d[ 9]) << 16)
+           |  (word64)((sword64) (d[10]) << 24)
+           |  (word64)((sword64) (d[11]) << 32)
+           |  (word64)((sword64) (d[12]) << 40)
+           |  (word64)((sword64) (d[13]) << 48);
+    dd[ 2] =  (word64)((sword64) (d[14]) <<  0)
+           |  (word64)((sword64) (d[15]) <<  8)
+           |  (word64)((sword64) (d[16]) << 16)
+           |  (word64)((sword64) (d[17]) << 24)
+           |  (word64)((sword64) (d[18]) << 32)
+           |  (word64)((sword64) (d[19]) << 40)
+           |  (word64)((sword64) (d[20]) << 48);
+    dd[ 3] =  (word64)((sword64) (d[21]) <<  0)
+           |  (word64)((sword64) (d[22]) <<  8)
+           |  (word64)((sword64) (d[23]) << 16)
+           |  (word64)((sword64) (d[24]) << 24)
+           |  (word64)((sword64) (d[25]) << 32)
+           |  (word64)((sword64) (d[26]) << 40)
+           |  (word64)((sword64) (d[27]) << 48);
+    dd[ 4] =  (word64)((sword64) (d[28]) <<  0)
+           |  (word64)((sword64) (d[29]) <<  8)
+           |  (word64)((sword64) (d[30]) << 16)
+           |  (word64)((sword64) (d[31]) << 24)
+           |  (word64)((sword64) (d[32]) << 32)
+           |  (word64)((sword64) (d[33]) << 40)
+           |  (word64)((sword64) (d[34]) << 48);
+    dd[ 5] =  (word64)((sword64) (d[35]) <<  0)
+           |  (word64)((sword64) (d[36]) <<  8)
+           |  (word64)((sword64) (d[37]) << 16)
+           |  (word64)((sword64) (d[38]) << 24)
+           |  (word64)((sword64) (d[39]) << 32)
+           |  (word64)((sword64) (d[40]) << 40)
+           |  (word64)((sword64) (d[41]) << 48);
+    dd[ 6] =  (word64)((sword64) (d[42]) <<  0)
+           |  (word64)((sword64) (d[43]) <<  8)
+           |  (word64)((sword64) (d[44]) << 16)
+           |  (word64)((sword64) (d[45]) << 24)
+           |  (word64)((sword64) (d[46]) << 32)
+           |  (word64)((sword64) (d[47]) << 40)
+           |  (word64)((sword64) (d[48]) << 48);
+    dd[ 7] =  (word64)((sword64) (d[49]) <<  0)
+           |  (word64)((sword64) (d[50]) <<  8)
+           |  (word64)((sword64) (d[51]) << 16)
+           |  (word64)((sword64) (d[52]) << 24)
+           |  (word64)((sword64) (d[53]) << 32)
+           |  (word64)((sword64) (d[54]) << 40)
+           |  (word64)((sword64) (d[55]) << 48);
 
     /* a * b + d */
-    t[ 0] = (word128)dd[ 0] + (sword128)ad[ 0] * bd[ 0];
-    t[ 1] = (word128)dd[ 1] + (sword128)ad[ 0] * bd[ 1]
-                            + (sword128)ad[ 1] * bd[ 0];
-    t[ 2] = (word128)dd[ 2] + (sword128)ad[ 0] * bd[ 2]
-                            + (sword128)ad[ 1] * bd[ 1]
-                            + (sword128)ad[ 2] * bd[ 0];
-    t[ 3] = (word128)dd[ 3] + (sword128)ad[ 0] * bd[ 3]
-                            + (sword128)ad[ 1] * bd[ 2]
-                            + (sword128)ad[ 2] * bd[ 1]
-                            + (sword128)ad[ 3] * bd[ 0];
-    t[ 4] = (word128)dd[ 4] + (sword128)ad[ 0] * bd[ 4]
+    t[ 0] = (word128)dd[ 0] + (word128)((sword128)ad[ 0] * bd[ 0]);
+    t[ 1] = (word128)dd[ 1] + (word128)((sword128)ad[ 0] * bd[ 1]
+                                      + (sword128)ad[ 1] * bd[ 0]);
+    t[ 2] = (word128)dd[ 2] + (word128)((sword128)ad[ 0] * bd[ 2]
+                                      + (sword128)ad[ 1] * bd[ 1]
+                                      + (sword128)ad[ 2] * bd[ 0]);
+    t[ 3] = (word128)dd[ 3] + (word128)((sword128)ad[ 0] * bd[ 3]
+                                      + (sword128)ad[ 1] * bd[ 2]
+                                      + (sword128)ad[ 2] * bd[ 1]
+                                      + (sword128)ad[ 3] * bd[ 0]);
+    t[ 4] = (word128)dd[ 4] + (word128)((sword128)ad[ 0] * bd[ 4]
                             + (sword128)ad[ 1] * bd[ 3]
                             + (sword128)ad[ 2] * bd[ 2]
                             + (sword128)ad[ 3] * bd[ 1]
-                            + (sword128)ad[ 4] * bd[ 0];
-    t[ 5] = (word128)dd[ 5] + (sword128)ad[ 0] * bd[ 5]
+                                        + (sword128)ad[ 4] * bd[ 0]);
+    t[ 5] = (word128)dd[ 5] + (word128)((sword128)ad[ 0] * bd[ 5]
                             + (sword128)ad[ 1] * bd[ 4]
                             + (sword128)ad[ 2] * bd[ 3]
                             + (sword128)ad[ 3] * bd[ 2]
                             + (sword128)ad[ 4] * bd[ 1]
-                            + (sword128)ad[ 5] * bd[ 0];
-    t[ 6] = (word128)dd[ 6] + (sword128)ad[ 0] * bd[ 6]
+                                        + (sword128)ad[ 5] * bd[ 0]);
+    t[ 6] = (word128)dd[ 6] + (word128)((sword128)ad[ 0] * bd[ 6]
                             + (sword128)ad[ 1] * bd[ 5]
                             + (sword128)ad[ 2] * bd[ 4]
                             + (sword128)ad[ 3] * bd[ 3]
                             + (sword128)ad[ 4] * bd[ 2]
                             + (sword128)ad[ 5] * bd[ 1]
-                            + (sword128)ad[ 6] * bd[ 0];
-    t[ 7] = (word128)dd[ 7] + (sword128)ad[ 0] * bd[ 7]
+                                        + (sword128)ad[ 6] * bd[ 0]);
+    t[ 7] = (word128)dd[ 7] + (word128)((sword128)ad[ 0] * bd[ 7]
                             + (sword128)ad[ 1] * bd[ 6]
                             + (sword128)ad[ 2] * bd[ 5]
                             + (sword128)ad[ 3] * bd[ 4]
                             + (sword128)ad[ 4] * bd[ 3]
                             + (sword128)ad[ 5] * bd[ 2]
                             + (sword128)ad[ 6] * bd[ 1]
-                            + (sword128)ad[ 7] * bd[ 0];
-    t[ 8] = (word128)          (sword128)ad[ 1] * bd[ 7]
+                                        + (sword128)ad[ 7] * bd[ 0]);
+    t[ 8] = (word128)          ((sword128)ad[ 1] * bd[ 7]
                             + (sword128)ad[ 2] * bd[ 6]
                             + (sword128)ad[ 3] * bd[ 5]
                             + (sword128)ad[ 4] * bd[ 4]
                             + (sword128)ad[ 5] * bd[ 3]
                             + (sword128)ad[ 6] * bd[ 2]
-                            + (sword128)ad[ 7] * bd[ 1];
-    t[ 9] = (word128)          (sword128)ad[ 2] * bd[ 7]
+                                + (sword128)ad[ 7] * bd[ 1]);
+    t[ 9] = (word128)          ((sword128)ad[ 2] * bd[ 7]
                             + (sword128)ad[ 3] * bd[ 6]
                             + (sword128)ad[ 4] * bd[ 5]
                             + (sword128)ad[ 5] * bd[ 4]
                             + (sword128)ad[ 6] * bd[ 3]
-                            + (sword128)ad[ 7] * bd[ 2];
-    t[10] = (word128)          (sword128)ad[ 3] * bd[ 7]
+                                + (sword128)ad[ 7] * bd[ 2]);
+    t[10] = (word128)          ((sword128)ad[ 3] * bd[ 7]
                             + (sword128)ad[ 4] * bd[ 6]
                             + (sword128)ad[ 5] * bd[ 5]
                             + (sword128)ad[ 6] * bd[ 4]
-                            + (sword128)ad[ 7] * bd[ 3];
-    t[11] = (word128)          (sword128)ad[ 4] * bd[ 7]
+                                + (sword128)ad[ 7] * bd[ 3]);
+    t[11] = (word128)          ((sword128)ad[ 4] * bd[ 7]
                             + (sword128)ad[ 5] * bd[ 6]
                             + (sword128)ad[ 6] * bd[ 5]
-                            + (sword128)ad[ 7] * bd[ 4];
-    t[12] = (word128)          (sword128)ad[ 5] * bd[ 7]
+                                + (sword128)ad[ 7] * bd[ 4]);
+    t[12] = (word128)          ((sword128)ad[ 5] * bd[ 7]
                             + (sword128)ad[ 6] * bd[ 6]
-                            + (sword128)ad[ 7] * bd[ 5];
-    t[13] = (word128)          (sword128)ad[ 6] * bd[ 7]
-                            + (sword128)ad[ 7] * bd[ 6];
+                                + (sword128)ad[ 7] * bd[ 5]);
+    t[13] = (word128)          ((sword128)ad[ 6] * bd[ 7]
+                                + (sword128)ad[ 7] * bd[ 6]);
     t[14] = (word128)          (sword128)ad[ 7] * bd[ 7];
     t[15] = 0;
 
@@ -1070,31 +1070,39 @@ void sc448_muladd(byte* r, const byte* a, const byte* b, const byte* d)
     o = rd[ 6] >> 56; rd[ 7] += o; rd[ 6] = rd[ 6] & 0xffffffffffffff;
     /* Reduce to mod order. */
     u = 0;
-    u += rd[0] - (sword64)0x078c292ab5844f3L; u >>= 56;
-    u += rd[1] - (sword64)0x0c2728dc58f5523L; u >>= 56;
-    u += rd[2] - (sword64)0x049aed63690216cL; u >>= 56;
-    u += rd[3] - (sword64)0x07cca23e9c44edbL; u >>= 56;
-    u += rd[4] - (sword64)0x0ffffffffffffffL; u >>= 56;
-    u += rd[5] - (sword64)0x0ffffffffffffffL; u >>= 56;
-    u += rd[6] - (sword64)0x0ffffffffffffffL; u >>= 56;
-    u += rd[7] - (sword64)0x03fffffffffffffL; u >>= 56;
+    u += (sword64)rd[0] - (sword64)0x078c292ab5844f3L; u >>= 56;
+    u += (sword64)rd[1] - (sword64)0x0c2728dc58f5523L; u >>= 56;
+    u += (sword64)rd[2] - (sword64)0x049aed63690216cL; u >>= 56;
+    u += (sword64)rd[3] - (sword64)0x07cca23e9c44edbL; u >>= 56;
+    u += (sword64)rd[4] - (sword64)0x0ffffffffffffffL; u >>= 56;
+    u += (sword64)rd[5] - (sword64)0x0ffffffffffffffL; u >>= 56;
+    u += (sword64)rd[6] - (sword64)0x0ffffffffffffffL; u >>= 56;
+    u += (sword64)rd[7] - (sword64)0x03fffffffffffffL; u >>= 56;
     o = (word64)0 - (u >= 0);
     u = 0;
-    u += rd[0] - ((word64)0x078c292ab5844f3L & o); rd[0] = u & 0xffffffffffffff;
+    u += (sword64)rd[0] - (sword64)((word64)0x078c292ab5844f3L & o);
+    rd[0] = u & 0xffffffffffffff;
     u >>= 56;
-    u += rd[1] - ((word64)0x0c2728dc58f5523L & o); rd[1] = u & 0xffffffffffffff;
+    u += (sword64)rd[1] - (sword64)((word64)0x0c2728dc58f5523L & o);
+    rd[1] = u & 0xffffffffffffff;
     u >>= 56;
-    u += rd[2] - ((word64)0x049aed63690216cL & o); rd[2] = u & 0xffffffffffffff;
+    u += (sword64)rd[2] - (sword64)((word64)0x049aed63690216cL & o);
+    rd[2] = u & 0xffffffffffffff;
     u >>= 56;
-    u += rd[3] - ((word64)0x07cca23e9c44edbL & o); rd[3] = u & 0xffffffffffffff;
+    u += (sword64)rd[3] - (sword64)((word64)0x07cca23e9c44edbL & o);
+    rd[3] = u & 0xffffffffffffff;
     u >>= 56;
-    u += rd[4] - ((word64)0x0ffffffffffffffL & o); rd[4] = u & 0xffffffffffffff;
+    u += (sword64)rd[4] - (sword64)((word64)0x0ffffffffffffffL & o);
+    rd[4] = u & 0xffffffffffffff;
     u >>= 56;
-    u += rd[5] - ((word64)0x0ffffffffffffffL & o); rd[5] = u & 0xffffffffffffff;
+    u += (sword64)rd[5] - (sword64)((word64)0x0ffffffffffffffL & o);
+    rd[5] = u & 0xffffffffffffff;
     u >>= 56;
-    u += rd[6] - ((word64)0x0ffffffffffffffL & o); rd[6] = u & 0xffffffffffffff;
+    u += (sword64)rd[6] - (sword64)((word64)0x0ffffffffffffffL & o);
+    rd[6] = u & 0xffffffffffffff;
     u >>= 56;
-    u += rd[7] - ((word64)0x03fffffffffffffL & o); rd[7] = u & 0xffffffffffffff;
+    u += (sword64)rd[7] - (sword64)((word64)0x03fffffffffffffL & o);
+    rd[7] = u & 0xffffffffffffff;
 
     /* Convert to bytes */
     r[ 0] = (byte)(rd[0 ] >>  0);
@@ -6257,55 +6265,55 @@ void sc448_muladd(byte* r, const byte* a, const byte* b, const byte* d)
     o = rd[14] >> 28; rd[15] += o; rd[14] = rd[14] & 0xfffffff;
     /* Reduce to mod order. */
     u = 0;
-    u += rd[0] - (sword32)0x0b5844f3L; u >>= 28;
-    u += rd[1] - (sword32)0x078c292aL; u >>= 28;
-    u += rd[2] - (sword32)0x058f5523L; u >>= 28;
-    u += rd[3] - (sword32)0x0c2728dcL; u >>= 28;
-    u += rd[4] - (sword32)0x0690216cL; u >>= 28;
-    u += rd[5] - (sword32)0x049aed63L; u >>= 28;
-    u += rd[6] - (sword32)0x09c44edbL; u >>= 28;
-    u += rd[7] - (sword32)0x07cca23eL; u >>= 28;
-    u += rd[8] - (sword32)0x0fffffffL; u >>= 28;
-    u += rd[9] - (sword32)0x0fffffffL; u >>= 28;
-    u += rd[10] - (sword32)0x0fffffffL; u >>= 28;
-    u += rd[11] - (sword32)0x0fffffffL; u >>= 28;
-    u += rd[12] - (sword32)0x0fffffffL; u >>= 28;
-    u += rd[13] - (sword32)0x0fffffffL; u >>= 28;
-    u += rd[14] - (sword32)0x0fffffffL; u >>= 28;
-    u += rd[15] - (sword32)0x03ffffffL; u >>= 28;
+    u += (sword32)(rd[0] - (sword32)0x0b5844f3L); u >>= 28;
+    u += (sword32)(rd[1] - (sword32)0x078c292aL); u >>= 28;
+    u += (sword32)(rd[2] - (sword32)0x058f5523L); u >>= 28;
+    u += (sword32)(rd[3] - (sword32)0x0c2728dcL); u >>= 28;
+    u += (sword32)(rd[4] - (sword32)0x0690216cL); u >>= 28;
+    u += (sword32)(rd[5] - (sword32)0x049aed63L); u >>= 28;
+    u += (sword32)(rd[6] - (sword32)0x09c44edbL); u >>= 28;
+    u += (sword32)(rd[7] - (sword32)0x07cca23eL); u >>= 28;
+    u += (sword32)(rd[8] - (sword32)0x0fffffffL); u >>= 28;
+    u += (sword32)(rd[9] - (sword32)0x0fffffffL); u >>= 28;
+    u += (sword32)(rd[10] - (sword32)0x0fffffffL); u >>= 28;
+    u += (sword32)(rd[11] - (sword32)0x0fffffffL); u >>= 28;
+    u += (sword32)(rd[12] - (sword32)0x0fffffffL); u >>= 28;
+    u += (sword32)(rd[13] - (sword32)0x0fffffffL); u >>= 28;
+    u += (sword32)(rd[14] - (sword32)0x0fffffffL); u >>= 28;
+    u += (sword32)(rd[15] - (sword32)0x03ffffffL); u >>= 28;
     o = (word32)0 - (u >= 0);
     u = 0;
-    u += rd[0] - ((word32)0x0b5844f3L & o); rd[0] = u & 0xfffffff;
+    u += (sword32)(rd[0] - ((word32)0x0b5844f3L & o)); rd[0] = u & 0xfffffff;
     u >>= 28;
-    u += rd[1] - ((word32)0x078c292aL & o); rd[1] = u & 0xfffffff;
+    u += (sword32)(rd[1] - ((word32)0x078c292aL & o)); rd[1] = u & 0xfffffff;
     u >>= 28;
-    u += rd[2] - ((word32)0x058f5523L & o); rd[2] = u & 0xfffffff;
+    u += (sword32)(rd[2] - ((word32)0x058f5523L & o)); rd[2] = u & 0xfffffff;
     u >>= 28;
-    u += rd[3] - ((word32)0x0c2728dcL & o); rd[3] = u & 0xfffffff;
+    u += (sword32)(rd[3] - ((word32)0x0c2728dcL & o)); rd[3] = u & 0xfffffff;
     u >>= 28;
-    u += rd[4] - ((word32)0x0690216cL & o); rd[4] = u & 0xfffffff;
+    u += (sword32)(rd[4] - ((word32)0x0690216cL & o)); rd[4] = u & 0xfffffff;
     u >>= 28;
-    u += rd[5] - ((word32)0x049aed63L & o); rd[5] = u & 0xfffffff;
+    u += (sword32)(rd[5] - ((word32)0x049aed63L & o)); rd[5] = u & 0xfffffff;
     u >>= 28;
-    u += rd[6] - ((word32)0x09c44edbL & o); rd[6] = u & 0xfffffff;
+    u += (sword32)(rd[6] - ((word32)0x09c44edbL & o)); rd[6] = u & 0xfffffff;
     u >>= 28;
-    u += rd[7] - ((word32)0x07cca23eL & o); rd[7] = u & 0xfffffff;
+    u += (sword32)(rd[7] - ((word32)0x07cca23eL & o)); rd[7] = u & 0xfffffff;
     u >>= 28;
-    u += rd[8] - ((word32)0x0fffffffL & o); rd[8] = u & 0xfffffff;
+    u += (sword32)(rd[8] - ((word32)0x0fffffffL & o)); rd[8] = u & 0xfffffff;
     u >>= 28;
-    u += rd[9] - ((word32)0x0fffffffL & o); rd[9] = u & 0xfffffff;
+    u += (sword32)(rd[9] - ((word32)0x0fffffffL & o)); rd[9] = u & 0xfffffff;
     u >>= 28;
-    u += rd[10] - ((word32)0x0fffffffL & o); rd[10] = u & 0xfffffff;
+    u += (sword32)(rd[10] - ((word32)0x0fffffffL & o)); rd[10] = u & 0xfffffff;
     u >>= 28;
-    u += rd[11] - ((word32)0x0fffffffL & o); rd[11] = u & 0xfffffff;
+    u += (sword32)(rd[11] - ((word32)0x0fffffffL & o)); rd[11] = u & 0xfffffff;
     u >>= 28;
-    u += rd[12] - ((word32)0x0fffffffL & o); rd[12] = u & 0xfffffff;
+    u += (sword32)(rd[12] - ((word32)0x0fffffffL & o)); rd[12] = u & 0xfffffff;
     u >>= 28;
-    u += rd[13] - ((word32)0x0fffffffL & o); rd[13] = u & 0xfffffff;
+    u += (sword32)(rd[13] - ((word32)0x0fffffffL & o)); rd[13] = u & 0xfffffff;
     u >>= 28;
-    u += rd[14] - ((word32)0x0fffffffL & o); rd[14] = u & 0xfffffff;
+    u += (sword32)(rd[14] - ((word32)0x0fffffffL & o)); rd[14] = u & 0xfffffff;
     u >>= 28;
-    u += rd[15] - ((word32)0x03ffffffL & o); rd[15] = u & 0xfffffff;
+    u += (sword32)(rd[15] - ((word32)0x03ffffffL & o)); rd[15] = u & 0xfffffff;
 
     /* Convert to bytes */
     r[ 0] = (byte)(rd[0 ] >>  0);
@@ -10561,7 +10569,7 @@ void ge448_to_bytes(byte *b, const ge448_p2 *p)
     fe448_mul(x, p->X, recip);
     fe448_mul(y, p->Y, recip);
     fe448_to_bytes(b, y);
-    b[56] = (byte)fe448_isnegative(x) << 7;
+    b[56] = (byte)((byte)fe448_isnegative(x) << 7);
 }
 
 /* Convert point to byte array assuming z is 1.
@@ -10572,7 +10580,7 @@ void ge448_to_bytes(byte *b, const ge448_p2 *p)
 static void ge448_p2z1_to_bytes(byte *b, const ge448_p2 *p)
 {
     fe448_to_bytes(b, p->Y);
-    b[56] = (byte)fe448_isnegative(p->X) << 7;
+    b[56] = (byte)((byte)fe448_isnegative(p->X) << 7);
 }
 
 /* Compress the point to y-ordinate and negative bit.
@@ -10694,15 +10702,15 @@ int ge448_scalarmult_base(ge448_p2* r, const byte* a)
 
     carry = 0;
     for (i = 0; i < 56; ++i) {
-        e[2 * i + 0] = ((a[i] >> 0) & 0xf) + carry;
-        carry = e[2 * i + 0] + 8;
+        e[2 * i + 0] = (byte)(((a[i] >> 0) & 0xf) + carry);
+        carry = (byte)(e[2 * i + 0] + 8);
         carry >>= 4;
-        e[2 * i + 0] -= (byte)(carry << 4);
+        e[2 * i + 0] = (byte)(e[2 * i + 0] - (byte)(carry << 4));
 
-        e[2 * i + 1] = ((a[i] >> 4) & 0xf) + carry;
-        carry = e[2 * i + 1] + 8;
-        carry >>= 4;
-        e[2 * i + 1] -= (byte)(carry << 4);
+        e[2 * i + 1] = (byte)(((a[i] >> 4) & 0xf) + carry);
+        carry = (byte)(e[2 * i + 1] + 8);
+        carry = (byte)(carry >> 4);
+        e[2 * i + 1] = (byte)(e[2 * i + 1] - (carry << 4));
     }
     e[112] = carry;
     /* each e[i] is between -8 and 8 */
@@ -10762,11 +10770,11 @@ static void slide(sword8 *r, const byte *a)
             }
 
             if (r[i] + (r[i + b] << b) <= 31) {
-                r[i] += (sword8)(r[i + b] << b);
+                r[i] = (sword8)(r[i] + (r[i + b] << b));
                 r[i + b] = 0;
             }
             else if (r[i] - (r[i + b] << b) >= -31) {
-                r[i] -= (sword8)(r[i + b] << b);
+                r[i] = (sword8)(r[i] - (r[i + b] << b));
                 for (k = i + b; k < 448; ++k) {
                     if (!r[k]) {
                         r[k] = 1;

--- a/wolfcrypt/src/ge_operations.c
+++ b/wolfcrypt/src/ge_operations.c
@@ -9125,12 +9125,12 @@ void ge_scalarmult_base(ge_p3 *h,const unsigned char *a)
 
   carry = 0;
   for (i = 0;i < 63;++i) {
-    e[i] += carry;
-    carry = e[i] + 8;
-    carry >>= 4;
-    e[i] -= (signed char)(carry << 4);
+    e[i] = (signed char)(e[i] + carry);
+    carry = (signed char)(e[i] + 8);
+    carry = (signed char)(carry >> 4);
+    e[i] = (signed char)(e[i] - (carry << 4));
   }
-  e[63] += carry;
+  e[63] = (signed char)(e[63] + carry);
   /* each e[i] is between -8 and 8 */
 
 #ifndef CURVED25519_ASM
@@ -9190,9 +9190,10 @@ static void slide(signed char *r,const unsigned char *a)
       for (b = 1;b <= 6 && i + b < SLIDE_SIZE;++b) {
         if (r[i + b]) {
           if (r[i] + (r[i + b] << b) <= 15) {
-            r[i] += (signed char)(r[i + b] << b); r[i + b] = 0;
+              r[i] = (signed char)(r[i] + (r[i + b] << b));
+              r[i + b] = 0;
           } else if (r[i] - (r[i + b] << b) >= -15) {
-            r[i] -= (signed char)(r[i + b] << b);
+            r[i] = (signed char)(r[i] - (r[i + b] << b));
             for (k = i + b;k < SLIDE_SIZE;++k) {
               if (!r[k]) {
                 r[k] = 1;

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -942,11 +942,11 @@ static void wc_srtp_kdf_first_block(const byte* salt, word32 saltSz, int kdrIdx,
         }
         else {
             /* XOR in as bit shifted index. */
-            block[WC_SRTP_MAX_SALT - indexSz] ^= index[0] >> bits;
+            block[WC_SRTP_MAX_SALT - indexSz] ^= (byte)(index[0] >> bits);
             for (i = 1; i < indexSz; i++) {
                 block[i + WC_SRTP_MAX_SALT - indexSz] ^=
-                    (index[i-1] << (8 - bits)) |
-                    (index[i+0] >>      bits );
+                    (byte)((index[i-1] << (8 - bits)) |
+                           (index[i+0] >>      bits ));
             }
         }
     }

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -118,14 +118,14 @@ masking and clearing memory logic.
 /* This routine performs a left circular arithmetic shift of <x> by <y> value */
 WC_MISC_STATIC WC_INLINE word16 rotlFixed16(word16 x, word16 y)
 {
-    return (x << y) | (x >> (sizeof(x) * 8 - y));
+    return (word16)((x << y) | (x >> (sizeof(x) * 8U - y)));
 }
 
 
 /* This routine performs a right circular arithmetic shift of <x> by <y> value */
 WC_MISC_STATIC WC_INLINE word16 rotrFixed16(word16 x, word16 y)
 {
-    return (x >> y) | (x << (sizeof(x) * 8 - y));
+    return (word16)((x >> y) | (x << (sizeof(x) * 8U - y)));
 }
 
 /* This routine performs a byte swap of 32-bit word value. */
@@ -196,7 +196,7 @@ WC_MISC_STATIC WC_INLINE void ByteReverseWords(word32* out, const word32* in,
 
         byteCount &= ~0x3U;
 
-        for (i = 0; i < byteCount; i += sizeof(word32)) {
+        for (i = 0; i < byteCount; i += (word32)sizeof(word32)) {
             XMEMCPY(&scratch, in_bytes + i, sizeof(scratch));
             scratch = ByteReverseWord32(scratch);
             XMEMCPY(out_bytes + i, &scratch, sizeof(scratch));
@@ -619,11 +619,11 @@ WC_MISC_STATIC WC_INLINE signed char HexCharToByte(char ch)
 {
     signed char ret = (signed char)ch;
     if (ret >= '0' && ret <= '9')
-        ret -= '0';
+        ret = (signed char)(ret - '0');
     else if (ret >= 'A' && ret <= 'F')
-        ret -= 'A' - 10;
+        ret = (signed char)(ret - ('A' - 10));
     else if (ret >= 'a' && ret <= 'f')
-        ret -= 'a' - 10;
+        ret = (signed char)(ret - ('a' - 10));
     else
         ret = -1; /* error case - return code must be signed */
     return ret;

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -978,7 +978,7 @@ int wc_i2d_PKCS12(WC_PKCS12* pkcs12, byte** der, int* derSz)
 
         totalSz += 4; /* Element */
 
-        totalSz += 2 + sizeof(WC_PKCS12_DATA_OID);
+        totalSz += 2U + (word32)sizeof(WC_PKCS12_DATA_OID);
 
         totalSz += 4; /* Seq */
 
@@ -1037,7 +1037,7 @@ int wc_i2d_PKCS12(WC_PKCS12* pkcs12, byte** der, int* derSz)
         /* OID */
         idx += (word32)SetObjectId(sizeof(WC_PKCS12_DATA_OID), &buf[idx]);
         XMEMCPY(&buf[idx], WC_PKCS12_DATA_OID, sizeof(WC_PKCS12_DATA_OID));
-        idx += sizeof(WC_PKCS12_DATA_OID);
+        idx += (word32)sizeof(WC_PKCS12_DATA_OID);
 
         /* Element */
         buf[idx++] = ASN_CONSTRUCTED | ASN_CONTEXT_SPECIFIC;
@@ -2080,12 +2080,12 @@ static int wc_PKCS12_encrypt_content(WC_PKCS12* pkcs12, WC_RNG* rng,
 
         /* calculate size */
         totalSz  = (word32)SetObjectId(sizeof(WC_PKCS12_ENCRYPTED_OID), seq);
-        totalSz += sizeof(WC_PKCS12_ENCRYPTED_OID);
+        totalSz += (word32)sizeof(WC_PKCS12_ENCRYPTED_OID);
         totalSz += ASN_TAG_SZ;
 
         length  = (word32)SetMyVersion(0, seq, 0);
         tmpSz   = (word32)SetObjectId(sizeof(WC_PKCS12_DATA_OID), seq);
-        tmpSz  += sizeof(WC_PKCS12_DATA_OID);
+        tmpSz  += (word32)sizeof(WC_PKCS12_DATA_OID);
         tmpSz  += encSz;
         length += SetSequence(tmpSz, seq) + tmpSz;
         outerSz = SetSequence(length, seq) + length;
@@ -2108,7 +2108,7 @@ static int wc_PKCS12_encrypt_content(WC_PKCS12* pkcs12, WC_RNG* rng,
         }
         XMEMCPY(out + idx, WC_PKCS12_ENCRYPTED_OID,
                 sizeof(WC_PKCS12_ENCRYPTED_OID));
-        idx += sizeof(WC_PKCS12_ENCRYPTED_OID);
+        idx += (word32)sizeof(WC_PKCS12_ENCRYPTED_OID);
 
         if (idx + 1 > *outSz){
             return BUFFER_E;
@@ -2149,7 +2149,7 @@ static int wc_PKCS12_encrypt_content(WC_PKCS12* pkcs12, WC_RNG* rng,
             return BUFFER_E;
         }
         XMEMCPY(out + idx, WC_PKCS12_DATA_OID, sizeof(WC_PKCS12_DATA_OID));
-        idx += sizeof(WC_PKCS12_DATA_OID);
+        idx += (word32)sizeof(WC_PKCS12_DATA_OID);
 
         /* copy over encrypted data */
         if (idx + encSz > *outSz){
@@ -2171,7 +2171,7 @@ static int wc_PKCS12_encrypt_content(WC_PKCS12* pkcs12, WC_RNG* rng,
     if (type == WC_PKCS12_DATA) {
         /* calculate size */
         totalSz = (word32)SetObjectId(sizeof(WC_PKCS12_DATA_OID), seq);
-        totalSz += sizeof(WC_PKCS12_DATA_OID);
+        totalSz += (word32)sizeof(WC_PKCS12_DATA_OID);
         totalSz += ASN_TAG_SZ;
 
         length   = SetOctetString(contentSz, seq);
@@ -2197,7 +2197,7 @@ static int wc_PKCS12_encrypt_content(WC_PKCS12* pkcs12, WC_RNG* rng,
             return BUFFER_E;
         }
         XMEMCPY(out + idx, WC_PKCS12_DATA_OID, sizeof(WC_PKCS12_DATA_OID));
-        idx += sizeof(WC_PKCS12_DATA_OID);
+        idx += (word32)sizeof(WC_PKCS12_DATA_OID);
 
         if (idx + 1 > *outSz){
             return BUFFER_E;

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -7127,7 +7127,7 @@ static int wc_PKCS7_KariGenerateSharedInfo(WC_PKCS7_KARI* kari, int keyWrapOID)
 
     /* suppPubInfo */
     suppPubInfoSeqSz = (int)SetImplicit(ASN_SEQUENCE, 2,
-                                        (word32)kekOctetSz + sizeof(word32),
+                                        (word32)kekOctetSz + (word32)sizeof(word32),
                                         suppPubInfoSeq, 0);
     sharedInfoSz += suppPubInfoSeqSz;
 
@@ -8911,9 +8911,9 @@ static int wc_PKCS7_PwriKek_KeyWrap(wc_PKCS7* pkcs7, const byte* kek, word32 kek
         return BUFFER_E;
 
     out[0] = (byte)cekSz;
-    out[1] = ~cek[0];
-    out[2] = ~cek[1];
-    out[3] = ~cek[2];
+    out[1] = (byte)~cek[0];
+    out[2] = (byte)~cek[1];
+    out[3] = (byte)~cek[2];
     XMEMCPY(out + 4, cek, cekSz);
 
     /* random padding of size padSz */

--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -826,7 +826,7 @@ int wc_scrypt(byte* output, const byte* passwd, int passLen,
         goto end;
     }
     /* Temporary for scryptROMix. */
-    v = (byte*)XMALLOC((size_t)((1 << cost) * bSz), NULL,
+    v = (byte*)XMALLOC((size_t)((1U << cost) * bSz), NULL,
                        DYNAMIC_TYPE_TMP_BUFFER);
     if (v == NULL) {
         ret = MEMORY_E;
@@ -848,7 +848,7 @@ int wc_scrypt(byte* output, const byte* passwd, int passLen,
 
     /* Step 2. */
     for (i = 0; i < parallel; i++)
-        scryptROMix(blocks + i * (int)bSz, v, y, (int)blockSize, 1 << cost);
+        scryptROMix(blocks + i * (int)bSz, v, y, (int)blockSize, 1U << cost);
 
     /* Step 3. */
     ret = wc_PBKDF2(output, passwd, passLen, blocks, (int)blocksSz, 1, dkLen,

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -598,14 +598,14 @@ static WC_INLINE void array_add(byte* d, word32 dLen, const byte* s, word32 sLen
 
         dIdx = (int)dLen - 1;
         for (sIdx = (int)sLen - 1; sIdx >= 0; sIdx--) {
-            carry += (word16)((word16)d[dIdx] + (word16)s[sIdx]);
+            carry = (word16)(carry + d[dIdx] + s[sIdx]);
             d[dIdx] = (byte)carry;
             carry >>= 8;
             dIdx--;
         }
 
         for (; dIdx >= 0; dIdx--) {
-            carry += (word16)d[dIdx];
+            carry = (word16)(carry + d[dIdx]);
             d[dIdx] = (byte)carry;
             carry >>= 8;
         }

--- a/wolfcrypt/src/sha3.c
+++ b/wolfcrypt/src/sha3.c
@@ -550,7 +550,7 @@ void BlockSha3(word64* s)
 #ifndef SHA3_BY_SPEC
     word64 t1;
 #endif
-    byte i;
+    word32 i;
 
     for (i = 0; i < 24; i += 2)
     {
@@ -694,7 +694,7 @@ static int Sha3Update(wc_Sha3* sha3, const byte* data, word32 len, byte p)
         }
         data += i;
         len -= i;
-        sha3->i += (byte) i;
+        sha3->i = (byte)(sha3->i + i);
 
         if (sha3->i == p * 8) {
             for (i = 0; i < p; i++) {
@@ -708,12 +708,12 @@ static int Sha3Update(wc_Sha3* sha3, const byte* data, word32 len, byte p)
             sha3->i = 0;
         }
     }
-    blocks = len / (p * 8);
+    blocks = len / (p * 8U);
     #ifdef USE_INTEL_SPEEDUP
     if ((SHA3_BLOCK_N != NULL) && (blocks > 0)) {
-        (*SHA3_BLOCK_N)(sha3->s, data, blocks, p * 8);
-        len -= blocks * (p * 8);
-        data += blocks * (p * 8);
+        (*SHA3_BLOCK_N)(sha3->s, data, blocks, p * 8U);
+        len -= blocks * (p * 8U);
+        data += blocks * (p * 8U);
         blocks = 0;
     }
     #endif
@@ -726,15 +726,15 @@ static int Sha3Update(wc_Sha3* sha3, const byte* data, word32 len, byte p)
     #else
         BlockSha3(sha3->s);
     #endif
-        len -= p * 8;
-        data += p * 8;
+        len -= p * 8U;
+        data += p * 8U;
     }
 #if defined(WOLFSSL_LINUXKM) && defined(USE_INTEL_SPEEDUP)
     if (SHA3_BLOCK == sha3_block_avx2)
         RESTORE_VECTOR_REGISTERS();
 #endif
     XMEMCPY(sha3->t, data, len);
-    sha3->i += (byte)len;
+    sha3->i = (byte)(sha3->i + len);
 
     return 0;
 }
@@ -749,7 +749,7 @@ static int Sha3Update(wc_Sha3* sha3, const byte* data, word32 len, byte p)
  */
 static int Sha3Final(wc_Sha3* sha3, byte padChar, byte* hash, byte p, word32 l)
 {
-    word32 rate = p * 8;
+    word32 rate = p * 8U;
     word32 j;
     word32 i;
 
@@ -761,7 +761,7 @@ static int Sha3Final(wc_Sha3* sha3, byte padChar, byte* hash, byte p, word32 l)
     sha3->t[sha3->i ]  = padChar;
     sha3->t[rate - 1] |= 0x80;
     if (rate - 1 > (word32)sha3->i + 1) {
-        XMEMSET(sha3->t + sha3->i + 1, 0, rate - 1 - (sha3->i + 1));
+        XMEMSET(sha3->t + sha3->i + 1, 0, rate - 1U - (sha3->i + 1U));
     }
     for (i = 0; i < p; i++) {
         sha3->s[i] ^= Load64BitBigEndian(sha3->t + 8 * i);

--- a/wolfcrypt/src/siphash.c
+++ b/wolfcrypt/src/siphash.c
@@ -256,14 +256,14 @@ int wc_SipHashUpdate(SipHash* sipHash, const unsigned char* in, word32 inSz)
     if ((ret == 0) && (inSz > 0)) {
         /* Add to cache if already started. */
         if (sipHash->cacheCnt > 0) {
-            byte len = SIPHASH_BLOCK_SIZE - sipHash->cacheCnt;
+            byte len = (byte)(SIPHASH_BLOCK_SIZE - sipHash->cacheCnt);
             if (len > inSz) {
                 len = (byte)inSz;
             }
             XMEMCPY(sipHash->cache + sipHash->cacheCnt, in, len);
             in += len;
             inSz -= len;
-            sipHash->cacheCnt += len;
+            sipHash->cacheCnt = (byte)(sipHash->cacheCnt + len);
 
             if (sipHash->cacheCnt == SIPHASH_BLOCK_SIZE) {
                 /* Compress the block from the cache. */
@@ -331,7 +331,7 @@ int wc_SipHashFinal(SipHash* sipHash, unsigned char* out, unsigned char outSz)
 
     if (ret == 0) {
         /* Put in remaining cached message bytes. */
-        XMEMSET(sipHash->cache + sipHash->cacheCnt, 0, 7 - sipHash->cacheCnt);
+        XMEMSET(sipHash->cache + sipHash->cacheCnt, 0, 7U - sipHash->cacheCnt);
         sipHash->cache[7] = (byte)(sipHash->inCnt + sipHash->cacheCnt);
 
         SipHashCompress(sipHash, sipHash->cache);

--- a/wolfcrypt/src/sp_c32.c
+++ b/wolfcrypt/src/sp_c32.c
@@ -22446,7 +22446,7 @@ static void sp_256_ecc_recode_6_9(const sp_digit* k, ecc_recode_256* v)
             n >>= o;
         }
 
-        y += (word8)carry;
+        y = (word8)(y + carry);
         v[i].i = recode_index_9_6[y];
         v[i].neg = recode_neg_9_6[y];
         carry = (y >> 6) + v[i].neg;
@@ -29915,7 +29915,7 @@ static void sp_384_ecc_recode_6_15(const sp_digit* k, ecc_recode_384* v)
             n >>= o;
         }
 
-        y += (word8)carry;
+        y = (word8)(y + carry);
         v[i].i = recode_index_15_6[y];
         v[i].neg = recode_neg_15_6[y];
         carry = (y >> 6) + v[i].neg;
@@ -37434,7 +37434,7 @@ static void sp_521_ecc_recode_6_21(const sp_digit* k, ecc_recode_521* v)
             n >>= o;
         }
 
-        y += (word8)carry;
+        y = (word8)(y + carry);
         v[i].i = recode_index_21_6[y];
         v[i].neg = recode_neg_21_6[y];
         carry = (y >> 6) + v[i].neg;
@@ -46251,7 +46251,7 @@ static void sp_1024_ecc_recode_7_42(const sp_digit* k, ecc_recode_1024* v)
             n >>= o;
         }
 
-        y += (word8)carry;
+        y = (word8)(y + carry);
         v[i].i = recode_index_42_7[y];
         v[i].neg = recode_neg_42_7[y];
         carry = (y >> 7) + v[i].neg;

--- a/wolfcrypt/src/sp_c64.c
+++ b/wolfcrypt/src/sp_c64.c
@@ -23382,7 +23382,7 @@ static void sp_256_ecc_recode_6_5(const sp_digit* k, ecc_recode_256* v)
             n >>= o;
         }
 
-        y += (word8)carry;
+        y = (word8)(y + carry);
         v[i].i = recode_index_5_6[y];
         v[i].neg = recode_neg_5_6[y];
         carry = (y >> 6) + v[i].neg;
@@ -30318,7 +30318,7 @@ static void sp_384_ecc_recode_6_7(const sp_digit* k, ecc_recode_384* v)
             n >>= o;
         }
 
-        y += (word8)carry;
+        y = (word8)(y + carry);
         v[i].i = recode_index_7_6[y];
         v[i].neg = recode_neg_7_6[y];
         carry = (y >> 6) + v[i].neg;
@@ -37715,7 +37715,7 @@ static void sp_521_ecc_recode_6_9(const sp_digit* k, ecc_recode_521* v)
             n >>= o;
         }
 
-        y += (word8)carry;
+        y = (word8)(y + carry);
         v[i].i = recode_index_9_6[y];
         v[i].neg = recode_neg_9_6[y];
         carry = (y >> 6) + v[i].neg;
@@ -45594,7 +45594,7 @@ static void sp_1024_ecc_recode_7_18(const sp_digit* k, ecc_recode_1024* v)
             n >>= o;
         }
 
-        y += (word8)carry;
+        y = (word8)(y + carry);
         v[i].i = recode_index_18_7[y];
         v[i].neg = recode_neg_18_7[y];
         carry = (y >> 7) + v[i].neg;

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -1186,10 +1186,10 @@ int wc_strcasecmp(const char *s1, const char *s2)
     for (;;++s1, ++s2) {
         c1 = *s1;
         if ((c1 >= 'a') && (c1 <= 'z'))
-            c1 -= ('a' - 'A');
+            c1 = (char)(c1 - ('a' - 'A'));
         c2 = *s2;
         if ((c2 >= 'a') && (c2 <= 'z'))
-            c2 -= ('a' - 'A');
+            c2 = (char)(c2 - ('a' - 'A'));
         if ((c1 != c2) || (c1 == 0))
             break;
     }
@@ -1204,10 +1204,10 @@ int wc_strncasecmp(const char *s1, const char *s2, size_t n)
     for (c1 = 0, c2 = 0; n > 0; --n, ++s1, ++s2) {
         c1 = *s1;
         if ((c1 >= 'a') && (c1 <= 'z'))
-            c1 -= ('a' - 'A');
+            c1 = (char)(c1 - ('a' - 'A'));
         c2 = *s2;
         if ((c2 >= 'a') && (c2 <= 'z'))
-            c2 -= ('a' - 'A');
+            c2 = (char)(c2 - ('a' - 'A'));
         if ((c1 != c2) || (c1 == 0))
             break;
     }


### PR DESCRIPTION
wolfCrypt `-Wconversion` expansion: fix numerous warnings from `-Warith-conversion -Wenum-conversion -Wfloat-conversion -Wsign-conversion`.

tested with `wolfssl-multi-test.sh ... super-quick-check '.*Wconversion.*'` with
```
CONVERSION_WARNINGS=(-Wconversion -Warith-conversion -Wenum-conversion -Wfloat-conversion -Wsign-conversion)
```
and
```
FIPS_CONVERSION_WARNINGS=(-Wconversion)
```

(`CONVERSION_WARNINGS` and `FIPS_CONVERSION_WARNINGS` are enhancements not yet pushed, that substitute for ad hoc `-Wconversion` in `'.*Wconversion.*'` scenarios.)
