### PR TITLE
Coverity misc

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -477,20 +477,23 @@ int DeriveTlsKeys(WOLFSSL* ssl)
         return MEMORY_E;
     }
 #endif
+
+    XMEMSET(key_dig, 0, MAX_PRF_DIG);
+
 #if !defined(NO_CERTS) && defined(HAVE_PK_CALLBACKS)
-        ret = PROTOCOLCB_UNAVAILABLE;
-        if (ssl->ctx->GenSessionKeyCb) {
-            void* ctx = wolfSSL_GetGenSessionKeyCtx(ssl);
-            ret = ssl->ctx->GenSessionKeyCb(ssl, ctx);
-        }
-        if (!ssl->ctx->GenSessionKeyCb ||
-            ret == WC_NO_ERR_TRACE(PROTOCOLCB_UNAVAILABLE))
+    ret = PROTOCOLCB_UNAVAILABLE;
+    if (ssl->ctx->GenSessionKeyCb) {
+        void* ctx = wolfSSL_GetGenSessionKeyCtx(ssl);
+        ret = ssl->ctx->GenSessionKeyCb(ssl, ctx);
+    }
+    if (!ssl->ctx->GenSessionKeyCb ||
+        ret == WC_NO_ERR_TRACE(PROTOCOLCB_UNAVAILABLE))
 #endif
-        ret = _DeriveTlsKeys(key_dig, (word32)key_dig_len,
-                         ssl->arrays->masterSecret, SECRET_LEN,
-                         ssl->arrays->serverRandom, ssl->arrays->clientRandom,
-                         IsAtLeastTLSv1_2(ssl), ssl->specs.mac_algorithm,
-                         ssl->heap, ssl->devId);
+    ret = _DeriveTlsKeys(key_dig, (word32)key_dig_len,
+                     ssl->arrays->masterSecret, SECRET_LEN,
+                     ssl->arrays->serverRandom, ssl->arrays->clientRandom,
+                     IsAtLeastTLSv1_2(ssl), ssl->specs.mac_algorithm,
+                     ssl->heap, ssl->devId);
     if (ret == 0)
         ret = StoreKeys(ssl, key_dig, PROVISION_CLIENT_SERVER);
 
