### PR TITLE
dtls13: additional epoch checks

### DIFF
--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -42,6 +42,7 @@ jobs:
             --enable-psk --enable-aesccm --enable-nullcipher CPPFLAGS=-DWOLFSSL_STATIC_RSA',
           '--enable-ascon --enable-experimental',
           '--enable-ascon CPPFLAGS=-DWOLFSSL_ASCON_UNROLL --enable-experimental',
+          '--enable-all --enable-examples=dynamic',
         ]
     name: make check
     if: github.repository_owner == 'wolfssl'

--- a/configure.ac
+++ b/configure.ac
@@ -8202,6 +8202,11 @@ AC_ARG_ENABLE([examples],
 AS_IF([test "x$ENABLED_FILESYSTEM" = "xno"], [ENABLED_EXAMPLES="no"])
 AS_IF([test "x$ENABLED_CRYPTONLY" = "xyes"], [ENABLED_EXAMPLES="no"])
 
+# Enable static to be able to test internals
+if test "$ENABLED_EXAMPLES" = "yes"
+then
+    enable_static=yes
+fi
 
 # Enable wolfCrypt test and benchmark
 if test "$ENABLED_LINUXKM" = "yes"
@@ -10261,10 +10266,8 @@ case $host_os in
         fi ;;
 esac
 
-if test "$enable_shared" = "no"; then
-    if test "$enable_static" = "yes"; then
-        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_TEST_STATIC_BUILD"
-    fi
+if test "$enable_static" = "yes"; then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_TEST_STATIC_BUILD"
 fi
 
 if test "x$ENABLED_LINUXKM" = "xyes"; then
@@ -10526,6 +10529,7 @@ AM_CONDITIONAL([BUILD_MAXQ10XX],[test "x$ENABLED_MAXQ10XX" = "xyes"])
 AM_CONDITIONAL([BUILD_ARIA],[test "x$ENABLED_ARIA" = "xyes"])
 AM_CONDITIONAL([BUILD_XILINX],[test "x$ENABLED_XILINX" = "xyes"])
 AM_CONDITIONAL([BUILD_AUTOSAR],[test "x$ENABLED_AUTOSAR" = "xyes"])
+AM_CONDITIONAL([BUILD_STATIC],[test "x$enable_static" = "xyes"])
 
 if test "$ENABLED_REPRODUCIBLE_BUILD" != "yes" &&
    (test "$ax_enable_debug" = "yes" ||

--- a/configure.ac
+++ b/configure.ac
@@ -8203,9 +8203,14 @@ AS_IF([test "x$ENABLED_FILESYSTEM" = "xno"], [ENABLED_EXAMPLES="no"])
 AS_IF([test "x$ENABLED_CRYPTONLY" = "xyes"], [ENABLED_EXAMPLES="no"])
 
 # Enable static to be able to test internals
-if test "$ENABLED_EXAMPLES" = "yes"
+if test "$ENABLED_EXAMPLES" = "yes" && test "$ENABLED_FIPS" = "no"
 then
     enable_static=yes
+fi
+# Revert back to yes to make further checks easier
+if test "$ENABLED_EXAMPLES" = "dynamic"
+then
+    ENABLED_EXAMPLES=yes
 fi
 
 # Enable wolfCrypt test and benchmark
@@ -10266,7 +10271,8 @@ case $host_os in
         fi ;;
 esac
 
-if test "$enable_static" = "yes"; then
+if test "$enable_static" = "yes" && test "$ENABLED_FIPS" = "no"
+then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_TEST_STATIC_BUILD"
 fi
 

--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -1640,6 +1640,102 @@ static int Dtls13AcceptFragmented(WOLFSSL *ssl, enum HandShakeType type)
 #endif
     return 0;
 }
+
+int Dtls13CheckEpoch(WOLFSSL* ssl, enum HandShakeType type)
+{
+    w64wrapper plainEpoch = w64From32(0x0, 0x0);
+    w64wrapper hsEpoch = w64From32(0x0, DTLS13_EPOCH_HANDSHAKE);
+    w64wrapper t0Epoch = w64From32(0x0, DTLS13_EPOCH_TRAFFIC0);
+
+    if (IsAtLeastTLSv1_3(ssl->version)) {
+        switch (type) {
+            case client_hello:
+            case server_hello:
+            case hello_verify_request:
+            case hello_retry_request:
+            case hello_request:
+                if (!w64Equal(ssl->keys.curEpoch64, plainEpoch)) {
+                    WOLFSSL_MSG("Msg should be epoch 0");
+                    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
+                    return SANITY_MSG_E;
+                }
+                break;
+            case encrypted_extensions:
+            case server_key_exchange:
+            case server_hello_done:
+            case client_key_exchange:
+                if (!w64Equal(ssl->keys.curEpoch64, hsEpoch)) {
+                    if (ssl->options.side == WOLFSSL_CLIENT_END &&
+                            ssl->options.serverState < SERVER_HELLO_COMPLETE) {
+                        /* before processing SH we don't know which version
+                         * will be negotiated.  */
+                        if (!w64Equal(ssl->keys.curEpoch64, plainEpoch)) {
+                            WOLFSSL_MSG("Msg should be epoch 2 or 0");
+                            WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
+                            return SANITY_MSG_E;
+                        }
+                    }
+                    else {
+                        WOLFSSL_MSG("Msg should be epoch 2");
+                        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
+                        return SANITY_MSG_E;
+                    }
+                }
+                break;
+            case certificate_request:
+            case certificate:
+            case certificate_verify:
+            case finished:
+                if (!ssl->options.handShakeDone) {
+                    if (!w64Equal(ssl->keys.curEpoch64, hsEpoch)) {
+                        if (ssl->options.side == WOLFSSL_CLIENT_END &&
+                            ssl->options.serverState < SERVER_HELLO_COMPLETE) {
+                            /* before processing SH we don't know which version
+                             * will be negotiated.  */
+                            if (!w64Equal(ssl->keys.curEpoch64, plainEpoch)) {
+                                WOLFSSL_MSG("Msg should be epoch 2 or 0");
+                                WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
+                                return SANITY_MSG_E;
+                            }
+                        }
+                        else {
+                            WOLFSSL_MSG("Msg should be epoch 2");
+                            WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
+                            return SANITY_MSG_E;
+                        }
+                    }
+                }
+                else {
+                    /* Allow epoch 2 in case of rtx */
+                    if (!w64GTE(ssl->keys.curEpoch64, hsEpoch)) {
+                        WOLFSSL_MSG("Msg should be epoch 2+");
+                        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
+                        return SANITY_MSG_E;
+                    }
+                }
+                break;
+            case certificate_status:
+            case change_cipher_hs:
+            case key_update:
+            case session_ticket:
+                if (!w64GTE(ssl->keys.curEpoch64, t0Epoch)) {
+                    WOLFSSL_MSG("Msg should be epoch 3+");
+                    WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
+                    return SANITY_MSG_E;
+                }
+                break;
+            case end_of_early_data:
+            case message_hash:
+            case no_shake:
+            default:
+                WOLFSSL_MSG("Unknown message type");
+                WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
+                return SANITY_MSG_E;
+        }
+    }
+    return 0;
+}
+
 /**
  * Dtls13HandshakeRecv() - process an handshake message. Deal with
  fragmentation if needed
@@ -1670,6 +1766,12 @@ static int _Dtls13HandshakeRecv(WOLFSSL* ssl, byte* input, word32 size,
 
     /* Need idx + fragLength as we don't advance the inputBuffer idx value */
     ret = EarlySanityCheckMsgReceived(ssl, handshakeType, idx + fragLength);
+    if (ret != 0) {
+        WOLFSSL_ERROR(ret);
+        return ret;
+    }
+
+    ret = Dtls13CheckEpoch(ssl, handshakeType);
     if (ret != 0) {
         WOLFSSL_ERROR(ret);
         return ret;

--- a/src/internal.c
+++ b/src/internal.c
@@ -21012,6 +21012,16 @@ int DoApplicationData(WOLFSSL* ssl, byte* input, word32* inOutIdx, int sniff)
         isEarlyData = isEarlyData && w64Equal(ssl->keys.curEpoch64,
                 w64From32(0x0, DTLS13_EPOCH_EARLYDATA));
 #endif
+#ifdef WOLFSSL_DTLS13
+    /* Application data should never appear in epoch 0 or 2 */
+    if (ssl->options.tls1_3 && ssl->options.dtls &&
+        (w64Equal(ssl->keys.curEpoch64, w64From32(0x0, DTLS13_EPOCH_HANDSHAKE))
+                || w64Equal(ssl->keys.curEpoch64, w64From32(0x0, 0x0))))
+    {
+        WOLFSSL_ERROR_VERBOSE(SANITY_MSG_E);
+        return SANITY_MSG_E;
+    }
+#endif
 
 #ifdef WOLFSSL_EARLY_DATA
     if (isEarlyData && acceptEarlyData) {

--- a/tests/api.c
+++ b/tests/api.c
@@ -37981,6 +37981,7 @@ static int test_wolfSSL_ciphersuite_auth(void)
 static int test_wolfSSL_sigalg_info(void)
 {
     EXPECT_DECLS;
+#ifdef WOLFSSL_TEST_STATIC_BUILD
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_EXTRA)
     byte hashSigAlgo[WOLFSSL_MAX_SIGALGO];
     word16 len = 0;
@@ -38011,6 +38012,7 @@ static int test_wolfSSL_sigalg_info(void)
         ExpectIntNE(hashAlgo, 0);
     }
 
+#endif
 #endif
     return EXPECT_RESULT();
 }
@@ -56408,6 +56410,7 @@ static void test_wolfSSL_dtls12_fragments_spammer(WOLFSSL* ssl)
     }
 }
 
