### PR TITLE
20250410-linuxkm-fixes

### DIFF
--- a/linuxkm/Kbuild
+++ b/linuxkm/Kbuild
@@ -21,6 +21,14 @@
 .ONESHELL:
 SHELL=bash
 
+ifeq "$(KERNEL_ARCH)" "x86"
+    KERNEL_ARCH_X86 := yes
+else ifeq "$(KERNEL_ARCH)" "x86_64"
+    KERNEL_ARCH_X86 := yes
+else
+    KERNEL_ARCH_X86 := no
+endif
+
 ifeq "$(WOLFSSL_OBJ_FILES)" ""
     $(error $$WOLFSSL_OBJ_FILES is unset.)
 endif
@@ -31,9 +39,7 @@ endif
 
 WOLFSSL_CFLAGS += -ffreestanding -Wframe-larger-than=$(MAX_STACK_FRAME_SIZE) -isystem $(shell $(CC) -print-file-name=include)
 
-ifeq "$(KERNEL_ARCH)" "x86"
-    WOLFSSL_CFLAGS += -mpreferred-stack-boundary=4
-else ifeq "$(KERNEL_ARCH)" "aarch64"
+ifeq "$(KERNEL_ARCH)" "aarch64"
     WOLFSSL_CFLAGS += -mno-outline-atomics
 else ifeq "$(KERNEL_ARCH)" "arm64"
     WOLFSSL_CFLAGS += -mno-outline-atomics
@@ -65,7 +71,7 @@ HOST_EXTRACFLAGS += $(NOSTDINC_FLAGS) $(LINUXINCLUDE) $(KBUILD_CFLAGS) -static -
 
 # "-mindirect-branch=keep -mfunction-return=keep" to avoid "undefined reference
 #  to `__x86_return_thunk'" on CONFIG_RETHUNK kernels (5.19.0-rc7)
-ifeq "$(KERNEL_ARCH)" "x86"
+ifeq "$(KERNEL_ARCH_X86)" "yes"
   HOST_EXTRACFLAGS += -mindirect-branch=keep -mfunction-return=keep
 endif
 
@@ -97,7 +103,7 @@ $(obj)/wolfcrypt/src/aes.o: ccflags-y = $(WOLFSSL_CFLAGS) $(WOLFSSL_CFLAGS_YES_V
 ifeq "$(ENABLED_LINUXKM_PIE)" "yes"
     PIE_FLAGS := -fPIE -fno-stack-protector -fno-toplevel-reorder
     PIE_SUPPORT_FLAGS := -DUSE_WOLFSSL_LINUXKM_PIE_REDIRECT_TABLE
-    ifeq "$(KERNEL_ARCH)" "x86"
+    ifeq "$(KERNEL_ARCH_X86)" "yes"
         PIE_FLAGS += -mcmodel=small -mindirect-branch=keep -mfunction-return=keep
     endif
     ifeq "$(KERNEL_ARCH)" "mips"

--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -137,7 +137,7 @@
              * fortify_panic().
              */
             extern void __my_fortify_panic(const char *name) __noreturn __cold;
-            #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,8,0)
+            #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0)
                 /* see linux 3d965b33e40d9 */
                 #define fortify_panic(func, write, avail, size, retfail) \
                         __my_fortify_panic(#func)
@@ -882,7 +882,11 @@
      */
     #define key_update wc_key_update
 
-    #define lkm_printf(format, args...) printk(KERN_INFO "wolfssl: %s(): " format, __func__, ## args)
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)
+        #define lkm_printf(format, args...) _printk(KERN_INFO "wolfssl: %s(): " format, __func__, ## args)
+    #else
+        #define lkm_printf(format, args...) printk(KERN_INFO "wolfssl: %s(): " format, __func__, ## args)
+    #endif
     #define printf(...) lkm_printf(__VA_ARGS__)
 
     #ifdef HAVE_FIPS

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -646,8 +646,8 @@ extern const unsigned int wolfCrypt_FIPS_ro_end[];
 #define FIPS_IN_CORE_KEY_SZ 32
 #define FIPS_IN_CORE_VERIFY_SZ FIPS_IN_CORE_KEY_SZ
 typedef int (*fips_address_function)(void);
-#define MAX_FIPS_DATA_SZ  100000
-#define MAX_FIPS_CODE_SZ 1000000
+#define MAX_FIPS_DATA_SZ 10000000
+#define MAX_FIPS_CODE_SZ 10000000
 extern int GenBase16_Hash(const byte* in, int length, char* out, int outSz);
 
 static int updateFipsHash(void)


### PR DESCRIPTION
`linuxkm/Kbuild`: treat `KERNEL_ARCH` "x86_64" as "x86" and remove inapt `-mpreferred-stack-boundary=4` from x86 `WOLFSSL_CFLAGS`;

`linuxkm/linuxkm_wc_port.h`: use >=6.9.0 as the gate for 5-arg `fortify_panic()`;

in `lkm_printf()` definition, use `_printk` on >5.15.0;

`linuxkm/module_hooks.c`: raise `MAX_FIPS_DATA_SZ` and `MAX_FIPS_CODE_SZ` to accommodate growth.

tested with `wolfssl-multi-test.sh ... check-source-text quantum-safe-wolfssl-all-crypto-only-noasm-linuxkm-insmod quantum-safe-wolfssl-all-crypto-only-intelasm-sp-asm-linuxkm-insmod linuxkm-all-aesni-insmod linuxkm-commercial-pie-insmod linuxkm-noasm-ksanitize-insmod linuxkm-legacy-5.10-insmod linuxkm-legacy-5.15-insmod`
