### PR TITLE
Fix for QUIC test `test_provide_quic_data`

### DIFF
--- a/tests/quic.c
+++ b/tests/quic.c
@@ -274,6 +274,8 @@ static int test_provide_quic_data(void) {
     size_t len;
     int ret = 0;
 
+    XMEMSET(lbuffer, 0, sizeof(lbuffer));
+
     AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
     AssertTrue(wolfSSL_CTX_set_quic_method(ctx, &dummy_method) == WOLFSSL_SUCCESS);
     /* provide_quic_data() feeds CRYPTO packets inside a QUIC Frame into


### PR DESCRIPTION
# Description

Fix for QUIC test introduced in PR #8358

# Testing

`../testing/git-hooks/wolfssl-multi-test.sh -d quantum-safe-wolfssl-all-fortify-source-asm`

```
[quantum-safe-wolfssl-all-fortify-source-asm] [25 of 39] [69be9aa211]
    configure...   real 0m20.751s  user 0m12.019s  sys 0m11.122s
    build...   real 1m13.383s  user 7m54.023s  sys 0m22.818s
    check...FAIL: scripts/unit.test
   real 0m29.810s  user 0m26.107s  sys 0m9.569s

scripts/unit.log tail:
    test_set_quic_method: passed
SSL quic data buffered:
  - 0-104/104 (cap 2048, level=0)
  scratch: -

ERROR - tests/quic.c line 292 failed with:
    expected: provide_data(ssl, wolfssl_encryption_initial, lbuffer+4, len, 0) is true
    result:   provide_data(ssl, wolfssl_encryption_initial, lbuffer+4, len, 0) => FALSE

FAIL scripts/unit.test (exit status: 134)
```


How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
