### PR TITLE
linuxkm rsa: add more pkcs1pad sha variants

### DIFF
--- a/linuxkm/lkcapi_glue.c
+++ b/linuxkm/lkcapi_glue.c
@@ -607,14 +607,23 @@ static int linuxkm_lkcapi_register(void)
     #if defined(LINUXKM_DIRECT_RSA)
     REGISTER_ALG(direct_rsa, akcipher, linuxkm_test_rsa);
     #endif /* LINUXKM_DIRECT_RSA */
+    #ifdef WOLFSSL_SHA224
+    REGISTER_ALG(pkcs1_sha224, akcipher, linuxkm_test_pkcs1_sha224);
+    #endif /* WOLFSSL_SHA224 */
     #ifndef NO_SHA256
-    REGISTER_ALG(pkcs1_sha256, akcipher,
-                 linuxkm_test_pkcs1_sha256);
+    REGISTER_ALG(pkcs1_sha256, akcipher, linuxkm_test_pkcs1_sha256);
     #endif /* !NO_SHA256 */
+    #ifdef WOLFSSL_SHA384
+    REGISTER_ALG(pkcs1_sha384, akcipher, linuxkm_test_pkcs1_sha384);
+    #endif /* WOLFSSL_SHA384 */
     #ifdef WOLFSSL_SHA512
-    REGISTER_ALG(pkcs1_sha512, akcipher,
-                 linuxkm_test_pkcs1_sha512);
+    REGISTER_ALG(pkcs1_sha512, akcipher, linuxkm_test_pkcs1_sha512);
     #endif /* WOLFSSL_SHA512 */
+    #ifdef WOLFSSL_SHA3
+    REGISTER_ALG(pkcs1_sha3_256, akcipher, linuxkm_test_pkcs1_sha3_256);
+    REGISTER_ALG(pkcs1_sha3_384, akcipher, linuxkm_test_pkcs1_sha3_384);
+    REGISTER_ALG(pkcs1_sha3_512, akcipher, linuxkm_test_pkcs1_sha3_512);
+    #endif /* WOLFSSL_SHA3 */
 #endif
 
 #ifdef LINUXKM_LKCAPI_REGISTER_DH
@@ -835,12 +844,26 @@ static int linuxkm_lkcapi_unregister(void)
     #if defined(LINUXKM_DIRECT_RSA)
         UNREGISTER_ALG(direct_rsa, akcipher);
     #endif /* LINUXKM_DIRECT_RSA */
+    #ifdef WOLFSSL_SHA224
+        UNREGISTER_ALG(pkcs1_sha224, akcipher);
+    #endif /* WOLFSSL_SHA224 */
     #ifndef NO_SHA256
         UNREGISTER_ALG(pkcs1_sha256, akcipher);
     #endif /* !NO_SHA256 */
+    #ifdef WOLFSSL_SHA384
+        UNREGISTER_ALG(pkcs1_sha384, akcipher);
+    #endif /* WOLFSSL_SHA384 */
+    #ifdef WOLFSSL_SHA384
+        UNREGISTER_ALG(pkcs1_sha384, akcipher);
+    #endif /* WOLFSSL_SHA384 */
     #ifdef WOLFSSL_SHA512
         UNREGISTER_ALG(pkcs1_sha512, akcipher);
     #endif /* WOLFSSL_SHA512 */
+    #ifdef WOLFSSL_SHA3
+        UNREGISTER_ALG(pkcs1_sha3_256, akcipher);
+        UNREGISTER_ALG(pkcs1_sha3_384, akcipher);
+        UNREGISTER_ALG(pkcs1_sha3_512, akcipher);
+    #endif /* WOLFSSL_SHA3 */
 #endif /* LINUXKM_LKCAPI_REGISTER_RSA */
 
 #ifdef LINUXKM_LKCAPI_REGISTER_DH

--- a/linuxkm/lkcapi_rsa_glue.c
+++ b/linuxkm/lkcapi_rsa_glue.c
@@ -43,13 +43,33 @@
 #define WOLFKM_RSA_NAME      ("rsa")
 #define WOLFKM_RSA_DRIVER    ("rsa" WOLFKM_DRIVER_FIPS "-wolfcrypt")
 
