### PR TITLE
Fixes from CodeSonar report

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -14178,8 +14178,10 @@ mem_error:
     if (store != NULL)
         wolfSSL_X509_STORE_CTX_free(store);
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
-    if (x509 != NULL)
+    if (x509 != NULL) {
         wolfSSL_X509_free(x509);
+        x509 = NULL;
+    }
 #endif
     XFREE(domain, heap, DYNAMIC_TYPE_STRING);
     return MEMORY_E;
@@ -14605,6 +14607,7 @@ int LoadCertByIssuer(WOLFSSL_X509_STORE* store, X509_NAME* issuer, int type)
                     if (x509 != NULL) {
                        ret = wolfSSL_X509_STORE_add_cert(store, x509);
                        wolfSSL_X509_free(x509);
+                       x509 = NULL;
                     } else {
                        WOLFSSL_MSG("failed to load certificate");
                        ret = WOLFSSL_FAILURE;
@@ -31661,6 +31664,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
                     return CLIENT_CERT_CB_ERROR;
                 }
                 wolfSSL_X509_free(x509);
+                x509 = NULL;
                 wolfSSL_EVP_PKEY_free(pkey);
 
             }

--- a/src/keys.c
+++ b/src/keys.c
@@ -124,6 +124,9 @@ int GetCipherSpec(word16 side, byte cipherSuite0, byte cipherSuite,
     }
 #endif /* NO_WOLFSSL_CLIENT */
 
