### PR TITLE
20250416-linuxkm-FIPS-wrappers

### DIFF
--- a/linuxkm/lkcapi_ecdh_glue.c
+++ b/linuxkm/lkcapi_ecdh_glue.c
@@ -523,8 +523,10 @@ static int km_ecdh_compute_shared_secret(struct kpp_request *req)
         goto ecdh_shared_secret_end;
     }
 
+    PRIVATE_KEY_UNLOCK();
     err = wc_ecc_shared_secret(ctx->key, ecc_pub, shared_secret,
                                &shared_secret_len);
+    PRIVATE_KEY_LOCK();
 
     if (unlikely(err || shared_secret_len != ctx->curve_len)) {
         #ifdef WOLFKM_DEBUG_ECDH

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -27,8 +27,6 @@
 #endif
 #endif
 
-#define FIPS_NO_WRAPPERS
-
 #define WOLFSSL_LINUXKM_NEED_LINUX_CURRENT
 
 #include <wolfssl/wolfcrypt/libwolfssl_sources.h>


### PR DESCRIPTION
`linuxkm/module_hooks.c`: don't define `FIPS_NO_WRAPPERS`;

`linuxkm/lkcapi_ecdh_glue.c`: in `km_ecdh_compute_shared_secret()`, wrap `wc_ecc_shared_secret()` in `PRIVATE_KEY_UNLOCK`...`PRIVATE_KEY_LOCK`.

tested with `wolfssl-multi-test.sh ... check-source-text quantum-safe-wolfssl-all-crypto-only-intelasm-sp-asm-linuxkm-insmod 'linuxkm-6.12-all-cryptonly.*' 'linuxkm-.*fips.*(ksanitizer|kmemleak)'`
