### PR TITLE
Fix potential memory leak on error in LoadCRL()

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -1776,6 +1776,10 @@ int LoadCRL(WOLFSSL_CRL* crl, const char* path, int type, int monitor)
             ret = ProcessFile(NULL, name, type, CRL_TYPE, NULL, 0, crl, VERIFY);
             if (ret != WOLFSSL_SUCCESS) {
                 WOLFSSL_MSG("CRL file load failed");
+                wc_ReadDirClose(readCtx);
+#ifdef WOLFSSL_SMALL_STACK
+                XFREE(readCtx, crl->heap, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
                 return ret;
             }
         }


### PR DESCRIPTION
# Description

If ProcessFile() fails, the code does not clean up readCtx. Perform the same cleanup as after the loop to fix this.

Note: this was found by an experimental static analyser I'm developing, so it's possible that I'm missing some details as I'm not very familiar with the code.

# Testing

It appears that this if condition is not hit when running `make test`, unless I miss something. So I didn't know how to test this.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
