### PR TITLE
20250501-linuxkm-ecdsa-workaround

### DIFF
--- a/linuxkm/lkcapi_dh_glue.c
+++ b/linuxkm/lkcapi_dh_glue.c
@@ -2821,11 +2821,11 @@ static int linuxkm_test_kpp_driver(const char * driver,
     if (IS_ERR(tfm)) {
         pr_err("error: allocating kpp algorithm %s failed: %ld\n",
                driver, PTR_ERR(tfm));
-        tfm = NULL;
         if (PTR_ERR(tfm) == -ENOMEM)
             test_rc = MEMORY_E;
         else
             test_rc = BAD_FUNC_ARG;
+        tfm = NULL;
         goto test_kpp_end;
     }
 
@@ -2833,11 +2833,11 @@ static int linuxkm_test_kpp_driver(const char * driver,
     if (IS_ERR(req)) {
         pr_err("error: allocating kpp request %s failed\n",
                driver);
-        req = NULL;
         if (PTR_ERR(req) == -ENOMEM)
             test_rc = MEMORY_E;
         else
             test_rc = BAD_FUNC_ARG;
+        req = NULL;
         goto test_kpp_end;
     }
 

--- a/linuxkm/lkcapi_ecdh_glue.c
+++ b/linuxkm/lkcapi_ecdh_glue.c
@@ -804,11 +804,11 @@ static int linuxkm_test_ecdh_nist_driver(const char * driver,
     if (IS_ERR(tfm)) {
         pr_err("error: allocating kpp algorithm %s failed: %ld\n",
                driver, PTR_ERR(tfm));
-        tfm = NULL;
         if (PTR_ERR(tfm) == -ENOMEM)
             test_rc = MEMORY_E;
         else
             test_rc = BAD_FUNC_ARG;
+        tfm = NULL;
         goto test_ecdh_nist_end;
     }
 
@@ -816,11 +816,11 @@ static int linuxkm_test_ecdh_nist_driver(const char * driver,
     if (IS_ERR(req)) {
         pr_err("error: allocating kpp request %s failed\n",
                driver);
-        req = NULL;
         if (PTR_ERR(req) == -ENOMEM)
             test_rc = MEMORY_E;
         else
             test_rc = BAD_FUNC_ARG;
+        req = NULL;
         goto test_ecdh_nist_end;
     }
 

--- a/linuxkm/lkcapi_ecdsa_glue.c
+++ b/linuxkm/lkcapi_ecdsa_glue.c
@@ -680,11 +680,11 @@ static int linuxkm_test_ecdsa_nist_driver(const char * driver,
     if (IS_ERR(tfm)) {
         pr_err("error: allocating akcipher algorithm %s failed: %ld\n",
                driver, PTR_ERR(tfm));
-        tfm = NULL;
         if (PTR_ERR(tfm) == -ENOMEM)
             test_rc = MEMORY_E;
         else
             test_rc = BAD_FUNC_ARG;
+        tfm = NULL;
         goto test_ecdsa_nist_end;
     }
 
@@ -692,11 +692,11 @@ static int linuxkm_test_ecdsa_nist_driver(const char * driver,
     if (IS_ERR(req)) {
         pr_err("error: allocating akcipher request %s failed\n",
                driver);
-        req = NULL;
         if (PTR_ERR(req) == -ENOMEM)
             test_rc = MEMORY_E;
         else
             test_rc = BAD_FUNC_ARG;
+        req = NULL;
         goto test_ecdsa_nist_end;
     }
 

--- a/linuxkm/lkcapi_rsa_glue.c
+++ b/linuxkm/lkcapi_rsa_glue.c
@@ -1653,11 +1653,11 @@ static int linuxkm_test_pkcs1_driver(const char * driver, int nbits,
     if (IS_ERR(tfm)) {
         pr_err("error: allocating akcipher algorithm %s failed: %ld\n",
                driver, PTR_ERR(tfm));
-        tfm = NULL;
         if (PTR_ERR(tfm) == -ENOMEM)
             test_rc = MEMORY_E;
         else
             test_rc = BAD_FUNC_ARG;
+        tfm = NULL;
         goto test_pkcs1_end;
     }
 
@@ -1665,11 +1665,11 @@ static int linuxkm_test_pkcs1_driver(const char * driver, int nbits,
     if (IS_ERR(req)) {
         pr_err("error: allocating akcipher request %s failed\n",
                driver);
-        req = NULL;
         if (PTR_ERR(req) == -ENOMEM)
             test_rc = MEMORY_E;
         else
             test_rc = BAD_FUNC_ARG;
+        req = NULL;
         goto test_pkcs1_end;
     }
 


### PR DESCRIPTION
`linuxkm/lkcapi_glue.c`: with kernels <6.3.0, disable kernel `fips_enabled` mode while registering FIPS ECDSA shims, to work around crypto manager bug (not recognized as FIPS-allowed algorithms).

`linuxkm/lkcapi_*_glue.c`: in test harnesses, fix several out-of-order `NULL`ing of `PTR_ERR`-type pointers in error paths.

tested with
```
wolfssl-multi-test.sh ...
 check-source-text
 linuxkm-5.10.236-all-cryptonly-intelasm-fips-v6-dyn-hash-LKCAPI-insmod
 linuxkm-all-fips-v6-cryptonly-LKCAPI-insmod-fortify
 linuxkm-cryptonly-intelasm-fips-v6-dyn-hash-LKCAPI-yes-twc-insmod-ksanitizer
 linuxkm-6.12-all-cryptonly-intelasm-fips-v6-dyn-hash-LKCAPI-insmod
```
