### PR TITLE
Speculative fix for CodeSonar overflow issue in ssl_certman.c

### DIFF
--- a/src/ssl_certman.c
+++ b/src/ssl_certman.c
@@ -1525,7 +1525,7 @@ int CM_MemRestoreCertCache(WOLFSSL_CERT_MANAGER* cm, const void* mem, int sz)
     WOLFSSL_ENTER("CM_MemRestoreCertCache");
 
     /* Check memory available is bigger than cache header. */
-    if (current > end) {
+    if ((sz < (int)sizeof(CertCacheHeader)) || (current > end)) {
         WOLFSSL_MSG("Cert Cache Memory buffer too small");
         ret = BUFFER_E;
     }


### PR DESCRIPTION

# Description
CodeSonar thinks there is a buffer overrun in `CM_MemRestoreCertCache` when checking `hdr->version`, etc. The length is checked indirectly when comparing `current > end`. 

This change provides a more direct check to see if CodeSonar is happy.

[Buffer Overrun _ daily _ CodeSonar.pdf](https://github.com/user-attachments/files/19915073/Buffer.Overrun._.daily._.CodeSonar.pdf)

# Testing

Awaiting CodeSonar run.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
