### PR TITLE
Update ssl code for ML_DSA.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5749,6 +5749,7 @@ int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify)
                 break;
             #endif /* HAVE_FALCON */
             #if defined(HAVE_DILITHIUM)
+            #ifdef WOLFSSL_DILITHIUM_FIPS204_DRAFT
             case DILITHIUM_LEVEL2k:
                 if (cm->minDilithiumKeySz < 0 ||
                     DILITHIUM_LEVEL2_KEY_SIZE < (word16)cm->minDilithiumKeySz) {
@@ -5766,6 +5767,28 @@ int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify)
             case DILITHIUM_LEVEL5k:
                 if (cm->minDilithiumKeySz < 0 ||
                     DILITHIUM_LEVEL5_KEY_SIZE < (word16)cm->minDilithiumKeySz) {
+                    ret = DILITHIUM_KEY_SIZE_E;
+                    WOLFSSL_MSG("\tCA Dilithium level 5 key size error");
+                }
+                break;
+            #endif /* WOLFSSL_DILITHIUM_FIPS204_DRAFT */
+            case ML_DSA_LEVEL2k:
+                if (cm->minDilithiumKeySz < 0 ||
+                    ML_DSA_LEVEL2_KEY_SIZE < (word16)cm->minDilithiumKeySz) {
+                    ret = DILITHIUM_KEY_SIZE_E;
+                    WOLFSSL_MSG("\tCA Dilithium level 2 key size error");
+                }
+                break;
+            case ML_DSA_LEVEL3k:
+                if (cm->minDilithiumKeySz < 0 ||
+                    ML_DSA_LEVEL3_KEY_SIZE < (word16)cm->minDilithiumKeySz) {
+                    ret = DILITHIUM_KEY_SIZE_E;
+                    WOLFSSL_MSG("\tCA Dilithium level 3 key size error");
+                }
+                break;
+            case ML_DSA_LEVEL5k:
+                if (cm->minDilithiumKeySz < 0 ||
+                    ML_DSA_LEVEL5_KEY_SIZE < (word16)cm->minDilithiumKeySz) {
                     ret = DILITHIUM_KEY_SIZE_E;
                     WOLFSSL_MSG("\tCA Dilithium level 5 key size error");
                 }
@@ -6788,9 +6811,15 @@ static int check_cert_key_dev(word32 keyOID, byte* privKey, word32 privSz,
     }
 #endif
 #if defined(HAVE_DILITHIUM)
