### PR TITLE
Fixes to support _WIN32_WCE (VS 2008 with WinCE 6.0/7.0)

### DIFF
--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -182,7 +182,7 @@ static WC_INLINE int wolfSSL_LastError(int err, SOCKET_T sd)
  */
 static int TranslateIoReturnCode(int err, SOCKET_T sd, int direction)
 {
-#ifdef  _WIN32
+#if defined(_WIN32) && !defined(__WATCOMC__) && !defined(_WIN32_WCE)
     size_t errstr_offset;
     char errstr[WOLFSSL_STRERROR_BUFFER_SIZE];
 #endif /* _WIN32 */
@@ -241,7 +241,7 @@ static int TranslateIoReturnCode(int err, SOCKET_T sd, int direction)
         return WOLFSSL_CBIO_ERR_CONN_CLOSE;
     }
 
-#if defined(_WIN32) && !defined(__WATCOMC__)
+#if defined(_WIN32) && !defined(__WATCOMC__) && !defined(_WIN32_WCE)
     strcpy_s(errstr, sizeof(errstr), "\tGeneral error: ");
     errstr_offset = strlen(errstr);
     FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1622,6 +1622,17 @@ typedef struct w64wrapper {
         typedef unsigned int   THREAD_RETURN;
         typedef TaskHandle_t   THREAD_TYPE;
         #define WOLFSSL_THREAD
+    #elif defined(_WIN32_WCE)
+        typedef unsigned      THREAD_RETURN;
+        typedef size_t        THREAD_TYPE;
+        typedef struct COND_TYPE {
+            wolfSSL_Mutex mutex;
+            HANDLE cond;
+        } COND_TYPE;
+        #define WOLFSSL_COND
+        #define INVALID_THREAD_VAL ((THREAD_TYPE)(INVALID_HANDLE_VALUE))
+        #define WOLFSSL_THREAD __stdcall
+        #define WOLFSSL_THREAD_NO_JOIN __cdecl
     #elif defined(USE_WINDOWS_API)
         typedef unsigned      THREAD_RETURN;
         typedef uintptr_t     THREAD_TYPE;


### PR DESCRIPTION
# Description

Fixes to support `_WIN32_WCE` (VS 2008 with WinCE 6.0/7.0). 

This should have been part of #8621.

# Testing

Tested with VS 2008 and .NET 3.5 on Win CE 6.0/7.0.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
