### PR TITLE
20250409-linuxkm-fortify_panic-6v8

### DIFF
--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -137,7 +137,13 @@
              * fortify_panic().
              */
             extern void __my_fortify_panic(const char *name) __noreturn __cold;
-            #define fortify_panic __my_fortify_panic
+            #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,8,0)
+                /* see linux 3d965b33e40d9 */
+                #define fortify_panic(func, write, avail, size, retfail) \
+                        __my_fortify_panic(#func)
+            #else
+                #define fortify_panic __my_fortify_panic
+            #endif
         #endif
 
         /* the _FORTIFY_SOURCE macros and implementations for several string


### PR DESCRIPTION
`linuxkm/linuxkm_wc_port.h`: on kernel >=6.8, for `CONFIG_FORTIFY_SOURCE`, use 5-arg `fortify_panic()` override macro.

tested with `wolfssl-multi-test.sh ... linuxkm-6.12-all-cryptonly-aesni-fips-dev-dyn-hash-LKCAPI-insmod-fallback-fuzzing check-source-text`
