### PR TITLE
20250411-more-libwolfssl_sources_h-2

### DIFF
--- a/wolfcrypt/src/port/kcapi/kcapi_aes.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_aes.c
@@ -23,6 +23,8 @@
 
 #if !defined(NO_AES) && defined(WOLFSSL_KCAPI_AES)
 
+#include <errno.h>
+
 #if defined(HAVE_FIPS) && \
     defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)
 

--- a/wolfcrypt/src/port/liboqs/liboqs.c
+++ b/wolfcrypt/src/port/liboqs/liboqs.c
@@ -19,6 +19,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
+
 /*
 
 DESCRIPTION
@@ -26,15 +28,6 @@ This library provides the support interfaces to the liboqs library providing
 implementations for Post-Quantum cryptography algorithms.
 
 */
-
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
-#include <wolfssl/wolfcrypt/types.h>
-#include <wolfssl/wolfcrypt/logging.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
 
 #include <wolfssl/wolfcrypt/port/liboqs/liboqs.h>
 

--- a/wolfcrypt/src/port/riscv/riscv-64-aes.c
+++ b/wolfcrypt/src/port/riscv/riscv-64-aes.c
@@ -19,19 +19,13 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
-#include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/port/riscv/riscv-64-asm.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
 
 #if !defined(NO_AES)
 
 #include <wolfssl/wolfcrypt/aes.h>
-
-#include <wolfssl/wolfcrypt/logging.h>
 
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>

--- a/wolfcrypt/src/port/riscv/riscv-64-chacha.c
+++ b/wolfcrypt/src/port/riscv/riscv-64-chacha.c
@@ -19,24 +19,19 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
+
 /* The paper NEON crypto by Daniel J. Bernstein and Peter Schwabe was used to
  * optimize for ARM:
  *   https://cryptojedi.org/papers/veccrypto-20120320.pdf
  */
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/port/riscv/riscv-64-asm.h>
 
 #ifdef WOLFSSL_RISCV_ASM
 #ifdef HAVE_CHACHA
 
 #include <wolfssl/wolfcrypt/chacha.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/cpuid.h>
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>

--- a/wolfcrypt/src/port/riscv/riscv-64-poly1305.c
+++ b/wolfcrypt/src/port/riscv/riscv-64-poly1305.c
@@ -19,25 +19,19 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
+
 /*
- * Based off the public domain implementations by Andrew Moon
+ * Based on the public domain implementations by Andrew Moon
  * and Daniel J. Bernstein
  */
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
-#include <wolfssl/wolfcrypt/types.h>
 #include <wolfssl/wolfcrypt/port/riscv/riscv-64-asm.h>
 
 #ifdef WOLFSSL_RISCV_ASM
 
 #ifdef HAVE_POLY1305
 #include <wolfssl/wolfcrypt/poly1305.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
-#include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/cpuid.h>
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>

--- a/wolfcrypt/src/port/riscv/riscv-64-sha256.c
+++ b/wolfcrypt/src/port/riscv/riscv-64-sha256.c
@@ -19,12 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #ifdef WOLFSSL_RISCV_ASM
 #if !defined(NO_SHA256) || defined(WOLFSSL_SHA224)
@@ -47,8 +42,6 @@
         return 0;
     }
 #endif
-#include <wolfssl/wolfcrypt/logging.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
 
 #include <wolfssl/wolfcrypt/port/riscv/riscv-64-asm.h>
 

--- a/wolfcrypt/src/port/riscv/riscv-64-sha3.c
+++ b/wolfcrypt/src/port/riscv/riscv-64-sha3.c
@@ -19,12 +19,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/port/riscv/riscv-64-asm.h>
 
 #ifdef WOLFSSL_RISCV_ASM

--- a/wolfcrypt/src/port/riscv/riscv-64-sha512.c
+++ b/wolfcrypt/src/port/riscv/riscv-64-sha512.c
@@ -19,12 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #ifdef WOLFSSL_RISCV_ASM
 #if !defined(NO_SHA512) || defined(WOLFSSL_SHA384)
@@ -47,8 +42,6 @@
         return 0;
     }
 #endif
