### PR TITLE
Fix SE050 Port

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2732,7 +2732,7 @@ AC_ARG_WITH([se050],
     [
         AC_MSG_CHECKING([for SE050])
 
-        LIBS="$LIBS -lSSS_APIs"
+        LIBS="$LIBS -lSSS_APIs -lex_common"
         AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <fsl_sss_api.h>]], [[ sss_mac_init(0);]])],[ libse050_linked=yes ],[ libse050_linked=no ])
 
         if test "x$libse050_linked" = "xno" ; then

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -9225,6 +9225,7 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
 #elif defined(WOLFSSL_XILINX_CRYPT_VERSAL)
    byte sigRS[ECC_MAX_CRYPTO_HW_SIZE * 2];
    byte hashcopy[ECC_MAX_CRYPTO_HW_SIZE] = {0};
+#elif defined(WOLFSSL_SE050)
 #else
    int curveLoaded = 0;
    DECLARE_CURVE_SPECS(ECC_CURVE_FIELD_COUNT);

--- a/wolfcrypt/src/port/nxp/README_SE050.md
+++ b/wolfcrypt/src/port/nxp/README_SE050.md
@@ -34,21 +34,24 @@ Raspberry Pi, [here](https://www.nxp.com/docs/en/application-note/AN12570.pdf).
 
 Summarizing the build steps for Raspberry Pi:
 
+In `raspi-config` go to "Interface Options" and enable I2C.
+
 ```sh
+$ sudo apt update
+$ sudo apt install cmake libssl-dev cmake-curses-gui git
 $ cd ~
 $ mkdir se_mw
 $ unzip SE-PLUG-TRUST-MW.zip -d se_mw
-$ cd se_mw/simw-top/scripts
+$ cd se_mw/se05x_mw_v04.05.01/simw-top/scripts
 $ python create_cmake_projects.py rpi
-$ cd ~/se_mw/simw-top_build/raspbian_native_se050_t1oi2c
+$ cd ~/se_mw/se05x_mw_v04.05.01/simw-top_build/raspbian_native_se050_t1oi2c
 $ ccmake .
 # Make sure the following are set:
-#    `Host OS` to `Raspbian`
-#    `Host Crypto` to `None` (see HostCrypto section below)
+#    `PTMW_Host` to `Raspbian`
+#    `PTMW_HostCrypto` to `User` (see HostCrypto section below)
 #    `SMCOM` to `T1oI2C`
 $ c # to configure
-$ g # to generate
-$ q
+$ g # to generate, this will exit upon completion
 $ cmake --build .
 $ sudo make install
 ```
@@ -56,7 +59,7 @@ $ sudo make install
 This will also compile several demo apps which can be run if wanted, ie:
 
 ```sh
-$ cd ~/se_mw/simw-top_build/raspbian_native_se050_t1oi2c/bin
+$ cd ~/se_mw/se05x_mw_v04.05.01/simw-top_build/raspbian_native_se050_t1oi2c/bin
 $ ./ex_ecc  # (or, ./se05x_GetInfo, etc)
 ```
 

--- a/wolfcrypt/src/port/nxp/se050_port.c
+++ b/wolfcrypt/src/port/nxp/se050_port.c
@@ -2332,6 +2332,7 @@ void se050_ecc_free_key(struct ecc_key* key)
     if (status == kStatus_SSS_Success) {
         status = sss_key_object_get_handle(&keyObject, key->keyId);
     }
+
     if (status == kStatus_SSS_Success) {
         sss_key_object_free(&keyObject);
         key->keyId = 0;
@@ -2532,8 +2533,8 @@ int se050_ecc_create_key(struct ecc_key* key, int curve_id, int keySize)
     wolfSSL_CryptHwMutexUnLock();
 
 #ifdef SE050_DEBUG
-    printf("se050_ecc_create_key: key %p, ret %d, keyId %d\n",
-        key, ret, key->keyId);
+    printf("se050_ecc_create_key: key %p, ret %d, status %d, keyId %d\n",
+        key, ret, status, key->keyId);
 #endif
 
     return ret;
@@ -2688,7 +2689,8 @@ int se050_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key,
     wolfSSL_CryptHwMutexUnLock();
 
 #ifdef SE050_DEBUG
-    printf("se050_ecc_shared_secret: ret %d, outlen %d\n", ret, *outlen);
+    printf("se050_ecc_shared_secret: ret %d, status %d, outlen %d\n", ret,
+            status, *outlen);
 #endif
 
     return ret;

--- a/wolfssl/wolfcrypt/port/nxp/se050_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/se050_port.h
@@ -155,13 +155,14 @@ WOLFSSL_LOCAL void se050_aes_free(struct Aes* aes);
 struct WC_RNG;
 struct ecc_key;
 
+#ifdef HAVE_ECC
 WOLFSSL_LOCAL int se050_ecc_use_key_id(struct ecc_key* key, word32 keyId);
 WOLFSSL_LOCAL int se050_ecc_get_key_id(struct ecc_key* key, word32* keyId);
 WOLFSSL_LOCAL int se050_ecc_sign_hash_ex(const byte* in, word32 inLen,
-    mp_int* r, mp_int* s, byte* out, word32 *outLen, struct ecc_key* key);
+    MATH_INT_T* r, MATH_INT_T* s, byte* out, word32 *outLen, struct ecc_key* key);
 
 WOLFSSL_LOCAL int se050_ecc_verify_hash_ex(const byte* hash, word32 hashlen,
-    mp_int* r, mp_int* s, struct ecc_key* key, int* res);
+    MATH_INT_T* r, MATH_INT_T* s, struct ecc_key* key, int* res);
 
 WOLFSSL_LOCAL int se050_ecc_create_key(struct ecc_key* key, int curve_id,
     int keySize);


### PR DESCRIPTION
The SE050 port won't compile in the latest wolfSSL. This patch:

* Updates the documentation
* Fixes a missing `#ifdef` that breaks the build
* Changes the use of `mp_int` to `MATH_INT_T`
* Fixes compiler error with `ecc.c`
* Adds a tiny bit of extra debugging info

# Testing

Tested with an SE050 on a Raspberry Pi.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
