### PR TITLE
Tests api.c: sha512 big endian

### DIFF
--- a/tests/api/test_digest.h
+++ b/tests/api/test_digest.h
@@ -628,6 +628,30 @@ do {                                                                           \
 
 #endif
 
+#define DIGEST_TRANSFORM_FINAL_RAW_ALL_TEST(type, name, upper, abcBlockStr,    \
+                                            abcHashStr)                        \
+    type dgst;                                                                 \
+    const char* abc##name##Data = abcBlockStr;                                 \
+    const char* abcHash = abcHashStr;                                          \
+    byte abcData[WC_##upper##_BLOCK_SIZE];                                     \
+    byte hash[WC_##upper##_DIGEST_SIZE];                                       \
+                                                                               \
+    XMEMCPY(abcData, abc##name##Data, WC_##upper##_BLOCK_SIZE);                \
+                                                                               \
+    ExpectIntEQ(wc_Init##name(&dgst), 0);                                      \
+                                                                               \
+    /* Test bad args. */                                                       \
+    ExpectIntEQ(wc_##name##Transform(NULL, NULL), BAD_FUNC_ARG);               \
+    ExpectIntEQ(wc_##name##Transform(&dgst, NULL), BAD_FUNC_ARG);              \
+    ExpectIntEQ(wc_##name##Transform(NULL, (byte*)abc##name##Data),            \
+        BAD_FUNC_ARG);                                                         \
+                                                                               \
+    ExpectIntEQ(wc_##name##Transform(&dgst, (byte*)abcData), 0);               \
+    ExpectIntEQ(wc_##name##FinalRaw(&dgst, hash), 0);                          \
+    ExpectBufEQ(hash, (byte*)abcHash, WC_##upper##_DIGEST_SIZE);               \
+                                                                               \
+    wc_##name##Free(&dgst)
+
 #define DIGEST_FLAGS_TEST(type, name)                                          \
     type dgst;                                                                 \
     type dgst_copy;                                                            \

--- a/tests/api/test_sha512.c
+++ b/tests/api/test_sha512.c
@@ -257,7 +257,7 @@ int test_wc_Sha512Transform(void)
     (defined(OPENSSL_EXTRA) || defined(HAVE_CURL)) && \
     !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || \
     (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 3)))
-    DIGEST_TRANSFORM_FINAL_RAW_TEST(wc_Sha512, Sha512, SHA512,
+    DIGEST_TRANSFORM_FINAL_RAW_ALL_TEST(wc_Sha512, Sha512, SHA512,
                                     "\x80\x63\x62\x61\x00\x00\x00\x00"
                                     "\x00\x00\x00\x00\x00\x00\x00\x00"
                                     "\x00\x00\x00\x00\x00\x00\x00\x00"
@@ -458,7 +458,7 @@ int test_wc_Sha512_224Transform(void)
     (defined(OPENSSL_EXTRA) || defined(HAVE_CURL)) && \
     !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || \
     (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 3)))
-    DIGEST_TRANSFORM_FINAL_RAW_TEST(wc_Sha512, Sha512_224, SHA512_224,
+    DIGEST_TRANSFORM_FINAL_RAW_ALL_TEST(wc_Sha512, Sha512_224, SHA512_224,
                                     "\x61\x62\x63\x80\x00\x00\x00\x00"
                                     "\x00\x00\x00\x00\x00\x00\x00\x00"
                                     "\x00\x00\x00\x00\x00\x00\x00\x00"
@@ -656,7 +656,7 @@ int test_wc_Sha512_256Transform(void)
     (defined(OPENSSL_EXTRA) || defined(HAVE_CURL)) && \
     !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || \
     (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 3)))
-    DIGEST_TRANSFORM_FINAL_RAW_TEST(wc_Sha512, Sha512_256, SHA512_256,
+    DIGEST_TRANSFORM_FINAL_RAW_ALL_TEST(wc_Sha512, Sha512_256, SHA512_256,
                                     "\x61\x62\x63\x80\x00\x00\x00\x00"
                                     "\x00\x00\x00\x00\x00\x00\x00\x00"
                                     "\x00\x00\x00\x00\x00\x00\x00\x00"


### PR DESCRIPTION
# Description

Don't need to reverse bytes for SHA-512 Transform API.

# Testing

./configure '--disable-shared' '--host=ppc64' 'CC=powerpc64-linux-gnu-gcc' 'LDFLAGS=--static' '--enable-sha512' '--enable-opensslextra'
./tests/unit.test --api


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
