### PR TITLE
Fix Arduino progmem print, AVR WOLFSSL_USER_IO

### DIFF
--- a/IDE/ARDUINO/wolfssl-arduino.cpp
+++ b/IDE/ARDUINO/wolfssl-arduino.cpp
@@ -25,9 +25,33 @@
 /* Function to allow wolfcrypt to use Arduino Serial.print for debug messages.
  * See wolfssl/wolfcrypt/logging.c */
 
+#if defined(__AVR__)
+#include <avr/pgmspace.h>  /* Required for PROGMEM handling on AVR */
+#endif
+
 int wolfSSL_Arduino_Serial_Print(const char* const s)
 {
     /* Reminder: Serial.print is only available in C++ */
-    Serial.println(F(s));
+    int is_progmem = 0;
+
+#if defined(__AVR__)
+    const char* t;
+    t = s;
+
+    /* Safely check if `s` is in PROGMEM, 0x8000 is typical for AVR flash */
+    if (reinterpret_cast<uint16_t>(t) >= 0x8000) {
+        while (pgm_read_byte(t)) {
+            Serial.write(pgm_read_byte(t++));
+        }
+        Serial.println();
+        is_progmem = 1;
+    }
+#endif
+
+    /* Print normally for non-AVR boards or RAM-stored strings */
+    if (!is_progmem) {
+        Serial.println(s);
+    }
+
     return 0;
 };

--- a/IDE/ARDUINO/wolfssl-arduino.sh
+++ b/IDE/ARDUINO/wolfssl-arduino.sh
@@ -262,6 +262,11 @@ if [ "$THIS_DIR" = "ARDUINO" ]; then
     # Copy examples
     mkdir -p ".${ROOT_SRC_DIR}"/examples
 
+    EXAMPLES_DIR_REAL_PATH=$(realpath ".${EXAMPLES_DIR}")
+    echo "Source WOLFSSL_EXAMPLES_ROOT=$WOLFSSL_EXAMPLES_ROOT"
+    echo "Destination EXAMPLES_DIR=.${EXAMPLES_DIR}"
+    echo "EXAMPLES_DIR_REAL_PATH=${EXAMPLES_DIR_REAL_PATH}"
+
     if [ -n "$WOLFSSL_EXAMPLES_ROOT" ]; then
         echo "Copy template example...."
         mkdir -p ".${EXAMPLES_DIR}"/template/wolfssl_library/src
@@ -294,6 +299,9 @@ if [ "$THIS_DIR" = "ARDUINO" ]; then
     else
         NO_ARDUINO_EXAMPLES=1
     fi
+    echo "Examples copied to .${EXAMPLES_DIR}"
+    echo "ls ${EXAMPLES_DIR_REAL_PATH}"
+    ls "${EXAMPLES_DIR_REAL_PATH}"
 else
     echo "ERROR: You must be in the IDE/ARDUINO directory to run this script"
     exit 1

--- a/examples/configs/user_settings_arduino.h
+++ b/examples/configs/user_settings_arduino.h
@@ -92,9 +92,13 @@
 #elif defined(WOLFSSL_SERVER_EXAMPLE)
     #define NO_WOLFSSL_CLIENT
 #elif defined(WOLFSSL_TEMPLATE_EXAMPLE)
+    #define NO_TLS
+    #define WOLFCRYPT_ONLY
     #define NO_WOLFSSL_SERVER
     #define NO_WOLFSSL_CLIENT
 #elif defined(WOLFSSL_AES_CTR_EXAMPLE)
+    #define NO_TLS
+    #define WOLFCRYPT_ONLY
     #define NO_WOLFSSL_SERVER
     #define NO_WOLFSSL_CLIENT
     #define WOLFSSL_AES

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -316,6 +316,7 @@
 
     /* board-specific */
     #if defined(__AVR__)
+        #define WOLFSSL_USER_IO
         #define WOLFSSL_NO_SOCK
         #define NO_WRITEV
     #elif defined(__arm__)


### PR DESCRIPTION
# Description

Related to https://github.com/wolfSSL/wolfssl/pull/8514 this PR fixes the Arduino `Serial.print()` used by wolfSSL [logging]() via `wolfSSL_Arduino_Serial_Print()`. 

Without this change, some Arduino targets (e.g.  AVR Arduino Uno) will see a compile-time error:

```
C:\\Users\\gojimmypi\\AppData\\Local\\Arduino15\\packages\\arduino\\tools\\avr-gcc\\7.3.0-atmel3.6.1-arduino7/bin/avr-g++" -c -g -Os -w -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -MMD -flto -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO=10607 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR "-IC:\\Users\\gojimmypi\\AppData\\Local\\Arduino15\\packages\\arduino\\hardware\\avr\\1.8.6\\cores\\arduino" "-IC:\\Users\\gojimmypi\\AppData\\Local\\Arduino15\\packages\\arduino\\hardware\\avr\\1.8.6\\variants\\standard" "-Ic:\\Users\\gojimmypi\\Documents\\Arduino\\libraries\\wolfssl\\src" "c:\\Users\\gojimmypi\\Documents\\Arduino\\libraries\\wolfssl\\src\\wolfssl-arduino.cpp" -o "C:\\Users\\gojimmypi\\AppData\\Local\\arduino\\sketches\\89891228178DAE8CA0A558C95DF5D42C\\libraries\\wolfssl\\wolfssl-arduino.cpp.o"
In file included from C:\Users\gojimmypi\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.6\cores\arduino/Arduino.h:28:0,
                 from c:\Users\gojimmypi\Documents\Arduino\libraries\wolfssl\src\wolfssl-arduino.cpp:22:
c:\Users\gojimmypi\Documents\Arduino\libraries\wolfssl\src\wolfssl-arduino.cpp: In function 'int wolfSSL_Arduino_Serial_Print(const char*)':
C:\Users\gojimmypi\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.6\cores\arduino/WString.h:38:74: error: initializer fails to determine size of '__c'
 #define F(string_literal) (reinterpret_cast<const __FlashStringHelper *>(PSTR(string_literal)))
                                                                          ^
c:\Users\gojimmypi\Documents\Arduino\libraries\wolfssl\src\wolfssl-arduino.cpp:31:21: note: in expansion of macro 'F'
      Serial.println(F(s));
                     ^
C:\Users\gojimmypi\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.6\cores\arduino/WString.h:38:74: error: array must be initialized with a brace-enclosed initializer
 #define F(string_literal) (reinterpret_cast<const __FlashStringHelper *>(PSTR(string_literal)))
                                                                          ^
c:\Users\gojimmypi\Documents\Arduino\libraries\wolfssl\src\wolfssl-arduino.cpp:31:21: note: in expansion of macro 'F'
      Serial.println(F(s));
                     ^

Using library wolfssl at version 5.7.6 in folder: C:\Users\gojimmypi\Documents\Arduino\libraries\wolfssl 
exit status 1

```

Edit: during testing I added some additional logging to the `IDE/ARDUINO/wolfssl-arduino.sh` publishing script, as well as some board-specific checks for networking capabilities in `wolfcrypt/settings.h`

Fixes zd# n/a

# Testing

How did you test?

Manually tested in Arduino IDE with  manual install (note new example location, see https://github.com/wolfSSL/wolfssl-examples/pull/499).

```
$ echo $WOLFSSL_EXAMPLES_ROOT
/mnt/c/workspace/wolfssl-examples-gojimmypi
gojimmypi:/mnt/c/workspace/wolfssl-gojimmypi-pr/IDE/ARDUINO
$ ./wolfssl-arduino.sh INSTALL
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
