### PR TITLE
20250206-winsockapi-tweaks

### DIFF
--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -38,6 +38,7 @@
     #define _WINSOCKAPI_ /* block inclusion of winsock.h header file */
     #include <windows.h>
     #include <wincrypt.h>
+    #undef _WINSOCKAPI_
 
     /* mingw gcc does not support pragma comment, and the
      * linking with crypt32 is handled in configure.ac */

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -14465,6 +14465,7 @@ void bench_sphincsKeySign(byte level, byte optim)
     #define WIN32_LEAN_AND_MEAN
     #define _WINSOCKAPI_ /* block inclusion of winsock.h header file */
     #include <windows.h>
+    #undef _WINSOCKAPI_
 
     double current_time(int reset)
     {

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -90,6 +90,7 @@ This library contains implementation for the random number generator.
     #define _WINSOCKAPI_ /* block inclusion of winsock.h header file */
     #include <windows.h>
     #include <wincrypt.h>
+    #undef _WINSOCKAPI_
 #elif defined(HAVE_WNR)
     #include <wnr.h>
     #include <wolfssl/wolfcrypt/logging.h>

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -156,6 +156,7 @@
     #elif defined(__NT__)
         #define _WINSOCKAPI_ /* block inclusion of winsock.h header file */
         #include <windows.h>
+        #undef _WINSOCKAPI_
     #elif defined(__LINUX__)
         #ifndef SINGLE_THREADED
             #define WOLFSSL_PTHREADS
@@ -168,6 +169,7 @@
     #else
         #define _WINSOCKAPI_ /* block inclusion of winsock.h header file */
         #include <windows.h>
+        #undef _WINSOCKAPI_
     #endif
 #elif defined(THREADX)
     #ifndef SINGLE_THREADED

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -2134,6 +2134,7 @@ static WC_INLINE unsigned int my_psk_client_cs_cb(WOLFSSL* ssl,
     #define WIN32_LEAN_AND_MEAN
     #define _WINSOCKAPI_ /* block inclusion of winsock.h header file */
     #include <windows.h>
+    #undef _WINSOCKAPI_
 
     static WC_INLINE double current_time(int reset)
     {

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -160,9 +160,12 @@
             #define WIN32_LEAN_AND_MEAN
         #endif
         #if !defined(WOLFSSL_SGX) && !defined(WOLFSSL_NOT_WINDOWS_API)
-            #define _WINSOCKAPI_ /* block inclusion of winsock.h header file */
+            #define _WINSOCKAPI_ /* block inclusion of winsock.h header file. */
             #include <windows.h>
+            /* winsock2.h expects _WINSOCKAPI_ to be undef, and defines it. */
+            #undef _WINSOCKAPI_
             #ifndef WOLFSSL_USER_IO
+                #include <winsock2.h>
                 #include <ws2tcpip.h> /* required for InetPton */
             #endif
         #endif /* WOLFSSL_SGX */


### PR DESCRIPTION
`#undef _WINSOCKAPI_` after defining it to "block inclusion of winsock.h header file", to fix `#warning` in `/usr/x86_64-w64-mingw32/usr/include/winsock2.h`.

tested with `wolfssl-multi-test.sh ... cross-amd64-mingw-all-crypto-Wconversion cross-mingw-all-crypto check-source-text`
