### PR TITLE
20241221-wolfCrypt-more-AES_BLOCK_SIZE

### DIFF
--- a/IDE/QNX/example-cmac/cmac-test.c
+++ b/IDE/QNX/example-cmac/cmac-test.c
@@ -41,13 +41,13 @@ static int createTag(const byte* key, int keySz, byte* msg, int msgSz,
         byte* msg2, int msg2Sz)
 {
     Cmac cmac;
-    byte tag[AES_BLOCK_SIZE];
+    byte tag[WC_AES_BLOCK_SIZE];
     word32 i, tagSz;
     byte out[48];
     word32 outSz;
 
     XMEMSET(tag, 0, sizeof(tag));
-    tagSz = AES_BLOCK_SIZE;
+    tagSz = WC_AES_BLOCK_SIZE;
 
     outSz = 48;
     wc_caamCoverKey((byte*)key, keySz, out, &outSz, 0);

--- a/IDE/Renesas/e2studio/RA6M4/test/src/wolfssl_sce_unit_test.c
+++ b/IDE/Renesas/e2studio/RA6M4/test/src/wolfssl_sce_unit_test.c
@@ -107,8 +107,8 @@ static int sce_aes_cbc_test(int prnt, FSPSM_AES_PWKEY aes_key)
 
     Aes  aes[1];
 
-    byte cipher[AES_BLOCK_SIZE];
-    byte plain[AES_BLOCK_SIZE];
+    byte cipher[WC_AES_BLOCK_SIZE];
+    byte plain[WC_AES_BLOCK_SIZE];
     int  ret = 0;
 
     WOLFSSL_SMALL_STACK_STATIC const byte msg[] = {
@@ -119,8 +119,8 @@ static int sce_aes_cbc_test(int prnt, FSPSM_AES_PWKEY aes_key)
     };
     byte iv[]  = "1234567890abcdef   ";  /* align */
 
-    XMEMSET(cipher, 0, AES_BLOCK_SIZE);
-    XMEMSET(plain, 0, AES_BLOCK_SIZE);
+    XMEMSET(cipher, 0, WC_AES_BLOCK_SIZE);
+    XMEMSET(plain, 0, WC_AES_BLOCK_SIZE);
 
     if (prnt) {
         printf(" sce_aes_cbc_test() ");
@@ -129,9 +129,9 @@ static int sce_aes_cbc_test(int prnt, FSPSM_AES_PWKEY aes_key)
     ret = wc_AesInit(aes, NULL, devId);
     if (ret == 0) {
         ret = wc_AesSetKey(aes, (byte*)aes_key,
-        		AES_BLOCK_SIZE, iv, AES_ENCRYPTION);
+        		WC_AES_BLOCK_SIZE, iv, AES_ENCRYPTION);
         if (ret == 0) {
-            ret = wc_AesCbcEncrypt(aes, cipher, msg, AES_BLOCK_SIZE);
+            ret = wc_AesCbcEncrypt(aes, cipher, msg, WC_AES_BLOCK_SIZE);
         }
 
         wc_AesFree(aes);
@@ -144,15 +144,15 @@ static int sce_aes_cbc_test(int prnt, FSPSM_AES_PWKEY aes_key)
     ret = wc_AesInit(aes, NULL, devId);
     if (ret == 0) {
         ret = wc_AesSetKey(aes, (byte*)aes_key,
-        		AES_BLOCK_SIZE, iv, AES_ENCRYPTION);
+        		WC_AES_BLOCK_SIZE, iv, AES_ENCRYPTION);
         if (ret == 0)
-            ret = wc_AesCbcDecrypt(aes, plain, cipher, AES_BLOCK_SIZE);
+            ret = wc_AesCbcDecrypt(aes, plain, cipher, WC_AES_BLOCK_SIZE);
 
         wc_AesFree(aes);
     }
     if (ret != 0)
         ret = -2;
-    if (XMEMCMP(plain, msg, AES_BLOCK_SIZE) != 0)
+    if (XMEMCMP(plain, msg, WC_AES_BLOCK_SIZE) != 0)
         ret = -3;
 #endif /* HAVE_AES_DECRYPT */
 
@@ -189,8 +189,8 @@ static void tskAes128_Cbc_Test(void *pvParam)
 static int sce_aes256_test(int prnt, FSPSM_AES_PWKEY aes_key)
 {
     Aes enc[1];
-    byte cipher[AES_BLOCK_SIZE];
-    byte plain[AES_BLOCK_SIZE];
+    byte cipher[WC_AES_BLOCK_SIZE];
+    byte plain[WC_AES_BLOCK_SIZE];
     Aes dec[1];
     int  ret = 0;
 
@@ -219,20 +219,20 @@ static int sce_aes256_test(int prnt, FSPSM_AES_PWKEY aes_key)
     }
 
     ret = wc_AesSetKey(enc, (byte*)aes_key,
-    		AES_BLOCK_SIZE*2, iv, AES_ENCRYPTION);
+    		WC_AES_BLOCK_SIZE*2, iv, AES_ENCRYPTION);
     if (ret != 0){
         ret = -3;
         goto out;
     }
 
     ret = wc_AesSetKey(dec, (byte*)aes_key,
-    		AES_BLOCK_SIZE*2, iv, AES_DECRYPTION);
+    		WC_AES_BLOCK_SIZE*2, iv, AES_DECRYPTION);
     if (ret != 0) {
         ret = -4;
         goto out;
     }
 
-    XMEMSET(cipher, 0, AES_BLOCK_SIZE);
+    XMEMSET(cipher, 0, WC_AES_BLOCK_SIZE);
     ret = wc_AesCbcEncrypt(enc, cipher, msg, (int) sizeof(msg));
 
     if (ret != 0) {
@@ -240,7 +240,7 @@ static int sce_aes256_test(int prnt, FSPSM_AES_PWKEY aes_key)
         goto out;
     }
 
-    XMEMSET(plain, 0, AES_BLOCK_SIZE);
+    XMEMSET(plain, 0, WC_AES_BLOCK_SIZE);
     ret = wc_AesCbcDecrypt(dec, plain, cipher, (int) sizeof(cipher));
 
     if (ret != 0){
@@ -340,8 +340,8 @@ static int sce_aesgcm256_test(int prnt, FSPSM_AES_PWKEY aes256_key)
     };
 
     byte resultT[sizeof(t1)];
-    byte resultP[sizeof(p) + AES_BLOCK_SIZE];
-    byte resultC[sizeof(p) + AES_BLOCK_SIZE];
+    byte resultP[sizeof(p) + WC_AES_BLOCK_SIZE];
+    byte resultC[sizeof(p) + WC_AES_BLOCK_SIZE];
     int  result = 0;
     int  ret;
 
@@ -366,7 +366,7 @@ static int sce_aesgcm256_test(int prnt, FSPSM_AES_PWKEY aes256_key)
     }
 
     result = wc_AesGcmSetKey(enc,
-        (byte*)aes256_key, AES_BLOCK_SIZE*2);
+        (byte*)aes256_key, WC_AES_BLOCK_SIZE*2);
     if (result != 0) {
         ret = -3;
         goto out;
@@ -383,7 +383,7 @@ static int sce_aesgcm256_test(int prnt, FSPSM_AES_PWKEY aes256_key)
     }
 
     result = wc_AesGcmSetKey(dec,
-            (byte*)aes256_key, AES_BLOCK_SIZE*2);
+            (byte*)aes256_key, WC_AES_BLOCK_SIZE*2);
     if (result != 0) {
         ret = -7;
         goto out;
@@ -408,7 +408,7 @@ static int sce_aesgcm256_test(int prnt, FSPSM_AES_PWKEY aes256_key)
     XMEMSET(resultP, 0, sizeof(resultP));
 
     wc_AesGcmSetKey(enc,
-        (byte*)aes256_key, AES_BLOCK_SIZE*2);
+        (byte*)aes256_key, WC_AES_BLOCK_SIZE*2);
     /* AES-GCM encrypt and decrypt both use AES encrypt internally */
     result = wc_AesGcmEncrypt(enc, resultC, p, sizeof(p),
                                 (byte*)iv1, sizeof(iv1),
@@ -527,8 +527,8 @@ static int sce_aesgcm128_test(int prnt, FSPSM_AES_PWKEY aes128_key)
     };
 
     byte resultT[sizeof(t1)];
-    byte resultP[sizeof(p) + AES_BLOCK_SIZE];
-    byte resultC[sizeof(p) + AES_BLOCK_SIZE];
+    byte resultP[sizeof(p) + WC_AES_BLOCK_SIZE];
+    byte resultC[sizeof(p) + WC_AES_BLOCK_SIZE];
     int  result = 0;
     int ret;
 
@@ -553,7 +553,7 @@ static int sce_aesgcm128_test(int prnt, FSPSM_AES_PWKEY aes128_key)
         goto out;
     }
 
-    wc_AesGcmSetKey(enc, (byte*)aes128_key, AES_BLOCK_SIZE);
+    wc_AesGcmSetKey(enc, (byte*)aes128_key, WC_AES_BLOCK_SIZE);
     if (result != 0) {
         ret = -3;
         goto out;

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_tsip_unit_test.c
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_tsip_unit_test.c
@@ -126,8 +126,8 @@ static int tsip_aes_cbc_test(int prnt, tsip_aes_key_index_t* aes_key)
 
     Aes  aes[1];
 
-    byte cipher[AES_BLOCK_SIZE];
-    byte plain[AES_BLOCK_SIZE];
+    byte cipher[WC_AES_BLOCK_SIZE];
+    byte plain[WC_AES_BLOCK_SIZE];
     int  ret = 0;
 
     WOLFSSL_SMALL_STACK_STATIC const byte msg[] = {
@@ -139,8 +139,8 @@ static int tsip_aes_cbc_test(int prnt, tsip_aes_key_index_t* aes_key)
     byte key[] = "0123456789abcdef   ";  /* align */
     byte iv[]  = "1234567890abcdef   ";  /* align */
 
-    ForceZero(cipher, AES_BLOCK_SIZE);
-    ForceZero(plain, AES_BLOCK_SIZE);
+    ForceZero(cipher, WC_AES_BLOCK_SIZE);
+    ForceZero(plain, WC_AES_BLOCK_SIZE);
 
     if (prnt) {
         printf(" tsip_aes_cbc_test() ");
@@ -148,13 +148,13 @@ static int tsip_aes_cbc_test(int prnt, tsip_aes_key_index_t* aes_key)
 
     ret = wc_AesInit(aes, NULL, INVALID_DEVID);
     if (ret == 0) {
-        ret = wc_AesSetKey(aes, key, AES_BLOCK_SIZE, iv, AES_ENCRYPTION);
+        ret = wc_AesSetKey(aes, key, WC_AES_BLOCK_SIZE, iv, AES_ENCRYPTION);
         XMEMCPY(&aes->ctx.tsip_keyIdx, aes_key,
                         sizeof(tsip_aes_key_index_t));
 
         aes->ctx.keySize = aes->keylen;
         if (ret == 0) {
-            ret = wc_tsip_AesCbcEncrypt(aes, cipher, msg, AES_BLOCK_SIZE);
+            ret = wc_tsip_AesCbcEncrypt(aes, cipher, msg, WC_AES_BLOCK_SIZE);
         }
 
         wc_AesFree(aes);
@@ -167,18 +167,18 @@ static int tsip_aes_cbc_test(int prnt, tsip_aes_key_index_t* aes_key)
     if (ret == 0)
         ret = wc_AesInit(aes, NULL, INVALID_DEVID);
     if (ret == 0) {
-        ret = wc_AesSetKey(aes, key, AES_BLOCK_SIZE, iv, AES_DECRYPTION);
+        ret = wc_AesSetKey(aes, key, WC_AES_BLOCK_SIZE, iv, AES_DECRYPTION);
         XMEMCPY(&aes->ctx.tsip_keyIdx, aes_key,
                 sizeof(tsip_aes_key_index_t));
         aes->ctx.keySize = aes->keylen;
         if (ret == 0)
-            ret = wc_tsip_AesCbcDecrypt(aes, plain, cipher, AES_BLOCK_SIZE);
+            ret = wc_tsip_AesCbcDecrypt(aes, plain, cipher, WC_AES_BLOCK_SIZE);
 
         wc_AesFree(aes);
     }
     if (ret != 0)
         ret = -2;
-    if (XMEMCMP(plain, msg, AES_BLOCK_SIZE) != 0)
+    if (XMEMCMP(plain, msg, WC_AES_BLOCK_SIZE) != 0)
         ret = -3;
 #endif /* HAVE_AES_DECRYPT */
 
@@ -216,8 +216,8 @@ static void tskAes128_Cbc_Test(void *pvParam)
 static int tsip_aes256_test(int prnt, tsip_aes_key_index_t* aes_key)
 {
     Aes enc[1];
-    byte cipher[AES_BLOCK_SIZE];
-    byte plain[AES_BLOCK_SIZE];
+    byte cipher[WC_AES_BLOCK_SIZE];
+    byte plain[WC_AES_BLOCK_SIZE];
     Aes dec[1];
     int  ret = 0;
 
@@ -279,7 +279,7 @@ static int tsip_aes256_test(int prnt, tsip_aes_key_index_t* aes_key)
         dec->ctx.keySize = dec->keylen;
     }
 
-    ForceZero(cipher, AES_BLOCK_SIZE);
+    ForceZero(cipher, WC_AES_BLOCK_SIZE);
     ret = wc_tsip_AesCbcEncrypt(enc, cipher, msg, (int) sizeof(msg));
 
     if (ret != 0) {
@@ -287,7 +287,7 @@ static int tsip_aes256_test(int prnt, tsip_aes_key_index_t* aes_key)
         goto out;
     }
 
-    ForceZero(plain, AES_BLOCK_SIZE);
+    ForceZero(plain, WC_AES_BLOCK_SIZE);
     ret = wc_tsip_AesCbcDecrypt(dec, plain, cipher, (int) sizeof(cipher));
 
     if (ret != 0){
@@ -395,8 +395,8 @@ static int tsip_aesgcm256_test(int prnt, tsip_aes_key_index_t* aes256_key)
     };
 
     byte resultT[sizeof(t1)];
-    byte resultP[sizeof(p) + AES_BLOCK_SIZE];
-    byte resultC[sizeof(p) + AES_BLOCK_SIZE];
+    byte resultP[sizeof(p) + WC_AES_BLOCK_SIZE];
+    byte resultC[sizeof(p) + WC_AES_BLOCK_SIZE];
     int  result = 0;
     int  ret;
 
@@ -575,8 +575,8 @@ static int tsip_aesgcm128_test(int prnt, tsip_aes_key_index_t* aes128_key)
     };
 
     byte resultT[sizeof(t3)];
-    byte resultP[sizeof(p3) + AES_BLOCK_SIZE];
-    byte resultC[sizeof(p3) + AES_BLOCK_SIZE];
+    byte resultP[sizeof(p3) + WC_AES_BLOCK_SIZE];
+    byte resultC[sizeof(p3) + WC_AES_BLOCK_SIZE];
     int  result = 0;
     int ret;
 

--- a/IDE/Renesas/e2studio/RZN2L/test/src/test/wolfssl_rsip_unit_test.c
+++ b/IDE/Renesas/e2studio/RZN2L/test/src/test/wolfssl_rsip_unit_test.c
@@ -134,8 +134,8 @@ static int rsip_aes128_cbc_test(int prnt, FSPSM_AES_PWKEY aes_key)
 
     Aes  aes[1];
 
-    byte cipher[AES_BLOCK_SIZE];
-    byte plain[AES_BLOCK_SIZE];
+    byte cipher[WC_AES_BLOCK_SIZE];
+    byte plain[WC_AES_BLOCK_SIZE];
     word32 keySz = (word32)(128/8);
     int  ret = 0;
 
@@ -147,8 +147,8 @@ static int rsip_aes128_cbc_test(int prnt, FSPSM_AES_PWKEY aes_key)
     };
     byte iv[]  = "1234567890abcdef   ";  /* align */
 
-    XMEMSET(cipher, 0, AES_BLOCK_SIZE);
-    XMEMSET(plain, 0, AES_BLOCK_SIZE);
+    XMEMSET(cipher, 0, WC_AES_BLOCK_SIZE);
+    XMEMSET(plain, 0, WC_AES_BLOCK_SIZE);
 
     if (prnt) {
         printf(" rsip_aes_cbc_test() ");
@@ -159,7 +159,7 @@ static int rsip_aes128_cbc_test(int prnt, FSPSM_AES_PWKEY aes_key)
         ret = wc_AesSetKey(aes, (byte*)aes_key, keySz,
                                iv, AES_ENCRYPTION);
         if (ret == 0) {
-            ret = wc_AesCbcEncrypt(aes, cipher, msg, AES_BLOCK_SIZE);
+            ret = wc_AesCbcEncrypt(aes, cipher, msg, WC_AES_BLOCK_SIZE);
         }
 
         wc_AesFree(aes);
@@ -174,13 +174,13 @@ static int rsip_aes128_cbc_test(int prnt, FSPSM_AES_PWKEY aes_key)
         ret = wc_AesSetKey(aes, (byte*)aes_key, keySz,
                                iv, AES_DECRYPTION);
         if (ret == 0)
-            ret = wc_AesCbcDecrypt(aes, plain, cipher, AES_BLOCK_SIZE);
+            ret = wc_AesCbcDecrypt(aes, plain, cipher, WC_AES_BLOCK_SIZE);
 
         wc_AesFree(aes);
     }
     if (ret != 0)
         ret = -2;
-    if (XMEMCMP(plain, msg, AES_BLOCK_SIZE) != 0)
+    if (XMEMCMP(plain, msg, WC_AES_BLOCK_SIZE) != 0)
         ret = -3;
 #endif /* HAVE_AES_DECRYPT */
 
@@ -217,8 +217,8 @@ static void tskAes128_Cbc_Test(void *pvParam)
 static int rsip_aes256_cbc_test(int prnt, FSPSM_AES_PWKEY aes_key)
 {
     Aes enc[1];
-    byte cipher[AES_BLOCK_SIZE];
-    byte plain[AES_BLOCK_SIZE];
+    byte cipher[WC_AES_BLOCK_SIZE];
+    byte plain[WC_AES_BLOCK_SIZE];
     Aes dec[1];
     const word32 keySz = (word32)(256/8);
     int  ret = 0;
@@ -261,7 +261,7 @@ static int rsip_aes256_cbc_test(int prnt, FSPSM_AES_PWKEY aes_key)
         goto out;
     }
 
-    XMEMSET(cipher, 0, AES_BLOCK_SIZE);
+    XMEMSET(cipher, 0, WC_AES_BLOCK_SIZE);
     ret = wc_AesCbcEncrypt(enc, cipher, msg, (int) sizeof(msg));
 
     if (ret != 0) {
@@ -269,7 +269,7 @@ static int rsip_aes256_cbc_test(int prnt, FSPSM_AES_PWKEY aes_key)
         goto out;
     }
 
-    XMEMSET(plain, 0, AES_BLOCK_SIZE);
+    XMEMSET(plain, 0, WC_AES_BLOCK_SIZE);
     ret = wc_AesCbcDecrypt(dec, plain, cipher, (int) sizeof(cipher));
 
     if (ret != 0){
@@ -368,8 +368,8 @@ static int rsip_aesgcm256_test(int prnt, FSPSM_AES_PWKEY aes256_key)
     };
 
     byte resultT[sizeof(t1)];
-    byte resultP[sizeof(p) + AES_BLOCK_SIZE];
-    byte resultC[sizeof(p) + AES_BLOCK_SIZE];
+    byte resultP[sizeof(p) + WC_AES_BLOCK_SIZE];
+    byte resultC[sizeof(p) + WC_AES_BLOCK_SIZE];
     int  result = 0;
     int  ret;
 
@@ -554,8 +554,8 @@ static int rsip_aesgcm128_test(int prnt, FSPSM_AES_PWKEY aes128_key)
     };
 
     byte resultT[sizeof(t1)];
-    byte resultP[sizeof(p) + AES_BLOCK_SIZE];
-    byte resultC[sizeof(p) + AES_BLOCK_SIZE];
+    byte resultP[sizeof(p) + WC_AES_BLOCK_SIZE];
+    byte resultC[sizeof(p) + WC_AES_BLOCK_SIZE];
     int  result = 0;
     int ret;
 

--- a/wolfcrypt/src/port/Espressif/esp32_aes.c
+++ b/wolfcrypt/src/port/Espressif/esp32_aes.c
@@ -514,9 +514,9 @@ int wc_esp32AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     int ret;
     int i;
     int offset = 0;
-    word32 blocks = (sz / AES_BLOCK_SIZE);
+    word32 blocks = (sz / WC_AES_BLOCK_SIZE);
     byte *iv;
-    byte temp_block[AES_BLOCK_SIZE];
+    byte temp_block[WC_AES_BLOCK_SIZE];
 
     ESP_LOGV(TAG, "enter wc_esp32AesCbcEncrypt");
 
@@ -533,19 +533,19 @@ int wc_esp32AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 
     if (ret == ESP_OK) {
         while (blocks--) {
-            XMEMCPY(temp_block, in + offset, AES_BLOCK_SIZE);
+            XMEMCPY(temp_block, in + offset, WC_AES_BLOCK_SIZE);
 
             /* XOR block with IV for CBC */
-            for (i = 0; i < AES_BLOCK_SIZE; i++) {
+            for (i = 0; i < WC_AES_BLOCK_SIZE; i++) {
                 temp_block[i] ^= iv[i];
             }
 
             esp_aes_bk(temp_block, (out + offset));
 
-            offset += AES_BLOCK_SIZE;
+            offset += WC_AES_BLOCK_SIZE;
 
             /* store IV for next block */
-            XMEMCPY(iv, out + offset - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
+            XMEMCPY(iv, out + offset - WC_AES_BLOCK_SIZE, WC_AES_BLOCK_SIZE);
         } /* while (blocks--) */
     } /* if Set Mode successful (ret == ESP_OK) */
 
@@ -573,9 +573,9 @@ int wc_esp32AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 
     int i;
     int offset = 0;
-    word32 blocks = (sz / AES_BLOCK_SIZE);
+    word32 blocks = (sz / WC_AES_BLOCK_SIZE);
     byte* iv;
-    byte temp_block[AES_BLOCK_SIZE];
+    byte temp_block[WC_AES_BLOCK_SIZE];
 
     ESP_LOGV(TAG, "enter wc_esp32AesCbcDecrypt");
 
@@ -592,19 +592,19 @@ int wc_esp32AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 
     if (ret == ESP_OK) {
         while (blocks--) {
-            XMEMCPY(temp_block, in + offset, AES_BLOCK_SIZE);
+            XMEMCPY(temp_block, in + offset, WC_AES_BLOCK_SIZE);
 
             esp_aes_bk((in + offset), (out + offset));
 
             /* XOR block with IV for CBC */
-            for (i = 0; i < AES_BLOCK_SIZE; i++) {
+            for (i = 0; i < WC_AES_BLOCK_SIZE; i++) {
                 (out + offset)[i] ^= iv[i];
             }
 
             /* store IV for next block */
-            XMEMCPY(iv, temp_block, AES_BLOCK_SIZE);
+            XMEMCPY(iv, temp_block, WC_AES_BLOCK_SIZE);
 
-            offset += AES_BLOCK_SIZE;
+            offset += WC_AES_BLOCK_SIZE;
         } /* while (blocks--) */
         esp_aes_hw_Leave();
     } /* if Set Mode was successful (ret == ESP_OK) */

--- a/wolfcrypt/src/port/Renesas/renesas_fspsm_aes.c
+++ b/wolfcrypt/src/port/Renesas/renesas_fspsm_aes.c
@@ -243,7 +243,7 @@ WOLFSSL_LOCAL int  wc_fspsm_AesGcmEncrypt(struct Aes* aes, byte* out,
     (void) key_server_aes;
 
     /* sanity check */
-    if (aes == NULL || authTagSz > AES_BLOCK_SIZE || ivSz == 0 || ctx == NULL) {
+    if (aes == NULL || authTagSz > WC_AES_BLOCK_SIZE || ivSz == 0 || ctx == NULL) {
         return BAD_FUNC_ARG;
     }
 
@@ -275,8 +275,8 @@ WOLFSSL_LOCAL int  wc_fspsm_AesGcmEncrypt(struct Aes* aes, byte* out,
         /* allocate buffers for plain text, cipher text and authTag to make sure
          * those buffers 32bit aligned as SCE requests.
          */
-         delta = ((sz % AES_BLOCK_SIZE) == 0) ? 0 :
-                             (byte)(AES_BLOCK_SIZE - (sz % AES_BLOCK_SIZE));
+         delta = ((sz % WC_AES_BLOCK_SIZE) == 0) ? 0 :
+                             (byte)(WC_AES_BLOCK_SIZE - (sz % WC_AES_BLOCK_SIZE));
         plainBuf  = XMALLOC(sz, aes->heap, DYNAMIC_TYPE_AES);
         cipherBuf = XMALLOC(sz + delta, aes->heap, DYNAMIC_TYPE_AES);
         aTagBuf   = XMALLOC(SCE_AES_GCM_AUTH_TAG_SIZE, aes->heap,
@@ -371,7 +371,7 @@ WOLFSSL_LOCAL int  wc_fspsm_AesGcmEncrypt(struct Aes* aes, byte* out,
                 */
                 dataLen = 0;
                 ret = finalFn(&_handle,
-                           cipherBuf + (sz + delta - AES_BLOCK_SIZE),
+                           cipherBuf + (sz + delta - WC_AES_BLOCK_SIZE),
                               &dataLen,
                               aTagBuf);
 
@@ -452,7 +452,7 @@ WOLFSSL_LOCAL int  wc_fspsm_AesGcmDecrypt(struct Aes* aes, byte* out,
     FSPSM_AES_PWKEY      key_server_aes = NULL;
     (void) key_client_aes;
     /* sanity check */
-    if (aes == NULL || authTagSz > AES_BLOCK_SIZE || ivSz == 0 || ctx == NULL) {
+    if (aes == NULL || authTagSz > WC_AES_BLOCK_SIZE || ivSz == 0 || ctx == NULL) {
         return BAD_FUNC_ARG;
     }
 
@@ -482,8 +482,8 @@ WOLFSSL_LOCAL int  wc_fspsm_AesGcmDecrypt(struct Aes* aes, byte* out,
        /* allocate buffers for plain-text, cipher-text, authTag and AAD.
          * TSIP requests those buffers 32bit aligned.
          */
-         delta = ((sz % AES_BLOCK_SIZE) == 0) ? 0 :
-                            (byte)(AES_BLOCK_SIZE - (sz % AES_BLOCK_SIZE));
+         delta = ((sz % WC_AES_BLOCK_SIZE) == 0) ? 0 :
+                            (byte)(WC_AES_BLOCK_SIZE - (sz % WC_AES_BLOCK_SIZE));
         cipherBuf = XMALLOC(sz, aes->heap, DYNAMIC_TYPE_AES);
         plainBuf  = XMALLOC(sz + delta, aes->heap, DYNAMIC_TYPE_AES);
         aTagBuf   = XMALLOC(SCE_AES_GCM_AUTH_TAG_SIZE, aes->heap,
@@ -571,7 +571,7 @@ WOLFSSL_LOCAL int  wc_fspsm_AesGcmDecrypt(struct Aes* aes, byte* out,
             if (ret == FSP_SUCCESS) {
                 dataLen = 0;
                 ret = finalFn(&_handle,
-                                  plainBuf + (sz + delta - AES_BLOCK_SIZE),
+                                  plainBuf + (sz + delta - WC_AES_BLOCK_SIZE),
                             &dataLen,
                             aTagBuf,
                             min(16, authTagSz));
@@ -620,7 +620,7 @@ WOLFSSL_LOCAL int wc_fspsm_AesCbcEncrypt(struct Aes* aes, byte* out,
 {
     FSPSM_AES_HANDLE _handle;
     int ret;
-    word32 blocks = (sz / AES_BLOCK_SIZE);
+    word32 blocks = (sz / WC_AES_BLOCK_SIZE);
     uint32_t dataLength;
     byte *iv;
 
@@ -656,13 +656,13 @@ WOLFSSL_LOCAL int wc_fspsm_AesCbcEncrypt(struct Aes* aes, byte* out,
 
         if (aes->ctx.keySize == 16)
             ret = FSPSM_AES128CBCEnc_Up(&_handle, (uint8_t*)in,
-                                    (uint8_t*)out, (uint32_t)AES_BLOCK_SIZE);
+                                    (uint8_t*)out, (uint32_t)WC_AES_BLOCK_SIZE);
         else
             ret = FSPSM_AES256CBCEnc_Up(&_handle, (uint8_t*)in,
-                                    (uint8_t*)out, (uint32_t)AES_BLOCK_SIZE);
+                                    (uint8_t*)out, (uint32_t)WC_AES_BLOCK_SIZE);
 
-        in  += AES_BLOCK_SIZE;
-        out += AES_BLOCK_SIZE;
+        in  += WC_AES_BLOCK_SIZE;
+        out += WC_AES_BLOCK_SIZE;
     }
 
     if (ret == FSP_SUCCESS) {
@@ -694,7 +694,7 @@ WOLFSSL_LOCAL int wc_fspsm_AesCbcDecrypt(struct Aes* aes, byte* out,
 {
     FSPSM_AES_HANDLE _handle;
     int ret;
-    word32 blocks = (sz / AES_BLOCK_SIZE);
+    word32 blocks = (sz / WC_AES_BLOCK_SIZE);
     uint32_t dataLength;
     byte *iv;
 
@@ -727,13 +727,13 @@ WOLFSSL_LOCAL int wc_fspsm_AesCbcDecrypt(struct Aes* aes, byte* out,
 
         if (aes->ctx.keySize == 16)
             ret = FSPSM_AES128CBCDec_Up(&_handle, (uint8_t*)in,
-                                        (uint8_t*)out, (uint32_t)AES_BLOCK_SIZE);
+                                        (uint8_t*)out, (uint32_t)WC_AES_BLOCK_SIZE);
         else
             ret = FSPSM_AES256CBCDec_Up(&_handle, (uint8_t*)in,
-                                        (uint8_t*)out, (uint32_t)AES_BLOCK_SIZE);
+                                        (uint8_t*)out, (uint32_t)WC_AES_BLOCK_SIZE);
 
-        in  += AES_BLOCK_SIZE;
-        out += AES_BLOCK_SIZE;
+        in  += WC_AES_BLOCK_SIZE;
+        out += WC_AES_BLOCK_SIZE;
     }
 
     if (ret == FSP_SUCCESS) {

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_aes.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_aes.c
@@ -100,9 +100,9 @@ WOLFSSL_LOCAL int tsip_Tls13AesEncrypt(
     e_tsip_err_t    err = TSIP_SUCCESS;
     TsipUserCtx*    tuc = NULL;
     e_tsip_tls13_cipher_suite_t cs;
-    word32  cipher[(AES_BLOCK_SIZE + TSIP_AES_GCM_AUTH_TAG_SIZE) /
+    word32  cipher[(WC_AES_BLOCK_SIZE + TSIP_AES_GCM_AUTH_TAG_SIZE) /
                                                              sizeof(word32)];
-    word32  plain[AES_BLOCK_SIZE / sizeof(word32)];
+    word32  plain[WC_AES_BLOCK_SIZE / sizeof(word32)];
     int             idxIn,idxOut;
     uint32_t        remain;
     uint32_t        dataSz, finalSz;
@@ -177,7 +177,7 @@ WOLFSSL_LOCAL int tsip_Tls13AesEncrypt(
 
         while (err == TSIP_SUCCESS && remain > 0) {
 
-            dataSz = min(remain, AES_BLOCK_SIZE);
+            dataSz = min(remain, WC_AES_BLOCK_SIZE);
             ForceZero(plain, sizeof(plain));
             ForceZero(cipher, sizeof(cipher));
             XMEMCPY(plain, input + idxIn, dataSz);
@@ -190,7 +190,7 @@ WOLFSSL_LOCAL int tsip_Tls13AesEncrypt(
                                     dataSz);
 
             if (err == TSIP_SUCCESS) {
-                if (dataSz >= AES_BLOCK_SIZE) {
+                if (dataSz >= WC_AES_BLOCK_SIZE) {
                     XMEMCPY(output + idxOut, cipher, dataSz);
                     idxOut += dataSz;
                 }
@@ -247,8 +247,8 @@ WOLFSSL_LOCAL int tsip_Tls13AesDecrypt(
     e_tsip_err_t    err = TSIP_SUCCESS;
     TsipUserCtx*    tuc = NULL;
     e_tsip_tls13_cipher_suite_t cs;
-    word32          cipher[AES_BLOCK_SIZE / sizeof(word32)];
-    word32          plain[AES_BLOCK_SIZE / sizeof(word32)];
+    word32          cipher[WC_AES_BLOCK_SIZE / sizeof(word32)];
+    word32          plain[WC_AES_BLOCK_SIZE / sizeof(word32)];
     int             idxIn,idxOut;
     int             blocks;
     uint32_t        remain,conRemain;
@@ -302,7 +302,7 @@ WOLFSSL_LOCAL int tsip_Tls13AesDecrypt(
         return CRYPTOCB_UNAVAILABLE;
 
 
-    blocks    = sz / AES_BLOCK_SIZE;
+    blocks    = sz / WC_AES_BLOCK_SIZE;
     remain    = sz;
     conRemain = sz - TSIP_AES_GCM_AUTH_TAG_SIZE;
 
@@ -326,9 +326,9 @@ WOLFSSL_LOCAL int tsip_Tls13AesDecrypt(
 
         while (err == TSIP_SUCCESS && (blocks--) >= 0) {
 
-            dataSz = min(remain, AES_BLOCK_SIZE);
+            dataSz = min(remain, WC_AES_BLOCK_SIZE);
             XMEMCPY(cipher, input + idxIn, dataSz);
-            ForceZero(plain, AES_BLOCK_SIZE);
+            ForceZero(plain, WC_AES_BLOCK_SIZE);
 
             err = R_TSIP_Tls13DecryptUpdate(
                                     &(tuc->handle13),
@@ -337,7 +337,7 @@ WOLFSSL_LOCAL int tsip_Tls13AesDecrypt(
                                     dataSz);
 
             if (err == TSIP_SUCCESS) {
-                if (dataSz >= AES_BLOCK_SIZE && conRemain >= AES_BLOCK_SIZE) {
+                if (dataSz >= WC_AES_BLOCK_SIZE && conRemain >= WC_AES_BLOCK_SIZE) {
                     XMEMCPY(output + idxOut, plain, dataSz);
                     idxOut += dataSz;
                     conRemain -= min(conRemain, dataSz);
@@ -472,7 +472,7 @@ int wc_tsip_AesCbcEncrypt(struct Aes* aes, byte* out, const byte* in, word32 sz)
 {
     tsip_aes_handle_t _handle;
     int ret;
-    word32 blocks = (sz / AES_BLOCK_SIZE);
+    word32 blocks = (sz / WC_AES_BLOCK_SIZE);
     uint32_t dataLength;
     byte *iv;
 
@@ -502,13 +502,13 @@ int wc_tsip_AesCbcEncrypt(struct Aes* aes, byte* out, const byte* in, word32 sz)
     while (ret == TSIP_SUCCESS && blocks--) {
         if (aes->ctx.keySize == 16)
             ret = R_TSIP_Aes128CbcEncryptUpdate(&_handle, (uint8_t*)in,
-                                    (uint8_t*)out, (uint32_t)AES_BLOCK_SIZE);
+                                    (uint8_t*)out, (uint32_t)WC_AES_BLOCK_SIZE);
         else
             ret = R_TSIP_Aes256CbcEncryptUpdate(&_handle, (uint8_t*)in,
-                                    (uint8_t*)out, (uint32_t)AES_BLOCK_SIZE);
+                                    (uint8_t*)out, (uint32_t)WC_AES_BLOCK_SIZE);
 
-        in  += AES_BLOCK_SIZE;
-        out += AES_BLOCK_SIZE;
+        in  += WC_AES_BLOCK_SIZE;
+        out += WC_AES_BLOCK_SIZE;
     }
 
     if (ret == TSIP_SUCCESS) {
@@ -532,7 +532,7 @@ int wc_tsip_AesCbcDecrypt(struct Aes* aes, byte* out, const byte* in, word32 sz)
 {
    tsip_aes_handle_t _handle;
     int ret;
-    word32 blocks = (sz / AES_BLOCK_SIZE);
+    word32 blocks = (sz / WC_AES_BLOCK_SIZE);
     uint32_t dataLength;
     byte *iv;
 
@@ -561,13 +561,13 @@ int wc_tsip_AesCbcDecrypt(struct Aes* aes, byte* out, const byte* in, word32 sz)
 
         if (aes->ctx.keySize == 16)
             ret = R_TSIP_Aes128CbcDecryptUpdate(&_handle, (uint8_t*)in,
-                                        (uint8_t*)out, (uint32_t)AES_BLOCK_SIZE);
+                                        (uint8_t*)out, (uint32_t)WC_AES_BLOCK_SIZE);
         else
             ret = R_TSIP_Aes256CbcDecryptUpdate(&_handle, (uint8_t*)in,
-                                        (uint8_t*)out, (uint32_t)AES_BLOCK_SIZE);
+                                        (uint8_t*)out, (uint32_t)WC_AES_BLOCK_SIZE);
 
-        in  += AES_BLOCK_SIZE;
-        out += AES_BLOCK_SIZE;
+        in  += WC_AES_BLOCK_SIZE;
+        out += WC_AES_BLOCK_SIZE;
     }
 
     if (ret == TSIP_SUCCESS) {
@@ -660,8 +660,8 @@ int wc_tsip_AesGcmEncrypt(
 
     userCtx = (TsipUserCtx*)ctx;
 
-    /* buffer for cipher data output must be multiple of AES_BLOCK_SIZE */
-    cipherBufSz = ((sz / AES_BLOCK_SIZE) + 1) * AES_BLOCK_SIZE;
+    /* buffer for cipher data output must be multiple of WC_AES_BLOCK_SIZE */
+    cipherBufSz = ((sz / WC_AES_BLOCK_SIZE) + 1) * WC_AES_BLOCK_SIZE;
 
     if ((ret = tsip_hw_lock()) == 0) {
 
@@ -754,7 +754,7 @@ int wc_tsip_AesGcmEncrypt(
             */
             dataLen = 0;
             err = finalFn(&hdl,
-                          cipherBuf + (sz / AES_BLOCK_SIZE) * AES_BLOCK_SIZE,
+                          cipherBuf + (sz / WC_AES_BLOCK_SIZE) * WC_AES_BLOCK_SIZE,
                           &dataLen,
                           aTagBuf); /* aad of 16 bytes will be output */
 
@@ -859,8 +859,8 @@ int wc_tsip_AesGcmDecrypt(
 
     userCtx = (TsipUserCtx *)ctx;
 
-    /* buffer for plain data output must be multiple of AES_BLOCK_SIZE */
-    plainBufSz = ((sz / AES_BLOCK_SIZE) + 1) * AES_BLOCK_SIZE;
+    /* buffer for plain data output must be multiple of WC_AES_BLOCK_SIZE */
+    plainBufSz = ((sz / WC_AES_BLOCK_SIZE) + 1) * WC_AES_BLOCK_SIZE;
 
     if ((ret = tsip_hw_lock()) == 0) {
 
@@ -950,7 +950,7 @@ int wc_tsip_AesGcmDecrypt(
             if (err == TSIP_SUCCESS) {
                 dataLen = 0;
                 err = finalFn(&hdl,
-                        plainBuf + (sz / AES_BLOCK_SIZE) * AES_BLOCK_SIZE,
+                        plainBuf + (sz / WC_AES_BLOCK_SIZE) * WC_AES_BLOCK_SIZE,
                         &dataLen,
                         aTagBuf,
                         min(16, authTagSz)); /* TSIP accepts upto 16 byte */

--- a/wolfcrypt/src/port/af_alg/afalg_aes.c
+++ b/wolfcrypt/src/port/af_alg/afalg_aes.c
@@ -177,7 +177,7 @@ int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen,
         }
 
 #ifdef WOLFSSL_AES_CBC_LENGTH_CHECKS
-        if (sz % AES_BLOCK_SIZE) {
+        if (sz % WC_AES_BLOCK_SIZE) {
             return BAD_LENGTH_E;
         }
 #endif
@@ -190,8 +190,8 @@ int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen,
             }
         }
 
-        sz = sz - (sz % AES_BLOCK_SIZE);
-        if ((sz / AES_BLOCK_SIZE) > 0) {
+        sz = sz - (sz % WC_AES_BLOCK_SIZE);
+        if ((sz / WC_AES_BLOCK_SIZE) > 0) {
             /* update IV */
             cmsg = CMSG_FIRSTHDR(&(aes->msg));
             ret = wc_Afalg_SetIv(CMSG_NXTHDR(&(aes->msg), cmsg),
@@ -218,7 +218,7 @@ int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen,
             }
 
             /* set IV for next CBC call */
-            XMEMCPY(aes->reg, out + sz - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
+            XMEMCPY(aes->reg, out + sz - WC_AES_BLOCK_SIZE, WC_AES_BLOCK_SIZE);
         }
 
         return 0;
@@ -235,7 +235,7 @@ int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen,
             return BAD_FUNC_ARG;
         }
 
-        if (sz % AES_BLOCK_SIZE) {
+        if (sz % WC_AES_BLOCK_SIZE) {
 #ifdef WOLFSSL_AES_CBC_LENGTH_CHECKS
             return BAD_LENGTH_E;
 #else
@@ -250,7 +250,7 @@ int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen,
             }
         }
 
-        if ((sz / AES_BLOCK_SIZE) > 0) {
+        if ((sz / WC_AES_BLOCK_SIZE) > 0) {
             /* update IV */
             cmsg = CMSG_FIRSTHDR(&(aes->msg));
             ret = wc_Afalg_SetIv(CMSG_NXTHDR(&(aes->msg), cmsg),
@@ -267,7 +267,7 @@ int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen,
             aes->msg.msg_iovlen = 1; /* # of iov structures */
 
             /* set IV for next CBC call */
-            XMEMCPY(aes->reg, in + sz - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
+            XMEMCPY(aes->reg, in + sz - WC_AES_BLOCK_SIZE, WC_AES_BLOCK_SIZE);
 
             ret = (int)sendmsg(aes->rdFd, &(aes->msg), 0);
             if (ret < 0) {
@@ -336,13 +336,13 @@ static int wc_Afalg_AesDirect(Aes* aes, byte* out, const byte* in, word32 sz)
 #if defined(WOLFSSL_AES_DIRECT) && defined(WOLFSSL_AFALG)
 int wc_AesEncryptDirect(Aes* aes, byte* out, const byte* in)
 {
-    return wc_Afalg_AesDirect(aes, out, in, AES_BLOCK_SIZE);
+    return wc_Afalg_AesDirect(aes, out, in, WC_AES_BLOCK_SIZE);
 }
 
 
 int wc_AesDecryptDirect(Aes* aes, byte* out, const byte* in)
 {
-    return wc_Afalg_AesDirect(aes, out, in, AES_BLOCK_SIZE);
+    return wc_Afalg_AesDirect(aes, out, in, WC_AES_BLOCK_SIZE);
 }
 
 
@@ -363,7 +363,7 @@ int wc_AesSetKeyDirect(Aes* aes, const byte* userKey, word32 keylen,
         {
             /* in network byte order so start at end and work back */
             int i;
-            for (i = AES_BLOCK_SIZE - 1; i >= 0; i--) {
+            for (i = WC_AES_BLOCK_SIZE - 1; i >= 0; i--) {
                 if (++inOutCtr[i])  /* we're done unless we overflow */
                     return;
             }
@@ -381,7 +381,7 @@ int wc_AesSetKeyDirect(Aes* aes, const byte* userKey, word32 keylen,
             }
 
             /* consume any unused bytes left in aes->tmp */
-            tmp = (byte*)aes->tmp + AES_BLOCK_SIZE - aes->left;
+            tmp = (byte*)aes->tmp + WC_AES_BLOCK_SIZE - aes->left;
             while (aes->left && sz) {
                *(out++) = *(in++) ^ *(tmp++);
                aes->left--;
@@ -397,11 +397,11 @@ int wc_AesSetKeyDirect(Aes* aes, const byte* userKey, word32 keylen,
             }
 
             if (sz > 0) {
-                aes->left = sz % AES_BLOCK_SIZE;
+                aes->left = sz % WC_AES_BLOCK_SIZE;
 
                 /* clear previously leftover data */
                 tmp = (byte*)aes->tmp;
-                XMEMSET(tmp, 0, AES_BLOCK_SIZE);
+                XMEMSET(tmp, 0, WC_AES_BLOCK_SIZE);
 
                 /* update IV */
                 cmsg = CMSG_FIRSTHDR(&(aes->msg));
@@ -419,7 +419,7 @@ int wc_AesSetKeyDirect(Aes* aes, const byte* userKey, word32 keylen,
                 iov[1].iov_base = tmp;
                 if (aes->left > 0) {
                     XMEMCPY(tmp, in + sz - aes->left, aes->left);
-                    iov[1].iov_len  = AES_BLOCK_SIZE;
+                    iov[1].iov_len  = WC_AES_BLOCK_SIZE;
                 }
                 else {
                     iov[1].iov_len  = 0;
@@ -440,7 +440,7 @@ int wc_AesSetKeyDirect(Aes* aes, const byte* userKey, word32 keylen,
 
                 iov[1].iov_base = tmp;
                 if (aes->left > 0) {
-                    iov[1].iov_len  = AES_BLOCK_SIZE;
+                    iov[1].iov_len  = WC_AES_BLOCK_SIZE;
                 }
                 else {
                     iov[1].iov_len  = 0;
@@ -453,14 +453,14 @@ int wc_AesSetKeyDirect(Aes* aes, const byte* userKey, word32 keylen,
 
                 if (aes->left > 0) {
                     XMEMCPY(out + sz - aes->left, tmp, aes->left);
-                    aes->left = AES_BLOCK_SIZE - aes->left;
+                    aes->left = WC_AES_BLOCK_SIZE - aes->left;
                 }
             }
 
             /* adjust counter after call to hardware */
-            while (sz >= AES_BLOCK_SIZE) {
+            while (sz >= WC_AES_BLOCK_SIZE) {
                 IncrementAesCounter((byte*)aes->reg);
-                sz  -= AES_BLOCK_SIZE;
+                sz  -= WC_AES_BLOCK_SIZE;
             }
 
             if (aes->left > 0) {
@@ -566,10 +566,10 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     struct iovec    iov[3];
     int ret;
     struct msghdr* msg;
-    byte scratch[AES_BLOCK_SIZE];
+    byte scratch[WC_AES_BLOCK_SIZE];
 
     /* argument checks */
-    if (aes == NULL || authTagSz > AES_BLOCK_SIZE) {
+    if (aes == NULL || authTagSz > WC_AES_BLOCK_SIZE) {
         return BAD_FUNC_ARG;
     }
 
@@ -639,7 +639,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
         #ifndef NO_WOLFSSL_ALLOC_ALIGN
             byte* tmp_align;
             tmp = (byte*)XMALLOC(sz + WOLFSSL_XILINX_ALIGN +
-                    AES_BLOCK_SIZE, aes->heap, DYNAMIC_TYPE_TMP_BUFFER);
+                    WC_AES_BLOCK_SIZE, aes->heap, DYNAMIC_TYPE_TMP_BUFFER);
             if (tmp == NULL) {
                 return MEMORY_E;
             }
@@ -655,7 +655,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
         else {
             iov[0].iov_base = (byte*)in;
         }
-        iov[0].iov_len  = sz + AES_BLOCK_SIZE;
+        iov[0].iov_len  = sz + WC_AES_BLOCK_SIZE;
 
         msg->msg_iov    = iov;
         msg->msg_iovlen = 1; /* # of iov structures */
@@ -668,7 +668,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
             return WC_AFALG_SOCK_E;
         }
 
-        ret = read(aes->rdFd, out, sz + AES_BLOCK_SIZE);
+        ret = read(aes->rdFd, out, sz + WC_AES_BLOCK_SIZE);
         if (ret < 0) {
             return WC_AFALG_SOCK_E;
         }
@@ -677,10 +677,10 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
 
     /* handle completing tag with using software if additional data added */
     if (authIn != NULL && authInSz > 0) {
-        byte initalCounter[AES_BLOCK_SIZE];
-        XMEMSET(initalCounter, 0, AES_BLOCK_SIZE);
+        byte initalCounter[WC_AES_BLOCK_SIZE];
+        XMEMSET(initalCounter, 0, WC_AES_BLOCK_SIZE);
         XMEMCPY(initalCounter, iv, ivSz);
-        initalCounter[AES_BLOCK_SIZE - 1] = 1;
+        initalCounter[WC_AES_BLOCK_SIZE - 1] = 1;
         GHASH(&aes->gcm, authIn, authInSz, out, sz, authTag, authTagSz);
         ret = wc_AesEncryptDirect(aes, scratch, initalCounter);
         if (ret < 0) {
@@ -756,19 +756,19 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     struct cmsghdr* cmsg;
     struct msghdr* msg;
     struct iovec    iov[3];
-    byte scratch[AES_BLOCK_SIZE];
+    byte scratch[WC_AES_BLOCK_SIZE];
     int ret;
 #ifdef WOLFSSL_AFALG_XILINX_AES
     byte* tag = (byte*)authTag;
-    byte buf[AES_BLOCK_SIZE];
-    byte initalCounter[AES_BLOCK_SIZE];
+    byte buf[WC_AES_BLOCK_SIZE];
+    byte initalCounter[WC_AES_BLOCK_SIZE];
 #ifndef NO_WOLFSSL_ALLOC_ALIGN
     byte* tmp = NULL;
 #endif
 #endif
 
     /* argument checks */
-    if (aes == NULL || authTagSz > AES_BLOCK_SIZE) {
+    if (aes == NULL || authTagSz > WC_AES_BLOCK_SIZE) {
         return BAD_FUNC_ARG;
     }
 
@@ -830,33 +830,33 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     /* check for and handle additional data */
     if (authIn != NULL && authInSz > 0) {
 
-        XMEMSET(initalCounter, 0, AES_BLOCK_SIZE);
+        XMEMSET(initalCounter, 0, WC_AES_BLOCK_SIZE);
         XMEMCPY(initalCounter, iv, ivSz);
-        initalCounter[AES_BLOCK_SIZE - 1] = 1;
+        initalCounter[WC_AES_BLOCK_SIZE - 1] = 1;
         tag = buf;
-        GHASH(&aes->gcm, NULL, 0, in, sz, tag, AES_BLOCK_SIZE);
+        GHASH(&aes->gcm, NULL, 0, in, sz, tag, WC_AES_BLOCK_SIZE);
         ret = wc_AesEncryptDirect(aes, scratch, initalCounter);
         if (ret < 0)
             return ret;
-        xorbuf(tag, scratch, AES_BLOCK_SIZE);
+        xorbuf(tag, scratch, WC_AES_BLOCK_SIZE);
         if (ret != 0) {
             return AES_GCM_AUTH_E;
         }
     }
 
     /* it is assumed that in buffer size is large enough to hold TAG */
-    XMEMCPY((byte*)in + sz, tag, AES_BLOCK_SIZE);
+    XMEMCPY((byte*)in + sz, tag, WC_AES_BLOCK_SIZE);
     if ((wc_ptr_t)in % WOLFSSL_XILINX_ALIGN) {
     #ifndef NO_WOLFSSL_ALLOC_ALIGN
         byte* tmp_align;
         tmp = (byte*)XMALLOC(sz + WOLFSSL_XILINX_ALIGN +
-                AES_BLOCK_SIZE, aes->heap, DYNAMIC_TYPE_TMP_BUFFER);
+                WC_AES_BLOCK_SIZE, aes->heap, DYNAMIC_TYPE_TMP_BUFFER);
         if (tmp == NULL) {
             return MEMORY_E;
         }
         tmp_align = tmp + (WOLFSSL_XILINX_ALIGN -
                 ((size_t)tmp % WOLFSSL_XILINX_ALIGN));
-        XMEMCPY(tmp_align, in, sz + AES_BLOCK_SIZE);
+        XMEMCPY(tmp_align, in, sz + WC_AES_BLOCK_SIZE);
         iov[0].iov_base = tmp_align;
     #else
         WOLFSSL_MSG("Buffer expected to be word aligned");
@@ -866,7 +866,7 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     else {
         iov[0].iov_base = (byte*)in;
     }
-    iov[0].iov_len = sz + AES_BLOCK_SIZE;
+    iov[0].iov_len = sz + WC_AES_BLOCK_SIZE;
 
     msg->msg_iov = iov;
     msg->msg_iovlen = 1;
@@ -879,18 +879,18 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
         return WC_AFALG_SOCK_E;
     }
 
-    ret = read(aes->rdFd, out, sz + AES_BLOCK_SIZE);
+    ret = read(aes->rdFd, out, sz + WC_AES_BLOCK_SIZE);
     if (ret < 0) {
         return AES_GCM_AUTH_E;
     }
 
     /* check on tag */
     if (authIn != NULL && authInSz > 0) {
-        GHASH(&aes->gcm, authIn, authInSz, in, sz, tag, AES_BLOCK_SIZE);
+        GHASH(&aes->gcm, authIn, authInSz, in, sz, tag, WC_AES_BLOCK_SIZE);
         ret = wc_AesEncryptDirect(aes, scratch, initalCounter);
         if (ret < 0)
             return ret;
-        xorbuf(tag, scratch, AES_BLOCK_SIZE);
+        xorbuf(tag, scratch, WC_AES_BLOCK_SIZE);
         if (ConstantCompare(tag, authTag, authTagSz) != 0) {
             return AES_GCM_AUTH_E;
         }

--- a/wolfcrypt/src/port/autosar/crypto.c
+++ b/wolfcrypt/src/port/autosar/crypto.c
@@ -250,7 +250,7 @@ Std_ReturnType wolfSSL_Crypto_CBC(Crypto_JobType* job)
             return E_NOT_OK;
         }
 
-        if (iv != NULL && ivSz < AES_BLOCK_SIZE) {
+        if (iv != NULL && ivSz < WC_AES_BLOCK_SIZE) {
             WOLFSSL_MSG("Error IV is too small");
             return E_NOT_OK;
         }

--- a/wolfcrypt/src/port/caam/caam_aes.c
+++ b/wolfcrypt/src/port/caam/caam_aes.c
@@ -112,7 +112,7 @@ int  wc_AesCbcEncrypt(Aes* aes, byte* out,
         return BAD_FUNC_ARG;
     }
 
-    blocks = sz / AES_BLOCK_SIZE;
+    blocks = sz / WC_AES_BLOCK_SIZE;
 
     if (blocks > 0) {
         Buffer buf[4];
@@ -131,19 +131,19 @@ int  wc_AesCbcEncrypt(Aes* aes, byte* out,
 
         buf[1].BufferType = DataBuffer;
         buf[1].TheAddress = (Address)aes->reg;
-        buf[1].Length     = AES_BLOCK_SIZE;
+        buf[1].Length     = WC_AES_BLOCK_SIZE;
 
         buf[2].BufferType = DataBuffer;
         buf[2].TheAddress = (Address)in;
-        buf[2].Length     = blocks * AES_BLOCK_SIZE;
+        buf[2].Length     = blocks * WC_AES_BLOCK_SIZE;
 
         buf[3].BufferType = DataBuffer | LastBuffer;
         buf[3].TheAddress = (Address)out;
-        buf[3].Length     = blocks * AES_BLOCK_SIZE;
+        buf[3].Length     = blocks * WC_AES_BLOCK_SIZE;
 
         arg[0] = CAAM_ENC;
         arg[1] = keySz;
-        arg[2] = blocks * AES_BLOCK_SIZE;
+        arg[2] = blocks * WC_AES_BLOCK_SIZE;
 
         if ((ret = wc_caamAddAndWait(buf, 4, arg, CAAM_AESCBC)) != 0) {
             WOLFSSL_MSG("Error with CAAM AES CBC encrypt");
@@ -165,7 +165,7 @@ int  wc_AesCbcDecrypt(Aes* aes, byte* out,
         return BAD_FUNC_ARG;
     }
 
-    blocks = sz / AES_BLOCK_SIZE;
+    blocks = sz / WC_AES_BLOCK_SIZE;
 
     if (blocks > 0) {
         Buffer buf[4];
@@ -184,19 +184,19 @@ int  wc_AesCbcDecrypt(Aes* aes, byte* out,
 
         buf[1].BufferType = DataBuffer;
         buf[1].TheAddress = (Address)aes->reg;
-        buf[1].Length     = AES_BLOCK_SIZE;
+        buf[1].Length     = WC_AES_BLOCK_SIZE;
 
         buf[2].BufferType = DataBuffer;
         buf[2].TheAddress = (Address)in;
-        buf[2].Length     = blocks * AES_BLOCK_SIZE;
+        buf[2].Length     = blocks * WC_AES_BLOCK_SIZE;
 
         buf[3].BufferType = DataBuffer | LastBuffer;
         buf[3].TheAddress = (Address)out;
-        buf[3].Length     = blocks * AES_BLOCK_SIZE;
+        buf[3].Length     = blocks * WC_AES_BLOCK_SIZE;
 
         arg[0] = CAAM_DEC;
         arg[1] = keySz;
-        arg[2] = blocks * AES_BLOCK_SIZE;
+        arg[2] = blocks * WC_AES_BLOCK_SIZE;
 
         if ((ret = wc_caamAddAndWait(buf, arg, CAAM_AESCBC)) != 0) {
             WOLFSSL_MSG("Error with CAAM AES CBC decrypt");
@@ -208,7 +208,7 @@ int  wc_AesCbcDecrypt(Aes* aes, byte* out,
 }
 
 #if defined(HAVE_AES_ECB)
-/* is assumed that input size is a multiple of AES_BLOCK_SIZE */
+/* is assumed that input size is a multiple of WC_AES_BLOCK_SIZE */
 int wc_AesEcbEncrypt(Aes* aes, byte* out,
                                   const byte* in, word32 sz)
 {
@@ -222,7 +222,7 @@ int wc_AesEcbEncrypt(Aes* aes, byte* out,
         return BAD_FUNC_ARG;
     }
 
-    blocks = sz / AES_BLOCK_SIZE;
+    blocks = sz / WC_AES_BLOCK_SIZE;
 
     if ((ret = wc_AesGetKeySize(aes, &keySz)) != 0) {
         return ret;
@@ -235,15 +235,15 @@ int wc_AesEcbEncrypt(Aes* aes, byte* out,
 
     buf[1].BufferType = DataBuffer;
     buf[1].TheAddress = (Address)in;
-    buf[1].Length     = blocks * AES_BLOCK_SIZE;
+    buf[1].Length     = blocks * WC_AES_BLOCK_SIZE;
 
     buf[2].BufferType = DataBuffer | LastBuffer;
     buf[2].TheAddress = (Address)out;
-    buf[2].Length     = blocks * AES_BLOCK_SIZE;
+    buf[2].Length     = blocks * WC_AES_BLOCK_SIZE;
 
     arg[0] = CAAM_ENC;
     arg[1] = keySz;
-    arg[2] = blocks * AES_BLOCK_SIZE;
+    arg[2] = blocks * WC_AES_BLOCK_SIZE;
 
     if ((ret = wc_caamAddAndWait(buf, arg, CAAM_AESECB)) != 0) {
         WOLFSSL_MSG("Error with CAAM AES ECB encrypt");
@@ -267,7 +267,7 @@ int wc_AesEcbDecrypt(Aes* aes, byte* out,
         return BAD_FUNC_ARG;
     }
 
-    blocks = sz / AES_BLOCK_SIZE;
+    blocks = sz / WC_AES_BLOCK_SIZE;
 
     if ((ret = wc_AesGetKeySize(aes, &keySz)) != 0) {
         return ret;
@@ -280,15 +280,15 @@ int wc_AesEcbDecrypt(Aes* aes, byte* out,
 
     buf[1].BufferType = DataBuffer;
     buf[1].TheAddress = (Address)in;
-    buf[1].Length     = blocks * AES_BLOCK_SIZE;
+    buf[1].Length     = blocks * WC_AES_BLOCK_SIZE;
 
     buf[2].BufferType = DataBuffer | LastBuffer;
     buf[2].TheAddress = (Address)out;
-    buf[2].Length     = blocks * AES_BLOCK_SIZE;
+    buf[2].Length     = blocks * WC_AES_BLOCK_SIZE;
 
     arg[0] = CAAM_DEC;
     arg[1] = keySz;
-    arg[2] = blocks * AES_BLOCK_SIZE;
+    arg[2] = blocks * WC_AES_BLOCK_SIZE;
 
     if ((ret = wc_caamAddAndWait(buf, arg, CAAM_AESECB)) != 0) {
         WOLFSSL_MSG("Error with CAAM AES ECB decrypt");
@@ -306,7 +306,7 @@ static WC_INLINE void IncrementAesCounter(byte* inOutCtr)
 {
     /* in network byte order so start at end and work back */
     int i;
-    for (i = AES_BLOCK_SIZE - 1; i >= 0; i--) {
+    for (i = WC_AES_BLOCK_SIZE - 1; i >= 0; i--) {
         if (++inOutCtr[i])  /* we're done unless we overflow */
             return;
     }
@@ -331,7 +331,7 @@ int wc_AesCtrEncrypt(Aes* aes, byte* out,
     }
 
     /* consume any unused bytes left in aes->tmp */
-    tmp = (byte*)aes->tmp + AES_BLOCK_SIZE - aes->left;
+    tmp = (byte*)aes->tmp + WC_AES_BLOCK_SIZE - aes->left;
     while (aes->left && sz) {
         *(out++) = *(in++) ^ *(tmp++);
         aes->left--;
@@ -339,7 +339,7 @@ int wc_AesCtrEncrypt(Aes* aes, byte* out,
     }
 
     /* do full blocks to then get potential left over amount */
-    blocks = sz / AES_BLOCK_SIZE;
+    blocks = sz / WC_AES_BLOCK_SIZE;
     if (blocks > 0) {
         /* Set buffers for key, cipher text, and plain text */
         buf[0].BufferType = DataBuffer;
@@ -348,28 +348,28 @@ int wc_AesCtrEncrypt(Aes* aes, byte* out,
 
         buf[1].BufferType = DataBuffer;
         buf[1].TheAddress = (Address)aes->reg;
-        buf[1].Length     = AES_BLOCK_SIZE;
+        buf[1].Length     = WC_AES_BLOCK_SIZE;
 
         buf[2].BufferType = DataBuffer;
         buf[2].TheAddress = (Address)in;
-        buf[2].Length     = blocks * AES_BLOCK_SIZE;
+        buf[2].Length     = blocks * WC_AES_BLOCK_SIZE;
 
         buf[3].BufferType = DataBuffer | LastBuffer;
         buf[3].TheAddress = (Address)out;
-        buf[3].Length     = blocks * AES_BLOCK_SIZE;
+        buf[3].Length     = blocks * WC_AES_BLOCK_SIZE;
 
         arg[0] = CAAM_ENC;
         arg[1] = keySz;
-        arg[2] = blocks * AES_BLOCK_SIZE;
+        arg[2] = blocks * WC_AES_BLOCK_SIZE;
 
         if ((ret = wc_caamAddAndWait(buf, arg, CAAM_AESCTR)) != 0) {
             WOLFSSL_MSG("Error with CAAM AES CTR encrypt");
             return ret;
         }
 
-        out += blocks * AES_BLOCK_SIZE;
-        in  += blocks * AES_BLOCK_SIZE;
-        sz  -= blocks * AES_BLOCK_SIZE;
+        out += blocks * WC_AES_BLOCK_SIZE;
+        in  += blocks * WC_AES_BLOCK_SIZE;
+        sz  -= blocks * WC_AES_BLOCK_SIZE;
     }
 
     if (sz) {
@@ -377,7 +377,7 @@ int wc_AesCtrEncrypt(Aes* aes, byte* out,
             return ret;
         IncrementAesCounter((byte*)aes->reg);
 
-        aes->left = AES_BLOCK_SIZE;
+        aes->left = WC_AES_BLOCK_SIZE;
         tmp = (byte*)aes->tmp;
 
         while (sz--) {
@@ -415,15 +415,15 @@ int wc_AesEncryptDirect(Aes* aes, byte* out, const byte* in)
 
      buf[1].BufferType = DataBuffer;
      buf[1].TheAddress = (Address)in;
-     buf[1].Length     = AES_BLOCK_SIZE;
+     buf[1].Length     = WC_AES_BLOCK_SIZE;
 
      buf[2].BufferType = DataBuffer | LastBuffer;
      buf[2].TheAddress = (Address)out;
-     buf[2].Length     = AES_BLOCK_SIZE;
+     buf[2].Length     = WC_AES_BLOCK_SIZE;
 
      arg[0] = CAAM_ENC;
      arg[1] = keySz;
-     arg[2] = AES_BLOCK_SIZE;
+     arg[2] = WC_AES_BLOCK_SIZE;
 
      if ((ret = wc_caamAddAndWait(buf, arg, CAAM_AESECB)) != 0) {
          WOLFSSL_MSG("Error with CAAM AES direct encrypt");
@@ -456,15 +456,15 @@ int wc_AesDecryptDirect(Aes* aes, byte* out, const byte* in)
 
      buf[1].BufferType = DataBuffer;
      buf[1].TheAddress = (Address)in;
-     buf[1].Length     = AES_BLOCK_SIZE;
+     buf[1].Length     = WC_AES_BLOCK_SIZE;
 
      buf[2].BufferType = DataBuffer | LastBuffer;
      buf[2].TheAddress = (Address)out;
-     buf[2].Length     = AES_BLOCK_SIZE;
+     buf[2].Length     = WC_AES_BLOCK_SIZE;
 
      arg[0] = CAAM_DEC;
      arg[1] = keySz;
-     arg[2] = AES_BLOCK_SIZE;
+     arg[2] = WC_AES_BLOCK_SIZE;
 
      if ((ret = wc_caamAddAndWait(buf, arg, CAAM_AESECB)) != 0) {
          WOLFSSL_MSG("Error with CAAM AES direct decrypt");
@@ -493,7 +493,7 @@ int  wc_AesCcmEncrypt(Aes* aes, byte* out,
     word32 arg[4];
     word32 keySz;
     word32 i;
-    byte B0Ctr0[AES_BLOCK_SIZE + AES_BLOCK_SIZE];
+    byte B0Ctr0[WC_AES_BLOCK_SIZE + WC_AES_BLOCK_SIZE];
     int lenSz;
     byte mask = 0xFF;
     const word32 wordSz = (word32)sizeof(word32);
@@ -502,7 +502,7 @@ int  wc_AesCcmEncrypt(Aes* aes, byte* out,
     /* sanity check on arguments */
     if (aes == NULL || out == NULL || in == NULL || nonce == NULL
             || authTag == NULL || nonceSz < 7 || nonceSz > 13 ||
-        authTagSz > AES_BLOCK_SIZE)
+        authTagSz > WC_AES_BLOCK_SIZE)
         return BAD_FUNC_ARG;
 
     if ((ret = wc_AesCcmCheckTagSize(authTagSz)) != 0) {
@@ -515,18 +515,18 @@ int  wc_AesCcmEncrypt(Aes* aes, byte* out,
 
     /* set up B0 and CTR0 similar to how wolfcrypt/src/aes.c does */
     XMEMCPY(B0Ctr0+1, nonce, nonceSz);
-    XMEMCPY(B0Ctr0+AES_BLOCK_SIZE+1, nonce, nonceSz);
-    lenSz = AES_BLOCK_SIZE - 1 - (byte)nonceSz;
+    XMEMCPY(B0Ctr0+WC_AES_BLOCK_SIZE+1, nonce, nonceSz);
+    lenSz = WC_AES_BLOCK_SIZE - 1 - (byte)nonceSz;
     B0Ctr0[0] = (authInSz > 0 ? 64 : 0)
          + (8 * (((byte)authTagSz - 2) / 2))
          + (lenSz - 1);
     for (i = 0; i < lenSz; i++) {
         if (mask && i >= wordSz)
             mask = 0x00;
-        B0Ctr0[AES_BLOCK_SIZE - 1 - i] = (inSz >> ((8 * i) & mask)) & mask;
-        B0Ctr0[AES_BLOCK_SIZE + AES_BLOCK_SIZE - 1 - i] = 0;
+        B0Ctr0[WC_AES_BLOCK_SIZE - 1 - i] = (inSz >> ((8 * i) & mask)) & mask;
+        B0Ctr0[WC_AES_BLOCK_SIZE + WC_AES_BLOCK_SIZE - 1 - i] = 0;
     }
-    B0Ctr0[AES_BLOCK_SIZE] = lenSz - 1;
+    B0Ctr0[WC_AES_BLOCK_SIZE] = lenSz - 1;
 
     /* Set buffers for key, cipher text, and plain text */
     buf[0].BufferType = DataBuffer;
@@ -535,7 +535,7 @@ int  wc_AesCcmEncrypt(Aes* aes, byte* out,
 
     buf[1].BufferType = DataBuffer;
     buf[1].TheAddress = (Address)B0Ctr0;
-    buf[1].Length     = AES_BLOCK_SIZE + AES_BLOCK_SIZE;
+    buf[1].Length     = WC_AES_BLOCK_SIZE + WC_AES_BLOCK_SIZE;
 
     buf[2].BufferType = DataBuffer;
     buf[2].TheAddress = (Address)authIn;
@@ -575,8 +575,8 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out,
     word32 arg[4];
     word32 keySz;
     word32 i;
-    byte B0Ctr0[AES_BLOCK_SIZE + AES_BLOCK_SIZE];
-    byte tag[AES_BLOCK_SIZE];
+    byte B0Ctr0[WC_AES_BLOCK_SIZE + WC_AES_BLOCK_SIZE];
+    byte tag[WC_AES_BLOCK_SIZE];
     int lenSz;
     byte mask = 0xFF;
     const word32 wordSz = (word32)sizeof(word32);
@@ -585,7 +585,7 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out,
     /* sanity check on arguments */
     if (aes == NULL || out == NULL || in == NULL || nonce == NULL
             || authTag == NULL || nonceSz < 7 || nonceSz > 13 ||
-        authTagSz > AES_BLOCK_SIZE)
+        authTagSz > WC_AES_BLOCK_SIZE)
         return BAD_FUNC_ARG;
 
     if ((ret = wc_AesCcmCheckTagSize(authTagSz)) != 0) {
@@ -598,19 +598,19 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out,
 
     /* set up B0 and CTR0 similar to how wolfcrypt/src/aes.c does */
     XMEMCPY(B0Ctr0+1, nonce, nonceSz);
-    XMEMCPY(B0Ctr0+AES_BLOCK_SIZE+1, nonce, nonceSz);
-    lenSz = AES_BLOCK_SIZE - 1 - (byte)nonceSz;
+    XMEMCPY(B0Ctr0+WC_AES_BLOCK_SIZE+1, nonce, nonceSz);
+    lenSz = WC_AES_BLOCK_SIZE - 1 - (byte)nonceSz;
     B0Ctr0[0] = (authInSz > 0 ? 64 : 0)
          + (8 * (((byte)authTagSz - 2) / 2))
          + (lenSz - 1);
     for (i = 0; i < lenSz; i++) {
         if (mask && i >= wordSz)
             mask = 0x00;
-        B0Ctr0[AES_BLOCK_SIZE - 1 - i] = (inSz >> ((8 * i) & mask)) & mask;
-        B0Ctr0[AES_BLOCK_SIZE + AES_BLOCK_SIZE - 1 - i] = 0;
+        B0Ctr0[WC_AES_BLOCK_SIZE - 1 - i] = (inSz >> ((8 * i) & mask)) & mask;
+        B0Ctr0[WC_AES_BLOCK_SIZE + WC_AES_BLOCK_SIZE - 1 - i] = 0;
     }
-    B0Ctr0[AES_BLOCK_SIZE] = lenSz - 1;
-    if ((ret = wc_AesEncryptDirect(aes, tag, B0Ctr0 + AES_BLOCK_SIZE)) != 0)
+    B0Ctr0[WC_AES_BLOCK_SIZE] = lenSz - 1;
+    if ((ret = wc_AesEncryptDirect(aes, tag, B0Ctr0 + WC_AES_BLOCK_SIZE)) != 0)
         return ret;
 
     /* Set buffers for key, cipher text, and plain text */
@@ -620,7 +620,7 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out,
 
     buf[1].BufferType = DataBuffer;
     buf[1].TheAddress = (Address)B0Ctr0;
-    buf[1].Length     = AES_BLOCK_SIZE + AES_BLOCK_SIZE;
+    buf[1].Length     = WC_AES_BLOCK_SIZE + WC_AES_BLOCK_SIZE;
 
     buf[2].BufferType = DataBuffer;
     buf[2].TheAddress = (Address)authIn;
@@ -653,8 +653,8 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out,
         ret = AES_CCM_AUTH_E;
     }
 
-    ForceZero(tag, AES_BLOCK_SIZE);
-    ForceZero(B0Ctr0, AES_BLOCK_SIZE * 2);
+    ForceZero(tag, WC_AES_BLOCK_SIZE);
+    ForceZero(B0Ctr0, WC_AES_BLOCK_SIZE * 2);
 
     return ret;
 

--- a/wolfcrypt/src/port/caam/wolfcaam_aes.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_aes.c
@@ -122,8 +122,8 @@ static word32 CreateB0CTR(byte* B0Ctr0, const byte* nonce, word32 nonceSz,
 
     /* set up B0 and CTR0 similar to how wolfcrypt/src/aes.c does */
     XMEMCPY(B0Ctr0+1, nonce, nonceSz);
-    XMEMCPY(B0Ctr0+AES_BLOCK_SIZE+1, nonce, nonceSz);
-    lenSz = AES_BLOCK_SIZE - 1 - (byte)nonceSz;
+    XMEMCPY(B0Ctr0+WC_AES_BLOCK_SIZE+1, nonce, nonceSz);
+    lenSz = WC_AES_BLOCK_SIZE - 1 - (byte)nonceSz;
     B0Ctr0[0] = 0;
     if (authInSz > 0) {
         B0Ctr0[0] |= 0x40; /* set aad bit */
@@ -139,10 +139,10 @@ static word32 CreateB0CTR(byte* B0Ctr0, const byte* nonce, word32 nonceSz,
     for (i = 0; i < lenSz; i++) {
         if (mask && i >= wordSz)
             mask = 0x00;
-        B0Ctr0[AES_BLOCK_SIZE - 1 - i] = (inSz >> ((8 * i) & mask)) & mask;
-        B0Ctr0[AES_BLOCK_SIZE + AES_BLOCK_SIZE - 1 - i] = 0;
+        B0Ctr0[WC_AES_BLOCK_SIZE - 1 - i] = (inSz >> ((8 * i) & mask)) & mask;
+        B0Ctr0[WC_AES_BLOCK_SIZE + WC_AES_BLOCK_SIZE - 1 - i] = 0;
     }
-    B0Ctr0[AES_BLOCK_SIZE] = lenSz - 1;
+    B0Ctr0[WC_AES_BLOCK_SIZE] = lenSz - 1;
 
     return 0;
 }
@@ -157,12 +157,12 @@ int wc_CAAM_AesCcmEncrypt(Aes* aes, const byte* in, byte* out, word32 sz,
         const byte* authIn, word32 authInSz)
 {
 #ifndef WOLFSSL_SECO_CAAM
-    byte B0Ctr0[AES_BLOCK_SIZE + AES_BLOCK_SIZE];
+    byte B0Ctr0[WC_AES_BLOCK_SIZE + WC_AES_BLOCK_SIZE];
 #endif
 
     if (aes == NULL || (sz != 0 && (in == NULL || out == NULL)) ||
         nonce == NULL || authTag == NULL || nonceSz < 7 || nonceSz > 13 ||
-            authTagSz > AES_BLOCK_SIZE)
+            authTagSz > WC_AES_BLOCK_SIZE)
         return BAD_FUNC_ARG;
 
     /* sanity check on tag size */
@@ -172,7 +172,7 @@ int wc_CAAM_AesCcmEncrypt(Aes* aes, const byte* in, byte* out, word32 sz,
 
 #ifndef WOLFSSL_SECO_CAAM
     CreateB0CTR(B0Ctr0, nonce, nonceSz, authInSz, authTagSz, sz);
-    return wc_CAAM_AesAeadCommon(aes, in, out, sz, B0Ctr0, 2*AES_BLOCK_SIZE,
+    return wc_CAAM_AesAeadCommon(aes, in, out, sz, B0Ctr0, 2*WC_AES_BLOCK_SIZE,
         authTag, authTagSz, authIn, authInSz, CAAM_ENC, CAAM_AESCCM);
 #else
     return wc_CAAM_AesAeadCommon(aes, in, out, sz, nonce, nonceSz,
@@ -190,13 +190,13 @@ int wc_CAAM_AesCcmDecrypt(Aes* aes, const byte* in, byte* out, word32 sz,
 {
     int ret;
 #ifndef WOLFSSL_SECO_CAAM
-    byte B0Ctr0[AES_BLOCK_SIZE + AES_BLOCK_SIZE];
+    byte B0Ctr0[WC_AES_BLOCK_SIZE + WC_AES_BLOCK_SIZE];
 #endif
 
     /* sanity check on arguments */
     if (aes == NULL || (sz != 0 && (in == NULL || out == NULL)) ||
         nonce == NULL || authTag == NULL || nonceSz < 7 || nonceSz > 13 ||
-        authTagSz > AES_BLOCK_SIZE)
+        authTagSz > WC_AES_BLOCK_SIZE)
         return BAD_FUNC_ARG;
 
     /* sanity check on tag size */
@@ -206,7 +206,7 @@ int wc_CAAM_AesCcmDecrypt(Aes* aes, const byte* in, byte* out, word32 sz,
 
 #ifndef WOLFSSL_SECO_CAAM
     CreateB0CTR(B0Ctr0, nonce, nonceSz, authInSz, authTagSz, sz);
-    ret = wc_CAAM_AesAeadCommon(aes, in, out, sz, B0Ctr0, 2*AES_BLOCK_SIZE,
+    ret = wc_CAAM_AesAeadCommon(aes, in, out, sz, B0Ctr0, 2*WC_AES_BLOCK_SIZE,
             (byte*)authTag, authTagSz, authIn, authInSz, CAAM_DEC, CAAM_AESCCM);
 #else
     ret = wc_CAAM_AesAeadCommon(aes, in, out, sz, nonce, nonceSz,
@@ -260,7 +260,7 @@ static int wc_CAAM_AesCbcCtrCommon(Aes* aes, byte* out, const byte* in,
         return BAD_FUNC_ARG;
     }
 
-    blocks = sz / AES_BLOCK_SIZE;
+    blocks = sz / WC_AES_BLOCK_SIZE;
 
     if (blocks > 0) {
         CAAM_BUFFER buf[5];
@@ -279,24 +279,24 @@ static int wc_CAAM_AesCbcCtrCommon(Aes* aes, byte* out, const byte* in,
 
         buf[1].BufferType = DataBuffer;
         buf[1].TheAddress = (CAAM_ADDRESS)aes->reg;
-        buf[1].Length     = AES_BLOCK_SIZE;
+        buf[1].Length     = WC_AES_BLOCK_SIZE;
 
         buf[2].BufferType = DataBuffer;
         buf[2].TheAddress = (CAAM_ADDRESS)in;
-        buf[2].Length     = blocks * AES_BLOCK_SIZE;
+        buf[2].Length     = blocks * WC_AES_BLOCK_SIZE;
 
         buf[3].BufferType = DataBuffer | LastBuffer;
         buf[3].TheAddress = (CAAM_ADDRESS)out;
-        buf[3].Length     = blocks * AES_BLOCK_SIZE;
+        buf[3].Length     = blocks * WC_AES_BLOCK_SIZE;
 
         /* buffer for updated IV */
         buf[4].BufferType = DataBuffer;
         buf[4].TheAddress = (CAAM_ADDRESS)aes->reg;
-        buf[4].Length     = AES_BLOCK_SIZE;
+        buf[4].Length     = WC_AES_BLOCK_SIZE;
 
         arg[0] = dir;
         arg[1] = keySz;
-        arg[2] = blocks * AES_BLOCK_SIZE;
+        arg[2] = blocks * WC_AES_BLOCK_SIZE;
         arg[3] = aes->blackKey;
 
         if ((ret = wc_caamAddAndWait(buf, 5, arg, mode)) != 0) {
@@ -314,7 +314,7 @@ static WC_INLINE void IncrementAesCounter(byte* inOutCtr)
 {
     /* in network byte order so start at end and work back */
     int i;
-    for (i = AES_BLOCK_SIZE - 1; i >= 0; i--) {
+    for (i = WC_AES_BLOCK_SIZE - 1; i >= 0; i--) {
         if (++inOutCtr[i])  /* we're done unless we overflow */
             return;
     }
@@ -335,7 +335,7 @@ int wc_CAAM_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     }
 
     /* consume any unused bytes left in aes->tmp */
-    tmp = (byte*)aes->tmp + AES_BLOCK_SIZE - aes->left;
+    tmp = (byte*)aes->tmp + WC_AES_BLOCK_SIZE - aes->left;
     while (aes->left && sz) {
         *(out++) = *(in++) ^ *(tmp++);
         aes->left--;
@@ -343,14 +343,14 @@ int wc_CAAM_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     }
 
     /* do full blocks to then get potential left over amount */
-    blocks = sz / AES_BLOCK_SIZE;
+    blocks = sz / WC_AES_BLOCK_SIZE;
     if (blocks > 0) {
-        ret = wc_CAAM_AesCbcCtrCommon(aes, out, in, blocks * AES_BLOCK_SIZE,
+        ret = wc_CAAM_AesCbcCtrCommon(aes, out, in, blocks * WC_AES_BLOCK_SIZE,
             CAAM_ENC, CAAM_AESCTR);
 
-        out += blocks * AES_BLOCK_SIZE;
-        in  += blocks * AES_BLOCK_SIZE;
-        sz  -= blocks * AES_BLOCK_SIZE;
+        out += blocks * WC_AES_BLOCK_SIZE;
+        in  += blocks * WC_AES_BLOCK_SIZE;
+        sz  -= blocks * WC_AES_BLOCK_SIZE;
     }
 
     if (sz) {
@@ -360,7 +360,7 @@ int wc_CAAM_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
         }
         IncrementAesCounter((byte*)aes->reg);
 
-        aes->left = AES_BLOCK_SIZE;
+        aes->left = WC_AES_BLOCK_SIZE;
         tmp = (byte*)aes->tmp;
 
         while (sz--) {
@@ -399,7 +399,7 @@ static int wc_CAAM_AesEcbCommon(Aes* aes, byte* out, const byte* in, word32 sz,
         return BAD_FUNC_ARG;
     }
 
-    blocks = sz / AES_BLOCK_SIZE;
+    blocks = sz / WC_AES_BLOCK_SIZE;
 
     if (wc_AesGetKeySize(aes, &keySz) != 0 && aes->blackKey == 0) {
         return BAD_FUNC_ARG;
@@ -413,17 +413,17 @@ static int wc_CAAM_AesEcbCommon(Aes* aes, byte* out, const byte* in, word32 sz,
 
     buf[idx].BufferType = DataBuffer;
     buf[idx].TheAddress = (CAAM_ADDRESS)in;
-    buf[idx].Length     = blocks * AES_BLOCK_SIZE;
+    buf[idx].Length     = blocks * WC_AES_BLOCK_SIZE;
     idx++;
 
     buf[idx].BufferType = DataBuffer | LastBuffer;
     buf[idx].TheAddress = (CAAM_ADDRESS)out;
-    buf[idx].Length     = blocks * AES_BLOCK_SIZE;
+    buf[idx].Length     = blocks * WC_AES_BLOCK_SIZE;
     idx++;
 
     arg[0] = dir;
     arg[1] = keySz;
-    arg[2] = blocks * AES_BLOCK_SIZE;
+    arg[2] = blocks * WC_AES_BLOCK_SIZE;
     arg[3] = aes->blackKey;
 
     if ((ret = wc_caamAddAndWait(buf, idx, arg, CAAM_AESECB)) != 0) {
@@ -435,7 +435,7 @@ static int wc_CAAM_AesEcbCommon(Aes* aes, byte* out, const byte* in, word32 sz,
 }
 
 
-/* is assumed that input size is a multiple of AES_BLOCK_SIZE */
+/* is assumed that input size is a multiple of WC_AES_BLOCK_SIZE */
 int wc_CAAM_AesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
     return wc_CAAM_AesEcbCommon(aes, out, in, sz, CAAM_ENC);

--- a/wolfcrypt/src/port/caam/wolfcaam_cmac.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_cmac.c
@@ -39,7 +39,7 @@ int wc_CAAM_Cmac(Cmac* cmac, const byte* key, word32 keySz, const byte* in,
     word32 args[4] = {0};
     CAAM_BUFFER buf[9];
     word32 idx = 0;
-    byte scratch[AES_BLOCK_SIZE];
+    byte scratch[WC_AES_BLOCK_SIZE];
     int ret;
     int blocks = 0;
 
@@ -70,7 +70,7 @@ int wc_CAAM_Cmac(Cmac* cmac, const byte* key, word32 keySz, const byte* in,
         cmac->keylen = keySz;
         cmac->initialized = 0;
         cmac->bufferSz = 0;
-        XMEMSET(cmac->buffer, 0, AES_BLOCK_SIZE);
+        XMEMSET(cmac->buffer, 0, WC_AES_BLOCK_SIZE);
         return 0;
     }
 
@@ -95,12 +95,12 @@ int wc_CAAM_Cmac(Cmac* cmac, const byte* key, word32 keySz, const byte* in,
         if (cmac->bufferSz > 0) {
             word32 add;
 
-            if (cmac->bufferSz > AES_BLOCK_SIZE) {
+            if (cmac->bufferSz > WC_AES_BLOCK_SIZE) {
                 WOLFSSL_MSG("Error with CMAC buffer size");
                 return -1;
             }
-            add = (sz < ((int)(AES_BLOCK_SIZE - cmac->bufferSz))) ? sz :
-                   (int)(AES_BLOCK_SIZE - cmac->bufferSz);
+            add = (sz < ((int)(WC_AES_BLOCK_SIZE - cmac->bufferSz))) ? sz :
+                   (int)(WC_AES_BLOCK_SIZE - cmac->bufferSz);
             XMEMCPY(&cmac->buffer[cmac->bufferSz], pt, add);
 
             cmac->bufferSz += add;
@@ -110,33 +110,33 @@ int wc_CAAM_Cmac(Cmac* cmac, const byte* key, word32 keySz, const byte* in,
 
         /* flash out temporary storage for block size if full and more data
          * is coming, otherwise hold it until final operation */
-        if (cmac->bufferSz == AES_BLOCK_SIZE && (sz > 0)) {
+        if (cmac->bufferSz == WC_AES_BLOCK_SIZE && (sz > 0)) {
             buf[idx].TheAddress = (CAAM_ADDRESS)scratch;
             buf[idx].Length = cmac->bufferSz;
             idx++;
             blocks++;
             cmac->bufferSz = 0;
-            XMEMCPY(scratch, (byte*)cmac->buffer, AES_BLOCK_SIZE);
+            XMEMCPY(scratch, (byte*)cmac->buffer, WC_AES_BLOCK_SIZE);
         }
 
         /* In order to trigger read of CTX state there needs to be some data
          * saved until final call */
-        if ((sz >= AES_BLOCK_SIZE) && (sz % AES_BLOCK_SIZE == 0)) {
+        if ((sz >= WC_AES_BLOCK_SIZE) && (sz % WC_AES_BLOCK_SIZE == 0)) {
 
             if (cmac->bufferSz > 0) {
                 /* this case should never be hit */
                 return BAD_FUNC_ARG;
             }
 
-            XMEMCPY(&cmac->buffer[0], pt + sz - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
-            cmac->bufferSz = AES_BLOCK_SIZE;
-            sz -= AES_BLOCK_SIZE;
+            XMEMCPY(&cmac->buffer[0], pt + sz - WC_AES_BLOCK_SIZE, WC_AES_BLOCK_SIZE);
+            cmac->bufferSz = WC_AES_BLOCK_SIZE;
+            sz -= WC_AES_BLOCK_SIZE;
         }
 
-        if (sz >= AES_BLOCK_SIZE) {
+        if (sz >= WC_AES_BLOCK_SIZE) {
             buf[idx].TheAddress = (CAAM_ADDRESS)pt;
-            buf[idx].Length = sz - (sz % AES_BLOCK_SIZE);
-            blocks += sz / AES_BLOCK_SIZE;
+            buf[idx].Length = sz - (sz % WC_AES_BLOCK_SIZE);
+            blocks += sz / WC_AES_BLOCK_SIZE;
             sz -= buf[idx].Length;
             pt += buf[idx].Length;
             idx++;
@@ -186,9 +186,9 @@ int wc_CAAM_Cmac(Cmac* cmac, const byte* key, word32 keySz, const byte* in,
 
     /* store leftovers */
     if (sz > 0) {
-        word32 add = (sz < (int)(AES_BLOCK_SIZE - cmac->bufferSz))?
+        word32 add = (sz < (int)(WC_AES_BLOCK_SIZE - cmac->bufferSz))?
                                               (word32)sz :
-                                              (AES_BLOCK_SIZE - cmac->bufferSz);
+                                              (WC_AES_BLOCK_SIZE - cmac->bufferSz);
 
         if (pt == NULL) {
             return MEMORY_E;

--- a/wolfcrypt/src/port/caam/wolfcaam_fsl_nxp.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_fsl_nxp.c
@@ -271,8 +271,8 @@ static int DoAesCBC(unsigned int args[4], CAAM_BUFFER *buf, int sz)
 
         /* store updated CBC state */
         XMEMCPY((byte*)buf[4].TheAddress,
-                (byte*)buf[2].TheAddress + buf[2].Length - AES_BLOCK_SIZE,
-                AES_BLOCK_SIZE);
+                (byte*)buf[2].TheAddress + buf[2].Length - WC_AES_BLOCK_SIZE,
+                WC_AES_BLOCK_SIZE);
     }
     else {
         status = CAAM_AES_EncryptCbc(CAAM, &hndl,
@@ -282,8 +282,8 @@ static int DoAesCBC(unsigned int args[4], CAAM_BUFFER *buf, int sz)
 
         /* store updated CBC state */
         XMEMCPY((byte*)buf[4].TheAddress,
-            (byte*)buf[3].TheAddress + buf[3].Length - AES_BLOCK_SIZE,
-            AES_BLOCK_SIZE);
+            (byte*)buf[3].TheAddress + buf[3].Length - WC_AES_BLOCK_SIZE,
+            WC_AES_BLOCK_SIZE);
     }
 
     if (status != kStatus_Success) {

--- a/wolfcrypt/src/port/caam/wolfcaam_seco.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_seco.c
@@ -829,8 +829,8 @@ static hsm_err_t wc_SECO_CMAC(unsigned int args[4], CAAM_BUFFER* buf, int sz)
         mac_args.payload_size = buf[2].Length;
 
         mac_args.mac      = (uint8_t*)buf[1].TheAddress;
-        mac_args.mac_size = (buf[1].Length < AES_BLOCK_SIZE)? buf[1].Length:
-                                                              AES_BLOCK_SIZE;
+        mac_args.mac_size = (buf[1].Length < WC_AES_BLOCK_SIZE)? buf[1].Length:
+                                                              WC_AES_BLOCK_SIZE;
     #ifdef DEBUG_SECO
         printf("CMAC arguments used:\n");
         printf("\tkey id       = %d\n", mac_args.key_identifier);
@@ -1105,7 +1105,7 @@ word32 wc_SECO_WrapKey(word32 keyId, byte* in, word32 inSz, byte* iv,
     }
 
     /* iv + key + tag */
-    wrappedKeySz = GCM_NONCE_MID_SZ + inSz + AES_BLOCK_SIZE;
+    wrappedKeySz = GCM_NONCE_MID_SZ + inSz + WC_AES_BLOCK_SIZE;
     wrappedKey = (byte*)XMALLOC(wrappedKeySz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (wrappedKey == NULL) {
         WOLFSSL_MSG("Error malloc'ing buffer for wrapped key");
@@ -1155,7 +1155,7 @@ word32 wc_SECO_WrapKey(word32 keyId, byte* in, word32 inSz, byte* iv,
 
     if (ret == 0) {
         ret = wc_AesGcmEncrypt(&aes, wrappedKey + ivSz, in, inSz,
-                wrappedKey, ivSz, wrappedKey + ivSz + inSz, AES_BLOCK_SIZE,
+                wrappedKey, ivSz, wrappedKey + ivSz + inSz, WC_AES_BLOCK_SIZE,
                 NULL, 0);
         if (ret != 0) {
             WOLFSSL_MSG("error with AES-GCM encrypt when wrapping key");

--- a/wolfcrypt/src/port/cavium/cavium_octeon_sync.c
+++ b/wolfcrypt/src/port/cavium/cavium_octeon_sync.c
@@ -506,12 +506,12 @@ static NOOPT int Octeon_AesGcm_SetIV(Aes* aes, byte* iv, word32 ivSz)
         }
         else {
             int blocks, remainder, i;
-            byte aesBlock[AES_BLOCK_SIZE];
+            byte aesBlock[WC_AES_BLOCK_SIZE];
 
-            blocks = ivSz / AES_BLOCK_SIZE;
-            remainder = ivSz % AES_BLOCK_SIZE;
+            blocks = ivSz / WC_AES_BLOCK_SIZE;
+            remainder = ivSz % WC_AES_BLOCK_SIZE;
 
-            for (i = 0; i < blocks; i++, iv += AES_BLOCK_SIZE)
+            for (i = 0; i < blocks; i++, iv += WC_AES_BLOCK_SIZE)
                 Octeon_GHASH_Update(iv);
 
             XMEMSET(aesBlock, 0, sizeof(aesBlock));
@@ -535,7 +535,7 @@ static NOOPT int Octeon_AesGcm_SetIV(Aes* aes, byte* iv, word32 ivSz)
 static NOOPT int Octeon_AesGcm_SetAAD(Aes* aes, byte* aad, word32 aadSz)
 {
     word64* p;
-    ALIGN16 byte aesBlock[AES_BLOCK_SIZE];
+    ALIGN16 byte aesBlock[WC_AES_BLOCK_SIZE];
     int blocks, remainder, i;
 
     if (aes == NULL || (aadSz != 0 && aad == NULL))
@@ -544,14 +544,14 @@ static NOOPT int Octeon_AesGcm_SetAAD(Aes* aes, byte* aad, word32 aadSz)
     if (aadSz == 0)
         return 0;
 
-    blocks = aadSz / AES_BLOCK_SIZE;
-    remainder = aadSz % AES_BLOCK_SIZE;
+    blocks = aadSz / WC_AES_BLOCK_SIZE;
+    remainder = aadSz % WC_AES_BLOCK_SIZE;
 
     Octeon_GHASH_Restore(0xe100, aes->H);
 
     p = (word64*)aesBlock;
 
-    for (i = 0; i < blocks; i++, aad += AES_BLOCK_SIZE) {
+    for (i = 0; i < blocks; i++, aad += WC_AES_BLOCK_SIZE) {
         CVMX_LOADUNA_INT64(p[0], aad, 0);
         CVMX_LOADUNA_INT64(p[1], aad, 8);
         CVMX_MT_GFM_XOR0(p[0]);
@@ -574,8 +574,8 @@ static int Octeon_AesGcm_SetEncrypt(Aes* aes, byte* in, byte* out, word32 inSz,
         int encrypt)
 {
     word32 i, blocks, remainder;
-    ALIGN16 byte aesBlockIn[AES_BLOCK_SIZE];
-    ALIGN16 byte aesBlockOut[AES_BLOCK_SIZE];
+    ALIGN16 byte aesBlockIn[WC_AES_BLOCK_SIZE];
+    ALIGN16 byte aesBlockOut[WC_AES_BLOCK_SIZE];
     word64* pIn;
     word64* pOut;
     word64* pIv;
@@ -592,11 +592,11 @@ static int Octeon_AesGcm_SetEncrypt(Aes* aes, byte* in, byte* out, word32 inSz,
     CVMX_MT_AES_ENC0(pIv[0]);
     CVMX_MT_AES_ENC1(pIv[1]);
 
-    blocks = inSz / AES_BLOCK_SIZE;
-    remainder = inSz % AES_BLOCK_SIZE;
+    blocks = inSz / WC_AES_BLOCK_SIZE;
+    remainder = inSz % WC_AES_BLOCK_SIZE;
 
     for (i = 0; i < blocks;
-            i++, in += AES_BLOCK_SIZE, out += AES_BLOCK_SIZE) {
+            i++, in += WC_AES_BLOCK_SIZE, out += WC_AES_BLOCK_SIZE) {
         CVMX_PREFETCH128(in);
         aes->reg[3]++;
 
@@ -623,7 +623,7 @@ static int Octeon_AesGcm_SetEncrypt(Aes* aes, byte* in, byte* out, word32 inSz,
     }
 
     if (remainder > 0) {
-        ALIGN16 byte aesBlockMask[AES_BLOCK_SIZE];
+        ALIGN16 byte aesBlockMask[WC_AES_BLOCK_SIZE];
         word64* pMask = (word64*)aesBlockMask;
 
         XMEMSET(aesBlockOut, 0, sizeof(aesBlockOut));
@@ -676,8 +676,8 @@ static NOOPT int Octeon_AesGcm_Finalize(Aes* aes, word32 inSz, word32 aadSz,
     word64* pIn;
     word64* pOut;
     uint32_t countSave;
-    ALIGN16 byte aesBlockIn[AES_BLOCK_SIZE];
-    ALIGN16 byte aesBlockOut[AES_BLOCK_SIZE];
+    ALIGN16 byte aesBlockIn[WC_AES_BLOCK_SIZE];
+    ALIGN16 byte aesBlockOut[WC_AES_BLOCK_SIZE];
 
     countSave = aes->reg[3];
     aes->reg[3] = aes->y0;

--- a/wolfcrypt/src/port/cuda/aes-cuda.cu
+++ b/wolfcrypt/src/port/cuda/aes-cuda.cu
@@ -957,18 +957,18 @@ void AesEncrypt_C(Aes* aes, const byte* inBlock, byte* outBlock,
 #endif
 
     if ( ret == cudaSuccess )
-        ret = cudaMalloc(&inBlock_GPU, AES_BLOCK_SIZE);
+        ret = cudaMalloc(&inBlock_GPU, WC_AES_BLOCK_SIZE);
     if ( ret == cudaSuccess )
-        ret = cudaMemcpy(inBlock_GPU, inBlock, AES_BLOCK_SIZE, cudaMemcpyDefault);
+        ret = cudaMemcpy(inBlock_GPU, inBlock, WC_AES_BLOCK_SIZE, cudaMemcpyDefault);
 
     if ( ret == cudaSuccess )
-        ret = cudaMalloc(&outBlock_GPU, AES_BLOCK_SIZE);
+        ret = cudaMalloc(&outBlock_GPU, WC_AES_BLOCK_SIZE);
 
     if ( ret == cudaSuccess )
         AesEncrypt_C_CUDA<<<1,1>>>(rk_GPU, inBlock_GPU, outBlock_GPU, r, 1);
 
     if ( ret == cudaSuccess )
-        ret = cudaMemcpy(outBlock, outBlock_GPU, AES_BLOCK_SIZE, cudaMemcpyDefault);
+        ret = cudaMemcpy(outBlock, outBlock_GPU, WC_AES_BLOCK_SIZE, cudaMemcpyDefault);
 
     cudaFree(inBlock_GPU);
     cudaFree(outBlock_GPU);
@@ -1013,8 +1013,8 @@ void AesEncryptBlocks_C(Aes* aes, const byte* in, byte* out, word32 sz)
 
     if ( ret == cudaSuccess ) {
         int blockSize = 256;
-        int numBlocks = (sz / AES_BLOCK_SIZE + blockSize - 1) / blockSize;
-        AesEncrypt_C_CUDA<<<numBlocks,blockSize>>>(rk_GPU, in_GPU, out_GPU, aes->rounds >> 1, sz / AES_BLOCK_SIZE);
+        int numBlocks = (sz / WC_AES_BLOCK_SIZE + blockSize - 1) / blockSize;
+        AesEncrypt_C_CUDA<<<numBlocks,blockSize>>>(rk_GPU, in_GPU, out_GPU, aes->rounds >> 1, sz / WC_AES_BLOCK_SIZE);
     }
 
     if ( ret == cudaSuccess )
@@ -1043,12 +1043,12 @@ void AesEncrypt_C_CUDA(Aes* aes, const byte* inBlock, byte* outBlock,
 
     (void)r;
 
-    XMEMCPY(state, inBlock, AES_BLOCK_SIZE);
-    XMEMSET(((byte*)state) + AES_BLOCK_SIZE, 0, sizeof(state) - AES_BLOCK_SIZE);
+    XMEMCPY(state, inBlock, WC_AES_BLOCK_SIZE);
+    XMEMSET(((byte*)state) + WC_AES_BLOCK_SIZE, 0, sizeof(state) - WC_AES_BLOCK_SIZE);
 
     bs_encrypt(state, aes->bs_key, aes->rounds);
 
-    XMEMCPY(outBlock, state, AES_BLOCK_SIZE);
+    XMEMCPY(outBlock, state, WC_AES_BLOCK_SIZE);
 }
 
 void AesEncrypt_C(Aes* aes, const byte* inBlock, byte* outBlock,

--- a/wolfcrypt/src/port/intel/quickassist_sync.c
+++ b/wolfcrypt/src/port/intel/quickassist_sync.c
@@ -970,7 +970,7 @@ static int IntelQaSymCipher(IntelQaDev* dev, byte* out, const byte* in,
     metaBuf = XMALLOC(metaSize, dev->heap, DYNAMIC_TYPE_ASYNC_NUMA);
     dataBuf = XMALLOC(dataLen, dev->heap, DYNAMIC_TYPE_ASYNC_NUMA);
     XMEMCPY(dataBuf, in, inOutSz);
-    ivBuf = XMALLOC(AES_BLOCK_SIZE, dev->heap, DYNAMIC_TYPE_ASYNC_NUMA);
+    ivBuf = XMALLOC(WC_AES_BLOCK_SIZE, dev->heap, DYNAMIC_TYPE_ASYNC_NUMA);
     XMEMCPY(ivBuf, iv, ivSz);
     authTagBuf = XMALLOC(authTagSz, dev->heap, DYNAMIC_TYPE_ASYNC_NUMA);
 
@@ -983,9 +983,9 @@ static int IntelQaSymCipher(IntelQaDev* dev, byte* out, const byte* in,
     /* AAD */
     if (authIn && authInSz > 0) {
         /* make sure AAD is block aligned */
-        if (authInSzAligned % AES_BLOCK_SIZE) {
-            authInSzAligned += AES_BLOCK_SIZE -
-                (authInSzAligned % AES_BLOCK_SIZE);
+        if (authInSzAligned % WC_AES_BLOCK_SIZE) {
+            authInSzAligned += WC_AES_BLOCK_SIZE -
+                (authInSzAligned % WC_AES_BLOCK_SIZE);
         }
 
         authInBuf = XMALLOC(authInSzAligned, dev->heap,
@@ -1125,7 +1125,7 @@ int IntelQaSymAesCbcEncrypt(IntelQaDev* dev,
         CPA_CY_SYM_CIPHER_DIRECTION_ENCRYPT,
         CPA_CY_SYM_HASH_NONE, NULL, 0, NULL, 0);
 
-    XMEMCPY((byte*)iv, out + sz - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
+    XMEMCPY((byte*)iv, out + sz - WC_AES_BLOCK_SIZE, WC_AES_BLOCK_SIZE);
     return ret;
 }
 
@@ -1135,17 +1135,17 @@ int IntelQaSymAesCbcDecrypt(IntelQaDev* dev,
             const byte* key, word32 keySz,
             const byte* iv, word32 ivSz)
 {
-    byte nextIv[AES_BLOCK_SIZE];
+    byte nextIv[WC_AES_BLOCK_SIZE];
     int ret;
 
-    XMEMCPY(nextIv, in + sz - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
+    XMEMCPY(nextIv, in + sz - WC_AES_BLOCK_SIZE, WC_AES_BLOCK_SIZE);
     ret = IntelQaSymCipher(dev, out, in, sz,
         key, keySz, iv, ivSz,
         CPA_CY_SYM_OP_CIPHER, CPA_CY_SYM_CIPHER_AES_CBC,
         CPA_CY_SYM_CIPHER_DIRECTION_DECRYPT,
         CPA_CY_SYM_HASH_NONE, NULL, 0, NULL, 0);
 
-    XMEMCPY((byte*)iv, nextIv, AES_BLOCK_SIZE);
+    XMEMCPY((byte*)iv, nextIv, WC_AES_BLOCK_SIZE);
     return ret;
 }
 #endif /* HAVE_AES_DECRYPT */
@@ -1241,7 +1241,7 @@ int IntelQaSymSync_CryptoDevCb(int devId, struct wc_CryptoInfo* info, void* ctx)
                         info->cipher.aescbc.in,
                         info->cipher.aescbc.sz,
                         (byte*)aes->devKey, aes->keylen,
-                        (byte*)aes->reg, AES_BLOCK_SIZE);
+                        (byte*)aes->reg, WC_AES_BLOCK_SIZE);
             }
             else {
                 rc = IntelQaSymAesCbcDecrypt(dev,
@@ -1249,7 +1249,7 @@ int IntelQaSymSync_CryptoDevCb(int devId, struct wc_CryptoInfo* info, void* ctx)
                         info->cipher.aescbc.in,
                         info->cipher.aescbc.sz,
                         (byte*)aes->devKey, aes->keylen,
-                        (byte*)aes->reg, AES_BLOCK_SIZE);
+                        (byte*)aes->reg, WC_AES_BLOCK_SIZE);
             }
         }
         #endif /* !NO_AES */

--- a/wolfcrypt/src/port/kcapi/kcapi_aes.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_aes.c
@@ -123,7 +123,7 @@
         struct iovec iov;
 
         if (aes == NULL || out == NULL || in == NULL || \
-                                                     sz % AES_BLOCK_SIZE != 0) {
+                                                     sz % WC_AES_BLOCK_SIZE != 0) {
             ret = BAD_FUNC_ARG;
         }
 
@@ -243,7 +243,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     /* argument checks */
     if ((aes == NULL) || ((sz != 0 && (in == NULL || out == NULL))) ||
         (iv == NULL) || ((authTag == NULL) && (authTagSz > 0)) ||
-        (authTagSz > AES_BLOCK_SIZE) || ((authIn == NULL) && (authInSz > 0))) {
+        (authTagSz > WC_AES_BLOCK_SIZE) || ((authIn == NULL) && (authInSz > 0))) {
         ret = BAD_FUNC_ARG;
     }
 
@@ -356,7 +356,7 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     /* argument checks */
     if ((aes == NULL) || ((sz != 0 && (in == NULL || out == NULL))) ||
         (iv == NULL) || ((authTag == NULL) && (authTagSz > 0)) ||
-        (authTagSz > AES_BLOCK_SIZE) || ((authIn == NULL) && (authInSz > 0))) {
+        (authTagSz > WC_AES_BLOCK_SIZE) || ((authIn == NULL) && (authInSz > 0))) {
         ret = BAD_FUNC_ARG;
     }
 

--- a/wolfcrypt/src/port/maxim/max3266x.c
+++ b/wolfcrypt/src/port/maxim/max3266x.c
@@ -435,7 +435,7 @@ int wc_MxcCb_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     }
 
     /* Always enforce a length check */
-    if (sz % AES_BLOCK_SIZE) {
+    if (sz % WC_AES_BLOCK_SIZE) {
     #ifdef WOLFSSL_AES_CBC_LENGTH_CHECKS
         return BAD_LENGTH_E;
     #else
@@ -457,7 +457,7 @@ int wc_MxcCb_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
                                     (unsigned int)keySize);
     /* store iv for next call */
     if (status == 0) {
-        XMEMCPY(iv, out + sz - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
+        XMEMCPY(iv, out + sz - WC_AES_BLOCK_SIZE, WC_AES_BLOCK_SIZE);
     }
     return (status == 0) ? 0 : -1;
 }
@@ -545,14 +545,14 @@ int wc_MxcCb_AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     word32 keySize;
     int status;
     byte *iv;
-    byte temp_block[AES_BLOCK_SIZE];
+    byte temp_block[WC_AES_BLOCK_SIZE];
 
     if ((in == NULL) || (out == NULL) || (aes == NULL)) {
         return BAD_FUNC_ARG;
     }
 
     /* Always enforce a length check */
-    if (sz % AES_BLOCK_SIZE) {
+    if (sz % WC_AES_BLOCK_SIZE) {
     #ifdef WOLFSSL_AES_CBC_LENGTH_CHECKS
         return BAD_LENGTH_E;
     #else
@@ -570,14 +570,14 @@ int wc_MxcCb_AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     }
 
     /* get IV for next call */
-    XMEMCPY(temp_block, in + sz - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
+    XMEMCPY(temp_block, in + sz - WC_AES_BLOCK_SIZE, WC_AES_BLOCK_SIZE);
     status = wc_MXC_TPU_AesDecrypt(in, iv, (byte*)aes->devKey,
                                     MXC_TPU_MODE_CBC, sz, out,
                                     keySize);
 
     /* store iv for next call */
     if (status == 0) {
-        XMEMCPY(iv, temp_block, AES_BLOCK_SIZE);
+        XMEMCPY(iv, temp_block, WC_AES_BLOCK_SIZE);
     }
     return (status == 0) ? 0 : -1;
 }

--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -255,7 +255,7 @@ int  DCPAesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     if (ret)
         ret = WC_HW_E;
     else
-        XMEMCPY(aes->reg, out, AES_BLOCK_SIZE);
+        XMEMCPY(aes->reg, out, WC_AES_BLOCK_SIZE);
     dcp_unlock();
     return ret;
 }
@@ -270,7 +270,7 @@ int  DCPAesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     if (ret)
         ret = WC_HW_E;
     else
-        XMEMCPY(aes->reg, in, AES_BLOCK_SIZE);
+        XMEMCPY(aes->reg, in, WC_AES_BLOCK_SIZE);
     dcp_unlock();
     return ret;
 }

--- a/wolfcrypt/src/port/psa/psa_aes.c
+++ b/wolfcrypt/src/port/psa/psa_aes.c
@@ -293,7 +293,7 @@ int wc_psa_aes_free(Aes *aes)
 int wc_AesEncrypt(Aes *aes, const byte *inBlock, byte *outBlock)
 {
     return wc_psa_aes_encrypt_decrypt(aes, inBlock, outBlock,
-                                      AES_BLOCK_SIZE, PSA_ALG_ECB_NO_PADDING,
+                                      WC_AES_BLOCK_SIZE, PSA_ALG_ECB_NO_PADDING,
                                       AES_ENCRYPTION);
 }
 
@@ -301,7 +301,7 @@ int wc_AesEncrypt(Aes *aes, const byte *inBlock, byte *outBlock)
 int wc_AesDecrypt(Aes *aes, const byte *inBlock, byte *outBlock)
 {
     return wc_psa_aes_encrypt_decrypt(aes, inBlock, outBlock,
-                                      AES_BLOCK_SIZE, PSA_ALG_ECB_NO_PADDING,
+                                      WC_AES_BLOCK_SIZE, PSA_ALG_ECB_NO_PADDING,
                                       AES_DECRYPTION);
 }
 #endif
@@ -319,7 +319,7 @@ int wc_AesCtrEncrypt(Aes *aes, byte *out, const byte *in, word32 sz)
 int wc_AesCbcEncrypt(Aes *aes, byte *out, const byte *in, word32 sz)
 {
 
-    if (sz % AES_BLOCK_SIZE != 0)
+    if (sz % WC_AES_BLOCK_SIZE != 0)
 #if defined (WOLFSSL_AES_CBC_LENGTH_CHECKS)
         return BAD_LENGTH_E;
 #else
@@ -334,7 +334,7 @@ int wc_AesCbcEncrypt(Aes *aes, byte *out, const byte *in, word32 sz)
 int wc_AesCbcDecrypt(Aes *aes, byte *out, const byte *in, word32 sz)
 {
 
-    if (sz % AES_BLOCK_SIZE != 0)
+    if (sz % WC_AES_BLOCK_SIZE != 0)
 #if defined (WOLFSSL_AES_CBC_LENGTH_CHECKS)
         return BAD_LENGTH_E;
 #else

--- a/wolfcrypt/src/port/riscv/riscv-64-aes.c
+++ b/wolfcrypt/src/port/riscv/riscv-64-aes.c
@@ -679,12 +679,12 @@ static void wc_AesDecrypt(Aes* aes, const byte* in, byte* out)
  * @param pin]  sz   Number of bytes to encrypt.
  * @return  0 on success.
  * @return  BAD_FUNC_ARG when aes, out or in is NULL.
- * @return  BAD_LENGTH_E when sz is not a multiple of AES_BLOCK_SIZE.
+ * @return  BAD_LENGTH_E when sz is not a multiple of WC_AES_BLOCK_SIZE.
  */
 int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
     int ret = 0;
-    word32 blocks = sz / AES_BLOCK_SIZE;
+    word32 blocks = sz / WC_AES_BLOCK_SIZE;
 
     /* Validate parameters. */
     if ((aes == NULL) || (out == NULL) || (in == NULL)) {
@@ -692,7 +692,7 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     }
 #ifdef WOLFSSL_AES_CBC_LENGTH_CHECKS
     /* Ensure a multiple of blocks is to be encrypted.  */
-    if ((ret == 0) && (sz % AES_BLOCK_SIZE)) {
+    if ((ret == 0) && (sz % WC_AES_BLOCK_SIZE)) {
         ret = BAD_LENGTH_E;
     }
 #endif
@@ -890,20 +890,20 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
  * @param pin]  sz   Number of bytes to decrypt.
  * @return  0 on success.
  * @return  BAD_FUNC_ARG when aes, out or in is NULL.
- * @return  BAD_FUNC_ARG when sz is not a multiple of AES_BLOCK_SIZE.
- * @return  BAD_LENGTH_E when sz is not a multiple of AES_BLOCK_SIZE.
+ * @return  BAD_FUNC_ARG when sz is not a multiple of WC_AES_BLOCK_SIZE.
+ * @return  BAD_LENGTH_E when sz is not a multiple of WC_AES_BLOCK_SIZE.
  */
 int wc_AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
     int ret = 0;
-    word32 blocks = sz / AES_BLOCK_SIZE;
+    word32 blocks = sz / WC_AES_BLOCK_SIZE;
 
     /* Validate parameters. */
     if ((aes == NULL) || (out == NULL) || (in == NULL)) {
         ret = BAD_FUNC_ARG;
     }
     /* Ensure a multiple of blocks is being decrypted.  */
-    if ((ret == 0) && (sz % AES_BLOCK_SIZE)) {
+    if ((ret == 0) && (sz % WC_AES_BLOCK_SIZE)) {
 #ifdef WOLFSSL_AES_CBC_LENGTH_CHECKS
         ret = BAD_LENGTH_E;
 #else
@@ -1377,7 +1377,7 @@ int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
         processed = min(aes->left, sz);
         if (processed > 0) {
             /* XOR in encrypted counter.  */
-            xorbufout(out, in, (byte*)aes->tmp + AES_BLOCK_SIZE - aes->left,
+            xorbufout(out, in, (byte*)aes->tmp + WC_AES_BLOCK_SIZE - aes->left,
                 processed);
             out += processed;
             in += processed;
@@ -1386,12 +1386,12 @@ int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
         }
 
         /* Do whole blocks of data. */
-        while (sz >= AES_BLOCK_SIZE) {
-            word32 blocks = sz / AES_BLOCK_SIZE;
+        while (sz >= WC_AES_BLOCK_SIZE) {
+            word32 blocks = sz / WC_AES_BLOCK_SIZE;
 
             wc_aes_ctr_encrypt_asm(aes, out, in, blocks);
 
-            processed = blocks * AES_BLOCK_SIZE;
+            processed = blocks * WC_AES_BLOCK_SIZE;
             out += processed;
             in  += processed;
             sz  -= processed;
@@ -1402,14 +1402,14 @@ int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
             /* Encrypt counter and store in aes->tmp.
              * Use up aes->tmp to encrypt data less than a block.
              */
-            static const byte zeros[AES_BLOCK_SIZE] = {
+            static const byte zeros[WC_AES_BLOCK_SIZE] = {
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
             };
 
             wc_aes_ctr_encrypt_asm(aes, (byte*)aes->tmp, zeros, 1);
             /* XOR in encrypted counter. */
             xorbufout(out, in, aes->tmp, sz);
-            aes->left = AES_BLOCK_SIZE - sz;
+            aes->left = WC_AES_BLOCK_SIZE - sz;
         }
     }
 
@@ -3861,12 +3861,12 @@ static WC_INLINE void xorbufout16(byte* out, const byte* a, const byte* b)
  * @param pin]  sz   Number of bytes to encrypt.
  * @return  0 on success.
  * @return  BAD_FUNC_ARG when aes, out or in is NULL.
- * @return  BAD_LENGTH_E when sz is not a multiple of AES_BLOCK_SIZE.
+ * @return  BAD_LENGTH_E when sz is not a multiple of WC_AES_BLOCK_SIZE.
  */
 int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
     int ret = 0;
-    word32 blocks = sz / AES_BLOCK_SIZE;
+    word32 blocks = sz / WC_AES_BLOCK_SIZE;
 
     /* Validate parameters. */
     if ((aes == NULL) || (out == NULL) || (in == NULL)) {
@@ -3874,7 +3874,7 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     }
 #ifdef WOLFSSL_AES_CBC_LENGTH_CHECKS
     /* Ensure a multiple of blocks is to be encrypted.  */
-    if ((ret == 0) && (sz % AES_BLOCK_SIZE)) {
+    if ((ret == 0) && (sz % WC_AES_BLOCK_SIZE)) {
         ret = BAD_LENGTH_E;
     }
 #endif
@@ -3884,17 +3884,17 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
             /* Encrypt first block with IV. */
             xorbufout16(out, (byte*)aes->reg, in);
             wc_AesEncrypt(aes, out, out);
-            in += AES_BLOCK_SIZE;
-            out += AES_BLOCK_SIZE;
+            in += WC_AES_BLOCK_SIZE;
+            out += WC_AES_BLOCK_SIZE;
             for (blocks--; blocks > 0; blocks--) {
                 /* Encrypt a block with previous output block as IV. */
-                xorbufout16(out, out - AES_BLOCK_SIZE, in);
+                xorbufout16(out, out - WC_AES_BLOCK_SIZE, in);
                 wc_AesEncrypt(aes, out, out);
-                in += AES_BLOCK_SIZE;
-                out += AES_BLOCK_SIZE;
+                in += WC_AES_BLOCK_SIZE;
+                out += WC_AES_BLOCK_SIZE;
             }
             /* Copy last output block into AES object as next IV. */
-            memcpy16((byte*)aes->reg, out - AES_BLOCK_SIZE);
+            memcpy16((byte*)aes->reg, out - WC_AES_BLOCK_SIZE);
         }
         /* in and out are same buffer. */
         else {
@@ -3902,15 +3902,15 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
             /* Encrypt first block with IV. */
             xorbuf16(data, (byte*)aes->reg);
             wc_AesEncrypt(aes, data, data);
-            data += AES_BLOCK_SIZE;
+            data += WC_AES_BLOCK_SIZE;
             for (blocks--; blocks > 0; blocks--) {
                 /* Encrypt a block with previous output block as IV. */
-                xorbuf16(data, data - AES_BLOCK_SIZE);
+                xorbuf16(data, data - WC_AES_BLOCK_SIZE);
                 wc_AesEncrypt(aes, data, data);
-                data += AES_BLOCK_SIZE;
+                data += WC_AES_BLOCK_SIZE;
             }
             /* Copy last output block into AES object as next IV. */
-            memcpy16((byte*)aes->reg, data - AES_BLOCK_SIZE);
+            memcpy16((byte*)aes->reg, data - WC_AES_BLOCK_SIZE);
         }
     }
 
@@ -3928,20 +3928,20 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
  * @param pin]  sz   Number of bytes to decrypt.
  * @return  0 on success.
  * @return  BAD_FUNC_ARG when aes, out or in is NULL.
- * @return  BAD_FUNC_ARG when sz is not a multiple of AES_BLOCK_SIZE.
- * @return  BAD_LENGTH_E when sz is not a multiple of AES_BLOCK_SIZE.
+ * @return  BAD_FUNC_ARG when sz is not a multiple of WC_AES_BLOCK_SIZE.
+ * @return  BAD_LENGTH_E when sz is not a multiple of WC_AES_BLOCK_SIZE.
  */
 int wc_AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
     int ret = 0;
-    word32 blocks = sz / AES_BLOCK_SIZE;
+    word32 blocks = sz / WC_AES_BLOCK_SIZE;
 
     /* Validate parameters. */
     if ((aes == NULL) || (out == NULL) || (in == NULL)) {
         ret = BAD_FUNC_ARG;
     }
     /* Ensure a multiple of blocks is being decrypted.  */
-    if ((ret == 0) && (sz % AES_BLOCK_SIZE)) {
+    if ((ret == 0) && (sz % WC_AES_BLOCK_SIZE)) {
 #ifdef WOLFSSL_AES_CBC_LENGTH_CHECKS
         ret = BAD_LENGTH_E;
 #else
@@ -3954,17 +3954,17 @@ int wc_AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
             /* Decrypt first block with the IV. */
             wc_AesDecrypt(aes, in, out);
             xorbuf16(out, (byte*)aes->reg);
-            in += AES_BLOCK_SIZE;
-            out += AES_BLOCK_SIZE;
+            in += WC_AES_BLOCK_SIZE;
+            out += WC_AES_BLOCK_SIZE;
             for (blocks--; blocks > 0; blocks--) {
                 /* Decrypt a block with previous input block as IV. */
                 wc_AesDecrypt(aes, in, out);
-                xorbuf16(out, in - AES_BLOCK_SIZE);
-                in += AES_BLOCK_SIZE;
-                out += AES_BLOCK_SIZE;
+                xorbuf16(out, in - WC_AES_BLOCK_SIZE);
+                in += WC_AES_BLOCK_SIZE;
+                out += WC_AES_BLOCK_SIZE;
             }
             /* Copy last output block into AES object as next IV. */
-            memcpy16((byte*)aes->reg, in - AES_BLOCK_SIZE);
+            memcpy16((byte*)aes->reg, in - WC_AES_BLOCK_SIZE);
         }
         /* in and out are same buffer. */
         else {
@@ -3978,12 +3978,12 @@ int wc_AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
                     memcpy16((byte*)aes->reg, (byte*)aes->tmp);
                     break;
                 }
-                data += AES_BLOCK_SIZE;
+                data += WC_AES_BLOCK_SIZE;
                 /* Decrypt block with the IV in aes->tmp. */
                 memcpy16((byte*)aes->reg, data);
                 wc_AesDecrypt(aes, data, data);
                 xorbuf16(data, (byte*)aes->tmp);
-                data += AES_BLOCK_SIZE;
+                data += WC_AES_BLOCK_SIZE;
             }
         }
     }
@@ -4003,7 +4003,7 @@ int wc_AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
  * @param pin]  sz   Number of bytes to encrypt.
  * @return  0 on success.
  * @return  BAD_FUNC_ARG when aes, out or in is NULL.
- * @return  BAD_LENGTH_E when sz is not a multiple of AES_BLOCK_SIZE.
+ * @return  BAD_LENGTH_E when sz is not a multiple of WC_AES_BLOCK_SIZE.
  */
 int wc_AesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
@@ -4014,7 +4014,7 @@ int wc_AesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
         ret = BAD_FUNC_ARG;
     }
     /* Ensure a multiple of blocks is to be encrypted.  */
-    if ((ret == 0) && ((sz % AES_BLOCK_SIZE) != 0)) {
+    if ((ret == 0) && ((sz % WC_AES_BLOCK_SIZE) != 0)) {
         ret = BAD_LENGTH_E;
     }
 
@@ -4022,9 +4022,9 @@ int wc_AesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
         /* Encrypt block by block. */
         while (sz > 0) {
             wc_AesEncrypt(aes, in, out);
-            out += AES_BLOCK_SIZE;
-            in += AES_BLOCK_SIZE;
-            sz -= AES_BLOCK_SIZE;
+            out += WC_AES_BLOCK_SIZE;
+            in += WC_AES_BLOCK_SIZE;
+            sz -= WC_AES_BLOCK_SIZE;
         }
     }
 
@@ -4040,7 +4040,7 @@ int wc_AesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
  * @param pin]  sz   Number of bytes to encrypt.
  * @return  0 on success.
  * @return  BAD_FUNC_ARG when aes, out or in is NULL.
- * @return  BAD_LENGTH_E when sz is not a multiple of AES_BLOCK_SIZE.
+ * @return  BAD_LENGTH_E when sz is not a multiple of WC_AES_BLOCK_SIZE.
  */
 int wc_AesEcbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
@@ -4051,7 +4051,7 @@ int wc_AesEcbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
         ret = BAD_FUNC_ARG;
     }
     /* Ensure a multiple of blocks is to be decrypted.  */
-    if ((ret == 0) && ((sz % AES_BLOCK_SIZE) != 0)) {
+    if ((ret == 0) && ((sz % WC_AES_BLOCK_SIZE) != 0)) {
         ret = BAD_LENGTH_E;
     }
 
@@ -4059,9 +4059,9 @@ int wc_AesEcbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
         /* Decrypt block by block. */
         while (sz > 0) {
             wc_AesDecrypt(aes, in, out);
-            out += AES_BLOCK_SIZE;
-            in += AES_BLOCK_SIZE;
-            sz -= AES_BLOCK_SIZE;
+            out += WC_AES_BLOCK_SIZE;
+            in += WC_AES_BLOCK_SIZE;
+            sz -= WC_AES_BLOCK_SIZE;
         }
     }
 
@@ -4083,7 +4083,7 @@ static WC_INLINE void IncrementAesCounter(byte* inOutCtr)
     int i;
 
     /* Big-endian array - start at last element and move back. */
-    for (i = AES_BLOCK_SIZE - 1; i >= 0; i--) {
+    for (i = WC_AES_BLOCK_SIZE - 1; i >= 0; i--) {
         /* Result not zero means no carry. */
         if ((++inOutCtr[i]) != 0) {
             return;
@@ -4105,7 +4105,7 @@ static WC_INLINE void IncrementAesCounter(byte* inOutCtr)
  */
 int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
-    byte scratch[AES_BLOCK_SIZE];
+    byte scratch[WC_AES_BLOCK_SIZE];
     word32 processed;
     int ret = 0;
 
@@ -4137,7 +4137,7 @@ int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
         processed = min(aes->left, sz);
         if (processed > 0) {
             /* XOR in encrypted counter.  */
-            xorbufout(out, in, (byte*)aes->tmp + AES_BLOCK_SIZE - aes->left,
+            xorbufout(out, in, (byte*)aes->tmp + WC_AES_BLOCK_SIZE - aes->left,
                 processed);
             out += processed;
             in += processed;
@@ -4146,18 +4146,18 @@ int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
         }
 
         /* Do whole blocks of data. */
-        while (sz >= AES_BLOCK_SIZE) {
+        while (sz >= WC_AES_BLOCK_SIZE) {
             wc_AesEncrypt(aes, (byte*)aes->reg, scratch);
             xorbuf16(scratch, in);
             memcpy16(out, scratch);
             IncrementAesCounter((byte*)aes->reg);
 
-            out += AES_BLOCK_SIZE;
-            in  += AES_BLOCK_SIZE;
-            sz  -= AES_BLOCK_SIZE;
+            out += WC_AES_BLOCK_SIZE;
+            in  += WC_AES_BLOCK_SIZE;
+            sz  -= WC_AES_BLOCK_SIZE;
             aes->left = 0;
         }
-        ForceZero(scratch, AES_BLOCK_SIZE);
+        ForceZero(scratch, WC_AES_BLOCK_SIZE);
 
         if (sz > 0) {
             /* Encrypt counter and store in aes->tmp.
@@ -4165,7 +4165,7 @@ int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
              */
             wc_AesEncrypt(aes, (byte*)aes->reg, (byte*)aes->tmp);
             IncrementAesCounter((byte*)aes->reg);
-            aes->left = AES_BLOCK_SIZE - sz;
+            aes->left = WC_AES_BLOCK_SIZE - sz;
             /* XOR in encrypted counter. */
             xorbufout(out, in, aes->tmp, sz);
         }
@@ -4214,7 +4214,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
         memcpy16((byte*)aes->reg, iv);
     }
     else {
-        XMEMSET(aes->reg,  0, AES_BLOCK_SIZE);
+        XMEMSET(aes->reg,  0, WC_AES_BLOCK_SIZE);
     }
 
     return ret;
@@ -4308,7 +4308,7 @@ static WC_INLINE void RIGHTSHIFTX(byte* x)
     int carryIn = 0;
     byte borrow = (0x00 - (x[15] & 0x01)) & 0xE1;
 
-    for (i = 0; i < AES_BLOCK_SIZE; i++) {
+    for (i = 0; i < WC_AES_BLOCK_SIZE; i++) {
         int carryOut = (x[i] & 0x01) << 7;
         x[i] = (byte) ((x[i] >> 1) | carryIn);
         carryIn = carryOut;
@@ -4336,10 +4336,10 @@ static WC_INLINE void Shift4_M0(byte *r8, byte *z8)
 void GenerateM0(Gcm* gcm)
 {
     int i;
-    byte (*m)[AES_BLOCK_SIZE] = gcm->M0;
+    byte (*m)[WC_AES_BLOCK_SIZE] = gcm->M0;
 
     /* 0 times -> 0x0 */
-    XMEMSET(m[0x0], 0, AES_BLOCK_SIZE);
+    XMEMSET(m[0x0], 0, WC_AES_BLOCK_SIZE);
     /* 1 times -> 0x8 */
     memcpy16(m[0x8], gcm->H);
     /* 2 times -> 0x4 */
@@ -4398,7 +4398,7 @@ void GenerateM0(Gcm* gcm)
 int wc_AesGcmSetKey(Aes* aes, const byte* key, word32 len)
 {
     int  ret = 0;
-    byte iv[AES_BLOCK_SIZE];
+    byte iv[WC_AES_BLOCK_SIZE];
 
     if (aes == NULL) {
         ret = BAD_FUNC_ARG;
@@ -4408,7 +4408,7 @@ int wc_AesGcmSetKey(Aes* aes, const byte* key, word32 len)
     }
 
     if (ret == 0) {
-        XMEMSET(iv, 0, AES_BLOCK_SIZE);
+        XMEMSET(iv, 0, WC_AES_BLOCK_SIZE);
         ret = wc_AesSetKey(aes, key, len, iv, AES_ENCRYPTION);
     }
     if (ret == 0) {
@@ -4555,8 +4555,8 @@ void GHASH(Gcm* gcm, const byte* a, word32 aSz, const byte* c, word32 cSz,
     byte* s, word32 sSz)
 {
     if (gcm != NULL) {
-        byte x[AES_BLOCK_SIZE];
-        byte scratch[AES_BLOCK_SIZE];
+        byte x[WC_AES_BLOCK_SIZE];
+        byte scratch[WC_AES_BLOCK_SIZE];
         byte* h = gcm->H;
 
         __asm__ __volatile__ (
@@ -4888,8 +4888,8 @@ static void GMULT(byte* x, byte* y)
 void GHASH(Gcm* gcm, const byte* a, word32 aSz, const byte* c, word32 cSz,
     byte* s, word32 sSz)
 {
-    byte x[AES_BLOCK_SIZE];
-    byte scratch[AES_BLOCK_SIZE];
+    byte x[WC_AES_BLOCK_SIZE];
+    byte scratch[WC_AES_BLOCK_SIZE];
     word32 blocks, partial;
     byte* h;
 
@@ -4898,19 +4898,19 @@ void GHASH(Gcm* gcm, const byte* a, word32 aSz, const byte* c, word32 cSz,
     }
 
     h = gcm->H;
-    XMEMSET(x, 0, AES_BLOCK_SIZE);
+    XMEMSET(x, 0, WC_AES_BLOCK_SIZE);
 
     /* Hash in A, the Additional Authentication Data */
     if (aSz != 0 && a != NULL) {
-        blocks = aSz / AES_BLOCK_SIZE;
-        partial = aSz % AES_BLOCK_SIZE;
+        blocks = aSz / WC_AES_BLOCK_SIZE;
+        partial = aSz % WC_AES_BLOCK_SIZE;
         while (blocks--) {
             xorbuf16(x, a);
             GMULT(x, h);
-            a += AES_BLOCK_SIZE;
+            a += WC_AES_BLOCK_SIZE;
         }
         if (partial != 0) {
-            XMEMSET(scratch, 0, AES_BLOCK_SIZE);
+            XMEMSET(scratch, 0, WC_AES_BLOCK_SIZE);
             XMEMCPY(scratch, a, partial);
             xorbuf16(x, scratch);
             GMULT(x, h);
@@ -4919,15 +4919,15 @@ void GHASH(Gcm* gcm, const byte* a, word32 aSz, const byte* c, word32 cSz,
 
     /* Hash in C, the Ciphertext */
     if (cSz != 0 && c != NULL) {
-        blocks = cSz / AES_BLOCK_SIZE;
-        partial = cSz % AES_BLOCK_SIZE;
+        blocks = cSz / WC_AES_BLOCK_SIZE;
+        partial = cSz % WC_AES_BLOCK_SIZE;
         while (blocks--) {
             xorbuf16(x, c);
             GMULT(x, h);
-            c += AES_BLOCK_SIZE;
+            c += WC_AES_BLOCK_SIZE;
         }
         if (partial != 0) {
-            XMEMSET(scratch, 0, AES_BLOCK_SIZE);
+            XMEMSET(scratch, 0, WC_AES_BLOCK_SIZE);
             XMEMCPY(scratch, c, partial);
             xorbuf16(x, scratch);
             GMULT(x, h);
@@ -5299,23 +5299,23 @@ void GHASH(Gcm* gcm, const byte* a, word32 aSz, const byte* c, word32 cSz,
     byte* s, word32 sSz)
 {
     if (gcm != NULL) {
-        byte x[AES_BLOCK_SIZE];
-        byte scratch[AES_BLOCK_SIZE];
+        byte x[WC_AES_BLOCK_SIZE];
+        byte scratch[WC_AES_BLOCK_SIZE];
         word32 blocks, partial;
         byte* h = gcm->H;
 
-        XMEMSET(x, 0, AES_BLOCK_SIZE);
+        XMEMSET(x, 0, WC_AES_BLOCK_SIZE);
 
         /* Hash in A, the Additional Authentication Data */
         if (aSz != 0 && a != NULL) {
-            blocks = aSz / AES_BLOCK_SIZE;
-            partial = aSz % AES_BLOCK_SIZE;
+            blocks = aSz / WC_AES_BLOCK_SIZE;
+            partial = aSz % WC_AES_BLOCK_SIZE;
             if (blocks > 0) {
                 ghash_blocks(x, h, a, blocks);
-                a += blocks * AES_BLOCK_SIZE;
+                a += blocks * WC_AES_BLOCK_SIZE;
             }
             if (partial != 0) {
-                XMEMSET(scratch, 0, AES_BLOCK_SIZE);
+                XMEMSET(scratch, 0, WC_AES_BLOCK_SIZE);
                 XMEMCPY(scratch, a, partial);
                 xorbuf16(x, scratch);
                 GMULT(x, h);
@@ -5324,14 +5324,14 @@ void GHASH(Gcm* gcm, const byte* a, word32 aSz, const byte* c, word32 cSz,
 
         /* Hash in C, the Ciphertext */
         if (cSz != 0 && c != NULL) {
-            blocks = cSz / AES_BLOCK_SIZE;
-            partial = cSz % AES_BLOCK_SIZE;
+            blocks = cSz / WC_AES_BLOCK_SIZE;
+            partial = cSz % WC_AES_BLOCK_SIZE;
             if (blocks > 0) {
                 ghash_blocks(x, h, c, blocks);
-                c += blocks * AES_BLOCK_SIZE;
+                c += blocks * WC_AES_BLOCK_SIZE;
             }
             if (partial != 0) {
-                XMEMSET(scratch, 0, AES_BLOCK_SIZE);
+                XMEMSET(scratch, 0, WC_AES_BLOCK_SIZE);
                 XMEMCPY(scratch, c, partial);
                 xorbuf16(x, scratch);
                 GMULT(x, h);
@@ -5380,8 +5380,8 @@ static void Aes128GcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     const byte* nonce, word32 nonceSz, byte* tag, word32 tagSz,
     const byte* aad, word32 aadSz)
 {
-    byte counter[AES_BLOCK_SIZE];
-    byte scratch[AES_BLOCK_SIZE];
+    byte counter[WC_AES_BLOCK_SIZE];
+    byte scratch[WC_AES_BLOCK_SIZE];
     /* Noticed different optimization levels treated head of array different.
      * Some cases was stack pointer plus offset others was a register containing
      * address. To make uniform for passing in to inline assembly code am using
@@ -5390,17 +5390,17 @@ static void Aes128GcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     byte* ctr  = counter;
     byte* key = (byte*)aes->key;
 
-    XMEMSET(counter, 0, AES_BLOCK_SIZE);
+    XMEMSET(counter, 0, WC_AES_BLOCK_SIZE);
     if (nonceSz == GCM_NONCE_MID_SZ) {
         XMEMCPY(counter, nonce, GCM_NONCE_MID_SZ);
-        counter[AES_BLOCK_SIZE - 1] = 1;
+        counter[WC_AES_BLOCK_SIZE - 1] = 1;
     }
     else {
 #ifdef OPENSSL_EXTRA
         word32 aadTemp = aes->gcm.aadLen;
         aes->gcm.aadLen = 0;
 #endif
-        GHASH(&aes->gcm, NULL, 0, nonce, nonceSz, counter, AES_BLOCK_SIZE);
+        GHASH(&aes->gcm, NULL, 0, nonce, nonceSz, counter, WC_AES_BLOCK_SIZE);
 #ifdef OPENSSL_EXTRA
         aes->gcm.aadLen = aadTemp;
 #endif
@@ -5878,8 +5878,8 @@ static void Aes192GcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     const byte* nonce, word32 nonceSz, byte* tag, word32 tagSz,
     const byte* aad, word32 aadSz)
 {
-    byte counter[AES_BLOCK_SIZE];
-    byte scratch[AES_BLOCK_SIZE];
+    byte counter[WC_AES_BLOCK_SIZE];
+    byte scratch[WC_AES_BLOCK_SIZE];
     /* Noticed different optimization levels treated head of array different.
      * Some cases was stack pointer plus offset others was a register containing
      * address. To make uniform for passing in to inline assembly code am using
@@ -5888,17 +5888,17 @@ static void Aes192GcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     byte* ctr  = counter;
     byte* key = (byte*)aes->key;
 
-    XMEMSET(counter, 0, AES_BLOCK_SIZE);
+    XMEMSET(counter, 0, WC_AES_BLOCK_SIZE);
     if (nonceSz == GCM_NONCE_MID_SZ) {
         XMEMCPY(counter, nonce, GCM_NONCE_MID_SZ);
-        counter[AES_BLOCK_SIZE - 1] = 1;
+        counter[WC_AES_BLOCK_SIZE - 1] = 1;
     }
     else {
 #ifdef OPENSSL_EXTRA
         word32 aadTemp = aes->gcm.aadLen;
         aes->gcm.aadLen = 0;
 #endif
-        GHASH(&aes->gcm, NULL, 0, nonce, nonceSz, counter, AES_BLOCK_SIZE);
+        GHASH(&aes->gcm, NULL, 0, nonce, nonceSz, counter, WC_AES_BLOCK_SIZE);
 #ifdef OPENSSL_EXTRA
         aes->gcm.aadLen = aadTemp;
 #endif
@@ -6390,8 +6390,8 @@ static void Aes256GcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     const byte* nonce, word32 nonceSz, byte* tag, word32 tagSz,
     const byte* aad, word32 aadSz)
 {
-    byte counter[AES_BLOCK_SIZE];
-    byte scratch[AES_BLOCK_SIZE];
+    byte counter[WC_AES_BLOCK_SIZE];
+    byte scratch[WC_AES_BLOCK_SIZE];
     /* Noticed different optimization levels treated head of array different.
      * Some cases was stack pointer plus offset others was a register containing
      * address. To make uniform for passing in to inline assembly code am using
@@ -6400,17 +6400,17 @@ static void Aes256GcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     byte* ctr  = counter;
     byte* key = (byte*)aes->key;
 
-    XMEMSET(counter, 0, AES_BLOCK_SIZE);
+    XMEMSET(counter, 0, WC_AES_BLOCK_SIZE);
     if (nonceSz == GCM_NONCE_MID_SZ) {
         XMEMCPY(counter, nonce, GCM_NONCE_MID_SZ);
-        counter[AES_BLOCK_SIZE - 1] = 1;
+        counter[WC_AES_BLOCK_SIZE - 1] = 1;
     }
     else {
 #ifdef OPENSSL_EXTRA
         word32 aadTemp = aes->gcm.aadLen;
         aes->gcm.aadLen = 0;
 #endif
-        GHASH(&aes->gcm, NULL, 0, nonce, nonceSz, counter, AES_BLOCK_SIZE);
+        GHASH(&aes->gcm, NULL, 0, nonce, nonceSz, counter, WC_AES_BLOCK_SIZE);
 #ifdef OPENSSL_EXTRA
         aes->gcm.aadLen = aadTemp;
 #endif
@@ -6918,7 +6918,7 @@ static void Aes256GcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
  * @return  BAD_FUNC_ARG when nonceSz is zero.
  * @return  BAD_FUNC_ARG when aad is NULL but aadSz is not zero.
  * @return  BAD_FUNC_ARG when tagSz is less than WOLFSSL_MIN_AUTH_TAG_SZ or
- *          greater than AES_BLOCK_SIZE.
+ *          greater than WC_AES_BLOCK_SIZE.
  * @return  BAD_FUNC_ARG when sz is not zero but in or out is NULL.
  */
 int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
@@ -6936,7 +6936,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     }
 
     if ((ret == 0) && ((tagSz < WOLFSSL_MIN_AUTH_TAG_SZ) ||
-            (tagSz > AES_BLOCK_SIZE))) {
+            (tagSz > WC_AES_BLOCK_SIZE))) {
         WOLFSSL_MSG("GcmEncrypt tagSz error");
         ret = BAD_FUNC_ARG;
     }
@@ -6995,8 +6995,8 @@ static int Aes128GcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     const byte* aad, word32 aadSz)
 {
     int ret = 0;
-    byte counter[AES_BLOCK_SIZE];
-    byte scratch[AES_BLOCK_SIZE];
+    byte counter[WC_AES_BLOCK_SIZE];
+    byte scratch[WC_AES_BLOCK_SIZE];
     /* Noticed different optimization levels treated head of array different.
      * Some cases was stack pointer plus offset others was a register containing
      * address. To make uniform for passing in to inline assembly code am using
@@ -7005,17 +7005,17 @@ static int Aes128GcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     byte* ctr  = counter;
     byte* key = (byte*)aes->key;
 
-    XMEMSET(counter, 0, AES_BLOCK_SIZE);
+    XMEMSET(counter, 0, WC_AES_BLOCK_SIZE);
     if (nonceSz == GCM_NONCE_MID_SZ) {
         XMEMCPY(counter, nonce, GCM_NONCE_MID_SZ);
-        counter[AES_BLOCK_SIZE - 1] = 1;
+        counter[WC_AES_BLOCK_SIZE - 1] = 1;
     }
     else {
 #ifdef OPENSSL_EXTRA
         word32 aadTemp = aes->gcm.aadLen;
         aes->gcm.aadLen = 0;
 #endif
-        GHASH(&aes->gcm, NULL, 0, nonce, nonceSz, counter, AES_BLOCK_SIZE);
+        GHASH(&aes->gcm, NULL, 0, nonce, nonceSz, counter, WC_AES_BLOCK_SIZE);
 #ifdef OPENSSL_EXTRA
         aes->gcm.aadLen = aadTemp;
 #endif
@@ -7504,8 +7504,8 @@ static int Aes192GcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     const byte* aad, word32 aadSz)
 {
     int ret = 0;
-    byte counter[AES_BLOCK_SIZE];
-    byte scratch[AES_BLOCK_SIZE];
+    byte counter[WC_AES_BLOCK_SIZE];
+    byte scratch[WC_AES_BLOCK_SIZE];
     /* Noticed different optimization levels treated head of array different.
      * Some cases was stack pointer plus offset others was a register containing
      * address. To make uniform for passing in to inline assembly code am using
@@ -7514,17 +7514,17 @@ static int Aes192GcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     byte* ctr  = counter;
     byte* key = (byte*)aes->key;
 
-    XMEMSET(counter, 0, AES_BLOCK_SIZE);
+    XMEMSET(counter, 0, WC_AES_BLOCK_SIZE);
     if (nonceSz == GCM_NONCE_MID_SZ) {
         XMEMCPY(counter, nonce, GCM_NONCE_MID_SZ);
-        counter[AES_BLOCK_SIZE - 1] = 1;
+        counter[WC_AES_BLOCK_SIZE - 1] = 1;
     }
     else {
 #ifdef OPENSSL_EXTRA
         word32 aadTemp = aes->gcm.aadLen;
         aes->gcm.aadLen = 0;
 #endif
-        GHASH(&aes->gcm, NULL, 0, nonce, nonceSz, counter, AES_BLOCK_SIZE);
+        GHASH(&aes->gcm, NULL, 0, nonce, nonceSz, counter, WC_AES_BLOCK_SIZE);
 #ifdef OPENSSL_EXTRA
         aes->gcm.aadLen = aadTemp;
 #endif
@@ -8027,8 +8027,8 @@ static int Aes256GcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     const byte* aad, word32 aadSz)
 {
     int ret = 0;
-    byte counter[AES_BLOCK_SIZE];
-    byte scratch[AES_BLOCK_SIZE];
+    byte counter[WC_AES_BLOCK_SIZE];
+    byte scratch[WC_AES_BLOCK_SIZE];
     /* Noticed different optimization levels treated head of array different.
      * Some cases was stack pointer plus offset others was a register containing
      * address. To make uniform for passing in to inline assembly code am using
@@ -8037,17 +8037,17 @@ static int Aes256GcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     byte* ctr  = counter;
     byte* key = (byte*)aes->key;
 
-    XMEMSET(counter, 0, AES_BLOCK_SIZE);
+    XMEMSET(counter, 0, WC_AES_BLOCK_SIZE);
     if (nonceSz == GCM_NONCE_MID_SZ) {
         XMEMCPY(counter, nonce, GCM_NONCE_MID_SZ);
-        counter[AES_BLOCK_SIZE - 1] = 1;
+        counter[WC_AES_BLOCK_SIZE - 1] = 1;
     }
     else {
 #ifdef OPENSSL_EXTRA
         word32 aadTemp = aes->gcm.aadLen;
         aes->gcm.aadLen = 0;
 #endif
-        GHASH(&aes->gcm, NULL, 0, nonce, nonceSz, counter, AES_BLOCK_SIZE);
+        GHASH(&aes->gcm, NULL, 0, nonce, nonceSz, counter, WC_AES_BLOCK_SIZE);
 #ifdef OPENSSL_EXTRA
         aes->gcm.aadLen = aadTemp;
 #endif
@@ -8562,7 +8562,7 @@ static int Aes256GcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
  * @return  BAD_FUNC_ARG when nonceSz is zero.
  * @return  BAD_FUNC_ARG when aad is NULL but aadSz is not zero.
  * @return  BAD_FUNC_ARG when tagSz is less than WOLFSSL_MIN_AUTH_TAG_SZ or
- *          greater than AES_BLOCK_SIZE.
+ *          greater than WC_AES_BLOCK_SIZE.
  * @return  BAD_FUNC_ARG when sz is not zero but in or out is NULL.
  * @return  AES_GCM_AUTH_E when authentication tag computed doesn't match
  *          tag passed in.
@@ -8575,7 +8575,7 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
 
     /* sanity checks */
     if ((aes == NULL) || (nonce == NULL) || (tag == NULL) ||
-            (tagSz > AES_BLOCK_SIZE) || (tagSz < WOLFSSL_MIN_AUTH_TAG_SZ) ||
+            (tagSz > WC_AES_BLOCK_SIZE) || (tagSz < WOLFSSL_MIN_AUTH_TAG_SZ) ||
             ((aad == NULL) && (aadSz > 0)) || (nonceSz == 0) ||
             ((sz != 0) && ((in == NULL) || (out == NULL)))) {
         WOLFSSL_MSG("a NULL parameter passed in when size is larger than 0");
@@ -8643,7 +8643,7 @@ static const word16 R[32] = {
  *                      On out, result of GMULT.
  * @param [in]       y  Value to GMULT.
  */
-static WC_INLINE void GMULT(byte *x, byte m[32][AES_BLOCK_SIZE])
+static WC_INLINE void GMULT(byte *x, byte m[32][WC_AES_BLOCK_SIZE])
 {
     int i;
     word64 z8[2] = {0, 0};
@@ -8725,23 +8725,23 @@ void GHASH(Gcm* gcm, const byte* a, word32 aSz, const byte* c, word32 cSz,
     byte* s, word32 sSz)
 {
     if (gcm != NULL) {
-        byte x[AES_BLOCK_SIZE];
-        byte scratch[AES_BLOCK_SIZE];
+        byte x[WC_AES_BLOCK_SIZE];
+        byte scratch[WC_AES_BLOCK_SIZE];
         word32 blocks, partial;
 
-        XMEMSET(x, 0, AES_BLOCK_SIZE);
+        XMEMSET(x, 0, WC_AES_BLOCK_SIZE);
 
         /* Hash in A, the Additional Authentication Data */
         if (aSz != 0 && a != NULL) {
-            blocks = aSz / AES_BLOCK_SIZE;
-            partial = aSz % AES_BLOCK_SIZE;
+            blocks = aSz / WC_AES_BLOCK_SIZE;
+            partial = aSz % WC_AES_BLOCK_SIZE;
             while (blocks--) {
                 xorbuf16(x, a);
                 GMULT(x, gcm->M0);
-                a += AES_BLOCK_SIZE;
+                a += WC_AES_BLOCK_SIZE;
             }
             if (partial != 0) {
-                XMEMSET(scratch, 0, AES_BLOCK_SIZE);
+                XMEMSET(scratch, 0, WC_AES_BLOCK_SIZE);
                 XMEMCPY(scratch, a, partial);
                 xorbuf16(x, scratch);
                 GMULT(x, gcm->M0);
@@ -8750,15 +8750,15 @@ void GHASH(Gcm* gcm, const byte* a, word32 aSz, const byte* c, word32 cSz,
 
         /* Hash in C, the Ciphertext */
         if (cSz != 0 && c != NULL) {
-            blocks = cSz / AES_BLOCK_SIZE;
-            partial = cSz % AES_BLOCK_SIZE;
+            blocks = cSz / WC_AES_BLOCK_SIZE;
+            partial = cSz % WC_AES_BLOCK_SIZE;
             while (blocks--) {
                 xorbuf16(x, c);
                 GMULT(x, gcm->M0);
-                c += AES_BLOCK_SIZE;
+                c += WC_AES_BLOCK_SIZE;
             }
             if (partial != 0) {
-                XMEMSET(scratch, 0, AES_BLOCK_SIZE);
+                XMEMSET(scratch, 0, WC_AES_BLOCK_SIZE);
                 XMEMCPY(scratch, c, partial);
                 xorbuf16(x, scratch);
                 GMULT(x, gcm->M0);
@@ -8789,7 +8789,7 @@ static WC_INLINE void IncrementGcmCounter(byte* inOutCtr)
     int i;
 
     /* Big-endian array - start at last element and move back. */
-    for (i = AES_BLOCK_SIZE - 1; i >= AES_BLOCK_SIZE - CTR_SZ; i--) {
+    for (i = WC_AES_BLOCK_SIZE - 1; i >= WC_AES_BLOCK_SIZE - CTR_SZ; i--) {
         /* Result not zero means no carry. */
         if ((++inOutCtr[i]) != 0) {
             return;
@@ -8814,7 +8814,7 @@ static WC_INLINE void IncrementGcmCounter(byte* inOutCtr)
  * @return  BAD_FUNC_ARG when nonceSz is zero.
  * @return  BAD_FUNC_ARG when aad is NULL but aadSz is not zero.
  * @return  BAD_FUNC_ARG when tagSz is less than WOLFSSL_MIN_AUTH_TAG_SZ or
- *          greater than AES_BLOCK_SIZE.
+ *          greater than WC_AES_BLOCK_SIZE.
  * @return  BAD_FUNC_ARG when sz is not zero but in or out is NULL.
  */
 int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
@@ -8822,13 +8822,13 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     const byte* aad, word32 aadSz)
 {
     int ret = 0;
-    word32 blocks = sz / AES_BLOCK_SIZE;
-    word32 partial = sz % AES_BLOCK_SIZE;
+    word32 blocks = sz / WC_AES_BLOCK_SIZE;
+    word32 partial = sz % WC_AES_BLOCK_SIZE;
     const byte* p = in;
     byte* c = out;
-    ALIGN16 byte counter[AES_BLOCK_SIZE];
-    ALIGN16 byte initialCounter[AES_BLOCK_SIZE];
-    ALIGN16 byte scratch[AES_BLOCK_SIZE];
+    ALIGN16 byte counter[WC_AES_BLOCK_SIZE];
+    ALIGN16 byte initialCounter[WC_AES_BLOCK_SIZE];
+    ALIGN16 byte scratch[WC_AES_BLOCK_SIZE];
 
     /* Validate parameters. */
     if ((aes == NULL) || (nonce == NULL) || (nonceSz == 0) || (tag == NULL) ||
@@ -8839,7 +8839,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     }
 
     if ((ret == 0) && ((tagSz < WOLFSSL_MIN_AUTH_TAG_SZ) ||
-            (tagSz > AES_BLOCK_SIZE))) {
+            (tagSz > WC_AES_BLOCK_SIZE))) {
         WOLFSSL_MSG("GcmEncrypt tagSz error");
         ret = BAD_FUNC_ARG;
     }
@@ -8850,8 +8850,8 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
             /* Counter is IV with bottom 4 bytes set to: 0x00,0x00,0x00,0x01. */
             XMEMCPY(counter, nonce, nonceSz);
             XMEMSET(counter + GCM_NONCE_MID_SZ, 0,
-                AES_BLOCK_SIZE - GCM_NONCE_MID_SZ - 1);
-            counter[AES_BLOCK_SIZE - 1] = 1;
+                WC_AES_BLOCK_SIZE - GCM_NONCE_MID_SZ - 1);
+            counter[WC_AES_BLOCK_SIZE - 1] = 1;
         }
         else {
             /* Counter is GHASH of IV. */
@@ -8859,7 +8859,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
             word32 aadTemp = aes->gcm.aadLen;
             aes->gcm.aadLen = 0;
         #endif
-            GHASH(&aes->gcm, NULL, 0, nonce, nonceSz, counter, AES_BLOCK_SIZE);
+            GHASH(&aes->gcm, NULL, 0, nonce, nonceSz, counter, WC_AES_BLOCK_SIZE);
         #ifdef OPENSSL_EXTRA
             aes->gcm.aadLen = aadTemp;
         #endif
@@ -8870,8 +8870,8 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
             IncrementGcmCounter(counter);
             wc_AesEncrypt(aes, counter, scratch);
             xorbufout16(c, scratch, p);
-            p += AES_BLOCK_SIZE;
-            c += AES_BLOCK_SIZE;
+            p += WC_AES_BLOCK_SIZE;
+            c += WC_AES_BLOCK_SIZE;
         }
 
         if (partial != 0) {
@@ -8912,7 +8912,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
  * @return  BAD_FUNC_ARG when nonceSz is zero.
  * @return  BAD_FUNC_ARG when aad is NULL but aadSz is not zero.
  * @return  BAD_FUNC_ARG when tagSz is less than WOLFSSL_MIN_AUTH_TAG_SZ or
- *          greater than AES_BLOCK_SIZE.
+ *          greater than WC_AES_BLOCK_SIZE.
  * @return  BAD_FUNC_ARG when sz is not zero but in or out is NULL.
  * @return  AES_GCM_AUTH_E when authentication tag computed doesn't match
  *          tag passed in.
@@ -8922,19 +8922,19 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     const byte* aad, word32 aadSz)
 {
     int ret = 0;
-    word32 blocks = sz / AES_BLOCK_SIZE;
-    word32 partial = sz % AES_BLOCK_SIZE;
+    word32 blocks = sz / WC_AES_BLOCK_SIZE;
+    word32 partial = sz % WC_AES_BLOCK_SIZE;
     const byte* c = in;
     byte* p = out;
-    ALIGN16 byte counter[AES_BLOCK_SIZE];
-    ALIGN16 byte scratch[AES_BLOCK_SIZE];
-    ALIGN16 byte Tprime[AES_BLOCK_SIZE];
-    ALIGN16 byte EKY0[AES_BLOCK_SIZE];
+    ALIGN16 byte counter[WC_AES_BLOCK_SIZE];
+    ALIGN16 byte scratch[WC_AES_BLOCK_SIZE];
+    ALIGN16 byte Tprime[WC_AES_BLOCK_SIZE];
+    ALIGN16 byte EKY0[WC_AES_BLOCK_SIZE];
     sword32 res;
 
     /* Validate parameters. */
     if ((aes == NULL) || (nonce == NULL) || (tag == NULL) ||
-            (tagSz > AES_BLOCK_SIZE) || (tagSz < WOLFSSL_MIN_AUTH_TAG_SZ) ||
+            (tagSz > WC_AES_BLOCK_SIZE) || (tagSz < WOLFSSL_MIN_AUTH_TAG_SZ) ||
             ((aad == NULL) && (aadSz > 0)) || (nonceSz == 0) ||
             ((sz != 0) && ((in == NULL) || (out == NULL)))) {
         WOLFSSL_MSG("a NULL parameter passed in when size is larger than 0");
@@ -8946,8 +8946,8 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
             /* Counter is IV with bottom 4 bytes set to: 0x00,0x00,0x00,0x01. */
             XMEMCPY(counter, nonce, nonceSz);
             XMEMSET(counter + GCM_NONCE_MID_SZ, 0,
-                AES_BLOCK_SIZE - GCM_NONCE_MID_SZ - 1);
-            counter[AES_BLOCK_SIZE - 1] = 1;
+                WC_AES_BLOCK_SIZE - GCM_NONCE_MID_SZ - 1);
+            counter[WC_AES_BLOCK_SIZE - 1] = 1;
         }
         else {
             /* Counter is GHASH of IV. */
@@ -8955,7 +8955,7 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
             word32 aadTemp = aes->gcm.aadLen;
             aes->gcm.aadLen = 0;
         #endif
-            GHASH(&aes->gcm, NULL, 0, nonce, nonceSz, counter, AES_BLOCK_SIZE);
+            GHASH(&aes->gcm, NULL, 0, nonce, nonceSz, counter, WC_AES_BLOCK_SIZE);
         #ifdef OPENSSL_EXTRA
             aes->gcm.aadLen = aadTemp;
         #endif
@@ -8991,8 +8991,8 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
             IncrementGcmCounter(counter);
             wc_AesEncrypt(aes, counter, scratch);
             xorbufout16(p, scratch, c);
-            p += AES_BLOCK_SIZE;
-            c += AES_BLOCK_SIZE;
+            p += WC_AES_BLOCK_SIZE;
+            c += WC_AES_BLOCK_SIZE;
         }
 
         if (partial != 0) {
@@ -9030,10 +9030,10 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
 static void roll_x(Aes* aes, const byte* in, word32 inSz, byte* out)
 {
     /* process the bulk of the data */
-    while (inSz >= AES_BLOCK_SIZE) {
+    while (inSz >= WC_AES_BLOCK_SIZE) {
         xorbuf16(out, in);
-        in += AES_BLOCK_SIZE;
-        inSz -= AES_BLOCK_SIZE;
+        in += WC_AES_BLOCK_SIZE;
+        inSz -= WC_AES_BLOCK_SIZE;
 
         wc_AesEncrypt(aes, out, out);
     }
@@ -9070,7 +9070,7 @@ static void roll_auth(Aes* aes, const byte* in, word32 inSz, byte* out)
      */
 
     /* start fill out the rest of the first block */
-    remainder = AES_BLOCK_SIZE - authLenSz;
+    remainder = WC_AES_BLOCK_SIZE - authLenSz;
     if (inSz >= remainder) {
         /* plenty of bulk data to fill the remainder of this block */
         xorbuf(out + authLenSz, in, remainder);
@@ -9094,7 +9094,7 @@ static WC_INLINE void AesCcmCtrInc(byte* B, word32 lenSz)
     word32 i;
 
     for (i = 0; i < lenSz; i++) {
-        if (++B[AES_BLOCK_SIZE - 1 - i] != 0) return;
+        if (++B[WC_AES_BLOCK_SIZE - 1 - i] != 0) return;
     }
 }
 
@@ -9118,21 +9118,21 @@ int wc_AesCcmEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
     }
 
     if (ret == 0) {
-        byte A[AES_BLOCK_SIZE];
-        byte B[AES_BLOCK_SIZE];
+        byte A[WC_AES_BLOCK_SIZE];
+        byte B[WC_AES_BLOCK_SIZE];
         byte lenSz;
         byte i;
 
         XMEMCPY(B+1, nonce, nonceSz);
-        lenSz = AES_BLOCK_SIZE - 1 - (byte)nonceSz;
+        lenSz = WC_AES_BLOCK_SIZE - 1 - (byte)nonceSz;
         B[0] = (authInSz > 0 ? 64 : 0)
              + (8 * (((byte)authTagSz - 2) / 2))
              + (lenSz - 1);
         for (i = 0; (i < lenSz) && (i < (byte)sizeof(word32)); i++) {
-            B[AES_BLOCK_SIZE - 1 - i] = inSz >> (8 * i);
+            B[WC_AES_BLOCK_SIZE - 1 - i] = inSz >> (8 * i);
         }
         for (; i < lenSz; i++) {
-            B[AES_BLOCK_SIZE - 1 - i] = 0;
+            B[WC_AES_BLOCK_SIZE - 1 - i] = 0;
         }
 
         wc_AesEncrypt(aes, B, A);
@@ -9147,21 +9147,21 @@ int wc_AesCcmEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
 
         B[0] = lenSz - 1;
         for (i = 0; i < lenSz; i++) {
-            B[AES_BLOCK_SIZE - 1 - i] = 0;
+            B[WC_AES_BLOCK_SIZE - 1 - i] = 0;
         }
         wc_AesEncrypt(aes, B, A);
         xorbuf(authTag, A, authTagSz);
 
         B[15] = 1;
-        while (inSz >= AES_BLOCK_SIZE) {
+        while (inSz >= WC_AES_BLOCK_SIZE) {
             wc_AesEncrypt(aes, B, A);
             xorbuf16(A, in);
             memcpy16(out, A);
 
             AesCcmCtrInc(B, lenSz);
-            inSz -= AES_BLOCK_SIZE;
-            in += AES_BLOCK_SIZE;
-            out += AES_BLOCK_SIZE;
+            inSz -= WC_AES_BLOCK_SIZE;
+            in += WC_AES_BLOCK_SIZE;
+            out += WC_AES_BLOCK_SIZE;
         }
         if (inSz > 0) {
             wc_AesEncrypt(aes, B, A);
@@ -9169,8 +9169,8 @@ int wc_AesCcmEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
             XMEMCPY(out, A, inSz);
         }
 
-        ForceZero(A, AES_BLOCK_SIZE);
-        ForceZero(B, AES_BLOCK_SIZE);
+        ForceZero(A, WC_AES_BLOCK_SIZE);
+        ForceZero(B, WC_AES_BLOCK_SIZE);
     }
 
     return ret;
@@ -9196,31 +9196,31 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
     }
 
     if (ret == 0) {
-        byte A[AES_BLOCK_SIZE];
-        byte B[AES_BLOCK_SIZE];
+        byte A[WC_AES_BLOCK_SIZE];
+        byte B[WC_AES_BLOCK_SIZE];
         byte lenSz;
         byte i;
         byte* o = out;
         word32 oSz = inSz;
 
         XMEMCPY(B+1, nonce, nonceSz);
-        lenSz = AES_BLOCK_SIZE - 1 - (byte)nonceSz;
+        lenSz = WC_AES_BLOCK_SIZE - 1 - (byte)nonceSz;
 
         B[0] = lenSz - 1;
         for (i = 0; i < lenSz; i++) {
-            B[AES_BLOCK_SIZE - 1 - i] = 0;
+            B[WC_AES_BLOCK_SIZE - 1 - i] = 0;
         }
         B[15] = 1;
 
-        while (oSz >= AES_BLOCK_SIZE) {
+        while (oSz >= WC_AES_BLOCK_SIZE) {
             wc_AesEncrypt(aes, B, A);
             xorbuf16(A, in);
             memcpy16(o, A);
 
             AesCcmCtrInc(B, lenSz);
-            oSz -= AES_BLOCK_SIZE;
-            in += AES_BLOCK_SIZE;
-            o += AES_BLOCK_SIZE;
+            oSz -= WC_AES_BLOCK_SIZE;
+            in += WC_AES_BLOCK_SIZE;
+            o += WC_AES_BLOCK_SIZE;
         }
         if (inSz > 0) {
             wc_AesEncrypt(aes, B, A);
@@ -9229,7 +9229,7 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
         }
 
         for (i = 0; i < lenSz; i++) {
-            B[AES_BLOCK_SIZE - 1 - i] = 0;
+            B[WC_AES_BLOCK_SIZE - 1 - i] = 0;
         }
         wc_AesEncrypt(aes, B, A);
 
@@ -9237,10 +9237,10 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
              + (8 * (((byte)authTagSz - 2) / 2))
              + (lenSz - 1);
         for (i = 0; (i < lenSz) && (i < (byte)sizeof(word32)); i++) {
-            B[AES_BLOCK_SIZE - 1 - i] = inSz >> (8 * i);
+            B[WC_AES_BLOCK_SIZE - 1 - i] = inSz >> (8 * i);
         }
         for (; i < lenSz; i++) {
-            B[AES_BLOCK_SIZE - 1 - i] = 0;
+            B[WC_AES_BLOCK_SIZE - 1 - i] = 0;
         }
 
         wc_AesEncrypt(aes, B, A);
@@ -9254,7 +9254,7 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
 
         B[0] = lenSz - 1;
         for (i = 0; i < lenSz; i++) {
-            B[AES_BLOCK_SIZE - 1 - i] = 0;
+            B[WC_AES_BLOCK_SIZE - 1 - i] = 0;
         }
         wc_AesEncrypt(aes, B, B);
         xorbuf(A, B, authTagSz);
@@ -9267,8 +9267,8 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
             ret = AES_CCM_AUTH_E;
         }
 
-        ForceZero(A, AES_BLOCK_SIZE);
-        ForceZero(B, AES_BLOCK_SIZE);
+        ForceZero(A, WC_AES_BLOCK_SIZE);
+        ForceZero(B, WC_AES_BLOCK_SIZE);
         o = NULL;
     }
 

--- a/wolfcrypt/src/port/ti/ti-aes.c
+++ b/wolfcrypt/src/port/ti/ti-aes.c
@@ -63,9 +63,9 @@ static int AesSetIV(Aes* aes, const byte* iv)
         return BAD_FUNC_ARG;
 
     if (iv)
-        XMEMCPY(aes->reg, iv, AES_BLOCK_SIZE);
+        XMEMCPY(aes->reg, iv, WC_AES_BLOCK_SIZE);
     else
-        XMEMSET(aes->reg,  0, AES_BLOCK_SIZE);
+        XMEMSET(aes->reg,  0, WC_AES_BLOCK_SIZE);
 
     return 0;
 }
@@ -150,7 +150,7 @@ static int AesAlign16(Aes* aes, byte* out, const byte* in, word32 sz,
     ROM_AESKey1Set(AES_BASE, (uint32_t *)aes->key, aes->keylen-8);
     if (dir == AES_CFG_DIR_DECRYPT && mode == AES_CFG_MODE_CBC) {
         /* if input and output same will overwrite input iv */
-        XMEMCPY(aes->tmp, in + sz - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
+        XMEMCPY(aes->tmp, in + sz - WC_AES_BLOCK_SIZE, WC_AES_BLOCK_SIZE);
     }
     ROM_AESDataProcess(AES_BASE, (uint32_t *)in, (uint32_t *)out, sz);
     wolfSSL_TI_unlockCCM();
@@ -158,19 +158,19 @@ static int AesAlign16(Aes* aes, byte* out, const byte* in, word32 sz,
     /* store iv for next call */
     if (mode == AES_CFG_MODE_CBC) {
         if (dir == AES_CFG_DIR_ENCRYPT)
-            XMEMCPY(aes->reg, out + sz - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
+            XMEMCPY(aes->reg, out + sz - WC_AES_BLOCK_SIZE, WC_AES_BLOCK_SIZE);
         else
-            XMEMCPY(aes->reg, aes->tmp, AES_BLOCK_SIZE);
+            XMEMCPY(aes->reg, aes->tmp, WC_AES_BLOCK_SIZE);
     }
 
     if (mode == AES_CFG_MODE_CTR) {
         do {
             int i;
-            for (i = AES_BLOCK_SIZE - 1; i >= 0; i--) {
+            for (i = WC_AES_BLOCK_SIZE - 1; i >= 0; i--) {
                  if (++((byte*)aes->reg)[i])
                      break;
             }
-            sz -= AES_BLOCK_SIZE;
+            sz -= WC_AES_BLOCK_SIZE;
         } while ((int)sz > 0);
     }
 
@@ -186,7 +186,7 @@ static int AesProcess(Aes* aes, byte* out, const byte* in, word32 sz,
 
     if ((aes == NULL) || (in == NULL) || (out == NULL))
         return BAD_FUNC_ARG;
-    if (sz % AES_BLOCK_SIZE)
+    if (sz % WC_AES_BLOCK_SIZE)
         return BAD_FUNC_ARG;
 
     while (sz > 0) {
@@ -225,7 +225,7 @@ int wc_AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 #ifdef WOLFSSL_AES_COUNTER
 int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
-    char out_block[AES_BLOCK_SIZE];
+    char out_block[WC_AES_BLOCK_SIZE];
     int odd;
     int even;
     char *tmp; /* (char *)aes->tmp, for short */
@@ -233,28 +233,28 @@ int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 
     tmp = (char *)aes->tmp;
     if (aes->left) {
-        if ((aes->left + sz) >= AES_BLOCK_SIZE) {
-            odd = AES_BLOCK_SIZE - aes->left;
+        if ((aes->left + sz) >= WC_AES_BLOCK_SIZE) {
+            odd = WC_AES_BLOCK_SIZE - aes->left;
         } else {
             odd = sz;
         }
         XMEMCPY(tmp+aes->left, in, odd);
-        if ((odd+aes->left) == AES_BLOCK_SIZE) {
-            ret = AesProcess(aes, (byte*)out_block, (byte const *)tmp, AES_BLOCK_SIZE,
+        if ((odd+aes->left) == WC_AES_BLOCK_SIZE) {
+            ret = AesProcess(aes, (byte*)out_block, (byte const *)tmp, WC_AES_BLOCK_SIZE,
                         AES_CFG_DIR_ENCRYPT, AES_CFG_MODE_CTR);
             if (ret != 0)
                 return ret;
             XMEMCPY(out, out_block+aes->left, odd);
             aes->left = 0;
-            XMEMSET(tmp, 0x0, AES_BLOCK_SIZE);
+            XMEMSET(tmp, 0x0, WC_AES_BLOCK_SIZE);
         }
         in += odd;
         out+= odd;
         sz -= odd;
     }
-    odd = sz % AES_BLOCK_SIZE;  /* if there is tail fragment */
-    if (sz / AES_BLOCK_SIZE) {
-        even = (sz/AES_BLOCK_SIZE)*AES_BLOCK_SIZE;
+    odd = sz % WC_AES_BLOCK_SIZE;  /* if there is tail fragment */
+    if (sz / WC_AES_BLOCK_SIZE) {
+        even = (sz/WC_AES_BLOCK_SIZE)*WC_AES_BLOCK_SIZE;
         ret = AesProcess(aes, out, in, even, AES_CFG_DIR_ENCRYPT, AES_CFG_MODE_CTR);
         if (ret != 0)
             return ret;
@@ -262,9 +262,9 @@ int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
         in  += even;
     }
     if (odd) {
-        XMEMSET(tmp+aes->left, 0x0, AES_BLOCK_SIZE - aes->left);
+        XMEMSET(tmp+aes->left, 0x0, WC_AES_BLOCK_SIZE - aes->left);
         XMEMCPY(tmp+aes->left, in, odd);
-        ret = AesProcess(aes, (byte*)out_block, (byte const *)tmp, AES_BLOCK_SIZE,
+        ret = AesProcess(aes, (byte*)out_block, (byte const *)tmp, WC_AES_BLOCK_SIZE,
                     AES_CFG_DIR_ENCRYPT,
                     AES_CFG_MODE_CTR_NOCTR /* Counter mode without counting IV */
                     );
@@ -281,12 +281,12 @@ int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 #if defined(WOLFSSL_AES_DIRECT)
 int wc_AesEncryptDirect(Aes* aes, byte* out, const byte* in)
 {
-    return AesProcess(aes, out, in, AES_BLOCK_SIZE, AES_CFG_DIR_ENCRYPT,
+    return AesProcess(aes, out, in, WC_AES_BLOCK_SIZE, AES_CFG_DIR_ENCRYPT,
         AES_CFG_MODE_CBC);
 }
 int wc_AesDecryptDirect(Aes* aes, byte* out, const byte* in)
 {
-    return AesProcess(aes, out, in, AES_BLOCK_SIZE, AES_CFG_DIR_DECRYPT,
+    return AesProcess(aes, out, in, WC_AES_BLOCK_SIZE, AES_CFG_DIR_DECRYPT,
         AES_CFG_MODE_CBC);
 }
 int wc_AesSetKeyDirect(Aes* aes, const byte* key, word32 len, const byte* iv,
@@ -312,7 +312,7 @@ static WC_INLINE void IncCtr(byte* ctr, word32 ctrSz)
 
 static int AesAuthSetKey(Aes* aes, const byte* key, word32 keySz)
 {
-    byte nonce[AES_BLOCK_SIZE];
+    byte nonce[WC_AES_BLOCK_SIZE];
 
     if ((aes == NULL) || (key == NULL))
         return BAD_FUNC_ARG;
@@ -406,16 +406,16 @@ static void AesAuthSetIv(Aes *aes, const byte *nonce, word32 len, word32 L,
             byte *b = (byte*)aes->reg;
             if (nonce != NULL)
                 XMEMCPY(aes->reg, nonce, len);
-            b[AES_BLOCK_SIZE-4] = 0;
-            b[AES_BLOCK_SIZE-3] = 0;
-            b[AES_BLOCK_SIZE-2] = 0;
-            b[AES_BLOCK_SIZE-1] = 1;
+            b[WC_AES_BLOCK_SIZE-4] = 0;
+            b[WC_AES_BLOCK_SIZE-3] = 0;
+            b[WC_AES_BLOCK_SIZE-2] = 0;
+            b[WC_AES_BLOCK_SIZE-1] = 1;
 
         }
         else {
-            word32 zeros[AES_BLOCK_SIZE/sizeof(word32)];
-            word32 subkey[AES_BLOCK_SIZE/sizeof(word32)];
-            word32 nonce_padded[AES_BLOCK_SIZE/sizeof(word32)];
+            word32 zeros[WC_AES_BLOCK_SIZE/sizeof(word32)];
+            word32 subkey[WC_AES_BLOCK_SIZE/sizeof(word32)];
+            word32 nonce_padded[WC_AES_BLOCK_SIZE/sizeof(word32)];
             word32 i;
 
             XMEMSET(zeros, 0, sizeof(zeros)); /* init to zero */
@@ -437,10 +437,10 @@ static void AesAuthSetIv(Aes *aes, const byte *nonce, word32 len, word32 L,
             ROM_AESAuthLengthSet(AES_BASE, 0);
 
             /* copy nonce */
-            for (i = 0; i < len; i += AES_BLOCK_SIZE) {
+            for (i = 0; i < len; i += WC_AES_BLOCK_SIZE) {
                 word32 nonceSz = len - i;
-                if (nonceSz > AES_BLOCK_SIZE)
-                    nonceSz = AES_BLOCK_SIZE;
+                if (nonceSz > WC_AES_BLOCK_SIZE)
+                    nonceSz = WC_AES_BLOCK_SIZE;
                 XMEMSET(nonce_padded, 0, sizeof(nonce_padded));
                 XMEMCPY(nonce_padded, (word32*)(nonce + i), nonceSz);
                 ROM_AESDataWrite(AES_BASE, nonce_padded);
@@ -462,7 +462,7 @@ static int AesAuthEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
     byte *in_a,     *in_save = NULL;
     byte *out_a,    *out_save = NULL;
     byte *authIn_a, *authIn_save = NULL;
-    word32 tmpTag[AES_BLOCK_SIZE/sizeof(word32)];
+    word32 tmpTag[WC_AES_BLOCK_SIZE/sizeof(word32)];
 
     ret = AesAuthArgCheck(aes, out, in, inSz, nonce, nonceSz, authTag,
         authTagSz, &M, &L);
@@ -480,7 +480,7 @@ static int AesAuthEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
         ROM_AESReset(AES_BASE);
         ROM_AESConfigSet(AES_BASE, (aes->keylen-8) | AES_CFG_DIR_ENCRYPT | AES_CFG_MODE_ECB);
         ROM_AESKey1Set(AES_BASE, aes->key, (aes->keylen-8));
-        ROM_AESDataProcess(AES_BASE, aes->reg, tmpTag, AES_BLOCK_SIZE);
+        ROM_AESDataProcess(AES_BASE, aes->reg, tmpTag, WC_AES_BLOCK_SIZE);
         wolfSSL_TI_unlockCCM();
         XMEMCPY(authTag, tmpTag, authTagSz);
         return 0;
@@ -562,7 +562,7 @@ static int AesAuthDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
     byte *in_a,     *in_save = NULL;
     byte *out_a,    *out_save = NULL;
     byte *authIn_a, *authIn_save = NULL;
-    word32 tmpTag[AES_BLOCK_SIZE/sizeof(word32)];
+    word32 tmpTag[WC_AES_BLOCK_SIZE/sizeof(word32)];
 
     ret = AesAuthArgCheck(aes, out, in, inSz, nonce, nonceSz, authTag,
         authTagSz, &M, &L);
@@ -580,7 +580,7 @@ static int AesAuthDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
         ROM_AESReset(AES_BASE);
         ROM_AESConfigSet(AES_BASE, (aes->keylen-8) | AES_CFG_DIR_ENCRYPT | AES_CFG_MODE_ECB);
         ROM_AESKey1Set(AES_BASE, aes->key, (aes->keylen-8));
-        ROM_AESDataProcess(AES_BASE, aes->reg, tmpTag, AES_BLOCK_SIZE);
+        ROM_AESDataProcess(AES_BASE, aes->reg, tmpTag, WC_AES_BLOCK_SIZE);
         wolfSSL_TI_unlockCCM();
 
         if (XMEMCMP(authTag, tmpTag, authTagSz) != 0) {
@@ -831,7 +831,7 @@ int wc_GmacVerify(const byte* key, word32 keySz,
 #endif
 
     if (key == NULL || iv == NULL || (authIn == NULL && authInSz != 0) ||
-        authTag == NULL || authTagSz == 0 || authTagSz > AES_BLOCK_SIZE) {
+        authTag == NULL || authTagSz == 0 || authTagSz > WC_AES_BLOCK_SIZE) {
 
         return BAD_FUNC_ARG;
     }

--- a/wolfcrypt/src/port/xilinx/xil-aesgcm.c
+++ b/wolfcrypt/src/port/xilinx/xil-aesgcm.c
@@ -219,10 +219,10 @@ static WC_INLINE int handle_aad(       Aes* aes,
                                       byte* authTag,
                                 const byte* authIn, word32 authInSz) {
     int ret;
-    byte scratch[AES_BLOCK_SIZE];
-    byte initalCounter[AES_BLOCK_SIZE] = { 0 };
+    byte scratch[WC_AES_BLOCK_SIZE];
+    byte initalCounter[WC_AES_BLOCK_SIZE] = { 0 };
     XMEMCPY(initalCounter, iv, AEAD_NONCE_SZ);
-    initalCounter[AES_BLOCK_SIZE - 1] = 1;
+    initalCounter[WC_AES_BLOCK_SIZE - 1] = 1;
     GHASH(&aes->gcm, authIn, authInSz, data, sz, authTag, AES_GCM_AUTH_SZ);
     ret = wc_AesEncryptDirect(aes, scratch, initalCounter);
     if (ret == 0)
@@ -524,8 +524,8 @@ int  wc_AesGcmEncrypt(Aes* aes, byte* out,
                                    const byte* authIn, word32 authInSz)
 {
     byte* tmp;
-    byte scratch[AES_BLOCK_SIZE];
-    byte initalCounter[AES_BLOCK_SIZE];
+    byte scratch[WC_AES_BLOCK_SIZE];
+    byte initalCounter[WC_AES_BLOCK_SIZE];
     int ret;
 
     if ((in == NULL && sz > 0) || iv == NULL || authTag == NULL ||
@@ -572,9 +572,9 @@ int  wc_AesGcmEncrypt(Aes* aes, byte* out,
     /* handle completing tag with any additional data */
     if (authIn != NULL) {
         /* @TODO avoid hashing out again since Xilinx call already does */
-        XMEMSET(initalCounter, 0, AES_BLOCK_SIZE);
+        XMEMSET(initalCounter, 0, WC_AES_BLOCK_SIZE);
         XMEMCPY(initalCounter, iv, ivSz);
-        initalCounter[AES_BLOCK_SIZE - 1] = 1;
+        initalCounter[WC_AES_BLOCK_SIZE - 1] = 1;
         GHASH(&aes->gcm, authIn, authInSz, out, sz, authTag, authTagSz);
         ret = wc_AesEncryptDirect(aes, scratch, initalCounter);
         if (ret < 0)
@@ -594,8 +594,8 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out,
 {
     byte* tag;
     byte buf[AES_GCM_AUTH_SZ];
-    byte scratch[AES_BLOCK_SIZE];
-    byte initalCounter[AES_BLOCK_SIZE];
+    byte scratch[WC_AES_BLOCK_SIZE];
+    byte initalCounter[WC_AES_BLOCK_SIZE];
     int ret;
 
     if (in == NULL || iv == NULL || authTag == NULL ||
@@ -610,9 +610,9 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out,
 
     /* account for additional data */
     if (authIn != NULL && authInSz > 0) {
-        XMEMSET(initalCounter, 0, AES_BLOCK_SIZE);
+        XMEMSET(initalCounter, 0, WC_AES_BLOCK_SIZE);
         XMEMCPY(initalCounter, iv, ivSz);
-        initalCounter[AES_BLOCK_SIZE - 1] = 1;
+        initalCounter[WC_AES_BLOCK_SIZE - 1] = 1;
         tag = buf;
         GHASH(&aes->gcm, NULL, 0, in, sz, tag, AES_GCM_AUTH_SZ);
         ret = wc_AesEncryptDirect(aes, scratch, initalCounter);

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -850,7 +850,7 @@ WOLFSSL_API int wc_AesEaxFree(AesEax* eax);
  */
 #define GHASH_ONE_BLOCK(aes, block)                     \
     do {                                                \
-        xorbuf(AES_TAG(aes), block, AES_BLOCK_SIZE);    \
+        xorbuf(AES_TAG(aes), block, WC_AES_BLOCK_SIZE); \
         GMULT_AARCH64(AES_TAG(aes), aes->gcm.H);        \
     }                                                   \
     while (0)


### PR DESCRIPTION
wolfssl/wolfcrypt/aes.h: fix stray reference to `AES_BLOCK_SIZE` in def for `GHASH_ONE_BLOCK()`.

In `wolfcrypt/src/port/` and `IDE/`, replace remaining uses of `AES_BLOCK_SIZE` with `WC_AES_BLOCKSIZE` for compatibility with `OPENSSL_COEXIST`.

Automated replacement with
```
git ls-files -z wolfcrypt/src/port/ IDE/ | xargs -0 pcre2grep -l '[^_]AES_BLOCK_SIZE' | xargs sed --regexp-extended --in-place 's/([^_])AES_BLOCK_SIZE/\1WC_AES_BLOCK_SIZE/g'
```

Checked for mis-transformations with
```
git ls-files -z | xargs -0 pcre2grep '[^-[()+*/[:space:]]WC_AES_BLOCK_SIZE' | less
```

Checked for residual hits with
```
git ls-files -z | xargs -0 pcre2grep '[^_]AES_BLOCK_SIZE' | less
```

Deliberately excluded:
* `ChangeLog.md` -- do not alter history.
* `doc/` -- do not confuse documentation with newly prefixed macro, because `AES_BLOCK_SIZE` is available unless `-DOPENSSL_COEXIST`.
* `tests/api.c` -- the unit tests deliberately use compatibility names, and are not compatible with `-DOPENSSL_COEXIST` (`tests/unit.h` expressly undefines it).
* `wrapper/CSharp/wolfSSL_CSharp/wolfCrypt.cs` -- false positive hits on C# names.
* `wrapper/CSharp/wolfCrypt-Test/wolfCrypt-Test.cs` -- false positive hits on C# names.
* reference in `wolfssl/wolfcrypt/aes.h` that defines `AES_BLOCK_SIZE` when `-UOPENSSL_COEXIST`.
* reference in `wolfssl/wolfcrypt/settings.h` that defines `WC_AES_BLOCK_SIZE` for old FIPS when `-UWC_AES_BLOCK_SIZE`.

Tested with `wolfssl-multi-test.sh ... check-source-text quantum-safe-wolfssl-all-g++-latest-debug quantum-safe-wolfssl-all-cppcheck clang-tidy-all-sp-all sanitizer-all-intelasm-c-fallback-fuzzer`

Note, this PR extends the work merged in #8265.