+#define WOLFKM_PKCS1_SHA224_NAME   ("pkcs1pad(rsa,sha224)")
+#define WOLFKM_PKCS1_SHA224_DRIVER ("pkcs1pad(rsa" WOLFKM_DRIVER_FIPS \
+                                    "-wolfcrypt,sha224)")
+
 #define WOLFKM_PKCS1_SHA256_NAME   ("pkcs1pad(rsa,sha256)")
 #define WOLFKM_PKCS1_SHA256_DRIVER ("pkcs1pad(rsa" WOLFKM_DRIVER_FIPS \
                                     "-wolfcrypt,sha256)")
 
+#define WOLFKM_PKCS1_SHA384_NAME   ("pkcs1pad(rsa,sha384)")
+#define WOLFKM_PKCS1_SHA384_DRIVER ("pkcs1pad(rsa" WOLFKM_DRIVER_FIPS \
+                                    "-wolfcrypt,sha384)")
+
 #define WOLFKM_PKCS1_SHA512_NAME   ("pkcs1pad(rsa,sha512)")
 #define WOLFKM_PKCS1_SHA512_DRIVER ("pkcs1pad(rsa" WOLFKM_DRIVER_FIPS \
                                     "-wolfcrypt,sha512)")
+
+#define WOLFKM_PKCS1_SHA3_256_NAME   ("pkcs1pad(rsa,sha3-256)")
+#define WOLFKM_PKCS1_SHA3_256_DRIVER ("pkcs1pad(rsa" WOLFKM_DRIVER_FIPS \
+                                      "-wolfcrypt,sha3-256)")
+
+#define WOLFKM_PKCS1_SHA3_384_NAME   ("pkcs1pad(rsa,sha3-384)")
+#define WOLFKM_PKCS1_SHA3_384_DRIVER ("pkcs1pad(rsa" WOLFKM_DRIVER_FIPS \
+                                      "-wolfcrypt,sha3-384)")
+
+#define WOLFKM_PKCS1_SHA3_512_NAME   ("pkcs1pad(rsa,sha3-512)")
+#define WOLFKM_PKCS1_SHA3_512_DRIVER ("pkcs1pad(rsa" WOLFKM_DRIVER_FIPS \
+                                      "-wolfcrypt,sha3-512)")
 
 #if defined(WOLFSSL_KEY_GEN)
     #if defined(LINUXKM_DIRECT_RSA)
@@ -62,12 +82,23 @@
 #if defined(LINUXKM_DIRECT_RSA)
     static int direct_rsa_loaded = 0;
 #endif /* LINUXKM_DIRECT_RSA */
+#ifdef WOLFSSL_SHA224
+    static int pkcs1_sha224_loaded = 0;
+#endif /* WOLFSSL_SHA224 */
 #ifndef NO_SHA256
     static int pkcs1_sha256_loaded = 0;
 #endif /* !NO_SHA256 */
+#ifdef WOLFSSL_SHA384
+    static int pkcs1_sha384_loaded = 0;
+#endif /* WOLFSSL_SHA384 */
 #ifdef WOLFSSL_SHA512
     static int pkcs1_sha512_loaded = 0;
 #endif /* WOLFSSL_SHA512 */