@@ -13100,7 +13103,7 @@ static int TLSX_ECH_Write(WOLFSSL_ECH* ech, byte msgType, byte* writeBuf,
 static int TLSX_ECH_GetSize(WOLFSSL_ECH* ech, byte msgType)
 {
     int ret;
-    word32 size;
+    word32 size = 0;
 
     if (ech->state == ECH_WRITE_GREASE) {
         size = sizeof(ech->type) + sizeof(ech->cipherSuite) +

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5053,7 +5053,6 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     byte tls12minor;
 #ifdef WOLFSSL_ASYNC_CRYPT
     Dsh13Args* args = NULL;
-    WOLFSSL_ASSERT_SIZEOF_GE(ssl->async->args, *args);
 #else
     Dsh13Args  args[1];
 #endif
@@ -5061,16 +5060,19 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     WOLFSSL_START(WC_FUNC_SERVER_HELLO_DO);
     WOLFSSL_ENTER("DoTls13ServerHello");
 
+    if (ssl == NULL || ssl->arrays == NULL)
+        return BAD_FUNC_ARG;
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    WOLFSSL_ASSERT_SIZEOF_GE(ssl->async->args, *args);
+#endif
+
     tls12minor = TLSv1_2_MINOR;
 
 #ifdef WOLFSSL_DTLS13
     if (ssl->options.dtls)
         tls12minor = DTLSv1_2_MINOR;
 #endif /*  WOLFSSL_DTLS13 */
-
-
-    if (ssl == NULL || ssl->arrays == NULL)
-        return BAD_FUNC_ARG;
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     if (ssl->async == NULL) {

--- a/tests/api.c
+++ b/tests/api.c
@@ -10080,14 +10080,17 @@ static void test_wolfSSL_CTX_add_session_on_result(WOLFSSL* ssl)
         sess = &test_wolfSSL_CTX_add_session_client_sess;
     if (*sess == NULL) {
 #ifdef NO_SESSION_CACHE_REF
-        AssertNotNull(*sess = wolfSSL_get1_session(ssl));
+        *sess = wolfSSL_get1_session(ssl);
+        AssertNotNull(*sess);
 #else
         /* Test for backwards compatibility */
         if (wolfSSL_is_server(ssl)) {
-            AssertNotNull(*sess = wolfSSL_get1_session(ssl));
+            *sess = wolfSSL_get1_session(ssl);
+            AssertNotNull(*sess);
         }
         else {
-            AssertNotNull(*sess = wolfSSL_get_session(ssl));
+            *sess = wolfSSL_get_session(ssl);
+            AssertNotNull(*sess);
         }
 #endif
         /* Now save the session in the internal store to make it available
@@ -10114,8 +10117,8 @@ static void test_wolfSSL_CTX_add_session_on_result(WOLFSSL* ssl)
     /* Save CTX to be able to decrypt tickets */
     if (wolfSSL_is_server(ssl) &&
             test_wolfSSL_CTX_add_session_server_ctx == NULL) {
-        AssertNotNull(test_wolfSSL_CTX_add_session_server_ctx
-                = wolfSSL_get_SSL_CTX(ssl));
+        test_wolfSSL_CTX_add_session_server_ctx = wolfSSL_get_SSL_CTX(ssl);
+        AssertNotNull(test_wolfSSL_CTX_add_session_server_ctx);
         AssertIntEQ(wolfSSL_CTX_up_ref(wolfSSL_get_SSL_CTX(ssl)),
                 WOLFSSL_SUCCESS);
     }
@@ -37389,10 +37392,13 @@ static THREAD_RETURN WOLFSSL_THREAD test_wolfSSL_BIO_accept_client(void* args)
     (void)args;
 
     AssertIntGT(snprintf(connectAddr, sizeof(connectAddr), "%s:%d", wolfSSLIP, wolfSSLPort), 0);
-    AssertNotNull(clientBio = BIO_new_connect(connectAddr));
+    clientBio = BIO_new_connect(connectAddr);
+    AssertNotNull(clientBio);
     AssertIntEQ(BIO_do_connect(clientBio), 1);
-    AssertNotNull(ctx = SSL_CTX_new(SSLv23_method()));
-    AssertNotNull(sslClient = SSL_new(ctx));
+    ctx = SSL_CTX_new(SSLv23_method());
+    AssertNotNull(ctx);
+    sslClient = SSL_new(ctx);
+    AssertNotNull(sslClient);
     AssertIntEQ(wolfSSL_CTX_load_verify_locations(ctx, caCertFile, 0), WOLFSSL_SUCCESS);
     SSL_set_bio(sslClient, clientBio, clientBio);
     AssertIntEQ(SSL_connect(sslClient), 1);

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -309,6 +309,8 @@ static int test_crl_monitor(void)
     int ret = -1;
     int i = -1, j;
 
+    XMEMSET(tmpDir, '\0', sizeof(tmpDir));
+
     printf("\nRunning CRL monitor test\n");
 
     (void)XSNPRINTF(rounds, sizeof(rounds), "%d", CRL_MONITOR_TEST_ROUNDS);
@@ -499,7 +501,11 @@ static void show_ciphers(void)
 /* Cleanup temporary output file. */
 static void cleanup_output(void)
 {
-    remove(outputName);
+    int ret = 0;
+    ret = remove(outputName);
+    if (ret < 0) {
+        fprintf(stderr, "remove(%s) failed: %d\n", outputName, ret);
+    }
 }
 
 /* Validate output equals input using a hash. Remove temporary output file.

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -7645,8 +7645,12 @@ int wc_ecc_gen_deterministic_k(const byte* hash, word32 hashSz,
     /* 3.2 c. Set K = 0x00 0x00 ... */
     XMEMSET(K, 0x00, KSz);
 
-    mp_init(z1); /* always init z1 and free z1 */
-    ret = mp_to_unsigned_bin_len(priv, x, (int)qLen);
+    if (ret == 0) {
+        ret = mp_init(z1); /* always init z1 and free z1 */
+    }
+    if (ret == 0) {
+        ret = mp_to_unsigned_bin_len(priv, x, (int)qLen);
+    }
     if (ret == 0) {
     #ifdef WOLFSSL_CHECK_MEM_ZERO
         wc_MemZero_Add("wc_ecc_gen_deterministic_k x", x, qLen);
@@ -7690,7 +7694,7 @@ int wc_ecc_gen_deterministic_k(const byte* hash, word32 hashSz,
     #endif
         {
             /* use original hash and keep leading 0's */
-            mp_to_unsigned_bin_len(z1, h1, (int)h1len);
+            ret = mp_to_unsigned_bin_len(z1, h1, (int)h1len);
         }
     }
     mp_free(z1);

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -2084,6 +2084,7 @@ static WC_INLINE int my_psk_use_session_cb(WOLFSSL* ssl,
     numCiphers = sk_num(supportedCiphers);
 
     for (i = 0; i < numCiphers; ++i) {
+        XMEMSET(buf, 0, sizeof(buf));
 
         if ((cipher = (const WOLFSSL_CIPHER*)sk_value(supportedCiphers, i))) {
             SSL_CIPHER_description(cipher, buf, sizeof(buf));


### PR DESCRIPTION
# Description

Fixes misc warnings from coverity:
- Fix assignment_where_comparison_intended and related in tests/quic.c and tests/api.c.
- Fix uninitialized vars and check_after_deref.
- Check return values in ecc.c and testsuite.c.
