### PR TITLE
Correct Arduino comments spelling

### DIFF
--- a/IDE/ARDUINO/Arduino_README_prepend.md
+++ b/IDE/ARDUINO/Arduino_README_prepend.md
@@ -28,7 +28,7 @@ Tips for success:
 - For every source file that uses wolfssl, include `wolfssl/wolfcrypt/settings.h` before any other wolfSSL include, typically via `#include "wolfssl.h"`.
 - See the [wolfSSL docs](https://www.wolfssl.com/documentation/manuals/wolfssl/chapter02.html) for details on build configuration macros.
 
-## wpolfSSL Examples
+## wolfSSL Examples
 
 Additional wolfSSL examples can be found at:
 

--- a/IDE/ARDUINO/sketches/wolfssl_client/wolfssl_client.ino
+++ b/IDE/ARDUINO/sketches/wolfssl_client/wolfssl_client.ino
@@ -87,7 +87,7 @@ Tested with:
 
 /* wolfSSL user_settings.h must be included from settings.h
  * Make all configurations changes in user_settings.h
- * Do not edit wolfSSL `settings.h` or `configh.h` files.
+ * Do not edit wolfSSL `settings.h` or `config.h` files.
  * Do not explicitly include user_settings.h in any source code.
  * Each Arduino sketch that uses wolfSSL must have: #include "wolfssl.h"
  * C/C++ source files can use: #include <wolfssl/wolfcrypt/settings.h>

--- a/IDE/ARDUINO/sketches/wolfssl_server/wolfssl_server.ino
+++ b/IDE/ARDUINO/sketches/wolfssl_server/wolfssl_server.ino
@@ -87,7 +87,7 @@ Tested with:
 
 /* wolfSSL user_settings.h must be included from settings.h
  * Make all configurations changes in user_settings.h
- * Do not edit wolfSSL `settings.h` or `configh.h` files.
+ * Do not edit wolfSSL `settings.h` or `config.h` files.
  * Do not explicitly include user_settings.h in any source code.
  * Each Arduino sketch that uses wolfSSL must have: #include "wolfssl.h"
  * C/C++ source files can use: #include <wolfssl/wolfcrypt/settings.h>

--- a/IDE/ARDUINO/sketches/wolfssl_version/wolfssl_version.ino
+++ b/IDE/ARDUINO/sketches/wolfssl_version/wolfssl_version.ino
@@ -23,7 +23,7 @@
 
  /* wolfSSL user_settings.h must be included from settings.h
   * Make all configurations changes in user_settings.h
-  * Do not edit wolfSSL `settings.h` or `configh.h` files.
+  * Do not edit wolfSSL `settings.h` or `config.h` files.
   * Do not explicitly include user_settings.h in any source code.
   * Each Arduino sketch that uses wolfSSL must have: #include "wolfssl.h"
   * C/C++ source files can use: #include <wolfssl/wolfcrypt/settings.h>

--- a/IDE/ARDUINO/wolfssl.h
+++ b/IDE/ARDUINO/wolfssl.h
@@ -29,7 +29,7 @@
 
 /* wolfSSL user_settings.h must be included from settings.h
  * Make all configurations changes in user_settings.h
- * Do not edit wolfSSL `settings.h` or `configh.h` files.
+ * Do not edit wolfSSL `settings.h` or `config.h` files.
  * Do not explicitly include user_settings.h in any source code.
  * Each Arduino sketch that uses wolfSSL must have: #include "wolfssl.h"
  * C/C++ source files can use: #include <wolfssl/wolfcrypt/settings.h>


### PR DESCRIPTION
# Description

Spelling corrections related to https://github.com/wolfSSL/wolfssl/pull/8381

Fixes zd#

# Testing

no code change.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
