### PR TITLE
20250321-Wdeclaration-after-statements-and-Kyber-fixes

### DIFF
--- a/.github/workflows/pq-all.yml
+++ b/.github/workflows/pq-all.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         config: [
           # Add new configs here
-          '--enable-intelasm --enable-sp-asm --enable-all --enable-testcert --enable-acert --enable-dtls13 --enable-dtls-mtu --enable-dtls-frag-ch --enable-dtlscid --enable-quic --with-sys-crypto-policy --enable-experimental --enable-kyber=yes,original --enable-lms --enable-xmss --enable-dilithium --enable-dual-alg-certs --disable-qt CPPFLAGS="-pedantic -DWOLFCRYPT_TEST_LINT -DNO_WOLFSSL_CIPHER_SUITE_TEST"'
+          '--enable-intelasm --enable-sp-asm --enable-all --enable-testcert --enable-acert --enable-dtls13 --enable-dtls-mtu --enable-dtls-frag-ch --enable-dtlscid --enable-quic --with-sys-crypto-policy --enable-experimental --enable-kyber=yes,original --enable-lms --enable-xmss --enable-dilithium --enable-dual-alg-certs --disable-qt CPPFLAGS="-pedantic -Wdeclaration-after-statement -DWOLFCRYPT_TEST_LINT -DNO_WOLFSSL_CIPHER_SUITE_TEST"'
         ]
     name: make check
     if: github.repository_owner == 'wolfssl'

--- a/configure.ac
+++ b/configure.ac
@@ -5673,7 +5673,8 @@ AS_CASE([$FIPS_VERSION],
             -DHAVE_FIPS_VERSION_MINOR=$HAVE_FIPS_VERSION_MINOR \
             -DHAVE_FIPS_VERSION_PATCH=$HAVE_FIPS_VERSION_PATCH \
             -DNO_BIG_INT \
-            -DWC_RNG_SEED_CB"
+            -DWC_RNG_SEED_CB \
+            -DNO_PBKDF2"
 
 # optimizations section
 
@@ -5700,9 +5701,9 @@ AS_CASE([$FIPS_VERSION],
                (test "$FIPS_VERSION" != "lean-aesgcm-dev" || test "$enable_hkdf" != "yes")],
             [enable_hkdf="no"; ENABLED_HKDF="no"; AM_CFLAGS="$AM_CFLAGS -UHAVE_HKDF"])
 
-        AS_IF([test "$ENABLED_PWDBASED" != "yes" &&
-               (test "$FIPS_VERSION" != "lean-aesgcm-dev" || test "$enable_pwdbased" != "no")],
-            [enable_pwdbased="yes"; ENABLED_PWDBASED="yes"; AM_CFLAGS="$AM_CFLAGS -DHAVE_PBKDF2"])
+        AS_IF([test "$ENABLED_PWDBASED" != "no" &&
+               (test "$FIPS_VERSION" != "lean-aesgcm-dev" || test "$enable_pwdbased" != "yes")],
+            [enable_pwdbased="no"; ENABLED_PWDBASED="no"])
 
         AS_IF([test "$ENABLED_SRTP" != "no" &&
                (test "$FIPS_VERSION" != "lean-aesgcm-dev" || test "$enable_srtp" != "yes")],

--- a/configure.ac
+++ b/configure.ac
@@ -1416,14 +1416,14 @@ AC_ARG_WITH([liboqs],
 # Used:
 #  - SHA3, Shake128 and Shake256
 AC_ARG_ENABLE([kyber],
-    [AS_HELP_STRING([--enable-kyber],[Enable MLKEM (default: disabled)])],
+    [AS_HELP_STRING([--enable-kyber],[Enable Kyber/MLKEM (default: disabled)])],
     [ ENABLED_MLKEM=$enableval ],
     [ ENABLED_MLKEM=no ]
     )
+# note, inherits default from "kyber" clause above.
 AC_ARG_ENABLE([mlkem],
-    [AS_HELP_STRING([--enable-kyber],[Enable MLKEM (default: disabled)])],
-    [ ENABLED_MLKEM=$enableval ],
-    [ ENABLED_MLKEM=no ]
+    [AS_HELP_STRING([--enable-mlkem],[Enable MLKEM (default: disabled)])],
+    [ ENABLED_MLKEM=$enableval ]
     )
 
 ENABLED_WC_MLKEM=no
@@ -1434,13 +1434,18 @@ ENABLED_MLKEM_DECAPSULATE=no
 for v in `echo $ENABLED_MLKEM | tr "," " "`
 do
   case $v in
-  yes)
+  yes|all)
     ENABLED_MLKEM512=yes
     ENABLED_MLKEM768=yes
     ENABLED_MLKEM1024=yes
     ENABLED_MLKEM_MAKE_KEY=yes
     ENABLED_MLKEM_ENCAPSULATE=yes
     ENABLED_MLKEM_DECAPSULATE=yes
