### PR TITLE
Fix OPENSSL_ALL build with WOLFSSL_NO_REALLOC

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -2770,9 +2770,21 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
         }
         else {
             size_t currLen = XSTRLEN(b->ip);
+        #ifdef WOLFSSL_NO_REALLOC
+            char* tmp = NULL;
+        #endif
+
             if (currLen != newLen) {
+        #ifdef WOLFSSL_NO_REALLOC
+                tmp = b->ip;
+                b->ip = (char*)XMALLOC(newLen+1, b->heap, DYNAMIC_TYPE_OPENSSL);
+                XMEMCPY(b->ip, tmp, newLen);
+                XFREE(tmp, b->heap, DYNAMIC_TYPE_OPENSSL);
+                tmp = NULL;
+        #else
                 b->ip = (char*)XREALLOC(b->ip, newLen + 1, b->heap,
                     DYNAMIC_TYPE_OPENSSL);
+        #endif
                 if (b->ip == NULL) {
                     WOLFSSL_MSG("Hostname realloc failed.");
                     return WOLFSSL_FAILURE;

--- a/src/conf.c
+++ b/src/conf.c
@@ -773,8 +773,18 @@ static char* expandValue(WOLFSSL_CONF *conf, const char* section,
                     /* This will allocate slightly more memory than necessary
                      * but better be safe */
                     strLen += valueLen;
+                #ifdef WOLFSSL_NO_REALLOC
+                    newRet = (char*)XMALLOC(strLen + 1, NULL,
+                            DYNAMIC_TYPE_OPENSSL);
+                    if (newRet != NULL) {
+                       XMEMCPY(newRet, ret, (strLen - valueLen) + 1);
+                       XFREE(ret, NULL, DYNAMIC_TYPE_OPENSSL);
+                       ret = NULL;
+                    }
+                #else
                     newRet = (char*)XREALLOC(ret, strLen + 1, NULL,
                             DYNAMIC_TYPE_OPENSSL);
+                #endif
                     if (!newRet) {
                         WOLFSSL_MSG("realloc error");
                         goto expand_cleanup;

--- a/src/internal.c
+++ b/src/internal.c
@@ -39404,8 +39404,19 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 WOLFSSL_MSG("Found session matching the session id"
                             " found in the ticket");
                 /* Allocate and populate an InternalTicket */
+            #ifdef WOLFSSL_NO_REALLOC
+                tmp = (byte*)XMALLOC(sizeof(InternalTicket), ssl->heap,
+                        DYNAMIC_TYPE_TLSX);
+                if (tmp != NULL)
+                {
+                   XMEMCPY(tmp, psk->identity, psk->identityLen);
+                   XFREE(psk->identity, ssl->heap, DYNAMIC_TYPE_TLSX);
+                   psk->identity = NULL;
+                }
+            #else
                 tmp = (byte*)XREALLOC(psk->identity, sizeof(InternalTicket),
                         ssl->heap, DYNAMIC_TYPE_TLSX);
+            #endif
                 if (tmp != NULL) {
                     XMEMSET(tmp, 0, sizeof(InternalTicket));
                     psk->identity = tmp;

--- a/src/pk.c
+++ b/src/pk.c
@@ -518,8 +518,19 @@ static int der_to_enc_pem_alloc(unsigned char* der, int derSz,
         byte *tmpBuf;
 
         /* Add space for padding. */
+    #ifdef WOLFSSL_NO_REALLOC
+        tmpBuf = (byte*)XMALLOC((size_t)(derSz + blockSz), heap,
+            DYNAMIC_TYPE_TMP_BUFFER);
+        if (tmpBuf != NULL)
+        {
+                XMEMCPY(tmpBuf, der, (size_t)(derSz));
+                XFREE(der, heap, DYNAMIC_TYPE_TMP_BUFFER);
+                der = NULL;
+        }
+    #else
         tmpBuf = (byte*)XREALLOC(der, (size_t)(derSz + blockSz), heap,
             DYNAMIC_TYPE_TMP_BUFFER);
+    #endif
         if (tmpBuf == NULL) {
             WOLFSSL_ERROR_MSG("Extending DER buffer failed");
             ret = 0; /* der buffer is free'd at the end of the function */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -24807,8 +24807,18 @@ int wolfSSL_BUF_MEM_grow_ex(WOLFSSL_BUF_MEM* buf, size_t len,
     /* expand size, to handle growth */
     mx = (len_int + 3) / 3 * 4;
 
+#ifdef WOLFSSL_NO_REALLOC
+    tmp = (char*)XMALLOC(mx, NULL, DYNAMIC_TYPE_OPENSSL);
+    if (tmp != NULL) {
+       XMEMCPY(tmp, buf->data, len_int);
+       XFREE(buf->data, NULL, DYNAMIC_TYPE_OPENSSL);
+       buf->data = NULL;
+    }
+#else
     /* use realloc */
     tmp = (char*)XREALLOC(buf->data, mx, NULL, DYNAMIC_TYPE_OPENSSL);
+#endif
+
     if (tmp == NULL) {
         return 0; /* ERR_R_MALLOC_FAILURE; */
     }
@@ -24850,7 +24860,18 @@ int wolfSSL_BUF_MEM_resize(WOLFSSL_BUF_MEM* buf, size_t len)
     mx = ((int)len + 3) / 3 * 4;
 
     /* We want to shrink the internal buffer */
+#ifdef WOLFSSL_NO_REALLOC
+    tmp = (char*)XMALLOC(mx, NULL, DYNAMIC_TYPE_OPENSSL);
+    if (tmp != NULL )
+    {
+        XMEMCPY(tmp, buf->data, len);
+        XFREE(buf->data,NULL,DYNAMIC_TYPE_OPENSSL);
+        buf->data = NULL;
+    }
+#else
     tmp = (char*)XREALLOC(buf->data, mx, NULL, DYNAMIC_TYPE_OPENSSL);
+#endif
+
     if (tmp == NULL)
         return 0;
 

--- a/src/ssl_asn1.c
+++ b/src/ssl_asn1.c
@@ -797,9 +797,18 @@ static int wolfssl_asn1_bit_string_grow(WOLFSSL_ASN1_BIT_STRING* bitStr,
     int ret = 1;
     byte* tmp;
 
+#ifdef WOLFSSL_NO_REALLOC
+    tmp = (byte*)XMALLOC((size_t)len, NULL, DYNAMIC_TYPE_OPENSSL);
+    if (tmp != NULL) {
+       XMEMCPY(tmp, bitStr->data, bitStr->length);
+       XFREE(bitStr->data, NULL, DYNAMIC_TYPE_OPENSSL);
+       bitStr->data = NULL;
+    }
+#else
     /* Realloc to length required. */
     tmp = (byte*)XREALLOC(bitStr->data, (size_t)len, NULL,
         DYNAMIC_TYPE_OPENSSL);
+#endif
     if (tmp == NULL) {
         ret = 0;
     }

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -2422,6 +2422,10 @@ int wolfSSL_HwPkMutexUnLock(void)
 
     int wc_InitMutex(wolfSSL_Mutex* m)
     {
+    #if (defined(HAVE_FIPS) && FIPS_VERSION_EQ(5,2))
+        if (wolfCrypt_GetMode_fips() == FIPS_MODE_INIT)
+            return 0;
+    #endif
         if (_mutex_init(m, NULL) == MQX_EOK)
             return 0;
         else
@@ -2438,6 +2442,13 @@ int wolfSSL_HwPkMutexUnLock(void)
 
     int wc_LockMutex(wolfSSL_Mutex* m)
     {
+    #if (defined(HAVE_FIPS) && FIPS_VERSION_EQ(5,2))
+        if (m->VALID != MUTEX_VALID) {
+            if (_mutex_init(m, NULL) != MQX_EOK)
+                return BAD_MUTEX_E;
+        }
+    #endif
+
         if (_mutex_lock(m) == MQX_EOK)
             return 0;
         else
@@ -2446,6 +2457,13 @@ int wolfSSL_HwPkMutexUnLock(void)
 
     int wc_UnLockMutex(wolfSSL_Mutex* m)
     {
+    #if (defined(HAVE_FIPS) && FIPS_VERSION_EQ(5,2))
+        if (m->VALID != MUTEX_VALID) {
+            if (_mutex_init(m, NULL) != MQX_EOK)
+                return BAD_MUTEX_E;
+        }
+    #endif
+
         if (_mutex_unlock(m) == MQX_EOK)
             return 0;
         else
@@ -2710,7 +2728,9 @@ int wolfSSL_HwPkMutexUnLock(void)
 
 #elif defined(WOLFSSL_CMSIS_RTOS)
 
-    #define CMSIS_NMUTEX 10
+    #ifndef CMSIS_NMUTEX
+        #define CMSIS_NMUTEX 10
+    #endif
     osMutexDef(wolfSSL_mt0);  osMutexDef(wolfSSL_mt1);  osMutexDef(wolfSSL_mt2);
     osMutexDef(wolfSSL_mt3);  osMutexDef(wolfSSL_mt4);  osMutexDef(wolfSSL_mt5);
     osMutexDef(wolfSSL_mt6);  osMutexDef(wolfSSL_mt7);  osMutexDef(wolfSSL_mt8);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -76,7 +76,7 @@
 #endif
 
 #ifdef OPENSSL_ALL
-    #ifndef WOLFSSL_HAVE_BIO_ADDR
+    #if !defined(WOLFSSL_HAVE_BIO_ADDR) && !defined(WOLFSSL_NO_SOCK)
     #define WOLFSSL_HAVE_BIO_ADDR
     #endif
     #if defined(WOLFSSL_DTLS) && !defined(WOLFSSL_DTLS_MTU)


### PR DESCRIPTION
# Description

- Fix OPENSSL_ALL build with WOLFSSL_NO_REALLOC
- Fix for multi-threaded issue on FIPS MQX. InitMutex is called in `fipsEntry()` before the OS is initialized, causing the module to go into an error state.
- Make the `CMSIS_NMUTEX` macro overridable so that applications that make heavy use of threads can use a higher number

Fixes zd#18687

# Testing

Tested on Customer OS & HW

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
