### PR TITLE
Fix Qt Nightly Jenkins failure

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -14514,7 +14514,7 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_set_peer_cert_chain(WOLFSSL* ssl)
     if (sk != NULL) {
         if (ssl->options.side == WOLFSSL_SERVER_END) {
             if (ssl->session->peer)
-                X509_free(ssl->session->peer);
+                wolfSSL_X509_free(ssl->session->peer);
 
             ssl->session->peer = wolfSSL_sk_X509_pop(sk);
             ssl->session->peerVerifyRet = ssl->peerVerifyRet;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -14495,6 +14495,14 @@ static WOLF_STACK_OF(WOLFSSL_X509)* CreatePeerCertChain(const WOLFSSL* ssl,
     if (sk == NULL) {
         WOLFSSL_MSG("Null session chain");
     }
+#if defined(WOLFSSL_QT)
+    /* Qt handles a peer cert pushing to chain. */
+    else if (ssl->options.side == WOLFSSL_SERVER_END) {
+        /* to be compliant with openssl
+           first element is kept as peer cert on server side.*/
+        wolfSSL_sk_X509_pop(sk);
+    }
+#endif
     return sk;
 }
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -51898,8 +51898,7 @@ static int msgSrvCb(SSL_CTX *ctx, SSL *ssl)
     fprintf(stderr, "\n===== msgSrvCb called ====\n");
 #if defined(SESSION_CERTS) && defined(TEST_PEER_CERT_CHAIN)
     ExpectTrue(SSL_get_peer_cert_chain(ssl) != NULL);
-    chain = (WOLFSSL_X509_CHAIN *)SSL_get_peer_cert_chain(ssl);
-    ExpectIntEQ(chain->count, 2);
+    ExpectIntEQ(((WOLFSSL_X509_CHAIN *)SSL_get_peer_cert_chain(ssl))->count, 2);
     ExpectNotNull(SSL_get0_verified_chain(ssl));
 #endif
 


### PR DESCRIPTION
# Description
Fix Qt Jenkins failure. The failure starts after [PR#8345](https://github.com/wolfSSL/wolfssl/pull/8345) merged.

# Testing

Run Qt Jenkins test

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