-    if ((keyOID == DILITHIUM_LEVEL2k) ||
-        (keyOID == DILITHIUM_LEVEL3k) ||
-        (keyOID == DILITHIUM_LEVEL5k)) {
+    if ((keyOID == ML_DSA_LEVEL2k) ||
+        (keyOID == ML_DSA_LEVEL3k) ||
+        (keyOID == ML_DSA_LEVEL5k)
+        #ifdef WOLFSSL_DILITHIUM_FIPS204_DRAFT
+     || (keyOID == DILITHIUM_LEVEL2k)
+     || (keyOID == DILITHIUM_LEVEL3k)
+     || (keyOID == DILITHIUM_LEVEL5k)
+        #endif /* WOLFSSL_DILITHIUM_FIPS204_DRAFT */
+        ) {
         type = DYNAMIC_TYPE_DILITHIUM;
     }
 #endif
@@ -6820,9 +6849,15 @@ static int check_cert_key_dev(word32 keyOID, byte* privKey, word32 privSz,
         }
         #endif
         #if defined(HAVE_DILITHIUM)
-        if ((keyOID == DILITHIUM_LEVEL2k) ||
-            (keyOID == DILITHIUM_LEVEL3k) ||
-            (keyOID == DILITHIUM_LEVEL5k)) {
+        if ((keyOID == ML_DSA_LEVEL2k) ||
+            (keyOID == ML_DSA_LEVEL3k) ||
+            (keyOID == ML_DSA_LEVEL5k)
+            #ifdef WOLFSSL_DILITHIUM_FIPS204_DRAFT
+         || (keyOID == DILITHIUM_LEVEL2k)
+         || (keyOID == DILITHIUM_LEVEL3k)
+         || (keyOID == DILITHIUM_LEVEL5k)
+            #endif /* WOLFSSL_DILITHIUM_FIPS204_DRAFT */
+            ) {
             ret = wc_CryptoCb_PqcSignatureCheckPrivKey(pkey,
                                         WC_PQC_SIG_TYPE_DILITHIUM,
                                         pubKey, pubSz);
@@ -6859,9 +6894,15 @@ static int check_cert_key_dev(word32 keyOID, byte* privKey, word32 privSz,
         }
     #endif
     #if defined(HAVE_DILITHIUM)
-        if ((keyOID == DILITHIUM_LEVEL2k) ||
-            (keyOID == DILITHIUM_LEVEL3k) ||
-            (keyOID == DILITHIUM_LEVEL5k)) {
+        if ((keyOID == ML_DSA_LEVEL2k) ||
+            (keyOID == ML_DSA_LEVEL3k) ||
+            (keyOID == ML_DSA_LEVEL5k)
+            #ifdef WOLFSSL_DILITHIUM_FIPS204_DRAFT
+         || (keyOID == DILITHIUM_LEVEL2k) ||
+         || (keyOID == DILITHIUM_LEVEL3k) ||
+         || (keyOID == DILITHIUM_LEVEL5k)
+            #endif /* WOLFSSL_DILITHIUM_FIPS204_DRAFT */
+            ) {
             wc_dilithium_free((dilithium_key*)pkey);
         }
     #endif
@@ -7686,31 +7727,31 @@ static int d2iTryDilithiumKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
 
     /* Test if Dilithium key. Try all levels. */
     if (priv) {
-        isDilithium = ((wc_dilithium_set_level(dilithium, 2) == 0) &&
+        isDilithium = ((wc_dilithium_set_level(dilithium, WC_ML_DSA_44) == 0) &&
                        (wc_dilithium_import_private(mem,
                           (word32)memSz, dilithium) == 0));
         if (!isDilithium) {
-            isDilithium = ((wc_dilithium_set_level(dilithium, 3) == 0) &&
+            isDilithium = ((wc_dilithium_set_level(dilithium, WC_ML_DSA_65) == 0) &&
                            (wc_dilithium_import_private(mem,
                               (word32)memSz, dilithium) == 0));
         }
         if (!isDilithium) {
-            isDilithium = ((wc_dilithium_set_level(dilithium, 5) == 0) &&
+            isDilithium = ((wc_dilithium_set_level(dilithium, WC_ML_DSA_87) == 0) &&
                            (wc_dilithium_import_private(mem,
                               (word32)memSz, dilithium) == 0));
         }
     }
     else {
-        isDilithium = ((wc_dilithium_set_level(dilithium, 2) == 0) &&
+        isDilithium = ((wc_dilithium_set_level(dilithium, WC_ML_DSA_44) == 0) &&
                        (wc_dilithium_import_public(mem, (word32)memSz,
                           dilithium) == 0));
         if (!isDilithium) {
-            isDilithium = ((wc_dilithium_set_level(dilithium, 3) == 0) &&
+            isDilithium = ((wc_dilithium_set_level(dilithium, WC_ML_DSA_65) == 0) &&
                            (wc_dilithium_import_public(mem, (word32)memSz,
                               dilithium) == 0));
         }
         if (!isDilithium) {
-            isDilithium = ((wc_dilithium_set_level(dilithium, 5) == 0) &&
+            isDilithium = ((wc_dilithium_set_level(dilithium, WC_ML_DSA_87) == 0) &&
                            (wc_dilithium_import_public(mem, (word32)memSz,
                               dilithium) == 0));
         }
@@ -12038,13 +12079,13 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             *sigAlgo = FALCON_LEVEL5k;
             break;
         case dilithium_level2_sa_algo:
-            *sigAlgo = DILITHIUM_LEVEL2k;
+            *sigAlgo = ML_DSA_LEVEL2k;
             break;
         case dilithium_level3_sa_algo:
-            *sigAlgo = DILITHIUM_LEVEL3k;
+            *sigAlgo = ML_DSA_LEVEL3k;
             break;
         case dilithium_level5_sa_algo:
-            *sigAlgo = DILITHIUM_LEVEL5k;
+            *sigAlgo = ML_DSA_LEVEL5k;
             break;
         case sm2_sa_algo:
             *sigAlgo = SM2k;
@@ -18298,12 +18339,20 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
                                                           "Falcon Level 5"},
     #endif /* HAVE_FALCON */
     #ifdef HAVE_DILITHIUM
+    #ifdef WOLFSSL_DILITHIUM_FIPS204_DRAFT
         { CTC_DILITHIUM_LEVEL2, DILITHIUM_LEVEL2k,  oidKeyType,
           "Dilithium Level 2", "Dilithium Level 2"},
         { CTC_DILITHIUM_LEVEL3, DILITHIUM_LEVEL3k,  oidKeyType,
           "Dilithium Level 3", "Dilithium Level 3"},
         { CTC_DILITHIUM_LEVEL5, DILITHIUM_LEVEL5k,  oidKeyType,
           "Dilithium Level 5", "Dilithium Level 5"},
+    #endif /* WOLFSSL_DILITHIUM_FIPS204_DRAFT */
+        { CTC_ML_DSA_LEVEL2, ML_DSA_LEVEL2k,  oidKeyType,
+          "ML_DSA Level 2", "ML_DSA Level 2"},
+        { CTC_ML_DSA_LEVEL3, ML_DSA_LEVEL3k,  oidKeyType,
+          "ML_DSA Level 3", "ML_DSA Level 3"},
+        { CTC_ML_DSA_LEVEL5, ML_DSA_LEVEL5k,  oidKeyType,
+          "ML_DSA Level 5", "ML_DSA Level 5"},
     #endif /* HAVE_DILITHIUM */
 
         /* oidCurveType */
@@ -18686,13 +18735,13 @@ static int SaToNid(byte sa, int* nid)
             *nid = CTC_FALCON_LEVEL5;
             break;
         case dilithium_level2_sa_algo:
-            *nid = CTC_DILITHIUM_LEVEL2;
+            *nid = CTC_ML_DSA_LEVEL2;
             break;
         case dilithium_level3_sa_algo:
-            *nid = CTC_DILITHIUM_LEVEL3;
+            *nid = CTC_ML_DSA_LEVEL3;
             break;
         case dilithium_level5_sa_algo:
-            *nid = CTC_DILITHIUM_LEVEL5;
+            *nid = CTC_ML_DSA_LEVEL5;
             break;
         case sm2_sa_algo:
             *nid = WC_NID_sm2;

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -10149,13 +10149,13 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
             #endif
             #ifdef HAVE_DILITHIUM
                 case dilithium_level2_sa_algo:
-                    ret = decodeDilithiumKey(ssl, 2);
+                    ret = decodeDilithiumKey(ssl, WC_ML_DSA_44);
                     break;
                 case dilithium_level3_sa_algo:
-                    ret = decodeDilithiumKey(ssl, 3);
+                    ret = decodeDilithiumKey(ssl, WC_ML_DSA_65);
                     break;
                 case dilithium_level5_sa_algo:
-                    ret = decodeDilithiumKey(ssl, 5);
+                    ret = decodeDilithiumKey(ssl, WC_ML_DSA_87);
                     break;
             #endif
             #ifdef HAVE_FALCON

--- a/src/x509.c
+++ b/src/x509.c
@@ -11051,9 +11051,15 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
         }
     #endif
     #if defined(HAVE_DILITHIUM)
-        if ((x509->pubKeyOID == DILITHIUM_LEVEL2k) ||
-            (x509->pubKeyOID == DILITHIUM_LEVEL3k) ||
-            (x509->pubKeyOID == DILITHIUM_LEVEL5k)) {
+        if ((x509->pubKeyOID == ML_DSA_LEVEL2k) ||
+            (x509->pubKeyOID == ML_DSA_LEVEL3k) ||
+            (x509->pubKeyOID == ML_DSA_LEVEL5k)
+            #ifdef WOLFSSL_DILITHIUM_FIPS204_DRAFT
+         || (x509->pubKeyOID == DILITHIUM_LEVEL2k)
+         || (x509->pubKeyOID == DILITHIUM_LEVEL3k)
+         || (x509->pubKeyOID == DILITHIUM_LEVEL5k)
+            #endif /* WOLFSSL_DILITHIUM_FIPS204_DRAFT */
+            ) {
             dilithium = (dilithium_key*)XMALLOC(sizeof(dilithium_key), NULL,
                                           DYNAMIC_TYPE_DILITHIUM);
             if (dilithium == NULL) {
@@ -11069,18 +11075,32 @@ static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
                 return ret;
             }
 
-            if (x509->pubKeyOID == DILITHIUM_LEVEL2k) {
+            if (x509->pubKeyOID == ML_DSA_LEVEL2k) {
+                type = ML_DSA_LEVEL2_TYPE;
+                wc_dilithium_set_level(dilithium, WC_ML_DSA_44);
+            }
+            else if (x509->pubKeyOID == ML_DSA_LEVEL3k) {
+                type = ML_DSA_LEVEL3_TYPE;
+                wc_dilithium_set_level(dilithium, WC_ML_DSA_65);
+            }
+            else if (x509->pubKeyOID == ML_DSA_LEVEL5k) {
+                type = ML_DSA_LEVEL5_TYPE;
+                wc_dilithium_set_level(dilithium, WC_ML_DSA_87);
+            }
+            #ifdef WOLFSSL_DILITHIUM_FIPS204_DRAFT
+            else if (x509->pubKeyOID == DILITHIUM_LEVEL2k) {
                 type = DILITHIUM_LEVEL2_TYPE;
-                wc_dilithium_set_level(dilithium, 2);
+                wc_dilithium_set_level(dilithium, WC_ML_DSA_44_DRAFT);
             }
             else if (x509->pubKeyOID == DILITHIUM_LEVEL3k) {
                 type = DILITHIUM_LEVEL3_TYPE;
-                wc_dilithium_set_level(dilithium, 3);
+                wc_dilithium_set_level(dilithium, WC_ML_DSA_65_DRAFT);
             }
             else if (x509->pubKeyOID == DILITHIUM_LEVEL5k) {
                 type = DILITHIUM_LEVEL5_TYPE;
-                wc_dilithium_set_level(dilithium, 5);
+                wc_dilithium_set_level(dilithium, WC_ML_DSA_87_DRAFT);
             }
+            #endif /* WOLFSSL_DILITHIUM_FIPS204_DRAFT */
 
             ret = wc_Dilithium_PublicKeyDecode(x509->pubKey.buffer, &idx,
                                     dilithium, x509->pubKey.length);
@@ -11261,9 +11281,15 @@ cleanup:
         }
     #endif
     #if defined(HAVE_DILITHIUM)
-        if ((x509->pubKeyOID == DILITHIUM_LEVEL2k) ||
-            (x509->pubKeyOID == DILITHIUM_LEVEL3k) ||
-            (x509->pubKeyOID == DILITHIUM_LEVEL5k)) {
+        if ((x509->pubKeyOID == ML_DSA_LEVEL2k) ||
+            (x509->pubKeyOID == ML_DSA_LEVEL3k) ||
+            (x509->pubKeyOID == ML_DSA_LEVEL5k)
+        #ifdef WOLFSSL_DILITHIUM_FIPS204_DRAFT
+         || (x509->pubKeyOID == DILITHIUM_LEVEL2k)
+         || (x509->pubKeyOID == DILITHIUM_LEVEL3k)
+         || (x509->pubKeyOID == DILITHIUM_LEVEL5k)
+        #endif
+        ) {
             wc_dilithium_free(dilithium);
             XFREE(dilithium, NULL, DYNAMIC_TYPE_DILITHIUM);
         }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -17833,7 +17833,7 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
                 case DILITHIUM_LEVEL2k:
                 case DILITHIUM_LEVEL3k:
                 case DILITHIUM_LEVEL5k:
-                #endif
+                #endif /* WOLFSSL_DILITHIUM_FIPS204_DRAFT */
                 case ML_DSA_LEVEL2k:
                 case ML_DSA_LEVEL3k:
                 case ML_DSA_LEVEL5k:


### PR DESCRIPTION
# Description

Update ssl code in `src/*.c` to be consistent with `wolfcrypt/src/asn.c` handling of ML_DSA vs Dilithium (draft):
- Guard symbols like `DILITHIUM_LEVEL2k` behind `#ifdef WOLFSSL_DILITHIUM_FIPS204_DRAFT`.
- Update `wc_dilithium_set_level()` calls to use appropriate `WC_ML_DSA_XX_DRAFT` or `WC_ML_DSA_XX` define rather than numeric value.
- Update cert/key loading code in `src/ssl_load.c` to recognize ML-DSA final vs Dilithium draft.

Fixes dual alg ML-DSA example: https://github.com/wolfSSL/wolfssl-examples/tree/master/X9.146#ecdsa-demos.

# Testing

- https://github.com/wolfSSL/wolfssl-examples/pull/479
