### PR TITLE
Fixes for ECC non-blocking tests

### DIFF
--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -84,6 +84,7 @@ jobs:
         os: [ ubuntu-22.04, macos-latest ]
         user-settings: [
           # Add new user_settings.h here
+          'examples/configs/user_settings_eccnonblock.h',
           'examples/configs/user_settings_min_ecc.h',
           'examples/configs/user_settings_wolfboot_keytools.h',
           'examples/configs/user_settings_wolftpm.h',

--- a/examples/configs/include.am
+++ b/examples/configs/include.am
@@ -5,6 +5,7 @@ EXTRA_DIST += examples/configs/README.md
 EXTRA_DIST += examples/configs/user_settings_all.h
 EXTRA_DIST += examples/configs/user_settings_arduino.h
 EXTRA_DIST += examples/configs/user_settings_EBSnet.h
+EXTRA_DIST += examples/configs/user_settings_eccnonblock.h
 EXTRA_DIST += examples/configs/user_settings_espressif.h
 EXTRA_DIST += examples/configs/user_settings_fipsv2.h
 EXTRA_DIST += examples/configs/user_settings_fipsv5.h

--- a/examples/configs/user_settings_eccnonblock.h
+++ b/examples/configs/user_settings_eccnonblock.h
@@ -1,0 +1,138 @@
+/* user_settings_eccnonblock.h
+ *
+ * Copyright (C) 2006-2025 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* Example wolfSSL user_settings.h file for ECC only non-blocking crypto.
+ * See doc/dox_comments/header_files/ecc.h wc_ecc_set_nonblock for example.
+ */
+
+/* Settings based on this configure:
+./configure --enable-cryptonly --enable-ecc=nonblock --with-eccminsz=256 \
+    --enable-sp=nonblock,ec256,nomalloc --enable-sp-math --disable-sp-asm \
+    --disable-rsa --disable-dh \
+    CFLAGS="-DWOLFSSL_DEBUG_NONBLOCK -DSP_WORD_SIZE=32 -DECC_USER_CURVES \
+            -DWOLFSSL_PUBLIC_MP"
+*/
+
+/* Tested using:
+cp ./examples/configs/user_settings_eccnonblock.h user_settings.h
+./configure --enable-usersettings --enable-debug --disable-examples
+make
+./wolfcrypt/test/test/wolfcrypt
+*/
+
+/* Example test results:
+ecc_test_curve keySize = 32
+ECC non-block sign: 12301 times
+ECC non-block verify: 24109 times
+ECC non-block key gen: 11784 times
+ECC non-block shared secret: 11783 times
+
+ecc_test_curve keySize = 48
+ECC non-block sign: 18445 times
+ECC non-block verify: 36141 times
+ECC non-block key gen: 17672 times
+ECC non-block shared secret: 17671 times
+
+ecc_test_curve keySize = 66
+ECC non-block sign: 25021 times
+ECC non-block verify: 49019 times
+ECC non-block key gen: 23974 times
+ECC non-block shared secret: 23973 times
+*/
+
+#ifndef WOLFSSL_USER_SETTINGS_H
+#define WOLFSSL_USER_SETTINGS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Choose the ECC curve */
+#define ECC_USER_CURVES /* Manually specify curves enabled */
+#if   1 /* SECP256R1 */
+    #define ECC_MIN_KEY_SZ 256
+#elif 1 /* SECP384R1 */
+    #define HAVE_ECC384
+    #define NO_ECC256
+    #define ECC_MIN_KEY_SZ 384
+    #define WOLFSSL_SP_NO_256
+    #define WOLFSSL_SP_384
+#else /* SECP521R1 */
+    #define HAVE_ECC521
+    #define NO_ECC256
+    #define ECC_MIN_KEY_SZ 521
+    #define WOLFSSL_SP_NO_256
+    #define WOLFSSL_SP_521
+#endif
+
+/* Features */
+#define WOLFCRYPT_ONLY
+#define WOLFSSL_ASN_TEMPLATE
+#define WOLFSSL_PUBLIC_MP /* expose mp_ math API's */
+#define HAVE_HASHDRBG /* enable hash based pseudo RNG */
+
+/* ECC */
+#define HAVE_ECC
+#define WC_ECC_NONBLOCK
+#define ECC_TIMING_RESISTANT
+
+/* Math options */
+/* sp_c32.c */
+#define SP_WORD_SIZE 32
+#define WOLFSSL_HAVE_SP_ECC
+#define WOLFSSL_SP_SMALL
+#define WOLFSSL_SP_NO_MALLOC
+#define WOLFSSL_SP_NONBLOCK
+#define WOLFSSL_SP_MATH /* forces only single precision */
+
+/* Hashing */
+#define WOLFSL_SHA512
+#define WOLFSL_SHA384
+#undef NO_SHA256
+
+/* Debugging */
+#if 1
+    #undef  DEBUG_WOLFSSL
+    #define DEBUG_WOLFSSL
+    #define WOLFSSL_DEBUG_NONBLOCK
+#endif
+
+/* Disabled algorithms */
+#define NO_OLD_TLS
+#define NO_RSA
+#define NO_DH
+#define NO_PSK
+#define NO_MD4
+#define NO_MD5
+#define NO_SHA
+#define NO_DSA
+#define NO_DES3
+#define NO_BIG_INT
+#define NO_RC4
+#define WOLFSSL_NO_SHAKE128
+#define WOLFSSL_NO_SHAKE256
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* WOLFSSL_USER_SETTINGS_H */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -33268,6 +33268,7 @@ exit:
 /* ./configure --enable-ecc=nonblock --enable-sp=yes,nonblock CFLAGS="-DWOLFSSL_PUBLIC_MP" */
 #if defined(WC_ECC_NONBLOCK) && defined(WOLFSSL_HAVE_SP_ECC) && \
     defined(WOLFSSL_PUBLIC_MP)
+#ifndef NO_ECC256
 /* ECC Private Key "d" */
 static const byte p256PrivKey[] = {
     /* SECP256R1 */
@@ -33277,6 +33278,7 @@ static const byte p256PrivKey[] = {
     0x15, 0xdb, 0x4c, 0x43, 0xcd, 0xfa, 0xe5, 0x1f,
     0x3d, 0x4c, 0x37, 0xfe, 0x59, 0x3b, 0x96, 0xd8
 };
+#endif
 #ifdef HAVE_ECC384
 static const byte p384PrivKey[] = {
     /* SECP384R1 */
@@ -33306,6 +33308,7 @@ static const byte p521PrivKey[] = {
 #endif /* HAVE_ECC521 */
 
 /* ECC public key Qx/Qy */
+#ifndef NO_ECC256
 static const byte p256PubKey[] = {
     /* SECP256R1 */
     /* Qx */
@@ -33319,6 +33322,7 @@ static const byte p256PubKey[] = {
     0x43, 0x24, 0xe6, 0x82, 0x00, 0x40, 0xc6, 0xdb,
     0x1c, 0x2f, 0xcd, 0x38, 0x4b, 0x60, 0xdd, 0x61
 };
+#endif
 #ifdef HAVE_ECC384
 static const byte p384PubKey[] = {
     /* SECP384R1 */
@@ -33362,6 +33366,9 @@ static const byte p521PubKey[] = {
     0x40, 0x5c, 0x4f, 0xd6, 0x13, 0x73, 0x42, 0xbc,
     0x91, 0xd9
 };
+#endif
+
+#if defined(HAVE_ECC_SIGN) && defined(HAVE_ECC_VERIFY)
 
 /* perform verify of signature and hash using public key */
 /* key is public Qx + public Qy */
@@ -33698,12 +33705,14 @@ static wc_test_ret_t ecc_test_nonblock(WC_RNG* rng)
     const byte* pubKeys[3] = {NULL, NULL, NULL};
     word32 pubKeySzs[3] = {0, 0, 0};
 
+#ifndef NO_ECC256
     curveIds[0] = ECC_SECP256R1;
     curveSzs[0] = 32;
     privKeys[0] = p256PrivKey;
     privKeySzs[0] = sizeof(p256PrivKey);
     pubKeys[0] = p256PubKey;
     pubKeySzs[0] = sizeof(p256PubKey);
+#endif
 #ifdef HAVE_ECC384
     curveIds[1] = ECC_SECP384R1;
     curveSzs[1] = 48;


### PR DESCRIPTION
# Description

Fixes for ECC non-blocking tests. 
Added example user_settings.h build test. 
Demonstrate ECC 256, 384 and 521 bit.

# Testing

```
cp ./examples/configs/user_settings_eccnonblock.h user_settings.h
./configure --enable-usersettings --enable-debug --disable-examples
make
./wolfcrypt/test/test/wolfcrypt
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
