### PR TITLE
Remove dead code in TLSX_PopulateExtensions() around MAX_PSK_ID_LEN check

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -13781,11 +13781,6 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
                 word64 now, milli;
             #endif
 
-                if (isServer && (sess->ticketLen > MAX_PSK_ID_LEN)) {
-                    WOLFSSL_MSG("Session ticket length for PSK ext is too large");
-                    return BUFFER_ERROR;
-                }
-
                 /* Determine the MAC algorithm for the cipher suite used. */
                 ssl->options.cipherSuite0 = sess->cipherSuite0;
                 ssl->options.cipherSuite  = sess->cipherSuite;


### PR DESCRIPTION
# Description

Fixes dead code recently introduced with https://github.com/wolfSSL/wolfssl/pull/8302. Caught by Coverity scan:

```
>>>     CID 445084:  Control flow issues  (DEADCODE)
>>>     Execution cannot reach the expression "sess->ticketLen > 1536" inside this statement: "if (isServer && sess->ticke...".
13784                     if (isServer && (sess->ticketLen > MAX_PSK_ID_LEN)) {
13785                         WOLFSSL_MSG("Session ticket length for PSK ext is too large");
13786                         return BUFFER_ERROR;
13787                     }
```

The given code block is inside the following condition, which means this will never be called on the server-side (isServer=true):

```
if (!isServer && IsAtLeastTLSv1_3(ssl->version)) {
...
}
```

# Testing

Caught by Coverity scan. See PR #8302 for testing notes.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
