### PR TITLE
coverity: tests quic cleanup.

### DIFF
--- a/tests/quic.c
+++ b/tests/quic.c
@@ -114,12 +114,13 @@ static WOLFSSL_QUIC_METHOD null_method = {
 };
 
 static int test_set_quic_method(void) {
-    WOLFSSL_CTX *ctx;
-    WOLFSSL *ssl;
-    int ret = 0, i;
-    const uint8_t *data;
-    size_t data_len;
-    ctx_setups valids[] = {
+    EXPECT_DECLS;
+    WOLFSSL_CTX *   ctx = NULL;
+    WOLFSSL *       ssl = NULL;
+    int             i = 0;
+    const uint8_t * data = NULL;
+    size_t          data_len = 0;;
+    ctx_setups      valids[] = {
 #ifdef WOLFSSL_TLS13
         { "TLSv1.3 server", wolfTLSv1_3_server_method(), 1},
         { "TLSv1.3 client", wolfTLSv1_3_client_method(), 0},
@@ -139,52 +140,52 @@ static int test_set_quic_method(void) {
     };
 
     for (i = 0; valids[i].name != NULL; ++i) {
-        AssertNotNull(ctx = wolfSSL_CTX_new(valids[i].method));
+        ExpectNotNull(ctx = wolfSSL_CTX_new(valids[i].method));
         if (valids[i].is_server) {
-            AssertTrue(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile,
+            ExpectTrue(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile,
                                                         WOLFSSL_FILETYPE_PEM));
-            AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKeyFile,
+            ExpectTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKeyFile,
                                                        WOLFSSL_FILETYPE_PEM));
         }
         /* ctx does not have quic enabled, so will SSL* derived from it */
-        AssertNotNull(ssl = wolfSSL_new(ctx));
-        AssertFalse(wolfSSL_is_quic(ssl));
+        ExpectNotNull(ssl = wolfSSL_new(ctx));
+        ExpectFalse(wolfSSL_is_quic(ssl));
         /* Enable quic on the SSL* */
-        AssertFalse(wolfSSL_set_quic_method(ssl, &null_method) == WOLFSSL_SUCCESS);
-        AssertTrue(wolfSSL_set_quic_method(ssl, &dummy_method) == WOLFSSL_SUCCESS);
-        AssertTrue(wolfSSL_is_quic(ssl));
+        ExpectFalse(wolfSSL_set_quic_method(ssl, &null_method) == WOLFSSL_SUCCESS);
+        ExpectTrue(wolfSSL_set_quic_method(ssl, &dummy_method) == WOLFSSL_SUCCESS);
+        ExpectTrue(wolfSSL_is_quic(ssl));
         /* Check some default, initial behaviour */
-        AssertTrue(wolfSSL_set_quic_transport_params(ssl, NULL, 0) == WOLFSSL_SUCCESS);
+        ExpectTrue(wolfSSL_set_quic_transport_params(ssl, NULL, 0) == WOLFSSL_SUCCESS);
         wolfSSL_get_peer_quic_transport_params(ssl, &data, &data_len);
-        AssertNull(data);
-        AssertTrue(data_len == 0);
-        AssertTrue(wolfSSL_quic_read_level(ssl) == wolfssl_encryption_initial);
-        AssertTrue(wolfSSL_quic_write_level(ssl) == wolfssl_encryption_initial);
-        AssertTrue(wolfSSL_get_quic_transport_version(ssl) == 0);
+        ExpectNull(data);
+        ExpectTrue(data_len == 0);
+        ExpectTrue(wolfSSL_quic_read_level(ssl) == wolfssl_encryption_initial);
+        ExpectTrue(wolfSSL_quic_write_level(ssl) == wolfssl_encryption_initial);
+        ExpectTrue(wolfSSL_get_quic_transport_version(ssl) == 0);
         wolfSSL_set_quic_transport_version(ssl, TLSX_KEY_QUIC_TP_PARAMS);
-        AssertTrue(wolfSSL_get_quic_transport_version(ssl) == TLSX_KEY_QUIC_TP_PARAMS);
+        ExpectTrue(wolfSSL_get_quic_transport_version(ssl) == TLSX_KEY_QUIC_TP_PARAMS);
         wolfSSL_set_quic_use_legacy_codepoint(ssl, 1);
-        AssertTrue(wolfSSL_get_quic_transport_version(ssl) == TLSX_KEY_QUIC_TP_PARAMS_DRAFT);
+        ExpectTrue(wolfSSL_get_quic_transport_version(ssl) == TLSX_KEY_QUIC_TP_PARAMS_DRAFT);
         wolfSSL_set_quic_use_legacy_codepoint(ssl, 0);
-        AssertTrue(wolfSSL_get_quic_transport_version(ssl) == TLSX_KEY_QUIC_TP_PARAMS);
+        ExpectTrue(wolfSSL_get_quic_transport_version(ssl) == TLSX_KEY_QUIC_TP_PARAMS);
         /* max flight len during stages of handhshake, we us 16k initial and on
          * app data, and during handshake allow larger for cert exchange. This is
          * more advisory for the network code. ngtcp2 has its own ideas, for example.
          */
         data_len = wolfSSL_quic_max_handshake_flight_len(ssl, wolfssl_encryption_initial);
-        AssertTrue(data_len == 16*1024);
+        ExpectTrue(data_len == 16*1024);
         data_len = wolfSSL_quic_max_handshake_flight_len(ssl, wolfssl_encryption_early_data);
-        AssertTrue(data_len == 0);
+        ExpectTrue(data_len == 0);
         data_len = wolfSSL_quic_max_handshake_flight_len(ssl, wolfssl_encryption_handshake);
-        AssertTrue(data_len >= 16*1024);
+        ExpectTrue(data_len >= 16*1024);
         data_len = wolfSSL_quic_max_handshake_flight_len(ssl, wolfssl_encryption_application);
-        AssertTrue(data_len == 16*1024);
+        ExpectTrue(data_len == 16*1024);
         wolfSSL_free(ssl);
         /* Enabled quic on the ctx */
-        AssertTrue(wolfSSL_CTX_set_quic_method(ctx, &dummy_method) == WOLFSSL_SUCCESS);
+        ExpectTrue(wolfSSL_CTX_set_quic_method(ctx, &dummy_method) == WOLFSSL_SUCCESS);
         /* It will be enabled on the SSL* */
-        AssertNotNull(ssl = wolfSSL_new(ctx));
-        AssertTrue(wolfSSL_is_quic(ssl));
+        ExpectNotNull(ssl = wolfSSL_new(ctx));
+        ExpectTrue(wolfSSL_is_quic(ssl));
         wolfSSL_free(ssl);
 
         wolfSSL_CTX_free(ctx);
@@ -192,24 +193,24 @@ static int test_set_quic_method(void) {
 
     for (i = 0; invalids[i].name != NULL; ++i) {
 
-        AssertNotNull(ctx = wolfSSL_CTX_new(invalids[i].method));
-        AssertTrue(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile,
+        ExpectNotNull(ctx = wolfSSL_CTX_new(invalids[i].method));
+        ExpectTrue(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile,
                                                     WOLFSSL_FILETYPE_PEM));
-        AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKeyFile,
+        ExpectTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKeyFile,
                                                    WOLFSSL_FILETYPE_PEM));
-        AssertFalse(wolfSSL_CTX_set_quic_method(ctx, &dummy_method) == WOLFSSL_SUCCESS);
-        AssertNotNull(ssl = wolfSSL_new(ctx));
-        AssertFalse(wolfSSL_set_quic_method(ssl, &dummy_method) == WOLFSSL_SUCCESS);
-        AssertFalse(wolfSSL_is_quic(ssl));
+        ExpectFalse(wolfSSL_CTX_set_quic_method(ctx, &dummy_method) == WOLFSSL_SUCCESS);
+        ExpectNotNull(ssl = wolfSSL_new(ctx));
+        ExpectFalse(wolfSSL_set_quic_method(ssl, &dummy_method) == WOLFSSL_SUCCESS);
+        ExpectFalse(wolfSSL_is_quic(ssl));
         /* even though not quic, this is the only level we can return */
-        AssertTrue(wolfSSL_quic_read_level(ssl) == wolfssl_encryption_initial);
-        AssertTrue(wolfSSL_quic_write_level(ssl) == wolfssl_encryption_initial);
+        ExpectTrue(wolfSSL_quic_read_level(ssl) == wolfssl_encryption_initial);
+        ExpectTrue(wolfSSL_quic_write_level(ssl) == wolfssl_encryption_initial);
         wolfSSL_free(ssl);
         wolfSSL_CTX_free(ctx);
     }
 
-    printf("    test_set_quic_method: %s\n", (ret == 0)? passed : failed);
-    return ret;
+    printf("    test_set_quic_method: %s\n", (EXPECT_SUCCESS()) ? passed : failed);
+    return EXPECT_RESULT();
 }
 
 static size_t fake_record(byte rtype, word32 rlen, uint8_t *rec)
@@ -278,16 +279,16 @@ static int provide_data(WOLFSSL *ssl, WOLFSSL_ENCRYPTION_LEVEL level,
 }
 
 static int test_provide_quic_data(void) {
-    WOLFSSL_CTX *ctx;
-    WOLFSSL *ssl;
-    uint8_t lbuffer[16*1024];
-    size_t len;
-    int ret = 0;
+    EXPECT_DECLS;
+    WOLFSSL_CTX * ctx = NULL;
+    WOLFSSL *     ssl = NULL;
+    uint8_t       lbuffer[16*1024];
+    size_t        len = 0;
 
     XMEMSET(lbuffer, 0, sizeof(lbuffer));
 
-    AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
-    AssertTrue(wolfSSL_CTX_set_quic_method(ctx, &dummy_method) == WOLFSSL_SUCCESS);
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
+    ExpectTrue(wolfSSL_CTX_set_quic_method(ctx, &dummy_method) == WOLFSSL_SUCCESS);
     /* provide_quic_data() feeds CRYPTO packets inside a QUIC Frame into
     * the TLSv1.3 state machine.
      * The data fed is not the QUIC frame, but the TLS record inside it.
@@ -297,66 +298,66 @@ static int test_provide_quic_data(void) {
      * - encryption level only ever increases for subsequent TLS records
      * - a TLS record is received complete before the encryption level increases
      */
-    AssertNotNull(ssl = wolfSSL_new(ctx));
+    ExpectNotNull(ssl = wolfSSL_new(ctx));
     len = fake_record(1, 100, lbuffer);
-    AssertTrue(provide_data(ssl, wolfssl_encryption_initial, lbuffer, 1, 0));
-    AssertTrue(provide_data(ssl, wolfssl_encryption_initial, lbuffer+1, 3, 0));
-    AssertTrue(provide_data(ssl, wolfssl_encryption_initial, lbuffer+4, len, 0)
+    ExpectTrue(provide_data(ssl, wolfssl_encryption_initial, lbuffer, 1, 0));
+    ExpectTrue(provide_data(ssl, wolfssl_encryption_initial, lbuffer+1, 3, 0));
+    ExpectTrue(provide_data(ssl, wolfssl_encryption_initial, lbuffer+4, len, 0)
             );
     len = fake_record(2, 1523, lbuffer);
-    AssertTrue(provide_data(ssl, wolfssl_encryption_handshake, lbuffer, len, 0));
+    ExpectTrue(provide_data(ssl, wolfssl_encryption_handshake, lbuffer, len, 0));
     len = fake_record(2, 1, lbuffer);
     len += fake_record(3, 190, lbuffer+len);
-    AssertTrue(provide_data(ssl, wolfssl_encryption_handshake, lbuffer, len, 0));
+    ExpectTrue(provide_data(ssl, wolfssl_encryption_handshake, lbuffer, len, 0));
     len = fake_record(5, 2049, lbuffer);
-    AssertTrue(provide_data(ssl, wolfssl_encryption_application, lbuffer, len, 0));
+    ExpectTrue(provide_data(ssl, wolfssl_encryption_application, lbuffer, len, 0));
     /* adding another record with decreased level must fail */
     len = fake_record(1, 100, lbuffer);
-    AssertTrue(provide_data(ssl, wolfssl_encryption_initial, lbuffer, len, 1));
+    ExpectTrue(provide_data(ssl, wolfssl_encryption_initial, lbuffer, len, 1));
     wolfSSL_free(ssl);
 
-    AssertNotNull(ssl = wolfSSL_new(ctx));
+    ExpectNotNull(ssl = wolfSSL_new(ctx));
     len = fake_record(1, 100, lbuffer);
-    AssertTrue(provide_data(ssl, wolfssl_encryption_initial, lbuffer, 24, 0));
+    ExpectTrue(provide_data(ssl, wolfssl_encryption_initial, lbuffer, 24, 0));
     len = shift_record(lbuffer, len, 24);
     len += fake_record(2, 4000, lbuffer+len);
-    AssertTrue(provide_data(ssl, wolfssl_encryption_initial, lbuffer, len - 99, 0));
+    ExpectTrue(provide_data(ssl, wolfssl_encryption_initial, lbuffer, len - 99, 0));
     len = shift_record(lbuffer, len, len - 99);
     len += fake_record(5, 2049, lbuffer+len);
-    AssertTrue(provide_data(ssl, wolfssl_encryption_initial, lbuffer, len, 0));
+    ExpectTrue(provide_data(ssl, wolfssl_encryption_initial, lbuffer, len, 0));
     /* should be recognized as complete and level increase needs to be accepted */
     len = fake_record(2, 1, lbuffer);
     len += fake_record(3, 190, lbuffer+len);
-    AssertTrue(provide_data(ssl, wolfssl_encryption_handshake, lbuffer, len - 10, 0));
+    ExpectTrue(provide_data(ssl, wolfssl_encryption_handshake, lbuffer, len - 10, 0));
     len = shift_record(lbuffer, len, len - 10);
     /* Change level with incomplete record in lbuffer, needs to fail */
     len += fake_record(5, 8102, lbuffer+len);
-    AssertTrue(provide_data(ssl, wolfssl_encryption_application, lbuffer, len - 10, 1));
+    ExpectTrue(provide_data(ssl, wolfssl_encryption_application, lbuffer, len - 10, 1));
     wolfSSL_free(ssl);
 
     wolfSSL_CTX_free(ctx);
 
-    printf("    test_provide_quic_data: %s\n", (ret == 0)? passed : failed);
-    return 0;
+    printf("    test_provide_quic_data: %s\n", (EXPECT_SUCCESS()) ? passed : failed);
+    return EXPECT_RESULT();
 }
 
 
 static int test_quic_crypt(void) {
-    WOLFSSL_CTX *ctx;
-    WOLFSSL *ssl;
-    const WOLFSSL_EVP_CIPHER *aead_cipher;
-    int ret = 0;
+    EXPECT_DECLS;
+    WOLFSSL_CTX * ctx = NULL;
+    WOLFSSL *     ssl = NULL;
+    const WOLFSSL_EVP_CIPHER * aead_cipher = NULL;
 
-    AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
-    AssertTrue(wolfSSL_CTX_set_quic_method(ctx, &dummy_method) == WOLFSSL_SUCCESS);
-    AssertNotNull(ssl = wolfSSL_new(ctx));
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
+    ExpectTrue(wolfSSL_CTX_set_quic_method(ctx, &dummy_method) == WOLFSSL_SUCCESS);
+    ExpectNotNull(ssl = wolfSSL_new(ctx));
 
     /* don't have an AEAD cipher selected before start */
-    AssertTrue(wolfSSL_CIPHER_get_id(wolfSSL_get_current_cipher(ssl)) == 0);
-    AssertNotNull(aead_cipher = wolfSSL_EVP_aes_128_gcm());
-    AssertTrue(wolfSSL_quic_aead_is_gcm(aead_cipher) != 0);
-    AssertTrue(wolfSSL_quic_aead_is_ccm(aead_cipher) == 0);
-    AssertTrue(wolfSSL_quic_aead_is_chacha20(aead_cipher) == 0);
+    ExpectTrue(wolfSSL_CIPHER_get_id(wolfSSL_get_current_cipher(ssl)) == 0);
+    ExpectNotNull(aead_cipher = wolfSSL_EVP_aes_128_gcm());
+    ExpectTrue(wolfSSL_quic_aead_is_gcm(aead_cipher) != 0);
+    ExpectTrue(wolfSSL_quic_aead_is_ccm(aead_cipher) == 0);
+    ExpectTrue(wolfSSL_quic_aead_is_chacha20(aead_cipher) == 0);
 
     if (1) {
         /* check that our enc-/decrypt support in quic rount-trips */
@@ -372,30 +373,34 @@ static int test_quic_crypt(void) {
                                            0x77, 0x08, 0xa9, 0x60, 0x17, 0x73, 0xc5, 0x07, 0xf3, 0x04, 0xc9, 0x3f, 0x67, 0x4d, 0x12,
                                            0xa1, 0x02, 0x93, 0xc2, 0x3c, 0xd3, 0xf8, 0x59, 0x33, 0xd5, 0x01, 0xc3, 0xbb, 0xaa, 0xe6,
                                            0x3f, 0xbb, 0x23, 0x66, 0x94, 0x26, 0x28, 0x43, 0xa5, 0xfd, 0x2f};
-        WOLFSSL_EVP_CIPHER_CTX *enc_ctx, *dec_ctx;
-        uint8_t *encrypted, *decrypted;
-        size_t tag_len, enc_len, dec_len;
+        WOLFSSL_EVP_CIPHER_CTX * enc_ctx = NULL;
+        WOLFSSL_EVP_CIPHER_CTX * dec_ctx = NULL;
+        uint8_t * encrypted = NULL;
+        uint8_t * decrypted = NULL;
+        size_t tag_len = 0;
+        size_t enc_len = 0;
+        size_t dec_len = 0;
 
-        AssertTrue((tag_len = wolfSSL_quic_get_aead_tag_len(aead_cipher)) == 16);
+        ExpectTrue((tag_len = wolfSSL_quic_get_aead_tag_len(aead_cipher)) == 16);
         dec_len = sizeof(plaintext);
         enc_len = dec_len + tag_len;
         encrypted = (uint8_t*)XMALLOC(enc_len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        AssertNotNull(encrypted);
+        ExpectNotNull(encrypted);
         decrypted = (uint8_t*)XMALLOC(dec_len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        AssertNotNull(decrypted);
+        ExpectNotNull(decrypted);
 
-        AssertNotNull(enc_ctx = wolfSSL_quic_crypt_new(aead_cipher, key, iv, 1));
-        AssertTrue(wolfSSL_quic_aead_encrypt(encrypted, enc_ctx,
+        ExpectNotNull(enc_ctx = wolfSSL_quic_crypt_new(aead_cipher, key, iv, 1));
+        ExpectTrue(wolfSSL_quic_aead_encrypt(encrypted, enc_ctx,
                                              plaintext, sizeof(plaintext),
                                              NULL, aad, sizeof(aad)) == WOLFSSL_SUCCESS);
-        AssertTrue(memcmp(expected, encrypted, dec_len) == 0);
-        AssertTrue(memcmp(expected+dec_len, encrypted+dec_len, tag_len) == 0);
+        ExpectTrue(memcmp(expected, encrypted, dec_len) == 0);
+        ExpectTrue(memcmp(expected+dec_len, encrypted+dec_len, tag_len) == 0);
 
-        AssertNotNull(dec_ctx = wolfSSL_quic_crypt_new(aead_cipher, key, iv, 0));
-        AssertTrue(wolfSSL_quic_aead_decrypt(decrypted, dec_ctx,
+        ExpectNotNull(dec_ctx = wolfSSL_quic_crypt_new(aead_cipher, key, iv, 0));
+        ExpectTrue(wolfSSL_quic_aead_decrypt(decrypted, dec_ctx,
                                              encrypted, enc_len,
                                              NULL, aad, sizeof(aad)) == WOLFSSL_SUCCESS);
-        AssertTrue(memcmp(plaintext, decrypted, dec_len) == 0);
+        ExpectTrue(memcmp(plaintext, decrypted, dec_len) == 0);
 
         XFREE(encrypted, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         XFREE(decrypted, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -406,8 +411,8 @@ static int test_quic_crypt(void) {
     wolfSSL_free(ssl);
     wolfSSL_CTX_free(ctx);
 
-    printf("    test_quic_crypt: %s\n", (ret == 0)? passed : failed);
-    return ret;
+    printf("    test_quic_crypt: %s\n", (EXPECT_SUCCESS()) ? passed : failed);
+    return EXPECT_RESULT();
 }
 
 typedef struct OutputBuffer {
@@ -1111,19 +1116,19 @@ static void QuicConversation_fail(QuicConversation *conv)
 #endif /* HAVE_SESSION_TICKET */
 
 static int test_quic_client_hello(int verbose) {
-    WOLFSSL_CTX *ctx;
-    int ret = 0;
+    EXPECT_DECLS;
+    WOLFSSL_CTX * ctx = NULL;
     QuicTestContext tctx;
 
     (void)ctx_dump_output;
 
-    AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
 
     QuicTestContext_init(&tctx, ctx, "client", verbose);
     /* Without any QUIC transport params, this needs to fail */
-    AssertTrue(wolfSSL_set_quic_transport_params(tctx.ssl, NULL, 0) == WOLFSSL_SUCCESS);
-    AssertTrue(wolfSSL_quic_read_write(tctx.ssl) != 0);
-    AssertIntEQ(wolfSSL_get_error(tctx.ssl, 0), WC_NO_ERR_TRACE(QUIC_TP_MISSING_E));
+    ExpectTrue(wolfSSL_set_quic_transport_params(tctx.ssl, NULL, 0) == WOLFSSL_SUCCESS);
+    ExpectTrue(wolfSSL_quic_read_write(tctx.ssl) != 0);
+    ExpectIntEQ(wolfSSL_get_error(tctx.ssl, 0), WC_NO_ERR_TRACE(QUIC_TP_MISSING_E));
     QuicTestContext_free(&tctx);
 
     /* Set transport params, expect both extensions */
@@ -1132,48 +1137,49 @@ static int test_quic_client_hello(int verbose) {
     wolfSSL_UseSNI(tctx.ssl, WOLFSSL_SNI_HOST_NAME,
                    "wolfssl.com", sizeof("wolfssl.com")-1);
 #endif
-    AssertTrue(wolfSSL_connect(tctx.ssl) != 0);
-    AssertIntEQ(wolfSSL_get_error(tctx.ssl, 0), WC_NO_ERR_TRACE(SSL_ERROR_WANT_READ));
+    ExpectTrue(wolfSSL_connect(tctx.ssl) != 0);
+    ExpectIntEQ(wolfSSL_get_error(tctx.ssl, 0), WC_NO_ERR_TRACE(SSL_ERROR_WANT_READ));
     check_quic_client_hello_tp(&tctx.output, 1, 1);
     QuicTestContext_free(&tctx);
 
     /* Set transport params v1, expect v1 extension */
     QuicTestContext_init(&tctx, ctx, "client", verbose);
     wolfSSL_set_quic_transport_version(tctx.ssl, TLSX_KEY_QUIC_TP_PARAMS);
-    AssertTrue(wolfSSL_connect(tctx.ssl) != 0);
+    ExpectTrue(wolfSSL_connect(tctx.ssl) != 0);
     check_quic_client_hello_tp(&tctx.output, 1, 0);
     QuicTestContext_free(&tctx);
 
     /* Set transport params draft, expect draft extension */
     QuicTestContext_init(&tctx, ctx, "client", verbose);
     wolfSSL_set_quic_transport_version(tctx.ssl, TLSX_KEY_QUIC_TP_PARAMS_DRAFT);
-    AssertTrue(wolfSSL_connect(tctx.ssl) != 0);
+    ExpectTrue(wolfSSL_connect(tctx.ssl) != 0);
     check_quic_client_hello_tp(&tctx.output, 0, 1);
     QuicTestContext_free(&tctx);
 
     /* Set transport params 0, expect both extension */
     QuicTestContext_init(&tctx, ctx, "client", verbose);
     wolfSSL_set_quic_transport_version(tctx.ssl, 0);
-    AssertTrue(wolfSSL_connect(tctx.ssl) != 0);
+    ExpectTrue(wolfSSL_connect(tctx.ssl) != 0);
     check_quic_client_hello_tp(&tctx.output, 1, 1);
     QuicTestContext_free(&tctx);
 
     wolfSSL_CTX_free(ctx);
-    printf("    test_quic_client_hello: %s\n", (ret == 0)? passed : failed);
+    printf("    test_quic_client_hello: %s\n", (EXPECT_SUCCESS())? passed : failed);
 
-    return ret;
+    return EXPECT_RESULT();
 }
 
 static int test_quic_server_hello(int verbose) {
-    WOLFSSL_CTX *ctx_c, *ctx_s;
-    int ret = 0;
+    EXPECT_DECLS;
+    WOLFSSL_CTX * ctx_c = NULL;
+    WOLFSSL_CTX * ctx_s = NULL;
     QuicTestContext tclient, tserver;
     QuicConversation conv;
 
-    AssertNotNull(ctx_c = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
-    AssertNotNull(ctx_s = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
-    AssertTrue(wolfSSL_CTX_use_certificate_file(ctx_s, svrCertFile, WOLFSSL_FILETYPE_PEM));
-    AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx_s, svrKeyFile, WOLFSSL_FILETYPE_PEM));
+    ExpectNotNull(ctx_c = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
+    ExpectNotNull(ctx_s = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
+    ExpectTrue(wolfSSL_CTX_use_certificate_file(ctx_s, svrCertFile, WOLFSSL_FILETYPE_PEM));
+    ExpectTrue(wolfSSL_CTX_use_PrivateKey_file(ctx_s, svrKeyFile, WOLFSSL_FILETYPE_PEM));
 
     /* setup ssls */
     QuicTestContext_init(&tclient, ctx_c, "client", verbose);
@@ -1198,23 +1204,23 @@ static int test_quic_server_hello(int verbose) {
     conv.started = 1;
     /* run till end */
     QuicConversation_do(&conv);
-    AssertIntEQ(tclient.output.len, 0);
-    AssertIntEQ(tserver.output.len, 0);
+    ExpectIntEQ(tclient.output.len, 0);
+    ExpectIntEQ(tserver.output.len, 0);
     /* what have we seen? */
 #ifdef HAVE_SESSION_TICKET
-    AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
+    ExpectStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
         "Certificate:CertificateVerify:Finished:Finished:SessionTicket");
 #else
-    AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
+    ExpectStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
         "Certificate:CertificateVerify:Finished:Finished");
 #endif
     /* we are at application encryption level */
-    AssertTrue(wolfSSL_quic_read_level(tclient.ssl) == wolfssl_encryption_application);
-    AssertTrue(wolfSSL_quic_write_level(tclient.ssl) == wolfssl_encryption_application);
-    AssertTrue(wolfSSL_quic_read_level(tserver.ssl) == wolfssl_encryption_application);
-    AssertTrue(wolfSSL_quic_write_level(tserver.ssl) == wolfssl_encryption_application);
+    ExpectTrue(wolfSSL_quic_read_level(tclient.ssl) == wolfssl_encryption_application);
+    ExpectTrue(wolfSSL_quic_write_level(tclient.ssl) == wolfssl_encryption_application);
+    ExpectTrue(wolfSSL_quic_read_level(tserver.ssl) == wolfssl_encryption_application);
+    ExpectTrue(wolfSSL_quic_write_level(tserver.ssl) == wolfssl_encryption_application);
     /* the last client write (FINISHED) was at handshake level */
-    AssertTrue(tclient.output.level == wolfssl_encryption_handshake);
+    ExpectTrue(tclient.output.level == wolfssl_encryption_handshake);
     /* we have the app secrets */
     check_secrets(&tclient, wolfssl_encryption_application,
         DEFAULT_TLS_DIGEST_SZ, DEFAULT_TLS_DIGEST_SZ);
@@ -1224,10 +1230,10 @@ static int test_quic_server_hello(int verbose) {
     assert_secrets_EQ(&tclient, &tserver, wolfssl_encryption_handshake);
     assert_secrets_EQ(&tclient, &tserver, wolfssl_encryption_application);
     /* AEAD cipher should be known */
-    AssertNotNull(wolfSSL_quic_get_aead(tclient.ssl));
-    AssertNotNull(wolfSSL_quic_get_aead(tserver.ssl));
+    ExpectNotNull(wolfSSL_quic_get_aead(tclient.ssl));
+    ExpectNotNull(wolfSSL_quic_get_aead(tserver.ssl));
     /* What was negiotiated and is it the same? */
-    AssertIntEQ(wolfSSL_get_peer_quic_transport_version(tclient.ssl),
+    ExpectIntEQ(wolfSSL_get_peer_quic_transport_version(tclient.ssl),
                 wolfSSL_get_peer_quic_transport_version(tserver.ssl));
 
     QuicTestContext_free(&tclient);
@@ -1235,21 +1241,22 @@ static int test_quic_server_hello(int verbose) {
 
     wolfSSL_CTX_free(ctx_c);
     wolfSSL_CTX_free(ctx_s);
-    printf("    test_quic_server_hello: %s\n", (ret == 0)? passed : failed);
+    printf("    test_quic_server_hello: %s\n", (EXPECT_RESULT())? passed : failed);
 
-    return ret;
+    return EXPECT_RESULT();
 }
 
 static int test_quic_server_hello_fail(int verbose) {
-    WOLFSSL_CTX *ctx_c, *ctx_s;
-    int ret = 0;
+    EXPECT_DECLS;
+    WOLFSSL_CTX * ctx_c = NULL;
+    WOLFSSL_CTX * ctx_s = NULL;
     QuicTestContext tclient, tserver;
     QuicConversation conv;
 
-    AssertNotNull(ctx_c = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
-    AssertNotNull(ctx_s = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
-    AssertTrue(wolfSSL_CTX_use_certificate_file(ctx_s, svrCertFile, WOLFSSL_FILETYPE_PEM));
-    AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx_s, svrKeyFile, WOLFSSL_FILETYPE_PEM));
+    ExpectNotNull(ctx_c = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
+    ExpectNotNull(ctx_s = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
+    ExpectTrue(wolfSSL_CTX_use_certificate_file(ctx_s, svrCertFile, WOLFSSL_FILETYPE_PEM));
+    ExpectTrue(wolfSSL_CTX_use_PrivateKey_file(ctx_s, svrKeyFile, WOLFSSL_FILETYPE_PEM));
 
     /* setup ssls */
     QuicTestContext_init_fail_cb(&tclient, ctx_c, "client", verbose);
@@ -1270,18 +1277,18 @@ static int test_quic_server_hello_fail(int verbose) {
     /* confirm failure to generate secrets */
     {
         int idx = (int)wolfssl_encryption_handshake;
-        AssertTrue(idx < 4);
-        AssertIntEQ(tclient.rx_secret_len[idx], 0);
-        AssertIntEQ(tclient.tx_secret_len[idx], 0);
+        ExpectTrue(idx < 4);
+        ExpectIntEQ(tclient.rx_secret_len[idx], 0);
+        ExpectIntEQ(tclient.tx_secret_len[idx], 0);
     }
     QuicTestContext_free(&tclient);
     QuicTestContext_free(&tserver);
 
     wolfSSL_CTX_free(ctx_c);
     wolfSSL_CTX_free(ctx_s);
-    printf("    test_quic_server_hello_fail: %s\n", (ret == 0)? passed : failed);
+    printf("    test_quic_server_hello_fail: %s\n", (EXPECT_RESULT())? passed : failed);
 
-    return ret;
+    return EXPECT_RESULT();
 }
 
 /* This has gotten a bit out of hand. */
@@ -1329,17 +1336,18 @@ static int select_ALPN(WOLFSSL *ssl,
 }
 
 static int test_quic_alpn(int verbose) {
-    WOLFSSL_CTX *ctx_c, *ctx_s;
-    int ret = 0;
+    EXPECT_DECLS;
+    WOLFSSL_CTX * ctx_c = NULL;
+    WOLFSSL_CTX * ctx_s = NULL;
     QuicTestContext tclient, tserver;
     QuicConversation conv;
     struct stripe_buffer stripe;
     unsigned char alpn_protos[256];
 
-    AssertNotNull(ctx_c = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
-    AssertNotNull(ctx_s = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
-    AssertTrue(wolfSSL_CTX_use_certificate_file(ctx_s, svrCertFile, WOLFSSL_FILETYPE_PEM));
-    AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx_s, svrKeyFile, WOLFSSL_FILETYPE_PEM));
+    ExpectNotNull(ctx_c = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
+    ExpectNotNull(ctx_s = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
+    ExpectTrue(wolfSSL_CTX_use_certificate_file(ctx_s, svrCertFile, WOLFSSL_FILETYPE_PEM));
+    ExpectTrue(wolfSSL_CTX_use_PrivateKey_file(ctx_s, svrKeyFile, WOLFSSL_FILETYPE_PEM));
 
     stripe.stripe[0] = '\0';
     wolfSSL_CTX_set_servername_callback(ctx_s, inspect_SNI);
@@ -1362,20 +1370,20 @@ static int test_quic_alpn(int verbose) {
     wolfSSL_set_alpn_protos(tclient.ssl, alpn_protos, 1 + strlen("test"));
 
     QuicConversation_do(&conv);
-    AssertIntEQ(tclient.output.len, 0);
-    AssertIntEQ(tserver.output.len, 0);
+    ExpectIntEQ(tclient.output.len, 0);
+    ExpectIntEQ(tserver.output.len, 0);
 
     /* SNI callback needs to be called before ALPN callback */
-    AssertStrEQ(stripe.stripe, "SA");
+    ExpectStrEQ(stripe.stripe, "SA");
 
     QuicTestContext_free(&tclient);
     QuicTestContext_free(&tserver);
 
     wolfSSL_CTX_free(ctx_c);
     wolfSSL_CTX_free(ctx_s);
-    printf("    test_quic_alpn: %s\n", (ret == 0)? passed : failed);
+    printf("    test_quic_alpn: %s\n", (EXPECT_SUCCESS())? passed : failed);
 
-    return ret;
+    return EXPECT_RESULT();
 }
 #endif /* REALLY_HAVE_ALPN_AND_SNI */
 
@@ -1383,22 +1391,23 @@ static int test_quic_alpn(int verbose) {
 #ifdef HAVE_SESSION_TICKET
 
 static int test_quic_key_share(int verbose) {
-    WOLFSSL_CTX *ctx_c, *ctx_s;
-    int ret = 0;
+    EXPECT_DECLS;
+    WOLFSSL_CTX * ctx_c = NULL;
+    WOLFSSL_CTX * ctx_s = NULL;
     QuicTestContext tclient, tserver;
     QuicConversation conv;
 
-    AssertNotNull(ctx_c = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
-    AssertNotNull(ctx_s = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
-    AssertTrue(wolfSSL_CTX_use_certificate_file(ctx_s, svrCertFile, WOLFSSL_FILETYPE_PEM));
-    AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx_s, svrKeyFile, WOLFSSL_FILETYPE_PEM));
+    ExpectNotNull(ctx_c = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
+    ExpectNotNull(ctx_s = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
+    ExpectTrue(wolfSSL_CTX_use_certificate_file(ctx_s, svrCertFile, WOLFSSL_FILETYPE_PEM));
+    ExpectTrue(wolfSSL_CTX_use_PrivateKey_file(ctx_s, svrKeyFile, WOLFSSL_FILETYPE_PEM));
 
     /* setup & handshake defaults */
     QuicTestContext_init(&tclient, ctx_c, "client", verbose);
     QuicTestContext_init(&tserver, ctx_s, "server", verbose);
     QuicConversation_init(&conv, &tclient, &tserver);
     QuicConversation_do(&conv);
-    AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
+    ExpectStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
         "Certificate:CertificateVerify:Finished:Finished:SessionTicket");
     QuicTestContext_free(&tclient);
     QuicTestContext_free(&tserver);
@@ -1408,13 +1417,13 @@ static int test_quic_key_share(int verbose) {
     /*If that is supported by the server, expect a smooth handshake.*/
     QuicTestContext_init(&tclient, ctx_c, "client", verbose);
     QuicTestContext_init(&tserver, ctx_s, "server", verbose);
-    AssertTrue(wolfSSL_set1_curves_list(tclient.ssl, "X25519:P-256")
+    ExpectTrue(wolfSSL_set1_curves_list(tclient.ssl, "X25519:P-256")
                == WOLFSSL_SUCCESS);
-    AssertTrue(wolfSSL_set1_curves_list(tserver.ssl, "X25519")
+    ExpectTrue(wolfSSL_set1_curves_list(tserver.ssl, "X25519")
                == WOLFSSL_SUCCESS);
     QuicConversation_init(&conv, &tclient, &tserver);
     QuicConversation_do(&conv);
-    AssertStrEQ(conv.rec_log,
+    ExpectStrEQ(conv.rec_log,
         "ClientHello:ServerHello:EncryptedExtension:"
             "Certificate:CertificateVerify:Finished:Finished:SessionTicket");
     QuicTestContext_free(&tclient);
@@ -1424,13 +1433,13 @@ static int test_quic_key_share(int verbose) {
     /* If group is not supported by server, expect HelloRetry */
     QuicTestContext_init(&tclient, ctx_c, "client", verbose);
     QuicTestContext_init(&tserver, ctx_s, "server", verbose);
-    AssertTrue(wolfSSL_set1_curves_list(tclient.ssl, "X25519:P-256")
+    ExpectTrue(wolfSSL_set1_curves_list(tclient.ssl, "X25519:P-256")
                == WOLFSSL_SUCCESS);
-    AssertTrue(wolfSSL_set1_curves_list(tserver.ssl, "P-256")
+    ExpectTrue(wolfSSL_set1_curves_list(tserver.ssl, "P-256")
                == WOLFSSL_SUCCESS);
     QuicConversation_init(&conv, &tclient, &tserver);
     QuicConversation_do(&conv);
-    AssertStrEQ(conv.rec_log,
+    ExpectStrEQ(conv.rec_log,
         "ClientHello:ServerHello:ClientHello:ServerHello:EncryptedExtension:"
             "Certificate:CertificateVerify:Finished:Finished:SessionTicket");
     QuicTestContext_free(&tclient);
@@ -1440,38 +1449,38 @@ static int test_quic_key_share(int verbose) {
     /* If no group overlap, expect failure */
     QuicTestContext_init(&tclient, ctx_c, "client", verbose);
     QuicTestContext_init(&tserver, ctx_s, "server", verbose);
-    AssertTrue(wolfSSL_set1_curves_list(tclient.ssl, "P-256")
+    ExpectTrue(wolfSSL_set1_curves_list(tclient.ssl, "P-256")
                == WOLFSSL_SUCCESS);
-    AssertTrue(wolfSSL_set1_curves_list(tserver.ssl, "X25519")
+    ExpectTrue(wolfSSL_set1_curves_list(tserver.ssl, "X25519")
                == WOLFSSL_SUCCESS);
     QuicConversation_init(&conv, &tclient, &tserver);
     QuicConversation_fail(&conv);
-    AssertIntEQ(wolfSSL_get_error(tserver.ssl, 0), WC_NO_ERR_TRACE(SSL_ERROR_WANT_READ));
-    AssertIntEQ(wolfSSL_get_error(tclient.ssl, 0), WC_NO_ERR_TRACE(BAD_KEY_SHARE_DATA));
+    ExpectIntEQ(wolfSSL_get_error(tserver.ssl, 0), WC_NO_ERR_TRACE(SSL_ERROR_WANT_READ));
+    ExpectIntEQ(wolfSSL_get_error(tclient.ssl, 0), WC_NO_ERR_TRACE(BAD_KEY_SHARE_DATA));
     QuicTestContext_free(&tclient);
     QuicTestContext_free(&tserver);
     printf("    test_quic_key_share: no match ok\n");
 
     wolfSSL_CTX_free(ctx_c);
     wolfSSL_CTX_free(ctx_s);
-    printf("    test_quic_key_share: %s\n", (ret == 0)? passed : failed);
-    return ret;
+    printf("    test_quic_key_share: %s\n", (EXPECT_RESULT())? passed : failed);
+    return EXPECT_RESULT();
 }
 
 static int test_quic_resumption(int verbose) {
+    EXPECT_DECLS;
     WOLFSSL_CTX *ctx_c, *ctx_s;
     WOLFSSL_SESSION *session, *session_restored;
-    int ret = 0;
     QuicTestContext tclient, tserver;
     QuicConversation conv;
     unsigned char session_buffer[16 * 1024], *session_data;
     const unsigned char *session_data2;
     unsigned int session_size;
 
-    AssertNotNull(ctx_c = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
-    AssertNotNull(ctx_s = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
-    AssertTrue(wolfSSL_CTX_use_certificate_file(ctx_s, svrCertFile, WOLFSSL_FILETYPE_PEM));
-    AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx_s, svrKeyFile, WOLFSSL_FILETYPE_PEM));
+    ExpectNotNull(ctx_c = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
+    ExpectNotNull(ctx_s = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
+    ExpectTrue(wolfSSL_CTX_use_certificate_file(ctx_s, svrCertFile, WOLFSSL_FILETYPE_PEM));
+    ExpectTrue(wolfSSL_CTX_use_PrivateKey_file(ctx_s, svrKeyFile, WOLFSSL_FILETYPE_PEM));
 
     /* setup ssls */
     QuicTestContext_init(&tclient, ctx_c, "client", verbose);
@@ -1481,20 +1490,20 @@ static int test_quic_resumption(int verbose) {
     /* run till end */
     QuicConversation_do(&conv);
     /* what have we seen? */
-    AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
+    ExpectStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
         "Certificate:CertificateVerify:Finished:Finished:SessionTicket");
 
     /* Should have received a session ticket, save the session
      * and also make a serialized/deserialized copy to check that persisting
      * a session works. */
-    AssertTrue(tclient.ticket_len > 0);
-    AssertNotNull(session = wolfSSL_get1_session(tclient.ssl));
-    AssertTrue((session_size = (unsigned int)wolfSSL_i2d_SSL_SESSION(session, NULL)) > 0);
-    AssertTrue((size_t)session_size < sizeof(session_buffer));
+    ExpectTrue(tclient.ticket_len > 0);
+    ExpectNotNull(session = wolfSSL_get1_session(tclient.ssl));
+    ExpectTrue((session_size = (unsigned int)wolfSSL_i2d_SSL_SESSION(session, NULL)) > 0);
+    ExpectTrue((size_t)session_size < sizeof(session_buffer));
     session_data2 = session_data = session_buffer;
     session_size = (unsigned int)wolfSSL_i2d_SSL_SESSION(session, &session_data);
     session_restored = wolfSSL_d2i_SSL_SESSION(NULL, &session_data2, session_size);
-    AssertNotNull(session_restored);
+    ExpectNotNull(session_restored);
 
     QuicTestContext_free(&tserver);
     QuicTestContext_free(&tclient);
@@ -1502,12 +1511,12 @@ static int test_quic_resumption(int verbose) {
     /* Do a Session resumption with the session object */
     QuicTestContext_init(&tserver, ctx_s, "server", verbose);
     QuicTestContext_init(&tclient, ctx_c, "client_resume", verbose);
-    AssertIntEQ(wolfSSL_set_session(tclient.ssl, session), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_set_session(tclient.ssl, session), WOLFSSL_SUCCESS);
     /* let them talk */
     QuicConversation_init(&conv, &tclient, &tserver);
     QuicConversation_do(&conv);
     /* this is what should happen. Look Ma, no certificate! */
-    AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
+    ExpectStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
         "Finished:Finished:SessionTicket");
     QuicTestContext_free(&tclient);
     QuicTestContext_free(&tserver);
@@ -1515,12 +1524,12 @@ static int test_quic_resumption(int verbose) {
     /* Do a Session resumption with the restored session object */
     QuicTestContext_init(&tserver, ctx_s, "server", verbose);
     QuicTestContext_init(&tclient, ctx_c, "client_resume_restored", verbose);
-    AssertIntEQ(wolfSSL_set_session(tclient.ssl, session_restored), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_set_session(tclient.ssl, session_restored), WOLFSSL_SUCCESS);
     /* let them talk */
     QuicConversation_init(&conv, &tclient, &tserver);
     QuicConversation_do(&conv);
     /* this is what should happen. Look Ma, no certificate! */
-    AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
+    ExpectStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
         "Finished:Finished:SessionTicket");
     QuicTestContext_free(&tclient);
     QuicTestContext_free(&tserver);
@@ -1528,17 +1537,17 @@ static int test_quic_resumption(int verbose) {
     {
         /* Do a Session resumption with a new server ctx */
         WOLFSSL_CTX *ctx_s2;
-        AssertNotNull(ctx_s2 = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
-        AssertTrue(wolfSSL_CTX_use_certificate_file(ctx_s2, eccCertFile, WOLFSSL_FILETYPE_PEM));
-        AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx_s2, eccKeyFile, WOLFSSL_FILETYPE_PEM));
+        ExpectNotNull(ctx_s2 = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
+        ExpectTrue(wolfSSL_CTX_use_certificate_file(ctx_s2, eccCertFile, WOLFSSL_FILETYPE_PEM));
+        ExpectTrue(wolfSSL_CTX_use_PrivateKey_file(ctx_s2, eccKeyFile, WOLFSSL_FILETYPE_PEM));
 
         QuicTestContext_init(&tserver, ctx_s2, "server2", verbose);
         QuicTestContext_init(&tclient, ctx_c, "client_resume2", verbose);
-        AssertIntEQ(wolfSSL_set_session(tclient.ssl, session_restored), WOLFSSL_SUCCESS);
+        ExpectIntEQ(wolfSSL_set_session(tclient.ssl, session_restored), WOLFSSL_SUCCESS);
         /* let them talk */
         QuicConversation_init(&conv, &tclient, &tserver);
         QuicConversation_do(&conv);
-        AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
+        ExpectStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
             "Certificate:CertificateVerify:Finished:Finished:SessionTicket");
         QuicTestContext_free(&tclient);
         QuicTestContext_free(&tserver);
@@ -1550,45 +1559,46 @@ static int test_quic_resumption(int verbose) {
     wolfSSL_CTX_free(ctx_c);
     wolfSSL_CTX_free(ctx_s);
 
-    printf("    test_quic_resumption: %s\n", (ret == 0)? passed : failed);
-    return ret;
+    printf("    test_quic_resumption: %s\n", (EXPECT_SUCCESS())? passed : failed);
+    return EXPECT_RESULT();
 }
 
 #ifdef WOLFSSL_EARLY_DATA
 static int test_quic_early_data(int verbose) {
-    WOLFSSL_CTX *ctx_c, *ctx_s;
-    int ret = 0;
+    EXPECT_DECLS;
+    WOLFSSL_CTX * ctx_c = NULL; 
+    WOLFSSL_CTX * ctx_s = NULL;
     QuicTestContext tclient, tserver;
     QuicConversation conv;
     const byte early_data[] = "Nulla dies sine linea!";
-    size_t ed_written;
-    WOLFSSL_SESSION *session;
-    unsigned int max_early_sz;
+    size_t ed_written = 0;
+    WOLFSSL_SESSION * session = NULL;
+    unsigned int max_early_sz = 0;
 
-    AssertNotNull(ctx_c = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
+    ExpectNotNull(ctx_c = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
     wolfSSL_CTX_UseSessionTicket(ctx_c);
 
-    AssertNotNull(ctx_s = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
-    AssertTrue(wolfSSL_CTX_use_certificate_file(ctx_s, svrCertFile, WOLFSSL_FILETYPE_PEM));
-    AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx_s, svrKeyFile, WOLFSSL_FILETYPE_PEM));
+    ExpectNotNull(ctx_s = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
+    ExpectTrue(wolfSSL_CTX_use_certificate_file(ctx_s, svrCertFile, WOLFSSL_FILETYPE_PEM));
+    ExpectTrue(wolfSSL_CTX_use_PrivateKey_file(ctx_s, svrKeyFile, WOLFSSL_FILETYPE_PEM));
 
     /* setup ssls */
     QuicTestContext_init(&tclient, ctx_c, "client", verbose);
     QuicTestContext_init(&tserver, ctx_s, "server", verbose);
     wolfSSL_set_quic_early_data_enabled(tserver.ssl, 1);
     /* QUIC only allows 0xffffffff or 0x0 as values */
-    AssertIntEQ(wolfSSL_get_max_early_data(tserver.ssl), UINT32_MAX);
+    ExpectIntEQ(wolfSSL_get_max_early_data(tserver.ssl), UINT32_MAX);
 
     QuicConversation_init(&conv, &tclient, &tserver);
     /* run till end */
     QuicConversation_do(&conv);
     /* what have we seen? */
-    AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
+    ExpectStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:"
         "Certificate:CertificateVerify:Finished:Finished:SessionTicket");
 
     /* Should have received a session ticket, save the session */
-    AssertTrue(tclient.ticket_len > 0);
-    AssertNotNull(session = wolfSSL_get1_session(tclient.ssl));
+    ExpectTrue(tclient.ticket_len > 0);
+    ExpectNotNull(session = wolfSSL_get1_session(tclient.ssl));
     QuicTestContext_free(&tclient);
     QuicTestContext_free(&tserver);
 
@@ -1596,35 +1606,35 @@ static int test_quic_early_data(int verbose) {
      * Since we enabled early data in the server that created the session,
      * we need to see it here. */
     max_early_sz = wolfSSL_SESSION_get_max_early_data(session);
-    AssertIntEQ(max_early_sz, UINT32_MAX);
+    ExpectIntEQ(max_early_sz, UINT32_MAX);
 
     /* Do a Session resumption with the ticket */
     QuicTestContext_init(&tserver, ctx_s, "server", verbose);
     QuicTestContext_init(&tclient, ctx_c, "client", verbose);
-    AssertIntEQ(wolfSSL_set_session(tclient.ssl, session), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_set_session(tclient.ssl, session), WOLFSSL_SUCCESS);
     /* enable early data -*/
     wolfSSL_set_quic_early_data_enabled(tserver.ssl, 1);
     /* client will send, and server will receive implicitly */
     QuicConversation_init(&conv, &tclient, &tserver);
     QuicConversation_start(&conv, early_data, sizeof(early_data), &ed_written);
     QuicConversation_do(&conv);
-    AssertIntEQ(wolfSSL_get_early_data_status(tclient.ssl), WOLFSSL_EARLY_DATA_ACCEPTED);
+    ExpectIntEQ(wolfSSL_get_early_data_status(tclient.ssl), WOLFSSL_EARLY_DATA_ACCEPTED);
 
     QuicTestContext_free(&tclient);
     QuicTestContext_free(&tserver);
 
     QuicTestContext_init(&tserver, ctx_s, "server", verbose);
     QuicTestContext_init(&tclient, ctx_c, "client", verbose);
-    AssertIntEQ(wolfSSL_set_session(tclient.ssl, session), WOLFSSL_SUCCESS);
+    ExpectIntEQ(wolfSSL_set_session(tclient.ssl, session), WOLFSSL_SUCCESS);
     /* client will send, and server will receive */
     QuicConversation_init(&conv, &tclient, &tserver);
     /* make QuicConversation_do() use wolfSSL_read_early_data() */
     conv.accept_early_data = 1;
     QuicConversation_start(&conv, early_data, sizeof(early_data), &ed_written);
     QuicConversation_do(&conv);
-    AssertIntEQ(wolfSSL_get_early_data_status(tclient.ssl), WOLFSSL_EARLY_DATA_ACCEPTED);
-    AssertIntEQ(conv.early_data_len, sizeof(early_data));
-    AssertStrEQ(conv.early_data, (const char*)early_data);
+    ExpectIntEQ(wolfSSL_get_early_data_status(tclient.ssl), WOLFSSL_EARLY_DATA_ACCEPTED);
+    ExpectIntEQ(conv.early_data_len, sizeof(early_data));
+    ExpectStrEQ(conv.early_data, (const char*)early_data);
 
     QuicTestContext_free(&tclient);
     QuicTestContext_free(&tserver);
@@ -1632,9 +1642,9 @@ static int test_quic_early_data(int verbose) {
     wolfSSL_SESSION_free(session);
     wolfSSL_CTX_free(ctx_c);
     wolfSSL_CTX_free(ctx_s);
-    printf("    test_quic_early_data: %s\n", (ret == 0)? passed : failed);
+    printf("    test_quic_early_data: %s\n", (EXPECT_SUCCESS())? passed : failed);
 
-    return ret;
+    return EXPECT_RESULT();
 }
 #endif /* WOLFSSL_EARLY_DATA */
 
@@ -1667,19 +1677,19 @@ static int new_session_cb(WOLFSSL *ssl, WOLFSSL_SESSION *session)
 
 static int test_quic_session_export(int verbose)
 {
+    EXPECT_DECLS;
     WOLFSSL_CTX *ctx_c, *ctx_s;
     WOLFSSL_SESSION *session = NULL;
-    int ret = 0;
     QuicTestContext tclient, tserver;
     QuicConversation conv;
     byte session_data[16*1024];
     const byte *bp;
     word32 session_len;
 
-    AssertNotNull(ctx_c = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
-    AssertNotNull(ctx_s = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
-    AssertTrue(wolfSSL_CTX_use_certificate_file(ctx_s, svrCertFile, WOLFSSL_FILETYPE_PEM));
-    AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx_s, svrKeyFile, WOLFSSL_FILETYPE_PEM));
+    ExpectNotNull(ctx_c = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
+    ExpectNotNull(ctx_s = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
+    ExpectTrue(wolfSSL_CTX_use_certificate_file(ctx_s, svrCertFile, WOLFSSL_FILETYPE_PEM));
+    ExpectTrue(wolfSSL_CTX_use_PrivateKey_file(ctx_s, svrKeyFile, WOLFSSL_FILETYPE_PEM));
 
     /* Uses CTX session callback for new sessions */
     wolfSSL_CTX_sess_set_new_cb(ctx_c, new_session_cb);
@@ -1692,10 +1702,10 @@ static int test_quic_session_export(int verbose)
     /* run till end */
     QuicConversation_do(&conv);
     /* what have we seen? */
-    AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:Certificate:CertificateVerify:Finished:Finished:SessionTicket");
+    ExpectStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:Certificate:CertificateVerify:Finished:Finished:SessionTicket");
 
     /* Should have received a session, save it */
-    AssertTrue(tclient.session_len > 0);
+    ExpectTrue(tclient.session_len > 0);
     memcpy(session_data, tclient.session, tclient.session_len);
     session_len = tclient.session_len;
     if (verbose)
@@ -1708,15 +1718,15 @@ static int test_quic_session_export(int verbose)
     QuicTestContext_init(&tserver, ctx_s, "server", verbose);
     QuicTestContext_init(&tclient, ctx_c, "client_resume", verbose);
     bp = session_data;
-    AssertNotNull(session = wolfSSL_d2i_SSL_SESSION(NULL, &bp, session_len));
-    AssertIntEQ(wolfSSL_set_session(tclient.ssl, session), WOLFSSL_SUCCESS);
+    ExpectNotNull(session = wolfSSL_d2i_SSL_SESSION(NULL, &bp, session_len));
+    ExpectIntEQ(wolfSSL_set_session(tclient.ssl, session), WOLFSSL_SUCCESS);
     wolfSSL_SESSION_free(session);
 
     /* let them talk */
     QuicConversation_init(&conv, &tclient, &tserver);
     QuicConversation_do(&conv);
     /* this is what should happen. Look Ma, no certificate! */
-    AssertStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:Finished:Finished:SessionTicket");
+    ExpectStrEQ(conv.rec_log, "ClientHello:ServerHello:EncryptedExtension:Finished:Finished:SessionTicket");
 
     QuicTestContext_free(&tclient);
     QuicTestContext_free(&tserver);
@@ -1724,8 +1734,8 @@ static int test_quic_session_export(int verbose)
     wolfSSL_CTX_free(ctx_c);
     wolfSSL_CTX_free(ctx_s);
 
-    printf("    test_quic_session_export: %s\n", (ret == 0)? passed : failed);
-    return ret;
+    printf("    test_quic_session_export: %s\n", (EXPECT_RESULT())? passed : failed);
+    return EXPECT_RESULT();
 }
 #endif /* WOLFSSL_SESSION_EXPORT */
 
@@ -1739,26 +1749,26 @@ int QuicTest(void)
     int verbose = 0;
     printf(" Begin QUIC Tests\n");
 
-    if ((ret = test_set_quic_method()) != 0) goto leave;
-    if ((ret = test_provide_quic_data()) != 0) goto leave;
-    if ((ret = test_quic_crypt()) != 0) goto leave;
-    if ((ret = test_quic_client_hello(verbose)) != 0) goto leave;
-    if ((ret = test_quic_server_hello(verbose)) != 0) goto leave;
-    if ((ret = test_quic_server_hello_fail(verbose)) != 0) goto leave;
+    if ((ret = test_set_quic_method()) != TEST_SUCCESS) goto leave;
+    if ((ret = test_provide_quic_data()) != TEST_SUCCESS) goto leave;
+    if ((ret = test_quic_crypt()) != TEST_SUCCESS) goto leave;
+    if ((ret = test_quic_client_hello(verbose)) != TEST_SUCCESS) goto leave;
+    if ((ret = test_quic_server_hello(verbose)) != TEST_SUCCESS) goto leave;
+    if ((ret = test_quic_server_hello_fail(verbose)) != TEST_SUCCESS) goto leave;
 #ifdef REALLY_HAVE_ALPN_AND_SNI
-    if ((ret = test_quic_alpn(verbose)) != 0) goto leave;
+    if ((ret = test_quic_alpn(verbose)) != TEST_SUCCESS) goto leave;
 #endif /* REALLY_HAVE_ALPN_AND_SNI */
 #ifdef HAVE_SESSION_TICKET
-    if ((ret = test_quic_key_share(verbose)) != 0) goto leave;
-    if ((ret = test_quic_resumption(verbose)) != 0) goto leave;
+    if ((ret = test_quic_key_share(verbose)) != TEST_SUCCESS) goto leave;
+    if ((ret = test_quic_resumption(verbose)) != TEST_SUCCESS) goto leave;
 #ifdef WOLFSSL_EARLY_DATA
-    if ((ret = test_quic_early_data(verbose)) != 0) goto leave;
+    if ((ret = test_quic_early_data(verbose)) != TEST_SUCCESS) goto leave;
 #endif /* WOLFSSL_EARLY_DATA */
-    if ((ret = test_quic_session_export(verbose)) != 0) goto leave;
+    if ((ret = test_quic_session_export(verbose)) != TEST_SUCCESS) goto leave;
 #endif /* HAVE_SESSION_TICKET */
 
 leave:
-    if (ret != 0)
+    if (ret != TEST_SUCCESS)
         printf("  FAILED: some tests did not pass.\n");
     printf(" End QUIC Tests\n");
 #endif

--- a/tests/quic.c
+++ b/tests/quic.c
@@ -1337,12 +1337,15 @@ static int select_ALPN(WOLFSSL *ssl,
 
 static int test_quic_alpn(int verbose) {
     EXPECT_DECLS;
-    WOLFSSL_CTX * ctx_c = NULL;
-    WOLFSSL_CTX * ctx_s = NULL;
-    QuicTestContext tclient, tserver;
-    QuicConversation conv;
+    WOLFSSL_CTX *        ctx_c = NULL;
+    WOLFSSL_CTX *        ctx_s = NULL;
+    QuicTestContext      tclient, tserver;
+    QuicConversation     conv;
     struct stripe_buffer stripe;
-    unsigned char alpn_protos[256];
+    unsigned char        alpn_protos[256];
+
+    XMEMSET(&stripe, 0, sizeof(stripe));
+    XMEMSET(alpn_protos, 0, sizeof(alpn_protos));
 
     ExpectNotNull(ctx_c = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
     ExpectNotNull(ctx_s = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
@@ -1392,9 +1395,9 @@ static int test_quic_alpn(int verbose) {
 
 static int test_quic_key_share(int verbose) {
     EXPECT_DECLS;
-    WOLFSSL_CTX * ctx_c = NULL;
-    WOLFSSL_CTX * ctx_s = NULL;
-    QuicTestContext tclient, tserver;
+    WOLFSSL_CTX *    ctx_c = NULL;
+    WOLFSSL_CTX *    ctx_s = NULL;
+    QuicTestContext  tclient, tserver;
     QuicConversation conv;
 
     ExpectNotNull(ctx_c = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
@@ -1469,13 +1472,16 @@ static int test_quic_key_share(int verbose) {
 
 static int test_quic_resumption(int verbose) {
     EXPECT_DECLS;
-    WOLFSSL_CTX *ctx_c, *ctx_s;
-    WOLFSSL_SESSION *session, *session_restored;
-    QuicTestContext tclient, tserver;
-    QuicConversation conv;
-    unsigned char session_buffer[16 * 1024], *session_data;
-    const unsigned char *session_data2;
-    unsigned int session_size;
+    WOLFSSL_CTX *         ctx_c = NULL;
+    WOLFSSL_CTX *         ctx_s = NULL;
+    WOLFSSL_SESSION *     session = NULL;
+    WOLFSSL_SESSION *     session_restored = NULL;
+    QuicTestContext       tclient, tserver;
+    QuicConversation      conv;
+    unsigned char         session_buffer[16 * 1024];
+    unsigned char *       session_data = NULL;
+    const unsigned char * session_data2 = NULL;
+    unsigned int          session_size = 0;
 
     ExpectNotNull(ctx_c = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
     ExpectNotNull(ctx_s = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
@@ -1536,7 +1542,7 @@ static int test_quic_resumption(int verbose) {
 
     {
         /* Do a Session resumption with a new server ctx */
-        WOLFSSL_CTX *ctx_s2;
+        WOLFSSL_CTX * ctx_s2 = NULL;
         ExpectNotNull(ctx_s2 = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
         ExpectTrue(wolfSSL_CTX_use_certificate_file(ctx_s2, eccCertFile, WOLFSSL_FILETYPE_PEM));
         ExpectTrue(wolfSSL_CTX_use_PrivateKey_file(ctx_s2, eccKeyFile, WOLFSSL_FILETYPE_PEM));
@@ -1566,14 +1572,14 @@ static int test_quic_resumption(int verbose) {
 #ifdef WOLFSSL_EARLY_DATA
 static int test_quic_early_data(int verbose) {
     EXPECT_DECLS;
-    WOLFSSL_CTX * ctx_c = NULL; 
-    WOLFSSL_CTX * ctx_s = NULL;
-    QuicTestContext tclient, tserver;
-    QuicConversation conv;
-    const byte early_data[] = "Nulla dies sine linea!";
-    size_t ed_written = 0;
+    WOLFSSL_CTX *     ctx_c = NULL;
+    WOLFSSL_CTX *     ctx_s = NULL;
+    QuicTestContext   tclient, tserver;
+    QuicConversation  conv;
+    const byte        early_data[] = "Nulla dies sine linea!";
+    size_t            ed_written = 0;
     WOLFSSL_SESSION * session = NULL;
-    unsigned int max_early_sz = 0;
+    unsigned int      max_early_sz = 0;
 
     ExpectNotNull(ctx_c = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
     wolfSSL_CTX_UseSessionTicket(ctx_c);
@@ -1650,10 +1656,10 @@ static int test_quic_early_data(int verbose) {
 
 static int new_session_cb(WOLFSSL *ssl, WOLFSSL_SESSION *session)
 {
-    QuicTestContext *ctx = (QuicTestContext*)wolfSSL_get_app_data(ssl);
-    byte *data;
-    int ret = 0;
-    int sz;
+    QuicTestContext * ctx = (QuicTestContext*)wolfSSL_get_app_data(ssl);
+    byte * data = NULL;
+    int    ret = 0;
+    int    sz = 0;
 
     AssertNotNull(ctx);
 
@@ -1678,13 +1684,14 @@ static int new_session_cb(WOLFSSL *ssl, WOLFSSL_SESSION *session)
 static int test_quic_session_export(int verbose)
 {
     EXPECT_DECLS;
-    WOLFSSL_CTX *ctx_c, *ctx_s;
-    WOLFSSL_SESSION *session = NULL;
-    QuicTestContext tclient, tserver;
-    QuicConversation conv;
-    byte session_data[16*1024];
-    const byte *bp;
-    word32 session_len;
+    WOLFSSL_CTX *     ctx_c = NULL;
+    WOLFSSL_CTX *     ctx_s = NULL;
+    WOLFSSL_SESSION * session = NULL;
+    QuicTestContext   tclient, tserver;
+    QuicConversation  conv;
+    byte              session_data[16*1024];
+    const byte *      bp = NULL;
+    word32            session_len = 0;
 
     ExpectNotNull(ctx_c = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
     ExpectNotNull(ctx_s = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));

--- a/tests/quic.c
+++ b/tests/quic.c
@@ -402,7 +402,8 @@ static int test_quic_crypt(void) {
     ExpectTrue(wolfSSL_quic_aead_is_ccm(aead_cipher) == 0);
     ExpectTrue(wolfSSL_quic_aead_is_chacha20(aead_cipher) == 0);
 
-    ExpectTrue((tag_len = wolfSSL_quic_get_aead_tag_len(aead_cipher)) == 16);
+    tag_len = wolfSSL_quic_get_aead_tag_len(aead_cipher);
+    ExpectTrue(tag_len == 16);
     dec_len = sizeof(plaintext);
     enc_len = dec_len + tag_len;
     encrypted = (uint8_t*)XMALLOC(enc_len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -1569,7 +1570,8 @@ static int test_quic_resumption(int verbose) {
      * a session works. */
     ExpectTrue(tclient.ticket_len > 0);
     ExpectNotNull(session = wolfSSL_get1_session(tclient.ssl));
-    ExpectTrue((session_size = (unsigned int)wolfSSL_i2d_SSL_SESSION(session, NULL)) > 0);
+    session_size = (unsigned int)wolfSSL_i2d_SSL_SESSION(session, NULL);
+    ExpectTrue(session_size > 0);
     ExpectTrue((size_t)session_size < sizeof(session_buffer));
     session_data2 = session_data = session_buffer;
     session_size = (unsigned int)wolfSSL_i2d_SSL_SESSION(session,

--- a/tests/quic.c
+++ b/tests/quic.c
@@ -1775,9 +1775,10 @@ int QuicTest(void)
 #endif /* HAVE_SESSION_TICKET */
 
 leave:
-    if (ret != TEST_SUCCESS)
+    if (ret != TEST_SUCCESS) {
         printf("  FAILED: some tests did not pass.\n");
+    }
     printf(" End QUIC Tests\n");
 #endif
-    return ret;
+    return ret == TEST_SUCCESS ? 0 : -1;
 }

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -245,7 +245,7 @@ int unit_test(int argc, char** argv)
     #endif /* WOLFSSL_W64_WRAPPER */
 
     #ifdef WOLFSSL_QUIC
-        if ((ret = QuicTest()) != TEST_SUCCESS) {
+        if ((ret = QuicTest()) != 0) {
             printf("quic test failed with %d\n", ret);
             goto exit;
         }

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -245,7 +245,7 @@ int unit_test(int argc, char** argv)
     #endif /* WOLFSSL_W64_WRAPPER */
 
     #ifdef WOLFSSL_QUIC
-        if ((ret = QuicTest()) != 0) {
+        if ((ret = QuicTest()) != TEST_SUCCESS) {
             printf("quic test failed with %d\n", ret);
             goto exit;
         }


### PR DESCRIPTION
# Description

Clean up tests/quic.c:
- Use Expect* macros instead of Asserts. Fixes a bunch of coverity `dead_error_condition:` warnings, because ret value was never updated or checked.
- Clean up line lengths.
- Fix some c89-clang-tidy warnings (uninitialized data, mixing code and declarations, etc).

# Testing

```
./configure --enable-quic --enable-earlydata --enable-session-ticket
make
./tests/unit.test
```

```
./wolfssl-multi-test.sh --with-prepared-wolfssl-workspace=/home/jordan/work/wolfssl/ \
   --no-result-cache all-c89-clang-tidy
```
