### PR TITLE
Fix missing heap hint in RNG health test XMALLOC call

### DIFF
--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -2184,7 +2184,7 @@ static int wc_RNG_HealthTestLocal(int reseed, void* heap, int devId)
 #endif
 
 #ifdef WOLFSSL_SMALL_STACK
-    check = (byte*)XMALLOC(RNG_HEALTH_TEST_CHECK_SIZE, NULL,
+    check = (byte*)XMALLOC(RNG_HEALTH_TEST_CHECK_SIZE, heap,
                            DYNAMIC_TYPE_TMP_BUFFER);
     if (check == NULL) {
         return MEMORY_E;
@@ -2304,7 +2304,7 @@ static int wc_RNG_HealthTestLocal(int reseed, void* heap, int devId)
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(check, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(check, heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return ret;


### PR DESCRIPTION
Pass provided heap hint to XMALLOC instead of NULL in RNG health test function to ensure proper memory allocation with custom heap.
Reported by zd#19102.