### PR TITLE
20250411-more-libwolfssl_sources_h

### DIFF
--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -27,10 +27,7 @@
 #include <wolfssl/internal.h>
 #include <wolfssl/ssl.h>
 #include <wolfssl/wolfcrypt/aes.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/kdf.h>
-#include <wolfssl/wolfcrypt/logging.h>
-#include <wolfssl/wolfcrypt/types.h>
 
 #ifdef NO_INLINE
 #include <wolfssl/wolfcrypt/misc.h>

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -93,8 +93,6 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
     #include <wolfcrypt/src/port/ti/ti-aes.c>
 #else
 
-#include <wolfssl/wolfcrypt/logging.h>
-
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>
 #else
@@ -348,7 +346,6 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
 #elif defined(HAVE_COLDFIRE_SEC)
     /* Freescale Coldfire SEC support for CBC mode.
      * NOTE: no support for AES-CTR/GCM/CCM/Direct */
-    #include <wolfssl/wolfcrypt/types.h>
     #include "sec.h"
     #include "mcf5475_sec.h"
     #include "mcf5475_siu.h"

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -106,7 +106,6 @@ ASN Options:
  *  usage.
 */
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #ifndef NO_RSA
     #include <wolfssl/wolfcrypt/rsa.h>
     #if defined(WOLFSSL_XILINX_CRYPT) || defined(WOLFSSL_CRYPTOCELL)

--- a/wolfcrypt/src/chacha.c
+++ b/wolfcrypt/src/chacha.c
@@ -78,7 +78,6 @@ Public domain.
 /* BEGIN ChaCha C implementation */
 #if defined(HAVE_CHACHA)
 
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/cpuid.h>
 
 #ifdef CHACHA_AEAD_TEST

--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -47,7 +47,6 @@
     #include <wolfcrypt/src/misc.c>
 #endif
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/aes.h>
 #include <wolfssl/wolfcrypt/cmac.h>
 

--- a/wolfcrypt/src/des3.c
+++ b/wolfcrypt/src/des3.c
@@ -440,8 +440,6 @@
 
 #elif defined(HAVE_COLDFIRE_SEC)
 
-    #include <wolfssl/wolfcrypt/types.h>
-
     #include "sec.h"
     #include "mcf5475_sec.h"
     #include "mcf5475_siu.h"

--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -36,8 +36,6 @@
 #endif
 
 #include <wolfssl/wolfcrypt/dh.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/logging.h>
 
 #ifdef WOLFSSL_HAVE_SP_DH
 #include <wolfssl/wolfcrypt/sp.h>

--- a/wolfcrypt/src/falcon.c
+++ b/wolfcrypt/src/falcon.c
@@ -32,7 +32,6 @@
 #endif
 
 #include <wolfssl/wolfcrypt/falcon.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>
 #else

--- a/wolfcrypt/src/ge_low_mem.c
+++ b/wolfcrypt/src/ge_low_mem.c
@@ -27,7 +27,6 @@
 #ifdef ED25519_SMALL /* use slower code that takes less memory */
 
 #include <wolfssl/wolfcrypt/ge_operations.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>
 #else

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -258,7 +258,6 @@ void WOLFSSL_TIME(int count)
     /* the requisite linux/kernel.h is included in wc_port.h, with incompatible warnings masked out. */
 #elif defined(FUSION_RTOS)
     #include <fclstdio.h>
-    #include <wolfssl/wolfcrypt/wc_port.h>
     #define fprintf FCL_FPRINTF
 #else
     #include <stdio.h>  /* for default printf stuff */

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -73,8 +73,6 @@ void *z_realloc(void *ptr, size_t size)
 #ifdef USE_WOLFSSL_MEMORY
 
 #include <wolfssl/wolfcrypt/memory.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/logging.h>
 
 #if defined(WOLFSSL_DEBUG_MEMORY) && defined(WOLFSSL_DEBUG_MEMORY_PRINT)
 #include <stdio.h>

