### PR TITLE
20250226-fixes

### DIFF
--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -30,6 +30,11 @@
         #error Unsupported kernel.
     #endif
 
+    #if defined(HAVE_FIPS) && defined(LINUXKM_LKCAPI_REGISTER_AESXTS) && defined(CONFIG_CRYPTO_MANAGER_EXTRA_TESTS)
+        /* CONFIG_CRYPTO_MANAGER_EXTRA_TESTS expects AES-XTS-384 to work, even when CONFIG_CRYPTO_FIPS, but FIPS 140-3 only allows AES-XTS-256 and AES-XTS-512. */
+        #error CONFIG_CRYPTO_MANAGER_EXTRA_TESTS is incompatible with FIPS wolfCrypt AES-XTS -- please reconfigure the target kernel to disable CONFIG_CRYPTO_MANAGER_EXTRA_TESTS.
+    #endif
+
     #ifdef HAVE_CONFIG_H
         #ifndef PACKAGE_NAME
             #error wc_port.h included before config.h

--- a/src/internal.c
+++ b/src/internal.c
@@ -41793,7 +41793,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                         ret = args->lastErr;
                         args->lastErr = 0; /* reset */
                         /* On error 'ret' will be negative */
-                        mask = (byte)((ret >> ((sizeof(ret) * 8) - 1)) & 0xFF) - 1;
+                        mask = (byte)(((unsigned int)ret >> ((sizeof(ret) * 8) - 1)) - 1);
 
                         /* build PreMasterSecret */
                         ssl->arrays->preMasterSecret[0] = ssl->chVersion.major;

