### PR TITLE
20241219-gating-fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -949,7 +949,6 @@ then
     test "$enable_ocsp" = "" && enable_ocsp=no
     test "$enable_tlsx" = "" && enable_tlsx=no
     test "$enable_sni" = "" && enable_sni=no
-    test "$enable_sni" = "" && enable_sni=no
     test "$enable_crl_monitor" = "" && enable_crl_monitor=no
     test "$enable_alpn" = "" && enable_alpn=no
     test "$enable_pkcallbacks" = "" && enable_pkcallbacks=no
@@ -5518,7 +5517,7 @@ AS_CASE([$FIPS_VERSION],
         # for armasm on arm-v7 or earlier (see armasm setup above).
         AS_IF([test "$ENABLED_AESGCM_STREAM" != "yes" &&
                (test "$FIPS_VERSION" != "dev" || test "$enable_aesgcm_stream" != "no") &&
-               (test "$ENABLED_ARMASM" = "no" || test "$ENABLED_ARMASM_CRYPTO" = "no")],
+               ! (test "$ENABLED_ARMASM" = "yes" && test "$ENABLED_ARMASM_CRYPTO" = "no")],
             [ENABLED_AESGCM_STREAM="yes"])
 
         AS_IF([test "x$ENABLED_AESOFB" = "xno" &&
@@ -5537,7 +5536,7 @@ AS_CASE([$FIPS_VERSION],
 
         AS_IF([test "x$ENABLED_AESXTS_STREAM" = "xno" &&
                (test "$FIPS_VERSION" != "dev" || test "$enable_aesxts_stream" != "no") &&
-               (test "$ENABLED_ARMASM" = "no" || test "$ENABLED_ARMASM_CRYPTO" = "no")],
+               ! (test "$ENABLED_ARMASM" = "yes" && test "$ENABLED_ARMASM_CRYPTO" = "no")],
             [ENABLED_AESXTS_STREAM="yes"])
 
         AS_IF([(test "$ENABLED_AESCCM" = "yes" && test "$HAVE_AESCCM_PORT" != "yes") ||

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -21480,7 +21480,8 @@ unsigned long wolfSSL_ERR_peek_error_line_data(const char **file, int *line,
 }
 #endif
 
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL) || \
+    defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
 
 #if !defined(WOLFSSL_USER_IO)
 /* converts an IPv6 or IPv4 address into an octet string for use with rfc3280
@@ -21648,7 +21649,7 @@ WOLF_STACK_OF(WOLFSSL_CIPHER) *wolfSSL_get_ciphers_compat(const WOLFSSL *ssl)
     }
     return ssl->suitesStack;
 }
-#endif /* OPENSSL_ALL || WOLFSSL_NGINX || WOLFSSL_HAPROXY */
+#endif /* OPENSSL_EXTRA || OPENSSL_ALL || WOLFSSL_NGINX || WOLFSSL_HAPROXY */
 
 #if defined(OPENSSL_EXTRA) || defined(HAVE_SECRET_CALLBACK)
 long wolfSSL_SSL_CTX_get_timeout(const WOLFSSL_CTX *ctx)

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -5765,7 +5765,8 @@ struct WOLFSSL {
 #ifdef OPENSSL_EXTRA
     const Suites*   clSuites;
 #endif
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL) || \
+    defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
     WOLF_STACK_OF(WOLFSSL_CIPHER)* suitesStack; /* stack of available cipher
                                                  * suites */
 #endif


### PR DESCRIPTION
`src/ssl.c` and `wolfssl/internal.h`: gate in `wolfSSL_get_ciphers_compat()` in `OPENSSL_EXTRA` builds, so that `--with-sys-crypto-policy` works with `OPENSSL_EXTRA` but without `OPENSSL_ALL`.

`configure.ac`: more fixes for FIPS v6 armasm settings, re `ENABLED_ARMASM_CRYPTO`.

tested with `wolfssl-multi-test.sh ... super-quick-check cross-aarch64-armasm-fips-140-3-dev-all-unittest-sanitizer cross-armv7a-armasm-fips-140-3-ready-sp-all-testsuite-sanitizer all-crypto-openssl-extra-coexist-TEST_OPENSSL_COEXIST all-crypto-openssl-extra-coexist-smallstack-TEST_OPENSSL_COEXIST all-crypto-openssl-extra-coexist-TEST_OPENSSL_COEXIST-fips-dev`
