### PR TITLE
Ed25519: fix tests to compile with feature defines

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -54725,7 +54725,11 @@ static int test_wolfSSL_private_keys(void)
     ExpectNotNull(ssl = SSL_new(ctx));
 
     #if !defined(NO_CHECK_PRIVATE_KEY)
+    #ifdef HAVE_ED25519_MAKE_KEY
     ExpectIntNE(wolfSSL_check_private_key(ssl), WOLFSSL_SUCCESS);
+    #else
+    ExpectIntEQ(wolfSSL_check_private_key(ssl), WOLFSSL_SUCCESS);
+    #endif
     #endif
 
     SSL_free(ssl);

--- a/wolfcrypt/src/ge_operations.c
+++ b/wolfcrypt/src/ge_operations.c
@@ -9392,7 +9392,7 @@ B is the Ed25519 base point (x,4/5) with x positive.
 int ge_double_scalarmult_vartime(ge_p2 *r, const unsigned char *a,
                                  const ge_p3 *A, const unsigned char *b)
 {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
   signed char *aslide = NULL;
   signed char *bslide = NULL;
   ge_cached *Ai = NULL; /* A,3A,5A,7A,9A,11A,13A,15A */
@@ -9413,7 +9413,7 @@ int ge_double_scalarmult_vartime(ge_p2 *r, const unsigned char *a,
 #endif
   int i;
 
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
   if (((aslide = (signed char *)XMALLOC(SLIDE_SIZE, NULL, DYNAMIC_TYPE_TMP_BUFFER))== NULL) ||
       ((bslide = (signed char *)XMALLOC(SLIDE_SIZE, NULL, DYNAMIC_TYPE_TMP_BUFFER))== NULL) ||
       ((Ai = (ge_cached *)XMALLOC(8 * sizeof(*Ai), NULL, DYNAMIC_TYPE_TMP_BUFFER))== NULL) ||
@@ -9475,7 +9475,7 @@ int ge_double_scalarmult_vartime(ge_p2 *r, const unsigned char *a,
   }
 #endif
 
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
   out:
 
   XFREE(aslide, NULL, DYNAMIC_TYPE_TMP_BUFFER);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -36697,23 +36697,33 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ed25519_test(void)
         ERROR_OUT(WC_TEST_RET_ENC_EC(ret), cleanup);
     #endif
 #else
-    wc_ed25519_init_ex(key, HEAP_HINT, devId);
-    wc_ed25519_init_ex(key2, HEAP_HINT, devId);
+    ret = wc_ed25519_init_ex(key, HEAP_HINT, devId);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), cleanup);
+    ret = wc_ed25519_init_ex(key2, HEAP_HINT, devId);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), cleanup);
     #if !defined(NO_ASN) && defined(HAVE_ED25519_SIGN)
-    wc_ed25519_init_ex(key3, HEAP_HINT, devId);
+    ret = wc_ed25519_init_ex(key3, HEAP_HINT, devId);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), cleanup);
     #endif
 #endif
 
 #ifdef HAVE_ED25519_MAKE_KEY
-    wc_ed25519_make_key(&rng, ED25519_KEY_SIZE, key);
-    wc_ed25519_make_key(&rng, ED25519_KEY_SIZE, key2);
+    ret = wc_ed25519_make_key(&rng, ED25519_KEY_SIZE, key);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), cleanup);
+    ret = wc_ed25519_make_key(&rng, ED25519_KEY_SIZE, key2);
+    if (ret != 0)
+        ERROR_OUT(WC_TEST_RET_ENC_EC(ret), cleanup);
 #endif
 
     /* helper functions for signature and key size */
     keySz = (word32)wc_ed25519_size(key);
     sigSz = (word32)wc_ed25519_sig_size(key);
 
-#if defined(HAVE_ED25519_SIGN) && defined(HAVE_ED25519_KEY_EXPORT) &&\
+#if defined(HAVE_ED25519_SIGN) && defined(HAVE_ED25519_KEY_EXPORT) && \
         defined(HAVE_ED25519_KEY_IMPORT)
     for (i = 0; i < 6; i++) {
         outlen = sizeof(out);
@@ -36788,6 +36798,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ed25519_test(void)
 #endif /* HAVE_ED25519_VERIFY */
     }
 
+#ifdef HAVE_ED25519_VERIFY
     {
         /* Run tests for some rare code paths */
         /* sig is exactly equal to the order */
@@ -36860,6 +36871,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ed25519_test(void)
         if (ret != WC_NO_ERR_TRACE(SIG_VERIFY_E))
             ERROR_OUT(WC_TEST_RET_ENC_EC(ret), cleanup);
     }
+#endif /* HAVE_ED25519_VERIFY */
 
     ret = ed25519ctx_test();
     if (ret != 0)
@@ -36928,18 +36940,14 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t ed25519_test(void)
 
     if (XMEMCMP(out, sigs[0], 64))
         ERROR_OUT(WC_TEST_RET_ENC_NC, cleanup);
-
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-    wc_ed25519_delete(key3, &key3);
-#else
-    wc_ed25519_free(key3);
-#endif
 #endif /* NO_ASN */
 #endif /* HAVE_ED25519_SIGN && HAVE_ED25519_KEY_EXPORT && HAVE_ED25519_KEY_IMPORT */
 
+#if defined(HAVE_ED25519_KEY_IMPORT)
     ret = ed25519_test_check_key();
     if (ret < 0)
         goto cleanup;
+#endif
 #ifdef WOLFSSL_TEST_CERT
     ret = ed25519_test_cert();
     if (ret < 0)
@@ -36957,9 +36965,15 @@ cleanup:
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     wc_ed25519_delete(key, &key);
     wc_ed25519_delete(key2, &key2);
+#if !defined(NO_ASN) && defined(HAVE_ED25519_SIGN)
+    wc_ed25519_delete(key3, &key3);
+#endif
 #else
     wc_ed25519_free(key);
     wc_ed25519_free(key2);
+#if !defined(NO_ASN) && defined(HAVE_ED25519_SIGN)
+    wc_ed25519_free(key3);
+#endif
 #endif
 
 #if defined(HAVE_HASHDRBG) || defined(NO_RC4)


### PR DESCRIPTION
# Description

ge_operations.c: USe WOLFSSL_NO_MALLOC rather than WOLFSSL_SP_NO_MALLOC.

# Testing

./configure '--disable-shared' '--enable-curve25519' '--enable-ed25519' 'CFLAGS=-DNO_ED25519_VERIFY'
make

./configure --disable-shared --enable-curve25519 --enable-ed25519 "CFLAGS=-DNO_ED25519_KEY_IMPORT"
make

./configure '--disable-shared' '--enable-curve25519' '--enable-ed25519' 'CFLAGS=-DNO_ED25519_MAKE_KEY -DNO_ED25519_SIGN' '--enable-opensslall'
make
/tests/unit.test -test_wolfSSL_private_keys

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
