### PR TITLE
internal.c: Fix memory leak in HashSkeData

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -29851,7 +29851,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
         ssl->buffers.digest.length = (unsigned int)digest_sz;
 
         /* buffer for hash */
-        if (!ssl->buffers.digest.buffer) {
+        if (ssl->buffers.digest.buffer) {
             if (!ssl->options.dontFreeDigest) {
                 XFREE(ssl->buffers.digest.buffer, ssl->heap,
                     DYNAMIC_TYPE_DIGEST);


### PR DESCRIPTION
The original code did never free the digest buffer.