+    /* Initialize specs */
+    XMEMSET(specs, 0, sizeof(CipherSpecs));
+
     /* Chacha extensions, 0xcc */
     if (cipherSuite0 == CHACHA_BYTE) {
 

--- a/src/pk.c
+++ b/src/pk.c
@@ -731,7 +731,7 @@ static int wolfssl_print_indent(WOLFSSL_BIO* bio, char* line, int lineLen,
     if (indent > 0) {
         /* Print indent spaces. */
         int len_wanted = XSNPRINTF(line, (size_t)lineLen, "%*s", indent, " ");
-        if (len_wanted >= lineLen) {
+        if ((len_wanted < 0) || (len_wanted >= lineLen)) {
             WOLFSSL_ERROR_MSG("Buffer overflow formatting indentation");
             ret = 0;
         }
@@ -16172,6 +16172,11 @@ static int pem_write_data(const char *name, const char *header,
         /* Return buffer and length of data. */
         *pemOut = pem;
         *pemOutLen = (word32)((size_t)p - (size_t)pem);
+    }
+    else {
+        /* Dispose of any allocated memory. */
+        XFREE(pem, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        pem = NULL;
     }
 
     return ret;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1006,7 +1006,7 @@ int GetEchConfigsEx(WOLFSSL_EchConfig* configs, byte* output, word32* outputLen)
     word32 totalLen = 2;
     word32 workingOutputLen;
 
-    if (configs == NULL || outputLen == NULL)
+    if (configs == NULL || outputLen == NULL || *outputLen < totalLen)
         return BAD_FUNC_ARG;
 
     workingOutputLen = *outputLen - totalLen;
@@ -12511,6 +12511,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             err = WOLFSSL_SUCCESS;
 cleanup:
             wolfSSL_X509_free(cert);
+            cert = NULL;
             wolfSSL_BIO_free(bio);
             if (err != WOLFSSL_SUCCESS) {
                 /* We failed so return NULL */
@@ -14520,6 +14521,7 @@ static int PushCAx509Chain(WOLFSSL_CERT_MANAGER* cm,
             break;
         if (wolfSSL_sk_X509_push(sk, issuer) <= 0) {
             wolfSSL_X509_free(issuer);
+            issuer = NULL;
             return WOLFSSL_FATAL_ERROR;
         }
         x = issuer;
@@ -14565,6 +14567,7 @@ static WOLF_STACK_OF(WOLFSSL_X509)* CreatePeerCertChain(const WOLFSSL* ssl,
         if (err != 0) {
             WOLFSSL_MSG("Error decoding cert");
             wolfSSL_X509_free(x509);
+            x509 = NULL;
             wolfSSL_sk_X509_pop_free(sk, NULL);
             return NULL;
         }
@@ -21159,6 +21162,7 @@ long wolfSSL_CTX_ctrl(WOLFSSL_CTX* ctx, int cmd, long opt, void* pt)
                     WOLFSSL_MSG("Error adding certificate to context");
                     /* Decrease reference count on failure */
                     wolfSSL_X509_free(x509);
+                    x509 = NULL;
                 }
             }
         }
@@ -22993,7 +22997,7 @@ int wolfSSL_sk_WOLFSSL_STRING_num(WOLF_STACK_OF(WOLFSSL_STRING)* strings)
 void wolfSSL_get0_alpn_selected(const WOLFSSL *ssl, const unsigned char **data,
                                 unsigned int *len)
 {
-    word16 nameLen;
+    word16 nameLen = 0;
 
     if (ssl != NULL && data != NULL && len != NULL) {
         TLSX_ALPN_GetRequest(ssl->extensions, (void **)data, &nameLen);

--- a/src/ssl_certman.c
+++ b/src/ssl_certman.c
@@ -397,6 +397,7 @@ WOLFSSL_STACK* wolfSSL_CertManagerGetCerts(WOLFSSL_CERT_MANAGER* cm)
         /* Decode certificate. */
         if ((!err) && (wolfSSL_sk_X509_push(sk, x509) <= 0)) {
             wolfSSL_X509_free(x509);
+            x509 = NULL;
             err = 1;
         }
     }

--- a/src/ssl_load.c
+++ b/src/ssl_load.c
@@ -4839,6 +4839,7 @@ long wolfSSL_CTX_add_extra_chain_cert(WOLFSSL_CTX* ctx, WOLFSSL_X509* x509)
     if (ret == 1) {
         /* On success WOLFSSL_X509 memory is responsibility of SSL context. */
         wolfSSL_X509_free(x509);
+        x509 = NULL;
     }
 
     WOLFSSL_LEAVE("wolfSSL_CTX_add_extra_chain_cert", ret);
@@ -4932,6 +4933,7 @@ int wolfSSL_CTX_add0_chain_cert(WOLFSSL_CTX* ctx, WOLFSSL_X509* x509)
     if (ret == 1) {
         /* Down reference or free original now as we own certificate. */
         wolfSSL_X509_free(x509);
+        x509 = NULL;
     }
 
     return ret;
@@ -4990,6 +4992,7 @@ int wolfSSL_CTX_add1_chain_cert(WOLFSSL_CTX* ctx, WOLFSSL_X509* x509)
         if (ret != 1) {
             /* Decrease reference count on error as we didn't store it. */
             wolfSSL_X509_free(x509);
+            x509 = NULL;
         }
     }
 
@@ -5053,6 +5056,7 @@ int wolfSSL_add0_chain_cert(WOLFSSL* ssl, WOLFSSL_X509* x509)
             if (ret != 1) {
                 /* Free it now on error. */
                 wolfSSL_X509_free(x509);
+                x509 = NULL;
             }
         }
     }
@@ -5085,6 +5089,7 @@ int wolfSSL_add1_chain_cert(WOLFSSL* ssl, WOLFSSL_X509* x509)
         if ((ret = wolfSSL_add0_chain_cert(ssl, x509)) != 1) {
             /* Decrease reference count on error as not stored. */
             wolfSSL_X509_free(x509);
+            x509 = NULL;
         }
     }
 

--- a/src/ssl_p7p12.c
+++ b/src/ssl_p7p12.c
@@ -227,6 +227,7 @@ WOLFSSL_STACK* wolfSSL_PKCS7_to_stack(PKCS7* pkcs7)
         if (x509) {
             if (wolfSSL_sk_X509_push(ret, x509) <= 0) {
                 wolfSSL_X509_free(x509);
+                x509 = NULL;
                 WOLFSSL_MSG("wolfSSL_sk_X509_push error");
                 goto error;
             }
@@ -1176,6 +1177,8 @@ PKCS7* wolfSSL_SMIME_read_PKCS7(WOLFSSL_BIO* in,
                                           DYNAMIC_TYPE_PKCS7);
             if (canonSection == NULL) {
                 goto error;
+            } else {
+                XMEMSET(canonSection, 0, (word32)canonSize);
             }
 
             lineLen = wolfSSL_BIO_gets(in, section, remainLen);
@@ -1908,12 +1911,14 @@ int wolfSSL_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
                 WOLFSSL_MSG("Issue with parsing certificate");
                 FreeDecodedCert(DeCert);
                 wolfSSL_X509_free(x509);
+                x509 = NULL;
             }
             else {
                 if (CopyDecodedToX509(x509, DeCert) != 0) {
                     WOLFSSL_MSG("Failed to copy decoded cert");
                     FreeDecodedCert(DeCert);
                     wolfSSL_X509_free(x509);
+                    x509 = NULL;
                     wolfSSL_sk_X509_pop_free(*ca, NULL); *ca = NULL;
                     XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
                     XFREE(certData, heap, DYNAMIC_TYPE_PKCS);
@@ -1933,6 +1938,7 @@ int wolfSSL_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
                 if (wolfSSL_sk_X509_push(*ca, x509) <= 0) {
                     WOLFSSL_MSG("Failed to push x509 onto stack");
                     wolfSSL_X509_free(x509);
+                    x509 = NULL;
                     wolfSSL_sk_X509_pop_free(*ca, NULL); *ca = NULL;
                     XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
                     XFREE(certData, heap, DYNAMIC_TYPE_PKCS);

--- a/src/ssl_sess.c
+++ b/src/ssl_sess.c
@@ -1452,6 +1452,7 @@ int wolfSSL_GetSessionFromCache(WOLFSSL* ssl, WOLFSSL_SESSION* output)
 #if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
     if (peer != NULL) {
         wolfSSL_X509_free(peer);
+        peer = NULL;
     }
 #endif
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -8692,6 +8692,7 @@ static int SendTls13Certificate(WOLFSSL* ssl)
                 ssl->options.sendVerify = SEND_CERT;
             }
             wolfSSL_X509_free(x509);
+            x509 = NULL;
             wolfSSL_EVP_PKEY_free(pkey);
         }
     }

--- a/src/x509.c
+++ b/src/x509.c
@@ -3599,9 +3599,8 @@ char* wolfSSL_X509_get_name_oneline(WOLFSSL_X509_NAME* name, char* in, int sz)
                 WOLFSSL_MSG("Memory error");
                 return NULL;
             }
-            if ((strLen = XSNPRINTF(str, (size_t)strSz, "%s=%s, ", sn, buf))
-                >= strSz)
-            {
+            strLen = XSNPRINTF(str, (size_t)strSz, "%s=%s, ", sn, buf);
+            if ((strLen  < 0) || (strLen  >= strSz)) {
                 WOLFSSL_MSG("buffer overrun");
                 XFREE(str, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                 return NULL;
@@ -3617,8 +3616,8 @@ char* wolfSSL_X509_get_name_oneline(WOLFSSL_X509_NAME* name, char* in, int sz)
                 WOLFSSL_MSG("Memory error");
                 return NULL;
             }
-            if ((strLen = XSNPRINTF(str, (size_t)strSz, "%s=%s", sn,
-                    buf)) >= strSz) {
+            strLen = XSNPRINTF(str, (size_t)strSz, "%s=%s", sn, buf);
+            if ((strLen  < 0) || (strLen  >= strSz)) {
                 WOLFSSL_MSG("buffer overrun");
                 XFREE(str, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                 return NULL;
@@ -6971,7 +6970,7 @@ static int X509PrintPubKey(WOLFSSL_BIO* bio, WOLFSSL_X509* x509, int indent)
         case ECDSAk:
             len = XSNPRINTF(scratch, MAX_WIDTH,
                     "%*sPublic Key Algorithm: EC\n", indent + 4, "");
-            if (len >= MAX_WIDTH)
+            if ((len < 0) || (len >= MAX_WIDTH))
                 return WOLFSSL_FAILURE;
             if (wolfSSL_BIO_write(bio, scratch, len) <= 0)
                 return WOLFSSL_FAILURE;
@@ -7033,22 +7032,21 @@ static int X509PrintVersion(WOLFSSL_BIO* bio, int version, int indent)
     char scratch[MAX_WIDTH];
     int scratchLen;
 
-    if ((scratchLen = XSNPRINTF(scratch, MAX_WIDTH,
-                                 "%*s%s", indent, "", "Version:"))
-        >= MAX_WIDTH)
-    {
+    scratchLen = XSNPRINTF(scratch, MAX_WIDTH, "%*s%s", indent, "", "Version:");
+    if ((scratchLen < 0) || (scratchLen >= MAX_WIDTH)) {
         return WOLFSSL_FAILURE;
     }
+
     if (wolfSSL_BIO_write(bio, scratch, scratchLen) <= 0) {
         return WOLFSSL_FAILURE;
     }
 
-    if ((scratchLen = XSNPRINTF(scratch, MAX_WIDTH,
-                                 " %d (0x%x)\n", version, (byte)version-1))
-        >= MAX_WIDTH)
-    {
+    scratchLen = XSNPRINTF(scratch, MAX_WIDTH, " %d (0x%x)\n",
+                    version, (byte)version-1);
+    if ((scratchLen < 0) || (scratchLen >= MAX_WIDTH)) {
         return WOLFSSL_FAILURE;
     }
+
     if (wolfSSL_BIO_write(bio, scratch, scratchLen) <= 0) {
         return WOLFSSL_FAILURE;
     }
@@ -8064,6 +8062,7 @@ int wc_GeneratePreTBS(DecodedCert* cert, byte *der, int derSz) {
 
     if (x != NULL) {
         wolfSSL_X509_free(x);
+        x = NULL;
     }
 
     return ret;

--- a/src/x509_str.c
+++ b/src/x509_str.c
@@ -100,6 +100,7 @@ void wolfSSL_X509_STORE_CTX_free(WOLFSSL_X509_STORE_CTX* ctx)
 
         if (ctx->current_issuer != NULL) {
             wolfSSL_X509_free(ctx->current_issuer);
+            ctx->current_issuer = NULL;
         }
 #endif
 
@@ -815,6 +816,7 @@ WOLFSSL_STACK* wolfSSL_X509_STORE_CTX_get_chain(WOLFSSL_X509_STORE_CTX* ctx)
             if (wolfSSL_sk_X509_push(sk, x509) <= 0) {
                 WOLFSSL_MSG("Unable to load x509 into stack");
                 wolfSSL_X509_free(x509);
+                x509 = NULL;
                 error = 1;
                 break;
             }
@@ -837,11 +839,13 @@ WOLFSSL_STACK* wolfSSL_X509_STORE_CTX_get_chain(WOLFSSL_X509_STORE_CTX* ctx)
                             WOLFSSL_MSG("Unable to load CA x509 into stack");
                             error = 1;
                             wolfSSL_X509_free(issuer);
+                            issuer = NULL;
                         }
                     }
                     else {
                         WOLFSSL_MSG("Certificate is self signed");
                         wolfSSL_X509_free(issuer);
+                        issuer = NULL;
                     }
                 }
                 else {
@@ -849,6 +853,7 @@ WOLFSSL_STACK* wolfSSL_X509_STORE_CTX_get_chain(WOLFSSL_X509_STORE_CTX* ctx)
                 }
             }
             wolfSSL_X509_free(x509);
+            x509 = NULL;
         }
 #endif
         if (error) {
@@ -968,6 +973,7 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_X509_STORE_get1_certs(
                                 <= 0) {
                         err = 1;
                         wolfSSL_X509_free(filteredCert);
+                        filteredCert = NULL;
                         break;
                     }
                 }
@@ -1405,6 +1411,7 @@ int wolfSSL_X509_STORE_add_cert(WOLFSSL_X509_STORE* store, WOLFSSL_X509* x509)
                     else {
                         result = WOLFSSL_FATAL_ERROR;
                         wolfSSL_X509_free(x509);
+                        x509 = NULL;
                     }
                 }
             }
@@ -1420,6 +1427,7 @@ int wolfSSL_X509_STORE_add_cert(WOLFSSL_X509_STORE* store, WOLFSSL_X509* x509)
                     else {
                         result = WOLFSSL_FATAL_ERROR;
                         wolfSSL_X509_free(x509);
+                        x509 = NULL;
                     }
                 }
             }
