### PR TITLE
20250418-linuxkm-lkcapi-cleanup

### DIFF
--- a/linuxkm/lkcapi_ecdh_glue.c
+++ b/linuxkm/lkcapi_ecdh_glue.c
@@ -133,7 +133,7 @@ static struct kpp_alg ecdh_nist_p384 = {
     .exit                  = km_ecdh_exit,
 };
 
-/**
+/*
  * Set the secret. Kernel crypto expects secret is passed with
  * struct kpp_secret as header, followed by secret data as payload.
  * See these for more info:
@@ -141,7 +141,7 @@ static struct kpp_alg ecdh_nist_p384 = {
  *  - include/crypto/kpp.h
  *
  * An empty payload means this function will gen the ecc key pair.
- * */
+ */
 static int km_ecdh_set_secret(struct crypto_kpp *tfm, const void *buf,
                               unsigned int len)
 {
@@ -360,12 +360,12 @@ static int km_ecdh_nist_p384_init(struct crypto_kpp *tfm)
     return km_ecdh_init(tfm, ECC_SECP384R1);
 }
 
-/**
+/*
  * Generate the ecc public key:
  *   - req->src should be null
  *   - req->dst is where we place the public key.
  * The kernel api expects raw uncompressed pub key, without leading byte.
- * */
+ */
 static int km_ecdh_gen_pub(struct kpp_request *req)
 {
     struct crypto_kpp *  tfm = NULL;
@@ -463,11 +463,11 @@ ecdh_gen_pub_end:
     return err;
 }
 