+    if test "$v" = "all"
+    then
+        ENABLED_ML_KEM=yes
+        ENABLED_ORIGINAL=yes
+    fi
     ;;
   no)
     ;;
@@ -1466,11 +1471,6 @@ do
     ENABLED_MLKEM_ENCAPSULATE=yes
     ;;
   decapsulate|dec)
-    ENABLED_MLKEM_DECAPSULATE=yes
-    ;;
-  all)
-    ENABLED_MLKEM_MAKE_KEY=yes
-    ENABLED_MLKEM_ENCAPSULATE=yes
     ENABLED_MLKEM_DECAPSULATE=yes
     ;;
   original|kyber)

--- a/src/tls.c
+++ b/src/tls.c
@@ -10894,9 +10894,10 @@ int TLSX_CKS_Set(WOLFSSL* ssl, TLSX** extensions)
 int TLSX_CKS_Parse(WOLFSSL* ssl, byte* input, word16 length,
                    TLSX** extensions)
 {
-    (void) extensions;
     int ret;
     int i, j;
+
+    (void) extensions;
 
     /* Validating the input. */
     if (length == 0)

--- a/tests/api.c
+++ b/tests/api.c
@@ -29768,14 +29768,16 @@ static int msgSrvCb(SSL_CTX *ctx, SSL *ssl)
 #endif
 
 #if defined(OPENSSL_ALL) && defined(SESSION_CERTS) && !defined(NO_BIO)
-    WOLFSSL_X509* peer = NULL;
+    {
+        WOLFSSL_X509* peer = NULL;
 
-    ExpectNotNull(peer= wolfSSL_get_peer_certificate(ssl));
-    ExpectNotNull(bio = BIO_new_fp(stderr, BIO_NOCLOSE));
+        ExpectNotNull(peer= wolfSSL_get_peer_certificate(ssl));
+        ExpectNotNull(bio = BIO_new_fp(stderr, BIO_NOCLOSE));
 
-    fprintf(stderr, "Peer Certificate = :\n");
-    X509_print(bio,peer);
-    X509_free(peer);
+        fprintf(stderr, "Peer Certificate = :\n");
+        X509_print(bio,peer);
+        X509_free(peer);
+    }
 
     ExpectNotNull(sk = SSL_get_peer_cert_chain(ssl));
     if (sk == NULL) {

--- a/tests/api/test_evp.c
+++ b/tests/api/test_evp.c
@@ -74,7 +74,7 @@ int test_wolfSSL_EVP_CIPHER_type_string(void)
     EXPECT_DECLS;
 #ifdef OPENSSL_EXTRA
     const char* cipherStr;
-    
+
     /* Test with valid cipher types */
 #ifndef NO_AES
     #ifdef WOLFSSL_AES_128
@@ -94,7 +94,7 @@ int test_wolfSSL_EVP_CIPHER_type_string(void)
     cipherStr = wolfSSL_EVP_CIPHER_type_string(WC_NULL_CIPHER_TYPE);
     ExpectNotNull(cipherStr);
     ExpectStrEQ(cipherStr, "NULL");
-    
+
     /* Test with invalid cipher type */
     cipherStr = wolfSSL_EVP_CIPHER_type_string(0xFFFF);
     ExpectNull(cipherStr);

--- a/tests/api/test_evp.c
+++ b/tests/api/test_evp.c
@@ -76,7 +76,7 @@ int test_wolfSSL_EVP_CIPHER_type_string(void)
     const char* cipherStr;
 
     /* Test with valid cipher types */
-#ifndef NO_AES
+#ifdef HAVE_AES_CBC
     #ifdef WOLFSSL_AES_128
     cipherStr = wolfSSL_EVP_CIPHER_type_string(WC_AES_128_CBC_TYPE);
     ExpectNotNull(cipherStr);

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -9675,8 +9675,10 @@ static void bench_mlkem_keygen(int type, const char* name, int keySize,
 #ifdef MLKEM_NONDETERMINISTIC
             ret = wc_KyberKey_MakeKey(key, &gRng);
 #else
-            unsigned char rand[WC_ML_KEM_MAKEKEY_RAND_SZ] = {0,};
-            ret = wc_KyberKey_MakeKeyWithRandom(key, rand, sizeof(rand));
+            {
+                unsigned char rand[WC_ML_KEM_MAKEKEY_RAND_SZ] = {0,};
+                ret = wc_KyberKey_MakeKeyWithRandom(key, rand, sizeof(rand));
+            }
 #endif
             if (ret != 0)
                 goto exit;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -21236,10 +21236,11 @@ static int DecodeAltSigAlg(const byte* input, int sz, DecodedCert* cert)
  * like a traditional signature in the certificate. */
 static int DecodeAltSigVal(const byte* input, int sz, DecodedCert* cert)
 {
-    (void)cert;
     int ret = 0;
     word32 idx = 0;
     int len = 0;
+
+    (void)cert;
 
     WOLFSSL_ENTER("DecodeAltSigVal");
 
@@ -32238,14 +32239,13 @@ int wc_MakeSigWithBitStr(byte *sig, int sigSz, int sType, byte* buf,
     falcon_key*        falconKey = NULL;
     dilithium_key*     dilithiumKey = NULL;
     sphincs_key*       sphincsKey = NULL;
-
-    WOLFSSL_ENTER("wc_MakeSigWithBitStr");
-
     int ret = 0;
     int headerSz;
     void* heap = NULL;
     CertSignCtx  certSignCtx_lcl;
     CertSignCtx* certSignCtx = &certSignCtx_lcl;
+
+    WOLFSSL_ENTER("wc_MakeSigWithBitStr");
 
     if ((sig == NULL) || (sigSz <= 0)) {
         return BAD_FUNC_ARG;

--- a/wolfcrypt/src/wc_mlkem_poly.c
+++ b/wolfcrypt/src/wc_mlkem_poly.c
@@ -1345,8 +1345,10 @@ void mlkem_keygen(sword16* s, sword16* t, sword16* e, const sword16* a, int k)
  * @param  [in]   e2  Error polynomial.
  * @param  [in]   m   Message polynomial.
  * @param  [in]   k   Number of polynomials in vector.
+ * @return  0 on success.
+ *
  */
-void mlkem_encapsulate(const sword16* t, sword16* u , sword16* v,
+int mlkem_encapsulate(const sword16* t, sword16* u , sword16* v,
     const sword16* a, sword16* y, const sword16* e1, const sword16* e2,
     const sword16* m, int k)
 {
@@ -1416,6 +1418,8 @@ void mlkem_encapsulate(const sword16* t, sword16* u , sword16* v,
     /* Add errors and message to v and reduce.
      * Step 21: v <- InvNTT(t_hat_trans o y_hat) + e_2 + mu) */
     mlkem_add3_reduce(v, e2, m);
+
+    return 0;
 }
 #endif /* !WOLFSSL_MLKEM_NO_ENCAPSULATE || !WOLFSSL_MLKEM_NO_DECAPSULATE */
 
@@ -1660,8 +1664,9 @@ int mlkem_keygen_seeds(sword16* s, sword16* t, MLKEM_PRF_T* prf,
  * @param  [in]   e2   Error polynomial.
  * @param  [in]   m    Message polynomial.
  * @param  [in]   k    Number of polynomials in vector.
+ * @return  0 on success.
  */
-static void mlkem_encapsulate_c(const sword16* pub, sword16* u, sword16* v,
+static int mlkem_encapsulate_c(const sword16* pub, sword16* u, sword16* v,
     const sword16* a, sword16* y, const sword16* e1, const sword16* e2,
     const sword16* m, int k)
 {
@@ -1696,6 +1701,8 @@ static void mlkem_encapsulate_c(const sword16* pub, sword16* u, sword16* v,
         sword16 t = v[i] + e2[i] + m[i];
         v[i] = MLKEM_BARRETT_RED(t);
     }
+
+    return 0;
 }
 
 /* Encapsulate message.
@@ -1709,8 +1716,9 @@ static void mlkem_encapsulate_c(const sword16* pub, sword16* u, sword16* v,
  * @param  [in]   e2   Error polynomial.
  * @param  [in]   m    Message polynomial.
  * @param  [in]   k    Number of polynomials in vector.
+ * @return  0 on success.
  */
-void mlkem_encapsulate(const sword16* pub, sword16* u, sword16* v,
+int mlkem_encapsulate(const sword16* pub, sword16* u, sword16* v,
     const sword16* a, sword16* y, const sword16* e1, const sword16* e2,
     const sword16* m, int k)
 {
@@ -1718,11 +1726,12 @@ void mlkem_encapsulate(const sword16* pub, sword16* u, sword16* v,
     if (IS_INTEL_AVX2(cpuid_flags) && (SAVE_VECTOR_REGISTERS2() == 0)) {
         mlkem_encapsulate_avx2(pub, u, v, a, y, e1, e2, m, k);
         RESTORE_VECTOR_REGISTERS();
+        return 0;
     }
     else
 #endif
     {
-        mlkem_encapsulate_c(pub, u, v, a, y, e1, e2, m, k);
+        return mlkem_encapsulate_c(pub, u, v, a, y, e1, e2, m, k);
     }
 }
 

--- a/wolfssl/wolfcrypt/wc_mlkem.h
+++ b/wolfssl/wolfcrypt/wc_mlkem.h
@@ -163,7 +163,7 @@ int mlkem_keygen_seeds(sword16* priv, sword16* pub, MLKEM_PRF_T* prf,
 #endif
 #ifndef WOLFSSL_MLKEM_ENCAPSULATE_SMALL_MEM
 WOLFSSL_LOCAL
-void mlkem_encapsulate(const sword16* pub, sword16* bp, sword16* v,
+int mlkem_encapsulate(const sword16* pub, sword16* bp, sword16* v,
     const sword16* at, sword16* sp, const sword16* ep, const sword16* epp,
     const sword16* m, int kp);
 #else


### PR DESCRIPTION
fix various `-Wdeclaration-after-statement`s, and add `-Wdeclaration-after-statement` to `.github/workflows/pq-all.yml`.

rearrange code/gating in `wolfcrypt/src/wc_mlkem.c`:`mlkemkey_encapsulate()` for
  clarity and to fix a `-Wdeclaration-after-statement`.

also, made `mlkem_encapsulate_c()` and `mlkem_encapsulate()` return error code
  (currently always zero) rather than `void`, for consistency.

`configure.ac`: fix Kyber/ML-KEM option setup.

tested with `wolfssl-multi-test.sh ... super-quick-check all-gcc-debug-c99 benchmark-wolfcrypt-intelasm-all linuxkm-legacy-5.4-insmod linuxkm-legacy-5.10-insmod llm-analyze-changes` using qwen2.5-72B-32k.

also tested directly with `make check` using the revised recipe in `.github/workflows/pq-all.yml`, with and without `-DWOLFSSL_MLKEM_ENCAPSULATE_SMALL_MEM` and `-DWOLFSSL_MLKEM_CACHE_A`.
