### PR TITLE
Intel x86_64, gcc, icc: put branches on 32 byte boundary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -180,7 +180,7 @@ if test "$host_cpu" = "x86_64"
 then
     if test "$CC" = "gcc" || test "$CC" = "icc"
     then
-        EXTRA_OPTS_CFLAGS="$EXTRA_OPTS_CFLAGS -Wa,-mbranches-within-32B-boundaries"
+        EXTRA_OPTS_CFLAGS="$EXTRA_OPTS_CFLAGS -Wa,-mbranches-within-32B-boundaries -falign-loops=64"
     fi
 fi
 OPTIMIZE_CFLAGS="$OPTIMIZE_CFLAGS $EXTRA_OPTS_CFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -175,6 +175,19 @@ DEBUG_CFLAGS="-g -DDEBUG -DDEBUG_WOLFSSL"
 LIB_ADD=
 LIB_STATIC_ADD=
 
+EXTRA_OPTS_CFLAGS=
+if test "$host_cpu" = "x86_64"
+then
+    if test "$CC" = "gcc" || test "$CC" = "icc"
+    then
+        EXTRA_OPTS_CFLAGS="$EXTRA_OPTS_CFLAGS -Wa,-mbranches-within-32B-boundaries"
+    fi
+fi
+OPTIMIZE_CFLAGS="$OPTIMIZE_CFLAGS $EXTRA_OPTS_CFLAGS"
+OPTIMIZE_FAST_CFLAGS="$OPTIMIZE_FAST_CFLAGS $EXTRA_OPTS_CFLAGS"
+OPTIMIZE_HUGE_CFLAGS="$OPTIMIZE_HUGE_CFLAGS $EXTRA_OPTS_CFLAGS"
+DEBUG_VFLAGS="$DEBUG_VFLAGS $EXTRA_OPTS_CFLAGS"
+
 if test "$output_objdir" = ""
 then
     output_objdir=.

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -8637,7 +8637,7 @@ void bench_srtpkdf(void)
     bench_stats_start(&count, &start);
     PRIVATE_KEY_UNLOCK();
     do {
-        for (i = 0; i < numBlocks; i++) {
+        for (i = 0; i < numBlocks * 1000; i++) {
             ret = wc_SRTP_KDF(key, AES_128_KEY_SIZE, salt, sizeof(salt),
                 kdrIdx, index, keyE, AES_128_KEY_SIZE, keyA, sizeof(keyA),
                 keyS, sizeof(keyS));
@@ -8660,7 +8660,7 @@ void bench_srtpkdf(void)
     bench_stats_start(&count, &start);
     PRIVATE_KEY_UNLOCK();
     do {
-        for (i = 0; i < numBlocks; i++) {
+        for (i = 0; i < numBlocks * 1000; i++) {
             ret = wc_SRTP_KDF(key, AES_256_KEY_SIZE, salt, sizeof(salt),
                 kdrIdx, index, keyE, AES_256_KEY_SIZE, keyA, sizeof(keyA),
                 keyS, sizeof(keyS));
@@ -8683,7 +8683,7 @@ void bench_srtpkdf(void)
     bench_stats_start(&count, &start);
     PRIVATE_KEY_UNLOCK();
     do {
-        for (i = 0; i < numBlocks; i++) {
+        for (i = 0; i < numBlocks * 1000; i++) {
             ret = wc_SRTCP_KDF(key, AES_128_KEY_SIZE, salt, sizeof(salt),
                 kdrIdx, index, keyE, AES_128_KEY_SIZE, keyA, sizeof(keyA),
                 keyS, sizeof(keyS));
@@ -8706,7 +8706,7 @@ void bench_srtpkdf(void)
     bench_stats_start(&count, &start);
     PRIVATE_KEY_UNLOCK();
     do {
-        for (i = 0; i < numBlocks; i++) {
+        for (i = 0; i < numBlocks * 1000; i++) {
             ret = wc_SRTCP_KDF(key, AES_256_KEY_SIZE, salt, sizeof(salt),
                 kdrIdx, index, keyE, AES_256_KEY_SIZE, keyA, sizeof(keyA),
                 keyS, sizeof(keyS));

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -1051,11 +1051,7 @@ int wc_SRTP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
             ret = MEMORY_E;
         }
     }
-    if (aes != NULL)
 #endif
-    {
-        XMEMSET(aes, 0, sizeof(Aes));
-    }
 
     /* Setup AES object. */
     if (ret == 0) {
@@ -1155,11 +1151,7 @@ int wc_SRTCP_KDF_ex(const byte* key, word32 keySz, const byte* salt, word32 salt
             ret = MEMORY_E;
         }
     }
-    if (aes != NULL)
 #endif
-    {
-        XMEMSET(aes, 0, sizeof(Aes));
-    }
 
     /* Setup AES object. */
     if (ret == 0) {
@@ -1256,11 +1248,7 @@ int wc_SRTP_KDF_label(const byte* key, word32 keySz, const byte* salt,
             ret = MEMORY_E;
         }
     }
-    if (aes != NULL)
 #endif
-    {
-        XMEMSET(aes, 0, sizeof(Aes));
-    }
 
     /* Setup AES object. */
     if (ret == 0) {
@@ -1339,11 +1327,7 @@ int wc_SRTCP_KDF_label(const byte* key, word32 keySz, const byte* salt,
             ret = MEMORY_E;
         }
     }
-    if (aes != NULL)
 #endif
-    {
-        XMEMSET(aes, 0, sizeof(Aes));
-    }
 
     /* Setup AES object. */
     if (ret == 0) {


### PR DESCRIPTION
# Description

Improved security with compile flag.

Fixes zd#19594

# Testing

./configure --enable-all

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
