### PR TITLE
20250204-fix-null-ptr-increments

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -27822,6 +27822,7 @@ static int ParseCipherList(Suites* suites,
             }
             if (currLen == 0)
                 break;
+            ++next; /* increment to skip ':' */
         }
 
     #if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)
@@ -28173,8 +28174,7 @@ static int ParseCipherList(Suites* suites,
                 break;
             }
         }
-    }
-    while (next++); /* increment to skip ':' */
+    } while (next);
 
     if (ret) {
         int keySz = 0;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -9221,8 +9221,14 @@ static int CheckcipherList(const char* list)
 
         next   = XSTRSTR(next, ":");
 
-        current_length = (!next) ? (word32)XSTRLEN(current)
-                                 : (word32)(next - current);
+        if (next) {
+            current_length = (word32)(next - current);
+            ++next; /* increment to skip ':' */
+        }
+        else {
+            current_length = (word32)XSTRLEN(current);
+        }
+
         if (current_length == 0) {
             break;
         }
@@ -9279,8 +9285,7 @@ static int CheckcipherList(const char* list)
             /* list has mixed suites */
             return 0;
         }
-    }
-    while (next++); /* increment to skip ':' */
+    } while (next);
 
     if (findTLSv13Suites == 0 && findbeforeSuites == 1) {
         ret = 1;/* only before TLSv13 suites */


### PR DESCRIPTION
`src/internal.c` and `src/ssl.c`: in `CheckcipherList()` and `ParseCipherList()`, refactor `while (next++)` to `while (next)` to avoid clang21 `UndefinedBehaviorSanitizer` "applying non-zero offset 1 to null pointer".

tested with `wolfssl-multi-test.sh ... check-source-text sanitizer-clang-all-intelasm quantum-safe-wolfssl-all-clang-tidy` after upgrade to llvm-21.0.0_pre20250201.
