### PR TITLE
CRL: fix memory allocation failure leaks

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -14092,6 +14092,11 @@ void wolfSSL_X509_OBJECT_free(WOLFSSL_X509_OBJECT *obj)
         if (obj->type == WOLFSSL_X509_LU_X509) {
             wolfSSL_X509_free(obj->data.x509);
         }
+    #ifdef HAVE_CRL
+        else if (obj->type == WOLFSSL_X509_LU_CRL) {
+            wolfSSL_X509_CRL_free(obj->data.crl);
+        }
+    #endif
         else {
             /* We don't free as this will point to
              * store->cm->crl which we don't own */

--- a/src/x509_str.c
+++ b/src/x509_str.c
@@ -1912,6 +1912,7 @@ WOLF_STACK_OF(WOLFSSL_X509_OBJECT)* wolfSSL_X509_STORE_get0_objects(
 
 #ifdef HAVE_CRL
     if (store->cm->crl != NULL) {
+        int res;
         obj = wolfSSL_X509_OBJECT_new();
         if (obj == NULL) {
             WOLFSSL_MSG("wolfSSL_X509_OBJECT_new error");
@@ -1923,6 +1924,11 @@ WOLF_STACK_OF(WOLFSSL_X509_OBJECT)* wolfSSL_X509_STORE_get0_objects(
             goto err_cleanup;
         }
         obj->type = WOLFSSL_X509_LU_CRL;
+        wolfSSL_RefInc(&store->cm->crl->ref, &res);
+        if (res != 0) {
+            WOLFSSL_MSG("Failed to lock crl mutex");
+            goto err_cleanup;
+        }
         obj->data.crl = store->cm->crl;
     }
 #endif

--- a/tests/api.c
+++ b/tests/api.c
@@ -55756,7 +55756,6 @@ static int test_X509_STORE_get0_objects(void)
             ExpectIntEQ(X509_STORE_add_crl(store_cpy, crl), WOLFSSL_SUCCESS);
 
             ExpectNotNull(crl = X509_OBJECT_get0_X509_CRL(objCopy));
-            X509_CRL_free(crl);
             break;
         }
 #endif

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2638,6 +2638,9 @@ struct WOLFSSL_CRL {
     wolfSSL_CRL_mfd_t     mfd;
     int                   setup;         /* thread is setup predicate */
 #endif
+#ifdef OPENSSL_ALL
+    wolfSSL_Ref           ref;
+#endif
     void*                 heap;          /* heap hint for dynamic memory */
 };
 


### PR DESCRIPTION
# Description

On memory allocation failure, some functions were leaking memory.

Also add reference counting to CRL object so that a deep copy of a list of CRLs doesn't leak memory.
The test was explicitly freeing each CRL in the list.

# Testing

./configure '--disable-shared' '--enable-crl' '--enable-opensslall'
/test_X509_STORE_get0_objects was explicitly freeing the deep copied list.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