+#ifdef WOLFSSL_TEST_STATIC_BUILD
 #ifdef WOLFSSL_DTLS13
 static void test_wolfSSL_dtls13_fragments_spammer(WOLFSSL* ssl)
 {
@@ -56454,6 +56457,7 @@ static void test_wolfSSL_dtls13_fragments_spammer(WOLFSSL* ssl)
     }
 }
 #endif
+#endif
 
 static int test_wolfSSL_dtls_fragments(void)
 {
@@ -56470,9 +56474,11 @@ static int test_wolfSSL_dtls_fragments(void)
         {wolfDTLSv1_2_client_method, wolfDTLSv1_2_server_method,
                 test_wolfSSL_dtls12_fragments_spammer},
 #endif
+#ifdef WOLFSSL_TEST_STATIC_BUILD
 #ifdef WOLFSSL_DTLS13
         {wolfDTLSv1_3_client_method, wolfDTLSv1_3_server_method,
                 test_wolfSSL_dtls13_fragments_spammer},
+#endif
 #endif
     };
 
@@ -56668,7 +56674,7 @@ static int test_wolfSSL_dtls_bad_record(void)
 
 #if defined(WOLFSSL_DTLS13) && !defined(WOLFSSL_TLS13_IGNORE_AEAD_LIMITS) && \
     !defined(NO_WOLFSSL_CLIENT) && !defined(NO_WOLFSSL_SERVER) && \
