### PR TITLE
Aarch64 CPU Id: FreeBSD/OpenBSD fix

### DIFF
--- a/wolfcrypt/src/cpuid.c
+++ b/wolfcrypt/src/cpuid.c
@@ -259,8 +259,10 @@
 
             if (features & CPUID_AARCH64_FEAT_AES)
                 cpuid_flags |= CPUID_AES;
-            if (features & CPUID_AARCH64_FEAT_PMULL)
+            if (features & CPUID_AARCH64_FEAT_AES_PMULL) {
+                cpuid_flags |= CPUID_AES;
                 cpuid_flags |= CPUID_PMULL;
+            }
             if (features & CPUID_AARCH64_FEAT_SHA256)
                 cpuid_flags |= CPUID_SHA256;
             if (features & CPUID_AARCH64_FEAT_SHA256_512)


### PR DESCRIPTION
# Description

Fix name and flags set.

Fixes #8347

# Testing

Customer tested.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