--- a/wolfcrypt/src/port/af_alg/afalg_aes.c
+++ b/wolfcrypt/src/port/af_alg/afalg_aes.c
@@ -19,20 +19,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
-
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if !defined(NO_AES) && (defined(WOLFSSL_AFALG) || \
                          defined(WOLFSSL_AFALG_XILINX_AES))
 
 #include <wolfssl/wolfcrypt/aes.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/port/af_alg/wc_afalg.h>
 
 #include <sys/uio.h> /* for readv */

--- a/wolfcrypt/src/port/af_alg/afalg_hash.c
+++ b/wolfcrypt/src/port/af_alg/afalg_hash.c
@@ -19,18 +19,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if defined(WOLFSSL_AFALG_HASH) || (defined(WOLFSSL_AFALG_XILINX_SHA3) \
         && defined(WOLFSSL_SHA3))
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/port/af_alg/wc_afalg.h>
 #include <wolfssl/wolfcrypt/port/af_alg/afalg_hash.h>
 

--- a/wolfcrypt/src/port/af_alg/wc_afalg.c
+++ b/wolfcrypt/src/port/af_alg/wc_afalg.c
@@ -19,13 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/logging.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if defined(WOLFSSL_AFALG) || defined(WOLFSSL_AFALG_XILINX)
 

--- a/wolfcrypt/src/port/arm/armv8-aes.c
+++ b/wolfcrypt/src/port/arm/armv8-aes.c
@@ -19,19 +19,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 /*
  * There are two versions one for 64 (Aarch64) and one for 32 bit (Aarch32).
  * If changing one check the other.
  */
-
-
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
 
 #if !defined(NO_AES) && defined(WOLFSSL_ARMASM)
 
@@ -56,7 +49,6 @@
 #endif
 
 #include <wolfssl/wolfcrypt/aes.h>
-#include <wolfssl/wolfcrypt/logging.h>
 
 #if FIPS_VERSION3_GE(6,0,0)
     const unsigned int wolfCrypt_FIPS_aes_ro_sanity[2] =

--- a/wolfcrypt/src/port/arm/armv8-chacha.c
+++ b/wolfcrypt/src/port/arm/armv8-chacha.c
@@ -19,23 +19,17 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
+
 /*  The paper NEON crypto by Daniel J. Bernstein and Peter Schwabe was used to
  *  optimize for ARM
  *  https://cryptojedi.org/papers/neoncrypto-20120320.pdf
  */
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
-
 #if defined(WOLFSSL_ARMASM)
 #ifdef HAVE_CHACHA
 
 #include <wolfssl/wolfcrypt/chacha.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/cpuid.h>
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>

--- a/wolfcrypt/src/port/arm/armv8-poly1305.c
+++ b/wolfcrypt/src/port/arm/armv8-poly1305.c
@@ -19,24 +19,17 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
+
 /*
- * Based off the public domain implementations by Andrew Moon
+ * Based on the public domain implementations by Andrew Moon
  * and Daniel J. Bernstein
  */
-
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
-#include <wolfssl/wolfcrypt/types.h>
 
 #ifdef WOLFSSL_ARMASM
 
 #ifdef HAVE_POLY1305
 #include <wolfssl/wolfcrypt/poly1305.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/cpuid.h>
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>

--- a/wolfcrypt/src/port/arm/armv8-sha256.c
+++ b/wolfcrypt/src/port/arm/armv8-sha256.c
@@ -19,12 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #ifdef WOLFSSL_ARMASM
 #if !defined(NO_SHA256) || defined(WOLFSSL_SHA224)
@@ -47,8 +42,6 @@
         return 0;
     }
 #endif
-#include <wolfssl/wolfcrypt/logging.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/cpuid.h>
 
 #ifdef NO_INLINE

--- a/wolfcrypt/src/port/arm/armv8-sha512.c
+++ b/wolfcrypt/src/port/arm/armv8-sha512.c
@@ -19,11 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #ifdef WOLFSSL_ARMASM
 #if defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)
@@ -47,11 +43,8 @@
         return 0;
     }
 #endif
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/cpuid.h>
 #include <wolfssl/wolfcrypt/hash.h>
-
-#include <wolfssl/wolfcrypt/logging.h>
 
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>