+#ifdef WOLFSSL_SHA3
+    static int pkcs1_sha3_256_loaded = 0;
+    static int pkcs1_sha3_384_loaded = 0;
+    static int pkcs1_sha3_512_loaded = 0;
+#endif /* WOLFSSL_SHA3 */
 
 struct km_rsa_ctx {
     WC_RNG       rng;            /* needed for pkcs1 padding, and blinding */
@@ -94,12 +125,23 @@ static unsigned int km_rsa_max_size(struct crypto_akcipher *tfm);
 #endif /* LINUXKM_DIRECT_RSA */
 
 /* pkcs1 callbacks */
+#ifdef WOLFSSL_SHA224
+    static int          km_pkcs1_sha224_init(struct crypto_akcipher *tfm);
+#endif /* WOLFSSL_SHA224 */
 #ifndef NO_SHA256
     static int          km_pkcs1_sha256_init(struct crypto_akcipher *tfm);
 #endif /* !NO_SHA256 */
+#ifdef WOLFSSL_SHA384
+    static int          km_pkcs1_sha384_init(struct crypto_akcipher *tfm);
+#endif /* WOLFSSL_SHA384 */
 #ifdef WOLFSSL_SHA512
     static int          km_pkcs1_sha512_init(struct crypto_akcipher *tfm);
 #endif /* WOLFSSL_SHA512 */
+#ifdef WOLFSSL_SHA3
+    static int          km_pkcs1_sha3_256_init(struct crypto_akcipher *tfm);
+    static int          km_pkcs1_sha3_384_init(struct crypto_akcipher *tfm);
+    static int          km_pkcs1_sha3_512_init(struct crypto_akcipher *tfm);
+#endif /* WOLFSSL_SHA3 */
 #if !defined(LINUXKM_AKCIPHER_NO_SIGNVERIFY)
     static int          km_pkcs1_sign(struct akcipher_request *req);
     static int          km_pkcs1_verify(struct akcipher_request *req);
@@ -128,6 +170,27 @@ static struct akcipher_alg direct_rsa = {
 };
 #endif /* LINUXKM_DIRECT_RSA */
 
+#ifdef WOLFSSL_SHA224
+static struct akcipher_alg pkcs1_sha224 = {
+    .base.cra_name        = WOLFKM_PKCS1_SHA224_NAME,
+    .base.cra_driver_name = WOLFKM_PKCS1_SHA224_DRIVER,
+    .base.cra_priority    = WOLFSSL_LINUXKM_LKCAPI_PRIORITY,
+    .base.cra_module      = THIS_MODULE,
+    .base.cra_ctxsize     = sizeof(struct km_rsa_ctx),
+    #if !defined(LINUXKM_AKCIPHER_NO_SIGNVERIFY)
+    .sign                 = km_pkcs1_sign,
+    .verify               = km_pkcs1_verify,
+    #endif /* !LINUXKM_AKCIPHER_NO_SIGNVERIFY */
+    .encrypt              = km_pkcs1_enc,
+    .decrypt              = km_pkcs1_dec,
+    .set_priv_key         = km_rsa_set_priv,
+    .set_pub_key          = km_rsa_set_pub,
+    .max_size             = km_rsa_max_size,
+    .init                 = km_pkcs1_sha224_init,
+    .exit                 = km_rsa_exit,
+};
+#endif /* WOLFSSL_SHA224 */
+
 #ifndef NO_SHA256
 static struct akcipher_alg pkcs1_sha256 = {
     .base.cra_name        = WOLFKM_PKCS1_SHA256_NAME,
@@ -149,6 +212,27 @@ static struct akcipher_alg pkcs1_sha256 = {
 };
 #endif /* !NO_SHA256 */
 
+#ifdef WOLFSSL_SHA384
+static struct akcipher_alg pkcs1_sha384 = {
+    .base.cra_name        = WOLFKM_PKCS1_SHA384_NAME,
+    .base.cra_driver_name = WOLFKM_PKCS1_SHA384_DRIVER,
+    .base.cra_priority    = WOLFSSL_LINUXKM_LKCAPI_PRIORITY,
+    .base.cra_module      = THIS_MODULE,
+    .base.cra_ctxsize     = sizeof(struct km_rsa_ctx),
+    #if !defined(LINUXKM_AKCIPHER_NO_SIGNVERIFY)
+    .sign                 = km_pkcs1_sign,
+    .verify               = km_pkcs1_verify,
+    #endif /* !LINUXKM_AKCIPHER_NO_SIGNVERIFY */
+    .encrypt              = km_pkcs1_enc,
+    .decrypt              = km_pkcs1_dec,
+    .set_priv_key         = km_rsa_set_priv,
+    .set_pub_key          = km_rsa_set_pub,
+    .max_size             = km_rsa_max_size,
+    .init                 = km_pkcs1_sha384_init,
+    .exit                 = km_rsa_exit,
+};
+#endif /* WOLFSSL_SHA384 */
+
 #ifdef WOLFSSL_SHA512
 static struct akcipher_alg pkcs1_sha512 = {
     .base.cra_name        = WOLFKM_PKCS1_SHA512_NAME,
@@ -169,6 +253,65 @@ static struct akcipher_alg pkcs1_sha512 = {
     .exit                 = km_rsa_exit,
 };
 #endif /* WOLFSSL_SHA512 */
+
+#ifdef WOLFSSL_SHA3
+static struct akcipher_alg pkcs1_sha3_256 = {
+    .base.cra_name        = WOLFKM_PKCS1_SHA3_256_NAME,
+    .base.cra_driver_name = WOLFKM_PKCS1_SHA3_256_DRIVER,
+    .base.cra_priority    = WOLFSSL_LINUXKM_LKCAPI_PRIORITY,
+    .base.cra_module      = THIS_MODULE,
+    .base.cra_ctxsize     = sizeof(struct km_rsa_ctx),
+    #if !defined(LINUXKM_AKCIPHER_NO_SIGNVERIFY)
+    .sign                 = km_pkcs1_sign,
+    .verify               = km_pkcs1_verify,
+    #endif /* !LINUXKM_AKCIPHER_NO_SIGNVERIFY */
+    .encrypt              = km_pkcs1_enc,
+    .decrypt              = km_pkcs1_dec,
+    .set_priv_key         = km_rsa_set_priv,
+    .set_pub_key          = km_rsa_set_pub,
+    .max_size             = km_rsa_max_size,
+    .init                 = km_pkcs1_sha3_256_init,
+    .exit                 = km_rsa_exit,
+};
+
+static struct akcipher_alg pkcs1_sha3_384 = {
+    .base.cra_name        = WOLFKM_PKCS1_SHA3_384_NAME,
+    .base.cra_driver_name = WOLFKM_PKCS1_SHA3_384_DRIVER,
+    .base.cra_priority    = WOLFSSL_LINUXKM_LKCAPI_PRIORITY,
+    .base.cra_module      = THIS_MODULE,
+    .base.cra_ctxsize     = sizeof(struct km_rsa_ctx),
+    #if !defined(LINUXKM_AKCIPHER_NO_SIGNVERIFY)
+    .sign                 = km_pkcs1_sign,
+    .verify               = km_pkcs1_verify,
+    #endif /* !LINUXKM_AKCIPHER_NO_SIGNVERIFY */
+    .encrypt              = km_pkcs1_enc,
+    .decrypt              = km_pkcs1_dec,
+    .set_priv_key         = km_rsa_set_priv,
+    .set_pub_key          = km_rsa_set_pub,
+    .max_size             = km_rsa_max_size,
+    .init                 = km_pkcs1_sha3_384_init,
+    .exit                 = km_rsa_exit,
+};
+
+static struct akcipher_alg pkcs1_sha3_512 = {
+    .base.cra_name        = WOLFKM_PKCS1_SHA3_512_NAME,
+    .base.cra_driver_name = WOLFKM_PKCS1_SHA3_512_DRIVER,
+    .base.cra_priority    = WOLFSSL_LINUXKM_LKCAPI_PRIORITY,
+    .base.cra_module      = THIS_MODULE,
+    .base.cra_ctxsize     = sizeof(struct km_rsa_ctx),
+    #if !defined(LINUXKM_AKCIPHER_NO_SIGNVERIFY)
+    .sign                 = km_pkcs1_sign,
+    .verify               = km_pkcs1_verify,
+    #endif /* !LINUXKM_AKCIPHER_NO_SIGNVERIFY */
+    .encrypt              = km_pkcs1_enc,
+    .decrypt              = km_pkcs1_dec,
+    .set_priv_key         = km_rsa_set_priv,
+    .set_pub_key          = km_rsa_set_pub,
+    .max_size             = km_rsa_max_size,
+    .init                 = km_pkcs1_sha3_512_init,
+    .exit                 = km_rsa_exit,
+};
+#endif /* WOLFSSL_SHA3 */
 
 static int km_rsa_init(struct crypto_akcipher *tfm, int hash_oid)
 {
@@ -215,16 +358,37 @@ static int km_rsa_init(struct crypto_akcipher *tfm, int hash_oid)
     case 0:
         ctx->digest_len = 0;
         break;
+    #ifdef WOLFSSL_SHA224
+    case SHA224h:
+        ctx->digest_len = WC_SHA224_DIGEST_SIZE;
+        break;
+    #endif /* WOLFSSL_SHA224 */
     #ifndef NO_SHA256
     case SHA256h:
         ctx->digest_len = WC_SHA256_DIGEST_SIZE;
         break;
     #endif /* !NO_SHA256 */
+    #ifdef WOLFSSL_SHA384
+    case SHA384h:
+        ctx->digest_len = WC_SHA384_DIGEST_SIZE;
+        break;
+    #endif /* WOLFSSL_SHA384 */
     #ifdef WOLFSSL_SHA512
     case SHA512h:
         ctx->digest_len = WC_SHA512_DIGEST_SIZE;
         break;
     #endif /* WOLFSSL_SHA512 */
+    #ifdef WOLFSSL_SHA3
+    case SHA3_256h:
+        ctx->digest_len = WC_SHA3_256_DIGEST_SIZE;
+        break;
+    case SHA3_384h:
+        ctx->digest_len = WC_SHA3_384_DIGEST_SIZE;
+        break;
+    case SHA3_512h:
+        ctx->digest_len = WC_SHA3_512_DIGEST_SIZE;
+        break;
+    #endif /* WOLFSSL_SHA3 */
     default:
         pr_err("%s: init: unhandled hash_oid: %d\n", WOLFKM_RSA_DRIVER,
                hash_oid);
@@ -486,7 +650,7 @@ static int km_rsa_set_priv(struct crypto_akcipher *tfm, const void *key,
     ctx->key_len = (word32) key_len;
 
     #ifdef WOLFKM_DEBUG_RSA
-    pr_info("info: exiting km_rsa_set_priv\n");
+    pr_info("info: exiting km_rsa_set_priv: %d\n", keylen);
     #endif /* WOLFKM_DEBUG_RSA */
     return err;
 }
@@ -541,7 +705,7 @@ static int km_rsa_set_pub(struct crypto_akcipher *tfm, const void *key,
     ctx->key_len = (word32) key_len;
 
     #ifdef WOLFKM_DEBUG_RSA
-    pr_info("info: exiting km_rsa_set_pub\n");
+    pr_info("info: exiting km_rsa_set_pub %d\n", keylen);
     #endif /* WOLFKM_DEBUG_RSA */
     return err;
 }
@@ -585,6 +749,13 @@ static void km_rsa_exit(struct crypto_akcipher *tfm)
     return;
 }
 
+#ifdef WOLFSSL_SHA224
+static int km_pkcs1_sha224_init(struct crypto_akcipher *tfm)
+{
+    return km_rsa_init(tfm, SHA224h);
+}
+#endif /* WOLFSSL_SHA224 */
+
 #ifndef NO_SHA256
 static int km_pkcs1_sha256_init(struct crypto_akcipher *tfm)
 {
@@ -592,12 +763,35 @@ static int km_pkcs1_sha256_init(struct crypto_akcipher *tfm)
 }
 #endif /* !NO_SHA256 */
 
+#ifdef WOLFSSL_SHA384
+static int km_pkcs1_sha384_init(struct crypto_akcipher *tfm)
+{
+    return km_rsa_init(tfm, SHA384h);
+}
+#endif /* WOLFSSL_SHA384 */
+
 #ifdef WOLFSSL_SHA512
 static int km_pkcs1_sha512_init(struct crypto_akcipher *tfm)
 {
     return km_rsa_init(tfm, SHA512h);
 }
 #endif /* WOLFSSL_SHA512 */
+#ifdef WOLFSSL_SHA3
+static int km_pkcs1_sha3_256_init(struct crypto_akcipher *tfm)
+{
+    return km_rsa_init(tfm, SHA3_256h);
+}
+
+static int km_pkcs1_sha3_384_init(struct crypto_akcipher *tfm)
+{
+    return km_rsa_init(tfm, SHA3_384h);
+}
+
+static int km_pkcs1_sha3_512_init(struct crypto_akcipher *tfm)
+{
+    return km_rsa_init(tfm, SHA3_512h);
+}
+#endif /* WOLFSSL_SHA3 */
 
 #if !defined(LINUXKM_AKCIPHER_NO_SIGNVERIFY)
 static int km_pkcs1_sign(struct akcipher_request *req)
@@ -691,8 +885,10 @@ pkcs1_sign_out:
     if (sig != NULL) { free(sig); sig = NULL; }
 
     #ifdef WOLFKM_DEBUG_RSA
-    pr_info("info: exiting km_pkcs1_sign\n");
+    pr_info("info: exiting km_pkcs1_sign msg_len %d, enc_msg_len %d,"
+            " sig_len %d, err %d", req->src_len, enc_len, sig_len, err);
     #endif /* WOLFKM_DEBUG_RSA */
+
     return err;
 }
 
@@ -740,12 +936,20 @@ static int km_pkcs1_verify(struct akcipher_request *req)
 
     hash_enc_len = get_hash_enc_len(ctx->hash_oid);
     if (hash_enc_len <= 0) {
+        #ifdef WOLFKM_DEBUG_RSA
+        pr_err("error: %s: bad hash enc len %d",
+               WOLFKM_RSA_DRIVER, hash_enc_len);
+        #endif /* WOLFKM_DEBUG_RSA */
         err = -EINVAL;
         goto pkcs1_verify_out;
     }
 
     if (msg_len != ctx->digest_len || sig_len != ctx->key_len) {
         /* invalid src or dst args */
+        #ifdef WOLFKM_DEBUG_RSA
+        pr_err("error: %s: got msg_len %d, expected %d",
+               WOLFKM_RSA_DRIVER, msg_len, ctx->digest_len);
+        #endif /* WOLFKM_DEBUG_RSA */
         err = -EINVAL;
         goto pkcs1_verify_out;
     }
@@ -802,7 +1006,8 @@ pkcs1_verify_out:
     if (sig != NULL) { free(sig); sig = NULL; }
 
     #ifdef WOLFKM_DEBUG_RSA
-    pr_info("info: exiting km_pkcs1_verify\n");
+    pr_info("info: exiting km_pkcs1_verify msg_len %d, enc_msg_len %d,"
+            " sig_len %d, err %d", msg_len, enc_msg_len, sig_len, err);
     #endif /* WOLFKM_DEBUG_RSA */
     return err;
 }
@@ -877,7 +1082,7 @@ pkcs1_enc_out:
     if (enc != NULL) { free(enc); enc = NULL; }
     if (dec != NULL) { free(dec); dec = NULL; }
     #ifdef WOLFKM_DEBUG_RSA
-    pr_info("info: exiting km_pkcs1_enc\n");
+    pr_info("info: exiting km_pkcs1_enc %d\n", err);
     #endif /* WOLFKM_DEBUG_RSA */
     return err;
 }
