### PR TITLE
EdDSA Ed448: sc_muladd now does full reduction

### DIFF
--- a/wolfssl/wolfcrypt/ge_448.h
+++ b/wolfssl/wolfcrypt/ge_448.h
@@ -65,6 +65,7 @@ WOLFSSL_LOCAL int  ge448_from_bytes_negate_vartime(ge448_p2 *r, const byte *b);
 WOLFSSL_LOCAL int  ge448_double_scalarmult_vartime(ge448_p2 *r, const byte *a,
                                     const ge448_p2 *A, const byte *b);
 WOLFSSL_LOCAL int  ge448_scalarmult_base(ge448_p2* h, const byte* a);
+/* Only performs a weak reduce. */
 WOLFSSL_LOCAL void sc448_reduce(byte* b);
 WOLFSSL_LOCAL void sc448_muladd(byte* r, const byte* a, const byte* b, const byte* d);
 WOLFSSL_LOCAL void ge448_to_bytes(byte *s, const ge448_p2 *h);


### PR DESCRIPTION
# Description

sc_muladd was reducing to word boundary and not to order. Now reduces to order as last step.

Fixes zd#19061

# Testing

POC

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
