### PR TITLE
Add option to disallow automatic use of "default" devId

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8791,10 +8791,20 @@ AC_ARG_ENABLE([cryptodev],
 
 # Support for crypto callbacks
 AC_ARG_ENABLE([cryptocb],
-    [AS_HELP_STRING([--enable-cryptocb],[Enable crypto callbacks (default: disabled)])],
-    [ ENABLED_CRYPTOCB=$enableval ],
-    [ ENABLED_CRYPTOCB=no ]
-    )
+    [AS_HELP_STRING([--enable-cryptocb],
+        [Enable crypto callbacks (default: disabled). Use 'no-default-devid' to enable without a platform-specific default device ID])],
+[
+    case "$enableval" in
+        no-default-devid)
+            ENABLED_CRYPTOCB=yes
+            AM_CPPFLAGS="$AM_CPPFLAGS -DWC_NO_DEFAULT_DEVID"
+            ;;
+        *)
+            ENABLED_CRYPTOCB="$enableval"
+            ;;
+    esac
+],
+[ ENABLED_CRYPTOCB=no ])
 
 # Enable testing of cryptoCb using software crypto. On platforms where wolfCrypt tests
 # are used to test a custom cryptoCb, it may be desired to disable this so wolfCrypt tests
@@ -9264,14 +9274,6 @@ if test "$ENABLED_LOWRESOURCE" = "yes" && test "$ENABLED_ECC" = "yes" && (test "
 then
     AM_CFLAGS="$AM_CFLAGS -DALT_ECC_SIZE"
 fi
-
-AC_ARG_ENABLE([default-devid],
-    [AS_HELP_STRING([--disable-default-devid],[Disable default device ID (default: disabled)])],
-    [ if test "x$enableval" = "xno" ; then
-        AM_CFLAGS="$AM_CFLAGS -DWC_NO_DEFAULT_DEVID"
-      fi
-    ],
-    [ENABLED_DEFAULT_DEVID=yes])
 
 ################################################################################
 # Update ENABLE_* variables                                                    #

--- a/configure.ac
+++ b/configure.ac
@@ -9265,6 +9265,14 @@ then
     AM_CFLAGS="$AM_CFLAGS -DALT_ECC_SIZE"
 fi
 
+AC_ARG_ENABLE([default-devid],
+    [AS_HELP_STRING([--disable-default-devid],[Disable default device ID (default: disabled)])],
+    [ if test "x$enableval" = "xno" ; then
+        AM_CFLAGS="$AM_CFLAGS -DWC_NO_DEFAULT_DEVID"
+      fi
+    ],
+    [ENABLED_DEFAULT_DEVID=yes])
+
 ################################################################################
 # Update ENABLE_* variables                                                    #
 ################################################################################

--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -1882,6 +1882,12 @@ int wc_CryptoCb_DefaultDevID(void)
 {
     int ret;
 
+/* Explicitly disable the "default devId" behavior. Ensures that any devId
+ * will only be used if explicitly passed as an argument to crypto functions,
+ * and never automatically selected. */
+#ifdef WC_NO_DEFAULT_DEVID
+    ret = INVALID_DEVID;
+#else
     /* conditional macro selection based on build */
 #ifdef WOLFSSL_CAAM_DEVID
     ret = WOLFSSL_CAAM_DEVID;
@@ -1893,6 +1899,7 @@ int wc_CryptoCb_DefaultDevID(void)
     /* try first available */
     ret = wc_CryptoCb_GetDevIdAtIndex(0);
 #endif
+#endif /* WC_NO_DEFAULT_DEVID */
 
     return ret;
 }


### PR DESCRIPTION
# Description

Adds a build option preventing any API that currently uses `wc_CryptoCb_DefaultDevID` to fall back to a "default" devId (which currently is just the first registered global devId) from doing so.

The `wc_CryptoCb_DefaultDevID()` function is currently used by [SHA](https://github.com/wolfSSL/wolfssl/blame/517f4bd561ce1dd1c2404c8c9cc2b06eec6ff97a/wolfcrypt/src/sha256.c#L2226) and [hash.c](https://github.com/wolfSSL/wolfssl/blame/517f4bd561ce1dd1c2404c8c9cc2b06eec6ff97a/wolfcrypt/src/hash.c#L1396) implementations, which causes them to automatically choose a devId even when not requested. I think this behavior is incorrect, as I might not want my cryptoCb devId to be used when I don't explicitly choose to use it, and if one is to be used, it should definitely not just be the somewhat arbitrary choice of the first one in the global list. 

IMO, the correct behavior would be to always use `INVALID_DEVID` unless you explicitly opt in to a fixed platform-wide devID by building with a special platform configuration flag (`WOLFSSL_CAAM_DEVID`, etc.). We should never arbitrarily choose the first devId from the list. However, I realize that certain platforms may be relying on this functionality currently, so I've elected to make the change opt-in to prevent breaking on platforms for which we don't have CI coverage (the only real places this is relevant).

If we are okay with the slightly more intrusive step of defaulting to the new "`INVALID_DEVID` as default" behavior but provide a build macro to keep the current behavior, I think that would be even better, so let me know and I can change the default.

Relevant: #4916 and #7127

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
