### PR TITLE
20250120-lean-fips

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5951,7 +5951,7 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SHAKE128"
     if test "$ENABLED_SHA3" = "no"
     then
-        AC_MSG_ERROR([Must have SHA-3 enabled: --enable-sha3])
+        AC_MSG_ERROR([shake128 requires SHA-3: --enable-sha3])
     fi
 else
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_NO_SHAKE128"
@@ -5967,7 +5967,7 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SHAKE256"
     if test "$ENABLED_SHA3" = "no"
     then
-        AC_MSG_ERROR([Must have SHA-3 enabled: --enable-sha3])
+        AC_MSG_ERROR([shake256 requires SHA-3: --enable-sha3])
     fi
 else
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_NO_SHAKE256"

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -244,6 +244,38 @@ static int wolfssl_init(void)
         }
         return -ECANCELED;
     }
+#endif /* HAVE_FIPS */
+
+#ifdef WC_RNG_SEED_CB
+    ret = wc_SetSeed_Cb(wc_GenerateSeed);
+    if (ret < 0) {
+        pr_err("wc_SetSeed_Cb() failed with return code %d.\n", ret);
+        (void)libwolfssl_cleanup();
+        msleep(10);
+        return -ECANCELED;
+    }
+#endif
+
+#ifdef WOLFCRYPT_ONLY
+    ret = wolfCrypt_Init();
+    if (ret != 0) {
+        pr_err("wolfCrypt_Init() failed: %s\n", wc_GetErrorString(ret));
+        return -ECANCELED;
+    }
+#else
+    ret = wolfSSL_Init();
+    if (ret != WOLFSSL_SUCCESS) {
+        pr_err("wolfSSL_Init() failed: %s\n", wc_GetErrorString(ret));
+        return -ECANCELED;
+    }
+#endif
+
+#ifdef HAVE_FIPS
+    ret = wc_RunAllCast_fips();
+    if (ret != 0) {
+        pr_err("wc_RunAllCast_fips() failed with return value %d\n", ret);
+        return -ECANCELED;
+    }
 
     pr_info("FIPS 140-3 wolfCrypt-fips v%d.%d.%d%s%s startup "
             "self-test succeeded.\n",
@@ -270,32 +302,7 @@ static int wolfssl_init(void)
             ""
 #endif
         );
-
 #endif /* HAVE_FIPS */
-
-#ifdef WC_RNG_SEED_CB
-    ret = wc_SetSeed_Cb(wc_GenerateSeed);
-    if (ret < 0) {
-        pr_err("wc_SetSeed_Cb() failed with return code %d.\n", ret);
-        (void)libwolfssl_cleanup();
-        msleep(10);
-        return -ECANCELED;
-    }
-#endif
-
-#ifdef WOLFCRYPT_ONLY
-    ret = wolfCrypt_Init();
-    if (ret != 0) {
-        pr_err("wolfCrypt_Init() failed: %s\n", wc_GetErrorString(ret));
-        return -ECANCELED;
-    }
-#else
-    ret = wolfSSL_Init();
-    if (ret != WOLFSSL_SUCCESS) {
-        pr_err("wolfSSL_Init() failed: %s\n", wc_GetErrorString(ret));
-        return -ECANCELED;
-    }
-#endif
 
 #ifndef NO_CRYPT_TEST
     ret = wolfcrypt_test(NULL);

--- a/src/internal.c
+++ b/src/internal.c
@@ -25686,7 +25686,7 @@ int SendData(WOLFSSL* ssl, const void* data, int sz)
 }
 
 /* process input data */
-int ReceiveData(WOLFSSL* ssl, byte* output, int sz, int peek)
+int ReceiveData(WOLFSSL* ssl, byte* output, size_t sz, int peek)
 {
     int size;
     int error = ssl->error;
@@ -25842,7 +25842,7 @@ startScr:
 #endif
     }
 
-    size = (int)min((word32)sz, ssl->buffers.clearOutputBuffer.length);
+    size = (int)min_size_t(sz, (size_t)ssl->buffers.clearOutputBuffer.length);
 
     XMEMCPY(output, ssl->buffers.clearOutputBuffer.buffer, size);
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -25300,15 +25300,20 @@ static int ssl_in_handshake(WOLFSSL *ssl, int send)
     return 0;
 }
 
