### PR TITLE
20250129-CT-tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2488,6 +2488,7 @@ if(WOLFSSL_EXAMPLES)
     # Build unit tests
     add_executable(unit_test
         tests/api.c
+        tests/api/ascon.c
         tests/hash.c
         tests/srp.c
         tests/suites.c

--- a/src/internal.c
+++ b/src/internal.c
@@ -25852,7 +25852,8 @@ startScr:
 #endif
     }
 
-    size = (int)min_size_t(sz, (size_t)ssl->buffers.clearOutputBuffer.length);
+    size = (sz < (size_t)ssl->buffers.clearOutputBuffer.length) ?
+        (int)sz : (int)ssl->buffers.clearOutputBuffer.length;
 
     XMEMCPY(output, ssl->buffers.clearOutputBuffer.buffer, size);
 

--- a/wolfcrypt/src/coding.c
+++ b/wolfcrypt/src/coding.c
@@ -490,7 +490,7 @@ int Base64_Encode_NoNl(const byte* in, word32 inLen, byte* out, word32* outLen)
 #ifdef WOLFSSL_BASE16
 
 static
-const byte hexDecode[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+const ALIGN64 byte hexDecode[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
                            BAD, BAD, BAD, BAD, BAD, BAD, BAD,
                            10, 11, 12, 13, 14, 15,  /* upper case A-F */
                            BAD, BAD, BAD, BAD, BAD, BAD, BAD, BAD,
@@ -556,6 +556,11 @@ int Base16_Decode(const byte* in, word32 inLen, byte* out, word32* outLen)
     return 0;
 }
 
+static
+const ALIGN64 byte hexEncode[] = { '0', '1', '2', '3', '4', '5', '6', '7',
+                                   '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
+};
+
 int Base16_Encode(const byte* in, word32 inLen, byte* out, word32* outLen)
 {
     word32 outIdx = 0;
@@ -571,15 +576,8 @@ int Base16_Encode(const byte* in, word32 inLen, byte* out, word32* outLen)
         byte hb = in[i] >> 4;
         byte lb = in[i] & 0x0f;
 
-        /* ASCII value */
-        hb = (byte)(hb + '0');
-        if (hb > '9')
-            hb = (byte)(hb + 7U);
-
-        /* ASCII value */
-        lb = (byte)(lb + '0');
-        if (lb>'9')
-            lb = (byte)(lb + 7U);
+        hb = hexEncode[hb];
+        lb = hexEncode[lb];
 
         out[outIdx++] = hb;
         out[outIdx++] = lb;

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -8016,7 +8016,7 @@ int sp_submod(const sp_int* a, const sp_int* b, const sp_int* m, sp_int* r)
 }
 #endif /* WOLFSSL_SP_MATH_ALL */
 
-/* Constant time clamping/
+/* Constant time clamping.
  *
  * @param [in, out] a  SP integer to clamp.
  */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -598,8 +598,10 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  aes192_test(void);
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  aes256_test(void);
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  aesofb_test(void);
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  cmac_test(void);
+#ifdef HAVE_ASCON
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  ascon_hash256_test(void);
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  ascon_aead128_test(void);
+#endif
 #if defined(WOLFSSL_SIPHASH)
 WOLFSSL_TEST_SUBROUTINE wc_test_ret_t  siphash_test(void);
 #endif

--- a/wolfssl/wolfcrypt/misc.h
+++ b/wolfssl/wolfcrypt/misc.h
@@ -107,7 +107,6 @@ void   ByteReverseWords64(word64* out, const word64* in, word32 byteCount);
     #endif
     WOLFSSL_LOCAL word32 min(word32 a, word32 b);
 #endif
-WOLFSSL_LOCAL size_t min_size_t(size_t a, size_t b);
 
 #ifndef WOLFSSL_HAVE_MAX
     #if defined(HAVE_FIPS) && !defined(max) /* so ifdef check passes */
@@ -115,7 +114,6 @@ WOLFSSL_LOCAL size_t min_size_t(size_t a, size_t b);
     #endif
     WOLFSSL_LOCAL word32 max(word32 a, word32 b);
 #endif /* WOLFSSL_HAVE_MAX */
-WOLFSSL_LOCAL size_t max_size_t(size_t a, size_t b);
 
 
 void c32to24(word32 in, word24 out);
@@ -136,6 +134,9 @@ WOLFSSL_LOCAL int CharIsWhiteSpace(char ch);
 WOLFSSL_LOCAL byte ctMaskGT(int a, int b);
 WOLFSSL_LOCAL byte ctMaskGTE(int a, int b);
 WOLFSSL_LOCAL int  ctMaskIntGTE(int a, int b);
+#ifdef WORD64_AVAILABLE
+WOLFSSL_LOCAL word32 ctMaskWord32GTE(word32 a, word32 b);
+#endif
 WOLFSSL_LOCAL byte ctMaskLT(int a, int b);
 WOLFSSL_LOCAL byte ctMaskLTE(int a, int b);
 WOLFSSL_LOCAL byte ctMaskEq(int a, int b);


### PR DESCRIPTION
CT tweaks:

in wolfcrypt/src/coding.c, add ALIGN64 to hexDecode[], and add hexEncode[] for use by Base16_Encode();

in wolfcrypt/src/misc.c and wolfssl/wolfcrypt/misc.h:

move ctMask*() up so that min() and max() can use them, and add ctMaskWord32GTE();

add ALIGN64 to kHexChar[];

add CT implementation of CharIsWhiteSpace();

remove min_size_t() and max_size_t() recently added, but only one user (refactored).

see ZD#19291


also: fixes for gating/tooling around ASCON.


tested with `wolfssl-multi-test.sh ... super-quick-check all-gcc-c99`
