### PR TITLE
20250130-UHAVE_FFDHE_2048

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -99283,8 +99283,18 @@ static int test_dtls_frag_ch(void)
             WOLFSSL_SUCCESS);
     ExpectIntEQ(wolfSSL_UseKeyShare(ssl_c, WOLFSSL_ECC_SECP521R1),
             WOLFSSL_SUCCESS);
+#ifdef HAVE_FFDHE_2048
     ExpectIntEQ(wolfSSL_UseKeyShare(ssl_c, WOLFSSL_FFDHE_2048),
             WOLFSSL_SUCCESS);
+#endif
+#ifdef HAVE_FFDHE_3072
+    ExpectIntEQ(wolfSSL_UseKeyShare(ssl_c, WOLFSSL_FFDHE_3072),
+            WOLFSSL_SUCCESS);
+#endif
+#ifdef HAVE_FFDHE_4096
+    ExpectIntEQ(wolfSSL_UseKeyShare(ssl_c, WOLFSSL_FFDHE_4096),
+            WOLFSSL_SUCCESS);
+#endif
 
     ExpectIntEQ(wolfSSL_dtls13_allow_ch_frag(ssl_s, 1), WOLFSSL_SUCCESS);
 

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -9460,7 +9460,8 @@ void bench_dh(int useDeviceID)
             ret = wc_DhKeyDecode(tmp, &idx, dhKey[i], (word32)bytes);
     #endif
         }
-    #if defined(HAVE_FFDHE_2048) || defined(HAVE_FFDHE_3072)
+    #if defined(HAVE_FFDHE_2048) || defined(HAVE_FFDHE_3072) || \
+        defined(HAVE_FFDHE_4096)
     #ifdef HAVE_PUBLIC_FFDHE
         else if (params != NULL) {
             ret = wc_DhSetKey(dhKey[i], params->p, params->p_len,


### PR DESCRIPTION
`tests/api.c` and `wolfcrypt/benchmark/benchmark.c`: fixes for building with `HAVE_FFDHE_3072` and/or `HAVE_FFDHE_4096` but without `HAVE_FFDHE_2048`.

tested with
```
./configure --enable-all --with-eccminsz=256 --with-max-rsa-bits=8192 CFLAGS='-DRSA_MIN_SIZE=2048 -UHAVE_FFDHE_2048 -DHAVE_FFDHE_3072 -DHAVE_FFDHE_4096 -DHAVE_FFDHE_6144 -DHAVE_FFDHE_8192'
```
and same without DHE 3072:
```
`./configure --enable-all --with-eccminsz=256 --with-max-rsa-bits=8192 CFLAGS='-DRSA_MIN_SIZE=2048 -UHAVE_FFDHE_2048 -UHAVE_FFDHE_3072 -DHAVE_FFDHE_4096 -DHAVE_FFDHE_6144 -DHAVE_FFDHE_8192'`
```
