### PR TITLE
20241210-fixes

### DIFF
--- a/cmake/options.h.in
+++ b/cmake/options.h.in
@@ -22,7 +22,9 @@
 
 /* cmake template for options.h */
 
-#ifndef WOLFSSL_OPTIONS_H
+#ifdef WOLFSSL_NO_OPTIONS_H
+/* options.h inhibited by configuration */
+#elif !defined(WOLFSSL_OPTIONS_H)
 #define WOLFSSL_OPTIONS_H
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -10169,7 +10169,9 @@ echo " *" >> $OPTION_FILE
 echo " */" >> $OPTION_FILE
 
 echo "" >> $OPTION_FILE
-echo "#ifndef WOLFSSL_OPTIONS_H" >> $OPTION_FILE
+echo "#ifdef WOLFSSL_NO_OPTIONS_H" >> $OPTION_FILE
+echo "/* options.h inhibited by configuration */" >> $OPTION_FILE
+echo "#elif !defined(WOLFSSL_OPTIONS_H)" >> $OPTION_FILE
 echo "#define WOLFSSL_OPTIONS_H" >> $OPTION_FILE
 echo "" >> $OPTION_FILE
 echo "" >> $OPTION_FILE

--- a/linuxkm/Kbuild
+++ b/linuxkm/Kbuild
@@ -89,7 +89,7 @@ endif
 ccflags-y := $(WOLFSSL_CFLAGS) $(WOLFSSL_CFLAGS_NO_VECTOR_INSNS)
 
 $(obj)/libwolfssl.mod.o: ccflags-y :=
-$(obj)/wolfcrypt/test/test.o: ccflags-y += -DNO_MAIN_DRIVER
+$(obj)/wolfcrypt/test/test.o: ccflags-y += -DNO_MAIN_DRIVER -DWOLFSSL_NO_OPTIONS_H
 
 $(obj)/wolfcrypt/src/aes.o: ccflags-y = $(WOLFSSL_CFLAGS) $(WOLFSSL_CFLAGS_YES_VECTOR_INSNS)
 
@@ -109,7 +109,7 @@ ifeq "$(ENABLED_LINUXKM_PIE)" "yes"
     $(obj)/linuxkm/module_hooks.o: ccflags-y += $(PIE_SUPPORT_FLAGS)
 endif
 
-$(obj)/wolfcrypt/benchmark/benchmark.o: ccflags-y = $(WOLFSSL_CFLAGS) $(CFLAGS_FPU_ENABLE) $(CFLAGS_SIMD_ENABLE) $(PIE_SUPPORT_FLAGS) -DNO_MAIN_FUNCTION
+$(obj)/wolfcrypt/benchmark/benchmark.o: ccflags-y = $(WOLFSSL_CFLAGS) $(CFLAGS_FPU_ENABLE) $(CFLAGS_SIMD_ENABLE) $(PIE_SUPPORT_FLAGS) -DNO_MAIN_FUNCTION -DWOLFSSL_NO_OPTIONS_H
 $(obj)/wolfcrypt/benchmark/benchmark.o: asflags-y = $(WOLFSSL_ASFLAGS) $(ASFLAGS_FPU_ENABLE_SIMD_DISABLE)
 
 asflags-y := $(WOLFSSL_ASFLAGS) $(ASFLAGS_FPUSIMD_DISABLE)

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -61,7 +61,7 @@
     #include <config.h>
 #endif
 
-#ifndef WOLFSSL_USER_SETTINGS
+#if !defined(WOLFSSL_USER_SETTINGS) && !defined(WOLFSSL_NO_OPTIONS_H)
     #include <wolfssl/options.h>
 #endif
 #include <wolfssl/wolfcrypt/settings.h> /* also picks up user_settings.h */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -32,7 +32,7 @@
     #include <config.h>
 #endif
 
-#ifndef WOLFSSL_USER_SETTINGS
+#if !defined(WOLFSSL_USER_SETTINGS) && !defined(WOLFSSL_NO_OPTIONS_H)
     #include <wolfssl/options.h>
 #endif
 #include <wolfssl/wolfcrypt/settings.h>

