### PR TITLE
ML-KEM/Kyber: mlkem_encapsulate not to return a value

### DIFF
--- a/wolfcrypt/src/wc_mlkem.c
+++ b/wolfcrypt/src/wc_mlkem.c
@@ -788,7 +788,7 @@ static int mlkemkey_encapsulate(MlKemKey* key, const byte* m, byte* r, byte* c)
 
         /* Perform encapsulation maths.
          *   Steps 18-19, 21: calculate u and v */
-        ret = mlkem_encapsulate(key->pub, u, v, a, y, e1, e2, mu, k);
+        mlkem_encapsulate(key->pub, u, v, a, y, e1, e2, mu, k);
     }
 #else /* WOLFSSL_MLKEM_ENCAPSULATE_SMALL_MEM */
     if (ret == 0) {

--- a/wolfcrypt/src/wc_mlkem_poly.c
+++ b/wolfcrypt/src/wc_mlkem_poly.c
@@ -1348,7 +1348,7 @@ void mlkem_keygen(sword16* s, sword16* t, sword16* e, const sword16* a, int k)
  * @return  0 on success.
  *
  */
-int mlkem_encapsulate(const sword16* t, sword16* u , sword16* v,
+void mlkem_encapsulate(const sword16* t, sword16* u , sword16* v,
     const sword16* a, sword16* y, const sword16* e1, const sword16* e2,
     const sword16* m, int k)
 {
@@ -1418,8 +1418,6 @@ int mlkem_encapsulate(const sword16* t, sword16* u , sword16* v,
     /* Add errors and message to v and reduce.
      * Step 21: v <- InvNTT(t_hat_trans o y_hat) + e_2 + mu) */
     mlkem_add3_reduce(v, e2, m);
-
-    return 0;
 }
 #endif /* !WOLFSSL_MLKEM_NO_ENCAPSULATE || !WOLFSSL_MLKEM_NO_DECAPSULATE */
 
@@ -1666,7 +1664,7 @@ int mlkem_keygen_seeds(sword16* s, sword16* t, MLKEM_PRF_T* prf,
  * @param  [in]   k    Number of polynomials in vector.
  * @return  0 on success.
  */
-static int mlkem_encapsulate_c(const sword16* pub, sword16* u, sword16* v,
+static void mlkem_encapsulate_c(const sword16* pub, sword16* u, sword16* v,
     const sword16* a, sword16* y, const sword16* e1, const sword16* e2,
     const sword16* m, int k)
 {
@@ -1701,8 +1699,6 @@ static int mlkem_encapsulate_c(const sword16* pub, sword16* u, sword16* v,
         sword16 t = v[i] + e2[i] + m[i];
         v[i] = MLKEM_BARRETT_RED(t);
     }
-
-    return 0;
 }
 
 /* Encapsulate message.
@@ -1718,7 +1714,7 @@ static int mlkem_encapsulate_c(const sword16* pub, sword16* u, sword16* v,
  * @param  [in]   k    Number of polynomials in vector.
  * @return  0 on success.
  */
-int mlkem_encapsulate(const sword16* pub, sword16* u, sword16* v,
+void mlkem_encapsulate(const sword16* pub, sword16* u, sword16* v,
     const sword16* a, sword16* y, const sword16* e1, const sword16* e2,
     const sword16* m, int k)
 {
@@ -1726,12 +1722,11 @@ int mlkem_encapsulate(const sword16* pub, sword16* u, sword16* v,
     if (IS_INTEL_AVX2(cpuid_flags) && (SAVE_VECTOR_REGISTERS2() == 0)) {
         mlkem_encapsulate_avx2(pub, u, v, a, y, e1, e2, m, k);
         RESTORE_VECTOR_REGISTERS();
-        return 0;
     }
     else
 #endif
     {
-        return mlkem_encapsulate_c(pub, u, v, a, y, e1, e2, m, k);
+        mlkem_encapsulate_c(pub, u, v, a, y, e1, e2, m, k);
     }
 }
 

--- a/wolfssl/wolfcrypt/wc_mlkem.h
+++ b/wolfssl/wolfcrypt/wc_mlkem.h
@@ -163,7 +163,7 @@ int mlkem_keygen_seeds(sword16* priv, sword16* pub, MLKEM_PRF_T* prf,
 #endif
 #ifndef WOLFSSL_MLKEM_ENCAPSULATE_SMALL_MEM
 WOLFSSL_LOCAL
-int mlkem_encapsulate(const sword16* pub, sword16* bp, sword16* v,
+void mlkem_encapsulate(const sword16* pub, sword16* bp, sword16* v,
     const sword16* at, sword16* sp, const sword16* ep, const sword16* epp,
     const sword16* m, int kp);
 #else


### PR DESCRIPTION
# Description

Don't return a value from mlkem_encapsulate() to ensure code is just the maths.

# Testing

./configure '--disable-shared' '--enable-kyber' '--enable-intelasm'

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
