### PR TITLE
Fix types.h for MSVC6.0

### DIFF
--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -252,7 +252,8 @@ decouple library dependencies with standard string, memory and so on.
          #endif
     #endif
 
-    #if (defined(_MSC_VER) && !defined(WOLFSSL_NOT_WINDOWS_API)) || \
+    #if (defined(_MSC_VER) && (_MSC_VER == 1200)) ||  /* MSVC6 */ \
+        (defined(_MSC_VER) && !defined(WOLFSSL_NOT_WINDOWS_API)) || \
            defined(__BCPLUSPLUS__) || \
            (defined(__WATCOMC__) && defined(__WATCOM_INT64__))
         /* windows types */


### PR DESCRIPTION
# Description

MSVC6 does not have the "long long" data type. However, MSVC6 does have built-in support for `__int64` and `unsigned __int64`. Windows.h is not necessary for this.

Fixes zd19742

# Testing

Customer conifirmed

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
