### PR TITLE
WOLFSSL_ALWAYS_KEEP_SNI enabled by default with --enable-jni

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6848,6 +6848,7 @@ then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_EX_DATA"
     AM_CFLAGS="$AM_CFLAGS -DKEEP_PEER_CERT"
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALWAYS_VERIFY_CB"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALWAYS_KEEP_SNI"
 
     # Enable prereqs if not already enabled
     if test "x$ENABLED_DTLS" = "xno"


### PR DESCRIPTION
Modifies configure.ac so --enable-jni enables WOLFSSL_ALWAYS_KEEP_SNI by default.
