### PR TITLE
linuxkm fedora: fix uninitialized build error.

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -1967,8 +1967,8 @@ static word32 GetTable8_4(const byte* t, byte o0, byte o1, byte o2, byte o3)
 static void AesEncrypt_C(Aes* aes, const byte* inBlock, byte* outBlock,
         word32 r)
 {
-    word32 s0, s1, s2, s3;
-    word32 t0, t1, t2, t3;
+    word32 s0 = 0, s1 = 0, s2 = 0, s3 = 0;
+    word32 t0 = 0, t1 = 0, t2 = 0, t3 = 0;
     const word32* rk;
 
 #ifdef WC_C_DYNAMIC_FALLBACK
@@ -3016,8 +3016,8 @@ static WARN_UNUSED_RESULT WC_INLINE word32 PreFetchTd4(void)
 static void AesDecrypt_C(Aes* aes, const byte* inBlock, byte* outBlock,
     word32 r)
 {
-    word32 s0, s1, s2, s3;
-    word32 t0, t1, t2, t3;
+    word32 s0 = 0, s1 = 0, s2 = 0, s3 = 0;
+    word32 t0 = 0, t1 = 0, t2 = 0, t3 = 0;
     const word32* rk;
 
 #ifdef WC_C_DYNAMIC_FALLBACK


### PR DESCRIPTION
# Description

Fix error when building linuxkm on fedora:
```
wolfcrypt/src/aes.c:1970:12: error: ‘s0’ may be used uninitialized [-Werror=maybe-uninitialized]
 1970 |     word32 s0, s1, s2, s3;
      |            ^~
wolfcrypt/src/aes.c:1970:16: error: ‘s1’ may be used uninitialized [-Werror=maybe-uninitialized]
 1970 |     word32 s0, s1, s2, s3;
      |                ^~
...etc...
```

```
gcc --version
gcc (GCC) 14.2.1 20250110 (Red Hat 14.2.1-7)
```

note: s0, s1, s2, s3 are immediately initialized later in XMEMCPY. This is pacifying compiler warning. Maybe not worth fixing. Could be from a combination of gcc version and `CONFIG_FORTIFY_SOURCE=y`.

# Testing


```
./configure --enable-linuxkm \
  --with-linux-source=/home/jordan/work/kernel/kernel/linux-6.13.7 \
  && make
```