### PR TITLE
20250414-fix-curve255519_der_test-fips-v6

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -35648,7 +35648,11 @@ static wc_test_ret_t curve255519_der_test(void)
         0xA2, 0x5B, 0x38, 0xFD, 0x96, 0xDB, 0x2A, 0x26
     };
     curve25519_key key;
+#if !defined(HAVE_FIPS) || FIPS_VERSION3_GE(7,0,0)
     byte output[CURVE25519_MAX_KEY_TO_DER_SZ];
+#else
+    byte output[128];
+#endif
     word32 outputSz = (word32)sizeof(output);
     word32 idx;
 

--- a/wolfssl/wolfcrypt/curve25519.h
+++ b/wolfssl/wolfcrypt/curve25519.h
@@ -44,12 +44,7 @@
 
 #define CURVE25519_KEYSIZE 32
 #define CURVE25519_PUB_KEY_SIZE 32
-
-enum {
-    CURVE25519_MAX_KEY_TO_DER_SZ = 82,  /* for exported DER keys temp buffer */
-
-    WOLF_ENUM_DUMMY_LAST_ELEMENT(CURVE25519)
-};
+#define CURVE25519_MAX_KEY_TO_DER_SZ 82 /* for exported DER keys temp buffer */
 
 #ifdef WOLFSSL_NAMES_STATIC
 typedef char curve25519_str[12];


### PR DESCRIPTION
`CURVE25519_MAX_KEY_TO_DER_SZ`: refactor to macro like other `CURVE25519_` constants, and add FIPS clause in `curve255519_der_test()` to accommodate FIPS v6.

tested with `wolfssl-multi-test.sh ... check-source-text linuxkm-6.12-all-cryptonly-aesni-fips-v6-dyn-hash-LKCAPI-insmod`
