### PR TITLE
20250122-enable-fips-requires-arg

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -423,7 +423,7 @@ AS_CASE([$ENABLED_FIPS],
         FIPS_VERSION="disabled"
         ENABLED_FIPS="no"
     ],
-    [v1|yes|cert2425],[
+    [v1|cert2425],[
         FIPS_VERSION="v1"
         HAVE_FIPS_VERSION_MAJOR=1
         ENABLED_FIPS="yes"
@@ -510,7 +510,8 @@ AS_CASE([$ENABLED_FIPS],
         # for dev, DEF_SP_MATH and DEF_FAST_MATH follow non-FIPS defaults (currently sp-math-all)
     ],
     [
-        AC_MSG_ERROR([Invalid value for --enable-fips "$ENABLED_FIPS" (main options: v1, v2, v5, v6, ready, dev, rand, no, disabled)])
+        AS_IF([test "$ENABLED_FIPS" = "yes"],[ENABLED_FIPS="(unset)"],[ENABLED_FIPS=\"$ENABLED_FIPS\"])
+        AC_MSG_ERROR([Invalid value for --enable-fips $ENABLED_FIPS (main options: v1, v2, v5, v6, ready, dev, rand, no, disabled)])
     ])
 
 if test -z "$HAVE_FIPS_VERSION_MAJOR"

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2980,7 +2980,7 @@ enum { /* ssl Constants */
     /* Operation did not complete; callback needs this API to be called again.*/
     WOLFSSL_ERROR_WANT_X509_LOOKUP =  4,
 
-    /* Some sort of sytem I/O error happened.*/
+    /* Some sort of system I/O error happened.*/
     WOLFSSL_ERROR_SYSCALL          =  5,
 
     /* The connection has been closed with a closure alert.*/


### PR DESCRIPTION
configure.ac: require explicit arg for --enable-fips.

wolfssl/ssl.h: fix speling erorr (thanks codespell).
