### PR TITLE
random implementation does not require PIC32 build macro

### DIFF
--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -2775,7 +2775,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         return ret;
     }
 
-#elif defined(MICROCHIP_PIC32)
+#elif defined(MICROCHIP_PIC32) || defined(MICROCHIP_MPLAB_HARMONY)
 
     #ifdef MICROCHIP_MPLAB_HARMONY
         #ifdef MICROCHIP_MPLAB_HARMONY_3

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -767,11 +767,13 @@ typedef struct w64wrapper {
         #endif
 
         #ifndef XSTRCASECMP
-        #if defined(MICROCHIP_PIC32) && (__XC32_VERSION >= 1000) && (__XC32_VERSION < 4000)
+        #if (defined(MICROCHIP_MPLAB_HARMONY) || defined(MICROCHIP_PIC32)) && \
+            (__XC32_VERSION >= 1000) && (__XC32_VERSION < 4000)
             /* XC32 supports str[n]casecmp in version >= 1.0 through 4.0. */
             #define XSTRCASECMP(s1,s2) strcasecmp((s1),(s2))
-        #elif defined(MICROCHIP_PIC32) || defined(WOLFSSL_TIRTOS) || \
-                defined(WOLFSSL_ZEPHYR) || defined(MICROCHIP_PIC24)
+        #elif defined(MICROCHIP_MPLAB_HARMONY) || defined(MICROCHIP_PIC32) || \
+              defined(WOLFSSL_TIRTOS) || defined(WOLFSSL_ZEPHYR) || \
+              defined(MICROCHIP_PIC24)
             /* XC32 version < 1.0 does not support strcasecmp. */
             #define USE_WOLF_STRCASECMP
         #elif defined(USE_WINDOWS_API) || defined(FREERTOS_TCP_WINSIM)
@@ -799,11 +801,13 @@ typedef struct w64wrapper {
         #endif /* !XSTRCASECMP */
 
         #ifndef XSTRNCASECMP
-        #if defined(MICROCHIP_PIC32) && (__XC32_VERSION >= 1000)
+        #if (defined(MICROCHIP_MPLAB_HARMONY) || defined(MICROCHIP_PIC32)) && \
+            (__XC32_VERSION >= 1000)
             /* XC32 supports str[n]casecmp in version >= 1.0. */
             #define XSTRNCASECMP(s1,s2,n) strncasecmp((s1),(s2),(n))
-        #elif defined(MICROCHIP_PIC32) || defined(WOLFSSL_TIRTOS) || \
-                defined(WOLFSSL_ZEPHYR) || defined(MICROCHIP_PIC24)
+        #elif defined(MICROCHIP_MPLAB_HARMONY) || defined(MICROCHIP_PIC32) || \
+              defined(WOLFSSL_TIRTOS) || defined(WOLFSSL_ZEPHYR) || \
+              defined(MICROCHIP_PIC24)
             /* XC32 version < 1.0 does not support strncasecmp. */
             #define USE_WOLF_STRNCASECMP
         #elif defined(USE_WINDOWS_API) || defined(FREERTOS_TCP_WINSIM)


### PR DESCRIPTION
Building for a SAMV71 with microchip harmony and wanting to avoid defining the MICROCHIP_PIC32 macro.

These changes are from an SFTP port and trying to use wolfSSH as a library with user_settings.h