-    defined(HAVE_IO_TESTS_DEPENDENCIES)
+    defined(HAVE_IO_TESTS_DEPENDENCIES) && defined(WOLFSSL_TEST_STATIC_BUILD)
 static volatile int test_AEAD_seq_num = 0;
 #ifdef WOLFSSL_ATOMIC_INITIALIZER
 wolfSSL_Atomic_Int test_AEAD_done = WOLFSSL_ATOMIC_INITIALIZER(0);
@@ -59051,7 +59057,8 @@ static int test_wolfSSL_CRYPTO_get_ex_new_index(void)
     return EXPECT_RESULT();
 }
 
-#if defined(HAVE_EX_DATA_CRYPTO) && defined(OPENSSL_EXTRA)
+#if defined(HAVE_EX_DATA_CRYPTO) && defined(OPENSSL_EXTRA) && \
+    defined(WOLFSSL_TEST_STATIC_BUILD)
 
 #define SESSION_NEW_IDX_LONG 0xDEADBEEF
 #define SESSION_NEW_IDX_VAL  ((void*)0xAEADAEAD)
@@ -60403,6 +60410,7 @@ static int test_wolfSSL_FIPS_mode(void)
     return EXPECT_RESULT();
 }
 
+#ifdef WOLFSSL_TEST_STATIC_BUILD
 #ifdef WOLFSSL_DTLS
 
 /* Prints out the current window */
@@ -60496,7 +60504,9 @@ static int test_wolfSSL_DtlsUpdateWindow(void)
     return EXPECT_RESULT();
 }
 #endif /* WOLFSSL_DTLS */
+#endif
 
+#ifdef WOLFSSL_TEST_STATIC_BUILD
 #ifdef WOLFSSL_DTLS
 static int DFB_TEST(WOLFSSL* ssl, word32 seq, word32 len, word32 f_offset,
         word32 f_len, word32 f_count, byte ready, word32 bytesReceived)
@@ -60621,6 +60631,7 @@ static int test_wolfSSL_DTLS_fragment_buckets(void)
     return EXPECT_RESULT();
 }
 
+#endif
 #endif
 
 
@@ -60916,7 +60927,7 @@ static int test_WOLFSSL_dtls_version_alert(void)
         * !defined(NO_OLD_TLS) && !defined(NO_RSA)
         */
 
-
+#ifdef WOLFSSL_TEST_STATIC_BUILD
 #if defined(WOLFSSL_TICKET_NONCE_MALLOC) && defined(HAVE_SESSION_TICKET)       \
     && defined(WOLFSSL_TLS13) &&                                               \
     (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))\
@@ -61094,6 +61105,7 @@ static int test_ticket_nonce_malloc(void)
 }
 
 #endif /* WOLFSSL_TICKET_NONCE_MALLOC */
+#endif /* WOLFSSL_TEST_STATIC_BUILD */
 
 #if defined(HAVE_SESSION_TICKET) && !defined(WOLFSSL_NO_TLS12) && \
     !defined(WOLFSSL_TICKET_DECRYPT_NO_CREATE) &&                 \
@@ -67548,7 +67560,9 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_CTX_get0_privatekey),
 #ifdef WOLFSSL_DTLS
     TEST_DECL(test_wolfSSL_DtlsUpdateWindow),
+#ifdef WOLFSSL_TEST_STATIC_BUILD
     TEST_DECL(test_wolfSSL_DTLS_fragment_buckets),
+#endif
 #endif
     TEST_DECL(test_wolfSSL_dtls_set_mtu),
     /* Uses Assert in handshake callback. */
@@ -67708,10 +67722,12 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_TLS_13_ticket_different_ciphers),
     TEST_DECL(test_WOLFSSL_dtls_version_alert),
 
+#ifdef WOLFSSL_TEST_STATIC_BUILD
 #if defined(WOLFSSL_TICKET_NONCE_MALLOC) && defined(HAVE_SESSION_TICKET)       \
     && defined(WOLFSSL_TLS13) &&                                               \
     (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
     TEST_DECL(test_ticket_nonce_malloc),
+#endif
 #endif
     TEST_DECL(test_ticket_ret_create),
     TEST_DECL(test_wrong_cs_downgrade),

--- a/tests/api.c
+++ b/tests/api.c
@@ -67558,9 +67558,9 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_SetMinMaxDhKey_Sz),
     TEST_DECL(test_SetTmpEC_DHE_Sz),
     TEST_DECL(test_wolfSSL_CTX_get0_privatekey),
+#ifdef WOLFSSL_TEST_STATIC_BUILD
 #ifdef WOLFSSL_DTLS
     TEST_DECL(test_wolfSSL_DtlsUpdateWindow),
-#ifdef WOLFSSL_TEST_STATIC_BUILD
     TEST_DECL(test_wolfSSL_DTLS_fragment_buckets),
 #endif
 #endif

--- a/tests/api.c
+++ b/tests/api.c
@@ -67782,6 +67782,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_SSLDisableRead),
     TEST_DECL(test_wolfSSL_inject),
     TEST_DECL(test_wolfSSL_dtls_cid_parse),
+    TEST_DECL(test_dtls13_epochs),
     TEST_DECL(test_ocsp_status_callback),
     TEST_DECL(test_ocsp_basic_verify),
     TEST_DECL(test_ocsp_response_parsing),

--- a/tests/api/test_dtls.c
+++ b/tests/api/test_dtls.c
@@ -595,3 +595,56 @@ int test_wolfSSL_dtls_cid_parse(void)
 #endif
     return EXPECT_RESULT();
 }
+
+int test_dtls13_epochs(void) {
+    EXPECT_DECLS;
+#ifdef WOLFSSL_TEST_STATIC_BUILD
+#if defined(WOLFSSL_DTLS13)
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL* ssl = NULL;
+    byte input[20];
+    word32 inOutIdx = 0;
+
+    XMEMSET(input, 0, sizeof(input));
+
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfDTLSv1_3_client_method()));
+    ExpectNotNull(ssl = wolfSSL_new(ctx));
+    /* Some manual setup to enter the epoch check */
+    ExpectTrue(ssl->options.tls1_3 = 1);
+
+    inOutIdx = 0;
+    ssl->keys.curEpoch64 = w64From32(0x0, 0x0);
+    ExpectIntEQ(DoApplicationData(ssl, input, &inOutIdx, 0), SANITY_MSG_E);
+    inOutIdx = 0;
+    ssl->keys.curEpoch64 = w64From32(0x0, 0x2);
+    ExpectIntEQ(DoApplicationData(ssl, input, &inOutIdx, 0), SANITY_MSG_E);
+
+    ssl->keys.curEpoch64 = w64From32(0x0, 0x1);
+    ExpectIntEQ(Dtls13CheckEpoch(ssl, client_hello), SANITY_MSG_E);
+    ExpectIntEQ(Dtls13CheckEpoch(ssl, server_hello), SANITY_MSG_E);
+    ExpectIntEQ(Dtls13CheckEpoch(ssl, hello_verify_request), SANITY_MSG_E);
+    ExpectIntEQ(Dtls13CheckEpoch(ssl, hello_retry_request), SANITY_MSG_E);
+    ExpectIntEQ(Dtls13CheckEpoch(ssl, hello_request), SANITY_MSG_E);
+    ExpectIntEQ(Dtls13CheckEpoch(ssl, encrypted_extensions), SANITY_MSG_E);
+    ExpectIntEQ(Dtls13CheckEpoch(ssl, server_key_exchange), SANITY_MSG_E);
+    ExpectIntEQ(Dtls13CheckEpoch(ssl, server_hello_done), SANITY_MSG_E);
+    ExpectIntEQ(Dtls13CheckEpoch(ssl, client_key_exchange), SANITY_MSG_E);
+    ExpectIntEQ(Dtls13CheckEpoch(ssl, certificate_request), SANITY_MSG_E);
+    ExpectIntEQ(Dtls13CheckEpoch(ssl, certificate), SANITY_MSG_E);
+    ExpectIntEQ(Dtls13CheckEpoch(ssl, certificate_verify), SANITY_MSG_E);
+    ExpectIntEQ(Dtls13CheckEpoch(ssl, finished), SANITY_MSG_E);
+    ExpectIntEQ(Dtls13CheckEpoch(ssl, certificate_status), SANITY_MSG_E);
+    ExpectIntEQ(Dtls13CheckEpoch(ssl, change_cipher_hs), SANITY_MSG_E);
+    ExpectIntEQ(Dtls13CheckEpoch(ssl, key_update), SANITY_MSG_E);
+    ExpectIntEQ(Dtls13CheckEpoch(ssl, session_ticket), SANITY_MSG_E);
+    ExpectIntEQ(Dtls13CheckEpoch(ssl, end_of_early_data), SANITY_MSG_E);
+    ExpectIntEQ(Dtls13CheckEpoch(ssl, message_hash), SANITY_MSG_E);
+    ExpectIntEQ(Dtls13CheckEpoch(ssl, no_shake), SANITY_MSG_E);
+
+    wolfSSL_CTX_free(ctx);
+    wolfSSL_free(ssl);
+#endif
+#endif
+    return EXPECT_RESULT();
+}
+

--- a/tests/api/test_dtls.h
+++ b/tests/api/test_dtls.h
@@ -25,5 +25,6 @@
 int test_dtls12_basic_connection_id(void);
 int test_dtls13_basic_connection_id(void);
 int test_wolfSSL_dtls_cid_parse(void);
+int test_dtls13_epochs(void);
 
 #endif /* TESTS_API_DTLS_H */

--- a/tests/include.am
+++ b/tests/include.am
@@ -24,7 +24,9 @@ endif
 tests_unit_test_CFLAGS       = -DNO_MAIN_DRIVER $(AM_CFLAGS) $(WOLFSENTRY_INCLUDE)
 tests_unit_test_LDADD        = src/libwolfssl@LIBSUFFIX@.la $(LIB_STATIC_ADD) $(WOLFSENTRY_LIB)
 if BUILD_STATIC
+if !BUILD_FIPS
 tests_unit_test_LDFLAGS      = -static
+endif
 endif
 tests_unit_test_DEPENDENCIES = src/libwolfssl@LIBSUFFIX@.la
 include tests/api/include.am

--- a/tests/include.am
+++ b/tests/include.am
@@ -23,6 +23,9 @@ endif
 
 tests_unit_test_CFLAGS       = -DNO_MAIN_DRIVER $(AM_CFLAGS) $(WOLFSENTRY_INCLUDE)
 tests_unit_test_LDADD        = src/libwolfssl@LIBSUFFIX@.la $(LIB_STATIC_ADD) $(WOLFSENTRY_LIB)
+if BUILD_STATIC
+tests_unit_test_LDFLAGS      = -static
+endif
 tests_unit_test_DEPENDENCIES = src/libwolfssl@LIBSUFFIX@.la
 include tests/api/include.am
 endif

--- a/wolfcrypt/benchmark/include.am
+++ b/wolfcrypt/benchmark/include.am
@@ -8,7 +8,9 @@ noinst_PROGRAMS += wolfcrypt/benchmark/benchmark
 wolfcrypt_benchmark_benchmark_SOURCES      = wolfcrypt/benchmark/benchmark.c
 wolfcrypt_benchmark_benchmark_LDADD        = src/libwolfssl@LIBSUFFIX@.la $(LIB_STATIC_ADD)
 if BUILD_STATIC
+if !BUILD_FIPS
 wolfcrypt_benchmark_benchmark_LDFLAGS      = -static
+endif
 endif
 wolfcrypt_benchmark_benchmark_DEPENDENCIES = src/libwolfssl@LIBSUFFIX@.la
 noinst_HEADERS += wolfcrypt/benchmark/benchmark.h

--- a/wolfcrypt/benchmark/include.am
+++ b/wolfcrypt/benchmark/include.am
@@ -7,6 +7,9 @@ if BUILD_BENCHMARK
 noinst_PROGRAMS += wolfcrypt/benchmark/benchmark
 wolfcrypt_benchmark_benchmark_SOURCES      = wolfcrypt/benchmark/benchmark.c
 wolfcrypt_benchmark_benchmark_LDADD        = src/libwolfssl@LIBSUFFIX@.la $(LIB_STATIC_ADD)
+if BUILD_STATIC
+wolfcrypt_benchmark_benchmark_LDFLAGS      = -static
+endif
 wolfcrypt_benchmark_benchmark_DEPENDENCIES = src/libwolfssl@LIBSUFFIX@.la
 noinst_HEADERS += wolfcrypt/benchmark/benchmark.h
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2435,8 +2435,7 @@ typedef struct CipherSuite {
 #endif
 } CipherSuite;
 
