### PR TITLE
ECH: generate multiple configs and rotate echConfigs

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -50104,6 +50104,26 @@ static int test_wolfSSL_Tls13_ECH_params(void)
         "ech-public-name.com", 1000, 1000, 1000));
 
     /* invalid ctx */
+    ExpectIntNE(WOLFSSL_SUCCESS, wolfSSL_CTX_SetEchConfigsBase64(NULL,
+        (char*)testBuf, sizeof(testBuf)));
+    /* invalid base64 configs */
+    ExpectIntNE(WOLFSSL_SUCCESS, wolfSSL_CTX_SetEchConfigsBase64(ctx,
+        NULL, sizeof(testBuf)));
+    /* invalid length */
+    ExpectIntNE(WOLFSSL_SUCCESS, wolfSSL_CTX_SetEchConfigsBase64(ctx,
+        (char*)testBuf, 0));
+
+    /* invalid ctx */
+    ExpectIntNE(WOLFSSL_SUCCESS, wolfSSL_CTX_SetEchConfigs(NULL,
+        testBuf, sizeof(testBuf)));
+    /* invalid configs */
+    ExpectIntNE(WOLFSSL_SUCCESS, wolfSSL_CTX_SetEchConfigs(ctx,
+        NULL, sizeof(testBuf)));
+    /* invalid length */
+    ExpectIntNE(WOLFSSL_SUCCESS, wolfSSL_CTX_SetEchConfigs(ctx,
+        testBuf, 0));
+
+    /* invalid ctx */
     ExpectIntNE(WOLFSSL_SUCCESS, wolfSSL_CTX_GetEchConfigs(NULL, NULL,
         &outputLen));
     /* invalid output len */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3176,6 +3176,10 @@ WOLFSSL_LOCAL int EchConfigGetSupportedCipherSuite(WOLFSSL_EchConfig* config);
 
 WOLFSSL_LOCAL int TLSX_FinalizeEch(WOLFSSL_ECH* ech, byte* aad, word32 aadLen);
 
+
+WOLFSSL_LOCAL int SetEchConfigsEx(WOLFSSL_EchConfig** outputConfigs, void* heap,
+    const byte* echConfigs, word32 echConfigsLen);
+
 WOLFSSL_LOCAL int GetEchConfig(WOLFSSL_EchConfig* config, byte* output,
     word32* outputLen);
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1181,6 +1181,12 @@ WOLFSSL_API WOLFSSL_METHOD *wolfSSLv23_method(void);
 WOLFSSL_API int wolfSSL_CTX_GenerateEchConfig(WOLFSSL_CTX* ctx,
     const char* publicName, word16 kemId, word16 kdfId, word16 aeadId);
 
+WOLFSSL_API int wolfSSL_CTX_SetEchConfigsBase64(WOLFSSL_CTX* ctx,
+    const char* echConfigs64, word32 echConfigs64Len);
+
+WOLFSSL_API int wolfSSL_CTX_SetEchConfigs(WOLFSSL_CTX* ctx,
+    const byte* echConfigs, word32 echConfigsLen);
+
 WOLFSSL_API int wolfSSL_CTX_GetEchConfigs(WOLFSSL_CTX* ctx, byte* output,
     word32* outputLen);
 


### PR DESCRIPTION
# Description

Change wolfSSL_CTX_GenerateEchConfig to generate multiple configs, add functions to rotate the server's echConfigs.

#7668 (comment)

# Testing

./configure '--disable-shared' '--enable-all' '--enable-ech'

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