@@ -957,7 +1162,7 @@ pkcs1_dec_out:
     if (dec != NULL) { free(dec); dec = NULL; }
 
     #ifdef WOLFKM_DEBUG_RSA
-    pr_info("info: exiting km_pkcs1_dec\n");
+    pr_info("info: exiting km_pkcs1_dec %d", err);
     #endif /* WOLFKM_DEBUG_RSA */
     return err;
 }
@@ -987,7 +1192,7 @@ static int linuxkm_test_rsa(void)
     rc = linuxkm_test_rsa_driver(WOLFKM_RSA_DRIVER, 4096);
     if (rc) { return rc; }
 
-
+    #ifdef WOLFKM_DEBUG_RSA_GENERIC
     /* repeat test against stock linux RSA akcipher. */
     rc = linuxkm_test_rsa_driver("rsa-generic", 2048);
     if (rc) { return rc; }
@@ -997,6 +1202,7 @@ static int linuxkm_test_rsa(void)
 
     rc = linuxkm_test_rsa_driver("rsa-generic", 4096);
     if (rc) { return rc; }
+    #endif /* WOLFKM_DEBUG_RSA_GENERIC */
     #endif /* WOLFKM_DEBUG_RSA */
     #endif /* WOLFSSL_KEY_GEN */
 
