### PR TITLE
Fix shadow global declaration on old versions of gcc

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -25348,10 +25348,10 @@ int SendAsyncData(WOLFSSL* ssl)
  * 2 in SCR and we have plain data ready
  * Early data logic may bypass this logic in TLSv1.3 when appropriate.
  */
-static int ssl_in_handshake(WOLFSSL *ssl, int send)
+static int ssl_in_handshake(WOLFSSL *ssl, int send_value)
 {
     if (IsSCR(ssl)) {
-        if (send) {
+        if (send_value) {
             /* allow sending data in SCR */
             return 0;
         } else {

--- a/src/ssl_asn1.c
+++ b/src/ssl_asn1.c
@@ -1093,36 +1093,36 @@ static int wolfssl_asn1_integer_require_len(WOLFSSL_ASN1_INTEGER* a, int len,
  */
 WOLFSSL_ASN1_INTEGER* wolfSSL_ASN1_INTEGER_dup(const WOLFSSL_ASN1_INTEGER* src)
 {
-    WOLFSSL_ASN1_INTEGER* dup = NULL;
+    WOLFSSL_ASN1_INTEGER* dup_value = NULL;
 
     WOLFSSL_ENTER("wolfSSL_ASN1_INTEGER_dup");
 
     /* Check for object to duplicate. */
     if (src != NULL) {
         /* Create a new ASN.1 INTEGER object to be copied into. */
-        dup = wolfSSL_ASN1_INTEGER_new();
+        dup_value = wolfSSL_ASN1_INTEGER_new();
     }
     /* Check for object to copy into. */
-    if (dup != NULL) {
+    if (dup_value != NULL) {
         /* Copy simple fields. */
-        dup->length   = src->length;
-        dup->negative = src->negative;
-        dup->type     = src->type;
+        dup_value->length   = src->length;
+        dup_value->negative = src->negative;
+        dup_value->type     = src->type;
 
         if (!src->isDynamic) {
             /* Copy over data from/to fixed buffer. */
-            XMEMCPY(dup->intData, src->intData, WOLFSSL_ASN1_INTEGER_MAX);
+            XMEMCPY(dup_value->intData, src->intData, WOLFSSL_ASN1_INTEGER_MAX);
         }
-        else if (wolfssl_asn1_integer_require_len(dup, src->length, 0) == 0) {
-            wolfSSL_ASN1_INTEGER_free(dup);
-            dup = NULL;
+        else if (wolfssl_asn1_integer_require_len(dup_value, src->length, 0) == 0) {
+            wolfSSL_ASN1_INTEGER_free(dup_value);
+            dup_value = NULL;
         }
         else {
-            XMEMCPY(dup->data, src->data, (size_t)src->length);
+            XMEMCPY(dup_value->data, src->data, (size_t)src->length);
         }
     }
 
-    return dup;
+    return dup_value;
 }
 #endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL */
 

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -8259,9 +8259,9 @@ void wolfSSL_EVP_init(void)
     }
 #endif /* !NO_AES || !NO_DES3 */
 
-    static int IsCipherTypeAEAD(unsigned char cipherType)
+    static int IsCipherTypeAEAD(unsigned char cipherType_value)
     {
-        switch (cipherType) {
+        switch (cipherType_value) {
             case WC_AES_128_GCM_TYPE:
             case WC_AES_192_GCM_TYPE:
             case WC_AES_256_GCM_TYPE:

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -8216,7 +8216,7 @@ int sp_addmod_ct(const sp_int* a, const sp_int* b, const sp_int* m, sp_int* r)
  * @return  MP_OKAY on success.
  */
 static void _sp_submod_ct(const sp_int* a, const sp_int* b, const sp_int* m,
-    unsigned int max, sp_int* r)
+    unsigned int max_value, sp_int* r)
 {
 #ifndef SQR_MUL_ASM
     sp_int_sword w;
@@ -8237,7 +8237,7 @@ static void _sp_submod_ct(const sp_int* a, const sp_int* b, const sp_int* m,
     l = 0;
     h = 0;
 #endif
-    for (i = 0; i < max; i++) {
+    for (i = 0; i < max_value; i++) {
         /* Values past 'used' are not initialized. */
         mask_a += (i == a->used);
         mask_b += (i == b->used);


### PR DESCRIPTION
Old versions of gcc (4.3.3 at least) complain on local variables shadowing global names. Some of them are well-known unix function names like 'send' and 'dup'. Others are simply local collisions.

Simply rename the local variables to avoid the clash.

# Description

Please describe the scope of the fix or feature addition.

Simply rename of variables to avoid name collision

Fixes zd#

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
