### PR TITLE
ML-KEM/Kyber: cache A from key generation for decapsulation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1399,6 +1399,9 @@ do
   small)
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_KYBER_SMALL"
     ;;
+  cache-a)
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_MLKEM_CACHE_A"
+    ;;
   512)
     ENABLED_KYBER512=yes
     ;;

--- a/wolfssl/wolfcrypt/wc_kyber.h
+++ b/wolfssl/wolfcrypt/wc_kyber.h
@@ -62,6 +62,7 @@ enum {
     KYBER_FLAG_PUB_SET  = 0x0002,
     KYBER_FLAG_BOTH_SET = 0x0003,
     KYBER_FLAG_H_SET    = 0x0004,
+    KYBER_FLAG_A_SET    = 0x0008,
 
     /* 2 bits of random used to create noise value. */
     KYBER_CBD_ETA2          = 2,
@@ -137,6 +138,10 @@ struct KyberKey {
     byte h[KYBER_SYM_SZ];
     /* Randomizer for decapsulation. */
     byte z[KYBER_SYM_SZ];
+#ifdef WOLFSSL_MLKEM_CACHE_A
+    /* A matrix from key generation. */
+    sword16 a[KYBER_MAX_K * KYBER_MAX_K * KYBER_N];
+#endif
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
# Description

Matrix A is expensive to calculate.
Usage of ML-KEM/Kyber is
  1. First peer generates a key and sends public to second peer.
2. Second peer encapsulates secret with public key and sends to first peer.
3. First peer decapsulates (including encapsulating to ensure same as seen) with key from key generation.
Caching A keeps the matrix A for encapsulation part of decapsulation.
The matrix needs to be transposed for encapsulation.

# Testing

Regression tested ML-KEM/Kyber.

```
./autogen.sh
./configure --enable-kyber=all,cache-a
./wolfcrypt/benchmark/benchmark -kyber
```
Performance of decapasulation wiill significantly improve.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
