### PR TITLE
20250506-fixes-and-test-coverage

### DIFF
--- a/.github/workflows/async.yml
+++ b/.github/workflows/async.yml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         config: [
           # Add new configs here
-          '--enable-asynccrypt --enable-all --enable-dtls13',
-          '--enable-asynccrypt-sw --enable-ocspstapling --enable-ocspstapling2',
-          '--enable-ocsp CFLAGS="-DTEST_NONBLOCK_CERTS"',
+          '--enable-asynccrypt --enable-all --enable-dtls13 CFLAGS="-pedantic -Wdeclaration-after-statement -DTEST_LIBWOLFSSL_SOURCES_INCLUSION_SEQUENCE -DWOLFCRYPT_TEST_LINT"',
+          '--enable-asynccrypt-sw --enable-ocspstapling --enable-ocspstapling2 CFLAGS="-pedantic -Wdeclaration-after-statement -DTEST_LIBWOLFSSL_SOURCES_INCLUSION_SEQUENCE"',
+          '--enable-ocsp CFLAGS="-DTEST_NONBLOCK_CERTS -pedantic -Wdeclaration-after-statement -DTEST_LIBWOLFSSL_SOURCES_INCLUSION_SEQUENCE"',
         ]
     name: make check
     if: github.repository_owner == 'wolfssl'

--- a/.github/workflows/multi-arch.yml
+++ b/.github/workflows/multi-arch.yml
@@ -30,6 +30,7 @@ jobs:
           - HOST: riscv64-linux-gnu
             CC: riscv64-linux-gnu-gcc
             ARCH: riscv64
+            EXTRA_OPTS: --enable-riscv-asm
           # Config to ensure CPUs without Thumb instructions compiles
           - HOST: arm-linux-gnueabi
             CC: arm-linux-gnueabi-gcc
@@ -51,7 +52,7 @@ jobs:
             CC: ${{ matrix.CC }}
             CFLAGS: ${{ matrix.CFLAGS }}
             QEMU_LD_PREFIX: /usr/${{ matrix.HOST }}
-        run: ./autogen.sh && ./configure --host=${{ matrix.HOST }} --enable-all --disable-examples ${{ matrix.EXTRA_OPTS }} && make
+        run: ./autogen.sh && ./configure --host=${{ matrix.HOST }} --enable-all --disable-examples CPPFLAGS="-pedantic -Wdeclaration-after-statement -DTEST_LIBWOLFSSL_SOURCES_INCLUSION_SEQUENCE -DWOLFCRYPT_TEST_LINT" ${{ matrix.EXTRA_OPTS }} && make
       - name: Print errors
         if: ${{ failure() }}
         run: |

--- a/.github/workflows/multi-compiler.yml
+++ b/.github/workflows/multi-compiler.yml
@@ -55,7 +55,7 @@ jobs:
         env:
             CC: ${{ matrix.CC }}
             CXX: ${{ matrix.CXX }}
-        run: ./autogen.sh && ./configure && make && make dist
+        run: ./autogen.sh && ./configure CFLAGS="-pedantic -Wdeclaration-after-statement" && make && make dist
       - name: Show log on errors
         if: ${{ failure() }}
         run: |

--- a/.github/workflows/no-malloc.yml
+++ b/.github/workflows/no-malloc.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         config: [
           # Add new configs here
-          '--enable-rsa --enable-keygen --disable-dh CFLAGS="-DWOLFSSL_NO_MALLOC -DRSA_MIN_SIZE=1024"',
+          '--enable-rsa --enable-keygen --disable-dh CFLAGS="-DWOLFSSL_NO_MALLOC -DRSA_MIN_SIZE=1024 -pedantic -Wdeclaration-after-statement -DTEST_LIBWOLFSSL_SOURCES_INCLUSION_SEQUENCE"',
         ]
     name: make check
     if: github.repository_owner == 'wolfssl'

