### PR TITLE
ECC non-blocking: make sp_ecc_ctx data aligned

### DIFF
--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -387,11 +387,11 @@ extern "C" {
 /* Non-blocking ECC operation context. */
 typedef struct sp_ecc_ctx {
     #ifdef WOLFSSL_SP_521
-    byte data[66*80]; /* stack data */
+    XALIGNED(4) byte data[66*80]; /* stack data */
     #elif defined(WOLFSSL_SP_384)
-    byte data[48*80]; /* stack data */
+    XALIGNED(4) byte data[48*80]; /* stack data */
     #else
-    byte data[32*80]; /* stack data */
+    XALIGNED(4) byte data[32*80]; /* stack data */
     #endif
 } sp_ecc_ctx_t;
 #endif


### PR DESCRIPTION
# Description

Align data on 4 byte boundary for ARM chips.

Fixes zd#19756

# Testing

./configure --disable-shared LDFLAGS=--static --host=thumb CC=arm-linux-gnueabi-gcc --enable-sp=nonblock
still compiles/

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
