### PR TITLE
ARM ASM: available for SHA-384 only too

### DIFF
--- a/wolfcrypt/src/port/arm/armv8-32-sha512-asm.S
+++ b/wolfcrypt/src/port/arm/armv8-32-sha512-asm.S
@@ -33,7 +33,7 @@
 #ifdef WOLFSSL_ARMASM
 #if !defined(__aarch64__) && !defined(WOLFSSL_ARMASM_THUMB2)
 #ifndef WOLFSSL_ARMASM_INLINE
-#ifdef WOLFSSL_SHA512
+#if defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)
 #ifdef WOLFSSL_ARMASM_NO_NEON
 	.text
 	.type	L_SHA512_transform_len_k, %object
@@ -9284,7 +9284,7 @@ L_SHA512_transform_neon_len_start:
 	bx	lr
 	.size	Transform_Sha512_Len,.-Transform_Sha512_Len
 #endif /* !WOLFSSL_ARMASM_NO_NEON */
-#endif /* WOLFSSL_SHA512 */
+#endif /* WOLFSSL_SHA512 || WOLFSSL_SHA384 */
 #endif /* !__aarch64__ && !WOLFSSL_ARMASM_THUMB2 */
 #endif /* WOLFSSL_ARMASM */
 

--- a/wolfcrypt/src/port/arm/armv8-32-sha512-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-sha512-asm_c.c
@@ -49,7 +49,7 @@
 #define __asm__        __asm
 #define __volatile__   volatile
 #endif /* __KEIL__ */
-#ifdef WOLFSSL_SHA512
+#if defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)
 #include <wolfssl/wolfcrypt/sha512.h>
 
 #ifdef WOLFSSL_ARMASM_NO_NEON
@@ -9081,7 +9081,7 @@ void Transform_Sha512_Len(wc_Sha512* sha512_p, const byte* data_p, word32 len_p)
 }
 
 #endif /* !WOLFSSL_ARMASM_NO_NEON */
-#endif /* WOLFSSL_SHA512 */
+#endif /* WOLFSSL_SHA512 || WOLFSSL_SHA384 */
 #endif /* !__aarch64__ && !WOLFSSL_ARMASM_THUMB2 */
 #endif /* WOLFSSL_ARMASM */
 

--- a/wolfcrypt/src/port/arm/armv8-sha512-asm.S
+++ b/wolfcrypt/src/port/arm/armv8-sha512-asm.S
@@ -31,7 +31,7 @@
 #ifdef WOLFSSL_ARMASM
 #ifdef __aarch64__
 #ifndef WOLFSSL_ARMASM_INLINE
-#ifdef WOLFSSL_SHA512
+#if defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)
 #ifndef __APPLE__
 	.text
 	.type	L_SHA512_transform_neon_len_k, %object
@@ -1730,7 +1730,7 @@ L_sha512_len_crypto_begin:
 	.size	Transform_Sha512_Len_crypto,.-Transform_Sha512_Len_crypto
 #endif /* __APPLE__ */
 #endif /* WOLFSSL_ARMASM_CRYPTO_SHA512 */
-#endif /* WOLFSSL_SHA512 */
+#endif /* WOLFSSL_SHA512 || WOLFSSL_SHA384 */
 #endif /* __aarch64__ */
 #endif /* WOLFSSL_ARMASM */
 

--- a/wolfcrypt/src/port/arm/armv8-sha512-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-sha512-asm_c.c
@@ -34,7 +34,7 @@
 #ifdef WOLFSSL_ARMASM_INLINE
 #include <wolfssl/wolfcrypt/sha512.h>
 
