### PR TITLE
20250109-memory-errors

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -1027,6 +1027,7 @@ static int DupX509_CRL(WOLFSSL_X509_CRL *dupl, const WOLFSSL_X509_CRL* crl)
             if (dupl->monitors[0].path != NULL) {
                 XFREE(dupl->monitors[0].path, dupl->heap,
                         DYNAMIC_TYPE_CRL_MONITOR);
+                dupl->monitors[0].path = NULL;
             }
             return MEMORY_E;
         }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -7991,7 +7991,7 @@ int wolfSSL_i2d_PKCS8_PKEY(WOLFSSL_PKCS8_PRIV_KEY_INFO* key, unsigned char** pp)
         return WOLFSSL_FATAL_ERROR;
     len = (int)keySz;
 
-    if (pp == NULL)
+    if ((pp == NULL) || (len == 0))
         return len;
 
     if (*pp == NULL) {

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -6960,7 +6960,7 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         echX = TLSX_Find(ssl->extensions, TLSX_ECH);
 
         if (echX == NULL)
-            return WOLFSSL_FATAL_ERROR;
+            ERROR_OUT(WOLFSSL_FATAL_ERROR, exit_dch);
 
         ((WOLFSSL_ECH*)echX->data)->aad = input + HANDSHAKE_HEADER_SZ;
         ((WOLFSSL_ECH*)echX->data)->aadLen = helloSz;

--- a/src/x509.c
+++ b/src/x509.c
@@ -1690,7 +1690,6 @@ WOLFSSL_v3_ext_method* wolfSSL_X509V3_EXT_get(WOLFSSL_X509_EXTENSION* ex)
         WOLFSSL_MSG("Failed to get nid from passed extension object");
         return NULL;
     }
-    XMEMSET(&method, 0, sizeof(WOLFSSL_v3_ext_method));
     switch (nid) {
         case WC_NID_basic_constraints:
             break;

--- a/tests/api.c
+++ b/tests/api.c
@@ -33411,7 +33411,7 @@ static int test_wc_dilithium_check_key(void)
         &privCheckKeyLen, pubCheckKey, &pubCheckKeyLen), 0);
 
     /* Modify hash. */
