### PR TITLE
test_dual_alg_ecdsa_mldsa: fix decoded cert leak.

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -1741,6 +1741,7 @@ static int test_dual_alg_ecdsa_mldsa(void)
         cm = NULL;
     }
 
+    wc_FreeDecodedCert(&d_cert);
     wc_ecc_free(&ca_key);
     wc_MlDsaKey_Free(&alt_ca_key);
     wc_FreeRng(&rng);


### PR DESCRIPTION
# Description

Fix oversight from added test:
- https://github.com/wolfSSL/wolfssl/pull/8425

A `wc_FreeDecodedCert()` call was missing.
# Testing

Reproduced with `wolfssl-multi-test.sh`:

```
./wolfssl-multi-test.sh --no-result-cache \
  --with-prepared-wolfssl-workspace=/home/jordan/work/wolfssl/ \
  quantum-safe-wolfssl-all-intelasm-sp-asm-sanitizer
```
