### PR TITLE
Add NULL_CIPHER_TYPE support to wolfSSL_EVP_CipherUpdate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2514,6 +2514,7 @@ if(WOLFSSL_EXAMPLES)
         tests/api/test_ascon.c
         tests/api/test_mlkem.c
         tests/api/test_ocsp.c
+        tests/api/test_evp.c
         tests/hash.c
         tests/srp.c
         tests/suites.c

--- a/tests/api.c
+++ b/tests/api.c
@@ -303,6 +303,7 @@
 #include <tests/api/test_mlkem.h>
 #include <tests/api/test_dtls.h>
 #include <tests/api/test_ocsp.h>
+#include <tests/api/test_evp.h>
 
 #if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && !defined(NO_TLS) && \
     !defined(NO_RSA)        && !defined(SINGLE_THREADED) && \
@@ -94611,6 +94612,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_EVP_ENCODE_CTX_free),
     TEST_DECL(test_wolfSSL_EVP_EncodeInit),
     TEST_DECL(test_wolfSSL_EVP_EncodeUpdate),
+    TEST_DECL(test_wolfSSL_EVP_CipherUpdate_Null),
     TEST_DECL(test_wolfSSL_EVP_EncodeFinal),
     TEST_DECL(test_wolfSSL_EVP_DecodeInit),
     TEST_DECL(test_wolfSSL_EVP_DecodeUpdate),

--- a/tests/api/include.am
+++ b/tests/api/include.am
@@ -16,6 +16,7 @@ tests_unit_test_SOURCES += tests/api/test_ascon.c
 tests_unit_test_SOURCES += tests/api/test_mlkem.c
 tests_unit_test_SOURCES += tests/api/test_dtls.c
 tests_unit_test_SOURCES += tests/api/test_ocsp.c
+tests_unit_test_SOURCES += tests/api/test_evp.c
 endif
 EXTRA_DIST += tests/api/api.h
 EXTRA_DIST += tests/api/test_md5.h
@@ -35,4 +36,5 @@ EXTRA_DIST += tests/api/test_dtls.h
 EXTRA_DIST += tests/api/test_ocsp.h
 EXTRA_DIST += tests/api/test_ocsp_test_blobs.h
 EXTRA_DIST += tests/api/create_ocsp_test_blobs.py
+EXTRA_DIST += tests/api/test_evp.h
 

--- a/tests/api/test_evp.c
+++ b/tests/api/test_evp.c
@@ -1,0 +1,70 @@
+/* test_evp.c
+ *
+ * Copyright (C) 2006-2025 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/options.h>
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+
+#include <tests/unit.h>
+#include <wolfssl/openssl/evp.h>
+#include <tests/api/test_evp.h>
+
+/* Test for NULL_CIPHER_TYPE in wolfSSL_EVP_CipherUpdate() */
+int test_wolfSSL_EVP_CipherUpdate_Null(void)
+{
+    EXPECT_DECLS;
+#ifdef OPENSSL_EXTRA
+    WOLFSSL_EVP_CIPHER_CTX* ctx;
+    const char* testData = "Test NULL cipher data";
+    unsigned char output[100];
+    int outputLen = 0;
+    int testDataLen = (int)XSTRLEN(testData);
+
+    /* Create and initialize the cipher context */
+    ctx = wolfSSL_EVP_CIPHER_CTX_new();
+    ExpectNotNull(ctx);
+
+    /* Initialize with NULL cipher */
+    ExpectIntEQ(wolfSSL_EVP_CipherInit_ex(ctx, wolfSSL_EVP_enc_null(), 
+                                         NULL, NULL, NULL, 1), WOLFSSL_SUCCESS);
+
+    /* Test encryption (which should just copy the data) */
+    ExpectIntEQ(wolfSSL_EVP_CipherUpdate(ctx, output, &outputLen, 
+                                        (const unsigned char*)testData, 
+                                        testDataLen), WOLFSSL_SUCCESS);
+    
+    /* Verify output length matches input length */
+    ExpectIntEQ(outputLen, testDataLen);
+    
+    /* Verify output data matches input data (no encryption occurred) */
+    ExpectIntEQ(XMEMCMP(output, testData, testDataLen), 0);
+
+    /* Clean up */
+    wolfSSL_EVP_CIPHER_CTX_free(ctx);
+#endif /* OPENSSL_EXTRA */
+
+    return EXPECT_RESULT();
+}
+

--- a/tests/api/test_evp.c
+++ b/tests/api/test_evp.c
@@ -47,17 +47,17 @@ int test_wolfSSL_EVP_CipherUpdate_Null(void)
     ExpectNotNull(ctx);
 
     /* Initialize with NULL cipher */
-    ExpectIntEQ(wolfSSL_EVP_CipherInit_ex(ctx, wolfSSL_EVP_enc_null(), 
+    ExpectIntEQ(wolfSSL_EVP_CipherInit_ex(ctx, wolfSSL_EVP_enc_null(),
                                          NULL, NULL, NULL, 1), WOLFSSL_SUCCESS);
 
     /* Test encryption (which should just copy the data) */
-    ExpectIntEQ(wolfSSL_EVP_CipherUpdate(ctx, output, &outputLen, 
-                                        (const unsigned char*)testData, 
+    ExpectIntEQ(wolfSSL_EVP_CipherUpdate(ctx, output, &outputLen,
+                                        (const unsigned char*)testData,
                                         testDataLen), WOLFSSL_SUCCESS);
-    
+
     /* Verify output length matches input length */
     ExpectIntEQ(outputLen, testDataLen);
-    
+
     /* Verify output data matches input data (no encryption occurred) */
     ExpectIntEQ(XMEMCMP(output, testData, testDataLen), 0);
 

--- a/tests/api/test_evp.h
+++ b/tests/api/test_evp.h
@@ -1,0 +1,27 @@
+/* test_evp.h
+ *
+ * Copyright (C) 2006-2025 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifndef WOLFSSL_TEST_EVP_H
+#define WOLFSSL_TEST_EVP_H
+
+int test_wolfSSL_EVP_CipherUpdate_Null(void);
+
+#endif /* WOLFSSL_TEST_EVP_H */

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -1059,6 +1059,14 @@ int wolfSSL_EVP_CipherUpdate(WOLFSSL_EVP_CIPHER_CTX *ctx,
     }
 
     switch (ctx->cipherType) {
+        case WC_NULL_CIPHER_TYPE:
+            if (out == NULL) {
+                WOLFSSL_MSG("Bad argument");
+                return WOLFSSL_FAILURE;
+            }
+            XMEMCPY(out, in, inl);
+            *outl = inl;
+            return WOLFSSL_SUCCESS;
 #if !defined(NO_AES) && defined(HAVE_AESGCM)
         case WC_AES_128_GCM_TYPE:
         case WC_AES_192_GCM_TYPE:


### PR DESCRIPTION
# Description

This PR implements support for the NULL_CIPHER_TYPE in wolfSSL_EVP_CipherUpdate() and adds a test case in tests/api/test_evp.c.

Fixes zd#18687

# Testing

The newly added unit tests fail if running `make check` without the patch to evp.c

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
