### PR TITLE
20250403-fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -516,6 +516,14 @@ AS_CASE([$ENABLED_FIPS],
         ENABLED_FIPS="yes"
         # for dev, DEF_SP_MATH and DEF_FAST_MATH follow non-FIPS defaults (currently sp-math-all)
     ],
+    [v5-kcapi],[
+        FIPS_VERSION="v5-dev"
+        HAVE_FIPS_VERSION_MAJOR=5
+        HAVE_FIPS_VERSION_MINOR=3
+        HAVE_FIPS_VERSION_PATCH=0
+        ENABLED_FIPS="yes"
+        # for dev, DEF_SP_MATH and DEF_FAST_MATH follow non-FIPS defaults (currently sp-math-all)
+    ],
     [v6],[
         FIPS_VERSION="v6"
         HAVE_FIPS_VERSION=6

--- a/tests/api.c
+++ b/tests/api.c
@@ -4933,11 +4933,13 @@ static int test_wolfSSL_FPKI(void)
         DYNAMIC_TYPE_TMP_BUFFER));
     ExpectIntEQ(wc_GetFASCNFromCert(&cert, fascn, &fascnSz), 0);
     XFREE(fascn, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    fascn = NULL;
 
     ExpectIntEQ(wc_GetUUIDFromCert(&cert, NULL, &uuidSz), WC_NO_ERR_TRACE(LENGTH_ONLY_E));
     ExpectNotNull(uuid = (byte*)XMALLOC(uuidSz, NULL, DYNAMIC_TYPE_TMP_BUFFER));
     ExpectIntEQ(wc_GetUUIDFromCert(&cert, uuid, &uuidSz), 0);
     XFREE(uuid, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    uuid = NULL;
     wc_FreeDecodedCert(&cert);
 
     XMEMSET(buf, 0, 4096);

--- a/wolfcrypt/src/port/arm/thumb2-aes-asm_c.c
+++ b/wolfcrypt/src/port/arm/thumb2-aes-asm_c.c
@@ -1908,7 +1908,7 @@ void AES_ECB_decrypt(const unsigned char* in, unsigned char* out,
     register word32* L_AES_Thumb2_td_ecb_c __asm__ ("r5") =
         (word32*)L_AES_Thumb2_td_ecb;
 
-    register byte L_AES_Thumb2_td4_c __asm__ ("r6") = (byte)&L_AES_Thumb2_td4;
+    register byte L_AES_Thumb2_td4_c __asm__ ("r6") = (byte)(word32)&L_AES_Thumb2_td4;
 
 #else
     register word32* L_AES_Thumb2_td_ecb_c = (word32*)L_AES_Thumb2_td_ecb;
@@ -2134,7 +2134,7 @@ void AES_CBC_decrypt(const unsigned char* in, unsigned char* out,
     register word32* L_AES_Thumb2_td_ecb_c __asm__ ("r6") =
         (word32*)L_AES_Thumb2_td_ecb;
 
-    register byte L_AES_Thumb2_td4_c __asm__ ("r7") = (byte)&L_AES_Thumb2_td4;
+    register byte L_AES_Thumb2_td4_c __asm__ ("r7") = (byte)(word32)&L_AES_Thumb2_td4;
 
 #else
     register word32* L_AES_Thumb2_td_ecb_c = (word32*)L_AES_Thumb2_td_ecb;


### PR DESCRIPTION
`tests/api.c`: fix double-`free()`s in `test_wolfSSL_FPKI()`.

`configure.ac`: add v5-kcapi to FIPS version map, same as v5-dev, but version 5.3.0 (as v5-dev was before 9d931d45de).

`wolfcrypt/src/wc_mlkem_poly.c`: move `mlkem_ntt_add_to()` implementation to resolve gating inconsistency (fixes armasm on arm32).

`wolfcrypt/src/port/arm/thumb2-aes-asm_c.c`: fix a pair of `-Wpointer-to-int-cast`s in `AES_ECB_decrypt()` and `AES_CBC_decrypt()`.

tested with
```
wolfssl-multi-test.sh ...
check-source-text
clang-tidy-all-sp-all
quantum-safe-wolfssl-all-clang-tidy
quantum-safe-wolfssl-all-cross-armv7a-armasm-unittest
quantum-safe-wolfssl-all-gcc-latest
quantum-safe-wolfssl-all-fortify-source-noasm
quantum-safe-wolfssl-cross-aarch64-armasm-unittest-sanitizer
quantum-safe-wolfssl-wolfsm-all-cross-aarch64-noasm-unittest
quantum-safe-wolfssl-all-cross-armv7a-noasm-unittest-Os-smallstack
cross-armv7m-armasm-thumb-fips-140-3-dev-sp-asm-all-crypto-only
fips-140-3-dev-kcapi
fips-140-3-v5-dev-all
```
