### PR TITLE
Add cert update to workflow

### DIFF
--- a/.github/workflows/mosquitto.yml
+++ b/.github/workflows/mosquitto.yml
@@ -77,6 +77,12 @@ jobs:
           ref: v${{ matrix.ref }}
           path: mosquitto
 
+      - name: Update certs
+        run: |
+            cd $GITHUB_WORKSPACE/mosquitto/test/ssl
+            ./gen.sh
+            cat all-ca.crt >> server.crt
+
       - name: Configure and build mosquitto
         run: |
             cd $GITHUB_WORKSPACE/mosquitto/


### PR DESCRIPTION
# Description

Mosquitto v2.0.18 test certs are expired. Adding a call to update the test certs in the workflow

### NOTE
Depends on https://github.com/wolfSSL/osp/pull/237

# Testing

GH workflow

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
