### PR TITLE
fix nds build for libnds 2

### DIFF
--- a/IDE/NDS/README.md
+++ b/IDE/NDS/README.md
@@ -15,13 +15,16 @@ $ ./configure \
     AR=$DEVKITARM/bin/arm-none-eabi-ar \
     STRIP=$DEVKITARM/bin/arm-none-eabi-strip \
     RANLIB=$DEVKITARM/bin/arm-none-eabi-ranlib \
-    LIBS="-lfat -lnds9" \
-    LDFLAGS="-L/opt/devkitpro/libnds/lib" \
+    LIBS="-lfat -lnds9 -lcalico_ds9" \
+    LDFLAGS="-L$DEVKITPRO/libnds/lib \
+        -L$DEVKITPRO/calico/lib" \
     --prefix=$DEVKITPRO/portlibs/nds \
     CFLAGS="-march=armv5te -mtune=arm946e-s \
-        --specs=ds_arm9.specs -DARM9 -DWOLFSSL_NDS \
+        -specs=$DEVKITPRO/calico/share/ds9.specs \
+        -D__NDS__ -DARM9 -D__thumb__=0 \
         -DWOLFSSL_MELONDS \
-        -DWOLFSSL_USER_IO \
+        -DWOLFSSL_NDS -DWOLFSSL_USER_IO \
+        -I$DEVKITPRO/calico/include \
         -I$DEVKITPRO/libnds/include" \
     --enable-fastmath --disable-benchmark \
     --disable-shared --disable-examples --disable-ecc
@@ -37,12 +40,15 @@ $ ./configure \
     AR=$DEVKITARM/bin/arm-none-eabi-ar \
     STRIP=$DEVKITARM/bin/arm-none-eabi-strip \
     RANLIB=$DEVKITARM/bin/arm-none-eabi-ranlib \
-    LIBS="-lfat -lnds9" \
-    LDFLAGS="-L/opt/devkitpro/libnds/lib" \
+    LIBS="-lfat -lnds9 -lcalico_ds9" \
+    LDFLAGS="-L$DEVKITPRO/libnds/lib \
+        -L$DEVKITPRO/calico/lib" \
     --prefix=$DEVKITPRO/portlibs/nds \
     CFLAGS="-march=armv5te -mtune=arm946e-s \
-        --specs=ds_arm9.specs -DARM9 -DWOLFSSL_NDS \
-        -DWOLFSSL_USER_IO \
+        -specs=$DEVKITPRO/calico/share/ds9.specs \
+        -D__NDS__ -DARM9 -D__thumb__=0 \
+        -DWOLFSSL_NDS -DWOLFSSL_USER_IO \
+        -I$DEVKITPRO/calico/include \
         -I$DEVKITPRO/libnds/include" \
     --enable-fastmath --disable-benchmark \
     --disable-shared --disable-examples --disable-ecc


### PR DESCRIPTION
# Description

libnds got a v2 update recently https://devkitpro.org/viewtopic.php?f=13&t=9662#p18269 and it broke the build due to this: https://github.com/devkitPro/devkitarm-rules/commit/6f96e768dea3d04d217266f6493156a0be942262

# Checklist

 - [x] updated appropriate READMEs

Edit: nvm, even on wii the --enable-opensslextra doesn't seem give me the funcs I want regardless. `BN_CTX_new();` is always undefined and not in the wolfssl lib...