### PR TITLE
20250417-LINUXKM_DIRECT_RSA

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9404,7 +9404,7 @@ then
     for lkcapi_alg in $(echo "$ENABLED_LINUXKM_LKCAPI_REGISTER" | tr ',' ' ')
     do
         case "$lkcapi_alg" in
-        all) AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_REGISTER_ALL"           ;;
+        all) AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_REGISTER_ALL -DWC_RSA_NO_PADDING" ;;
         'cbc(aes)') test "$ENABLED_AESCBC" != "no" || AC_MSG_ERROR([linuxkm-lkcapi-register ${lkcapi_alg}: AES-CBC implementation not enabled.])
                     AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_REGISTER_AESCBC" ;;
         'cfb(aes)') test "$ENABLED_AESCFB" != "no" || AC_MSG_ERROR([linuxkm-lkcapi-register ${lkcapi_alg}: AES-CFB implementation not enabled.])
@@ -9425,7 +9425,7 @@ then
                     AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_REGISTER_ECDSA" ;;
         'ecdh')     AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_REGISTER_ECDH" ;;
         'rsa')      test "$ENABLED_RSA" != "no" || AC_MSG_ERROR([linuxkm-lkcapi-register ${lkcapi_alg}: RSA implementation not enabled.])
-                    AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_REGISTER_RSA" ;;
+                    AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_REGISTER_RSA -DWC_RSA_NO_PADDING" ;;
         # disable options
         '-cbc(aes)') AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_DONT_REGISTER_AESCBC" ;;
         '-cfb(aes)') AM_CFLAGS="$AM_CFLAGS -DLINUXKM_LKCAPI_DONT_REGISTER_AESCFB" ;;

--- a/linuxkm/lkcapi_rsa_glue.c
+++ b/linuxkm/lkcapi_rsa_glue.c
@@ -33,11 +33,9 @@
     #error LINUXKM_LKCAPI_REGISTER_RSA and RSA_VERIFY_ONLY not supported
 #endif /* WOLFSSL_RSA_VERIFY_ONLY || WOLFSSL_RSA_PUBLIC_ONLY */
 
-#if defined(WC_RSA_DIRECT) || defined(WC_RSA_NO_PADDING) || \
-    defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+#ifdef WC_RSA_NO_PADDING
     #define LINUXKM_DIRECT_RSA
-#endif /* WC_RSA_DIRECT || WC_RSA_NO_PADDING || OPENSSL_EXTRA ||
-        * OPENSSL_EXTRA_X509_SMALL */
+#endif /* WC_RSA_NO_PADDING */
 
 #include <wolfssl/wolfcrypt/asn.h>
 #include <wolfssl/wolfcrypt/rsa.h>


### PR DESCRIPTION
`linuxkm/lkcapi_rsa_glue.c`: gate `LINUXKM_DIRECT_RSA` directly on `WC_RSA_NO_PADDING`;

`configure.ac`: always pass `-DWC_RSA_NO_PADDING` for `--enable-linuxkm-lkcapi-register=rsa` or `=all`.

tested with `wolfssl-multi-test.sh ... linuxkm linuxkm-all-aesni-insmod linuxkm-aescbc-cryptonly-noasm-fips-v5-dyn-hash-LKCAPI-yes-twc-insmod linuxkm-all-asm-cryptonly-opensslextra-pie check-source-text`
