### PR TITLE
Fix warning about ESP_IDF_VERSION_MAJOR not being defined when defining FREERTOS.

### DIFF
--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -284,7 +284,7 @@
 #else /* MULTI_THREADED */
     /* FREERTOS comes first to enable use of FreeRTOS Windows simulator only */
     #if defined(FREERTOS)
-        #if ESP_IDF_VERSION_MAJOR >= 4
+        #if defined(ESP_IDF_VERSION_MAJOR) && (ESP_IDF_VERSION_MAJOR >= 4)
             typedef SemaphoreHandle_t wolfSSL_Mutex;
         #else
             typedef xSemaphoreHandle wolfSSL_Mutex;


### PR DESCRIPTION
# Description

Fixes zd# 19270

# Testing

Customer confirmed fix

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