@@ -1004,81 +1210,152 @@ static int linuxkm_test_rsa(void)
 }
 #endif /* LINUXKM_DIRECT_RSA */
 
+#if defined(WOLFSSL_KEY_GEN)
+/* Test the given pkcs1 wolfcrypt driver and generic driver for a
+ * hash oid and hash length.
+ * */
+static int linuxkm_test_pkcs1_hash(const char * wc_driver,
+                                   const char * generic_driver,
+                                   int hash_oid, word32 hash_len)
+{
+    int rc = 0;
+
+    rc = linuxkm_test_pkcs1_driver(wc_driver, 2048,
+                                   hash_oid, hash_len);
+    if (rc) { return rc; }
+
+    #ifdef WOLFKM_DEBUG_RSA
+    /* repeat with additional key lengths */
+    rc = linuxkm_test_pkcs1_driver(wc_driver, 3072,
+                                   hash_oid, hash_len);
+    if (rc) { return rc; }
+
+    rc = linuxkm_test_pkcs1_driver(wc_driver, 4096,
+                                   hash_oid, hash_len);
+    if (rc) { return rc; }
+
+    #ifdef WOLFKM_DEBUG_RSA_GENERIC
+    /* repeat tests against stock linux rsa-generic pkcs1pad. */
+    rc = linuxkm_test_pkcs1_driver(generic_driver, 2048,
+                                   hash_oid, hash_len);
+    if (rc) { return rc; }
+
+    rc = linuxkm_test_pkcs1_driver(generic_driver, 3072,
+                                   hash_oid, hash_len);
+    if (rc) { return rc; }
+
+    rc = linuxkm_test_pkcs1_driver(generic_driver, 4096,
+                                   hash_oid, hash_len);
+    if (rc) { return rc; }
+    #endif /* WOLFKM_DEBUG_RSA_GENERIC */
+    #endif /* WOLFKM_DEBUG_RSA */
+
+    (void)generic_driver;
+
+    return rc;
+}
+#endif /* WOLFSSL_KEY_GEN */
+
+#ifdef WOLFSSL_SHA224
+static int linuxkm_test_pkcs1_sha224(void)
+{
+    int rc = 0;
+
+    #if defined(WOLFSSL_KEY_GEN)
+    rc = linuxkm_test_pkcs1_hash(WOLFKM_PKCS1_SHA224_DRIVER,
+                                 "pkcs1pad(rsa-generic,sha224)",
+                                 SHA224h, WC_SHA224_DIGEST_SIZE);
+    #endif /* WOLFSSL_KEY_GEN */
+
+    return rc;
+}
+#endif /* WOLFSSL_SHA224 */
+
 #ifndef NO_SHA256
 static int linuxkm_test_pkcs1_sha256(void)
 {
     int rc = 0;
 
-    #ifdef WOLFSSL_KEY_GEN
-    rc = linuxkm_test_pkcs1_driver(WOLFKM_PKCS1_SHA256_DRIVER, 2048,
-                                   SHA256h, 32);
-    if (rc) { return rc; }
-
-    #ifdef WOLFKM_DEBUG_RSA
-    rc = linuxkm_test_pkcs1_driver(WOLFKM_PKCS1_SHA256_DRIVER, 3072,
-                                   SHA256h, 32);
-    if (rc) { return rc; }
-
-    rc = linuxkm_test_pkcs1_driver(WOLFKM_PKCS1_SHA256_DRIVER, 4096,
-                                   SHA256h, 32);
-    if (rc) { return rc; }
-
-    /* repeat test against stock linux pkcs1pad. */
-    rc = linuxkm_test_pkcs1_driver("pkcs1pad(rsa-generic,sha256)", 2048,
-                                   SHA256h, 32);
-    if (rc) { return rc; }
-
-    rc = linuxkm_test_pkcs1_driver("pkcs1pad(rsa-generic,sha256)", 3072,
-                                   SHA256h, 32);
-    if (rc) { return rc; }
-
-    rc = linuxkm_test_pkcs1_driver("pkcs1pad(rsa-generic,sha256)", 4096,
-                                   SHA256h, 32);
-    if (rc) { return rc; }
-    #endif /* WOLFKM_DEBUG_RSA */
+    #if defined(WOLFSSL_KEY_GEN)
+    rc = linuxkm_test_pkcs1_hash(WOLFKM_PKCS1_SHA256_DRIVER,
+                                 "pkcs1pad(rsa-generic,sha256)",
+                                 SHA256h, WC_SHA256_DIGEST_SIZE);
     #endif /* WOLFSSL_KEY_GEN */
 
     return rc;
 }
 #endif /* !NO_SHA256 */
 
