### PR TITLE
Fix issue with wc_lms_impl.c or wc_lms not including settings.h

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -2433,7 +2433,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 }
                 else if (XSTRCMP(myoptarg, "verifyInfo") == 0) {
                     printf("Verify should not override error\n");
-                    myVerifyAction = VERIFY_USE_PREVERFIY;
+                    myVerifyAction = VERIFY_USE_PREVERIFY;
                 }
                 else if (XSTRCMP(myoptarg, "useSupCurve") == 0) {
                     printf("Attempting to test use supported curve\n");
@@ -3506,7 +3506,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     #endif
     }
     if (useVerifyCb || myVerifyAction == VERIFY_FORCE_FAIL ||
-            myVerifyAction == VERIFY_USE_PREVERFIY) {
+            myVerifyAction == VERIFY_USE_PREVERIFY) {
         wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_PEER, myVerify);
     }
     else if (!usePsk && !useAnon && doPeerCheck == 0) {

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -1882,7 +1882,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                 }
                 else if (XSTRCMP(myoptarg, "verifyInfo") == 0) {
                     printf("Verify should use preverify (just show info)\n");
-                    myVerifyAction = VERIFY_USE_PREVERFIY;
+                    myVerifyAction = VERIFY_USE_PREVERIFY;
                 }
                 else if (XSTRCMP(myoptarg, "loadSSL") == 0) {
                     printf("Also load cert/key into wolfSSL object\n");

--- a/tests/api.c
+++ b/tests/api.c
@@ -9472,7 +9472,7 @@ static int test_wolfSSL_CTX_verifyDepth_ServerClient_1_ctx_ready(
     WOLFSSL_CTX* ctx)
 {
     wolfSSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, myVerify);
-    myVerifyAction = VERIFY_USE_PREVERFIY;
+    myVerifyAction = VERIFY_USE_PREVERIFY;
     wolfSSL_CTX_set_verify_depth(ctx, 2);
     return TEST_SUCCESS;
 }
@@ -9552,7 +9552,7 @@ static int test_wolfSSL_CTX_verifyDepth_ServerClient_3_ctx_ready(
     WOLFSSL_CTX* ctx)
 {
     wolfSSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, myVerify);
-    myVerifyAction = VERIFY_USE_PREVERFIY;
+    myVerifyAction = VERIFY_USE_PREVERIFY;
     wolfSSL_CTX_set_verify_depth(ctx, 0);
     return TEST_SUCCESS;
 }
@@ -95334,7 +95334,7 @@ static int test_revoked_loaded_int_cert_ctx_ready1(WOLFSSL_CTX* ctx)
 {
     EXPECT_DECLS;
     wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_PEER, myVerify);