@@ -1491,7 +1499,7 @@ int X509StoreLoadCertBuffer(WOLFSSL_X509_STORE *str,
             }
         }
         wolfSSL_X509_free(x509);
-
+        x509 = NULL;
     }
     else {
         ret = WOLFSSL_FAILURE;
@@ -1788,6 +1796,7 @@ WOLFSSL_STACK* wolfSSL_X509_STORE_GetCerts(WOLFSSL_X509_STORE_CTX* s)
             if (wolfSSL_sk_X509_push(sk, x509) <= 0) {
                 WOLFSSL_MSG("Unable to load x509 into stack");
                 wolfSSL_X509_free(x509);
+                x509 = NULL;
                 goto error;
             }
         }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -36772,6 +36772,9 @@ int wc_Ed25519PublicKeyDecode(const byte* input, word32* inOutIdx,
         return BAD_FUNC_ARG;
     }
 
+    /* init pubKey */
+    XMEMSET(pubKey, 0, sizeof(pubKey));
+
     ret = DecodeAsymKeyPublic(input, inOutIdx, inSz,
         pubKey, &pubKeyLen, ED25519k);
     if (ret == 0) {
@@ -36811,6 +36814,9 @@ int wc_Curve25519PublicKeyDecode(const byte* input, word32* inOutIdx,
     if (input == NULL || inOutIdx == NULL || key == NULL || inSz == 0) {
         return BAD_FUNC_ARG;
     }
+
+    /* init pubKey */
+    XMEMSET(pubKey, 0, sizeof(pubKey));
 
     ret = DecodeAsymKeyPublic(input, inOutIdx, inSz,
         pubKey, &pubKeyLen, X25519k);
@@ -37213,6 +37219,9 @@ int wc_Curve448PublicKeyDecode(const byte* input, word32* inOutIdx,
     if (input == NULL || inOutIdx == NULL || key == NULL || inSz == 0) {
         return BAD_FUNC_ARG;
     }
+
+    /* init pubKey */
+    XMEMSET(pubKey, 0, sizeof(pubKey));
 
     ret = DecodeAsymKeyPublic(input, inOutIdx, inSz,
         pubKey, &pubKeyLen, X448k);

--- a/wolfcrypt/src/cpuid.c
+++ b/wolfcrypt/src/cpuid.c
@@ -55,7 +55,8 @@
         int got_intel_cpu = 0;
         int got_amd_cpu = 0;
         unsigned int reg[5];
-        reg[4] = '\0';
+
+        XMEMSET(reg, '\0', sizeof(reg));
         cpuid(reg, 0, 0);
 
         /* check for Intel cpu */

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -1059,7 +1059,7 @@ int wolfSSL_EVP_CipherUpdate(WOLFSSL_EVP_CIPHER_CTX *ctx,
                 WOLFSSL_MSG("Bad argument");
                 return WOLFSSL_FAILURE;
             }
-            XMEMCPY(out, in, inl);
+            XMEMMOVE(out, in, inl);
             *outl = inl;
             return WOLFSSL_SUCCESS;
 #if !defined(NO_AES) && defined(HAVE_AESGCM)

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -1175,7 +1175,7 @@ static int PKCS12_CheckConstructedZero(byte* data, word32 dataSz, word32* idx)
 {
     word32 oid;
     int    ret = 0;
-    int    number, size;
+    int    number, size = 0;
     byte   tag = 0;
 
     if (GetSequence(data, idx, &size, dataSz) < 0) {

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -4063,11 +4063,12 @@ int wc_RsaPSS_CheckPadding_ex2(const byte* in, word32 inSz, byte* sig,
     int ret = 0;
     byte sigCheckBuf[WC_MAX_DIGEST_SIZE*2 + RSA_PSS_PAD_SZ];
     byte *sigCheck = sigCheckBuf;
-
+    int digSz;
     (void)bits;
 
-    if (in == NULL || sig == NULL ||
-                               inSz != (word32)wc_HashGetDigestSize(hashType)) {
+    digSz = wc_HashGetDigestSize(hashType);
+
+    if (in == NULL || sig == NULL || digSz < 0 || inSz != (word32)digSz) {
         ret = BAD_FUNC_ARG;
     }
 

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -650,11 +650,13 @@ int wc_ReadDirFirst(ReadDirCtx* ctx, const char* path, char** name)
     if (name)
         *name = NULL;
 
+    if (ctx != NULL)
+        XMEMSET(ctx, 0, sizeof(ReadDirCtx));
+
     if (ctx == NULL || path == NULL) {
         return BAD_FUNC_ARG;
     }
 
-    XMEMSET(ctx, 0, sizeof(ReadDirCtx));
     pathLen = (int)XSTRLEN(path);
 
 #ifdef USE_WINDOWS_API


### PR DESCRIPTION
# Description

class | significance | file | line number | procedure
-- | -- | -- | -- | --
Leak | Reliability | pk.c | 16134 | pem_write_data
Uninitialized Variable | Security | cpuid.c | 62 | cpuid_flag
Uninitialized Variable | Security | ssl.c | 23000 | wolfSSL_get0_alpn_selected
Uninitialized Variable | Security | cpuid.c | 69 | cpuid_flag
Uninitialized Variable | Security | cpuid.c | 63 | cpuid_flag
Uninitialized Variable | Security | cpuid.c | 70 | cpuid_flag
Uninitialized Variable | Security | cpuid.c | 64 | cpuid_flag
Uninitialized Variable | Security | ssl.c | 1012 | GetEchConfigsEx
Uninitialized Variable | Security | cpuid.c | 71 | cpuid_flag
Uninitialized Variable | Security | wc_port.c | 960 | wc_ReadDirClose
Use After Free | Security | x509.c | 3351 | ExternalFreeX509
Unreasonable Size Argument | Security | x509.c | 3633 | wolfSSL_X509_get_name_oneline
Unreasonable Size Argument | Security | rsa.c | 4136 | wc_RsaPSS_CheckPadding_ex2
Uninitialized Variable | Security | ssl_p7p12.c | 1224 | wolfSSL_SMIME_read_PKCS7
Unreasonable Size Argument | Security | x509.c | 3653 | wolfSSL_X509_get_name_oneline
Unreasonable Size Argument | Security | bio.c | 740 | wolfSSL_BIO_write
Unreasonable Size Argument | Security | bio.c | 735 | wolfSSL_BIO_write
Uninitialized Variable | Security | ed25519.c | 1162 | wc_ed25519_import_public_ex
Uninitialized Variable | Security | curve448.c | 318 | wc_curve448_import_public_ex
Overlapping Memory Regions | Security | evp.c | 1062 | wolfSSL_EVP_CipherUpdate
Unreasonable Size Argument | Security | bio.c | 625 | wolfSSL_BIO_MEMORY_write
Unreasonable Size Argument | Security | wolfio.c | 1185 | wolfIO_Send
Uninitialized Variable | Security | curve25519.c | 106 | curve25519_copy_point

# Testing

CI + CodeSonar validation

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