--- a/.github/workflows/opensslcoexist.yml
+++ b/.github/workflows/opensslcoexist.yml
@@ -18,8 +18,8 @@ jobs:
       matrix:
         config: [
           # Add new configs here
-          '--verbose --enable-all --disable-all-osp --disable-opensslall --enable-opensslcoexist CPPFLAGS="-DNO_WOLFSSL_CIPHER_SUITE_TEST -pedantic"',
-          '--verbose --enable-all --disable-all-osp --disable-opensslall --enable-opensslcoexist CPPFLAGS="-DNO_WOLFSSL_CIPHER_SUITE_TEST -pedantic -DTEST_OPENSSL_COEXIST"'
+          '--verbose --enable-all --disable-all-osp --disable-opensslall --enable-opensslcoexist CPPFLAGS="-DNO_WOLFSSL_CIPHER_SUITE_TEST -pedantic -Wdeclaration-after-statement -DTEST_LIBWOLFSSL_SOURCES_INCLUSION_SEQUENCE"',
+          '--verbose --enable-all --disable-all-osp --disable-opensslall --enable-opensslcoexist CPPFLAGS="-DNO_WOLFSSL_CIPHER_SUITE_TEST -pedantic -DTEST_OPENSSL_COEXIST -Wdeclaration-after-statement -DTEST_LIBWOLFSSL_SOURCES_INCLUSION_SEQUENCE"'
         ]
     name: make check
     if: github.repository_owner == 'wolfssl'

--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Build and test wolfSSL
         uses: wolfSSL/actions-build-autotools-project@v1
         with:
-          configure: ${{ matrix.config }}
+          configure: CFLAGS="-pedantic -Wno-overlength-strings -Wdeclaration-after-statement -DTEST_LIBWOLFSSL_SOURCES_INCLUSION_SEQUENCE" ${{ matrix.config }}
           check: true
 
   make_user_settings:

--- a/configure.ac
+++ b/configure.ac
@@ -9026,7 +9026,7 @@ if test "$ENABLED_SP_ASM" = "yes" && test "$ENABLED_SP" = "yes"; then
     ENABLED_SP_X86_64_ASM=yes
     ;;
   *)
-    AC_MSG_ERROR([ASM not available for CPU. Supported CPUs: x86_64, aarch64, arm])
+    AC_MSG_ERROR([SP ASM not available for CPU. Supported CPUs: x86_64, aarch64, arm])
     ;;
   esac
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5056,16 +5056,15 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 #else
     Dsh13Args  args[1];
 #endif
+#ifdef WOLFSSL_ASYNC_CRYPT
+    WOLFSSL_ASSERT_SIZEOF_GE(ssl->async->args, *args);
+#endif
 
     WOLFSSL_START(WC_FUNC_SERVER_HELLO_DO);
     WOLFSSL_ENTER("DoTls13ServerHello");
 
     if (ssl == NULL || ssl->arrays == NULL)
         return BAD_FUNC_ARG;
-
-#ifdef WOLFSSL_ASYNC_CRYPT
-    WOLFSSL_ASSERT_SIZEOF_GE(ssl->async->args, *args);
-#endif
 
     tls12minor = TLSv1_2_MINOR;
 


### PR DESCRIPTION
`src/tls13.c`: in `DoTls13ServerHello()` `WOLFSSL_ASYNC_CRYPT` path, fix `-Wdeclaration-after-statement` caused by fallthrough definition;

`.github/workflows`: update `async.yml`, `multi-arch.yml`, `multi-compiler.yml`, `no-malloc.yml`, and `os-check.yml`, with `-pedantic` and related flags, and add `--enable-riscv-asm` to `multi-arch.yml` RISC-V scenario;

`configure.ac`: clarify error message for "SP ASM not available for CPU."

tested with `wolfssl-multi-test.sh ... check-source-text check-configure` and a slew of manual builds using the workflow configs.
