### PR TITLE
ML-KEM/Kyber: fix for big-endian

### DIFF
--- a/wolfcrypt/src/wc_mlkem_poly.c
+++ b/wolfcrypt/src/wc_mlkem_poly.c
@@ -3166,7 +3166,8 @@ static unsigned int mlkem_rej_uniform_c(sword16* p, unsigned int len,
     unsigned int i;
     unsigned int j;
 
-#if defined(WOLFSSL_MLKEM_SMALL) || !defined(WC_64BIT_CPU)
+#if defined(WOLFSSL_MLKEM_SMALL) || !defined(WC_64BIT_CPU) || \
+    defined(BIG_ENDIAN_ORDER)
     /* Keep sampling until maximum number of integers reached or buffer used up.
      * Step 4. */
     for (i = 0, j = 0; (i < len) && (j <= rLen - 3); j += 3) {


### PR DESCRIPTION
# Description

Don't pull apart the nibbles when big-endian in reject uniform C code.

# Testing

./uatogen.sh
./configure '--disable-shared' 'LDFLAGS=--static' '--host=ppc64' 'CC=powerpc64-linux-gnu-gcc' '--enable-kyber' 'host_alias=ppc64'
make
./wolfcrypt/test/testwolfcrypt


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
