### PR TITLE
LMS: change identifiers to match standard

### DIFF
--- a/wolfcrypt/src/wc_lms_impl.c
+++ b/wolfcrypt/src/wc_lms_impl.c
@@ -1339,10 +1339,10 @@ static void wc_lmots_public_key_encode(const LmsParams* params,
     const byte* priv_i = priv + LMS_Q_LEN + params->hash_len;
 
     /* u32str(type) || ... || T(1) */
-    c32toa(params->lmsType, pub);
+    c32toa(params->lmsType & LMS_H_W_MASK, pub);
     pub += 4;
     /* u32str(type) || u32str(otstype) || ... || T(1) */
-    c32toa(params->lmOtsType, pub);
+    c32toa(params->lmOtsType & LMS_H_W_MASK, pub);
     pub += 4;
     /* u32str(type) || u32str(otstype) || I || T(1) */
     XMEMCPY(pub, priv_i, LMS_I_LEN);
@@ -1365,14 +1365,14 @@ static int wc_lmots_public_key_check(const LmsParams* params, const byte* pub)
     ato32(pub, &type);
     pub += 4;
     /* Compare with parameters. */
-    if (type != params->lmsType) {
+    if (type != (params->lmsType & LMS_H_W_MASK)) {
         ret = PUBLIC_KEY_E;
     }
     if (ret == 0) {
         /* Get node hash and Winternitz width type. */
         ato32(pub, &type);
         /* Compare with parameters. */
-        if (type != params->lmOtsType) {
+        if (type != (params->lmOtsType & LMS_H_W_MASK)) {
             ret = PUBLIC_KEY_E;
         }
     }
@@ -2250,7 +2250,7 @@ static int wc_lms_sign(LmsState* state, const byte* priv, const byte* msg,
     s += LMS_Q_LEN;
 
     /* ots_signature = sig = u32str(type) || ... */
-    c32toa(state->params->lmOtsType, s);
+    c32toa(state->params->lmOtsType & LMS_H_W_MASK, s);
     s += LMS_TYPE_LEN;
     /* Sign this level.
      * S = u32str(q) || ots_signature || ... */
@@ -2259,7 +2259,7 @@ static int wc_lms_sign(LmsState* state, const byte* priv, const byte* msg,
         /* Skip over ots_signature. */
         s += params->hash_len + params->p * params->hash_len;
         /* S = u32str(q) || ots_signature || u32str(type) || ... */
-        c32toa(params->lmsType, s);
+        c32toa(params->lmsType & LMS_H_W_MASK, s);
     }
 
     return ret;
@@ -2280,13 +2280,13 @@ static void wc_lms_sig_copy(const LmsParams* params, const byte* y,
     XMEMCPY(sig, priv, LMS_Q_LEN);
     sig += LMS_Q_LEN;
     /* S = u32str(q) || ... */
-    c32toa(params->lmOtsType, sig);
+    c32toa(params->lmOtsType & LMS_H_W_MASK, sig);
     sig += LMS_TYPE_LEN;
     /* S = u32str(q) || ots_signature || ... */
     XMEMCPY(sig, y, params->hash_len + params->p * params->hash_len);
     sig += params->hash_len + params->p * params->hash_len;
     /* S = u32str(q) || ots_signature || u32str(type) || ... */
-    c32toa(params->lmsType, sig);
+    c32toa(params->lmsType & LMS_H_W_MASK, sig);
 }
 #endif /* !WOLFSSL_WC_LMS_SMALL && !WOLFSSL_LMS_NO_SIG_CACHE */
 #endif /* !WOLFSSL_LMS_VERIFY_ONLY */

--- a/wolfssl/wolfcrypt/wc_lms.h
+++ b/wolfssl/wolfcrypt/wc_lms.h
@@ -303,13 +303,13 @@
 #endif
 
 /* Indicates using SHA-256 for hashing. */
-#define LMS_SHA256                  0x00
+#define LMS_SHA256                  0x0000
 /* Indicates using SHA-256/192 for hashing. */
-#define LMS_SHA256_192              0x10
+#define LMS_SHA256_192              0x1000
 /* Mask to get hashing algorithm from type. */
-#define LMS_HASH_MASK               0xf0
+#define LMS_HASH_MASK               0xf000
 /* Mask to get height or Winternitz width from type. */
-#define LMS_H_W_MASK                0x0f
+#define LMS_H_W_MASK                0x0fff
 
 /* LMS Parameters. */
 /* SHA-256 hash, 32-bytes of hash used, tree height of 5. */
@@ -333,24 +333,24 @@
 #define LMOTS_SHA256_N32_W8         0x04
 
 /* SHA-256 hash, 32-bytes of hash used, tree height of 5. */
-#define LMS_SHA256_M24_H5           (0x05 | LMS_SHA256_192)
+#define LMS_SHA256_M24_H5           (0x0a | LMS_SHA256_192)
 /* SHA-256 hash, 32-bytes of hash used, tree height of 10. */
-#define LMS_SHA256_M24_H10          (0x06 | LMS_SHA256_192)
+#define LMS_SHA256_M24_H10          (0x0b | LMS_SHA256_192)
 /* SHA-256 hash, 32-bytes of hash used, tree height of 15. */
-#define LMS_SHA256_M24_H15          (0x07 | LMS_SHA256_192)
+#define LMS_SHA256_M24_H15          (0x0c | LMS_SHA256_192)
 /* SHA-256 hash, 32-bytes of hash used, tree height of 20. */
-#define LMS_SHA256_M24_H20          (0x08 | LMS_SHA256_192)
+#define LMS_SHA256_M24_H20          (0x0d | LMS_SHA256_192)
 /* SHA-256 hash, 32-bytes of hash used, tree height of 25. */
-#define LMS_SHA256_M24_H25          (0x09 | LMS_SHA256_192)
+#define LMS_SHA256_M24_H25          (0x0e | LMS_SHA256_192)
 
 /* SHA-256 hash, 32-bytes of hash used, Winternitz width of 1 bit. */
-#define LMOTS_SHA256_N24_W1         (0x01 | LMS_SHA256_192)
+#define LMOTS_SHA256_N24_W1         (0x05 | LMS_SHA256_192)
 /* SHA-256 hash, 32-bytes of hash used, Winternitz width of 2 bits. */
-#define LMOTS_SHA256_N24_W2         (0x02 | LMS_SHA256_192)
+#define LMOTS_SHA256_N24_W2         (0x06 | LMS_SHA256_192)
 /* SHA-256 hash, 32-bytes of hash used, Winternitz width of 4 bits. */
-#define LMOTS_SHA256_N24_W4         (0x03 | LMS_SHA256_192)
+#define LMOTS_SHA256_N24_W4         (0x07 | LMS_SHA256_192)
 /* SHA-256 hash, 32-bytes of hash used, Winternitz width of 8 bits. */
-#define LMOTS_SHA256_N24_W8         (0x04 | LMS_SHA256_192)
+#define LMOTS_SHA256_N24_W8         (0x08 | LMS_SHA256_192)
 
 typedef struct LmsParams {
     /* Number of tree levels. */


### PR DESCRIPTION
# Description

Use the identifiers from IANA for LMS.

Fixes zd#9653

# Testing

./configure '--disable-shared' '--enable-lms=yes,sha256-192' '--enable-intelasm'

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
