### PR TITLE
Properly check for signature_algorithms from the client in a TLS 1.3 server.

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -7053,7 +7053,9 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             WOLFSSL_MSG("Client did not send a KeyShare extension");
             ERROR_OUT(INCOMPLETE_DATA, exit_dch);
         }
-        if (TLSX_Find(ssl->extensions, TLSX_SIGNATURE_ALGORITHMS) == NULL) {
+        /* Can't check ssl->extensions here as SigAlgs are unconditionally
+           set by TLSX_PopulateExtensions */
+        if (args->clSuites->hashSigAlgoSz == 0) {
             WOLFSSL_MSG("Client did not send a SignatureAlgorithms extension");
             ERROR_OUT(INCOMPLETE_DATA, exit_dch);
         }


### PR DESCRIPTION
# Description

The server was checking ssl->extensions which will always have an entry for TLSX_SIGNATURE_ALGORITHMS as it is unconditionally added by TLSX_PopulateExtensions earlier in the DoTls13ClientHello function. Instead, check args->clSuites->hashSigAlgoSz which is only set if signature_algorithms is found and parsed by TLSX_Parse.

Fixes #8355

# Testing

Hacked client to not send sig_algs, confirmed server disconnected as expected, and that server connected to normal client as expected.
Hack used to prevent client from sending sig_algs:
```
diff --git a/src/tls.c b/src/tls.c
index e3829cb38..5156c2f89 100644
--- a/src/tls.c
+++ b/src/tls.c
@@ -13673,10 +13673,12 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
     } /* is not server */

 #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
-    WOLFSSL_MSG("Adding signature algorithms extension");
-    if ((ret = TLSX_SetSignatureAlgorithms(&ssl->extensions, ssl, ssl->heap))
-                                                                         != 0) {
-            return ret;
+    if (isServer) {
+        WOLFSSL_MSG("Adding signature algorithms extension");
+        if ((ret = TLSX_SetSignatureAlgorithms(&ssl->extensions, ssl, ssl->heap))
+                                                                            != 0) {
+                return ret;
+        }
     }
 #else
     ret = 0;
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation