### PR TITLE
LMS: add API to get Key ID from raw private key

### DIFF
--- a/wolfcrypt/src/ext_lms.c
+++ b/wolfcrypt/src/ext_lms.c
@@ -1049,4 +1049,12 @@ int wc_LmsKey_Verify(LmsKey * key, const byte * sig, word32 sigSz,
     return 0;
 }
 
+const byte * wc_LmsKey_GetKidFromPrivRaw(const byte * priv, word32 privSz)
+{
+    if ((priv == NULL) || (privSz < 16)) {
+        return NULL;
+    }
+    return priv - 16;
+}
+
 #endif /* WOLFSSL_HAVE_LMS && HAVE_LIBLMS */

--- a/wolfcrypt/src/wc_lms.c
+++ b/wolfcrypt/src/wc_lms.c
@@ -1264,4 +1264,28 @@ int wc_LmsKey_Verify(LmsKey* key, const byte* sig, word32 sigSz,
     return ret;
 }
 
+/* Get the Key ID from the raw private key data.
+ *
+ * PRIV = Q | PARAMS | SEED | I
+ * where I is the Key ID.
+ *
+ * @param [in] priv    Private key data.
+ * @param [in] privSz  Size of private key data.
+ * @param  Pointer to 16 byte Key ID in the private key.
+ * @return  NULL on failure.
+ */
+const byte * wc_LmsKey_GetKidFromPrivRaw(const byte * priv, word32 privSz)
+{
+    word32 seedSz = privSz - LMS_Q_LEN + HSS_PRIV_KEY_PARAM_SET_LEN - LMS_I_LEN;
+
+    if (priv == NULL) {
+        return NULL;
+    }
+    if ((seedSz != WC_SHA256_192_DIGEST_SIZE) &&
+            (seedSz != WC_SHA256_DIGEST_SIZE)) {
+        return NULL;
+    }
+    return priv - LMS_I_LEN;
+}
+
 #endif /* WOLFSSL_HAVE_LMS && WOLFSSL_WC_LMS */

--- a/wolfssl/wolfcrypt/lms.h
+++ b/wolfssl/wolfcrypt/lms.h
@@ -186,6 +186,9 @@ WOLFSSL_API int  wc_LmsKey_Verify(LmsKey * key, const byte * sig, word32 sigSz,
     const byte * msg, int msgSz);
 WOLFSSL_API const char * wc_LmsKey_ParmToStr(enum wc_LmsParm lmsParm);
 WOLFSSL_API const char * wc_LmsKey_RcToStr(enum wc_LmsRc lmsRc);
+
+WOLFSSL_API const byte * wc_LmsKey_GetKidFromPrivRaw(const byte * priv,
+    word32 privSz);
 #ifdef __cplusplus
     } /* extern "C" */
 #endif


### PR DESCRIPTION
# Description

Always last 16 bytes of private key.

Fixes zd#19653

# Testing

./configure '--disable-shared' '--enable-lms=yes,sha256-192' '--enable-intelasm'

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
