### PR TITLE
Fix an off-by-one buffer error in asn.c.

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -26153,7 +26153,7 @@ int wc_EncryptedInfoParse(EncryptedInfo* info, const char** pBuffer,
             newline = XSTRNSTR(finish, "\r", min(finishSz, PEM_LINE_LEN));
 
             /* get cipher name */
-            if (NAME_SZ < (finish - start)) /* buffer size of info->name */
+            if (NAME_SZ <= (finish - start)) /* buffer size of info->name */
                 return BUFFER_E;
             if (XMEMCPY(info->name, start, (size_t)(finish - start)) == NULL)
                 return BUFFER_E;


### PR DESCRIPTION
Need to ensure "finish-start" is less than the size before using it as an index a few lines down.

# Description

On line 26156 of asn.c, a check is made that "finish-start" is greater than the size of the buffer and if so, it returns an error.  A few lines down the buffer is accessed at index "finish-start", which will write off the end of the buffer if "finish-start" equals the size of the buffer.  The fix is to ensure that "finish-start" is less than the buffer size by changing "<" to "<=" on the comparison.

ZD 19834