### PR TITLE
Printing the rfc822Mailbox x509 attribute

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -13726,6 +13726,10 @@ static int get_dn_attr_by_nid(int n, const char** buf)
             str = "title";
             len = 5;
             break;
+        case WC_NID_rfc822Mailbox:
+            str = "mail";
+            len = 4;
+            break;
         default:
             WOLFSSL_MSG("Attribute type not found");
             str = NULL;


### PR DESCRIPTION
# Description

Providing the appropriate string in `get_dn_attr_by_nid()` for the `WC_NID_rfc822Mailbox` nid

Fixes zd#18920

# Testing

Tested using customer's cert using wolfclu `wolfssl x509 -in test.pem -inform PEM `

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