--- a/wolfssl/options.h.in
+++ b/wolfssl/options.h.in
@@ -22,7 +22,9 @@
 
 /* default blank options for autoconf */
 
-#ifndef WOLFSSL_OPTIONS_H
+#ifdef WOLFSSL_NO_OPTIONS_H
+/* options.h inhibited by configuration */
+#elif !defined(WOLFSSL_OPTIONS_H)
 #define WOLFSSL_OPTIONS_H
 
 

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -47,11 +47,14 @@
     extern "C" {
 #endif
 
-/* This flag allows wolfSSL to include options.h instead of having client
- * projects do it themselves. This should *NEVER* be defined when building
- * wolfSSL as it can cause hard to debug problems. */
-#if defined(EXTERNAL_OPTS_OPENVPN) || defined(WOLFSSL_USE_OPTIONS_H)
-#include <wolfssl/options.h>
+/* WOLFSSL_USE_OPTIONS_H directs wolfSSL to include options.h on behalf of
+ * application code, rather than the application including it directly.  This is
+ * not defined when compiling wolfSSL library objects, which are configured
+ * through CFLAGS.
+ */
+#if (defined(EXTERNAL_OPTS_OPENVPN) || defined(WOLFSSL_USE_OPTIONS_H)) && \
+    !defined(WOLFSSL_NO_OPTIONS_H)
+    #include <wolfssl/options.h>
 #endif
 
 /* Uncomment next line if using IPHONE */
@@ -335,10 +338,13 @@
     #include "nucleus.h"
     #include "os/networking/ssl/lite/cyassl_nucleus_defs.h"
 #elif !defined(BUILDING_WOLFSSL) && !defined(WOLFSSL_OPTIONS_H) && \
-      !defined(WOLFSSL_CUSTOM_CONFIG)
-    /* This warning indicates that the settings header may not be included before
-     * other wolfSSL headers. If you are using a custom configuration method,
-     * define WOLFSSL_CUSTOM_CONFIG to override this error. */
+      !defined(WOLFSSL_NO_OPTIONS_H) && !defined(WOLFSSL_CUSTOM_CONFIG)
+    /* This warning indicates that wolfSSL features may not have been properly
+     * configured before other wolfSSL headers were included. If you are using
+     * an alternative configuration method -- e.g. custom header, or CFLAGS in
+     * an application build -- then your application can avoid this warning by
+     * defining WOLFSSL_NO_OPTIONS_H or WOLFSSL_CUSTOM_CONFIG as appropriate.
+     */
     #warning "No configuration for wolfSSL detected, check header order"
 #endif
 


### PR DESCRIPTION
add support for WOLFSSL_NO_OPTIONS_H:
* activate WOLFSSL_NO_OPTIONS_H in linuxkm/Kbuild for in-module test.o and benchmark.o.
* refine explanatory comments in settings.h re WOLFSSL_USE_OPTIONS_H, WOLFSSL_NO_OPTIONS_H, and WOLFSSL_CUSTOM_CONFIG.
* add safety catch to options.h/options.h.in to inhibit inclusion if defined(WOLFSSL_NO_OPTIONS_H).
* for good measure, add explicit check for WOLFSSL_NO_OPTIONS_H to wolfcrypt/benchmark/benchmark.c and wolfcrypt/test/test.c.

tested with `wolfssl-multi-test.sh ... check-source-text check-configure quantum-safe-wolfssl-all-g++-latest-debug cmake-defaults make-dist-clean-check quantum-safe-wolfssl-all-crypto-only-noasm-linuxkm-insmod quantum-safe-wolfssl-all-crypto-only-intelasm-sp-asm-linuxkm-insmod linuxkm-all-fips-140-3 linuxkm-all-fips-140-3-dev-dyn-hash linuxkm-benchmarks-insmod linuxkm-legacy-3.16 linuxkm-legacy-4.4-insmod linuxkm-mainline-intelasm-sp-asm-pie-gcc-latest-insmod`