--- a/wolfcrypt/src/port/arm/cryptoCell.c
+++ b/wolfcrypt/src/port/arm/cryptoCell.c
@@ -19,11 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 /* This source is included in wc_port.c */
 /* WOLFSSL_CRYPTOCELL_C is defined by wc_port.c in case compile tries to
@@ -32,8 +28,6 @@
 
 #ifdef WOLFSSL_CRYPTOCELL
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/ecc.h>
 #include <wolfssl/wolfcrypt/port/arm/cryptoCell.h>
 

--- a/wolfcrypt/src/port/arm/cryptoCellHash.c
+++ b/wolfcrypt/src/port/arm/cryptoCellHash.c
@@ -19,11 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 /* This source is included in wc_port.c */
 /* WOLFSSL_CRYPTOCELL_HASH_C is defined by wc_port.c in case compile tries
@@ -31,8 +27,6 @@
 #ifdef WOLFSSL_CRYPTOCELL_HASH_C
 #if !defined(NO_SHA256) && defined(WOLFSSL_CRYPTOCELL)
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/sha256.h>
 #include <wolfssl/wolfcrypt/port/arm/cryptoCell.h>
 

--- a/wolfcrypt/src/port/arm/thumb2-chacha.c
+++ b/wolfcrypt/src/port/arm/thumb2-chacha.c
@@ -19,19 +19,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if defined(WOLFSSL_ARMASM) && defined(WOLFSSL_ARMASM_THUMB2)
 #ifdef HAVE_CHACHA
 
 #include <wolfssl/wolfcrypt/chacha.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/cpuid.h>
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>

--- a/wolfcrypt/src/port/arm/thumb2-poly1305.c
+++ b/wolfcrypt/src/port/arm/thumb2-poly1305.c
@@ -19,20 +19,13 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
-#include <wolfssl/wolfcrypt/types.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #ifdef WOLFSSL_ARMASM
 #ifdef WOLFSSL_ARMASM_THUMB2
 
 #ifdef HAVE_POLY1305
 #include <wolfssl/wolfcrypt/poly1305.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/cpuid.h>
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>

--- a/wolfcrypt/src/port/devcrypto/devcrypto_aes.c
+++ b/wolfcrypt/src/port/devcrypto/devcrypto_aes.c
@@ -19,18 +19,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if !defined(NO_AES) && defined(WOLFSSL_DEVCRYPTO)
 
 #include <wolfssl/wolfcrypt/aes.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/port/devcrypto/wc_devcrypto.h>
 
 #ifdef NO_INLINE

--- a/wolfcrypt/src/port/devcrypto/devcrypto_ecdsa.c
+++ b/wolfcrypt/src/port/devcrypto/devcrypto_ecdsa.c
@@ -19,18 +19,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if defined(WOLFSSL_DEVCRYPTO_ECDSA)
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/ecc.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/port/devcrypto/wc_devcrypto.h>
 
 

--- a/wolfcrypt/src/port/devcrypto/devcrypto_hash.c
+++ b/wolfcrypt/src/port/devcrypto/devcrypto_hash.c
@@ -19,17 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if defined(WOLFSSL_DEVCRYPTO_HASH)
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/port/devcrypto/wc_devcrypto.h>
 
 #if !defined(NO_SHA256)

--- a/wolfcrypt/src/port/devcrypto/devcrypto_hmac.c
+++ b/wolfcrypt/src/port/devcrypto/devcrypto_hmac.c
@@ -19,18 +19,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if defined(WOLFSSL_DEVCRYPTO_HMAC)
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/hmac.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/port/devcrypto/wc_devcrypto.h>
 
 static int InternalTypeToDevcrypto(int t)

--- a/wolfcrypt/src/port/devcrypto/devcrypto_rsa.c
+++ b/wolfcrypt/src/port/devcrypto/devcrypto_rsa.c
@@ -19,18 +19,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if defined(WOLFSSL_DEVCRYPTO_RSA)
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/rsa.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/port/devcrypto/wc_devcrypto.h>
 
 static void wc_SetupRsaPublic(struct crypt_kop* kop, WC_CRYPTODEV* dev,

--- a/wolfcrypt/src/port/devcrypto/devcrypto_x25519.c
+++ b/wolfcrypt/src/port/devcrypto/devcrypto_x25519.c
@@ -19,18 +19,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if defined(WOLFSSL_DEVCRYPTO_CURVE25519)
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/curve25519.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/port/devcrypto/wc_devcrypto.h>
 
 const unsigned char qle[] = {

--- a/wolfcrypt/src/port/devcrypto/wc_devcrypto.c
+++ b/wolfcrypt/src/port/devcrypto/wc_devcrypto.c
@@ -19,19 +19,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if defined(WOLFSSL_DEVCRYPTO)
 
 static volatile int fd;
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/port/devcrypto/wc_devcrypto.h>
 
 int wc_DevCryptoInit(void)

--- a/wolfcrypt/src/port/kcapi/kcapi_aes.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_aes.c
@@ -19,16 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
-
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <errno.h>
-
-#include <wolfssl/wolfcrypt/settings.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if !defined(NO_AES) && defined(WOLFSSL_KCAPI_AES)
 
@@ -45,7 +36,6 @@
 #endif
 
 #include <wolfssl/wolfcrypt/aes.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/port/kcapi/wc_kcapi.h>
 
 #ifdef NO_INLINE

--- a/wolfcrypt/src/port/kcapi/kcapi_dh.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_dh.c
@@ -19,17 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if defined(WOLFSSL_KCAPI_DH) && !defined(NO_DH)
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/port/kcapi/wc_kcapi.h>
 #include <wolfssl/wolfcrypt/port/kcapi/kcapi_dh.h>
 #include <wolfssl/wolfcrypt/dh.h>

--- a/wolfcrypt/src/port/kcapi/kcapi_ecc.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_ecc.c
@@ -19,17 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if defined(WOLFSSL_KCAPI_ECC) && defined(HAVE_ECC)
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/port/kcapi/wc_kcapi.h>
 #include <wolfssl/wolfcrypt/port/kcapi/kcapi_ecc.h>
 #include <wolfssl/wolfcrypt/ecc.h>

--- a/wolfcrypt/src/port/kcapi/kcapi_hash.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_hash.c
@@ -19,6 +19,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
+
 /*
  * KCAPI hash options:
  *
@@ -26,18 +28,10 @@
  *     Needed to get the current hash and continue with more data.
  */
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
-
 #if defined(WOLFSSL_KCAPI_HASH)
 
 #define FIPS_NO_WRAPPERS
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/port/kcapi/wc_kcapi.h>
 #include <wolfssl/wolfcrypt/port/kcapi/kcapi_hash.h>
 

