### PR TITLE
20250217-fixes

### DIFF
--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -2921,8 +2921,13 @@ static int PKCS7_EncodeSigned(wc_PKCS7* pkcs7,
     /* SignerIdentifier */
     if (pkcs7->sidType == CMS_ISSUER_AND_SERIAL_NUMBER) {
         /* IssuerAndSerialNumber */
-        esd->issuerSnSz = (word32)SetSerialNumber(pkcs7->issuerSn, pkcs7->issuerSnSz,
+        ret = SetSerialNumber(pkcs7->issuerSn, pkcs7->issuerSnSz,
                                           esd->issuerSn, MAX_SN_SZ, MAX_SN_SZ);
+        if (ret < 0) {
+            idx = ret;
+            goto out;
+        }
+        esd->issuerSnSz = (word32)ret;
         signerInfoSz += esd->issuerSnSz;
         esd->issuerNameSz = SetSequence(pkcs7->issuerSz, esd->issuerName);
         signerInfoSz += esd->issuerNameSz + pkcs7->issuerSz;


### PR DESCRIPTION
`wolfcrypt/src/pkcs7.c`: in `PKCS7_EncodeSigned()`, check for error from `SetSerialNumber()`.