--- a/tests/api/test_sha256.c
+++ b/tests/api/test_sha256.c
@@ -202,6 +202,7 @@ int test_wc_Sha256Transform(void)
 {
     EXPECT_DECLS;
 #if !defined(NO_SHA256) && (defined(OPENSSL_EXTRA) || defined(HAVE_CURL)) && \
+    !defined(WOLFSSL_KCAPI_HASH) && !defined(WOLFSSL_AFALG_HASH) && \
     !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || \
     (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 3)))
     DIGEST_TRANSFORM_FINAL_RAW_TEST(wc_Sha256, Sha256, SHA256,

--- a/tests/api/test_sha3.c
+++ b/tests/api/test_sha3.c
@@ -861,6 +861,7 @@ int test_wc_Shake128_Absorb(void)
 
     ExpectIntEQ(wc_InitShake128(&shake128, HEAP_HINT, INVALID_DEVID), 0);
 
+#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)
     ExpectIntEQ(wc_Shake128_Absorb(NULL     , NULL    , 1),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_Shake128_Absorb(&shake128, NULL    , 1),
@@ -869,6 +870,8 @@ int test_wc_Shake128_Absorb(void)
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
     ExpectIntEQ(wc_Shake128_Absorb(&shake128, NULL, 0), 0);
+#endif
+
     ExpectIntEQ(wc_Shake128_Absorb(&shake128, (byte*)"a", 1), 0);
 
     wc_Shake128_Free(&shake128);
@@ -885,6 +888,7 @@ int test_wc_Shake128_SqueezeBlocks(void)
 
     ExpectIntEQ(wc_InitShake128(&shake128, HEAP_HINT, INVALID_DEVID), 0);
 
+#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)
     ExpectIntEQ(wc_Shake128_SqueezeBlocks(NULL     , NULL, 1),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_Shake128_SqueezeBlocks(&shake128, NULL, 1),
@@ -893,6 +897,7 @@ int test_wc_Shake128_SqueezeBlocks(void)
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
     ExpectIntEQ(wc_Shake128_SqueezeBlocks(&shake128, NULL, 0), 0);
+#endif
     ExpectIntEQ(wc_Shake128_SqueezeBlocks(&shake128, hash, 1), 0);
 
     wc_Shake128_Free(&shake128);
@@ -1281,6 +1286,7 @@ int test_wc_Shake256_Absorb(void)
 
     ExpectIntEQ(wc_InitShake256(&shake256, HEAP_HINT, INVALID_DEVID), 0);
 
+#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)
     ExpectIntEQ(wc_Shake256_Absorb(NULL     , NULL    , 1),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_Shake256_Absorb(&shake256, NULL    , 1),
@@ -1289,6 +1295,7 @@ int test_wc_Shake256_Absorb(void)
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
     ExpectIntEQ(wc_Shake256_Absorb(&shake256, NULL, 0), 0);
+#endif
     ExpectIntEQ(wc_Shake256_Absorb(&shake256, (byte*)"a", 1), 0);
 
     wc_Shake256_Free(&shake256);
@@ -1305,6 +1312,7 @@ int test_wc_Shake256_SqueezeBlocks(void)
 
     ExpectIntEQ(wc_InitShake256(&shake256, HEAP_HINT, INVALID_DEVID), 0);
 
+#if !defined(HAVE_FIPS) || FIPS_VERSION_GE(7,0)
     ExpectIntEQ(wc_Shake256_SqueezeBlocks(NULL     , NULL, 1),
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
     ExpectIntEQ(wc_Shake256_SqueezeBlocks(&shake256, NULL, 1),
@@ -1313,6 +1321,7 @@ int test_wc_Shake256_SqueezeBlocks(void)
         WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
     ExpectIntEQ(wc_Shake256_SqueezeBlocks(&shake256, NULL, 0), 0);
+#endif
     ExpectIntEQ(wc_Shake256_SqueezeBlocks(&shake256, hash, 1), 0);
 
     wc_Shake256_Free(&shake256);

--- a/wolfssl/wolfcrypt/hash.h
+++ b/wolfssl/wolfcrypt/hash.h
@@ -83,16 +83,6 @@ enum wc_MACAlgorithm {
     sm3_mac
 };
 
-enum wc_HashFlags {
-    WC_HASH_FLAG_NONE =     0x00000000,
-    WC_HASH_FLAG_WILLCOPY = 0x00000001, /* flag to indicate hash will be copied */
-    WC_HASH_FLAG_ISCOPY =   0x00000002, /* hash is copy */
-#ifdef WOLFSSL_SHA3
-    WC_HASH_SHA3_KECCAK256 =0x00010000, /* Older KECCAK256 */
-#endif
-    WOLF_ENUM_DUMMY_LAST_ELEMENT(WC_HASH)
-};
-
 /* hash union */
 typedef union {
 #ifndef NO_MD5

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -264,10 +264,14 @@ struct wc_Sha256 {
 WOLFSSL_API int wc_InitSha256(wc_Sha256* sha);
 WOLFSSL_API int wc_InitSha256_ex(wc_Sha256* sha, void* heap, int devId);
 WOLFSSL_API int wc_Sha256Update(wc_Sha256* sha, const byte* data, word32 len);
+
+#if !defined(WOLFSSL_KCAPI_HASH) && !defined(WOLFSSL_AFALG_HASH)
 WOLFSSL_API int wc_Sha256FinalRaw(wc_Sha256* sha256, byte* hash);
+#endif
 WOLFSSL_API int wc_Sha256Final(wc_Sha256* sha256, byte* hash);
 WOLFSSL_API void wc_Sha256Free(wc_Sha256* sha256);
-#if defined(OPENSSL_EXTRA) || defined(HAVE_CURL)
+#if (defined(OPENSSL_EXTRA) || defined(HAVE_CURL)) && \
+    !defined(WOLFSSL_KCAPI_HASH) && !defined(WOLFSSL_AFALG_HASH)
 WOLFSSL_API int wc_Sha256Transform(wc_Sha256* sha, const unsigned char* data);
 #endif
 #if defined(WOLFSSL_HAVE_LMS) && !defined(WOLFSSL_LMS_FULL_HASH)

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1247,6 +1247,16 @@ typedef struct w64wrapper {
     #endif /* HAVE_SELFTEST */
     };
 
+    enum wc_HashFlags {
+        WC_HASH_FLAG_NONE =     0x00000000,
+        WC_HASH_FLAG_WILLCOPY = 0x00000001, /* flag to indicate hash will be copied */
+        WC_HASH_FLAG_ISCOPY =   0x00000002, /* hash is copy */
+    #ifdef WOLFSSL_SHA3
+        WC_HASH_SHA3_KECCAK256 =0x00010000, /* Older KECCAK256 */
+    #endif
+        WOLF_ENUM_DUMMY_LAST_ELEMENT(WC_HASH)
+    };
+
     /* cipher types */
     enum wc_CipherType {
         WC_CIPHER_NONE = 0,


### PR DESCRIPTION
linuxkm/linuxkm_wc_port.h: add #error if the user tries to use the kernel crypto fuzzer with FIPS AES-XTS (kernel bug).

src/internal.c: fix shiftTooManyBitsSigned in DefTicketEncCb().

tests/api/test_sha256.c and wolfssl/wolfcrypt/sha256.h: gate raw transform APIs (wc_Sha256Transform(), wc_Sha256FinalRaw()) and tests on !defined(WOLFSSL_KCAPI_HASH) && !defined(WOLFSSL_AFALG_HASH).

move enum wc_HashFlags from wolfssl/wolfcrypt/hash.h to wolfssl/wolfcrypt/types.h to resolve circular dependency detected by cross-armv7m-armasm-thumb-fips-140-3-dev-sp-asm-all-crypto-only.

add FIPS_VERSION_GE(7,0) gates to new null-arg tests in test_wc_Shake{128,256}_*().

optimize ByteReverseWords() for cases where only one operand is unaligned, and add correct handling of unaligned data in ByteReverseWords64() to resolve unaligned access sanitizer report in cross-aarch64_be-all-sp-asm-unittest-sanitizer.
