### PR TITLE
20240110-revert-8340

### DIFF
--- a/src/quic.c
+++ b/src/quic.c
@@ -154,15 +154,17 @@ static int quic_record_append(WOLFSSL *ssl, QuicRecord *qr, const uint8_t *data,
         }
     }
 
-    if (!quic_record_complete(qr) && len != 0) {
-        missing = qr->len - qr->end;
-        if (len > missing) {
-            len = missing;
-        }
-        XMEMCPY(qr->data + qr->end, data, len);
-        qr->end += (word32)len;
-        consumed += len;
+    if (quic_record_complete(qr) || len == 0) {
+        return 0;
     }
+
+    missing = qr->len - qr->end;
+    if (len > missing) {
+        len = missing;
+    }
+    XMEMCPY(qr->data + qr->end, data, len);
+    qr->end += (word32)len;
+    consumed += len;
 
 cleanup:
     *pconsumed = (ret == WOLFSSL_SUCCESS) ? consumed : 0;

--- a/tests/quic.c
+++ b/tests/quic.c
@@ -287,10 +287,7 @@ static int test_provide_quic_data(void) {
      */
     AssertNotNull(ssl = wolfSSL_new(ctx));
     len = fake_record(1, 100, lbuffer);
-    AssertTrue(provide_data(ssl, wolfssl_encryption_initial, lbuffer, 1, 0));
-    AssertTrue(provide_data(ssl, wolfssl_encryption_initial, lbuffer+1, 3, 0));
-    AssertTrue(provide_data(ssl, wolfssl_encryption_initial, lbuffer+4, len, 0)
-            );
+    AssertTrue(provide_data(ssl, wolfssl_encryption_initial, lbuffer, len, 0));
     len = fake_record(2, 1523, lbuffer);
     AssertTrue(provide_data(ssl, wolfssl_encryption_handshake, lbuffer, len, 0));
     len = fake_record(2, 1, lbuffer);


### PR DESCRIPTION
Revert "quic_record_append: return correct code"

This reverts commit bc12dad041594366a232a0022a04024b6254390d.

This commit broke builds that combine QUIC and PQ -- known failures are pq-all-valgrind-unittest, pq-hybrid-all-rpk, pq-hybrid-all-rpk-valgrind-unittest, quantum-safe-wolfssl-all-gcc-latest, quantum-safe-wolfssl-all-g++-latest, quantum-safe-wolfssl-all-fortify-source-asm, quantum-safe-wolfssl-all-fortify-source-asm-noasm, and quantum-safe-wolfssl-all-intelasm-sp-asm-valgrind.

Note that the unit.test asserts added by this commit fail both before and after reversion.

Excerpts from representative defect reports:
```
[pq-all-valgrind-unittest] [83 of 323] [dc2ada117e]
    configure...   real 0m10.088s  user 0m7.186s  sys 0m3.653s
    build...   real 0m30.714s  user 1m28.350s  sys 0m5.297s
    valgrind unit.test...==19540== Conditional jump or move depends on uninitialised value(s)
    [...]
    pq-all-valgrind-unittest fail_analysis
    failed config: '--srcdir' '.' '--disable-jobserver' '--enable-option-checking=fatal' '--enable-all' '--e
nable-testcert' '--enable-acert' '--enable-dtls13' '--enable-dtls-mtu' '--enable-dtls-frag-ch' '--enable-dtl
scid' '--enable-quic' '--with-sys-crypto-policy' '--disable-asm' '--enable-experimental' '--with-liboqs' 'LD
FLAGS=-ggdb -fno-omit-frame-pointer' '--disable-optflags' 'CPPFLAGS=-DNO_WOLFSSL_CIPHER_SUITE_TEST -DWOLFSSL
_OLD_PRIME_CHECK -pedantic' 'CFLAGS=-ggdb -fno-omit-frame-pointer -O2'
```
```
[pq-hybrid-all-rpk] [84 of 323] [dc2ada117e]
    configure...   real 0m9.592s  user 0m6.871s  sys 0m3.527s
    build...   real 0m22.215s  user 1m15.551s  sys 0m4.231s
    check...FAIL: scripts/unit.test
   real 0m20.247s  user 0m8.630s  sys 0m3.892s

scripts/unit.log tail:
    test_set_quic_method: passed
SSL quic data buffered: 
  - 0-104/104 (cap 2048, level=0)
  scratch: -

ERROR - tests/quic.c line 292 failed with:
    expected: provide_data(ssl, wolfssl_encryption_initial, lbuffer+4, len, 0) is true
    result:   provide_data(ssl, wolfssl_encryption_initial, lbuffer+4, len, 0) => FALSE

FAIL scripts/unit.test (exit status: 134)

check exited with status 2
[...]
    pq-hybrid-all-rpk fail_check
    failed config: '--srcdir' '.' '--disable-jobserver' '--enable-option-checking=fatal' '--enable-all' '--enable-testcert' '--enable-acert' '--enable-dtls13' '--enable-dtls-mtu' '--enable-dtls-frag-ch' '--enable-dtlscid' '--enable-quic' '--with-sys-crypto-policy' '--enable-intelasm' '--enable-sp-asm' '--enable-experimental' '--with-liboqs' '--enable-dual-alg-certs' 'CPPFLAGS=-DHAVE_RPK -DNO_WOLFSSL_CIPHER_SUITE_TEST -DWOLFSSL_OLD_PRIME_CHECK -pedantic'
```
```
[quantum-safe-wolfssl-all-gcc-latest] [90 of 323] [dc2ada117e]
    configure...   real 0m10.336s  user 0m7.270s  sys 0m3.835s
    build...   real 0m50.334s  user 2m28.108s  sys 0m4.276s
    check...FAIL: scripts/unit.test
   real 0m21.048s  user 0m10.091s  sys 0m3.816s

scripts/unit.log tail:
    test_set_quic_method: passed
SSL quic data buffered: 
  - 0-104/104 (cap 2048, level=0)
  scratch: -

ERROR - tests/quic.c line 292 failed with:
    expected: provide_data(ssl, wolfssl_encryption_initial, lbuffer+4, len, 0) is true
    result:   provide_data(ssl, wolfssl_encryption_initial, lbuffer+4, len, 0) => FALSE

FAIL scripts/unit.test (exit status: 134)

check exited with status 2
[...]
    quantum-safe-wolfssl-all-gcc-latest fail_check
    failed config: '--srcdir' '.' '--disable-jobserver' '--enable-option-checking=fatal' '--enable-all' '--enable-testcert' '--enable-acert' '--enable-dtls13' '--enable-dtls-mtu' '--enable-dtls-frag-ch' '--enable-dtlscid' '--enable-quic' '--with-sys-crypto-policy' '--enable-intelasm' '--enable-sp-asm' '--enable-experimental' '--enable-kyber=all,original' '--enable-lms' '--enable-xmss' '--enable-dilithium' '--enable-dual-alg-certs' '--disable-qt' 'CPPFLAGS=-pedantic -DWOLFCRYPT_TEST_LINT' 'CC=gcc-15'
```
```
[quantum-safe-wolfssl-all-intelasm-sp-asm-valgrind] [103 of 323] [dc2ada117e]
    configure...   real 0m10.104s  user 0m7.239s  sys 0m3.668s
    build...   real 0m31.571s  user 1m35.470s  sys 0m5.622s
    valgrind unit.test...==6659== Conditional jump or move depends on uninitialised value(s)
[...]
    quantum-safe-wolfssl-all-intelasm-sp-asm-valgrind fail_analysis
    failed config: '--srcdir' '.' '--disable-jobserver' '--enable-option-checking=fatal' '--enable-all' '--enable-testcert' '--enable-acert' '--enable-dtls13' '--enable-dtls-mtu' '--enable-dtls-frag-ch' '--enable-dtlscid' '--enable-quic' '--with-sys-crypto-policy' '--enable-intelasm' '--enable-sp-asm' '--enable-experimental' '--enable-kyber=all,original' '--enable-lms' '--enable-xmss' '--enable-dilithium' '--enable-dual-alg-certs' '--disable-qt' 'CPPFLAGS=-DNO_WOLFSSL_CIPHER_SUITE_TEST -DWOLFSSL_OLD_PRIME_CHECK -pedantic' 'LDFLAGS=-ggdb -fno-omit-frame-pointer' '--disable-optflags' 'CFLAGS=-ggdb -fno-omit-frame-pointer -O2'
```
