### PR TITLE
Added neccesary macros when building wolfTPM Zephyr with wolfSSL

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2562,7 +2562,7 @@ extern void uITRON4_free(void *p) ;
     #if !defined(CONFIG_NET_SOCKETS_POSIX_NAMES) && !defined(CONFIG_POSIX_API)
     #define CONFIG_NET_SOCKETS_POSIX_NAMES
     #endif
-#endif
+#endif /* WOLFSSL_ZEPHYR */
 
 #ifdef WOLFSSL_IMX6
     #ifndef SIZEOF_LONG_LONG

--- a/zephyr/user_settings.h
+++ b/zephyr/user_settings.h
@@ -160,6 +160,12 @@ extern "C" {
     #define WOLFSSL_SET_CIPHER_BYTES
 #endif
 
+/* wolfTPM Zephyr */
+#if defined(CONFIG_WOLFTPM)
+    #define WOLF_CRYPTO_CB
+    #define WOLFSSL_AES_CFB
+#endif
+
 /* ------------------------------------------------------------------------- */
 /* Algorithms */
 /* ------------------------------------------------------------------------- */


### PR DESCRIPTION
# Description

wolfTPM Zephyr builds are dependent on wolfSSL so we need to add `WOLF_CRYPTO_CB` and `WOLFSSL_AES_CFB` macros in wolfSSL Zephyr user_settings.h when we are building with wolfTPM. 

https://github.com/wolfSSL/wolfTPM/pull/395 is dependent on these fixes to build. 

# Testing

setup env and run:
```
west update
cd [zephyrproject]
west build -p auto -b qemu_x86 modules/lib/wolftpm/zephyr/samples/wolftpm_wrap_test
west build -p auto -b qemu_x86 modules/lib/wolftpm/zephyr/samples/wolftpm_wrap_caps
```
