### PR TITLE
20250125-aarch64-armasm-AES-ECB-fix

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -11847,7 +11847,13 @@ static WARN_UNUSED_RESULT int _AesEcbEncrypt(
 #elif defined(__aarch64__) && defined(WOLFSSL_ARMASM) && \
       !defined(WOLFSSL_ARMASM_NO_HW_CRYPTO)
     if (aes->use_aes_hw_crypto) {
-        AES_encrypt_AARCH64(in, out, (byte*)aes->key, (int)aes->rounds);
+        word32 i;
+
+        for (i = 0; i < sz; i += WC_AES_BLOCK_SIZE) {
+            AES_encrypt_AARCH64(in, out, (byte*)aes->key, (int)aes->rounds);
+            in += WC_AES_BLOCK_SIZE;
+            out += WC_AES_BLOCK_SIZE;
+        }
     }
     else
 #endif
@@ -11905,7 +11911,13 @@ static WARN_UNUSED_RESULT int _AesEcbDecrypt(
 #elif defined(__aarch64__) && defined(WOLFSSL_ARMASM) && \
       !defined(WOLFSSL_ARMASM_NO_HW_CRYPTO)
     if (aes->use_aes_hw_crypto) {
-        AES_decrypt_AARCH64(in, out, (byte*)aes->key, (int)aes->rounds);
+        word32 i;
+
+        for (i = 0; i < sz; i += WC_AES_BLOCK_SIZE) {
+            AES_decrypt_AARCH64(in, out, (byte*)aes->key, (int)aes->rounds);
+            in += WC_AES_BLOCK_SIZE;
+            out += WC_AES_BLOCK_SIZE;
+        }
     }
     else
 #endif


### PR DESCRIPTION
`wolfcrypt/src/aes.c`: in `_AesEcbEncrypt()` and `_AesEcbDecrypt()`, implement missing iteration for `AES_encrypt_AARCH64()` and `AES_decrypt_AARCH64()`.

tested with `wolfssl-multi-test.sh ... check-source-text cross-aarch64-armasm-fips-140-3-dev-all-unittest-sanitizer` using FIPS update at https://github.com/wolfSSL/fips/pull/320
