### PR TITLE
ntp 4.2.8p17 additions

### DIFF
--- a/.github/workflows/ntp.yml
+++ b/.github/workflows/ntp.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         # List of releases to test
-        ref: [ 4.2.8p15 ]
+        ref: [ 4.2.8p15, 4.2.8p17 ]
     name: ${{ matrix.ref }}
     if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-22.04

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -18124,6 +18124,9 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
     #ifdef WOLFSSL_MD2
         { WC_NID_md2, MD2h, oidHashType, "MD2", "md2"},
     #endif
+    #ifndef NO_MD4
+        { WC_NID_md4, MD4h, oidHashType, "MD4", "md4"},
+    #endif
     #ifndef NO_MD5
         { WC_NID_md5, MD5h, oidHashType, "MD5", "md5"},
     #endif

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -202,79 +202,20 @@
  *
  * For OpenSSL compatibility.
  *
- * This function shouldn't exist!
- * Uses defines in wolfssl/openssl/evp.h.
- * Uses EccEnumToNID which uses defines in wolfssl/openssl/ec.h.
- *
  * @param [in] sn  Short name of OID.
  * @return  NID corresponding to shortname on success.
  * @return  WC_NID_undef when not recognized.
  */
 int wc_OBJ_sn2nid(const char *sn)
 {
-    const struct {
-        const char *sn;
-        int  nid;
-    } sn2nid[] = {
-#ifndef NO_CERTS
-        {WOLFSSL_COMMON_NAME, WC_NID_commonName},
-        {WOLFSSL_COUNTRY_NAME, WC_NID_countryName},
-        {WOLFSSL_LOCALITY_NAME, WC_NID_localityName},
-        {WOLFSSL_STATE_NAME, WC_NID_stateOrProvinceName},
-        {WOLFSSL_ORG_NAME, WC_NID_organizationName},
-        {WOLFSSL_ORGUNIT_NAME, WC_NID_organizationalUnitName},
-    #ifdef WOLFSSL_CERT_NAME_ALL
-        {WOLFSSL_NAME, WC_NID_name},
-        {WOLFSSL_INITIALS, WC_NID_initials},
-        {WOLFSSL_GIVEN_NAME, WC_NID_givenName},
-        {WOLFSSL_DNQUALIFIER, WC_NID_dnQualifier},
-    #endif
-        {WOLFSSL_EMAIL_ADDR, WC_NID_emailAddress},
-#endif
-        {"SHA1", WC_NID_sha1},
-        {NULL, -1}};
-    int i;
-#ifdef HAVE_ECC
-    char curveName[ECC_MAXNAME + 1];
-    int eccEnum;
-#endif
-
+    const WOLFSSL_ObjectInfo *obj_info = wolfssl_object_info;
+    size_t i;
     WOLFSSL_ENTER("wc_OBJ_sn2nid");
-
-    for(i=0; sn2nid[i].sn != NULL; i++) {
-        if (XSTRCMP(sn, sn2nid[i].sn) == 0) {
-            return sn2nid[i].nid;
-        }
+    for (i = 0; i < wolfssl_object_info_sz; i++, obj_info++) {
+        if (XSTRCMP(sn, obj_info->sName) == 0)
+            return obj_info->nid;
     }
-
-#ifdef HAVE_ECC
-    if (XSTRLEN(sn) > ECC_MAXNAME)
-        return WC_NID_undef;
-
-    /* Nginx uses this OpenSSL string. */
-    if (XSTRCMP(sn, "prime256v1") == 0)
-        sn = "SECP256R1";
-    /* OpenSSL allows lowercase curve names */
-    for (i = 0; i < (int)(sizeof(curveName) - 1) && *sn; i++) {
-        curveName[i] = (char)XTOUPPER((unsigned char) *sn++);
-    }
-    curveName[i] = '\0';
-    /* find based on name and return NID */
-    for (i = 0;
-#ifndef WOLFSSL_ECC_CURVE_STATIC
-         ecc_sets[i].size != 0 && ecc_sets[i].name != NULL;
-#else
-         ecc_sets[i].size != 0;
-#endif
-         i++) {
-        if (XSTRCMP(curveName, ecc_sets[i].name) == 0) {
-            eccEnum = ecc_sets[i].id;
-            /* Convert enum value in ecc_curve_id to OpenSSL NID */
-            return EccEnumToNID(eccEnum);
-        }
-    }
-#endif /* HAVE_ECC */
-
+    WOLFSSL_MSG("short name not found in table");
     return WC_NID_undef;
 }
 #endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */

--- a/tests/api.c
+++ b/tests/api.c
@@ -76143,14 +76143,10 @@ static int test_wolfSSL_OBJ_sn(void)
                            NID_stateOrProvinceName,NID_organizationName,
                            NID_organizationalUnitName,NID_emailAddress};
     const char* sn_open_set[] = {"CN","C","L","ST","O","OU","emailAddress"};
-    const char* sn_wolf_set[] = {WOLFSSL_COMMON_NAME,WOLFSSL_COUNTRY_NAME,
-                                WOLFSSL_LOCALITY_NAME, WOLFSSL_STATE_NAME,
-                                WOLFSSL_ORG_NAME, WOLFSSL_ORGUNIT_NAME,
-                                WOLFSSL_EMAIL_ADDR};
 
     ExpectIntEQ(wolfSSL_OBJ_sn2nid(NULL), NID_undef);
     for (i = 0; i < maxIdx; i++) {
-        ExpectIntEQ(wolfSSL_OBJ_sn2nid(sn_wolf_set[i]), nid_set[i]);
+        ExpectIntEQ(wolfSSL_OBJ_sn2nid(sn_open_set[i]), nid_set[i]);
         ExpectStrEQ(wolfSSL_OBJ_nid2sn(nid_set[i]), sn_open_set[i]);
     }
 

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -10884,6 +10884,10 @@ const WOLFSSL_EVP_MD* wolfSSL_EVP_get_digestbynid(int id)
     WOLFSSL_MSG("wolfSSL_get_digestbynid");
 
     switch(id) {
+#ifndef NO_MD4
+        case WC_NID_md4:
+            return wolfSSL_EVP_md4();
+#endif
 #ifndef NO_MD5
         case WC_NID_md5:
             return wolfSSL_EVP_md5();

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1249,6 +1249,7 @@ enum Oid_Types {
 
 enum Hash_Sum  {
     MD2h      = 646,
+    MD4h      = 648,
     MD5h      = 649,
     SHAh      =  88,
     SHA224h   = 417,


### PR DESCRIPTION
- OBJ_sn2nid: use correct short names
- Add MD4 to EVP layer
- Add ntp 4.2.8p17 to tested versions