### PR TITLE
Fix for WOLFSSL_NO_REALLOC build crash

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -2778,9 +2778,11 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
         #ifdef WOLFSSL_NO_REALLOC
                 tmp = b->ip;
                 b->ip = (char*)XMALLOC(newLen+1, b->heap, DYNAMIC_TYPE_OPENSSL);
-                XMEMCPY(b->ip, tmp, newLen);
-                XFREE(tmp, b->heap, DYNAMIC_TYPE_OPENSSL);
-                tmp = NULL;
+                if (b->ip != NULL && tmp != NULL) {
+                    XMEMCPY(b->ip, tmp, newLen);
+                    XFREE(tmp, b->heap, DYNAMIC_TYPE_OPENSSL);
+                    tmp = NULL;
+            }
         #else
                 b->ip = (char*)XREALLOC(b->ip, newLen + 1, b->heap,
                     DYNAMIC_TYPE_OPENSSL);

--- a/src/conf.c
+++ b/src/conf.c
@@ -776,7 +776,7 @@ static char* expandValue(WOLFSSL_CONF *conf, const char* section,
                 #ifdef WOLFSSL_NO_REALLOC
                     newRet = (char*)XMALLOC(strLen + 1, NULL,
                             DYNAMIC_TYPE_OPENSSL);
-                    if (newRet != NULL) {
+                    if (newRet != NULL && ret != NULL) {
                        XMEMCPY(newRet, ret, (strLen - valueLen) + 1);
                        XFREE(ret, NULL, DYNAMIC_TYPE_OPENSSL);
                        ret = NULL;

--- a/src/internal.c
+++ b/src/internal.c
@@ -39407,7 +39407,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             #ifdef WOLFSSL_NO_REALLOC
                 tmp = (byte*)XMALLOC(sizeof(InternalTicket), ssl->heap,
                         DYNAMIC_TYPE_TLSX);
-                if (tmp != NULL)
+                if (tmp != NULL && psk->identity != NULL)
                 {
                    XMEMCPY(tmp, psk->identity, psk->identityLen);
                    XFREE(psk->identity, ssl->heap, DYNAMIC_TYPE_TLSX);

--- a/src/pk.c
+++ b/src/pk.c
@@ -521,7 +521,7 @@ static int der_to_enc_pem_alloc(unsigned char* der, int derSz,
     #ifdef WOLFSSL_NO_REALLOC
         tmpBuf = (byte*)XMALLOC((size_t)(derSz + blockSz), heap,
             DYNAMIC_TYPE_TMP_BUFFER);
-        if (tmpBuf != NULL)
+        if (tmpBuf != NULL && der != NULL)
         {
                 XMEMCPY(tmpBuf, der, (size_t)(derSz));
                 XFREE(der, heap, DYNAMIC_TYPE_TMP_BUFFER);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -24809,7 +24809,7 @@ int wolfSSL_BUF_MEM_grow_ex(WOLFSSL_BUF_MEM* buf, size_t len,
 
 #ifdef WOLFSSL_NO_REALLOC
     tmp = (char*)XMALLOC(mx, NULL, DYNAMIC_TYPE_OPENSSL);
-    if (tmp != NULL) {
+    if (tmp != NULL && buf->data != NULL) {
        XMEMCPY(tmp, buf->data, len_int);
        XFREE(buf->data, NULL, DYNAMIC_TYPE_OPENSSL);
        buf->data = NULL;
@@ -24862,7 +24862,7 @@ int wolfSSL_BUF_MEM_resize(WOLFSSL_BUF_MEM* buf, size_t len)
     /* We want to shrink the internal buffer */
 #ifdef WOLFSSL_NO_REALLOC
     tmp = (char*)XMALLOC(mx, NULL, DYNAMIC_TYPE_OPENSSL);
-    if (tmp != NULL )
+    if (tmp != NULL && buf->data != NULL)
     {
         XMEMCPY(tmp, buf->data, len);
         XFREE(buf->data,NULL,DYNAMIC_TYPE_OPENSSL);

--- a/src/ssl_asn1.c
+++ b/src/ssl_asn1.c
@@ -799,7 +799,7 @@ static int wolfssl_asn1_bit_string_grow(WOLFSSL_ASN1_BIT_STRING* bitStr,
 
 #ifdef WOLFSSL_NO_REALLOC
     tmp = (byte*)XMALLOC((size_t)len, NULL, DYNAMIC_TYPE_OPENSSL);
-    if (tmp != NULL) {
+    if (tmp != NULL && bitStr->data != NULL) {
        XMEMCPY(tmp, bitStr->data, bitStr->length);
        XFREE(bitStr->data, NULL, DYNAMIC_TYPE_OPENSSL);
        bitStr->data = NULL;


### PR DESCRIPTION
# Description

Fix for `make check` crash introduced in https://github.com/wolfSSL/wolfssl/pull/8369



# Testing

./configure --enable-all CFLAGS=-DWOLFSSL_NO_REALLOC && make check

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
