### PR TITLE
Poly1305 ARM32 assembly code: loading with ldm

### DIFF
--- a/wolfcrypt/src/port/arm/armv8-32-poly1305-asm.S
+++ b/wolfcrypt/src/port/arm/armv8-32-poly1305-asm.S
@@ -815,7 +815,10 @@ L_poly1305_arm32_blocks_start_1:
 	mov	r12, #1
 	push	{r2}
 	# Load message
-	ldm	r1, {r2, r3, r4, r5}
+	ldr	r2, [r1]
+	ldr	r3, [r1, #4]
+	ldr	r4, [r1, #8]
+	ldr	r5, [r1, #12]
 	# Add message
 	adds	r7, r7, r2
 	adcs	r8, r8, r3

--- a/wolfcrypt/src/port/arm/armv8-32-poly1305-asm_c.c
+++ b/wolfcrypt/src/port/arm/armv8-32-poly1305-asm_c.c
@@ -870,7 +870,10 @@ void poly1305_arm32_blocks(Poly1305* ctx_p, const unsigned char* m_p,
         "mov	r12, #1\n\t"
         "push	{r2}\n\t"
         /* Load message */
-        "ldm	%[m], {r2, r3, r4, r5}\n\t"
+        "ldr	%[bytes], [%[m]]\n\t"
+        "ldr	r3, [%[m], #4]\n\t"
+        "ldr	r4, [%[m], #8]\n\t"
+        "ldr	r5, [%[m], #12]\n\t"
         /* Add message */
         "adds	r7, r7, %[bytes]\n\t"
         "adcs	r8, r8, r3\n\t"


### PR DESCRIPTION
# Description

Loading message with ldm, that requires aligned pointers, when 64n + 16*[1-3] bytes are to be processed.

# Testing

Enable assembly with ARMv7a all build and run all tests with emulator that crashes when unaligned loads are performed.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
