### PR TITLE
Fix the typo in aarch64 AES MPULL macro.

### DIFF
--- a/wolfcrypt/src/cpuid.c
+++ b/wolfcrypt/src/cpuid.c
@@ -259,7 +259,7 @@
 
             if (features & CPUID_AARCH64_FEAT_AES)
                 cpuid_flags |= CPUID_AES;
-            if (features & CPUID_AARCH64_FEAT_PMULL)
+            if (features & CPUID_AARCH64_FEAT_AES_PMULL)
                 cpuid_flags |= CPUID_PMULL;
             if (features & CPUID_AARCH64_FEAT_SHA256)
                 cpuid_flags |= CPUID_SHA256;


### PR DESCRIPTION
# Description

Currently the build fails in FreeBSD `aarch64` with the following message

> FreeBSD main-arm64-default-job-07 15.0-CURRENT FreeBSD 15.0-CURRENT 1500030 arm64

```
wolfcrypt/src/cpuid.c:262:28: error: use of undeclared identifier 'CPUID_AARCH64_FEAT_PMULL'
  262 |             if (features & CPUID_AARCH64_FEAT_PMULL)
      |                            ^
1 error generated.
--- wolfcrypt/src/src_libwolfssl_la-sp_int.lo ---
--- wolfcrypt/src/src_libwolfssl_la-cpuid.lo ---
*** [wolfcrypt/src/src_libwolfssl_la-cpuid.lo] Error code 1

make[2]: stopped making "all-am" in /wrkdirs/usr/ports/security/wolfssl/work/wolfssl-5.7.6
```

[Full build log](https://pkg-status.freebsd.org/ampere2/data/main-arm64-default/p1afdc808e67b_s62e841ccce3/logs/wolfssl-5.7.6.log)

The PR fixes the typo in the macro name.

# Testing

Applied the patch and was able to rebuild successfully in `aarch64`.


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
