### PR TITLE
Read DER BIO: fix for when BIO data is less than seq buffer size

### DIFF
--- a/src/pk.c
+++ b/src/pk.c
@@ -1558,7 +1558,11 @@ static int wolfssl_read_der_bio(WOLFSSL_BIO* bio, unsigned char** out)
         WOLFSSL_ERROR_MSG("Malloc failure");
         err = 1;
     }
-    if (!err) {
+    if ((!err) && (derLen <= (int)sizeof(seq))) {
+        /* Copy the previously read data into the buffer. */
+        XMEMCPY(der, seq, derLen);
+    }
+    else if (!err) {
         /* Calculate the unread amount. */
         int len = derLen - (int)sizeof(seq);
         /* Copy the previously read data into the buffer. */

--- a/tests/api.c
+++ b/tests/api.c
@@ -72654,9 +72654,14 @@ static int test_wolfSSL_d2i_PrivateKeys_bio(void)
 
 #if defined(WOLFSSL_KEY_GEN) && !defined(NO_RSA)
     {
+        const unsigned char seqOnly[] = { 0x30, 0x00, 0x00, 0x00, 0x00, 0x00 };
         RSA* rsa = NULL;
         /* Tests bad parameters */
         ExpectNull(d2i_RSAPrivateKey_bio(NULL, NULL));
+
+        /* Test using bad data. */
+        ExpectIntGT(BIO_write(bio, seqOnly, sizeof(seqOnly)), 0);
+        ExpectNull(d2i_RSAPrivateKey_bio(bio, NULL));
 
         /* RSA not set yet, expecting to fail*/
         rsa = wolfSSL_RSA_new();


### PR DESCRIPTION
# Description

wolfssl_read_der_bio did not not handle the length to be read from the BIO being less than the size of the sequence buffer.

Fixes zd#19363

# Testing

./configure '--disable-shared' '--enable-opensslall' '--enable-keygen' 'CC=clang -fsanitize=address'
make
./tests/unit.test -test_wolfSSL_d2i_PrivateKeys_bio

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
