### PR TITLE
correct comment for _WINSOCKAPI_ macro manipulation

### DIFF
--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -38,7 +38,7 @@
     #define _WINSOCKAPI_ /* block inclusion of winsock.h header file */
     #include <windows.h>
     #include <wincrypt.h>
-    #undef _WINSOCKAPI_
+    #undef _WINSOCKAPI_ /* undefine it for MINGW winsock2.h header file */
 
     /* mingw gcc does not support pragma comment, and the
      * linking with crypt32 is handled in configure.ac */

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -14584,7 +14584,7 @@ void bench_sphincsKeySign(byte level, byte optim)
     #define WIN32_LEAN_AND_MEAN
     #define _WINSOCKAPI_ /* block inclusion of winsock.h header file */
     #include <windows.h>
-    #undef _WINSOCKAPI_
+    #undef _WINSOCKAPI_ /* undefine it for MINGW winsock2.h header file */
 
     double current_time(int reset)
     {

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -90,7 +90,7 @@ This library contains implementation for the random number generator.
     #define _WINSOCKAPI_ /* block inclusion of winsock.h header file */
     #include <windows.h>
     #include <wincrypt.h>
-    #undef _WINSOCKAPI_
+    #undef _WINSOCKAPI_ /* undefine it for MINGW winsock2.h header file */
 #elif defined(HAVE_WNR)
     #include <wnr.h>
     #include <wolfssl/wolfcrypt/logging.h>

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -156,7 +156,7 @@
     #elif defined(__NT__)
         #define _WINSOCKAPI_ /* block inclusion of winsock.h header file */
         #include <windows.h>
-        #undef _WINSOCKAPI_
+        #undef _WINSOCKAPI_ /* undefine it for MINGW winsock2.h header file */
     #elif defined(__LINUX__)
         #ifndef SINGLE_THREADED
             #define WOLFSSL_PTHREADS
@@ -169,7 +169,7 @@
     #else
         #define _WINSOCKAPI_ /* block inclusion of winsock.h header file */
         #include <windows.h>
-        #undef _WINSOCKAPI_
+        #undef _WINSOCKAPI_ /* undefine it for MINGW winsock2.h header file */
     #endif
 #elif defined(THREADX)
     #ifndef SINGLE_THREADED

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -2124,7 +2124,7 @@ static WC_INLINE unsigned int my_psk_client_cs_cb(WOLFSSL* ssl,
     #define WIN32_LEAN_AND_MEAN
     #define _WINSOCKAPI_ /* block inclusion of winsock.h header file */
     #include <windows.h>
-    #undef _WINSOCKAPI_
+    #undef _WINSOCKAPI_ /* undefine it for MINGW winsock2.h header file */
 
     static WC_INLINE double current_time(int reset)
     {

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -125,6 +125,7 @@
         #if defined(USE_WINDOWS_API)
             #define _WINSOCKAPI_ /* block inclusion of winsock.h header file */
             #include <windows.h>
+            #undef _WINSOCKAPI_ /* undefine it for MINGW winsock2.h header file */
             #include <process.h>
         #elif defined(__OS2__)
             #define INCL_DOSSEMAPHORES
@@ -143,6 +144,7 @@
         #if defined(USE_WINDOWS_API)
             #define _WINSOCKAPI_ /* block inclusion of winsock.h header file */
             #include <windows.h>
+            #undef _WINSOCKAPI_ /* undefine it for MINGW winsock2.h header file */
         #elif defined(__OS2__)
             #include <os2.h>
         #endif
@@ -162,8 +164,7 @@
         #if !defined(WOLFSSL_SGX) && !defined(WOLFSSL_NOT_WINDOWS_API)
             #define _WINSOCKAPI_ /* block inclusion of winsock.h header file. */
             #include <windows.h>
-            /* winsock2.h expects _WINSOCKAPI_ to be undef, and defines it. */
-            #undef _WINSOCKAPI_
+            #undef _WINSOCKAPI_ /* undefine it for MINGW winsock2.h header file */
             #ifndef WOLFSSL_USER_IO
                 #include <winsock2.h>
                 #include <ws2tcpip.h> /* required for InetPton */
@@ -1218,6 +1219,7 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
 #elif defined(_WIN32_WCE)
     #define _WINSOCKAPI_ /* block inclusion of winsock.h header file */
     #include <windows.h>
+    #undef _WINSOCKAPI_ /* undefine it for MINGW winsock2.h header file */
     #include <stdlib.h> /* For file system */
 
     time_t windows_time(time_t* timer);


### PR DESCRIPTION
# Description

add correct comment

The issue is with MINGW winsock2.h header file which is not compatible with Miscrosoft version
and handle **`_WINSOCKAPI_`** macro differently

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
