### PR TITLE
20241216-linuxkm-export-ns-quotes

### DIFF
--- a/linuxkm/Kbuild
+++ b/linuxkm/Kbuild
@@ -137,16 +137,16 @@ $(obj)/wolfcrypt/src/poly1305_asm.o: asflags-y = $(WOLFSSL_ASFLAGS) $(ASFLAGS_FP
 $(obj)/wolfcrypt/src/poly1305_asm.o: OBJECT_FILES_NON_STANDARD := y
 $(obj)/wolfcrypt/src/wc_kyber_asm.o: asflags-y = $(WOLFSSL_ASFLAGS) $(ASFLAGS_FPU_DISABLE_SIMD_ENABLE)
 
+ifndef READELF
+    READELF := readelf
+endif
+
 ifeq "$(ENABLED_LINUXKM_PIE)" "yes"
 
 rename-pie-text-and-data-sections: $(WOLFSSL_OBJ_TARGETS)
 
 ifndef NM
     NM := nm
-endif
-
-ifndef READELF
-    READELF := readelf
 endif
 
 ifndef OBJCOPY
@@ -197,9 +197,9 @@ $(obj)/linuxkm/module_exports.c: $(src)/module_exports.c.template $(WOLFSSL_OBJ_
 		$(AWK) '/^ *[0-9]+: / {							\
 		  if ($$8 !~ /^(wc_|wolf|WOLF|TLSX_)/){next;}				\
 		  if (($$4 == "FUNC") && ($$5 == "GLOBAL") && ($$6 == "DEFAULT")) {	\
-		    print "EXPORT_SYMBOL_NS_GPL(" $$8 ", WOLFSSL);";    		\
+		    print "EXPORT_SYMBOL_NS_GPL(" $$8 ", EXPORT_SYMBOL_NS_Q(WOLFSSL));";\
 		  }									\
 		}' >> $@
-	@echo -e '#ifndef NO_CRYPT_TEST\nEXPORT_SYMBOL_NS_GPL(wolfcrypt_test, WOLFSSL);\n#endif' >> $@
+	@echo -e '#ifndef NO_CRYPT_TEST\nEXPORT_SYMBOL_NS_GPL(wolfcrypt_test, EXPORT_SYMBOL_NS_Q(WOLFSSL));\n#endif' >> $@
 
 clean-files := linuxkm src wolfcrypt

--- a/linuxkm/module_exports.c.template
+++ b/linuxkm/module_exports.c.template
@@ -47,6 +47,12 @@
 #define EXPORT_SYMBOL_NS_GPL(sym, ns) EXPORT_SYMBOL_GPL(sym)
 #endif
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
+#define EXPORT_SYMBOL_NS_Q(x) #x
+#else
+#define EXPORT_SYMBOL_NS_Q(x) x
+#endif
+
 #include <wolfssl/wolfcrypt/memory.h>
 #include <wolfssl/wolfcrypt/wc_port.h>
 #include <wolfssl/wolfcrypt/logging.h>


### PR DESCRIPTION
`linuxkm/Kbuild` and `linuxkm/module_exports.c.template`: on kernel >=6.13, add quotes around the namespace arg to `EXPORT_SYMBOL_NS_GPL()` (upstream change actually made in 6.13-rc2).

tested with `wolfssl-multi-test.sh ... check-source-text linuxkm linuxkm-all-aesni-insmod linuxkm-all-cryptonly-intelasm-LKCAPI-insmod-mainline-fallback-fuzzing linuxkm-legacy-3.16 linuxkm-legacy-4.4-insmod`
