### PR TITLE
Regression testing: fixes

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -12667,15 +12667,9 @@ err:
     static void wolfssl_x509_name_entry_set(WOLFSSL_X509_NAME_ENTRY* ne,
         int nid, int type, const unsigned char *data, int dataSz)
     {
-        WOLFSSL_ASN1_OBJECT* object;
-
         ne->nid = nid;
         /* Reuse the object if already available. */
-        object = wolfSSL_OBJ_nid2obj_ex(nid, ne->object);
-        if (object != NULL) {
-            /* Set the object when no error. */
-            ne->object = object;
-        }
+        ne->object = wolfSSL_OBJ_nid2obj_ex(nid, ne->object);
         if (ne->value == NULL) {
             ne->value = wolfSSL_ASN1_STRING_type_new(type);
         }

--- a/tests/api.c
+++ b/tests/api.c
@@ -72825,6 +72825,9 @@ static int test_wolfSSL_GENERAL_NAME_print(void)
         wolfSSL_ASN1_STRING_free(gn->d.ia5);
         gn->d.registeredID = ridObj;
     }
+    else {
+        wolfSSL_ASN1_OBJECT_free(ridObj);
+    }
     ExpectIntEQ(GENERAL_NAME_print(out, gn), 1);
     XMEMSET(outbuf,0,sizeof(outbuf));
     ExpectIntGT(BIO_read(out, outbuf, sizeof(outbuf)), 0);
@@ -100778,7 +100781,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_X509_STORE_CTX),
     TEST_DECL(test_wolfSSL_X509_STORE_CTX_ex),
     TEST_DECL(test_X509_STORE_untrusted),
-#if defined(OPENSSL_ALL)
+#if defined(OPENSSL_ALL) && !defined(NO_RSA)
     TEST_DECL(test_X509_STORE_InvalidCa),
 #endif
     TEST_DECL(test_wolfSSL_X509_STORE_CTX_trusted_stack_cleanup),

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -12861,7 +12861,7 @@ static wc_test_ret_t aes_cbc_oneshot_test(void)
 }
 #endif
 
-#if defined(WOLFSSL_AES_COUNTER) && defined(HAVE_AES_DECRYPT)
+#if defined(WOLFSSL_AES_COUNTER)
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t aes_ctr_test(void)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)


### PR DESCRIPTION
# Description


src/x509.c: wolfssl_x509_name_entry_set() ne->object is freed if call to wolfSSL_OBJ_nid2obj_ex() fails. Always assign directly back to ne->object.

wolfcrypt/test/test.c: aes_ctr_test() doesn't need AES decrypt ./configure '--disable-shared' '--enable-cryptonly' 'CFLAGS=-DNO_AES_DECRYPT' '--disable-aescbc' '--disable-aesofb' '--disable-aescfb' '--disable-aesgcm' '--disable-aesccm' '--enable-aesctr' '--disable-aesxts' '--disable-aeseax'

tests/api.c: test_X509_STORE_InvalidCa() only defined when !NO_RSA ./configure '--disable-shared' '--enable-opensslall' '--disable-rsa'

tests/api.c: test_wolfSSL_GENERAL_NAME_print() free ridObj if not assigned into gn.

# Testing

See above and memory failure testing.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