-/* use wolfSSL_API visibility to be able to test in tests/api.c */
-WOLFSSL_API void InitSuitesHashSigAlgo(byte* hashSigAlgo, int have,
+WOLFSSL_LOCAL void InitSuitesHashSigAlgo(byte* hashSigAlgo, int have,
                                        int tls1_2, int keySz, word16* len);
 WOLFSSL_LOCAL int AllocateCtxSuites(WOLFSSL_CTX* ctx);
 WOLFSSL_LOCAL int AllocateSuites(WOLFSSL* ssl);
@@ -3392,13 +3391,6 @@ WOLFSSL_LOCAL void* TLSX_CSR2_GetRequest(TLSX* extensions, byte status_type,
 WOLFSSL_LOCAL int   TLSX_CSR2_ForceRequest(WOLFSSL* ssl);
 
 #endif
-
-#if defined(WOLFSSL_PUBLIC_ASN) && defined(HAVE_PK_CALLBACKS)
-/* Internal callback guarded by WOLFSSL_PUBLIC_ASN because of DecodedCert. */
-typedef int (*CallbackProcessPeerCert)(WOLFSSL* ssl, DecodedCert* p_cert);
-WOLFSSL_API void wolfSSL_CTX_SetProcessPeerCertCb(WOLFSSL_CTX* ctx,
-       CallbackProcessPeerCert cb);
-#endif /* DecodedCert && HAVE_PK_CALLBACKS */
 
 #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
 typedef struct SignatureAlgorithms {
@@ -4700,8 +4692,7 @@ WOLFSSL_LOCAL WOLFSSL_SESSION* wolfSSL_GetSession(
     WOLFSSL* ssl, byte* masterSecret, byte restoreSessionCerts);
 WOLFSSL_LOCAL void SetupSession(WOLFSSL* ssl);
 WOLFSSL_LOCAL void AddSession(WOLFSSL* ssl);
-/* use wolfSSL_API visibility to be able to test in tests/api.c */
-WOLFSSL_API int AddSessionToCache(WOLFSSL_CTX* ctx,
+WOLFSSL_LOCAL int AddSessionToCache(WOLFSSL_CTX* ctx,
     WOLFSSL_SESSION* addSession, const byte* id, byte idSz, int* sessionIndex,
     int side, word16 useTicket, ClientSession** clientCacheEntry);
 #ifndef NO_CLIENT_CACHE
@@ -4717,8 +4708,7 @@ WOLFSSL_LOCAL int TlsSessionCacheGetAndRdLock(const byte *id,
 WOLFSSL_LOCAL int TlsSessionCacheGetAndWrLock(const byte *id,
     WOLFSSL_SESSION **sess, word32 *lockedRow, byte side);
 WOLFSSL_LOCAL void EvictSessionFromCache(WOLFSSL_SESSION* session);
-/* WOLFSSL_API to test it in tests/api.c */
-WOLFSSL_API int wolfSSL_GetSessionFromCache(WOLFSSL* ssl, WOLFSSL_SESSION* output);
+WOLFSSL_LOCAL int wolfSSL_GetSessionFromCache(WOLFSSL* ssl, WOLFSSL_SESSION* output);
 WOLFSSL_LOCAL int wolfSSL_SetSession(WOLFSSL* ssl, WOLFSSL_SESSION* session);
 WOLFSSL_LOCAL void wolfSSL_FreeSession(WOLFSSL_CTX* ctx,
         WOLFSSL_SESSION* session);
@@ -6382,7 +6372,6 @@ WOLFSSL_LOCAL int  SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup);
 WOLFSSL_LOCAL int  InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup);
 WOLFSSL_LOCAL int  ReinitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup);
 WOLFSSL_LOCAL void FreeSSL(WOLFSSL* ssl, void* heap);
-WOLFSSL_API   void wolfSSL_ResourceFree(WOLFSSL* ssl);   /* Micrium uses */
 #ifndef OPENSSL_COEXIST
 #define SSL_ResourceFree wolfSSL_ResourceFree
 #endif
@@ -6748,18 +6737,15 @@ WOLFSSL_LOCAL word32 MacSize(const WOLFSSL* ssl);
 #ifdef WOLFSSL_DTLS
     WOLFSSL_LOCAL DtlsMsg* DtlsMsgNew(word32 sz, byte tx, void* heap);
     WOLFSSL_LOCAL void DtlsMsgDelete(DtlsMsg* item, void* heap);
-    /* Use WOLFSSL_API to enable src/api.c testing */
-    WOLFSSL_API void DtlsMsgListDelete(DtlsMsg* head, void* heap);
+    WOLFSSL_LOCAL void DtlsMsgListDelete(DtlsMsg* head, void* heap);
     WOLFSSL_LOCAL void DtlsTxMsgListClean(WOLFSSL* ssl);
     WOLFSSL_LOCAL int  DtlsMsgSet(DtlsMsg* msg, word32 seq, word16 epoch,
                                   const byte* data, byte type,
                                   word32 fragOffset, word32 fragSz, void* heap,
                                   word32 totalLen, byte encrypted);
-    /* Use WOLFSSL_API to enable src/api.c testing */
-    WOLFSSL_API DtlsMsg* DtlsMsgFind(DtlsMsg* head, word16 epoch, word32 seq);
+    WOLFSSL_LOCAL DtlsMsg* DtlsMsgFind(DtlsMsg* head, word16 epoch, word32 seq);
 
-    /* Use WOLFSSL_API to enable src/api.c testing */
-    WOLFSSL_API void DtlsMsgStore(WOLFSSL* ssl, word16 epoch, word32 seq,
+    WOLFSSL_LOCAL void DtlsMsgStore(WOLFSSL* ssl, word16 epoch, word32 seq,
                                     const byte* data, word32 dataSz, byte type,
                                     word32 fragOffset, word32 fragSz,
                                     void* heap);
@@ -6949,8 +6935,7 @@ WOLFSSL_LOCAL int BuildMessage(WOLFSSL* ssl, byte* output, int outSz,
                         int sizeOnly, int asyncOkay, int epochOrder);
 
 #ifdef WOLFSSL_TLS13
-/* Use WOLFSSL_API to use this function in tests/api.c */
-WOLFSSL_API int BuildTls13Message(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
+WOLFSSL_LOCAL int BuildTls13Message(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
                int inSz, int type, int hashOutput, int sizeOnly, int asyncOkay);
 WOLFSSL_LOCAL int Tls13UpdateKeys(WOLFSSL* ssl);
 #endif
@@ -7007,7 +6992,7 @@ WOLFSSL_LOCAL word32 nid2oid(int nid, int grp);
 #endif
 
 #ifdef WOLFSSL_DTLS
-WOLFSSL_API int wolfSSL_DtlsUpdateWindow(word16 cur_hi, word32 cur_lo,
+WOLFSSL_LOCAL int wolfSSL_DtlsUpdateWindow(word16 cur_hi, word32 cur_lo,
         word16* next_hi, word32* next_lo, word32 *window);
 WOLFSSL_LOCAL int DtlsUpdateWindow(WOLFSSL* ssl);
 WOLFSSL_LOCAL void DtlsResetState(WOLFSSL *ssl);
@@ -7017,8 +7002,7 @@ WOLFSSL_LOCAL void DtlsSetSeqNumForReply(WOLFSSL* ssl);
 
 #ifdef WOLFSSL_DTLS13
 
-/* Use WOLFSSL_API to use this function in tests/api.c */
-WOLFSSL_API struct Dtls13Epoch* Dtls13GetEpoch(WOLFSSL* ssl,
+WOLFSSL_LOCAL struct Dtls13Epoch* Dtls13GetEpoch(WOLFSSL* ssl,
     w64wrapper epochNumber);
 WOLFSSL_LOCAL void Dtls13SetOlderEpochSide(WOLFSSL* ssl, w64wrapper epochNumber,
     int side);
@@ -7108,9 +7092,8 @@ typedef struct CRYPTO_EX_cb_ctx {
     struct CRYPTO_EX_cb_ctx* next;
 } CRYPTO_EX_cb_ctx;
 
-/* use wolfSSL_API visibility to be able to clear in tests/api.c */
-WOLFSSL_API extern CRYPTO_EX_cb_ctx* crypto_ex_cb_ctx_session;
-WOLFSSL_API void crypto_ex_cb_free(CRYPTO_EX_cb_ctx* cb_ctx);
+WOLFSSL_LOCAL extern CRYPTO_EX_cb_ctx* crypto_ex_cb_ctx_session;
+WOLFSSL_LOCAL void crypto_ex_cb_free(CRYPTO_EX_cb_ctx* cb_ctx);
 WOLFSSL_LOCAL void crypto_ex_cb_setup_new_data(void *new_obj,
         CRYPTO_EX_cb_ctx* cb_ctx, WOLFSSL_CRYPTO_EX_DATA* ex_data);
 WOLFSSL_LOCAL void crypto_ex_cb_free_data(void *obj, CRYPTO_EX_cb_ctx* cb_ctx,

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -7038,6 +7038,7 @@ WOLFSSL_LOCAL int Dtls13HandshakeSend(WOLFSSL* ssl, byte* output,
     word16 output_size, word16 length, enum HandShakeType handshake_type,
     int hash_output);
 WOLFSSL_LOCAL int Dtls13RecordRecvd(WOLFSSL* ssl);
+WOLFSSL_LOCAL int Dtls13CheckEpoch(WOLFSSL* ssl, enum HandShakeType type);
 WOLFSSL_LOCAL int Dtls13HandshakeRecv(WOLFSSL* ssl, byte* input,
     word32* inOutIdx, word32 totalSz);
 WOLFSSL_LOCAL int Dtls13HandshakeAddHeader(WOLFSSL* ssl, byte* output,

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1446,6 +1446,7 @@ WOLFSSL_API unsigned int wolfSSL_SESSION_get_max_early_data(const WOLFSSL_SESSIO
 WOLFSSL_ABI WOLFSSL_API void wolfSSL_CTX_free(WOLFSSL_CTX* ctx);
 WOLFSSL_ABI WOLFSSL_API void wolfSSL_free(WOLFSSL* ssl);
 WOLFSSL_ABI WOLFSSL_API int  wolfSSL_shutdown(WOLFSSL* ssl);
+WOLFSSL_API void wolfSSL_ResourceFree(WOLFSSL* ssl);   /* Micrium uses */
 WOLFSSL_API int wolfSSL_SendUserCanceled(WOLFSSL* ssl);
 WOLFSSL_API int  wolfSSL_send(WOLFSSL* ssl, const void* data, int sz, int flags);
 WOLFSSL_API int  wolfSSL_recv(WOLFSSL* ssl, void* data, int sz, int flags);
@@ -5841,6 +5842,12 @@ WOLFSSL_API size_t wolfSSL_get_peer_finished(const WOLFSSL *ssl, void *buf, size
 #endif /* WOLFSSL_HAVE_TLS_UNIQUE */
 
 #ifdef HAVE_PK_CALLBACKS
+#ifdef WOLFSSL_PUBLIC_ASN
+/* Internal callback guarded by WOLFSSL_PUBLIC_ASN because of DecodedCert. */
+typedef int (*CallbackProcessPeerCert)(WOLFSSL* ssl, DecodedCert* p_cert);
+WOLFSSL_API void wolfSSL_CTX_SetProcessPeerCertCb(WOLFSSL_CTX* ctx,
+       CallbackProcessPeerCert cb);
+#endif /* WOLFSSL_PUBLIC_ASN */
 WOLFSSL_API int wolfSSL_IsPrivatePkSet(WOLFSSL* ssl);
 WOLFSSL_API int wolfSSL_CTX_IsPrivatePkSet(WOLFSSL_CTX* ctx);
 #endif


### PR DESCRIPTION
- internal.h: don't export internal functions in shared lib
  - Enable the static library when examples are enabled and link api.c and benchmark.c statically
