### PR TITLE
Remove redefinition of MlKemKey and Fix build issue in benchmark

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1124,6 +1124,7 @@ static const bench_pq_hash_sig_alg bench_pq_hash_sig_opt[] = {
 };
 #endif /* BENCH_PQ_STATEFUL_HBS */
 
+#ifndef WOLFSSL_BENCHMARK_ALL
 #if defined(WOLFSSL_HAVE_MLKEM) || defined(HAVE_FALCON) || \
     defined(HAVE_DILITHIUM) || defined(HAVE_SPHINCS)
 /* The post-quantum-specific mapping of command line option to bit values and
@@ -1179,6 +1180,8 @@ static const bench_pq_alg bench_pq_asym_opt2[] = {
     { NULL, 0, }
 };
 #endif /* HAVE_SPHINCS */
+#endif
+
 #endif
 
 #ifdef HAVE_WNR

--- a/wolfssl/wolfcrypt/wc_mlkem.h
+++ b/wolfssl/wolfcrypt/wc_mlkem.h
@@ -146,9 +146,6 @@ struct MlKemKey {
     extern "C" {
 #endif
 
-/* For backward compatibility */
-typedef struct MlKemKey KyberKey;
-
 WOLFSSL_LOCAL
 void mlkem_init(void);
 


### PR DESCRIPTION
# Description
The KyberKey macro to MlKemKey causes a typedef redefinition error on
builds using C99 compilers and below. This PR removes the macro

There is a 'defined but not used' build error that shows up in benchmark when any of the PQC algos are enabled with `-DWOLFSSL_BENCHMARK_ALL`. This PR fixes this build issue.
Fixes zd#19867

# Reproducing the error
```
./configure --enable-shake128 --enable-shake256 --enable-mlkem \
--enable-dilithium  --disable-examples \
CFLAGS="-std=c99 -pedantic -DWOLFSSL_BENCHMARK_ALL" && make
```