+#ifdef WOLFSSL_SHA384
+static int linuxkm_test_pkcs1_sha384(void)
+{
+    int rc = 0;
+
+    #if defined(WOLFSSL_KEY_GEN)
+    rc = linuxkm_test_pkcs1_hash(WOLFKM_PKCS1_SHA384_DRIVER,
+                                 "pkcs1pad(rsa-generic,sha384)",
+                                 SHA384h, WC_SHA384_DIGEST_SIZE);
+    #endif /* WOLFSSL_KEY_GEN */
+
+    return rc;
+}
+#endif /* WOLFSSL_SHA384 */
+
 #ifdef WOLFSSL_SHA512
 static int linuxkm_test_pkcs1_sha512(void)
 {
     int rc = 0;
 
-    #ifdef WOLFSSL_KEY_GEN
-    rc = linuxkm_test_pkcs1_driver(WOLFKM_PKCS1_SHA512_DRIVER, 2048,
-                                   SHA512h, 64);
-    if (rc) { return rc; }
-
-    #ifdef WOLFKM_DEBUG_RSA
-    rc = linuxkm_test_pkcs1_driver(WOLFKM_PKCS1_SHA512_DRIVER, 3072,
-                                   SHA512h, 64);
-    if (rc) { return rc; }
-
-    rc = linuxkm_test_pkcs1_driver(WOLFKM_PKCS1_SHA512_DRIVER, 4096,
-                                   SHA512h, 64);
-    if (rc) { return rc; }
-
-    /* repeat test against stock linux pkcs1pad. */
-    rc = linuxkm_test_pkcs1_driver("pkcs1pad(rsa-generic,sha512)", 2048,
-                                   SHA512h, 64);
-    if (rc) { return rc; }
-
-    rc = linuxkm_test_pkcs1_driver("pkcs1pad(rsa-generic,sha512)", 3072,
-                                   SHA512h, 64);
-    if (rc) { return rc; }
-
-    rc = linuxkm_test_pkcs1_driver("pkcs1pad(rsa-generic,sha512)", 4096,
-                                   SHA512h, 64);
-    if (rc) { return rc; }
-    #endif /* WOLFKM_DEBUG_RSA */
+    #if defined(WOLFSSL_KEY_GEN)
+    rc = linuxkm_test_pkcs1_hash(WOLFKM_PKCS1_SHA512_DRIVER,
+                                 "pkcs1pad(rsa-generic,sha512)",
+                                 SHA512h, WC_SHA512_DIGEST_SIZE);
     #endif /* WOLFSSL_KEY_GEN */
 
     return rc;
 }
 #endif /* WOLFSSL_SHA512 */
