### PR TITLE
20241221-fix-CEscape-bounds-check

### DIFF
--- a/wolfcrypt/src/coding.c
+++ b/wolfcrypt/src/coding.c
@@ -297,7 +297,7 @@ static int CEscape(int escaped, byte e, byte* out, word32* i, word32 maxSz,
 
     if (raw)
         basic = e;
-    else if (e <= sizeof(base64Encode))
+    else if (e < sizeof(base64Encode))
         basic = base64Encode[e];
     else
         return BAD_FUNC_ARG;


### PR DESCRIPTION
`wolfcrypt/src/coding.c`: fix incorrect array bounds check in `CEscape()`, introduced in 8bbe8a7c8a (before which there was no bounds check at all).

