### PR TITLE
Ada: prepare inclusion of v5.8.0 in Alire index

### DIFF
--- a/wrapper/Ada/alire.toml
+++ b/wrapper/Ada/alire.toml
@@ -1,10 +1,10 @@
 name = "wolfssl"
 description = "WolfSSL encryption library and its Ada bindings"
-version = "5.7.6"
+version = "5.8.0"
 
 authors = ["WolfSSL Team <support@wolfssl.com>"]
-maintainers = ["Fernando Oleo Blanco <irvise@irvise.xyz>"]
-maintainers-logins = ["Irvise"]
+maintainers = ["Fernando Oleo Blanco <irvise@irvise.xyz>", "Manuel Gomez <mgrojo@gmail.com>"]
+maintainers-logins = ["Irvise", "mgrojo"]
 licenses = "GPL-2.0-only"
 website = "https://www.wolfssl.com/"
 project-files = ["wolfssl.gpr"]


### PR DESCRIPTION
# Description

This prepares the Alire manifest for publishing in the Alire index.

It can also be done with a fork, see draft PR: https://github.com/alire-project/alire-index/pull/1485, but I suppose it's better if the origin remits to the official repository. I will redo the Alire PR if the commit enters this repository.

Fixes #8490

# Testing

How did you test?

Automatic tests by `alr publish`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
