### PR TITLE
adjust MSYS CI Build

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -18,23 +18,18 @@ jobs:
     defaults:
       run:
         shell: msys2 {0}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - { sys: ucrt64,  compiler: mingw-w64-ucrt-x86_64-gcc }
-          - { sys: mingw64, compiler: mingw-w64-x86_64-gcc }
-          - { sys: msys, compiler: gcc }
     steps:
       - uses: actions/checkout@v3
       - uses: msys2/setup-msys2@v2
         with:
-          msystem: ${{ matrix.sys }}
+          msystem: msys
           update: true
-          install: git ${{matrix.compiler}} autotools base-devel autoconf netcat
+          install: git gcc autotools base-devel autoconf netcat
       - name: configure wolfSSL
         run: ./autogen.sh && ./configure CFLAGS="-DUSE_CERT_BUFFERS_2048 -DUSE_CERT_BUFFERS_256 -DNO_WRITE_TEMP_FILES"
       - name: build wolfSSL
+        run: make
+      - name: run tests
         run: make check
       - name: Display log
         if: always()

--- a/tests/api.c
+++ b/tests/api.c
@@ -415,6 +415,12 @@ int testDevId = WOLFSSL_CAAM_DEVID;
 int testDevId = INVALID_DEVID;
 #endif
 
+#ifdef USE_WINDOWS_API
+    #define MESSAGE_TYPE_CAST char*
+#else
+    #define MESSAGE_TYPE_CAST void*
+#endif
+
 /*----------------------------------------------------------------------------*
  | BIO with fixed read/write size
  *----------------------------------------------------------------------------*/
@@ -56353,10 +56359,10 @@ static void test_wolfSSL_dtls_plaintext_client(WOLFSSL* ssl)
     AssertIntGE(fd, 0);
     generateDTLSMsg(ch, sizeof(ch), 20, client_hello, 0);
     /* Server should ignore this datagram */
-    AssertIntEQ(send(fd, ch, sizeof(ch), 0), sizeof(ch));
+    AssertIntEQ(send(fd, (MESSAGE_TYPE_CAST)ch, sizeof(ch), 0), sizeof(ch));
     generateDTLSMsg(ch, sizeof(ch), 20, client_hello, 10000);
     /* Server should ignore this datagram */
-    AssertIntEQ(send(fd, ch, sizeof(ch), 0), sizeof(ch));
+    AssertIntEQ(send(fd, (MESSAGE_TYPE_CAST)ch, sizeof(ch), 0), sizeof(ch));
 
     AssertIntEQ(wolfSSL_write(ssl, msg, sizeof(msg)), sizeof(msg));
     AssertIntGT(wolfSSL_read(ssl, reply, sizeof(reply)),0);
@@ -56467,7 +56473,7 @@ static void test_wolfSSL_dtls12_fragments_spammer(WOLFSSL* ssl)
         delay.tv_nsec = 10000000; /* wait 0.01 seconds */
         c32toa(seq_number, b + seq_offset);
         c16toa(msg_number, b + msg_offset);
-        ret = (int)send(fd, b, 55, 0);
+        ret = (int)send(fd, (MESSAGE_TYPE_CAST)b, 55, 0);
         nanosleep(&delay, NULL);
     }
 }
@@ -56513,7 +56519,7 @@ static void test_wolfSSL_dtls13_fragments_spammer(WOLFSSL* ssl)
         ret = sendSz = BuildTls13Message(ssl, sendBuf, sendSz, b,
             (int)idx, handshake, 0, 0, 0);
         if (sendSz > 0)
-            ret = (int)send(fd, sendBuf, (size_t)sendSz, 0);
+            ret = (int)send(fd, (MESSAGE_TYPE_CAST)sendBuf, (size_t)sendSz, 0);
         nanosleep(&delay, NULL);
     }
 }
@@ -56587,7 +56593,7 @@ static void test_wolfSSL_dtls_send_alert(WOLFSSL* ssl)
 
     fd = wolfSSL_get_wfd(ssl);
     AssertIntGE(fd, 0);
-    ret = (int)send(fd, alert_msg, sizeof(alert_msg), 0);
+    ret = (int)send(fd, (MESSAGE_TYPE_CAST)alert_msg, sizeof(alert_msg), 0);
     AssertIntGT(ret, 0);
 }
 
@@ -56658,7 +56664,7 @@ static void test_wolfSSL_send_bad_record(WOLFSSL* ssl)
 
     fd = wolfSSL_get_wfd(ssl);
     AssertIntGE(fd, 0);
-    ret = (int)send(fd, bad_msg, sizeof(bad_msg), 0);
+    ret = (int)send(fd, (MESSAGE_TYPE_CAST)bad_msg, sizeof(bad_msg), 0);
     AssertIntEQ(ret, sizeof(bad_msg));
     ret = wolfSSL_write(ssl, "badrecordtest", sizeof("badrecordtest"));
     AssertIntEQ(ret, sizeof("badrecordtest"));
@@ -57016,10 +57022,10 @@ static void test_wolfSSL_dtls_send_ch(WOLFSSL* ssl)
 
     fd = wolfSSL_get_wfd(ssl);
     AssertIntGE(fd, 0);
-    ret = (int)send(fd, ch_msg, sizeof(ch_msg), 0);
+    ret = (int)send(fd, (MESSAGE_TYPE_CAST)ch_msg, sizeof(ch_msg), 0);
     AssertIntGT(ret, 0);
     /* consume the HRR otherwise handshake will fail */
-    ret = (int)recv(fd, ch_msg, sizeof(ch_msg), 0);
+    ret = (int)recv(fd, (MESSAGE_TYPE_CAST)ch_msg, sizeof(ch_msg), 0);
     AssertIntGT(ret, 0);
 }
 
@@ -57088,11 +57094,11 @@ static void test_wolfSSL_dtls_send_ch_with_invalid_cookie(WOLFSSL* ssl)
 
     fd = wolfSSL_get_wfd(ssl);
     if (fd >= 0) {
-        ret = (int)send(fd, ch_msh_invalid_cookie,
+        ret = (int)send(fd, (MESSAGE_TYPE_CAST)ch_msh_invalid_cookie,
                 sizeof(ch_msh_invalid_cookie), 0);
         AssertIntGT(ret, 0);
         /* should reply with an illegal_parameter reply */
-        ret = (int)recv(fd, alert_reply, sizeof(alert_reply), 0);
+        ret = (int)recv(fd, (MESSAGE_TYPE_CAST)alert_reply, sizeof(alert_reply), 0);
         AssertIntEQ(ret, sizeof(expected_alert_reply));
         AssertIntEQ(XMEMCMP(alert_reply, expected_alert_reply,
                 sizeof(expected_alert_reply)), 0);


### PR DESCRIPTION
# Description

msys2 build only tests msys system. Adds type casts necessary to build test later when configuring with --enable-all.

Fixes zd#

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
