### PR TITLE
Fix debug logs (disabled in PR #8616)

### DIFF
--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -158,7 +158,7 @@ wolfSSL_Logging_cb wolfSSL_GetLoggingCb(void)
 int wolfSSL_Debugging_ON(void)
 {
 #ifdef DEBUG_WOLFSSL
-    loggingEnabled = 0;
+    loggingEnabled = 1;
 #if defined(WOLFSSL_APACHE_MYNEWT)
     log_register("wolfcrypt", &mynewt_log, &log_console_handler, NULL, LOG_SYSLEVEL);
 #endif /* WOLFSSL_APACHE_MYNEWT */


### PR DESCRIPTION
# Description

Fix debug logs (disabled in PR #8616)

Broken in https://github.com/wolfSSL/wolfssl/pull/8616/files#diff-f51b9f2b7435023a38d4ad25c7be607692520f4809b8d1d91745d054d938ddc4R161

# Testing

`./configure --enable-debug && make && ./examples/server/server`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
