### PR TITLE
20250312-linuxkm-lkcapi-aes-cfb-fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9063,7 +9063,6 @@ then
         'cbc(aes)') test "$ENABLED_AESCBC" != "no" || AC_MSG_ERROR([linuxkm-lkcapi-register ${lkcapi_alg}: AES-CBC implementation not enabled.])
                     AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_REGISTER_AESCBC" ;;
         'cfb(aes)') test "$ENABLED_AESCFB" != "no" || AC_MSG_ERROR([linuxkm-lkcapi-register ${lkcapi_alg}: AES-CFB implementation not enabled.])
-                    test "$ENABLED_EXPERIMENTAL" = "yes" || AC_MSG_ERROR([linuxkm-lkcapi-register ${lkcapi_alg}: requires --enable-experimental.])
                     AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_REGISTER_AESCFB" ;;
         'gcm(aes)') test "$ENABLED_AESGCM" != "no" || AC_MSG_ERROR([linuxkm-lkcapi-register ${lkcapi_alg}: AES-GCM implementation not enabled.])
                     test "$ENABLED_AESGCM_STREAM" != "no" || AC_MSG_ERROR([linuxkm-lkcapi-register ${lkcapi_alg}: --enable-aesgcm-stream is required for LKCAPI.])

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -270,7 +270,7 @@ static int wolfssl_init(void)
     }
 #endif
 
-#ifdef HAVE_FIPS
+#if defined(HAVE_FIPS) && FIPS_VERSION3_GT(5,2,0)
     ret = wc_RunAllCast_fips();
     if (ret != 0) {
         pr_err("wc_RunAllCast_fips() failed with return value %d\n", ret);
@@ -302,7 +302,7 @@ static int wolfssl_init(void)
             ""
 #endif
         );
-#endif /* HAVE_FIPS */
+#endif /* HAVE_FIPS && FIPS_VERSION3_GT(5,2,0) */
 
 #ifndef NO_CRYPT_TEST
     ret = wolfcrypt_test(NULL);
@@ -314,8 +314,10 @@ static int wolfssl_init(void)
     }
     pr_info("wolfCrypt self-test passed.\n");
 #else
+#if !defined(HAVE_FIPS) || FIPS_VERSION3_LE(5,2,0)
     pr_info("skipping full wolfcrypt_test() "
             "(configure with --enable-crypttests to enable).\n");
+#endif
 #endif
 
 #ifdef LINUXKM_LKCAPI_REGISTER


### PR DESCRIPTION
`linuxkm/lkcapi_glue.c`: fix aes-cfb wrappers, and add `WOLFSSL_DEBUG_TRACE_ERROR_CODES` support for `EINVAL`/`ENOMEM`/`EBADMSG`;

`configure.ac`: remove `ENABLED_EXPERIMENTAL` requirement for
  `--enable-linuxkm-lkcapi-register=cfb(aes)`;

`linuxkm/module_hooks.c`: omit "skipping full wolfcrypt_test" message if
  `wc_RunAllCast_fips()` was run.

tested with `wolfssl-multi-test.sh ... linuxkm-all-aesni-cryptonly-LKCAPI-insmod-crypto-fuzzer linuxkm-all-cryptonly-intelasm-LKCAPI-insmod-mainline-fallback-fuzzing linuxkm-mainline-plus-wireguard linuxkm-mainline-pie linuxkm-mainline-aesni-pie-gcc-latest-insmod linuxkm-mainline-intelasm-sp-asm-pie-gcc-latest-insmod check-source-text check-configure` with `cfb(aes)` added to `LKCAPI_REGISTER_FLAGS`.
