### PR TITLE
Update README.md to reflect FIPS 140-3 validated Certificate #4718

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ OpenSSL.
 
 wolfSSL is powered by the wolfCrypt cryptography library. Two versions of
 wolfCrypt have been FIPS 140-2 validated (Certificate #2425 and
-certificate #3389). FIPS 140-3 validation is in progress. For additional
+certificate #3389). FIPS 140-3 validated (Certificate #4718). For additional
 information, visit the [wolfCrypt FIPS FAQ](https://www.wolfssl.com/license/fips/)
 or contact fips@wolfssl.com.
 


### PR DESCRIPTION
# Description

Updated README.md to reflect wolfssl [completed FIPS 140-3 Cryptographic Module Validation Program Certificate  #4718](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4718).

Fixes zd# n/a

# Testing

README edit only, no testing.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
