### PR TITLE
20250125-fips204-fixes

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6965,8 +6965,8 @@ static int check_cert_key_dev(word32 keyOID, byte* privKey, word32 privSz,
             (keyOID == ML_DSA_LEVEL3k) ||
             (keyOID == ML_DSA_LEVEL5k)
             #ifdef WOLFSSL_DILITHIUM_FIPS204_DRAFT
-         || (keyOID == DILITHIUM_LEVEL2k) ||
-         || (keyOID == DILITHIUM_LEVEL3k) ||
+         || (keyOID == DILITHIUM_LEVEL2k)
+         || (keyOID == DILITHIUM_LEVEL3k)
          || (keyOID == DILITHIUM_LEVEL5k)
             #endif /* WOLFSSL_DILITHIUM_FIPS204_DRAFT */
             ) {

--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -1184,8 +1184,8 @@ static int ProcessBufferTryDecode(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
         (*keyFormat == ML_DSA_LEVEL3k) ||
         (*keyFormat == ML_DSA_LEVEL5k)
     #ifdef WOLFSSL_DILITHIUM_FIPS204_DRAFT
-     || (*keyFormat == DILITHIUM_LEVEL2k) ||
-     || (*keyFormat == DILITHIUM_LEVEL3k) ||
+     || (*keyFormat == DILITHIUM_LEVEL2k)
+     || (*keyFormat == DILITHIUM_LEVEL3k)
      || (*keyFormat == DILITHIUM_LEVEL5k)
     #endif
         )) {


### PR DESCRIPTION
`src/ssl.c` and `src/ssl_load.c`: fix syntax flubs in `WOLFSSL_DILITHIUM_FIPS204_DRAFT` paths.

tested with `wolfssl-multi-test.sh ... quantum-safe-wolfssl-all-fips204-clang-tidy`