+
+#ifdef WOLFSSL_SHA3
+static int linuxkm_test_pkcs1_sha3_256(void)
+{
+    int rc = 0;
+
+    #if defined(WOLFSSL_KEY_GEN)
+    rc = linuxkm_test_pkcs1_hash(WOLFKM_PKCS1_SHA3_256_DRIVER,
+                                 "pkcs1pad(rsa-generic,sha3-256)",
+                                 SHA3_256h, WC_SHA3_256_DIGEST_SIZE);
+    #endif /* WOLFSSL_KEY_GEN */
+
+    return rc;
+}
+
+static int linuxkm_test_pkcs1_sha3_384(void)
+{
+    int rc = 0;
+
+    #if defined(WOLFSSL_KEY_GEN)
+    rc = linuxkm_test_pkcs1_hash(WOLFKM_PKCS1_SHA3_384_DRIVER,
+                                 "pkcs1pad(rsa-generic,sha3-384)",
+                                 SHA3_384h, WC_SHA3_384_DIGEST_SIZE);
+    #endif /* WOLFSSL_KEY_GEN */
+
+    return rc;
+}
+
+static int linuxkm_test_pkcs1_sha3_512(void)
+{
+    int rc = 0;
+
+    #if defined(WOLFSSL_KEY_GEN)
+    rc = linuxkm_test_pkcs1_hash(WOLFKM_PKCS1_SHA3_512_DRIVER,
+                                 "pkcs1pad(rsa-generic,sha3-512)",
+                                 SHA3_512h, WC_SHA3_512_DIGEST_SIZE);
+    #endif /* WOLFSSL_KEY_GEN */
+
+    return rc;
+}
+#endif /* WOLFSSL_SHA3 */
 
 #if defined(LINUXKM_DIRECT_RSA) && defined(WOLFSSL_KEY_GEN)
 /*
@@ -1447,12 +1724,14 @@ static int linuxkm_test_pkcs1_driver(const char * driver, int nbits,
     #endif /* !LINUXKM_AKCIPHER_NO_SIGNVERIFY */
     int                       n_diff = 0;
 
