### PR TITLE
20250107-clang-tidy-null-derefs

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -4316,6 +4316,11 @@ int TLSX_UseCertificateStatusRequestV2(TLSX** extensions, byte status_type,
         CertificateStatusRequestItemV2* last =
                                (CertificateStatusRequestItemV2*)extension->data;
 
+        if (last == NULL) {
+            XFREE(csr2, heap, DYNAMIC_TYPE_TLSX);
+            return BAD_FUNC_ARG;
+        }
+
         for (; last->next; last = last->next);
 
         last->next = csr2;

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -1144,7 +1144,7 @@ static WARN_UNUSED_RESULT int freeDecCertList(WC_DerCertList** list,
 #ifdef ASN_BER_TO_DER
 /* append data to encrypted content cache in PKCS12 structure
  * return buffer on success, NULL on error */
-static byte* PKCS12_ConcatonateContent(WC_PKCS12* pkcs12,byte* mergedData,
+static byte* PKCS12_ConcatenateContent(WC_PKCS12* pkcs12,byte* mergedData,
         word32* mergedSz, byte* in, word32 inSz)
 {
     byte* oldContent;
@@ -1257,7 +1257,7 @@ static int PKCS12_CoalesceOctetStrings(WC_PKCS12* pkcs12, byte* data,
                     ret = MEMORY_E;
                 }
             }
-            mergedData = PKCS12_ConcatonateContent(pkcs12, mergedData,
+            mergedData = PKCS12_ConcatenateContent(pkcs12, mergedData,
                     &mergedSz, &data[*idx], (word32)encryptedContentSz);
             if (mergedData == NULL) {
                 ret = MEMORY_E;
@@ -1269,15 +1269,17 @@ static int PKCS12_CoalesceOctetStrings(WC_PKCS12* pkcs12, byte* data,
         *idx += (word32)encryptedContentSz;
     }
 
-    *idx = saveIdx;
+    if (ret == 0) {
+        *idx = saveIdx;
 
-    *idx += SetLength(mergedSz, &data[*idx]);
+        *idx += SetLength(mergedSz, &data[*idx]);
 
-    if (mergedSz > 0) {
-        /* Copy over concatenated octet strings into data buffer */
-        XMEMCPY(&data[*idx], mergedData, mergedSz);
+        if (mergedSz > 0) {
+            /* Copy over concatenated octet strings into data buffer */
+            XMEMCPY(&data[*idx], mergedData, mergedSz);
 
-        XFREE(mergedData, pkcs12->heap, DYNAMIC_TYPE_PKCS);
+            XFREE(mergedData, pkcs12->heap, DYNAMIC_TYPE_PKCS);
+        }
     }
 
     return ret;


### PR DESCRIPTION
`src/tls.c`: fix possible null deref in `TLSX_UseCertificateStatusRequestV2()`.

`wolfcrypt/src/pkcs12.c`: fix possible null deref in `PKCS12_CoalesceOctetStrings()`, and fix spelling of `PKCS12_ConcatenateContent()`.

These defects were newly detected by `clang-tidy` in `llvm-core/clang-20.0.0_pre20250104`:
```
/tmp/tmp.4346_11739/wolfssl_test_workdir.22472/wolfssl/wolfcrypt/src/pkcs12.c:1278:9: note: Null pointer passed to 2nd parameter expecting 'nonnull'
1278 |         XMEMCPY(&data[*idx], mergedData, mergedSz);
|         ^
```
```
/tmp/tmp.4346_11739/wolfssl_test_workdir.22472/wolfssl/src/tls.c:4319:16: note: Access to field 'next' results in a dereference of a null pointer (loaded from variable 'last')
4319 |         for (; last->next; last = last->next);
|                ^~~~
```

Tested with `wolfssl-multi-test.sh ... clang-tidy-all-sp-all check-source-text`.