--- a/wolfcrypt/src/port/kcapi/kcapi_hmac.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_hmac.c
@@ -19,19 +19,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if defined(WOLFSSL_KCAPI_HMAC) && !defined(NO_HMAC)
 
 #define FIPS_NO_WRAPPERS
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/port/kcapi/wc_kcapi.h>
 #include <wolfssl/wolfcrypt/port/kcapi/kcapi_hmac.h>
 #include <wolfssl/wolfcrypt/hmac.h>

--- a/wolfcrypt/src/port/kcapi/kcapi_rsa.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_rsa.c
@@ -19,17 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if defined(WOLFSSL_KCAPI_RSA) && !defined(NO_RSA)
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/port/kcapi/wc_kcapi.h>
 #include <wolfssl/wolfcrypt/port/kcapi/kcapi_rsa.h>
 #include <wolfssl/wolfcrypt/rsa.h>

--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -46,9 +46,6 @@
 #endif
 
 #if FIPS_VERSION3_GE(6,0,0)
-    #ifdef DEBUG_WOLFSSL
-        #include <wolfssl/wolfcrypt/logging.h>
-    #endif
     const unsigned int wolfCrypt_FIPS_pbkdf_ro_sanity[2] =
                                                      { 0x1a2b3c4d, 0x00000010 };
     int wolfCrypt_FIPS_PBKDF_sanity(void)

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -86,7 +86,6 @@ This library contains implementation for the random number generator.
     #undef _WINSOCKAPI_ /* undefine it for MINGW winsock2.h header file */
 #elif defined(HAVE_WNR)
     #include <wnr.h>
-    #include <wolfssl/wolfcrypt/logging.h>
     wolfSSL_Mutex wnr_mutex WOLFSSL_MUTEX_INITIALIZER_CLAUSE(wnr_mutex);    /* global netRandom mutex */
     int wnr_timeout     = 0;    /* entropy timeout, milliseconds */
     #ifndef WOLFSSL_MUTEX_INITIALIZER

