### PR TITLE
20250206-unit-test-helgrind-fixes

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -91146,7 +91146,14 @@ static void test_AEAD_limit_server(WOLFSSL* ssl)
     tcp_set_nonblocking(&fd); /* So that read doesn't block */
     wolfSSL_dtls_set_using_nonblock(ssl, 1);
     test_AEAD_get_limits(ssl, NULL, NULL, &sendLimit);
-    while (! WOLFSSL_ATOMIC_LOAD(test_AEAD_done) && ret > 0) {
+    while (!
+    #ifdef WOLFSSL_ATOMIC_INITIALIZER
+           WOLFSSL_ATOMIC_LOAD(test_AEAD_done)
+    #else
+           test_AEAD_done
+    #endif
+           && ret > 0)
+    {
         counter++;
 #ifdef WOLFSSL_MUTEX_INITIALIZER
         (void)wc_LockMutex(&test_AEAD_mutex);

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -422,6 +422,8 @@
 #ifdef SINGLE_THREADED
     typedef int wolfSSL_Atomic_Int;
     #define WOLFSSL_ATOMIC_INITIALIZER(x) (x)
+    #define WOLFSSL_ATOMIC_LOAD(x) (x)
+    #define WOLFSSL_ATOMIC_STORE(x, val) (x) = (val)
     #define WOLFSSL_ATOMIC_OPS
 #elif defined(HAVE_C___ATOMIC)
 #ifdef __cplusplus
@@ -429,6 +431,8 @@
     /* C++ using direct calls to compiler built-in functions */
     typedef volatile int wolfSSL_Atomic_Int;
     #define WOLFSSL_ATOMIC_INITIALIZER(x) (x)
+    #define WOLFSSL_ATOMIC_LOAD(x) __atomic_load_n(&(x), __ATOMIC_CONSUME)
+    #define WOLFSSL_ATOMIC_STORE(x, val) __atomic_store_n(&(x), val, __ATOMIC_RELEASE)
     #define WOLFSSL_ATOMIC_OPS
 #endif
 #else
@@ -437,6 +441,8 @@
     #include <stdatomic.h>
     typedef atomic_int wolfSSL_Atomic_Int;
     #define WOLFSSL_ATOMIC_INITIALIZER(x) (x)
+    #define WOLFSSL_ATOMIC_LOAD(x) atomic_load(&(x))
+    #define WOLFSSL_ATOMIC_STORE(x, val) atomic_store(&(x), val)
     #define WOLFSSL_ATOMIC_OPS
     #endif /* WOLFSSL_HAVE_ATOMIC_H */
 #endif
@@ -449,6 +455,8 @@
     #endif
     typedef volatile long wolfSSL_Atomic_Int;
     #define WOLFSSL_ATOMIC_INITIALIZER(x) (x)
+    #define WOLFSSL_ATOMIC_LOAD(x) (x)
+    #define WOLFSSL_ATOMIC_STORE(x, val) (x) = (val)
     #define WOLFSSL_ATOMIC_OPS
 #endif
 #endif /* WOLFSSL_NO_ATOMICS */


### PR DESCRIPTION
`tests/api.c`: fix data races in `test_wolfSSL_CTX_add_session_ctx_ready()` using a mutex, and in `test_wolfSSL_dtls_AEAD_limit()` using a mutex, an atomic integer, and a `volatile` attribute.

`wolfssl/wolfcrypt/wc_port.h`: add `WOLFSSL_ATOMIC_LOAD()` and `WOLFSSL_ATOMIC_STORE()` definitions.

tested with `wolfssl-multi-test.sh ... quantum-safe-wolfssl-all-intelasm-sp-asm-helgrind check-source-text`

(`quantum-safe-wolfssl-all-intelasm-sp-asm-helgrind` is a new test)

Note, also tried testing using `valgrind --tool=drd` but saw various nondeterministic failures, in e.g. `test_wolfSSL_UseALPN_connection`, `test_wolfSSL_BIO_accept`, and particularly, `test_ticket_and_psk_mixing_on_result`.  Not yet known if true or false positive.
