### PR TITLE
20250317-linuxkm-AES-GCM

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9069,8 +9069,7 @@ then
     for lkcapi_alg in $(echo "$ENABLED_LINUXKM_LKCAPI_REGISTER" | tr ',' ' ')
     do
         case "$lkcapi_alg" in
-        all) test "$ENABLED_EXPERIMENTAL" = "yes" || AC_MSG_ERROR([linuxkm-lkcapi-register ${lkcapi_alg}: requires --enable-experimental.])
-             AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_REGISTER_ALL"           ;;
+        all) AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_REGISTER_ALL"           ;;
         'cbc(aes)') test "$ENABLED_AESCBC" != "no" || AC_MSG_ERROR([linuxkm-lkcapi-register ${lkcapi_alg}: AES-CBC implementation not enabled.])
                     AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_REGISTER_AESCBC" ;;
         'cfb(aes)') test "$ENABLED_AESCFB" != "no" || AC_MSG_ERROR([linuxkm-lkcapi-register ${lkcapi_alg}: AES-CFB implementation not enabled.])

--- a/configure.ac
+++ b/configure.ac
@@ -9077,7 +9077,6 @@ then
                     AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_REGISTER_AESCFB" ;;
         'gcm(aes)') test "$ENABLED_AESGCM" != "no" || AC_MSG_ERROR([linuxkm-lkcapi-register ${lkcapi_alg}: AES-GCM implementation not enabled.])
                     test "$ENABLED_AESGCM_STREAM" != "no" || AC_MSG_ERROR([linuxkm-lkcapi-register ${lkcapi_alg}: --enable-aesgcm-stream is required for LKCAPI.])
-                    test "$ENABLED_EXPERIMENTAL" = "yes" || AC_MSG_ERROR([linuxkm-lkcapi-register ${lkcapi_alg}: requires --enable-experimental.])
                     AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_REGISTER_AESGCM" ;;
         'xts(aes)') test "$ENABLED_AESXTS" != "no" || AC_MSG_ERROR([linuxkm-lkcapi-register ${lkcapi_alg}: AES-XTS implementation not enabled.])
                     test "$ENABLED_AESXTS_STREAM" != "no" || AC_MSG_ERROR([linuxkm-lkcapi-register ${lkcapi_alg}: --enable-aesxts-stream is required for LKCAPI.])

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3641,6 +3641,8 @@ extern void uITRON4_free(void *p) ;
     #ifndef NO_OLD_SSL_NAMES
         #define NO_OLD_SSL_NAMES
     #endif
+    #undef WOLFSSL_MIN_AUTH_TAG_SZ
+    #define WOLFSSL_MIN_AUTH_TAG_SZ 4
 #endif
 
 


### PR DESCRIPTION
linuxkm: fix AES-GCM shim implementation and self-test.

tested with
```
wolfssl-multi-test.sh ...
check-source-text
linuxkm-aesgcm-cryptonly-noasm-LKCAPI-no-twc-insmod-crypto-fuzzer-extras
linuxkm-all-cryptonly-aesni-fips-dev-dyn-hash-LKCAPI-insmod-fallback-fuzzing
linuxkm-all-fips-dev-cryptonly-LKCAPI-insmod-fortify
linuxkm-legacy-5.4-insmod
linuxkm-legacy-5.10-insmod
linuxkm-legacy-6.6-insmod
linuxkm-legacy-6.12-insmod
linuxkm-fips-v6-static-hash-intelasm-LKCAPI-insmod
linuxkm-all-fips-v5-cryptonly-LKCAPI-insmod-fortify
linuxkm-all-fips-v5-aesni-cryptonly-LKCAPI-insmod-fortify
linuxkm-noasm-ksanitize-insmod
linuxkm-aesni-insmod-kmemleak
```
with `gcm(aes)` added to `LKCAPI_REGISTER_FLAGS`
