### PR TITLE
Remove linuxkm-pie dependency for FIPS linuxkm

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -659,9 +659,6 @@ AC_ARG_ENABLE([linuxkm-pie],
 if test "$ENABLED_LINUXKM_PIE" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_LINUXKM_PIE_SUPPORT"
-elif test "$ENABLED_FIPS" = yes && test "$ENABLED_LINUXKM" = yes
-then
-    AC_MSG_ERROR([FIPS linuxkm requires linuxkm-pie.])
 fi
 AC_SUBST([ENABLED_LINUXKM_PIE])
 

--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -497,10 +497,6 @@
         #error "compiling -fPIE requires PIE redirect table."
     #endif
 
-    #if defined(HAVE_FIPS) && !defined(HAVE_LINUXKM_PIE_SUPPORT)
-        #error "FIPS build requires PIE support."
-    #endif
-
     #ifdef USE_WOLFSSL_LINUXKM_PIE_REDIRECT_TABLE
 
 #ifdef CONFIG_MIPS

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -48,6 +48,8 @@
 #ifndef NO_CRYPT_TEST
     #include <wolfcrypt/test/test.h>
 #endif
+#include <wolfssl/wolfcrypt/random.h>
+#include <wolfssl/wolfcrypt/sha256.h>
 
 static int libwolfssl_cleanup(void) {
     int ret;

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -3617,8 +3617,12 @@ extern void uITRON4_free(void *p) ;
     #undef WOLFSSL_HAVE_MAX
     #undef WOLFSSL_HAVE_ASSERT_H
     #define WOLFSSL_NO_ASSERT_H
-    #define SIZEOF_LONG         8
-    #define SIZEOF_LONG_LONG    8
+    #ifndef SIZEOF_LONG
+        #define SIZEOF_LONG         8
+    #endif
+    #ifndef SIZEOF_LONG_LONG
+        #define SIZEOF_LONG_LONG    8
+    #endif
     #define CHAR_BIT            8
     #ifndef WOLFSSL_SP_DIV_64
         #define WOLFSSL_SP_DIV_64


### PR DESCRIPTION
# Description

- Removing linuxkm-pie dependency for FIPS linuxkm and some tiny build fixes


# Testing

Tested on customer's OpenWRT MIPS build with FIPS wolfSSL kernel module

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
