### PR TITLE
Add wc_PKCS12_parse_ex() to keep PKCS8 header

### DIFF
--- a/tests/api/test_mldsa.c
+++ b/tests/api/test_mldsa.c
@@ -16793,7 +16793,8 @@ int test_mldsa_pkcs12(void)
     defined(HAVE_DILITHIUM) && !defined(NO_TLS) && \
     !defined(NO_PWDBASED) && !defined(NO_HMAC) && \
     !defined(NO_CERTS) && !defined(NO_DES3) && \
-    (!defined(NO_WOLFSSL_CLIENT) || !defined(NO_WOLFSSL_SERVER))
+    (!defined(NO_WOLFSSL_CLIENT) || !defined(NO_WOLFSSL_SERVER)) && \
+    defined(WOLFSSL_CERT_GEN)
 
     WOLFSSL_CTX* ctx = NULL;
     word32 i;
@@ -16943,7 +16944,6 @@ int test_mldsa_pkcs12(void)
     wolfSSL_CTX_free(ctx);
     XFREE(inCert, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     XFREE(inKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-
 #endif
     return EXPECT_RESULT();
 }

--- a/tests/api/test_mldsa.h
+++ b/tests/api/test_mldsa.h
@@ -36,6 +36,7 @@ int test_wc_dilithium_make_key_from_seed(void);
 int test_wc_dilithium_sig_kats(void);
 int test_wc_dilithium_verify_kats(void);
 int test_mldsa_pkcs8(void);
+int test_mldsa_pkcs12(void);
 
 #define TEST_MLDSA_DECLS                                            \
     TEST_DECL_GROUP("mldsa", test_wc_dilithium),                    \
@@ -49,6 +50,7 @@ int test_mldsa_pkcs8(void);
     TEST_DECL_GROUP("mldsa", test_wc_dilithium_make_key_from_seed), \
     TEST_DECL_GROUP("mldsa", test_wc_dilithium_sig_kats),           \
     TEST_DECL_GROUP("mldsa", test_wc_dilithium_verify_kats),        \
-    TEST_DECL_GROUP("mldsa", test_mldsa_pkcs8)
+    TEST_DECL_GROUP("mldsa", test_mldsa_pkcs8),                     \
+    TEST_DECL_GROUP("mldsa", test_mldsa_pkcs12)
 
 #endif /* WOLFCRYPT_TEST_MLDSA_H */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -9155,9 +9155,12 @@ int wc_GetKeyOID(byte* key, word32 keySz, const byte** curveOID, word32* oidSz,
         if (dilithium == NULL)
             return MEMORY_E;
 
-        if (wc_dilithium_init(dilithium) != 0) {
-            tmpIdx = 0;
-            if (wc_dilithium_set_level(dilithium, WC_ML_DSA_44) == 0) {
+        /* wc_dilithium_init() returns 0 on success and a non-zero value on
+         * failure. */
+        if (wc_dilithium_init(dilithium) == 0) {
+            if ((*algoID == 0) &&
+                (wc_dilithium_set_level(dilithium, WC_ML_DSA_44) == 0)) {
+                tmpIdx = 0;
                 if (wc_Dilithium_PrivateKeyDecode(key, &tmpIdx, dilithium,
                         keySz) == 0) {
                     *algoID = ML_DSA_LEVEL2k;
@@ -9166,7 +9169,9 @@ int wc_GetKeyOID(byte* key, word32 keySz, const byte** curveOID, word32* oidSz,
                     WOLFSSL_MSG("Not Dilithium Level 2 DER key");
                 }
             }
-            else if (wc_dilithium_set_level(dilithium, WC_ML_DSA_65) == 0) {
+            if ((*algoID == 0) &&
+                (wc_dilithium_set_level(dilithium, WC_ML_DSA_65) == 0)) {
+                tmpIdx = 0;
                 if (wc_Dilithium_PrivateKeyDecode(key, &tmpIdx, dilithium,
                         keySz) == 0) {
                     *algoID = ML_DSA_LEVEL3k;
@@ -9175,7 +9180,9 @@ int wc_GetKeyOID(byte* key, word32 keySz, const byte** curveOID, word32* oidSz,
                     WOLFSSL_MSG("Not Dilithium Level 3 DER key");
                 }
             }
-            else if (wc_dilithium_set_level(dilithium, WC_ML_DSA_87) == 0) {
+            if ((*algoID == 0) &&
+                (wc_dilithium_set_level(dilithium, WC_ML_DSA_87) == 0)) {
+                tmpIdx = 0;
                 if (wc_Dilithium_PrivateKeyDecode(key, &tmpIdx, dilithium,
                         keySz) == 0) {
                     *algoID = ML_DSA_LEVEL5k;

--- a/wolfssl/wolfcrypt/pkcs12.h
+++ b/wolfssl/wolfcrypt/pkcs12.h
@@ -55,6 +55,9 @@ WOLFSSL_API int wc_i2d_PKCS12(WC_PKCS12* pkcs12, byte** der, int* derSz);
 WOLFSSL_API int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
         byte** pkey, word32* pkeySz, byte** cert, word32* certSz,
         WC_DerCertList** ca);
+WOLFSSL_API int wc_PKCS12_parse_ex(WC_PKCS12* pkcs12, const char* psw,
+        byte** pkey, word32* pkeySz, byte** cert, word32* certSz,
+        WC_DerCertList** ca, int keepKeyHeader);
 WOLFSSL_LOCAL int wc_PKCS12_verify_ex(WC_PKCS12* pkcs12,
         const byte* psw, word32 pswSz);
 WOLFSSL_API WC_PKCS12* wc_PKCS12_create(char* pass, word32 passSz,


### PR DESCRIPTION
# Description

This PR introduces the `wc_PKCS12_parse_ex()`.
It's for keeping PKCS8 header instead of existing the `wc_PKCS12_parse()` which removes the header.
Keeping the header makes passing a private key DER to some functions like `wolfSSL_CTX_use_PrivateKey_buffer()` easier.

Small bug fix of the `wc_GetKeyOID()` is side effect when creating tests.

# Testing

./configure --enable-dilithium --enable-asn --enable-keygen --enable-debug -enable-des3 -enable-pkcs12 -enable-certgen && make test

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation