### PR TITLE
test_wolfssl_EVP_aes_gcm: fix for mem fail testing

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -77198,7 +77198,7 @@ static int test_wolfssl_EVP_aes_gcm(void)
         ciphertxtSz += len;
         ExpectIntEQ(1, EVP_CIPHER_CTX_ctrl(&en[i], EVP_CTRL_GCM_GET_TAG,
             AES_BLOCK_SIZE, tag));
-        ExpectIntEQ(wolfSSL_EVP_CIPHER_CTX_cleanup(&en[i]), 1);
+        wolfSSL_EVP_CIPHER_CTX_cleanup(&en[i]);
 
         EVP_CIPHER_CTX_init(&de[i]);
         if (i == 0) {
@@ -77283,7 +77283,7 @@ static int test_wolfssl_EVP_aes_gcm(void)
         ExpectIntEQ(0, EVP_DecryptFinal_ex(&de[i], decryptedtxt, &len));
         ExpectIntEQ(0, len);
 
-        ExpectIntEQ(wolfSSL_EVP_CIPHER_CTX_cleanup(&de[i]), 1);
+        wolfSSL_EVP_CIPHER_CTX_cleanup(&de[i]);
     }
 #endif /* OPENSSL_EXTRA && !NO_AES && HAVE_AESGCM */
     return EXPECT_RESULT();


### PR DESCRIPTION
# Description

Fix test to not leak when memory allocation failure testing. When not supporting AES-GCM streaming, allocation failures occur. Always call cleanup.

# Testing

./configure '--disable-shared' '--enable-opensslextra' 'C_EXTRA_FLAGS=-DWOLFSSL_MEM_FAIL_COUNT' 'CC=clang -fsanitize=address' '--enable-debug'
MEM_FAIL_CNT=3 ./tests/unit.test -test_wolfssl_EVP_aes_gcm

master:
```
MemFailCount Total: 2
MemFailCount Frees: 1
```
(Also when MEM_FAIL_CNT equals: 5, 7, 9, 11, 13)

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
