### PR TITLE
20250108-PKCS12_CoalesceOctetStrings-leak

### DIFF
--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -1277,10 +1277,10 @@ static int PKCS12_CoalesceOctetStrings(WC_PKCS12* pkcs12, byte* data,
         if (mergedSz > 0) {
             /* Copy over concatenated octet strings into data buffer */
             XMEMCPY(&data[*idx], mergedData, mergedSz);
-
-            XFREE(mergedData, pkcs12->heap, DYNAMIC_TYPE_PKCS);
         }
     }
+
+    XFREE(mergedData, pkcs12->heap, DYNAMIC_TYPE_PKCS);
 
     return ret;
 }


### PR DESCRIPTION
`wolfcrypt/src/pkcs12.c`: fix resource leak in `PKCS12_CoalesceOctetStrings()`.

tested with `wolfssl-multi-test.sh ... check-source-text quantum-safe-wolfssl-all-intelasm-sp-asm-sanitizer quantum-safe-wolfssl-all-clang-tidy`
