### PR TITLE
Clear old ssl->error after retry

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -25676,6 +25676,9 @@ int SendData(WOLFSSL* ssl, const void* data, size_t sz)
             }
             return error;
         }
+        else {
+            ssl->error = 0; /* Clear any previous errors */
+        }
 
         sent += buffSz;
 


### PR DESCRIPTION
# Description

*  the output from SendBuffered() gets saved in a local variable (named error), and this gets stored in ssl->error only when SendBuffered() returns an error. When data transmission is successful, the internal error state of ssl (ssl->error) is not updated.

Fixes zd19323

# Testing

Customer confirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