-#ifdef WOLFSSL_SHA512
+#if defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)
 static const word64 L_SHA512_transform_neon_len_k[] = {
     0x428a2f98d728ae22, 0x7137449123ef65cd,
     0xb5c0fbcfec4d3b2f, 0xe9b5dba58189dbbc,
@@ -1582,7 +1582,7 @@ void Transform_Sha512_Len_crypto(wc_Sha512* sha512, const byte* data, word32 len
 }
 
 #endif /* WOLFSSL_ARMASM_CRYPTO_SHA512 */
-#endif /* WOLFSSL_SHA512 */
+#endif /* WOLFSSL_SHA512 || WOLFSSL_SHA384 */
 #endif /* __aarch64__ */
 #endif /* WOLFSSL_ARMASM */
 #endif /* WOLFSSL_ARMASM_INLINE */

--- a/wolfcrypt/src/port/arm/thumb2-sha512-asm.S
+++ b/wolfcrypt/src/port/arm/thumb2-sha512-asm.S
@@ -34,7 +34,7 @@
 #ifndef WOLFSSL_ARMASM_INLINE
 	.thumb
 	.syntax unified
-#ifdef WOLFSSL_SHA512
+#if defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)
 #ifdef WOLFSSL_ARMASM_NO_NEON
 	.text
 	.type	L_SHA512_transform_len_k, %object
@@ -3667,7 +3667,7 @@ L_SHA512_transform_len_start:
 	/* Cycle Count = 5021 */
 	.size	Transform_Sha512_Len,.-Transform_Sha512_Len
 #endif /* WOLFSSL_ARMASM_NO_NEON */
-#endif /* WOLFSSL_SHA512 */
+#endif /* WOLFSSL_SHA512 || WOLFSSL_SHA384 */
 #endif /* WOLFSSL_ARMASM_THUMB2 */
 #endif /* WOLFSSL_ARMASM */
 

--- a/wolfcrypt/src/port/arm/thumb2-sha512-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-sha512-asm_c.c
@@ -43,7 +43,7 @@
 #define __asm__        __asm
 #define __volatile__   volatile
 #endif /* __KEIL__ */
-#ifdef WOLFSSL_SHA512
+#if defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)
 #include <wolfssl/wolfcrypt/sha512.h>
 
 #ifdef WOLFSSL_ARMASM_NO_NEON
@@ -3589,7 +3589,7 @@ void Transform_Sha512_Len(wc_Sha512* sha512, const byte* data, word32 len)
 }
 
 #endif /* WOLFSSL_ARMASM_NO_NEON */
-#endif /* WOLFSSL_SHA512 */
+#endif /* WOLFSSL_SHA512 || WOLFSSL_SHA384 */
 #endif /* WOLFSSL_ARMASM_THUMB2 */
 #endif /* WOLFSSL_ARMASM */
 #endif /* WOLFSSL_ARMASM_INLINE */

--- a/wolfssl/wolfcrypt/sha512.h
+++ b/wolfssl/wolfcrypt/sha512.h
@@ -224,7 +224,7 @@ struct wc_Sha512 {
 
 #endif /* HAVE_FIPS */
 
-#ifdef WOLFSSL_SHA512
+#if defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)
 
 #ifdef WOLFSSL_ARMASM
 #ifdef __aarch64__


### PR DESCRIPTION
# Description

Add HAVE_SHA384 to check for whether assembly code is available.

# Testing

./configure -disable-shared --enable-cryptonly --disable-rsa --disable-dh --disable-ecc --disable-curve25519 --host=aarch64 CC=aarch64-linux-gnu-gcc LDFLAGS=--static --enable-armasm --disable-sha224 --enable-sha384 --disable-sha512
./configure --disable-shared --disable-shared --enable-cryptonly --disable-rsa --disable-dh --disable-ecc --disable-curve25519 --host=armv8 CC=arm-linux-gnueabihf-gcc LDFLAGS=--static --enable-armasm --disable-sha224 --enable-sha384 --disable-sha512
./configure --disable-shared --disable-shared --enable-cryptonly --disable-rsa --disable-dh --disable-ecc --disable-curve25519 --host=armv7a CC=arm-linux-gnueabihf-gcc LDFLAGS=--static --enable-armasm --disable-sha224 --enable-sha384 --disable-sha512
./configure --disable-shared --disable-shared --enable-cryptonly --disable-rsa --disable-dh --disable-ecc --disable-curve25519 --host=armv7m CC=arm-linux-gnueabi-gcc LDFLAGS=--static --enable-armasm --disable-sha224 --enable-sha384 --disable-sha512

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
