### PR TITLE
Set the CMake compiler version for failing gh actions

### DIFF
--- a/.github/workflows/grpc.yml
+++ b/.github/workflows/grpc.yml
@@ -71,6 +71,11 @@ jobs:
         with:
           name: wolf-install-grpc
 
+      - name: Setup cmake version
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.25.x'
+
       - name: untar build-dir
         run: tar -xf build-dir.tgz
 

--- a/.github/workflows/jwt-cpp.yml
+++ b/.github/workflows/jwt-cpp.yml
@@ -66,6 +66,11 @@ jobs:
         with:
           name: wolf-install-jwt-cpp
 
+      - name: Setup cmake version
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.25.x'
+
       - name: untar build-dir
         run: tar -xf build-dir.tgz
 

--- a/.github/workflows/libvncserver.yml
+++ b/.github/workflows/libvncserver.yml
@@ -55,6 +55,11 @@ jobs:
         with:
           name: wolf-install-libvncserver
 
+      - name: Setup cmake version
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.25.x'
+
       - name: untar build-dir
         run: tar -xf build-dir.tgz
 

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -49,6 +49,11 @@ jobs:
             python3-ply python3-setuptools python-is-python3 qemu-kvm rsync socat srecord sudo \
             texinfo unzip wget ovmf xz-utils
 
+      - name: Setup cmake version
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.25.x'
+
       - name: Install west
         run: sudo pip install west
 


### PR DESCRIPTION
# Description

Fixes failing zephyr,  grpc, jwt-cpp and libvncserver github action tests


# Testing

Tested via Github actions

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
