### PR TITLE
20250108-reproducible-build-backtrace

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -573,7 +573,10 @@ then
     AS_CASE([$xxx_ar_flags],[*'use zero for timestamps and uids/gids'*],[AR_FLAGS="Dcr" lt_ar_flags="Dcr"])
     AS_CASE([$xxx_ranlib_flags],[*'Use zero for symbol map timestamp'*],[RANLIB="${RANLIB} -D"])
 
-    AM_CFLAGS="$AM_CFLAGS -DHAVE_REPRODUCIBLE_BUILD -g0"
+    if test "$ENABLED_DEBUG_TRACE_ERRCODES" != "backtrace"
+    then
+        AM_CFLAGS="$AM_CFLAGS -DHAVE_REPRODUCIBLE_BUILD -g0"
+    fi
 
     # opportunistically use -ffile-prefix-map (added in GCC8 and LLVM10)
 


### PR DESCRIPTION
`configure.ac`: fix `--enable-debug-trace-errcodes=backtrace` with `--enable-reproducible-build`: don't add `-g0` to `CFLAGS` when both are enabled, because `-g0` makes backtracing impossible.

Note this also fixes `--enable-debug-trace-errcodes=backtrace` for `--enable-fips`, which implies `--enable-reproducible-build`.

Tested with `wolfssl-multi-test.sh ... check-source-text check-configure` and with
```
./configure --quiet --disable-jobserver --enable-fips=dev --enable-all --enable-testcert --enable-acert --enable-dtls13 --enable-dtls-mtu --enable-dtls-frag-ch --enable-quic --with-sys-crypto-policy --enable-experimental '--enable-kyber=all,original' --enable-lms --enable-xmss --enable-dilithium CPPFLAGS='-DHAVE_PUBLIC_FFDHE -DWOLFCRYPT_FIPS_CORE_HASH_VALUE=9E18EBC1F3C2858202657806D22FBC7B02AE3A547C15A99FCCB49C8900D295A2' --enable-debug-trace-errcodes=backtrace
```
