### PR TITLE
20250507-fips-all

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1044,7 +1044,6 @@ then
     test "$enable_trustedca" = "" && enable_trustedca=yes
     test "$enable_session_ticket" = "" && enable_session_ticket=yes
     test "$enable_earlydata" = "" && enable_earlydata=yes
-    test "$enable_ech" = "" && enable_ech=yes
     test "$enable_rpk" = "" && enable_rpk=yes
 
     if test "$ENABLED_LINUXKM_DEFAULTS" != "yes"
@@ -1066,6 +1065,7 @@ then
 
     if test "$ENABLED_FIPS" = "no"
     then
+        test "$enable_ech" = "" && enable_ech=yes
         test "$enable_scep" = "" && enable_scep=yes
         test "$enable_mcast" = "" && enable_mcast=yes
     fi
@@ -1272,8 +1272,6 @@ then
     test "$enable_certext" = "" && enable_certext=yes
     test "$enable_sep" = "" && enable_sep=yes
     test "$enable_hkdf" = "" && enable_hkdf=yes
-    test "$enable_curve25519" = "" && enable_curve25519=yes
-    test "$enable_curve448" = "" && enable_curve448=yes
     test "$enable_fpecc" = "" && test "$enable_ecc" != "no" && enable_fpecc=yes
     test "$enable_eccencrypt" = "" && test "$enable_ecc" != "no" && enable_eccencrypt=yes
     test "$enable_psk" = "" && enable_psk=yes
@@ -1322,6 +1320,8 @@ then
 
     if test "$ENABLED_FIPS" = "no"
     then
+        test "$enable_curve25519" = "" && enable_curve25519=yes
+        test "$enable_curve448" = "" && enable_curve448=yes
         test "$enable_cryptocb" = "" && enable_cryptocb=yes
         test "$enable_pkcallbacks" = "" && enable_pkcallbacks=yes
         test "$enable_xchacha" = "" && test "$enable_chacha" != "no" && enable_xchacha=yes
@@ -4442,7 +4442,7 @@ AC_ARG_ENABLE([curve25519],
     [ ENABLED_CURVE25519=no ]
     )
 
-if test "$ENABLED_QUIC" = "yes" && test "$ENABLED_CURVE25519" = "no"
+if test "$ENABLED_QUIC" = "yes" && test "$ENABLED_CURVE25519" = "no" && test "$ENABLED_FIPS" = "no"
 then
     ENABLED_CURVE25519=yes
 fi
