### PR TITLE
Link to advapi32 on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2412,7 +2412,7 @@ target_link_libraries(wolfssl PUBLIC ${WOLFSSL_LINK_LIBS})
 if(WIN32)
     # For Windows link ws2_32
     target_link_libraries(wolfssl PUBLIC
-        $<$<PLATFORM_ID:Windows>:ws2_32 crypt32>)
+        $<$<PLATFORM_ID:Windows>:ws2_32 crypt32 advapi32>)
 elseif(APPLE)
     if(WOLFSSL_SYS_CA_CERTS)
         target_link_libraries(wolfssl PUBLIC


### PR DESCRIPTION
`random.c` on Windows uses old CryptoAPI functions like  CryptAcquireContext , which are present in advapi32, but it wasn't linked explicitly.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
