### PR TITLE
Fix cmake lean_tls build

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -83,5 +83,25 @@ jobs:
         cmake --build .
         cmake --install .
 
+        # clean up
+        cd ..
+        rm -rf build
+
         # Kyber Cmake broken
         # -DWOLFSSL_KYBER:BOOL=yes
+
+# build "lean-tls" wolfssl
+    - name: Build wolfssl with lean-tls
+      working-directory: ./wolfssl
+      run: |
+        mkdir build
+        cd build
+        cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DWOLFSSL_INSTALL=yes -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/install" \
+            -DWOLFSSL_LEAN_TLS:BOOL=yes \
+            ..
+        cmake --build .
+        cmake --install .
+
+        # clean up
+        cd ..
+        rm -rf build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1141,8 +1141,7 @@ if(NOT WOLFSSL_MEMORY)
 else()
     # turn off memory cb if leanpsk or leantls on
     if(WOLFSSL_LEAN_PSK OR WOLFSSL_LEAN_TLS)
-        # but don't turn on NO_WOLFSSL_MEMORY because using own
-        override_cache(WOLFSSL_MEMORY "no")
+        list(APPEND WOLFSSL_DEFINITIONS "-DNO_WOLFSSL_MEMORY")
     endif()
 endif()
 


### PR DESCRIPTION
# Description

Cmake build with `-DWOLFSSL_LEAN_TLS=ON` should also add `NO_WOLFSSL_MEMORY`

Fixes #8456 

# Testing

```
wolfssl/build$ cmake .. -DWOLFSSL_LEAN_TLS=ON
wolfssl/build$ cmake --build .
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