-#include <wolfssl/wolfcrypt/logging.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
 
 #include <wolfssl/wolfcrypt/port/riscv/riscv-64-asm.h>
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -6363,7 +6363,7 @@ WOLFSSL_TEST_SUBROUTINE wc_test_ret_t hash_test(void)
         }
 
        if (ret != 0) {
-           ERROR_OUT(WC_TEST_RET_ENC_I(BAD_FUNC_ARG), out);
+           ERROR_OUT(WC_TEST_RET_ENC_EC(BAD_FUNC_ARG), out);
        }
 #endif
         ret = wc_HashInit(hash, typesGood[i]);

--- a/wolfssl/wolfcrypt/libwolfssl_sources.h
+++ b/wolfssl/wolfcrypt/libwolfssl_sources.h
@@ -29,7 +29,8 @@
 #define LIBWOLFSSL_SOURCES_H
 
 #if defined(TEST_LIBWOLFSSL_SOURCES_INCLUSION_SEQUENCE) && \
-    defined(WOLF_CRYPT_SETTINGS_H)
+    defined(WOLF_CRYPT_SETTINGS_H) &&                      \
+    !defined(LIBWOLFSSL_SOURCES_ASM_H)
     #error settings.h included before libwolfssl_sources.h.
 #endif
 
@@ -37,8 +38,9 @@
     #define BUILDING_WOLFSSL
 #endif
 
-#ifdef HAVE_CONFIG_H
+#if defined(HAVE_CONFIG_H) && !defined(WC_CONFIG_H_INCLUDED)
     #include <config.h>
+    #define WC_CONFIG_H_INCLUDED
 #endif
 
 #include <wolfssl/wolfcrypt/types.h>

--- a/wolfssl/wolfcrypt/libwolfssl_sources_asm.h
+++ b/wolfssl/wolfcrypt/libwolfssl_sources_asm.h
@@ -29,7 +29,8 @@
 #define LIBWOLFSSL_SOURCES_ASM_H
 
 #if defined(TEST_LIBWOLFSSL_SOURCES_INCLUSION_SEQUENCE) && \
-    defined(WOLF_CRYPT_SETTINGS_H)
+    defined(WOLF_CRYPT_SETTINGS_H) &&                      \
+    !defined(LIBWOLFSSL_SOURCES_H)
     #error settings.h included before libwolfssl_sources_asm.h.
 #endif
 
@@ -37,8 +38,9 @@
     #define BUILDING_WOLFSSL
 #endif
 
-#ifdef HAVE_CONFIG_H
+#if defined(HAVE_CONFIG_H) && !defined(WC_CONFIG_H_INCLUDED)
     #include <config.h>
+    #define WC_CONFIG_H_INCLUDED
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>


### PR DESCRIPTION
`wolfssl/wolfcrypt/libwolfssl_sources*.h`: check if the other `libwolfssl_sources*.h` was included before concluding that "#error settings.h included before libwolfssl_sources.h.", and add `WC_CONFIG_H_INCLUDED` to inhibit multiple inclusions of `config.h`;

`wolfcrypt/src/port/kcapi/kcapi_aes.c`: restore `#include <errno.h>` removed incorrectly in ed5d8f8e6b;

`wolfcrypt/src/port/liboqs/liboqs.c`: include `libwolfssl_sources.h`;

`wolfcrypt/src/port/riscv/*.c`: include `libwolfssl_sources.h`;

`wolfcrypt/test/test.c`: fix use of `WC_TEST_RET_ENC_I()` where `WC_TEST_RET_ENC_EC()` was required.

tested with `wolfssl-multi-test.sh ... super-quick-check pq-all pq-hybrid-all-rpk quantum-safe-wolfssl-all-crypto-only-intelasm-sp-asm-linuxkm-insmod fips-140-3-dev-kcapi linuxkm-6.12-all-cryptonly-intelasm-fips-dev-dyn-hash-LKCAPI-insmod lean-fips-dev-armv7-small-armasm-sanitizer linuxkm-mainline-intelasm-sp-asm-pie-gcc-latest-insmod cross-riscv64-all-asm linuxkm-6.12-all-cryptonly-intelasm-fips-v6-dyn-hash-LKCAPI-insmod`