-    if (pubCheckKey != NULL) {
+    if ((pubCheckKey != NULL) && EXPECT_SUCCESS()) {
         pubCheckKey[0] ^= 0x80;
         ExpectIntEQ(wc_dilithium_import_key(NULL, 0, NULL, 0, NULL),
             WC_NO_ERR_TRACE(BAD_FUNC_ARG));
@@ -78037,7 +78037,6 @@ static int test_wolfSSL_d2i_OCSP_CERTID(void)
 {
     EXPECT_DECLS;
 #if (defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY)) && defined(HAVE_OCSP)
-    WOLFSSL_OCSP_CERTID* certId;
     WOLFSSL_OCSP_CERTID* certIdGood;
     WOLFSSL_OCSP_CERTID* certIdBad;
     const unsigned char* rawCertIdPtr;
@@ -78056,40 +78055,49 @@ static int test_wolfSSL_d2i_OCSP_CERTID(void)
 
     /* If the cert ID is NULL the function should allocate it and copy the
      * data to it. */
-    certId = NULL;
-    ExpectNotNull(certId = wolfSSL_d2i_OCSP_CERTID(&certId, &rawCertIdPtr,
-        sizeof(rawCertId)));
-    ExpectIntEQ(certId->rawCertIdSize, sizeof(rawCertId));
-    if (certId != NULL) {
-        XFREE(certId->rawCertId, NULL, DYNAMIC_TYPE_OPENSSL);
-        XFREE(certId, NULL, DYNAMIC_TYPE_OPENSSL);
+    {
+        WOLFSSL_OCSP_CERTID* certId = NULL;
+        ExpectNotNull(certId = wolfSSL_d2i_OCSP_CERTID(&certId, &rawCertIdPtr,
+                                                       sizeof(rawCertId)));
+        ExpectIntEQ(certId->rawCertIdSize, sizeof(rawCertId));
+        if (certId != NULL) {
+            XFREE(certId->rawCertId, NULL, DYNAMIC_TYPE_OPENSSL);
+            XFREE(certId, NULL, DYNAMIC_TYPE_OPENSSL);
+        }
     }
 
     /* If the cert ID is not NULL the function will just copy the data to it. */
-    ExpectNotNull(certId = (WOLFSSL_OCSP_CERTID*)XMALLOC(sizeof(*certId), NULL,
-        DYNAMIC_TYPE_TMP_BUFFER));
-    ExpectNotNull(certId);
-    ExpectNotNull(XMEMSET(certId, 0, sizeof(*certId)));
+    {
+        WOLFSSL_OCSP_CERTID* certId = NULL;
+        ExpectNotNull(certId = (WOLFSSL_OCSP_CERTID*)XMALLOC(sizeof(*certId), NULL,
+                                                             DYNAMIC_TYPE_TMP_BUFFER));
+        ExpectNotNull(certId);
+        if (certId != NULL)
+            XMEMSET(certId, 0, sizeof(*certId));
 
-    /* Reset rawCertIdPtr since it was push forward in the previous call. */
-    rawCertIdPtr = &rawCertId[0];
-    ExpectNotNull(certIdGood = wolfSSL_d2i_OCSP_CERTID(&certId, &rawCertIdPtr,
-        sizeof(rawCertId)));
-    ExpectPtrEq(certIdGood, certId);
-    ExpectIntEQ(certId->rawCertIdSize, sizeof(rawCertId));
-    if (certId != NULL) {
-        XFREE(certId->rawCertId, NULL, DYNAMIC_TYPE_OPENSSL);
-        XFREE(certId, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        certId = NULL;
+        /* Reset rawCertIdPtr since it was push forward in the previous call. */
+        rawCertIdPtr = &rawCertId[0];
+        ExpectNotNull(certIdGood = wolfSSL_d2i_OCSP_CERTID(&certId, &rawCertIdPtr,
+                                                           sizeof(rawCertId)));
+        ExpectPtrEq(certIdGood, certId);
+        ExpectIntEQ(certId->rawCertIdSize, sizeof(rawCertId));
+        if (certId != NULL) {
+            XFREE(certId->rawCertId, NULL, DYNAMIC_TYPE_OPENSSL);
+            XFREE(certId, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            certId = NULL;
+        }
     }
 
     /* The below tests should fail when passed bad parameters. NULL should
      * always be returned. */
-    ExpectNull(certIdBad = wolfSSL_d2i_OCSP_CERTID(NULL, &rawCertIdPtr,
-        sizeof(rawCertId)));
-    ExpectNull(certIdBad = wolfSSL_d2i_OCSP_CERTID(&certId, NULL,
-        sizeof(rawCertId)));
-    ExpectNull(certIdBad = wolfSSL_d2i_OCSP_CERTID(&certId, &rawCertIdPtr, 0));
+    {
+        WOLFSSL_OCSP_CERTID* certId = NULL;
+        ExpectNull(certIdBad = wolfSSL_d2i_OCSP_CERTID(NULL, &rawCertIdPtr,
+                                                       sizeof(rawCertId)));
+        ExpectNull(certIdBad = wolfSSL_d2i_OCSP_CERTID(&certId, NULL,
+                                                       sizeof(rawCertId)));
+        ExpectNull(certIdBad = wolfSSL_d2i_OCSP_CERTID(&certId, &rawCertIdPtr, 0));
+    }
 #endif
     return EXPECT_RESULT();
 }
@@ -84988,6 +84996,7 @@ static int test_wolfSSL_PEM_X509_INFO_read_bio(void)
 
     ExpectIntEQ(0, XSTRNCMP(subject, exp1, sizeof(exp1)));
     XFREE(subject, 0, DYNAMIC_TYPE_OPENSSL);
+    subject = NULL;
     X509_INFO_free(info);
     info = NULL;
 
@@ -84997,6 +85006,7 @@ static int test_wolfSSL_PEM_X509_INFO_read_bio(void)
 
     ExpectIntEQ(0, XSTRNCMP(subject, exp2, sizeof(exp2)));
     XFREE(subject, 0, DYNAMIC_TYPE_OPENSSL);
+    subject = NULL;
     X509_INFO_free(info);
     ExpectNull(info = sk_X509_INFO_pop(sk));
 

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1725,7 +1725,9 @@ static const char* bench_result_words3[][5] = {
 #endif
 
 #ifdef LINUX_RUSAGE_UTIME
-    static void check_for_excessive_stime(const char *desc,
+    static void check_for_excessive_stime(const char *algo,
+                                          int strength,
+                                          const char *desc,
                                           const char *desc_extra);
 #endif
 
@@ -2518,7 +2520,7 @@ static void bench_stats_sym_finish(const char* desc, int useDeviceID,
 #endif
 
 #ifdef LINUX_RUSAGE_UTIME
-    check_for_excessive_stime(desc, "");
+    check_for_excessive_stime(desc, 0, "", "");
 #endif
 
     /* calculate actual bytes */
@@ -2744,7 +2746,7 @@ static void bench_stats_asym_finish_ex(const char* algo, int strength,
     total = current_time(0) - start;
 
 #ifdef LINUX_RUSAGE_UTIME
-    check_for_excessive_stime(desc, desc_extra);
+    check_for_excessive_stime(algo, strength, desc, desc_extra);
 #endif
 
 #ifdef GENERATE_MACHINE_PARSEABLE_REPORT
@@ -14672,7 +14674,9 @@ void bench_sphincsKeySign(byte level, byte optim)
             (double)rusage.ru_utime.tv_usec / MILLION_VALUE;
     }
 
-    static void check_for_excessive_stime(const char *desc,
+    static void check_for_excessive_stime(const char *algo,
+                                          int strength,
+                                          const char *desc,
                                           const char *desc_extra)
     {
         double start_utime = (double)base_rusage.ru_utime.tv_sec +
@@ -14685,11 +14689,20 @@ void bench_sphincsKeySign(byte level, byte optim)
             (double)cur_rusage.ru_stime.tv_usec / MILLION_VALUE;
         double stime_utime_ratio =
             (cur_stime - start_stime) / (cur_utime - start_utime);
-        if (stime_utime_ratio > .1)
-            printf("%swarning, "
-                   "excessive system time ratio for %s%s (" FLT_FMT_PREC "%%).\n",
-                   err_prefix, desc, desc_extra,
-                   FLT_FMT_PREC_ARGS(3, stime_utime_ratio * 100.0));
+        if (stime_utime_ratio > .1) {
+            if (strength > 0) {
+                printf("%swarning, "
+                       "excessive system time ratio for %s-%d-%s%s (" FLT_FMT_PREC "%%).\n",
+                       err_prefix, algo, strength, desc, desc_extra,
+                       FLT_FMT_PREC_ARGS(3, stime_utime_ratio * 100.0));
+            }
+            else {
+                printf("%swarning, "
+                       "excessive system time ratio for %s%s%s (" FLT_FMT_PREC "%%).\n",
+                       err_prefix, algo, desc, desc_extra,
+                       FLT_FMT_PREC_ARGS(3, stime_utime_ratio * 100.0));
+            }
+        }
     }
 
 #elif defined(WOLFSSL_LINUXKM)

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -7429,7 +7429,7 @@ int wc_CreatePKCS8Key(byte* out, word32* outSz, byte* key, word32 keySz,
         /* Get the size of the DER encoding. */
         ret = SizeASN_Items(pkcs8KeyASN, dataASN, pkcs8KeyASN_Length-1, &sz);
     }
-    if (ret == 0) {
+    if ((ret == 0) || (ret == WC_NO_ERR_TRACE(LENGTH_ONLY_E))) {
         /* Always return the calculated size. */
         *outSz = (word32)sz;
     }

--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -2036,19 +2036,21 @@ static int wc_DhAgree_Sync(DhKey* key, byte* agree, word32* agreeSz,
 #ifndef WOLFSSL_SP_NO_2048
     if (mp_count_bits(&key->p) == 2048) {
         if (mp_init(y) != MP_OKAY)
-            return MP_INIT_E;
+            ret = MP_INIT_E;
 
-        SAVE_VECTOR_REGISTERS(ret = _svr_ret;);
+        if (ret == 0) {
+            SAVE_VECTOR_REGISTERS(ret = _svr_ret;);
 
-        if (ret == 0 && mp_read_unsigned_bin(y, otherPub, pubSz) != MP_OKAY)
-            ret = MP_READ_E;
+            if (ret == 0 && mp_read_unsigned_bin(y, otherPub, pubSz) != MP_OKAY)
+                ret = MP_READ_E;
 
-        if (ret == 0)
-            ret = sp_DhExp_2048(y, priv, privSz, &key->p, agree, agreeSz);
+            if (ret == 0)
+                ret = sp_DhExp_2048(y, priv, privSz, &key->p, agree, agreeSz);
 
-        mp_clear(y);
+            mp_clear(y);
 
-        RESTORE_VECTOR_REGISTERS();
+            RESTORE_VECTOR_REGISTERS();
+        }
 
         /* make sure agree is > 1 (SP800-56A, 5.7.1.1) */
         if ((ret == 0) &&
@@ -2070,19 +2072,21 @@ static int wc_DhAgree_Sync(DhKey* key, byte* agree, word32* agreeSz,
 #ifndef WOLFSSL_SP_NO_3072
     if (mp_count_bits(&key->p) == 3072) {
         if (mp_init(y) != MP_OKAY)
-            return MP_INIT_E;
+            ret = MP_INIT_E;
 
-        SAVE_VECTOR_REGISTERS(ret = _svr_ret;);
+        if (ret == 0) {
+            SAVE_VECTOR_REGISTERS(ret = _svr_ret;);
 
-        if (ret == 0 && mp_read_unsigned_bin(y, otherPub, pubSz) != MP_OKAY)
-            ret = MP_READ_E;
+            if (ret == 0 && mp_read_unsigned_bin(y, otherPub, pubSz) != MP_OKAY)
+                ret = MP_READ_E;
 
-        if (ret == 0)
-            ret = sp_DhExp_3072(y, priv, privSz, &key->p, agree, agreeSz);
+            if (ret == 0)
+                ret = sp_DhExp_3072(y, priv, privSz, &key->p, agree, agreeSz);
 
-        mp_clear(y);
+            mp_clear(y);
 
-        RESTORE_VECTOR_REGISTERS();
+            RESTORE_VECTOR_REGISTERS();
+        }
 
         /* make sure agree is > 1 (SP800-56A, 5.7.1.1) */
         if ((ret == 0) &&
@@ -2104,19 +2108,21 @@ static int wc_DhAgree_Sync(DhKey* key, byte* agree, word32* agreeSz,
 #ifdef WOLFSSL_SP_4096
     if (mp_count_bits(&key->p) == 4096) {
         if (mp_init(y) != MP_OKAY)
-            return MP_INIT_E;
+            ret = MP_INIT_E;
 
-        SAVE_VECTOR_REGISTERS(ret = _svr_ret;);
+        if (ret == 0) {
+            SAVE_VECTOR_REGISTERS(ret = _svr_ret;);
 
-        if (ret == 0 && mp_read_unsigned_bin(y, otherPub, pubSz) != MP_OKAY)
-            ret = MP_READ_E;
+            if (ret == 0 && mp_read_unsigned_bin(y, otherPub, pubSz) != MP_OKAY)
+                ret = MP_READ_E;
 
-        if (ret == 0)
-            ret = sp_DhExp_4096(y, priv, privSz, &key->p, agree, agreeSz);
+            if (ret == 0)
+                ret = sp_DhExp_4096(y, priv, privSz, &key->p, agree, agreeSz);
 
-        mp_clear(y);
+            mp_clear(y);
 
-        RESTORE_VECTOR_REGISTERS();
+            RESTORE_VECTOR_REGISTERS();
+        }
 
         /* make sure agree is > 1 (SP800-56A, 5.7.1.1) */
         if ((ret == 0) &&

--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -2195,7 +2195,7 @@ static int dilithium_rej_ntt_poly_ex(wc_Shake* shake128, byte* seed, sword32* a,
 static int dilithium_rej_ntt_poly(wc_Shake* shake128, byte* seed, sword32* a,
     void* heap)
 {
-    int ret;
+    int ret = 0;
 #if defined(WOLFSSL_SMALL_STACK)
     byte* h = NULL;
 #else
@@ -2212,7 +2212,8 @@ static int dilithium_rej_ntt_poly(wc_Shake* shake128, byte* seed, sword32* a,
     }
 #endif
 
-    ret = dilithium_rej_ntt_poly_ex(shake128, seed, a, h);
+    if (ret == 0)
+        ret = dilithium_rej_ntt_poly_ex(shake128, seed, a, h);
 
 #if defined(WOLFSSL_SMALL_STACK)
     XFREE(h, heap, DYNAMIC_TYPE_DILITHIUM);
@@ -6076,6 +6077,7 @@ static int dilithium_sign_with_seed_mu(dilithium_key* key,
             ret = MEMORY_E;
         }
         else {
+            XMEMSET(key->s1, 0, params->aSz);
             key->s2 = key->s1  + params->s1Sz / sizeof(*s1);
             key->t0 = key->s2  + params->s2Sz / sizeof(*s2);
         }
@@ -7223,6 +7225,9 @@ static int dilithium_verify_mu(dilithium_key* key, const byte* mu,
         if (key->a == NULL) {
             ret = MEMORY_E;
         }
+        else {
+            XMEMSET(key->a, 0, params->aSz);
+        }
     }
 #endif
     if (ret == 0) {
@@ -7236,6 +7241,9 @@ static int dilithium_verify_mu(dilithium_key* key, const byte* mu,
             DYNAMIC_TYPE_DILITHIUM);
         if (key->t1 == NULL) {
             ret = MEMORY_E;
+        }
+        else {
+            XMEMSET(key->t1, 0, params->s2Sz);
         }
     }
 #endif
@@ -7259,6 +7267,7 @@ static int dilithium_verify_mu(dilithium_key* key, const byte* mu,
             ret = MEMORY_E;
         }
         else {
+            XMEMSET(z, 0, allocSz);
             c   = z  + params->s1Sz / sizeof(*z);
             w   = c  + DILITHIUM_N;
 #ifndef WC_DILITHIUM_CACHE_PUB_VECTORS
@@ -7387,6 +7396,7 @@ static int dilithium_verify_mu(dilithium_key* key, const byte* mu,
             ret = MEMORY_E;
         }
         else {
+            XMEMSET(z, 0, allocSz);
             c     = z + params->s1Sz / sizeof(*t1);
             w     = c + DILITHIUM_N;
             t1    = w + DILITHIUM_N;
@@ -8908,6 +8918,7 @@ int wc_dilithium_check_key(dilithium_key* key)
             ret = MEMORY_E;
         }
         else {
+            XMEMSET(s1, 0, allocSz);
             s2 = s1 + params->s1Sz / sizeof(*s1);
             t0 = s2 + params->s2Sz / sizeof(*s2);
             t  = t0 + params->s2Sz / sizeof(*t0);
@@ -9197,6 +9208,9 @@ int wc_dilithium_import_public(const byte* in, word32 inLen, dilithium_key* key)
             if (key->t1 == NULL) {
                 ret = MEMORY_E;
             }
+            else {
+                XMEMSET(key->t1, 0, key->params->s2Sz);
+            }
         }
     #endif
     }
@@ -9212,6 +9226,9 @@ int wc_dilithium_import_public(const byte* in, word32 inLen, dilithium_key* key)
                 DYNAMIC_TYPE_DILITHIUM);
             if (key->a == NULL) {
                 ret = MEMORY_E;
+            }
+            else {
+                XMEMSET(key->a, 0, params->aSz);
             }
         }
     #endif
@@ -9282,6 +9299,9 @@ static int dilithium_set_priv_key(const byte* priv, word32 privSz,
             if (key->a == NULL) {
                 ret = MEMORY_E;
             }
+            else {
+                XMEMSET(key->a, 0, params->aSz);
+            }
         }
     }
 #endif
@@ -9302,6 +9322,9 @@ static int dilithium_set_priv_key(const byte* priv, word32 privSz,
             key->heap, DYNAMIC_TYPE_DILITHIUM);
         if (key->s1 == NULL) {
             ret = MEMORY_E;
+        }
+        else {
+            XMEMSET(key->s1, 0, params->s1Sz + params->s2Sz + params->s2Sz);
         }
         if (ret == 0) {
             /* Set pointers into allocated memory. */

--- a/wolfcrypt/src/hpke.c
+++ b/wolfcrypt/src/hpke.c
@@ -1021,8 +1021,10 @@ static int wc_HpkeDecap(Hpke* hpke, void* receiverKey, const byte* pubKey,
 #ifdef ECC_TIMING_RESISTANT
                 rng = wc_rng_new(NULL, 0, hpke->heap);
 
-                if (rng == NULL)
-                    return RNG_FAILURE_E;
+                if (rng == NULL) {
+                    ret = RNG_FAILURE_E;
+                    break;
+                }
 
                 wc_ecc_set_rng((ecc_key*)receiverKey, rng);
 #endif

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -289,6 +289,7 @@ static int GetSafeContent(WC_PKCS12* pkcs12, const byte* input,
         if (wc_BerToDer(input, safe->dataSz, NULL,
                         &pkcs12->safeDersz) != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
             WOLFSSL_MSG("Not BER sequence");
+            freeSafe(safe, pkcs12->heap);
             return ASN_PARSE_E;
         }
 

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -297,7 +297,9 @@ static int wc_PKCS7_AddDataToStream(wc_PKCS7* pkcs7, byte* in, word32 inSz,
         }
 
         /* check if internal buffer size needs to be increased */
-        if (len + pkcs7->stream->length > pkcs7->stream->bufferSz) {
+        if ((len + pkcs7->stream->length > pkcs7->stream->bufferSz) ||
+            (pkcs7->stream->buffer == NULL))
+        {
             int ret = wc_PKCS7_GrowStream(pkcs7, expected);
             if (ret < 0) {
                 return ret;
@@ -11530,6 +11532,10 @@ static int wc_PKCS7_DecryptKari(wc_PKCS7* pkcs7, byte* in, word32 inSz,
                 ret = wc_ecc_export_x963(kari->senderKey, NULL, &tmpKeySz);
                 PRIVATE_KEY_LOCK();
                 if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
+                    wc_PKCS7_KariFree(kari);
+                    #ifdef WOLFSSL_SMALL_STACK
+                    XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+                    #endif
                     return ret;
                 }
 
@@ -11544,12 +11550,20 @@ static int wc_PKCS7_DecryptKari(wc_PKCS7* pkcs7, byte* in, word32 inSz,
                 tmpKeyDer = (byte*)XMALLOC(tmpKeySz, pkcs7->heap,
                         DYNAMIC_TYPE_TMP_BUFFER);
                 if (tmpKeyDer == NULL) {
+                    wc_PKCS7_KariFree(kari);
+                    #ifdef WOLFSSL_SMALL_STACK
+                    XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+                    #endif
                     return MEMORY_E;
                 }
 
                 ret = wc_EccPublicKeyToDer(kari->senderKey, tmpKeyDer,
                                          tmpKeySz, 1);
                 if (ret < 0) {
+                    wc_PKCS7_KariFree(kari);
+                    #ifdef WOLFSSL_SMALL_STACK
+                    XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+                    #endif
                     XFREE(tmpKeyDer, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
                     return ret;
                 }
@@ -12889,17 +12903,20 @@ int wc_PKCS7_EncodeAuthEnvelopedData(wc_PKCS7* pkcs7, byte* output,
                               (int)pkcs7->unauthAttribsSz);
         unauthAttribsCount = pkcs7->unauthAttribsSz;
 
-        flatUnauthAttribs = (byte*)XMALLOC(unauthAttribsSz, pkcs7->heap,
-                                            DYNAMIC_TYPE_PKCS7);
-        if (flatUnauthAttribs == NULL) {
-            wc_PKCS7_FreeEncodedRecipientSet(pkcs7);
-            XFREE(aadBuffer, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
-            XFREE(flatAuthAttribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
-            return MEMORY_E;
+        if (unauthAttribsSz > 0) {
+            flatUnauthAttribs = (byte*)XMALLOC(unauthAttribsSz, pkcs7->heap,
+                                               DYNAMIC_TYPE_PKCS7);
+            if (flatUnauthAttribs == NULL) {
+                wc_PKCS7_FreeEncodedRecipientSet(pkcs7);
+                XFREE(aadBuffer, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
+                XFREE(flatAuthAttribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+                return MEMORY_E;
+            }
+
+            FlattenAttributes(pkcs7, flatUnauthAttribs, unauthAttribs,
+                              (int)unauthAttribsCount);
         }
 
-        FlattenAttributes(pkcs7, flatUnauthAttribs, unauthAttribs,
-                          (int)unauthAttribsCount);
         unauthAttribsSetSz = SetImplicit(ASN_SET, 2, unauthAttribsSz,
                                          unauthAttribSet, 0);
     }
@@ -13098,8 +13115,10 @@ int wc_PKCS7_EncodeAuthEnvelopedData(wc_PKCS7* pkcs7, byte* output,
     if (unauthAttribsSz > 0) {
         XMEMCPY(output + idx, unauthAttribSet, unauthAttribsSetSz);
         idx += (int)unauthAttribsSetSz;
-        XMEMCPY(output + idx, flatUnauthAttribs, unauthAttribsSz);
-        idx += (int)unauthAttribsSz;
+        if (unauthAttribsSz > 0) {
+            XMEMCPY(output + idx, flatUnauthAttribs, unauthAttribsSz);
+            idx += (int)unauthAttribsSz;
+        }
     }
 
     XFREE(flatUnauthAttribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
@@ -13926,23 +13945,27 @@ int wc_PKCS7_EncodeEncryptedData(wc_PKCS7* pkcs7, byte* output, word32 outputSz)
                                      pkcs7->unprotectedAttribs,
                                      (int)pkcs7->unprotectedAttribsSz);
 
-        flatAttribs = (byte*)XMALLOC(attribsSz, pkcs7->heap,
-                                                            DYNAMIC_TYPE_PKCS7);
-        if (flatAttribs == NULL) {
-            XFREE(attribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
-            XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
-            XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
-            return MEMORY_E;
+        if (attribsSz > 0) {
+            flatAttribs = (byte*)XMALLOC(attribsSz, pkcs7->heap,
+                                         DYNAMIC_TYPE_PKCS7);
+            if (flatAttribs == NULL) {
+                XFREE(attribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+                XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+                XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+                return MEMORY_E;
+            }
+
+            ret = FlattenAttributes(pkcs7, flatAttribs, attribs,
+                                    (int)attribsCount);
+            if (ret != 0) {
+                XFREE(attribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+                XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+                XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+                XFREE(flatAttribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+                return ret;
+            }
         }
 
-        ret = FlattenAttributes(pkcs7, flatAttribs, attribs, (int)attribsCount);
-        if (ret != 0) {
-            XFREE(attribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
-            XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
-            XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
-            XFREE(flatAttribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
-            return ret;
-        }
         attribsSetSz = SetImplicit(ASN_SET, 1, attribsSz, attribSet, 0);
 
     } else {
@@ -14009,8 +14032,10 @@ int wc_PKCS7_EncodeEncryptedData(wc_PKCS7* pkcs7, byte* output, word32 outputSz)
     if (pkcs7->unprotectedAttribsSz != 0) {
         XMEMCPY(output + idx, attribSet, attribsSetSz);
         idx += (int)attribsSetSz;
-        XMEMCPY(output + idx, flatAttribs, attribsSz);
-        idx += (int)attribsSz;
+        if (attribsSz > 0) {
+            XMEMCPY(output + idx, flatAttribs, attribsSz);
+            idx += (int)attribsSz;
+        }
     }
 
     XFREE(attribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
@@ -14324,6 +14349,11 @@ int wc_PKCS7_DecodeEncryptedData(wc_PKCS7* pkcs7, byte* in, word32 inSz,
             version    = (int)pkcs7->stream->vers;
             tmpIv      = pkcs7->stream->tmpIv;
 #endif
+            if (encryptedContentSz <= 0) {
+                ret = BUFFER_E;
+                break;
+            }
+
             if (ret == 0 && (encryptedContent = (byte*)XMALLOC(
                                   (unsigned int)encryptedContentSz, pkcs7->heap,
                                   DYNAMIC_TYPE_PKCS7)) == NULL) {

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -13115,10 +13115,8 @@ int wc_PKCS7_EncodeAuthEnvelopedData(wc_PKCS7* pkcs7, byte* output,
     if (unauthAttribsSz > 0) {
         XMEMCPY(output + idx, unauthAttribSet, unauthAttribsSetSz);
         idx += (int)unauthAttribsSetSz;
-        if (unauthAttribsSz > 0) {
-            XMEMCPY(output + idx, flatUnauthAttribs, unauthAttribsSz);
-            idx += (int)unauthAttribsSz;
-        }
+        XMEMCPY(output + idx, flatUnauthAttribs, unauthAttribsSz);
+        idx += (int)unauthAttribsSz;
     }
 
     XFREE(flatUnauthAttribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);

--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -840,6 +840,8 @@ int wc_scrypt(byte* output, const byte* passwd, int passLen,
         goto end;
     }
 
+    XMEMSET(y, 0, (size_t)(blockSize * 128));
+
     /* Step 1. */
     ret = wc_PBKDF2(blocks, passwd, passLen, salt, saltLen, 1, (int)blocksSz,
                     WC_SHA256);

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -646,6 +646,8 @@ static int _ifc_pairwise_consistency_test(RsaKey* key, WC_RNG* rng)
     ret = wc_RsaEncryptSize(key);
     if (ret < 0)
         return ret;
+    else if (ret == 0)
+        return BAD_FUNC_ARG;
     sigLen = (word32)ret;
 
     WOLFSSL_MSG("Doing RSA consistency test");
@@ -1756,6 +1758,7 @@ static int RsaUnPad_PSS(byte *pkcsBlock, unsigned int pkcsBlockLen,
     if (tmp == NULL) {
         return MEMORY_E;
     }
+    XMEMSET(tmp, 0, (size_t)maskLen);
 #endif
 
     if ((ret = RsaMGF(mgf, pkcsBlock + maskLen, (word32)hLen, tmp, (word32)maskLen,

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -12003,9 +12003,14 @@ int sp_mul(const sp_int* a, const sp_int* b, sp_int* r)
     }
 
     /* Need extra digit during calculation. */
+    /* NOLINTBEGIN(clang-analyzer-core.UndefinedBinaryOperatorResult) */
+    /* clang-tidy falsely believes that r->size was corrupted by the _sp_copy()
+     * to "Copy base into working variable" in _sp_exptmod_ex().
+     */
     if ((err == MP_OKAY) && (a->used + b->used > r->size)) {
         err = MP_VAL;
     }
+    /* NOLINTEND(clang-analyzer-core.UndefinedBinaryOperatorResult) */
 
 #if 0
     if (err == MP_OKAY) {

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -17982,9 +17982,14 @@ int sp_mont_norm(sp_int* norm, const sp_int* m)
     if (err == MP_OKAY) {
         /* Find top bit and ensure norm has enough space. */
         bits = (unsigned int)sp_count_bits(m);
+        /* NOLINTBEGIN(clang-analyzer-core.UndefinedBinaryOperatorResult) */
+        /* clang-tidy falsely believes that norm->size was corrupted by the
+         * _sp_copy() to "Set real working value to base." in _sp_exptmod_ex().
+         */
         if (bits >= (unsigned int)norm->size * SP_WORD_SIZE) {
             err = MP_VAL;
         }
+        /* NOLINTEND(clang-analyzer-core.UndefinedBinaryOperatorResult) */
     }
     if (err == MP_OKAY) {
         /* Round up for case when m is less than a word - no advantage in using

--- a/wolfcrypt/src/srp.c
+++ b/wolfcrypt/src/srp.c
@@ -152,39 +152,39 @@ static int SrpHashFinal(SrpHash* hash, byte* digest)
     }
 }
 
-static word32 SrpHashSize(SrpType type)
+static int SrpHashSize(SrpType type)
 {
     switch (type) {
         case SRP_TYPE_SHA:
             #ifndef NO_SHA
                 return WC_SHA_DIGEST_SIZE;
             #else
-                return 0;
+                return ALGO_ID_E;
             #endif
 
         case SRP_TYPE_SHA256:
             #ifndef NO_SHA256
                 return WC_SHA256_DIGEST_SIZE;
             #else
-                return 0;
+                return ALGO_ID_E;
             #endif
 
         case SRP_TYPE_SHA384:
             #ifdef WOLFSSL_SHA384
                 return WC_SHA384_DIGEST_SIZE;
             #else
-                return 0;
+                return ALGO_ID_E;
             #endif
 
         case SRP_TYPE_SHA512:
             #ifdef WOLFSSL_SHA512
                 return WC_SHA512_DIGEST_SIZE;
             #else
-                return 0;
+                return ALGO_ID_E;
             #endif
 
         default:
-            return 0;
+            return ALGO_ID_E;
     }
 }
 
@@ -353,13 +353,18 @@ int wc_SrpSetParams(Srp* srp, const byte* N,    word32 nSz,
     byte digest2[SRP_MAX_DIGEST_SIZE];
     byte pad = 0;
     int r;
-    word32 i, j = 0;
+    word32 i;
+    int hashSize = 0;
 
     if (!srp || !N || !g || !salt || nSz < gSz)
         return BAD_FUNC_ARG;
 
     if (!srp->user)
         return SRP_CALL_ORDER_E;
+
+    hashSize = SrpHashSize(srp->type);
+    if (hashSize < 0)
+        return hashSize;
 
     /* Set N */
     if (mp_read_unsigned_bin(&srp->N, N, nSz) != MP_OKAY)
@@ -389,7 +394,7 @@ int wc_SrpSetParams(Srp* srp, const byte* N,    word32 nSz,
     srp->saltSz = saltSz;
 
     /* Set k = H(N, g) */
-            r = SrpHashInit(&hash, srp->type, srp->heap);
+    r = SrpHashInit(&hash, srp->type, srp->heap);
     if (!r) r = SrpHashUpdate(&hash, (byte*) N, nSz);
     for (i = 0; (word32)i < nSz - gSz; i++) {
         if (!r) r = SrpHashUpdate(&hash, &pad, 1);
@@ -414,7 +419,7 @@ int wc_SrpSetParams(Srp* srp, const byte* N,    word32 nSz,
 
     /* digest1 = H(N) ^ H(g) */
     if (r == 0) {
-        for (i = 0, j = SrpHashSize(srp->type); i < j; i++)
+        for (i = 0; i < (word32)hashSize; i++)
             digest1[i] ^= digest2[i];
     }
 
@@ -425,8 +430,8 @@ int wc_SrpSetParams(Srp* srp, const byte* N,    word32 nSz,
     SrpHashFree(&hash);
 
     /* client proof = H( H(N) ^ H(g) | H(user) | salt) */
-    if (!r) r = SrpHashUpdate(&srp->client_proof, digest1, j);
-    if (!r) r = SrpHashUpdate(&srp->client_proof, digest2, j);
+    if (!r) r = SrpHashUpdate(&srp->client_proof, digest1, (word32)hashSize);
+    if (!r) r = SrpHashUpdate(&srp->client_proof, digest2, (word32)hashSize);
     if (!r) r = SrpHashUpdate(&srp->client_proof, salt, saltSz);
 
     return r;
@@ -436,7 +441,7 @@ int wc_SrpSetPassword(Srp* srp, const byte* password, word32 size)
 {
     SrpHash hash;
     byte digest[SRP_MAX_DIGEST_SIZE];
-    word32 digestSz;
+    int digestSz;
     int r;
 
     if (!srp || !password || srp->side != SRP_CLIENT_SIDE)
@@ -446,6 +451,8 @@ int wc_SrpSetPassword(Srp* srp, const byte* password, word32 size)
         return SRP_CALL_ORDER_E;
 
     digestSz = SrpHashSize(srp->type);
+    if (digestSz < 0)
+        return digestSz;
 
     /* digest = H(username | ':' | password) */
             r = SrpHashInit(&hash, srp->type, srp->heap);
@@ -458,12 +465,12 @@ int wc_SrpSetPassword(Srp* srp, const byte* password, word32 size)
     /* digest = H(salt | H(username | ':' | password)) */
     if (!r) r = SrpHashInit(&hash, srp->type, srp->heap);
     if (!r) r = SrpHashUpdate(&hash, srp->salt, srp->saltSz);
-    if (!r) r = SrpHashUpdate(&hash, digest, digestSz);
+    if (!r) r = SrpHashUpdate(&hash, digest, (word32)digestSz);
     if (!r) r = SrpHashFinal(&hash, digest);
     SrpHashFree(&hash);
 
     /* Set x (private key) */
-    if (!r) r = mp_read_unsigned_bin(&srp->auth, digest, digestSz);
+    if (!r) r = mp_read_unsigned_bin(&srp->auth, digest, (word32)digestSz);
 
     ForceZero(digest, SRP_MAX_DIGEST_SIZE);
 
@@ -572,9 +579,14 @@ int wc_SrpGetPublic(Srp* srp, byte* pub, word32* size)
 #endif
     word32 modulusSz;
     int r;
+    int hashSize;
 
     if (!srp || !pub || !size)
         return BAD_FUNC_ARG;
+
+    hashSize = SrpHashSize(srp->type);
+    if (hashSize < 0)
+        return hashSize;
 
     if (mp_iszero(&srp->auth) == MP_YES)
         return SRP_CALL_ORDER_E;
@@ -616,7 +628,7 @@ int wc_SrpGetPublic(Srp* srp, byte* pub, word32* size)
             {
                 r = mp_init_multi(i, j, 0, 0, 0, 0);
             }
-            if (!r) r = mp_read_unsigned_bin(i, srp->k,SrpHashSize(srp->type));
+            if (!r) r = mp_read_unsigned_bin(i, srp->k, (word32)hashSize);
             if (!r) r = mp_iszero(i) == MP_YES ? SRP_BAD_KEY_E : 0;
             if (!r) r = mp_exptmod(&srp->g, &srp->priv, &srp->N, pubkey);
             if (!r) r = mp_mulmod(i, &srp->auth, &srp->N, j);
@@ -654,17 +666,22 @@ static int wc_SrpSetKey(Srp* srp, byte* secret, word32 size)
 {
     SrpHash hash;
     byte digest[SRP_MAX_DIGEST_SIZE];
-    word32 i, j, digestSz = SrpHashSize(srp->type);
+    word32 i, j;
+    int digestSz;
     byte counter[4];
     int r = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
+    digestSz = SrpHashSize(srp->type);
+    if (digestSz < 0)
+        return digestSz;
+
     XMEMSET(digest, 0, SRP_MAX_DIGEST_SIZE);
 
-    srp->key = (byte*)XMALLOC(2 * digestSz, srp->heap, DYNAMIC_TYPE_SRP);
+    srp->key = (byte*)XMALLOC(2 * (word32)digestSz, srp->heap, DYNAMIC_TYPE_SRP);
     if (srp->key == NULL)
         return MEMORY_E;
 
-    srp->keySz = 2 * digestSz;
+    srp->keySz = 2 * (word32)digestSz;
 
     for (i = j = 0; j < srp->keySz; i++) {
         counter[0] = (byte)(i >> 24);
@@ -677,7 +694,7 @@ static int wc_SrpSetKey(Srp* srp, byte* secret, word32 size)
         if (!r) r = SrpHashUpdate(&hash, counter, 4);
 
         if (!r) {
-            if (j + digestSz > srp->keySz) {
+            if (j + (word32)digestSz > srp->keySz) {
                 r = SrpHashFinal(&hash, digest);
                 XMEMCPY(srp->key + j, digest, srp->keySz - j);
                 j = srp->keySz;
@@ -685,7 +702,7 @@ static int wc_SrpSetKey(Srp* srp, byte* secret, word32 size)
             else
             {
                 r = SrpHashFinal(&hash, srp->key + j);
-                j += digestSz;
+                j += (word32)digestSz;
             }
         }
         SrpHashFree(&hash);
@@ -715,7 +732,8 @@ int wc_SrpComputeKey(Srp* srp, byte* clientPubKey, word32 clientPubKeySz,
     mp_int u[1], s[1], temp1[1], temp2[1];
 #endif
     byte *secret = NULL;
-    word32 i, secretSz, digestSz;
+    word32 i, secretSz;
+    int digestSz;
     byte pad = 0;
     int r;
 
@@ -761,6 +779,11 @@ int wc_SrpComputeKey(Srp* srp, byte* clientPubKey, word32 clientPubKeySz,
         goto out;
 
     digestSz = SrpHashSize(srp->type);
+    if (digestSz < 0) {
+        r = digestSz;
+        goto out;
+    }
+
     secretSz = (word32)mp_unsigned_bin_size(&srp->N);
 
     if ((secretSz < clientPubKeySz) || (secretSz < serverPubKeySz)) {
@@ -795,7 +818,7 @@ int wc_SrpComputeKey(Srp* srp, byte* clientPubKey, word32 clientPubKeySz,
     /* set u */
     if ((r = SrpHashFinal(hash, digest)))
         goto out;
-    if ((r = mp_read_unsigned_bin(u, digest, SrpHashSize(srp->type))))
+    if ((r = mp_read_unsigned_bin(u, digest, (word32)digestSz)))
         goto out;
     SrpHashFree(hash);
 
@@ -804,7 +827,7 @@ int wc_SrpComputeKey(Srp* srp, byte* clientPubKey, word32 clientPubKeySz,
     if (srp->side == SRP_CLIENT_SIDE) {
 
         /* temp1 = B - k * v; rejects k == 0, B == 0 and B >= N. */
-        if ((r = mp_read_unsigned_bin(temp1, srp->k, digestSz)))
+        if ((r = mp_read_unsigned_bin(temp1, srp->k, (word32)digestSz)))
             goto out;
         if (mp_iszero(temp1) == MP_YES) {
             r = SRP_BAD_KEY_E;
@@ -940,11 +963,16 @@ int wc_SrpComputeKey(Srp* srp, byte* clientPubKey, word32 clientPubKeySz,
 int wc_SrpGetProof(Srp* srp, byte* proof, word32* size)
 {
     int r;
+    int hashSize;
 
     if (!srp || !proof || !size)
         return BAD_FUNC_ARG;
 
-    if (*size < SrpHashSize(srp->type))
+    hashSize = SrpHashSize(srp->type);
+    if (hashSize < 0)
+        return ALGO_ID_E;
+
+    if (*size < (word32)hashSize)
         return BUFFER_E;
 
     if ((r = SrpHashFinal(srp->side == SRP_CLIENT_SIDE
@@ -952,7 +980,7 @@ int wc_SrpGetProof(Srp* srp, byte* proof, word32* size)
                           : &srp->server_proof, proof)) != 0)
         return r;
 
-    *size = SrpHashSize(srp->type);
+    *size = (word32)hashSize;
 
     if (srp->side == SRP_CLIENT_SIDE) {
         /* server proof = H( A | client proof | K) */
@@ -967,11 +995,16 @@ int wc_SrpVerifyPeersProof(Srp* srp, byte* proof, word32 size)
 {
     byte digest[SRP_MAX_DIGEST_SIZE];
     int r;
+    int hashSize;
 
     if (!srp || !proof)
         return BAD_FUNC_ARG;
 
-    if (size != SrpHashSize(srp->type))
+    hashSize = SrpHashSize(srp->type);
+    if (hashSize < 0)
+        return ALGO_ID_E;
+
+    if (size != (word32)hashSize)
         return BUFFER_E;
 
     r = SrpHashFinal(srp->side == SRP_CLIENT_SIDE ? &srp->server_proof

--- a/wolfcrypt/src/wc_kyber_poly.c
+++ b/wolfcrypt/src/wc_kyber_poly.c
@@ -2400,8 +2400,10 @@ static int kyber_gen_matrix_c(KYBER_PRF_T* prf, sword16* a, int kp, byte* seed,
 
 #if !defined(WOLFSSL_KYBER_SMALL) && defined(WC_64BIT_CPU)
     /* Loading 64 bits, only using 48 bits. Loading 2 bytes more than used. */
-    rand[GEN_MATRIX_SIZE+0] = 0xff;
-    rand[GEN_MATRIX_SIZE+1] = 0xff;
+    if (ret == 0) {
+        rand[GEN_MATRIX_SIZE+0] = 0xff;
+        rand[GEN_MATRIX_SIZE+1] = 0xff;
+    }
 #endif
 
     /* Generate each vector of polynomials. */

--- a/wolfcrypt/src/wc_lms_impl.c
+++ b/wolfcrypt/src/wc_lms_impl.c
@@ -2097,8 +2097,10 @@ static int wc_lms_treehash_update(LmsState* state, LmsPrivState* privState,
 #endif /* WOLFSSL_SMALL_STACK */
 
     /* Public key, root node, is top of data stack. */
-    XMEMCPY(stack, stackCache->stack, params->height * params->hash_len);
-    sp = stack + stackCache->offset;
+    if (ret == 0) {
+        XMEMCPY(stack, stackCache->stack, params->height * params->hash_len);
+        sp = stack + stackCache->offset;
+    }
 
     /* Compute all nodes requested. */
     for (i = min_idx; (ret == 0) && (i <= max_idx); i++) {
@@ -2193,7 +2195,7 @@ static int wc_lms_treehash_update(LmsState* state, LmsPrivState* privState,
         }
     }
 
-    if (!useRoot) {
+    if (!useRoot && (ret == 0)) {
         /* Copy stack back. */
         XMEMCPY(stackCache->stack, stack, params->height * params->hash_len);
         stackCache->offset = (word32)((size_t)sp - (size_t)stack);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -7801,9 +7801,9 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t chacha_test(void)
     byte   plain_big[CHACHA_BIG_TEST_SIZE] = {0};
     byte   input_big[CHACHA_BIG_TEST_SIZE] = {0};
 #else
-    byte*  cipher_big;
-    byte*  plain_big;
-    byte*  input_big;
+    byte*  cipher_big = NULL;
+    byte*  plain_big = NULL;
+    byte*  input_big = NULL;
 #endif /* WOLFSSL_SMALL_STACK && !WOLFSSL_NO_MALLOC */
     int    block_size;
 #endif /* BENCH_EMBEDDED */
@@ -7827,17 +7827,17 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t chacha_test(void)
     cipher_big = (byte*)XMALLOC(CHACHA_BIG_TEST_SIZE, HEAP_HINT,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
     if (cipher_big == NULL) {
-        return MEMORY_E;
+        ERROR_OUT(WC_TEST_RET_ENC_ERRNO, out);
     }
     plain_big = (byte*)XMALLOC(CHACHA_BIG_TEST_SIZE, HEAP_HINT,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
     if (plain_big == NULL) {
-        return MEMORY_E;
+        ERROR_OUT(WC_TEST_RET_ENC_ERRNO, out);
     }
     input_big = (byte*)XMALLOC(CHACHA_BIG_TEST_SIZE, HEAP_HINT,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
     if (input_big == NULL) {
-        return MEMORY_E;
+        ERROR_OUT(WC_TEST_RET_ENC_ERRNO, out);
     }
     XMEMSET(cipher_big, 0, CHACHA_BIG_TEST_SIZE);
     XMEMSET(plain_big, 0, CHACHA_BIG_TEST_SIZE);
@@ -7860,24 +7860,24 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t chacha_test(void)
         ret |= wc_Chacha_SetKey(&enc, keys[i], keySz);
         ret |= wc_Chacha_SetKey(&dec, keys[i], keySz);
         if (ret != 0)
-            return ret;
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
         ret |= wc_Chacha_SetIV(&enc, cipher, 0);
         ret |= wc_Chacha_SetIV(&dec, cipher, 0);
         if (ret != 0)
-            return ret;
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
         XMEMCPY(plain, input, 8);
 
         ret |= wc_Chacha_Process(&enc, cipher, plain,  (word32)8);
         ret |= wc_Chacha_Process(&dec, plain,  cipher, (word32)8);
         if (ret != 0)
-            return ret;
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
         if (XMEMCMP(test_chacha[i], cipher, 8))
-            return WC_TEST_RET_ENC_I(i);
+            ERROR_OUT(WC_TEST_RET_ENC_I(i), out);
 
         if (XMEMCMP(plain, input, 8))
-            return WC_TEST_RET_ENC_I(i);
+            ERROR_OUT(WC_TEST_RET_ENC_I(i), out);
     }
 
     /* test of starting at a different counter
@@ -7890,20 +7890,20 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t chacha_test(void)
     ret |= wc_Chacha_SetKey(&enc, keys[0], keySz);
     ret |= wc_Chacha_SetKey(&dec, keys[0], keySz);
     if (ret != 0)
-        return ret;
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
     ret |= wc_Chacha_SetIV(&enc, cipher, 0);
     ret |= wc_Chacha_SetIV(&dec, cipher, 1);
     if (ret != 0)
-        return ret;
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
     ret |= wc_Chacha_Process(&enc, cipher, plain,  sizeof(plain));
     ret |= wc_Chacha_Process(&dec, sliver,  cipher + 64, sizeof(sliver));
     if (ret != 0)
-        return ret;
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
     if (XMEMCMP(plain + 64, sliver, 64))
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
 #ifndef BENCH_EMBEDDED
     /* test of encrypting more data */
@@ -7912,24 +7912,24 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t chacha_test(void)
     ret |= wc_Chacha_SetKey(&enc, keys[0], keySz);
     ret |= wc_Chacha_SetKey(&dec, keys[0], keySz);
     if (ret != 0)
-        return ret;
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
     ret |= wc_Chacha_SetIV(&enc, ivs[2], 0);
     ret |= wc_Chacha_SetIV(&dec, ivs[2], 0);
     if (ret != 0)
-        return ret;
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
     ret |= wc_Chacha_Process(&enc, cipher_big, plain_big, CHACHA_BIG_TEST_SIZE);
     ret |= wc_Chacha_Process(&dec, plain_big,  cipher_big,
                                                           CHACHA_BIG_TEST_SIZE);
     if (ret != 0)
-        return ret;
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
     if (XMEMCMP(plain_big, input_big, CHACHA_BIG_TEST_SIZE))
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     if (XMEMCMP(cipher_big, cipher_big_result, CHACHA_BIG_TEST_SIZE))
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     for (i = 0; i < 18; ++i) {
         /* this will test all paths
@@ -7942,23 +7942,23 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t chacha_test(void)
         ret |= wc_Chacha_SetKey(&enc, keys[0], keySz);
         ret |= wc_Chacha_SetKey(&dec, keys[0], keySz);
         if (ret != 0)
-            return ret;
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
         ret |= wc_Chacha_SetIV(&enc, ivs[2], 0);
         ret |= wc_Chacha_SetIV(&dec, ivs[2], 0);
         if (ret != 0)
-            return ret;
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
         ret |= wc_Chacha_Process(&enc, cipher_big, plain_big , (word32)block_size);
         ret |= wc_Chacha_Process(&dec, plain_big , cipher_big, (word32)block_size);
         if (ret != 0)
-            return ret;
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
         if (XMEMCMP(plain_big, input_big, (word32)block_size))
-            return WC_TEST_RET_ENC_I(i);
+            ERROR_OUT(WC_TEST_RET_ENC_I(i), out);
 
         if (XMEMCMP(cipher_big, cipher_big_result, (word32)block_size))
-            return WC_TEST_RET_ENC_I(i);
+            ERROR_OUT(WC_TEST_RET_ENC_I(i), out);
     }
 
     /* Streaming test */
@@ -7967,50 +7967,56 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t chacha_test(void)
 
         ret = wc_Chacha_SetKey(&enc, keys[0], keySz);
         if (ret != 0)
-            return WC_TEST_RET_ENC_EC(ret);
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
         ret = wc_Chacha_SetKey(&dec, keys[0], keySz);
         if (ret != 0)
-            return WC_TEST_RET_ENC_EC(ret);
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
         ret = wc_Chacha_SetIV(&enc, ivs[2], 0);
         if (ret != 0)
-            return WC_TEST_RET_ENC_EC(ret);
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
         ret = wc_Chacha_SetIV(&dec, ivs[2], 0);
         if (ret != 0)
-            return WC_TEST_RET_ENC_EC(ret);
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
         for (j = 0; j < CHACHA_BIG_TEST_SIZE - i; j+= i) {
             ret = wc_Chacha_Process(&enc, cipher_big + j, plain_big + j, (word32)i);
             if (ret != 0)
-                return WC_TEST_RET_ENC_EC(ret);
+                ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
             ret = wc_Chacha_Process(&dec, plain_big + j, cipher_big + j, (word32)i);
             if (ret != 0)
-                return WC_TEST_RET_ENC_EC(ret);
+                ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
         }
 
         rem = CHACHA_BIG_TEST_SIZE - j;
         ret = wc_Chacha_Process(&enc, cipher_big + j, plain_big + j, (word32)rem);
         if (ret != 0)
-            return WC_TEST_RET_ENC_EC(ret);
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
         ret = wc_Chacha_Process(&dec, plain_big + j, cipher_big + j, (word32)rem);
         if (ret != 0)
-            return WC_TEST_RET_ENC_EC(ret);
+            ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
 
         if (XMEMCMP(plain_big, input_big, CHACHA_BIG_TEST_SIZE))
-            return WC_TEST_RET_ENC_I(i);
+            ERROR_OUT(WC_TEST_RET_ENC_I(i), out);
 
         if (XMEMCMP(cipher_big, cipher_big_result, CHACHA_BIG_TEST_SIZE))
-            return WC_TEST_RET_ENC_I(i);
+            ERROR_OUT(WC_TEST_RET_ENC_I(i), out);
     }
 
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
+#endif /* BENCH_EMBEDDED */
+
+    ret = 0;
+
+out:
+
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC) && \
+        !defined(BENCH_EMBEDDED)
     XFREE(cipher_big, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     XFREE(plain_big, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     XFREE(input_big, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
 #endif /* WOLFSSL_SMALL_STACK && !WOLFSSL_NO_MALLOC */
-#endif /* BENCH_EMBEDDED */
 
-    return 0;
+    return ret;
 }
 #endif /* HAVE_CHACHA */
 
@@ -21127,7 +21133,7 @@ static wc_test_ret_t rsa_keygen_test(WC_RNG* rng)
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     if (! genKey)
-        ERROR_OUT(MEMORY_E, exit_rsa);
+        ERROR_OUT(WC_TEST_RET_ENC_EC(MEMORY_E), exit_rsa);
 #endif
 
     XMEMSET(genKey, 0, sizeof *genKey);
@@ -21545,9 +21551,14 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_test(void)
     wc_test_ret_t ret;
     size_t bytes = 0;
     WC_RNG rng;
+#if !defined(WOLFSSL_NO_MALLOC)
+    byte*  der = NULL;
+#endif
+#if defined(WOLFSSL_CERT_REQ) && !defined(WOLFSSL_NO_MALLOC)
+    Cert  *req = NULL;
+#endif
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     byte*  tmp = NULL;
-    byte*  der = NULL;
     RsaKey *key = NULL;
 #else
     RsaKey key[1];
@@ -22046,11 +22057,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_test(void)
 
 #if defined(WOLFSSL_CERT_REQ) && !defined(WOLFSSL_NO_MALLOC)
     {
-        Cert        *req;
         int         derSz;
-#ifndef WOLFSSL_SMALL_STACK
-        byte*  der = NULL;
-#endif
 
         req = (Cert *)XMALLOC(sizeof *req, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         if (! req)
@@ -22153,8 +22160,9 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_test(void)
         }
 
         XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(req, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         der = NULL;
+        XFREE(req, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+        req = NULL;
     }
 #endif /* WOLFSSL_CERT_REQ */
 #endif /* WOLFSSL_CERT_GEN */
@@ -22181,7 +22189,13 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t rsa_test(void)
 
 exit_rsa:
 
-    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
+#if !defined(WOLFSSL_NO_MALLOC)
+    XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    #if defined(WOLFSSL_CERT_REQ)
+    XFREE(req, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    #endif
+#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     wc_DeleteRsaKey(key, &key);
     #if defined(WOLFSSL_CERT_EXT) || defined(WOLFSSL_CERT_GEN)
     wc_DeleteRsaKey(keypub, &keypub);
@@ -22189,8 +22203,7 @@ exit_rsa:
     #ifdef WOLFSSL_TEST_CERT
     XFREE(cert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     #endif
-     XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-     XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
 #else
     wc_FreeRsaKey(key);
     #if defined(WOLFSSL_CERT_EXT) || defined(WOLFSSL_CERT_GEN)
@@ -22868,10 +22881,20 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t dh_test(void)
     DhKey *key = (DhKey *)XMALLOC(sizeof *key, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     DhKey *key2 = (DhKey *)XMALLOC(sizeof *key2, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     byte  *tmp = (byte *)XMALLOC(DH_TEST_TMP_SIZE, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    #if !defined(NO_ASN) && (defined(WOLFSSL_DH_EXTRA) && !defined(NO_FILESYSTEM) && \
+        (!defined(HAVE_FIPS) || \
+        (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION > 2))))
+    byte *tmp2 = NULL;
+    #endif
 #else
     DhKey key[1];
     DhKey key2[1];
     byte  tmp[DH_TEST_TMP_SIZE];
+    #if !defined(NO_ASN) && (defined(WOLFSSL_DH_EXTRA) && !defined(NO_FILESYSTEM) && \
+        (!defined(HAVE_FIPS) || \
+        (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION > 2))))
+    byte  tmp2[DH_TEST_TMP_SIZE];
+    #endif
 #endif
 
 #ifndef WC_NO_RNG
@@ -23100,12 +23123,6 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t dh_test(void)
 #ifndef NO_ASN
     {
         /* DH Private - Key Export / Import */
-    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-        byte *tmp2;
-    #else
-        byte  tmp2[DH_TEST_TMP_SIZE];
-    #endif
-
     #if defined(USE_CERT_BUFFERS_2048)
         XMEMCPY(tmp, dh_ffdhe_statickey_der_2048, sizeof_dh_ffdhe_statickey_der_2048);
         bytes = sizeof_dh_ffdhe_statickey_der_2048;
@@ -23173,10 +23190,6 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t dh_test(void)
         if (ret <= 0 || bytes != idx || XMEMCMP(tmp, tmp2, bytes) != 0) {
             ERROR_OUT(WC_TEST_RET_ENC_NC, done);
         }
-
-    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-        XFREE(tmp2, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-    #endif
     }
 #else
     ret = wc_DhSetKey(key, dh_p, sizeof(dh_p), dh_g, sizeof(dh_g));
@@ -23278,6 +23291,11 @@ done:
         XFREE(key2, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     }
     XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    #if !defined(NO_ASN) && (defined(WOLFSSL_DH_EXTRA) && !defined(NO_FILESYSTEM) && \
+        (!defined(HAVE_FIPS) || \
+        (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION > 2))))
+    XFREE(tmp2, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    #endif
     XFREE(priv, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     XFREE(pub, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     XFREE(priv2, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -24667,15 +24685,48 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
     wc_test_ret_t ret;
 #ifdef WOLFSSL_SMALL_STACK
     WOLFSSL_EVP_MD_CTX *md_ctx = (WOLFSSL_EVP_MD_CTX *)XMALLOC(sizeof(WOLFSSL_EVP_MD_CTX), NULL, DYNAMIC_TYPE_OPENSSL);
+    WOLFSSL_EVP_CIPHER_CTX *ctx = wolfSSL_EVP_CIPHER_CTX_new();
+    WOLFSSL_EVP_CIPHER_CTX *en = wolfSSL_EVP_CIPHER_CTX_new();
+    WOLFSSL_EVP_CIPHER_CTX *de = wolfSSL_EVP_CIPHER_CTX_new();
+    WOLFSSL_EVP_CIPHER_CTX *p_en = wolfSSL_EVP_CIPHER_CTX_new();
+    WOLFSSL_EVP_CIPHER_CTX *p_de = wolfSSL_EVP_CIPHER_CTX_new();
+    #if !defined(NO_AES) && !defined(WOLFSSL_NO_OPENSSL_AES_LOW_LEVEL_API) && \
+        defined(WOLFSSL_AES_DIRECT) && defined(WOLFSSL_AES_256)
+    WOLFSSL_AES_KEY *enc = (WOLFSSL_AES_KEY *)XMALLOC(sizeof *enc, HEAP_HINT, DYNAMIC_TYPE_AES);
+    #ifdef HAVE_AES_DECRYPT
+    WOLFSSL_AES_KEY *dec = (WOLFSSL_AES_KEY *)XMALLOC(sizeof *dec, HEAP_HINT, DYNAMIC_TYPE_AES);
+    #endif
+    #endif /* !NO_AES && !WOLFSSL_NO_OPENSSL_AES_LOW_LEVEL_API */
 #else
     WOLFSSL_EVP_MD_CTX md_ctx[1];
+    WOLFSSL_EVP_CIPHER_CTX ctx[1];
+    WOLFSSL_EVP_CIPHER_CTX en[1];
+    WOLFSSL_EVP_CIPHER_CTX de[1];
+    #if !defined(NO_AES) && !defined(WOLFSSL_NO_OPENSSL_AES_LOW_LEVEL_API) && \
+        defined(WOLFSSL_AES_DIRECT) && defined(WOLFSSL_AES_256)
+    WOLFSSL_AES_KEY enc[1];
+    #ifdef HAVE_AES_DECRYPT
+    WOLFSSL_AES_KEY dec[1];
+    #endif
+    #endif /* !NO_AES */
 #endif
     testVector a, b, c, d, e, f;
     byte       hash[WC_SHA256_DIGEST_SIZE*2];  /* max size */
 
 #ifdef WOLFSSL_SMALL_STACK
-    if (md_ctx == NULL)
-        return WC_TEST_RET_ENC_EC(MEMORY_E);
+    if ((md_ctx == NULL) || (ctx == NULL) || (en == NULL) || (de == NULL) ||
+        (p_en == NULL) || (p_de == NULL)
+    #if !defined(NO_AES) && !defined(WOLFSSL_NO_OPENSSL_AES_LOW_LEVEL_API) && \
+        defined(WOLFSSL_AES_DIRECT) && defined(WOLFSSL_AES_256)
+        || (enc == NULL)
+    #ifdef HAVE_AES_DECRYPT
+        || (dec == NULL)
+    #endif
+    #endif
+        )
+    {
+        ERROR_OUT(WC_TEST_RET_ENC_EC(MEMORY_E), out);
+    }
 #endif
 
     WOLFSSL_ENTER("openssl_test");
@@ -24697,10 +24748,11 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
         p = (byte*)wolfSSL_CRYPTO_malloc(10, "", 0);
 
         if (p == NULL) {
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+        } else {
+            XMEMSET(p, 0, 10);
+            wolfSSL_CRYPTO_free(p, "", 0);
         }
-        XMEMSET(p, 0, 10);
-        wolfSSL_CRYPTO_free(p, "", 0);
     }
 
 #ifndef NO_MD5
@@ -24721,9 +24773,9 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
     }
     wolfSSL_EVP_MD_CTX_cleanup(md_ctx);
     if (ret != WOLFSSL_SUCCESS)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     if (XMEMCMP(hash, a.output, WC_MD5_DIGEST_SIZE) != 0)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 #endif /* NO_MD5 */
 
 #ifndef NO_SHA
@@ -24744,9 +24796,9 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
     }
     wolfSSL_EVP_MD_CTX_cleanup(md_ctx);
     if (ret != WOLFSSL_SUCCESS)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     if (XMEMCMP(hash, b.output, b.outLen) != 0)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 #endif /* NO_SHA */
 
 #ifdef WOLFSSL_SHA224
@@ -24766,7 +24818,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
     }
     wolfSSL_EVP_MD_CTX_cleanup(md_ctx);
     if (ret != WOLFSSL_SUCCESS || XMEMCMP(hash, e.output, e.outLen) != 0) {
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     }
 #endif /* WOLFSSL_SHA224 */
 
@@ -24787,7 +24839,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
     }
     wolfSSL_EVP_MD_CTX_cleanup(md_ctx);
     if (ret != WOLFSSL_SUCCESS || XMEMCMP(hash, d.output, d.outLen) != 0) {
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     }
 #endif /* !NO_SHA256 */
 
@@ -24810,7 +24862,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
     }
     wolfSSL_EVP_MD_CTX_cleanup(md_ctx);
     if (ret != WOLFSSL_SUCCESS || XMEMCMP(hash, e.output, e.outLen) != 0) {
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     }
 #endif /* WOLFSSL_SHA384 */
 
@@ -24834,7 +24886,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
     }
     wolfSSL_EVP_MD_CTX_cleanup(md_ctx);
     if (ret != WOLFSSL_SUCCESS || XMEMCMP(hash, f.output, f.outLen) != 0) {
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     }
 
 #if !defined(WOLFSSL_NOSHA512_224) && \
@@ -24856,7 +24908,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
     }
     wolfSSL_EVP_MD_CTX_cleanup(md_ctx);
     if (ret != WOLFSSL_SUCCESS || XMEMCMP(hash, f.output, f.outLen) != 0) {
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     }
 #endif /* !WOLFSSL_NOSHA512_224 && !FIPS ... */
 
@@ -24879,7 +24931,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
     }
     wolfSSL_EVP_MD_CTX_cleanup(md_ctx);
     if (ret != WOLFSSL_SUCCESS || XMEMCMP(hash, f.output, f.outLen) != 0) {
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     }
 #endif /* !WOLFSSL_NOSHA512_224 && !FIPS ... */
 #endif /* WOLFSSL_SHA512 */
@@ -24902,7 +24954,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
     }
     wolfSSL_EVP_MD_CTX_cleanup(md_ctx);
     if (ret != WOLFSSL_SUCCESS || XMEMCMP(hash, e.output, e.outLen) != 0) {
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     }
 #endif /* WOLFSSL_NOSHA3_224 */
 
@@ -24924,7 +24976,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
     }
     wolfSSL_EVP_MD_CTX_cleanup(md_ctx);
     if (ret != WOLFSSL_SUCCESS || XMEMCMP(hash, d.output, d.outLen) != 0) {
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     }
 #endif /* WOLFSSL_NOSHA3_256 */
 
@@ -24946,7 +24998,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
     }
     wolfSSL_EVP_MD_CTX_cleanup(md_ctx);
     if (ret != WOLFSSL_SUCCESS || XMEMCMP(hash, e.output, e.outLen) != 0) {
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     }
 
 #ifndef WOLFSSL_NOSHA3_512
@@ -24970,19 +25022,14 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
     wolfSSL_EVP_MD_CTX_cleanup(md_ctx);
     if (ret != WOLFSSL_SUCCESS ||
             XMEMCMP(hash, f.output, f.outLen) != 0) {
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     }
 #endif /* WOLFSSL_NOSHA3_512 */
 #endif /* WOLFSSL_SHA3 */
 
-#ifdef WOLFSSL_SMALL_STACK
-    XFREE(md_ctx, NULL, DYNAMIC_TYPE_OPENSSL);
-    md_ctx = NULL;
-#endif
-
 #ifndef WC_NO_RNG
     if (wolfSSL_RAND_bytes(hash, sizeof(hash)) != WOLFSSL_SUCCESS)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 #endif
 
 #ifndef NO_MD5
@@ -25002,7 +25049,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
         XMEMCMP(hash, c.output, c.outLen) != 0)
 #endif
     {
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     }
 #endif /* NO_MD5 */
 
@@ -25034,32 +25081,27 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
     wolfSSL_DES_cbc_encrypt(cipher, plain, sizeof(vector), &sched, &iv, WC_DES_DECRYPT);
 
     if (XMEMCMP(plain, vector, sizeof(vector)) != 0)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     if (XMEMCMP(cipher, verify, sizeof(verify)) != 0)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         /* test changing iv */
     wolfSSL_DES_ncbc_encrypt(vector, cipher, 8, &sched, &iv, WC_DES_ENCRYPT);
     wolfSSL_DES_ncbc_encrypt(vector + 8, cipher + 8, 16, &sched, &iv, WC_DES_ENCRYPT);
 
     if (XMEMCMP(cipher, verify, sizeof(verify)) != 0)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     }  /* end des test */
 #endif /* NO_DES3 */
 
 #if !defined(NO_AES) && !defined(WOLFCRYPT_ONLY)
     if ((ret = openssl_aes_test()) != 0) {
-        return ret;
+        ERROR_OUT(ret, out);
     }
 #if defined(WOLFSSL_AES_128) && defined(HAVE_AES_CBC)
     {   /* evp_cipher test: EVP_aes_128_cbc */
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-        WOLFSSL_EVP_CIPHER_CTX *ctx = wolfSSL_EVP_CIPHER_CTX_new();
-#else
-        WOLFSSL_EVP_CIPHER_CTX ctx[1];
-#endif
         int idx, cipherSz, plainSz;
         WOLFSSL_SMALL_STACK_STATIC const byte msg[] = { /* "Now is the time for all " w/o trailing 0 */
             0x6e,0x6f,0x77,0x20,0x69,0x73,0x20,0x74,
@@ -25085,11 +25127,6 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
         byte cipher[WC_AES_BLOCK_SIZE * 4];
         byte plain [WC_AES_BLOCK_SIZE * 4];
 
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-        if (ctx == NULL)
-            return MEMORY_E;
-#endif
-
         cipherSz = 0;
         wolfSSL_EVP_CIPHER_CTX_init(ctx);
         ret = wolfSSL_EVP_CipherInit(ctx, wolfSSL_EVP_aes_128_cbc(), key, iv, 1);
@@ -25105,9 +25142,9 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
         }
         wolfSSL_EVP_CIPHER_CTX_cleanup(ctx);
         if (ret != WOLFSSL_SUCCESS)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if (cipherSz != (int)sizeof(verify) || XMEMCMP(cipher, verify, cipherSz))
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         /* check partial decrypt (not enough padding for full block) */
         plainSz = 0;
@@ -25130,7 +25167,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
             ret = WC_TEST_RET_ENC_NC;
         wolfSSL_EVP_CIPHER_CTX_cleanup(ctx);
         if (ret != WOLFSSL_SUCCESS)
-            return ret;
+            ERROR_OUT(ret, out);
 
         plainSz = 0;
         wolfSSL_EVP_CIPHER_CTX_init(ctx);
@@ -25147,9 +25184,9 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
         }
         wolfSSL_EVP_CIPHER_CTX_cleanup(ctx);
         if (ret != WOLFSSL_SUCCESS)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if (plainSz != (int)sizeof(msg) || XMEMCMP(plain, msg, sizeof(msg)))
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         cipherSz = 0;
         wolfSSL_EVP_CIPHER_CTX_init(ctx);
@@ -25166,23 +25203,14 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
         }
         wolfSSL_EVP_CIPHER_CTX_cleanup(ctx);
         if (ret != WOLFSSL_SUCCESS)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if (cipherSz != (int)sizeof(verify2) || XMEMCMP(cipher, verify2, cipherSz))
-            return WC_TEST_RET_ENC_NC;
-
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-        wolfSSL_EVP_CIPHER_CTX_free(ctx);
-#endif
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     }  /* end evp_cipher test: EVP_aes_128_cbc*/
 #endif /* WOLFSSL_AES_128 && HAVE_AES_CBC */
 
 #if defined(HAVE_AES_ECB) && defined(WOLFSSL_AES_256)
     {   /* evp_cipher test: EVP_aes_256_ecb*/
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-        WOLFSSL_EVP_CIPHER_CTX *ctx = wolfSSL_EVP_CIPHER_CTX_new();
-#else
-        WOLFSSL_EVP_CIPHER_CTX ctx[1];
-#endif
         WOLFSSL_SMALL_STACK_STATIC const byte msg[] = {
           0x6b,0xc1,0xbe,0xe2,0x2e,0x40,0x9f,0x96,
           0xe9,0x3d,0x7e,0x11,0x73,0x93,0x17,0x2a
@@ -25200,20 +25228,15 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
         byte cipher[WC_AES_BLOCK_SIZE * 4];
         byte plain [WC_AES_BLOCK_SIZE * 4];
 
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-        if (ctx == NULL)
-            return MEMORY_E;
-#endif
-
         wolfSSL_EVP_CIPHER_CTX_init(ctx);
         ret = wolfSSL_EVP_CipherInit(ctx, wolfSSL_EVP_aes_256_ecb(), (unsigned char*)key, NULL, 1);
         if (ret == WOLFSSL_SUCCESS)
             ret = wolfSSL_EVP_Cipher(ctx, cipher, (byte*)msg, 16);
         wolfSSL_EVP_CIPHER_CTX_cleanup(ctx);
         if (ret != 16)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if (XMEMCMP(cipher, verify, WC_AES_BLOCK_SIZE))
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         wolfSSL_EVP_CIPHER_CTX_init(ctx);
         ret = wolfSSL_EVP_CipherInit(ctx, wolfSSL_EVP_aes_256_ecb(), (unsigned char*)key, NULL, 0);
@@ -25221,13 +25244,9 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
             ret = wolfSSL_EVP_Cipher(ctx, plain, cipher, 16);
         wolfSSL_EVP_CIPHER_CTX_cleanup(ctx);
         if (ret != 16)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if (XMEMCMP(plain, msg, WC_AES_BLOCK_SIZE))
-            return WC_TEST_RET_ENC_NC;
-
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-        wolfSSL_EVP_CIPHER_CTX_free(ctx);
-#endif
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     }  /* end evp_cipher test */
 #endif /* HAVE_AES_ECB && WOLFSSL_AES_128 */
 
@@ -25238,18 +25257,6 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
 {
 
   /* Test: AES_encrypt/decrypt/set Key */
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-  WOLFSSL_AES_KEY *enc = (WOLFSSL_AES_KEY *)XMALLOC(sizeof *enc, HEAP_HINT, DYNAMIC_TYPE_AES);
-  #ifdef HAVE_AES_DECRYPT
-  WOLFSSL_AES_KEY *dec = (WOLFSSL_AES_KEY *)XMALLOC(sizeof *dec, HEAP_HINT, DYNAMIC_TYPE_AES);
-  #endif
-#else
-  WOLFSSL_AES_KEY enc[1];
-  #ifdef HAVE_AES_DECRYPT
-  WOLFSSL_AES_KEY dec[1];
-  #endif
-#endif
-
   WOLFSSL_SMALL_STACK_STATIC const byte msg[] =
   {
       0x6b,0xc1,0xbe,0xe2,0x2e,0x40,0x9f,0x96,
@@ -25275,15 +25282,6 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
 
   printf("openSSL extra test\n") ;
 
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-  if (enc == NULL)
-      return MEMORY_E;
-  #ifdef HAVE_AES_DECRYPT
-  if (dec == NULL)
-      return MEMORY_E;
-  #endif
-#endif
-
   wolfSSL_AES_set_encrypt_key(key, sizeof(key)*8, enc);
   wolfSSL_AES_set_decrypt_key(key, sizeof(key)*8, dec);
 
@@ -25292,18 +25290,11 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
 #ifdef HAVE_AES_DECRYPT
   wolfSSL_AES_decrypt(cipher, plain, dec);
   if (XMEMCMP(plain, msg, WC_AES_BLOCK_SIZE))
-      return WC_TEST_RET_ENC_NC;
+      ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 #endif /* HAVE_AES_DECRYPT */
 
   if (XMEMCMP(cipher, verify, WC_AES_BLOCK_SIZE))
-      return WC_TEST_RET_ENC_NC;
-
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-  XFREE(enc, HEAP_HINT, DYNAMIC_TYPE_AES);
-  #ifdef HAVE_AES_DECRYPT
-  XFREE(dec, HEAP_HINT, DYNAMIC_TYPE_AES);
-  #endif
-#endif
+      ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 }
 
 #endif /* WOLFSSL_AES_DIRECT && WOLFSSL_AES_256 */
@@ -25358,12 +25349,6 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
         0xb9,0xd7,0xcb,0x08,0xb0,0xe1,0x7b,0xa0,
         0xc2
     };
-
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-    WOLFSSL_EVP_CIPHER_CTX *p_en;
-    WOLFSSL_EVP_CIPHER_CTX *p_de;
-#endif
-
 #endif /* WOLFSSL_AES_128 */
 
 #ifdef WOLFSSL_AES_192
@@ -25427,105 +25412,85 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
     };
 #endif /* WOLFSSL_AES_256 */
 
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-    WOLFSSL_EVP_CIPHER_CTX *en = wolfSSL_EVP_CIPHER_CTX_new();
-    WOLFSSL_EVP_CIPHER_CTX *de = wolfSSL_EVP_CIPHER_CTX_new();
-    if ((en == NULL) || (de == NULL))
-        return MEMORY_E;
-#else
-    WOLFSSL_EVP_CIPHER_CTX en[1];
-    WOLFSSL_EVP_CIPHER_CTX de[1];
-#endif
-
 #ifdef WOLFSSL_AES_128
 
     wolfSSL_EVP_CIPHER_CTX_init(en);
     if (wolfSSL_EVP_CipherInit(en, wolfSSL_EVP_aes_128_ctr(),
             (unsigned char*)ctrKey, (unsigned char*)ctrIv, 0) == 0)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     if (wolfSSL_EVP_Cipher(en, (byte*)cipherBuff, (byte*)ctrPlain,
             WC_AES_BLOCK_SIZE*4) != WC_AES_BLOCK_SIZE*4)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     wolfSSL_EVP_CIPHER_CTX_init(de);
     if (wolfSSL_EVP_CipherInit(de, wolfSSL_EVP_aes_128_ctr(),
             (unsigned char*)ctrKey, (unsigned char*)ctrIv, 0) == 0)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     if (wolfSSL_EVP_Cipher(de, (byte*)plainBuff, (byte*)cipherBuff,
             WC_AES_BLOCK_SIZE*4) != WC_AES_BLOCK_SIZE*4)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     if (XMEMCMP(cipherBuff, ctrCipher, WC_AES_BLOCK_SIZE*4))
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     if (XMEMCMP(plainBuff, ctrPlain, WC_AES_BLOCK_SIZE*4))
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     wolfSSL_EVP_CIPHER_CTX_cleanup(en);
     wolfSSL_EVP_CIPHER_CTX_cleanup(de);
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-    p_en = wolfSSL_EVP_CIPHER_CTX_new();
-    if (p_en == NULL)
-        return WC_TEST_RET_ENC_ERRNO;
-    p_de = wolfSSL_EVP_CIPHER_CTX_new();
-    if (p_de == NULL)
-        return WC_TEST_RET_ENC_ERRNO;
-
     if (wolfSSL_EVP_CipherInit(p_en, wolfSSL_EVP_aes_128_ctr(),
             (unsigned char*)ctrKey, (unsigned char*)ctrIv, 0) == 0)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     if (wolfSSL_EVP_Cipher(p_en, (byte*)cipherBuff, (byte*)ctrPlain,
             WC_AES_BLOCK_SIZE*4) != WC_AES_BLOCK_SIZE*4)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     if (wolfSSL_EVP_CipherInit(p_de, wolfSSL_EVP_aes_128_ctr(),
             (unsigned char*)ctrKey, (unsigned char*)ctrIv, 0) == 0)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     if (wolfSSL_EVP_Cipher(p_de, (byte*)plainBuff, (byte*)cipherBuff,
             WC_AES_BLOCK_SIZE*4) != WC_AES_BLOCK_SIZE*4)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     wolfSSL_EVP_CIPHER_CTX_cleanup(p_en);
     wolfSSL_EVP_CIPHER_CTX_cleanup(p_de);
-
-    wolfSSL_EVP_CIPHER_CTX_free(p_en);
-    wolfSSL_EVP_CIPHER_CTX_free(p_de);
 #endif /* WOLFSSL_SMALL_STACK && !WOLFSSL_NO_MALLOC */
 
     if (XMEMCMP(cipherBuff, ctrCipher, WC_AES_BLOCK_SIZE*4))
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     if (XMEMCMP(plainBuff, ctrPlain, WC_AES_BLOCK_SIZE*4))
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     wolfSSL_EVP_CIPHER_CTX_init(en);
     if (wolfSSL_EVP_CipherInit(en, wolfSSL_EVP_aes_128_ctr(),
         (unsigned char*)ctrKey, (unsigned char*)ctrIv, 0) == 0)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     if (wolfSSL_EVP_Cipher(en, (byte*)cipherBuff, (byte*)ctrPlain, 9) != 9)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     wolfSSL_EVP_CIPHER_CTX_init(de);
     if (wolfSSL_EVP_CipherInit(de, wolfSSL_EVP_aes_128_ctr(),
         (unsigned char*)ctrKey, (unsigned char*)ctrIv, 0) == 0)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     if (wolfSSL_EVP_Cipher(de, (byte*)plainBuff, (byte*)cipherBuff, 9) != 9)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     if (XMEMCMP(plainBuff, ctrPlain, 9))
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     if (XMEMCMP(cipherBuff, ctrCipher, 9))
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     if (wolfSSL_EVP_Cipher(en, (byte*)cipherBuff, (byte*)ctrPlain, 9) != 9)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     if (wolfSSL_EVP_Cipher(de, (byte*)plainBuff, (byte*)cipherBuff, 9) != 9)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     if (XMEMCMP(plainBuff, ctrPlain, 9))
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     if (XMEMCMP(cipherBuff, oddCipher, 9))
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     wolfSSL_EVP_CIPHER_CTX_cleanup(en);
     wolfSSL_EVP_CIPHER_CTX_cleanup(de);
@@ -25535,24 +25500,24 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
     wolfSSL_EVP_CIPHER_CTX_init(en);
     if (wolfSSL_EVP_CipherInit(en, wolfSSL_EVP_aes_192_ctr(),
             (unsigned char*)ctr192Key, (unsigned char*)ctr192Iv, 0) == 0)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     if (wolfSSL_EVP_Cipher(en, (byte*)cipherBuff, (byte*)ctr192Plain,
             WC_AES_BLOCK_SIZE) != WC_AES_BLOCK_SIZE)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     wolfSSL_EVP_CIPHER_CTX_init(de);
     if (wolfSSL_EVP_CipherInit(de, wolfSSL_EVP_aes_192_ctr(),
         (unsigned char*)ctr192Key, (unsigned char*)ctr192Iv, 0) == 0)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     XMEMSET(plainBuff, 0, sizeof(plainBuff));
     if (wolfSSL_EVP_Cipher(de, (byte*)plainBuff, (byte*)cipherBuff,
             WC_AES_BLOCK_SIZE) != WC_AES_BLOCK_SIZE)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     if (XMEMCMP(plainBuff, ctr192Plain, sizeof(ctr192Plain)))
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     if (XMEMCMP(ctr192Cipher, cipherBuff, sizeof(ctr192Cipher)))
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     wolfSSL_EVP_CIPHER_CTX_cleanup(en);
     wolfSSL_EVP_CIPHER_CTX_cleanup(de);
@@ -25562,33 +25527,28 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
     wolfSSL_EVP_CIPHER_CTX_init(en);
     if (wolfSSL_EVP_CipherInit(en, wolfSSL_EVP_aes_256_ctr(),
         (unsigned char*)ctr256Key, (unsigned char*)ctr256Iv, 0) == 0)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     if (wolfSSL_EVP_Cipher(en, (byte*)cipherBuff, (byte*)ctr256Plain,
             WC_AES_BLOCK_SIZE) != WC_AES_BLOCK_SIZE)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     wolfSSL_EVP_CIPHER_CTX_init(de);
     if (wolfSSL_EVP_CipherInit(de, wolfSSL_EVP_aes_256_ctr(),
         (unsigned char*)ctr256Key, (unsigned char*)ctr256Iv, 0) == 0)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     XMEMSET(plainBuff, 0, sizeof(plainBuff));
     if (wolfSSL_EVP_Cipher(de, (byte*)plainBuff, (byte*)cipherBuff,
             WC_AES_BLOCK_SIZE) != WC_AES_BLOCK_SIZE)
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     if (XMEMCMP(plainBuff, ctr256Plain, sizeof(ctr256Plain)))
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     if (XMEMCMP(ctr256Cipher, cipherBuff, sizeof(ctr256Cipher)))
-        return WC_TEST_RET_ENC_NC;
+        ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
     wolfSSL_EVP_CIPHER_CTX_cleanup(en);
     wolfSSL_EVP_CIPHER_CTX_cleanup(de);
 #endif /* WOLFSSL_AES_256 */
-
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-    wolfSSL_EVP_CIPHER_CTX_free(en);
-    wolfSSL_EVP_CIPHER_CTX_free(de);
-#endif
 }
 #endif /* HAVE_AES_COUNTER */
 
@@ -25614,268 +25574,276 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_test(void)
 
         byte cipher[WC_AES_BLOCK_SIZE * 4];
         byte plain [WC_AES_BLOCK_SIZE * 4];
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-        WOLFSSL_EVP_CIPHER_CTX *en = wolfSSL_EVP_CIPHER_CTX_new();
-        WOLFSSL_EVP_CIPHER_CTX *de = wolfSSL_EVP_CIPHER_CTX_new();
-#else
-        WOLFSSL_EVP_CIPHER_CTX en[1];
-        WOLFSSL_EVP_CIPHER_CTX de[1];
-#endif
         int outlen ;
         int total = 0;
 
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-        if ((en == NULL) || (de == NULL))
-            return MEMORY_E;
-#endif
-
         wolfSSL_EVP_CIPHER_CTX_init(en);
         if (wolfSSL_EVP_CipherInit(en, wolfSSL_EVP_aes_128_cbc(),
             (unsigned char*)key, (unsigned char*)iv, 1) == 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         /* openSSL compatibility, if(inlen == 0)return 1; */
         if (wolfSSL_EVP_CipherUpdate(en, (byte*)cipher, &outlen,
                                                     (byte*)cbcPlain, 0) != 1)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         if (wolfSSL_EVP_CIPHER_CTX_cleanup(en) != WOLFSSL_SUCCESS)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         wolfSSL_EVP_CIPHER_CTX_init(en);
         if (wolfSSL_EVP_CipherInit(en, wolfSSL_EVP_aes_128_cbc(),
             (unsigned char*)key, (unsigned char*)iv, 1) == 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if (wolfSSL_EVP_CipherUpdate(en, (byte*)cipher, &outlen,
                                                     (byte*)cbcPlain, 9) == 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if(outlen != 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         total += outlen;
 
         if (wolfSSL_EVP_CipherUpdate(en, (byte*)&cipher[total], &outlen,
                                                 (byte*)&cbcPlain[9]  , 9) == 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if(outlen != 16)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         total += outlen;
 
         if (wolfSSL_EVP_CipherFinal(en, (byte*)&cipher[total], &outlen) == 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if(outlen != 16)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         total += outlen;
         if(total != 32)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         total = 0;
         wolfSSL_EVP_CIPHER_CTX_init(de);
         if (wolfSSL_EVP_CipherInit(de, wolfSSL_EVP_aes_128_cbc(),
             (unsigned char*)key, (unsigned char*)iv, 0) == 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         if (wolfSSL_EVP_CipherUpdate(de, (byte*)plain, &outlen, (byte*)cipher, 6) == 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if(outlen != 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         total += outlen;
 
         if (wolfSSL_EVP_CipherUpdate(de, (byte*)&plain[total], &outlen,
                                                     (byte*)&cipher[6], 12) == 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if(outlen != 0)
         total += outlen;
 
         if (wolfSSL_EVP_CipherUpdate(de, (byte*)&plain[total], &outlen,
                                                 (byte*)&cipher[6+12], 14) == 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if(outlen != 16)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         total += outlen;
 
         if (wolfSSL_EVP_CipherFinal(de, (byte*)&plain[total], &outlen) == 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if(outlen != 2)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         total += outlen;
 
         if(total != 18)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         if (XMEMCMP(plain, cbcPlain, 18))
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         total = 0;
         if (wolfSSL_EVP_CIPHER_CTX_cleanup(en) != WOLFSSL_SUCCESS)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         wolfSSL_EVP_CIPHER_CTX_init(en);
         if (wolfSSL_EVP_EncryptInit(en, wolfSSL_EVP_aes_128_cbc(),
             (unsigned char*)key, (unsigned char*)iv) == 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if (wolfSSL_EVP_CipherUpdate(en, (byte*)cipher, &outlen, (byte*)cbcPlain, 9) == 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if(outlen != 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         total += outlen;
 
         if (wolfSSL_EVP_CipherUpdate(en, (byte*)&cipher[total], &outlen, (byte*)&cbcPlain[9]  , 9) == 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if(outlen != 16)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         total += outlen;
 
         if (wolfSSL_EVP_EncryptFinal(en, (byte*)&cipher[total], &outlen) == 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if(outlen != 16)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         total += outlen;
-        if(total != 32)
-            return 3438;
+        if (total != 32)
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         total = 0;
         if (wolfSSL_EVP_CIPHER_CTX_cleanup(de) != WOLFSSL_SUCCESS)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         wolfSSL_EVP_CIPHER_CTX_init(de);
         if (wolfSSL_EVP_DecryptInit(de, wolfSSL_EVP_aes_128_cbc(),
             (unsigned char*)key, (unsigned char*)iv) == 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         if (wolfSSL_EVP_CipherUpdate(de, (byte*)plain, &outlen, (byte*)cipher, 6) == 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if(outlen != 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         total += outlen;
 
         if (wolfSSL_EVP_CipherUpdate(de, (byte*)&plain[total], &outlen, (byte*)&cipher[6], 12) == 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if(outlen != 0)
         total += outlen;
 
         if (wolfSSL_EVP_CipherUpdate(de, (byte*)&plain[total], &outlen, (byte*)&cipher[6+12], 14) == 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if(outlen != 16)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         total += outlen;
 
         if (wolfSSL_EVP_DecryptFinal(de, (byte*)&plain[total], &outlen) == 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if(outlen != 2)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         total += outlen;
 
-        if(total != 18)
-            return 3447;
+        if (total != 18)
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         if (XMEMCMP(plain, cbcPlain, 18))
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         if (wolfSSL_EVP_Cipher_key_length(NULL) != 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         if (wolfSSL_EVP_Cipher_key_length(wolfSSL_EVP_aes_128_cbc()) != 16)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         if (wolfSSL_EVP_CIPHER_CTX_mode(NULL) != 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         if (wolfSSL_EVP_CIPHER_CTX_mode(en) != (en->flags & WOLFSSL_EVP_CIPH_MODE))
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         if (wolfSSL_EVP_CIPHER_CTX_cleanup(en) != WOLFSSL_SUCCESS)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         wolfSSL_EVP_CIPHER_CTX_init(en);
         if (wolfSSL_EVP_CipherInit_ex(en, wolfSSL_EVP_aes_128_cbc(), NULL,
             (unsigned char*)key, (unsigned char*)iv, 0) == 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         if (wolfSSL_EVP_CIPHER_CTX_cleanup(en) != WOLFSSL_SUCCESS)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         wolfSSL_EVP_CIPHER_CTX_init(en);
         if (wolfSSL_EVP_EncryptInit_ex(en, wolfSSL_EVP_aes_128_cbc(), NULL,
                 (unsigned char*)key, (unsigned char*)iv) == 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         if (wolfSSL_EVP_EncryptFinal_ex(NULL, NULL, NULL)
             != WC_NO_ERR_TRACE(WOLFSSL_FAILURE))
         {
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         }
 
         if (wolfSSL_EVP_EncryptFinal(NULL, NULL, NULL)
             != WC_NO_ERR_TRACE(WOLFSSL_FAILURE))
         {
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         }
 
         if (wolfSSL_EVP_CIPHER_CTX_cleanup(de) != WOLFSSL_SUCCESS)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         if (wolfSSL_EVP_CIPHER_CTX_cleanup(de) != WOLFSSL_SUCCESS)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         wolfSSL_EVP_CIPHER_CTX_init(de);
         if (wolfSSL_EVP_DecryptInit_ex(de, wolfSSL_EVP_aes_128_cbc(), NULL,
                 (unsigned char*)key, (unsigned char*)iv) == 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         if (wolfSSL_EVP_DecryptFinal(NULL, NULL, NULL)
             != WC_NO_ERR_TRACE(WOLFSSL_FAILURE))
         {
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         }
 
         if (wolfSSL_EVP_DecryptFinal_ex(NULL, NULL, NULL)
             != WC_NO_ERR_TRACE(WOLFSSL_FAILURE))
         {
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         }
 
         if (wolfSSL_EVP_CIPHER_CTX_block_size(NULL) != WC_NO_ERR_TRACE(WOLFSSL_FAILURE))
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         if (wolfSSL_EVP_CIPHER_CTX_cleanup(en) != WOLFSSL_SUCCESS)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         wolfSSL_EVP_CIPHER_CTX_init(en);
         wolfSSL_EVP_EncryptInit_ex(en, wolfSSL_EVP_aes_128_cbc(), NULL,
                 (unsigned char*)key, (unsigned char*)iv);
         if (wolfSSL_EVP_CIPHER_CTX_block_size(en) != en->block_size)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         if (wolfSSL_EVP_CIPHER_block_size(NULL) != WC_NO_ERR_TRACE(WOLFSSL_FAILURE))
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         if (wolfSSL_EVP_CIPHER_block_size(wolfSSL_EVP_aes_128_cbc()) != WC_AES_BLOCK_SIZE)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         if (WOLFSSL_EVP_CIPHER_mode(NULL) != 0)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         if (wolfSSL_EVP_CIPHER_flags(wolfSSL_EVP_aes_128_cbc()) != WOLFSSL_EVP_CIPH_CBC_MODE)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         wolfSSL_EVP_CIPHER_CTX_clear_flags(en, 0xFFFFFFFF);
         wolfSSL_EVP_CIPHER_CTX_set_flags(en, 42);
         if (en->flags != 42)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         if (wolfSSL_EVP_CIPHER_CTX_set_padding(NULL, 0) !=
                 WC_NO_ERR_TRACE(WOLFSSL_FAILURE))
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if (wolfSSL_EVP_CIPHER_CTX_set_padding(en, 0) != WOLFSSL_SUCCESS)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if (wolfSSL_EVP_CIPHER_CTX_set_padding(en, 1) != WOLFSSL_SUCCESS)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
 
         if (wolfSSL_EVP_CIPHER_CTX_cleanup(en) != WOLFSSL_SUCCESS)
-            return WC_TEST_RET_ENC_NC;
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         if (wolfSSL_EVP_CIPHER_CTX_cleanup(de) != WOLFSSL_SUCCESS)
-            return WC_TEST_RET_ENC_NC;
-
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-        wolfSSL_EVP_CIPHER_CTX_free(en);
-        wolfSSL_EVP_CIPHER_CTX_free(de);
-#endif
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
     }
 #endif /* WOLFSSL_AES_128 && HAVE_AES_CBC */
 #endif /* !NO_AES && !WOLFCRYPT_ONLY */
-    return 0;
+
+    ret = 0;
+
+out:
+
+#ifdef WOLFSSL_SMALL_STACK
+    XFREE(md_ctx, NULL, DYNAMIC_TYPE_OPENSSL);
+    wolfSSL_EVP_CIPHER_CTX_free(ctx);
+    wolfSSL_EVP_CIPHER_CTX_free(en);
+    wolfSSL_EVP_CIPHER_CTX_free(de);
+    wolfSSL_EVP_CIPHER_CTX_free(p_en);
+    wolfSSL_EVP_CIPHER_CTX_free(p_de);
+    #if !defined(NO_AES) && !defined(WOLFSSL_NO_OPENSSL_AES_LOW_LEVEL_API) && \
+        defined(WOLFSSL_AES_DIRECT) && defined(WOLFSSL_AES_256)
+    XFREE(enc, HEAP_HINT, DYNAMIC_TYPE_AES);
+    #ifdef HAVE_AES_DECRYPT
+    XFREE(dec, HEAP_HINT, DYNAMIC_TYPE_AES);
+    #endif
+    #endif
+#else
+    (void)en;
+    (void)de;
+    (void)ctx;
+#endif
+
+    return ret;
 }
 
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openSSL_evpMD_test(void)
@@ -26490,8 +26458,10 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_evpSig_test(void)
     ret1 = wolfSSL_RSA_LoadDer_ex(prvRsa, prvTmp, prvBytes, WOLFSSL_RSA_LOAD_PRIVATE);
     ret2 = wolfSSL_RSA_LoadDer_ex(pubRsa, pubTmp, pubBytes, WOLFSSL_RSA_LOAD_PUBLIC);
     if((ret1 != WOLFSSL_SUCCESS) || (ret2 != WOLFSSL_SUCCESS)){
-      printf("error with RSA_LoadDer_ex\n");
-      return WC_TEST_RET_ENC_NC;
+        XFREE(pubTmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(prvTmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+        printf("error with RSA_LoadDer_ex\n");
+        return WC_TEST_RET_ENC_NC;
     }
 
     prvPkey = wolfSSL_EVP_PKEY_new();
@@ -26516,6 +26486,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_evpSig_test(void)
     verf = wolfSSL_EVP_MD_CTX_new();
     if((sign == NULL)||(verf == NULL)){
         printf("error with WOLFSSL_EVP_MD_CTX_create\n");
+        XFREE(pubTmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(prvTmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         wolfSSL_EVP_MD_CTX_free(sign);
         wolfSSL_EVP_MD_CTX_free(verf);
         return WC_TEST_RET_ENC_NC;
@@ -26524,6 +26496,8 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t openssl_evpSig_test(void)
     ret = wolfSSL_EVP_SignInit(sign, wolfSSL_EVP_sha1());
     if (ret != WOLFSSL_SUCCESS){
         printf("error with EVP_SignInit\n");
+        XFREE(pubTmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(prvTmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         wolfSSL_EVP_MD_CTX_free(sign);
         wolfSSL_EVP_MD_CTX_free(verf);
         return WC_TEST_RET_ENC_NC;
@@ -38124,8 +38098,11 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ed448_test(void)
 
             exportPKey = (byte *)XMALLOC(exportPSz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             exportSKey = (byte *)XMALLOC(exportSSz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-            if ((exportPKey == NULL) || (exportSKey == NULL))
+            if ((exportPKey == NULL) || (exportSKey == NULL)) {
+                XFREE(exportPKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+                XFREE(exportSKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
                 ERROR_OUT(WC_TEST_RET_ENC_NC, out);
+            }
 #endif
 
             ret = 0;
@@ -45826,8 +45803,7 @@ static wc_test_ret_t dilithium_param_test(int param, WC_RNG* rng)
 
     ret = wc_dilithium_init(key);
     if (ret != 0) {
-        ret = WC_TEST_RET_ENC_EC(ret);
-        return ret;
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out);
     }
 
     ret = wc_dilithium_set_level(key, param);
@@ -46240,32 +46216,32 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t xmss_test(void)
     if (ret != 0) { return WC_TEST_RET_ENC_EC(ret); }
 
     ret = wc_XmssKey_Init(&signingKey, NULL, INVALID_DEVID);
-    if (ret != 0) { return WC_TEST_RET_ENC_EC(ret); }
+    if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out); }
 
     ret = wc_XmssKey_Init(&verifyKey, NULL, INVALID_DEVID);
-    if (ret != 0) { return WC_TEST_RET_ENC_EC(ret); }
+    if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out); }
 
     /* Set the parameter string to the signing key, and
      * get sizes for secret key, pub key, and signature. */
     ret = wc_XmssKey_SetParamStr(&signingKey, param);
-    if (ret != 0) { return WC_TEST_RET_ENC_EC(ret); }
+    if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out); }
 
     ret = wc_XmssKey_GetPubLen(&signingKey, &pkSz);
-    if (ret != 0) { return WC_TEST_RET_ENC_EC(ret); }
+    if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out); }
 
     if (pkSz != XMSS_SHA256_PUBLEN) {
-        return WC_TEST_RET_ENC_EC(pkSz);
+        ERROR_OUT(WC_TEST_RET_ENC_I(pkSz), out);
     }
 
     ret = wc_XmssKey_GetPrivLen(&signingKey, &skSz);
-    if (ret != 0) { return WC_TEST_RET_ENC_EC(ret); }
+    if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out); }
 
     ret = wc_XmssKey_GetSigLen(&signingKey, &sigSz);
-    if (ret != 0) { return WC_TEST_RET_ENC_EC(ret); }
+    if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out); }
 
     /* Allocate signature array. */
     sig = (byte *)XMALLOC(sigSz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-    if (sig == NULL) { return WC_TEST_RET_ENC_ERRNO; }
+    if (sig == NULL) { ERROR_OUT(WC_TEST_RET_ENC_ERRNO, out); }
 
     bufSz = sigSz;
 
@@ -46278,30 +46254,30 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t xmss_test(void)
 
     /* Allocate current and old secret keys.*/
     sk = (unsigned char *)XMALLOC(skSz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-    if (sk == NULL) { return WC_TEST_RET_ENC_ERRNO; }
+    if (sk == NULL) { ERROR_OUT(WC_TEST_RET_ENC_ERRNO, out); }
 
     old_sk = (unsigned char *)XMALLOC(skSz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-    if (old_sk == NULL) { return WC_TEST_RET_ENC_ERRNO; }
+    if (old_sk == NULL) { ERROR_OUT(WC_TEST_RET_ENC_ERRNO, out); }
 
     XMEMSET(sk, 0, skSz);
     XMEMSET(old_sk, 0, skSz);
     XMEMSET(sig, 0, sigSz);
 
     ret = wc_XmssKey_SetWriteCb(&signingKey, xmss_write_key_mem);
-    if (ret != 0) { return WC_TEST_RET_ENC_EC(ret); }
+    if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out); }
 
     ret = wc_XmssKey_SetReadCb(&signingKey, xmss_read_key_mem);
-    if (ret != 0) { return WC_TEST_RET_ENC_EC(ret); }
+    if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out); }
 
     ret = wc_XmssKey_SetContext(&signingKey, (void *) sk);
-    if (ret != 0) { return WC_TEST_RET_ENC_EC(ret); }
+    if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out); }
 
     ret = wc_XmssKey_MakeKey(&signingKey, &rng);
-    if (ret != 0) { return WC_TEST_RET_ENC_EC(ret); }
+    if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out); }
 
     /* Export the pub to a verify key. */
     ret = wc_XmssKey_ExportPub(&verifyKey, &signingKey);
-    if (ret != 0) { return WC_TEST_RET_ENC_EC(ret); }
+    if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out); }
 
     /* Repeat a few times to check that:
      *   1. The secret key is mutated on each sign.
@@ -46312,15 +46288,15 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t xmss_test(void)
         XMEMCPY(old_sk, sk, skSz);
 
         ret = wc_XmssKey_Sign(&signingKey, sig, &sigSz, (byte *) msg, msgSz);
-        if (ret != 0) { return WC_TEST_RET_ENC_I(i); }
-        if (sigSz != bufSz) { return WC_TEST_RET_ENC_I(i); }
+        if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_I(i), out); }
+        if (sigSz != bufSz) { ERROR_OUT(WC_TEST_RET_ENC_I(i), out); }
 
         /* Old secret key and current secret key should not match. */
         ret = XMEMCMP(old_sk, sk, skSz);
-        if (ret == 0) { return WC_TEST_RET_ENC_I(i); }
+        if (ret == 0) { ERROR_OUT(WC_TEST_RET_ENC_I(i), out); }
 
         ret = wc_XmssKey_Verify(&verifyKey, sig, sigSz, (byte *) msg, msgSz);
-        if (ret != 0) { return WC_TEST_RET_ENC_I(i); }
+        if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_I(i), out); }
 
         /* Flip bits in a few places throughout the signature, stepping in multiple
          * of hash size. These should all fail with -1. */
@@ -46331,13 +46307,15 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t xmss_test(void)
                                      msgSz);
             if ((ret2 != -1) && (ret2 != WC_NO_ERR_TRACE(SIG_VERIFY_E))) {
                 /* Verify passed when it should have failed. */
-                return WC_TEST_RET_ENC_I(j);
+                ERROR_OUT(WC_TEST_RET_ENC_I(j), out);
             }
 
             /* Flip this spot back. */
             sig[j] ^= 1;
         }
     }
+
+out:
 
     /* Cleanup everything. */
     XFREE(sig, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -46350,6 +46328,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t xmss_test(void)
     old_sk = NULL;
 
     wc_XmssKey_Free(&signingKey);
+    wc_XmssKey_Free(&verifyKey);
     wc_FreeRng(&rng);
 
     return ret;
@@ -46881,13 +46860,16 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t lms_test(void)
     XMEMSET(priv, 0, sizeof(priv));
     XMEMSET(old_priv, 0, sizeof(old_priv));
     XMEMSET(sig, 0, WC_TEST_LMS_SIG_LEN);
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&signingKey, 0, sizeof(signingKey));
+    XMEMSET(&verifyKey, 0, sizeof(verifyKey));
 
 #ifndef HAVE_FIPS
     ret = wc_InitRng_ex(&rng, HEAP_HINT, INVALID_DEVID);
 #else
     ret = wc_InitRng(&rng);
 #endif
-    if (ret != 0) { return WC_TEST_RET_ENC_EC(ret); }
+    if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out); }
 
    /* This test:
     * levels: 1
@@ -46899,37 +46881,37 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t lms_test(void)
     */
 
     ret = wc_LmsKey_Init(&signingKey, NULL, INVALID_DEVID);
-    if (ret != 0) { return WC_TEST_RET_ENC_EC(ret); }
+    if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out); }
 
     ret = wc_LmsKey_Init(&verifyKey, NULL, INVALID_DEVID);
-    if (ret != 0) { return WC_TEST_RET_ENC_EC(ret); }
+    if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out); }
 
     ret = wc_LmsKey_SetParameters(&signingKey, 1, 5, 1);
-    if (ret != 0) { return WC_TEST_RET_ENC_EC(ret); }
+    if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out); }
 
     ret = wc_LmsKey_SetWriteCb(&signingKey, lms_write_key_mem);
-    if (ret != 0) { return WC_TEST_RET_ENC_EC(ret); }
+    if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out); }
 
     ret = wc_LmsKey_SetReadCb(&signingKey, lms_read_key_mem);
-    if (ret != 0) { return WC_TEST_RET_ENC_EC(ret); }
+    if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out); }
 
     ret = wc_LmsKey_SetContext(&signingKey, (void *) priv);
-    if (ret != 0) { return WC_TEST_RET_ENC_EC(ret); }
+    if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out); }
 
     ret = wc_LmsKey_MakeKey(&signingKey, &rng);
-    if (ret != 0) { return WC_TEST_RET_ENC_EC(ret); }
+    if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out); }
 
     XMEMCPY(old_priv, priv, sizeof(priv));
 
     ret = wc_LmsKey_ExportPub(&verifyKey, &signingKey);
-    if (ret != 0) { return WC_TEST_RET_ENC_EC(ret); }
+    if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out); }
 
     ret = wc_LmsKey_GetSigLen(&verifyKey, &sigSz);
-    if (ret != 0) { return WC_TEST_RET_ENC_EC(ret); }
+    if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_EC(ret), out); }
 
     if (sigSz != WC_TEST_LMS_SIG_LEN) {
         printf("error: got %u, expected %d\n", sigSz, WC_TEST_LMS_SIG_LEN);
-        return WC_TEST_RET_ENC_EC(sigSz);
+        ERROR_OUT(WC_TEST_RET_ENC_I(sigSz), out);
     }
 
     /* 2 ** 5 should be the max number of signatures */
@@ -46937,23 +46919,23 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t lms_test(void)
         /* We should have remaining signstures. */
         sigsLeft = wc_LmsKey_SigsLeft(&signingKey);
         if (sigsLeft == 0) {
-            return WC_TEST_RET_ENC_EC(sigsLeft);
+            ERROR_OUT(WC_TEST_RET_ENC_NC, out);
         }
 
         /* Sign with key. The private key will be updated on every signature. */
         ret = wc_LmsKey_Sign(&signingKey, sig, &sigSz, (byte *) msg, msgSz);
-        if (ret != 0) { return WC_TEST_RET_ENC_I(i); }
+        if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_I(i), out); }
 
         /* The updated private key should not match the old one. */
         if (XMEMCMP(old_priv, priv, sizeof(priv)) == 0) {
             printf("error: current priv key should not match old: %d\n", i);
-            return WC_TEST_RET_ENC_I(i);
+            ERROR_OUT(WC_TEST_RET_ENC_I(i), out);
         }
 
         XMEMCPY(old_priv, priv, sizeof(priv));
 
         ret = wc_LmsKey_Verify(&verifyKey, sig, sigSz, (byte *) msg, msgSz);
-        if (ret != 0) { return WC_TEST_RET_ENC_I(i); }
+        if (ret != 0) { ERROR_OUT(WC_TEST_RET_ENC_I(i), out); }
 
         /* Flip bits in a few places throughout the signature, stepping in multiple
          * of hash size. These should all fail with -1. */
@@ -46964,7 +46946,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t lms_test(void)
                                      msgSz);
             if ((ret2 != -1) && (ret2 != WC_NO_ERR_TRACE(SIG_VERIFY_E))) {
                 /* Verify passed when it should have failed. */
-                return WC_TEST_RET_ENC_I(j);
+                ERROR_OUT(WC_TEST_RET_ENC_I(j), out);
             }
 
             /* Flip this spot back. */
@@ -46975,8 +46957,10 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t lms_test(void)
     /* This should be the last signature. */
     sigsLeft = wc_LmsKey_SigsLeft(&signingKey);
     if (sigsLeft != 0) {
-        return WC_TEST_RET_ENC_EC(sigsLeft);
+        ERROR_OUT(WC_TEST_RET_ENC_I(sigsLeft), out);
     }
+
+out:
 
     wc_LmsKey_Free(&signingKey);
     wc_LmsKey_Free(&verifyKey);
@@ -58060,7 +58044,15 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t memcb_test(void)
     }
 
     b = (byte*)XMALLOC(1024, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-    b = (byte*)XREALLOC(b, 1024, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    {
+        byte *new_b = (byte*)XREALLOC(b, 1024, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+        if (new_b)
+            b = new_b;
+        else {
+            XFREE(b, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+            ERROR_OUT(WC_TEST_RET_ENC_EC(MEMORY_E), exit_memcb);
+        }
+    }
     XFREE(b, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
 
 #ifndef WOLFSSL_STATIC_MEMORY


### PR DESCRIPTION
numerous fixes for memory errors reported by `clang-tidy`, most of them true positives, unmasked by `CPPFLAGS=-DNO_WOLFSSL_MEMORY`: `clang-analyzer-unix.Malloc`, `clang-analyzer-core.NullDereference`, `clang-analyzer-core.uninitialized.Assign`, `clang-analyzer-core.UndefinedBinaryOperatorResult`, and `clang-analyzer-optin.portability.UnixAPI` (re `malloc(0)`).

several fixes for memory error reported by `cppcheck`:

`wolfcrypt/src/ecc.c`: fix for `cppcheck` `oppositeInnerCondition` from `cppcheck-2.16.0` in `_ecc_make_key_ex()`, and fixes for related unhandled errors discovered by manual inspection;

`wolfcrypt/test/test.c`: fix `XREALLOC` call in `memcb_test()` to resolve `cppcheck`-detected memleak.

full `wolfssl-multi-test.sh` run underway.
