### PR TITLE
Improve ML-DSA private key import and the test

### DIFF
--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -1020,8 +1020,7 @@ static int ProcessBufferTryDecodeDilithium(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
         }
         else if (*keyFormat == 0) {
             WOLFSSL_MSG("Not a Dilithium key");
-            /* Unknowun format was not dilithium, so keep trying other formats. */
-            ret = 0;
+            /* Unknown format was not dilithium, so keep trying other formats. */
         }
         
         /* Free dynamically allocated data in key. */

--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -946,7 +946,7 @@ static int ProcessBufferTryDecodeDilithium(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
     int ret;
     word32 idx;
     dilithium_key* key;
-    int keyFormatTemp = 0; 
+    int keyFormatTemp = 0;
     int keyTypeTemp;
     int keySizeTemp;
 
@@ -958,7 +958,7 @@ static int ProcessBufferTryDecodeDilithium(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
     }
 
     /* Initialize Dilithium key. */
-    ret = wc_dilithium_init(key); 
+    ret = wc_dilithium_init(key);
     if (ret == 0) {
         /* Decode as a Dilithium private key. */
         idx = 0;
@@ -1023,7 +1023,7 @@ static int ProcessBufferTryDecodeDilithium(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
             /* Unknown format wasn't dilithium, so keep trying other formats. */
             ret = 0;
         }
-        
+
         /* Free dynamically allocated data in key. */
         wc_dilithium_free(key);
     }

--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -1021,6 +1021,7 @@ static int ProcessBufferTryDecodeDilithium(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
         else if (*keyFormat == 0) {
             WOLFSSL_MSG("Not a Dilithium key");
             /* Unknown format wasn't dilithium, so keep trying other formats. */
+            ret = 0;
         }
         
         /* Free dynamically allocated data in key. */

--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -965,7 +965,7 @@ static int ProcessBufferTryDecodeDilithium(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
         ret = wc_Dilithium_PrivateKeyDecode(der->buffer, &idx, key, der->length);
         if (ret == 0) {
             ret = dilithium_get_oid_sum(key, &keyFormatTemp);
-            if(ret == 0) {
+            if (ret == 0) {
                 /* Format is known. */
                 #if defined(WOLFSSL_DILITHIUM_FIPS204_DRAFT)
                 if (keyFormatTemp == DILITHIUM_LEVEL2k) {
@@ -999,7 +999,7 @@ static int ProcessBufferTryDecodeDilithium(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
                 }
             }
 
-            if(ret == 0) {
+            if (ret == 0) {
                 /* Get the minimum Dilithium key size from SSL or SSL context
                  * object. */
                 int minKeySz = ssl ? ssl->options.minDilithiumKeySz :
@@ -1012,7 +1012,7 @@ static int ProcessBufferTryDecodeDilithium(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
                 }
             }
 
-            if(ret == 0) {
+            if (ret == 0) {
                 *keyFormat = keyFormatTemp;
                 *keyType = keyTypeTemp;
                 *keySize = keySizeTemp;

--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -1020,7 +1020,7 @@ static int ProcessBufferTryDecodeDilithium(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
         }
         else if (*keyFormat == 0) {
             WOLFSSL_MSG("Not a Dilithium key");
-            /* Unknown format was not dilithium, so keep trying other formats. */
+            /* Unknown format wasn't dilithium, so keep trying other formats. */
         }
         
         /* Free dynamically allocated data in key. */

--- a/tests/api.c
+++ b/tests/api.c
@@ -13944,7 +13944,7 @@ static int test_wolfSSL_PKCS8_MLDSA(void)
     size_t i;
     const int derMaxSz = 8192;    /* Largest size will be 7520 of separated format, WC_ML_DSA_87, DER */
     const int tempMaxSz = 10240;  /* Largest size will be 10239 of separated format, WC_MLS_DSA_87, PEM */
-    byte* der = NULL;  
+    byte* der = NULL;
     byte* temp = NULL;  /* Store PEM or intermediate key */
     word32 derSz = 0;
     word32 pemSz = 0;
@@ -13964,7 +13964,7 @@ static int test_wolfSSL_PKCS8_MLDSA(void)
     (void) pemSz;
 
     ExpectNotNull(der = (byte*) XMALLOC(derMaxSz, NULL, DYNAMIC_TYPE_TMP_BUFFER));
-    ExpectNotNull(temp = (byte*) XMALLOC(tempMaxSz, NULL, DYNAMIC_TYPE_TMP_BUFFER)); 
+    ExpectNotNull(temp = (byte*) XMALLOC(tempMaxSz, NULL, DYNAMIC_TYPE_TMP_BUFFER));
 
 #ifndef NO_WOLFSSL_SERVER
     ExpectNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_server_method()));
@@ -13980,7 +13980,7 @@ static int test_wolfSSL_PKCS8_MLDSA(void)
         ExpectIntEQ(wc_dilithium_set_level(&mldsa_key, test_variant[i].wcId), 0);
         ExpectIntEQ(wc_dilithium_make_key(&mldsa_key, &rng), 0);
 
-        ExpectIntGT(derSz = wc_Dilithium_KeyToDer(&mldsa_key, der, derMaxSz), 0); 
+        ExpectIntGT(derSz = wc_Dilithium_KeyToDer(&mldsa_key, der, derMaxSz), 0);
         ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_buffer(ctx, der, derSz,
             WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
 
@@ -13996,7 +13996,7 @@ static int test_wolfSSL_PKCS8_MLDSA(void)
         ExpectIntEQ(wc_dilithium_set_level(&mldsa_key, test_variant[i].wcId), 0);
         ExpectIntEQ(wc_dilithium_make_key(&mldsa_key, &rng), 0);
 
-        ExpectIntGT(derSz = wc_Dilithium_PrivateKeyToDer(&mldsa_key, der, derMaxSz), 0); 
+        ExpectIntGT(derSz = wc_Dilithium_PrivateKeyToDer(&mldsa_key, der, derMaxSz), 0);
         ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_buffer(ctx, der, derSz,
             WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
 
@@ -14006,7 +14006,7 @@ static int test_wolfSSL_PKCS8_MLDSA(void)
             WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
 #endif /* WOLFSSL_DER_TO_PEM */
     }
-    
+
     /* Test private + public key (integrated format) */
     for(i = 0; i < sizeof(test_variant) / sizeof(test_variant[0]); ++i) {
         ExpectIntEQ(wc_dilithium_set_level(&mldsa_key, test_variant[i].wcId), 0);

--- a/tests/api.c
+++ b/tests/api.c
@@ -13933,6 +13933,119 @@ static int test_wolfSSL_PKCS8_ED448(void)
     return EXPECT_RESULT();
 }
 
+static int test_wolfSSL_PKCS8_MLDSA(void)
+{
+    EXPECT_DECLS;
+#if !defined(NO_ASN) && defined(HAVE_PKCS8) && \
+    defined(HAVE_DILITHIUM) && !defined(NO_TLS) && \
+    (!defined(NO_WOLFSSL_CLIENT) || !defined(NO_WOLFSSL_SERVER))
+
+    WOLFSSL_CTX* ctx = NULL;
+    size_t i;
+    const int derMaxSz = 8192;    /* Largest size will be 7520 of separated format, WC_ML_DSA_87, DER */
+    const int tempMaxSz = 10240;  /* Largest size will be 10239 of separated format, WC_MLS_DSA_87, PEM */
+    byte* der = NULL;  
+    byte* temp = NULL;  /* Store PEM or intermediate key */
+    word32 derSz = 0;
+    word32 pemSz = 0;
+    word32 keySz = 0;
+    dilithium_key mldsa_key;
+    WC_RNG rng;
+    word32 size;
+
+    struct {
+        int wcId;
+        int oidSum;
+        int keySz;
+    } test_variant[] = {{WC_ML_DSA_44, ML_DSA_LEVEL2k, ML_DSA_LEVEL2_PRV_KEY_SIZE},
+                        {WC_ML_DSA_65, ML_DSA_LEVEL3k, ML_DSA_LEVEL3_PRV_KEY_SIZE},
+                        {WC_ML_DSA_87, ML_DSA_LEVEL5k, ML_DSA_LEVEL5_PRV_KEY_SIZE}};
+
+    (void) pemSz;
+
+    ExpectNotNull(der = (byte*) XMALLOC(derMaxSz, NULL, DYNAMIC_TYPE_TMP_BUFFER));
+    ExpectNotNull(temp = (byte*) XMALLOC(tempMaxSz, NULL, DYNAMIC_TYPE_TMP_BUFFER)); 
+
+#ifndef NO_WOLFSSL_SERVER
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_server_method()));
+#else
+    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()));
+#endif /* NO_WOLFSSL_SERVER */
+
+    ExpectIntEQ(wc_InitRng(&rng), 0);
+    ExpectIntEQ(wc_dilithium_init(&mldsa_key), 0);
+
+    /* Test private + public key (separated format) */
+    for(i = 0; i < sizeof(test_variant) / sizeof(test_variant[0]); ++i) {
+        ExpectIntEQ(wc_dilithium_set_level(&mldsa_key, test_variant[i].wcId), 0);
+        ExpectIntEQ(wc_dilithium_make_key(&mldsa_key, &rng), 0);
+
+        ExpectIntGT(derSz = wc_Dilithium_KeyToDer(&mldsa_key, der, derMaxSz), 0); 
+        ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_buffer(ctx, der, derSz,
+            WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
+
+#ifdef WOLFSSL_DER_TO_PEM
+        ExpectIntGT(pemSz = wc_DerToPem(der, derSz, temp, tempMaxSz, PKCS8_PRIVATEKEY_TYPE), 0);
+        ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_buffer(ctx, temp, pemSz,
+            WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+#endif /* WOLFSSL_DER_TO_PEM */
+    }
+
+    /* Test private key only */
+    for(i = 0; i < sizeof(test_variant) / sizeof(test_variant[0]); ++i) {
+        ExpectIntEQ(wc_dilithium_set_level(&mldsa_key, test_variant[i].wcId), 0);
+        ExpectIntEQ(wc_dilithium_make_key(&mldsa_key, &rng), 0);
+
+        ExpectIntGT(derSz = wc_Dilithium_PrivateKeyToDer(&mldsa_key, der, derMaxSz), 0); 
+        ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_buffer(ctx, der, derSz,
+            WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
+
+#ifdef WOLFSSL_DER_TO_PEM
+        ExpectIntGT(pemSz = wc_DerToPem(der, derSz, temp, tempMaxSz, PKCS8_PRIVATEKEY_TYPE), 0);
+        ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_buffer(ctx, temp, pemSz,
+            WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+#endif /* WOLFSSL_DER_TO_PEM */
+    }
+    
+    /* Test private + public key (integrated format) */
+    for(i = 0; i < sizeof(test_variant) / sizeof(test_variant[0]); ++i) {
+        ExpectIntEQ(wc_dilithium_set_level(&mldsa_key, test_variant[i].wcId), 0);
+        ExpectIntEQ(wc_dilithium_make_key(&mldsa_key, &rng), 0);
+
+        keySz = 0;
+        temp[0] = 0x04;                                 /* ASN.1 OCTET STRING */
+        temp[1] = 0x82;                                 /* 2 bytes length field */
+        temp[2] = (test_variant[i].keySz >> 8) & 0xff;  /* MSB of the length */
+        temp[3] = test_variant[i].keySz & 0xff;         /* LSB of the length */
+        keySz += 4;
+        size = tempMaxSz - keySz;
+        ExpectIntEQ(wc_dilithium_export_private(&mldsa_key, temp + keySz, &size), 0);
+        keySz += size;
+        size = tempMaxSz - keySz;
+        ExpectIntEQ(wc_dilithium_export_public(&mldsa_key, temp + keySz, &size), 0);
+        keySz += size;
+        derSz = derMaxSz;
+        ExpectIntGT(wc_CreatePKCS8Key(der, &derSz, temp, keySz, test_variant[i].oidSum, NULL, 0), 0);
+        ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_buffer(ctx, der, derSz,
+            WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
+
+#ifdef WOLFSSL_DER_TO_PEM
+        ExpectIntGT(pemSz = wc_DerToPem(der, derSz, temp, tempMaxSz, PKCS8_PRIVATEKEY_TYPE), 0);
+        ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_buffer(ctx, temp, pemSz,
+            WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
+#endif /* WOLFSSL_DER_TO_PEM */
+    }
+
+    wc_dilithium_free(&mldsa_key);
+    ExpectIntEQ(wc_FreeRng(&rng), 0);
+    wolfSSL_CTX_free(ctx);
+    XFREE(temp, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+
+#endif
+    return EXPECT_RESULT();
+}
+
 /* Testing functions dealing with PKCS5 */
 static int test_wolfSSL_PKCS5(void)
 {
@@ -67519,6 +67632,7 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_PKCS8),
     TEST_DECL(test_wolfSSL_PKCS8_ED25519),
     TEST_DECL(test_wolfSSL_PKCS8_ED448),
+    TEST_DECL(test_wolfSSL_PKCS8_MLDSA),
 
 #ifdef HAVE_IO_TESTS_DEPENDENCIES
     TEST_DECL(test_wolfSSL_get_finished),

--- a/tests/api.c
+++ b/tests/api.c
@@ -13933,119 +13933,6 @@ static int test_wolfSSL_PKCS8_ED448(void)
     return EXPECT_RESULT();
 }
 
-static int test_wolfSSL_PKCS8_MLDSA(void)
-{
-    EXPECT_DECLS;
-#if !defined(NO_ASN) && defined(HAVE_PKCS8) && \
-    defined(HAVE_DILITHIUM) && !defined(NO_TLS) && \
-    (!defined(NO_WOLFSSL_CLIENT) || !defined(NO_WOLFSSL_SERVER))
-
-    WOLFSSL_CTX* ctx = NULL;
-    size_t i;
-    const int derMaxSz = 8192;    /* Largest size will be 7520 of separated format, WC_ML_DSA_87, DER */
-    const int tempMaxSz = 10240;  /* Largest size will be 10239 of separated format, WC_MLS_DSA_87, PEM */
-    byte* der = NULL;
-    byte* temp = NULL;  /* Store PEM or intermediate key */
-    word32 derSz = 0;
-    word32 pemSz = 0;
-    word32 keySz = 0;
-    dilithium_key mldsa_key;
-    WC_RNG rng;
-    word32 size;
-
-    struct {
-        int wcId;
-        int oidSum;
-        int keySz;
-    } test_variant[] = {{WC_ML_DSA_44, ML_DSA_LEVEL2k, ML_DSA_LEVEL2_PRV_KEY_SIZE},
-                        {WC_ML_DSA_65, ML_DSA_LEVEL3k, ML_DSA_LEVEL3_PRV_KEY_SIZE},
-                        {WC_ML_DSA_87, ML_DSA_LEVEL5k, ML_DSA_LEVEL5_PRV_KEY_SIZE}};
-
-    (void) pemSz;
-
-    ExpectNotNull(der = (byte*) XMALLOC(derMaxSz, NULL, DYNAMIC_TYPE_TMP_BUFFER));
-    ExpectNotNull(temp = (byte*) XMALLOC(tempMaxSz, NULL, DYNAMIC_TYPE_TMP_BUFFER));
-
-#ifndef NO_WOLFSSL_SERVER
-    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_server_method()));
-#else
-    ExpectNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()));
-#endif /* NO_WOLFSSL_SERVER */
-
-    ExpectIntEQ(wc_InitRng(&rng), 0);
-    ExpectIntEQ(wc_dilithium_init(&mldsa_key), 0);
-
-    /* Test private + public key (separated format) */
-    for(i = 0; i < sizeof(test_variant) / sizeof(test_variant[0]); ++i) {
-        ExpectIntEQ(wc_dilithium_set_level(&mldsa_key, test_variant[i].wcId), 0);
-        ExpectIntEQ(wc_dilithium_make_key(&mldsa_key, &rng), 0);
-
-        ExpectIntGT(derSz = wc_Dilithium_KeyToDer(&mldsa_key, der, derMaxSz), 0);
-        ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_buffer(ctx, der, derSz,
-            WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
-
-#ifdef WOLFSSL_DER_TO_PEM
-        ExpectIntGT(pemSz = wc_DerToPem(der, derSz, temp, tempMaxSz, PKCS8_PRIVATEKEY_TYPE), 0);
-        ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_buffer(ctx, temp, pemSz,
-            WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
-#endif /* WOLFSSL_DER_TO_PEM */
-    }
-
-    /* Test private key only */
-    for(i = 0; i < sizeof(test_variant) / sizeof(test_variant[0]); ++i) {
-        ExpectIntEQ(wc_dilithium_set_level(&mldsa_key, test_variant[i].wcId), 0);
-        ExpectIntEQ(wc_dilithium_make_key(&mldsa_key, &rng), 0);
-
-        ExpectIntGT(derSz = wc_Dilithium_PrivateKeyToDer(&mldsa_key, der, derMaxSz), 0);
-        ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_buffer(ctx, der, derSz,
-            WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
-
-#ifdef WOLFSSL_DER_TO_PEM
-        ExpectIntGT(pemSz = wc_DerToPem(der, derSz, temp, tempMaxSz, PKCS8_PRIVATEKEY_TYPE), 0);
-        ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_buffer(ctx, temp, pemSz,
-            WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
-#endif /* WOLFSSL_DER_TO_PEM */
-    }
-
-    /* Test private + public key (integrated format) */
-    for(i = 0; i < sizeof(test_variant) / sizeof(test_variant[0]); ++i) {
-        ExpectIntEQ(wc_dilithium_set_level(&mldsa_key, test_variant[i].wcId), 0);
-        ExpectIntEQ(wc_dilithium_make_key(&mldsa_key, &rng), 0);
-
-        keySz = 0;
-        temp[0] = 0x04;                                 /* ASN.1 OCTET STRING */
-        temp[1] = 0x82;                                 /* 2 bytes length field */
-        temp[2] = (test_variant[i].keySz >> 8) & 0xff;  /* MSB of the length */
-        temp[3] = test_variant[i].keySz & 0xff;         /* LSB of the length */
-        keySz += 4;
-        size = tempMaxSz - keySz;
-        ExpectIntEQ(wc_dilithium_export_private(&mldsa_key, temp + keySz, &size), 0);
-        keySz += size;
-        size = tempMaxSz - keySz;
-        ExpectIntEQ(wc_dilithium_export_public(&mldsa_key, temp + keySz, &size), 0);
-        keySz += size;
-        derSz = derMaxSz;
-        ExpectIntGT(wc_CreatePKCS8Key(der, &derSz, temp, keySz, test_variant[i].oidSum, NULL, 0), 0);
-        ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_buffer(ctx, der, derSz,
-            WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
-
-#ifdef WOLFSSL_DER_TO_PEM
-        ExpectIntGT(pemSz = wc_DerToPem(der, derSz, temp, tempMaxSz, PKCS8_PRIVATEKEY_TYPE), 0);
-        ExpectIntEQ(wolfSSL_CTX_use_PrivateKey_buffer(ctx, temp, pemSz,
-            WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
-#endif /* WOLFSSL_DER_TO_PEM */
-    }
-
-    wc_dilithium_free(&mldsa_key);
-    ExpectIntEQ(wc_FreeRng(&rng), 0);
-    wolfSSL_CTX_free(ctx);
-    XFREE(temp, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-
-#endif
-    return EXPECT_RESULT();
-}
-
 /* Testing functions dealing with PKCS5 */
 static int test_wolfSSL_PKCS5(void)
 {
@@ -67632,7 +67519,6 @@ TEST_CASE testCases[] = {
     TEST_DECL(test_wolfSSL_PKCS8),
     TEST_DECL(test_wolfSSL_PKCS8_ED25519),
     TEST_DECL(test_wolfSSL_PKCS8_ED448),
-    TEST_DECL(test_wolfSSL_PKCS8_MLDSA),
 
 #ifdef HAVE_IO_TESTS_DEPENDENCIES
     TEST_DECL(test_wolfSSL_get_finished),

--- a/tests/api/test_mldsa.c
+++ b/tests/api/test_mldsa.c
@@ -2959,7 +2959,7 @@ int test_wc_dilithium_der(void)
     idx = 0;
 #ifdef WOLFSSL_DILITHIUM_FIPS204_DRAFT
     ExpectIntEQ(wc_Dilithium_PrivateKeyDecode(der, &idx, key, privDerLen),
-                WC_NO_ERR_TRACE(BAD_FUNC_ARG));
+                WC_NO_ERR_TRACE(ASN_PARSE_E));
 #else
     ExpectIntEQ(wc_Dilithium_PrivateKeyDecode(der, &idx, key, privDerLen),
                 WC_NO_ERR_TRACE(ASN_PARSE_E));

--- a/tests/api/test_mldsa.c
+++ b/tests/api/test_mldsa.c
@@ -16705,7 +16705,7 @@ int test_mldsa_pkcs8(void)
     ExpectIntEQ(wc_dilithium_init(&mldsa_key), 0);
 
     /* Test private + public key (separated format) */
-    for(i = 0; i < sizeof(test_variant) / sizeof(test_variant[0]); ++i) {
+    for (i = 0; i < sizeof(test_variant) / sizeof(test_variant[0]); ++i) {
         ExpectIntEQ(wc_dilithium_set_level(&mldsa_key,
             test_variant[i].wcId), 0);
         ExpectIntEQ(wc_dilithium_make_key(&mldsa_key, &rng), 0);
@@ -16724,7 +16724,7 @@ int test_mldsa_pkcs8(void)
     }
 
     /* Test private key only */
-    for(i = 0; i < sizeof(test_variant) / sizeof(test_variant[0]); ++i) {
+    for (i = 0; i < sizeof(test_variant) / sizeof(test_variant[0]); ++i) {
         ExpectIntEQ(wc_dilithium_set_level(&mldsa_key, test_variant[i].wcId),
             0);
         ExpectIntEQ(wc_dilithium_make_key(&mldsa_key, &rng), 0);
@@ -16743,7 +16743,7 @@ int test_mldsa_pkcs8(void)
     }
 
     /* Test private + public key (integrated format) */
-    for(i = 0; i < sizeof(test_variant) / sizeof(test_variant[0]); ++i) {
+    for (i = 0; i < sizeof(test_variant) / sizeof(test_variant[0]); ++i) {
         ExpectIntEQ(wc_dilithium_set_level(&mldsa_key, test_variant[i].wcId),
             0);
         ExpectIntEQ(wc_dilithium_make_key(&mldsa_key, &rng), 0);

--- a/tests/api/test_mldsa.h
+++ b/tests/api/test_mldsa.h
@@ -35,6 +35,7 @@ int test_wc_dilithium_der(void);
 int test_wc_dilithium_make_key_from_seed(void);
 int test_wc_dilithium_sig_kats(void);
 int test_wc_dilithium_verify_kats(void);
+int test_mldsa_pkcs8(void);
 
 #define TEST_MLDSA_DECLS                                            \
     TEST_DECL_GROUP("mldsa", test_wc_dilithium),                    \
@@ -47,6 +48,7 @@ int test_wc_dilithium_verify_kats(void);
     TEST_DECL_GROUP("mldsa", test_wc_dilithium_der),                \
     TEST_DECL_GROUP("mldsa", test_wc_dilithium_make_key_from_seed), \
     TEST_DECL_GROUP("mldsa", test_wc_dilithium_sig_kats),           \
-    TEST_DECL_GROUP("mldsa", test_wc_dilithium_verify_kats)
+    TEST_DECL_GROUP("mldsa", test_wc_dilithium_verify_kats),        \
+    TEST_DECL_GROUP("mldsa", test_mldsa_pkcs8)
 
 #endif /* WOLFCRYPT_TEST_MLDSA_H */

--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -9664,7 +9664,7 @@ int wc_Dilithium_PrivateKeyDecode(const byte* input, word32* inOutIdx,
 
     if (ret == 0) {
         /* Get OID sum for level. */
-        if(key->level == 0) { /* Check first, because key->params will be NULL
+        if (key->level == 0) { /* Check first, because key->params will be NULL
                                * when key->level = 0 */
             /* Level not set by caller, decode from DER */
             keytype = ANONk;

--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -9664,7 +9664,8 @@ int wc_Dilithium_PrivateKeyDecode(const byte* input, word32* inOutIdx,
 
     if (ret == 0) {
         /* Get OID sum for level. */ 
-        if(key->level == 0) { /* Check first, because key->params will be NULL when key->level = 0 */
+        if(key->level == 0) { /* Check first, because key->params will be NULL
+                               * when key->level = 0 */
             /* Level not set by caller, decode from DER */
             keytype = ANONk;
         }

--- a/wolfcrypt/src/dilithium.c
+++ b/wolfcrypt/src/dilithium.c
@@ -9663,7 +9663,7 @@ int wc_Dilithium_PrivateKeyDecode(const byte* input, word32* inOutIdx,
     }
 
     if (ret == 0) {
-        /* Get OID sum for level. */ 
+        /* Get OID sum for level. */
         if(key->level == 0) { /* Check first, because key->params will be NULL
                                * when key->level = 0 */
             /* Level not set by caller, decode from DER */

--- a/wolfssl/wolfcrypt/dilithium.h
+++ b/wolfssl/wolfcrypt/dilithium.h
@@ -117,6 +117,10 @@
 /* Buffer sizes large enough to store exported DER encoded keys */
 #define DILITHIUM_LEVEL2_PUB_KEY_DER_SIZE 1334
 #define DILITHIUM_LEVEL2_PRV_KEY_DER_SIZE 2588
+#define DILITHIUM_LEVEL2_BOTH_KEY_DER_SIZE 3904
+/* PEM size with the header "-----BEGIN PRIVATE KEY-----" and
+ * the footer "-----END PRIVATE KEY-----" */
+#define DILITHIUM_LEVEL2_BOTH_KEY_PEM_SIZE 5344
 
 #define DILITHIUM_LEVEL3_KEY_SIZE       4032
 #define DILITHIUM_LEVEL3_SIG_SIZE       3309
@@ -126,7 +130,10 @@
 /* Buffer sizes large enough to store exported DER encoded keys */
 #define DILITHIUM_LEVEL3_PUB_KEY_DER_SIZE 1974
 #define DILITHIUM_LEVEL3_PRV_KEY_DER_SIZE 4060
-
+#define DILITHIUM_LEVEL3_BOTH_KEY_DER_SIZE 6016
+/* PEM size with the header "-----BEGIN PRIVATE KEY-----" and
+ * the footer "-----END PRIVATE KEY-----" */
+#define DILITHIUM_LEVEL3_BOTH_KEY_PEM_SIZE 8204
 
 #define DILITHIUM_LEVEL5_KEY_SIZE       4896
 #define DILITHIUM_LEVEL5_SIG_SIZE       4627
@@ -136,6 +143,10 @@
 /* Buffer sizes large enough to store exported DER encoded keys */
 #define DILITHIUM_LEVEL5_PUB_KEY_DER_SIZE 2614
 #define DILITHIUM_LEVEL5_PRV_KEY_DER_SIZE 4924
+#define DILITHIUM_LEVEL5_BOTH_KEY_DER_SIZE 7520
+/* PEM size with the header "-----BEGIN PRIVATE KEY-----" and
+ * the footer "-----END PRIVATE KEY-----" */
+#define DILITHIUM_LEVEL5_BOTH_KEY_PEM_SIZE 10239
 
 #define ML_DSA_LEVEL2_KEY_SIZE          2560
 #define ML_DSA_LEVEL2_SIG_SIZE          2420
@@ -145,6 +156,10 @@
 /* Buffer sizes large enough to store exported DER encoded keys */
 #define ML_DSA_LEVEL2_PUB_KEY_DER_SIZE DILITHIUM_LEVEL2_PUB_KEY_DER_SIZE
 #define ML_DSA_LEVEL2_PRV_KEY_DER_SIZE DILITHIUM_LEVEL2_PRV_KEY_DER_SIZE
+#define ML_DSA_LEVEL2_BOTH_KEY_DER_SIZE DILITHIUM_LEVEL2_BOTH_KEY_DER_SIZE
+/* PEM size with the header "-----BEGIN PRIVATE KEY-----" and
+ * the footer "-----END PRIVATE KEY-----" */
+#define ML_DSA_LEVEL2_BOTH_KEY_PEM_SIZE DILITHIUM_LEVEL2_BOTH_KEY_PEM_SIZE
 
 #define ML_DSA_LEVEL3_KEY_SIZE          4032
 #define ML_DSA_LEVEL3_SIG_SIZE          3309
@@ -154,6 +169,10 @@
 /* Buffer sizes large enough to store exported DER encoded keys */
 #define ML_DSA_LEVEL3_PUB_KEY_DER_SIZE DILITHIUM_LEVEL3_PUB_KEY_DER_SIZE
 #define ML_DSA_LEVEL3_PRV_KEY_DER_SIZE DILITHIUM_LEVEL3_PRV_KEY_DER_SIZE
+#define ML_DSA_LEVEL3_BOTH_KEY_DER_SIZE DILITHIUM_LEVEL3_BOTH_KEY_DER_SIZE
+/* PEM size with the header "-----BEGIN PRIVATE KEY-----" and
+ * the footer "-----END PRIVATE KEY-----" */
+#define ML_DSA_LEVEL3_BOTH_KEY_PEM_SIZE DILITHIUM_LEVEL3_BOTH_KEY_PEM_SIZE
 
 #define ML_DSA_LEVEL5_KEY_SIZE          4896
 #define ML_DSA_LEVEL5_SIG_SIZE          4627
@@ -163,6 +182,10 @@
 /* Buffer sizes large enough to store exported DER encoded keys */
 #define ML_DSA_LEVEL5_PUB_KEY_DER_SIZE DILITHIUM_LEVEL5_PUB_KEY_DER_SIZE
 #define ML_DSA_LEVEL5_PRV_KEY_DER_SIZE DILITHIUM_LEVEL5_PRV_KEY_DER_SIZE
+#define ML_DSA_LEVEL5_BOTH_KEY_DER_SIZE DILITHIUM_LEVEL5_BOTH_KEY_DER_SIZE
+/* PEM size with the header "-----BEGIN PRIVATE KEY-----" and
+ * the footer "-----END PRIVATE KEY-----" */
+#define ML_DSA_LEVEL5_BOTH_KEY_PEM_SIZE DILITHIUM_LEVEL5_BOTH_KEY_PEM_SIZE
 
 
 
@@ -524,6 +547,10 @@
 /* Buffer sizes large enough to store exported DER encoded keys */
 #define DILITHIUM_LEVEL2_PUB_KEY_DER_SIZE 1334
 #define DILITHIUM_LEVEL2_PRV_KEY_DER_SIZE 2588
+#define DILITHIUM_LEVEL2_BOTH_KEY_DER_SIZE 3904
+/* PEM size with the header "-----BEGIN PRIVATE KEY-----" and
+ * the footer "-----END PRIVATE KEY-----" */
+#define DILITHIUM_LEVEL2_BOTH_KEY_PEM_SIZE 5344
 
 #define DILITHIUM_LEVEL3_KEY_SIZE     OQS_SIG_ml_dsa_65_ipd_length_secret_key
 #define DILITHIUM_LEVEL3_SIG_SIZE     OQS_SIG_ml_dsa_65_ipd_length_signature
@@ -533,6 +560,10 @@
 /* Buffer sizes large enough to store exported DER encoded keys */
 #define DILITHIUM_LEVEL3_PUB_KEY_DER_SIZE 1974
 #define DILITHIUM_LEVEL3_PRV_KEY_DER_SIZE 4060
+#define DILITHIUM_LEVEL3_BOTH_KEY_DER_SIZE 6016
+/* PEM size with the header "-----BEGIN PRIVATE KEY-----" and
+ * the footer "-----END PRIVATE KEY-----" */
+#define DILITHIUM_LEVEL3_BOTH_KEY_PEM_SIZE 8204
 
 #define DILITHIUM_LEVEL5_KEY_SIZE     OQS_SIG_ml_dsa_87_ipd_length_secret_key
 #define DILITHIUM_LEVEL5_SIG_SIZE     OQS_SIG_ml_dsa_87_ipd_length_signature
@@ -542,7 +573,10 @@
 /* Buffer sizes large enough to store exported DER encoded keys */
 #define DILITHIUM_LEVEL5_PUB_KEY_DER_SIZE 2614
 #define DILITHIUM_LEVEL5_PRV_KEY_DER_SIZE 4924
-
+#define DILITHIUM_LEVEL5_BOTH_KEY_DER_SIZE 7520
+/* PEM size with the header "-----BEGIN PRIVATE KEY-----" and
+ * the footer "-----END PRIVATE KEY-----" */
+#define DILITHIUM_LEVEL5_BOTH_KEY_PEM_SIZE 10239
 
 #define ML_DSA_LEVEL2_KEY_SIZE        OQS_SIG_ml_dsa_44_ipd_length_secret_key
 #define ML_DSA_LEVEL2_SIG_SIZE        OQS_SIG_ml_dsa_44_ipd_length_signature
@@ -552,6 +586,10 @@
 /* Buffer sizes large enough to store exported DER encoded keys */
 #define ML_DSA_LEVEL2_PUB_KEY_DER_SIZE DILITHIUM_LEVEL2_PUB_KEY_DER_SIZE
 #define ML_DSA_LEVEL2_PRV_KEY_DER_SIZE DILITHIUM_LEVEL2_PRV_KEY_DER_SIZE
+#define ML_DSA_LEVEL2_BOTH_KEY_DER_SIZE DILITHIUM_LEVEL2_BOTH_KEY_DER_SIZE
+/* PEM size with the header "-----BEGIN PRIVATE KEY-----" and
+ * the footer "-----END PRIVATE KEY-----" */
+#define ML_DSA_LEVEL2_BOTH_KEY_PEM_SIZE DILITHIUM_LEVEL2_BOTH_KEY_PEM_SIZE
 
 #define ML_DSA_LEVEL3_KEY_SIZE        OQS_SIG_ml_dsa_65_ipd_length_secret_key
 #define ML_DSA_LEVEL3_SIG_SIZE        OQS_SIG_ml_dsa_65_ipd_length_signature
@@ -561,6 +599,10 @@
 /* Buffer sizes large enough to store exported DER encoded keys */
 #define ML_DSA_LEVEL3_PUB_KEY_DER_SIZE DILITHIUM_LEVEL3_PUB_KEY_DER_SIZE
 #define ML_DSA_LEVEL3_PRV_KEY_DER_SIZE DILITHIUM_LEVEL3_PRV_KEY_DER_SIZE
+#define ML_DSA_LEVEL3_BOTH_KEY_DER_SIZE DILITHIUM_LEVEL3_BOTH_KEY_DER_SIZE
+/* PEM size with the header "-----BEGIN PRIVATE KEY-----" and
+ * the footer "-----END PRIVATE KEY-----" */
+#define ML_DSA_LEVEL3_BOTH_KEY_PEM_SIZE DILITHIUM_LEVEL3_BOTH_KEY_PEM_SIZE
 
 #define ML_DSA_LEVEL5_KEY_SIZE        OQS_SIG_ml_dsa_87_ipd_length_secret_key
 #define ML_DSA_LEVEL5_SIG_SIZE        OQS_SIG_ml_dsa_87_ipd_length_signature
@@ -570,6 +612,10 @@
 /* Buffer sizes large enough to store exported DER encoded keys */
 #define ML_DSA_LEVEL5_PUB_KEY_DER_SIZE DILITHIUM_LEVEL5_PUB_KEY_DER_SIZE
 #define ML_DSA_LEVEL5_PRV_KEY_DER_SIZE DILITHIUM_LEVEL5_PRV_KEY_DER_SIZE
+#define ML_DSA_LEVEL5_BOTH_KEY_DER_SIZE DILITHIUM_LEVEL5_BOTH_KEY_DER_SIZE
+/* PEM size with the header "-----BEGIN PRIVATE KEY-----" and
+ * the footer "-----END PRIVATE KEY-----" */
+#define ML_DSA_LEVEL5_BOTH_KEY_PEM_SIZE DILITHIUM_LEVEL5_BOTH_KEY_PEM_SIZE
 
 #endif
 
@@ -580,6 +626,10 @@
 /* Buffer sizes large enough to store exported DER encoded keys */
 #define DILITHIUM_MAX_PUB_KEY_DER_SIZE DILITHIUM_LEVEL5_PUB_KEY_DER_SIZE
 #define DILITHIUM_MAX_PRV_KEY_DER_SIZE DILITHIUM_LEVEL5_PRV_KEY_DER_SIZE
+#define DILITHIUM_MAX_BOTH_KEY_DER_SIZE DILITHIUM_LEVEL5_BOTH_KEY_DER_SIZE
+/* PEM size with the header "-----BEGIN PRIVATE KEY-----" and
+ * the footer "-----END PRIVATE KEY-----" */
+#define DILITHIUM_MAX_BOTH_KEY_PEM_SIZE DILITHIUM_LEVEL5_BOTH_KEY_PEM_SIZE
 
 
 #ifdef WOLF_PRIVATE_KEY_ID

--- a/wolfssl/wolfcrypt/dilithium.h
+++ b/wolfssl/wolfcrypt/dilithium.h
@@ -814,6 +814,10 @@ int wc_dilithium_export_key(dilithium_key* key, byte* priv, word32 *privSz,
 #endif
 
 #ifndef WOLFSSL_DILITHIUM_NO_ASN1
+WOLFSSL_LOCAL int dilithium_get_oid_sum(dilithium_key* key, int* keyFormat);
+#endif /* WOLFSSL_DILITHIUM_NO_ASN1 */
+
+#ifndef WOLFSSL_DILITHIUM_NO_ASN1
 #if defined(WOLFSSL_DILITHIUM_PRIVATE_KEY)
 WOLFSSL_API int wc_Dilithium_PrivateKeyDecode(const byte* input,
     word32* inOutIdx, dilithium_key* key, word32 inSz);


### PR DESCRIPTION
# Description

This PR improve the following items.

- `wolfSSL_CTX_use_PrivateKey_buffer()` and similar functions can't import DER format of ML-DSA private key
- There's no test for `wolfSSL_CTX_use_PrivateKey_buffer()` with ML-DSA private key (PEM and DER)

# Testing

./configure --enable-dilithium --enable-asn --enable-keygen && make test
./configure --enable-dilithium=yes,draft --enable-asn --enable-keygen && make test

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation