### PR TITLE
Fix memory leak

### DIFF
--- a/wolfcrypt/src/port/aria/aria-cryptocb.c
+++ b/wolfcrypt/src/port/aria/aria-cryptocb.c
@@ -558,8 +558,10 @@ int wc_AriaDerive(ecc_key* private_key, ecc_key* public_key,
                         (ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)))
                         ret = wc_AriaFree(&(info->hash.sha256->hSession),NULL);
                 }
-                if (ret != 0)
+                if (ret != 0) {
+                    wc_AriaFree(&(info->hash.sha256->hSession),NULL);
                     ret = CRYPTOCB_UNAVAILABLE;
+                }
                 /* reset devId */
                 info->hash.sha256->devId = devIdArg;
             }
@@ -590,7 +592,10 @@ int wc_AriaDerive(ecc_key* private_key, ecc_key* public_key,
                         ret = wc_AriaFree(&(info->hash.sha384->hSession),NULL);
                     }
                 }
-                if (ret != 0) ret = CRYPTOCB_UNAVAILABLE;
+                if (ret != 0) {
+                    wc_AriaFree(&(info->hash.sha384->hSession),NULL);
+                    ret = CRYPTOCB_UNAVAILABLE;
+                }
                 /* reset devId */
                 info->hash.sha384->devId = devIdArg;
             }


### PR DESCRIPTION
# Description

On a failure resources were not being properly cleaned up when using ARIA ciphers.

Fixes zd#18920

# Testing

Used valgrind on the testsuite to make sure there are no leaks.