-    hash = malloc(WC_SHA512_DIGEST_SIZE);
+    hash = malloc(hash_len);
     if (! hash) {
         pr_err("error: allocating hash buffer failed.\n");
         test_rc = MEMORY_E;
         goto test_pkcs1_end;
     }
+
+    memset(hash, 0, hash_len);
 
     /* hash the test msg with hash algo. */
     ret = wc_Hash(wc_OidGetHash(hash_oid), p_vector, sizeof(p_vector),
@@ -1896,8 +2175,13 @@ static int get_hash_enc_len(int hash_oid)
     int enc_len = -1;
 
     switch (hash_oid) {
+    case SHA224h:
     case SHA256h:
+    case SHA384h:
     case SHA512h:
+    case SHA3_256h:
+    case SHA3_384h:
+    case SHA3_512h:
         enc_len = 19;
         break;
     default:


### PR DESCRIPTION
# Description

Adds these algs:
- pkcs1_sha224
- pkcs1_sha384
- pkcs1_sha3_256
- pkcs1_sha3_384
- pkcs1_sha3_512

note: Usually only pkcs1 sha256 and sha512 appear in /proc/crypto . However on linux 6.12 and later these additional hash algs are labeled "fips_approved" in crypto/testmgr.c, so it's probably a good idea to add them in case.

pkcs1 sha256 and sha512 were already supported.

## Testing

- linuxkm-legacy-6.12-insmod
- linuxkm-aesni-LKCS-no-twc-insmod-ksanitize-6.1.73
- linuxkm-noasm-insmod-kmemleak
- linuxkm-noasm-insmod-crypto-fuzzer-extras