-    myVerifyAction = VERIFY_USE_PREVERFIY;
+    myVerifyAction = VERIFY_USE_PREVERIFY;
     ExpectIntEQ(wolfSSL_CTX_load_verify_locations_ex(ctx,
             "./certs/ca-cert.pem", NULL, 0), WOLFSSL_SUCCESS);
     ExpectIntEQ(wolfSSL_CTX_load_verify_locations_ex(ctx,
@@ -95354,7 +95354,7 @@ static int test_revoked_loaded_int_cert_ctx_ready2(WOLFSSL_CTX* ctx)
 {
     EXPECT_DECLS;
     wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_PEER, myVerify);
-    myVerifyAction = VERIFY_USE_PREVERFIY;
+    myVerifyAction = VERIFY_USE_PREVERIFY;
     ExpectIntEQ(wolfSSL_CTX_load_verify_locations_ex(ctx,
             "./certs/ca-cert.pem", NULL, 0), WOLFSSL_SUCCESS);
     ExpectIntEQ(wolfSSL_CTX_load_verify_locations_ex(ctx,
@@ -95391,7 +95391,7 @@ static int test_revoked_loaded_int_cert_ctx_ready3(WOLFSSL_CTX* ctx)
 {
     EXPECT_DECLS;
     wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_PEER, myVerify);
-    myVerifyAction = VERIFY_USE_PREVERFIY;
+    myVerifyAction = VERIFY_USE_PREVERIFY;
     ExpectIntEQ(wolfSSL_CTX_load_verify_locations_ex(ctx,
             "./certs/ca-cert.pem", NULL, 0), WOLFSSL_SUCCESS);
     ExpectIntEQ(wolfSSL_CTX_load_verify_locations_ex(ctx,

--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -2761,8 +2761,8 @@ static int dilithium_vec_expand_mask(wc_Shake* shake256, byte* seed,
         word16 n = kappa + r;
 
         /* Step 4: Append to seed and squeeze out data. */
-        seed[DILITHIUM_PRIV_RAND_SEED_SZ + 0] = n;
-        seed[DILITHIUM_PRIV_RAND_SEED_SZ + 1] = n >> 8;
+        seed[DILITHIUM_PRIV_RAND_SEED_SZ + 0] = (byte)n;
+        seed[DILITHIUM_PRIV_RAND_SEED_SZ + 1] = (byte)(n >> 8);
         ret = dilithium_squeeze256(shake256, seed, DILITHIUM_Y_SEED_SZ, v,
             DILITHIUM_MAX_V_BLOCKS);
         if (ret == 0) {

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -24,6 +24,7 @@
     #include <config.h>
 #endif
 
+#include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/wc_port.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/logging.h>

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -24,6 +24,7 @@
     #include <config.h>
 #endif
 
+#include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/wc_port.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/logging.h>

--- a/wolfcrypt/src/wc_kyber_poly.c
+++ b/wolfcrypt/src/wc_kyber_poly.c
@@ -49,7 +49,7 @@
  * WOLFSSL_SMALL_STACK                                        Default: OFF
  *   Use less stack by dynamically allocating local variables.
  *
- * WOLFSSL_KYBER_NTT_UNROLL                                   Defualt: OFF
+ * WOLFSSL_KYBER_NTT_UNROLL                                   Default: OFF
  *   Enable an alternative NTT implementation that may be faster on some
  *   platforms and is smaller in code size.
  * WOLFSSL_KYBER_INVNTT_UNROLL                                Default: OFF
@@ -61,6 +61,7 @@
     #include <config.h>
 #endif
 
+#include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/wc_kyber.h>
 #include <wolfssl/wolfcrypt/cpuid.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
@@ -1133,7 +1134,7 @@ void kyber_keygen(sword16* priv, sword16* pub, sword16* e, const sword16* a,
     }
 }
 
-/* Encapsuluate message.
+/* Encapsulate message.
  *
  * @param  [in]   pub  Public key vector of polynomials.
  * @param  [out]  bp   Vector of polynomials.
@@ -1266,7 +1267,7 @@ void kyber_keygen(sword16* priv, sword16* pub, sword16* e, const sword16* a,
     }
 }
 
-/* Encapsuluate message.
+/* Encapsulate message.
  *
  * @param  [in]   pub  Public key vector of polynomials.
  * @param  [out]  bp   Vector of polynomials.
@@ -2713,7 +2714,7 @@ static void kyber_cbd_eta3(sword16* p, const byte* r)
 /* Get noise/error by calculating random bytes and sampling to a binomial
  * distribution.
  *
- * @param  [in, out]  prf   Psuedo-random function object.
+ * @param  [in, out]  prf   Pseudo-random function object.
  * @param  [out]      p     Polynomial.
  * @param  [in]       seed  Seed to use when calculating random.
  * @param  [in]       eta1  Size of noise/error integers.
@@ -2756,7 +2757,7 @@ static int kyber_get_noise_eta1_c(KYBER_PRF_T* prf, sword16* p,
 /* Get noise/error by calculating random bytes and sampling to a binomial
  * distribution. Values -2..2
  *
- * @param  [in, out]  prf   Psuedo-random function object.
+ * @param  [in, out]  prf   Pseudo-random function object.
  * @param  [out]      p     Polynomial.
  * @param  [in]       seed  Seed to use when calculating random.
  * @return  0 on success.
@@ -2835,7 +2836,7 @@ static void kyber_get_noise_x4_eta3_avx2(byte* rand, byte* seed)
 /* Get noise/error by calculating random bytes and sampling to a binomial
  * distribution. Values -2..2
  *
- * @param  [in, out]  prf   Psuedo-random function object.
+ * @param  [in, out]  prf   Pseudo-random function object.
  * @param  [out]      p     Polynomial.
  * @param  [in]       seed  Seed to use when calculating random.
  * @return  0 on success.
@@ -2858,7 +2859,7 @@ static int kyber_get_noise_eta2_avx2(KYBER_PRF_T* prf, sword16* p,
 /* Get the noise/error by calculating random bytes and sampling to a binomial
  * distribution.
  *
- * @param  [in, out]  prf   Psuedo-random function object.
+ * @param  [in, out]  prf   Pseudo-random function object.
  * @param  [out]      vec1  First Vector of polynomials.
  * @param  [out]      vec2  Second Vector of polynomials.
  * @param  [out]      poly  Polynomial.
@@ -2925,7 +2926,7 @@ static int kyber_get_noise_k3_avx2(sword16* vec1, sword16* vec2, sword16* poly,
 /* Get the noise/error by calculating random bytes and sampling to a binomial
  * distribution.
  *
- * @param  [in, out]  prf   Psuedo-random function object.
+ * @param  [in, out]  prf   Pseudo-random function object.
  * @param  [out]      vec1  First Vector of polynomials.
  * @param  [out]      vec2  Second Vector of polynomials.
  * @param  [out]      poly  Polynomial.
@@ -3163,7 +3164,7 @@ static int kyber_get_noise_k4_aarch64(sword16* vec1, sword16* vec2,
 /* Get the noise/error by calculating random bytes and sampling to a binomial
  * distribution.
  *
- * @param  [in, out]  prf   Psuedo-random function object.
+ * @param  [in, out]  prf   Pseudo-random function object.
  * @param  [in]       kp    Number of polynomials in vector.
  * @param  [out]      vec1  First Vector of polynomials.
  * @param  [in]       eta1  Size of noise/error integers with first vector.
@@ -3208,7 +3209,7 @@ static int kyber_get_noise_c(KYBER_PRF_T* prf, int kp, sword16* vec1, int eta1,
 /* Get the noise/error by calculating random bytes and sampling to a binomial
  * distribution.
  *
- * @param  [in, out]  prf   Psuedo-random function object.
+ * @param  [in, out]  prf   Pseudo-random function object.
  * @param  [in]       kp    Number of polynomials in vector.
  * @param  [out]      vec1  First Vector of polynomials.
  * @param  [out]      vec2  Second Vector of polynomials.

--- a/wolfcrypt/src/wc_lms_impl.c
+++ b/wolfcrypt/src/wc_lms_impl.c
@@ -104,7 +104,7 @@
 
 
 #ifdef WC_LMS_DEBUG_PRINT_DATA
-/* Print data when dubgging implementation.
+/* Print data when debugging implementation.
  *
  * @param [in] name  String to print before data.
  * @param [in] data  Array of bytes.
@@ -859,7 +859,7 @@ static int wc_lmots_msg_hash(LmsState* state, const byte* msg, word32 msgSz,
  *        }
  *        y[i] = tmp
  *      }
- * x[i] can be calculated on the fly using psueodo key generation in Appendix A.
+ * x[i] can be calculated on the fly using pseudo key generation in Appendix A.
  * Appendix A, The elements of the LM-OTS private keys are computed as:
  *   x_q[i] = H(I || u32str(q) || u16str(i) || u8str(0xff) || SEED).
  *
@@ -875,7 +875,7 @@ static int wc_lmots_compute_y_from_seed(LmsState* state, const byte* seed,
     const byte* msg, word32 msgSz, const byte* c, byte* y)
 {
     const LmsParams* params = state->params;
-    int ret = 0;
+    int ret;
     word16 i;
     byte q[LMS_MAX_NODE_LEN + LMS_CKSM_LEN];
 #ifdef WOLFSSL_SMALL_STACK
@@ -892,8 +892,8 @@ static int wc_lmots_compute_y_from_seed(LmsState* state, const byte* seed,
     ret = wc_lmots_msg_hash(state, msg, msgSz, c, q);
     if (ret == 0) {
         /* Calculate checksum list all coefficients. */
-        ret = wc_lmots_q_expand(q, params->hash_len, params->width, params->ls,
-             a);
+        ret = wc_lmots_q_expand(q, (word8)params->hash_len, params->width,
+            params->ls, a);
     }
 #ifndef WC_LMS_FULL_HASH
     if (ret == 0) {
@@ -1063,8 +1063,8 @@ static int wc_lmots_compute_kc_from_sig(LmsState* state, const byte* msg,
     }
     if (ret == 0) {
         /* Calculate checksum list all coefficients. */
-        ret = wc_lmots_q_expand(q, params->hash_len, params->width, params->ls,
-            a);
+        ret = wc_lmots_q_expand(q, (word8)params->hash_len, params->width,
+            params->ls, a);
     }
 #ifndef WC_LMS_FULL_HASH
     if (ret == 0) {
@@ -1178,7 +1178,7 @@ static int wc_lmots_compute_kc_from_sig(LmsState* state, const byte* msg,
  *      }
  *      K = H(I || u32str(q) || u16str(D_PBLC) || y[0] || ... || y[p-1])
  *   ...
- * x[i] can be calculated on the fly using psueodo key generation in Appendix A.
+ * x[i] can be calculated on the fly using pseudo key generation in Appendix A.
  * Appendix A, The elements of the LM-OTS private keys are computed as:
  *   x_q[i] = H(I || u32str(q) || u16str(i) || u8str(0xff) || SEED).
  *
@@ -3679,11 +3679,11 @@ int wc_hss_sigsleft(const LmsParams* params, const byte* priv_raw)
  *
  * @param [in, out] state  LMS state.
  * @param [in]      pub    HSS public key.
- * @param [in]      msg    Message to rifyn.
+ * @param [in]      msg    Message to verify.
  * @param [in]      msgSz  Length of message in bytes.
  * @param [in]      sig    Signature of message.
  * @return  0 on success.
- * @return  SIG_VERFIY_E on failure.
+ * @return  SIG_VERIFY_E on failure.
  */
 int wc_hss_verify(LmsState* state, const byte* pub, const byte* msg,
     word32 msgSz, const byte* sig)

--- a/wolfcrypt/src/wc_lms_impl.c
+++ b/wolfcrypt/src/wc_lms_impl.c
@@ -41,6 +41,7 @@
     #include <config.h>
 #endif
 
+#include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/wc_lms.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -2397,7 +2397,7 @@ static WC_INLINE void OCSPRespFreeCb(void* ioCtx, unsigned char* response)
 enum {
     VERIFY_OVERRIDE_ERROR,
     VERIFY_FORCE_FAIL,
-    VERIFY_USE_PREVERFIY,
+    VERIFY_USE_PREVERIFY,
     VERIFY_OVERRIDE_DATE_ERR,
 };
 static THREAD_LS_T int myVerifyAction = VERIFY_OVERRIDE_ERROR;

--- a/wolfssl/wolfcrypt/wc_lms.h
+++ b/wolfssl/wolfcrypt/wc_lms.h
@@ -88,6 +88,8 @@
 #ifndef WC_LMS_H
 #define WC_LMS_H
 
+#include <wolfssl/wolfcrypt/types.h>
+
 #if defined(WOLFSSL_HAVE_LMS) && defined(WOLFSSL_WC_LMS)
 
 #include <wolfssl/wolfcrypt/lms.h>

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -947,9 +947,11 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
 /* Windows API defines its own min() macro. */
 #if defined(USE_WINDOWS_API)
     #if defined(min) || defined(WOLFSSL_MYSQL_COMPATIBLE)
+        #undef  WOLFSSL_HAVE_MIN
         #define WOLFSSL_HAVE_MIN
     #endif /* min */
     #if defined(max) || defined(WOLFSSL_MYSQL_COMPATIBLE)
+        #undef  WOLFSSL_HAVE_MAX
         #define WOLFSSL_HAVE_MAX
     #endif /* max */
 #endif /* USE_WINDOWS_API */


### PR DESCRIPTION
# Description

Fixed issue with wc_lms_impl.c or wc_lms not including settings.h, which caused issue enabling LMS from user_settings.h.
Fixed some minor cast warnings and spelling errors.

Required for https://github.com/wolfSSL/wolfBoot/pull/521

```
keytools % make
../../lib/wolfssl/wolfcrypt/src/wc_lms_impl.c:233:40: error: unknown type name 'wc_Sha256'
  233 | static WC_INLINE int wc_lms_hash_block(wc_Sha256* sha256, const byte* data,
      |                                        ^
../../lib/wolfssl/wolfcrypt/src/wc_lms_impl.c:237:12: error: call to undeclared function 'wc_Sha256HashBlock'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  237 |     return wc_Sha256HashBlock(sha256, data, hash);
      |            ^
```

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
