### PR TITLE
Regression test fixes

### DIFF
--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -1545,11 +1545,14 @@ static int Dtls13RtxSendBuffered(WOLFSSL* ssl)
     byte* output;
     int isLast;
     int sendSz;
+#ifndef NO_ASN_TIME
     word32 now;
+#endif
     int ret;
 
     WOLFSSL_ENTER("Dtls13RtxSendBuffered");
 
+#ifndef NO_ASN_TIME
     now = LowResTimer();
     if (now - ssl->dtls13Rtx.lastRtx < DTLS13_MIN_RTX_INTERVAL) {
 #ifdef WOLFSSL_DEBUG_TLS
@@ -1559,6 +1562,7 @@ static int Dtls13RtxSendBuffered(WOLFSSL* ssl)
     }
 
     ssl->dtls13Rtx.lastRtx = now;
+#endif
 
     r = ssl->dtls13Rtx.rtxRecords;
     prevNext = &ssl->dtls13Rtx.rtxRecords;

--- a/src/dtls13.c
+++ b/src/dtls13.c
@@ -1959,6 +1959,9 @@ int Dtls13DeriveSnKeys(WOLFSSL* ssl, int provision)
 
 end:
     ForceZero(key_dig, MAX_PRF_DIG);
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    wc_MemZero_Check(key_dig, sizeof(key_dig));
+#endif
     return ret;
 }
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -47887,6 +47887,12 @@ static int test_tls13_apis(void)
 #elif defined(HAVE_ECC)
     const char*  ourCert = eccCertFile;
     const char*  ourKey  = eccKeyFile;
+#elif defined(HAVE_ED25519)
+    const char*  ourCert = edCertFile;
+    const char*  ourKey  = edKeyFile;
+#elif defined(HAVE_ED448)
+    const char*  ourCert = ed448CertFile;
+    const char*  ourKey  = ed448KeyFile;
 #endif
 #endif
 #endif

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -38392,7 +38392,8 @@ static int DecodeBasicOcspResponse(byte* source, word32* ioIndex,
         if (DecodeCerts(source, &idx, resp, size) < 0)
             return ASN_PARSE_E;
 
-        ret = OcspCheckCert(resp, noVerify, noVerifySignature, cm, heap);
+        ret = OcspCheckCert(resp, noVerify, noVerifySignature,
+            (WOLFSSL_CERT_MANAGER*)cm, heap);
         if (ret == 0) {
             sigValid = 1;
         }
@@ -38407,7 +38408,7 @@ static int DecodeBasicOcspResponse(byte* source, word32* ioIndex,
     if (!noVerifySignature && !sigValid) {
         Signer* ca;
         SignatureCtx sigCtx;
-        ca = OcspFindSigner(resp, cm);
+        ca = OcspFindSigner(resp, (WOLFSSL_CERT_MANAGER*)cm);
         if (ca == NULL)
             return ASN_NO_SIGNER_E;
 

--- a/wolfssl/wolfcrypt/mem_track.h
+++ b/wolfssl/wolfcrypt/mem_track.h
@@ -596,7 +596,7 @@ static WC_INLINE int StackSizeCheck(struct func_args* args, thread_func tf)
 #endif
 
 #ifdef PTHREAD_STACK_MIN
-    if (stackSize < PTHREAD_STACK_MIN)
+    if (stackSize < (size_t)PTHREAD_STACK_MIN)
         stackSize = PTHREAD_STACK_MIN;
 #endif
 
@@ -677,7 +677,7 @@ static WC_INLINE int StackSizeCheck_launch(struct func_args* args,
     struct stack_size_debug_context* shim_args;
 
 #ifdef PTHREAD_STACK_MIN
-    if (stackSize < PTHREAD_STACK_MIN)
+    if (stackSize < (size_t)PTHREAD_STACK_MIN)
         stackSize = PTHREAD_STACK_MIN;
 #endif
 


### PR DESCRIPTION
# Description

dtls13.c: LowResTimer() not available when NO_ASN_TIME is defined.
api.c: Add certificate and key to use for when only Ed25519 or Ed448.
asn.c: Casts needed for g++ compile.
mem_track.c: Casts needed for g++ compile.

# Testing

Multiple configurations

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