-int SendData(WOLFSSL* ssl, const void* data, int sz)
+int SendData(WOLFSSL* ssl, const void* data, size_t sz)
 {
-    int sent = 0,  /* plainText size */
-        sendSz,
+    word32 sent = 0; /* plainText size */
+    int sendSz,
         ret;
 #if defined(WOLFSSL_EARLY_DATA) && defined(WOLFSSL_EARLY_DATA_GROUP)
     int groupMsgs = 0;
 #endif
     int error = ssl->error;
+
+    if (sz > INT_MAX) {
+        WOLFSSL_MSG("SendData sz overflow");
+        return WOLFSSL_FATAL_ERROR;
+    }
 
     if (error == WC_NO_ERR_TRACE(WANT_WRITE)
     #ifdef WOLFSSL_ASYNC_CRYPT
@@ -25414,7 +25419,7 @@ int SendData(WOLFSSL* ssl, const void* data, int sz)
             sent = ssl->buffers.prevSent + ssl->buffers.plainSz;
             WOLFSSL_MSG("sent write buffered data");
 
-            if (sent > sz) {
+            if (sent > (word32)sz) {
                 WOLFSSL_MSG("error: write() after WANT_WRITE with short size");
                 return (ssl->error = BAD_FUNC_ARG);
             }
@@ -25503,19 +25508,19 @@ int SendData(WOLFSSL* ssl, const void* data, int sz)
 
 #ifdef WOLFSSL_DTLS
         if (ssl->options.dtls) {
-            buffSz = wolfSSL_GetMaxFragSize(ssl, sz - sent);
+            buffSz = wolfSSL_GetMaxFragSize(ssl, (word32)sz - sent);
         }
         else
 #endif
         {
-            buffSz = wolfSSL_GetMaxFragSize(ssl, sz - sent);
+            buffSz = wolfSSL_GetMaxFragSize(ssl, (word32)sz - sent);
 
         }
 
-        if (sent == sz) break;
+        if (sent == (word32)sz) break;
 
 #if defined(WOLFSSL_DTLS) && !defined(WOLFSSL_NO_DTLS_SIZE_CHECK)
-        if (ssl->options.dtls && (buffSz < sz - sent)) {
+        if (ssl->options.dtls && ((size_t)buffSz < (word32)sz - sent)) {
             error = DTLS_SIZE_ERROR;
             ssl->error = error;
             WOLFSSL_ERROR(error);
@@ -25692,6 +25697,11 @@ int ReceiveData(WOLFSSL* ssl, byte* output, size_t sz, int peek)
     int error = ssl->error;
 
     WOLFSSL_ENTER("ReceiveData");
+
+    if (sz > INT_MAX) {
+        WOLFSSL_MSG("ReceiveData sz overflow");
+        return WOLFSSL_FATAL_ERROR;
+    }
 
     /* reset error state */
     if (error == WC_NO_ERR_TRACE(WANT_READ) ||

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3044,7 +3044,7 @@ int wolfSSL_write(WOLFSSL* ssl, const void* data, int sz)
     if (sz < 0)
         return BAD_FUNC_ARG;
 
-    return wolfSSL_write_internal(ssl, data, sz);
+    return wolfSSL_write_internal(ssl, data, (size_t)sz);
 }
 
 int wolfSSL_inject(WOLFSSL* ssl, const void* data, int sz)
@@ -11328,7 +11328,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         #endif
             byte* myBuffer  = staticBuffer;
             int   dynamic   = 0;
-            int   sending   = 0;
+            word32 sending   = 0;
             int   idx       = 0;
             int   i;
             int   ret;
@@ -11336,11 +11336,11 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             WOLFSSL_ENTER("wolfSSL_writev");
 
             for (i = 0; i < iovcnt; i++)
-                sending += (int)iov[i].iov_len;
+                sending += iov[i].iov_len;
 
-            if (sending > (int)sizeof(staticBuffer)) {
-                myBuffer = (byte*)XMALLOC((size_t)sending, ssl->heap,
-                                                           DYNAMIC_TYPE_WRITEV);
+            if (sending > sizeof(staticBuffer)) {
+                myBuffer = (byte*)XMALLOC(sending, ssl->heap,
+                                          DYNAMIC_TYPE_WRITEV);
                 if (!myBuffer)
                     return MEMORY_ERROR;
 
@@ -11357,7 +11357,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             */
             PRAGMA_GCC_DIAG_PUSH
             PRAGMA_GCC("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
-            ret = wolfSSL_write(ssl, myBuffer, sending);
+            ret = wolfSSL_write_internal(ssl, myBuffer, sending);
             PRAGMA_GCC_DIAG_POP
 
             if (dynamic)

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -14887,7 +14887,7 @@ int wolfSSL_read_early_data(WOLFSSL* ssl, void* data, int sz, int* outSz)
             return WOLFSSL_FATAL_ERROR;
     }
     if (ssl->options.handShakeState == SERVER_FINISHED_COMPLETE) {
-        ret = ReceiveData(ssl, (byte*)data, sz, FALSE);
+        ret = ReceiveData(ssl, (byte*)data, (size_t)sz, FALSE);
         if (ret > 0)
             *outSz = ret;
         if (ssl->error == WC_NO_ERR_TRACE(ZERO_RETURN)) {

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -586,7 +586,7 @@
 #undef LIBCALL_CHECK_RET
 #if defined(NO_STDIO_FILESYSTEM) || defined(NO_ERROR_STRINGS) || \
     defined(NO_MAIN_DRIVER) || defined(BENCH_EMBEDDED)
-#define LIBCALL_CHECK_RET(...) __VA_ARGS__
+#define LIBCALL_CHECK_RET(...) (void)(__VA_ARGS__)
 #else
 #define LIBCALL_CHECK_RET(...) do {                           \
         int _libcall_ret = (__VA_ARGS__);                     \

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -6886,7 +6886,7 @@ void GHASH(Gcm* gcm, const byte* a, word32 aSz, const byte* c,
 #define GHASH_ONE_BLOCK_SW(aes, block)                  \
     do {                                                \
         xorbuf(AES_TAG(aes), block, WC_AES_BLOCK_SIZE); \
-        GMULT(AES_TAG(aes), aes->gcm.H);                \
+        GMULT(AES_TAG(aes), (aes)->gcm.H);              \
     }                                                   \
     while (0)
 #endif /* WOLFSSL_AESGCM_STREAM */

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -10986,7 +10986,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
         #if defined(WOLFSSL_SHA3) && defined(WOLFSSL_SHAKE256)
             case WC_HASH_TYPE_SHAKE256:
         #endif
-                return EVP_MD_FLAG_XOF;
+                return WOLFSSL_EVP_MD_FLAG_XOF;
             default:
                 return 0;
         }
@@ -11062,7 +11062,7 @@ int wolfSSL_EVP_MD_block_size(const WOLFSSL_EVP_MD* type)
 #endif
 #ifndef NO_MD4
     if (XSTRCMP(type, WC_SN_md4) == 0) {
-        return MD4_BLOCK_SIZE;
+        return WC_MD4_BLOCK_SIZE;
     } else
 #endif
 #ifndef NO_MD5
@@ -11137,7 +11137,7 @@ int wolfSSL_EVP_MD_size(const WOLFSSL_EVP_MD* type)
 #endif
 #ifndef NO_MD4
     if (XSTRCMP(type, WC_SN_md4) == 0) {
-        return MD4_DIGEST_SIZE;
+        return WC_MD4_DIGEST_SIZE;
     } else
 #endif
 #ifndef NO_MD5

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -535,7 +535,7 @@ WC_MISC_STATIC WC_INLINE int ConstantCompare(const byte* a, const byte* b,
     }
 #endif /* !WOLFSSL_HAVE_MAX */
 
-    WC_MISC_STATIC WC_INLINE size_t max_size_t_(size_t a, size_t b)
+    WC_MISC_STATIC WC_INLINE size_t max_size_t(size_t a, size_t b)
     {
         return a > b ? a : b;
     }

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -519,6 +519,11 @@ WC_MISC_STATIC WC_INLINE int ConstantCompare(const byte* a, const byte* b,
     }
 #endif /* !WOLFSSL_HAVE_MIN */
 
+    WC_MISC_STATIC WC_INLINE size_t min_size_t(size_t a, size_t b)
+    {
+        return a > b ? b : a;
+    }
+
 #ifndef WOLFSSL_HAVE_MAX
     #define WOLFSSL_HAVE_MAX
     #if defined(HAVE_FIPS) && !defined(max) /* so ifdef check passes */
@@ -529,6 +534,11 @@ WC_MISC_STATIC WC_INLINE int ConstantCompare(const byte* a, const byte* b,
         return a > b ? a : b;
     }
 #endif /* !WOLFSSL_HAVE_MAX */
+
+    WC_MISC_STATIC WC_INLINE size_t max_size_t_(size_t a, size_t b)
+    {
+        return a > b ? a : b;
+    }
 
 #ifndef WOLFSSL_NO_INT_ENCODE
 /* converts a 32 bit integer to 24 bit */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -6521,7 +6521,7 @@ WOLFSSL_LOCAL int SendHelloRequest(WOLFSSL* ssl);
 WOLFSSL_LOCAL int SendCertificateStatus(WOLFSSL* ssl);
 WOLFSSL_LOCAL int SendServerKeyExchange(WOLFSSL* ssl);
 WOLFSSL_LOCAL int SendBuffered(WOLFSSL* ssl);
-WOLFSSL_LOCAL int ReceiveData(WOLFSSL* ssl, byte* output, int sz, int peek);
+WOLFSSL_LOCAL int ReceiveData(WOLFSSL* ssl, byte* output, size_t sz, int peek);
 WOLFSSL_LOCAL int SendFinished(WOLFSSL* ssl);
 WOLFSSL_LOCAL int RetrySendAlert(WOLFSSL* ssl);
 WOLFSSL_LOCAL int SendAlert(WOLFSSL* ssl, int severity, int type);

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4801,9 +4801,9 @@ typedef struct Buffers {
     buffer          clearOutputBuffer;
     buffer          sig;                   /* signature data */
     buffer          digest;                /* digest data */
-    int             prevSent;              /* previous plain text bytes sent
+    word32          prevSent;              /* previous plain text bytes sent
                                               when got WANT_WRITE            */
-    int             plainSz;               /* plain text bytes in buffer to send
+    word32          plainSz;               /* plain text bytes in buffer to send
                                               when got WANT_WRITE            */
     byte            weOwnCert;             /* SSL own cert flag */
     byte            weOwnCertChain;        /* SSL own cert chain flag */
@@ -6500,7 +6500,7 @@ WOLFSSL_LOCAL int DoClientTicket_ex(const WOLFSSL* ssl, PreSharedKey* psk,
 
 WOLFSSL_LOCAL int DoClientTicket(WOLFSSL* ssl, const byte* input, word32 len);
 #endif /* HAVE_SESSION_TICKET */
-WOLFSSL_LOCAL int SendData(WOLFSSL* ssl, const void* data, int sz);
+WOLFSSL_LOCAL int SendData(WOLFSSL* ssl, const void* data, size_t sz);
 #ifdef WOLFSSL_THREADED_CRYPT
 WOLFSSL_LOCAL int SendAsyncData(WOLFSSL* ssl);
 #endif

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -1150,6 +1150,7 @@ WOLFSSL_API int wolfSSL_EVP_SignInit_ex(WOLFSSL_EVP_MD_CTX* ctx,
 #define WOLFSSL_EVP_CTRL_CCM_SET_TAG           WOLFSSL_EVP_CTRL_AEAD_SET_TAG
 #define WOLFSSL_EVP_CTRL_CCM_SET_L             0x14
 #define WOLFSSL_EVP_CTRL_CCM_SET_MSGLEN        0x15
+#define WOLFSSL_EVP_MD_FLAG_XOF 0x2
 
 #define WOLFSSL_NO_PADDING_BLOCK_SIZE      1
 
@@ -1262,7 +1263,7 @@ WOLFSSL_API int wolfSSL_EVP_SignInit_ex(WOLFSSL_EVP_MD_CTX* ctx,
 #define EVP_MD_CTX_set_flags(ctx, flags) WC_DO_NOTHING
 #endif
 
-#define EVP_MD_FLAG_XOF 0x2
+#define EVP_MD_FLAG_XOF WOLFSSL_EVP_MD_FLAG_XOF
 
 #define EVP_Digest             wolfSSL_EVP_Digest
 #define EVP_DigestInit         wolfSSL_EVP_DigestInit

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1368,7 +1368,7 @@ WOLFSSL_ABI WOLFSSL_API int  wolfSSL_write(
 WOLFSSL_API int wolfSSL_write_ex(WOLFSSL* ssl, const void* data, int sz,
     size_t* wr);
 WOLFSSL_ABI WOLFSSL_API int  wolfSSL_read(WOLFSSL* ssl, void* data, int sz);
-WOLFSSL_API int wolfSSL_read_ex(WOLFSSL* ssl, void* data, int sz, size_t* rd);
+WOLFSSL_API int wolfSSL_read_ex(WOLFSSL* ssl, void* data, size_t sz, size_t* rd);
 WOLFSSL_API int  wolfSSL_peek(WOLFSSL* ssl, void* data, int sz);
 WOLFSSL_ABI WOLFSSL_API int  wolfSSL_accept(WOLFSSL* ssl);
 WOLFSSL_API int wolfSSL_inject(WOLFSSL* ssl, const void* data, int sz);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -604,7 +604,7 @@ struct WOLFSSL_EVP_PKEY {
 
 typedef struct WOLFSSL_BUFFER_INFO {
     unsigned char* buffer;
-    unsigned int length;
+    word32 length;
 } WOLFSSL_BUFFER_INFO;
 
 typedef struct WOLFSSL_BUF_MEM {
@@ -1365,7 +1365,7 @@ WOLFSSL_API int wolfSSL_get_wfd(const WOLFSSL* ssl);
 WOLFSSL_ABI WOLFSSL_API int  wolfSSL_connect(WOLFSSL* ssl);
 WOLFSSL_ABI WOLFSSL_API int  wolfSSL_write(
     WOLFSSL* ssl, const void* data, int sz);
-WOLFSSL_API int wolfSSL_write_ex(WOLFSSL* ssl, const void* data, int sz,
+WOLFSSL_API int wolfSSL_write_ex(WOLFSSL* ssl, const void* data, size_t sz,
     size_t* wr);
 WOLFSSL_ABI WOLFSSL_API int  wolfSSL_read(WOLFSSL* ssl, void* data, int sz);
 WOLFSSL_API int wolfSSL_read_ex(WOLFSSL* ssl, void* data, size_t sz, size_t* rd);

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -326,7 +326,7 @@ wc_static_assert((int)MIN_CODE_E <= (int)WC_SPAN2_MIN_CODE_E);
 #ifdef NO_ERROR_STRINGS
     #define wc_GetErrorString(error) "no support for error strings built in"
     #define wc_ErrorString(err, buf) \
-        (void)err; XSTRNCPY((buf), wc_GetErrorString((err)), \
+        (void)(err); XSTRNCPY((buf), wc_GetErrorString(err), \
         WOLFSSL_MAX_ERROR_SZ);
 
 #else

--- a/wolfssl/wolfcrypt/fips_test.h
+++ b/wolfssl/wolfcrypt/fips_test.h
@@ -72,7 +72,9 @@ enum FipsCastId {
     FIPS_CAST_ED25519           = 16,
     FIPS_CAST_ED448             = 17,
     FIPS_CAST_PBKDF2            = 18,
-    FIPS_CAST_COUNT             = 19
+    /* v7.0.0 + */
+    FIPS_CAST_AES_ECB           = 19,
+    FIPS_CAST_COUNT             = 20
 };
 
 enum FipsCastStateId {

--- a/wolfssl/wolfcrypt/misc.h
+++ b/wolfssl/wolfcrypt/misc.h
@@ -107,6 +107,7 @@ void   ByteReverseWords64(word64* out, const word64* in, word32 byteCount);
     #endif
     WOLFSSL_LOCAL word32 min(word32 a, word32 b);
 #endif
+WOLFSSL_LOCAL size_t min_size_t(size_t a, size_t b);
 
 #ifndef WOLFSSL_HAVE_MAX
     #if defined(HAVE_FIPS) && !defined(max) /* so ifdef check passes */
@@ -114,6 +115,7 @@ void   ByteReverseWords64(word64* out, const word64* in, word32 byteCount);
     #endif
     WOLFSSL_LOCAL word32 max(word32 a, word32 b);
 #endif /* WOLFSSL_HAVE_MAX */
+WOLFSSL_LOCAL size_t max_size_t(size_t a, size_t b);
 
 
 void c32to24(word32 in, word24 out);

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3599,7 +3599,10 @@ extern void uITRON4_free(void *p) ;
         #define WOLFSSL_TEST_SUBROUTINE static
     #endif
     #undef HAVE_PTHREAD
+    /* linuxkm uses linux/string.h, included by linuxkm_wc_port.h. */
     #undef HAVE_STRINGS_H
+    /* linuxkm uses linux/limits.h, included by linuxkm_wc_port.h. */
+    #undef HAVE_LIMITS_H
     #undef HAVE_ERRNO_H
     #undef HAVE_THREAD_LS
     #undef HAVE_ATEXIT

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -212,10 +212,10 @@ decouple library dependencies with standard string, memory and so on.
 
     /* try to set SIZEOF_LONG or SIZEOF_LONG_LONG if user didn't */
     #if defined(_WIN32) || defined(HAVE_LIMITS_H)
+        #include <limits.h>
         /* make sure both SIZEOF_LONG_LONG and SIZEOF_LONG are set,
          * otherwise causes issues with CTC_SETTINGS */
         #if !defined(SIZEOF_LONG_LONG) || !defined(SIZEOF_LONG)
-            #include <limits.h>
             #if !defined(SIZEOF_LONG) && defined(ULONG_MAX) && \
                     (ULONG_MAX == 0xffffffffUL)
                 #define SIZEOF_LONG 4


### PR DESCRIPTION
`wolfssl/wolfcrypt/types.h`: tweak for buildability in no-PK FIPS, re `limits.h`.

fixes for `clang-tidy` complaints with `NO_ERROR_STRINGS`.

`configure.ac`: tweaks for clarity

see https://github.com/wolfSSL/fips/pull/320
