### PR TITLE
Fix broken verify on Ada wrapper

### DIFF
--- a/wrapper/Ada/tls_client.adb
+++ b/wrapper/Ada/tls_client.adb
@@ -219,7 +219,7 @@ package body Tls_Client with SPARK_Mode is
       --  Require mutual authentication.
       WolfSSL.Set_Verify
          (Context => Ctx,
-          Mode    => WolfSSL.Verify_Peer & WolfSSL.Verify_Fail_If_No_Peer_Cert);
+          Mode    => WolfSSL.Verify_Peer or WolfSSL.Verify_Fail_If_No_Peer_Cert);
 
       --  Load client certificate into WOLFSSL_CTX.
       Result := WolfSSL.Use_Certificate_File (Context => Ctx,

--- a/wrapper/Ada/tls_server.adb
+++ b/wrapper/Ada/tls_server.adb
@@ -200,7 +200,14 @@ package body Tls_Server with SPARK_Mode is
       --  Require mutual authentication.
       WolfSSL.Set_Verify
          (Context => Ctx,
-          Mode    => WolfSSL.Verify_Peer & WolfSSL.Verify_Fail_If_No_Peer_Cert);
+          Mode    => WolfSSL.Verify_Peer or WolfSSL.Verify_Fail_If_No_Peer_Cert);
+
+      --  Check verify is set correctly (GitHub #7461)
+      if WolfSSL.Get_Verify(Context => Ctx) /= (WolfSSL.Verify_Peer or WolfSSL.Verify_Fail_If_No_Peer_Cert) then
+          Put ("Error: Verify does not match requested");
+          New_Line;
+          return;
+      end if;
 
       --  Load server certificates into WOLFSSL_CTX.
       Result := WolfSSL.Use_Certificate_File (Context => Ctx,

--- a/wrapper/Ada/user_settings.h
+++ b/wrapper/Ada/user_settings.h
@@ -260,9 +260,9 @@ extern "C" {
 
 
 /* Openssl compatibility */
+#define OPENSSL_EXTRA
 #if 0 /* DG Disabled */
     /* Openssl compatibility API's */
-    #define OPENSSL_EXTRA
     #define OPENSSL_ALL
     #define HAVE_OPENSSL_CMD
     #define SSL_TXT_TLSV1_2

--- a/wrapper/Ada/wolfssl.adb
+++ b/wrapper/Ada/wolfssl.adb
@@ -204,12 +204,12 @@ package body WolfSSL is
    --  PSK connection. If a PSK connection is being made then the
    --  connection will go through without a peer cert.
 
-   function "&" (Left, Right : Mode_Type) return Mode_Type is
+   function "or" (Left, Right : Mode_Type) return Mode_Type is
       L : constant Unsigned_32 := Unsigned_32 (Left);
       R : constant Unsigned_32 := Unsigned_32 (Right);
    begin
-      return Mode_Type (L and R);
-   end "&";
+      return Mode_Type (L or R);
+   end "or";
 
    procedure Set_Verify (Context : Context_Type;
                          Mode    : Mode_Type) is
@@ -218,6 +218,16 @@ package body WolfSSL is
                               Mode     => int (Mode),
                               Callback => null);
    end Set_Verify;
+
+   function WolfSSL_Get_Verify(Context : Context_Type) return int with
+     Convention    => C,
+     External_Name => "wolfSSL_CTX_get_verify_mode",
+     Import        => True;
+
+   function Get_Verify (Context : Context_Type) return Mode_Type is
+   begin
+      return Mode_Type (WolfSSL_Get_Verify(Context));
+   end Get_Verify;
 
    function Use_Certificate_File (Context : Context_Type;
                                   File    : char_array;

--- a/wrapper/Ada/wolfssl.ads
+++ b/wrapper/Ada/wolfssl.ads
@@ -100,7 +100,7 @@ package WolfSSL with SPARK_Mode is
 
    type Mode_Type is private;
 
-   function "&" (Left, Right : Mode_Type) return Mode_Type;
+   function "or" (Left, Right : Mode_Type) return Mode_Type;
 
    Verify_None : constant Mode_Type;
    --  Client mode: the client will not verify the certificate received
@@ -142,6 +142,8 @@ package WolfSSL with SPARK_Mode is
                          Mode    : Mode_Type) with
       Pre => Is_Valid (Context);
    --  This function sets the verification method for remote peers
+
+   function Get_Verify (Context : Context_Type) return Mode_Type;
 
    type File_Format is private;
 


### PR DESCRIPTION
# Description

The Ada wrapper had an `&` operator for the verification mode. This effectively caused the verification mode to equal `0`.

The operator has been switched to `or` now, in addition, a getter has been added to the API. This allows for the test I've added to the server code to verify that it is being set correctly.

`OPENSSL_ALL` flag added to Ada so that the verify mode getter function is compiled in.

Fixes #7461

Thanks to @dalybrown for reporting it.

# Testing

Test added to the `tls_server_main` code, it will abort with an error if the mode is not set correctly. Also confirmed by inspecting the parameters given to `wolfSSL_CTX_set_verify()` and `wolfSSL_CTX_get_verify()` when they were called.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
