### PR TITLE
Coverity unchecked return value

### DIFF
--- a/tests/api/test_dsa.c
+++ b/tests/api/test_dsa.c
@@ -128,7 +128,7 @@ int test_wc_DsaSignVerify(void)
 #if !defined(HAVE_FIPS) && defined(WOLFSSL_PUBLIC_MP)
     /* hard set q to 0 and test fail case */
     mp_free(&key.q);
-    mp_init(&key.q);
+    ExpectIntEQ(mp_init(&key.q), 0);
     ExpectIntEQ(wc_DsaSign(hash, signature, &key, &rng), WC_NO_ERR_TRACE(BAD_FUNC_ARG));
 
     mp_set(&key.q, 1);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -55282,8 +55282,12 @@ static wc_test_ret_t mp_test_radix_16(mp_int* a, mp_int* r, WC_RNG* rng)
             ret = randNum(a, j, rng, NULL);
             if (ret != 0)
                     return WC_TEST_RET_ENC_EC(ret);
-            mp_radix_size(a, MP_RADIX_HEX, &size);
-            mp_toradix(a, str, MP_RADIX_HEX);
+            ret = mp_radix_size(a, MP_RADIX_HEX, &size);
+            if (ret != 0)
+                return WC_TEST_RET_ENC_EC(ret);
+            ret = mp_toradix(a, str, MP_RADIX_HEX);
+            if (ret != 0)
+                return WC_TEST_RET_ENC_EC(ret);
             if ((int)XSTRLEN(str) != size - 1)
                 return WC_TEST_RET_ENC_NC;
             mp_read_radix(r, str, MP_RADIX_HEX);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -55361,7 +55361,7 @@ static wc_test_ret_t mp_test_shift(mp_int* a, mp_int* r1, WC_RNG* rng)
         return WC_TEST_RET_ENC_EC(ret);
     for (i = 0; i < 4; i++) {
         ret = mp_copy(r1, a);
-        if (ret != WC_NO_ERR_TRACE(MP_VAL))
+        if (ret != MP_OKAY)
             return WC_TEST_RET_ENC_EC(ret);
 #if !defined(NO_DH) || defined(HAVE_ECC) || (!defined(NO_RSA) && \
     defined(WC_RSA_BLINDING) && !defined(WOLFSSL_RSA_VERIFY_ONLY))
@@ -56788,7 +56788,7 @@ static wc_test_ret_t mp_test_shbd(mp_int* a, mp_int* b, WC_RNG* rng)
             if (ret != MP_OKAY)
                 return WC_TEST_RET_ENC_EC(ret);
             ret = mp_copy(a, b);
-            if (ret != WC_NO_ERR_TRACE(MP_VAL))
+            if (ret != MP_OKAY)
                 return WC_TEST_RET_ENC_EC(ret);
             for (k = 0; k <= DIGIT_BIT * 2; k++) {
                 ret = mp_mul_2d(a, k, a);
@@ -56809,7 +56809,7 @@ static wc_test_ret_t mp_test_shbd(mp_int* a, mp_int* b, WC_RNG* rng)
             if (ret != MP_OKAY)
                 return WC_TEST_RET_ENC_EC(ret);
             ret = mp_copy(a, b);
-            if (ret != WC_NO_ERR_TRACE(MP_VAL))
+            if (ret != MP_OKAY)
                 return WC_TEST_RET_ENC_EC(ret);
             for (k = 0; k < 10; k++) {
                 ret = mp_lshd(a, k);
@@ -57605,7 +57605,7 @@ static wc_test_ret_t mp_test_exptmod(mp_int* b, mp_int* e, mp_int* m, mp_int* r)
     mp_add_d(b, 1, b);
     mp_set(e, 0x3);
     ret = mp_copy(b, m);
-    if (ret != WC_NO_ERR_TRACE(MP_VAL))
+    if (ret != MP_OKAY)
         return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_ex(b, e, 1, m, r);
     if (ret != MP_OKAY)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -55360,7 +55360,9 @@ static wc_test_ret_t mp_test_shift(mp_int* a, mp_int* r1, WC_RNG* rng)
     if (ret != 0)
         return WC_TEST_RET_ENC_EC(ret);
     for (i = 0; i < 4; i++) {
-        mp_copy(r1, a);
+        ret = mp_copy(r1, a);
+        if (ret != WC_NO_ERR_TRACE(MP_VAL))
+            return WC_TEST_RET_ENC_EC(ret);
 #if !defined(NO_DH) || defined(HAVE_ECC) || (!defined(NO_RSA) && \
     defined(WC_RSA_BLINDING) && !defined(WOLFSSL_RSA_VERIFY_ONLY))
         ret = mp_lshd(r1, i);
@@ -56785,7 +56787,9 @@ static wc_test_ret_t mp_test_shbd(mp_int* a, mp_int* b, WC_RNG* rng)
             ret = randNum(a, j, rng, NULL);
             if (ret != MP_OKAY)
                 return WC_TEST_RET_ENC_EC(ret);
-            mp_copy(a, b);
+            ret = mp_copy(a, b);
+            if (ret != WC_NO_ERR_TRACE(MP_VAL))
+                return WC_TEST_RET_ENC_EC(ret);
             for (k = 0; k <= DIGIT_BIT * 2; k++) {
                 ret = mp_mul_2d(a, k, a);
                 if (ret != MP_OKAY)
@@ -56804,7 +56808,9 @@ static wc_test_ret_t mp_test_shbd(mp_int* a, mp_int* b, WC_RNG* rng)
             ret = randNum(a, j, rng, NULL);
             if (ret != MP_OKAY)
                 return WC_TEST_RET_ENC_EC(ret);
-            mp_copy(a, b);
+            ret = mp_copy(a, b);
+            if (ret != WC_NO_ERR_TRACE(MP_VAL))
+                return WC_TEST_RET_ENC_EC(ret);
             for (k = 0; k < 10; k++) {
                 ret = mp_lshd(a, k);
                 if (ret != MP_OKAY)
@@ -57598,7 +57604,9 @@ static wc_test_ret_t mp_test_exptmod(mp_int* b, mp_int* e, mp_int* m, mp_int* r)
     mp_mul_2d(b, DIGIT_BIT, b);
     mp_add_d(b, 1, b);
     mp_set(e, 0x3);
-    mp_copy(b, m);
+    ret = mp_copy(b, m);
+    if (ret != WC_NO_ERR_TRACE(MP_VAL))
+        return WC_TEST_RET_ENC_EC(ret);
     ret = mp_exptmod_ex(b, e, 1, m, r);
     if (ret != MP_OKAY)
         return WC_TEST_RET_ENC_EC(ret);


### PR DESCRIPTION
# Description

Check return values of:
- InitHandshakeHashes
- InitHandshakeHashesAndCopy
- mp_copy
- mp_radix_size, mp_toradix

Fixes "Unchecked return value" warning in coverity.