-/**
+/*
  * Generate ecc shared secret.
  *   - req->src has raw pub key from other party.
  *   - req->dst is shared secret output buffer.
- * */
+ */
 static int km_ecdh_compute_shared_secret(struct kpp_request *req)
 {
     struct crypto_kpp *  tfm = NULL;
@@ -596,7 +596,7 @@ static int linuxkm_test_ecdh_nist_p192(void)
 {
     int rc = 0;
     /* reference values from kernel crypto/testmgr.h */
-    const byte secret[] = {
+    static const byte secret[] = {
 #ifdef LITTLE_ENDIAN_ORDER
         0x02, 0x00, /* type */
         0x1e, 0x00, /* len */
@@ -613,7 +613,7 @@ static int linuxkm_test_ecdh_nist_p192(void)
     };
 
     /* 48 byte pub key */
-    const byte b_pub[] = {
+    static const byte b_pub[] = {
         0xc3, 0xba, 0x67, 0x4b, 0x71, 0xec, 0xd0, 0x76,
         0x7a, 0x99, 0x75, 0x64, 0x36, 0x13, 0x9a, 0x94,
         0x5d, 0x8b, 0xdc, 0x60, 0x90, 0x91, 0xfd, 0x3f,
@@ -622,7 +622,7 @@ static int linuxkm_test_ecdh_nist_p192(void)
         0x07, 0xd6, 0xbd, 0x1c, 0xe6, 0x8d, 0x9d, 0x67
     };
 
-    const byte expected_a_pub[] = {
+    static const byte expected_a_pub[] = {
         0x1a, 0x04, 0xdb, 0xa5, 0xe1, 0xdd, 0x4e, 0x79,
         0xa3, 0xe6, 0xef, 0x0e, 0x5c, 0x80, 0x49, 0x85,
         0xfa, 0x78, 0xb4, 0xef, 0x49, 0xbd, 0x4c, 0x7c,
@@ -632,7 +632,7 @@ static int linuxkm_test_ecdh_nist_p192(void)
     };
 
     /* 24 byte shared secret */
-    const byte shared_secret[] = {
+    static const byte shared_secret[] = {
         0xf4, 0x57, 0xcc, 0x4f, 0x1f, 0x4e, 0x31, 0xcc,
         0xe3, 0x40, 0x60, 0xc8, 0x06, 0x93, 0xc6, 0x2e,
         0x99, 0x80, 0x81, 0x28, 0xaf, 0xc5, 0x51, 0x74
@@ -651,7 +651,7 @@ static int linuxkm_test_ecdh_nist_p256(void)
 {
     int rc = 0;
     /* reference values from kernel crypto/testmgr.h */
-    const byte secret[] = {
+    static const byte secret[] = {
 #ifdef LITTLE_ENDIAN_ORDER
         0x02, 0x00, /* type */
         0x26, 0x00, /* len */
@@ -668,7 +668,7 @@ static int linuxkm_test_ecdh_nist_p256(void)
     };
 
     /* 64 byte pub key */
-    const byte b_pub[] = {
+    static const byte b_pub[] = {
         0xcc, 0xb4, 0xda, 0x74, 0xb1, 0x47, 0x3f, 0xea,
         0x6c, 0x70, 0x9e, 0x38, 0x2d, 0xc7, 0xaa, 0xb7,
         0x29, 0xb2, 0x47, 0x03, 0x19, 0xab, 0xdd, 0x34,
@@ -679,7 +679,7 @@ static int linuxkm_test_ecdh_nist_p256(void)
         0x6f, 0xdb, 0xa9, 0xaa, 0xfc, 0x77, 0x81, 0xf3,
     };
 
-    const byte expected_a_pub[] = {
+    static const byte expected_a_pub[] = {
         0x1a, 0x7f, 0xeb, 0x52, 0x00, 0xbd, 0x3c, 0x31,
         0x7d, 0xb6, 0x70, 0xc1, 0x86, 0xa6, 0xc7, 0xc4,
         0x3b, 0xc5, 0x5f, 0x6c, 0x6f, 0x58, 0x3c, 0xf5,
@@ -691,7 +691,7 @@ static int linuxkm_test_ecdh_nist_p256(void)
     };
 
     /* 32 byte shared secret */
-    const byte shared_secret[] = {
+    static const byte shared_secret[] = {
         0xea, 0x17, 0x6f, 0x7e, 0x6e, 0x57, 0x26, 0x38,
         0x8b, 0xfb, 0x41, 0xeb, 0xba, 0xc8, 0x6d, 0xa5,
         0xa8, 0x72, 0xd1, 0xff, 0xc9, 0x47, 0x3d, 0xaa,
@@ -710,7 +710,7 @@ static int linuxkm_test_ecdh_nist_p384(void)
 {
     int rc = 0;
     /* reference values from kernel crypto/testmgr.h */
-    const byte secret[] = {
+    static const byte secret[] = {
 #ifdef LITTLE_ENDIAN_ORDER
         0x02, 0x00, /* type */
         0x36, 0x00, /* len */
@@ -729,7 +729,7 @@ static int linuxkm_test_ecdh_nist_p384(void)
     };
 
     /* 96 byte pub key */
-    const byte b_pub[] = {
+    static const byte b_pub[] = {
         0xE5, 0x58, 0xDB, 0xEF, 0x53, 0xEE, 0xCD, 0xE3,
         0xD3, 0xFC, 0xCF, 0xC1, 0xAE, 0xA0, 0x8A, 0x89,
         0xA9, 0x87, 0x47, 0x5D, 0x12, 0xFD, 0x95, 0x0D,
@@ -745,7 +745,7 @@ static int linuxkm_test_ecdh_nist_p384(void)
     };
 
     /* 96 byte pub key */
-    const byte expected_a_pub[] = {
+    static const byte expected_a_pub[] = {
         0x66, 0x78, 0x42, 0xD7, 0xD1, 0x80, 0xAC, 0x2C,
         0xDE, 0x6F, 0x74, 0xF3, 0x75, 0x51, 0xF5, 0x57,
         0x55, 0xC7, 0x64, 0x5C, 0x20, 0xEF, 0x73, 0xE3,
@@ -761,7 +761,7 @@ static int linuxkm_test_ecdh_nist_p384(void)
     };
 
     /* 48 byte shared secret */
-    const byte shared_secret[] = {
+    static const byte shared_secret[] = {
         0x11, 0x18, 0x73, 0x31, 0xC2, 0x79, 0x96, 0x2D,
         0x93, 0xD6, 0x04, 0x24, 0x3F, 0xD5, 0x92, 0xCB,
         0x9D, 0x0A, 0x92, 0x6F, 0x42, 0x2E, 0x47, 0x18,
@@ -796,10 +796,10 @@ static int linuxkm_test_ecdh_nist_driver(const char * driver,
     byte *               dst_buf = NULL;
     unsigned int         src_len = pub_len;
     unsigned int         dst_len = 0;
-    /**
+    /*
      * Allocate the kpp transform, and set up
      * the kpp request.
-     * */
+     */
     tfm = crypto_alloc_kpp(driver, 0, 0);
     if (IS_ERR(tfm)) {
         pr_err("error: allocating kpp algorithm %s failed: %ld\n",

--- a/linuxkm/lkcapi_glue.c
+++ b/linuxkm/lkcapi_glue.c
@@ -26,6 +26,10 @@
     #error lkcapi_glue.c included in non-LINUXKM_LKCAPI_REGISTER project.
 #endif
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 0)
+    #error LINUXKM_LKCAPI_REGISTER is supported only on Linux kernel versions >= 5.4.0.
+#endif
+
 /* kernel crypto self-test includes test setups that have different expected
  * results FIPS vs non-FIPS.
  */
@@ -48,16 +52,16 @@
 #endif
 
 #ifndef WOLFSSL_LINUXKM_LKCAPI_PRIORITY
-/* Larger number means higher priority.  The highest in-tree priority is 4001,
- * in the Cavium driver.
- */
-#define WOLFSSL_LINUXKM_LKCAPI_PRIORITY 10000
+    /* Larger number means higher priority.  The highest in-tree priority is
+     * 4001, in the Cavium driver.
+     */
+    #define WOLFSSL_LINUXKM_LKCAPI_PRIORITY 10000
 #endif
 
 #ifdef CONFIG_CRYPTO_MANAGER_EXTRA_TESTS
-static int disable_setkey_warnings = 0;
+    static int disable_setkey_warnings = 0;
 #else
-#define disable_setkey_warnings 0
+    #define disable_setkey_warnings 0
 #endif
 
 #ifdef HAVE_FIPS
@@ -239,9 +243,9 @@ WC_MAYBE_UNUSED static int check_shash_driver_masking(struct crypto_shash *tfm, 
     #undef LINUXKM_LKCAPI_REGISTER_RSA
 #endif /* !NO_RSA */
 
-/**
+/*
  * extra checks on kernel version, and ecc sizes.
- * */
+ */
 #if defined (LINUXKM_LKCAPI_REGISTER_ECDSA)
     #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0) && \
         defined(CONFIG_CRYPTO_FIPS) && defined(CONFIG_CRYPTO_MANAGER)
@@ -388,7 +392,6 @@ static int linuxkm_lkcapi_register(void)
 #ifdef LINUXKM_LKCAPI_REGISTER_SHA1
     REGISTER_ALG(sha1_alg, crypto_register_shash, linuxkm_test_sha1);
 #endif
-
 #ifdef LINUXKM_LKCAPI_REGISTER_SHA2_224
     REGISTER_ALG(sha2_224_alg, crypto_register_shash, linuxkm_test_sha2_224);
 #endif
@@ -541,7 +544,6 @@ static void linuxkm_lkcapi_unregister(void)
 #ifdef LINUXKM_LKCAPI_REGISTER_SHA1
     UNREGISTER_ALG(sha1_alg, crypto_unregister_shash);
 #endif
-
 #ifdef LINUXKM_LKCAPI_REGISTER_SHA2_224
     UNREGISTER_ALG(sha2_224_alg, crypto_unregister_shash);
 #endif
@@ -595,21 +597,20 @@ static void linuxkm_lkcapi_unregister(void)
     UNREGISTER_ALG(sha3_512_hmac_alg, crypto_unregister_shash);
 #endif
 
-
 #ifdef LINUXKM_LKCAPI_REGISTER_ECDSA
     #if defined(LINUXKM_ECC192)
-    UNREGISTER_ALG(ecdsa_nist_p192, crypto_unregister_akcipher);
+        UNREGISTER_ALG(ecdsa_nist_p192, crypto_unregister_akcipher);
     #endif /* LINUXKM_ECC192 */
     UNREGISTER_ALG(ecdsa_nist_p256, crypto_unregister_akcipher);
     UNREGISTER_ALG(ecdsa_nist_p384, crypto_unregister_akcipher);
     #if defined(HAVE_ECC521)
-    UNREGISTER_ALG(ecdsa_nist_p521, crypto_unregister_akcipher);
+        UNREGISTER_ALG(ecdsa_nist_p521, crypto_unregister_akcipher);
     #endif /* HAVE_ECC521 */
 #endif /* LINUXKM_LKCAPI_REGISTER_ECDSA */
 
 #ifdef LINUXKM_LKCAPI_REGISTER_ECDH
     #if defined(LINUXKM_ECC192)
-    UNREGISTER_ALG(ecdh_nist_p192, crypto_unregister_kpp);
+        UNREGISTER_ALG(ecdh_nist_p192, crypto_unregister_kpp);
     #endif /* LINUXKM_ECC192 */
     UNREGISTER_ALG(ecdh_nist_p256, crypto_unregister_kpp);
     UNREGISTER_ALG(ecdh_nist_p384, crypto_unregister_kpp);
@@ -618,13 +619,13 @@ static void linuxkm_lkcapi_unregister(void)
 
 #ifdef LINUXKM_LKCAPI_REGISTER_RSA
     #if defined(LINUXKM_DIRECT_RSA)
-    UNREGISTER_ALG(direct_rsa, crypto_unregister_akcipher);
+        UNREGISTER_ALG(direct_rsa, crypto_unregister_akcipher);
     #endif /* LINUXKM_DIRECT_RSA */
     #ifndef NO_SHA256
-    UNREGISTER_ALG(pkcs1_sha256, crypto_unregister_akcipher);
+        UNREGISTER_ALG(pkcs1_sha256, crypto_unregister_akcipher);
     #endif /* !NO_SHA256 */
     #ifdef WOLFSSL_SHA512
-    UNREGISTER_ALG(pkcs1_sha512, crypto_unregister_akcipher);
+        UNREGISTER_ALG(pkcs1_sha512, crypto_unregister_akcipher);
     #endif /* WOLFSSL_SHA512 */
 #endif /* LINUXKM_LKCAPI_REGISTER_RSA */
 

--- a/linuxkm/lkcapi_rsa_glue.c
+++ b/linuxkm/lkcapi_rsa_glue.c
@@ -52,21 +52,21 @@
                                     "-wolfcrypt,sha512)")
 
 #if defined(WOLFSSL_KEY_GEN)
-#if defined(LINUXKM_DIRECT_RSA)
-static int  linuxkm_test_rsa_driver(const char * driver, int nbits);
-#endif /* LINUXKM_DIRECT_RSA */
-static int  linuxkm_test_pkcs1_driver(const char * driver, int nbits,
-                                      int hash_oid, word32 hash_len);
+    #if defined(LINUXKM_DIRECT_RSA)
+        static int  linuxkm_test_rsa_driver(const char * driver, int nbits);
+    #endif /* LINUXKM_DIRECT_RSA */
+    static int  linuxkm_test_pkcs1_driver(const char * driver, int nbits,
+                                          int hash_oid, word32 hash_len);
 #endif /* WOLFSSL_KEY_GEN */
 
 #if defined(LINUXKM_DIRECT_RSA)
-static int direct_rsa_loaded = 0;
+    static int direct_rsa_loaded = 0;
 #endif /* LINUXKM_DIRECT_RSA */
 #ifndef NO_SHA256
-static int pkcs1_sha256_loaded = 0;
+    static int pkcs1_sha256_loaded = 0;
 #endif /* !NO_SHA256 */
 #ifdef WOLFSSL_SHA512
-static int pkcs1_sha512_loaded = 0;
+    static int pkcs1_sha512_loaded = 0;
 #endif /* WOLFSSL_SHA512 */
 
 struct km_rsa_ctx {
@@ -87,28 +87,28 @@ static int          km_rsa_set_pub(struct crypto_akcipher *tfm,
 static unsigned int km_rsa_max_size(struct crypto_akcipher *tfm);
 
 #if defined(LINUXKM_DIRECT_RSA)
-/* direct rsa callbacks */
-static int          km_direct_rsa_init(struct crypto_akcipher *tfm);
-static int          km_direct_rsa_enc(struct akcipher_request *req);
-static int          km_direct_rsa_dec(struct akcipher_request *req);
+    /* direct rsa callbacks */
+    static int          km_direct_rsa_init(struct crypto_akcipher *tfm);
+    static int          km_direct_rsa_enc(struct akcipher_request *req);
+    static int          km_direct_rsa_dec(struct akcipher_request *req);
 #endif /* LINUXKM_DIRECT_RSA */
 
 /* pkcs1 callbacks */
 #ifndef NO_SHA256
-static int          km_pkcs1_sha256_init(struct crypto_akcipher *tfm);
+    static int          km_pkcs1_sha256_init(struct crypto_akcipher *tfm);
 #endif /* !NO_SHA256 */
 #ifdef WOLFSSL_SHA512
-static int          km_pkcs1_sha512_init(struct crypto_akcipher *tfm);
+    static int          km_pkcs1_sha512_init(struct crypto_akcipher *tfm);
 #endif /* WOLFSSL_SHA512 */
 #if !defined(LINUXKM_AKCIPHER_NO_SIGNVERIFY)
-static int          km_pkcs1_sign(struct akcipher_request *req);
-static int          km_pkcs1_verify(struct akcipher_request *req);
+    static int          km_pkcs1_sign(struct akcipher_request *req);
+    static int          km_pkcs1_verify(struct akcipher_request *req);
 #endif /* !LINUXKM_AKCIPHER_NO_SIGNVERIFY */
-static int          km_pkcs1_enc(struct akcipher_request *req);
-static int          km_pkcs1_dec(struct akcipher_request *req);
+    static int          km_pkcs1_enc(struct akcipher_request *req);
+    static int          km_pkcs1_dec(struct akcipher_request *req);
 /* misc */
 #if !defined(LINUXKM_AKCIPHER_NO_SIGNVERIFY)
-static int          get_hash_enc_len(int hash_oid);
+    static int          get_hash_enc_len(int hash_oid);
 #endif /* !LINUXKM_AKCIPHER_NO_SIGNVERIFY */
 
 #if defined(LINUXKM_DIRECT_RSA)
@@ -231,7 +231,7 @@ static int km_rsa_init(struct crypto_akcipher *tfm, int hash_oid)
 }
 
 #if defined(LINUXKM_DIRECT_RSA)
-/**
+/*
  * RSA encrypt with public key.
  *
  * Requires that crypto_akcipher_set_pub_key has been called first.
@@ -242,7 +242,7 @@ static int km_rsa_init(struct crypto_akcipher *tfm, int hash_oid)
  *
  * returns 0   on success
  * returns < 0 on error
- * */
+ */
 static int km_direct_rsa_enc(struct akcipher_request *req)
 {
     struct crypto_akcipher * tfm = NULL;
@@ -321,14 +321,14 @@ rsa_enc_out:
     return err;
 }
 
-/**
+/*
  * RSA decrypt with private key.
  *
  * Requires that crypto_akcipher_set_priv_key has been called first.
  *
  * returns 0   on success
  * returns < 0 on error
- * */
+ */
 static int km_direct_rsa_dec(struct akcipher_request *req)
 {
     struct crypto_akcipher * tfm = NULL;
@@ -412,13 +412,13 @@ rsa_dec_out:
 }
 #endif /* LINUXKM_DIRECT_RSA */
 
-/**
+/*
  * Decodes and sets the RSA private key.
  *
  * param tfm     the crypto_akcipher transform
  * param key     BER encoded private key and parameters
  * param keylen  key length
- * */
+ */
 static int km_rsa_set_priv(struct crypto_akcipher *tfm, const void *key,
                             unsigned int keylen)
 {
@@ -472,13 +472,13 @@ static int km_rsa_set_priv(struct crypto_akcipher *tfm, const void *key,
     return err;
 }
 
-/**
+/*
  * Decodes and sets the RSA pub key.
  *
  * param tfm     the crypto_akcipher transform
  * param key     BER encoded pub key and parameters
  * param keylen  key length
- * */
+ */
 static int km_rsa_set_pub(struct crypto_akcipher *tfm, const void *key,
                            unsigned int keylen)
 {
@@ -527,9 +527,9 @@ static int km_rsa_set_pub(struct crypto_akcipher *tfm, const void *key,
     return err;
 }
 
-/**
+/*
  * Returns dest buffer size required for key.
- * */
+ */
 static unsigned int km_rsa_max_size(struct crypto_akcipher *tfm)
 {
     struct km_rsa_ctx * ctx = NULL;
@@ -677,7 +677,7 @@ pkcs1_sign_out:
     return err;
 }
 
-/**
+/*
  * Verify a pkcs1 encoded signature.
  *
  * The total size of req->src is src_len + dst_len:
@@ -687,7 +687,7 @@ pkcs1_sign_out:
  * dst should be null.
  * See kernel:
  *   - include/crypto/akcipher.h
- * */
+ */
 static int km_pkcs1_verify(struct akcipher_request *req)
 {
     struct crypto_akcipher * tfm = NULL;
@@ -944,9 +944,9 @@ pkcs1_dec_out:
 }
 
 #if defined(LINUXKM_DIRECT_RSA) && defined(WC_RSA_NO_PADDING)
-/**
+/*
  * Tests implemented below.
- * */
+ */
 static int linuxkm_test_rsa(void)
 {
     int rc = 0;
@@ -1062,7 +1062,7 @@ static int linuxkm_test_pkcs1_sha512(void)
 #endif /* WOLFSSL_SHA512 */
 
 #if defined(LINUXKM_DIRECT_RSA) && defined(WOLFSSL_KEY_GEN)
-/**
+/*
  * Test linux kernel crypto driver:
  *   1. generate RSA key with wolfcrypt.
  *   2. sanity check wolfcrypt encrypt + decrypt.
@@ -1071,7 +1071,7 @@ static int linuxkm_test_pkcs1_sha512(void)
  *      crypto_akcipher_set_pub_key, crypto_akcipher_set_priv_key.
  *   5. test: kernel public encrypt + wolfcrypt private decrypt
  *   6. test: wolfcrypt public encrypt + kernel private decrypt
- * */
+ */
 static int linuxkm_test_rsa_driver(const char * driver, int nbits)
 {
     int                       test_rc = -1;
@@ -1410,7 +1410,7 @@ static int linuxkm_test_pkcs1_driver(const char * driver, int nbits,
         0x66,0x6f,0x72,0x20,0x61,0x6c,0x6c,0x20,
         0x67,0x6f,0x6f,0x64,0x20,0x6d,0x65,0x6e
     };
-    byte                      hash[WC_SHA512_DIGEST_SIZE];
+    byte *                    hash = NULL;
     byte *                    sig = NULL;
     byte *                    km_sig = NULL;
     byte *                    dec = NULL;
@@ -1425,6 +1425,12 @@ static int linuxkm_test_pkcs1_driver(const char * driver, int nbits,
     struct scatterlist        src_tab[2];
     #endif /* !LINUXKM_AKCIPHER_NO_SIGNVERIFY */
     int                       n_diff = 0;
+
+    hash = malloc(WC_SHA512_DIGEST_SIZE);
+    if (! hash) {
+        pr_err("error: allocating hash buffer failed.\n");
+        goto test_pkcs1_end;
+    }
 
     /* hash the test msg with hash algo. */
     ret = wc_Hash(wc_OidGetHash(hash_oid), p_vector, sizeof(p_vector),
@@ -1798,6 +1804,8 @@ test_pkcs1_end:
 
     if (key) { free(key); key = NULL; }
 
+    if (hash) { free(hash); }
+
     #ifdef WOLFKM_DEBUG_RSA
     pr_info("info: %s, %d, %d: self test returned: %d\n", driver,
             nbits, key_len, ret);
@@ -1807,9 +1815,9 @@ test_pkcs1_end:
 }
 #endif /* (!NO_SHA256 || WOLFSSL_SHA512) && WOLFSSL_KEY_GEN */
 
-/**
+/*
  * returns the additional encoding length for given hash oid.
- * */
+ */
 #if !defined(LINUXKM_AKCIPHER_NO_SIGNVERIFY)
 static int get_hash_enc_len(int hash_oid)
 {

--- a/linuxkm/lkcapi_sha_glue.c
+++ b/linuxkm/lkcapi_sha_glue.c
@@ -209,41 +209,43 @@
 #endif
 
 #ifdef WOLFSSL_SHA3
-    #if (defined(LINUXKM_LKCAPI_REGISTER_ALL) && !defined(LINUXKM_LKCAPI_DONT_REGISTER_SHA3_224)) && \
-        !defined(LINUXKM_LKCAPI_REGISTER_SHA3_224)
-        #define LINUXKM_LKCAPI_REGISTER_SHA3_224
-    #endif
-    #if (defined(LINUXKM_LKCAPI_REGISTER_ALL) && !defined(LINUXKM_LKCAPI_DONT_REGISTER_SHA3_256)) && \
-        !defined(LINUXKM_LKCAPI_REGISTER_SHA3_256)
-        #define LINUXKM_LKCAPI_REGISTER_SHA3_256
-    #endif
-    #if (defined(LINUXKM_LKCAPI_REGISTER_ALL) && !defined(LINUXKM_LKCAPI_DONT_REGISTER_SHA3_384)) && \
-        !defined(LINUXKM_LKCAPI_REGISTER_SHA3_384)
-        #define LINUXKM_LKCAPI_REGISTER_SHA3_384
-    #endif
-    #if (defined(LINUXKM_LKCAPI_REGISTER_ALL) && !defined(LINUXKM_LKCAPI_DONT_REGISTER_SHA3_512)) && \
-        !defined(LINUXKM_LKCAPI_REGISTER_SHA3_512)
-        #define LINUXKM_LKCAPI_REGISTER_SHA3_512
+    #ifdef LINUXKM_LKCAPI_REGISTER_ALL
+        #if !defined(LINUXKM_LKCAPI_DONT_REGISTER_SHA3_224) && \
+            !defined(LINUXKM_LKCAPI_REGISTER_SHA3_224)
+            #define LINUXKM_LKCAPI_REGISTER_SHA3_224
+        #endif
+        #if !defined(LINUXKM_LKCAPI_DONT_REGISTER_SHA3_256) && \
+            !defined(LINUXKM_LKCAPI_REGISTER_SHA3_256)
+            #define LINUXKM_LKCAPI_REGISTER_SHA3_256
+        #endif
+        #if !defined(LINUXKM_LKCAPI_DONT_REGISTER_SHA3_384) && \
+            !defined(LINUXKM_LKCAPI_REGISTER_SHA3_384)
+            #define LINUXKM_LKCAPI_REGISTER_SHA3_384
+        #endif
+        #if !defined(LINUXKM_LKCAPI_DONT_REGISTER_SHA3_512) && \
+            !defined(LINUXKM_LKCAPI_REGISTER_SHA3_512)
+            #define LINUXKM_LKCAPI_REGISTER_SHA3_512
+        #endif
     #endif
     #ifdef NO_HMAC
         #undef LINUXKM_LKCAPI_REGISTER_SHA3_224_HMAC
         #undef LINUXKM_LKCAPI_REGISTER_SHA3_256_HMAC
         #undef LINUXKM_LKCAPI_REGISTER_SHA3_384_HMAC
         #undef LINUXKM_LKCAPI_REGISTER_SHA3_512_HMAC
-    #else
-        #if (defined(LINUXKM_LKCAPI_REGISTER_ALL) && !defined(LINUXKM_LKCAPI_DONT_REGISTER_SHA3_224_HMAC)) && \
+    #elif defined(LINUXKM_LKCAPI_REGISTER_ALL)
+        #if !defined(LINUXKM_LKCAPI_DONT_REGISTER_SHA3_224_HMAC) && \
             !defined(LINUXKM_LKCAPI_REGISTER_SHA3_224_HMAC)
             #define LINUXKM_LKCAPI_REGISTER_SHA3_224_HMAC
         #endif
-        #if (defined(LINUXKM_LKCAPI_REGISTER_ALL) && !defined(LINUXKM_LKCAPI_DONT_REGISTER_SHA3_256_HMAC)) && \
+        #if !defined(LINUXKM_LKCAPI_DONT_REGISTER_SHA3_256_HMAC) && \
             !defined(LINUXKM_LKCAPI_REGISTER_SHA3_256_HMAC)
             #define LINUXKM_LKCAPI_REGISTER_SHA3_256_HMAC
         #endif
-        #if (defined(LINUXKM_LKCAPI_REGISTER_ALL) && !defined(LINUXKM_LKCAPI_DONT_REGISTER_SHA3_384_HMAC)) && \
+        #if !defined(LINUXKM_LKCAPI_DONT_REGISTER_SHA3_384_HMAC) && \
             !defined(LINUXKM_LKCAPI_REGISTER_SHA3_384_HMAC)
             #define LINUXKM_LKCAPI_REGISTER_SHA3_384_HMAC
         #endif
-        #if (defined(LINUXKM_LKCAPI_REGISTER_ALL) && !defined(LINUXKM_LKCAPI_DONT_REGISTER_SHA3_512_HMAC)) && \
+        #if !defined(LINUXKM_LKCAPI_DONT_REGISTER_SHA3_512_HMAC) && \
             !defined(LINUXKM_LKCAPI_REGISTER_SHA3_512_HMAC)
             #define LINUXKM_LKCAPI_REGISTER_SHA3_512_HMAC
         #endif
@@ -257,6 +259,19 @@
     #undef LINUXKM_LKCAPI_REGISTER_SHA3_256_HMAC
     #undef LINUXKM_LKCAPI_REGISTER_SHA3_384_HMAC
     #undef LINUXKM_LKCAPI_REGISTER_SHA3_512_HMAC
+#endif
+
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 6, 0)) &&  \
+    (defined(LINUXKM_LKCAPI_REGISTER_SHA1_HMAC) ||     \
+     defined(LINUXKM_LKCAPI_REGISTER_SHA2_224_HMAC) || \
+     defined(LINUXKM_LKCAPI_REGISTER_SHA2_256_HMAC) || \
+     defined(LINUXKM_LKCAPI_REGISTER_SHA2_384_HMAC) || \
+     defined(LINUXKM_LKCAPI_REGISTER_SHA2_512_HMAC) || \
+     defined(LINUXKM_LKCAPI_REGISTER_SHA3_224_HMAC) || \
+     defined(LINUXKM_LKCAPI_REGISTER_SHA3_256_HMAC) || \
+     defined(LINUXKM_LKCAPI_REGISTER_SHA3_384_HMAC) || \
+     defined(LINUXKM_LKCAPI_REGISTER_SHA3_512_HMAC))
+    #error LINUXKM_LKCAPI_REGISTER for HMACs is supported only on Linux kernel versions >= 5.6.0.
 #endif
 
 struct km_sha_state {
@@ -326,7 +341,7 @@ static int km_ ## name ## _init(struct shash_desc *desc) {                 \
         return 0;                                                          \
     else                                                                   \
         return -EINVAL;                                                    \
-    }                                                                      \
+}                                                                          \
                                                                            \
 static int km_ ## name ## _update(struct shash_desc *desc, const u8 *data, \
                                   unsigned int len)                        \
@@ -339,7 +354,7 @@ static int km_ ## name ## _update(struct shash_desc *desc, const u8 *data, \
         return 0;                                                          \
     else                                                                   \
         return -EINVAL;                                                    \
-    }                                                                      \
+}                                                                          \
                                                                            \
 static int km_ ## name ## _final(struct shash_desc *desc, u8 *out) {       \
     struct km_sha_state *ctx = (struct km_sha_state *)shash_desc_ctx(desc);\
@@ -417,7 +432,6 @@ struct wc_swallow_the_semicolon
 static int km_ ## name ## _init(struct shash_desc *desc) {                 \
     struct km_sha_state *ctx = (struct km_sha_state *)shash_desc_ctx(desc);\
     int ret;                                                               \
-                                                                           \
                                                                            \
     ctx-> name ## _state = malloc(sizeof *ctx-> name ## _state);           \
     if (! ctx-> name ## _state)                                            \

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3393,7 +3393,7 @@ WOLFSSL_LOCAL int   TLSX_CSR2_ForceRequest(WOLFSSL* ssl);
 #endif
 
 #if defined(WOLFSSL_PUBLIC_ASN) && defined(HAVE_PK_CALLBACKS)
-/* Internal callback guarded by WOLFSSL_PUBLIC_ASN because of DecodedCert. */
+/* Internal callback guarded by WOLFSSL_TEST_VIS because of DecodedCert. */
 typedef int (*CallbackProcessPeerCert)(WOLFSSL* ssl, DecodedCert* p_cert);
 WOLFSSL_TEST_VIS void wolfSSL_CTX_SetProcessPeerCertCb(WOLFSSL_CTX* ctx,
        CallbackProcessPeerCert cb);
@@ -4715,7 +4715,6 @@ WOLFSSL_LOCAL int TlsSessionCacheGetAndRdLock(const byte *id,
 WOLFSSL_LOCAL int TlsSessionCacheGetAndWrLock(const byte *id,
     WOLFSSL_SESSION **sess, word32 *lockedRow, byte side);
 WOLFSSL_LOCAL void EvictSessionFromCache(WOLFSSL_SESSION* session);
-/* WOLFSSL_TEST_VIS to test it in tests/api.c */
 WOLFSSL_TEST_VIS int wolfSSL_GetSessionFromCache(WOLFSSL* ssl, WOLFSSL_SESSION* output);
 WOLFSSL_LOCAL int wolfSSL_SetSession(WOLFSSL* ssl, WOLFSSL_SESSION* session);
 WOLFSSL_LOCAL void wolfSSL_FreeSession(WOLFSSL_CTX* ctx,
@@ -6578,7 +6577,7 @@ WOLFSSL_LOCAL int TLSv1_3_Capable(WOLFSSL* ssl);
 WOLFSSL_LOCAL void FreeHandshakeResources(WOLFSSL* ssl);
 WOLFSSL_LOCAL void ShrinkInputBuffer(WOLFSSL* ssl, int forcedFree);
 WOLFSSL_LOCAL void ShrinkOutputBuffer(WOLFSSL* ssl);
-WOLFSSL_TEST_VIS byte* GetOutputBuffer(WOLFSSL* ssl);
+WOLFSSL_LOCAL byte* GetOutputBuffer(WOLFSSL* ssl);
 
 WOLFSSL_LOCAL int CipherRequires(byte first, byte second, int requirement);
 WOLFSSL_LOCAL int VerifyClientSuite(word16 havePSK, byte cipherSuite0,
@@ -6746,17 +6745,14 @@ WOLFSSL_LOCAL word32 MacSize(const WOLFSSL* ssl);
 #ifdef WOLFSSL_DTLS
     WOLFSSL_LOCAL DtlsMsg* DtlsMsgNew(word32 sz, byte tx, void* heap);
     WOLFSSL_LOCAL void DtlsMsgDelete(DtlsMsg* item, void* heap);
-    /* Use WOLFSSL_TEST_VIS to enable src/api.c testing */
     WOLFSSL_TEST_VIS void DtlsMsgListDelete(DtlsMsg* head, void* heap);
     WOLFSSL_LOCAL void DtlsTxMsgListClean(WOLFSSL* ssl);
     WOLFSSL_LOCAL int  DtlsMsgSet(DtlsMsg* msg, word32 seq, word16 epoch,
                                   const byte* data, byte type,
                                   word32 fragOffset, word32 fragSz, void* heap,
                                   word32 totalLen, byte encrypted);
-    /* Use WOLFSSL_TEST_VIS to enable src/api.c testing */
     WOLFSSL_TEST_VIS DtlsMsg* DtlsMsgFind(DtlsMsg* head, word16 epoch, word32 seq);
 
-    /* Use WOLFSSL_TEST_VIS to enable src/api.c testing */
     WOLFSSL_TEST_VIS void DtlsMsgStore(WOLFSSL* ssl, word16 epoch, word32 seq,
                                     const byte* data, word32 dataSz, byte type,
                                     word32 fragOffset, word32 fragSz,
@@ -6947,7 +6943,6 @@ WOLFSSL_LOCAL int BuildMessage(WOLFSSL* ssl, byte* output, int outSz,
                         int sizeOnly, int asyncOkay, int epochOrder);
 
 #ifdef WOLFSSL_TLS13
-/* Use WOLFSSL_TEST_VIS to use this function in tests/api.c */
 WOLFSSL_TEST_VIS int BuildTls13Message(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
                int inSz, int type, int hashOutput, int sizeOnly, int asyncOkay);
 WOLFSSL_LOCAL int Tls13UpdateKeys(WOLFSSL* ssl);
@@ -7015,7 +7010,6 @@ WOLFSSL_LOCAL void DtlsSetSeqNumForReply(WOLFSSL* ssl);
 
 #ifdef WOLFSSL_DTLS13
 
-/* Use WOLFSSL_TEST_VIS to use this function in tests/api.c */
 WOLFSSL_TEST_VIS struct Dtls13Epoch* Dtls13GetEpoch(WOLFSSL* ssl,
     w64wrapper epochNumber);
 WOLFSSL_LOCAL void Dtls13SetOlderEpochSide(WOLFSSL* ssl, w64wrapper epochNumber,


### PR DESCRIPTION
linuxkm: clean up LKCAPI glue:

typography fixes;

`static` attr on const byte arrays;

refactor `km_ecdsa_verify()` to use a single heap allocation;

fix `linuxkm_test_ecdsa_nist_driver()` to copy `sig` and `hash` to a heap allocation before passing to `sg_set_buf()` (avoids unmapping of `rodata`);

in `linuxkm_test_pkcs1_driver()` move hash from stack to heap;

add `LINUX_VERSION_CODE` >= 5.4 assertion in `linuxkm/lkcapi_glue.c`;

streamline macro logic in `linuxkm/lkcapi_sha_glue.c`.

unrelated, re #8689:
`wolfssl/internal.h`: clean up `WOLFSSL_TEST_VIS` comments and an unneeded attr on `GetOutputBuffer()`.
