### PR TITLE
Fix compile issue with NO_WOLFSSL_DIR

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -2643,7 +2643,8 @@ static int test_wolfSSL_CTX_load_system_CA_certs(void)
         ret = -1;
     }
     if (ret == 0) {
-    #if defined(USE_WINDOWS_API) || defined(__APPLE__)
+    #if defined(USE_WINDOWS_API) || defined(__APPLE__) || \
+        defined(NO_WOLFSSL_DIR)
         dirValid = 1;
     #else
         word32 numDirs;


### PR DESCRIPTION
# Description

`test_wolfSSL_CTX_load_system_CA_certs()` would try to use DIR functions when `NO_WOLFSSL_DIR` was used.

# Testing

On Linux:

```sh
export CFLAGS="-DNO_WOLFSSL_DIR"
./configure
make
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
