### PR TITLE
Check r and s len before copying

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -26492,7 +26492,9 @@ static int test_wc_ecc_rs_to_sig(void)
     byte        s[KEY24];
     word32      rlen = (word32)sizeof(r);
     word32      slen = (word32)sizeof(s);
+#if !defined(HAVE_SELFTEST) && !defined(HAVE_FIPS)
     word32      zeroLen = 0;
+#endif
 
     /* Init stack variables. */
     XMEMSET(sig, 0, ECC_MAX_SIG_SIZE);
@@ -26518,11 +26520,12 @@ static int test_wc_ecc_rs_to_sig(void)
         WC_NO_ERR_TRACE(ECC_BAD_ARG_E));
     ExpectIntEQ(wc_ecc_sig_to_rs(sig, siglen, r, &rlen, s, NULL),
         WC_NO_ERR_TRACE(ECC_BAD_ARG_E));
+#if !defined(HAVE_SELFTEST) && !defined(HAVE_FIPS)
     ExpectIntEQ(wc_ecc_sig_to_rs(sig, siglen, r, &zeroLen, s, &slen),
         WC_NO_ERR_TRACE(ASN_PARSE_E));
     ExpectIntEQ(wc_ecc_sig_to_rs(sig, siglen, r, &rlen, s, &zeroLen),
         WC_NO_ERR_TRACE(ASN_PARSE_E));
-
+#endif
 #endif
     return EXPECT_RESULT();
 } /* END test_wc_ecc_rs_to_sig */

--- a/tests/api.c
+++ b/tests/api.c
@@ -26522,9 +26522,9 @@ static int test_wc_ecc_rs_to_sig(void)
         WC_NO_ERR_TRACE(ECC_BAD_ARG_E));
 #if !defined(HAVE_SELFTEST) && !defined(HAVE_FIPS)
     ExpectIntEQ(wc_ecc_sig_to_rs(sig, siglen, r, &zeroLen, s, &slen),
-        WC_NO_ERR_TRACE(ASN_PARSE_E));
+        WC_NO_ERR_TRACE(BUFFER_E));
     ExpectIntEQ(wc_ecc_sig_to_rs(sig, siglen, r, &rlen, s, &zeroLen),
-        WC_NO_ERR_TRACE(ASN_PARSE_E));
+        WC_NO_ERR_TRACE(BUFFER_E));
 #endif
 #endif
     return EXPECT_RESULT();

--- a/tests/api.c
+++ b/tests/api.c
@@ -26492,6 +26492,7 @@ static int test_wc_ecc_rs_to_sig(void)
     byte        s[KEY24];
     word32      rlen = (word32)sizeof(r);
     word32      slen = (word32)sizeof(s);
+    word32      zeroLen = 0;
 
     /* Init stack variables. */
     XMEMSET(sig, 0, ECC_MAX_SIG_SIZE);
@@ -26517,6 +26518,11 @@ static int test_wc_ecc_rs_to_sig(void)
         WC_NO_ERR_TRACE(ECC_BAD_ARG_E));
     ExpectIntEQ(wc_ecc_sig_to_rs(sig, siglen, r, &rlen, s, NULL),
         WC_NO_ERR_TRACE(ECC_BAD_ARG_E));
+    ExpectIntEQ(wc_ecc_sig_to_rs(sig, siglen, r, &zeroLen, s, &slen),
+        WC_NO_ERR_TRACE(ASN_PARSE_E));
+    ExpectIntEQ(wc_ecc_sig_to_rs(sig, siglen, r, &rlen, s, &zeroLen),
+        WC_NO_ERR_TRACE(ASN_PARSE_E));
+
 #endif
     return EXPECT_RESULT();
 } /* END test_wc_ecc_rs_to_sig */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -33784,7 +33784,7 @@ int DecodeECC_DSA_Sig_Bin(const byte* sig, word32 sigLen, byte* r, word32* rLen,
             *rLen = (word32)len;
         else {
             /* Buffer too small to hold r value */
-            return BUFFER_E;
+            return ASN_PARSE_E;
         }
     }
     if (r)
@@ -33799,7 +33799,7 @@ int DecodeECC_DSA_Sig_Bin(const byte* sig, word32 sigLen, byte* r, word32* rLen,
             *sLen = (word32)len;
         else {
             /* Buffer too small to hold r value */
-            return BUFFER_E;
+            return ASN_PARSE_E;
         }
     }
     if (s)

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -1300,7 +1300,7 @@ static int GetASN_StoreData(const ASNItem* asn, ASNGetData* data,
                 WOLFSSL_MSG_VSNPRINTF("Buffer too small for data: %d %d", len,
                         *data->data.buffer.length);
             #endif
-                return ASN_PARSE_E;
+                return BUFFER_E;
             }
             /* Copy in data and record actual length seen. */
             XMEMCPY(data->data.buffer.data, input + idx, (size_t)len);
@@ -33784,7 +33784,7 @@ int DecodeECC_DSA_Sig_Bin(const byte* sig, word32 sigLen, byte* r, word32* rLen,
             *rLen = (word32)len;
         else {
             /* Buffer too small to hold r value */
-            return ASN_PARSE_E;
+            return BUFFER_E;
         }
     }
     if (r)
@@ -33798,8 +33798,8 @@ int DecodeECC_DSA_Sig_Bin(const byte* sig, word32 sigLen, byte* r, word32* rLen,
         if (*sLen >= (word32)len)
             *sLen = (word32)len;
         else {
-            /* Buffer too small to hold r value */
-            return ASN_PARSE_E;
+            /* Buffer too small to hold s value */
+            return BUFFER_E;
         }
     }
     if (s)

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -33779,8 +33779,14 @@ int DecodeECC_DSA_Sig_Bin(const byte* sig, word32 sigLen, byte* r, word32* rLen,
     ret = GetASNInt(sig, &idx, &len, sigLen);
     if (ret != 0)
         return ret;
-    if (rLen)
-        *rLen = (word32)len;
+    if (rLen) {
+        if (*rLen >= (word32)len)
+            *rLen = (word32)len;
+        else {
+            /* Buffer too small to hold r value */
+            return BUFFER_E;
+        }
+    }
     if (r)
         XMEMCPY(r, (byte*)sig + idx, (size_t)len);
     idx += (word32)len;
@@ -33788,8 +33794,14 @@ int DecodeECC_DSA_Sig_Bin(const byte* sig, word32 sigLen, byte* r, word32* rLen,
     ret = GetASNInt(sig, &idx, &len, sigLen);
     if (ret != 0)
         return ret;
-    if (sLen)
-        *sLen = (word32)len;
+    if (sLen) {
+        if (*sLen >= (word32)len)
+            *sLen = (word32)len;
+        else {
+            /* Buffer too small to hold r value */
+            return BUFFER_E;
+        }
+    }
     if (s)
         XMEMCPY(s, (byte*)sig + idx, (size_t)len);
 


### PR DESCRIPTION
# Description

`DecodeECC_DSA_Sig_Bin()` does not take into account the rLen and sLen values provided as input. These parameters are intended to represent the sizes of the buffers for r and s, as outlined in the documentation for wc_ecc_sig_to_rs().

Fix checks len values and returns `ASN_PARSE_E` if too small to hold sig component.

Fixes zd19220

# Testing

`./configure --enable-asn=original`

* confirmed same behavior with ASN_TEMPLATE

# Checklist

 - [ x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
