### PR TITLE
Fix for STM32 Hash with IRQ enabled

### DIFF
--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -164,8 +164,9 @@ static void wc_Stm32_Hash_RestoreContext(STM32_HASH_Context* ctx, int algo)
         /* init content */
 
     #if defined(HASH_IMR_DINIE) && defined(HASH_IMR_DCIE)
-        /* enable IRQ's */
-        HASH->IMR |= (HASH_IMR_DINIE | HASH_IMR_DCIE);
+        /* Disable IRQ's - wolfSSL does not use the HASH/RNG IRQ
+         * If using the HAL hashing API's directly it will re-enable the IRQs */
+        HASH->IMR &= ~(HASH_IMR_DINIE | HASH_IMR_DCIE);
     #endif
 
         /* reset the control register */


### PR DESCRIPTION
# Description

Fix for STM32 Hash with NVIC (IRQ) enabled that can cause a DINIS interrupt that does not get cleared. If the HASH NVIC tab has Interrupts enabled it can cause an IRQ to be triggered that is not cleared. This is because the wolfSSL implementation of STM32 Hash does not call the HAL HASH API's and does not use interrupts yet. 

Fixes ZD 19778

# Testing

Tested on STM32H753.
<img width="1596" alt="Screenshot 2025-04-23 at 12 00 53 PM" src="https://github.com/user-attachments/assets/41e43c5d-92c0-4eb1-9d50-66cdc6f1b9f3" />
<img width="576" alt="Screenshot 2025-04-23 at 12 01 10 PM" src="https://github.com/user-attachments/assets/54a92ee4-2df3-495d-8b04-3e46fc5405a1" />

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
