### PR TITLE
Fix coverity warnings

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -20968,6 +20968,7 @@ int TimingPadVerify(WOLFSSL* ssl, const byte* input, int padLen, int macSz,
     byte good;
     int  ret = 0;
 
+    XMEMSET(verify, 0, WC_MAX_DIGEST_SIZE);
     good = MaskPadding(input, pLen, macSz);
     /* 4th argument has potential to underflow, ssl->hmac function should
      * either increment the size by (macSz + padLen + 1) before use or check on
@@ -21601,6 +21602,7 @@ static WC_INLINE int VerifyMac(WOLFSSL* ssl, const byte* input, word32 msgSz,
     byte   verify[WC_MAX_DIGEST_SIZE];
 
     XMEMSET(verify, 0, WC_MAX_DIGEST_SIZE);
+
     if (ssl->specs.cipher_type == block) {
         pad = input[msgSz - 1];
         padByte = 1;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -20538,6 +20538,8 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
         unsigned int sum = 0;
         unsigned int outSz = MAX_OID_SZ;
         unsigned char out[MAX_OID_SZ];
+
+        XMEMSET(out, 0, sizeof(out));
     #endif
 
         WOLFSSL_ENTER("wolfSSL_OBJ_txt2nid");

--- a/src/tls.c
+++ b/src/tls.c
@@ -7743,8 +7743,11 @@ static int TLSX_KeyShare_GenDhKey(WOLFSSL *ssl, KeyShareEntry* kse)
 
     if (ret != 0) {
         /* Cleanup on error, otherwise data owned by key share entry */
-        XFREE(kse->privKey, ssl->heap, DYNAMIC_TYPE_PRIVATE_KEY);
-        kse->privKey = NULL;
+        if (kse->privKey) {
+            ForceZero(kse->privKey, pvtSz);
+            XFREE(kse->privKey, ssl->heap, DYNAMIC_TYPE_PRIVATE_KEY);
+            kse->privKey = NULL;
+        }
         XFREE(kse->pubKey, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
         kse->pubKey = NULL;
     }
@@ -8335,7 +8338,11 @@ static int TLSX_KeyShare_GenPqcKeyClient(WOLFSSL *ssl, KeyShareEntry* kse)
         XFREE(kse->pubKey, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
         kse->pubKey = NULL;
     #ifndef WOLFSSL_TLSX_PQC_MLKEM_STORE_OBJ
-        XFREE(privKey, ssl->heap, DYNAMIC_TYPE_PRIVATE_KEY);
+        if (privKey) {
+            ForceZero(privKey, privSz);
+            XFREE(privKey, ssl->heap, DYNAMIC_TYPE_PRIVATE_KEY);
+            privKey = NULL;
+        }
     #else
         XFREE(kem, ssl->heap, DYNAMIC_TYPE_PRIVATE_KEY);
         kse->key = NULL;
@@ -8804,8 +8811,11 @@ static int TLSX_KeyShare_ProcessDh(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
         wc_FreeDhKey(dhKey);
     XFREE(keyShareEntry->key, ssl->heap, DYNAMIC_TYPE_DH);
     keyShareEntry->key = NULL;
-    XFREE(keyShareEntry->privKey, ssl->heap, DYNAMIC_TYPE_PRIVATE_KEY);
-    keyShareEntry->privKey = NULL;
+    if (keyShareEntry->privKey) {
+        ForceZero(keyShareEntry->privKey, keyShareEntry->keyLen);
+        XFREE(keyShareEntry->privKey, ssl->heap, DYNAMIC_TYPE_PRIVATE_KEY);
+        keyShareEntry->privKey = NULL;
+    }
     XFREE(keyShareEntry->pubKey, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
     keyShareEntry->pubKey = NULL;
     XFREE(keyShareEntry->ke, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5964,6 +5964,8 @@ static int FindPsk(WOLFSSL* ssl, PreSharedKey* psk, const byte* suite, int* err)
 
     WOLFSSL_ENTER("FindPsk");
 
+    XMEMSET(foundSuite, 0, sizeof(foundSuite));
+
     ret = FindPskSuite(ssl, psk, ssl->arrays->psk_key, &ssl->arrays->psk_keySz,
                        suite, &found, foundSuite);
     if (ret == 0 && found) {

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -33849,6 +33849,8 @@ int wc_SetExtKeyUsageOID(Cert *cert, const char *in, word32 sz, byte idx,
     byte oid[CTC_MAX_EKU_OID_SZ];
     word32 oidSz = CTC_MAX_EKU_OID_SZ;
 
+    XMEMSET(oid, 0, sizeof(oid));
+
     if (idx >= CTC_MAX_EKU_NB || sz >= CTC_MAX_EKU_OID_SZ) {
         WOLFSSL_MSG("Either idx or sz was too large");
         return BAD_FUNC_ARG;
@@ -33875,6 +33877,8 @@ int wc_SetCustomExtension(Cert *cert, int critical, const char *oid,
     byte encodedOid[MAX_OID_SZ];
     word32 encodedOidSz = MAX_OID_SZ;
     int ret;
+
+    XMEMSET(encodedOid, 0, sizeof(encodedOid));
 
     if (cert == NULL || oid == NULL || der == NULL || derSz == 0) {
         return BAD_FUNC_ARG;

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -780,6 +780,7 @@ int wc_ShaFinalRaw(wc_Sha* sha, byte* hash)
 {
 #ifdef LITTLE_ENDIAN_ORDER
     word32 digest[WC_SHA_DIGEST_SIZE / sizeof(word32)];
+    XMEMSET(digest, 0, sizeof(digest));
 #endif
 
     if (sha == NULL || hash == NULL) {

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -1683,6 +1683,7 @@ static int InitSha256(wc_Sha256* sha256)
     {
     #ifdef LITTLE_ENDIAN_ORDER
         word32 digest[WC_SHA256_DIGEST_SIZE / sizeof(word32)];
+        XMEMSET(digest, 0, sizeof(digest));
     #endif
 
         if (sha256 == NULL || hash == NULL) {


### PR DESCRIPTION
# Description

- Fix uninitialized var warnings.
- Add missing ForceZero for private key in key exchange.

Fixes zd19763.
