### PR TITLE
Fix ESP ROM header path for IDF >= 5.4

### DIFF
--- a/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
+++ b/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
@@ -330,7 +330,7 @@ enum {
         #include <driver/periph_ctrl.h>
     #endif
 
-    #if ESP_IDF_VERSION_MAJOR >= 4
+    #if ESP_IDF_VERSION_MAJOR == 4 || (ESP_IDF_VERSION_MAJOR == 5 && ESP_IDF_VERSION_MINOR < 4)
         #include <esp32/rom/ets_sys.h>
     #else
         #include <rom/ets_sys.h>
@@ -375,9 +375,7 @@ enum {
         #include <driver/periph_ctrl.h>
     #endif
 
-    #if ESP_IDF_VERSION_MAJOR >= 4
-        /* #include <esp32/rom/ets_sys.h> */
-    #else
+    #if ESP_IDF_VERSION_MAJOR < 4
         #include <rom/ets_sys.h>
     #endif
 
@@ -411,9 +409,7 @@ enum {
         #include <driver/periph_ctrl.h>
     #endif
 
-    #if ESP_IDF_VERSION_MAJOR >= 4
-    /* #include <esp32/rom/ets_sys.h> */
-    #else
+    #if ESP_IDF_VERSION_MAJOR < 4
         #include <rom/ets_sys.h>
     #endif
 
@@ -447,9 +443,7 @@ enum {
         #include <driver/periph_ctrl.h>
     #endif
 
-    #if ESP_IDF_VERSION_MAJOR >= 4
-        /* #include <esp32/rom/ets_sys.h> */
-    #else
+    #if ESP_IDF_VERSION_MAJOR < 4
         #include <rom/ets_sys.h>
     #endif
 
@@ -719,7 +713,9 @@ extern "C"
 */
 
 #ifndef NO_AES
-    #if ESP_IDF_VERSION_MAJOR >= 4
+    #if ESP_IDF_VERSION_MAJOR > 5 || (ESP_IDF_VERSION_MAJOR == 5 && ESP_IDF_VERSION_MINOR >= 4)
+        #include "rom/aes.h"
+    #elif ESP_IDF_VERSION_MAJOR >= 4
         #include "esp32/rom/aes.h"
     #elif defined(CONFIG_IDF_TARGET_ESP8266)
         /* no hardware includes for ESP8266*/
@@ -780,7 +776,14 @@ extern "C"
 
     #define SHA_CTX ETS_SHAContext
 
-    #if ESP_IDF_VERSION_MAJOR >= 4
+    #if ESP_IDF_VERSION_MAJOR > 5 || (ESP_IDF_VERSION_MAJOR == 5 && ESP_IDF_VERSION_MINOR >= 4)
+        #include "rom/sha.h"
+        #if defined(CONFIG_IDF_TARGET_ESP32)
+            #define WC_ESP_SHA_TYPE enum SHA_TYPE
+        #else
+            #define WC_ESP_SHA_TYPE SHA_TYPE
+        #endif
+    #elif ESP_IDF_VERSION_MAJOR >= 4
         #if defined(CONFIG_IDF_TARGET_ESP32)
             #include "esp32/rom/sha.h"
             #define WC_ESP_SHA_TYPE enum SHA_TYPE

--- a/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
+++ b/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
@@ -716,7 +716,24 @@ extern "C"
     #if ESP_IDF_VERSION_MAJOR > 5 || (ESP_IDF_VERSION_MAJOR == 5 && ESP_IDF_VERSION_MINOR >= 4)
         #include "rom/aes.h"
     #elif ESP_IDF_VERSION_MAJOR >= 4
-        #include "esp32/rom/aes.h"
+        #if defined(CONFIG_IDF_TARGET_ESP32)
+            #include "esp32/rom/aes.h"
+        #elif defined(CONFIG_IDF_TARGET_ESP32C2) || \
+              defined(CONFIG_IDF_TARGET_ESP8684)
+            #include "esp32c2/rom/aes.h"
+        #elif defined(CONFIG_IDF_TARGET_ESP32C3)
+            #include "esp32c3/rom/aes.h"
+        #elif defined(CONFIG_IDF_TARGET_ESP32C6)
+            #include "esp32c6/rom/aes.h"
+        #elif defined(CONFIG_IDF_TARGET_ESP32H2)
+            #include "esp32h2/rom/aes.h"
+        #elif defined(CONFIG_IDF_TARGET_ESP32S2)
+            #include "esp32s2/rom/aes.h"
+        #elif defined(CONFIG_IDF_TARGET_ESP32S3)
+            #include "esp32s3/rom/aes.h"
+        #else
+            #include "rom/aes.h"
+        #endif
     #elif defined(CONFIG_IDF_TARGET_ESP8266)
         /* no hardware includes for ESP8266*/
     #else


### PR DESCRIPTION

# Description

Starting from IDF 5.4 ROM includes should not use the target prefix in the include folder, see
https://docs.espressif.com/projects/esp-idf/en/stable/esp32/migration-guides/release-5.x/5.4/system.html#esp-rom

I also removed commented out rom includes.

This should fix #8266.

# Testing

I tested a build on ESP-IDF 5.4 using the managed version of wolfssl, from here: https://components.espressif.com/components/wolfssl/wolfssl/versions/5.7.4-preview1f
where I manually patched `esp32-crypt.h` with the one in this PR.

It seems that the repo cannot be used directly as an ESP-IDF component, and I could
not find the process to actually build the IDF component as it is released on the registry,
hence the testing is a bit unorthodox. However, I'd be willing to run more tests if someone
can point me to what would be a nominal way to test an ESP build of wolfSSL.

# Checklist

This is a fix for an updated version of an external tool, it didn't seem like any of these
needed updating (but let me know if I missed something):

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation