### PR TITLE
Fix potential memory leak on error in wolfSSL_EVP_SignFinal()

### DIFF
--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -4044,8 +4044,10 @@ int wolfSSL_EVP_SignFinal(WOLFSSL_EVP_MD_CTX *ctx, unsigned char *sigret,
         if (ecdsaSig == NULL)
             return WOLFSSL_FAILURE;
         ret = wolfSSL_i2d_ECDSA_SIG(ecdsaSig, NULL);
-        if (ret <= 0 || ret > (int)*siglen)
+        if (ret <= 0 || ret > (int)*siglen) {
+            wolfSSL_ECDSA_SIG_free(ecdsaSig);
             return WOLFSSL_FAILURE;
+        }
         ret = wolfSSL_i2d_ECDSA_SIG(ecdsaSig, &sigret);
         wolfSSL_ECDSA_SIG_free(ecdsaSig);
         if (ret <= 0 || ret > (int)*siglen)


### PR DESCRIPTION
# Description

`ecdsaSig` is a local variable pointing to new memory, but the error path in `ret <= 0 || ret > (int)*siglen` does not free this. Fix it by adding a wolfSSL_ECDSA_SIG_free() in this path.

Note: this was found by an experimental static analyser I'm developing, so it's possible that I'm missing some details as I'm not very familiar with the code.

# Testing

Tested by hand by hardcoding the error condition to true.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
