### PR TITLE
openssl compat: Push/pop to/from the end of the list object

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -42369,32 +42369,7 @@ WOLFSSL_BY_DIR_HASH* wolfSSL_sk_BY_DIR_HASH_value(
 WOLFSSL_BY_DIR_HASH* wolfSSL_sk_BY_DIR_HASH_pop(
                                 WOLF_STACK_OF(WOLFSSL_BY_DIR_HASH)* sk)
 {
-    WOLFSSL_STACK* node;
-    WOLFSSL_BY_DIR_HASH* hash;
-
-    WOLFSSL_ENTER("wolfSSL_sk_BY_DIR_HASH_pop");
-
-    if (sk == NULL) {
-        return NULL;
-    }
-
-    node = sk->next;
-    hash = sk->data.dir_hash;
-
-    if (node != NULL) { /* update sk and remove node from stack */
-        sk->data.dir_hash = node->data.dir_hash;
-        sk->next = node->next;
-        wolfSSL_sk_free_node(node);
-    }
-    else { /* last x509 in stack */
-        sk->data.dir_hash = NULL;
-    }
-
-    if (sk->num > 0) {
-        sk->num -= 1;
-    }
-
-    return hash;
+    return wolfSSL_sk_pop(sk);
 }
 /* release all contents in stack, and then release stack itself. */
 /* Second argument is a function pointer to release resources.   */
@@ -42449,39 +42424,13 @@ void wolfSSL_sk_BY_DIR_HASH_free(WOLF_STACK_OF(WOLFSSL_BY_DIR_HASH) *sk)
 int wolfSSL_sk_BY_DIR_HASH_push(WOLF_STACK_OF(WOLFSSL_BY_DIR_HASH)* sk,
                                                WOLFSSL_BY_DIR_HASH* in)
 {
-    WOLFSSL_STACK* node;
-
     WOLFSSL_ENTER("wolfSSL_sk_BY_DIR_HASH_push");
 
     if (sk == NULL || in == NULL) {
         return WOLFSSL_FAILURE;
     }
 
-    /* no previous values in stack */
-    if (sk->data.dir_hash == NULL) {
-        sk->data.dir_hash = in;
-        sk->num += 1;
-        return WOLFSSL_SUCCESS;
-    }
-
-    /* stack already has value(s) create a new node and add more */
-    node = (WOLFSSL_STACK*)XMALLOC(sizeof(WOLFSSL_STACK), NULL,
-            DYNAMIC_TYPE_OPENSSL);
-    if (node == NULL) {
-        WOLFSSL_MSG("Memory error");
-        return WOLFSSL_FAILURE;
-    }
-    XMEMSET(node, 0, sizeof(WOLFSSL_STACK));
-
-    /* push new obj onto head of stack */
-    node->data.dir_hash    = sk->data.dir_hash;
-    node->next             = sk->next;
-    node->type             = sk->type;
-    sk->next               = node;
-    sk->data.dir_hash      = in;
-    sk->num                += 1;
-
-    return WOLFSSL_SUCCESS;
+    return wolfSSL_sk_push(sk, in);
 }
 /* create an instance of WOLFSSL_BY_DIR_entry structure */
 WOLFSSL_BY_DIR_entry* wolfSSL_BY_DIR_entry_new(void)
@@ -42552,32 +42501,7 @@ WOLFSSL_BY_DIR_entry* wolfSSL_sk_BY_DIR_entry_value(
 WOLFSSL_BY_DIR_entry* wolfSSL_sk_BY_DIR_entry_pop(
                                 WOLF_STACK_OF(WOLFSSL_BY_DIR_entry)* sk)
 {
-    WOLFSSL_STACK* node;
-    WOLFSSL_BY_DIR_entry* entry;
-
-    WOLFSSL_ENTER("wolfSSL_sk_BY_DIR_entry_pop");
-
-    if (sk == NULL) {
-        return NULL;
-    }
-
-    node = sk->next;
-    entry = sk->data.dir_entry;
-
-    if (node != NULL) { /* update sk and remove node from stack */
-        sk->data.dir_entry = node->data.dir_entry;
-        sk->next = node->next;
-        wolfSSL_sk_free_node(node);
-    }
-    else { /* last x509 in stack */
-        sk->data.dir_entry = NULL;
-    }
-
-    if (sk->num > 0) {
-        sk->num -= 1;
-    }
-
-    return entry;
+    return wolfSSL_sk_pop(sk);
 }
 /* release all contents in stack, and then release stack itself. */
 /* Second argument is a function pointer to release resources.   */
@@ -42633,37 +42557,13 @@ void wolfSSL_sk_BY_DIR_entry_free(WOLF_STACK_OF(wolfSSL_BY_DIR_entry) *sk)
 int wolfSSL_sk_BY_DIR_entry_push(WOLF_STACK_OF(WOLFSSL_BY_DIR_entry)* sk,
                                                WOLFSSL_BY_DIR_entry* in)
 {
-    WOLFSSL_STACK* node;
+    WOLFSSL_ENTER("wolfSSL_sk_BY_DIR_entry_push");
 
     if (sk == NULL || in == NULL) {
         return WOLFSSL_FAILURE;
     }
 
-    /* no previous values in stack */
-    if (sk->data.dir_entry == NULL) {
-        sk->data.dir_entry = in;
-        sk->num += 1;
-        return WOLFSSL_SUCCESS;
-    }
-
-    /* stack already has value(s) create a new node and add more */
-    node = (WOLFSSL_STACK*)XMALLOC(sizeof(WOLFSSL_STACK), NULL,
-            DYNAMIC_TYPE_OPENSSL);
-    if (node == NULL) {
-        WOLFSSL_MSG("Memory error");
-        return WOLFSSL_FAILURE;
-    }
-    XMEMSET(node, 0, sizeof(WOLFSSL_STACK));
-
-    /* push new obj onto head of stack */
-    node->data.dir_entry    = sk->data.dir_entry;
-    node->next              = sk->next;
-    node->type              = sk->type;
-    sk->next                = node;
-    sk->data.dir_entry      = in;
-    sk->num                 += 1;
-
-    return WOLFSSL_SUCCESS;
+    return wolfSSL_sk_push(sk, in);
 }
 
 #endif /* OPENSSL_ALL */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -14743,14 +14743,14 @@ int wolfSSL_sk_push(WOLFSSL_STACK* sk, const void *data)
 {
     WOLFSSL_ENTER("wolfSSL_sk_push");
 
-    return wolfSSL_sk_insert(sk, data, 0);
+    return wolfSSL_sk_insert(sk, data, -1);
 }
 
 void* wolfSSL_sk_pop(WOLFSSL_STACK* sk)
 {
     WOLFSSL_ENTER("wolfSSL_sk_pop");
 
-    return wolfSSL_sk_pop_node(sk, 0);
+    return wolfSSL_sk_pop_node(sk, -1);
 }
 
 /* return number of elements on success 0 on fail */

--- a/src/x509.c
+++ b/src/x509.c
@@ -2360,7 +2360,7 @@ void* wolfSSL_X509_get_ext_d2i(const WOLFSSL_X509* x509, int nid, int* c,
 
                     dns = dns->next;
                     /* Using wolfSSL_sk_insert to maintain backwards
-                     * compatiblity with earlier versions of _push API that
+                     * compatibility with earlier versions of _push API that
                      * pushed items to the start of the list instead of the
                      * end. */
                     if (wolfSSL_sk_insert(sk, gn, 0) <= 0) {
@@ -4207,7 +4207,7 @@ int wolfSSL_sk_X509_push(WOLF_STACK_OF(WOLFSSL_X509_NAME)* sk,
 /* Return and remove the last x509 pushed on stack */
 WOLFSSL_X509* wolfSSL_sk_X509_pop(WOLF_STACK_OF(WOLFSSL_X509_NAME)* sk)
 {
-    return wolfSSL_sk_pop(sk);
+    return (WOLFSSL_X509*)wolfSSL_sk_pop(sk);
 }
 
 /* Getter function for WOLFSSL_X509 pointer
@@ -4234,7 +4234,7 @@ WOLFSSL_X509* wolfSSL_sk_X509_value(WOLF_STACK_OF(WOLFSSL_X509)* sk, int i)
 /* Return and remove the first x509 pushed on stack */
 WOLFSSL_X509* wolfSSL_sk_X509_shift(WOLF_STACK_OF(WOLFSSL_X509)* sk)
 {
-    return wolfSSL_sk_pop_node(sk, 0);
+    return (WOLFSSL_X509*)wolfSSL_sk_pop_node(sk, 0);
 }
 
 #endif /* OPENSSL_EXTRA */
@@ -4547,17 +4547,7 @@ int wolfSSL_sk_GENERAL_NAME_push(WOLFSSL_GENERAL_NAMES* sk,
  */
 WOLFSSL_GENERAL_NAME* wolfSSL_sk_GENERAL_NAME_value(WOLFSSL_STACK* sk, int idx)
 {
-    WOLFSSL_STACK* ret;
-
-    if (sk == NULL) {
-        return NULL;
-    }
-
-    ret = wolfSSL_sk_get_node(sk, idx);
-    if (ret != NULL) {
-        return ret->data.gn;
-    }
-    return NULL;
+    return (WOLFSSL_GENERAL_NAME*)wolfSSL_sk_value(sk, idx);
 }
 
 /* Gets the number of nodes in the stack
@@ -4570,11 +4560,7 @@ int wolfSSL_sk_GENERAL_NAME_num(WOLFSSL_STACK* sk)
 {
     WOLFSSL_ENTER("wolfSSL_sk_GENERAL_NAME_num");
 
-    if (sk == NULL) {
-        return WOLFSSL_FATAL_ERROR;
-    }
-
-    return (int)sk->num;
+    return wolfSSL_sk_num(sk);
 }
 
 /* Allocates an empty GENERAL NAME stack */
@@ -13398,7 +13384,7 @@ WOLFSSL_X509_NAME* wolfSSL_sk_X509_NAME_value(
 WOLFSSL_X509_NAME* wolfSSL_sk_X509_NAME_pop(
     WOLF_STACK_OF(WOLFSSL_X509_NAME)* sk)
 {
-    return wolfSSL_sk_pop(sk);
+    return (WOLFSSL_X509_NAME*)wolfSSL_sk_pop(sk);
 }
 
 void wolfSSL_sk_X509_NAME_pop_free(WOLF_STACK_OF(WOLFSSL_X509_NAME)* sk,
@@ -13549,7 +13535,7 @@ WOLFSSL_X509_INFO* wolfSSL_sk_X509_INFO_value(
 WOLFSSL_X509_INFO* wolfSSL_sk_X509_INFO_pop(
         WOLF_STACK_OF(WOLFSSL_X509_INFO)* sk)
 {
-    return wolfSSL_sk_pop(sk);
+    return (WOLFSSL_X509_INFO*)wolfSSL_sk_pop(sk);
 }
 
 #if defined(OPENSSL_ALL)
@@ -15206,7 +15192,10 @@ int wolfSSL_X509_REQ_add1_attr_by_NID(WOLFSSL_X509 *req,
         }
         if ((req->reqAttributes != NULL) &&
                 (req->reqAttributes->type == STACK_TYPE_X509_REQ_ATTR)) {
-            ret = wolfSSL_sk_push(req->reqAttributes, attr) > 0
+            /* Using wolfSSL_sk_insert to maintain backwards compatibility with
+             * earlier versions of _push API that pushed items to the start of
+             * the list instead of the end. */
+            ret = wolfSSL_sk_insert(req->reqAttributes, attr, 0) > 0
                     ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
         }
         else {

--- a/src/x509.c
+++ b/src/x509.c
@@ -4203,30 +4203,7 @@ int wolfSSL_sk_X509_push(WOLF_STACK_OF(WOLFSSL_X509_NAME)* sk,
 /* Return and remove the last x509 pushed on stack */
 WOLFSSL_X509* wolfSSL_sk_X509_pop(WOLF_STACK_OF(WOLFSSL_X509_NAME)* sk)
 {
-    WOLFSSL_STACK* node;
-    WOLFSSL_X509*  x509;
-
-    if (sk == NULL) {
-        return NULL;
-    }
-
-    node = sk->next;
-    x509 = sk->data.x509;
-
-    if (node != NULL) { /* update sk and remove node from stack */
-        sk->data.x509 = node->data.x509;
-        sk->next = node->next;
-        XFREE(node, NULL, DYNAMIC_TYPE_X509);
-    }
-    else { /* last x509 in stack */
-        sk->data.x509 = NULL;
-    }
-
-    if (sk->num > 0) {
-        sk->num--;
-    }
-
-    return x509;
+    return wolfSSL_sk_pop(sk);
 }
 
 /* Getter function for WOLFSSL_X509 pointer
@@ -13448,30 +13425,7 @@ WOLFSSL_X509_NAME* wolfSSL_sk_X509_NAME_value(
 WOLFSSL_X509_NAME* wolfSSL_sk_X509_NAME_pop(
     WOLF_STACK_OF(WOLFSSL_X509_NAME)* sk)
 {
-    WOLFSSL_STACK* node;
-    WOLFSSL_X509_NAME* name;
-
-    if (sk == NULL) {
-        return NULL;
-    }
-
-    node = sk->next;
-    name = sk->data.name;
-
-    if (node != NULL) { /* update sk and remove node from stack */
-        sk->data.name = node->data.name;
-        sk->next = node->next;
-        XFREE(node, NULL, DYNAMIC_TYPE_OPENSSL);
-    }
-    else { /* last x509 in stack */
-        sk->data.name = NULL;
-    }
-
-    if (sk->num > 0) {
-        sk->num -= 1;
-    }
-
-    return name;
+    return wolfSSL_sk_pop(sk);
 }
 
 void wolfSSL_sk_X509_NAME_pop_free(WOLF_STACK_OF(WOLFSSL_X509_NAME)* sk,
@@ -13622,30 +13576,7 @@ WOLFSSL_X509_INFO* wolfSSL_sk_X509_INFO_value(
 WOLFSSL_X509_INFO* wolfSSL_sk_X509_INFO_pop(
         WOLF_STACK_OF(WOLFSSL_X509_INFO)* sk)
 {
-    WOLFSSL_STACK* node;
-    WOLFSSL_X509_INFO* info;
-
-    if (sk == NULL) {
-        return NULL;
-    }
-
-    node = sk->next;
-    info = sk->data.info;
-
-    if (node != NULL) { /* update sk and remove node from stack */
-        sk->data.info = node->data.info;
-        sk->next = node->next;
-        wolfSSL_sk_free_node(node);
-    }
-    else { /* last x509 in stack */
-        sk->data.info = NULL;
-    }
-
-    if (sk->num > 0) {
-        sk->num -= 1;
-    }
-
-    return info;
+    return wolfSSL_sk_pop(sk);
 }
 
 #if defined(OPENSSL_ALL)

--- a/src/x509.c
+++ b/src/x509.c
@@ -2359,7 +2359,11 @@ void* wolfSSL_X509_get_ext_d2i(const WOLFSSL_X509* x509, int nid, int* c,
                     }
 
                     dns = dns->next;
-                    if (wolfSSL_sk_GENERAL_NAME_push(sk, gn) <= 0) {
+                    /* Using wolfSSL_sk_insert to maintain backwards
+                     * compatiblity with earlier versions of _push API that
+                     * pushed items to the start of the list instead of the
+                     * end. */
+                    if (wolfSSL_sk_insert(sk, gn, 0) <= 0) {
                         WOLFSSL_MSG("Error pushing ASN1 object onto stack");
                         goto err;
                     }

--- a/tests/api.c
+++ b/tests/api.c
@@ -22069,7 +22069,7 @@ static int test_wolfSSL_X509_INFO_multiple_info(void)
         ExpectNotNull(info = sk_X509_INFO_value(info_stack, i));
         ExpectNotNull(info->x509);
         ExpectNull(info->crl);
-        if (i != 0) {
+        if (i != 2) {
             ExpectNotNull(info->x_pkey);
             ExpectIntEQ(X509_check_private_key(info->x509,
                                                info->x_pkey->dec_pkey), 1);
@@ -36213,7 +36213,7 @@ static int test_GENERAL_NAME_set0_othername(void)
 
     ExpectNull(sk_GENERAL_NAME_value(NULL, 0));
     ExpectNull(sk_GENERAL_NAME_value(gns, 20));
-    ExpectNotNull(gn = sk_GENERAL_NAME_value(gns, 2));
+    ExpectNotNull(gn = sk_GENERAL_NAME_value(gns, 0));
     ExpectIntEQ(gn->type, 0);
 
     sk_GENERAL_NAME_pop_free(gns, GENERAL_NAME_free);
@@ -46197,8 +46197,8 @@ static int test_sk_X509(void)
         sk_X509_push(s, &x2);
         ExpectIntEQ(sk_X509_num(s), 2);
         ExpectNull(sk_X509_value(s, 2));
-        ExpectIntEQ((sk_X509_value(s, 0) == &x2), 1);
-        ExpectIntEQ((sk_X509_value(s, 1) == &x1), 1);
+        ExpectIntEQ((sk_X509_value(s, 0) == &x1), 1);
+        ExpectIntEQ((sk_X509_value(s, 1) == &x2), 1);
         sk_X509_push(s, &x2);
 
         sk_X509_pop_free(s, free_x509);
@@ -46223,20 +46223,20 @@ static int test_sk_X509(void)
         for (i = 0; i < len; ++i) {
             sk_X509_push(s, xList[i]);
             ExpectIntEQ(sk_X509_num(s), i + 1);
-            ExpectIntEQ((sk_X509_value(s, 0) == xList[i]), 1);
-            ExpectIntEQ((sk_X509_value(s, i) == xList[0]), 1);
+            ExpectIntEQ((sk_X509_value(s, 0) == xList[0]), 1);
+            ExpectIntEQ((sk_X509_value(s, i) == xList[i]), 1);
         }
 
-        /* pop returns and removes last pushed on stack, which is index 0
+        /* pop returns and removes last pushed on stack, which is the last index
          * in sk_x509_value */
-        for (i = 0; i < len; ++i) {
-            X509 * x = sk_X509_value(s, 0);
+        for (i = len-1; i >= 0; --i) {
+            X509 * x = sk_X509_value(s, i);
             X509 * y = sk_X509_pop(s);
-            X509 * z = xList[len - 1 - i];
+            X509 * z = xList[i];
 
-            ExpectIntEQ((x == y), 1);
-            ExpectIntEQ((x == z), 1);
-            ExpectIntEQ(sk_X509_num(s), len - 1 - i);
+            ExpectPtrEq(x, y);
+            ExpectPtrEq(x, z);
+            ExpectIntEQ(sk_X509_num(s), i);
         }
 
         sk_free(s);
@@ -46248,14 +46248,14 @@ static int test_sk_X509(void)
         for (i = 0; i < len; ++i) {
             sk_X509_push(s, xList[i]);
             ExpectIntEQ(sk_X509_num(s), i + 1);
-            ExpectIntEQ((sk_X509_value(s, 0) == xList[i]), 1);
-            ExpectIntEQ((sk_X509_value(s, i) == xList[0]), 1);
+            ExpectIntEQ((sk_X509_value(s, 0) == xList[0]), 1);
+            ExpectIntEQ((sk_X509_value(s, i) == xList[i]), 1);
         }
 
         /* shift returns and removes first pushed on stack, which is index i
          * in sk_x509_value() */
         for (i = 0; i < len; ++i) {
-            X509 * x = sk_X509_value(s, len - 1 - i);
+            X509 * x = sk_X509_value(s, 0);
             X509 * y = sk_X509_shift(s);
             X509 * z = xList[i];
 
@@ -49234,12 +49234,12 @@ static int test_wolfSSL_d2i_X509_REQ(void)
         ExpectIntEQ(X509_REQ_get_attr_by_NID(NULL, NID_pkcs9_challengePassword,
             -1), -1);
         ExpectIntEQ(X509_REQ_get_attr_by_NID(req, NID_pkcs9_challengePassword,
-            -1), 1);
+            -1), 0);
         ExpectNull(X509_REQ_get_attr(NULL, 3));
         ExpectNull(X509_REQ_get_attr(req, 3));
         ExpectNull(X509_REQ_get_attr(NULL, 0));
         ExpectNull(X509_REQ_get_attr(empty, 0));
-        ExpectNotNull(attr = X509_REQ_get_attr(req, 1));
+        ExpectNotNull(attr = X509_REQ_get_attr(req, 0));
         ExpectNull(X509_ATTRIBUTE_get0_type(NULL, 1));
         ExpectNull(X509_ATTRIBUTE_get0_type(attr, 1));
         ExpectNull(X509_ATTRIBUTE_get0_type(NULL, 0));

--- a/tests/api.c
+++ b/tests/api.c
@@ -36208,12 +36208,12 @@ static int test_GENERAL_NAME_set0_othername(void)
     ExpectNotNull(gns = (GENERAL_NAMES*)X509_get_ext_d2i(x509,
         NID_subject_alt_name, NULL, NULL));
 
-    ExpectIntEQ(sk_GENERAL_NAME_num(NULL), WOLFSSL_FATAL_ERROR);
+    ExpectIntEQ(sk_GENERAL_NAME_num(NULL), 0);
     ExpectIntEQ(sk_GENERAL_NAME_num(gns), 3);
 
     ExpectNull(sk_GENERAL_NAME_value(NULL, 0));
     ExpectNull(sk_GENERAL_NAME_value(gns, 20));
-    ExpectNotNull(gn = sk_GENERAL_NAME_value(gns, 0));
+    ExpectNotNull(gn = sk_GENERAL_NAME_value(gns, 2));
     ExpectIntEQ(gn->type, 0);
 
     sk_GENERAL_NAME_pop_free(gns, GENERAL_NAME_free);
@@ -49234,12 +49234,12 @@ static int test_wolfSSL_d2i_X509_REQ(void)
         ExpectIntEQ(X509_REQ_get_attr_by_NID(NULL, NID_pkcs9_challengePassword,
             -1), -1);
         ExpectIntEQ(X509_REQ_get_attr_by_NID(req, NID_pkcs9_challengePassword,
-            -1), 0);
+            -1), 1);
         ExpectNull(X509_REQ_get_attr(NULL, 3));
         ExpectNull(X509_REQ_get_attr(req, 3));
         ExpectNull(X509_REQ_get_attr(NULL, 0));
         ExpectNull(X509_REQ_get_attr(empty, 0));
-        ExpectNotNull(attr = X509_REQ_get_attr(req, 0));
+        ExpectNotNull(attr = X509_REQ_get_attr(req, 1));
         ExpectNull(X509_ATTRIBUTE_get0_type(NULL, 1));
         ExpectNull(X509_ATTRIBUTE_get0_type(attr, 1));
         ExpectNull(X509_ATTRIBUTE_get0_type(NULL, 0));

--- a/tests/api.c
+++ b/tests/api.c
@@ -28646,7 +28646,7 @@ static int test_X509_STORE_get0_objects(void)
 #endif
     ExpectNotNull(objsCopy = sk_X509_OBJECT_deep_copy(objs, NULL, NULL));
     ExpectIntEQ(sk_X509_OBJECT_num(objs), sk_X509_OBJECT_num(objsCopy));
-    for (i = 0; i < sk_X509_OBJECT_num(objs); i++) {
+    for (i = 0; i < sk_X509_OBJECT_num(objs) && EXPECT_SUCCESS(); i++) {
         obj = (X509_OBJECT*)sk_X509_OBJECT_value(objs, i);
     #ifdef HAVE_CRL
         objCopy = (X509_OBJECT*)sk_X509_OBJECT_value(objsCopy, i);

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -158,7 +158,7 @@ wolfSSL_Logging_cb wolfSSL_GetLoggingCb(void)
 int wolfSSL_Debugging_ON(void)
 {
 #ifdef DEBUG_WOLFSSL
-    loggingEnabled = 1;
+    loggingEnabled = 0;
 #if defined(WOLFSSL_APACHE_MYNEWT)
     log_register("wolfcrypt", &mynewt_log, &log_console_handler, NULL, LOG_SYSLEVEL);
 #endif /* WOLFSSL_APACHE_MYNEWT */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -7189,6 +7189,7 @@ WOLFSSL_LOCAL int TranslateErrorToAlert(int err);
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)
 WOLFSSL_LOCAL void* wolfssl_sk_pop_type(WOLFSSL_STACK* sk,
                                         WOLF_STACK_TYPE type);
+WOLFSSL_LOCAL void* wolfSSL_sk_pop_node(WOLFSSL_STACK* sk, int idx);
 WOLFSSL_LOCAL WOLFSSL_STACK* wolfssl_sk_new_type(WOLF_STACK_TYPE type);
 
 WOLFSSL_LOCAL int wolfssl_asn1_obj_set(WOLFSSL_ASN1_OBJECT* obj,

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1853,6 +1853,7 @@ WOLFSSL_API int wolfSSL_sk_push_node(WOLFSSL_STACK** stack, WOLFSSL_STACK* in);
 WOLFSSL_API WOLFSSL_STACK* wolfSSL_sk_get_node(WOLFSSL_STACK* sk, int idx);
 WOLFSSL_API int wolfSSL_sk_push(WOLFSSL_STACK *st, const void *data);
 WOLFSSL_API int wolfSSL_sk_insert(WOLFSSL_STACK *sk, const void *data, int idx);
+WOLFSSL_API void* wolfSSL_sk_pop(WOLFSSL_STACK* sk);
 
 #if defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA) || defined(WOLFSSL_QT)
 WOLFSSL_API int wolfSSL_sk_ACCESS_DESCRIPTION_push(


### PR DESCRIPTION
- The last object pushed should be visible in the highest index
- Refactor *_push and *_pop compat API