### PR TITLE
revert BN_CTX_init stub for older applications

### DIFF
--- a/src/ssl_bn.c
+++ b/src/ssl_bn.c
@@ -2382,6 +2382,27 @@ WOLFSSL_BN_CTX* wolfSSL_BN_CTX_new(void)
     return ctx;
 }
 
+
+#ifndef NO_WOLFSSL_STUB
+/* deprecated
+ *
+ * Initialize a BN context object.
+ * This function was removed in OpenSSL 1.1.0 and later.
+ * Keeping a stub function here for older applications that have BN_CTX_init()
+ * calls.
+ *
+ * @param [in] ctx  Dummy BN context.
+ */
+void wolfSSL_BN_CTX_init(WOLFSSL_BN_CTX* ctx)
+{
+    (void)ctx;
+    WOLFSSL_ENTER("wolfSSL_BN_CTX_init");
+    WOLFSSL_STUB("wolfSSL_BN_CTX_init");
+    WOLFSSL_MSG("wolfSSL_BN_CTX_init is deprecated");
+}
+#endif
+
+
 /* Free a BN context object.
  *
  * @param [in] ctx  BN context object.

--- a/tests/api.c
+++ b/tests/api.c
@@ -28725,9 +28725,6 @@ static int test_wolfSSL_BN_CTX(void)
 
     ExpectNotNull(bn_ctx = BN_CTX_new());
 
-    /* No implementation. */
-    BN_CTX_init(NULL);
-
     ExpectNull(BN_CTX_get(NULL));
     ExpectNotNull(BN_CTX_get(bn_ctx));
     ExpectNotNull(BN_CTX_get(bn_ctx));
@@ -28740,6 +28737,7 @@ static int test_wolfSSL_BN_CTX(void)
     /* No implementation. */
     BN_CTX_start(NULL);
     BN_CTX_start(bn_ctx);
+    BN_CTX_init(NULL);
 #endif
 
     BN_CTX_free(NULL);

--- a/tests/api.c
+++ b/tests/api.c
@@ -28725,6 +28725,9 @@ static int test_wolfSSL_BN_CTX(void)
 
     ExpectNotNull(bn_ctx = BN_CTX_new());
 
+    /* No implementation. */
+    BN_CTX_init(NULL);
+
     ExpectNull(BN_CTX_get(NULL));
     ExpectNotNull(BN_CTX_get(bn_ctx));
     ExpectNotNull(BN_CTX_get(bn_ctx));

--- a/wolfssl/openssl/bn.h
+++ b/wolfssl/openssl/bn.h
@@ -88,6 +88,7 @@ typedef struct WOLFSSL_BN_MONT_CTX WOLFSSL_BN_MONT_CTX;
 typedef struct WOLFSSL_BN_GENCB    WOLFSSL_BN_GENCB;
 
 WOLFSSL_API WOLFSSL_BN_CTX* wolfSSL_BN_CTX_new(void);
+WOLFSSL_API void           wolfSSL_BN_CTX_init(WOLFSSL_BN_CTX* ctx);
 WOLFSSL_API void           wolfSSL_BN_CTX_free(WOLFSSL_BN_CTX* ctx);
 
 WOLFSSL_API WOLFSSL_BIGNUM* wolfSSL_BN_new(void);

--- a/wolfssl/openssl/bn.h
+++ b/wolfssl/openssl/bn.h
@@ -216,6 +216,7 @@ typedef WOLFSSL_BN_GENCB    BN_GENCB;
 
 #ifndef NO_WOLFSSL_BN_CTX
 #define BN_CTX_new        wolfSSL_BN_CTX_new
+#define BN_CTX_init       wolfSSL_BN_CTX_init
 #define BN_CTX_free       wolfSSL_BN_CTX_free
 #else
 #define BN_CTX_new()      ((BN_CTX*)-1)


### PR DESCRIPTION
BN_CTX_init functionality was removed in OpenSSL 1.1.0. This reverts the removal of the function though for use with old applications. It maintains backwards compatibility with the wolfSSL 5.7.6 API set.