### PR TITLE
20250313-various-fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,6 +124,7 @@ AC_CHECK_LIB([network],[socket])
 AC_C_BIGENDIAN
 AC_C___ATOMIC
 AC_CHECK_HEADER(stdatomic.h, [AM_CPPFLAGS="$AM_CPPFLAGS -DWOLFSSL_HAVE_ATOMIC_H"],[])
+AC_CHECK_HEADER(assert.h, [AM_CPPFLAGS="$AM_CPPFLAGS -DWOLFSSL_HAVE_ASSERT_H"],[])
 
 # check if functions of interest are linkable, but also check if
 # they're declared by the expected headers, and if not, supersede the
@@ -1212,6 +1213,16 @@ then
     esac
 fi
 
+# 32 bit armasm and RISC-V asm don't yet support WOLFSSL_AESGCM_STREAM.  Disable
+# implicit activation, and error on explicit activation.
+if test "$enable_riscv_asm" = "yes" || (test "$enable_armasm" = "yes" && test "$host_cpu" != "aarch64" && test "$host_cpu" != "aarch64_be")
+then
+    if test "$enable_aesgcm_stream" = "yes"
+    then
+        AC_MSG_ERROR([32 bit armasm and RISC-V asm don't yet support WOLFSSL_AESGCM_STREAM.])
+    fi
+    enable_aesgcm_stream=no
+fi
 
 # All wolfCrypt features:
 AC_ARG_ENABLE([all-crypto],
@@ -6058,7 +6069,7 @@ fi
 
 # CHACHA
 AC_ARG_ENABLE([chacha],
-    [AS_HELP_STRING([--enable-chacha],[Enable CHACHA (default: enabled). Use `=noasm` to disable ASM AVX/AVX2 speedups])],
+    [AS_HELP_STRING([--enable-chacha],[Enable CHACHA (default: enabled). Use `=noasm` to disable asm speedups])],
     [ ENABLED_CHACHA=$enableval ],
     [ ENABLED_CHACHA=$CHACHA_DEFAULT]
     )
@@ -9744,7 +9755,12 @@ if test "$ENABLED_AESGCM_STREAM" != "no"
 then
     if test "$ENABLED_AESGCM" = "no"
     then
-        AC_MSG_ERROR([AES-GCM streaming enabled but AES-GCM is disabled])
+        AC_MSG_ERROR([AES-GCM streaming is enabled but AES-GCM is disabled.])
+    elif test "$ENABLED_RISCV_ASM" = "yes" || \
+         (test "$ENABLED_ARMASM" = "yes" && \
+          test "$host_cpu" != "aarch64" && test "$host_cpu" != "aarch64_be")
+    then
+        AC_MSG_ERROR([32 bit armasm and RISC-V asm don't yet support WOLFSSL_AESGCM_STREAM.])
     else
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_AESGCM_STREAM"
         AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_AESGCM_STREAM"
@@ -10156,6 +10172,7 @@ AM_CONDITIONAL([BUILD_SHA224],[test "x$ENABLED_SHA224" = "xyes" || test "x$ENABL
 AM_CONDITIONAL([BUILD_SHA3],[test "x$ENABLED_SHA3" != "xno" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_POLY1305],[test "x$ENABLED_POLY1305" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_CHACHA],[test "x$ENABLED_CHACHA" = "xyes" || test "x$ENABLED_CHACHA" = "xnoasm" || test "x$ENABLED_USERSETTINGS" = "xyes"])
+AM_CONDITIONAL([BUILD_CHACHA_NOASM],[test "$ENABLED_CHACHA" = "noasm"])
 AM_CONDITIONAL([BUILD_XCHACHA],[test "x$ENABLED_XCHACHA" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_ASCON],[test "x$ENABLED_ASCON" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_SM2],[test "x$ENABLED_SM2" != "xno" || test "x$ENABLED_USERSETTINGS" = "xyes"])

--- a/src/include.am
+++ b/src/include.am
@@ -1127,6 +1127,7 @@ endif
 
 if BUILD_CHACHA
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/chacha.c
+if !BUILD_CHACHA_NOASM
 if BUILD_ARMASM
 if BUILD_ARM_NONTHUMB
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/port/arm/armv8-chacha.c
@@ -1159,6 +1160,7 @@ src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/chacha_asm.S
 endif BUILD_INTELASM
 endif !BUILD_X86_ASM
 endif !BUILD_ARMASM
+endif !BUILD_CHACHA_NOASM
 if BUILD_POLY1305
 src_libwolfssl@LIBSUFFIX@_la_SOURCES += wolfcrypt/src/chacha20_poly1305.c
 endif BUILD_POLY1305

--- a/tests/api.c
+++ b/tests/api.c
@@ -86346,7 +86346,8 @@ static int test_TLSX_CA_NAMES_bad_extension(void)
 #if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_TLS13) && \
     !defined(NO_CERTS) && !defined(WOLFSSL_NO_CA_NAMES) && \
     defined(OPENSSL_EXTRA) && defined(WOLFSSL_SHA384) && \
-    defined(HAVE_NULL_CIPHER)
+    defined(HAVE_NULL_CIPHER) && defined(HAVE_CHACHA) && \
+    defined(HAVE_POLY1305)
     /* This test should only fail (with BUFFER_ERROR) when we actually try to
      * parse the CA Names extension. Otherwise it will return other non-related
      * errors. If CA Names will be parsed in more configurations, that should

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -6473,7 +6473,7 @@ static WC_INLINE void IncCtr(byte* ctr, word32 ctrSz)
 #endif
 
 #if defined(WOLFSSL_ARMASM) && !defined(__aarch64__)
-    /* implemented in wolfcrypt/src/port/arm/rmv8-aes.c */
+    /* implemented in wolfcrypt/src/port/arm/armv8-aes.c */
 
 #elif defined(WOLFSSL_RISCV_ASM)
     /* implemented in wolfcrypt/src/port/risc-v/riscv-64-aes.c */
@@ -10874,7 +10874,7 @@ int wc_AesCcmCheckTagSize(int sz)
 }
 
 #if defined(WOLFSSL_ARMASM) && !defined(__aarch64__)
-    /* implemented in wolfcrypt/src/port/arm/rmv8-aes.c */
+    /* implemented in wolfcrypt/src/port/arm/armv8-aes.c */
 
 #elif defined(WOLFSSL_RISCV_ASM)
     /* implementation located in wolfcrypt/src/port/risc-v/riscv-64-aes.c */

--- a/wolfcrypt/src/chacha.c
+++ b/wolfcrypt/src/chacha.c
@@ -72,10 +72,10 @@ Public domain.
 #endif /* HAVE_CHACHA */
 
 
-#if defined(WOLFSSL_ARMASM)
+#if defined(WOLFSSL_ARMASM) && !defined(NO_CHACHA_ASM)
     /* implementation is located in wolfcrypt/src/port/arm/armv8-chacha.c */
 
-#elif defined(WOLFSSL_RISCV_ASM)
+#elif defined(WOLFSSL_RISCV_ASM) && !defined(NO_CHACHA_ASM)
     /* implementation located in wolfcrypt/src/port/riscv/riscv-64-chacha.c */
 
 #else

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1808,6 +1808,11 @@ typedef struct w64wrapper {
         #define wc_static_assert(expr) struct wc_static_assert_dummy_struct
         #define wc_static_assert2(expr, msg) wc_static_assert(expr)
     #elif !defined(wc_static_assert)
+        #if defined(WOLFSSL_HAVE_ASSERT_H) || \
+            (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)) || \
+            (defined(__cplusplus) && (__cplusplus >= 201103L))
+            #include <assert.h>
+        #endif
         #if (defined(__cplusplus) && (__cplusplus >= 201703L)) || \
                (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 202311L)) || \
                (defined(_MSVC_LANG) && (__cpp_static_assert >= 201411L))


### PR DESCRIPTION
`configure.ac`:
* sense `assert.h` and define `WOLFSSL_HAVE_ASSERT_H` accordingly.
* force off `enable_aesgcm_stream` if 32 bit armasm or riscv-asm (not yet implemented or buildable).
* add `AM_CONDITIONAL([BUILD_CHACHA_NOASM, ...])` when `--enable-chacha=noasm`.

`src/include.am`: gate armasm/riscv_asm chacha files on `!BUILD_CHACHA_NOASM`.

`tests/api.c`: add missing `HAVE_CHACHA`&&`HAVE_POLY1305` gate around `test_TLSX_CA_NAMES_bad_extension()`.

`wolfcrypt/src/chacha.c`: tweak `WOLFSSL_ARMASM` and `WOLFSSL_RISCV_ASM` codepaths to also depend on !`NO_CHACHA_ASM`.

`wolfssl/wolfcrypt/types.h`: in setup for `wc_static_assert()`, `#include <assert.h>` if `WOLFSSL_HAVE_ASSERT_H`, >=C11, or >=C++11.

tested with
```
wolfssl-multi-test.sh ...
    super-quick-check
    quantum-safe-wolfssl-all-cross-armv7a-armasm-unittest
    quantum-safe-wolfssl-all-cross-armv7a-armasm-unittest-Os
    quantum-safe-wolfssl-all-cross-armv7a-armasm-unittest-Os-smallstack
    quantum-safe-wolfssl-all-cross-armv7a-noasm-unittest-Os-smallstack
    lean-fips-dev-armv7-small-armasm
    lean-fips-dev-armv7-small-armasm-sanitizer
    cross-armv6zk-all-armasm
    cross-riscv64-all-asm
    cross-armv7a-all-armasm-testsuite-sanitizer
    cross-armv7a-armasm-fips-140-3-dev-sp-all-testsuite-sanitizer
    cross-armv6zk-all-asm-testwolfcrypt-sanitizer
    cross-armv7a-all-armasm-testwolfcrypt-sanitizer
```