@@ -5627,13 +5627,17 @@ AS_CASE([$FIPS_VERSION],
         AS_IF([test "x$ENABLED_ED25519" != "xyes" &&
                (test "$FIPS_VERSION" != "dev" || test "$enable_ed25519" != "no")],
             [ENABLED_ED25519="yes"; AM_CFLAGS="$AM_CFLAGS -DHAVE_ED25519 -DHAVE_ED25519_KEY_IMPORT"])
-        AS_IF([test "$ENABLED_CURVE25519" = "yes"],
+
+        AS_IF([test "$ENABLED_CURVE25519" != "no" &&
+               (test "$FIPS_VERSION" != "dev" || test "$enable_curve25519" = "")],
             [ENABLED_CURVE25519="no"; AM_CFLAGS="$AM_CFLAGS"])
 
         AS_IF([test "x$ENABLED_ED448" != "xyes" &&
                (test "$FIPS_VERSION" != "dev" || test "$enable_ed448" != "no")],
             [ENABLED_ED448="yes"; AM_CFLAGS="$AM_CFLAGS -DHAVE_ED448 -DHAVE_ED448_KEY_IMPORT"])
-        AS_IF([test "x$ENABLED_CURVE448" = "xyes"],
+
+        AS_IF([test "$ENABLED_CURVE448" != "no" &&
+               (test "$FIPS_VERSION" != "dev" || test "$enable_curve448" = "")],
             [ENABLED_CURVE448="no"; AM_CFLAGS="$AM_CFLAGS"])
 
         AS_IF([test "x$ENABLED_ED25519_STREAM" != "xyes" &&

--- a/tests/quic.c
+++ b/tests/quic.c
@@ -1509,10 +1509,19 @@ static int test_quic_key_share(int verbose) {
     /*If that is supported by the server, expect a smooth handshake.*/
     QuicTestContext_init(&tclient, ctx_c, "client", verbose);
     QuicTestContext_init(&tserver, ctx_s, "server", verbose);
+
+#ifdef HAVE_CURVE25519
     ExpectTrue(wolfSSL_set1_curves_list(tclient.ssl, "X25519:P-256")
                == WOLFSSL_SUCCESS);
     ExpectTrue(wolfSSL_set1_curves_list(tserver.ssl, "X25519")
                == WOLFSSL_SUCCESS);
+#else
+    ExpectTrue(wolfSSL_set1_curves_list(tclient.ssl, "P-256:P-384")
+               == WOLFSSL_SUCCESS);
+    ExpectTrue(wolfSSL_set1_curves_list(tserver.ssl, "P-256")
+               == WOLFSSL_SUCCESS);
+#endif
+
     QuicConversation_init(&conv, &tclient, &tserver);
     QuicConversation_do(&conv);
     ExpectStrEQ(conv.rec_log,
@@ -1525,10 +1534,19 @@ static int test_quic_key_share(int verbose) {
     /* If group is not supported by server, expect HelloRetry */
     QuicTestContext_init(&tclient, ctx_c, "client", verbose);
     QuicTestContext_init(&tserver, ctx_s, "server", verbose);
+
+#ifdef HAVE_CURVE25519
     ExpectTrue(wolfSSL_set1_curves_list(tclient.ssl, "X25519:P-256")
                == WOLFSSL_SUCCESS);
     ExpectTrue(wolfSSL_set1_curves_list(tserver.ssl, "P-256")
                == WOLFSSL_SUCCESS);
+#else
+    ExpectTrue(wolfSSL_set1_curves_list(tclient.ssl, "P-384:P-256")
+               == WOLFSSL_SUCCESS);
+    ExpectTrue(wolfSSL_set1_curves_list(tserver.ssl, "P-256")
+               == WOLFSSL_SUCCESS);
+#endif
+
     QuicConversation_init(&conv, &tclient, &tserver);
     QuicConversation_do(&conv);
     ExpectStrEQ(conv.rec_log,
@@ -1541,10 +1559,19 @@ static int test_quic_key_share(int verbose) {
     /* If no group overlap, expect failure */
     QuicTestContext_init(&tclient, ctx_c, "client", verbose);
     QuicTestContext_init(&tserver, ctx_s, "server", verbose);
+
+#ifdef HAVE_CURVE25519
     ExpectTrue(wolfSSL_set1_curves_list(tclient.ssl, "P-256")
                == WOLFSSL_SUCCESS);
     ExpectTrue(wolfSSL_set1_curves_list(tserver.ssl, "X25519")
                == WOLFSSL_SUCCESS);
+#else
+    ExpectTrue(wolfSSL_set1_curves_list(tclient.ssl, "P-256")
+               == WOLFSSL_SUCCESS);
+    ExpectTrue(wolfSSL_set1_curves_list(tserver.ssl, "P-384")
+               == WOLFSSL_SUCCESS);
+#endif
+
     QuicConversation_init(&conv, &tclient, &tserver);
     QuicConversation_fail(&conv);
     ExpectIntEQ(wolfSSL_get_error(tserver.ssl, 0),


### PR DESCRIPTION
clean up Curve25519/Curve448 dependencies in FIPS builds:

`configure.ac`:

* in FIPS setup, fix sensing of `ENABLED_CURVE25519` and `ENABLED_CURVE448` to prevent `noasm` sneaking through, and allow `--enable-fips=dev` to enable them via override;

* `enable-all` enables ECH only if !FIPS;

* `enable-all-crypto` enables curve25519/curve448 only if !FIPS;

* QUIC implication of `ENABLED_CURVE25519` is inhibited if FIPS;

`tests/quic.c`: add !`HAVE_CURVE25519` paths in `test_quic_key_share()` to allow FIPS QUIC.

tested with
```
wolfssl-multi-test.sh ...
check-source-text
check-configure
all-crypto-openssl-extra-coexist-fips-v6
all-crypto-openssl-extra-coexist-fips-dev
all-crypto-openssl-extra-coexist-TEST_OPENSSL_COEXIST-fips-v6
all-crypto-openssl-extra-coexist-TEST_OPENSSL_COEXIST-fips-dev
fips-140-3-ready-all
fips-140-3-v6-all
fips-140-3-dev-all
fips-140-3-dev-all-trace-errcodes
fips-140-3-dev-all-cryptonly
fips-140-3-dev-all-crypto-no-sha-1
cross-aarch64-armasm-fips-140-3-dev-all-unittest-sanitizer
clang-tidy-fips-140-3-dev-all
clang-tidy-fips-140-3-dev-all-crypto-no-sha-1
clang-tidy-fips-140-3-v6-all
clang-tidy-fips-140-3-v6-all-smallstack
all-sanitize-fips-140-3-dev
```

(that list includes the full nightly set of FIPS enable-all mashups, all of which fail without these fixes, and all of which succeed with them.)
