### PR TITLE
20250411-fixes

### DIFF
--- a/.github/workflows/pq-all.yml
+++ b/.github/workflows/pq-all.yml
@@ -18,7 +18,8 @@ jobs:
       matrix:
         config: [
           # Add new configs here
-          '--enable-intelasm --enable-sp-asm --enable-all --enable-testcert --enable-acert --enable-dtls13 --enable-dtls-mtu --enable-dtls-frag-ch --enable-dtlscid --enable-quic --with-sys-crypto-policy --enable-experimental --enable-kyber=yes,original --enable-lms --enable-xmss --enable-dilithium --enable-dual-alg-certs --disable-qt CPPFLAGS="-pedantic -Wdeclaration-after-statement -DWOLFCRYPT_TEST_LINT -DNO_WOLFSSL_CIPHER_SUITE_TEST"'
+          '--enable-intelasm --enable-sp-asm --enable-all --enable-testcert --enable-acert --enable-dtls13 --enable-dtls-mtu --enable-dtls-frag-ch --enable-dtlscid --enable-quic --with-sys-crypto-policy --enable-experimental --enable-kyber=yes,original --enable-lms --enable-xmss --enable-dilithium --enable-dual-alg-certs --disable-qt CPPFLAGS="-pedantic -Wdeclaration-after-statement -DWOLFCRYPT_TEST_LINT -DNO_WOLFSSL_CIPHER_SUITE_TEST -DTEST_LIBWOLFSSL_SOURCES_INCLUSION_SEQUENCE"',
+          '--enable-intelasm --enable-sp-asm --enable-all --enable-testcert --enable-acert --enable-dtls13 --enable-dtls-mtu --enable-dtls-frag-ch --enable-dtlscid --enable-quic --with-sys-crypto-policy --enable-experimental --enable-kyber=yes,original --enable-lms --enable-xmss --enable-dilithium --enable-dual-alg-certs --disable-qt CPPFLAGS="-pedantic -Wdeclaration-after-statement -DWOLFCRYPT_TEST_LINT -DNO_WOLFSSL_CIPHER_SUITE_TEST -DTEST_LIBWOLFSSL_SOURCES_INCLUSION_SEQUENCE" CC=c++'
         ]
     name: make check
     if: github.repository_owner == 'wolfssl'

--- a/src/internal.c
+++ b/src/internal.c
@@ -42369,7 +42369,7 @@ WOLFSSL_BY_DIR_HASH* wolfSSL_sk_BY_DIR_HASH_value(
 WOLFSSL_BY_DIR_HASH* wolfSSL_sk_BY_DIR_HASH_pop(
                                 WOLF_STACK_OF(WOLFSSL_BY_DIR_HASH)* sk)
 {
-    return wolfSSL_sk_pop(sk);
+    return (WOLFSSL_BY_DIR_HASH *)wolfSSL_sk_pop(sk);
 }
 /* release all contents in stack, and then release stack itself. */
 /* Second argument is a function pointer to release resources.   */
@@ -42501,7 +42501,7 @@ WOLFSSL_BY_DIR_entry* wolfSSL_sk_BY_DIR_entry_value(
 WOLFSSL_BY_DIR_entry* wolfSSL_sk_BY_DIR_entry_pop(
                                 WOLF_STACK_OF(WOLFSSL_BY_DIR_entry)* sk)
 {
-    return wolfSSL_sk_pop(sk);
+    return (WOLFSSL_BY_DIR_entry *)wolfSSL_sk_pop(sk);
 }
 /* release all contents in stack, and then release stack itself. */
 /* Second argument is a function pointer to release resources.   */

--- a/tests/api.c
+++ b/tests/api.c
@@ -15772,10 +15772,12 @@ static int test_wc_PKCS7_EncodeSignedData(void)
     {
         int signedSz = 0, i;
         encodeSignedDataStream strm;
-        int numberOfChunkSizes = 4;
-        word32 chunkSizes[] = { 4080, 4096, 5000, 9999 };
+        static const int numberOfChunkSizes = 4;
+        static const word32 chunkSizes[] = { 4080, 4096, 5000, 9999 };
         /* chunkSizes were chosen to test around the default 4096 octet string
          * size used in pkcs7.c */
+
+        XMEMSET(&strm, 0, sizeof(strm));
 
         ExpectNotNull(pkcs7 = wc_PKCS7_New(HEAP_HINT, testDevId));
         ExpectIntEQ(wc_PKCS7_Init(pkcs7, HEAP_HINT, INVALID_DEVID), 0);

--- a/tests/api.c
+++ b/tests/api.c
@@ -33034,7 +33034,7 @@ static int test_wolfSSL_PKCS8_d2i(void)
     bio = NULL;
 
     /* https://github.com/wolfSSL/wolfssl/issues/8610 */
-    bytes = (int)XSTRLEN((void*)pkcs8_buffer);
+    bytes = (int)XSTRLEN((char *)pkcs8_buffer);
     ExpectNotNull(bio = BIO_new_mem_buf((void*)pkcs8_buffer, bytes));
     ExpectIntEQ(BIO_get_mem_data(bio, &p), bytes);
     ExpectIntEQ(XMEMCMP(p, pkcs8_buffer, bytes), 0);


### PR DESCRIPTION
`tests/api.c`: fix error path uninited-data defects in `test_wc_PKCS7_EncodeSignedData()` (followup to bf95f80c6d, detected by valgrind).

`src/internal.c, tests/api.c`: add missing casts for C++ compatibility (fixes "invalid conversion" errors).

`.github/workflows/pq-all.yml`: add `-DTEST_LIBWOLFSSL_SOURCES_INCLUSION_SEQUENCE`, and add a config with `CC=c++`.

tested with `wolfssl-multi-test.sh ... check-source-text quantum-safe-wolfssl-all-g++-latest-debug quantum-safe-wolfssl-all-intelasm-sp-asm-valgrind quantum-safe-wolfssl-all-clang++-latest quantum-safe-wolfssl-all-cppcheck clang-tidy-all-sp-all`
