### PR TITLE
dual alg: add ML-DSA test, and misc cleanup.

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -1695,10 +1695,10 @@ int wolfSSL_X509_EXTENSION_set_critical(WOLFSSL_X509_EXTENSION* ex, int crit)
  * Returns NULL on error or pointer to the v3_ext_method populated with
  * extension type-specific X509V3_EXT_* function(s).
  *
- * NOTE: WC_NID_subject_key_identifier is currently the only extension implementing
- * the X509V3_EXT_* functions, as it is the only type called directly by QT. The
- * other extension types return a pointer to a v3_ext_method struct that
- * contains only the NID.
+ * NOTE: WC_NID_subject_key_identifier is currently the only extension
+ * implementing the X509V3_EXT_* functions, as it is the only type called
+ * directly by QT. The other extension types return a pointer to a
+ * v3_ext_method struct that contains only the NID.
  */
 #if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
 const WOLFSSL_v3_ext_method* wolfSSL_X509V3_EXT_get(WOLFSSL_X509_EXTENSION* ex)
@@ -4559,7 +4559,8 @@ error:
  *          WOLFSSL_SUCCESS otherwise.
  */
 int wolfSSL_GENERAL_NAME_set0_othername(WOLFSSL_GENERAL_NAME* gen,
-                                        WOLFSSL_ASN1_OBJECT* oid, WOLFSSL_ASN1_TYPE* value)
+                                        WOLFSSL_ASN1_OBJECT* oid,
+                                        WOLFSSL_ASN1_TYPE* value)
 {
     WOLFSSL_ASN1_OBJECT *x = NULL;
 
@@ -13951,7 +13952,8 @@ int wolfSSL_X509_NAME_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509_NAME* name,
         int tmpSz;
 
         /* reverse name order for RFC2253 and DN_REV */
-        if ((flags & WOLFSSL_XN_FLAG_RFC2253) || (flags & WOLFSSL_XN_FLAG_DN_REV)) {
+        if ((flags & WOLFSSL_XN_FLAG_RFC2253) ||
+            (flags & WOLFSSL_XN_FLAG_DN_REV)) {
             ne = wolfSSL_X509_NAME_get_entry(name, count - i - 1);
         }
         else {

--- a/src/x509.c
+++ b/src/x509.c
@@ -8088,10 +8088,11 @@ int wolfSSL_i2d_X509(WOLFSSL_X509* x509, unsigned char** out)
 /* Generate a der preTBS from a decoded cert, and write
  * to buffer.
  *
- * @param[in]  cert  The decoded cert to parse.
- * @param[out] der   The der buffer to write in.
- * @param[in]  derZ  The der buffer size.
- * @return     preTBS der size on success.
+ * @param [in]  cert  The decoded cert to parse.
+ * @param [out] der   The der buffer to write in.
+ * @param [in]  derSz The der buffer size.
+ *
+ * @return  preTBS der size on success.
  * */
 int wc_GeneratePreTBS(DecodedCert* cert, byte *der, int derSz) {
     int ret = 0;
@@ -15743,6 +15744,17 @@ int wolfSSL_X509_ACERT_verify(WOLFSSL_X509_ACERT* x509, WOLFSSL_EVP_PKEY* pkey)
     return ret == 0 ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
 }
 
+/* Loads an x509 attribute certificate from buffer, and returns
+ * pointer to new WOLFSSL_X509_ACERT struct on success.
+ *
+ * @param [in]  buf    The acert buffer to load.
+ * @param [in]  sz     The size of the buffer.
+ * @param [in]  format The format of the buffer data.
+ * @param [in]  heap   Dynamic memory allocation hint.
+ *
+ * @return  pointer to WOLFSSL_X509_ACERT on success.
+ * @return  NULL on error.
+ * */
 WOLFSSL_X509_ACERT * wolfSSL_X509_ACERT_load_certificate_buffer_ex(
     const unsigned char* buf, int sz, int format, void * heap)
 {

--- a/src/x509.c
+++ b/src/x509.c
@@ -8084,10 +8084,20 @@ int wolfSSL_i2d_X509(WOLFSSL_X509* x509, unsigned char** out)
 }
 
 #ifdef WOLFSSL_DUAL_ALG_CERTS
+/* Generate a der preTBS from a decoded cert, and write
+ * to buffer.
+ *
+ * @param[in]  cert  The decoded cert to parse.
+ * @param[out] der   The der buffer to write in.
+ * @param[in]  derZ  The der buffer size.
+ * @return     preTBS der size on success.
+ * */
 int wc_GeneratePreTBS(DecodedCert* cert, byte *der, int derSz) {
     int ret = 0;
     WOLFSSL_X509 *x = NULL;
     byte certIsCSR = 0;
+
+    WOLFSSL_ENTER("wc_GeneratePreTBS");
 
     if ((cert == NULL) || (der == NULL) || (derSz <= 0)) {
         return BAD_FUNC_ARG;

--- a/tests/api.c
+++ b/tests/api.c
@@ -1611,7 +1611,7 @@ static int test_dual_alg_support(void)
 
 /**
  * Test dual-alg ECDSA + ML-DSA:
- *  - keygen + certgen
+ *  - keygen + certgen + cert manager load
  * */
 static int test_dual_alg_ecdsa_mldsa(void)
 {
@@ -1661,7 +1661,7 @@ static int test_dual_alg_ecdsa_mldsa(void)
     ExpectIntEQ(ret, 0);
     ret = wc_MlDsaKey_SetParams(&alt_ca_key, WC_ML_DSA_44);
     ExpectIntEQ(ret, 0);
-    ret = wc_dilithium_make_key(&alt_ca_key, &rng);
+    ret = wc_MlDsaKey_MakeKey(&alt_ca_key, &rng);
     ExpectIntEQ(ret, 0);
     alt_pub_sz = wc_MlDsaKey_PublicKeyToDer(&alt_ca_key, alt_pub_der,
                                             alt_pub_sz, 1);
@@ -1739,9 +1739,9 @@ static int test_dual_alg_ecdsa_mldsa(void)
         ret = wolfSSL_CertManagerLoadCABuffer(cm, final_der, final_der_sz,
                                               WOLFSSL_FILETYPE_ASN1);
         ExpectIntEQ(ret, WOLFSSL_SUCCESS);
-    }
 
-    wolfSSL_CertManagerFree(cm);
+        wolfSSL_CertManagerFree(cm);
+    }
 
     wc_ecc_free(&ca_key);
     wc_MlDsaKey_Free(&alt_ca_key);

--- a/tests/api.c
+++ b/tests/api.c
@@ -1621,7 +1621,7 @@ static int test_dual_alg_ecdsa_mldsa(void)
     defined(WOLFSSL_WC_DILITHIUM) && \
     !defined(WOLFSSL_DILITHIUM_NO_MAKE_KEY) && \
     !defined(WOLFSSL_DILITHIUM_NO_SIGN) && \
-    !defined(WOLFSSL_DILITHIUM_NO_VERIFY)
+    !defined(WOLFSSL_DILITHIUM_NO_VERIFY) && !defined(WOLFSSL_SMALL_STACK)
     WOLFSSL_CERT_MANAGER * cm = NULL;
     MlDsaKey    alt_ca_key;
     ecc_key     ca_key;
@@ -1735,12 +1735,16 @@ static int test_dual_alg_ecdsa_mldsa(void)
     cm = wolfSSL_CertManagerNew();
     ExpectNotNull(cm);
 
+    /* Load the certificate into CertManager. */
     if (cm != NULL && final_der_sz > 0) {
         ret = wolfSSL_CertManagerLoadCABuffer(cm, final_der, final_der_sz,
                                               WOLFSSL_FILETYPE_ASN1);
         ExpectIntEQ(ret, WOLFSSL_SUCCESS);
+    }
 
+    if (cm != NULL) {
         wolfSSL_CertManagerFree(cm);
+        cm = NULL;
     }
 
     wc_ecc_free(&ca_key);

--- a/tests/api.c
+++ b/tests/api.c
@@ -1609,6 +1609,149 @@ static int test_dual_alg_support(void)
 }
 #endif /* WOLFSSL_DUAL_ALG_CERTS && !NO_FILESYSTEM */
 
+/**
+ * Test dual-alg ECDSA + ML-DSA:
+ *  - keygen + certgen
+ * */
+static int test_dual_alg_ecdsa_mldsa(void)
+{
+    EXPECT_DECLS;
+#if defined(WOLFSSL_DUAL_ALG_CERTS) && defined(HAVE_DILITHIUM) && \
+    defined(HAVE_ECC) && !defined(WC_NO_RNG) && \
+    defined(WOLFSSL_WC_DILITHIUM) && \
+    !defined(WOLFSSL_DILITHIUM_NO_MAKE_KEY) && \
+    !defined(WOLFSSL_DILITHIUM_NO_SIGN) && \
+    !defined(WOLFSSL_DILITHIUM_NO_VERIFY)
+    WOLFSSL_CERT_MANAGER * cm = NULL;
+    MlDsaKey    alt_ca_key;
+    ecc_key     ca_key;
+    WC_RNG      rng;
+    int         ret = 0;
+    DecodedCert d_cert;
+    Cert        new_cert;
+    /* various tmp buffs.  */
+    byte        alt_pub_der[LARGE_TEMP_SZ];
+    word32      alt_pub_sz = LARGE_TEMP_SZ;
+    byte        alt_sig_alg[LARGE_TEMP_SZ];
+    word32      alt_sig_alg_sz = LARGE_TEMP_SZ;
+    byte        tbs_der[LARGE_TEMP_SZ];
+    word32      tbs_der_sz = LARGE_TEMP_SZ;
+    byte        alt_sig[LARGE_TEMP_SZ];
+    word32      alt_sig_sz = LARGE_TEMP_SZ;
+    /* Intermediate der. */
+    byte        der[LARGE_TEMP_SZ];
+    word32      der_sz = LARGE_TEMP_SZ;
+    /* The final der will be large because of ML-DSA signature. */
+    byte        final_der[2 * LARGE_TEMP_SZ];
+    word32      final_der_sz = 2 * LARGE_TEMP_SZ;
+
+    XMEMSET(alt_pub_der, 0, alt_pub_sz);
+    XMEMSET(alt_sig_alg, 0, alt_sig_alg_sz);
+    XMEMSET(tbs_der, 0, tbs_der_sz);
+    XMEMSET(alt_sig, 0, alt_sig_sz);
+    XMEMSET(der, 0, der_sz);
+    XMEMSET(final_der, 0, final_der_sz);
+
+    ExpectIntEQ(wc_InitRng(&rng), 0);
+
+    /**
+     * ML-DSA key gen.
+     * */
+    ret = wc_MlDsaKey_Init(&alt_ca_key, NULL, INVALID_DEVID);
+    ExpectIntEQ(ret, 0);
+    ret = wc_MlDsaKey_SetParams(&alt_ca_key, WC_ML_DSA_44);
+    ExpectIntEQ(ret, 0);
+    ret = wc_dilithium_make_key(&alt_ca_key, &rng);
+    ExpectIntEQ(ret, 0);
+    alt_pub_sz = wc_MlDsaKey_PublicKeyToDer(&alt_ca_key, alt_pub_der,
+                                            alt_pub_sz, 1);
+    ExpectIntGT(alt_pub_sz, 0);
+
+    alt_sig_alg_sz = SetAlgoID(CTC_SHA256wECDSA, alt_sig_alg, oidSigType, 0);
+    ExpectIntGT(alt_sig_alg_sz, 0);
+
+    /**
+     * ECC key gen.
+     * */
+    ret = wc_ecc_init(&ca_key);
+    ExpectIntEQ(ret, 0);
+    ret = wc_ecc_make_key(&rng, KEY32, &ca_key);
+    ExpectIntEQ(ret, 0);
+
+    /**
+     * Cert gen.
+     * */
+    wc_InitCert(&new_cert);
+    strncpy(new_cert.subject.country, "US", CTC_NAME_SIZE);
+    strncpy(new_cert.subject.state, "MT", CTC_NAME_SIZE);
+    strncpy(new_cert.subject.locality, "Bozeman", CTC_NAME_SIZE);
+    strncpy(new_cert.subject.org, "wolfSSL", CTC_NAME_SIZE);
+    strncpy(new_cert.subject.unit, "Engineering", CTC_NAME_SIZE);
+    strncpy(new_cert.subject.commonName, "www.wolfssl.com", CTC_NAME_SIZE);
+    strncpy(new_cert.subject.email, "root@wolfssl.com", CTC_NAME_SIZE);
+    new_cert.sigType = CTC_SHA256wECDSA;
+    new_cert.isCA    = 1;
+
+    ret = wc_SetCustomExtension(&new_cert, 0, "1.2.3.4.5",
+                         (const byte *)"This is NOT a critical extension", 32);
+    ExpectIntEQ(ret, 0);
+
+    ExpectIntEQ(wc_SetCustomExtension(&new_cert, 0, "2.5.29.72", alt_pub_der,
+                alt_pub_sz), 0);
+    ExpectIntEQ(wc_SetCustomExtension(&new_cert, 0, "2.5.29.73", alt_sig_alg,
+                alt_sig_alg_sz), 0);
+
+    ret = wc_MakeCert_ex(&new_cert, der, der_sz, ECC_TYPE, &ca_key, &rng);
+    ExpectIntGT(ret, 0);
+
+    der_sz = wc_SignCert_ex(new_cert.bodySz, new_cert.sigType, der, der_sz,
+                            ECC_TYPE, &ca_key, &rng);
+    ExpectIntGT(der_sz, 0);
+
+    wc_InitDecodedCert(&d_cert, der, der_sz, 0);
+    ret = wc_ParseCert(&d_cert, CERT_TYPE, NO_VERIFY, NULL);
+    ExpectIntEQ(ret, 0);
+
+    tbs_der_sz = wc_GeneratePreTBS(&d_cert, tbs_der, tbs_der_sz);
+    ExpectIntGT(tbs_der_sz, 0);
+
+    alt_sig_sz = wc_MakeSigWithBitStr(alt_sig, alt_sig_sz,
+                                      CTC_ML_DSA_LEVEL2, tbs_der, tbs_der_sz,
+                                      ML_DSA_LEVEL2_TYPE, &alt_ca_key, &rng);
+    ExpectIntGT(alt_sig_sz, 0);
+
+    ret = wc_SetCustomExtension(&new_cert, 0, "2.5.29.74", alt_sig, alt_sig_sz);
+    ExpectIntEQ(ret, 0);
+
+    /* Finally generate the new certificate. */
+    ret = wc_MakeCert_ex(&new_cert, final_der, final_der_sz, ECC_TYPE, &ca_key,
+                         &rng);
+    ExpectIntGT(ret, 0);
+
+    final_der_sz = wc_SignCert_ex(new_cert.bodySz, new_cert.sigType, final_der,
+                                  final_der_sz, ECC_TYPE, &ca_key, &rng);
+    ExpectIntGT(final_der_sz, 0);
+
+    cm = wolfSSL_CertManagerNew();
+    ExpectNotNull(cm);
+
+    if (cm != NULL && final_der_sz > 0) {
+        ret = wolfSSL_CertManagerLoadCABuffer(cm, final_der, final_der_sz,
+                                              WOLFSSL_FILETYPE_ASN1);
+        ExpectIntEQ(ret, WOLFSSL_SUCCESS);
+    }
+
+    wolfSSL_CertManagerFree(cm);
+
+    wc_ecc_free(&ca_key);
+    wc_MlDsaKey_Free(&alt_ca_key);
+    wc_FreeRng(&rng);
+
+#endif /* WOLFSSL_DUAL_ALG_CERTS && DILITHIUM and more */
+    return EXPECT_RESULT();
+}
+
+
 /*----------------------------------------------------------------------------*
  | Context
  *----------------------------------------------------------------------------*/
@@ -101832,6 +101975,8 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_Init),
 
     TEST_DECL(test_dual_alg_support),
+
+    TEST_DECL(test_dual_alg_ecdsa_mldsa),
 
     /*********************************
      * OpenSSL compatibility API tests

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -32147,9 +32147,11 @@ static int SignCert(int requestSz, int sType, byte* buf, word32 buffSz,
  * @param [in]  buf     The input buf to sign.
  * @param [in]  bufSz   The buffer size
  * @param [in]  keyType The key type.
+ * @param [in]  key     Key data.
  * @param [in]  rng     Random number generator.
- * @return      Size of signature on success.
- * @return      < 0 on error.
+ *
+ * @return  Size of signature on success.
+ * @return  < 0 on error.
  * */
 int wc_MakeSigWithBitStr(byte *sig, int sigSz, int sType, byte* buf,
                          word32 bufSz, int keyType, void* key, WC_RNG* rng)
@@ -32282,14 +32284,16 @@ int wc_MakeSigWithBitStr(byte *sig, int sigSz, int sType, byte* buf,
 /* Sign an x509 Certificate v3 from cert input using any
  * key type, and write to buffer.
  *
- * @param [in]  requestSz Size of requested data to sign.
- * @param [in]  sType     The signature type.
- * @param [in]  derSz     Der buffer size.
- * @param [in]  keyType   The type of key.
- * @param [in]  key       Key data.
- * @param [in]  rng       Random number generator.
- * @return      Size of signature on success.
- * @return      < 0 on error
+ * @param [in]     requestSz Size of requested data to sign.
+ * @param [in]     sType     The signature type.
+ * @param [in,out] buf       Der buffer to sign.
+ * @param [in]     buffSz    Der buffer size.
+ * @param [in]     keyType   The type of key.
+ * @param [in]     key       Key data.
+ * @param [in]     rng       Random number generator.
+ *
+ * @return  Size of signature on success.
+ * @return  < 0 on error
  * */
 int wc_SignCert_ex(int requestSz, int sType, byte* buf, word32 buffSz,
                    int keyType, void* key, WC_RNG* rng)
@@ -40940,7 +40944,7 @@ static int DecodeAcertGeneralName(const byte* input, word32* inOutIdx,
  * @param [in]      input    Buffer holding encoded data.
  * @param [in]      sz       Size of encoded data in bytes.
  * @param [in]      tag      ASN.1 tag value expected in header.
- * @param [in, out] acert    Decoded certificate object.
+ * @param [in, out] acert    Decoded attribute certificate object.
  * @param [in, out] entries  Linked list of DNS name entries.
  *
  * @return  0 on success.
@@ -41069,7 +41073,7 @@ enum {
  *
  * @param [in]      input     Buffer containing encoded Holder field.
  * @param [in]      len       Length of Holder field.
- * @param [in, out] acert     Decoded certificate object.
+ * @param [in, out] acert     Decoded attribute certificate object.
  *
  * @return  0 on success.
  * @return  ASN_PARSE_E when BER encoded data does not match ASN.1 items or

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -2451,8 +2451,9 @@ static int GetASNHeader_ex(const byte* input, byte tag, word32* inOutIdx,
             ret = ASN_PARSE_E;
         }
         else if ((input[(int)idx + length - 1] & 0x80) == 0x80) {
-            /* Last octet of a sub-identifier has bit 8 clear. Last octet must be
-            * last of a subidentifier. Ensure last octet hasn't got top bit set. */
+            /* Last octet of a sub-identifier has bit 8 clear. Last octet must
+             * be last of a subidentifier. Ensure last octet hasn't got top bit
+             * set. */
             WOLFSSL_MSG("OID last octet has top bit set");
             ret = ASN_PARSE_E;
         }
@@ -3629,8 +3630,8 @@ word32 SetIndefEnd(byte* output)
 
 /* Breaks an octet string up into chunks for use with streaming
  * returns 0 on success and updates idx */
-int StreamOctetString(const byte* inBuf, word32 inBufSz, byte* out, word32* outSz,
-    word32* idx)
+int StreamOctetString(const byte* inBuf, word32 inBufSz, byte* out,
+                      word32* outSz, word32* idx)
 {
     word32 i  = 0;
     word32 outIdx = *idx;
@@ -11477,8 +11478,8 @@ int wc_DsaKeyToParamsDer(DsaKey* key, byte* output, word32 inLen)
 }
 
 /* This version of the function allows output to be NULL. In that case, the
-   DsaKeyIntsToDer will return WC_NO_ERR_TRACE(LENGTH_ONLY_E) and the required output buffer
-   size will be pointed to by inLen. */
+   DsaKeyIntsToDer will return WC_NO_ERR_TRACE(LENGTH_ONLY_E) and the required
+   output buffer size will be pointed to by inLen. */
 int wc_DsaKeyToParamsDer_ex(DsaKey* key, byte* output, word32* inLen)
 {
     if (!key || !inLen)
@@ -16265,7 +16266,8 @@ static WC_INLINE int IsSigAlgoECC(word32 algoOID)
  * @return  Encoded data size on success.
  * @return  0 when dynamic memory allocation fails.
  */
-static word32 SetAlgoIDImpl(int algoOID, byte* output, int type, int curveSz, byte absentParams)
+static word32 SetAlgoIDImpl(int algoOID, byte* output, int type, int curveSz,
+                            byte absentParams)
 {
 #ifndef WOLFSSL_ASN_TEMPLATE
     word32 tagSz, idSz, seqSz, algoSz = 0;
@@ -16395,7 +16397,8 @@ word32 SetAlgoID(int algoOID, byte* output, int type, int curveSz)
     return SetAlgoIDImpl(algoOID, output, type, curveSz, FALSE);
 }
 
-word32 SetAlgoIDEx(int algoOID, byte* output, int type, int curveSz, byte absentParams)
+word32 SetAlgoIDEx(int algoOID, byte* output, int type, int curveSz,
+                   byte absentParams)
 {
     return SetAlgoIDImpl(algoOID, output, type, curveSz, absentParams);
 }
@@ -34375,7 +34378,8 @@ int wc_EccPrivateKeyDecode(const byte* input, word32* inOutIdx, ecc_key* key,
                     ret = BUFFER_E;
                 else {
             #ifdef WOLFSSL_SMALL_STACK
-                    pub = (byte*)XMALLOC(pubSz, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+                    pub = (byte*)XMALLOC(pubSz, key->heap,
+                                         DYNAMIC_TYPE_TMP_BUFFER);
                     if (pub == NULL)
                         ret = MEMORY_E;
                     else
@@ -36015,7 +36019,8 @@ int wc_Ed25519PrivateKeyToDer(ed25519_key* key, byte* output, word32 inLen)
 #if defined(HAVE_CURVE25519) && defined(HAVE_CURVE25519_KEY_EXPORT)
 /* Write only private Curve25519 key to DER format,
  * length on success else < 0 */
-int wc_Curve25519PrivateKeyToDer(curve25519_key* key, byte* output, word32 inLen)
+int wc_Curve25519PrivateKeyToDer(curve25519_key* key, byte* output,
+                                 word32 inLen)
 {
     int    ret;
     byte   privKey[CURVE25519_KEYSIZE];
@@ -36057,7 +36062,8 @@ int wc_Curve25519PublicKeyToDer(curve25519_key* key, byte* output, word32 inLen,
 /* Export Curve25519 key to DER format - handles private only, public only,
  * or private+public key pairs based on what's set in the key structure.
  * Returns length written on success, negative on error */
-int wc_Curve25519KeyToDer(curve25519_key* key, byte* output, word32 inLen, int withAlg)
+int wc_Curve25519KeyToDer(curve25519_key* key, byte* output, word32 inLen,
+                          int withAlg)
 {
     int ret;
     byte privKey[CURVE25519_KEYSIZE];
@@ -36488,12 +36494,13 @@ static int DecodeSingleResponse(byte* source, word32* ioIndex, word32 size,
             single->status->thisDateParsed.length);
 #endif
     if (GetBasicDate(source, &idx, single->status->thisDate,
-                                                &single->status->thisDateFormat, size) < 0)
+                     &single->status->thisDateFormat, size) < 0)
         return ASN_PARSE_E;
 
 #ifndef NO_ASN_TIME_CHECK
 #ifndef WOLFSSL_NO_OCSP_DATE_CHECK
-    if (!XVALIDATE_DATE(single->status->thisDate, single->status->thisDateFormat, ASN_BEFORE))
+    if (!XVALIDATE_DATE(single->status->thisDate,
+        single->status->thisDateFormat, ASN_BEFORE))
         return ASN_BEFORE_DATE_E;
 #endif
 #endif
@@ -36524,7 +36531,7 @@ static int DecodeSingleResponse(byte* source, word32* ioIndex, word32 size,
                 single->status->nextDateParsed.length);
 #endif
         if (GetBasicDate(source, &idx, single->status->nextDate,
-                                                &single->status->nextDateFormat, size) < 0)
+                         &single->status->nextDateFormat, size) < 0)
             return ASN_PARSE_E;
 
 #ifndef NO_ASN_TIME_CHECK
@@ -38685,7 +38692,7 @@ static int ParseCRL_CertList(RevokedCert* rcert, DecodedCRL* dcrl,
     {
 #if !defined(NO_ASN_TIME) && !defined(WOLFSSL_NO_CRL_DATE_CHECK)
         if (verify != NO_VERIFY &&
-                !XVALIDATE_DATE(dcrl->nextDate, dcrl->nextDateFormat, ASN_AFTER)) {
+            !XVALIDATE_DATE(dcrl->nextDate, dcrl->nextDateFormat, ASN_AFTER)) {
             WOLFSSL_MSG("CRL after date is no longer valid");
             WOLFSSL_ERROR_VERBOSE(CRL_CERT_DATE_ERR);
             return CRL_CERT_DATE_ERR;
@@ -39790,8 +39797,8 @@ int wc_MIME_header_strip(char* in, char** out, size_t start, size_t end)
 }
 
 /*****************************************************************************
-* wc_MIME_find_header_name - Searches through all given headers until a header with
-* a name matching the provided name is found.
+* wc_MIME_find_header_name - Searches through all given headers until a header
+* with a name matching the provided name is found.
 *
 * RETURNS:
 * returns a pointer to the found header, if no match was found, returns NULL.
@@ -39869,8 +39876,8 @@ char* wc_MIME_single_canonicalize(const char* line, word32* len)
 }
 
 /*****************************************************************************
-* wc_MIME_free_hdrs - Frees all MIME headers, parameters and strings starting from
-* the provided header pointer.
+* wc_MIME_free_hdrs - Frees all MIME headers, parameters and strings starting
+* from the provided header pointer.
 *
 * RETURNS:
 * returns zero on success, non-zero on error.
@@ -40726,9 +40733,9 @@ int wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz, const byte* e,
 #endif /* !NO_RSA && (!NO_BIG_INT || WOLFSSL_SP_MATH) */
 
 #if defined(WOLFSSL_ACERT) && defined(WOLFSSL_ASN_TEMPLATE)
-/* Initialize decoded certificate object with buffer of DER encoding.
+/* Initialize decoded attribute certificate object with buffer of DER encoding.
  *
- * @param [in, out] cert    Decoded certificate object.
+ * @param [in, out] acert   Decoded attribute certificate object.
  * @param [in]      source  Buffer containing DER encoded certificate.
  * @param [in]      inSz    Size of DER data in buffer in bytes.
  * @param [in]      heap    Dynamic memory hint.
@@ -40755,7 +40762,7 @@ void InitDecodedAcert(DecodedAcert* acert, const byte* source, word32 inSz,
 
 /* Free the decoded attribute cert object's dynamic data.
  *
- * @param [in, out] acert  Attribute Decoded certificate object.
+ * @param [in, out] acert   Decoded attribute certificate object.
  */
 void FreeDecodedAcert(DecodedAcert * acert)
 {
@@ -40792,7 +40799,7 @@ void FreeDecodedAcert(DecodedAcert * acert)
  * @param [in, out] inOutIdx  On in, the index of the start of the OtherName.
  *                            On out, index after OtherName.
  * @param [in]      len       Length of data in buffer.
- * @param [in]      cert      Decoded attribute certificate object.
+ * @param [in]      acert     Decoded attribute certificate object.
  * @param [in, out] entries   Linked list of DNS name entries.
  *
  * @return  0 on success.
@@ -40933,7 +40940,7 @@ static int DecodeAcertGeneralName(const byte* input, word32* inOutIdx,
  * @param [in]      input    Buffer holding encoded data.
  * @param [in]      sz       Size of encoded data in bytes.
  * @param [in]      tag      ASN.1 tag value expected in header.
- * @param [in, out] cert     Decoded certificate object.
+ * @param [in, out] acert    Decoded certificate object.
  * @param [in, out] entries  Linked list of DNS name entries.
  *
  * @return  0 on success.
@@ -41060,10 +41067,9 @@ enum {
 
 /* Decode the Holder field of an x509 attribute certificate.
  *
- *
  * @param [in]      input     Buffer containing encoded Holder field.
  * @param [in]      len       Length of Holder field.
- * @param [in]      cert      Decoded certificate object.
+ * @param [in, out] acert     Decoded certificate object.
  *
  * @return  0 on success.
  * @return  ASN_PARSE_E when BER encoded data does not match ASN.1 items or
@@ -41227,7 +41233,7 @@ enum {
  *
  * @param [in]      input     Buffer containing encoded AttCertIssuer field.
  * @param [in]      len       Length of Holder field.
- * @param [in]      cert      Decoded certificate object.
+ * @param [in,out]  acert     Decoded attribute certificate object.
  *
  * @return  0 on success.
  * @return  ASN_PARSE_E when BER encoded data does not match ASN.1 items or
@@ -41403,8 +41409,10 @@ enum {
  *   - extensions
  *   - attributes
  *
- * Returns 0 on success.
- * Returns negative error code on error/failure.
+ * @param [in, out] acert   Decoded attribute certificate object.
+ * @param [in]      verify  Whether to verify dates.
+ * @return  0 on success.
+ * @return  negative error code on error/fail.
  * */
 int ParseX509Acert(DecodedAcert* acert, int verify)
 {
@@ -41614,7 +41622,6 @@ int ParseX509Acert(DecodedAcert* acert, int verify)
 }
 
 /* Given the parsed attribute cert info, verify the signature.
- *
  * The sigCtx is alloced and freed here.
  *
  * @param [in]      acinfo        the parsed acinfo sequence
@@ -41705,7 +41712,7 @@ int VerifyX509Acert(const byte* der, word32 derSz,
     const byte *   sigParams = NULL;
     word32         sigParamsSz = 0;
 
-    WOLFSSL_MSG("ParseX509Acert");
+    WOLFSSL_MSG("VerifyX509Acert");
 
     if (der == NULL || pubKey == NULL || derSz == 0 || pubKeySz == 0) {
         WOLFSSL_MSG("error: VerifyX509Acert: bad args");
@@ -41794,6 +41801,10 @@ int VerifyX509Acert(const byte* der, word32 derSz,
     return ret;
 }
 
+/**
+ * Wrapper API to expose Acert ASN functions. See Acert ASN functions
+ * for comments.
+ * */
 void wc_InitDecodedAcert(DecodedAcert* acert, const byte* source, word32 inSz,
                          void* heap)
 {

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -2347,13 +2347,6 @@ WOLFSSL_LOCAL int CheckCertSignaturePubKey(const byte* cert, word32 certSz,
                                         word32 pubKeySz, int pubKeyOID);
 #endif /* OPENSSL_EXTRA || WOLFSSL_SMALL_CERT_VERIFY */
 
-#ifdef WOLFSSL_DUAL_ALG_CERTS
-WOLFSSL_LOCAL int wc_ConfirmAltSignature(
-    const byte* buf, word32 bufSz,
-    const byte* key, word32 keySz, word32 keyOID,
-    const byte* sig, word32 sigSz, word32 sigOID,
-    void *heap);
-#endif /* WOLFSSL_DUAL_ALG_CERTS */
 #if (defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_IMPORT) || \
     (defined(HAVE_ED448) && defined(HAVE_ED448_KEY_IMPORT)))
 WOLFSSL_LOCAL int wc_CertGetPubKey(const byte* cert, word32 certSz,

--- a/wolfssl/wolfcrypt/dilithium.h
+++ b/wolfssl/wolfcrypt/dilithium.h
@@ -894,6 +894,13 @@ WOLFSSL_API int wc_Dilithium_PrivateKeyToDer(dilithium_key* key, byte* output,
 #define wc_MlDsaKey_Verify(key, sig, sigSz, msg, msgSz, res)    \
     wc_dilithium_verify_msg(sig, sigSz, msg, msgSz, res, key)
 
+#define wc_MlDsaKey_PublicKeyToDer(key, output, len, withAlg)   \
+    wc_Dilithium_PublicKeyToDer(key, output, len, withAlg)
+
+#define wc_MlDsaKey_PrivateKeyToDer(key, output, len)           \
+    wc_Dilithium_PrivateKeyToDer(key, output, len)
+
+
 WOLFSSL_API int wc_MlDsaKey_GetPrivLen(MlDsaKey* key, int* len);
 WOLFSSL_API int wc_MlDsaKey_GetPubLen(MlDsaKey* key, int* len);
 WOLFSSL_API int wc_MlDsaKey_GetSigLen(MlDsaKey* key, int* len);


### PR DESCRIPTION
# Description
Add a dual-alg ML-DSA + ECDSA test, and some miscellaneous cleanup:

- Add `test_dual_alg_ecdsa_mldsa()` to tests/api.c (Based on ecdsa + mldsa demo here: https://github.com/wolfSSL/wolfssl-examples/tree/master/X9.146).
- Add missing comments to ASN functions, and trim line lengths.
- Remove unused WOLFSSL_LOCAL function `wc_ConfirmAltSignature()`.
- Add missing `wc_MlDsaKey_*KeyToDer()` define to wolfssl/wolfcrypt/dilithium.h

# Testing

```
./configure --enable-experimental --enable-dual-alg-certs --enable-dilithium --enable-debug && make
./tests/unit.test --list | grep dual_alg
338: test_dual_alg_support
339: test_dual_alg_ecdsa_mldsa
./tests/unit.test -339
```


