### PR TITLE
Fix for crypto callback macro guards with `DEBUG_CRYPTOCB`

### DIFF
--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -207,6 +207,8 @@ WOLFSSL_API void wc_CryptoCb_InfoString(wc_CryptoInfo* info)
             info->cipher.type, info->cipher.ctx);
     }
 #endif /* !NO_AES || !NO_DES3 */
+#if !defined(NO_SHA) || !defined(NO_SHA256) || \
+    defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA3)
     else if (info->algo_type == WC_ALGO_TYPE_HASH) {
         printf("Crypto CB: %s %s (%d) (%p ctx) %s\n",
             GetAlgoTypeStr(info->algo_type),
@@ -214,6 +216,8 @@ WOLFSSL_API void wc_CryptoCb_InfoString(wc_CryptoInfo* info)
             info->hash.type, info->hash.ctx,
             (info->hash.in != NULL) ? "Update" : "Final");
     }
+#endif
+#ifndef NO_HMAC
     else if (info->algo_type == WC_ALGO_TYPE_HMAC) {
         printf("Crypto CB: %s %s (%d) (%p ctx) %s\n",
             GetAlgoTypeStr(info->algo_type),
@@ -221,6 +225,7 @@ WOLFSSL_API void wc_CryptoCb_InfoString(wc_CryptoInfo* info)
             info->hmac.macType, info->hmac.hmac,
             (info->hmac.in != NULL) ? "Update" : "Final");
     }
+#endif
 #ifdef WOLFSSL_CMAC
     else if (info->algo_type == WC_ALGO_TYPE_CMAC) {
         printf("Crypto CB: %s %s (%d) (%p ctx) %s %s %s\n",

--- a/wolfssl/wolfcrypt/cryptocb.h
+++ b/wolfssl/wolfcrypt/cryptocb.h
@@ -375,7 +375,7 @@ typedef struct wc_CryptoInfo {
     } cipher;
 #endif /* !NO_AES || !NO_DES3 */
 #if !defined(NO_SHA) || !defined(NO_SHA256) || \
-    defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)
+    defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA3)
     struct {
         int type; /* enum wc_HashType */
         const byte* in;


### PR DESCRIPTION
# Description

Fix for crypto callback without HMAC and `DEBUG_CRYPTOCB` 

# Testing

`./configure --enable-cryptonly --enable-cryptocb --disable-hmac CFLAGS="-DDEBUG_CRYPTOCB" && make`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