--- a/wolfcrypt/src/rc2.c
+++ b/wolfcrypt/src/rc2.c
@@ -38,7 +38,6 @@ This library provides the interface to the RC2 encryption algorithm (RFC 2268)
 #endif
 
 #include <wolfssl/wolfcrypt/rc2.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
 
 /* Table based on value of PI, defined in RFC 2268 */
 static const byte pitable[256] = {

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -91,7 +91,6 @@ RSA Key Size Configuration:
 
 
 #include <wolfssl/wolfcrypt/random.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #ifdef WOLF_CRYPTO_CB
     #include <wolfssl/wolfcrypt/cryptocb.h>
 #endif

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -40,7 +40,6 @@
 #endif
 
 #include <wolfssl/wolfcrypt/sha.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/hash.h>
 
 #ifdef WOLF_CRYPTO_CB
@@ -103,7 +102,6 @@
 
 #else
 
-#include <wolfssl/wolfcrypt/logging.h>
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>
 #else

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -72,7 +72,6 @@ on the specific device platform.
 #endif
 
 #include <wolfssl/wolfcrypt/sha256.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/cpuid.h>
 #include <wolfssl/wolfcrypt/hash.h>
 
@@ -121,8 +120,6 @@ on the specific device platform.
     /* Already brought in by sha256.h */
     /* #include <wolfssl/wolfcrypt/port/maxim/max3266x.h> */
 #else
-
-#include <wolfssl/wolfcrypt/logging.h>
 
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -51,7 +51,6 @@
 #endif
 
 #include <wolfssl/wolfcrypt/sha512.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/cpuid.h>
 #include <wolfssl/wolfcrypt/hash.h>
 
@@ -67,8 +66,6 @@
 #if defined(USE_SLOW_SHA2) && !defined(USE_SLOW_SHA512)
     #define USE_SLOW_SHA512
 #endif
-
-#include <wolfssl/wolfcrypt/logging.h>
 
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>

--- a/wolfcrypt/src/sphincs.c
+++ b/wolfcrypt/src/sphincs.c
@@ -32,7 +32,6 @@
 #endif
 
 #include <wolfssl/wolfcrypt/sphincs.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>
 #else

--- a/wolfcrypt/src/wc_mlkem_poly.c
+++ b/wolfcrypt/src/wc_mlkem_poly.c
@@ -69,7 +69,6 @@
 
 #include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
-#include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/wc_mlkem.h>
 #include <wolfssl/wolfcrypt/cpuid.h>
 

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -25,11 +25,6 @@
     #include <AvailabilityMacros.h>
 #endif
 
-#include <wolfssl/wolfcrypt/settings.h>
-#include <wolfssl/wolfcrypt/types.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/logging.h>
-#include <wolfssl/wolfcrypt/wc_port.h>
 #ifdef HAVE_ECC
     #include <wolfssl/wolfcrypt/ecc.h>
 #endif


### PR DESCRIPTION
update several files in `wolfcrypt/src/port/arm` to include `libwolfssl_sources.h`;

update `wolfcrypt/src/port/af_alg`, `wolfcrypt/src/port/devcrypto`, and `wolfcrypt/src/port/kcapi` to include `libwolfssl_sources.h`;

remove a slew of includes across lib sources made redundant by `libwolfssl_sources.h`.

tested with `wolfssl-multi-test.sh ... super-quick-check` using fips-dev from https://github.com/wolfSSL/fips/pull/341 and wolfsm from https://github.com/wolfSSL/wolfsm/pull/27, with `-DTEST_LIBWOLFSSL_SOURCES_INCLUSION_SEQUENCE`.

also used
```
git grep -E '#include <wolfssl/wolfcrypt/(error-crypt|settings|logging|types|wc_port)\.h>' src wolfcrypt/src/
```
to find and fix redundant and missing includes, and used 
```
git diff --color=always | egrep -v '#include <wolfssl/wolfcrypt/(error-crypt|settings|logging|types|wc_port)\.h>' | less
```
to confirm no needed includes were inadvertently removed.
