### PR TITLE
coverity: pacify test_md5 uninitialized scalar variable warning.

### DIFF
--- a/tests/api/test_digest.h
+++ b/tests/api/test_digest.h
@@ -378,8 +378,9 @@ do {                                                                           \
                                                                                \
     XMEMSET(data, 0xa5, sizeof(data));                                         \
                                                                                \
-    ExpectIntEQ(wc_Init##name(&src), 0);                                       \
+    XMEMSET(&src, 0, sizeof(src));                                             \
     XMEMSET(&dst, 0, sizeof(dst));                                             \
+    ExpectIntEQ(wc_Init##name(&src), 0);                                       \
                                                                                \
     /* Tests bad params. */                                                    \
     ExpectIntEQ(wc_##name##Copy(NULL, NULL), WC_NO_ERR_TRACE(BAD_FUNC_ARG));   \
@@ -513,6 +514,7 @@ do {                                                                           \
     const char* emptyHash = emptyHashStr;                                      \
     const char* abcHash = abcHashStr;                                          \
                                                                                \
+    XMEMSET(&dgst, 0, sizeof(dgst));                                           \
     ExpectIntEQ(wc_Init##name(&dgst), 0);                                      \
                                                                                \
     ExpectIntEQ(wc_##name##GetHash(NULL, NULL),                                \
@@ -657,6 +659,7 @@ do {                                                                           \
     type dgst_copy;                                                            \
     word32 flags;                                                              \
                                                                                \
+    XMEMSET(&dgst, 0, sizeof(dgst));                                           \
     XMEMSET(&dgst_copy, 0, sizeof(dgst_copy));                                 \
     ExpectIntEQ(wc_Init##name(&dgst), 0);                                      \
                                                                                \


### PR DESCRIPTION
# Description

Pacify coverity uninitialized scalar variable warnings in tests/api/test_md5.c.