### PR TITLE
Entropy Apple: change time function called

### DIFF
--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -818,7 +818,7 @@ static WC_INLINE word64 Entropy_TimeHiRes(void)
  */
 static WC_INLINE word64 Entropy_TimeHiRes(void)
 {
-    return mach_absolute_time();
+    return clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW);
 }
 #elif !defined(ENTROPY_MEMUSE_THREAD) && defined(__aarch64__)
 /* Get the high resolution time counter.


### PR DESCRIPTION
# Description

Use clock_gettime_nsec_np and get the raw monotonic counter.

# Testing

gather and analyse on ARM Mac

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
