### PR TITLE
Fix for finishedSz checking with TLSv1.3 and `WOLFSSL_HAVE_TLS_UNIQUE` (CID444418)

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -10865,12 +10865,12 @@ int DoTls13Finished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     }
 
     if (sniff == NO_SNIFF) {
-        ret = BuildTls13HandshakeHmac(ssl, secret, mac, &finishedSz);
 
-        if (finishedSz > WOLFSSL_MAX_8BIT) {
+        ret = BuildTls13HandshakeHmac(ssl, secret, mac, &finishedSz);
+    #ifdef WOLFSSL_HAVE_TLS_UNIQUE
+        if (finishedSz > TLS_FINISHED_SZ_MAX) {
             return BUFFER_ERROR;
         }
-    #ifdef WOLFSSL_HAVE_TLS_UNIQUE
         if (ssl->options.side == WOLFSSL_CLIENT_END) {
             XMEMCPY(ssl->serverFinished, mac, finishedSz);
             ssl->serverFinished_len = (byte)finishedSz;


### PR DESCRIPTION
# Description

Fix for `finishedSz` checking with TLSv1.3 and `WOLFSSL_HAVE_TLS_UNIQUE`.
Fixes CID444418. 
Introduced in https://github.com/wolfSSL/wolfssl/pull/8181

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
