### PR TITLE
Various improvements to iscacii and CMake key log

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,9 @@ check_function_exists("socket" HAVE_SOCKET)
 check_function_exists("strftime" HAVE_STRFTIME)
 check_function_exists("__atomic_fetch_add" HAVE_C___ATOMIC)
 
+include(CheckSymbolExists)
+check_symbol_exists(isascii "ctype.h" HAVE_ISASCII)
+
 include(CheckTypeSize)
 
 check_type_size("__uint128_t" __UINT128_T)
@@ -893,7 +896,7 @@ endif()
 #       - SEP
 
 add_option("WOLFSSL_KEYGEN"
-    "Enable key generation (default: disabled)])"
+    "Enable key generation (default: disabled)"
     "no" "yes;no")
 
 add_option("WOLFSSL_CERTGEN"
@@ -2318,6 +2321,18 @@ if (ENABLE_SCCACHE AND (NOT WOLFSSL_SCCACHE_ALREADY_SET_FLAG))
         endif()
         set(WOLFSSL_SCCACHE_ALREADY_SET_FLAG ON)
     endif()
+endif()
+
+add_option("WOLFSSL_KEYLOG_EXPORT"
+    "Enable insecure export of TLS secrets to an NSS keylog file (default: disabled)"
+    "no" "yes;no")
+if(WOLFSSL_KEYLOG_EXPORT)
+    message(WARNING "Keylog export enabled -- Sensitive key data will be stored insecurely.")
+    list(APPEND WOLFSSL_DEFINITIONS
+        "-DSHOW_SECRETS"
+        "-DHAVE_SECRET_CALLBACK"
+        "-DWOLFSSL_SSLKEYLOGFILE"
+        "-DWOLFSSL_KEYLOG_EXPORT_WARNED")
 endif()
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -119,7 +119,7 @@ then
     AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_EXPERIMENTAL_SETTINGS"
 fi
 
-AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netdb.h netinet/in.h stddef.h time.h sys/ioctl.h sys/socket.h sys/time.h errno.h sys/un.h])
+AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netdb.h netinet/in.h stddef.h time.h sys/ioctl.h sys/socket.h sys/time.h errno.h sys/un.h ctype.h])
 AC_CHECK_LIB([network],[socket])
 AC_C_BIGENDIAN
 AC_C___ATOMIC
@@ -129,8 +129,8 @@ AC_CHECK_HEADER(assert.h, [AM_CPPFLAGS="$AM_CPPFLAGS -DWOLFSSL_HAVE_ASSERT_H"],[
 # check if functions of interest are linkable, but also check if
 # they're declared by the expected headers, and if not, supersede the
 # unusable positive from AC_CHECK_FUNCS().
-AC_CHECK_FUNCS([gethostbyname getaddrinfo gettimeofday gmtime_r gmtime_s inet_ntoa memset socket strftime atexit])
-AC_CHECK_DECLS([gethostbyname, getaddrinfo, gettimeofday, gmtime_r, gmtime_s, inet_ntoa, memset, socket, strftime, atexit], [], [
+AC_CHECK_FUNCS([gethostbyname getaddrinfo gettimeofday gmtime_r gmtime_s inet_ntoa memset socket strftime atexit isascii])
+AC_CHECK_DECLS([gethostbyname, getaddrinfo, gettimeofday, gmtime_r, gmtime_s, inet_ntoa, memset, socket, strftime, atexit, isascii], [], [
 if test "$(eval echo \$"$(eval 'echo ac_cv_func_${as_decl_name}')")" = "yes"
 then
     AC_MSG_NOTICE([    note: earlier check for $(eval 'echo ${as_decl_name}') superseded.])
@@ -159,6 +159,9 @@ fi
 #endif
 #ifdef HAVE_STDLIB_H
     #include <stdlib.h>
+#endif
+#ifdef HAVE_CTYPE_H
+    #include <ctype.h>
 #endif
 ]])
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1005,7 +1005,7 @@ typedef struct w64wrapper {
         #endif
         #if defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
         #define XISALNUM(c)     isalnum((c))
-        #ifdef NO_STDLIB_ISASCII
+        #if !defined(HAVE_ISASCII) || defined(NO_STDLIB_ISASCII)
             #define XISASCII(c) (((c) >= 0 && (c) <= 127) ? 1 : 0)
         #else
             #define XISASCII(c) isascii((c))


### PR DESCRIPTION
# Description

Various improvements to iscacii and CMake key log:
* Detect 'isascii' at configuration (tested with `./configure CFLAGS="-DNO_STDLIB_ISASCII" && make check`).
* Add mew CMake option `WOLFSSL_KEYLOG_EXPORT` (fixes #8165) 
Replaces PR #8174 and #8158. Thank you @redbaron.

# Testing

```
./configure CFLAGS="-DNO_STDLIB_ISASCII" && make check
mkdir build && cd build && cmake .. -DWOLFSSL_KEYLOG_EXPORT=YES && make
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
