### PR TITLE
20250220-misc-UnalignedWord64

### DIFF
--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -254,36 +254,6 @@ WC_MISC_STATIC WC_INLINE void writeUnalignedWords32(byte *out, const word32 *in,
 
 #if defined(WORD64_AVAILABLE) && !defined(WOLFSSL_NO_WORD64_OPS)
 
-#ifdef WOLFSSL_X86_64_BUILD
-
-WC_MISC_STATIC WC_INLINE word64 readUnalignedWord64(const byte *in)
-{
-    return ((word64*)in)[0];
-}
-
-WC_MISC_STATIC WC_INLINE word64 writeUnalignedWord64(void *out, word64 in)
-{
-    return ((word64*)out)[0] = in;
-}
-
-WC_MISC_STATIC WC_INLINE void readUnalignedWords64(word64 *out, const byte *in,
-                                                   size_t count)
-{
-    const word64 *in_word64 = (const word64 *)in;
-    while (count-- > 0)
-        *out++ = *in_word64++;
-}
-
-WC_MISC_STATIC WC_INLINE void writeUnalignedWords64(byte *out, const word64 *in,
-                                                    size_t count)
-{
-    word64 *out_word64 = (word64 *)out;
-    while (count-- > 0)
-        *out_word64++ = *in++;
-}
-
-#else
-
 WC_MISC_STATIC WC_INLINE word64 readUnalignedWord64(const byte *in)
 {
     if (((wc_ptr_t)in & (wc_ptr_t)(sizeof(word64) - 1U)) == (wc_ptr_t)0)
@@ -330,8 +300,6 @@ WC_MISC_STATIC WC_INLINE void writeUnalignedWords64(byte *out, const word64 *in,
         XMEMCPY(out, in, count * sizeof(*in));
     }
 }
-
-#endif
 
 WC_MISC_STATIC WC_INLINE word64 rotlFixed64(word64 x, word64 y)
 {

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -17157,18 +17157,18 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t camellia_test(void)
     wc_Camellia cam;
     WOLFSSL_SMALL_STACK_STATIC const test_vector_t testVectors[] =
     {
-        {CAM_ECB_ENC, pte, ive, c1, k1, sizeof(k1), -114},
-        {CAM_ECB_ENC, pte, ive, c2, k2, sizeof(k2), -115},
-        {CAM_ECB_ENC, pte, ive, c3, k3, sizeof(k3), -116},
-        {CAM_ECB_DEC, pte, ive, c1, k1, sizeof(k1), -117},
-        {CAM_ECB_DEC, pte, ive, c2, k2, sizeof(k2), -118},
-        {CAM_ECB_DEC, pte, ive, c3, k3, sizeof(k3), -119},
-        {CAM_CBC_ENC, ptc, ivc, c4, k4, sizeof(k4), -120},
-        {CAM_CBC_ENC, ptc, ivc, c5, k5, sizeof(k5), -121},
-        {CAM_CBC_ENC, ptc, ivc, c6, k6, sizeof(k6), -122},
-        {CAM_CBC_DEC, ptc, ivc, c4, k4, sizeof(k4), -123},
-        {CAM_CBC_DEC, ptc, ivc, c5, k5, sizeof(k5), -124},
-        {CAM_CBC_DEC, ptc, ivc, c6, k6, sizeof(k6), -125}
+        {CAM_ECB_ENC, pte, ive, c1, k1, sizeof(k1), 114},
+        {CAM_ECB_ENC, pte, ive, c2, k2, sizeof(k2), 115},
+        {CAM_ECB_ENC, pte, ive, c3, k3, sizeof(k3), 116},
+        {CAM_ECB_DEC, pte, ive, c1, k1, sizeof(k1), 117},
+        {CAM_ECB_DEC, pte, ive, c2, k2, sizeof(k2), 118},
+        {CAM_ECB_DEC, pte, ive, c3, k3, sizeof(k3), 119},
+        {CAM_CBC_ENC, ptc, ivc, c4, k4, sizeof(k4), 120},
+        {CAM_CBC_ENC, ptc, ivc, c5, k5, sizeof(k5), 121},
+        {CAM_CBC_ENC, ptc, ivc, c6, k6, sizeof(k6), 122},
+        {CAM_CBC_DEC, ptc, ivc, c4, k4, sizeof(k4), 123},
+        {CAM_CBC_DEC, ptc, ivc, c5, k5, sizeof(k5), 124},
+        {CAM_CBC_DEC, ptc, ivc, c6, k6, sizeof(k6), 125}
     };
     int i, testsSz;
     int ret;
@@ -17178,7 +17178,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t camellia_test(void)
     for (i = 0; i < testsSz; i++) {
         if (wc_CamelliaSetKey(&cam, testVectors[i].key, testVectors[i].keySz,
                                                         testVectors[i].iv) != 0)
-            return testVectors[i].errorCode;
+            return WC_TEST_RET_ENC_I(testVectors[i].errorCode);
 
         switch (testVectors[i].type) {
             case CAM_ECB_ENC:
@@ -17186,28 +17186,28 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t camellia_test(void)
                                                 testVectors[i].plaintext);
                 if (ret != 0 || XMEMCMP(out, testVectors[i].ciphertext,
                                                         WC_CAMELLIA_BLOCK_SIZE))
-                    return testVectors[i].errorCode;
+                    return WC_TEST_RET_ENC_I(testVectors[i].errorCode);
                 break;
             case CAM_ECB_DEC:
                 ret = wc_CamelliaDecryptDirect(&cam, out,
                                                     testVectors[i].ciphertext);
                 if (ret != 0 || XMEMCMP(out, testVectors[i].plaintext,
                                                         WC_CAMELLIA_BLOCK_SIZE))
-                    return testVectors[i].errorCode;
+                    return WC_TEST_RET_ENC_I(testVectors[i].errorCode);
                 break;
             case CAM_CBC_ENC:
                 ret = wc_CamelliaCbcEncrypt(&cam, out, testVectors[i].plaintext,
                                                            WC_CAMELLIA_BLOCK_SIZE);
                 if (ret != 0 || XMEMCMP(out, testVectors[i].ciphertext,
                                                         WC_CAMELLIA_BLOCK_SIZE))
-                    return testVectors[i].errorCode;
+                    return WC_TEST_RET_ENC_I(testVectors[i].errorCode);
                 break;
             case CAM_CBC_DEC:
                 ret = wc_CamelliaCbcDecrypt(&cam, out,
                                 testVectors[i].ciphertext, WC_CAMELLIA_BLOCK_SIZE);
                 if (ret != 0 || XMEMCMP(out, testVectors[i].plaintext,
                                                            WC_CAMELLIA_BLOCK_SIZE))
-                    return testVectors[i].errorCode;
+                    return WC_TEST_RET_ENC_I(testVectors[i].errorCode);
                 break;
             default:
                 break;

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -150,9 +150,17 @@ decouple library dependencies with standard string, memory and so on.
         /* The C standards don't define empty aggregates, but gcc and clang do.
          * We need to accommodate them for one of the same reasons C++ does --
          * conditionally empty aggregates, e.g. in hash.h.
+         *
+         * Nonetheless, in C++, empty aggregates wind up with size 1.  If we use
+         * the [0] construct and the header is compiled by clang++, it warns
+         * "struct has size 0 in C, size 1 in C++ [-Wextern-c-compat]", despite
+         * the extern "C" wrapper.  We sidestep this warning by recognizing
+         * here that C++ doesn't support truly empty aggregates.  LLVM, for its part,
+         * deprecates compilation of C code as C++ using clang++.
          */
         #if !defined(WOLF_C89) && defined(__GNUC__) &&  \
                 !defined(__STRICT_ANSI__) &&            \
+                !defined(__cplusplus) &&                \
                 defined(HAVE_ANONYMOUS_INLINE_AGGREGATES)
             #define HAVE_EMPTY_AGGREGATES 1
         #endif


### PR DESCRIPTION
`misc.c`: undo changes in 82b50f19c6 "when Intel x64 build, assume able to read/write unaligned" -- provokes sanitizer on amd64, and is not portable (e.g. different behavior on Intel vs AMD).  all performance-sensitive `word64` reads/writes should be on known-aligned data.

`wolfssl/wolfcrypt/types.h`: don't define `HAVE_EMPTY_AGGREGATES` when `defined(__cplusplus)` (fixes #8478).

`wolfcrypt/test/test.c`: fix return values in `camellia_test()` (also fixes some false positive `-Wreturn-stack-address`es from `clang++`).

tested with `wolfssl-multi-test.sh ... quantum-safe-wolfssl-all-noasm-sanitizer 'quantum-safe-wolfssl-all-clang\+\+-latest'` (the latter a new scenario).
