### PR TITLE
PKCS Pad: public API to do PKCS padding

### DIFF
--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -8706,14 +8706,10 @@ int wc_PKCS7_SetContentType(wc_PKCS7* pkcs7, byte* contentType, word32 sz)
 /* return size of padded data, padded to blockSz chunks, or negative on error */
 int wc_PKCS7_GetPadSize(word32 inputSz, word32 blockSz)
 {
-    word32 padSz;
-
     if (blockSz == 0)
         return BAD_FUNC_ARG;
 
-    padSz = blockSz - (inputSz % blockSz);
-
-    return (int)padSz;
+    return (int)(blockSz - (inputSz % blockSz));
 }
 
 
@@ -8722,28 +8718,16 @@ int wc_PKCS7_GetPadSize(word32 inputSz, word32 blockSz)
 int wc_PKCS7_PadData(byte* in, word32 inSz, byte* out, word32 outSz,
                      word32 blockSz)
 {
-    int ret;
-    word32 i, padSz;
-
     if (in == NULL  || inSz == 0 ||
-        out == NULL || outSz == 0)
+        out == NULL || outSz == 0 || blockSz == 0)
         return BAD_FUNC_ARG;
 
-    ret = wc_PKCS7_GetPadSize(inSz, blockSz);
-    if (ret < 0)
-        return ret;
-    padSz = (word32)ret;
-
-    if (outSz < (inSz + padSz))
+    if (outSz < wc_PkcsPad(NULL, inSz, blockSz))
         return BAD_FUNC_ARG;
 
     XMEMCPY(out, in, inSz);
 
-    for (i = 0; i < padSz; i++) {
-        out[inSz + i] = (byte)padSz;
-    }
-
-    return (int)(inSz + padSz);
+    return (int)wc_PkcsPad(out, inSz, blockSz);
 }
 
 

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -729,6 +729,8 @@ WOLFSSL_API void wc_FreeDer(DerBuffer** pDer);
                                 word32 outputSz, byte *cipherIno, int type);
 #endif
 
+WOLFSSL_API word32 wc_PkcsPad(byte* buf, word32 sz, word32 blockSz);
+
 #ifndef NO_RSA
     WOLFSSL_API int wc_RsaPublicKeyDecode_ex(const byte* input, word32* inOutIdx,
         word32 inSz, const byte** n, word32* nSz, const byte** e, word32* eSz);


### PR DESCRIPTION
# Description

PKCS padding adds length of padding as repeated padding byte.
Use the new function in all places.

Fixes zd#19391

# Testing

./configure --enable-pkcs7
make test

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
